### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/src/liballoc/collections/btree/map.rs
+++ b/src/liballoc/collections/btree/map.rs
@@ -2499,15 +2499,14 @@ impl<'a, K: Ord, V> VacantEntry<'a, K, V> {
     ///
     /// ```
     /// use std::collections::BTreeMap;
+    /// use std::collections::btree_map::Entry;
     ///
-    /// let mut count: BTreeMap<&str, usize> = BTreeMap::new();
+    /// let mut map: BTreeMap<&str, u32> = BTreeMap::new();
     ///
-    /// // count the number of occurrences of letters in the vec
-    /// for x in vec!["a","b","a","c","a","b"] {
-    ///     *count.entry(x).or_insert(0) += 1;
+    /// if let Entry::Vacant(o) = map.entry("poneyland") {
+    ///     o.insert(37);
     /// }
-    ///
-    /// assert_eq!(count["a"], 3);
+    /// assert_eq!(map["poneyland"], 37);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn insert(self, value: V) -> &'a mut V {

--- a/src/libcore/num/f32.rs
+++ b/src/libcore/num/f32.rs
@@ -25,7 +25,7 @@ use crate::num::FpCategory;
 /// // deprecated way
 /// let r = std::f32::RADIX;
 ///
-/// // correct way
+/// // intended way
 /// let r = f32::RADIX;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -40,7 +40,7 @@ pub const RADIX: u32 = f32::RADIX;
 /// // deprecated way
 /// let d = std::f32::MANTISSA_DIGITS;
 ///
-/// // correct way
+/// // intended way
 /// let d = f32::MANTISSA_DIGITS;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -55,7 +55,7 @@ pub const MANTISSA_DIGITS: u32 = f32::MANTISSA_DIGITS;
 /// // deprecated way
 /// let d = std::f32::DIGITS;
 ///
-/// // correct way
+/// // intended way
 /// let d = f32::DIGITS;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -74,7 +74,7 @@ pub const DIGITS: u32 = f32::DIGITS;
 /// // deprecated way
 /// let e = std::f32::EPSILON;
 ///
-/// // correct way
+/// // intended way
 /// let e = f32::EPSILON;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -89,7 +89,7 @@ pub const EPSILON: f32 = f32::EPSILON;
 /// // deprecated way
 /// let min = std::f32::MIN;
 ///
-/// // correct way
+/// // intended way
 /// let min = f32::MIN;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -104,7 +104,7 @@ pub const MIN: f32 = f32::MIN;
 /// // deprecated way
 /// let min = std::f32::MIN_POSITIVE;
 ///
-/// // correct way
+/// // intended way
 /// let min = f32::MIN_POSITIVE;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -119,7 +119,7 @@ pub const MIN_POSITIVE: f32 = f32::MIN_POSITIVE;
 /// // deprecated way
 /// let max = std::f32::MAX;
 ///
-/// // correct way
+/// // intended way
 /// let max = f32::MAX;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -134,7 +134,7 @@ pub const MAX: f32 = f32::MAX;
 /// // deprecated way
 /// let min = std::f32::MIN_EXP;
 ///
-/// // correct way
+/// // intended way
 /// let min = f32::MIN_EXP;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -149,7 +149,7 @@ pub const MIN_EXP: i32 = f32::MIN_EXP;
 /// // deprecated way
 /// let max = std::f32::MAX_EXP;
 ///
-/// // correct way
+/// // intended way
 /// let max = f32::MAX_EXP;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -164,7 +164,7 @@ pub const MAX_EXP: i32 = f32::MAX_EXP;
 /// // deprecated way
 /// let min = std::f32::MIN_10_EXP;
 ///
-/// // correct way
+/// // intended way
 /// let min = f32::MIN_10_EXP;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -179,7 +179,7 @@ pub const MIN_10_EXP: i32 = f32::MIN_10_EXP;
 /// // deprecated way
 /// let max = std::f32::MAX_10_EXP;
 ///
-/// // correct way
+/// // intended way
 /// let max = f32::MAX_10_EXP;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -194,7 +194,7 @@ pub const MAX_10_EXP: i32 = f32::MAX_10_EXP;
 /// // deprecated way
 /// let nan = std::f32::NAN;
 ///
-/// // correct way
+/// // intended way
 /// let nan = f32::NAN;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -209,7 +209,7 @@ pub const NAN: f32 = f32::NAN;
 /// // deprecated way
 /// let inf = std::f32::INFINITY;
 ///
-/// // correct way
+/// // intended way
 /// let inf = f32::INFINITY;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -224,7 +224,7 @@ pub const INFINITY: f32 = f32::INFINITY;
 /// // deprecated way
 /// let ninf = std::f32::NEG_INFINITY;
 ///
-/// // correct way
+/// // intended way
 /// let ninf = f32::NEG_INFINITY;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/libcore/num/f32.rs
+++ b/src/libcore/num/f32.rs
@@ -18,15 +18,45 @@ use crate::num::FpCategory;
 
 /// The radix or base of the internal representation of `f32`.
 /// Use [`f32::RADIX`](../../std/primitive.f32.html#associatedconstant.RADIX) instead.
+///
+/// # Examples
+///
+/// ```rust
+/// // deprecated way
+/// let r = std::f32::RADIX;
+///
+/// // correct way
+/// let r = f32::RADIX;
+/// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 pub const RADIX: u32 = f32::RADIX;
 
 /// Number of significant digits in base 2.
 /// Use [`f32::MANTISSA_DIGITS`](../../std/primitive.f32.html#associatedconstant.MANTISSA_DIGITS) instead.
+///
+/// # Examples
+///
+/// ```rust
+/// // deprecated way
+/// let d = std::f32::MANTISSA_DIGITS;
+///
+/// // correct way
+/// let d = f32::MANTISSA_DIGITS;
+/// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 pub const MANTISSA_DIGITS: u32 = f32::MANTISSA_DIGITS;
 /// Approximate number of significant digits in base 10.
 /// Use [`f32::DIGITS`](../../std/primitive.f32.html#associatedconstant.DIGITS) instead.
+///
+/// # Examples
+///
+/// ```rust
+/// // deprecated way
+/// let d = std::f32::DIGITS;
+///
+/// // correct way
+/// let d = f32::DIGITS;
+/// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 pub const DIGITS: u32 = f32::DIGITS;
 
@@ -36,50 +66,160 @@ pub const DIGITS: u32 = f32::DIGITS;
 /// This is the difference between `1.0` and the next larger representable number.
 ///
 /// [Machine epsilon]: https://en.wikipedia.org/wiki/Machine_epsilon
+///
+/// # Examples
+///
+/// ```rust
+/// // deprecated way
+/// let e = std::f32::EPSILON;
+///
+/// // correct way
+/// let e = f32::EPSILON;
+/// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 pub const EPSILON: f32 = f32::EPSILON;
 
 /// Smallest finite `f32` value.
 /// Use [`f32::MIN`](../../std/primitive.f32.html#associatedconstant.MIN) instead.
+///
+/// # Examples
+///
+/// ```rust
+/// // deprecated way
+/// let min = std::f32::MIN;
+///
+/// // correct way
+/// let min = f32::MIN;
+/// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 pub const MIN: f32 = f32::MIN;
 /// Smallest positive normal `f32` value.
 /// Use [`f32::MIN_POSITIVE`](../../std/primitive.f32.html#associatedconstant.MIN_POSITIVE) instead.
+///
+/// # Examples
+///
+/// ```rust
+/// // deprecated way
+/// let min = std::f32::MIN_POSITIVE;
+///
+/// // correct way
+/// let min = f32::MIN_POSITIVE;
+/// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 pub const MIN_POSITIVE: f32 = f32::MIN_POSITIVE;
 /// Largest finite `f32` value.
 /// Use [`f32::MAX`](../../std/primitive.f32.html#associatedconstant.MAX) instead.
+///
+/// # Examples
+///
+/// ```rust
+/// // deprecated way
+/// let max = std::f32::MAX;
+///
+/// // correct way
+/// let max = f32::MAX;
+/// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 pub const MAX: f32 = f32::MAX;
 
 /// One greater than the minimum possible normal power of 2 exponent.
 /// Use [`f32::MIN_EXP`](../../std/primitive.f32.html#associatedconstant.MIN_EXP) instead.
+///
+/// # Examples
+///
+/// ```rust
+/// // deprecated way
+/// let min = std::f32::MIN_EXP;
+///
+/// // correct way
+/// let min = f32::MIN_EXP;
+/// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 pub const MIN_EXP: i32 = f32::MIN_EXP;
 /// Maximum possible power of 2 exponent.
 /// Use [`f32::MAX_EXP`](../../std/primitive.f32.html#associatedconstant.MAX_EXP) instead.
+///
+/// # Examples
+///
+/// ```rust
+/// // deprecated way
+/// let max = std::f32::MAX_EXP;
+///
+/// // correct way
+/// let max = f32::MAX_EXP;
+/// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 pub const MAX_EXP: i32 = f32::MAX_EXP;
 
 /// Minimum possible normal power of 10 exponent.
 /// Use [`f32::MIN_10_EXP`](../../std/primitive.f32.html#associatedconstant.MIN_10_EXP) instead.
+///
+/// # Examples
+///
+/// ```rust
+/// // deprecated way
+/// let min = std::f32::MIN_10_EXP;
+///
+/// // correct way
+/// let min = f32::MIN_10_EXP;
+/// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 pub const MIN_10_EXP: i32 = f32::MIN_10_EXP;
 /// Maximum possible power of 10 exponent.
 /// Use [`f32::MAX_10_EXP`](../../std/primitive.f32.html#associatedconstant.MAX_10_EXP) instead.
+///
+/// # Examples
+///
+/// ```rust
+/// // deprecated way
+/// let max = std::f32::MAX_10_EXP;
+///
+/// // correct way
+/// let max = f32::MAX_10_EXP;
+/// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 pub const MAX_10_EXP: i32 = f32::MAX_10_EXP;
 
 /// Not a Number (NaN).
 /// Use [`f32::NAN`](../../std/primitive.f32.html#associatedconstant.NAN) instead.
+///
+/// # Examples
+///
+/// ```rust
+/// // deprecated way
+/// let nan = std::f32::NAN;
+///
+/// // correct way
+/// let nan = f32::NAN;
+/// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 pub const NAN: f32 = f32::NAN;
 /// Infinity (∞).
 /// Use [`f32::INFINITY`](../../std/primitive.f32.html#associatedconstant.INFINITY) instead.
+///
+/// # Examples
+///
+/// ```rust
+/// // deprecated way
+/// let inf = std::f32::INFINITY;
+///
+/// // correct way
+/// let inf = f32::INFINITY;
+/// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 pub const INFINITY: f32 = f32::INFINITY;
 /// Negative infinity (−∞).
 /// Use [`f32::NEG_INFINITY`](../../std/primitive.f32.html#associatedconstant.NEG_INFINITY) instead.
+///
+/// # Examples
+///
+/// ```rust
+/// // deprecated way
+/// let ninf = std::f32::NEG_INFINITY;
+///
+/// // correct way
+/// let ninf = f32::NEG_INFINITY;
+/// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 pub const NEG_INFINITY: f32 = f32::NEG_INFINITY;
 

--- a/src/libcore/num/f32.rs
+++ b/src/libcore/num/f32.rs
@@ -45,6 +45,7 @@ pub const RADIX: u32 = f32::RADIX;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 pub const MANTISSA_DIGITS: u32 = f32::MANTISSA_DIGITS;
+
 /// Approximate number of significant digits in base 10.
 /// Use [`f32::DIGITS`](../../std/primitive.f32.html#associatedconstant.DIGITS) instead.
 ///
@@ -93,6 +94,7 @@ pub const EPSILON: f32 = f32::EPSILON;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 pub const MIN: f32 = f32::MIN;
+
 /// Smallest positive normal `f32` value.
 /// Use [`f32::MIN_POSITIVE`](../../std/primitive.f32.html#associatedconstant.MIN_POSITIVE) instead.
 ///
@@ -107,6 +109,7 @@ pub const MIN: f32 = f32::MIN;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 pub const MIN_POSITIVE: f32 = f32::MIN_POSITIVE;
+
 /// Largest finite `f32` value.
 /// Use [`f32::MAX`](../../std/primitive.f32.html#associatedconstant.MAX) instead.
 ///
@@ -136,6 +139,7 @@ pub const MAX: f32 = f32::MAX;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 pub const MIN_EXP: i32 = f32::MIN_EXP;
+
 /// Maximum possible power of 2 exponent.
 /// Use [`f32::MAX_EXP`](../../std/primitive.f32.html#associatedconstant.MAX_EXP) instead.
 ///
@@ -165,6 +169,7 @@ pub const MAX_EXP: i32 = f32::MAX_EXP;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 pub const MIN_10_EXP: i32 = f32::MIN_10_EXP;
+
 /// Maximum possible power of 10 exponent.
 /// Use [`f32::MAX_10_EXP`](../../std/primitive.f32.html#associatedconstant.MAX_10_EXP) instead.
 ///
@@ -194,6 +199,7 @@ pub const MAX_10_EXP: i32 = f32::MAX_10_EXP;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 pub const NAN: f32 = f32::NAN;
+
 /// Infinity (∞).
 /// Use [`f32::INFINITY`](../../std/primitive.f32.html#associatedconstant.INFINITY) instead.
 ///
@@ -208,6 +214,7 @@ pub const NAN: f32 = f32::NAN;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 pub const INFINITY: f32 = f32::INFINITY;
+
 /// Negative infinity (−∞).
 /// Use [`f32::NEG_INFINITY`](../../std/primitive.f32.html#associatedconstant.NEG_INFINITY) instead.
 ///

--- a/src/libcore/num/f64.rs
+++ b/src/libcore/num/f64.rs
@@ -18,15 +18,46 @@ use crate::num::FpCategory;
 
 /// The radix or base of the internal representation of `f64`.
 /// Use [`f64::RADIX`](../../std/primitive.f64.html#associatedconstant.RADIX) instead.
+///
+/// # Examples
+///
+/// ```rust
+/// // deprecated way
+/// let r = std::f64::RADIX;
+///
+/// // intended way
+/// let r = f64::RADIX;
+/// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 pub const RADIX: u32 = f64::RADIX;
 
 /// Number of significant digits in base 2.
 /// Use [`f64::MANTISSA_DIGITS`](../../std/primitive.f64.html#associatedconstant.MANTISSA_DIGITS) instead.
+///
+/// # Examples
+///
+/// ```rust
+/// // deprecated way
+/// let d = std::f64::MANTISSA_DIGITS;
+///
+/// // intended way
+/// let d = f64::MANTISSA_DIGITS;
+/// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 pub const MANTISSA_DIGITS: u32 = f64::MANTISSA_DIGITS;
+
 /// Approximate number of significant digits in base 10.
 /// Use [`f64::DIGITS`](../../std/primitive.f64.html#associatedconstant.DIGITS) instead.
+///
+/// # Examples
+///
+/// ```rust
+/// // deprecated way
+/// let d = std::f64::DIGITS;
+///
+/// // intended way
+/// let d = f64::DIGITS;
+/// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 pub const DIGITS: u32 = f64::DIGITS;
 
@@ -36,50 +67,166 @@ pub const DIGITS: u32 = f64::DIGITS;
 /// This is the difference between `1.0` and the next larger representable number.
 ///
 /// [Machine epsilon]: https://en.wikipedia.org/wiki/Machine_epsilon
+///
+/// # Examples
+///
+/// ```rust
+/// // deprecated way
+/// let e = std::f64::EPSILON;
+///
+/// // intended way
+/// let e = f64::EPSILON;
+/// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 pub const EPSILON: f64 = f64::EPSILON;
 
 /// Smallest finite `f64` value.
 /// Use [`f64::MIN`](../../std/primitive.f64.html#associatedconstant.MIN) instead.
+///
+/// # Examples
+///
+/// ```rust
+/// // deprecated way
+/// let min = std::f64::MIN;
+///
+/// // intended way
+/// let min = f64::MIN;
+/// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 pub const MIN: f64 = f64::MIN;
+
 /// Smallest positive normal `f64` value.
 /// Use [`f64::MIN_POSITIVE`](../../std/primitive.f64.html#associatedconstant.MIN_POSITIVE) instead.
+///
+/// # Examples
+///
+/// ```rust
+/// // deprecated way
+/// let min = std::f64::MIN_POSITIVE;
+///
+/// // intended way
+/// let min = f64::MIN_POSITIVE;
+/// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 pub const MIN_POSITIVE: f64 = f64::MIN_POSITIVE;
+
 /// Largest finite `f64` value.
 /// Use [`f64::MAX`](../../std/primitive.f64.html#associatedconstant.MAX) instead.
+///
+/// # Examples
+///
+/// ```rust
+/// // deprecated way
+/// let max = std::f64::MAX;
+///
+/// // intended way
+/// let max = f64::MAX;
+/// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 pub const MAX: f64 = f64::MAX;
 
 /// One greater than the minimum possible normal power of 2 exponent.
 /// Use [`f64::MIN_EXP`](../../std/primitive.f64.html#associatedconstant.MIN_EXP) instead.
+///
+/// # Examples
+///
+/// ```rust
+/// // deprecated way
+/// let min = std::f64::MIN_EXP;
+///
+/// // intended way
+/// let min = f64::MIN_EXP;
+/// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 pub const MIN_EXP: i32 = f64::MIN_EXP;
+
 /// Maximum possible power of 2 exponent.
 /// Use [`f64::MAX_EXP`](../../std/primitive.f64.html#associatedconstant.MAX_EXP) instead.
+///
+/// # Examples
+///
+/// ```rust
+/// // deprecated way
+/// let max = std::f64::MAX_EXP;
+///
+/// // intended way
+/// let max = f64::MAX_EXP;
+/// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 pub const MAX_EXP: i32 = f64::MAX_EXP;
 
 /// Minimum possible normal power of 10 exponent.
 /// Use [`f64::MIN_10_EXP`](../../std/primitive.f64.html#associatedconstant.MIN_10_EXP) instead.
+///
+/// # Examples
+///
+/// ```rust
+/// // deprecated way
+/// let min = std::f64::MIN_10_EXP;
+///
+/// // intended way
+/// let min = f64::MIN_10_EXP;
+/// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 pub const MIN_10_EXP: i32 = f64::MIN_10_EXP;
+
 /// Maximum possible power of 10 exponent.
 /// Use [`f64::MAX_10_EXP`](../../std/primitive.f64.html#associatedconstant.MAX_10_EXP) instead.
+///
+/// # Examples
+///
+/// ```rust
+/// // deprecated way
+/// let max = std::f64::MAX_10_EXP;
+///
+/// // intended way
+/// let max = f64::MAX_10_EXP;
+/// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 pub const MAX_10_EXP: i32 = f64::MAX_10_EXP;
 
 /// Not a Number (NaN).
 /// Use [`f64::NAN`](../../std/primitive.f64.html#associatedconstant.NAN) instead.
+///
+/// # Examples
+///
+/// ```rust
+/// // deprecated way
+/// let nan = std::f64::NAN;
+///
+/// // intended way
+/// let nan = f64::NAN;
+/// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 pub const NAN: f64 = f64::NAN;
+
 /// Infinity (∞).
 /// Use [`f64::INFINITY`](../../std/primitive.f64.html#associatedconstant.INFINITY) instead.
+///
+/// # Examples
+///
+/// ```rust
+/// // deprecated way
+/// let inf = std::f64::INFINITY;
+///
+/// // intended way
+/// let inf = f64::INFINITY;
+/// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 pub const INFINITY: f64 = f64::INFINITY;
+
 /// Negative infinity (−∞).
 /// Use [`f64::NEG_INFINITY`](../../std/primitive.f64.html#associatedconstant.NEG_INFINITY) instead.
+///
+/// # Examples
+///
+/// ```rust
+/// // deprecated way
+/// let ninf = std::f64::NEG_INFINITY;
+///
+/// // intended way
+/// let ninf = f64::NEG_INFINITY;
+/// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 pub const NEG_INFINITY: f64 = f64::NEG_INFINITY;
 

--- a/src/libcore/num/int_macros.rs
+++ b/src/libcore/num/int_macros.rs
@@ -12,14 +12,36 @@ macro_rules! int_module {
     ($T:ident, #[$attr:meta]) => (
         doc_comment! {
             concat!("The smallest value that can be represented by this integer type.
-Use [`", stringify!($T), "::MIN", "`](../../std/primitive.", stringify!($T), ".html#associatedconstant.MIN) instead."),
+Use [`", stringify!($T), "::MIN", "`](../../std/primitive.", stringify!($T), ".html#associatedconstant.MIN) instead.
+
+# Examples
+
+```rust
+// deprecated way
+let min = std::", stringify!($T), "::MIN;
+
+// intended way
+let min = ", stringify!($T), "::MIN;
+```
+"),
             #[$attr]
             pub const MIN: $T = $T::MIN;
         }
 
         doc_comment! {
             concat!("The largest value that can be represented by this integer type.
-Use [`", stringify!($T), "::MAX", "`](../../std/primitive.", stringify!($T), ".html#associatedconstant.MAX) instead."),
+Use [`", stringify!($T), "::MAX", "`](../../std/primitive.", stringify!($T), ".html#associatedconstant.MAX) instead.
+
+# Examples
+
+```rust
+// deprecated way
+let max = std::", stringify!($T), "::MAX;
+
+// intended way
+let max = ", stringify!($T), "::MAX;
+```
+"),
             #[$attr]
             pub const MAX: $T = $T::MAX;
         }

--- a/src/librustc_builtin_macros/deriving/debug.rs
+++ b/src/librustc_builtin_macros/deriving/debug.rs
@@ -88,7 +88,7 @@ fn show_substructure(cx: &mut ExtCtxt<'_>, span: Span, substr: &Substructure<'_>
 
                 // Use `let _ = expr;` to avoid triggering the
                 // unused_results lint.
-                stmts.push(stmt_let_undescore(cx, span, expr));
+                stmts.push(stmt_let_underscore(cx, span, expr));
             }
         }
         ast::VariantData::Struct(..) => {
@@ -112,7 +112,7 @@ fn show_substructure(cx: &mut ExtCtxt<'_>, span: Span, substr: &Substructure<'_>
                     Ident::new(sym::field, span),
                     vec![name, field],
                 );
-                stmts.push(stmt_let_undescore(cx, span, expr));
+                stmts.push(stmt_let_underscore(cx, span, expr));
             }
         }
     }
@@ -124,7 +124,7 @@ fn show_substructure(cx: &mut ExtCtxt<'_>, span: Span, substr: &Substructure<'_>
     cx.expr_block(block)
 }
 
-fn stmt_let_undescore(cx: &mut ExtCtxt<'_>, sp: Span, expr: P<ast::Expr>) -> ast::Stmt {
+fn stmt_let_underscore(cx: &mut ExtCtxt<'_>, sp: Span, expr: P<ast::Expr>) -> ast::Stmt {
     let local = P(ast::Local {
         pat: cx.pat_wild(sp),
         ty: None,

--- a/src/librustc_middle/ty/layout.rs
+++ b/src/librustc_middle/ty/layout.rs
@@ -2607,7 +2607,7 @@ where
 
                     // `Box` (`UniqueBorrowed`) are not necessarily dereferenceable
                     // for the entire duration of the function as they can be deallocated
-                    // any time. Set their valid size to 0.
+                    // at any time. Set their valid size to 0.
                     attrs.pointee_size = match kind {
                         PointerKind::UniqueOwned => Size::ZERO,
                         _ => pointee.size,

--- a/src/librustc_mir/borrow_check/mod.rs
+++ b/src/librustc_mir/borrow_check/mod.rs
@@ -180,11 +180,14 @@ fn do_mir_borrowck<'a, 'tcx>(
     let location_table = &LocationTable::new(&body);
 
     let mut errors_buffer = Vec::new();
-    let (move_data, move_errors): (MoveData<'tcx>, Option<Vec<(Place<'tcx>, MoveError<'tcx>)>>) =
+    let (move_data, move_errors): (MoveData<'tcx>, Vec<(Place<'tcx>, MoveError<'tcx>)>) =
         match MoveData::gather_moves(&body, tcx, param_env) {
-            Ok(move_data) => (move_data, None),
-            Err((move_data, move_errors)) => (move_data, Some(move_errors)),
+            Ok(move_data) => (move_data, Vec::new()),
+            Err((move_data, move_errors)) => (move_data, move_errors),
         };
+    let promoted_errors = promoted
+        .iter_enumerated()
+        .map(|(idx, body)| (idx, MoveData::gather_moves(&body, tcx, param_env)));
 
     let mdpe = MoveDataParamEnv { move_data, param_env };
 
@@ -264,6 +267,41 @@ fn do_mir_borrowck<'a, 'tcx>(
         _ => true,
     };
 
+    for (idx, move_data_results) in promoted_errors {
+        let promoted_body = &promoted[idx];
+        let dominators = promoted_body.dominators();
+
+        if let Err((move_data, move_errors)) = move_data_results {
+            let mut promoted_mbcx = MirBorrowckCtxt {
+                infcx,
+                body: promoted_body,
+                mir_def_id: def_id.to_def_id(),
+                move_data: &move_data,
+                location_table: &LocationTable::new(promoted_body),
+                movable_generator,
+                locals_are_invalidated_at_exit,
+                access_place_error_reported: Default::default(),
+                reservation_error_reported: Default::default(),
+                reservation_warnings: Default::default(),
+                move_error_reported: BTreeMap::new(),
+                uninitialized_error_reported: Default::default(),
+                errors_buffer,
+                regioncx: regioncx.clone(),
+                used_mut: Default::default(),
+                used_mut_upvars: SmallVec::new(),
+                borrow_set: borrow_set.clone(),
+                dominators,
+                upvars: Vec::new(),
+                local_names: IndexVec::from_elem(None, &promoted_body.local_decls),
+                region_names: RefCell::default(),
+                next_region_name: RefCell::new(1),
+                polonius_output: None,
+            };
+            promoted_mbcx.report_move_errors(move_errors);
+            errors_buffer = promoted_mbcx.errors_buffer;
+        };
+    }
+
     let dominators = body.dominators();
 
     let mut mbcx = MirBorrowckCtxt {
@@ -301,9 +339,7 @@ fn do_mir_borrowck<'a, 'tcx>(
         borrows: flow_borrows,
     };
 
-    if let Some(errors) = move_errors {
-        mbcx.report_move_errors(errors);
-    }
+    mbcx.report_move_errors(move_errors);
 
     dataflow::visit_results(
         &body,

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -1753,7 +1753,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
         potential_assoc_types: Vec<Span>,
         trait_bounds: &[hir::PolyTraitRef<'_>],
     ) {
-        if !associated_types.values().any(|v| !v.is_empty()) {
+        if associated_types.values().all(|v| v.is_empty()) {
             return;
         }
         let tcx = self.tcx();

--- a/src/test/ui/borrowck/move-error-in-promoted-2.rs
+++ b/src/test/ui/borrowck/move-error-in-promoted-2.rs
@@ -1,0 +1,10 @@
+// Regression test for #70934
+
+struct S;
+
+fn foo() {
+    &([S][0],);
+    //~^ ERROR cannot move out of type `[S; 1]`
+}
+
+fn main() {}

--- a/src/test/ui/borrowck/move-error-in-promoted-2.stderr
+++ b/src/test/ui/borrowck/move-error-in-promoted-2.stderr
@@ -1,0 +1,12 @@
+error[E0508]: cannot move out of type `[S; 1]`, a non-copy array
+  --> $DIR/move-error-in-promoted-2.rs:6:7
+   |
+LL |     &([S][0],);
+   |       ^^^^^^
+   |       |
+   |       cannot move out of here
+   |       move occurs because value has type `S`, which does not implement the `Copy` trait
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0508`.

--- a/src/test/ui/borrowck/move-error-in-promoted.rs
+++ b/src/test/ui/borrowck/move-error-in-promoted.rs
@@ -1,0 +1,17 @@
+// Regression test for #70934
+
+fn f() {
+    const C: [S2; 1] = [S2];
+    let _ = S1(C[0]).clone();
+    //~^ ERROR cannot move out of type `[S2; 1]`
+}
+
+#[derive(Clone)]
+struct S1(S2);
+
+#[derive(Clone)]
+struct S2;
+
+fn main() {
+    f();
+}

--- a/src/test/ui/borrowck/move-error-in-promoted.stderr
+++ b/src/test/ui/borrowck/move-error-in-promoted.stderr
@@ -1,0 +1,12 @@
+error[E0508]: cannot move out of type `[S2; 1]`, a non-copy array
+  --> $DIR/move-error-in-promoted.rs:5:16
+   |
+LL |     let _ = S1(C[0]).clone();
+   |                ^^^^
+   |                |
+   |                cannot move out of here
+   |                move occurs because value has type `S2`, which does not implement the `Copy` trait
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0508`.


### PR DESCRIPTION
Successful merges:

 - #71587 (Report cannot move errors in promoted MIR)
 - #71845 (Add const examples)
 - #71883 (add a missing "at" in a comment)
 - #71891 (¬∃x. ¬y => ∀x. y)
 - #71892 (Update btree_map::VacantEntry::insert docs to actually call insert)
 - #71904 (fix typo in function name)

Failed merges:


r? @ghost