### PR TITLE
Dead-code pass highlights too much of impl functions

### DIFF
--- a/src/test/ui/lint/dead-code/lint-dead-code-3.stderr
+++ b/src/test/ui/lint/dead-code/lint-dead-code-3.stderr
@@ -11,10 +11,10 @@ LL | #![deny(dead_code)]
    |         ^^^^^^^^^
 
 error: associated function is never used: `foo`
-  --> $DIR/lint-dead-code-3.rs:15:5
+  --> $DIR/lint-dead-code-3.rs:15:8
    |
 LL |     fn foo(&self) {
-   |     ^^^^^^^^^^^^^
+   |        ^^^
 
 error: function is never used: `bar`
   --> $DIR/lint-dead-code-3.rs:20:4

--- a/src/test/ui/lint/dead-code/lint-dead-code-6.rs
+++ b/src/test/ui/lint/dead-code/lint-dead-code-6.rs
@@ -1,0 +1,20 @@
+#![deny(dead_code)]
+
+struct UnusedStruct; //~ ERROR struct is never constructed: `UnusedStruct`
+impl UnusedStruct {
+    fn unused_impl_fn_1() { //~ ERROR associated function is never used: `unused_impl_fn_1`
+        println!("blah");
+    }
+
+    fn unused_impl_fn_2(var: i32) { //~ ERROR associated function is never used: `unused_impl_fn_2`
+        println!("foo {}", var);
+    }
+
+    fn unused_impl_fn_3( //~ ERROR associated function is never used: `unused_impl_fn_3`
+        var: i32,
+    ) {
+        println!("bar {}", var);
+    }
+}
+
+fn main() {}

--- a/src/test/ui/lint/dead-code/lint-dead-code-6.stderr
+++ b/src/test/ui/lint/dead-code/lint-dead-code-6.stderr
@@ -1,0 +1,32 @@
+error: struct is never constructed: `UnusedStruct`
+  --> $DIR/lint-dead-code-6.rs:3:8
+   |
+LL | struct UnusedStruct;
+   |        ^^^^^^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/lint-dead-code-6.rs:1:9
+   |
+LL | #![deny(dead_code)]
+   |         ^^^^^^^^^
+
+error: associated function is never used: `unused_impl_fn_1`
+  --> $DIR/lint-dead-code-6.rs:5:8
+   |
+LL |     fn unused_impl_fn_1() {
+   |        ^^^^^^^^^^^^^^^^
+
+error: associated function is never used: `unused_impl_fn_2`
+  --> $DIR/lint-dead-code-6.rs:9:8
+   |
+LL |     fn unused_impl_fn_2(var: i32) {
+   |        ^^^^^^^^^^^^^^^^
+
+error: associated function is never used: `unused_impl_fn_3`
+  --> $DIR/lint-dead-code-6.rs:13:8
+   |
+LL |     fn unused_impl_fn_3(
+   |        ^^^^^^^^^^^^^^^^
+
+error: aborting due to 4 previous errors
+


### PR DESCRIPTION
Fixes #66627.
Previous diagnostic:
```
error: method is never used: `unused_impl_fn_3`
  --> src/main.rs:28:5
   |
28 | /     fn unused_impl_fn_3(
29 | |         var: i32,
30 | |     ) {
31 | |         println!("bar {}", var);
32 | |     }
   | |_____^
```
New diagnostic:
```
error: associated function is never used: `unused_impl_fn_3`
  --> $DIR/lint-dead-code-6.rs:13:8
   |
LL |     fn unused_impl_fn_3(
   |        ^^^^^^^^^^^^^^^^
```

This makes associated functions in line with free-standing functions.