### PR TITLE
Doc alias improvements

### DIFF
--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -643,6 +643,15 @@ impl Attributes {
             })
             .collect()
     }
+
+    pub fn get_doc_aliases(&self) -> FxHashSet<String> {
+        self.other_attrs
+            .lists(sym::doc)
+            .filter(|a| a.check_name(sym::alias))
+            .filter_map(|a| a.value_str().map(|s| s.to_string().replace("\"", "")))
+            .filter(|v| !v.is_empty())
+            .collect::<FxHashSet<_>>()
+    }
 }
 
 impl PartialEq for Attributes {

--- a/src/librustdoc/html/layout.rs
+++ b/src/librustdoc/html/layout.rs
@@ -114,7 +114,6 @@ pub fn render<T: Print, S: Print>(
         window.rootPath = \"{root_path}\";\
         window.currentCrate = \"{krate}\";\
     </script>\
-    <script src=\"{root_path}aliases{suffix}.js\"></script>\
     <script src=\"{static_root_path}main{suffix}.js\"></script>\
     {static_extra_scripts}\
     {extra_scripts}\

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -825,42 +825,6 @@ themePicker.onblur = handleThemeButtonsBlur;
         Ok((ret, krates))
     }
 
-    fn show_item(item: &IndexItem, krate: &str) -> String {
-        format!(
-            "{{'crate':'{}','ty':{},'name':'{}','desc':'{}','p':'{}'{}}}",
-            krate,
-            item.ty as usize,
-            item.name,
-            item.desc.replace("'", "\\'"),
-            item.path,
-            if let Some(p) = item.parent_idx { format!(",'parent':{}", p) } else { String::new() }
-        )
-    }
-
-    let dst = cx.dst.join(&format!("aliases{}.js", cx.shared.resource_suffix));
-    {
-        let (mut all_aliases, _) = try_err!(collect(&dst, &krate.name, "ALIASES"), &dst);
-        let mut output = String::with_capacity(100);
-        for (alias, items) in cx.cache.get_aliases() {
-            if items.is_empty() {
-                continue;
-            }
-            output.push_str(&format!(
-                "\"{}\":[{}],",
-                alias,
-                items.iter().map(|v| show_item(v, &krate.name)).collect::<Vec<_>>().join(",")
-            ));
-        }
-        all_aliases.push(format!("ALIASES[\"{}\"] = {{{}}};", krate.name, output));
-        all_aliases.sort();
-        let mut v = Buffer::html();
-        writeln!(&mut v, "var ALIASES = {{}};");
-        for aliases in &all_aliases {
-            writeln!(&mut v, "{}", aliases);
-        }
-        cx.shared.fs.write(&dst, v.into_inner().into_bytes())?;
-    }
-
     use std::ffi::OsString;
 
     #[derive(Debug)]

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -278,7 +278,7 @@ pub struct RenderInfo {
 /// Struct representing one entry in the JS search index. These are all emitted
 /// by hand to a large JS file at the end of cache-creation.
 #[derive(Debug)]
-pub struct IndexItem {
+struct IndexItem {
     ty: ItemType,
     name: String,
     path: String,

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -278,7 +278,7 @@ pub struct RenderInfo {
 /// Struct representing one entry in the JS search index. These are all emitted
 /// by hand to a large JS file at the end of cache-creation.
 #[derive(Debug)]
-struct IndexItem {
+pub struct IndexItem {
     ty: ItemType,
     name: String,
     path: String,
@@ -293,7 +293,12 @@ impl Serialize for IndexItem {
     where
         S: Serializer,
     {
-        assert_eq!(self.parent.is_some(), self.parent_idx.is_some());
+        assert_eq!(
+            self.parent.is_some(),
+            self.parent_idx.is_some(),
+            "`{}` is missing idx",
+            self.name
+        );
 
         (self.ty, &self.name, &self.path, &self.desc, self.parent_idx, &self.search_type)
             .serialize(serializer)
@@ -836,7 +841,7 @@ themePicker.onblur = handleThemeButtonsBlur;
     {
         let (mut all_aliases, _) = try_err!(collect(&dst, &krate.name, "ALIASES"), &dst);
         let mut output = String::with_capacity(100);
-        for (alias, items) in &cx.cache.aliases {
+        for (alias, items) in cx.cache.get_aliases() {
             if items.is_empty() {
                 continue;
             }

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -1781,12 +1781,13 @@ function getSearchElement() {
                 if (aliases) {
                     ALIASES[crate] = {};
                     var j, local_aliases;
-                    for (i = 0; i < aliases.length; ++i) {
-                        var alias_name = aliases[i][0];
+                    for (var alias_name in aliases) {
+                        if (!aliases.hasOwnProperty(alias_name)) { continue; }
+
                         if (!ALIASES[crate].hasOwnProperty(alias_name)) {
                             ALIASES[crate][alias_name] = [];
                         }
-                        local_aliases = aliases[i][1];
+                        local_aliases = aliases[alias_name];
                         for (j = 0; j < local_aliases.length; ++j) {
                             ALIASES[crate][alias_name].push(local_aliases[j] + currentIndex);
                         }

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -972,7 +972,7 @@ function getSearchElement() {
                     desc: item.desc,
                     ty: item.ty,
                     parent: item.parent,
-                    type: item.parent,
+                    type: item.type,
                     is_alias: true,
                 };
             }

--- a/src/test/rustdoc-js-std/alias-2.js
+++ b/src/test/rustdoc-js-std/alias-2.js
@@ -4,9 +4,9 @@ const QUERY = '+';
 
 const EXPECTED = {
     'others': [
-        { 'path': 'core', 'name': 'AddAssign' },
-        { 'path': 'core', 'name': 'Add' },
-        { 'path': 'std', 'name': 'AddAssign' },
+        { 'path': 'core::ops', 'name': 'AddAssign' },
+        { 'path': 'core::ops', 'name': 'Add' },
+        { 'path': 'std::ops', 'name': 'AddAssign' },
         { 'path': 'std::ops', 'name': 'Add' },
     ],
 };

--- a/src/test/rustdoc-js-std/alias-2.js
+++ b/src/test/rustdoc-js-std/alias-2.js
@@ -1,12 +1,10 @@
-// ignore-order
-
 const QUERY = '+';
 
 const EXPECTED = {
     'others': [
-        { 'path': 'core::ops', 'name': 'AddAssign' },
-        { 'path': 'core::ops', 'name': 'Add' },
         { 'path': 'std::ops', 'name': 'AddAssign' },
         { 'path': 'std::ops', 'name': 'Add' },
+        { 'path': 'core::ops', 'name': 'AddAssign' },
+        { 'path': 'core::ops', 'name': 'Add' },
     ],
 };

--- a/src/test/rustdoc-js-std/alias-2.js
+++ b/src/test/rustdoc-js-std/alias-2.js
@@ -4,7 +4,9 @@ const QUERY = '+';
 
 const EXPECTED = {
     'others': [
-        { 'path': 'std::ops', 'name': 'AddAssign' },
+        { 'path': 'core', 'name': 'AddAssign' },
+        { 'path': 'core', 'name': 'Add' },
+        { 'path': 'std', 'name': 'AddAssign' },
         { 'path': 'std::ops', 'name': 'Add' },
     ],
 };

--- a/src/test/rustdoc-js-std/alias.js
+++ b/src/test/rustdoc-js-std/alias.js
@@ -5,7 +5,7 @@ const QUERY = '[';
 const EXPECTED = {
     'others': [
         { 'path': 'std', 'name': 'slice' },
-        { 'path': 'std::ops', 'name': 'IndexMut' },
-        { 'path': 'std::ops', 'name': 'Index' },
+        { 'path': 'std', 'name': 'IndexMut' },
+        { 'path': 'std', 'name': 'Index' },
     ],
 };

--- a/src/test/rustdoc-js-std/alias.js
+++ b/src/test/rustdoc-js-std/alias.js
@@ -5,7 +5,7 @@ const QUERY = '[';
 const EXPECTED = {
     'others': [
         { 'path': 'std', 'name': 'slice' },
-        { 'path': 'std', 'name': 'IndexMut' },
-        { 'path': 'std', 'name': 'Index' },
+        { 'path': 'std::ops', 'name': 'IndexMut' },
+        { 'path': 'std::ops', 'name': 'Index' },
     ],
 };

--- a/src/test/rustdoc-js/doc-alias.js
+++ b/src/test/rustdoc-js/doc-alias.js
@@ -32,7 +32,8 @@ const EXPECTED = [
                 'path': 'doc_alias',
                 'name': 'Struct',
                 'alias': 'StructItem',
-                'href': '../doc_alias/struct.Struct.html'
+                'href': '../doc_alias/struct.Struct.html',
+                'is_alias': true
             },
         ],
     },
@@ -42,7 +43,8 @@ const EXPECTED = [
                 'path': 'doc_alias::Struct',
                 'name': 'field',
                 'alias': 'StructFieldItem',
-                'href': '../doc_alias/struct.Struct.html#structfield.field'
+                'href': '../doc_alias/struct.Struct.html#structfield.field',
+                'is_alias': true
             },
         ],
     },
@@ -52,7 +54,8 @@ const EXPECTED = [
                 'path': 'doc_alias::Struct',
                 'name': 'method',
                 'alias': 'StructMethodItem',
-                'href': '../doc_alias/struct.Struct.html#method.method'
+                'href': '../doc_alias/struct.Struct.html#method.method',
+                'is_alias': true
             },
         ],
     },
@@ -65,8 +68,15 @@ const EXPECTED = [
         'others': [],
     },
     {
-        // ImplTraitFunction
-        'others': [],
+        'others': [
+            {
+                'path': 'doc_alias::Struct',
+                'name': 'function',
+                'alias': 'ImplTraitFunction',
+                'href': '../doc_alias/struct.Struct.html#method.function',
+                'is_alias': true
+            },
+        ],
     },
     {
         'others': [
@@ -74,7 +84,8 @@ const EXPECTED = [
                 'path': 'doc_alias',
                 'name': 'Enum',
                 'alias': 'EnumItem',
-                'href': '../doc_alias/enum.Enum.html'
+                'href': '../doc_alias/enum.Enum.html',
+                'is_alias': true
             },
         ],
     },
@@ -84,7 +95,8 @@ const EXPECTED = [
                 'path': 'doc_alias::Enum',
                 'name': 'Variant',
                 'alias': 'VariantItem',
-                'href': '../doc_alias/enum.Enum.html#variant.Variant'
+                'href': '../doc_alias/enum.Enum.html#variant.Variant',
+                'is_alias': true
             },
         ],
     },
@@ -94,7 +106,8 @@ const EXPECTED = [
                 'path': 'doc_alias::Enum',
                 'name': 'method',
                 'alias': 'EnumMethodItem',
-                'href': '../doc_alias/enum.Enum.html#method.method'
+                'href': '../doc_alias/enum.Enum.html#method.method',
+                'is_alias': true
             },
         ],
     },
@@ -104,7 +117,8 @@ const EXPECTED = [
                 'path': 'doc_alias',
                 'name': 'Typedef',
                 'alias': 'TypedefItem',
-                'href': '../doc_alias/type.Typedef.html'
+                'href': '../doc_alias/type.Typedef.html',
+                'is_alias': true
             },
         ],
     },
@@ -114,7 +128,8 @@ const EXPECTED = [
                 'path': 'doc_alias',
                 'name': 'Trait',
                 'alias': 'TraitItem',
-                'href': '../doc_alias/trait.Trait.html'
+                'href': '../doc_alias/trait.Trait.html',
+                'is_alias': true
             },
         ],
     },
@@ -124,7 +139,8 @@ const EXPECTED = [
                 'path': 'doc_alias::Trait',
                 'name': 'Target',
                 'alias': 'TraitTypeItem',
-                'href': '../doc_alias/trait.Trait.html#associatedtype.Target'
+                'href': '../doc_alias/trait.Trait.html#associatedtype.Target',
+                'is_alias': true
             },
         ],
     },
