### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/src/libcore/macros/mod.rs
+++ b/src/libcore/macros/mod.rs
@@ -1316,7 +1316,7 @@ pub(crate) mod builtin {
     ///
     /// Read the [unstable book] for the usage.
     ///
-    /// [unstable book]: ../unstable-book/library-features/asm.html
+    /// [unstable book]: ../unstable-book/library-features/llvm-asm.html
     #[unstable(
         feature = "llvm_asm",
         issue = "70173",

--- a/src/librustc_middle/mir/mod.rs
+++ b/src/librustc_middle/mir/mod.rs
@@ -625,6 +625,9 @@ pub struct BlockTailInfo {
     /// Examples include `{ ...; tail };` and `let _ = { ...; tail };`
     /// but not e.g., `let _x = { ...; tail };`
     pub tail_result_is_ignored: bool,
+
+    /// `Span` of the tail expression.
+    pub span: Span,
 }
 
 /// A MIR local.

--- a/src/librustc_mir_build/build/block.rs
+++ b/src/librustc_mir_build/build/block.rs
@@ -173,7 +173,11 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         if let Some(expr) = expr {
             let tail_result_is_ignored =
                 destination_ty.is_unit() || this.block_context.currently_ignores_tail_results();
-            this.block_context.push(BlockFrame::TailExpr { tail_result_is_ignored });
+            let span = match expr {
+                ExprRef::Hair(expr) => expr.span,
+                ExprRef::Mirror(ref expr) => expr.span,
+            };
+            this.block_context.push(BlockFrame::TailExpr { tail_result_is_ignored, span });
 
             unpack!(block = this.into(destination, block, expr));
             let popped = this.block_context.pop();

--- a/src/librustc_mir_build/build/expr/stmt.rs
+++ b/src/librustc_mir_build/build/expr/stmt.rs
@@ -151,7 +151,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                                 }
                             }
                             this.block_context
-                                .push(BlockFrame::TailExpr { tail_result_is_ignored: true });
+                                .push(BlockFrame::TailExpr { tail_result_is_ignored: true, span: expr.span });
                             return Some(expr.span);
                         }
                     }

--- a/src/librustc_mir_build/build/mod.rs
+++ b/src/librustc_mir_build/build/mod.rs
@@ -245,6 +245,9 @@ enum BlockFrame {
         ///
         /// Example: `let _ = { STMT_1; EXPR };`
         tail_result_is_ignored: bool,
+
+        /// `Span` of the tail expression.
+        span: Span,
     },
 
     /// Generic mark meaning that the block occurred as a subexpression
