### PR TITLE
Revert #71372 ("Fix #! (shebang) stripping account space issue").

### DIFF
--- a/src/librustc_lexer/src/lib.rs
+++ b/src/librustc_lexer/src/lib.rs
@@ -236,15 +236,10 @@ pub enum Base {
 /// (e.g. "#![deny(missing_docs)]").
 pub fn strip_shebang(input: &str) -> Option<usize> {
     debug_assert!(!input.is_empty());
-    let s: &str = &remove_whitespace(input);
-    if !s.starts_with("#!") || s.starts_with("#![") {
+    if !input.starts_with("#!") || input.starts_with("#![") {
         return None;
     }
     Some(input.find('\n').unwrap_or(input.len()))
-}
-
-fn remove_whitespace(s: &str) -> String {
-    s.chars().filter(|c| !c.is_whitespace()).collect()
 }
 
 /// Parses the first token from the provided input string.

--- a/src/librustc_lexer/src/tests.rs
+++ b/src/librustc_lexer/src/tests.rs
@@ -145,22 +145,4 @@ mod tests {
             }),
         );
     }
-
-    #[test]
-    fn test_valid_shebang() {
-        // https://github.com/rust-lang/rust/issues/70528
-        let input = "#!/usr/bin/rustrun";
-        let actual = strip_shebang(input);
-        let expected: Option<usize> = Some(18);
-        assert_eq!(expected, actual);
-    }
-
-    #[test]
-    fn test_invalid_shebang_valid_rust_syntax() {
-        // https://github.com/rust-lang/rust/issues/70528
-        let input = "#!    [bad_attribute]";
-        let actual = strip_shebang(input);
-        let expected: Option<usize> = None;
-        assert_eq!(expected, actual);
-    }
 }


### PR DESCRIPTION
While #71372 fixed some of the problems `#!`-stripping had, it introduced others:
* inefficient implementation (`.chars().filter(...).collect()` on the entire input file)
  * this also means the length returned isn't always correct, leading to e.g. #71471
* it ignores whitespace anywhere, stripping ` # ! ...` which isn't a valid shebang
  * the definition of "whitespace" it uses includes newlines, which means even `\n#\n!\n...` is stripped as a shebang (and anything matching the regex `\s*#\s*!\s*`, and not followed by `[`, really)
* it's backward-incompatible but didn't go through Crater

Now, #71487 is already open and will solve all of these issues. But for running Crater, and just in case #71487 takes a bit longer, I decided it's safer to just revert #71372.

This will also make #71372's diff clearer, as it will start again from the original whitespace-unaware version.

r? @petrochenkov 