### PR TITLE
Use f64 in f64 examples

### DIFF
--- a/src/libcore/num/f64.rs
+++ b/src/libcore/num/f64.rs
@@ -474,11 +474,11 @@ impl f64 {
     /// assuming that the value is finite and fits in that type.
     ///
     /// ```
-    /// let value = 4.6_f32;
+    /// let value = 4.6_f64;
     /// let rounded = unsafe { value.to_int_unchecked::<u16>() };
     /// assert_eq!(rounded, 4);
     ///
-    /// let value = -128.9_f32;
+    /// let value = -128.9_f64;
     /// let rounded = unsafe { value.to_int_unchecked::<i8>() };
     /// assert_eq!(rounded, i8::MIN);
     /// ```


### PR DESCRIPTION
I believe that this is a copy/paste error; this example was using f32,
but it's the docs for f64.