### PR TITLE
Document From trait for Option implementations

### DIFF
--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -1376,6 +1376,7 @@ impl<'a, T> From<&'a Option<T>> for Option<&'a T> {
     /// Converts from `&Option<T>` to `Option<&T>`.
     ///
     /// # Examples
+    ///
     /// Converts an `Option<`[`String`]`>` into an `Option<`[`usize`]`>`, preserving the original.
     /// The [`map`] method takes the `self` argument by value, consuming the original,
     /// so this technique uses `as_ref` to first take an `Option` to a reference

--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -1387,7 +1387,7 @@ impl<'a, T> From<&'a Option<T>> for Option<&'a T> {
     /// ```
     /// let s: Option<String> = Some(String::from("Hello, Rustaceans!"));
     /// let o: Option<usize> = Option::from(&s).map(|ss: &String| ss.len());
-    /// println!("Can still print s: {}", s);
+    /// println!("Can still print s: {:?}", s);
     /// assert_eq!(o, Some(18));
     /// ```
     fn from(o: &'a Option<T>) -> Option<&'a T> {

--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -1389,7 +1389,9 @@ impl<'a, T> From<&'a Option<T>> for Option<&'a T> {
     /// ```
     /// let s: Option<String> = Some(String::from("Hello, Rustaceans!"));
     /// let o: Option<usize> = Option::from(&s).map(|ss: &String| ss.len());
+    ///
     /// println!("Can still print s: {:?}", s);
+    ///
     /// assert_eq!(o, Some(18));
     /// ```
     fn from(o: &'a Option<T>) -> Option<&'a T> {

--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -1363,6 +1363,7 @@ impl<T> From<T> for Option<T> {
     ///
     /// ```
     /// let o: Option<u8> = Option::from(67);
+    ///
     /// assert_eq!(Some(67), o);
     /// ```
     fn from(val: T) -> Option<T> {

--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -1357,12 +1357,38 @@ impl<'a, T> IntoIterator for &'a mut Option<T> {
 
 #[stable(since = "1.12.0", feature = "option_from")]
 impl<T> From<T> for Option<T> {
+    /// Copies val to a new Option::Some
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let o: Option<u8> = Option::from(67);
+    /// assert_eq!(Some(67), o);
+    /// ```
     fn from(val: T) -> Option<T> {
         Some(val)
     }
 }
 
 #[stable(feature = "option_ref_from_ref_option", since = "1.30.0")]
+    /// Converts from &Option<T> to Option<&T>
+    ///
+    /// # Examples
+    /// Converts an `Option<`[`String`]`>` into an `Option<`[`usize`]`>`, preserving the original.
+    /// The [`map`] method takes the `self` argument by value, consuming the original,
+    /// so this technique uses `as_ref` to first take an `Option` to a reference
+    /// to the value inside the original.
+    ///
+    /// [`map`]: enum.Option.html#method.map
+    /// [`String`]: ../../std/string/struct.String.html
+    /// [`usize`]: ../../std/primitive.usize.html
+    ///
+    /// ```
+    /// let s: Option<String> = Some(String::from("Hello, Rustaceans!"));
+    /// let o: Option<usize> = Option::from(&s).map(|ss: &String| ss.len());
+    /// println!("Can still print s: {}", s);
+    /// assert_eq!(o, Some(18));
+    /// ```
 impl<'a, T> From<&'a Option<T>> for Option<&'a T> {
     fn from(o: &'a Option<T>) -> Option<&'a T> {
         o.as_ref()
@@ -1371,6 +1397,19 @@ impl<'a, T> From<&'a Option<T>> for Option<&'a T> {
 
 #[stable(feature = "option_ref_from_ref_option", since = "1.30.0")]
 impl<'a, T> From<&'a mut Option<T>> for Option<&'a mut T> {
+    /// Converts from &mut Option<T> to Option<&mut T>
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let mut s = Some(String::from("Hello"));
+    /// let o: Option<&mut String> = Option::from(&mut s);
+    /// match o {
+    ///     Some(t) => *t = String::from("Hello, Rustaceans!"),
+    ///     None => (),
+    /// }
+    /// assert_eq!(s, Some(String::from("Hello, Rustaceans!")));
+    /// ```
     fn from(o: &'a mut Option<T>) -> Option<&'a mut T> {
         o.as_mut()
     }

--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -1405,6 +1405,7 @@ impl<'a, T> From<&'a mut Option<T>> for Option<&'a mut T> {
     /// ```
     /// let mut s = Some(String::from("Hello"));
     /// let o: Option<&mut String> = Option::from(&mut s);
+    ///
     /// match o {
     ///     Some(t) => *t = String::from("Hello, Rustaceans!"),
     ///     None => (),

--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -1411,6 +1411,7 @@ impl<'a, T> From<&'a mut Option<T>> for Option<&'a mut T> {
     ///     Some(t) => *t = String::from("Hello, Rustaceans!"),
     ///     None => (),
     /// }
+    ///
     /// assert_eq!(s, Some(String::from("Hello, Rustaceans!")));
     /// ```
     fn from(o: &'a mut Option<T>) -> Option<&'a mut T> {

--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -1371,6 +1371,7 @@ impl<T> From<T> for Option<T> {
 }
 
 #[stable(feature = "option_ref_from_ref_option", since = "1.30.0")]
+impl<'a, T> From<&'a Option<T>> for Option<&'a T> {
     /// Converts from &Option<T> to Option<&T>
     ///
     /// # Examples
@@ -1389,7 +1390,6 @@ impl<T> From<T> for Option<T> {
     /// println!("Can still print s: {}", s);
     /// assert_eq!(o, Some(18));
     /// ```
-impl<'a, T> From<&'a Option<T>> for Option<&'a T> {
     fn from(o: &'a Option<T>) -> Option<&'a T> {
         o.as_ref()
     }

--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -1373,7 +1373,7 @@ impl<T> From<T> for Option<T> {
 
 #[stable(feature = "option_ref_from_ref_option", since = "1.30.0")]
 impl<'a, T> From<&'a Option<T>> for Option<&'a T> {
-    /// Converts from &Option<T> to Option<&T>
+    /// Converts from `&Option<T>` to `Option<&T>`.
     ///
     /// # Examples
     /// Converts an `Option<`[`String`]`>` into an `Option<`[`usize`]`>`, preserving the original.

--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -1357,7 +1357,7 @@ impl<'a, T> IntoIterator for &'a mut Option<T> {
 
 #[stable(since = "1.12.0", feature = "option_from")]
 impl<T> From<T> for Option<T> {
-    /// Copies val to a new Option::Some
+    /// Copies `val` into a new `Some`.
     ///
     /// # Examples
     ///

--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -1399,7 +1399,7 @@ impl<'a, T> From<&'a Option<T>> for Option<&'a T> {
 
 #[stable(feature = "option_ref_from_ref_option", since = "1.30.0")]
 impl<'a, T> From<&'a mut Option<T>> for Option<&'a mut T> {
-    /// Converts from &mut Option<T> to Option<&mut T>
+    /// Converts from `&mut Option<T>` to `Option<&mut T>`
     ///
     /// # Examples
     ///

--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -1380,7 +1380,7 @@ impl<'a, T> From<&'a Option<T>> for Option<&'a T> {
     /// so this technique uses `as_ref` to first take an `Option` to a reference
     /// to the value inside the original.
     ///
-    /// [`map`]: enum.Option.html#method.map
+    /// [`map`]: ../../std/option/enum.Option.html#method.map
     /// [`String`]: ../../std/string/struct.String.html
     /// [`usize`]: ../../std/primitive.usize.html
     ///


### PR DESCRIPTION
Add documentation for ```From``` trait for ```std::option::Option``` implementations

This PR solves a part of #51430 ( CC @skade )

This is my first PR ever in contributing for OSS. I'm happy to learn and make any changes if necessary :)