### PR TITLE
[const-prop] Don't replace Rvalues that are already constants

### DIFF
--- a/src/librustc_mir/transform/const_prop.rs
+++ b/src/librustc_mir/transform/const_prop.rs
@@ -616,6 +616,13 @@ impl<'mir, 'tcx> ConstPropagator<'mir, 'tcx> {
         value: OpTy<'tcx>,
         source_info: SourceInfo,
     ) {
+        if let Rvalue::Use(Operand::Constant(c)) = rval {
+            if !matches!(c.literal.val, ConstKind::Unevaluated(..)) {
+                trace!("skipping replace of Rvalue::Use({:?} because it is already a const", c);
+                return;
+            }
+        }
+
         trace!("attepting to replace {:?} with {:?}", rval, value);
         if let Err(e) = self.ecx.const_validate_operand(
             value,

--- a/src/test/mir-opt/const_prop/mutable_variable/rustc.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/mutable_variable/rustc.main.ConstProp.diff
@@ -26,8 +26,7 @@
                                            // + ty: i32
                                            // + val: Value(Scalar(0x00000063))
                                            // mir::Constant
--                                          // + span: $DIR/mutable_variable.rs:6:9: 6:11
-+                                          // + span: $DIR/mutable_variable.rs:6:5: 6:11
+                                           // + span: $DIR/mutable_variable.rs:6:9: 6:11
                                            // + literal: Const { ty: i32, val: Value(Scalar(0x00000063)) }
           StorageLive(_2);                 // scope 1 at $DIR/mutable_variable.rs:7:9: 7:10
 -         _2 = _1;                         // scope 1 at $DIR/mutable_variable.rs:7:13: 7:14

--- a/src/test/mir-opt/const_prop/mutable_variable_aggregate/rustc.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/mutable_variable_aggregate/rustc.main.ConstProp.diff
@@ -34,8 +34,7 @@
                                            // + ty: i32
                                            // + val: Value(Scalar(0x00000063))
                                            // mir::Constant
--                                          // + span: $DIR/mutable_variable_aggregate.rs:6:11: 6:13
-+                                          // + span: $DIR/mutable_variable_aggregate.rs:6:5: 6:13
+                                           // + span: $DIR/mutable_variable_aggregate.rs:6:11: 6:13
                                            // + literal: Const { ty: i32, val: Value(Scalar(0x00000063)) }
           StorageLive(_2);                 // scope 1 at $DIR/mutable_variable_aggregate.rs:7:9: 7:10
 -         _2 = _1;                         // scope 1 at $DIR/mutable_variable_aggregate.rs:7:13: 7:14

--- a/src/test/mir-opt/copy_propagation_arg/rustc.arg_src.CopyPropagation.diff
+++ b/src/test/mir-opt/copy_propagation_arg/rustc.arg_src.CopyPropagation.diff
@@ -17,7 +17,7 @@
                                            // + ty: i32
                                            // + val: Value(Scalar(0x0000007b))
                                            // mir::Constant
-                                           // + span: $DIR/copy_propagation_arg.rs:29:5: 29:12
+                                           // + span: $DIR/copy_propagation_arg.rs:29:9: 29:12
                                            // + literal: Const { ty: i32, val: Value(Scalar(0x0000007b)) }
           _0 = _2;                         // scope 1 at $DIR/copy_propagation_arg.rs:30:5: 30:6
           StorageDead(_2);                 // scope 0 at $DIR/copy_propagation_arg.rs:31:1: 31:2

--- a/src/test/mir-opt/copy_propagation_arg/rustc.bar.CopyPropagation.diff
+++ b/src/test/mir-opt/copy_propagation_arg/rustc.bar.CopyPropagation.diff
@@ -28,7 +28,7 @@
                                            // + ty: u8
                                            // + val: Value(Scalar(0x05))
                                            // mir::Constant
-                                           // + span: $DIR/copy_propagation_arg.rs:17:5: 17:10
+                                           // + span: $DIR/copy_propagation_arg.rs:17:9: 17:10
                                            // + literal: Const { ty: u8, val: Value(Scalar(0x05)) }
           _0 = const ();                   // scope 0 at $DIR/copy_propagation_arg.rs:15:19: 18:2
                                            // ty::Const


### PR DESCRIPTION
This cleans up a few mir-opt tests which have slight changes to spans for `consts` as a result of replacing them with new Rvalues. 