@@ -372,8 +375,8 @@ impl BlockContext {
             match bf {
                 BlockFrame::SubExpr => continue,
                 BlockFrame::Statement { .. } => break,
-                &BlockFrame::TailExpr { tail_result_is_ignored } => {
-                    return Some(BlockTailInfo { tail_result_is_ignored });
+                &BlockFrame::TailExpr { tail_result_is_ignored, span } => {
+                    return Some(BlockTailInfo { tail_result_is_ignored, span });
                 }
             }
         }
@@ -397,7 +400,7 @@ impl BlockContext {
 
             // otherwise: use accumulated is_ignored state.
             Some(
-                BlockFrame::TailExpr { tail_result_is_ignored: ignored }
+                BlockFrame::TailExpr { tail_result_is_ignored: ignored, .. }
                 | BlockFrame::Statement { ignores_expr_result: ignored },
             ) => *ignored,
         }

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -570,8 +570,9 @@ pub trait Read {
     /// Like `read`, except that it reads into a slice of buffers.
     ///
     /// Data is copied to fill each buffer in order, with the final buffer
-    /// written to possibly being only partially filled. This method must behave
-    /// as a single call to `read` with the buffers concatenated would.
+    /// written to possibly being only partially filled. This method must
+    /// behave equivalently to a single call to `read` with concatenated
+    /// buffers.
     ///
     /// The default implementation calls `read` with either the first nonempty
     /// buffer provided, or an empty one if none exists.

--- a/src/test/ui/associated-consts/issue-24949-assoc-const-static-recursion-impl.rs
+++ b/src/test/ui/associated-consts/issue-24949-assoc-const-static-recursion-impl.rs
@@ -1,0 +1,15 @@
+// Check for recursion involving references to impl-associated const.
+
+trait Foo {
+    const BAR: u32;
+}
+
+const IMPL_REF_BAR: u32 = GlobalImplRef::BAR; //~ ERROR E0391
+
+struct GlobalImplRef;
+
+impl GlobalImplRef {
+    const BAR: u32 = IMPL_REF_BAR;
+}
+
+fn main() {}

--- a/src/test/ui/associated-consts/issue-24949-assoc-const-static-recursion-impl.stderr
+++ b/src/test/ui/associated-consts/issue-24949-assoc-const-static-recursion-impl.stderr
@@ -1,0 +1,44 @@
+error[E0391]: cycle detected when const-evaluating + checking `IMPL_REF_BAR`
+  --> $DIR/issue-24949-assoc-const-static-recursion-impl.rs:7:1
+   |
+LL | const IMPL_REF_BAR: u32 = GlobalImplRef::BAR;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: ...which requires const-evaluating + checking `IMPL_REF_BAR`...
+  --> $DIR/issue-24949-assoc-const-static-recursion-impl.rs:7:1
+   |
+LL | const IMPL_REF_BAR: u32 = GlobalImplRef::BAR;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: ...which requires const-evaluating `IMPL_REF_BAR`...
+  --> $DIR/issue-24949-assoc-const-static-recursion-impl.rs:7:1
+   |
+LL | const IMPL_REF_BAR: u32 = GlobalImplRef::BAR;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: ...which requires normalizing `<impl at $DIR/issue-24949-assoc-const-static-recursion-impl.rs:11:1: 13:2>::BAR`...
+note: ...which requires const-evaluating + checking `<impl at $DIR/issue-24949-assoc-const-static-recursion-impl.rs:11:1: 13:2>::BAR`...
+  --> $DIR/issue-24949-assoc-const-static-recursion-impl.rs:12:5
+   |
+LL |     const BAR: u32 = IMPL_REF_BAR;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: ...which requires const-evaluating + checking `<impl at $DIR/issue-24949-assoc-const-static-recursion-impl.rs:11:1: 13:2>::BAR`...
+  --> $DIR/issue-24949-assoc-const-static-recursion-impl.rs:12:5
+   |
+LL |     const BAR: u32 = IMPL_REF_BAR;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: ...which requires const-evaluating `<impl at $DIR/issue-24949-assoc-const-static-recursion-impl.rs:11:1: 13:2>::BAR`...
+  --> $DIR/issue-24949-assoc-const-static-recursion-impl.rs:12:5
+   |
+LL |     const BAR: u32 = IMPL_REF_BAR;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: ...which requires processing `<impl at $DIR/issue-24949-assoc-const-static-recursion-impl.rs:11:1: 13:2>::BAR`...
+  --> $DIR/issue-24949-assoc-const-static-recursion-impl.rs:12:5
+   |
+LL |     const BAR: u32 = IMPL_REF_BAR;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: ...which requires normalizing `IMPL_REF_BAR`...
+   = note: ...which again requires const-evaluating + checking `IMPL_REF_BAR`, completing the cycle
+   = note: cycle used when running analysis passes on this crate
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0391`.

--- a/src/test/ui/associated-consts/issue-24949-assoc-const-static-recursion-trait-default.rs
+++ b/src/test/ui/associated-consts/issue-24949-assoc-const-static-recursion-trait-default.rs
@@ -1,0 +1,17 @@
+// Check for recursion involving references to trait-associated const default.
+
+trait Foo {
+    const BAR: u32;
+}
+
+trait FooDefault {
+    const BAR: u32 = DEFAULT_REF_BAR;
+}
+
+const DEFAULT_REF_BAR: u32 = <GlobalDefaultRef>::BAR; //~ ERROR E0391
+
+struct GlobalDefaultRef;
+
+impl FooDefault for GlobalDefaultRef {}
+
+fn main() {}

--- a/src/test/ui/associated-consts/issue-24949-assoc-const-static-recursion-trait-default.stderr
+++ b/src/test/ui/associated-consts/issue-24949-assoc-const-static-recursion-trait-default.stderr
@@ -1,0 +1,44 @@
+error[E0391]: cycle detected when const-evaluating + checking `DEFAULT_REF_BAR`
+  --> $DIR/issue-24949-assoc-const-static-recursion-trait-default.rs:11:1
+   |
+LL | const DEFAULT_REF_BAR: u32 = <GlobalDefaultRef>::BAR;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: ...which requires const-evaluating + checking `DEFAULT_REF_BAR`...
+  --> $DIR/issue-24949-assoc-const-static-recursion-trait-default.rs:11:1
+   |
+LL | const DEFAULT_REF_BAR: u32 = <GlobalDefaultRef>::BAR;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: ...which requires const-evaluating `DEFAULT_REF_BAR`...
+  --> $DIR/issue-24949-assoc-const-static-recursion-trait-default.rs:11:1
+   |
+LL | const DEFAULT_REF_BAR: u32 = <GlobalDefaultRef>::BAR;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: ...which requires normalizing `<GlobalDefaultRef as FooDefault>::BAR`...
+note: ...which requires const-evaluating + checking `FooDefault::BAR`...
+  --> $DIR/issue-24949-assoc-const-static-recursion-trait-default.rs:8:5
+   |
+LL |     const BAR: u32 = DEFAULT_REF_BAR;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: ...which requires const-evaluating + checking `FooDefault::BAR`...
+  --> $DIR/issue-24949-assoc-const-static-recursion-trait-default.rs:8:5
+   |
+LL |     const BAR: u32 = DEFAULT_REF_BAR;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: ...which requires const-evaluating `FooDefault::BAR`...
+  --> $DIR/issue-24949-assoc-const-static-recursion-trait-default.rs:8:5
+   |
+LL |     const BAR: u32 = DEFAULT_REF_BAR;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: ...which requires processing `FooDefault::BAR`...
+  --> $DIR/issue-24949-assoc-const-static-recursion-trait-default.rs:8:5
+   |
+LL |     const BAR: u32 = DEFAULT_REF_BAR;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: ...which requires normalizing `DEFAULT_REF_BAR`...
+   = note: ...which again requires const-evaluating + checking `DEFAULT_REF_BAR`, completing the cycle
+   = note: cycle used when running analysis passes on this crate
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0391`.

--- a/src/test/ui/associated-consts/issue-24949-assoc-const-static-recursion-trait.rs
+++ b/src/test/ui/associated-consts/issue-24949-assoc-const-static-recursion-trait.rs
@@ -1,0 +1,15 @@
+// Check for recursion involving references to trait-associated const.
+
+trait Foo {
+    const BAR: u32;
+}
+
+const TRAIT_REF_BAR: u32 = <GlobalTraitRef>::BAR; //~ ERROR E0391
+
+struct GlobalTraitRef;
+
+impl Foo for GlobalTraitRef {
+    const BAR: u32 = TRAIT_REF_BAR;
+}
+
+fn main() {}

--- a/src/test/ui/associated-consts/issue-24949-assoc-const-static-recursion-trait.stderr
+++ b/src/test/ui/associated-consts/issue-24949-assoc-const-static-recursion-trait.stderr
@@ -1,0 +1,44 @@
+error[E0391]: cycle detected when const-evaluating + checking `TRAIT_REF_BAR`
+  --> $DIR/issue-24949-assoc-const-static-recursion-trait.rs:7:1
+   |
+LL | const TRAIT_REF_BAR: u32 = <GlobalTraitRef>::BAR;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: ...which requires const-evaluating + checking `TRAIT_REF_BAR`...
+  --> $DIR/issue-24949-assoc-const-static-recursion-trait.rs:7:1
+   |
+LL | const TRAIT_REF_BAR: u32 = <GlobalTraitRef>::BAR;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: ...which requires const-evaluating `TRAIT_REF_BAR`...
+  --> $DIR/issue-24949-assoc-const-static-recursion-trait.rs:7:1
+   |
+LL | const TRAIT_REF_BAR: u32 = <GlobalTraitRef>::BAR;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: ...which requires normalizing `<GlobalTraitRef as Foo>::BAR`...
+note: ...which requires const-evaluating + checking `<impl at $DIR/issue-24949-assoc-const-static-recursion-trait.rs:11:1: 13:2>::BAR`...
+  --> $DIR/issue-24949-assoc-const-static-recursion-trait.rs:12:5
+   |
+LL |     const BAR: u32 = TRAIT_REF_BAR;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: ...which requires const-evaluating + checking `<impl at $DIR/issue-24949-assoc-const-static-recursion-trait.rs:11:1: 13:2>::BAR`...
+  --> $DIR/issue-24949-assoc-const-static-recursion-trait.rs:12:5
+   |
+LL |     const BAR: u32 = TRAIT_REF_BAR;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: ...which requires const-evaluating `<impl at $DIR/issue-24949-assoc-const-static-recursion-trait.rs:11:1: 13:2>::BAR`...
+  --> $DIR/issue-24949-assoc-const-static-recursion-trait.rs:12:5
+   |
+LL |     const BAR: u32 = TRAIT_REF_BAR;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: ...which requires processing `<impl at $DIR/issue-24949-assoc-const-static-recursion-trait.rs:11:1: 13:2>::BAR`...
+  --> $DIR/issue-24949-assoc-const-static-recursion-trait.rs:12:5
+   |
+LL |     const BAR: u32 = TRAIT_REF_BAR;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: ...which requires normalizing `TRAIT_REF_BAR`...
+   = note: ...which again requires const-evaluating + checking `TRAIT_REF_BAR`, completing the cycle
+   = note: cycle used when running analysis passes on this crate
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0391`.

--- a/src/test/ui/const-generics/issues/issue-69654.rs
+++ b/src/test/ui/const-generics/issues/issue-69654.rs
@@ -1,0 +1,18 @@
+#![feature(const_generics)]
+#![allow(incomplete_features)]
+
+trait Bar<O> {}
+impl<O> Bar<O> for [u8; O] {}
+//~^ ERROR expected value, found type parameter `O`
+
+struct Foo<const O: usize> {}
+impl<const O: usize> Foo<O>
+where
+    [u8; O]: Bar<[(); O]>,
+{
+    fn foo() {}
+}
+
+fn main() {
+    Foo::foo();
+}

--- a/src/test/ui/const-generics/issues/issue-69654.stderr
+++ b/src/test/ui/const-generics/issues/issue-69654.stderr
@@ -1,0 +1,14 @@
+error[E0423]: expected value, found type parameter `O`
+  --> $DIR/issue-69654.rs:5:25
+   |
+LL | impl<O> Bar<O> for [u8; O] {}
+   |                         ^ help: a tuple variant with a similar name exists: `Ok`
+   | 
+  ::: $SRC_DIR/libcore/result.rs:LL:COL
+   |
+LL |     Ok(#[stable(feature = "rust1", since = "1.0.0")] T),
+   |     --------------------------------------------------- similarly named tuple variant `Ok` defined here
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0423`.

--- a/src/test/ui/nll/issue-54382-use-span-of-tail-of-block.stderr
+++ b/src/test/ui/nll/issue-54382-use-span-of-tail-of-block.stderr
@@ -13,7 +13,10 @@ LL |
 LL |     ;
    |     - ... and the borrow might be used here, when that temporary is dropped and runs the `Drop` code for type `D`
    |
-   = note: The temporary is part of an expression at the end of a block. Consider adding semicolon after the expression so its temporaries are dropped sooner, before the local variables declared by the block are dropped.
+help: consider adding semicolon after the expression so its temporaries are dropped sooner, before the local variables declared by the block are dropped
+   |
+LL |             D("other").next(&_thing1);
+   |                                      ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/issue-54556-niconii.stderr
+++ b/src/test/ui/nll/issue-54556-niconii.stderr
@@ -13,7 +13,10 @@ LL | }
    | `counter` dropped here while still borrowed
    | ... and the borrow might be used here, when that temporary is dropped and runs the destructor for type `std::result::Result<MutexGuard<'_>, ()>`
    |
-   = note: The temporary is part of an expression at the end of a block. Consider adding semicolon after the expression so its temporaries are dropped sooner, before the local variables declared by the block are dropped.
+help: consider adding semicolon after the expression so its temporaries are dropped sooner, before the local variables declared by the block are dropped
+   |
+LL |     if let Ok(_) = counter.lock() { };
+   |                                      ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/issue-54556-stephaneyfx.stderr
+++ b/src/test/ui/nll/issue-54556-stephaneyfx.stderr
@@ -12,7 +12,12 @@ LL | }
    | `stmt` dropped here while still borrowed
    | ... and the borrow might be used here, when that temporary is dropped and runs the destructor for type `std::iter::Map<Rows<'_>, [closure@$DIR/issue-54556-stephaneyfx.rs:28:14: 28:23]>`
    |
