### PR TITLE
reword "possible candidate" import suggestion

### DIFF
--- a/src/librustc_resolve/late/diagnostics.rs
+++ b/src/librustc_resolve/late/diagnostics.rs
@@ -873,7 +873,10 @@ impl<'a> LateResolutionVisitor<'a, '_, '_> {
                     let module_def_id = module.def_id().unwrap();
                     if module_def_id == def_id {
                         let path = Path { span: name_binding.span, segments: path_segments };
-                        result = Some((module, ImportSuggestion { did: Some(def_id), path }));
+                        result = Some((
+                            module,
+                            ImportSuggestion { did: Some(def_id), descr: "module", path },
+                        ));
                     } else {
                         // add the module to the lookup
                         if seen_modules.insert(module_def_id) {

--- a/src/test/ui/class-missing-self.stderr
+++ b/src/test/ui/class-missing-self.stderr
@@ -10,7 +10,7 @@ error[E0425]: cannot find function `sleep` in this scope
 LL |       sleep();
    |       ^^^^^ not found in this scope
    |
-help: possible candidate is found in another module, you can import it into scope
+help: consider importing this function
    |
 LL | use std::thread::sleep;
    |

--- a/src/test/ui/crate-in-paths.stderr
+++ b/src/test/ui/crate-in-paths.stderr
@@ -4,7 +4,7 @@ error[E0425]: cannot find value `Foo` in this scope
 LL |     Foo;
    |     ^^^ not found in this scope
    |
-help: possible candidate is found in another module, you can import it into scope
+help: consider importing this unit struct
    |
 LL | use crate::bar::Foo;
    |

--- a/src/test/ui/did_you_mean/issue-56028-there-is-an-enum-variant.stderr
+++ b/src/test/ui/did_you_mean/issue-56028-there-is-an-enum-variant.stderr
@@ -22,7 +22,7 @@ error[E0425]: cannot find value `Set` in this scope
 LL | fn setup() -> Set { Set }
    |                     ^^^ not found in this scope
    |
-help: possible candidates are found in other modules, you can import them into scope
+help: consider importing one of these items
    |
 LL | use AffixHeart::Set;
    |

--- a/src/test/ui/glob-resolve1.stderr
+++ b/src/test/ui/glob-resolve1.stderr
@@ -4,7 +4,7 @@ error[E0425]: cannot find function `fpriv` in this scope
 LL |     fpriv();
    |     ^^^^^ not found in this scope
    |
-help: possible candidate is found in another module, you can import it into scope
+help: consider importing this function
    |
 LL | use bar::fpriv;
    |
@@ -15,7 +15,7 @@ error[E0425]: cannot find function `epriv` in this scope
 LL |     epriv();
    |     ^^^^^ not found in this scope
    |
-help: possible candidate is found in another module, you can import it into scope
+help: consider importing this function
    |
 LL | use bar::epriv;
    |
@@ -32,7 +32,7 @@ error[E0425]: cannot find value `C` in this scope
 LL |     C;
    |     ^ not found in this scope
    |
-help: possible candidate is found in another module, you can import it into scope
+help: consider importing this unit struct
    |
 LL | use bar::C;
    |
@@ -56,7 +56,7 @@ help: an enum with a similar name exists
    |
 LL |     foo::<B>();
    |           ^
-help: possible candidate is found in another module, you can import it into scope
+help: consider importing this enum
    |
 LL | use bar::A;
    |
@@ -74,7 +74,7 @@ help: an enum with a similar name exists
    |
 LL |     foo::<B>();
    |           ^
-help: possible candidate is found in another module, you can import it into scope
+help: consider importing this struct
    |
 LL | use bar::C;
    |
@@ -92,7 +92,7 @@ help: an enum with a similar name exists
    |
 LL |     foo::<B>();
    |           ^
-help: possible candidate is found in another module, you can import it into scope
+help: consider importing this type alias
    |
 LL | use bar::D;
    |

--- a/src/test/ui/hygiene/globs.stderr
+++ b/src/test/ui/hygiene/globs.stderr
@@ -4,7 +4,7 @@ error[E0425]: cannot find function `f` in this scope
 LL |         f();
    |         ^ not found in this scope
    |
-help: possible candidate is found in another module, you can import it into scope
+help: consider importing one of these items
    |
 LL | use foo::f;
    |
@@ -23,7 +23,7 @@ LL | |     }
    | |_____- in this macro invocation
    |
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
-help: possible candidates are found in other modules, you can import them into scope
+help: consider importing one of these items
    |
 LL | use bar::g;
    |
@@ -41,7 +41,7 @@ LL | n!(f);
 LL |         n!(f);
    |            ^ not found in this scope
    |
-   = note: possible candidate is found in another module, you can import it into scope:
+   = note: consider importing one of these items:
            foo::f
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -54,7 +54,7 @@ LL | n!(f);
 LL |                 f
    |                 ^ not found in this scope
    |
-   = note: possible candidate is found in another module, you can import it into scope:
+   = note: consider importing one of these items:
            foo::f
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/impl-trait/universal_wrong_bounds.stderr
+++ b/src/test/ui/impl-trait/universal_wrong_bounds.stderr
@@ -4,7 +4,7 @@ error[E0404]: expected trait, found derive macro `Debug`
 LL | fn wants_debug(g: impl Debug) { }
    |                        ^^^^^ not a trait
    |
-help: possible better candidate is found in another module, you can import it into scope
+help: consider importing this trait instead
    |
 LL | use std::fmt::Debug;
    |
@@ -15,7 +15,7 @@ error[E0404]: expected trait, found derive macro `Debug`
 LL | fn wants_display(g: impl Debug) { }
    |                          ^^^^^ not a trait
    |
-help: possible better candidate is found in another module, you can import it into scope
+help: consider importing this trait instead
    |
 LL | use std::fmt::Debug;
    |

--- a/src/test/ui/issues/issue-17546.stderr
+++ b/src/test/ui/issues/issue-17546.stderr
@@ -24,7 +24,7 @@ error[E0573]: expected type, found variant `Result`
 LL |     fn new() -> Result<foo::MyEnum, String> {
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ not a type
    |
-help: possible better candidates are found in other modules, you can import them into scope
+help: consider importing one of these items instead
    |
 LL |     use std::fmt::Result;
    |
@@ -42,7 +42,7 @@ error[E0573]: expected type, found variant `Result`
 LL | fn new() -> Result<foo::MyEnum, String> {
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^ not a type
    |
-help: possible better candidates are found in other modules, you can import them into scope
+help: consider importing one of these items instead
    |
 LL | use std::fmt::Result;
    |

--- a/src/test/ui/issues/issue-35675.stderr
+++ b/src/test/ui/issues/issue-35675.stderr
@@ -15,7 +15,7 @@ error[E0425]: cannot find function, tuple struct or tuple variant `Apple` in thi
 LL |     Apple(5)
    |     ^^^^^ not found in this scope
    |
-help: possible candidate is found in another module, you can import it into scope
+help: consider importing this tuple variant
    |
 LL | use Fruit::Apple;
    |
@@ -35,7 +35,7 @@ error[E0425]: cannot find function, tuple struct or tuple variant `Apple` in thi
 LL |     Apple(5)
    |     ^^^^^ not found in this scope
    |
-help: possible candidate is found in another module, you can import it into scope
+help: consider importing this tuple variant
    |
 LL | use Fruit::Apple;
    |

--- a/src/test/ui/issues/issue-37534.stderr
+++ b/src/test/ui/issues/issue-37534.stderr
@@ -4,7 +4,7 @@ error[E0404]: expected trait, found derive macro `Hash`
 LL | struct Foo<T: ?Hash> { }
    |                ^^^^ not a trait
    |
-help: possible better candidate is found in another module, you can import it into scope
+help: consider importing this trait instead
    |
 LL | use std::hash::Hash;
    |

--- a/src/test/ui/issues/issue-38293.stderr
+++ b/src/test/ui/issues/issue-38293.stderr
@@ -10,7 +10,7 @@ error[E0423]: expected function, found module `baz`
 LL |     baz();
    |     ^^^ not a function
    |
-help: possible better candidate is found in another module, you can import it into scope
+help: consider importing this function instead
    |
 LL | use bar::baz;
    |

--- a/src/test/ui/issues/issue-42944.stderr
+++ b/src/test/ui/issues/issue-42944.stderr
@@ -10,7 +10,7 @@ error[E0425]: cannot find function, tuple struct or tuple variant `B` in this sc
 LL |         B(());
    |         ^ not found in this scope
    |
-help: possible candidate is found in another module, you can import it into scope
+help: consider importing this tuple struct
    |
 LL |     use foo::B;
    |

--- a/src/test/ui/issues/issue-4366-2.stderr
+++ b/src/test/ui/issues/issue-4366-2.stderr
@@ -4,7 +4,7 @@ error[E0412]: cannot find type `Bar` in this scope
 LL |         fn sub() -> Bar { 1 }
    |                     ^^^ not found in this scope
    |
-help: possible candidate is found in another module, you can import it into scope
+help: consider importing this type alias
    |
 LL |         use a::b::Bar;
    |
@@ -15,7 +15,7 @@ error[E0423]: expected function, found module `foo`
 LL |     foo();
    |     ^^^ not a function
    |
-help: possible better candidates are found in other modules, you can import them into scope
+help: consider importing one of these items instead
    |
 LL | use foo::foo;
    |

--- a/src/test/ui/issues/issue-4366.stderr
+++ b/src/test/ui/issues/issue-4366.stderr
@@ -4,7 +4,7 @@ error[E0425]: cannot find function `foo` in this scope
 LL |         fn sub() -> isize { foo(); 1 }
    |                             ^^^ not found in this scope
    |
-help: possible candidates are found in other modules, you can import them into scope
+help: consider importing one of these items
    |
 LL |         use foo::foo;
    |

--- a/src/test/ui/issues/issue-50599.stderr
+++ b/src/test/ui/issues/issue-50599.stderr
@@ -4,7 +4,7 @@ error[E0425]: cannot find value `LOG10_2` in module `std::f64`
 LL |     const M: usize = (f64::from(N) * std::f64::LOG10_2) as usize;
    |                                                ^^^^^^^ not found in `std::f64`
    |
-help: possible candidates are found in other modules, you can import them into scope
+help: consider importing one of these items
    |
 LL | use std::f32::consts::LOG10_2;
    |

--- a/src/test/ui/lexical-scopes.stderr
+++ b/src/test/ui/lexical-scopes.stderr
@@ -4,7 +4,7 @@ error[E0574]: expected struct, variant or union type, found type parameter `T`
 LL |     let t = T { i: 0 };
    |             ^ not a struct, variant or union type
    |
-help: possible better candidate is found in another module, you can import it into scope
+help: consider importing this struct instead
    |
 LL | use T;
    |

--- a/src/test/ui/lint/use_suggestion_json.stderr
+++ b/src/test/ui/lint/use_suggestion_json.stderr
@@ -94,7 +94,7 @@ mod foo {
   ],
   "children": [
     {
-      "message": "possible candidates are found in other modules, you can import them into scope",
+      "message": "consider importing one of these items",
       "code": null,
       "level": "help",
       "spans": [
@@ -385,7 +385,7 @@ mod foo {
 \u001b[0m\u001b[1m\u001b[38;5;12mLL\u001b[0m\u001b[0m \u001b[0m\u001b[0m\u001b[1m\u001b[38;5;12m| \u001b[0m\u001b[0m    let x: Iter;\u001b[0m
 \u001b[0m   \u001b[0m\u001b[0m\u001b[1m\u001b[38;5;12m| \u001b[0m\u001b[0m           \u001b[0m\u001b[0m\u001b[1m\u001b[38;5;9m^^^^\u001b[0m\u001b[0m \u001b[0m\u001b[0m\u001b[1m\u001b[38;5;9mnot found in this scope\u001b[0m
 \u001b[0m   \u001b[0m\u001b[0m\u001b[1m\u001b[38;5;12m|\u001b[0m
-\u001b[0m\u001b[1m\u001b[38;5;14mhelp\u001b[0m\u001b[0m: possible candidates are found in other modules, you can import them into scope\u001b[0m
+\u001b[0m\u001b[1m\u001b[38;5;14mhelp\u001b[0m\u001b[0m: consider importing one of these items\u001b[0m
 \u001b[0m   \u001b[0m\u001b[0m\u001b[1m\u001b[38;5;12m|\u001b[0m
 \u001b[0m\u001b[1m\u001b[38;5;12mLL\u001b[0m\u001b[0m \u001b[0m\u001b[0m\u001b[1m\u001b[38;5;12m| \u001b[0m\u001b[0muse std::collections::binary_heap::Iter;\u001b[0m
 \u001b[0m   \u001b[0m\u001b[0m\u001b[1m\u001b[38;5;12m|\u001b[0m

--- a/src/test/ui/macros/macro-outer-attributes.stderr
+++ b/src/test/ui/macros/macro-outer-attributes.stderr
@@ -4,7 +4,7 @@ error[E0425]: cannot find function `bar` in module `a`
 LL |     a::bar();
    |        ^^^ not found in `a`
    |
-help: possible candidate is found in another module, you can import it into scope
+help: consider importing this function
    |
 LL | use b::bar;
    |

--- a/src/test/ui/namespace/namespace-mix.stderr
+++ b/src/test/ui/namespace/namespace-mix.stderr
@@ -12,7 +12,7 @@ help: a tuple struct with a similar name exists
    |
 LL |     check(m1::TS);
    |               ^^
-help: possible better candidates are found in other modules, you can import them into scope
+help: consider importing one of these items instead
    |
 LL | use m2::S;
    |
@@ -35,7 +35,7 @@ help: a tuple struct with a similar name exists
    |
 LL |     check(xm1::TS);
    |                ^^
-help: possible better candidates are found in other modules, you can import them into scope
+help: consider importing one of these items instead
    |
 LL | use m2::S;
    |
@@ -57,7 +57,7 @@ help: a tuple variant with a similar name exists
    |
 LL |     check(m7::TV);
    |               ^^
-help: possible better candidates are found in other modules, you can import them into scope
+help: consider importing one of these items instead
    |
 LL | use m8::V;
    |
@@ -79,7 +79,7 @@ help: a tuple variant with a similar name exists
    |
 LL |     check(xm7::TV);
    |                ^^
-help: possible better candidates are found in other modules, you can import them into scope
+help: consider importing one of these items instead
    |
 LL | use m8::V;
    |

--- a/src/test/ui/no-implicit-prelude-nested.stderr
+++ b/src/test/ui/no-implicit-prelude-nested.stderr
@@ -4,7 +4,7 @@ error[E0405]: cannot find trait `Add` in this scope
 LL |         impl Add for Test {}
    |              ^^^ not found in this scope
    |
-help: possible candidate is found in another module, you can import it into scope
+help: consider importing this trait
    |
 LL |         use std::ops::Add;
    |
@@ -15,7 +15,7 @@ error[E0404]: expected trait, found derive macro `Clone`
 LL |         impl Clone for Test {}
    |              ^^^^^ not a trait
    |
-help: possible better candidates are found in other modules, you can import them into scope
+help: consider importing one of these items instead
    |
 LL |         use std::clone::Clone;
    |
@@ -28,7 +28,7 @@ error[E0405]: cannot find trait `Iterator` in this scope
 LL |         impl Iterator for Test {}
    |              ^^^^^^^^ not found in this scope
    |
-help: possible candidates are found in other modules, you can import them into scope
+help: consider importing one of these items
    |
 LL |         use std::iter::Iterator;
    |
@@ -41,7 +41,7 @@ error[E0405]: cannot find trait `ToString` in this scope
 LL |         impl ToString for Test {}
    |              ^^^^^^^^ not found in this scope
    |
-help: possible candidates are found in other modules, you can import them into scope
+help: consider importing one of these items
    |
 LL |         use std::prelude::v1::ToString;
    |
@@ -60,7 +60,7 @@ error[E0425]: cannot find function `drop` in this scope
 LL |             drop(2)
    |             ^^^^ not found in this scope
    |
-help: possible candidates are found in other modules, you can import them into scope
+help: consider importing one of these items
    |
 LL |         use std::mem::drop;
    |
@@ -73,7 +73,7 @@ error[E0405]: cannot find trait `Add` in this scope
 LL |     impl Add for Test {}
    |          ^^^ not found in this scope
    |
-help: possible candidate is found in another module, you can import it into scope
+help: consider importing this trait
    |
 LL |     use std::ops::Add;
    |
@@ -84,7 +84,7 @@ error[E0404]: expected trait, found derive macro `Clone`
 LL |     impl Clone for Test {}
    |          ^^^^^ not a trait
    |
-help: possible better candidates are found in other modules, you can import them into scope
+help: consider importing one of these items instead
    |
 LL |     use std::clone::Clone;
    |
@@ -97,7 +97,7 @@ error[E0405]: cannot find trait `Iterator` in this scope
 LL |     impl Iterator for Test {}
    |          ^^^^^^^^ not found in this scope
    |
-help: possible candidates are found in other modules, you can import them into scope
+help: consider importing one of these items
    |
 LL |     use std::iter::Iterator;
    |
@@ -110,7 +110,7 @@ error[E0405]: cannot find trait `ToString` in this scope
 LL |     impl ToString for Test {}
    |          ^^^^^^^^ not found in this scope
    |
-help: possible candidates are found in other modules, you can import them into scope
+help: consider importing one of these items
    |
 LL |     use std::prelude::v1::ToString;
    |
@@ -129,7 +129,7 @@ error[E0425]: cannot find function `drop` in this scope
 LL |         drop(2)
    |         ^^^^ not found in this scope
    |
-help: possible candidates are found in other modules, you can import them into scope
+help: consider importing one of these items
    |
 LL |     use std::mem::drop;
    |
@@ -142,7 +142,7 @@ error[E0405]: cannot find trait `Add` in this scope
 LL |         impl Add for Test {}
    |              ^^^ not found in this scope
    |
-help: possible candidate is found in another module, you can import it into scope
+help: consider importing this trait
    |
 LL |         use std::ops::Add;
    |
@@ -153,7 +153,7 @@ error[E0404]: expected trait, found derive macro `Clone`
 LL |         impl Clone for Test {}
    |              ^^^^^ not a trait
    |
-help: possible better candidates are found in other modules, you can import them into scope
+help: consider importing one of these items instead
    |
 LL |         use std::clone::Clone;
    |
@@ -166,7 +166,7 @@ error[E0405]: cannot find trait `Iterator` in this scope
 LL |         impl Iterator for Test {}
    |              ^^^^^^^^ not found in this scope
    |
-help: possible candidates are found in other modules, you can import them into scope
+help: consider importing one of these items
    |
 LL |         use std::iter::Iterator;
    |
@@ -179,7 +179,7 @@ error[E0405]: cannot find trait `ToString` in this scope
 LL |         impl ToString for Test {}
    |              ^^^^^^^^ not found in this scope
    |
-help: possible candidates are found in other modules, you can import them into scope
+help: consider importing one of these items
    |
 LL |         use std::prelude::v1::ToString;
    |
@@ -198,7 +198,7 @@ error[E0425]: cannot find function `drop` in this scope
 LL |             drop(2)
    |             ^^^^ not found in this scope
    |
-help: possible candidates are found in other modules, you can import them into scope
+help: consider importing one of these items
    |
 LL |         use std::mem::drop;
    |

--- a/src/test/ui/no-implicit-prelude.stderr
+++ b/src/test/ui/no-implicit-prelude.stderr
@@ -4,7 +4,7 @@ error[E0405]: cannot find trait `Add` in this scope
 LL | impl Add for Test {}
    |      ^^^ not found in this scope
    |
-help: possible candidate is found in another module, you can import it into scope
+help: consider importing this trait
    |
 LL | use std::ops::Add;
    |
@@ -15,7 +15,7 @@ error[E0404]: expected trait, found derive macro `Clone`
 LL | impl Clone for Test {}
    |      ^^^^^ not a trait
    |
-help: possible better candidates are found in other modules, you can import them into scope
+help: consider importing one of these items instead
    |
 LL | use std::clone::Clone;
    |
@@ -28,7 +28,7 @@ error[E0405]: cannot find trait `Iterator` in this scope
 LL | impl Iterator for Test {}
    |      ^^^^^^^^ not found in this scope
    |
-help: possible candidates are found in other modules, you can import them into scope
+help: consider importing one of these items
    |
 LL | use std::iter::Iterator;
    |
@@ -41,7 +41,7 @@ error[E0405]: cannot find trait `ToString` in this scope
 LL | impl ToString for Test {}
    |      ^^^^^^^^ not found in this scope
    |
-help: possible candidates are found in other modules, you can import them into scope
+help: consider importing one of these items
    |
 LL | use std::prelude::v1::ToString;
    |
@@ -60,7 +60,7 @@ error[E0425]: cannot find function `drop` in this scope
 LL |     drop(2)
    |     ^^^^ not found in this scope
    |
-help: possible candidates are found in other modules, you can import them into scope
+help: consider importing one of these items
    |
 LL | use std::mem::drop;
    |

--- a/src/test/ui/parser/circular_modules_main.stderr
+++ b/src/test/ui/parser/circular_modules_main.stderr
@@ -10,7 +10,7 @@ error[E0425]: cannot find function `say_hello` in module `circular_modules_hello
 LL |     circular_modules_hello::say_hello();
    |                             ^^^^^^^^^ not found in `circular_modules_hello`
    |
-help: possible candidate is found in another module, you can import it into scope
+help: consider importing this function
    |
 LL | use circular_modules_hello::say_hello;
    |

--- a/src/test/ui/privacy/privacy-ns1.stderr
+++ b/src/test/ui/privacy/privacy-ns1.stderr
@@ -11,7 +11,7 @@ help: a unit struct with a similar name exists
    |
 LL |     Baz();
    |     ^^^
-help: possible better candidates are found in other modules, you can import them into scope
+help: consider importing one of these items instead
    |
 LL | use foo1::Bar;
    |
@@ -33,7 +33,7 @@ help: a unit struct with a similar name exists
    |
 LL |     Baz();
    |     ^^^
-help: possible candidates are found in other modules, you can import them into scope
+help: consider importing one of these items
    |
 LL | use foo1::Bar;
    |
@@ -55,7 +55,7 @@ help: a struct with a similar name exists
    |
 LL |     let _x: Box<Baz>;
    |                 ^^^
-help: possible candidates are found in other modules, you can import them into scope
+help: consider importing one of these items
    |
 LL | use foo1::Bar;
    |

--- a/src/test/ui/privacy/privacy-ns2.stderr
+++ b/src/test/ui/privacy/privacy-ns2.stderr
@@ -4,7 +4,7 @@ error[E0423]: expected function, tuple struct or tuple variant, found trait `Bar
 LL |     Bar();
    |     ^^^ not a function, tuple struct or tuple variant
    |
-help: possible better candidates are found in other modules, you can import them into scope
+help: consider importing one of these items instead
    |
 LL | use foo1::Bar;
    |
@@ -26,7 +26,7 @@ help: a unit struct with a similar name exists
    |
 LL |     Baz();
    |     ^^^
-help: possible better candidates are found in other modules, you can import them into scope
+help: consider importing one of these items instead
    |
 LL | use foo1::Bar;
    |
@@ -45,7 +45,7 @@ help: use `=` if you meant to assign
    |
 LL |     let _x = Bar();
    |            ^
-help: possible better candidates are found in other modules, you can import them into scope
+help: consider importing one of these items instead
    |
 LL | use foo1::Bar;
    |

--- a/src/test/ui/proc-macro/attributes-on-modules-fail.stderr
+++ b/src/test/ui/proc-macro/attributes-on-modules-fail.stderr
@@ -50,7 +50,7 @@ help: a type alias with a similar name exists
    |
 LL |     type A = A;
    |              ^
-help: possible candidate is found in another module, you can import it into scope
+help: consider importing this struct
    |
 LL |     use Y;
    |
@@ -65,7 +65,7 @@ help: a type alias with a similar name exists
    |
 LL | type A = A;
    |          ^
-help: possible candidate is found in another module, you can import it into scope
+help: consider importing this struct
    |
 LL | use m::X;
    |

--- a/src/test/ui/proc-macro/generate-mod.stderr
+++ b/src/test/ui/proc-macro/generate-mod.stderr
@@ -4,7 +4,7 @@ error[E0412]: cannot find type `FromOutside` in this scope
 LL | generate_mod::check!();
    | ^^^^^^^^^^^^^^^^^^^^^^^ not found in this scope
    |
-   = note: possible candidate is found in another module, you can import it into scope:
+   = note: consider importing this struct:
            FromOutside
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -14,7 +14,7 @@ error[E0412]: cannot find type `Outer` in this scope
 LL | generate_mod::check!();
    | ^^^^^^^^^^^^^^^^^^^^^^^ not found in this scope
    |
-   = note: possible candidate is found in another module, you can import it into scope:
+   = note: consider importing this struct:
            Outer
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -24,7 +24,7 @@ error[E0412]: cannot find type `FromOutside` in this scope
 LL | #[generate_mod::check_attr]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ not found in this scope
    |
-   = note: possible candidate is found in another module, you can import it into scope:
+   = note: consider importing this struct:
            FromOutside
    = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -34,7 +34,7 @@ error[E0412]: cannot find type `OuterAttr` in this scope
 LL | #[generate_mod::check_attr]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ not found in this scope
    |
-   = note: possible candidate is found in another module, you can import it into scope:
+   = note: consider importing this struct:
            OuterAttr
    = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/proc-macro/mixed-site-span.stderr
+++ b/src/test/ui/proc-macro/mixed-site-span.stderr
@@ -27,7 +27,7 @@ LL | pass_dollar_crate!();
    | ^^^^^^^^^^^^^^^^^^^^^ not found in `$crate`
    |
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
-help: possible candidate is found in another module, you can import it into scope
+help: consider importing this struct
    |
 LL | use ItemUse;
    |

--- a/src/test/ui/resolve/enums-are-namespaced-xc.stderr
+++ b/src/test/ui/resolve/enums-are-namespaced-xc.stderr
@@ -4,7 +4,7 @@ error[E0425]: cannot find value `A` in crate `namespaced_enums`
 LL |     let _ = namespaced_enums::A;
    |                               ^ not found in `namespaced_enums`
    |
-help: possible candidate is found in another module, you can import it into scope
+help: consider importing this unit variant
    |
 LL | use namespaced_enums::Foo::A;
    |
@@ -15,7 +15,7 @@ error[E0425]: cannot find function, tuple struct or tuple variant `B` in crate `
 LL |     let _ = namespaced_enums::B(10);
    |                               ^ not found in `namespaced_enums`
    |
-help: possible candidate is found in another module, you can import it into scope
+help: consider importing this tuple variant
    |
 LL | use namespaced_enums::Foo::B;
    |
@@ -26,7 +26,7 @@ error[E0422]: cannot find struct, variant or union type `C` in crate `namespaced
 LL |     let _ = namespaced_enums::C { a: 10 };
    |                               ^ not found in `namespaced_enums`
    |
-help: possible candidate is found in another module, you can import it into scope
+help: consider importing this variant
    |
 LL | use namespaced_enums::Foo::C;
    |

--- a/src/test/ui/resolve/issue-16058.stderr
+++ b/src/test/ui/resolve/issue-16058.stderr
@@ -4,7 +4,7 @@ error[E0574]: expected struct, variant or union type, found enum `Result`
 LL |         Result {
    |         ^^^^^^ not a struct, variant or union type
    |
-help: possible better candidates are found in other modules, you can import them into scope
+help: consider importing one of these items instead
    |
 LL | use std::fmt::Result;
    |

--- a/src/test/ui/resolve/issue-17518.stderr
+++ b/src/test/ui/resolve/issue-17518.stderr
@@ -4,7 +4,7 @@ error[E0422]: cannot find struct, variant or union type `E` in this scope
 LL |     E { name: "foobar" };
    |     ^ not found in this scope
    |
-help: possible candidate is found in another module, you can import it into scope
+help: consider importing this variant
    |
 LL | use SomeEnum::E;
    |

--- a/src/test/ui/resolve/issue-21221-1.stderr
+++ b/src/test/ui/resolve/issue-21221-1.stderr
@@ -4,7 +4,7 @@ error[E0405]: cannot find trait `Mul` in this scope
 LL | impl Mul for Foo {
    |      ^^^ not found in this scope
    |
-help: possible candidates are found in other modules, you can import them into scope
+help: consider importing one of these items
    |
 LL | use mul1::Mul;
    |
@@ -19,7 +19,7 @@ error[E0412]: cannot find type `Mul` in this scope
 LL | fn getMul() -> Mul {
    |                ^^^ not found in this scope
    |
-help: possible candidates are found in other modules, you can import them into scope
+help: consider importing one of these items
    |
 LL | use mul1::Mul;
    |
@@ -43,7 +43,7 @@ error[E0405]: cannot find trait `Div` in this scope
 LL | impl Div for Foo {
    |      ^^^ not found in this scope
    |
-help: possible candidate is found in another module, you can import it into scope
+help: consider importing this trait
    |
 LL | use std::ops::Div;
    |

--- a/src/test/ui/resolve/issue-21221-2.stderr
+++ b/src/test/ui/resolve/issue-21221-2.stderr
@@ -4,7 +4,7 @@ error[E0405]: cannot find trait `T` in this scope
 LL | impl T for Foo { }
    |      ^ not found in this scope
    |
-help: possible candidate is found in another module, you can import it into scope
+help: consider importing this trait
    |
 LL | use foo::bar::T;
    |

--- a/src/test/ui/resolve/issue-21221-3.stderr
+++ b/src/test/ui/resolve/issue-21221-3.stderr
@@ -4,7 +4,7 @@ error[E0405]: cannot find trait `OuterTrait` in this scope
 LL | impl OuterTrait for Foo {}
    |      ^^^^^^^^^^ not found in this scope
    |
-help: possible candidate is found in another module, you can import it into scope
+help: consider importing this trait
    |
 LL | use issue_21221_3::outer::OuterTrait;
    |

--- a/src/test/ui/resolve/issue-21221-4.stderr
+++ b/src/test/ui/resolve/issue-21221-4.stderr
@@ -4,7 +4,7 @@ error[E0405]: cannot find trait `T` in this scope
 LL | impl T for Foo {}
    |      ^ not found in this scope
    |
-help: possible candidate is found in another module, you can import it into scope
+help: consider importing this trait
    |
 LL | use issue_21221_4::T;
    |

--- a/src/test/ui/resolve/issue-3907.stderr
+++ b/src/test/ui/resolve/issue-3907.stderr
@@ -9,7 +9,7 @@ help: you might have meant to use `#![feature(trait_alias)]` instead of a `type`
    |
 LL | type Foo = dyn issue_3907::Foo;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-help: possible better candidate is found in another module, you can import it into scope
+help: consider importing this trait instead
    |
 LL | use issue_3907::Foo;
    |

--- a/src/test/ui/resolve/privacy-enum-ctor.stderr
+++ b/src/test/ui/resolve/privacy-enum-ctor.stderr
@@ -67,7 +67,7 @@ LL |     let _: E = E::Struct;
    |                ^^^^^^^^^
 LL |     let _: E = E::Unit;
    |                ^^^^^^^
-help: possible better candidates are found in other modules, you can import them into scope
+help: consider importing one of these items instead
    |
 LL | use std::f32::consts::E;
    |
@@ -99,7 +99,7 @@ LL |     let _: E = E::Struct;
    |                ^^^^^^^^^
 LL |     let _: E = E::Unit;
    |                ^^^^^^^
-help: possible better candidates are found in other modules, you can import them into scope
+help: consider importing one of these items instead
    |
 LL | use std::f32::consts::E;
    |
@@ -130,7 +130,7 @@ help: an enum with a similar name exists
    |
 LL |     let _: E = m::n::Z;
    |            ^
-help: possible candidate is found in another module, you can import it into scope
+help: consider importing this enum
    |
 LL | use m::n::Z;
    |
@@ -163,7 +163,7 @@ help: an enum with a similar name exists
    |
 LL |     let _: E = m::n::Z::Fn;
    |            ^
-help: possible candidate is found in another module, you can import it into scope
+help: consider importing this enum
    |
 LL | use m::n::Z;
    |
@@ -181,7 +181,7 @@ help: an enum with a similar name exists
    |
 LL |     let _: E = m::n::Z::Struct;
    |            ^
-help: possible candidate is found in another module, you can import it into scope
+help: consider importing this enum
    |
 LL | use m::n::Z;
    |
@@ -210,7 +210,7 @@ help: an enum with a similar name exists
    |
 LL |     let _: E = m::n::Z::Unit {};
    |            ^
-help: possible candidate is found in another module, you can import it into scope
+help: consider importing this enum
    |
 LL | use m::n::Z;
    |

--- a/src/test/ui/resolve/privacy-struct-ctor.stderr
+++ b/src/test/ui/resolve/privacy-struct-ctor.stderr
@@ -33,7 +33,7 @@ error[E0423]: expected value, found struct `xcrate::S`
 LL |     xcrate::S;
    |     ^^^^^^^^^ constructor is not visible here due to private fields
    |
-help: possible better candidate is found in another module, you can import it into scope
+help: consider importing this tuple struct instead
    |
 LL | use m::S;
    |

--- a/src/test/ui/resolve/resolve-primitive-fallback.stderr
+++ b/src/test/ui/resolve/resolve-primitive-fallback.stderr
@@ -10,7 +10,7 @@ error[E0412]: cannot find type `u8` in the crate root
 LL |     let _: ::u8;
    |              ^^ not found in the crate root
    |
-help: possible candidate is found in another module, you can import it into scope
+help: consider importing this builtin type
    |
 LL | use std::primitive::u8;
    |

--- a/src/test/ui/resolve/use_suggestion_placement.stderr
+++ b/src/test/ui/resolve/use_suggestion_placement.stderr
@@ -4,7 +4,7 @@ error[E0412]: cannot find type `Path` in this scope
 LL |     type Bar = Path;
    |                ^^^^ not found in this scope
    |
-help: possible candidate is found in another module, you can import it into scope
+help: consider importing this struct
    |
 LL |     use std::path::Path;
    |
@@ -15,7 +15,7 @@ error[E0425]: cannot find value `A` in this scope
 LL |     let _ = A;
    |             ^ not found in this scope
    |
-help: possible candidate is found in another module, you can import it into scope
+help: consider importing this constant
    |
 LL | use m::A;
    |
@@ -26,7 +26,7 @@ error[E0412]: cannot find type `HashMap` in this scope
 LL |     type Dict<K, V> = HashMap<K, V>;
    |                       ^^^^^^^ not found in this scope
    |
-help: possible candidates are found in other modules, you can import them into scope
+help: consider importing one of these items
    |
 LL | use std::collections::HashMap;
    |

--- a/src/test/ui/rust-2018/issue-52202-use-suggestions.stderr
+++ b/src/test/ui/rust-2018/issue-52202-use-suggestions.stderr
@@ -4,7 +4,7 @@ error[E0422]: cannot find struct, variant or union type `Drain` in this scope
 LL |     let _d = Drain {};
    |              ^^^^^ not found in this scope
    |
-help: possible candidates are found in other modules, you can import them into scope
+help: consider importing one of these items
    |
 LL | use crate::plumbing::Drain;
    |

--- a/src/test/ui/self/self_type_keyword.stderr
+++ b/src/test/ui/self/self_type_keyword.stderr
@@ -66,7 +66,7 @@ error[E0531]: cannot find unit struct, unit variant or constant `Self` in this s
 LL |         mut Self => (),
    |             ^^^^ not found in this scope
    |
-help: possible candidate is found in another module, you can import it into scope
+help: consider importing this unit struct
    |
 LL | use foo::Self;
    |

--- a/src/test/ui/span/issue-35987.stderr
+++ b/src/test/ui/span/issue-35987.stderr
@@ -4,7 +4,7 @@ error[E0404]: expected trait, found type parameter `Add`
 LL | impl<T: Clone, Add> Add for Foo<T> {
    |                     ^^^ not a trait
    |
-help: possible better candidate is found in another module, you can import it into scope
+help: consider importing this trait instead
    |
 LL | use std::ops::Add;
    |

--- a/src/test/ui/suggestions/no-extern-crate-in-type.stderr
+++ b/src/test/ui/suggestions/no-extern-crate-in-type.stderr
@@ -4,7 +4,7 @@ error[E0412]: cannot find type `Foo` in this scope
 LL | type Output = Option<Foo>;
    |                      ^^^ not found in this scope
    |
-help: possible candidate is found in another module, you can import it into scope
+help: consider importing this struct
    |
 LL | use foo::Foo;
    |

--- a/src/test/ui/suggestions/raw-name-use-suggestion.stderr
+++ b/src/test/ui/suggestions/raw-name-use-suggestion.stderr
@@ -26,7 +26,7 @@ error[E0425]: cannot find function `r#break` in this scope
 LL |     r#break();
    |     ^^^^^^^ not found in this scope
    |
-help: possible candidate is found in another module, you can import it into scope
+help: consider importing this function
    |
 LL | use foo::r#break;
    |

--- a/src/test/ui/use/use-super-global-path.stderr
+++ b/src/test/ui/use/use-super-global-path.stderr
@@ -22,7 +22,7 @@ error[E0425]: cannot find function `main` in this scope
 LL |         main();
    |         ^^^^ not found in this scope
    |
-help: possible candidate is found in another module, you can import it into scope
+help: consider importing this function
    |
 LL |     use main;
    |


### PR DESCRIPTION
This suggestion has always read a bit awkwardly to me, particularly the "possible better candidate" variant.

This commit rewords the suggestion to be more concise and mention the kind of the suggested item. There isn't a nice way to label individual suggestions, so I opted to use "items" in the case of multiple suggestions.