### PR TITLE
remove `&'static` bound from type_id intrinsic (RFC 1849)

### DIFF
--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -1012,7 +1012,7 @@ extern "rust-intrinsic" {
     /// The stabilized version of this intrinsic is
     /// [`std::any::TypeId::of`](../../std/any/struct.TypeId.html#method.of)
     #[rustc_const_unstable(feature = "const_type_id", issue = "none")]
-    pub fn type_id<T: ?Sized + 'static>() -> u64;
+    pub fn type_id<T: ?Sized>() -> u64;
 
     /// A guard for unsafe functions that cannot ever be executed if `T` is uninhabited:
     /// This will statically either panic, or do nothing.

--- a/src/test/ui/auxiliary/typeid-intrinsic-aux1.rs
+++ b/src/test/ui/auxiliary/typeid-intrinsic-aux1.rs
@@ -5,6 +5,7 @@ pub struct B(Option<A>);
 pub struct C(Option<isize>);
 pub struct D(Option<&'static str>);
 pub struct E(Result<&'static str, isize>);
+pub struct J<'a>(&'a str);
 
 pub type F = Option<isize>;
 pub type G = usize;
@@ -22,6 +23,7 @@ pub fn id_F() -> TypeId { TypeId::of::<F>() }
 pub fn id_G() -> TypeId { TypeId::of::<G>() }
 pub fn id_H() -> TypeId { TypeId::of::<H>() }
 pub fn id_I() -> TypeId { TypeId::of::<I>() }
+pub fn id_J() -> TypeId { TypeId::of::<J>() }
 
 pub fn foo<T: Any>() -> TypeId { TypeId::of::<T>() }
 

--- a/src/test/ui/auxiliary/typeid-intrinsic-aux2.rs
+++ b/src/test/ui/auxiliary/typeid-intrinsic-aux2.rs
@@ -5,6 +5,7 @@ pub struct B(Option<A>);
 pub struct C(Option<isize>);
 pub struct D(Option<&'static str>);
 pub struct E(Result<&'static str, isize>);
+pub struct J<'a>(&'a str);
 
 pub type F = Option<isize>;
 pub type G = usize;
@@ -22,6 +23,7 @@ pub fn id_F() -> TypeId { TypeId::of::<F>() }
 pub fn id_G() -> TypeId { TypeId::of::<G>() }
 pub fn id_H() -> TypeId { TypeId::of::<H>() }
 pub fn id_I() -> TypeId { TypeId::of::<I>() }
+pub fn id_J() -> TypeId { TypeId::of::<J>() }
 
 pub fn foo<T: Any>() -> TypeId { TypeId::of::<T>() }
 

--- a/src/test/ui/typeid-intrinsic.rs
+++ b/src/test/ui/typeid-intrinsic.rs
@@ -11,9 +11,13 @@ extern crate typeid_intrinsic_aux2 as other2;
 
 use std::hash::{SipHasher, Hasher, Hash};
 use std::any::TypeId;
+use std::intrinsics::type_id;
 
 struct A;
 struct Test;
+struct ContainsRef<'a>{
+    field: &'a str
+}
 
 pub fn main() {
     assert_eq!(TypeId::of::<other1::A>(), other1::id_A());
@@ -25,6 +29,7 @@ pub fn main() {
     assert_eq!(TypeId::of::<other1::G>(), other1::id_G());
     assert_eq!(TypeId::of::<other1::H>(), other1::id_H());
     assert_eq!(TypeId::of::<other1::I>(), other1::id_I());
+    assert_eq!(TypeId::of::<other1::J>(), other1::id_J());
 
     assert_eq!(TypeId::of::<other2::A>(), other2::id_A());
     assert_eq!(TypeId::of::<other2::B>(), other2::id_B());
@@ -35,6 +40,7 @@ pub fn main() {
     assert_eq!(TypeId::of::<other2::G>(), other2::id_G());
     assert_eq!(TypeId::of::<other2::H>(), other2::id_H());
     assert_eq!(TypeId::of::<other1::I>(), other2::id_I());
+    assert_eq!(TypeId::of::<other2::J>(), other2::id_J());
 
     assert_eq!(other1::id_F(), other2::id_F());
     assert_eq!(other1::id_G(), other2::id_G());
@@ -47,6 +53,7 @@ pub fn main() {
     assert_eq!(TypeId::of::<A>(), other2::foo::<A>());
     assert_eq!(TypeId::of::<A>(), other1::foo::<A>());
     assert_eq!(other2::foo::<A>(), other1::foo::<A>());
+    assert_eq!(other1::id_J(), other2::id_J());
 
     // sanity test of TypeId
     let (a, b, c) = (TypeId::of::<usize>(), TypeId::of::<&'static str>(),
@@ -94,4 +101,11 @@ pub fn main() {
         TypeId::of::<for<'a, 'b> fn(&'a i32, &'b i32) -> &'a i32>(),
         TypeId::of::<for<'a, 'b> fn(&'b i32, &'a i32) -> &'a i32>()
     );
+
+    // non-static lifetimes are OK but ignored for the raw type_id intrinsic
+    fn non_static<'a>(arg: &'a str) {
+        assert_eq!(unsafe { type_id::<ContainsRef<'a>>() },
+                   unsafe { type_id::<ContainsRef<'static>>() });
+    }
+    non_static(&String::from("rah"));
 }

--- a/src/test/ui/typeid-intrinsic.rs
+++ b/src/test/ui/typeid-intrinsic.rs
@@ -53,7 +53,6 @@ pub fn main() {
     assert_eq!(TypeId::of::<A>(), other2::foo::<A>());
     assert_eq!(TypeId::of::<A>(), other1::foo::<A>());
     assert_eq!(other2::foo::<A>(), other1::foo::<A>());
-    assert_eq!(other1::id_J(), other2::id_J());
 
     // sanity test of TypeId
     let (a, b, c) = (TypeId::of::<usize>(), TypeId::of::<&'static str>(),

--- a/src/test/ui/typeid-intrinsic.rs
+++ b/src/test/ui/typeid-intrinsic.rs
@@ -16,7 +16,7 @@ use std::intrinsics::type_id;
 struct A;
 struct Test;
 struct ContainsRef<'a>{
-    field: &'a str
+    _field: &'a str
 }
 
 pub fn main() {
@@ -103,9 +103,8 @@ pub fn main() {
     );
 
     // non-static lifetimes are OK but ignored for the raw type_id intrinsic
-    fn non_static<'a>(arg: &'a str) {
-        assert_eq!(unsafe { type_id::<ContainsRef<'a>>() },
-                   unsafe { type_id::<ContainsRef<'static>>() });
+    fn non_static<'a>(_arg: &'a str) {
+        assert_eq!(type_id::<ContainsRef<'a>>(), type_id::<ContainsRef<'static>>());
     }
     non_static(&String::from("rah"));
 }


### PR DESCRIPTION
Reopen of #66272 

The broken test in the original PR was not supposed to pass.
By removing it, everything passes.

cc #41875 
r? @Dylan-DPC 