### PR TITLE
Fix clippy warnings

### DIFF
--- a/src/librustc_attr/builtin.rs
+++ b/src/librustc_attr/builtin.rs
@@ -634,7 +634,7 @@ pub fn eval_condition(
                 [NestedMetaItem::Literal(Lit { span, .. })
                 | NestedMetaItem::MetaItem(MetaItem { span, .. })] => {
                     sess.span_diagnostic
-                        .struct_span_err(*span, &*format!("expected a version literal"))
+                        .struct_span_err(*span, "expected a version literal")
                         .emit();
                     return false;
                 }

--- a/src/librustc_data_structures/tiny_list.rs
+++ b/src/librustc_data_structures/tiny_list.rs
@@ -52,7 +52,7 @@ impl<T: PartialEq> TinyList<T> {
             if &e.data == data {
                 return true;
             }
-            elem = e.next.as_ref().map(|e| &**e);
+            elem = e.next.as_deref();
         }
         false
     }
@@ -62,7 +62,7 @@ impl<T: PartialEq> TinyList<T> {
         let (mut elem, mut count) = (self.head.as_ref(), 0);
         while let Some(ref e) = elem {
             count += 1;
-            elem = e.next.as_ref().map(|e| &**e);
+            elem = e.next.as_deref();
         }
         count
     }

--- a/src/librustc_infer/traits/util.rs
+++ b/src/librustc_infer/traits/util.rs
@@ -112,8 +112,7 @@ pub fn elaborate_predicates<'tcx>(
     tcx: TyCtxt<'tcx>,
     predicates: impl Iterator<Item = ty::Predicate<'tcx>>,
 ) -> Elaborator<'tcx> {
-    let obligations =
-        predicates.into_iter().map(|predicate| predicate_obligation(predicate, None)).collect();
+    let obligations = predicates.map(|predicate| predicate_obligation(predicate, None)).collect();
     elaborate_obligations(tcx, obligations)
 }
 
@@ -149,7 +148,7 @@ impl Elaborator<'tcx> {
                 // Get predicates declared on the trait.
                 let predicates = tcx.super_predicates_of(data.def_id());
 
-                let obligations = predicates.predicates.into_iter().map(|(pred, span)| {
+                let obligations = predicates.predicates.iter().map(|(pred, span)| {
                     predicate_obligation(
                         pred.subst_supertrait(tcx, &data.to_poly_trait_ref()),
                         Some(*span),

--- a/src/librustc_interface/queries.rs
+++ b/src/librustc_interface/queries.rs
@@ -137,7 +137,7 @@ impl<'tcx> Queries<'tcx> {
             let result = passes::register_plugins(
                 self.session(),
                 &*self.codegen_backend().metadata_loader(),
-                self.compiler.register_lints.as_ref().map(|p| &**p).unwrap_or_else(|| empty),
+                self.compiler.register_lints.as_deref().unwrap_or_else(|| empty),
                 krate,
                 &crate_name,
             );

--- a/src/librustc_middle/dep_graph/mod.rs
+++ b/src/librustc_middle/dep_graph/mod.rs
@@ -72,9 +72,9 @@ impl rustc_query_system::dep_graph::DepKind for DepKind {
         })
     }
 
-    fn read_deps<OP>(op: OP) -> ()
+    fn read_deps<OP>(op: OP)
     where
-        OP: for<'a> FnOnce(Option<&'a Lock<TaskDeps>>) -> (),
+        OP: for<'a> FnOnce(Option<&'a Lock<TaskDeps>>),
     {
         ty::tls::with_context_opt(|icx| {
             let icx = if let Some(icx) = icx { icx } else { return };

--- a/src/librustc_middle/hir/mod.rs
+++ b/src/librustc_middle/hir/mod.rs
@@ -78,7 +78,6 @@ pub fn provide(providers: &mut Providers<'_>) {
         &tcx.untracked_crate.modules[&module]
     };
     providers.hir_owner = |tcx, id| tcx.index_hir(LOCAL_CRATE).map[id].signature;
-    providers.hir_owner_nodes =
-        |tcx, id| tcx.index_hir(LOCAL_CRATE).map[id].with_bodies.as_ref().map(|nodes| &**nodes);
+    providers.hir_owner_nodes = |tcx, id| tcx.index_hir(LOCAL_CRATE).map[id].with_bodies.as_deref();
     map::provide(providers);
 }

--- a/src/librustc_middle/ty/mod.rs
+++ b/src/librustc_middle/ty/mod.rs
@@ -280,7 +280,7 @@ impl<'tcx> AssociatedItems<'tcx> {
         &self,
         name: Symbol,
     ) -> impl '_ + Iterator<Item = &ty::AssocItem> {
-        self.items.get_by_key(&name).map(|v| *v)
+        self.items.get_by_key(&name).copied()
     }
 
     /// Returns an iterator over all associated items with the given name.

--- a/src/librustc_middle/ty/trait_def.rs
+++ b/src/librustc_middle/ty/trait_def.rs
@@ -171,10 +171,7 @@ impl<'tcx> TyCtxt<'tcx> {
     pub fn all_impls(self, def_id: DefId) -> impl Iterator<Item = DefId> + 'tcx {
         let TraitImpls { blanket_impls, non_blanket_impls } = self.trait_impls_of(def_id);
 
-        blanket_impls
-            .into_iter()
-            .chain(non_blanket_impls.into_iter().map(|(_, v)| v).flatten())
-            .cloned()
+        blanket_impls.iter().chain(non_blanket_impls.iter().map(|(_, v)| v).flatten()).cloned()
     }
 }
 

--- a/src/librustc_mir_build/hair/pattern/check_match.rs
+++ b/src/librustc_mir_build/hair/pattern/check_match.rs
@@ -246,7 +246,7 @@ impl<'tcx> MatchVisitor<'_, 'tcx> {
             );
         }
 