-   = note: The temporary is part of an expression at the end of a block. Consider forcing this temporary to be dropped sooner, before the block's local variables are dropped. For example, you could save the expression's value in a new local variable `x` and then make `x` be the expression at the end of the block.
+   = note: the temporary is part of an expression at the end of a block;
+           consider forcing this temporary to be dropped sooner, before the block's local variables are dropped
+help: for example, you could save the expression's value in a new local variable `x` and then make `x` be the expression at the end of the block
+   |
+LL |     let x = rows.map(|row| row).next(); x
+   |     ^^^^^^^                           ^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/issue-54556-temps-in-tail-diagnostic.stderr
+++ b/src/test/ui/nll/issue-54556-temps-in-tail-diagnostic.stderr
@@ -12,7 +12,10 @@ LL |
 LL |     ;
    |     - ... and the borrow might be used here, when that temporary is dropped and runs the `Drop` code for type `D`
    |
-   = note: The temporary is part of an expression at the end of a block. Consider adding semicolon after the expression so its temporaries are dropped sooner, before the local variables declared by the block are dropped.
+help: consider adding semicolon after the expression so its temporaries are dropped sooner, before the local variables declared by the block are dropped
+   |
+LL |         D(&_thing1).end();
+   |                          ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/issue-54556-used-vs-unused-tails.stderr
+++ b/src/test/ui/nll/issue-54556-used-vs-unused-tails.stderr
@@ -8,7 +8,10 @@ LL |     {              let mut _t1 = D(Box::new("t1")); D(&_t1).end()    } ; //
    |                                                     | borrowed value does not live long enough
    |                                                     a temporary with access to the borrow is created here ...
    |
