### PR TITLE
Don't pass --dynamic-linker for Fuchsia dylibs

### DIFF
--- a/src/librustc_codegen_ssa/back/link.rs
+++ b/src/librustc_codegen_ssa/back/link.rs
@@ -1422,7 +1422,7 @@ fn linker_with_args<'a, B: ArchiveBuilder<'a>>(
     add_pre_link_args(cmd, sess, flavor, crate_type);
 
     // NO-OPT-OUT, OBJECT-FILES-NO, AUDIT-ORDER
-    if sess.target.target.options.is_like_fuchsia {
+    if sess.target.target.options.is_like_fuchsia && crate_type == CrateType::Executable {
         let prefix = match sess.opts.debugging_opts.sanitizer {
             Some(Sanitizer::Address) => "asan/",
             _ => "",


### PR DESCRIPTION
This was causing a PT_INTERP header in Fuchsia dylibs (implying that
they're executable when they're not).

r? @Mark-Simulacrum 
cc @frobtech @petrhosek 