### PR TITLE
[CI] Use the latest Python available on Windows

### DIFF
--- a/src/ci/scripts/install-msys2-packages.sh
+++ b/src/ci/scripts/install-msys2-packages.sh
@@ -9,11 +9,19 @@ if isWindows; then
     pacman -S --noconfirm --needed base-devel ca-certificates make diffutils tar \
         binutils
 
+    # Detect the native Python version installed on the agent. On GitHub
+    # Actions, the C:\hostedtoolcache\windows\Python directory contains a
+    # subdirectory for each installed Python version.
+    #
+    # The -V flag of the sort command sorts the input by version number.
+    native_python_version="$(ls /c/hostedtoolcache/windows/Python | sort -Vr | head -n 1)"
+
     # Make sure we use the native python interpreter instead of some msys equivalent
     # one way or another. The msys interpreters seem to have weird path conversions
     # baked in which break LLVM's build system one way or another, so let's use the
     # native version which keeps everything as native as possible.
-    python_home="C:/hostedtoolcache/windows/Python/3.7.6/x64"
+    python_home="/c/hostedtoolcache/windows/Python/${native_python_version}/x64"
     cp "${python_home}/python.exe" "${python_home}/python3.exe"
-    ciCommandAddPath "C:\\hostedtoolcache\\windows\\Python\\3.7.6\\x64"
+    ciCommandAddPath "C:\\hostedtoolcache\\windows\\Python\\${native_python_version}\\x64"
+    ciCommandAddPath "C:\\hostedtoolcache\\windows\\Python\\${native_python_version}\\x64\\Scripts"
 fi


### PR DESCRIPTION
This PR changes our Windows CI to always use the latest Python interpreter available in the GHA tool cache instead of hardcoding Python 3.7.6. This is needed because occasionally GitHub bumps the installed version, deleting the previous one.

This fixes the current GHA outage we're having. I fully expect the outage to propagate to Azure Pipelines in the coming days if we don't merge this, as both GHA and Azure use the same underlying image. Once the PR is merged we can re-enabled the double-gating.

r? @Mark-Simulacrum 