### PR TITLE
De-abuse TyKind::Error in exhaustiveness checking

### DIFF
--- a/src/librustc_mir_build/hair/pattern/_match.rs
+++ b/src/librustc_mir_build/hair/pattern/_match.rs
@@ -64,9 +64,9 @@
 /// (`Constructor`, `Fields`) pairs, handling all the special cases correctly.
 ///
 /// Caveat: this constructors/fields distinction doesn't quite cover every Rust value. For example
-/// a value of type `Rc<u64>` doesn't fit this idea very well, nor do function pointers and various
-/// other things. However, the idea covers everything that can be pattern-matched, and this is all
-/// we need for exhaustiveness checking.
+/// a value of type `Rc<u64>` doesn't fit this idea very well, nor do various other things.
+/// However, this idea covers everything that can be pattern-matched, and this is all we need for
+/// exhaustiveness checking.
 ///
 ///
 /// # Algorithm

--- a/src/librustc_mir_build/hair/pattern/_match.rs
+++ b/src/librustc_mir_build/hair/pattern/_match.rs
@@ -877,36 +877,37 @@ impl<'tcx> Constructor<'tcx> {
                             .fields
                             .iter()
                             .map(|field| {
+                                let ty = field.ty(cx.tcx, substs);
                                 let is_visible = adt.is_enum()
                                     || field.vis.is_accessible_from(cx.module, cx.tcx);
-                                let is_uninhabited = cx.is_uninhabited(field.ty(cx.tcx, substs));
-                                match (is_visible, is_non_exhaustive, is_uninhabited) {
-                                    // Treat all uninhabited types in non-exhaustive variants as
-                                    // `TyErr`.
-                                    (_, true, true) => cx.tcx.types.err,
-                                    // Treat all non-visible fields as `TyErr`. They can't appear
-                                    // in any other pattern from this match (because they are
-                                    // private), so their type does not matter - but we don't want
-                                    // to know they are uninhabited.
-                                    (false, ..) => cx.tcx.types.err,
-                                    (true, ..) => {
-                                        let ty = field.ty(cx.tcx, substs);
-                                        match ty.kind {
-                                            // If the field type returned is an array of an unknown
-                                            // size return an TyErr.
-                                            ty::Array(_, len)
-                                                if len
+                                let is_uninhabited = cx.is_uninhabited(ty);
+                                // Treat all non-visible fields as `TyErr`. They can't appear
+                                // in any other pattern from this match (because they are
+                                // private), so their type does not matter - but we don't want
+                                // to know they are uninhabited.
+                                let allowed_to_inspect = is_visible
+                                    && match (is_non_exhaustive, is_uninhabited) {
+                                        // Treat all uninhabited types in non-exhaustive variants as
+                                        // `TyErr`.
+                                        (true, true) => false,
+                                        (_, _) => {
+                                            match ty.kind {
+                                                // If the field type returned is an array of an unknown
+                                                // size return an TyErr.
+                                                ty::Array(_, len) => len
                                                     .try_eval_usize(cx.tcx, cx.param_env)
-                                                    .is_none() =>
-                                            {
-                                                cx.tcx.types.err
+                                                    .is_some(),
+                                                _ => true,
                                             }
-                                            _ => ty,
                                         }
-                                    }
+                                    };
+
+                                if allowed_to_inspect {
+                                    Pat::wildcard_from_ty(ty)
+                                } else {
+                                    Pat::wildcard_from_ty(cx.tcx.types.err)
                                 }
                             })
-                            .map(Pat::wildcard_from_ty)
                             .collect()
                     }
                 }

--- a/src/librustc_mir_build/hair/pattern/_match.rs
+++ b/src/librustc_mir_build/hair/pattern/_match.rs
@@ -65,8 +65,7 @@
 ///
 /// Caveat: this constructors/fields distinction doesn't quite cover every Rust value. For example
 /// a value of type `Rc<u64>` doesn't fit this idea very well, nor do various other things.
-/// However, this idea covers everything that can be pattern-matched, and this is all we need for
-/// exhaustiveness checking.
+/// However, this idea covers most of the cases that are relevant to exhaustiveness checking.
 ///
 ///
 /// # Algorithm

--- a/src/librustc_mir_build/hair/pattern/_match.rs
+++ b/src/librustc_mir_build/hair/pattern/_match.rs
@@ -963,11 +963,12 @@ impl<'p, 'tcx> FilteredField<'p, 'tcx> {
 ///
 /// If a private or `non_exhaustive` field is uninhabited, the code mustn't observe that it is
 /// uninhabited. For that, we filter these fields out of the matrix. This is subtle because we
-/// still need to have those fields back when going to/from a `Pat`. Mot of this is handled
-/// automatically in `Fields`, but when constructing or deconstructing fields you need to use the
-/// correct method. As a rule, when going to/from the matrix, use the filtered field list; when
-/// going to/from `Pat`, use the full field list.
-/// This filtering is uncommon in practice, because uninhabited fields are rarely used.
+/// still need to have those fields back when going to/from a `Pat`. Most of this is handled
+/// automatically in `Fields`, but when constructing or deconstructing `Fields` you need to be
+/// careful. As a rule, when going to/from the matrix, use the filtered field list; when going
+/// to/from `Pat`, use the full field list.
+/// This filtering is uncommon in practice, because uninhabited fields are rarely used, so we avoid
+/// it when possible to preserve performance.
 #[derive(Debug, Clone)]
 enum Fields<'p, 'tcx> {
     /// Lists of patterns that don't contain any filtered fields.

--- a/src/librustc_mir_build/hair/pattern/_match.rs
+++ b/src/librustc_mir_build/hair/pattern/_match.rs
@@ -885,22 +885,10 @@ impl<'tcx> Constructor<'tcx> {
                                 // in any other pattern from this match (because they are
                                 // private), so their type does not matter - but we don't want
                                 // to know they are uninhabited.
-                                let allowed_to_inspect = is_visible
-                                    && match (is_non_exhaustive, is_uninhabited) {
-                                        // Treat all uninhabited types in non-exhaustive variants as
-                                        // `TyErr`.
-                                        (true, true) => false,
-                                        (_, _) => {
-                                            match ty.kind {
-                                                // If the field type returned is an array of an unknown
-                                                // size return an TyErr.
-                                                ty::Array(_, len) => len
-                                                    .try_eval_usize(cx.tcx, cx.param_env)
-                                                    .is_some(),
-                                                _ => true,
-                                            }
-                                        }
-                                    };
+                                // Also treat all uninhabited types in non-exhaustive variants as
+                                // `TyErr`.
+                                let allowed_to_inspect =
+                                    is_visible && !(is_non_exhaustive && is_uninhabited);
 
                                 if allowed_to_inspect {
                                     Pat::wildcard_from_ty(ty)

--- a/src/librustc_mir_build/hair/pattern/_match.rs
+++ b/src/librustc_mir_build/hair/pattern/_match.rs
@@ -1033,7 +1033,7 @@ impl<'tcx> Constructor<'tcx> {
 
     /// Like `apply`, but where all the subpatterns are wildcards `_`.
     fn apply_wildcards<'a>(&self, cx: &MatchCheckCtxt<'a, 'tcx>, ty: Ty<'tcx>) -> Pat<'tcx> {
-        let subpatterns = self.wildcard_subpatterns(cx, ty).into_iter().rev();
+        let subpatterns = self.wildcard_subpatterns(cx, ty).into_iter();
         self.apply(cx, ty, subpatterns)
     }
 }

--- a/src/librustc_mir_build/hair/pattern/_match.rs
+++ b/src/librustc_mir_build/hair/pattern/_match.rs
@@ -880,15 +880,15 @@ impl<'tcx> Constructor<'tcx> {
                                 let ty = field.ty(cx.tcx, substs);
                                 let is_visible = adt.is_enum()
                                     || field.vis.is_accessible_from(cx.module, cx.tcx);
-                                let is_uninhabited = cx.is_uninhabited(ty);
-                                // Treat all non-visible fields as `TyErr`. They can't appear
-                                // in any other pattern from this match (because they are
+                                let is_inhabited = !cx.is_uninhabited(ty);
+                                // Treat all uninhabited non-visible fields as `TyErr`. They can't
+                                // appear in any other pattern from this match (because they are
                                 // private), so their type does not matter - but we don't want
                                 // to know they are uninhabited.
                                 // Also treat all uninhabited types in non-exhaustive variants as
                                 // `TyErr`.
                                 let allowed_to_inspect =
-                                    is_visible && !(is_non_exhaustive && is_uninhabited);
+                                    is_inhabited || (is_visible && !is_non_exhaustive);
 
                                 if allowed_to_inspect {
                                     Pat::wildcard_from_ty(ty)

--- a/src/librustc_mir_build/hair/pattern/_match.rs
+++ b/src/librustc_mir_build/hair/pattern/_match.rs
@@ -982,7 +982,7 @@ impl<'tcx> Constructor<'tcx> {
     }
 }
 
-/// Some fields need to be explicitely hidden away in certain cases; see the comment above the
+/// Some fields need to be explicitly hidden away in certain cases; see the comment above the
 /// `Fields` struct. This struct represents such a potentially-hidden field. When a field is hidden
 /// we still keep its type around.
 #[derive(Debug, Copy, Clone)]

--- a/src/librustc_mir_build/hair/pattern/_match.rs
+++ b/src/librustc_mir_build/hair/pattern/_match.rs
@@ -242,7 +242,7 @@ use rustc_hir::{HirId, RangeEnd};
 use rustc_middle::mir::interpret::{truncate, AllocId, ConstValue, Pointer, Scalar};
 use rustc_middle::mir::Field;
 use rustc_middle::ty::layout::IntegerExt;
-use rustc_middle::ty::{self, Const, Ty, TyCtxt, TypeFoldable};
+use rustc_middle::ty::{self, Const, Ty, TyCtxt};
 use rustc_session::lint;
 use rustc_span::{Span, DUMMY_SP};
 use rustc_target::abi::{Integer, Size, VariantIdx};
@@ -1739,11 +1739,7 @@ impl<'tcx> fmt::Debug for MissingConstructors<'tcx> {
 /// to a set of such vectors `m` - this is defined as there being a set of
 /// inputs that will match `v` but not any of the sets in `m`.
 ///
-/// All the patterns at each column of the `matrix ++ v` matrix must
-/// have the same type, except that wildcard (PatKind::Wild) patterns
-/// with type `TyErr` are also allowed, even if the "type of the column"
-/// is not `TyErr`. That is used to represent private fields, as using their
-/// real type would assert that they are inhabited.
+/// All the patterns at each column of the `matrix ++ v` matrix must have the same type.
 ///
 /// This is used both for reachability checking (if a pattern isn't useful in
 /// relation to preceding patterns, it is not reachable) and exhaustiveness
@@ -1807,34 +1803,7 @@ crate fn is_useful<'p, 'tcx>(
         return if any_is_useful { Useful(unreachable_pats) } else { NotUseful };
     }
 
-    let (ty, span) = matrix
-        .heads()
-        .map(|r| (r.ty, r.span))
-        .find(|(ty, _)| !ty.references_error())
-        .unwrap_or((v.head().ty, v.head().span));
-    let pcx = PatCtxt {
-        // TyErr is used to represent the type of wildcard patterns matching
-        // against inaccessible (private) fields of structs, so that we won't
-        // be able to observe whether the types of the struct's fields are
-        // inhabited.
-        //
-        // If the field is truly inaccessible, then all the patterns
-        // matching against it must be wildcard patterns, so its type
-        // does not matter.
-        //
-        // However, if we are matching against non-wildcard patterns, we
-        // need to know the real type of the field so we can specialize
-        // against it. This primarily occurs through constants - they
-        // can include contents for fields that are inaccessible at the
-        // location of the match. In that case, the field's type is
-        // inhabited - by the constant - so we can just use it.
-        //
-        // FIXME: this might lead to "unstable" behavior with macro hygiene
-        // introducing uninhabited patterns for inaccessible fields. We
-        // need to figure out how to model that.
-        ty,
-        span,
-    };
+    let pcx = PatCtxt { ty: v.head().ty, span: v.head().span };
 
     debug!("is_useful_expand_first_col: pcx={:#?}, expanding {:#?}", pcx, v.head());
 

--- a/src/librustc_mir_build/hair/pattern/check_match.rs
+++ b/src/librustc_mir_build/hair/pattern/check_match.rs
@@ -186,30 +186,10 @@ impl<'tcx> MatchVisitor<'_, 'tcx> {
         // Fourth, check for unreachable arms.
         let matrix = check_arms(&mut cx, &inlined_arms, source);
 
-        // FIXME: getting the type using `node_type` means that if `f` has output type `!`, we
-        // get `scrut_ty = !` instead of `bool` in the following:
-        // ```
-        // fn from(never: !) -> usize {
-        //     match never {
-        //         true => 1,
-        //         false => 0,
-        //     }
-        // }
-        // ```
-        // If we use `expr_ty_adjusted` instead, then the following breaks, because we get
-        // `scrut_ty = ()` instead of `!`.
-        // ```
-        // fn from(never: !) -> usize {
-        //     match never {}
-        // }
-        // ```
-        // As a workaround, we retrieve the type from the match arms when possible.
-        let scrut_ty = self.tables.node_type(scrut.hir_id);
-        let scrut_ty = inlined_arms.iter().map(|(p, _, _)| p.ty).next().unwrap_or(scrut_ty);
-
         // Fifth, check if the match is exhaustive.
         // Note: An empty match isn't the same as an empty matrix for diagnostics purposes,
         // since an empty matrix can occur when there are arms, if those arms all have guards.
+        let scrut_ty = self.tables.expr_ty_adjusted(scrut);
         let is_empty_match = inlined_arms.is_empty();
         check_exhaustive(&mut cx, scrut_ty, scrut.span, &matrix, scrut.hir_id, is_empty_match);
     }

--- a/src/librustc_typeck/check/_match.rs
+++ b/src/librustc_typeck/check/_match.rs
@@ -436,6 +436,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         if let Some(m) = contains_ref_bindings {
             self.check_expr_with_needs(scrut, Needs::maybe_mut_place(m))
+        } else if arms.is_empty() {
+            self.check_expr(scrut)
         } else {
             // ...but otherwise we want to use any supertype of the
             // scrutinee. This is sort of a workaround, see note (*) in

--- a/src/test/ui/pattern/usefulness/issue-71930-type-of-match-scrutinee.rs
+++ b/src/test/ui/pattern/usefulness/issue-71930-type-of-match-scrutinee.rs
@@ -1,0 +1,22 @@
+// check-pass
+
+// In PR 71930, it was discovered that the code to retrieve the inferred type of a match scrutinee
+// was incorrect.
+
+fn f() -> ! {
+    panic!()
+}
+
+fn g() -> usize {
+    match f() { // Should infer type `bool`
+        false => 0,
+        true => 1,
+    }
+}
+
+fn h() -> usize {
+    match f() { // Should infer type `!`
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
Replaces https://github.com/rust-lang/rust/pull/71074. Context: https://github.com/rust-lang/rust/issues/70866.

In order to remove the use of `TyKind::Error`, I had to make sure we skip over those fields whose inhabitedness should not be observed. This is potentially error-prone however, since we must be careful not to mix filtered and unfiltered lists of patterns. I managed to hide away most of the filtering behind a new `Fields` struct, that I used everywhere relevant. I quite like the result; I think the twin concepts of `Constructor` and `Fields` make a good mental model.

As usual, I tried to separate commits that shuffle code around from commits that require more thought to review.

cc @varkor @Centril