### PR TITLE
Handle build completion message from Cargo

### DIFF
--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -1012,4 +1012,7 @@ pub enum CargoMessage<'a> {
     BuildScriptExecuted {
         package_id: Cow<'a, str>,
     },
+    BuildFinished {
+        success: bool,
+    },
 }


### PR DESCRIPTION
This was introduced in the recent bump to 1.44 bootstrap cargo

Fixes #71561.