### PR TITLE
Bump pulldown-cmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -487,7 +487,7 @@ dependencies = [
  "if_chain",
  "itertools 0.9.0",
  "lazy_static 1.4.0",
- "pulldown-cmark 0.7.0",
+ "pulldown-cmark 0.7.1",
  "quine-mc_cluskey",
  "regex-syntax",
  "semver",
@@ -2657,9 +2657,9 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c2d7fd131800e0d63df52aff46201acaab70b431a4a1ec6f0343fe8e64f35a4"
+checksum = "3e142c3b8f49d2200605ee6ba0b1d757310e9e7a72afe78c36ee2ef67300ee00"
 dependencies = [
  "bitflags",
  "memchr",
@@ -4341,7 +4341,7 @@ version = "0.0.0"
 dependencies = [
  "itertools 0.8.0",
  "minifier",
- "pulldown-cmark 0.7.0",
+ "pulldown-cmark 0.7.1",
  "rustc-rayon",
  "serde",
  "serde_json",


### PR DESCRIPTION
Pulls in 0.7.1 with the following fixes:

- Update html5ever to 0.25
- Fix hang on unclosed html element

Closes #70871