### PR TITLE
Revert PR 70566 for const validation fix

### DIFF
--- a/src/librustc_mir/transform/const_prop.rs
+++ b/src/librustc_mir/transform/const_prop.rs
@@ -596,6 +596,11 @@ impl<'mir, 'tcx> ConstPropagator<'mir, 'tcx> {
             return None;
         }
 
+        // FIXME we need to revisit this for #67176
+        if rvalue.needs_subst() {
+            return None;
+        }
+
         // Perform any special handling for specific Rvalue types.
         // Generally, checks here fall into one of two categories:
         //   1. Additional checking to provide useful lints to the user
@@ -634,11 +639,6 @@ impl<'mir, 'tcx> ConstPropagator<'mir, 'tcx> {
             }
 
             _ => {}
-        }
-
-        // FIXME we need to revisit this for #67176
-        if rvalue.needs_subst() {
-            return None;
         }
 
         self.use_ecx(|this| {

--- a/src/test/ui/consts/const-eval/ice-generic-assoc-const.rs
+++ b/src/test/ui/consts/const-eval/ice-generic-assoc-const.rs
@@ -1,4 +1,5 @@
-// check-pass
+// build-pass (tests post-monomorphisation failure)
+#![crate_type = "lib"]
 
 pub trait Nullable {
     const NULL: Self;
@@ -12,7 +13,4 @@ impl<T> Nullable for *const T {
     fn is_null(&self) -> bool {
         *self == Self::NULL
     }
-}
-
-fn main() {
 }

--- a/src/test/ui/lint/lint-exceeding-bitshifts.noopt.stderr
+++ b/src/test/ui/lint/lint-exceeding-bitshifts.noopt.stderr
@@ -1,152 +1,146 @@
-warning: this arithmetic operation will overflow
-  --> $DIR/lint-exceeding-bitshifts.rs:18:20
-   |
-LL |     const N: i32 = T::N << 42;
-   |                    ^^^^^^^^^^ attempt to shift left with overflow
-   |
-note: the lint level is defined here
-  --> $DIR/lint-exceeding-bitshifts.rs:9:9
-   |
-LL | #![warn(arithmetic_overflow, const_err)]
-   |         ^^^^^^^^^^^^^^^^^^^
-
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:22:13
    |
 LL |     let _ = x << 42;
    |             ^^^^^^^ attempt to shift left with overflow
+   |
+note: the lint level is defined here
+  --> $DIR/lint-exceeding-bitshifts.rs:9:9
+   |
+LL | #![deny(arithmetic_overflow, const_err)]
+   |         ^^^^^^^^^^^^^^^^^^^
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:27:15
    |
 LL |       let n = 1u8 << 8;
    |               ^^^^^^^^ attempt to shift left with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:29:15
    |
 LL |       let n = 1u16 << 16;
    |               ^^^^^^^^^^ attempt to shift left with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:31:15
    |
 LL |       let n = 1u32 << 32;
    |               ^^^^^^^^^^ attempt to shift left with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:33:15
    |
 LL |       let n = 1u64 << 64;
    |               ^^^^^^^^^^ attempt to shift left with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:35:15
    |
 LL |       let n = 1i8 << 8;
    |               ^^^^^^^^ attempt to shift left with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:37:15
    |
 LL |       let n = 1i16 << 16;
    |               ^^^^^^^^^^ attempt to shift left with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:39:15
    |
 LL |       let n = 1i32 << 32;
    |               ^^^^^^^^^^ attempt to shift left with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:41:15
    |
 LL |       let n = 1i64 << 64;
    |               ^^^^^^^^^^ attempt to shift left with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:44:15
    |
 LL |       let n = 1u8 >> 8;
    |               ^^^^^^^^ attempt to shift right with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:46:15
    |
 LL |       let n = 1u16 >> 16;
    |               ^^^^^^^^^^ attempt to shift right with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:48:15
    |
 LL |       let n = 1u32 >> 32;
    |               ^^^^^^^^^^ attempt to shift right with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:50:15
    |
 LL |       let n = 1u64 >> 64;
    |               ^^^^^^^^^^ attempt to shift right with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:52:15
    |
 LL |       let n = 1i8 >> 8;
    |               ^^^^^^^^ attempt to shift right with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:54:15
    |
 LL |       let n = 1i16 >> 16;
    |               ^^^^^^^^^^ attempt to shift right with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:56:15
    |
 LL |       let n = 1i32 >> 32;
    |               ^^^^^^^^^^ attempt to shift right with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:58:15
    |
 LL |       let n = 1i64 >> 64;
    |               ^^^^^^^^^^ attempt to shift right with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:62:15
    |
 LL |       let n = n << 8;
    |               ^^^^^^ attempt to shift left with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:64:15
    |
 LL |       let n = 1u8 << -8;
    |               ^^^^^^^^^ attempt to shift left with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:69:15
    |
 LL |       let n = 1u8 << (4+4);
    |               ^^^^^^^^^^^^ attempt to shift left with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:71:15
    |
 LL |       let n = 1i64 >> [64][0];
    |               ^^^^^^^^^^^^^^^ attempt to shift right with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:77:15
    |
 LL |       let n = 1_isize << BITS;
    |               ^^^^^^^^^^^^^^^ attempt to shift left with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:78:15
    |
 LL |       let n = 1_usize << BITS;
    |               ^^^^^^^^^^^^^^^ attempt to shift left with overflow
 
-warning: 24 warnings emitted
+error: aborting due to 23 previous errors
 

--- a/src/test/ui/lint/lint-exceeding-bitshifts.opt.stderr
+++ b/src/test/ui/lint/lint-exceeding-bitshifts.opt.stderr
@@ -1,152 +1,146 @@
-warning: this arithmetic operation will overflow
-  --> $DIR/lint-exceeding-bitshifts.rs:18:20
-   |
-LL |     const N: i32 = T::N << 42;
-   |                    ^^^^^^^^^^ attempt to shift left with overflow
-   |
-note: the lint level is defined here
-  --> $DIR/lint-exceeding-bitshifts.rs:9:9
-   |
-LL | #![warn(arithmetic_overflow, const_err)]
-   |         ^^^^^^^^^^^^^^^^^^^
-
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:22:13
    |
 LL |     let _ = x << 42;
    |             ^^^^^^^ attempt to shift left with overflow
+   |
+note: the lint level is defined here
+  --> $DIR/lint-exceeding-bitshifts.rs:9:9
+   |
+LL | #![deny(arithmetic_overflow, const_err)]
+   |         ^^^^^^^^^^^^^^^^^^^
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:27:15
    |
 LL |       let n = 1u8 << 8;
    |               ^^^^^^^^ attempt to shift left with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:29:15
    |
 LL |       let n = 1u16 << 16;
    |               ^^^^^^^^^^ attempt to shift left with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:31:15
    |
 LL |       let n = 1u32 << 32;
    |               ^^^^^^^^^^ attempt to shift left with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:33:15
    |
 LL |       let n = 1u64 << 64;
    |               ^^^^^^^^^^ attempt to shift left with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:35:15
    |
 LL |       let n = 1i8 << 8;
    |               ^^^^^^^^ attempt to shift left with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:37:15
    |
 LL |       let n = 1i16 << 16;
    |               ^^^^^^^^^^ attempt to shift left with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:39:15
    |
 LL |       let n = 1i32 << 32;
    |               ^^^^^^^^^^ attempt to shift left with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:41:15
    |
 LL |       let n = 1i64 << 64;
    |               ^^^^^^^^^^ attempt to shift left with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:44:15
    |
 LL |       let n = 1u8 >> 8;
    |               ^^^^^^^^ attempt to shift right with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:46:15
    |
 LL |       let n = 1u16 >> 16;
    |               ^^^^^^^^^^ attempt to shift right with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:48:15
    |
 LL |       let n = 1u32 >> 32;
    |               ^^^^^^^^^^ attempt to shift right with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:50:15
    |
 LL |       let n = 1u64 >> 64;
    |               ^^^^^^^^^^ attempt to shift right with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:52:15
    |
 LL |       let n = 1i8 >> 8;
    |               ^^^^^^^^ attempt to shift right with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:54:15
    |
 LL |       let n = 1i16 >> 16;
    |               ^^^^^^^^^^ attempt to shift right with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:56:15
    |
 LL |       let n = 1i32 >> 32;
    |               ^^^^^^^^^^ attempt to shift right with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:58:15
    |
 LL |       let n = 1i64 >> 64;
    |               ^^^^^^^^^^ attempt to shift right with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:62:15
    |
 LL |       let n = n << 8;
    |               ^^^^^^ attempt to shift left with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:64:15
    |
 LL |       let n = 1u8 << -8;
    |               ^^^^^^^^^ attempt to shift left with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:69:15
    |
 LL |       let n = 1u8 << (4+4);
    |               ^^^^^^^^^^^^ attempt to shift left with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:71:15
    |
 LL |       let n = 1i64 >> [64][0];
    |               ^^^^^^^^^^^^^^^ attempt to shift right with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:77:15
    |
 LL |       let n = 1_isize << BITS;
    |               ^^^^^^^^^^^^^^^ attempt to shift left with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:78:15
    |
 LL |       let n = 1_usize << BITS;
    |               ^^^^^^^^^^^^^^^ attempt to shift left with overflow
 
-warning: 24 warnings emitted
+error: aborting due to 23 previous errors
 

--- a/src/test/ui/lint/lint-exceeding-bitshifts.opt_with_overflow_checks.stderr
+++ b/src/test/ui/lint/lint-exceeding-bitshifts.opt_with_overflow_checks.stderr
@@ -1,152 +1,146 @@
-warning: this arithmetic operation will overflow
-  --> $DIR/lint-exceeding-bitshifts.rs:18:20
-   |
-LL |     const N: i32 = T::N << 42;
-   |                    ^^^^^^^^^^ attempt to shift left with overflow
-   |
-note: the lint level is defined here
-  --> $DIR/lint-exceeding-bitshifts.rs:9:9
-   |
-LL | #![warn(arithmetic_overflow, const_err)]
-   |         ^^^^^^^^^^^^^^^^^^^
-
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:22:13
    |
 LL |     let _ = x << 42;
    |             ^^^^^^^ attempt to shift left with overflow
+   |
+note: the lint level is defined here
+  --> $DIR/lint-exceeding-bitshifts.rs:9:9
+   |
+LL | #![deny(arithmetic_overflow, const_err)]
+   |         ^^^^^^^^^^^^^^^^^^^
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:27:15
    |
 LL |       let n = 1u8 << 8;
    |               ^^^^^^^^ attempt to shift left with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:29:15
    |
 LL |       let n = 1u16 << 16;
    |               ^^^^^^^^^^ attempt to shift left with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:31:15
    |
 LL |       let n = 1u32 << 32;
    |               ^^^^^^^^^^ attempt to shift left with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:33:15
    |
 LL |       let n = 1u64 << 64;
    |               ^^^^^^^^^^ attempt to shift left with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:35:15
    |
 LL |       let n = 1i8 << 8;
    |               ^^^^^^^^ attempt to shift left with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:37:15
    |
 LL |       let n = 1i16 << 16;
    |               ^^^^^^^^^^ attempt to shift left with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:39:15
    |
 LL |       let n = 1i32 << 32;
    |               ^^^^^^^^^^ attempt to shift left with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:41:15
    |
 LL |       let n = 1i64 << 64;
    |               ^^^^^^^^^^ attempt to shift left with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:44:15
    |
 LL |       let n = 1u8 >> 8;
    |               ^^^^^^^^ attempt to shift right with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:46:15
    |
 LL |       let n = 1u16 >> 16;
    |               ^^^^^^^^^^ attempt to shift right with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:48:15
    |
 LL |       let n = 1u32 >> 32;
    |               ^^^^^^^^^^ attempt to shift right with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:50:15
    |
 LL |       let n = 1u64 >> 64;
    |               ^^^^^^^^^^ attempt to shift right with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:52:15
    |
 LL |       let n = 1i8 >> 8;
    |               ^^^^^^^^ attempt to shift right with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:54:15
    |
 LL |       let n = 1i16 >> 16;
    |               ^^^^^^^^^^ attempt to shift right with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:56:15
    |
 LL |       let n = 1i32 >> 32;
    |               ^^^^^^^^^^ attempt to shift right with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:58:15
    |
 LL |       let n = 1i64 >> 64;
    |               ^^^^^^^^^^ attempt to shift right with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:62:15
    |
 LL |       let n = n << 8;
    |               ^^^^^^ attempt to shift left with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:64:15
    |
 LL |       let n = 1u8 << -8;
    |               ^^^^^^^^^ attempt to shift left with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:69:15
    |
 LL |       let n = 1u8 << (4+4);
    |               ^^^^^^^^^^^^ attempt to shift left with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:71:15
    |
 LL |       let n = 1i64 >> [64][0];
    |               ^^^^^^^^^^^^^^^ attempt to shift right with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:77:15
    |
 LL |       let n = 1_isize << BITS;
    |               ^^^^^^^^^^^^^^^ attempt to shift left with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:78:15
    |
 LL |       let n = 1_usize << BITS;
    |               ^^^^^^^^^^^^^^^ attempt to shift left with overflow
 
-warning: 24 warnings emitted
+error: aborting due to 23 previous errors
 

--- a/src/test/ui/lint/lint-exceeding-bitshifts.rs
+++ b/src/test/ui/lint/lint-exceeding-bitshifts.rs
@@ -2,11 +2,11 @@
 //[noopt]compile-flags: -C opt-level=0
 //[opt]compile-flags: -O
 //[opt_with_overflow_checks]compile-flags: -C overflow-checks=on -O
-// build-pass
-// ignore-pass (test emits codegen-time warnings and verifies that they are not errors)
+
+// build-fail
 
 #![crate_type="lib"]
-#![warn(arithmetic_overflow, const_err)]
+#![deny(arithmetic_overflow, const_err)]
 #![allow(unused_variables)]
 #![allow(dead_code)]
 
@@ -15,65 +15,65 @@ pub trait Foo {
 }
 
 impl<T: Foo> Foo for Vec<T> {
-    const N: i32 = T::N << 42; //~ WARN: arithmetic operation will overflow
+    const N: i32 = T::N << 42; // FIXME this should warn
 }
 
 pub fn foo(x: i32) {
-    let _ = x << 42; //~ WARN: arithmetic operation will overflow
+    let _ = x << 42; //~ ERROR: arithmetic operation will overflow
 }
 
 pub fn main() {
       let n = 1u8 << 7;
-      let n = 1u8 << 8;   //~ WARN: arithmetic operation will overflow
+      let n = 1u8 << 8;   //~ ERROR: arithmetic operation will overflow
       let n = 1u16 << 15;
-      let n = 1u16 << 16; //~ WARN: arithmetic operation will overflow
+      let n = 1u16 << 16; //~ ERROR: arithmetic operation will overflow
       let n = 1u32 << 31;
-      let n = 1u32 << 32; //~ WARN: arithmetic operation will overflow
+      let n = 1u32 << 32; //~ ERROR: arithmetic operation will overflow
       let n = 1u64 << 63;
-      let n = 1u64 << 64; //~ WARN: arithmetic operation will overflow
+      let n = 1u64 << 64; //~ ERROR: arithmetic operation will overflow
       let n = 1i8 << 7;
-      let n = 1i8 << 8;   //~ WARN: arithmetic operation will overflow
+      let n = 1i8 << 8;   //~ ERROR: arithmetic operation will overflow
       let n = 1i16 << 15;
-      let n = 1i16 << 16; //~ WARN: arithmetic operation will overflow
+      let n = 1i16 << 16; //~ ERROR: arithmetic operation will overflow
       let n = 1i32 << 31;
-      let n = 1i32 << 32; //~ WARN: arithmetic operation will overflow
+      let n = 1i32 << 32; //~ ERROR: arithmetic operation will overflow
       let n = 1i64 << 63;
-      let n = 1i64 << 64; //~ WARN: arithmetic operation will overflow
+      let n = 1i64 << 64; //~ ERROR: arithmetic operation will overflow
 
       let n = 1u8 >> 7;
-      let n = 1u8 >> 8;   //~ WARN: arithmetic operation will overflow
+      let n = 1u8 >> 8;   //~ ERROR: arithmetic operation will overflow
       let n = 1u16 >> 15;
-      let n = 1u16 >> 16; //~ WARN: arithmetic operation will overflow
+      let n = 1u16 >> 16; //~ ERROR: arithmetic operation will overflow
       let n = 1u32 >> 31;
-      let n = 1u32 >> 32; //~ WARN: arithmetic operation will overflow
+      let n = 1u32 >> 32; //~ ERROR: arithmetic operation will overflow
       let n = 1u64 >> 63;
-      let n = 1u64 >> 64; //~ WARN: arithmetic operation will overflow
+      let n = 1u64 >> 64; //~ ERROR: arithmetic operation will overflow
       let n = 1i8 >> 7;
-      let n = 1i8 >> 8;   //~ WARN: arithmetic operation will overflow
+      let n = 1i8 >> 8;   //~ ERROR: arithmetic operation will overflow
       let n = 1i16 >> 15;
-      let n = 1i16 >> 16; //~ WARN: arithmetic operation will overflow
+      let n = 1i16 >> 16; //~ ERROR: arithmetic operation will overflow
       let n = 1i32 >> 31;
-      let n = 1i32 >> 32; //~ WARN: arithmetic operation will overflow
+      let n = 1i32 >> 32; //~ ERROR: arithmetic operation will overflow
       let n = 1i64 >> 63;
-      let n = 1i64 >> 64; //~ WARN: arithmetic operation will overflow
+      let n = 1i64 >> 64; //~ ERROR: arithmetic operation will overflow
 
       let n = 1u8;
       let n = n << 7;
-      let n = n << 8; //~ WARN: arithmetic operation will overflow
+      let n = n << 8; //~ ERROR: arithmetic operation will overflow
 
-      let n = 1u8 << -8; //~ WARN: arithmetic operation will overflow
+      let n = 1u8 << -8; //~ ERROR: arithmetic operation will overflow
 
       let n = 1i8<<(1isize+-1);
 
       let n = 1u8 << (4+3);
-      let n = 1u8 << (4+4); //~ WARN: arithmetic operation will overflow
+      let n = 1u8 << (4+4); //~ ERROR: arithmetic operation will overflow
       let n = 1i64 >> [63][0];
-      let n = 1i64 >> [64][0]; //~ WARN: arithmetic operation will overflow
+      let n = 1i64 >> [64][0]; //~ ERROR: arithmetic operation will overflow
 
       #[cfg(target_pointer_width = "32")]
       const BITS: usize = 32;
       #[cfg(target_pointer_width = "64")]
       const BITS: usize = 64;
-      let n = 1_isize << BITS; //~ WARN: arithmetic operation will overflow
-      let n = 1_usize << BITS; //~ WARN: arithmetic operation will overflow
+      let n = 1_isize << BITS; //~ ERROR: arithmetic operation will overflow
+      let n = 1_usize << BITS; //~ ERROR: arithmetic operation will overflow
 }


### PR DESCRIPTION
This is a port of PR #71441 but ported to the master branch, as discussed in [yesterday's T-compiler meeting](https://zulip-archive.rust-lang.org/131828tcompiler/88751weeklymeeting2020042354818.html#195065903)