### PR TITLE
Rework MIR drop tree lowering

### DIFF
--- a/src/librustc_mir/dataflow/move_paths/builder.rs
+++ b/src/librustc_mir/dataflow/move_paths/builder.rs
@@ -361,16 +361,13 @@ impl<'b, 'a, 'tcx> Gatherer<'b, 'a, 'tcx> {
     fn gather_terminator(&mut self, term: &Terminator<'tcx>) {
         match term.kind {
             TerminatorKind::Goto { target: _ }
+            | TerminatorKind::Return
             | TerminatorKind::Resume
             | TerminatorKind::Abort
             | TerminatorKind::GeneratorDrop
             | TerminatorKind::FalseEdges { .. }
             | TerminatorKind::FalseUnwind { .. }
             | TerminatorKind::Unreachable => {}
-
-            TerminatorKind::Return => {
-                self.gather_move(Place::return_place());
-            }
 
             TerminatorKind::Assert { ref cond, .. } => {
                 self.gather_operand(cond);

--- a/src/librustc_mir/dataflow/move_paths/builder.rs
+++ b/src/librustc_mir/dataflow/move_paths/builder.rs
@@ -361,12 +361,16 @@ impl<'b, 'a, 'tcx> Gatherer<'b, 'a, 'tcx> {
     fn gather_terminator(&mut self, term: &Terminator<'tcx>) {
         match term.kind {
             TerminatorKind::Goto { target: _ }
+            | TerminatorKind::FalseEdges { .. }
+            | TerminatorKind::FalseUnwind { .. }
+            // In some sense returning moves the return place into the current
+            // call's destination, however, since there are no statements after
+            // this that could possibly access the return place, this doesn't
+            // need recording.
             | TerminatorKind::Return
             | TerminatorKind::Resume
             | TerminatorKind::Abort
             | TerminatorKind::GeneratorDrop
-            | TerminatorKind::FalseEdges { .. }
-            | TerminatorKind::FalseUnwind { .. }
             | TerminatorKind::Unreachable => {}
 
             TerminatorKind::Assert { ref cond, .. } => {

--- a/src/librustc_mir/util/graphviz.rs
+++ b/src/librustc_mir/util/graphviz.rs
@@ -97,12 +97,17 @@ where
     write!(w, r#"<table border="0" cellborder="1" cellspacing="0">"#)?;
 
     // Basic block number at the top.
+    let (blk, color) = if data.is_cleanup {
+        (format!("{} (cleanup)", block.index()), "lightblue")
+    } else {
+        (format!("{}", block.index()), "gray")
+    };
     write!(
         w,
-        r#"<tr><td {attrs} colspan="{colspan}">{blk}</td></tr>"#,
-        attrs = r#"bgcolor="gray" align="center""#,
+        r#"<tr><td bgcolor="{color}" align="center" colspan="{colspan}">{blk}</td></tr>"#,
         colspan = num_cols,
-        blk = block.index()
+        blk = blk,
+        color = color
     )?;
 
     init(w)?;

--- a/src/librustc_mir_build/build/block.rs
+++ b/src/librustc_mir_build/build/block.rs
@@ -26,14 +26,16 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         self.in_opt_scope(opt_destruction_scope.map(|de| (de, source_info)), move |this| {
             this.in_scope((region_scope, source_info), LintLevel::Inherited, move |this| {
                 if targeted_by_break {
-                    // This is a `break`-able block
-                    let exit_block = this.cfg.start_new_block();
-                    let block_exit =
-                        this.in_breakable_scope(None, exit_block, destination, |this| {
-                            this.ast_block_stmts(destination, block, span, stmts, expr, safety_mode)
-                        });
-                    this.cfg.goto(unpack!(block_exit), source_info, exit_block);
-                    exit_block.unit()
+                    this.in_breakable_scope(None, destination, span, |this| {
+                        Some(this.ast_block_stmts(
+                            destination,
+                            block,
+                            span,
+                            stmts,
+                            expr,
+                            safety_mode,
+                        ))
+                    })
                 } else {
                     this.ast_block_stmts(destination, block, span, stmts, expr, safety_mode)
                 }

--- a/src/librustc_mir_build/build/expr/into.rs
+++ b/src/librustc_mir_build/build/expr/into.rs
@@ -134,23 +134,19 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 // body, even when the exact code in the body cannot unwind
 
                 let loop_block = this.cfg.start_new_block();
-                let exit_block = this.cfg.start_new_block();
 
                 // Start the loop.
                 this.cfg.goto(block, source_info, loop_block);
 
-                this.in_breakable_scope(Some(loop_block), exit_block, destination, move |this| {
+                this.in_breakable_scope(Some(loop_block), destination, expr_span, move |this| {
                     // conduct the test, if necessary
                     let body_block = this.cfg.start_new_block();
-                    let diverge_cleanup = this.diverge_cleanup();
                     this.cfg.terminate(
                         loop_block,
                         source_info,
-                        TerminatorKind::FalseUnwind {
-                            real_target: body_block,
-                            unwind: Some(diverge_cleanup),
-                        },
+                        TerminatorKind::FalseUnwind { real_target: body_block, unwind: None },
                     );
+                    this.diverge_from(loop_block);
 
                     // The “return” value of the loop body must always be an unit. We therefore
                     // introduce a unit temporary as the destination for the loop body.
@@ -158,8 +154,10 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     // Execute the body, branching back to the test.
                     let body_block_end = unpack!(this.into(tmp, body_block, body));
                     this.cfg.goto(body_block_end, source_info, loop_block);
-                });
-                exit_block.unit()
+
+                    // Loops are only exited by `break` expressions.
+                    None
+                })
             }
             ExprKind::Call { ty, fun, args, from_hir_call } => {
                 let intrinsic = match ty.kind {
@@ -201,7 +199,6 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                         .collect();
 
                     let success = this.cfg.start_new_block();
-                    let cleanup = this.diverge_cleanup();
 
                     this.record_operands_moved(&args);
 
@@ -211,7 +208,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                         TerminatorKind::Call {
                             func: fun,
                             args,
-                            cleanup: Some(cleanup),
+                            cleanup: None,
                             // FIXME(varkor): replace this with an uninhabitedness-based check.
                             // This requires getting access to the current module to call
                             // `tcx.is_ty_uninhabited_from`, which is currently tricky to do.
@@ -223,6 +220,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                             from_hir_call,
                         },
                     );
+                    this.diverge_from(block);
                     success.unit()
                 }
             }
@@ -358,12 +356,12 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 let scope = this.local_scope();
                 let value = unpack!(block = this.as_operand(block, scope, value));
                 let resume = this.cfg.start_new_block();
-                let cleanup = this.generator_drop_cleanup();
                 this.cfg.terminate(
                     block,
                     source_info,
-                    TerminatorKind::Yield { value, resume, resume_arg: destination, drop: cleanup },
+                    TerminatorKind::Yield { value, resume, resume_arg: destination, drop: None },
                 );
+                this.generator_drop_cleanup(block);
                 resume.unit()
             }
 

--- a/src/librustc_mir_build/build/matches/mod.rs
+++ b/src/librustc_mir_build/build/matches/mod.rs
@@ -225,8 +225,6 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         outer_source_info: SourceInfo,
         fake_borrow_temps: Vec<(Place<'tcx>, Local)>,
     ) -> BlockAnd<()> {
-        let match_scope = self.scopes.topmost();
-
         let arm_end_blocks: Vec<_> = arm_candidates
             .into_iter()
             .map(|(arm, candidate)| {
@@ -247,7 +245,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     let arm_block = this.bind_pattern(
                         outer_source_info,
                         candidate,
-                        arm.guard.as_ref().map(|g| (g, match_scope)),
+                        arm.guard.as_ref(),
                         &fake_borrow_temps,
                         scrutinee_span,
                         Some(arm.scope),
@@ -284,7 +282,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         &mut self,
         outer_source_info: SourceInfo,
         candidate: Candidate<'_, 'tcx>,
-        guard: Option<(&Guard<'tcx>, region::Scope)>,
+        guard: Option<&Guard<'tcx>>,
         fake_borrow_temps: &Vec<(Place<'tcx>, Local)>,
         scrutinee_span: Span,
         arm_scope: Option<region::Scope>,
@@ -1563,7 +1561,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         &mut self,
         candidate: Candidate<'pat, 'tcx>,
         parent_bindings: &[(Vec<Binding<'tcx>>, Vec<Ascription<'tcx>>)],
-        guard: Option<(&Guard<'tcx>, region::Scope)>,
+        guard: Option<&Guard<'tcx>>,
         fake_borrows: &Vec<(Place<'tcx>, Local)>,
         scrutinee_span: Span,
         schedule_drops: bool,
@@ -1675,7 +1673,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         //      the reference that we create for the arm.
         //    * So we eagerly create the reference for the arm and then take a
         //      reference to that.
-        if let Some((guard, region_scope)) = guard {
+        if let Some(guard) = guard {
             let tcx = self.hir.tcx();
             let bindings = parent_bindings
                 .iter()
@@ -1719,12 +1717,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 unreachable
             });
             let outside_scope = self.cfg.start_new_block();
-            self.exit_scope(
-                source_info.span,
-                region_scope,
-                otherwise_post_guard_block,
-                outside_scope,
-            );
+            self.exit_top_scope(otherwise_post_guard_block, outside_scope, source_info);
             self.false_edges(
                 outside_scope,
                 otherwise_block,

--- a/src/librustc_mir_build/build/matches/test.rs
+++ b/src/librustc_mir_build/build/matches/test.rs
@@ -423,7 +423,6 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         let bool_ty = self.hir.bool_ty();
         let eq_result = self.temp(bool_ty, source_info.span);
         let eq_block = self.cfg.start_new_block();
-        let cleanup = self.diverge_cleanup();
         self.cfg.terminate(
             block,
             source_info,
@@ -440,11 +439,12 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     literal: method,
                 }),
                 args: vec![val, expect],
-                destination: Some((eq_result, eq_block)),
-                cleanup: Some(cleanup),
+                destination: Some((eq_result.clone(), eq_block)),
+                cleanup: None,
                 from_hir_call: false,
             },
         );
+        self.diverge_from(block);
 
         if let [success_block, fail_block] = *make_target_blocks(self) {
             // check the result

--- a/src/librustc_mir_build/build/matches/test.rs
+++ b/src/librustc_mir_build/build/matches/test.rs
@@ -439,7 +439,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     literal: method,
                 }),
                 args: vec![val, expect],
-                destination: Some((eq_result.clone(), eq_block)),
+                destination: Some((eq_result, eq_block)),
                 cleanup: None,
                 from_hir_call: false,
             },

--- a/src/librustc_mir_build/build/mod.rs
+++ b/src/librustc_mir_build/build/mod.rs
@@ -327,11 +327,6 @@ struct Builder<'a, 'tcx> {
 
     var_debug_info: Vec<VarDebugInfo<'tcx>>,
 
-    /// Cached block with the `RESUME` terminator; this is created
-    /// when first set of cleanups are built.
-    cached_resume_block: Option<BasicBlock>,
-    /// Cached block with the `RETURN` terminator.
-    cached_return_block: Option<BasicBlock>,
     /// Cached block with the `UNREACHABLE` terminator.
     cached_unreachable_block: Option<BasicBlock>,
 }
@@ -590,50 +585,34 @@ where
         region::Scope { id: body.value.hir_id.local_id, data: region::ScopeData::CallSite };
     let arg_scope =
         region::Scope { id: body.value.hir_id.local_id, data: region::ScopeData::Arguments };
-    let mut block = START_BLOCK;
     let source_info = builder.source_info(span);
     let call_site_s = (call_site_scope, source_info);
-    unpack!(
-        block = builder.in_scope(call_site_s, LintLevel::Inherited, |builder| {
-            if should_abort_on_panic(tcx, fn_def_id, abi) {
-                builder.schedule_abort();
-            }
-
-            let arg_scope_s = (arg_scope, source_info);
-            // `return_block` is called when we evaluate a `return` expression, so
-            // we just use `START_BLOCK` here.
-            unpack!(
-                block = builder.in_breakable_scope(
-                    None,
-                    START_BLOCK,
-                    Place::return_place(),
-                    |builder| {
-                        builder.in_scope(arg_scope_s, LintLevel::Inherited, |builder| {
-                            builder.args_and_body(
-                                block,
-                                fn_def_id.to_def_id(),
-                                &arguments,
-                                arg_scope,
-                                &body.value,
-                            )
-                        })
-                    },
-                )
-            );
-            // Attribute epilogue to function's closing brace
-            let fn_end = span.shrink_to_hi();
-            let source_info = builder.source_info(fn_end);
-            let return_block = builder.return_block();
-            builder.cfg.goto(block, source_info, return_block);
-            builder.cfg.terminate(return_block, source_info, TerminatorKind::Return);
-            // Attribute any unreachable codepaths to the function's closing brace
-            if let Some(unreachable_block) = builder.cached_unreachable_block {
-                builder.cfg.terminate(unreachable_block, source_info, TerminatorKind::Unreachable);
-            }
-            return_block.unit()
-        })
-    );
-    assert_eq!(block, builder.return_block());
+    unpack!(builder.in_scope(call_site_s, LintLevel::Inherited, |builder| {
+        let arg_scope_s = (arg_scope, source_info);
+        // Attribute epilogue to function's closing brace
+        let fn_end = span.shrink_to_hi();
+        let return_block =
+            unpack!(builder.in_breakable_scope(None, Place::return_place(), fn_end, |builder| {
+                Some(builder.in_scope(arg_scope_s, LintLevel::Inherited, |builder| {
+                    builder.args_and_body(
+                        START_BLOCK,
+                        fn_def_id.to_def_id(),
+                        &arguments,
+                        arg_scope,
+                        &body.value,
+                    )
+                }))
+            }));
+        let source_info = builder.source_info(fn_end);
+        builder.cfg.terminate(return_block, source_info, TerminatorKind::Return);
+        let should_abort = should_abort_on_panic(tcx, fn_def_id, abi);
+        builder.build_drop_trees(should_abort);
+        // Attribute any unreachable codepaths to the function's closing brace
+        if let Some(unreachable_block) = builder.cached_unreachable_block {
+            builder.cfg.terminate(unreachable_block, source_info, TerminatorKind::Unreachable);
+        }
+        return_block.unit()
+    }));
 
     let spread_arg = if abi == Abi::RustCall {
         // RustCall pseudo-ABI untuples the last argument.
@@ -667,8 +646,7 @@ fn construct_const<'a, 'tcx>(
     let source_info = builder.source_info(span);
     builder.cfg.terminate(block, source_info, TerminatorKind::Return);
 
-    // Constants can't `return` so a return block should not be created.
-    assert_eq!(builder.cached_return_block, None);
+    builder.build_drop_trees(false);
 
     // Constants may be match expressions in which case an unreachable block may
     // be created, so terminate it properly.
@@ -735,7 +713,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             fn_span: span,
             arg_count,
             generator_kind,
-            scopes: Default::default(),
+            scopes: scope::Scopes::new(),
             block_context: BlockContext::new(),
             source_scopes: IndexVec::new(),
             source_scope: OUTERMOST_SOURCE_SCOPE,
@@ -748,8 +726,6 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             var_indices: Default::default(),
             unit_temp: None,
             var_debug_info: vec![],
-            cached_resume_block: None,
-            cached_return_block: None,
             cached_unreachable_block: None,
         };
 
@@ -978,17 +954,6 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 let tmp = self.temp(ty, fn_span);
                 self.unit_temp = Some(tmp);
                 tmp
-            }
-        }
-    }
-
-    fn return_block(&mut self) -> BasicBlock {
-        match self.cached_return_block {
-            Some(rb) => rb,
-            None => {
-                let rb = self.cfg.start_new_block();
-                self.cached_return_block = Some(rb);
-                rb
             }
         }
     }

--- a/src/librustc_mir_build/build/scope.rs
+++ b/src/librustc_mir_build/build/scope.rs
@@ -69,7 +69,7 @@ scheduled in a [DropTree]. Later, before `in_breakable_scope` exits, the drops
 will be added to the CFG.
 
 Panics are handled in a similar fashion, except that the drops are added to the
-mir once the rest of the function has finished being lowered. If a terminator
+MIR once the rest of the function has finished being lowered. If a terminator
 can panic, call `diverge_from(block)` with the block containing the terminator
 `block`.
 
@@ -284,8 +284,8 @@ impl DropTree {
         blocks: &mut IndexVec<DropIdx, Option<BasicBlock>>,
     ) {
         // StorageDead statements can share blocks with each other and also with
-        // a Drop terminator. We iterate through the blocks to find which blocks
-        // need
+        // a Drop terminator. We iterate through the drops to find which drops
+        // need their own block.
         #[derive(Clone, Copy)]
         enum Block {
             // This drop is unreachable
@@ -294,7 +294,7 @@ impl DropTree {
             // specified index.
             Shares(DropIdx),
             // This drop has more than one way of being reached, or it is
-            // branched to from outside the tree, or it's predecessor is a
+            // branched to from outside the tree, or its predecessor is a
             // `Value` drop.
             Own,
         }
@@ -307,7 +307,7 @@ impl DropTree {
             needs_block[ROOT_NODE] = Block::Own;
         }
 
-        // Sort so that we only need to check the last
+        // Sort so that we only need to check the last value.
         let entry_points = &mut self.entry_points;
         entry_points.sort();
 

--- a/src/librustc_mir_build/build/scope.rs
+++ b/src/librustc_mir_build/build/scope.rs
@@ -6,30 +6,31 @@ contents, and then pop it off. Every scope is named by a
 
 ### SEME Regions
 
-When pushing a new scope, we record the current point in the graph (a
+When pushing a new [Scope], we record the current point in the graph (a
 basic block); this marks the entry to the scope. We then generate more
 stuff in the control-flow graph. Whenever the scope is exited, either
 via a `break` or `return` or just by fallthrough, that marks an exit
 from the scope. Each lexical scope thus corresponds to a single-entry,
 multiple-exit (SEME) region in the control-flow graph.
 
-For now, we keep a mapping from each `region::Scope` to its
-corresponding SEME region for later reference (see caveat in next
-paragraph). This is because region scopes are tied to
-them. Eventually, when we shift to non-lexical lifetimes, there should
-be no need to remember this mapping.
+For now, we record the `region::Scope` to each SEME region for later reference
+(see caveat in next paragraph). This is because destruction scopes are tied to
+them. This may change in the future so that MIR lowering determines its own
+destruction scopes.
 
 ### Not so SEME Regions
 
 In the course of building matches, it sometimes happens that certain code
 (namely guards) gets executed multiple times. This means that the scope lexical
 scope may in fact correspond to multiple, disjoint SEME regions. So in fact our
-mapping is from one scope to a vector of SEME regions.
+mapping is from one scope to a vector of SEME regions. Since the SEME regions
+are disjoint, the mapping is still one-to-one for the set of SEME regions that
+we're currently in.
 
-Also in matches, the scopes assigned to arms are not even SEME regions! Each
-arm has a single region with one entry for each pattern. We manually
+Also in matches, the scopes assigned to arms are not always even SEME regions!
+Each arm has a single region with one entry for each pattern. We manually
 manipulate the scheduled drops in this scope to avoid dropping things multiple
-times, although drop elaboration would clean this up for value drops.
+times.
 
 ### Drops
 
@@ -60,38 +61,48 @@ that for now); any later drops would also drop `y`.
 
 There are numerous "normal" ways to early exit a scope: `break`,
 `continue`, `return` (panics are handled separately). Whenever an
-early exit occurs, the method `exit_scope` is called. It is given the
+early exit occurs, the method `break_scope` is called. It is given the
 current point in execution where the early exit occurs, as well as the
 scope you want to branch to (note that all early exits from to some
-other enclosing scope). `exit_scope` will record this exit point and
-also add all drops.
+other enclosing scope). `break_scope` will record the set of drops currently
+scheduled in a [DropTree]. Later, before `in_breakable_scope` exits, the drops
+will be added to the CFG.
 
-Panics are handled in a similar fashion, except that a panic always
-returns out to the `DIVERGE_BLOCK`. To trigger a panic, simply call
-`panic(p)` with the current point `p`. Or else you can call
-`diverge_cleanup`, which will produce a block that you can branch to
-which does the appropriate cleanup and then diverges. `panic(p)`
-simply calls `diverge_cleanup()` and adds an edge from `p` to the
-result.
+Panics are handled in a similar fashion, except that the drops are added to the
+mir once the rest of the function has finished being lowered. If a terminator
+can panic, call `diverge_from(block)` with the block containing the terminator
+`block`.
 
-### Loop scopes
+### Breakable scopes
 
 In addition to the normal scope stack, we track a loop scope stack
-that contains only loops. It tracks where a `break` and `continue`
-should go to.
+that contains only loops and breakable blocks. It tracks where a `break`,
+`continue` or `return` should go to.
 
 */
 
 use crate::build::{BlockAnd, BlockAndExtension, BlockFrame, Builder, CFG};
 use crate::hair::{Expr, ExprRef, LintLevel};
-use rustc_middle::middle::region;
-use rustc_middle::mir::*;
 use rustc_data_structures::fx::FxHashMap;
 use rustc_hir as hir;
-use rustc_hir::GeneratorKind;
+use rustc_index::vec::IndexVec;
+use rustc_middle::middle::region;
+use rustc_middle::mir::*;
 use rustc_span::{Span, DUMMY_SP};
-use std::collections::hash_map::Entry;
-use std::mem;
+
+#[derive(Debug)]
+pub struct Scopes<'tcx> {
+    scopes: Vec<Scope>,
+    /// The current set of breakable scopes. See module comment for more details.
+    breakable_scopes: Vec<BreakableScope<'tcx>>,
+
+    /// Drops that need to be done on unwind paths. See the comment on
+    /// [DropTree] for more details.
+    unwind_drops: DropTree,
+
+    /// Drops that need to be done on paths to the `GeneratorDrop` terminator.
+    generator_drops: DropTree,
+}
 
 #[derive(Debug)]
 struct Scope {
@@ -112,73 +123,45 @@ struct Scope {
 
     moved_locals: Vec<Local>,
 
-    /// The cache for drop chain on “normal” exit into a particular BasicBlock.
-    cached_exits: FxHashMap<(BasicBlock, region::Scope), BasicBlock>,
+    /// The drop index that will drop everything in and below this scope on an
+    /// unwind path.
+    cached_unwind_block: Option<DropIdx>,
 
-    /// The cache for drop chain on "generator drop" exit.
-    cached_generator_drop: Option<BasicBlock>,
-
-    /// The cache for drop chain on "unwind" exit.
-    cached_unwind: CachedBlock,
+    /// The drop index that will drop everything in and below this scope on a
+    /// generator drop path.
+    cached_generator_drop_block: Option<DropIdx>,
 }
 
-#[derive(Debug, Default)]
-crate struct Scopes<'tcx> {
-    scopes: Vec<Scope>,
-    /// The current set of breakable scopes. See module comment for more details.
-    breakable_scopes: Vec<BreakableScope<'tcx>>,
-}
-
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 struct DropData {
-    /// span where drop obligation was incurred (typically where place was declared)
-    span: Span,
+    /// The `Span` where drop obligation was incurred (typically where place was
+    /// declared)
+    source_info: SourceInfo,
 
     /// local to drop
     local: Local,
 
     /// Whether this is a value Drop or a StorageDead.
     kind: DropKind,
-
-    /// The cached blocks for unwinds.
-    cached_block: CachedBlock,
 }
 
-#[derive(Debug, Default, Clone, Copy)]
-struct CachedBlock {
-    /// The cached block for the cleanups-on-diverge path. This block
-    /// contains code to run the current drop and all the preceding
-    /// drops (i.e., those having lower index in Drop’s Scope drop
-    /// array)
-    unwind: Option<BasicBlock>,
-
-    /// The cached block for unwinds during cleanups-on-generator-drop path
-    ///
-    /// This is split from the standard unwind path here to prevent drop
-    /// elaboration from creating drop flags that would have to be captured
-    /// by the generator. I'm not sure how important this optimization is,
-    /// but it is here.
-    generator_drop: Option<BasicBlock>,
-}
-
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub(crate) enum DropKind {
     Value,
     Storage,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 struct BreakableScope<'tcx> {
     /// Region scope of the loop
     region_scope: region::Scope,
-    /// Where the body of the loop begins. `None` if block
-    continue_block: Option<BasicBlock>,
-    /// Block to branch into when the loop or block terminates (either by being
-    /// `break`-en out from, or by having its condition to become false)
-    break_block: BasicBlock,
     /// The destination of the loop/block expression itself (i.e., where to put
-    /// the result of a `break` expression)
+    /// the result of a `break` or `return` expression)
     break_destination: Place<'tcx>,
+    /// Drops that happen on the `break`/`return` path.
+    break_drops: DropTree,
+    /// Drops that happen on the `continue` path.
+    continue_drops: Option<DropTree>,
 }
 
 /// The target of an expression that breaks out of a scope
@@ -189,61 +172,33 @@ crate enum BreakableTarget {
     Return,
 }
 
-impl CachedBlock {
-    fn invalidate(&mut self) {
-        *self = CachedBlock::default();
-    }
+rustc_index::newtype_index! {
+    struct DropIdx { .. }
+}
 
-    fn get(&self, generator_drop: bool) -> Option<BasicBlock> {
-        if generator_drop { self.generator_drop } else { self.unwind }
-    }
+const ROOT_NODE: DropIdx = DropIdx::from_u32(0);
 
-    fn ref_mut(&mut self, generator_drop: bool) -> &mut Option<BasicBlock> {
-        if generator_drop { &mut self.generator_drop } else { &mut self.unwind }
-    }
+/// A tree of drops that we have deferred lowering. It's used for:
+///
+/// * Drops on unwind paths
+/// * Drops on generator drop paths (when a suspended generator is dropped)
+/// * Drops on return and loop exit paths
+///
+/// Once no more nodes could be added to the tree, we lower it to MIR in one go
+/// in `build_drop_tree`.
+#[derive(Debug)]
+struct DropTree {
+    /// Drops in the tree.
+    drops: IndexVec<DropIdx, (DropData, DropIdx)>,
+    /// Map for finding the inverse of the `next_drop` relation:
+    ///
+    /// `previous_drops[(drops[i].1, drops[i].0.local, drops[i].0.kind] == i`
+    previous_drops: FxHashMap<(DropIdx, Local, DropKind), DropIdx>,
+    /// Edges into the `DropTree` that need to be added once it's lowered.
+    entry_points: Vec<(DropIdx, BasicBlock)>,
 }
 
 impl Scope {
-    /// Invalidates all the cached blocks in the scope.
-    ///
-    /// Should always be run for all inner scopes when a drop is pushed into some scope enclosing a
-    /// larger extent of code.
-    ///
-    /// `storage_only` controls whether to invalidate only drop paths that run `StorageDead`.
-    /// `this_scope_only` controls whether to invalidate only drop paths that refer to the current
-    /// top-of-scope (as opposed to dependent scopes).
-    fn invalidate_cache(
-        &mut self,
-        storage_only: bool,
-        generator_kind: Option<GeneratorKind>,
-        this_scope_only: bool,
-    ) {
-        // FIXME: maybe do shared caching of `cached_exits` etc. to handle functions
-        // with lots of `try!`?
-
-        // cached exits drop storage and refer to the top-of-scope
-        self.cached_exits.clear();
-
-        // the current generator drop and unwind refer to top-of-scope
-        self.cached_generator_drop = None;
-
-        let ignore_unwinds = storage_only && generator_kind.is_none();
-        if !ignore_unwinds {
-            self.cached_unwind.invalidate();
-        }
-
-        if !ignore_unwinds && !this_scope_only {
-            for drop_data in &mut self.drops {
-                drop_data.cached_block.invalidate();
-            }
-        }
-    }
-
-    /// Given a span and this scope's source scope, make a SourceInfo.
-    fn source_info(&self, span: Span) -> SourceInfo {
-        SourceInfo { span, scope: self.source_scope }
-    }
-
     /// Whether there's anything to do for the cleanup path, that is,
     /// when unwinding through this scope. This includes destructors,
     /// but not StorageDead statements, which don't get emitted at all
@@ -261,11 +216,182 @@ impl Scope {
             DropKind::Storage => false,
         })
     }
+
+    fn invalidate_cache(&mut self) {
+        self.cached_unwind_block = None;
+        self.cached_generator_drop_block = None;
+    }
+}
+
+/// A trait that determined how [DropTree::lower_to_mir] creates its blocks and
+/// links to any entry nodes.
+trait DropTreeBuilder<'tcx> {
+    /// Create a new block for the tree. This should call either
+    /// `cfg.start_new_block()` or `cfg.start_new_cleanup_block()`.
+    fn make_block(cfg: &mut CFG<'tcx>) -> BasicBlock;
+
+    /// Links a block outside the drop tree, `from`, to the block `to` inside
+    /// the drop tree.
+    fn add_entry(cfg: &mut CFG<'tcx>, from: BasicBlock, to: BasicBlock);
+}
+
+impl DropTree {
+    fn new() -> Self {
+        let fake_source_info = SourceInfo::outermost(DUMMY_SP);
+        let fake_data =
+            DropData { source_info: fake_source_info, local: Local::MAX, kind: DropKind::Storage };
+        let drop_idx = DropIdx::MAX;
+        let drops = IndexVec::from_elem_n((fake_data, drop_idx), 1);
+        Self { drops, entry_points: Vec::new(), previous_drops: FxHashMap::default() }
+    }
+
+    fn add_drop(&mut self, drop: DropData, next: DropIdx) -> DropIdx {
+        let drops = &mut self.drops;
+        *self
+            .previous_drops
+            .entry((next, drop.local, drop.kind))
+            .or_insert_with(|| drops.push((drop, next)))
+    }
+
+    fn add_entry(&mut self, from: BasicBlock, to: DropIdx) {
+        debug_assert!(to < self.drops.next_index());
+        self.entry_points.push((to, from));
+    }
+
+    fn build_mir<'tcx, T: DropTreeBuilder<'tcx>>(
+        &mut self,
+        cfg: &mut CFG<'tcx>,
+        blocks: &mut IndexVec<DropIdx, Option<BasicBlock>>,
+    ) {
+        debug!("DropTree::build_mir(drops = {:#?})", self);
+        assert_eq!(blocks.len(), self.drops.len());
+
+        self.assign_blocks::<T>(cfg, blocks);
+        self.link_blocks(cfg, blocks)
+    }
+
+    /// Assign blocks for all of the drops in the drop tree that need them.
+    fn assign_blocks<'tcx, T: DropTreeBuilder<'tcx>>(
+        &mut self,
+        cfg: &mut CFG<'tcx>,
+        blocks: &mut IndexVec<DropIdx, Option<BasicBlock>>,
+    ) {
+        // StorageDead statements can share blocks with each other and also with
+        // a Drop terminator. We iterate through the blocks to find which blocks
+        // need
+        #[derive(Clone, Copy)]
+        enum Block {
+            // This drop is unreachable
+            None,
+            // This drop is only reachable through the `StorageDead` with the
+            // specified index.
+            Shares(DropIdx),
+            // This drop has more than one way of being reached, or it is
+            // branched to from outside the tree, or it's predecessor is a
+            // `Value` drop.
+            Own,
+        }
+
+        let mut needs_block = IndexVec::from_elem(Block::None, &self.drops);
+        if blocks[ROOT_NODE].is_some() {
+            // In some cases (such as drops for `continue`) the root node
+            // already has a block. In this case, make sure that we don't
+            // override it.
+            needs_block[ROOT_NODE] = Block::Own;
+        }
+
+        // Sort so that we only need to check the last
+        let entry_points = &mut self.entry_points;
+        entry_points.sort();
+
+        for (drop_idx, drop_data) in self.drops.iter_enumerated().rev() {
+            if entry_points.last().map_or(false, |entry_point| entry_point.0 == drop_idx) {
+                let block = *blocks[drop_idx].get_or_insert_with(|| T::make_block(cfg));
+                needs_block[drop_idx] = Block::Own;
+                while entry_points.last().map_or(false, |entry_point| entry_point.0 == drop_idx) {
+                    let entry_block = entry_points.pop().unwrap().1;
+                    T::add_entry(cfg, entry_block, block);
+                }
+            }
+            match needs_block[drop_idx] {
+                Block::None => continue,
+                Block::Own => {
+                    blocks[drop_idx].get_or_insert_with(|| T::make_block(cfg));
+                }
+                Block::Shares(pred) => {
+                    blocks[drop_idx] = blocks[pred];
+                }
+            }
+            if let DropKind::Value = drop_data.0.kind {
+                needs_block[drop_data.1] = Block::Own;
+            } else {
+                if drop_idx != ROOT_NODE {
+                    match &mut needs_block[drop_data.1] {
+                        pred @ Block::None => *pred = Block::Shares(drop_idx),
+                        pred @ Block::Shares(_) => *pred = Block::Own,
+                        Block::Own => (),
+                    }
+                }
+            }
+        }
+
+        debug!("assign_blocks: blocks = {:#?}", blocks);
+        assert!(entry_points.is_empty());
+    }
+
+    fn link_blocks<'tcx>(
+        &self,
+        cfg: &mut CFG<'tcx>,
+        blocks: &IndexVec<DropIdx, Option<BasicBlock>>,
+    ) {
+        for (drop_idx, drop_data) in self.drops.iter_enumerated().rev() {
+            let block = if let Some(block) = blocks[drop_idx] {
+                block
+            } else {
+                continue;
+            };
+            match drop_data.0.kind {
+                DropKind::Value => {
+                    let terminator = TerminatorKind::Drop {
+                        target: blocks[drop_data.1].unwrap(),
+                        // The caller will handle this if needed.
+                        unwind: None,
+                        location: drop_data.0.local.into(),
+                    };
+                    cfg.terminate(block, drop_data.0.source_info, terminator);
+                }
+                // Root nodes don't correspond to a drop.
+                DropKind::Storage if drop_idx == ROOT_NODE => {}
+                DropKind::Storage => {
+                    let stmt = Statement {
+                        source_info: drop_data.0.source_info,
+                        kind: StatementKind::StorageDead(drop_data.0.local),
+                    };
+                    cfg.push(block, stmt);
+                    let target = blocks[drop_data.1].unwrap();
+                    if target != block {
+                        // Diagnostics don't use this `Span` but debuginfo
+                        // might. Since we don't want breakpoints to be placed
+                        // here, especially when this is on an unwind path, we
+                        // use `DUMMY_SP`.
+                        let source_info = SourceInfo { span: DUMMY_SP, ..drop_data.0.source_info };
+                        let terminator = TerminatorKind::Goto { target };
+                        cfg.terminate(block, source_info, terminator);
+                    }
+                }
+            }
+        }
+    }
 }
 
 impl<'tcx> Scopes<'tcx> {
-    fn len(&self) -> usize {
-        self.scopes.len()
+    pub(crate) fn new() -> Self {
+        Self {
+            scopes: Vec::new(),
+            breakable_scopes: Vec::new(),
+            unwind_drops: DropTree::new(),
+            generator_drops: DropTree::new(),
+        }
     }
 
     fn push_scope(&mut self, region_scope: (region::Scope, SourceInfo), vis_scope: SourceScope) {
@@ -276,93 +402,28 @@ impl<'tcx> Scopes<'tcx> {
             region_scope_span: region_scope.1.span,
             drops: vec![],
             moved_locals: vec![],
-            cached_generator_drop: None,
-            cached_exits: Default::default(),
-            cached_unwind: CachedBlock::default(),
+            cached_unwind_block: None,
+            cached_generator_drop_block: None,
         });
     }
 
-    fn pop_scope(
-        &mut self,
-        region_scope: (region::Scope, SourceInfo),
-    ) -> (Scope, Option<BasicBlock>) {
+    fn pop_scope(&mut self, region_scope: (region::Scope, SourceInfo)) -> Scope {
         let scope = self.scopes.pop().unwrap();
         assert_eq!(scope.region_scope, region_scope.0);
-        let unwind_to =
-            self.scopes.last().and_then(|next_scope| next_scope.cached_unwind.get(false));
-        (scope, unwind_to)
+        scope
     }
 
-    fn may_panic(&self, scope_count: usize) -> bool {
-        let len = self.len();
-        self.scopes[(len - scope_count)..].iter().any(|s| s.needs_cleanup())
-    }
-
-    /// Finds the breakable scope for a given label. This is used for
-    /// resolving `return`, `break` and `continue`.
-    fn find_breakable_scope(
-        &self,
-        span: Span,
-        target: BreakableTarget,
-    ) -> (BasicBlock, region::Scope, Option<Place<'tcx>>) {
-        let get_scope = |scope: region::Scope| {
-            // find the loop-scope by its `region::Scope`.
-            self.breakable_scopes
-                .iter()
-                .rfind(|breakable_scope| breakable_scope.region_scope == scope)
-                .unwrap_or_else(|| span_bug!(span, "no enclosing breakable scope found"))
-        };
-        match target {
-            BreakableTarget::Return => {
-                let scope = &self.breakable_scopes[0];
-                if scope.break_destination != Place::return_place() {
-                    span_bug!(span, "`return` in item with no return scope");
-                }
-                (scope.break_block, scope.region_scope, Some(scope.break_destination))
-            }
-            BreakableTarget::Break(scope) => {
-                let scope = get_scope(scope);
-                (scope.break_block, scope.region_scope, Some(scope.break_destination))
-            }
-            BreakableTarget::Continue(scope) => {
-                let scope = get_scope(scope);
-                let continue_block = scope
-                    .continue_block
-                    .unwrap_or_else(|| span_bug!(span, "missing `continue` block"));
-                (continue_block, scope.region_scope, None)
-            }
-        }
-    }
-
-    fn num_scopes_above(&self, region_scope: region::Scope, span: Span) -> usize {
-        let scope_count = self
-            .scopes
+    fn scope_index(&self, region_scope: region::Scope, span: Span) -> usize {
+        self.scopes
             .iter()
-            .rev()
-            .position(|scope| scope.region_scope == region_scope)
-            .unwrap_or_else(|| span_bug!(span, "region_scope {:?} does not enclose", region_scope));
-        let len = self.len();
-        assert!(scope_count < len, "should not use `exit_scope` to pop ALL scopes");
-        scope_count
-    }
-
-    fn iter_mut(&mut self) -> impl DoubleEndedIterator<Item = &mut Scope> + '_ {
-        self.scopes.iter_mut().rev()
-    }
-
-    fn top_scopes(&mut self, count: usize) -> impl DoubleEndedIterator<Item = &mut Scope> + '_ {
-        let len = self.len();
-        self.scopes[len - count..].iter_mut()
+            .rposition(|scope| scope.region_scope == region_scope)
+            .unwrap_or_else(|| span_bug!(span, "region_scope {:?} does not enclose", region_scope))
     }
 
     /// Returns the topmost active scope, which is known to be alive until
     /// the next scope expression.
-    pub(super) fn topmost(&self) -> region::Scope {
+    fn topmost(&self) -> region::Scope {
         self.scopes.last().expect("topmost_scope: no scopes present").region_scope
-    }
-
-    fn source_info(&self, index: usize, span: Span) -> SourceInfo {
-        self.scopes[self.len() - index].source_info(span)
     }
 }
 
@@ -371,28 +432,50 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
     // ==========================
     //  Start a breakable scope, which tracks where `continue`, `break` and
     //  `return` should branch to.
-    crate fn in_breakable_scope<F, R>(
+    crate fn in_breakable_scope<F>(
         &mut self,
         loop_block: Option<BasicBlock>,
-        break_block: BasicBlock,
         break_destination: Place<'tcx>,
+        span: Span,
         f: F,
-    ) -> R
+    ) -> BlockAnd<()>
     where
-        F: FnOnce(&mut Builder<'a, 'tcx>) -> R,
+        F: FnOnce(&mut Builder<'a, 'tcx>) -> Option<BlockAnd<()>>,
     {
         let region_scope = self.scopes.topmost();
         let scope = BreakableScope {
             region_scope,
-            continue_block: loop_block,
-            break_block,
             break_destination,
+            break_drops: DropTree::new(),
+            continue_drops: loop_block.map(|_| DropTree::new()),
         };
         self.scopes.breakable_scopes.push(scope);
-        let res = f(self);
+        let normal_exit_block = f(self);
         let breakable_scope = self.scopes.breakable_scopes.pop().unwrap();
         assert!(breakable_scope.region_scope == region_scope);
-        res
+        let break_block = self.build_exit_tree(breakable_scope.break_drops, None);
+        breakable_scope.continue_drops.map(|drops| {
+            self.build_exit_tree(drops, loop_block);
+        });
+        match (normal_exit_block, break_block) {
+            (Some(block), None) | (None, Some(block)) => block,
+            (None, None) => self.cfg.start_new_block().unit(),
+            (Some(normal_block), Some(exit_block)) => {
+                let target = self.cfg.start_new_block();
+                let source_info = self.source_info(span);
+                self.cfg.terminate(
+                    unpack!(normal_block),
+                    source_info,
+                    TerminatorKind::Goto { target },
+                );
+                self.cfg.terminate(
+                    unpack!(exit_block),
+                    source_info,
+                    TerminatorKind::Goto { target },
+                );
+                target.unit()
+            }
+        }
     }
 
     crate fn in_opt_scope<F, R>(
@@ -476,46 +559,51 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         mut block: BasicBlock,
     ) -> BlockAnd<()> {
         debug!("pop_scope({:?}, {:?})", region_scope, block);
-        // If we are emitting a `drop` statement, we need to have the cached
-        // diverge cleanup pads ready in case that drop panics.
-        if self.scopes.may_panic(1) {
-            self.diverge_cleanup();
-        }
-        let (scope, unwind_to) = self.scopes.pop_scope(region_scope);
-        let unwind_to = unwind_to.unwrap_or_else(|| self.resume_block());
 
-        unpack!(
-            block = build_scope_drops(
-                &mut self.cfg,
-                self.generator_kind,
-                &scope,
-                block,
-                unwind_to,
-                self.arg_count,
-                false, // not generator
-                false, // not unwind path
-            )
-        );
+        block = self.leave_top_scope(block);
+
+        self.scopes.pop_scope(region_scope);
 
         block.unit()
     }
 
+    /// Sets up the drops for breaking from `block` to `target`.
     crate fn break_scope(
         &mut self,
         mut block: BasicBlock,
         value: Option<ExprRef<'tcx>>,
-        scope: BreakableTarget,
+        target: BreakableTarget,
         source_info: SourceInfo,
     ) -> BlockAnd<()> {
-        let (mut target_block, region_scope, destination) =
-            self.scopes.find_breakable_scope(source_info.span, scope);
-        if let BreakableTarget::Return = scope {
-            // We call this now, rather than when we start lowering the
-            // function so that the return block doesn't precede the entire
-            // rest of the CFG. Some passes and LLVM prefer blocks to be in
-            // approximately CFG order.
-            target_block = self.return_block();
-        }
+        let span = source_info.span;
+
+        let get_scope_index = |scope: region::Scope| {
+            // find the loop-scope by its `region::Scope`.
+            self.scopes
+                .breakable_scopes
+                .iter()
+                .rposition(|breakable_scope| breakable_scope.region_scope == scope)
+                .unwrap_or_else(|| span_bug!(span, "no enclosing breakable scope found"))
+        };
+        let (break_index, destination) = match target {
+            BreakableTarget::Return => {
+                let scope = &self.scopes.breakable_scopes[0];
+                if scope.break_destination != Place::return_place() {
+                    span_bug!(span, "`return` in item with no return scope");
+                }
+                (0, Some(scope.break_destination))
+            }
+            BreakableTarget::Break(scope) => {
+                let break_index = get_scope_index(scope);
+                let scope = &self.scopes.breakable_scopes[break_index];
+                (break_index, Some(scope.break_destination))
+            }
+            BreakableTarget::Continue(scope) => {
+                let break_index = get_scope_index(scope);
+                (break_index, None)
+            }
+        };
+
         if let Some(destination) = destination {
             if let Some(value) = value {
                 debug!("stmt_expr Break val block_context.push(SubExpr)");
@@ -528,131 +616,57 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         } else {
             assert!(value.is_none(), "`return` and `break` should have a destination");
         }
-        self.exit_scope(source_info.span, region_scope, block, target_block);
+
+        let region_scope = self.scopes.breakable_scopes[break_index].region_scope;
+        let scope_index = self.scopes.scope_index(region_scope, span);
+        let drops = if destination.is_some() {
+            &mut self.scopes.breakable_scopes[break_index].break_drops
+        } else {
+            self.scopes.breakable_scopes[break_index].continue_drops.as_mut().unwrap()
+        };
+        let mut drop_idx = ROOT_NODE;
+        for scope in &self.scopes.scopes[scope_index + 1..] {
+            for drop in &scope.drops {
+                drop_idx = drops.add_drop(*drop, drop_idx);
+            }
+        }
+        drops.add_entry(block, drop_idx);
+
+        // `build_drop_tree` doesn't have access to our source_info, so we
+        // create a dummy terminator now. `TerminatorKind::Resume` is used
+        // because MIR type checking will panic if it hasn't been overwritten.
+        self.cfg.terminate(block, source_info, TerminatorKind::Resume);
+
         self.cfg.start_new_block().unit()
     }
 
-    /// Branch out of `block` to `target`, exiting all scopes up to
-    /// and including `region_scope`. This will insert whatever drops are
-    /// needed. See module comment for details.
-    crate fn exit_scope(
+    crate fn exit_top_scope(
         &mut self,
-        span: Span,
-        region_scope: region::Scope,
         mut block: BasicBlock,
         target: BasicBlock,
+        source_info: SourceInfo,
     ) {
-        debug!(
-            "exit_scope(region_scope={:?}, block={:?}, target={:?})",
-            region_scope, block, target
-        );
-        let scope_count = self.scopes.num_scopes_above(region_scope, span);
-
-        // If we are emitting a `drop` statement, we need to have the cached
-        // diverge cleanup pads ready in case that drop panics.
-        let may_panic = self.scopes.may_panic(scope_count);
-        if may_panic {
-            self.diverge_cleanup();
-        }
-
-        let mut scopes = self.scopes.top_scopes(scope_count + 1).rev();
-        let mut scope = scopes.next().unwrap();
-        for next_scope in scopes {
-            if scope.drops.is_empty() {
-                scope = next_scope;
-                continue;
-            }
-            let source_info = scope.source_info(span);
-            block = match scope.cached_exits.entry((target, region_scope)) {
-                Entry::Occupied(e) => {
-                    self.cfg.goto(block, source_info, *e.get());
-                    return;
-                }
-                Entry::Vacant(v) => {
-                    let b = self.cfg.start_new_block();
-                    self.cfg.goto(block, source_info, b);
-                    v.insert(b);
-                    b
-                }
-            };
-
-            let unwind_to = next_scope.cached_unwind.get(false).unwrap_or_else(|| {
-                debug_assert!(!may_panic, "cached block not present?");
-                START_BLOCK
-            });
-
-            unpack!(
-                block = build_scope_drops(
-                    &mut self.cfg,
-                    self.generator_kind,
-                    scope,
-                    block,
-                    unwind_to,
-                    self.arg_count,
-                    false, // not generator
-                    false, // not unwind path
-                )
-            );
-
-            scope = next_scope;
-        }
-
-        self.cfg.goto(block, self.scopes.source_info(scope_count, span), target);
+        block = self.leave_top_scope(block);
+        self.cfg.terminate(block, source_info, TerminatorKind::Goto { target });
     }
 
-    /// Creates a path that performs all required cleanup for dropping a generator.
-    ///
-    /// This path terminates in GeneratorDrop. Returns the start of the path.
-    /// None indicates there’s no cleanup to do at this point.
-    crate fn generator_drop_cleanup(&mut self) -> Option<BasicBlock> {
-        // Fill in the cache for unwinds
-        self.diverge_cleanup_gen(true);
+    fn leave_top_scope(&mut self, block: BasicBlock) -> BasicBlock {
+        // If we are emitting a `drop` statement, we need to have the cached
+        // diverge cleanup pads ready in case that drop panics.
+        let needs_cleanup = self.scopes.scopes.last().map_or(false, |scope| scope.needs_cleanup());
+        let is_generator = self.generator_kind.is_some();
+        let unwind_to = if needs_cleanup { self.diverge_cleanup() } else { DropIdx::MAX };
 
-        let src_info = self.scopes.source_info(self.scopes.len(), self.fn_span);
-        let resume_block = self.resume_block();
-        let mut scopes = self.scopes.iter_mut().peekable();
-        let mut block = self.cfg.start_new_block();
-        let result = block;
-
-        while let Some(scope) = scopes.next() {
-            block = if let Some(b) = scope.cached_generator_drop {
-                self.cfg.goto(block, src_info, b);
-                return Some(result);
-            } else {
-                let b = self.cfg.start_new_block();
-                scope.cached_generator_drop = Some(b);
-                self.cfg.goto(block, src_info, b);
-                b
-            };
-
-            let unwind_to = scopes
-                .peek()
-                .as_ref()
-                .map(|scope| {
-                    scope
-                        .cached_unwind
-                        .get(true)
-                        .unwrap_or_else(|| span_bug!(src_info.span, "cached block not present?"))
-                })
-                .unwrap_or(resume_block);
-
-            unpack!(
-                block = build_scope_drops(
-                    &mut self.cfg,
-                    self.generator_kind,
-                    scope,
-                    block,
-                    unwind_to,
-                    self.arg_count,
-                    true, // is generator
-                    true, // is cached path
-                )
-            );
-        }
-
-        self.cfg.terminate(block, src_info, TerminatorKind::GeneratorDrop);
-
-        Some(result)
+        let scope = self.scopes.scopes.last().expect("leave_top_scope called with no scopes");
+        unpack!(build_scope_drops(
+            &mut self.cfg,
+            &mut self.scopes.unwind_drops,
+            scope,
+            block,
+            unwind_to,
+            is_generator && needs_cleanup,
+            self.arg_count,
+        ))
     }
 
     /// Creates a new source scope, nested in the current one.
@@ -728,15 +742,6 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         }
     }
 
-    // Schedule an abort block - this is used for some ABIs that cannot unwind
-    crate fn schedule_abort(&mut self) -> BasicBlock {
-        let source_info = self.scopes.source_info(self.scopes.len(), self.fn_span);
-        let abortblk = self.cfg.start_new_cleanup_block();
-        self.cfg.terminate(abortblk, source_info, TerminatorKind::Abort);
-        self.cached_resume_block = Some(abortblk);
-        abortblk
-    }
-
     // Scheduling drops
     // ================
     crate fn schedule_drop_storage_and_value(
@@ -749,11 +754,10 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         self.schedule_drop(span, region_scope, local, DropKind::Value);
     }
 
-    /// Indicates that `place` should be dropped on exit from
-    /// `region_scope`.
+    /// Indicates that `place` should be dropped on exit from `region_scope`.
     ///
-    /// When called with `DropKind::Storage`, `place` should be a local
-    /// with an index higher than the current `self.arg_count`.
+    /// When called with `DropKind::Storage`, `place` shouldn't be the return
+    /// place, or a function parameter.
     crate fn schedule_drop(
         &mut self,
         span: Span,
@@ -781,70 +785,74 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             }
         };
 
-        for scope in self.scopes.iter_mut() {
-            let this_scope = scope.region_scope == region_scope;
-            // When building drops, we try to cache chains of drops in such a way so these drops
-            // could be reused by the drops which would branch into the cached (already built)
-            // blocks.  This, however, means that whenever we add a drop into a scope which already
-            // had some blocks built (and thus, cached) for it, we must invalidate all caches which
-            // might branch into the scope which had a drop just added to it. This is necessary,
-            // because otherwise some other code might use the cache to branch into already built
-            // chain of drops, essentially ignoring the newly added drop.
-            //
-            // For example consider there’s two scopes with a drop in each. These are built and
-            // thus the caches are filled:
-            //
-            // +--------------------------------------------------------+
-            // | +---------------------------------+                    |
-            // | | +--------+     +-------------+  |  +---------------+ |
-            // | | | return | <-+ | drop(outer) | <-+ |  drop(middle) | |
-            // | | +--------+     +-------------+  |  +---------------+ |
-            // | +------------|outer_scope cache|--+                    |
-            // +------------------------------|middle_scope cache|------+
-            //
-            // Now, a new, inner-most scope is added along with a new drop into both inner-most and
-            // outer-most scopes:
-            //
-            // +------------------------------------------------------------+
-            // | +----------------------------------+                       |
-            // | | +--------+      +-------------+  |   +---------------+   | +-------------+
-            // | | | return | <+   | drop(new)   | <-+  |  drop(middle) | <--+| drop(inner) |
-            // | | +--------+  |   | drop(outer) |  |   +---------------+   | +-------------+
-            // | |             +-+ +-------------+  |                       |
-            // | +---|invalid outer_scope cache|----+                       |
-            // +----=----------------|invalid middle_scope cache|-----------+
-            //
-            // If, when adding `drop(new)` we do not invalidate the cached blocks for both
-            // outer_scope and middle_scope, then, when building drops for the inner (right-most)
-            // scope, the old, cached blocks, without `drop(new)` will get used, producing the
-            // wrong results.
-            //
-            // The cache and its invalidation for unwind branch is somewhat special. The cache is
-            // per-drop, rather than per scope, which has a several different implications. Adding
-            // a new drop into a scope will not invalidate cached blocks of the prior drops in the
-            // scope. That is true, because none of the already existing drops will have an edge
-            // into a block with the newly added drop.
-            //
-            // Note that this code iterates scopes from the inner-most to the outer-most,
-            // invalidating caches of each scope visited. This way bare minimum of the
-            // caches gets invalidated. i.e., if a new drop is added into the middle scope, the
-            // cache of outer scope stays intact.
-            scope.invalidate_cache(!needs_drop, self.generator_kind, this_scope);
-            if this_scope {
+        // When building drops, we try to cache chains of drops to reduce the
+        // number of `DropTree::add_drop` calls. This, however, means that
+        // whenever we add a drop into a scope which already had some entries
+        // in the drop tree built (and thus, cached) for it, we must invalidate
+        // all caches which might branch into the scope which had a drop just
+        // added to it. This is necessary, because otherwise some other code
+        // might use the cache to branch into already built chain of drops,
+        // essentially ignoring the newly added drop.
+        //
+        // For example consider there’s two scopes with a drop in each. These
+        // are built and thus the caches are filled:
+        //
+        // +--------------------------------------------------------+
+        // | +---------------------------------+                    |
+        // | | +--------+     +-------------+  |  +---------------+ |
+        // | | | return | <-+ | drop(outer) | <-+ |  drop(middle) | |
+        // | | +--------+     +-------------+  |  +---------------+ |
+        // | +------------|outer_scope cache|--+                    |
+        // +------------------------------|middle_scope cache|------+
+        //
+        // Now, a new, inner-most scope is added along with a new drop into
+        // both inner-most and outer-most scopes:
+        //
+        // +------------------------------------------------------------+
+        // | +----------------------------------+                       |
+        // | | +--------+      +-------------+  |   +---------------+   | +-------------+
+        // | | | return | <+   | drop(new)   | <-+  |  drop(middle) | <--+| drop(inner) |
+        // | | +--------+  |   | drop(outer) |  |   +---------------+   | +-------------+
+        // | |             +-+ +-------------+  |                       |
+        // | +---|invalid outer_scope cache|----+                       |
+        // +----=----------------|invalid middle_scope cache|-----------+
+        //
+        // If, when adding `drop(new)` we do not invalidate the cached blocks for both
+        // outer_scope and middle_scope, then, when building drops for the inner (right-most)
+        // scope, the old, cached blocks, without `drop(new)` will get used, producing the
+        // wrong results.
+        //
+        // Note that this code iterates scopes from the inner-most to the outer-most,
+        // invalidating caches of each scope visited. This way bare minimum of the
+        // caches gets invalidated. i.e., if a new drop is added into the middle scope, the
+        // cache of outer scope stays intact.
+        //
+        // Since we only cache drops for the unwind path and the generator drop
+        // path, we only need to invalidate the cache for drops that happen on
+        // the unwind or generator drop paths. This means that for
+        // non-generators we don't need to invalidate caches for `DropKind::Storage`.
+        let invalidate_caches = needs_drop || self.generator_kind.is_some();
+        for scope in self.scopes.scopes.iter_mut().rev() {
+            if invalidate_caches {
+                scope.invalidate_cache();
+            }
+
+            if scope.region_scope == region_scope {
                 let region_scope_span =
                     region_scope.span(self.hir.tcx(), &self.hir.region_scope_tree);
                 // Attribute scope exit drops to scope's closing brace.
                 let scope_end = self.hir.tcx().sess.source_map().end_point(region_scope_span);
 
                 scope.drops.push(DropData {
-                    span: scope_end,
+                    source_info: SourceInfo { span: scope_end, scope: scope.source_scope },
                     local,
                     kind: drop_kind,
-                    cached_block: CachedBlock::default(),
                 });
+
                 return;
             }
         }
+
         span_bug!(span, "region scope {:?} not in scope to drop {:?}", region_scope, local);
     }
 
@@ -893,8 +901,9 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
 
             Some(local_scope) => self
                 .scopes
+                .scopes
                 .iter_mut()
-                .find(|scope| scope.region_scope == local_scope)
+                .rfind(|scope| scope.region_scope == local_scope)
                 .unwrap_or_else(|| bug!("scope {:?} not found in scope list!", local_scope)),
         };
 
@@ -944,13 +953,16 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     // Manually drop the condition on both branches.
                     let top_scope = self.scopes.scopes.last_mut().unwrap();
                     let top_drop_data = top_scope.drops.pop().unwrap();
+                    if self.generator_kind.is_some() {
+                        top_scope.invalidate_cache();
+                    }
 
                     match top_drop_data.kind {
                         DropKind::Value { .. } => {
                             bug!("Drop scheduled on top of condition variable")
                         }
                         DropKind::Storage => {
-                            let source_info = top_scope.source_info(top_drop_data.span);
+                            let source_info = top_drop_data.source_info;
                             let local = top_drop_data.local;
                             assert_eq!(local, cond_temp, "Drop scheduled on top of condition");
                             self.cfg.push(
@@ -963,8 +975,6 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                             );
                         }
                     }
-
-                    top_scope.invalidate_cache(true, self.generator_kind, true);
                 } else {
                     bug!("Expected as_local_operand to produce a temporary");
                 }
@@ -974,62 +984,86 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         (true_block, false_block)
     }
 
-    /// Creates a path that performs all required cleanup for unwinding.
+    /// Returns the [DropIdx] for the innermost drop if the function unwound at
+    /// this point. The `DropIdx` will be created if it doesn't already exist.
+    fn diverge_cleanup(&mut self) -> DropIdx {
+        let is_generator = self.generator_kind.is_some();
+        let (uncached_scope, mut cached_drop) = self
+            .scopes
+            .scopes
+            .iter()
+            .enumerate()
+            .rev()
+            .find_map(|(scope_idx, scope)| {
+                scope.cached_unwind_block.map(|cached_block| (scope_idx + 1, cached_block))
+            })
+            .unwrap_or((0, ROOT_NODE));
+
+        for scope in &mut self.scopes.scopes[uncached_scope..] {
+            for drop in &scope.drops {
+                if is_generator || drop.kind == DropKind::Value {
+                    cached_drop = self.scopes.unwind_drops.add_drop(*drop, cached_drop);
+                }
+            }
+            scope.cached_unwind_block = Some(cached_drop);
+        }
+
+        cached_drop
+    }
+
+    /// Prepares to create a path that performs all required cleanup for a
+    /// terminator that can unwind at the given basic block.
     ///
-    /// This path terminates in Resume. Returns the start of the path.
-    /// See module comment for more details.
-    crate fn diverge_cleanup(&mut self) -> BasicBlock {
-        self.diverge_cleanup_gen(false)
+    /// This path terminates in Resume. The path isn't created until after all
+    /// of the non-unwind paths in this item have been lowered.
+    crate fn diverge_from(&mut self, start: BasicBlock) {
+        debug_assert!(
+            matches!(
+                self.cfg.block_data(start).terminator().kind,
+                TerminatorKind::Assert { .. }
+                | TerminatorKind::Call {..}
+                | TerminatorKind::DropAndReplace { .. }
+                | TerminatorKind::FalseUnwind { .. }
+            ),
+            "diverge_from called on block with terminator that cannot unwind."
+        );
+
+        let next_drop = self.diverge_cleanup();
+        self.scopes.unwind_drops.add_entry(start, next_drop);
     }
 
-    fn resume_block(&mut self) -> BasicBlock {
-        if let Some(target) = self.cached_resume_block {
-            target
-        } else {
-            let resumeblk = self.cfg.start_new_cleanup_block();
-            self.cfg.terminate(
-                resumeblk,
-                SourceInfo::outermost(self.fn_span),
-                TerminatorKind::Resume,
-            );
-            self.cached_resume_block = Some(resumeblk);
-            resumeblk
-        }
-    }
+    /// Sets up a path that performs all required cleanup for dropping a
+    /// generator, starting from the given block that ends in
+    /// [TerminatorKind::Yield].
+    ///
+    /// This path terminates in GeneratorDrop.
+    crate fn generator_drop_cleanup(&mut self, yield_block: BasicBlock) {
+        debug_assert!(
+            matches!(
+                self.cfg.block_data(yield_block).terminator().kind,
+                TerminatorKind::Yield { .. }
+            ),
+            "generator_drop_cleanup called on block with non-yield terminator."
+        );
+        let (uncached_scope, mut cached_drop) = self
+            .scopes
+            .scopes
+            .iter()
+            .enumerate()
+            .rev()
+            .find_map(|(scope_idx, scope)| {
+                scope.cached_generator_drop_block.map(|cached_block| (scope_idx + 1, cached_block))
+            })
+            .unwrap_or((0, ROOT_NODE));
 
-    fn diverge_cleanup_gen(&mut self, generator_drop: bool) -> BasicBlock {
-        // Build up the drops in **reverse** order. The end result will
-        // look like:
-        //
-        //    scopes[n] -> scopes[n-1] -> ... -> scopes[0]
-        //
-        // However, we build this in **reverse order**. That is, we
-        // process scopes[0], then scopes[1], etc, pointing each one at
-        // the result generates from the one before. Along the way, we
-        // store caches. If everything is cached, we'll just walk right
-        // to left reading the cached results but never created anything.
-
-        // Find the last cached block
-        debug!("diverge_cleanup_gen(self.scopes = {:?})", self.scopes);
-        let cached_cleanup = self.scopes.iter_mut().enumerate().find_map(|(idx, ref scope)| {
-            let cached_block = scope.cached_unwind.get(generator_drop)?;
-            Some((cached_block, idx))
-        });
-        let (mut target, first_uncached) =
-            cached_cleanup.unwrap_or_else(|| (self.resume_block(), self.scopes.len()));
-
-        for scope in self.scopes.top_scopes(first_uncached) {
-            target = build_diverge_scope(
-                &mut self.cfg,
-                scope.region_scope_span,
-                scope,
-                target,
-                generator_drop,
-                self.generator_kind,
-            );
+        for scope in &mut self.scopes.scopes[uncached_scope..] {
+            for drop in &scope.drops {
+                cached_drop = self.scopes.generator_drops.add_drop(*drop, cached_drop);
+            }
+            scope.cached_generator_drop_block = Some(cached_drop);
         }
 
-        target
+        self.scopes.generator_drops.add_entry(yield_block, cached_drop);
     }
 
     /// Utility function for *non*-scope code to build their own drops
@@ -1042,21 +1076,18 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
     ) -> BlockAnd<()> {
         let source_info = self.source_info(span);
         let next_target = self.cfg.start_new_block();
-        let diverge_target = self.diverge_cleanup();
+
         self.cfg.terminate(
             block,
             source_info,
-            TerminatorKind::DropAndReplace {
-                location,
-                value,
-                target: next_target,
-                unwind: Some(diverge_target),
-            },
+            TerminatorKind::DropAndReplace { location, value, target: next_target, unwind: None },
         );
+        self.diverge_from(block);
+
         next_target.unit()
     }
 
-    /// Creates an Assert terminator and return the success block.
+    /// Creates an `Assert` terminator and return the success block.
     /// If the boolean condition operand is not the expected value,
     /// a runtime panic will be caused with the given message.
     crate fn assert(
@@ -1068,51 +1099,41 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         span: Span,
     ) -> BasicBlock {
         let source_info = self.source_info(span);
-
         let success_block = self.cfg.start_new_block();
-        let cleanup = self.diverge_cleanup();
 
         self.cfg.terminate(
             block,
             source_info,
-            TerminatorKind::Assert {
-                cond,
-                expected,
-                msg,
-                target: success_block,
-                cleanup: Some(cleanup),
-            },
+            TerminatorKind::Assert { cond, expected, msg, target: success_block, cleanup: None },
         );
+        self.diverge_from(block);
 
         success_block
     }
 
-    // `match` arm scopes
-    // ==================
     /// Unschedules any drops in the top scope.
     ///
     /// This is only needed for `match` arm scopes, because they have one
     /// entrance per pattern, but only one exit.
-    pub(crate) fn clear_top_scope(&mut self, region_scope: region::Scope) {
+    crate fn clear_top_scope(&mut self, region_scope: region::Scope) {
         let top_scope = self.scopes.scopes.last_mut().unwrap();
 
         assert_eq!(top_scope.region_scope, region_scope);
 
         top_scope.drops.clear();
-        top_scope.invalidate_cache(false, self.generator_kind, true);
+        top_scope.invalidate_cache();
     }
 }
 
-/// Builds drops for pop_scope and exit_scope.
+/// Builds drops for `pop_scope` and `leave_top_scope`.
 fn build_scope_drops<'tcx>(
     cfg: &mut CFG<'tcx>,
-    generator_kind: Option<GeneratorKind>,
+    unwind_drops: &mut DropTree,
     scope: &Scope,
     mut block: BasicBlock,
-    last_unwind_to: BasicBlock,
+    mut unwind_to: DropIdx,
+    storage_dead_on_unwind: bool,
     arg_count: usize,
-    generator_drop: bool,
-    is_cached_path: bool,
 ) -> BlockAnd<()> {
     debug!("build_scope_drops({:?} -> {:?})", block, scope);
 
@@ -1135,37 +1156,43 @@ fn build_scope_drops<'tcx>(
     // drops for the unwind path should have already been generated by
     // `diverge_cleanup_gen`.
 
-    for drop_idx in (0..scope.drops.len()).rev() {
-        let drop_data = &scope.drops[drop_idx];
-        let source_info = scope.source_info(drop_data.span);
+    for drop_data in scope.drops.iter().rev() {
+        let source_info = drop_data.source_info;
         let local = drop_data.local;
 
         match drop_data.kind {
             DropKind::Value => {
+                // `unwind_to` should drop the value that we're about to
+                // schedule. If dropping this value panics, then we continue
+                // with the *next* value on the unwind path.
+                debug_assert_eq!(unwind_drops.drops[unwind_to].0.local, drop_data.local);
+                debug_assert_eq!(unwind_drops.drops[unwind_to].0.kind, drop_data.kind);
+                unwind_to = unwind_drops.drops[unwind_to].1;
+
                 // If the operand has been moved, and we are not on an unwind
                 // path, then don't generate the drop. (We only take this into
                 // account for non-unwind paths so as not to disturb the
                 // caching mechanism.)
-                if !is_cached_path && scope.moved_locals.iter().any(|&o| o == local) {
+                if scope.moved_locals.iter().any(|&o| o == local) {
                     continue;
                 }
 
-                let unwind_to = get_unwind_to(scope, generator_kind, drop_idx, generator_drop)
-                    .unwrap_or(last_unwind_to);
+                unwind_drops.add_entry(block, unwind_to);
 
                 let next = cfg.start_new_block();
                 cfg.terminate(
                     block,
                     source_info,
-                    TerminatorKind::Drop {
-                        location: local.into(),
-                        target: next,
-                        unwind: Some(unwind_to),
-                    },
+                    TerminatorKind::Drop { location: local.into(), target: next, unwind: None },
                 );
                 block = next;
             }
             DropKind::Storage => {
+                if storage_dead_on_unwind {
+                    debug_assert_eq!(unwind_drops.drops[unwind_to].0.local, drop_data.local);
+                    debug_assert_eq!(unwind_drops.drops[unwind_to].0.kind, drop_data.kind);
+                    unwind_to = unwind_drops.drops[unwind_to].1;
+                }
                 // Only temps and vars need their storage dead.
                 assert!(local.index() > arg_count);
                 cfg.push(block, Statement { source_info, kind: StatementKind::StorageDead(local) });
@@ -1175,139 +1202,180 @@ fn build_scope_drops<'tcx>(
     block.unit()
 }
 
-fn get_unwind_to(
-    scope: &Scope,
-    generator_kind: Option<GeneratorKind>,
-    unwind_from: usize,
-    generator_drop: bool,
-) -> Option<BasicBlock> {
-    for drop_idx in (0..unwind_from).rev() {
-        let drop_data = &scope.drops[drop_idx];
-        match (generator_kind, &drop_data.kind) {
-            (Some(_), DropKind::Storage) => {
-                return Some(drop_data.cached_block.get(generator_drop).unwrap_or_else(|| {
-                    span_bug!(drop_data.span, "cached block not present for {:?}", drop_data)
-                }));
+impl<'a, 'tcx: 'a> Builder<'a, 'tcx> {
+    /// Build a drop tree for a breakable scope.
+    ///
+    /// If `continue_block` is `Some`, then the tree is for `continue` inside a
+    /// loop. Otherwise this is for `break` or `return`.
+    fn build_exit_tree(
+        &mut self,
+        mut drops: DropTree,
+        continue_block: Option<BasicBlock>,
+    ) -> Option<BlockAnd<()>> {
+        let mut blocks = IndexVec::from_elem(None, &drops.drops);
+        blocks[ROOT_NODE] = continue_block;
+
+        drops.build_mir::<ExitScopes>(&mut self.cfg, &mut blocks);
+
+        // Link the exit drop tree to unwind drop tree.
+        if drops.drops.iter().any(|(drop, _)| drop.kind == DropKind::Value) {
+            let unwind_target = self.diverge_cleanup();
+            let mut unwind_indices = IndexVec::from_elem_n(unwind_target, 1);
+            for (drop_idx, drop_data) in drops.drops.iter_enumerated().skip(1) {
+                match drop_data.0.kind {
+                    DropKind::Storage => {
+                        if self.generator_kind.is_some() {
+                            let unwind_drop = self
+                                .scopes
+                                .unwind_drops
+                                .add_drop(drop_data.0, unwind_indices[drop_data.1]);
+                            unwind_indices.push(unwind_drop);
+                        } else {
+                            unwind_indices.push(unwind_indices[drop_data.1]);
+                        }
+                    }
+                    DropKind::Value => {
+                        let unwind_drop = self
+                            .scopes
+                            .unwind_drops
+                            .add_drop(drop_data.0, unwind_indices[drop_data.1]);
+                        self.scopes
+                            .unwind_drops
+                            .add_entry(blocks[drop_idx].unwrap(), unwind_indices[drop_data.1]);
+                        unwind_indices.push(unwind_drop);
+                    }
+                }
             }
-            (None, DropKind::Value) => {
-                return Some(drop_data.cached_block.get(generator_drop).unwrap_or_else(|| {
-                    span_bug!(drop_data.span, "cached block not present for {:?}", drop_data)
-                }));
-            }
-            _ => (),
+        }
+        blocks[ROOT_NODE].map(BasicBlock::unit)
+    }
+
+    /// Build the unwind and generator drop trees.
+    crate fn build_drop_trees(&mut self, should_abort: bool) {
+        if self.generator_kind.is_some() {
+            self.build_generator_drop_trees(should_abort);
+        } else {
+            Self::build_unwind_tree(
+                &mut self.cfg,
+                &mut self.scopes.unwind_drops,
+                self.fn_span,
+                should_abort,
+                &mut None,
+            );
         }
     }
-    None
+
+    fn build_generator_drop_trees(&mut self, should_abort: bool) {
+        // Build the drop tree for dropping the generator while it's suspended.
+        let drops = &mut self.scopes.generator_drops;
+        let cfg = &mut self.cfg;
+        let fn_span = self.fn_span;
+        let mut blocks = IndexVec::from_elem(None, &drops.drops);
+        drops.build_mir::<GeneratorDrop>(cfg, &mut blocks);
+        if let Some(root_block) = blocks[ROOT_NODE] {
+            cfg.terminate(
+                root_block,
+                SourceInfo::outermost(fn_span),
+                TerminatorKind::GeneratorDrop,
+            );
+        }
+
+        // Build the drop tree for unwinding in the normal control flow paths.
+        let resume_block = &mut None;
+        let unwind_drops = &mut self.scopes.unwind_drops;
+        Self::build_unwind_tree(cfg, unwind_drops, fn_span, should_abort, resume_block);
+
+        // Build the drop tree for unwinding when dropping a suspended
+        // generator.
+        //
+        // This is a different tree to the standard unwind paths here to
+        // prevent drop elaboration from creating drop flags that would have
+        // to be captured by the generator. I'm not sure how important this
+        // optimization is, but it is here.
+        for (drop_idx, drop_data) in drops.drops.iter_enumerated() {
+            if let DropKind::Value = drop_data.0.kind {
+                debug_assert!(drop_data.1 < drops.drops.next_index());
+                drops.entry_points.push((drop_data.1, blocks[drop_idx].unwrap()));
+            }
+        }
+        Self::build_unwind_tree(cfg, drops, fn_span, should_abort, resume_block);
+    }
+
+    fn build_unwind_tree(
+        cfg: &mut CFG<'tcx>,
+        drops: &mut DropTree,
+        fn_span: Span,
+        should_abort: bool,
+        resume_block: &mut Option<BasicBlock>,
+    ) {
+        let mut blocks = IndexVec::from_elem(None, &drops.drops);
+        blocks[ROOT_NODE] = *resume_block;
+        drops.build_mir::<Unwind>(cfg, &mut blocks);
+        if let (None, Some(resume)) = (*resume_block, blocks[ROOT_NODE]) {
+            // `TerminatorKind::Abort` is used for `#[unwind(aborts)]`
+            // functions.
+            let terminator =
+                if should_abort { TerminatorKind::Abort } else { TerminatorKind::Resume };
+
+            cfg.terminate(resume, SourceInfo::outermost(fn_span), terminator);
+
+            *resume_block = blocks[ROOT_NODE];
+        }
+    }
 }
 
-fn build_diverge_scope<'tcx>(
-    cfg: &mut CFG<'tcx>,
-    span: Span,
-    scope: &mut Scope,
-    mut target: BasicBlock,
-    generator_drop: bool,
-    generator_kind: Option<GeneratorKind>,
-) -> BasicBlock {
-    // Build up the drops in **reverse** order. The end result will
-    // look like:
-    //
-    //    [drops[n]] -...-> [drops[0]] -> [target]
-    //
-    // The code in this function reads from right to left. At each
-    // point, we check for cached blocks representing the
-    // remainder. If everything is cached, we'll just walk right to
-    // left reading the cached results but never create anything.
+// DropTreeBuilder implementations.
 
-    let source_scope = scope.source_scope;
-    let source_info = |span| SourceInfo { span, scope: source_scope };
+struct ExitScopes;
 
-    // We keep track of StorageDead statements to prepend to our current block
-    // and store them here, in reverse order.
-    let mut storage_deads = vec![];
+impl<'tcx> DropTreeBuilder<'tcx> for ExitScopes {
+    fn make_block(cfg: &mut CFG<'tcx>) -> BasicBlock {
+        cfg.start_new_block()
+    }
+    fn add_entry(cfg: &mut CFG<'tcx>, from: BasicBlock, to: BasicBlock) {
+        cfg.block_data_mut(from).terminator_mut().kind = TerminatorKind::Goto { target: to };
+    }
+}
 
-    let mut target_built_by_us = false;
+struct GeneratorDrop;
 
-    // Build up the drops. Here we iterate the vector in
-    // *forward* order, so that we generate drops[0] first (right to
-    // left in diagram above).
-    debug!("build_diverge_scope({:?})", scope.drops);
-    for (j, drop_data) in scope.drops.iter_mut().enumerate() {
-        debug!("build_diverge_scope drop_data[{}]: {:?}", j, drop_data);
-        // Only full value drops are emitted in the diverging path,
-        // not StorageDead, except in the case of generators.
-        //
-        // Note: This may not actually be what we desire (are we
-        // "freeing" stack storage as we unwind, or merely observing a
-        // frozen stack)? In particular, the intent may have been to
-        // match the behavior of clang, but on inspection eddyb says
-        // this is not what clang does.
-        match drop_data.kind {
-            DropKind::Storage if generator_kind.is_some() => {
-                storage_deads.push(Statement {
-                    source_info: source_info(drop_data.span),
-                    kind: StatementKind::StorageDead(drop_data.local),
-                });
-                if !target_built_by_us {
-                    // We cannot add statements to an existing block, so we create a new
-                    // block for our StorageDead statements.
-                    let block = cfg.start_new_cleanup_block();
-                    let source_info = SourceInfo { span: DUMMY_SP, scope: source_scope };
-                    cfg.goto(block, source_info, target);
-                    target = block;
-                    target_built_by_us = true;
-                }
-                *drop_data.cached_block.ref_mut(generator_drop) = Some(target);
-            }
-            DropKind::Storage => {}
-            DropKind::Value => {
-                let cached_block = drop_data.cached_block.ref_mut(generator_drop);
-                target = if let Some(cached_block) = *cached_block {
-                    storage_deads.clear();
-                    target_built_by_us = false;
-                    cached_block
-                } else {
-                    push_storage_deads(cfg, target, &mut storage_deads);
-                    let block = cfg.start_new_cleanup_block();
-                    cfg.terminate(
-                        block,
-                        source_info(drop_data.span),
-                        TerminatorKind::Drop {
-                            location: drop_data.local.into(),
-                            target,
-                            unwind: None,
-                        },
-                    );
-                    *cached_block = Some(block);
-                    target_built_by_us = true;
-                    block
-                };
-            }
+impl<'tcx> DropTreeBuilder<'tcx> for GeneratorDrop {
+    fn make_block(cfg: &mut CFG<'tcx>) -> BasicBlock {
+        cfg.start_new_block()
+    }
+    fn add_entry(cfg: &mut CFG<'tcx>, from: BasicBlock, to: BasicBlock) {
+        let kind = &mut cfg.block_data_mut(from).terminator_mut().kind;
+        if let TerminatorKind::Yield { drop, .. } = kind {
+            *drop = Some(to);
         };
     }
-    push_storage_deads(cfg, target, &mut storage_deads);
-    *scope.cached_unwind.ref_mut(generator_drop) = Some(target);
-
-    assert!(storage_deads.is_empty());
-    debug!("build_diverge_scope({:?}, {:?}) = {:?}", scope, span, target);
-
-    target
 }
 
-fn push_storage_deads<'tcx>(
-    cfg: &mut CFG<'tcx>,
-    target: BasicBlock,
-    storage_deads: &mut Vec<Statement<'tcx>>,
-) {
-    if storage_deads.is_empty() {
-        return;
+struct Unwind;
+
+impl<'tcx> DropTreeBuilder<'tcx> for Unwind {
+    fn make_block(cfg: &mut CFG<'tcx>) -> BasicBlock {
+        cfg.start_new_cleanup_block()
     }
-    let statements = &mut cfg.block_data_mut(target).statements;
-    storage_deads.reverse();
-    debug!(
-        "push_storage_deads({:?}), storage_deads={:?}, statements={:?}",
-        target, storage_deads, statements
-    );
-    storage_deads.append(statements);
-    mem::swap(statements, storage_deads);
-    assert!(storage_deads.is_empty());
+    fn add_entry(cfg: &mut CFG<'tcx>, from: BasicBlock, to: BasicBlock) {
+        let term = &mut cfg.block_data_mut(from).terminator_mut().kind;
+        match term {
+            TerminatorKind::Drop { unwind, .. }
+            | TerminatorKind::DropAndReplace { unwind, .. }
+            | TerminatorKind::FalseUnwind { unwind, .. }
+            | TerminatorKind::Call { cleanup: unwind, .. }
+            | TerminatorKind::Assert { cleanup: unwind, .. } => {
+                *unwind = Some(to);
+            }
+            TerminatorKind::Goto { .. }
+            | TerminatorKind::SwitchInt { .. }
+            | TerminatorKind::Resume
+            | TerminatorKind::Abort
+            | TerminatorKind::Return
+            | TerminatorKind::Unreachable
+            | TerminatorKind::Yield { .. }
+            | TerminatorKind::GeneratorDrop
+            | TerminatorKind::FalseEdges { .. } => bug!("cannot unwind from {:?}", term),
+        }
+    }
 }

--- a/src/librustc_mir_build/build/scope.rs
+++ b/src/librustc_mir_build/build/scope.rs
@@ -237,6 +237,9 @@ trait DropTreeBuilder<'tcx> {
 
 impl DropTree {
     fn new() -> Self {
+        // The root node of the tree doesn't represent a drop, but instead
+        // represents the block in the tree that should be jumped to once all
+        // of the required drops have been performed.
         let fake_source_info = SourceInfo::outermost(DUMMY_SP);
         let fake_data =
             DropData { source_info: fake_source_info, local: Local::MAX, kind: DropKind::Storage };
@@ -258,6 +261,10 @@ impl DropTree {
         self.entry_points.push((to, from));
     }
 
+    /// Builds the MIR for a given drop tree.
+    ///
+    /// `blocks` should have the same length as `self.drops`, and may have its
+    /// first value set to some already existing block.
     fn build_mir<'tcx, T: DropTreeBuilder<'tcx>>(
         &mut self,
         cfg: &mut CFG<'tcx>,
@@ -1344,10 +1351,16 @@ impl<'tcx> DropTreeBuilder<'tcx> for GeneratorDrop {
         cfg.start_new_block()
     }
     fn add_entry(cfg: &mut CFG<'tcx>, from: BasicBlock, to: BasicBlock) {
-        let kind = &mut cfg.block_data_mut(from).terminator_mut().kind;
-        if let TerminatorKind::Yield { drop, .. } = kind {
+        let term = cfg.block_data_mut(from).terminator_mut();
+        if let TerminatorKind::Yield { ref mut drop, .. } = term.kind {
             *drop = Some(to);
-        };
+        } else {
+            span_bug!(
+                term.source_info.span,
+                "cannot enter generator drop tree from {:?}",
+                term.kind
+            )
+        }
     }
 }
 
@@ -1358,8 +1371,8 @@ impl<'tcx> DropTreeBuilder<'tcx> for Unwind {
         cfg.start_new_cleanup_block()
     }
     fn add_entry(cfg: &mut CFG<'tcx>, from: BasicBlock, to: BasicBlock) {
-        let term = &mut cfg.block_data_mut(from).terminator_mut().kind;
-        match term {
+        let term = &mut cfg.block_data_mut(from).terminator_mut();
+        match &mut term.kind {
             TerminatorKind::Drop { unwind, .. }
             | TerminatorKind::DropAndReplace { unwind, .. }
             | TerminatorKind::FalseUnwind { unwind, .. }
@@ -1375,7 +1388,9 @@ impl<'tcx> DropTreeBuilder<'tcx> for Unwind {
             | TerminatorKind::Unreachable
             | TerminatorKind::Yield { .. }
             | TerminatorKind::GeneratorDrop
-            | TerminatorKind::FalseEdges { .. } => bug!("cannot unwind from {:?}", term),
+            | TerminatorKind::FalseEdges { .. } => {
+                span_bug!(term.source_info.span, "cannot unwind from {:?}", term.kind)
+            }
         }
     }
 }

--- a/src/test/codegen/drop.rs
+++ b/src/test/codegen/drop.rs
@@ -23,13 +23,13 @@ pub fn droppy() {
 // FIXME(eddyb) the `void @` forces a match on the instruction, instead of the
 // comment, that's `; call core::intrinsics::drop_in_place::<drop::SomeUniqueName>`
 // for the `v0` mangling, should switch to matching on that once `legacy` is gone.
+// CHECK-NOT: call void @{{.*}}drop_in_place{{.*}}SomeUniqueName
+// CHECK: invoke void @{{.*}}drop_in_place{{.*}}SomeUniqueName
+// CHECK: invoke void @{{.*}}drop_in_place{{.*}}SomeUniqueName
 // CHECK-NOT: invoke void @{{.*}}drop_in_place{{.*}}SomeUniqueName
 // CHECK: call void @{{.*}}drop_in_place{{.*}}SomeUniqueName
 // CHECK: call void @{{.*}}drop_in_place{{.*}}SomeUniqueName
-// CHECK-NOT: call void @{{.*}}drop_in_place{{.*}}SomeUniqueName
-// CHECK: invoke void @{{.*}}drop_in_place{{.*}}SomeUniqueName
 // CHECK: call void @{{.*}}drop_in_place{{.*}}SomeUniqueName
-// CHECK: invoke void @{{.*}}drop_in_place{{.*}}SomeUniqueName
 // CHECK: call void @{{.*}}drop_in_place{{.*}}SomeUniqueName
 // CHECK-NOT: {{(call|invoke) void @.*}}drop_in_place{{.*}}SomeUniqueName
 // The next line checks for the } that ends the function definition

--- a/src/test/mir-opt/basic_assignment/rustc.main.SimplifyCfg-initial.after.mir
+++ b/src/test/mir-opt/basic_assignment/rustc.main.SimplifyCfg-initial.after.mir
@@ -47,30 +47,14 @@ fn main() -> () {
         StorageLive(_5);                 // scope 3 at $DIR/basic_assignment.rs:19:9: 19:15
         StorageLive(_6);                 // scope 4 at $DIR/basic_assignment.rs:23:14: 23:20
         _6 = move _4;                    // scope 4 at $DIR/basic_assignment.rs:23:14: 23:20
-        replace(_5 <- move _6) -> [return: bb2, unwind: bb5]; // scope 4 at $DIR/basic_assignment.rs:23:5: 23:11
+        replace(_5 <- move _6) -> [return: bb1, unwind: bb5]; // scope 4 at $DIR/basic_assignment.rs:23:5: 23:11
     }
 
-    bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/basic_assignment.rs:10:1: 24:2
+    bb1: {
+        drop(_6) -> [return: bb2, unwind: bb6]; // scope 4 at $DIR/basic_assignment.rs:23:19: 23:20
     }
 
     bb2: {
-        drop(_6) -> [return: bb6, unwind: bb4]; // scope 4 at $DIR/basic_assignment.rs:23:19: 23:20
-    }
-
-    bb3 (cleanup): {
-        drop(_4) -> bb1;                 // scope 2 at $DIR/basic_assignment.rs:24:1: 24:2
-    }
-
-    bb4 (cleanup): {
-        drop(_5) -> bb3;                 // scope 3 at $DIR/basic_assignment.rs:24:1: 24:2
-    }
-
-    bb5 (cleanup): {
-        drop(_6) -> bb4;                 // scope 4 at $DIR/basic_assignment.rs:23:19: 23:20
-    }
-
-    bb6: {
         StorageDead(_6);                 // scope 4 at $DIR/basic_assignment.rs:23:19: 23:20
         _0 = const ();                   // scope 0 at $DIR/basic_assignment.rs:10:11: 24:2
                                          // ty::Const
@@ -79,18 +63,34 @@ fn main() -> () {
                                          // mir::Constant
                                          // + span: $DIR/basic_assignment.rs:10:11: 24:2
                                          // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
-        drop(_5) -> [return: bb7, unwind: bb3]; // scope 3 at $DIR/basic_assignment.rs:24:1: 24:2
+        drop(_5) -> [return: bb3, unwind: bb7]; // scope 3 at $DIR/basic_assignment.rs:24:1: 24:2
     }
 
-    bb7: {
+    bb3: {
         StorageDead(_5);                 // scope 3 at $DIR/basic_assignment.rs:24:1: 24:2
-        drop(_4) -> [return: bb8, unwind: bb1]; // scope 2 at $DIR/basic_assignment.rs:24:1: 24:2
+        drop(_4) -> [return: bb4, unwind: bb8]; // scope 2 at $DIR/basic_assignment.rs:24:1: 24:2
     }
 
-    bb8: {
+    bb4: {
         StorageDead(_4);                 // scope 2 at $DIR/basic_assignment.rs:24:1: 24:2
         StorageDead(_2);                 // scope 1 at $DIR/basic_assignment.rs:24:1: 24:2
         StorageDead(_1);                 // scope 0 at $DIR/basic_assignment.rs:24:1: 24:2
         return;                          // scope 0 at $DIR/basic_assignment.rs:24:2: 24:2
+    }
+
+    bb5 (cleanup): {
+        drop(_6) -> bb6;                 // scope 4 at $DIR/basic_assignment.rs:23:19: 23:20
+    }
+
+    bb6 (cleanup): {
+        drop(_5) -> bb7;                 // scope 3 at $DIR/basic_assignment.rs:24:1: 24:2
+    }
+
+    bb7 (cleanup): {
+        drop(_4) -> bb8;                 // scope 2 at $DIR/basic_assignment.rs:24:1: 24:2
+    }
+
+    bb8 (cleanup): {
+        resume;                          // scope 0 at $DIR/basic_assignment.rs:10:1: 24:2
     }
 }

--- a/src/test/mir-opt/box_expr/rustc.main.ElaborateDrops.before.mir
+++ b/src/test/mir-opt/box_expr/rustc.main.ElaborateDrops.before.mir
@@ -14,7 +14,7 @@ fn main() -> () {
         StorageLive(_1);                 // scope 0 at $DIR/box_expr.rs:7:9: 7:10
         StorageLive(_2);                 // scope 0 at $DIR/box_expr.rs:7:13: 7:25
         _2 = Box(S);                     // scope 0 at $DIR/box_expr.rs:7:13: 7:25
-        (*_2) = const S::new() -> [return: bb2, unwind: bb3]; // scope 0 at $DIR/box_expr.rs:7:17: 7:25
+        (*_2) = const S::new() -> [return: bb1, unwind: bb7]; // scope 0 at $DIR/box_expr.rs:7:17: 7:25
                                          // ty::Const
                                          // + ty: fn() -> S {S::new}
                                          // + val: Value(Scalar(<ZST>))
@@ -23,25 +23,17 @@ fn main() -> () {
                                          // + literal: Const { ty: fn() -> S {S::new}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/box_expr.rs:6:1: 9:2
+    bb1: {
+        _1 = move _2;                    // scope 0 at $DIR/box_expr.rs:7:13: 7:25
+        drop(_2) -> bb2;                 // scope 0 at $DIR/box_expr.rs:7:24: 7:25
     }
 
     bb2: {
-        _1 = move _2;                    // scope 0 at $DIR/box_expr.rs:7:13: 7:25
-        drop(_2) -> bb4;                 // scope 0 at $DIR/box_expr.rs:7:24: 7:25
-    }
-
-    bb3 (cleanup): {
-        drop(_2) -> bb1;                 // scope 0 at $DIR/box_expr.rs:7:24: 7:25
-    }
-
-    bb4: {
         StorageDead(_2);                 // scope 0 at $DIR/box_expr.rs:7:24: 7:25
         StorageLive(_3);                 // scope 1 at $DIR/box_expr.rs:8:5: 8:12
         StorageLive(_4);                 // scope 1 at $DIR/box_expr.rs:8:10: 8:11
         _4 = move _1;                    // scope 1 at $DIR/box_expr.rs:8:10: 8:11
-        _3 = const std::mem::drop::<std::boxed::Box<S>>(move _4) -> [return: bb5, unwind: bb7]; // scope 1 at $DIR/box_expr.rs:8:5: 8:12
+        _3 = const std::mem::drop::<std::boxed::Box<S>>(move _4) -> [return: bb3, unwind: bb5]; // scope 1 at $DIR/box_expr.rs:8:5: 8:12
                                          // ty::Const
                                          // + ty: fn(std::boxed::Box<S>) {std::mem::drop::<std::boxed::Box<S>>}
                                          // + val: Value(Scalar(<ZST>))
@@ -50,7 +42,7 @@ fn main() -> () {
                                          // + literal: Const { ty: fn(std::boxed::Box<S>) {std::mem::drop::<std::boxed::Box<S>>}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb5: {
+    bb3: {
         StorageDead(_4);                 // scope 1 at $DIR/box_expr.rs:8:11: 8:12
         StorageDead(_3);                 // scope 1 at $DIR/box_expr.rs:8:12: 8:13
         _0 = const ();                   // scope 0 at $DIR/box_expr.rs:6:11: 9:2
@@ -60,19 +52,27 @@ fn main() -> () {
                                          // mir::Constant
                                          // + span: $DIR/box_expr.rs:6:11: 9:2
                                          // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
-        drop(_1) -> bb8;                 // scope 0 at $DIR/box_expr.rs:9:1: 9:2
+        drop(_1) -> bb4;                 // scope 0 at $DIR/box_expr.rs:9:1: 9:2
     }
 
-    bb6 (cleanup): {
-        drop(_1) -> bb1;                 // scope 0 at $DIR/box_expr.rs:9:1: 9:2
+    bb4: {
+        StorageDead(_1);                 // scope 0 at $DIR/box_expr.rs:9:1: 9:2
+        return;                          // scope 0 at $DIR/box_expr.rs:9:2: 9:2
     }
 
-    bb7 (cleanup): {
+    bb5 (cleanup): {
         drop(_4) -> bb6;                 // scope 1 at $DIR/box_expr.rs:8:11: 8:12
     }
 
-    bb8: {
-        StorageDead(_1);                 // scope 0 at $DIR/box_expr.rs:9:1: 9:2
-        return;                          // scope 0 at $DIR/box_expr.rs:9:2: 9:2
+    bb6 (cleanup): {
+        drop(_1) -> bb8;                 // scope 0 at $DIR/box_expr.rs:9:1: 9:2
+    }
+
+    bb7 (cleanup): {
+        drop(_2) -> bb8;                 // scope 0 at $DIR/box_expr.rs:7:24: 7:25
+    }
+
+    bb8 (cleanup): {
+        resume;                          // scope 0 at $DIR/box_expr.rs:6:1: 9:2
     }
 }

--- a/src/test/mir-opt/const-promotion-extern-static/rustc.BAR.PromoteTemps.diff
+++ b/src/test/mir-opt/const-promotion-extern-static/rustc.BAR.PromoteTemps.diff
@@ -33,7 +33,7 @@
 +                                          // + literal: Const { ty: &[&i32; 1], val: Unevaluated(DefId(0:6 ~ const_promotion_extern_static[317d]::BAR[0]), [], Some(promoted[0])) }
 +         _2 = &(*_6);                     // scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:35
           _1 = move _2 as &[&i32] (Pointer(Unsize)); // scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:35
-          _0 = const core::slice::<impl [&i32]>::as_ptr(move _1) -> [return: bb2, unwind: bb1]; // scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:44
+          _0 = const core::slice::<impl [&i32]>::as_ptr(move _1) -> [return: bb1, unwind: bb2]; // scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:44
                                            // ty::Const
                                            // + ty: for<'r> fn(&'r [&i32]) -> *const &i32 {core::slice::<impl [&i32]>::as_ptr}
                                            // + val: Value(Scalar(<ZST>))
@@ -42,14 +42,14 @@
                                            // + literal: Const { ty: for<'r> fn(&'r [&i32]) -> *const &i32 {core::slice::<impl [&i32]>::as_ptr}, val: Value(Scalar(<ZST>)) }
       }
   
-      bb1 (cleanup): {
-          resume;                          // scope 0 at $DIR/const-promotion-extern-static.rs:9:1: 9:45
-      }
-  
-      bb2: {
+      bb1: {
 -         StorageDead(_5);                 // scope 0 at $DIR/const-promotion-extern-static.rs:9:43: 9:44
 -         StorageDead(_3);                 // scope 0 at $DIR/const-promotion-extern-static.rs:9:43: 9:44
           return;                          // scope 0 at $DIR/const-promotion-extern-static.rs:9:1: 9:45
+      }
+  
+      bb2 (cleanup): {
+          resume;                          // scope 0 at $DIR/const-promotion-extern-static.rs:9:1: 9:45
       }
 - }
 - 

--- a/src/test/mir-opt/const-promotion-extern-static/rustc.FOO.PromoteTemps.diff
+++ b/src/test/mir-opt/const-promotion-extern-static/rustc.FOO.PromoteTemps.diff
@@ -35,7 +35,7 @@
 +                                          // + literal: Const { ty: &[&i32; 1], val: Unevaluated(DefId(0:7 ~ const_promotion_extern_static[317d]::FOO[0]), [], Some(promoted[0])) }
 +         _2 = &(*_6);                     // scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:46
           _1 = move _2 as &[&i32] (Pointer(Unsize)); // scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:46
-          _0 = const core::slice::<impl [&i32]>::as_ptr(move _1) -> [return: bb2, unwind: bb1]; // scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:55
+          _0 = const core::slice::<impl [&i32]>::as_ptr(move _1) -> [return: bb1, unwind: bb2]; // scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:55
                                            // ty::Const
                                            // + ty: for<'r> fn(&'r [&i32]) -> *const &i32 {core::slice::<impl [&i32]>::as_ptr}
                                            // + val: Value(Scalar(<ZST>))
@@ -44,14 +44,14 @@
                                            // + literal: Const { ty: for<'r> fn(&'r [&i32]) -> *const &i32 {core::slice::<impl [&i32]>::as_ptr}, val: Value(Scalar(<ZST>)) }
       }
   
-      bb1 (cleanup): {
-          resume;                          // scope 0 at $DIR/const-promotion-extern-static.rs:13:1: 13:56
-      }
-  
-      bb2: {
+      bb1: {
 -         StorageDead(_5);                 // scope 0 at $DIR/const-promotion-extern-static.rs:13:54: 13:55
 -         StorageDead(_3);                 // scope 0 at $DIR/const-promotion-extern-static.rs:13:54: 13:55
           return;                          // scope 0 at $DIR/const-promotion-extern-static.rs:13:1: 13:56
+      }
+  
+      bb2 (cleanup): {
+          resume;                          // scope 0 at $DIR/const-promotion-extern-static.rs:13:1: 13:56
       }
   }
 - 

--- a/src/test/mir-opt/const_prop/boxes/rustc.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/boxes/rustc.main.ConstProp.diff
@@ -35,14 +35,10 @@
                                            // + span: $DIR/boxes.rs:12:25: 12:26
                                            // + literal: Const { ty: i32, val: Value(Scalar(0x00000000)) }
           StorageDead(_2);                 // scope 0 at $DIR/boxes.rs:12:25: 12:26
-          drop(_3) -> [return: bb2, unwind: bb1]; // scope 0 at $DIR/boxes.rs:12:26: 12:27
+          drop(_3) -> [return: bb1, unwind: bb2]; // scope 0 at $DIR/boxes.rs:12:26: 12:27
       }
   
-      bb1 (cleanup): {
-          resume;                          // scope 0 at $DIR/boxes.rs:11:1: 13:2
-      }
-  
-      bb2: {
+      bb1: {
           StorageDead(_3);                 // scope 0 at $DIR/boxes.rs:12:26: 12:27
           _0 = const ();                   // scope 0 at $DIR/boxes.rs:11:11: 13:2
                                            // ty::Const
@@ -53,6 +49,10 @@
                                            // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           StorageDead(_1);                 // scope 0 at $DIR/boxes.rs:13:1: 13:2
           return;                          // scope 0 at $DIR/boxes.rs:13:2: 13:2
+      }
+  
+      bb2 (cleanup): {
+          resume;                          // scope 0 at $DIR/boxes.rs:11:1: 13:2
       }
   }
   

--- a/src/test/mir-opt/generator-drop-cleanup/rustc.main-{{closure}}.generator_drop.0.mir
+++ b/src/test/mir-opt/generator-drop-cleanup/rustc.main-{{closure}}.generator_drop.0.mir
@@ -21,31 +21,31 @@ fn main::{{closure}}#0(_1: *mut [generator@$DIR/generator-drop-cleanup.rs:10:15:
 
     bb0: {
         _9 = discriminant((*_1));        // scope 0 at $DIR/generator-drop-cleanup.rs:10:15: 13:6
-        switchInt(move _9) -> [0u32: bb7, 3u32: bb11, otherwise: bb12]; // scope 0 at $DIR/generator-drop-cleanup.rs:10:15: 13:6
+        switchInt(move _9) -> [0u32: bb7, 3u32: bb10, otherwise: bb11]; // scope 0 at $DIR/generator-drop-cleanup.rs:10:15: 13:6
     }
 
-    bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/generator-drop-cleanup.rs:10:15: 13:6
+    bb1: {
+        StorageDead(_5);                 // scope 1 at $DIR/generator-drop-cleanup.rs:12:13: 12:14
+        StorageDead(_4);                 // scope 1 at $DIR/generator-drop-cleanup.rs:12:14: 12:15
+        drop((((*_1) as variant#3).0: std::string::String)) -> [return: bb2, unwind: bb5]; // scope 0 at $DIR/generator-drop-cleanup.rs:13:5: 13:6
     }
 
-    bb2 (cleanup): {
+    bb2: {
         nop;                             // scope 0 at $DIR/generator-drop-cleanup.rs:13:5: 13:6
         goto -> bb8;                     // scope 0 at $DIR/generator-drop-cleanup.rs:13:5: 13:6
     }
 
     bb3: {
-        StorageDead(_5);                 // scope 1 at $DIR/generator-drop-cleanup.rs:12:13: 12:14
-        StorageDead(_4);                 // scope 1 at $DIR/generator-drop-cleanup.rs:12:14: 12:15
-        drop((((*_1) as variant#3).0: std::string::String)) -> [return: bb4, unwind: bb2]; // scope 0 at $DIR/generator-drop-cleanup.rs:13:5: 13:6
-    }
-
-    bb4: {
-        nop;                             // scope 0 at $DIR/generator-drop-cleanup.rs:13:5: 13:6
-        goto -> bb9;                     // scope 0 at $DIR/generator-drop-cleanup.rs:13:5: 13:6
-    }
-
-    bb5: {
         return;                          // scope 0 at $DIR/generator-drop-cleanup.rs:10:15: 13:6
+    }
+
+    bb4 (cleanup): {
+        resume;                          // scope 0 at $DIR/generator-drop-cleanup.rs:10:15: 13:6
+    }
+
+    bb5 (cleanup): {
+        nop;                             // scope 0 at $DIR/generator-drop-cleanup.rs:13:5: 13:6
+        goto -> bb4;                     // scope 0 at $DIR/generator-drop-cleanup.rs:13:5: 13:6
     }
 
     bb6: {
@@ -53,28 +53,24 @@ fn main::{{closure}}#0(_1: *mut [generator@$DIR/generator-drop-cleanup.rs:10:15:
     }
 
     bb7: {
-        goto -> bb10;                    // scope 0 at $DIR/generator-drop-cleanup.rs:10:15: 13:6
+        goto -> bb9;                     // scope 0 at $DIR/generator-drop-cleanup.rs:10:15: 13:6
     }
 
-    bb8 (cleanup): {
-        goto -> bb1;                     // scope 0 at $DIR/generator-drop-cleanup.rs:13:5: 13:6
+    bb8: {
+        goto -> bb3;                     // scope 0 at $DIR/generator-drop-cleanup.rs:13:5: 13:6
     }
 
     bb9: {
-        goto -> bb5;                     // scope 0 at $DIR/generator-drop-cleanup.rs:13:5: 13:6
-    }
-
-    bb10: {
         goto -> bb6;                     // scope 0 at $DIR/generator-drop-cleanup.rs:10:15: 13:6
     }
 
-    bb11: {
+    bb10: {
         StorageLive(_4);                 // scope 0 at $DIR/generator-drop-cleanup.rs:10:15: 13:6
         StorageLive(_5);                 // scope 0 at $DIR/generator-drop-cleanup.rs:10:15: 13:6
-        goto -> bb3;                     // scope 0 at $DIR/generator-drop-cleanup.rs:10:15: 13:6
+        goto -> bb1;                     // scope 0 at $DIR/generator-drop-cleanup.rs:10:15: 13:6
     }
 
-    bb12: {
+    bb11: {
         return;                          // scope 0 at $DIR/generator-drop-cleanup.rs:10:15: 13:6
     }
 }

--- a/src/test/mir-opt/generator-storage-dead-unwind/rustc.main-{{closure}}.StateTransform.before.mir
+++ b/src/test/mir-opt/generator-storage-dead-unwind/rustc.main-{{closure}}.StateTransform.before.mir
@@ -39,20 +39,16 @@ yields ()
         StorageLive(_5);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:25:9: 25:14
         StorageLive(_6);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:25:9: 25:14
         _6 = ();                         // scope 2 at $DIR/generator-storage-dead-unwind.rs:25:9: 25:14
-        _5 = yield(move _6) -> [resume: bb2, drop: bb4]; // scope 2 at $DIR/generator-storage-dead-unwind.rs:25:9: 25:14
+        _5 = yield(move _6) -> [resume: bb1, drop: bb5]; // scope 2 at $DIR/generator-storage-dead-unwind.rs:25:9: 25:14
     }
 
-    bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/generator-storage-dead-unwind.rs:22:16: 28:6
-    }
-
-    bb2: {
+    bb1: {
         StorageDead(_6);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:25:13: 25:14
         StorageDead(_5);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:25:14: 25:15
         StorageLive(_7);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:26:9: 26:16
         StorageLive(_8);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:26:14: 26:15
         _8 = move _3;                    // scope 2 at $DIR/generator-storage-dead-unwind.rs:26:14: 26:15
-        _7 = const take::<Foo>(move _8) -> [return: bb7, unwind: bb9]; // scope 2 at $DIR/generator-storage-dead-unwind.rs:26:9: 26:16
+        _7 = const take::<Foo>(move _8) -> [return: bb2, unwind: bb9]; // scope 2 at $DIR/generator-storage-dead-unwind.rs:26:9: 26:16
                                          // ty::Const
                                          // + ty: fn(Foo) {take::<Foo>}
                                          // + val: Value(Scalar(<ZST>))
@@ -61,34 +57,13 @@ yields ()
                                          // + literal: Const { ty: fn(Foo) {take::<Foo>}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb3 (cleanup): {
-        StorageDead(_3);                 // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
-        drop(_1) -> bb1;                 // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
-    }
-
-    bb4: {
-        StorageDead(_6);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:25:13: 25:14
-        StorageDead(_5);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:25:14: 25:15
-        StorageDead(_4);                 // scope 1 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
-        drop(_3) -> [return: bb5, unwind: bb3]; // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
-    }
-
-    bb5: {
-        StorageDead(_3);                 // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
-        drop(_1) -> [return: bb6, unwind: bb1]; // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
-    }
-
-    bb6: {
-        generator_drop;                  // scope 0 at $DIR/generator-storage-dead-unwind.rs:22:16: 28:6
-    }
-
-    bb7: {
+    bb2: {
         StorageDead(_8);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:26:15: 26:16
         StorageDead(_7);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:26:16: 26:17
         StorageLive(_9);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:27:9: 27:16
         StorageLive(_10);                // scope 2 at $DIR/generator-storage-dead-unwind.rs:27:14: 27:15
         _10 = move _4;                   // scope 2 at $DIR/generator-storage-dead-unwind.rs:27:14: 27:15
-        _9 = const take::<Bar>(move _10) -> [return: bb10, unwind: bb11]; // scope 2 at $DIR/generator-storage-dead-unwind.rs:27:9: 27:16
+        _9 = const take::<Bar>(move _10) -> [return: bb3, unwind: bb8]; // scope 2 at $DIR/generator-storage-dead-unwind.rs:27:9: 27:16
                                          // ty::Const
                                          // + ty: fn(Bar) {take::<Bar>}
                                          // + val: Value(Scalar(<ZST>))
@@ -97,19 +72,7 @@ yields ()
                                          // + literal: Const { ty: fn(Bar) {take::<Bar>}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb8 (cleanup): {
-        StorageDead(_4);                 // scope 1 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
-        StorageDead(_3);                 // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
-        drop(_1) -> bb1;                 // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
-    }
-
-    bb9 (cleanup): {
-        StorageDead(_8);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:26:15: 26:16
-        StorageDead(_7);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:26:16: 26:17
-        goto -> bb8;                     // scope 2 at $DIR/generator-storage-dead-unwind.rs:1:1: 1:1
-    }
-
-    bb10: {
+    bb3: {
         StorageDead(_10);                // scope 2 at $DIR/generator-storage-dead-unwind.rs:27:15: 27:16
         StorageDead(_9);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:27:16: 27:17
         _0 = const ();                   // scope 0 at $DIR/generator-storage-dead-unwind.rs:22:19: 28:6
@@ -121,16 +84,53 @@ yields ()
                                          // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
         StorageDead(_4);                 // scope 1 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
         StorageDead(_3);                 // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
-        drop(_1) -> [return: bb12, unwind: bb1]; // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
+        drop(_1) -> [return: bb4, unwind: bb11]; // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
+    }
+
+    bb4: {
+        return;                          // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:6: 28:6
+    }
+
+    bb5: {
+        StorageDead(_6);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:25:13: 25:14
+        StorageDead(_5);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:25:14: 25:15
+        StorageDead(_4);                 // scope 1 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
+        drop(_3) -> [return: bb6, unwind: bb12]; // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
+    }
+
+    bb6: {
+        StorageDead(_3);                 // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
+        drop(_1) -> [return: bb7, unwind: bb11]; // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
+    }
+
+    bb7: {
+        generator_drop;                  // scope 0 at $DIR/generator-storage-dead-unwind.rs:22:16: 28:6
+    }
+
+    bb8 (cleanup): {
+        StorageDead(_10);                // scope 2 at $DIR/generator-storage-dead-unwind.rs:27:15: 27:16
+        StorageDead(_9);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:27:16: 27:17
+        goto -> bb10;                    // scope 2 at $DIR/generator-storage-dead-unwind.rs:1:1: 1:1
+    }
+
+    bb9 (cleanup): {
+        StorageDead(_8);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:26:15: 26:16
+        StorageDead(_7);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:26:16: 26:17
+        goto -> bb10;                    // scope 2 at $DIR/generator-storage-dead-unwind.rs:1:1: 1:1
+    }
+
+    bb10 (cleanup): {
+        StorageDead(_4);                 // scope 1 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
+        StorageDead(_3);                 // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
+        drop(_1) -> bb11;                // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
     }
 
     bb11 (cleanup): {
-        StorageDead(_10);                // scope 2 at $DIR/generator-storage-dead-unwind.rs:27:15: 27:16
-        StorageDead(_9);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:27:16: 27:17
-        goto -> bb8;                     // scope 2 at $DIR/generator-storage-dead-unwind.rs:1:1: 1:1
+        resume;                          // scope 0 at $DIR/generator-storage-dead-unwind.rs:22:16: 28:6
     }
 
-    bb12: {
-        return;                          // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:6: 28:6
+    bb12 (cleanup): {
+        StorageDead(_3);                 // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
+        drop(_1) -> bb11;                // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
     }
 }

--- a/src/test/mir-opt/graphviz/rustc.main.mir_map.0.dot
+++ b/src/test/mir-opt/graphviz/rustc.main.mir_map.0.dot
@@ -3,8 +3,5 @@ digraph Mir_0_3 {
     node [fontname="monospace"];
     edge [fontname="monospace"];
     label=<fn main() -&gt; ()<br align="left"/>>;
-    bb0__0_3 [shape="none", label=<<table border="0" cellborder="1" cellspacing="0"><tr><td bgcolor="gray" align="center" colspan="1">0</td></tr><tr><td align="left" balign="left">_0 = const ()<br/></td></tr><tr><td align="left">goto</td></tr></table>>];
-    bb1__0_3 [shape="none", label=<<table border="0" cellborder="1" cellspacing="0"><tr><td bgcolor="gray" align="center" colspan="1">1</td></tr><tr><td align="left">resume</td></tr></table>>];
-    bb2__0_3 [shape="none", label=<<table border="0" cellborder="1" cellspacing="0"><tr><td bgcolor="gray" align="center" colspan="1">2</td></tr><tr><td align="left">return</td></tr></table>>];
-    bb0__0_3 -> bb2__0_3 [label=""];
+    bb0__0_3 [shape="none", label=<<table border="0" cellborder="1" cellspacing="0"><tr><td bgcolor="gray" align="center" colspan="1">0</td></tr><tr><td align="left" balign="left">_0 = const ()<br/></td></tr><tr><td align="left">return</td></tr></table>>];
 }

--- a/src/test/mir-opt/inline/inline-into-box-place/32bit/rustc.main.Inline.diff
+++ b/src/test/mir-opt/inline/inline-into-box-place/32bit/rustc.main.Inline.diff
@@ -17,7 +17,7 @@
           StorageLive(_1);                 // scope 0 at $DIR/inline-into-box-place.rs:8:9: 8:11
           StorageLive(_2);                 // scope 0 at $DIR/inline-into-box-place.rs:8:29: 8:43
           _2 = Box(std::vec::Vec<u32>);    // scope 0 at $DIR/inline-into-box-place.rs:8:29: 8:43
--         (*_2) = const std::vec::Vec::<u32>::new() -> [return: bb2, unwind: bb4]; // scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
+-         (*_2) = const std::vec::Vec::<u32>::new() -> [return: bb1, unwind: bb4]; // scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
 +         _4 = &mut (*_2);                 // scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
 +         ((*_4).0: alloc::raw_vec::RawVec<u32>) = const alloc::raw_vec::RawVec::<u32> { ptr: std::ptr::Unique::<u32> { pointer: {0x4 as *const u32}, _marker: std::marker::PhantomData::<u32> }, cap: 0usize, alloc: std::alloc::Global }; // scope 2 at $SRC_DIR/liballoc/vec.rs:LL:COL
                                            // ty::Const
@@ -31,11 +31,7 @@
 -                                          // + literal: Const { ty: fn() -> std::vec::Vec<u32> {std::vec::Vec::<u32>::new}, val: Value(Scalar(<ZST>)) }
 -     }
 - 
--     bb1 (cleanup): {
--         resume;                          // scope 0 at $DIR/inline-into-box-place.rs:7:1: 9:2
--     }
-- 
--     bb2: {
+-     bb1: {
 +                                          // + span: $SRC_DIR/liballoc/vec.rs:LL:COL
 +                                          // + user_ty: UserType(0)
 +                                          // + literal: Const { ty: alloc::raw_vec::RawVec<u32>, val: Value(ByRef { alloc: Allocation { bytes: [4, 0, 0, 0, 0, 0, 0, 0], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [255], len: Size { raw: 8 } }, size: Size { raw: 8 }, align: Align { pow2: 2 }, mutability: Not, extra: () }, offset: Size { raw: 0 } }) }
@@ -55,28 +51,29 @@
                                            // mir::Constant
                                            // + span: $DIR/inline-into-box-place.rs:7:11: 9:2
                                            // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
--         drop(_1) -> [return: bb3, unwind: bb1]; // scope 0 at $DIR/inline-into-box-place.rs:9:1: 9:2
-+         drop(_1) -> [return: bb2, unwind: bb1]; // scope 0 at $DIR/inline-into-box-place.rs:9:1: 9:2
+-         drop(_1) -> [return: bb2, unwind: bb3]; // scope 0 at $DIR/inline-into-box-place.rs:9:1: 9:2
++         drop(_1) -> [return: bb1, unwind: bb2]; // scope 0 at $DIR/inline-into-box-place.rs:9:1: 9:2
       }
   
--     bb3: {
--         StorageDead(_1);                 // scope 0 at $DIR/inline-into-box-place.rs:9:1: 9:2
--         return;                          // scope 0 at $DIR/inline-into-box-place.rs:9:2: 9:2
-+     bb1 (cleanup): {
-+         resume;                          // scope 0 at $DIR/inline-into-box-place.rs:7:1: 9:2
+-     bb2: {
++     bb1: {
+          StorageDead(_1);                 // scope 0 at $DIR/inline-into-box-place.rs:9:1: 9:2
+          return;                          // scope 0 at $DIR/inline-into-box-place.rs:9:2: 9:2
       }
   
+-     bb3 (cleanup): {
++     bb2 (cleanup): {
+          resume;                          // scope 0 at $DIR/inline-into-box-place.rs:7:1: 9:2
+-     }
+- 
 -     bb4 (cleanup): {
--         _3 = const alloc::alloc::box_free::<std::vec::Vec<u32>>(move (_2.0: std::ptr::Unique<std::vec::Vec<u32>>)) -> bb1; // scope 0 at $DIR/inline-into-box-place.rs:8:42: 8:43
+-         _3 = const alloc::alloc::box_free::<std::vec::Vec<u32>>(move (_2.0: std::ptr::Unique<std::vec::Vec<u32>>)) -> bb3; // scope 0 at $DIR/inline-into-box-place.rs:8:42: 8:43
 -                                          // ty::Const
 -                                          // + ty: unsafe fn(std::ptr::Unique<std::vec::Vec<u32>>) {alloc::alloc::box_free::<std::vec::Vec<u32>>}
 -                                          // + val: Value(Scalar(<ZST>))
 -                                          // mir::Constant
 -                                          // + span: $DIR/inline-into-box-place.rs:8:42: 8:43
 -                                          // + literal: Const { ty: unsafe fn(std::ptr::Unique<std::vec::Vec<u32>>) {alloc::alloc::box_free::<std::vec::Vec<u32>>}, val: Value(Scalar(<ZST>)) }
-+     bb2: {
-+         StorageDead(_1);                 // scope 0 at $DIR/inline-into-box-place.rs:9:1: 9:2
-+         return;                          // scope 0 at $DIR/inline-into-box-place.rs:9:2: 9:2
       }
   }
   

--- a/src/test/mir-opt/inline/inline-into-box-place/64bit/rustc.main.Inline.diff
+++ b/src/test/mir-opt/inline/inline-into-box-place/64bit/rustc.main.Inline.diff
@@ -17,7 +17,7 @@
           StorageLive(_1);                 // scope 0 at $DIR/inline-into-box-place.rs:8:9: 8:11
           StorageLive(_2);                 // scope 0 at $DIR/inline-into-box-place.rs:8:29: 8:43
           _2 = Box(std::vec::Vec<u32>);    // scope 0 at $DIR/inline-into-box-place.rs:8:29: 8:43
--         (*_2) = const std::vec::Vec::<u32>::new() -> [return: bb2, unwind: bb4]; // scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
+-         (*_2) = const std::vec::Vec::<u32>::new() -> [return: bb1, unwind: bb4]; // scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
 +         _4 = &mut (*_2);                 // scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
 +         ((*_4).0: alloc::raw_vec::RawVec<u32>) = const alloc::raw_vec::RawVec::<u32> { ptr: std::ptr::Unique::<u32> { pointer: {0x4 as *const u32}, _marker: std::marker::PhantomData::<u32> }, cap: 0usize, alloc: std::alloc::Global }; // scope 2 at $SRC_DIR/liballoc/vec.rs:LL:COL
                                            // ty::Const
@@ -31,11 +31,7 @@
 -                                          // + literal: Const { ty: fn() -> std::vec::Vec<u32> {std::vec::Vec::<u32>::new}, val: Value(Scalar(<ZST>)) }
 -     }
 - 
--     bb1 (cleanup): {
--         resume;                          // scope 0 at $DIR/inline-into-box-place.rs:7:1: 9:2
--     }
-- 
--     bb2: {
+-     bb1: {
 +                                          // + span: $SRC_DIR/liballoc/vec.rs:LL:COL
 +                                          // + user_ty: UserType(0)
 +                                          // + literal: Const { ty: alloc::raw_vec::RawVec<u32>, val: Value(ByRef { alloc: Allocation { bytes: [4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [65535], len: Size { raw: 16 } }, size: Size { raw: 16 }, align: Align { pow2: 3 }, mutability: Not, extra: () }, offset: Size { raw: 0 } }) }
@@ -55,28 +51,29 @@
                                            // mir::Constant
                                            // + span: $DIR/inline-into-box-place.rs:7:11: 9:2
                                            // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
--         drop(_1) -> [return: bb3, unwind: bb1]; // scope 0 at $DIR/inline-into-box-place.rs:9:1: 9:2
-+         drop(_1) -> [return: bb2, unwind: bb1]; // scope 0 at $DIR/inline-into-box-place.rs:9:1: 9:2
+-         drop(_1) -> [return: bb2, unwind: bb3]; // scope 0 at $DIR/inline-into-box-place.rs:9:1: 9:2
++         drop(_1) -> [return: bb1, unwind: bb2]; // scope 0 at $DIR/inline-into-box-place.rs:9:1: 9:2
       }
   
--     bb3: {
--         StorageDead(_1);                 // scope 0 at $DIR/inline-into-box-place.rs:9:1: 9:2
--         return;                          // scope 0 at $DIR/inline-into-box-place.rs:9:2: 9:2
-+     bb1 (cleanup): {
-+         resume;                          // scope 0 at $DIR/inline-into-box-place.rs:7:1: 9:2
+-     bb2: {
++     bb1: {
+          StorageDead(_1);                 // scope 0 at $DIR/inline-into-box-place.rs:9:1: 9:2
+          return;                          // scope 0 at $DIR/inline-into-box-place.rs:9:2: 9:2
       }
   
+-     bb3 (cleanup): {
++     bb2 (cleanup): {
+          resume;                          // scope 0 at $DIR/inline-into-box-place.rs:7:1: 9:2
+-     }
+- 
 -     bb4 (cleanup): {
--         _3 = const alloc::alloc::box_free::<std::vec::Vec<u32>>(move (_2.0: std::ptr::Unique<std::vec::Vec<u32>>)) -> bb1; // scope 0 at $DIR/inline-into-box-place.rs:8:42: 8:43
+-         _3 = const alloc::alloc::box_free::<std::vec::Vec<u32>>(move (_2.0: std::ptr::Unique<std::vec::Vec<u32>>)) -> bb3; // scope 0 at $DIR/inline-into-box-place.rs:8:42: 8:43
 -                                          // ty::Const
 -                                          // + ty: unsafe fn(std::ptr::Unique<std::vec::Vec<u32>>) {alloc::alloc::box_free::<std::vec::Vec<u32>>}
 -                                          // + val: Value(Scalar(<ZST>))
 -                                          // mir::Constant
 -                                          // + span: $DIR/inline-into-box-place.rs:8:42: 8:43
 -                                          // + literal: Const { ty: unsafe fn(std::ptr::Unique<std::vec::Vec<u32>>) {alloc::alloc::box_free::<std::vec::Vec<u32>>}, val: Value(Scalar(<ZST>)) }
-+     bb2: {
-+         StorageDead(_1);                 // scope 0 at $DIR/inline-into-box-place.rs:9:1: 9:2
-+         return;                          // scope 0 at $DIR/inline-into-box-place.rs:9:2: 9:2
       }
   }
   

--- a/src/test/mir-opt/issue-38669/rustc.main.SimplifyCfg-initial.after.mir
+++ b/src/test/mir-opt/issue-38669/rustc.main.SimplifyCfg-initial.after.mir
@@ -21,30 +21,26 @@ fn main() -> () {
                                          // + span: $DIR/issue-38669.rs:5:28: 5:33
                                          // + literal: Const { ty: bool, val: Value(Scalar(0x00)) }
         FakeRead(ForLet, _1);            // scope 0 at $DIR/issue-38669.rs:5:9: 5:25
-        goto -> bb2;                     // scope 1 at $DIR/issue-38669.rs:6:5: 11:6
+        goto -> bb1;                     // scope 1 at $DIR/issue-38669.rs:6:5: 11:6
     }
 
-    bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/issue-38669.rs:4:1: 12:2
+    bb1: {
+        falseUnwind -> [real: bb2, cleanup: bb6]; // scope 1 at $DIR/issue-38669.rs:6:5: 11:6
     }
 
     bb2: {
-        falseUnwind -> [real: bb3, cleanup: bb1]; // scope 1 at $DIR/issue-38669.rs:6:5: 11:6
-    }
-
-    bb3: {
         StorageLive(_3);                 // scope 1 at $DIR/issue-38669.rs:7:9: 9:10
         StorageLive(_4);                 // scope 1 at $DIR/issue-38669.rs:7:12: 7:24
         _4 = _1;                         // scope 1 at $DIR/issue-38669.rs:7:12: 7:24
         FakeRead(ForMatchedPlace, _4);   // scope 1 at $DIR/issue-38669.rs:7:12: 7:24
-        switchInt(_4) -> [false: bb5, otherwise: bb4]; // scope 1 at $DIR/issue-38669.rs:7:9: 9:10
+        switchInt(_4) -> [false: bb4, otherwise: bb3]; // scope 1 at $DIR/issue-38669.rs:7:9: 9:10
+    }
+
+    bb3: {
+        falseEdges -> [real: bb5, imaginary: bb4]; // scope 1 at $DIR/issue-38669.rs:7:9: 9:10
     }
 
     bb4: {
-        falseEdges -> [real: bb6, imaginary: bb5]; // scope 1 at $DIR/issue-38669.rs:7:9: 9:10
-    }
-
-    bb5: {
         _3 = const ();                   // scope 1 at $DIR/issue-38669.rs:7:9: 9:10
                                          // ty::Const
                                          // + ty: ()
@@ -68,10 +64,10 @@ fn main() -> () {
                                          // mir::Constant
                                          // + span: $DIR/issue-38669.rs:6:10: 11:6
                                          // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
-        goto -> bb2;                     // scope 1 at $DIR/issue-38669.rs:6:5: 11:6
+        goto -> bb1;                     // scope 1 at $DIR/issue-38669.rs:6:5: 11:6
     }
 
-    bb6: {
+    bb5: {
         _0 = const ();                   // scope 1 at $DIR/issue-38669.rs:8:13: 8:18
                                          // ty::Const
                                          // + ty: ()
@@ -83,5 +79,9 @@ fn main() -> () {
         StorageDead(_3);                 // scope 1 at $DIR/issue-38669.rs:9:9: 9:10
         StorageDead(_1);                 // scope 0 at $DIR/issue-38669.rs:12:1: 12:2
         return;                          // scope 0 at $DIR/issue-38669.rs:12:2: 12:2
+    }
+
+    bb6 (cleanup): {
+        resume;                          // scope 0 at $DIR/issue-38669.rs:4:1: 12:2
     }
 }

--- a/src/test/mir-opt/issue-41110/rustc.main.ElaborateDrops.after.mir
+++ b/src/test/mir-opt/issue-41110/rustc.main.ElaborateDrops.after.mir
@@ -32,7 +32,7 @@ fn main() -> () {
         StorageLive(_3);                 // scope 0 at $DIR/issue-41110.rs:8:21: 8:27
         StorageLive(_4);                 // scope 0 at $DIR/issue-41110.rs:8:21: 8:22
         _4 = S;                          // scope 0 at $DIR/issue-41110.rs:8:21: 8:22
-        _3 = const S::id(move _4) -> [return: bb2, unwind: bb4]; // scope 0 at $DIR/issue-41110.rs:8:21: 8:27
+        _3 = const S::id(move _4) -> [return: bb1, unwind: bb4]; // scope 0 at $DIR/issue-41110.rs:8:21: 8:27
                                          // ty::Const
                                          // + ty: fn(S) -> S {S::id}
                                          // + val: Value(Scalar(<ZST>))
@@ -41,11 +41,7 @@ fn main() -> () {
                                          // + literal: Const { ty: fn(S) -> S {S::id}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/issue-41110.rs:7:1: 9:2
-    }
-
-    bb2: {
+    bb1: {
         StorageDead(_4);                 // scope 0 at $DIR/issue-41110.rs:8:26: 8:27
         _5 = const false;                // scope 0 at $DIR/issue-41110.rs:8:13: 8:28
                                          // ty::Const
@@ -54,7 +50,7 @@ fn main() -> () {
                                          // mir::Constant
                                          // + span: $DIR/issue-41110.rs:8:13: 8:28
                                          // + literal: Const { ty: bool, val: Value(Scalar(0x00)) }
-        _1 = const S::other(move _2, move _3) -> [return: bb6, unwind: bb5]; // scope 0 at $DIR/issue-41110.rs:8:13: 8:28
+        _1 = const S::other(move _2, move _3) -> [return: bb2, unwind: bb3]; // scope 0 at $DIR/issue-41110.rs:8:13: 8:28
                                          // ty::Const
                                          // + ty: fn(S, S) {S::other}
                                          // + val: Value(Scalar(<ZST>))
@@ -63,19 +59,7 @@ fn main() -> () {
                                          // + literal: Const { ty: fn(S, S) {S::other}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb3 (cleanup): {
-        goto -> bb9;                     // scope 0 at $DIR/issue-41110.rs:8:27: 8:28
-    }
-
-    bb4 (cleanup): {
-        goto -> bb3;                     // scope 0 at $DIR/issue-41110.rs:8:26: 8:27
-    }
-
-    bb5 (cleanup): {
-        goto -> bb3;                     // scope 0 at $DIR/issue-41110.rs:8:27: 8:28
-    }
-
-    bb6: {
+    bb2: {
         StorageDead(_3);                 // scope 0 at $DIR/issue-41110.rs:8:27: 8:28
         _5 = const false;                // scope 0 at $DIR/issue-41110.rs:8:27: 8:28
                                          // ty::Const
@@ -96,22 +80,27 @@ fn main() -> () {
         return;                          // scope 0 at $DIR/issue-41110.rs:9:2: 9:2
     }
 
+    bb3 (cleanup): {
+        goto -> bb5;                     // scope 0 at $DIR/issue-41110.rs:8:27: 8:28
+    }
+
+    bb4 (cleanup): {
+        goto -> bb5;                     // scope 0 at $DIR/issue-41110.rs:8:26: 8:27
+    }
+
+    bb5 (cleanup): {
+        goto -> bb8;                     // scope 0 at $DIR/issue-41110.rs:8:27: 8:28
+    }
+
+    bb6 (cleanup): {
+        resume;                          // scope 0 at $DIR/issue-41110.rs:7:1: 9:2
+    }
+
     bb7 (cleanup): {
-        drop(_2) -> bb1;                 // scope 0 at $DIR/issue-41110.rs:8:27: 8:28
+        drop(_2) -> bb6;                 // scope 0 at $DIR/issue-41110.rs:8:27: 8:28
     }
 
     bb8 (cleanup): {
-        _5 = const false;                // scope 0 at $DIR/issue-41110.rs:8:27: 8:28
-                                         // ty::Const
-                                         // + ty: bool
-                                         // + val: Value(Scalar(0x00))
-                                         // mir::Constant
-                                         // + span: $DIR/issue-41110.rs:8:27: 8:28
-                                         // + literal: Const { ty: bool, val: Value(Scalar(0x00)) }
-        goto -> bb7;                     // scope 0 at $DIR/issue-41110.rs:8:27: 8:28
-    }
-
-    bb9 (cleanup): {
-        switchInt(_5) -> [false: bb1, otherwise: bb8]; // scope 0 at $DIR/issue-41110.rs:8:27: 8:28
+        switchInt(_5) -> [false: bb6, otherwise: bb7]; // scope 0 at $DIR/issue-41110.rs:8:27: 8:28
     }
 }

--- a/src/test/mir-opt/issue-41110/rustc.test.ElaborateDrops.after.mir
+++ b/src/test/mir-opt/issue-41110/rustc.test.ElaborateDrops.after.mir
@@ -37,7 +37,7 @@ fn test() -> () {
         StorageLive(_3);                 // scope 2 at $DIR/issue-41110.rs:17:5: 17:12
         StorageLive(_4);                 // scope 2 at $DIR/issue-41110.rs:17:10: 17:11
         _4 = move _2;                    // scope 2 at $DIR/issue-41110.rs:17:10: 17:11
-        _3 = const std::mem::drop::<S>(move _4) -> [return: bb2, unwind: bb5]; // scope 2 at $DIR/issue-41110.rs:17:5: 17:12
+        _3 = const std::mem::drop::<S>(move _4) -> [return: bb1, unwind: bb7]; // scope 2 at $DIR/issue-41110.rs:17:5: 17:12
                                          // ty::Const
                                          // + ty: fn(S) {std::mem::drop::<S>}
                                          // + val: Value(Scalar(<ZST>))
@@ -46,11 +46,7 @@ fn test() -> () {
                                          // + literal: Const { ty: fn(S) {std::mem::drop::<S>}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/issue-41110.rs:14:1: 19:2
-    }
-
-    bb2: {
+    bb1: {
         StorageDead(_4);                 // scope 2 at $DIR/issue-41110.rs:17:11: 17:12
         StorageDead(_3);                 // scope 2 at $DIR/issue-41110.rs:17:12: 17:13
         StorageLive(_5);                 // scope 2 at $DIR/issue-41110.rs:18:9: 18:10
@@ -65,27 +61,11 @@ fn test() -> () {
         goto -> bb12;                    // scope 2 at $DIR/issue-41110.rs:18:5: 18:6
     }
 
-    bb3 (cleanup): {
-        goto -> bb15;                    // scope 0 at $DIR/issue-41110.rs:19:1: 19:2
+    bb2: {
+        goto -> bb3;                     // scope 2 at $DIR/issue-41110.rs:18:9: 18:10
     }
 
-    bb4 (cleanup): {
-        goto -> bb3;                     // scope 1 at $DIR/issue-41110.rs:19:1: 19:2
-    }
-
-    bb5 (cleanup): {
-        goto -> bb4;                     // scope 2 at $DIR/issue-41110.rs:17:11: 17:12
-    }
-
-    bb6: {
-        goto -> bb8;                     // scope 2 at $DIR/issue-41110.rs:18:9: 18:10
-    }
-
-    bb7 (cleanup): {
-        goto -> bb4;                     // scope 2 at $DIR/issue-41110.rs:18:9: 18:10
-    }
-
-    bb8: {
+    bb3: {
         StorageDead(_5);                 // scope 2 at $DIR/issue-41110.rs:18:9: 18:10
         _0 = const ();                   // scope 0 at $DIR/issue-41110.rs:14:15: 19:2
                                          // ty::Const
@@ -94,15 +74,15 @@ fn test() -> () {
                                          // mir::Constant
                                          // + span: $DIR/issue-41110.rs:14:15: 19:2
                                          // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
-        drop(_2) -> [return: bb9, unwind: bb3]; // scope 1 at $DIR/issue-41110.rs:19:1: 19:2
+        drop(_2) -> [return: bb4, unwind: bb9]; // scope 1 at $DIR/issue-41110.rs:19:1: 19:2
     }
 
-    bb9: {
+    bb4: {
         StorageDead(_2);                 // scope 1 at $DIR/issue-41110.rs:19:1: 19:2
-        goto -> bb10;                    // scope 0 at $DIR/issue-41110.rs:19:1: 19:2
+        goto -> bb5;                     // scope 0 at $DIR/issue-41110.rs:19:1: 19:2
     }
 
-    bb10: {
+    bb5: {
         _6 = const false;                // scope 0 at $DIR/issue-41110.rs:19:1: 19:2
                                          // ty::Const
                                          // + ty: bool
@@ -114,32 +94,41 @@ fn test() -> () {
         return;                          // scope 0 at $DIR/issue-41110.rs:19:2: 19:2
     }
 
-    bb11 (cleanup): {
-        _2 = move _5;                    // scope 2 at $DIR/issue-41110.rs:18:5: 18:6
-        goto -> bb7;                     // scope 2 at $DIR/issue-41110.rs:18:5: 18:6
+    bb6 (cleanup): {
+        goto -> bb8;                     // scope 2 at $DIR/issue-41110.rs:18:9: 18:10
     }
 
-    bb12: {
+    bb7 (cleanup): {
+        goto -> bb8;                     // scope 2 at $DIR/issue-41110.rs:17:11: 17:12
+    }
+
+    bb8 (cleanup): {
+        goto -> bb9;                     // scope 1 at $DIR/issue-41110.rs:19:1: 19:2
+    }
+
+    bb9 (cleanup): {
+        goto -> bb14;                    // scope 0 at $DIR/issue-41110.rs:19:1: 19:2
+    }
+
+    bb10 (cleanup): {
+        resume;                          // scope 0 at $DIR/issue-41110.rs:14:1: 19:2
+    }
+
+    bb11 (cleanup): {
         _2 = move _5;                    // scope 2 at $DIR/issue-41110.rs:18:5: 18:6
         goto -> bb6;                     // scope 2 at $DIR/issue-41110.rs:18:5: 18:6
     }
 
+    bb12: {
+        _2 = move _5;                    // scope 2 at $DIR/issue-41110.rs:18:5: 18:6
+        goto -> bb2;                     // scope 2 at $DIR/issue-41110.rs:18:5: 18:6
+    }
+
     bb13 (cleanup): {
-        drop(_1) -> bb1;                 // scope 0 at $DIR/issue-41110.rs:19:1: 19:2
+        drop(_1) -> bb10;                // scope 0 at $DIR/issue-41110.rs:19:1: 19:2
     }
 
     bb14 (cleanup): {
-        _6 = const false;                // scope 0 at $DIR/issue-41110.rs:19:1: 19:2
-                                         // ty::Const
-                                         // + ty: bool
-                                         // + val: Value(Scalar(0x00))
-                                         // mir::Constant
-                                         // + span: $DIR/issue-41110.rs:19:1: 19:2
-                                         // + literal: Const { ty: bool, val: Value(Scalar(0x00)) }
-        goto -> bb13;                    // scope 0 at $DIR/issue-41110.rs:19:1: 19:2
-    }
-
-    bb15 (cleanup): {
-        switchInt(_6) -> [false: bb1, otherwise: bb14]; // scope 0 at $DIR/issue-41110.rs:19:1: 19:2
+        switchInt(_6) -> [false: bb10, otherwise: bb13]; // scope 0 at $DIR/issue-41110.rs:19:1: 19:2
     }
 }

--- a/src/test/mir-opt/issue-41697/32bit/rustc.{{impl}}-{{constant}}.SimplifyCfg-qualify-consts.after.mir
+++ b/src/test/mir-opt/issue-41697/32bit/rustc.{{impl}}-{{constant}}.SimplifyCfg-qualify-consts.after.mir
@@ -18,15 +18,15 @@
                                          // mir::Constant
                                          // + span: $DIR/issue-41697.rs:18:21: 18:22
                                          // + literal: Const { ty: usize, val: Value(Scalar(0x00000001)) }
-        assert(!move (_1.1: bool), "attempt to add with overflow") -> [success: bb2, unwind: bb1]; // scope 0 at $DIR/issue-41697.rs:18:19: 18:22
+        assert(!move (_1.1: bool), "attempt to add with overflow") -> [success: bb1, unwind: bb2]; // scope 0 at $DIR/issue-41697.rs:18:19: 18:22
     }
 
-    bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/issue-41697.rs:18:19: 18:22
-    }
-
-    bb2: {
+    bb1: {
         _0 = move (_1.0: usize);         // scope 0 at $DIR/issue-41697.rs:18:19: 18:22
         return;                          // scope 0 at $DIR/issue-41697.rs:18:19: 18:22
+    }
+
+    bb2 (cleanup): {
+        resume;                          // scope 0 at $DIR/issue-41697.rs:18:19: 18:22
     }
 }

--- a/src/test/mir-opt/issue-41697/64bit/rustc.{{impl}}-{{constant}}.SimplifyCfg-qualify-consts.after.mir
+++ b/src/test/mir-opt/issue-41697/64bit/rustc.{{impl}}-{{constant}}.SimplifyCfg-qualify-consts.after.mir
@@ -18,15 +18,15 @@
                                          // mir::Constant
                                          // + span: $DIR/issue-41697.rs:18:21: 18:22
                                          // + literal: Const { ty: usize, val: Value(Scalar(0x0000000000000001)) }
-        assert(!move (_1.1: bool), "attempt to add with overflow") -> [success: bb2, unwind: bb1]; // scope 0 at $DIR/issue-41697.rs:18:19: 18:22
+        assert(!move (_1.1: bool), "attempt to add with overflow") -> [success: bb1, unwind: bb2]; // scope 0 at $DIR/issue-41697.rs:18:19: 18:22
     }
 
-    bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/issue-41697.rs:18:19: 18:22
-    }
-
-    bb2: {
+    bb1: {
         _0 = move (_1.0: usize);         // scope 0 at $DIR/issue-41697.rs:18:19: 18:22
         return;                          // scope 0 at $DIR/issue-41697.rs:18:19: 18:22
+    }
+
+    bb2 (cleanup): {
+        resume;                          // scope 0 at $DIR/issue-41697.rs:18:19: 18:22
     }
 }

--- a/src/test/mir-opt/issue-41888/rustc.main.ElaborateDrops.after.mir
+++ b/src/test/mir-opt/issue-41888/rustc.main.ElaborateDrops.after.mir
@@ -44,7 +44,7 @@ fn main() -> () {
                                          // + literal: Const { ty: bool, val: Value(Scalar(0x00)) }
         StorageLive(_1);                 // scope 0 at $DIR/issue-41888.rs:7:9: 7:10
         StorageLive(_2);                 // scope 1 at $DIR/issue-41888.rs:8:8: 8:14
-        _2 = const cond() -> [return: bb2, unwind: bb3]; // scope 1 at $DIR/issue-41888.rs:8:8: 8:14
+        _2 = const cond() -> [return: bb1, unwind: bb11]; // scope 1 at $DIR/issue-41888.rs:8:8: 8:14
                                          // ty::Const
                                          // + ty: fn() -> bool {cond}
                                          // + val: Value(Scalar(<ZST>))
@@ -53,19 +53,11 @@ fn main() -> () {
                                          // + literal: Const { ty: fn() -> bool {cond}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/issue-41888.rs:6:1: 15:2
+    bb1: {
+        switchInt(_2) -> [false: bb2, otherwise: bb3]; // scope 1 at $DIR/issue-41888.rs:8:5: 14:6
     }
 
     bb2: {
-        switchInt(_2) -> [false: bb4, otherwise: bb5]; // scope 1 at $DIR/issue-41888.rs:8:5: 14:6
-    }
-
-    bb3 (cleanup): {
-        goto -> bb1;                     // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
-    }
-
-    bb4: {
         _0 = const ();                   // scope 1 at $DIR/issue-41888.rs:8:5: 14:6
                                          // ty::Const
                                          // + ty: ()
@@ -73,10 +65,10 @@ fn main() -> () {
                                          // mir::Constant
                                          // + span: $DIR/issue-41888.rs:8:5: 14:6
                                          // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
-        goto -> bb11;                    // scope 1 at $DIR/issue-41888.rs:8:5: 14:6
+        goto -> bb8;                     // scope 1 at $DIR/issue-41888.rs:8:5: 14:6
     }
 
-    bb5: {
+    bb3: {
         StorageLive(_3);                 // scope 1 at $DIR/issue-41888.rs:9:13: 9:20
         StorageLive(_4);                 // scope 1 at $DIR/issue-41888.rs:9:18: 9:19
         _4 = K;                          // scope 1 at $DIR/issue-41888.rs:9:18: 9:19
@@ -85,21 +77,17 @@ fn main() -> () {
         goto -> bb14;                    // scope 1 at $DIR/issue-41888.rs:9:9: 9:10
     }
 
-    bb6: {
-        goto -> bb8;                     // scope 1 at $DIR/issue-41888.rs:9:19: 9:20
+    bb4: {
+        goto -> bb5;                     // scope 1 at $DIR/issue-41888.rs:9:19: 9:20
     }
 
-    bb7 (cleanup): {
-        goto -> bb3;                     // scope 1 at $DIR/issue-41888.rs:9:19: 9:20
-    }
-
-    bb8: {
+    bb5: {
         StorageDead(_3);                 // scope 1 at $DIR/issue-41888.rs:9:19: 9:20
         _5 = discriminant(_1);           // scope 1 at $DIR/issue-41888.rs:10:16: 10:24
-        switchInt(move _5) -> [0isize: bb10, otherwise: bb9]; // scope 1 at $DIR/issue-41888.rs:10:16: 10:24
+        switchInt(move _5) -> [0isize: bb7, otherwise: bb6]; // scope 1 at $DIR/issue-41888.rs:10:16: 10:24
     }
 
-    bb9: {
+    bb6: {
         _0 = const ();                   // scope 1 at $DIR/issue-41888.rs:10:9: 13:10
                                          // ty::Const
                                          // + ty: ()
@@ -107,10 +95,10 @@ fn main() -> () {
                                          // mir::Constant
                                          // + span: $DIR/issue-41888.rs:10:9: 13:10
                                          // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
-        goto -> bb11;                    // scope 1 at $DIR/issue-41888.rs:10:9: 13:10
+        goto -> bb8;                     // scope 1 at $DIR/issue-41888.rs:10:9: 13:10
     }
 
-    bb10: {
+    bb7: {
         StorageLive(_6);                 // scope 1 at $DIR/issue-41888.rs:10:21: 10:23
         _9 = const false;                // scope 1 at $DIR/issue-41888.rs:10:21: 10:23
                                          // ty::Const
@@ -128,14 +116,14 @@ fn main() -> () {
                                          // + span: $DIR/issue-41888.rs:10:29: 13:10
                                          // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
         StorageDead(_6);                 // scope 1 at $DIR/issue-41888.rs:13:9: 13:10
-        goto -> bb11;                    // scope 1 at $DIR/issue-41888.rs:10:9: 13:10
+        goto -> bb8;                     // scope 1 at $DIR/issue-41888.rs:10:9: 13:10
     }
 
-    bb11: {
-        goto -> bb21;                    // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
+    bb8: {
+        goto -> bb20;                    // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
     }
 
-    bb12: {
+    bb9: {
         _7 = const false;                // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
                                          // ty::Const
                                          // + ty: bool
@@ -162,6 +150,18 @@ fn main() -> () {
         return;                          // scope 0 at $DIR/issue-41888.rs:15:2: 15:2
     }
 
+    bb10 (cleanup): {
+        goto -> bb11;                    // scope 1 at $DIR/issue-41888.rs:9:19: 9:20
+    }
+
+    bb11 (cleanup): {
+        goto -> bb12;                    // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
+    }
+
+    bb12 (cleanup): {
+        resume;                          // scope 0 at $DIR/issue-41888.rs:6:1: 15:2
+    }
+
     bb13 (cleanup): {
         _7 = const true;                 // scope 1 at $DIR/issue-41888.rs:9:9: 9:10
                                          // ty::Const
@@ -185,7 +185,7 @@ fn main() -> () {
                                          // + span: $DIR/issue-41888.rs:9:9: 9:10
                                          // + literal: Const { ty: bool, val: Value(Scalar(0x01)) }
         _1 = move _3;                    // scope 1 at $DIR/issue-41888.rs:9:9: 9:10
-        goto -> bb7;                     // scope 1 at $DIR/issue-41888.rs:9:9: 9:10
+        goto -> bb10;                    // scope 1 at $DIR/issue-41888.rs:9:9: 9:10
     }
 
     bb14: {
@@ -211,7 +211,7 @@ fn main() -> () {
                                          // + span: $DIR/issue-41888.rs:9:9: 9:10
                                          // + literal: Const { ty: bool, val: Value(Scalar(0x01)) }
         _1 = move _3;                    // scope 1 at $DIR/issue-41888.rs:9:9: 9:10
-        goto -> bb6;                     // scope 1 at $DIR/issue-41888.rs:9:9: 9:10
+        goto -> bb4;                     // scope 1 at $DIR/issue-41888.rs:9:9: 9:10
     }
 
     bb15: {
@@ -222,47 +222,36 @@ fn main() -> () {
                                          // mir::Constant
                                          // + span: $DIR/issue-41888.rs:15:1: 15:2
                                          // + literal: Const { ty: bool, val: Value(Scalar(0x00)) }
-        goto -> bb12;                    // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
+        goto -> bb9;                     // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
     }
 
     bb16 (cleanup): {
-        _7 = const false;                // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
-                                         // ty::Const
-                                         // + ty: bool
-                                         // + val: Value(Scalar(0x00))
-                                         // mir::Constant
-                                         // + span: $DIR/issue-41888.rs:15:1: 15:2
-                                         // + literal: Const { ty: bool, val: Value(Scalar(0x00)) }
-        goto -> bb1;                     // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
+        goto -> bb12;                    // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
     }
 
-    bb17 (cleanup): {
-        goto -> bb16;                    // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
+    bb17: {
+        drop(_1) -> [return: bb15, unwind: bb12]; // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
     }
 
-    bb18: {
-        drop(_1) -> [return: bb15, unwind: bb16]; // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
+    bb18 (cleanup): {
+        drop(_1) -> bb12;                // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
     }
 
-    bb19 (cleanup): {
-        drop(_1) -> bb16;                // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
+    bb19: {
+        _10 = discriminant(_1);          // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
+        switchInt(move _10) -> [0isize: bb15, otherwise: bb17]; // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
     }
 
     bb20: {
-        _10 = discriminant(_1);          // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
-        switchInt(move _10) -> [0isize: bb15, otherwise: bb18]; // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
+        switchInt(_7) -> [false: bb15, otherwise: bb19]; // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
     }
 
-    bb21: {
-        switchInt(_7) -> [false: bb15, otherwise: bb20]; // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
+    bb21 (cleanup): {
+        _11 = discriminant(_1);          // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
+        switchInt(move _11) -> [0isize: bb16, otherwise: bb18]; // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
     }
 
     bb22 (cleanup): {
-        _11 = discriminant(_1);          // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
-        switchInt(move _11) -> [0isize: bb17, otherwise: bb19]; // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
-    }
-
-    bb23 (cleanup): {
-        switchInt(_7) -> [false: bb16, otherwise: bb22]; // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
+        switchInt(_7) -> [false: bb12, otherwise: bb21]; // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
     }
 }

--- a/src/test/mir-opt/issue-49232/rustc.main.mir_map.0.mir
+++ b/src/test/mir-opt/issue-49232/rustc.main.mir_map.0.mir
@@ -17,14 +17,10 @@ fn main() -> () {
     }
 
     bb1: {
-        falseUnwind -> [real: bb3, cleanup: bb4]; // scope 0 at $DIR/issue-49232.rs:6:5: 14:6
+        falseUnwind -> [real: bb2, cleanup: bb11]; // scope 0 at $DIR/issue-49232.rs:6:5: 14:6
     }
 
     bb2: {
-        goto -> bb14;                    // scope 0 at $DIR/issue-49232.rs:15:2: 15:2
-    }
-
-    bb3: {
         StorageLive(_2);                 // scope 0 at $DIR/issue-49232.rs:7:13: 7:19
         StorageLive(_3);                 // scope 0 at $DIR/issue-49232.rs:8:19: 8:23
         _3 = const true;                 // scope 0 at $DIR/issue-49232.rs:8:19: 8:23
@@ -35,18 +31,14 @@ fn main() -> () {
                                          // + span: $DIR/issue-49232.rs:8:19: 8:23
                                          // + literal: Const { ty: bool, val: Value(Scalar(0x01)) }
         FakeRead(ForMatchedPlace, _3);   // scope 0 at $DIR/issue-49232.rs:8:19: 8:23
-        switchInt(_3) -> [false: bb5, otherwise: bb6]; // scope 0 at $DIR/issue-49232.rs:9:17: 9:22
+        switchInt(_3) -> [false: bb3, otherwise: bb4]; // scope 0 at $DIR/issue-49232.rs:9:17: 9:22
     }
 
-    bb4 (cleanup): {
-        resume;                          // scope 0 at $DIR/issue-49232.rs:5:1: 15:2
+    bb3: {
+        falseEdges -> [real: bb5, imaginary: bb4]; // scope 0 at $DIR/issue-49232.rs:9:17: 9:22
     }
 
-    bb5: {
-        falseEdges -> [real: bb7, imaginary: bb6]; // scope 0 at $DIR/issue-49232.rs:9:17: 9:22
-    }
-
-    bb6: {
+    bb4: {
         _0 = const ();                   // scope 0 at $DIR/issue-49232.rs:10:25: 10:30
                                          // ty::Const
                                          // + ty: ()
@@ -54,10 +46,10 @@ fn main() -> () {
                                          // mir::Constant
                                          // + span: $DIR/issue-49232.rs:10:25: 10:30
                                          // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
-        goto -> bb8;                     // scope 0 at $DIR/issue-49232.rs:10:25: 10:30
+        goto -> bb10;                    // scope 0 at $DIR/issue-49232.rs:10:25: 10:30
     }
 
-    bb7: {
+    bb5: {
         _2 = const 4i32;                 // scope 0 at $DIR/issue-49232.rs:9:26: 9:27
                                          // ty::Const
                                          // + ty: i32
@@ -65,20 +57,10 @@ fn main() -> () {
                                          // mir::Constant
                                          // + span: $DIR/issue-49232.rs:9:26: 9:27
                                          // + literal: Const { ty: i32, val: Value(Scalar(0x00000004)) }
-        goto -> bb12;                    // scope 0 at $DIR/issue-49232.rs:8:13: 11:14
+        goto -> bb8;                     // scope 0 at $DIR/issue-49232.rs:8:13: 11:14
     }
 
-    bb8: {
-        StorageDead(_3);                 // scope 0 at $DIR/issue-49232.rs:12:10: 12:11
-        goto -> bb9;                     // scope 0 at $DIR/issue-49232.rs:10:25: 10:30
-    }
-
-    bb9: {
-        StorageDead(_2);                 // scope 0 at $DIR/issue-49232.rs:14:5: 14:6
-        goto -> bb2;                     // scope 0 at $DIR/issue-49232.rs:10:25: 10:30
-    }
-
-    bb10: {
+    bb6: {
         _4 = const ();                   // scope 0 at $DIR/issue-49232.rs:10:25: 10:30
                                          // ty::Const
                                          // + ty: ()
@@ -89,17 +71,17 @@ fn main() -> () {
         unreachable;                     // scope 0 at $DIR/issue-49232.rs:10:25: 10:30
     }
 
-    bb11: {
-        goto -> bb12;                    // scope 0 at $DIR/issue-49232.rs:8:13: 11:14
+    bb7: {
+        goto -> bb8;                     // scope 0 at $DIR/issue-49232.rs:8:13: 11:14
     }
 
-    bb12: {
+    bb8: {
         FakeRead(ForLet, _2);            // scope 0 at $DIR/issue-49232.rs:7:13: 7:19
         StorageDead(_3);                 // scope 0 at $DIR/issue-49232.rs:12:10: 12:11
         StorageLive(_5);                 // scope 1 at $DIR/issue-49232.rs:13:9: 13:22
         StorageLive(_6);                 // scope 1 at $DIR/issue-49232.rs:13:14: 13:21
         _6 = &_2;                        // scope 1 at $DIR/issue-49232.rs:13:14: 13:21
-        _5 = const std::mem::drop::<&i32>(move _6) -> [return: bb13, unwind: bb4]; // scope 1 at $DIR/issue-49232.rs:13:9: 13:22
+        _5 = const std::mem::drop::<&i32>(move _6) -> [return: bb9, unwind: bb11]; // scope 1 at $DIR/issue-49232.rs:13:9: 13:22
                                          // ty::Const
                                          // + ty: fn(&i32) {std::mem::drop::<&i32>}
                                          // + val: Value(Scalar(<ZST>))
@@ -108,7 +90,7 @@ fn main() -> () {
                                          // + literal: Const { ty: fn(&i32) {std::mem::drop::<&i32>}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb13: {
+    bb9: {
         StorageDead(_6);                 // scope 1 at $DIR/issue-49232.rs:13:21: 13:22
         StorageDead(_5);                 // scope 1 at $DIR/issue-49232.rs:13:22: 13:23
         _1 = const ();                   // scope 0 at $DIR/issue-49232.rs:6:10: 14:6
@@ -122,7 +104,13 @@ fn main() -> () {
         goto -> bb1;                     // scope 0 at $DIR/issue-49232.rs:6:5: 14:6
     }
 
-    bb14: {
+    bb10: {
+        StorageDead(_3);                 // scope 0 at $DIR/issue-49232.rs:12:10: 12:11
+        StorageDead(_2);                 // scope 0 at $DIR/issue-49232.rs:14:5: 14:6
         return;                          // scope 0 at $DIR/issue-49232.rs:15:2: 15:2
+    }
+
+    bb11 (cleanup): {
+        resume;                          // scope 0 at $DIR/issue-49232.rs:5:1: 15:2
     }
 }

--- a/src/test/mir-opt/issue-62289/rustc.test.ElaborateDrops.before.mir
+++ b/src/test/mir-opt/issue-62289/rustc.test.ElaborateDrops.before.mir
@@ -30,7 +30,7 @@ fn test() -> std::option::Option<std::boxed::Box<u32>> {
         StorageLive(_3);                 // scope 0 at $DIR/issue-62289.rs:9:15: 9:20
         StorageLive(_4);                 // scope 0 at $DIR/issue-62289.rs:9:15: 9:19
         _4 = std::option::Option::<u32>::None; // scope 0 at $DIR/issue-62289.rs:9:15: 9:19
-        _3 = const <std::option::Option<u32> as std::ops::Try>::into_result(move _4) -> [return: bb2, unwind: bb3]; // scope 0 at $DIR/issue-62289.rs:9:15: 9:20
+        _3 = const <std::option::Option<u32> as std::ops::Try>::into_result(move _4) -> [return: bb1, unwind: bb12]; // scope 0 at $DIR/issue-62289.rs:9:15: 9:20
                                          // ty::Const
                                          // + ty: fn(std::option::Option<u32>) -> std::result::Result<<std::option::Option<u32> as std::ops::Try>::Ok, <std::option::Option<u32> as std::ops::Try>::Error> {<std::option::Option<u32> as std::ops::Try>::into_result}
                                          // + val: Value(Scalar(<ZST>))
@@ -39,40 +39,32 @@ fn test() -> std::option::Option<std::boxed::Box<u32>> {
                                          // + literal: Const { ty: fn(std::option::Option<u32>) -> std::result::Result<<std::option::Option<u32> as std::ops::Try>::Ok, <std::option::Option<u32> as std::ops::Try>::Error> {<std::option::Option<u32> as std::ops::Try>::into_result}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/issue-62289.rs:8:1: 10:2
+    bb1: {
+        StorageDead(_4);                 // scope 0 at $DIR/issue-62289.rs:9:19: 9:20
+        _5 = discriminant(_3);           // scope 0 at $DIR/issue-62289.rs:9:19: 9:20
+        switchInt(move _5) -> [0isize: bb2, 1isize: bb4, otherwise: bb3]; // scope 0 at $DIR/issue-62289.rs:9:19: 9:20
     }
 
     bb2: {
-        StorageDead(_4);                 // scope 0 at $DIR/issue-62289.rs:9:19: 9:20
-        _5 = discriminant(_3);           // scope 0 at $DIR/issue-62289.rs:9:19: 9:20
-        switchInt(move _5) -> [0isize: bb4, 1isize: bb6, otherwise: bb5]; // scope 0 at $DIR/issue-62289.rs:9:19: 9:20
-    }
-
-    bb3 (cleanup): {
-        drop(_2) -> bb1;                 // scope 0 at $DIR/issue-62289.rs:9:20: 9:21
-    }
-
-    bb4: {
         StorageLive(_10);                // scope 0 at $DIR/issue-62289.rs:9:15: 9:20
         _10 = ((_3 as Ok).0: u32);       // scope 0 at $DIR/issue-62289.rs:9:15: 9:20
         (*_2) = _10;                     // scope 4 at $DIR/issue-62289.rs:9:15: 9:20
         StorageDead(_10);                // scope 0 at $DIR/issue-62289.rs:9:19: 9:20
         _1 = move _2;                    // scope 0 at $DIR/issue-62289.rs:9:10: 9:21
-        drop(_2) -> [return: bb12, unwind: bb11]; // scope 0 at $DIR/issue-62289.rs:9:20: 9:21
+        drop(_2) -> [return: bb7, unwind: bb11]; // scope 0 at $DIR/issue-62289.rs:9:20: 9:21
     }
 
-    bb5: {
+    bb3: {
         unreachable;                     // scope 0 at $DIR/issue-62289.rs:9:15: 9:20
     }
 
-    bb6: {
+    bb4: {
         StorageLive(_6);                 // scope 0 at $DIR/issue-62289.rs:9:19: 9:20
         _6 = ((_3 as Err).0: std::option::NoneError); // scope 0 at $DIR/issue-62289.rs:9:19: 9:20
         StorageLive(_8);                 // scope 2 at $DIR/issue-62289.rs:9:19: 9:20
         StorageLive(_9);                 // scope 2 at $DIR/issue-62289.rs:9:19: 9:20
         _9 = _6;                         // scope 2 at $DIR/issue-62289.rs:9:19: 9:20
-        _8 = const <std::option::NoneError as std::convert::From<std::option::NoneError>>::from(move _9) -> [return: bb8, unwind: bb3]; // scope 2 at $DIR/issue-62289.rs:9:19: 9:20
+        _8 = const <std::option::NoneError as std::convert::From<std::option::NoneError>>::from(move _9) -> [return: bb5, unwind: bb12]; // scope 2 at $DIR/issue-62289.rs:9:19: 9:20
                                          // ty::Const
                                          // + ty: fn(std::option::NoneError) -> std::option::NoneError {<std::option::NoneError as std::convert::From<std::option::NoneError>>::from}
                                          // + val: Value(Scalar(<ZST>))
@@ -81,13 +73,9 @@ fn test() -> std::option::Option<std::boxed::Box<u32>> {
                                          // + literal: Const { ty: fn(std::option::NoneError) -> std::option::NoneError {<std::option::NoneError as std::convert::From<std::option::NoneError>>::from}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb7: {
-        return;                          // scope 0 at $DIR/issue-62289.rs:10:2: 10:2
-    }
-
-    bb8: {
+    bb5: {
         StorageDead(_9);                 // scope 2 at $DIR/issue-62289.rs:9:19: 9:20
-        _0 = const <std::option::Option<std::boxed::Box<u32>> as std::ops::Try>::from_error(move _8) -> [return: bb9, unwind: bb3]; // scope 2 at $DIR/issue-62289.rs:9:19: 9:20
+        _0 = const <std::option::Option<std::boxed::Box<u32>> as std::ops::Try>::from_error(move _8) -> [return: bb6, unwind: bb12]; // scope 2 at $DIR/issue-62289.rs:9:19: 9:20
                                          // ty::Const
                                          // + ty: fn(<std::option::Option<std::boxed::Box<u32>> as std::ops::Try>::Error) -> std::option::Option<std::boxed::Box<u32>> {<std::option::Option<std::boxed::Box<u32>> as std::ops::Try>::from_error}
                                          // + val: Value(Scalar(<ZST>))
@@ -96,32 +84,44 @@ fn test() -> std::option::Option<std::boxed::Box<u32>> {
                                          // + literal: Const { ty: fn(<std::option::Option<std::boxed::Box<u32>> as std::ops::Try>::Error) -> std::option::Option<std::boxed::Box<u32>> {<std::option::Option<std::boxed::Box<u32>> as std::ops::Try>::from_error}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb9: {
+    bb6: {
         StorageDead(_8);                 // scope 2 at $DIR/issue-62289.rs:9:19: 9:20
         StorageDead(_6);                 // scope 0 at $DIR/issue-62289.rs:9:19: 9:20
-        drop(_2) -> bb10;                // scope 0 at $DIR/issue-62289.rs:9:20: 9:21
+        drop(_2) -> bb9;                 // scope 0 at $DIR/issue-62289.rs:9:20: 9:21
+    }
+
+    bb7: {
+        StorageDead(_2);                 // scope 0 at $DIR/issue-62289.rs:9:20: 9:21
+        _0 = std::option::Option::<std::boxed::Box<u32>>::Some(move _1); // scope 0 at $DIR/issue-62289.rs:9:5: 9:22
+        drop(_1) -> bb8;                 // scope 0 at $DIR/issue-62289.rs:9:21: 9:22
+    }
+
+    bb8: {
+        StorageDead(_1);                 // scope 0 at $DIR/issue-62289.rs:9:21: 9:22
+        StorageDead(_3);                 // scope 0 at $DIR/issue-62289.rs:10:1: 10:2
+        goto -> bb10;                    // scope 0 at $DIR/issue-62289.rs:10:2: 10:2
+    }
+
+    bb9: {
+        StorageDead(_2);                 // scope 0 at $DIR/issue-62289.rs:9:20: 9:21
+        StorageDead(_1);                 // scope 0 at $DIR/issue-62289.rs:9:21: 9:22
+        StorageDead(_3);                 // scope 0 at $DIR/issue-62289.rs:10:1: 10:2
+        goto -> bb10;                    // scope 0 at $DIR/issue-62289.rs:10:2: 10:2
     }
 
     bb10: {
-        StorageDead(_2);                 // scope 0 at $DIR/issue-62289.rs:9:20: 9:21
-        StorageDead(_1);                 // scope 0 at $DIR/issue-62289.rs:9:21: 9:22
-        StorageDead(_3);                 // scope 0 at $DIR/issue-62289.rs:10:1: 10:2
-        goto -> bb7;                     // scope 0 at $DIR/issue-62289.rs:9:19: 9:20
+        return;                          // scope 0 at $DIR/issue-62289.rs:10:2: 10:2
     }
 
     bb11 (cleanup): {
-        drop(_1) -> bb1;                 // scope 0 at $DIR/issue-62289.rs:9:21: 9:22
-    }
-
-    bb12: {
-        StorageDead(_2);                 // scope 0 at $DIR/issue-62289.rs:9:20: 9:21
-        _0 = std::option::Option::<std::boxed::Box<u32>>::Some(move _1); // scope 0 at $DIR/issue-62289.rs:9:5: 9:22
         drop(_1) -> bb13;                // scope 0 at $DIR/issue-62289.rs:9:21: 9:22
     }
 
-    bb13: {
-        StorageDead(_1);                 // scope 0 at $DIR/issue-62289.rs:9:21: 9:22
-        StorageDead(_3);                 // scope 0 at $DIR/issue-62289.rs:10:1: 10:2
-        goto -> bb7;                     // scope 0 at $DIR/issue-62289.rs:10:2: 10:2
+    bb12 (cleanup): {
+        drop(_2) -> bb13;                // scope 0 at $DIR/issue-62289.rs:9:20: 9:21
+    }
+
+    bb13 (cleanup): {
+        resume;                          // scope 0 at $DIR/issue-62289.rs:8:1: 10:2
     }
 }

--- a/src/test/mir-opt/loop_test/rustc.main.SimplifyCfg-qualify-consts.after.mir
+++ b/src/test/mir-opt/loop_test/rustc.main.SimplifyCfg-qualify-consts.after.mir
@@ -23,18 +23,14 @@ fn main() -> () {
                                          // + span: $DIR/loop_test.rs:10:8: 10:12
                                          // + literal: Const { ty: bool, val: Value(Scalar(0x01)) }
         FakeRead(ForMatchedPlace, _2);   // scope 0 at $DIR/loop_test.rs:10:8: 10:12
-        switchInt(_2) -> [false: bb3, otherwise: bb2]; // scope 0 at $DIR/loop_test.rs:10:5: 12:6
+        switchInt(_2) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/loop_test.rs:10:5: 12:6
     }
 
-    bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/loop_test.rs:6:1: 17:2
+    bb1: {
+        falseEdges -> [real: bb3, imaginary: bb2]; // scope 0 at $DIR/loop_test.rs:10:5: 12:6
     }
 
     bb2: {
-        falseEdges -> [real: bb4, imaginary: bb3]; // scope 0 at $DIR/loop_test.rs:10:5: 12:6
-    }
-
-    bb3: {
         _1 = const ();                   // scope 0 at $DIR/loop_test.rs:10:5: 12:6
                                          // ty::Const
                                          // + ty: ()
@@ -45,10 +41,10 @@ fn main() -> () {
         StorageDead(_2);                 // scope 0 at $DIR/loop_test.rs:12:5: 12:6
         StorageDead(_1);                 // scope 0 at $DIR/loop_test.rs:12:5: 12:6
         StorageLive(_4);                 // scope 0 at $DIR/loop_test.rs:13:5: 16:6
-        goto -> bb5;                     // scope 0 at $DIR/loop_test.rs:13:5: 16:6
+        goto -> bb4;                     // scope 0 at $DIR/loop_test.rs:13:5: 16:6
     }
 
-    bb4: {
+    bb3: {
         _0 = const ();                   // scope 0 at $DIR/loop_test.rs:11:9: 11:15
                                          // ty::Const
                                          // + ty: ()
@@ -61,11 +57,11 @@ fn main() -> () {
         return;                          // scope 0 at $DIR/loop_test.rs:17:2: 17:2
     }
 
-    bb5: {
-        falseUnwind -> [real: bb6, cleanup: bb1]; // scope 0 at $DIR/loop_test.rs:13:5: 16:6
+    bb4: {
+        falseUnwind -> [real: bb5, cleanup: bb6]; // scope 0 at $DIR/loop_test.rs:13:5: 16:6
     }
 
-    bb6: {
+    bb5: {
         StorageLive(_6);                 // scope 0 at $DIR/loop_test.rs:14:13: 14:14
         _6 = const 1i32;                 // scope 0 at $DIR/loop_test.rs:14:17: 14:18
                                          // ty::Const
@@ -76,6 +72,10 @@ fn main() -> () {
                                          // + literal: Const { ty: i32, val: Value(Scalar(0x00000001)) }
         FakeRead(ForLet, _6);            // scope 0 at $DIR/loop_test.rs:14:13: 14:14
         StorageDead(_6);                 // scope 0 at $DIR/loop_test.rs:16:5: 16:6
-        goto -> bb5;                     // scope 0 at $DIR/loop_test.rs:15:9: 15:17
+        goto -> bb4;                     // scope 0 at $DIR/loop_test.rs:1:1: 1:1
+    }
+
+    bb6 (cleanup): {
+        resume;                          // scope 0 at $DIR/loop_test.rs:6:1: 17:2
     }
 }

--- a/src/test/mir-opt/match-arm-scopes/rustc.complicated_match.ElaborateDrops.after.mir
+++ b/src/test/mir-opt/match-arm-scopes/rustc.complicated_match.ElaborateDrops.after.mir
@@ -30,30 +30,26 @@ fn complicated_match(_1: bool, _2: (bool, bool, std::string::String)) -> i32 {
     }
 
     bb0: {
-        switchInt((_2.0: bool)) -> [false: bb6, otherwise: bb2]; // scope 0 at $DIR/match-arm-scopes.rs:16:10: 16:15
+        switchInt((_2.0: bool)) -> [false: bb5, otherwise: bb1]; // scope 0 at $DIR/match-arm-scopes.rs:16:10: 16:15
     }
 
-    bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/match-arm-scopes.rs:14:1: 19:2
+    bb1: {
+        switchInt((_2.1: bool)) -> [false: bb10, otherwise: bb2]; // scope 0 at $DIR/match-arm-scopes.rs:16:29: 16:34
     }
 
     bb2: {
-        switchInt((_2.1: bool)) -> [false: bb14, otherwise: bb3]; // scope 0 at $DIR/match-arm-scopes.rs:16:29: 16:34
+        switchInt((_2.0: bool)) -> [false: bb3, otherwise: bb17]; // scope 0 at $DIR/match-arm-scopes.rs:17:10: 17:14
     }
 
     bb3: {
-        switchInt((_2.0: bool)) -> [false: bb4, otherwise: bb21]; // scope 0 at $DIR/match-arm-scopes.rs:17:10: 17:14
-    }
-
-    bb4: {
         StorageLive(_15);                // scope 0 at $DIR/match-arm-scopes.rs:17:32: 17:33
         _15 = (_2.1: bool);              // scope 0 at $DIR/match-arm-scopes.rs:17:32: 17:33
         StorageLive(_16);                // scope 0 at $DIR/match-arm-scopes.rs:17:35: 17:36
         _16 = move (_2.2: std::string::String); // scope 0 at $DIR/match-arm-scopes.rs:17:35: 17:36
-        goto -> bb20;                    // scope 0 at $DIR/match-arm-scopes.rs:15:5: 18:6
+        goto -> bb16;                    // scope 0 at $DIR/match-arm-scopes.rs:15:5: 18:6
     }
 
-    bb5: {
+    bb4: {
         _0 = const 1i32;                 // scope 1 at $DIR/match-arm-scopes.rs:16:77: 16:78
                                          // ty::Const
                                          // + ty: i32
@@ -61,10 +57,10 @@ fn complicated_match(_1: bool, _2: (bool, bool, std::string::String)) -> i32 {
                                          // mir::Constant
                                          // + span: $DIR/match-arm-scopes.rs:16:77: 16:78
                                          // + literal: Const { ty: i32, val: Value(Scalar(0x00000001)) }
-        drop(_7) -> [return: bb19, unwind: bb10]; // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
+        drop(_7) -> [return: bb15, unwind: bb22]; // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
     }
 
-    bb6: {
+    bb5: {
         StorageLive(_6);                 // scope 0 at $DIR/match-arm-scopes.rs:16:17: 16:18
         _6 = &(_2.1: bool);              // scope 0 at $DIR/match-arm-scopes.rs:16:17: 16:18
         StorageLive(_8);                 // scope 0 at $DIR/match-arm-scopes.rs:16:20: 16:21
@@ -72,16 +68,16 @@ fn complicated_match(_1: bool, _2: (bool, bool, std::string::String)) -> i32 {
         StorageLive(_9);                 // scope 0 at $DIR/match-arm-scopes.rs:16:42: 16:73
         StorageLive(_10);                // scope 0 at $DIR/match-arm-scopes.rs:16:45: 16:49
         _10 = _1;                        // scope 0 at $DIR/match-arm-scopes.rs:16:45: 16:49
-        switchInt(_10) -> [false: bb7, otherwise: bb8]; // scope 0 at $DIR/match-arm-scopes.rs:16:42: 16:73
+        switchInt(_10) -> [false: bb6, otherwise: bb7]; // scope 0 at $DIR/match-arm-scopes.rs:16:42: 16:73
+    }
+
+    bb6: {
+        _9 = (*_6);                      // scope 0 at $DIR/match-arm-scopes.rs:16:70: 16:71
+        StorageDead(_10);                // scope 0 at $DIR/match-arm-scopes.rs:16:72: 16:73
+        switchInt(move _9) -> [false: bb9, otherwise: bb8]; // scope 0 at $DIR/match-arm-scopes.rs:16:42: 16:73
     }
 
     bb7: {
-        _9 = (*_6);                      // scope 0 at $DIR/match-arm-scopes.rs:16:70: 16:71
-        StorageDead(_10);                // scope 0 at $DIR/match-arm-scopes.rs:16:72: 16:73
-        switchInt(move _9) -> [false: bb13, otherwise: bb12]; // scope 0 at $DIR/match-arm-scopes.rs:16:42: 16:73
-    }
-
-    bb8: {
         _0 = const 3i32;                 // scope 0 at $DIR/match-arm-scopes.rs:16:59: 16:60
                                          // ty::Const
                                          // + ty: i32
@@ -91,40 +87,26 @@ fn complicated_match(_1: bool, _2: (bool, bool, std::string::String)) -> i32 {
                                          // + literal: Const { ty: i32, val: Value(Scalar(0x00000003)) }
         StorageDead(_10);                // scope 0 at $DIR/match-arm-scopes.rs:16:72: 16:73
         StorageDead(_9);                 // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
-        StorageDead(_8);                 // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
-        StorageDead(_6);                 // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
-        goto -> bb11;                    // scope 0 at $DIR/match-arm-scopes.rs:16:52: 16:60
+        goto -> bb20;                    // scope 0 at $DIR/match-arm-scopes.rs:1:1: 1:1
     }
 
-    bb9: {
-        return;                          // scope 0 at $DIR/match-arm-scopes.rs:19:2: 19:2
-    }
-
-    bb10 (cleanup): {
-        goto -> bb25;                    // scope 0 at $DIR/match-arm-scopes.rs:19:1: 19:2
-    }
-
-    bb11: {
-        drop(_2) -> [return: bb9, unwind: bb1]; // scope 0 at $DIR/match-arm-scopes.rs:19:1: 19:2
-    }
-
-    bb12: {
+    bb8: {
         StorageDead(_9);                 // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
         StorageLive(_5);                 // scope 0 at $DIR/match-arm-scopes.rs:16:17: 16:18
         _5 = (_2.1: bool);               // scope 0 at $DIR/match-arm-scopes.rs:16:17: 16:18
         StorageLive(_7);                 // scope 0 at $DIR/match-arm-scopes.rs:16:20: 16:21
         _7 = move (_2.2: std::string::String); // scope 0 at $DIR/match-arm-scopes.rs:16:20: 16:21
-        goto -> bb5;                     // scope 0 at $DIR/match-arm-scopes.rs:15:5: 18:6
+        goto -> bb4;                     // scope 0 at $DIR/match-arm-scopes.rs:15:5: 18:6
     }
 
-    bb13: {
+    bb9: {
         StorageDead(_9);                 // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
         StorageDead(_8);                 // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
         StorageDead(_6);                 // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
-        goto -> bb2;                     // scope 0 at $DIR/match-arm-scopes.rs:16:42: 16:73
+        goto -> bb1;                     // scope 0 at $DIR/match-arm-scopes.rs:16:42: 16:73
     }
 
-    bb14: {
+    bb10: {
         StorageLive(_6);                 // scope 0 at $DIR/match-arm-scopes.rs:16:26: 16:27
         _6 = &(_2.0: bool);              // scope 0 at $DIR/match-arm-scopes.rs:16:26: 16:27
         StorageLive(_8);                 // scope 0 at $DIR/match-arm-scopes.rs:16:36: 16:37
@@ -132,16 +114,16 @@ fn complicated_match(_1: bool, _2: (bool, bool, std::string::String)) -> i32 {
         StorageLive(_12);                // scope 0 at $DIR/match-arm-scopes.rs:16:42: 16:73
         StorageLive(_13);                // scope 0 at $DIR/match-arm-scopes.rs:16:45: 16:49
         _13 = _1;                        // scope 0 at $DIR/match-arm-scopes.rs:16:45: 16:49
-        switchInt(_13) -> [false: bb15, otherwise: bb16]; // scope 0 at $DIR/match-arm-scopes.rs:16:42: 16:73
+        switchInt(_13) -> [false: bb11, otherwise: bb12]; // scope 0 at $DIR/match-arm-scopes.rs:16:42: 16:73
     }
 
-    bb15: {
+    bb11: {
         _12 = (*_6);                     // scope 0 at $DIR/match-arm-scopes.rs:16:70: 16:71
         StorageDead(_13);                // scope 0 at $DIR/match-arm-scopes.rs:16:72: 16:73
-        switchInt(move _12) -> [false: bb18, otherwise: bb17]; // scope 0 at $DIR/match-arm-scopes.rs:16:42: 16:73
+        switchInt(move _12) -> [false: bb14, otherwise: bb13]; // scope 0 at $DIR/match-arm-scopes.rs:16:42: 16:73
     }
 
-    bb16: {
+    bb12: {
         _0 = const 3i32;                 // scope 0 at $DIR/match-arm-scopes.rs:16:59: 16:60
                                          // ty::Const
                                          // + ty: i32
@@ -151,36 +133,34 @@ fn complicated_match(_1: bool, _2: (bool, bool, std::string::String)) -> i32 {
                                          // + literal: Const { ty: i32, val: Value(Scalar(0x00000003)) }
         StorageDead(_13);                // scope 0 at $DIR/match-arm-scopes.rs:16:72: 16:73
         StorageDead(_12);                // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
-        StorageDead(_8);                 // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
-        StorageDead(_6);                 // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
-        goto -> bb11;                    // scope 0 at $DIR/match-arm-scopes.rs:16:52: 16:60
+        goto -> bb20;                    // scope 0 at $DIR/match-arm-scopes.rs:1:1: 1:1
     }
 
-    bb17: {
+    bb13: {
         StorageDead(_12);                // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
         StorageLive(_5);                 // scope 0 at $DIR/match-arm-scopes.rs:16:26: 16:27
         _5 = (_2.0: bool);               // scope 0 at $DIR/match-arm-scopes.rs:16:26: 16:27
         StorageLive(_7);                 // scope 0 at $DIR/match-arm-scopes.rs:16:36: 16:37
         _7 = move (_2.2: std::string::String); // scope 0 at $DIR/match-arm-scopes.rs:16:36: 16:37
-        goto -> bb5;                     // scope 0 at $DIR/match-arm-scopes.rs:15:5: 18:6
+        goto -> bb4;                     // scope 0 at $DIR/match-arm-scopes.rs:15:5: 18:6
     }
 
-    bb18: {
+    bb14: {
         StorageDead(_12);                // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
         StorageDead(_8);                 // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
         StorageDead(_6);                 // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
-        goto -> bb3;                     // scope 0 at $DIR/match-arm-scopes.rs:16:42: 16:73
+        goto -> bb2;                     // scope 0 at $DIR/match-arm-scopes.rs:16:42: 16:73
     }
 
-    bb19: {
+    bb15: {
         StorageDead(_7);                 // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
         StorageDead(_5);                 // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
         StorageDead(_8);                 // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
         StorageDead(_6);                 // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
-        goto -> bb23;                    // scope 0 at $DIR/match-arm-scopes.rs:15:5: 18:6
+        goto -> bb19;                    // scope 0 at $DIR/match-arm-scopes.rs:15:5: 18:6
     }
 
-    bb20: {
+    bb16: {
         _0 = const 2i32;                 // scope 2 at $DIR/match-arm-scopes.rs:17:41: 17:42
                                          // ty::Const
                                          // + ty: i32
@@ -188,48 +168,58 @@ fn complicated_match(_1: bool, _2: (bool, bool, std::string::String)) -> i32 {
                                          // mir::Constant
                                          // + span: $DIR/match-arm-scopes.rs:17:41: 17:42
                                          // + literal: Const { ty: i32, val: Value(Scalar(0x00000002)) }
-        drop(_16) -> [return: bb22, unwind: bb10]; // scope 0 at $DIR/match-arm-scopes.rs:17:42: 17:43
+        drop(_16) -> [return: bb18, unwind: bb22]; // scope 0 at $DIR/match-arm-scopes.rs:17:42: 17:43
     }
 
-    bb21: {
+    bb17: {
         StorageLive(_15);                // scope 0 at $DIR/match-arm-scopes.rs:17:16: 17:17
         _15 = (_2.1: bool);              // scope 0 at $DIR/match-arm-scopes.rs:17:16: 17:17
         StorageLive(_16);                // scope 0 at $DIR/match-arm-scopes.rs:17:19: 17:20
         _16 = move (_2.2: std::string::String); // scope 0 at $DIR/match-arm-scopes.rs:17:19: 17:20
-        goto -> bb20;                    // scope 0 at $DIR/match-arm-scopes.rs:15:5: 18:6
+        goto -> bb16;                    // scope 0 at $DIR/match-arm-scopes.rs:15:5: 18:6
     }
 
-    bb22: {
+    bb18: {
         StorageDead(_16);                // scope 0 at $DIR/match-arm-scopes.rs:17:42: 17:43
         StorageDead(_15);                // scope 0 at $DIR/match-arm-scopes.rs:17:42: 17:43
-        goto -> bb23;                    // scope 0 at $DIR/match-arm-scopes.rs:15:5: 18:6
+        goto -> bb19;                    // scope 0 at $DIR/match-arm-scopes.rs:15:5: 18:6
     }
 
-    bb23: {
-        goto -> bb29;                    // scope 0 at $DIR/match-arm-scopes.rs:19:1: 19:2
+    bb19: {
+        goto -> bb26;                    // scope 0 at $DIR/match-arm-scopes.rs:19:1: 19:2
     }
 
-    bb24 (cleanup): {
-        goto -> bb1;                     // scope 0 at $DIR/match-arm-scopes.rs:19:1: 19:2
+    bb20: {
+        StorageDead(_8);                 // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
+        StorageDead(_6);                 // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
+        drop(_2) -> [return: bb21, unwind: bb23]; // scope 0 at $DIR/match-arm-scopes.rs:19:1: 19:2
     }
 
-    bb25 (cleanup): {
-        goto -> bb24;                    // scope 0 at $DIR/match-arm-scopes.rs:19:1: 19:2
+    bb21: {
+        return;                          // scope 0 at $DIR/match-arm-scopes.rs:19:2: 19:2
     }
 
-    bb26: {
-        goto -> bb9;                     // scope 0 at $DIR/match-arm-scopes.rs:19:1: 19:2
-    }
-
-    bb27 (cleanup): {
-        goto -> bb1;                     // scope 0 at $DIR/match-arm-scopes.rs:19:1: 19:2
-    }
-
-    bb28 (cleanup): {
+    bb22 (cleanup): {
         goto -> bb27;                    // scope 0 at $DIR/match-arm-scopes.rs:19:1: 19:2
     }
 
-    bb29: {
-        goto -> bb26;                    // scope 0 at $DIR/match-arm-scopes.rs:19:1: 19:2
+    bb23 (cleanup): {
+        resume;                          // scope 0 at $DIR/match-arm-scopes.rs:14:1: 19:2
+    }
+
+    bb24: {
+        goto -> bb21;                    // scope 0 at $DIR/match-arm-scopes.rs:19:1: 19:2
+    }
+
+    bb25 (cleanup): {
+        goto -> bb23;                    // scope 0 at $DIR/match-arm-scopes.rs:19:1: 19:2
+    }
+
+    bb26: {
+        goto -> bb24;                    // scope 0 at $DIR/match-arm-scopes.rs:19:1: 19:2
+    }
+
+    bb27 (cleanup): {
+        goto -> bb23;                    // scope 0 at $DIR/match-arm-scopes.rs:19:1: 19:2
     }
 }

--- a/src/test/mir-opt/match-arm-scopes/rustc.complicated_match.SimplifyCfg-initial.after.mir
+++ b/src/test/mir-opt/match-arm-scopes/rustc.complicated_match.SimplifyCfg-initial.after.mir
@@ -31,42 +31,38 @@ fn complicated_match(_1: bool, _2: (bool, bool, std::string::String)) -> i32 {
 
     bb0: {
         FakeRead(ForMatchedPlace, _2);   // scope 0 at $DIR/match-arm-scopes.rs:15:11: 15:16
-        switchInt((_2.0: bool)) -> [false: bb2, otherwise: bb3]; // scope 0 at $DIR/match-arm-scopes.rs:16:10: 16:15
+        switchInt((_2.0: bool)) -> [false: bb1, otherwise: bb2]; // scope 0 at $DIR/match-arm-scopes.rs:16:10: 16:15
     }
 
-    bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/match-arm-scopes.rs:14:1: 19:2
+    bb1: {
+        falseEdges -> [real: bb8, imaginary: bb3]; // scope 0 at $DIR/match-arm-scopes.rs:16:9: 16:22
     }
 
     bb2: {
-        falseEdges -> [real: bb9, imaginary: bb4]; // scope 0 at $DIR/match-arm-scopes.rs:16:9: 16:22
+        switchInt((_2.1: bool)) -> [false: bb3, otherwise: bb4]; // scope 0 at $DIR/match-arm-scopes.rs:16:29: 16:34
     }
 
     bb3: {
-        switchInt((_2.1: bool)) -> [false: bb4, otherwise: bb5]; // scope 0 at $DIR/match-arm-scopes.rs:16:29: 16:34
+        falseEdges -> [real: bb14, imaginary: bb5]; // scope 0 at $DIR/match-arm-scopes.rs:16:25: 16:38
     }
 
     bb4: {
-        falseEdges -> [real: bb18, imaginary: bb6]; // scope 0 at $DIR/match-arm-scopes.rs:16:25: 16:38
+        switchInt((_2.0: bool)) -> [false: bb6, otherwise: bb5]; // scope 0 at $DIR/match-arm-scopes.rs:17:10: 17:14
     }
 
     bb5: {
-        switchInt((_2.0: bool)) -> [false: bb7, otherwise: bb6]; // scope 0 at $DIR/match-arm-scopes.rs:17:10: 17:14
+        falseEdges -> [real: bb22, imaginary: bb6]; // scope 0 at $DIR/match-arm-scopes.rs:17:9: 17:21
     }
 
     bb6: {
-        falseEdges -> [real: bb26, imaginary: bb7]; // scope 0 at $DIR/match-arm-scopes.rs:17:9: 17:21
-    }
-
-    bb7: {
         StorageLive(_15);                // scope 0 at $DIR/match-arm-scopes.rs:17:32: 17:33
         _15 = (_2.1: bool);              // scope 0 at $DIR/match-arm-scopes.rs:17:32: 17:33
         StorageLive(_16);                // scope 0 at $DIR/match-arm-scopes.rs:17:35: 17:36
         _16 = move (_2.2: std::string::String); // scope 0 at $DIR/match-arm-scopes.rs:17:35: 17:36
-        goto -> bb25;                    // scope 0 at $DIR/match-arm-scopes.rs:15:5: 18:6
+        goto -> bb21;                    // scope 0 at $DIR/match-arm-scopes.rs:15:5: 18:6
     }
 
-    bb8: {
+    bb7: {
         _0 = const 1i32;                 // scope 1 at $DIR/match-arm-scopes.rs:16:77: 16:78
                                          // ty::Const
                                          // + ty: i32
@@ -74,10 +70,10 @@ fn complicated_match(_1: bool, _2: (bool, bool, std::string::String)) -> i32 {
                                          // mir::Constant
                                          // + span: $DIR/match-arm-scopes.rs:16:77: 16:78
                                          // + literal: Const { ty: i32, val: Value(Scalar(0x00000001)) }
-        drop(_7) -> [return: bb24, unwind: bb14]; // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
+        drop(_7) -> [return: bb20, unwind: bb27]; // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
     }
 
-    bb9: {
+    bb8: {
         StorageLive(_6);                 // scope 0 at $DIR/match-arm-scopes.rs:16:17: 16:18
         _6 = &(_2.1: bool);              // scope 0 at $DIR/match-arm-scopes.rs:16:17: 16:18
         StorageLive(_8);                 // scope 0 at $DIR/match-arm-scopes.rs:16:20: 16:21
@@ -88,20 +84,20 @@ fn complicated_match(_1: bool, _2: (bool, bool, std::string::String)) -> i32 {
         StorageLive(_10);                // scope 0 at $DIR/match-arm-scopes.rs:16:45: 16:49
         _10 = _1;                        // scope 0 at $DIR/match-arm-scopes.rs:16:45: 16:49
         FakeRead(ForMatchedPlace, _10);  // scope 0 at $DIR/match-arm-scopes.rs:16:45: 16:49
-        switchInt(_10) -> [false: bb11, otherwise: bb10]; // scope 0 at $DIR/match-arm-scopes.rs:16:42: 16:73
+        switchInt(_10) -> [false: bb10, otherwise: bb9]; // scope 0 at $DIR/match-arm-scopes.rs:16:42: 16:73
+    }
+
+    bb9: {
+        falseEdges -> [real: bb11, imaginary: bb10]; // scope 0 at $DIR/match-arm-scopes.rs:16:42: 16:73
     }
 
     bb10: {
-        falseEdges -> [real: bb12, imaginary: bb11]; // scope 0 at $DIR/match-arm-scopes.rs:16:42: 16:73
+        _9 = (*_6);                      // scope 0 at $DIR/match-arm-scopes.rs:16:70: 16:71
+        StorageDead(_10);                // scope 0 at $DIR/match-arm-scopes.rs:16:72: 16:73
+        switchInt(move _9) -> [false: bb13, otherwise: bb12]; // scope 0 at $DIR/match-arm-scopes.rs:16:42: 16:73
     }
 
     bb11: {
-        _9 = (*_6);                      // scope 0 at $DIR/match-arm-scopes.rs:16:70: 16:71
-        StorageDead(_10);                // scope 0 at $DIR/match-arm-scopes.rs:16:72: 16:73
-        switchInt(move _9) -> [false: bb17, otherwise: bb16]; // scope 0 at $DIR/match-arm-scopes.rs:16:42: 16:73
-    }
-
-    bb12: {
         _0 = const 3i32;                 // scope 0 at $DIR/match-arm-scopes.rs:16:59: 16:60
                                          // ty::Const
                                          // + ty: i32
@@ -111,24 +107,10 @@ fn complicated_match(_1: bool, _2: (bool, bool, std::string::String)) -> i32 {
                                          // + literal: Const { ty: i32, val: Value(Scalar(0x00000003)) }
         StorageDead(_10);                // scope 0 at $DIR/match-arm-scopes.rs:16:72: 16:73
         StorageDead(_9);                 // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
-        StorageDead(_8);                 // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
-        StorageDead(_6);                 // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
-        goto -> bb15;                    // scope 0 at $DIR/match-arm-scopes.rs:16:52: 16:60
+        goto -> bb25;                    // scope 0 at $DIR/match-arm-scopes.rs:1:1: 1:1
     }
 
-    bb13: {
-        return;                          // scope 0 at $DIR/match-arm-scopes.rs:19:2: 19:2
-    }
-
-    bb14 (cleanup): {
-        drop(_2) -> bb1;                 // scope 0 at $DIR/match-arm-scopes.rs:19:1: 19:2
-    }
-
-    bb15: {
-        drop(_2) -> [return: bb13, unwind: bb1]; // scope 0 at $DIR/match-arm-scopes.rs:19:1: 19:2
-    }
-
-    bb16: {
+    bb12: {
         StorageDead(_9);                 // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
         FakeRead(ForMatchGuard, _3);     // scope 0 at $DIR/match-arm-scopes.rs:16:72: 16:73
         FakeRead(ForMatchGuard, _4);     // scope 0 at $DIR/match-arm-scopes.rs:16:72: 16:73
@@ -138,17 +120,17 @@ fn complicated_match(_1: bool, _2: (bool, bool, std::string::String)) -> i32 {
         _5 = (_2.1: bool);               // scope 0 at $DIR/match-arm-scopes.rs:16:17: 16:18
         StorageLive(_7);                 // scope 0 at $DIR/match-arm-scopes.rs:16:20: 16:21
         _7 = move (_2.2: std::string::String); // scope 0 at $DIR/match-arm-scopes.rs:16:20: 16:21
-        goto -> bb8;                     // scope 0 at $DIR/match-arm-scopes.rs:15:5: 18:6
+        goto -> bb7;                     // scope 0 at $DIR/match-arm-scopes.rs:15:5: 18:6
     }
 
-    bb17: {
+    bb13: {
         StorageDead(_9);                 // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
         StorageDead(_8);                 // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
         StorageDead(_6);                 // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
-        falseEdges -> [real: bb3, imaginary: bb4]; // scope 0 at $DIR/match-arm-scopes.rs:16:42: 16:73
+        falseEdges -> [real: bb2, imaginary: bb3]; // scope 0 at $DIR/match-arm-scopes.rs:16:42: 16:73
     }
 
-    bb18: {
+    bb14: {
         StorageLive(_6);                 // scope 0 at $DIR/match-arm-scopes.rs:16:26: 16:27
         _6 = &(_2.0: bool);              // scope 0 at $DIR/match-arm-scopes.rs:16:26: 16:27
         StorageLive(_8);                 // scope 0 at $DIR/match-arm-scopes.rs:16:36: 16:37
@@ -159,20 +141,20 @@ fn complicated_match(_1: bool, _2: (bool, bool, std::string::String)) -> i32 {
         StorageLive(_13);                // scope 0 at $DIR/match-arm-scopes.rs:16:45: 16:49
         _13 = _1;                        // scope 0 at $DIR/match-arm-scopes.rs:16:45: 16:49
         FakeRead(ForMatchedPlace, _13);  // scope 0 at $DIR/match-arm-scopes.rs:16:45: 16:49
-        switchInt(_13) -> [false: bb20, otherwise: bb19]; // scope 0 at $DIR/match-arm-scopes.rs:16:42: 16:73
+        switchInt(_13) -> [false: bb16, otherwise: bb15]; // scope 0 at $DIR/match-arm-scopes.rs:16:42: 16:73
     }
 
-    bb19: {
-        falseEdges -> [real: bb21, imaginary: bb20]; // scope 0 at $DIR/match-arm-scopes.rs:16:42: 16:73
+    bb15: {
+        falseEdges -> [real: bb17, imaginary: bb16]; // scope 0 at $DIR/match-arm-scopes.rs:16:42: 16:73
     }
 
-    bb20: {
+    bb16: {
         _12 = (*_6);                     // scope 0 at $DIR/match-arm-scopes.rs:16:70: 16:71
         StorageDead(_13);                // scope 0 at $DIR/match-arm-scopes.rs:16:72: 16:73
-        switchInt(move _12) -> [false: bb23, otherwise: bb22]; // scope 0 at $DIR/match-arm-scopes.rs:16:42: 16:73
+        switchInt(move _12) -> [false: bb19, otherwise: bb18]; // scope 0 at $DIR/match-arm-scopes.rs:16:42: 16:73
     }
 
-    bb21: {
+    bb17: {
         _0 = const 3i32;                 // scope 0 at $DIR/match-arm-scopes.rs:16:59: 16:60
                                          // ty::Const
                                          // + ty: i32
@@ -182,12 +164,10 @@ fn complicated_match(_1: bool, _2: (bool, bool, std::string::String)) -> i32 {
                                          // + literal: Const { ty: i32, val: Value(Scalar(0x00000003)) }
         StorageDead(_13);                // scope 0 at $DIR/match-arm-scopes.rs:16:72: 16:73
         StorageDead(_12);                // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
-        StorageDead(_8);                 // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
-        StorageDead(_6);                 // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
-        goto -> bb15;                    // scope 0 at $DIR/match-arm-scopes.rs:16:52: 16:60
+        goto -> bb25;                    // scope 0 at $DIR/match-arm-scopes.rs:1:1: 1:1
     }
 
-    bb22: {
+    bb18: {
         StorageDead(_12);                // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
         FakeRead(ForMatchGuard, _3);     // scope 0 at $DIR/match-arm-scopes.rs:16:72: 16:73
         FakeRead(ForMatchGuard, _4);     // scope 0 at $DIR/match-arm-scopes.rs:16:72: 16:73
@@ -197,25 +177,25 @@ fn complicated_match(_1: bool, _2: (bool, bool, std::string::String)) -> i32 {
         _5 = (_2.0: bool);               // scope 0 at $DIR/match-arm-scopes.rs:16:26: 16:27
         StorageLive(_7);                 // scope 0 at $DIR/match-arm-scopes.rs:16:36: 16:37
         _7 = move (_2.2: std::string::String); // scope 0 at $DIR/match-arm-scopes.rs:16:36: 16:37
-        goto -> bb8;                     // scope 0 at $DIR/match-arm-scopes.rs:15:5: 18:6
+        goto -> bb7;                     // scope 0 at $DIR/match-arm-scopes.rs:15:5: 18:6
     }
 
-    bb23: {
+    bb19: {
         StorageDead(_12);                // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
         StorageDead(_8);                 // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
         StorageDead(_6);                 // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
-        falseEdges -> [real: bb5, imaginary: bb6]; // scope 0 at $DIR/match-arm-scopes.rs:16:42: 16:73
+        falseEdges -> [real: bb4, imaginary: bb5]; // scope 0 at $DIR/match-arm-scopes.rs:16:42: 16:73
     }
 
-    bb24: {
+    bb20: {
         StorageDead(_7);                 // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
         StorageDead(_5);                 // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
         StorageDead(_8);                 // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
         StorageDead(_6);                 // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
-        goto -> bb28;                    // scope 0 at $DIR/match-arm-scopes.rs:15:5: 18:6
+        goto -> bb24;                    // scope 0 at $DIR/match-arm-scopes.rs:15:5: 18:6
     }
 
-    bb25: {
+    bb21: {
         _0 = const 2i32;                 // scope 2 at $DIR/match-arm-scopes.rs:17:41: 17:42
                                          // ty::Const
                                          // + ty: i32
@@ -223,24 +203,42 @@ fn complicated_match(_1: bool, _2: (bool, bool, std::string::String)) -> i32 {
                                          // mir::Constant
                                          // + span: $DIR/match-arm-scopes.rs:17:41: 17:42
                                          // + literal: Const { ty: i32, val: Value(Scalar(0x00000002)) }
-        drop(_16) -> [return: bb27, unwind: bb14]; // scope 0 at $DIR/match-arm-scopes.rs:17:42: 17:43
+        drop(_16) -> [return: bb23, unwind: bb27]; // scope 0 at $DIR/match-arm-scopes.rs:17:42: 17:43
     }
 
-    bb26: {
+    bb22: {
         StorageLive(_15);                // scope 0 at $DIR/match-arm-scopes.rs:17:16: 17:17
         _15 = (_2.1: bool);              // scope 0 at $DIR/match-arm-scopes.rs:17:16: 17:17
         StorageLive(_16);                // scope 0 at $DIR/match-arm-scopes.rs:17:19: 17:20
         _16 = move (_2.2: std::string::String); // scope 0 at $DIR/match-arm-scopes.rs:17:19: 17:20
-        goto -> bb25;                    // scope 0 at $DIR/match-arm-scopes.rs:15:5: 18:6
+        goto -> bb21;                    // scope 0 at $DIR/match-arm-scopes.rs:15:5: 18:6
     }
 
-    bb27: {
+    bb23: {
         StorageDead(_16);                // scope 0 at $DIR/match-arm-scopes.rs:17:42: 17:43
         StorageDead(_15);                // scope 0 at $DIR/match-arm-scopes.rs:17:42: 17:43
-        goto -> bb28;                    // scope 0 at $DIR/match-arm-scopes.rs:15:5: 18:6
+        goto -> bb24;                    // scope 0 at $DIR/match-arm-scopes.rs:15:5: 18:6
     }
 
-    bb28: {
-        drop(_2) -> [return: bb13, unwind: bb1]; // scope 0 at $DIR/match-arm-scopes.rs:19:1: 19:2
+    bb24: {
+        drop(_2) -> [return: bb26, unwind: bb28]; // scope 0 at $DIR/match-arm-scopes.rs:19:1: 19:2
+    }
+
+    bb25: {
+        StorageDead(_8);                 // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
+        StorageDead(_6);                 // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
+        drop(_2) -> [return: bb26, unwind: bb28]; // scope 0 at $DIR/match-arm-scopes.rs:19:1: 19:2
+    }
+
+    bb26: {
+        return;                          // scope 0 at $DIR/match-arm-scopes.rs:19:2: 19:2
+    }
+
+    bb27 (cleanup): {
+        drop(_2) -> bb28;                // scope 0 at $DIR/match-arm-scopes.rs:19:1: 19:2
+    }
+
+    bb28 (cleanup): {
+        resume;                          // scope 0 at $DIR/match-arm-scopes.rs:14:1: 19:2
     }
 }

--- a/src/test/mir-opt/match_false_edges/rustc.full_tested_match.PromoteTemps.after.mir
+++ b/src/test/mir-opt/match_false_edges/rustc.full_tested_match.PromoteTemps.after.mir
@@ -35,14 +35,10 @@ fn full_tested_match() -> () {
                                          // + literal: Const { ty: i32, val: Value(Scalar(0x0000002a)) }
         FakeRead(ForMatchedPlace, _2);   // scope 0 at $DIR/match_false_edges.rs:15:19: 15:27
         _3 = discriminant(_2);           // scope 0 at $DIR/match_false_edges.rs:16:9: 16:16
-        switchInt(move _3) -> [0isize: bb2, 1isize: bb3, otherwise: bb5]; // scope 0 at $DIR/match_false_edges.rs:16:9: 16:16
+        switchInt(move _3) -> [0isize: bb1, 1isize: bb2, otherwise: bb4]; // scope 0 at $DIR/match_false_edges.rs:16:9: 16:16
     }
 
-    bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/match_false_edges.rs:14:1: 20:2
-    }
-
-    bb2: {
+    bb1: {
         _1 = (const 3i32, const 3i32);   // scope 0 at $DIR/match_false_edges.rs:18:17: 18:23
                                          // ty::Const
                                          // + ty: i32
@@ -56,22 +52,22 @@ fn full_tested_match() -> () {
                                          // mir::Constant
                                          // + span: $DIR/match_false_edges.rs:18:21: 18:22
                                          // + literal: Const { ty: i32, val: Value(Scalar(0x00000003)) }
-        goto -> bb11;                    // scope 0 at $DIR/match_false_edges.rs:15:13: 19:6
+        goto -> bb10;                    // scope 0 at $DIR/match_false_edges.rs:15:13: 19:6
+    }
+
+    bb2: {
+        falseEdges -> [real: bb5, imaginary: bb3]; // scope 0 at $DIR/match_false_edges.rs:16:9: 16:16
     }
 
     bb3: {
-        falseEdges -> [real: bb6, imaginary: bb4]; // scope 0 at $DIR/match_false_edges.rs:16:9: 16:16
+        falseEdges -> [real: bb9, imaginary: bb1]; // scope 0 at $DIR/match_false_edges.rs:17:9: 17:16
     }
 
     bb4: {
-        falseEdges -> [real: bb10, imaginary: bb2]; // scope 0 at $DIR/match_false_edges.rs:17:9: 17:16
-    }
-
-    bb5: {
         unreachable;                     // scope 0 at $DIR/match_false_edges.rs:15:19: 15:27
     }
 
-    bb6: {
+    bb5: {
         StorageLive(_6);                 // scope 0 at $DIR/match_false_edges.rs:16:14: 16:15
         _11 = const full_tested_match::promoted[0]; // scope 0 at $DIR/match_false_edges.rs:16:14: 16:15
                                          // ty::Const
@@ -83,7 +79,7 @@ fn full_tested_match() -> () {
         _6 = &(((*_11) as Some).0: i32); // scope 0 at $DIR/match_false_edges.rs:16:14: 16:15
         _4 = &shallow _2;                // scope 0 at $DIR/match_false_edges.rs:15:19: 15:27
         StorageLive(_7);                 // scope 0 at $DIR/match_false_edges.rs:16:20: 16:27
-        _7 = const guard() -> [return: bb7, unwind: bb1]; // scope 0 at $DIR/match_false_edges.rs:16:20: 16:27
+        _7 = const guard() -> [return: bb6, unwind: bb11]; // scope 0 at $DIR/match_false_edges.rs:16:20: 16:27
                                          // ty::Const
                                          // + ty: fn() -> bool {guard}
                                          // + val: Value(Scalar(<ZST>))
@@ -92,11 +88,11 @@ fn full_tested_match() -> () {
                                          // + literal: Const { ty: fn() -> bool {guard}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb7: {
-        switchInt(move _7) -> [false: bb9, otherwise: bb8]; // scope 0 at $DIR/match_false_edges.rs:16:20: 16:27
+    bb6: {
+        switchInt(move _7) -> [false: bb8, otherwise: bb7]; // scope 0 at $DIR/match_false_edges.rs:16:20: 16:27
     }
 
-    bb8: {
+    bb7: {
         StorageDead(_7);                 // scope 0 at $DIR/match_false_edges.rs:16:37: 16:38
         FakeRead(ForMatchGuard, _4);     // scope 0 at $DIR/match_false_edges.rs:16:26: 16:27
         FakeRead(ForGuardBinding, _6);   // scope 0 at $DIR/match_false_edges.rs:16:26: 16:27
@@ -114,16 +110,16 @@ fn full_tested_match() -> () {
         StorageDead(_8);                 // scope 2 at $DIR/match_false_edges.rs:16:36: 16:37
         StorageDead(_5);                 // scope 0 at $DIR/match_false_edges.rs:16:37: 16:38
         StorageDead(_6);                 // scope 0 at $DIR/match_false_edges.rs:16:37: 16:38
-        goto -> bb11;                    // scope 0 at $DIR/match_false_edges.rs:15:13: 19:6
+        goto -> bb10;                    // scope 0 at $DIR/match_false_edges.rs:15:13: 19:6
+    }
+
+    bb8: {
+        StorageDead(_7);                 // scope 0 at $DIR/match_false_edges.rs:16:37: 16:38
+        StorageDead(_6);                 // scope 0 at $DIR/match_false_edges.rs:16:37: 16:38
+        goto -> bb3;                     // scope 0 at $DIR/match_false_edges.rs:16:20: 16:27
     }
 
     bb9: {
-        StorageDead(_7);                 // scope 0 at $DIR/match_false_edges.rs:16:37: 16:38
-        StorageDead(_6);                 // scope 0 at $DIR/match_false_edges.rs:16:37: 16:38
-        goto -> bb4;                     // scope 0 at $DIR/match_false_edges.rs:16:20: 16:27
-    }
-
-    bb10: {
         StorageLive(_9);                 // scope 0 at $DIR/match_false_edges.rs:17:14: 17:15
         _9 = ((_2 as Some).0: i32);      // scope 0 at $DIR/match_false_edges.rs:17:14: 17:15
         StorageLive(_10);                // scope 3 at $DIR/match_false_edges.rs:17:24: 17:25
@@ -137,10 +133,10 @@ fn full_tested_match() -> () {
                                          // + literal: Const { ty: i32, val: Value(Scalar(0x00000002)) }
         StorageDead(_10);                // scope 3 at $DIR/match_false_edges.rs:17:25: 17:26
         StorageDead(_9);                 // scope 0 at $DIR/match_false_edges.rs:17:26: 17:27
-        goto -> bb11;                    // scope 0 at $DIR/match_false_edges.rs:15:13: 19:6
+        goto -> bb10;                    // scope 0 at $DIR/match_false_edges.rs:15:13: 19:6
     }
 
-    bb11: {
+    bb10: {
         StorageDead(_2);                 // scope 0 at $DIR/match_false_edges.rs:19:6: 19:7
         StorageDead(_1);                 // scope 0 at $DIR/match_false_edges.rs:19:6: 19:7
         _0 = const ();                   // scope 0 at $DIR/match_false_edges.rs:14:28: 20:2
@@ -151,5 +147,9 @@ fn full_tested_match() -> () {
                                          // + span: $DIR/match_false_edges.rs:14:28: 20:2
                                          // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
         return;                          // scope 0 at $DIR/match_false_edges.rs:20:2: 20:2
+    }
+
+    bb11 (cleanup): {
+        resume;                          // scope 0 at $DIR/match_false_edges.rs:14:1: 20:2
     }
 }

--- a/src/test/mir-opt/match_false_edges/rustc.full_tested_match2.PromoteTemps.before.mir
+++ b/src/test/mir-opt/match_false_edges/rustc.full_tested_match2.PromoteTemps.before.mir
@@ -34,22 +34,18 @@ fn full_tested_match2() -> () {
                                          // + literal: Const { ty: i32, val: Value(Scalar(0x0000002a)) }
         FakeRead(ForMatchedPlace, _2);   // scope 0 at $DIR/match_false_edges.rs:26:19: 26:27
         _3 = discriminant(_2);           // scope 0 at $DIR/match_false_edges.rs:27:9: 27:16
-        switchInt(move _3) -> [0isize: bb2, 1isize: bb3, otherwise: bb5]; // scope 0 at $DIR/match_false_edges.rs:27:9: 27:16
+        switchInt(move _3) -> [0isize: bb1, 1isize: bb2, otherwise: bb4]; // scope 0 at $DIR/match_false_edges.rs:27:9: 27:16
     }
 
-    bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/match_false_edges.rs:25:1: 31:2
+    bb1: {
+        falseEdges -> [real: bb9, imaginary: bb3]; // scope 0 at $DIR/match_false_edges.rs:28:9: 28:13
     }
 
     bb2: {
-        falseEdges -> [real: bb10, imaginary: bb4]; // scope 0 at $DIR/match_false_edges.rs:28:9: 28:13
+        falseEdges -> [real: bb5, imaginary: bb1]; // scope 0 at $DIR/match_false_edges.rs:27:9: 27:16
     }
 
     bb3: {
-        falseEdges -> [real: bb6, imaginary: bb2]; // scope 0 at $DIR/match_false_edges.rs:27:9: 27:16
-    }
-
-    bb4: {
         StorageLive(_9);                 // scope 0 at $DIR/match_false_edges.rs:29:14: 29:15
         _9 = ((_2 as Some).0: i32);      // scope 0 at $DIR/match_false_edges.rs:29:14: 29:15
         StorageLive(_10);                // scope 3 at $DIR/match_false_edges.rs:29:24: 29:25
@@ -63,19 +59,19 @@ fn full_tested_match2() -> () {
                                          // + literal: Const { ty: i32, val: Value(Scalar(0x00000002)) }
         StorageDead(_10);                // scope 3 at $DIR/match_false_edges.rs:29:25: 29:26
         StorageDead(_9);                 // scope 0 at $DIR/match_false_edges.rs:29:26: 29:27
-        goto -> bb11;                    // scope 0 at $DIR/match_false_edges.rs:26:13: 30:6
+        goto -> bb10;                    // scope 0 at $DIR/match_false_edges.rs:26:13: 30:6
     }
 
-    bb5: {
+    bb4: {
         unreachable;                     // scope 0 at $DIR/match_false_edges.rs:26:19: 26:27
     }
 
-    bb6: {
+    bb5: {
         StorageLive(_6);                 // scope 0 at $DIR/match_false_edges.rs:27:14: 27:15
         _6 = &((_2 as Some).0: i32);     // scope 0 at $DIR/match_false_edges.rs:27:14: 27:15
         _4 = &shallow _2;                // scope 0 at $DIR/match_false_edges.rs:26:19: 26:27
         StorageLive(_7);                 // scope 0 at $DIR/match_false_edges.rs:27:20: 27:27
-        _7 = const guard() -> [return: bb7, unwind: bb1]; // scope 0 at $DIR/match_false_edges.rs:27:20: 27:27
+        _7 = const guard() -> [return: bb6, unwind: bb11]; // scope 0 at $DIR/match_false_edges.rs:27:20: 27:27
                                          // ty::Const
                                          // + ty: fn() -> bool {guard}
                                          // + val: Value(Scalar(<ZST>))
@@ -84,11 +80,11 @@ fn full_tested_match2() -> () {
                                          // + literal: Const { ty: fn() -> bool {guard}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb7: {
-        switchInt(move _7) -> [false: bb9, otherwise: bb8]; // scope 0 at $DIR/match_false_edges.rs:27:20: 27:27
+    bb6: {
+        switchInt(move _7) -> [false: bb8, otherwise: bb7]; // scope 0 at $DIR/match_false_edges.rs:27:20: 27:27
     }
 
-    bb8: {
+    bb7: {
         StorageDead(_7);                 // scope 0 at $DIR/match_false_edges.rs:27:37: 27:38
         FakeRead(ForMatchGuard, _4);     // scope 0 at $DIR/match_false_edges.rs:27:26: 27:27
         FakeRead(ForGuardBinding, _6);   // scope 0 at $DIR/match_false_edges.rs:27:26: 27:27
@@ -106,16 +102,16 @@ fn full_tested_match2() -> () {
         StorageDead(_8);                 // scope 2 at $DIR/match_false_edges.rs:27:36: 27:37
         StorageDead(_5);                 // scope 0 at $DIR/match_false_edges.rs:27:37: 27:38
         StorageDead(_6);                 // scope 0 at $DIR/match_false_edges.rs:27:37: 27:38
-        goto -> bb11;                    // scope 0 at $DIR/match_false_edges.rs:26:13: 30:6
+        goto -> bb10;                    // scope 0 at $DIR/match_false_edges.rs:26:13: 30:6
+    }
+
+    bb8: {
+        StorageDead(_7);                 // scope 0 at $DIR/match_false_edges.rs:27:37: 27:38
+        StorageDead(_6);                 // scope 0 at $DIR/match_false_edges.rs:27:37: 27:38
+        falseEdges -> [real: bb3, imaginary: bb1]; // scope 0 at $DIR/match_false_edges.rs:27:20: 27:27
     }
 
     bb9: {
-        StorageDead(_7);                 // scope 0 at $DIR/match_false_edges.rs:27:37: 27:38
-        StorageDead(_6);                 // scope 0 at $DIR/match_false_edges.rs:27:37: 27:38
-        falseEdges -> [real: bb4, imaginary: bb2]; // scope 0 at $DIR/match_false_edges.rs:27:20: 27:27
-    }
-
-    bb10: {
         _1 = (const 3i32, const 3i32);   // scope 0 at $DIR/match_false_edges.rs:28:17: 28:23
                                          // ty::Const
                                          // + ty: i32
@@ -129,10 +125,10 @@ fn full_tested_match2() -> () {
                                          // mir::Constant
                                          // + span: $DIR/match_false_edges.rs:28:21: 28:22
                                          // + literal: Const { ty: i32, val: Value(Scalar(0x00000003)) }
-        goto -> bb11;                    // scope 0 at $DIR/match_false_edges.rs:26:13: 30:6
+        goto -> bb10;                    // scope 0 at $DIR/match_false_edges.rs:26:13: 30:6
     }
 
-    bb11: {
+    bb10: {
         StorageDead(_2);                 // scope 0 at $DIR/match_false_edges.rs:30:6: 30:7
         StorageDead(_1);                 // scope 0 at $DIR/match_false_edges.rs:30:6: 30:7
         _0 = const ();                   // scope 0 at $DIR/match_false_edges.rs:25:29: 31:2
@@ -143,5 +139,9 @@ fn full_tested_match2() -> () {
                                          // + span: $DIR/match_false_edges.rs:25:29: 31:2
                                          // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
         return;                          // scope 0 at $DIR/match_false_edges.rs:31:2: 31:2
+    }
+
+    bb11 (cleanup): {
+        resume;                          // scope 0 at $DIR/match_false_edges.rs:25:1: 31:2
     }
 }

--- a/src/test/mir-opt/match_false_edges/rustc.main.PromoteTemps.before.mir
+++ b/src/test/mir-opt/match_false_edges/rustc.main.PromoteTemps.before.mir
@@ -45,22 +45,18 @@ fn main() -> () {
                                          // + literal: Const { ty: i32, val: Value(Scalar(0x00000001)) }
         FakeRead(ForMatchedPlace, _2);   // scope 0 at $DIR/match_false_edges.rs:35:19: 35:26
         _4 = discriminant(_2);           // scope 0 at $DIR/match_false_edges.rs:36:9: 36:17
-        switchInt(move _4) -> [1isize: bb3, otherwise: bb2]; // scope 0 at $DIR/match_false_edges.rs:36:9: 36:17
+        switchInt(move _4) -> [1isize: bb2, otherwise: bb1]; // scope 0 at $DIR/match_false_edges.rs:36:9: 36:17
     }
 
-    bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/match_false_edges.rs:34:1: 41:2
+    bb1: {
+        falseEdges -> [real: bb9, imaginary: bb4]; // scope 0 at $DIR/match_false_edges.rs:37:9: 37:11
     }
 
     bb2: {
-        falseEdges -> [real: bb10, imaginary: bb5]; // scope 0 at $DIR/match_false_edges.rs:37:9: 37:11
+        falseEdges -> [real: bb5, imaginary: bb1]; // scope 0 at $DIR/match_false_edges.rs:36:9: 36:17
     }
 
     bb3: {
-        falseEdges -> [real: bb6, imaginary: bb2]; // scope 0 at $DIR/match_false_edges.rs:36:9: 36:17
-    }
-
-    bb4: {
         StorageLive(_14);                // scope 0 at $DIR/match_false_edges.rs:39:9: 39:11
         _14 = _2;                        // scope 0 at $DIR/match_false_edges.rs:39:9: 39:11
         _1 = const 4i32;                 // scope 5 at $DIR/match_false_edges.rs:39:15: 39:16
@@ -71,19 +67,19 @@ fn main() -> () {
                                          // + span: $DIR/match_false_edges.rs:39:15: 39:16
                                          // + literal: Const { ty: i32, val: Value(Scalar(0x00000004)) }
         StorageDead(_14);                // scope 0 at $DIR/match_false_edges.rs:39:16: 39:17
-        goto -> bb15;                    // scope 0 at $DIR/match_false_edges.rs:35:13: 40:6
+        goto -> bb14;                    // scope 0 at $DIR/match_false_edges.rs:35:13: 40:6
+    }
+
+    bb4: {
+        falseEdges -> [real: bb10, imaginary: bb3]; // scope 0 at $DIR/match_false_edges.rs:38:9: 38:16
     }
 
     bb5: {
-        falseEdges -> [real: bb11, imaginary: bb4]; // scope 0 at $DIR/match_false_edges.rs:38:9: 38:16
-    }
-
-    bb6: {
         StorageLive(_7);                 // scope 0 at $DIR/match_false_edges.rs:36:14: 36:16
         _7 = &((_2 as Some).0: i32);     // scope 0 at $DIR/match_false_edges.rs:36:14: 36:16
         _5 = &shallow _2;                // scope 0 at $DIR/match_false_edges.rs:35:19: 35:26
         StorageLive(_8);                 // scope 0 at $DIR/match_false_edges.rs:36:21: 36:28
-        _8 = const guard() -> [return: bb7, unwind: bb1]; // scope 0 at $DIR/match_false_edges.rs:36:21: 36:28
+        _8 = const guard() -> [return: bb6, unwind: bb15]; // scope 0 at $DIR/match_false_edges.rs:36:21: 36:28
                                          // ty::Const
                                          // + ty: fn() -> bool {guard}
                                          // + val: Value(Scalar(<ZST>))
@@ -92,11 +88,11 @@ fn main() -> () {
                                          // + literal: Const { ty: fn() -> bool {guard}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb7: {
-        switchInt(move _8) -> [false: bb9, otherwise: bb8]; // scope 0 at $DIR/match_false_edges.rs:36:21: 36:28
+    bb6: {
+        switchInt(move _8) -> [false: bb8, otherwise: bb7]; // scope 0 at $DIR/match_false_edges.rs:36:21: 36:28
     }
 
-    bb8: {
+    bb7: {
         StorageDead(_8);                 // scope 0 at $DIR/match_false_edges.rs:36:33: 36:34
         FakeRead(ForMatchGuard, _5);     // scope 0 at $DIR/match_false_edges.rs:36:27: 36:28
         FakeRead(ForGuardBinding, _7);   // scope 0 at $DIR/match_false_edges.rs:36:27: 36:28
@@ -111,16 +107,16 @@ fn main() -> () {
                                          // + literal: Const { ty: i32, val: Value(Scalar(0x00000001)) }
         StorageDead(_6);                 // scope 0 at $DIR/match_false_edges.rs:36:33: 36:34
         StorageDead(_7);                 // scope 0 at $DIR/match_false_edges.rs:36:33: 36:34
-        goto -> bb15;                    // scope 0 at $DIR/match_false_edges.rs:35:13: 40:6
+        goto -> bb14;                    // scope 0 at $DIR/match_false_edges.rs:35:13: 40:6
+    }
+
+    bb8: {
+        StorageDead(_8);                 // scope 0 at $DIR/match_false_edges.rs:36:33: 36:34
+        StorageDead(_7);                 // scope 0 at $DIR/match_false_edges.rs:36:33: 36:34
+        falseEdges -> [real: bb1, imaginary: bb1]; // scope 0 at $DIR/match_false_edges.rs:36:21: 36:28
     }
 
     bb9: {
-        StorageDead(_8);                 // scope 0 at $DIR/match_false_edges.rs:36:33: 36:34
-        StorageDead(_7);                 // scope 0 at $DIR/match_false_edges.rs:36:33: 36:34
-        falseEdges -> [real: bb2, imaginary: bb2]; // scope 0 at $DIR/match_false_edges.rs:36:21: 36:28
-    }
-
-    bb10: {
         StorageLive(_9);                 // scope 0 at $DIR/match_false_edges.rs:37:9: 37:11
         _9 = _2;                         // scope 0 at $DIR/match_false_edges.rs:37:9: 37:11
         _1 = const 2i32;                 // scope 3 at $DIR/match_false_edges.rs:37:15: 37:16
@@ -131,17 +127,17 @@ fn main() -> () {
                                          // + span: $DIR/match_false_edges.rs:37:15: 37:16
                                          // + literal: Const { ty: i32, val: Value(Scalar(0x00000002)) }
         StorageDead(_9);                 // scope 0 at $DIR/match_false_edges.rs:37:16: 37:17
-        goto -> bb15;                    // scope 0 at $DIR/match_false_edges.rs:35:13: 40:6
+        goto -> bb14;                    // scope 0 at $DIR/match_false_edges.rs:35:13: 40:6
     }
 
-    bb11: {
+    bb10: {
         StorageLive(_11);                // scope 0 at $DIR/match_false_edges.rs:38:14: 38:15
         _11 = &((_2 as Some).0: i32);    // scope 0 at $DIR/match_false_edges.rs:38:14: 38:15
         _5 = &shallow _2;                // scope 0 at $DIR/match_false_edges.rs:35:19: 35:26
         StorageLive(_12);                // scope 0 at $DIR/match_false_edges.rs:38:20: 38:29
         StorageLive(_13);                // scope 0 at $DIR/match_false_edges.rs:38:27: 38:28
         _13 = (*_11);                    // scope 0 at $DIR/match_false_edges.rs:38:27: 38:28
-        _12 = const guard2(move _13) -> [return: bb12, unwind: bb1]; // scope 0 at $DIR/match_false_edges.rs:38:20: 38:29
+        _12 = const guard2(move _13) -> [return: bb11, unwind: bb15]; // scope 0 at $DIR/match_false_edges.rs:38:20: 38:29
                                          // ty::Const
                                          // + ty: fn(i32) -> bool {guard2}
                                          // + val: Value(Scalar(<ZST>))
@@ -150,12 +146,12 @@ fn main() -> () {
                                          // + literal: Const { ty: fn(i32) -> bool {guard2}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb12: {
+    bb11: {
         StorageDead(_13);                // scope 0 at $DIR/match_false_edges.rs:38:28: 38:29
-        switchInt(move _12) -> [false: bb14, otherwise: bb13]; // scope 0 at $DIR/match_false_edges.rs:38:20: 38:29
+        switchInt(move _12) -> [false: bb13, otherwise: bb12]; // scope 0 at $DIR/match_false_edges.rs:38:20: 38:29
     }
 
-    bb13: {
+    bb12: {
         StorageDead(_12);                // scope 0 at $DIR/match_false_edges.rs:38:34: 38:35
         FakeRead(ForMatchGuard, _5);     // scope 0 at $DIR/match_false_edges.rs:38:28: 38:29
         FakeRead(ForGuardBinding, _11);  // scope 0 at $DIR/match_false_edges.rs:38:28: 38:29
@@ -170,16 +166,16 @@ fn main() -> () {
                                          // + literal: Const { ty: i32, val: Value(Scalar(0x00000003)) }
         StorageDead(_10);                // scope 0 at $DIR/match_false_edges.rs:38:34: 38:35
         StorageDead(_11);                // scope 0 at $DIR/match_false_edges.rs:38:34: 38:35
-        goto -> bb15;                    // scope 0 at $DIR/match_false_edges.rs:35:13: 40:6
+        goto -> bb14;                    // scope 0 at $DIR/match_false_edges.rs:35:13: 40:6
+    }
+
+    bb13: {
+        StorageDead(_12);                // scope 0 at $DIR/match_false_edges.rs:38:34: 38:35
+        StorageDead(_11);                // scope 0 at $DIR/match_false_edges.rs:38:34: 38:35
+        falseEdges -> [real: bb3, imaginary: bb3]; // scope 0 at $DIR/match_false_edges.rs:38:20: 38:29
     }
 
     bb14: {
-        StorageDead(_12);                // scope 0 at $DIR/match_false_edges.rs:38:34: 38:35
-        StorageDead(_11);                // scope 0 at $DIR/match_false_edges.rs:38:34: 38:35
-        falseEdges -> [real: bb4, imaginary: bb4]; // scope 0 at $DIR/match_false_edges.rs:38:20: 38:29
-    }
-
-    bb15: {
         StorageDead(_2);                 // scope 0 at $DIR/match_false_edges.rs:40:6: 40:7
         StorageDead(_1);                 // scope 0 at $DIR/match_false_edges.rs:40:6: 40:7
         _0 = const ();                   // scope 0 at $DIR/match_false_edges.rs:34:11: 41:2
@@ -190,5 +186,9 @@ fn main() -> () {
                                          // + span: $DIR/match_false_edges.rs:34:11: 41:2
                                          // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
         return;                          // scope 0 at $DIR/match_false_edges.rs:41:2: 41:2
+    }
+
+    bb15 (cleanup): {
+        resume;                          // scope 0 at $DIR/match_false_edges.rs:34:1: 41:2
     }
 }

--- a/src/test/mir-opt/nll/region-subtyping-basic/32bit/rustc.main.nll.0.mir
+++ b/src/test/mir-opt/nll/region-subtyping-basic/32bit/rustc.main.nll.0.mir
@@ -5,21 +5,21 @@
 | '_#1r | Local | ['_#1r]
 |
 | Inferred Region Values
-| '_#0r | U0 | {bb0[0..=8], bb1[0], bb2[0..=8], bb3[0], bb4[0..=1], bb5[0..=3], bb6[0..=3], bb7[0..=2], bb8[0..=5], '_#0r, '_#1r}
-| '_#1r | U0 | {bb0[0..=8], bb1[0], bb2[0..=8], bb3[0], bb4[0..=1], bb5[0..=3], bb6[0..=3], bb7[0..=2], bb8[0..=5], '_#1r}
+| '_#0r | U0 | {bb0[0..=8], bb1[0..=8], bb2[0], bb3[0..=1], bb4[0..=3], bb5[0..=3], bb6[0..=2], bb7[0..=5], bb8[0], '_#0r, '_#1r}
+| '_#1r | U0 | {bb0[0..=8], bb1[0..=8], bb2[0], bb3[0..=1], bb4[0..=3], bb5[0..=3], bb6[0..=2], bb7[0..=5], bb8[0], '_#1r}
 | '_#2r | U0 | {}
-| '_#3r | U0 | {bb2[0..=8], bb3[0], bb5[0..=2]}
-| '_#4r | U0 | {bb2[1..=8], bb3[0], bb5[0..=2]}
-| '_#5r | U0 | {bb2[4..=8], bb3[0], bb5[0..=2]}
+| '_#3r | U0 | {bb1[0..=8], bb2[0], bb4[0..=2]}
+| '_#4r | U0 | {bb1[1..=8], bb2[0], bb4[0..=2]}
+| '_#5r | U0 | {bb1[4..=8], bb2[0], bb4[0..=2]}
 |
 | Inference Constraints
-| '_#0r live at {bb0[0..=8], bb1[0], bb2[0..=8], bb3[0], bb4[0..=1], bb5[0..=3], bb6[0..=3], bb7[0..=2], bb8[0..=5]}
-| '_#1r live at {bb0[0..=8], bb1[0], bb2[0..=8], bb3[0], bb4[0..=1], bb5[0..=3], bb6[0..=3], bb7[0..=2], bb8[0..=5]}
-| '_#3r live at {bb2[0]}
-| '_#4r live at {bb2[1..=3]}
-| '_#5r live at {bb2[4..=8], bb3[0], bb5[0..=2]}
-| '_#3r: '_#4r due to Assignment at Single(bb2[0])
-| '_#4r: '_#5r due to Assignment at Single(bb2[3])
+| '_#0r live at {bb0[0..=8], bb1[0..=8], bb2[0], bb3[0..=1], bb4[0..=3], bb5[0..=3], bb6[0..=2], bb7[0..=5], bb8[0]}
+| '_#1r live at {bb0[0..=8], bb1[0..=8], bb2[0], bb3[0..=1], bb4[0..=3], bb5[0..=3], bb6[0..=2], bb7[0..=5], bb8[0]}
+| '_#3r live at {bb1[0]}
+| '_#4r live at {bb1[1..=3]}
+| '_#5r live at {bb1[4..=8], bb2[0], bb4[0..=2]}
+| '_#3r: '_#4r due to Assignment at Single(bb1[0])
+| '_#4r: '_#5r due to Assignment at Single(bb1[3])
 |
 fn main() -> () {
     let mut _0: ();                      // return place in scope 0 at $DIR/region-subtyping-basic.rs:16:11: 16:11
@@ -76,38 +76,34 @@ fn main() -> () {
                                          // + literal: Const { ty: usize, val: Value(Scalar(0x00000000)) }
         _4 = Len(_1);                    // bb0[6]: scope 1 at $DIR/region-subtyping-basic.rs:18:14: 18:18
         _5 = Lt(_3, _4);                 // bb0[7]: scope 1 at $DIR/region-subtyping-basic.rs:18:14: 18:18
-        assert(move _5, "index out of bounds: the len is {} but the index is {}", move _4, _3) -> [success: bb2, unwind: bb1]; // bb0[8]: scope 1 at $DIR/region-subtyping-basic.rs:18:14: 18:18
+        assert(move _5, "index out of bounds: the len is {} but the index is {}", move _4, _3) -> [success: bb1, unwind: bb8]; // bb0[8]: scope 1 at $DIR/region-subtyping-basic.rs:18:14: 18:18
     }
 
-    bb1 (cleanup): {
-        resume;                          // bb1[0]: scope 0 at $DIR/region-subtyping-basic.rs:16:1: 25:2
-    }
-
-    bb2: {
-        _2 = &'_#3r _1[_3];              // bb2[0]: scope 1 at $DIR/region-subtyping-basic.rs:18:13: 18:18
-        FakeRead(ForLet, _2);            // bb2[1]: scope 1 at $DIR/region-subtyping-basic.rs:18:9: 18:10
-        StorageLive(_6);                 // bb2[2]: scope 2 at $DIR/region-subtyping-basic.rs:19:9: 19:10
-        _6 = _2;                         // bb2[3]: scope 2 at $DIR/region-subtyping-basic.rs:19:13: 19:14
-        FakeRead(ForLet, _6);            // bb2[4]: scope 2 at $DIR/region-subtyping-basic.rs:19:9: 19:10
-        StorageLive(_7);                 // bb2[5]: scope 3 at $DIR/region-subtyping-basic.rs:20:8: 20:12
-        _7 = const Const(Value(Scalar(0x01)): bool); // bb2[6]: scope 3 at $DIR/region-subtyping-basic.rs:20:8: 20:12
+    bb1: {
+        _2 = &'_#3r _1[_3];              // bb1[0]: scope 1 at $DIR/region-subtyping-basic.rs:18:13: 18:18
+        FakeRead(ForLet, _2);            // bb1[1]: scope 1 at $DIR/region-subtyping-basic.rs:18:9: 18:10
+        StorageLive(_6);                 // bb1[2]: scope 2 at $DIR/region-subtyping-basic.rs:19:9: 19:10
+        _6 = _2;                         // bb1[3]: scope 2 at $DIR/region-subtyping-basic.rs:19:13: 19:14
+        FakeRead(ForLet, _6);            // bb1[4]: scope 2 at $DIR/region-subtyping-basic.rs:19:9: 19:10
+        StorageLive(_7);                 // bb1[5]: scope 3 at $DIR/region-subtyping-basic.rs:20:8: 20:12
+        _7 = const Const(Value(Scalar(0x01)): bool); // bb1[6]: scope 3 at $DIR/region-subtyping-basic.rs:20:8: 20:12
                                          // ty::Const
                                          // + ty: bool
                                          // + val: Value(Scalar(0x01))
                                          // mir::Constant
                                          // + span: $DIR/region-subtyping-basic.rs:20:8: 20:12
                                          // + literal: Const { ty: bool, val: Value(Scalar(0x01)) }
-        FakeRead(ForMatchedPlace, _7);   // bb2[7]: scope 3 at $DIR/region-subtyping-basic.rs:20:8: 20:12
-        switchInt(_7) -> [Const(Value(Scalar(0x00)): bool): bb4, otherwise: bb3]; // bb2[8]: scope 3 at $DIR/region-subtyping-basic.rs:20:5: 24:6
+        FakeRead(ForMatchedPlace, _7);   // bb1[7]: scope 3 at $DIR/region-subtyping-basic.rs:20:8: 20:12
+        switchInt(_7) -> [Const(Value(Scalar(0x00)): bool): bb3, otherwise: bb2]; // bb1[8]: scope 3 at $DIR/region-subtyping-basic.rs:20:5: 24:6
+    }
+
+    bb2: {
+        falseEdges -> [real: bb4, imaginary: bb3]; // bb2[0]: scope 3 at $DIR/region-subtyping-basic.rs:20:5: 24:6
     }
 
     bb3: {
-        falseEdges -> [real: bb5, imaginary: bb4]; // bb3[0]: scope 3 at $DIR/region-subtyping-basic.rs:20:5: 24:6
-    }
-
-    bb4: {
-        StorageLive(_10);                // bb4[0]: scope 3 at $DIR/region-subtyping-basic.rs:23:9: 23:18
-        _10 = const Const(Value(Scalar(<ZST>)): fn(usize) -> bool {use_x})(const Const(Value(Scalar(0x00000016)): usize)) -> [return: bb7, unwind: bb1]; // bb4[1]: scope 3 at $DIR/region-subtyping-basic.rs:23:9: 23:18
+        StorageLive(_10);                // bb3[0]: scope 3 at $DIR/region-subtyping-basic.rs:23:9: 23:18
+        _10 = const Const(Value(Scalar(<ZST>)): fn(usize) -> bool {use_x})(const Const(Value(Scalar(0x00000016)): usize)) -> [return: bb6, unwind: bb8]; // bb3[1]: scope 3 at $DIR/region-subtyping-basic.rs:23:9: 23:18
                                          // ty::Const
                                          // + ty: fn(usize) -> bool {use_x}
                                          // + val: Value(Scalar(<ZST>))
@@ -122,11 +118,11 @@ fn main() -> () {
                                          // + literal: Const { ty: usize, val: Value(Scalar(0x00000016)) }
     }
 
-    bb5: {
-        StorageLive(_8);                 // bb5[0]: scope 3 at $DIR/region-subtyping-basic.rs:21:9: 21:18
-        StorageLive(_9);                 // bb5[1]: scope 3 at $DIR/region-subtyping-basic.rs:21:15: 21:17
-        _9 = (*_6);                      // bb5[2]: scope 3 at $DIR/region-subtyping-basic.rs:21:15: 21:17
-        _8 = const Const(Value(Scalar(<ZST>)): fn(usize) -> bool {use_x})(move _9) -> [return: bb6, unwind: bb1]; // bb5[3]: scope 3 at $DIR/region-subtyping-basic.rs:21:9: 21:18
+    bb4: {
+        StorageLive(_8);                 // bb4[0]: scope 3 at $DIR/region-subtyping-basic.rs:21:9: 21:18
+        StorageLive(_9);                 // bb4[1]: scope 3 at $DIR/region-subtyping-basic.rs:21:15: 21:17
+        _9 = (*_6);                      // bb4[2]: scope 3 at $DIR/region-subtyping-basic.rs:21:15: 21:17
+        _8 = const Const(Value(Scalar(<ZST>)): fn(usize) -> bool {use_x})(move _9) -> [return: bb5, unwind: bb8]; // bb4[3]: scope 3 at $DIR/region-subtyping-basic.rs:21:9: 21:18
                                          // ty::Const
                                          // + ty: fn(usize) -> bool {use_x}
                                          // + val: Value(Scalar(<ZST>))
@@ -135,37 +131,41 @@ fn main() -> () {
                                          // + literal: Const { ty: fn(usize) -> bool {use_x}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb6: {
-        StorageDead(_9);                 // bb6[0]: scope 3 at $DIR/region-subtyping-basic.rs:21:17: 21:18
-        StorageDead(_8);                 // bb6[1]: scope 3 at $DIR/region-subtyping-basic.rs:21:18: 21:19
-        _0 = const Const(Value(Scalar(<ZST>)): ()); // bb6[2]: scope 3 at $DIR/region-subtyping-basic.rs:20:13: 22:6
+    bb5: {
+        StorageDead(_9);                 // bb5[0]: scope 3 at $DIR/region-subtyping-basic.rs:21:17: 21:18
+        StorageDead(_8);                 // bb5[1]: scope 3 at $DIR/region-subtyping-basic.rs:21:18: 21:19
+        _0 = const Const(Value(Scalar(<ZST>)): ()); // bb5[2]: scope 3 at $DIR/region-subtyping-basic.rs:20:13: 22:6
                                          // ty::Const
                                          // + ty: ()
                                          // + val: Value(Scalar(<ZST>))
                                          // mir::Constant
                                          // + span: $DIR/region-subtyping-basic.rs:20:13: 22:6
                                          // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
-        goto -> bb8;                     // bb6[3]: scope 3 at $DIR/region-subtyping-basic.rs:20:5: 24:6
+        goto -> bb7;                     // bb5[3]: scope 3 at $DIR/region-subtyping-basic.rs:20:5: 24:6
     }
 
-    bb7: {
-        StorageDead(_10);                // bb7[0]: scope 3 at $DIR/region-subtyping-basic.rs:23:18: 23:19
-        _0 = const Const(Value(Scalar(<ZST>)): ()); // bb7[1]: scope 3 at $DIR/region-subtyping-basic.rs:22:12: 24:6
+    bb6: {
+        StorageDead(_10);                // bb6[0]: scope 3 at $DIR/region-subtyping-basic.rs:23:18: 23:19
+        _0 = const Const(Value(Scalar(<ZST>)): ()); // bb6[1]: scope 3 at $DIR/region-subtyping-basic.rs:22:12: 24:6
                                          // ty::Const
                                          // + ty: ()
                                          // + val: Value(Scalar(<ZST>))
                                          // mir::Constant
                                          // + span: $DIR/region-subtyping-basic.rs:22:12: 24:6
                                          // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
-        goto -> bb8;                     // bb7[2]: scope 3 at $DIR/region-subtyping-basic.rs:20:5: 24:6
+        goto -> bb7;                     // bb6[2]: scope 3 at $DIR/region-subtyping-basic.rs:20:5: 24:6
     }
 
-    bb8: {
-        StorageDead(_6);                 // bb8[0]: scope 2 at $DIR/region-subtyping-basic.rs:25:1: 25:2
-        StorageDead(_3);                 // bb8[1]: scope 1 at $DIR/region-subtyping-basic.rs:25:1: 25:2
-        StorageDead(_2);                 // bb8[2]: scope 1 at $DIR/region-subtyping-basic.rs:25:1: 25:2
-        StorageDead(_1);                 // bb8[3]: scope 0 at $DIR/region-subtyping-basic.rs:25:1: 25:2
-        StorageDead(_7);                 // bb8[4]: scope 0 at $DIR/region-subtyping-basic.rs:25:1: 25:2
-        return;                          // bb8[5]: scope 0 at $DIR/region-subtyping-basic.rs:25:2: 25:2
+    bb7: {
+        StorageDead(_6);                 // bb7[0]: scope 2 at $DIR/region-subtyping-basic.rs:25:1: 25:2
+        StorageDead(_3);                 // bb7[1]: scope 1 at $DIR/region-subtyping-basic.rs:25:1: 25:2
+        StorageDead(_2);                 // bb7[2]: scope 1 at $DIR/region-subtyping-basic.rs:25:1: 25:2
+        StorageDead(_1);                 // bb7[3]: scope 0 at $DIR/region-subtyping-basic.rs:25:1: 25:2
+        StorageDead(_7);                 // bb7[4]: scope 0 at $DIR/region-subtyping-basic.rs:25:1: 25:2
+        return;                          // bb7[5]: scope 0 at $DIR/region-subtyping-basic.rs:25:2: 25:2
+    }
+
+    bb8 (cleanup): {
+        resume;                          // bb8[0]: scope 0 at $DIR/region-subtyping-basic.rs:16:1: 25:2
     }
 }

--- a/src/test/mir-opt/nll/region-subtyping-basic/64bit/rustc.main.nll.0.mir
+++ b/src/test/mir-opt/nll/region-subtyping-basic/64bit/rustc.main.nll.0.mir
@@ -5,21 +5,21 @@
 | '_#1r | Local | ['_#1r]
 |
 | Inferred Region Values
-| '_#0r | U0 | {bb0[0..=8], bb1[0], bb2[0..=8], bb3[0], bb4[0..=1], bb5[0..=3], bb6[0..=3], bb7[0..=2], bb8[0..=5], '_#0r, '_#1r}
-| '_#1r | U0 | {bb0[0..=8], bb1[0], bb2[0..=8], bb3[0], bb4[0..=1], bb5[0..=3], bb6[0..=3], bb7[0..=2], bb8[0..=5], '_#1r}
+| '_#0r | U0 | {bb0[0..=8], bb1[0..=8], bb2[0], bb3[0..=1], bb4[0..=3], bb5[0..=3], bb6[0..=2], bb7[0..=5], bb8[0], '_#0r, '_#1r}
+| '_#1r | U0 | {bb0[0..=8], bb1[0..=8], bb2[0], bb3[0..=1], bb4[0..=3], bb5[0..=3], bb6[0..=2], bb7[0..=5], bb8[0], '_#1r}
 | '_#2r | U0 | {}
-| '_#3r | U0 | {bb2[0..=8], bb3[0], bb5[0..=2]}
-| '_#4r | U0 | {bb2[1..=8], bb3[0], bb5[0..=2]}
-| '_#5r | U0 | {bb2[4..=8], bb3[0], bb5[0..=2]}
+| '_#3r | U0 | {bb1[0..=8], bb2[0], bb4[0..=2]}
+| '_#4r | U0 | {bb1[1..=8], bb2[0], bb4[0..=2]}
+| '_#5r | U0 | {bb1[4..=8], bb2[0], bb4[0..=2]}
 |
 | Inference Constraints
-| '_#0r live at {bb0[0..=8], bb1[0], bb2[0..=8], bb3[0], bb4[0..=1], bb5[0..=3], bb6[0..=3], bb7[0..=2], bb8[0..=5]}
-| '_#1r live at {bb0[0..=8], bb1[0], bb2[0..=8], bb3[0], bb4[0..=1], bb5[0..=3], bb6[0..=3], bb7[0..=2], bb8[0..=5]}
-| '_#3r live at {bb2[0]}
-| '_#4r live at {bb2[1..=3]}
-| '_#5r live at {bb2[4..=8], bb3[0], bb5[0..=2]}
-| '_#3r: '_#4r due to Assignment at Single(bb2[0])
-| '_#4r: '_#5r due to Assignment at Single(bb2[3])
+| '_#0r live at {bb0[0..=8], bb1[0..=8], bb2[0], bb3[0..=1], bb4[0..=3], bb5[0..=3], bb6[0..=2], bb7[0..=5], bb8[0]}
+| '_#1r live at {bb0[0..=8], bb1[0..=8], bb2[0], bb3[0..=1], bb4[0..=3], bb5[0..=3], bb6[0..=2], bb7[0..=5], bb8[0]}
+| '_#3r live at {bb1[0]}
+| '_#4r live at {bb1[1..=3]}
+| '_#5r live at {bb1[4..=8], bb2[0], bb4[0..=2]}
+| '_#3r: '_#4r due to Assignment at Single(bb1[0])
+| '_#4r: '_#5r due to Assignment at Single(bb1[3])
 |
 fn main() -> () {
     let mut _0: ();                      // return place in scope 0 at $DIR/region-subtyping-basic.rs:16:11: 16:11
@@ -76,38 +76,34 @@ fn main() -> () {
                                          // + literal: Const { ty: usize, val: Value(Scalar(0x0000000000000000)) }
         _4 = Len(_1);                    // bb0[6]: scope 1 at $DIR/region-subtyping-basic.rs:18:14: 18:18
         _5 = Lt(_3, _4);                 // bb0[7]: scope 1 at $DIR/region-subtyping-basic.rs:18:14: 18:18
-        assert(move _5, "index out of bounds: the len is {} but the index is {}", move _4, _3) -> [success: bb2, unwind: bb1]; // bb0[8]: scope 1 at $DIR/region-subtyping-basic.rs:18:14: 18:18
+        assert(move _5, "index out of bounds: the len is {} but the index is {}", move _4, _3) -> [success: bb1, unwind: bb8]; // bb0[8]: scope 1 at $DIR/region-subtyping-basic.rs:18:14: 18:18
     }
 
-    bb1 (cleanup): {
-        resume;                          // bb1[0]: scope 0 at $DIR/region-subtyping-basic.rs:16:1: 25:2
-    }
-
-    bb2: {
-        _2 = &'_#3r _1[_3];              // bb2[0]: scope 1 at $DIR/region-subtyping-basic.rs:18:13: 18:18
-        FakeRead(ForLet, _2);            // bb2[1]: scope 1 at $DIR/region-subtyping-basic.rs:18:9: 18:10
-        StorageLive(_6);                 // bb2[2]: scope 2 at $DIR/region-subtyping-basic.rs:19:9: 19:10
-        _6 = _2;                         // bb2[3]: scope 2 at $DIR/region-subtyping-basic.rs:19:13: 19:14
-        FakeRead(ForLet, _6);            // bb2[4]: scope 2 at $DIR/region-subtyping-basic.rs:19:9: 19:10
-        StorageLive(_7);                 // bb2[5]: scope 3 at $DIR/region-subtyping-basic.rs:20:8: 20:12
-        _7 = const Const(Value(Scalar(0x01)): bool); // bb2[6]: scope 3 at $DIR/region-subtyping-basic.rs:20:8: 20:12
+    bb1: {
+        _2 = &'_#3r _1[_3];              // bb1[0]: scope 1 at $DIR/region-subtyping-basic.rs:18:13: 18:18
+        FakeRead(ForLet, _2);            // bb1[1]: scope 1 at $DIR/region-subtyping-basic.rs:18:9: 18:10
+        StorageLive(_6);                 // bb1[2]: scope 2 at $DIR/region-subtyping-basic.rs:19:9: 19:10
+        _6 = _2;                         // bb1[3]: scope 2 at $DIR/region-subtyping-basic.rs:19:13: 19:14
+        FakeRead(ForLet, _6);            // bb1[4]: scope 2 at $DIR/region-subtyping-basic.rs:19:9: 19:10
+        StorageLive(_7);                 // bb1[5]: scope 3 at $DIR/region-subtyping-basic.rs:20:8: 20:12
+        _7 = const Const(Value(Scalar(0x01)): bool); // bb1[6]: scope 3 at $DIR/region-subtyping-basic.rs:20:8: 20:12
                                          // ty::Const
                                          // + ty: bool
                                          // + val: Value(Scalar(0x01))
                                          // mir::Constant
                                          // + span: $DIR/region-subtyping-basic.rs:20:8: 20:12
                                          // + literal: Const { ty: bool, val: Value(Scalar(0x01)) }
-        FakeRead(ForMatchedPlace, _7);   // bb2[7]: scope 3 at $DIR/region-subtyping-basic.rs:20:8: 20:12
-        switchInt(_7) -> [Const(Value(Scalar(0x00)): bool): bb4, otherwise: bb3]; // bb2[8]: scope 3 at $DIR/region-subtyping-basic.rs:20:5: 24:6
+        FakeRead(ForMatchedPlace, _7);   // bb1[7]: scope 3 at $DIR/region-subtyping-basic.rs:20:8: 20:12
+        switchInt(_7) -> [Const(Value(Scalar(0x00)): bool): bb3, otherwise: bb2]; // bb1[8]: scope 3 at $DIR/region-subtyping-basic.rs:20:5: 24:6
+    }
+
+    bb2: {
+        falseEdges -> [real: bb4, imaginary: bb3]; // bb2[0]: scope 3 at $DIR/region-subtyping-basic.rs:20:5: 24:6
     }
 
     bb3: {
-        falseEdges -> [real: bb5, imaginary: bb4]; // bb3[0]: scope 3 at $DIR/region-subtyping-basic.rs:20:5: 24:6
-    }
-
-    bb4: {
-        StorageLive(_10);                // bb4[0]: scope 3 at $DIR/region-subtyping-basic.rs:23:9: 23:18
-        _10 = const Const(Value(Scalar(<ZST>)): fn(usize) -> bool {use_x})(const Const(Value(Scalar(0x0000000000000016)): usize)) -> [return: bb7, unwind: bb1]; // bb4[1]: scope 3 at $DIR/region-subtyping-basic.rs:23:9: 23:18
+        StorageLive(_10);                // bb3[0]: scope 3 at $DIR/region-subtyping-basic.rs:23:9: 23:18
+        _10 = const Const(Value(Scalar(<ZST>)): fn(usize) -> bool {use_x})(const Const(Value(Scalar(0x0000000000000016)): usize)) -> [return: bb6, unwind: bb8]; // bb3[1]: scope 3 at $DIR/region-subtyping-basic.rs:23:9: 23:18
                                          // ty::Const
                                          // + ty: fn(usize) -> bool {use_x}
                                          // + val: Value(Scalar(<ZST>))
@@ -122,11 +118,11 @@ fn main() -> () {
                                          // + literal: Const { ty: usize, val: Value(Scalar(0x0000000000000016)) }
     }
 
-    bb5: {
-        StorageLive(_8);                 // bb5[0]: scope 3 at $DIR/region-subtyping-basic.rs:21:9: 21:18
-        StorageLive(_9);                 // bb5[1]: scope 3 at $DIR/region-subtyping-basic.rs:21:15: 21:17
-        _9 = (*_6);                      // bb5[2]: scope 3 at $DIR/region-subtyping-basic.rs:21:15: 21:17
-        _8 = const Const(Value(Scalar(<ZST>)): fn(usize) -> bool {use_x})(move _9) -> [return: bb6, unwind: bb1]; // bb5[3]: scope 3 at $DIR/region-subtyping-basic.rs:21:9: 21:18
+    bb4: {
+        StorageLive(_8);                 // bb4[0]: scope 3 at $DIR/region-subtyping-basic.rs:21:9: 21:18
+        StorageLive(_9);                 // bb4[1]: scope 3 at $DIR/region-subtyping-basic.rs:21:15: 21:17
+        _9 = (*_6);                      // bb4[2]: scope 3 at $DIR/region-subtyping-basic.rs:21:15: 21:17
+        _8 = const Const(Value(Scalar(<ZST>)): fn(usize) -> bool {use_x})(move _9) -> [return: bb5, unwind: bb8]; // bb4[3]: scope 3 at $DIR/region-subtyping-basic.rs:21:9: 21:18
                                          // ty::Const
                                          // + ty: fn(usize) -> bool {use_x}
                                          // + val: Value(Scalar(<ZST>))
@@ -135,37 +131,41 @@ fn main() -> () {
                                          // + literal: Const { ty: fn(usize) -> bool {use_x}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb6: {
-        StorageDead(_9);                 // bb6[0]: scope 3 at $DIR/region-subtyping-basic.rs:21:17: 21:18
-        StorageDead(_8);                 // bb6[1]: scope 3 at $DIR/region-subtyping-basic.rs:21:18: 21:19
-        _0 = const Const(Value(Scalar(<ZST>)): ()); // bb6[2]: scope 3 at $DIR/region-subtyping-basic.rs:20:13: 22:6
+    bb5: {
+        StorageDead(_9);                 // bb5[0]: scope 3 at $DIR/region-subtyping-basic.rs:21:17: 21:18
+        StorageDead(_8);                 // bb5[1]: scope 3 at $DIR/region-subtyping-basic.rs:21:18: 21:19
+        _0 = const Const(Value(Scalar(<ZST>)): ()); // bb5[2]: scope 3 at $DIR/region-subtyping-basic.rs:20:13: 22:6
                                          // ty::Const
                                          // + ty: ()
                                          // + val: Value(Scalar(<ZST>))
                                          // mir::Constant
                                          // + span: $DIR/region-subtyping-basic.rs:20:13: 22:6
                                          // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
-        goto -> bb8;                     // bb6[3]: scope 3 at $DIR/region-subtyping-basic.rs:20:5: 24:6
+        goto -> bb7;                     // bb5[3]: scope 3 at $DIR/region-subtyping-basic.rs:20:5: 24:6
     }
 
-    bb7: {
-        StorageDead(_10);                // bb7[0]: scope 3 at $DIR/region-subtyping-basic.rs:23:18: 23:19
-        _0 = const Const(Value(Scalar(<ZST>)): ()); // bb7[1]: scope 3 at $DIR/region-subtyping-basic.rs:22:12: 24:6
+    bb6: {
+        StorageDead(_10);                // bb6[0]: scope 3 at $DIR/region-subtyping-basic.rs:23:18: 23:19
+        _0 = const Const(Value(Scalar(<ZST>)): ()); // bb6[1]: scope 3 at $DIR/region-subtyping-basic.rs:22:12: 24:6
                                          // ty::Const
                                          // + ty: ()
                                          // + val: Value(Scalar(<ZST>))
                                          // mir::Constant
                                          // + span: $DIR/region-subtyping-basic.rs:22:12: 24:6
                                          // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
-        goto -> bb8;                     // bb7[2]: scope 3 at $DIR/region-subtyping-basic.rs:20:5: 24:6
+        goto -> bb7;                     // bb6[2]: scope 3 at $DIR/region-subtyping-basic.rs:20:5: 24:6
     }
 
-    bb8: {
-        StorageDead(_6);                 // bb8[0]: scope 2 at $DIR/region-subtyping-basic.rs:25:1: 25:2
-        StorageDead(_3);                 // bb8[1]: scope 1 at $DIR/region-subtyping-basic.rs:25:1: 25:2
-        StorageDead(_2);                 // bb8[2]: scope 1 at $DIR/region-subtyping-basic.rs:25:1: 25:2
-        StorageDead(_1);                 // bb8[3]: scope 0 at $DIR/region-subtyping-basic.rs:25:1: 25:2
-        StorageDead(_7);                 // bb8[4]: scope 0 at $DIR/region-subtyping-basic.rs:25:1: 25:2
-        return;                          // bb8[5]: scope 0 at $DIR/region-subtyping-basic.rs:25:2: 25:2
+    bb7: {
+        StorageDead(_6);                 // bb7[0]: scope 2 at $DIR/region-subtyping-basic.rs:25:1: 25:2
+        StorageDead(_3);                 // bb7[1]: scope 1 at $DIR/region-subtyping-basic.rs:25:1: 25:2
+        StorageDead(_2);                 // bb7[2]: scope 1 at $DIR/region-subtyping-basic.rs:25:1: 25:2
+        StorageDead(_1);                 // bb7[3]: scope 0 at $DIR/region-subtyping-basic.rs:25:1: 25:2
+        StorageDead(_7);                 // bb7[4]: scope 0 at $DIR/region-subtyping-basic.rs:25:1: 25:2
+        return;                          // bb7[5]: scope 0 at $DIR/region-subtyping-basic.rs:25:2: 25:2
+    }
+
+    bb8 (cleanup): {
+        resume;                          // bb8[0]: scope 0 at $DIR/region-subtyping-basic.rs:16:1: 25:2
     }
 }

--- a/src/test/mir-opt/no-drop-for-inactive-variant/rustc.unwrap.SimplifyCfg-elaborate-drops.after.mir
+++ b/src/test/mir-opt/no-drop-for-inactive-variant/rustc.unwrap.SimplifyCfg-elaborate-drops.after.mir
@@ -14,16 +14,12 @@ fn unwrap(_1: std::option::Option<T>) -> T {
 
     bb0: {
         _2 = discriminant(_1);           // scope 0 at $DIR/no-drop-for-inactive-variant.rs:9:9: 9:16
-        switchInt(move _2) -> [0isize: bb2, 1isize: bb4, otherwise: bb3]; // scope 0 at $DIR/no-drop-for-inactive-variant.rs:9:9: 9:16
+        switchInt(move _2) -> [0isize: bb1, 1isize: bb3, otherwise: bb2]; // scope 0 at $DIR/no-drop-for-inactive-variant.rs:9:9: 9:16
     }
 
-    bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/no-drop-for-inactive-variant.rs:7:1: 12:2
-    }
-
-    bb2: {
+    bb1: {
         StorageLive(_4);                 // scope 0 at $SRC_DIR/libstd/macros.rs:LL:COL
-        const std::rt::begin_panic::<&str>(const "explicit panic") -> bb5; // scope 0 at $SRC_DIR/libstd/macros.rs:LL:COL
+        const std::rt::begin_panic::<&str>(const "explicit panic") -> bb4; // scope 0 at $SRC_DIR/libstd/macros.rs:LL:COL
                                          // ty::Const
                                          // + ty: fn(&str) -> ! {std::rt::begin_panic::<&str>}
                                          // + val: Value(Scalar(<ZST>))
@@ -38,11 +34,11 @@ fn unwrap(_1: std::option::Option<T>) -> T {
                                          // + literal: Const { ty: &str, val: Value(Slice { data: Allocation { bytes: [101, 120, 112, 108, 105, 99, 105, 116, 32, 112, 97, 110, 105, 99], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [16383], len: Size { raw: 14 } }, size: Size { raw: 14 }, align: Align { pow2: 0 }, mutability: Not, extra: () }, start: 0, end: 14 }) }
     }
 
-    bb3: {
+    bb2: {
         unreachable;                     // scope 0 at $DIR/no-drop-for-inactive-variant.rs:8:11: 8:14
     }
 
-    bb4: {
+    bb3: {
         StorageLive(_3);                 // scope 0 at $DIR/no-drop-for-inactive-variant.rs:9:14: 9:15
         _3 = move ((_1 as Some).0: T);   // scope 0 at $DIR/no-drop-for-inactive-variant.rs:9:14: 9:15
         _0 = move _3;                    // scope 1 at $DIR/no-drop-for-inactive-variant.rs:9:20: 9:21
@@ -51,7 +47,11 @@ fn unwrap(_1: std::option::Option<T>) -> T {
         return;                          // scope 0 at $DIR/no-drop-for-inactive-variant.rs:12:2: 12:2
     }
 
+    bb4 (cleanup): {
+        drop(_1) -> bb5;                 // scope 0 at $DIR/no-drop-for-inactive-variant.rs:12:1: 12:2
+    }
+
     bb5 (cleanup): {
-        drop(_1) -> bb1;                 // scope 0 at $DIR/no-drop-for-inactive-variant.rs:12:1: 12:2
+        resume;                          // scope 0 at $DIR/no-drop-for-inactive-variant.rs:7:1: 12:2
     }
 }

--- a/src/test/mir-opt/no-spurious-drop-after-call/rustc.main.ElaborateDrops.before.mir
+++ b/src/test/mir-opt/no-spurious-drop-after-call/rustc.main.ElaborateDrops.before.mir
@@ -20,7 +20,7 @@ fn main() -> () {
                                          // + span: $DIR/no-spurious-drop-after-call.rs:9:20: 9:22
                                          // + literal: Const { ty: &str, val: Value(Slice { data: Allocation { bytes: [], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [], len: Size { raw: 0 } }, size: Size { raw: 0 }, align: Align { pow2: 0 }, mutability: Not, extra: () }, start: 0, end: 0 }) }
         _3 = &(*_4);                     // scope 0 at $DIR/no-spurious-drop-after-call.rs:9:20: 9:22
-        _2 = const <str as std::string::ToString>::to_string(move _3) -> bb2; // scope 0 at $DIR/no-spurious-drop-after-call.rs:9:20: 9:34
+        _2 = const <str as std::string::ToString>::to_string(move _3) -> bb1; // scope 0 at $DIR/no-spurious-drop-after-call.rs:9:20: 9:34
                                          // ty::Const
                                          // + ty: for<'r> fn(&'r str) -> std::string::String {<str as std::string::ToString>::to_string}
                                          // + val: Value(Scalar(<ZST>))
@@ -29,13 +29,9 @@ fn main() -> () {
                                          // + literal: Const { ty: for<'r> fn(&'r str) -> std::string::String {<str as std::string::ToString>::to_string}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/no-spurious-drop-after-call.rs:8:1: 10:2
-    }
-
-    bb2: {
+    bb1: {
         StorageDead(_3);                 // scope 0 at $DIR/no-spurious-drop-after-call.rs:9:33: 9:34
-        _1 = const std::mem::drop::<std::string::String>(move _2) -> [return: bb3, unwind: bb4]; // scope 0 at $DIR/no-spurious-drop-after-call.rs:9:5: 9:35
+        _1 = const std::mem::drop::<std::string::String>(move _2) -> [return: bb2, unwind: bb3]; // scope 0 at $DIR/no-spurious-drop-after-call.rs:9:5: 9:35
                                          // ty::Const
                                          // + ty: fn(std::string::String) {std::mem::drop::<std::string::String>}
                                          // + val: Value(Scalar(<ZST>))
@@ -44,7 +40,7 @@ fn main() -> () {
                                          // + literal: Const { ty: fn(std::string::String) {std::mem::drop::<std::string::String>}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb3: {
+    bb2: {
         StorageDead(_2);                 // scope 0 at $DIR/no-spurious-drop-after-call.rs:9:34: 9:35
         StorageDead(_4);                 // scope 0 at $DIR/no-spurious-drop-after-call.rs:9:35: 9:36
         StorageDead(_1);                 // scope 0 at $DIR/no-spurious-drop-after-call.rs:9:35: 9:36
@@ -58,7 +54,11 @@ fn main() -> () {
         return;                          // scope 0 at $DIR/no-spurious-drop-after-call.rs:10:2: 10:2
     }
 
+    bb3 (cleanup): {
+        drop(_2) -> bb4;                 // scope 0 at $DIR/no-spurious-drop-after-call.rs:9:34: 9:35
+    }
+
     bb4 (cleanup): {
-        drop(_2) -> bb1;                 // scope 0 at $DIR/no-spurious-drop-after-call.rs:9:34: 9:35
+        resume;                          // scope 0 at $DIR/no-spurious-drop-after-call.rs:8:1: 10:2
     }
 }

--- a/src/test/mir-opt/packed-struct-drop-aligned/32bit/rustc.main.SimplifyCfg-elaborate-drops.after.mir
+++ b/src/test/mir-opt/packed-struct-drop-aligned/32bit/rustc.main.SimplifyCfg-elaborate-drops.after.mir
@@ -43,18 +43,18 @@ fn main() -> () {
         drop(_6) -> [return: bb4, unwind: bb3]; // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:5: 7:8
     }
 
-    bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/packed-struct-drop-aligned.rs:5:1: 8:2
-    }
-
-    bb2: {
+    bb1: {
         StorageDead(_1);                 // scope 0 at $DIR/packed-struct-drop-aligned.rs:8:1: 8:2
         return;                          // scope 0 at $DIR/packed-struct-drop-aligned.rs:8:2: 8:2
     }
 
+    bb2 (cleanup): {
+        resume;                          // scope 0 at $DIR/packed-struct-drop-aligned.rs:5:1: 8:2
+    }
+
     bb3 (cleanup): {
         (_1.0: Aligned) = move _4;       // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:5: 7:8
-        drop(_1) -> bb1;                 // scope 0 at $DIR/packed-struct-drop-aligned.rs:8:1: 8:2
+        drop(_1) -> bb2;                 // scope 0 at $DIR/packed-struct-drop-aligned.rs:8:1: 8:2
     }
 
     bb4: {
@@ -68,6 +68,6 @@ fn main() -> () {
                                          // mir::Constant
                                          // + span: $DIR/packed-struct-drop-aligned.rs:5:11: 8:2
                                          // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
-        drop(_1) -> [return: bb2, unwind: bb1]; // scope 0 at $DIR/packed-struct-drop-aligned.rs:8:1: 8:2
+        drop(_1) -> [return: bb1, unwind: bb2]; // scope 0 at $DIR/packed-struct-drop-aligned.rs:8:1: 8:2
     }
 }

--- a/src/test/mir-opt/packed-struct-drop-aligned/64bit/rustc.main.SimplifyCfg-elaborate-drops.after.mir
+++ b/src/test/mir-opt/packed-struct-drop-aligned/64bit/rustc.main.SimplifyCfg-elaborate-drops.after.mir
@@ -43,18 +43,18 @@ fn main() -> () {
         drop(_6) -> [return: bb4, unwind: bb3]; // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:5: 7:8
     }
 
-    bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/packed-struct-drop-aligned.rs:5:1: 8:2
-    }
-
-    bb2: {
+    bb1: {
         StorageDead(_1);                 // scope 0 at $DIR/packed-struct-drop-aligned.rs:8:1: 8:2
         return;                          // scope 0 at $DIR/packed-struct-drop-aligned.rs:8:2: 8:2
     }
 
+    bb2 (cleanup): {
+        resume;                          // scope 0 at $DIR/packed-struct-drop-aligned.rs:5:1: 8:2
+    }
+
     bb3 (cleanup): {
         (_1.0: Aligned) = move _4;       // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:5: 7:8
-        drop(_1) -> bb1;                 // scope 0 at $DIR/packed-struct-drop-aligned.rs:8:1: 8:2
+        drop(_1) -> bb2;                 // scope 0 at $DIR/packed-struct-drop-aligned.rs:8:1: 8:2
     }
 
     bb4: {
@@ -68,6 +68,6 @@ fn main() -> () {
                                          // mir::Constant
                                          // + span: $DIR/packed-struct-drop-aligned.rs:5:11: 8:2
                                          // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
-        drop(_1) -> [return: bb2, unwind: bb1]; // scope 0 at $DIR/packed-struct-drop-aligned.rs:8:1: 8:2
+        drop(_1) -> [return: bb1, unwind: bb2]; // scope 0 at $DIR/packed-struct-drop-aligned.rs:8:1: 8:2
     }
 }

--- a/src/test/mir-opt/retag/rustc.main.SimplifyCfg-elaborate-drops.after.mir
+++ b/src/test/mir-opt/retag/rustc.main.SimplifyCfg-elaborate-drops.after.mir
@@ -82,7 +82,7 @@ fn main() -> () {
         Retag(_7);                       // scope 1 at $DIR/retag.rs:32:29: 32:35
         _6 = &mut (*_7);                 // scope 1 at $DIR/retag.rs:32:29: 32:35
         Retag([2phase] _6);              // scope 1 at $DIR/retag.rs:32:29: 32:35
-        _3 = const Test::foo(move _4, move _6) -> [return: bb2, unwind: bb3]; // scope 1 at $DIR/retag.rs:32:17: 32:36
+        _3 = const Test::foo(move _4, move _6) -> [return: bb1, unwind: bb7]; // scope 1 at $DIR/retag.rs:32:17: 32:36
                                          // ty::Const
                                          // + ty: for<'r, 'x> fn(&'r Test, &'x mut i32) -> &'x mut i32 {Test::foo}
                                          // + val: Value(Scalar(<ZST>))
@@ -91,23 +91,15 @@ fn main() -> () {
                                          // + literal: Const { ty: for<'r, 'x> fn(&'r Test, &'x mut i32) -> &'x mut i32 {Test::foo}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/retag.rs:29:1: 51:2
-    }
-
-    bb2: {
+    bb1: {
         Retag(_3);                       // scope 1 at $DIR/retag.rs:32:17: 32:36
         StorageDead(_6);                 // scope 1 at $DIR/retag.rs:32:35: 32:36
         StorageDead(_4);                 // scope 1 at $DIR/retag.rs:32:35: 32:36
         StorageDead(_7);                 // scope 1 at $DIR/retag.rs:32:36: 32:37
-        drop(_5) -> [return: bb4, unwind: bb1]; // scope 1 at $DIR/retag.rs:32:36: 32:37
+        drop(_5) -> [return: bb2, unwind: bb8]; // scope 1 at $DIR/retag.rs:32:36: 32:37
     }
 
-    bb3 (cleanup): {
-        drop(_5) -> bb1;                 // scope 1 at $DIR/retag.rs:32:36: 32:37
-    }
-
-    bb4: {
+    bb2: {
         StorageDead(_5);                 // scope 1 at $DIR/retag.rs:32:36: 32:37
         StorageLive(_8);                 // scope 2 at $DIR/retag.rs:33:13: 33:14
         StorageLive(_9);                 // scope 2 at $DIR/retag.rs:33:19: 33:20
@@ -159,10 +151,10 @@ fn main() -> () {
         Retag(_18);                      // scope 6 at $DIR/retag.rs:44:16: 44:18
         _17 = &(*_18);                   // scope 6 at $DIR/retag.rs:44:16: 44:18
         Retag(_17);                      // scope 6 at $DIR/retag.rs:44:16: 44:18
-        _15 = move _16(move _17) -> bb5; // scope 6 at $DIR/retag.rs:44:14: 44:19
+        _15 = move _16(move _17) -> bb3; // scope 6 at $DIR/retag.rs:44:14: 44:19
     }
 
-    bb5: {
+    bb3: {
         Retag(_15);                      // scope 6 at $DIR/retag.rs:44:14: 44:19
         StorageDead(_17);                // scope 6 at $DIR/retag.rs:44:18: 44:19
         StorageDead(_16);                // scope 6 at $DIR/retag.rs:44:18: 44:19
@@ -193,7 +185,7 @@ fn main() -> () {
         Retag(_23);                      // scope 7 at $DIR/retag.rs:47:21: 47:23
         _22 = &(*_23);                   // scope 7 at $DIR/retag.rs:47:21: 47:23
         Retag(_22);                      // scope 7 at $DIR/retag.rs:47:21: 47:23
-        _19 = const Test::foo_shr(move _20, move _22) -> [return: bb6, unwind: bb7]; // scope 7 at $DIR/retag.rs:47:5: 47:24
+        _19 = const Test::foo_shr(move _20, move _22) -> [return: bb4, unwind: bb6]; // scope 7 at $DIR/retag.rs:47:5: 47:24
                                          // ty::Const
                                          // + ty: for<'r, 'x> fn(&'r Test, &'x i32) -> &'x i32 {Test::foo_shr}
                                          // + val: Value(Scalar(<ZST>))
@@ -202,19 +194,15 @@ fn main() -> () {
                                          // + literal: Const { ty: for<'r, 'x> fn(&'r Test, &'x i32) -> &'x i32 {Test::foo_shr}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb6: {
+    bb4: {
         Retag(_19);                      // scope 7 at $DIR/retag.rs:47:5: 47:24
         StorageDead(_22);                // scope 7 at $DIR/retag.rs:47:23: 47:24
         StorageDead(_20);                // scope 7 at $DIR/retag.rs:47:23: 47:24
         StorageDead(_23);                // scope 7 at $DIR/retag.rs:47:24: 47:25
-        drop(_21) -> [return: bb8, unwind: bb1]; // scope 7 at $DIR/retag.rs:47:24: 47:25
+        drop(_21) -> [return: bb5, unwind: bb8]; // scope 7 at $DIR/retag.rs:47:24: 47:25
     }
 
-    bb7 (cleanup): {
-        drop(_21) -> bb1;                // scope 7 at $DIR/retag.rs:47:24: 47:25
-    }
-
-    bb8: {
+    bb5: {
         StorageDead(_21);                // scope 7 at $DIR/retag.rs:47:24: 47:25
         StorageDead(_19);                // scope 7 at $DIR/retag.rs:47:24: 47:25
         StorageLive(_25);                // scope 7 at $DIR/retag.rs:50:9: 50:11
@@ -235,5 +223,17 @@ fn main() -> () {
         StorageDead(_13);                // scope 1 at $DIR/retag.rs:51:1: 51:2
         StorageDead(_1);                 // scope 0 at $DIR/retag.rs:51:1: 51:2
         return;                          // scope 0 at $DIR/retag.rs:51:2: 51:2
+    }
+
+    bb6 (cleanup): {
+        drop(_21) -> bb8;                // scope 7 at $DIR/retag.rs:47:24: 47:25
+    }
+
+    bb7 (cleanup): {
+        drop(_5) -> bb8;                 // scope 1 at $DIR/retag.rs:32:36: 32:37
+    }
+
+    bb8 (cleanup): {
+        resume;                          // scope 0 at $DIR/retag.rs:29:1: 51:2
     }
 }

--- a/src/test/mir-opt/simple-match/32bit/rustc.match_bool.mir_map.0.mir
+++ b/src/test/mir-opt/simple-match/32bit/rustc.match_bool.mir_map.0.mir
@@ -6,18 +6,14 @@ fn match_bool(_1: bool) -> usize {
 
     bb0: {
         FakeRead(ForMatchedPlace, _1);   // scope 0 at $DIR/simple-match.rs:6:11: 6:12
-        switchInt(_1) -> [false: bb3, otherwise: bb2]; // scope 0 at $DIR/simple-match.rs:7:9: 7:13
+        switchInt(_1) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/simple-match.rs:7:9: 7:13
     }
 
-    bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/simple-match.rs:5:1: 10:2
+    bb1: {
+        falseEdges -> [real: bb3, imaginary: bb2]; // scope 0 at $DIR/simple-match.rs:7:9: 7:13
     }
 
     bb2: {
-        falseEdges -> [real: bb4, imaginary: bb3]; // scope 0 at $DIR/simple-match.rs:7:9: 7:13
-    }
-
-    bb3: {
         _0 = const 20usize;              // scope 0 at $DIR/simple-match.rs:8:14: 8:16
                                          // ty::Const
                                          // + ty: usize
@@ -25,10 +21,10 @@ fn match_bool(_1: bool) -> usize {
                                          // mir::Constant
                                          // + span: $DIR/simple-match.rs:8:14: 8:16
                                          // + literal: Const { ty: usize, val: Value(Scalar(0x00000014)) }
-        goto -> bb5;                     // scope 0 at $DIR/simple-match.rs:6:5: 9:6
+        goto -> bb4;                     // scope 0 at $DIR/simple-match.rs:6:5: 9:6
     }
 
-    bb4: {
+    bb3: {
         _0 = const 10usize;              // scope 0 at $DIR/simple-match.rs:7:17: 7:19
                                          // ty::Const
                                          // + ty: usize
@@ -36,14 +32,10 @@ fn match_bool(_1: bool) -> usize {
                                          // mir::Constant
                                          // + span: $DIR/simple-match.rs:7:17: 7:19
                                          // + literal: Const { ty: usize, val: Value(Scalar(0x0000000a)) }
-        goto -> bb5;                     // scope 0 at $DIR/simple-match.rs:6:5: 9:6
+        goto -> bb4;                     // scope 0 at $DIR/simple-match.rs:6:5: 9:6
     }
 
-    bb5: {
-        goto -> bb6;                     // scope 0 at $DIR/simple-match.rs:10:2: 10:2
-    }
-
-    bb6: {
+    bb4: {
         return;                          // scope 0 at $DIR/simple-match.rs:10:2: 10:2
     }
 }

--- a/src/test/mir-opt/simple-match/64bit/rustc.match_bool.mir_map.0.mir
+++ b/src/test/mir-opt/simple-match/64bit/rustc.match_bool.mir_map.0.mir
@@ -6,18 +6,14 @@ fn match_bool(_1: bool) -> usize {
 
     bb0: {
         FakeRead(ForMatchedPlace, _1);   // scope 0 at $DIR/simple-match.rs:6:11: 6:12
-        switchInt(_1) -> [false: bb3, otherwise: bb2]; // scope 0 at $DIR/simple-match.rs:7:9: 7:13
+        switchInt(_1) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/simple-match.rs:7:9: 7:13
     }
 
-    bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/simple-match.rs:5:1: 10:2
+    bb1: {
+        falseEdges -> [real: bb3, imaginary: bb2]; // scope 0 at $DIR/simple-match.rs:7:9: 7:13
     }
 
     bb2: {
-        falseEdges -> [real: bb4, imaginary: bb3]; // scope 0 at $DIR/simple-match.rs:7:9: 7:13
-    }
-
-    bb3: {
         _0 = const 20usize;              // scope 0 at $DIR/simple-match.rs:8:14: 8:16
                                          // ty::Const
                                          // + ty: usize
@@ -25,10 +21,10 @@ fn match_bool(_1: bool) -> usize {
                                          // mir::Constant
                                          // + span: $DIR/simple-match.rs:8:14: 8:16
                                          // + literal: Const { ty: usize, val: Value(Scalar(0x0000000000000014)) }
-        goto -> bb5;                     // scope 0 at $DIR/simple-match.rs:6:5: 9:6
+        goto -> bb4;                     // scope 0 at $DIR/simple-match.rs:6:5: 9:6
     }
 
-    bb4: {
+    bb3: {
         _0 = const 10usize;              // scope 0 at $DIR/simple-match.rs:7:17: 7:19
                                          // ty::Const
                                          // + ty: usize
@@ -36,14 +32,10 @@ fn match_bool(_1: bool) -> usize {
                                          // mir::Constant
                                          // + span: $DIR/simple-match.rs:7:17: 7:19
                                          // + literal: Const { ty: usize, val: Value(Scalar(0x000000000000000a)) }
-        goto -> bb5;                     // scope 0 at $DIR/simple-match.rs:6:5: 9:6
+        goto -> bb4;                     // scope 0 at $DIR/simple-match.rs:6:5: 9:6
     }
 
-    bb5: {
-        goto -> bb6;                     // scope 0 at $DIR/simple-match.rs:10:2: 10:2
-    }
-
-    bb6: {
+    bb4: {
         return;                          // scope 0 at $DIR/simple-match.rs:10:2: 10:2
     }
 }

--- a/src/test/mir-opt/simplify_cfg/rustc.main.SimplifyCfg-early-opt.diff
+++ b/src/test/mir-opt/simplify_cfg/rustc.main.SimplifyCfg-early-opt.diff
@@ -13,7 +13,7 @@
 - 
 -     bb1: {
           StorageLive(_2);                 // scope 0 at $DIR/simplify_cfg.rs:7:12: 7:17
--         _2 = const bar() -> bb3;         // scope 0 at $DIR/simplify_cfg.rs:7:12: 7:17
+-         _2 = const bar() -> bb2;         // scope 0 at $DIR/simplify_cfg.rs:7:12: 7:17
 +         _2 = const bar() -> bb1;         // scope 0 at $DIR/simplify_cfg.rs:7:12: 7:17
                                            // ty::Const
                                            // + ty: fn() -> bool {bar}
@@ -23,22 +23,18 @@
                                            // + literal: Const { ty: fn() -> bool {bar}, val: Value(Scalar(<ZST>)) }
       }
   
--     bb2 (cleanup): {
--         resume;                          // scope 0 at $DIR/simplify_cfg.rs:5:1: 11:2
+-     bb2: {
+-         nop;                             // scope 0 at $DIR/simplify_cfg.rs:7:12: 7:17
+-         switchInt(_2) -> [false: bb4, otherwise: bb3]; // scope 0 at $DIR/simplify_cfg.rs:7:9: 9:10
 +     bb1: {
 +         switchInt(_2) -> [false: bb2, otherwise: bb3]; // scope 0 at $DIR/simplify_cfg.rs:7:9: 9:10
       }
   
 -     bb3: {
--         nop;                             // scope 0 at $DIR/simplify_cfg.rs:7:12: 7:17
--         switchInt(_2) -> [false: bb5, otherwise: bb4]; // scope 0 at $DIR/simplify_cfg.rs:7:9: 9:10
+-         goto -> bb5;                     // scope 0 at $DIR/simplify_cfg.rs:7:9: 9:10
 -     }
 - 
 -     bb4: {
--         goto -> bb6;                     // scope 0 at $DIR/simplify_cfg.rs:7:9: 9:10
--     }
-- 
--     bb5: {
 +     bb2: {
           _1 = const ();                   // scope 0 at $DIR/simplify_cfg.rs:7:9: 9:10
                                            // ty::Const
@@ -51,7 +47,7 @@
           goto -> bb0;                     // scope 0 at $DIR/simplify_cfg.rs:6:5: 10:6
       }
   
--     bb6: {
+-     bb5: {
 +     bb3: {
           _0 = const ();                   // scope 0 at $DIR/simplify_cfg.rs:8:13: 8:18
                                            // ty::Const
@@ -62,6 +58,10 @@
                                            // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           StorageDead(_2);                 // scope 0 at $DIR/simplify_cfg.rs:10:5: 10:6
           return;                          // scope 0 at $DIR/simplify_cfg.rs:11:2: 11:2
+-     }
+- 
+-     bb6 (cleanup): {
+-         resume;                          // scope 0 at $DIR/simplify_cfg.rs:5:1: 11:2
       }
   }
   

--- a/src/test/mir-opt/simplify_cfg/rustc.main.SimplifyCfg-initial.diff
+++ b/src/test/mir-opt/simplify_cfg/rustc.main.SimplifyCfg-initial.diff
@@ -9,21 +9,17 @@
   
       bb0: {
 -         goto -> bb1;                     // scope 0 at $DIR/simplify_cfg.rs:6:5: 10:6
-+         falseUnwind -> [real: bb1, cleanup: bb2]; // scope 0 at $DIR/simplify_cfg.rs:6:5: 10:6
++         falseUnwind -> [real: bb1, cleanup: bb6]; // scope 0 at $DIR/simplify_cfg.rs:6:5: 10:6
       }
   
       bb1: {
--         falseUnwind -> [real: bb3, cleanup: bb4]; // scope 0 at $DIR/simplify_cfg.rs:6:5: 10:6
+-         falseUnwind -> [real: bb2, cleanup: bb11]; // scope 0 at $DIR/simplify_cfg.rs:6:5: 10:6
 -     }
 - 
 -     bb2: {
--         goto -> bb13;                    // scope 0 at $DIR/simplify_cfg.rs:11:2: 11:2
--     }
-- 
--     bb3: {
           StorageLive(_2);                 // scope 0 at $DIR/simplify_cfg.rs:7:12: 7:17
--         _2 = const bar() -> [return: bb5, unwind: bb4]; // scope 0 at $DIR/simplify_cfg.rs:7:12: 7:17
-+         _2 = const bar() -> [return: bb3, unwind: bb2]; // scope 0 at $DIR/simplify_cfg.rs:7:12: 7:17
+-         _2 = const bar() -> [return: bb3, unwind: bb11]; // scope 0 at $DIR/simplify_cfg.rs:7:12: 7:17
++         _2 = const bar() -> [return: bb2, unwind: bb6]; // scope 0 at $DIR/simplify_cfg.rs:7:12: 7:17
                                            // ty::Const
                                            // + ty: fn() -> bool {bar}
                                            // + val: Value(Scalar(<ZST>))
@@ -32,26 +28,21 @@
                                            // + literal: Const { ty: fn() -> bool {bar}, val: Value(Scalar(<ZST>)) }
       }
   
--     bb4 (cleanup): {
-+     bb2 (cleanup): {
-          resume;                          // scope 0 at $DIR/simplify_cfg.rs:5:1: 11:2
+-     bb3: {
++     bb2: {
+          FakeRead(ForMatchedPlace, _2);   // scope 0 at $DIR/simplify_cfg.rs:7:12: 7:17
+-         switchInt(_2) -> [false: bb5, otherwise: bb4]; // scope 0 at $DIR/simplify_cfg.rs:7:9: 9:10
++         switchInt(_2) -> [false: bb4, otherwise: bb3]; // scope 0 at $DIR/simplify_cfg.rs:7:9: 9:10
+      }
+  
+-     bb4: {
+-         falseEdges -> [real: bb6, imaginary: bb5]; // scope 0 at $DIR/simplify_cfg.rs:7:9: 9:10
++     bb3: {
++         falseEdges -> [real: bb5, imaginary: bb4]; // scope 0 at $DIR/simplify_cfg.rs:7:9: 9:10
       }
   
 -     bb5: {
-+     bb3: {
-          FakeRead(ForMatchedPlace, _2);   // scope 0 at $DIR/simplify_cfg.rs:7:12: 7:17
--         switchInt(_2) -> [false: bb7, otherwise: bb6]; // scope 0 at $DIR/simplify_cfg.rs:7:9: 9:10
-+         switchInt(_2) -> [false: bb5, otherwise: bb4]; // scope 0 at $DIR/simplify_cfg.rs:7:9: 9:10
-      }
-  
--     bb6: {
--         falseEdges -> [real: bb8, imaginary: bb7]; // scope 0 at $DIR/simplify_cfg.rs:7:9: 9:10
 +     bb4: {
-+         falseEdges -> [real: bb6, imaginary: bb5]; // scope 0 at $DIR/simplify_cfg.rs:7:9: 9:10
-      }
-  
--     bb7: {
-+     bb5: {
           _1 = const ();                   // scope 0 at $DIR/simplify_cfg.rs:7:9: 9:10
                                            // ty::Const
                                            // + ty: ()
@@ -59,13 +50,13 @@
                                            // mir::Constant
                                            // + span: $DIR/simplify_cfg.rs:7:9: 9:10
                                            // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
--         goto -> bb12;                    // scope 0 at $DIR/simplify_cfg.rs:7:9: 9:10
+-         goto -> bb9;                     // scope 0 at $DIR/simplify_cfg.rs:7:9: 9:10
 +         StorageDead(_2);                 // scope 0 at $DIR/simplify_cfg.rs:10:5: 10:6
 +         goto -> bb0;                     // scope 0 at $DIR/simplify_cfg.rs:6:5: 10:6
       }
   
--     bb8: {
-+     bb6: {
+-     bb6: {
++     bb5: {
           _0 = const ();                   // scope 0 at $DIR/simplify_cfg.rs:8:13: 8:18
                                            // ty::Const
                                            // + ty: ()
@@ -73,29 +64,30 @@
                                            // mir::Constant
                                            // + span: $DIR/simplify_cfg.rs:8:13: 8:18
                                            // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
--         goto -> bb9;                     // scope 0 at $DIR/simplify_cfg.rs:8:13: 8:18
+-         goto -> bb10;                    // scope 0 at $DIR/simplify_cfg.rs:8:13: 8:18
+-     }
+- 
+-     bb7: {
+-         unreachable;                     // scope 0 at $DIR/simplify_cfg.rs:7:18: 9:10
+-     }
+- 
+-     bb8: {
+-         goto -> bb9;                     // scope 0 at $DIR/simplify_cfg.rs:7:9: 9:10
 -     }
 - 
 -     bb9: {
           StorageDead(_2);                 // scope 0 at $DIR/simplify_cfg.rs:10:5: 10:6
--         goto -> bb2;                     // scope 0 at $DIR/simplify_cfg.rs:8:13: 8:18
--     }
-- 
--     bb10: {
--         unreachable;                     // scope 0 at $DIR/simplify_cfg.rs:7:18: 9:10
--     }
-- 
--     bb11: {
--         goto -> bb12;                    // scope 0 at $DIR/simplify_cfg.rs:7:9: 9:10
--     }
-- 
--     bb12: {
--         StorageDead(_2);                 // scope 0 at $DIR/simplify_cfg.rs:10:5: 10:6
 -         goto -> bb1;                     // scope 0 at $DIR/simplify_cfg.rs:6:5: 10:6
 -     }
 - 
--     bb13: {
+-     bb10: {
+-         StorageDead(_2);                 // scope 0 at $DIR/simplify_cfg.rs:10:5: 10:6
           return;                          // scope 0 at $DIR/simplify_cfg.rs:11:2: 11:2
+      }
+  
+-     bb11 (cleanup): {
++     bb6 (cleanup): {
+          resume;                          // scope 0 at $DIR/simplify_cfg.rs:5:1: 11:2
       }
   }
   

--- a/src/test/mir-opt/simplify_try/rustc.try_identity.SimplifyArmIdentity.diff
+++ b/src/test/mir-opt/simplify_try/rustc.try_identity.SimplifyArmIdentity.diff
@@ -60,7 +60,7 @@
 +         _0 = move _1;                    // scope 8 at $SRC_DIR/libcore/result.rs:LL:COL
 +         nop;                             // scope 8 at $SRC_DIR/libcore/result.rs:LL:COL
 +         nop;                             // scope 8 at $SRC_DIR/libcore/result.rs:LL:COL
-          goto -> bb3;                     // scope 0 at $DIR/simplify_try.rs:6:14: 6:15
+          goto -> bb3;                     // scope 0 at $DIR/simplify_try.rs:8:2: 8:2
       }
   
       bb3: {

--- a/src/test/mir-opt/storage_live_dead_in_statics/rustc.XXX.mir_map.0.mir
+++ b/src/test/mir-opt/storage_live_dead_in_statics/rustc.XXX.mir_map.0.mir
@@ -663,8 +663,4 @@ static XXX: &Foo = {
         StorageDead(_1);                 // scope 0 at $DIR/storage_live_dead_in_statics.rs:23:1: 23:2
         return;                          // scope 0 at $DIR/storage_live_dead_in_statics.rs:5:1: 23:3
     }
-
-    bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/storage_live_dead_in_statics.rs:5:1: 23:3
-    }
 }

--- a/src/test/mir-opt/uniform_array_move_out/rustc.move_out_by_subslice.mir_map.0.mir
+++ b/src/test/mir-opt/uniform_array_move_out/rustc.move_out_by_subslice.mir_map.0.mir
@@ -28,22 +28,10 @@ fn move_out_by_subslice() -> () {
                                          // + span: $DIR/uniform_array_move_out.rs:11:18: 11:19
                                          // + literal: Const { ty: i32, val: Value(Scalar(0x00000001)) }
         _2 = move _3;                    // scope 0 at $DIR/uniform_array_move_out.rs:11:14: 11:19
-        drop(_3) -> [return: bb4, unwind: bb2]; // scope 0 at $DIR/uniform_array_move_out.rs:11:18: 11:19
+        drop(_3) -> [return: bb1, unwind: bb9]; // scope 0 at $DIR/uniform_array_move_out.rs:11:18: 11:19
     }
 
-    bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/uniform_array_move_out.rs:10:1: 13:2
-    }
-
-    bb2 (cleanup): {
-        drop(_2) -> bb1;                 // scope 0 at $DIR/uniform_array_move_out.rs:11:26: 11:27
-    }
-
-    bb3 (cleanup): {
-        drop(_3) -> bb2;                 // scope 0 at $DIR/uniform_array_move_out.rs:11:18: 11:19
-    }
-
-    bb4: {
+    bb1: {
         StorageDead(_3);                 // scope 0 at $DIR/uniform_array_move_out.rs:11:18: 11:19
         StorageLive(_4);                 // scope 0 at $DIR/uniform_array_move_out.rs:11:21: 11:26
         StorageLive(_5);                 // scope 0 at $DIR/uniform_array_move_out.rs:11:21: 11:26
@@ -56,29 +44,21 @@ fn move_out_by_subslice() -> () {
                                          // + span: $DIR/uniform_array_move_out.rs:11:25: 11:26
                                          // + literal: Const { ty: i32, val: Value(Scalar(0x00000002)) }
         _4 = move _5;                    // scope 0 at $DIR/uniform_array_move_out.rs:11:21: 11:26
-        drop(_5) -> [return: bb7, unwind: bb5]; // scope 0 at $DIR/uniform_array_move_out.rs:11:25: 11:26
+        drop(_5) -> [return: bb2, unwind: bb8]; // scope 0 at $DIR/uniform_array_move_out.rs:11:25: 11:26
     }
 
-    bb5 (cleanup): {
-        drop(_4) -> bb2;                 // scope 0 at $DIR/uniform_array_move_out.rs:11:26: 11:27
-    }
-
-    bb6 (cleanup): {
-        drop(_5) -> bb5;                 // scope 0 at $DIR/uniform_array_move_out.rs:11:25: 11:26
-    }
-
-    bb7: {
+    bb2: {
         StorageDead(_5);                 // scope 0 at $DIR/uniform_array_move_out.rs:11:25: 11:26
         _1 = [move _2, move _4];         // scope 0 at $DIR/uniform_array_move_out.rs:11:13: 11:27
-        drop(_4) -> [return: bb8, unwind: bb2]; // scope 0 at $DIR/uniform_array_move_out.rs:11:26: 11:27
+        drop(_4) -> [return: bb3, unwind: bb9]; // scope 0 at $DIR/uniform_array_move_out.rs:11:26: 11:27
     }
 
-    bb8: {
+    bb3: {
         StorageDead(_4);                 // scope 0 at $DIR/uniform_array_move_out.rs:11:26: 11:27
-        drop(_2) -> [return: bb9, unwind: bb1]; // scope 0 at $DIR/uniform_array_move_out.rs:11:26: 11:27
+        drop(_2) -> [return: bb4, unwind: bb10]; // scope 0 at $DIR/uniform_array_move_out.rs:11:26: 11:27
     }
 
-    bb9: {
+    bb4: {
         StorageDead(_2);                 // scope 0 at $DIR/uniform_array_move_out.rs:11:26: 11:27
         FakeRead(ForLet, _1);            // scope 0 at $DIR/uniform_array_move_out.rs:11:9: 11:10
         StorageLive(_6);                 // scope 1 at $DIR/uniform_array_move_out.rs:12:10: 12:17
@@ -90,28 +70,32 @@ fn move_out_by_subslice() -> () {
                                          // mir::Constant
                                          // + span: $DIR/uniform_array_move_out.rs:10:27: 13:2
                                          // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
-        drop(_6) -> [return: bb12, unwind: bb10]; // scope 1 at $DIR/uniform_array_move_out.rs:13:1: 13:2
+        drop(_6) -> [return: bb5, unwind: bb7]; // scope 1 at $DIR/uniform_array_move_out.rs:13:1: 13:2
+    }
+
+    bb5: {
+        StorageDead(_6);                 // scope 1 at $DIR/uniform_array_move_out.rs:13:1: 13:2
+        drop(_1) -> [return: bb6, unwind: bb10]; // scope 0 at $DIR/uniform_array_move_out.rs:13:1: 13:2
+    }
+
+    bb6: {
+        StorageDead(_1);                 // scope 0 at $DIR/uniform_array_move_out.rs:13:1: 13:2
+        return;                          // scope 0 at $DIR/uniform_array_move_out.rs:13:2: 13:2
+    }
+
+    bb7 (cleanup): {
+        drop(_1) -> bb10;                // scope 0 at $DIR/uniform_array_move_out.rs:13:1: 13:2
+    }
+
+    bb8 (cleanup): {
+        drop(_4) -> bb9;                 // scope 0 at $DIR/uniform_array_move_out.rs:11:26: 11:27
+    }
+
+    bb9 (cleanup): {
+        drop(_2) -> bb10;                // scope 0 at $DIR/uniform_array_move_out.rs:11:26: 11:27
     }
 
     bb10 (cleanup): {
-        drop(_1) -> bb1;                 // scope 0 at $DIR/uniform_array_move_out.rs:13:1: 13:2
-    }
-
-    bb11 (cleanup): {
-        drop(_6) -> bb10;                // scope 1 at $DIR/uniform_array_move_out.rs:13:1: 13:2
-    }
-
-    bb12: {
-        StorageDead(_6);                 // scope 1 at $DIR/uniform_array_move_out.rs:13:1: 13:2
-        drop(_1) -> [return: bb13, unwind: bb1]; // scope 0 at $DIR/uniform_array_move_out.rs:13:1: 13:2
-    }
-
-    bb13: {
-        StorageDead(_1);                 // scope 0 at $DIR/uniform_array_move_out.rs:13:1: 13:2
-        goto -> bb14;                    // scope 0 at $DIR/uniform_array_move_out.rs:13:2: 13:2
-    }
-
-    bb14: {
-        return;                          // scope 0 at $DIR/uniform_array_move_out.rs:13:2: 13:2
+        resume;                          // scope 0 at $DIR/uniform_array_move_out.rs:10:1: 13:2
     }
 }

--- a/src/test/mir-opt/uniform_array_move_out/rustc.move_out_from_end.mir_map.0.mir
+++ b/src/test/mir-opt/uniform_array_move_out/rustc.move_out_from_end.mir_map.0.mir
@@ -28,22 +28,10 @@ fn move_out_from_end() -> () {
                                          // + span: $DIR/uniform_array_move_out.rs:5:18: 5:19
                                          // + literal: Const { ty: i32, val: Value(Scalar(0x00000001)) }
         _2 = move _3;                    // scope 0 at $DIR/uniform_array_move_out.rs:5:14: 5:19
-        drop(_3) -> [return: bb4, unwind: bb2]; // scope 0 at $DIR/uniform_array_move_out.rs:5:18: 5:19
+        drop(_3) -> [return: bb1, unwind: bb9]; // scope 0 at $DIR/uniform_array_move_out.rs:5:18: 5:19
     }
 
-    bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/uniform_array_move_out.rs:4:1: 7:2
-    }
-
-    bb2 (cleanup): {
-        drop(_2) -> bb1;                 // scope 0 at $DIR/uniform_array_move_out.rs:5:26: 5:27
-    }
-
-    bb3 (cleanup): {
-        drop(_3) -> bb2;                 // scope 0 at $DIR/uniform_array_move_out.rs:5:18: 5:19
-    }
-
-    bb4: {
+    bb1: {
         StorageDead(_3);                 // scope 0 at $DIR/uniform_array_move_out.rs:5:18: 5:19
         StorageLive(_4);                 // scope 0 at $DIR/uniform_array_move_out.rs:5:21: 5:26
         StorageLive(_5);                 // scope 0 at $DIR/uniform_array_move_out.rs:5:21: 5:26
@@ -56,29 +44,21 @@ fn move_out_from_end() -> () {
                                          // + span: $DIR/uniform_array_move_out.rs:5:25: 5:26
                                          // + literal: Const { ty: i32, val: Value(Scalar(0x00000002)) }
         _4 = move _5;                    // scope 0 at $DIR/uniform_array_move_out.rs:5:21: 5:26
-        drop(_5) -> [return: bb7, unwind: bb5]; // scope 0 at $DIR/uniform_array_move_out.rs:5:25: 5:26
+        drop(_5) -> [return: bb2, unwind: bb8]; // scope 0 at $DIR/uniform_array_move_out.rs:5:25: 5:26
     }
 
-    bb5 (cleanup): {
-        drop(_4) -> bb2;                 // scope 0 at $DIR/uniform_array_move_out.rs:5:26: 5:27
-    }
-
-    bb6 (cleanup): {
-        drop(_5) -> bb5;                 // scope 0 at $DIR/uniform_array_move_out.rs:5:25: 5:26
-    }
-
-    bb7: {
+    bb2: {
         StorageDead(_5);                 // scope 0 at $DIR/uniform_array_move_out.rs:5:25: 5:26
         _1 = [move _2, move _4];         // scope 0 at $DIR/uniform_array_move_out.rs:5:13: 5:27
-        drop(_4) -> [return: bb8, unwind: bb2]; // scope 0 at $DIR/uniform_array_move_out.rs:5:26: 5:27
+        drop(_4) -> [return: bb3, unwind: bb9]; // scope 0 at $DIR/uniform_array_move_out.rs:5:26: 5:27
     }
 
-    bb8: {
+    bb3: {
         StorageDead(_4);                 // scope 0 at $DIR/uniform_array_move_out.rs:5:26: 5:27
-        drop(_2) -> [return: bb9, unwind: bb1]; // scope 0 at $DIR/uniform_array_move_out.rs:5:26: 5:27
+        drop(_2) -> [return: bb4, unwind: bb10]; // scope 0 at $DIR/uniform_array_move_out.rs:5:26: 5:27
     }
 
-    bb9: {
+    bb4: {
         StorageDead(_2);                 // scope 0 at $DIR/uniform_array_move_out.rs:5:26: 5:27
         FakeRead(ForLet, _1);            // scope 0 at $DIR/uniform_array_move_out.rs:5:9: 5:10
         StorageLive(_6);                 // scope 1 at $DIR/uniform_array_move_out.rs:6:14: 6:16
@@ -90,28 +70,32 @@ fn move_out_from_end() -> () {
                                          // mir::Constant
                                          // + span: $DIR/uniform_array_move_out.rs:4:24: 7:2
                                          // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
-        drop(_6) -> [return: bb12, unwind: bb10]; // scope 1 at $DIR/uniform_array_move_out.rs:7:1: 7:2
+        drop(_6) -> [return: bb5, unwind: bb7]; // scope 1 at $DIR/uniform_array_move_out.rs:7:1: 7:2
+    }
+
+    bb5: {
+        StorageDead(_6);                 // scope 1 at $DIR/uniform_array_move_out.rs:7:1: 7:2
+        drop(_1) -> [return: bb6, unwind: bb10]; // scope 0 at $DIR/uniform_array_move_out.rs:7:1: 7:2
+    }
+
+    bb6: {
+        StorageDead(_1);                 // scope 0 at $DIR/uniform_array_move_out.rs:7:1: 7:2
+        return;                          // scope 0 at $DIR/uniform_array_move_out.rs:7:2: 7:2
+    }
+
+    bb7 (cleanup): {
+        drop(_1) -> bb10;                // scope 0 at $DIR/uniform_array_move_out.rs:7:1: 7:2
+    }
+
+    bb8 (cleanup): {
+        drop(_4) -> bb9;                 // scope 0 at $DIR/uniform_array_move_out.rs:5:26: 5:27
+    }
+
+    bb9 (cleanup): {
+        drop(_2) -> bb10;                // scope 0 at $DIR/uniform_array_move_out.rs:5:26: 5:27
     }
 
     bb10 (cleanup): {
-        drop(_1) -> bb1;                 // scope 0 at $DIR/uniform_array_move_out.rs:7:1: 7:2
-    }
-
-    bb11 (cleanup): {
-        drop(_6) -> bb10;                // scope 1 at $DIR/uniform_array_move_out.rs:7:1: 7:2
-    }
-
-    bb12: {
-        StorageDead(_6);                 // scope 1 at $DIR/uniform_array_move_out.rs:7:1: 7:2
-        drop(_1) -> [return: bb13, unwind: bb1]; // scope 0 at $DIR/uniform_array_move_out.rs:7:1: 7:2
-    }
-
-    bb13: {
-        StorageDead(_1);                 // scope 0 at $DIR/uniform_array_move_out.rs:7:1: 7:2
-        goto -> bb14;                    // scope 0 at $DIR/uniform_array_move_out.rs:7:2: 7:2
-    }
-
-    bb14: {
-        return;                          // scope 0 at $DIR/uniform_array_move_out.rs:7:2: 7:2
+        resume;                          // scope 0 at $DIR/uniform_array_move_out.rs:4:1: 7:2
     }
 }

--- a/src/test/mir-opt/unusual-item-types/32bit/rustc.E-V-{{constant}}.mir_map.0.mir
+++ b/src/test/mir-opt/unusual-item-types/32bit/rustc.E-V-{{constant}}.mir_map.0.mir
@@ -13,8 +13,4 @@ E::V::{{constant}}#0: isize = {
                                          // + literal: Const { ty: isize, val: Value(Scalar(0x00000005)) }
         return;                          // scope 0 at $DIR/unusual-item-types.rs:22:9: 22:10
     }
-
-    bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/unusual-item-types.rs:22:9: 22:10
-    }
 }

--- a/src/test/mir-opt/unusual-item-types/32bit/rustc.ptr-drop_in_place.std__vec__Vec_i32_.AddMovesForPackedDrops.before.mir
+++ b/src/test/mir-opt/unusual-item-types/32bit/rustc.ptr-drop_in_place.std__vec__Vec_i32_.AddMovesForPackedDrops.before.mir
@@ -6,7 +6,7 @@ fn std::intrinsics::drop_in_place(_1: *mut std::vec::Vec<i32>) -> () {
     let mut _3: ();                      // in scope 0 at $SRC_DIR/libcore/ptr/mod.rs:LL:COL
 
     bb0: {
-        goto -> bb7;                     // scope 0 at $SRC_DIR/libcore/ptr/mod.rs:LL:COL
+        goto -> bb6;                     // scope 0 at $SRC_DIR/libcore/ptr/mod.rs:LL:COL
     }
 
     bb1: {
@@ -22,20 +22,16 @@ fn std::intrinsics::drop_in_place(_1: *mut std::vec::Vec<i32>) -> () {
     }
 
     bb4 (cleanup): {
-        goto -> bb2;                     // scope 0 at $SRC_DIR/libcore/ptr/mod.rs:LL:COL
+        drop(((*_1).0: alloc::raw_vec::RawVec<i32>)) -> bb2; // scope 0 at $SRC_DIR/libcore/ptr/mod.rs:LL:COL
     }
 
-    bb5 (cleanup): {
-        drop(((*_1).0: alloc::raw_vec::RawVec<i32>)) -> bb4; // scope 0 at $SRC_DIR/libcore/ptr/mod.rs:LL:COL
+    bb5: {
+        drop(((*_1).0: alloc::raw_vec::RawVec<i32>)) -> [return: bb3, unwind: bb2]; // scope 0 at $SRC_DIR/libcore/ptr/mod.rs:LL:COL
     }
 
     bb6: {
-        drop(((*_1).0: alloc::raw_vec::RawVec<i32>)) -> [return: bb3, unwind: bb4]; // scope 0 at $SRC_DIR/libcore/ptr/mod.rs:LL:COL
-    }
-
-    bb7: {
         _2 = &mut (*_1);                 // scope 0 at $SRC_DIR/libcore/ptr/mod.rs:LL:COL
-        _3 = const <std::vec::Vec<i32> as std::ops::Drop>::drop(move _2) -> [return: bb6, unwind: bb5]; // scope 0 at $SRC_DIR/libcore/ptr/mod.rs:LL:COL
+        _3 = const <std::vec::Vec<i32> as std::ops::Drop>::drop(move _2) -> [return: bb5, unwind: bb4]; // scope 0 at $SRC_DIR/libcore/ptr/mod.rs:LL:COL
                                          // ty::Const
                                          // + ty: for<'r> fn(&'r mut std::vec::Vec<i32>) {<std::vec::Vec<i32> as std::ops::Drop>::drop}
                                          // + val: Value(Scalar(<ZST>))

--- a/src/test/mir-opt/unusual-item-types/32bit/rustc.{{impl}}-ASSOCIATED_CONSTANT.mir_map.0.mir
+++ b/src/test/mir-opt/unusual-item-types/32bit/rustc.{{impl}}-ASSOCIATED_CONSTANT.mir_map.0.mir
@@ -13,8 +13,4 @@ const <impl at $DIR/unusual-item-types.rs:9:1: 11:2>::ASSOCIATED_CONSTANT: i32 =
                                          // + literal: Const { ty: i32, val: Value(Scalar(0x00000002)) }
         return;                          // scope 0 at $DIR/unusual-item-types.rs:10:5: 10:40
     }
-
-    bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/unusual-item-types.rs:10:5: 10:40
-    }
 }

--- a/src/test/mir-opt/unusual-item-types/64bit/rustc.E-V-{{constant}}.mir_map.0.mir
+++ b/src/test/mir-opt/unusual-item-types/64bit/rustc.E-V-{{constant}}.mir_map.0.mir
@@ -13,8 +13,4 @@ E::V::{{constant}}#0: isize = {
                                          // + literal: Const { ty: isize, val: Value(Scalar(0x0000000000000005)) }
         return;                          // scope 0 at $DIR/unusual-item-types.rs:22:9: 22:10
     }
-
-    bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/unusual-item-types.rs:22:9: 22:10
-    }
 }

--- a/src/test/mir-opt/unusual-item-types/64bit/rustc.ptr-drop_in_place.std__vec__Vec_i32_.AddMovesForPackedDrops.before.mir
+++ b/src/test/mir-opt/unusual-item-types/64bit/rustc.ptr-drop_in_place.std__vec__Vec_i32_.AddMovesForPackedDrops.before.mir
@@ -6,7 +6,7 @@ fn std::intrinsics::drop_in_place(_1: *mut std::vec::Vec<i32>) -> () {
     let mut _3: ();                      // in scope 0 at $SRC_DIR/libcore/ptr/mod.rs:LL:COL
 
     bb0: {
-        goto -> bb7;                     // scope 0 at $SRC_DIR/libcore/ptr/mod.rs:LL:COL
+        goto -> bb6;                     // scope 0 at $SRC_DIR/libcore/ptr/mod.rs:LL:COL
     }
 
     bb1: {
@@ -22,20 +22,16 @@ fn std::intrinsics::drop_in_place(_1: *mut std::vec::Vec<i32>) -> () {
     }
 
     bb4 (cleanup): {
-        goto -> bb2;                     // scope 0 at $SRC_DIR/libcore/ptr/mod.rs:LL:COL
+        drop(((*_1).0: alloc::raw_vec::RawVec<i32>)) -> bb2; // scope 0 at $SRC_DIR/libcore/ptr/mod.rs:LL:COL
     }
 
-    bb5 (cleanup): {
-        drop(((*_1).0: alloc::raw_vec::RawVec<i32>)) -> bb4; // scope 0 at $SRC_DIR/libcore/ptr/mod.rs:LL:COL
+    bb5: {
+        drop(((*_1).0: alloc::raw_vec::RawVec<i32>)) -> [return: bb3, unwind: bb2]; // scope 0 at $SRC_DIR/libcore/ptr/mod.rs:LL:COL
     }
 
     bb6: {
-        drop(((*_1).0: alloc::raw_vec::RawVec<i32>)) -> [return: bb3, unwind: bb4]; // scope 0 at $SRC_DIR/libcore/ptr/mod.rs:LL:COL
-    }
-
-    bb7: {
         _2 = &mut (*_1);                 // scope 0 at $SRC_DIR/libcore/ptr/mod.rs:LL:COL
-        _3 = const <std::vec::Vec<i32> as std::ops::Drop>::drop(move _2) -> [return: bb6, unwind: bb5]; // scope 0 at $SRC_DIR/libcore/ptr/mod.rs:LL:COL
+        _3 = const <std::vec::Vec<i32> as std::ops::Drop>::drop(move _2) -> [return: bb5, unwind: bb4]; // scope 0 at $SRC_DIR/libcore/ptr/mod.rs:LL:COL
                                          // ty::Const
                                          // + ty: for<'r> fn(&'r mut std::vec::Vec<i32>) {<std::vec::Vec<i32> as std::ops::Drop>::drop}
                                          // + val: Value(Scalar(<ZST>))

--- a/src/test/mir-opt/unusual-item-types/64bit/rustc.{{impl}}-ASSOCIATED_CONSTANT.mir_map.0.mir
+++ b/src/test/mir-opt/unusual-item-types/64bit/rustc.{{impl}}-ASSOCIATED_CONSTANT.mir_map.0.mir
@@ -13,8 +13,4 @@ const <impl at $DIR/unusual-item-types.rs:9:1: 11:2>::ASSOCIATED_CONSTANT: i32 =
                                          // + literal: Const { ty: i32, val: Value(Scalar(0x00000002)) }
         return;                          // scope 0 at $DIR/unusual-item-types.rs:10:5: 10:40
     }
-
-    bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/unusual-item-types.rs:10:5: 10:40
-    }
 }

--- a/src/test/mir-opt/while-storage/rustc.while_loop.PreCodegen.after.mir
+++ b/src/test/mir-opt/while-storage/rustc.while_loop.PreCodegen.after.mir
@@ -70,7 +70,7 @@ fn while_loop(_1: bool) -> () {
                                          // + span: $DIR/while-storage.rs:12:13: 12:18
                                          // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
         StorageDead(_4);                 // scope 0 at $DIR/while-storage.rs:14:5: 14:6
-        goto -> bb7;                     // scope 0 at $DIR/while-storage.rs:12:13: 12:18
+        goto -> bb7;                     // scope 0 at $DIR/while-storage.rs:1:1: 1:1
     }
 
     bb7: {


### PR DESCRIPTION
This PR changes how drops are generated in MIR construction. This is the first half of the fix for #47949.

Rather than generating the drops for a given unwind/break/continue/return/generator drop path as soon as they are needed, the required drops are recorded and get generated later.

The motivation for this is
* It simplifies the caching scheme, because it's now possible to walk up the currently scheduled drop tree to recover state.
* The basic block order for MIR more closely resembles execution order.

This PR also:
* Highlights cleanup blocks in the graphviz MIR output.
* Removes some unnecessary drop flag assignments.