### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3977,7 +3977,6 @@ name = "rustc_middle"
 version = "0.0.0"
 dependencies = [
  "arena",
- "backtrace",
  "bitflags",
  "byteorder",
  "log",

--- a/src/librustc_middle/Cargo.toml
+++ b/src/librustc_middle/Cargo.toml
@@ -30,7 +30,6 @@ rustc_index = { path = "../librustc_index" }
 rustc_serialize = { path = "../libserialize", package = "serialize" }
 rustc_ast = { path = "../librustc_ast" }
 rustc_span = { path = "../librustc_span" }
-backtrace = "0.3.40"
 byteorder = { version = "1.3" }
 smallvec = { version = "1.0", features = ["union", "may_dangle"] }
 measureme = "0.7.1"

--- a/src/librustc_middle/lib.rs
+++ b/src/librustc_middle/lib.rs
@@ -23,6 +23,7 @@
 //! This API is completely unstable and subject to change.
 
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/")]
+#![feature(backtrace)]
 #![feature(bool_to_option)]
 #![feature(box_patterns)]
 #![feature(box_syntax)]

--- a/src/librustc_middle/mir/interpret/error.rs
+++ b/src/librustc_middle/mir/interpret/error.rs
@@ -439,10 +439,10 @@ impl fmt::Display for UndefinedBehaviorInfo {
             DerefFunctionPointer(a) => write!(f, "accessing {} which contains a function", a),
             ValidationFailure(ref err) => write!(f, "type validation failed: {}", err),
             InvalidBool(b) => {
-                write!(f, "interpreting an invalid 8-bit value as a bool: 0x{:2x}", b)
+                write!(f, "interpreting an invalid 8-bit value as a bool: 0x{:02x}", b)
             }
             InvalidChar(c) => {
-                write!(f, "interpreting an invalid 32-bit value as a char: 0x{:8x}", c)
+                write!(f, "interpreting an invalid 32-bit value as a char: 0x{:08x}", c)
             }
             InvalidDiscriminant(val) => write!(f, "enum value has invalid discriminant: {}", val),
             InvalidFunctionPointer(p) => {

--- a/src/librustc_mir/const_eval/error.rs
+++ b/src/librustc_mir/const_eval/error.rs
@@ -52,7 +52,7 @@ impl Error for ConstEvalErrKind {}
 /// Should be called only if the error is actually going to to be reported!
 pub fn error_to_const_error<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>>(
     ecx: &InterpCx<'mir, 'tcx, M>,
-    mut error: InterpErrorInfo<'tcx>,
+    error: InterpErrorInfo<'tcx>,
 ) -> ConstEvalErr<'tcx> {
     error.print_backtrace();
     let stacktrace = ecx.generate_stacktrace();

--- a/src/librustc_trait_selection/traits/util.rs
+++ b/src/librustc_trait_selection/traits/util.rs
@@ -217,7 +217,6 @@ pub fn impl_trait_ref_and_oblig<'a, 'tcx>(
     (impl_trait_ref, impl_obligations)
 }
 
-/// See [`super::obligations_for_generics`].
 pub fn predicates_for_generics<'tcx>(
     cause: ObligationCause<'tcx>,
     recursion_depth: usize,

--- a/src/test/ui/process-termination/process-termination-blocking-io.rs
+++ b/src/test/ui/process-termination/process-termination-blocking-io.rs
@@ -2,6 +2,7 @@
 // https://github.com/fortanix/rust-sgx/issues/109
 
 // run-pass
+// ignore-wasm no threads support
 
 use std::{net::TcpListener, sync::mpsc, thread};
 

--- a/src/test/ui/process-termination/process-termination-blocking-io.rs
+++ b/src/test/ui/process-termination/process-termination-blocking-io.rs
@@ -1,0 +1,18 @@
+// program should terminate even if a thread is blocked on I/O.
+// https://github.com/fortanix/rust-sgx/issues/109
+
+// run-pass
+
+use std::{net::TcpListener, sync::mpsc, thread};
+
+fn main() {
+    let (tx, rx) = mpsc::channel();
+    thread::spawn(move || {
+        let listen = TcpListener::bind("0:0").unwrap();
+        tx.send(()).unwrap();
+        while let Ok(_) = listen.accept() {}
+    });
+    rx.recv().unwrap();
+    for _ in 0..3 { thread::yield_now(); }
+    println!("Exiting main thread");
+}

--- a/src/test/ui/process-termination/process-termination-simple.rs
+++ b/src/test/ui/process-termination/process-termination-simple.rs
@@ -1,6 +1,7 @@
 // program should terminate when std::process::exit is called from any thread
 
 // run-pass
+// ignore-wasm no threads support
 
 use std::{process, thread};
 

--- a/src/test/ui/process-termination/process-termination-simple.rs
+++ b/src/test/ui/process-termination/process-termination-simple.rs
@@ -1,0 +1,12 @@
+// program should terminate when std::process::exit is called from any thread
+
+// run-pass
+
+use std::{process, thread};
+
+fn main() {
+    let h = thread::spawn(|| {
+        process::exit(0);
+    });
+    let _ = h.join();
+}


### PR DESCRIPTION
Successful merges:

 - #70416 (Process termination test for SGX)
 - #71712 (Miri: port error backtraces to std::backtrace)
 - #71739 (remove obsolete comment)
 - #71747 (Remove deadcode in eval_mir_constant_to_operand)
 - #71749 (fix Miri error message padding)

Failed merges:


r? @ghost