### PR TITLE
Add comment for `Ord` implementation for array

### DIFF
--- a/src/libcore/array/mod.rs
+++ b/src/libcore/array/mod.rs
@@ -375,6 +375,7 @@ where
     }
 }
 
+/// Implements comparison of arrays lexicographically.
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: Ord, const N: usize> Ord for [T; N]
 where


### PR DESCRIPTION
Corresponding to `Ord` implementation for slice. It hints new comer the rule of comparing two arrays.