### PR TITLE
Move `Layout` and `LayoutErr` to `core::mem`

### DIFF
--- a/src/liballoc/alloc.rs
+++ b/src/liballoc/alloc.rs
@@ -9,6 +9,26 @@ use core::ptr::{NonNull, Unique};
 #[doc(inline)]
 pub use core::alloc::*;
 
+#[stable(feature = "alloc_layout", since = "1.28.0")]
+#[doc(no_inline)]
+/// **This alias is soft-deprecated.**
+///
+/// Although using it won’t cause compilation warning, new code should use [`mem::Layout`] directly
+/// instead.
+///
+/// [`mem::Layout`]: core::mem::Layout
+pub use core::mem::Layout;
+
+#[stable(feature = "alloc_layout", since = "1.28.0")]
+#[doc(no_inline)]
+/// **This alias is soft-deprecated.**
+///
+/// Although using it won’t cause compilation warning, new code should use [`mem::LayoutError`]
+/// directly instead.
+///
+/// [`mem::LayoutError`]: core::mem::LayoutError
+pub use core::mem::LayoutError as LayoutErr;
+
 #[cfg(test)]
 mod tests;
 

--- a/src/liballoc/alloc.rs
+++ b/src/liballoc/alloc.rs
@@ -9,24 +9,24 @@ use core::ptr::{NonNull, Unique};
 #[doc(inline)]
 pub use core::alloc::*;
 
-#[stable(feature = "alloc_layout", since = "1.28.0")]
-#[doc(no_inline)]
 /// **This alias is soft-deprecated.**
 ///
 /// Although using it won’t cause compilation warning, new code should use [`mem::Layout`] directly
 /// instead.
 ///
 /// [`mem::Layout`]: core::mem::Layout
-pub use core::mem::Layout;
-
 #[stable(feature = "alloc_layout", since = "1.28.0")]
 #[doc(no_inline)]
+pub use core::mem::Layout;
+
 /// **This alias is soft-deprecated.**
 ///
 /// Although using it won’t cause compilation warning, new code should use [`mem::LayoutError`]
 /// directly instead.
 ///
 /// [`mem::LayoutError`]: core::mem::LayoutError
+#[stable(feature = "alloc_layout", since = "1.28.0")]
+#[doc(no_inline)]
 pub use core::mem::LayoutError as LayoutErr;
 
 #[cfg(test)]
@@ -82,7 +82,8 @@ pub struct Global;
 /// # Examples
 ///
 /// ```
-/// use std::alloc::{alloc, dealloc, Layout};
+/// use std::alloc::{alloc, dealloc};
+/// use std::mem::Layout;
 ///
 /// unsafe {
 ///     let layout = Layout::new::<u16>();
