### PR TITLE
Use python3 as default executable for x.py

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -171,7 +171,7 @@
 # rustdoc tests, the lldb python interpreter, and some dist bits and pieces.
 #
 # Defaults to the Python interpreter used to execute x.py.
-#python = "python"
+#python = "python3"
 
 # Force Cargo to check that Cargo.lock describes the precise dependency
 # set that all the Cargo.toml files create, instead of updating it.

--- a/x.py
+++ b/x.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # This file is only a "symlink" to bootstrap.py, all logic should go there.
 


### PR DESCRIPTION
It seems that most distributions do not symlink python3 to python by default, as
was expected when adding this code. We still support python 2.7, but the default
is python 3, so reflect that here as well.

Fixes #71818

r? @cuviper to confirm my logic here is sound