### PR TITLE
Improve performance of `std::fs::write` by preallocating the file on disk

### DIFF
--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -343,7 +343,9 @@ pub fn read_to_string<P: AsRef<Path>>(path: P) -> io::Result<String> {
 #[stable(feature = "fs_read_write_bytes", since = "1.26.0")]
 pub fn write<P: AsRef<Path>, C: AsRef<[u8]>>(path: P, contents: C) -> io::Result<()> {
     fn inner(path: &Path, contents: &[u8]) -> io::Result<()> {
-        File::create(path)?.write_all(contents)
+        let mut file = File::create(path)?;
+        file.set_len(contents.len() as u64)?;
+        file.write_all(contents)
     }
     inner(path.as_ref(), contents.as_ref())
 }

--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -344,7 +344,7 @@ pub fn read_to_string<P: AsRef<Path>>(path: P) -> io::Result<String> {
 pub fn write<P: AsRef<Path>, C: AsRef<[u8]>>(path: P, contents: C) -> io::Result<()> {
     fn inner(path: &Path, contents: &[u8]) -> io::Result<()> {
         let mut file = File::create(path)?;
-        file.set_len(contents.len() as u64)?;
+        let _ = file.set_len(contents.len() as u64);
         file.write_all(contents)
     }
     inner(path.as_ref(), contents.as_ref())


### PR DESCRIPTION
Currently, `fs::write` takes in a `contents: &[u8]` and writes it to a new file with the given `path`, using `write_all`.

However, since we already know the length of the file we are about to write (that is, `contents.len()`), it may make sense to preallocate that file on disk using `File::set_len()`. On my system, this improves performance significantly.

Note that `fs::read` also preallocates a byte vector using file metadata when reading:

```rust
Vec::with_capacity(initial_buffer_size(&file))
```