### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/src/librustc_codegen_ssa/back/write.rs
+++ b/src/librustc_codegen_ssa/back/write.rs
@@ -715,10 +715,51 @@ fn execute_work_item<B: ExtraBackendMethods>(
 }
 
 // Actual LTO type we end up choosing based on multiple factors.
-enum ComputedLtoType {
+pub enum ComputedLtoType {
     No,
     Thin,
     Fat,
+}
+
+pub fn compute_per_cgu_lto_type(
+    sess_lto: &Lto,
+    opts: &config::Options,
+    sess_crate_types: &[CrateType],
+    module_kind: ModuleKind,
+) -> ComputedLtoType {
+    // Metadata modules never participate in LTO regardless of the lto
+    // settings.
+    if module_kind == ModuleKind::Metadata {
+        return ComputedLtoType::No;
+    }
+
+    // If the linker does LTO, we don't have to do it. Note that we
+    // keep doing full LTO, if it is requested, as not to break the
+    // assumption that the output will be a single module.
+    let linker_does_lto = opts.cg.linker_plugin_lto.enabled();
+
+    // When we're automatically doing ThinLTO for multi-codegen-unit
+    // builds we don't actually want to LTO the allocator modules if
+    // it shows up. This is due to various linker shenanigans that
+    // we'll encounter later.
+    let is_allocator = module_kind == ModuleKind::Allocator;
+
+    // We ignore a request for full crate grath LTO if the cate type
+    // is only an rlib, as there is no full crate graph to process,
+    // that'll happen later.
+    //
+    // This use case currently comes up primarily for targets that
+    // require LTO so the request for LTO is always unconditionally
+    // passed down to the backend, but we don't actually want to do
+    // anything about it yet until we've got a final product.
+    let is_rlib = sess_crate_types.len() == 1 && sess_crate_types[0] == CrateType::Rlib;
+
+    match sess_lto {
+        Lto::ThinLocal if !linker_does_lto && !is_allocator => ComputedLtoType::Thin,
+        Lto::Thin if !linker_does_lto && !is_rlib => ComputedLtoType::Thin,
+        Lto::Fat if !is_rlib => ComputedLtoType::Fat,
+        _ => ComputedLtoType::No,
+    }
 }
 
 fn execute_optimize_work_item<B: ExtraBackendMethods>(
@@ -737,39 +778,7 @@ fn execute_optimize_work_item<B: ExtraBackendMethods>(
     // back to the coordinator thread for further LTO processing (which
     // has to wait for all the initial modules to be optimized).
 
-    // If the linker does LTO, we don't have to do it. Note that we
-    // keep doing full LTO, if it is requested, as not to break the
-    // assumption that the output will be a single module.
-    let linker_does_lto = cgcx.opts.cg.linker_plugin_lto.enabled();
-
-    // When we're automatically doing ThinLTO for multi-codegen-unit
-    // builds we don't actually want to LTO the allocator modules if
-    // it shows up. This is due to various linker shenanigans that
-    // we'll encounter later.
-    let is_allocator = module.kind == ModuleKind::Allocator;
-
-    // We ignore a request for full crate grath LTO if the cate type
-    // is only an rlib, as there is no full crate graph to process,
-    // that'll happen later.
-    //
-    // This use case currently comes up primarily for targets that
-    // require LTO so the request for LTO is always unconditionally
-    // passed down to the backend, but we don't actually want to do
-    // anything about it yet until we've got a final product.
-    let is_rlib = cgcx.crate_types.len() == 1 && cgcx.crate_types[0] == CrateType::Rlib;
-
-    // Metadata modules never participate in LTO regardless of the lto
-    // settings.
-    let lto_type = if module.kind == ModuleKind::Metadata {
-        ComputedLtoType::No
-    } else {
-        match cgcx.lto {
-            Lto::ThinLocal if !linker_does_lto && !is_allocator => ComputedLtoType::Thin,
-            Lto::Thin if !linker_does_lto && !is_rlib => ComputedLtoType::Thin,
-            Lto::Fat if !is_rlib => ComputedLtoType::Fat,
-            _ => ComputedLtoType::No,
-        }
-    };
+    let lto_type = compute_per_cgu_lto_type(&cgcx.lto, &cgcx.opts, &cgcx.crate_types, module.kind);
 
     // If we're doing some form of incremental LTO then we need to be sure to
     // save our module to disk first.

--- a/src/librustc_error_codes/error_codes/E0569.md
+++ b/src/librustc_error_codes/error_codes/E0569.md
@@ -1,5 +1,5 @@
 If an impl has a generic parameter with the `#[may_dangle]` attribute, then
-that impl must be declared as an `unsafe impl.
+that impl must be declared as an `unsafe impl`.
 
 Erroneous code example:
 

--- a/src/librustc_interface/util.rs
+++ b/src/librustc_interface/util.rs
@@ -49,7 +49,7 @@ pub fn add_configuration(
 
     cfg.extend(codegen_backend.target_features(sess).into_iter().map(|feat| (tf, Some(feat))));
 
-    if sess.crt_static_feature(None) {
+    if sess.crt_static(None) {
         cfg.insert((tf, Some(Symbol::intern("crt-static"))));
     }
 }

--- a/src/librustc_mir_build/build/block.rs
+++ b/src/librustc_mir_build/build/block.rs
@@ -145,7 +145,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                         }));
 
                         debug!("ast_block_stmts: pattern={:?}", pattern);
-                        this.visit_bindings(
+                        this.visit_primary_bindings(
                             &pattern,
                             UserTypeProjections::none(),
                             &mut |this, _, _, _, node, span, _, _| {

--- a/src/librustc_mir_build/build/matches/mod.rs
+++ b/src/librustc_mir_build/build/matches/mod.rs
@@ -511,7 +511,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         opt_match_place: Option<(Option<&Place<'tcx>>, Span)>,
     ) -> Option<SourceScope> {
         debug!("declare_bindings: pattern={:?}", pattern);
-        self.visit_bindings(
+        self.visit_primary_bindings(
             &pattern,
             UserTypeProjections::none(),
             &mut |this, mutability, name, mode, var, span, ty, user_ty| {
@@ -563,7 +563,10 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         self.schedule_drop(span, region_scope, local_id, DropKind::Value);
     }
 
-    pub(super) fn visit_bindings(
+    /// Visit all of the primary bindings in a patterns, that is, visit the
+    /// leftmost occurrence of each variable bound in a pattern. A variable
+    /// will occur more than once in an or-pattern.
+    pub(super) fn visit_primary_bindings(
         &mut self,
         pattern: &Pat<'tcx>,
         pattern_user_ty: UserTypeProjections,
@@ -578,12 +581,26 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             UserTypeProjections,
         ),
     ) {
-        debug!("visit_bindings: pattern={:?} pattern_user_ty={:?}", pattern, pattern_user_ty);
+        debug!(
+            "visit_primary_bindings: pattern={:?} pattern_user_ty={:?}",
+            pattern, pattern_user_ty
+        );
         match *pattern.kind {
-            PatKind::Binding { mutability, name, mode, var, ty, ref subpattern, .. } => {
-                f(self, mutability, name, mode, var, pattern.span, ty, pattern_user_ty.clone());
+            PatKind::Binding {
+                mutability,
+                name,
+                mode,
+                var,
+                ty,
+                ref subpattern,
+                is_primary,
+                ..
+            } => {
+                if is_primary {
+                    f(self, mutability, name, mode, var, pattern.span, ty, pattern_user_ty.clone());
+                }
                 if let Some(subpattern) = subpattern.as_ref() {
-                    self.visit_bindings(subpattern, pattern_user_ty, f);
+                    self.visit_primary_bindings(subpattern, pattern_user_ty, f);
                 }
             }
 
@@ -592,20 +609,24 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 let from = u32::try_from(prefix.len()).unwrap();
                 let to = u32::try_from(suffix.len()).unwrap();
                 for subpattern in prefix {
-                    self.visit_bindings(subpattern, pattern_user_ty.clone().index(), f);
+                    self.visit_primary_bindings(subpattern, pattern_user_ty.clone().index(), f);
                 }
                 for subpattern in slice {
-                    self.visit_bindings(subpattern, pattern_user_ty.clone().subslice(from, to), f);
+                    self.visit_primary_bindings(
+                        subpattern,
+                        pattern_user_ty.clone().subslice(from, to),
+                        f,
+                    );
                 }
                 for subpattern in suffix {
-                    self.visit_bindings(subpattern, pattern_user_ty.clone().index(), f);
+                    self.visit_primary_bindings(subpattern, pattern_user_ty.clone().index(), f);
                 }
             }
 
             PatKind::Constant { .. } | PatKind::Range { .. } | PatKind::Wild => {}
 
             PatKind::Deref { ref subpattern } => {
-                self.visit_bindings(subpattern, pattern_user_ty.deref(), f);
+                self.visit_primary_bindings(subpattern, pattern_user_ty.deref(), f);
             }
 
             PatKind::AscribeUserType {
@@ -630,14 +651,14 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     projs: Vec::new(),
                 };
                 let subpattern_user_ty = pattern_user_ty.push_projection(&projection, user_ty_span);
-                self.visit_bindings(subpattern, subpattern_user_ty, f)
+                self.visit_primary_bindings(subpattern, subpattern_user_ty, f)
             }
 
             PatKind::Leaf { ref subpatterns } => {
                 for subpattern in subpatterns {
                     let subpattern_user_ty = pattern_user_ty.clone().leaf(subpattern.field);
-                    debug!("visit_bindings: subpattern_user_ty={:?}", subpattern_user_ty);
-                    self.visit_bindings(&subpattern.pattern, subpattern_user_ty, f);
+                    debug!("visit_primary_bindings: subpattern_user_ty={:?}", subpattern_user_ty);
+                    self.visit_primary_bindings(&subpattern.pattern, subpattern_user_ty, f);
                 }
             }
 
@@ -645,11 +666,17 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 for subpattern in subpatterns {
                     let subpattern_user_ty =
                         pattern_user_ty.clone().variant(adt_def, variant_index, subpattern.field);
-                    self.visit_bindings(&subpattern.pattern, subpattern_user_ty, f);
+                    self.visit_primary_bindings(&subpattern.pattern, subpattern_user_ty, f);
                 }
             }
             PatKind::Or { ref pats } => {
-                self.visit_bindings(&pats[0], pattern_user_ty, f);
+                // In cases where we recover from errors the primary bindings
+                // may not all be in the leftmost subpattern. For example in
+                // `let (x | y) = ...`, the primary binding of `y` occurs in
+                // the right subpattern
+                for subpattern in pats {
+                    self.visit_primary_bindings(subpattern, pattern_user_ty.clone(), f);
+                }
             }
         }
     }
@@ -1953,7 +1980,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             is_block_tail: None,
             local_info: LocalInfo::User(ClearCrossCrate::Set(BindingForm::Var(VarBindingForm {
                 binding_mode,
-                // hypothetically, `visit_bindings` could try to unzip
+                // hypothetically, `visit_primary_bindings` could try to unzip
                 // an outermost hir::Ty as we descend, matching up
                 // idents in pat; but complex w/ unclear UI payoff.
                 // Instead, just abandon providing diagnostic info.

--- a/src/librustc_mir_build/build/matches/simplify.rs
+++ b/src/librustc_mir_build/build/matches/simplify.rs
@@ -129,7 +129,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 Ok(())
             }
 
-            PatKind::Binding { name, mutability, mode, var, ty, ref subpattern } => {
+            PatKind::Binding { name, mutability, mode, var, ty, ref subpattern, is_primary: _ } => {
                 candidate.bindings.push(Binding {
                     name,
                     mutability,

--- a/src/librustc_mir_build/hair/pattern/mod.rs
+++ b/src/librustc_mir_build/hair/pattern/mod.rs
@@ -133,6 +133,9 @@ crate enum PatKind<'tcx> {
         var: hir::HirId,
         ty: Ty<'tcx>,
         subpattern: Option<Pat<'tcx>>,
+        /// Is this the leftmost occurance of the binding, i.e., is `var` the
+        /// `HirId` of this pattern?
+        is_primary: bool,
     },
 
     /// `Foo(...)` or `Foo{...}` or `Foo`, where `Foo` is a variant name from an ADT with
@@ -601,6 +604,7 @@ impl<'a, 'tcx> PatCtxt<'a, 'tcx> {
                     var: id,
                     ty: var_ty,
                     subpattern: self.lower_opt_pattern(sub),
+                    is_primary: id == pat.hir_id,
                 }
             }
 
@@ -964,7 +968,7 @@ impl<'tcx> PatternFoldable<'tcx> for PatKind<'tcx> {
                     user_ty_span,
                 },
             },
-            PatKind::Binding { mutability, name, mode, var, ty, ref subpattern } => {
+            PatKind::Binding { mutability, name, mode, var, ty, ref subpattern, is_primary } => {
                 PatKind::Binding {
                     mutability: mutability.fold_with(folder),
                     name: name.fold_with(folder),
@@ -972,6 +976,7 @@ impl<'tcx> PatternFoldable<'tcx> for PatKind<'tcx> {
                     var: var.fold_with(folder),
                     ty: ty.fold_with(folder),
                     subpattern: subpattern.fold_with(folder),
+                    is_primary,
                 }
             }
             PatKind::Variant { adt_def, substs, variant_index, ref subpatterns } => {

--- a/src/librustc_session/session.rs
+++ b/src/librustc_session/session.rs
@@ -553,16 +553,11 @@ impl Session {
 
     /// Check whether this compile session and crate type use static crt.
     pub fn crt_static(&self, crate_type: Option<CrateType>) -> bool {
-        // If the target does not opt in to crt-static support, use its default.
-        if self.target.target.options.crt_static_respected {
-            self.crt_static_feature(crate_type)
-        } else {
-            self.target.target.options.crt_static_default
+        if !self.target.target.options.crt_static_respected {
+            // If the target does not opt in to crt-static support, use its default.
+            return self.target.target.options.crt_static_default;
         }
-    }
 
-    /// Check whether this compile session and crate type use `crt-static` feature.
-    pub fn crt_static_feature(&self, crate_type: Option<CrateType>) -> bool {
         let requested_features = self.opts.cg.target_feature.split(',');
         let found_negative = requested_features.clone().any(|r| r == "-crt-static");
         let found_positive = requested_features.clone().any(|r| r == "+crt-static");

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -2281,7 +2281,10 @@ fn short_stability(item: &clean::Item, cx: &Context) -> Vec<String> {
             );
             message.push_str(&format!(": {}", html.to_string()));
         }
-        stability.push(format!("<div class='stab deprecated'>{}</div>", message));
+        stability.push(format!(
+            "<div class='stab deprecated'><span class='emoji'>👎</span> {}</div>",
+            message,
+        ));
     }
 
     if let Some(stab) = item.stability.as_ref().filter(|stab| stab.level == stability::Unstable) {

--- a/src/test/incremental/lto-in-linker.rs
+++ b/src/test/incremental/lto-in-linker.rs
@@ -1,0 +1,8 @@
+// revisions:cfail1 cfail2
+// compile-flags: -Z query-dep-graph --crate-type rlib -C linker-plugin-lto -O
+// build-pass
+
+#![feature(rustc_attrs)]
+#![rustc_partition_reused(module = "lto_in_linker", cfg = "cfail2")]
+
+pub fn foo() {}

--- a/src/test/incremental/rlib-lto.rs
+++ b/src/test/incremental/rlib-lto.rs
@@ -1,0 +1,8 @@
+// revisions:cfail1 cfail2
+// compile-flags: -Z query-dep-graph --crate-type rlib -C lto
+// build-pass
+
+#![feature(rustc_attrs)]
+#![rustc_partition_reused(module = "rlib_lto", cfg = "cfail2")]
+
+pub fn foo() {}

--- a/src/test/rustdoc/issue-32374.rs
+++ b/src/test/rustdoc/issue-32374.rs
@@ -10,7 +10,7 @@
 // @matches issue_32374/index.html '//*[@class="docblock-short"]/text()' 'Docs'
 
 // @has issue_32374/struct.T.html '//*[@class="stab deprecated"]' \
-//      'Deprecated since 1.0.0: text'
+//      '👎 Deprecated since 1.0.0: text'
 // @has - '<code>test</code>&nbsp;<a href="http://issue_url/32374">#32374</a>'
 // @matches issue_32374/struct.T.html '//*[@class="stab unstable"]' \
 //      '🔬 This is a nightly-only experimental API. \(test\s#32374\)$'
@@ -20,7 +20,7 @@
 pub struct T;
 
 // @has issue_32374/struct.U.html '//*[@class="stab deprecated"]' \
-//      'Deprecated since 1.0.0: deprecated'
+//      '👎 Deprecated since 1.0.0: deprecated'
 // @has issue_32374/struct.U.html '//*[@class="stab unstable"]' \
 //      '🔬 This is a nightly-only experimental API. (test #32374)'
 // @has issue_32374/struct.U.html '//details' \

--- a/src/test/ui/crt-static-on-works.rs
+++ b/src/test/ui/crt-static-on-works.rs
@@ -1,9 +1,6 @@
 // run-pass
-
-#![allow(stable_features)]
-// compile-flags:-C target-feature=+crt-static -Z unstable-options
-
-#![feature(cfg_target_feature)]
+// compile-flags:-C target-feature=+crt-static
+// only-msvc
 
 #[cfg(target_feature = "crt-static")]
 fn main() {}

--- a/src/test/ui/or-patterns/mismatched-bindings-async-fn.rs
+++ b/src/test/ui/or-patterns/mismatched-bindings-async-fn.rs
@@ -1,0 +1,16 @@
+// Regression test for #71297
+// edition:2018
+
+#![feature(or_patterns)]
+
+async fn a((x | s): String) {}
+//~^ ERROR variable `x` is not bound in all patterns
+//~| ERROR variable `s` is not bound in all patterns
+
+async fn b() {
+    let x | s = String::new();
+    //~^ ERROR variable `x` is not bound in all patterns
+    //~| ERROR variable `s` is not bound in all patterns
+}
+
+fn main() {}

--- a/src/test/ui/or-patterns/mismatched-bindings-async-fn.stderr
+++ b/src/test/ui/or-patterns/mismatched-bindings-async-fn.stderr
@@ -1,0 +1,35 @@
+error[E0408]: variable `x` is not bound in all patterns
+  --> $DIR/mismatched-bindings-async-fn.rs:6:17
+   |
+LL | async fn a((x | s): String) {}
+   |             -   ^ pattern doesn't bind `x`
+   |             |
+   |             variable not in all patterns
+
+error[E0408]: variable `s` is not bound in all patterns
+  --> $DIR/mismatched-bindings-async-fn.rs:6:13
+   |
+LL | async fn a((x | s): String) {}
+   |             ^   - variable not in all patterns
+   |             |
+   |             pattern doesn't bind `s`
+
+error[E0408]: variable `x` is not bound in all patterns
+  --> $DIR/mismatched-bindings-async-fn.rs:11:13
+   |
+LL |     let x | s = String::new();
+   |         -   ^ pattern doesn't bind `x`
+   |         |
+   |         variable not in all patterns
+
+error[E0408]: variable `s` is not bound in all patterns
+  --> $DIR/mismatched-bindings-async-fn.rs:11:9
+   |
+LL |     let x | s = String::new();
+   |         ^   - variable not in all patterns
+   |         |
+   |         pattern doesn't bind `s`
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0408`.


### PR DESCRIPTION
Successful merges:

 - #71557 (Fix ICE for broken or-pattern in async fn)
 - #71775 (Enable `cfg` predicate for `target_feature = "crt-static"` only if the target supports it)
 - #72014 (Deprecated emoji)
 - #72020 (Fix disagreeement about CGU reuse and LTO)
 - #72043 (Add missing backtick in E0569 explanation)

Failed merges:


r? @ghost