### PR TITLE
Fix hang in lexical_region_resolve

### DIFF
--- a/src/test/ui/regions/issue-72051-member-region-hang.rs
+++ b/src/test/ui/regions/issue-72051-member-region-hang.rs
@@ -1,0 +1,7 @@
+// Regression test for #72051, hang when resolving regions.
+
+// check-pass
+// edition:2018
+
+pub async fn query<'a>(_: &(), _: &(), _: (&(dyn std::any::Any + 'a),) ) {}
+fn main() {}


### PR DESCRIPTION
Regionck was stuck in a loop where a region value was changing between two equal regions.

Closes #72051