@@ -134,7 +150,8 @@ const EXPECTED = [
                 'path': 'doc_alias::Trait',
                 'name': 'AssociatedConst',
                 'alias': 'AssociatedConstItem',
-                'href': '../doc_alias/trait.Trait.html#associatedconstant.AssociatedConst'
+                'href': '../doc_alias/trait.Trait.html#associatedconstant.AssociatedConst',
+                'is_alias': true
             },
         ],
     },
@@ -144,7 +161,8 @@ const EXPECTED = [
                 'path': 'doc_alias::Trait',
                 'name': 'function',
                 'alias': 'TraitFunctionItem',
-                'href': '../doc_alias/trait.Trait.html#tymethod.function'
+                'href': '../doc_alias/trait.Trait.html#tymethod.function',
+                'is_alias': true
             },
         ],
     },
@@ -154,7 +172,8 @@ const EXPECTED = [
                 'path': 'doc_alias',
                 'name': 'function',
                 'alias': 'FunctionItem',
-                'href': '../doc_alias/fn.function.html'
+                'href': '../doc_alias/fn.function.html',
+                'is_alias': true
             },
         ],
     },
@@ -164,7 +183,8 @@ const EXPECTED = [
                 'path': 'doc_alias',
                 'name': 'Module',
                 'alias': 'ModuleItem',
-                'href': '../doc_alias/Module/index.html'
+                'href': '../doc_alias/Module/index.html',
+                'is_alias': true
             },
         ],
     },
