### PR TITLE
Be slightly more precise about any::type_name()'s guarantees.

### DIFF
--- a/src/libcore/any.rs
+++ b/src/libcore/any.rs
@@ -446,14 +446,14 @@ impl TypeId {
 /// # Note
 ///
 /// This is intended for diagnostic use. The exact contents and format of the
-/// string are not specified, other than being a best-effort description of the
-/// type. For example, `type_name::<Option<String>>()` could return the
-/// `"Option<String>"` or `"std::option::Option<std::string::String>"`, but not
-/// `"foobar"`. In addition, the output may change between versions of the
-/// compiler.
+/// string retrned are not specified, other than being a best-effort description
+/// of the type. For example, amongst the strings
+/// that `type_name::<Option<String>>()` might map to are `"Option<String>"` and
+/// `"std::option::Option<std::string::String>"`.
 ///
-/// The type name should not be considered a unique identifier of a type;
-/// multiple types may share the same type name.
+/// The returned string must not be considered to be a unique identifier of a
+/// type as multiple types may map to the same type name. In addition, the
+/// output may change between versions of the compiler.
 ///
 /// The current implementation uses the same infrastructure as compiler
 /// diagnostics and debuginfo, but this is not guaranteed.

--- a/src/libcore/any.rs
+++ b/src/libcore/any.rs
@@ -452,7 +452,9 @@ impl TypeId {
 /// `"std::option::Option<std::string::String>"`.
 ///
 /// The returned string must not be considered to be a unique identifier of a
-/// type as multiple types may map to the same type name. In addition, the
+/// type as multiple types may map to the same type name. Similarly, there is no
+/// guarantee that all parts of a type will appear in the returned string: for
+/// example, lifetime specifiers are currently not included. In addition, the
 /// output may change between versions of the compiler.
 ///
 /// The current implementation uses the same infrastructure as compiler

--- a/src/libcore/any.rs
+++ b/src/libcore/any.rs
@@ -448,7 +448,7 @@ impl TypeId {
 /// This is intended for diagnostic use. The exact contents and format of the
 /// string returned are not specified, other than being a best-effort
 /// description of the type. For example, amongst the strings
-/// that `type_name::<Option<String>>()` might map to are `"Option<String>"` and
+/// that `type_name::<Option<String>>()` might return are `"Option<String>"` and
 /// `"std::option::Option<std::string::String>"`.
 ///
 /// The returned string must not be considered to be a unique identifier of a

--- a/src/libcore/any.rs
+++ b/src/libcore/any.rs
@@ -446,8 +446,8 @@ impl TypeId {
 /// # Note
 ///
 /// This is intended for diagnostic use. The exact contents and format of the
-/// string retrned are not specified, other than being a best-effort description
-/// of the type. For example, amongst the strings
+/// string returned are not specified, other than being a best-effort
+/// description of the type. For example, amongst the strings
 /// that `type_name::<Option<String>>()` might map to are `"Option<String>"` and
 /// `"std::option::Option<std::string::String>"`.
 ///


### PR DESCRIPTION
The first commit in this PR rephrases the current documentation for `any::type_name()` to be a little more specific about the guarantees (or lack thereof) that this function makes. The second commit explicitly documents that lifetimes are currently not included in the output (since this bit me particularly hard recently).