### PR TITLE
Stabilize process_set_argv0 feature for Unix

### DIFF
--- a/src/libstd/sys/unix/ext/process.rs
+++ b/src/libstd/sys/unix/ext/process.rs
@@ -111,7 +111,7 @@ pub trait CommandExt {
     ///
     /// Set the first process argument, `argv[0]`, to something other than the
     /// default executable path.
-    #[unstable(feature = "process_set_argv0", issue = "66510")]
+    #[stable(feature = "process_set_argv0", since = "1.45.0")]
     fn arg0<S>(&mut self, arg: S) -> &mut process::Command
     where
         S: AsRef<OsStr>;

--- a/src/libstd/sys/vxworks/ext/process.rs
+++ b/src/libstd/sys/vxworks/ext/process.rs
@@ -111,7 +111,7 @@ pub trait CommandExt {
     ///
     /// Set the first process argument, `argv[0]`, to something other than the
     /// default executable path.
-    #[unstable(feature = "process_set_argv0", issue = "66510")]
+    #[stable(feature = "process_set_argv0", since = "1.45.0")]
     fn arg0<S>(&mut self, arg: S) -> &mut process::Command
     where
         S: AsRef<OsStr>;

--- a/src/test/ui/command/command-argv0-debug.rs
+++ b/src/test/ui/command/command-argv0-debug.rs
@@ -4,8 +4,6 @@
 // ignore-cloudabi no processes
 // ignore-emscripten no processes
 // ignore-sgx no processes
-#![feature(process_set_argv0)]
-
 use std::os::unix::process::CommandExt;
 use std::process::Command;
 

--- a/src/test/ui/command/command-argv0.rs
+++ b/src/test/ui/command/command-argv0.rs
@@ -4,8 +4,6 @@
 // ignore-cloudabi no processes
 // ignore-emscripten no processes
 // ignore-sgx no processes
-#![feature(process_set_argv0)]
-
 use std::env;
 use std::os::unix::process::CommandExt;
 use std::process::Command;


### PR DESCRIPTION
This stabilizes process_set_argv0 targeting 1.45.0. It has been
useful in practice and seems useful as-is.

The equivalent feature could be implemented for Windows, but as far as I
know nobody has. That can be done separately.

Tracking issue: #66510