### PR TITLE
Emit a warning when optimization fuel runs out

### DIFF
--- a/src/librustc_session/session.rs
+++ b/src/librustc_session/session.rs
@@ -813,7 +813,7 @@ impl Session {
                 let mut fuel = self.optimization_fuel.lock();
                 ret = fuel.remaining != 0;
                 if fuel.remaining == 0 && !fuel.out_of_fuel {
-                    eprintln!("optimization-fuel-exhausted: {}", msg());
+                    self.warn(&format!("optimization-fuel-exhausted: {}", msg()));
                     fuel.out_of_fuel = true;
                 } else if fuel.remaining > 0 {
                     fuel.remaining -= 1;

--- a/src/test/ui/optimization-fuel-0.rs
+++ b/src/test/ui/optimization-fuel-0.rs
@@ -4,8 +4,7 @@
 
 use std::mem::size_of;
 
-// (#55495: The --error-format is to sidestep an issue in our test harness)
-// compile-flags: --error-format human -Z fuel=foo=0
+// compile-flags: -Z fuel=foo=0
 
 struct S1(u8, u16, u8);
 struct S2(u8, u16, u8);

--- a/src/test/ui/optimization-fuel-0.stderr
+++ b/src/test/ui/optimization-fuel-0.stderr
@@ -1,1 +1,4 @@
-optimization-fuel-exhausted: Reorder fields of "S1"
+warning: optimization-fuel-exhausted: Reorder fields of "S1"
+
+warning: 1 warning emitted
+

--- a/src/test/ui/optimization-fuel-1.rs
+++ b/src/test/ui/optimization-fuel-1.rs
@@ -4,8 +4,7 @@
 
 use std::mem::size_of;
 
-// (#55495: The --error-format is to sidestep an issue in our test harness)
-// compile-flags: --error-format human -Z fuel=foo=1
+// compile-flags: -Z fuel=foo=1
 
 struct S1(u8, u16, u8);
 struct S2(u8, u16, u8);

--- a/src/test/ui/optimization-fuel-1.stderr
+++ b/src/test/ui/optimization-fuel-1.stderr
@@ -1,1 +1,4 @@
-optimization-fuel-exhausted: Reorder fields of "S2"
+warning: optimization-fuel-exhausted: Reorder fields of "S2"
+
+warning: 1 warning emitted
+


### PR DESCRIPTION
`eprintln!` gets swallowed by Cargo too easily.