### PR TITLE
Make MIR typeck use `LocalDefId` and fix docs

### DIFF
--- a/src/librustc_mir/borrow_check/mod.rs
+++ b/src/librustc_mir/borrow_check/mod.rs
@@ -209,7 +209,7 @@ fn do_mir_borrowck<'a, 'tcx>(
         nll_errors,
     } = nll::compute_regions(
         infcx,
-        def_id.to_def_id(),
+        def_id,
         free_regions,
         body,
         &promoted,


### PR DESCRIPTION
The docs on `fn type_check` were not in sync with the arguments it takes.

r? @matthewjasper 