### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -393,10 +393,14 @@ You can find documentation style guidelines in [RFC 1574][rfc1574].
 
 [rfc1574]: https://github.com/rust-lang/rfcs/blob/master/text/1574-more-api-documentation-conventions.md#appendix-a-full-conventions-text
 
-In many cases, you don't need a full `./x.py doc`. You can use `rustdoc` directly
-to check small fixes. For example, `rustdoc src/doc/reference.md` will render
-reference to `doc/reference.html`. The CSS might be messed up, but you can
-verify that the HTML is right.
+In many cases, you don't need a full `./x.py doc`, which will build the entire
+stage 2 compiler. When updating documentation for the standard library, first
+try `./x.py doc --stage 0 src/libstd`. Results will should appear in
+`build/$TARGET/crate-docs`.
+
+You can also use `rustdoc` directly to check small fixes. For example,
+`rustdoc src/doc/reference.md` will render reference to `doc/reference.html`.
+The CSS might be messed up, but you can verify that the HTML is right.
 
 Additionally, contributions to the [rustc-dev-guide] are always welcome. Contributions
 can be made directly at [the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -193,7 +193,7 @@ it can be found [here][rctd].
 As a developer to this repository, you don't have to treat the following external projects
 differently from other crates that are directly in this repo:
 
-* none so far, see https://github.com/rust-lang/rust/issues/70651 for more info
+* Clippy
 
 They are just regular files and directories. This is in contrast to `submodule` dependencies
 (see below for those). Only tool authors will actually use any operations here.
@@ -247,7 +247,7 @@ git subtree add -P src/tools/clippy https://github.com/rust-lang/rust-clippy.git
 This will create a new commit, which you may not rebase under any circumstances! Delete the commit
 and redo the operation if you need to rebase.
 
-Now you're done, the `src/tools/clippy` directory behaves as if clippy were part of the rustc
+Now you're done, the `src/tools/clippy` directory behaves as if Clippy were part of the rustc
 monorepo, so no one but you (or others that synchronize subtrees) actually needs to use `git subtree`.
 
 
@@ -255,7 +255,6 @@ monorepo, so no one but you (or others that synchronize subtrees) actually needs
 
 Currently building Rust will also build the following external projects:
 
-* [clippy](https://github.com/rust-lang/rust-clippy)
 * [miri](https://github.com/rust-lang/miri)
 * [rustfmt](https://github.com/rust-lang/rustfmt)
 * [rls](https://github.com/rust-lang/rls/)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -394,9 +394,13 @@ You can find documentation style guidelines in [RFC 1574][rfc1574].
 [rfc1574]: https://github.com/rust-lang/rfcs/blob/master/text/1574-more-api-documentation-conventions.md#appendix-a-full-conventions-text
 
 In many cases, you don't need a full `./x.py doc`, which will build the entire
-stage 2 compiler. When updating documentation for the standard library, first
-try `./x.py doc --stage 0 src/libstd`. Results will should appear in
-`build/$TARGET/crate-docs`.
+stage 2 compiler and compile the various books published on
+[doc.rust-lang.org]. When updating documentation for the standard library,
+first try `./x.py doc --stage 0 src/libstd`. If that fails, or if you need to
+see the output from the latest version of `rustdoc`, use `--stage 1` instead of
+`--stage 0`. Results should appear in `build/$TARGET/crate-docs`.
+
+[doc.rust-lang.org]: htts://doc.rust-lang.org
 
 You can also use `rustdoc` directly to check small fixes. For example,
 `rustdoc src/doc/reference.md` will render reference to `doc/reference.html`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -511,7 +511,7 @@ are:
 * Don't be afraid to ask! The Rust community is friendly and helpful.
 
 [rustc dev guide]: https://rustc-dev-guide.rust-lang.org/about-this-guide.html
-[gdfrustc]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc/
+[gdfrustc]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/
 [gsearchdocs]: https://www.google.com/search?q=site:doc.rust-lang.org+your+query+here
 [rif]: http://internals.rust-lang.org
 [rr]: https://doc.rust-lang.org/book/README.html

--- a/src/librustc_mir/borrow_check/type_check/mod.rs
+++ b/src/librustc_mir/borrow_check/type_check/mod.rs
@@ -2290,36 +2290,54 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
                 right,
             ) => {
                 let ty_left = left.ty(body, tcx);
-                if let ty::RawPtr(_) | ty::FnPtr(_) = ty_left.kind {
-                    let ty_right = right.ty(body, tcx);
-                    let common_ty = self.infcx.next_ty_var(TypeVariableOrigin {
-                        kind: TypeVariableOriginKind::MiscVariable,
-                        span: body.source_info(location).span,
-                    });
-                    self.sub_types(
-                        common_ty,
-                        ty_left,
-                        location.to_locations(),
-                        ConstraintCategory::Boring,
-                    )
-                    .unwrap_or_else(|err| {
-                        bug!("Could not equate type variable with {:?}: {:?}", ty_left, err)
-                    });
-                    if let Err(terr) = self.sub_types(
-                        common_ty,
-                        ty_right,
-                        location.to_locations(),
-                        ConstraintCategory::Boring,
-                    ) {
-                        span_mirbug!(
-                            self,
-                            rvalue,
-                            "unexpected comparison types {:?} and {:?} yields {:?}",
+                match ty_left.kind {
+                    // Types with regions are comparable if they have a common super-type.
+                    ty::RawPtr(_) | ty::FnPtr(_) => {
+                        let ty_right = right.ty(body, tcx);
+                        let common_ty = self.infcx.next_ty_var(TypeVariableOrigin {
+                            kind: TypeVariableOriginKind::MiscVariable,
+                            span: body.source_info(location).span,
+                        });
+                        self.relate_types(
+                            common_ty,
+                            ty::Variance::Contravariant,
                             ty_left,
-                            ty_right,
-                            terr
+                            location.to_locations(),
+                            ConstraintCategory::Boring,
                         )
+                        .unwrap_or_else(|err| {
+                            bug!("Could not equate type variable with {:?}: {:?}", ty_left, err)
+                        });
+                        if let Err(terr) = self.relate_types(
+                            common_ty,
+                            ty::Variance::Contravariant,
+                            ty_right,
+                            location.to_locations(),
+                            ConstraintCategory::Boring,
+                        ) {
+                            span_mirbug!(
+                                self,
+                                rvalue,
+                                "unexpected comparison types {:?} and {:?} yields {:?}",
+                                ty_left,
+                                ty_right,
+                                terr
+                            )
+                        }
                     }
+                    // For types with no regions we can just check that the
+                    // both operands have the same type.
+                    ty::Int(_) | ty::Uint(_) | ty::Bool | ty::Char | ty::Float(_)
+                        if ty_left == right.ty(body, tcx) => {}
+                    // Other types are compared by trait methods, not by
+                    // `Rvalue::BinaryOp`.
+                    _ => span_mirbug!(
+                        self,
+                        rvalue,
+                        "unexpected comparison types {:?} and {:?}",
+                        ty_left,
+                        right.ty(body, tcx)
+                    ),
                 }
             }
 

--- a/src/test/ui/nll/type-check-pointer-comparisons.rs
+++ b/src/test/ui/nll/type-check-pointer-comparisons.rs
@@ -21,13 +21,13 @@ fn compare_fn_ptr<'a, 'b, 'c>(f: fn(&'c mut &'a i32), g: fn(&'c mut &'b i32)) {
 }
 
 fn compare_hr_fn_ptr<'a>(f: fn(&'a i32), g: fn(&i32)) {
-    f == g;
-    //~^ ERROR higher-ranked subtype error
+    // Ideally this should compile with the operands swapped as well, but HIR
+    // type checking prevents it (and stops compilation) for now.
+    f == g; // OK
 }
 
 fn compare_const_fn_ptr<'a>(f: *const fn(&'a i32), g: *const fn(&i32)) {
-    f == g;
-    //~^ ERROR higher-ranked subtype error
+    f == g; // OK
 }
 
 fn main() {}

--- a/src/test/ui/nll/type-check-pointer-comparisons.stderr
+++ b/src/test/ui/nll/type-check-pointer-comparisons.stderr
@@ -76,17 +76,5 @@ LL |     f == g;
 
 help: `'a` and `'b` must be the same: replace one with the other
 
-error: higher-ranked subtype error
-  --> $DIR/type-check-pointer-comparisons.rs:24:5
-   |
-LL |     f == g;
-   |     ^^^^^^
-
-error: higher-ranked subtype error
-  --> $DIR/type-check-pointer-comparisons.rs:29:5
-   |
-LL |     f == g;
-   |     ^^^^^^
-
-error: aborting due to 8 previous errors
+error: aborting due to 6 previous errors
 


### PR DESCRIPTION
Successful merges:

 - #71645 (Direct contributors to try stage 0 rustdoc first)
 - #71801 (Correctly check comparison operator in MIR typeck)
 - #71844 (List Clippy as a subtree, instead of a submodule)
 - #71864 (Update link in contributing.md)

Failed merges:


r? @ghost