### PR TITLE
Add newer rust versions to linker-plugin-lto.md

### DIFF
--- a/src/doc/rustc/src/linker-plugin-lto.md
+++ b/src/doc/rustc/src/linker-plugin-lto.md
@@ -100,11 +100,17 @@ LLVM. However, the approximation is usually reliable.
 
 The following table shows known good combinations of toolchain versions.
 
-|           |  Clang 7  |  Clang 8  |
-|-----------|-----------|-----------|
-| Rust 1.34 |     ✗     |     ✓     |
-| Rust 1.35 |     ✗     |     ✓     |
-| Rust 1.36 |     ✗     |     ✓     |
-| Rust 1.37 |     ✗     |     ✓     |
+|           |  Clang 7  |  Clang 8  |  Clang 9  |
+|-----------|-----------|-----------|-----------|
+| Rust 1.34 |     ✗     |     ✓     |     ✗     |
+| Rust 1.35 |     ✗     |     ✓     |     ✗     |
+| Rust 1.36 |     ✗     |     ✓     |     ✗     |
+| Rust 1.37 |     ✗     |     ✓     |     ✗     |
+| Rust 1.38 |     ✗     |     ✗     |     ✓     |
+| Rust 1.39 |     ✗     |     ✗     |     ✓     |
+| Rust 1.40 |     ✗     |     ✗     |     ✓     |
+| Rust 1.41 |     ✗     |     ✗     |     ✓     |
+| Rust 1.42 |     ✗     |     ✗     |     ✓     |
+| Rust 1.43 |     ✗     |     ✗     |     ✓     |
 
 Note that the compatibility policy for this feature might change in the future.


### PR DESCRIPTION
Hi,
This doc got a bit out of date,
it's hosted here: https://doc.rust-lang.org/rustc/linker-plugin-lto.html
you can check the versions I've added via:
```bash
$ rustup install 1.38.0
$ rustc +1.38.0 -vV
rustc 1.38.0 (625451e37 2019-09-23)
binary: rustc
commit-hash: 625451e376bb2e5283fc4741caa0a3e8a2ca4d54
commit-date: 2019-09-23
host: x86_64-unknown-linux-gnu
release: 1.38.0
LLVM version: 9.0

$ rustup install 1.43.1
$ rustc +1.43.1 -vV
rustc 1.43.1 (8d69840ab 2020-05-04)
binary: rustc
commit-hash: 8d69840ab92ea7f4d323420088dd8c9775f180cd
commit-date: 2020-05-04
host: x86_64-unknown-linux-gnu
release: 1.43.1
LLVM version: 9.0
```