### PR TITLE
Rollup of 10 pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
       CI_JOB_NAME: "${{ matrix.name }}"
       SCCACHE_BUCKET: rust-lang-gha-caches
       TOOLSTATE_REPO: "https://github.com/pietroalbini/rust-toolstate"
+      CACHE_DOMAIN: ci-caches-gha.rust-lang.org
     if: "github.event_name == 'pull_request'"
     strategy:
       matrix:
@@ -146,6 +147,7 @@ jobs:
       TOOLSTATE_PUBLISH: 1
       CACHES_AWS_ACCESS_KEY_ID: AKIA46X5W6CZOMUQATD5
       ARTIFACTS_AWS_ACCESS_KEY_ID: AKIA46X5W6CZH5AYXDVF
+      CACHE_DOMAIN: ci-caches-gha.rust-lang.org
     if: "github.event_name == 'push' && github.ref == 'refs/heads/try' && github.repository == 'rust-lang-ci/rust'"
     strategy:
       matrix:
@@ -255,6 +257,7 @@ jobs:
       TOOLSTATE_PUBLISH: 1
       CACHES_AWS_ACCESS_KEY_ID: AKIA46X5W6CZOMUQATD5
       ARTIFACTS_AWS_ACCESS_KEY_ID: AKIA46X5W6CZH5AYXDVF
+      CACHE_DOMAIN: ci-caches-gha.rust-lang.org
     if: "github.event_name == 'push' && github.ref == 'refs/heads/auto' && github.repository == 'rust-lang-ci/rust'"
     strategy:
       matrix:
@@ -606,6 +609,7 @@ jobs:
       TOOLSTATE_PUBLISH: 1
       CACHES_AWS_ACCESS_KEY_ID: AKIA46X5W6CZOMUQATD5
       ARTIFACTS_AWS_ACCESS_KEY_ID: AKIA46X5W6CZH5AYXDVF
+      CACHE_DOMAIN: ci-caches-gha.rust-lang.org
     if: "github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository == 'rust-lang-ci/rust'"
     steps:
       - name: checkout the source code

--- a/src/ci/github-actions/ci.yml
+++ b/src/ci/github-actions/ci.yml
@@ -37,6 +37,7 @@ x--expand-yaml-anchors--remove:
   - &public-variables
     SCCACHE_BUCKET: rust-lang-gha-caches
     TOOLSTATE_REPO: https://github.com/pietroalbini/rust-toolstate
+    CACHE_DOMAIN: ci-caches-gha.rust-lang.org
 
   - &prod-variables
     SCCACHE_BUCKET: rust-lang-gha-caches
@@ -51,6 +52,7 @@ x--expand-yaml-anchors--remove:
     # (caches, artifacts...).
     CACHES_AWS_ACCESS_KEY_ID: AKIA46X5W6CZOMUQATD5
     ARTIFACTS_AWS_ACCESS_KEY_ID: AKIA46X5W6CZH5AYXDVF
+    CACHE_DOMAIN: ci-caches-gha.rust-lang.org
 
   - &base-job
     env: {}

--- a/src/libcore/num/f32.rs
+++ b/src/libcore/num/f32.rs
@@ -367,7 +367,7 @@ impl f32 {
     /// Infinity (∞).
     #[stable(feature = "assoc_int_consts", since = "1.43.0")]
     pub const INFINITY: f32 = 1.0_f32 / 0.0_f32;
-    /// Negative infinity (-∞).
+    /// Negative infinity (−∞).
     #[stable(feature = "assoc_int_consts", since = "1.43.0")]
     pub const NEG_INFINITY: f32 = -1.0_f32 / 0.0_f32;
 

--- a/src/libcore/num/f64.rs
+++ b/src/libcore/num/f64.rs
@@ -366,7 +366,7 @@ impl f64 {
     /// Infinity (∞).
     #[stable(feature = "assoc_int_consts", since = "1.43.0")]
     pub const INFINITY: f64 = 1.0_f64 / 0.0_f64;
-    /// Negative infinity (-∞).
+    /// Negative infinity (−∞).
     #[stable(feature = "assoc_int_consts", since = "1.43.0")]
     pub const NEG_INFINITY: f64 = -1.0_f64 / 0.0_f64;
 

--- a/src/librustc_ast_lowering/lib.rs
+++ b/src/librustc_ast_lowering/lib.rs
@@ -33,7 +33,7 @@
 #![feature(array_value_iter)]
 #![feature(crate_visibility_modifier)]
 #![feature(marker_trait_attr)]
-#![feature(specialization)]
+#![feature(specialization)] // FIXME: min_specialization does not work
 #![feature(or_patterns)]
 #![recursion_limit = "256"]
 

--- a/src/librustc_attr/builtin.rs
+++ b/src/librustc_attr/builtin.rs
@@ -634,7 +634,7 @@ pub fn eval_condition(
                 [NestedMetaItem::Literal(Lit { span, .. })
                 | NestedMetaItem::MetaItem(MetaItem { span, .. })] => {
                     sess.span_diagnostic
-                        .struct_span_err(*span, &*format!("expected a version literal"))
+                        .struct_span_err(*span, "expected a version literal")
                         .emit();
                     return false;
                 }

--- a/src/librustc_data_structures/lib.rs
+++ b/src/librustc_data_structures/lib.rs
@@ -12,7 +12,7 @@
 #![feature(generators)]
 #![feature(generator_trait)]
 #![feature(fn_traits)]
-#![feature(specialization)]
+#![feature(min_specialization)]
 #![feature(optin_builtin_traits)]
 #![feature(nll)]
 #![feature(allow_internal_unstable)]

--- a/src/librustc_data_structures/tiny_list.rs
+++ b/src/librustc_data_structures/tiny_list.rs
@@ -52,7 +52,7 @@ impl<T: PartialEq> TinyList<T> {
             if &e.data == data {
                 return true;
             }
-            elem = e.next.as_ref().map(|e| &**e);
+            elem = e.next.as_deref();
         }
         false
     }
@@ -62,7 +62,7 @@ impl<T: PartialEq> TinyList<T> {
         let (mut elem, mut count) = (self.head.as_ref(), 0);
         while let Some(ref e) = elem {
             count += 1;
-            elem = e.next.as_ref().map(|e| &**e);
+            elem = e.next.as_deref();
         }
         count
     }

--- a/src/librustc_error_codes/error_codes/E0571.md
+++ b/src/librustc_error_codes/error_codes/E0571.md
@@ -7,7 +7,7 @@ Example of erroneous code:
 # fn satisfied(n: usize) -> bool { n % 23 == 0 }
 let result = while true {
     if satisfied(i) {
-        break 2*i; // error: `break` with value from a `while` loop
+        break 2 * i; // error: `break` with value from a `while` loop
     }
     i += 1;
 };
@@ -22,9 +22,9 @@ Make sure `break value;` statements only occur in `loop` loops:
 ```
 # let mut i = 1;
 # fn satisfied(n: usize) -> bool { n % 23 == 0 }
-let result = loop { // ok!
+let result = loop { // This is now a "loop" loop.
     if satisfied(i) {
-        break 2*i;
+        break 2 * i; // ok!
     }
     i += 1;
 };

--- a/src/librustc_error_codes/error_codes/E0579.md
+++ b/src/librustc_error_codes/error_codes/E0579.md
@@ -1,7 +1,4 @@
-When matching against an exclusive range, the compiler verifies that the range
-is non-empty. Exclusive range patterns include the start point but not the end
-point, so this is equivalent to requiring the start of the range to be less
-than the end of the range.
+A lower range wasn't less than the upper range.
 
 Erroneous code example:
 
@@ -17,3 +14,8 @@ fn main() {
     }
 }
 ```
+
+When matching against an exclusive range, the compiler verifies that the range
+is non-empty. Exclusive range patterns include the start point but not the end
+point, so this is equivalent to requiring the start of the range to be less
+than the end of the range.

--- a/src/librustc_hir/lib.rs
+++ b/src/librustc_hir/lib.rs
@@ -8,7 +8,7 @@
 #![feature(const_panic)]
 #![feature(in_band_lifetimes)]
 #![feature(or_patterns)]
-#![feature(specialization)]
+#![feature(min_specialization)]
 #![recursion_limit = "256"]
 
 #[macro_use]

--- a/src/librustc_infer/traits/util.rs
+++ b/src/librustc_infer/traits/util.rs
@@ -112,8 +112,7 @@ pub fn elaborate_predicates<'tcx>(
     tcx: TyCtxt<'tcx>,
     predicates: impl Iterator<Item = ty::Predicate<'tcx>>,
 ) -> Elaborator<'tcx> {
-    let obligations =
-        predicates.into_iter().map(|predicate| predicate_obligation(predicate, None)).collect();
+    let obligations = predicates.map(|predicate| predicate_obligation(predicate, None)).collect();
     elaborate_obligations(tcx, obligations)
 }
 
