### PR TITLE
Use -fvisibility=hidden for libunwind

### DIFF
--- a/src/libunwind/build.rs
+++ b/src/libunwind/build.rs
@@ -89,6 +89,7 @@ mod llvm_libunwind {
             cfg.flag("-fno-rtti");
             cfg.flag("-fstrict-aliasing");
             cfg.flag("-funwind-tables");
+            cfg.flag("-fvisibility=hidden");
         }
 
         let mut unwind_sources = vec![


### PR DESCRIPTION
We don't want to export any symbols from Rust's version of libunwind
as these may collide with other copies of libunwind e.g. when linking
Rust staticlib together C/C++ libraries that have their own version.