### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -1448,8 +1448,8 @@ any high-order bits of `rhs` that would cause the shift to exceed the bitwidth o
 
 Note that this is *not* the same as a rotate-left; the RHS of a wrapping shift-left is restricted to
 the range of the type, rather than the bits shifted out of the LHS being returned to the other end.
-The primitive integer types all implement a `rotate_left` function, which may be what you want
-instead.
+The primitive integer types all implement a `[`rotate_left`](#method.rotate_left) function,
+which may be what you want instead.
 
 # Examples
 
@@ -1480,8 +1480,8 @@ removes any high-order bits of `rhs` that would cause the shift to exceed the bi
 
 Note that this is *not* the same as a rotate-right; the RHS of a wrapping shift-right is restricted
 to the range of the type, rather than the bits shifted out of the LHS being returned to the other
-end. The primitive integer types all implement a `rotate_right` function, which may be what you want
-instead.
+end. The primitive integer types all implement a [`rotate_right`](#method.rotate_right) function,
+which may be what you want instead.
 
 # Examples
 
@@ -3508,8 +3508,8 @@ Note that this is *not* the same as a rotate-left; the
 RHS of a wrapping shift-left is restricted to the range
 of the type, rather than the bits shifted out of the LHS
 being returned to the other end. The primitive integer
-types all implement a `rotate_left` function, which may
-be what you want instead.
+types all implement a [`rotate_left`](#method.rotate_left) function,
+which may be what you want instead.
 
 # Examples
 
@@ -3542,8 +3542,8 @@ Note that this is *not* the same as a rotate-right; the
 RHS of a wrapping shift-right is restricted to the range
 of the type, rather than the bits shifted out of the LHS
 being returned to the other end. The primitive integer
-types all implement a `rotate_right` function, which may
-be what you want instead.
+types all implement a [`rotate_right`](#method.rotate_right) function,
+which may be what you want instead.
 
 # Examples
 

--- a/src/libcore/ops/try.rs
+++ b/src/libcore/ops/try.rs
@@ -25,7 +25,6 @@
     )
 )]
 #[doc(alias = "?")]
-#[cfg_attr(not(bootstrap), lang = "try_trait")]
 pub trait Try {
     /// The type of this value when viewed as successful.
     #[unstable(feature = "try_trait", issue = "42327")]

--- a/src/libcore/ops/try.rs
+++ b/src/libcore/ops/try.rs
@@ -25,7 +25,7 @@
     )
 )]
 #[doc(alias = "?")]
- #[cfg_attr(not(bootstrap), lang = "try_trait")]
+#[cfg_attr(not(bootstrap), lang = "try_trait")]
 pub trait Try {
     /// The type of this value when viewed as successful.
     #[unstable(feature = "try_trait", issue = "42327")]

--- a/src/libcore/ops/try.rs
+++ b/src/libcore/ops/try.rs
@@ -25,6 +25,7 @@
     )
 )]
 #[doc(alias = "?")]
+ #[cfg_attr(not(bootstrap), lang = "try_trait")]
 pub trait Try {
     /// The type of this value when viewed as successful.
     #[unstable(feature = "try_trait", issue = "42327")]

--- a/src/librustc_hir/lang_items.rs
+++ b/src/librustc_hir/lang_items.rs
@@ -194,6 +194,7 @@ language_item_table! {
     ShrAssignTraitLangItem,      "shr_assign",         shr_assign_trait,        Target::Trait;
     IndexTraitLangItem,          "index",              index_trait,             Target::Trait;
     IndexMutTraitLangItem,       "index_mut",          index_mut_trait,         Target::Trait;
+
     UnsafeCellTypeLangItem,      "unsafe_cell",        unsafe_cell_type,        Target::Struct;
     VaListTypeLangItem,          "va_list",            va_list,                 Target::Struct;
 

--- a/src/librustc_hir/lang_items.rs
+++ b/src/librustc_hir/lang_items.rs
@@ -194,6 +194,7 @@ language_item_table! {
     ShrAssignTraitLangItem,      "shr_assign",         shr_assign_trait,        Target::Trait;
     IndexTraitLangItem,          "index",              index_trait,             Target::Trait;
     IndexMutTraitLangItem,       "index_mut",          index_mut_trait,         Target::Trait;
+    TryTraitLangItem,            "try_trait",                try_trait,               Target::Trait;
 
     UnsafeCellTypeLangItem,      "unsafe_cell",        unsafe_cell_type,        Target::Struct;
     VaListTypeLangItem,          "va_list",            va_list,                 Target::Struct;

--- a/src/librustc_hir/lang_items.rs
+++ b/src/librustc_hir/lang_items.rs
@@ -194,8 +194,6 @@ language_item_table! {
     ShrAssignTraitLangItem,      "shr_assign",         shr_assign_trait,        Target::Trait;
     IndexTraitLangItem,          "index",              index_trait,             Target::Trait;
     IndexMutTraitLangItem,       "index_mut",          index_mut_trait,         Target::Trait;
-    TryTraitLangItem,            "try_trait",                try_trait,               Target::Trait;
-
     UnsafeCellTypeLangItem,      "unsafe_cell",        unsafe_cell_type,        Target::Struct;
     VaListTypeLangItem,          "va_list",            va_list,                 Target::Struct;
 

--- a/src/librustc_middle/hir/map/mod.rs
+++ b/src/librustc_middle/hir/map/mod.rs
@@ -390,7 +390,7 @@ impl<'hir> Map<'hir> {
     /// Given a `HirId`, returns the `BodyId` associated with it,
     /// if the node is a body owner, otherwise returns `None`.
     pub fn maybe_body_owned_by(&self, hir_id: HirId) -> Option<BodyId> {
-        if let Some(node) = self.find(hir_id) { associated_body(node) } else { None }
+        self.find(hir_id).map(associated_body).flatten()
     }
 
     /// Given a body owner's id, returns the `BodyId` associated with it.

--- a/src/librustc_middle/hir/map/mod.rs
+++ b/src/librustc_middle/hir/map/mod.rs
@@ -390,11 +390,7 @@ impl<'hir> Map<'hir> {
     /// Given a `HirId`, returns the `BodyId` associated with it,
     /// if the node is a body owner, otherwise returns `None`.
     pub fn maybe_body_owned_by(&self, hir_id: HirId) -> Option<BodyId> {
-        if let Some(node) = self.find(hir_id) {
-            associated_body(node)
-        } else {
-            bug!("no entry for id `{}`", hir_id)
-        }
+        if let Some(node) = self.find(hir_id) { associated_body(node) } else { None }
     }
 
     /// Given a body owner's id, returns the `BodyId` associated with it.

--- a/src/librustc_middle/query/mod.rs
+++ b/src/librustc_middle/query/mod.rs
@@ -1164,6 +1164,12 @@ rustc_queries! {
             desc { "evaluating trait selection obligation `{}`", goal.value }
         }
 
+        query type_implements_trait(
+            key: (DefId, Ty<'tcx>, SubstsRef<'tcx>, ty::ParamEnv<'tcx>, )
+        ) -> bool {
+            desc { "evaluating `type_implements_trait` `{:?}`", key }
+        }
+
         /// Do not call this query directly: part of the `Eq` type-op
         query type_op_ascribe_user_type(
             goal: CanonicalTypeOpAscribeUserTypeGoal<'tcx>

--- a/src/librustc_middle/ty/query/keys.rs
+++ b/src/librustc_middle/ty/query/keys.rs
@@ -295,3 +295,15 @@ impl Key for (Symbol, u32, u32) {
         DUMMY_SP
     }
 }
+
+impl<'tcx> Key for (DefId, Ty<'tcx>, SubstsRef<'tcx>, ty::ParamEnv<'tcx>) {
+    type CacheSelector = DefaultCacheSelector;
+
+    fn query_crate(&self) -> CrateNum {
+        LOCAL_CRATE
+    }
+
+    fn default_span(&self, _tcx: TyCtxt<'_>) -> Span {
+        DUMMY_SP
+    }
+}

--- a/src/librustc_mir/monomorphize/mod.rs
+++ b/src/librustc_mir/monomorphize/mod.rs
@@ -2,6 +2,8 @@ use rustc_middle::traits;
 use rustc_middle::ty::adjustment::CustomCoerceUnsized;
 use rustc_middle::ty::{self, Ty, TyCtxt};
 
+use rustc_hir::lang_items::CoerceUnsizedTraitLangItem;
+
 pub mod collector;
 pub mod partitioning;
 
@@ -10,7 +12,7 @@ pub fn custom_coerce_unsize_info<'tcx>(
     source_ty: Ty<'tcx>,
     target_ty: Ty<'tcx>,
 ) -> CustomCoerceUnsized {
-    let def_id = tcx.lang_items().coerce_unsized_trait().unwrap();
+    let def_id = tcx.require_lang_item(CoerceUnsizedTraitLangItem, None);
 
     let trait_ref = ty::Binder::bind(ty::TraitRef {
         def_id,

--- a/src/librustc_mir/transform/const_prop.rs
+++ b/src/librustc_mir/transform/const_prop.rs
@@ -616,6 +616,13 @@ impl<'mir, 'tcx> ConstPropagator<'mir, 'tcx> {
         value: OpTy<'tcx>,
         source_info: SourceInfo,
     ) {
+        if let Rvalue::Use(Operand::Constant(c)) = rval {
+            if !matches!(c.literal.val, ConstKind::Unevaluated(..)) {
+                trace!("skipping replace of Rvalue::Use({:?} because it is already a const", c);
+                return;
+            }
+        }
+
         trace!("attepting to replace {:?} with {:?}", rval, value);
         if let Err(e) = self.ecx.const_validate_operand(
             value,

--- a/src/librustc_mir_build/hair/pattern/const_to_pat.rs
+++ b/src/librustc_mir_build/hair/pattern/const_to_pat.rs
@@ -141,7 +141,8 @@ impl<'a, 'tcx> ConstToPat<'a, 'tcx> {
                 // code at the moment, because types like `for <'a> fn(&'a ())` do
                 // not *yet* implement `PartialEq`. So for now we leave this here.
                 let ty_is_partial_eq: bool = {
-                    let partial_eq_trait_id = self.tcx().require_lang_item(EqTraitLangItem, None);
+                    let partial_eq_trait_id =
+                        self.tcx().require_lang_item(EqTraitLangItem, Some(self.span));
                     let obligation: PredicateObligation<'_> = predicate_for_trait_def(
                         self.tcx(),
                         self.param_env,

--- a/src/librustc_trait_selection/traits/error_reporting/mod.rs
+++ b/src/librustc_trait_selection/traits/error_reporting/mod.rs
@@ -400,6 +400,17 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                         self.suggest_remove_reference(&obligation, &mut err, &trait_ref);
                         self.suggest_semicolon_removal(&obligation, &mut err, span, &trait_ref);
                         self.note_version_mismatch(&mut err, &trait_ref);
+                        //self.sugggest_await_before_try(&mut err, &obligation, &trait_ref);
+                        debug!(
+                            "suggest_await_befor_try: trait_predicate={:?} obligation={:?}, trait_ref={:?}",
+                            trait_predicate, obligation, trait_ref
+                        );
+                        self.suggest_await_befor_try(
+                            &mut err,
+                            &obligation,
+                            trait_ref.self_ty(),
+                            span,
+                        );
                         if self.suggest_impl_trait(&mut err, span, &obligation, &trait_ref) {
                             err.emit();
                             return;

--- a/src/librustc_trait_selection/traits/error_reporting/mod.rs
+++ b/src/librustc_trait_selection/traits/error_reporting/mod.rs
@@ -400,17 +400,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                         self.suggest_remove_reference(&obligation, &mut err, &trait_ref);
                         self.suggest_semicolon_removal(&obligation, &mut err, span, &trait_ref);
                         self.note_version_mismatch(&mut err, &trait_ref);
-                        //self.sugggest_await_before_try(&mut err, &obligation, &trait_ref);
-                        debug!(
-                            "suggest_await_befor_try: trait_predicate={:?} obligation={:?}, trait_ref={:?}",
-                            trait_predicate, obligation, trait_ref
-                        );
-                        self.suggest_await_befor_try(
-                            &mut err,
-                            &obligation,
-                            trait_ref.self_ty(),
-                            span,
-                        );
+                        self.suggest_await_before_try(&mut err, &obligation, &trait_ref, span);
                         if self.suggest_impl_trait(&mut err, span, &obligation, &trait_ref) {
                             err.emit();
                             return;

--- a/src/librustc_trait_selection/traits/structural_match.rs
+++ b/src/librustc_trait_selection/traits/structural_match.rs
@@ -4,6 +4,7 @@ use crate::traits::{self, ConstPatternStructural, TraitEngine};
 
 use rustc_data_structures::fx::FxHashSet;
 use rustc_hir as hir;
+use rustc_hir::lang_items::{StructuralPeqTraitLangItem, StructuralTeqTraitLangItem};
 use rustc_middle::ty::{self, AdtDef, Ty, TyCtxt, TypeFoldable, TypeVisitor};
 use rustc_span::Span;
 
@@ -69,7 +70,7 @@ pub fn type_marked_structural(
     let mut fulfillment_cx = traits::FulfillmentContext::new();
     let cause = ObligationCause::new(span, id, ConstPatternStructural);
     // require `#[derive(PartialEq)]`
