### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/src/librustc_ast/lib.rs
+++ b/src/librustc_ast/lib.rs
@@ -19,6 +19,10 @@
 #![feature(unicode_internals)]
 #![recursion_limit = "256"]
 
+// FIXME(#56935): Work around ICEs during cross-compilation.
+#[allow(unused)]
+extern crate rustc_macros;
+
 #[macro_export]
 macro_rules! unwrap_or {
     ($opt:expr, $default:expr) => {

--- a/src/librustc_attr/lib.rs
+++ b/src/librustc_attr/lib.rs
@@ -6,6 +6,10 @@
 
 #![feature(or_patterns)]
 
+// FIXME(#56935): Work around ICEs during cross-compilation.
+#[allow(unused)]
+extern crate rustc_macros;
+
 mod builtin;
 
 pub use builtin::*;

--- a/src/librustc_codegen_llvm/back/write.rs
+++ b/src/librustc_codegen_llvm/back/write.rs
@@ -651,10 +651,10 @@ pub(crate) unsafe fn codegen(
                     "LLVM_module_codegen_embed_bitcode",
                     &module.name[..],
                 );
-                embed_bitcode(cgcx, llcx, llmod, Some(data));
+                embed_bitcode(cgcx, llcx, llmod, &config.bc_cmdline, Some(data));
             }
         } else if config.emit_obj == EmitObj::ObjectCode(BitcodeSection::Marker) {
-            embed_bitcode(cgcx, llcx, llmod, None);
+            embed_bitcode(cgcx, llcx, llmod, &config.bc_cmdline, None);
         }
 
         if config.emit_ir {
@@ -777,8 +777,8 @@ pub(crate) unsafe fn codegen(
 /// * __LLVM,__cmdline
 ///
 /// It appears *both* of these sections are necessary to get the linker to
-/// recognize what's going on. For us though we just always throw in an empty
-/// cmdline section.
+/// recognize what's going on. A suitable cmdline value is taken from the
+/// target spec.
 ///
 /// Furthermore debug/O1 builds don't actually embed bitcode but rather just
 /// embed an empty section.
@@ -789,6 +789,7 @@ unsafe fn embed_bitcode(
     cgcx: &CodegenContext<LlvmCodegenBackend>,
     llcx: &llvm::Context,
     llmod: &llvm::Module,
+    cmdline: &str,
     bitcode: Option<&[u8]>,
 ) {
     let llconst = common::bytes_in_context(llcx, bitcode.unwrap_or(&[]));
@@ -800,14 +801,15 @@ unsafe fn embed_bitcode(
     llvm::LLVMSetInitializer(llglobal, llconst);
 
     let is_apple = cgcx.opts.target_triple.triple().contains("-ios")
-        || cgcx.opts.target_triple.triple().contains("-darwin");
+        || cgcx.opts.target_triple.triple().contains("-darwin")
+        || cgcx.opts.target_triple.triple().contains("-tvos");
 
     let section = if is_apple { "__LLVM,__bitcode\0" } else { ".llvmbc\0" };
     llvm::LLVMSetSection(llglobal, section.as_ptr().cast());
     llvm::LLVMRustSetLinkage(llglobal, llvm::Linkage::PrivateLinkage);
     llvm::LLVMSetGlobalConstant(llglobal, llvm::True);
 
-    let llconst = common::bytes_in_context(llcx, &[]);
+    let llconst = common::bytes_in_context(llcx, cmdline.as_bytes());
     let llglobal = llvm::LLVMAddGlobal(
         llmod,
         common::val_ty(llconst),

--- a/src/librustc_codegen_llvm/back/write.rs
+++ b/src/librustc_codegen_llvm/back/write.rs
@@ -651,10 +651,8 @@ pub(crate) unsafe fn codegen(
                     "LLVM_module_codegen_embed_bitcode",
                     &module.name[..],
                 );
-                embed_bitcode(cgcx, llcx, llmod, &config.bc_cmdline, Some(data));
+                embed_bitcode(cgcx, llcx, llmod, &config.bc_cmdline, data);
             }
-        } else if config.emit_obj == EmitObj::ObjectCode(BitcodeSection::Marker) {
-            embed_bitcode(cgcx, llcx, llmod, &config.bc_cmdline, None);
         }
 
         if config.emit_ir {
@@ -790,9 +788,9 @@ unsafe fn embed_bitcode(
     llcx: &llvm::Context,
     llmod: &llvm::Module,
     cmdline: &str,
-    bitcode: Option<&[u8]>,
+    bitcode: &[u8],
 ) {
-    let llconst = common::bytes_in_context(llcx, bitcode.unwrap_or(&[]));
+    let llconst = common::bytes_in_context(llcx, bitcode);
     let llglobal = llvm::LLVMAddGlobal(
         llmod,
         common::val_ty(llconst),

--- a/src/librustc_codegen_ssa/back/write.rs
+++ b/src/librustc_codegen_ssa/back/write.rs
@@ -68,10 +68,6 @@ pub enum BitcodeSection {
     // No bitcode section.
     None,
 
-    // An empty bitcode section (to placate tools such as the iOS linker that
-    // require this section even if they don't use it).
-    Marker,
-
     // A full, uncompressed bitcode section.
     Full,
 }
@@ -148,16 +144,8 @@ impl ModuleConfig {
             || sess.opts.cg.linker_plugin_lto.enabled()
         {
             EmitObj::Bitcode
-        } else if sess.target.target.options.forces_embed_bitcode {
+        } else if need_bitcode_in_object(sess) {
             EmitObj::ObjectCode(BitcodeSection::Full)
-        } else if need_crate_bitcode_for_rlib(sess) {
-            let force_full = need_crate_bitcode_for_rlib(sess);
-            match sess.opts.optimize {
-                config::OptLevel::No | config::OptLevel::Less if !force_full => {
-                    EmitObj::ObjectCode(BitcodeSection::Marker)
-                }
-                _ => EmitObj::ObjectCode(BitcodeSection::Full),
-            }
         } else {
             EmitObj::ObjectCode(BitcodeSection::None)
         };
@@ -376,10 +364,12 @@ pub struct CompiledModules {
     pub allocator_module: Option<CompiledModule>,
 }
 
-fn need_crate_bitcode_for_rlib(sess: &Session) -> bool {
-    sess.opts.cg.embed_bitcode
+fn need_bitcode_in_object(sess: &Session) -> bool {
+    let requested_for_rlib = sess.opts.cg.embed_bitcode
         && sess.crate_types.borrow().contains(&CrateType::Rlib)
-        && sess.opts.output_types.contains_key(&OutputType::Exe)
+        && sess.opts.output_types.contains_key(&OutputType::Exe);
+    let forced_by_target = sess.target.target.options.forces_embed_bitcode;
+    requested_for_rlib || forced_by_target
 }
 
 fn need_pre_lto_bitcode_for_incr_comp(sess: &Session) -> bool {

--- a/src/librustc_codegen_ssa/back/write.rs
+++ b/src/librustc_codegen_ssa/back/write.rs
@@ -101,6 +101,7 @@ pub struct ModuleConfig {
     pub emit_ir: bool,
     pub emit_asm: bool,
     pub emit_obj: EmitObj,
+    pub bc_cmdline: String,
 
     // Miscellaneous flags.  These are mostly copied from command-line
     // options.
@@ -213,6 +214,7 @@ impl ModuleConfig {
                 false
             ),
             emit_obj,
+            bc_cmdline: sess.target.target.options.bitcode_llvm_cmdline.clone(),
 
             verify_llvm_ir: sess.verify_llvm_ir(),
             no_prepopulate_passes: sess.opts.cg.no_prepopulate_passes,

--- a/src/librustc_codegen_ssa/back/write.rs
+++ b/src/librustc_codegen_ssa/back/write.rs
@@ -147,6 +147,8 @@ impl ModuleConfig {
             || sess.opts.cg.linker_plugin_lto.enabled()
         {
             EmitObj::Bitcode
+        } else if sess.target.target.options.forces_embed_bitcode {
+            EmitObj::ObjectCode(BitcodeSection::Full)
         } else if need_crate_bitcode_for_rlib(sess) {
             let force_full = need_crate_bitcode_for_rlib(sess);
             match sess.opts.optimize {

--- a/src/librustc_mir_build/hair/pattern/_match.rs
+++ b/src/librustc_mir_build/hair/pattern/_match.rs
@@ -580,21 +580,11 @@ crate struct MatchCheckCtxt<'a, 'tcx> {
     /// outside it's module and should not be matchable with an empty match
     /// statement.
     crate module: DefId,
-    param_env: ty::ParamEnv<'tcx>,
+    crate param_env: ty::ParamEnv<'tcx>,
     crate pattern_arena: &'a TypedArena<Pat<'tcx>>,
 }
 
 impl<'a, 'tcx> MatchCheckCtxt<'a, 'tcx> {
-    crate fn create_and_enter<R>(
-        tcx: TyCtxt<'tcx>,
-        param_env: ty::ParamEnv<'tcx>,
-        pattern_arena: &'a TypedArena<Pat<'tcx>>,
-        module: DefId,
-        f: impl FnOnce(MatchCheckCtxt<'a, 'tcx>) -> R,
-    ) -> R {
-        f(MatchCheckCtxt { tcx, param_env, module, pattern_arena })
-    }
-
     fn is_uninhabited(&self, ty: Ty<'tcx>) -> bool {
         if self.tcx.features().exhaustive_patterns {
             self.tcx.is_ty_uninhabited_from(self.module, ty, self.param_env)

--- a/src/librustc_mir_build/hair/pattern/_match.rs
+++ b/src/librustc_mir_build/hair/pattern/_match.rs
@@ -588,12 +588,11 @@ impl<'a, 'tcx> MatchCheckCtxt<'a, 'tcx> {
     crate fn create_and_enter<R>(
         tcx: TyCtxt<'tcx>,
         param_env: ty::ParamEnv<'tcx>,
+        pattern_arena: &'a TypedArena<Pat<'tcx>>,
         module: DefId,
-        f: impl FnOnce(MatchCheckCtxt<'_, 'tcx>) -> R,
+        f: impl FnOnce(MatchCheckCtxt<'a, 'tcx>) -> R,
     ) -> R {
-        let pattern_arena = TypedArena::default();
-
-        f(MatchCheckCtxt { tcx, param_env, module, pattern_arena: &pattern_arena })
+        f(MatchCheckCtxt { tcx, param_env, module, pattern_arena })
     }
 
     fn is_uninhabited(&self, ty: Ty<'tcx>) -> bool {

--- a/src/librustc_mir_build/hair/pattern/check_match.rs
+++ b/src/librustc_mir_build/hair/pattern/check_match.rs
@@ -149,13 +149,13 @@ impl<'tcx> MatchVisitor<'_, 'tcx> {
 
     fn check_in_cx(&self, hir_id: HirId, f: impl FnOnce(MatchCheckCtxt<'_, 'tcx>)) {
         let module = self.tcx.parent_module(hir_id);
-        MatchCheckCtxt::create_and_enter(
-            self.tcx,
-            self.param_env,
-            &self.pattern_arena,
-            module.to_def_id(),
-            f,
-        );
+        let cx = MatchCheckCtxt {
+            tcx: self.tcx,
+            param_env: self.param_env,
+            module: module.to_def_id(),
+            pattern_arena: &self.pattern_arena,
+        };
+        f(cx);
     }
 
     fn check_match(

--- a/src/librustc_mir_build/hair/pattern/check_match.rs
+++ b/src/librustc_mir_build/hair/pattern/check_match.rs
@@ -147,15 +147,13 @@ impl<'tcx> MatchVisitor<'_, 'tcx> {
         (pattern, pattern_ty)
     }
 
-    fn check_in_cx(&self, hir_id: HirId, f: impl FnOnce(MatchCheckCtxt<'_, 'tcx>)) {
-        let module = self.tcx.parent_module(hir_id);
-        let cx = MatchCheckCtxt {
+    fn new_cx(&self, hir_id: HirId) -> MatchCheckCtxt<'_, 'tcx> {
+        MatchCheckCtxt {
             tcx: self.tcx,
             param_env: self.param_env,
-            module: module.to_def_id(),
+            module: self.tcx.parent_module(hir_id).to_def_id(),
             pattern_arena: &self.pattern_arena,
-        };
-        f(cx);
+        }
     }
 
     fn check_match(
@@ -169,91 +167,88 @@ impl<'tcx> MatchVisitor<'_, 'tcx> {
             self.check_patterns(arm.guard.is_some(), &arm.pat);
         }
 
-        self.check_in_cx(scrut.hir_id, |ref mut cx| {
-            let mut have_errors = false;
+        let mut cx = self.new_cx(scrut.hir_id);
 
-            let inlined_arms: Vec<_> = arms
-                .iter()
-                .map(|hir::Arm { pat, guard, .. }| {
-                    (self.lower_pattern(cx, pat, &mut have_errors).0, pat.hir_id, guard.is_some())
-                })
-                .collect();
+        let mut have_errors = false;
 
-            // Bail out early if inlining failed.
-            if have_errors {
-                return;
-            }
+        let inlined_arms: Vec<_> = arms
+            .iter()
+            .map(|hir::Arm { pat, guard, .. }| {
+                (self.lower_pattern(&mut cx, pat, &mut have_errors).0, pat.hir_id, guard.is_some())
+            })
+            .collect();
 
-            // Fourth, check for unreachable arms.
-            let matrix = check_arms(cx, &inlined_arms, source);
+        // Bail out early if inlining failed.
+        if have_errors {
+            return;
+        }
 
-            // Fifth, check if the match is exhaustive.
-            let scrut_ty = self.tables.node_type(scrut.hir_id);
-            // Note: An empty match isn't the same as an empty matrix for diagnostics purposes,
-            // since an empty matrix can occur when there are arms, if those arms all have guards.
-            let is_empty_match = inlined_arms.is_empty();
-            check_exhaustive(cx, scrut_ty, scrut.span, &matrix, scrut.hir_id, is_empty_match);
-        })
+        // Fourth, check for unreachable arms.
+        let matrix = check_arms(&mut cx, &inlined_arms, source);
+
+        // Fifth, check if the match is exhaustive.
+        let scrut_ty = self.tables.node_type(scrut.hir_id);
+        // Note: An empty match isn't the same as an empty matrix for diagnostics purposes,
+        // since an empty matrix can occur when there are arms, if those arms all have guards.
+        let is_empty_match = inlined_arms.is_empty();
+        check_exhaustive(&mut cx, scrut_ty, scrut.span, &matrix, scrut.hir_id, is_empty_match);
     }
 
     fn check_irrefutable(&self, pat: &'tcx Pat<'tcx>, origin: &str, sp: Option<Span>) {
-        self.check_in_cx(pat.hir_id, |ref mut cx| {
-            let (pattern, pattern_ty) = self.lower_pattern(cx, pat, &mut false);
-            let pats: Matrix<'_, '_> = vec![PatStack::from_pattern(pattern)].into_iter().collect();
+        let mut cx = self.new_cx(pat.hir_id);
 
-            let witnesses = match check_not_useful(cx, pattern_ty, &pats, pat.hir_id) {
-                Ok(_) => return,
-                Err(err) => err,
-            };
+        let (pattern, pattern_ty) = self.lower_pattern(&mut cx, pat, &mut false);
+        let pats: Matrix<'_, '_> = vec![PatStack::from_pattern(pattern)].into_iter().collect();
 
-            let joined_patterns = joined_uncovered_patterns(&witnesses);
-            let mut err = struct_span_err!(
-                self.tcx.sess,
-                pat.span,
-                E0005,
-                "refutable pattern in {}: {} not covered",
-                origin,
-                joined_patterns
+        let witnesses = match check_not_useful(&mut cx, pattern_ty, &pats, pat.hir_id) {
+            Ok(_) => return,
+            Err(err) => err,
+        };
+
+        let joined_patterns = joined_uncovered_patterns(&witnesses);
+        let mut err = struct_span_err!(
+            self.tcx.sess,
+            pat.span,
+            E0005,
+            "refutable pattern in {}: {} not covered",
+            origin,
+            joined_patterns
+        );
+        let suggest_if_let = match &pat.kind {
+            hir::PatKind::Path(hir::QPath::Resolved(None, path))
+                if path.segments.len() == 1 && path.segments[0].args.is_none() =>
+            {
+                const_not_var(&mut err, cx.tcx, pat, path);
+                false
+            }
+            _ => {
+                err.span_label(pat.span, pattern_not_covered_label(&witnesses, &joined_patterns));
+                true
+            }
+        };
+
+        if let (Some(span), true) = (sp, suggest_if_let) {
+            err.note(
+                "`let` bindings require an \"irrefutable pattern\", like a `struct` or \
+                 an `enum` with only one variant",
             );
-            let suggest_if_let = match &pat.kind {
-                hir::PatKind::Path(hir::QPath::Resolved(None, path))
-                    if path.segments.len() == 1 && path.segments[0].args.is_none() =>
-                {
-                    const_not_var(&mut err, cx.tcx, pat, path);
-                    false
-                }
-                _ => {
-                    err.span_label(
-                        pat.span,
-                        pattern_not_covered_label(&witnesses, &joined_patterns),
-                    );
-                    true
-                }
-            };
-
-            if let (Some(span), true) = (sp, suggest_if_let) {
-                err.note(
-                    "`let` bindings require an \"irrefutable pattern\", like a `struct` or \
-                     an `enum` with only one variant",
-                );
-                if let Ok(snippet) = self.tcx.sess.source_map().span_to_snippet(span) {
-                    err.span_suggestion(
-                        span,
-                        "you might want to use `if let` to ignore the variant that isn't matched",
-                        format!("if {} {{ /* */ }}", &snippet[..snippet.len() - 1]),
-                        Applicability::HasPlaceholders,
-                    );
-                }
-                err.note(
-                    "for more information, visit \
-                     https://doc.rust-lang.org/book/ch18-02-refutability.html",
+            if let Ok(snippet) = self.tcx.sess.source_map().span_to_snippet(span) {
+                err.span_suggestion(
+                    span,
+                    "you might want to use `if let` to ignore the variant that isn't matched",
+                    format!("if {} {{ /* */ }}", &snippet[..snippet.len() - 1]),
+                    Applicability::HasPlaceholders,
                 );
             }
+            err.note(
+                "for more information, visit \
+                 https://doc.rust-lang.org/book/ch18-02-refutability.html",
+            );
+        }
 
-            adt_defined_here(cx, &mut err, pattern_ty, &witnesses);
-            err.note(&format!("the matched value is of type `{}`", pattern_ty));
-            err.emit();
-        });
+        adt_defined_here(&mut cx, &mut err, pattern_ty, &witnesses);
+        err.note(&format!("the matched value is of type `{}`", pattern_ty));
+        err.emit();
     }
 }
 

--- a/src/librustc_span/lib.rs
+++ b/src/librustc_span/lib.rs
@@ -14,7 +14,7 @@
 #![feature(optin_builtin_traits)]
 #![feature(specialization)]
 
-// allow wasm target for rustc-ap-rustc_span
+// FIXME(#56935): Work around ICEs during cross-compilation.
 #[allow(unused)]
 extern crate rustc_macros;
 

--- a/src/librustc_span/lib.rs
+++ b/src/librustc_span/lib.rs
@@ -15,6 +15,7 @@
 #![feature(specialization)]
 
 // allow wasm target for rustc-ap-rustc_span
+#[allow(unused)]
 extern crate rustc_macros;
 
 use rustc_data_structures::AtomicRef;

--- a/src/librustc_span/lib.rs
+++ b/src/librustc_span/lib.rs
@@ -14,6 +14,9 @@
 #![feature(optin_builtin_traits)]
 #![feature(specialization)]
 
+// allow wasm target for rustc-ap-rustc_span
+extern crate rustc_macros;
+
 use rustc_data_structures::AtomicRef;
 use rustc_macros::HashStable_Generic;
 use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};

--- a/src/librustc_target/lib.rs
+++ b/src/librustc_target/lib.rs
@@ -17,6 +17,10 @@
 #![feature(associated_type_bounds)]
 #![feature(exhaustive_patterns)]
 
+// FIXME(#56935): Work around ICEs during cross-compilation.
+#[allow(unused)]
+extern crate rustc_macros;
+
 #[macro_use]
 extern crate log;
 

--- a/src/librustc_target/spec/aarch64_apple_ios.rs
+++ b/src/librustc_target/spec/aarch64_apple_ios.rs
@@ -19,6 +19,7 @@ pub fn target() -> TargetResult {
             eliminate_frame_pointer: false,
             max_atomic_width: Some(128),
             abi_blacklist: super::arm_base::abi_blacklist(),
+            forces_embed_bitcode: true,
             ..base
         },
     })

--- a/src/librustc_target/spec/aarch64_apple_ios.rs
+++ b/src/librustc_target/spec/aarch64_apple_ios.rs
@@ -20,6 +20,17 @@ pub fn target() -> TargetResult {
             max_atomic_width: Some(128),
             abi_blacklist: super::arm_base::abi_blacklist(),
             forces_embed_bitcode: true,
+            // Taken from a clang build on Xcode 11.4.1.
+            // These arguments are not actually invoked - they just have
+            // to look right to pass App Store validation.
+            bitcode_llvm_cmdline: "-triple\0\
+                arm64-apple-ios11.0.0\0\
+                -emit-obj\0\
+                -disable-llvm-passes\0\
+                -target-abi\0\
+                darwinpcs\0\
+                -Os\0"
+                .to_string(),
             ..base
         },
     })

--- a/src/librustc_target/spec/aarch64_apple_tvos.rs
+++ b/src/librustc_target/spec/aarch64_apple_tvos.rs
@@ -19,6 +19,7 @@ pub fn target() -> TargetResult {
             eliminate_frame_pointer: false,
             max_atomic_width: Some(128),
             abi_blacklist: super::arm_base::abi_blacklist(),
+            forces_embed_bitcode: true,
             ..base
         },
     })

--- a/src/librustc_target/spec/mod.rs
+++ b/src/librustc_target/spec/mod.rs
@@ -785,6 +785,8 @@ pub struct TargetOptions {
     pub obj_is_bitcode: bool,
     /// Whether the target requires that emitted object code includes bitcode.
     pub forces_embed_bitcode: bool,
+    /// Content of the LLVM cmdline section associated with embedded bitcode.
+    pub bitcode_llvm_cmdline: String,
 
     /// Don't use this field; instead use the `.min_atomic_width()` method.
     pub min_atomic_width: Option<u64>,
@@ -942,6 +944,7 @@ impl Default for TargetOptions {
             has_elf_tls: false,
             obj_is_bitcode: false,
             forces_embed_bitcode: false,
+            bitcode_llvm_cmdline: String::new(),
             min_atomic_width: None,
             max_atomic_width: None,
             atomic_cas: true,
@@ -1282,6 +1285,7 @@ impl Target {
         key!(has_elf_tls, bool);
         key!(obj_is_bitcode, bool);
         key!(forces_embed_bitcode, bool);
+        key!(bitcode_llvm_cmdline);
         key!(max_atomic_width, Option<u64>);
         key!(min_atomic_width, Option<u64>);
         key!(atomic_cas, bool);
@@ -1510,6 +1514,7 @@ impl ToJson for Target {
         target_option_val!(has_elf_tls);
         target_option_val!(obj_is_bitcode);
         target_option_val!(forces_embed_bitcode);
+        target_option_val!(bitcode_llvm_cmdline);
         target_option_val!(min_atomic_width);
         target_option_val!(max_atomic_width);
         target_option_val!(atomic_cas);

--- a/src/librustc_target/spec/mod.rs
+++ b/src/librustc_target/spec/mod.rs
@@ -783,6 +783,8 @@ pub struct TargetOptions {
     // If we give emcc .o files that are actually .bc files it
     // will 'just work'.
     pub obj_is_bitcode: bool,
+    /// Whether the target requires that emitted object code includes bitcode.
+    pub forces_embed_bitcode: bool,
 
     /// Don't use this field; instead use the `.min_atomic_width()` method.
     pub min_atomic_width: Option<u64>,
@@ -939,6 +941,7 @@ impl Default for TargetOptions {
             allow_asm: true,
             has_elf_tls: false,
             obj_is_bitcode: false,
+            forces_embed_bitcode: false,
             min_atomic_width: None,
             max_atomic_width: None,
             atomic_cas: true,
@@ -1278,6 +1281,7 @@ impl Target {
         key!(main_needs_argc_argv, bool);
         key!(has_elf_tls, bool);
         key!(obj_is_bitcode, bool);
+        key!(forces_embed_bitcode, bool);
         key!(max_atomic_width, Option<u64>);
         key!(min_atomic_width, Option<u64>);
         key!(atomic_cas, bool);
@@ -1505,6 +1509,7 @@ impl ToJson for Target {
         target_option_val!(main_needs_argc_argv);
         target_option_val!(has_elf_tls);
         target_option_val!(obj_is_bitcode);
+        target_option_val!(forces_embed_bitcode);
         target_option_val!(min_atomic_width);
         target_option_val!(max_atomic_width);
         target_option_val!(atomic_cas);

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -205,6 +205,56 @@ pub fn new_handler(
     )
 }
 
+/// This function is used to setup the lint initialization. By default, in rustdoc, everything
+/// is "allowed". Depending if we run in test mode or not, we want some of them to be at their
+/// default level. For example, the "INVALID_CODEBLOCK_ATTRIBUTE" lint is activated in both
+/// modes.
+///
+/// A little detail easy to forget is that there is a way to set the lint level for all lints
+/// through the "WARNINGS" lint. To prevent this to happen, we set it back to its "normal" level
+/// inside this function.
+///
+/// It returns a tuple containing:
+///  * Vector of tuples of lints' name and their associated "max" level
+///  * HashMap of lint id with their associated "max" level
+pub fn init_lints<F>(
+    mut whitelisted_lints: Vec<String>,
+    lint_opts: Vec<(String, lint::Level)>,
+    filter_call: F,
+) -> (Vec<(String, lint::Level)>, FxHashMap<lint::LintId, lint::Level>)
+where
+    F: Fn(&lint::Lint) -> Option<(String, lint::Level)>,
+{
+    let warnings_lint_name = lint::builtin::WARNINGS.name;
+
+    whitelisted_lints.push(warnings_lint_name.to_owned());
+    whitelisted_lints.extend(lint_opts.iter().map(|(lint, _)| lint).cloned());
+
+    let lints = || {
+        lint::builtin::HardwiredLints::get_lints()
+            .into_iter()
+            .chain(rustc_lint::SoftLints::get_lints().into_iter())
+    };
+
+    let lint_opts = lints()
+        .filter_map(|lint| if lint.name == warnings_lint_name { None } else { filter_call(lint) })
+        .chain(lint_opts.into_iter())
+        .collect::<Vec<_>>();
+
+    let lint_caps = lints()
+        .filter_map(|lint| {
+            // We don't want to whitelist *all* lints so let's
+            // ignore those ones.
+            if whitelisted_lints.iter().any(|l| lint.name == l) {
+                None
+            } else {
+                Some((lint::LintId::of(lint), lint::Allow))
+            }
+        })
+        .collect();
+    (lint_opts, lint_caps)
+}
+
 pub fn run_core(options: RustdocOptions) -> (clean::Crate, RenderInfo, RenderOptions) {
     // Parse, resolve, and typecheck the given crate.
 
@@ -248,7 +298,6 @@ pub fn run_core(options: RustdocOptions) -> (clean::Crate, RenderInfo, RenderOpt
     let input = Input::File(input);
 
     let intra_link_resolution_failure_name = lint::builtin::INTRA_DOC_LINK_RESOLUTION_FAILURE.name;
-    let warnings_lint_name = lint::builtin::WARNINGS.name;
     let missing_docs = rustc_lint::builtin::MISSING_DOCS.name;
     let missing_doc_example = rustc_lint::builtin::MISSING_DOC_CODE_EXAMPLES.name;
     let private_doc_tests = rustc_lint::builtin::PRIVATE_DOC_TESTS.name;
@@ -257,8 +306,7 @@ pub fn run_core(options: RustdocOptions) -> (clean::Crate, RenderInfo, RenderOpt
 
     // In addition to those specific lints, we also need to whitelist those given through
     // command line, otherwise they'll get ignored and we don't want that.
-    let mut whitelisted_lints = vec![
-        warnings_lint_name.to_owned(),
+    let whitelisted_lints = vec![
         intra_link_resolution_failure_name.to_owned(),
         missing_docs.to_owned(),
         missing_doc_example.to_owned(),
@@ -267,39 +315,15 @@ pub fn run_core(options: RustdocOptions) -> (clean::Crate, RenderInfo, RenderOpt
         invalid_codeblock_attribute_name.to_owned(),
     ];
 
-    whitelisted_lints.extend(lint_opts.iter().map(|(lint, _)| lint).cloned());
-
-    let lints = || {
-        lint::builtin::HardwiredLints::get_lints()
-            .into_iter()
-            .chain(rustc_lint::SoftLints::get_lints().into_iter())
-    };
-
-    let lint_opts = lints()
-        .filter_map(|lint| {
-            if lint.name == warnings_lint_name
-                || lint.name == intra_link_resolution_failure_name
-                || lint.name == invalid_codeblock_attribute_name
-            {
-                None
-            } else {
-                Some((lint.name_lower(), lint::Allow))
-            }
-        })
-        .chain(lint_opts.into_iter())
-        .collect::<Vec<_>>();
-
-    let lint_caps = lints()
-        .filter_map(|lint| {
-            // We don't want to whitelist *all* lints so let's
-            // ignore those ones.
-            if whitelisted_lints.iter().any(|l| lint.name == l) {
-                None
-            } else {
-                Some((lint::LintId::of(lint), lint::Allow))
-            }
-        })
-        .collect();
+    let (lint_opts, lint_caps) = init_lints(whitelisted_lints, lint_opts, |lint| {
+        if lint.name == intra_link_resolution_failure_name
+            || lint.name == invalid_codeblock_attribute_name
+        {
+            None
+        } else {
+            Some((lint.name_lower(), lint::Allow))
+        }
+    });
 
     let crate_types = if proc_macro_crate {
         vec![config::CrateType::ProcMacro]

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -26,6 +26,7 @@ use tempfile::Builder as TempFileBuilder;
 
 use crate::clean::Attributes;
 use crate::config::Options;
+use crate::core::init_lints;
 use crate::html::markdown::{self, ErrorCodes, Ignore, LangString};
 use crate::passes::span_of_attrs;
 
@@ -43,44 +44,19 @@ pub struct TestOptions {
 pub fn run(options: Options) -> i32 {
     let input = config::Input::File(options.input.clone());
 
-    let warnings_lint_name = lint::builtin::WARNINGS.name;
     let invalid_codeblock_attribute_name = rustc_lint::builtin::INVALID_CODEBLOCK_ATTRIBUTE.name;
 
     // In addition to those specific lints, we also need to whitelist those given through
     // command line, otherwise they'll get ignored and we don't want that.
-    let mut whitelisted_lints =
-        vec![warnings_lint_name.to_owned(), invalid_codeblock_attribute_name.to_owned()];
+    let whitelisted_lints = vec![invalid_codeblock_attribute_name.to_owned()];
 
-    whitelisted_lints.extend(options.lint_opts.iter().map(|(lint, _)| lint).cloned());
-
-    let lints = || {
-        lint::builtin::HardwiredLints::get_lints()
-            .into_iter()
-            .chain(rustc_lint::SoftLints::get_lints().into_iter())
-    };
-
-    let lint_opts = lints()
-        .filter_map(|lint| {
-            if lint.name == warnings_lint_name || lint.name == invalid_codeblock_attribute_name {
-                None
-            } else {
-                Some((lint.name_lower(), lint::Allow))
-            }
-        })
-        .chain(options.lint_opts.clone().into_iter())
-        .collect::<Vec<_>>();
-
-    let lint_caps = lints()
-        .filter_map(|lint| {
-            // We don't want to whitelist *all* lints so let's
-            // ignore those ones.
-            if whitelisted_lints.iter().any(|l| lint.name == l) {
-                None
-            } else {
-                Some((lint::LintId::of(lint), lint::Allow))
-            }
-        })
-        .collect();
+    let (lint_opts, lint_caps) = init_lints(whitelisted_lints, options.lint_opts.clone(), |lint| {
+        if lint.name == invalid_codeblock_attribute_name {
+            None
+        } else {
+            Some((lint.name_lower(), lint::Allow))
+        }
+    });
 
     let crate_types = if options.proc_macro_crate {
         vec![config::CrateType::ProcMacro]

--- a/src/test/ui/unsized-locals/issue-30276-feature-flagged.rs
+++ b/src/test/ui/unsized-locals/issue-30276-feature-flagged.rs
@@ -1,0 +1,7 @@
+#![feature(unsized_locals)]
+
+struct Test([i32]);
+
+fn main() {
+    let _x: fn(_) -> Test = Test;
+} //~^the size for values of type `[i32]` cannot be known at compilation time

--- a/src/test/ui/unsized-locals/issue-30276-feature-flagged.stderr
+++ b/src/test/ui/unsized-locals/issue-30276-feature-flagged.stderr
@@ -1,0 +1,14 @@
+error[E0277]: the size for values of type `[i32]` cannot be known at compilation time
+  --> $DIR/issue-30276-feature-flagged.rs:6:29
+   |
+LL |     let _x: fn(_) -> Test = Test;
+   |                             ^^^^ doesn't have a size known at compile-time
+   |
+   = help: within `Test`, the trait `std::marker::Sized` is not implemented for `[i32]`
+   = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
+   = note: required because it appears within the type `Test`
+   = note: the return type of a function must have a statically known size
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/unsized-locals/issue-30276.rs
+++ b/src/test/ui/unsized-locals/issue-30276.rs
@@ -1,0 +1,5 @@
+struct Test([i32]);
+
+fn main() {
+    let _x: fn(_) -> Test = Test;
+} //~^the size for values of type `[i32]` cannot be known at compilation time

--- a/src/test/ui/unsized-locals/issue-30276.stderr
+++ b/src/test/ui/unsized-locals/issue-30276.stderr
@@ -1,0 +1,14 @@
+error[E0277]: the size for values of type `[i32]` cannot be known at compilation time
+  --> $DIR/issue-30276.rs:4:29
+   |
+LL |     let _x: fn(_) -> Test = Test;
+   |                             ^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `std::marker::Sized` is not implemented for `[i32]`
+   = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
+   = note: all function arguments must have a statically known size
+   = help: unsized locals are gated as an unstable feature
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Successful merges:

 - #71581 (Unify lints handling in rustdoc)
 - #71710 (Test for zero-sized function items not ICEing)
 - #71970 (Improve bitcode generation for Apple platforms)
 - #71975 (Reduce `TypedArena` creations in `check_match`.)
 - #72003 (allow wasm target for rustc-ap-rustc_span)
 - #72017 (Work around ICEs during cross-compilation for target, ast, & attr)

Failed merges:


r? @ghost