### PR TITLE
use min_specialization for some rustc crates where it requires no changes

### DIFF
--- a/src/librustc_ast_lowering/lib.rs
+++ b/src/librustc_ast_lowering/lib.rs
@@ -33,7 +33,7 @@
 #![feature(array_value_iter)]
 #![feature(crate_visibility_modifier)]
 #![feature(marker_trait_attr)]
-#![feature(specialization)]
+#![feature(specialization)] // FIXME: min_specialization does not work
 #![feature(or_patterns)]
 #![recursion_limit = "256"]
 

--- a/src/librustc_data_structures/lib.rs
+++ b/src/librustc_data_structures/lib.rs
@@ -12,7 +12,7 @@
 #![feature(generators)]
 #![feature(generator_trait)]
 #![feature(fn_traits)]
-#![feature(specialization)]
+#![feature(min_specialization)]
 #![feature(optin_builtin_traits)]
 #![feature(nll)]
 #![feature(allow_internal_unstable)]

--- a/src/librustc_hir/lib.rs
+++ b/src/librustc_hir/lib.rs
@@ -8,7 +8,7 @@
 #![feature(const_panic)]
 #![feature(in_band_lifetimes)]
 #![feature(or_patterns)]
-#![feature(specialization)]
+#![feature(min_specialization)]
 #![recursion_limit = "256"]
 
 #[macro_use]

--- a/src/librustc_metadata/lib.rs
+++ b/src/librustc_metadata/lib.rs
@@ -7,7 +7,7 @@
 #![feature(nll)]
 #![feature(or_patterns)]
 #![feature(proc_macro_internals)]
-#![feature(specialization)]
+#![feature(specialization)] // FIXME: min_specialization ICEs
 #![feature(stmt_expr_attributes)]
 #![recursion_limit = "256"]
 

--- a/src/librustc_middle/lib.rs
+++ b/src/librustc_middle/lib.rs
@@ -41,7 +41,7 @@
 #![feature(option_expect_none)]
 #![feature(or_patterns)]
 #![feature(range_is_empty)]
-#![feature(specialization)]
+#![feature(specialization)] // FIXME: min_specialization does not work
 #![feature(track_caller)]
 #![feature(trusted_len)]
 #![feature(vec_remove_item)]

--- a/src/librustc_mir/lib.rs
+++ b/src/librustc_mir/lib.rs
@@ -19,7 +19,7 @@ Rust MIR: a lowered representation of Rust.
 #![feature(exhaustive_patterns)]
 #![feature(iter_order_by)]
 #![feature(never_type)]
-#![feature(specialization)]
+#![feature(min_specialization)]
 #![feature(trusted_len)]
 #![feature(try_blocks)]
 #![feature(associated_type_bounds)]

--- a/src/librustc_query_system/lib.rs
+++ b/src/librustc_query_system/lib.rs
@@ -4,7 +4,7 @@
 #![feature(const_panic)]
 #![feature(core_intrinsics)]
 #![feature(hash_raw_entry)]
-#![feature(specialization)]
+#![feature(specialization)] // FIXME: min_specialization rejects `default const`
 #![feature(stmt_expr_attributes)]
 #![feature(vec_remove_item)]
 

--- a/src/librustc_span/lib.rs
+++ b/src/librustc_span/lib.rs
@@ -12,7 +12,7 @@
 #![feature(negative_impls)]
 #![feature(nll)]
 #![feature(optin_builtin_traits)]
-#![feature(specialization)]
+#![feature(min_specialization)]
 
 // FIXME(#56935): Work around ICEs during cross-compilation.
 #[allow(unused)]

--- a/src/libserialize/lib.rs
+++ b/src/libserialize/lib.rs
@@ -10,7 +10,7 @@ Core encoding and decoding interfaces.
     test(attr(allow(unused_variables), deny(warnings)))
 )]
 #![feature(box_syntax)]
-#![feature(specialization)]
+#![feature(specialization)] // FIXME: min_specialization does not work
 #![feature(never_type)]
 #![feature(nll)]
 #![feature(associated_type_bounds)]


### PR DESCRIPTION
and add FIXME for the rest

Cc @matthewjasper 