### PR TITLE
[beta] backports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2298,9 +2298,9 @@ checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
 name = "openssl-src"
-version = "111.8.1+1.1.1f"
+version = "111.9.0+1.1.1g"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f04f0299a91de598dde58d2e99101895498dcf3d58896a3297798f28b27c8b72"
+checksum = "a2dbe10ddd1eb335aba3780eb2eaa13e1b7b441d2562fd962398740927f39ec4"
 dependencies = [
  "cc",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -412,9 +412,9 @@ version = "0.1.0"
 
 [[package]]
 name = "cc"
-version = "1.0.50"
+version = "1.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95e28fa049fda1c330bcf9d723be7663a899c4679724b34c81e9f5a326aab8cd"
+checksum = "c3d87b23d6a92cd03af510a5ade527033f6aa6fa92161e2d5863a907d4c5e31d"
 dependencies = [
  "jobserver",
 ]

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,15 @@
+Version 1.43.1 (2020-05-07)
+===========================
+
+* [Updated openssl-src to 1.1.1g for CVE-2020-1967.][71430]
+* [Fixed the stabilization of AVX-512 features.][71473]
+* [Fixed `cargo package --list` not working with unpublished dependencies.][cargo/8151]
+
+[71430]: https://github.com/rust-lang/rust/pull/71430
+[71473]: https://github.com/rust-lang/rust/issues/71473
+[cargo/8151]: https://github.com/rust-lang/cargo/issues/8151
+
+
 Version 1.43.0 (2020-04-23)
 ==========================
 
@@ -14,7 +26,7 @@ Language
 - [Merge `fn` syntax + cleanup item parsing.][68728]
 - [`item` macro fragments can be interpolated into `trait`s, `impl`s, and `extern` blocks.][69366]
   For example, you may now write:
-  ```rust 
+  ```rust
   macro_rules! mac_trait {
       ($i:item) => {
           trait T { $i }
@@ -82,7 +94,7 @@ Misc
 - [Certain checks in the `const_err` lint were deemed unrelated to const
   evaluation][69185], and have been moved to the `unconditional_panic` and
   `arithmetic_overflow` lints.
-  
+
 Compatibility Notes
 -------------------
 
@@ -173,7 +185,7 @@ Language
      (e.g. `type Foo: Ord;`).
    - `...` (the C-variadic type) may occur syntactically directly as the type of
       any function parameter.
-  
+
   These are still rejected *semantically*, so you will likely receive an error
   but these changes can be seen and parsed by procedural macros and
   conditional compilation.
@@ -465,7 +477,7 @@ Compatibility Notes
 - [Using `#[inline]` on function prototypes and consts now emits a warning under
   `unused_attribute` lint.][65294] Using `#[inline]` anywhere else inside traits
   or `extern` blocks now correctly emits a hard error.
-  
+
 [65294]: https://github.com/rust-lang/rust/pull/65294/
 [66103]: https://github.com/rust-lang/rust/pull/66103/
 [65843]: https://github.com/rust-lang/rust/pull/65843/

--- a/src/ci/scripts/install-msys2-packages.sh
+++ b/src/ci/scripts/install-msys2-packages.sh
@@ -9,11 +9,19 @@ if isWindows; then
     pacman -S --noconfirm --needed base-devel ca-certificates make diffutils tar \
         binutils
 
+    # Detect the native Python version installed on the agent. On GitHub
+    # Actions, the C:\hostedtoolcache\windows\Python directory contains a
+    # subdirectory for each installed Python version.
+    #
+    # The -V flag of the sort command sorts the input by version number.
+    native_python_version="$(ls /c/hostedtoolcache/windows/Python | sort -Vr | head -n 1)"
+
     # Make sure we use the native python interpreter instead of some msys equivalent
     # one way or another. The msys interpreters seem to have weird path conversions
     # baked in which break LLVM's build system one way or another, so let's use the
     # native version which keeps everything as native as possible.
-    python_home="C:/hostedtoolcache/windows/Python/3.7.6/x64"
+    python_home="/c/hostedtoolcache/windows/Python/${native_python_version}/x64"
     cp "${python_home}/python.exe" "${python_home}/python3.exe"
-    ciCommandAddPath "C:\\hostedtoolcache\\windows\\Python\\3.7.6\\x64"
+    ciCommandAddPath "C:\\hostedtoolcache\\windows\\Python\\${native_python_version}\\x64"
+    ciCommandAddPath "C:\\hostedtoolcache\\windows\\Python\\${native_python_version}\\x64\\Scripts"
 fi

--- a/src/libcore/tests/lib.rs
+++ b/src/libcore/tests/lib.rs
@@ -42,6 +42,7 @@
 #![feature(unwrap_infallible)]
 #![feature(leading_trailing_ones)]
 #![feature(const_forget)]
+#![feature(option_unwrap_none)]
 
 extern crate test;
 

--- a/src/librustc_error_codes/error_codes/E0751.md
+++ b/src/librustc_error_codes/error_codes/E0751.md
@@ -2,7 +2,7 @@ There are both a positive and negative trait implementation for the same type.
 
 Erroneous code example:
 
-```compile_fail,E0748
+```compile_fail,E0751
 trait MyTrait {}
 impl MyTrait for i32 { }
 impl !MyTrait for i32 { }

--- a/src/librustc_infer/infer/outlives/verify.rs
+++ b/src/librustc_infer/infer/outlives/verify.rs
@@ -223,7 +223,7 @@ impl<'cx, 'tcx> VerifyBoundCx<'cx, 'tcx> {
         // like `T` and `T::Item`. It may not work as well for things
         // like `<T as Foo<'a>>::Item`.
         let c_b = self.param_env.caller_bounds;
-        let param_bounds = self.collect_outlives_from_predicate_list(&compare_ty, c_b);
+        let param_bounds = self.collect_outlives_from_predicate_list(&compare_ty, c_b.into_iter());
 
         // Next, collect regions we scraped from the well-formedness
         // constraints in the fn signature. To do that, we walk the list
@@ -315,15 +315,12 @@ impl<'cx, 'tcx> VerifyBoundCx<'cx, 'tcx> {
         let tcx = self.tcx;
         let assoc_item = tcx.associated_item(assoc_item_def_id);
         let trait_def_id = assoc_item.container.assert_trait();
-        let trait_predicates =
-            tcx.predicates_of(trait_def_id).predicates.iter().map(|(p, _)| *p).collect();
+        let trait_predicates = tcx.predicates_of(trait_def_id).predicates.iter().map(|(p, _)| *p);
         let identity_substs = InternalSubsts::identity_for_item(tcx, assoc_item_def_id);
         let identity_proj = tcx.mk_projection(assoc_item_def_id, identity_substs);
         self.collect_outlives_from_predicate_list(
             move |ty| ty == identity_proj,
-            traits::elaborate_predicates(tcx, trait_predicates)
-                .map(|o| o.predicate)
-                .collect::<Vec<_>>(),
+            traits::elaborate_predicates(tcx, trait_predicates).map(|o| o.predicate),
         )
         .map(|b| b.1)
     }

--- a/src/librustc_infer/traits/util.rs
+++ b/src/librustc_infer/traits/util.rs
@@ -149,21 +149,20 @@ impl Elaborator<'tcx> {
                 // Get predicates declared on the trait.
                 let predicates = tcx.super_predicates_of(data.def_id());
 
-                let obligations = predicates.predicates.iter().map(|(pred, span)| {
+                let obligations = predicates.predicates.into_iter().map(|(pred, span)| {
                     predicate_obligation(
                         pred.subst_supertrait(tcx, &data.to_poly_trait_ref()),
                         Some(*span),
                     )
                 });
-                debug!("super_predicates: data={:?} predicates={:?}", data, &obligations);
+                debug!("super_predicates: data={:?}", data);
 
                 // Only keep those bounds that we haven't already seen.
                 // This is necessary to prevent infinite recursion in some
                 // cases. One common case is when people define
                 // `trait Sized: Sized { }` rather than `trait Sized { }`.
                 let visited = &mut self.visited;
-                let obligations =
-                    obligations.filter(|obligation| visited.insert(&obligation.predicate));
+                let obligations = obligations.filter(|o| visited.insert(&o.predicate));
 
                 self.stack.extend(obligations);
             }

--- a/src/librustc_infer/traits/util.rs
+++ b/src/librustc_infer/traits/util.rs
@@ -97,24 +97,22 @@ pub fn elaborate_trait_ref<'tcx>(
     tcx: TyCtxt<'tcx>,
     trait_ref: ty::PolyTraitRef<'tcx>,
 ) -> Elaborator<'tcx> {
-    elaborate_predicates(tcx, vec![trait_ref.without_const().to_predicate()])
+    elaborate_predicates(tcx, std::iter::once(trait_ref.without_const().to_predicate()))
 }
 
 pub fn elaborate_trait_refs<'tcx>(
     tcx: TyCtxt<'tcx>,
     trait_refs: impl Iterator<Item = ty::PolyTraitRef<'tcx>>,
 ) -> Elaborator<'tcx> {
-    let predicates = trait_refs.map(|trait_ref| trait_ref.without_const().to_predicate()).collect();
+    let predicates = trait_refs.map(|trait_ref| trait_ref.without_const().to_predicate());
     elaborate_predicates(tcx, predicates)
 }
 
 pub fn elaborate_predicates<'tcx>(
     tcx: TyCtxt<'tcx>,
-    mut predicates: Vec<ty::Predicate<'tcx>>,
+    predicates: impl IntoIterator<Item = ty::Predicate<'tcx>>,
 ) -> Elaborator<'tcx> {
