### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/src/liballoc/fmt.rs
+++ b/src/liballoc/fmt.rs
@@ -50,8 +50,8 @@
 //! The internal iterator over the argument has not been advanced by the time
 //! the first `{}` is seen, so it prints the first argument. Then upon reaching
 //! the second `{}`, the iterator has advanced forward to the second argument.
-//! Essentially, parameters which explicitly name their argument do not affect
-//! parameters which do not name an argument in terms of positional specifiers.
+//! Essentially, parameters that explicitly name their argument do not affect
+//! parameters that do not name an argument in terms of positional specifiers.
 //!
 //! A format string is required to use all of its arguments, otherwise it is a
 //! compile-time error. You may refer to the same argument more than once in the
@@ -60,7 +60,7 @@
 //! ## Named parameters
 //!
 //! Rust itself does not have a Python-like equivalent of named parameters to a
-//! function, but the [`format!`] macro is a syntax extension which allows it to
+//! function, but the [`format!`] macro is a syntax extension that allows it to
 //! leverage named parameters. Named parameters are listed at the end of the
 //! argument list and have the syntax:
 //!
@@ -77,7 +77,7 @@
 //! ```
 //!
 //! It is not valid to put positional parameters (those without names) after
-//! arguments which have names. Like with positional parameters, it is not
+//! arguments that have names. Like with positional parameters, it is not
 //! valid to provide named parameters that are unused by the format string.
 //!
 //! # Formatting Parameters

--- a/src/liballoc/fmt.rs
+++ b/src/liballoc/fmt.rs
@@ -173,9 +173,9 @@
 //!         like `{:08}` would yield `00000001` for the integer `1`, while the
 //!         same format would yield `-0000001` for the integer `-1`. Notice that
 //!         the negative version has one fewer zero than the positive version.
-//!         Note that padding zeroes are always placed after the sign (if any)
+//!         Note that padding zeros are always placed after the sign (if any)
 //!         and before the digits. When used together with the `#` flag, a similar
-//!         rule applies: padding zeroes are inserted after the prefix but before
+//!         rule applies: padding zeros are inserted after the prefix but before
 //!         the digits. The prefix is included in the total width.
 //!
 //! ## Precision

--- a/src/liballoc/fmt.rs
+++ b/src/liballoc/fmt.rs
@@ -495,7 +495,7 @@
 //! This structure can then be passed to the [`write`] and [`format`] functions
 //! inside this module in order to process the format string.
 //! The goal of this macro is to even further prevent intermediate allocations
-//! when dealing formatting strings.
+//! when dealing with formatting strings.
 //!
 //! For example, a logging library could use the standard formatting syntax, but
 //! it would internally pass around this structure until it has been determined

--- a/src/liballoc/fmt.rs
+++ b/src/liballoc/fmt.rs
@@ -470,7 +470,7 @@
 //!
 //! ### `format_args!`
 //!
-//! This is a curious macro which is used to safely pass around
+//! This is a curious macro used to safely pass around
 //! an opaque object describing the format string. This object
 //! does not require any heap allocations to create, and it only
 //! references information on the stack. Under the hood, all of

--- a/src/liballoc/fmt.rs
+++ b/src/liballoc/fmt.rs
@@ -130,7 +130,7 @@
 //!
 //! The default [fill/alignment](#fillalignment) for non-numerics is a space and
 //! left-aligned. The
-//! default for numeric formatters is also a space but with right-alignment. If
+//! default for numeric formatters is also a space character but with right-alignment. If
 //! the `0` flag (see below) is specified for numerics, then the implicit fill character is
 //! `0`.
 //!

--- a/src/liballoc/fmt.rs
+++ b/src/liballoc/fmt.rs
@@ -161,7 +161,7 @@
 //!         `Signed` trait. This flag indicates that the correct sign (`+` or `-`)
 //!         should always be printed.
 //! * `-` - Currently not used
-//! * `#` - This flag is indicates that the "alternate" form of printing should
+//! * `#` - This flag indicates that the "alternate" form of printing should
 //!         be used. The alternate forms are:
 //!     * `#?` - pretty-print the [`Debug`] formatting
 //!     * `#x` - precedes the argument with a `0x`

--- a/src/liballoc/fmt.rs
+++ b/src/liballoc/fmt.rs
@@ -130,7 +130,7 @@
 //!
 //! The default [fill/alignment](#fillalignment) for non-numerics is a space and
 //! left-aligned. The
-//! defaults for numeric formatters is also a space but with right-alignment. If
+//! default for numeric formatters is also a space but with right-alignment. If
 //! the `0` flag (see below) is specified for numerics, then the implicit fill character is
 //! `0`.
 //!

--- a/src/liballoc/fmt.rs
+++ b/src/liballoc/fmt.rs
@@ -251,7 +251,7 @@
 //!
 //! In some programming languages, the behavior of string formatting functions
 //! depends on the operating system's locale setting. The format functions
-//! provided by Rust's standard library do not have any concept of locale, and
+//! provided by Rust's standard library do not have any concept of locale and
 //! will produce the same results on all systems regardless of user
 //! configuration.
 //!

