### PR TITLE
Fix suggestion to borrow in struct

### DIFF
--- a/src/librustc_trait_selection/traits/error_reporting/suggestions.rs
+++ b/src/librustc_trait_selection/traits/error_reporting/suggestions.rs
@@ -570,33 +570,30 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                     // original type obligation, not the last one that failed, which is arbitrary.
                     // Because of this, we modify the error to refer to the original obligation and
                     // return early in the caller.
-                    
 
                     let has_colon = self
-                            .tcx
-                            .sess
-                            .source_map()
-                            .span_to_snippet(span)
-                            .map(|w| w.contains(":"))
-                            .unwrap_or(false);
+                        .tcx
+                        .sess
+                        .source_map()
+                        .span_to_snippet(span)
+                        .map(|w| w.contains(":"))
+                        .unwrap_or(false);
 
                     let has_double_colon = self
-                            .tcx
-                            .sess
-                            .source_map()
-                            .span_to_snippet(span)
-                            .map(|w| w.contains("::"))
-                            .unwrap_or(false);
+                        .tcx
+                        .sess
+                        .source_map()
+                        .span_to_snippet(span)
+                        .map(|w| w.contains("::"))
+                        .unwrap_or(false);
 
                     let has_bracket = self
-                            .tcx
-                            .sess
-                            .source_map()
-                            .span_to_snippet(span)
-                            .map(|w| w.contains("{"))
-                            .unwrap_or(false);
-
-                   
+                        .tcx
+                        .sess
+                        .source_map()
+                        .span_to_snippet(span)
+                        .map(|w| w.contains("{"))
+                        .unwrap_or(false);
 
                     let msg = format!(
                         "the trait bound `{}: {}` is not satisfied",
@@ -620,7 +617,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                             obligation.parent_trait_ref.skip_binder().print_only_trait_path(),
                         ),
                     );
-                
+
                     // This if is to prevent a special edge-case
                     if !has_colon || has_double_colon || has_bracket {
                         // We don't want a borrowing suggestion on the fields in structs,

--- a/src/librustc_trait_selection/traits/error_reporting/suggestions.rs
+++ b/src/librustc_trait_selection/traits/error_reporting/suggestions.rs
@@ -571,30 +571,6 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                     // Because of this, we modify the error to refer to the original obligation and
                     // return early in the caller.
 
-                    let has_colon = self
-                        .tcx
-                        .sess
-                        .source_map()
-                        .span_to_snippet(span)
-                        .map(|w| w.contains(":"))
-                        .unwrap_or(false);
-
-                    let has_double_colon = self
-                        .tcx
-                        .sess
-                        .source_map()
-                        .span_to_snippet(span)
-                        .map(|w| w.contains("::"))
-                        .unwrap_or(false);
-
-                    let has_bracket = self
-                        .tcx
-                        .sess
-                        .source_map()
-                        .span_to_snippet(span)
-                        .map(|w| w.contains("{"))
-                        .unwrap_or(false);
-
                     let msg = format!(
                         "the trait bound `{}: {}` is not satisfied",
                         found,
@@ -619,7 +595,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                     );
 
                     // This if is to prevent a special edge-case
-                    if !has_colon || has_double_colon || has_bracket {
+                    if !span.from_expansion() {
                         // We don't want a borrowing suggestion on the fields in structs,
                         // ```
                         // struct Foo {

--- a/src/librustc_trait_selection/traits/error_reporting/suggestions.rs
+++ b/src/librustc_trait_selection/traits/error_reporting/suggestions.rs
@@ -562,6 +562,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                 param_env,
                 new_trait_ref.without_const().to_predicate(),
             );
+
             if self.predicate_must_hold_modulo_regions(&new_obligation) {
                 if let Ok(snippet) = self.tcx.sess.source_map().span_to_snippet(span) {
                     // We have a very specific type of error, where just borrowing this argument
@@ -569,6 +570,34 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                     // original type obligation, not the last one that failed, which is arbitrary.
                     // Because of this, we modify the error to refer to the original obligation and
                     // return early in the caller.
+                    
+
+                    let has_colon = self
+                            .tcx
+                            .sess
+                            .source_map()
+                            .span_to_snippet(span)
+                            .map(|w| w.contains(":"))
+                            .unwrap_or(false);
+
+                    let has_double_colon = self
+                            .tcx
+                            .sess
+                            .source_map()
+                            .span_to_snippet(span)
+                            .map(|w| w.contains("::"))
+                            .unwrap_or(false);
+
+                    let has_bracket = self
+                            .tcx
+                            .sess
+                            .source_map()
+                            .span_to_snippet(span)
+                            .map(|w| w.contains("{"))
+                            .unwrap_or(false);
+
+                   
+
                     let msg = format!(
                         "the trait bound `{}: {}` is not satisfied",
                         found,
@@ -591,12 +620,23 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                             obligation.parent_trait_ref.skip_binder().print_only_trait_path(),
                         ),
                     );
-                    err.span_suggestion(
-                        span,
-                        "consider borrowing here",
-                        format!("&{}", snippet),
-                        Applicability::MaybeIncorrect,
-                    );
+                
+                    // This if is to prevent a special edge-case
+                    if !has_colon || has_double_colon || has_bracket {
+                        // We don't want a borrowing suggestion on the fields in structs,
+                        // ```
+                        // struct Foo {
+                        //  the_foos: Vec<Foo>
+                        // }
+                        // ```
+
+                        err.span_suggestion(
+                            span,
+                            "consider borrowing here",
+                            format!("&{}", snippet),
+                            Applicability::MaybeIncorrect,
+                        );
+                    }
                     return true;
                 }
             }

--- a/src/test/ui/traits/traits-issue-71136.rs
+++ b/src/test/ui/traits/traits-issue-71136.rs
@@ -1,0 +1,8 @@
+struct Foo(u8);
+
+#[derive(Clone)]
+struct FooHolster {
+    the_foos: Vec<Foo>, //~ERROR Clone
+}
+
+fn main() {}

--- a/src/test/ui/traits/traits-issue-71136.stderr
+++ b/src/test/ui/traits/traits-issue-71136.stderr
@@ -1,0 +1,13 @@
+error[E0277]: the trait bound `Foo: std::clone::Clone` is not satisfied
+  --> $DIR/traits-issue-71136.rs:5:5
+   |
+LL |     the_foos: Vec<Foo>,
+   |     ^^^^^^^^^^^^^^^^^^ expected an implementor of trait `std::clone::Clone`
+   |
+   = note: required because of the requirements on the impl of `std::clone::Clone` for `std::vec::Vec<Foo>`
+   = note: required by `std::clone::Clone::clone`
+   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
The corresponding issue is #71136.
The compiler suggests that borrowing `the_foos` might solve the problem. This is obviously incorrect.
```
struct Foo(u8);

#[derive(Clone)]
struct FooHolster {
    the_foos: Vec<Foo>,
}
```

I propose as fix to check if there is any colon in the span. However, there might a case where `my_method(B { a: 1, b : foo })` would be appropriate to show a suggestion for `&B ...`.  To fix that too, we can simply check if there is a bracket in the span. This is only possible because both spans are different. 
Issue's span: `the_foos: Vec<Foo>`
other's span: `B { a : 1, b : foo }`