### PR TITLE
abort_internal is safe

### DIFF
--- a/src/libstd/alloc.rs
+++ b/src/libstd/alloc.rs
@@ -279,7 +279,7 @@ pub fn rust_oom(layout: Layout) -> ! {
     let hook: fn(Layout) =
         if hook.is_null() { default_alloc_error_hook } else { unsafe { mem::transmute(hook) } };
     hook(layout);
-    unsafe { crate::sys::abort_internal() }
+    crate::process::abort()
 }
 
 #[cfg(not(test))]

--- a/src/libstd/process.rs
+++ b/src/libstd/process.rs
@@ -1620,7 +1620,7 @@ pub fn exit(code: i32) -> ! {
 /// [panic hook]: ../../std/panic/fn.set_hook.html
 #[stable(feature = "process_abort", since = "1.17.0")]
 pub fn abort() -> ! {
-    unsafe { crate::sys::abort_internal() };
+    crate::sys::abort_internal();
 }
 
 /// Returns the OS-assigned process identifier associated with this process.

--- a/src/libstd/sys/cloudabi/mod.rs
+++ b/src/libstd/sys/cloudabi/mod.rs
@@ -51,8 +51,11 @@ pub fn decode_error_kind(errno: i32) -> ErrorKind {
     }
 }
 
-pub unsafe fn abort_internal() -> ! {
-    core::intrinsics::abort();
+pub fn abort_internal() -> ! {
+    #[cfg_attr(not(bootstrap), allow(unused_unsafe))] // remove `unsafe` on bootstrap bump
+    unsafe {
+        core::intrinsics::abort();
+    }
 }
 
 pub use libc::strlen;

--- a/src/libstd/sys/hermit/mod.rs
+++ b/src/libstd/sys/hermit/mod.rs
@@ -74,8 +74,10 @@ pub extern "C" fn floor(x: f64) -> f64 {
     unsafe { intrinsics::floorf64(x) }
 }
 
-pub unsafe fn abort_internal() -> ! {
-    abi::abort();
+pub fn abort_internal() -> ! {
+    unsafe {
+        abi::abort();
+    }
 }
 
 // FIXME: just a workaround to test the system
@@ -88,7 +90,7 @@ pub fn hashmap_random_keys() -> (u64, u64) {
 #[cfg(not(test))]
 #[no_mangle]
 // NB. used by both libunwind and libpanic_abort
-pub unsafe extern "C" fn __rust_abort() {
+pub extern "C" fn __rust_abort() {
     abort_internal();
 }
 

--- a/src/libstd/sys/sgx/mod.rs
+++ b/src/libstd/sys/sgx/mod.rs
@@ -124,7 +124,7 @@ pub unsafe fn strlen(mut s: *const c_char) -> usize {
     return n;
 }
 
-pub unsafe fn abort_internal() -> ! {
+pub fn abort_internal() -> ! {
     abi::usercalls::exit(true)
 }
 
@@ -133,7 +133,7 @@ pub unsafe fn abort_internal() -> ! {
 #[cfg(not(test))]
 #[no_mangle]
 // NB. used by both libunwind and libpanic_abort
-pub unsafe extern "C" fn __rust_abort() {
+pub extern "C" fn __rust_abort() {
     abort_internal();
 }
 

--- a/src/libstd/sys/unix/mod.rs
+++ b/src/libstd/sys/unix/mod.rs
@@ -163,6 +163,6 @@ where
 // understandable error message like "Abort trap" rather than "Illegal
 // instruction" that intrinsics::abort would cause, as intrinsics::abort is
 // implemented as an illegal instruction.
-pub unsafe fn abort_internal() -> ! {
-    libc::abort()
+pub fn abort_internal() -> ! {
+    unsafe { libc::abort() }
 }

--- a/src/libstd/sys/vxworks/mod.rs
+++ b/src/libstd/sys/vxworks/mod.rs
@@ -108,6 +108,6 @@ where
 // understandable error message like "Abort trap" rather than "Illegal
 // instruction" that intrinsics::abort would cause, as intrinsics::abort is
 // implemented as an illegal instruction.
-pub unsafe fn abort_internal() -> ! {
-    libc::abort()
+pub fn abort_internal() -> ! {
+    unsafe { libc::abort() }
 }

--- a/src/libstd/sys/wasi/mod.rs
+++ b/src/libstd/sys/wasi/mod.rs
@@ -100,8 +100,8 @@ pub unsafe fn strlen(mut s: *const c_char) -> usize {
     return n;
 }
 
-pub unsafe fn abort_internal() -> ! {
-    libc::abort()
+pub fn abort_internal() -> ! {
+    unsafe { libc::abort() }
 }
 
 pub fn hashmap_random_keys() -> (u64, u64) {

--- a/src/libstd/sys/wasm/mod.rs
+++ b/src/libstd/sys/wasm/mod.rs
@@ -81,8 +81,8 @@ pub unsafe fn strlen(mut s: *const c_char) -> usize {
     return n;
 }
 
-pub unsafe fn abort_internal() -> ! {
-    crate::arch::wasm32::unreachable()
+pub fn abort_internal() -> ! {
+    unsafe { crate::arch::wasm32::unreachable() }
 }
 
 // We don't have randomness yet, but I totally used a random number generator to

--- a/src/libstd/sys/windows/mod.rs
+++ b/src/libstd/sys/windows/mod.rs
@@ -308,11 +308,14 @@ pub fn dur2timeout(dur: Duration) -> c::DWORD {
 //
 // https://docs.microsoft.com/en-us/cpp/intrinsics/fastfail
 #[allow(unreachable_code)]
-pub unsafe fn abort_internal() -> ! {
+pub fn abort_internal() -> ! {
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    {
+    unsafe {
         llvm_asm!("int $$0x29" :: "{ecx}"(7) ::: volatile); // 7 is FAST_FAIL_FATAL_APP_EXIT
         crate::intrinsics::unreachable();
     }
-    crate::intrinsics::abort();
+    #[cfg_attr(not(bootstrap), allow(unused_unsafe))] // remove `unsafe` on bootstrap bump
+    unsafe {
+        crate::intrinsics::abort();
+    }
 }

--- a/src/libstd/sys_common/util.rs
+++ b/src/libstd/sys_common/util.rs
@@ -16,9 +16,7 @@ pub fn dumb_print(args: fmt::Arguments<'_>) {
 
 pub fn abort(args: fmt::Arguments<'_>) -> ! {
     dumb_print(format_args!("fatal runtime error: {}\n", args));
-    unsafe {
-        crate::sys::abort_internal();
-    }
+    crate::sys::abort_internal();
 }
 
 #[allow(dead_code)] // stack overflow detection not enabled on all platforms


### PR DESCRIPTION
`sys::abort_internal` is stably exposed as a safe function. Forward that assumption "inwards" to the `sys` module by making the function itself safe, too.

This corresponds to what https://github.com/rust-lang/rust/pull/72204 did for the intrinsic. We should probably wait until that lands because some of the intrinsic calls in this PR might then need adjustments.