-        adt_defined_here(&mut cx, &mut err, pattern_ty, &witnesses);
+        adt_defined_here(&cx, &mut err, pattern_ty, &witnesses);
         err.note(&format!("the matched value is of type `{}`", pattern_ty));
         err.emit();
     }

--- a/src/librustc_mir_build/hair/pattern/const_to_pat.rs
+++ b/src/librustc_mir_build/hair/pattern/const_to_pat.rs
@@ -121,7 +121,7 @@ impl<'a, 'tcx> ConstToPat<'a, 'tcx> {
                         )
                     }
                     traits::NonStructuralMatchTy::Dynamic => {
-                        format!("trait objects cannot be used in patterns")
+                        "trait objects cannot be used in patterns".to_string()
                     }
                     traits::NonStructuralMatchTy::Param => {
                         bug!("use of constant whose type is a parameter inside a pattern")

--- a/src/librustc_passes/liveness.rs
+++ b/src/librustc_passes/liveness.rs
@@ -931,7 +931,7 @@ impl<'a, 'tcx> Liveness<'a, 'tcx> {
         if blk.targeted_by_break {
             self.break_ln.insert(blk.hir_id, succ);
         }
-        let succ = self.propagate_through_opt_expr(blk.expr.as_ref().map(|e| &**e), succ);
+        let succ = self.propagate_through_opt_expr(blk.expr.as_deref(), succ);
         blk.stmts.iter().rev().fold(succ, |succ, stmt| self.propagate_through_stmt(stmt, succ))
     }
 
@@ -952,7 +952,7 @@ impl<'a, 'tcx> Liveness<'a, 'tcx> {
                 // initialization, which is mildly more complex than checking
                 // once at the func header but otherwise equivalent.
 
-                let succ = self.propagate_through_opt_expr(local.init.as_ref().map(|e| &**e), succ);
+                let succ = self.propagate_through_opt_expr(local.init.as_deref(), succ);
                 self.define_bindings_in_pat(&local.pat, succ)
             }
             hir::StmtKind::Item(..) => succ,

--- a/src/librustc_passes/region.rs
+++ b/src/librustc_passes/region.rs
@@ -797,7 +797,7 @@ impl<'tcx> Visitor<'tcx> for RegionResolutionVisitor<'tcx> {
         resolve_expr(self, ex);
     }
     fn visit_local(&mut self, l: &'tcx Local<'tcx>) {
-        resolve_local(self, Some(&l.pat), l.init.as_ref().map(|e| &**e));
+        resolve_local(self, Some(&l.pat), l.init.as_deref());
     }
 }
 

