### PR TITLE
remove obsolete comment

### DIFF
--- a/src/librustc_mir/util/elaborate_drops.rs
+++ b/src/librustc_mir/util/elaborate_drops.rs
@@ -835,13 +835,6 @@ where
         }
     }
 
-    /// Returns a basic block that drop a place using the context
-    /// and path in `c`. If `mode` is something, also clear `c`
-    /// according to it.
-    ///
-    /// if FLAG(self.path)
-    ///     if let Some(mode) = mode: FLAG(self.path)[mode] = false
-    ///     drop(self.place)
     fn complete_drop(
         &mut self,
         drop_mode: Option<DropFlagMode>,


### PR DESCRIPTION
Not sure if it's better to have an outdated comment or no comment at all (made obsolete by 2b9fea1300b515e0f8929bb3a09d4fb6fef3f0ea).