### PR TITLE
Add the Stream trait

### DIFF
--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -143,6 +143,7 @@ use core::ops::{
 };
 use core::pin::Pin;
 use core::ptr::{self, NonNull, Unique};
+use core::stream::Stream;
 use core::task::{Context, Poll};
 
 use crate::alloc::{self, AllocInit, AllocRef, Global};
@@ -1148,5 +1149,18 @@ impl<F: ?Sized + Future + Unpin> Future for Box<F> {
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         F::poll(Pin::new(&mut *self), cx)
+    }
+}
+
+#[unstable(feature = "stream", issue = "none")]
+impl<S: ?Sized + Stream + Unpin> Stream for Box<S> {
+    type Item = S::Item;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        S::poll_next(Pin::new(&mut *self), cx)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (**self).size_hint()
     }
 }

--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -111,6 +111,7 @@
 #![feature(specialization)]
 #![feature(staged_api)]
 #![feature(std_internals)]
+#![feature(stream)]
 #![feature(str_internals)]
 #![feature(trusted_len)]
 #![feature(try_reserve)]

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -253,6 +253,7 @@ pub mod unicode;
 /* Async */
 #[cfg(not(test))] // See #65860
 pub mod future;
+pub mod stream;
 pub mod task;
 
 /* Heap memory allocator trait */

--- a/src/libcore/stream.rs
+++ b/src/libcore/stream.rs
@@ -1,0 +1,98 @@
+//! Asynchronous sequences of values.
+#![unstable(feature = "stream", issue = "none")]
+use crate::marker::Unpin;
+use crate::ops::DerefMut;
+use crate::pin::Pin;
+use crate::task::{Context, Poll};
+
+/// A stream of values produced asynchronously.
+///
+/// If `Future<Output = T>` is an asynchronous version of `T`, then `Stream<Item = T>` is an asynchronous version of
+/// `Iterator<Item = T>`. A stream represents a sequence of value-producing events that occur asynchronously to the
+/// caller.
+///
+/// The trait is modeled after `Future`, but allows `poll_next` to be called even after a value has been produced,
+/// yielding `None` once the stream has been fully exhausted.
+#[unstable(feature = "stream", issue = "none")]
+pub trait Stream {
+    /// Values yielded by the stream.
+    type Item;
+
+    /// Attempt to pull out the next value of this stream, registering the current task for wakeup if the value is not
+    /// yet available, and returning `None` if the stream is exhausted.
+    ///
+    /// # Return value
+    ///
+    /// There are several possible return values, each indicating a distinct stream state:
+    ///
+    /// * `Poll::Pending` means that this stream's next value is not ready yet. Implementations will ensure that the
+    ///     current task will be notified when the next value may be ready.
+    /// * `Poll::Ready(Some(val))` means that the stream has successfully produced a value, `val`, and may produce
+    ///     further values on subsequent `poll_next` calls.
+    /// * `Poll::Ready(None)` means that the stream has terminated, and `poll_next` should not be invoked again.
+    ///
+    /// # Panics
+    ///
+    /// Once a stream is finished, i.e. `Ready(None)` has been returned, further calls may result in a panic or other
+    /// "bad behavior".
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>>;
+
+    /// Returns the bounds on the remaining length of the stream.
+    ///
+    /// Specifically, `size_hint()` returns a tuple where the first element is a lower bound, and the second element is
+    /// the upper bound.
+    ///
+    /// The second half of the tuple that is returned is an `Option<usize>`. A `None` here means that there is no known
+    /// upper bound, or the bound is larger than `usize`.
+    ///
+    /// # Implementation notes
+    ///
+    /// It is not enforced that a stream implementation yields the declared number of elements. A buggy stream may yield
+    /// less than the lower bound or more than the upper bound of elements.
+    ///
+    /// `size_hint()` is primarily intended to be used for optimizations such as reserving space for the elements of the
+    /// stream, but must not be trusted to e.g. omit bounds checks in unsafe code. An incorrect implementation of
+    /// `size_hint()` should not lead to memory safety violations.
+    ///
+    /// That said, the implementation should provide a correct estimation, because otherwise it would be a violation of
+    /// the trait's protocol.
+    ///
+    /// The default implementation returns `(0, None)` which is correct for any stream.
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (0, None)
+    }
+}
+
+#[unstable(feature = "stream", issue = "none")]
+impl<S> Stream for &mut S
+where
+    S: ?Sized + Stream + Unpin,
+{
+    type Item = S::Item;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        S::poll_next(Pin::new(&mut **self), cx)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (**self).size_hint()
+    }
+}
+
+#[unstable(feature = "stream", issue = "none")]
+impl<P> Stream for Pin<P>
+where
+    P: DerefMut + Unpin,
+    P::Target: Stream,
+{
+    type Item = <P::Target as Stream>::Item;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.get_mut().as_mut().poll_next(cx)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (**self).size_hint()
+    }
+}

--- a/src/libcore/stream.rs
+++ b/src/libcore/stream.rs
@@ -33,8 +33,13 @@ pub trait Stream {
     ///
     /// # Panics
     ///
-    /// Once a stream is finished, i.e. `Ready(None)` has been returned, further calls may result in a panic or other
-    /// "bad behavior".
+    /// Once a stream has finished (returned `Ready(None)` from `poll_next`), calling its
+    /// `poll_next` method again may panic, block forever, or cause other kinds of
+    /// problems; the `Stream` trait places no requirements on the effects of
+    /// such a call. However, as the `poll_next` method is not marked `unsafe`,
+    /// Rust's usual rules apply: calls must never cause undefined behavior
+    /// (memory corruption, incorrect use of `unsafe` functions, or the like),
+    /// regardless of the stream's state.
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>>;
 
     /// Returns the bounds on the remaining length of the stream.

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -304,6 +304,7 @@
 #![feature(std_internals)]
 #![feature(stdsimd)]
 #![feature(stmt_expr_attributes)]
+#![feature(stream)]
 #![feature(str_internals)]
 #![feature(test)]
 #![feature(thread_local)]
@@ -431,6 +432,8 @@ pub use core::ptr;
 pub use core::raw;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use core::result;
+#[unstable(feature = "stream", issue = "none")]
+pub use core::stream;
 #[stable(feature = "i128", since = "1.26.0")]
 pub use core::u128;
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/libstd/panic.rs
+++ b/src/libstd/panic.rs
@@ -12,6 +12,7 @@ use crate::panicking;
 use crate::pin::Pin;
 use crate::ptr::{NonNull, Unique};
 use crate::rc::Rc;
+use crate::stream::Stream;
 use crate::sync::atomic;
 use crate::sync::{Arc, Mutex, RwLock};
 use crate::task::{Context, Poll};
@@ -333,6 +334,20 @@ impl<F: Future> Future for AssertUnwindSafe<F> {
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let pinned_field = unsafe { Pin::map_unchecked_mut(self, |x| &mut x.0) };
         F::poll(pinned_field, cx)
+    }
+}
+
+#[unstable(feature = "stream", issue = "none")]
+impl<S: Stream> Stream for AssertUnwindSafe<S> {
+    type Item = S::Item;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let pinned_field = unsafe { Pin::map_unchecked_mut(self, |x| &mut x.0) };
+        S::poll_next(pinned_field, cx)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
     }
 }
 


### PR DESCRIPTION
This is a direct copy of the futures crate's version, which should enable that crate to reexport std's version in the future while preserving backwards compatibility. Like Future, this doesn't include
any of the various convenience methods - those can be added later and for now pulled from crates like futures.