### PR TITLE
Allow `Unreachable` terminators unconditionally in const-checking

### DIFF
--- a/src/librustc_mir/transform/qualify_min_const_fn.rs
+++ b/src/librustc_mir/transform/qualify_min_const_fn.rs
@@ -344,7 +344,8 @@ fn check_terminator(
         | TerminatorKind::FalseUnwind { .. }
         | TerminatorKind::Goto { .. }
         | TerminatorKind::Return
-        | TerminatorKind::Resume => Ok(()),
+        | TerminatorKind::Resume
+        | TerminatorKind::Unreachable => Ok(()),
 
         TerminatorKind::Drop { location, .. } => check_place(tcx, *location, span, def_id, body),
         TerminatorKind::DropAndReplace { location, value, .. } => {
@@ -360,12 +361,7 @@ fn check_terminator(
             check_operand(tcx, discr, span, def_id, body)
         }
 
-        // FIXME(ecstaticmorse): We probably want to allow `Unreachable` unconditionally.
-        TerminatorKind::Unreachable if feature_allowed(tcx, def_id, sym::const_if_match) => Ok(()),
-
-        TerminatorKind::Abort | TerminatorKind::Unreachable => {
-            Err((span, "const fn with unreachable code is not stable".into()))
-        }
+        TerminatorKind::Abort => Err((span, "abort is not stable in const fn".into())),
         TerminatorKind::GeneratorDrop | TerminatorKind::Yield { .. } => {
             Err((span, "const fn generators are unstable".into()))
         }


### PR DESCRIPTION
If we ever actually reach an `Unreachable` terminator while executing, the MIR is ill-formed or the user's program is UB due to something like `unreachable_unchecked`. I don't think we need to forbid these in `qualify_min_const_fn`.

r? @oli-obk 