### PR TITLE
SipHasher with keys initialized to 0 should just use new()

### DIFF
--- a/src/test/ui/deriving/deriving-hash.rs
+++ b/src/test/ui/deriving/deriving-hash.rs
@@ -24,7 +24,7 @@ struct Person {
 enum E { A=1, B }
 
 fn hash<T: Hash>(t: &T) -> u64 {
-    let mut s = SipHasher::new_with_keys(0, 0);
+    let mut s = SipHasher::new();
     t.hash(&mut s);
     s.finish()
 }

--- a/src/test/ui/issues/issue-16530.rs
+++ b/src/test/ui/issues/issue-16530.rs
@@ -7,9 +7,9 @@ use std::hash::{SipHasher, Hasher, Hash};
 struct Empty;
 
 pub fn main() {
-    let mut s1 = SipHasher::new_with_keys(0, 0);
+    let mut s1 = SipHasher::new();
     Empty.hash(&mut s1);
-    let mut s2 = SipHasher::new_with_keys(0, 0);
+    let mut s2 = SipHasher::new();
     Empty.hash(&mut s2);
     assert_eq!(s1.finish(), s2.finish());
 }


### PR DESCRIPTION
I believe that is what the `new()` is for, for good reasons.