### PR TITLE
Continue lowering for unsupported async generator instead of returning an error.

### DIFF
--- a/src/librustc_ast_lowering/expr.rs
+++ b/src/librustc_ast_lowering/expr.rs
@@ -1021,7 +1021,6 @@ impl<'hir> LoweringContext<'_, 'hir> {
                     "`async` generators are not yet supported"
                 )
                 .emit();
-                return hir::ExprKind::Err;
             }
             None => self.generator_kind = Some(hir::GeneratorKind::Gen),
         }

--- a/src/librustc_middle/ty/context.rs
+++ b/src/librustc_middle/ty/context.rs
@@ -1114,16 +1114,13 @@ impl<'tcx> TyCtxt<'tcx> {
 
         let mut trait_map: FxHashMap<_, FxHashMap<_, _>> = FxHashMap::default();
         for (k, v) in resolutions.trait_map {
-            // FIXME(#71104) Should really be using just `node_id_to_hir_id` but
-            // some `NodeId` do not seem to have a corresponding HirId.
-            if let Some(hir_id) = definitions.opt_node_id_to_hir_id(k) {
-                let map = trait_map.entry(hir_id.owner).or_default();
-                let v = v
-                    .into_iter()
-                    .map(|tc| tc.map_import_ids(|id| definitions.node_id_to_hir_id(id)))
-                    .collect();
-                map.insert(hir_id.local_id, StableVec::new(v));
-            }
+            let hir_id = definitions.node_id_to_hir_id(k);
+            let map = trait_map.entry(hir_id.owner).or_default();
+            let v = v
+                .into_iter()
+                .map(|tc| tc.map_import_ids(|id| definitions.node_id_to_hir_id(id)))
+                .collect();
+            map.insert(hir_id.local_id, StableVec::new(v));
         }
 
         GlobalCtxt {


### PR DESCRIPTION
This way the hir is "valid" and we can remove one more call to
`opt_node_id_to_hir_id` but an error is still emitted.

This is another partial fix for #71104

r? @eddyb 