### PR TITLE
Slice retain

### DIFF
--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -125,6 +125,7 @@
 #![feature(alloc_layout_extra)]
 #![feature(try_trait)]
 #![feature(associated_type_bounds)]
+#![feature(slice_retain)]
 
 // Allow testing this library
 

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -1103,26 +1103,12 @@ impl<T> Vec<T> {
     /// assert_eq!(vec, [2, 3, 5]);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn retain<F>(&mut self, mut f: F)
+    pub fn retain<F>(&mut self, f: F)
     where
         F: FnMut(&T) -> bool,
     {
-        let len = self.len();
-        let mut del = 0;
-        {
-            let v = &mut **self;
-
-            for i in 0..len {
-                if !f(&v[i]) {
-                    del += 1;
-                } else if del > 0 {
-                    v.swap(i - del, i);
-                }
-            }
-        }
-        if del > 0 {
-            self.truncate(len - del);
-        }
+        let retained_len = self.as_mut_slice().retain(f).len();
+        self.truncate(retained_len);
     }
 
     /// Removes all but the first of consecutive elements in the vector that resolve to the same

--- a/src/libcore/tests/lib.rs
+++ b/src/libcore/tests/lib.rs
@@ -43,6 +43,7 @@
 #![feature(leading_trailing_ones)]
 #![feature(const_forget)]
 #![feature(option_unwrap_none)]
+#![feature(slice_retain)]
 
 extern crate test;
 

--- a/src/libcore/tests/slice.rs
+++ b/src/libcore/tests/slice.rs
@@ -1636,6 +1636,17 @@ fn test_slice_partition_dedup_partialeq() {
 }
 
 #[test]
+fn test_slice_retain() {
+    let mut slice = [1, 2, 2, 3, 1, 4];
+    let retained = slice.retain(|&x| x == 1);
+    assert_eq!(retained, &[1, 1]);
+
+    let mut slice = [1, 2, 2, 3, 1, 4];
+    let retained = slice.retain(|&x| x % 2 == 0);
+    assert_eq!(retained, &[2, 2, 4]);
+}
+
+#[test]
 fn test_copy_within() {
     // Start to end, with a RangeTo.
     let mut bytes = *b"Hello, World!";


### PR DESCRIPTION
adds `retain` method on slice. This meant moving the `retain` implementation from `Vec` to `slice` and having `Vec`'s `retain` method rely on `slice`'s.

tracking issue: #71831