### PR TITLE
Defunctionalize spans for diagnostics

### DIFF
--- a/src/librustc_codegen_llvm/consts.rs
+++ b/src/librustc_codegen_llvm/consts.rs
@@ -260,7 +260,7 @@ impl CodegenCx<'ll, 'tcx> {
             debug!("get_static: sym={} item_attr={:?}", sym, self.tcx.item_attrs(def_id));
 
             let attrs = self.tcx.codegen_fn_attrs(def_id);
-            let span = self.tcx.def_span(def_id);
+            let span = self.tcx.real_def_span(def_id);
             let g = check_and_apply_linkage(&self, &attrs, ty, sym, span);
 
             // Thread-local statics in some other crate need to *always* be linked

--- a/src/librustc_codegen_llvm/context.rs
+++ b/src/librustc_codegen_llvm/context.rs
@@ -18,7 +18,7 @@ use rustc_middle::ty::layout::{HasParamEnv, LayoutError, TyAndLayout};
 use rustc_middle::ty::{self, Instance, Ty, TyCtxt};
 use rustc_session::config::{CFGuard, CrateType, DebugInfo};
 use rustc_session::Session;
-use rustc_span::source_map::{Span, DUMMY_SP};
+use rustc_span::source_map::{SpanId, DUMMY_SPID};
 use rustc_span::symbol::Symbol;
 use rustc_target::abi::{HasDataLayout, LayoutOf, PointeeInfo, Size, TargetDataLayout, VariantIdx};
 use rustc_target::spec::{HasTargetSpec, RelocModel, Target, TlsModel};
@@ -820,10 +820,10 @@ impl LayoutOf for CodegenCx<'ll, 'tcx> {
     type TyAndLayout = TyAndLayout<'tcx>;
 
     fn layout_of(&self, ty: Ty<'tcx>) -> Self::TyAndLayout {
-        self.spanned_layout_of(ty, DUMMY_SP)
+        self.spanned_layout_of(ty, DUMMY_SPID)
     }
 
-    fn spanned_layout_of(&self, ty: Ty<'tcx>, span: Span) -> Self::TyAndLayout {
+    fn spanned_layout_of(&self, ty: Ty<'tcx>, span: SpanId) -> Self::TyAndLayout {
         self.tcx.layout_of(ty::ParamEnv::reveal_all().and(ty)).unwrap_or_else(|e| {
             if let LayoutError::SizeOverflow(_) = e {
                 self.sess().span_fatal(span, &e.to_string())

--- a/src/librustc_codegen_llvm/debuginfo/create_scope_map.rs
+++ b/src/librustc_codegen_llvm/debuginfo/create_scope_map.rs
@@ -59,7 +59,7 @@ fn make_mir_scope(
         debug_context.scopes[parent]
     } else {
         // The root is the function itself.
-        let loc = cx.lookup_debug_loc(mir.span.lo());
+        let loc = cx.lookup_debug_loc(cx.tcx.reify_span(mir.span).lo());
         debug_context.scopes[scope] = DebugScope {
             scope_metadata: Some(fn_metadata),
             file_start_pos: loc.file.start_pos,
@@ -75,7 +75,7 @@ fn make_mir_scope(
         return;
     }
 
-    let loc = cx.lookup_debug_loc(scope_data.span.lo());
+    let loc = cx.lookup_debug_loc(cx.tcx.reify_span(scope_data.span).lo());
     let file_metadata = file_metadata(cx, &loc.file, debug_context.defining_crate);
 
     let scope_metadata = unsafe {

--- a/src/librustc_codegen_llvm/debuginfo/metadata.rs
+++ b/src/librustc_codegen_llvm/debuginfo/metadata.rs
@@ -2313,7 +2313,7 @@ pub fn create_global_var_metadata(cx: &CodegenCx<'ll, '_>, def_id: DefId, global
     // We may want to remove the namespace scope if we're in an extern block (see
     // https://github.com/rust-lang/rust/pull/46457#issuecomment-351750952).
     let var_scope = get_namespace_for_item(cx, def_id);
-    let span = tcx.def_span(def_id);
+    let span = tcx.real_def_span(def_id);
 
     let (file_metadata, line_number) = if !span.is_dummy() {
         let loc = cx.lookup_debug_loc(span.lo());

--- a/src/librustc_codegen_llvm/debuginfo/mod.rs
+++ b/src/librustc_codegen_llvm/debuginfo/mod.rs
@@ -237,7 +237,7 @@ impl DebugInfoMethods<'tcx> for CodegenCx<'ll, 'tcx> {
             return None;
         }
 
-        let span = mir.span;
+        let span = self.tcx().reify_span(mir.span);
 
         // This can be the case for functions inlined from another crate
         if span.is_dummy() {

--- a/src/librustc_codegen_ssa/back/write.rs
+++ b/src/librustc_codegen_ssa/back/write.rs
@@ -1612,7 +1612,7 @@ impl SharedEmitterMain {
                     if let Some(code) = diag.code {
                         d.code(code);
                     }
-                    handler.emit_diagnostic(&d);
+                    handler.emit_diagnostic(d);
                 }
                 Ok(SharedEmitterMessage::InlineAsmError(cookie, msg)) => {
                     sess.span_err(ExpnId::from_u32(cookie).expn_data().call_site, &msg)

--- a/src/librustc_codegen_ssa/back/write.rs
+++ b/src/librustc_codegen_ssa/back/write.rs
@@ -1570,7 +1570,7 @@ impl SharedEmitter {
 }
 
 impl Emitter for SharedEmitter {
-    fn emit_diagnostic(&mut self, diag: &rustc_errors::Diagnostic) {
+    fn emit_diagnostic(&mut self, diag: &rustc_errors::RealDiagnostic) {
         drop(self.sender.send(SharedEmitterMessage::Diagnostic(Diagnostic {
             msg: diag.message(),
             code: diag.code.clone(),

--- a/src/librustc_codegen_ssa/base.rs
+++ b/src/librustc_codegen_ssa/base.rs
@@ -45,7 +45,7 @@ use rustc_middle::ty::{self, Instance, Ty, TyCtxt};
 use rustc_session::cgu_reuse_tracker::CguReuse;
 use rustc_session::config::{self, EntryFnType};
 use rustc_session::Session;
-use rustc_span::Span;
+use rustc_span::SpanId;
 use rustc_symbol_mangling::test as symbol_names_test;
 use rustc_target::abi::{Abi, Align, LayoutOf, Scalar, VariantIdx};
 
@@ -414,7 +414,7 @@ pub fn maybe_create_entry_wrapper<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
 
     fn create_entry_fn<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
         cx: &'a Bx::CodegenCx,
-        sp: Span,
+        sp: SpanId,
         rust_main: Bx::Value,
         rust_main_def_id: LocalDefId,
         use_start_lang_item: bool,

--- a/src/librustc_codegen_ssa/mir/analyze.rs
+++ b/src/librustc_codegen_ssa/mir/analyze.rs
@@ -224,7 +224,7 @@ impl<'mir, 'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> Visitor<'tcx>
         if let Some(index) = place.as_local() {
             self.assign(index, location);
             let decl_span = self.fx.mir.local_decls[index].source_info.span;
-            if !self.fx.rvalue_creates_operand(rvalue, decl_span) {
+            if !self.fx.rvalue_creates_operand(rvalue, self.fx.cx.tcx().reify_span(decl_span)) {
                 self.not_ssa(index);
             }
         } else {

--- a/src/librustc_codegen_ssa/mir/block.rs
+++ b/src/librustc_codegen_ssa/mir/block.rs
@@ -406,6 +406,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
         self.set_debug_loc(&mut bx, terminator.source_info);
 
         // Get the location information.
+        let span = bx.tcx().reify_span(span);
         let location = self.get_caller_location(&mut bx, span).immediate();
 
         // Put together the arguments to the panic entry point.
@@ -606,6 +607,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
             bug!("`miri_start_panic` should never end up in compiled code");
         }
 
+        let span = bx.tcx().reify_span(span);
         if self.codegen_panic_intrinsic(
             &helper,
             &mut bx,
@@ -670,7 +672,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                             let c = self.eval_mir_constant(constant);
                             let (llval, ty) = self.simd_shuffle_indices(
                                 &bx,
-                                constant.span,
+                                bx.tcx().reify_span(constant.span),
                                 constant.literal.ty,
                                 c,
                             );
@@ -689,7 +691,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                 &fn_abi,
                 &args,
                 dest,
-                terminator.source_info.span,
+                bx.tcx().reify_span(terminator.source_info.span),
             );
 
             if let ReturnDest::IndirectOperand(dst, _) = ret_dest {

--- a/src/librustc_codegen_ssa/mir/rvalue.rs
+++ b/src/librustc_codegen_ssa/mir/rvalue.rs
@@ -751,7 +751,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
             mir::Rvalue::Aggregate(..) => {
                 let ty = rvalue.ty(self.mir, self.cx.tcx());
                 let ty = self.monomorphize(&ty);
-                self.cx.spanned_layout_of(ty, span).is_zst()
+                self.cx.spanned_layout_of(ty, span.into()).is_zst()
             }
         }
 

--- a/src/librustc_codegen_ssa/mir/statement.rs
+++ b/src/librustc_codegen_ssa/mir/statement.rs
@@ -97,7 +97,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                         &asm.asm,
                         outputs,
                         input_vals,
-                        statement.source_info.span,
+                        bx.tcx().reify_span(statement.source_info.span),
                     );
                     if !res {
                         struct_span_err!(

--- a/src/librustc_codegen_ssa/traits/type_.rs
+++ b/src/librustc_codegen_ssa/traits/type_.rs
@@ -5,7 +5,7 @@ use crate::common::TypeKind;
 use crate::mir::place::PlaceRef;
 use rustc_middle::ty::layout::TyAndLayout;
 use rustc_middle::ty::{self, Ty};
-use rustc_span::DUMMY_SP;
+use rustc_span::DUMMY_SPID;
 use rustc_target::abi::call::{ArgAbi, CastTarget, FnAbi, Reg};
 use rustc_target::abi::Integer;
 
@@ -70,16 +70,16 @@ pub trait DerivedTypeMethods<'tcx>: BaseTypeMethods<'tcx> + MiscMethods<'tcx> {
     }
 
     fn type_is_sized(&self, ty: Ty<'tcx>) -> bool {
-        ty.is_sized(self.tcx().at(DUMMY_SP), ty::ParamEnv::reveal_all())
+        ty.is_sized(self.tcx().at(DUMMY_SPID), ty::ParamEnv::reveal_all())
     }
 
     fn type_is_freeze(&self, ty: Ty<'tcx>) -> bool {
-        ty.is_freeze(self.tcx(), ty::ParamEnv::reveal_all(), DUMMY_SP)
+        ty.is_freeze(self.tcx(), ty::ParamEnv::reveal_all(), DUMMY_SPID)
     }
 
     fn type_has_metadata(&self, ty: Ty<'tcx>) -> bool {
         let param_env = ty::ParamEnv::reveal_all();
-        if ty.is_sized(self.tcx().at(DUMMY_SP), param_env) {
+        if ty.is_sized(self.tcx().at(DUMMY_SPID), param_env) {
             return false;
         }
 

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -1173,7 +1173,7 @@ pub fn report_ice(info: &panic::PanicInfo<'_>, bug_report_url: &str) {
     // it wants to print.
     if !info.payload().is::<rustc_errors::ExplicitBug>() {
         let d = rustc_errors::Diagnostic::new(rustc_errors::Level::Bug, "unexpected panic");
-        handler.emit_diagnostic(&d);
+        handler.emit_diagnostic(d);
     }
 
     let mut xs: Vec<Cow<'static, str>> = vec![

--- a/src/librustc_errors/annotate_snippet_emitter_writer.rs
+++ b/src/librustc_errors/annotate_snippet_emitter_writer.rs
@@ -7,13 +7,13 @@
 
 use crate::emitter::FileWithAnnotatedLines;
 use crate::snippet::Line;
-use crate::{CodeSuggestion, Diagnostic, DiagnosticId, Emitter, Level, SubDiagnostic};
+use crate::{CodeSuggestion, DiagnosticId, Emitter, Level, RealDiagnostic, RealSubDiagnostic};
 use annotate_snippets::display_list::DisplayList;
 use annotate_snippets::formatter::DisplayListFormatter;
 use annotate_snippets::snippet::*;
 use rustc_data_structures::sync::Lrc;
 use rustc_span::source_map::SourceMap;
-use rustc_span::{Loc, MultiSpan, SourceFile};
+use rustc_span::{Loc, MultiSpan, SourceFile, Span};
 
 /// Generates diagnostics using annotate-snippet
 pub struct AnnotateSnippetEmitterWriter {
@@ -28,7 +28,7 @@ pub struct AnnotateSnippetEmitterWriter {
 
 impl Emitter for AnnotateSnippetEmitterWriter {
     /// The entry point for the diagnostics generation
-    fn emit_diagnostic(&mut self, diag: &Diagnostic) {
+    fn emit_diagnostic(&mut self, diag: &RealDiagnostic) {
         let mut children = diag.children.clone();
         let (mut primary_span, suggestions) = self.primary_span_formatted(&diag);
 
@@ -68,9 +68,9 @@ struct DiagnosticConverter<'a> {
     code: Option<DiagnosticId>,
     msp: MultiSpan,
     #[allow(dead_code)]
-    children: &'a [SubDiagnostic],
+    children: &'a [RealSubDiagnostic],
     #[allow(dead_code)]
-    suggestions: &'a [CodeSuggestion],
+    suggestions: &'a [CodeSuggestion<Span>],
 }
 
 impl<'a> DiagnosticConverter<'a> {
@@ -191,8 +191,8 @@ impl AnnotateSnippetEmitterWriter {
         message: String,
         code: &Option<DiagnosticId>,
         msp: &MultiSpan,
-        children: &[SubDiagnostic],
-        suggestions: &[CodeSuggestion],
+        children: &[RealSubDiagnostic],
+        suggestions: &[CodeSuggestion<Span>],
     ) {
         let converter = DiagnosticConverter {
             source_map: self.source_map.clone(),

--- a/src/librustc_errors/diagnostic_builder.rs
+++ b/src/librustc_errors/diagnostic_builder.rs
@@ -97,8 +97,8 @@ impl<'a> DerefMut for DiagnosticBuilder<'a> {
 impl<'a> DiagnosticBuilder<'a> {
     /// Emit the diagnostic.
     pub fn emit(&mut self) {
-        self.0.handler.emit_diagnostic(&self);
-        self.cancel();
+        let diag = std::mem::replace(&mut self.0.diagnostic, Diagnostic::new(Level::Cancelled, ""));
+        self.0.handler.emit_diagnostic(diag);
     }
 
     /// Emit the diagnostic unless `delay` is true,
@@ -179,8 +179,8 @@ impl<'a> DiagnosticBuilder<'a> {
     /// locally in whichever way makes the most sense.
     pub fn delay_as_bug(&mut self) {
         self.level = Level::Bug;
-        self.0.handler.delay_as_bug(self.0.diagnostic.clone());
-        self.cancel();
+        let diag = std::mem::replace(&mut self.0.diagnostic, Diagnostic::new(Level::Cancelled, ""));
+        self.0.handler.delay_as_bug(diag);
     }
 
     /// Adds a span/label to be included in the resulting snippet.

--- a/src/librustc_errors/json.rs
+++ b/src/librustc_errors/json.rs
@@ -14,7 +14,7 @@ use rustc_span::source_map::{FilePathMapping, SourceMap};
 use crate::emitter::{Emitter, HumanReadableErrorType};
 use crate::registry::Registry;
 use crate::{Applicability, DiagnosticId};
-use crate::{CodeSuggestion, SubDiagnostic};
+use crate::{CodeSuggestion, RealDiagnostic, RealSubDiagnostic};
 
 use rustc_data_structures::sync::Lrc;
 use rustc_span::hygiene::ExpnData;
@@ -98,7 +98,7 @@ impl JsonEmitter {
 }
 
 impl Emitter for JsonEmitter {
-    fn emit_diagnostic(&mut self, diag: &crate::Diagnostic) {
+    fn emit_diagnostic(&mut self, diag: &RealDiagnostic) {
         let data = Diagnostic::from_errors_diagnostic(diag, self);
         let result = if self.pretty {
             writeln!(&mut self.dst, "{}", as_pretty_json(&data))
@@ -220,7 +220,7 @@ struct ArtifactNotification<'a> {
 }
 
 impl Diagnostic {
-    fn from_errors_diagnostic(diag: &crate::Diagnostic, je: &JsonEmitter) -> Diagnostic {
+    fn from_errors_diagnostic(diag: &crate::RealDiagnostic, je: &JsonEmitter) -> Diagnostic {
         let sugg = diag.suggestions.iter().map(|sugg| Diagnostic {
             message: sugg.msg.clone(),
             code: None,
@@ -268,7 +268,7 @@ impl Diagnostic {
         }
     }
 
-    fn from_sub_diagnostic(diag: &SubDiagnostic, je: &JsonEmitter) -> Diagnostic {
+    fn from_sub_diagnostic(diag: &RealSubDiagnostic, je: &JsonEmitter) -> Diagnostic {
         Diagnostic {
             message: diag.message(),
             code: None,
@@ -354,7 +354,7 @@ impl DiagnosticSpan {
             .collect()
     }
 
-    fn from_suggestion(suggestion: &CodeSuggestion, je: &JsonEmitter) -> Vec<DiagnosticSpan> {
+    fn from_suggestion(suggestion: &CodeSuggestion<Span>, je: &JsonEmitter) -> Vec<DiagnosticSpan> {
         suggestion
             .substitutions
             .iter()

--- a/src/librustc_expand/base.rs
+++ b/src/librustc_expand/base.rs
@@ -17,7 +17,7 @@ use rustc_span::edition::Edition;
 use rustc_span::hygiene::{AstPass, ExpnData, ExpnId, ExpnKind};
 use rustc_span::source_map::SourceMap;
 use rustc_span::symbol::{kw, sym, Ident, Symbol};
-use rustc_span::{FileName, MultiSpan, Span, DUMMY_SP};
+use rustc_span::{FileName, MultiSpanId, Span, DUMMY_SP};
 use smallvec::{smallvec, SmallVec};
 
 use std::default::Default;
@@ -1014,7 +1014,7 @@ impl<'a> ExtCtxt<'a> {
         self.current_expansion.id.expansion_cause()
     }
 
-    pub fn struct_span_err<S: Into<MultiSpan>>(&self, sp: S, msg: &str) -> DiagnosticBuilder<'a> {
+    pub fn struct_span_err<S: Into<MultiSpanId>>(&self, sp: S, msg: &str) -> DiagnosticBuilder<'a> {
         self.parse_sess.span_diagnostic.struct_span_err(sp, msg)
     }
 
@@ -1023,13 +1023,13 @@ impl<'a> ExtCtxt<'a> {
     ///
     /// Compilation will be stopped in the near future (at the end of
     /// the macro expansion phase).
-    pub fn span_err<S: Into<MultiSpan>>(&self, sp: S, msg: &str) {
+    pub fn span_err<S: Into<MultiSpanId>>(&self, sp: S, msg: &str) {
         self.parse_sess.span_diagnostic.span_err(sp, msg);
     }
-    pub fn span_warn<S: Into<MultiSpan>>(&self, sp: S, msg: &str) {
+    pub fn span_warn<S: Into<MultiSpanId>>(&self, sp: S, msg: &str) {
         self.parse_sess.span_diagnostic.span_warn(sp, msg);
     }
-    pub fn span_bug<S: Into<MultiSpan>>(&self, sp: S, msg: &str) -> ! {
+    pub fn span_bug<S: Into<MultiSpanId>>(&self, sp: S, msg: &str) -> ! {
         self.parse_sess.span_diagnostic.span_bug(sp, msg);
     }
     pub fn trace_macros_diag(&mut self) {

--- a/src/librustc_expand/proc_macro_server.rs
+++ b/src/librustc_expand/proc_macro_server.rs
@@ -634,7 +634,7 @@ impl server::Diagnostic for Rustc<'_> {
         diag.sub(level.to_internal(), msg, MultiSpan::from_spans(spans), None);
     }
     fn emit(&mut self, diag: Self::Diagnostic) {
-        self.sess.span_diagnostic.emit_diagnostic(&diag);
+        self.sess.span_diagnostic.emit_diagnostic(diag);
     }
 }
 

--- a/src/librustc_infer/infer/error_reporting/mod.rs
+++ b/src/librustc_infer/infer/error_reporting/mod.rs
@@ -1467,7 +1467,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
         impl<'tcx> ty::fold::TypeVisitor<'tcx> for OpaqueTypesVisitor<'tcx> {
             fn visit_ty(&mut self, t: Ty<'tcx>) -> bool {
                 if let Some((kind, def_id)) = TyCategory::from_ty(t) {
-                    let span = self.tcx.def_span(def_id);
+                    let span = self.tcx.real_def_span(def_id);
                     // Avoid cluttering the output when the "found" and error span overlap:
                     //
                     // error[E0308]: mismatched types
@@ -1543,7 +1543,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                             self.tcx
                                 .sess
                                 .source_map()
-                                .mk_substr_filename(self.tcx.def_span(*def_id)),
+                                .mk_substr_filename(self.tcx.real_def_span(*def_id)),
                         ),
                         (true, _) => format!(" ({})", ty.sort_string(self.tcx)),
                         (false, _) => "".to_string(),

--- a/src/librustc_infer/infer/error_reporting/need_type_info.rs
+++ b/src/librustc_infer/infer/error_reporting/need_type_info.rs
@@ -505,7 +505,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
             .span
             .span_labels()
             .iter()
-            .any(|span_label| span_label.label.is_some() && span_label.span == span)
+            .any(|span_label| span_label.label.is_some() && span_label.span == span.into())
             && local_visitor.found_arg_pattern.is_none()
         {
             // Avoid multiple labels pointing at `span`.

--- a/src/librustc_infer/infer/error_reporting/nice_region_error/trait_impl_difference.rs
+++ b/src/librustc_infer/infer/error_reporting/nice_region_error/trait_impl_difference.rs
@@ -6,7 +6,7 @@ use crate::infer::{Subtype, ValuePairs};
 use crate::traits::ObligationCauseCode::CompareImplMethodObligation;
 use rustc_errors::ErrorReported;
 use rustc_middle::ty::Ty;
-use rustc_span::Span;
+use rustc_span::{Span, SpanId};
 
 impl<'a, 'tcx> NiceRegionError<'a, 'tcx> {
     /// Print the error message for lifetime errors when the `impl` doesn't conform to the `trait`.
@@ -47,7 +47,7 @@ impl<'a, 'tcx> NiceRegionError<'a, 'tcx> {
         None
     }
 
-    fn emit_err(&self, sp: Span, expected: Ty<'tcx>, found: Ty<'tcx>, impl_sp: Span) {
+    fn emit_err(&self, sp: Span, expected: Ty<'tcx>, found: Ty<'tcx>, impl_sp: SpanId) {
         let mut err = self
             .tcx()
             .sess

--- a/src/librustc_infer/infer/lexical_region_resolve/mod.rs
+++ b/src/librustc_infer/infer/lexical_region_resolve/mod.rs
@@ -664,7 +664,7 @@ impl<'cx, 'tcx> LexicalResolver<'cx, 'tcx> {
                 .iter()
                 .map(|&choice_region| var_data.normalize(self.tcx(), choice_region));
             if !choice_regions.clone().any(|choice_region| member_region == choice_region) {
-                let span = self.tcx().def_span(member_constraint.opaque_type_def_id);
+                let span = self.tcx().real_def_span(member_constraint.opaque_type_def_id);
                 errors.push(RegionResolutionError::MemberConstraintFailure {
                     span,
                     hidden_ty: member_constraint.hidden_ty,

--- a/src/librustc_infer/infer/mod.rs
+++ b/src/librustc_infer/infer/mod.rs
@@ -33,7 +33,7 @@ use rustc_middle::ty::{self, GenericParamDefKind, InferConst, Ty, TyCtxt};
 use rustc_middle::ty::{ConstVid, FloatVid, IntVid, TyVid};
 use rustc_session::config::BorrowckMode;
 use rustc_span::symbol::Symbol;
-use rustc_span::Span;
+use rustc_span::{Span, SpanId};
 
 use std::cell::{Cell, Ref, RefCell};
 use std::collections::BTreeMap;
@@ -1579,7 +1579,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
         def_id: DefId,
         substs: SubstsRef<'tcx>,
         promoted: Option<mir::Promoted>,
-        span: Option<Span>,
+        span: Option<SpanId>,
     ) -> ConstEvalResult<'tcx> {
         let mut original_values = OriginalQueryValues::default();
         let canonical = self.canonicalize_query(&(param_env, substs), &mut original_values);

--- a/src/librustc_interface/callbacks.rs
+++ b/src/librustc_interface/callbacks.rs
@@ -35,10 +35,10 @@ fn track_diagnostic(diagnostic: Diagnostic) -> RealDiagnostic {
                 let mut diagnostics = diagnostics.lock();
                 diagnostics.extend(Some(diagnostic.clone()));
             }
-            diagnostic.map_span(|s| match s {
-                rustc_span::SpanId::Span(s) => s,
-                rustc_span::SpanId::DefId(d) => icx.tcx.def_span(d),
-            })
+
+            // Ignore dependencies when reifying spans.
+            let icx = tls::ImplicitCtxt { task_deps: None, ..icx.clone() };
+            tls::enter_context(&icx, |icx| diagnostic.map_span(|s| icx.tcx.reify_span(s)))
         } else {
             diagnostic.map_span(|s| match s {
                 rustc_span::SpanId::Span(s) => s,

--- a/src/librustc_interface/callbacks.rs
+++ b/src/librustc_interface/callbacks.rs
@@ -28,7 +28,7 @@ fn span_debug(span: rustc_span::Span, f: &mut fmt::Formatter<'_>) -> fmt::Result
 /// This is a callback from librustc_ast as it cannot access the implicit state
 /// in librustc_middle otherwise. It is used to when diagnostic messages are
 /// emitted and stores them in the current query, if there is one.
-fn track_diagnostic(diagnostic: &Diagnostic) {
+fn track_diagnostic(diagnostic: Diagnostic) -> Diagnostic {
     tls::with_context_opt(|icx| {
         if let Some(icx) = icx {
             if let Some(ref diagnostics) = icx.diagnostics {
@@ -36,7 +36,8 @@ fn track_diagnostic(diagnostic: &Diagnostic) {
                 diagnostics.extend(Some(diagnostic.clone()));
             }
         }
-    })
+    });
+    diagnostic
 }
 
 /// This is a callback from librustc_hir as it cannot access the implicit state
@@ -57,5 +58,5 @@ fn def_id_debug(def_id: rustc_hir::def_id::DefId, f: &mut fmt::Formatter<'_>) ->
 pub fn setup_callbacks() {
     rustc_span::SPAN_DEBUG.swap(&(span_debug as fn(_, &mut fmt::Formatter<'_>) -> _));
     rustc_hir::def_id::DEF_ID_DEBUG.swap(&(def_id_debug as fn(_, &mut fmt::Formatter<'_>) -> _));
-    TRACK_DIAGNOSTICS.swap(&(track_diagnostic as fn(&_)));
+    TRACK_DIAGNOSTICS.swap(&(track_diagnostic as fn(_) -> _));
 }

--- a/src/librustc_interface/callbacks.rs
+++ b/src/librustc_interface/callbacks.rs
@@ -15,9 +15,10 @@ use std::fmt;
 
 /// This is a callback from librustc_ast as it cannot access the implicit state
 /// in librustc_middle otherwise.
-fn span_debug(span: rustc_span::Span, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+fn span_debug(span: rustc_span::SpanId, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     tls::with_opt(|tcx| {
         if let Some(tcx) = tcx {
+            let span = tcx.reify_span(span);
             write!(f, "{}", tcx.sess.source_map().span_to_string(span))
         } else {
             rustc_span::default_span_debug(span, f)

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -562,7 +562,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for MissingCopyImplementations {
             return;
         }
         let param_env = ty::ParamEnv::empty();
-        if ty.is_copy_modulo_regions(cx.tcx, param_env, item.span) {
+        if ty.is_copy_modulo_regions(cx.tcx, param_env, item.span.into()) {
             return;
         }
         if can_type_implement_copy(cx.tcx, param_env, ty).is_ok() {

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -42,7 +42,7 @@ use rustc_session::lint::FutureIncompatibleInfo;
 use rustc_span::edition::Edition;
 use rustc_span::source_map::Spanned;
 use rustc_span::symbol::{kw, sym, Ident, Symbol};
-use rustc_span::{BytePos, Span};
+use rustc_span::{BytePos, Span, SpanId};
 use rustc_target::abi::VariantIdx;
 use rustc_trait_selection::traits::misc::can_type_implement_copy;
 
@@ -1491,7 +1491,7 @@ declare_lint_pass!(ExplicitOutlivesRequirements => [EXPLICIT_OUTLIVES_REQUIREMEN
 
 impl ExplicitOutlivesRequirements {
     fn lifetimes_outliving_lifetime<'tcx>(
-        inferred_outlives: &'tcx [(ty::Predicate<'tcx>, Span)],
+        inferred_outlives: &'tcx [(ty::Predicate<'tcx>, SpanId)],
         index: u32,
     ) -> Vec<ty::Region<'tcx>> {
         inferred_outlives
@@ -1510,7 +1510,7 @@ impl ExplicitOutlivesRequirements {
     }
 
     fn lifetimes_outliving_type<'tcx>(
-        inferred_outlives: &'tcx [(ty::Predicate<'tcx>, Span)],
+        inferred_outlives: &'tcx [(ty::Predicate<'tcx>, SpanId)],
         index: u32,
     ) -> Vec<ty::Region<'tcx>> {
         inferred_outlives
@@ -1529,7 +1529,7 @@ impl ExplicitOutlivesRequirements {
         &self,
         param: &'tcx hir::GenericParam<'tcx>,
         tcx: TyCtxt<'tcx>,
-        inferred_outlives: &'tcx [(ty::Predicate<'tcx>, Span)],
+        inferred_outlives: &'tcx [(ty::Predicate<'tcx>, SpanId)],
         ty_generics: &'tcx ty::Generics,
     ) -> Vec<ty::Region<'tcx>> {
         let index =

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -1977,7 +1977,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for InvalidValue {
                                         if span.is_none() {
                                             // Point to this field, should be helpful for figuring
                                             // out where the source of the error is.
-                                            let span = tcx.def_span(field.did);
+                                            let span = tcx.real_def_span(field.did);
                                             write!(
                                                 &mut msg,
                                                 " (in this {} field)",

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -1133,7 +1133,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for TypeAliasBounds {
         // The parameters must not have bounds
         for param in type_alias_generics.params.iter() {
             let spans: Vec<_> = param.bounds.iter().map(|b| b.span()).collect();
-            let suggestion = spans
+            let suggestion: Vec<_> = spans
                 .iter()
                 .map(|sp| {
                     let start = param.span.between(*sp); // Include the `:` in `T: Bound`.

--- a/src/librustc_lint/context.rs
+++ b/src/librustc_lint/context.rs
@@ -34,7 +34,7 @@ use rustc_middle::ty::{self, print::Printer, subst::GenericArg, Ty, TyCtxt};
 use rustc_session::lint::{add_elided_lifetime_in_path_suggestion, BuiltinLintDiagnostics};
 use rustc_session::lint::{FutureIncompatibleInfo, Level, Lint, LintBuffer, LintId};
 use rustc_session::Session;
-use rustc_span::{symbol::Symbol, MultiSpan, Span, DUMMY_SP};
+use rustc_span::{symbol::Symbol, MultiSpanId, Span, DUMMY_SP};
 use rustc_target::abi::LayoutOf;
 
 use std::slice;
@@ -477,7 +477,7 @@ pub trait LintContext: Sized {
     fn lookup_with_diagnostics(
         &self,
         lint: &'static Lint,
-        span: Option<impl Into<MultiSpan>>,
+        span: Option<impl Into<MultiSpanId>>,
         decorate: impl for<'a> FnOnce(LintDiagnosticBuilder<'a>),
         diagnostic: BuiltinLintDiagnostics,
     ) {
@@ -576,16 +576,16 @@ pub trait LintContext: Sized {
         });
     }
 
-    // FIXME: These methods should not take an Into<MultiSpan> -- instead, callers should need to
+    // FIXME: These methods should not take an Into<MultiSpanId> -- instead, callers should need to
     // set the span in their `decorate` function (preferably using set_span).
-    fn lookup<S: Into<MultiSpan>>(
+    fn lookup<S: Into<MultiSpanId>>(
         &self,
         lint: &'static Lint,
         span: Option<S>,
         decorate: impl for<'a> FnOnce(LintDiagnosticBuilder<'a>),
     );
 
-    fn struct_span_lint<S: Into<MultiSpan>>(
+    fn struct_span_lint<S: Into<MultiSpanId>>(
         &self,
         lint: &'static Lint,
         span: S,
@@ -629,7 +629,7 @@ impl LintContext for LateContext<'_, '_> {
         &*self.lint_store
     }
 
-    fn lookup<S: Into<MultiSpan>>(
+    fn lookup<S: Into<MultiSpanId>>(
         &self,
         lint: &'static Lint,
         span: Option<S>,
@@ -656,7 +656,7 @@ impl LintContext for EarlyContext<'_> {
         &*self.lint_store
     }
 
-    fn lookup<S: Into<MultiSpan>>(
+    fn lookup<S: Into<MultiSpanId>>(
         &self,
         lint: &'static Lint,
         span: Option<S>,

--- a/src/librustc_lint/levels.rs
+++ b/src/librustc_lint/levels.rs
@@ -17,7 +17,7 @@ use rustc_middle::ty::TyCtxt;
 use rustc_session::lint::{builtin, Level, Lint};
 use rustc_session::parse::feature_err;
 use rustc_session::Session;
-use rustc_span::source_map::MultiSpan;
+use rustc_span::source_map::MultiSpanId;
 use rustc_span::symbol::{sym, Symbol};
 
 use std::cmp;
@@ -398,7 +398,7 @@ impl<'s> LintLevelsBuilder<'s> {
     pub fn struct_lint(
         &self,
         lint: &'static Lint,
-        span: Option<MultiSpan>,
+        span: Option<MultiSpanId>,
         decorate: impl for<'a> FnOnce(LintDiagnosticBuilder<'a>),
     ) {
         let (level, src) = self.lint_level(lint);

--- a/src/librustc_macros/src/query.rs
+++ b/src/librustc_macros/src/query.rs
@@ -496,7 +496,7 @@ pub fn rustc_queries(input: TokenStream) -> TokenStream {
                             force_query::<crate::ty::query::queries::#name<'_>, _>(
                                 $tcx,
                                 key,
-                                DUMMY_SP,
+                                DUMMY_SPID,
                                 *$dep_node
                             );
                             return true;

--- a/src/librustc_metadata/rmeta/decoder.rs
+++ b/src/librustc_metadata/rmeta/decoder.rs
@@ -34,7 +34,7 @@ use rustc_serialize::{opaque, Decodable, Decoder, SpecializedDecoder};
 use rustc_session::Session;
 use rustc_span::source_map::{respan, Spanned};
 use rustc_span::symbol::{sym, Ident, Symbol};
-use rustc_span::{self, hygiene::MacroKind, BytePos, Pos, Span, DUMMY_SP};
+use rustc_span::{self, hygiene::MacroKind, BytePos, Pos, Span, SpanId, DUMMY_SP};
 
 use log::debug;
 use proc_macro::bridge::client::ProcMacro;
@@ -837,7 +837,7 @@ impl<'a, 'tcx> CrateMetadataRef<'a> {
         &self,
         item_id: DefIndex,
         tcx: TyCtxt<'tcx>,
-    ) -> &'tcx [(ty::Predicate<'tcx>, Span)] {
+    ) -> &'tcx [(ty::Predicate<'tcx>, SpanId)] {
         self.root
             .tables
             .inferred_outlives

--- a/src/librustc_metadata/rmeta/decoder/cstore_impl.rs
+++ b/src/librustc_metadata/rmeta/decoder/cstore_impl.rs
@@ -124,7 +124,7 @@ provide! { <'tcx> tcx, def_id, other, cdata,
     static_mutability => { cdata.static_mutability(def_id.index) }
     generator_kind => { cdata.generator_kind(def_id.index) }
     def_kind => { cdata.def_kind(def_id.index) }
-    def_span => { cdata.get_span(def_id.index, &tcx.sess) }
+    real_def_span => { cdata.get_span(def_id.index, &tcx.sess) }
     lookup_stability => {
         cdata.get_stability(def_id.index).map(|s| tcx.intern_stability(s))
     }

--- a/src/librustc_metadata/rmeta/encoder.rs
+++ b/src/librustc_metadata/rmeta/encoder.rs
@@ -622,7 +622,7 @@ impl EncodeContext<'tcx> {
         record!(self.tables.kind[def_id] <- EntryKind::Variant(self.lazy(data)));
         record!(self.tables.visibility[def_id] <-
             ty::Visibility::from_hir(enum_vis, enum_id, self.tcx));
-        record!(self.tables.span[def_id] <- self.tcx.def_span(def_id));
+        record!(self.tables.span[def_id] <- self.tcx.real_def_span(def_id));
         record!(self.tables.attributes[def_id] <- &self.tcx.get_attrs(def_id)[..]);
         record!(self.tables.children[def_id] <- variant.fields.iter().map(|f| {
             assert!(f.did.is_local());
@@ -671,7 +671,7 @@ impl EncodeContext<'tcx> {
 
         record!(self.tables.kind[def_id] <- EntryKind::Variant(self.lazy(data)));
         record!(self.tables.visibility[def_id] <- ctor_vis);
-        record!(self.tables.span[def_id] <- self.tcx.def_span(def_id));
+        record!(self.tables.span[def_id] <- self.tcx.real_def_span(def_id));
         self.encode_stability(def_id);
         self.encode_deprecation(def_id);
         self.encode_item_type(def_id);
@@ -706,7 +706,7 @@ impl EncodeContext<'tcx> {
 
         record!(self.tables.kind[def_id] <- EntryKind::Mod(self.lazy(data)));
         record!(self.tables.visibility[def_id] <- ty::Visibility::from_hir(vis, id, self.tcx));
-        record!(self.tables.span[def_id] <- self.tcx.def_span(def_id));
+        record!(self.tables.span[def_id] <- self.tcx.real_def_span(def_id));
         record!(self.tables.attributes[def_id] <- attrs);
         record!(self.tables.children[def_id] <- md.item_ids.iter().map(|item_id| {
             tcx.hir().local_def_id(item_id.id).local_def_index
@@ -733,7 +733,7 @@ impl EncodeContext<'tcx> {
 
         record!(self.tables.kind[def_id] <- EntryKind::Field);
         record!(self.tables.visibility[def_id] <- field.vis);
-        record!(self.tables.span[def_id] <- self.tcx.def_span(def_id));
+        record!(self.tables.span[def_id] <- self.tcx.real_def_span(def_id));
         record!(self.tables.attributes[def_id] <- variant_data.fields()[field_index].attrs);
         self.encode_ident_span(def_id, field.ident);
         self.encode_stability(def_id);
@@ -774,7 +774,7 @@ impl EncodeContext<'tcx> {
 
         record!(self.tables.kind[def_id] <- EntryKind::Struct(self.lazy(data), adt_def.repr));
         record!(self.tables.visibility[def_id] <- ctor_vis);
-        record!(self.tables.span[def_id] <- self.tcx.def_span(def_id));
+        record!(self.tables.span[def_id] <- self.tcx.real_def_span(def_id));
         self.encode_stability(def_id);
         self.encode_deprecation(def_id);
         self.encode_item_type(def_id);
@@ -1301,7 +1301,7 @@ impl EncodeContext<'tcx> {
     fn encode_info_for_generic_param(&mut self, def_id: DefId, kind: EntryKind, encode_type: bool) {
         record!(self.tables.kind[def_id] <- kind);
         record!(self.tables.visibility[def_id] <- ty::Visibility::Public);
-        record!(self.tables.span[def_id] <- self.tcx.def_span(def_id));
+        record!(self.tables.span[def_id] <- self.tcx.real_def_span(def_id));
         if encode_type {
             self.encode_item_type(def_id);
         }
@@ -1326,7 +1326,7 @@ impl EncodeContext<'tcx> {
             _ => bug!("closure that is neither generator nor closure"),
         });
         record!(self.tables.visibility[def_id.to_def_id()] <- ty::Visibility::Public);
-        record!(self.tables.span[def_id.to_def_id()] <- self.tcx.def_span(def_id));
+        record!(self.tables.span[def_id.to_def_id()] <- self.tcx.real_def_span(def_id));
         record!(self.tables.attributes[def_id.to_def_id()] <- &self.tcx.get_attrs(def_id.to_def_id())[..]);
         self.encode_item_type(def_id.to_def_id());
         if let ty::Closure(def_id, substs) = ty.kind {
@@ -1346,7 +1346,7 @@ impl EncodeContext<'tcx> {
 
         record!(self.tables.kind[def_id.to_def_id()] <- EntryKind::Const(qualifs, const_data));
         record!(self.tables.visibility[def_id.to_def_id()] <- ty::Visibility::Public);
-        record!(self.tables.span[def_id.to_def_id()] <- self.tcx.def_span(def_id));
+        record!(self.tables.span[def_id.to_def_id()] <- self.tcx.real_def_span(def_id));
         self.encode_item_type(def_id.to_def_id());
         self.encode_generics(def_id.to_def_id());
         self.encode_explicit_predicates(def_id.to_def_id());

--- a/src/librustc_metadata/rmeta/encoder.rs
+++ b/src/librustc_metadata/rmeta/encoder.rs
@@ -253,10 +253,10 @@ impl<'tcx> SpecializedEncoder<interpret::AllocId> for EncodeContext<'tcx> {
     }
 }
 
-impl<'tcx> SpecializedEncoder<&'tcx [(ty::Predicate<'tcx>, Span)]> for EncodeContext<'tcx> {
+impl<'tcx> SpecializedEncoder<&'tcx [(ty::Predicate<'tcx>, SpanId)]> for EncodeContext<'tcx> {
     fn specialized_encode(
         &mut self,
-        predicates: &&'tcx [(ty::Predicate<'tcx>, Span)],
+        predicates: &&'tcx [(ty::Predicate<'tcx>, SpanId)],
     ) -> Result<(), Self::Error> {
         ty_codec::encode_spanned_predicates(self, predicates, |ecx| &mut ecx.predicate_shorthands)
     }

--- a/src/librustc_metadata/rmeta/mod.rs
+++ b/src/librustc_metadata/rmeta/mod.rs
@@ -20,7 +20,7 @@ use rustc_session::config::SymbolManglingVersion;
 use rustc_session::CrateDisambiguator;
 use rustc_span::edition::Edition;
 use rustc_span::symbol::Symbol;
-use rustc_span::{self, Span};
+use rustc_span::{self, Span, SpanId};
 use rustc_target::spec::{PanicStrategy, TargetTriple};
 
 use std::marker::PhantomData;
@@ -273,7 +273,7 @@ define_tables! {
     // as it's an `enum` for which we want to derive (de)serialization,
     // so the `ty::codec` APIs handle the whole `&'tcx [...]` at once.
     // Also, as an optimization, a missing entry indicates an empty `&[]`.
-    inferred_outlives: Table<DefIndex, Lazy!(&'tcx [(ty::Predicate<'tcx>, Span)])>,
+    inferred_outlives: Table<DefIndex, Lazy!(&'tcx [(ty::Predicate<'tcx>, SpanId)])>,
     super_predicates: Table<DefIndex, Lazy!(ty::GenericPredicates<'tcx>)>,
     mir: Table<DefIndex, Lazy!(mir::Body<'tcx>)>,
     promoted_mir: Table<DefIndex, Lazy!(IndexVec<mir::Promoted, mir::Body<'tcx>>)>,

--- a/src/librustc_middle/lint.rs
+++ b/src/librustc_middle/lint.rs
@@ -339,7 +339,7 @@ pub fn struct_lint_level<'s, 'd>(
 pub fn in_external_macro(sess: &Session, span: SpanId) -> bool {
     let span = match span {
         SpanId::Span(span) => span,
-        SpanId::DefId(def_id) => crate::ty::tls::with(|tcx| tcx.def_span(def_id)),
+        SpanId::DefId(def_id) => crate::ty::tls::with(|tcx| tcx.real_def_span(def_id)),
     };
     let expn_data = span.ctxt().outer_expn_data();
     match expn_data.kind {

--- a/src/librustc_middle/middle/stability.rs
+++ b/src/librustc_middle/middle/stability.rs
@@ -110,7 +110,7 @@ pub fn report_unstable(
     let span_key = msp.primary_span().and_then(|sp: Span| {
         if !sp.is_dummy() {
             let file = sm.lookup_char_pos(sp.lo()).file;
-            if file.is_imported() { None } else { Some(span) }
+            if file.is_imported() { None } else { Some(span.into()) }
         } else {
             None
         }

--- a/src/librustc_middle/mir/interpret/error.rs
+++ b/src/librustc_middle/mir/interpret/error.rs
@@ -36,7 +36,7 @@ pub type ConstEvalResult<'tcx> = Result<ConstValue<'tcx>, ErrorHandled>;
 
 #[derive(Debug)]
 pub struct ConstEvalErr<'tcx> {
-    pub span: Span,
+    pub span: SpanId,
     pub error: crate::mir::interpret::InterpError<'tcx>,
     pub stacktrace: Vec<FrameInfo<'tcx>>,
 }

--- a/src/librustc_middle/mir/interpret/error.rs
+++ b/src/librustc_middle/mir/interpret/error.rs
@@ -11,7 +11,7 @@ use rustc_hir as hir;
 use rustc_hir::definitions::DefPathData;
 use rustc_macros::HashStable;
 use rustc_session::CtfeBacktrace;
-use rustc_span::{def_id::DefId, Pos, Span};
+use rustc_span::{def_id::DefId, Pos, Span, SpanId};
 use rustc_target::abi::{Align, Size};
 use std::{any::Any, backtrace::Backtrace, fmt, mem};
 
@@ -86,7 +86,7 @@ impl<'tcx> ConstEvalErr<'tcx> {
         tcx: TyCtxtAt<'tcx>,
         message: &str,
         lint_root: hir::HirId,
-        span: Option<Span>,
+        span: Option<impl Into<SpanId>>,
     ) -> ErrorHandled {
         self.struct_generic(
             tcx,
@@ -94,6 +94,7 @@ impl<'tcx> ConstEvalErr<'tcx> {
             |mut lint: DiagnosticBuilder<'_>| {
                 // Apply the span.
                 if let Some(span) = span {
+                    let span = span.into();
                     let primary_spans = lint.span.primary_spans().to_vec();
                     // point at the actual error as the primary span
                     lint.replace_span_with(span);

--- a/src/librustc_middle/mir/interpret/error.rs
+++ b/src/librustc_middle/mir/interpret/error.rs
@@ -11,7 +11,7 @@ use rustc_hir as hir;
 use rustc_hir::definitions::DefPathData;
 use rustc_macros::HashStable;
 use rustc_session::CtfeBacktrace;
-use rustc_span::{def_id::DefId, Pos, Span, SpanId};
+use rustc_span::{def_id::DefId, Pos, SpanId};
 use rustc_target::abi::{Align, Size};
 use std::{any::Any, backtrace::Backtrace, fmt, mem};
 
@@ -44,7 +44,7 @@ pub struct ConstEvalErr<'tcx> {
 #[derive(Debug)]
 pub struct FrameInfo<'tcx> {
     pub instance: ty::Instance<'tcx>,
-    pub span: Span,
+    pub span: SpanId,
     pub lint_root: Option<hir::HirId>,
 }
 
@@ -59,7 +59,8 @@ impl<'tcx> fmt::Display for FrameInfo<'tcx> {
                 write!(f, "inside `{}`", self.instance)?;
             }
             if !self.span.is_dummy() {
-                let lo = tcx.sess.source_map().lookup_char_pos(self.span.lo());
+                let span = tcx.reify_span(self.span);
+                let lo = tcx.sess.source_map().lookup_char_pos(span.lo());
                 write!(f, " at {}:{}:{}", lo.file.name, lo.line, lo.col.to_usize() + 1)?;
             }
             Ok(())

--- a/src/librustc_middle/mir/interpret/queries.rs
+++ b/src/librustc_middle/mir/interpret/queries.rs
@@ -4,7 +4,7 @@ use crate::mir;
 use crate::ty::subst::{InternalSubsts, SubstsRef};
 use crate::ty::{self, TyCtxt};
 use rustc_hir::def_id::DefId;
-use rustc_span::Span;
+use rustc_span::SpanId;
 
 impl<'tcx> TyCtxt<'tcx> {
     /// Evaluates a constant without providing any substitutions. This is useful to evaluate consts
@@ -37,7 +37,7 @@ impl<'tcx> TyCtxt<'tcx> {
         def_id: DefId,
         substs: SubstsRef<'tcx>,
         promoted: Option<mir::Promoted>,
-        span: Option<Span>,
+        span: Option<SpanId>,
     ) -> ConstEvalResult<'tcx> {
         match ty::Instance::resolve(self, param_env, def_id, substs) {
             Ok(Some(instance)) => {
@@ -53,7 +53,7 @@ impl<'tcx> TyCtxt<'tcx> {
         self,
         param_env: ty::ParamEnv<'tcx>,
         instance: ty::Instance<'tcx>,
-        span: Option<Span>,
+        span: Option<SpanId>,
     ) -> ConstEvalResult<'tcx> {
         self.const_eval_global_id(param_env, GlobalId { instance, promoted: None }, span)
     }
@@ -63,7 +63,7 @@ impl<'tcx> TyCtxt<'tcx> {
         self,
         param_env: ty::ParamEnv<'tcx>,
         cid: GlobalId<'tcx>,
-        span: Option<Span>,
+        span: Option<SpanId>,
     ) -> ConstEvalResult<'tcx> {
         // Const-eval shouldn't depend on lifetimes at all, so we can erase them, which should
         // improve caching of queries.

--- a/src/librustc_middle/mir/mono.rs
+++ b/src/librustc_middle/mir/mono.rs
@@ -10,7 +10,7 @@ use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
 use rustc_hir::def_id::{CrateNum, DefId, LocalDefId, LOCAL_CRATE};
 use rustc_hir::HirId;
 use rustc_session::config::OptLevel;
-use rustc_span::source_map::Span;
+use rustc_span::source_map::SpanId;
 use rustc_span::symbol::Symbol;
 use std::fmt;
 use std::hash::Hash;
@@ -195,7 +195,7 @@ impl<'tcx> MonoItem<'tcx> {
         }
     }
 
-    pub fn local_span(&self, tcx: TyCtxt<'tcx>) -> Option<Span> {
+    pub fn local_span(&self, tcx: TyCtxt<'tcx>) -> Option<SpanId> {
         match *self {
             MonoItem::Fn(Instance { def, .. }) => {
                 def.def_id().as_local().map(|def_id| tcx.hir().as_local_hir_id(def_id))
@@ -205,7 +205,7 @@ impl<'tcx> MonoItem<'tcx> {
             }
             MonoItem::GlobalAsm(hir_id) => Some(hir_id),
         }
-        .map(|hir_id| tcx.hir().span(hir_id))
+        .map(|hir_id| tcx.hir().span(hir_id).into())
     }
 }
 

--- a/src/librustc_middle/mir/query.rs
+++ b/src/librustc_middle/mir/query.rs
@@ -7,7 +7,7 @@ use rustc_hir as hir;
 use rustc_hir::def_id::DefId;
 use rustc_index::bit_set::BitMatrix;
 use rustc_index::vec::IndexVec;
-use rustc_span::{Span, Symbol};
+use rustc_span::{SpanId, Symbol};
 use rustc_target::abi::VariantIdx;
 use smallvec::SmallVec;
 
@@ -157,7 +157,7 @@ pub struct ClosureOutlivesRequirement<'tcx> {
     pub outlived_free_region: ty::RegionVid,
 
     // If not, report an error here ...
-    pub blame_span: Span,
+    pub blame_span: SpanId,
 
     // ... due to this reason.
     pub category: ConstraintCategory,

--- a/src/librustc_middle/mir/visit.rs
+++ b/src/librustc_middle/mir/visit.rs
@@ -1,7 +1,7 @@
 use crate::mir::*;
 use crate::ty::subst::SubstsRef;
 use crate::ty::{CanonicalUserTypeAnnotation, Ty};
-use rustc_span::Span;
+use rustc_span::SpanId;
 
 // # The MIR Visitor
 //
@@ -163,7 +163,7 @@ macro_rules! make_mir_visitor {
             }
 
             fn visit_span(&mut self,
-                          span: & $($mutability)? Span) {
+                          span: & $($mutability)? SpanId) {
                 self.super_span(span);
             }
 
@@ -774,7 +774,7 @@ macro_rules! make_mir_visitor {
                 self.visit_const(literal, location);
             }
 
-            fn super_span(&mut self, _span: & $($mutability)? Span) {
+            fn super_span(&mut self, _span: & $($mutability)? SpanId) {
             }
 
             fn super_source_info(&mut self, source_info: & $($mutability)? SourceInfo) {
@@ -798,8 +798,8 @@ macro_rules! make_mir_visitor {
                 _index: UserTypeAnnotationIndex,
                 ty: & $($mutability)? CanonicalUserTypeAnnotation<'tcx>,
             ) {
-                self.visit_span(& $($mutability)? ty.span);
-                self.visit_ty(& $($mutability)? ty.inferred_ty, TyContext::UserTy(ty.span));
+                self.visit_span(& $($mutability)? ty.span.into());
+                self.visit_ty(& $($mutability)? ty.inferred_ty, TyContext::UserTy(ty.span.into()));
             }
 
             fn super_ty(&mut self, _ty: $(& $mutability)? Ty<'tcx>) {
@@ -1024,7 +1024,7 @@ pub enum TyContext {
     },
 
     /// The inferred type of a user type annotation.
-    UserTy(Span),
+    UserTy(SpanId),
 
     /// The return type of the function.
     ReturnTy(SourceInfo),

--- a/src/librustc_middle/query/mod.rs
+++ b/src/librustc_middle/query/mod.rs
@@ -618,7 +618,7 @@ rustc_queries! {
         }
 
         query def_kind(_: DefId) -> DefKind {}
-        query def_span(_: DefId) -> Span {
+        query real_def_span(_: DefId) -> Span {
             // FIXME(mw): DefSpans are not really inputs since they are derived from
             // HIR. But at the moment HIR hashing still contains some hacks that allow
             // to make type debuginfo to be source location independent. Declaring

--- a/src/librustc_middle/query/mod.rs
+++ b/src/librustc_middle/query/mod.rs
@@ -245,7 +245,7 @@ rustc_queries! {
 
         /// Returns the inferred outlives predicates (e.g., for `struct
         /// Foo<'a, T> { x: &'a T }`, this would return `T: 'a`).
-        query inferred_outlives_of(_: DefId) -> &'tcx [(ty::Predicate<'tcx>, Span)] {}
+        query inferred_outlives_of(_: DefId) -> &'tcx [(ty::Predicate<'tcx>, SpanId)] {}
 
         /// Maps from the `DefId` of a trait to the list of
         /// super-predicates. This is a subset of the full list of
@@ -1048,7 +1048,7 @@ rustc_queries! {
             desc { |tcx| "maybe_unused_trait_import for `{}`", tcx.def_path_str(def_id.to_def_id()) }
         }
         query maybe_unused_extern_crates(_: CrateNum)
-            -> &'tcx [(DefId, Span)] {
+            -> &'tcx [(DefId, SpanId)] {
             eval_always
             desc { "looking up all possibly unused extern crates" }
         }

--- a/src/librustc_middle/ty/codec.rs
+++ b/src/librustc_middle/ty/codec.rs
@@ -14,7 +14,7 @@ use crate::ty::{self, List, Ty, TyCtxt};
 use rustc_data_structures::fx::FxHashMap;
 use rustc_hir::def_id::{CrateNum, DefId};
 use rustc_serialize::{opaque, Decodable, Decoder, Encodable, Encoder};
-use rustc_span::Span;
+use rustc_span::SpanId;
 use std::hash::Hash;
 use std::intrinsics;
 
@@ -93,7 +93,7 @@ where
 
 pub fn encode_spanned_predicates<'tcx, E, C>(
     encoder: &mut E,
-    predicates: &'tcx [(ty::Predicate<'tcx>, Span)],
+    predicates: &'tcx [(ty::Predicate<'tcx>, SpanId)],
     cache: C,
 ) -> Result<(), E::Error>
 where
@@ -187,7 +187,7 @@ where
 #[inline]
 pub fn decode_spanned_predicates<D>(
     decoder: &mut D,
-) -> Result<&'tcx [(ty::Predicate<'tcx>, Span)], D::Error>
+) -> Result<&'tcx [(ty::Predicate<'tcx>, SpanId)], D::Error>
 where
     D: TyDecoder<'tcx>,
 {
@@ -356,7 +356,7 @@ macro_rules! implement_ty_decoder {
             use $crate::ty::subst::SubstsRef;
             use rustc_hir::def_id::{CrateNum};
 
-            use rustc_span::Span;
+            use rustc_span::SpanId;
 
             use super::$DecoderName;
 
@@ -413,10 +413,10 @@ macro_rules! implement_ty_decoder {
                 }
             }
 
-            impl<$($typaram),*> SpecializedDecoder<&'tcx [(ty::Predicate<'tcx>, Span)]>
+            impl<$($typaram),*> SpecializedDecoder<&'tcx [(ty::Predicate<'tcx>, SpanId)]>
             for $DecoderName<$($typaram),*> {
                 fn specialized_decode(&mut self)
-                                      -> Result<&'tcx [(ty::Predicate<'tcx>, Span)], Self::Error> {
+                                      -> Result<&'tcx [(ty::Predicate<'tcx>, SpanId)], Self::Error> {
                     decode_spanned_predicates(self)
                 }
             }

--- a/src/librustc_middle/ty/context.rs
+++ b/src/librustc_middle/ty/context.rs
@@ -57,7 +57,7 @@ use rustc_macros::HashStable;
 use rustc_session::config::{BorrowckMode, CrateType, OutputFilenames};
 use rustc_session::lint::{Level, Lint};
 use rustc_session::Session;
-use rustc_span::source_map::MultiSpan;
+use rustc_span::source_map::MultiSpanId;
 use rustc_span::symbol::{kw, sym, Symbol};
 use rustc_span::Span;
 use rustc_target::abi::{Layout, TargetDataLayout, VariantIdx};
@@ -2562,7 +2562,7 @@ impl<'tcx> TyCtxt<'tcx> {
         self,
         lint: &'static Lint,
         hir_id: HirId,
-        span: impl Into<MultiSpan>,
+        span: impl Into<MultiSpanId>,
         decorate: impl for<'a> FnOnce(LintDiagnosticBuilder<'a>),
     ) {
         let (level, src) = self.lint_level_at_node(lint, hir_id);

--- a/src/librustc_middle/ty/context.rs
+++ b/src/librustc_middle/ty/context.rs
@@ -942,7 +942,7 @@ pub struct GlobalCtxt<'tcx> {
     pub queries: query::Queries<'tcx>,
 
     maybe_unused_trait_imports: FxHashSet<LocalDefId>,
-    maybe_unused_extern_crates: Vec<(DefId, Span)>,
+    maybe_unused_extern_crates: Vec<(DefId, SpanId)>,
     /// A map of glob use to a set of names it actually imports. Currently only
     /// used in save-analysis.
     glob_map: FxHashMap<LocalDefId, FxHashSet<Symbol>>,
@@ -1158,7 +1158,7 @@ impl<'tcx> TyCtxt<'tcx> {
             maybe_unused_extern_crates: resolutions
                 .maybe_unused_extern_crates
                 .into_iter()
-                .map(|(id, sp)| (definitions.local_def_id(id).to_def_id(), sp))
+                .map(|(id, sp)| (definitions.local_def_id(id).to_def_id(), sp.into()))
                 .collect(),
             glob_map: resolutions
                 .glob_map

--- a/src/librustc_middle/ty/context.rs
+++ b/src/librustc_middle/ty/context.rs
@@ -59,7 +59,7 @@ use rustc_session::lint::{Level, Lint};
 use rustc_session::Session;
 use rustc_span::source_map::MultiSpanId;
 use rustc_span::symbol::{kw, sym, Symbol};
-use rustc_span::Span;
+use rustc_span::{Span, SpanId};
 use rustc_target::abi::{Layout, TargetDataLayout, VariantIdx};
 use rustc_target::spec::abi;
 
@@ -1223,6 +1223,17 @@ impl<'tcx> TyCtxt<'tcx> {
 
     pub fn features(self) -> &'tcx rustc_feature::Features {
         self.features_query(LOCAL_CRATE)
+    }
+
+    pub fn def_span(self, id: impl ty::query::IntoQueryParam<rustc_span::def_id::DefId>) -> SpanId {
+        SpanId::DefId(id.into_query_param())
+    }
+
+    pub fn reify_span(self, sp: SpanId) -> Span {
+        match sp {
+            SpanId::Span(sp) => sp,
+            SpanId::DefId(id) => self.real_def_span(id),
+        }
     }
 
     pub fn def_key(self, id: DefId) -> rustc_hir::definitions::DefKey {

--- a/src/librustc_middle/ty/error.rs
+++ b/src/librustc_middle/ty/error.rs
@@ -381,11 +381,11 @@ impl<'tcx> TyCtxt<'tcx> {
                     }
                     (ty::Param(expected), ty::Param(found)) => {
                         let generics = self.generics_of(body_owner_def_id);
-                        let e_span = self.def_span(generics.type_param(expected, self).def_id);
+                        let e_span = self.real_def_span(generics.type_param(expected, self).def_id);
                         if !sp.contains(e_span) {
                             db.span_label(e_span, "expected type parameter");
                         }
-                        let f_span = self.def_span(generics.type_param(found, self).def_id);
+                        let f_span = self.real_def_span(generics.type_param(found, self).def_id);
                         if !sp.contains(f_span) {
                             db.span_label(f_span, "found type parameter");
                         }
@@ -404,7 +404,7 @@ impl<'tcx> TyCtxt<'tcx> {
                     }
                     (ty::Param(p), ty::Projection(proj)) | (ty::Projection(proj), ty::Param(p)) => {
                         let generics = self.generics_of(body_owner_def_id);
-                        let p_span = self.def_span(generics.type_param(p, self).def_id);
+                        let p_span = self.real_def_span(generics.type_param(p, self).def_id);
                         if !sp.contains(p_span) {
                             db.span_label(p_span, "this type parameter");
                         }
@@ -446,7 +446,7 @@ impl<'tcx> TyCtxt<'tcx> {
                     (ty::Param(p), ty::Dynamic(..) | ty::Opaque(..))
                     | (ty::Dynamic(..) | ty::Opaque(..), ty::Param(p)) => {
                         let generics = self.generics_of(body_owner_def_id);
-                        let p_span = self.def_span(generics.type_param(p, self).def_id);
+                        let p_span = self.real_def_span(generics.type_param(p, self).def_id);
                         if !sp.contains(p_span) {
                             db.span_label(p_span, "this type parameter");
                         }
@@ -486,7 +486,7 @@ impl<T> Trait<T> for X {
                     }
                     (ty::Param(p), _) | (_, ty::Param(p)) => {
                         let generics = self.generics_of(body_owner_def_id);
-                        let p_span = self.def_span(generics.type_param(p, self).def_id);
+                        let p_span = self.real_def_span(generics.type_param(p, self).def_id);
                         if !sp.contains(p_span) {
                             db.span_label(p_span, "this type parameter");
                         }
@@ -696,7 +696,7 @@ impl<T> Trait<T> for X {
             // a return type. This can occur when dealing with `TryStream` (#71035).
             if self.constrain_associated_type_structured_suggestion(
                 db,
-                self.def_span(def_id),
+                self.real_def_span(def_id),
                 &assoc,
                 values.found,
                 &msg,
@@ -766,7 +766,7 @@ fn foo(&self) -> Self::T { String::new() }
                         if item_def_id == proj_ty_item_def_id =>
                     {
                         Some((
-                            self.sess.source_map().guess_head_span(self.def_span(item.def_id)),
+                            self.sess.source_map().guess_head_span(self.real_def_span(item.def_id)),
                             format!("consider calling `{}`", self.def_path_str(item.def_id)),
                         ))
                     }

--- a/src/librustc_middle/ty/layout.rs
+++ b/src/librustc_middle/ty/layout.rs
@@ -12,7 +12,7 @@ use rustc_index::bit_set::BitSet;
 use rustc_index::vec::{Idx, IndexVec};
 use rustc_session::{DataTypeKind, FieldInfo, SizeKind, VariantInfo};
 use rustc_span::symbol::{Ident, Symbol};
-use rustc_span::DUMMY_SP;
+use rustc_span::DUMMY_SPID;
 use rustc_target::abi::call::{
     ArgAbi, ArgAttribute, ArgAttributes, Conv, FnAbi, PassMode, Reg, RegKind,
 };
@@ -535,7 +535,7 @@ impl<'tcx> LayoutCx<'tcx, TyCtxt<'tcx>> {
                 }
 
                 let pointee = tcx.normalize_erasing_regions(param_env, pointee);
-                if pointee.is_sized(tcx.at(DUMMY_SP), param_env) {
+                if pointee.is_sized(tcx.at(DUMMY_SPID), param_env) {
                     return Ok(tcx.intern_layout(Layout::scalar(self, data_ptr)));
                 }
 
@@ -798,7 +798,7 @@ impl<'tcx> LayoutCx<'tcx, TyCtxt<'tcx>> {
                         let param_env = tcx.param_env(def.did);
                         let last_field = def.variants[v].fields.last().unwrap();
                         let always_sized =
-                            tcx.type_of(last_field.did).is_sized(tcx.at(DUMMY_SP), param_env);
+                            tcx.type_of(last_field.did).is_sized(tcx.at(DUMMY_SPID), param_env);
                         if !always_sized {
                             StructKind::MaybeUnsized
                         } else {
@@ -2160,7 +2160,7 @@ where
 
             ty::Ref(_, ty, mt) if offset.bytes() == 0 => {
                 let tcx = cx.tcx();
-                let is_freeze = ty.is_freeze(tcx, cx.param_env(), DUMMY_SP);
+                let is_freeze = ty.is_freeze(tcx, cx.param_env(), DUMMY_SPID);
                 let kind = match mt {
                     hir::Mutability::Not => {
                         if is_freeze {

--- a/src/librustc_middle/ty/mod.rs
+++ b/src/librustc_middle/ty/mod.rs
@@ -39,7 +39,7 @@ use rustc_serialize::{self, Encodable, Encoder};
 use rustc_session::DataTypeKind;
 use rustc_span::hygiene::ExpnId;
 use rustc_span::symbol::{kw, sym, Ident, Symbol};
-use rustc_span::Span;
+use rustc_span::{Span, SpanId};
 use rustc_target::abi::{Align, VariantIdx};
 
 use std::cell::RefCell;
@@ -1082,7 +1082,7 @@ impl<'tcx> Generics {
 #[derive(Copy, Clone, Default, Debug, RustcEncodable, RustcDecodable, HashStable)]
 pub struct GenericPredicates<'tcx> {
     pub parent: Option<DefId>,
-    pub predicates: &'tcx [(Predicate<'tcx>, Span)],
+    pub predicates: &'tcx [(Predicate<'tcx>, SpanId)],
 }
 
 impl<'tcx> GenericPredicates<'tcx> {
@@ -1206,7 +1206,7 @@ pub struct CratePredicatesMap<'tcx> {
     /// For each struct with outlive bounds, maps to a vector of the
     /// predicate of its outlive bounds. If an item has no outlives
     /// bounds, it will have no entry.
-    pub predicates: FxHashMap<DefId, &'tcx [(ty::Predicate<'tcx>, Span)]>,
+    pub predicates: FxHashMap<DefId, &'tcx [(ty::Predicate<'tcx>, SpanId)]>,
 }
 
 impl<'tcx> AsRef<Predicate<'tcx>> for Predicate<'tcx> {
@@ -1529,7 +1529,7 @@ impl<'tcx> Predicate<'tcx> {
 #[derive(Clone, Debug, TypeFoldable)]
 pub struct InstantiatedPredicates<'tcx> {
     pub predicates: Vec<Predicate<'tcx>>,
-    pub spans: Vec<Span>,
+    pub spans: Vec<SpanId>,
 }
 
 impl<'tcx> InstantiatedPredicates<'tcx> {

--- a/src/librustc_middle/ty/print/pretty.rs
+++ b/src/librustc_middle/ty/print/pretty.rs
@@ -895,7 +895,7 @@ pub trait PrettyPrinter<'tcx>:
                         }
                         _ => {
                             if did.is_local() {
-                                let span = self.tcx().def_span(did);
+                                let span = self.tcx().real_def_span(did);
                                 if let Ok(snip) = self.tcx().sess.source_map().span_to_snippet(span)
                                 {
                                     p!(write("{}", snip))
@@ -1347,7 +1347,7 @@ impl<F: fmt::Write> Printer<'tcx> for FmtPrinter<'_, 'tcx, F> {
                 // pretty printing some span information. This should
                 // only occur very early in the compiler pipeline.
                 let parent_def_id = DefId { index: key.parent.unwrap(), ..def_id };
-                let span = self.tcx.def_span(def_id);
+                let span = self.tcx.real_def_span(def_id);
 
                 self = self.print_def_path(parent_def_id, &[])?;
 

--- a/src/librustc_middle/ty/query/keys.rs
+++ b/src/librustc_middle/ty/query/keys.rs
@@ -8,7 +8,7 @@ use crate::ty::{self, Ty, TyCtxt};
 use rustc_hir::def_id::{CrateNum, DefId, LocalDefId, LOCAL_CRATE};
 use rustc_query_system::query::DefaultCacheSelector;
 use rustc_span::symbol::Symbol;
-use rustc_span::{Span, DUMMY_SP};
+use rustc_span::{SpanId, DUMMY_SPID};
 
 /// The `Key` trait controls what types can legally be used as the key
 /// for a query.
@@ -21,7 +21,7 @@ pub trait Key {
 
     /// In the event that a cycle occurs, if no explicit span has been
     /// given for a query with key `self`, what span should we use?
-    fn default_span(&self, tcx: TyCtxt<'_>) -> Span;
+    fn default_span(&self, tcx: TyCtxt<'_>) -> SpanId;
 }
 
 impl<'tcx> Key for ty::InstanceDef<'tcx> {
@@ -31,7 +31,7 @@ impl<'tcx> Key for ty::InstanceDef<'tcx> {
         LOCAL_CRATE
     }
 
-    fn default_span(&self, tcx: TyCtxt<'_>) -> Span {
+    fn default_span(&self, tcx: TyCtxt<'_>) -> SpanId {
         tcx.def_span(self.def_id())
     }
 }
@@ -43,7 +43,7 @@ impl<'tcx> Key for ty::Instance<'tcx> {
         LOCAL_CRATE
     }
 
-    fn default_span(&self, tcx: TyCtxt<'_>) -> Span {
+    fn default_span(&self, tcx: TyCtxt<'_>) -> SpanId {
         tcx.def_span(self.def_id())
     }
 }
@@ -55,7 +55,7 @@ impl<'tcx> Key for mir::interpret::GlobalId<'tcx> {
         self.instance.query_crate()
     }
 
-    fn default_span(&self, tcx: TyCtxt<'_>) -> Span {
+    fn default_span(&self, tcx: TyCtxt<'_>) -> SpanId {
         self.instance.default_span(tcx)
     }
 }
@@ -67,8 +67,8 @@ impl<'tcx> Key for mir::interpret::LitToConstInput<'tcx> {
         LOCAL_CRATE
     }
 
-    fn default_span(&self, _tcx: TyCtxt<'_>) -> Span {
-        DUMMY_SP
+    fn default_span(&self, _tcx: TyCtxt<'_>) -> SpanId {
+        DUMMY_SPID
     }
 }
 
@@ -78,8 +78,8 @@ impl Key for CrateNum {
     fn query_crate(&self) -> CrateNum {
         *self
     }
-    fn default_span(&self, _: TyCtxt<'_>) -> Span {
-        DUMMY_SP
+    fn default_span(&self, _: TyCtxt<'_>) -> SpanId {
+        DUMMY_SPID
     }
 }
 
@@ -89,7 +89,7 @@ impl Key for LocalDefId {
     fn query_crate(&self) -> CrateNum {
         self.to_def_id().query_crate()
     }
-    fn default_span(&self, tcx: TyCtxt<'_>) -> Span {
+    fn default_span(&self, tcx: TyCtxt<'_>) -> SpanId {
         self.to_def_id().default_span(tcx)
     }
 }
@@ -100,7 +100,7 @@ impl Key for DefId {
     fn query_crate(&self) -> CrateNum {
         self.krate
     }
-    fn default_span(&self, tcx: TyCtxt<'_>) -> Span {
+    fn default_span(&self, tcx: TyCtxt<'_>) -> SpanId {
         tcx.def_span(*self)
     }
 }
@@ -111,7 +111,7 @@ impl Key for (DefId, DefId) {
     fn query_crate(&self) -> CrateNum {
         self.0.krate
     }
-    fn default_span(&self, tcx: TyCtxt<'_>) -> Span {
+    fn default_span(&self, tcx: TyCtxt<'_>) -> SpanId {
         self.1.default_span(tcx)
     }
 }
@@ -122,7 +122,7 @@ impl Key for (DefId, LocalDefId) {
     fn query_crate(&self) -> CrateNum {
         self.0.krate
     }
-    fn default_span(&self, tcx: TyCtxt<'_>) -> Span {
+    fn default_span(&self, tcx: TyCtxt<'_>) -> SpanId {
         self.1.default_span(tcx)
     }
 }
@@ -133,7 +133,7 @@ impl Key for (CrateNum, DefId) {
     fn query_crate(&self) -> CrateNum {
         self.0
     }
-    fn default_span(&self, tcx: TyCtxt<'_>) -> Span {
+    fn default_span(&self, tcx: TyCtxt<'_>) -> SpanId {
         self.1.default_span(tcx)
     }
 }
@@ -144,7 +144,7 @@ impl Key for (DefId, SimplifiedType) {
     fn query_crate(&self) -> CrateNum {
         self.0.krate
     }
-    fn default_span(&self, tcx: TyCtxt<'_>) -> Span {
+    fn default_span(&self, tcx: TyCtxt<'_>) -> SpanId {
         self.0.default_span(tcx)
     }
 }
@@ -155,8 +155,8 @@ impl<'tcx> Key for SubstsRef<'tcx> {
     fn query_crate(&self) -> CrateNum {
         LOCAL_CRATE
     }
-    fn default_span(&self, _: TyCtxt<'_>) -> Span {
-        DUMMY_SP
+    fn default_span(&self, _: TyCtxt<'_>) -> SpanId {
+        DUMMY_SPID
     }
 }
 
@@ -166,7 +166,7 @@ impl<'tcx> Key for (DefId, SubstsRef<'tcx>) {
     fn query_crate(&self) -> CrateNum {
         self.0.krate
     }
-    fn default_span(&self, tcx: TyCtxt<'_>) -> Span {
+    fn default_span(&self, tcx: TyCtxt<'_>) -> SpanId {
         self.0.default_span(tcx)
     }
 }
@@ -177,7 +177,7 @@ impl<'tcx> Key for (ty::ParamEnv<'tcx>, ty::PolyTraitRef<'tcx>) {
     fn query_crate(&self) -> CrateNum {
         self.1.def_id().krate
     }
-    fn default_span(&self, tcx: TyCtxt<'_>) -> Span {
+    fn default_span(&self, tcx: TyCtxt<'_>) -> SpanId {
         tcx.def_span(self.1.def_id())
     }
 }
@@ -188,8 +188,8 @@ impl<'tcx> Key for (&'tcx ty::Const<'tcx>, mir::Field) {
     fn query_crate(&self) -> CrateNum {
         LOCAL_CRATE
     }
-    fn default_span(&self, _: TyCtxt<'_>) -> Span {
-        DUMMY_SP
+    fn default_span(&self, _: TyCtxt<'_>) -> SpanId {
+        DUMMY_SPID
     }
 }
 
@@ -199,7 +199,7 @@ impl<'tcx> Key for ty::PolyTraitRef<'tcx> {
     fn query_crate(&self) -> CrateNum {
         self.def_id().krate
     }
-    fn default_span(&self, tcx: TyCtxt<'_>) -> Span {
+    fn default_span(&self, tcx: TyCtxt<'_>) -> SpanId {
         tcx.def_span(self.def_id())
     }
 }
@@ -210,8 +210,8 @@ impl<'tcx> Key for GenericArg<'tcx> {
     fn query_crate(&self) -> CrateNum {
         LOCAL_CRATE
     }
-    fn default_span(&self, _: TyCtxt<'_>) -> Span {
-        DUMMY_SP
+    fn default_span(&self, _: TyCtxt<'_>) -> SpanId {
+        DUMMY_SPID
     }
 }
 
@@ -221,8 +221,8 @@ impl<'tcx> Key for &'tcx ty::Const<'tcx> {
     fn query_crate(&self) -> CrateNum {
         LOCAL_CRATE
     }
-    fn default_span(&self, _: TyCtxt<'_>) -> Span {
-        DUMMY_SP
+    fn default_span(&self, _: TyCtxt<'_>) -> SpanId {
+        DUMMY_SPID
     }
 }
 
@@ -232,8 +232,8 @@ impl<'tcx> Key for Ty<'tcx> {
     fn query_crate(&self) -> CrateNum {
         LOCAL_CRATE
     }
-    fn default_span(&self, _: TyCtxt<'_>) -> Span {
-        DUMMY_SP
+    fn default_span(&self, _: TyCtxt<'_>) -> SpanId {
+        DUMMY_SPID
     }
 }
 
@@ -243,8 +243,8 @@ impl<'tcx> Key for ty::ParamEnv<'tcx> {
     fn query_crate(&self) -> CrateNum {
         LOCAL_CRATE
     }
-    fn default_span(&self, _: TyCtxt<'_>) -> Span {
-        DUMMY_SP
+    fn default_span(&self, _: TyCtxt<'_>) -> SpanId {
+        DUMMY_SPID
     }
 }
 
@@ -254,7 +254,7 @@ impl<'tcx, T: Key> Key for ty::ParamEnvAnd<'tcx, T> {
     fn query_crate(&self) -> CrateNum {
         self.value.query_crate()
     }
-    fn default_span(&self, tcx: TyCtxt<'_>) -> Span {
+    fn default_span(&self, tcx: TyCtxt<'_>) -> SpanId {
         self.value.default_span(tcx)
     }
 }
@@ -265,8 +265,8 @@ impl Key for Symbol {
     fn query_crate(&self) -> CrateNum {
         LOCAL_CRATE
     }
-    fn default_span(&self, _tcx: TyCtxt<'_>) -> Span {
-        DUMMY_SP
+    fn default_span(&self, _tcx: TyCtxt<'_>) -> SpanId {
+        DUMMY_SPID
     }
 }
 
@@ -279,8 +279,8 @@ impl<'tcx, T> Key for Canonical<'tcx, T> {
         LOCAL_CRATE
     }
 
-    fn default_span(&self, _tcx: TyCtxt<'_>) -> Span {
-        DUMMY_SP
+    fn default_span(&self, _tcx: TyCtxt<'_>) -> SpanId {
+        DUMMY_SPID
     }
 }
 
@@ -291,7 +291,7 @@ impl Key for (Symbol, u32, u32) {
         LOCAL_CRATE
     }
 
-    fn default_span(&self, _tcx: TyCtxt<'_>) -> Span {
-        DUMMY_SP
+    fn default_span(&self, _tcx: TyCtxt<'_>) -> SpanId {
+        DUMMY_SPID
     }
 }

--- a/src/librustc_middle/ty/query/mod.rs
+++ b/src/librustc_middle/ty/query/mod.rs
@@ -52,7 +52,7 @@ use rustc_target::spec::PanicStrategy;
 use rustc_ast::ast;
 use rustc_attr as attr;
 use rustc_span::symbol::Symbol;
-use rustc_span::{Span, DUMMY_SP};
+use rustc_span::{Span, SpanId, DUMMY_SP, DUMMY_SPID};
 use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::ops::Deref;
@@ -215,4 +215,4 @@ mod sealed {
     }
 }
 
-use sealed::IntoQueryParam;
+pub(crate) use sealed::IntoQueryParam;

--- a/src/librustc_middle/ty/query/on_disk_cache.rs
+++ b/src/librustc_middle/ty/query/on_disk_cache.rs
@@ -21,7 +21,7 @@ use rustc_span::hygiene::{ExpnId, SyntaxContext};
 use rustc_span::source_map::{SourceMap, StableSourceFileId};
 use rustc_span::symbol::Ident;
 use rustc_span::CachingSourceMapView;
-use rustc_span::{BytePos, SourceFile, Span, DUMMY_SP};
+use rustc_span::{BytePos, SourceFile, Span, SpanId, DUMMY_SP};
 use std::mem;
 
 const TAG_FILE_FOOTER: u128 = 0xC0FFEE_C0FFEE_C0FFEE_C0FFEE_C0FFEE;
@@ -838,7 +838,7 @@ where
     }
 }
 
-impl<'a, 'tcx, E> SpecializedEncoder<&'tcx [(ty::Predicate<'tcx>, Span)]>
+impl<'a, 'tcx, E> SpecializedEncoder<&'tcx [(ty::Predicate<'tcx>, SpanId)]>
     for CacheEncoder<'a, 'tcx, E>
 where
     E: 'a + TyEncoder,
@@ -846,7 +846,7 @@ where
     #[inline]
     fn specialized_encode(
         &mut self,
-        predicates: &&'tcx [(ty::Predicate<'tcx>, Span)],
+        predicates: &&'tcx [(ty::Predicate<'tcx>, SpanId)],
     ) -> Result<(), Self::Error> {
         ty_codec::encode_spanned_predicates(self, predicates, |encoder| {
             &mut encoder.predicate_shorthands

--- a/src/librustc_middle/ty/query/plumbing.rs
+++ b/src/librustc_middle/ty/query/plumbing.rs
@@ -12,7 +12,9 @@ use rustc_query_system::query::{CycleError, QueryJobId, QueryJobInfo};
 use rustc_data_structures::fx::FxHashMap;
 use rustc_data_structures::sync::Lock;
 use rustc_data_structures::thin_vec::ThinVec;
-use rustc_errors::{struct_span_err, Diagnostic, DiagnosticBuilder, Handler, Level};
+use rustc_errors::{
+    struct_span_err, Diagnostic, DiagnosticBuilder, Handler, Level, RealDiagnostic,
+};
 use rustc_span::def_id::DefId;
 use rustc_span::Span;
 
@@ -144,7 +146,7 @@ impl<'tcx> TyCtxt<'tcx> {
                         } else {
                             break;
                         };
-                    let mut diag = Diagnostic::new(
+                    let mut diag = RealDiagnostic::new(
                         Level::FailureNote,
                         &format!(
                             "#{} [{}] {}",

--- a/src/librustc_middle/ty/structural_impls.rs
+++ b/src/librustc_middle/ty/structural_impls.rs
@@ -290,6 +290,7 @@ CloneTypeFoldableAndLiftImpls! {
     crate::ty::UniverseIndex,
     crate::ty::Variance,
     ::rustc_span::Span,
+    ::rustc_span::SpanId,
 }
 
 ///////////////////////////////////////////////////////////////////////////

--- a/src/librustc_middle/ty/util.rs
+++ b/src/librustc_middle/ty/util.rs
@@ -18,7 +18,7 @@ use rustc_hir as hir;
 use rustc_hir::def::DefKind;
 use rustc_hir::def_id::DefId;
 use rustc_macros::HashStable;
-use rustc_span::Span;
+use rustc_span::{Span, SpanId};
 use rustc_target::abi::{Integer, Size, TargetDataLayout};
 use smallvec::SmallVec;
 use std::{cmp, fmt};
@@ -683,7 +683,7 @@ impl<'tcx> ty::TyS<'tcx> {
         &'tcx self,
         tcx: TyCtxt<'tcx>,
         param_env: ty::ParamEnv<'tcx>,
-        span: Span,
+        span: SpanId,
     ) -> bool {
         tcx.at(span).is_copy_raw(param_env.and(self))
     }
@@ -709,7 +709,7 @@ impl<'tcx> ty::TyS<'tcx> {
         &'tcx self,
         tcx: TyCtxt<'tcx>,
         param_env: ty::ParamEnv<'tcx>,
-        span: Span,
+        span: SpanId,
     ) -> bool {
         self.is_trivially_freeze() || tcx.at(span).is_freeze_raw(param_env.and(self))
     }

--- a/src/librustc_middle/util/bug.rs
+++ b/src/librustc_middle/util/bug.rs
@@ -45,7 +45,7 @@ fn opt_span_bug_fmt<S: Into<MultiSpanId>>(
 /// interactions with the query system and incremental.
 pub fn trigger_delay_span_bug(tcx: TyCtxt<'_>, key: rustc_hir::def_id::DefId) {
     tcx.sess.delay_span_bug(
-        tcx.def_span(key),
+        tcx.real_def_span(key),
         "delayed span bug triggered by #[rustc_error(delay_span_bug_from_inside_query)]",
     );
 }

--- a/src/librustc_middle/util/bug.rs
+++ b/src/librustc_middle/util/bug.rs
@@ -1,7 +1,7 @@
 // These functions are used by macro expansion for bug! and span_bug!
 
 use crate::ty::{tls, TyCtxt};
-use rustc_span::{MultiSpan, Span};
+use rustc_span::{MultiSpanId, Span};
 use std::fmt;
 
 #[cold]
@@ -14,7 +14,7 @@ pub fn bug_fmt(file: &'static str, line: u32, args: fmt::Arguments<'_>) -> ! {
 
 #[cold]
 #[inline(never)]
-pub fn span_bug_fmt<S: Into<MultiSpan>>(
+pub fn span_bug_fmt<S: Into<MultiSpanId>>(
     file: &'static str,
     line: u32,
     span: S,
@@ -23,7 +23,7 @@ pub fn span_bug_fmt<S: Into<MultiSpan>>(
     opt_span_bug_fmt(file, line, Some(span), args);
 }
 
-fn opt_span_bug_fmt<S: Into<MultiSpan>>(
+fn opt_span_bug_fmt<S: Into<MultiSpanId>>(
     file: &'static str,
     line: u32,
     span: Option<S>,

--- a/src/librustc_mir/borrow_check/constraints/graph.rs
+++ b/src/librustc_mir/borrow_check/constraints/graph.rs
@@ -2,7 +2,7 @@ use rustc_data_structures::graph;
 use rustc_index::vec::IndexVec;
 use rustc_middle::mir::ConstraintCategory;
 use rustc_middle::ty::RegionVid;
-use rustc_span::DUMMY_SP;
+use rustc_span::DUMMY_SPID;
 
 use crate::borrow_check::{
     constraints::OutlivesConstraintIndex,
@@ -155,7 +155,7 @@ impl<'s, D: ConstraintGraphDirecton> Iterator for Edges<'s, D> {
             Some(OutlivesConstraint {
                 sup: self.static_region,
                 sub: next_static_idx.into(),
-                locations: Locations::All(DUMMY_SP),
+                locations: Locations::All(DUMMY_SPID),
                 category: ConstraintCategory::Internal,
             })
         } else {

--- a/src/librustc_mir/borrow_check/diagnostics/outlives_suggestion.rs
+++ b/src/librustc_mir/borrow_check/diagnostics/outlives_suggestion.rs
@@ -260,7 +260,7 @@ impl OutlivesSuggestionBuilder {
 
         // We want this message to appear after other messages on the mir def.
         let mir_span = mbcx.infcx.tcx.def_span(mbcx.mir_def_id);
-        diag.sort_span = mir_span.shrink_to_hi();
+        diag.sort_span = mir_span.shrink_to_hi().into();
 
         // Buffer the diagnostic
         diag.buffer(&mut mbcx.errors_buffer);

--- a/src/librustc_mir/borrow_check/diagnostics/outlives_suggestion.rs
+++ b/src/librustc_mir/borrow_check/diagnostics/outlives_suggestion.rs
@@ -259,7 +259,7 @@ impl OutlivesSuggestionBuilder {
         };
 
         // We want this message to appear after other messages on the mir def.
-        let mir_span = mbcx.infcx.tcx.def_span(mbcx.mir_def_id);
+        let mir_span = mbcx.infcx.tcx.real_def_span(mbcx.mir_def_id);
         diag.sort_span = mir_span.shrink_to_hi().into();
 
         // Buffer the diagnostic

--- a/src/librustc_mir/borrow_check/diagnostics/region_errors.rs
+++ b/src/librustc_mir/borrow_check/diagnostics/region_errors.rs
@@ -604,7 +604,7 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
                     diag.help(&format!("consider replacing `{}` with `{}`", fr_name, static_str));
                 } else {
                     // Otherwise, we should suggest adding a constraint on the return type.
-                    let span = self.infcx.tcx.def_span(*did);
+                    let span = self.infcx.tcx.real_def_span(*did);
                     if let Ok(snippet) = self.infcx.tcx.sess.source_map().span_to_snippet(span) {
                         let suggestable_fr_name = if fr_name.was_named() {
                             fr_name.to_string()

--- a/src/librustc_mir/borrow_check/diagnostics/var_name.rs
+++ b/src/librustc_mir/borrow_check/diagnostics/var_name.rs
@@ -3,7 +3,7 @@ use crate::borrow_check::{nll::ToRegionVid, region_infer::RegionInferenceContext
 use rustc_index::vec::{Idx, IndexVec};
 use rustc_middle::mir::{Body, Local};
 use rustc_middle::ty::{RegionVid, TyCtxt};
-use rustc_span::source_map::Span;
+use rustc_span::source_map::SpanId;
 use rustc_span::symbol::Symbol;
 
 impl<'tcx> RegionInferenceContext<'tcx> {
@@ -14,7 +14,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
         local_names: &IndexVec<Local, Option<Symbol>>,
         upvars: &[Upvar],
         fr: RegionVid,
-    ) -> Option<(Option<Symbol>, Span)> {
+    ) -> Option<(Option<Symbol>, SpanId)> {
         debug!("get_var_name_and_span_for_region(fr={:?})", fr);
         assert!(self.universal_regions().is_universal_region(fr));
 
@@ -61,12 +61,12 @@ impl<'tcx> RegionInferenceContext<'tcx> {
         tcx: TyCtxt<'tcx>,
         upvars: &[Upvar],
         upvar_index: usize,
-    ) -> (Symbol, Span) {
+    ) -> (Symbol, SpanId) {
         let upvar_hir_id = upvars[upvar_index].var_hir_id;
         debug!("get_upvar_name_and_span_for_region: upvar_hir_id={:?}", upvar_hir_id);
 
         let upvar_name = tcx.hir().name(upvar_hir_id);
-        let upvar_span = tcx.hir().span(upvar_hir_id);
+        let upvar_span = tcx.hir().span(upvar_hir_id).into();
         debug!(
             "get_upvar_name_and_span_for_region: upvar_name={:?} upvar_span={:?}",
             upvar_name, upvar_span
@@ -111,7 +111,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
         body: &Body<'tcx>,
         local_names: &IndexVec<Local, Option<Symbol>>,
         argument_index: usize,
-    ) -> (Option<Symbol>, Span) {
+    ) -> (Option<Symbol>, SpanId) {
         let implicit_inputs = self.universal_regions().defining_ty.implicit_inputs();
         let argument_local = Local::new(implicit_inputs + argument_index + 1);
         debug!("get_argument_name_and_span_for_region: argument_local={:?}", argument_local);

--- a/src/librustc_mir/borrow_check/member_constraints.rs
+++ b/src/librustc_mir/borrow_check/member_constraints.rs
@@ -3,7 +3,7 @@ use rustc_hir::def_id::DefId;
 use rustc_index::vec::IndexVec;
 use rustc_middle::infer::MemberConstraint;
 use rustc_middle::ty::{self, Ty};
-use rustc_span::Span;
+use rustc_span::SpanId;
 use std::hash::Hash;
 use std::ops::Index;
 
@@ -36,7 +36,7 @@ crate struct NllMemberConstraint<'tcx> {
     crate opaque_type_def_id: DefId,
 
     /// The span where the hidden type was instantiated.
-    crate definition_span: Span,
+    crate definition_span: SpanId,
 
     /// The hidden type in which `R0` appears. (Used in error reporting.)
     crate hidden_ty: Ty<'tcx>,
@@ -92,7 +92,7 @@ impl<'tcx> MemberConstraintSet<'tcx, ty::RegionVid> {
             next_constraint,
             member_region_vid,
             opaque_type_def_id: m_c.opaque_type_def_id,
-            definition_span: m_c.definition_span,
+            definition_span: m_c.definition_span.into(),
             hidden_ty: m_c.hidden_ty,
             start_index,
             end_index,

--- a/src/librustc_mir/borrow_check/mod.rs
+++ b/src/librustc_mir/borrow_check/mod.rs
@@ -441,7 +441,7 @@ fn do_mir_borrowck<'a, 'tcx>(
         mbcx.errors_buffer.sort_by_key(|diag| diag.sort_span);
 
         for diag in mbcx.errors_buffer.drain(..) {
-            mbcx.infcx.tcx.sess.diagnostic().emit_diagnostic(&diag);
+            mbcx.infcx.tcx.sess.diagnostic().emit_diagnostic(diag);
         }
     }
 

--- a/src/librustc_mir/borrow_check/region_infer/opaque_types.rs
+++ b/src/librustc_mir/borrow_check/region_infer/opaque_types.rs
@@ -2,7 +2,7 @@ use rustc_data_structures::fx::FxHashMap;
 use rustc_hir::def_id::DefId;
 use rustc_infer::infer::InferCtxt;
 use rustc_middle::ty::{self, TyCtxt, TypeFoldable};
-use rustc_span::Span;
+use rustc_span::SpanId;
 use rustc_trait_selection::opaque_types::InferCtxtExt;
 
 use super::RegionInferenceContext;
@@ -51,7 +51,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
         &self,
         infcx: &InferCtxt<'_, 'tcx>,
         opaque_ty_decls: FxHashMap<DefId, ty::ResolvedOpaqueTy<'tcx>>,
-        span: Span,
+        span: SpanId,
     ) -> FxHashMap<DefId, ty::ResolvedOpaqueTy<'tcx>> {
         opaque_ty_decls
             .into_iter()
@@ -119,7 +119,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
                     opaque_def_id,
                     universal_substs,
                     universal_concrete_type,
-                    span,
+                    infcx.tcx.reify_span(span),
                 );
                 (
                     opaque_def_id,

--- a/src/librustc_mir/borrow_check/type_check/free_region_relations.rs
+++ b/src/librustc_mir/borrow_check/type_check/free_region_relations.rs
@@ -8,7 +8,7 @@ use rustc_infer::infer::InferCtxt;
 use rustc_middle::mir::ConstraintCategory;
 use rustc_middle::traits::query::OutlivesBound;
 use rustc_middle::ty::{self, RegionVid, Ty, TyCtxt};
-use rustc_span::DUMMY_SP;
+use rustc_span::DUMMY_SPID;
 use rustc_trait_selection::traits::query::type_op::{self, TypeOp};
 use std::rc::Rc;
 
@@ -291,7 +291,7 @@ impl UniversalRegionRelationsBuilder<'cx, 'tcx> {
                 &self.region_bound_pairs,
                 self.implicit_region_bound,
                 self.param_env,
-                Locations::All(DUMMY_SP),
+                Locations::All(DUMMY_SPID),
                 ConstraintCategory::Internal,
                 &mut self.constraints,
             )

--- a/src/librustc_mir/borrow_check/type_check/liveness/trace.rs
+++ b/src/librustc_mir/borrow_check/type_check/liveness/trace.rs
@@ -475,7 +475,10 @@ impl LivenessContext<'_, '_, '_, 'tcx> {
 
         drop_data.dropck_result.report_overflows(
             self.typeck.infcx.tcx,
-            self.body.source_info(*drop_locations.first().unwrap()).span,
+            self.typeck
+                .infcx
+                .tcx
+                .reify_span(self.body.source_info(*drop_locations.first().unwrap()).span),
             dropped_ty,
         );
 

--- a/src/librustc_mir/borrow_check/universal_regions.rs
+++ b/src/librustc_mir/borrow_check/universal_regions.rs
@@ -457,7 +457,7 @@ impl<'cx, 'tcx> UniversalRegionsBuilder<'cx, 'tcx> {
             if self.infcx.tcx.fn_sig(def_id).c_variadic() {
                 let va_list_did = self.infcx.tcx.require_lang_item(
                     lang_items::VaListTypeLangItem,
-                    Some(self.infcx.tcx.def_span(self.mir_def_id)),
+                    Some(self.infcx.tcx.real_def_span(self.mir_def_id)),
                 );
                 let region = self
                     .infcx

--- a/src/librustc_mir/const_eval/eval_queries.rs
+++ b/src/librustc_mir/const_eval/eval_queries.rs
@@ -10,7 +10,7 @@ use rustc_middle::mir;
 use rustc_middle::mir::interpret::{ConstEvalErr, ErrorHandled};
 use rustc_middle::traits::Reveal;
 use rustc_middle::ty::{self, subst::Subst, TyCtxt};
-use rustc_span::source_map::Span;
+use rustc_span::source_map::SpanId;
 use rustc_target::abi::{Abi, LayoutOf};
 use std::convert::TryInto;
 
@@ -81,7 +81,7 @@ fn eval_body_using_ecx<'mir, 'tcx>(
 /// parameter. These bounds are passed to `mk_eval_cx` via the `ParamEnv` argument.
 pub(super) fn mk_eval_cx<'mir, 'tcx>(
     tcx: TyCtxt<'tcx>,
-    span: Span,
+    span: SpanId,
     param_env: ty::ParamEnv<'tcx>,
     can_access_statics: bool,
 ) -> CompileTimeEvalContext<'mir, 'tcx> {
@@ -180,8 +180,7 @@ fn validate_and_turn_into_const<'tcx>(
     let cid = key.value;
     let def_id = cid.instance.def.def_id();
     let is_static = tcx.is_static(def_id);
-    let ecx =
-        mk_eval_cx(tcx, tcx.real_def_span(key.value.instance.def_id()), key.param_env, is_static);
+    let ecx = mk_eval_cx(tcx, tcx.def_span(key.value.instance.def_id()), key.param_env, is_static);
     let val = (|| {
         let mplace = ecx.raw_const_to_mplace(constant)?;
 

--- a/src/librustc_mir/const_eval/eval_queries.rs
+++ b/src/librustc_mir/const_eval/eval_queries.rs
@@ -180,7 +180,8 @@ fn validate_and_turn_into_const<'tcx>(
     let cid = key.value;
     let def_id = cid.instance.def.def_id();
     let is_static = tcx.is_static(def_id);
-    let ecx = mk_eval_cx(tcx, tcx.def_span(key.value.instance.def_id()), key.param_env, is_static);
+    let ecx =
+        mk_eval_cx(tcx, tcx.real_def_span(key.value.instance.def_id()), key.param_env, is_static);
     let val = (|| {
         let mplace = ecx.raw_const_to_mplace(constant)?;
 

--- a/src/librustc_mir/const_eval/mod.rs
+++ b/src/librustc_mir/const_eval/mod.rs
@@ -4,7 +4,7 @@ use std::convert::TryFrom;
 
 use rustc_middle::mir;
 use rustc_middle::ty::{self, TyCtxt};
-use rustc_span::{source_map::DUMMY_SP, symbol::Symbol};
+use rustc_span::{source_map::DUMMY_SPID, symbol::Symbol};
 use rustc_target::abi::VariantIdx;
 
 use crate::interpret::{intern_const_alloc_recursive, ConstValue, InternKind, InterpCx};
@@ -30,7 +30,7 @@ pub(crate) fn const_field<'tcx>(
     value: &'tcx ty::Const<'tcx>,
 ) -> ConstValue<'tcx> {
     trace!("const_field: {:?}, {:?}", field, value);
-    let ecx = mk_eval_cx(tcx, DUMMY_SP, param_env, false);
+    let ecx = mk_eval_cx(tcx, DUMMY_SPID, param_env, false);
     // get the operand again
     let op = ecx.eval_const_to_op(value, None).unwrap();
     // downcast
@@ -50,7 +50,7 @@ pub(crate) fn const_caller_location(
     (file, line, col): (Symbol, u32, u32),
 ) -> ConstValue<'tcx> {
     trace!("const_caller_location: {}:{}:{}", file, line, col);
-    let mut ecx = mk_eval_cx(tcx, DUMMY_SP, ty::ParamEnv::reveal_all(), false);
+    let mut ecx = mk_eval_cx(tcx, DUMMY_SPID, ty::ParamEnv::reveal_all(), false);
 
     let loc_place = ecx.alloc_caller_location(file, line, col);
     intern_const_alloc_recursive(&mut ecx, InternKind::Constant, loc_place, false).unwrap();
@@ -65,7 +65,7 @@ pub(crate) fn destructure_const<'tcx>(
     val: &'tcx ty::Const<'tcx>,
 ) -> mir::DestructuredConst<'tcx> {
     trace!("destructure_const: {:?}", val);
-    let ecx = mk_eval_cx(tcx, DUMMY_SP, param_env, false);
+    let ecx = mk_eval_cx(tcx, DUMMY_SPID, param_env, false);
     let op = ecx.eval_const_to_op(val, None).unwrap();
 
     let variant = ecx.read_discriminant(op).unwrap().1;

--- a/src/librustc_mir/dataflow/framework/tests.rs
+++ b/src/librustc_mir/dataflow/framework/tests.rs
@@ -6,7 +6,7 @@ use rustc_index::bit_set::BitSet;
 use rustc_index::vec::IndexVec;
 use rustc_middle::mir::{self, BasicBlock, Location};
 use rustc_middle::ty;
-use rustc_span::DUMMY_SP;
+use rustc_span::DUMMY_SPID;
 
 use super::*;
 use crate::dataflow::BottomValue;
@@ -16,7 +16,7 @@ use crate::dataflow::BottomValue;
 /// This is the `Body` that will be used by the `MockAnalysis` below. The shape of its CFG is not
 /// important.
 fn mock_body() -> mir::Body<'static> {
-    let source_info = mir::SourceInfo::outermost(DUMMY_SP);
+    let source_info = mir::SourceInfo::outermost(DUMMY_SPID);
 
     let mut blocks = IndexVec::new();
     let mut block = |n, kind| {

--- a/src/librustc_mir/dataflow/impls/borrowed_locals.rs
+++ b/src/librustc_mir/dataflow/impls/borrowed_locals.rs
@@ -4,7 +4,7 @@ use crate::dataflow::{AnalysisDomain, GenKill, GenKillAnalysis};
 use rustc_middle::mir::visit::Visitor;
 use rustc_middle::mir::*;
 use rustc_middle::ty::{ParamEnv, TyCtxt};
-use rustc_span::DUMMY_SP;
+use rustc_span::DUMMY_SPID;
 
 pub type MaybeMutBorrowedLocals<'mir, 'tcx> = MaybeBorrowedLocals<MutBorrow<'mir, 'tcx>>;
 
@@ -231,7 +231,7 @@ impl MutBorrow<'mir, 'tcx> {
     ///
     /// [rust-lang/unsafe-code-guidelines#134]: https://github.com/rust-lang/unsafe-code-guidelines/issues/134
     fn shared_borrow_allows_mutation(&self, place: Place<'tcx>) -> bool {
-        !place.ty(self.body, self.tcx).ty.is_freeze(self.tcx, self.param_env, DUMMY_SP)
+        !place.ty(self.body, self.tcx).ty.is_freeze(self.tcx, self.param_env, DUMMY_SPID)
     }
 }
 

--- a/src/librustc_mir/dataflow/move_paths/mod.rs
+++ b/src/librustc_mir/dataflow/move_paths/mod.rs
@@ -3,7 +3,7 @@ use rustc_data_structures::fx::FxHashMap;
 use rustc_index::vec::{Enumerated, IndexVec};
 use rustc_middle::mir::*;
 use rustc_middle::ty::{ParamEnv, Ty, TyCtxt};
-use rustc_span::Span;
+use rustc_span::SpanId;
 use smallvec::SmallVec;
 
 use std::fmt;
@@ -277,7 +277,7 @@ impl fmt::Debug for Init {
 }
 
 impl Init {
-    crate fn span<'tcx>(&self, body: &Body<'tcx>) -> Span {
+    crate fn span<'tcx>(&self, body: &Body<'tcx>) -> SpanId {
         match self.location {
             InitLocation::Argument(local) => body.local_decls[local].source_info.span,
             InitLocation::Statement(location) => body.source_info(location).span,

--- a/src/librustc_mir/interpret/eval_context.rs
+++ b/src/librustc_mir/interpret/eval_context.rs
@@ -17,7 +17,7 @@ use rustc_middle::ty::layout::{self, TyAndLayout};
 use rustc_middle::ty::{
     self, fold::BottomUpFolder, query::TyCtxtAt, subst::SubstsRef, Ty, TyCtxt, TypeFoldable,
 };
-use rustc_span::{source_map::DUMMY_SP, Span};
+use rustc_span::{source_map::DUMMY_SP, SpanId};
 use rustc_target::abi::{Align, HasDataLayout, LayoutOf, Size, TargetDataLayout};
 
 use super::{
@@ -307,7 +307,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
     }
 
     #[inline(always)]
-    pub fn set_span(&mut self, span: Span) {
+    pub fn set_span(&mut self, span: SpanId) {
         self.tcx.span = span;
         self.memory.tcx.span = span;
     }

--- a/src/librustc_mir/interpret/eval_context.rs
+++ b/src/librustc_mir/interpret/eval_context.rs
@@ -17,7 +17,7 @@ use rustc_middle::ty::layout::{self, TyAndLayout};
 use rustc_middle::ty::{
     self, fold::BottomUpFolder, query::TyCtxtAt, subst::SubstsRef, Ty, TyCtxt, TypeFoldable,
 };
-use rustc_span::{source_map::DUMMY_SP, SpanId};
+use rustc_span::{SpanId, DUMMY_SP, DUMMY_SPID};
 use rustc_target::abi::{Align, HasDataLayout, LayoutOf, Size, TargetDataLayout};
 
 use super::{
@@ -392,7 +392,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
 
     #[inline]
     pub fn type_is_freeze(&self, ty: Ty<'tcx>) -> bool {
-        ty.is_freeze(*self.tcx, self.param_env, DUMMY_SP)
+        ty.is_freeze(*self.tcx, self.param_env, DUMMY_SPID)
     }
 
     pub fn load_mir(
@@ -948,7 +948,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                     mir::ClearCrossCrate::Clear => None,
                 }
             });
-            let span = source_info.map_or(DUMMY_SP, |source_info| source_info.span);
+            let span = source_info.map_or(DUMMY_SP, |source_info| source_info.span).into();
 
             frames.push(FrameInfo { span, instance: frame.instance, lint_root });
         }

--- a/src/librustc_mir/interpret/eval_context.rs
+++ b/src/librustc_mir/interpret/eval_context.rs
@@ -17,7 +17,7 @@ use rustc_middle::ty::layout::{self, TyAndLayout};
 use rustc_middle::ty::{
     self, fold::BottomUpFolder, query::TyCtxtAt, subst::SubstsRef, Ty, TyCtxt, TypeFoldable,
 };
-use rustc_span::{SpanId, DUMMY_SP, DUMMY_SPID};
+use rustc_span::{SpanId, DUMMY_SPID};
 use rustc_target::abi::{Align, HasDataLayout, LayoutOf, Size, TargetDataLayout};
 
 use super::{
@@ -948,7 +948,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                     mir::ClearCrossCrate::Clear => None,
                 }
             });
-            let span = source_info.map_or(DUMMY_SP, |source_info| source_info.span).into();
+            let span = source_info.map_or(DUMMY_SPID, |source_info| source_info.span).into();
 
             frames.push(FrameInfo { span, instance: frame.instance, lint_root });
         }

--- a/src/librustc_mir/interpret/intern.rs
+++ b/src/librustc_mir/interpret/intern.rs
@@ -109,7 +109,9 @@ fn intern_shallow<'rt, 'mir, 'tcx, M: CompileTimeMachine<'mir, 'tcx>>(
     // access this one.
     if mode == InternMode::Static {
         // When `ty` is `None`, we assume no interior mutability.
-        let frozen = ty.map_or(true, |ty| ty.is_freeze(ecx.tcx.tcx, ecx.param_env, ecx.tcx.span));
+        let frozen = ty.map_or(true, |ty| {
+            ty.is_freeze(ecx.tcx.tcx, ecx.param_env, ecx.tcx.reify_span(ecx.tcx.span))
+        });
         // For statics, allocation mutability is the combination of the place mutability and
         // the type mutability.
         // The entire allocation needs to be mutable if it contains an `UnsafeCell` anywhere.

--- a/src/librustc_mir/interpret/intern.rs
+++ b/src/librustc_mir/interpret/intern.rs
@@ -109,9 +109,7 @@ fn intern_shallow<'rt, 'mir, 'tcx, M: CompileTimeMachine<'mir, 'tcx>>(
     // access this one.
     if mode == InternMode::Static {
         // When `ty` is `None`, we assume no interior mutability.
-        let frozen = ty.map_or(true, |ty| {
-            ty.is_freeze(ecx.tcx.tcx, ecx.param_env, ecx.tcx.reify_span(ecx.tcx.span))
-        });
+        let frozen = ty.map_or(true, |ty| ty.is_freeze(ecx.tcx.tcx, ecx.param_env, ecx.tcx.span));
         // For statics, allocation mutability is the combination of the place mutability and
         // the type mutability.
         // The entire allocation needs to be mutable if it contains an `UnsafeCell` anywhere.

--- a/src/librustc_mir/interpret/intern.rs
+++ b/src/librustc_mir/interpret/intern.rs
@@ -207,7 +207,7 @@ impl<'rt, 'mir, 'tcx: 'mir, M: CompileTimeMachine<'mir, 'tcx>> ValueVisitor<'mir
                     self.intern_shallow(vtable.alloc_id, Mutability::Not, None)?;
                 } else {
                     self.ecx().tcx.sess.delay_span_bug(
-                        rustc_span::DUMMY_SP,
+                        rustc_span::DUMMY_SPID,
                         "vtables pointers cannot be integer pointers",
                     );
                 }

--- a/src/librustc_mir/interpret/intrinsics/caller_location.rs
+++ b/src/librustc_mir/interpret/intrinsics/caller_location.rs
@@ -2,7 +2,7 @@ use std::convert::TryFrom;
 
 use rustc_hir::lang_items::PanicLocationLangItem;
 use rustc_middle::ty::subst::Subst;
-use rustc_span::{Span, Symbol};
+use rustc_span::{SpanId, Symbol};
 use rustc_target::abi::LayoutOf;
 
 use crate::interpret::{
@@ -13,7 +13,7 @@ use crate::interpret::{
 impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
     /// Walks up the callstack from the intrinsic's callsite, searching for the first callsite in a
     /// frame which is not `#[track_caller]`.
-    crate fn find_closest_untracked_caller_location(&self) -> Span {
+    crate fn find_closest_untracked_caller_location(&self) -> SpanId {
         self.stack()
             .iter()
             .rev()
@@ -59,7 +59,8 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
         location
     }
 
-    crate fn location_triple_for_span(&self, span: Span) -> (Symbol, u32, u32) {
+    crate fn location_triple_for_span(&self, span: SpanId) -> (Symbol, u32, u32) {
+        let span = self.tcx.reify_span(span);
         let topmost = span.ctxt().outer_expn().expansion_cause().unwrap_or(span);
         let caller = self.tcx.sess.source_map().lookup_char_pos(topmost.lo());
         (
@@ -69,7 +70,10 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
         )
     }
 
-    pub fn alloc_caller_location_for_span(&mut self, span: Span) -> MPlaceTy<'tcx, M::PointerTag> {
+    pub fn alloc_caller_location_for_span(
+        &mut self,
+        span: SpanId,
+    ) -> MPlaceTy<'tcx, M::PointerTag> {
         let (file, line, column) = self.location_triple_for_span(span);
         self.alloc_caller_location(file, line, column)
     }

--- a/src/librustc_mir/interpret/step.rs
+++ b/src/librustc_mir/interpret/step.rs
@@ -76,7 +76,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
 
     fn statement(&mut self, stmt: &mir::Statement<'tcx>) -> InterpResult<'tcx> {
         info!("{:?}", stmt);
-        self.set_span(stmt.source_info.span);
+        self.set_span(stmt.source_info.span.into());
 
         use rustc_middle::mir::StatementKind::*;
 
@@ -273,7 +273,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
 
     fn terminator(&mut self, terminator: &mir::Terminator<'tcx>) -> InterpResult<'tcx> {
         info!("{:?}", terminator.kind);
-        self.set_span(terminator.source_info.span);
+        self.set_span(terminator.source_info.span.into());
 
         self.eval_terminator(terminator)?;
         if !self.stack().is_empty() {

--- a/src/librustc_mir/monomorphize/collector.rs
+++ b/src/librustc_mir/monomorphize/collector.rs
@@ -809,8 +809,8 @@ fn find_vtable_types_for_unsizing<'tcx>(
     let ptr_vtable = |inner_source: Ty<'tcx>, inner_target: Ty<'tcx>| {
         let param_env = ty::ParamEnv::reveal_all();
         let type_has_metadata = |ty: Ty<'tcx>| -> bool {
-            use rustc_span::DUMMY_SP;
-            if ty.is_sized(tcx.at(DUMMY_SP), param_env) {
+            use rustc_span::DUMMY_SPID;
+            if ty.is_sized(tcx.at(DUMMY_SPID), param_env) {
                 return false;
             }
             let tail = tcx.struct_tail_erasing_lifetimes(ty, param_env);

--- a/src/librustc_mir/monomorphize/partitioning.rs
+++ b/src/librustc_mir/monomorphize/partitioning.rs
@@ -870,7 +870,11 @@ where
             // Deterministically select one of the spans for error reporting
             let span = match (span1, span2) {
                 (Some(span1), Some(span2)) => {
-                    Some(if span1.lo().0 > span2.lo().0 { span1 } else { span2 })
+                    Some(if tcx.reify_span(span1).lo().0 > tcx.reify_span(span2).lo().0 {
+                        span1
+                    } else {
+                        span2
+                    })
                 }
                 (span1, span2) => span1.or(span2),
             };

--- a/src/librustc_mir/shim.rs
+++ b/src/librustc_mir/shim.rs
@@ -306,7 +306,7 @@ fn build_clone_shim<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId, self_ty: Ty<'tcx>) -
     let param_env = tcx.param_env(def_id);
 
     let mut builder = CloneShimBuilder::new(tcx, def_id, self_ty);
-    let is_copy = self_ty.is_copy_modulo_regions(tcx, param_env, builder.span);
+    let is_copy = self_ty.is_copy_modulo_regions(tcx, param_env, builder.span.into());
 
     let dest = Place::return_place();
     let src = tcx.mk_place_deref(Place::from(Local::new(1 + 0)));

--- a/src/librustc_mir/shim.rs
+++ b/src/librustc_mir/shim.rs
@@ -170,7 +170,7 @@ fn build_drop_shim<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId, ty: Option<Ty<'tcx>>)
     };
     let sig = tcx.fn_sig(def_id).subst(tcx, substs);
     let sig = tcx.erase_late_bound_regions(&sig);
-    let span = tcx.def_span(def_id);
+    let span = tcx.real_def_span(def_id);
 
     let source_info = SourceInfo::outermost(span);
 
@@ -344,7 +344,7 @@ impl CloneShimBuilder<'tcx> {
         let substs = tcx.mk_substs_trait(self_ty, &[]);
         let sig = tcx.fn_sig(def_id).subst(tcx, substs);
         let sig = tcx.erase_late_bound_regions(&sig);
-        let span = tcx.def_span(def_id);
+        let span = tcx.real_def_span(def_id);
 
         CloneShimBuilder {
             tcx,
@@ -673,7 +673,7 @@ fn build_call_shim<'tcx>(
         sig.inputs_and_output = tcx.intern_type_list(&inputs_and_output);
     }
 
-    let span = tcx.def_span(def_id);
+    let span = tcx.real_def_span(def_id);
 
     debug!("build_call_shim: sig={:?}", sig);
 

--- a/src/librustc_mir/transform/check_consts/qualifs.rs
+++ b/src/librustc_mir/transform/check_consts/qualifs.rs
@@ -128,7 +128,13 @@ impl Qualif for CustomEq {
         // `Option::<NonStructuralMatchTy>::Some`), in which case some values of this type may be
         // structural-match (`Option::None`).
         let id = cx.tcx.hir().local_def_id_to_hir_id(cx.def_id.as_local().unwrap());
-        traits::search_for_structural_match_violation(id, cx.body.span, cx.tcx, ty).is_some()
+        traits::search_for_structural_match_violation(
+            id,
+            cx.tcx.reify_span(cx.body.span),
+            cx.tcx,
+            ty,
+        )
+        .is_some()
     }
 
     fn in_adt_inherently(
@@ -138,9 +144,9 @@ impl Qualif for CustomEq {
     ) -> bool {
         let ty = cx.tcx.mk_ty(ty::Adt(adt, substs));
         let id = cx.tcx.hir().local_def_id_to_hir_id(cx.def_id.as_local().unwrap());
-        cx.tcx
-            .infer_ctxt()
-            .enter(|infcx| !traits::type_marked_structural(id, cx.body.span, &infcx, ty))
+        cx.tcx.infer_ctxt().enter(|infcx| {
+            !traits::type_marked_structural(id, cx.tcx.reify_span(cx.body.span), &infcx, ty)
+        })
     }
 }
 

--- a/src/librustc_mir/transform/check_consts/qualifs.rs
+++ b/src/librustc_mir/transform/check_consts/qualifs.rs
@@ -5,7 +5,7 @@
 use rustc_infer::infer::TyCtxtInferExt;
 use rustc_middle::mir::*;
 use rustc_middle::ty::{self, subst::SubstsRef, AdtDef, Ty};
-use rustc_span::DUMMY_SP;
+use rustc_span::DUMMY_SPID;
 use rustc_trait_selection::traits;
 
 use super::ConstCx;
@@ -78,7 +78,7 @@ impl Qualif for HasMutInterior {
     }
 
     fn in_any_value_of_ty(cx: &ConstCx<'_, 'tcx>, ty: Ty<'tcx>) -> bool {
-        !ty.is_freeze(cx.tcx, cx.param_env, DUMMY_SP)
+        !ty.is_freeze(cx.tcx, cx.param_env, DUMMY_SPID)
     }
 
     fn in_adt_inherently(cx: &ConstCx<'_, 'tcx>, adt: &'tcx AdtDef, _: SubstsRef<'tcx>) -> bool {

--- a/src/librustc_mir/transform/check_unsafety.rs
+++ b/src/librustc_mir/transform/check_unsafety.rs
@@ -271,7 +271,7 @@ impl<'a, 'tcx> Visitor<'tcx> for UnsafetyChecker<'a, 'tcx> {
                             if !elem_ty.is_copy_modulo_regions(
                                 self.tcx,
                                 self.param_env,
-                                self.source_info.span,
+                                self.source_info.span.into(),
                             ) {
                                 self.require_unsafe(
                                     "assignment to non-`Copy` union field",
@@ -419,7 +419,7 @@ impl<'a, 'tcx> UnsafetyChecker<'a, 'tcx> {
                             } else if !place.ty(self.body, self.tcx).ty.is_freeze(
                                 self.tcx,
                                 self.param_env,
-                                self.source_info.span,
+                                self.source_info.span.into(),
                             ) {
                                 (
                                     "borrow of layout constrained field with interior \

--- a/src/librustc_mir/transform/const_prop.rs
+++ b/src/librustc_mir/transform/const_prop.rs
@@ -132,7 +132,7 @@ impl<'tcx> MirPass<'tcx> for ConstProp {
             Default::default(),
             body.arg_count,
             Default::default(),
-            tcx.def_span(source.def_id()),
+            tcx.real_def_span(source.def_id()),
             Default::default(),
             body.generator_kind,
         );
@@ -405,7 +405,7 @@ impl<'mir, 'tcx> ConstPropagator<'mir, 'tcx> {
             Ok(op) => Some(op),
             Err(error) => {
                 // Make sure errors point at the constant.
-                self.ecx.set_span(c.span);
+                self.ecx.set_span(c.span.into());
                 let err = error_to_const_error(&self.ecx, error);
                 if let Some(lint_root) = self.lint_root(source_info) {
                     let lint_only = match c.literal.val {
@@ -827,7 +827,7 @@ impl<'mir, 'tcx> MutVisitor<'tcx> for ConstPropagator<'mir, 'tcx> {
     fn visit_statement(&mut self, statement: &mut Statement<'tcx>, location: Location) {
         trace!("visit_statement: {:?}", statement);
         let source_info = statement.source_info;
-        self.ecx.set_span(source_info.span);
+        self.ecx.set_span(source_info.span.into());
         self.source_info = Some(source_info);
         if let StatementKind::Assign(box (place, ref mut rval)) = statement.kind {
             let place_ty: Ty<'tcx> = place.ty(&self.local_decls, self.tcx).ty;
@@ -898,7 +898,7 @@ impl<'mir, 'tcx> MutVisitor<'tcx> for ConstPropagator<'mir, 'tcx> {
 
     fn visit_terminator(&mut self, terminator: &mut Terminator<'tcx>, location: Location) {
         let source_info = terminator.source_info;
-        self.ecx.set_span(source_info.span);
+        self.ecx.set_span(source_info.span.into());
         self.source_info = Some(source_info);
         self.super_terminator(terminator, location);
         match &mut terminator.kind {

--- a/src/librustc_mir/transform/const_prop.rs
+++ b/src/librustc_mir/transform/const_prop.rs
@@ -21,7 +21,7 @@ use rustc_middle::ty::layout::{HasTyCtxt, LayoutError, TyAndLayout};
 use rustc_middle::ty::subst::{InternalSubsts, Subst};
 use rustc_middle::ty::{self, ConstKind, Instance, ParamEnv, Ty, TyCtxt, TypeFoldable};
 use rustc_session::lint;
-use rustc_span::{def_id::DefId, Span};
+use rustc_span::{def_id::DefId, SpanId};
 use rustc_target::abi::{HasDataLayout, LayoutOf, Size, TargetDataLayout};
 use rustc_trait_selection::traits;
 
@@ -132,7 +132,7 @@ impl<'tcx> MirPass<'tcx> for ConstProp {
             Default::default(),
             body.arg_count,
             Default::default(),
-            tcx.real_def_span(source.def_id()),
+            tcx.def_span(source.def_id()),
             Default::default(),
             body.generator_kind,
         );
@@ -602,7 +602,7 @@ impl<'mir, 'tcx> ConstPropagator<'mir, 'tcx> {
     }
 
     /// Creates a new `Operand::Constant` from a `Scalar` value
-    fn operand_from_scalar(&self, scalar: Scalar, ty: Ty<'tcx>, span: Span) -> Operand<'tcx> {
+    fn operand_from_scalar(&self, scalar: Scalar, ty: Ty<'tcx>, span: SpanId) -> Operand<'tcx> {
         Operand::Constant(Box::new(Constant {
             span,
             user_ty: None,

--- a/src/librustc_mir/transform/elaborate_drops.rs
+++ b/src/librustc_mir/transform/elaborate_drops.rs
@@ -14,7 +14,7 @@ use rustc_hir as hir;
 use rustc_index::bit_set::BitSet;
 use rustc_middle::mir::*;
 use rustc_middle::ty::{self, TyCtxt};
-use rustc_span::Span;
+use rustc_span::SpanId;
 use rustc_target::abi::VariantIdx;
 use std::fmt;
 
@@ -265,7 +265,7 @@ impl<'b, 'tcx> ElaborateDropsCtxt<'b, 'tcx> {
         self.env.param_env
     }
 
-    fn create_drop_flag(&mut self, index: MovePathIndex, span: Span) {
+    fn create_drop_flag(&mut self, index: MovePathIndex, span: SpanId) {
         let tcx = self.tcx;
         let patch = &mut self.patch;
         debug!("create_drop_flag({:?})", self.body.span);
@@ -465,7 +465,7 @@ impl<'b, 'tcx> ElaborateDropsCtxt<'b, 'tcx> {
         }
     }
 
-    fn constant_bool(&self, span: Span, val: bool) -> Rvalue<'tcx> {
+    fn constant_bool(&self, span: SpanId, val: bool) -> Rvalue<'tcx> {
         Rvalue::Use(Operand::Constant(Box::new(Constant {
             span,
             user_ty: None,

--- a/src/librustc_mir/transform/promote_consts.rs
+++ b/src/librustc_mir/transform/promote_consts.rs
@@ -22,7 +22,7 @@ use rustc_middle::ty::cast::CastTy;
 use rustc_middle::ty::subst::InternalSubsts;
 use rustc_middle::ty::{self, List, TyCtxt, TypeFoldable};
 use rustc_span::symbol::sym;
-use rustc_span::{Span, DUMMY_SPID};
+use rustc_span::{SpanId, DUMMY_SPID};
 
 use rustc_index::vec::{Idx, IndexVec};
 use rustc_target::spec::abi::Abi;
@@ -144,7 +144,7 @@ struct Collector<'a, 'tcx> {
     ccx: &'a ConstCx<'a, 'tcx>,
     temps: IndexVec<Local, TempState>,
     candidates: Vec<Candidate>,
-    span: Span,
+    span: SpanId,
 }
 
 impl<'tcx> Visitor<'tcx> for Collector<'_, 'tcx> {
@@ -785,7 +785,7 @@ impl<'a, 'tcx> Promoter<'a, 'tcx> {
         })
     }
 
-    fn assign(&mut self, dest: Local, rvalue: Rvalue<'tcx>, span: Span) {
+    fn assign(&mut self, dest: Local, rvalue: Rvalue<'tcx>, span: SpanId) {
         let last = self.promoted.basic_blocks().last().unwrap();
         let data = &mut self.promoted[last];
         data.statements.push(Statement {

--- a/src/librustc_mir/transform/promote_consts.rs
+++ b/src/librustc_mir/transform/promote_consts.rs
@@ -22,7 +22,7 @@ use rustc_middle::ty::cast::CastTy;
 use rustc_middle::ty::subst::InternalSubsts;
 use rustc_middle::ty::{self, List, TyCtxt, TypeFoldable};
 use rustc_span::symbol::sym;
-use rustc_span::{Span, DUMMY_SP};
+use rustc_span::{Span, DUMMY_SPID};
 
 use rustc_index::vec::{Idx, IndexVec};
 use rustc_target::spec::abi::Abi;
@@ -330,7 +330,7 @@ impl<'tcx> Validator<'_, 'tcx> {
                                     Place::ty_from(place.local, proj_base, self.body, self.tcx)
                                         .projection_ty(self.tcx, elem)
                                         .ty;
-                                if ty.is_freeze(self.tcx, self.param_env, DUMMY_SP) {
+                                if ty.is_freeze(self.tcx, self.param_env, DUMMY_SPID) {
                                     has_mut_interior = false;
                                     break;
                                 }
@@ -653,7 +653,7 @@ impl<'tcx> Validator<'_, 'tcx> {
                         let ty = Place::ty_from(place.local, proj_base, self.body, self.tcx)
                             .projection_ty(self.tcx, elem)
                             .ty;
-                        if ty.is_freeze(self.tcx, self.param_env, DUMMY_SP) {
+                        if ty.is_freeze(self.tcx, self.param_env, DUMMY_SPID) {
                             has_mut_interior = false;
                             break;
                         }

--- a/src/librustc_mir/transform/qualify_min_const_fn.rs
+++ b/src/librustc_mir/transform/qualify_min_const_fn.rs
@@ -51,7 +51,7 @@ pub fn is_min_const_fn(tcx: TyCtxt<'tcx>, def_id: DefId, body: &'a Body<'tcx>) -
 
                             let generics = tcx.generics_of(current);
                             let def = generics.type_param(p, tcx);
-                            let span = tcx.def_span(def.def_id);
+                            let span = tcx.real_def_span(def.def_id);
                             return Err((
                                 span,
                                 "trait bounds other than `Sized` \

--- a/src/librustc_mir/transform/qualify_min_const_fn.rs
+++ b/src/librustc_mir/transform/qualify_min_const_fn.rs
@@ -5,10 +5,10 @@ use rustc_middle::mir::*;
 use rustc_middle::ty::subst::GenericArgKind;
 use rustc_middle::ty::{self, adjustment::PointerCast, Predicate, Ty, TyCtxt};
 use rustc_span::symbol::{sym, Symbol};
-use rustc_span::Span;
+use rustc_span::SpanId;
 use std::borrow::Cow;
 
-type McfResult = Result<(), (Span, Cow<'static, str>)>;
+type McfResult = Result<(), (SpanId, Cow<'static, str>)>;
 
 pub fn is_min_const_fn(tcx: TyCtxt<'tcx>, def_id: DefId, body: &'a Body<'tcx>) -> McfResult {
     // Prevent const trait methods from being annotated as `stable`.
@@ -51,7 +51,7 @@ pub fn is_min_const_fn(tcx: TyCtxt<'tcx>, def_id: DefId, body: &'a Body<'tcx>) -
 
                             let generics = tcx.generics_of(current);
                             let def = generics.type_param(p, tcx);
-                            let span = tcx.real_def_span(def.def_id);
+                            let span = tcx.def_span(def.def_id);
                             return Err((
                                 span,
                                 "trait bounds other than `Sized` \
@@ -92,7 +92,7 @@ pub fn is_min_const_fn(tcx: TyCtxt<'tcx>, def_id: DefId, body: &'a Body<'tcx>) -
     Ok(())
 }
 
-fn check_ty(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>, span: Span, fn_def_id: DefId) -> McfResult {
+fn check_ty(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>, span: SpanId, fn_def_id: DefId) -> McfResult {
     for arg in ty.walk() {
         let ty = match arg.unpack() {
             GenericArgKind::Type(ty) => ty,
@@ -150,7 +150,7 @@ fn check_rvalue(
     body: &Body<'tcx>,
     def_id: DefId,
     rvalue: &Rvalue<'tcx>,
-    span: Span,
+    span: SpanId,
 ) -> McfResult {
     match rvalue {
         Rvalue::Repeat(operand, _) | Rvalue::Use(operand) => {
@@ -262,7 +262,7 @@ fn check_statement(
 fn check_operand(
     tcx: TyCtxt<'tcx>,
     operand: &Operand<'tcx>,
-    span: Span,
+    span: SpanId,
     def_id: DefId,
     body: &Body<'tcx>,
 ) -> McfResult {
@@ -278,7 +278,7 @@ fn check_operand(
 fn check_place(
     tcx: TyCtxt<'tcx>,
     place: Place<'tcx>,
-    span: Span,
+    span: SpanId,
     def_id: DefId,
     body: &Body<'tcx>,
 ) -> McfResult {

--- a/src/librustc_mir/transform/rustc_peek.rs
+++ b/src/librustc_mir/transform/rustc_peek.rs
@@ -1,6 +1,6 @@
 use rustc_ast::ast;
 use rustc_span::symbol::sym;
-use rustc_span::Span;
+use rustc_span::SpanId;
 use rustc_target::spec::abi::Abi;
 
 use crate::transform::{MirPass, MirSource};
@@ -190,7 +190,7 @@ impl PeekCallKind {
 pub struct PeekCall {
     arg: Local,
     kind: PeekCallKind,
-    span: Span,
+    span: SpanId,
 }
 
 impl PeekCall {

--- a/src/librustc_mir/util/borrowck_errors.rs
+++ b/src/librustc_mir/util/borrowck_errors.rs
@@ -1,17 +1,17 @@
 use rustc_errors::{struct_span_err, DiagnosticBuilder, DiagnosticId};
 use rustc_middle::ty::{self, Ty, TyCtxt};
-use rustc_span::{MultiSpanId, Span};
+use rustc_span::{MultiSpanId, SpanId};
 
 impl<'cx, 'tcx> crate::borrow_check::MirBorrowckCtxt<'cx, 'tcx> {
-    crate fn cannot_move_when_borrowed(&self, span: Span, desc: &str) -> DiagnosticBuilder<'cx> {
+    crate fn cannot_move_when_borrowed(&self, span: SpanId, desc: &str) -> DiagnosticBuilder<'cx> {
         struct_span_err!(self, span, E0505, "cannot move out of {} because it is borrowed", desc,)
     }
 
     crate fn cannot_use_when_mutably_borrowed(
         &self,
-        span: Span,
+        span: SpanId,
         desc: &str,
-        borrow_span: Span,
+        borrow_span: SpanId,
         borrow_desc: &str,
     ) -> DiagnosticBuilder<'cx> {
         let mut err = struct_span_err!(
@@ -29,7 +29,7 @@ impl<'cx, 'tcx> crate::borrow_check::MirBorrowckCtxt<'cx, 'tcx> {
 
     crate fn cannot_act_on_uninitialized_variable(
         &self,
-        span: Span,
+        span: SpanId,
         verb: &str,
         desc: &str,
     ) -> DiagnosticBuilder<'cx> {
@@ -45,12 +45,12 @@ impl<'cx, 'tcx> crate::borrow_check::MirBorrowckCtxt<'cx, 'tcx> {
 
     crate fn cannot_mutably_borrow_multiply(
         &self,
-        new_loan_span: Span,
+        new_loan_span: SpanId,
         desc: &str,
         opt_via: &str,
-        old_loan_span: Span,
+        old_loan_span: SpanId,
         old_opt_via: &str,
-        old_load_end_span: Option<Span>,
+        old_load_end_span: Option<SpanId>,
     ) -> DiagnosticBuilder<'cx> {
         let via =
             |msg: &str| if msg.is_empty() { "".to_string() } else { format!(" (via {})", msg) };
@@ -94,10 +94,10 @@ impl<'cx, 'tcx> crate::borrow_check::MirBorrowckCtxt<'cx, 'tcx> {
 
     crate fn cannot_uniquely_borrow_by_two_closures(
         &self,
-        new_loan_span: Span,
+        new_loan_span: SpanId,
         desc: &str,
-        old_loan_span: Span,
-        old_load_end_span: Option<Span>,
+        old_loan_span: SpanId,
+        old_load_end_span: Option<SpanId>,
     ) -> DiagnosticBuilder<'cx> {
         let mut err = struct_span_err!(
             self,
@@ -123,14 +123,14 @@ impl<'cx, 'tcx> crate::borrow_check::MirBorrowckCtxt<'cx, 'tcx> {
 
     crate fn cannot_uniquely_borrow_by_one_closure(
         &self,
-        new_loan_span: Span,
+        new_loan_span: SpanId,
         container_name: &str,
         desc_new: &str,
         opt_via: &str,
-        old_loan_span: Span,
+        old_loan_span: SpanId,
         noun_old: &str,
         old_opt_via: &str,
-        previous_end_span: Option<Span>,
+        previous_end_span: Option<SpanId>,
     ) -> DiagnosticBuilder<'cx> {
         let mut err = struct_span_err!(
             self,
@@ -154,14 +154,14 @@ impl<'cx, 'tcx> crate::borrow_check::MirBorrowckCtxt<'cx, 'tcx> {
 
     crate fn cannot_reborrow_already_uniquely_borrowed(
         &self,
-        new_loan_span: Span,
+        new_loan_span: SpanId,
         container_name: &str,
         desc_new: &str,
         opt_via: &str,
         kind_new: &str,
-        old_loan_span: Span,
+        old_loan_span: SpanId,
         old_opt_via: &str,
-        previous_end_span: Option<Span>,
+        previous_end_span: Option<SpanId>,
         second_borrow_desc: &str,
     ) -> DiagnosticBuilder<'cx> {
         let mut err = struct_span_err!(
@@ -190,15 +190,15 @@ impl<'cx, 'tcx> crate::borrow_check::MirBorrowckCtxt<'cx, 'tcx> {
 
     crate fn cannot_reborrow_already_borrowed(
         &self,
-        span: Span,
+        span: SpanId,
         desc_new: &str,
         msg_new: &str,
         kind_new: &str,
-        old_span: Span,
+        old_span: SpanId,
         noun_old: &str,
         kind_old: &str,
         msg_old: &str,
-        old_load_end_span: Option<Span>,
+        old_load_end_span: Option<SpanId>,
     ) -> DiagnosticBuilder<'cx> {
         let via =
             |msg: &str| if msg.is_empty() { "".to_string() } else { format!(" (via {})", msg) };
@@ -239,8 +239,8 @@ impl<'cx, 'tcx> crate::borrow_check::MirBorrowckCtxt<'cx, 'tcx> {
 
     crate fn cannot_assign_to_borrowed(
         &self,
-        span: Span,
-        borrow_span: Span,
+        span: SpanId,
+        borrow_span: SpanId,
         desc: &str,
     ) -> DiagnosticBuilder<'cx> {
         let mut err = struct_span_err!(
@@ -258,7 +258,7 @@ impl<'cx, 'tcx> crate::borrow_check::MirBorrowckCtxt<'cx, 'tcx> {
 
     crate fn cannot_reassign_immutable(
         &self,
-        span: Span,
+        span: SpanId,
         desc: &str,
         is_arg: bool,
     ) -> DiagnosticBuilder<'cx> {
@@ -266,13 +266,13 @@ impl<'cx, 'tcx> crate::borrow_check::MirBorrowckCtxt<'cx, 'tcx> {
         struct_span_err!(self, span, E0384, "cannot assign {} {}", msg, desc)
     }
 
-    crate fn cannot_assign(&self, span: Span, desc: &str) -> DiagnosticBuilder<'cx> {
+    crate fn cannot_assign(&self, span: SpanId, desc: &str) -> DiagnosticBuilder<'cx> {
         struct_span_err!(self, span, E0594, "cannot assign to {}", desc)
     }
 
     crate fn cannot_move_out_of(
         &self,
-        move_from_span: Span,
+        move_from_span: SpanId,
         move_from_desc: &str,
     ) -> DiagnosticBuilder<'cx> {
         struct_span_err!(self, move_from_span, E0507, "cannot move out of {}", move_from_desc,)
@@ -283,7 +283,7 @@ impl<'cx, 'tcx> crate::borrow_check::MirBorrowckCtxt<'cx, 'tcx> {
     /// didn't capture whether there was an indexing operation or not.
     crate fn cannot_move_out_of_interior_noncopy(
         &self,
-        move_from_span: Span,
+        move_from_span: SpanId,
         ty: Ty<'_>,
         is_index: Option<bool>,
     ) -> DiagnosticBuilder<'cx> {
@@ -306,7 +306,7 @@ impl<'cx, 'tcx> crate::borrow_check::MirBorrowckCtxt<'cx, 'tcx> {
 
     crate fn cannot_move_out_of_interior_of_drop(
         &self,
-        move_from_span: Span,
+        move_from_span: SpanId,
         container_ty: Ty<'_>,
     ) -> DiagnosticBuilder<'cx> {
         let mut err = struct_span_err!(
@@ -322,7 +322,7 @@ impl<'cx, 'tcx> crate::borrow_check::MirBorrowckCtxt<'cx, 'tcx> {
 
     crate fn cannot_act_on_moved_value(
         &self,
-        use_span: Span,
+        use_span: SpanId,
         verb: &str,
         optional_adverb_for_moved: &str,
         moved_path: Option<String>,
@@ -342,7 +342,7 @@ impl<'cx, 'tcx> crate::borrow_check::MirBorrowckCtxt<'cx, 'tcx> {
 
     crate fn cannot_borrow_path_as_mutable_because(
         &self,
-        span: Span,
+        span: SpanId,
         path: &str,
         reason: &str,
     ) -> DiagnosticBuilder<'cx> {
@@ -351,8 +351,8 @@ impl<'cx, 'tcx> crate::borrow_check::MirBorrowckCtxt<'cx, 'tcx> {
 
     crate fn cannot_mutate_in_immutable_section(
         &self,
-        mutate_span: Span,
-        immutable_span: Span,
+        mutate_span: SpanId,
+        immutable_span: SpanId,
         immutable_place: &str,
         immutable_section: &str,
         action: &str,
@@ -373,8 +373,8 @@ impl<'cx, 'tcx> crate::borrow_check::MirBorrowckCtxt<'cx, 'tcx> {
 
     crate fn cannot_borrow_across_generator_yield(
         &self,
-        span: Span,
-        yield_span: Span,
+        span: SpanId,
+        yield_span: SpanId,
     ) -> DiagnosticBuilder<'cx> {
         let mut err = struct_span_err!(
             self,
@@ -386,7 +386,7 @@ impl<'cx, 'tcx> crate::borrow_check::MirBorrowckCtxt<'cx, 'tcx> {
         err
     }
 
-    crate fn cannot_borrow_across_destructor(&self, borrow_span: Span) -> DiagnosticBuilder<'cx> {
+    crate fn cannot_borrow_across_destructor(&self, borrow_span: SpanId) -> DiagnosticBuilder<'cx> {
         struct_span_err!(
             self,
             borrow_span,
@@ -397,7 +397,7 @@ impl<'cx, 'tcx> crate::borrow_check::MirBorrowckCtxt<'cx, 'tcx> {
 
     crate fn path_does_not_live_long_enough(
         &self,
-        span: Span,
+        span: SpanId,
         path: &str,
     ) -> DiagnosticBuilder<'cx> {
         struct_span_err!(self, span, E0597, "{} does not live long enough", path,)
@@ -405,7 +405,7 @@ impl<'cx, 'tcx> crate::borrow_check::MirBorrowckCtxt<'cx, 'tcx> {
 
     crate fn cannot_return_reference_to_local(
         &self,
-        span: Span,
+        span: SpanId,
         return_kind: &str,
         reference_desc: &str,
         path_desc: &str,
@@ -430,10 +430,10 @@ impl<'cx, 'tcx> crate::borrow_check::MirBorrowckCtxt<'cx, 'tcx> {
 
     crate fn cannot_capture_in_long_lived_closure(
         &self,
-        closure_span: Span,
+        closure_span: SpanId,
         closure_kind: &str,
         borrowed_path: &str,
-        capture_span: Span,
+        capture_span: SpanId,
     ) -> DiagnosticBuilder<'cx> {
         let mut err = struct_span_err!(
             self,
@@ -452,12 +452,12 @@ impl<'cx, 'tcx> crate::borrow_check::MirBorrowckCtxt<'cx, 'tcx> {
 
     crate fn thread_local_value_does_not_live_long_enough(
         &self,
-        span: Span,
+        span: SpanId,
     ) -> DiagnosticBuilder<'cx> {
         struct_span_err!(self, span, E0712, "thread-local variable borrowed past end of function",)
     }
 
-    crate fn temporary_value_borrowed_for_too_long(&self, span: Span) -> DiagnosticBuilder<'cx> {
+    crate fn temporary_value_borrowed_for_too_long(&self, span: SpanId) -> DiagnosticBuilder<'cx> {
         struct_span_err!(self, span, E0716, "temporary value dropped while borrowed",)
     }
 
@@ -473,7 +473,7 @@ impl<'cx, 'tcx> crate::borrow_check::MirBorrowckCtxt<'cx, 'tcx> {
 
 crate fn borrowed_data_escapes_closure<'tcx>(
     tcx: TyCtxt<'tcx>,
-    escape_span: Span,
+    escape_span: SpanId,
     escapes_from: &str,
 ) -> DiagnosticBuilder<'tcx> {
     struct_span_err!(

--- a/src/librustc_mir/util/borrowck_errors.rs
+++ b/src/librustc_mir/util/borrowck_errors.rs
@@ -1,6 +1,6 @@
 use rustc_errors::{struct_span_err, DiagnosticBuilder, DiagnosticId};
 use rustc_middle::ty::{self, Ty, TyCtxt};
-use rustc_span::{MultiSpan, Span};
+use rustc_span::{MultiSpanId, Span};
 
 impl<'cx, 'tcx> crate::borrow_check::MirBorrowckCtxt<'cx, 'tcx> {
     crate fn cannot_move_when_borrowed(&self, span: Span, desc: &str) -> DiagnosticBuilder<'cx> {
@@ -461,7 +461,7 @@ impl<'cx, 'tcx> crate::borrow_check::MirBorrowckCtxt<'cx, 'tcx> {
         struct_span_err!(self, span, E0716, "temporary value dropped while borrowed",)
     }
 
-    fn struct_span_err_with_code<S: Into<MultiSpan>>(
+    fn struct_span_err_with_code<S: Into<MultiSpanId>>(
         &self,
         sp: S,
         msg: &str,

--- a/src/librustc_mir/util/elaborate_drops.rs
+++ b/src/librustc_mir/util/elaborate_drops.rs
@@ -877,8 +877,10 @@ where
     ) -> BasicBlock {
         let tcx = self.tcx();
         let unit_temp = Place::from(self.new_temp(tcx.mk_unit()));
-        let free_func =
-            tcx.require_lang_item(lang_items::BoxFreeFnLangItem, Some(self.source_info.span));
+        let free_func = tcx.require_lang_item(
+            lang_items::BoxFreeFnLangItem,
+            Some(tcx.reify_span(self.source_info.span)),
+        );
         let args = adt.variants[VariantIdx::new(0)]
             .fields
             .iter()

--- a/src/librustc_mir/util/patch.rs
+++ b/src/librustc_mir/util/patch.rs
@@ -1,7 +1,7 @@
 use rustc_index::vec::{Idx, IndexVec};
 use rustc_middle::mir::*;
 use rustc_middle::ty::Ty;
-use rustc_span::Span;
+use rustc_span::SpanId;
 
 /// This struct represents a patch to MIR, which can add
 /// new statements and basic blocks and patch over block
@@ -80,14 +80,14 @@ impl<'tcx> MirPatch<'tcx> {
         Location { block: bb, statement_index: offset }
     }
 
-    pub fn new_temp(&mut self, ty: Ty<'tcx>, span: Span) -> Local {
+    pub fn new_temp(&mut self, ty: Ty<'tcx>, span: SpanId) -> Local {
         let index = self.next_local;
         self.next_local += 1;
         self.new_locals.push(LocalDecl::new(ty, span));
         Local::new(index as usize)
     }
 
-    pub fn new_internal(&mut self, ty: Ty<'tcx>, span: Span) -> Local {
+    pub fn new_internal(&mut self, ty: Ty<'tcx>, span: SpanId) -> Local {
         let index = self.next_local;
         self.next_local += 1;
         self.new_locals.push(LocalDecl::new(ty, span).internal());

--- a/src/librustc_mir/util/pretty.rs
+++ b/src/librustc_mir/util/pretty.rs
@@ -421,7 +421,11 @@ impl Visitor<'tcx> for ExtraComments<'tcx> {
 }
 
 fn comment(tcx: TyCtxt<'_>, SourceInfo { span, scope }: SourceInfo) -> String {
-    format!("scope {} at {}", scope.index(), tcx.sess.source_map().span_to_string(span))
+    format!(
+        "scope {} at {}",
+        scope.index(),
+        tcx.sess.source_map().span_to_string(tcx.reify_span(span))
+    )
 }
 
 /// Prints local variables in a scope tree.

--- a/src/librustc_mir_build/build/block.rs
+++ b/src/librustc_mir_build/build/block.rs
@@ -4,7 +4,7 @@ use crate::build::{BlockAnd, BlockAndExtension, BlockFrame, Builder};
 use crate::hair::*;
 use rustc_hir as hir;
 use rustc_middle::mir::*;
-use rustc_span::Span;
+use rustc_span::SpanId;
 
 impl<'a, 'tcx> Builder<'a, 'tcx> {
     crate fn ast_block(
@@ -47,7 +47,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         &mut self,
         destination: Place<'tcx>,
         mut block: BasicBlock,
-        span: Span,
+        span: SpanId,
         stmts: Vec<StmtRef<'tcx>>,
         expr: Option<ExprRef<'tcx>>,
         safety_mode: BlockSafety,
@@ -106,7 +106,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
 
                     // Declare the bindings, which may create a source scope.
                     let remainder_span =
-                        remainder_scope.span(this.hir.tcx(), &this.hir.region_scope_tree);
+                        remainder_scope.span(this.hir.tcx(), &this.hir.region_scope_tree).into();
 
                     let visibility_scope =
                         Some(this.new_source_scope(remainder_span, LintLevel::Inherited, None));
@@ -176,7 +176,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             let tail_result_is_ignored =
                 destination_ty.is_unit() || this.block_context.currently_ignores_tail_results();
             let span = match expr {
-                ExprRef::Hair(expr) => expr.span,
+                ExprRef::Hair(expr) => expr.span.into(),
                 ExprRef::Mirror(ref expr) => expr.span,
             };
             this.block_context.push(BlockFrame::TailExpr { tail_result_is_ignored, span });
@@ -209,7 +209,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
     }
 
     /// If we are changing the safety mode, create a new source scope
-    fn update_source_scope_for_safety_mode(&mut self, span: Span, safety_mode: BlockSafety) {
+    fn update_source_scope_for_safety_mode(&mut self, span: SpanId, safety_mode: BlockSafety) {
         debug!("update_source_scope_for({:?}, {:?})", span, safety_mode);
         let new_unsafety = match safety_mode {
             BlockSafety::Safe => None,

--- a/src/librustc_mir_build/build/expr/as_constant.rs
+++ b/src/librustc_mir_build/build/expr/as_constant.rs
@@ -24,7 +24,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             ExprKind::Literal { literal, user_ty } => {
                 let user_ty = user_ty.map(|user_ty| {
                     this.canonical_user_type_annotations.push(CanonicalUserTypeAnnotation {
-                        span,
+                        span: this.hir.tcx().reify_span(span),
                         user_ty,
                         inferred_ty: ty,
                     })

--- a/src/librustc_mir_build/build/expr/as_operand.rs
+++ b/src/librustc_mir_build/build/expr/as_operand.rs
@@ -172,7 +172,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
 
             if !ty.is_sized(tcx.at(span), param_env) {
                 // !sized means !copy, so this is an unsized move
-                assert!(!ty.is_copy_modulo_regions(tcx, param_env, span));
+                assert!(!ty.is_copy_modulo_regions(tcx, param_env, span.into()));
 
                 // As described above, detect the case where we are passing a value of unsized
                 // type, and that value is coming from the deref of a box.

--- a/src/librustc_mir_build/build/expr/as_place.rs
+++ b/src/librustc_mir_build/build/expr/as_place.rs
@@ -8,7 +8,7 @@ use rustc_middle::middle::region;
 use rustc_middle::mir::AssertKind::BoundsCheck;
 use rustc_middle::mir::*;
 use rustc_middle::ty::{self, CanonicalUserTypeAnnotation, Ty, TyCtxt, Variance};
-use rustc_span::Span;
+use rustc_span::SpanId;
 
 use rustc_index::vec::Idx;
 
@@ -180,7 +180,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 if let Some(user_ty) = user_ty {
                     let annotation_index =
                         this.canonical_user_type_annotations.push(CanonicalUserTypeAnnotation {
-                            span: source_info.span,
+                            span: this.hir.tcx().reify_span(source_info.span),
                             user_ty,
                             inferred_ty: expr.ty,
                         });
@@ -209,7 +209,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 if let Some(user_ty) = user_ty {
                     let annotation_index =
                         this.canonical_user_type_annotations.push(CanonicalUserTypeAnnotation {
-                            span: source_info.span,
+                            span: this.hir.tcx().reify_span(source_info.span),
                             user_ty,
                             inferred_ty: expr.ty,
                         });
@@ -286,7 +286,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         mutability: Mutability,
         fake_borrow_temps: Option<&mut Vec<Local>>,
         temp_lifetime: Option<region::Scope>,
-        expr_span: Span,
+        expr_span: SpanId,
         source_info: SourceInfo,
     ) -> BlockAnd<PlaceBuilder<'tcx>> {
         let lhs = self.hir.mirror(base);
@@ -331,7 +331,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         block: BasicBlock,
         slice: Place<'tcx>,
         index: Local,
-        expr_span: Span,
+        expr_span: SpanId,
         source_info: SourceInfo,
     ) -> BasicBlock {
         let usize_ty = self.hir.usize_ty();
@@ -359,7 +359,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         base_place: &PlaceBuilder<'tcx>,
         block: BasicBlock,
         fake_borrow_temps: &mut Vec<Local>,
-        expr_span: Span,
+        expr_span: SpanId,
         source_info: SourceInfo,
     ) {
         let tcx = self.hir.tcx();

--- a/src/librustc_mir_build/build/expr/as_rvalue.rs
+++ b/src/librustc_mir_build/build/expr/as_rvalue.rs
@@ -9,7 +9,7 @@ use rustc_middle::middle::region;
 use rustc_middle::mir::AssertKind;
 use rustc_middle::mir::*;
 use rustc_middle::ty::{self, Ty, UpvarSubsts};
-use rustc_span::Span;
+use rustc_span::SpanId;
 
 impl<'a, 'tcx> Builder<'a, 'tcx> {
     /// Returns an rvalue suitable for use until the end of the current
@@ -271,7 +271,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         &mut self,
         mut block: BasicBlock,
         op: BinOp,
-        span: Span,
+        span: SpanId,
         ty: Ty<'tcx>,
         lhs: Operand<'tcx>,
         rhs: Operand<'tcx>,
@@ -368,7 +368,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
 
     fn limit_capture_mutability(
         &mut self,
-        upvar_span: Span,
+        upvar_span: SpanId,
         upvar_ty: Ty<'tcx>,
         temp_lifetime: Option<region::Scope>,
         mut block: BasicBlock,
@@ -444,7 +444,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
     }
 
     // Helper to get a `-1` value of the appropriate type
-    fn neg_1_literal(&mut self, span: Span, ty: Ty<'tcx>) -> Operand<'tcx> {
+    fn neg_1_literal(&mut self, span: SpanId, ty: Ty<'tcx>) -> Operand<'tcx> {
         let param_ty = ty::ParamEnv::empty().and(ty);
         let bits = self.hir.tcx().layout_of(param_ty).unwrap().size.bits();
         let n = (!0u128) >> (128 - bits);
@@ -454,7 +454,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
     }
 
     // Helper to get the minimum value of the appropriate type
-    fn minval_literal(&mut self, span: Span, ty: Ty<'tcx>) -> Operand<'tcx> {
+    fn minval_literal(&mut self, span: SpanId, ty: Ty<'tcx>) -> Operand<'tcx> {
         assert!(ty.is_signed());
         let param_ty = ty::ParamEnv::empty().and(ty);
         let bits = self.hir.tcx().layout_of(param_ty).unwrap().size.bits();

--- a/src/librustc_mir_build/build/expr/into.rs
+++ b/src/librustc_mir_build/build/expr/into.rs
@@ -289,7 +289,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 let inferred_ty = expr.ty;
                 let user_ty = user_ty.map(|ty| {
                     this.canonical_user_type_annotations.push(CanonicalUserTypeAnnotation {
-                        span: source_info.span,
+                        span: this.hir.tcx().reify_span(source_info.span),
                         user_ty: ty,
                         inferred_ty,
                     })

--- a/src/librustc_mir_build/build/expr/stmt.rs
+++ b/src/librustc_mir_build/build/expr/stmt.rs
@@ -151,7 +151,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                                 }
                             }
                             this.block_context
-                                .push(BlockFrame::TailExpr { tail_result_is_ignored: true, span: expr.span });
+                                .push(BlockFrame::TailExpr { tail_result_is_ignored: true, span: expr.span.into() });
                             return Some(expr.span);
                         }
                     }
@@ -162,7 +162,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     unpack!(block = this.as_temp(block, statement_scope, expr, Mutability::Not));
 
                 if let Some(span) = adjusted_span {
-                    this.local_decls[temp].source_info.span = span;
+                    this.local_decls[temp].source_info.span = span.into();
                     this.block_context.pop();
                 }
 

--- a/src/librustc_mir_build/hair/cx/block.rs
+++ b/src/librustc_mir_build/hair/cx/block.rs
@@ -21,7 +21,7 @@ impl<'tcx> Mirror<'tcx> for &'tcx hir::Block<'tcx> {
             targeted_by_break: self.targeted_by_break,
             region_scope: region::Scope { id: self.hir_id.local_id, data: region::ScopeData::Node },
             opt_destruction_scope,
-            span: self.span,
+            span: self.span.into(),
             stmts,
             expr: self.expr.to_ref(),
             safety_mode: match self.rules {
@@ -73,7 +73,7 @@ fn mirror_stmts<'a, 'tcx>(
                             kind: Box::new(PatKind::AscribeUserType {
                                 ascription: hair::pattern::Ascription {
                                     user_ty: PatTyProj::from_user_type(user_ty),
-                                    user_ty_span: ty.span,
+                                    user_ty_span: ty.span.into(),
                                     variance: ty::Variance::Covariant,
                                 },
                                 subpattern: pattern,
@@ -110,7 +110,7 @@ crate fn to_expr_ref<'a, 'tcx>(
     let expr = Expr {
         ty: block_ty,
         temp_lifetime,
-        span: block.span,
+        span: block.span.into(),
         kind: ExprKind::Block { body: block },
     };
     expr.to_ref()

--- a/src/librustc_mir_build/hair/cx/mod.rs
+++ b/src/librustc_mir_build/hair/cx/mod.rs
@@ -49,7 +49,7 @@ crate struct Cx<'a, 'tcx> {
     check_overflow: bool,
 
     /// See field with the same name on `mir::Body`.
-    control_flow_destroyed: Vec<(Span, String)>,
+    control_flow_destroyed: Vec<(SpanId, String)>,
 }
 
 impl<'a, 'tcx> Cx<'a, 'tcx> {
@@ -93,7 +93,7 @@ impl<'a, 'tcx> Cx<'a, 'tcx> {
         }
     }
 
-    crate fn control_flow_destroyed(self) -> Vec<(Span, String)> {
+    crate fn control_flow_destroyed(self) -> Vec<(SpanId, String)> {
         self.control_flow_destroyed
     }
 }
@@ -132,7 +132,7 @@ impl<'a, 'tcx> Cx<'a, 'tcx> {
         &mut self,
         lit: &'tcx ast::LitKind,
         ty: Ty<'tcx>,
-        sp: Span,
+        sp: SpanId,
         neg: bool,
     ) -> &'tcx ty::Const<'tcx> {
         trace!("const_eval_literal: {:#?}, {:?}, {:?}, {:?}", lit, ty, sp, neg);
@@ -204,8 +204,8 @@ impl<'a, 'tcx> Cx<'a, 'tcx> {
         self.check_overflow
     }
 
-    crate fn type_is_copy_modulo_regions(&self, ty: Ty<'tcx>, span: Span) -> bool {
-        self.infcx.type_is_copy_modulo_regions(self.param_env, ty, span)
+    crate fn type_is_copy_modulo_regions(&self, ty: Ty<'tcx>, span: SpanId) -> bool {
+        self.infcx.type_is_copy_modulo_regions(self.param_env, ty, self.infcx.tcx.reify_span(span))
     }
 }
 

--- a/src/librustc_mir_build/hair/mod.rs
+++ b/src/librustc_mir_build/hair/mod.rs
@@ -13,7 +13,7 @@ use rustc_middle::mir::{BinOp, BorrowKind, Field, UnOp};
 use rustc_middle::ty::adjustment::PointerCast;
 use rustc_middle::ty::subst::SubstsRef;
 use rustc_middle::ty::{AdtDef, Const, Ty, UpvarSubsts, UserType};
-use rustc_span::Span;
+use rustc_span::SpanId;
 use rustc_target::abi::VariantIdx;
 
 crate mod constant;
@@ -36,7 +36,7 @@ crate struct Block<'tcx> {
     crate targeted_by_break: bool,
     crate region_scope: region::Scope,
     crate opt_destruction_scope: Option<region::Scope>,
-    crate span: Span,
+    crate span: SpanId,
     crate stmts: Vec<StmtRef<'tcx>>,
     crate expr: Option<ExprRef<'tcx>>,
     crate safety_mode: BlockSafety,
@@ -95,7 +95,7 @@ crate enum StmtKind<'tcx> {
 
 // `Expr` is used a lot. Make sure it doesn't unintentionally get bigger.
 #[cfg(target_arch = "x86_64")]
-rustc_data_structures::static_assert_size!(Expr<'_>, 168);
+rustc_data_structures::static_assert_size!(Expr<'_>, 176);
 
 /// The Hair trait implementor lowers their expressions (`&'tcx H::Expr`)
 /// into instances of this `Expr` enum. This lowering can be done
@@ -121,7 +121,7 @@ crate struct Expr<'tcx> {
     crate temp_lifetime: Option<region::Scope>,
 
     /// span of the expression in the source
-    crate span: Span,
+    crate span: SpanId,
 
     /// kind of expression
     crate kind: ExprKind<'tcx>,
@@ -312,7 +312,7 @@ crate struct Arm<'tcx> {
     crate body: ExprRef<'tcx>,
     crate lint_level: LintLevel,
     crate scope: region::Scope,
-    crate span: Span,
+    crate span: SpanId,
 }
 
 #[derive(Clone, Debug)]
@@ -327,9 +327,9 @@ crate enum LogicalOp {
 }
 
 impl<'tcx> ExprRef<'tcx> {
-    crate fn span(&self) -> Span {
+    crate fn span(&self) -> SpanId {
         match self {
-            ExprRef::Hair(expr) => expr.span,
+            ExprRef::Hair(expr) => expr.span.into(),
             ExprRef::Mirror(expr) => expr.span,
         }
     }

--- a/src/librustc_mir_build/hair/pattern/check_match.rs
+++ b/src/librustc_mir_build/hair/pattern/check_match.rs
@@ -579,7 +579,7 @@ fn maybe_point_at_variant(ty: Ty<'_>, patterns: &[super::Pat<'_>]) -> Vec<Span> 
 
 /// Check if a by-value binding is by-value. That is, check if the binding's type is not `Copy`.
 fn is_binding_by_move(cx: &MatchVisitor<'_, '_>, hir_id: HirId, span: Span) -> bool {
-    !cx.tables.node_type(hir_id).is_copy_modulo_regions(cx.tcx, cx.param_env, span)
+    !cx.tables.node_type(hir_id).is_copy_modulo_regions(cx.tcx, cx.param_env, span.into())
 }
 
 /// Check the legality of legality of by-move bindings.

--- a/src/librustc_mir_build/hair/pattern/mod.rs
+++ b/src/librustc_mir_build/hair/pattern/mod.rs
@@ -804,7 +804,7 @@ impl<'a, 'tcx> PatCtxt<'a, 'tcx> {
         let mir_structural_match_violation = self.tcx.mir_const_qualif(instance.def_id()).custom_eq;
         debug!("mir_structural_match_violation({:?}) -> {}", qpath, mir_structural_match_violation);
 
-        match self.tcx.const_eval_instance(param_env_reveal_all, instance, Some(span)) {
+        match self.tcx.const_eval_instance(param_env_reveal_all, instance, Some(span.into())) {
             Ok(value) => {
                 let const_ = ty::Const::from_value(self.tcx, value, self.tables.node_type(id));
 

--- a/src/librustc_mir_build/lints.rs
+++ b/src/librustc_mir_build/lints.rs
@@ -8,7 +8,7 @@ use rustc_middle::mir::{BasicBlock, Body, Operand, TerminatorKind};
 use rustc_middle::ty::subst::{GenericArg, InternalSubsts};
 use rustc_middle::ty::{self, AssocItem, AssocItemContainer, Instance, TyCtxt};
 use rustc_session::lint::builtin::UNCONDITIONAL_RECURSION;
-use rustc_span::Span;
+use rustc_span::SpanId;
 
 crate fn check<'tcx>(tcx: TyCtxt<'tcx>, body: &Body<'tcx>, def_id: LocalDefId) {
     let hir_id = tcx.hir().as_local_hir_id(def_id);
@@ -60,7 +60,7 @@ struct Search<'mir, 'tcx> {
     def_id: LocalDefId,
     trait_substs: &'tcx [GenericArg<'tcx>],
 
-    reachable_recursive_calls: Vec<Span>,
+    reachable_recursive_calls: Vec<SpanId>,
 }
 
 impl<'mir, 'tcx> Search<'mir, 'tcx> {

--- a/src/librustc_parse/lib.rs
+++ b/src/librustc_parse/lib.rs
@@ -42,7 +42,7 @@ macro_rules! panictry_buffer {
             Ok(e) => e,
             Err(errs) => {
                 for e in errs {
-                    $handler.emit_diagnostic(&e);
+                    $handler.emit_diagnostic(e);
                 }
                 FatalError.raise()
             }
@@ -176,7 +176,7 @@ fn file_to_source_file(sess: &ParseSess, path: &Path, spanopt: Option<Span>) -> 
     match try_file_to_source_file(sess, path, spanopt) {
         Ok(source_file) => source_file,
         Err(d) => {
-            sess.span_diagnostic.emit_diagnostic(&d);
+            sess.span_diagnostic.emit_diagnostic(d);
             FatalError.raise();
         }
     }

--- a/src/librustc_parse/parser/diagnostics.rs
+++ b/src/librustc_parse/parser/diagnostics.rs
@@ -12,7 +12,7 @@ use rustc_errors::{pluralize, struct_span_err};
 use rustc_errors::{Applicability, DiagnosticBuilder, Handler, PResult};
 use rustc_span::source_map::Spanned;
 use rustc_span::symbol::{kw, Ident};
-use rustc_span::{MultiSpan, Span, SpanSnippetError, DUMMY_SP};
+use rustc_span::{MultiSpanId, Span, SpanSnippetError, DUMMY_SP};
 
 use log::{debug, trace};
 
@@ -41,7 +41,7 @@ pub enum Error {
 }
 
 impl Error {
-    fn span_err(self, sp: impl Into<MultiSpan>, handler: &Handler) -> DiagnosticBuilder<'_> {
+    fn span_err(self, sp: impl Into<MultiSpanId>, handler: &Handler) -> DiagnosticBuilder<'_> {
         match self {
             Error::UselessDocComment => {
                 let mut err = struct_span_err!(
@@ -106,7 +106,7 @@ crate enum ConsumeClosingDelim {
 }
 
 impl<'a> Parser<'a> {
-    pub(super) fn span_fatal_err<S: Into<MultiSpan>>(
+    pub(super) fn span_fatal_err<S: Into<MultiSpanId>>(
         &self,
         sp: S,
         err: Error,
@@ -114,11 +114,11 @@ impl<'a> Parser<'a> {
         err.span_err(sp, self.diagnostic())
     }
 
-    pub fn struct_span_err<S: Into<MultiSpan>>(&self, sp: S, m: &str) -> DiagnosticBuilder<'a> {
+    pub fn struct_span_err<S: Into<MultiSpanId>>(&self, sp: S, m: &str) -> DiagnosticBuilder<'a> {
         self.sess.span_diagnostic.struct_span_err(sp, m)
     }
 
-    pub fn span_bug<S: Into<MultiSpan>>(&self, sp: S, m: &str) -> ! {
+    pub fn span_bug<S: Into<MultiSpanId>>(&self, sp: S, m: &str) -> ! {
         self.sess.span_diagnostic.span_bug(sp, m)
     }
 

--- a/src/librustc_privacy/lib.rs
+++ b/src/librustc_privacy/lib.rs
@@ -340,7 +340,7 @@ fn def_id_visibility<'tcx>(
         None => {
             let vis = tcx.visibility(def_id);
             let descr = if vis == ty::Visibility::Public { "public" } else { "private" };
-            (vis, tcx.def_span(def_id), descr)
+            (vis, tcx.real_def_span(def_id), descr)
         }
     }
 }

--- a/src/librustc_query_system/dep_graph/graph.rs
+++ b/src/librustc_query_system/dep_graph/graph.rs
@@ -763,7 +763,7 @@ impl<K: DepKind> DepGraph<K> {
             let handle = tcx.diagnostic();
 
             for diagnostic in diagnostics {
-                handle.emit_diagnostic(&diagnostic);
+                handle.emit_diagnostic(diagnostic);
             }
 
             // Mark the node as green now that diagnostics are emitted

--- a/src/librustc_resolve/imports.rs
+++ b/src/librustc_resolve/imports.rs
@@ -1414,7 +1414,7 @@ impl<'a, 'b> ImportResolver<'a, 'b> {
                                 .to_owned();
                             let error_id = (
                                 DiagnosticMessageId::ErrorId(0), // no code?!
-                                Some(binding.span),
+                                Some(binding.span.into()),
                                 msg.clone(),
                             );
                             let fresh =

--- a/src/librustc_session/lint.rs
+++ b/src/librustc_session/lint.rs
@@ -3,7 +3,7 @@ use rustc_ast::node_id::{NodeId, NodeMap};
 use rustc_data_structures::stable_hasher::{HashStable, StableHasher, ToStableHashKey};
 use rustc_errors::{pluralize, Applicability, DiagnosticBuilder};
 use rustc_span::edition::Edition;
-use rustc_span::{sym, symbol::Ident, MultiSpan, Span, Symbol};
+use rustc_span::{sym, symbol::Ident, MultiSpanId, Span, Symbol};
 
 pub mod builtin;
 
@@ -199,7 +199,7 @@ pub enum BuiltinLintDiagnostics {
 #[derive(PartialEq)]
 pub struct BufferedEarlyLint {
     /// The span of code that we are linting on.
-    pub span: MultiSpan,
+    pub span: MultiSpanId,
 
     /// The lint message.
     pub msg: String,
@@ -232,7 +232,7 @@ impl LintBuffer {
         &mut self,
         lint: &'static Lint,
         node_id: NodeId,
-        span: MultiSpan,
+        span: MultiSpanId,
         msg: &str,
         diagnostic: BuiltinLintDiagnostics,
     ) {
@@ -249,7 +249,7 @@ impl LintBuffer {
         &mut self,
         lint: &'static Lint,
         id: NodeId,
-        sp: impl Into<MultiSpan>,
+        sp: impl Into<MultiSpanId>,
         msg: &str,
     ) {
         self.add_lint(lint, id, sp.into(), msg, BuiltinLintDiagnostics::Normal)
@@ -259,7 +259,7 @@ impl LintBuffer {
         &mut self,
         lint: &'static Lint,
         id: NodeId,
-        sp: impl Into<MultiSpan>,
+        sp: impl Into<MultiSpanId>,
         msg: &str,
         diagnostic: BuiltinLintDiagnostics,
     ) {

--- a/src/librustc_session/parse.rs
+++ b/src/librustc_session/parse.rs
@@ -11,7 +11,7 @@ use rustc_feature::{find_feature_issue, GateIssue, UnstableFeatures};
 use rustc_span::edition::Edition;
 use rustc_span::hygiene::ExpnId;
 use rustc_span::source_map::{FilePathMapping, SourceMap};
-use rustc_span::{MultiSpan, Span, Symbol};
+use rustc_span::{MultiSpanId, Span, Symbol};
 
 use std::path::PathBuf;
 use std::str;
@@ -79,7 +79,7 @@ impl SymbolGallery {
 pub fn feature_err<'a>(
     sess: &'a ParseSess,
     feature: Symbol,
-    span: impl Into<MultiSpan>,
+    span: impl Into<MultiSpanId>,
     explain: &str,
 ) -> DiagnosticBuilder<'a> {
     feature_err_issue(sess, feature, span, GateIssue::Language, explain)
@@ -92,7 +92,7 @@ pub fn feature_err<'a>(
 pub fn feature_err_issue<'a>(
     sess: &'a ParseSess,
     feature: Symbol,
-    span: impl Into<MultiSpan>,
+    span: impl Into<MultiSpanId>,
     issue: GateIssue,
     explain: &str,
 ) -> DiagnosticBuilder<'a> {
@@ -177,7 +177,7 @@ impl ParseSess {
     pub fn buffer_lint(
         &self,
         lint: &'static Lint,
-        span: impl Into<MultiSpan>,
+        span: impl Into<MultiSpanId>,
         node_id: NodeId,
         msg: &str,
     ) {
@@ -195,7 +195,7 @@ impl ParseSess {
     pub fn buffer_lint_with_diagnostic(
         &self,
         lint: &'static Lint,
-        span: impl Into<MultiSpan>,
+        span: impl Into<MultiSpanId>,
         node_id: NodeId,
         msg: &str,
         diagnostic: BuiltinLintDiagnostics,

--- a/src/librustc_span/lib.rs
+++ b/src/librustc_span/lib.rs
@@ -240,6 +240,7 @@ impl Ord for Span {
 }
 
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, RustcEncodable, RustcDecodable)]
+#[derive(HashStable_Generic)]
 pub enum SpanId {
     Span(Span),
     DefId(DefId),

--- a/src/librustc_span/lib.rs
+++ b/src/librustc_span/lib.rs
@@ -245,6 +245,8 @@ pub enum SpanId {
     DefId(DefId),
 }
 
+pub const DUMMY_SPID: SpanId = SpanId::Span(DUMMY_SP);
+
 impl Default for SpanId {
     fn default() -> SpanId {
         SpanId::Span(DUMMY_SP)

--- a/src/librustc_span/lib.rs
+++ b/src/librustc_span/lib.rs
@@ -801,10 +801,10 @@ impl<Span: SpanLike> Multi<Span> {
 }
 
 impl<S> Multi<S> {
-    pub fn map_span<S2>(&self, f: impl Fn(&S) -> S2) -> Multi<S2> {
+    pub fn map_span<S2>(self, f: impl Fn(S) -> S2) -> Multi<S2> {
         Multi {
-            primary_spans: self.primary_spans.iter().map(&f).collect(),
-            span_labels: self.span_labels.iter().map(|(s, l)| (f(s), l.clone())).collect(),
+            primary_spans: self.primary_spans.into_iter().map(&f).collect(),
+            span_labels: self.span_labels.into_iter().map(|(s, l)| (f(s), l.clone())).collect(),
         }
     }
 }
@@ -823,7 +823,7 @@ impl From<Span> for MultiSpanId {
 
 impl From<MultiSpan> for MultiSpanId {
     fn from(ms: MultiSpan) -> MultiSpanId {
-        ms.map_span(|s| SpanId::Span(*s))
+        ms.map_span(SpanId::Span)
     }
 }
 

--- a/src/librustc_target/abi/mod.rs
+++ b/src/librustc_target/abi/mod.rs
@@ -9,7 +9,7 @@ use std::ops::{Add, AddAssign, Deref, Mul, Range, RangeInclusive, Sub};
 
 use rustc_index::vec::{Idx, IndexVec};
 use rustc_macros::HashStable_Generic;
-use rustc_span::Span;
+use rustc_span::SpanId;
 
 pub mod call;
 
@@ -971,7 +971,7 @@ pub trait LayoutOf {
     type TyAndLayout;
 
     fn layout_of(&self, ty: Self::Ty) -> Self::TyAndLayout;
-    fn spanned_layout_of(&self, ty: Self::Ty, _span: Span) -> Self::TyAndLayout {
+    fn spanned_layout_of(&self, ty: Self::Ty, _span: SpanId) -> Self::TyAndLayout {
         self.layout_of(ty)
     }
 }

--- a/src/librustc_trait_selection/infer.rs
+++ b/src/librustc_trait_selection/infer.rs
@@ -44,7 +44,7 @@ impl<'cx, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'cx, 'tcx> {
         let ty = self.resolve_vars_if_possible(&ty);
 
         if !(param_env, ty).needs_infer() {
-            return ty.is_copy_modulo_regions(self.tcx, param_env, span);
+            return ty.is_copy_modulo_regions(self.tcx, param_env, span.into());
         }
 
         let copy_def_id = self.tcx.require_lang_item(lang_items::CopyTraitLangItem, None);

--- a/src/librustc_trait_selection/opaque_types.rs
+++ b/src/librustc_trait_selection/opaque_types.rs
@@ -407,7 +407,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
 
         let opaque_type_generics = tcx.generics_of(def_id);
 
-        let span = tcx.def_span(def_id);
+        let span = tcx.real_def_span(def_id);
 
         // If there are required region bounds, we can use them.
         if opaque_defn.has_required_region_bounds {
@@ -566,7 +566,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
             return false;
         }
 
-        let span = self.tcx.def_span(opaque_type_def_id);
+        let span = self.tcx.real_def_span(opaque_type_def_id);
 
         // Without a feature-gate, we only generate member-constraints for async-await.
         let context_name = match opaque_defn.origin {
@@ -836,7 +836,7 @@ impl TypeFolder<'tcx> for ReverseMapper<'tcx> {
                     unexpected_hidden_region_diagnostic(
                         self.tcx,
                         None,
-                        self.tcx.def_span(self.opaque_type_def_id),
+                        self.tcx.real_def_span(self.opaque_type_def_id),
                         hidden_ty,
                         r,
                     )
@@ -1121,7 +1121,7 @@ impl<'a, 'tcx> Instantiator<'a, 'tcx> {
             debug!("instantiate_opaque_types: returning concrete ty {:?}", opaque_defn.concrete_ty);
             return opaque_defn.concrete_ty;
         }
-        let span = tcx.def_span(def_id);
+        let span = tcx.real_def_span(def_id);
         debug!("fold_opaque_ty {:?} {:?}", self.value_span, span);
         let ty_var = infcx
             .next_ty_var(TypeVariableOrigin { kind: TypeVariableOriginKind::TypeInference, span });

--- a/src/librustc_trait_selection/traits/error_reporting/mod.rs
+++ b/src/librustc_trait_selection/traits/error_reporting/mod.rs
@@ -1148,7 +1148,8 @@ impl<'a, 'tcx> InferCtxtPrivExt<'tcx> for InferCtxt<'a, 'tcx> {
             }
 
             let msg = format!("type mismatch resolving `{}`", predicate);
-            let error_id = (DiagnosticMessageId::ErrorId(271), Some(obligation.cause.span), msg);
+            let error_id =
+                (DiagnosticMessageId::ErrorId(271), Some(obligation.cause.span.into()), msg);
             let fresh = self.tcx.sess.one_time_diagnostics.borrow_mut().insert(error_id);
             if fresh {
                 let mut diag = struct_span_err!(

--- a/src/librustc_trait_selection/traits/error_reporting/mod.rs
+++ b/src/librustc_trait_selection/traits/error_reporting/mod.rs
@@ -381,7 +381,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                             err.note(s.as_str());
                         }
                         if let Some(ref s) = enclosing_scope {
-                            let enclosing_scope_span = tcx.def_span(
+                            let enclosing_scope_span = tcx.real_def_span(
                                 tcx.hir()
                                     .opt_local_def_id(obligation.cause.body_id)
                                     .unwrap_or_else(|| {
@@ -1295,8 +1295,8 @@ impl<'a, 'tcx> InferCtxtPrivExt<'tcx> for InferCtxt<'a, 'tcx> {
                     Some(t) => Some(t),
                     None => {
                         let ty = parent_trait_ref.skip_binder().self_ty();
-                        let span =
-                            TyCategory::from_ty(ty).map(|(_, def_id)| self.tcx.def_span(def_id));
+                        let span = TyCategory::from_ty(ty)
+                            .map(|(_, def_id)| self.tcx.real_def_span(def_id));
                         Some((ty.to_string(), span))
                     }
                 }
@@ -1331,7 +1331,7 @@ impl<'a, 'tcx> InferCtxtPrivExt<'tcx> for InferCtxt<'a, 'tcx> {
             .collect();
         for trait_with_same_path in traits_with_same_path {
             if let Some(impl_def_id) = get_trait_impl(*trait_with_same_path) {
-                let impl_span = self.tcx.def_span(impl_def_id);
+                let impl_span = self.tcx.real_def_span(impl_def_id);
                 err.span_help(impl_span, "trait impl with same name found");
                 let trait_crate = self.tcx.crate_name(trait_with_same_path.krate);
                 let crate_msg = format!(

--- a/src/librustc_trait_selection/traits/error_reporting/suggestions.rs
+++ b/src/librustc_trait_selection/traits/error_reporting/suggestions.rs
@@ -16,7 +16,7 @@ use rustc_middle::ty::{
     TyCtxt, TypeFoldable, WithConstness,
 };
 use rustc_span::symbol::{kw, sym, Ident, Symbol};
-use rustc_span::{MultiSpan, Span, DUMMY_SP};
+use rustc_span::{MultiSpanId, Span, DUMMY_SP};
 use std::fmt;
 
 use super::InferCtxtPrivExt;
@@ -1448,7 +1448,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
             ));
 
             let original_span = err.span.primary_span().unwrap();
-            let mut span = MultiSpan::from_span(original_span);
+            let mut span = MultiSpanId::from_span(original_span);
 
             let message = outer_generator
                 .and_then(|generator_did| {
@@ -1483,10 +1483,10 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
 
         if let Some(await_span) = from_awaited_ty {
             // The type causing this obligation is one being awaited at await_span.
-            let mut span = MultiSpan::from_span(await_span);
+            let mut span = MultiSpanId::from_span(await_span);
 
             span.push_span_label(
-                await_span,
+                await_span.into(),
                 format!("await occurs here on type `{}`, which {}", target_ty, trait_explanation),
             );
 
@@ -1503,21 +1503,21 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                 "note_obligation_cause_for_async_await generator_interior_types: {:#?}",
                 tables.generator_interior_types
             );
-            let mut span = MultiSpan::from_span(yield_span);
+            let mut span = MultiSpanId::from_span(yield_span);
             span.push_span_label(
-                yield_span,
+                yield_span.into(),
                 format!("{} occurs here, with `{}` maybe used later", await_or_yield, snippet),
             );
 
             span.push_span_label(
-                target_span,
+                target_span.into(),
                 format!("has type `{}` which {}", target_ty, trait_explanation),
             );
 
             // If available, use the scope span to annotate the drop location.
             if let Some(scope_span) = scope_span {
                 span.push_span_label(
-                    source_map.end_point(*scope_span),
+                    source_map.end_point(*scope_span).into(),
                     format!("`{}` is later dropped here", snippet),
                 );
             }

--- a/src/librustc_trait_selection/traits/fulfill.rs
+++ b/src/librustc_trait_selection/traits/fulfill.rs
@@ -514,7 +514,7 @@ impl<'a, 'b, 'tcx> ObligationProcessor for FulfillProcessor<'a, 'b, 'tcx> {
                     def_id,
                     substs,
                     None,
-                    Some(obligation.cause.span),
+                    Some(obligation.cause.span.into()),
                 ) {
                     Ok(_) => ProcessResult::Changed(vec![]),
                     Err(err) => ProcessResult::Error(CodeSelectionError(ConstEvalFailure(err))),

--- a/src/librustc_trait_selection/traits/misc.rs
+++ b/src/librustc_trait_selection/traits/misc.rs
@@ -52,7 +52,7 @@ pub fn can_type_implement_copy(
                 let ctx = traits::FulfillmentContext::new();
                 match traits::fully_normalize(&infcx, ctx, cause, param_env, &ty) {
                     Ok(ty) => {
-                        if !infcx.type_is_copy_modulo_regions(param_env, ty, span) {
+                        if !infcx.type_is_copy_modulo_regions(param_env, ty, span.into()) {
                             infringing.push(field);
                         }
                     }

--- a/src/librustc_trait_selection/traits/misc.rs
+++ b/src/librustc_trait_selection/traits/misc.rs
@@ -47,7 +47,7 @@ pub fn can_type_implement_copy(
                 if ty.references_error() {
                     continue;
                 }
-                let span = tcx.def_span(field.did);
+                let span = tcx.real_def_span(field.did);
                 let cause = ObligationCause { span, ..ObligationCause::dummy() };
                 let ctx = traits::FulfillmentContext::new();
                 match traits::fully_normalize(&infcx, ctx, cause, param_env, &ty) {

--- a/src/librustc_trait_selection/traits/project.rs
+++ b/src/librustc_trait_selection/traits/project.rs
@@ -423,7 +423,7 @@ pub fn normalize_projection_type<'a, 'b, 'tcx>(
         let def_id = projection_ty.item_def_id;
         let ty_var = selcx.infcx().next_ty_var(TypeVariableOrigin {
             kind: TypeVariableOriginKind::NormalizeProjectionType,
-            span: tcx.def_span(def_id),
+            span: tcx.real_def_span(def_id),
         });
         let projection = ty::Binder::dummy(ty::ProjectionPredicate { projection_ty, ty: ty_var });
         let obligation =
@@ -756,7 +756,7 @@ fn normalize_to_error<'a, 'tcx>(
     let def_id = projection_ty.item_def_id;
     let new_value = selcx.infcx().next_ty_var(TypeVariableOrigin {
         kind: TypeVariableOriginKind::NormalizeProjectionType,
-        span: tcx.def_span(def_id),
+        span: tcx.real_def_span(def_id),
     });
     Normalized { value: new_value, obligations: vec![trait_obligation] }
 }

--- a/src/librustc_trait_selection/traits/util.rs
+++ b/src/librustc_trait_selection/traits/util.rs
@@ -1,5 +1,5 @@
 use rustc_errors::DiagnosticBuilder;
-use rustc_span::Span;
+use rustc_span::SpanId;
 use smallvec::smallvec;
 use smallvec::SmallVec;
 
@@ -31,11 +31,11 @@ pub struct TraitAliasExpander<'tcx> {
 /// Stores information about the expansion of a trait via a path of zero or more trait aliases.
 #[derive(Debug, Clone)]
 pub struct TraitAliasExpansionInfo<'tcx> {
-    pub path: SmallVec<[(ty::PolyTraitRef<'tcx>, Span); 4]>,
+    pub path: SmallVec<[(ty::PolyTraitRef<'tcx>, SpanId); 4]>,
 }
 
 impl<'tcx> TraitAliasExpansionInfo<'tcx> {
-    fn new(trait_ref: ty::PolyTraitRef<'tcx>, span: Span) -> Self {
+    fn new(trait_ref: ty::PolyTraitRef<'tcx>, span: SpanId) -> Self {
         Self { path: smallvec![(trait_ref, span)] }
     }
 
@@ -63,15 +63,15 @@ impl<'tcx> TraitAliasExpansionInfo<'tcx> {
         &self.top().0
     }
 
-    pub fn top(&self) -> &(ty::PolyTraitRef<'tcx>, Span) {
+    pub fn top(&self) -> &(ty::PolyTraitRef<'tcx>, SpanId) {
         self.path.last().unwrap()
     }
 
-    pub fn bottom(&self) -> &(ty::PolyTraitRef<'tcx>, Span) {
+    pub fn bottom(&self) -> &(ty::PolyTraitRef<'tcx>, SpanId) {
         self.path.first().unwrap()
     }
 
-    fn clone_and_push(&self, trait_ref: ty::PolyTraitRef<'tcx>, span: Span) -> Self {
+    fn clone_and_push(&self, trait_ref: ty::PolyTraitRef<'tcx>, span: SpanId) -> Self {
         let mut path = self.path.clone();
         path.push((trait_ref, span));
 
@@ -81,7 +81,7 @@ impl<'tcx> TraitAliasExpansionInfo<'tcx> {
 
 pub fn expand_trait_aliases<'tcx>(
     tcx: TyCtxt<'tcx>,
-    trait_refs: impl Iterator<Item = (ty::PolyTraitRef<'tcx>, Span)>,
+    trait_refs: impl Iterator<Item = (ty::PolyTraitRef<'tcx>, SpanId)>,
 ) -> TraitAliasExpander<'tcx> {
     let items: Vec<_> =
         trait_refs.map(|(trait_ref, span)| TraitAliasExpansionInfo::new(trait_ref, span)).collect();

--- a/src/librustc_trait_selection/traits/wf.rs
+++ b/src/librustc_trait_selection/traits/wf.rs
@@ -549,7 +549,8 @@ impl<'a, 'tcx> WfPredicates<'a, 'tcx> {
             .into_iter()
             .zip(predicates.spans.into_iter())
             .map(|(pred, span)| {
-                let cause = self.cause(traits::BindingObligation(def_id, span));
+                let cause =
+                    self.cause(traits::BindingObligation(def_id, self.infcx.tcx.reify_span(span)));
                 traits::Obligation::new(cause, self.param_env, pred)
             })
             .filter(|pred| !pred.has_escaping_bound_vars())

--- a/src/librustc_traits/dropck_outlives.rs
+++ b/src/librustc_traits/dropck_outlives.rs
@@ -289,7 +289,7 @@ crate fn adt_dtorck_constraint(
     def_id: DefId,
 ) -> Result<DtorckConstraint<'_>, NoSolution> {
     let def = tcx.adt_def(def_id);
-    let span = tcx.def_span(def_id);
+    let span = tcx.real_def_span(def_id);
     debug!("dtorck_constraint: {:?}", def);
 
     if def.is_phantom_data() {

--- a/src/librustc_ty/needs_drop.rs
+++ b/src/librustc_ty/needs_drop.rs
@@ -5,7 +5,7 @@ use rustc_hir::def_id::DefId;
 use rustc_middle::ty::subst::Subst;
 use rustc_middle::ty::util::{needs_drop_components, AlwaysRequiresDrop};
 use rustc_middle::ty::{self, Ty, TyCtxt};
-use rustc_span::DUMMY_SP;
+use rustc_span::DUMMY_SPID;
 
 type NeedsDropResult<T> = Result<T, AlwaysRequiresDrop>;
 
@@ -71,7 +71,7 @@ where
                 // Not having a `Span` isn't great. But there's hopefully some other
                 // recursion limit error as well.
                 tcx.sess.span_err(
-                    DUMMY_SP,
+                    DUMMY_SPID,
                     &format!("overflow while checking whether `{}` requires drop", self.query_ty),
                 );
                 return Some(Err(AlwaysRequiresDrop));
@@ -91,7 +91,7 @@ where
 
             for component in components {
                 match component.kind {
-                    _ if component.is_copy_modulo_regions(tcx, self.param_env, DUMMY_SP) => (),
+                    _ if component.is_copy_modulo_regions(tcx, self.param_env, DUMMY_SPID) => (),
 
                     ty::Closure(_, substs) => {
                         for upvar_ty in substs.as_closure().upvar_tys() {

--- a/src/librustc_ty/ty.rs
+++ b/src/librustc_ty/ty.rs
@@ -225,7 +225,7 @@ fn associated_items(tcx: TyCtxt<'_>, def_id: DefId) -> ty::AssociatedItems<'_> {
     ty::AssociatedItems::new(items)
 }
 
-fn def_span(tcx: TyCtxt<'_>, def_id: DefId) -> Span {
+fn real_def_span(tcx: TyCtxt<'_>, def_id: DefId) -> Span {
     tcx.hir().span_if_local(def_id).unwrap()
 }
 
@@ -274,7 +274,7 @@ fn param_env(tcx: TyCtxt<'_>, def_id: DefId) -> ty::ParamEnv<'_> {
         .map_or(hir::CRATE_HIR_ID, |id| {
             tcx.hir().maybe_body_owned_by(id).map_or(id, |body| body.hir_id)
         });
-    let cause = traits::ObligationCause::misc(tcx.def_span(def_id), body_id);
+    let cause = traits::ObligationCause::misc(tcx.real_def_span(def_id), body_id);
     traits::normalize_param_env_or_error(tcx, def_id, unnormalized_env, cause)
 }
 
@@ -376,7 +376,7 @@ pub fn provide(providers: &mut ty::query::Providers<'_>) {
         associated_item_def_ids,
         associated_items,
         adt_sized_constraint,
-        def_span,
+        real_def_span,
         param_env,
         trait_of_item,
         crate_disambiguator,

--- a/src/librustc_typeck/check/autoderef.rs
+++ b/src/librustc_typeck/check/autoderef.rs
@@ -238,7 +238,7 @@ pub fn report_autoderef_recursion_limit_error<'tcx>(tcx: TyCtxt<'tcx>, span: Spa
     // We've reached the recursion limit, error gracefully.
     let suggested_limit = *tcx.sess.recursion_limit.get() * 2;
     let msg = format!("reached the recursion limit while auto-dereferencing `{:?}`", ty);
-    let error_id = (DiagnosticMessageId::ErrorId(55), Some(span), msg);
+    let error_id = (DiagnosticMessageId::ErrorId(55), Some(span.into()), msg);
     let fresh = tcx.sess.one_time_diagnostics.borrow_mut().insert(error_id);
     if fresh {
         struct_span_err!(

--- a/src/librustc_typeck/check/compare_method.rs
+++ b/src/librustc_typeck/check/compare_method.rs
@@ -811,7 +811,7 @@ fn compare_synthetic_generics<'tcx>(
         if impl_synthetic != trait_synthetic {
             let impl_hir_id = tcx.hir().as_local_hir_id(impl_def_id.expect_local());
             let impl_span = tcx.hir().span(impl_hir_id);
-            let trait_span = tcx.def_span(trait_def_id);
+            let trait_span = tcx.real_def_span(trait_def_id);
             let mut err = struct_span_err!(
                 tcx.sess,
                 impl_span,

--- a/src/librustc_typeck/check/dropck.rs
+++ b/src/librustc_typeck/check/dropck.rs
@@ -82,7 +82,7 @@ fn ensure_drop_params_and_item_params_correspond<'tcx>(
 
         let named_type = tcx.type_of(self_type_did);
 
-        let drop_impl_span = tcx.def_span(drop_impl_did);
+        let drop_impl_span = tcx.real_def_span(drop_impl_did);
         let fresh_impl_substs =
             infcx.fresh_substs_for_item(drop_impl_span, drop_impl_did.to_def_id());
         let fresh_impl_self_ty = drop_impl_ty.subst(tcx, fresh_impl_substs);

--- a/src/librustc_typeck/check/method/confirm.rs
+++ b/src/librustc_typeck/check/method/confirm.rs
@@ -11,7 +11,7 @@ use rustc_middle::ty::adjustment::{AllowTwoPhase, AutoBorrow, AutoBorrowMutabili
 use rustc_middle::ty::fold::TypeFoldable;
 use rustc_middle::ty::subst::{Subst, SubstsRef};
 use rustc_middle::ty::{self, GenericParamDefKind, Ty};
-use rustc_span::Span;
+use rustc_span::{Span, SpanId};
 use rustc_trait_selection::traits;
 
 use std::ops::Deref;
@@ -32,7 +32,7 @@ impl<'a, 'tcx> Deref for ConfirmContext<'a, 'tcx> {
 
 pub struct ConfirmResult<'tcx> {
     pub callee: MethodCallee<'tcx>,
-    pub illegal_sized_bound: Option<Span>,
+    pub illegal_sized_bound: Option<SpanId>,
 }
 
 impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
@@ -565,7 +565,7 @@ impl<'a, 'tcx> ConfirmContext<'a, 'tcx> {
     fn predicates_require_illegal_sized_bound(
         &self,
         predicates: &ty::InstantiatedPredicates<'tcx>,
-    ) -> Option<Span> {
+    ) -> Option<SpanId> {
         let sized_def_id = match self.tcx.lang_items().sized_trait() {
             Some(def_id) => def_id,
             None => return None,
@@ -581,7 +581,7 @@ impl<'a, 'tcx> ConfirmContext<'a, 'tcx> {
                         .find_map(
                             |(p, span)| if *p == obligation.predicate { Some(*span) } else { None },
                         )
-                        .unwrap_or(rustc_span::DUMMY_SP);
+                        .unwrap_or(rustc_span::DUMMY_SPID);
                     Some((trait_pred, span))
                 }
                 _ => None,

--- a/src/librustc_typeck/check/method/mod.rs
+++ b/src/librustc_typeck/check/method/mod.rs
@@ -207,6 +207,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             self.confirm_method(span, self_expr, call_expr, self_ty, pick.clone(), segment);
 
         if let Some(span) = result.illegal_sized_bound {
+            let span = self.tcx.reify_span(span);
             let mut needs_mut = false;
             if let ty::Ref(region, t_type, mutability) = self_ty.kind {
                 let trait_type = self

--- a/src/librustc_typeck/check/method/probe.rs
+++ b/src/librustc_typeck/check/method/probe.rs
@@ -1634,11 +1634,11 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
             GenericParamDefKind::Type { .. } => self
                 .next_ty_var(TypeVariableOrigin {
                     kind: TypeVariableOriginKind::SubstitutionPlaceholder,
-                    span: self.tcx.def_span(def_id),
+                    span: self.tcx.real_def_span(def_id),
                 })
                 .into(),
             GenericParamDefKind::Const { .. } => {
-                let span = self.tcx.def_span(def_id);
+                let span = self.tcx.real_def_span(def_id);
                 let origin = ConstVariableOrigin {
                     kind: ConstVariableOriginKind::SubstitutionPlaceholder,
                     span,

--- a/src/librustc_typeck/check/method/suggest.rs
+++ b/src/librustc_typeck/check/method/suggest.rs
@@ -195,7 +195,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             .tcx
                             .sess
                             .source_map()
-                            .guess_head_span(self.tcx.def_span(item.def_id));
+                            .guess_head_span(self.tcx.real_def_span(item.def_id));
                         let idx = if sources.len() > 1 {
                             let msg = &format!(
                                 "candidate #{} is defined in the trait `{}`",
@@ -568,7 +568,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 let mut restrict_type_params = false;
                 if !unsatisfied_predicates.is_empty() {
                     let def_span = |def_id| {
-                        self.tcx.sess.source_map().guess_head_span(self.tcx.def_span(def_id))
+                        self.tcx.sess.source_map().guess_head_span(self.tcx.real_def_span(def_id))
                     };
                     let mut type_params = FxHashMap::default();
                     let mut bound_spans = vec![];

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -2771,7 +2771,7 @@ impl<'a, 'tcx> AstConv<'tcx> for FnCtxt<'a, 'tcx> {
                         if data.skip_binder().self_ty().is_param(index) =>
                     {
                         // HACK(eddyb) should get the original `Span`.
-                        let span = tcx.def_span(def_id);
+                        let span = tcx.real_def_span(def_id);
                         Some((predicate, span))
                     }
                     _ => None,
@@ -3369,7 +3369,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             // self.out.extend(obligations);
 
             let cause = traits::ObligationCause::new(
-                self.tcx.def_span(const_def_id.to_def_id()),
+                self.tcx.real_def_span(const_def_id.to_def_id()),
                 self.body_id,
                 traits::MiscObligation,
             );

--- a/src/librustc_typeck/check/wfcheck.rs
+++ b/src/librustc_typeck/check/wfcheck.rs
@@ -241,7 +241,8 @@ fn check_object_unsafe_self_trait_by_name(tcx: TyCtxt<'_>, item: &hir::TraitItem
         if tcx.object_safety_violations(trait_def_id).is_empty() {
             return;
         }
-        let sugg = trait_should_be_self.iter().map(|span| (*span, "Self".to_string())).collect();
+        let sugg: Vec<_> =
+            trait_should_be_self.iter().map(|span| (*span, "Self".to_string())).collect();
         tcx.sess
             .struct_span_err(
                 trait_should_be_self,

--- a/src/librustc_typeck/check/wfcheck.rs
+++ b/src/librustc_typeck/check/wfcheck.rs
@@ -419,7 +419,7 @@ fn check_type_defn<'tcx, F>(
                     InternalSubsts::identity_for_item(fcx.tcx, discr_def_id.to_def_id());
 
                 let cause = traits::ObligationCause::new(
-                    fcx.tcx.def_span(discr_def_id),
+                    fcx.tcx.real_def_span(discr_def_id),
                     fcx.body_id,
                     traits::MiscObligation,
                 );
@@ -699,7 +699,7 @@ fn check_where_clauses<'tcx, 'fcx>(
                 if !ty.needs_subst() {
                     fcx.register_wf_obligation(
                         ty,
-                        fcx.tcx.def_span(param.def_id),
+                        fcx.tcx.real_def_span(param.def_id),
                         ObligationCauseCode::MiscObligation,
                     );
                 }

--- a/src/librustc_typeck/check/writeback.rs
+++ b/src/librustc_typeck/check/writeback.rs
@@ -403,7 +403,7 @@ impl<'cx, 'tcx> WritebackCx<'cx, 'tcx> {
         if !errors_buffer.is_empty() {
             errors_buffer.sort_by_key(|diag| diag.span.primary_span());
             for diag in errors_buffer.drain(..) {
-                self.tcx().sess.diagnostic().emit_diagnostic(&diag);
+                self.tcx().sess.diagnostic().emit_diagnostic(diag);
             }
         }
     }

--- a/src/librustc_typeck/check_unused.rs
+++ b/src/librustc_typeck/check_unused.rs
@@ -5,7 +5,7 @@ use rustc_hir::def_id::{DefId, DefIdSet, LOCAL_CRATE};
 use rustc_hir::itemlikevisit::ItemLikeVisitor;
 use rustc_middle::ty::TyCtxt;
 use rustc_session::lint;
-use rustc_span::{Span, Symbol};
+use rustc_span::{Span, SpanId, Symbol};
 
 pub fn check_crate(tcx: TyCtxt<'_>) {
     let mut used_trait_imports = DefIdSet::default();
@@ -70,7 +70,7 @@ fn unused_crates_lint(tcx: TyCtxt<'_>) {
     // Collect first the crates that are completely unused.  These we
     // can always suggest removing (no matter which edition we are
     // in).
-    let unused_extern_crates: FxHashMap<DefId, Span> = tcx
+    let unused_extern_crates: FxHashMap<DefId, SpanId> = tcx
         .maybe_unused_extern_crates(LOCAL_CRATE)
         .iter()
         .filter(|&&(def_id, _)| {
@@ -125,7 +125,7 @@ fn unused_crates_lint(tcx: TyCtxt<'_>) {
                         .get_attrs(extern_crate.def_id)
                         .iter()
                         .map(|attr| attr.span)
-                        .fold(span, |acc, attr_span| acc.to(attr_span));
+                        .fold(tcx.reify_span(span), |acc, attr_span| acc.to(attr_span));
 
                     lint.build("unused extern crate")
                         .span_suggestion_short(

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -1651,7 +1651,7 @@ fn predicates_of(tcx: TyCtxt<'_>, def_id: DefId) -> ty::GenericPredicates<'_> {
         // prove that the trait applies to the types that were
         // used, and adding the predicate into this list ensures
         // that this is done.
-        let span = tcx.sess.source_map().guess_head_span(tcx.def_span(def_id));
+        let span = tcx.sess.source_map().guess_head_span(tcx.real_def_span(def_id));
         result.predicates =
             tcx.arena.alloc_from_iter(result.predicates.iter().copied().chain(std::iter::once((
                 ty::TraitRef::identity(tcx, def_id).without_const().to_predicate(),
@@ -1728,7 +1728,7 @@ fn explicit_predicates_of(tcx: TyCtxt<'_>, def_id: DefId) -> ty::GenericPredicat
                         opaque_ty,
                         bounds,
                         SizedByDefault::Yes,
-                        tcx.def_span(def_id),
+                        tcx.real_def_span(def_id),
                     );
 
                     predicates.extend(bounds.predicates(tcx, opaque_ty));
@@ -1776,7 +1776,7 @@ fn explicit_predicates_of(tcx: TyCtxt<'_>, def_id: DefId) -> ty::GenericPredicat
                             opaque_ty,
                             bounds,
                             SizedByDefault::Yes,
-                            tcx.def_span(def_id),
+                            tcx.real_def_span(def_id),
                         );
 
                         bounds.predicates(tcx, opaque_ty)
@@ -1830,7 +1830,7 @@ fn explicit_predicates_of(tcx: TyCtxt<'_>, def_id: DefId) -> ty::GenericPredicat
     if let Some(trait_ref) = is_default_impl_trait {
         predicates.push((
             trait_ref.to_poly_trait_ref().without_const().to_predicate(),
-            tcx.def_span(def_id),
+            tcx.real_def_span(def_id),
         ));
     }
 

--- a/src/librustc_typeck/collect/type_of.rs
+++ b/src/librustc_typeck/collect/type_of.rs
@@ -444,7 +444,7 @@ fn find_opaque_ty_constraints(tcx: TyCtxt<'_>, def_id: LocalDefId) -> Ty<'_> {
                 );
 
                 // FIXME(oli-obk): trace the actual span from inference to improve errors.
-                let span = self.tcx.def_span(def_id);
+                let span = self.tcx.real_def_span(def_id);
 
                 // HACK(eddyb) this check shouldn't be needed, as `wfcheck`
                 // performs the same checks, in theory, but I've kept it here

--- a/src/librustc_typeck/constrained_generic_params.rs
+++ b/src/librustc_typeck/constrained_generic_params.rs
@@ -1,7 +1,7 @@
 use rustc_data_structures::fx::FxHashSet;
 use rustc_middle::ty::fold::{TypeFoldable, TypeVisitor};
 use rustc_middle::ty::{self, Ty, TyCtxt};
-use rustc_span::source_map::Span;
+use rustc_span::SpanId;
 
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
 pub struct Parameter(pub u32);
@@ -146,7 +146,7 @@ pub fn identify_constrained_generic_params<'tcx>(
 /// think of any.
 pub fn setup_constraining_predicates<'tcx>(
     tcx: TyCtxt<'tcx>,
-    predicates: &mut [(ty::Predicate<'tcx>, Span)],
+    predicates: &mut [(ty::Predicate<'tcx>, SpanId)],
     impl_trait_ref: Option<ty::TraitRef<'tcx>>,
     input_parameters: &mut FxHashSet<Parameter>,
 ) {

--- a/src/librustc_typeck/impl_wf_check.rs
+++ b/src/librustc_typeck/impl_wf_check.rs
@@ -160,7 +160,7 @@ fn enforce_impl_params_are_constrained(
                 if !input_parameters.contains(&cgp::Parameter::from(param_ty)) {
                     report_unused_parameter(
                         tcx,
-                        tcx.def_span(param.def_id),
+                        tcx.real_def_span(param.def_id),
                         "type",
                         &param_ty.to_string(),
                     );
@@ -173,7 +173,7 @@ fn enforce_impl_params_are_constrained(
                 {
                     report_unused_parameter(
                         tcx,
-                        tcx.def_span(param.def_id),
+                        tcx.real_def_span(param.def_id),
                         "lifetime",
                         &param.name.to_string(),
                     );
@@ -184,7 +184,7 @@ fn enforce_impl_params_are_constrained(
                 if !input_parameters.contains(&cgp::Parameter::from(param_ct)) {
                     report_unused_parameter(
                         tcx,
-                        tcx.def_span(param.def_id),
+                        tcx.real_def_span(param.def_id),
                         "const",
                         &param_ct.to_string(),
                     );

--- a/src/librustc_typeck/lib.rs
+++ b/src/librustc_typeck/lib.rs
@@ -100,7 +100,7 @@ use rustc_middle::ty::query::Providers;
 use rustc_middle::ty::{self, Ty, TyCtxt};
 use rustc_middle::util;
 use rustc_session::config::EntryFnType;
-use rustc_span::{Span, DUMMY_SP};
+use rustc_span::{Span, DUMMY_SPID};
 use rustc_target::spec::abi::Abi;
 use rustc_trait_selection::traits::error_reporting::InferCtxtExt as _;
 use rustc_trait_selection::traits::{
@@ -398,7 +398,7 @@ pub fn hir_trait_to_predicates<'tcx>(
     let _ = AstConv::instantiate_poly_trait_ref_inner(
         &item_cx,
         hir_trait,
-        DUMMY_SP,
+        DUMMY_SPID,
         hir::Constness::NotConst,
         self_ty,
         &mut bounds,

--- a/src/librustc_typeck/lib.rs
+++ b/src/librustc_typeck/lib.rs
@@ -154,7 +154,7 @@ fn require_same_types<'tcx>(
 
 fn check_main_fn_ty(tcx: TyCtxt<'_>, main_def_id: LocalDefId) {
     let main_id = tcx.hir().as_local_hir_id(main_def_id);
-    let main_span = tcx.def_span(main_def_id);
+    let main_span = tcx.real_def_span(main_def_id);
     let main_t = tcx.type_of(main_def_id);
     match main_t.kind {
         ty::FnDef(..) => {
@@ -233,7 +233,7 @@ fn check_main_fn_ty(tcx: TyCtxt<'_>, main_def_id: LocalDefId) {
 
 fn check_start_fn_ty(tcx: TyCtxt<'_>, start_def_id: LocalDefId) {
     let start_id = tcx.hir().as_local_hir_id(start_def_id);
-    let start_span = tcx.def_span(start_def_id);
+    let start_span = tcx.real_def_span(start_def_id);
     let start_t = tcx.type_of(start_def_id);
     match start_t.kind {
         ty::FnDef(..) => {

--- a/src/librustc_typeck/outlives/implicit_infer.rs
+++ b/src/librustc_typeck/outlives/implicit_infer.rs
@@ -5,7 +5,7 @@ use rustc_hir::itemlikevisit::ItemLikeVisitor;
 use rustc_hir::Node;
 use rustc_middle::ty::subst::{GenericArg, GenericArgKind, Subst};
 use rustc_middle::ty::{self, Ty, TyCtxt};
-use rustc_span::Span;
+use rustc_span::SpanId;
 
 use super::explicit::ExplicitPredicatesMap;
 use super::utils::*;
@@ -77,7 +77,7 @@ impl<'cx, 'tcx> ItemLikeVisitor<'tcx> for InferVisitor<'cx, 'tcx> {
                     // (struct/enum/union) there will be outlive
                     // requirements for adt_def.
                     let field_ty = self.tcx.type_of(field_def.did);
-                    let field_span = self.tcx.real_def_span(field_def.did);
+                    let field_span = self.tcx.def_span(field_def.did);
                     insert_required_predicates_to_be_wf(
                         self.tcx,
                         field_ty,
@@ -114,7 +114,7 @@ impl<'cx, 'tcx> ItemLikeVisitor<'tcx> for InferVisitor<'cx, 'tcx> {
 fn insert_required_predicates_to_be_wf<'tcx>(
     tcx: TyCtxt<'tcx>,
     field_ty: Ty<'tcx>,
-    field_span: Span,
+    field_span: SpanId,
     global_inferred_outlives: &FxHashMap<DefId, RequiredPredicates<'tcx>>,
     required_predicates: &mut RequiredPredicates<'tcx>,
     explicit_map: &mut ExplicitPredicatesMap<'tcx>,

--- a/src/librustc_typeck/outlives/implicit_infer.rs
+++ b/src/librustc_typeck/outlives/implicit_infer.rs
@@ -77,7 +77,7 @@ impl<'cx, 'tcx> ItemLikeVisitor<'tcx> for InferVisitor<'cx, 'tcx> {
                     // (struct/enum/union) there will be outlive
                     // requirements for adt_def.
                     let field_ty = self.tcx.type_of(field_def.did);
-                    let field_span = self.tcx.def_span(field_def.did);
+                    let field_span = self.tcx.real_def_span(field_def.did);
                     insert_required_predicates_to_be_wf(
                         self.tcx,
                         field_ty,

--- a/src/librustc_typeck/outlives/mod.rs
+++ b/src/librustc_typeck/outlives/mod.rs
@@ -5,7 +5,7 @@ use rustc_middle::ty::query::Providers;
 use rustc_middle::ty::subst::GenericArgKind;
 use rustc_middle::ty::{self, CratePredicatesMap, TyCtxt};
 use rustc_span::symbol::sym;
-use rustc_span::Span;
+use rustc_span::SpanId;
 
 mod explicit;
 mod implicit_infer;
@@ -17,7 +17,7 @@ pub fn provide(providers: &mut Providers<'_>) {
     *providers = Providers { inferred_outlives_of, inferred_outlives_crate, ..*providers };
 }
 
-fn inferred_outlives_of(tcx: TyCtxt<'_>, item_def_id: DefId) -> &[(ty::Predicate<'_>, Span)] {
+fn inferred_outlives_of(tcx: TyCtxt<'_>, item_def_id: DefId) -> &[(ty::Predicate<'_>, SpanId)] {
     let id = tcx.hir().as_local_hir_id(item_def_id.expect_local());
 
     match tcx.hir().get(id) {
@@ -87,13 +87,13 @@ fn inferred_outlives_crate(tcx: TyCtxt<'_>, crate_num: CrateNum) -> CratePredica
                         ty::Predicate::TypeOutlives(ty::Binder::bind(ty::OutlivesPredicate(
                             ty1, region2,
                         ))),
-                        span,
+                        span.into(),
                     )),
                     GenericArgKind::Lifetime(region1) => Some((
                         ty::Predicate::RegionOutlives(ty::Binder::bind(ty::OutlivesPredicate(
                             region1, region2,
                         ))),
-                        span,
+                        span.into(),
                     )),
                     GenericArgKind::Const(_) => {
                         // Generic consts don't impose any constraints.

--- a/src/librustc_typeck/outlives/utils.rs
+++ b/src/librustc_typeck/outlives/utils.rs
@@ -1,14 +1,14 @@
 use rustc_middle::ty::outlives::Component;
 use rustc_middle::ty::subst::{GenericArg, GenericArgKind};
 use rustc_middle::ty::{self, Region, RegionKind, Ty, TyCtxt};
-use rustc_span::Span;
+use rustc_span::SpanId;
 use smallvec::smallvec;
 use std::collections::BTreeMap;
 
 /// Tracks the `T: 'a` or `'a: 'a` predicates that we have inferred
 /// must be added to the struct header.
 pub type RequiredPredicates<'tcx> =
-    BTreeMap<ty::OutlivesPredicate<GenericArg<'tcx>, ty::Region<'tcx>>, Span>;
+    BTreeMap<ty::OutlivesPredicate<GenericArg<'tcx>, ty::Region<'tcx>>, SpanId>;
 
 /// Given a requirement `T: 'a` or `'b: 'a`, deduce the
 /// outlives_component and add it to `required_predicates`
@@ -16,7 +16,7 @@ pub fn insert_outlives_predicate<'tcx>(
     tcx: TyCtxt<'tcx>,
     kind: GenericArg<'tcx>,
     outlived_region: Region<'tcx>,
-    span: Span,
+    span: SpanId,
     required_predicates: &mut RequiredPredicates<'tcx>,
 ) {
     // If the `'a` region is bound within the field type itself, we

--- a/src/librustdoc/passes/check_code_block_syntax.rs
+++ b/src/librustdoc/passes/check_code_block_syntax.rs
@@ -1,6 +1,6 @@
 use rustc_ast::token;
 use rustc_data_structures::sync::{Lock, Lrc};
-use rustc_errors::{emitter::Emitter, Applicability, Diagnostic, Handler};
+use rustc_errors::{emitter::Emitter, Applicability, Handler, RealDiagnostic};
 use rustc_parse::lexer::StringReader as Lexer;
 use rustc_session::parse::ParseSess;
 use rustc_span::source_map::{FilePathMapping, SourceMap};
@@ -130,7 +130,7 @@ struct BufferEmitter {
 }
 
 impl Emitter for BufferEmitter {
-    fn emit_diagnostic(&mut self, diag: &Diagnostic) {
+    fn emit_diagnostic(&mut self, diag: &RealDiagnostic) {
         self.messages.borrow_mut().push(format!("error from rustc: {}", diag.message[0].0));
     }
 

--- a/src/test/ui/consts/dangling-alloc-id-ice.stderr
+++ b/src/test/ui/consts/dangling-alloc-id-ice.stderr
@@ -5,7 +5,9 @@ LL | / const FOO: &() = {
 LL | |     let y = ();
 LL | |     unsafe { Foo { y: &y }.long_live_the_unit }
 LL | | };
-   | |__^ encountered dangling pointer in final constant
+   | |  ^ encountered dangling pointer in final constant
+   | |__|
+   | 
    |
    = note: `#[deny(const_err)]` on by default
 

--- a/src/test/ui/consts/dangling_raw_ptr.stderr
+++ b/src/test/ui/consts/dangling_raw_ptr.stderr
@@ -5,7 +5,9 @@ LL | / const FOO: *const u32 = {
 LL | |     let x = 42;
 LL | |     &x
 LL | | };
-   | |__^ encountered dangling pointer in final constant
+   | |  ^ encountered dangling pointer in final constant
+   | |__|
+   | 
    |
    = note: `#[deny(const_err)]` on by default
 

--- a/src/test/ui/consts/miri_unleashed/mutable_const2.stderr
+++ b/src/test/ui/consts/miri_unleashed/mutable_const2.stderr
@@ -14,7 +14,7 @@ error: internal compiler error: mutable allocation in constant
 LL | const MUTABLE_BEHIND_RAW: *mut i32 = &UnsafeCell::new(42) as *const _ as *mut _;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-thread 'rustc' panicked at 'no errors encountered even though `delay_span_bug` issued', src/librustc_errors/lib.rs:366:17
+thread 'rustc' panicked at 'no errors encountered even though `delay_span_bug` issued', src/librustc_errors/lib.rs:368:17
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 
 error: internal compiler error: unexpected panic

--- a/src/test/ui/consts/miri_unleashed/mutable_const2.stderr
+++ b/src/test/ui/consts/miri_unleashed/mutable_const2.stderr
@@ -14,7 +14,7 @@ error: internal compiler error: mutable allocation in constant
 LL | const MUTABLE_BEHIND_RAW: *mut i32 = &UnsafeCell::new(42) as *const _ as *mut _;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-thread 'rustc' panicked at 'no errors encountered even though `delay_span_bug` issued', src/librustc_errors/lib.rs:368:17
+thread 'rustc' panicked at 'no errors encountered even though `delay_span_bug` issued', src/librustc_errors/lib.rs:399:17
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 
 error: internal compiler error: unexpected panic

--- a/src/tools/clippy/clippy_lints/src/as_conversions.rs
+++ b/src/tools/clippy/clippy_lints/src/as_conversions.rs
@@ -40,7 +40,7 @@ declare_lint_pass!(AsConversions => [AS_CONVERSIONS]);
 
 impl EarlyLintPass for AsConversions {
     fn check_expr(&mut self, cx: &EarlyContext<'_>, expr: &Expr) {
-        if in_external_macro(cx.sess(), expr.span) {
+        if in_external_macro(cx.sess(), expr.span.into()) {
             return;
         }
 

--- a/src/tools/clippy/clippy_lints/src/attrs.rs
+++ b/src/tools/clippy/clippy_lints/src/attrs.rs
@@ -288,7 +288,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Attributes {
                 let skip_unused_imports = item.attrs.iter().any(|attr| attr.check_name(sym!(macro_use)));
 
                 for attr in item.attrs {
-                    if in_external_macro(cx.sess(), attr.span) {
+                    if in_external_macro(cx.sess(), attr.span.into()) {
                         return;
                     }
                     if let Some(lint_list) = &attr.meta_item_list() {

--- a/src/tools/clippy/clippy_lints/src/block_in_if_condition.rs
+++ b/src/tools/clippy/clippy_lints/src/block_in_if_condition.rs
@@ -76,7 +76,7 @@ const COMPLEX_BLOCK_MESSAGE: &str = "in an `if` condition, avoid complex blocks 
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for BlockInIfCondition {
     fn check_expr(&mut self, cx: &LateContext<'a, 'tcx>, expr: &'tcx Expr<'_>) {
-        if in_external_macro(cx.sess(), expr.span) {
+        if in_external_macro(cx.sess(), expr.span.into()) {
             return;
         }
         if let Some((cond, _, _)) = higher::if_block(&expr) {

--- a/src/tools/clippy/clippy_lints/src/checked_conversions.rs
+++ b/src/tools/clippy/clippy_lints/src/checked_conversions.rs
@@ -44,7 +44,7 @@ declare_lint_pass!(CheckedConversions => [CHECKED_CONVERSIONS]);
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for CheckedConversions {
     fn check_expr(&mut self, cx: &LateContext<'_, '_>, item: &Expr<'_>) {
         let result = if_chain! {
-            if !in_external_macro(cx.sess(), item.span);
+            if !in_external_macro(cx.sess(), item.span.into());
             if let ExprKind::Binary(op, ref left, ref right) = &item.kind;
 
             then {

--- a/src/tools/clippy/clippy_lints/src/else_if_without_else.rs
+++ b/src/tools/clippy/clippy_lints/src/else_if_without_else.rs
@@ -50,7 +50,7 @@ declare_lint_pass!(ElseIfWithoutElse => [ELSE_IF_WITHOUT_ELSE]);
 
 impl EarlyLintPass for ElseIfWithoutElse {
     fn check_expr(&mut self, cx: &EarlyContext<'_>, mut item: &Expr) {
-        if in_external_macro(cx.sess(), item.span) {
+        if in_external_macro(cx.sess(), item.span.into()) {
             return;
         }
 

--- a/src/tools/clippy/clippy_lints/src/eta_reduction.rs
+++ b/src/tools/clippy/clippy_lints/src/eta_reduction.rs
@@ -62,7 +62,7 @@ declare_lint_pass!(EtaReduction => [REDUNDANT_CLOSURE, REDUNDANT_CLOSURE_FOR_MET
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for EtaReduction {
     fn check_expr(&mut self, cx: &LateContext<'a, 'tcx>, expr: &'tcx Expr<'_>) {
-        if in_external_macro(cx.sess(), expr.span) {
+        if in_external_macro(cx.sess(), expr.span.into()) {
             return;
         }
 

--- a/src/tools/clippy/clippy_lints/src/formatting.rs
+++ b/src/tools/clippy/clippy_lints/src/formatting.rs
@@ -205,7 +205,7 @@ fn check_else(cx: &EarlyContext<'_>, expr: &Expr) {
         if let ExprKind::If(_, then, Some(else_)) = &expr.kind;
         if is_block(else_) || is_if(else_);
         if !differing_macro_contexts(then.span, else_.span);
-        if !then.span.from_expansion() && !in_external_macro(cx.sess, expr.span);
+        if !then.span.from_expansion() && !in_external_macro(cx.sess, expr.span.into());
 
         // workaround for rust-lang/rust#43081
         if expr.span.lo().0 != 0 && expr.span.hi().0 != 0;

--- a/src/tools/clippy/clippy_lints/src/functions.rs
+++ b/src/tools/clippy/clippy_lints/src/functions.rs
@@ -507,7 +507,7 @@ fn is_mutable_ty<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, ty: Ty<'tcx>, span: Span,
         // primitive types are never mutable
         ty::Bool | ty::Char | ty::Int(_) | ty::Uint(_) | ty::Float(_) | ty::Str => false,
         ty::Adt(ref adt, ref substs) => {
-            tys.insert(adt.did) && !ty.is_freeze(cx.tcx, cx.param_env, span)
+            tys.insert(adt.did) && !ty.is_freeze(cx.tcx, cx.param_env, span.into())
                 || KNOWN_WRAPPER_TYS.iter().any(|path| match_def_path(cx, adt.did, path))
                     && substs.types().any(|ty| is_mutable_ty(cx, ty, span, tys))
         },

--- a/src/tools/clippy/clippy_lints/src/functions.rs
+++ b/src/tools/clippy/clippy_lints/src/functions.rs
@@ -318,7 +318,7 @@ impl<'a, 'tcx> Functions {
     }
 
     fn check_line_number(self, cx: &LateContext<'_, '_>, span: Span, body: &'tcx hir::Body<'_>) {
-        if in_external_macro(cx.sess(), span) {
+        if in_external_macro(cx.sess(), span.into()) {
             return;
         }
 
@@ -407,7 +407,7 @@ fn check_needless_must_use(
     fn_header_span: Span,
     attr: &Attribute,
 ) {
-    if in_external_macro(cx.sess(), item_span) {
+    if in_external_macro(cx.sess(), item_span.into()) {
         return;
     }
     if returns_unit(decl) {
@@ -448,7 +448,7 @@ fn check_must_use_candidate<'a, 'tcx>(
 ) {
     if has_mutable_arg(cx, body)
         || mutates_static(cx, body)
-        || in_external_macro(cx.sess(), item_span)
+        || in_external_macro(cx.sess(), item_span.into())
         || returns_unit(decl)
         || !cx.access_levels.is_exported(item_id)
         || is_must_use_ty(cx, return_ty(cx, item_id))

--- a/src/tools/clippy/clippy_lints/src/if_not_else.rs
+++ b/src/tools/clippy/clippy_lints/src/if_not_else.rs
@@ -49,7 +49,7 @@ declare_lint_pass!(IfNotElse => [IF_NOT_ELSE]);
 
 impl EarlyLintPass for IfNotElse {
     fn check_expr(&mut self, cx: &EarlyContext<'_>, item: &Expr) {
-        if in_external_macro(cx.sess(), item.span) {
+        if in_external_macro(cx.sess(), item.span.into()) {
             return;
         }
         if let ExprKind::If(ref cond, _, Some(ref els)) = item.kind {

--- a/src/tools/clippy/clippy_lints/src/let_if_seq.rs
+++ b/src/tools/clippy/clippy_lints/src/let_if_seq.rs
@@ -76,7 +76,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for LetIfSeq {
                     let has_interior_mutability = !cx.tables.node_type(canonical_id).is_freeze(
                         cx.tcx,
                         cx.param_env,
-                        span
+                        span.into()
                     );
                     if has_interior_mutability { return; }
 

--- a/src/tools/clippy/clippy_lints/src/let_underscore.rs
+++ b/src/tools/clippy/clippy_lints/src/let_underscore.rs
@@ -68,7 +68,7 @@ const SYNC_GUARD_PATHS: [&[&str]; 3] = [
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for LetUnderscore {
     fn check_local(&mut self, cx: &LateContext<'_, '_>, local: &Local<'_>) {
-        if in_external_macro(cx.tcx.sess, local.span) {
+        if in_external_macro(cx.tcx.sess, local.span.into()) {
             return;
         }
 

--- a/src/tools/clippy/clippy_lints/src/literal_representation.rs
+++ b/src/tools/clippy/clippy_lints/src/literal_representation.rs
@@ -176,7 +176,7 @@ declare_lint_pass!(LiteralDigitGrouping => [
 
 impl EarlyLintPass for LiteralDigitGrouping {
     fn check_expr(&mut self, cx: &EarlyContext<'_>, expr: &Expr) {
-        if in_external_macro(cx.sess(), expr.span) {
+        if in_external_macro(cx.sess(), expr.span.into()) {
             return;
         }
 
@@ -350,7 +350,7 @@ impl_lint_pass!(DecimalLiteralRepresentation => [DECIMAL_LITERAL_REPRESENTATION]
 
 impl EarlyLintPass for DecimalLiteralRepresentation {
     fn check_expr(&mut self, cx: &EarlyContext<'_>, expr: &Expr) {
-        if in_external_macro(cx.sess(), expr.span) {
+        if in_external_macro(cx.sess(), expr.span.into()) {
             return;
         }
 

--- a/src/tools/clippy/clippy_lints/src/loops.rs
+++ b/src/tools/clippy/clippy_lints/src/loops.rs
@@ -528,7 +528,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Loops {
                                 && arms[1].guard.is_none()
                                 && is_simple_break_expr(&arms[1].body)
                             {
-                                if in_external_macro(cx.sess(), expr.span) {
+                                if in_external_macro(cx.sess(), expr.span.into()) {
                                     return;
                                 }
 

--- a/src/tools/clippy/clippy_lints/src/match_on_vec_items.rs
+++ b/src/tools/clippy/clippy_lints/src/match_on_vec_items.rs
@@ -47,7 +47,7 @@ declare_lint_pass!(MatchOnVecItems => [MATCH_ON_VEC_ITEMS]);
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for MatchOnVecItems {
     fn check_expr(&mut self, cx: &LateContext<'a, 'tcx>, expr: &'tcx Expr<'tcx>) {
         if_chain! {
-            if !in_external_macro(cx.sess(), expr.span);
+            if !in_external_macro(cx.sess(), expr.span.into());
             if let ExprKind::Match(ref match_expr, _, MatchSource::Normal) = expr.kind;
             if let Some(idx_expr) = is_vec_indexing(cx, match_expr);
             if let ExprKind::Index(vec, idx) = idx_expr.kind;

--- a/src/tools/clippy/clippy_lints/src/matches.rs
+++ b/src/tools/clippy/clippy_lints/src/matches.rs
@@ -364,7 +364,7 @@ impl_lint_pass!(Matches => [
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Matches {
     fn check_expr(&mut self, cx: &LateContext<'a, 'tcx>, expr: &'tcx Expr<'_>) {
-        if in_external_macro(cx.sess(), expr.span) {
+        if in_external_macro(cx.sess(), expr.span.into()) {
             return;
         }
         if let ExprKind::Match(ref ex, ref arms, MatchSource::Normal) = expr.kind {
@@ -389,7 +389,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Matches {
 
     fn check_local(&mut self, cx: &LateContext<'a, 'tcx>, local: &'tcx Local<'_>) {
         if_chain! {
-            if !in_external_macro(cx.sess(), local.span);
+            if !in_external_macro(cx.sess(), local.span.into());
             if !in_macro(local.span);
             if let Some(ref expr) = local.init;
             if let ExprKind::Match(ref target, ref arms, MatchSource::Normal) = expr.kind;
@@ -425,7 +425,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Matches {
 
     fn check_pat(&mut self, cx: &LateContext<'a, 'tcx>, pat: &'tcx Pat<'_>) {
         if_chain! {
-            if !in_external_macro(cx.sess(), pat.span);
+            if !in_external_macro(cx.sess(), pat.span.into());
             if !in_macro(pat.span);
             if let PatKind::Struct(ref qpath, fields, true) = pat.kind;
             if let QPath::Resolved(_, ref path) = qpath;

--- a/src/tools/clippy/clippy_lints/src/mem_replace.rs
+++ b/src/tools/clippy/clippy_lints/src/mem_replace.rs
@@ -170,7 +170,7 @@ fn check_replace_with_uninit(cx: &LateContext<'_, '_>, src: &Expr<'_>, expr_span
 fn check_replace_with_default(cx: &LateContext<'_, '_>, src: &Expr<'_>, dest: &Expr<'_>, expr_span: Span) {
     if let ExprKind::Call(ref repl_func, _) = src.kind {
         if_chain! {
-            if !in_external_macro(cx.tcx.sess, expr_span);
+            if !in_external_macro(cx.tcx.sess, expr_span.into());
             if let ExprKind::Path(ref repl_func_qpath) = repl_func.kind;
             if let Some(repl_def_id) = cx.tables.qpath_res(repl_func_qpath, repl_func.hir_id).opt_def_id();
             if match_def_path(cx, repl_def_id, &paths::DEFAULT_TRAIT_METHOD);

--- a/src/tools/clippy/clippy_lints/src/methods/mod.rs
+++ b/src/tools/clippy/clippy_lints/src/methods/mod.rs
@@ -1450,7 +1450,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Methods {
     }
 
     fn check_impl_item(&mut self, cx: &LateContext<'a, 'tcx>, impl_item: &'tcx hir::ImplItem<'_>) {
-        if in_external_macro(cx.sess(), impl_item.span) {
+        if in_external_macro(cx.sess(), impl_item.span.into()) {
             return;
         }
         let name = impl_item.ident.name.as_str();

--- a/src/tools/clippy/clippy_lints/src/misc_early.rs
+++ b/src/tools/clippy/clippy_lints/src/misc_early.rs
@@ -412,7 +412,7 @@ impl EarlyLintPass for MiscEarlyLints {
     }
 
     fn check_expr(&mut self, cx: &EarlyContext<'_>, expr: &Expr) {
-        if in_external_macro(cx.sess(), expr.span) {
+        if in_external_macro(cx.sess(), expr.span.into()) {
             return;
         }
         match expr.kind {

--- a/src/tools/clippy/clippy_lints/src/missing_const_for_fn.rs
+++ b/src/tools/clippy/clippy_lints/src/missing_const_for_fn.rs
@@ -83,7 +83,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for MissingConstForFn {
     ) {
         let def_id = cx.tcx.hir().local_def_id(hir_id);
 
-        if in_external_macro(cx.tcx.sess, span) || is_entrypoint_fn(cx, def_id.to_def_id()) {
+        if in_external_macro(cx.tcx.sess, span.into()) || is_entrypoint_fn(cx, def_id.to_def_id()) {
             return;
         }
 

--- a/src/tools/clippy/clippy_lints/src/missing_inline.rs
+++ b/src/tools/clippy/clippy_lints/src/missing_inline.rs
@@ -81,7 +81,7 @@ declare_lint_pass!(MissingInline => [MISSING_INLINE_IN_PUBLIC_ITEMS]);
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for MissingInline {
     fn check_item(&mut self, cx: &LateContext<'a, 'tcx>, it: &'tcx hir::Item<'_>) {
-        if rustc_middle::lint::in_external_macro(cx.sess(), it.span) || is_executable(cx) {
+        if rustc_middle::lint::in_external_macro(cx.sess(), it.span.into()) || is_executable(cx) {
             return;
         }
 
@@ -131,7 +131,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for MissingInline {
 
     fn check_impl_item(&mut self, cx: &LateContext<'a, 'tcx>, impl_item: &'tcx hir::ImplItem<'_>) {
         use rustc_middle::ty::{ImplContainer, TraitContainer};
-        if rustc_middle::lint::in_external_macro(cx.sess(), impl_item.span) || is_executable(cx) {
+        if rustc_middle::lint::in_external_macro(cx.sess(), impl_item.span.into()) || is_executable(cx) {
             return;
         }
 

--- a/src/tools/clippy/clippy_lints/src/mut_key.rs
+++ b/src/tools/clippy/clippy_lints/src/mut_key.rs
@@ -118,7 +118,7 @@ fn is_mutable_type<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, ty: Ty<'tcx>, span: Spa
             size.try_eval_usize(cx.tcx, cx.param_env).map_or(true, |u| u != 0) && is_mutable_type(cx, inner_ty, span)
         },
         Tuple(..) => ty.tuple_fields().any(|ty| is_mutable_type(cx, ty, span)),
-        Adt(..) => cx.tcx.layout_of(cx.param_env.and(ty)).is_ok() && !ty.is_freeze(cx.tcx, cx.param_env, span),
+        Adt(..) => cx.tcx.layout_of(cx.param_env.and(ty)).is_ok() && !ty.is_freeze(cx.tcx, cx.param_env, span.into()),
         _ => false,
     }
 }

--- a/src/tools/clippy/clippy_lints/src/mut_mut.rs
+++ b/src/tools/clippy/clippy_lints/src/mut_mut.rs
@@ -48,7 +48,7 @@ impl<'a, 'tcx> intravisit::Visitor<'tcx> for MutVisitor<'a, 'tcx> {
     type Map = Map<'tcx>;
 
     fn visit_expr(&mut self, expr: &'tcx hir::Expr<'_>) {
-        if in_external_macro(self.cx.sess(), expr.span) {
+        if in_external_macro(self.cx.sess(), expr.span.into()) {
             return;
         }
 

--- a/src/tools/clippy/clippy_lints/src/neg_cmp_op_on_partial_ord.rs
+++ b/src/tools/clippy/clippy_lints/src/neg_cmp_op_on_partial_ord.rs
@@ -49,7 +49,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NoNegCompOpForPartialOrd {
     fn check_expr(&mut self, cx: &LateContext<'a, 'tcx>, expr: &'tcx Expr<'_>) {
         if_chain! {
 
-            if !in_external_macro(cx.sess(), expr.span);
+            if !in_external_macro(cx.sess(), expr.span.into());
             if let ExprKind::Unary(UnOp::UnNot, ref inner) = expr.kind;
             if let ExprKind::Binary(ref op, ref left, _) = inner.kind;
             if let BinOpKind::Le | BinOpKind::Ge | BinOpKind::Lt | BinOpKind::Gt = op.node;

--- a/src/tools/clippy/clippy_lints/src/new_without_default.rs
+++ b/src/tools/clippy/clippy_lints/src/new_without_default.rs
@@ -227,7 +227,7 @@ fn can_derive_default<'t, 'c>(ty: Ty<'t>, cx: &LateContext<'c, 't>, default_trai
                     return None;
                 }
             }
-            Some(cx.tcx.def_span(adt_def.did))
+            Some(cx.tcx.real_def_span(adt_def.did))
         },
         _ => None,
     }

--- a/src/tools/clippy/clippy_lints/src/new_without_default.rs
+++ b/src/tools/clippy/clippy_lints/src/new_without_default.rs
@@ -102,7 +102,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NewWithoutDefault {
             for assoc_item in items {
                 if let hir::AssocItemKind::Fn { has_self: false } = assoc_item.kind {
                     let impl_item = cx.tcx.hir().impl_item(assoc_item.id);
-                    if in_external_macro(cx.sess(), impl_item.span) {
+                    if in_external_macro(cx.sess(), impl_item.span.into()) {
                         return;
                     }
                     if let hir::ImplItemKind::Fn(ref sig, _) = impl_item.kind {

--- a/src/tools/clippy/clippy_lints/src/non_copy_const.rs
+++ b/src/tools/clippy/clippy_lints/src/non_copy_const.rs
@@ -10,7 +10,7 @@ use rustc_lint::{LateContext, LateLintPass, Lint};
 use rustc_middle::ty::adjustment::Adjust;
 use rustc_middle::ty::{Ty, TypeFlags};
 use rustc_session::{declare_lint_pass, declare_tool_lint};
-use rustc_span::{InnerSpan, Span, DUMMY_SP};
+use rustc_span::{InnerSpan, Span, DUMMY_SPID};
 use rustc_typeck::hir_ty_to_ty;
 
 use crate::utils::{in_constant, is_copy, qpath_res, span_lint_and_then};
@@ -110,7 +110,7 @@ impl Source {
 }
 
 fn verify_ty_bound<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, ty: Ty<'tcx>, source: Source) {
-    if ty.is_freeze(cx.tcx, cx.param_env, DUMMY_SP) || is_copy(cx, ty) {
+    if ty.is_freeze(cx.tcx, cx.param_env, DUMMY_SPID) || is_copy(cx, ty) {
         // An `UnsafeCell` is `!Copy`, and an `UnsafeCell` is also the only type which
         // is `!Freeze`, thus if our type is `Copy` we can be sure it must be `Freeze`
         // as well.

--- a/src/tools/clippy/clippy_lints/src/question_mark.rs
+++ b/src/tools/clippy/clippy_lints/src/question_mark.rs
@@ -137,7 +137,7 @@ impl QuestionMark {
     fn moves_by_default(cx: &LateContext<'_, '_>, expression: &Expr<'_>) -> bool {
         let expr_ty = cx.tables.expr_ty(expression);
 
-        !expr_ty.is_copy_modulo_regions(cx.tcx, cx.param_env, expression.span)
+        !expr_ty.is_copy_modulo_regions(cx.tcx, cx.param_env, expression.span.into())
     }
 
     fn is_option(cx: &LateContext<'_, '_>, expression: &Expr<'_>) -> bool {

--- a/src/tools/clippy/clippy_lints/src/redundant_clone.rs
+++ b/src/tools/clippy/clippy_lints/src/redundant_clone.rs
@@ -99,7 +99,8 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for RedundantClone {
         for (bb, bbdata) in mir.basic_blocks().iter_enumerated() {
             let terminator = bbdata.terminator();
 
-            if terminator.source_info.span.from_expansion() {
+            let span = cx.tcx.reify_span(terminator.source_info.span);
+            if span.from_expansion() {
                 continue;
             }
 
@@ -217,7 +218,6 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for RedundantClone {
             );
 
             if !used || !consumed_or_mutated {
-                let span = terminator.source_info.span;
                 let scope = terminator.source_info.scope;
                 let node = mir.source_scopes[scope]
                     .local_data

--- a/src/tools/clippy/clippy_lints/src/returns.rs
+++ b/src/tools/clippy/clippy_lints/src/returns.rs
@@ -150,7 +150,7 @@ impl Return {
     fn emit_return_lint(cx: &EarlyContext<'_>, ret_span: Span, inner_span: Option<Span>, replacement: RetReplacement) {
         match inner_span {
             Some(inner_span) => {
-                if in_external_macro(cx.sess(), inner_span) || inner_span.from_expansion() {
+                if in_external_macro(cx.sess(), inner_span.into()) || inner_span.from_expansion() {
                     return;
                 }
 
@@ -204,9 +204,9 @@ impl Return {
             if let ast::PatKind::Ident(_, ident, _) = local.pat.kind;
             if let ast::ExprKind::Path(_, ref path) = retexpr.kind;
             if match_path_ast(path, &[&*ident.name.as_str()]);
-            if !in_external_macro(cx.sess(), initexpr.span);
-            if !in_external_macro(cx.sess(), retexpr.span);
-            if !in_external_macro(cx.sess(), local.span);
+            if !in_external_macro(cx.sess(), initexpr.span.into());
+            if !in_external_macro(cx.sess(), retexpr.span.into());
+            if !in_external_macro(cx.sess(), local.span.into());
             if !in_macro(local.span);
             then {
                 span_lint_and_then(

--- a/src/tools/clippy/clippy_lints/src/shadow.rs
+++ b/src/tools/clippy/clippy_lints/src/shadow.rs
@@ -96,7 +96,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Shadow {
         _: Span,
         _: HirId,
     ) {
-        if in_external_macro(cx.sess(), body.value.span) {
+        if in_external_macro(cx.sess(), body.value.span.into()) {
             return;
         }
         check_fn(cx, decl, body);
@@ -129,7 +129,7 @@ fn check_block<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, block: &'tcx Block<'_>, bin
 }
 
 fn check_local<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, local: &'tcx Local<'_>, bindings: &mut Vec<(Name, Span)>) {
-    if in_external_macro(cx.sess(), local.span) {
+    if in_external_macro(cx.sess(), local.span.into()) {
         return;
     }
     if higher::is_from_for_desugar(local) {
@@ -317,7 +317,7 @@ fn lint_shadow<'a, 'tcx>(
 }
 
 fn check_expr<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, expr: &'tcx Expr<'_>, bindings: &mut Vec<(Name, Span)>) {
-    if in_external_macro(cx.sess(), expr.span) {
+    if in_external_macro(cx.sess(), expr.span.into()) {
         return;
     }
     match expr.kind {

--- a/src/tools/clippy/clippy_lints/src/strings.rs
+++ b/src/tools/clippy/clippy_lints/src/strings.rs
@@ -80,7 +80,7 @@ declare_lint_pass!(StringAdd => [STRING_ADD, STRING_ADD_ASSIGN]);
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for StringAdd {
     fn check_expr(&mut self, cx: &LateContext<'a, 'tcx>, e: &'tcx Expr<'_>) {
-        if in_external_macro(cx.sess(), e.span) {
+        if in_external_macro(cx.sess(), e.span.into()) {
             return;
         }
 

--- a/src/tools/clippy/clippy_lints/src/transmuting_null.rs
+++ b/src/tools/clippy/clippy_lints/src/transmuting_null.rs
@@ -31,7 +31,7 @@ const LINT_MSG: &str = "transmuting a known null pointer into a reference.";
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for TransmutingNull {
     fn check_expr(&mut self, cx: &LateContext<'a, 'tcx>, expr: &'tcx Expr<'_>) {
-        if in_external_macro(cx.sess(), expr.span) {
+        if in_external_macro(cx.sess(), expr.span.into()) {
             return;
         }
 

--- a/src/tools/clippy/clippy_lints/src/try_err.rs
+++ b/src/tools/clippy/clippy_lints/src/try_err.rs
@@ -55,7 +55,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for TryErr {
         //         val,
         // };
         if_chain! {
-            if !in_external_macro(cx.tcx.sess, expr.span);
+            if !in_external_macro(cx.tcx.sess, expr.span.into());
             if let ExprKind::Match(ref match_arg, _, MatchSource::TryDesugar) = expr.kind;
             if let ExprKind::Call(ref match_fun, ref try_args) = match_arg.kind;
             if let ExprKind::Path(ref match_fun_path) = match_fun.kind;

--- a/src/tools/clippy/clippy_lints/src/types.rs
+++ b/src/tools/clippy/clippy_lints/src/types.rs
@@ -604,7 +604,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for LetUnitValue {
     fn check_stmt(&mut self, cx: &LateContext<'a, 'tcx>, stmt: &'tcx Stmt<'_>) {
         if let StmtKind::Local(ref local) = stmt.kind {
             if is_unit(cx.tables.pat_ty(&local.pat)) {
-                if in_external_macro(cx.sess(), stmt.span) || local.pat.span.from_expansion() {
+                if in_external_macro(cx.sess(), stmt.span.into()) || local.pat.span.from_expansion() {
                     return;
                 }
                 if higher::is_from_for_desugar(local) {
@@ -1349,7 +1349,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Casts {
                 match lit.node {
                     LitKind::Int(_, LitIntType::Unsuffixed) | LitKind::Float(_, LitFloatType::Unsuffixed) => {},
                     _ => {
-                        if cast_from.kind == cast_to.kind && !in_external_macro(cx.sess(), expr.span) {
+                        if cast_from.kind == cast_to.kind && !in_external_macro(cx.sess(), expr.span.into()) {
                             span_lint(
                                 cx,
                                 UNNECESSARY_CAST,
@@ -1363,7 +1363,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Casts {
                     },
                 }
             }
-            if cast_from.is_numeric() && cast_to.is_numeric() && !in_external_macro(cx.sess(), expr.span) {
+            if cast_from.is_numeric() && cast_to.is_numeric() && !in_external_macro(cx.sess(), expr.span.into()) {
                 lint_numeric_casts(cx, expr, ex, cast_from, cast_to);
             }
 
@@ -2290,7 +2290,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for ImplicitHasher {
                     vis.visit_ty(ty);
 
                     for target in &vis.found {
-                        if in_external_macro(cx.sess(), generics.span) {
+                        if in_external_macro(cx.sess(), generics.span.into()) {
                             continue;
                         }
                         let generics_suggestion_span = generics.span.substitute_dummy({

--- a/src/tools/clippy/clippy_lints/src/unwrap.rs
+++ b/src/tools/clippy/clippy_lints/src/unwrap.rs
@@ -140,7 +140,7 @@ impl<'a, 'tcx> Visitor<'tcx> for UnwrappableVariablesVisitor<'a, 'tcx> {
 
     fn visit_expr(&mut self, expr: &'tcx Expr<'_>) {
         // Shouldn't lint when `expr` is in macro.
-        if in_external_macro(self.cx.tcx.sess, expr.span) {
+        if in_external_macro(self.cx.tcx.sess, expr.span.into()) {
             return;
         }
         if let Some((cond, then, els)) = if_block(&expr) {

--- a/src/tools/clippy/clippy_lints/src/use_self.rs
+++ b/src/tools/clippy/clippy_lints/src/use_self.rs
@@ -159,7 +159,7 @@ fn check_trait_method_impl_decl<'a, 'tcx>(
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UseSelf {
     fn check_item(&mut self, cx: &LateContext<'a, 'tcx>, item: &'tcx Item<'_>) {
-        if in_external_macro(cx.sess(), item.span) {
+        if in_external_macro(cx.sess(), item.span.into()) {
             return;
         }
         if_chain! {

--- a/src/tools/clippy/clippy_lints/src/utils/diagnostics.rs
+++ b/src/tools/clippy/clippy_lints/src/utils/diagnostics.rs
@@ -3,7 +3,7 @@
 use rustc_errors::{Applicability, CodeSuggestion, DiagnosticBuilder, Substitution, SubstitutionPart, SuggestionStyle};
 use rustc_hir::HirId;
 use rustc_lint::{LateContext, Lint, LintContext};
-use rustc_span::source_map::{MultiSpan, Span};
+use rustc_span::source_map::{MultiSpanId, Span};
 use std::env;
 
 fn docs_link(diag: &mut DiagnosticBuilder<'_>, lint: &'static Lint) {
@@ -36,7 +36,7 @@ fn docs_link(diag: &mut DiagnosticBuilder<'_>, lint: &'static Lint) {
 /// 17 |     std::mem::forget(seven);
 ///    |     ^^^^^^^^^^^^^^^^^^^^^^^
 /// ```
-pub fn span_lint<T: LintContext>(cx: &T, lint: &'static Lint, sp: impl Into<MultiSpan>, msg: &str) {
+pub fn span_lint<T: LintContext>(cx: &T, lint: &'static Lint, sp: impl Into<MultiSpanId>, msg: &str) {
     cx.struct_span_lint(lint, sp, |diag| {
         let mut diag = diag.build(msg);
         docs_link(&mut diag, lint);
@@ -206,7 +206,7 @@ where
         substitutions: vec![Substitution {
             parts: sugg
                 .into_iter()
-                .map(|(span, snippet)| SubstitutionPart { snippet, span })
+                .map(|(span, snippet)| SubstitutionPart { snippet, span: span.into() })
                 .collect(),
         }],
         msg: help_msg,

--- a/src/tools/clippy/clippy_lints/src/utils/mod.rs
+++ b/src/tools/clippy/clippy_lints/src/utils/mod.rs
@@ -45,7 +45,7 @@ use rustc_middle::ty::{self, layout::IntegerExt, subst::GenericArg, Binder, Ty, 
 use rustc_span::hygiene::{ExpnKind, MacroKind};
 use rustc_span::source_map::original_sp;
 use rustc_span::symbol::{self, kw, Symbol};
-use rustc_span::{BytePos, Pos, Span, DUMMY_SP};
+use rustc_span::{BytePos, Pos, Span, DUMMY_SP, DUMMY_SPID};
 use rustc_target::abi::Integer;
 use rustc_trait_selection::traits::predicate_for_trait_def;
 use rustc_trait_selection::traits::query::evaluate_obligation::InferCtxtExt;
@@ -914,7 +914,7 @@ pub fn type_is_unsafe_function<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, ty: Ty<'tcx
 }
 
 pub fn is_copy<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, ty: Ty<'tcx>) -> bool {
-    ty.is_copy_modulo_regions(cx.tcx, cx.param_env, DUMMY_SP)
+    ty.is_copy_modulo_regions(cx.tcx, cx.param_env, DUMMY_SPID)
 }
 
 /// Checks if an expression is constructing a tuple-like enum variant or struct

--- a/src/tools/clippy/src/driver.rs
+++ b/src/tools/clippy/src/driver.rs
@@ -258,7 +258,7 @@ fn report_clippy_ice(info: &panic::PanicInfo<'_>, bug_report_url: &str) {
     // it wants to print.
     if !info.payload().is::<rustc_errors::ExplicitBug>() {
         let d = rustc_errors::Diagnostic::new(rustc_errors::Level::Bug, "unexpected panic");
-        handler.emit_diagnostic(&d);
+        handler.emit_diagnostic(d);
     }
 
     let version_info = rustc_tools_util::get_version_info!();


### PR DESCRIPTION
This is another experiment for #47389. 

The idea is to avoid manipulating concrete spans when constructing diagnostics,
and replace those by abstract spans. The diagnostic emission (and re-emission in incr. compilation) are responsible for reifying the spans.

The goal is to remove dependency from diagnostics to spans.

This PR introduces a new `SpanId` type, which is used for diagnostics.
For now, it has 2 variants:
- a concrete `Span`;
- a `DefId`, and represents its `def_span`.
A `GuessHeadSpan` variant may be useful.

Most of the changes are the mechanical substitution `def_span -> real_def_span`.
The next step is to have the `SpanId` to bubble up and down,
and reduce the amount of back-and-forth.

Open questions:
- what operations should be allowed on `SpanId`?
- why do I get spurious spaces in some ui tests?
- should we be doing this at all?

Once I have more visibility on those questions, I will file a MCP.

r? @pnkfelix 
cc @estebank for diagnostics