### PR TITLE
Fix typo Arbintrary to Arbitrary

### DIFF
--- a/src/librustc_error_codes/error_codes/E0307.md
+++ b/src/librustc_error_codes/error_codes/E0307.md
@@ -64,7 +64,7 @@ impl Trait for Foo {
 }
 ```
 
-The nightly feature [Arbintrary self types][AST] extends the accepted
+The nightly feature [Arbitrary self types][AST] extends the accepted
 set of receiver types to also include any type that can dereference to
 `Self`:
 


### PR DESCRIPTION
Signed-off-by: Rustin-Liu <rustin.liu@gmail.com>

Closes #72122.