-   = note: The temporary is part of an expression at the end of a block. Consider adding semicolon after the expression so its temporaries are dropped sooner, before the local variables declared by the block are dropped.
+help: consider adding semicolon after the expression so its temporaries are dropped sooner, before the local variables declared by the block are dropped
+   |
+LL |     {              let mut _t1 = D(Box::new("t1")); D(&_t1).end();    } ; // suggest `;`
+   |                                                                  ^
 
 error[E0597]: `_t1` does not live long enough
   --> $DIR/issue-54556-used-vs-unused-tails.rs:13:55
@@ -20,7 +23,10 @@ LL |     {            { let mut _t1 = D(Box::new("t1")); D(&_t1).end() }  } ; //
    |                                                     | borrowed value does not live long enough
    |                                                     a temporary with access to the borrow is created here ...
    |
-   = note: The temporary is part of an expression at the end of a block. Consider adding semicolon after the expression so its temporaries are dropped sooner, before the local variables declared by the block are dropped.
+help: consider adding semicolon after the expression so its temporaries are dropped sooner, before the local variables declared by the block are dropped
+   |
+LL |     {            { let mut _t1 = D(Box::new("t1")); D(&_t1).end(); }  } ; // suggest `;`
+   |                                                                  ^
 
 error[E0597]: `_t1` does not live long enough
   --> $DIR/issue-54556-used-vs-unused-tails.rs:16:55
