### PR TITLE
Update the Fuchsia linker defaults

### DIFF
--- a/src/librustc_target/spec/fuchsia_base.rs
+++ b/src/librustc_target/spec/fuchsia_base.rs
@@ -9,7 +9,14 @@ pub fn opts() -> TargetOptions {
             "--eh-frame-hdr".to_string(),
             "--hash-style=gnu".to_string(),
             "-z".to_string(),
+            "max-page-size=4096".to_string(),
+            "-z".to_string(),
+            "now".to_string(),
+            "-z".to_string(),
             "rodynamic".to_string(),
+            "-z".to_string(),
+            "separate-loadable-segments".to_string(),
+            "--pack-dyn-relocs=relr".to_string(),
         ],
     );
 


### PR DESCRIPTION
This updates the linker defaults aligning them with Clang. Specifically,
we use 4K pages on all platforms, we always use BIND_NOW, we prefer all
loadable segments be separate and page aligned, and we support RELR
relocations.