### PR TITLE
Fix doc link to Eq trait from PartialEq trait

### DIFF
--- a/src/libcore/cmp.rs
+++ b/src/libcore/cmp.rs
@@ -191,6 +191,7 @@ use self::Ordering::*;
 /// assert_eq!(x.eq(&y), false);
 /// ```
 ///
+/// [`Eq`]: Eq
 /// [`eq`]: PartialEq::eq
 /// [`ne`]: PartialEq::ne
 #[lang = "eq"]


### PR DESCRIPTION
The `Eq` link was incorrectly going to the `eq` method of `PartialEq`
instead of to the `Eq` trait.