### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/src/liballoc/collections/btree/node.rs
+++ b/src/liballoc/collections/btree/node.rs
@@ -131,7 +131,7 @@ impl<K, V> BoxedNode<K, V> {
     }
 
     unsafe fn from_ptr(ptr: NonNull<LeafNode<K, V>>) -> Self {
-        BoxedNode { ptr: Unique::from(ptr) }
+        BoxedNode { ptr: Unique::new_unchecked(ptr.as_ptr()) }
     }
 
     fn as_ptr(&self) -> NonNull<LeafNode<K, V>> {

--- a/src/liballoc/raw_vec.rs
+++ b/src/liballoc/raw_vec.rs
@@ -151,7 +151,7 @@ impl<T, A: AllocRef> RawVec<T, A> {
 
             let memory = alloc.alloc(layout, init).unwrap_or_else(|_| handle_alloc_error(layout));
             Self {
-                ptr: memory.ptr.cast().into(),
+                ptr: unsafe { Unique::new_unchecked(memory.ptr.cast().as_ptr()) },
                 cap: Self::capacity_from_bytes(memory.size),
                 alloc,
             }
@@ -469,7 +469,7 @@ impl<T, A: AllocRef> RawVec<T, A> {
     }
 
     fn set_memory(&mut self, memory: MemoryBlock) {
-        self.ptr = memory.ptr.cast().into();
+        self.ptr = unsafe { Unique::new_unchecked(memory.ptr.cast().as_ptr()) };
         self.cap = Self::capacity_from_bytes(memory.size);
     }
 

--- a/src/libcore/ptr/unique.rs
+++ b/src/libcore/ptr/unique.rs
@@ -3,7 +3,6 @@ use crate::fmt;
 use crate::marker::{PhantomData, Unsize};
 use crate::mem;
 use crate::ops::{CoerceUnsized, DispatchFromDyn};
-use crate::ptr::NonNull;
 
 // ignore-tidy-undocumented-unsafe
 
@@ -169,21 +168,5 @@ impl<T: ?Sized> From<&mut T> for Unique<T> {
     #[inline]
     fn from(reference: &mut T) -> Self {
         unsafe { Unique { pointer: reference as *mut T, _marker: PhantomData } }
-    }
-}
-
-#[unstable(feature = "ptr_internals", issue = "none")]
-impl<T: ?Sized> From<&T> for Unique<T> {
-    #[inline]
-    fn from(reference: &T) -> Self {
-        unsafe { Unique { pointer: reference as *const T, _marker: PhantomData } }
-    }
-}
-
-#[unstable(feature = "ptr_internals", issue = "none")]
-impl<T: ?Sized> From<NonNull<T>> for Unique<T> {
-    #[inline]
-    fn from(p: NonNull<T>) -> Self {
-        unsafe { Unique::new_unchecked(p.as_ptr()) }
     }
 }

--- a/src/libproc_macro/lib.rs
+++ b/src/libproc_macro/lib.rs
@@ -303,7 +303,7 @@ impl Span {
     /// definition site (local variables, labels, `$crate`) and sometimes at the macro
     /// call site (everything else).
     /// The span location is taken from the call-site.
-    #[unstable(feature = "proc_macro_mixed_site", issue = "65049")]
+    #[stable(feature = "proc_macro_mixed_site", since = "1.45.0")]
     pub fn mixed_site() -> Span {
         Span(bridge::client::Span::mixed_site())
     }

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -2064,52 +2064,64 @@ impl<'a> Resolver<'a> {
                 };
             }
 
-            let binding = if let Some(module) = module {
-                self.resolve_ident_in_module(
-                    module,
-                    ident,
-                    ns,
-                    parent_scope,
-                    record_used,
-                    path_span,
-                )
-            } else if ribs.is_none() || opt_ns.is_none() || opt_ns == Some(MacroNS) {
-                let scopes = ScopeSet::All(ns, opt_ns.is_none());
-                self.early_resolve_ident_in_lexical_scope(
-                    ident,
-                    scopes,
-                    parent_scope,
-                    record_used,
-                    record_used,
-                    path_span,
-                )
-            } else {
-                let record_used_id =
-                    if record_used { crate_lint.node_id().or(Some(CRATE_NODE_ID)) } else { None };
-                match self.resolve_ident_in_lexical_scope(
-                    ident,
-                    ns,
-                    parent_scope,
-                    record_used_id,
-                    path_span,
-                    &ribs.unwrap()[ns],
-                ) {
-                    // we found a locally-imported or available item/module
-                    Some(LexicalScopeBinding::Item(binding)) => Ok(binding),
-                    // we found a local variable or type param
-                    Some(LexicalScopeBinding::Res(res))
-                        if opt_ns == Some(TypeNS) || opt_ns == Some(ValueNS) =>
-                    {
-                        record_segment_res(self, res);
-                        return PathResult::NonModule(PartialRes::with_unresolved_segments(
-                            res,
-                            path.len() - 1,
-                        ));
+            enum FindBindingResult<'a> {
+                Binding(Result<&'a NameBinding<'a>, Determinacy>),
+                PathResult(PathResult<'a>),
+            }
+            let find_binding_in_ns = |this: &mut Self, ns| {
+                let binding = if let Some(module) = module {
+                    this.resolve_ident_in_module(
+                        module,
+                        ident,
+                        ns,
+                        parent_scope,
+                        record_used,
+                        path_span,
+                    )
+                } else if ribs.is_none() || opt_ns.is_none() || opt_ns == Some(MacroNS) {
+                    let scopes = ScopeSet::All(ns, opt_ns.is_none());
+                    this.early_resolve_ident_in_lexical_scope(
+                        ident,
+                        scopes,
+                        parent_scope,
+                        record_used,
+                        record_used,
+                        path_span,
+                    )
+                } else {
+                    let record_used_id = if record_used {
+                        crate_lint.node_id().or(Some(CRATE_NODE_ID))
+                    } else {
+                        None
+                    };
+                    match this.resolve_ident_in_lexical_scope(
+                        ident,
+                        ns,
+                        parent_scope,
+                        record_used_id,
+                        path_span,
+                        &ribs.unwrap()[ns],
+                    ) {
+                        // we found a locally-imported or available item/module
+                        Some(LexicalScopeBinding::Item(binding)) => Ok(binding),
+                        // we found a local variable or type param
+                        Some(LexicalScopeBinding::Res(res))
+                            if opt_ns == Some(TypeNS) || opt_ns == Some(ValueNS) =>
+                        {
+                            record_segment_res(this, res);
+                            return FindBindingResult::PathResult(PathResult::NonModule(
+                                PartialRes::with_unresolved_segments(res, path.len() - 1),
+                            ));
+                        }
+                        _ => Err(Determinacy::determined(record_used)),
                     }
-                    _ => Err(Determinacy::determined(record_used)),
-                }
+                };
+                FindBindingResult::Binding(binding)
             };
-
+            let binding = match find_binding_in_ns(self, ns) {
+                FindBindingResult::PathResult(x) => return x,
+                FindBindingResult::Binding(binding) => binding,
+            };
             match binding {
                 Ok(binding) => {
                     if i == 1 {
@@ -2199,7 +2211,30 @@ impl<'a> Resolver<'a> {
                     } else if i == 0 {
                         (format!("use of undeclared type or module `{}`", ident), None)
                     } else {
-                        (format!("could not find `{}` in `{}`", ident, path[i - 1].ident), None)
+                        let mut msg =
+                            format!("could not find `{}` in `{}`", ident, path[i - 1].ident);
+                        if ns == TypeNS {
+                            if let FindBindingResult::Binding(Ok(_)) =
+                                find_binding_in_ns(self, ValueNS)
+                            {
+                                msg = format!(
+                                    "`{}` in `{}` is a concrete value, not a module or Struct you specified",
+                                    ident,
+                                    path[i - 1].ident
+                                );
+                            };
+                        } else if ns == ValueNS {
+                            if let FindBindingResult::Binding(Ok(_)) =
+                                find_binding_in_ns(self, TypeNS)
+                            {
+                                msg = format!(
+                                    "`{}` in `{}` is a type, not a concrete value you specified",
+                                    ident,
+                                    path[i - 1].ident
+                                );
+                            };
+                        }
+                        (msg, None)
                     };
                     return PathResult::Failed {
                         span: ident.span,

--- a/src/librustc_span/source_map.rs
+++ b/src/librustc_span/source_map.rs
@@ -20,7 +20,6 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::Ordering;
 
 use log::debug;
-use std::env;
 use std::fs;
 use std::io;
 
@@ -64,9 +63,6 @@ pub trait FileLoader {
     /// Query the existence of a file.
     fn file_exists(&self, path: &Path) -> bool;
 
-    /// Returns an absolute path to a file, if possible.
-    fn abs_path(&self, path: &Path) -> Option<PathBuf>;
-
     /// Read the contents of an UTF-8 file into memory.
     fn read_file(&self, path: &Path) -> io::Result<String>;
 }
@@ -77,14 +73,6 @@ pub struct RealFileLoader;
 impl FileLoader for RealFileLoader {
     fn file_exists(&self, path: &Path) -> bool {
         fs::metadata(path).is_ok()
-    }
-
-    fn abs_path(&self, path: &Path) -> Option<PathBuf> {
-        if path.is_absolute() {
-            Some(path.to_path_buf())
-        } else {
-            env::current_dir().ok().map(|cwd| cwd.join(path))
-        }
     }
 
     fn read_file(&self, path: &Path) -> io::Result<String> {

--- a/src/librustc_trait_selection/traits/error_reporting/suggestions.rs
+++ b/src/librustc_trait_selection/traits/error_reporting/suggestions.rs
@@ -84,6 +84,8 @@ pub trait InferCtxtExt<'tcx> {
         trait_ref: &ty::Binder<ty::TraitRef<'tcx>>,
     );
 
+    fn return_type_span(&self, obligation: &PredicateObligation<'tcx>) -> Option<Span>;
+
     fn suggest_impl_trait(
         &self,
         err: &mut DiagnosticBuilder<'tcx>,
@@ -758,6 +760,17 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                 }
             }
         }
+    }
+
+    fn return_type_span(&self, obligation: &PredicateObligation<'tcx>) -> Option<Span> {
+        let hir = self.tcx.hir();
+        let parent_node = hir.get_parent_node(obligation.cause.body_id);
+        let sig = match hir.find(parent_node) {
+            Some(hir::Node::Item(hir::Item { kind: hir::ItemKind::Fn(sig, ..), .. })) => sig,
+            _ => return None,
+        };
+
+        if let hir::FnRetTy::Return(ret_ty) = sig.decl.output { Some(ret_ty.span) } else { None }
     }
 
     /// If all conditions are met to identify a returned `dyn Trait`, suggest using `impl Trait` if

--- a/src/test/ui/codemap_tests/two_files.stderr
+++ b/src/test/ui/codemap_tests/two_files.stderr
@@ -4,7 +4,11 @@ error[E0404]: expected trait, found type alias `Bar`
 LL | impl Bar for Baz { }
    |      ^^^ type aliases cannot be used as traits
    |
-   = note: did you mean to use a trait alias?
+help: you might have meant to use `#![feature(trait_alias)]` instead of a `type` alias
+  --> $DIR/two_files_data.rs:5:1
+   |
+LL | type Bar = dyn Foo;
+   | ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/error-codes/E0423.stderr
+++ b/src/test/ui/error-codes/E0423.stderr
@@ -45,9 +45,12 @@ error[E0423]: expected value, found struct `T`
   --> $DIR/E0423.rs:14:8
    |
 LL |     if T {} == T {} { println!("Ok"); }
-   |        ^---
-   |        |
-   |        help: surround the struct literal with parenthesis: `(T {})`
+   |        ^
+   |
+help: surround the struct literal with parentheses
+   |
+LL |     if (T {}) == T {} { println!("Ok"); }
+   |        ^    ^
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/issues/issue-32709.stderr
+++ b/src/test/ui/issues/issue-32709.stderr
@@ -1,6 +1,8 @@
 error[E0277]: `?` couldn't convert the error to `()`
   --> $DIR/issue-32709.rs:4:11
    |
+LL | fn a() -> Result<i32, ()> {
+   |           --------------- expected `()` because of this
 LL |     Err(5)?;
    |           ^ the trait `std::convert::From<{integer}>` is not implemented for `()`
    |

--- a/src/test/ui/issues/issue-71406.rs
+++ b/src/test/ui/issues/issue-71406.rs
@@ -1,0 +1,6 @@
+use std::sync::mpsc;
+
+fn main() {
+    let (tx, rx) = mpsc::channel::new(1);
+    //~^ ERROR `channel` in `mpsc` is a concrete value, not a module or Struct you specified
+}

--- a/src/test/ui/issues/issue-71406.rs
+++ b/src/test/ui/issues/issue-71406.rs
@@ -2,5 +2,5 @@ use std::sync::mpsc;
 
 fn main() {
     let (tx, rx) = mpsc::channel::new(1);
-    //~^ ERROR `channel` in `mpsc` is a concrete value, not a module or Struct you specified
+    //~^ ERROR expected type, found function `channel` in `mpsc`
 }

--- a/src/test/ui/issues/issue-71406.stderr
+++ b/src/test/ui/issues/issue-71406.stderr
@@ -1,8 +1,8 @@
-error[E0433]: failed to resolve: `channel` in `mpsc` is a concrete value, not a module or Struct you specified
+error[E0433]: failed to resolve: expected type, found function `channel` in `mpsc`
   --> $DIR/issue-71406.rs:4:26
    |
 LL |     let (tx, rx) = mpsc::channel::new(1);
-   |                          ^^^^^^^ `channel` in `mpsc` is a concrete value, not a module or Struct you specified
+   |                          ^^^^^^^ expected type, found function `channel` in `mpsc`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-71406.stderr
+++ b/src/test/ui/issues/issue-71406.stderr
@@ -1,0 +1,9 @@
+error[E0433]: failed to resolve: `channel` in `mpsc` is a concrete value, not a module or Struct you specified
+  --> $DIR/issue-71406.rs:4:26
+   |
+LL |     let (tx, rx) = mpsc::channel::new(1);
+   |                          ^^^^^^^ `channel` in `mpsc` is a concrete value, not a module or Struct you specified
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0433`.

--- a/src/test/ui/option-to-result.stderr
+++ b/src/test/ui/option-to-result.stderr
@@ -1,6 +1,9 @@
 error[E0277]: `?` couldn't convert the error to `()`
   --> $DIR/option-to-result.rs:5:6
    |
+LL | fn test_result() -> Result<(),()> {
+   |                     ------------- expected `()` because of this
+LL |     let a:Option<()> = Some(());
 LL |     a?;
    |      ^ the trait `std::convert::From<std::option::NoneError>` is not implemented for `()`
    |
@@ -14,6 +17,9 @@ LL |     a.ok_or_else(|| /* error value */)?;
 error[E0277]: `?` couldn't convert the error to `std::option::NoneError`
   --> $DIR/option-to-result.rs:11:6
    |
+LL | fn test_option() -> Option<i32>{
+   |                     ----------- expected `std::option::NoneError` because of this
+LL |     let a:Result<i32, i32> = Ok(5);
 LL |     a?;
    |      ^ the trait `std::convert::From<i32>` is not implemented for `std::option::NoneError`
    |

--- a/src/test/ui/proc-macro/auxiliary/mixed-site-span.rs
+++ b/src/test/ui/proc-macro/auxiliary/mixed-site-span.rs
@@ -2,7 +2,6 @@
 // no-prefer-dynamic
 
 #![feature(proc_macro_hygiene)]
-#![feature(proc_macro_mixed_site)]
 #![feature(proc_macro_quote)]
 
 #![crate_type = "proc-macro"]

--- a/src/test/ui/resolve/issue-3907.stderr
+++ b/src/test/ui/resolve/issue-3907.stderr
@@ -4,7 +4,11 @@ error[E0404]: expected trait, found type alias `Foo`
 LL | impl Foo for S {
    |      ^^^ type aliases cannot be used as traits
    |
-   = note: did you mean to use a trait alias?
+help: you might have meant to use `#![feature(trait_alias)]` instead of a `type` alias
+  --> $DIR/issue-3907.rs:5:1
+   |
+LL | type Foo = dyn issue_3907::Foo;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: possible better candidate is found in another module, you can import it into scope
    |
 LL | use issue_3907::Foo;

--- a/src/test/ui/resolve/issue-5035.stderr
+++ b/src/test/ui/resolve/issue-5035.stderr
@@ -16,7 +16,11 @@ LL | impl K for isize {}
    |      type aliases cannot be used as traits
    |      help: a trait with a similar name exists: `I`
    |
-   = note: did you mean to use a trait alias?
+help: you might have meant to use `#![feature(trait_alias)]` instead of a `type` alias
+  --> $DIR/issue-5035.rs:2:1
+   |
+LL | type K = dyn I;
+   | ^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/resolve/unboxed-closure-sugar-nonexistent-trait.stderr
+++ b/src/test/ui/resolve/unboxed-closure-sugar-nonexistent-trait.stderr
@@ -10,7 +10,11 @@ error[E0404]: expected trait, found type alias `Typedef`
 LL | fn g<F:Typedef(isize) -> isize>(x: F) {}
    |        ^^^^^^^^^^^^^^^^^^^^^^^ type aliases cannot be used as traits
    |
-   = note: did you mean to use a trait alias?
+help: you might have meant to use `#![feature(trait_alias)]` instead of a `type` alias
+  --> $DIR/unboxed-closure-sugar-nonexistent-trait.rs:4:1
+   |
+LL | type Typedef = isize;
+   | ^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/struct-literal-variant-in-if.stderr
+++ b/src/test/ui/struct-literal-variant-in-if.stderr
@@ -46,9 +46,12 @@ error[E0423]: expected value, found struct variant `E::V`
   --> $DIR/struct-literal-variant-in-if.rs:10:13
    |
 LL |     if x == E::V { field } {}
-   |             ^^^^----------
-   |             |
-   |             help: surround the struct literal with parenthesis: `(E::V { field })`
+   |             ^^^^
+   |
+help: surround the struct literal with parentheses
+   |
+LL |     if x == (E::V { field }) {}
+   |             ^              ^
 
 error[E0308]: mismatched types
   --> $DIR/struct-literal-variant-in-if.rs:10:20

--- a/src/test/ui/try-on-option.stderr
+++ b/src/test/ui/try-on-option.stderr
@@ -1,6 +1,9 @@
 error[E0277]: `?` couldn't convert the error to `()`
   --> $DIR/try-on-option.rs:7:6
    |
+LL | fn foo() -> Result<u32, ()> {
+   |             --------------- expected `()` because of this
+LL |     let x: Option<u32> = None;
 LL |     x?;
    |      ^ the trait `std::convert::From<std::option::NoneError>` is not implemented for `()`
    |


### PR DESCRIPTION
Successful merges:

 - #68716 (Stabilize `Span::mixed_site`)
 - #71263 (Remove unused abs_path method from rustc_span::source_map::FileLoader)
 - #71409 (Point at the return type on `.into()` failure caused by `?`)
 - #71419 (add message for resolution failure because wrong namespace)
 - #71438 (Tweak some suggestions in `rustc_resolve`)
 - #71589 (remove Unique::from for shared pointer types)

Failed merges:


r? @ghost