### PR TITLE
[miri] Throw UB if target size and data size don't match

### DIFF
--- a/src/librustc_middle/mir/interpret/error.rs
+++ b/src/librustc_middle/mir/interpret/error.rs
@@ -361,6 +361,11 @@ pub enum UndefinedBehaviorInfo {
     InvalidUndefBytes(Option<Pointer>),
     /// Working with a local that is not currently live.
     DeadLocal,
+    /// Data size is not equal to target size
+    ArgumentSizeMismatch {
+        target_size: u64,
+        data_size: u64,
+    },
 }
 
 impl fmt::Debug for UndefinedBehaviorInfo {
@@ -422,6 +427,11 @@ impl fmt::Debug for UndefinedBehaviorInfo {
                 "using uninitialized data, but this operation requires initialized memory"
             ),
             DeadLocal => write!(f, "accessing a dead local variable"),
+            ArgumentSizeMismatch { target_size, data_size } => write!(
+                f,
+                "argument size mismatch: expected {} bytes but got {} bytes instead",
+                target_size, data_size
+            ),
         }
     }
 }

--- a/src/librustc_middle/mir/interpret/error.rs
+++ b/src/librustc_middle/mir/interpret/error.rs
@@ -361,7 +361,7 @@ pub enum UndefinedBehaviorInfo {
     InvalidUndefBytes(Option<Pointer>),
     /// Working with a local that is not currently live.
     DeadLocal,
-    /// Data size is not equal to target size
+    /// Data size is not equal to target size.
     ScalarSizeMismatch {
         target_size: u64,
         data_size: u64,

--- a/src/librustc_middle/mir/interpret/error.rs
+++ b/src/librustc_middle/mir/interpret/error.rs
@@ -362,7 +362,7 @@ pub enum UndefinedBehaviorInfo {
     /// Working with a local that is not currently live.
     DeadLocal,
     /// Data size is not equal to target size
-    ArgumentSizeMismatch {
+    ScalarSizeMismatch {
         target_size: u64,
         data_size: u64,
     },
@@ -427,9 +427,9 @@ impl fmt::Debug for UndefinedBehaviorInfo {
                 "using uninitialized data, but this operation requires initialized memory"
             ),
             DeadLocal => write!(f, "accessing a dead local variable"),
-            ArgumentSizeMismatch { target_size, data_size } => write!(
+            ScalarSizeMismatch { target_size, data_size } => write!(
                 f,
-                "argument size mismatch: expected {} bytes but got {} bytes instead",
+                "scalar size mismatch: expected {} bytes but got {} bytes instead",
                 target_size, data_size
             ),
         }

--- a/src/librustc_middle/mir/interpret/value.rs
+++ b/src/librustc_middle/mir/interpret/value.rs
@@ -393,7 +393,12 @@ impl<'tcx, Tag> Scalar<Tag> {
         assert_ne!(target_size.bytes(), 0, "you should never look at the bits of a ZST");
         match self {
             Scalar::Raw { data, size } => {
-                assert_eq!(target_size.bytes(), u64::from(size));
+                if target_size.bytes() != u64::from(size) {
+                    throw_ub!(ArgumentSizeMismatch {
+                        target_size: target_size.bytes(),
+                        data_size: u64::from(size)
+                    });
+                }
                 Scalar::check_data(data, size);
                 Ok(data)
             }

--- a/src/librustc_middle/mir/interpret/value.rs
+++ b/src/librustc_middle/mir/interpret/value.rs
@@ -394,9 +394,9 @@ impl<'tcx, Tag> Scalar<Tag> {
         match self {
             Scalar::Raw { data, size } => {
                 if target_size.bytes() != u64::from(size) {
-                    throw_ub!(ArgumentSizeMismatch {
+                    throw_ub!(ScalarSizeMismatch {
                         target_size: target_size.bytes(),
-                        data_size: u64::from(size)
+                        data_size: u64::from(size),
                     });
                 }
                 Scalar::check_data(data, size);


### PR DESCRIPTION
Issue: https://github.com/rust-lang/miri/issues/1355

If an extern C function is defined as

```
extern "C" {
    fn malloc(size: u32) -> *mut std::ffi::c_void;
}
```

on a 64-bit machine(ie. pointer sizes don't match), return undefined behaviour from Miri when [converting the argument into machine_usize](https://github.com/rust-lang/miri/blob/master/src/shims/foreign_items.rs#L200)