--- a/src/librustc_mir/interpret/validity.rs
+++ b/src/librustc_mir/interpret/validity.rs
@@ -321,11 +321,12 @@ impl<'rt, 'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> ValidityVisitor<'rt, 'mir, '
                 try_validation!(
                     self.ecx.read_drop_type_from_vtable(vtable),
                     self.path,
-                    err_ub!(InvalidDropFn(..)) |
                     err_ub!(DanglingIntPointer(..)) |
                     err_ub!(InvalidFunctionPointer(..)) |
                     err_unsup!(ReadBytesAsPointer) =>
-                        { "invalid drop function pointer in vtable" },
+                        { "invalid drop function pointer in vtable (not pointing to a function)" },
+                    err_ub!(InvalidDropFn(..)) =>
+                        { "invalid drop function pointer in vtable (function has incompatible signature)" },
                 );
                 try_validation!(
                     self.ecx.read_size_and_align_from_vtable(vtable),
@@ -400,7 +401,7 @@ impl<'rt, 'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> ValidityVisitor<'rt, 'mir, '
             err_ub!(DanglingIntPointer(0, _)) =>
                 { "a NULL {}", kind },
             err_ub!(DanglingIntPointer(i, _)) =>
-                { "a dangling {} (address {} is unallocated)", kind, i },
+                { "a dangling {} (address 0x{:x} is unallocated)", kind, i },
             err_ub!(PointerOutOfBounds { .. }) =>
                 { "a dangling {} (going beyond the bounds of its allocation)", kind },
             err_unsup!(ReadBytesAsPointer) =>

--- a/src/librustc_typeck/check/closure.rs
+++ b/src/librustc_typeck/check/closure.rs
@@ -178,7 +178,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         match expected_ty.kind {
             ty::Dynamic(ref object_type, ..) => {
                 let sig = object_type.projection_bounds().find_map(|pb| {
-                    let pb = pb.with_self_ty(self.tcx, self.tcx.types.err);
+                    let pb = pb.with_self_ty(self.tcx, self.tcx.types.trait_object_dummy_self);
                     self.deduce_sig_from_projection(None, &pb)
                 });
                 let kind = object_type

--- a/src/libstd/sys/unix/ext/net.rs
+++ b/src/libstd/sys/unix/ext/net.rs
@@ -7,6 +7,7 @@ use libc;
 
 // FIXME(#43348): Make libc adapt #[doc(cfg(...))] so we don't need these fake definitions here?
 #[cfg(not(unix))]
+#[allow(non_camel_case_types)]
 mod libc {
     pub use libc::c_int;
     pub type socklen_t = u32;

--- a/src/libstd/sys/unix/ext/raw.rs
+++ b/src/libstd/sys/unix/ext/raw.rs
@@ -11,10 +11,15 @@
 #![allow(deprecated)]
 
 #[stable(feature = "raw_ext", since = "1.1.0")]
+#[allow(non_camel_case_types)]
 pub type uid_t = u32;
+
 #[stable(feature = "raw_ext", since = "1.1.0")]
+#[allow(non_camel_case_types)]
 pub type gid_t = u32;
+
 #[stable(feature = "raw_ext", since = "1.1.0")]
+#[allow(non_camel_case_types)]
 pub type pid_t = i32;
 
 #[doc(inline)]

--- a/src/test/auxiliary/rust_test_helpers.c
+++ b/src/test/auxiliary/rust_test_helpers.c
@@ -368,6 +368,7 @@ rust_dbg_unpack_option_u64(struct U8TaggedEnumOptionU64 o, uint64_t *into) {
         return 0;
     default:
         assert(0 && "unexpected tag");
+        return 0;
     }
 }
 
@@ -411,5 +412,6 @@ rust_dbg_unpack_option_u64u64(struct U8TaggedEnumOptionU64U64 o, uint64_t *a, ui
         return 0;
     default:
         assert(0 && "unexpected tag");
+        return 0;
     }
 }

--- a/src/test/codegen/ffi-out-of-bounds-loads.rs
+++ b/src/test/codegen/ffi-out-of-bounds-loads.rs
@@ -1,5 +1,8 @@
-// compile-flags: -C no-prepopulate-passes
 // Regression test for #29988
+
+// compile-flags: -C no-prepopulate-passes
+// only-x86_64
+// ignore-windows
 
 #[repr(C)]
 struct S {

--- a/src/test/codegen/ffi-out-of-bounds-loads.rs
+++ b/src/test/codegen/ffi-out-of-bounds-loads.rs
@@ -1,0 +1,22 @@
+// compile-flags: -C no-prepopulate-passes
+// Regression test for #29988
+
+#[repr(C)]
+struct S {
+    f1: i32,
+    f2: i32,
+    f3: i32,
+}
+
+extern {
+    fn foo(s: S);
+}
+
+fn main() {
+    let s = S { f1: 1, f2: 2, f3: 3 };
+    unsafe {
+        // CHECK: load { i64, i32 }, { i64, i32 }* {{.*}}, align 4
+        // CHECK: call void @foo({ i64, i32 } {{.*}})
+        foo(s);
+    }
+}

--- a/src/test/ui/consts/const-eval/ub-wide-ptr.stderr
+++ b/src/test/ui/consts/const-eval/ub-wide-ptr.stderr
@@ -170,7 +170,7 @@ error[E0080]: it is undefined behavior to use this value
   --> $DIR/ub-wide-ptr.rs:109:1
    |
 LL | const TRAIT_OBJ_BAD_DROP_FN_NULL: &dyn Trait = unsafe { mem::transmute((&92u8, &[0usize; 8])) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered invalid drop function pointer in vtable
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered invalid drop function pointer in vtable (not pointing to a function)
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
@@ -178,7 +178,7 @@ error[E0080]: it is undefined behavior to use this value
   --> $DIR/ub-wide-ptr.rs:111:1
    |
 LL | const TRAIT_OBJ_BAD_DROP_FN_INT: &dyn Trait = unsafe { mem::transmute((&92u8, &[1usize; 8])) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered invalid drop function pointer in vtable
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered invalid drop function pointer in vtable (not pointing to a function)
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
@@ -186,7 +186,7 @@ error[E0080]: it is undefined behavior to use this value
   --> $DIR/ub-wide-ptr.rs:113:1
    |
 LL | const TRAIT_OBJ_BAD_DROP_FN_NOT_FN_PTR: &dyn Trait = unsafe { mem::transmute((&92u8, &[&42u8; 8])) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered invalid drop function pointer in vtable
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered invalid drop function pointer in vtable (not pointing to a function)
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 

--- a/src/test/ui/enum/issue-67945-1.rs
+++ b/src/test/ui/enum/issue-67945-1.rs
@@ -1,0 +1,8 @@
+enum Bug<S> {
+    Var = {
+        let x: S = 0; //~ ERROR: mismatched types
+        0
+    },
+}
+
+fn main() {}

--- a/src/test/ui/enum/issue-67945-1.stderr
+++ b/src/test/ui/enum/issue-67945-1.stderr
@@ -1,0 +1,17 @@
+error[E0308]: mismatched types
+  --> $DIR/issue-67945-1.rs:3:20
+   |
+LL | enum Bug<S> {
+   |          - this type parameter
+LL |     Var = {
+LL |         let x: S = 0;
+   |                -   ^ expected type parameter `S`, found integer
+   |                |
+   |                expected due to this
+   |
+   = note: expected type parameter `S`
+                        found type `{integer}`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/enum/issue-67945-2.rs
+++ b/src/test/ui/enum/issue-67945-2.rs
@@ -1,0 +1,9 @@
+#![feature(type_ascription)]
+
+enum Bug<S> {
+    Var = 0: S,
+    //~^ ERROR: mismatched types
+    //~| ERROR: mismatched types
+}
+
+fn main() {}

--- a/src/test/ui/enum/issue-67945-2.stderr
+++ b/src/test/ui/enum/issue-67945-2.stderr
@@ -1,0 +1,25 @@
+error[E0308]: mismatched types
+  --> $DIR/issue-67945-2.rs:4:11
+   |
+LL | enum Bug<S> {
+   |          - this type parameter
+LL |     Var = 0: S,
+   |           ^ expected type parameter `S`, found integer
+   |
+   = note: expected type parameter `S`
+                        found type `{integer}`
+
+error[E0308]: mismatched types
+  --> $DIR/issue-67945-2.rs:4:11
+   |
+LL | enum Bug<S> {
+   |          - this type parameter
+LL |     Var = 0: S,
+   |           ^^^^ expected `isize`, found type parameter `S`
+   |
+   = note:        expected type `isize`
+           found type parameter `S`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/lifetimes/issue-34979.rs
+++ b/src/test/ui/lifetimes/issue-34979.rs
@@ -1,0 +1,9 @@
+trait Foo {}
+impl<'a, T> Foo for &'a T {}
+
+struct Ctx<'a>(&'a ())
+where
+    &'a (): Foo, //~ ERROR: type annotations needed
+    &'static (): Foo;
+
+fn main() {}

--- a/src/test/ui/lifetimes/issue-34979.stderr
+++ b/src/test/ui/lifetimes/issue-34979.stderr
@@ -1,0 +1,14 @@
+error[E0283]: type annotations needed
+  --> $DIR/issue-34979.rs:6:13
+   |
+LL | trait Foo {}
+   | --------- required by this bound in `Foo`
+...
+LL |     &'a (): Foo,
+   |             ^^^ cannot infer type for reference `&'a ()`
+   |
+   = note: cannot satisfy `&'a (): Foo`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0283`.


### PR DESCRIPTION
Successful merges:

 - #71938 (Use trait_object_dummy_self instead of err)
 - #71952 (Add some regression tests)
 - #71959 (tests: Fix warnings in `rust_test_helpers.c`)
 - #71962 (Grammar)
 - #71972 (use hex for pointers in Miri error messages)
 - #71980 (Allow a few warnings.)

Failed merges:


r? @ghost