### PR TITLE
Aggressively check for non-`PartialEq` types in `const_to_pat`

### DIFF
--- a/src/test/ui/consts/const_in_pattern/issue-65466.rs
+++ b/src/test/ui/consts/const_in_pattern/issue-65466.rs
@@ -1,6 +1,4 @@
-// FIXME: This still ICEs.
-//
-// ignore-test
+// This used to ICE in #65466.
 
 #![deny(indirect_structural_match)]
 
@@ -18,6 +16,7 @@ fn main() {
     let x = O::None;
     match &[x][..] {
         C => (),
+        //~^ must implement `PartialEq`
         _ => (),
     }
 }

--- a/src/test/ui/consts/const_in_pattern/issue-65466.stderr
+++ b/src/test/ui/consts/const_in_pattern/issue-65466.stderr
@@ -1,15 +1,8 @@
-error[E0601]: `main` function not found in crate `issue_65466`
-  --> $DIR/issue-65466.rs:1:1
+error: `&[O<B>]` must implement `PartialEq` to be used in a pattern
+  --> $DIR/issue-65466.rs:18:9
    |
-LL | / #![deny(indirect_structural_match)]
-LL | |
-LL | | #[derive(PartialEq, Eq)]
-LL | | enum O<T> {
-...  |
-LL | |     }
-LL | | }
-   | |_^ consider adding a `main` function to `$DIR/issue-65466.rs`
+LL |         C => (),
+   |         ^
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0601`.

--- a/src/test/ui/consts/const_in_pattern/reject_non_partial_eq.rs
+++ b/src/test/ui/consts/const_in_pattern/reject_non_partial_eq.rs
@@ -26,7 +26,7 @@ fn main() {
 
     match None {
         NO_PARTIAL_EQ_NONE => println!("NO_PARTIAL_EQ_NONE"),
-        //~^ ERROR must be annotated with `#[derive(PartialEq, Eq)]`
+        //~^ ERROR must implement `PartialEq`
         _ => panic!("whoops"),
     }
 }

--- a/src/test/ui/consts/const_in_pattern/reject_non_partial_eq.stderr
+++ b/src/test/ui/consts/const_in_pattern/reject_non_partial_eq.stderr
@@ -1,4 +1,4 @@
-error: to use a constant of type `NoPartialEq` in a pattern, `NoPartialEq` must be annotated with `#[derive(PartialEq, Eq)]`
+error: `std::option::Option<NoPartialEq>` must implement `PartialEq` to be used in a pattern
   --> $DIR/reject_non_partial_eq.rs:28:9
    |
 LL |         NO_PARTIAL_EQ_NONE => println!("NO_PARTIAL_EQ_NONE"),

--- a/src/test/ui/match/issue-70972-dyn-trait.rs
+++ b/src/test/ui/match/issue-70972-dyn-trait.rs
@@ -4,7 +4,7 @@ fn main() {
     let a: &dyn Send = &7u32;
     match a {
         F => panic!(),
-        //~^ ERROR trait objects cannot be used in patterns
+        //~^ ERROR must implement `PartialEq`
         _ => {}
     }
 }

--- a/src/test/ui/match/issue-70972-dyn-trait.stderr
+++ b/src/test/ui/match/issue-70972-dyn-trait.stderr
@@ -1,4 +1,4 @@
-error: trait objects cannot be used in patterns
+error: `&dyn std::marker::Send` must implement `PartialEq` to be used in a pattern
   --> $DIR/issue-70972-dyn-trait.rs:6:9
    |
 LL |         F => panic!(),

--- a/src/test/ui/rfc1445/issue-61188-match-slice-forbidden-without-eq.rs
+++ b/src/test/ui/rfc1445/issue-61188-match-slice-forbidden-without-eq.rs
@@ -13,7 +13,7 @@ const A: &[B] = &[];
 pub fn main() {
     match &[][..] {
         A => (),
-        //~^ ERROR must be annotated with `#[derive(PartialEq, Eq)]`
+        //~^ ERROR must implement `PartialEq`
         _ => (),
     }
 }

--- a/src/test/ui/rfc1445/issue-61188-match-slice-forbidden-without-eq.stderr
+++ b/src/test/ui/rfc1445/issue-61188-match-slice-forbidden-without-eq.stderr
@@ -1,4 +1,4 @@
-error: to use a constant of type `B` in a pattern, `B` must be annotated with `#[derive(PartialEq, Eq)]`
+error: `&[B]` must implement `PartialEq` to be used in a pattern
   --> $DIR/issue-61188-match-slice-forbidden-without-eq.rs:15:9
    |
 LL |         A => (),


### PR DESCRIPTION
Resolves #65466.

Previously, we allowed constants without structural match violations through to codegen even if they did not satisfy `PartialEq`. This was because higher-ranked types such as `for<'r> fn(&'r i32)` needed to be allowed in patterns, despite the fact that they cannot be proven to be `PartialEq`. I think this is due to a limitation in the trait solver?

This PR falls back to a terrible hack–replacing all late-bound regions with concrete ones–after initially failing to prove `PartialEq`. This succeeds for higher-ranked types that would implement `PartialEq` with some unconstrained set of concrete lifetimes, such as the aforementioned function pointer. Now we can reject types that don't satisfy `PartialEq` without breaking backwards compatibility for function pointers. This prevents some ICEs during codegen.

cc rust-lang/rfcs#1445

r? @pnkfelix (diff -w recommended)