### PR TITLE
Work around ICEs during cross-compilation for target, ast, & attr

### DIFF
--- a/src/librustc_ast/lib.rs
+++ b/src/librustc_ast/lib.rs
@@ -19,6 +19,10 @@
 #![feature(unicode_internals)]
 #![recursion_limit = "256"]
 
+// FIXME(#56935): Work around ICEs during cross-compilation.
+#[allow(unused)]
+extern crate rustc_macros;
+
 #[macro_export]
 macro_rules! unwrap_or {
     ($opt:expr, $default:expr) => {

--- a/src/librustc_attr/lib.rs
+++ b/src/librustc_attr/lib.rs
@@ -6,6 +6,10 @@
 
 #![feature(or_patterns)]
 
+// FIXME(#56935): Work around ICEs during cross-compilation.
+#[allow(unused)]
+extern crate rustc_macros;
+
 mod builtin;
 
 pub use builtin::*;

--- a/src/librustc_target/lib.rs
+++ b/src/librustc_target/lib.rs
@@ -17,6 +17,10 @@
 #![feature(associated_type_bounds)]
 #![feature(exhaustive_patterns)]
 
+// FIXME(#56935): Work around ICEs during cross-compilation.
+#[allow(unused)]
+extern crate rustc_macros;
+
 #[macro_use]
 extern crate log;
 


### PR DESCRIPTION
This applies the fix for #72003 to work around #56935 to three more libraries. With these additional fixes, I'm able to use rustfmt_lib from wasm (https://github.com/rust-lang/rustfmt/issues/4132#issuecomment-616587989), which was my goal.

To get it working locally and to test, I copied the `.cargo/registry/src` and applied the fix and replaced the reference in my project:
``` toml
[replace]
"rustc-ap-rustc_span:656.0.0" = { path = "../rustc-ap-rustc_span" }
"rustc-ap-rustc_target:656.0.0" = { path = "../rustc-ap-rustc_target" }
"rustc-ap-rustc_ast:656.0.0" = { path = "../rustc-ap-rustc_ast" }
"rustc-ap-rustc_attr:656.0.0" = { path = "../rustc-ap-rustc_attr" }
```