### PR TITLE
Make Iterator::unzip fast

### DIFF
--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -125,6 +125,7 @@
 #![feature(alloc_layout_extra)]
 #![feature(try_trait)]
 #![feature(associated_type_bounds)]
+#![feature(extend_with_capacity)]
 
 // Allow testing this library
 

--- a/src/libcore/iter/traits/collect.rs
+++ b/src/libcore/iter/traits/collect.rs
@@ -341,6 +341,12 @@ pub trait Extend<A> {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     fn extend<T: IntoIterator<Item = A>>(&mut self, iter: T);
+
+    /// Creates this collection with a reserved capacity.
+    #[unstable(feature = "extend_with_capacity", issue = "none")]
+    fn with_capacity(_capacity: usize) -> Self where Self: Default {
+        Self::default()
+    }
 }
 
 #[stable(feature = "extend_for_unit", since = "1.28.0")]

--- a/src/libcore/iter/traits/iterator.rs
+++ b/src/libcore/iter/traits/iterator.rs
@@ -2672,8 +2672,9 @@ pub trait Iterator {
             }
         }
 
-        let mut ts: FromA = Default::default();
-        let mut us: FromB = Default::default();
+        let cap = self.size_hint().0.saturating_add(1);
+        let mut ts: FromA = Extend::with_capacity(cap);
+        let mut us: FromB = Extend::with_capacity(cap);
 
         self.for_each(extend(&mut ts, &mut us));
 


### PR DESCRIPTION
Closes #72085

This consists of the following optimizations:

* Adds a `with_capacity` function to `Extend`. This definitely needs more thought if it's going to be stabilized, so I'm not writing an RFC yet. This takes off most of the performance gap.
* Optimizes `Vec`'s `Extend` implementation for the case where `size_hint` is 1. This shaves off the remaining performance gap.

Here's a fancy graph of the improvement:
![image](https://user-images.githubusercontent.com/8355305/81761149-36e26280-9497-11ea-8e03-ca3bd25a906d.png)
