### PR TITLE
Add clarification on std::cfg macro docs v. #[cfg] attribute

### DIFF
--- a/src/libcore/macros/mod.rs
+++ b/src/libcore/macros/mod.rs
@@ -1159,6 +1159,10 @@ pub(crate) mod builtin {
     /// The syntax given to this macro is the same syntax as the [`cfg`]
     /// attribute.
     ///
+    /// `cfg!`, unlike `#[cfg]`, does not remove any code and only evaluates to true or false. For
+    /// example, this means all code in an if/else block needs to be valid when `cfg!` is used for
+    /// the condition, regardless of what `cfg!` is evaluating.
+    ///
     /// [`cfg`]: ../reference/conditional-compilation.html#the-cfg-attribute
     ///
     /// # Examples

--- a/src/libcore/macros/mod.rs
+++ b/src/libcore/macros/mod.rs
@@ -1160,7 +1160,7 @@ pub(crate) mod builtin {
     /// attribute.
     ///
     /// `cfg!`, unlike `#[cfg]`, does not remove any code and only evaluates to true or false. For
-    /// example, this means all code in an if/else block needs to be valid when `cfg!` is used for
+    /// example, all blocks in an if/else expression need to be valid when `cfg!` is used for
     /// the condition, regardless of what `cfg!` is evaluating.
     ///
     /// [`cfg`]: ../reference/conditional-compilation.html#the-cfg-attribute


### PR DESCRIPTION
The wording was discussed, to a limited degree in #71679.  This tries to
address some confusion I as well as someone else had independently when
looking at this macro.

Fixes #71679