### PR TITLE
Suggest removing semicolon in last expression only if it's type is known

### DIFF
--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -5387,7 +5387,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             _ => return None,
         };
         let last_expr_ty = self.node_ty(last_expr.hir_id);
-        if self.can_sub(self.param_env, last_expr_ty, expected_ty).is_err() {
+        if matches!(last_expr_ty.kind, ty::Error)
+            || self.can_sub(self.param_env, last_expr_ty, expected_ty).is_err()
+        {
             return None;
         }
         let original_span = original_sp(last_stmt.span, blk.span);

--- a/src/test/ui/issues/issue-43162.stderr
+++ b/src/test/ui/issues/issue-43162.stderr
@@ -17,9 +17,6 @@ LL | fn foo() -> bool {
    |    ---      ^^^^ expected `bool`, found `()`
    |    |
    |    implicitly returns `()` as its body has no tail or `return` expression
-LL |
-LL |     break true;
-   |               - help: consider removing this semicolon
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/typeck/issue-67971.rs
+++ b/src/test/ui/typeck/issue-67971.rs
@@ -1,0 +1,9 @@
+struct S {}
+
+fn foo(ctx: &mut S) -> String { //~ ERROR mismatched types
+    // Don't suggest to remove semicolon as it won't fix anything
+    ctx.sleep = 0;
+    //~^ ERROR no field `sleep` on type `&mut S`
+}
+
+fn main() {}

--- a/src/test/ui/typeck/issue-67971.stderr
+++ b/src/test/ui/typeck/issue-67971.stderr
@@ -1,0 +1,18 @@
+error[E0609]: no field `sleep` on type `&mut S`
+  --> $DIR/issue-67971.rs:5:9
+   |
+LL |     ctx.sleep = 0;
+   |         ^^^^^ unknown field
+
+error[E0308]: mismatched types
+  --> $DIR/issue-67971.rs:3:24
+   |
+LL | fn foo(ctx: &mut S) -> String {
+   |    ---                 ^^^^^^ expected struct `std::string::String`, found `()`
+   |    |
+   |    implicitly returns `()` as its body has no tail or `return` expression
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0308, E0609.
+For more information about an error, try `rustc --explain E0308`.


### PR DESCRIPTION
Fixes #67971

Is there a syntax for explicitly checking if a note doesn't exist in test output? Something like `//~ !NOTE ...`

I believe r? @estebank deals with diagnostics.