### PR TITLE
Fix bootstrap failing on win32

### DIFF
--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -180,12 +180,15 @@ def format_build_time(duration):
 def default_build_triple():
     """Build triple as in LLVM"""
     default_encoding = sys.getdefaultencoding()
-    required = not sys.platform == 'win32'
-    ostype = require(["uname", "-s"], exit=required).decode(default_encoding)
-    cputype = require(['uname', '-m'], exit=required).decode(default_encoding)
+    required = sys.platform != 'win32'
+    ostype = require(["uname", "-s"], exit=required)
+    cputype = require(['uname', '-m'], exit=required)
 
     if ostype is None or cputype is None:
         return 'x86_64-pc-windows-msvc'
+
+    ostype = ostype.decode(default_encoding)
+    cputype = cputype.decode(default_encoding)
 
     # The goal here is to come up with the same triple as LLVM would,
     # at least for the subset of platforms we're willing to target.


### PR DESCRIPTION
```powershell
python x.py -h # or really any x.py command
```
would fail with
```
info: Downloading and building bootstrap before processing --help
      command. See src/bootstrap/README.md for help with common
      commands.
Updating only changed submodules
Submodules updated in 0.15 seconds
Traceback (most recent call last):
  File "x.py", line 11, in <module>
    bootstrap.main()
  File "C:\Users\Joshua\Projects\forks\rust\src\bootstrap\bootstrap.py", line 960, in main
    bootstrap(help_triggered)
  File "C:\Users\Joshua\Projects\forks\rust\src\bootstrap\bootstrap.py", line 925, in bootstrap
    build.build = args.build or build.build_triple()
  File "C:\Users\Joshua\Projects\forks\rust\src\bootstrap\bootstrap.py", line 731, in build_triple
    return default_build_triple()
  File "C:\Users\Joshua\Projects\forks\rust\src\bootstrap\bootstrap.py", line 184, in default_build_triple
    ostype = require(["uname", "-s"], exit=required).decode(default_encoding)
AttributeError: 'NoneType' object has no attribute 'decode'
```

This PR defers the `decode` call until after we're sure `ostype` and `cputype` are not `None`, as they would be on Windows since `uname` doesn't exist