### PR TITLE
Add Iterator::starts_with

### DIFF
--- a/src/libcore/benches/iter.rs
+++ b/src/libcore/benches/iter.rs
@@ -345,3 +345,13 @@ fn bench_partial_cmp(b: &mut Bencher) {
 fn bench_lt(b: &mut Bencher) {
     b.iter(|| (0..100000).map(black_box).lt((0..100000).map(black_box)))
 }
+
+#[bench]
+fn bench_starts_with_vec(b: &mut Bencher) {
+    b.iter(|| black_box((0..100)).collect::<Vec<_>>().starts_with(&[0..3]));
+}
+
+#[bench]
+fn bench_starts_with_iter(b: &mut Bencher) {
+    b.iter(|| black_box((0..100)).starts_with((0..3)));
+}

--- a/src/libcore/iter/traits/iterator.rs
+++ b/src/libcore/iter/traits/iterator.rs
@@ -549,6 +549,53 @@ pub trait Iterator {
         Zip::new(self, other.into_iter())
     }
 
+    /// Checks if an iterator starts with a given iterator.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// #![feature(iter_starts_with)]
+    /// let mut a1 = (0..1000).filter(|i|i % 2 == 0);
+    /// let a2 = (0..3).map(|i|i*2); // 0, 2, 4
+    /// assert_eq!(a1.starts_with(a2), true);
+    /// ```
+    ///
+    /// ```
+    /// #![feature(iter_starts_with)]
+    /// let s = "a b c d";
+    /// assert!(s.chars().filter(|c|!c.is_whitespace()).starts_with("abc".chars()));
+    /// ```
+    ///
+    /// `starts_with` exists to avoid needing to `collect::<Vec<_>>` when comparing prefixes of
+    /// iterators.
+    ///
+    #[inline]
+    #[unstable(feature = "iter_starts_with", reason = "recently added", issue = "none")]
+    fn starts_with<I>(&mut self, other: I) -> bool
+    where
+        I: IntoIterator,
+        Self::Item: PartialEq<I::Item>,
+        Self: Sized,
+    {
+        let mut other = other.into_iter();
+        loop {
+            let patt = match other.next() {
+                Some(el) => el,
+                None => return true,
+            };
+            match self.next() {
+                None => return false,
+                Some(us) => {
+                    if us != patt {
+                        return false;
+                    }
+                }
+            }
+        }
+    }
+
     /// Takes a closure and creates an iterator which calls that closure on each
     /// element.
     ///

--- a/src/libcore/tests/iter.rs
+++ b/src/libcore/tests/iter.rs
@@ -3125,3 +3125,14 @@ fn test_flatten_non_fused_inner() {
     assert_eq!(iter.next(), Some(1));
     assert_eq!(iter.next(), None);
 }
+
+#[test]
+fn test_iter_starts_with() {
+    let v = vec![1, 2, 3, 4];
+    assert!(v.iter().starts_with(&[1, 2]));
+    assert_eq!(v.iter().starts_with(&[2, 3, 4]), false);
+    assert_eq!(v.iter().filter(|x| x != &&1).starts_with([1, 2, 3, 4, 5].iter()), false);
+    assert!((0..1000).filter(|x| x % 2 == 0).starts_with((0..5).map(|i| i * 2)));
+
+    assert!("a b c d     efg".chars().filter(|c| !c.is_whitespace()).starts_with("abc".chars()))
+}

--- a/src/libcore/tests/lib.rs
+++ b/src/libcore/tests/lib.rs
@@ -34,6 +34,7 @@
 #![feature(iter_partition_in_place)]
 #![feature(iter_is_partitioned)]
 #![feature(iter_order_by)]
+#![feature(iter_starts_with)]
 #![feature(cmp_min_max_by)]
 #![feature(iter_map_while)]
 #![feature(const_slice_from_raw_parts)]


### PR DESCRIPTION
## Justification

I've frequently run into the issue where I want to check the prefix after a filter or map. It's not fundamentally necessary to convert to a `Vec` first, but ergonomically, it's difficult to avoid in practice.

## Usage Examples

```rust
"a b c".chars().filter(|c|!c.is_whitespace()).starts_with("abc".chars())
// vs.
"a b c".chars().filter(|c|!c.is_whitespace()).collect::<String>().starts_with("abc");

(0..1000).starts_with(0..5) //etc.
```
In the benchmarks I ran (patt len = 4) This is approximately:
- 3x faster on ranges
- 10x faster for strings (as in the above example) or for `Vec<Char>`

Another option if you know the length of the pattern is `take(n).eq(other)`. This approach appears to be within the margin of error vs. `take(n).eq(..)` (unsurprising, since the code is very similar in structure). 

The existence of this method also helps to protect from non-obvious bugs from attempts to implement this yourself. Consider:
```rust
let inp = 0..1000;
inp.zip(0..5).all(|(a,b)|a==b)
```
This seems plausible -- in fact, it was originally how I was planning on implementing `starts_with`. But it has a subtle bug because `zip` will terminate on whichever iterator finishes first. As discussed in comments below, it fails if the input is shorter than the pattern.
```rust
Iter::empty().zip(0..5).all(|a,b|a == b) // true
```

If this is something Rust would consider moving forward with, I can benchmark it more extensively. Someone smarter than me may also be able to optimize the implementation.

## Issues
- I'm not sure if there's a better way to do this, but it can take some massaging to get the types to line up properly. `eq` et al also suffer from the same issue.

```rust
(0..5).starts_with(&[1,2,3])

3017 |     (0..5).starts_with(&[1,2,3]);
     |            ^^^^^^^^^^^ expected reference, found integer
     |
     = note: expected reference `&{integer}`
                     found type `{integer}`
```

- Currently, it doesn't consume the input iterator, but instead consumes as little of it as possible. I could also imagine that could lead to confusing behavior, and it may be better to simply consume it to prevent surprising results.