@@ -174,7 +194,8 @@ const EXPECTED = [
                 'path': 'doc_alias',
                 'name': 'Const',
                 'alias': 'ConstItem',
-                'href': '../doc_alias/constant.Const.html'
+                'href': '../doc_alias/constant.Const.html',
+                'is_alias': true
             },
         ],
     },
@@ -184,7 +205,8 @@ const EXPECTED = [
                 'path': 'doc_alias',
                 'name': 'Static',
                 'alias': 'StaticItem',
-                'href': '../doc_alias/static.Static.html'
+                'href': '../doc_alias/static.Static.html',
+                'is_alias': true
             },
         ],
     },
@@ -194,7 +216,8 @@ const EXPECTED = [
                 'path': 'doc_alias',
                 'name': 'Union',
                 'alias': 'UnionItem',
-                'href': '../doc_alias/union.Union.html'
+                'href': '../doc_alias/union.Union.html',
+                'is_alias': true
             },
             // Not an alias!
             {
@@ -210,7 +233,8 @@ const EXPECTED = [
                 'path': 'doc_alias::Union',
                 'name': 'union_item',
                 'alias': 'UnionFieldItem',
-                'href': '../doc_alias/union.Union.html#structfield.union_item'
+                'href': '../doc_alias/union.Union.html#structfield.union_item',
+                'is_alias': true
             },
         ],
     },
