### PR TITLE
Disable localization for all linkers

### DIFF
--- a/src/librustc_codegen_ssa/back/link.rs
+++ b/src/librustc_codegen_ssa/back/link.rs
@@ -16,7 +16,7 @@ use rustc_target::spec::{LinkerFlavor, LldFlavor, PanicStrategy, RelocModel, Rel
 
 use super::archive::ArchiveBuilder;
 use super::command::Command;
-use super::linker::Linker;
+use super::linker::{self, Linker};
 use super::rpath::{self, RPathConfig};
 use crate::{
     looks_like_rust_object_file, CodegenResults, CrateInfo, METADATA_FILENAME,
@@ -497,6 +497,8 @@ fn link_natively<'a, B: ArchiveBuilder<'a>>(
         codegen_results,
         target_cpu,
     );
+
+    linker::disable_localization(&mut cmd);
 
     for &(ref k, ref v) in &sess.target.target.options.link_env {
         cmd.env(k, v);

--- a/src/librustc_codegen_ssa/back/linker.rs
+++ b/src/librustc_codegen_ssa/back/linker.rs
@@ -19,6 +19,19 @@ use rustc_session::Session;
 use rustc_span::symbol::Symbol;
 use rustc_target::spec::{LinkerFlavor, LldFlavor};
 
+/// Disables non-English messages from localized linkers.
+/// Such messages may cause issues with text encoding on Windows (#35785)
+/// and prevent inspection of linker output in case of errors, which we occasionally do.
+/// This should be acceptable because other messages from rustc are in English anyway,
+/// and may also be desirable to improve searchability of the linker diagnostics.
+pub fn disable_localization(linker: &mut Command) {
+    // No harm in setting both env vars simultaneously.
+    // Unix-style linkers.
+    linker.env("LC_ALL", "C");
+    // MSVC's `link.exe`.
+    linker.env("VSLANG", "1033");
+}
+
 /// For all the linkers we support, and information they might
 /// need out of the shared crate context before we get rid of it.
 #[derive(RustcEncodable, RustcDecodable)]

--- a/src/librustc_target/spec/msvc_base.rs
+++ b/src/librustc_target/spec/msvc_base.rs
@@ -21,10 +21,6 @@ pub fn opts() -> TargetOptions {
         executables: true,
         is_like_windows: true,
         is_like_msvc: true,
-        // set VSLANG to 1033 can prevent link.exe from using
-        // language packs, and avoid generating Non-UTF-8 error
-        // messages if a link error occurred.
-        link_env: vec![("VSLANG".to_string(), "1033".to_string())],
         lld_flavor: LldFlavor::Link,
         pre_link_args,
         abi_return_struct_as_int: true,


### PR DESCRIPTION
We previously disabled non-English output from `link.exe` due to encoding issues (#35785).

In https://github.com/rust-lang/rust/pull/70740 it was pointed out that it also prevents correct inspection of the linker output, which we have to do occasionally.

So this PR disables localization for all linkers.