### PR TITLE
Don't copy bytecode files into the incr. comp. cache.

### DIFF
--- a/src/librustc_codegen_ssa/back/write.rs
+++ b/src/librustc_codegen_ssa/back/write.rs
@@ -23,7 +23,7 @@ use rustc_hir::def_id::{CrateNum, LOCAL_CRATE};
 use rustc_incremental::{
     copy_cgu_workproducts_to_incr_comp_cache_dir, in_incr_comp_dir, in_incr_comp_dir_sess,
 };
-use rustc_middle::dep_graph::{WorkProduct, WorkProductFileKind, WorkProductId};
+use rustc_middle::dep_graph::{WorkProduct, WorkProductId};
 use rustc_middle::middle::cstore::EncodedMetadata;
 use rustc_middle::middle::exported_symbols::SymbolExportLevel;
 use rustc_middle::ty::TyCtxt;
@@ -478,10 +478,7 @@ fn copy_all_cgu_workproducts_to_incr_comp_cache_dir(
         let mut files = vec![];
 
         if let Some(ref path) = module.object {
-            files.push((WorkProductFileKind::Object, path.clone()));
-        }
-        if let Some(ref path) = module.bytecode {
-            files.push((WorkProductFileKind::Bytecode, path.clone()));
+            files.push(path.clone());
         }
 
         if let Some((id, product)) =
@@ -818,20 +815,9 @@ fn execute_copy_from_cache_work_item<B: ExtraBackendMethods>(
 ) -> Result<WorkItemResult<B>, FatalError> {
     let incr_comp_session_dir = cgcx.incr_comp_session_dir.as_ref().unwrap();
     let mut object = None;
-    let mut bytecode = None;
-    for (kind, saved_file) in &module.source.saved_files {
-        let obj_out = match kind {
-            WorkProductFileKind::Object => {
-                let path = cgcx.output_filenames.temp_path(OutputType::Object, Some(&module.name));
-                object = Some(path.clone());
-                path
-            }
-            WorkProductFileKind::Bytecode => {
-                let path = cgcx.output_filenames.temp_path(OutputType::Bitcode, Some(&module.name));
-                bytecode = Some(path.clone());
-                path
-            }
-        };
+    for saved_file in &module.source.saved_files {
+        let obj_out = cgcx.output_filenames.temp_path(OutputType::Object, Some(&module.name));
+        object = Some(obj_out.clone());
         let source_file = in_incr_comp_dir(&incr_comp_session_dir, &saved_file);
         debug!(
             "copying pre-existing module `{}` from {:?} to {}",
@@ -851,13 +837,12 @@ fn execute_copy_from_cache_work_item<B: ExtraBackendMethods>(
     }
 
     assert_eq!(object.is_some(), module_config.emit_obj != EmitObj::None);
-    assert_eq!(bytecode.is_some(), module_config.emit_bc);
 
     Ok(WorkItemResult::Compiled(CompiledModule {
         name: module.name,
         kind: ModuleKind::Regular,
         object,
-        bytecode,
+        bytecode: None,
     }))
 }
 

--- a/src/librustc_incremental/persist/load.rs
+++ b/src/librustc_incremental/persist/load.rs
@@ -134,7 +134,7 @@ pub fn load_dep_graph(sess: &Session) -> DepGraphFuture {
 
             for swp in work_products {
                 let mut all_files_exist = true;
-                for &(_, ref file_name) in swp.work_product.saved_files.iter() {
+                for file_name in swp.work_product.saved_files.iter() {
                     let path = in_incr_comp_dir_sess(sess, file_name);
                     if !path.exists() {
                         all_files_exist = false;

--- a/src/librustc_incremental/persist/save.rs
+++ b/src/librustc_incremental/persist/save.rs
@@ -74,9 +74,9 @@ pub fn save_work_product_index(
         if !new_work_products.contains_key(id) {
             work_product::delete_workproduct_files(sess, wp);
             debug_assert!(
-                wp.saved_files.iter().all(|&(_, ref file_name)| {
-                    !in_incr_comp_dir_sess(sess, file_name).exists()
-                })
+                wp.saved_files
+                    .iter()
+                    .all(|file_name| { !in_incr_comp_dir_sess(sess, file_name).exists() })
             );
         }
     }
@@ -85,7 +85,7 @@ pub fn save_work_product_index(
     debug_assert!({
         new_work_products
             .iter()
-            .flat_map(|(_, wp)| wp.saved_files.iter().map(|&(_, ref name)| name))
+            .flat_map(|(_, wp)| wp.saved_files.iter())
             .map(|name| in_incr_comp_dir_sess(sess, name))
             .all(|path| path.exists())
     });

--- a/src/librustc_incremental/persist/work_product.rs
+++ b/src/librustc_incremental/persist/work_product.rs
@@ -2,7 +2,7 @@
 
 use crate::persist::fs::*;
 use rustc_fs_util::link_or_copy;
-use rustc_middle::dep_graph::{WorkProduct, WorkProductFileKind, WorkProductId};
+use rustc_middle::dep_graph::{WorkProduct, WorkProductId};
 use rustc_session::Session;
 use std::fs as std_fs;
 use std::path::PathBuf;
@@ -10,22 +10,18 @@ use std::path::PathBuf;
 pub fn copy_cgu_workproducts_to_incr_comp_cache_dir(
     sess: &Session,
     cgu_name: &str,
-    files: &[(WorkProductFileKind, PathBuf)],
+    files: &[PathBuf],
 ) -> Option<(WorkProductId, WorkProduct)> {
     debug!("copy_cgu_workproducts_to_incr_comp_cache_dir({:?},{:?})", cgu_name, files);
     sess.opts.incremental.as_ref()?;
 
     let saved_files = files
         .iter()
-        .map(|&(kind, ref path)| {
-            let extension = match kind {
-                WorkProductFileKind::Object => "o",
-                WorkProductFileKind::Bytecode => "bc",
-            };
-            let file_name = format!("{}.{}", cgu_name, extension);
+        .map(|path| {
+            let file_name = format!("{}.o", cgu_name);
             let path_in_incr_dir = in_incr_comp_dir_sess(sess, &file_name);
             match link_or_copy(path, &path_in_incr_dir) {
-                Ok(_) => Some((kind, file_name)),
+                Ok(_) => Some(file_name),
                 Err(err) => {
                     sess.warn(&format!(
                         "error copying object file `{}` \
@@ -47,7 +43,7 @@ pub fn copy_cgu_workproducts_to_incr_comp_cache_dir(
 }
 
 pub fn delete_workproduct_files(sess: &Session, work_product: &WorkProduct) {
-    for &(_, ref file_name) in &work_product.saved_files {
+    for file_name in &work_product.saved_files {
         let path = in_incr_comp_dir_sess(sess, file_name);
         match std_fs::remove_file(&path) {
             Ok(()) => {}

--- a/src/librustc_middle/dep_graph/mod.rs
+++ b/src/librustc_middle/dep_graph/mod.rs
@@ -12,7 +12,7 @@ mod dep_node;
 pub(crate) use rustc_query_system::dep_graph::DepNodeParams;
 pub use rustc_query_system::dep_graph::{
     debug, hash_result, DepContext, DepNodeColor, DepNodeIndex, SerializedDepNodeIndex,
-    WorkProduct, WorkProductFileKind, WorkProductId,
+    WorkProduct, WorkProductId,
 };
 
 pub use dep_node::{label_strs, DepConstructor, DepKind, DepNode, DepNodeExt};

--- a/src/librustc_query_system/dep_graph/graph.rs
+++ b/src/librustc_query_system/dep_graph/graph.rs
@@ -861,13 +861,7 @@ impl<K: DepKind> DepGraph<K> {
 pub struct WorkProduct {
     pub cgu_name: String,
     /// Saved files associated with this CGU.
-    pub saved_files: Vec<(WorkProductFileKind, String)>,
-}
-
-#[derive(Clone, Copy, Debug, RustcEncodable, RustcDecodable, PartialEq)]
-pub enum WorkProductFileKind {
-    Object,
-    Bytecode,
+    pub saved_files: Vec<String>,
 }
 
 #[derive(Clone)]

--- a/src/librustc_query_system/dep_graph/mod.rs
+++ b/src/librustc_query_system/dep_graph/mod.rs
@@ -6,7 +6,6 @@ mod query;
 mod serialized;
 
 pub use dep_node::{DepNode, DepNodeParams, WorkProductId};
-pub use graph::WorkProductFileKind;
 pub use graph::{hash_result, DepGraph, DepNodeColor, DepNodeIndex, TaskDeps, WorkProduct};
 pub use prev::PreviousDepGraph;
 pub use query::DepGraphQuery;


### PR DESCRIPTION
It's no longer necessary now that bitcode is embedded into object files.

This change meant that `WorkProductFileKind::Bytecode` is no longer
necessary, which means that type is no longer necessary, which allowed
several places in the code to become simpler.

This commit was written by @nnethercote in https://github.com/rust-lang/rust/pull/70458 but that didn't land. In the meantime though we managed to land it in https://github.com/rust-lang/rust/pull/71528 and that doesn't seem to be causing too many fires, so I'm re-sending this patch!