### PR TITLE
Add Entry::occupied(), Entry::vacant() option getters

### DIFF
--- a/src/libstd/collections/hash/map.rs
+++ b/src/libstd/collections/hash/map.rs
@@ -2062,7 +2062,7 @@ impl<'a, K, V> Entry<'a, K, V> {
     /// let mut map: HashMap<usize, &str> = HashMap::new();
     /// map.insert(42, "asdf");
     ///
-    /// let maybe_replaced = map.entry(42).occupied().map(|o| o.insert("hee hee"));
+    /// let maybe_replaced = map.entry(42).occupied().map(|mut o| o.insert("hee hee"));
     ///
     /// assert_eq!(maybe_replaced, Some("asdf"));
     /// assert_eq!(map[&42], "hee hee");

--- a/src/libstd/collections/hash/map.rs
+++ b/src/libstd/collections/hash/map.rs
@@ -3364,7 +3364,7 @@ mod test_map {
     #[test]
     fn test_entry_take_doesnt_corrupt() {
         #![allow(deprecated)] //rand
-                              // Test for #19292
+        // Test for #19292
         fn check(m: &HashMap<i32, ()>) {
             for k in m.keys() {
                 assert!(m.contains_key(k), "{} is in keys() but not in the map?", k);

--- a/src/libstd/collections/hash/map.rs
+++ b/src/libstd/collections/hash/map.rs
@@ -2050,6 +2050,54 @@ impl<'a, K, V> Entry<'a, K, V> {
             Vacant(entry) => entry.insert_entry(value),
         }
     }
+
+    /// Returns `Some(entry)` if `self` is an `OccupiedEntry`, or else `None`
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(entry_option_getters)]
+    /// use std::collections::HashMap;
+    ///
+    /// let mut map: HashMap<usize, &str> = HashMap::new();
+    /// map.insert(42, "asdf");
+    ///
+    /// let maybe_replaced = map.entry(42).occupied().map(|o| o.insert("hee hee"));
+    ///
+    /// assert_eq!(maybe_replaced, Some("asdf"));
+    /// assert_eq!(map[&42], "hee hee");
+    /// ```
+    #[inline]
+    #[unstable(feature = "entry_option_getters", issue = "none")]
+    pub fn occupied(self) -> Option<OccupiedEntry<'a, K, V>> {
+        match self {
+            Occupied(entry) => Some(entry),
+            Vacant(_entry) => None,
+        }
+    }
+
+    /// Returns `Some(entry)` if `self` is an `VacantEntry`, or else `None`
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(entry_option_getters)]
+    /// use std::collections::HashMap;
+    ///
+    /// let mut map: HashMap<usize, &str> = HashMap::new();
+    ///
+    /// let maybe_inserted = map.entry(42).vacant().map(|v| v.insert("hee hee"));
+    ///
+    /// assert_eq!(maybe_inserted, Some(&mut "hee hee"));
+    /// ```
+    #[inline]
+    #[unstable(feature = "entry_option_getters", issue = "none")]
+    pub fn vacant(self) -> Option<VacantEntry<'a, K, V>> {
+        match self {
+            Occupied(_entry) => None,
+            Vacant(entry) => Some(entry),
+        }
+    }
 }
 
 impl<'a, K, V: Default> Entry<'a, K, V> {
@@ -3316,7 +3364,7 @@ mod test_map {
     #[test]
     fn test_entry_take_doesnt_corrupt() {
         #![allow(deprecated)] //rand
-        // Test for #19292
+                              // Test for #19292
         fn check(m: &HashMap<i32, ()>) {
             for k in m.keys() {
                 assert!(m.contains_key(k), "{} is in keys() but not in the map?", k);


### PR DESCRIPTION
I'm not sure if I'm allowed to just open this kind of thing, but it seemed minor enough that it wouldn't need a full RFC.

Some of the reasoning for this is:
- Importing the `Entry` enum into scope is annoying, it's 4 path segments and is just kinda verbose; I think composing using helper methods on `Entry` is much nicer, and the API is already kinda geared in that direction.
- For these methods specifically, none of the existing helper methods cover the cases where:
  - you want to do something to a `VacantEntry` and remember that it was vacant, which could be done with `entry.vacant().map(|v| { ... })`
  - you want to remove the entry if it's present, or maybe modify it, and remember that it was occupied. e.g. `entry.occupied().map(|o| o.remove() + 1)`

:shrug: these are pretty specific use cases, but in general these can be used for composing more `entry` operations.