### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/src/librustc_ast_lowering/expr.rs
+++ b/src/librustc_ast_lowering/expr.rs
@@ -397,12 +397,8 @@ impl<'hir> LoweringContext<'_, 'hir> {
         let then_arm = self.arm(then_pat, self.arena.alloc(then_expr));
 
         // `match <scrutinee> { ... }`
-        let match_expr = self.expr_match(
-            scrutinee.span,
-            scrutinee,
-            arena_vec![self; then_arm, else_arm],
-            desugar,
-        );
+        let match_expr =
+            self.expr_match(span, scrutinee, arena_vec![self; then_arm, else_arm], desugar);
 
         // `[opt_ident]: loop { ... }`
         hir::ExprKind::Loop(self.block_expr(self.arena.alloc(match_expr)), opt_label, source)

--- a/src/librustc_codegen_ssa/back/write.rs
+++ b/src/librustc_codegen_ssa/back/write.rs
@@ -119,7 +119,12 @@ pub struct ModuleConfig {
 }
 
 impl ModuleConfig {
-    fn new(kind: ModuleKind, sess: &Session, no_builtins: bool) -> ModuleConfig {
+    fn new(
+        kind: ModuleKind,
+        sess: &Session,
+        no_builtins: bool,
+        is_compiler_builtins: bool,
+    ) -> ModuleConfig {
         // If it's a regular module, use `$regular`, otherwise use `$other`.
         // `$regular` and `$other` are evaluated lazily.
         macro_rules! if_regular {
@@ -160,7 +165,10 @@ impl ModuleConfig {
             passes: if_regular!(
                 {
                     let mut passes = sess.opts.cg.passes.clone();
-                    if sess.opts.debugging_opts.profile {
+                    // compiler_builtins overrides the codegen-units settings,
+                    // which is incompatible with -Zprofile which requires that
+                    // only a single codegen unit is used per crate.
+                    if sess.opts.debugging_opts.profile && !is_compiler_builtins {
                         passes.push("insert-gcov-profiling".to_owned());
                     }
                     passes
@@ -405,6 +413,8 @@ pub fn start_async_codegen<B: ExtraBackendMethods>(
     let crate_name = tcx.crate_name(LOCAL_CRATE);
     let crate_hash = tcx.crate_hash(LOCAL_CRATE);
     let no_builtins = attr::contains_name(&tcx.hir().krate().item.attrs, sym::no_builtins);
+    let is_compiler_builtins =
+        attr::contains_name(&tcx.hir().krate().item.attrs, sym::compiler_builtins);
     let subsystem =
         attr::first_attr_value_str_by_name(&tcx.hir().krate().item.attrs, sym::windows_subsystem);
     let windows_subsystem = subsystem.map(|subsystem| {
@@ -421,9 +431,12 @@ pub fn start_async_codegen<B: ExtraBackendMethods>(
     let linker_info = LinkerInfo::new(tcx);
     let crate_info = CrateInfo::new(tcx);
 
-    let regular_config = ModuleConfig::new(ModuleKind::Regular, sess, no_builtins);
-    let metadata_config = ModuleConfig::new(ModuleKind::Metadata, sess, no_builtins);
-    let allocator_config = ModuleConfig::new(ModuleKind::Allocator, sess, no_builtins);
+    let regular_config =
+        ModuleConfig::new(ModuleKind::Regular, sess, no_builtins, is_compiler_builtins);
+    let metadata_config =
+        ModuleConfig::new(ModuleKind::Metadata, sess, no_builtins, is_compiler_builtins);
+    let allocator_config =
+        ModuleConfig::new(ModuleKind::Allocator, sess, no_builtins, is_compiler_builtins);
 
     let (shared_emitter, shared_emitter_main) = SharedEmitter::new();
     let (codegen_worker_send, codegen_worker_receive) = channel();

--- a/src/librustc_lint/unused.rs
+++ b/src/librustc_lint/unused.rs
@@ -16,7 +16,7 @@ use rustc_middle::ty::{self, Ty};
 use rustc_session::lint::builtin::UNUSED_ATTRIBUTES;
 use rustc_span::symbol::Symbol;
 use rustc_span::symbol::{kw, sym};
-use rustc_span::{BytePos, Span};
+use rustc_span::{BytePos, Span, DUMMY_SP};
 
 use log::debug;
 
@@ -415,6 +415,12 @@ trait UnusedDelimLint {
         msg: &str,
         keep_space: (bool, bool),
     ) {
+        // FIXME(flip1995): Quick and dirty fix for #70814. This should be fixed in rustdoc
+        // properly.
+        if span == DUMMY_SP {
+            return;
+        }
+
         cx.struct_span_lint(self.lint(), span, |lint| {
             let span_msg = format!("unnecessary {} around {}", Self::DELIM_STR, msg);
             let mut err = lint.build(&span_msg);

--- a/src/librustc_mir/transform/const_prop.rs
+++ b/src/librustc_mir/transform/const_prop.rs
@@ -596,6 +596,11 @@ impl<'mir, 'tcx> ConstPropagator<'mir, 'tcx> {
             return None;
         }
 
+        // FIXME we need to revisit this for #67176
+        if rvalue.needs_subst() {
+            return None;
+        }
+
         // Perform any special handling for specific Rvalue types.
         // Generally, checks here fall into one of two categories:
         //   1. Additional checking to provide useful lints to the user
@@ -634,11 +639,6 @@ impl<'mir, 'tcx> ConstPropagator<'mir, 'tcx> {
             }
 
             _ => {}
-        }
-
-        // FIXME we need to revisit this for #67176
-        if rvalue.needs_subst() {
-            return None;
         }
 
         self.use_ecx(|this| {

--- a/src/test/mir-opt/while-storage/rustc.while_loop.PreCodegen.after.mir
+++ b/src/test/mir-opt/while-storage/rustc.while_loop.PreCodegen.after.mir
@@ -57,7 +57,7 @@ fn while_loop(_1: bool) -> () {
 
     bb5: {
         StorageDead(_4);                 // bb5[0]: scope 0 at $DIR/while-storage.rs:14:5: 14:6
-        StorageDead(_2);                 // bb5[1]: scope 0 at $DIR/while-storage.rs:10:21: 10:22
+        StorageDead(_2);                 // bb5[1]: scope 0 at $DIR/while-storage.rs:14:5: 14:6
         goto -> bb0;                     // bb5[2]: scope 0 at $DIR/while-storage.rs:10:5: 14:6
     }
 
@@ -74,7 +74,7 @@ fn while_loop(_1: bool) -> () {
     }
 
     bb7: {
-        StorageDead(_2);                 // bb7[0]: scope 0 at $DIR/while-storage.rs:10:21: 10:22
+        StorageDead(_2);                 // bb7[0]: scope 0 at $DIR/while-storage.rs:14:5: 14:6
         return;                          // bb7[1]: scope 0 at $DIR/while-storage.rs:15:2: 15:2
     }
 }

--- a/src/test/rustdoc-ui/unused-braces-lint.rs
+++ b/src/test/rustdoc-ui/unused-braces-lint.rs
@@ -1,0 +1,14 @@
+// check-pass
+
+// This tests the bug in #70814, where the unused_braces lint triggered on the following code
+// without providing a span.
+
+#![deny(unused_braces)]
+
+fn main() {
+    {
+        {
+            use std;
+        }
+    }
+}

--- a/src/test/ui/block-result/block-must-not-have-result-while.stderr
+++ b/src/test/ui/block-result/block-must-not-have-result-while.stderr
@@ -9,8 +9,14 @@ LL |     while true {
 error[E0308]: mismatched types
   --> $DIR/block-must-not-have-result-while.rs:3:9
    |
-LL |         true
-   |         ^^^^ expected `()`, found `bool`
+LL | /     while true {
+LL | |         true
+   | |         ^^^^ expected `()`, found `bool`
+LL | |
+LL | |     }
+   | |     -- help: consider using a semicolon here
+   | |_____|
+   |       expected this to be `()`
 
 error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui/consts/const-eval/ice-generic-assoc-const.rs
+++ b/src/test/ui/consts/const-eval/ice-generic-assoc-const.rs
@@ -1,4 +1,5 @@
-// check-pass
+// build-pass (tests post-monomorphisation failure)
+#![crate_type = "lib"]
 
 pub trait Nullable {
     const NULL: Self;
@@ -12,7 +13,4 @@ impl<T> Nullable for *const T {
     fn is_null(&self) -> bool {
         *self == Self::NULL
     }
-}
-
-fn main() {
 }

--- a/src/test/ui/lint/lint-exceeding-bitshifts.noopt.stderr
+++ b/src/test/ui/lint/lint-exceeding-bitshifts.noopt.stderr
@@ -1,152 +1,146 @@
-warning: this arithmetic operation will overflow
-  --> $DIR/lint-exceeding-bitshifts.rs:18:20
-   |
-LL |     const N: i32 = T::N << 42;
-   |                    ^^^^^^^^^^ attempt to shift left with overflow
-   |
-note: the lint level is defined here
-  --> $DIR/lint-exceeding-bitshifts.rs:9:9
-   |
-LL | #![warn(arithmetic_overflow, const_err)]
-   |         ^^^^^^^^^^^^^^^^^^^
-
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:22:13
    |
 LL |     let _ = x << 42;
    |             ^^^^^^^ attempt to shift left with overflow
+   |
+note: the lint level is defined here
+  --> $DIR/lint-exceeding-bitshifts.rs:9:9
+   |
+LL | #![deny(arithmetic_overflow, const_err)]
+   |         ^^^^^^^^^^^^^^^^^^^
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:27:15
    |
 LL |       let n = 1u8 << 8;
    |               ^^^^^^^^ attempt to shift left with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:29:15
    |
 LL |       let n = 1u16 << 16;
    |               ^^^^^^^^^^ attempt to shift left with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:31:15
    |
 LL |       let n = 1u32 << 32;
    |               ^^^^^^^^^^ attempt to shift left with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:33:15
    |
 LL |       let n = 1u64 << 64;
    |               ^^^^^^^^^^ attempt to shift left with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:35:15
    |
 LL |       let n = 1i8 << 8;
    |               ^^^^^^^^ attempt to shift left with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:37:15
    |
 LL |       let n = 1i16 << 16;
    |               ^^^^^^^^^^ attempt to shift left with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:39:15
    |
 LL |       let n = 1i32 << 32;
    |               ^^^^^^^^^^ attempt to shift left with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:41:15
    |
 LL |       let n = 1i64 << 64;
    |               ^^^^^^^^^^ attempt to shift left with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:44:15
    |
 LL |       let n = 1u8 >> 8;
    |               ^^^^^^^^ attempt to shift right with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:46:15
    |
 LL |       let n = 1u16 >> 16;
    |               ^^^^^^^^^^ attempt to shift right with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:48:15
    |
 LL |       let n = 1u32 >> 32;
    |               ^^^^^^^^^^ attempt to shift right with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:50:15
    |
 LL |       let n = 1u64 >> 64;
    |               ^^^^^^^^^^ attempt to shift right with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:52:15
    |
 LL |       let n = 1i8 >> 8;
    |               ^^^^^^^^ attempt to shift right with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:54:15
    |
 LL |       let n = 1i16 >> 16;
    |               ^^^^^^^^^^ attempt to shift right with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:56:15
    |
 LL |       let n = 1i32 >> 32;
    |               ^^^^^^^^^^ attempt to shift right with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:58:15
    |
 LL |       let n = 1i64 >> 64;
    |               ^^^^^^^^^^ attempt to shift right with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:62:15
    |
 LL |       let n = n << 8;
    |               ^^^^^^ attempt to shift left with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:64:15
    |
 LL |       let n = 1u8 << -8;
    |               ^^^^^^^^^ attempt to shift left with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:69:15
    |
 LL |       let n = 1u8 << (4+4);
    |               ^^^^^^^^^^^^ attempt to shift left with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:71:15
    |
 LL |       let n = 1i64 >> [64][0];
    |               ^^^^^^^^^^^^^^^ attempt to shift right with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:77:15
    |
 LL |       let n = 1_isize << BITS;
    |               ^^^^^^^^^^^^^^^ attempt to shift left with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:78:15
    |
 LL |       let n = 1_usize << BITS;
    |               ^^^^^^^^^^^^^^^ attempt to shift left with overflow
 
-warning: 24 warnings emitted
+error: aborting due to 23 previous errors
 

--- a/src/test/ui/lint/lint-exceeding-bitshifts.opt.stderr
+++ b/src/test/ui/lint/lint-exceeding-bitshifts.opt.stderr
@@ -1,152 +1,146 @@
-warning: this arithmetic operation will overflow
-  --> $DIR/lint-exceeding-bitshifts.rs:18:20
-   |
-LL |     const N: i32 = T::N << 42;
-   |                    ^^^^^^^^^^ attempt to shift left with overflow
-   |
-note: the lint level is defined here
-  --> $DIR/lint-exceeding-bitshifts.rs:9:9
-   |
-LL | #![warn(arithmetic_overflow, const_err)]
-   |         ^^^^^^^^^^^^^^^^^^^
-
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:22:13
    |
 LL |     let _ = x << 42;
    |             ^^^^^^^ attempt to shift left with overflow
+   |
+note: the lint level is defined here
+  --> $DIR/lint-exceeding-bitshifts.rs:9:9
+   |
+LL | #![deny(arithmetic_overflow, const_err)]
+   |         ^^^^^^^^^^^^^^^^^^^
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:27:15
    |
 LL |       let n = 1u8 << 8;
    |               ^^^^^^^^ attempt to shift left with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:29:15
    |
 LL |       let n = 1u16 << 16;
    |               ^^^^^^^^^^ attempt to shift left with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:31:15
    |
 LL |       let n = 1u32 << 32;
    |               ^^^^^^^^^^ attempt to shift left with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:33:15
    |
 LL |       let n = 1u64 << 64;
    |               ^^^^^^^^^^ attempt to shift left with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:35:15
    |
 LL |       let n = 1i8 << 8;
    |               ^^^^^^^^ attempt to shift left with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:37:15
    |
 LL |       let n = 1i16 << 16;
    |               ^^^^^^^^^^ attempt to shift left with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:39:15
    |
 LL |       let n = 1i32 << 32;
    |               ^^^^^^^^^^ attempt to shift left with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:41:15
    |
 LL |       let n = 1i64 << 64;
    |               ^^^^^^^^^^ attempt to shift left with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:44:15
    |
 LL |       let n = 1u8 >> 8;
    |               ^^^^^^^^ attempt to shift right with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:46:15
    |
 LL |       let n = 1u16 >> 16;
    |               ^^^^^^^^^^ attempt to shift right with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:48:15
    |
 LL |       let n = 1u32 >> 32;
    |               ^^^^^^^^^^ attempt to shift right with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:50:15
    |
 LL |       let n = 1u64 >> 64;
    |               ^^^^^^^^^^ attempt to shift right with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:52:15
    |
 LL |       let n = 1i8 >> 8;
    |               ^^^^^^^^ attempt to shift right with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:54:15
    |
 LL |       let n = 1i16 >> 16;
    |               ^^^^^^^^^^ attempt to shift right with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:56:15
    |
 LL |       let n = 1i32 >> 32;
    |               ^^^^^^^^^^ attempt to shift right with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:58:15
    |
 LL |       let n = 1i64 >> 64;
    |               ^^^^^^^^^^ attempt to shift right with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:62:15
    |
 LL |       let n = n << 8;
    |               ^^^^^^ attempt to shift left with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:64:15
    |
 LL |       let n = 1u8 << -8;
    |               ^^^^^^^^^ attempt to shift left with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:69:15
    |
 LL |       let n = 1u8 << (4+4);
    |               ^^^^^^^^^^^^ attempt to shift left with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:71:15
    |
 LL |       let n = 1i64 >> [64][0];
    |               ^^^^^^^^^^^^^^^ attempt to shift right with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:77:15
    |
 LL |       let n = 1_isize << BITS;
    |               ^^^^^^^^^^^^^^^ attempt to shift left with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:78:15
    |
 LL |       let n = 1_usize << BITS;
    |               ^^^^^^^^^^^^^^^ attempt to shift left with overflow
 
-warning: 24 warnings emitted
+error: aborting due to 23 previous errors
 

--- a/src/test/ui/lint/lint-exceeding-bitshifts.opt_with_overflow_checks.stderr
+++ b/src/test/ui/lint/lint-exceeding-bitshifts.opt_with_overflow_checks.stderr
@@ -1,152 +1,146 @@
-warning: this arithmetic operation will overflow
-  --> $DIR/lint-exceeding-bitshifts.rs:18:20
-   |
-LL |     const N: i32 = T::N << 42;
-   |                    ^^^^^^^^^^ attempt to shift left with overflow
-   |
-note: the lint level is defined here
-  --> $DIR/lint-exceeding-bitshifts.rs:9:9
-   |
-LL | #![warn(arithmetic_overflow, const_err)]
-   |         ^^^^^^^^^^^^^^^^^^^
-
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:22:13
    |
 LL |     let _ = x << 42;
    |             ^^^^^^^ attempt to shift left with overflow
+   |
+note: the lint level is defined here
+  --> $DIR/lint-exceeding-bitshifts.rs:9:9
+   |
+LL | #![deny(arithmetic_overflow, const_err)]
+   |         ^^^^^^^^^^^^^^^^^^^
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:27:15
    |
 LL |       let n = 1u8 << 8;
    |               ^^^^^^^^ attempt to shift left with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:29:15
    |
 LL |       let n = 1u16 << 16;
    |               ^^^^^^^^^^ attempt to shift left with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:31:15
    |
 LL |       let n = 1u32 << 32;
    |               ^^^^^^^^^^ attempt to shift left with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:33:15
    |
 LL |       let n = 1u64 << 64;
    |               ^^^^^^^^^^ attempt to shift left with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:35:15
    |
 LL |       let n = 1i8 << 8;
    |               ^^^^^^^^ attempt to shift left with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:37:15
    |
 LL |       let n = 1i16 << 16;
    |               ^^^^^^^^^^ attempt to shift left with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:39:15
    |
 LL |       let n = 1i32 << 32;
    |               ^^^^^^^^^^ attempt to shift left with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:41:15
    |
 LL |       let n = 1i64 << 64;
    |               ^^^^^^^^^^ attempt to shift left with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:44:15
    |
 LL |       let n = 1u8 >> 8;
    |               ^^^^^^^^ attempt to shift right with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:46:15
    |
 LL |       let n = 1u16 >> 16;
    |               ^^^^^^^^^^ attempt to shift right with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:48:15
    |
 LL |       let n = 1u32 >> 32;
    |               ^^^^^^^^^^ attempt to shift right with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:50:15
    |
 LL |       let n = 1u64 >> 64;
    |               ^^^^^^^^^^ attempt to shift right with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:52:15
    |
 LL |       let n = 1i8 >> 8;
    |               ^^^^^^^^ attempt to shift right with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:54:15
    |
 LL |       let n = 1i16 >> 16;
    |               ^^^^^^^^^^ attempt to shift right with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:56:15
    |
 LL |       let n = 1i32 >> 32;
    |               ^^^^^^^^^^ attempt to shift right with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:58:15
    |
 LL |       let n = 1i64 >> 64;
    |               ^^^^^^^^^^ attempt to shift right with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:62:15
    |
 LL |       let n = n << 8;
    |               ^^^^^^ attempt to shift left with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:64:15
    |
 LL |       let n = 1u8 << -8;
    |               ^^^^^^^^^ attempt to shift left with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:69:15
    |
 LL |       let n = 1u8 << (4+4);
    |               ^^^^^^^^^^^^ attempt to shift left with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:71:15
    |
 LL |       let n = 1i64 >> [64][0];
    |               ^^^^^^^^^^^^^^^ attempt to shift right with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:77:15
    |
 LL |       let n = 1_isize << BITS;
    |               ^^^^^^^^^^^^^^^ attempt to shift left with overflow
 
-warning: this arithmetic operation will overflow
+error: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:78:15
    |
 LL |       let n = 1_usize << BITS;
    |               ^^^^^^^^^^^^^^^ attempt to shift left with overflow
 
-warning: 24 warnings emitted
+error: aborting due to 23 previous errors
 

--- a/src/test/ui/lint/lint-exceeding-bitshifts.rs
+++ b/src/test/ui/lint/lint-exceeding-bitshifts.rs
@@ -2,11 +2,11 @@
 //[noopt]compile-flags: -C opt-level=0
 //[opt]compile-flags: -O
 //[opt_with_overflow_checks]compile-flags: -C overflow-checks=on -O
-// build-pass
-// ignore-pass (test emits codegen-time warnings and verifies that they are not errors)
+
+// build-fail
 
 #![crate_type="lib"]
-#![warn(arithmetic_overflow, const_err)]
+#![deny(arithmetic_overflow, const_err)]
 #![allow(unused_variables)]
 #![allow(dead_code)]
 
@@ -15,65 +15,65 @@ pub trait Foo {
 }
 
 impl<T: Foo> Foo for Vec<T> {
-    const N: i32 = T::N << 42; //~ WARN: arithmetic operation will overflow
+    const N: i32 = T::N << 42; // FIXME this should warn
 }
 
 pub fn foo(x: i32) {
-    let _ = x << 42; //~ WARN: arithmetic operation will overflow
+    let _ = x << 42; //~ ERROR: arithmetic operation will overflow
 }
 
 pub fn main() {
       let n = 1u8 << 7;
-      let n = 1u8 << 8;   //~ WARN: arithmetic operation will overflow
+      let n = 1u8 << 8;   //~ ERROR: arithmetic operation will overflow
       let n = 1u16 << 15;
-      let n = 1u16 << 16; //~ WARN: arithmetic operation will overflow
+      let n = 1u16 << 16; //~ ERROR: arithmetic operation will overflow
       let n = 1u32 << 31;
-      let n = 1u32 << 32; //~ WARN: arithmetic operation will overflow
+      let n = 1u32 << 32; //~ ERROR: arithmetic operation will overflow
       let n = 1u64 << 63;
-      let n = 1u64 << 64; //~ WARN: arithmetic operation will overflow
+      let n = 1u64 << 64; //~ ERROR: arithmetic operation will overflow
       let n = 1i8 << 7;
-      let n = 1i8 << 8;   //~ WARN: arithmetic operation will overflow
+      let n = 1i8 << 8;   //~ ERROR: arithmetic operation will overflow
       let n = 1i16 << 15;
-      let n = 1i16 << 16; //~ WARN: arithmetic operation will overflow
+      let n = 1i16 << 16; //~ ERROR: arithmetic operation will overflow
       let n = 1i32 << 31;
-      let n = 1i32 << 32; //~ WARN: arithmetic operation will overflow
+      let n = 1i32 << 32; //~ ERROR: arithmetic operation will overflow
       let n = 1i64 << 63;
-      let n = 1i64 << 64; //~ WARN: arithmetic operation will overflow
+      let n = 1i64 << 64; //~ ERROR: arithmetic operation will overflow
 
       let n = 1u8 >> 7;
-      let n = 1u8 >> 8;   //~ WARN: arithmetic operation will overflow
+      let n = 1u8 >> 8;   //~ ERROR: arithmetic operation will overflow
       let n = 1u16 >> 15;
-      let n = 1u16 >> 16; //~ WARN: arithmetic operation will overflow
+      let n = 1u16 >> 16; //~ ERROR: arithmetic operation will overflow
       let n = 1u32 >> 31;
-      let n = 1u32 >> 32; //~ WARN: arithmetic operation will overflow
+      let n = 1u32 >> 32; //~ ERROR: arithmetic operation will overflow
       let n = 1u64 >> 63;
-      let n = 1u64 >> 64; //~ WARN: arithmetic operation will overflow
+      let n = 1u64 >> 64; //~ ERROR: arithmetic operation will overflow
       let n = 1i8 >> 7;
-      let n = 1i8 >> 8;   //~ WARN: arithmetic operation will overflow
+      let n = 1i8 >> 8;   //~ ERROR: arithmetic operation will overflow
       let n = 1i16 >> 15;
-      let n = 1i16 >> 16; //~ WARN: arithmetic operation will overflow
+      let n = 1i16 >> 16; //~ ERROR: arithmetic operation will overflow
       let n = 1i32 >> 31;
-      let n = 1i32 >> 32; //~ WARN: arithmetic operation will overflow
+      let n = 1i32 >> 32; //~ ERROR: arithmetic operation will overflow
       let n = 1i64 >> 63;
-      let n = 1i64 >> 64; //~ WARN: arithmetic operation will overflow
+      let n = 1i64 >> 64; //~ ERROR: arithmetic operation will overflow
 
       let n = 1u8;
       let n = n << 7;
-      let n = n << 8; //~ WARN: arithmetic operation will overflow
+      let n = n << 8; //~ ERROR: arithmetic operation will overflow
 
-      let n = 1u8 << -8; //~ WARN: arithmetic operation will overflow
+      let n = 1u8 << -8; //~ ERROR: arithmetic operation will overflow
 
       let n = 1i8<<(1isize+-1);
 
       let n = 1u8 << (4+3);
-      let n = 1u8 << (4+4); //~ WARN: arithmetic operation will overflow
+      let n = 1u8 << (4+4); //~ ERROR: arithmetic operation will overflow
       let n = 1i64 >> [63][0];
-      let n = 1i64 >> [64][0]; //~ WARN: arithmetic operation will overflow
+      let n = 1i64 >> [64][0]; //~ ERROR: arithmetic operation will overflow
 
       #[cfg(target_pointer_width = "32")]
       const BITS: usize = 32;
       #[cfg(target_pointer_width = "64")]
       const BITS: usize = 64;
-      let n = 1_isize << BITS; //~ WARN: arithmetic operation will overflow
-      let n = 1_usize << BITS; //~ WARN: arithmetic operation will overflow
+      let n = 1_isize << BITS; //~ ERROR: arithmetic operation will overflow
+      let n = 1_usize << BITS; //~ ERROR: arithmetic operation will overflow
 }


### PR DESCRIPTION
Successful merges:

 - #71364 (Ignore -Zprofile when building compiler_builtins)
 - #71494 (Fix span of while (let) expressions after lowering)
 - #71517 ( Quick and dirty fix of the unused_braces lint)
 - #71523 (Take a single root node in range_search)
 - #71533 (Revert PR 70566 for const validation fix)

Failed merges:


r? @ghost