### PR TITLE
Remove pointer comparison check before doing memcmp

### DIFF
--- a/src/libcore/slice/mod.rs
+++ b/src/libcore/slice/mod.rs
@@ -5859,9 +5859,6 @@ where
         if self.len() != other.len() {
             return false;
         }
-        if self.as_ptr() == other.as_ptr() {
-            return true;
-        }
         unsafe {
             let size = mem::size_of_val(self);
             memcmp(self.as_ptr() as *const u8, other.as_ptr() as *const u8, size) == 0

--- a/src/test/codegen/slice-ref-ptr-check.rs
+++ b/src/test/codegen/slice-ref-ptr-check.rs
@@ -1,0 +1,15 @@
+// ignore-tidy-linelength
+// compile-flags: -C opt-level=3
+
+#![crate_type = "lib"]
+
+// https://github.com/rust-lang/rust/issues/71602
+
+// CHECK-LABEL: @is_zero_slice
+#[no_mangle]
+pub fn is_zero_slice(data: &[u8; 4]) -> bool {
+    // CHECK: start
+    // CHECK-NOT: %_8.i.i.i = icmp eq [4 x i8]* %data, getelementptr inbounds (<{ [4 x i8] }>, <{ [4 x i8] }>* @alloc2, i64 0, i32 0)
+    // CHECK: ret
+    *data == [0; 4]
+}


### PR DESCRIPTION
The hypothesis is that removing this pointer check will help improve performance since in most cases slices won't be compared with themselves.

Closes #71602 