### PR TITLE
Add core::future::{poll_fn, PollFn}

### DIFF
--- a/src/libcore/future/mod.rs
+++ b/src/libcore/future/mod.rs
@@ -11,6 +11,7 @@ use crate::{
 
 mod future;
 mod pending;
+mod poll_fn;
 mod ready;
 
 #[stable(feature = "futures_api", since = "1.36.0")]
@@ -20,6 +21,9 @@ pub use self::future::Future;
 pub use pending::{pending, Pending};
 #[unstable(feature = "future_readiness_fns", issue = "70921")]
 pub use ready::{ready, Ready};
+
+#[unstable(feature = "future_poll_fn", issue = "72302")]
+pub use poll_fn::{poll_fn, PollFn};
 
 /// This type is needed because:
 ///

--- a/src/libcore/future/poll_fn.rs
+++ b/src/libcore/future/poll_fn.rs
@@ -1,0 +1,66 @@
+use crate::fmt;
+use crate::future::Future;
+use crate::pin::Pin;
+use crate::task::{Context, Poll};
+
+/// Creates a future that wraps a function returning `Poll`.
+///
+/// Polling the future delegates to the wrapped function.
+///
+/// # Examples
+///
+/// ```
+/// #![feature(future_poll_fn)]
+/// # async fn run() {
+/// use core::future::poll_fn;
+/// use core::task::{Context, Poll};
+///
+/// fn read_line(_cx: &mut Context<'_>) -> Poll<String> {
+///     Poll::Ready("Hello, World!".into())
+/// }
+///
+/// let read_future = poll_fn(read_line);
+/// assert_eq!(read_future.await, "Hello, World!".to_owned());
+/// # };
+/// ```
+#[unstable(feature = "future_poll_fn", issue = "72302")]
+pub fn poll_fn<T, F>(f: F) -> PollFn<F>
+where
+    F: FnMut(&mut Context<'_>) -> Poll<T>,
+{
+    PollFn { f }
+}
+
+/// A Future that wraps a function returning `Poll`.
+///
+/// This `struct` is created by the [`poll_fn`] function. See its
+/// documentation for more.
+///
+/// [`poll_fn`]: fn.poll_fn.html
+#[must_use = "futures do nothing unless you `.await` or poll them"]
+#[unstable(feature = "future_poll_fn", issue = "72302")]
+pub struct PollFn<F> {
+    f: F,
+}
+
+#[unstable(feature = "future_poll_fn", issue = "72302")]
+impl<F> Unpin for PollFn<F> {}
+
+#[unstable(feature = "future_poll_fn", issue = "72302")]
+impl<F> fmt::Debug for PollFn<F> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PollFn").finish()
+    }
+}
+
+#[unstable(feature = "future_poll_fn", issue = "72302")]
+impl<T, F> Future for PollFn<F>
+where
+    F: FnMut(&mut Context<'_>) -> Poll<T>,
+{
+    type Output = T;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<T> {
+        (&mut self.f)(cx)
+    }
+}


### PR DESCRIPTION
This is a sibling PR to #70834, adding `future::poll_fn`. This is a small helper function that helps bridge the gap between "poll state machines" and "async/await". It was first introduced in [futures@0.1.7](https://docs.rs/futures/0.1.7/futures/future/fn.poll_fn.html) in December of 2016, and has been tried and tested as part of the ecosystem for the past 3.5 years.

## Implementation

Much of the same reasoning from #70834 applies: by returning a concrete struct rather than an `async fn` we get to mark the future as `Unpin`. It also becomes named which allows storing it in structs without boxing. This implementation has been modified from the implementation in `futures-rs`.

## References
- [`futures::future::poll_fn`](https://docs.rs/futures/0.3.5/futures/future/fn.poll_fn.html)
- [`async_std::future::poll_fn`](https://docs.rs/async-std/1.5.0/async_std/future/fn.poll_fn.html)