--- a/src/librustc_query_system/dep_graph/dep_node.rs
+++ b/src/librustc_query_system/dep_graph/dep_node.rs
@@ -80,7 +80,7 @@ impl<K: DepKind> DepNode<K> {
             }
         }
 
-        return dep_node;
+        dep_node
     }
 }
 

--- a/src/librustc_query_system/dep_graph/mod.rs
+++ b/src/librustc_query_system/dep_graph/mod.rs
@@ -77,9 +77,9 @@ pub trait DepKind: Copy + fmt::Debug + Eq + Ord + Hash {
         OP: FnOnce() -> R;
 
     /// Access dependencies from current implicit context.
-    fn read_deps<OP>(op: OP) -> ()
+    fn read_deps<OP>(op: OP)
     where
-        OP: for<'a> FnOnce(Option<&'a Lock<TaskDeps<Self>>>) -> ();
+        OP: for<'a> FnOnce(Option<&'a Lock<TaskDeps<Self>>>);
 
     fn can_reconstruct_query_key(&self) -> bool;
 }

--- a/src/librustc_trait_selection/traits/chalk_fulfill.rs
+++ b/src/librustc_trait_selection/traits/chalk_fulfill.rs
@@ -39,7 +39,7 @@ fn environment<'tcx>(
     let ty::InstantiatedPredicates { predicates, .. } =
         tcx.predicates_of(def_id).instantiate_identity(tcx);
 
-    let clauses = predicates.into_iter().map(|pred| ChalkEnvironmentClause::Predicate(pred));
+    let clauses = predicates.into_iter().map(ChalkEnvironmentClause::Predicate);
 
     let hir_id = tcx.hir().as_local_hir_id(def_id.expect_local());
     let node = tcx.hir().get(hir_id);
