### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -180,12 +180,15 @@ def format_build_time(duration):
 def default_build_triple():
     """Build triple as in LLVM"""
     default_encoding = sys.getdefaultencoding()
-    required = not sys.platform == 'win32'
-    ostype = require(["uname", "-s"], exit=required).decode(default_encoding)
-    cputype = require(['uname', '-m'], exit=required).decode(default_encoding)
+    required = sys.platform != 'win32'
+    ostype = require(["uname", "-s"], exit=required)
+    cputype = require(['uname', '-m'], exit=required)
 
     if ostype is None or cputype is None:
         return 'x86_64-pc-windows-msvc'
+
+    ostype = ostype.decode(default_encoding)
+    cputype = cputype.decode(default_encoding)
 
     # The goal here is to come up with the same triple as LLVM would,
     # at least for the subset of platforms we're willing to target.

--- a/src/librustc_incremental/lib.rs
+++ b/src/librustc_incremental/lib.rs
@@ -15,7 +15,7 @@ pub mod assert_module_sources;
 mod persist;
 
 pub use assert_dep_graph::assert_dep_graph;
-pub use persist::copy_cgu_workproducts_to_incr_comp_cache_dir;
+pub use persist::copy_cgu_workproduct_to_incr_comp_cache_dir;
 pub use persist::delete_workproduct_files;
 pub use persist::dep_graph_tcx_init;
 pub use persist::finalize_session_directory;