@@ -32,7 +38,10 @@ LL |     {            { let mut _t1 = D(Box::new("t1")); D(&_t1).end() }; }   //
    |                                                     | borrowed value does not live long enough
    |                                                     a temporary with access to the borrow is created here ...
    |
-   = note: The temporary is part of an expression at the end of a block. Consider adding semicolon after the expression so its temporaries are dropped sooner, before the local variables declared by the block are dropped.
+help: consider adding semicolon after the expression so its temporaries are dropped sooner, before the local variables declared by the block are dropped
+   |
+LL |     {            { let mut _t1 = D(Box::new("t1")); D(&_t1).end(); }; }   // suggest `;`
+   |                                                                  ^
 
 error[E0597]: `_t1` does not live long enough
   --> $DIR/issue-54556-used-vs-unused-tails.rs:19:55
@@ -44,7 +53,10 @@ LL |     let _ =      { let mut _t1 = D(Box::new("t1")); D(&_t1).end()    } ; //
    |                                                     | borrowed value does not live long enough
    |                                                     a temporary with access to the borrow is created here ...
    |
-   = note: The temporary is part of an expression at the end of a block. Consider adding semicolon after the expression so its temporaries are dropped sooner, before the local variables declared by the block are dropped.
+help: consider adding semicolon after the expression so its temporaries are dropped sooner, before the local variables declared by the block are dropped
+   |
+LL |     let _ =      { let mut _t1 = D(Box::new("t1")); D(&_t1).end();    } ; // suggest `;`
+   |                                                                  ^
 
 error[E0597]: `_t1` does not live long enough
   --> $DIR/issue-54556-used-vs-unused-tails.rs:22:55