@@ -149,7 +148,7 @@ impl Elaborator<'tcx> {
                 // Get predicates declared on the trait.
                 let predicates = tcx.super_predicates_of(data.def_id());
 
-                let obligations = predicates.predicates.into_iter().map(|(pred, span)| {
+                let obligations = predicates.predicates.iter().map(|(pred, span)| {
                     predicate_obligation(
                         pred.subst_supertrait(tcx, &data.to_poly_trait_ref()),
                         Some(*span),

--- a/src/librustc_interface/queries.rs
+++ b/src/librustc_interface/queries.rs
@@ -137,7 +137,7 @@ impl<'tcx> Queries<'tcx> {
             let result = passes::register_plugins(
                 self.session(),
                 &*self.codegen_backend().metadata_loader(),
-                self.compiler.register_lints.as_ref().map(|p| &**p).unwrap_or_else(|| empty),
+                self.compiler.register_lints.as_deref().unwrap_or_else(|| empty),
                 krate,
                 &crate_name,
             );

--- a/src/librustc_metadata/lib.rs
+++ b/src/librustc_metadata/lib.rs
@@ -7,7 +7,7 @@
 #![feature(nll)]
 #![feature(or_patterns)]
 #![feature(proc_macro_internals)]
-#![feature(specialization)]
+#![feature(specialization)] // FIXME: min_specialization ICEs
 #![feature(stmt_expr_attributes)]
 #![recursion_limit = "256"]
 

--- a/src/librustc_middle/dep_graph/mod.rs
+++ b/src/librustc_middle/dep_graph/mod.rs
@@ -72,9 +72,9 @@ impl rustc_query_system::dep_graph::DepKind for DepKind {
         })
     }
 
-    fn read_deps<OP>(op: OP) -> ()
+    fn read_deps<OP>(op: OP)
     where
-        OP: for<'a> FnOnce(Option<&'a Lock<TaskDeps>>) -> (),
+        OP: for<'a> FnOnce(Option<&'a Lock<TaskDeps>>),
     {
         ty::tls::with_context_opt(|icx| {
             let icx = if let Some(icx) = icx { icx } else { return };

--- a/src/librustc_middle/hir/mod.rs
+++ b/src/librustc_middle/hir/mod.rs
@@ -78,7 +78,6 @@ pub fn provide(providers: &mut Providers<'_>) {
         &tcx.untracked_crate.modules[&module]
     };
     providers.hir_owner = |tcx, id| tcx.index_hir(LOCAL_CRATE).map[id].signature;
-    providers.hir_owner_nodes =
-        |tcx, id| tcx.index_hir(LOCAL_CRATE).map[id].with_bodies.as_ref().map(|nodes| &**nodes);
+    providers.hir_owner_nodes = |tcx, id| tcx.index_hir(LOCAL_CRATE).map[id].with_bodies.as_deref();
     map::provide(providers);
 }

--- a/src/librustc_middle/lib.rs
+++ b/src/librustc_middle/lib.rs
@@ -41,7 +41,7 @@
 #![feature(option_expect_none)]
 #![feature(or_patterns)]
 #![feature(range_is_empty)]
-#![feature(specialization)]
+#![feature(specialization)] // FIXME: min_specialization does not work
 #![feature(track_caller)]
 #![feature(trusted_len)]
 #![feature(vec_remove_item)]

--- a/src/librustc_middle/ty/mod.rs
+++ b/src/librustc_middle/ty/mod.rs
@@ -280,7 +280,7 @@ impl<'tcx> AssociatedItems<'tcx> {
         &self,
         name: Symbol,
     ) -> impl '_ + Iterator<Item = &ty::AssocItem> {
-        self.items.get_by_key(&name).map(|v| *v)
+        self.items.get_by_key(&name).copied()
     }
 
     /// Returns an iterator over all associated items with the given name.

--- a/src/librustc_middle/ty/print/pretty.rs
+++ b/src/librustc_middle/ty/print/pretty.rs
@@ -701,12 +701,14 @@ pub trait PrettyPrinter<'tcx>:
                 if self.tcx().sess.verbose() {
                     p!(write("{:?}", sz));
                 } else if let ty::ConstKind::Unevaluated(..) = sz.val {
-                    // do not try to evaluate unevaluated constants. If we are const evaluating an
+                    // Do not try to evaluate unevaluated constants. If we are const evaluating an
                     // array length anon const, rustc will (with debug assertions) print the
                     // constant's path. Which will end up here again.
                     p!(write("_"));
                 } else if let Some(n) = sz.val.try_to_bits(self.tcx().data_layout.pointer_size) {
                     p!(write("{}", n));
+                } else if let ty::ConstKind::Param(param) = sz.val {
+                    p!(write("{}", param));
                 } else {
                     p!(write("_"));
                 }

--- a/src/librustc_middle/ty/trait_def.rs
+++ b/src/librustc_middle/ty/trait_def.rs
@@ -171,10 +171,7 @@ impl<'tcx> TyCtxt<'tcx> {
     pub fn all_impls(self, def_id: DefId) -> impl Iterator<Item = DefId> + 'tcx {
         let TraitImpls { blanket_impls, non_blanket_impls } = self.trait_impls_of(def_id);
 
-        blanket_impls
-            .into_iter()
-            .chain(non_blanket_impls.into_iter().map(|(_, v)| v).flatten())
-            .cloned()
+        blanket_impls.iter().chain(non_blanket_impls.iter().map(|(_, v)| v).flatten()).cloned()
     }
 }
 

--- a/src/librustc_mir/lib.rs
+++ b/src/librustc_mir/lib.rs
@@ -19,7 +19,7 @@ Rust MIR: a lowered representation of Rust.
 #![feature(exhaustive_patterns)]
 #![feature(iter_order_by)]
 #![feature(never_type)]
-#![feature(specialization)]
+#![feature(min_specialization)]
 #![feature(trusted_len)]
 #![feature(try_blocks)]
 #![feature(associated_type_bounds)]

--- a/src/librustc_mir_build/hair/pattern/check_match.rs
+++ b/src/librustc_mir_build/hair/pattern/check_match.rs
@@ -246,7 +246,7 @@ impl<'tcx> MatchVisitor<'_, 'tcx> {
             );
         }
 
