### PR TITLE
allow wasm target for rustc-ap-rustc_span

### DIFF
--- a/src/librustc_span/lib.rs
+++ b/src/librustc_span/lib.rs
@@ -14,7 +14,7 @@
 #![feature(optin_builtin_traits)]
 #![feature(specialization)]
 
-// allow wasm target for rustc-ap-rustc_span
+// FIXME(#56935): Work around ICEs during cross-compilation.
 #[allow(unused)]
 extern crate rustc_macros;
 

--- a/src/librustc_span/lib.rs
+++ b/src/librustc_span/lib.rs
@@ -15,6 +15,7 @@
 #![feature(specialization)]
 
 // allow wasm target for rustc-ap-rustc_span
+#[allow(unused)]
 extern crate rustc_macros;
 
 use rustc_data_structures::AtomicRef;

--- a/src/librustc_span/lib.rs
+++ b/src/librustc_span/lib.rs
@@ -14,6 +14,9 @@
 #![feature(optin_builtin_traits)]
 #![feature(specialization)]
 
+// allow wasm target for rustc-ap-rustc_span
+extern crate rustc_macros;
+
 use rustc_data_structures::AtomicRef;
 use rustc_macros::HashStable_Generic;
 use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};


### PR DESCRIPTION
This fixes #71998 by applying the work-a-round. The root cause is probably #56935, as @petrochenkov pointed out.

I reproduced the bug by:
```
cd ~/.cargo/registry/src/github.com-1ecc6299db9ec823/rustc-ap-rustc_span-657.0.0/
cargo build --target wasm32-unknown-unknown
```

Adding this line fixes it.