### PR TITLE
Improve compiler error message for wrong generic parameter order

### DIFF
--- a/src/test/ui/const-generics/const-arg-type-arg-misordered.stderr
+++ b/src/test/ui/const-generics/const-arg-type-arg-misordered.stderr
@@ -14,6 +14,7 @@ LL | fn foo<const N: usize>() -> Array<N, ()> {
    |                                   ^
    |
    = note: type arguments must be provided before constant arguments
+   = help: reorder the arguments: types, then consts: `<T, N>`
 
 error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui/suggestions/suggest-move-types.stderr
+++ b/src/test/ui/suggestions/suggest-move-types.stderr
@@ -125,6 +125,7 @@ LL | struct Cl<'a, 'b, 'c, T, U, V, M: ThreeWithLifetime<T, 'a, A=(), B=(), C=()
    |                                                        ^^
    |
    = note: lifetime arguments must be provided before type arguments
+   = help: reorder the arguments: lifetimes, then types: `<'a, 'b, 'c, T, U, V>`
 
 error[E0747]: lifetime provided when a type was expected
   --> $DIR/suggest-move-types.rs:82:56
@@ -133,6 +134,7 @@ LL | struct Dl<'a, 'b, 'c, T, U, V, M: ThreeWithLifetime<T, 'a, A=(), B=(), U, '
    |                                                        ^^
    |
    = note: lifetime arguments must be provided before type arguments
+   = help: reorder the arguments: lifetimes, then types: `<'a, 'b, 'c, T, U, V>`
 
 error: aborting due to 12 previous errors
 


### PR DESCRIPTION
- Added optional "help" parameter that shows a help message on the compiler error if required.
- Added a simple ordered parameter as a sample help.

@varkor will make more changes as required. Let me know if I'm heading in the right direction.

Fixes #68437

r? @varkor 