### PR TITLE
fix doc reference

### DIFF
--- a/src/librustc_hir/hir.rs
+++ b/src/librustc_hir/hir.rs
@@ -2050,7 +2050,7 @@ pub struct Param<'hir> {
 pub struct FnDecl<'hir> {
     /// The types of the function's parameters.
     ///
-    /// Additional argument data is stored in the function's [body](Body::parameters).
+    /// Additional argument data is stored in the function's [body](Body::params).
     pub inputs: &'hir [Ty<'hir>],
     pub output: FnRetTy<'hir>,
     pub c_variadic: bool,


### PR DESCRIPTION
Should of been in e0ce9f8c0a97e5949c9cadd220279d6969289daa,
but that had a typo.