@@ -220,7 +244,8 @@ const EXPECTED = [
                 'path': 'doc_alias::Union',
                 'name': 'method',
                 'alias': 'UnionMethodItem',
-                'href': '../doc_alias/union.Union.html#method.method'
+                'href': '../doc_alias/union.Union.html#method.method',
+                'is_alias': true
             },
         ],
     },
@@ -230,7 +255,8 @@ const EXPECTED = [
                 'path': 'doc_alias',
                 'name': 'Macro',
                 'alias': 'MacroItem',
-                'href': '../doc_alias/macro.Macro.html'
+                'href': '../doc_alias/macro.Macro.html',
+                'is_alias': true
             },
         ],
     },

--- a/src/test/rustdoc-js/doc-alias.js
+++ b/src/test/rustdoc-js/doc-alias.js
@@ -1,0 +1,237 @@
+// exact-check
+
+const QUERY = [
+    'StructItem',
+    'StructFieldItem',
+    'StructMethodItem',
+    'ImplTraitItem',
+    'ImplAssociatedConstItem',
+    'ImplTraitFunction',
+    'EnumItem',
+    'VariantItem',
+    'EnumMethodItem',
+    'TypedefItem',
+    'TraitItem',
+    'TraitTypeItem',
+    'AssociatedConstItem',
+    'TraitFunctionItem',
+    'FunctionItem',
+    'ModuleItem',
+    'ConstItem',
+    'StaticItem',
+    'UnionItem',
+    'UnionFieldItem',
+    'UnionMethodItem',
+    'MacroItem',
+];
+
+const EXPECTED = [
+    {
+        'others': [
+            {
+                'path': 'doc_alias',
+                'name': 'Struct',
+                'alias': 'StructItem',
+                'href': '../doc_alias/struct.Struct.html'
+            },
+        ],
+    },
+    {
+        'others': [
+            {
+                'path': 'doc_alias::Struct',
+                'name': 'field',
+                'alias': 'StructFieldItem',
+                'href': '../doc_alias/struct.Struct.html#structfield.field'
+            },
+        ],
+    },
+    {
+        'others': [
+            {
+                'path': 'doc_alias::Struct',
+                'name': 'method',
+                'alias': 'StructMethodItem',
+                'href': '../doc_alias/struct.Struct.html#method.method'
+            },
+        ],
+    },
+    {
+        // ImplTraitItem
+        'others': [],
+    },
+    {
+        // ImplAssociatedConstItem
+        'others': [],
+    },
+    {
+        // ImplTraitFunction
+        'others': [],
+    },
+    {
+        'others': [
+            {
+                'path': 'doc_alias',
+                'name': 'Enum',
+                'alias': 'EnumItem',
+                'href': '../doc_alias/enum.Enum.html'
+            },
+        ],
+    },
+    {
+        'others': [
+            {
+                'path': 'doc_alias::Enum',
+                'name': 'Variant',
+                'alias': 'VariantItem',
+                'href': '../doc_alias/enum.Enum.html#variant.Variant'
+            },
+        ],
+    },
+    {
+        'others': [
+            {
+                'path': 'doc_alias::Enum',
+                'name': 'method',
+                'alias': 'EnumMethodItem',
+                'href': '../doc_alias/enum.Enum.html#method.method'
+            },
+        ],
+    },
+    {
+        'others': [
+            {
+                'path': 'doc_alias',
+                'name': 'Typedef',
+                'alias': 'TypedefItem',
+                'href': '../doc_alias/type.Typedef.html'
+            },
+        ],
+    },
+    {
+        'others': [
+            {
+                'path': 'doc_alias',
+                'name': 'Trait',
+                'alias': 'TraitItem',
+                'href': '../doc_alias/trait.Trait.html'
+            },
+        ],
+    },
+    {
+        'others': [
+            {
+                'path': 'doc_alias::Trait',
+                'name': 'Target',
+                'alias': 'TraitTypeItem',
+                'href': '../doc_alias/trait.Trait.html#associatedtype.Target'
+            },
+        ],
+    },
+    {
+        'others': [
+            {
+                'path': 'doc_alias::Trait',
+                'name': 'AssociatedConst',
+                'alias': 'AssociatedConstItem',
+                'href': '../doc_alias/trait.Trait.html#associatedconstant.AssociatedConst'
+            },
+        ],
+    },
+    {
+        'others': [
+            {
+                'path': 'doc_alias::Trait',
+                'name': 'function',
+                'alias': 'TraitFunctionItem',
+                'href': '../doc_alias/trait.Trait.html#tymethod.function'
+            },
+        ],
+    },
+    {
+        'others': [
+            {
+                'path': 'doc_alias',
+                'name': 'function',
+                'alias': 'FunctionItem',
+                'href': '../doc_alias/fn.function.html'
+            },
+        ],
+    },
+    {
+        'others': [
+            {
+                'path': 'doc_alias',
+                'name': 'Module',
+                'alias': 'ModuleItem',
+                'href': '../doc_alias/Module/index.html'
+            },
+        ],
+    },
+    {
+        'others': [
+            {
+                'path': 'doc_alias',
+                'name': 'Const',
+                'alias': 'ConstItem',
+                'href': '../doc_alias/constant.Const.html'
+            },
+        ],
+    },
+    {
+        'others': [
+            {
+                'path': 'doc_alias',
+                'name': 'Static',
+                'alias': 'StaticItem',
+                'href': '../doc_alias/static.Static.html'
+            },
+        ],
+    },
+    {
+        'others': [
+            {
+                'path': 'doc_alias',
+                'name': 'Union',
+                'alias': 'UnionItem',
+                'href': '../doc_alias/union.Union.html'
+            },
+            // Not an alias!
+            {
+                'path': 'doc_alias::Union',
+                'name': 'union_item',
+                'href': '../doc_alias/union.Union.html#structfield.union_item'
+            },
+        ],
+    },
+    {
+        'others': [
+            {
+                'path': 'doc_alias::Union',
+                'name': 'union_item',
+                'alias': 'UnionFieldItem',
+                'href': '../doc_alias/union.Union.html#structfield.union_item'
+            },
+        ],
+    },
+    {
+        'others': [
+            {
+                'path': 'doc_alias::Union',
+                'name': 'method',
+                'alias': 'UnionMethodItem',
+                'href': '../doc_alias/union.Union.html#method.method'
+            },
+        ],
+    },
+    {
+        'others': [
+            {
+                'path': 'doc_alias',
+                'name': 'Macro',
+                'alias': 'MacroItem',
+                'href': '../doc_alias/macro.Macro.html'
+            },
+        ],
+    },
+];

