### PR TITLE
correctly handle uninferred consts

### DIFF
--- a/src/test/ui/const-generics/uninferred-consts.rs
+++ b/src/test/ui/const-generics/uninferred-consts.rs
@@ -1,0 +1,12 @@
+#![feature(const_generics)]
+//~^ WARN the feature `const_generics` is incomplete
+
+// taken from https://github.com/rust-lang/rust/issues/70507#issuecomment-615268893
+struct Foo;
+impl Foo {
+    fn foo<const N: usize>(self) {}
+}
+fn main() {
+    Foo.foo();
+    //~^ ERROR type annotations needed
+}

--- a/src/test/ui/const-generics/uninferred-consts.stderr
+++ b/src/test/ui/const-generics/uninferred-consts.stderr
@@ -1,0 +1,20 @@
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/uninferred-consts.rs:1:12
+   |
+LL | #![feature(const_generics)]
+   |            ^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
+
+error[E0282]: type annotations needed
+  --> $DIR/uninferred-consts.rs:10:5
+   |
+LL |     Foo.foo();
+   |     ^^^^^^^^^
+   |
+   = note: unable to infer the value of a const parameter
+
+error: aborting due to previous error; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0282`.


### PR DESCRIPTION
fixes the ICE mentioned in https://github.com/rust-lang/rust/issues/70507#issuecomment-615268893

I originally tried to generalize `need_type_info_err` to also work with consts which was not as much fun as I hoped :sweat_smile:

It might be easier to have some duplication here and handle consts separately.

r? @varkor 