### PR TITLE
add regression tests for stalled_on const vars

### DIFF
--- a/src/librustc_trait_selection/traits/fulfill.rs
+++ b/src/librustc_trait_selection/traits/fulfill.rs
@@ -355,7 +355,7 @@ impl<'a, 'b, 'tcx> ObligationProcessor for FulfillProcessor<'a, 'b, 'tcx> {
                         // trait selection is because we don't have enough
                         // information about the types in the trait.
                         pending_obligation.stalled_on =
-                            trait_ref_type_vars(self.selcx, data.to_poly_trait_ref());
+                            trait_ref_infer_vars(self.selcx, data.to_poly_trait_ref());
 
                         debug!(
                             "process_predicate: pending obligation {:?} now stalled on {:?}",
@@ -433,7 +433,7 @@ impl<'a, 'b, 'tcx> ObligationProcessor for FulfillProcessor<'a, 'b, 'tcx> {
                     Ok(None) => {
                         let tcx = self.selcx.tcx();
                         pending_obligation.stalled_on =
-                            trait_ref_type_vars(self.selcx, data.to_poly_trait_ref(tcx));
+                            trait_ref_infer_vars(self.selcx, data.to_poly_trait_ref(tcx));
                         ProcessResult::Unchanged
                     }
                     Ok(Some(os)) => ProcessResult::Changed(mk_pending(infcx, os)),
@@ -539,8 +539,8 @@ impl<'a, 'b, 'tcx> ObligationProcessor for FulfillProcessor<'a, 'b, 'tcx> {
     }
 }
 
-/// Returns the set of type inference variables contained in a trait ref.
-fn trait_ref_type_vars<'a, 'tcx>(
+/// Returns the set of inference variables contained in a trait ref.
+fn trait_ref_infer_vars<'a, 'tcx>(
     selcx: &mut SelectionContext<'a, 'tcx>,
     trait_ref: ty::PolyTraitRef<'tcx>,
 ) -> Vec<TyOrConstInferVar<'tcx>> {

--- a/src/test/ui/const-generics/issue-70180-1-stalled_on.rs
+++ b/src/test/ui/const-generics/issue-70180-1-stalled_on.rs
@@ -1,0 +1,35 @@
+// build-pass
+#![feature(const_generics)]
+#![allow(incomplete_features)]
+
+pub fn works() {
+    let array/*: [_; _]*/ = default_array();
+    let _: [_; 4] = array;
+    Foo::foo(&array);
+}
+
+pub fn didnt_work() {
+    let array/*: [_; _]*/ = default_array();
+    Foo::foo(&array);
+    let _: [_; 4] = array;
+}
+
+trait Foo {
+    fn foo(&self) {}
+}
+
+impl Foo for [i32; 4] {}
+impl Foo for [i64; 8] {}
+
+// Only needed because `[_; _]` is not valid type syntax.
+fn default_array<T, const N: usize>() -> [T; N]
+where
+    [T; N]: Default,
+{
+    Default::default()
+}
+
+fn main() {
+    works();
+    didnt_work();
+}

--- a/src/test/ui/const-generics/issue-70180-2-stalled_on.rs
+++ b/src/test/ui/const-generics/issue-70180-2-stalled_on.rs
@@ -1,0 +1,35 @@
+// build-pass
+#![feature(const_generics)]
+#![allow(incomplete_features)]
+
+fn works() {
+    let array/*: [u8; _]*/ = default_byte_array();
+    let _: [_; 4] = array;
+    Foo::foo(&array);
+}
+
+fn didnt_work() {
+    let array/*: [u8; _]*/ = default_byte_array();
+    Foo::foo(&array);
+    let _: [_; 4] = array;
+}
+
+trait Foo<T> {
+    fn foo(&self) {}
+}
+
+impl Foo<i32> for [u8; 4] {}
+impl Foo<i64> for [u8; 8] {}
+
+// Only needed because `[u8; _]` is not valid type syntax.
+fn default_byte_array<const N: usize>() -> [u8; N]
+where
+    [u8; N]: Default,
+{
+    Default::default()
+}
+
+fn main() {
+    works();
+    didnt_work();
+}


### PR DESCRIPTION
closes #70180

Afaict this has been fixed sometime after #70213

`trait_ref_type_vars` correctly adds const infers and I did not find any remaining `FIXME`s which correspond to this issue. 
https://github.com/rust-lang/rust/blob/7c59a81a5fcbaaca311f744cd7c68d99bfbb05d3/src/librustc_trait_selection/traits/fulfill.rs#L555-L557

Added both examples from the issue as regression tests and renamed `trait_ref_type_vars` -> `trait_ref_infer_vars`.

r? @eddyb 