--- a/src/test/rustdoc-js/doc-alias.rs
+++ b/src/test/rustdoc-js/doc-alias.rs
@@ -19,7 +19,6 @@ impl Trait for Struct {
     #[doc(alias = "ImplAssociatedConstItem")]
     const AssociatedConst: i32 = 12;
 
-    // Shouldn't be listed in aliases!
     #[doc(alias = "ImplTraitFunction")]
     fn function() -> Self::Target { 0 }
 }

--- a/src/test/rustdoc-js/doc-alias.rs
+++ b/src/test/rustdoc-js/doc-alias.rs
@@ -1,0 +1,80 @@
+#![feature(doc_alias)]
+
+#[doc(alias = "StructItem")]
+pub struct Struct {
+    #[doc(alias = "StructFieldItem")]
+    pub field: u32,
+}
+
+impl Struct {
+    #[doc(alias = "StructMethodItem")]
+    pub fn method(&self) {}
+}
+
+impl Trait for Struct {
+    // Shouldn't be listed in aliases!
+    #[doc(alias = "ImplTraitItem")]
+    type Target = u32;
+    // Shouldn't be listed in aliases!
+    #[doc(alias = "ImplAssociatedConstItem")]
+    const AssociatedConst: i32 = 12;
+
+    // Shouldn't be listed in aliases!
+    #[doc(alias = "ImplTraitFunction")]
+    fn function() -> Self::Target { 0 }
+}
+
+#[doc(alias = "EnumItem")]
+pub enum Enum {
+    #[doc(alias = "VariantItem")]
+    Variant,
+}
+
+impl Enum {
+    #[doc(alias = "EnumMethodItem")]
+    pub fn method(&self) {}
+}
+
+#[doc(alias = "TypedefItem")]
+pub type Typedef = i32;
+
+#[doc(alias = "TraitItem")]
+pub trait Trait {
+    #[doc(alias = "TraitTypeItem")]
+    type Target;
+    #[doc(alias = "AssociatedConstItem")]
+    const AssociatedConst: i32;
+
+    #[doc(alias = "TraitFunctionItem")]
+    fn function() -> Self::Target;
+}
+
+#[doc(alias = "FunctionItem")]
+pub fn function() {}
+
+#[doc(alias = "ModuleItem")]
+pub mod Module {}
+
+#[doc(alias = "ConstItem")]
+pub const Const: u32 = 0;
+
+#[doc(alias = "StaticItem")]
+pub static Static: u32 = 0;
+
+#[doc(alias = "UnionItem")]
+pub union Union {
+    #[doc(alias = "UnionFieldItem")]
+    pub union_item: u32,
+    pub y: f32,
+}
+
+impl Union {
+    #[doc(alias = "UnionMethodItem")]
+    pub fn method(&self) {}
+}
+
+#[doc(alias = "MacroItem")]
+#[macro_export]
+macro_rules! Macro {
+    () => {}
+}