-        adt_defined_here(&mut cx, &mut err, pattern_ty, &witnesses);
+        adt_defined_here(&cx, &mut err, pattern_ty, &witnesses);
         err.note(&format!("the matched value is of type `{}`", pattern_ty));
         err.emit();
     }

--- a/src/librustc_mir_build/hair/pattern/const_to_pat.rs
+++ b/src/librustc_mir_build/hair/pattern/const_to_pat.rs
@@ -121,7 +121,7 @@ impl<'a, 'tcx> ConstToPat<'a, 'tcx> {
                         )
                     }
                     traits::NonStructuralMatchTy::Dynamic => {
-                        format!("trait objects cannot be used in patterns")
+                        "trait objects cannot be used in patterns".to_string()
                     }
                     traits::NonStructuralMatchTy::Param => {
                         bug!("use of constant whose type is a parameter inside a pattern")

--- a/src/librustc_passes/liveness.rs
+++ b/src/librustc_passes/liveness.rs
@@ -931,7 +931,7 @@ impl<'a, 'tcx> Liveness<'a, 'tcx> {
         if blk.targeted_by_break {
             self.break_ln.insert(blk.hir_id, succ);
         }
-        let succ = self.propagate_through_opt_expr(blk.expr.as_ref().map(|e| &**e), succ);
+        let succ = self.propagate_through_opt_expr(blk.expr.as_deref(), succ);
         blk.stmts.iter().rev().fold(succ, |succ, stmt| self.propagate_through_stmt(stmt, succ))
     }
 
@@ -952,7 +952,7 @@ impl<'a, 'tcx> Liveness<'a, 'tcx> {
                 // initialization, which is mildly more complex than checking
                 // once at the func header but otherwise equivalent.
 
-                let succ = self.propagate_through_opt_expr(local.init.as_ref().map(|e| &**e), succ);
+                let succ = self.propagate_through_opt_expr(local.init.as_deref(), succ);
                 self.define_bindings_in_pat(&local.pat, succ)
             }
             hir::StmtKind::Item(..) => succ,

--- a/src/librustc_passes/region.rs
+++ b/src/librustc_passes/region.rs
@@ -797,7 +797,7 @@ impl<'tcx> Visitor<'tcx> for RegionResolutionVisitor<'tcx> {
         resolve_expr(self, ex);
     }
     fn visit_local(&mut self, l: &'tcx Local<'tcx>) {
-        resolve_local(self, Some(&l.pat), l.init.as_ref().map(|e| &**e));
+        resolve_local(self, Some(&l.pat), l.init.as_deref());
     }
 }
 

--- a/src/librustc_query_system/dep_graph/dep_node.rs
+++ b/src/librustc_query_system/dep_graph/dep_node.rs
@@ -80,7 +80,7 @@ impl<K: DepKind> DepNode<K> {
             }
         }
 
-        return dep_node;
+        dep_node
     }
 }
 

