### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/src/libcore/num/f32.rs
+++ b/src/libcore/num/f32.rs
@@ -367,7 +367,7 @@ impl f32 {
     /// Infinity (∞).
     #[stable(feature = "assoc_int_consts", since = "1.43.0")]
     pub const INFINITY: f32 = 1.0_f32 / 0.0_f32;
-    /// Negative infinity (-∞).
+    /// Negative infinity (−∞).
     #[stable(feature = "assoc_int_consts", since = "1.43.0")]
     pub const NEG_INFINITY: f32 = -1.0_f32 / 0.0_f32;
 

--- a/src/libcore/num/f64.rs
+++ b/src/libcore/num/f64.rs
@@ -366,7 +366,7 @@ impl f64 {
     /// Infinity (∞).
     #[stable(feature = "assoc_int_consts", since = "1.43.0")]
     pub const INFINITY: f64 = 1.0_f64 / 0.0_f64;
-    /// Negative infinity (-∞).
+    /// Negative infinity (−∞).
     #[stable(feature = "assoc_int_consts", since = "1.43.0")]
     pub const NEG_INFINITY: f64 = -1.0_f64 / 0.0_f64;
 

--- a/src/librustc_ast_lowering/lib.rs
+++ b/src/librustc_ast_lowering/lib.rs
@@ -33,7 +33,7 @@
 #![feature(array_value_iter)]
 #![feature(crate_visibility_modifier)]
 #![feature(marker_trait_attr)]
-#![feature(specialization)]
+#![feature(specialization)] // FIXME: min_specialization does not work
 #![feature(or_patterns)]
 #![recursion_limit = "256"]
 

--- a/src/librustc_data_structures/lib.rs
+++ b/src/librustc_data_structures/lib.rs
@@ -12,7 +12,7 @@
 #![feature(generators)]
 #![feature(generator_trait)]
 #![feature(fn_traits)]
-#![feature(specialization)]
+#![feature(min_specialization)]
 #![feature(optin_builtin_traits)]
 #![feature(nll)]
 #![feature(allow_internal_unstable)]

--- a/src/librustc_error_codes/error_codes/E0571.md
+++ b/src/librustc_error_codes/error_codes/E0571.md
@@ -7,7 +7,7 @@ Example of erroneous code:
 # fn satisfied(n: usize) -> bool { n % 23 == 0 }
 let result = while true {
     if satisfied(i) {
-        break 2*i; // error: `break` with value from a `while` loop
+        break 2 * i; // error: `break` with value from a `while` loop
     }
     i += 1;
 };
@@ -22,9 +22,9 @@ Make sure `break value;` statements only occur in `loop` loops:
 ```
 # let mut i = 1;
 # fn satisfied(n: usize) -> bool { n % 23 == 0 }
-let result = loop { // ok!
+let result = loop { // This is now a "loop" loop.
     if satisfied(i) {
-        break 2*i;
+        break 2 * i; // ok!
     }
     i += 1;
 };

--- a/src/librustc_hir/lib.rs
+++ b/src/librustc_hir/lib.rs
@@ -8,7 +8,7 @@
 #![feature(const_panic)]
 #![feature(in_band_lifetimes)]
 #![feature(or_patterns)]
-#![feature(specialization)]
+#![feature(min_specialization)]
 #![recursion_limit = "256"]
 
 #[macro_use]

--- a/src/librustc_metadata/lib.rs
+++ b/src/librustc_metadata/lib.rs
@@ -7,7 +7,7 @@
 #![feature(nll)]
 #![feature(or_patterns)]
 #![feature(proc_macro_internals)]
-#![feature(specialization)]
+#![feature(specialization)] // FIXME: min_specialization ICEs
 #![feature(stmt_expr_attributes)]
 #![recursion_limit = "256"]
 

--- a/src/librustc_middle/lib.rs
+++ b/src/librustc_middle/lib.rs
@@ -41,7 +41,7 @@
 #![feature(option_expect_none)]
 #![feature(or_patterns)]
 #![feature(range_is_empty)]
-#![feature(specialization)]
+#![feature(specialization)] // FIXME: min_specialization does not work
 #![feature(track_caller)]
 #![feature(trusted_len)]
 #![feature(vec_remove_item)]

--- a/src/librustc_middle/ty/print/pretty.rs
+++ b/src/librustc_middle/ty/print/pretty.rs
@@ -701,12 +701,14 @@ pub trait PrettyPrinter<'tcx>:
                 if self.tcx().sess.verbose() {
                     p!(write("{:?}", sz));
                 } else if let ty::ConstKind::Unevaluated(..) = sz.val {
-                    // do not try to evaluate unevaluated constants. If we are const evaluating an
+                    // Do not try to evaluate unevaluated constants. If we are const evaluating an
                     // array length anon const, rustc will (with debug assertions) print the
                     // constant's path. Which will end up here again.
                     p!(write("_"));
                 } else if let Some(n) = sz.val.try_to_bits(self.tcx().data_layout.pointer_size) {
                     p!(write("{}", n));
+                } else if let ty::ConstKind::Param(param) = sz.val {
+                    p!(write("{}", param));
                 } else {
                     p!(write("_"));
                 }

--- a/src/librustc_mir/lib.rs
+++ b/src/librustc_mir/lib.rs
@@ -19,7 +19,7 @@ Rust MIR: a lowered representation of Rust.
 #![feature(exhaustive_patterns)]
 #![feature(iter_order_by)]
 #![feature(never_type)]
-#![feature(specialization)]
+#![feature(min_specialization)]
 #![feature(trusted_len)]
 #![feature(try_blocks)]
 #![feature(associated_type_bounds)]

--- a/src/librustc_query_system/lib.rs
+++ b/src/librustc_query_system/lib.rs
@@ -4,7 +4,7 @@
 #![feature(const_panic)]
 #![feature(core_intrinsics)]
 #![feature(hash_raw_entry)]
-#![feature(specialization)]
+#![feature(specialization)] // FIXME: min_specialization rejects `default const`
 #![feature(stmt_expr_attributes)]
 #![feature(vec_remove_item)]
 

--- a/src/librustc_session/session.rs
+++ b/src/librustc_session/session.rs
@@ -813,7 +813,7 @@ impl Session {
                 let mut fuel = self.optimization_fuel.lock();
                 ret = fuel.remaining != 0;
                 if fuel.remaining == 0 && !fuel.out_of_fuel {
-                    eprintln!("optimization-fuel-exhausted: {}", msg());
+                    self.warn(&format!("optimization-fuel-exhausted: {}", msg()));
                     fuel.out_of_fuel = true;
                 } else if fuel.remaining > 0 {
                     fuel.remaining -= 1;

--- a/src/librustc_span/lib.rs
+++ b/src/librustc_span/lib.rs
@@ -12,7 +12,7 @@
 #![feature(negative_impls)]
 #![feature(nll)]
 #![feature(optin_builtin_traits)]
-#![feature(specialization)]
+#![feature(min_specialization)]
 
 // FIXME(#56935): Work around ICEs during cross-compilation.
 #[allow(unused)]

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -2281,7 +2281,10 @@ fn short_stability(item: &clean::Item, cx: &Context) -> Vec<String> {
             );
             message.push_str(&format!(": {}", html.to_string()));
         }
-        stability.push(format!("<div class='stab deprecated'>{}</div>", message));
+        stability.push(format!(
+            "<div class='stab deprecated'><span class='emoji'>👎</span> {}</div>",
+            message,
+        ));
     }
 
     if let Some(stab) = item.stability.as_ref().filter(|stab| stab.level == stability::Unstable) {

--- a/src/libserialize/lib.rs
+++ b/src/libserialize/lib.rs
@@ -10,7 +10,7 @@ Core encoding and decoding interfaces.
     test(attr(allow(unused_variables), deny(warnings)))
 )]
 #![feature(box_syntax)]
-#![feature(specialization)]
+#![feature(specialization)] // FIXME: min_specialization does not work
 #![feature(never_type)]
 #![feature(nll)]
 #![feature(associated_type_bounds)]

--- a/src/test/incremental/const-generics/issue-62536.rs
+++ b/src/test/incremental/const-generics/issue-62536.rs
@@ -1,6 +1,6 @@
 // revisions:cfail1
 #![feature(const_generics)]
-//[cfail1]~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+//[cfail1]~^ WARN the feature `const_generics` is incomplete
 
 struct S<T, const N: usize>([T; N]);
 

--- a/src/test/incremental/const-generics/issue-64087.rs
+++ b/src/test/incremental/const-generics/issue-64087.rs
@@ -1,6 +1,6 @@
 // revisions:cfail1
 #![feature(const_generics)]
-//[cfail1]~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+//[cfail1]~^ WARN the feature `const_generics` is incomplete
 
 fn combinator<T, const S: usize>() -> [T; S] {}
 //[cfail1]~^ ERROR mismatched types

--- a/src/test/rustdoc/issue-32374.rs
+++ b/src/test/rustdoc/issue-32374.rs
@@ -10,7 +10,7 @@
 // @matches issue_32374/index.html '//*[@class="docblock-short"]/text()' 'Docs'
 
 // @has issue_32374/struct.T.html '//*[@class="stab deprecated"]' \
-//      'Deprecated since 1.0.0: text'
+//      '👎 Deprecated since 1.0.0: text'
 // @has - '<code>test</code>&nbsp;<a href="http://issue_url/32374">#32374</a>'
 // @matches issue_32374/struct.T.html '//*[@class="stab unstable"]' \
 //      '🔬 This is a nightly-only experimental API. \(test\s#32374\)$'
@@ -20,7 +20,7 @@
 pub struct T;
 
 // @has issue_32374/struct.U.html '//*[@class="stab deprecated"]' \
-//      'Deprecated since 1.0.0: deprecated'
+//      '👎 Deprecated since 1.0.0: deprecated'
 // @has issue_32374/struct.U.html '//*[@class="stab unstable"]' \
 //      '🔬 This is a nightly-only experimental API. (test #32374)'
 // @has issue_32374/struct.U.html '//details' \

--- a/src/test/ui/array-slice-vec/match_arr_unknown_len.rs
+++ b/src/test/ui/array-slice-vec/match_arr_unknown_len.rs
@@ -1,5 +1,5 @@
 #![feature(const_generics)]
-//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+//~^ WARN the feature `const_generics` is incomplete
 
 fn is_123<const N: usize>(x: [u32; N]) -> bool {
     match x {

--- a/src/test/ui/array-slice-vec/match_arr_unknown_len.stderr
+++ b/src/test/ui/array-slice-vec/match_arr_unknown_len.stderr
@@ -1,10 +1,11 @@
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/match_arr_unknown_len.rs:1:12
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
 
 error[E0308]: mismatched types
   --> $DIR/match_arr_unknown_len.rs:6:9

--- a/src/test/ui/array-slice-vec/match_arr_unknown_len.stderr
+++ b/src/test/ui/array-slice-vec/match_arr_unknown_len.stderr
@@ -13,7 +13,7 @@ LL |         [1, 2] => true,
    |         ^^^^^^ expected `2usize`, found `N`
    |
    = note: expected array `[u32; 2]`
-              found array `[u32; _]`
+              found array `[u32; N]`
 
 error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui/associated-type-bounds/duplicate.rs
+++ b/src/test/ui/associated-type-bounds/duplicate.rs
@@ -2,7 +2,7 @@
 
 #![feature(associated_type_bounds)]
 #![feature(type_alias_impl_trait)]
-#![feature(impl_trait_in_bindings)] //~ WARN the feature `impl_trait_in_bindings` is incomplete and may cause the compiler to crash [incomplete_features]
+#![feature(impl_trait_in_bindings)] //~ WARN the feature `impl_trait_in_bindings` is incomplete
 #![feature(untagged_unions)]
 
 use std::iter;

--- a/src/test/ui/associated-type-bounds/duplicate.stderr
+++ b/src/test/ui/associated-type-bounds/duplicate.stderr
@@ -1,10 +1,11 @@
-warning: the feature `impl_trait_in_bindings` is incomplete and may cause the compiler to crash
+warning: the feature `impl_trait_in_bindings` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/duplicate.rs:5:12
    |
 LL | #![feature(impl_trait_in_bindings)]
    |            ^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #63065 <https://github.com/rust-lang/rust/issues/63065> for more information
 
 error[E0719]: the value of the associated type `Item` (from trait `std::iter::Iterator`) is already specified
   --> $DIR/duplicate.rs:10:36

--- a/src/test/ui/associated-type-bounds/dyn-lcsit.stderr
+++ b/src/test/ui/associated-type-bounds/dyn-lcsit.stderr
@@ -1,10 +1,11 @@
-warning: the feature `impl_trait_in_bindings` is incomplete and may cause the compiler to crash
+warning: the feature `impl_trait_in_bindings` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/dyn-lcsit.rs:4:12
    |
 LL | #![feature(impl_trait_in_bindings)]
    |            ^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #63065 <https://github.com/rust-lang/rust/issues/63065> for more information
 
 warning: 1 warning emitted
 

--- a/src/test/ui/associated-type-bounds/lcsit.stderr
+++ b/src/test/ui/associated-type-bounds/lcsit.stderr
@@ -1,10 +1,11 @@
-warning: the feature `impl_trait_in_bindings` is incomplete and may cause the compiler to crash
+warning: the feature `impl_trait_in_bindings` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/lcsit.rs:4:12
    |
 LL | #![feature(impl_trait_in_bindings)]
    |            ^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #63065 <https://github.com/rust-lang/rust/issues/63065> for more information
 
 warning: 1 warning emitted
 

--- a/src/test/ui/binding/const-param.stderr
+++ b/src/test/ui/binding/const-param.stderr
@@ -1,10 +1,11 @@
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/const-param.rs:3:12
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
 
 error[E0158]: const parameters cannot be referenced in patterns
   --> $DIR/const-param.rs:7:9

--- a/src/test/ui/const-generics/apit-with-const-param.rs
+++ b/src/test/ui/const-generics/apit-with-const-param.rs
@@ -1,7 +1,7 @@
 // check-pass
 
 #![feature(const_generics)]
-//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+//~^ WARN the feature `const_generics` is incomplete
 
 trait Trait {}
 

--- a/src/test/ui/const-generics/apit-with-const-param.stderr
+++ b/src/test/ui/const-generics/apit-with-const-param.stderr
@@ -1,10 +1,11 @@
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/apit-with-const-param.rs:3:12
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
 
 warning: 1 warning emitted
 

--- a/src/test/ui/const-generics/argument_order.rs
+++ b/src/test/ui/const-generics/argument_order.rs
@@ -1,5 +1,5 @@
 #![feature(const_generics)]
-//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+//~^ WARN the feature `const_generics` is incomplete
 
 struct Bad<const N: usize, T> { //~ ERROR type parameters must be declared prior
     arr: [u8; { N }],

--- a/src/test/ui/const-generics/argument_order.stderr
+++ b/src/test/ui/const-generics/argument_order.stderr
@@ -4,13 +4,14 @@ error: type parameters must be declared prior to const parameters
 LL | struct Bad<const N: usize, T> {
    |           -----------------^- help: reorder the parameters: lifetimes, then types, then consts: `<T, const N: usize>`
 
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/argument_order.rs:1:12
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
 
 error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui/const-generics/array-impls/alloc-types-no-impls-length-33.stderr
+++ b/src/test/ui/const-generics/array-impls/alloc-types-no-impls-length-33.stderr
@@ -29,7 +29,7 @@ LL |     let boxed_array = <Box<[i32; 33]>>::try_from(boxed_slice);
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::convert::TryFrom<std::boxed::Box<[i32]>>` is not implemented for `std::boxed::Box<[i32; 33]>`
    |
    = help: the following implementations were found:
-             <std::boxed::Box<[T; _]> as std::convert::TryFrom<std::boxed::Box<[T]>>>
+             <std::boxed::Box<[T; N]> as std::convert::TryFrom<std::boxed::Box<[T]>>>
 
 error[E0277]: the trait bound `std::rc::Rc<[i32; 33]>: std::convert::From<std::rc::Rc<[i32]>>` is not satisfied
   --> $DIR/alloc-types-no-impls-length-33.rs:19:23
@@ -53,7 +53,7 @@ LL |     let boxed_array = <Rc<[i32; 33]>>::try_from(boxed_slice);
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::convert::TryFrom<std::rc::Rc<[i32]>>` is not implemented for `std::rc::Rc<[i32; 33]>`
    |
    = help: the following implementations were found:
-             <std::rc::Rc<[T; _]> as std::convert::TryFrom<std::rc::Rc<[T]>>>
+             <std::rc::Rc<[T; N]> as std::convert::TryFrom<std::rc::Rc<[T]>>>
 
 error[E0277]: the trait bound `std::sync::Arc<[i32; 33]>: std::convert::From<std::sync::Arc<[i32]>>` is not satisfied
   --> $DIR/alloc-types-no-impls-length-33.rs:26:23
@@ -77,7 +77,7 @@ LL |     let boxed_array = <Arc<[i32; 33]>>::try_from(boxed_slice);
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::convert::TryFrom<std::sync::Arc<[i32]>>` is not implemented for `std::sync::Arc<[i32; 33]>`
    |
    = help: the following implementations were found:
-             <std::sync::Arc<[T; _]> as std::convert::TryFrom<std::sync::Arc<[T]>>>
+             <std::sync::Arc<[T; N]> as std::convert::TryFrom<std::sync::Arc<[T]>>>
 
 error: aborting due to 7 previous errors
 

--- a/src/test/ui/const-generics/array-impls/core-traits-no-impls-length-33.stderr
+++ b/src/test/ui/const-generics/array-impls/core-traits-no-impls-length-33.stderr
@@ -39,9 +39,9 @@ LL |     for _ in &[0_usize; 33] {
    |              ^^^^^^^^^^^^^^ the trait `std::iter::IntoIterator` is not implemented for `&[usize; 33]`
    |
    = help: the following implementations were found:
-             <&'a [T; _] as std::iter::IntoIterator>
+             <&'a [T; N] as std::iter::IntoIterator>
              <&'a [T] as std::iter::IntoIterator>
-             <&'a mut [T; _] as std::iter::IntoIterator>
+             <&'a mut [T; N] as std::iter::IntoIterator>
              <&'a mut [T] as std::iter::IntoIterator>
    = note: required by `std::iter::IntoIterator::into_iter`
 

--- a/src/test/ui/const-generics/array-size-in-generic-struct-param.rs
+++ b/src/test/ui/const-generics/array-size-in-generic-struct-param.rs
@@ -1,5 +1,5 @@
 #![feature(const_generics)]
-//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+//~^ WARN the feature `const_generics` is incomplete
 
 #[allow(dead_code)]
 struct ArithArrayLen<const N: usize>([u32; 0 + N]);

--- a/src/test/ui/const-generics/array-size-in-generic-struct-param.stderr
+++ b/src/test/ui/const-generics/array-size-in-generic-struct-param.stderr
@@ -1,10 +1,11 @@
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/array-size-in-generic-struct-param.rs:1:12
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
 
 error: constant expression depends on a generic parameter
   --> $DIR/array-size-in-generic-struct-param.rs:5:38

--- a/src/test/ui/const-generics/array-wrapper-struct-ctor.rs
+++ b/src/test/ui/const-generics/array-wrapper-struct-ctor.rs
@@ -1,7 +1,7 @@
 // run-pass
 
 #![feature(const_generics)]
-//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+//~^ WARN the feature `const_generics` is incomplete
 
 #![allow(dead_code)]
 

--- a/src/test/ui/const-generics/array-wrapper-struct-ctor.stderr
+++ b/src/test/ui/const-generics/array-wrapper-struct-ctor.stderr
@@ -1,10 +1,11 @@
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/array-wrapper-struct-ctor.rs:3:12
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
 
 warning: 1 warning emitted
 

--- a/src/test/ui/const-generics/broken-mir-1.rs
+++ b/src/test/ui/const-generics/broken-mir-1.rs
@@ -1,7 +1,7 @@
 // run-pass
 
 #![feature(const_generics)]
-//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+//~^ WARN the feature `const_generics` is incomplete
 
 pub trait Foo {
     fn foo(&self);

--- a/src/test/ui/const-generics/broken-mir-1.stderr
+++ b/src/test/ui/const-generics/broken-mir-1.stderr
@@ -1,10 +1,11 @@
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/broken-mir-1.rs:3:12
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
 
 warning: 1 warning emitted
 

--- a/src/test/ui/const-generics/broken-mir-2.rs
+++ b/src/test/ui/const-generics/broken-mir-2.rs
@@ -1,5 +1,5 @@
 #![feature(const_generics)]
-//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+//~^ WARN the feature `const_generics` is incomplete
 
 use std::fmt::Debug;
 

--- a/src/test/ui/const-generics/broken-mir-2.stderr
+++ b/src/test/ui/const-generics/broken-mir-2.stderr
@@ -1,10 +1,11 @@
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/broken-mir-2.rs:1:12
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
 
 error[E0277]: arrays only have std trait implementations for lengths 0..=32
   --> $DIR/broken-mir-2.rs:7:36

--- a/src/test/ui/const-generics/broken-mir-2.stderr
+++ b/src/test/ui/const-generics/broken-mir-2.stderr
@@ -10,10 +10,10 @@ error[E0277]: arrays only have std trait implementations for lengths 0..=32
   --> $DIR/broken-mir-2.rs:7:36
    |
 LL | struct S<T: Debug, const N: usize>([T; N]);
-   |                                    ^^^^^^ the trait `std::array::LengthAtMost32` is not implemented for `[T; _]`
+   |                                    ^^^^^^ the trait `std::array::LengthAtMost32` is not implemented for `[T; N]`
    |
-   = note: required because of the requirements on the impl of `std::fmt::Debug` for `[T; _]`
-   = note: required because of the requirements on the impl of `std::fmt::Debug` for `&[T; _]`
+   = note: required because of the requirements on the impl of `std::fmt::Debug` for `[T; N]`
+   = note: required because of the requirements on the impl of `std::fmt::Debug` for `&[T; N]`
    = note: required for the cast to the object type `dyn std::fmt::Debug`
    = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/const-generics/cannot-infer-const-args.rs
+++ b/src/test/ui/const-generics/cannot-infer-const-args.rs
@@ -1,5 +1,5 @@
 #![feature(const_generics)]
-//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+//~^ WARN the feature `const_generics` is incomplete
 
 fn foo<const X: usize>() -> usize {
     0

--- a/src/test/ui/const-generics/cannot-infer-const-args.stderr
+++ b/src/test/ui/const-generics/cannot-infer-const-args.stderr
@@ -1,10 +1,11 @@
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/cannot-infer-const-args.rs:1:12
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
 
 error[E0282]: type annotations needed
   --> $DIR/cannot-infer-const-args.rs:9:5

--- a/src/test/ui/const-generics/cannot-infer-type-for-const-param.rs
+++ b/src/test/ui/const-generics/cannot-infer-type-for-const-param.rs
@@ -1,6 +1,6 @@
 // check-pass
 #![feature(const_generics)]
-//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+//~^ WARN the feature `const_generics` is incomplete
 
 // This test confirms that the types can be inferred correctly for this example with const
 // generics. Previously this would ICE, and more recently error.

--- a/src/test/ui/const-generics/cannot-infer-type-for-const-param.stderr
+++ b/src/test/ui/const-generics/cannot-infer-type-for-const-param.stderr
@@ -1,10 +1,11 @@
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/cannot-infer-type-for-const-param.rs:2:12
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
 
 warning: 1 warning emitted
 

--- a/src/test/ui/const-generics/concrete-const-as-fn-arg.rs
+++ b/src/test/ui/const-generics/concrete-const-as-fn-arg.rs
@@ -2,7 +2,7 @@
 // run-pass
 
 #![feature(const_generics)]
-//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+//~^ WARN the feature `const_generics` is incomplete
 
 struct A<const N: usize>; // ok
 

--- a/src/test/ui/const-generics/concrete-const-as-fn-arg.stderr
+++ b/src/test/ui/const-generics/concrete-const-as-fn-arg.stderr
@@ -1,10 +1,11 @@
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/concrete-const-as-fn-arg.rs:4:12
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
 
 warning: 1 warning emitted
 

--- a/src/test/ui/const-generics/concrete-const-impl-method.rs
+++ b/src/test/ui/const-generics/concrete-const-impl-method.rs
@@ -3,7 +3,7 @@
 // run-pass
 
 #![feature(const_generics)]
-//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+//~^ WARN the feature `const_generics` is incomplete
 
 pub struct A<const N: u32>;
 

--- a/src/test/ui/const-generics/concrete-const-impl-method.stderr
+++ b/src/test/ui/const-generics/concrete-const-impl-method.stderr
@@ -1,10 +1,11 @@
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/concrete-const-impl-method.rs:5:12
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
 
 warning: 1 warning emitted
 

--- a/src/test/ui/const-generics/condition-in-trait-const-arg.rs
+++ b/src/test/ui/const-generics/condition-in-trait-const-arg.rs
@@ -1,7 +1,7 @@
 // run-pass
 
 #![feature(const_generics)]
-//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+//~^ WARN the feature `const_generics` is incomplete
 
 trait IsZeroTrait<const IS_ZERO: bool>{}
 

--- a/src/test/ui/const-generics/condition-in-trait-const-arg.stderr
+++ b/src/test/ui/const-generics/condition-in-trait-const-arg.stderr
@@ -1,10 +1,11 @@
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/condition-in-trait-const-arg.rs:3:12
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
 
 warning: 1 warning emitted
 

--- a/src/test/ui/const-generics/const-arg-in-fn.rs
+++ b/src/test/ui/const-generics/const-arg-in-fn.rs
@@ -1,7 +1,7 @@
 // run-pass
 
 #![feature(const_generics)]
-//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+//~^ WARN the feature `const_generics` is incomplete
 
 fn const_u32_identity<const X: u32>() -> u32 {
     X

--- a/src/test/ui/const-generics/const-arg-in-fn.stderr
+++ b/src/test/ui/const-generics/const-arg-in-fn.stderr
@@ -1,10 +1,11 @@
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/const-arg-in-fn.rs:3:12
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
 
 warning: 1 warning emitted
 

--- a/src/test/ui/const-generics/const-arg-type-arg-misordered.rs
+++ b/src/test/ui/const-generics/const-arg-type-arg-misordered.rs
@@ -1,5 +1,5 @@
 #![feature(const_generics)]
-//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+//~^ WARN the feature `const_generics` is incomplete
 
 type Array<T, const N: usize> = [T; N];
 

--- a/src/test/ui/const-generics/const-arg-type-arg-misordered.stderr
+++ b/src/test/ui/const-generics/const-arg-type-arg-misordered.stderr
@@ -1,10 +1,11 @@
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/const-arg-type-arg-misordered.rs:1:12
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
 
 error[E0747]: constant provided when a type was expected
   --> $DIR/const-arg-type-arg-misordered.rs:6:35

--- a/src/test/ui/const-generics/const-expression-parameter.rs
+++ b/src/test/ui/const-generics/const-expression-parameter.rs
@@ -1,5 +1,5 @@
 #![feature(const_generics)]
-//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+//~^ WARN the feature `const_generics` is incomplete
 
 fn i32_identity<const X: i32>() -> i32 {
     5

--- a/src/test/ui/const-generics/const-expression-parameter.stderr
+++ b/src/test/ui/const-generics/const-expression-parameter.stderr
@@ -4,13 +4,14 @@ error: expected one of `,` or `>`, found `+`
 LL |     i32_identity::<1 + 2>();
    |                      ^ expected one of `,` or `>`
 
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/const-expression-parameter.rs:1:12
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
 
 error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui/const-generics/const-fn-with-const-param.rs
+++ b/src/test/ui/const-generics/const-fn-with-const-param.rs
@@ -1,6 +1,6 @@
 // run-pass
 #![feature(const_generics)]
-//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+//~^ WARN the feature `const_generics` is incomplete
 
 const fn const_u32_identity<const X: u32>() -> u32 {
     X

--- a/src/test/ui/const-generics/const-fn-with-const-param.stderr
+++ b/src/test/ui/const-generics/const-fn-with-const-param.stderr
@@ -1,10 +1,11 @@
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/const-fn-with-const-param.rs:2:12
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
 
 warning: 1 warning emitted
 

--- a/src/test/ui/const-generics/const-generic-array-wrapper.rs
+++ b/src/test/ui/const-generics/const-generic-array-wrapper.rs
@@ -1,7 +1,7 @@
 // run-pass
 
 #![feature(const_generics)]
-//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+//~^ WARN the feature `const_generics` is incomplete
 
 struct Foo<T, const N: usize>([T; N]);
 

--- a/src/test/ui/const-generics/const-generic-array-wrapper.stderr
+++ b/src/test/ui/const-generics/const-generic-array-wrapper.stderr
@@ -1,10 +1,11 @@
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/const-generic-array-wrapper.rs:3:12
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
 
 warning: 1 warning emitted
 

--- a/src/test/ui/const-generics/const-generic-type_name.rs
+++ b/src/test/ui/const-generics/const-generic-type_name.rs
@@ -1,7 +1,7 @@
 // run-pass
 
 #![feature(const_generics)]
-//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+//~^ WARN the feature `const_generics` is incomplete
 
 #[derive(Debug)]
 struct S<const N: usize>;

--- a/src/test/ui/const-generics/const-generic-type_name.stderr
+++ b/src/test/ui/const-generics/const-generic-type_name.stderr
@@ -1,10 +1,11 @@
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/const-generic-type_name.rs:3:12
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
 
 warning: 1 warning emitted
 

--- a/src/test/ui/const-generics/const-param-elided-lifetime.rs
+++ b/src/test/ui/const-generics/const-param-elided-lifetime.rs
@@ -4,7 +4,7 @@
 // lifetimes within const/static items.
 
 #![feature(const_generics)]
-//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+//~^ WARN the feature `const_generics` is incomplete
 
 struct A<const N: &u8>;
 //~^ ERROR `&` without an explicit lifetime name cannot be used here

--- a/src/test/ui/const-generics/const-param-elided-lifetime.stderr
+++ b/src/test/ui/const-generics/const-param-elided-lifetime.stderr
@@ -28,13 +28,14 @@ error[E0637]: `&` without an explicit lifetime name cannot be used here
 LL | fn bar<const N: &u8>() {}
    |                 ^ explicit lifetime name needed here
 
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/const-param-elided-lifetime.rs:6:12
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
 
 error: aborting due to 5 previous errors; 1 warning emitted
 

--- a/src/test/ui/const-generics/const-param-from-outer-fn.rs
+++ b/src/test/ui/const-generics/const-param-from-outer-fn.rs
@@ -1,5 +1,5 @@
 #![feature(const_generics)]
-//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+//~^ WARN the feature `const_generics` is incomplete
 
 fn foo<const X: u32>() {
     fn bar() -> u32 {

--- a/src/test/ui/const-generics/const-param-from-outer-fn.stderr
+++ b/src/test/ui/const-generics/const-param-from-outer-fn.stderr
@@ -8,13 +8,14 @@ LL |     fn bar() -> u32 {
 LL |         X
    |         ^ use of generic parameter from outer function
 
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/const-param-from-outer-fn.rs:1:12
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
 
 error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui/const-generics/const-param-in-trait.rs
+++ b/src/test/ui/const-generics/const-param-in-trait.rs
@@ -1,7 +1,7 @@
 // run-pass
 
 #![feature(const_generics)]
-//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+//~^ WARN the feature `const_generics` is incomplete
 
 trait Trait<const T: ()> {}
 

--- a/src/test/ui/const-generics/const-param-in-trait.stderr
+++ b/src/test/ui/const-generics/const-param-in-trait.stderr
@@ -1,10 +1,11 @@
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/const-param-in-trait.rs:3:12
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
 
 warning: 1 warning emitted
 

--- a/src/test/ui/const-generics/const-param-type-depends-on-type-param.rs
+++ b/src/test/ui/const-generics/const-param-type-depends-on-type-param.rs
@@ -1,5 +1,5 @@
 #![feature(const_generics)]
-//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+//~^ WARN the feature `const_generics` is incomplete
 
 // Currently, const parameters cannot depend on type parameters, because there is no way to
 // enforce the structural-match property on an arbitrary type parameter. This restriction

--- a/src/test/ui/const-generics/const-param-type-depends-on-type-param.stderr
+++ b/src/test/ui/const-generics/const-param-type-depends-on-type-param.stderr
@@ -1,10 +1,11 @@
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/const-param-type-depends-on-type-param.rs:1:12
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
 
 error[E0741]: `T` is not guaranteed to `#[derive(PartialEq, Eq)]`, so may not be used as the type of a const parameter
   --> $DIR/const-param-type-depends-on-type-param.rs:9:34

--- a/src/test/ui/const-generics/const-parameter-uppercase-lint.rs
+++ b/src/test/ui/const-generics/const-parameter-uppercase-lint.rs
@@ -1,5 +1,5 @@
 #![feature(const_generics)]
-//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+//~^ WARN the feature `const_generics` is incomplete
 
 #![deny(non_upper_case_globals)]
 

--- a/src/test/ui/const-generics/const-parameter-uppercase-lint.stderr
+++ b/src/test/ui/const-generics/const-parameter-uppercase-lint.stderr
@@ -1,10 +1,11 @@
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/const-parameter-uppercase-lint.rs:1:12
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
 
 error: const parameter `x` should have an upper case name
   --> $DIR/const-parameter-uppercase-lint.rs:6:15

--- a/src/test/ui/const-generics/const-types.rs
+++ b/src/test/ui/const-generics/const-types.rs
@@ -1,7 +1,7 @@
 // run-pass
 
 #![feature(const_generics)]
-//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+//~^ WARN the feature `const_generics` is incomplete
 
 #![allow(dead_code, unused_variables)]
 

--- a/src/test/ui/const-generics/const-types.stderr
+++ b/src/test/ui/const-generics/const-types.stderr
@@ -1,10 +1,11 @@
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/const-types.rs:3:12
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
 
 warning: 1 warning emitted
 

--- a/src/test/ui/const-generics/derive-debug-array-wrapper.rs
+++ b/src/test/ui/const-generics/derive-debug-array-wrapper.rs
@@ -1,5 +1,5 @@
 #![feature(const_generics)]
-//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+//~^ WARN the feature `const_generics` is incomplete
 
 #[derive(Debug)]
 struct X<const N: usize> {

--- a/src/test/ui/const-generics/derive-debug-array-wrapper.stderr
+++ b/src/test/ui/const-generics/derive-debug-array-wrapper.stderr
@@ -1,10 +1,11 @@
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/derive-debug-array-wrapper.rs:1:12
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
 
 error[E0277]: arrays only have std trait implementations for lengths 0..=32
   --> $DIR/derive-debug-array-wrapper.rs:6:5

--- a/src/test/ui/const-generics/derive-debug-array-wrapper.stderr
+++ b/src/test/ui/const-generics/derive-debug-array-wrapper.stderr
@@ -10,10 +10,10 @@ error[E0277]: arrays only have std trait implementations for lengths 0..=32
   --> $DIR/derive-debug-array-wrapper.rs:6:5
    |
 LL |     a: [u32; N],
-   |     ^^^^^^^^^^^ the trait `std::array::LengthAtMost32` is not implemented for `[u32; _]`
+   |     ^^^^^^^^^^^ the trait `std::array::LengthAtMost32` is not implemented for `[u32; N]`
    |
-   = note: required because of the requirements on the impl of `std::fmt::Debug` for `[u32; _]`
-   = note: required because of the requirements on the impl of `std::fmt::Debug` for `&[u32; _]`
+   = note: required because of the requirements on the impl of `std::fmt::Debug` for `[u32; N]`
+   = note: required because of the requirements on the impl of `std::fmt::Debug` for `&[u32; N]`
    = note: required for the cast to the object type `dyn std::fmt::Debug`
    = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/const-generics/different_byref.rs
+++ b/src/test/ui/const-generics/different_byref.rs
@@ -1,5 +1,5 @@
 #![feature(const_generics)]
-//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+//~^ WARN the feature `const_generics` is incomplete
 
 struct Const<const V: [usize; 1]> {}
 

--- a/src/test/ui/const-generics/different_byref.stderr
+++ b/src/test/ui/const-generics/different_byref.stderr
@@ -1,10 +1,11 @@
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/different_byref.rs:1:12
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
 
 error[E0308]: mismatched types
   --> $DIR/different_byref.rs:8:9

--- a/src/test/ui/const-generics/fn-const-param-call.rs
+++ b/src/test/ui/const-generics/fn-const-param-call.rs
@@ -1,7 +1,7 @@
 // run-pass
 
 #![feature(const_generics, const_compare_raw_pointers)]
-//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+//~^ WARN the feature `const_generics` is incomplete
 
 fn function() -> u32 {
     17

--- a/src/test/ui/const-generics/fn-const-param-call.stderr
+++ b/src/test/ui/const-generics/fn-const-param-call.stderr
@@ -1,10 +1,11 @@
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/fn-const-param-call.rs:3:12
    |
 LL | #![feature(const_generics, const_compare_raw_pointers)]
    |            ^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
 
 warning: 1 warning emitted
 

--- a/src/test/ui/const-generics/fn-const-param-infer.rs
+++ b/src/test/ui/const-generics/fn-const-param-infer.rs
@@ -1,5 +1,5 @@
 #![feature(const_generics, const_compare_raw_pointers)]
-//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+//~^ WARN the feature `const_generics` is incomplete
 
 struct Checked<const F: fn(usize) -> bool>;
 

--- a/src/test/ui/const-generics/fn-const-param-infer.stderr
+++ b/src/test/ui/const-generics/fn-const-param-infer.stderr
@@ -1,10 +1,11 @@
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/fn-const-param-infer.rs:1:12
    |
 LL | #![feature(const_generics, const_compare_raw_pointers)]
    |            ^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
 
 error[E0308]: mismatched types
   --> $DIR/fn-const-param-infer.rs:16:31

--- a/src/test/ui/const-generics/fn-taking-const-generic-array.rs
+++ b/src/test/ui/const-generics/fn-taking-const-generic-array.rs
@@ -1,7 +1,7 @@
 // run-pass
 
 #![feature(const_generics)]
-//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+//~^ WARN the feature `const_generics` is incomplete
 
 use std::fmt::Display;
 

--- a/src/test/ui/const-generics/fn-taking-const-generic-array.stderr
+++ b/src/test/ui/const-generics/fn-taking-const-generic-array.stderr
@@ -1,10 +1,11 @@
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/fn-taking-const-generic-array.rs:3:12
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
 
 warning: 1 warning emitted
 

--- a/src/test/ui/const-generics/forbid-non-structural_match-types.rs
+++ b/src/test/ui/const-generics/forbid-non-structural_match-types.rs
@@ -1,5 +1,5 @@
 #![feature(const_generics)]
-//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+//~^ WARN the feature `const_generics` is incomplete
 
 #[derive(PartialEq, Eq)]
 struct A;

--- a/src/test/ui/const-generics/forbid-non-structural_match-types.stderr
+++ b/src/test/ui/const-generics/forbid-non-structural_match-types.stderr
@@ -1,10 +1,11 @@
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/forbid-non-structural_match-types.rs:1:12
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
 
 error[E0741]: `C` must be annotated with `#[derive(PartialEq, Eq)]` to be used as the type of a const parameter
   --> $DIR/forbid-non-structural_match-types.rs:11:19

--- a/src/test/ui/const-generics/foreign-item-const-parameter.rs
+++ b/src/test/ui/const-generics/foreign-item-const-parameter.rs
@@ -1,5 +1,5 @@
 #![feature(const_generics)]
-//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+//~^ WARN the feature `const_generics` is incomplete
 
 extern "C" {
     fn foo<const X: usize>(); //~ ERROR foreign items may not have const parameters

--- a/src/test/ui/const-generics/foreign-item-const-parameter.stderr
+++ b/src/test/ui/const-generics/foreign-item-const-parameter.stderr
@@ -1,10 +1,11 @@
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/foreign-item-const-parameter.rs:1:12
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
 
 error[E0044]: foreign items may not have const parameters
   --> $DIR/foreign-item-const-parameter.rs:5:5

--- a/src/test/ui/const-generics/impl-const-generic-struct.rs
+++ b/src/test/ui/const-generics/impl-const-generic-struct.rs
@@ -1,7 +1,7 @@
 // run-pass
 
 #![feature(const_generics)]
-//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+//~^ WARN the feature `const_generics` is incomplete
 
 struct S<const X: u32>;
 

--- a/src/test/ui/const-generics/impl-const-generic-struct.stderr
+++ b/src/test/ui/const-generics/impl-const-generic-struct.stderr
@@ -1,10 +1,11 @@
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/impl-const-generic-struct.rs:3:12
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
 
 warning: 1 warning emitted
 

--- a/src/test/ui/const-generics/incorrect-number-of-const-args.rs
+++ b/src/test/ui/const-generics/incorrect-number-of-const-args.rs
@@ -1,5 +1,5 @@
 #![feature(const_generics)]
-//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+//~^ WARN the feature `const_generics` is incomplete
 
 fn foo<const X: usize, const Y: usize>() -> usize {
     0

--- a/src/test/ui/const-generics/incorrect-number-of-const-args.stderr
+++ b/src/test/ui/const-generics/incorrect-number-of-const-args.stderr
@@ -1,10 +1,11 @@
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/incorrect-number-of-const-args.rs:1:12
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
 
 error[E0107]: wrong number of const arguments: expected 2, found 1
   --> $DIR/incorrect-number-of-const-args.rs:9:5

--- a/src/test/ui/const-generics/infer_arg_from_pat.rs
+++ b/src/test/ui/const-generics/infer_arg_from_pat.rs
@@ -2,7 +2,7 @@
 //
 // see issue #70529
 #![feature(const_generics)]
-//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+//~^ WARN the feature `const_generics` is incomplete
 
 struct A<const N: usize> {
     arr: [u8; N],

--- a/src/test/ui/const-generics/infer_arg_from_pat.stderr
+++ b/src/test/ui/const-generics/infer_arg_from_pat.stderr
@@ -1,10 +1,11 @@
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/infer_arg_from_pat.rs:4:12
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
 
 warning: 1 warning emitted
 

--- a/src/test/ui/const-generics/infer_arr_len_from_pat.rs
+++ b/src/test/ui/const-generics/infer_arr_len_from_pat.rs
@@ -2,7 +2,7 @@
 //
 // see issue #70529
 #![feature(const_generics)]
-//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+//~^ WARN the feature `const_generics` is incomplete
 
 fn as_chunks<const N: usize>() -> [u8; N] {
     loop {}

--- a/src/test/ui/const-generics/infer_arr_len_from_pat.stderr
+++ b/src/test/ui/const-generics/infer_arr_len_from_pat.stderr
@@ -1,10 +1,11 @@
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/infer_arr_len_from_pat.rs:4:12
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
 
 warning: 1 warning emitted
 

--- a/src/test/ui/const-generics/integer-literal-generic-arg-in-where-clause.rs
+++ b/src/test/ui/const-generics/integer-literal-generic-arg-in-where-clause.rs
@@ -1,7 +1,7 @@
 // check-pass
 
 #![feature(const_generics)]
-//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+//~^ WARN the feature `const_generics` is incomplete
 
 fn takes_closure_of_array_3<F>(f: F) where F: Fn([i32; 3]) {
     f([1, 2, 3]);

--- a/src/test/ui/const-generics/integer-literal-generic-arg-in-where-clause.stderr
+++ b/src/test/ui/const-generics/integer-literal-generic-arg-in-where-clause.stderr
@@ -1,10 +1,11 @@
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/integer-literal-generic-arg-in-where-clause.rs:3:12
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
 
 warning: 1 warning emitted
 

--- a/src/test/ui/const-generics/issue-61522-array-len-succ.rs
+++ b/src/test/ui/const-generics/issue-61522-array-len-succ.rs
@@ -1,5 +1,5 @@
 #![feature(const_generics)]
-//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+//~^ WARN the feature `const_generics` is incomplete
 
 pub struct MyArray<const COUNT: usize>([u8; COUNT + 1]);
 //~^ ERROR constant expression depends on a generic parameter

--- a/src/test/ui/const-generics/issue-61522-array-len-succ.stderr
+++ b/src/test/ui/const-generics/issue-61522-array-len-succ.stderr
@@ -1,10 +1,11 @@
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/issue-61522-array-len-succ.rs:1:12
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
 
 error: constant expression depends on a generic parameter
   --> $DIR/issue-61522-array-len-succ.rs:4:40

--- a/src/test/ui/const-generics/issue-66596-impl-trait-for-str-const-arg.rs
+++ b/src/test/ui/const-generics/issue-66596-impl-trait-for-str-const-arg.rs
@@ -1,7 +1,7 @@
 // check-pass
 
 #![feature(const_generics)]
-//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+//~^ WARN the feature `const_generics` is incomplete
 
 trait Trait<const NAME: &'static str> {
     type Assoc;

--- a/src/test/ui/const-generics/issue-66596-impl-trait-for-str-const-arg.stderr
+++ b/src/test/ui/const-generics/issue-66596-impl-trait-for-str-const-arg.stderr
@@ -1,10 +1,11 @@
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/issue-66596-impl-trait-for-str-const-arg.rs:3:12
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
 
 warning: 1 warning emitted
 

--- a/src/test/ui/const-generics/issues/issue-60818-struct-constructors.rs
+++ b/src/test/ui/const-generics/issues/issue-60818-struct-constructors.rs
@@ -1,7 +1,7 @@
 // check-pass
 
 #![feature(const_generics)]
-//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+//~^ WARN the feature `const_generics` is incomplete
 
 struct Generic<const V: usize>;
 

--- a/src/test/ui/const-generics/issues/issue-60818-struct-constructors.stderr
+++ b/src/test/ui/const-generics/issues/issue-60818-struct-constructors.stderr
@@ -1,10 +1,11 @@
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/issue-60818-struct-constructors.rs:3:12
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
 
 warning: 1 warning emitted
 

--- a/src/test/ui/const-generics/issues/issue-61336-1.rs
+++ b/src/test/ui/const-generics/issues/issue-61336-1.rs
@@ -1,5 +1,5 @@
 #![feature(const_generics)]
-//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+//~^ WARN the feature `const_generics` is incomplete
 
 // build-pass
 

--- a/src/test/ui/const-generics/issues/issue-61336-1.stderr
+++ b/src/test/ui/const-generics/issues/issue-61336-1.stderr
@@ -1,10 +1,11 @@
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/issue-61336-1.rs:1:12
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
 
 warning: 1 warning emitted
 

--- a/src/test/ui/const-generics/issues/issue-61336-2.rs
+++ b/src/test/ui/const-generics/issues/issue-61336-2.rs
@@ -1,5 +1,5 @@
 #![feature(const_generics)]
-//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+//~^ WARN the feature `const_generics` is incomplete
 
 fn f<T: Copy, const N: usize>(x: T) -> [T; N] {
     [x; { N }]

--- a/src/test/ui/const-generics/issues/issue-61336-2.stderr
+++ b/src/test/ui/const-generics/issues/issue-61336-2.stderr
@@ -1,10 +1,11 @@
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/issue-61336-2.rs:1:12
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
 
 error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
   --> $DIR/issue-61336-2.rs:9:5

--- a/src/test/ui/const-generics/issues/issue-61336.rs
+++ b/src/test/ui/const-generics/issues/issue-61336.rs
@@ -1,5 +1,5 @@
 #![feature(const_generics)]
-//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+//~^ WARN the feature `const_generics` is incomplete
 
 fn f<T: Copy, const N: usize>(x: T) -> [T; N] {
     [x; N]

--- a/src/test/ui/const-generics/issues/issue-61336.stderr
+++ b/src/test/ui/const-generics/issues/issue-61336.stderr
@@ -1,10 +1,11 @@
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/issue-61336.rs:1:12
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
 
 error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
   --> $DIR/issue-61336.rs:9:5

--- a/src/test/ui/const-generics/issues/issue-61422.rs
+++ b/src/test/ui/const-generics/issues/issue-61422.rs
@@ -1,7 +1,7 @@
 // check-pass
 
 #![feature(const_generics)]
-//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+//~^ WARN the feature `const_generics` is incomplete
 
 use std::mem;
 

--- a/src/test/ui/const-generics/issues/issue-61422.stderr
+++ b/src/test/ui/const-generics/issues/issue-61422.stderr
@@ -1,10 +1,11 @@
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/issue-61422.rs:3:12
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
 
 warning: 1 warning emitted
 

--- a/src/test/ui/const-generics/issues/issue-61432.rs
+++ b/src/test/ui/const-generics/issues/issue-61432.rs
@@ -1,7 +1,7 @@
 // run-pass
 
 #![feature(const_generics)]
-//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+//~^ WARN the feature `const_generics` is incomplete
 
 fn promote<const N: i32>() {
     // works:

--- a/src/test/ui/const-generics/issues/issue-61432.stderr
+++ b/src/test/ui/const-generics/issues/issue-61432.stderr
@@ -1,10 +1,11 @@
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/issue-61432.rs:3:12
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
 
 warning: 1 warning emitted
 

--- a/src/test/ui/const-generics/issues/issue-61747.rs
+++ b/src/test/ui/const-generics/issues/issue-61747.rs
@@ -1,7 +1,7 @@
 // check-pass
 
 #![feature(const_generics)]
-//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+//~^ WARN the feature `const_generics` is incomplete
 
 struct Const<const N: usize>;
 

--- a/src/test/ui/const-generics/issues/issue-61747.stderr
+++ b/src/test/ui/const-generics/issues/issue-61747.stderr
@@ -1,10 +1,11 @@
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/issue-61747.rs:3:12
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
 
 warning: 1 warning emitted
 

--- a/src/test/ui/const-generics/issues/issue-62187-encountered-polymorphic-const.rs
+++ b/src/test/ui/const-generics/issues/issue-62187-encountered-polymorphic-const.rs
@@ -1,7 +1,7 @@
 // run-pass
 
 #![feature(const_generics)]
-//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+//~^ WARN the feature `const_generics` is incomplete
 
 pub trait BitLen: Sized {
     const BIT_LEN: usize;

--- a/src/test/ui/const-generics/issues/issue-62187-encountered-polymorphic-const.stderr
+++ b/src/test/ui/const-generics/issues/issue-62187-encountered-polymorphic-const.stderr
@@ -1,10 +1,11 @@
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/issue-62187-encountered-polymorphic-const.rs:3:12
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
 
 warning: unused variable: `foo`
   --> $DIR/issue-62187-encountered-polymorphic-const.rs:15:9

--- a/src/test/ui/const-generics/issues/issue-62456.rs
+++ b/src/test/ui/const-generics/issues/issue-62456.rs
@@ -1,5 +1,5 @@
 #![feature(const_generics)]
-//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+//~^ WARN the feature `const_generics` is incomplete
 
 fn foo<const N: usize>() {
     let _ = [0u64; N + 1];

--- a/src/test/ui/const-generics/issues/issue-62456.stderr
+++ b/src/test/ui/const-generics/issues/issue-62456.stderr
@@ -1,10 +1,11 @@
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/issue-62456.rs:1:12
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
 
 error: constant expression depends on a generic parameter
   --> $DIR/issue-62456.rs:5:20

--- a/src/test/ui/const-generics/issues/issue-62504.stderr
+++ b/src/test/ui/const-generics/issues/issue-62504.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL |         ArrayHolder([0; Self::SIZE])
    |                     ^^^^^^^^^^^^^^^ expected `X`, found `Self::SIZE`
    |
-   = note: expected array `[u32; _]`
+   = note: expected array `[u32; X]`
               found array `[u32; _]`
 
 error: constant expression depends on a generic parameter

--- a/src/test/ui/const-generics/issues/issue-62579-no-match.rs
+++ b/src/test/ui/const-generics/issues/issue-62579-no-match.rs
@@ -1,7 +1,7 @@
 // run-pass
 
 #![feature(const_generics)]
-//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+//~^ WARN the feature `const_generics` is incomplete
 
 #[derive(PartialEq, Eq)]
 struct NoMatch;

--- a/src/test/ui/const-generics/issues/issue-62579-no-match.stderr
+++ b/src/test/ui/const-generics/issues/issue-62579-no-match.stderr
@@ -1,10 +1,11 @@
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/issue-62579-no-match.rs:3:12
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
 
 warning: 1 warning emitted
 

--- a/src/test/ui/const-generics/issues/issue-63322-forbid-dyn.rs
+++ b/src/test/ui/const-generics/issues/issue-63322-forbid-dyn.rs
@@ -1,5 +1,5 @@
 #![feature(const_generics)]
-//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+//~^ WARN the feature `const_generics` is incomplete
 
 trait A {}
 struct B;

--- a/src/test/ui/const-generics/issues/issue-63322-forbid-dyn.stderr
+++ b/src/test/ui/const-generics/issues/issue-63322-forbid-dyn.stderr
@@ -1,10 +1,11 @@
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/issue-63322-forbid-dyn.rs:1:12
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
 
 error[E0741]: `&'static (dyn A + 'static)` must be annotated with `#[derive(PartialEq, Eq)]` to be used as the type of a const parameter
   --> $DIR/issue-63322-forbid-dyn.rs:8:18

--- a/src/test/ui/const-generics/issues/issue-64519.rs
+++ b/src/test/ui/const-generics/issues/issue-64519.rs
@@ -1,7 +1,7 @@
 // check-pass
 
 #![feature(const_generics)]
-//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+//~^ WARN the feature `const_generics` is incomplete
 
 struct Foo<const D: usize> {
     state: Option<[u8; D]>,

--- a/src/test/ui/const-generics/issues/issue-64519.stderr
+++ b/src/test/ui/const-generics/issues/issue-64519.stderr
@@ -1,10 +1,11 @@
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/issue-64519.rs:3:12
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
 
 warning: 1 warning emitted
 

--- a/src/test/ui/const-generics/issues/issue-66906.rs
+++ b/src/test/ui/const-generics/issues/issue-66906.rs
@@ -1,7 +1,7 @@
 // check-pass
 
 #![feature(const_generics)]
-//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+//~^ WARN the feature `const_generics` is incomplete
 
 pub struct Tuple;
 

--- a/src/test/ui/const-generics/issues/issue-66906.stderr
+++ b/src/test/ui/const-generics/issues/issue-66906.stderr
@@ -1,10 +1,11 @@
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/issue-66906.rs:3:12
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
 
 warning: 1 warning emitted
 

--- a/src/test/ui/const-generics/issues/issue-70125-1.rs
+++ b/src/test/ui/const-generics/issues/issue-70125-1.rs
@@ -1,6 +1,6 @@
 // run-pass
 #![feature(const_generics)]
-//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+//~^ WARN the feature `const_generics` is incomplete
 
 const L: usize = 4;
 

--- a/src/test/ui/const-generics/issues/issue-70125-1.stderr
+++ b/src/test/ui/const-generics/issues/issue-70125-1.stderr
@@ -1,10 +1,11 @@
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/issue-70125-1.rs:2:12
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
 
 warning: 1 warning emitted
 

--- a/src/test/ui/const-generics/issues/issue-70125-2.rs
+++ b/src/test/ui/const-generics/issues/issue-70125-2.rs
@@ -1,7 +1,7 @@
 // run-pass
 
 #![feature(const_generics)]
-//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+//~^ WARN the feature `const_generics` is incomplete
 
 fn main() {
     <()>::foo();

--- a/src/test/ui/const-generics/issues/issue-70125-2.stderr
+++ b/src/test/ui/const-generics/issues/issue-70125-2.stderr
@@ -1,10 +1,11 @@
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/issue-70125-2.rs:3:12
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
 
 warning: 1 warning emitted
 

--- a/src/test/ui/const-generics/issues/issue-70167.rs
+++ b/src/test/ui/const-generics/issues/issue-70167.rs
@@ -1,7 +1,7 @@
 // check-pass
 
 #![feature(const_generics)]
-//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+//~^ WARN the feature `const_generics` is incomplete
 
 pub trait Trait<const N: usize>: From<<Self as Trait<N>>::Item> {
   type Item;

--- a/src/test/ui/const-generics/issues/issue-70167.stderr
+++ b/src/test/ui/const-generics/issues/issue-70167.stderr
@@ -1,10 +1,11 @@
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/issue-70167.rs:3:12
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
 
 warning: 1 warning emitted
 

--- a/src/test/ui/const-generics/issues/issue70273-assoc-fn.rs
+++ b/src/test/ui/const-generics/issues/issue70273-assoc-fn.rs
@@ -1,7 +1,7 @@
 // check-pass
 
 #![feature(const_generics)]
-//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+//~^ WARN the feature `const_generics` is incomplete
 
 trait T<const A: usize> {
     fn f();

--- a/src/test/ui/const-generics/issues/issue70273-assoc-fn.stderr
+++ b/src/test/ui/const-generics/issues/issue70273-assoc-fn.stderr
@@ -1,10 +1,11 @@
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/issue70273-assoc-fn.rs:3:12
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
 
 warning: 1 warning emitted
 

--- a/src/test/ui/const-generics/mut-ref-const-param-array.rs
+++ b/src/test/ui/const-generics/mut-ref-const-param-array.rs
@@ -1,7 +1,7 @@
 // run-pass
 
 #![feature(const_generics)]
-//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+//~^ WARN the feature `const_generics` is incomplete
 
 use std::ops::AddAssign;
 

--- a/src/test/ui/const-generics/mut-ref-const-param-array.stderr
+++ b/src/test/ui/const-generics/mut-ref-const-param-array.stderr
@@ -1,10 +1,11 @@
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/mut-ref-const-param-array.rs:3:12
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
 
 warning: 1 warning emitted
 

--- a/src/test/ui/const-generics/raw-ptr-const-param-deref.rs
+++ b/src/test/ui/const-generics/raw-ptr-const-param-deref.rs
@@ -1,6 +1,6 @@
 // run-pass
 #![feature(const_generics, const_compare_raw_pointers)]
-//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+//~^ WARN the feature `const_generics` is incomplete
 
 const A: u32 = 3;
 

--- a/src/test/ui/const-generics/raw-ptr-const-param-deref.stderr
+++ b/src/test/ui/const-generics/raw-ptr-const-param-deref.stderr
@@ -1,10 +1,11 @@
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/raw-ptr-const-param-deref.rs:2:12
    |
 LL | #![feature(const_generics, const_compare_raw_pointers)]
    |            ^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
 
 warning: 1 warning emitted
 

--- a/src/test/ui/const-generics/raw-ptr-const-param.rs
+++ b/src/test/ui/const-generics/raw-ptr-const-param.rs
@@ -1,5 +1,5 @@
 #![feature(const_generics, const_compare_raw_pointers)]
-//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+//~^ WARN the feature `const_generics` is incomplete
 
 struct Const<const P: *const u32>;
 

--- a/src/test/ui/const-generics/raw-ptr-const-param.stderr
+++ b/src/test/ui/const-generics/raw-ptr-const-param.stderr
@@ -1,10 +1,11 @@
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/raw-ptr-const-param.rs:1:12
    |
 LL | #![feature(const_generics, const_compare_raw_pointers)]
    |            ^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
 
 error[E0308]: mismatched types
   --> $DIR/raw-ptr-const-param.rs:7:40

--- a/src/test/ui/const-generics/slice-const-param-mismatch.rs
+++ b/src/test/ui/const-generics/slice-const-param-mismatch.rs
@@ -1,5 +1,5 @@
 #![feature(const_generics)]
-//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+//~^ WARN the feature `const_generics` is incomplete
 
 struct ConstString<const T: &'static str>;
 struct ConstBytes<const T: &'static [u8]>;

--- a/src/test/ui/const-generics/slice-const-param-mismatch.stderr
+++ b/src/test/ui/const-generics/slice-const-param-mismatch.stderr
@@ -1,10 +1,11 @@
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/slice-const-param-mismatch.rs:1:12
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
 
 error[E0308]: mismatched types
   --> $DIR/slice-const-param-mismatch.rs:9:35

--- a/src/test/ui/const-generics/slice-const-param.rs
+++ b/src/test/ui/const-generics/slice-const-param.rs
@@ -1,7 +1,7 @@
 // run-pass
 
 #![feature(const_generics)]
-//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+//~^ WARN the feature `const_generics` is incomplete
 
 pub fn function_with_str<const STRING: &'static str>() -> &'static str {
     STRING

--- a/src/test/ui/const-generics/slice-const-param.stderr
+++ b/src/test/ui/const-generics/slice-const-param.stderr
@@ -1,10 +1,11 @@
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/slice-const-param.rs:3:12
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
 
 warning: 1 warning emitted
 

--- a/src/test/ui/const-generics/struct-with-invalid-const-param.rs
+++ b/src/test/ui/const-generics/struct-with-invalid-const-param.rs
@@ -1,5 +1,5 @@
 #![feature(const_generics)]
-//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+//~^ WARN the feature `const_generics` is incomplete
 
 struct S<const C: u8>(C); //~ ERROR expected type, found const parameter
 

--- a/src/test/ui/const-generics/struct-with-invalid-const-param.stderr
+++ b/src/test/ui/const-generics/struct-with-invalid-const-param.stderr
@@ -7,13 +7,14 @@ LL | struct S<const C: u8>(C);
    | |                     help: a struct with a similar name exists: `S`
    | similarly named struct `S` defined here
 
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/struct-with-invalid-const-param.rs:1:12
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
 
 error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui/const-generics/transparent-maybeunit-array-wrapper.rs
+++ b/src/test/ui/const-generics/transparent-maybeunit-array-wrapper.rs
@@ -1,7 +1,7 @@
 // run-pass
 
 #![feature(const_generics)]
-//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+//~^ WARN the feature `const_generics` is incomplete
 
 use std::mem::MaybeUninit;
 

--- a/src/test/ui/const-generics/transparent-maybeunit-array-wrapper.stderr
+++ b/src/test/ui/const-generics/transparent-maybeunit-array-wrapper.stderr
@@ -1,10 +1,11 @@
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/transparent-maybeunit-array-wrapper.rs:3:12
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
 
 warning: 1 warning emitted
 

--- a/src/test/ui/const-generics/type_of_anon_const.rs
+++ b/src/test/ui/const-generics/type_of_anon_const.rs
@@ -1,7 +1,7 @@
 // run-pass
 
 #![feature(const_generics)]
-//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+//~^ WARN the feature `const_generics` is incomplete
 
 trait T<const A: usize> {
     fn l<const N: bool>() -> usize;

--- a/src/test/ui/const-generics/type_of_anon_const.stderr
+++ b/src/test/ui/const-generics/type_of_anon_const.stderr
@@ -1,10 +1,11 @@
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/type_of_anon_const.rs:3:12
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
 
 warning: 1 warning emitted
 

--- a/src/test/ui/const-generics/types-mismatch-const-args.rs
+++ b/src/test/ui/const-generics/types-mismatch-const-args.rs
@@ -1,5 +1,5 @@
 #![feature(const_generics)]
-//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+//~^ WARN the feature `const_generics` is incomplete
 
 // tests the diagnostic output of type mismatches for types that have const generics arguments.
 

--- a/src/test/ui/const-generics/types-mismatch-const-args.stderr
+++ b/src/test/ui/const-generics/types-mismatch-const-args.stderr
@@ -1,10 +1,11 @@
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/types-mismatch-const-args.rs:1:12
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
 
 error[E0308]: mismatched types
   --> $DIR/types-mismatch-const-args.rs:13:41

--- a/src/test/ui/const-generics/uninferred-consts-during-codegen-1.rs
+++ b/src/test/ui/const-generics/uninferred-consts-during-codegen-1.rs
@@ -1,7 +1,7 @@
 // run-pass
 
 #![feature(const_generics)]
-//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+//~^ WARN the feature `const_generics` is incomplete
 
 use std::fmt;
 

--- a/src/test/ui/const-generics/uninferred-consts-during-codegen-1.stderr
+++ b/src/test/ui/const-generics/uninferred-consts-during-codegen-1.stderr
@@ -1,10 +1,11 @@
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/uninferred-consts-during-codegen-1.rs:3:12
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
 
 warning: 1 warning emitted
 

--- a/src/test/ui/const-generics/uninferred-consts-during-codegen-2.rs
+++ b/src/test/ui/const-generics/uninferred-consts-during-codegen-2.rs
@@ -1,7 +1,7 @@
 // run-pass
 
 #![feature(const_generics)]
-//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+//~^ WARN the feature `const_generics` is incomplete
 
 use std::fmt;
 

--- a/src/test/ui/const-generics/uninferred-consts-during-codegen-2.stderr
+++ b/src/test/ui/const-generics/uninferred-consts-during-codegen-2.stderr
@@ -1,10 +1,11 @@
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/uninferred-consts-during-codegen-2.rs:3:12
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
 
 warning: 1 warning emitted
 

--- a/src/test/ui/const-generics/unused-const-param.rs
+++ b/src/test/ui/const-generics/unused-const-param.rs
@@ -1,7 +1,7 @@
 // check-pass
 
 #![feature(const_generics)]
-//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+//~^ WARN the feature `const_generics` is incomplete
 
 struct A<const N: usize>; // ok
 

--- a/src/test/ui/const-generics/unused-const-param.stderr
+++ b/src/test/ui/const-generics/unused-const-param.stderr
@@ -1,10 +1,11 @@
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/unused-const-param.rs:3:12
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
 
 warning: 1 warning emitted
 

--- a/src/test/ui/const-generics/unused_braces.rs
+++ b/src/test/ui/const-generics/unused_braces.rs
@@ -2,7 +2,7 @@
 #![warn(unused_braces)]
 
 #![feature(const_generics)]
-//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+//~^ WARN the feature `const_generics` is incomplete
 
 struct A<const N: usize>;
 

--- a/src/test/ui/const-generics/unused_braces.stderr
+++ b/src/test/ui/const-generics/unused_braces.stderr
@@ -1,10 +1,11 @@
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/unused_braces.rs:4:12
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
 
 warning: unnecessary braces around const expression
   --> $DIR/unused_braces.rs:11:14

--- a/src/test/ui/error-codes/E0730.rs
+++ b/src/test/ui/error-codes/E0730.rs
@@ -1,5 +1,5 @@
 #![feature(const_generics)]
-//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+//~^ WARN the feature `const_generics` is incomplete
 
 fn is_123<const N: usize>(x: [u32; N]) -> bool {
     match x {

--- a/src/test/ui/error-codes/E0730.stderr
+++ b/src/test/ui/error-codes/E0730.stderr
@@ -1,10 +1,11 @@
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/E0730.rs:1:12
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
 
 error[E0730]: cannot pattern-match on an array without a fixed length
   --> $DIR/E0730.rs:6:9

--- a/src/test/ui/generic-associated-types/gat-incomplete-warning.stderr
+++ b/src/test/ui/generic-associated-types/gat-incomplete-warning.stderr
@@ -1,10 +1,11 @@
-warning: the feature `generic_associated_types` is incomplete and may cause the compiler to crash
+warning: the feature `generic_associated_types` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/gat-incomplete-warning.rs:3:12
    |
 LL | #![feature(generic_associated_types)]
    |            ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44265 <https://github.com/rust-lang/rust/issues/44265> for more information
 
 warning: 1 warning emitted
 

--- a/src/test/ui/hygiene/generic_params.stderr
+++ b/src/test/ui/hygiene/generic_params.stderr
@@ -1,10 +1,11 @@
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/generic_params.rs:6:37
    |
 LL | #![feature(decl_macro, rustc_attrs, const_generics)]
    |                                     ^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
 
 warning: 1 warning emitted
 

--- a/src/test/ui/hygiene/issue-61574-const-parameters.stderr
+++ b/src/test/ui/hygiene/issue-61574-const-parameters.stderr
@@ -1,10 +1,11 @@
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/issue-61574-const-parameters.rs:6:12
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
 
 warning: 1 warning emitted
 

--- a/src/test/ui/if-attrs/let-chains-attr.stderr
+++ b/src/test/ui/if-attrs/let-chains-attr.stderr
@@ -1,10 +1,11 @@
-warning: the feature `let_chains` is incomplete and may cause the compiler to crash
+warning: the feature `let_chains` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/let-chains-attr.rs:3:12
    |
 LL | #![feature(let_chains)]
    |            ^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
 
 warning: 1 warning emitted
 

--- a/src/test/ui/impl-trait-in-bindings.rs
+++ b/src/test/ui/impl-trait-in-bindings.rs
@@ -1,7 +1,7 @@
 // run-pass
 
 #![feature(impl_trait_in_bindings)]
-//~^ WARN the feature `impl_trait_in_bindings` is incomplete and may cause the compiler to crash
+//~^ WARN the feature `impl_trait_in_bindings` is incomplete
 
 use std::fmt::Debug;
 

--- a/src/test/ui/impl-trait-in-bindings.stderr
+++ b/src/test/ui/impl-trait-in-bindings.stderr
@@ -1,10 +1,11 @@
-warning: the feature `impl_trait_in_bindings` is incomplete and may cause the compiler to crash
+warning: the feature `impl_trait_in_bindings` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/impl-trait-in-bindings.rs:3:12
    |
 LL | #![feature(impl_trait_in_bindings)]
    |            ^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #63065 <https://github.com/rust-lang/rust/issues/63065> for more information
 
 warning: 1 warning emitted
 

--- a/src/test/ui/impl-trait/bindings-opaque.rs
+++ b/src/test/ui/impl-trait/bindings-opaque.rs
@@ -1,5 +1,5 @@
 #![feature(impl_trait_in_bindings)]
-//~^ WARN the feature `impl_trait_in_bindings` is incomplete and may cause the compiler to crash
+//~^ WARN the feature `impl_trait_in_bindings` is incomplete
 
 const FOO: impl Copy = 42;
 

--- a/src/test/ui/impl-trait/bindings-opaque.stderr
+++ b/src/test/ui/impl-trait/bindings-opaque.stderr
@@ -1,10 +1,11 @@
-warning: the feature `impl_trait_in_bindings` is incomplete and may cause the compiler to crash
+warning: the feature `impl_trait_in_bindings` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/bindings-opaque.rs:1:12
    |
 LL | #![feature(impl_trait_in_bindings)]
    |            ^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #63065 <https://github.com/rust-lang/rust/issues/63065> for more information
 
 error[E0599]: no method named `count_ones` found for opaque type `impl std::marker::Copy` in the current scope
   --> $DIR/bindings-opaque.rs:11:17

--- a/src/test/ui/impl-trait/bindings.rs
+++ b/src/test/ui/impl-trait/bindings.rs
@@ -1,5 +1,5 @@
 #![feature(impl_trait_in_bindings)]
-//~^ WARN the feature `impl_trait_in_bindings` is incomplete and may cause the compiler to crash
+//~^ WARN the feature `impl_trait_in_bindings` is incomplete
 
 fn a<T: Clone>(x: T) {
     const foo: impl Clone = x;

--- a/src/test/ui/impl-trait/bindings.stderr
+++ b/src/test/ui/impl-trait/bindings.stderr
@@ -22,13 +22,14 @@ error[E0435]: attempt to use a non-constant value in a constant
 LL |         const foo: impl Clone = x;
    |                                 ^ non-constant value
 
-warning: the feature `impl_trait_in_bindings` is incomplete and may cause the compiler to crash
+warning: the feature `impl_trait_in_bindings` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/bindings.rs:1:12
    |
 LL | #![feature(impl_trait_in_bindings)]
    |            ^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #63065 <https://github.com/rust-lang/rust/issues/63065> for more information
 
 error: aborting due to 4 previous errors; 1 warning emitted
 

--- a/src/test/ui/impl-trait/bound-normalization-fail.stderr
+++ b/src/test/ui/impl-trait/bound-normalization-fail.stderr
@@ -1,10 +1,11 @@
-warning: the feature `impl_trait_in_bindings` is incomplete and may cause the compiler to crash
+warning: the feature `impl_trait_in_bindings` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/bound-normalization-fail.rs:4:12
    |
 LL | #![feature(impl_trait_in_bindings)]
    |            ^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #63065 <https://github.com/rust-lang/rust/issues/63065> for more information
 
 error[E0271]: type mismatch resolving `<Foo<()> as FooLike>::Output == <T as impl_trait::Trait>::Assoc`
   --> $DIR/bound-normalization-fail.rs:27:32

--- a/src/test/ui/impl-trait/bound-normalization-pass.stderr
+++ b/src/test/ui/impl-trait/bound-normalization-pass.stderr
@@ -1,10 +1,11 @@
-warning: the feature `impl_trait_in_bindings` is incomplete and may cause the compiler to crash
+warning: the feature `impl_trait_in_bindings` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/bound-normalization-pass.rs:5:12
    |
 LL | #![feature(impl_trait_in_bindings)]
    |            ^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #63065 <https://github.com/rust-lang/rust/issues/63065> for more information
 
 warning: 1 warning emitted
 

--- a/src/test/ui/inference/cannot-infer-async-enabled-impl-trait-bindings.rs
+++ b/src/test/ui/inference/cannot-infer-async-enabled-impl-trait-bindings.rs
@@ -1,6 +1,6 @@
 // edition:2018
 #![feature(impl_trait_in_bindings)]
-//~^ WARN the feature `impl_trait_in_bindings` is incomplete and may cause the compiler to crash
+//~^ WARN the feature `impl_trait_in_bindings` is incomplete
 
 use std::io::Error;
 

--- a/src/test/ui/inference/cannot-infer-async-enabled-impl-trait-bindings.stderr
+++ b/src/test/ui/inference/cannot-infer-async-enabled-impl-trait-bindings.stderr
@@ -1,10 +1,11 @@
-warning: the feature `impl_trait_in_bindings` is incomplete and may cause the compiler to crash
+warning: the feature `impl_trait_in_bindings` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/cannot-infer-async-enabled-impl-trait-bindings.rs:2:12
    |
 LL | #![feature(impl_trait_in_bindings)]
    |            ^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #63065 <https://github.com/rust-lang/rust/issues/63065> for more information
 
 error[E0282]: type annotations needed for `impl std::future::Future`
   --> $DIR/cannot-infer-async-enabled-impl-trait-bindings.rs:13:9

--- a/src/test/ui/issues/issue-59508-1.rs
+++ b/src/test/ui/issues/issue-59508-1.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 #![feature(const_generics)]
-//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+//~^ WARN the feature `const_generics` is incomplete
 
 // This test checks that generic parameter re-ordering diagnostic suggestions mention that
 // consts come after types and lifetimes when the `const_generics` feature is enabled.

--- a/src/test/ui/issues/issue-59508-1.stderr
+++ b/src/test/ui/issues/issue-59508-1.stderr
@@ -4,13 +4,14 @@ error: lifetime parameters must be declared prior to type parameters
 LL |     pub fn do_things<T, 'a, 'b: 'a>() {
    |                     ----^^--^^----- help: reorder the parameters: lifetimes, then types, then consts: `<'a, 'b: 'a, T>`
 
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/issue-59508-1.rs:2:12
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
 
 error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui/optimization-fuel-0.rs
+++ b/src/test/ui/optimization-fuel-0.rs
@@ -4,8 +4,7 @@
 
 use std::mem::size_of;
 
-// (#55495: The --error-format is to sidestep an issue in our test harness)
-// compile-flags: --error-format human -Z fuel=foo=0
+// compile-flags: -Z fuel=foo=0
 
 struct S1(u8, u16, u8);
 struct S2(u8, u16, u8);

--- a/src/test/ui/optimization-fuel-0.stderr
+++ b/src/test/ui/optimization-fuel-0.stderr
@@ -1,1 +1,4 @@
-optimization-fuel-exhausted: Reorder fields of "S1"
+warning: optimization-fuel-exhausted: Reorder fields of "S1"
+
+warning: 1 warning emitted
+

--- a/src/test/ui/optimization-fuel-1.rs
+++ b/src/test/ui/optimization-fuel-1.rs
@@ -4,8 +4,7 @@
 
 use std::mem::size_of;
 
-// (#55495: The --error-format is to sidestep an issue in our test harness)
-// compile-flags: --error-format human -Z fuel=foo=1
+// compile-flags: -Z fuel=foo=1
 
 struct S1(u8, u16, u8);
 struct S2(u8, u16, u8);

--- a/src/test/ui/optimization-fuel-1.stderr
+++ b/src/test/ui/optimization-fuel-1.stderr
@@ -1,1 +1,4 @@
-optimization-fuel-exhausted: Reorder fields of "S2"
+warning: optimization-fuel-exhausted: Reorder fields of "S2"
+
+warning: 1 warning emitted
+

--- a/src/test/ui/parser/impl-item-type-no-body-semantic-fail.stderr
+++ b/src/test/ui/parser/impl-item-type-no-body-semantic-fail.stderr
@@ -42,13 +42,14 @@ LL |     type W where Self: Eq;
    |                          |
    |                          help: provide a definition for the type: `= <type>;`
 
-warning: the feature `generic_associated_types` is incomplete and may cause the compiler to crash
+warning: the feature `generic_associated_types` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/impl-item-type-no-body-semantic-fail.rs:1:12
    |
 LL | #![feature(generic_associated_types)]
    |            ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44265 <https://github.com/rust-lang/rust/issues/44265> for more information
 
 error[E0202]: associated types are not yet supported in inherent impls (see #8995)
   --> $DIR/impl-item-type-no-body-semantic-fail.rs:9:5

--- a/src/test/ui/resolve/issue-65035-static-with-parent-generics.rs
+++ b/src/test/ui/resolve/issue-65035-static-with-parent-generics.rs
@@ -1,5 +1,5 @@
 #![feature(const_generics)]
-//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+//~^ WARN the feature `const_generics` is incomplete
 
 fn f<T>() {
     extern "C" {

--- a/src/test/ui/resolve/issue-65035-static-with-parent-generics.stderr
+++ b/src/test/ui/resolve/issue-65035-static-with-parent-generics.stderr
@@ -40,13 +40,14 @@ LL | fn i<const N: usize>() {
 LL |     static a: [u8; N] = [0; N];
    |                             ^ use of generic parameter from outer function
 
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/issue-65035-static-with-parent-generics.rs:1:12
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
 
 error: aborting due to 5 previous errors; 1 warning emitted
 

--- a/src/test/ui/rfc-2497-if-let-chains/disallowed-positions.stderr
+++ b/src/test/ui/rfc-2497-if-let-chains/disallowed-positions.stderr
@@ -499,19 +499,22 @@ LL |         true && let 1 = 1
    = note: only supported directly in conditions of `if`- and `while`-expressions
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/disallowed-positions.rs:20:12
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
 
-warning: the feature `let_chains` is incomplete and may cause the compiler to crash
+warning: the feature `let_chains` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/disallowed-positions.rs:22:12
    |
 LL | #![feature(let_chains)] // Avoid inflating `.stderr` with overzealous gates in this test.
    |            ^^^^^^^^^^
+   |
+   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
 
 error[E0658]: `match` is not allowed in a `const`
   --> $DIR/disallowed-positions.rs:218:17

--- a/src/test/ui/rfc-2627-raw-dylib/link-ordinal-and-name.rs
+++ b/src/test/ui/rfc-2627-raw-dylib/link-ordinal-and-name.rs
@@ -1,5 +1,5 @@
 #![feature(raw_dylib)]
-//~^ WARN the feature `raw_dylib` is incomplete and may cause the compiler to crash
+//~^ WARN the feature `raw_dylib` is incomplete
 
 #[link(name="foo")]
 extern {

--- a/src/test/ui/rfc-2627-raw-dylib/link-ordinal-and-name.stderr
+++ b/src/test/ui/rfc-2627-raw-dylib/link-ordinal-and-name.stderr
@@ -1,10 +1,11 @@
-warning: the feature `raw_dylib` is incomplete and may cause the compiler to crash
+warning: the feature `raw_dylib` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/link-ordinal-and-name.rs:1:12
    |
 LL | #![feature(raw_dylib)]
    |            ^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #58713 <https://github.com/rust-lang/rust/issues/58713> for more information
 
 error: cannot use `#[link_name]` with `#[link_ordinal]`
   --> $DIR/link-ordinal-and-name.rs:7:5

--- a/src/test/ui/rfc-2627-raw-dylib/link-ordinal-invalid-format.rs
+++ b/src/test/ui/rfc-2627-raw-dylib/link-ordinal-invalid-format.rs
@@ -1,5 +1,5 @@
 #![feature(raw_dylib)]
-//~^ WARN the feature `raw_dylib` is incomplete and may cause the compiler to crash
+//~^ WARN the feature `raw_dylib` is incomplete
 
 #[link(name="foo")]
 extern {

--- a/src/test/ui/rfc-2627-raw-dylib/link-ordinal-invalid-format.stderr
+++ b/src/test/ui/rfc-2627-raw-dylib/link-ordinal-invalid-format.stderr
@@ -1,10 +1,11 @@
-warning: the feature `raw_dylib` is incomplete and may cause the compiler to crash
+warning: the feature `raw_dylib` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/link-ordinal-invalid-format.rs:1:12
    |
 LL | #![feature(raw_dylib)]
    |            ^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #58713 <https://github.com/rust-lang/rust/issues/58713> for more information
 
 error: illegal ordinal format in `link_ordinal`
   --> $DIR/link-ordinal-invalid-format.rs:6:5

--- a/src/test/ui/rfc-2627-raw-dylib/link-ordinal-too-large.rs
+++ b/src/test/ui/rfc-2627-raw-dylib/link-ordinal-too-large.rs
@@ -1,5 +1,5 @@
 #![feature(raw_dylib)]
-//~^ WARN the feature `raw_dylib` is incomplete and may cause the compiler to crash
+//~^ WARN the feature `raw_dylib` is incomplete
 
 #[link(name="foo")]
 extern {

--- a/src/test/ui/rfc-2627-raw-dylib/link-ordinal-too-large.stderr
+++ b/src/test/ui/rfc-2627-raw-dylib/link-ordinal-too-large.stderr
@@ -1,10 +1,11 @@
-warning: the feature `raw_dylib` is incomplete and may cause the compiler to crash
+warning: the feature `raw_dylib` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/link-ordinal-too-large.rs:1:12
    |
 LL | #![feature(raw_dylib)]
    |            ^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #58713 <https://github.com/rust-lang/rust/issues/58713> for more information
 
 error: ordinal value in `link_ordinal` is too large: `18446744073709551616`
   --> $DIR/link-ordinal-too-large.rs:6:5

--- a/src/test/ui/type-alias-impl-trait/assoc-type-const.rs
+++ b/src/test/ui/type-alias-impl-trait/assoc-type-const.rs
@@ -4,7 +4,7 @@
 
 #![feature(type_alias_impl_trait)]
 #![feature(const_generics)]
-//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+//~^ WARN the feature `const_generics` is incomplete
 
 trait UnwrapItemsExt<'a, const C: usize> {
     type Iter;

--- a/src/test/ui/type-alias-impl-trait/assoc-type-const.stderr
+++ b/src/test/ui/type-alias-impl-trait/assoc-type-const.stderr
@@ -1,10 +1,11 @@
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/assoc-type-const.rs:6:12
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
 
 warning: 1 warning emitted
 

--- a/src/test/ui/type-alias-impl-trait/type-alias-impl-trait-const.rs
+++ b/src/test/ui/type-alias-impl-trait/type-alias-impl-trait-const.rs
@@ -6,7 +6,7 @@
 // Specifically, this line requires `impl_trait_in_bindings` to be enabled:
 // https://github.com/rust-lang/rust/blob/481068a707679257e2a738b40987246e0420e787/src/librustc_typeck/check/mod.rs#L856
 #![feature(impl_trait_in_bindings)]
-//~^ WARN the feature `impl_trait_in_bindings` is incomplete and may cause the compiler to crash
+//~^ WARN the feature `impl_trait_in_bindings` is incomplete
 
 // Ensures that `const` items can constrain an opaque `impl Trait`.
 

--- a/src/test/ui/type-alias-impl-trait/type-alias-impl-trait-const.stderr
+++ b/src/test/ui/type-alias-impl-trait/type-alias-impl-trait-const.stderr
@@ -1,10 +1,11 @@
-warning: the feature `impl_trait_in_bindings` is incomplete and may cause the compiler to crash
+warning: the feature `impl_trait_in_bindings` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/type-alias-impl-trait-const.rs:8:12
    |
 LL | #![feature(impl_trait_in_bindings)]
    |            ^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #63065 <https://github.com/rust-lang/rust/issues/63065> for more information
 
 warning: 1 warning emitted
 


### PR DESCRIPTION
Successful merges:

 - #72014 (Deprecated emoji)
 - #72044 (use min_specialization for some rustc crates where it requires no changes)
 - #72045 (Incomplete features can also be unsound)
 - #72052 (display `ConstKind::Param`)
 - #72067 (Emit a warning when optimization fuel runs out)
 - #72072 (doc: minus (U+2212) instead of dash (U+002D) for negative infinity)
 - #72077 (Improve E0571 wording)

Failed merges:


r? @ghost