-    let structural_peq_def_id = infcx.tcx.lang_items().structural_peq_trait().unwrap();
+    let structural_peq_def_id = infcx.tcx.require_lang_item(StructuralPeqTraitLangItem, Some(span));
     fulfillment_cx.register_bound(
         infcx,
         ty::ParamEnv::empty(),
@@ -80,7 +81,7 @@ pub fn type_marked_structural(
     // for now, require `#[derive(Eq)]`. (Doing so is a hack to work around
     // the type `for<'a> fn(&'a ())` failing to implement `Eq` itself.)
     let cause = ObligationCause::new(span, id, ConstPatternStructural);
-    let structural_teq_def_id = infcx.tcx.lang_items().structural_teq_trait().unwrap();
+    let structural_teq_def_id = infcx.tcx.require_lang_item(StructuralTeqTraitLangItem, Some(span));
     fulfillment_cx.register_bound(
         infcx,
         ty::ParamEnv::empty(),

--- a/src/librustc_typeck/check/closure.rs
+++ b/src/librustc_typeck/check/closure.rs
@@ -6,7 +6,7 @@ use crate::astconv::AstConv;
 use crate::middle::region;
 use rustc_hir as hir;
 use rustc_hir::def_id::DefId;
-use rustc_hir::lang_items;
+use rustc_hir::lang_items::{FutureTraitLangItem, GeneratorTraitLangItem};
 use rustc_infer::infer::type_variable::{TypeVariableOrigin, TypeVariableOriginKind};
 use rustc_infer::infer::LateBoundRegionConversionTime;
 use rustc_infer::infer::{InferOk, InferResult};
@@ -245,7 +245,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let trait_ref = projection.to_poly_trait_ref(tcx);
 
         let is_fn = tcx.fn_trait_kind_from_lang_item(trait_ref.def_id()).is_some();
-        let gen_trait = tcx.require_lang_item(lang_items::GeneratorTraitLangItem, cause_span);
+        let gen_trait = tcx.require_lang_item(GeneratorTraitLangItem, cause_span);
         let is_gen = gen_trait == trait_ref.def_id();
         if !is_fn && !is_gen {
             debug!("deduce_sig_from_projection: not fn or generator");
@@ -678,7 +678,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         // Check that this is a projection from the `Future` trait.
         let trait_ref = predicate.projection_ty.trait_ref(self.tcx);
-        let future_trait = self.tcx.lang_items().future_trait().unwrap();
+        let future_trait = self.tcx.require_lang_item(FutureTraitLangItem, Some(cause_span));
         if trait_ref.def_id != future_trait {
             debug!("deduce_future_output_from_projection: not a future");
             return None;

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -100,7 +100,9 @@ use rustc_hir::def::{CtorOf, DefKind, Res};
 use rustc_hir::def_id::{CrateNum, DefId, DefIdMap, DefIdSet, LocalDefId, LOCAL_CRATE};
 use rustc_hir::intravisit::{self, NestedVisitorMap, Visitor};
 use rustc_hir::itemlikevisit::ItemLikeVisitor;
-use rustc_hir::lang_items;
+use rustc_hir::lang_items::{
+    FutureTraitLangItem, PinTypeLangItem, SizedTraitLangItem, VaListTypeLangItem,
+};
 use rustc_hir::{ExprKind, GenericArg, HirIdMap, Item, ItemKind, Node, PatKind, QPath};
 use rustc_index::bit_set::BitSet;
 use rustc_index::vec::Idx;
@@ -1342,10 +1344,8 @@ fn check_fn<'a, 'tcx>(
     // C-variadic fns also have a `VaList` input that's not listed in `fn_sig`
     // (as it's created inside the body itself, not passed in from outside).
     let maybe_va_list = if fn_sig.c_variadic {
-        let va_list_did = tcx.require_lang_item(
-            lang_items::VaListTypeLangItem,
-            Some(body.params.last().unwrap().span),
-        );
+        let va_list_did =
+            tcx.require_lang_item(VaListTypeLangItem, Some(body.params.last().unwrap().span));
         let region = tcx.mk_region(ty::ReScope(region::Scope {
             id: body.value.hir_id.local_id,
             data: region::ScopeData::CallSite,
@@ -3303,7 +3303,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         code: traits::ObligationCauseCode<'tcx>,
     ) {
         if !ty.references_error() {
-            let lang_item = self.tcx.require_lang_item(lang_items::SizedTraitLangItem, None);
+            let lang_item = self.tcx.require_lang_item(SizedTraitLangItem, None);
             self.require_type_meets(ty, span, code, lang_item);
         }
     }
@@ -5142,7 +5142,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             _ => {}
         }
         let boxed_found = self.tcx.mk_box(found);
-        let new_found = self.tcx.mk_lang_item(boxed_found, lang_items::PinTypeLangItem).unwrap();
+        let new_found = self.tcx.mk_lang_item(boxed_found, PinTypeLangItem).unwrap();
         if let (true, Ok(snippet)) = (
             self.can_coerce(new_found, expected),
             self.sess().source_map().span_to_snippet(expr.span),
@@ -5298,7 +5298,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 let sp = expr.span;
                 // Check for `Future` implementations by constructing a predicate to
                 // prove: `<T as Future>::Output == U`
-                let future_trait = self.tcx.lang_items().future_trait().unwrap();
+                let future_trait = self.tcx.require_lang_item(FutureTraitLangItem, Some(sp));
                 let item_def_id = self
                     .tcx
                     .associated_items(future_trait)

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -5317,22 +5317,23 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     item_def_id,
                 };
 
+                let cause = traits::ObligationCause::misc(sp, self.body_id);
+                let normalized_ty = self.fulfillment_cx.borrow_mut().normalize_projection_type(
+                    &self.infcx,
+                    self.param_env,
+                    projection_ty,
+                    cause,
+                );
+                debug!("suggest_missing_await: projection_type {:?}", normalized_ty);
+
                 let predicate =
                     ty::Predicate::Projection(ty::Binder::bind(ty::ProjectionPredicate {
                         projection_ty,
                         ty: expected,
                     }));
                 let obligation = traits::Obligation::new(self.misc(sp), self.param_env, predicate);
-                debug!("suggest_missing_await: trying obligation {:?}", obligation);
 
-                //let try_trait_def_id = self.tcx.require_lang_item(lang_items::TryTraitLangItem, None);
-                //let try_trait_ref = ty::TraitRef {
-                //    def_id: try_trait_def_id,
-                //    substs: self.tcx.mk_substs_trait(self.tcx.type_of(item_def_id), &[]),
-                //};
-                //let try_obligation = traits::Obligation::new(self.misc(sp), self.param_env, try_trait_ref.without_const().to_predicate());
-                //let try_trait_is_implemented = self.predicate_must_hold_modulo_regions(&try_obligation);
-                //debug!("suggest_missing_await: try trait is implemented {}", try_trait_is_implemented);
+                debug!("suggest_missing_await: trying obligation {:?}", obligation);
 
                 if self.infcx.predicate_may_hold(&obligation) {
                     debug!("suggest_missing_await: obligation held: {:?}", obligation);

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -5317,15 +5317,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     item_def_id,
                 };
 
-                let cause = traits::ObligationCause::misc(sp, self.body_id);
-                let normalized_ty = self.fulfillment_cx.borrow_mut().normalize_projection_type(
-                    &self.infcx,
-                    self.param_env,
-                    projection_ty,
-                    cause,
-                );
-                debug!("suggest_missing_await: projection_type {:?}", normalized_ty);
-
                 let predicate =
                     ty::Predicate::Projection(ty::Binder::bind(ty::ProjectionPredicate {
                         projection_ty,

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -5289,6 +5289,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         expected: Ty<'tcx>,
         found: Ty<'tcx>,
     ) {
+        debug!("suggest_missing_await: expr={:?} expected={:?}, found={:?}", expr, expected, found);
         // `.await` is not permitted outside of `async` bodies, so don't bother to suggest if the
         // body isn't `async`.
         let item_id = self.tcx().hir().get_parent_node(self.body_id);
@@ -5306,22 +5307,33 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     .next()
                     .unwrap()
                     .def_id;
+                // `<T as Future>::Output`
+                let projection_ty = ty::ProjectionTy {
+                    // `T`
+                    substs: self
+                        .tcx
+                        .mk_substs_trait(found, self.fresh_substs_for_item(sp, item_def_id)),
+                    // `Future::Output`
+                    item_def_id,
+                };
+
                 let predicate =
                     ty::Predicate::Projection(ty::Binder::bind(ty::ProjectionPredicate {
-                        // `<T as Future>::Output`
-                        projection_ty: ty::ProjectionTy {
-                            // `T`
-                            substs: self.tcx.mk_substs_trait(
-                                found,
-                                self.fresh_substs_for_item(sp, item_def_id),
-                            ),
-                            // `Future::Output`
-                            item_def_id,
-                        },
+                        projection_ty,
                         ty: expected,
                     }));
                 let obligation = traits::Obligation::new(self.misc(sp), self.param_env, predicate);
                 debug!("suggest_missing_await: trying obligation {:?}", obligation);
+
+                //let try_trait_def_id = self.tcx.require_lang_item(lang_items::TryTraitLangItem, None);
+                //let try_trait_ref = ty::TraitRef {
+                //    def_id: try_trait_def_id,
+                //    substs: self.tcx.mk_substs_trait(self.tcx.type_of(item_def_id), &[]),
+                //};
+                //let try_obligation = traits::Obligation::new(self.misc(sp), self.param_env, try_trait_ref.without_const().to_predicate());
+                //let try_trait_is_implemented = self.predicate_must_hold_modulo_regions(&try_obligation);
+                //debug!("suggest_missing_await: try trait is implemented {}", try_trait_is_implemented);
+
                 if self.infcx.predicate_may_hold(&obligation) {
                     debug!("suggest_missing_await: obligation held: {:?}", obligation);
                     if let Ok(code) = self.sess().source_map().span_to_snippet(sp) {

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -643,6 +643,15 @@ impl Attributes {
             })
             .collect()
     }
+
+    pub fn get_doc_aliases(&self) -> FxHashSet<String> {
+        self.other_attrs
+            .lists(sym::doc)
+            .filter(|a| a.check_name(sym::alias))
+            .filter_map(|a| a.value_str().map(|s| s.to_string().replace("\"", "")))
+            .filter(|v| !v.is_empty())
+            .collect::<FxHashSet<_>>()
+    }
 }
 
 impl PartialEq for Attributes {

--- a/src/librustdoc/html/layout.rs
+++ b/src/librustdoc/html/layout.rs
@@ -114,7 +114,6 @@ pub fn render<T: Print, S: Print>(
         window.rootPath = \"{root_path}\";\
         window.currentCrate = \"{krate}\";\
     </script>\
-    <script src=\"{root_path}aliases{suffix}.js\"></script>\
     <script src=\"{static_root_path}main{suffix}.js\"></script>\
     {static_extra_scripts}\
     {extra_scripts}\

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -825,42 +825,6 @@ themePicker.onblur = handleThemeButtonsBlur;
         Ok((ret, krates))
     }
 
-    fn show_item(item: &IndexItem, krate: &str) -> String {
-        format!(
-            "{{'crate':'{}','ty':{},'name':'{}','desc':'{}','p':'{}'{}}}",
-            krate,
-            item.ty as usize,
-            item.name,
-            item.desc.replace("'", "\\'"),
-            item.path,
-            if let Some(p) = item.parent_idx { format!(",'parent':{}", p) } else { String::new() }
-        )
-    }
-
-    let dst = cx.dst.join(&format!("aliases{}.js", cx.shared.resource_suffix));
-    {
-        let (mut all_aliases, _) = try_err!(collect(&dst, &krate.name, "ALIASES"), &dst);
-        let mut output = String::with_capacity(100);
-        for (alias, items) in cx.cache.get_aliases() {
-            if items.is_empty() {
-                continue;
-            }
-            output.push_str(&format!(
-                "\"{}\":[{}],",
-                alias,
-                items.iter().map(|v| show_item(v, &krate.name)).collect::<Vec<_>>().join(",")
-            ));
-        }
-        all_aliases.push(format!("ALIASES[\"{}\"] = {{{}}};", krate.name, output));
-        all_aliases.sort();
-        let mut v = Buffer::html();
-        writeln!(&mut v, "var ALIASES = {{}};");
-        for aliases in &all_aliases {
-            writeln!(&mut v, "{}", aliases);
-        }
-        cx.shared.fs.write(&dst, v.into_inner().into_bytes())?;
-    }
-
     use std::ffi::OsString;
 
     #[derive(Debug)]

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -278,7 +278,7 @@ pub struct RenderInfo {
 /// Struct representing one entry in the JS search index. These are all emitted
 /// by hand to a large JS file at the end of cache-creation.
 #[derive(Debug)]
-pub struct IndexItem {
+struct IndexItem {
     ty: ItemType,
     name: String,
     path: String,

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -278,7 +278,7 @@ pub struct RenderInfo {
 /// Struct representing one entry in the JS search index. These are all emitted
 /// by hand to a large JS file at the end of cache-creation.
 #[derive(Debug)]
-struct IndexItem {
+pub struct IndexItem {
     ty: ItemType,
     name: String,
     path: String,
@@ -293,7 +293,12 @@ impl Serialize for IndexItem {
     where
         S: Serializer,
     {
-        assert_eq!(self.parent.is_some(), self.parent_idx.is_some());
+        assert_eq!(
+            self.parent.is_some(),
+            self.parent_idx.is_some(),
+            "`{}` is missing idx",
+            self.name
+        );
 
         (self.ty, &self.name, &self.path, &self.desc, self.parent_idx, &self.search_type)
             .serialize(serializer)
@@ -836,7 +841,7 @@ themePicker.onblur = handleThemeButtonsBlur;
     {
         let (mut all_aliases, _) = try_err!(collect(&dst, &krate.name, "ALIASES"), &dst);
         let mut output = String::with_capacity(100);
-        for (alias, items) in &cx.cache.aliases {
+        for (alias, items) in cx.cache.get_aliases() {
             if items.is_empty() {
                 continue;
             }

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -1781,12 +1781,13 @@ function getSearchElement() {
                 if (aliases) {
                     ALIASES[crate] = {};
                     var j, local_aliases;
-                    for (i = 0; i < aliases.length; ++i) {
-                        var alias_name = aliases[i][0];
+                    for (var alias_name in aliases) {
+                        if (!aliases.hasOwnProperty(alias_name)) { continue; }
+
                         if (!ALIASES[crate].hasOwnProperty(alias_name)) {
                             ALIASES[crate][alias_name] = [];
                         }
-                        local_aliases = aliases[i][1];
+                        local_aliases = aliases[alias_name];
                         for (j = 0; j < local_aliases.length; ++j) {
                             ALIASES[crate][alias_name].push(local_aliases[j] + currentIndex);
                         }

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -972,7 +972,7 @@ function getSearchElement() {
                     desc: item.desc,
                     ty: item.ty,
                     parent: item.parent,
-                    type: item.parent,
+                    type: item.type,
                     is_alias: true,
                 };
             }

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -676,7 +676,11 @@ impl Collector {
     }
 
     fn generate_name(&self, line: usize, filename: &FileName) -> String {
-        format!("{} - {} (line {})", filename, self.names.join("::"), line)
+        let mut item_path = self.names.join("::");
+        if !item_path.is_empty() {
+            item_path.push(' ');
+        }
+        format!("{} - {}(line {})", filename, item_path, line)
     }
 
     pub fn set_position(&mut self, position: Span) {

--- a/src/libstd/collections/hash/map.rs
+++ b/src/libstd/collections/hash/map.rs
@@ -251,6 +251,9 @@ impl<K, V, S> HashMap<K, V, S> {
     /// cause many collisions and very poor performance. Setting it
     /// manually using this function can expose a DoS attack vector.
     ///
+    /// The `hash_builder` passed should implement the [`BuildHasher`] trait for
+    /// the HashMap to be useful, see its documentation for details.
+    ///
     /// # Examples
     ///
     /// ```
@@ -261,6 +264,8 @@ impl<K, V, S> HashMap<K, V, S> {
     /// let mut map = HashMap::with_hasher(s);
     /// map.insert(1, 2);
     /// ```
+    ///
+    /// [`BuildHasher`]: ../../std/hash/trait.BuildHasher.html
     #[inline]
     #[stable(feature = "hashmap_build_hasher", since = "1.7.0")]
     pub fn with_hasher(hash_builder: S) -> HashMap<K, V, S> {
@@ -278,6 +283,9 @@ impl<K, V, S> HashMap<K, V, S> {
     /// cause many collisions and very poor performance. Setting it
     /// manually using this function can expose a DoS attack vector.
     ///
+    /// The `hash_builder` passed should implement the [`BuildHasher`] trait for
+    /// the HashMap to be useful, see its documentation for details.
+    ///
     /// # Examples
     ///
     /// ```
@@ -288,6 +296,8 @@ impl<K, V, S> HashMap<K, V, S> {
     /// let mut map = HashMap::with_capacity_and_hasher(10, s);
     /// map.insert(1, 2);
     /// ```
+    ///
+    /// [`BuildHasher`]: ../../std/hash/trait.BuildHasher.html
     #[inline]
     #[stable(feature = "hashmap_build_hasher", since = "1.7.0")]
     pub fn with_capacity_and_hasher(capacity: usize, hash_builder: S) -> HashMap<K, V, S> {

--- a/src/libstd/collections/hash/set.rs
+++ b/src/libstd/collections/hash/set.rs
@@ -273,6 +273,9 @@ impl<T, S> HashSet<T, S> {
     /// cause many collisions and very poor performance. Setting it
     /// manually using this function can expose a DoS attack vector.
     ///
+    /// The `hash_builder` passed should implement the [`BuildHasher`] trait for
+    /// the HashMap to be useful, see its documentation for details.
+    ///
     /// # Examples
     ///
     /// ```
@@ -283,6 +286,8 @@ impl<T, S> HashSet<T, S> {
     /// let mut set = HashSet::with_hasher(s);
     /// set.insert(2);
     /// ```
+    ///
+    /// [`BuildHasher`]: ../../std/hash/trait.BuildHasher.html
     #[inline]
     #[stable(feature = "hashmap_build_hasher", since = "1.7.0")]
     pub fn with_hasher(hasher: S) -> HashSet<T, S> {
@@ -300,6 +305,9 @@ impl<T, S> HashSet<T, S> {
     /// cause many collisions and very poor performance. Setting it
     /// manually using this function can expose a DoS attack vector.
     ///
+    /// The `hash_builder` passed should implement the [`BuildHasher`] trait for
+    /// the HashMap to be useful, see its documentation for details.
+    ///
     /// # Examples
     ///
     /// ```
@@ -310,6 +318,8 @@ impl<T, S> HashSet<T, S> {
     /// let mut set = HashSet::with_capacity_and_hasher(10, s);
     /// set.insert(1);
     /// ```
+    ///
+    /// [`BuildHasher`]: ../../std/hash/trait.BuildHasher.html
     #[inline]
     #[stable(feature = "hashmap_build_hasher", since = "1.7.0")]
     pub fn with_capacity_and_hasher(capacity: usize, hasher: S) -> HashSet<T, S> {

--- a/src/test/mir-opt/const_prop/mutable_variable/rustc.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/mutable_variable/rustc.main.ConstProp.diff
@@ -26,8 +26,7 @@
                                            // + ty: i32
                                            // + val: Value(Scalar(0x00000063))
                                            // mir::Constant
--                                          // + span: $DIR/mutable_variable.rs:6:9: 6:11
-+                                          // + span: $DIR/mutable_variable.rs:6:5: 6:11
+                                           // + span: $DIR/mutable_variable.rs:6:9: 6:11
                                            // + literal: Const { ty: i32, val: Value(Scalar(0x00000063)) }
           StorageLive(_2);                 // scope 1 at $DIR/mutable_variable.rs:7:9: 7:10
 -         _2 = _1;                         // scope 1 at $DIR/mutable_variable.rs:7:13: 7:14

--- a/src/test/mir-opt/const_prop/mutable_variable_aggregate/rustc.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/mutable_variable_aggregate/rustc.main.ConstProp.diff
@@ -34,8 +34,7 @@
                                            // + ty: i32
                                            // + val: Value(Scalar(0x00000063))
                                            // mir::Constant
--                                          // + span: $DIR/mutable_variable_aggregate.rs:6:11: 6:13
-+                                          // + span: $DIR/mutable_variable_aggregate.rs:6:5: 6:13
+                                           // + span: $DIR/mutable_variable_aggregate.rs:6:11: 6:13
                                            // + literal: Const { ty: i32, val: Value(Scalar(0x00000063)) }
           StorageLive(_2);                 // scope 1 at $DIR/mutable_variable_aggregate.rs:7:9: 7:10
 -         _2 = _1;                         // scope 1 at $DIR/mutable_variable_aggregate.rs:7:13: 7:14

--- a/src/test/mir-opt/copy_propagation_arg/rustc.arg_src.CopyPropagation.diff
+++ b/src/test/mir-opt/copy_propagation_arg/rustc.arg_src.CopyPropagation.diff
@@ -17,7 +17,7 @@
                                            // + ty: i32
                                            // + val: Value(Scalar(0x0000007b))
                                            // mir::Constant
-                                           // + span: $DIR/copy_propagation_arg.rs:29:5: 29:12
+                                           // + span: $DIR/copy_propagation_arg.rs:29:9: 29:12
                                            // + literal: Const { ty: i32, val: Value(Scalar(0x0000007b)) }
           _0 = _2;                         // scope 1 at $DIR/copy_propagation_arg.rs:30:5: 30:6
           StorageDead(_2);                 // scope 0 at $DIR/copy_propagation_arg.rs:31:1: 31:2

--- a/src/test/mir-opt/copy_propagation_arg/rustc.bar.CopyPropagation.diff
+++ b/src/test/mir-opt/copy_propagation_arg/rustc.bar.CopyPropagation.diff
@@ -28,7 +28,7 @@
                                            // + ty: u8
                                            // + val: Value(Scalar(0x05))
                                            // mir::Constant
-                                           // + span: $DIR/copy_propagation_arg.rs:17:5: 17:10
+                                           // + span: $DIR/copy_propagation_arg.rs:17:9: 17:10
                                            // + literal: Const { ty: u8, val: Value(Scalar(0x05)) }
           _0 = const ();                   // scope 0 at $DIR/copy_propagation_arg.rs:15:19: 18:2
                                            // ty::Const

--- a/src/test/rustdoc-js-std/alias-2.js
+++ b/src/test/rustdoc-js-std/alias-2.js
@@ -4,9 +4,9 @@ const QUERY = '+';
 
 const EXPECTED = {
     'others': [
-        { 'path': 'core', 'name': 'AddAssign' },
-        { 'path': 'core', 'name': 'Add' },
-        { 'path': 'std', 'name': 'AddAssign' },
+        { 'path': 'core::ops', 'name': 'AddAssign' },
+        { 'path': 'core::ops', 'name': 'Add' },
+        { 'path': 'std::ops', 'name': 'AddAssign' },
         { 'path': 'std::ops', 'name': 'Add' },
     ],
 };

--- a/src/test/rustdoc-js-std/alias-2.js
+++ b/src/test/rustdoc-js-std/alias-2.js
@@ -1,12 +1,10 @@
-// ignore-order
-
 const QUERY = '+';
 
 const EXPECTED = {
     'others': [
-        { 'path': 'core::ops', 'name': 'AddAssign' },
-        { 'path': 'core::ops', 'name': 'Add' },
         { 'path': 'std::ops', 'name': 'AddAssign' },
         { 'path': 'std::ops', 'name': 'Add' },
+        { 'path': 'core::ops', 'name': 'AddAssign' },
+        { 'path': 'core::ops', 'name': 'Add' },
     ],
 };

--- a/src/test/rustdoc-js-std/alias-2.js
+++ b/src/test/rustdoc-js-std/alias-2.js
@@ -4,7 +4,9 @@ const QUERY = '+';
 
 const EXPECTED = {
     'others': [
-        { 'path': 'std::ops', 'name': 'AddAssign' },
+        { 'path': 'core', 'name': 'AddAssign' },
+        { 'path': 'core', 'name': 'Add' },
+        { 'path': 'std', 'name': 'AddAssign' },
         { 'path': 'std::ops', 'name': 'Add' },
     ],
 };

--- a/src/test/rustdoc-js-std/alias.js
+++ b/src/test/rustdoc-js-std/alias.js
@@ -5,7 +5,7 @@ const QUERY = '[';
 const EXPECTED = {
     'others': [
         { 'path': 'std', 'name': 'slice' },
-        { 'path': 'std::ops', 'name': 'IndexMut' },
-        { 'path': 'std::ops', 'name': 'Index' },
+        { 'path': 'std', 'name': 'IndexMut' },
+        { 'path': 'std', 'name': 'Index' },
     ],
 };

--- a/src/test/rustdoc-js-std/alias.js
+++ b/src/test/rustdoc-js-std/alias.js
@@ -5,7 +5,7 @@ const QUERY = '[';
 const EXPECTED = {
     'others': [
         { 'path': 'std', 'name': 'slice' },
-        { 'path': 'std', 'name': 'IndexMut' },
-        { 'path': 'std', 'name': 'Index' },
+        { 'path': 'std::ops', 'name': 'IndexMut' },
+        { 'path': 'std::ops', 'name': 'Index' },
     ],
 };

--- a/src/test/rustdoc-js/doc-alias.js
+++ b/src/test/rustdoc-js/doc-alias.js
@@ -32,7 +32,8 @@ const EXPECTED = [
                 'path': 'doc_alias',
                 'name': 'Struct',
                 'alias': 'StructItem',
-                'href': '../doc_alias/struct.Struct.html'
+                'href': '../doc_alias/struct.Struct.html',
+                'is_alias': true
             },
         ],
     },
@@ -42,7 +43,8 @@ const EXPECTED = [
                 'path': 'doc_alias::Struct',
                 'name': 'field',
                 'alias': 'StructFieldItem',
-                'href': '../doc_alias/struct.Struct.html#structfield.field'
+                'href': '../doc_alias/struct.Struct.html#structfield.field',
+                'is_alias': true
             },
         ],
     },
@@ -52,7 +54,8 @@ const EXPECTED = [
                 'path': 'doc_alias::Struct',
                 'name': 'method',
                 'alias': 'StructMethodItem',
-                'href': '../doc_alias/struct.Struct.html#method.method'
+                'href': '../doc_alias/struct.Struct.html#method.method',
+                'is_alias': true
             },
         ],
     },
@@ -65,8 +68,15 @@ const EXPECTED = [
         'others': [],
     },
     {
-        // ImplTraitFunction
-        'others': [],
+        'others': [
+            {
+                'path': 'doc_alias::Struct',
+                'name': 'function',
+                'alias': 'ImplTraitFunction',
+                'href': '../doc_alias/struct.Struct.html#method.function',
+                'is_alias': true
+            },
+        ],
     },
     {
         'others': [
@@ -74,7 +84,8 @@ const EXPECTED = [
                 'path': 'doc_alias',
                 'name': 'Enum',
                 'alias': 'EnumItem',
-                'href': '../doc_alias/enum.Enum.html'
+                'href': '../doc_alias/enum.Enum.html',
+                'is_alias': true
             },
         ],
     },
@@ -84,7 +95,8 @@ const EXPECTED = [
                 'path': 'doc_alias::Enum',
                 'name': 'Variant',
                 'alias': 'VariantItem',
-                'href': '../doc_alias/enum.Enum.html#variant.Variant'
+                'href': '../doc_alias/enum.Enum.html#variant.Variant',
+                'is_alias': true
             },
         ],
     },
@@ -94,7 +106,8 @@ const EXPECTED = [
                 'path': 'doc_alias::Enum',
                 'name': 'method',
                 'alias': 'EnumMethodItem',
-                'href': '../doc_alias/enum.Enum.html#method.method'
+                'href': '../doc_alias/enum.Enum.html#method.method',
+                'is_alias': true
             },
         ],
     },
@@ -104,7 +117,8 @@ const EXPECTED = [
                 'path': 'doc_alias',
                 'name': 'Typedef',
                 'alias': 'TypedefItem',
-                'href': '../doc_alias/type.Typedef.html'
+                'href': '../doc_alias/type.Typedef.html',
+                'is_alias': true
             },
         ],
     },
@@ -114,7 +128,8 @@ const EXPECTED = [
                 'path': 'doc_alias',
                 'name': 'Trait',
                 'alias': 'TraitItem',
-                'href': '../doc_alias/trait.Trait.html'
+                'href': '../doc_alias/trait.Trait.html',
+                'is_alias': true
             },
         ],
     },
@@ -124,7 +139,8 @@ const EXPECTED = [
                 'path': 'doc_alias::Trait',
                 'name': 'Target',
                 'alias': 'TraitTypeItem',
-                'href': '../doc_alias/trait.Trait.html#associatedtype.Target'
+                'href': '../doc_alias/trait.Trait.html#associatedtype.Target',
+                'is_alias': true
             },
         ],
     },
@@ -134,7 +150,8 @@ const EXPECTED = [
                 'path': 'doc_alias::Trait',
                 'name': 'AssociatedConst',
                 'alias': 'AssociatedConstItem',
-                'href': '../doc_alias/trait.Trait.html#associatedconstant.AssociatedConst'
+                'href': '../doc_alias/trait.Trait.html#associatedconstant.AssociatedConst',
+                'is_alias': true
             },
         ],
     },
@@ -144,7 +161,8 @@ const EXPECTED = [
                 'path': 'doc_alias::Trait',
                 'name': 'function',
                 'alias': 'TraitFunctionItem',
-                'href': '../doc_alias/trait.Trait.html#tymethod.function'
+                'href': '../doc_alias/trait.Trait.html#tymethod.function',
+                'is_alias': true
             },
         ],
     },
@@ -154,7 +172,8 @@ const EXPECTED = [
                 'path': 'doc_alias',
                 'name': 'function',
                 'alias': 'FunctionItem',
-                'href': '../doc_alias/fn.function.html'
+                'href': '../doc_alias/fn.function.html',
+                'is_alias': true
             },
         ],
     },
@@ -164,7 +183,8 @@ const EXPECTED = [
                 'path': 'doc_alias',
                 'name': 'Module',
                 'alias': 'ModuleItem',
-                'href': '../doc_alias/Module/index.html'
+                'href': '../doc_alias/Module/index.html',
+                'is_alias': true
             },
         ],
     },
@@ -174,7 +194,8 @@ const EXPECTED = [
                 'path': 'doc_alias',
                 'name': 'Const',
                 'alias': 'ConstItem',
-                'href': '../doc_alias/constant.Const.html'
+                'href': '../doc_alias/constant.Const.html',
+                'is_alias': true
             },
         ],
     },
@@ -184,7 +205,8 @@ const EXPECTED = [
                 'path': 'doc_alias',
                 'name': 'Static',
                 'alias': 'StaticItem',
-                'href': '../doc_alias/static.Static.html'
+                'href': '../doc_alias/static.Static.html',
+                'is_alias': true
             },
         ],
     },
@@ -194,7 +216,8 @@ const EXPECTED = [
                 'path': 'doc_alias',
                 'name': 'Union',
                 'alias': 'UnionItem',
-                'href': '../doc_alias/union.Union.html'
+                'href': '../doc_alias/union.Union.html',
+                'is_alias': true
             },
             // Not an alias!
             {
@@ -210,7 +233,8 @@ const EXPECTED = [
                 'path': 'doc_alias::Union',
                 'name': 'union_item',
                 'alias': 'UnionFieldItem',
-                'href': '../doc_alias/union.Union.html#structfield.union_item'
+                'href': '../doc_alias/union.Union.html#structfield.union_item',
+                'is_alias': true
             },
         ],
     },
@@ -220,7 +244,8 @@ const EXPECTED = [
                 'path': 'doc_alias::Union',
                 'name': 'method',
                 'alias': 'UnionMethodItem',
-                'href': '../doc_alias/union.Union.html#method.method'
+                'href': '../doc_alias/union.Union.html#method.method',
+                'is_alias': true
             },
         ],
     },
@@ -230,7 +255,8 @@ const EXPECTED = [
                 'path': 'doc_alias',
                 'name': 'Macro',
                 'alias': 'MacroItem',
-                'href': '../doc_alias/macro.Macro.html'
+                'href': '../doc_alias/macro.Macro.html',
+                'is_alias': true
             },
         ],
     },

--- a/src/test/rustdoc-js/doc-alias.js
+++ b/src/test/rustdoc-js/doc-alias.js
@@ -1,0 +1,237 @@
+// exact-check
+
+const QUERY = [
+    'StructItem',
+    'StructFieldItem',
+    'StructMethodItem',
+    'ImplTraitItem',
+    'ImplAssociatedConstItem',
+    'ImplTraitFunction',
+    'EnumItem',
+    'VariantItem',
+    'EnumMethodItem',
+    'TypedefItem',
+    'TraitItem',
+    'TraitTypeItem',
+    'AssociatedConstItem',
+    'TraitFunctionItem',
+    'FunctionItem',
+    'ModuleItem',
+    'ConstItem',
+    'StaticItem',
+    'UnionItem',
+    'UnionFieldItem',
+    'UnionMethodItem',
+    'MacroItem',
+];
+
+const EXPECTED = [
+    {
+        'others': [
+            {
+                'path': 'doc_alias',
+                'name': 'Struct',
+                'alias': 'StructItem',
+                'href': '../doc_alias/struct.Struct.html'
+            },
+        ],
+    },
+    {
+        'others': [
+            {
+                'path': 'doc_alias::Struct',
+                'name': 'field',
+                'alias': 'StructFieldItem',
+                'href': '../doc_alias/struct.Struct.html#structfield.field'
+            },
+        ],
+    },
+    {
+        'others': [
+            {
+                'path': 'doc_alias::Struct',
+                'name': 'method',
+                'alias': 'StructMethodItem',
+                'href': '../doc_alias/struct.Struct.html#method.method'
+            },
+        ],
+    },
+    {
+        // ImplTraitItem
+        'others': [],
+    },
+    {
+        // ImplAssociatedConstItem
+        'others': [],
+    },
+    {
+        // ImplTraitFunction
+        'others': [],
+    },
+    {
+        'others': [
+            {
+                'path': 'doc_alias',
+                'name': 'Enum',
+                'alias': 'EnumItem',
+                'href': '../doc_alias/enum.Enum.html'
+            },
+        ],
+    },
+    {
+        'others': [
+            {
+                'path': 'doc_alias::Enum',
+                'name': 'Variant',
+                'alias': 'VariantItem',
+                'href': '../doc_alias/enum.Enum.html#variant.Variant'
+            },
+        ],
+    },
+    {
+        'others': [
+            {
+                'path': 'doc_alias::Enum',
+                'name': 'method',
+                'alias': 'EnumMethodItem',
+                'href': '../doc_alias/enum.Enum.html#method.method'
+            },
+        ],
+    },
+    {
+        'others': [
+            {
+                'path': 'doc_alias',
+                'name': 'Typedef',
+                'alias': 'TypedefItem',
+                'href': '../doc_alias/type.Typedef.html'
+            },
+        ],
+    },
+    {
+        'others': [
+            {
+                'path': 'doc_alias',
+                'name': 'Trait',
+                'alias': 'TraitItem',
+                'href': '../doc_alias/trait.Trait.html'
+            },
+        ],
+    },
+    {
+        'others': [
+            {
+                'path': 'doc_alias::Trait',
+                'name': 'Target',
+                'alias': 'TraitTypeItem',
+                'href': '../doc_alias/trait.Trait.html#associatedtype.Target'
+            },
+        ],
+    },
+    {
+        'others': [
+            {
+                'path': 'doc_alias::Trait',
+                'name': 'AssociatedConst',
+                'alias': 'AssociatedConstItem',
+                'href': '../doc_alias/trait.Trait.html#associatedconstant.AssociatedConst'
+            },
+        ],
+    },
+    {
+        'others': [
+            {
+                'path': 'doc_alias::Trait',
+                'name': 'function',
+                'alias': 'TraitFunctionItem',
+                'href': '../doc_alias/trait.Trait.html#tymethod.function'
+            },
+        ],
+    },
+    {
+        'others': [
+            {
+                'path': 'doc_alias',
+                'name': 'function',
+                'alias': 'FunctionItem',
+                'href': '../doc_alias/fn.function.html'
+            },
+        ],
+    },
+    {
+        'others': [
+            {
+                'path': 'doc_alias',
+                'name': 'Module',
+                'alias': 'ModuleItem',
+                'href': '../doc_alias/Module/index.html'
+            },
+        ],
+    },
+    {
+        'others': [
+            {
+                'path': 'doc_alias',
+                'name': 'Const',
+                'alias': 'ConstItem',
+                'href': '../doc_alias/constant.Const.html'
+            },
+        ],
+    },
+    {
+        'others': [
+            {
+                'path': 'doc_alias',
+                'name': 'Static',
+                'alias': 'StaticItem',
+                'href': '../doc_alias/static.Static.html'
+            },
+        ],
+    },
+    {
+        'others': [
+            {
+                'path': 'doc_alias',
+                'name': 'Union',
+                'alias': 'UnionItem',
+                'href': '../doc_alias/union.Union.html'
+            },
+            // Not an alias!
+            {
+                'path': 'doc_alias::Union',
+                'name': 'union_item',
+                'href': '../doc_alias/union.Union.html#structfield.union_item'
+            },
+        ],
+    },
+    {
+        'others': [
+            {
+                'path': 'doc_alias::Union',
+                'name': 'union_item',
+                'alias': 'UnionFieldItem',
+                'href': '../doc_alias/union.Union.html#structfield.union_item'
+            },
+        ],
+    },
+    {
+        'others': [
+            {
+                'path': 'doc_alias::Union',
+                'name': 'method',
+                'alias': 'UnionMethodItem',
+                'href': '../doc_alias/union.Union.html#method.method'
+            },
+        ],
+    },
+    {
+        'others': [
+            {
+                'path': 'doc_alias',
+                'name': 'Macro',
+                'alias': 'MacroItem',
+                'href': '../doc_alias/macro.Macro.html'
+            },
+        ],
+    },
+];

--- a/src/test/rustdoc-js/doc-alias.rs
+++ b/src/test/rustdoc-js/doc-alias.rs
@@ -19,7 +19,6 @@ impl Trait for Struct {
     #[doc(alias = "ImplAssociatedConstItem")]
     const AssociatedConst: i32 = 12;
 
-    // Shouldn't be listed in aliases!
     #[doc(alias = "ImplTraitFunction")]
     fn function() -> Self::Target { 0 }
 }

--- a/src/test/rustdoc-js/doc-alias.rs
+++ b/src/test/rustdoc-js/doc-alias.rs
@@ -1,0 +1,80 @@
+#![feature(doc_alias)]
+
+#[doc(alias = "StructItem")]
+pub struct Struct {
+    #[doc(alias = "StructFieldItem")]
+    pub field: u32,
+}
+
+impl Struct {
+    #[doc(alias = "StructMethodItem")]
+    pub fn method(&self) {}
+}
+
+impl Trait for Struct {
+    // Shouldn't be listed in aliases!
+    #[doc(alias = "ImplTraitItem")]
+    type Target = u32;
+    // Shouldn't be listed in aliases!
+    #[doc(alias = "ImplAssociatedConstItem")]
+    const AssociatedConst: i32 = 12;
+
+    // Shouldn't be listed in aliases!
+    #[doc(alias = "ImplTraitFunction")]
+    fn function() -> Self::Target { 0 }
+}
+
+#[doc(alias = "EnumItem")]
+pub enum Enum {
+    #[doc(alias = "VariantItem")]
+    Variant,
+}
+
+impl Enum {
+    #[doc(alias = "EnumMethodItem")]
+    pub fn method(&self) {}
+}
+
+#[doc(alias = "TypedefItem")]
+pub type Typedef = i32;
+
+#[doc(alias = "TraitItem")]
+pub trait Trait {
+    #[doc(alias = "TraitTypeItem")]
+    type Target;
+    #[doc(alias = "AssociatedConstItem")]
+    const AssociatedConst: i32;
+
+    #[doc(alias = "TraitFunctionItem")]
+    fn function() -> Self::Target;
+}
+
+#[doc(alias = "FunctionItem")]
+pub fn function() {}
+
+#[doc(alias = "ModuleItem")]
+pub mod Module {}
+
+#[doc(alias = "ConstItem")]
+pub const Const: u32 = 0;
+
+#[doc(alias = "StaticItem")]
+pub static Static: u32 = 0;
+
+#[doc(alias = "UnionItem")]
+pub union Union {
+    #[doc(alias = "UnionFieldItem")]
+    pub union_item: u32,
+    pub y: f32,
+}
+
+impl Union {
+    #[doc(alias = "UnionMethodItem")]
+    pub fn method(&self) {}
+}
+
+#[doc(alias = "MacroItem")]
+#[macro_export]
+macro_rules! Macro {
+    () => {}
+}

--- a/src/test/rustdoc-ui/doctest-output.rs
+++ b/src/test/rustdoc-ui/doctest-output.rs
@@ -1,0 +1,15 @@
+// compile-flags:--test
+// normalize-stdout-test: "src/test/rustdoc-ui" -> "$$DIR"
+// check-pass
+
+//! ```
+//! assert_eq!(1 + 1, 2);
+//! ```
+
+pub mod foo {
+
+    /// ```
+    /// assert_eq!(1 + 1, 2);
+    /// ```
+    pub fn bar() {}
+}

--- a/src/test/rustdoc-ui/doctest-output.stdout
+++ b/src/test/rustdoc-ui/doctest-output.stdout
@@ -1,0 +1,7 @@
+
+running 2 tests
+test $DIR/doctest-output.rs - (line 5) ... ok
+test $DIR/doctest-output.rs - foo::bar (line 11) ... ok
+
+test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
+

--- a/src/test/ui/async-await/await-keyword/incorrect-syntax-suggestions.stderr
+++ b/src/test/ui/async-await/await-keyword/incorrect-syntax-suggestions.stderr
@@ -237,7 +237,10 @@ error[E0277]: the `?` operator can only be applied to values that implement `std
   --> $DIR/incorrect-syntax-suggestions.rs:16:19
    |
 LL |     let _ = await bar()?;
-   |                   ^^^^^^ the `?` operator cannot be applied to type `impl std::future::Future`
+   |                   ^^^^^^
+   |                   |
+   |                   the `?` operator cannot be applied to type `impl std::future::Future`
+   |                   help: consider using `.await` here: `bar().await?`
    |
    = help: the trait `std::ops::Try` is not implemented for `impl std::future::Future`
    = note: required by `std::ops::Try::into_result`

--- a/src/test/ui/async-await/issue-61076.rs
+++ b/src/test/ui/async-await/issue-61076.rs
@@ -1,11 +1,31 @@
 // edition:2018
 
+use core::future::Future;
+use core::pin::Pin;
+use core::task::{Context, Poll};
+
+struct T;
+
+impl Future for T {
+    type Output = Result<(), ()>;
+
+    fn poll(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Self::Output> {
+        Poll::Pending
+    }
+}
+
 async fn foo() -> Result<(), ()> {
     Ok(())
 }
 
 async fn bar() -> Result<(), ()> {
     foo()?; //~ ERROR the `?` operator can only be applied to values that implement `std::ops::Try`
+    Ok(())
+}
+
+async fn baz() -> Result<(), ()> {
+    let t = T;
+    t?; //~ ERROR the `?` operator can only be applied to values that implement `std::ops::Try`
     Ok(())
 }
 

--- a/src/test/ui/async-await/issue-61076.rs
+++ b/src/test/ui/async-await/issue-61076.rs
@@ -1,0 +1,12 @@
+// edition:2018
+
+async fn foo() -> Result<(), ()> {
+    Ok(())
+}
+
+async fn bar() -> Result<(), ()> {
+    foo()?;
+    Ok(())
+}
+
+fn main() {}

--- a/src/test/ui/async-await/issue-61076.rs
+++ b/src/test/ui/async-await/issue-61076.rs
@@ -5,7 +5,7 @@ async fn foo() -> Result<(), ()> {
 }
 
 async fn bar() -> Result<(), ()> {
-    foo()?;
+    foo()?; //~ ERROR the `?` operator can only be applied to values that implement `std::ops::Try`
     Ok(())
 }
 

--- a/src/test/ui/async-await/issue-61076.stderr
+++ b/src/test/ui/async-await/issue-61076.stderr
@@ -1,0 +1,15 @@
+error[E0277]: the `?` operator can only be applied to values that implement `std::ops::Try`
+  --> $DIR/issue-61076.rs:8:5
+   |
+LL |     foo()?;
+   |     ^^^^^^
+   |     |
+   |     the `?` operator cannot be applied to type `impl std::future::Future`
+   |     help: consider using `.await` here: `foo().await?`
+   |
+   = help: the trait `std::ops::Try` is not implemented for `impl std::future::Future`
+   = note: required by `std::ops::Try::into_result`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/async-await/issue-61076.stderr
+++ b/src/test/ui/async-await/issue-61076.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the `?` operator can only be applied to values that implement `std::ops::Try`
-  --> $DIR/issue-61076.rs:8:5
+  --> $DIR/issue-61076.rs:22:5
    |
 LL |     foo()?;
    |     ^^^^^^
@@ -10,6 +10,18 @@ LL |     foo()?;
    = help: the trait `std::ops::Try` is not implemented for `impl std::future::Future`
    = note: required by `std::ops::Try::into_result`
 
-error: aborting due to previous error
+error[E0277]: the `?` operator can only be applied to values that implement `std::ops::Try`
+  --> $DIR/issue-61076.rs:28:5
+   |
+LL |     t?;
+   |     ^^
+   |     |
+   |     the `?` operator cannot be applied to type `T`
+   |     help: consider using `.await` here: `t.await?`
+   |
+   = help: the trait `std::ops::Try` is not implemented for `T`
+   = note: required by `std::ops::Try::into_result`
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/async-await/try-on-option-in-async.rs
+++ b/src/test/ui/async-await/try-on-option-in-async.rs
@@ -7,7 +7,8 @@ async fn an_async_block() -> u32 {
         let x: Option<u32> = None;
         x?; //~ ERROR the `?` operator
         22
-    }.await
+    }
+    .await
 }
 
 async fn async_closure_containing_fn() -> u32 {

--- a/src/test/ui/async-await/try-on-option-in-async.stderr
+++ b/src/test/ui/async-await/try-on-option-in-async.stderr
@@ -7,14 +7,14 @@ LL | |         let x: Option<u32> = None;
 LL | |         x?;
    | |         ^^ cannot use the `?` operator in an async block that returns `{integer}`
 LL | |         22
-LL | |     }.await
+LL | |     }
    | |_____- this function should return `Result` or `Option` to accept `?`
    |
    = help: the trait `std::ops::Try` is not implemented for `{integer}`
    = note: required by `std::ops::Try::from_error`
 
 error[E0277]: the `?` operator can only be used in an async closure that returns `Result` or `Option` (or another type that implements `std::ops::Try`)
-  --> $DIR/try-on-option-in-async.rs:16:9
+  --> $DIR/try-on-option-in-async.rs:17:9
    |
 LL |       let async_closure = async || {
    |  __________________________________-
@@ -29,7 +29,7 @@ LL | |     };
    = note: required by `std::ops::Try::from_error`
 
 error[E0277]: the `?` operator can only be used in an async function that returns `Result` or `Option` (or another type that implements `std::ops::Try`)
-  --> $DIR/try-on-option-in-async.rs:25:5
+  --> $DIR/try-on-option-in-async.rs:26:5
    |
 LL |   async fn an_async_function() -> u32 {
    |  _____________________________________-

--- a/src/test/ui/consts/miri_unleashed/ptr_arith.rs
+++ b/src/test/ui/consts/miri_unleashed/ptr_arith.rs
@@ -1,0 +1,29 @@
+// compile-flags: -Zunleash-the-miri-inside-of-you
+#![feature(core_intrinsics)]
+#![allow(const_err)]
+
+// A test demonstrating that we prevent doing even trivial
+// pointer arithmetic or comparison during CTFE.
+
+static CMP: () = {
+    let x = &0 as *const _;
+    let _v = x == x;
+    //~^ ERROR could not evaluate static initializer
+    //~| NOTE pointer arithmetic or comparison
+};
+
+static INT_PTR_ARITH: () = unsafe {
+    let x: usize = std::mem::transmute(&0);
+    let _v = x + 0;
+    //~^ ERROR could not evaluate static initializer
+    //~| NOTE pointer-to-integer cast
+};
+
+static PTR_ARITH: () = unsafe {
+    let x = &0 as *const _;
+    let _v = core::intrinsics::offset(x, 0);
+    //~^ ERROR could not evaluate static initializer
+    //~| NOTE calling intrinsic `offset`
+};
+
+fn main() {}

--- a/src/test/ui/consts/miri_unleashed/ptr_arith.stderr
+++ b/src/test/ui/consts/miri_unleashed/ptr_arith.stderr
@@ -1,0 +1,39 @@
+error[E0080]: could not evaluate static initializer
+  --> $DIR/ptr_arith.rs:10:14
+   |
+LL |     let _v = x == x;
+   |              ^^^^^^ "pointer arithmetic or comparison" needs an rfc before being allowed inside constants
+
+error[E0080]: could not evaluate static initializer
+  --> $DIR/ptr_arith.rs:17:14
+   |
+LL |     let _v = x + 0;
+   |              ^^^^^ "pointer-to-integer cast" needs an rfc before being allowed inside constants
+
+error[E0080]: could not evaluate static initializer
+  --> $DIR/ptr_arith.rs:24:14
+   |
+LL |     let _v = core::intrinsics::offset(x, 0);
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ "calling intrinsic `offset`" needs an rfc before being allowed inside constants
+
+warning: skipping const checks
+   |
+help: skipping check for `const_compare_raw_pointers` feature
+  --> $DIR/ptr_arith.rs:10:14
+   |
+LL |     let _v = x == x;
+   |              ^^^^^^
+help: skipping check that does not even have a feature gate
+  --> $DIR/ptr_arith.rs:16:20
+   |
+LL |     let x: usize = std::mem::transmute(&0);
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^
+help: skipping check that does not even have a feature gate
+  --> $DIR/ptr_arith.rs:24:14
+   |
+LL |     let _v = core::intrinsics::offset(x, 0);
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 3 previous errors; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0080`.

--- a/src/tools/rustdoc-js/tester.js
+++ b/src/tools/rustdoc-js/tester.js
@@ -181,7 +181,7 @@ function loadThings(thingsToLoad, kindOfLoad, funcToCall, fileContent) {
     for (var i = 0; i < thingsToLoad.length; ++i) {
         var tmp = funcToCall(fileContent, thingsToLoad[i]);
         if (tmp === null) {
-            console.error('unable to find ' + kindOfLoad + ' "' + thingsToLoad[i] + '"');
+            console.log('unable to find ' + kindOfLoad + ' "' + thingsToLoad[i] + '"');
             process.exit(1);
         }
         content += tmp;
@@ -223,7 +223,8 @@ function loadMainJsAndIndex(mainJs, aliases, searchIndex, crate) {
         searchIndex.pop();
     }
     searchIndex.pop();
-    searchIndex = loadContent(searchIndex.join("\n") + '\nexports.searchIndex = searchIndex;');
+    var fullSearchIndex = searchIndex.join("\n") + '\nexports.rawSearchIndex = searchIndex;';
+    searchIndex = loadContent(fullSearchIndex);
     var finalJS = "";
 
     var arraysToLoad = ["itemTypes"];
@@ -235,7 +236,7 @@ function loadMainJsAndIndex(mainJs, aliases, searchIndex, crate) {
     // execQuery last parameter is built in buildIndex.
     // buildIndex requires the hashmap from search-index.
     var functionsToLoad = ["buildHrefAndPath", "pathSplitter", "levenshtein", "validateResult",
-                           "getQuery", "buildIndex", "execQuery", "execSearch"];
+                           "handleAliases", "getQuery", "buildIndex", "execQuery", "execSearch"];
 
     finalJS += 'window = { "currentCrate": "' + crate + '" };\n';
     finalJS += 'var rootPath = "../";\n';
@@ -245,24 +246,19 @@ function loadMainJsAndIndex(mainJs, aliases, searchIndex, crate) {
     finalJS += loadThings(functionsToLoad, 'function', extractFunction, mainJs);
 
     var loaded = loadContent(finalJS);
-    var index = loaded.buildIndex(searchIndex.searchIndex);
+    var index = loaded.buildIndex(searchIndex.rawSearchIndex);
+    // We make it "global" so that the "loaded.execSearch" function will find it.
+    rawSearchIndex = searchIndex.rawSearchIndex;
 
     return [loaded, index];
 }
 
-function runChecks(testFile, loaded, index) {
-    var errors = 0;
-    var loadedFile = loadContent(
-        readFile(testFile) + 'exports.QUERY = QUERY;exports.EXPECTED = EXPECTED;');
-
-    const expected = loadedFile.EXPECTED;
-    const query = loadedFile.QUERY;
+function runSearch(query, expected, index, loaded, loadedFile, queryName) {
     const filter_crate = loadedFile.FILTER_CRATE;
     const ignore_order = loadedFile.ignore_order;
     const exact_check = loadedFile.exact_check;
-    const should_fail = loadedFile.should_fail;
 
-    var results = loaded.execSearch(loaded.getQuery(query), index);
+    var results = loaded.execSearch(loaded.getQuery(query), index, filter_crate);
     var error_text = [];
 
     for (var key in expected) {
@@ -278,32 +274,68 @@ function runChecks(testFile, loaded, index) {
         for (var i = 0; i < entry.length; ++i) {
             var entry_pos = lookForEntry(entry[i], results[key]);
             if (entry_pos === null) {
-                error_text.push("==> Result not found in '" + key + "': '" +
+                error_text.push(queryName + "==> Result not found in '" + key + "': '" +
                                 JSON.stringify(entry[i]) + "'");
             } else if (exact_check === true && prev_pos + 1 !== entry_pos) {
-                error_text.push("==> Exact check failed at position " + (prev_pos + 1) + ": " +
-                                "expected '" + JSON.stringify(entry[i]) + "' but found '" +
+                error_text.push(queryName + "==> Exact check failed at position " + (prev_pos + 1) +
+                                ": expected '" + JSON.stringify(entry[i]) + "' but found '" +
                                 JSON.stringify(results[key][i]) + "'");
             } else if (ignore_order === false && entry_pos < prev_pos) {
-                error_text.push("==> '" + JSON.stringify(entry[i]) + "' was supposed to be " +
-                                " before '" + JSON.stringify(results[key][entry_pos]) + "'");
+                error_text.push(queryName + "==> '" + JSON.stringify(entry[i]) + "' was supposed " +
+                                "to be before '" + JSON.stringify(results[key][entry_pos]) + "'");
             } else {
                 prev_pos = entry_pos;
             }
         }
     }
-    if (error_text.length === 0 && should_fail === true) {
-        errors += 1;
-        console.error("FAILED");
-        console.error("==> Test was supposed to fail but all items were found...");
-    } else if (error_text.length !== 0 && should_fail === false) {
-        errors += 1;
-        console.error("FAILED");
-        console.error(error_text.join("\n"));
+    return error_text;
+}
+
+function checkResult(error_text, loadedFile, displaySuccess) {
+    if (error_text.length === 0 && loadedFile.should_fail === true) {
+        console.log("FAILED");
+        console.log("==> Test was supposed to fail but all items were found...");
+    } else if (error_text.length !== 0 && loadedFile.should_fail === false) {
+        console.log("FAILED");
+        console.log(error_text.join("\n"));
     } else {
-        console.log("OK");
+        if (displaySuccess) {
+            console.log("OK");
+        }
+        return 0;
     }
-    return errors;
+    return 1;
+}
+
+function runChecks(testFile, loaded, index) {
+    var loadedFile = loadContent(
+        readFile(testFile) + 'exports.QUERY = QUERY;exports.EXPECTED = EXPECTED;');
+
+    const expected = loadedFile.EXPECTED;
+    const query = loadedFile.QUERY;
+
+    if (Array.isArray(query)) {
+        if (!Array.isArray(expected)) {
+            console.log("FAILED");
+            console.log("==> If QUERY variable is an array, EXPECTED should be an array too");
+            return 1;
+        } else if (query.length !== expected.length) {
+            console.log("FAILED");
+            console.log("==> QUERY variable should have the same length as EXPECTED");
+            return 1;
+        }
+        for (var i = 0; i < query.length; ++i) {
+            var error_text = runSearch(query[i], expected[i], index, loaded, loadedFile,
+                "[ query `" + query[i] + "`]");
+            if (checkResult(error_text, loadedFile, false) !== 0) {
+                return 1;
+            }
+        }
+        console.log("OK");
+        return 0;
+    }
+    var error_text = runSearch(query, expected, index, loaded, loadedFile, "");
+    return checkResult(error_text, loadedFile, true);
 }
 
 function load_files(doc_folder, resource_suffix, crate) {
@@ -349,7 +381,7 @@ function parseOptions(args) {
             || args[i] === "--crate-name") {
             i += 1;
             if (i >= args.length) {
-                console.error("Missing argument after `" + args[i - 1] + "` option.");
+                console.log("Missing argument after `" + args[i - 1] + "` option.");
                 return null;
             }
             opts[correspondances[args[i - 1]]] = args[i];
@@ -357,17 +389,17 @@ function parseOptions(args) {
             showHelp();
             process.exit(0);
         } else {
-            console.error("Unknown option `" + args[i] + "`.");
-            console.error("Use `--help` to see the list of options");
+            console.log("Unknown option `" + args[i] + "`.");
+            console.log("Use `--help` to see the list of options");
             return null;
         }
     }
     if (opts["doc_folder"].length < 1) {
-        console.error("Missing `--doc-folder` option.");
+        console.log("Missing `--doc-folder` option.");
     } else if (opts["crate_name"].length < 1) {
-        console.error("Missing `--crate-name` option.");
+        console.log("Missing `--crate-name` option.");
     } else if (opts["test_folder"].length < 1 && opts["test_file"].length < 1) {
-        console.error("At least one of `--test-folder` or `--test-file` option is required.");
+        console.log("At least one of `--test-folder` or `--test-file` option is required.");
     } else {
         return opts;
     }

--- a/src/tools/rustdoc-js/tester.js
+++ b/src/tools/rustdoc-js/tester.js
@@ -218,7 +218,7 @@ function lookForEntry(entry, data) {
     return null;
 }
 
-function loadMainJsAndIndex(mainJs, searchIndex, crate) {
+function loadMainJsAndIndex(mainJs, searchIndex, storageJs, crate) {
     if (searchIndex[searchIndex.length - 1].length === 0) {
         searchIndex.pop();
     }
@@ -241,6 +241,7 @@ function loadMainJsAndIndex(mainJs, searchIndex, crate) {
     ALIASES = {};
     finalJS += 'window = { "currentCrate": "' + crate + '" };\n';
     finalJS += 'var rootPath = "../";\n';
+    finalJS += loadThings(["onEach"], 'function', extractFunction, storageJs);
     finalJS += loadThings(arraysToLoad, 'array', extractArrayVariable, mainJs);
     finalJS += loadThings(variablesToLoad, 'variable', extractVariable, mainJs);
     finalJS += loadThings(functionsToLoad, 'function', extractFunction, mainJs);
@@ -338,10 +339,11 @@ function runChecks(testFile, loaded, index) {
 
 function load_files(doc_folder, resource_suffix, crate) {
     var mainJs = readFile(path.join(doc_folder, "main" + resource_suffix + ".js"));
+    var storageJs = readFile(path.join(doc_folder, "storage" + resource_suffix + ".js"));
     var searchIndex = readFile(
         path.join(doc_folder, "search-index" + resource_suffix + ".js")).split("\n");
 
-    return loadMainJsAndIndex(mainJs, searchIndex, crate);
+    return loadMainJsAndIndex(mainJs, searchIndex, storageJs, crate);
 }
 
 function showHelp() {

--- a/src/tools/rustdoc-js/tester.js
+++ b/src/tools/rustdoc-js/tester.js
@@ -218,7 +218,7 @@ function lookForEntry(entry, data) {
     return null;
 }
 
-function loadMainJsAndIndex(mainJs, aliases, searchIndex, crate) {
+function loadMainJsAndIndex(mainJs, searchIndex, crate) {
     if (searchIndex[searchIndex.length - 1].length === 0) {
         searchIndex.pop();
     }
@@ -238,17 +238,15 @@ function loadMainJsAndIndex(mainJs, aliases, searchIndex, crate) {
     var functionsToLoad = ["buildHrefAndPath", "pathSplitter", "levenshtein", "validateResult",
                            "handleAliases", "getQuery", "buildIndex", "execQuery", "execSearch"];
 
+    ALIASES = {};
     finalJS += 'window = { "currentCrate": "' + crate + '" };\n';
     finalJS += 'var rootPath = "../";\n';
-    finalJS += aliases;
     finalJS += loadThings(arraysToLoad, 'array', extractArrayVariable, mainJs);
     finalJS += loadThings(variablesToLoad, 'variable', extractVariable, mainJs);
     finalJS += loadThings(functionsToLoad, 'function', extractFunction, mainJs);
 
     var loaded = loadContent(finalJS);
     var index = loaded.buildIndex(searchIndex.rawSearchIndex);
-    // We make it "global" so that the "loaded.execSearch" function will find it.
-    rawSearchIndex = searchIndex.rawSearchIndex;
 
     return [loaded, index];
 }
@@ -340,11 +338,10 @@ function runChecks(testFile, loaded, index) {
 
 function load_files(doc_folder, resource_suffix, crate) {
     var mainJs = readFile(path.join(doc_folder, "main" + resource_suffix + ".js"));
-    var aliases = readFile(path.join(doc_folder, "aliases" + resource_suffix + ".js"));
     var searchIndex = readFile(
         path.join(doc_folder, "search-index" + resource_suffix + ".js")).split("\n");
 
-    return loadMainJsAndIndex(mainJs, aliases, searchIndex, crate);
+    return loadMainJsAndIndex(mainJs, searchIndex, crate);
 }
 
 function showHelp() {


### PR DESCRIPTION
Successful merges:

 - #71677 (Add explicit references to the BuildHasher trait)
 - #71724 (Doc alias improvements)
 - #71948 (Suggest to await future before ? operator)
 - #72180 (remove extra space from crate-level doctest names)
 - #72216 (Remove `lang_items\(\).*\.unwrap\(\)`)
 - #72218 (make sure even unleashed miri does not do pointer stuff)
 - #72220 ([const-prop] Don't replace Rvalues that are already constants)
 - #72224 (doc: add links to rotate_(left|right))

Failed merges:


r? @ghost