### PR TITLE
Miri: unleash all feature gates

### DIFF
--- a/src/librustc_interface/interface.rs
+++ b/src/librustc_interface/interface.rs
@@ -193,7 +193,7 @@ pub fn run_compiler_in_existing_thread_pool<R>(
 
     let r = {
         let _sess_abort_error = OnDrop(|| {
-            compiler.sess.diagnostic().print_error_count(registry);
+            compiler.sess.finish_diagnostics(registry);
         });
 
         f(&compiler)

--- a/src/librustc_mir/transform/check_consts/validation.rs
+++ b/src/librustc_mir/transform/check_consts/validation.rs
@@ -248,9 +248,9 @@ impl Validator<'mir, 'tcx> {
             return;
         }
 
-        // If an operation is supported in miri (and is not already controlled by a feature gate) it
-        // can be turned on with `-Zunleash-the-miri-inside-of-you`.
-        let is_unleashable = O::IS_SUPPORTED_IN_MIRI && O::feature_gate().is_none();
+        // If an operation is supported in miri it can be turned on with
+        // `-Zunleash-the-miri-inside-of-you`.
+        let is_unleashable = O::IS_SUPPORTED_IN_MIRI;
 
         if is_unleashable && self.tcx.sess.opts.debugging_opts.unleash_the_miri_inside_of_you {
             self.tcx.sess.span_warn(span, "skipping const checks");

--- a/src/librustc_mir/transform/check_consts/validation.rs
+++ b/src/librustc_mir/transform/check_consts/validation.rs
@@ -253,7 +253,7 @@ impl Validator<'mir, 'tcx> {
         let is_unleashable = O::IS_SUPPORTED_IN_MIRI;
 
         if is_unleashable && self.tcx.sess.opts.debugging_opts.unleash_the_miri_inside_of_you {
-            self.tcx.sess.span_warn(span, "skipping const checks");
+            self.tcx.sess.span_warn(self.tcx.def_span(self.def_id), "skipping const checks");
             return;
         }
 

--- a/src/librustc_mir/transform/check_consts/validation.rs
+++ b/src/librustc_mir/transform/check_consts/validation.rs
@@ -256,6 +256,8 @@ impl Validator<'mir, 'tcx> {
             // Use `def_span` to deduplicate all warnings for the same const.
             self.tcx.sess.span_warn(self.tcx.def_span(self.def_id), "skipping const checks");
             if let Some(feature) = O::feature_gate() {
+                // We'd like to use `delay_span_bug` here, but we cannot as that ICEs
+                // before codegen has the chance to emit errors.  So we use a custom system instead.
                 self.tcx.sess.miri_unleashed_feature(feature);
             }
             return;

--- a/src/librustc_mir/transform/check_consts/validation.rs
+++ b/src/librustc_mir/transform/check_consts/validation.rs
@@ -254,6 +254,9 @@ impl Validator<'mir, 'tcx> {
 
         if is_unleashable && self.tcx.sess.opts.debugging_opts.unleash_the_miri_inside_of_you {
             self.tcx.sess.span_warn(self.tcx.def_span(self.def_id), "skipping const checks");
+            if let Some(feature) = O::feature_gate() {
+                self.tcx.sess.miri_unleashed_feature(feature);
+            }
             return;
         }
 

--- a/src/librustc_mir/transform/check_consts/validation.rs
+++ b/src/librustc_mir/transform/check_consts/validation.rs
@@ -253,6 +253,7 @@ impl Validator<'mir, 'tcx> {
         let is_unleashable = O::IS_SUPPORTED_IN_MIRI;
 
         if is_unleashable && self.tcx.sess.opts.debugging_opts.unleash_the_miri_inside_of_you {
+            // Use `def_span` to deduplicate all warnings for the same const.
             self.tcx.sess.span_warn(self.tcx.def_span(self.def_id), "skipping const checks");
             if let Some(feature) = O::feature_gate() {
                 self.tcx.sess.miri_unleashed_feature(feature);

--- a/src/librustc_mir/transform/check_consts/validation.rs
+++ b/src/librustc_mir/transform/check_consts/validation.rs
@@ -253,13 +253,7 @@ impl Validator<'mir, 'tcx> {
         let is_unleashable = O::IS_SUPPORTED_IN_MIRI;
 
         if is_unleashable && self.tcx.sess.opts.debugging_opts.unleash_the_miri_inside_of_you {
-            // Use `def_span` to deduplicate all warnings for the same const.
-            self.tcx.sess.span_warn(self.tcx.def_span(self.def_id), "skipping const checks");
-            if let Some(feature) = O::feature_gate() {
-                // We'd like to use `delay_span_bug` here, but we cannot as that ICEs
-                // before codegen has the chance to emit errors.  So we use a custom system instead.
-                self.tcx.sess.miri_unleashed_feature(feature);
-            }
+            self.tcx.sess.miri_unleashed_feature(span, O::feature_gate());
             return;
         }
 

--- a/src/librustc_session/session.rs
+++ b/src/librustc_session/session.rs
@@ -222,7 +222,7 @@ impl Session {
                 // We have skipped a feature gate, and not run into other errors... reject.
                 self.err(
                     "`-Zunleash-the-miri-inside-of-you` may not be used to circumvent feature \
-                     gates, except when testing error paths in the CTFE engine"
+                     gates, except when testing error paths in the CTFE engine",
                 );
             }
         }

--- a/src/test/ui/consts/const-eval/const_fn_ptr.rs
+++ b/src/test/ui/consts/const-eval/const_fn_ptr.rs
@@ -8,16 +8,16 @@ const fn double_const(x: usize) -> usize { x * 2 }
 const X: fn(usize) -> usize = double;
 const X_CONST: fn(usize) -> usize = double_const;
 
-const fn bar(x: usize) -> usize {
-    X(x) //~ WARNING skipping const checks
+const fn bar(x: usize) -> usize { //~ WARNING skipping const checks
+    X(x)
 }
 
-const fn bar_const(x: usize) -> usize {
-    X_CONST(x) //~ WARNING skipping const checks
+const fn bar_const(x: usize) -> usize { //~ WARNING skipping const checks
+    X_CONST(x)
 }
 
-const fn foo(x: fn(usize) -> usize, y: usize)  -> usize {
-    x(y) //~ WARNING skipping const checks
+const fn foo(x: fn(usize) -> usize, y: usize)  -> usize { //~ WARNING skipping const checks
+    x(y)
 }
 
 fn main() {

--- a/src/test/ui/consts/const-eval/const_fn_ptr.rs
+++ b/src/test/ui/consts/const-eval/const_fn_ptr.rs
@@ -8,15 +8,15 @@ const fn double_const(x: usize) -> usize { x * 2 }
 const X: fn(usize) -> usize = double;
 const X_CONST: fn(usize) -> usize = double_const;
 
-const fn bar(x: usize) -> usize { //~ WARNING skipping const checks
+const fn bar(x: usize) -> usize {
     X(x)
 }
 
-const fn bar_const(x: usize) -> usize { //~ WARNING skipping const checks
+const fn bar_const(x: usize) -> usize {
     X_CONST(x)
 }
 
-const fn foo(x: fn(usize) -> usize, y: usize)  -> usize { //~ WARNING skipping const checks
+const fn foo(x: fn(usize) -> usize, y: usize)  -> usize {
     x(y)
 }
 

--- a/src/test/ui/consts/const-eval/const_fn_ptr.stderr
+++ b/src/test/ui/consts/const-eval/const_fn_ptr.stderr
@@ -1,26 +1,20 @@
 warning: skipping const checks
-  --> $DIR/const_fn_ptr.rs:11:1
    |
-LL | / const fn bar(x: usize) -> usize {
-LL | |     X(x)
-LL | | }
-   | |_^
-
-warning: skipping const checks
-  --> $DIR/const_fn_ptr.rs:15:1
+help: skipping check that does not even have a feature gate
+  --> $DIR/const_fn_ptr.rs:12:5
    |
-LL | / const fn bar_const(x: usize) -> usize {
-LL | |     X_CONST(x)
-LL | | }
-   | |_^
-
-warning: skipping const checks
-  --> $DIR/const_fn_ptr.rs:19:1
+LL |     X(x)
+   |     ^^^^
+help: skipping check that does not even have a feature gate
+  --> $DIR/const_fn_ptr.rs:16:5
    |
-LL | / const fn foo(x: fn(usize) -> usize, y: usize)  -> usize {
-LL | |     x(y)
-LL | | }
-   | |_^
+LL |     X_CONST(x)
+   |     ^^^^^^^^^^
+help: skipping check that does not even have a feature gate
+  --> $DIR/const_fn_ptr.rs:20:5
+   |
+LL |     x(y)
+   |     ^^^^
 
-warning: 3 warnings emitted
+warning: 1 warning emitted
 

--- a/src/test/ui/consts/const-eval/const_fn_ptr.stderr
+++ b/src/test/ui/consts/const-eval/const_fn_ptr.stderr
@@ -1,20 +1,26 @@
 warning: skipping const checks
-  --> $DIR/const_fn_ptr.rs:12:5
+  --> $DIR/const_fn_ptr.rs:11:1
    |
-LL |     X(x)
-   |     ^^^^
+LL | / const fn bar(x: usize) -> usize {
+LL | |     X(x)
+LL | | }
+   | |_^
 
 warning: skipping const checks
-  --> $DIR/const_fn_ptr.rs:16:5
+  --> $DIR/const_fn_ptr.rs:15:1
    |
-LL |     X_CONST(x)
-   |     ^^^^^^^^^^
+LL | / const fn bar_const(x: usize) -> usize {
+LL | |     X_CONST(x)
+LL | | }
+   | |_^
 
 warning: skipping const checks
-  --> $DIR/const_fn_ptr.rs:20:5
+  --> $DIR/const_fn_ptr.rs:19:1
    |
-LL |     x(y)
-   |     ^^^^
+LL | / const fn foo(x: fn(usize) -> usize, y: usize)  -> usize {
+LL | |     x(y)
+LL | | }
+   | |_^
 
 warning: 3 warnings emitted
 

--- a/src/test/ui/consts/const-eval/const_fn_ptr_fail.rs
+++ b/src/test/ui/consts/const-eval/const_fn_ptr_fail.rs
@@ -6,9 +6,8 @@
 fn double(x: usize) -> usize { x * 2 }
 const X: fn(usize) -> usize = double;
 
-const fn bar(x: usize) -> usize {
+const fn bar(x: usize) -> usize { //~ WARNING skipping const checks
     X(x) // FIXME: this should error someday
-    //~^ WARN: skipping const checks
 }
 
 fn main() {}

--- a/src/test/ui/consts/const-eval/const_fn_ptr_fail.rs
+++ b/src/test/ui/consts/const-eval/const_fn_ptr_fail.rs
@@ -6,7 +6,7 @@
 fn double(x: usize) -> usize { x * 2 }
 const X: fn(usize) -> usize = double;
 
-const fn bar(x: usize) -> usize { //~ WARNING skipping const checks
+const fn bar(x: usize) -> usize {
     X(x) // FIXME: this should error someday
 }
 

--- a/src/test/ui/consts/const-eval/const_fn_ptr_fail.stderr
+++ b/src/test/ui/consts/const-eval/const_fn_ptr_fail.stderr
@@ -1,8 +1,10 @@
 warning: skipping const checks
-  --> $DIR/const_fn_ptr_fail.rs:10:5
+  --> $DIR/const_fn_ptr_fail.rs:9:1
    |
-LL |     X(x) // FIXME: this should error someday
-   |     ^^^^
+LL | / const fn bar(x: usize) -> usize {
+LL | |     X(x) // FIXME: this should error someday
+LL | | }
+   | |_^
 
 warning: 1 warning emitted
 

--- a/src/test/ui/consts/const-eval/const_fn_ptr_fail.stderr
+++ b/src/test/ui/consts/const-eval/const_fn_ptr_fail.stderr
@@ -1,10 +1,10 @@
 warning: skipping const checks
-  --> $DIR/const_fn_ptr_fail.rs:9:1
    |
-LL | / const fn bar(x: usize) -> usize {
-LL | |     X(x) // FIXME: this should error someday
-LL | | }
-   | |_^
+help: skipping check that does not even have a feature gate
+  --> $DIR/const_fn_ptr_fail.rs:10:5
+   |
+LL |     X(x) // FIXME: this should error someday
+   |     ^^^^
 
 warning: 1 warning emitted
 

--- a/src/test/ui/consts/const-eval/const_fn_ptr_fail2.rs
+++ b/src/test/ui/consts/const-eval/const_fn_ptr_fail2.rs
@@ -9,7 +9,7 @@ fn double(x: usize) -> usize {
 }
 const X: fn(usize) -> usize = double;
 
-const fn bar(x: fn(usize) -> usize, y: usize) -> usize { //~ WARN skipping const checks
+const fn bar(x: fn(usize) -> usize, y: usize) -> usize {
     x(y)
 }
 

--- a/src/test/ui/consts/const-eval/const_fn_ptr_fail2.rs
+++ b/src/test/ui/consts/const-eval/const_fn_ptr_fail2.rs
@@ -9,8 +9,8 @@ fn double(x: usize) -> usize {
 }
 const X: fn(usize) -> usize = double;
 
-const fn bar(x: fn(usize) -> usize, y: usize) -> usize {
-    x(y) //~ WARN skipping const checks
+const fn bar(x: fn(usize) -> usize, y: usize) -> usize { //~ WARN skipping const checks
+    x(y)
 }
 
 const Y: usize = bar(X, 2); // FIXME: should fail to typeck someday

--- a/src/test/ui/consts/const-eval/const_fn_ptr_fail2.stderr
+++ b/src/test/ui/consts/const-eval/const_fn_ptr_fail2.stderr
@@ -1,8 +1,10 @@
 warning: skipping const checks
-  --> $DIR/const_fn_ptr_fail2.rs:13:5
+  --> $DIR/const_fn_ptr_fail2.rs:12:1
    |
-LL |     x(y)
-   |     ^^^^
+LL | / const fn bar(x: fn(usize) -> usize, y: usize) -> usize {
+LL | |     x(y)
+LL | | }
+   | |_^
 
 error[E0080]: evaluation of constant expression failed
   --> $DIR/const_fn_ptr_fail2.rs:20:5

--- a/src/test/ui/consts/const-eval/const_fn_ptr_fail2.stderr
+++ b/src/test/ui/consts/const-eval/const_fn_ptr_fail2.stderr
@@ -1,11 +1,3 @@
-warning: skipping const checks
-  --> $DIR/const_fn_ptr_fail2.rs:12:1
-   |
-LL | / const fn bar(x: fn(usize) -> usize, y: usize) -> usize {
-LL | |     x(y)
-LL | | }
-   | |_^
-
 error[E0080]: evaluation of constant expression failed
   --> $DIR/const_fn_ptr_fail2.rs:20:5
    |
@@ -25,6 +17,14 @@ LL |     assert_eq!(Z, 4);
    |                referenced constant has errors
    |
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+warning: skipping const checks
+   |
+help: skipping check that does not even have a feature gate
+  --> $DIR/const_fn_ptr_fail2.rs:13:5
+   |
+LL |     x(y)
+   |     ^^^^
 
 error: aborting due to 2 previous errors; 1 warning emitted
 

--- a/src/test/ui/consts/const-points-to-static.rs
+++ b/src/test/ui/consts/const-points-to-static.rs
@@ -3,8 +3,9 @@
 #![allow(dead_code)]
 
 const TEST: &u8 = &MY_STATIC;
-//~^ skipping const checks
-//~| it is undefined behavior to use this value
+//~^ ERROR it is undefined behavior to use this value
+//~| NOTE  encountered a reference pointing to a static variable
+//~| NOTE
 
 static MY_STATIC: u8 = 4;
 

--- a/src/test/ui/consts/const-points-to-static.stderr
+++ b/src/test/ui/consts/const-points-to-static.stderr
@@ -1,9 +1,3 @@
-warning: skipping const checks
-  --> $DIR/const-points-to-static.rs:5:1
-   |
-LL | const TEST: &u8 = &MY_STATIC;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
 error[E0080]: it is undefined behavior to use this value
   --> $DIR/const-points-to-static.rs:5:1
    |
@@ -11,6 +5,14 @@ LL | const TEST: &u8 = &MY_STATIC;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a reference pointing to a static variable
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+
+warning: skipping const checks
+   |
+help: skipping check that does not even have a feature gate
+  --> $DIR/const-points-to-static.rs:5:20
+   |
+LL | const TEST: &u8 = &MY_STATIC;
+   |                    ^^^^^^^^^
 
 error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui/consts/const-points-to-static.stderr
+++ b/src/test/ui/consts/const-points-to-static.stderr
@@ -1,8 +1,8 @@
 warning: skipping const checks
-  --> $DIR/const-points-to-static.rs:5:20
+  --> $DIR/const-points-to-static.rs:5:1
    |
 LL | const TEST: &u8 = &MY_STATIC;
-   |                    ^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0080]: it is undefined behavior to use this value
   --> $DIR/const-points-to-static.rs:5:1

--- a/src/test/ui/consts/const-prop-read-static-in-const.rs
+++ b/src/test/ui/consts/const-prop-read-static-in-const.rs
@@ -3,7 +3,6 @@
 #![allow(dead_code)]
 
 const TEST: u8 = MY_STATIC; //~ ERROR any use of this value will cause an error
-//~^ skipping const checks
 
 static MY_STATIC: u8 = 4;
 

--- a/src/test/ui/consts/const-prop-read-static-in-const.stderr
+++ b/src/test/ui/consts/const-prop-read-static-in-const.stderr
@@ -1,9 +1,3 @@
-warning: skipping const checks
-  --> $DIR/const-prop-read-static-in-const.rs:5:1
-   |
-LL | const TEST: u8 = MY_STATIC;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
 error: any use of this value will cause an error
   --> $DIR/const-prop-read-static-in-const.rs:5:18
    |
@@ -13,6 +7,14 @@ LL | const TEST: u8 = MY_STATIC;
    |                  constant accesses static
    |
    = note: `#[deny(const_err)]` on by default
+
+warning: skipping const checks
+   |
+help: skipping check that does not even have a feature gate
+  --> $DIR/const-prop-read-static-in-const.rs:5:18
+   |
+LL | const TEST: u8 = MY_STATIC;
+   |                  ^^^^^^^^^
 
 error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui/consts/const-prop-read-static-in-const.stderr
+++ b/src/test/ui/consts/const-prop-read-static-in-const.stderr
@@ -1,8 +1,8 @@
 warning: skipping const checks
-  --> $DIR/const-prop-read-static-in-const.rs:5:18
+  --> $DIR/const-prop-read-static-in-const.rs:5:1
    |
 LL | const TEST: u8 = MY_STATIC;
-   |                  ^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: any use of this value will cause an error
   --> $DIR/const-prop-read-static-in-const.rs:5:18

--- a/src/test/ui/consts/miri_unleashed/abi-mismatch.rs
+++ b/src/test/ui/consts/miri_unleashed/abi-mismatch.rs
@@ -7,7 +7,6 @@
 const extern "C" fn c_fn() {}
 
 const fn call_rust_fn(my_fn: extern "Rust" fn()) {
-//~^ WARN skipping const checks
     my_fn();
     //~^ ERROR could not evaluate static initializer
     //~| NOTE calling a function with ABI C using caller ABI Rust
@@ -15,7 +14,6 @@ const fn call_rust_fn(my_fn: extern "Rust" fn()) {
 }
 
 static VAL: () = call_rust_fn(unsafe { std::mem::transmute(c_fn as extern "C" fn()) });
-//~^ WARN skipping const checks
-//~| NOTE inside `VAL`
+//~^ NOTE inside `VAL`
 
 fn main() {}

--- a/src/test/ui/consts/miri_unleashed/abi-mismatch.rs
+++ b/src/test/ui/consts/miri_unleashed/abi-mismatch.rs
@@ -7,9 +7,9 @@
 const extern "C" fn c_fn() {}
 
 const fn call_rust_fn(my_fn: extern "Rust" fn()) {
+//~^ WARN skipping const checks
     my_fn();
-    //~^ WARN skipping const checks
-    //~| ERROR could not evaluate static initializer
+    //~^ ERROR could not evaluate static initializer
     //~| NOTE calling a function with ABI C using caller ABI Rust
     //~| NOTE inside `call_rust_fn`
 }

--- a/src/test/ui/consts/miri_unleashed/abi-mismatch.stderr
+++ b/src/test/ui/consts/miri_unleashed/abi-mismatch.stderr
@@ -1,23 +1,29 @@
 warning: skipping const checks
-  --> $DIR/abi-mismatch.rs:10:5
+  --> $DIR/abi-mismatch.rs:9:1
    |
-LL |     my_fn();
-   |     ^^^^^^^
+LL | / const fn call_rust_fn(my_fn: extern "Rust" fn()) {
+LL | |
+LL | |     my_fn();
+LL | |
+LL | |
+LL | |
+LL | | }
+   | |_^
 
 warning: skipping const checks
-  --> $DIR/abi-mismatch.rs:17:40
+  --> $DIR/abi-mismatch.rs:17:1
    |
 LL | static VAL: () = call_rust_fn(unsafe { std::mem::transmute(c_fn as extern "C" fn()) });
-   |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0080]: could not evaluate static initializer
-  --> $DIR/abi-mismatch.rs:10:5
+  --> $DIR/abi-mismatch.rs:11:5
    |
 LL |     my_fn();
    |     ^^^^^^^
    |     |
    |     calling a function with ABI C using caller ABI Rust
-   |     inside `call_rust_fn` at $DIR/abi-mismatch.rs:10:5
+   |     inside `call_rust_fn` at $DIR/abi-mismatch.rs:11:5
 ...
 LL | static VAL: () = call_rust_fn(unsafe { std::mem::transmute(c_fn as extern "C" fn()) });
    |                  --------------------------------------------------------------------- inside `VAL` at $DIR/abi-mismatch.rs:17:18

--- a/src/test/ui/consts/miri_unleashed/abi-mismatch.stderr
+++ b/src/test/ui/consts/miri_unleashed/abi-mismatch.stderr
@@ -1,33 +1,28 @@
-warning: skipping const checks
-  --> $DIR/abi-mismatch.rs:9:1
-   |
-LL | / const fn call_rust_fn(my_fn: extern "Rust" fn()) {
-LL | |
-LL | |     my_fn();
-LL | |
-LL | |
-LL | |
-LL | | }
-   | |_^
-
-warning: skipping const checks
-  --> $DIR/abi-mismatch.rs:17:1
-   |
-LL | static VAL: () = call_rust_fn(unsafe { std::mem::transmute(c_fn as extern "C" fn()) });
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
 error[E0080]: could not evaluate static initializer
-  --> $DIR/abi-mismatch.rs:11:5
+  --> $DIR/abi-mismatch.rs:10:5
    |
 LL |     my_fn();
    |     ^^^^^^^
    |     |
    |     calling a function with ABI C using caller ABI Rust
-   |     inside `call_rust_fn` at $DIR/abi-mismatch.rs:11:5
+   |     inside `call_rust_fn` at $DIR/abi-mismatch.rs:10:5
 ...
 LL | static VAL: () = call_rust_fn(unsafe { std::mem::transmute(c_fn as extern "C" fn()) });
-   |                  --------------------------------------------------------------------- inside `VAL` at $DIR/abi-mismatch.rs:17:18
+   |                  --------------------------------------------------------------------- inside `VAL` at $DIR/abi-mismatch.rs:16:18
 
-error: aborting due to previous error; 2 warnings emitted
+warning: skipping const checks
+   |
+help: skipping check that does not even have a feature gate
+  --> $DIR/abi-mismatch.rs:10:5
+   |
+LL |     my_fn();
+   |     ^^^^^^^
+help: skipping check that does not even have a feature gate
+  --> $DIR/abi-mismatch.rs:16:40
+   |
+LL | static VAL: () = call_rust_fn(unsafe { std::mem::transmute(c_fn as extern "C" fn()) });
+   |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/miri_unleashed/assoc_const.rs
+++ b/src/test/ui/consts/miri_unleashed/assoc_const.rs
@@ -11,7 +11,7 @@ trait Foo<T> {
 }
 
 trait Bar<T, U: Foo<T>> {
-    const F: u32 = (U::X, 42).1; //~ WARN skipping const checks
+    const F: u32 = (U::X, 42).1;
 }
 
 impl Foo<u32> for () {

--- a/src/test/ui/consts/miri_unleashed/assoc_const.stderr
+++ b/src/test/ui/consts/miri_unleashed/assoc_const.stderr
@@ -1,8 +1,8 @@
 warning: skipping const checks
-  --> $DIR/assoc_const.rs:14:20
+  --> $DIR/assoc_const.rs:14:5
    |
 LL |     const F: u32 = (U::X, 42).1;
-   |                    ^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0080]: erroneous constant used
   --> $DIR/assoc_const.rs:31:13

--- a/src/test/ui/consts/miri_unleashed/assoc_const.stderr
+++ b/src/test/ui/consts/miri_unleashed/assoc_const.stderr
@@ -1,14 +1,16 @@
-warning: skipping const checks
-  --> $DIR/assoc_const.rs:14:5
-   |
-LL |     const F: u32 = (U::X, 42).1;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
 error[E0080]: erroneous constant used
   --> $DIR/assoc_const.rs:31:13
    |
 LL |     let y = <String as Bar<Vec<u32>, String>>::F;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ referenced constant has errors
+
+warning: skipping const checks
+   |
+help: skipping check that does not even have a feature gate
+  --> $DIR/assoc_const.rs:14:20
+   |
+LL |     const F: u32 = (U::X, 42).1;
+   |                    ^^^^^^^^^^
 
 error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui/consts/miri_unleashed/box.rs
+++ b/src/test/ui/consts/miri_unleashed/box.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zunleash-the-miri-inside-of-you
+// compile-flags: -Zunleash-the-miri-inside-of-you -Zdeduplicate-diagnostics
 #![feature(box_syntax)]
 #![allow(const_err)]
 
@@ -6,12 +6,8 @@ use std::mem::ManuallyDrop;
 
 fn main() {}
 
-static TEST_BAD: &mut i32 = {
+static TEST_BAD: &mut i32 = { //~ WARN skipping const checks
     &mut *(box 0)
-    //~^ WARN skipping const check
-    //~| ERROR could not evaluate static initializer
+    //~^ ERROR could not evaluate static initializer
     //~| NOTE heap allocations
-    //~| WARN skipping const checks
-    //~| WARN skipping const checks
-    //~| WARN skipping const checks
 };

--- a/src/test/ui/consts/miri_unleashed/box.rs
+++ b/src/test/ui/consts/miri_unleashed/box.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zunleash-the-miri-inside-of-you -Zdeduplicate-diagnostics
+// compile-flags: -Zunleash-the-miri-inside-of-you
 #![feature(box_syntax)]
 #![allow(const_err)]
 

--- a/src/test/ui/consts/miri_unleashed/box.rs
+++ b/src/test/ui/consts/miri_unleashed/box.rs
@@ -6,7 +6,7 @@ use std::mem::ManuallyDrop;
 
 fn main() {}
 
-static TEST_BAD: &mut i32 = { //~ WARN skipping const checks
+static TEST_BAD: &mut i32 = {
     &mut *(box 0)
     //~^ ERROR could not evaluate static initializer
     //~| NOTE heap allocations

--- a/src/test/ui/consts/miri_unleashed/box.rs
+++ b/src/test/ui/consts/miri_unleashed/box.rs
@@ -1,5 +1,5 @@
 // compile-flags: -Zunleash-the-miri-inside-of-you
-#![feature(const_mut_refs, box_syntax)]
+#![feature(box_syntax)]
 #![allow(const_err)]
 
 use std::mem::ManuallyDrop;
@@ -11,4 +11,7 @@ static TEST_BAD: &mut i32 = {
     //~^ WARN skipping const check
     //~| ERROR could not evaluate static initializer
     //~| NOTE heap allocations
+    //~| WARN skipping const checks
+    //~| WARN skipping const checks
+    //~| WARN skipping const checks
 };

--- a/src/test/ui/consts/miri_unleashed/box.stderr
+++ b/src/test/ui/consts/miri_unleashed/box.stderr
@@ -1,18 +1,31 @@
-warning: skipping const checks
-  --> $DIR/box.rs:9:1
-   |
-LL | / static TEST_BAD: &mut i32 = {
-LL | |     &mut *(box 0)
-LL | |
-LL | |
-LL | | };
-   | |__^
-
 error[E0080]: could not evaluate static initializer
   --> $DIR/box.rs:10:11
    |
 LL |     &mut *(box 0)
    |           ^^^^^^^ "heap allocations via `box` keyword" needs an rfc before being allowed inside constants
+
+warning: skipping const checks
+   |
+help: skipping check that does not even have a feature gate
+  --> $DIR/box.rs:10:11
+   |
+LL |     &mut *(box 0)
+   |           ^^^^^^^
+help: skipping check for `const_mut_refs` feature
+  --> $DIR/box.rs:10:16
+   |
+LL |     &mut *(box 0)
+   |                ^
+help: skipping check for `const_mut_refs` feature
+  --> $DIR/box.rs:10:5
+   |
+LL |     &mut *(box 0)
+   |     ^^^^^^^^^^^^^
+help: skipping check for `const_mut_refs` feature
+  --> $DIR/box.rs:10:5
+   |
+LL |     &mut *(box 0)
+   |     ^^^^^^^^^^^^^
 
 error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui/consts/miri_unleashed/box.stderr
+++ b/src/test/ui/consts/miri_unleashed/box.stderr
@@ -4,12 +4,30 @@ warning: skipping const checks
 LL |     &mut *(box 0)
    |           ^^^^^^^
 
+warning: skipping const checks
+  --> $DIR/box.rs:10:16
+   |
+LL |     &mut *(box 0)
+   |                ^
+
+warning: skipping const checks
+  --> $DIR/box.rs:10:5
+   |
+LL |     &mut *(box 0)
+   |     ^^^^^^^^^^^^^
+
+warning: skipping const checks
+  --> $DIR/box.rs:10:5
+   |
+LL |     &mut *(box 0)
+   |     ^^^^^^^^^^^^^
+
 error[E0080]: could not evaluate static initializer
   --> $DIR/box.rs:10:11
    |
 LL |     &mut *(box 0)
    |           ^^^^^^^ "heap allocations via `box` keyword" needs an rfc before being allowed inside constants
 
-error: aborting due to previous error; 1 warning emitted
+error: aborting due to previous error; 4 warnings emitted
 
 For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/miri_unleashed/box.stderr
+++ b/src/test/ui/consts/miri_unleashed/box.stderr
@@ -1,26 +1,12 @@
 warning: skipping const checks
-  --> $DIR/box.rs:10:11
+  --> $DIR/box.rs:9:1
    |
-LL |     &mut *(box 0)
-   |           ^^^^^^^
-
-warning: skipping const checks
-  --> $DIR/box.rs:10:16
-   |
-LL |     &mut *(box 0)
-   |                ^
-
-warning: skipping const checks
-  --> $DIR/box.rs:10:5
-   |
-LL |     &mut *(box 0)
-   |     ^^^^^^^^^^^^^
-
-warning: skipping const checks
-  --> $DIR/box.rs:10:5
-   |
-LL |     &mut *(box 0)
-   |     ^^^^^^^^^^^^^
+LL | / static TEST_BAD: &mut i32 = {
+LL | |     &mut *(box 0)
+LL | |
+LL | |
+LL | | };
+   | |__^
 
 error[E0080]: could not evaluate static initializer
   --> $DIR/box.rs:10:11
@@ -28,6 +14,6 @@ error[E0080]: could not evaluate static initializer
 LL |     &mut *(box 0)
    |           ^^^^^^^ "heap allocations via `box` keyword" needs an rfc before being allowed inside constants
 
-error: aborting due to previous error; 4 warnings emitted
+error: aborting due to previous error; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/miri_unleashed/const_refers_to_static.rs
+++ b/src/test/ui/consts/miri_unleashed/const_refers_to_static.rs
@@ -1,5 +1,5 @@
 // build-fail
-// compile-flags: -Zunleash-the-miri-inside-of-you -Zdeduplicate-diagnostics
+// compile-flags: -Zunleash-the-miri-inside-of-you
 #![allow(const_err)]
 
 use std::sync::atomic::AtomicUsize;

--- a/src/test/ui/consts/miri_unleashed/const_refers_to_static.rs
+++ b/src/test/ui/consts/miri_unleashed/const_refers_to_static.rs
@@ -1,5 +1,5 @@
 // build-fail
-// compile-flags: -Zunleash-the-miri-inside-of-you
+// compile-flags: -Zunleash-the-miri-inside-of-you -Zdeduplicate-diagnostics
 #![allow(const_err)]
 
 use std::sync::atomic::AtomicUsize;
@@ -9,23 +9,20 @@ use std::sync::atomic::Ordering;
 // when *using* the const.
 
 const MUTATE_INTERIOR_MUT: usize = {
+//~^ WARN skipping const checks
     static FOO: AtomicUsize = AtomicUsize::new(0);
     FOO.fetch_add(1, Ordering::Relaxed)
-    //~^ WARN skipping const checks
-    //~| WARN skipping const checks
 };
 
 const READ_INTERIOR_MUT: usize = {
+//~^ WARN skipping const checks
     static FOO: AtomicUsize = AtomicUsize::new(0);
     unsafe { *(&FOO as *const _ as *const usize) }
-    //~^ WARN skipping const checks
-    //~| WARN skipping const checks
 };
 
 static mut MUTABLE: u32 = 0;
 const READ_MUT: u32 = unsafe { MUTABLE };
 //~^ WARN skipping const checks
-//~| WARN skipping const checks
 
 fn main() {
     MUTATE_INTERIOR_MUT;

--- a/src/test/ui/consts/miri_unleashed/const_refers_to_static.rs
+++ b/src/test/ui/consts/miri_unleashed/const_refers_to_static.rs
@@ -1,8 +1,6 @@
 // build-fail
 // compile-flags: -Zunleash-the-miri-inside-of-you -Zdeduplicate-diagnostics
 #![allow(const_err)]
-#![feature(const_raw_ptr_deref)] // FIXME: cannot remove because then rustc thinks there is no error
-#![crate_type = "lib"]
 
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
@@ -26,7 +24,7 @@ static mut MUTABLE: u32 = 0;
 const READ_MUT: u32 = unsafe { MUTABLE };
 //~^ WARN skipping const checks
 
-pub fn main() {
+fn main() {
     MUTATE_INTERIOR_MUT;
     //~^ ERROR: erroneous constant used
     READ_INTERIOR_MUT;

--- a/src/test/ui/consts/miri_unleashed/const_refers_to_static.rs
+++ b/src/test/ui/consts/miri_unleashed/const_refers_to_static.rs
@@ -1,6 +1,8 @@
 // build-fail
 // compile-flags: -Zunleash-the-miri-inside-of-you -Zdeduplicate-diagnostics
 #![allow(const_err)]
+#![feature(const_raw_ptr_deref)] // FIXME: cannot remove because then rustc thinks there is no error
+#![crate_type = "lib"]
 
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
@@ -24,7 +26,7 @@ static mut MUTABLE: u32 = 0;
 const READ_MUT: u32 = unsafe { MUTABLE };
 //~^ WARN skipping const checks
 
-fn main() {
+pub fn main() {
     MUTATE_INTERIOR_MUT;
     //~^ ERROR: erroneous constant used
     READ_INTERIOR_MUT;

--- a/src/test/ui/consts/miri_unleashed/const_refers_to_static.rs
+++ b/src/test/ui/consts/miri_unleashed/const_refers_to_static.rs
@@ -2,8 +2,6 @@
 // compile-flags: -Zunleash-the-miri-inside-of-you
 #![allow(const_err)]
 
-#![feature(const_raw_ptr_deref)]
-
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 
@@ -21,6 +19,7 @@ const READ_INTERIOR_MUT: usize = {
     static FOO: AtomicUsize = AtomicUsize::new(0);
     unsafe { *(&FOO as *const _ as *const usize) }
     //~^ WARN skipping const checks
+    //~| WARN skipping const checks
 };
 
 static mut MUTABLE: u32 = 0;

--- a/src/test/ui/consts/miri_unleashed/const_refers_to_static.rs
+++ b/src/test/ui/consts/miri_unleashed/const_refers_to_static.rs
@@ -9,20 +9,17 @@ use std::sync::atomic::Ordering;
 // when *using* the const.
 
 const MUTATE_INTERIOR_MUT: usize = {
-//~^ WARN skipping const checks
     static FOO: AtomicUsize = AtomicUsize::new(0);
     FOO.fetch_add(1, Ordering::Relaxed)
 };
 
 const READ_INTERIOR_MUT: usize = {
-//~^ WARN skipping const checks
     static FOO: AtomicUsize = AtomicUsize::new(0);
     unsafe { *(&FOO as *const _ as *const usize) }
 };
 
 static mut MUTABLE: u32 = 0;
 const READ_MUT: u32 = unsafe { MUTABLE };
-//~^ WARN skipping const checks
 
 fn main() {
     MUTATE_INTERIOR_MUT;

--- a/src/test/ui/consts/miri_unleashed/const_refers_to_static.stderr
+++ b/src/test/ui/consts/miri_unleashed/const_refers_to_static.stderr
@@ -1,5 +1,5 @@
 warning: skipping const checks
-  --> $DIR/const_refers_to_static.rs:13:1
+  --> $DIR/const_refers_to_static.rs:11:1
    |
 LL | / const MUTATE_INTERIOR_MUT: usize = {
 LL | |
@@ -9,7 +9,7 @@ LL | | };
    | |__^
 
 warning: skipping const checks
-  --> $DIR/const_refers_to_static.rs:19:1
+  --> $DIR/const_refers_to_static.rs:17:1
    |
 LL | / const READ_INTERIOR_MUT: usize = {
 LL | |
@@ -19,25 +19,25 @@ LL | | };
    | |__^
 
 warning: skipping const checks
-  --> $DIR/const_refers_to_static.rs:26:1
+  --> $DIR/const_refers_to_static.rs:24:1
    |
 LL | const READ_MUT: u32 = unsafe { MUTABLE };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0080]: erroneous constant used
-  --> $DIR/const_refers_to_static.rs:30:5
+  --> $DIR/const_refers_to_static.rs:28:5
    |
 LL |     MUTATE_INTERIOR_MUT;
    |     ^^^^^^^^^^^^^^^^^^^ referenced constant has errors
 
 error[E0080]: erroneous constant used
-  --> $DIR/const_refers_to_static.rs:32:5
+  --> $DIR/const_refers_to_static.rs:30:5
    |
 LL |     READ_INTERIOR_MUT;
    |     ^^^^^^^^^^^^^^^^^ referenced constant has errors
 
 error[E0080]: erroneous constant used
-  --> $DIR/const_refers_to_static.rs:34:5
+  --> $DIR/const_refers_to_static.rs:32:5
    |
 LL |     READ_MUT;
    |     ^^^^^^^^ referenced constant has errors

--- a/src/test/ui/consts/miri_unleashed/const_refers_to_static.stderr
+++ b/src/test/ui/consts/miri_unleashed/const_refers_to_static.stderr
@@ -1,57 +1,47 @@
 warning: skipping const checks
-  --> $DIR/const_refers_to_static.rs:13:5
+  --> $DIR/const_refers_to_static.rs:11:1
    |
-LL |     FOO.fetch_add(1, Ordering::Relaxed)
-   |     ^^^
+LL | / const MUTATE_INTERIOR_MUT: usize = {
+LL | |
+LL | |     static FOO: AtomicUsize = AtomicUsize::new(0);
+LL | |     FOO.fetch_add(1, Ordering::Relaxed)
+LL | | };
+   | |__^
 
 warning: skipping const checks
-  --> $DIR/const_refers_to_static.rs:13:5
+  --> $DIR/const_refers_to_static.rs:17:1
    |
-LL |     FOO.fetch_add(1, Ordering::Relaxed)
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | / const READ_INTERIOR_MUT: usize = {
+LL | |
+LL | |     static FOO: AtomicUsize = AtomicUsize::new(0);
+LL | |     unsafe { *(&FOO as *const _ as *const usize) }
+LL | | };
+   | |__^
 
 warning: skipping const checks
-  --> $DIR/const_refers_to_static.rs:20:17
-   |
-LL |     unsafe { *(&FOO as *const _ as *const usize) }
-   |                 ^^^
-
-warning: skipping const checks
-  --> $DIR/const_refers_to_static.rs:20:14
-   |
-LL |     unsafe { *(&FOO as *const _ as *const usize) }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-warning: skipping const checks
-  --> $DIR/const_refers_to_static.rs:26:32
+  --> $DIR/const_refers_to_static.rs:24:1
    |
 LL | const READ_MUT: u32 = unsafe { MUTABLE };
-   |                                ^^^^^^^
-
-warning: skipping const checks
-  --> $DIR/const_refers_to_static.rs:26:32
-   |
-LL | const READ_MUT: u32 = unsafe { MUTABLE };
-   |                                ^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0080]: erroneous constant used
-  --> $DIR/const_refers_to_static.rs:31:5
+  --> $DIR/const_refers_to_static.rs:28:5
    |
 LL |     MUTATE_INTERIOR_MUT;
    |     ^^^^^^^^^^^^^^^^^^^ referenced constant has errors
 
 error[E0080]: erroneous constant used
-  --> $DIR/const_refers_to_static.rs:33:5
+  --> $DIR/const_refers_to_static.rs:30:5
    |
 LL |     READ_INTERIOR_MUT;
    |     ^^^^^^^^^^^^^^^^^ referenced constant has errors
 
 error[E0080]: erroneous constant used
-  --> $DIR/const_refers_to_static.rs:35:5
+  --> $DIR/const_refers_to_static.rs:32:5
    |
 LL |     READ_MUT;
    |     ^^^^^^^^ referenced constant has errors
 
-error: aborting due to 3 previous errors; 6 warnings emitted
+error: aborting due to 3 previous errors; 3 warnings emitted
 
 For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/miri_unleashed/const_refers_to_static.stderr
+++ b/src/test/ui/consts/miri_unleashed/const_refers_to_static.stderr
@@ -1,47 +1,54 @@
-warning: skipping const checks
-  --> $DIR/const_refers_to_static.rs:11:1
-   |
-LL | / const MUTATE_INTERIOR_MUT: usize = {
-LL | |
-LL | |     static FOO: AtomicUsize = AtomicUsize::new(0);
-LL | |     FOO.fetch_add(1, Ordering::Relaxed)
-LL | | };
-   | |__^
-
-warning: skipping const checks
-  --> $DIR/const_refers_to_static.rs:17:1
-   |
-LL | / const READ_INTERIOR_MUT: usize = {
-LL | |
-LL | |     static FOO: AtomicUsize = AtomicUsize::new(0);
-LL | |     unsafe { *(&FOO as *const _ as *const usize) }
-LL | | };
-   | |__^
-
-warning: skipping const checks
-  --> $DIR/const_refers_to_static.rs:24:1
-   |
-LL | const READ_MUT: u32 = unsafe { MUTABLE };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
 error[E0080]: erroneous constant used
-  --> $DIR/const_refers_to_static.rs:28:5
+  --> $DIR/const_refers_to_static.rs:25:5
    |
 LL |     MUTATE_INTERIOR_MUT;
    |     ^^^^^^^^^^^^^^^^^^^ referenced constant has errors
 
 error[E0080]: erroneous constant used
-  --> $DIR/const_refers_to_static.rs:30:5
+  --> $DIR/const_refers_to_static.rs:27:5
    |
 LL |     READ_INTERIOR_MUT;
    |     ^^^^^^^^^^^^^^^^^ referenced constant has errors
 
 error[E0080]: erroneous constant used
-  --> $DIR/const_refers_to_static.rs:32:5
+  --> $DIR/const_refers_to_static.rs:29:5
    |
 LL |     READ_MUT;
    |     ^^^^^^^^ referenced constant has errors
 
-error: aborting due to 3 previous errors; 3 warnings emitted
+warning: skipping const checks
+   |
+help: skipping check that does not even have a feature gate
+  --> $DIR/const_refers_to_static.rs:13:5
+   |
+LL |     FOO.fetch_add(1, Ordering::Relaxed)
+   |     ^^^
+help: skipping check that does not even have a feature gate
+  --> $DIR/const_refers_to_static.rs:13:5
+   |
+LL |     FOO.fetch_add(1, Ordering::Relaxed)
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: skipping check that does not even have a feature gate
+  --> $DIR/const_refers_to_static.rs:18:17
+   |
+LL |     unsafe { *(&FOO as *const _ as *const usize) }
+   |                 ^^^
+help: skipping check for `const_raw_ptr_deref` feature
+  --> $DIR/const_refers_to_static.rs:18:14
+   |
+LL |     unsafe { *(&FOO as *const _ as *const usize) }
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: skipping check that does not even have a feature gate
+  --> $DIR/const_refers_to_static.rs:22:32
+   |
+LL | const READ_MUT: u32 = unsafe { MUTABLE };
+   |                                ^^^^^^^
+help: skipping check that does not even have a feature gate
+  --> $DIR/const_refers_to_static.rs:22:32
+   |
+LL | const READ_MUT: u32 = unsafe { MUTABLE };
+   |                                ^^^^^^^
+
+error: aborting due to 3 previous errors; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/miri_unleashed/const_refers_to_static.stderr
+++ b/src/test/ui/consts/miri_unleashed/const_refers_to_static.stderr
@@ -1,51 +1,57 @@
 warning: skipping const checks
-  --> $DIR/const_refers_to_static.rs:15:5
+  --> $DIR/const_refers_to_static.rs:13:5
    |
 LL |     FOO.fetch_add(1, Ordering::Relaxed)
    |     ^^^
 
 warning: skipping const checks
-  --> $DIR/const_refers_to_static.rs:15:5
+  --> $DIR/const_refers_to_static.rs:13:5
    |
 LL |     FOO.fetch_add(1, Ordering::Relaxed)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: skipping const checks
-  --> $DIR/const_refers_to_static.rs:22:17
+  --> $DIR/const_refers_to_static.rs:20:17
    |
 LL |     unsafe { *(&FOO as *const _ as *const usize) }
    |                 ^^^
 
 warning: skipping const checks
-  --> $DIR/const_refers_to_static.rs:27:32
+  --> $DIR/const_refers_to_static.rs:20:14
+   |
+LL |     unsafe { *(&FOO as *const _ as *const usize) }
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: skipping const checks
+  --> $DIR/const_refers_to_static.rs:26:32
    |
 LL | const READ_MUT: u32 = unsafe { MUTABLE };
    |                                ^^^^^^^
 
 warning: skipping const checks
-  --> $DIR/const_refers_to_static.rs:27:32
+  --> $DIR/const_refers_to_static.rs:26:32
    |
 LL | const READ_MUT: u32 = unsafe { MUTABLE };
    |                                ^^^^^^^
 
 error[E0080]: erroneous constant used
-  --> $DIR/const_refers_to_static.rs:32:5
+  --> $DIR/const_refers_to_static.rs:31:5
    |
 LL |     MUTATE_INTERIOR_MUT;
    |     ^^^^^^^^^^^^^^^^^^^ referenced constant has errors
 
 error[E0080]: erroneous constant used
-  --> $DIR/const_refers_to_static.rs:34:5
+  --> $DIR/const_refers_to_static.rs:33:5
    |
 LL |     READ_INTERIOR_MUT;
    |     ^^^^^^^^^^^^^^^^^ referenced constant has errors
 
 error[E0080]: erroneous constant used
-  --> $DIR/const_refers_to_static.rs:36:5
+  --> $DIR/const_refers_to_static.rs:35:5
    |
 LL |     READ_MUT;
    |     ^^^^^^^^ referenced constant has errors
 
-error: aborting due to 3 previous errors; 5 warnings emitted
+error: aborting due to 3 previous errors; 6 warnings emitted
 
 For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/miri_unleashed/const_refers_to_static.stderr
+++ b/src/test/ui/consts/miri_unleashed/const_refers_to_static.stderr
@@ -1,5 +1,5 @@
 warning: skipping const checks
-  --> $DIR/const_refers_to_static.rs:11:1
+  --> $DIR/const_refers_to_static.rs:13:1
    |
 LL | / const MUTATE_INTERIOR_MUT: usize = {
 LL | |
@@ -9,7 +9,7 @@ LL | | };
    | |__^
 
 warning: skipping const checks
-  --> $DIR/const_refers_to_static.rs:17:1
+  --> $DIR/const_refers_to_static.rs:19:1
    |
 LL | / const READ_INTERIOR_MUT: usize = {
 LL | |
@@ -19,25 +19,25 @@ LL | | };
    | |__^
 
 warning: skipping const checks
-  --> $DIR/const_refers_to_static.rs:24:1
+  --> $DIR/const_refers_to_static.rs:26:1
    |
 LL | const READ_MUT: u32 = unsafe { MUTABLE };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0080]: erroneous constant used
-  --> $DIR/const_refers_to_static.rs:28:5
+  --> $DIR/const_refers_to_static.rs:30:5
    |
 LL |     MUTATE_INTERIOR_MUT;
    |     ^^^^^^^^^^^^^^^^^^^ referenced constant has errors
 
 error[E0080]: erroneous constant used
-  --> $DIR/const_refers_to_static.rs:30:5
+  --> $DIR/const_refers_to_static.rs:32:5
    |
 LL |     READ_INTERIOR_MUT;
    |     ^^^^^^^^^^^^^^^^^ referenced constant has errors
 
 error[E0080]: erroneous constant used
-  --> $DIR/const_refers_to_static.rs:32:5
+  --> $DIR/const_refers_to_static.rs:34:5
    |
 LL |     READ_MUT;
    |     ^^^^^^^^ referenced constant has errors

--- a/src/test/ui/consts/miri_unleashed/const_refers_to_static2.rs
+++ b/src/test/ui/consts/miri_unleashed/const_refers_to_static2.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zunleash-the-miri-inside-of-you -Zdeduplicate-diagnostics
+// compile-flags: -Zunleash-the-miri-inside-of-you
 #![allow(const_err)]
 
 use std::sync::atomic::AtomicUsize;

--- a/src/test/ui/consts/miri_unleashed/const_refers_to_static2.rs
+++ b/src/test/ui/consts/miri_unleashed/const_refers_to_static2.rs
@@ -1,8 +1,6 @@
 // compile-flags: -Zunleash-the-miri-inside-of-you
 #![allow(const_err)]
 
-#![feature(const_raw_ptr_deref)]
-
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 
@@ -15,6 +13,7 @@ const REF_INTERIOR_MUT: &usize = { //~ ERROR undefined behavior to use this valu
     static FOO: AtomicUsize = AtomicUsize::new(0);
     unsafe { &*(&FOO as *const _ as *const usize) }
     //~^ WARN skipping const checks
+    //~| WARN skipping const checks
 };
 
 // ok some day perhaps

--- a/src/test/ui/consts/miri_unleashed/const_refers_to_static2.rs
+++ b/src/test/ui/consts/miri_unleashed/const_refers_to_static2.rs
@@ -8,7 +8,6 @@ use std::sync::atomic::Ordering;
 // so they cause an immediate error when *defining* the const.
 
 const REF_INTERIOR_MUT: &usize = { //~ ERROR undefined behavior to use this value
-//~^ WARN skipping const checks
 //~| NOTE encountered a reference pointing to a static variable
 //~| NOTE
     static FOO: AtomicUsize = AtomicUsize::new(0);
@@ -17,7 +16,6 @@ const REF_INTERIOR_MUT: &usize = { //~ ERROR undefined behavior to use this valu
 
 // ok some day perhaps
 const READ_IMMUT: &usize = { //~ ERROR it is undefined behavior to use this value
-//~^ WARN skipping const checks
 //~| NOTE encountered a reference pointing to a static variable
 //~| NOTE
     static FOO: usize = 0;

--- a/src/test/ui/consts/miri_unleashed/const_refers_to_static2.rs
+++ b/src/test/ui/consts/miri_unleashed/const_refers_to_static2.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zunleash-the-miri-inside-of-you
+// compile-flags: -Zunleash-the-miri-inside-of-you -Zdeduplicate-diagnostics
 #![allow(const_err)]
 
 use std::sync::atomic::AtomicUsize;
@@ -8,21 +8,20 @@ use std::sync::atomic::Ordering;
 // so they cause an immediate error when *defining* the const.
 
 const REF_INTERIOR_MUT: &usize = { //~ ERROR undefined behavior to use this value
+//~^ WARN skipping const checks
 //~| NOTE encountered a reference pointing to a static variable
 //~| NOTE
     static FOO: AtomicUsize = AtomicUsize::new(0);
     unsafe { &*(&FOO as *const _ as *const usize) }
-    //~^ WARN skipping const checks
-    //~| WARN skipping const checks
 };
 
 // ok some day perhaps
 const READ_IMMUT: &usize = { //~ ERROR it is undefined behavior to use this value
+//~^ WARN skipping const checks
 //~| NOTE encountered a reference pointing to a static variable
 //~| NOTE
     static FOO: usize = 0;
     &FOO
-    //~^ WARN skipping const checks
 };
 
 fn main() {}

--- a/src/test/ui/consts/miri_unleashed/const_refers_to_static2.stderr
+++ b/src/test/ui/consts/miri_unleashed/const_refers_to_static2.stderr
@@ -1,32 +1,7 @@
-warning: skipping const checks
-  --> $DIR/const_refers_to_static2.rs:10:1
-   |
-LL | / const REF_INTERIOR_MUT: &usize = {
-LL | |
-LL | |
-LL | |
-LL | |     static FOO: AtomicUsize = AtomicUsize::new(0);
-LL | |     unsafe { &*(&FOO as *const _ as *const usize) }
-LL | | };
-   | |__^
-
-warning: skipping const checks
-  --> $DIR/const_refers_to_static2.rs:19:1
-   |
-LL | / const READ_IMMUT: &usize = {
-LL | |
-LL | |
-LL | |
-LL | |     static FOO: usize = 0;
-LL | |     &FOO
-LL | | };
-   | |__^
-
 error[E0080]: it is undefined behavior to use this value
   --> $DIR/const_refers_to_static2.rs:10:1
    |
 LL | / const REF_INTERIOR_MUT: &usize = {
-LL | |
 LL | |
 LL | |
 LL | |     static FOO: AtomicUsize = AtomicUsize::new(0);
@@ -37,10 +12,9 @@ LL | | };
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/const_refers_to_static2.rs:19:1
+  --> $DIR/const_refers_to_static2.rs:18:1
    |
 LL | / const READ_IMMUT: &usize = {
-LL | |
 LL | |
 LL | |
 LL | |     static FOO: usize = 0;
@@ -50,6 +24,24 @@ LL | | };
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
-error: aborting due to 2 previous errors; 2 warnings emitted
+warning: skipping const checks
+   |
+help: skipping check that does not even have a feature gate
+  --> $DIR/const_refers_to_static2.rs:14:18
+   |
+LL |     unsafe { &*(&FOO as *const _ as *const usize) }
+   |                  ^^^
+help: skipping check for `const_raw_ptr_deref` feature
+  --> $DIR/const_refers_to_static2.rs:14:14
+   |
+LL |     unsafe { &*(&FOO as *const _ as *const usize) }
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: skipping check that does not even have a feature gate
+  --> $DIR/const_refers_to_static2.rs:22:6
+   |
+LL |     &FOO
+   |      ^^^
+
+error: aborting due to 2 previous errors; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/miri_unleashed/const_refers_to_static2.stderr
+++ b/src/test/ui/consts/miri_unleashed/const_refers_to_static2.stderr
@@ -1,20 +1,26 @@
 warning: skipping const checks
-  --> $DIR/const_refers_to_static2.rs:14:18
+  --> $DIR/const_refers_to_static2.rs:10:1
    |
-LL |     unsafe { &*(&FOO as *const _ as *const usize) }
-   |                  ^^^
+LL | / const REF_INTERIOR_MUT: &usize = {
+LL | |
+LL | |
+LL | |
+LL | |     static FOO: AtomicUsize = AtomicUsize::new(0);
+LL | |     unsafe { &*(&FOO as *const _ as *const usize) }
+LL | | };
+   | |__^
 
 warning: skipping const checks
-  --> $DIR/const_refers_to_static2.rs:14:14
+  --> $DIR/const_refers_to_static2.rs:19:1
    |
-LL |     unsafe { &*(&FOO as *const _ as *const usize) }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-warning: skipping const checks
-  --> $DIR/const_refers_to_static2.rs:24:6
-   |
-LL |     &FOO
-   |      ^^^
+LL | / const READ_IMMUT: &usize = {
+LL | |
+LL | |
+LL | |
+LL | |     static FOO: usize = 0;
+LL | |     &FOO
+LL | | };
+   | |__^
 
 error[E0080]: it is undefined behavior to use this value
   --> $DIR/const_refers_to_static2.rs:10:1
@@ -22,28 +28,28 @@ error[E0080]: it is undefined behavior to use this value
 LL | / const REF_INTERIOR_MUT: &usize = {
 LL | |
 LL | |
-LL | |     static FOO: AtomicUsize = AtomicUsize::new(0);
-...  |
 LL | |
+LL | |     static FOO: AtomicUsize = AtomicUsize::new(0);
+LL | |     unsafe { &*(&FOO as *const _ as *const usize) }
 LL | | };
    | |__^ type validation failed: encountered a reference pointing to a static variable
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/const_refers_to_static2.rs:20:1
+  --> $DIR/const_refers_to_static2.rs:19:1
    |
 LL | / const READ_IMMUT: &usize = {
 LL | |
 LL | |
+LL | |
 LL | |     static FOO: usize = 0;
 LL | |     &FOO
-LL | |
 LL | | };
    | |__^ type validation failed: encountered a reference pointing to a static variable
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
-error: aborting due to 2 previous errors; 3 warnings emitted
+error: aborting due to 2 previous errors; 2 warnings emitted
 
 For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/miri_unleashed/const_refers_to_static2.stderr
+++ b/src/test/ui/consts/miri_unleashed/const_refers_to_static2.stderr
@@ -1,23 +1,29 @@
 warning: skipping const checks
-  --> $DIR/const_refers_to_static2.rs:16:18
+  --> $DIR/const_refers_to_static2.rs:14:18
    |
 LL |     unsafe { &*(&FOO as *const _ as *const usize) }
    |                  ^^^
 
 warning: skipping const checks
-  --> $DIR/const_refers_to_static2.rs:25:6
+  --> $DIR/const_refers_to_static2.rs:14:14
+   |
+LL |     unsafe { &*(&FOO as *const _ as *const usize) }
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: skipping const checks
+  --> $DIR/const_refers_to_static2.rs:24:6
    |
 LL |     &FOO
    |      ^^^
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/const_refers_to_static2.rs:12:1
+  --> $DIR/const_refers_to_static2.rs:10:1
    |
 LL | / const REF_INTERIOR_MUT: &usize = {
 LL | |
 LL | |
 LL | |     static FOO: AtomicUsize = AtomicUsize::new(0);
-LL | |     unsafe { &*(&FOO as *const _ as *const usize) }
+...  |
 LL | |
 LL | | };
    | |__^ type validation failed: encountered a reference pointing to a static variable
@@ -25,7 +31,7 @@ LL | | };
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/const_refers_to_static2.rs:21:1
+  --> $DIR/const_refers_to_static2.rs:20:1
    |
 LL | / const READ_IMMUT: &usize = {
 LL | |
@@ -38,6 +44,6 @@ LL | | };
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
-error: aborting due to 2 previous errors; 2 warnings emitted
+error: aborting due to 2 previous errors; 3 warnings emitted
 
 For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/miri_unleashed/const_refers_to_static_cross_crate.rs
+++ b/src/test/ui/consts/miri_unleashed/const_refers_to_static_cross_crate.rs
@@ -9,33 +9,32 @@ extern crate static_cross_crate;
 // Sneaky: reference to a mutable static.
 // Allowing this would be a disaster for pattern matching, we could violate exhaustiveness checking!
 const SLICE_MUT: &[u8; 1] = { //~ ERROR undefined behavior to use this value
+//~^ WARN skipping const checks
 //~| NOTE encountered a reference pointing to a static variable
 //~| NOTE
     unsafe { &static_cross_crate::ZERO }
-    //~^ WARN skipping const checks
 };
 
 const U8_MUT: &u8 = { //~ ERROR undefined behavior to use this value
+//~^ WARN skipping const checks
 //~| NOTE encountered a reference pointing to a static variable
 //~| NOTE
     unsafe { &static_cross_crate::ZERO[0] }
-    //~^ WARN skipping const checks
 };
 
 // Also test indirection that reads from other static. This causes a const_err.
 #[warn(const_err)] //~ NOTE
 const U8_MUT2: &u8 = { //~ NOTE
+//~^ WARN skipping const checks
     unsafe { &(*static_cross_crate::ZERO_REF)[0] }
-    //~^ WARN skipping const checks
-    //~| WARN [const_err]
+    //~^ WARN [const_err]
     //~| NOTE constant accesses static
 };
 #[warn(const_err)] //~ NOTE
 const U8_MUT3: &u8 = { //~ NOTE
+//~^ WARN skipping const checks
     unsafe { match static_cross_crate::OPT_ZERO { Some(ref u) => u, None => panic!() } }
-    //~^ WARN skipping const checks
-    //~| WARN skipping const checks
-    //~| WARN [const_err]
+    //~^ WARN [const_err]
     //~| NOTE constant accesses static
 };
 

--- a/src/test/ui/consts/miri_unleashed/const_refers_to_static_cross_crate.rs
+++ b/src/test/ui/consts/miri_unleashed/const_refers_to_static_cross_crate.rs
@@ -2,7 +2,7 @@
 // aux-build:static_cross_crate.rs
 #![allow(const_err)]
 
-#![feature(exclusive_range_pattern, half_open_range_patterns, const_if_match, const_panic)]
+#![feature(exclusive_range_pattern, half_open_range_patterns, const_if_match)]
 
 extern crate static_cross_crate;
 
@@ -34,6 +34,7 @@ const U8_MUT2: &u8 = { //~ NOTE
 const U8_MUT3: &u8 = { //~ NOTE
     unsafe { match static_cross_crate::OPT_ZERO { Some(ref u) => u, None => panic!() } }
     //~^ WARN skipping const checks
+    //~| WARN skipping const checks
     //~| WARN [const_err]
     //~| NOTE constant accesses static
 };

--- a/src/test/ui/consts/miri_unleashed/const_refers_to_static_cross_crate.rs
+++ b/src/test/ui/consts/miri_unleashed/const_refers_to_static_cross_crate.rs
@@ -9,14 +9,12 @@ extern crate static_cross_crate;
 // Sneaky: reference to a mutable static.
 // Allowing this would be a disaster for pattern matching, we could violate exhaustiveness checking!
 const SLICE_MUT: &[u8; 1] = { //~ ERROR undefined behavior to use this value
-//~^ WARN skipping const checks
 //~| NOTE encountered a reference pointing to a static variable
 //~| NOTE
     unsafe { &static_cross_crate::ZERO }
 };
 
 const U8_MUT: &u8 = { //~ ERROR undefined behavior to use this value
-//~^ WARN skipping const checks
 //~| NOTE encountered a reference pointing to a static variable
 //~| NOTE
     unsafe { &static_cross_crate::ZERO[0] }
@@ -25,14 +23,12 @@ const U8_MUT: &u8 = { //~ ERROR undefined behavior to use this value
 // Also test indirection that reads from other static. This causes a const_err.
 #[warn(const_err)] //~ NOTE
 const U8_MUT2: &u8 = { //~ NOTE
-//~^ WARN skipping const checks
     unsafe { &(*static_cross_crate::ZERO_REF)[0] }
     //~^ WARN [const_err]
     //~| NOTE constant accesses static
 };
 #[warn(const_err)] //~ NOTE
 const U8_MUT3: &u8 = { //~ NOTE
-//~^ WARN skipping const checks
     unsafe { match static_cross_crate::OPT_ZERO { Some(ref u) => u, None => panic!() } }
     //~^ WARN [const_err]
     //~| NOTE constant accesses static

--- a/src/test/ui/consts/miri_unleashed/const_refers_to_static_cross_crate.rs
+++ b/src/test/ui/consts/miri_unleashed/const_refers_to_static_cross_crate.rs
@@ -1,7 +1,8 @@
-// compile-flags: -Zunleash-the-miri-inside-of-you -Zdeduplicate-diagnostics
+// compile-flags: -Zunleash-the-miri-inside-of-you
 // aux-build:static_cross_crate.rs
 #![allow(const_err)]
 
+// `const_if_match` is a HIR check and thus needed even when unleashed.
 #![feature(exclusive_range_pattern, half_open_range_patterns, const_if_match)]
 
 extern crate static_cross_crate;
@@ -38,6 +39,7 @@ pub fn test(x: &[u8; 1]) -> bool {
     match x {
         SLICE_MUT => true,
         //~^ ERROR could not evaluate constant pattern
+        //~| ERROR could not evaluate constant pattern
         &[1..] => false,
     }
 }
@@ -46,6 +48,7 @@ pub fn test2(x: &u8) -> bool {
     match x {
         U8_MUT => true,
         //~^ ERROR could not evaluate constant pattern
+        //~| ERROR could not evaluate constant pattern
         &(1..) => false,
     }
 }
@@ -56,6 +59,7 @@ pub fn test3(x: &u8) -> bool {
     match x {
         U8_MUT2 => true,
         //~^ ERROR could not evaluate constant pattern
+        //~| ERROR could not evaluate constant pattern
         &(1..) => false,
     }
 }
@@ -63,6 +67,7 @@ pub fn test4(x: &u8) -> bool {
     match x {
         U8_MUT3 => true,
         //~^ ERROR could not evaluate constant pattern
+        //~| ERROR could not evaluate constant pattern
         &(1..) => false,
     }
 }

--- a/src/test/ui/consts/miri_unleashed/const_refers_to_static_cross_crate.stderr
+++ b/src/test/ui/consts/miri_unleashed/const_refers_to_static_cross_crate.stderr
@@ -1,5 +1,5 @@
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/const_refers_to_static_cross_crate.rs:11:1
+  --> $DIR/const_refers_to_static_cross_crate.rs:12:1
    |
 LL | / const SLICE_MUT: &[u8; 1] = {
 LL | |
@@ -11,13 +11,13 @@ LL | | };
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error: could not evaluate constant pattern
-  --> $DIR/const_refers_to_static_cross_crate.rs:39:9
+  --> $DIR/const_refers_to_static_cross_crate.rs:40:9
    |
 LL |         SLICE_MUT => true,
    |         ^^^^^^^^^
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/const_refers_to_static_cross_crate.rs:17:1
+  --> $DIR/const_refers_to_static_cross_crate.rs:18:1
    |
 LL | / const U8_MUT: &u8 = {
 LL | |
@@ -29,13 +29,13 @@ LL | | };
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error: could not evaluate constant pattern
-  --> $DIR/const_refers_to_static_cross_crate.rs:47:9
+  --> $DIR/const_refers_to_static_cross_crate.rs:49:9
    |
 LL |         U8_MUT => true,
    |         ^^^^^^
 
 warning: any use of this value will cause an error
-  --> $DIR/const_refers_to_static_cross_crate.rs:26:14
+  --> $DIR/const_refers_to_static_cross_crate.rs:27:14
    |
 LL | / const U8_MUT2: &u8 = {
 LL | |     unsafe { &(*static_cross_crate::ZERO_REF)[0] }
@@ -46,19 +46,19 @@ LL | | };
    | |__-
    |
 note: the lint level is defined here
-  --> $DIR/const_refers_to_static_cross_crate.rs:24:8
+  --> $DIR/const_refers_to_static_cross_crate.rs:25:8
    |
 LL | #[warn(const_err)]
    |        ^^^^^^^^^
 
 error: could not evaluate constant pattern
-  --> $DIR/const_refers_to_static_cross_crate.rs:57:9
+  --> $DIR/const_refers_to_static_cross_crate.rs:60:9
    |
 LL |         U8_MUT2 => true,
    |         ^^^^^^^
 
 warning: any use of this value will cause an error
-  --> $DIR/const_refers_to_static_cross_crate.rs:32:51
+  --> $DIR/const_refers_to_static_cross_crate.rs:33:51
    |
 LL | / const U8_MUT3: &u8 = {
 LL | |     unsafe { match static_cross_crate::OPT_ZERO { Some(ref u) => u, None => panic!() } }
@@ -69,13 +69,37 @@ LL | | };
    | |__-
    |
 note: the lint level is defined here
-  --> $DIR/const_refers_to_static_cross_crate.rs:30:8
+  --> $DIR/const_refers_to_static_cross_crate.rs:31:8
    |
 LL | #[warn(const_err)]
    |        ^^^^^^^^^
 
 error: could not evaluate constant pattern
-  --> $DIR/const_refers_to_static_cross_crate.rs:64:9
+  --> $DIR/const_refers_to_static_cross_crate.rs:68:9
+   |
+LL |         U8_MUT3 => true,
+   |         ^^^^^^^
+
+error: could not evaluate constant pattern
+  --> $DIR/const_refers_to_static_cross_crate.rs:40:9
+   |
+LL |         SLICE_MUT => true,
+   |         ^^^^^^^^^
+
+error: could not evaluate constant pattern
+  --> $DIR/const_refers_to_static_cross_crate.rs:49:9
+   |
+LL |         U8_MUT => true,
+   |         ^^^^^^
+
+error: could not evaluate constant pattern
+  --> $DIR/const_refers_to_static_cross_crate.rs:60:9
+   |
+LL |         U8_MUT2 => true,
+   |         ^^^^^^^
+
+error: could not evaluate constant pattern
+  --> $DIR/const_refers_to_static_cross_crate.rs:68:9
    |
 LL |         U8_MUT3 => true,
    |         ^^^^^^^
@@ -83,62 +107,62 @@ LL |         U8_MUT3 => true,
 warning: skipping const checks
    |
 help: skipping check that does not even have a feature gate
-  --> $DIR/const_refers_to_static_cross_crate.rs:14:15
+  --> $DIR/const_refers_to_static_cross_crate.rs:15:15
    |
 LL |     unsafe { &static_cross_crate::ZERO }
    |               ^^^^^^^^^^^^^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/const_refers_to_static_cross_crate.rs:14:15
+  --> $DIR/const_refers_to_static_cross_crate.rs:15:15
    |
 LL |     unsafe { &static_cross_crate::ZERO }
    |               ^^^^^^^^^^^^^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/const_refers_to_static_cross_crate.rs:20:15
+  --> $DIR/const_refers_to_static_cross_crate.rs:21:15
    |
 LL |     unsafe { &static_cross_crate::ZERO[0] }
    |               ^^^^^^^^^^^^^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/const_refers_to_static_cross_crate.rs:20:15
+  --> $DIR/const_refers_to_static_cross_crate.rs:21:15
    |
 LL |     unsafe { &static_cross_crate::ZERO[0] }
    |               ^^^^^^^^^^^^^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/const_refers_to_static_cross_crate.rs:20:15
+  --> $DIR/const_refers_to_static_cross_crate.rs:21:15
    |
 LL |     unsafe { &static_cross_crate::ZERO[0] }
    |               ^^^^^^^^^^^^^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/const_refers_to_static_cross_crate.rs:26:17
+  --> $DIR/const_refers_to_static_cross_crate.rs:27:17
    |
 LL |     unsafe { &(*static_cross_crate::ZERO_REF)[0] }
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/const_refers_to_static_cross_crate.rs:32:20
+  --> $DIR/const_refers_to_static_cross_crate.rs:33:20
    |
 LL |     unsafe { match static_cross_crate::OPT_ZERO { Some(ref u) => u, None => panic!() } }
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/const_refers_to_static_cross_crate.rs:32:20
+  --> $DIR/const_refers_to_static_cross_crate.rs:33:20
    |
 LL |     unsafe { match static_cross_crate::OPT_ZERO { Some(ref u) => u, None => panic!() } }
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/const_refers_to_static_cross_crate.rs:32:20
+  --> $DIR/const_refers_to_static_cross_crate.rs:33:20
    |
 LL |     unsafe { match static_cross_crate::OPT_ZERO { Some(ref u) => u, None => panic!() } }
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: skipping check for `const_panic` feature
-  --> $DIR/const_refers_to_static_cross_crate.rs:32:77
+  --> $DIR/const_refers_to_static_cross_crate.rs:33:77
    |
 LL |     unsafe { match static_cross_crate::OPT_ZERO { Some(ref u) => u, None => panic!() } }
    |                                                                             ^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/const_refers_to_static_cross_crate.rs:32:20
+  --> $DIR/const_refers_to_static_cross_crate.rs:33:20
    |
 LL |     unsafe { match static_cross_crate::OPT_ZERO { Some(ref u) => u, None => panic!() } }
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 6 previous errors; 3 warnings emitted
+error: aborting due to 10 previous errors; 3 warnings emitted
 
 For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/miri_unleashed/const_refers_to_static_cross_crate.stderr
+++ b/src/test/ui/consts/miri_unleashed/const_refers_to_static_cross_crate.stderr
@@ -18,7 +18,7 @@ LL | | };
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error: could not evaluate constant pattern
-  --> $DIR/const_refers_to_static_cross_crate.rs:43:9
+  --> $DIR/const_refers_to_static_cross_crate.rs:44:9
    |
 LL |         SLICE_MUT => true,
    |         ^^^^^^^^^
@@ -43,7 +43,7 @@ LL | | };
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error: could not evaluate constant pattern
-  --> $DIR/const_refers_to_static_cross_crate.rs:51:9
+  --> $DIR/const_refers_to_static_cross_crate.rs:52:9
    |
 LL |         U8_MUT => true,
    |         ^^^^^^
@@ -73,7 +73,7 @@ LL | #[warn(const_err)]
    |        ^^^^^^^^^
 
 error: could not evaluate constant pattern
-  --> $DIR/const_refers_to_static_cross_crate.rs:61:9
+  --> $DIR/const_refers_to_static_cross_crate.rs:62:9
    |
 LL |         U8_MUT2 => true,
    |         ^^^^^^^
@@ -84,12 +84,21 @@ warning: skipping const checks
 LL |     unsafe { match static_cross_crate::OPT_ZERO { Some(ref u) => u, None => panic!() } }
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+warning: skipping const checks
+  --> $DIR/const_refers_to_static_cross_crate.rs:35:77
+   |
+LL |     unsafe { match static_cross_crate::OPT_ZERO { Some(ref u) => u, None => panic!() } }
+   |                                                                             ^^^^^^^^
+   |
+   = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
 warning: any use of this value will cause an error
   --> $DIR/const_refers_to_static_cross_crate.rs:35:51
    |
 LL | / const U8_MUT3: &u8 = {
 LL | |     unsafe { match static_cross_crate::OPT_ZERO { Some(ref u) => u, None => panic!() } }
    | |                                                   ^^^^^^^^^^^ constant accesses static
+LL | |
 LL | |
 LL | |
 LL | |
@@ -103,11 +112,11 @@ LL | #[warn(const_err)]
    |        ^^^^^^^^^
 
 error: could not evaluate constant pattern
-  --> $DIR/const_refers_to_static_cross_crate.rs:68:9
+  --> $DIR/const_refers_to_static_cross_crate.rs:69:9
    |
 LL |         U8_MUT3 => true,
    |         ^^^^^^^
 
-error: aborting due to 6 previous errors; 6 warnings emitted
+error: aborting due to 6 previous errors; 7 warnings emitted
 
 For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/miri_unleashed/const_refers_to_static_cross_crate.stderr
+++ b/src/test/ui/consts/miri_unleashed/const_refers_to_static_cross_crate.stderr
@@ -1,19 +1,7 @@
-warning: skipping const checks
-  --> $DIR/const_refers_to_static_cross_crate.rs:11:1
-   |
-LL | / const SLICE_MUT: &[u8; 1] = {
-LL | |
-LL | |
-LL | |
-LL | |     unsafe { &static_cross_crate::ZERO }
-LL | | };
-   | |__^
-
 error[E0080]: it is undefined behavior to use this value
   --> $DIR/const_refers_to_static_cross_crate.rs:11:1
    |
 LL | / const SLICE_MUT: &[u8; 1] = {
-LL | |
 LL | |
 LL | |
 LL | |     unsafe { &static_cross_crate::ZERO }
@@ -23,27 +11,15 @@ LL | | };
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error: could not evaluate constant pattern
-  --> $DIR/const_refers_to_static_cross_crate.rs:43:9
+  --> $DIR/const_refers_to_static_cross_crate.rs:39:9
    |
 LL |         SLICE_MUT => true,
    |         ^^^^^^^^^
 
-warning: skipping const checks
-  --> $DIR/const_refers_to_static_cross_crate.rs:18:1
-   |
-LL | / const U8_MUT: &u8 = {
-LL | |
-LL | |
-LL | |
-LL | |     unsafe { &static_cross_crate::ZERO[0] }
-LL | | };
-   | |__^
-
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/const_refers_to_static_cross_crate.rs:18:1
+  --> $DIR/const_refers_to_static_cross_crate.rs:17:1
    |
 LL | / const U8_MUT: &u8 = {
-LL | |
 LL | |
 LL | |
 LL | |     unsafe { &static_cross_crate::ZERO[0] }
@@ -53,27 +29,15 @@ LL | | };
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error: could not evaluate constant pattern
-  --> $DIR/const_refers_to_static_cross_crate.rs:51:9
+  --> $DIR/const_refers_to_static_cross_crate.rs:47:9
    |
 LL |         U8_MUT => true,
    |         ^^^^^^
 
-warning: skipping const checks
-  --> $DIR/const_refers_to_static_cross_crate.rs:27:1
-   |
-LL | / const U8_MUT2: &u8 = {
-LL | |
-LL | |     unsafe { &(*static_cross_crate::ZERO_REF)[0] }
-LL | |
-LL | |
-LL | | };
-   | |__^
-
 warning: any use of this value will cause an error
-  --> $DIR/const_refers_to_static_cross_crate.rs:29:14
+  --> $DIR/const_refers_to_static_cross_crate.rs:26:14
    |
 LL | / const U8_MUT2: &u8 = {
-LL | |
 LL | |     unsafe { &(*static_cross_crate::ZERO_REF)[0] }
    | |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constant accesses static
 LL | |
@@ -82,33 +46,21 @@ LL | | };
    | |__-
    |
 note: the lint level is defined here
-  --> $DIR/const_refers_to_static_cross_crate.rs:26:8
+  --> $DIR/const_refers_to_static_cross_crate.rs:24:8
    |
 LL | #[warn(const_err)]
    |        ^^^^^^^^^
 
 error: could not evaluate constant pattern
-  --> $DIR/const_refers_to_static_cross_crate.rs:61:9
+  --> $DIR/const_refers_to_static_cross_crate.rs:57:9
    |
 LL |         U8_MUT2 => true,
    |         ^^^^^^^
 
-warning: skipping const checks
-  --> $DIR/const_refers_to_static_cross_crate.rs:34:1
-   |
-LL | / const U8_MUT3: &u8 = {
-LL | |
-LL | |     unsafe { match static_cross_crate::OPT_ZERO { Some(ref u) => u, None => panic!() } }
-LL | |
-LL | |
-LL | | };
-   | |__^
-
 warning: any use of this value will cause an error
-  --> $DIR/const_refers_to_static_cross_crate.rs:36:51
+  --> $DIR/const_refers_to_static_cross_crate.rs:32:51
    |
 LL | / const U8_MUT3: &u8 = {
-LL | |
 LL | |     unsafe { match static_cross_crate::OPT_ZERO { Some(ref u) => u, None => panic!() } }
    | |                                                   ^^^^^^^^^^^ constant accesses static
 LL | |
@@ -117,17 +69,76 @@ LL | | };
    | |__-
    |
 note: the lint level is defined here
-  --> $DIR/const_refers_to_static_cross_crate.rs:33:8
+  --> $DIR/const_refers_to_static_cross_crate.rs:30:8
    |
 LL | #[warn(const_err)]
    |        ^^^^^^^^^
 
 error: could not evaluate constant pattern
-  --> $DIR/const_refers_to_static_cross_crate.rs:68:9
+  --> $DIR/const_refers_to_static_cross_crate.rs:64:9
    |
 LL |         U8_MUT3 => true,
    |         ^^^^^^^
 
-error: aborting due to 6 previous errors; 6 warnings emitted
+warning: skipping const checks
+   |
+help: skipping check that does not even have a feature gate
+  --> $DIR/const_refers_to_static_cross_crate.rs:14:15
+   |
+LL |     unsafe { &static_cross_crate::ZERO }
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^
+help: skipping check that does not even have a feature gate
+  --> $DIR/const_refers_to_static_cross_crate.rs:14:15
+   |
+LL |     unsafe { &static_cross_crate::ZERO }
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^
+help: skipping check that does not even have a feature gate
+  --> $DIR/const_refers_to_static_cross_crate.rs:20:15
+   |
+LL |     unsafe { &static_cross_crate::ZERO[0] }
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^
+help: skipping check that does not even have a feature gate
+  --> $DIR/const_refers_to_static_cross_crate.rs:20:15
+   |
+LL |     unsafe { &static_cross_crate::ZERO[0] }
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^
+help: skipping check that does not even have a feature gate
+  --> $DIR/const_refers_to_static_cross_crate.rs:20:15
+   |
+LL |     unsafe { &static_cross_crate::ZERO[0] }
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^
+help: skipping check that does not even have a feature gate
+  --> $DIR/const_refers_to_static_cross_crate.rs:26:17
+   |
+LL |     unsafe { &(*static_cross_crate::ZERO_REF)[0] }
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: skipping check that does not even have a feature gate
+  --> $DIR/const_refers_to_static_cross_crate.rs:32:20
+   |
+LL |     unsafe { match static_cross_crate::OPT_ZERO { Some(ref u) => u, None => panic!() } }
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: skipping check that does not even have a feature gate
+  --> $DIR/const_refers_to_static_cross_crate.rs:32:20
+   |
+LL |     unsafe { match static_cross_crate::OPT_ZERO { Some(ref u) => u, None => panic!() } }
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: skipping check that does not even have a feature gate
+  --> $DIR/const_refers_to_static_cross_crate.rs:32:20
+   |
+LL |     unsafe { match static_cross_crate::OPT_ZERO { Some(ref u) => u, None => panic!() } }
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: skipping check for `const_panic` feature
+  --> $DIR/const_refers_to_static_cross_crate.rs:32:77
+   |
+LL |     unsafe { match static_cross_crate::OPT_ZERO { Some(ref u) => u, None => panic!() } }
+   |                                                                             ^^^^^^^^
+help: skipping check that does not even have a feature gate
+  --> $DIR/const_refers_to_static_cross_crate.rs:32:20
+   |
+LL |     unsafe { match static_cross_crate::OPT_ZERO { Some(ref u) => u, None => panic!() } }
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 6 previous errors; 3 warnings emitted
 
 For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/miri_unleashed/const_refers_to_static_cross_crate.stderr
+++ b/src/test/ui/consts/miri_unleashed/const_refers_to_static_cross_crate.stderr
@@ -1,8 +1,13 @@
 warning: skipping const checks
-  --> $DIR/const_refers_to_static_cross_crate.rs:14:15
+  --> $DIR/const_refers_to_static_cross_crate.rs:11:1
    |
-LL |     unsafe { &static_cross_crate::ZERO }
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^
+LL | / const SLICE_MUT: &[u8; 1] = {
+LL | |
+LL | |
+LL | |
+LL | |     unsafe { &static_cross_crate::ZERO }
+LL | | };
+   | |__^
 
 error[E0080]: it is undefined behavior to use this value
   --> $DIR/const_refers_to_static_cross_crate.rs:11:1
@@ -10,24 +15,29 @@ error[E0080]: it is undefined behavior to use this value
 LL | / const SLICE_MUT: &[u8; 1] = {
 LL | |
 LL | |
-LL | |     unsafe { &static_cross_crate::ZERO }
 LL | |
+LL | |     unsafe { &static_cross_crate::ZERO }
 LL | | };
    | |__^ type validation failed: encountered a reference pointing to a static variable
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error: could not evaluate constant pattern
-  --> $DIR/const_refers_to_static_cross_crate.rs:44:9
+  --> $DIR/const_refers_to_static_cross_crate.rs:43:9
    |
 LL |         SLICE_MUT => true,
    |         ^^^^^^^^^
 
 warning: skipping const checks
-  --> $DIR/const_refers_to_static_cross_crate.rs:21:15
+  --> $DIR/const_refers_to_static_cross_crate.rs:18:1
    |
-LL |     unsafe { &static_cross_crate::ZERO[0] }
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^
+LL | / const U8_MUT: &u8 = {
+LL | |
+LL | |
+LL | |
+LL | |     unsafe { &static_cross_crate::ZERO[0] }
+LL | | };
+   | |__^
 
 error[E0080]: it is undefined behavior to use this value
   --> $DIR/const_refers_to_static_cross_crate.rs:18:1
@@ -35,32 +45,37 @@ error[E0080]: it is undefined behavior to use this value
 LL | / const U8_MUT: &u8 = {
 LL | |
 LL | |
-LL | |     unsafe { &static_cross_crate::ZERO[0] }
 LL | |
+LL | |     unsafe { &static_cross_crate::ZERO[0] }
 LL | | };
    | |__^ type validation failed: encountered a reference pointing to a static variable
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error: could not evaluate constant pattern
-  --> $DIR/const_refers_to_static_cross_crate.rs:52:9
+  --> $DIR/const_refers_to_static_cross_crate.rs:51:9
    |
 LL |         U8_MUT => true,
    |         ^^^^^^
 
 warning: skipping const checks
-  --> $DIR/const_refers_to_static_cross_crate.rs:28:17
-   |
-LL |     unsafe { &(*static_cross_crate::ZERO_REF)[0] }
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-warning: any use of this value will cause an error
-  --> $DIR/const_refers_to_static_cross_crate.rs:28:14
+  --> $DIR/const_refers_to_static_cross_crate.rs:27:1
    |
 LL | / const U8_MUT2: &u8 = {
+LL | |
+LL | |     unsafe { &(*static_cross_crate::ZERO_REF)[0] }
+LL | |
+LL | |
+LL | | };
+   | |__^
+
+warning: any use of this value will cause an error
+  --> $DIR/const_refers_to_static_cross_crate.rs:29:14
+   |
+LL | / const U8_MUT2: &u8 = {
+LL | |
 LL | |     unsafe { &(*static_cross_crate::ZERO_REF)[0] }
    | |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constant accesses static
-LL | |
 LL | |
 LL | |
 LL | | };
@@ -73,33 +88,29 @@ LL | #[warn(const_err)]
    |        ^^^^^^^^^
 
 error: could not evaluate constant pattern
-  --> $DIR/const_refers_to_static_cross_crate.rs:62:9
+  --> $DIR/const_refers_to_static_cross_crate.rs:61:9
    |
 LL |         U8_MUT2 => true,
    |         ^^^^^^^
 
 warning: skipping const checks
-  --> $DIR/const_refers_to_static_cross_crate.rs:35:20
-   |
-LL |     unsafe { match static_cross_crate::OPT_ZERO { Some(ref u) => u, None => panic!() } }
-   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-warning: skipping const checks
-  --> $DIR/const_refers_to_static_cross_crate.rs:35:77
-   |
-LL |     unsafe { match static_cross_crate::OPT_ZERO { Some(ref u) => u, None => panic!() } }
-   |                                                                             ^^^^^^^^
-   |
-   = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
-
-warning: any use of this value will cause an error
-  --> $DIR/const_refers_to_static_cross_crate.rs:35:51
+  --> $DIR/const_refers_to_static_cross_crate.rs:34:1
    |
 LL | / const U8_MUT3: &u8 = {
+LL | |
+LL | |     unsafe { match static_cross_crate::OPT_ZERO { Some(ref u) => u, None => panic!() } }
+LL | |
+LL | |
+LL | | };
+   | |__^
+
+warning: any use of this value will cause an error
+  --> $DIR/const_refers_to_static_cross_crate.rs:36:51
+   |
+LL | / const U8_MUT3: &u8 = {
+LL | |
 LL | |     unsafe { match static_cross_crate::OPT_ZERO { Some(ref u) => u, None => panic!() } }
    | |                                                   ^^^^^^^^^^^ constant accesses static
-LL | |
-LL | |
 LL | |
 LL | |
 LL | | };
@@ -112,11 +123,11 @@ LL | #[warn(const_err)]
    |        ^^^^^^^^^
 
 error: could not evaluate constant pattern
-  --> $DIR/const_refers_to_static_cross_crate.rs:69:9
+  --> $DIR/const_refers_to_static_cross_crate.rs:68:9
    |
 LL |         U8_MUT3 => true,
    |         ^^^^^^^
 
-error: aborting due to 6 previous errors; 7 warnings emitted
+error: aborting due to 6 previous errors; 6 warnings emitted
 
 For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/miri_unleashed/drop.rs
+++ b/src/test/ui/consts/miri_unleashed/drop.rs
@@ -13,7 +13,6 @@ static TEST_OK: () = {
 
 // Make sure we catch executing bad drop functions.
 // The actual error is tested by the error-pattern above.
-static TEST_BAD: () = {
+static TEST_BAD: () = { //~ WARN skipping const checks
     let _v: Vec<i32> = Vec::new();
-    //~^ WARN skipping const check
 };

--- a/src/test/ui/consts/miri_unleashed/drop.rs
+++ b/src/test/ui/consts/miri_unleashed/drop.rs
@@ -13,6 +13,6 @@ static TEST_OK: () = {
 
 // Make sure we catch executing bad drop functions.
 // The actual error is tested by the error-pattern above.
-static TEST_BAD: () = { //~ WARN skipping const checks
+static TEST_BAD: () = {
     let _v: Vec<i32> = Vec::new();
 };

--- a/src/test/ui/consts/miri_unleashed/drop.stderr
+++ b/src/test/ui/consts/miri_unleashed/drop.stderr
@@ -1,8 +1,10 @@
 warning: skipping const checks
-  --> $DIR/drop.rs:17:9
+  --> $DIR/drop.rs:16:1
    |
-LL |     let _v: Vec<i32> = Vec::new();
-   |         ^^
+LL | / static TEST_BAD: () = {
+LL | |     let _v: Vec<i32> = Vec::new();
+LL | | };
+   | |__^
 
 error[E0080]: could not evaluate static initializer
   --> $SRC_DIR/libcore/ptr/mod.rs:LL:COL
@@ -17,10 +19,10 @@ LL | | }
    | |_calling non-const function `<std::vec::Vec<i32> as std::ops::Drop>::drop`
    |   inside `std::intrinsics::drop_in_place::<std::vec::Vec<i32>> - shim(Some(std::vec::Vec<i32>))` at $SRC_DIR/libcore/ptr/mod.rs:LL:COL
    | 
-  ::: $DIR/drop.rs:19:1
+  ::: $DIR/drop.rs:18:1
    |
 LL |   };
-   |   - inside `TEST_BAD` at $DIR/drop.rs:19:1
+   |   - inside `TEST_BAD` at $DIR/drop.rs:18:1
 
 error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui/consts/miri_unleashed/drop.stderr
+++ b/src/test/ui/consts/miri_unleashed/drop.stderr
@@ -1,11 +1,3 @@
-warning: skipping const checks
-  --> $DIR/drop.rs:16:1
-   |
-LL | / static TEST_BAD: () = {
-LL | |     let _v: Vec<i32> = Vec::new();
-LL | | };
-   | |__^
-
 error[E0080]: could not evaluate static initializer
   --> $SRC_DIR/libcore/ptr/mod.rs:LL:COL
    |
@@ -23,6 +15,14 @@ LL | | }
    |
 LL |   };
    |   - inside `TEST_BAD` at $DIR/drop.rs:18:1
+
+warning: skipping const checks
+   |
+help: skipping check that does not even have a feature gate
+  --> $DIR/drop.rs:17:9
+   |
+LL |     let _v: Vec<i32> = Vec::new();
+   |         ^^
 
 error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui/consts/miri_unleashed/inline_asm.rs
+++ b/src/test/ui/consts/miri_unleashed/inline_asm.rs
@@ -6,9 +6,10 @@
 fn main() {}
 
 // Make sure we catch executing inline assembly.
-static TEST_BAD: () = { //~ WARN skipping const checks
+static TEST_BAD: () = {
     unsafe { llvm_asm!("xor %eax, %eax" ::: "eax"); }
     //~^ ERROR could not evaluate static initializer
     //~| NOTE inline assembly is not supported
+    //~| NOTE in this expansion of llvm_asm!
     //~| NOTE in this expansion of llvm_asm!
 };

--- a/src/test/ui/consts/miri_unleashed/inline_asm.rs
+++ b/src/test/ui/consts/miri_unleashed/inline_asm.rs
@@ -6,11 +6,9 @@
 fn main() {}
 
 // Make sure we catch executing inline assembly.
-static TEST_BAD: () = {
+static TEST_BAD: () = { //~ WARN skipping const checks
     unsafe { llvm_asm!("xor %eax, %eax" ::: "eax"); }
     //~^ ERROR could not evaluate static initializer
-    //~| NOTE in this expansion of llvm_asm!
     //~| NOTE inline assembly is not supported
-    //~| WARN skipping const checks
     //~| NOTE in this expansion of llvm_asm!
 };

--- a/src/test/ui/consts/miri_unleashed/inline_asm.stderr
+++ b/src/test/ui/consts/miri_unleashed/inline_asm.stderr
@@ -1,10 +1,13 @@
 warning: skipping const checks
-  --> $DIR/inline_asm.rs:10:14
+  --> $DIR/inline_asm.rs:9:1
    |
-LL |     unsafe { llvm_asm!("xor %eax, %eax" ::: "eax"); }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+LL | / static TEST_BAD: () = {
+LL | |     unsafe { llvm_asm!("xor %eax, %eax" ::: "eax"); }
+LL | |
+LL | |
+LL | |
+LL | | };
+   | |__^
 
 error[E0080]: could not evaluate static initializer
   --> $DIR/inline_asm.rs:10:14

--- a/src/test/ui/consts/miri_unleashed/inline_asm.stderr
+++ b/src/test/ui/consts/miri_unleashed/inline_asm.stderr
@@ -1,14 +1,3 @@
-warning: skipping const checks
-  --> $DIR/inline_asm.rs:9:1
-   |
-LL | / static TEST_BAD: () = {
-LL | |     unsafe { llvm_asm!("xor %eax, %eax" ::: "eax"); }
-LL | |
-LL | |
-LL | |
-LL | | };
-   | |__^
-
 error[E0080]: could not evaluate static initializer
   --> $DIR/inline_asm.rs:10:14
    |
@@ -16,6 +5,15 @@ LL |     unsafe { llvm_asm!("xor %eax, %eax" ::: "eax"); }
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ inline assembly is not supported
    |
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+warning: skipping const checks
+   |
+help: skipping check that does not even have a feature gate
+  --> $DIR/inline_asm.rs:10:14
+   |
+LL |     unsafe { llvm_asm!("xor %eax, %eax" ::: "eax"); }
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui/consts/miri_unleashed/mutable_const.rs
+++ b/src/test/ui/consts/miri_unleashed/mutable_const.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zunleash-the-miri-inside-of-you
+// compile-flags: -Zunleash-the-miri-inside-of-you -Zdeduplicate-diagnostics
 // normalize-stderr-test "alloc[0-9]+" -> "allocN"
 
 #![deny(const_err)] // The `allow` variant is tested by `mutable_const2`.
@@ -14,12 +14,11 @@ const MUTABLE_BEHIND_RAW: *mut i32 = &UnsafeCell::new(42) as *const _ as *mut _;
 //~^ WARN: skipping const checks
 
 const MUTATING_BEHIND_RAW: () = { //~ NOTE
+//~^ WARN skipping const checks
     // Test that `MUTABLE_BEHIND_RAW` is actually immutable, by doing this at const time.
     unsafe {
         *MUTABLE_BEHIND_RAW = 99 //~ ERROR any use of this value will cause an error
         //~^ NOTE: which is read-only
-        //~| WARN skipping const checks
-        //~| WARN skipping const checks
         // FIXME would be good to match more of the error message here, but looks like we
         // normalize *after* checking the annoations here.
     }

--- a/src/test/ui/consts/miri_unleashed/mutable_const.rs
+++ b/src/test/ui/consts/miri_unleashed/mutable_const.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zunleash-the-miri-inside-of-you -Zdeduplicate-diagnostics
+// compile-flags: -Zunleash-the-miri-inside-of-you
 // normalize-stderr-test "alloc[0-9]+" -> "allocN"
 
 #![deny(const_err)] // The `allow` variant is tested by `mutable_const2`.

--- a/src/test/ui/consts/miri_unleashed/mutable_const.rs
+++ b/src/test/ui/consts/miri_unleashed/mutable_const.rs
@@ -1,8 +1,6 @@
 // compile-flags: -Zunleash-the-miri-inside-of-you
 // normalize-stderr-test "alloc[0-9]+" -> "allocN"
 
-#![feature(const_raw_ptr_deref)]
-#![feature(const_mut_refs)]
 #![deny(const_err)] // The `allow` variant is tested by `mutable_const2`.
 //~^ NOTE lint level
 // Here we check that even though `MUTABLE_BEHIND_RAW` is created from a mutable
@@ -20,6 +18,8 @@ const MUTATING_BEHIND_RAW: () = { //~ NOTE
     unsafe {
         *MUTABLE_BEHIND_RAW = 99 //~ ERROR any use of this value will cause an error
         //~^ NOTE: which is read-only
+        //~| WARN skipping const checks
+        //~| WARN skipping const checks
         // FIXME would be good to match more of the error message here, but looks like we
         // normalize *after* checking the annoations here.
     }

--- a/src/test/ui/consts/miri_unleashed/mutable_const.rs
+++ b/src/test/ui/consts/miri_unleashed/mutable_const.rs
@@ -11,10 +11,8 @@ use std::cell::UnsafeCell;
 
 // make sure we do not just intern this as mutable
 const MUTABLE_BEHIND_RAW: *mut i32 = &UnsafeCell::new(42) as *const _ as *mut _;
-//~^ WARN: skipping const checks
 
 const MUTATING_BEHIND_RAW: () = { //~ NOTE
-//~^ WARN skipping const checks
     // Test that `MUTABLE_BEHIND_RAW` is actually immutable, by doing this at const time.
     unsafe {
         *MUTABLE_BEHIND_RAW = 99 //~ ERROR any use of this value will cause an error

--- a/src/test/ui/consts/miri_unleashed/mutable_const.stderr
+++ b/src/test/ui/consts/miri_unleashed/mutable_const.stderr
@@ -1,11 +1,23 @@
 warning: skipping const checks
-  --> $DIR/mutable_const.rs:15:38
+  --> $DIR/mutable_const.rs:13:38
    |
 LL | const MUTABLE_BEHIND_RAW: *mut i32 = &UnsafeCell::new(42) as *const _ as *mut _;
    |                                      ^^^^^^^^^^^^^^^^^^^^
 
+warning: skipping const checks
+  --> $DIR/mutable_const.rs:19:9
+   |
+LL |         *MUTABLE_BEHIND_RAW = 99
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: skipping const checks
+  --> $DIR/mutable_const.rs:19:9
+   |
+LL |         *MUTABLE_BEHIND_RAW = 99
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^
+
 error: any use of this value will cause an error
-  --> $DIR/mutable_const.rs:21:9
+  --> $DIR/mutable_const.rs:19:9
    |
 LL | / const MUTATING_BEHIND_RAW: () = {
 LL | |     // Test that `MUTABLE_BEHIND_RAW` is actually immutable, by doing this at const time.
@@ -18,10 +30,10 @@ LL | | };
    | |__-
    |
 note: the lint level is defined here
-  --> $DIR/mutable_const.rs:6:9
+  --> $DIR/mutable_const.rs:4:9
    |
 LL | #![deny(const_err)] // The `allow` variant is tested by `mutable_const2`.
    |         ^^^^^^^^^
 
-error: aborting due to previous error; 1 warning emitted
+error: aborting due to previous error; 3 warnings emitted
 

--- a/src/test/ui/consts/miri_unleashed/mutable_const.stderr
+++ b/src/test/ui/consts/miri_unleashed/mutable_const.stderr
@@ -1,25 +1,26 @@
 warning: skipping const checks
-  --> $DIR/mutable_const.rs:13:38
+  --> $DIR/mutable_const.rs:13:1
    |
 LL | const MUTABLE_BEHIND_RAW: *mut i32 = &UnsafeCell::new(42) as *const _ as *mut _;
-   |                                      ^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: skipping const checks
-  --> $DIR/mutable_const.rs:19:9
-   |
-LL |         *MUTABLE_BEHIND_RAW = 99
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^
-
-warning: skipping const checks
-  --> $DIR/mutable_const.rs:19:9
-   |
-LL |         *MUTABLE_BEHIND_RAW = 99
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: any use of this value will cause an error
-  --> $DIR/mutable_const.rs:19:9
+  --> $DIR/mutable_const.rs:16:1
    |
 LL | / const MUTATING_BEHIND_RAW: () = {
+LL | |
+LL | |     // Test that `MUTABLE_BEHIND_RAW` is actually immutable, by doing this at const time.
+LL | |     unsafe {
+...  |
+LL | |     }
+LL | | };
+   | |__^
+
+error: any use of this value will cause an error
+  --> $DIR/mutable_const.rs:20:9
+   |
+LL | / const MUTATING_BEHIND_RAW: () = {
+LL | |
 LL | |     // Test that `MUTABLE_BEHIND_RAW` is actually immutable, by doing this at const time.
 LL | |     unsafe {
 LL | |         *MUTABLE_BEHIND_RAW = 99
@@ -35,5 +36,5 @@ note: the lint level is defined here
 LL | #![deny(const_err)] // The `allow` variant is tested by `mutable_const2`.
    |         ^^^^^^^^^
 
-error: aborting due to previous error; 3 warnings emitted
+error: aborting due to previous error; 2 warnings emitted
 

--- a/src/test/ui/consts/miri_unleashed/mutable_const.stderr
+++ b/src/test/ui/consts/miri_unleashed/mutable_const.stderr
@@ -1,26 +1,7 @@
-warning: skipping const checks
-  --> $DIR/mutable_const.rs:13:1
-   |
-LL | const MUTABLE_BEHIND_RAW: *mut i32 = &UnsafeCell::new(42) as *const _ as *mut _;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-warning: skipping const checks
-  --> $DIR/mutable_const.rs:16:1
-   |
-LL | / const MUTATING_BEHIND_RAW: () = {
-LL | |
-LL | |     // Test that `MUTABLE_BEHIND_RAW` is actually immutable, by doing this at const time.
-LL | |     unsafe {
-...  |
-LL | |     }
-LL | | };
-   | |__^
-
 error: any use of this value will cause an error
-  --> $DIR/mutable_const.rs:20:9
+  --> $DIR/mutable_const.rs:18:9
    |
 LL | / const MUTATING_BEHIND_RAW: () = {
-LL | |
 LL | |     // Test that `MUTABLE_BEHIND_RAW` is actually immutable, by doing this at const time.
 LL | |     unsafe {
 LL | |         *MUTABLE_BEHIND_RAW = 99
@@ -36,5 +17,23 @@ note: the lint level is defined here
 LL | #![deny(const_err)] // The `allow` variant is tested by `mutable_const2`.
    |         ^^^^^^^^^
 
-error: aborting due to previous error; 2 warnings emitted
+warning: skipping const checks
+   |
+help: skipping check that does not even have a feature gate
+  --> $DIR/mutable_const.rs:13:38
+   |
+LL | const MUTABLE_BEHIND_RAW: *mut i32 = &UnsafeCell::new(42) as *const _ as *mut _;
+   |                                      ^^^^^^^^^^^^^^^^^^^^
+help: skipping check for `const_raw_ptr_deref` feature
+  --> $DIR/mutable_const.rs:18:9
+   |
+LL |         *MUTABLE_BEHIND_RAW = 99
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^
+help: skipping check for `const_mut_refs` feature
+  --> $DIR/mutable_const.rs:18:9
+   |
+LL |         *MUTABLE_BEHIND_RAW = 99
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui/consts/miri_unleashed/mutable_const2.rs
+++ b/src/test/ui/consts/miri_unleashed/mutable_const2.rs
@@ -11,7 +11,6 @@ use std::cell::UnsafeCell;
 
 // make sure we do not just intern this as mutable
 const MUTABLE_BEHIND_RAW: *mut i32 = &UnsafeCell::new(42) as *const _ as *mut _;
-//~^ WARN: skipping const checks
-//~| ERROR: mutable allocation in constant
+//~^ ERROR: mutable allocation in constant
 
 fn main() {}

--- a/src/test/ui/consts/miri_unleashed/mutable_const2.rs
+++ b/src/test/ui/consts/miri_unleashed/mutable_const2.rs
@@ -5,8 +5,6 @@
 // normalize-stderr-test "note: compiler flags: .*" -> "note: compiler flags: FLAGS"
 // normalize-stderr-test "interpret/intern.rs:[0-9]+:[0-9]+" -> "interpret/intern.rs:LL:CC"
 
-#![feature(const_raw_ptr_deref)]
-#![feature(const_mut_refs)]
 #![allow(const_err)]
 
 use std::cell::UnsafeCell;

--- a/src/test/ui/consts/miri_unleashed/mutable_const2.stderr
+++ b/src/test/ui/consts/miri_unleashed/mutable_const2.stderr
@@ -1,8 +1,10 @@
 warning: skipping const checks
-  --> $DIR/mutable_const2.rs:13:1
+   |
+help: skipping check that does not even have a feature gate
+  --> $DIR/mutable_const2.rs:13:38
    |
 LL | const MUTABLE_BEHIND_RAW: *mut i32 = &UnsafeCell::new(42) as *const _ as *mut _;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                      ^^^^^^^^^^^^^^^^^^^^
 
 warning: 1 warning emitted
 

--- a/src/test/ui/consts/miri_unleashed/mutable_const2.stderr
+++ b/src/test/ui/consts/miri_unleashed/mutable_const2.stderr
@@ -1,8 +1,8 @@
 warning: skipping const checks
-  --> $DIR/mutable_const2.rs:13:38
+  --> $DIR/mutable_const2.rs:13:1
    |
 LL | const MUTABLE_BEHIND_RAW: *mut i32 = &UnsafeCell::new(42) as *const _ as *mut _;
-   |                                      ^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: 1 warning emitted
 

--- a/src/test/ui/consts/miri_unleashed/mutable_const2.stderr
+++ b/src/test/ui/consts/miri_unleashed/mutable_const2.stderr
@@ -1,5 +1,5 @@
 warning: skipping const checks
-  --> $DIR/mutable_const2.rs:15:38
+  --> $DIR/mutable_const2.rs:13:38
    |
 LL | const MUTABLE_BEHIND_RAW: *mut i32 = &UnsafeCell::new(42) as *const _ as *mut _;
    |                                      ^^^^^^^^^^^^^^^^^^^^
@@ -7,7 +7,7 @@ LL | const MUTABLE_BEHIND_RAW: *mut i32 = &UnsafeCell::new(42) as *const _ as *m
 warning: 1 warning emitted
 
 error: internal compiler error: mutable allocation in constant
-  --> $DIR/mutable_const2.rs:15:1
+  --> $DIR/mutable_const2.rs:13:1
    |
 LL | const MUTABLE_BEHIND_RAW: *mut i32 = &UnsafeCell::new(42) as *const _ as *mut _;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/consts/miri_unleashed/mutable_references.rs
+++ b/src/test/ui/consts/miri_unleashed/mutable_references.rs
@@ -26,9 +26,8 @@ struct Meh {
 
 unsafe impl Sync for Meh {}
 
-static MEH: Meh = Meh {
+static MEH: Meh = Meh { //~ WARN skipping const checks
     x: &UnsafeCell::new(42),
-    //~^ WARN: skipping const checks
 };
 
 // this is fine for the same reason as `BAR`.

--- a/src/test/ui/consts/miri_unleashed/mutable_references.rs
+++ b/src/test/ui/consts/miri_unleashed/mutable_references.rs
@@ -1,5 +1,4 @@
 // compile-flags: -Zunleash-the-miri-inside-of-you
-#![feature(const_mut_refs)]
 #![allow(const_err)]
 
 use std::cell::UnsafeCell;
@@ -8,15 +7,18 @@ use std::cell::UnsafeCell;
 
 // this is fine because is not possible to mutate through an immutable reference.
 static FOO: &&mut u32 = &&mut 42;
+//~^ WARN skipping const checks
 
 // this is fine because accessing an immutable static `BAR` is equivalent to accessing `*&BAR`
 // which puts the mutable reference behind an immutable one.
 static BAR: &mut () = &mut ();
+//~^ WARN skipping const checks
 
 struct Foo<T>(T);
 
 // this is fine for the same reason as `BAR`.
 static BOO: &mut Foo<()> = &mut Foo(());
+//~^ WARN skipping const checks
 
 struct Meh {
     x: &'static UnsafeCell<i32>,
@@ -31,6 +33,7 @@ static MEH: Meh = Meh {
 
 // this is fine for the same reason as `BAR`.
 static OH_YES: &mut i32 = &mut 42;
+//~^ WARN skipping const checks
 
 fn main() {
     unsafe {

--- a/src/test/ui/consts/miri_unleashed/mutable_references.rs
+++ b/src/test/ui/consts/miri_unleashed/mutable_references.rs
@@ -7,18 +7,15 @@ use std::cell::UnsafeCell;
 
 // this is fine because is not possible to mutate through an immutable reference.
 static FOO: &&mut u32 = &&mut 42;
-//~^ WARN skipping const checks
 
 // this is fine because accessing an immutable static `BAR` is equivalent to accessing `*&BAR`
 // which puts the mutable reference behind an immutable one.
 static BAR: &mut () = &mut ();
-//~^ WARN skipping const checks
 
 struct Foo<T>(T);
 
 // this is fine for the same reason as `BAR`.
 static BOO: &mut Foo<()> = &mut Foo(());
-//~^ WARN skipping const checks
 
 struct Meh {
     x: &'static UnsafeCell<i32>,
@@ -26,13 +23,12 @@ struct Meh {
 
 unsafe impl Sync for Meh {}
 
-static MEH: Meh = Meh { //~ WARN skipping const checks
+static MEH: Meh = Meh {
     x: &UnsafeCell::new(42),
 };
 
 // this is fine for the same reason as `BAR`.
 static OH_YES: &mut i32 = &mut 42;
-//~^ WARN skipping const checks
 
 fn main() {
     unsafe {

--- a/src/test/ui/consts/miri_unleashed/mutable_references.stderr
+++ b/src/test/ui/consts/miri_unleashed/mutable_references.stderr
@@ -1,15 +1,39 @@
 warning: skipping const checks
-  --> $DIR/mutable_references.rs:28:8
+  --> $DIR/mutable_references.rs:9:26
+   |
+LL | static FOO: &&mut u32 = &&mut 42;
+   |                          ^^^^^^^
+
+warning: skipping const checks
+  --> $DIR/mutable_references.rs:14:23
+   |
+LL | static BAR: &mut () = &mut ();
+   |                       ^^^^^^^
+
+warning: skipping const checks
+  --> $DIR/mutable_references.rs:20:28
+   |
+LL | static BOO: &mut Foo<()> = &mut Foo(());
+   |                            ^^^^^^^^^^^^
+
+warning: skipping const checks
+  --> $DIR/mutable_references.rs:30:8
    |
 LL |     x: &UnsafeCell::new(42),
    |        ^^^^^^^^^^^^^^^^^^^^
 
+warning: skipping const checks
+  --> $DIR/mutable_references.rs:35:27
+   |
+LL | static OH_YES: &mut i32 = &mut 42;
+   |                           ^^^^^^^
+
 error[E0594]: cannot assign to `*OH_YES`, as `OH_YES` is an immutable static item
-  --> $DIR/mutable_references.rs:39:5
+  --> $DIR/mutable_references.rs:42:5
    |
 LL |     *OH_YES = 99;
    |     ^^^^^^^^^^^^ cannot assign
 
-error: aborting due to previous error; 1 warning emitted
+error: aborting due to previous error; 5 warnings emitted
 
 For more information about this error, try `rustc --explain E0594`.

--- a/src/test/ui/consts/miri_unleashed/mutable_references.stderr
+++ b/src/test/ui/consts/miri_unleashed/mutable_references.stderr
@@ -1,41 +1,37 @@
-warning: skipping const checks
-  --> $DIR/mutable_references.rs:9:1
-   |
-LL | static FOO: &&mut u32 = &&mut 42;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-warning: skipping const checks
-  --> $DIR/mutable_references.rs:14:1
-   |
-LL | static BAR: &mut () = &mut ();
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-warning: skipping const checks
-  --> $DIR/mutable_references.rs:20:1
-   |
-LL | static BOO: &mut Foo<()> = &mut Foo(());
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-warning: skipping const checks
-  --> $DIR/mutable_references.rs:29:1
-   |
-LL | / static MEH: Meh = Meh {
-LL | |     x: &UnsafeCell::new(42),
-LL | | };
-   | |__^
-
-warning: skipping const checks
-  --> $DIR/mutable_references.rs:34:1
-   |
-LL | static OH_YES: &mut i32 = &mut 42;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
 error[E0594]: cannot assign to `*OH_YES`, as `OH_YES` is an immutable static item
-  --> $DIR/mutable_references.rs:41:5
+  --> $DIR/mutable_references.rs:37:5
    |
 LL |     *OH_YES = 99;
    |     ^^^^^^^^^^^^ cannot assign
 
-error: aborting due to previous error; 5 warnings emitted
+warning: skipping const checks
+   |
+help: skipping check for `const_mut_refs` feature
+  --> $DIR/mutable_references.rs:9:26
+   |
+LL | static FOO: &&mut u32 = &&mut 42;
+   |                          ^^^^^^^
+help: skipping check for `const_mut_refs` feature
+  --> $DIR/mutable_references.rs:13:23
+   |
+LL | static BAR: &mut () = &mut ();
+   |                       ^^^^^^^
+help: skipping check for `const_mut_refs` feature
+  --> $DIR/mutable_references.rs:18:28
+   |
+LL | static BOO: &mut Foo<()> = &mut Foo(());
+   |                            ^^^^^^^^^^^^
+help: skipping check that does not even have a feature gate
+  --> $DIR/mutable_references.rs:27:8
+   |
+LL |     x: &UnsafeCell::new(42),
+   |        ^^^^^^^^^^^^^^^^^^^^
+help: skipping check for `const_mut_refs` feature
+  --> $DIR/mutable_references.rs:31:27
+   |
+LL | static OH_YES: &mut i32 = &mut 42;
+   |                           ^^^^^^^
+
+error: aborting due to previous error; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0594`.

--- a/src/test/ui/consts/miri_unleashed/mutable_references.stderr
+++ b/src/test/ui/consts/miri_unleashed/mutable_references.stderr
@@ -1,35 +1,37 @@
 warning: skipping const checks
-  --> $DIR/mutable_references.rs:9:26
+  --> $DIR/mutable_references.rs:9:1
    |
 LL | static FOO: &&mut u32 = &&mut 42;
-   |                          ^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: skipping const checks
-  --> $DIR/mutable_references.rs:14:23
+  --> $DIR/mutable_references.rs:14:1
    |
 LL | static BAR: &mut () = &mut ();
-   |                       ^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: skipping const checks
-  --> $DIR/mutable_references.rs:20:28
+  --> $DIR/mutable_references.rs:20:1
    |
 LL | static BOO: &mut Foo<()> = &mut Foo(());
-   |                            ^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: skipping const checks
-  --> $DIR/mutable_references.rs:30:8
+  --> $DIR/mutable_references.rs:29:1
    |
-LL |     x: &UnsafeCell::new(42),
-   |        ^^^^^^^^^^^^^^^^^^^^
+LL | / static MEH: Meh = Meh {
+LL | |     x: &UnsafeCell::new(42),
+LL | | };
+   | |__^
 
 warning: skipping const checks
-  --> $DIR/mutable_references.rs:35:27
+  --> $DIR/mutable_references.rs:34:1
    |
 LL | static OH_YES: &mut i32 = &mut 42;
-   |                           ^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0594]: cannot assign to `*OH_YES`, as `OH_YES` is an immutable static item
-  --> $DIR/mutable_references.rs:42:5
+  --> $DIR/mutable_references.rs:41:5
    |
 LL |     *OH_YES = 99;
    |     ^^^^^^^^^^^^ cannot assign

--- a/src/test/ui/consts/miri_unleashed/mutable_references_ice.rs
+++ b/src/test/ui/consts/miri_unleashed/mutable_references_ice.rs
@@ -18,7 +18,7 @@ struct Meh {
 unsafe impl Sync for Meh {}
 
 // the following will never be ok!
-const MUH: Meh = Meh { //~ WARN skipping const checks
+const MUH: Meh = Meh {
     x: &UnsafeCell::new(42),
 };
 

--- a/src/test/ui/consts/miri_unleashed/mutable_references_ice.rs
+++ b/src/test/ui/consts/miri_unleashed/mutable_references_ice.rs
@@ -18,8 +18,8 @@ struct Meh {
 unsafe impl Sync for Meh {}
 
 // the following will never be ok!
-const MUH: Meh = Meh {
-    x: &UnsafeCell::new(42), //~ WARN: skipping const checks
+const MUH: Meh = Meh { //~ WARN skipping const checks
+    x: &UnsafeCell::new(42),
 };
 
 fn main() {

--- a/src/test/ui/consts/miri_unleashed/mutable_references_ice.stderr
+++ b/src/test/ui/consts/miri_unleashed/mutable_references_ice.stderr
@@ -1,8 +1,10 @@
 warning: skipping const checks
-  --> $DIR/mutable_references_ice.rs:22:8
+  --> $DIR/mutable_references_ice.rs:21:1
    |
-LL |     x: &UnsafeCell::new(42),
-   |        ^^^^^^^^^^^^^^^^^^^^
+LL | / const MUH: Meh = Meh {
+LL | |     x: &UnsafeCell::new(42),
+LL | | };
+   | |__^
 
 thread 'rustc' panicked at 'assertion failed: `(left != right)`
   left: `Const`,

--- a/src/test/ui/consts/miri_unleashed/mutable_references_ice.stderr
+++ b/src/test/ui/consts/miri_unleashed/mutable_references_ice.stderr
@@ -1,11 +1,3 @@
-warning: skipping const checks
-  --> $DIR/mutable_references_ice.rs:21:1
-   |
-LL | / const MUH: Meh = Meh {
-LL | |     x: &UnsafeCell::new(42),
-LL | | };
-   | |__^
-
 thread 'rustc' panicked at 'assertion failed: `(left != right)`
   left: `Const`,
  right: `Const`: UnsafeCells are not allowed behind references in constants. This should have been prevented statically by const qualification. If this were allowed one would be able to change a constant at one use site and other use sites could observe that mutation.', src/librustc_mir/interpret/intern.rs:LL:CC
@@ -20,6 +12,14 @@ note: we would appreciate a bug report: https://github.com/rust-lang/rust/blob/m
 note: rustc VERSION running on TARGET
 
 note: compiler flags: FLAGS
+
+warning: skipping const checks
+   |
+help: skipping check that does not even have a feature gate
+  --> $DIR/mutable_references_ice.rs:22:8
+   |
+LL |     x: &UnsafeCell::new(42),
+   |        ^^^^^^^^^^^^^^^^^^^^
 
 warning: 1 warning emitted
 

--- a/src/test/ui/consts/miri_unleashed/non_const_fn.rs
+++ b/src/test/ui/consts/miri_unleashed/non_const_fn.rs
@@ -6,7 +6,7 @@
 
 fn foo() {}
 
-static C: () = foo(); //~ WARN: skipping const checks
+static C: () = foo();
 //~^ ERROR could not evaluate static initializer
 //~| NOTE calling non-const function `foo`
 

--- a/src/test/ui/consts/miri_unleashed/non_const_fn.stderr
+++ b/src/test/ui/consts/miri_unleashed/non_const_fn.stderr
@@ -1,14 +1,16 @@
-warning: skipping const checks
-  --> $DIR/non_const_fn.rs:9:1
-   |
-LL | static C: () = foo();
-   | ^^^^^^^^^^^^^^^^^^^^^
-
 error[E0080]: could not evaluate static initializer
   --> $DIR/non_const_fn.rs:9:16
    |
 LL | static C: () = foo();
    |                ^^^^^ calling non-const function `foo`
+
+warning: skipping const checks
+   |
+help: skipping check that does not even have a feature gate
+  --> $DIR/non_const_fn.rs:9:16
+   |
+LL | static C: () = foo();
+   |                ^^^^^
 
 error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui/consts/miri_unleashed/non_const_fn.stderr
+++ b/src/test/ui/consts/miri_unleashed/non_const_fn.stderr
@@ -1,8 +1,8 @@
 warning: skipping const checks
-  --> $DIR/non_const_fn.rs:9:16
+  --> $DIR/non_const_fn.rs:9:1
    |
 LL | static C: () = foo();
-   |                ^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^
 
 error[E0080]: could not evaluate static initializer
   --> $DIR/non_const_fn.rs:9:16

--- a/src/test/ui/consts/miri_unleashed/read_from_static.rs
+++ b/src/test/ui/consts/miri_unleashed/read_from_static.rs
@@ -1,9 +1,9 @@
 // run-pass
 // compile-flags: -Zunleash-the-miri-inside-of-you
-#![feature(const_mut_refs)]
 #![allow(const_err)]
 
 static OH_YES: &mut i32 = &mut 42;
+//~^ WARN skipping const checks
 
 fn main() {
     // Make sure `OH_YES` can be read.

--- a/src/test/ui/consts/miri_unleashed/read_from_static.stderr
+++ b/src/test/ui/consts/miri_unleashed/read_from_static.stderr
@@ -1,0 +1,8 @@
+warning: skipping const checks
+  --> $DIR/read_from_static.rs:5:27
+   |
+LL | static OH_YES: &mut i32 = &mut 42;
+   |                           ^^^^^^^
+
+warning: 1 warning emitted
+

--- a/src/test/ui/consts/miri_unleashed/read_from_static.stderr
+++ b/src/test/ui/consts/miri_unleashed/read_from_static.stderr
@@ -1,8 +1,8 @@
 warning: skipping const checks
-  --> $DIR/read_from_static.rs:5:27
+  --> $DIR/read_from_static.rs:5:1
    |
 LL | static OH_YES: &mut i32 = &mut 42;
-   |                           ^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: 1 warning emitted
 

--- a/src/test/ui/consts/miri_unleashed/read_from_static.stderr
+++ b/src/test/ui/consts/miri_unleashed/read_from_static.stderr
@@ -1,8 +1,0 @@
-warning: skipping const checks
-  --> $DIR/read_from_static.rs:5:1
-   |
-LL | static OH_YES: &mut i32 = &mut 42;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-warning: 1 warning emitted
-

--- a/src/test/ui/consts/read_from_static_mut_ref.rs
+++ b/src/test/ui/consts/read_from_static_mut_ref.rs
@@ -1,9 +1,8 @@
 // run-pass
-// compile-flags: -Zunleash-the-miri-inside-of-you
+#![feature(const_mut_refs)]
 #![allow(const_err)]
 
 static OH_YES: &mut i32 = &mut 42;
-//~^ WARN skipping const checks
 
 fn main() {
     // Make sure `OH_YES` can be read.

--- a/src/test/ui/rfc-2091-track-caller/caller-location-fnptr-rt-ctfe-equiv.rs
+++ b/src/test/ui/rfc-2091-track-caller/caller-location-fnptr-rt-ctfe-equiv.rs
@@ -15,10 +15,10 @@ const fn attributed() -> L {
     std::intrinsics::caller_location()
 }
 
-const fn calling_attributed() -> L {
+const fn calling_attributed() -> L { //~ WARN skipping const checks
     // We need `-Z unleash-the-miri-inside-of-you` for this as we don't have `const fn` pointers.
     let ptr: fn() -> L = attributed;
-    ptr() //~ WARN skipping const checks
+    ptr()
 }
 
 fn main() {

--- a/src/test/ui/rfc-2091-track-caller/caller-location-fnptr-rt-ctfe-equiv.rs
+++ b/src/test/ui/rfc-2091-track-caller/caller-location-fnptr-rt-ctfe-equiv.rs
@@ -15,7 +15,7 @@ const fn attributed() -> L {
     std::intrinsics::caller_location()
 }
 
-const fn calling_attributed() -> L { //~ WARN skipping const checks
+const fn calling_attributed() -> L {
     // We need `-Z unleash-the-miri-inside-of-you` for this as we don't have `const fn` pointers.
     let ptr: fn() -> L = attributed;
     ptr()

--- a/src/test/ui/rfc-2091-track-caller/caller-location-fnptr-rt-ctfe-equiv.stderr
+++ b/src/test/ui/rfc-2091-track-caller/caller-location-fnptr-rt-ctfe-equiv.stderr
@@ -1,8 +1,12 @@
 warning: skipping const checks
-  --> $DIR/caller-location-fnptr-rt-ctfe-equiv.rs:21:5
+  --> $DIR/caller-location-fnptr-rt-ctfe-equiv.rs:18:1
    |
-LL |     ptr()
-   |     ^^^^^
+LL | / const fn calling_attributed() -> L {
+LL | |     // We need `-Z unleash-the-miri-inside-of-you` for this as we don't have `const fn` pointers.
+LL | |     let ptr: fn() -> L = attributed;
+LL | |     ptr()
+LL | | }
+   | |_^
 
 warning: 1 warning emitted
 

--- a/src/test/ui/rfc-2091-track-caller/caller-location-fnptr-rt-ctfe-equiv.stderr
+++ b/src/test/ui/rfc-2091-track-caller/caller-location-fnptr-rt-ctfe-equiv.stderr
@@ -1,12 +1,10 @@
 warning: skipping const checks
-  --> $DIR/caller-location-fnptr-rt-ctfe-equiv.rs:18:1
    |
-LL | / const fn calling_attributed() -> L {
-LL | |     // We need `-Z unleash-the-miri-inside-of-you` for this as we don't have `const fn` pointers.
-LL | |     let ptr: fn() -> L = attributed;
-LL | |     ptr()
-LL | | }
-   | |_^
+help: skipping check that does not even have a feature gate
+  --> $DIR/caller-location-fnptr-rt-ctfe-equiv.rs:21:5
+   |
+LL |     ptr()
+   |     ^^^^^
 
 warning: 1 warning emitted
 


### PR DESCRIPTION
IMO it is silly to unleash features that do not even have a feature gate yet, but not unleash features that do. The only thing this achieves is making unleashed mode annoying to use as we have to figure out the feature flags to enable (and not always do the error messages say what that flag is).

Given that the point of `-Z unleash-the-miri-inside-of-you` is to debug the Miri internals, I see no good reason for this extra hurdle. I cannot imagine a situation where we'd use that flag, realize the program also requires some feature gate, and then be like "oh I guess if this feature is unstable I will do something else". Instead, we'll always just add that flag to the code as well, so requiring the flag achieves nothing.

r? @oli-obk @ecstatic-morse 
Fixes https://github.com/rust-lang/rust/issues/71630