@@ -224,7 +224,7 @@ impl TraitEngine<'tcx> for FulfillmentContext<'tcx> {
                                 ),
 
                                 Err(_err) => errors.push(FulfillmentError {
-                                    obligation: obligation,
+                                    obligation,
                                     code: FulfillmentErrorCode::CodeSelectionError(
                                         SelectionError::Unimplemented,
                                     ),
@@ -238,7 +238,7 @@ impl TraitEngine<'tcx> for FulfillmentContext<'tcx> {
                     }
 
                     Err(NoSolution) => errors.push(FulfillmentError {
-                        obligation: obligation,
+                        obligation,
                         code: FulfillmentErrorCode::CodeSelectionError(
                             SelectionError::Unimplemented,
                         ),
@@ -257,6 +257,6 @@ impl TraitEngine<'tcx> for FulfillmentContext<'tcx> {
     }
 
     fn pending_obligations(&self) -> Vec<PredicateObligation<'tcx>> {
-        self.obligations.iter().map(|obligation| obligation.clone()).collect()
+        self.obligations.iter().cloned().collect()
     }
 }

--- a/src/librustc_trait_selection/traits/error_reporting/suggestions.rs
+++ b/src/librustc_trait_selection/traits/error_reporting/suggestions.rs
@@ -1854,7 +1854,7 @@ impl NextTypeParamName for &[hir::GenericParam<'_>] {
     fn next_type_param_name(&self, name: Option<&str>) -> String {
         // This is the whitelist of possible parameter names that we might suggest.
         let name = name.and_then(|n| n.chars().next()).map(|c| c.to_string().to_uppercase());
-        let name = name.as_ref().map(|s| s.as_str());
+        let name = name.as_deref();
         let possible_names = [name.unwrap_or("T"), "T", "U", "V", "X", "Y", "Z", "A", "B", "C"];
         let used_names = self
             .iter()

--- a/src/librustc_traits/chalk/db.rs
+++ b/src/librustc_traits/chalk/db.rs
@@ -59,7 +59,7 @@ impl<'tcx> chalk_solve::RustIrDatabase<RustInterner<'tcx>> for RustIrDatabase<'t
         // clauses or bounds?
         let predicates = self.tcx.predicates_defined_on(def_id).predicates;
         let where_clauses: Vec<_> = predicates
-            .into_iter()
+            .iter()
             .map(|(wc, _)| wc.subst(self.tcx, &bound_vars))
             .filter_map(|wc| LowerInto::<Option<chalk_ir::QuantifiedWhereClause<RustInterner<'tcx>>>>::lower_into(wc, &self.interner)).collect();
 
@@ -88,7 +88,7 @@ impl<'tcx> chalk_solve::RustIrDatabase<RustInterner<'tcx>> for RustIrDatabase<'t
         let binders = binders_for(&self.interner, bound_vars);
         let predicates = self.tcx.predicates_defined_on(def_id).predicates;
         let where_clauses: Vec<_> = predicates
-            .into_iter()
+            .iter()
             .map(|(wc, _)| wc.subst(self.tcx, &bound_vars))
             .filter_map(|wc| LowerInto::<Option<chalk_ir::QuantifiedWhereClause<RustInterner<'tcx>>>>::lower_into(wc, &self.interner)).collect();
 
@@ -134,7 +134,7 @@ impl<'tcx> chalk_solve::RustIrDatabase<RustInterner<'tcx>> for RustIrDatabase<'t
 
                 let predicates = self.tcx.predicates_of(adt_def_id).predicates;
                 let where_clauses: Vec<_> = predicates
-                    .into_iter()
+                    .iter()
                     .map(|(wc, _)| wc.subst(self.tcx, bound_vars))
                     .filter_map(|wc| LowerInto::<Option<chalk_ir::QuantifiedWhereClause<RustInterner<'tcx>>>>::lower_into(wc, &self.interner))
                     .collect();
@@ -166,46 +166,42 @@ impl<'tcx> chalk_solve::RustIrDatabase<RustInterner<'tcx>> for RustIrDatabase<'t
                         fundamental: adt_def.is_fundamental(),
                     },
                 });
-                return struct_datum;
+                struct_datum
             }
-            RustDefId::Ref(_) => {
-                return Arc::new(chalk_rust_ir::StructDatum {
-                    id: struct_id,
-                    binders: chalk_ir::Binders::new(
-                        chalk_ir::ParameterKinds::from(
-                            &self.interner,
-                            vec![
-                                chalk_ir::ParameterKind::Lifetime(()),
-                                chalk_ir::ParameterKind::Ty(()),
-                            ],
-                        ),
-                        chalk_rust_ir::StructDatumBound { fields: vec![], where_clauses: vec![] },
+            RustDefId::Ref(_) => Arc::new(chalk_rust_ir::StructDatum {
+                id: struct_id,
+                binders: chalk_ir::Binders::new(
+                    chalk_ir::ParameterKinds::from(
+                        &self.interner,
+                        vec![
+                            chalk_ir::ParameterKind::Lifetime(()),
+                            chalk_ir::ParameterKind::Ty(()),
+                        ],
                     ),
-                    flags: chalk_rust_ir::StructFlags { upstream: false, fundamental: false },
-                });
-            }
-            RustDefId::Array | RustDefId::Slice => {
-                return Arc::new(chalk_rust_ir::StructDatum {
-                    id: struct_id,
-                    binders: chalk_ir::Binders::new(
-                        chalk_ir::ParameterKinds::from(
-                            &self.interner,
-                            Some(chalk_ir::ParameterKind::Ty(())),
-                        ),
-                        chalk_rust_ir::StructDatumBound { fields: vec![], where_clauses: vec![] },
+                    chalk_rust_ir::StructDatumBound { fields: vec![], where_clauses: vec![] },
+                ),
+                flags: chalk_rust_ir::StructFlags { upstream: false, fundamental: false },
+            }),
+            RustDefId::Array | RustDefId::Slice => Arc::new(chalk_rust_ir::StructDatum {
+                id: struct_id,
+                binders: chalk_ir::Binders::new(
+                    chalk_ir::ParameterKinds::from(
+                        &self.interner,
+                        Some(chalk_ir::ParameterKind::Ty(())),
                     ),
-                    flags: chalk_rust_ir::StructFlags { upstream: false, fundamental: false },
-                });
-            }
+                    chalk_rust_ir::StructDatumBound { fields: vec![], where_clauses: vec![] },
+                ),
+                flags: chalk_rust_ir::StructFlags { upstream: false, fundamental: false },
+            }),
             RustDefId::Str | RustDefId::Never | RustDefId::FnDef(_) => {
-                return Arc::new(chalk_rust_ir::StructDatum {
+                Arc::new(chalk_rust_ir::StructDatum {
                     id: struct_id,
                     binders: chalk_ir::Binders::new(
                         chalk_ir::ParameterKinds::new(&self.interner),
                         chalk_rust_ir::StructDatumBound { fields: vec![], where_clauses: vec![] },
                     ),
                     flags: chalk_rust_ir::StructFlags { upstream: false, fundamental: false },
-                });
+                })
             }
 
             _ => bug!("Used not struct variant when expecting struct variant."),
@@ -228,7 +224,7 @@ impl<'tcx> chalk_solve::RustIrDatabase<RustInterner<'tcx>> for RustIrDatabase<'t
 
         let predicates = self.tcx.predicates_of(def_id).predicates;
         let where_clauses: Vec<_> = predicates
-            .into_iter()
+            .iter()
             .map(|(wc, _)| wc.subst(self.tcx, bound_vars))
             .filter_map(|wc| LowerInto::<Option<chalk_ir::QuantifiedWhereClause<RustInterner<'tcx>>>>::lower_into(wc, &self.interner)).collect();
 
@@ -260,7 +256,7 @@ impl<'tcx> chalk_solve::RustIrDatabase<RustInterner<'tcx>> for RustIrDatabase<'t
         // not there yet.
 
         let all_impls = self.tcx.all_impls(def_id);
-        let matched_impls = all_impls.into_iter().filter(|impl_def_id| {
+        let matched_impls = all_impls.filter(|impl_def_id| {
             use chalk_ir::could_match::CouldMatch;
             let trait_ref = self.tcx.impl_trait_ref(*impl_def_id).unwrap();
             let bound_vars = bound_vars_for_item(self.tcx, *impl_def_id);
@@ -304,7 +300,7 @@ impl<'tcx> chalk_solve::RustIrDatabase<RustInterner<'tcx>> for RustIrDatabase<'t
                 _ => {}
             }
         }
-        return false;
+        false
     }
 
     fn associated_ty_value(
@@ -379,7 +375,7 @@ impl<'tcx> chalk_solve::RustIrDatabase<RustInterner<'tcx>> for RustIrDatabase<'t
                                     ty::AdtKind::Struct | ty::AdtKind::Union => None,
                                     ty::AdtKind::Enum => {
                                         let constraint = self.tcx.adt_sized_constraint(adt_def_id);
-                                        if constraint.0.len() > 0 {
+                                        if !constraint.0.is_empty() {
                                             unimplemented!()
                                         } else {
                                             Some(true)
@@ -412,7 +408,7 @@ impl<'tcx> chalk_solve::RustIrDatabase<RustInterner<'tcx>> for RustIrDatabase<'t
                                     ty::AdtKind::Struct | ty::AdtKind::Union => None,
                                     ty::AdtKind::Enum => {
                                         let constraint = self.tcx.adt_sized_constraint(adt_def_id);
-                                        if constraint.0.len() > 0 {
+                                        if !constraint.0.is_empty() {
                                             unimplemented!()
                                         } else {
                                             Some(true)

--- a/src/librustc_traits/chalk/lowering.rs
+++ b/src/librustc_traits/chalk/lowering.rs
@@ -274,7 +274,7 @@ impl<'tcx> LowerInto<'tcx, chalk_ir::Ty<RustInterner<'tcx>>> for Ty<'tcx> {
         let uint = |i| apply(chalk_ir::TypeName::Scalar(chalk_ir::Scalar::Uint(i)), empty());
         let float = |f| apply(chalk_ir::TypeName::Scalar(chalk_ir::Scalar::Float(f)), empty());
 
-        return match self.kind {
+        match self.kind {
             Bool => apply(chalk_ir::TypeName::Scalar(chalk_ir::Scalar::Bool), empty()),
             Char => apply(chalk_ir::TypeName::Scalar(chalk_ir::Scalar::Char), empty()),
             Int(ty) => match ty {
@@ -370,7 +370,7 @@ impl<'tcx> LowerInto<'tcx, chalk_ir::Ty<RustInterner<'tcx>>> for Ty<'tcx> {
             .intern(interner),
             Infer(_infer) => unimplemented!(),
             Error => unimplemented!(),
-        };
+        }
     }
 }
 

--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -447,7 +447,7 @@ impl Options {
             None => return Err(3),
         };
 
-        match matches.opt_str("r").as_ref().map(|s| &**s) {
+        match matches.opt_str("r").as_deref() {
             Some("rust") | None => {}
             Some(s) => {
                 diag.struct_err(&format!("unknown input format: {}", s)).emit();

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -129,7 +129,7 @@ impl<'tcx> DocContext<'tcx> {
         );
 
         MAX_DEF_ID.with(|m| {
-            m.borrow_mut().entry(def_id.krate.clone()).or_insert(start_def_id);
+            m.borrow_mut().entry(def_id.krate).or_insert(start_def_id);
         });
 
         self.all_fake_def_ids.borrow_mut().insert(def_id);

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -796,7 +796,7 @@ themePicker.onblur = handleThemeButtonsBlur;
         if path.exists() {
             for line in BufReader::new(File::open(path)?).lines() {
                 let line = line?;
-                if !line.starts_with("\"") {
+                if !line.starts_with('"') {
                     continue;
                 }
                 if line.starts_with(&format!("\"{}\"", krate)) {
@@ -810,8 +810,7 @@ themePicker.onblur = handleThemeButtonsBlur;
                 }
                 krates.push(
                     line.split('"')
-                        .filter(|s| !s.is_empty())
-                        .next()
+                        .find(|s| !s.is_empty())
                         .map(|s| s.to_owned())
                         .unwrap_or_else(String::new),
                 );

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -255,8 +255,7 @@ fn run_test(
 
     let rustc_binary = options
         .test_builder
-        .as_ref()
-        .map(|v| &**v)
+        .as_deref()
         .unwrap_or_else(|| rustc_interface::util::rustc_path().expect("found rustc"));
     let mut compiler = Command::new(&rustc_binary);
     compiler.arg("--crate-type").arg("bin");

--- a/src/libstd/thread/mod.rs
+++ b/src/libstd/thread/mod.rs
@@ -1272,7 +1272,7 @@ impl Thread {
     }
 
     fn cname(&self) -> Option<&CStr> {
-        self.inner.name.as_ref().map(|s| &**s)
+        self.inner.name.as_deref()
     }
 }
 

--- a/src/libtest/cli.rs
+++ b/src/libtest/cli.rs
@@ -331,7 +331,7 @@ fn get_format(
     quiet: bool,
     allow_unstable: bool,
 ) -> OptPartRes<OutputFormat> {
-    let format = match matches.opt_str("format").as_ref().map(|s| &**s) {
+    let format = match matches.opt_str("format").as_deref() {
         None if quiet => OutputFormat::Terse,
         Some("pretty") | None => OutputFormat::Pretty,
         Some("terse") => OutputFormat::Terse,
@@ -355,7 +355,7 @@ fn get_format(
 }
 
 fn get_color_config(matches: &getopts::Matches) -> OptPartRes<ColorConfig> {
-    let color = match matches.opt_str("color").as_ref().map(|s| &**s) {
+    let color = match matches.opt_str("color").as_deref() {
         Some("auto") | None => ColorConfig::AutoColor,
         Some("always") => ColorConfig::AlwaysColor,
         Some("never") => ColorConfig::NeverColor,


### PR DESCRIPTION
Fixes clippy::{cone_on_copy, filter_next, redundant_closure, single_char_pattern, len_zero,redundant_field_names, useless_format, identity_conversion, map_clone, into_iter_on_ref, needless_return, option_as_ref_deref, unused_unit, unnecessary_mut_passed}

r? @Dylan-DPC 