-    let mut visited = PredicateSet::new(tcx);
-    predicates.retain(|pred| visited.insert(pred));
-    let obligations: Vec<_> =
+    let obligations =
         predicates.into_iter().map(|predicate| predicate_obligation(predicate, None)).collect();
     elaborate_obligations(tcx, obligations)
 }

--- a/src/librustc_lint/unused.rs
+++ b/src/librustc_lint/unused.rs
@@ -16,7 +16,7 @@ use rustc_middle::ty::{self, Ty};
 use rustc_session::lint::builtin::UNUSED_ATTRIBUTES;
 use rustc_span::symbol::Symbol;
 use rustc_span::symbol::{kw, sym};
-use rustc_span::{BytePos, Span};
+use rustc_span::{BytePos, Span, DUMMY_SP};
 
 use log::debug;
 
@@ -415,6 +415,12 @@ trait UnusedDelimLint {
         msg: &str,
         keep_space: (bool, bool),
     ) {
+        // FIXME(flip1995): Quick and dirty fix for #70814. This should be fixed in rustdoc
+        // properly.
+        if span == DUMMY_SP {
+            return;
+        }
+
         cx.struct_span_lint(self.lint(), span, |lint| {
             let span_msg = format!("unnecessary {} around {}", Self::DELIM_STR, msg);
             let mut err = lint.build(&span_msg);

--- a/src/librustc_middle/ty/trait_def.rs
+++ b/src/librustc_middle/ty/trait_def.rs
@@ -168,15 +168,13 @@ impl<'tcx> TyCtxt<'tcx> {
     }
 
     /// Returns a vector containing all impls
-    pub fn all_impls(self, def_id: DefId) -> Vec<DefId> {
-        let impls = self.trait_impls_of(def_id);
+    pub fn all_impls(self, def_id: DefId) -> impl Iterator<Item = DefId> + 'tcx {
+        let TraitImpls { blanket_impls, non_blanket_impls } = self.trait_impls_of(def_id);
 
-        impls
-            .blanket_impls
-            .iter()
-            .chain(impls.non_blanket_impls.values().flatten())
+        blanket_impls
+            .into_iter()
+            .chain(non_blanket_impls.into_iter().map(|(_, v)| v).flatten())
             .cloned()
-            .collect()
     }
 }
 

--- a/src/librustc_mir/borrow_check/type_check/mod.rs
+++ b/src/librustc_mir/borrow_check/type_check/mod.rs
@@ -690,6 +690,7 @@ impl<'a, 'b, 'tcx> TypeVerifier<'a, 'b, 'tcx> {
                 let fty = self.sanitize_type(place, fty);
                 match self.field_ty(place, base, field, location) {
                     Ok(ty) => {
+                        let ty = self.cx.normalize(ty, location);
                         if let Err(terr) = self.cx.eq_types(
                             ty,
                             fty,

--- a/src/librustc_mir/transform/const_prop.rs
+++ b/src/librustc_mir/transform/const_prop.rs
@@ -122,8 +122,7 @@ impl<'tcx> MirPass<'tcx> for ConstProp {
             .predicates_of(source.def_id())
             .predicates
             .iter()
-            .filter_map(|(p, _)| if p.is_global() { Some(*p) } else { None })
-            .collect();
+            .filter_map(|(p, _)| if p.is_global() { Some(*p) } else { None });
         if !traits::normalize_and_test_predicates(
             tcx,
             traits::elaborate_predicates(tcx, predicates).map(|o| o.predicate).collect(),

--- a/src/librustc_trait_selection/opaque_types.rs
+++ b/src/librustc_trait_selection/opaque_types.rs
@@ -418,7 +418,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
             let opaque_type = tcx.mk_opaque(def_id, opaque_defn.substs);
 
             let required_region_bounds =
-                required_region_bounds(tcx, opaque_type, bounds.predicates);
+                required_region_bounds(tcx, opaque_type, bounds.predicates.into_iter());
             debug_assert!(!required_region_bounds.is_empty());
 
             for required_region in required_region_bounds {
@@ -1127,7 +1127,8 @@ impl<'a, 'tcx> Instantiator<'a, 'tcx> {
 
         debug!("instantiate_opaque_types: bounds={:?}", bounds);
 
-        let required_region_bounds = required_region_bounds(tcx, ty, bounds.predicates.clone());
+        let required_region_bounds =
+            required_region_bounds(tcx, ty, bounds.predicates.iter().cloned());
         debug!("instantiate_opaque_types: required_region_bounds={:?}", required_region_bounds);
 
         // Make sure that we are in fact defining the *entire* type
@@ -1245,17 +1246,15 @@ pub fn may_define_opaque_type(tcx: TyCtxt<'_>, def_id: DefId, opaque_hir_id: hir
 crate fn required_region_bounds(
     tcx: TyCtxt<'tcx>,
     erased_self_ty: Ty<'tcx>,
-    predicates: Vec<ty::Predicate<'tcx>>,
+    predicates: impl Iterator<Item = ty::Predicate<'tcx>>,
 ) -> Vec<ty::Region<'tcx>> {
-    debug!(
-        "required_region_bounds(erased_self_ty={:?}, predicates={:?})",
-        erased_self_ty, predicates
-    );
+    debug!("required_region_bounds(erased_self_ty={:?})", erased_self_ty);
 
     assert!(!erased_self_ty.has_escaping_bound_vars());
 
     traits::elaborate_predicates(tcx, predicates)
         .filter_map(|obligation| {
+            debug!("required_region_bounds(obligation={:?})", obligation);
             match obligation.predicate {
                 ty::Predicate::Projection(..)
                 | ty::Predicate::Trait(..)

--- a/src/librustc_trait_selection/traits/auto_trait.rs
+++ b/src/librustc_trait_selection/traits/auto_trait.rs
@@ -281,7 +281,7 @@ impl AutoTraitFinder<'tcx> {
             },
         }));
 
-        let mut computed_preds: FxHashSet<_> = param_env.caller_bounds.iter().cloned().collect();
+        let computed_preds = param_env.caller_bounds.iter().cloned();
         let mut user_computed_preds: FxHashSet<_> =
             user_env.caller_bounds.iter().cloned().collect();
 
@@ -358,9 +358,11 @@ impl AutoTraitFinder<'tcx> {
                 _ => panic!("Unexpected error for '{:?}': {:?}", ty, result),
             };
 
-            computed_preds.extend(user_computed_preds.iter().cloned());
-            let normalized_preds =
-                elaborate_predicates(tcx, computed_preds.iter().cloned()).map(|o| o.predicate);
+            let normalized_preds = elaborate_predicates(
+                tcx,
+                computed_preds.clone().chain(user_computed_preds.iter().cloned()),
+            )
+            .map(|o| o.predicate);
             new_env =
                 ty::ParamEnv::new(tcx.mk_predicates(normalized_preds), param_env.reveal, None);
         }
@@ -738,7 +740,7 @@ impl AutoTraitFinder<'tcx> {
                             if p.ty().skip_binder().has_infer_types() {
                                 if !self.evaluate_nested_obligations(
                                     ty,
-                                    v.clone().iter().cloned(),
+                                    v.into_iter(),
                                     computed_preds,
                                     fresh_preds,
                                     predicates,

--- a/src/librustc_trait_selection/traits/auto_trait.rs
+++ b/src/librustc_trait_selection/traits/auto_trait.rs
@@ -360,8 +360,7 @@ impl AutoTraitFinder<'tcx> {
 
             computed_preds.extend(user_computed_preds.iter().cloned());
             let normalized_preds =
-                elaborate_predicates(tcx, computed_preds.iter().cloned().collect())
-                    .map(|o| o.predicate);
+                elaborate_predicates(tcx, computed_preds.iter().cloned()).map(|o| o.predicate);
             new_env =
                 ty::ParamEnv::new(tcx.mk_predicates(normalized_preds), param_env.reveal, None);
         }

--- a/src/librustc_trait_selection/traits/error_reporting/mod.rs
+++ b/src/librustc_trait_selection/traits/error_reporting/mod.rs
@@ -1208,8 +1208,7 @@ impl<'a, 'tcx> InferCtxtPrivExt<'tcx> for InferCtxt<'a, 'tcx> {
 
         match simp {
             Some(simp) => all_impls
-                .iter()
-                .filter_map(|&def_id| {
+                .filter_map(|def_id| {
                     let imp = self.tcx.impl_trait_ref(def_id).unwrap();
                     let imp_simp = fast_reject::simplify_type(self.tcx, imp.self_ty(), true);
                     if let Some(imp_simp) = imp_simp {
@@ -1217,13 +1216,10 @@ impl<'a, 'tcx> InferCtxtPrivExt<'tcx> for InferCtxt<'a, 'tcx> {
                             return None;
                         }
                     }
-
                     Some(imp)
                 })
                 .collect(),
-            None => {
-                all_impls.iter().map(|&def_id| self.tcx.impl_trait_ref(def_id).unwrap()).collect()
-            }
+            None => all_impls.map(|def_id| self.tcx.impl_trait_ref(def_id).unwrap()).collect(),
         }
     }
 

--- a/src/librustc_trait_selection/traits/error_reporting/mod.rs
+++ b/src/librustc_trait_selection/traits/error_reporting/mod.rs
@@ -1007,7 +1007,7 @@ impl<'a, 'tcx> InferCtxtPrivExt<'tcx> for InferCtxt<'a, 'tcx> {
             }
         };
 
-        for obligation in super::elaborate_predicates(self.tcx, vec![*cond]) {
+        for obligation in super::elaborate_predicates(self.tcx, std::iter::once(*cond)) {
             if let ty::Predicate::Trait(implication, _) = obligation.predicate {
                 let error = error.to_poly_trait_ref();
                 let implication = implication.to_poly_trait_ref();

--- a/src/librustc_trait_selection/traits/mod.rs
+++ b/src/librustc_trait_selection/traits/mod.rs
@@ -110,8 +110,8 @@ pub enum TraitQueryMode {
 pub fn predicates_for_generics<'tcx>(
     cause: ObligationCause<'tcx>,
     param_env: ty::ParamEnv<'tcx>,
-    generic_bounds: &ty::InstantiatedPredicates<'tcx>,
-) -> PredicateObligations<'tcx> {
+    generic_bounds: ty::InstantiatedPredicates<'tcx>,
+) -> impl Iterator<Item = PredicateObligation<'tcx>> {
     util::predicates_for_generics(cause, 0, param_env, generic_bounds)
 }
 

--- a/src/librustc_trait_selection/traits/mod.rs
+++ b/src/librustc_trait_selection/traits/mod.rs
@@ -297,7 +297,7 @@ pub fn normalize_param_env_or_error<'tcx>(
     );
 
     let mut predicates: Vec<_> =
-        util::elaborate_predicates(tcx, unnormalized_env.caller_bounds.to_vec())
+        util::elaborate_predicates(tcx, unnormalized_env.caller_bounds.into_iter().cloned())
             .map(|obligation| obligation.predicate)
             .collect();
 

--- a/src/librustc_trait_selection/traits/object_safety.rs
+++ b/src/librustc_trait_selection/traits/object_safety.rs
@@ -302,7 +302,7 @@ fn generics_require_sized_self(tcx: TyCtxt<'_>, def_id: DefId) -> bool {
     // Search for a predicate like `Self : Sized` amongst the trait bounds.
     let predicates = tcx.predicates_of(def_id);
     let predicates = predicates.instantiate_identity(tcx).predicates;
-    elaborate_predicates(tcx, predicates).any(|obligation| match obligation.predicate {
+    elaborate_predicates(tcx, predicates.into_iter()).any(|obligation| match obligation.predicate {
         ty::Predicate::Trait(ref trait_pred, _) => {
             trait_pred.def_id() == sized_def_id && trait_pred.skip_binder().self_ty().is_param(0)
         }

--- a/src/librustc_trait_selection/traits/select.rs
+++ b/src/librustc_trait_selection/traits/select.rs
@@ -1443,7 +1443,8 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             bounds
         );
 
-        let elaborated_predicates = util::elaborate_predicates(self.tcx(), bounds.predicates);
+        let elaborated_predicates =
+            util::elaborate_predicates(self.tcx(), bounds.predicates.into_iter());
         let matching_bound = elaborated_predicates.filter_to_traits().find(|bound| {
             self.infcx.probe(|_| {
                 self.match_projection(

--- a/src/librustc_trait_selection/traits/specialize/mod.rs
+++ b/src/librustc_trait_selection/traits/specialize/mod.rs
@@ -189,26 +189,22 @@ fn fulfill_implication<'a, 'tcx>(
 
     let selcx = &mut SelectionContext::new(&infcx);
     let target_substs = infcx.fresh_substs_for_item(DUMMY_SP, target_impl);
-    let (target_trait_ref, mut obligations) =
+    let (target_trait_ref, obligations) =
         impl_trait_ref_and_oblig(selcx, param_env, target_impl, target_substs);
-    debug!(
-        "fulfill_implication: target_trait_ref={:?}, obligations={:?}",
-        target_trait_ref, obligations
-    );
 
     // do the impls unify? If not, no specialization.
-    match infcx.at(&ObligationCause::dummy(), param_env).eq(source_trait_ref, target_trait_ref) {
-        Ok(InferOk { obligations: o, .. }) => {
-            obligations.extend(o);
-        }
-        Err(_) => {
-            debug!(
-                "fulfill_implication: {:?} does not unify with {:?}",
-                source_trait_ref, target_trait_ref
-            );
-            return Err(());
-        }
-    }
+    let more_obligations =
+        match infcx.at(&ObligationCause::dummy(), param_env).eq(source_trait_ref, target_trait_ref)
+        {
+            Ok(InferOk { obligations, .. }) => obligations,
+            Err(_) => {
+                debug!(
+                    "fulfill_implication: {:?} does not unify with {:?}",
+                    source_trait_ref, target_trait_ref
+                );
+                return Err(());
+            }
+        };
 
     // attempt to prove all of the predicates for impl2 given those for impl1
     // (which are packed up in penv)
@@ -226,7 +222,7 @@ fn fulfill_implication<'a, 'tcx>(
         // we already make a mockery out of the region system, so
         // why not ignore them a bit earlier?
         let mut fulfill_cx = FulfillmentContext::new_ignoring_regions();
-        for oblig in obligations.into_iter() {
+        for oblig in obligations.chain(more_obligations) {
             fulfill_cx.register_predicate_obligation(&infcx, oblig);
         }
         match fulfill_cx.select_all_or_error(infcx) {
@@ -261,7 +257,7 @@ pub(super) fn specialization_graph_provider(
 ) -> &specialization_graph::Graph {
     let mut sg = specialization_graph::Graph::new();
 
-    let mut trait_impls = tcx.all_impls(trait_id);
+    let mut trait_impls: Vec<_> = tcx.all_impls(trait_id).collect();
 
     // The coherence checking implementation seems to rely on impls being
     // iterated over (roughly) in definition order, so we are sorting by

--- a/src/librustc_trait_selection/traits/specialize/mod.rs
+++ b/src/librustc_trait_selection/traits/specialize/mod.rs
@@ -345,7 +345,7 @@ fn report_negative_positive_conflict(
     let mut err = struct_span_err!(
         tcx.sess,
         impl_span,
-        E0748,
+        E0751,
         "found both positive and negative implementation of trait `{}`{}:",
         overlap.trait_desc,
         overlap.self_desc.clone().map_or(String::new(), |ty| format!(" for type `{}`", ty))

--- a/src/librustc_trait_selection/traits/wf.rs
+++ b/src/librustc_trait_selection/traits/wf.rs
@@ -140,7 +140,7 @@ fn extend_cause_with_original_assoc_item_obligation<'tcx>(
     item: Option<&hir::Item<'tcx>>,
     cause: &mut traits::ObligationCause<'tcx>,
     pred: &ty::Predicate<'_>,
-    mut trait_assoc_items: impl Iterator<Item = ty::AssocItem>,
+    mut trait_assoc_items: impl Iterator<Item = &'tcx ty::AssocItem>,
 ) {
     debug!(
         "extended_cause_with_original_assoc_item_obligation {:?} {:?} {:?} {:?}",
@@ -232,34 +232,33 @@ impl<'a, 'tcx> WfPredicates<'a, 'tcx> {
 
         let item = self.item;
 
-        if let Elaborate::All = elaborate {
-            let implied_obligations = traits::util::elaborate_obligations(tcx, obligations.clone());
-            let implied_obligations = implied_obligations.map(|obligation| {
-                debug!("compute_trait_ref implied_obligation {:?}", obligation);
-                debug!("compute_trait_ref implied_obligation cause {:?}", obligation.cause);
-                let mut cause = cause.clone();
-                if let Some(parent_trait_ref) = obligation.predicate.to_opt_poly_trait_ref() {
-                    let derived_cause = traits::DerivedObligationCause {
-                        parent_trait_ref,
-                        parent_code: Rc::new(obligation.cause.code.clone()),
-                    };
-                    cause.code = traits::ObligationCauseCode::DerivedObligation(derived_cause);
-                }
-                extend_cause_with_original_assoc_item_obligation(
-                    tcx,
-                    trait_ref,
-                    item,
-                    &mut cause,
-                    &obligation.predicate,
-                    tcx.associated_items(trait_ref.def_id).in_definition_order().copied(),
-                );
-                debug!("compute_trait_ref new cause {:?}", cause);
-                traits::Obligation::new(cause, param_env, obligation.predicate)
-            });
-            self.out.extend(implied_obligations);
-        }
+        let extend = |obligation: traits::PredicateObligation<'tcx>| {
+            let mut cause = cause.clone();
+            if let Some(parent_trait_ref) = obligation.predicate.to_opt_poly_trait_ref() {
+                let derived_cause = traits::DerivedObligationCause {
+                    parent_trait_ref,
+                    parent_code: Rc::new(obligation.cause.code.clone()),
+                };
+                cause.code = traits::ObligationCauseCode::DerivedObligation(derived_cause);
+            }
+            extend_cause_with_original_assoc_item_obligation(
+                tcx,
+                trait_ref,
+                item,
+                &mut cause,
+                &obligation.predicate,
+                tcx.associated_items(trait_ref.def_id).in_definition_order(),
+            );
+            traits::Obligation::new(cause, param_env, obligation.predicate)
+        };
 
-        self.out.extend(obligations);
+        if let Elaborate::All = elaborate {
+            let implied_obligations = traits::util::elaborate_obligations(tcx, obligations);
+            let implied_obligations = implied_obligations.map(extend);
+            self.out.extend(implied_obligations);
+        } else {
+            self.out.extend(obligations);
+        }
 
         self.out.extend(trait_ref.substs.types().filter(|ty| !ty.has_escaping_bound_vars()).map(
             |ty| traits::Obligation::new(cause.clone(), param_env, ty::Predicate::WellFormed(ty)),

--- a/src/librustc_trait_selection/traits/wf.rs
+++ b/src/librustc_trait_selection/traits/wf.rs
@@ -627,16 +627,13 @@ pub fn object_region_bounds<'tcx>(
     // a placeholder type.
     let open_ty = tcx.mk_ty_infer(ty::FreshTy(0));
 
-    let predicates = existential_predicates
-        .iter()
-        .filter_map(|predicate| {
-            if let ty::ExistentialPredicate::Projection(_) = *predicate.skip_binder() {
-                None
-            } else {
-                Some(predicate.with_self_ty(tcx, open_ty))
-            }
-        })
-        .collect();
+    let predicates = existential_predicates.iter().filter_map(|predicate| {
+        if let ty::ExistentialPredicate::Projection(_) = *predicate.skip_binder() {
+            None
+        } else {
+            Some(predicate.with_self_ty(tcx, open_ty))
+        }
+    });
 
     required_region_bounds(tcx, open_ty, predicates)
 }

--- a/src/librustc_typeck/check/method/confirm.rs
+++ b/src/librustc_typeck/check/method/confirm.rs
@@ -114,7 +114,7 @@ impl<'a, 'tcx> ConfirmContext<'a, 'tcx> {
         // a custom error in that case.
         if illegal_sized_bound.is_none() {
             let method_ty = self.tcx.mk_fn_ptr(ty::Binder::bind(method_sig));
-            self.add_obligations(method_ty, all_substs, &method_predicates);
+            self.add_obligations(method_ty, all_substs, method_predicates);
         }
 
         // Create the final `MethodCallee`.
@@ -395,7 +395,7 @@ impl<'a, 'tcx> ConfirmContext<'a, 'tcx> {
         &mut self,
         fty: Ty<'tcx>,
         all_substs: SubstsRef<'tcx>,
-        method_predicates: &ty::InstantiatedPredicates<'tcx>,
+        method_predicates: ty::InstantiatedPredicates<'tcx>,
     ) {
         debug!(
             "add_obligations: fty={:?} all_substs={:?} method_predicates={:?}",

--- a/src/librustc_typeck/check/method/confirm.rs
+++ b/src/librustc_typeck/check/method/confirm.rs
@@ -572,7 +572,7 @@ impl<'a, 'tcx> ConfirmContext<'a, 'tcx> {
             None => return None,
         };
 
-        traits::elaborate_predicates(self.tcx, predicates.predicates.clone())
+        traits::elaborate_predicates(self.tcx, predicates.predicates.iter().copied())
             .filter_map(|obligation| match obligation.predicate {
                 ty::Predicate::Trait(trait_pred, _) if trait_pred.def_id() == sized_def_id => {
                     let span = predicates

--- a/src/librustc_typeck/check/method/mod.rs
+++ b/src/librustc_typeck/check/method/mod.rs
@@ -390,7 +390,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         assert!(!bounds.has_escaping_bound_vars());
 
         let cause = traits::ObligationCause::misc(span, self.body_id);
-        obligations.extend(traits::predicates_for_generics(cause.clone(), self.param_env, &bounds));
+        obligations.extend(traits::predicates_for_generics(cause.clone(), self.param_env, bounds));
 
         // Also add an obligation for the method type being well-formed.
         let method_ty = tcx.mk_fn_ptr(ty::Binder::bind(fn_sig));

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -3434,7 +3434,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     pub fn add_obligations_for_parameters(
         &self,
         cause: traits::ObligationCause<'tcx>,
-        predicates: &ty::InstantiatedPredicates<'tcx>,
+        predicates: ty::InstantiatedPredicates<'tcx>,
     ) {
         assert!(!predicates.has_escaping_bound_vars());
 
@@ -4385,7 +4385,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             let (bounds, _) = self.instantiate_bounds(path_span, did, substs);
             let cause =
                 traits::ObligationCause::new(path_span, self.body_id, traits::ItemObligation(did));
-            self.add_obligations_for_parameters(cause, &bounds);
+            self.add_obligations_for_parameters(cause, bounds);
 
             Some((variant, ty))
         } else {
@@ -5654,9 +5654,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         for (i, mut obligation) in traits::predicates_for_generics(
             traits::ObligationCause::new(span, self.body_id, traits::ItemObligation(def_id)),
             self.param_env,
-            &bounds,
+            bounds,
         )
-        .into_iter()
         .enumerate()
         {
             // This makes the error point at the bound, but we want to point at the argument

--- a/src/librustc_typeck/check/op.rs
+++ b/src/librustc_typeck/check/op.rs
@@ -251,7 +251,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             }
             Err(()) => {
                 // error types are considered "builtin"
-                if !lhs_ty.references_error() {
+                if !lhs_ty.references_error() && !rhs_ty.references_error() {
                     let source_map = self.tcx.sess.source_map();
                     match is_assign {
                         IsAssign::Yes => {

--- a/src/librustc_typeck/check/wfcheck.rs
+++ b/src/librustc_typeck/check/wfcheck.rs
@@ -1225,7 +1225,7 @@ fn check_false_global_bounds(fcx: &FnCtxt<'_, '_>, span: Span, id: hir::HirId) {
     let empty_env = ty::ParamEnv::empty();
 
     let def_id = fcx.tcx.hir().local_def_id(id);
-    let predicates = fcx.tcx.predicates_of(def_id).predicates.iter().map(|(p, _)| *p).collect();
+    let predicates = fcx.tcx.predicates_of(def_id).predicates.iter().map(|(p, _)| *p);
     // Check elaborated bounds.
     let implied_obligations = traits::elaborate_predicates(fcx.tcx, predicates);
 

--- a/src/librustc_typeck/impl_wf_check/min_specialization.rs
+++ b/src/librustc_typeck/impl_wf_check/min_specialization.rs
@@ -322,7 +322,7 @@ fn check_predicates<'tcx>(
     // which is sound because we forbid impls like the following
     //
     // impl<D: Debug> AlwaysApplicable for D { }
-    let always_applicable_traits: Vec<_> = impl1_predicates
+    let always_applicable_traits = impl1_predicates
         .predicates
         .iter()
         .filter(|predicate| {
@@ -331,8 +331,7 @@ fn check_predicates<'tcx>(
                 Some(TraitSpecializationKind::AlwaysApplicable)
             )
         })
-        .copied()
-        .collect();
+        .copied();
 
     // Include the well-formed predicates of the type parameters of the impl.
     for ty in tcx.impl_trait_ref(impl1_def_id).unwrap().substs.types() {

--- a/src/stage0.txt
+++ b/src/stage0.txt
@@ -12,8 +12,8 @@
 # source tarball for a stable release you'll likely see `1.x.0` for rustc and
 # `0.x.0` for Cargo where they were released on `date`.
 
-date: 2020-04-21
-rustc: 1.43.0
+date: 2020-05-07
+rustc: 1.43.1
 cargo: 0.44.0
 
 # We use a nightly rustfmt to format the source because it solves some
@@ -40,4 +40,4 @@ cargo: 0.44.0
 # looking at a beta source tarball and it's uncommented we'll shortly comment it
 # out.
 
-dev: 1
+#dev: 1

--- a/src/test/rustdoc-ui/unused-braces-lint.rs
+++ b/src/test/rustdoc-ui/unused-braces-lint.rs
@@ -1,0 +1,14 @@
+// check-pass
+
+// This tests the bug in #70814, where the unused_braces lint triggered on the following code
+// without providing a span.
+
+#![deny(unused_braces)]
+
+fn main() {
+    {
+        {
+            use std;
+        }
+    }
+}

--- a/src/test/ui/binding/ambiguity-item.rs
+++ b/src/test/ui/binding/ambiguity-item.rs
@@ -14,5 +14,6 @@ fn main() {
     let v = f; //~ ERROR `f` is ambiguous
     match v {
         f => {} //~ ERROR `f` is ambiguous
+        mut f => {} // OK, unambiguously a fresh binding due to `mut`
     }
 }

--- a/src/test/ui/coherence/coherence-conflicting-negative-trait-impl.stderr
+++ b/src/test/ui/coherence/coherence-conflicting-negative-trait-impl.stderr
@@ -1,4 +1,4 @@
-error[E0748]: found both positive and negative implementation of trait `std::marker::Send` for type `TestType<_>`:
+error[E0751]: found both positive and negative implementation of trait `std::marker::Send` for type `TestType<_>`:
   --> $DIR/coherence-conflicting-negative-trait-impl.rs:11:1
    |
 LL | unsafe impl<T: MyTrait + 'static> Send for TestType<T> {}
@@ -18,5 +18,5 @@ LL | unsafe impl<T: 'static> Send for TestType<T> {}
 
 error: aborting due to 2 previous errors
 
-Some errors have detailed explanations: E0119, E0748.
+Some errors have detailed explanations: E0119, E0751.
 For more information about an error, try `rustc --explain E0119`.

--- a/src/test/ui/consts/issue-70773-mir-typeck-lt-norm.rs
+++ b/src/test/ui/consts/issue-70773-mir-typeck-lt-norm.rs
@@ -7,6 +7,7 @@ fn init_hash(_: &mut [u8; HASH_LEN]) {}
 fn foo<'a>() -> &'a () {
     Hash([0; HASH_LEN]);
     init_hash(&mut [0; HASH_LEN]);
+    let (_array,) = ([0; HASH_LEN],);
     &()
 }
 

--- a/src/test/ui/issues-71798.rs
+++ b/src/test/ui/issues-71798.rs
@@ -1,0 +1,7 @@
+fn test_ref(x: &u32) -> impl std::future::Future<Output = u32> + '_ {
+    *x //~^ ERROR the trait bound `u32: std::future::Future` is not satisfied
+}
+
+fn main() {
+    let _ = test_ref & u; //~ ERROR cannot find value `u` in this scope
+}

--- a/src/test/ui/issues-71798.stderr
+++ b/src/test/ui/issues-71798.stderr
@@ -1,0 +1,20 @@
+error[E0425]: cannot find value `u` in this scope
+  --> $DIR/issues-71798.rs:6:24
+   |
+LL |     let _ = test_ref & u;
+   |                        ^ not found in this scope
+
+error[E0277]: the trait bound `u32: std::future::Future` is not satisfied
+  --> $DIR/issues-71798.rs:1:25
+   |
+LL | fn test_ref(x: &u32) -> impl std::future::Future<Output = u32> + '_ {
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::future::Future` is not implemented for `u32`
+LL |     *x
+   |     -- this returned value is of type `u32`
+   |
+   = note: the return type of a function must have a statically known size
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0277, E0425.
+For more information about an error, try `rustc --explain E0277`.

--- a/src/test/ui/issues/issue-33140-hack-boundaries.rs
+++ b/src/test/ui/issues/issue-33140-hack-boundaries.rs
@@ -23,7 +23,7 @@ trait Trait2 {}
 
 impl Trait2 for dyn Send {}
 impl !Trait2 for dyn Send {}
-//~^ ERROR E0748
+//~^ ERROR E0751
 
 // Problem 3: type parameter
 trait Trait3<T: ?Sized> {}

--- a/src/test/ui/issues/issue-33140-hack-boundaries.stderr
+++ b/src/test/ui/issues/issue-33140-hack-boundaries.stderr
@@ -6,7 +6,7 @@ LL | impl Trait1 for dyn Send {}
 LL | impl Trait1 for dyn Send {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `(dyn std::marker::Send + 'static)`
 
-error[E0748]: found both positive and negative implementation of trait `Trait2` for type `(dyn std::marker::Send + 'static)`:
+error[E0751]: found both positive and negative implementation of trait `Trait2` for type `(dyn std::marker::Send + 'static)`:
   --> $DIR/issue-33140-hack-boundaries.rs:25:1
    |
 LL | impl Trait2 for dyn Send {}
@@ -64,5 +64,5 @@ LL | impl Trait5 for dyn Send where u32: Copy {}
 
 error: aborting due to 8 previous errors
 
-Some errors have detailed explanations: E0119, E0748.
+Some errors have detailed explanations: E0119, E0751.
 For more information about an error, try `rustc --explain E0119`.

--- a/src/test/ui/specialization/specialization-overlap-negative.rs
+++ b/src/test/ui/specialization/specialization-overlap-negative.rs
@@ -6,6 +6,6 @@ trait MyTrait {}
 struct TestType<T>(::std::marker::PhantomData<T>);
 
 unsafe impl<T: Clone> Send for TestType<T> {}
-impl<T: MyTrait> !Send for TestType<T> {} //~ ERROR E0748
+impl<T: MyTrait> !Send for TestType<T> {} //~ ERROR E0751
 
 fn main() {}

--- a/src/test/ui/specialization/specialization-overlap-negative.stderr
+++ b/src/test/ui/specialization/specialization-overlap-negative.stderr
@@ -1,4 +1,4 @@
-error[E0748]: found both positive and negative implementation of trait `std::marker::Send` for type `TestType<_>`:
+error[E0751]: found both positive and negative implementation of trait `std::marker::Send` for type `TestType<_>`:
   --> $DIR/specialization-overlap-negative.rs:9:1
    |
 LL | unsafe impl<T: Clone> Send for TestType<T> {}
@@ -8,4 +8,4 @@ LL | impl<T: MyTrait> !Send for TestType<T> {}
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0748`.
+For more information about this error, try `rustc --explain E0751`.

--- a/src/test/ui/specialization/specialization-polarity.rs
+++ b/src/test/ui/specialization/specialization-polarity.rs
@@ -7,11 +7,11 @@
 auto trait Foo {}
 
 impl<T> Foo for T {}
-impl !Foo for u8 {} //~ ERROR E0748
+impl !Foo for u8 {} //~ ERROR E0751
 
 auto trait Bar {}
 
 impl<T> !Bar for T {}
-impl Bar for u8 {} //~ ERROR E0748
+impl Bar for u8 {} //~ ERROR E0751
 
 fn main() {}

--- a/src/test/ui/specialization/specialization-polarity.stderr
+++ b/src/test/ui/specialization/specialization-polarity.stderr
@@ -1,4 +1,4 @@
-error[E0748]: found both positive and negative implementation of trait `Foo` for type `u8`:
+error[E0751]: found both positive and negative implementation of trait `Foo` for type `u8`:
   --> $DIR/specialization-polarity.rs:10:1
    |
 LL | impl<T> Foo for T {}
@@ -6,7 +6,7 @@ LL | impl<T> Foo for T {}
 LL | impl !Foo for u8 {}
    | ^^^^^^^^^^^^^^^^ negative implementation here
 
-error[E0748]: found both positive and negative implementation of trait `Bar` for type `u8`:
+error[E0751]: found both positive and negative implementation of trait `Bar` for type `u8`:
   --> $DIR/specialization-polarity.rs:15:1
    |
 LL | impl<T> !Bar for T {}
@@ -16,4 +16,4 @@ LL | impl Bar for u8 {}
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0748`.
+For more information about this error, try `rustc --explain E0751`.

--- a/src/test/ui/traits/negative-impls/negative-specializes-positive-item.rs
+++ b/src/test/ui/traits/negative-impls/negative-specializes-positive-item.rs
@@ -8,6 +8,6 @@ trait MyTrait {
 impl<T> MyTrait for T {
     default fn foo() {}
 }
-impl !MyTrait for u32 {} //~ ERROR E0748
+impl !MyTrait for u32 {} //~ ERROR E0751
 
 fn main() {}

--- a/src/test/ui/traits/negative-impls/negative-specializes-positive-item.stderr
+++ b/src/test/ui/traits/negative-impls/negative-specializes-positive-item.stderr
@@ -1,4 +1,4 @@
-error[E0748]: found both positive and negative implementation of trait `MyTrait` for type `u32`:
+error[E0751]: found both positive and negative implementation of trait `MyTrait` for type `u32`:
   --> $DIR/negative-specializes-positive-item.rs:11:1
    |
 LL | impl<T> MyTrait for T {
@@ -9,4 +9,4 @@ LL | impl !MyTrait for u32 {}
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0748`.
+For more information about this error, try `rustc --explain E0751`.

--- a/src/test/ui/traits/negative-impls/negative-specializes-positive.rs
+++ b/src/test/ui/traits/negative-impls/negative-specializes-positive.rs
@@ -4,7 +4,7 @@
 // Negative impl for u32 cannot "specialize" the base impl.
 trait MyTrait {}
 impl<T> MyTrait for T {}
-impl !MyTrait for u32 {} //~ ERROR E0748
+impl !MyTrait for u32 {} //~ ERROR E0751
 
 // The second impl specializes the first, no error.
 trait MyTrait2 {}

--- a/src/test/ui/traits/negative-impls/negative-specializes-positive.stderr
+++ b/src/test/ui/traits/negative-impls/negative-specializes-positive.stderr
@@ -1,4 +1,4 @@
-error[E0748]: found both positive and negative implementation of trait `MyTrait` for type `u32`:
+error[E0751]: found both positive and negative implementation of trait `MyTrait` for type `u32`:
   --> $DIR/negative-specializes-positive.rs:7:1
    |
 LL | impl<T> MyTrait for T {}
@@ -8,4 +8,4 @@ LL | impl !MyTrait for u32 {}
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0748`.
+For more information about this error, try `rustc --explain E0751`.

--- a/src/test/ui/traits/negative-impls/pin-unsound-issue-66544-clone.rs
+++ b/src/test/ui/traits/negative-impls/pin-unsound-issue-66544-clone.rs
@@ -5,7 +5,7 @@ use std::pin::Pin;
 struct MyType<'a>(Cell<Option<&'a mut MyType<'a>>>, PhantomPinned);
 
 impl<'a> Clone for &'a mut MyType<'a> {
-    //~^ ERROR E0748
+    //~^ ERROR E0751
     fn clone(&self) -> &'a mut MyType<'a> {
         self.0.replace(None).unwrap()
     }

--- a/src/test/ui/traits/negative-impls/pin-unsound-issue-66544-clone.stderr
+++ b/src/test/ui/traits/negative-impls/pin-unsound-issue-66544-clone.stderr
@@ -1,4 +1,4 @@
-error[E0748]: found both positive and negative implementation of trait `std::clone::Clone` for type `&mut MyType<'_>`:
+error[E0751]: found both positive and negative implementation of trait `std::clone::Clone` for type `&mut MyType<'_>`:
   --> $DIR/pin-unsound-issue-66544-clone.rs:7:1
    |
 LL | impl<'a> Clone for &'a mut MyType<'a> {
@@ -8,4 +8,4 @@ LL | impl<'a> Clone for &'a mut MyType<'a> {
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0748`.
+For more information about this error, try `rustc --explain E0751`.

--- a/src/test/ui/traits/negative-impls/pin-unsound-issue-66544-derefmut.rs
+++ b/src/test/ui/traits/negative-impls/pin-unsound-issue-66544-derefmut.rs
@@ -10,7 +10,7 @@ use std::pin::Pin;
 struct MyType<'a>(Cell<Option<&'a mut MyType<'a>>>, PhantomPinned);
 
 impl<'a> DerefMut for &'a MyType<'a> {
-    //~^ ERROR E0748
+    //~^ ERROR E0751
     fn deref_mut(&mut self) -> &mut MyType<'a> {
         self.0.replace(None).unwrap()
     }

--- a/src/test/ui/traits/negative-impls/pin-unsound-issue-66544-derefmut.stderr
+++ b/src/test/ui/traits/negative-impls/pin-unsound-issue-66544-derefmut.stderr
@@ -1,4 +1,4 @@
-error[E0748]: found both positive and negative implementation of trait `std::ops::DerefMut` for type `&MyType<'_>`:
+error[E0751]: found both positive and negative implementation of trait `std::ops::DerefMut` for type `&MyType<'_>`:
   --> $DIR/pin-unsound-issue-66544-derefmut.rs:12:1
    |
 LL | impl<'a> DerefMut for &'a MyType<'a> {
@@ -8,4 +8,4 @@ LL | impl<'a> DerefMut for &'a MyType<'a> {
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0748`.
+For more information about this error, try `rustc --explain E0751`.

--- a/src/test/ui/traits/negative-impls/positive-specializes-negative.rs
+++ b/src/test/ui/traits/negative-impls/positive-specializes-negative.rs
@@ -4,6 +4,6 @@
 trait MyTrait {}
 
 impl<T> !MyTrait for T {}
-impl MyTrait for u32 {} //~ ERROR E0748
+impl MyTrait for u32 {} //~ ERROR E0751
 
 fn main() {}

--- a/src/test/ui/traits/negative-impls/positive-specializes-negative.stderr
+++ b/src/test/ui/traits/negative-impls/positive-specializes-negative.stderr
@@ -1,4 +1,4 @@
-error[E0748]: found both positive and negative implementation of trait `MyTrait` for type `u32`:
+error[E0751]: found both positive and negative implementation of trait `MyTrait` for type `u32`:
   --> $DIR/positive-specializes-negative.rs:7:1
    |
 LL | impl<T> !MyTrait for T {}
@@ -8,4 +8,4 @@ LL | impl MyTrait for u32 {}
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0748`.
+For more information about this error, try `rustc --explain E0751`.


### PR DESCRIPTION
This backport rollup includes the following:
 * [beta] Update cargo #71967 
 * Backport 1.43.1 release notes to master #71914 
 * Update the `cc` crate #71882 
 * resolve: Relax fresh binding disambiguation slightly to fix regression #71846 
 * Do not try to find binop method on RHS `TyErr` #71810 
 * Quick and dirty fix of the unused_braces lint #71517 
 * Update stdarch submodule #71495 
 * normalize field projection ty to fix broken MIR issue #71488 
 * Update openssl-src to 1.1.1g #71430 
 * fix error code in E0751.md #71426 
 * Don't fuse Chain in its second iterator #71404 
 * Remove some `Vec` allocations to improve performance #71268 
 * [CI] Use the latest Python available on Windows #71995 

It also switches the bootstrap compiler to 1.43.1.
