### PR TITLE
Hide some members of TypeckTables behind queries

### DIFF
--- a/src/librustc_middle/arena.rs
+++ b/src/librustc_middle/arena.rs
@@ -67,6 +67,10 @@ macro_rules! arena_types {
             [] attribute: rustc_ast::ast::Attribute,
             [] name_set: rustc_data_structures::fx::FxHashSet<rustc_ast::ast::Name>,
             [] hir_id_set: rustc_hir::HirIdSet,
+            // Sub-parts of the TypeckTables
+            [decode] concrete_opaque_types: rustc_data_structures::fx::FxHashMap<rustc_hir::def_id::DefId, rustc_middle::ty::ResolvedOpaqueTy<$tcx>>,
+            [decode] upvar_list: rustc_middle::ty::UpvarListMap,
+            [decode] user_provided_sigs: rustc_data_structures::fx::FxHashMap<rustc_hir::def_id::DefId, rustc_middle::ty::CanonicalPolyFnSig<$tcx>>,
 
             // Interned types
             [] tys: rustc_middle::ty::TyS<$tcx>,

--- a/src/librustc_middle/query/mod.rs
+++ b/src/librustc_middle/query/mod.rs
@@ -495,6 +495,11 @@ rustc_queries! {
             desc { |tcx| "user_provided_sigs `{}`", tcx.def_path_str(key.to_def_id()) }
             cache_on_disk_if { true }
         }
+
+        query upvar_list(key: LocalDefId) -> &'tcx ty::UpvarListMap {
+            desc { |tcx| "upvar_list `{}`", tcx.def_path_str(key.to_def_id()) }
+            cache_on_disk_if { true }
+        }
     }
 
     Other {

--- a/src/librustc_middle/query/mod.rs
+++ b/src/librustc_middle/query/mod.rs
@@ -490,6 +490,11 @@ rustc_queries! {
             desc { |tcx| "type-checking `{}`", tcx.def_path_str(key.to_def_id()) }
             cache_on_disk_if { true }
         }
+
+        query user_provided_sigs(key: LocalDefId) -> &'tcx FxHashMap<DefId, ty::CanonicalPolyFnSig<'tcx>> {
+            desc { |tcx| "user_provided_sigs `{}`", tcx.def_path_str(key.to_def_id()) }
+            cache_on_disk_if { true }
+        }
     }
 
     Other {

--- a/src/librustc_middle/query/mod.rs
+++ b/src/librustc_middle/query/mod.rs
@@ -480,6 +480,11 @@ rustc_queries! {
                 typeck_tables.map(|x| &*tcx.arena.alloc(x))
             }
         }
+
+        query typeck_has_errors(key: LocalDefId) -> Option<ErrorReported> {
+            desc { |tcx| "type-checking `{}`", tcx.def_path_str(key.to_def_id()) }
+            cache_on_disk_if { true }
+        }
     }
 
     Other {

--- a/src/librustc_middle/query/mod.rs
+++ b/src/librustc_middle/query/mod.rs
@@ -481,6 +481,11 @@ rustc_queries! {
             }
         }
 
