### PR TITLE
Adding constant-propagation tests

### DIFF
--- a/src/test/ui/mir/mir_constprop_dodges_bad_ops_that_never_happen.rs
+++ b/src/test/ui/mir/mir_constprop_dodges_bad_ops_that_never_happen.rs
@@ -1,0 +1,27 @@
+// compile-flags: -Z mir-opt-level=3
+// check-pass
+
+// This test is designed to never trigger `unconditional_panic`.
+// If it does, there's a bug in the MIR optimizations.
+#![deny(unconditional_panic)]
+fn main() {
+    let z = combine_wisely(1, 0);
+}
+
+// If `combine_wisely` is called with a `y` value
+// equal to zero, the branch where we compute `x/y`
+// will not be executed. Our constant propagation pass must
+// be smart enough to avoid computing these invalid states
+// if they are, semantically, never going to happen.
+//
+// This test will fail if we ever drop the ball with
+// regards to constant propagation and its savvyness
+// concerning control flow.
+#[inline(never)]
+fn combine_wisely(x: u32, y: u32) -> u32 {
+    if y != 0 {
+        x / y
+    } else {
+        x + y
+    }
+}


### PR DESCRIPTION
I want to add many miscellaneous tests from here. 

We're starting with a sanity check for when we start propagating local variables through blocks. The added test should never fail to compile, and if it does, it will most likely be because we've messed up somewhere in the control-flow-dependent propagation.

I summon Oliver for this, as we've talked before about this particular topic.

r? @oli-obk 

Total lists of tests this PR is planned to include (check: implemented, otherwise only planned)
- [x] Test for control-flow dependent propagation
- [ ] Test or tests to showcase the full extent possible of constant propagation