### PR TITLE
rustc_target: Avoid an inappropriate use of `post_link_objects`

### DIFF
--- a/src/librustc_target/spec/x86_64_fortanix_unknown_sgx.rs
+++ b/src/librustc_target/spec/x86_64_fortanix_unknown_sgx.rs
@@ -1,6 +1,6 @@
 use std::iter;
 
-use super::{crt_objects, LinkerFlavor, LldFlavor, PanicStrategy, Target, TargetOptions};
+use super::{LinkerFlavor, LldFlavor, PanicStrategy, Target, TargetOptions};
 
 pub fn target() -> Result<Target, String> {
     const PRE_LINK_ARGS: &[&str] = &[
@@ -68,8 +68,6 @@ pub fn target() -> Result<Target, String> {
             PRE_LINK_ARGS.iter().cloned().map(String::from).collect(),
         ))
         .collect(),
-        // FIXME: libunwind is certainly not a CRT object, use some other option instead.
-        post_link_objects: crt_objects::all("libunwind.a"),
         override_export_symbols: Some(EXPORT_SYMBOLS.iter().cloned().map(String::from).collect()),
         relax_elf_relocations: true,
         ..Default::default()

--- a/src/libunwind/lib.rs
+++ b/src/libunwind/lib.rs
@@ -27,3 +27,7 @@ extern "C" {}
 #[link(name = "gcc_eh", kind = "static-nobundle", cfg(target_feature = "crt-static"))]
 #[link(name = "gcc_s", cfg(not(target_feature = "crt-static")))]
 extern "C" {}
+
+#[cfg(all(target_vendor = "fortanix", target_env = "sgx"))]
+#[link(name = "unwind", kind = "static-nobundle")]
+extern "C" {}


### PR DESCRIPTION
It isn't supposed to be used for linking libraries.
Also linking libunwind unconditionally (and not together with the `src/libunwind` crate) is suspicious.

@jethrogb @VardhanThigle
Could you verify that it works as expected?