### PR TITLE
Ensure that `./x.py doc --stage 0 src/libstd` works via CI

### DIFF
--- a/src/ci/docker/mingw-check/Dockerfile
+++ b/src/ci/docker/mingw-check/Dockerfile
@@ -27,4 +27,5 @@ ENV SCRIPT python3 ../x.py test src/tools/expand-yaml-anchors && \
            python3 ../x.py build --stage 0 src/tools/build-manifest && \
            python3 ../x.py test --stage 0 src/tools/compiletest && \
            python3 ../x.py test src/tools/tidy && \
+           python3 ../x.py doc --stage 0 src/libstd && \
            /scripts/validate-toolstate.sh


### PR DESCRIPTION
This was split off from #71645, which recommends that users first try building `libstd` docs with the bootstrap `rustdoc`. This should work in most cases, but will fail if we start using a very recent `rustdoc` feature outside a `#[cfg(not(bootstrap))]`.

It would be very nice to guarantee that `./x.py doc --stage 0 src/libstd` works, since it allows documentation changes to be rendered locally without needing to build the compiler. However, it may put too big a burden on `rustdoc` developers who presumably want to dogfood new features.