### PR TITLE
Remove redundant backtick in error message.

### DIFF
--- a/src/librustc_parse/parser/diagnostics.rs
+++ b/src/librustc_parse/parser/diagnostics.rs
@@ -927,7 +927,7 @@ impl<'a> Parser<'a> {
             return Ok(());
         }
         let sm = self.sess.source_map();
-        let msg = format!("expected `;`, found `{}`", super::token_descr(&self.token));
+        let msg = format!("expected `;`, found {}", super::token_descr(&self.token));
         let appl = Applicability::MachineApplicable;
         if self.token.span == DUMMY_SP || self.prev_token.span == DUMMY_SP {
             // Likely inside a macro, can't provide meaningful suggestions.

--- a/src/test/ui/parser/issue-3036.stderr
+++ b/src/test/ui/parser/issue-3036.stderr
@@ -1,4 +1,4 @@
-error: expected `;`, found ``}``
+error: expected `;`, found `}`
   --> $DIR/issue-3036.rs:5:14
    |
 LL |     let x = 3

--- a/src/test/ui/parser/recover-missing-semi.stderr
+++ b/src/test/ui/parser/recover-missing-semi.stderr
@@ -1,4 +1,4 @@
-error: expected `;`, found `keyword `let``
+error: expected `;`, found keyword `let`
   --> $DIR/recover-missing-semi.rs:2:22
    |
 LL |     let _: usize = ()
@@ -7,7 +7,7 @@ LL |     let _: usize = ()
 LL |     let _ = 3;
    |     --- unexpected token
 
-error: expected `;`, found `keyword `return``
+error: expected `;`, found keyword `return`
   --> $DIR/recover-missing-semi.rs:9:22
    |
 LL |     let _: usize = ()


### PR DESCRIPTION
The value passed in already has backticks surrounding the text.