--- a/src/librustc_incremental/persist/load.rs
+++ b/src/librustc_incremental/persist/load.rs
@@ -134,7 +134,7 @@ pub fn load_dep_graph(sess: &Session) -> DepGraphFuture {
 
             for swp in work_products {
                 let mut all_files_exist = true;
-                for file_name in swp.work_product.saved_files.iter() {
+                if let Some(ref file_name) = swp.work_product.saved_file {
                     let path = in_incr_comp_dir_sess(sess, file_name);
                     if !path.exists() {
                         all_files_exist = false;

--- a/src/librustc_incremental/persist/mod.rs
+++ b/src/librustc_incremental/persist/mod.rs
@@ -21,5 +21,5 @@ pub use load::LoadResult;
 pub use load::{load_dep_graph, DepGraphFuture};
 pub use save::save_dep_graph;
 pub use save::save_work_product_index;
-pub use work_product::copy_cgu_workproducts_to_incr_comp_cache_dir;
+pub use work_product::copy_cgu_workproduct_to_incr_comp_cache_dir;
 pub use work_product::delete_workproduct_files;

--- a/src/librustc_incremental/persist/save.rs
+++ b/src/librustc_incremental/persist/save.rs
@@ -74,9 +74,9 @@ pub fn save_work_product_index(
         if !new_work_products.contains_key(id) {
             work_product::delete_workproduct_files(sess, wp);
             debug_assert!(
-                wp.saved_files
-                    .iter()
-                    .all(|file_name| { !in_incr_comp_dir_sess(sess, file_name).exists() })
+                wp.saved_file.as_ref().map_or(true, |file_name| {
+                    !in_incr_comp_dir_sess(sess, &file_name).exists()
+                })
             );
         }
     }
@@ -85,7 +85,7 @@ pub fn save_work_product_index(
     debug_assert!({
         new_work_products
             .iter()
-            .flat_map(|(_, wp)| wp.saved_files.iter())
+            .flat_map(|(_, wp)| wp.saved_file.iter())
             .map(|name| in_incr_comp_dir_sess(sess, name))
             .all(|path| path.exists())
     });

--- a/src/librustc_incremental/persist/work_product.rs
+++ b/src/librustc_incremental/persist/work_product.rs
@@ -7,43 +7,41 @@ use rustc_session::Session;
 use std::fs as std_fs;
 use std::path::PathBuf;
 
-pub fn copy_cgu_workproducts_to_incr_comp_cache_dir(
+pub fn copy_cgu_workproduct_to_incr_comp_cache_dir(
     sess: &Session,
     cgu_name: &str,
-    files: &[PathBuf],
+    path: &Option<PathBuf>,
 ) -> Option<(WorkProductId, WorkProduct)> {
-    debug!("copy_cgu_workproducts_to_incr_comp_cache_dir({:?},{:?})", cgu_name, files);
+    debug!("copy_cgu_workproduct_to_incr_comp_cache_dir({:?},{:?})", cgu_name, path);
     sess.opts.incremental.as_ref()?;
 
-    let saved_files = files
-        .iter()
-        .map(|path| {
-            let file_name = format!("{}.o", cgu_name);
-            let path_in_incr_dir = in_incr_comp_dir_sess(sess, &file_name);
-            match link_or_copy(path, &path_in_incr_dir) {
-                Ok(_) => Some(file_name),
-                Err(err) => {
-                    sess.warn(&format!(
-                        "error copying object file `{}` \
-                                             to incremental directory as `{}`: {}",
-                        path.display(),
-                        path_in_incr_dir.display(),
-                        err
-                    ));
-                    None
-                }
+    let saved_file = if let Some(path) = path {
+        let file_name = format!("{}.o", cgu_name);
+        let path_in_incr_dir = in_incr_comp_dir_sess(sess, &file_name);
+        match link_or_copy(path, &path_in_incr_dir) {
+            Ok(_) => Some(file_name),
+            Err(err) => {
+                sess.warn(&format!(
+                    "error copying object file `{}` to incremental directory as `{}`: {}",
+                    path.display(),
+                    path_in_incr_dir.display(),
+                    err
+                ));
+                return None;
             }
-        })
-        .collect::<Option<Vec<_>>>()?;
+        }
+    } else {
+        None
+    };
 
-    let work_product = WorkProduct { cgu_name: cgu_name.to_string(), saved_files };
+    let work_product = WorkProduct { cgu_name: cgu_name.to_string(), saved_file };
 
     let work_product_id = WorkProductId::from_cgu_name(cgu_name);
     Some((work_product_id, work_product))
 }
 
 pub fn delete_workproduct_files(sess: &Session, work_product: &WorkProduct) {
-    for file_name in &work_product.saved_files {
+    if let Some(ref file_name) = work_product.saved_file {
         let path = in_incr_comp_dir_sess(sess, file_name);
         match std_fs::remove_file(&path) {
             Ok(()) => {}

--- a/src/librustc_middle/mir/mono.rs
+++ b/src/librustc_middle/mir/mono.rs
@@ -239,6 +239,9 @@ pub struct CodegenUnit<'tcx> {
     size_estimate: Option<usize>,
 }
 
+/// Specifies the linkage type for a `MonoItem`.
+///
+/// See https://llvm.org/docs/LangRef.html#linkage-types for more details about these variants.
 #[derive(Copy, Clone, PartialEq, Debug, RustcEncodable, RustcDecodable, HashStable)]
 pub enum Linkage {
     External,

--- a/src/librustc_query_system/dep_graph/graph.rs
+++ b/src/librustc_query_system/dep_graph/graph.rs
@@ -860,8 +860,8 @@ impl<K: DepKind> DepGraph<K> {
 #[derive(Clone, Debug, RustcEncodable, RustcDecodable)]
 pub struct WorkProduct {
     pub cgu_name: String,
-    /// Saved files associated with this CGU.
-    pub saved_files: Vec<String>,
+    /// Saved file associated with this CGU.
+    pub saved_file: Option<String>,
 }
 
 #[derive(Clone)]

--- a/src/librustc_typeck/check/demand.rs
+++ b/src/librustc_typeck/check/demand.rs
@@ -614,24 +614,24 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         // For now, don't suggest casting with `as`.
         let can_cast = false;
 
-        let mut prefix = String::new();
-        if let Some(hir::Node::Expr(hir::Expr {
-            kind: hir::ExprKind::Struct(_, fields, _), ..
+        let prefix = if let Some(hir::Node::Expr(hir::Expr {
+            kind: hir::ExprKind::Struct(_, fields, _),
+            ..
         })) = self.tcx.hir().find(self.tcx.hir().get_parent_node(expr.hir_id))
         {
             // `expr` is a literal field for a struct, only suggest if appropriate
-            for field in *fields {
-                if field.expr.hir_id == expr.hir_id && field.is_shorthand {
-                    // This is a field literal
-                    prefix = format!("{}: ", field.ident);
-                    break;
-                }
-            }
-            if &prefix == "" {
+            match (*fields)
+                .iter()
+                .find(|field| field.expr.hir_id == expr.hir_id && field.is_shorthand)
+            {
+                // This is a field literal
+                Some(field) => format!("{}: ", field.ident),
                 // Likely a field was meant, but this field wasn't found. Do not suggest anything.
-                return false;
+                None => return false,
             }
-        }
+        } else {
+            String::new()
+        };
         if let hir::ExprKind::Call(path, args) = &expr.kind {
             if let (hir::ExprKind::Path(hir::QPath::TypeRelative(base_ty, path_segment)), 1) =
                 (&path.kind, args.len())
@@ -723,7 +723,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
             let suggest_to_change_suffix_or_into =
                 |err: &mut DiagnosticBuilder<'_>, is_fallible: bool| {
-                    let into_sugg = into_suggestion.clone();
                     err.span_suggestion(
                         expr.span,
                         if literal_is_ty_suffixed(expr) {
@@ -738,7 +737,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         } else if is_fallible {
                             try_into_suggestion
                         } else {
-                            into_sugg
+                            into_suggestion.clone()
                         },
                         Applicability::MachineApplicable,
                     );

--- a/src/test/mir-opt/byte_slice/rustc.main.SimplifyCfg-elaborate-drops.after.mir
+++ b/src/test/mir-opt/byte_slice/rustc.main.SimplifyCfg-elaborate-drops.after.mir
@@ -16,10 +16,10 @@ fn main() -> () {
         _1 = const b"foo";               // scope 0 at $DIR/byte_slice.rs:5:13: 5:19
                                          // ty::Const
                                          // + ty: &[u8; 3]
-                                         // + val: Value(Scalar(alloc0+0x0))
+                                         // + val: Value(Scalar(alloc0))
                                          // mir::Constant
                                          // + span: $DIR/byte_slice.rs:5:13: 5:19
-                                         // + literal: Const { ty: &[u8; 3], val: Value(Scalar(alloc0+0x0)) }
+                                         // + literal: Const { ty: &[u8; 3], val: Value(Scalar(alloc0)) }
         StorageLive(_2);                 // scope 1 at $DIR/byte_slice.rs:6:9: 6:10
         _2 = [const 5u8, const 120u8];   // scope 1 at $DIR/byte_slice.rs:6:13: 6:24
                                          // ty::Const

--- a/src/test/mir-opt/const-promotion-extern-static/rustc.BAR-promoted[0].ConstProp.after.mir
+++ b/src/test/mir-opt/const-promotion-extern-static/rustc.BAR-promoted[0].ConstProp.after.mir
@@ -7,13 +7,13 @@ promoted[0] in BAR: &[&i32; 1] = {
     let mut _3: &i32;                    // in scope 0 at $DIR/const-promotion-extern-static.rs:9:33: 9:34
 
     bb0: {
-        _3 = const {alloc0+0x0: &i32};   // scope 0 at $DIR/const-promotion-extern-static.rs:9:33: 9:34
+        _3 = const {alloc0: &i32};       // scope 0 at $DIR/const-promotion-extern-static.rs:9:33: 9:34
                                          // ty::Const
                                          // + ty: &i32
-                                         // + val: Value(Scalar(alloc0+0x0))
+                                         // + val: Value(Scalar(alloc0))
                                          // mir::Constant
                                          // + span: $DIR/const-promotion-extern-static.rs:9:33: 9:34
-                                         // + literal: Const { ty: &i32, val: Value(Scalar(alloc0+0x0)) }
+                                         // + literal: Const { ty: &i32, val: Value(Scalar(alloc0)) }
         _2 = _3;                         // scope 0 at $DIR/const-promotion-extern-static.rs:9:32: 9:34
         _1 = [move _2];                  // scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:35
         _0 = &_1;                        // scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:35

--- a/src/test/mir-opt/const-promotion-extern-static/rustc.BAR.PromoteTemps.diff
+++ b/src/test/mir-opt/const-promotion-extern-static/rustc.BAR.PromoteTemps.diff
@@ -16,16 +16,16 @@
 -         StorageLive(_3);                 // scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:35
 -         StorageLive(_4);                 // scope 0 at $DIR/const-promotion-extern-static.rs:9:32: 9:34
 -         StorageLive(_5);                 // scope 0 at $DIR/const-promotion-extern-static.rs:9:33: 9:34
--         _5 = const {alloc0+0x0: &i32};   // scope 0 at $DIR/const-promotion-extern-static.rs:9:33: 9:34
+-         _5 = const {alloc0: &i32};       // scope 0 at $DIR/const-promotion-extern-static.rs:9:33: 9:34
 +         _6 = const BAR::promoted[0];     // scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:35
                                            // ty::Const
 -                                          // + ty: &i32
--                                          // + val: Value(Scalar(alloc0+0x0))
+-                                          // + val: Value(Scalar(alloc0))
 +                                          // + ty: &[&i32; 1]
 +                                          // + val: Unevaluated(DefId(0:6 ~ const_promotion_extern_static[317d]::BAR[0]), [], Some(promoted[0]))
                                            // mir::Constant
 -                                          // + span: $DIR/const-promotion-extern-static.rs:9:33: 9:34
--                                          // + literal: Const { ty: &i32, val: Value(Scalar(alloc0+0x0)) }
+-                                          // + literal: Const { ty: &i32, val: Value(Scalar(alloc0)) }
 -         _4 = &(*_5);                     // scope 0 at $DIR/const-promotion-extern-static.rs:9:32: 9:34
 -         _3 = [move _4];                  // scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:35
 -         _2 = &_3;                        // scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:35

--- a/src/test/mir-opt/const-promotion-extern-static/rustc.FOO-promoted[0].ConstProp.after.mir
+++ b/src/test/mir-opt/const-promotion-extern-static/rustc.FOO-promoted[0].ConstProp.after.mir
@@ -9,13 +9,13 @@ promoted[0] in FOO: &[&i32; 1] = {
     }
 
     bb0: {
-        _3 = const {alloc2+0x0: &i32};   // scope 0 at $DIR/const-promotion-extern-static.rs:13:42: 13:43
+        _3 = const {alloc2: &i32};       // scope 0 at $DIR/const-promotion-extern-static.rs:13:42: 13:43
                                          // ty::Const
                                          // + ty: &i32
-                                         // + val: Value(Scalar(alloc2+0x0))
+                                         // + val: Value(Scalar(alloc2))
                                          // mir::Constant
                                          // + span: $DIR/const-promotion-extern-static.rs:13:42: 13:43
-                                         // + literal: Const { ty: &i32, val: Value(Scalar(alloc2+0x0)) }
+                                         // + literal: Const { ty: &i32, val: Value(Scalar(alloc2)) }
         _2 = _3;                         // scope 0 at $DIR/const-promotion-extern-static.rs:13:41: 13:43
         _1 = [move _2];                  // scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:46
         _0 = &_1;                        // scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:46

--- a/src/test/mir-opt/const-promotion-extern-static/rustc.FOO.PromoteTemps.diff
+++ b/src/test/mir-opt/const-promotion-extern-static/rustc.FOO.PromoteTemps.diff
@@ -18,16 +18,16 @@
 -         StorageLive(_3);                 // scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:46
 -         StorageLive(_4);                 // scope 0 at $DIR/const-promotion-extern-static.rs:13:32: 13:45
 -         StorageLive(_5);                 // scope 1 at $DIR/const-promotion-extern-static.rs:13:42: 13:43
--         _5 = const {alloc2+0x0: &i32};   // scope 1 at $DIR/const-promotion-extern-static.rs:13:42: 13:43
+-         _5 = const {alloc2: &i32};       // scope 1 at $DIR/const-promotion-extern-static.rs:13:42: 13:43
 +         _6 = const FOO::promoted[0];     // scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:46
                                            // ty::Const
 -                                          // + ty: &i32
--                                          // + val: Value(Scalar(alloc2+0x0))
+-                                          // + val: Value(Scalar(alloc2))
 +                                          // + ty: &[&i32; 1]
 +                                          // + val: Unevaluated(DefId(0:7 ~ const_promotion_extern_static[317d]::FOO[0]), [], Some(promoted[0]))
                                            // mir::Constant
 -                                          // + span: $DIR/const-promotion-extern-static.rs:13:42: 13:43
--                                          // + literal: Const { ty: &i32, val: Value(Scalar(alloc2+0x0)) }
+-                                          // + literal: Const { ty: &i32, val: Value(Scalar(alloc2)) }
 -         _4 = &(*_5);                     // scope 1 at $DIR/const-promotion-extern-static.rs:13:41: 13:43
 -         _3 = [move _4];                  // scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:46
 -         _2 = &_3;                        // scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:46

--- a/src/test/mir-opt/const_allocation/32bit/rustc.main.ConstProp.after.mir
+++ b/src/test/mir-opt/const_allocation/32bit/rustc.main.ConstProp.after.mir
@@ -8,13 +8,13 @@ fn main() -> () {
     bb0: {
         StorageLive(_1);                 // scope 0 at $DIR/const_allocation.rs:8:5: 8:8
         StorageLive(_2);                 // scope 0 at $DIR/const_allocation.rs:8:5: 8:8
-        _2 = const {alloc0+0x0: &&[(std::option::Option<i32>, &[&str])]}; // scope 0 at $DIR/const_allocation.rs:8:5: 8:8
+        _2 = const {alloc0: &&[(std::option::Option<i32>, &[&str])]}; // scope 0 at $DIR/const_allocation.rs:8:5: 8:8
                                          // ty::Const
                                          // + ty: &&[(std::option::Option<i32>, &[&str])]
-                                         // + val: Value(Scalar(alloc0+0x0))
+                                         // + val: Value(Scalar(alloc0))
                                          // mir::Constant
                                          // + span: $DIR/const_allocation.rs:8:5: 8:8
-                                         // + literal: Const { ty: &&[(std::option::Option<i32>, &[&str])], val: Value(Scalar(alloc0+0x0)) }
+                                         // + literal: Const { ty: &&[(std::option::Option<i32>, &[&str])], val: Value(Scalar(alloc0)) }
         _1 = (*_2);                      // scope 0 at $DIR/const_allocation.rs:8:5: 8:8
         StorageDead(_2);                 // scope 0 at $DIR/const_allocation.rs:8:8: 8:9
         StorageDead(_1);                 // scope 0 at $DIR/const_allocation.rs:8:8: 8:9
@@ -30,19 +30,19 @@ fn main() -> () {
 }
 
 alloc0 (static: FOO, size: 8, align: 4) {
-    ╾─a17+0x0─╼ 03 00 00 00                         │ ╾──╼....
+    ╾─alloc17─╼ 03 00 00 00                         │ ╾──╼....
 }
 
 alloc17 (size: 48, align: 4) {
-    0x00 │ 00 00 00 00 __ __ __ __ ╾─a4+0x0──╼ 00 00 00 00 │ ....░░░░╾──╼....
-    0x10 │ 00 00 00 00 __ __ __ __ ╾─a8+0x0──╼ 02 00 00 00 │ ....░░░░╾──╼....
-    0x20 │ 01 00 00 00 2a 00 00 00 ╾─a13+0x0─╼ 03 00 00 00 │ ....*...╾──╼....
+    0x00 │ 00 00 00 00 __ __ __ __ ╾─alloc4──╼ 00 00 00 00 │ ....░░░░╾──╼....
+    0x10 │ 00 00 00 00 __ __ __ __ ╾─alloc8──╼ 02 00 00 00 │ ....░░░░╾──╼....
+    0x20 │ 01 00 00 00 2a 00 00 00 ╾─alloc13─╼ 03 00 00 00 │ ....*...╾──╼....
 }
 
 alloc4 (size: 0, align: 4) {}
 
 alloc8 (size: 16, align: 4) {
-    ╾─a7+0x0──╼ 03 00 00 00 ╾─a9+0x0──╼ 03 00 00 00 │ ╾──╼....╾──╼....
+    ╾─alloc7──╼ 03 00 00 00 ╾─alloc9──╼ 03 00 00 00 │ ╾──╼....╾──╼....
 }
 
 alloc7 (size: 3, align: 1) {
@@ -54,8 +54,8 @@ alloc9 (size: 3, align: 1) {
 }
 
 alloc13 (size: 24, align: 4) {
-    0x00 │ ╾─a12+0x0─╼ 03 00 00 00 ╾─a14+0x0─╼ 03 00 00 00 │ ╾──╼....╾──╼....
-    0x10 │ ╾─a15+0x0─╼ 04 00 00 00                         │ ╾──╼....
+    0x00 │ ╾─alloc12─╼ 03 00 00 00 ╾─alloc14─╼ 03 00 00 00 │ ╾──╼....╾──╼....
+    0x10 │ ╾─alloc15─╼ 04 00 00 00                         │ ╾──╼....
 }
 
 alloc12 (size: 3, align: 1) {

--- a/src/test/mir-opt/const_allocation/64bit/rustc.main.ConstProp.after.mir
+++ b/src/test/mir-opt/const_allocation/64bit/rustc.main.ConstProp.after.mir
@@ -8,13 +8,13 @@ fn main() -> () {
     bb0: {
         StorageLive(_1);                 // scope 0 at $DIR/const_allocation.rs:8:5: 8:8
         StorageLive(_2);                 // scope 0 at $DIR/const_allocation.rs:8:5: 8:8
-        _2 = const {alloc0+0x0: &&[(std::option::Option<i32>, &[&str])]}; // scope 0 at $DIR/const_allocation.rs:8:5: 8:8
+        _2 = const {alloc0: &&[(std::option::Option<i32>, &[&str])]}; // scope 0 at $DIR/const_allocation.rs:8:5: 8:8
                                          // ty::Const
                                          // + ty: &&[(std::option::Option<i32>, &[&str])]
-                                         // + val: Value(Scalar(alloc0+0x0))
+                                         // + val: Value(Scalar(alloc0))
                                          // mir::Constant
                                          // + span: $DIR/const_allocation.rs:8:5: 8:8
-                                         // + literal: Const { ty: &&[(std::option::Option<i32>, &[&str])], val: Value(Scalar(alloc0+0x0)) }
+                                         // + literal: Const { ty: &&[(std::option::Option<i32>, &[&str])], val: Value(Scalar(alloc0)) }
         _1 = (*_2);                      // scope 0 at $DIR/const_allocation.rs:8:5: 8:8
         StorageDead(_2);                 // scope 0 at $DIR/const_allocation.rs:8:8: 8:9
         StorageDead(_1);                 // scope 0 at $DIR/const_allocation.rs:8:8: 8:9
@@ -30,22 +30,22 @@ fn main() -> () {
 }
 
 alloc0 (static: FOO, size: 16, align: 8) {
-    ╾─────alloc17+0x0─────╼ 03 00 00 00 00 00 00 00 │ ╾──────╼........
+    ╾───────alloc17───────╼ 03 00 00 00 00 00 00 00 │ ╾──────╼........
 }
 
 alloc17 (size: 72, align: 8) {
-    0x00 │ 00 00 00 00 __ __ __ __ ╾─────alloc4+0x0──────╼ │ ....░░░░╾──────╼
+    0x00 │ 00 00 00 00 __ __ __ __ ╾───────alloc4────────╼ │ ....░░░░╾──────╼
     0x10 │ 00 00 00 00 00 00 00 00 00 00 00 00 __ __ __ __ │ ............░░░░
-    0x20 │ ╾─────alloc8+0x0──────╼ 02 00 00 00 00 00 00 00 │ ╾──────╼........
-    0x30 │ 01 00 00 00 2a 00 00 00 ╾─────alloc13+0x0─────╼ │ ....*...╾──────╼
+    0x20 │ ╾───────alloc8────────╼ 02 00 00 00 00 00 00 00 │ ╾──────╼........
+    0x30 │ 01 00 00 00 2a 00 00 00 ╾───────alloc13───────╼ │ ....*...╾──────╼
     0x40 │ 03 00 00 00 00 00 00 00                         │ ........
 }
 
 alloc4 (size: 0, align: 8) {}
 
 alloc8 (size: 32, align: 8) {
-    0x00 │ ╾─────alloc7+0x0──────╼ 03 00 00 00 00 00 00 00 │ ╾──────╼........
-    0x10 │ ╾─────alloc9+0x0──────╼ 03 00 00 00 00 00 00 00 │ ╾──────╼........
+    0x00 │ ╾───────alloc7────────╼ 03 00 00 00 00 00 00 00 │ ╾──────╼........
+    0x10 │ ╾───────alloc9────────╼ 03 00 00 00 00 00 00 00 │ ╾──────╼........
 }
 
 alloc7 (size: 3, align: 1) {
@@ -57,9 +57,9 @@ alloc9 (size: 3, align: 1) {
 }
 
 alloc13 (size: 48, align: 8) {
-    0x00 │ ╾─────alloc12+0x0─────╼ 03 00 00 00 00 00 00 00 │ ╾──────╼........
-    0x10 │ ╾─────alloc14+0x0─────╼ 03 00 00 00 00 00 00 00 │ ╾──────╼........
-    0x20 │ ╾─────alloc15+0x0─────╼ 04 00 00 00 00 00 00 00 │ ╾──────╼........
+    0x00 │ ╾───────alloc12───────╼ 03 00 00 00 00 00 00 00 │ ╾──────╼........
+    0x10 │ ╾───────alloc14───────╼ 03 00 00 00 00 00 00 00 │ ╾──────╼........
+    0x20 │ ╾───────alloc15───────╼ 04 00 00 00 00 00 00 00 │ ╾──────╼........
 }
 
 alloc12 (size: 3, align: 1) {

--- a/src/test/mir-opt/const_allocation2/32bit/rustc.main.ConstProp.after.mir
+++ b/src/test/mir-opt/const_allocation2/32bit/rustc.main.ConstProp.after.mir
@@ -8,13 +8,13 @@ fn main() -> () {
     bb0: {
         StorageLive(_1);                 // scope 0 at $DIR/const_allocation2.rs:5:5: 5:8
         StorageLive(_2);                 // scope 0 at $DIR/const_allocation2.rs:5:5: 5:8
-        _2 = const {alloc0+0x0: &&[(std::option::Option<i32>, &[&u8])]}; // scope 0 at $DIR/const_allocation2.rs:5:5: 5:8
+        _2 = const {alloc0: &&[(std::option::Option<i32>, &[&u8])]}; // scope 0 at $DIR/const_allocation2.rs:5:5: 5:8
                                          // ty::Const
                                          // + ty: &&[(std::option::Option<i32>, &[&u8])]
-                                         // + val: Value(Scalar(alloc0+0x0))
+                                         // + val: Value(Scalar(alloc0))
                                          // mir::Constant
                                          // + span: $DIR/const_allocation2.rs:5:5: 5:8
-                                         // + literal: Const { ty: &&[(std::option::Option<i32>, &[&u8])], val: Value(Scalar(alloc0+0x0)) }
+                                         // + literal: Const { ty: &&[(std::option::Option<i32>, &[&u8])], val: Value(Scalar(alloc0)) }
         _1 = (*_2);                      // scope 0 at $DIR/const_allocation2.rs:5:5: 5:8
         StorageDead(_2);                 // scope 0 at $DIR/const_allocation2.rs:5:8: 5:9
         StorageDead(_1);                 // scope 0 at $DIR/const_allocation2.rs:5:8: 5:9
@@ -30,19 +30,19 @@ fn main() -> () {
 }
 
 alloc0 (static: FOO, size: 8, align: 4) {
-    ╾─a21+0x0─╼ 03 00 00 00                         │ ╾──╼....
+    ╾─alloc21─╼ 03 00 00 00                         │ ╾──╼....
 }
 
 alloc21 (size: 48, align: 4) {
-    0x00 │ 00 00 00 00 __ __ __ __ ╾─a4+0x0──╼ 00 00 00 00 │ ....░░░░╾──╼....
-    0x10 │ 00 00 00 00 __ __ __ __ ╾─a9+0x0──╼ 02 00 00 00 │ ....░░░░╾──╼....
-    0x20 │ 01 00 00 00 2a 00 00 00 ╾─a19+0x0─╼ 03 00 00 00 │ ....*...╾──╼....
+    0x00 │ 00 00 00 00 __ __ __ __ ╾─alloc4──╼ 00 00 00 00 │ ....░░░░╾──╼....
+    0x10 │ 00 00 00 00 __ __ __ __ ╾─alloc9──╼ 02 00 00 00 │ ....░░░░╾──╼....
+    0x20 │ 01 00 00 00 2a 00 00 00 ╾─alloc19─╼ 03 00 00 00 │ ....*...╾──╼....
 }
 
 alloc4 (size: 0, align: 4) {}
 
 alloc9 (size: 8, align: 4) {
-    ╾─a7+0x0──╼ ╾─a8+0x0──╼                         │ ╾──╼╾──╼
+    ╾─alloc7──╼ ╾─alloc8──╼                         │ ╾──╼╾──╼
 }
 
 alloc7 (size: 1, align: 1) {
@@ -54,7 +54,7 @@ alloc8 (size: 1, align: 1) {
 }
 
 alloc19 (size: 12, align: 4) {
-    ╾─a15+0x3─╼ ╾─a16+0x0─╼ ╾─a18+0x2─╼             │ ╾──╼╾──╼╾──╼
+    ╾─a15+0x3─╼ ╾─alloc16─╼ ╾─a18+0x2─╼             │ ╾──╼╾──╼╾──╼
 }
 
 alloc15 (size: 4, align: 1) {

--- a/src/test/mir-opt/const_allocation2/64bit/rustc.main.ConstProp.after.mir
+++ b/src/test/mir-opt/const_allocation2/64bit/rustc.main.ConstProp.after.mir
@@ -8,13 +8,13 @@ fn main() -> () {
     bb0: {
         StorageLive(_1);                 // scope 0 at $DIR/const_allocation2.rs:5:5: 5:8
         StorageLive(_2);                 // scope 0 at $DIR/const_allocation2.rs:5:5: 5:8
-        _2 = const {alloc0+0x0: &&[(std::option::Option<i32>, &[&u8])]}; // scope 0 at $DIR/const_allocation2.rs:5:5: 5:8
+        _2 = const {alloc0: &&[(std::option::Option<i32>, &[&u8])]}; // scope 0 at $DIR/const_allocation2.rs:5:5: 5:8
                                          // ty::Const
                                          // + ty: &&[(std::option::Option<i32>, &[&u8])]
-                                         // + val: Value(Scalar(alloc0+0x0))
+                                         // + val: Value(Scalar(alloc0))
                                          // mir::Constant
                                          // + span: $DIR/const_allocation2.rs:5:5: 5:8
-                                         // + literal: Const { ty: &&[(std::option::Option<i32>, &[&u8])], val: Value(Scalar(alloc0+0x0)) }
+                                         // + literal: Const { ty: &&[(std::option::Option<i32>, &[&u8])], val: Value(Scalar(alloc0)) }
         _1 = (*_2);                      // scope 0 at $DIR/const_allocation2.rs:5:5: 5:8
         StorageDead(_2);                 // scope 0 at $DIR/const_allocation2.rs:5:8: 5:9
         StorageDead(_1);                 // scope 0 at $DIR/const_allocation2.rs:5:8: 5:9
@@ -30,21 +30,21 @@ fn main() -> () {
 }
 
 alloc0 (static: FOO, size: 16, align: 8) {
-    ╾─────alloc21+0x0─────╼ 03 00 00 00 00 00 00 00 │ ╾──────╼........
+    ╾───────alloc21───────╼ 03 00 00 00 00 00 00 00 │ ╾──────╼........
 }
 
 alloc21 (size: 72, align: 8) {
-    0x00 │ 00 00 00 00 __ __ __ __ ╾─────alloc4+0x0──────╼ │ ....░░░░╾──────╼
+    0x00 │ 00 00 00 00 __ __ __ __ ╾───────alloc4────────╼ │ ....░░░░╾──────╼
     0x10 │ 00 00 00 00 00 00 00 00 00 00 00 00 __ __ __ __ │ ............░░░░
-    0x20 │ ╾─────alloc9+0x0──────╼ 02 00 00 00 00 00 00 00 │ ╾──────╼........
-    0x30 │ 01 00 00 00 2a 00 00 00 ╾─────alloc19+0x0─────╼ │ ....*...╾──────╼
+    0x20 │ ╾───────alloc9────────╼ 02 00 00 00 00 00 00 00 │ ╾──────╼........
+    0x30 │ 01 00 00 00 2a 00 00 00 ╾───────alloc19───────╼ │ ....*...╾──────╼
     0x40 │ 03 00 00 00 00 00 00 00                         │ ........
 }
 
 alloc4 (size: 0, align: 8) {}
 
 alloc9 (size: 16, align: 8) {
-    ╾─────alloc7+0x0──────╼ ╾─────alloc8+0x0──────╼ │ ╾──────╼╾──────╼
+    ╾───────alloc7────────╼ ╾───────alloc8────────╼ │ ╾──────╼╾──────╼
 }
 
 alloc7 (size: 1, align: 1) {
@@ -56,7 +56,7 @@ alloc8 (size: 1, align: 1) {
 }
 
 alloc19 (size: 24, align: 8) {
-    0x00 │ ╾─────alloc15+0x3─────╼ ╾─────alloc16+0x0─────╼ │ ╾──────╼╾──────╼
+    0x00 │ ╾─────alloc15+0x3─────╼ ╾───────alloc16───────╼ │ ╾──────╼╾──────╼
     0x10 │ ╾─────alloc18+0x2─────╼                         │ ╾──────╼
 }
 

--- a/src/test/mir-opt/const_allocation3/32bit/rustc.main.ConstProp.after.mir
+++ b/src/test/mir-opt/const_allocation3/32bit/rustc.main.ConstProp.after.mir
@@ -8,13 +8,13 @@ fn main() -> () {
     bb0: {
         StorageLive(_1);                 // scope 0 at $DIR/const_allocation3.rs:5:5: 5:8
         StorageLive(_2);                 // scope 0 at $DIR/const_allocation3.rs:5:5: 5:8
-        _2 = const {alloc0+0x0: &&Packed}; // scope 0 at $DIR/const_allocation3.rs:5:5: 5:8
+        _2 = const {alloc0: &&Packed};   // scope 0 at $DIR/const_allocation3.rs:5:5: 5:8
                                          // ty::Const
                                          // + ty: &&Packed
-                                         // + val: Value(Scalar(alloc0+0x0))
+                                         // + val: Value(Scalar(alloc0))
                                          // mir::Constant
                                          // + span: $DIR/const_allocation3.rs:5:5: 5:8
-                                         // + literal: Const { ty: &&Packed, val: Value(Scalar(alloc0+0x0)) }
+                                         // + literal: Const { ty: &&Packed, val: Value(Scalar(alloc0)) }
         _1 = (*_2);                      // scope 0 at $DIR/const_allocation3.rs:5:5: 5:8
         StorageDead(_2);                 // scope 0 at $DIR/const_allocation3.rs:5:8: 5:9
         StorageDead(_1);                 // scope 0 at $DIR/const_allocation3.rs:5:8: 5:9
@@ -30,19 +30,19 @@ fn main() -> () {
 }
 
 alloc0 (static: FOO, size: 4, align: 4) {
-    ╾─a9+0x0──╼                                     │ ╾──╼
+    ╾─alloc9──╼                                     │ ╾──╼
 }
 
 alloc9 (size: 168, align: 1) {
     0x00 │ ab ab ab ab ab ab ab ab ab ab ab ab ab ab ab ab │ ................
-    0x10 │ ab ab ab ab ab ab ab ab ab ab ab ab ╾─a4+0x0──╼ │ ............╾──╼
+    0x10 │ ab ab ab ab ab ab ab ab ab ab ab ab ╾─alloc4──╼ │ ............╾──╼
     0x20 │ 01 ef cd ab 00 00 00 00 00 00 00 00 00 00 00 00 │ ................
     0x30 │ 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 │ ................
     0x40 │ 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 │ ................
     0x50 │ 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 │ ................
     0x60 │ 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 │ ................
     0x70 │ 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 │ ................
-    0x80 │ 00 00 00 00 00 00 00 00 00 00 ╾─a6+0x0──╼ 00 00 │ ..........╾──╼..
+    0x80 │ 00 00 00 00 00 00 00 00 00 00 ╾─alloc6──╼ 00 00 │ ..........╾──╼..
     0x90 │ ╾─a7+0x63─╼ 00 00 00 00 00 00 00 00 00 00 00 00 │ ╾──╼............
     0xa0 │ 00 00 00 00 00 00 00 00                         │ ........
 }

--- a/src/test/mir-opt/const_allocation3/64bit/rustc.main.ConstProp.after.mir
+++ b/src/test/mir-opt/const_allocation3/64bit/rustc.main.ConstProp.after.mir
@@ -8,13 +8,13 @@ fn main() -> () {
     bb0: {
         StorageLive(_1);                 // scope 0 at $DIR/const_allocation3.rs:5:5: 5:8
         StorageLive(_2);                 // scope 0 at $DIR/const_allocation3.rs:5:5: 5:8
-        _2 = const {alloc0+0x0: &&Packed}; // scope 0 at $DIR/const_allocation3.rs:5:5: 5:8
+        _2 = const {alloc0: &&Packed};   // scope 0 at $DIR/const_allocation3.rs:5:5: 5:8
                                          // ty::Const
                                          // + ty: &&Packed
-                                         // + val: Value(Scalar(alloc0+0x0))
+                                         // + val: Value(Scalar(alloc0))
                                          // mir::Constant
                                          // + span: $DIR/const_allocation3.rs:5:5: 5:8
-                                         // + literal: Const { ty: &&Packed, val: Value(Scalar(alloc0+0x0)) }
+                                         // + literal: Const { ty: &&Packed, val: Value(Scalar(alloc0)) }
         _1 = (*_2);                      // scope 0 at $DIR/const_allocation3.rs:5:5: 5:8
         StorageDead(_2);                 // scope 0 at $DIR/const_allocation3.rs:5:8: 5:9
         StorageDead(_1);                 // scope 0 at $DIR/const_allocation3.rs:5:8: 5:9
@@ -30,12 +30,12 @@ fn main() -> () {
 }
 
 alloc0 (static: FOO, size: 8, align: 8) {
-    ╾─────alloc9+0x0──────╼                         │ ╾──────╼
+    ╾───────alloc9────────╼                         │ ╾──────╼
 }
 
 alloc9 (size: 180, align: 1) {
     0x00 │ ab ab ab ab ab ab ab ab ab ab ab ab ab ab ab ab │ ................
-    0x10 │ ab ab ab ab ab ab ab ab ab ab ab ab ╾alloc4+0x0 │ ............╾───
+    0x10 │ ab ab ab ab ab ab ab ab ab ab ab ab ╾──alloc4── │ ............╾───
     0x20 │ ──────────╼ 01 ef cd ab 00 00 00 00 00 00 00 00 │ ───╼............
     0x30 │ 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 │ ................
     0x40 │ 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 │ ................
@@ -43,7 +43,7 @@ alloc9 (size: 180, align: 1) {
     0x60 │ 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 │ ................
     0x70 │ 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 │ ................
     0x80 │ 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ╾──── │ ..............╾─
-    0x90 │ ───alloc6+0x0───╼ 00 00 ╾─────alloc7+0x63─────╼ │ ─────╼..╾──────╼
+    0x90 │ ─────alloc6─────╼ 00 00 ╾─────alloc7+0x63─────╼ │ ─────╼..╾──────╼
     0xa0 │ 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 │ ................
     0xb0 │ 00 00 00 00                                     │ ....
 }

--- a/src/test/mir-opt/const_prop/mutable_variable_no_prop/rustc.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/mutable_variable_no_prop/rustc.main.ConstProp.diff
@@ -29,13 +29,13 @@
           StorageLive(_2);                 // scope 1 at $DIR/mutable_variable_no_prop.rs:8:5: 10:6
           StorageLive(_3);                 // scope 2 at $DIR/mutable_variable_no_prop.rs:9:13: 9:19
           StorageLive(_4);                 // scope 2 at $DIR/mutable_variable_no_prop.rs:9:13: 9:19
-          _4 = const {alloc0+0x0: *mut u32}; // scope 2 at $DIR/mutable_variable_no_prop.rs:9:13: 9:19
+          _4 = const {alloc0: *mut u32};   // scope 2 at $DIR/mutable_variable_no_prop.rs:9:13: 9:19
                                            // ty::Const
                                            // + ty: *mut u32
-                                           // + val: Value(Scalar(alloc0+0x0))
+                                           // + val: Value(Scalar(alloc0))
                                            // mir::Constant
                                            // + span: $DIR/mutable_variable_no_prop.rs:9:13: 9:19
-                                           // + literal: Const { ty: *mut u32, val: Value(Scalar(alloc0+0x0)) }
+                                           // + literal: Const { ty: *mut u32, val: Value(Scalar(alloc0)) }
           _3 = (*_4);                      // scope 2 at $DIR/mutable_variable_no_prop.rs:9:13: 9:19
           _1 = move _3;                    // scope 2 at $DIR/mutable_variable_no_prop.rs:9:9: 9:19
           StorageDead(_3);                 // scope 2 at $DIR/mutable_variable_no_prop.rs:9:18: 9:19

--- a/src/test/mir-opt/const_prop/read_immutable_static/rustc.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/read_immutable_static/rustc.main.ConstProp.diff
@@ -16,13 +16,13 @@
           StorageLive(_1);                 // scope 0 at $DIR/read_immutable_static.rs:7:9: 7:10
           StorageLive(_2);                 // scope 0 at $DIR/read_immutable_static.rs:7:13: 7:16
           StorageLive(_3);                 // scope 0 at $DIR/read_immutable_static.rs:7:13: 7:16
-          _3 = const {alloc0+0x0: &u8};    // scope 0 at $DIR/read_immutable_static.rs:7:13: 7:16
+          _3 = const {alloc0: &u8};        // scope 0 at $DIR/read_immutable_static.rs:7:13: 7:16
                                            // ty::Const
                                            // + ty: &u8
-                                           // + val: Value(Scalar(alloc0+0x0))
+                                           // + val: Value(Scalar(alloc0))
                                            // mir::Constant
                                            // + span: $DIR/read_immutable_static.rs:7:13: 7:16
-                                           // + literal: Const { ty: &u8, val: Value(Scalar(alloc0+0x0)) }
+                                           // + literal: Const { ty: &u8, val: Value(Scalar(alloc0)) }
 -         _2 = (*_3);                      // scope 0 at $DIR/read_immutable_static.rs:7:13: 7:16
 +         _2 = const 2u8;                  // scope 0 at $DIR/read_immutable_static.rs:7:13: 7:16
 +                                          // ty::Const
@@ -33,13 +33,13 @@
 +                                          // + literal: Const { ty: u8, val: Value(Scalar(0x02)) }
           StorageLive(_4);                 // scope 0 at $DIR/read_immutable_static.rs:7:19: 7:22
           StorageLive(_5);                 // scope 0 at $DIR/read_immutable_static.rs:7:19: 7:22
-          _5 = const {alloc0+0x0: &u8};    // scope 0 at $DIR/read_immutable_static.rs:7:19: 7:22
+          _5 = const {alloc0: &u8};        // scope 0 at $DIR/read_immutable_static.rs:7:19: 7:22
                                            // ty::Const
                                            // + ty: &u8
-                                           // + val: Value(Scalar(alloc0+0x0))
+                                           // + val: Value(Scalar(alloc0))
                                            // mir::Constant
                                            // + span: $DIR/read_immutable_static.rs:7:19: 7:22
-                                           // + literal: Const { ty: &u8, val: Value(Scalar(alloc0+0x0)) }
+                                           // + literal: Const { ty: &u8, val: Value(Scalar(alloc0)) }
 -         _4 = (*_5);                      // scope 0 at $DIR/read_immutable_static.rs:7:19: 7:22
 -         _1 = Add(move _2, move _4);      // scope 0 at $DIR/read_immutable_static.rs:7:13: 7:22
 +         _4 = const 2u8;                  // scope 0 at $DIR/read_immutable_static.rs:7:19: 7:22

--- a/src/test/ui/consts/const-eval/const-pointer-values-in-various-types.stderr
+++ b/src/test/ui/consts/const-eval/const-pointer-values-in-various-types.stderr
@@ -2,7 +2,7 @@ error[E0080]: it is undefined behavior to use this value
   --> $DIR/const-pointer-values-in-various-types.rs:25:5
    |
 LL |     const I32_REF_USIZE_UNION: usize = unsafe { Nonsense { int_32_ref: &3 }.u };
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc2+0x0, but expected initialized plain (non-pointer) bytes
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc2, but expected initialized plain (non-pointer) bytes
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
@@ -36,7 +36,7 @@ error[E0080]: it is undefined behavior to use this value
   --> $DIR/const-pointer-values-in-various-types.rs:37:5
    |
 LL |     const I32_REF_U64_UNION: u64 = unsafe { Nonsense { int_32_ref: &3 }.uint_64 };
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc22+0x0, but expected initialized plain (non-pointer) bytes
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc22, but expected initialized plain (non-pointer) bytes
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
@@ -76,7 +76,7 @@ error[E0080]: it is undefined behavior to use this value
   --> $DIR/const-pointer-values-in-various-types.rs:52:5
    |
 LL |     const I32_REF_I64_UNION: i64 = unsafe { Nonsense { int_32_ref: &3 }.int_64 };
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc47+0x0, but expected initialized plain (non-pointer) bytes
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc47, but expected initialized plain (non-pointer) bytes
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
@@ -100,7 +100,7 @@ error[E0080]: it is undefined behavior to use this value
   --> $DIR/const-pointer-values-in-various-types.rs:61:5
    |
 LL |     const I32_REF_F64_UNION: f64 = unsafe { Nonsense { int_32_ref: &3 }.float_64 };
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc62+0x0, but expected initialized plain (non-pointer) bytes
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc62, but expected initialized plain (non-pointer) bytes
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
@@ -148,7 +148,7 @@ error[E0080]: it is undefined behavior to use this value
   --> $DIR/const-pointer-values-in-various-types.rs:79:5
    |
 LL |     const STR_U64_UNION: u64 = unsafe { Nonsense { stringy: "3" }.uint_64 };
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc86+0x0, but expected initialized plain (non-pointer) bytes
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc86, but expected initialized plain (non-pointer) bytes
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
@@ -188,7 +188,7 @@ error[E0080]: it is undefined behavior to use this value
   --> $DIR/const-pointer-values-in-various-types.rs:94:5
    |
 LL |     const STR_I64_UNION: i64 = unsafe { Nonsense { stringy: "3" }.int_64 };
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc101+0x0, but expected initialized plain (non-pointer) bytes
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc101, but expected initialized plain (non-pointer) bytes
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
@@ -212,7 +212,7 @@ error[E0080]: it is undefined behavior to use this value
   --> $DIR/const-pointer-values-in-various-types.rs:103:5
    |
 LL |     const STR_F64_UNION: f64 = unsafe { Nonsense { stringy: "3" }.float_64 };
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc110+0x0, but expected initialized plain (non-pointer) bytes
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc110, but expected initialized plain (non-pointer) bytes
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 

--- a/src/test/ui/consts/const-eval/ref_to_int_match.stderr
+++ b/src/test/ui/consts/const-eval/ref_to_int_match.stderr
@@ -2,7 +2,7 @@ error[E0080]: it is undefined behavior to use this value
   --> $DIR/ref_to_int_match.rs:25:1
    |
 LL | const BAR: Int = unsafe { Foo { r: &42 }.f };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc2+0x0, but expected initialized plain (non-pointer) bytes
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc2, but expected initialized plain (non-pointer) bytes
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 

--- a/src/test/ui/consts/const-eval/ub-enum.stderr
+++ b/src/test/ui/consts/const-eval/ub-enum.stderr
@@ -10,7 +10,7 @@ error[E0080]: it is undefined behavior to use this value
   --> $DIR/ub-enum.rs:27:1
    |
 LL | const BAD_ENUM_PTR: Enum = unsafe { mem::transmute(&1) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc8+0x0 at .<enum-tag>, but expected initialized plain (non-pointer) bytes
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc8 at .<enum-tag>, but expected initialized plain (non-pointer) bytes
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
@@ -18,7 +18,7 @@ error[E0080]: it is undefined behavior to use this value
   --> $DIR/ub-enum.rs:30:1
    |
 LL | const BAD_ENUM_WRAPPED: Wrap<Enum> = unsafe { mem::transmute(&1) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc13+0x0 at .0.<enum-tag>, but expected initialized plain (non-pointer) bytes
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc13 at .0.<enum-tag>, but expected initialized plain (non-pointer) bytes
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
@@ -34,7 +34,7 @@ error[E0080]: it is undefined behavior to use this value
   --> $DIR/ub-enum.rs:44:1
    |
 LL | const BAD_ENUM2_PTR: Enum2 = unsafe { mem::transmute(&0) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc20+0x0 at .<enum-tag>, but expected initialized plain (non-pointer) bytes
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc20 at .<enum-tag>, but expected initialized plain (non-pointer) bytes
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
@@ -42,7 +42,7 @@ error[E0080]: it is undefined behavior to use this value
   --> $DIR/ub-enum.rs:47:1
    |
 LL | const BAD_ENUM2_WRAPPED: Wrap<Enum2> = unsafe { mem::transmute(&0) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc25+0x0 at .0.<enum-tag>, but expected initialized plain (non-pointer) bytes
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc25 at .0.<enum-tag>, but expected initialized plain (non-pointer) bytes
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
@@ -58,7 +58,7 @@ error[E0080]: it is undefined behavior to use this value
   --> $DIR/ub-enum.rs:60:1
    |
 LL | const BAD_ENUM2_OPTION_PTR: Option<Enum2> = unsafe { mem::transmute(&0) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc32+0x0 at .<enum-tag>, but expected initialized plain (non-pointer) bytes
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc32 at .<enum-tag>, but expected initialized plain (non-pointer) bytes
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 

--- a/src/test/ui/consts/const-eval/ub-ref.stderr
+++ b/src/test/ui/consts/const-eval/ub-ref.stderr
@@ -34,7 +34,7 @@ error[E0080]: it is undefined behavior to use this value
   --> $DIR/ub-ref.rs:24:1
    |
 LL | const REF_AS_USIZE: usize = unsafe { mem::transmute(&0) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc16+0x0, but expected initialized plain (non-pointer) bytes
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc16, but expected initialized plain (non-pointer) bytes
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 

--- a/src/test/ui/lint/issue-71290-unused-paren-binop.rs
+++ b/src/test/ui/lint/issue-71290-unused-paren-binop.rs
@@ -1,0 +1,17 @@
+// check-pass
+// Make sure unused parens lint doesn't emit a false positive.
+// See https://github.com/rust-lang/rust/issues/71290 for details.
+
+fn x() -> u8 {
+    ({ 0 }) + 1
+}
+
+fn y() -> u8 {
+    ({ 0 } + 1)
+}
+
+pub fn foo(a: bool, b: bool) -> u8 {
+    (if a { 1 } else { 0 } + if b { 1 } else { 0 })
+}
+
+fn main() {}

--- a/src/test/ui/lint/issue-71290-unused-paren-binop.rs
+++ b/src/test/ui/lint/issue-71290-unused-paren-binop.rs
@@ -1,6 +1,7 @@
 // check-pass
 // Make sure unused parens lint doesn't emit a false positive.
 // See https://github.com/rust-lang/rust/issues/71290 for details.
+#![deny(unused_parens)]
 
 fn x() -> u8 {
     ({ 0 }) + 1

--- a/src/test/ui/lint/issue-71290-unused-paren-binop.rs
+++ b/src/test/ui/lint/issue-71290-unused-paren-binop.rs
@@ -15,4 +15,9 @@ pub fn foo(a: bool, b: bool) -> u8 {
     (if a { 1 } else { 0 } + if b { 1 } else { 0 })
 }
 
+pub fn bar() -> u8 {
+    // Make sure nested expressions are handled correctly as well
+    ({ 0 } + 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9)
+}
+
 fn main() {}


### PR DESCRIPTION
Successful merges:

 - #71525 (`prefix` should not be mutable.)
 - #71741 (Pointer printing: do not print 0 offset)
 - #71910 (Fix unused_parens false positive when using binary operations)
 - #71964 (Fix bootstrap failing on win32)
 - #72126 (Change `WorkProduct::saved_files` to an `Option`.)
 - #72138 (Add doc comment for `rustc_middle::mir::mono::Linkage`)

Failed merges:


r? @ghost