### PR TITLE
Rename Unique::empty() -> Unique::dangling()

### DIFF
--- a/src/liballoc/raw_vec.rs
+++ b/src/liballoc/raw_vec.rs
@@ -25,9 +25,9 @@ mod tests;
 /// involved. This type is excellent for building your own data structures like Vec and VecDeque.
 /// In particular:
 ///
-/// * Produces `Unique::empty()` on zero-sized types.
-/// * Produces `Unique::empty()` on zero-length allocations.
-/// * Avoids freeing `Unique::empty()`.
+/// * Produces `Unique::dangling()` on zero-sized types.
+/// * Produces `Unique::dangling()` on zero-length allocations.
+/// * Avoids freeing `Unique::dangling()`.
 /// * Catches all overflows in capacity computations (promotes them to "capacity overflow" panics).
 /// * Guards against 32-bit systems allocating more than isize::MAX bytes.
 /// * Guards against overflowing your length.
@@ -125,7 +125,7 @@ impl<T, A: AllocRef> RawVec<T, A> {
     /// the returned `RawVec`.
     pub const fn new_in(alloc: A) -> Self {
         // `cap: 0` means "unallocated". zero-sized types are ignored.
-        Self { ptr: Unique::empty(), cap: 0, alloc }
+        Self { ptr: Unique::dangling(), cap: 0, alloc }
     }
 
     /// Like `with_capacity`, but parameterized over the choice of
@@ -172,7 +172,7 @@ impl<T, A: AllocRef> RawVec<T, A> {
     }
 
     /// Gets a raw pointer to the start of the allocation. Note that this is
-    /// `Unique::empty()` if `capacity == 0` or `T` is zero-sized. In the former case, you must
+    /// `Unique::dangling()` if `capacity == 0` or `T` is zero-sized. In the former case, you must
     /// be careful.
     pub fn ptr(&self) -> *mut T {
         self.ptr.as_ptr()

--- a/src/libcore/ptr/unique.rs
+++ b/src/libcore/ptr/unique.rs
@@ -70,9 +70,8 @@ impl<T: Sized> Unique<T> {
     /// a `T`, which means this must not be used as a "not yet initialized"
     /// sentinel value. Types that lazily allocate must track initialization by
     /// some other means.
-    // FIXME: rename to dangling() to match NonNull?
     #[inline]
-    pub const fn empty() -> Self {
+    pub const fn dangling() -> Self {
         // SAFETY: mem::align_of() returns a valid, non-null pointer. The
         // conditions to call new_unchecked() are thus respected.
         unsafe { Unique::new_unchecked(mem::align_of::<T>() as *mut T) }

--- a/src/test/ui/consts/const-ptr-unique-rpass.rs
+++ b/src/test/ui/consts/const-ptr-unique-rpass.rs
@@ -8,9 +8,9 @@ use test::black_box as b; // prevent promotion of the argument and const-propaga
 use std::ptr::Unique;
 
 
-const PTR: *mut u32 = Unique::empty().as_ptr();
+const PTR: *mut u32 = Unique::dangling().as_ptr();
 
 pub fn main() {
     // Be super-extra paranoid and cast the fn items to fn pointers before blackboxing them.
-    assert_eq!(PTR, b::<fn() -> _>(Unique::<u32>::empty)().as_ptr());
+    assert_eq!(PTR, b::<fn() -> _>(Unique::<u32>::dangling)().as_ptr());
 }


### PR DESCRIPTION
A `FIXME` comment in `src/libcore/ptr/unique.rs` suggested refactoring `Unique::empty()` to `Unique::dangling()` which this PR does.