### PR TITLE
Implement String::remove_matches

### DIFF
--- a/library/alloc/tests/lib.rs
+++ b/library/alloc/tests/lib.rs
@@ -21,6 +21,7 @@
 #![feature(slice_group_by)]
 #![feature(vec_extend_from_within)]
 #![feature(vec_spare_capacity)]
+#![feature(string_remove_matches)]
 
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};

--- a/library/alloc/tests/string.rs
+++ b/library/alloc/tests/string.rs
@@ -366,6 +366,33 @@ fn remove_bad() {
 }
 
 #[test]
+fn test_remove_matches() {
+    let mut s = "abc".to_string();
+
+    s.remove_matches('b');
+    assert_eq!(s, "ac");
+    s.remove_matches('b');
+    assert_eq!(s, "ac");
+
+    let mut s = "abcb".to_string();
+
+    s.remove_matches('b');
+    assert_eq!(s, "ac");
+
+    let mut s = "ศไทย中华Việt Nam; foobarศ".to_string();
+    s.remove_matches('ศ');
+    assert_eq!(s, "ไทย中华Việt Nam; foobar");
+
+    let mut s = "".to_string();
+    s.remove_matches("");
+    assert_eq!(s, "");
+
+    let mut s = "aaaaa".to_string();
+    s.remove_matches('a');
+    assert_eq!(s, "");
+}
+
+#[test]
 fn test_retain() {
     let mut s = String::from("α_β_γ");
 


### PR DESCRIPTION
Closes #50206.

I lifted the function help from @frewsxcv's original PR (#50015), hope they don't mind.

I'm also wondering whether it would be useful for `remove_matches` to collect up the removed substrings into a `Vec` and return them, right now they're just overwritten by the copy and lost.