### PR TITLE
Minor fixes to comments

### DIFF
--- a/src/librustc_ast_passes/node_count.rs
+++ b/src/librustc_ast_passes/node_count.rs
@@ -1,4 +1,4 @@
-// Simply gives a rought count of the number of nodes in an AST.
+// Simply gives a rough count of the number of nodes in an AST.
 
 use rustc_ast::ast::*;
 use rustc_ast::visit::*;

--- a/src/librustc_middle/middle/region.rs
+++ b/src/librustc_middle/middle/region.rs
@@ -4,7 +4,7 @@
 //! For more information about how MIR-based region-checking works,
 //! see the [rustc dev guide].
 //!
-//! [rustc dev guide]: https://rustc-dev-guide.rust-lang.org/mir/borrowck.html
+//! [rustc dev guide]: https://rustc-dev-guide.rust-lang.org/borrow_check.html
 
 use crate::ich::{NodeIdHashingMode, StableHashingContext};
 use crate::ty::{self, DefIdTree, TyCtxt};
@@ -181,7 +181,7 @@ impl Scope {
                 // `blk`; reuse span of `blk` and shift `lo`
                 // forward to end of indexed statement.
                 //
-                // (This is the special case aluded to in the
+                // (This is the special case alluded to in the
                 // doc-comment for this method)
 
                 let stmt_span = blk.stmts[first_statement_index.index()].span;


### PR DESCRIPTION
* In 'src/librustc_ast_passes/node_count.rs'
  * typo fix ('rought' -> 'rough')
* In 'src/librustc_middle/middle/region.rs',
  * fixed broken link to 'rustc-dev-guide'
  * typo fix ('aluded' -> 'alluded')

Thank you for reviewing this PR :)