### PR TITLE
Enable `cfg` predicate for `target_feature = "crt-static"` only if the target supports it

### DIFF
--- a/src/librustc_interface/util.rs
+++ b/src/librustc_interface/util.rs
@@ -49,7 +49,7 @@ pub fn add_configuration(
 
     cfg.extend(codegen_backend.target_features(sess).into_iter().map(|feat| (tf, Some(feat))));
 
-    if sess.crt_static_feature(None) {
+    if sess.crt_static(None) {
         cfg.insert((tf, Some(Symbol::intern("crt-static"))));
     }
 }

--- a/src/librustc_session/session.rs
+++ b/src/librustc_session/session.rs
@@ -553,16 +553,11 @@ impl Session {
 
     /// Check whether this compile session and crate type use static crt.
     pub fn crt_static(&self, crate_type: Option<CrateType>) -> bool {
-        // If the target does not opt in to crt-static support, use its default.
-        if self.target.target.options.crt_static_respected {
-            self.crt_static_feature(crate_type)
-        } else {
-            self.target.target.options.crt_static_default
+        if !self.target.target.options.crt_static_respected {
+            // If the target does not opt in to crt-static support, use its default.
+            return self.target.target.options.crt_static_default;
         }
-    }
 
-    /// Check whether this compile session and crate type use `crt-static` feature.
-    pub fn crt_static_feature(&self, crate_type: Option<CrateType>) -> bool {
         let requested_features = self.opts.cg.target_feature.split(',');
         let found_negative = requested_features.clone().any(|r| r == "-crt-static");
         let found_positive = requested_features.clone().any(|r| r == "+crt-static");

--- a/src/test/ui/crt-static-on-works.rs
+++ b/src/test/ui/crt-static-on-works.rs
@@ -1,9 +1,6 @@
 // run-pass
-
-#![allow(stable_features)]
-// compile-flags:-C target-feature=+crt-static -Z unstable-options
-
-#![feature(cfg_target_feature)]
+// compile-flags:-C target-feature=+crt-static
+// only-msvc
 
 #[cfg(target_feature = "crt-static")]
 fn main() {}


### PR DESCRIPTION
That's what all other `target_feature`s do.