### PR TITLE
make `mem::Discriminant` invariant

### DIFF
--- a/src/libcore/mem/mod.rs
+++ b/src/libcore/mem/mod.rs
@@ -929,8 +929,9 @@ pub unsafe fn transmute_copy<T, U>(src: &T) -> U {
 /// See the [`discriminant`] function in this module for more information.
 ///
 /// [`discriminant`]: fn.discriminant.html
+// We use `PhantomData<fn(T) -> T>` because we want `Discriminant` to be invariant.
 #[stable(feature = "discriminant_value", since = "1.21.0")]
-pub struct Discriminant<T>(u64, PhantomData<fn() -> T>);
+pub struct Discriminant<T>(u64, PhantomData<fn(T) -> T>);
 
 // N.B. These trait implementations cannot be derived because we don't want any bounds on T.
 


### PR DESCRIPTION
`mem::Discriminant` is currently covariant over T.
#70705 changes this to invariant, which is a breaking change.

This PR can be used for a crater run to check if more crates than expected depend on the variance of `Discriminant`, recommended in https://github.com/rust-lang/rust/pull/70705#discussion_r407385727

cc @RalfJung @eddyb 

Example breakage:
```rust
use std::mem::Discriminant;

pub fn variance<'a>(v: Discriminant<&'static ()>) -> Discriminant<&'a ()> {
    v
}
```