### PR TITLE
de-promote Duration::from_secs

### DIFF
--- a/src/libcore/time.rs
+++ b/src/libcore/time.rs
@@ -152,7 +152,6 @@ impl Duration {
     /// ```
     #[stable(feature = "duration", since = "1.3.0")]
     #[inline]
-    #[rustc_promotable]
     #[rustc_const_stable(feature = "duration_consts", since = "1.32.0")]
     pub const fn from_secs(secs: u64) -> Duration {
         Duration { secs, nanos: 0 }


### PR DESCRIPTION
In https://github.com/rust-lang/rust/pull/67531, we removed the `rustc_promotable` attribute from a bunch of `Duration` methods, but not from `Duration::from_secs`. This makes the current list of promotable functions the following (courtesy of @ecstatic-morse):

* `INT::min_value`, `INT::max_value`
* `std::mem::size_of`, `std::mem::align_of`
* `RangeInclusive::new` (backing `x..=y`)
* `std::ptr::null`, `std::ptr::null_mut`
* `RawWaker::new`, `RawWakerVTable::new` ???
* `Duration::from_secs`

I feel like the last one stands out a bit here -- the rest are all very core language primitives, and `RawWaker` has a strong motivation for getting a `'static` vtable. But a `&'static Duration`? That seems unlikely. So I propose we no longer promote calls to `Duration::from_secs`, which is what this PR does.

https://github.com/rust-lang/rust/pull/67531 saw zero regressions and I am not aware of anyone complaining that this broke their (non-cratered) code, so I consider it likely the same will be true here, but of course we'd do a crater run.

See [this document](https://github.com/rust-lang/const-eval/blob/master/promotion.md) for some more background on promotion and https://github.com/rust-lang/const-eval/issues/19 for some of the concerns around promoting function calls.