### PR TITLE
x.py: allow configuring the build directory

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -131,6 +131,10 @@
 # for each target triple.
 #target = ["x86_64-unknown-linux-gnu"] # defaults to just the build triple
 
+# Use this directory to store build artifacts.
+# You can use "$ROOT" to indicate the root of the git repository.
+#build-dir = "build"
+
 # Instead of downloading the src/stage0.txt version of Cargo specified, use
 # this Cargo binary instead to build all Rust code
 #cargo = "/path/to/bin/cargo"

--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -332,7 +332,7 @@ class RustBuild(object):
         self.rustc_channel = ''
         self.rustfmt_channel = ''
         self.build = ''
-        self.build_dir = os.path.join(os.getcwd(), "build")
+        self.build_dir = ''
         self.clean = False
         self.config_toml = ''
         self.rust_root = ''
@@ -891,7 +891,11 @@ def bootstrap(help_triggered):
     build.clean = args.clean
 
     try:
-        with open(args.config or 'config.toml') as config:
+        toml_path = args.config or 'config.toml'
+        if not os.path.exists(toml_path):
+            toml_path = os.path.join(build.rust_root, toml_path)
+
+        with open(toml_path) as config:
             build.config_toml = config.read()
     except (OSError, IOError):
         pass
@@ -905,6 +909,9 @@ def bootstrap(help_triggered):
     build.use_locked_deps = build.get_toml('locked-deps', 'build') == 'true'
 
     build.check_vendored_status()
+
+    build_dir = build.get_toml('build-dir', 'build') or 'build'
+    build.build_dir = os.path.abspath(build_dir.replace("$ROOT", build.rust_root))
 
     data = stage0_data(build.rust_root)
     build.date = data['date']

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -212,6 +212,8 @@ struct Build {
     host: Vec<String>,
     #[serde(default)]
     target: Vec<String>,
+    // This is ignored, the rust code always gets the build directory from the `BUILD_DIR` env variable
+    build_dir: Option<String>,
     cargo: Option<String>,
     rustc: Option<String>,
     rustfmt: Option<String>, /* allow bootstrap.py to use rustfmt key */


### PR DESCRIPTION
This allows configuring the directory for build artifacts, instead of having it always be `./build`. This means you can set it to a constant location, letting you reuse the same cache while working in several different directories.

The configuration lives in `config.toml` under `build.build-dir`. By default, it keeps the existing default of `./build`, but it can be configured to any relative or absolute path. Additionally, it allows making outputs relative to the root of the git repository using `$ROOT`.

r? @Mark-Simulacrum 