### PR TITLE
use new interface to create threads on HermitCore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1366,9 +1366,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.10"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "725cf19794cf90aa94e65050cb4191ff5d8fa87a498383774c47b332e3af952e"
+checksum = "61565ff7aaace3525556587bd2dc31d4a07071957be715e63ce7b1eccf51a8f4"
 dependencies = [
  "compiler_builtins",
  "libc",

--- a/src/libstd/Cargo.toml
+++ b/src/libstd/Cargo.toml
@@ -41,7 +41,7 @@ dlmalloc = { version = "0.1", features = ['rustc-dep-of-std'] }
 fortanix-sgx-abi = { version = "0.3.2", features = ['rustc-dep-of-std'] }
 
 [target.'cfg(all(any(target_arch = "x86_64", target_arch = "aarch64"), target_os = "hermit"))'.dependencies]
-hermit-abi = { version = "0.1.10", features = ['rustc-dep-of-std'] }
+hermit-abi = { version = "0.1.12", features = ['rustc-dep-of-std'] }
 
 [target.wasm32-wasi.dependencies]
 wasi = { version = "0.9.0", features = ['rustc-dep-of-std'], default-features = false }

--- a/src/libstd/sys/hermit/thread.rs
+++ b/src/libstd/sys/hermit/thread.rs
@@ -16,25 +16,24 @@ pub struct Thread {
 unsafe impl Send for Thread {}
 unsafe impl Sync for Thread {}
 
-pub const DEFAULT_MIN_STACK_SIZE: usize = 262144;
+pub const DEFAULT_MIN_STACK_SIZE: usize = 1_048_576;
 
 impl Thread {
     pub unsafe fn new_with_coreid(
-        _stack: usize,
+        stack: usize,
         p: Box<dyn FnOnce()>,
         core_id: isize,
     ) -> io::Result<Thread> {
         let p = Box::into_raw(box p);
-        let mut tid: Tid = u32::MAX;
-        let ret = abi::spawn(
-            &mut tid as *mut Tid,
+        let tid = abi::spawn2(
             thread_start,
-            &*p as *const _ as *const u8 as usize,
+            p as usize,
             abi::Priority::into(abi::NORMAL_PRIO),
+            stack,
             core_id,
         );
 
-        return if ret != 0 {
+        return if tid == 0 {
             // The thread failed to start and as a result p was not consumed. Therefore, it is
             // safe to reconstruct the box so that it gets deallocated.
             drop(Box::from_raw(p));

--- a/src/libstd/sys/hermit/thread.rs
+++ b/src/libstd/sys/hermit/thread.rs
@@ -16,7 +16,7 @@ pub struct Thread {
 unsafe impl Send for Thread {}
 unsafe impl Sync for Thread {}
 
-pub const DEFAULT_MIN_STACK_SIZE: usize = 1_048_576;
+pub const DEFAULT_MIN_STACK_SIZE: usize = 1 << 20;
 
 impl Thread {
     pub unsafe fn new_with_coreid(


### PR DESCRIPTION
- the new interface allows to define the stack size
- increase the default stack size to 1 MByte