### PR TITLE
Document unsafety for `*const T` and `*mut T`

### DIFF
--- a/src/libcore/ptr/const_ptr.rs
+++ b/src/libcore/ptr/const_ptr.rs
@@ -3,8 +3,6 @@ use crate::cmp::Ordering::{self, Equal, Greater, Less};
 use crate::intrinsics;
 use crate::mem;
 
-// ignore-tidy-undocumented-unsafe
-
 #[lang = "const_ptr"]
 impl<T: ?Sized> *const T {
     /// Returns `true` if the pointer is null.
@@ -215,6 +213,7 @@ impl<T: ?Sized> *const T {
     where
         T: Sized,
     {
+        // SAFETY: the `arith_offset` intrinsic has no prerequisites to be called.
         unsafe { intrinsics::arith_offset(self, count) }
     }
 
@@ -702,6 +701,7 @@ impl<T: ?Sized> *const T {
         if !align.is_power_of_two() {
             panic!("align_offset: align is not a power-of-two");
         }
+        // SAFETY: `align` has been checked to be a power of 2 above
         unsafe { align_offset(self, align) }
     }
 }
@@ -729,6 +729,8 @@ impl<T> *const [T] {
     #[unstable(feature = "slice_ptr_len", issue = "71146")]
     #[rustc_const_unstable(feature = "const_slice_ptr_len", issue = "71146")]
     pub const fn len(self) -> usize {
+        // SAFETY: this is safe because `*const [T]` and `FatPtr<T>` have the same layout.
+        // Only `std` can make this guarantee.
         unsafe { Repr { rust: self }.raw }.len
     }
 }

--- a/src/libcore/ptr/mut_ptr.rs
+++ b/src/libcore/ptr/mut_ptr.rs
@@ -2,8 +2,6 @@ use super::*;
 use crate::cmp::Ordering::{self, Equal, Greater, Less};
 use crate::intrinsics;
 
-// ignore-tidy-undocumented-unsafe
-
 #[lang = "mut_ptr"]
 impl<T: ?Sized> *mut T {
     /// Returns `true` if the pointer is null.
@@ -208,6 +206,7 @@ impl<T: ?Sized> *mut T {
     where
         T: Sized,
     {
+        // SAFETY: the `arith_offset` intrinsic has no prerequisites to be called.
         unsafe { intrinsics::arith_offset(self, count) as *mut T }
     }
 
@@ -890,6 +889,7 @@ impl<T: ?Sized> *mut T {
         if !align.is_power_of_two() {
             panic!("align_offset: align is not a power-of-two");
         }
+        // SAFETY: `align` has been checked to be a power of 2 above
         unsafe { align_offset(self, align) }
     }
 }
@@ -917,6 +917,8 @@ impl<T> *mut [T] {
     #[unstable(feature = "slice_ptr_len", issue = "71146")]
     #[rustc_const_unstable(feature = "const_slice_ptr_len", issue = "71146")]
     pub const fn len(self) -> usize {
+        // SAFETY: this is safe because `*const [T]` and `FatPtr<T>` have the same layout.
+        // Only `std` can make this guarantee.
         unsafe { Repr { rust_mut: self }.raw }.len
     }
 }


### PR DESCRIPTION
Helps with #66219
r? @Mark-Simulacrum 