### PR TITLE
Fix going back in history to a search result page on firefox

### DIFF
--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -2703,3 +2703,9 @@ function focusSearchBar() {
 function defocusSearchBar() {
     getSearchInput().blur();
 }
+
+// This is required in firefox. Explanations: when going back in the history, firefox doesn't re-run
+// the JS, therefore preventing rustdoc from setting a few things required to be able to reload the
+// previous search results (if you navigated to a search result with the keyboard, pressed enter on
+// it to navigate to that result, and then came back to this page).
+window.onunload = function(){};


### PR DESCRIPTION
This bug was actually firefox not re-running JS script when you go back in history. To trigger it on the current docs:

 * Make a search
 * Pick an element (which isn't on the same page as the current element!)
 * Go back in history

Instead of having the search results, you'll see the normal doc page. You can find a small explanation about it [here](http://web.archive.org/web/20100428053932/http://www.firefoxanswer.com/firefox/672-firefoxanswer.html).

r? @kinnison 

cc @ollie27 