### PR TITLE
Document unsafety in slice/sort.rs

### DIFF
--- a/src/libcore/slice/sort.rs
+++ b/src/libcore/slice/sort.rs
@@ -250,6 +250,7 @@ where
     let mut offsets_l = [MaybeUninit::<u8>::uninit(); BLOCK];
 
     // The current block on the right side (from `r.sub(block_r)` to `r`).
+    // SAFETY: The documentation for .add() specifically mention that `vec.as_ptr().add(vec.len())` is always safe`
     let mut r = unsafe { l.add(v.len()) };
     let mut block_r = BLOCK;
     let mut start_r = ptr::null_mut();
@@ -435,12 +436,14 @@ where
         let mut l = 0;
         let mut r = v.len();
         unsafe {
-            // Find the first element greater then or equal to the pivot.
+            // Find the first element greater than or equal to the pivot.
+            // SAFETY: We already do the bound checking here with `l<r`.
             while l < r && is_less(v.get_unchecked(l), pivot) {
                 l += 1;
             }
 
             // Find the last element smaller that the pivot.
+            // SAFETY: The minimum value for `l` is 0 and the maximum value for `r` is `v.len().`
             while l < r && !is_less(v.get_unchecked(r - 1), pivot) {
                 r -= 1;
             }
@@ -483,12 +486,14 @@ where
     let mut r = v.len();
     loop {
         unsafe {
-            // Find the first element greater that the pivot.
+            // Find the first element greater than the pivot.
+            // SAFETY: We already do the bound checking here with `l<r`
             while l < r && !is_less(pivot, v.get_unchecked(l)) {
                 l += 1;
             }
 
             // Find the last element equal to the pivot.
+            // SAFETY: The minimum value for `l` is 0 and the maximum value for `r` is `v.len().`
             while l < r && is_less(pivot, v.get_unchecked(r - 1)) {
                 r -= 1;
             }

--- a/src/libcore/slice/sort.rs
+++ b/src/libcore/slice/sort.rs
@@ -1,6 +1,6 @@
 //! Slice sorting
 //!
-//! This module contains an sort algorithm based on Orson Peters' pattern-defeating quicksort,
+//! This module contains a sorting algorithm based on Orson Peters' pattern-defeating quicksort,
 //! published at: https://github.com/orlp/pdqsort
 //!
 //! Unstable sorting is compatible with libcore because it doesn't allocate memory, unlike our
@@ -32,6 +32,20 @@ where
     F: FnMut(&T, &T) -> bool,
 {
     let len = v.len();
+    // SAFETY: The unsafe operations below involves indexing without a bound check (`get_unchecked` and `get_unchecked_mut`)
+    // and copying memory (`ptr::copy_nonoverlapping`).
+    //
+    // a. Indexing:
+    //  1. We checked the size of the array to >=2.
+    //  2. All the indexing that we will do is always between {0 <= index < len} at most.
+    //
+    // b. Memory copying
+    //  1. We are obtaining pointers to references which are guaranteed to be valid.
+    //  2. They cannot overlap because we obtain pointers to difference indices of the slice.
+    //     Namely, `i` and `i-1`.
+    //  3. FIXME: Guarantees that the elements are properly aligned?
+    //
+    // See comments below for further detail.
     unsafe {
         // If the first two elements are out-of-order...
         if len >= 2 && is_less(v.get_unchecked(1), v.get_unchecked(0)) {

--- a/src/libcore/slice/sort.rs
+++ b/src/libcore/slice/sort.rs
@@ -131,6 +131,8 @@ where
     let mut i = 1;
 
     for _ in 0..MAX_STEPS {
+        // SAFETY: We already explicitly done the bound checking with `i<len`
+        // All our indexing following that is only in the range {0 <= index < len}
         unsafe {
             // Find the next pair of adjacent out-of-order elements.
             while i < len && !is_less(v.get_unchecked(i), v.get_unchecked(i - 1)) {

--- a/src/libcore/slice/sort.rs
+++ b/src/libcore/slice/sort.rs
@@ -76,6 +76,20 @@ where
     F: FnMut(&T, &T) -> bool,
 {
     let len = v.len();
+    // SAFETY: As with shift_head, the unsafe operations below involves indexing without a bound check (`get_unchecked` and `get_unchecked_mut`)
+    // and copying memory (`ptr::copy_nonoverlapping`).
+    //
+    // a. Indexing:
+    //  1. We checked the size of the array to >=2.
+    //  2. All the indexing that we will do is always between {0 <= index < len-1} at most.
+    //
+    // b. Memory copying
+    //  1. We are obtaining pointers to references which are guaranteed to be valid.
+    //  2. They cannot overlap because we obtain pointers to difference indices of the slice.
+    //     Namely, `i` and `i+1`.
+    //  3. FIXME: Guarantees that the elements are properly aligned?
+    //
+    // See comments below for further detail.
     unsafe {
         // If the last two elements are out-of-order...
         if len >= 2 && is_less(v.get_unchecked(len - 1), v.get_unchecked(len - 2)) {

--- a/src/libcore/slice/sort.rs
+++ b/src/libcore/slice/sort.rs
@@ -435,15 +435,17 @@ where
         // Find the first pair of out-of-order elements.
         let mut l = 0;
         let mut r = v.len();
+
+        // SAFETY: The unsafety below involves indexing an array.
+        // For the first one: we already do the bound checking here with `l<r`.
+        // For the secondn one: the minimum value for `l` is 0 and the maximum value for `r` is `v.len().`
         unsafe {
             // Find the first element greater than or equal to the pivot.
-            // SAFETY: We already do the bound checking here with `l<r`.
             while l < r && is_less(v.get_unchecked(l), pivot) {
                 l += 1;
             }
 
             // Find the last element smaller that the pivot.
-            // SAFETY: The minimum value for `l` is 0 and the maximum value for `r` is `v.len().`
             while l < r && !is_less(v.get_unchecked(r - 1), pivot) {
                 r -= 1;
             }
@@ -477,6 +479,7 @@ where
 
     // Read the pivot into a stack-allocated variable for efficiency. If a following comparison
     // operation panics, the pivot will be automatically written back into the slice.
+    // SAFETY: The pointer here is valid because it is obtained from a reference to a slice.
     let mut tmp = mem::ManuallyDrop::new(unsafe { ptr::read(pivot) });
     let _pivot_guard = CopyOnDrop { src: &mut *tmp, dest: pivot };
     let pivot = &*tmp;
@@ -485,15 +488,16 @@ where
     let mut l = 0;
     let mut r = v.len();
     loop {
+        // SAFETY: The unsafety below involves indexing an array.
+        // For the first one: we already do the bound checking here with `l<r`.
+        // For the second one: the minimum value for `l` is 0 and the maximum value for `r` is `v.len().`
         unsafe {
             // Find the first element greater than the pivot.
-            // SAFETY: We already do the bound checking here with `l<r`
             while l < r && !is_less(pivot, v.get_unchecked(l)) {
                 l += 1;
             }
 
             // Find the last element equal to the pivot.
-            // SAFETY: The minimum value for `l` is 0 and the maximum value for `r` is `v.len().`
             while l < r && is_less(pivot, v.get_unchecked(r - 1)) {
                 r -= 1;
             }


### PR DESCRIPTION
Let me know if these documentations are accurate c:

I don't think I am capable enough to document the safety of `partition_blocks`, however.

Related issue #66219