### PR TITLE
Convert posix scripts to bash

### DIFF
--- a/configure
+++ b/configure
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 script="$(dirname $0)"/src/bootstrap/configure.py
 

--- a/src/ci/docker/disabled/dist-x86_64-haiku/llvm-config.sh
+++ b/src/ci/docker/disabled/dist-x86_64-haiku/llvm-config.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 case $1 in
 --version) echo  4.0.1;;

--- a/src/ci/docker/dist-various-2/build-fuchsia-toolchain.sh
+++ b/src/ci/docker/dist-various-2/build-fuchsia-toolchain.sh
@@ -45,7 +45,7 @@ rm -rf zircon
 for arch in x86_64 aarch64; do
   for tool in clang clang++; do
     cat >/usr/local/bin/${arch}-fuchsia-${tool} <<EOF
-#!/bin/sh
+#!/bin/bash
 ${tool} --target=${arch}-fuchsia --sysroot=/usr/local/${arch}-fuchsia "\$@"
 EOF
     chmod +x /usr/local/bin/${arch}-fuchsia-${tool}

--- a/src/ci/docker/dist-various-2/build-wasi-toolchain.sh
+++ b/src/ci/docker/dist-various-2/build-wasi-toolchain.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # ignore-tidy-linelength
 

--- a/src/ci/docker/scripts/android-start-emulator.sh
+++ b/src/ci/docker/scripts/android-start-emulator.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -ex
 

--- a/src/ci/docker/scripts/freebsd-toolchain.sh
+++ b/src/ci/docker/scripts/freebsd-toolchain.sh
@@ -90,7 +90,7 @@ set -x
 for tool in clang clang++; do
   tool_path=/usr/local/bin/${triple}-${tool}
   cat > "$tool_path" <<EOF
-#!/bin/sh
+#!/bin/bash
 exec $tool --sysroot=$sysroot --prefix=${sysroot}/bin "\$@" --target=$triple
 EOF
   chmod +x "$tool_path"

--- a/src/ci/docker/scripts/qemu-bare-bones-rcS
+++ b/src/ci/docker/scripts/qemu-bare-bones-rcS
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 mount -t proc none /proc
 mount -t sysfs none /sys
 /sbin/mdev -s

--- a/src/ci/docker/x86_64-gnu-tools/checktools.sh
+++ b/src/ci/docker/x86_64-gnu-tools/checktools.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -eu
 

--- a/src/etc/cat-and-grep.sh
+++ b/src/etc/cat-and-grep.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -eu
 
 # Performs `cat` and `grep` simultaneously for `run-make` tests in the Rust CI.

--- a/src/etc/installer/pkg/postinstall
+++ b/src/etc/installer/pkg/postinstall
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 source_dir="$(dirname "$0")"
 dest_dir="$2"

--- a/src/etc/rust-gdb
+++ b/src/etc/rust-gdb
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Exit if anything fails
 set -e
 

--- a/src/etc/rust-gdbgui
+++ b/src/etc/rust-gdbgui
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Exit if anything fails
 set -e

--- a/src/etc/rust-lldb
+++ b/src/etc/rust-lldb
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Exit if anything fails
 set -e

--- a/src/tools/linkchecker/linkcheck.sh
+++ b/src/tools/linkchecker/linkcheck.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # This is a script that can be used in each book's CI to validate links using
 # the same tool as rust-lang/rust.


### PR DESCRIPTION
This addresses #31036 

Additional PRs for this issue are in their respective repos:
- rust-lang/stdarch#853
- rust-lang/miri#1395
- rust-lang/rust-installer#102

Files not converted are:

- `src/tools/clippy/util/dev` (This is deprecated)
- `src/tools/rust-installer/test/image1/bin/program`
- `src/tools/rust-installer/test/image1/bin/program2`
- `src/tools/rust-installer/test/image1/bin/oldprogram`
- `src/tools/rust-installer/test/image1/bin/cargo`

All except the first are single-lined files that hold just `#!/bin/sh`

