### PR TITLE
Move the target libLLVM to llvm-tools-preview

### DIFF
--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -772,7 +772,8 @@ impl Step for Assemble {
 
         // Ensure that `libLLVM.so` ends up in the newly build compiler directory,
         // so that it can be found when the newly built `rustc` is run.
-        dist::maybe_install_llvm_dylib(builder, target_compiler.host, &sysroot);
+        dist::maybe_install_llvm_runtime(builder, target_compiler.host, &sysroot);
+        dist::maybe_install_llvm_target(builder, target_compiler.host, &sysroot);
 
         // Link the compiler binary itself into place
         let out_dir = builder.cargo_out(build_compiler, Mode::Rustc, host);


### PR DESCRIPTION
For running the compiler, we usually only need LLVM from `$sysroot/lib`,
which rustup will make available with `LD_LIBRARY_PATH`. We've also been
shipping LLVM in the `$target/lib` directory, which bloats the download
and installed size. The only times we do need the latter are for the
RPATH of `llvm-tools-preview` binaries, and for linking `rustc-dev`
libraries. We'll move it to the `llvm-tools-preview` component directly,
and `rustc-dev` will have an implicit dependency on it.

Here are the dist sizes that I got before and after this change:

    llvm-tools-1.45.0-dev-x86_64-unknown-linux-gnu.tar.gz     1.3M   24M
    llvm-tools-1.45.0-dev-x86_64-unknown-linux-gnu.tar.xz     748K   17M
    rustc-1.45.0-dev-x86_64-unknown-linux-gnu.tar.gz          83M    61M
    rustc-1.45.0-dev-x86_64-unknown-linux-gnu.tar.xz          56M    41M

The installed size should reduce by exactly one `libLLVM.so` (~70-80M),
unless you also install `llvm-tools`, and then it should be identical.

Resolves #70838.