### PR TITLE
Add a feature gate for allowing integers as the address of references in constants

### DIFF
--- a/src/librustc_feature/active.rs
+++ b/src/librustc_feature/active.rs
@@ -565,6 +565,9 @@ declare_features! (
     /// Allow conditional compilation depending on rust version
     (active, cfg_version, "1.45.0", Some(64796), None),
 
+    /// Allows constants of reference type to have integers for the address.
+    (active, const_int_ref, "1.45.0", Some(63197), None),
+
     // -------------------------------------------------------------------------
     // feature-group-end: actual feature gates
     // -------------------------------------------------------------------------

--- a/src/librustc_span/symbol.rs
+++ b/src/librustc_span/symbol.rs
@@ -219,6 +219,7 @@ symbols! {
         const_generics,
         const_if_match,
         const_indexing,
+        const_int_ref,
         const_in_array_repeat_expressions,
         const_let,
         const_loop,

--- a/src/test/ui/consts/const-eval/ub-ref.stderr
+++ b/src/test/ui/consts/const-eval/ub-ref.stderr
@@ -58,7 +58,7 @@ error[E0080]: it is undefined behavior to use this value
   --> $DIR/ub-ref.rs:33:1
    |
 LL | const USIZE_AS_REF: &'static u8 = unsafe { mem::transmute(1337usize) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a dangling reference (created from integer)
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a dangling reference (created from integer). Add `#![feature(const_int_ref)]` to the crate attributes to enable
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
@@ -66,7 +66,7 @@ error[E0080]: it is undefined behavior to use this value
   --> $DIR/ub-ref.rs:36:1
    |
 LL | const USIZE_AS_BOX: Box<u8> = unsafe { mem::transmute(1337usize) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a dangling box (created from integer)
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a dangling box (created from integer). Add `#![feature(const_int_ref)]` to the crate attributes to enable
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 

--- a/src/test/ui/consts/const-int-ref.rs
+++ b/src/test/ui/consts/const-int-ref.rs
@@ -1,0 +1,17 @@
+// gate-test-const_int_refs
+// revisions: gated vanilla
+
+//[gated] check-pass
+
+#![cfg_attr(gated, feature(const_int_ref))]
+
+#[repr(C)]
+union Transmute {
+    int: usize,
+    ptr: &'static i32
+}
+
+const GPIO: &i32 = unsafe { Transmute { int: 0x800 }.ptr };
+//[vanilla]~^ ERROR it is undefined behavior
+
+fn main() {}

--- a/src/test/ui/consts/const-int-ref.stderr
+++ b/src/test/ui/consts/const-int-ref.stderr
@@ -1,0 +1,15 @@
+error[E0601]: `main` function not found in crate `const_int_ref`
+  --> $DIR/const-int-ref.rs:3:1
+   |
+LL | / #[repr(C)]
+LL | | union Transmute {
+LL | |     int: usize,
+LL | |     ptr: &'static i32
+LL | | }
+LL | |
+LL | | const GPIO: &i32 = unsafe { Transmute { int: 0x800 }.ptr };
+   | |___________________________________________________________^ consider adding a `main` function to `$DIR/const-int-ref.rs`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0601`.

--- a/src/test/ui/consts/const-int-ref.vanilla.stderr
+++ b/src/test/ui/consts/const-int-ref.vanilla.stderr
@@ -1,0 +1,11 @@
+error[E0080]: it is undefined behavior to use this value
+  --> $DIR/const-int-ref.rs:14:1
+   |
+LL | const GPIO: &i32 = unsafe { Transmute { int: 0x800 }.ptr };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a dangling reference (created from integer). Add `#![feature(const_int_ref)]` to the crate attributes to enable
+   |
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0080`.


### PR DESCRIPTION
implementation for #63197

cc @rust-lang/wg-const-eval 