### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1366,9 +1366,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.10"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "725cf19794cf90aa94e65050cb4191ff5d8fa87a498383774c47b332e3af952e"
+checksum = "61565ff7aaace3525556587bd2dc31d4a07071957be715e63ce7b1eccf51a8f4"
 dependencies = [
  "compiler_builtins",
  "libc",

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,15 @@
+Version 1.43.1 (2020-05-07)
+===========================
+
+* [Updated openssl-src to 1.1.1g for CVE-2020-1967.][71430]
+* [Fixed the stabilization of AVX-512 features.][71473]
+* [Fixed `cargo package --list` not working with unpublished dependencies.][cargo/8151]
+
+[71430]: https://github.com/rust-lang/rust/pull/71430
+[71473]: https://github.com/rust-lang/rust/issues/71473
+[cargo/8151]: https://github.com/rust-lang/cargo/issues/8151
+
+
 Version 1.43.0 (2020-04-23)
 ==========================
 
@@ -14,7 +26,7 @@ Language
 - [Merge `fn` syntax + cleanup item parsing.][68728]
 - [`item` macro fragments can be interpolated into `trait`s, `impl`s, and `extern` blocks.][69366]
   For example, you may now write:
-  ```rust 
+  ```rust
   macro_rules! mac_trait {
       ($i:item) => {
           trait T { $i }
@@ -82,7 +94,7 @@ Misc
 - [Certain checks in the `const_err` lint were deemed unrelated to const
   evaluation][69185], and have been moved to the `unconditional_panic` and
   `arithmetic_overflow` lints.
-  
+
 Compatibility Notes
 -------------------
 
@@ -173,7 +185,7 @@ Language
      (e.g. `type Foo: Ord;`).
    - `...` (the C-variadic type) may occur syntactically directly as the type of
       any function parameter.
-  
+
   These are still rejected *semantically*, so you will likely receive an error
   but these changes can be seen and parsed by procedural macros and
   conditional compilation.
@@ -465,7 +477,7 @@ Compatibility Notes
 - [Using `#[inline]` on function prototypes and consts now emits a warning under
   `unused_attribute` lint.][65294] Using `#[inline]` anywhere else inside traits
   or `extern` blocks now correctly emits a hard error.
-  
+
 [65294]: https://github.com/rust-lang/rust/pull/65294/
 [66103]: https://github.com/rust-lang/rust/pull/66103/
 [65843]: https://github.com/rust-lang/rust/pull/65843/

--- a/src/bootstrap/flags.rs
+++ b/src/bootstrap/flags.rs
@@ -106,18 +106,18 @@ impl Flags {
 Usage: x.py <subcommand> [options] [<paths>...]
 
 Subcommands:
-    build       Compile either the compiler or libraries
-    check       Compile either the compiler or libraries, using cargo check
+    build, b    Compile either the compiler or libraries
+    check, c    Compile either the compiler or libraries, using cargo check
     clippy      Run clippy (uses rustup/cargo-installed clippy binary)
     fix         Run cargo fix
     fmt         Run rustfmt
-    test        Build and run some test suites
+    test, t     Build and run some test suites
     bench       Build and run some benchmarks
     doc         Build documentation
     clean       Clean out build directories
     dist        Build distribution artifacts
     install     Install distribution artifacts
-    run         Run tools contained in this repository
+    run, r      Run tools contained in this repository
 
 To learn more about a subcommand, run `./x.py <subcommand> -h`",
         );
@@ -184,17 +184,21 @@ To learn more about a subcommand, run `./x.py <subcommand> -h`",
         // there on out.
         let subcommand = args.iter().find(|&s| {
             (s == "build")
+                || (s == "b")
                 || (s == "check")
+                || (s == "c")
                 || (s == "clippy")
                 || (s == "fix")
                 || (s == "fmt")
                 || (s == "test")
+                || (s == "t")
                 || (s == "bench")
                 || (s == "doc")
                 || (s == "clean")
                 || (s == "dist")
                 || (s == "install")
                 || (s == "run")
+                || (s == "r")
         });
         let subcommand = match subcommand {
             Some(s) => s,
@@ -210,7 +214,7 @@ To learn more about a subcommand, run `./x.py <subcommand> -h`",
 
         // Some subcommands get extra options
         match subcommand.as_str() {
-            "test" => {
+            "test" | "t" => {
                 opts.optflag("", "no-fail-fast", "Run all tests regardless of failure");
                 opts.optmulti("", "test-args", "extra arguments", "ARGS");
                 opts.optmulti(
@@ -285,7 +289,7 @@ To learn more about a subcommand, run `./x.py <subcommand> -h`",
         }
         // Extra help text for some commands
         match subcommand.as_str() {
-            "build" => {
+            "build" | "b" => {
                 subcommand_help.push_str(
                     "\n
 Arguments:
@@ -312,7 +316,7 @@ Arguments:
     Once this is done, build/$ARCH/stage1 contains a usable compiler.",
                 );
             }
-            "check" => {
+            "check" | "c" => {
                 subcommand_help.push_str(
                     "\n
 Arguments:
@@ -362,7 +366,7 @@ Arguments:
         ./x.py fmt --check",
                 );
             }
-            "test" => {
+            "test" | "t" => {
                 subcommand_help.push_str(
                     "\n
 Arguments:
@@ -407,7 +411,7 @@ Arguments:
         ./x.py doc --stage 1",
                 );
             }
-            "run" => {
+            "run" | "r" => {
                 subcommand_help.push_str(
                     "\n
 Arguments:
@@ -453,11 +457,11 @@ Arguments:
         }
 
         let cmd = match subcommand.as_str() {
-            "build" => Subcommand::Build { paths },
-            "check" => Subcommand::Check { paths },
+            "build" | "b" => Subcommand::Build { paths },
+            "check" | "c" => Subcommand::Check { paths },
             "clippy" => Subcommand::Clippy { paths },
             "fix" => Subcommand::Fix { paths },
-            "test" => Subcommand::Test {
+            "test" | "t" => Subcommand::Test {
                 paths,
                 bless: matches.opt_present("bless"),
                 compare_mode: matches.opt_str("compare-mode"),
@@ -487,7 +491,7 @@ Arguments:
             "fmt" => Subcommand::Format { check: matches.opt_present("check") },
             "dist" => Subcommand::Dist { paths },
             "install" => Subcommand::Install { paths },
-            "run" => {
+            "run" | "r" => {
                 if paths.is_empty() {
                     println!("\nrun requires at least a path!\n");
                     usage(1, &opts, &subcommand_help, &extra_help);

--- a/src/liballoc/collections/btree/map.rs
+++ b/src/liballoc/collections/btree/map.rs
@@ -1545,16 +1545,10 @@ impl<K, V> IntoIterator for BTreeMap<K, V> {
 
     fn into_iter(self) -> IntoIter<K, V> {
         let mut me = ManuallyDrop::new(self);
-        if let Some(root) = me.root.as_mut() {
-            let root1 = unsafe { ptr::read(root).into_ref() };
-            let root2 = unsafe { ptr::read(root).into_ref() };
-            let len = me.length;
+        if let Some(root) = me.root.take() {
+            let (f, b) = full_range_search(root.into_ref());
 
-            IntoIter {
-                front: Some(root1.first_leaf_edge()),
-                back: Some(root2.last_leaf_edge()),
-                length: len,
-            }
+            IntoIter { front: Some(f), back: Some(b), length: me.length }
         } else {
             IntoIter { front: None, back: None, length: 0 }
         }
@@ -2042,6 +2036,7 @@ where
     }
 }
 
+/// Finds the leaf edges delimiting a specified range in or underneath a node.
 fn range_search<BorrowType, K, V, Q: ?Sized, R: RangeBounds<Q>>(
     root1: NodeRef<BorrowType, K, V, marker::LeafOrInternal>,
     root2: NodeRef<BorrowType, K, V, marker::LeafOrInternal>,
@@ -2126,6 +2121,33 @@ where
     }
 }
 
+/// Equivalent to `range_search(k, v, ..)` without the `Ord` bound.
+fn full_range_search<BorrowType, K, V>(
+    root: NodeRef<BorrowType, K, V, marker::LeafOrInternal>,
+) -> (
+    Handle<NodeRef<BorrowType, K, V, marker::Leaf>, marker::Edge>,
+    Handle<NodeRef<BorrowType, K, V, marker::Leaf>, marker::Edge>,
+) {
+    // We duplicate the root NodeRef here -- we will never access it in a way
+    // that overlaps references obtained from the root.
+    let mut min_node = unsafe { ptr::read(&root) };
+    let mut max_node = root;
+    loop {
+        let front = min_node.first_edge();
+        let back = max_node.last_edge();
+        match (front.force(), back.force()) {
+            (Leaf(f), Leaf(b)) => {
+                return (f, b);
+            }
+            (Internal(min_int), Internal(max_int)) => {
+                min_node = min_int.descend();
+                max_node = max_int.descend();
+            }
+            _ => unreachable!("BTreeMap has different depths"),
+        };
+    }
+}
+
 impl<K, V> BTreeMap<K, V> {
     /// Gets an iterator over the entries of the map, sorted by key.
     ///
@@ -2150,12 +2172,12 @@ impl<K, V> BTreeMap<K, V> {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn iter(&self) -> Iter<'_, K, V> {
-        Iter {
-            range: Range {
-                front: self.root.as_ref().map(|r| r.as_ref().first_leaf_edge()),
-                back: self.root.as_ref().map(|r| r.as_ref().last_leaf_edge()),
-            },
-            length: self.length,
+        if let Some(root) = &self.root {
+            let (f, b) = full_range_search(root.as_ref());
+
+            Iter { range: Range { front: Some(f), back: Some(b) }, length: self.length }
+        } else {
+            Iter { range: Range { front: None, back: None }, length: 0 }
         }
     }
 
@@ -2182,19 +2204,15 @@ impl<K, V> BTreeMap<K, V> {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn iter_mut(&mut self) -> IterMut<'_, K, V> {
-        IterMut {
-            range: if let Some(root) = &mut self.root {
-                let root1 = root.as_mut();
-                let root2 = unsafe { ptr::read(&root1) };
-                RangeMut {
-                    front: Some(root1.first_leaf_edge()),
-                    back: Some(root2.last_leaf_edge()),
-                    _marker: PhantomData,
-                }
-            } else {
-                RangeMut { front: None, back: None, _marker: PhantomData }
-            },
-            length: self.length,
+        if let Some(root) = &mut self.root {
+            let (f, b) = full_range_search(root.as_mut());
+
+            IterMut {
+                range: RangeMut { front: Some(f), back: Some(b), _marker: PhantomData },
+                length: self.length,
+            }
+        } else {
+            IterMut { range: RangeMut { front: None, back: None, _marker: PhantomData }, length: 0 }
         }
     }
 

--- a/src/librustc_codegen_ssa/mir/rvalue.rs
+++ b/src/librustc_codegen_ssa/mir/rvalue.rs
@@ -768,7 +768,7 @@ fn cast_float_to_int<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
 ) -> Bx::Value {
     let fptosui_result = if signed { bx.fptosi(x, int_ty) } else { bx.fptoui(x, int_ty) };
 
-    if !bx.cx().sess().opts.debugging_opts.saturating_float_casts {
+    if let Some(false) = bx.cx().sess().opts.debugging_opts.saturating_float_casts {
         return fptosui_result;
     }
 

--- a/src/librustc_interface/tests.rs
+++ b/src/librustc_interface/tests.rs
@@ -558,7 +558,7 @@ fn test_debugging_options_tracking_hash() {
     tracked!(sanitizer, Some(Sanitizer::Address));
     tracked!(sanitizer_memory_track_origins, 2);
     tracked!(sanitizer_recover, vec![Sanitizer::Address]);
-    tracked!(saturating_float_casts, true);
+    tracked!(saturating_float_casts, Some(true));
     tracked!(share_generics, Some(true));
     tracked!(show_span, Some(String::from("abc")));
     tracked!(src_hash_algorithm, Some(SourceFileHashAlgorithm::Sha1));

--- a/src/librustc_session/options.rs
+++ b/src/librustc_session/options.rs
@@ -936,9 +936,9 @@ options! {DebuggingOptions, DebuggingSetter, basic_debugging_options,
         "enable origins tracking in MemorySanitizer"),
     sanitizer_recover: Vec<Sanitizer> = (vec![], parse_sanitizer_list, [TRACKED],
         "enable recovery for selected sanitizers"),
-    saturating_float_casts: bool = (false, parse_bool, [TRACKED],
+    saturating_float_casts: Option<bool> = (None, parse_opt_bool, [TRACKED],
         "make float->int casts UB-free: numbers outside the integer type's range are clipped to \
-        the max/min integer respectively, and NaN is mapped to 0 (default: no)"),
+        the max/min integer respectively, and NaN is mapped to 0 (default: yes)"),
     save_analysis: bool = (false, parse_bool, [UNTRACKED],
         "write syntax and type analysis (in JSON format) information, in \
         addition to normal output (default: no)"),

--- a/src/librustc_typeck/check/demand.rs
+++ b/src/librustc_typeck/check/demand.rs
@@ -853,13 +853,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             cast_suggestion,
                             Applicability::MaybeIncorrect, // lossy conversion
                         );
-                        err.warn(
-                            "if the rounded value cannot be represented by the target \
-                                integer type, including `Inf` and `NaN`, casting will cause \
-                                undefined behavior \
-                                (see issue #10184 <https://github.com/rust-lang/rust/issues/10184> \
-                                for more information)",
-                        );
                     }
                     true
                 }

--- a/src/libstd/Cargo.toml
+++ b/src/libstd/Cargo.toml
@@ -41,7 +41,7 @@ dlmalloc = { version = "0.1", features = ['rustc-dep-of-std'] }
 fortanix-sgx-abi = { version = "0.3.2", features = ['rustc-dep-of-std'] }
 
 [target.'cfg(all(any(target_arch = "x86_64", target_arch = "aarch64"), target_os = "hermit"))'.dependencies]
-hermit-abi = { version = "0.1.10", features = ['rustc-dep-of-std'] }
+hermit-abi = { version = "0.1.12", features = ['rustc-dep-of-std'] }
 
 [target.wasm32-wasi.dependencies]
 wasi = { version = "0.9.0", features = ['rustc-dep-of-std'], default-features = false }

--- a/src/libstd/sys/hermit/thread.rs
+++ b/src/libstd/sys/hermit/thread.rs
@@ -16,25 +16,24 @@ pub struct Thread {
 unsafe impl Send for Thread {}
 unsafe impl Sync for Thread {}
 
-pub const DEFAULT_MIN_STACK_SIZE: usize = 262144;
+pub const DEFAULT_MIN_STACK_SIZE: usize = 1_048_576;
 
 impl Thread {
     pub unsafe fn new_with_coreid(
-        _stack: usize,
+        stack: usize,
         p: Box<dyn FnOnce()>,
         core_id: isize,
     ) -> io::Result<Thread> {
         let p = Box::into_raw(box p);
-        let mut tid: Tid = u32::MAX;
-        let ret = abi::spawn(
-            &mut tid as *mut Tid,
+        let tid = abi::spawn2(
             thread_start,
-            &*p as *const _ as *const u8 as usize,
+            p as usize,
             abi::Priority::into(abi::NORMAL_PRIO),
+            stack,
             core_id,
         );
 
-        return if ret != 0 {
+        return if tid == 0 {
             // The thread failed to start and as a result p was not consumed. Therefore, it is
             // safe to reconstruct the box so that it gets deallocated.
             drop(Box::from_raw(p));

--- a/src/libstd/sys/hermit/thread.rs
+++ b/src/libstd/sys/hermit/thread.rs
@@ -16,7 +16,7 @@ pub struct Thread {
 unsafe impl Send for Thread {}
 unsafe impl Sync for Thread {}
 
-pub const DEFAULT_MIN_STACK_SIZE: usize = 1_048_576;
+pub const DEFAULT_MIN_STACK_SIZE: usize = 1 << 20;
 
 impl Thread {
     pub unsafe fn new_with_coreid(

--- a/src/libstd/sys/unix/mutex.rs
+++ b/src/libstd/sys/unix/mutex.rs
@@ -28,14 +28,18 @@ impl Mutex {
         //
         // A pthread mutex initialized with PTHREAD_MUTEX_INITIALIZER will have
         // a type of PTHREAD_MUTEX_DEFAULT, which has undefined behavior if you
-        // try to re-lock it from the same thread when you already hold a lock.
+        // try to re-lock it from the same thread when you already hold a lock
+        // (https://pubs.opengroup.org/onlinepubs/9699919799/functions/pthread_mutex_init.html).
         //
         // In practice, glibc takes advantage of this undefined behavior to
         // implement hardware lock elision, which uses hardware transactional
-        // memory to avoid acquiring the lock. While a transaction is in
+        // memory to avoid acquiring the lock.
+        // This is the case even if PTHREAD_MUTEX_DEFAULT == PTHREAD_MUTEX_NORMAL
+        // (https://github.com/rust-lang/rust/issues/33770#issuecomment-220847521).
+        // As a consequence, while a transaction is in
         // progress, the lock appears to be unlocked. This isn't a problem for
         // other threads since the transactional memory will abort if a conflict
-        // is detected, however no abort is generated if re-locking from the
+        // is detected, however no abort is generated when re-locking from the
         // same thread.
         //
         // Since locking the same mutex twice will result in two aliasing &mut

--- a/src/libstd/sys/unix/mutex.rs
+++ b/src/libstd/sys/unix/mutex.rs
@@ -30,13 +30,15 @@ impl Mutex {
         // a type of PTHREAD_MUTEX_DEFAULT, which has undefined behavior if you
         // try to re-lock it from the same thread when you already hold a lock
         // (https://pubs.opengroup.org/onlinepubs/9699919799/functions/pthread_mutex_init.html).
+        // This is the case even if PTHREAD_MUTEX_DEFAULT == PTHREAD_MUTEX_NORMAL
+        // (https://github.com/rust-lang/rust/issues/33770#issuecomment-220847521) -- in that
+        // case, `pthread_mutexattr_settype(PTHREAD_MUTEX_DEFAULT)` will of course be the same
+        // as setting it to `PTHREAD_MUTEX_NORMAL`, but not setting any mode will result in
+        // a Mutex where re-locking is UB.
         //
         // In practice, glibc takes advantage of this undefined behavior to
         // implement hardware lock elision, which uses hardware transactional
-        // memory to avoid acquiring the lock.
-        // This is the case even if PTHREAD_MUTEX_DEFAULT == PTHREAD_MUTEX_NORMAL
-        // (https://github.com/rust-lang/rust/issues/33770#issuecomment-220847521).
-        // As a consequence, while a transaction is in
+        // memory to avoid acquiring the lock. While a transaction is in
         // progress, the lock appears to be unlocked. This isn't a problem for
         // other threads since the transactional memory will abort if a conflict
         // is detected, however no abort is generated when re-locking from the

--- a/src/libstd/sys/unix/rwlock.rs
+++ b/src/libstd/sys/unix/rwlock.rs
@@ -22,27 +22,26 @@ impl RWLock {
     pub unsafe fn read(&self) {
         let r = libc::pthread_rwlock_rdlock(self.inner.get());
 
-        // According to the pthread_rwlock_rdlock spec, this function **may**
-        // fail with EDEADLK if a deadlock is detected. On the other hand
-        // pthread mutexes will *never* return EDEADLK if they are initialized
-        // as the "fast" kind (which ours always are). As a result, a deadlock
-        // situation may actually return from the call to pthread_rwlock_rdlock
-        // instead of blocking forever (as mutexes and Windows rwlocks do). Note
-        // that not all unix implementations, however, will return EDEADLK for
-        // their rwlocks.
+        // According to POSIX, when a thread tries to acquire this read lock
+        // while it already holds the write lock
+        // (or vice versa, or tries to acquire the write lock twice),
+        // "the call shall either deadlock or return [EDEADLK]"
+        // (https://pubs.opengroup.org/onlinepubs/9699919799/functions/pthread_rwlock_wrlock.html,
+        // https://pubs.opengroup.org/onlinepubs/9699919799/functions/pthread_rwlock_rdlock.html).
+        // So, in principle, all we have to do here is check `r == 0` to be sure we properly
+        // got the lock.
         //
-        // We roughly maintain the deadlocking behavior by panicking to ensure
-        // that this lock acquisition does not succeed.
-        //
-        // We also check whether this lock is already write locked. This
-        // is only possible if it was write locked by the current thread and
-        // the implementation allows recursive locking. The POSIX standard
-        // doesn't require recursively locking a rwlock to deadlock, but we can't
-        // allow that because it could lead to aliasing issues.
+        // However, (at least) glibc before version 2.25 does not conform to this spec,
+        // and can return `r == 0` even when this thread already holds the write lock.
+        // We thus check for this situation ourselves and panic when detecting that a thread
+        // got the write lock more than once, or got a read and a write lock.
         if r == libc::EAGAIN {
             panic!("rwlock maximum reader count exceeded");
         } else if r == libc::EDEADLK || (r == 0 && *self.write_locked.get()) {
+            // Above, we make sure to only access `write_locked` when `r == 0` to avoid
+            // data races.
             if r == 0 {
+                // `pthread_rwlock_rdlock` succeeded when it should not have.
                 self.raw_unlock();
             }
             panic!("rwlock read lock would result in deadlock");
@@ -56,6 +55,7 @@ impl RWLock {
         let r = libc::pthread_rwlock_tryrdlock(self.inner.get());
         if r == 0 {
             if *self.write_locked.get() {
+                // `pthread_rwlock_tryrdlock` succeeded when it should not have.
                 self.raw_unlock();
                 false
             } else {
@@ -69,18 +69,21 @@ impl RWLock {
     #[inline]
     pub unsafe fn write(&self) {
         let r = libc::pthread_rwlock_wrlock(self.inner.get());
-        // See comments above for why we check for EDEADLK and write_locked. We
-        // also need to check that num_readers is 0.
+        // See comments above for why we check for EDEADLK and write_locked. For the same reason,
+        // we also need to check that there are no readers (tracked in `num_readers`).
         if r == libc::EDEADLK
-            || *self.write_locked.get()
+            || (r == 0 && *self.write_locked.get())
             || self.num_readers.load(Ordering::Relaxed) != 0
         {
+            // Above, we make sure to only access `write_locked` when `r == 0` to avoid
+            // data races.
             if r == 0 {
+                // `pthread_rwlock_wrlock` succeeded when it should not have.
                 self.raw_unlock();
             }
             panic!("rwlock write lock would result in deadlock");
         } else {
-            debug_assert_eq!(r, 0);
+            assert_eq!(r, 0);
         }
         *self.write_locked.get() = true;
     }
@@ -89,6 +92,7 @@ impl RWLock {
         let r = libc::pthread_rwlock_trywrlock(self.inner.get());
         if r == 0 {
             if *self.write_locked.get() || self.num_readers.load(Ordering::Relaxed) != 0 {
+                // `pthread_rwlock_trywrlock` succeeded when it should not have.
                 self.raw_unlock();
                 false
             } else {

--- a/src/libstd/sys/unix/rwlock.rs
+++ b/src/libstd/sys/unix/rwlock.rs
@@ -46,7 +46,9 @@ impl RWLock {
             }
             panic!("rwlock read lock would result in deadlock");
         } else {
-            assert_eq!(r, 0);
+            // According to POSIX, for a properly initialized rwlock this can only
+            // return EAGAIN or EDEADLK or 0. We rely on that.
+            debug_assert_eq!(r, 0);
             self.num_readers.fetch_add(1, Ordering::Relaxed);
         }
     }
@@ -83,7 +85,9 @@ impl RWLock {
             }
             panic!("rwlock write lock would result in deadlock");
         } else {
-            assert_eq!(r, 0);
+            // According to POSIX, for a properly initialized rwlock this can only
+            // return EDEADLK or 0. We rely on that.
+            debug_assert_eq!(r, 0);
         }
         *self.write_locked.get() = true;
     }

--- a/src/test/codegen/unchecked-float-casts.rs
+++ b/src/test/codegen/unchecked-float-casts.rs
@@ -1,7 +1,5 @@
-// compile-flags: -C no-prepopulate-passes
-
-// This file tests that we don't generate any code for saturation if
-// -Z saturating-float-casts is not enabled.
+// This file tests that we don't generate any code for saturation when using the
+// unchecked intrinsics.
 
 #![crate_type = "lib"]
 
@@ -12,7 +10,7 @@ pub fn f32_to_u32(x: f32) -> u32 {
     // CHECK-NOT: fcmp
     // CHECK-NOT: icmp
     // CHECK-NOT: select
-    x as u32
+    unsafe { x.to_int_unchecked() }
 }
 
 // CHECK-LABEL: @f32_to_i32
@@ -22,7 +20,7 @@ pub fn f32_to_i32(x: f32) -> i32 {
     // CHECK-NOT: fcmp
     // CHECK-NOT: icmp
     // CHECK-NOT: select
-    x as i32
+    unsafe { x.to_int_unchecked() }
 }
 
 #[no_mangle]
@@ -31,5 +29,5 @@ pub fn f64_to_u16(x: f64) -> u16 {
     // CHECK-NOT: fcmp
     // CHECK-NOT: icmp
     // CHECK-NOT: select
-    x as u16
+    unsafe { x.to_int_unchecked() }
 }

--- a/src/test/ui/deriving/deriving-hash.rs
+++ b/src/test/ui/deriving/deriving-hash.rs
@@ -24,7 +24,7 @@ struct Person {
 enum E { A=1, B }
 
 fn hash<T: Hash>(t: &T) -> u64 {
-    let mut s = SipHasher::new_with_keys(0, 0);
+    let mut s = SipHasher::new();
     t.hash(&mut s);
     s.finish()
 }

--- a/src/test/ui/issues/issue-16530.rs
+++ b/src/test/ui/issues/issue-16530.rs
@@ -7,9 +7,9 @@ use std::hash::{SipHasher, Hasher, Hash};
 struct Empty;
 
 pub fn main() {
-    let mut s1 = SipHasher::new_with_keys(0, 0);
+    let mut s1 = SipHasher::new();
     Empty.hash(&mut s1);
-    let mut s2 = SipHasher::new_with_keys(0, 0);
+    let mut s2 = SipHasher::new();
     Empty.hash(&mut s2);
     assert_eq!(s1.finish(), s2.finish());
 }

--- a/src/test/ui/numbers-arithmetic/saturating-float-casts.rs
+++ b/src/test/ui/numbers-arithmetic/saturating-float-casts.rs
@@ -1,14 +1,19 @@
 // run-pass
 // Tests saturating float->int casts. See u128-as-f32.rs for the opposite direction.
+//
+// Some of these tests come from a similar file in miri,
+// tests/run-pass/float.rs. They're just duplicated currently but we may want
+// to merge this in the future.
 
 #![feature(test, stmt_expr_attributes)]
+#![feature(track_caller)]
 #![deny(overflowing_literals)]
 extern crate test;
 
 use std::{f32, f64};
-use std::{u8, i8, u16, i16, u32, i32, u64, i64};
-#[cfg(not(target_os="emscripten"))]
-use std::{u128, i128};
+#[cfg(not(target_os = "emscripten"))]
+use std::{i128, u128};
+use std::{i16, i32, i64, i8, u16, u32, u64, u8};
 use test::black_box;
 
 macro_rules! test {
@@ -84,11 +89,459 @@ macro_rules! fptoui_tests {
     })
 }
 
+use std::fmt::Debug;
+
+// Helper function to avoid promotion so that this tests "run-time" casts, not CTFE.
+#[track_caller]
+#[inline(never)]
+fn assert_eq<T: PartialEq + Debug>(x: T, y: T) {
+    assert_eq!(x, y);
+}
+
+trait FloatToInt<Int>: Copy {
+    fn cast(self) -> Int;
+    unsafe fn cast_unchecked(self) -> Int;
+}
+
+impl FloatToInt<i8> for f32 {
+    fn cast(self) -> i8 {
+        self as _
+    }
+    unsafe fn cast_unchecked(self) -> i8 {
+        self.to_int_unchecked()
+    }
+}
+impl FloatToInt<i32> for f32 {
+    fn cast(self) -> i32 {
+        self as _
+    }
+    unsafe fn cast_unchecked(self) -> i32 {
+        self.to_int_unchecked()
+    }
+}
+impl FloatToInt<u32> for f32 {
+    fn cast(self) -> u32 {
+        self as _
+    }
+    unsafe fn cast_unchecked(self) -> u32 {
+        self.to_int_unchecked()
+    }
+}
+impl FloatToInt<i64> for f32 {
+    fn cast(self) -> i64 {
+        self as _
+    }
+    unsafe fn cast_unchecked(self) -> i64 {
+        self.to_int_unchecked()
+    }
+}
+impl FloatToInt<u64> for f32 {
+    fn cast(self) -> u64 {
+        self as _
+    }
+    unsafe fn cast_unchecked(self) -> u64 {
+        self.to_int_unchecked()
+    }
+}
+
+impl FloatToInt<i8> for f64 {
+    fn cast(self) -> i8 {
+        self as _
+    }
+    unsafe fn cast_unchecked(self) -> i8 {
+        self.to_int_unchecked()
+    }
+}
+impl FloatToInt<i32> for f64 {
+    fn cast(self) -> i32 {
+        self as _
+    }
+    unsafe fn cast_unchecked(self) -> i32 {
+        self.to_int_unchecked()
+    }
+}
+impl FloatToInt<u32> for f64 {
+    fn cast(self) -> u32 {
+        self as _
+    }
+    unsafe fn cast_unchecked(self) -> u32 {
+        self.to_int_unchecked()
+    }
+}
+impl FloatToInt<i64> for f64 {
+    fn cast(self) -> i64 {
+        self as _
+    }
+    unsafe fn cast_unchecked(self) -> i64 {
+        self.to_int_unchecked()
+    }
+}
+impl FloatToInt<u64> for f64 {
+    fn cast(self) -> u64 {
+        self as _
+    }
+    unsafe fn cast_unchecked(self) -> u64 {
+        self.to_int_unchecked()
+    }
+}
+// FIXME emscripten does not support i128
+#[cfg(not(target_os = "emscripten"))]
+impl FloatToInt<i128> for f64 {
+    fn cast(self) -> i128 {
+        self as _
+    }
+    unsafe fn cast_unchecked(self) -> i128 {
+        self.to_int_unchecked()
+    }
+}
+// FIXME emscripten does not support i128
+#[cfg(not(target_os = "emscripten"))]
+impl FloatToInt<u128> for f64 {
+    fn cast(self) -> u128 {
+        self as _
+    }
+    unsafe fn cast_unchecked(self) -> u128 {
+        self.to_int_unchecked()
+    }
+}
+
+/// Test this cast both via `as` and via `to_int_unchecked` (i.e., it must not saturate).
+#[track_caller]
+#[inline(never)]
+fn test_both_cast<F, I>(x: F, y: I)
+where
+    F: FloatToInt<I>,
+    I: PartialEq + Debug,
+{
+    assert_eq!(x.cast(), y);
+    assert_eq!(unsafe { x.cast_unchecked() }, y);
+}
+
+fn basic() {
+    // basic arithmetic
+    assert_eq(6.0_f32 * 6.0_f32, 36.0_f32);
+    assert_eq(6.0_f64 * 6.0_f64, 36.0_f64);
+    assert_eq(-{ 5.0_f32 }, -5.0_f32);
+    assert_eq(-{ 5.0_f64 }, -5.0_f64);
+    // infinities, NaN
+    assert!((5.0_f32 / 0.0).is_infinite());
+    assert_ne!({ 5.0_f32 / 0.0 }, { -5.0_f32 / 0.0 });
+    assert!((5.0_f64 / 0.0).is_infinite());
+    assert_ne!({ 5.0_f64 / 0.0 }, { 5.0_f64 / -0.0 });
+    assert!((-5.0_f32).sqrt().is_nan());
+    assert!((-5.0_f64).sqrt().is_nan());
+    assert_ne!(f32::NAN, f32::NAN);
+    assert_ne!(f64::NAN, f64::NAN);
+    // negative zero
+    let posz = 0.0f32;
+    let negz = -0.0f32;
+    assert_eq(posz, negz);
+    assert_ne!(posz.to_bits(), negz.to_bits());
+    let posz = 0.0f64;
+    let negz = -0.0f64;
+    assert_eq(posz, negz);
+    assert_ne!(posz.to_bits(), negz.to_bits());
+    // byte-level transmute
+    let x: u64 = unsafe { std::mem::transmute(42.0_f64) };
+    let y: f64 = unsafe { std::mem::transmute(x) };
+    assert_eq(y, 42.0_f64);
+    let x: u32 = unsafe { std::mem::transmute(42.0_f32) };
+    let y: f32 = unsafe { std::mem::transmute(x) };
+    assert_eq(y, 42.0_f32);
+}
+
+fn casts() {
+    // f32 -> i8
+    test_both_cast::<f32, i8>(127.99, 127);
+    test_both_cast::<f32, i8>(-128.99, -128);
+
+    // f32 -> i32
+    test_both_cast::<f32, i32>(0.0, 0);
+    test_both_cast::<f32, i32>(-0.0, 0);
+    test_both_cast::<f32, i32>(/*0x1p-149*/ f32::from_bits(0x00000001), 0);
+    test_both_cast::<f32, i32>(/*-0x1p-149*/ f32::from_bits(0x80000001), 0);
+    test_both_cast::<f32, i32>(/*0x1.19999ap+0*/ f32::from_bits(0x3f8ccccd), 1);
+    test_both_cast::<f32, i32>(/*-0x1.19999ap+0*/ f32::from_bits(0xbf8ccccd), -1);
+    test_both_cast::<f32, i32>(1.9, 1);
+    test_both_cast::<f32, i32>(-1.9, -1);
+    test_both_cast::<f32, i32>(5.0, 5);
+    test_both_cast::<f32, i32>(-5.0, -5);
+    test_both_cast::<f32, i32>(2147483520.0, 2147483520);
+    test_both_cast::<f32, i32>(-2147483648.0, -2147483648);
+    // unrepresentable casts
+    assert_eq::<i32>(2147483648.0f32 as i32, i32::MAX);
+    assert_eq::<i32>(-2147483904.0f32 as i32, i32::MIN);
+    assert_eq::<i32>(f32::MAX as i32, i32::MAX);
+    assert_eq::<i32>(f32::MIN as i32, i32::MIN);
+    assert_eq::<i32>(f32::INFINITY as i32, i32::MAX);
+    assert_eq::<i32>(f32::NEG_INFINITY as i32, i32::MIN);
+    assert_eq::<i32>(f32::NAN as i32, 0);
+    assert_eq::<i32>((-f32::NAN) as i32, 0);
+
+    // f32 -> u32
+    test_both_cast::<f32, u32>(0.0, 0);
+    test_both_cast::<f32, u32>(-0.0, 0);
+    test_both_cast::<f32, u32>(-0.9999999, 0);
+    test_both_cast::<f32, u32>(/*0x1p-149*/ f32::from_bits(0x1), 0);
+    test_both_cast::<f32, u32>(/*-0x1p-149*/ f32::from_bits(0x80000001), 0);
+    test_both_cast::<f32, u32>(/*0x1.19999ap+0*/ f32::from_bits(0x3f8ccccd), 1);
+    test_both_cast::<f32, u32>(1.9, 1);
+    test_both_cast::<f32, u32>(5.0, 5);
+    test_both_cast::<f32, u32>(2147483648.0, 0x8000_0000);
+    test_both_cast::<f32, u32>(4294967040.0, 0u32.wrapping_sub(256));
+    test_both_cast::<f32, u32>(/*-0x1.ccccccp-1*/ f32::from_bits(0xbf666666), 0);
+    test_both_cast::<f32, u32>(/*-0x1.fffffep-1*/ f32::from_bits(0xbf7fffff), 0);
+    test_both_cast::<f32, u32>((u32::MAX - 128) as f32, u32::MAX - 255); // rounding loss
+
+    // unrepresentable casts:
+
+    // rounds up and then becomes unrepresentable
+    assert_eq::<u32>((u32::MAX - 127) as f32 as u32, u32::MAX);
+
+    assert_eq::<u32>(4294967296.0f32 as u32, u32::MAX);
+    assert_eq::<u32>(-5.0f32 as u32, 0);
+    assert_eq::<u32>(f32::MAX as u32, u32::MAX);
+    assert_eq::<u32>(f32::MIN as u32, 0);
+    assert_eq::<u32>(f32::INFINITY as u32, u32::MAX);
+    assert_eq::<u32>(f32::NEG_INFINITY as u32, 0);
+    assert_eq::<u32>(f32::NAN as u32, 0);
+    assert_eq::<u32>((-f32::NAN) as u32, 0);
+
+    // f32 -> i64
+    test_both_cast::<f32, i64>(4294967296.0, 4294967296);
+    test_both_cast::<f32, i64>(-4294967296.0, -4294967296);
+    test_both_cast::<f32, i64>(9223371487098961920.0, 9223371487098961920);
+    test_both_cast::<f32, i64>(-9223372036854775808.0, -9223372036854775808);
+
+    // f64 -> i8
+    test_both_cast::<f64, i8>(127.99, 127);
+    test_both_cast::<f64, i8>(-128.99, -128);
+
+    // f64 -> i32
+    test_both_cast::<f64, i32>(0.0, 0);
+    test_both_cast::<f64, i32>(-0.0, 0);
+    test_both_cast::<f64, i32>(/*0x1.199999999999ap+0*/ f64::from_bits(0x3ff199999999999a), 1);
+    test_both_cast::<f64, i32>(
+        /*-0x1.199999999999ap+0*/ f64::from_bits(0xbff199999999999a),
+        -1,
+    );
+    test_both_cast::<f64, i32>(1.9, 1);
+    test_both_cast::<f64, i32>(-1.9, -1);
+    test_both_cast::<f64, i32>(1e8, 100_000_000);
+    test_both_cast::<f64, i32>(2147483647.0, 2147483647);
+    test_both_cast::<f64, i32>(-2147483648.0, -2147483648);
+    // unrepresentable casts
+    assert_eq::<i32>(2147483648.0f64 as i32, i32::MAX);
+    assert_eq::<i32>(-2147483649.0f64 as i32, i32::MIN);
+
+    // f64 -> i64
+    test_both_cast::<f64, i64>(0.0, 0);
+    test_both_cast::<f64, i64>(-0.0, 0);
+    test_both_cast::<f64, i64>(/*0x0.0000000000001p-1022*/ f64::from_bits(0x1), 0);
+    test_both_cast::<f64, i64>(
+        /*-0x0.0000000000001p-1022*/ f64::from_bits(0x8000000000000001),
+        0,
+    );
+    test_both_cast::<f64, i64>(/*0x1.199999999999ap+0*/ f64::from_bits(0x3ff199999999999a), 1);
+    test_both_cast::<f64, i64>(
+        /*-0x1.199999999999ap+0*/ f64::from_bits(0xbff199999999999a),
+        -1,
+    );
+    test_both_cast::<f64, i64>(5.0, 5);
+    test_both_cast::<f64, i64>(5.9, 5);
+    test_both_cast::<f64, i64>(-5.0, -5);
+    test_both_cast::<f64, i64>(-5.9, -5);
+    test_both_cast::<f64, i64>(4294967296.0, 4294967296);
+    test_both_cast::<f64, i64>(-4294967296.0, -4294967296);
+    test_both_cast::<f64, i64>(9223372036854774784.0, 9223372036854774784);
+    test_both_cast::<f64, i64>(-9223372036854775808.0, -9223372036854775808);
+    // unrepresentable casts
+    assert_eq::<i64>(9223372036854775808.0f64 as i64, i64::MAX);
+    assert_eq::<i64>(-9223372036854777856.0f64 as i64, i64::MIN);
+    assert_eq::<i64>(f64::MAX as i64, i64::MAX);
+    assert_eq::<i64>(f64::MIN as i64, i64::MIN);
+    assert_eq::<i64>(f64::INFINITY as i64, i64::MAX);
+    assert_eq::<i64>(f64::NEG_INFINITY as i64, i64::MIN);
+    assert_eq::<i64>(f64::NAN as i64, 0);
+    assert_eq::<i64>((-f64::NAN) as i64, 0);
+
+    // f64 -> u64
+    test_both_cast::<f64, u64>(0.0, 0);
+    test_both_cast::<f64, u64>(-0.0, 0);
+    test_both_cast::<f64, u64>(-0.99999999999, 0);
+    test_both_cast::<f64, u64>(5.0, 5);
+    test_both_cast::<f64, u64>(1e16, 10000000000000000);
+    test_both_cast::<f64, u64>((u64::MAX - 1024) as f64, u64::MAX - 2047); // rounding loss
+    test_both_cast::<f64, u64>(9223372036854775808.0, 9223372036854775808);
+    // unrepresentable casts
+    assert_eq::<u64>(-5.0f64 as u64, 0);
+    // rounds up and then becomes unrepresentable
+    assert_eq::<u64>((u64::MAX - 1023) as f64 as u64, u64::MAX);
+    assert_eq::<u64>(18446744073709551616.0f64 as u64, u64::MAX);
+    assert_eq::<u64>(f64::MAX as u64, u64::MAX);
+    assert_eq::<u64>(f64::MIN as u64, 0);
+    assert_eq::<u64>(f64::INFINITY as u64, u64::MAX);
+    assert_eq::<u64>(f64::NEG_INFINITY as u64, 0);
+    assert_eq::<u64>(f64::NAN as u64, 0);
+    assert_eq::<u64>((-f64::NAN) as u64, 0);
+
+    // FIXME emscripten does not support i128
+    #[cfg(not(target_os = "emscripten"))]
+    {
+        // f64 -> i128
+        assert_eq::<i128>(f64::MAX as i128, i128::MAX);
+        assert_eq::<i128>(f64::MIN as i128, i128::MIN);
+
+        // f64 -> u128
+        assert_eq::<u128>(f64::MAX as u128, u128::MAX);
+        assert_eq::<u128>(f64::MIN as u128, 0);
+    }
+
+    // int -> f32
+    assert_eq::<f32>(127i8 as f32, 127.0);
+    assert_eq::<f32>(2147483647i32 as f32, 2147483648.0);
+    assert_eq::<f32>((-2147483648i32) as f32, -2147483648.0);
+    assert_eq::<f32>(1234567890i32 as f32, /*0x1.26580cp+30*/ f32::from_bits(0x4e932c06));
+    assert_eq::<f32>(16777217i32 as f32, 16777216.0);
+    assert_eq::<f32>((-16777217i32) as f32, -16777216.0);
+    assert_eq::<f32>(16777219i32 as f32, 16777220.0);
+    assert_eq::<f32>((-16777219i32) as f32, -16777220.0);
+    assert_eq::<f32>(
+        0x7fffff4000000001i64 as f32,
+        /*0x1.fffffep+62*/ f32::from_bits(0x5effffff),
+    );
+    assert_eq::<f32>(
+        0x8000004000000001u64 as i64 as f32,
+        /*-0x1.fffffep+62*/ f32::from_bits(0xdeffffff),
+    );
+    assert_eq::<f32>(
+        0x0020000020000001i64 as f32,
+        /*0x1.000002p+53*/ f32::from_bits(0x5a000001),
+    );
+    assert_eq::<f32>(
+        0xffdfffffdfffffffu64 as i64 as f32,
+        /*-0x1.000002p+53*/ f32::from_bits(0xda000001),
+    );
+    // FIXME emscripten does not support i128
+    #[cfg(not(target_os = "emscripten"))]
+    {
+        assert_eq::<f32>(i128::MIN as f32, -170141183460469231731687303715884105728.0f32);
+        assert_eq::<f32>(u128::MAX as f32, f32::INFINITY); // saturation
+    }
+
+    // int -> f64
+    assert_eq::<f64>(127i8 as f64, 127.0);
+    assert_eq::<f64>(i16::MIN as f64, -32768.0f64);
+    assert_eq::<f64>(2147483647i32 as f64, 2147483647.0);
+    assert_eq::<f64>(-2147483648i32 as f64, -2147483648.0);
+    assert_eq::<f64>(987654321i32 as f64, 987654321.0);
+    assert_eq::<f64>(9223372036854775807i64 as f64, 9223372036854775807.0);
+    assert_eq::<f64>(-9223372036854775808i64 as f64, -9223372036854775808.0);
+    assert_eq::<f64>(4669201609102990i64 as f64, 4669201609102990.0); // Feigenbaum (?)
+    assert_eq::<f64>(9007199254740993i64 as f64, 9007199254740992.0);
+    assert_eq::<f64>(-9007199254740993i64 as f64, -9007199254740992.0);
+    assert_eq::<f64>(9007199254740995i64 as f64, 9007199254740996.0);
+    assert_eq::<f64>(-9007199254740995i64 as f64, -9007199254740996.0);
+    // FIXME emscripten does not support i128
+    #[cfg(not(target_os = "emscripten"))]
+    {
+        // even that fits...
+        assert_eq::<f64>(u128::MAX as f64, 340282366920938463463374607431768211455.0f64);
+    }
+
+    // f32 -> f64
+    assert_eq::<u64>((0.0f32 as f64).to_bits(), 0.0f64.to_bits());
+    assert_eq::<u64>(((-0.0f32) as f64).to_bits(), (-0.0f64).to_bits());
+    assert_eq::<f64>(5.0f32 as f64, 5.0f64);
+    assert_eq::<f64>(
+        /*0x1p-149*/ f32::from_bits(0x1) as f64,
+        /*0x1p-149*/ f64::from_bits(0x36a0000000000000),
+    );
+    assert_eq::<f64>(
+        /*-0x1p-149*/ f32::from_bits(0x80000001) as f64,
+        /*-0x1p-149*/ f64::from_bits(0xb6a0000000000000),
+    );
+    assert_eq::<f64>(
+        /*0x1.fffffep+127*/ f32::from_bits(0x7f7fffff) as f64,
+        /*0x1.fffffep+127*/ f64::from_bits(0x47efffffe0000000),
+    );
+    assert_eq::<f64>(
+        /*-0x1.fffffep+127*/ (-f32::from_bits(0x7f7fffff)) as f64,
+        /*-0x1.fffffep+127*/ -f64::from_bits(0x47efffffe0000000),
+    );
+    assert_eq::<f64>(
+        /*0x1p-119*/ f32::from_bits(0x4000000) as f64,
+        /*0x1p-119*/ f64::from_bits(0x3880000000000000),
+    );
+    assert_eq::<f64>(
+        /*0x1.8f867ep+125*/ f32::from_bits(0x7e47c33f) as f64,
+        6.6382536710104395e+37,
+    );
+    assert_eq::<f64>(f32::INFINITY as f64, f64::INFINITY);
+    assert_eq::<f64>(f32::NEG_INFINITY as f64, f64::NEG_INFINITY);
+
+    // f64 -> f32
+    assert_eq::<u32>((0.0f64 as f32).to_bits(), 0.0f32.to_bits());
+    assert_eq::<u32>(((-0.0f64) as f32).to_bits(), (-0.0f32).to_bits());
+    assert_eq::<f32>(5.0f64 as f32, 5.0f32);
+    assert_eq::<f32>(/*0x0.0000000000001p-1022*/ f64::from_bits(0x1) as f32, 0.0);
+    assert_eq::<f32>(/*-0x0.0000000000001p-1022*/ (-f64::from_bits(0x1)) as f32, -0.0);
+    assert_eq::<f32>(
+        /*0x1.fffffe0000000p-127*/ f64::from_bits(0x380fffffe0000000) as f32,
+        /*0x1p-149*/ f32::from_bits(0x800000),
+    );
+    assert_eq::<f32>(
+        /*0x1.4eae4f7024c7p+108*/ f64::from_bits(0x46b4eae4f7024c70) as f32,
+        /*0x1.4eae5p+108*/ f32::from_bits(0x75a75728),
+    );
+    assert_eq::<f32>(f64::MAX as f32, f32::INFINITY);
+    assert_eq::<f32>(f64::MIN as f32, f32::NEG_INFINITY);
+    assert_eq::<f32>(f64::INFINITY as f32, f32::INFINITY);
+    assert_eq::<f32>(f64::NEG_INFINITY as f32, f32::NEG_INFINITY);
+}
+
+fn ops() {
+    // f32 min/max
+    assert_eq((1.0 as f32).max(-1.0), 1.0);
+    assert_eq((1.0 as f32).min(-1.0), -1.0);
+    assert_eq(f32::NAN.min(9.0), 9.0);
+    assert_eq(f32::NAN.max(-9.0), -9.0);
+    assert_eq((9.0 as f32).min(f32::NAN), 9.0);
+    assert_eq((-9.0 as f32).max(f32::NAN), -9.0);
+
+    // f64 min/max
+    assert_eq((1.0 as f64).max(-1.0), 1.0);
+    assert_eq((1.0 as f64).min(-1.0), -1.0);
+    assert_eq(f64::NAN.min(9.0), 9.0);
+    assert_eq(f64::NAN.max(-9.0), -9.0);
+    assert_eq((9.0 as f64).min(f64::NAN), 9.0);
+    assert_eq((-9.0 as f64).max(f64::NAN), -9.0);
+
+    // f32 copysign
+    assert_eq(3.5_f32.copysign(0.42), 3.5_f32);
+    assert_eq(3.5_f32.copysign(-0.42), -3.5_f32);
+    assert_eq((-3.5_f32).copysign(0.42), 3.5_f32);
+    assert_eq((-3.5_f32).copysign(-0.42), -3.5_f32);
+    assert!(f32::NAN.copysign(1.0).is_nan());
+
+    // f64 copysign
+    assert_eq(3.5_f64.copysign(0.42), 3.5_f64);
+    assert_eq(3.5_f64.copysign(-0.42), -3.5_f64);
+    assert_eq((-3.5_f64).copysign(0.42), 3.5_f64);
+    assert_eq((-3.5_f64).copysign(-0.42), -3.5_f64);
+    assert!(f64::NAN.copysign(1.0).is_nan());
+}
+
 pub fn main() {
+    basic();
+    casts();
+    ops();
+
     common_fptoi_tests!(f* -> i8 i16 i32 i64 u8 u16 u32 u64);
     fptoui_tests!(f* -> u8 u16 u32 u64);
     // FIXME emscripten does not support i128
-    #[cfg(not(target_os="emscripten"))] {
+    #[cfg(not(target_os = "emscripten"))]
+    {
         common_fptoi_tests!(f* -> i128 u128);
         fptoui_tests!(f* -> u128);
     }
@@ -123,7 +576,7 @@ pub fn main() {
     test!(4294967296., f* -> u32, 4294967295);
 
     // # u128
-    #[cfg(not(target_os="emscripten"))]
+    #[cfg(not(target_os = "emscripten"))]
     {
         // float->int:
         test_c!(f32::MAX, f32 -> u128, 0xffffff00000000000000000000000000);

--- a/src/test/ui/numbers-arithmetic/saturating-float-casts.rs
+++ b/src/test/ui/numbers-arithmetic/saturating-float-casts.rs
@@ -1,6 +1,5 @@
 // run-pass
 // Tests saturating float->int casts. See u128-as-f32.rs for the opposite direction.
-// compile-flags: -Z saturating-float-casts
 
 #![feature(test, stmt_expr_attributes)]
 #![deny(overflowing_literals)]


### PR DESCRIPTION
Successful merges:

 - #71269 (Define UB in float-to-int casts to saturate)
 - #71510 (Btreemap iter intertwined)
 - #71591 (use new interface to create threads on HermitCore)
 - #71727 (SipHasher with keys initialized to 0 should just use new())
 - #71819 (x.py: Give a more helpful error message if curl isn't installed)
 - #71889 (Explain our RwLock implementation)
 - #71905 (Add command aliases from Cargo to x.py commands)
 - #71914 (Backport 1.43.1 release notes to master)

Failed merges:


r? @ghost