### PR TITLE
ci: use bash when executing the "bors build finished" jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -624,6 +624,7 @@ jobs:
     steps:
       - name: mark the job as a success
         run: exit 0
+        shell: bash
     name: bors build finished
     runs-on: ubuntu-latest
   try-failure:
@@ -633,6 +634,7 @@ jobs:
     steps:
       - name: mark the job as a failure
         run: exit 1
+        shell: bash
     name: bors build finished
     runs-on: ubuntu-latest
   auto-success:
@@ -642,6 +644,7 @@ jobs:
     steps:
       - name: mark the job as a success
         run: exit 0
+        shell: bash
     name: bors build finished
     runs-on: ubuntu-latest
   auto-failure:
@@ -651,5 +654,6 @@ jobs:
     steps:
       - name: mark the job as a failure
         run: exit 1
+        shell: bash
     name: bors build finished
     runs-on: ubuntu-latest

--- a/src/ci/github-actions/ci.yml
+++ b/src/ci/github-actions/ci.yml
@@ -210,12 +210,14 @@ x--expand-yaml-anchors--remove:
     steps:
       - name: mark the job as a success
         run: exit 0
+        shell: bash
     <<: *base-outcome-job
 
   - &base-failure-job
     steps:
       - name: mark the job as a failure
         run: exit 1
+        shell: bash
     <<: *base-outcome-job
 
 ###########################


### PR DESCRIPTION
We don't clone the repository in those builders, so the default shell (`src/ci/exec-with-shell.py`) is not present there. This fixes a GHA regression introduced in #71434.

r? @Mark-Simulacrum 