--- a/src/tools/rustdoc-js/tester.js
+++ b/src/tools/rustdoc-js/tester.js
@@ -181,7 +181,7 @@ function loadThings(thingsToLoad, kindOfLoad, funcToCall, fileContent) {
     for (var i = 0; i < thingsToLoad.length; ++i) {
         var tmp = funcToCall(fileContent, thingsToLoad[i]);
         if (tmp === null) {
-            console.error('unable to find ' + kindOfLoad + ' "' + thingsToLoad[i] + '"');
+            console.log('unable to find ' + kindOfLoad + ' "' + thingsToLoad[i] + '"');
             process.exit(1);
         }
         content += tmp;
@@ -223,7 +223,8 @@ function loadMainJsAndIndex(mainJs, aliases, searchIndex, crate) {
         searchIndex.pop();
     }
     searchIndex.pop();
-    searchIndex = loadContent(searchIndex.join("\n") + '\nexports.searchIndex = searchIndex;');
+    var fullSearchIndex = searchIndex.join("\n") + '\nexports.rawSearchIndex = searchIndex;';
+    searchIndex = loadContent(fullSearchIndex);
     var finalJS = "";
 
     var arraysToLoad = ["itemTypes"];
@@ -235,7 +236,7 @@ function loadMainJsAndIndex(mainJs, aliases, searchIndex, crate) {
     // execQuery last parameter is built in buildIndex.
     // buildIndex requires the hashmap from search-index.
     var functionsToLoad = ["buildHrefAndPath", "pathSplitter", "levenshtein", "validateResult",
-                           "getQuery", "buildIndex", "execQuery", "execSearch"];
+                           "handleAliases", "getQuery", "buildIndex", "execQuery", "execSearch"];
 
     finalJS += 'window = { "currentCrate": "' + crate + '" };\n';
     finalJS += 'var rootPath = "../";\n';
@@ -245,24 +246,19 @@ function loadMainJsAndIndex(mainJs, aliases, searchIndex, crate) {
     finalJS += loadThings(functionsToLoad, 'function', extractFunction, mainJs);
 
     var loaded = loadContent(finalJS);
-    var index = loaded.buildIndex(searchIndex.searchIndex);
+    var index = loaded.buildIndex(searchIndex.rawSearchIndex);
+    // We make it "global" so that the "loaded.execSearch" function will find it.
+    rawSearchIndex = searchIndex.rawSearchIndex;
 
     return [loaded, index];
 }
 
-function runChecks(testFile, loaded, index) {
-    var errors = 0;
-    var loadedFile = loadContent(
-        readFile(testFile) + 'exports.QUERY = QUERY;exports.EXPECTED = EXPECTED;');
-
-    const expected = loadedFile.EXPECTED;
-    const query = loadedFile.QUERY;
+function runSearch(query, expected, index, loaded, loadedFile, queryName) {
     const filter_crate = loadedFile.FILTER_CRATE;
     const ignore_order = loadedFile.ignore_order;
     const exact_check = loadedFile.exact_check;
-    const should_fail = loadedFile.should_fail;
 
-    var results = loaded.execSearch(loaded.getQuery(query), index);
+    var results = loaded.execSearch(loaded.getQuery(query), index, filter_crate);
     var error_text = [];
 
     for (var key in expected) {
@@ -278,32 +274,68 @@ function runChecks(testFile, loaded, index) {
         for (var i = 0; i < entry.length; ++i) {
             var entry_pos = lookForEntry(entry[i], results[key]);
             if (entry_pos === null) {
-                error_text.push("==> Result not found in '" + key + "': '" +
+                error_text.push(queryName + "==> Result not found in '" + key + "': '" +
                                 JSON.stringify(entry[i]) + "'");
             } else if (exact_check === true && prev_pos + 1 !== entry_pos) {
-                error_text.push("==> Exact check failed at position " + (prev_pos + 1) + ": " +
-                                "expected '" + JSON.stringify(entry[i]) + "' but found '" +
+                error_text.push(queryName + "==> Exact check failed at position " + (prev_pos + 1) +
+                                ": expected '" + JSON.stringify(entry[i]) + "' but found '" +
                                 JSON.stringify(results[key][i]) + "'");
             } else if (ignore_order === false && entry_pos < prev_pos) {
-                error_text.push("==> '" + JSON.stringify(entry[i]) + "' was supposed to be " +
-                                " before '" + JSON.stringify(results[key][entry_pos]) + "'");
+                error_text.push(queryName + "==> '" + JSON.stringify(entry[i]) + "' was supposed " +
+                                "to be before '" + JSON.stringify(results[key][entry_pos]) + "'");
             } else {
                 prev_pos = entry_pos;
             }
         }
     }
-    if (error_text.length === 0 && should_fail === true) {
-        errors += 1;
-        console.error("FAILED");
-        console.error("==> Test was supposed to fail but all items were found...");
-    } else if (error_text.length !== 0 && should_fail === false) {
-        errors += 1;
-        console.error("FAILED");
-        console.error(error_text.join("\n"));
+    return error_text;
+}
+
+function checkResult(error_text, loadedFile, displaySuccess) {
+    if (error_text.length === 0 && loadedFile.should_fail === true) {
+        console.log("FAILED");
+        console.log("==> Test was supposed to fail but all items were found...");
+    } else if (error_text.length !== 0 && loadedFile.should_fail === false) {
+        console.log("FAILED");
+        console.log(error_text.join("\n"));
     } else {
-        console.log("OK");
+        if (displaySuccess) {
+            console.log("OK");
+        }
+        return 0;
     }
-    return errors;
+    return 1;
+}
+
+function runChecks(testFile, loaded, index) {
+    var loadedFile = loadContent(
+        readFile(testFile) + 'exports.QUERY = QUERY;exports.EXPECTED = EXPECTED;');
+
+    const expected = loadedFile.EXPECTED;
+    const query = loadedFile.QUERY;
+
+    if (Array.isArray(query)) {
+        if (!Array.isArray(expected)) {
+            console.log("FAILED");
+            console.log("==> If QUERY variable is an array, EXPECTED should be an array too");
+            return 1;
+        } else if (query.length !== expected.length) {
+            console.log("FAILED");
+            console.log("==> QUERY variable should have the same length as EXPECTED");
+            return 1;
+        }
+        for (var i = 0; i < query.length; ++i) {
+            var error_text = runSearch(query[i], expected[i], index, loaded, loadedFile,
+                "[ query `" + query[i] + "`]");
+            if (checkResult(error_text, loadedFile, false) !== 0) {
+                return 1;
+            }
+        }
+        console.log("OK");
+        return 0;
+    }
+    var error_text = runSearch(query, expected, index, loaded, loadedFile, "");
+    return checkResult(error_text, loadedFile, true);
 }
 
 function load_files(doc_folder, resource_suffix, crate) {
@@ -349,7 +381,7 @@ function parseOptions(args) {
             || args[i] === "--crate-name") {
             i += 1;
             if (i >= args.length) {
-                console.error("Missing argument after `" + args[i - 1] + "` option.");
+                console.log("Missing argument after `" + args[i - 1] + "` option.");
                 return null;
             }
             opts[correspondances[args[i - 1]]] = args[i];
@@ -357,17 +389,17 @@ function parseOptions(args) {
             showHelp();
             process.exit(0);
         } else {
-            console.error("Unknown option `" + args[i] + "`.");
-            console.error("Use `--help` to see the list of options");
+            console.log("Unknown option `" + args[i] + "`.");
+            console.log("Use `--help` to see the list of options");
             return null;
         }
     }
     if (opts["doc_folder"].length < 1) {
-        console.error("Missing `--doc-folder` option.");
+        console.log("Missing `--doc-folder` option.");
     } else if (opts["crate_name"].length < 1) {
-        console.error("Missing `--crate-name` option.");
+        console.log("Missing `--crate-name` option.");
     } else if (opts["test_folder"].length < 1 && opts["test_file"].length < 1) {
-        console.error("At least one of `--test-folder` or `--test-file` option is required.");
+        console.log("At least one of `--test-folder` or `--test-file` option is required.");
     } else {
         return opts;
     }

--- a/src/tools/rustdoc-js/tester.js
+++ b/src/tools/rustdoc-js/tester.js
@@ -218,7 +218,7 @@ function lookForEntry(entry, data) {
     return null;
 }
 
-function loadMainJsAndIndex(mainJs, searchIndex, crate) {
+function loadMainJsAndIndex(mainJs, searchIndex, storageJs, crate) {
     if (searchIndex[searchIndex.length - 1].length === 0) {
         searchIndex.pop();
     }
@@ -241,6 +241,7 @@ function loadMainJsAndIndex(mainJs, searchIndex, crate) {
     ALIASES = {};
     finalJS += 'window = { "currentCrate": "' + crate + '" };\n';
     finalJS += 'var rootPath = "../";\n';
+    finalJS += loadThings(["onEach"], 'function', extractFunction, storageJs);
     finalJS += loadThings(arraysToLoad, 'array', extractArrayVariable, mainJs);
     finalJS += loadThings(variablesToLoad, 'variable', extractVariable, mainJs);
     finalJS += loadThings(functionsToLoad, 'function', extractFunction, mainJs);
@@ -338,10 +339,11 @@ function runChecks(testFile, loaded, index) {
 
 function load_files(doc_folder, resource_suffix, crate) {
     var mainJs = readFile(path.join(doc_folder, "main" + resource_suffix + ".js"));
+    var storageJs = readFile(path.join(doc_folder, "storage" + resource_suffix + ".js"));
     var searchIndex = readFile(
         path.join(doc_folder, "search-index" + resource_suffix + ".js")).split("\n");
 
-    return loadMainJsAndIndex(mainJs, searchIndex, crate);
+    return loadMainJsAndIndex(mainJs, searchIndex, storageJs, crate);
 }
 
 function showHelp() {

--- a/src/tools/rustdoc-js/tester.js
+++ b/src/tools/rustdoc-js/tester.js
@@ -218,7 +218,7 @@ function lookForEntry(entry, data) {
     return null;
 }
 
-function loadMainJsAndIndex(mainJs, aliases, searchIndex, crate) {
+function loadMainJsAndIndex(mainJs, searchIndex, crate) {
     if (searchIndex[searchIndex.length - 1].length === 0) {
         searchIndex.pop();
     }
@@ -238,17 +238,15 @@ function loadMainJsAndIndex(mainJs, aliases, searchIndex, crate) {
     var functionsToLoad = ["buildHrefAndPath", "pathSplitter", "levenshtein", "validateResult",
                            "handleAliases", "getQuery", "buildIndex", "execQuery", "execSearch"];
 
+    ALIASES = {};
     finalJS += 'window = { "currentCrate": "' + crate + '" };\n';
     finalJS += 'var rootPath = "../";\n';
-    finalJS += aliases;
     finalJS += loadThings(arraysToLoad, 'array', extractArrayVariable, mainJs);
     finalJS += loadThings(variablesToLoad, 'variable', extractVariable, mainJs);
     finalJS += loadThings(functionsToLoad, 'function', extractFunction, mainJs);
 
     var loaded = loadContent(finalJS);
     var index = loaded.buildIndex(searchIndex.rawSearchIndex);
-    // We make it "global" so that the "loaded.execSearch" function will find it.
-    rawSearchIndex = searchIndex.rawSearchIndex;
 
     return [loaded, index];
 }
@@ -340,11 +338,10 @@ function runChecks(testFile, loaded, index) {
 
 function load_files(doc_folder, resource_suffix, crate) {
     var mainJs = readFile(path.join(doc_folder, "main" + resource_suffix + ".js"));
-    var aliases = readFile(path.join(doc_folder, "aliases" + resource_suffix + ".js"));
     var searchIndex = readFile(
         path.join(doc_folder, "search-index" + resource_suffix + ".js")).split("\n");
 
-    return loadMainJsAndIndex(mainJs, aliases, searchIndex, crate);
+    return loadMainJsAndIndex(mainJs, searchIndex, crate);
 }
 
 function showHelp() {


### PR DESCRIPTION
After [this message](https://github.com/rust-lang/rust/issues/50146#issuecomment-496601755), I realized that the **doc alias**. So this PR does the followings:

 * Align the alias discovery on items added into the search-index. It brings a few nice advantages:
   * Instead of cloning the data between the two (in rustdoc source code), we now have the search-index one and aliases which reference to the first one. So we go from one big map containing a lot of duplicated data to just integers...
 * In the front-end (main.js), I improved the code around aliases to allow them to go through the same transformation as other items when we show the search results.
 * Improve the search tester in order to perform multiple requests into one file (I think it's better in this case than having a file for each case considering how many there are...)
    * I also had to add the new function inside the tester (`handleAliases`)

Once this PR is merged, I intend to finally stabilize this feature.

r? @ollie27 

cc @rust-lang/rustdoc 