@@ -56,7 +68,10 @@ LL |     let _u =     { let mut _t1 = D(Box::new("t1")); D(&_t1).unit()   } ; //
    |                                                     | borrowed value does not live long enough
    |                                                     a temporary with access to the borrow is created here ...
    |
-   = note: The temporary is part of an expression at the end of a block. Consider adding semicolon after the expression so its temporaries are dropped sooner, before the local variables declared by the block are dropped.
+help: consider adding semicolon after the expression so its temporaries are dropped sooner, before the local variables declared by the block are dropped
+   |
+LL |     let _u =     { let mut _t1 = D(Box::new("t1")); D(&_t1).unit();   } ; // suggest `;`
+   |                                                                   ^
 
 error[E0597]: `_t1` does not live long enough
   --> $DIR/issue-54556-used-vs-unused-tails.rs:25:55
@@ -68,7 +83,12 @@ LL |     let _x =     { let mut _t1 = D(Box::new("t1")); D(&_t1).end()    } ; //
    |                                                     | borrowed value does not live long enough
    |                                                     a temporary with access to the borrow is created here ...
    |
-   = note: The temporary is part of an expression at the end of a block. Consider forcing this temporary to be dropped sooner, before the block's local variables are dropped. For example, you could save the expression's value in a new local variable `x` and then make `x` be the expression at the end of the block.
+   = note: the temporary is part of an expression at the end of a block;
+           consider forcing this temporary to be dropped sooner, before the block's local variables are dropped
+help: for example, you could save the expression's value in a new local variable `x` and then make `x` be the expression at the end of the block
+   |
+LL |     let _x =     { let mut _t1 = D(Box::new("t1")); let x = D(&_t1).end(); x    } ; // `let x = ...; x`
+   |                                                     ^^^^^^^              ^^^
 
 error[E0597]: `_t1` does not live long enough
   --> $DIR/issue-54556-used-vs-unused-tails.rs:30:55
@@ -80,7 +100,12 @@ LL |     _y =         { let mut _t1 = D(Box::new("t1")); D(&_t1).end() } ; // `l
    |                                                     | borrowed value does not live long enough
    |                                                     a temporary with access to the borrow is created here ...
    |
-   = note: The temporary is part of an expression at the end of a block. Consider forcing this temporary to be dropped sooner, before the block's local variables are dropped. For example, you could save the expression's value in a new local variable `x` and then make `x` be the expression at the end of the block.
+   = note: the temporary is part of an expression at the end of a block;
+           consider forcing this temporary to be dropped sooner, before the block's local variables are dropped
+help: for example, you could save the expression's value in a new local variable `x` and then make `x` be the expression at the end of the block
+   |
+LL |     _y =         { let mut _t1 = D(Box::new("t1")); let x = D(&_t1).end(); x } ; // `let x = ...; x`
+   |                                                     ^^^^^^^              ^^^
 
 error[E0597]: `_t1` does not live long enough
   --> $DIR/issue-54556-used-vs-unused-tails.rs:37:55
@@ -93,7 +118,10 @@ LL | fn f_local_ref() { let mut _t1 = D(Box::new("t1")); D(&_t1).unit()   }  // 
    |                                                     | borrowed value does not live long enough
    |                                                     a temporary with access to the borrow is created here ...
    |
-   = note: The temporary is part of an expression at the end of a block. Consider adding semicolon after the expression so its temporaries are dropped sooner, before the local variables declared by the block are dropped.
+help: consider adding semicolon after the expression so its temporaries are dropped sooner, before the local variables declared by the block are dropped
+   |
+LL | fn f_local_ref() { let mut _t1 = D(Box::new("t1")); D(&_t1).unit();   }  // suggest `;`
+   |                                                                   ^
 
 error[E0597]: `_t1` does not live long enough
   --> $DIR/issue-54556-used-vs-unused-tails.rs:40:55
