### PR TITLE
Add setgroups to std::os::unix::process::CommandExt

### DIFF
--- a/library/std/src/sys/unix/ext/process.rs
+++ b/library/std/src/sys/unix/ext/process.rs
@@ -39,6 +39,15 @@ pub trait CommandExt {
         #[cfg(target_os = "vxworks")] id: u16,
     ) -> &mut process::Command;
 
+    /// Sets the supplementary group IDs for the calling process. Translates to
+    /// a `setgroups` call in the child process.
+    #[unstable(feature = "setgroups", issue = "38527", reason = "")]
+    fn groups(
+        &mut self,
+        #[cfg(not(target_os = "vxworks"))] groups: &[u32],
+        #[cfg(target_os = "vxworks")] groups: &[u16],
+    ) -> &mut process::Command;
+
     /// Schedules a closure to be run just before the `exec` function is
     /// invoked.
     ///
@@ -146,6 +155,15 @@ impl CommandExt for process::Command {
         #[cfg(target_os = "vxworks")] id: u16,
     ) -> &mut process::Command {
         self.as_inner_mut().gid(id);
+        self
+    }
+
+    fn groups(
+        &mut self,
+        #[cfg(not(target_os = "vxworks"))] groups: &[u32],
+        #[cfg(target_os = "vxworks")] groups: &[u16],
+    ) -> &mut process::Command {
+        self.as_inner_mut().groups(groups);
         self
     }
 

--- a/library/std/src/sys/unix/process/process_common.rs
+++ b/library/std/src/sys/unix/process/process_common.rs
@@ -87,6 +87,7 @@ pub struct Command {
     gid: Option<gid_t>,
     saw_nul: bool,
     closures: Vec<Box<dyn FnMut() -> io::Result<()> + Send + Sync>>,
+    groups: Option<Box<[gid_t]>>,
     stdin: Option<Stdio>,
     stdout: Option<Stdio>,
     stderr: Option<Stdio>,
@@ -148,6 +149,7 @@ impl Command {
             gid: None,
             saw_nul,
             closures: Vec::new(),
+            groups: None,
             stdin: None,
             stdout: None,
             stderr: None,
@@ -182,6 +184,9 @@ impl Command {
     }
     pub fn gid(&mut self, id: gid_t) {
         self.gid = Some(id);
+    }
+    pub fn groups(&mut self, groups: &[gid_t]) {
+        self.groups = Some(Box::from(groups));
     }
 
     pub fn saw_nul(&self) -> bool {
@@ -225,6 +230,10 @@ impl Command {
     #[allow(dead_code)]
     pub fn get_gid(&self) -> Option<gid_t> {
         self.gid
+    }
+    #[allow(dead_code)]
+    pub fn get_groups(&self) -> Option<&[gid_t]> {
+        self.groups.as_deref()
     }
 
     pub fn get_closures(&mut self) -> &mut Vec<Box<dyn FnMut() -> io::Result<()> + Send + Sync>> {

--- a/src/test/ui/command/command-setgroups.rs
+++ b/src/test/ui/command/command-setgroups.rs
@@ -1,0 +1,19 @@
+// run-pass
+// ignore-cloudabi
+// ignore-emscripten
+// ignore-sgx
+
+#![feature(rustc_private)]
+#![feature(setgroups)]
+
+extern crate libc;
+use std::process::Command;
+use std::os::unix::process::CommandExt;
+
+fn main() {
+    let max_ngroups = unsafe { libc::sysconf(libc::_SC_NGROUPS_MAX) };
+    let max_ngroups = max_ngroups as u32 + 1;
+    let vec: Vec<u32> = (0..max_ngroups).collect();
+    let p = Command::new("/bin/id").groups(&vec[..]).spawn();
+    assert!(p.is_err());
+}

--- a/src/test/ui/command/command-setgroups.rs
+++ b/src/test/ui/command/command-setgroups.rs
@@ -1,4 +1,5 @@
 // run-pass
+// ignore-windows - this is a unix-specific test
 // ignore-cloudabi
 // ignore-emscripten
 // ignore-sgx

--- a/src/test/ui/command/command-setgroups.rs
+++ b/src/test/ui/command/command-setgroups.rs
@@ -11,6 +11,12 @@ use std::process::Command;
 use std::os::unix::process::CommandExt;
 
 fn main() {
+    #[cfg(unix)]
+    run()
+}
+
+#[cfg(unix)]
+fn run() {
     let max_ngroups = unsafe { libc::sysconf(libc::_SC_NGROUPS_MAX) };
     let max_ngroups = max_ngroups as u32 + 1;
     let vec: Vec<u32> = (0..max_ngroups).collect();


### PR DESCRIPTION
Should fix #38527. I'm not sure groups is the greatest name though.