### PR TITLE
Stable backports for 1.43.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2249,9 +2249,9 @@ checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
 name = "openssl-src"
-version = "111.6.1+1.1.1d"
+version = "111.9.0+1.1.1g"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91b04cb43c1a8a90e934e0cd612e2a5715d976d2d6cff4490278a0cddf35005"
+checksum = "a2dbe10ddd1eb335aba3780eb2eaa13e1b7b441d2562fd962398740927f39ec4"
 dependencies = [
  "cc",
 ]

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,13 @@
+Version 1.43.1 (2020-05-07)
+===========================
+
+* [Updated openssl-src to 1.1.1g for CVE-2020-1967.][71430]
+* [Fixed the stabilization of AVX-512 features.][71473]
+
+[71430]: https://github.com/rust-lang/rust/pull/71430
+[71473]: https://github.com/rust-lang/rust/issues/71473
+
+
 Version 1.43.0 (2020-04-23)
 ==========================
 

--- a/src/bootstrap/channel.rs
+++ b/src/bootstrap/channel.rs
@@ -13,7 +13,7 @@ use build_helper::output;
 use crate::Build;
 
 // The version number
-pub const CFG_RELEASE_NUM: &str = "1.43.0";
+pub const CFG_RELEASE_NUM: &str = "1.43.1";
 
 pub struct GitInfo {
     inner: Option<Info>,

--- a/src/libcore/internal_macros.rs
+++ b/src/libcore/internal_macros.rs
@@ -117,3 +117,8 @@ macro_rules! impl_fn_for_zst {
         )+
     }
 }
+
+macro_rules! llvm_asm {
+    // Redirect to asm! for stdarch in stable 1.43
+    ($($arg:tt)*) => { $crate::asm!($($arg)*) }
+}


### PR DESCRIPTION
- Update openssl-src to 1.1.1g #71430
- Update stdarch submodule #71495

r? @Mark-Simulacrum 