### PR TITLE
Update cargo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,7 +292,7 @@ dependencies = [
 
 [[package]]
 name = "cargo"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "anyhow",
  "atty",
@@ -1251,9 +1251,9 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.13.2"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cfb93ca10f2934069c3aaafb753fbe0663f08ee009a01b6d62e062391447b15"
+checksum = "e1e02a51cd90229028c9bd8be0a0364f85b6b3199cccaa0ef39005ddbd5ac165"
 dependencies = [
  "bitflags",
  "libc",
@@ -1795,9 +1795,9 @@ dependencies = [
 
 [[package]]
 name = "libgit2-sys"
-version = "0.12.3+1.0.0"
+version = "0.12.5+1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7637dc15e7f05a16011723e0448655081fc01a374bcd368e2c9b9c7f5c5ab3ea"
+checksum = "3eadeec65514971355bf7134967a543f71372f35b53ac6c7143e7bd157f07535"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
11 commits in 8751eb3010d4cdb5329b5a6bd2b6d765c95b0dca..90931d9b31e8b854522fed00916504a3ac6d8619
2020-04-21 18:04:35 +0000 to 2020-04-28 01:56:59 +0000
- Use associated constants directly on primitive types instead of modules (rust-lang/cargo#8077)
- Clear `RUSTDOCFLAGS` before running tests (rust-lang/cargo#8168)
- Fix warning for `resolve` mismatch in workspace. (rust-lang/cargo#8169)
- Fix flaky linking_interrupted test. (rust-lang/cargo#8162)
- Fixed some unnecessary borrows and clones. (rust-lang/cargo#8146)
- Added warning when using restricted names in Windows. (rust-lang/cargo#8136)
- Add changelog about dylib uplift. (rust-lang/cargo#8161)
- Mention that cargo_metadata can parse json messages (rust-lang/cargo#8158)
- Re-enable rustc-info-cache test again (rust-lang/cargo#8155)
- Updates to path source walking. (rust-lang/cargo#8095)
- Bump to 0.46.0, update changelog (rust-lang/cargo#8153)