### PR TITLE
Do not remove closures during `ReplaceBodyWithLoop` pass

### DIFF
--- a/src/librustc_ast/ast.rs
+++ b/src/librustc_ast/ast.rs
@@ -899,6 +899,15 @@ impl Stmt {
             _ => false,
         }
     }
+
+    pub fn as_expr(&self) -> Option<&Expr> {
+        match self.kind {
+            StmtKind::Local(ref l) => l.init.as_ref().map(|e| &**e),
+            StmtKind::Expr(ref e) => Some(e),
+            StmtKind::Semi(ref e) => Some(e),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Clone, RustcEncodable, RustcDecodable, Debug)]

--- a/src/librustc_privacy/lib.rs
+++ b/src/librustc_privacy/lib.rs
@@ -944,11 +944,8 @@ impl Visitor<'tcx> for EmbargoVisitor<'tcx> {
         let macro_module_def_id =
             ty::DefIdTree::parent(self.tcx, self.tcx.hir().local_def_id(md.hir_id).to_def_id())
                 .unwrap();
-        // FIXME(#71104) Should really be using just `as_local_hir_id` but
-        // some `DefId` do not seem to have a corresponding HirId.
-        let hir_id = macro_module_def_id
-            .as_local()
-            .and_then(|def_id| self.tcx.hir().opt_local_def_id_to_hir_id(def_id));
+        let hir_id =
+            macro_module_def_id.as_local().map(|def_id| self.tcx.hir().as_local_hir_id(def_id));
         let mut module_id = match hir_id {
             Some(module_id) if self.tcx.hir().is_hir_id_module(module_id) => module_id,
             // `module_id` doesn't correspond to a `mod`, return early (#63164, #65252).

--- a/src/test/rustdoc/macro-in-async-block.rs
+++ b/src/test/rustdoc/macro-in-async-block.rs
@@ -1,0 +1,9 @@
+// Regression issue for rustdoc ICE encountered in PR #72088.
+// edition:2018
+#![feature(decl_macro)]
+
+fn main() {
+    async {
+        macro m() {}
+    };
+}

--- a/src/test/rustdoc/macro-in-closure.rs
+++ b/src/test/rustdoc/macro-in-closure.rs
@@ -6,4 +6,7 @@ fn main() {
     || {
         macro m() {}
     };
+    let _ = || {
+        macro n() {}
+    };
 }


### PR DESCRIPTION
Fixes #71820