### PR TITLE
use the new interface to initialize conditional variables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1439,9 +1439,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61565ff7aaace3525556587bd2dc31d4a07071957be715e63ce7b1eccf51a8f4"
+checksum = "91780f809e750b0a89f5544be56617ff6b1227ee485bcb06ebe10cdf89bd3b71"
 dependencies = [
  "compiler_builtins",
  "libc",

--- a/src/libstd/Cargo.toml
+++ b/src/libstd/Cargo.toml
@@ -41,7 +41,7 @@ dlmalloc = { version = "0.1", features = ['rustc-dep-of-std'] }
 fortanix-sgx-abi = { version = "0.3.2", features = ['rustc-dep-of-std'] }
 
 [target.'cfg(all(any(target_arch = "x86_64", target_arch = "aarch64"), target_os = "hermit"))'.dependencies]
-hermit-abi = { version = "0.1.12", features = ['rustc-dep-of-std'] }
+hermit-abi = { version = "0.1.13", features = ['rustc-dep-of-std'] }
 
 [target.wasm32-wasi.dependencies]
 wasi = { version = "0.9.0", features = ['rustc-dep-of-std'], default-features = false }

--- a/src/libstd/sys/hermit/condvar.rs
+++ b/src/libstd/sys/hermit/condvar.rs
@@ -9,9 +9,7 @@ pub struct Condvar {
 
 impl Condvar {
     pub const fn new() -> Condvar {
-        Condvar {
-            identifier: 0,
-        }
+        Condvar { identifier: 0 }
     }
 
     pub unsafe fn init(&mut self) {

--- a/src/libstd/sys/hermit/condvar.rs
+++ b/src/libstd/sys/hermit/condvar.rs
@@ -9,12 +9,13 @@ pub struct Condvar {
 
 impl Condvar {
     pub const fn new() -> Condvar {
-        Condvar { identifier: 0 }
+        Condvar {
+            identifier: 0,
+        }
     }
 
-    #[inline]
     pub unsafe fn init(&mut self) {
-        // nothing to do
+        let _ = abi::init_queue(self.id());
     }
 
     pub unsafe fn notify_one(&self) {
@@ -50,7 +51,6 @@ impl Condvar {
         ret
     }
 
-    #[inline]
     pub unsafe fn destroy(&self) {
         let _ = abi::destroy_queue(self.id());
     }


### PR DESCRIPTION
HermitCore introduce a new interface to intialize conditional variables.
Consequently, minor changes are required to support this interface.