### PR TITLE
Add `Cow::into_static`

### DIFF
--- a/src/liballoc/borrow.rs
+++ b/src/liballoc/borrow.rs
@@ -315,6 +315,17 @@ impl<B: ?Sized + ToOwned> Cow<'_, B> {
             Owned(owned) => owned,
         }
     }
+
+    /// Makes the `Cow` independent of its lifetime, by taking
+    /// ownership of the underlying data.
+    #[unstable(feature = "cow_into_static", issue = "none")]
+    #[must_use]
+    pub fn into_static(self) -> Cow<'static, B> {
+        match self {
+            Borrowed(b) => Owned(b.to_owned()),
+            Owned(o) => Owned(o),
+        }
+    }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]


### PR DESCRIPTION
#71320 is not possible, because of the blanket impl `From<T> for T`, so this adds an `into_static` method for `Cow`.