### PR TITLE
Add an index page for nightly rustc docs.

### DIFF
--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -478,7 +478,11 @@ impl Step for Rustc {
 
         // Build cargo command.
         let mut cargo = builder.cargo(compiler, Mode::Rustc, target, "doc");
-        cargo.env("RUSTDOCFLAGS", "--document-private-items");
+        cargo.env(
+            "RUSTDOCFLAGS",
+            "--document-private-items \
+            --enable-index-page -Zunstable-options",
+        );
         compile::rustc_cargo(builder, &mut cargo, target);
 
         // Only include compiler crates, no dependencies of those, such as `libc`.


### PR DESCRIPTION
This adds an `index.html` page at the root of the nightly-rustc docs so that the URL https://doc.rust-lang.org/nightly/nightly-rustc/ should have a landing page that lists all the crates.