@@ -164,7 +165,8 @@ pub unsafe fn realloc(ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 
 /// # Examples
 ///
 /// ```
-/// use std::alloc::{alloc_zeroed, dealloc, Layout};
+/// use std::alloc::{alloc_zeroed, dealloc};
+/// use std::mem::Layout;
 ///
 /// unsafe {
 ///     let layout = Layout::new::<u16>();

--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -122,8 +122,8 @@
 //! [`Box::<T>::from_raw(value)`]: struct.Box.html#method.from_raw
 //! [`Box::<T>::into_raw`]: struct.Box.html#method.into_raw
 //! [`Global`]: ../alloc/struct.Global.html
-//! [`Layout`]: ../alloc/struct.Layout.html
-//! [`Layout::for_value(&*value)`]: ../alloc/struct.Layout.html#method.for_value
+//! [`Layout`]: ../../core/mem/struct.Layout.html
+//! [`Layout::for_value(&*value)`]: ../../core/mem/struct.Layout.html#method.for_value
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
@@ -137,7 +137,7 @@ use core::future::Future;
 use core::hash::{Hash, Hasher};
 use core::iter::{FromIterator, FusedIterator, Iterator};
 use core::marker::{Unpin, Unsize};
-use core::mem;
+use core::mem::{self, Layout};
 use core::ops::{
     CoerceUnsized, Deref, DerefMut, DispatchFromDyn, Generator, GeneratorState, Receiver,
 };
@@ -194,7 +194,7 @@ impl<T> Box<T> {
     /// ```
     #[unstable(feature = "new_uninit", issue = "63291")]
     pub fn new_uninit() -> Box<mem::MaybeUninit<T>> {
-        let layout = alloc::Layout::new::<mem::MaybeUninit<T>>();
+        let layout = Layout::new::<mem::MaybeUninit<T>>();
         let ptr = Global
             .alloc(layout, AllocInit::Uninitialized)
             .unwrap_or_else(|_| alloc::handle_alloc_error(layout))
@@ -223,7 +223,7 @@ impl<T> Box<T> {
     /// [zeroed]: ../../std/mem/union.MaybeUninit.html#method.zeroed
     #[unstable(feature = "new_uninit", issue = "63291")]
     pub fn new_zeroed() -> Box<mem::MaybeUninit<T>> {
-        let layout = alloc::Layout::new::<mem::MaybeUninit<T>>();
+        let layout = Layout::new::<mem::MaybeUninit<T>>();
         let ptr = Global
             .alloc(layout, AllocInit::Zeroed)
             .unwrap_or_else(|_| alloc::handle_alloc_error(layout))
@@ -377,7 +377,8 @@ impl<T: ?Sized> Box<T> {
     /// ```
     /// Manually create a `Box` from scratch by using the global allocator:
     /// ```
-    /// use std::alloc::{alloc, Layout};
+    /// use std::alloc::alloc;
+    /// use std::mem::Layout;
     ///
     /// unsafe {
     ///     let ptr = alloc(Layout::new::<i32>()) as *mut i32;
@@ -387,7 +388,7 @@ impl<T: ?Sized> Box<T> {
     /// ```
     ///
     /// [memory layout]: index.html#memory-layout
-    /// [`Layout`]: ../alloc/struct.Layout.html
+    /// [`Layout`]: core::mem::Layout
     /// [`Box::into_raw`]: struct.Box.html#method.into_raw
     #[stable(feature = "box_raw", since = "1.4.0")]
     #[inline]
@@ -422,7 +423,8 @@ impl<T: ?Sized> Box<T> {
     /// Manual cleanup by explicitly running the destructor and deallocating
     /// the memory:
     /// ```
-    /// use std::alloc::{dealloc, Layout};
+    /// use std::alloc::dealloc;
+    /// use std::mem::Layout;
     /// use std::ptr;
     ///
     /// let x = Box::new(String::from("Hello"));

--- a/src/liballoc/collections/btree/node.rs
+++ b/src/liballoc/collections/btree/node.rs
@@ -33,11 +33,11 @@
 
 use core::cmp::Ordering;
 use core::marker::PhantomData;
-use core::mem::{self, MaybeUninit};
+use core::mem::{self, Layout, MaybeUninit};
 use core::ptr::{self, NonNull, Unique};
 use core::slice;
 
-use crate::alloc::{AllocRef, Global, Layout};
+use crate::alloc::{AllocRef, Global};
 use crate::boxed::Box;
 
 const B: usize = 6;

--- a/src/liballoc/collections/mod.rs
+++ b/src/liballoc/collections/mod.rs
@@ -41,8 +41,8 @@ pub use linked_list::LinkedList;
 #[doc(no_inline)]
 pub use vec_deque::VecDeque;
 
-use crate::alloc::{Layout, LayoutErr};
 use core::fmt::Display;
+use core::mem::{Layout, LayoutError};
 
 /// The error type for `try_reserve` methods.
 #[derive(Clone, PartialEq, Eq, Debug)]
@@ -71,9 +71,9 @@ pub enum TryReserveError {
 }
 
 #[unstable(feature = "try_reserve", reason = "new API", issue = "48043")]
-impl From<LayoutErr> for TryReserveError {
+impl From<LayoutError> for TryReserveError {
     #[inline]
-    fn from(_: LayoutErr) -> Self {
+    fn from(_: LayoutError) -> Self {
         TryReserveError::CapacityOverflow
     }
 }

--- a/src/liballoc/raw_vec.rs
+++ b/src/liballoc/raw_vec.rs
@@ -3,7 +3,7 @@
 
 use core::alloc::MemoryBlock;
 use core::cmp;
-use core::mem::{self, ManuallyDrop, MaybeUninit};
+use core::mem::{self, Layout, ManuallyDrop, MaybeUninit};
 use core::ops::Drop;
 use core::ptr::{NonNull, Unique};
 use core::slice;
@@ -11,7 +11,7 @@ use core::slice;
 use crate::alloc::{
     handle_alloc_error, AllocErr,
     AllocInit::{self, *},
-    AllocRef, Global, Layout,
+    AllocRef, Global,
     ReallocPlacement::{self, *},
 };
 use crate::boxed::Box;

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -245,13 +245,13 @@ use core::hash::{Hash, Hasher};
 use core::intrinsics::abort;
 use core::iter;
 use core::marker::{self, PhantomData, Unpin, Unsize};
-use core::mem::{self, align_of, align_of_val, forget, size_of_val};
+use core::mem::{self, align_of, align_of_val, forget, size_of_val, Layout};
 use core::ops::{CoerceUnsized, Deref, DispatchFromDyn, Receiver};
 use core::pin::Pin;
 use core::ptr::{self, NonNull};
 use core::slice::{self, from_raw_parts_mut};
 
-use crate::alloc::{box_free, handle_alloc_error, AllocInit, AllocRef, Global, Layout};
+use crate::alloc::{box_free, handle_alloc_error, AllocInit, AllocRef, Global};
 use crate::string::String;
 use crate::vec::Vec;
 

--- a/src/liballoc/sync.rs
+++ b/src/liballoc/sync.rs
@@ -16,7 +16,7 @@ use core::hash::{Hash, Hasher};
 use core::intrinsics::abort;
 use core::iter;
 use core::marker::{PhantomData, Unpin, Unsize};
-use core::mem::{self, align_of, align_of_val, size_of_val};
+use core::mem::{self, align_of, align_of_val, size_of_val, Layout};
 use core::ops::{CoerceUnsized, Deref, DispatchFromDyn, Receiver};
 use core::pin::Pin;
 use core::ptr::{self, NonNull};
@@ -24,7 +24,7 @@ use core::slice::{self, from_raw_parts_mut};
 use core::sync::atomic;
 use core::sync::atomic::Ordering::{Acquire, Relaxed, Release, SeqCst};
 
-use crate::alloc::{box_free, handle_alloc_error, AllocInit, AllocRef, Global, Layout};
+use crate::alloc::{box_free, handle_alloc_error, AllocInit, AllocRef, Global};
 use crate::boxed::Box;
 use crate::rc::is_dangling;
 use crate::string::String;

--- a/src/liballoc/tests/heap.rs
+++ b/src/liballoc/tests/heap.rs
@@ -1,4 +1,5 @@
-use std::alloc::{AllocInit, AllocRef, Global, Layout, System};
+use std::alloc::{AllocInit, AllocRef, Global, System};
+use std::mem::Layout;
 
 /// Issue #45955 and #62251.
 #[test]

--- a/src/libcore/alloc/global.rs
+++ b/src/libcore/alloc/global.rs
@@ -1,5 +1,5 @@
-use crate::alloc::Layout;
 use crate::cmp;
+use crate::mem::Layout;
 use crate::ptr;
 
 /// A memory allocator that can be registered as the standard library’s default
@@ -21,7 +21,8 @@ use crate::ptr;
 /// # Example
 ///
 /// ```no_run
-/// use std::alloc::{GlobalAlloc, Layout, alloc};
+/// use std::alloc::{GlobalAlloc, alloc};
+/// use std::mem::Layout;
 /// use std::ptr::null_mut;
 ///
 /// struct MyAllocator;

--- a/src/libcore/alloc/mod.rs
+++ b/src/libcore/alloc/mod.rs
@@ -3,12 +3,29 @@
 #![stable(feature = "alloc_module", since = "1.28.0")]
 
 mod global;
-mod layout;
 
 #[stable(feature = "global_alloc", since = "1.28.0")]
 pub use self::global::GlobalAlloc;
+
 #[stable(feature = "alloc_layout", since = "1.28.0")]
-pub use self::layout::{Layout, LayoutErr};
+#[doc(no_inline)]
+/// **This alias is soft-deprecated.**
+///
+/// Although using it won’t cause compilation warning, new code should use [`mem::Layout`] directly
+/// instead.
+///
+/// [`mem::Layout`]: crate::mem::Layout
+pub use crate::mem::Layout;
+
+#[stable(feature = "alloc_layout", since = "1.28.0")]
+#[doc(no_inline)]
+/// **This alias is soft-deprecated.**
+///
+/// Although using it won’t cause compilation warning, new code should use [`mem::LayoutError`]
+/// directly instead.
+///
+/// [`mem::LayoutError`]: crate::mem::LayoutError
+pub use crate::mem::LayoutError as LayoutErr;
 
 use crate::fmt;
 use crate::ptr::{self, NonNull};

--- a/src/libcore/mem/mod.rs
+++ b/src/libcore/mem/mod.rs
@@ -25,6 +25,10 @@ pub use maybe_uninit::MaybeUninit;
 #[doc(inline)]
 pub use crate::intrinsics::transmute;
 
+mod layout;
+#[stable(feature = "alloc_layout", since = "1.28.0")]
+pub use layout::{Layout, LayoutError};
+
 /// Takes ownership and "forgets" about the value **without running its destructor**.
 ///
 /// Any resources the value manages, such as heap memory or a file handle, will linger

--- a/src/libcore/tests/alloc.rs
+++ b/src/libcore/tests/alloc.rs
@@ -1,4 +1,4 @@
-use core::alloc::Layout;
+use core::mem::Layout;
 use core::ptr::NonNull;
 
 #[test]

--- a/src/libstd/alloc.rs
+++ b/src/libstd/alloc.rs
@@ -72,6 +72,26 @@ use crate::sys_common::util::dumb_print;
 #[doc(inline)]
 pub use alloc_crate::alloc::*;
 
+#[stable(feature = "alloc_layout", since = "1.28.0")]
+#[doc(no_inline)]
+/// **This alias is soft-deprecated.**
+///
+/// Although using it won’t cause compilation warning, new code should use [`mem::Layout`] directly
+/// instead.
+///
+/// [`mem::Layout`]: crate::mem::Layout
+pub use crate::mem::Layout;
+
+#[stable(feature = "alloc_layout", since = "1.28.0")]
+#[doc(no_inline)]
+/// **This alias is soft-deprecated.**
+///
+/// Although using it won’t cause compilation warning, new code should use [`mem::LayoutError`]
+/// directly instead.
+///
+/// [`mem::LayoutError`]: crate::mem::LayoutError
+pub use crate::mem::LayoutError as LayoutErr;
+
 /// The default memory allocator provided by the operating system.
 ///
 /// This is based on `malloc` on Unix platforms and `HeapAlloc` on Windows,

--- a/src/libstd/alloc.rs
+++ b/src/libstd/alloc.rs
@@ -16,7 +16,8 @@
 //! to route all default allocation requests to a custom object.
 //!
 //! ```rust
-//! use std::alloc::{GlobalAlloc, System, Layout};
+//! use std::alloc::{GlobalAlloc, System};
+//! use std::mem::Layout;
 //!
 //! struct MyAllocator;
 //!
@@ -72,24 +73,24 @@ use crate::sys_common::util::dumb_print;
 #[doc(inline)]
 pub use alloc_crate::alloc::*;
 
-#[stable(feature = "alloc_layout", since = "1.28.0")]
-#[doc(no_inline)]
 /// **This alias is soft-deprecated.**
 ///
 /// Although using it won’t cause compilation warning, new code should use [`mem::Layout`] directly
 /// instead.
 ///
 /// [`mem::Layout`]: crate::mem::Layout
-pub use crate::mem::Layout;
-
 #[stable(feature = "alloc_layout", since = "1.28.0")]
 #[doc(no_inline)]
+pub use crate::mem::Layout;
+
 /// **This alias is soft-deprecated.**
 ///
 /// Although using it won’t cause compilation warning, new code should use [`mem::LayoutError`]
 /// directly instead.
 ///
 /// [`mem::LayoutError`]: crate::mem::LayoutError
+#[stable(feature = "alloc_layout", since = "1.28.0")]
+#[doc(no_inline)]
 pub use crate::mem::LayoutError as LayoutErr;
 
 /// The default memory allocator provided by the operating system.
@@ -116,7 +117,8 @@ pub use crate::mem::LayoutError as LayoutErr;
 /// keeping track of the number of all bytes allocated:
 ///
 /// ```rust
-/// use std::alloc::{System, GlobalAlloc, Layout};
+/// use std::alloc::{System, GlobalAlloc};
+/// use std::mem::Layout;
 /// use std::sync::atomic::{AtomicUsize, Ordering::SeqCst};
 ///
 /// struct Counter;

--- a/src/libstd/error.rs
+++ b/src/libstd/error.rs
@@ -15,14 +15,14 @@
 
 use core::array;
 
-use crate::alloc::{AllocErr, LayoutErr};
+use crate::alloc::AllocErr;
 use crate::any::TypeId;
 use crate::backtrace::Backtrace;
 use crate::borrow::Cow;
 use crate::cell;
 use crate::char;
 use crate::fmt::{self, Debug, Display};
-use crate::mem::transmute;
+use crate::mem::{transmute, LayoutError};
 use crate::num;
 use crate::str;
 use crate::string;
@@ -407,7 +407,7 @@ impl Error for AllocErr {}
     reason = "the precise API and guarantees it provides may be tweaked.",
     issue = "32838"
 )]
-impl Error for LayoutErr {}
+impl Error for LayoutError {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl Error for str::ParseBoolError {

--- a/src/libstd/ffi/c_str.rs
+++ b/src/libstd/ffi/c_str.rs
@@ -757,7 +757,7 @@ impl From<Vec<NonZeroU8>> for CString {
             let v: Vec<u8> = {
                 // Safety:
                 //   - transmuting between `NonZeroU8` and `u8` is sound;
-                //   - `alloc::Layout<NonZeroU8> == alloc::Layout<u8>`.
+                //   - `mem::Layout<NonZeroU8> == mem::Layout<u8>`.
                 let (ptr, len, cap): (*mut NonZeroU8, _, _) = Vec::into_raw_parts(v);
                 Vec::from_raw_parts(ptr.cast::<u8>(), len, cap)
             };

--- a/src/libstd/sys/hermit/alloc.rs
+++ b/src/libstd/sys/hermit/alloc.rs
@@ -1,4 +1,5 @@
-use crate::alloc::{GlobalAlloc, Layout, System};
+use crate::alloc::{GlobalAlloc, System};
+use crate::mem::Layout;
 use crate::ptr;
 use crate::sys::hermit::abi;
 

--- a/src/libstd/sys/sgx/alloc.rs
+++ b/src/libstd/sys/sgx/alloc.rs
@@ -1,4 +1,5 @@
-use crate::alloc::{GlobalAlloc, Layout, System};
+use crate::alloc::{GlobalAlloc, System};
+use crate::mem::Layout;
 
 use super::waitqueue::SpinMutex;
 

--- a/src/libstd/sys/unix/alloc.rs
+++ b/src/libstd/sys/unix/alloc.rs
@@ -1,4 +1,5 @@
-use crate::alloc::{GlobalAlloc, Layout, System};
+use crate::alloc::{GlobalAlloc, System};
+use crate::mem::Layout;
 use crate::ptr;
 use crate::sys_common::alloc::{realloc_fallback, MIN_ALIGN};
 

--- a/src/libstd/sys/vxworks/alloc.rs
+++ b/src/libstd/sys/vxworks/alloc.rs
@@ -1,4 +1,5 @@
-use crate::alloc::{GlobalAlloc, Layout, System};
+use crate::alloc::{GlobalAlloc, System};
+use crate::mem::Layout;
 use crate::ptr;
 use crate::sys_common::alloc::{realloc_fallback, MIN_ALIGN};
 

--- a/src/libstd/sys/wasi/alloc.rs
+++ b/src/libstd/sys/wasi/alloc.rs
@@ -1,4 +1,5 @@
-use crate::alloc::{GlobalAlloc, Layout, System};
+use crate::alloc::{GlobalAlloc, System};
+use crate::mem::Layout;
 use crate::ptr;
 use crate::sys_common::alloc::{realloc_fallback, MIN_ALIGN};
 use libc;

--- a/src/libstd/sys/wasm/alloc.rs
+++ b/src/libstd/sys/wasm/alloc.rs
@@ -16,7 +16,8 @@
 //! The crate itself provides a global allocator which on wasm has no
 //! synchronization as there are no threads!
 
-use crate::alloc::{GlobalAlloc, Layout, System};
+use crate::alloc::{GlobalAlloc, System};
+use crate::mem::Layout;
 
 static mut DLMALLOC: dlmalloc::Dlmalloc = dlmalloc::DLMALLOC_INIT;
 

--- a/src/libstd/sys/windows/alloc.rs
+++ b/src/libstd/sys/windows/alloc.rs
@@ -1,4 +1,5 @@
-use crate::alloc::{GlobalAlloc, Layout, System};
+use crate::alloc::{GlobalAlloc, System};
+use crate::mem::Layout;
 use crate::sys::c;
 use crate::sys_common::alloc::{realloc_fallback, MIN_ALIGN};
 

--- a/src/libstd/sys_common/alloc.rs
+++ b/src/libstd/sys_common/alloc.rs
@@ -1,7 +1,8 @@
 #![allow(dead_code)]
 
-use crate::alloc::{GlobalAlloc, Layout, System};
+use crate::alloc::{GlobalAlloc, System};
 use crate::cmp;
+use crate::mem::Layout;
 use crate::ptr;
 
 // The minimum alignment guaranteed by the architecture. This value is used to

--- a/src/test/run-make-fulldeps/issue-51671/app.rs
+++ b/src/test/run-make-fulldeps/issue-51671/app.rs
@@ -3,7 +3,7 @@
 #![no_main]
 #![no_std]
 
-use core::alloc::Layout;
+use core::mem::Layout;
 use core::panic::PanicInfo;
 
 #[panic_handler]

--- a/src/test/run-make-fulldeps/issue-69368/b.rs
+++ b/src/test/run-make-fulldeps/issue-69368/b.rs
@@ -3,6 +3,6 @@
 #![no_std]
 
 #[alloc_error_handler]
-pub fn error_handler(_: core::alloc::Layout) -> ! {
+pub fn error_handler(_: core::mem::Layout) -> ! {
     panic!();
 }

--- a/src/test/run-make/wasm-symbols-not-exported/bar.rs
+++ b/src/test/run-make/wasm-symbols-not-exported/bar.rs
@@ -25,7 +25,7 @@ pub extern fn foo(a: u32) -> u32 {
 }
 
 #[alloc_error_handler]
-fn a(_: core::alloc::Layout) -> ! {
+fn a(_: core::mem::Layout) -> ! {
     loop {}
 }
 

--- a/src/test/rustdoc/issue-54478-demo-allocator.rs
+++ b/src/test/rustdoc/issue-54478-demo-allocator.rs
@@ -18,6 +18,7 @@
 //!
 //! ```rust
 //! use std::alloc::*;
+//! use std::mem::Layout;
 //!
 //! #[global_allocator]
 //! static ALLOC: A = A;

--- a/src/test/ui/alloc-error/alloc-error-handler-bad-signature-1.rs
+++ b/src/test/ui/alloc-error/alloc-error-handler-bad-signature-1.rs
@@ -4,7 +4,7 @@
 #![no_std]
 #![no_main]
 
-use core::alloc::Layout;
+use core::mem::Layout;
 
 #[alloc_error_handler]
 fn oom(

--- a/src/test/ui/allocator/allocator-args.rs
+++ b/src/test/ui/allocator/allocator-args.rs
@@ -1,4 +1,5 @@
-use std::alloc::{GlobalAlloc, Layout};
+use std::alloc::GlobalAlloc;
+use std::mem::Layout;
 
 struct A;
 

--- a/src/test/ui/allocator/allocator-args.stderr
+++ b/src/test/ui/allocator/allocator-args.stderr
@@ -1,5 +1,5 @@
 error: malformed `global_allocator` attribute input
-  --> $DIR/allocator-args.rs:10:1
+  --> $DIR/allocator-args.rs:11:1
    |
 LL | #[global_allocator(malloc)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: must be of the form: `#[global_allocator]`

--- a/src/test/ui/allocator/auxiliary/custom.rs
+++ b/src/test/ui/allocator/auxiliary/custom.rs
@@ -3,7 +3,8 @@
 #![feature(allocator_api)]
 #![crate_type = "rlib"]
 
-use std::alloc::{GlobalAlloc, System, Layout};
+use std::alloc::{GlobalAlloc, System};
+use std::mem::Layout;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 pub struct A(pub AtomicUsize);

--- a/src/test/ui/allocator/custom.rs
+++ b/src/test/ui/allocator/custom.rs
@@ -7,7 +7,8 @@
 
 extern crate helper;
 
-use std::alloc::{self, AllocInit, AllocRef, Global, Layout, System};
+use std::alloc::{self, AllocInit, AllocRef, Global, System};
+use std::mem::Layout;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 static HITS: AtomicUsize = AtomicUsize::new(0);

--- a/src/test/ui/allocator/xcrate-use.rs
+++ b/src/test/ui/allocator/xcrate-use.rs
@@ -9,7 +9,8 @@
 extern crate custom;
 extern crate helper;
 
-use std::alloc::{AllocInit, AllocRef, Global, Layout, System};
+use std::alloc::{AllocInit, AllocRef, Global, System};
+use std::mem::Layout;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 #[global_allocator]

--- a/src/test/ui/allocator/xcrate-use2.rs
+++ b/src/test/ui/allocator/xcrate-use2.rs
@@ -11,7 +11,8 @@ extern crate custom;
 extern crate custom_as_global;
 extern crate helper;
 
-use std::alloc::{alloc, dealloc, GlobalAlloc, System, Layout};
+use std::alloc::{alloc, dealloc, GlobalAlloc, System};
+use std::mem::Layout;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 static GLOBAL: custom::A = custom::A(AtomicUsize::new(0));

--- a/src/test/ui/consts/std/alloc.rs
+++ b/src/test/ui/consts/std/alloc.rs
@@ -1,4 +1,4 @@
-use std::alloc::Layout;
+use std::mem::Layout;
 
 // ok
 const LAYOUT_VALID: Layout = unsafe { Layout::from_size_align_unchecked(0x1000, 0x08) };

--- a/src/test/ui/default-alloc-error-hook.rs
+++ b/src/test/ui/default-alloc-error-hook.rs
@@ -3,8 +3,9 @@
 // ignore-emscripten no processes
 // ignore-sgx no processes
 
-use std::alloc::{Layout, handle_alloc_error};
+use std::alloc::{handle_alloc_error};
 use std::env;
+use std::mem::Layout;
 use std::process::Command;
 use std::str;
 

--- a/src/test/ui/feature-gates/feature-gate-alloc-error-handler.rs
+++ b/src/test/ui/feature-gates/feature-gate-alloc-error-handler.rs
@@ -3,7 +3,7 @@
 #![no_std]
 #![no_main]
 
-use core::alloc::Layout;
+use core::mem::Layout;
 
 #[alloc_error_handler] //~ ERROR the `#[alloc_error_handler]` attribute is an experimental feature
 fn oom(info: Layout) -> ! {

--- a/src/test/ui/layout_err_nonexhaustive.rs
+++ b/src/test/ui/layout_err_nonexhaustive.rs
@@ -1,0 +1,5 @@
+use std::mem::LayoutError;
+
+fn main() {
+    let _err = LayoutError; //~ ERROR expected value, found struct `LayoutError`
+}

--- a/src/test/ui/layout_err_nonexhaustive.stderr
+++ b/src/test/ui/layout_err_nonexhaustive.stderr
@@ -1,0 +1,9 @@
+error[E0423]: expected value, found struct `LayoutError`
+  --> $DIR/layout_err_nonexhaustive.rs:4:16
+   |
+LL |     let _err = LayoutError;
+   |                ^^^^^^^^^^^ constructor is not visible here due to private fields
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0423`.

--- a/src/test/ui/missing/missing-alloc_error_handler.rs
+++ b/src/test/ui/missing/missing-alloc_error_handler.rs
@@ -18,6 +18,6 @@ static A: MyAlloc = MyAlloc;
 struct MyAlloc;
 
 unsafe impl core::alloc::GlobalAlloc for MyAlloc {
-    unsafe fn alloc(&self, _: core::alloc::Layout) -> *mut u8 { 0 as _ }
-    unsafe fn dealloc(&self, _: *mut u8, _: core::alloc::Layout) {}
+    unsafe fn alloc(&self, _: core::mem::Layout) -> *mut u8 { 0 as _ }
+    unsafe fn dealloc(&self, _: *mut u8, _: core::mem::Layout) {}
 }

--- a/src/test/ui/missing/missing-allocator.rs
+++ b/src/test/ui/missing/missing-allocator.rs
@@ -11,7 +11,7 @@ fn panic(_: &core::panic::PanicInfo) -> ! {
 }
 
 #[alloc_error_handler]
-fn oom(_: core::alloc::Layout) -> ! {
+fn oom(_: core::mem::Layout) -> ! {
     loop {}
 }
 

--- a/src/test/ui/realloc-16687.rs
+++ b/src/test/ui/realloc-16687.rs
@@ -6,7 +6,8 @@
 
 #![feature(allocator_api)]
 
-use std::alloc::{handle_alloc_error, AllocInit, AllocRef, Global, Layout, ReallocPlacement};
+use std::alloc::{handle_alloc_error, AllocInit, AllocRef, Global, ReallocPlacement};
+use std::mem::Layout;
 use std::ptr::{self, NonNull};
 
 fn main() {

--- a/src/test/ui/regions/regions-mock-codegen.rs
+++ b/src/test/ui/regions/regions-mock-codegen.rs
@@ -4,7 +4,8 @@
 // pretty-expanded FIXME #23616
 #![feature(allocator_api)]
 
-use std::alloc::{handle_alloc_error, AllocInit, AllocRef, Global, Layout};
+use std::alloc::{handle_alloc_error, AllocInit, AllocRef, Global};
+use std::mem::Layout;
 use std::ptr::NonNull;
 
 struct arena(());


### PR DESCRIPTION
This moves `core::alloc::{Layout, LayoutErr}` to `core::mem::{Layout, LayoutError}` and reexport them as `core::alloc::{Layout, LayoutErr}`. Currently it is neither possible to deprecate reexports, nor to document them, however I added the comment so it shows up if *rustdoc* supports this one day. Also `#[doc(no_inline)]` was added to express, that this is a reexport, this is probably the best bet. The alternative would be `#[doc(hidden)]`.

It's may be an option to also reexport `mem::LayoutError` as `alloc::LayoutError` but this is not required.

~I have another commit in the queue which changes (I hope) all occurrences to the new path, but I want to wait for the CI first. This shouldn't cause *any* errors or warnings.~ I pushed the commit. All previous test passed.

r? @LukasKalbertodt 

closes rust-lang/wg-allocators#59