--- a/src/librustc_query_system/dep_graph/mod.rs
+++ b/src/librustc_query_system/dep_graph/mod.rs
@@ -77,9 +77,9 @@ pub trait DepKind: Copy + fmt::Debug + Eq + Ord + Hash {
         OP: FnOnce() -> R;
 
     /// Access dependencies from current implicit context.
-    fn read_deps<OP>(op: OP) -> ()
+    fn read_deps<OP>(op: OP)
     where
-        OP: for<'a> FnOnce(Option<&'a Lock<TaskDeps<Self>>>) -> ();
+        OP: for<'a> FnOnce(Option<&'a Lock<TaskDeps<Self>>>);
 
     fn can_reconstruct_query_key(&self) -> bool;
 }

--- a/src/librustc_query_system/lib.rs
+++ b/src/librustc_query_system/lib.rs
@@ -4,7 +4,7 @@
 #![feature(const_panic)]
 #![feature(core_intrinsics)]
 #![feature(hash_raw_entry)]
-#![feature(specialization)]
+#![feature(specialization)] // FIXME: min_specialization rejects `default const`
 #![feature(stmt_expr_attributes)]
 #![feature(vec_remove_item)]
 

--- a/src/librustc_session/session.rs
+++ b/src/librustc_session/session.rs
@@ -813,7 +813,7 @@ impl Session {
                 let mut fuel = self.optimization_fuel.lock();
                 ret = fuel.remaining != 0;
                 if fuel.remaining == 0 && !fuel.out_of_fuel {
-                    eprintln!("optimization-fuel-exhausted: {}", msg());
+                    self.warn(&format!("optimization-fuel-exhausted: {}", msg()));
                     fuel.out_of_fuel = true;
                 } else if fuel.remaining > 0 {
                     fuel.remaining -= 1;

--- a/src/librustc_span/lib.rs
+++ b/src/librustc_span/lib.rs
@@ -12,7 +12,7 @@
 #![feature(negative_impls)]
 #![feature(nll)]
 #![feature(optin_builtin_traits)]
-#![feature(specialization)]
+#![feature(min_specialization)]
 
 // FIXME(#56935): Work around ICEs during cross-compilation.
 #[allow(unused)]

--- a/src/librustc_trait_selection/traits/chalk_fulfill.rs
+++ b/src/librustc_trait_selection/traits/chalk_fulfill.rs
@@ -39,7 +39,7 @@ fn environment<'tcx>(
     let ty::InstantiatedPredicates { predicates, .. } =
         tcx.predicates_of(def_id).instantiate_identity(tcx);
 
-    let clauses = predicates.into_iter().map(|pred| ChalkEnvironmentClause::Predicate(pred));
+    let clauses = predicates.into_iter().map(ChalkEnvironmentClause::Predicate);
 
     let hir_id = tcx.hir().as_local_hir_id(def_id.expect_local());
     let node = tcx.hir().get(hir_id);
@@ -224,7 +224,7 @@ impl TraitEngine<'tcx> for FulfillmentContext<'tcx> {
                                 ),
 
                                 Err(_err) => errors.push(FulfillmentError {
-                                    obligation: obligation,
+                                    obligation,
                                     code: FulfillmentErrorCode::CodeSelectionError(
                                         SelectionError::Unimplemented,
                                     ),
@@ -238,7 +238,7 @@ impl TraitEngine<'tcx> for FulfillmentContext<'tcx> {
                     }
 
                     Err(NoSolution) => errors.push(FulfillmentError {
-                        obligation: obligation,
+                        obligation,
                         code: FulfillmentErrorCode::CodeSelectionError(
                             SelectionError::Unimplemented,
                         ),
@@ -257,6 +257,6 @@ impl TraitEngine<'tcx> for FulfillmentContext<'tcx> {
     }
 
     fn pending_obligations(&self) -> Vec<PredicateObligation<'tcx>> {
-        self.obligations.iter().map(|obligation| obligation.clone()).collect()
+        self.obligations.iter().cloned().collect()
     }
 }

--- a/src/librustc_trait_selection/traits/error_reporting/suggestions.rs
+++ b/src/librustc_trait_selection/traits/error_reporting/suggestions.rs
@@ -691,6 +691,15 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
             }
 
             if let ty::Ref(region, t_type, mutability) = trait_ref.skip_binder().self_ty().kind {
+                if region.is_late_bound() || t_type.has_escaping_bound_vars() {
+                    // Avoid debug assertion in `mk_obligation_for_def_id`.
+                    //
+                    // If the self type has escaping bound vars then it's not
+                    // going to be the type of an expression, so the suggestion
+                    // probably won't apply anyway.
+                    return;
+                }
+
                 let trait_type = match mutability {
                     hir::Mutability::Mut => self.tcx.mk_imm_ref(region, t_type),
                     hir::Mutability::Not => self.tcx.mk_mut_ref(region, t_type),

--- a/src/librustc_trait_selection/traits/error_reporting/suggestions.rs
+++ b/src/librustc_trait_selection/traits/error_reporting/suggestions.rs
@@ -1854,7 +1854,7 @@ impl NextTypeParamName for &[hir::GenericParam<'_>] {
     fn next_type_param_name(&self, name: Option<&str>) -> String {
         // This is the whitelist of possible parameter names that we might suggest.
         let name = name.and_then(|n| n.chars().next()).map(|c| c.to_string().to_uppercase());
-        let name = name.as_ref().map(|s| s.as_str());
+        let name = name.as_deref();
         let possible_names = [name.unwrap_or("T"), "T", "U", "V", "X", "Y", "Z", "A", "B", "C"];
         let used_names = self
             .iter()

--- a/src/librustc_traits/chalk/db.rs
+++ b/src/librustc_traits/chalk/db.rs
@@ -59,7 +59,7 @@ impl<'tcx> chalk_solve::RustIrDatabase<RustInterner<'tcx>> for RustIrDatabase<'t
         // clauses or bounds?
         let predicates = self.tcx.predicates_defined_on(def_id).predicates;
         let where_clauses: Vec<_> = predicates
-            .into_iter()
+            .iter()
             .map(|(wc, _)| wc.subst(self.tcx, &bound_vars))
             .filter_map(|wc| LowerInto::<Option<chalk_ir::QuantifiedWhereClause<RustInterner<'tcx>>>>::lower_into(wc, &self.interner)).collect();
 
@@ -88,7 +88,7 @@ impl<'tcx> chalk_solve::RustIrDatabase<RustInterner<'tcx>> for RustIrDatabase<'t
         let binders = binders_for(&self.interner, bound_vars);
         let predicates = self.tcx.predicates_defined_on(def_id).predicates;
         let where_clauses: Vec<_> = predicates
-            .into_iter()
+            .iter()
             .map(|(wc, _)| wc.subst(self.tcx, &bound_vars))
             .filter_map(|wc| LowerInto::<Option<chalk_ir::QuantifiedWhereClause<RustInterner<'tcx>>>>::lower_into(wc, &self.interner)).collect();
 
@@ -134,7 +134,7 @@ impl<'tcx> chalk_solve::RustIrDatabase<RustInterner<'tcx>> for RustIrDatabase<'t
 
                 let predicates = self.tcx.predicates_of(adt_def_id).predicates;
                 let where_clauses: Vec<_> = predicates
-                    .into_iter()
+                    .iter()
                     .map(|(wc, _)| wc.subst(self.tcx, bound_vars))
                     .filter_map(|wc| LowerInto::<Option<chalk_ir::QuantifiedWhereClause<RustInterner<'tcx>>>>::lower_into(wc, &self.interner))
                     .collect();
@@ -166,46 +166,42 @@ impl<'tcx> chalk_solve::RustIrDatabase<RustInterner<'tcx>> for RustIrDatabase<'t
                         fundamental: adt_def.is_fundamental(),
                     },
                 });
-                return struct_datum;
+                struct_datum
             }
-            RustDefId::Ref(_) => {
-                return Arc::new(chalk_rust_ir::StructDatum {
-                    id: struct_id,
-                    binders: chalk_ir::Binders::new(
-                        chalk_ir::ParameterKinds::from(
-                            &self.interner,
-                            vec![
-                                chalk_ir::ParameterKind::Lifetime(()),
-                                chalk_ir::ParameterKind::Ty(()),
-                            ],
-                        ),
-                        chalk_rust_ir::StructDatumBound { fields: vec![], where_clauses: vec![] },
+            RustDefId::Ref(_) => Arc::new(chalk_rust_ir::StructDatum {
+                id: struct_id,
+                binders: chalk_ir::Binders::new(
+                    chalk_ir::ParameterKinds::from(
+                        &self.interner,
+                        vec![
+                            chalk_ir::ParameterKind::Lifetime(()),
+                            chalk_ir::ParameterKind::Ty(()),
+                        ],
                     ),
-                    flags: chalk_rust_ir::StructFlags { upstream: false, fundamental: false },
-                });
-            }
-            RustDefId::Array | RustDefId::Slice => {
-                return Arc::new(chalk_rust_ir::StructDatum {
-                    id: struct_id,
-                    binders: chalk_ir::Binders::new(
-                        chalk_ir::ParameterKinds::from(
-                            &self.interner,
-                            Some(chalk_ir::ParameterKind::Ty(())),
-                        ),
-                        chalk_rust_ir::StructDatumBound { fields: vec![], where_clauses: vec![] },
+                    chalk_rust_ir::StructDatumBound { fields: vec![], where_clauses: vec![] },
+                ),
+                flags: chalk_rust_ir::StructFlags { upstream: false, fundamental: false },
+            }),
+            RustDefId::Array | RustDefId::Slice => Arc::new(chalk_rust_ir::StructDatum {
+                id: struct_id,
+                binders: chalk_ir::Binders::new(
+                    chalk_ir::ParameterKinds::from(
+                        &self.interner,
+                        Some(chalk_ir::ParameterKind::Ty(())),
                     ),
-                    flags: chalk_rust_ir::StructFlags { upstream: false, fundamental: false },
-                });
-            }
+                    chalk_rust_ir::StructDatumBound { fields: vec![], where_clauses: vec![] },
+                ),
+                flags: chalk_rust_ir::StructFlags { upstream: false, fundamental: false },
+            }),
             RustDefId::Str | RustDefId::Never | RustDefId::FnDef(_) => {
-                return Arc::new(chalk_rust_ir::StructDatum {
+                Arc::new(chalk_rust_ir::StructDatum {
                     id: struct_id,
                     binders: chalk_ir::Binders::new(
                         chalk_ir::ParameterKinds::new(&self.interner),
                         chalk_rust_ir::StructDatumBound { fields: vec![], where_clauses: vec![] },
                     ),
                     flags: chalk_rust_ir::StructFlags { upstream: false, fundamental: false },
-                });
+                })
             }
 
             _ => bug!("Used not struct variant when expecting struct variant."),
@@ -228,7 +224,7 @@ impl<'tcx> chalk_solve::RustIrDatabase<RustInterner<'tcx>> for RustIrDatabase<'t
 
         let predicates = self.tcx.predicates_of(def_id).predicates;
         let where_clauses: Vec<_> = predicates
-            .into_iter()
+            .iter()
             .map(|(wc, _)| wc.subst(self.tcx, bound_vars))
             .filter_map(|wc| LowerInto::<Option<chalk_ir::QuantifiedWhereClause<RustInterner<'tcx>>>>::lower_into(wc, &self.interner)).collect();
 
@@ -260,7 +256,7 @@ impl<'tcx> chalk_solve::RustIrDatabase<RustInterner<'tcx>> for RustIrDatabase<'t
         // not there yet.
 
         let all_impls = self.tcx.all_impls(def_id);
-        let matched_impls = all_impls.into_iter().filter(|impl_def_id| {
+        let matched_impls = all_impls.filter(|impl_def_id| {
             use chalk_ir::could_match::CouldMatch;
             let trait_ref = self.tcx.impl_trait_ref(*impl_def_id).unwrap();
             let bound_vars = bound_vars_for_item(self.tcx, *impl_def_id);
@@ -304,7 +300,7 @@ impl<'tcx> chalk_solve::RustIrDatabase<RustInterner<'tcx>> for RustIrDatabase<'t
                 _ => {}
             }
         }
-        return false;
+        false
     }
 
     fn associated_ty_value(
@@ -379,7 +375,7 @@ impl<'tcx> chalk_solve::RustIrDatabase<RustInterner<'tcx>> for RustIrDatabase<'t
                                     ty::AdtKind::Struct | ty::AdtKind::Union => None,
                                     ty::AdtKind::Enum => {
                                         let constraint = self.tcx.adt_sized_constraint(adt_def_id);
-                                        if constraint.0.len() > 0 {
+                                        if !constraint.0.is_empty() {
                                             unimplemented!()
                                         } else {
                                             Some(true)
@@ -412,7 +408,7 @@ impl<'tcx> chalk_solve::RustIrDatabase<RustInterner<'tcx>> for RustIrDatabase<'t
                                     ty::AdtKind::Struct | ty::AdtKind::Union => None,
                                     ty::AdtKind::Enum => {
                                         let constraint = self.tcx.adt_sized_constraint(adt_def_id);
-                                        if constraint.0.len() > 0 {
+                                        if !constraint.0.is_empty() {
                                             unimplemented!()
                                         } else {
                                             Some(true)

--- a/src/librustc_traits/chalk/lowering.rs
+++ b/src/librustc_traits/chalk/lowering.rs
@@ -274,7 +274,7 @@ impl<'tcx> LowerInto<'tcx, chalk_ir::Ty<RustInterner<'tcx>>> for Ty<'tcx> {
         let uint = |i| apply(chalk_ir::TypeName::Scalar(chalk_ir::Scalar::Uint(i)), empty());
         let float = |f| apply(chalk_ir::TypeName::Scalar(chalk_ir::Scalar::Float(f)), empty());
 
-        return match self.kind {
+        match self.kind {
             Bool => apply(chalk_ir::TypeName::Scalar(chalk_ir::Scalar::Bool), empty()),
             Char => apply(chalk_ir::TypeName::Scalar(chalk_ir::Scalar::Char), empty()),
             Int(ty) => match ty {
@@ -370,7 +370,7 @@ impl<'tcx> LowerInto<'tcx, chalk_ir::Ty<RustInterner<'tcx>>> for Ty<'tcx> {
             .intern(interner),
             Infer(_infer) => unimplemented!(),
             Error => unimplemented!(),
-        };
+        }
     }
 }
 

--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -447,7 +447,7 @@ impl Options {
             None => return Err(3),
         };
 
-        match matches.opt_str("r").as_ref().map(|s| &**s) {
+        match matches.opt_str("r").as_deref() {
             Some("rust") | None => {}
             Some(s) => {
                 diag.struct_err(&format!("unknown input format: {}", s)).emit();

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -129,7 +129,7 @@ impl<'tcx> DocContext<'tcx> {
         );
 
         MAX_DEF_ID.with(|m| {
-            m.borrow_mut().entry(def_id.krate.clone()).or_insert(start_def_id);
+            m.borrow_mut().entry(def_id.krate).or_insert(start_def_id);
         });
 
         self.all_fake_def_ids.borrow_mut().insert(def_id);

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -796,7 +796,7 @@ themePicker.onblur = handleThemeButtonsBlur;
         if path.exists() {
             for line in BufReader::new(File::open(path)?).lines() {
                 let line = line?;
-                if !line.starts_with("\"") {
+                if !line.starts_with('"') {
                     continue;
                 }
                 if line.starts_with(&format!("\"{}\"", krate)) {
@@ -810,8 +810,7 @@ themePicker.onblur = handleThemeButtonsBlur;
                 }
                 krates.push(
                     line.split('"')
-                        .filter(|s| !s.is_empty())
-                        .next()
+                        .find(|s| !s.is_empty())
                         .map(|s| s.to_owned())
                         .unwrap_or_else(String::new),
                 );

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -2281,7 +2281,10 @@ fn short_stability(item: &clean::Item, cx: &Context) -> Vec<String> {
             );
             message.push_str(&format!(": {}", html.to_string()));
         }
-        stability.push(format!("<div class='stab deprecated'>{}</div>", message));
+        stability.push(format!(
+            "<div class='stab deprecated'><span class='emoji'>👎</span> {}</div>",
+            message,
+        ));
     }
 
     if let Some(stab) = item.stability.as_ref().filter(|stab| stab.level == stability::Unstable) {

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -255,8 +255,7 @@ fn run_test(
 
     let rustc_binary = options
         .test_builder
-        .as_ref()
-        .map(|v| &**v)
+        .as_deref()
         .unwrap_or_else(|| rustc_interface::util::rustc_path().expect("found rustc"));
     let mut compiler = Command::new(&rustc_binary);
     compiler.arg("--crate-type").arg("bin");

--- a/src/libserialize/lib.rs
+++ b/src/libserialize/lib.rs
@@ -10,7 +10,7 @@ Core encoding and decoding interfaces.
     test(attr(allow(unused_variables), deny(warnings)))
 )]
 #![feature(box_syntax)]
-#![feature(specialization)]
+#![feature(specialization)] // FIXME: min_specialization does not work
 #![feature(never_type)]
 #![feature(nll)]
 #![feature(associated_type_bounds)]

--- a/src/libstd/thread/mod.rs
+++ b/src/libstd/thread/mod.rs
@@ -1272,7 +1272,7 @@ impl Thread {
     }
 
     fn cname(&self) -> Option<&CStr> {
-        self.inner.name.as_ref().map(|s| &**s)
+        self.inner.name.as_deref()
     }
 }
 

--- a/src/libtest/cli.rs
+++ b/src/libtest/cli.rs
@@ -331,7 +331,7 @@ fn get_format(
     quiet: bool,
     allow_unstable: bool,
 ) -> OptPartRes<OutputFormat> {
-    let format = match matches.opt_str("format").as_ref().map(|s| &**s) {
+    let format = match matches.opt_str("format").as_deref() {
         None if quiet => OutputFormat::Terse,
         Some("pretty") | None => OutputFormat::Pretty,
         Some("terse") => OutputFormat::Terse,
@@ -355,7 +355,7 @@ fn get_format(
 }
 
 fn get_color_config(matches: &getopts::Matches) -> OptPartRes<ColorConfig> {
-    let color = match matches.opt_str("color").as_ref().map(|s| &**s) {
+    let color = match matches.opt_str("color").as_deref() {
         Some("auto") | None => ColorConfig::AutoColor,
         Some("always") => ColorConfig::AlwaysColor,
         Some("never") => ColorConfig::NeverColor,

--- a/src/test/rustdoc/issue-32374.rs
+++ b/src/test/rustdoc/issue-32374.rs
@@ -10,7 +10,7 @@
 // @matches issue_32374/index.html '//*[@class="docblock-short"]/text()' 'Docs'
 
 // @has issue_32374/struct.T.html '//*[@class="stab deprecated"]' \
-//      'Deprecated since 1.0.0: text'
+//      '👎 Deprecated since 1.0.0: text'
 // @has - '<code>test</code>&nbsp;<a href="http://issue_url/32374">#32374</a>'
 // @matches issue_32374/struct.T.html '//*[@class="stab unstable"]' \
 //      '🔬 This is a nightly-only experimental API. \(test\s#32374\)$'
@@ -20,7 +20,7 @@
 pub struct T;
 
 // @has issue_32374/struct.U.html '//*[@class="stab deprecated"]' \
-//      'Deprecated since 1.0.0: deprecated'
+//      '👎 Deprecated since 1.0.0: deprecated'
 // @has issue_32374/struct.U.html '//*[@class="stab unstable"]' \
 //      '🔬 This is a nightly-only experimental API. (test #32374)'
 // @has issue_32374/struct.U.html '//details' \

--- a/src/test/ui/array-slice-vec/match_arr_unknown_len.stderr
+++ b/src/test/ui/array-slice-vec/match_arr_unknown_len.stderr
@@ -13,7 +13,7 @@ LL |         [1, 2] => true,
    |         ^^^^^^ expected `2usize`, found `N`
    |
    = note: expected array `[u32; 2]`
-              found array `[u32; _]`
+              found array `[u32; N]`
 
 error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui/const-generics/array-impls/alloc-types-no-impls-length-33.stderr
+++ b/src/test/ui/const-generics/array-impls/alloc-types-no-impls-length-33.stderr
@@ -29,7 +29,7 @@ LL |     let boxed_array = <Box<[i32; 33]>>::try_from(boxed_slice);
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::convert::TryFrom<std::boxed::Box<[i32]>>` is not implemented for `std::boxed::Box<[i32; 33]>`
    |
    = help: the following implementations were found:
-             <std::boxed::Box<[T; _]> as std::convert::TryFrom<std::boxed::Box<[T]>>>
+             <std::boxed::Box<[T; N]> as std::convert::TryFrom<std::boxed::Box<[T]>>>
 
 error[E0277]: the trait bound `std::rc::Rc<[i32; 33]>: std::convert::From<std::rc::Rc<[i32]>>` is not satisfied
   --> $DIR/alloc-types-no-impls-length-33.rs:19:23
@@ -53,7 +53,7 @@ LL |     let boxed_array = <Rc<[i32; 33]>>::try_from(boxed_slice);
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::convert::TryFrom<std::rc::Rc<[i32]>>` is not implemented for `std::rc::Rc<[i32; 33]>`
    |
    = help: the following implementations were found:
-             <std::rc::Rc<[T; _]> as std::convert::TryFrom<std::rc::Rc<[T]>>>
+             <std::rc::Rc<[T; N]> as std::convert::TryFrom<std::rc::Rc<[T]>>>
 
 error[E0277]: the trait bound `std::sync::Arc<[i32; 33]>: std::convert::From<std::sync::Arc<[i32]>>` is not satisfied
   --> $DIR/alloc-types-no-impls-length-33.rs:26:23
@@ -77,7 +77,7 @@ LL |     let boxed_array = <Arc<[i32; 33]>>::try_from(boxed_slice);
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::convert::TryFrom<std::sync::Arc<[i32]>>` is not implemented for `std::sync::Arc<[i32; 33]>`
    |
    = help: the following implementations were found:
-             <std::sync::Arc<[T; _]> as std::convert::TryFrom<std::sync::Arc<[T]>>>
+             <std::sync::Arc<[T; N]> as std::convert::TryFrom<std::sync::Arc<[T]>>>
 
 error: aborting due to 7 previous errors
 

--- a/src/test/ui/const-generics/array-impls/core-traits-no-impls-length-33.stderr
+++ b/src/test/ui/const-generics/array-impls/core-traits-no-impls-length-33.stderr
@@ -39,9 +39,9 @@ LL |     for _ in &[0_usize; 33] {
    |              ^^^^^^^^^^^^^^ the trait `std::iter::IntoIterator` is not implemented for `&[usize; 33]`
    |
    = help: the following implementations were found:
-             <&'a [T; _] as std::iter::IntoIterator>
+             <&'a [T; N] as std::iter::IntoIterator>
              <&'a [T] as std::iter::IntoIterator>
-             <&'a mut [T; _] as std::iter::IntoIterator>
+             <&'a mut [T; N] as std::iter::IntoIterator>
              <&'a mut [T] as std::iter::IntoIterator>
    = note: required by `std::iter::IntoIterator::into_iter`
 

--- a/src/test/ui/const-generics/broken-mir-2.stderr
+++ b/src/test/ui/const-generics/broken-mir-2.stderr
@@ -10,10 +10,10 @@ error[E0277]: arrays only have std trait implementations for lengths 0..=32
   --> $DIR/broken-mir-2.rs:7:36
    |
 LL | struct S<T: Debug, const N: usize>([T; N]);
-   |                                    ^^^^^^ the trait `std::array::LengthAtMost32` is not implemented for `[T; _]`
+   |                                    ^^^^^^ the trait `std::array::LengthAtMost32` is not implemented for `[T; N]`
    |
-   = note: required because of the requirements on the impl of `std::fmt::Debug` for `[T; _]`
-   = note: required because of the requirements on the impl of `std::fmt::Debug` for `&[T; _]`
+   = note: required because of the requirements on the impl of `std::fmt::Debug` for `[T; N]`
+   = note: required because of the requirements on the impl of `std::fmt::Debug` for `&[T; N]`
    = note: required for the cast to the object type `dyn std::fmt::Debug`
    = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/const-generics/derive-debug-array-wrapper.stderr
+++ b/src/test/ui/const-generics/derive-debug-array-wrapper.stderr
@@ -10,10 +10,10 @@ error[E0277]: arrays only have std trait implementations for lengths 0..=32
   --> $DIR/derive-debug-array-wrapper.rs:6:5
    |
 LL |     a: [u32; N],
-   |     ^^^^^^^^^^^ the trait `std::array::LengthAtMost32` is not implemented for `[u32; _]`
+   |     ^^^^^^^^^^^ the trait `std::array::LengthAtMost32` is not implemented for `[u32; N]`
    |
-   = note: required because of the requirements on the impl of `std::fmt::Debug` for `[u32; _]`
-   = note: required because of the requirements on the impl of `std::fmt::Debug` for `&[u32; _]`
+   = note: required because of the requirements on the impl of `std::fmt::Debug` for `[u32; N]`
+   = note: required because of the requirements on the impl of `std::fmt::Debug` for `&[u32; N]`
    = note: required for the cast to the object type `dyn std::fmt::Debug`
    = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/const-generics/issues/issue-62504.stderr
+++ b/src/test/ui/const-generics/issues/issue-62504.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL |         ArrayHolder([0; Self::SIZE])
    |                     ^^^^^^^^^^^^^^^ expected `X`, found `Self::SIZE`
    |
-   = note: expected array `[u32; _]`
+   = note: expected array `[u32; X]`
               found array `[u32; _]`
 
 error: constant expression depends on a generic parameter

--- a/src/test/ui/optimization-fuel-0.rs
+++ b/src/test/ui/optimization-fuel-0.rs
@@ -4,8 +4,7 @@
 
 use std::mem::size_of;
 
-// (#55495: The --error-format is to sidestep an issue in our test harness)
-// compile-flags: --error-format human -Z fuel=foo=0
+// compile-flags: -Z fuel=foo=0
 
 struct S1(u8, u16, u8);
 struct S2(u8, u16, u8);

--- a/src/test/ui/optimization-fuel-0.stderr
+++ b/src/test/ui/optimization-fuel-0.stderr
@@ -1,1 +1,4 @@
-optimization-fuel-exhausted: Reorder fields of "S1"
+warning: optimization-fuel-exhausted: Reorder fields of "S1"
+
+warning: 1 warning emitted
+

--- a/src/test/ui/optimization-fuel-1.rs
+++ b/src/test/ui/optimization-fuel-1.rs
@@ -4,8 +4,7 @@
 
 use std::mem::size_of;
 
-// (#55495: The --error-format is to sidestep an issue in our test harness)
-// compile-flags: --error-format human -Z fuel=foo=1
+// compile-flags: -Z fuel=foo=1
 
 struct S1(u8, u16, u8);
 struct S2(u8, u16, u8);

--- a/src/test/ui/optimization-fuel-1.stderr
+++ b/src/test/ui/optimization-fuel-1.stderr
@@ -1,1 +1,4 @@
-optimization-fuel-exhausted: Reorder fields of "S2"
+warning: optimization-fuel-exhausted: Reorder fields of "S2"
+
+warning: 1 warning emitted
+

--- a/src/test/ui/suggestions/imm-ref-trait-object-literal-bound-regions.rs
+++ b/src/test/ui/suggestions/imm-ref-trait-object-literal-bound-regions.rs
@@ -1,0 +1,18 @@
+// Regression test for #70813 (this used to trigger a debug assertion)
+
+trait Trait {}
+
+struct S;
+
+impl<'a> Trait for &'a mut S {}
+
+fn foo<X>(_: X)
+where
+    for<'b> &'b X: Trait,
+{
+}
+
+fn main() {
+    let s = S;
+    foo::<S>(s); //~ ERROR the trait bound `for<'b> &'b S: Trait` is not satisfied
+}

--- a/src/test/ui/suggestions/imm-ref-trait-object-literal-bound-regions.stderr
+++ b/src/test/ui/suggestions/imm-ref-trait-object-literal-bound-regions.stderr
@@ -1,0 +1,18 @@
+error[E0277]: the trait bound `for<'b> &'b S: Trait` is not satisfied
+  --> $DIR/imm-ref-trait-object-literal-bound-regions.rs:17:5
+   |
+LL | fn foo<X>(_: X)
+   |    --- required by a bound in this
+LL | where
+LL |     for<'b> &'b X: Trait,
+   |                    ----- required by this bound in `foo`
+...
+LL |     foo::<S>(s);
+   |     ^^^^^^^^ the trait `for<'b> Trait` is not implemented for `&'b S`
+   |
+   = help: the following implementations were found:
+             <&'a mut S as Trait>
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Successful merges:

 - #72014 (Deprecated emoji)
 - #72019 (Fix debug assertion in error code)
 - #72027 (Use CDN for ci-caches on download)
 - #72044 (use min_specialization for some rustc crates where it requires no changes)
 - #72052 (display `ConstKind::Param`)
 - #72067 (Emit a warning when optimization fuel runs out)
 - #72072 (doc: minus (U+2212) instead of dash (U+002D) for negative infinity)
 - #72077 (Improve E0571 wording)
 - #72107 (Clean up E0579 explanation)
 - #72109 (Fix clippy warnings)

Failed merges:


r? @ghost