### PR TITLE
bootstrap: remove lldb dist packaging

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -411,10 +411,6 @@
 # sysroot.
 #llvm-tools = false
 
-# Indicates whether LLDB will be made available in the sysroot.
-# This is only built if LLVM is also being built.
-#lldb = false
-
 # Whether to deny warnings in crates
 #deny-warnings = true
 

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -441,7 +441,6 @@ impl<'a> Builder<'a> {
                 dist::Clippy,
                 dist::Miri,
                 dist::LlvmTools,
-                dist::Lldb,
                 dist::Extended,
                 dist::HashSign
             ),

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -85,7 +85,6 @@ pub struct Config {
 
     pub use_lld: bool,
     pub lld_enabled: bool,
-    pub lldb_enabled: bool,
     pub llvm_tools_enabled: bool,
 
     pub llvm_cflags: Option<String>,
@@ -337,7 +336,6 @@ struct Rust {
     lld: Option<bool>,
     use_lld: Option<bool>,
     llvm_tools: Option<bool>,
-    lldb: Option<bool>,
     deny_warnings: Option<bool>,
     backtrace_on_ice: Option<bool>,
     verify_llvm_ir: Option<bool>,
@@ -585,7 +583,6 @@ impl Config {
             }
             set(&mut config.use_lld, rust.use_lld);
             set(&mut config.lld_enabled, rust.lld);
-            set(&mut config.lldb_enabled, rust.lldb);
             set(&mut config.llvm_tools_enabled, rust.llvm_tools);
             config.rustc_parallel = rust.parallel_compiler.unwrap_or(false);
             config.rustc_default_linker = rust.default_linker.clone();

--- a/src/bootstrap/configure.py
+++ b/src/bootstrap/configure.py
@@ -57,7 +57,6 @@ o("cargo-native-static", "build.cargo-native-static", "static native libraries i
 o("profiler", "build.profiler", "build the profiler runtime")
 o("full-tools", None, "enable all tools")
 o("lld", "rust.lld", "build lld")
-o("lldb", "rust.lldb", "build lldb")
 o("missing-tools", "dist.missing-tools", "allow failures when building tools")
 o("use-libcxx", "llvm.use-libcxx", "build LLVM with libc++")
 o("control-flow-guard", "rust.control-flow-guard", "Enable Control Flow Guard")

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -1029,14 +1029,6 @@ impl Build {
         self.rust_version()
     }
 
-    fn lldb_package_vers(&self) -> String {
-        self.package_vers(channel::CFG_RELEASE_NUM)
-    }
-
-    fn lldb_vers(&self) -> String {
-        self.rust_version()
-    }
-
     fn llvm_link_tools_dynamically(&self, target: Interned<String>) -> bool {
         target.contains("linux-gnu") || target.contains("apple-darwin")
     }

--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -184,7 +184,7 @@ impl Step for Llvm {
         }
 
         // For distribution we want the LLVM tools to be *statically* linked to libstdc++
-        if builder.config.llvm_tools_enabled || builder.config.lldb_enabled {
+        if builder.config.llvm_tools_enabled {
             if !target.contains("msvc") {
                 if target.contains("apple") {
                     cfg.define("CMAKE_EXE_LINKER_FLAGS", "-static-libstdc++");
@@ -212,17 +212,9 @@ impl Step for Llvm {
             enabled_llvm_projects.push("compiler-rt");
         }
 
-        if builder.config.lldb_enabled {
-            enabled_llvm_projects.push("clang");
-            enabled_llvm_projects.push("lldb");
-            // For the time being, disable code signing.
-            cfg.define("LLDB_CODESIGN_IDENTITY", "");
-            cfg.define("LLDB_NO_DEBUGSERVER", "ON");
-        } else {
-            // LLDB requires libxml2; but otherwise we want it to be disabled.
-            // See https://github.com/rust-lang/rust/pull/50104
-            cfg.define("LLVM_ENABLE_LIBXML2", "OFF");
-        }
+        // We want libxml to be disabled.
+        // See https://github.com/rust-lang/rust/pull/50104
+        cfg.define("LLVM_ENABLE_LIBXML2", "OFF");
 
         if !enabled_llvm_projects.is_empty() {
             enabled_llvm_projects.sort();

--- a/src/bootstrap/sanity.rs
+++ b/src/bootstrap/sanity.rs
@@ -117,14 +117,6 @@ pub fn check(build: &mut Build) {
                 build.config.ninja = true;
             }
         }
-
-        if build.config.lldb_enabled {
-            cmd_finder.must_have("swig");
-            let out = output(Command::new("swig").arg("-version"));
-            if !out.contains("SWIG Version 3") && !out.contains("SWIG Version 4") {
-                panic!("Ensure that Swig 3.x.x or 4.x.x is installed.");
-            }
-        }
     }
 
     build.config.python = build

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -1106,20 +1106,15 @@ impl Step for Compiletest {
                     .to_string()
             })
         };
-        let lldb_exe = if builder.config.lldb_enabled {
-            // Test against the lldb that was just built.
-            builder.llvm_out(target).join("bin").join("lldb")
-        } else {
-            PathBuf::from("lldb")
-        };
-        let lldb_version = Command::new(&lldb_exe)
+        let lldb_exe = "lldb";
+        let lldb_version = Command::new(lldb_exe)
             .arg("--version")
             .output()
             .map(|output| String::from_utf8_lossy(&output.stdout).to_string())
             .ok();
         if let Some(ref vers) = lldb_version {
             cmd.arg("--lldb-version").arg(vers);
-            let lldb_python_dir = run(Command::new(&lldb_exe).arg("-P")).ok();
+            let lldb_python_dir = run(Command::new(lldb_exe).arg("-P")).ok();
             if let Some(ref dir) = lldb_python_dir {
                 cmd.arg("--lldb-python-dir").arg(dir);
             }

--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -228,7 +228,6 @@ struct Builder {
     clippy_release: String,
     rustfmt_release: String,
     llvm_tools_release: String,
-    lldb_release: String,
     miri_release: String,
 
     input: PathBuf,
@@ -244,7 +243,6 @@ struct Builder {
     clippy_version: Option<String>,
     rustfmt_version: Option<String>,
     llvm_tools_version: Option<String>,
-    lldb_version: Option<String>,
     miri_version: Option<String>,
 
     rust_git_commit_hash: Option<String>,
@@ -253,7 +251,6 @@ struct Builder {
     clippy_git_commit_hash: Option<String>,
     rustfmt_git_commit_hash: Option<String>,
     llvm_tools_git_commit_hash: Option<String>,
-    lldb_git_commit_hash: Option<String>,
     miri_git_commit_hash: Option<String>,
 
     should_sign: bool,
@@ -284,7 +281,6 @@ fn main() {
     let miri_release = args.next().unwrap();
     let rustfmt_release = args.next().unwrap();
     let llvm_tools_release = args.next().unwrap();
-    let lldb_release = args.next().unwrap();
 
     // Do not ask for a passphrase while manually testing
     let mut passphrase = String::new();
@@ -300,7 +296,6 @@ fn main() {
         clippy_release,
         rustfmt_release,
         llvm_tools_release,
-        lldb_release,
         miri_release,
 
         input,
@@ -316,7 +311,6 @@ fn main() {
         clippy_version: None,
         rustfmt_version: None,
         llvm_tools_version: None,
-        lldb_version: None,
         miri_version: None,
 
         rust_git_commit_hash: None,
@@ -325,7 +319,6 @@ fn main() {
         clippy_git_commit_hash: None,
         rustfmt_git_commit_hash: None,
         llvm_tools_git_commit_hash: None,
-        lldb_git_commit_hash: None,
         miri_git_commit_hash: None,
 
         should_sign,
@@ -340,7 +333,6 @@ enum PkgType {
     Clippy,
     Rustfmt,
     LlvmTools,
-    Lldb,
     Miri,
     Other,
 }
@@ -355,7 +347,6 @@ impl PkgType {
             "clippy" | "clippy-preview" => Clippy,
             "rustfmt" | "rustfmt-preview" => Rustfmt,
             "llvm-tools" | "llvm-tools-preview" => LlvmTools,
-            "lldb" | "lldb-preview" => Lldb,
             "miri" | "miri-preview" => Miri,
             _ => Other,
         }
@@ -370,8 +361,6 @@ impl Builder {
         self.clippy_version = self.version("clippy", "x86_64-unknown-linux-gnu");
         self.rustfmt_version = self.version("rustfmt", "x86_64-unknown-linux-gnu");
         self.llvm_tools_version = self.version("llvm-tools", "x86_64-unknown-linux-gnu");
-        // lldb is only built for macOS.
-        self.lldb_version = self.version("lldb", "x86_64-apple-darwin");
         self.miri_version = self.version("miri", "x86_64-unknown-linux-gnu");
 
         self.rust_git_commit_hash = self.git_commit_hash("rust", "x86_64-unknown-linux-gnu");
@@ -381,7 +370,6 @@ impl Builder {
         self.rustfmt_git_commit_hash = self.git_commit_hash("rustfmt", "x86_64-unknown-linux-gnu");
         self.llvm_tools_git_commit_hash =
             self.git_commit_hash("llvm-tools", "x86_64-unknown-linux-gnu");
-        self.lldb_git_commit_hash = self.git_commit_hash("lldb", "x86_64-unknown-linux-gnu");
         self.miri_git_commit_hash = self.git_commit_hash("miri", "x86_64-unknown-linux-gnu");
 
         self.check_toolstate();
@@ -456,7 +444,6 @@ impl Builder {
         package("rustfmt-preview", HOSTS);
         package("rust-analysis", TARGETS);
         package("llvm-tools-preview", TARGETS);
-        package("lldb-preview", TARGETS);
     }
 
     fn add_profiles_to(&mut self, manifest: &mut Manifest) {
@@ -487,7 +474,6 @@ impl Builder {
                 "rls-preview",
                 "rust-src",
                 "llvm-tools-preview",
-                "lldb-preview",
                 "rust-analysis",
                 "miri-preview",
             ],
@@ -562,7 +548,6 @@ impl Builder {
             host_component("rls-preview"),
             host_component("rustfmt-preview"),
             host_component("llvm-tools-preview"),
-            host_component("lldb-preview"),
             host_component("rust-analysis"),
         ]);
 
@@ -692,7 +677,6 @@ impl Builder {
             Clippy => format!("clippy-{}-{}.tar.gz", self.clippy_release, target),
             Rustfmt => format!("rustfmt-{}-{}.tar.gz", self.rustfmt_release, target),
             LlvmTools => format!("llvm-tools-{}-{}.tar.gz", self.llvm_tools_release, target),
-            Lldb => format!("lldb-{}-{}.tar.gz", self.lldb_release, target),
             Miri => format!("miri-{}-{}.tar.gz", self.miri_release, target),
             Other => format!("{}-{}-{}.tar.gz", component, self.rust_release, target),
         }
@@ -706,7 +690,6 @@ impl Builder {
             Clippy => &self.clippy_version,
             Rustfmt => &self.rustfmt_version,
             LlvmTools => &self.llvm_tools_version,
-            Lldb => &self.lldb_version,
             Miri => &self.miri_version,
             _ => &self.rust_version,
         }
@@ -720,7 +703,6 @@ impl Builder {
             Clippy => &self.clippy_git_commit_hash,
             Rustfmt => &self.rustfmt_git_commit_hash,
             LlvmTools => &self.llvm_tools_git_commit_hash,
-            Lldb => &self.lldb_git_commit_hash,
             Miri => &self.miri_git_commit_hash,
             _ => &self.rust_git_commit_hash,
         }


### PR DESCRIPTION
The lldb-preview rustup package is missing on every single target, and has never been shipped beyond x86_64-apple-darwin. It was removed in #62592 which landed around a year ago, and there's not been demand that we re-enable it since, so we're now removing support entirely to cleanup the code a bit.

The hope is that this will also kill the useless "lldb-preview" row on https://rust-lang.github.io/rustup-components-history/.