### PR TITLE
Disallow forbidden usage of non-ascii identifiers.

### DIFF
--- a/src/librustc_error_codes/error_codes.rs
+++ b/src/librustc_error_codes/error_codes.rs
@@ -436,6 +436,7 @@ E0750: include_str!("./error_codes/E0750.md"),
 E0751: include_str!("./error_codes/E0751.md"),
 E0752: include_str!("./error_codes/E0752.md"),
 E0753: include_str!("./error_codes/E0753.md"),
+E0754: include_str!("./error_codes/E0754.md"),
 ;
 //  E0006, // merged with E0005
 //  E0008, // cannot bind by-move into a pattern guard

--- a/src/librustc_error_codes/error_codes/E0754.md
+++ b/src/librustc_error_codes/error_codes/E0754.md
@@ -1,0 +1,33 @@
+An non-ascii identifier was used in an invalid context.
+
+Erroneous code example:
+
+```compile_fail,E0754
+# #![feature(non_ascii_idents)]
+
+mod řųśť;
+// ^ error!
+fn main() {}
+```
+
+```compile_fail,E0754
+# #![feature(non_ascii_idents)]
+
+#[no_mangle]
+fn řųśť() {}
+// ^ error!
+fn main() {}
+```
+
+Non-ascii can be used as module names if it is inline
+or a #\[path\] attribute is specified. For example:
+
+```
+# #![feature(non_ascii_idents)]
+
+mod řųśť {
+    const IS_GREAT: bool = true;
+}
+
+fn main() {}
+```

--- a/src/test/ui/rfc-2457/auxiliary/mod_file_nonascii_with_path_allowed-aux.rs
+++ b/src/test/ui/rfc-2457/auxiliary/mod_file_nonascii_with_path_allowed-aux.rs
@@ -1,0 +1,1 @@
+pub trait Foo {}

--- a/src/test/ui/rfc-2457/mod_file_nonascii_forbidden.rs
+++ b/src/test/ui/rfc-2457/mod_file_nonascii_forbidden.rs
@@ -1,0 +1,6 @@
+#![feature(non_ascii_idents)]
+
+mod řųśť; //~ trying to load file for
+//~^ file not found for
+
+fn main() {}

--- a/src/test/ui/rfc-2457/mod_file_nonascii_forbidden.stderr
+++ b/src/test/ui/rfc-2457/mod_file_nonascii_forbidden.stderr
@@ -1,0 +1,20 @@
+error[E0583]: file not found for module `řųśť`
+  --> $DIR/mod_file_nonascii_forbidden.rs:3:1
+   |
+LL | mod řųśť;
+   | ^^^^^^^^^
+   |
+   = help: to create the module `řųśť`, create file "$DIR/řųśť.rs"
+
+error[E0754]: trying to load file for module `řųśť` with non ascii identifer name
+  --> $DIR/mod_file_nonascii_forbidden.rs:3:5
+   |
+LL | mod řųśť;
+   |     ^^^^
+   |
+   = help: consider using `#[path]` attribute to specify filesystem path
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0583, E0754.
+For more information about an error, try `rustc --explain E0583`.

--- a/src/test/ui/rfc-2457/mod_file_nonascii_with_path_allowed.rs
+++ b/src/test/ui/rfc-2457/mod_file_nonascii_with_path_allowed.rs
@@ -1,0 +1,7 @@
+// check-pass
+#![feature(non_ascii_idents)]
+
+#[path="auxiliary/mod_file_nonascii_with_path_allowed-aux.rs"]
+mod řųśť;
+
+fn main() {}

--- a/src/test/ui/rfc-2457/mod_inline_nonascii_allowed.rs
+++ b/src/test/ui/rfc-2457/mod_inline_nonascii_allowed.rs
@@ -1,0 +1,8 @@
+// check-pass
+#![feature(non_ascii_idents)]
+
+mod řųśť {
+    const IS_GREAT: bool = true;
+}
+
+fn main() {}

--- a/src/test/ui/rfc-2457/no_mangle_nonascii_forbidden.rs
+++ b/src/test/ui/rfc-2457/no_mangle_nonascii_forbidden.rs
@@ -1,0 +1,6 @@
+#![feature(non_ascii_idents)]
+
+#[no_mangle]
+pub fn řųśť() {}  //~ `#[no_mangle]` requires ASCII identifier
+
+fn main() {}

--- a/src/test/ui/rfc-2457/no_mangle_nonascii_forbidden.stderr
+++ b/src/test/ui/rfc-2457/no_mangle_nonascii_forbidden.stderr
@@ -1,0 +1,9 @@
+error[E0754]: `#[no_mangle]` requires ASCII identifier
+  --> $DIR/no_mangle_nonascii_forbidden.rs:4:1
+   |
+LL | pub fn řųśť() {}
+   | ^^^^^^^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0754`.


### PR DESCRIPTION
Part of RFC2457, this tightens allowed identifiers back to ascii only in two situations.

r? @petrochenkov 