### PR TITLE
Rename methods section

### DIFF
--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -1129,9 +1129,36 @@ pub struct IdMap {
     map: FxHashMap<String, usize>,
 }
 
+fn init_id_map() -> FxHashMap<String, usize> {
+    let mut map = FxHashMap::default();
+    // This is the list of IDs used by rustdoc templates.
+    map.insert("mainThemeStyle".to_owned(), 1);
+    map.insert("themeStyle".to_owned(), 1);
+    map.insert("theme-picker".to_owned(), 1);
+    map.insert("theme-choices".to_owned(), 1);
+    map.insert("settings-menu".to_owned(), 1);
+    map.insert("main".to_owned(), 1);
+    map.insert("search".to_owned(), 1);
+    map.insert("crate-search".to_owned(), 1);
+    map.insert("render-detail".to_owned(), 1);
+    map.insert("toggle-all-docs".to_owned(), 1);
+    map.insert("all-types".to_owned(), 1);
+    // This is the list of IDs used by rustdoc sections.
+    map.insert("fields".to_owned(), 1);
+    map.insert("variants".to_owned(), 1);
+    map.insert("implementors-list".to_owned(), 1);
+    map.insert("synthetic-implementors-list".to_owned(), 1);
+    map.insert("implementations".to_owned(), 1);
+    map.insert("trait-implementations".to_owned(), 1);
+    map.insert("synthetic-implementations".to_owned(), 1);
+    map.insert("blanket-implementations".to_owned(), 1);
+    map.insert("deref-methods".to_owned(), 1);
+    map
+}
+
 impl IdMap {
     pub fn new() -> Self {
-        IdMap::default()
+        IdMap { map: init_id_map() }
     }
 
     pub fn populate<I: IntoIterator<Item = String>>(&mut self, ids: I) {
@@ -1141,7 +1168,7 @@ impl IdMap {
     }
 
     pub fn reset(&mut self) {
-        self.map = FxHashMap::default();
+        self.map = init_id_map();
     }
 
     pub fn derive(&mut self, candidate: String) -> String {

--- a/src/librustdoc/html/markdown/tests.rs
+++ b/src/librustdoc/html/markdown/tests.rs
@@ -29,8 +29,8 @@ fn test_unique_id() {
         "examples-2",
         "method.into_iter-1",
         "foo-1",
-        "main",
-        "search",
+        "main-1",
+        "search-1",
         "methods",
         "examples-3",
         "method.into_iter-2",
@@ -191,8 +191,8 @@ fn test_header_ids_multiple_blocks() {
     t(
         &mut map,
         "# Main",
-        "<h1 id=\"main\" class=\"section-header\">\
-        <a href=\"#main\">Main</a></h1>",
+        "<h1 id=\"main-1\" class=\"section-header\">\
+        <a href=\"#main-1\">Main</a></h1>",
     );
     t(
         &mut map,

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -3413,8 +3413,8 @@ fn render_assoc_items(
                 write!(
                     w,
                     "\
-                    <h2 id='methods' class='small-section-header'>\
-                      Methods<a href='#methods' class='anchor'></a>\
+                    <h2 id='implementations' class='small-section-header'>\
+                      Implementations<a href='#implementations' class='anchor'></a>\
                     </h2>\
                 "
                 );
@@ -3475,10 +3475,10 @@ fn render_assoc_items(
             write!(
                 w,
                 "\
-                <h2 id='implementations' class='small-section-header'>\
-                  Trait Implementations<a href='#implementations' class='anchor'></a>\
+                <h2 id='trait-implementations' class='small-section-header'>\
+                  Trait Implementations<a href='#trait-implementations' class='anchor'></a>\
                 </h2>\
-                <div id='implementations-list'>{}</div>",
+                <div id='trait-implementations-list'>{}</div>",
                 impls
             );
         }
@@ -4097,8 +4097,8 @@ fn sidebar_assoc_items(it: &clean::Item) -> String {
             ret.sort();
             if !ret.is_empty() {
                 out.push_str(&format!(
-                    "<a class=\"sidebar-title\" href=\"#methods\">Methods\
-                                       </a><div class=\"sidebar-links\">{}</div>",
+                    "<a class=\"sidebar-title\" href=\"#implementations\">Methods</a>\
+                     <div class=\"sidebar-links\">{}</div>",
                     ret.join("")
                 ));
             }
@@ -4191,8 +4191,8 @@ fn sidebar_assoc_items(it: &clean::Item) -> String {
 
             if !concrete_format.is_empty() {
                 out.push_str(
-                    "<a class=\"sidebar-title\" href=\"#implementations\">\
-                              Trait Implementations</a>",
+                    "<a class=\"sidebar-title\" href=\"#trait-implementations\">\
+                        Trait Implementations</a>",
                 );
                 out.push_str(&format!("<div class=\"sidebar-links\">{}</div>", concrete_format));
             }
@@ -4200,7 +4200,7 @@ fn sidebar_assoc_items(it: &clean::Item) -> String {
             if !synthetic_format.is_empty() {
                 out.push_str(
                     "<a class=\"sidebar-title\" href=\"#synthetic-implementations\">\
-                              Auto Trait Implementations</a>",
+                        Auto Trait Implementations</a>",
                 );
                 out.push_str(&format!("<div class=\"sidebar-links\">{}</div>", synthetic_format));
             }
@@ -4208,7 +4208,7 @@ fn sidebar_assoc_items(it: &clean::Item) -> String {
             if !blanket_format.is_empty() {
                 out.push_str(
                     "<a class=\"sidebar-title\" href=\"#blanket-implementations\">\
-                              Blanket Implementations</a>",
+                        Blanket Implementations</a>",
                 );
                 out.push_str(&format!("<div class=\"sidebar-links\">{}</div>", blanket_format));
             }

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -2180,7 +2180,7 @@ function getSearchElement() {
         if (collapse) {
             toggleAllDocs(pageId, true);
         } else if (getCurrentValue("rustdoc-auto-hide-trait-implementations") !== "false") {
-            var impl_list = document.getElementById("implementations-list");
+            var impl_list = document.getElementById("trait-implementations-list");
 
             if (impl_list !== null) {
                 onEachLazy(impl_list.getElementsByClassName("collapse-toggle"), function(e) {

--- a/src/test/rustdoc/const-generics/add-impl.rs
+++ b/src/test/rustdoc/const-generics/add-impl.rs
@@ -11,7 +11,7 @@ pub struct Simd<T, const WIDTH: usize> {
     inner: T,
 }
 
-// @has foo/struct.Simd.html '//div[@id="implementations-list"]/h3/code' 'impl Add<Simd<u8, 16usize>> for Simd<u8, 16>'
+// @has foo/struct.Simd.html '//div[@id="trait-implementations-list"]/h3/code' 'impl Add<Simd<u8, 16usize>> for Simd<u8, 16>'
 impl Add for Simd<u8, 16> {
     type Output = Self;
 

--- a/src/test/rustdoc/duplicate_impls/issue-33054.rs
+++ b/src/test/rustdoc/duplicate_impls/issue-33054.rs
@@ -1,7 +1,7 @@
 // @has issue_33054/impls/struct.Foo.html
 // @has - '//code' 'impl Foo'
 // @has - '//code' 'impl Bar for Foo'
-// @count - '//*[@id="implementations-list"]/*[@class="impl"]' 1
+// @count - '//*[@id="trait-implementations-list"]/*[@class="impl"]' 1
 // @count - '//*[@id="main"]/*[@class="impl"]' 1
 // @has issue_33054/impls/bar/trait.Bar.html
 // @has - '//code' 'impl Bar for Foo'

--- a/src/test/rustdoc/issue-21474.rs
+++ b/src/test/rustdoc/issue-21474.rs
@@ -7,5 +7,5 @@ mod inner {
 pub trait Blah { }
 
 // @count issue_21474/struct.What.html \
-//        '//*[@id="implementations-list"]/*[@class="impl"]' 1
+//        '//*[@id="trait-implementations-list"]/*[@class="impl"]' 1
 pub struct What;

--- a/src/test/rustdoc/issue-45584.rs
+++ b/src/test/rustdoc/issue-45584.rs
@@ -4,12 +4,12 @@ pub trait Bar<T, U> {}
 
 // @has 'foo/struct.Foo1.html'
 pub struct Foo1;
-// @count - '//*[@id="implementations-list"]/*[@class="impl"]' 1
+// @count - '//*[@id="trait-implementations-list"]/*[@class="impl"]' 1
 // @has - '//*[@class="impl"]' "impl Bar<Foo1, &'static Foo1> for Foo1"
 impl Bar<Foo1, &'static Foo1> for Foo1 {}
 
 // @has 'foo/struct.Foo2.html'
 pub struct Foo2;
-// @count - '//*[@id="implementations-list"]/*[@class="impl"]' 1
+// @count - '//*[@id="trait-implementations-list"]/*[@class="impl"]' 1
 // @has - '//*[@class="impl"]' "impl Bar<&'static Foo2, Foo2> for u8"
 impl Bar<&'static Foo2, Foo2> for u8 {}

--- a/src/test/rustdoc/issue-55321.rs
+++ b/src/test/rustdoc/issue-55321.rs
@@ -1,8 +1,8 @@
 #![feature(negative_impls)]
 
 // @has issue_55321/struct.A.html
-// @has - '//*[@id="implementations-list"]/*[@class="impl"]//code' "impl !Send for A"
-// @has - '//*[@id="implementations-list"]/*[@class="impl"]//code' "impl !Sync for A"
+// @has - '//*[@id="trait-implementations-list"]/*[@class="impl"]//code' "impl !Send for A"
+// @has - '//*[@id="trait-implementations-list"]/*[@class="impl"]//code' "impl !Sync for A"
 pub struct A();
 
 impl !Send for A {}

--- a/src/test/rustdoc/negative-impl-sidebar.rs
+++ b/src/test/rustdoc/negative-impl-sidebar.rs
@@ -4,6 +4,6 @@
 pub struct Foo;
 
 // @has foo/struct.Foo.html
-// @has - '//*[@class="sidebar-title"][@href="#implementations"]' 'Trait Implementations'
+// @has - '//*[@class="sidebar-title"][@href="#trait-implementations"]' 'Trait Implementations'
 // @has - '//*[@class="sidebar-links"]/a' '!Sync'
 impl !Sync for Foo {}

--- a/src/test/rustdoc/struct-implementations-title.rs
+++ b/src/test/rustdoc/struct-implementations-title.rs
@@ -1,0 +1,9 @@
+#![crate_name = "foo"]
+
+pub struct Struc;
+
+// @has foo/struct.Struc.html
+// @has - '//*[@id="main"]/h2[@id="implementations"]' "Implementations"
+impl Struc {
+    pub const S: u64 = 0;
+}

--- a/src/test/rustdoc/synthetic_auto/manual.rs
+++ b/src/test/rustdoc/synthetic_auto/manual.rs
@@ -2,10 +2,10 @@
 // @has - '//*[@id="synthetic-implementations-list"]/*[@class="impl"]//code' 'impl<T> Sync for \
 // Foo<T> where T: Sync'
 //
-// @has - '//*[@id="implementations-list"]/*[@class="impl"]//code' \
+// @has - '//*[@id="trait-implementations-list"]/*[@class="impl"]//code' \
 // 'impl<T> Send for Foo<T>'
 //
-// @count - '//*[@id="implementations-list"]/*[@class="impl"]' 1
+// @count - '//*[@id="trait-implementations-list"]/*[@class="impl"]' 1
 // @count - '//*[@id="synthetic-implementations-list"]/*[@class="impl"]' 4
 pub struct Foo<T> {
     field: T,

--- a/src/test/rustdoc/typedef.rs
+++ b/src/test/rustdoc/typedef.rs
@@ -13,8 +13,8 @@ impl MyStruct {
 // @has - '//*[@class="impl"]//code' 'impl MyTrait for MyAlias'
 // @has - 'Alias docstring'
 // @has - '//*[@class="sidebar"]//p[@class="location"]' 'Type Definition MyAlias'
-// @has - '//*[@class="sidebar"]//a[@href="#methods"]' 'Methods'
-// @has - '//*[@class="sidebar"]//a[@href="#implementations"]' 'Trait Implementations'
+// @has - '//*[@class="sidebar"]//a[@href="#implementations"]' 'Methods'
+// @has - '//*[@class="sidebar"]//a[@href="#trait-implementations"]' 'Trait Implementations'
 /// Alias docstring
 pub type MyAlias = MyStruct;
 


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/70475.

It renames the section [methods](https://doc.rust-lang.org/nightly/std/string/struct.String.html#methods) into "Implementations". However, I didn't not update the title in the sidebar considering that it only lists methods under (even though I updated the link of the "methods" to make it point to the "implementations" section.

r? @kinnison 

cc @rust-lang/rustdoc 