### PR TITLE
Impl Error for Infallible

### DIFF
--- a/src/libstd/error.rs
+++ b/src/libstd/error.rs
@@ -14,6 +14,7 @@
 // reconsider what crate these items belong in.
 
 use core::array;
+use core::convert::Infallible;
 
 use crate::alloc::{AllocErr, LayoutErr};
 use crate::any::TypeId;
@@ -474,7 +475,7 @@ impl Error for string::FromUtf16Error {
 }
 
 #[stable(feature = "str_parse_error2", since = "1.8.0")]
-impl Error for string::ParseError {
+impl Error for Infallible {
     fn description(&self) -> &str {
         match *self {}
     }


### PR DESCRIPTION
This PR only changes the place where `impl Error for Infallible` is documented, as one could think that it is not the case when reading https://doc.rust-lang.org/nightly/std/convert/enum.Infallible.html.

Fixes #70842