### PR TITLE
Use CDN for ci-caches on download

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
       CI_JOB_NAME: "${{ matrix.name }}"
       SCCACHE_BUCKET: rust-lang-gha-caches
       TOOLSTATE_REPO: "https://github.com/pietroalbini/rust-toolstate"
+      CACHE_DOMAIN: ci-caches-gha.rust-lang.org
     if: "github.event_name == 'pull_request'"
     strategy:
       matrix:
@@ -146,6 +147,7 @@ jobs:
       TOOLSTATE_PUBLISH: 1
       CACHES_AWS_ACCESS_KEY_ID: AKIA46X5W6CZOMUQATD5
       ARTIFACTS_AWS_ACCESS_KEY_ID: AKIA46X5W6CZH5AYXDVF
+      CACHE_DOMAIN: ci-caches-gha.rust-lang.org
     if: "github.event_name == 'push' && github.ref == 'refs/heads/try' && github.repository == 'rust-lang-ci/rust'"
     strategy:
       matrix:
@@ -255,6 +257,7 @@ jobs:
       TOOLSTATE_PUBLISH: 1
       CACHES_AWS_ACCESS_KEY_ID: AKIA46X5W6CZOMUQATD5
       ARTIFACTS_AWS_ACCESS_KEY_ID: AKIA46X5W6CZH5AYXDVF
+      CACHE_DOMAIN: ci-caches-gha.rust-lang.org
     if: "github.event_name == 'push' && github.ref == 'refs/heads/auto' && github.repository == 'rust-lang-ci/rust'"
     strategy:
       matrix:
@@ -606,6 +609,7 @@ jobs:
       TOOLSTATE_PUBLISH: 1
       CACHES_AWS_ACCESS_KEY_ID: AKIA46X5W6CZOMUQATD5
       ARTIFACTS_AWS_ACCESS_KEY_ID: AKIA46X5W6CZH5AYXDVF
+      CACHE_DOMAIN: ci-caches-gha.rust-lang.org
     if: "github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository == 'rust-lang-ci/rust'"
     steps:
       - name: checkout the source code

--- a/src/ci/github-actions/ci.yml
+++ b/src/ci/github-actions/ci.yml
@@ -37,6 +37,7 @@ x--expand-yaml-anchors--remove:
   - &public-variables
     SCCACHE_BUCKET: rust-lang-gha-caches
     TOOLSTATE_REPO: https://github.com/pietroalbini/rust-toolstate
+    CACHE_DOMAIN: ci-caches-gha.rust-lang.org
 
   - &prod-variables
     SCCACHE_BUCKET: rust-lang-gha-caches
@@ -51,6 +52,7 @@ x--expand-yaml-anchors--remove:
     # (caches, artifacts...).
     CACHES_AWS_ACCESS_KEY_ID: AKIA46X5W6CZOMUQATD5
     ARTIFACTS_AWS_ACCESS_KEY_ID: AKIA46X5W6CZH5AYXDVF
+    CACHE_DOMAIN: ci-caches-gha.rust-lang.org
 
   - &base-job
     env: {}


### PR DESCRIPTION
This will reduce costs, as well as lays the groundwork for developers to be able
to locally pull the published docker images without needing AWS credentials.

r? @pietroalbini 