+        query concrete_opaque_types(key: LocalDefId) -> &'tcx FxHashMap<DefId, ty::ResolvedOpaqueTy<'tcx>> {
+            desc { |tcx| "concrete_opaque_types `{}`", tcx.def_path_str(key.to_def_id()) }
+            cache_on_disk_if { true }
+        }
+
         query typeck_has_errors(key: LocalDefId) -> Option<ErrorReported> {
             desc { |tcx| "type-checking `{}`", tcx.def_path_str(key.to_def_id()) }
             cache_on_disk_if { true }

--- a/src/librustc_mir/borrow_check/type_check/input_output.rs
+++ b/src/librustc_mir/borrow_check/type_check/input_output.rs
@@ -36,8 +36,8 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
         if !self.tcx().is_closure(self.mir_def_id) {
             user_provided_sig = None;
         } else {
-            let typeck_tables = self.tcx().typeck_tables_of(self.mir_def_id.expect_local());
-            user_provided_sig = match typeck_tables.user_provided_sigs.get(&self.mir_def_id) {
+            let user_provided_sigs = self.tcx().user_provided_sigs(self.mir_def_id.expect_local());
+            user_provided_sig = match user_provided_sigs.get(&self.mir_def_id) {
                 None => None,
                 Some(user_provided_poly_sig) => {
                     // Instantiate the canonicalized variables from

--- a/src/librustc_mir/borrow_check/type_check/mod.rs
+++ b/src/librustc_mir/borrow_check/type_check/mod.rs
@@ -1233,8 +1233,7 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
         let tcx = infcx.tcx;
         let param_env = self.param_env;
         let body = self.body;
-        let concrete_opaque_types =
-            &tcx.typeck_tables_of(anon_owner_def_id.expect_local()).concrete_opaque_types;
+        let concrete_opaque_types = tcx.concrete_opaque_types(anon_owner_def_id.expect_local());
         let mut opaque_type_values = Vec::new();
 
         debug!("eq_opaque_type_and_type: mir_def_id={:?}", self.mir_def_id);

--- a/src/librustc_mir/const_eval/eval_queries.rs
+++ b/src/librustc_mir/const_eval/eval_queries.rs
@@ -291,7 +291,7 @@ pub fn const_eval_raw_provider<'tcx>(
 
     if let Some(def_id) = def_id.as_local() {
         if tcx.has_typeck_tables(def_id) {
-            if let Some(error_reported) = tcx.typeck_tables_of(def_id).tainted_by_errors {
+            if let Some(error_reported) = tcx.typeck_has_errors(def_id) {
                 return Err(ErrorHandled::Reported(error_reported));
             }
         }

--- a/src/librustc_mir/interpret/eval_context.rs
+++ b/src/librustc_mir/interpret/eval_context.rs
@@ -404,7 +404,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
         let did = instance.def_id();
         if let Some(did) = did.as_local() {
             if self.tcx.has_typeck_tables(did) {
-                if let Some(error_reported) = self.tcx.typeck_tables_of(did).tainted_by_errors {
+                if let Some(error_reported) = self.tcx.typeck_has_errors(did) {
                     throw_inval!(TypeckError(error_reported))
                 }
             }

--- a/src/librustc_mir/interpret/validity.rs
+++ b/src/librustc_mir/interpret/validity.rs
@@ -200,8 +200,8 @@ impl<'rt, 'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> ValidityVisitor<'rt, 'mir, '
             ty::Closure(def_id, _) | ty::Generator(def_id, _, _) => {
                 let mut name = None;
                 if let Some(def_id) = def_id.as_local() {
-                    let tables = self.ecx.tcx.typeck_tables_of(def_id);
-                    if let Some(upvars) = tables.upvar_list.get(&def_id.to_def_id()) {
+                    let upvar_list = self.ecx.tcx.upvar_list(def_id);
+                    if let Some(upvars) = upvar_list.get(&def_id.to_def_id()) {
                         // Sometimes the index is beyond the number of upvars (seen
                         // for a generator).
                         if let Some((&var_hir_id, _)) = upvars.get_index(field) {

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -776,6 +776,7 @@ pub fn provide(providers: &mut Providers<'_>) {
         adt_destructor,
         used_trait_imports,
         typeck_has_errors,
+        concrete_opaque_types,
         check_item_well_formed,
         check_trait_item_well_formed,
         check_impl_item_well_formed,
@@ -860,6 +861,13 @@ fn used_trait_imports(tcx: TyCtxt<'_>, def_id: LocalDefId) -> &DefIdSet {
 
 fn typeck_has_errors(tcx: TyCtxt<'_>, def_id: LocalDefId) -> Option<ErrorReported> {
     tcx.typeck_tables_of(def_id).tainted_by_errors
+}
+
+fn concrete_opaque_types(
+    tcx: TyCtxt<'_>,
+    def_id: LocalDefId,
+) -> &'_ FxHashMap<DefId, ty::ResolvedOpaqueTy<'_>> {
+    &tcx.typeck_tables_of(def_id).concrete_opaque_types
 }
 
 /// Inspects the substs of opaque types, replacing any inference variables

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -775,6 +775,7 @@ pub fn provide(providers: &mut Providers<'_>) {
         has_typeck_tables,
         adt_destructor,
         used_trait_imports,
+        typeck_has_errors,
         check_item_well_formed,
         check_trait_item_well_formed,
         check_impl_item_well_formed,
@@ -855,6 +856,10 @@ fn has_typeck_tables(tcx: TyCtxt<'_>, def_id: DefId) -> bool {
 
 fn used_trait_imports(tcx: TyCtxt<'_>, def_id: LocalDefId) -> &DefIdSet {
     &*tcx.typeck_tables_of(def_id).used_trait_imports
+}
+
+fn typeck_has_errors(tcx: TyCtxt<'_>, def_id: LocalDefId) -> Option<ErrorReported> {
+    tcx.typeck_tables_of(def_id).tainted_by_errors
 }
 
 /// Inspects the substs of opaque types, replacing any inference variables

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -775,6 +775,7 @@ pub fn provide(providers: &mut Providers<'_>) {
         has_typeck_tables,
         adt_destructor,
         used_trait_imports,
+        user_provided_sigs,
         typeck_has_errors,
         concrete_opaque_types,
         check_item_well_formed,
@@ -857,6 +858,13 @@ fn has_typeck_tables(tcx: TyCtxt<'_>, def_id: DefId) -> bool {
 
 fn used_trait_imports(tcx: TyCtxt<'_>, def_id: LocalDefId) -> &DefIdSet {
     &*tcx.typeck_tables_of(def_id).used_trait_imports
+}
+
+fn user_provided_sigs(
+    tcx: TyCtxt<'_>,
+    def_id: LocalDefId,
+) -> &FxHashMap<DefId, ty::CanonicalPolyFnSig<'_>> {
+    &tcx.typeck_tables_of(def_id).user_provided_sigs
 }
 
 fn typeck_has_errors(tcx: TyCtxt<'_>, def_id: LocalDefId) -> Option<ErrorReported> {

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -776,6 +776,7 @@ pub fn provide(providers: &mut Providers<'_>) {
         adt_destructor,
         used_trait_imports,
         user_provided_sigs,
+        upvar_list,
         typeck_has_errors,
         concrete_opaque_types,
         check_item_well_formed,
@@ -865,6 +866,10 @@ fn user_provided_sigs(
     def_id: LocalDefId,
 ) -> &FxHashMap<DefId, ty::CanonicalPolyFnSig<'_>> {
     &tcx.typeck_tables_of(def_id).user_provided_sigs
+}
+
+fn upvar_list(tcx: TyCtxt<'_>, def_id: LocalDefId) -> &ty::UpvarListMap {
+    &tcx.typeck_tables_of(def_id).upvar_list
 }
 
 fn typeck_has_errors(tcx: TyCtxt<'_>, def_id: LocalDefId) -> Option<ErrorReported> {

--- a/src/librustc_typeck/collect/type_of.rs
+++ b/src/librustc_typeck/collect/type_of.rs
@@ -137,8 +137,7 @@ pub(super) fn type_of(tcx: TyCtxt<'_>, def_id: DefId) -> Ty<'_> {
                                     owner, def_id,
                                 ),
                             );
-                            if let Some(ErrorReported) =
-                                tcx.typeck_tables_of(owner.expect_local()).tainted_by_errors
+                            if let Some(ErrorReported) = tcx.typeck_has_errors(owner.expect_local())
                             {
                                 // Some error in the
                                 // owner fn prevented us from populating

--- a/src/librustc_typeck/collect/type_of.rs
+++ b/src/librustc_typeck/collect/type_of.rs
@@ -120,7 +120,7 @@ pub(super) fn type_of(tcx: TyCtxt<'_>, def_id: DefId) -> Ty<'_> {
                             // We shouldn't leak borrowck results through impl trait in bindings.
                             // For example, we shouldn't be able to tell if `x` in
                             // `let x: impl Sized + 'a = &()` has type `&'static ()` or `&'a ()`.
-                            &tcx.typeck_tables_of(owner.expect_local()).concrete_opaque_types
+                            tcx.concrete_opaque_types(owner.expect_local())
                         }
                         OpaqueTyOrigin::TypeAlias => {
                             span_bug!(item.span, "Type alias impl trait shouldn't have an owner")
@@ -427,7 +427,7 @@ fn find_opaque_ty_constraints(tcx: TyCtxt<'_>, def_id: LocalDefId) -> Ty<'_> {
             }
             // Calling `mir_borrowck` can lead to cycle errors through
             // const-checking, avoid calling it if we don't have to.
-            if !self.tcx.typeck_tables_of(def_id).concrete_opaque_types.contains_key(&self.def_id) {
+            if !self.tcx.concrete_opaque_types(def_id).contains_key(&self.def_id) {
                 debug!(
                     "find_opaque_ty_constraints: no constraint for `{:?}` at `{:?}`",
                     self.def_id, def_id,


### PR DESCRIPTION
This can avoid re-running type checking.

cc #45208 