### PR TITLE
Miri: better document and fix dynamic const pattern soundness checks

### DIFF
--- a/src/librustc_mir/const_eval/eval_queries.rs
+++ b/src/librustc_mir/const_eval/eval_queries.rs
@@ -193,7 +193,7 @@ fn validate_and_turn_into_const<'tcx>(
                     mplace.into(),
                     path,
                     &mut ref_tracking,
-                    /*may_ref_to_static*/ is_static,
+                    /*may_ref_to_static*/ ecx.memory.extra.can_access_statics,
                 )?;
             }
         }

--- a/src/librustc_mir/const_eval/machine.rs
+++ b/src/librustc_mir/const_eval/machine.rs
@@ -99,7 +99,12 @@ pub struct CompileTimeInterpreter<'mir, 'tcx> {
 
 #[derive(Copy, Clone, Debug)]
 pub struct MemoryExtra {
-    /// Whether this machine may read from statics
+    /// We need to make sure consts never point to anything mutable, even recursively. That is
+    /// relied on for pattern matching on consts with references.
+    /// To achieve this, two pieces have to work together:
+    /// * Interning makes everything outside of statics immutable.
+    /// * Pointers to allocations inside of statics can never leak outside, to a non-static global.
+    /// This boolean here controls the second part.
     pub(super) can_access_statics: bool,
 }
 
@@ -337,6 +342,8 @@ impl<'mir, 'tcx> interpret::Machine<'mir, 'tcx> for CompileTimeInterpreter<'mir,
             } else if static_def_id.is_some() {
                 // Machine configuration does not allow us to read statics
                 // (e.g., `const` initializer).
+                // See const_eval::machine::MemoryExtra::can_access_statics for why
+                // this check is so important.
                 Err(ConstEvalErrKind::ConstAccessesStatic.into())
             } else {
                 // Immutable global, this read is fine.

--- a/src/librustc_mir/const_eval/machine.rs
+++ b/src/librustc_mir/const_eval/machine.rs
@@ -343,7 +343,9 @@ impl<'mir, 'tcx> interpret::Machine<'mir, 'tcx> for CompileTimeInterpreter<'mir,
                 // Machine configuration does not allow us to read statics
                 // (e.g., `const` initializer).
                 // See const_eval::machine::MemoryExtra::can_access_statics for why
-                // this check is so important.
+                // this check is so important: if we could read statics, we could read pointers
+                // to mutable allocations *inside* statics. These allocations are not themselves
+                // statics, so pointers to them can get around the check in `validity.rs`.
                 Err(ConstEvalErrKind::ConstAccessesStatic.into())
             } else {
                 // Immutable global, this read is fine.

--- a/src/librustc_mir/interpret/memory.rs
+++ b/src/librustc_mir/interpret/memory.rs
@@ -453,7 +453,9 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> Memory<'mir, 'tcx, M> {
                 // thing here: one maps to `GlobalAlloc::Static`, this is the "lazy" ID,
                 // and the other one is maps to `GlobalAlloc::Memory`, this is returned by
                 // `const_eval_raw` and it is the "resolved" ID.
-                // The resolved ID is never used by the interpreted progrma, it is hidden.
+                // The resolved ID is never used by the interpreted program, it is hidden.
+                // This is relied upon for soundness of const-patterns; a pointer to the resolved
+                // ID would "sidestep" the checks that make sure consts do not point to statics!
                 // The `GlobalAlloc::Memory` branch here is still reachable though; when a static
                 // contains a reference to memory that was created during its evaluation (i.e., not
                 // to another static), those inner references only exist in "resolved" form.

--- a/src/test/ui/consts/miri_unleashed/auxiliary/static_cross_crate.rs
+++ b/src/test/ui/consts/miri_unleashed/auxiliary/static_cross_crate.rs
@@ -1,0 +1,1 @@
+pub static mut ZERO: [u8; 1] = [0];

--- a/src/test/ui/consts/miri_unleashed/auxiliary/static_cross_crate.rs
+++ b/src/test/ui/consts/miri_unleashed/auxiliary/static_cross_crate.rs
@@ -1,1 +1,3 @@
 pub static mut ZERO: [u8; 1] = [0];
+pub static ZERO_REF: &[u8; 1] = unsafe { &ZERO };
+pub static mut OPT_ZERO: Option<u8> = Some(0);

--- a/src/test/ui/consts/miri_unleashed/const_refers_to_static.rs
+++ b/src/test/ui/consts/miri_unleashed/const_refers_to_static.rs
@@ -7,7 +7,8 @@
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 
-// These tests only cause an error when *using* the const.
+// These fail during CTFE (as they read a static), so they only cause an error
+// when *using* the const.
 
 const MUTATE_INTERIOR_MUT: usize = {
     static FOO: AtomicUsize = AtomicUsize::new(0);

--- a/src/test/ui/consts/miri_unleashed/const_refers_to_static.stderr
+++ b/src/test/ui/consts/miri_unleashed/const_refers_to_static.stderr
@@ -1,47 +1,47 @@
 warning: skipping const checks
-  --> $DIR/const_refers_to_static.rs:14:5
+  --> $DIR/const_refers_to_static.rs:15:5
    |
 LL |     FOO.fetch_add(1, Ordering::Relaxed)
    |     ^^^
 
 warning: skipping const checks
-  --> $DIR/const_refers_to_static.rs:14:5
+  --> $DIR/const_refers_to_static.rs:15:5
    |
 LL |     FOO.fetch_add(1, Ordering::Relaxed)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: skipping const checks
-  --> $DIR/const_refers_to_static.rs:21:17
+  --> $DIR/const_refers_to_static.rs:22:17
    |
 LL |     unsafe { *(&FOO as *const _ as *const usize) }
    |                 ^^^
 
 warning: skipping const checks
-  --> $DIR/const_refers_to_static.rs:26:32
+  --> $DIR/const_refers_to_static.rs:27:32
    |
 LL | const READ_MUT: u32 = unsafe { MUTABLE };
    |                                ^^^^^^^
 
 warning: skipping const checks
-  --> $DIR/const_refers_to_static.rs:26:32
+  --> $DIR/const_refers_to_static.rs:27:32
    |
 LL | const READ_MUT: u32 = unsafe { MUTABLE };
    |                                ^^^^^^^
 
 error[E0080]: erroneous constant used
-  --> $DIR/const_refers_to_static.rs:31:5
+  --> $DIR/const_refers_to_static.rs:32:5
    |
 LL |     MUTATE_INTERIOR_MUT;
    |     ^^^^^^^^^^^^^^^^^^^ referenced constant has errors
 
 error[E0080]: erroneous constant used
-  --> $DIR/const_refers_to_static.rs:33:5
+  --> $DIR/const_refers_to_static.rs:34:5
    |
 LL |     READ_INTERIOR_MUT;
    |     ^^^^^^^^^^^^^^^^^ referenced constant has errors
 
 error[E0080]: erroneous constant used
-  --> $DIR/const_refers_to_static.rs:35:5
+  --> $DIR/const_refers_to_static.rs:36:5
    |
 LL |     READ_MUT;
    |     ^^^^^^^^ referenced constant has errors

--- a/src/test/ui/consts/miri_unleashed/const_refers_to_static2.rs
+++ b/src/test/ui/consts/miri_unleashed/const_refers_to_static2.rs
@@ -6,9 +6,12 @@
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 
-// These tests cause immediate error when *defining* the const.
+// These only fail during validation (they do not use but just create a reference to a static),
+// so they cause an immediate error when *defining* the const.
 
 const REF_INTERIOR_MUT: &usize = { //~ ERROR undefined behavior to use this value
+//~| NOTE encountered a reference pointing to a static variable
+//~| NOTE
     static FOO: AtomicUsize = AtomicUsize::new(0);
     unsafe { &*(&FOO as *const _ as *const usize) }
     //~^ WARN skipping const checks
@@ -16,6 +19,8 @@ const REF_INTERIOR_MUT: &usize = { //~ ERROR undefined behavior to use this valu
 
 // ok some day perhaps
 const READ_IMMUT: &usize = { //~ ERROR it is undefined behavior to use this value
+//~| NOTE encountered a reference pointing to a static variable
+//~| NOTE
     static FOO: usize = 0;
     &FOO
     //~^ WARN skipping const checks

--- a/src/test/ui/consts/miri_unleashed/const_refers_to_static2.stderr
+++ b/src/test/ui/consts/miri_unleashed/const_refers_to_static2.stderr
@@ -1,19 +1,21 @@
 warning: skipping const checks
-  --> $DIR/const_refers_to_static2.rs:13:18
+  --> $DIR/const_refers_to_static2.rs:16:18
    |
 LL |     unsafe { &*(&FOO as *const _ as *const usize) }
    |                  ^^^
 
 warning: skipping const checks
-  --> $DIR/const_refers_to_static2.rs:20:6
+  --> $DIR/const_refers_to_static2.rs:25:6
    |
 LL |     &FOO
    |      ^^^
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/const_refers_to_static2.rs:11:1
+  --> $DIR/const_refers_to_static2.rs:12:1
    |
 LL | / const REF_INTERIOR_MUT: &usize = {
+LL | |
+LL | |
 LL | |     static FOO: AtomicUsize = AtomicUsize::new(0);
 LL | |     unsafe { &*(&FOO as *const _ as *const usize) }
 LL | |
@@ -23,9 +25,11 @@ LL | | };
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/const_refers_to_static2.rs:18:1
+  --> $DIR/const_refers_to_static2.rs:21:1
    |
 LL | / const READ_IMMUT: &usize = {
+LL | |
+LL | |
 LL | |     static FOO: usize = 0;
 LL | |     &FOO
 LL | |

--- a/src/test/ui/consts/miri_unleashed/const_refers_to_static_cross_crate.rs
+++ b/src/test/ui/consts/miri_unleashed/const_refers_to_static_cross_crate.rs
@@ -1,0 +1,35 @@
+// compile-flags: -Zunleash-the-miri-inside-of-you
+// aux-build:static_cross_crate.rs
+#![allow(const_err)]
+
+#![feature(exclusive_range_pattern)]
+#![feature(half_open_range_patterns)]
+
+extern crate static_cross_crate;
+
+// Sneaky: reference to a mutable static.
+// Allowing this would be a disaster for pattern matching, we could violate exhaustiveness checking!
+const SLICE_MUT: &[u8; 1] = { //~ ERROR undefined behavior to use this value
+//~| NOTE encountered a reference pointing to a static variable
+//~| NOTE
+    unsafe { &static_cross_crate::ZERO }
+    //~^ WARN skipping const checks
+    //~| WARN skipping const checks
+};
+
+pub fn test(x: &[u8; 1]) -> bool {
+    match x {
+        SLICE_MUT => true,
+        //~^ ERROR could not evaluate constant pattern
+        //~| ERROR could not evaluate constant pattern
+        &[1..] => false,
+    }
+}
+
+fn main() {
+    unsafe {
+        static_cross_crate::ZERO[0] = 1;
+    }
+    // Now the pattern is not exhaustive any more!
+    test(&[0]);
+}

--- a/src/test/ui/consts/miri_unleashed/const_refers_to_static_cross_crate.rs
+++ b/src/test/ui/consts/miri_unleashed/const_refers_to_static_cross_crate.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zunleash-the-miri-inside-of-you
+// compile-flags: -Zunleash-the-miri-inside-of-you -Zdeduplicate-diagnostics
 // aux-build:static_cross_crate.rs
 #![allow(const_err)]
 
@@ -14,15 +14,28 @@ const SLICE_MUT: &[u8; 1] = { //~ ERROR undefined behavior to use this value
 //~| NOTE
     unsafe { &static_cross_crate::ZERO }
     //~^ WARN skipping const checks
-    //~| WARN skipping const checks
+};
+
+const SLICE_MUT2: &u8 = { //~ ERROR undefined behavior to use this value
+//~| NOTE encountered a reference pointing to a static variable
+//~| NOTE
+    unsafe { &static_cross_crate::ZERO[0] }
+    //~^ WARN skipping const checks
 };
 
 pub fn test(x: &[u8; 1]) -> bool {
     match x {
         SLICE_MUT => true,
         //~^ ERROR could not evaluate constant pattern
-        //~| ERROR could not evaluate constant pattern
         &[1..] => false,
+    }
+}
+
+pub fn test2(x: &u8) -> bool {
+    match x {
+        SLICE_MUT2 => true,
+        //~^ ERROR could not evaluate constant pattern
+        &(1..) => false,
     }
 }
 

--- a/src/test/ui/consts/miri_unleashed/const_refers_to_static_cross_crate.stderr
+++ b/src/test/ui/consts/miri_unleashed/const_refers_to_static_cross_crate.stderr
@@ -1,11 +1,11 @@
 warning: skipping const checks
-  --> $DIR/const_refers_to_static_cross_crate.rs:15:15
+  --> $DIR/const_refers_to_static_cross_crate.rs:14:15
    |
 LL |     unsafe { &static_cross_crate::ZERO }
    |               ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/const_refers_to_static_cross_crate.rs:12:1
+  --> $DIR/const_refers_to_static_cross_crate.rs:11:1
    |
 LL | / const SLICE_MUT: &[u8; 1] = {
 LL | |
@@ -18,21 +18,21 @@ LL | | };
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error: could not evaluate constant pattern
-  --> $DIR/const_refers_to_static_cross_crate.rs:28:9
+  --> $DIR/const_refers_to_static_cross_crate.rs:43:9
    |
 LL |         SLICE_MUT => true,
    |         ^^^^^^^^^
 
 warning: skipping const checks
-  --> $DIR/const_refers_to_static_cross_crate.rs:22:15
+  --> $DIR/const_refers_to_static_cross_crate.rs:21:15
    |
 LL |     unsafe { &static_cross_crate::ZERO[0] }
    |               ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/const_refers_to_static_cross_crate.rs:19:1
+  --> $DIR/const_refers_to_static_cross_crate.rs:18:1
    |
-LL | / const SLICE_MUT2: &u8 = {
+LL | / const U8_MUT: &u8 = {
 LL | |
 LL | |
 LL | |     unsafe { &static_cross_crate::ZERO[0] }
@@ -43,11 +43,71 @@ LL | | };
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error: could not evaluate constant pattern
-  --> $DIR/const_refers_to_static_cross_crate.rs:36:9
+  --> $DIR/const_refers_to_static_cross_crate.rs:51:9
    |
-LL |         SLICE_MUT2 => true,
-   |         ^^^^^^^^^^
+LL |         U8_MUT => true,
+   |         ^^^^^^
 
-error: aborting due to 4 previous errors; 2 warnings emitted
+warning: skipping const checks
+  --> $DIR/const_refers_to_static_cross_crate.rs:28:17
+   |
+LL |     unsafe { &(*static_cross_crate::ZERO_REF)[0] }
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: any use of this value will cause an error
+  --> $DIR/const_refers_to_static_cross_crate.rs:28:14
+   |
+LL | / const U8_MUT2: &u8 = {
+LL | |     unsafe { &(*static_cross_crate::ZERO_REF)[0] }
+   | |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constant accesses static
+LL | |
+LL | |
+LL | |
+LL | | };
+   | |__-
+   |
+note: the lint level is defined here
+  --> $DIR/const_refers_to_static_cross_crate.rs:26:8
+   |
+LL | #[warn(const_err)]
+   |        ^^^^^^^^^
+
+error: could not evaluate constant pattern
+  --> $DIR/const_refers_to_static_cross_crate.rs:61:9
+   |
+LL |         U8_MUT2 => true,
+   |         ^^^^^^^
+
+warning: skipping const checks
+  --> $DIR/const_refers_to_static_cross_crate.rs:35:20
+   |
+LL |     unsafe { match static_cross_crate::OPT_ZERO { Some(ref u) => u, None => panic!() } }
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: any use of this value will cause an error
+  --> $DIR/const_refers_to_static_cross_crate.rs:35:51
+   |
+LL | / const U8_MUT3: &u8 = {
+LL | |     unsafe { match static_cross_crate::OPT_ZERO { Some(ref u) => u, None => panic!() } }
+   | |                                                   ^^^^^^^^^^^ constant accesses static
+LL | |
+LL | |
+LL | |
+LL | | };
+   | |__-
+   |
+note: the lint level is defined here
+  --> $DIR/const_refers_to_static_cross_crate.rs:33:8
+   |
+LL | #[warn(const_err)]
+   |        ^^^^^^^^^
+
+error: could not evaluate constant pattern
+  --> $DIR/const_refers_to_static_cross_crate.rs:68:9
+   |
+LL |         U8_MUT3 => true,
+   |         ^^^^^^^
+
+error: aborting due to 6 previous errors; 6 warnings emitted
 
 For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/miri_unleashed/const_refers_to_static_cross_crate.stderr
+++ b/src/test/ui/consts/miri_unleashed/const_refers_to_static_cross_crate.stderr
@@ -4,12 +4,6 @@ warning: skipping const checks
 LL |     unsafe { &static_cross_crate::ZERO }
    |               ^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: skipping const checks
-  --> $DIR/const_refers_to_static_cross_crate.rs:15:15
-   |
-LL |     unsafe { &static_cross_crate::ZERO }
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^
-
 error[E0080]: it is undefined behavior to use this value
   --> $DIR/const_refers_to_static_cross_crate.rs:12:1
    |
@@ -18,6 +12,30 @@ LL | |
 LL | |
 LL | |     unsafe { &static_cross_crate::ZERO }
 LL | |
+LL | | };
+   | |__^ type validation failed: encountered a reference pointing to a static variable
+   |
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+
+error: could not evaluate constant pattern
+  --> $DIR/const_refers_to_static_cross_crate.rs:28:9
+   |
+LL |         SLICE_MUT => true,
+   |         ^^^^^^^^^
+
+warning: skipping const checks
+  --> $DIR/const_refers_to_static_cross_crate.rs:22:15
+   |
+LL |     unsafe { &static_cross_crate::ZERO[0] }
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0080]: it is undefined behavior to use this value
+  --> $DIR/const_refers_to_static_cross_crate.rs:19:1
+   |
+LL | / const SLICE_MUT2: &u8 = {
+LL | |
+LL | |
+LL | |     unsafe { &static_cross_crate::ZERO[0] }
 LL | |
 LL | | };
    | |__^ type validation failed: encountered a reference pointing to a static variable
@@ -25,17 +43,11 @@ LL | | };
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error: could not evaluate constant pattern
-  --> $DIR/const_refers_to_static_cross_crate.rs:22:9
+  --> $DIR/const_refers_to_static_cross_crate.rs:36:9
    |
-LL |         SLICE_MUT => true,
-   |         ^^^^^^^^^
+LL |         SLICE_MUT2 => true,
+   |         ^^^^^^^^^^
 
-error: could not evaluate constant pattern
-  --> $DIR/const_refers_to_static_cross_crate.rs:22:9
-   |
-LL |         SLICE_MUT => true,
-   |         ^^^^^^^^^
-
-error: aborting due to 3 previous errors; 2 warnings emitted
+error: aborting due to 4 previous errors; 2 warnings emitted
 
 For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/miri_unleashed/const_refers_to_static_cross_crate.stderr
+++ b/src/test/ui/consts/miri_unleashed/const_refers_to_static_cross_crate.stderr
@@ -1,0 +1,41 @@
+warning: skipping const checks
+  --> $DIR/const_refers_to_static_cross_crate.rs:15:15
+   |
+LL |     unsafe { &static_cross_crate::ZERO }
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: skipping const checks
+  --> $DIR/const_refers_to_static_cross_crate.rs:15:15
+   |
+LL |     unsafe { &static_cross_crate::ZERO }
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0080]: it is undefined behavior to use this value
+  --> $DIR/const_refers_to_static_cross_crate.rs:12:1
+   |
+LL | / const SLICE_MUT: &[u8; 1] = {
+LL | |
+LL | |
+LL | |     unsafe { &static_cross_crate::ZERO }
+LL | |
+LL | |
+LL | | };
+   | |__^ type validation failed: encountered a reference pointing to a static variable
+   |
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+
+error: could not evaluate constant pattern
+  --> $DIR/const_refers_to_static_cross_crate.rs:22:9
+   |
+LL |         SLICE_MUT => true,
+   |         ^^^^^^^^^
+
+error: could not evaluate constant pattern
+  --> $DIR/const_refers_to_static_cross_crate.rs:22:9
+   |
+LL |         SLICE_MUT => true,
+   |         ^^^^^^^^^
+
+error: aborting due to 3 previous errors; 2 warnings emitted
+
+For more information about this error, try `rustc --explain E0080`.


### PR DESCRIPTION
https://github.com/rust-lang/const-eval/issues/42 got me thinking about soundness for consts being used in patterns, and I found a hole in our existing dynamic checks: a const referring to a mutable static *in a different crate* was not caught. This PR fixes that. It also adds some comments that explain which invariants are crucial for soundness of const-patterns.

Curiously, trying to weaponize this soundness hole failed: pattern matching compilation ICEd when encountering the cross-crate static, saying "expected allocation ID alloc0 to point to memory". I don't know why that would happen, statics *should* be entirely normal memory for pattern matching to access.

r? @oli-obk
Cc @rust-lang/wg-const-eval 