### PR TITLE
Correctly handle UEFI targets as Windows-like when emitting sections for LLVM bitcode

### DIFF
--- a/src/librustc_codegen_llvm/back/write.rs
+++ b/src/librustc_codegen_llvm/back/write.rs
@@ -853,7 +853,9 @@ unsafe fn embed_bitcode(
         || cgcx.opts.target_triple.triple().starts_with("asmjs")
     {
         // nothing to do here
-    } else if cgcx.opts.target_triple.triple().contains("windows") {
+    } else if cgcx.opts.target_triple.triple().contains("windows")
+        || cgcx.opts.target_triple.triple().contains("uefi")
+    {
         let asm = "
             .section .llvmbc,\"n\"
             .section .llvmcmd,\"n\"


### PR DESCRIPTION
This handles UEFI handles when emitting inline assembly for sections containing LLVM bitcode. See details in #71880. I have locally confirmed that this change fixes compilation of projects using the `x86_64-unknown-uefi` target compiling with `cargo-xbuild`, but I am not very familiar with LLVM bitcode so this may not be the correct approach.

r? @alexcrichton as they wrote the initial LLVM bitcode emitting code?