@@ -106,7 +134,12 @@ LL | fn f() -> String { let mut _t1 = D(Box::new("t1")); D(&_t1).end()   }   // 
    |                                                     | borrowed value does not live long enough
    |                                                     a temporary with access to the borrow is created here ...
    |
-   = note: The temporary is part of an expression at the end of a block. Consider forcing this temporary to be dropped sooner, before the block's local variables are dropped. For example, you could save the expression's value in a new local variable `x` and then make `x` be the expression at the end of the block.
+   = note: the temporary is part of an expression at the end of a block;
+           consider forcing this temporary to be dropped sooner, before the block's local variables are dropped
+help: for example, you could save the expression's value in a new local variable `x` and then make `x` be the expression at the end of the block
+   |
+LL | fn f() -> String { let mut _t1 = D(Box::new("t1")); let x = D(&_t1).end(); x   }   // `let x = ...; x`
+   |                                                     ^^^^^^^              ^^^
 
 error: aborting due to 9 previous errors
 

--- a/src/test/ui/span/destructor-restrictions.stderr
+++ b/src/test/ui/span/destructor-restrictions.stderr
@@ -11,7 +11,12 @@ LL |     };
    |     |
    |     `*a` dropped here while still borrowed
    |
-   = note: The temporary is part of an expression at the end of a block. Consider forcing this temporary to be dropped sooner, before the block's local variables are dropped. For example, you could save the expression's value in a new local variable `x` and then make `x` be the expression at the end of the block.
+   = note: the temporary is part of an expression at the end of a block;
+           consider forcing this temporary to be dropped sooner, before the block's local variables are dropped
+help: for example, you could save the expression's value in a new local variable `x` and then make `x` be the expression at the end of the block
+   |
+LL |         let x = *a.borrow() + 1; x
+   |         ^^^^^^^                ^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/span/issue-23338-locals-die-before-temps-of-body.stderr
+++ b/src/test/ui/span/issue-23338-locals-die-before-temps-of-body.stderr
@@ -12,7 +12,12 @@ LL | }
    | `y` dropped here while still borrowed
    | ... and the borrow might be used here, when that temporary is dropped and runs the destructor for type `std::cell::Ref<'_, std::string::String>`
    |
-   = note: The temporary is part of an expression at the end of a block. Consider forcing this temporary to be dropped sooner, before the block's local variables are dropped. For example, you could save the expression's value in a new local variable `x` and then make `x` be the expression at the end of the block.
+   = note: the temporary is part of an expression at the end of a block;
+           consider forcing this temporary to be dropped sooner, before the block's local variables are dropped
+help: for example, you could save the expression's value in a new local variable `x` and then make `x` be the expression at the end of the block
+   |
+LL |     let x = y.borrow().clone(); x
+   |     ^^^^^^^                   ^^^
 
 error[E0597]: `y` does not live long enough
   --> $DIR/issue-23338-locals-die-before-temps-of-body.rs:17:9
@@ -27,7 +32,12 @@ LL |     };
    |     |
    |     `y` dropped here while still borrowed
    |
-   = note: The temporary is part of an expression at the end of a block. Consider forcing this temporary to be dropped sooner, before the block's local variables are dropped. For example, you could save the expression's value in a new local variable `x` and then make `x` be the expression at the end of the block.
+   = note: the temporary is part of an expression at the end of a block;
+           consider forcing this temporary to be dropped sooner, before the block's local variables are dropped
+help: for example, you could save the expression's value in a new local variable `x` and then make `x` be the expression at the end of the block
+   |
+LL |         let x = y.borrow().clone(); x
+   |         ^^^^^^^                   ^^^
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
Successful merges:

 - #71217 (Suggest `;` or assignment to drop borrows in tail exprs)
 - #71286 (Add regression test for #69654)
 - #71296 (Change wording on read_vectored docs)
 - #71654 (Update link to unstable book for llvm_asm macro)
 - #71657 (Add #24949 assoc constant static recursion test)

Failed merges:


r? @ghost