### PR TITLE
make recursive-zst test unleashed

### DIFF
--- a/src/test/ui/consts/recursive-zst-static.default.stderr
+++ b/src/test/ui/consts/recursive-zst-static.default.stderr
@@ -1,17 +1,17 @@
 error[E0391]: cycle detected when const-evaluating `FOO`
-  --> $DIR/recursive-zst-static.rs:7:18
+  --> $DIR/recursive-zst-static.rs:10:18
    |
 LL | static FOO: () = FOO;
    |                  ^^^
    |
 note: ...which requires const-evaluating `FOO`...
-  --> $DIR/recursive-zst-static.rs:7:1
+  --> $DIR/recursive-zst-static.rs:10:1
    |
 LL | static FOO: () = FOO;
    | ^^^^^^^^^^^^^^^^^^^^^
    = note: ...which again requires const-evaluating `FOO`, completing the cycle
 note: cycle used when const-evaluating + checking `FOO`
-  --> $DIR/recursive-zst-static.rs:7:1
+  --> $DIR/recursive-zst-static.rs:10:1
    |
 LL | static FOO: () = FOO;
    | ^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/consts/recursive-zst-static.rs
+++ b/src/test/ui/consts/recursive-zst-static.rs
@@ -1,3 +1,6 @@
+// revisions: default unleash
+//[unleash]compile-flags: -Zunleash-the-miri-inside-of-you
+
 // This test ensures that we do not allow ZST statics to initialize themselves without ever
 // actually creating a value of that type. This is important, as the ZST may have private fields
 // that users can reasonably expect to only get initialized by their own code. Thus unsafe code

--- a/src/test/ui/consts/recursive-zst-static.unleash.stderr
+++ b/src/test/ui/consts/recursive-zst-static.unleash.stderr
@@ -1,0 +1,21 @@
+error[E0391]: cycle detected when const-evaluating `FOO`
+  --> $DIR/recursive-zst-static.rs:10:18
+   |
+LL | static FOO: () = FOO;
+   |                  ^^^
+   |
+note: ...which requires const-evaluating `FOO`...
+  --> $DIR/recursive-zst-static.rs:10:1
+   |
+LL | static FOO: () = FOO;
+   | ^^^^^^^^^^^^^^^^^^^^^
+   = note: ...which again requires const-evaluating `FOO`, completing the cycle
+note: cycle used when const-evaluating + checking `FOO`
+  --> $DIR/recursive-zst-static.rs:10:1
+   |
+LL | static FOO: () = FOO;
+   | ^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0391`.


### PR DESCRIPTION
Make sure we find this issue even without const qualification.

r? @oli-obk @ecstatic-morse 