### PR TITLE
Remove clippy from some leftover lists of "possibly failing" tools

### DIFF
--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -528,7 +528,7 @@ impl Step for Clippy {
                 host,
                 "test",
                 "src/tools/clippy",
-                SourceType::Submodule,
+                SourceType::InTree,
                 &[],
             );
 

--- a/src/bootstrap/toolstate.rs
+++ b/src/bootstrap/toolstate.rs
@@ -78,7 +78,6 @@ static STABLE_TOOLS: &[(&str, &str)] = &[
     ("edition-guide", "src/doc/edition-guide"),
     ("rls", "src/tools/rls"),
     ("rustfmt", "src/tools/rustfmt"),
-    ("clippy-driver", "src/tools/clippy"),
 ];
 
 // These tools are permitted to not build on the beta/stable channels.

--- a/src/tools/publish_toolstate.py
+++ b/src/tools/publish_toolstate.py
@@ -25,10 +25,6 @@ except ImportError:
 # read privileges on it). CI will fail otherwise.
 MAINTAINERS = {
     'miri': {'oli-obk', 'RalfJung', 'eddyb'},
-    'clippy-driver': {
-        'Manishearth', 'llogiq', 'mcarton', 'oli-obk', 'phansch', 'flip1995',
-        'yaahc',
-    },
     'rls': {'Xanewok'},
     'rustfmt': {'topecongiro'},
     'book': {'carols10cents', 'steveklabnik'},
@@ -45,7 +41,6 @@ MAINTAINERS = {
 
 REPOS = {
     'miri': 'https://github.com/rust-lang/miri',
-    'clippy-driver': 'https://github.com/rust-lang/rust-clippy',
     'rls': 'https://github.com/rust-lang/rls',
     'rustfmt': 'https://github.com/rust-lang/rustfmt',
     'book': 'https://github.com/rust-lang/book',


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/70655 successfully made clippy get built and tested on CI on every merge, but the lack of emitted toolstate info caused the toolstate to get updated to test-fail. We should remove clippy entirely from toolstate, as it now is always test-pass.

The changes made in this PR reflect what we do for `rustdoc`, which is our preexisting tool that is gated on CI.

r? @Mark-Simulacrum 