### PR TITLE
Decode qualifs for associated const defaults

### DIFF
--- a/src/librustc_metadata/rmeta/decoder.rs
+++ b/src/librustc_metadata/rmeta/decoder.rs
@@ -1123,11 +1123,13 @@ impl<'a, 'tcx> CrateMetadataRef<'a> {
         match self.kind(id) {
             EntryKind::Const(qualif, _)
             | EntryKind::AssocConst(
-                AssocContainer::ImplDefault | AssocContainer::ImplFinal,
+                AssocContainer::ImplDefault
+                | AssocContainer::ImplFinal
+                | AssocContainer::TraitWithDefault,
                 qualif,
                 _,
             ) => qualif,
-            _ => bug!(),
+            _ => bug!("mir_const_qualif: unexpected kind"),
         }
     }
 

--- a/src/test/ui/consts/const_in_pattern/auxiliary/consts.rs
+++ b/src/test/ui/consts/const_in_pattern/auxiliary/consts.rs
@@ -9,3 +9,8 @@ impl PartialEq for CustomEq {
 
 pub const NONE: Option<CustomEq> = None;
 pub const SOME: Option<CustomEq> = Some(CustomEq);
+
+pub trait AssocConst {
+    const NONE: Option<CustomEq> = None;
+    const SOME: Option<CustomEq> = Some(CustomEq);
+}

--- a/src/test/ui/consts/const_in_pattern/cross-crate-fail.rs
+++ b/src/test/ui/consts/const_in_pattern/cross-crate-fail.rs
@@ -4,9 +4,21 @@
 
 extern crate consts;
 
+struct Defaulted;
+impl consts::AssocConst for Defaulted {}
+
 fn main() {
+    let _ = Defaulted;
     match None {
         consts::SOME => panic!(),
+        //~^ must be annotated with `#[derive(PartialEq, Eq)]`
+        //~| must be annotated with `#[derive(PartialEq, Eq)]`
+
+        _ => {}
+    }
+
+    match None {
+        <Defaulted as consts::AssocConst>::SOME  => panic!(),
         //~^ must be annotated with `#[derive(PartialEq, Eq)]`
         //~| must be annotated with `#[derive(PartialEq, Eq)]`
 

--- a/src/test/ui/consts/const_in_pattern/cross-crate-fail.stderr
+++ b/src/test/ui/consts/const_in_pattern/cross-crate-fail.stderr
@@ -1,14 +1,26 @@
 error: to use a constant of type `consts::CustomEq` in a pattern, `consts::CustomEq` must be annotated with `#[derive(PartialEq, Eq)]`
-  --> $DIR/cross-crate-fail.rs:9:9
+  --> $DIR/cross-crate-fail.rs:13:9
    |
 LL |         consts::SOME => panic!(),
    |         ^^^^^^^^^^^^
 
 error: to use a constant of type `consts::CustomEq` in a pattern, `consts::CustomEq` must be annotated with `#[derive(PartialEq, Eq)]`
-  --> $DIR/cross-crate-fail.rs:9:9
+  --> $DIR/cross-crate-fail.rs:21:9
+   |
+LL |         <Defaulted as consts::AssocConst>::SOME  => panic!(),
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: to use a constant of type `consts::CustomEq` in a pattern, `consts::CustomEq` must be annotated with `#[derive(PartialEq, Eq)]`
+  --> $DIR/cross-crate-fail.rs:13:9
    |
 LL |         consts::SOME => panic!(),
    |         ^^^^^^^^^^^^
 
-error: aborting due to 2 previous errors
+error: to use a constant of type `consts::CustomEq` in a pattern, `consts::CustomEq` must be annotated with `#[derive(PartialEq, Eq)]`
+  --> $DIR/cross-crate-fail.rs:21:9
+   |
+LL |         <Defaulted as consts::AssocConst>::SOME  => panic!(),
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 4 previous errors
 

--- a/src/test/ui/consts/const_in_pattern/cross-crate-pass.rs
+++ b/src/test/ui/consts/const_in_pattern/cross-crate-pass.rs
@@ -6,9 +6,18 @@
 extern crate consts;
 use consts::CustomEq;
 
+struct Defaulted;
+impl consts::AssocConst for Defaulted {}
+
 fn main() {
+    let _ = Defaulted;
     match Some(CustomEq) {
         consts::NONE => panic!(),
+        _ => {}
+    }
+
+    match Some(CustomEq) {
+        <Defaulted as consts::AssocConst>::NONE  => panic!(),
         _ => {}
     }
 }


### PR DESCRIPTION
Fixes #71734.

We encode qualifs for associated constants, but never expected to decode the qualifs for defaulted associated consts. Fix this, and test that associated const defaults have the correct qualifs cross-crate.

r? @tmandry 