### PR TITLE
Implement Fn traits for Rc and Arc

### DIFF
--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -1436,6 +1436,29 @@ impl<T: ?Sized> fmt::Pointer for Rc<T> {
     }
 }
 
+#[stable(feature = "rc_fn", since = "1.45.0")]
+impl<A, F: Fn<A> + ?Sized> FnOnce<A> for Rc<F> {
+    type Output = <F as FnOnce<A>>::Output;
+
+    extern "rust-call" fn call_once(self, args: A) -> Self::Output {
+        <F as Fn<A>>::call(&*self, args)
+    }
+}
+
+#[stable(feature = "rc_fn", since = "1.45.0")]
+impl<A, F: Fn<A> + ?Sized> FnMut<A> for Rc<F> {
+    extern "rust-call" fn call_mut(&mut self, args: A) -> Self::Output {
+        <F as Fn<A>>::call(self, args)
+    }
+}
+
+#[stable(feature = "rc_fn", since = "1.45.0")]
+impl<A, F: Fn<A> + ?Sized> Fn<A> for Rc<F> {
+    extern "rust-call" fn call(&self, args: A) -> Self::Output {
+        <F as Fn<A>>::call(self, args)
+    }
+}
+
 #[stable(feature = "from_for_ptrs", since = "1.6.0")]
 impl<T> From<T> for Rc<T> {
     fn from(t: T) -> Self {

--- a/src/liballoc/rc/tests.rs
+++ b/src/liballoc/rc/tests.rs
@@ -434,3 +434,23 @@ fn test_array_from_slice() {
     let a: Result<Rc<[u32; 2]>, _> = r.clone().try_into();
     assert!(a.is_err());
 }
+
+#[test]
+fn test_fn() {
+    fn apply_fn_once<T>(v: T, f: impl FnOnce(T)) {
+        f(v)
+    }
+    fn apply_fn_mut<T>(v: T, mut f: impl FnMut(T)) {
+        f(v)
+    }
+    fn apply_fn<T>(v: T, f: impl Fn(T)) {
+        f(v)
+    }
+
+    let x = RefCell::new(0);
+    let f = Rc::new(|v: i32| *x.borrow_mut() += v);
+    apply_fn_once(1, f.clone());
+    apply_fn_mut(2, f.clone());
+    apply_fn(4, f.clone());
+    assert_eq!(*x.borrow(), 7);
+}

--- a/src/liballoc/sync.rs
+++ b/src/liballoc/sync.rs
@@ -2066,6 +2066,29 @@ impl<T: ?Sized + Hash> Hash for Arc<T> {
     }
 }
 
+#[stable(feature = "rc_fn", since = "1.45.0")]
+impl<A, F: Fn<A> + ?Sized> FnOnce<A> for Arc<F> {
+    type Output = <F as FnOnce<A>>::Output;
+
+    extern "rust-call" fn call_once(self, args: A) -> Self::Output {
+        <F as Fn<A>>::call(&*self, args)
+    }
+}
+
+#[stable(feature = "rc_fn", since = "1.45.0")]
+impl<A, F: Fn<A> + ?Sized> FnMut<A> for Arc<F> {
+    extern "rust-call" fn call_mut(&mut self, args: A) -> Self::Output {
+        <F as Fn<A>>::call(self, args)
+    }
+}
+
+#[stable(feature = "rc_fn", since = "1.45.0")]
+impl<A, F: Fn<A> + ?Sized> Fn<A> for Arc<F> {
+    extern "rust-call" fn call(&self, args: A) -> Self::Output {
+        <F as Fn<A>>::call(self, args)
+    }
+}
+
 #[stable(feature = "from_for_ptrs", since = "1.6.0")]
 impl<T> From<T> for Arc<T> {
     fn from(t: T) -> Self {

--- a/src/liballoc/sync/tests.rs
+++ b/src/liballoc/sync/tests.rs
@@ -490,3 +490,23 @@ fn test_array_from_slice() {
     let a: Result<Arc<[u32; 2]>, _> = r.clone().try_into();
     assert!(a.is_err());
 }
+
+#[test]
+fn test_fn() {
+    fn apply_fn_once<T>(v: T, f: impl FnOnce(T)) {
+        f(v)
+    }
+    fn apply_fn_mut<T>(v: T, mut f: impl FnMut(T)) {
+        f(v)
+    }
+    fn apply_fn<T>(v: T, f: impl Fn(T)) {
+        f(v)
+    }
+
+    let x = Mutex::new(0);
+    let f = Arc::new(|v: i32| *x.lock().unwrap() += v);
+    apply_fn_once(1, f.clone());
+    apply_fn_mut(2, f.clone());
+    apply_fn(4, f.clone());
+    assert_eq!(*x.lock().unwrap(), 7);
+}


### PR DESCRIPTION
Given that `Box` implements `Fn` traits, I think it makes sense for `Rc` and `Arc` to do so as well. But since inner of `Rc` and `Arc` is shared, apparently they can only be invoked when `Fn` is satisfied.

WDYT?

I can create a tracking issue for it if the team is fine with this new `impl`.