### PR TITLE
Mark query function as must_use.

### DIFF
--- a/src/librustc_codegen_ssa/base.rs
+++ b/src/librustc_codegen_ssa/base.rs
@@ -539,7 +539,7 @@ pub fn codegen_crate<B: ExtraBackendMethods>(
     // unnecessarily.
     if tcx.dep_graph.is_fully_enabled() {
         for cgu in codegen_units {
-            tcx.codegen_unit(cgu.name());
+            tcx.ensure().codegen_unit(cgu.name());
         }
     }
 

--- a/src/librustc_metadata/rmeta/encoder.rs
+++ b/src/librustc_metadata/rmeta/encoder.rs
@@ -1729,8 +1729,8 @@ struct PrefetchVisitor<'tcx> {
 impl<'tcx> PrefetchVisitor<'tcx> {
     fn prefetch_mir(&self, def_id: LocalDefId) {
         if self.mir_keys.contains(&def_id) {
-            self.tcx.optimized_mir(def_id);
-            self.tcx.promoted_mir(def_id);
+            self.tcx.ensure().optimized_mir(def_id);
+            self.tcx.ensure().promoted_mir(def_id);
         }
     }
 }

--- a/src/librustc_middle/ty/query/plumbing.rs
+++ b/src/librustc_middle/ty/query/plumbing.rs
@@ -430,6 +430,7 @@ macro_rules! define_queries_inner {
 
             $($(#[$attr])*
             #[inline(always)]
+            #[must_use]
             pub fn $name(self, key: query_helper_param_ty!($($K)*))
                 -> <queries::$name<$tcx> as QueryConfig<TyCtxt<$tcx>>>::Stored
             {

--- a/src/librustc_mir/transform/check_unsafety.rs
+++ b/src/librustc_mir/transform/check_unsafety.rs
@@ -617,7 +617,7 @@ pub fn check_unsafety(tcx: TyCtxt<'_>, def_id: DefId) {
             }
             UnsafetyViolationKind::BorrowPacked(lint_hir_id) => {
                 if let Some(impl_def_id) = builtin_derive_def_id(tcx, def_id) {
-                    tcx.unsafe_derive_on_repr_packed(impl_def_id);
+                    tcx.ensure().unsafe_derive_on_repr_packed(impl_def_id);
                 } else {
                     tcx.struct_span_lint_hir(
                         SAFE_PACKED_BORROWS,

--- a/src/librustc_passes/check_attr.rs
+++ b/src/librustc_passes/check_attr.rs
@@ -77,7 +77,7 @@ impl CheckAttrVisitor<'tcx> {
         }
 
         if matches!(target, Target::Fn | Target::Method(_) | Target::ForeignFn) {
-            self.tcx.codegen_fn_attrs(self.tcx.hir().local_def_id(hir_id));
+            self.tcx.ensure().codegen_fn_attrs(self.tcx.hir().local_def_id(hir_id));
         }
 
         self.check_repr(attrs, span, target, item, hir_id);
@@ -390,7 +390,7 @@ impl CheckAttrVisitor<'tcx> {
             }
         }
         if target == Target::Closure {
-            self.tcx.codegen_fn_attrs(self.tcx.hir().local_def_id(expr.hir_id));
+            self.tcx.ensure().codegen_fn_attrs(self.tcx.hir().local_def_id(expr.hir_id));
         }
     }
 

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -1748,11 +1748,11 @@ pub fn check_item_type<'tcx>(tcx: TyCtxt<'tcx>, it: &'tcx hir::Item<'tcx>) {
         // Consts can play a role in type-checking, so they are included here.
         hir::ItemKind::Static(..) => {
             let def_id = tcx.hir().local_def_id(it.hir_id);
-            tcx.typeck_tables_of(def_id);
+            tcx.ensure().typeck_tables_of(def_id);
             maybe_check_static_with_link_section(tcx, def_id, it.span);
         }
         hir::ItemKind::Const(..) => {
-            tcx.typeck_tables_of(tcx.hir().local_def_id(it.hir_id));
+            tcx.ensure().typeck_tables_of(tcx.hir().local_def_id(it.hir_id));
         }
         hir::ItemKind::Enum(ref enum_definition, _) => {
             check_enum(tcx, it.span, &enum_definition.variants, it.hir_id);
@@ -2670,7 +2670,7 @@ pub fn check_enum<'tcx>(
 
     for v in vs {
         if let Some(ref e) = v.disr_expr {
-            tcx.typeck_tables_of(tcx.hir().local_def_id(e.hir_id));
+            tcx.ensure().typeck_tables_of(tcx.hir().local_def_id(e.hir_id));
         }
     }
 

--- a/src/librustc_typeck/coherence/mod.rs
+++ b/src/librustc_typeck/coherence/mod.rs
@@ -156,7 +156,7 @@ pub fn provide(providers: &mut Providers<'_>) {
 fn coherent_trait(tcx: TyCtxt<'_>, def_id: DefId) {
     // Trigger building the specialization graph for the trait. This will detect and report any
     // overlap errors.
-    tcx.specialization_graph_of(def_id);
+    tcx.ensure().specialization_graph_of(def_id);
 
     let impls = tcx.hir().trait_impls(def_id);
     for &hir_id in impls {


### PR DESCRIPTION
And use the `ensure()` version when the result is not needed.