### PR TITLE
Update RLS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3503,11 +3503,14 @@ name = "rustc-workspace-hack"
 version = "1.0.0"
 dependencies = [
  "crossbeam-utils 0.7.2",
+ "proc-macro2 1.0.3",
+ "quote 1.0.2",
  "serde",
  "serde_json",
  "smallvec 0.6.10",
  "smallvec 1.4.0",
  "syn 0.15.35",
+ "syn 1.0.11",
  "url 2.1.0",
  "winapi 0.3.8",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3102,7 +3102,6 @@ version = "0.6.0"
 dependencies = [
  "clippy_lints",
  "env_logger 0.7.1",
- "failure",
  "futures",
  "log",
  "rand 0.7.3",

--- a/src/tools/rustc-workspace-hack/Cargo.toml
+++ b/src/tools/rustc-workspace-hack/Cargo.toml
@@ -60,12 +60,15 @@ features = [
 [dependencies]
 curl-sys = { version = "0.4.13", features = ["http2", "libnghttp2-sys"], optional = true }
 crossbeam-utils = { version = "0.7.2", features = ["nightly"] }
+proc-macro2 = { version = "1", features = ["default"] }
+quote = { version = "1", features = ["default"] }
 serde = { version = "1.0.82", features = ['derive'] }
 serde_json = { version = "1.0.31", features = ["raw_value"] }
 smallvec-0_6 = { package = "smallvec", version = "0.6", features = ['union', 'may_dangle'] }
 smallvec = { version = "1.0", features = ['union', 'may_dangle'] }
-url = { version = "2.0", features = ['serde'] }
 syn = { version = "0.15", features = ['full', 'extra-traits'] }
+syn-1 = { package = "syn", version = "1", features = ['fold', 'full', 'extra-traits', 'visit'] }
+url = { version = "2.0", features = ['serde'] }
 
 [target.'cfg(not(windows))'.dependencies]
 openssl = { version = "0.10.12", optional = true }

--- a/src/tools/rustc-workspace-hack/Cargo.toml
+++ b/src/tools/rustc-workspace-hack/Cargo.toml
@@ -17,6 +17,8 @@ path = "lib.rs"
 [target.'cfg(windows)'.dependencies.winapi]
 version = "0.3"
 features = [
+  "aclapi",
+  "accctrl",
   "basetsd",
   "consoleapi",
   "errhandlingapi",
@@ -72,7 +74,6 @@ url = { version = "2.0", features = ['serde'] }
 
 [target.'cfg(not(windows))'.dependencies]
 openssl = { version = "0.10.12", optional = true }
-
 
 [features]
 all-static = ['openssl/vendored', 'curl-sys/static-curl', 'curl-sys/force-system-lib-on-osx']


### PR DESCRIPTION
In addition to fixing the toolstate, this also changes the default
compilation model to the out-of-process one, which should hopefully
target considerable memory usage for long-running instances of the RLS.

Fixes #71753

r? @ghost