### PR TITLE
Stability annotations on generic parameters (take 2)

### DIFF
--- a/src/librustc_metadata/rmeta/encoder.rs
+++ b/src/librustc_metadata/rmeta/encoder.rs
@@ -1612,6 +1612,9 @@ impl EncodeContext<'tcx> {
                         EntryKind::TypeParam,
                         default.is_some(),
                     );
+                    if default.is_some() {
+                        self.encode_stability(def_id.to_def_id());
+                    }
                 }
                 GenericParamKind::Const { .. } => {
                     self.encode_info_for_generic_param(
@@ -1619,6 +1622,7 @@ impl EncodeContext<'tcx> {
                         EntryKind::ConstParam,
                         true,
                     );
+                    // FIXME(const_generics:defaults)
                 }
             }
         }

--- a/src/librustc_middle/middle/stability.rs
+++ b/src/librustc_middle/middle/stability.rs
@@ -377,7 +377,7 @@ impl<'tcx> TyCtxt<'tcx> {
     /// This function will also check if the item is deprecated.
     /// If so, and `id` is not `None`, a deprecated lint attached to `id` will be emitted.
     pub fn check_stability(self, def_id: DefId, id: Option<HirId>, span: Span) {
-        self.check_stability_internal(def_id, id, span, |span, def_id| {
+        self.check_optional_stability(def_id, id, span, |span, def_id| {
             // The API could be uncallable for other reasons, for example when a private module
             // was referenced.
             self.sess.delay_span_bug(span, &format!("encountered unmarked API: {:?}", def_id));
@@ -391,7 +391,10 @@ impl<'tcx> TyCtxt<'tcx> {
     ///
     /// This function will also check if the item is deprecated.
     /// If so, and `id` is not `None`, a deprecated lint attached to `id` will be emitted.
-    pub fn check_stability_internal(
+    ///
+    /// The `unmarked` closure is called definitions without a stability annotation.
+    /// This is needed for generic parameters, since they may not be marked when used in a staged_api crate.
+    pub fn check_optional_stability(
         self,
         def_id: DefId,
         id: Option<HirId>,

--- a/src/librustc_middle/middle/stability.rs
+++ b/src/librustc_middle/middle/stability.rs
@@ -384,16 +384,10 @@ impl<'tcx> TyCtxt<'tcx> {
         })
     }
 
-    /// Checks if an item is stable or error out.
-    ///
-    /// If the item defined by `def_id` is unstable and the corresponding `#![feature]` does not
-    /// exist, emits an error.
-    ///
-    /// This function will also check if the item is deprecated.
-    /// If so, and `id` is not `None`, a deprecated lint attached to `id` will be emitted.
-    ///
-    /// The `unmarked` closure is called definitions without a stability annotation.
-    /// This is needed for generic parameters, since they may not be marked when used in a staged_api crate.
+    /// Like `check_stability`, except that we permit items to have custom behaviour for
+    /// missing stability attributes (not necessarily just emit a `bug!`). This is necessary
+    /// for default generic parameters, which only have stability attributes if they were
+    /// added after the type on which they're defined.
     pub fn check_optional_stability(
         self,
         def_id: DefId,

--- a/src/librustc_middle/middle/stability.rs
+++ b/src/librustc_middle/middle/stability.rs
@@ -280,15 +280,9 @@ impl<'tcx> TyCtxt<'tcx> {
     /// If `id` is `Some(_)`, this function will also check if the item at `def_id` has been
     /// deprecated. If the item is indeed deprecated, we will emit a deprecation lint attached to
     /// `id`.
-    pub fn eval_stability(
-        self,
-        def_id: DefId,
-        id: Option<HirId>,
-        span: Span,
-        check_deprecation: bool,
-    ) -> EvalResult {
+    pub fn eval_stability(self, def_id: DefId, id: Option<HirId>, span: Span) -> EvalResult {
         // Deprecated attributes apply in-crate and cross-crate.
-        if let (Some(id), true) = (id, check_deprecation) {
+        if let Some(id) = id {
             if let Some(depr_entry) = self.lookup_deprecation_entry(def_id) {
                 let parent_def_id = self.hir().local_def_id(self.hir().get_parent_item(id));
                 let skip = self
@@ -380,10 +374,10 @@ impl<'tcx> TyCtxt<'tcx> {
     /// If the item defined by `def_id` is unstable and the corresponding `#![feature]` does not
     /// exist, emits an error.
     ///
-    /// Additionally, this function will also check if the item is deprecated. If so, and `id` is
-    /// not `None`, a deprecated lint attached to `id` will be emitted.
+    /// This function will also check if the item is deprecated.
+    /// If so, and `id` is not `None`, a deprecated lint attached to `id` will be emitted.
     pub fn check_stability(self, def_id: DefId, id: Option<HirId>, span: Span) {
-        self.check_stability_internal(def_id, id, span, true, |span, def_id| {
+        self.check_stability_internal(def_id, id, span, |span, def_id| {
             // The API could be uncallable for other reasons, for example when a private module
             // was referenced.
             self.sess.delay_span_bug(span, &format!("encountered unmarked API: {:?}", def_id));
@@ -395,14 +389,13 @@ impl<'tcx> TyCtxt<'tcx> {
     /// If the item defined by `def_id` is unstable and the corresponding `#![feature]` does not
     /// exist, emits an error.
     ///
-    /// Additionally when `inherit_dep` is `true`, this function will also check if the item is deprecated. If so, and `id` is
-    /// not `None`, a deprecated lint attached to `id` will be emitted.
+    /// This function will also check if the item is deprecated.
+    /// If so, and `id` is not `None`, a deprecated lint attached to `id` will be emitted.
     pub fn check_stability_internal(
         self,
         def_id: DefId,
         id: Option<HirId>,
         span: Span,
-        check_deprecation: bool,
         unmarked: impl FnOnce(Span, DefId) -> (),
     ) {
         let soft_handler = |lint, span, msg: &_| {
@@ -410,7 +403,7 @@ impl<'tcx> TyCtxt<'tcx> {
                 lint.build(msg).emit()
             })
         };
-        match self.eval_stability(def_id, id, span, check_deprecation) {
+        match self.eval_stability(def_id, id, span) {
             EvalResult::Allow => {}
             EvalResult::Deny { feature, reason, issue, is_soft } => {
                 report_unstable(self.sess, feature, reason, issue, is_soft, span, soft_handler)

--- a/src/librustc_middle/middle/stability.rs
+++ b/src/librustc_middle/middle/stability.rs
@@ -280,9 +280,15 @@ impl<'tcx> TyCtxt<'tcx> {
     /// If `id` is `Some(_)`, this function will also check if the item at `def_id` has been
     /// deprecated. If the item is indeed deprecated, we will emit a deprecation lint attached to
     /// `id`.
-    pub fn eval_stability(self, def_id: DefId, id: Option<HirId>, span: Span) -> EvalResult {
+    pub fn eval_stability(
+        self,
+        def_id: DefId,
+        id: Option<HirId>,
+        span: Span,
+        check_deprecation: bool,
+    ) -> EvalResult {
         // Deprecated attributes apply in-crate and cross-crate.
-        if let Some(id) = id {
+        if let (Some(id), true) = (id, check_deprecation) {
             if let Some(depr_entry) = self.lookup_deprecation_entry(def_id) {
                 let parent_def_id = self.hir().local_def_id(self.hir().get_parent_item(id));
                 let skip = self
@@ -377,21 +383,39 @@ impl<'tcx> TyCtxt<'tcx> {
     /// Additionally, this function will also check if the item is deprecated. If so, and `id` is
     /// not `None`, a deprecated lint attached to `id` will be emitted.
     pub fn check_stability(self, def_id: DefId, id: Option<HirId>, span: Span) {
+        self.check_stability_internal(def_id, id, span, true, |span, def_id| {
+            // The API could be uncallable for other reasons, for example when a private module
+            // was referenced.
+            self.sess.delay_span_bug(span, &format!("encountered unmarked API: {:?}", def_id));
+        })
+    }
+
+    /// Checks if an item is stable or error out.
+    ///
+    /// If the item defined by `def_id` is unstable and the corresponding `#![feature]` does not
+    /// exist, emits an error.
+    ///
+    /// Additionally when `inherit_dep` is `true`, this function will also check if the item is deprecated. If so, and `id` is
+    /// not `None`, a deprecated lint attached to `id` will be emitted.
+    pub fn check_stability_internal(
+        self,
+        def_id: DefId,
+        id: Option<HirId>,
+        span: Span,
+        check_deprecation: bool,
+        unmarked: impl FnOnce(Span, DefId) -> (),
+    ) {
         let soft_handler = |lint, span, msg: &_| {
             self.struct_span_lint_hir(lint, id.unwrap_or(hir::CRATE_HIR_ID), span, |lint| {
                 lint.build(msg).emit()
             })
         };
-        match self.eval_stability(def_id, id, span) {
+        match self.eval_stability(def_id, id, span, check_deprecation) {
             EvalResult::Allow => {}
             EvalResult::Deny { feature, reason, issue, is_soft } => {
                 report_unstable(self.sess, feature, reason, issue, is_soft, span, soft_handler)
             }
-            EvalResult::Unmarked => {
-                // The API could be uncallable for other reasons, for example when a private module
-                // was referenced.
-                self.sess.delay_span_bug(span, &format!("encountered unmarked API: {:?}", def_id));
-            }
+            EvalResult::Unmarked => unmarked(span, def_id),
         }
     }
 

--- a/src/librustc_passes/stability.rs
+++ b/src/librustc_passes/stability.rs
@@ -36,8 +36,12 @@ enum AnnotationKind {
     Container,
 }
 
-/// Inheriting deprecations Nested items causes duplicate warnings.
-/// Inheriting the deprecation of `Foo<T>` onto the parameter `T`, would cause a duplicate warnings.
+/// Whether to inherit deprecation flags for nested items. In most cases, we do want to inherit
+/// deprecation, because nested items rarely have individual deprecation attributes, and so
+/// should be treated as deprecated if their parent is. However, default generic parameters
+/// have separate deprecation attributes from their parents, so we do not wish to inherit
+/// deprecation in this case. For example, inheriting deprecation for `T` in `Foo<T>`
+/// would cause a duplicate warning arising from both `Foo` and `T` being deprecated.
 #[derive(PartialEq, Copy, Clone)]
 enum InheritDeprecation {
     Yes,

--- a/src/librustc_passes/stability.rs
+++ b/src/librustc_passes/stability.rs
@@ -55,6 +55,7 @@ impl<'a, 'tcx> Annotator<'a, 'tcx> {
         attrs: &[Attribute],
         item_sp: Span,
         kind: AnnotationKind,
+        inherit_deprecation: bool,
         visit_children: F,
     ) where
         F: FnOnce(&mut Self),
@@ -65,6 +66,7 @@ impl<'a, 'tcx> Annotator<'a, 'tcx> {
                 attrs,
                 item_sp,
                 kind,
+                inherit_deprecation,
                 visit_children,
             );
             return;
@@ -112,8 +114,8 @@ impl<'a, 'tcx> Annotator<'a, 'tcx> {
             // If parent is deprecated and we're not, inherit this by merging
             // deprecated_since and its reason.
             if let Some(parent_stab) = self.parent_stab {
-                if
-                    parent_stab.rustc_depr.is_some()
+                if inherit_deprecation
+                    && parent_stab.rustc_depr.is_some()
                     && stab.rustc_depr.is_none()
                 {
                     stab.rustc_depr = parent_stab.rustc_depr.clone()
@@ -166,7 +168,7 @@ impl<'a, 'tcx> Annotator<'a, 'tcx> {
         if stab.is_none() {
             debug!("annotate: stab not found, parent = {:?}", self.parent_stab);
             if let Some(stab) = self.parent_stab {
-                if stab.level.is_unstable() {
+                if inherit_deprecation && stab.level.is_unstable() {
                     self.index.stab_map.insert(hir_id, stab);
                 }
             }
@@ -209,6 +211,7 @@ impl<'a, 'tcx> Annotator<'a, 'tcx> {
         attrs: &[Attribute],
         item_sp: Span,
         kind: AnnotationKind,
+        inherit_deprecation: bool,
         visit_children: impl FnOnce(&mut Self),
     ) {
         // Emit errors for non-staged-api crates.
@@ -236,7 +239,7 @@ impl<'a, 'tcx> Annotator<'a, 'tcx> {
         // Propagate unstability.  This can happen even for non-staged-api crates in case
         // -Zforce-unstable-if-unmarked is set.
         if let Some(stab) = self.parent_stab {
-            if stab.level.is_unstable() {
+            if inherit_deprecation && stab.level.is_unstable() {
                 self.index.stab_map.insert(hir_id, stab);
             }
         }
@@ -294,6 +297,7 @@ impl<'a, 'tcx> Visitor<'tcx> for Annotator<'a, 'tcx> {
                         &i.attrs,
                         i.span,
                         AnnotationKind::Required,
+                        true,
                         |_| {},
                     )
                 }
@@ -301,12 +305,12 @@ impl<'a, 'tcx> Visitor<'tcx> for Annotator<'a, 'tcx> {
             _ => {}
         }
 
-        self.annotate(i.hir_id, &i.attrs, i.span, kind, |v| intravisit::walk_item(v, i));
+        self.annotate(i.hir_id, &i.attrs, i.span, kind, true, |v| intravisit::walk_item(v, i));
         self.in_trait_impl = orig_in_trait_impl;
     }
 
     fn visit_trait_item(&mut self, ti: &'tcx hir::TraitItem<'tcx>) {
-        self.annotate(ti.hir_id, &ti.attrs, ti.span, AnnotationKind::Required, |v| {
+        self.annotate(ti.hir_id, &ti.attrs, ti.span, AnnotationKind::Required, true, |v| {
             intravisit::walk_trait_item(v, ti);
         });
     }
@@ -314,19 +318,20 @@ impl<'a, 'tcx> Visitor<'tcx> for Annotator<'a, 'tcx> {
     fn visit_impl_item(&mut self, ii: &'tcx hir::ImplItem<'tcx>) {
         let kind =
             if self.in_trait_impl { AnnotationKind::Prohibited } else { AnnotationKind::Required };
-        self.annotate(ii.hir_id, &ii.attrs, ii.span, kind, |v| {
+        self.annotate(ii.hir_id, &ii.attrs, ii.span, kind, true, |v| {
             intravisit::walk_impl_item(v, ii);
         });
     }
 
     fn visit_variant(&mut self, var: &'tcx Variant<'tcx>, g: &'tcx Generics<'tcx>, item_id: HirId) {
-        self.annotate(var.id, &var.attrs, var.span, AnnotationKind::Required, |v| {
+        self.annotate(var.id, &var.attrs, var.span, AnnotationKind::Required, true, |v| {
             if let Some(ctor_hir_id) = var.data.ctor_hir_id() {
                 v.annotate(
                     ctor_hir_id,
                     &var.attrs,
                     var.span,
                     AnnotationKind::Required,
+                    true,
                     |_| {},
                 );
             }
@@ -336,19 +341,19 @@ impl<'a, 'tcx> Visitor<'tcx> for Annotator<'a, 'tcx> {
     }
 
     fn visit_struct_field(&mut self, s: &'tcx StructField<'tcx>) {
-        self.annotate(s.hir_id, &s.attrs, s.span, AnnotationKind::Required, |v| {
+        self.annotate(s.hir_id, &s.attrs, s.span, AnnotationKind::Required, true, |v| {
             intravisit::walk_struct_field(v, s);
         });
     }
 
     fn visit_foreign_item(&mut self, i: &'tcx hir::ForeignItem<'tcx>) {
-        self.annotate(i.hir_id, &i.attrs, i.span, AnnotationKind::Required, |v| {
+        self.annotate(i.hir_id, &i.attrs, i.span, AnnotationKind::Required, true, |v| {
             intravisit::walk_foreign_item(v, i);
         });
     }
 
     fn visit_macro_def(&mut self, md: &'tcx hir::MacroDef<'tcx>) {
-        self.annotate(md.hir_id, &md.attrs, md.span, AnnotationKind::Required, |_| {});
+        self.annotate(md.hir_id, &md.attrs, md.span, AnnotationKind::Required, true, |_| {});
     }
 
     fn visit_generic_param(&mut self, p: &'tcx hir::GenericParam<'tcx>) {
@@ -360,7 +365,7 @@ impl<'a, 'tcx> Visitor<'tcx> for Annotator<'a, 'tcx> {
             _ => AnnotationKind::Prohibited,
         };
 
-        self.annotate(p.hir_id, &p.attrs, p.span, kind, |v| {
+        self.annotate(p.hir_id, &p.attrs, p.span, kind, false, |v| {
             intravisit::walk_generic_param(v, p);
         });
     }
@@ -503,6 +508,7 @@ fn new_index(tcx: TyCtxt<'tcx>) -> Index<'tcx> {
             &krate.item.attrs,
             krate.item.span,
             AnnotationKind::Required,
+            true,
             |v| intravisit::walk_crate(v, krate),
         );
     }

--- a/src/librustc_passes/stability.rs
+++ b/src/librustc_passes/stability.rs
@@ -36,6 +36,20 @@ enum AnnotationKind {
     Container,
 }
 
+/// Inheriting deprecations Nested items causes duplicate warnings.
+/// Inheriting the deprecation of `Foo<T>` onto the parameter `T`, would cause a duplicate warnings.
+#[derive(PartialEq, Copy, Clone)]
+enum InheritDeprecation {
+    Yes,
+    No,
+}
+
+impl InheritDeprecation {
+    fn yes(&self) -> bool {
+        *self == InheritDeprecation::Yes
+    }
+}
+
 // A private tree-walker for producing an Index.
 struct Annotator<'a, 'tcx> {
     tcx: TyCtxt<'tcx>,
@@ -55,7 +69,7 @@ impl<'a, 'tcx> Annotator<'a, 'tcx> {
         attrs: &[Attribute],
         item_sp: Span,
         kind: AnnotationKind,
-        inherit_deprecation: bool,
+        inherit_deprecation: InheritDeprecation,
         visit_children: F,
     ) where
         F: FnOnce(&mut Self),
@@ -114,7 +128,7 @@ impl<'a, 'tcx> Annotator<'a, 'tcx> {
             // If parent is deprecated and we're not, inherit this by merging
             // deprecated_since and its reason.
             if let Some(parent_stab) = self.parent_stab {
-                if inherit_deprecation
+                if inherit_deprecation.yes()
                     && parent_stab.rustc_depr.is_some()
                     && stab.rustc_depr.is_none()
                 {
@@ -168,7 +182,7 @@ impl<'a, 'tcx> Annotator<'a, 'tcx> {
         if stab.is_none() {
             debug!("annotate: stab not found, parent = {:?}", self.parent_stab);
             if let Some(stab) = self.parent_stab {
-                if inherit_deprecation && stab.level.is_unstable() {
+                if inherit_deprecation.yes() && stab.level.is_unstable() {
                     self.index.stab_map.insert(hir_id, stab);
                 }
             }
@@ -211,7 +225,7 @@ impl<'a, 'tcx> Annotator<'a, 'tcx> {
         attrs: &[Attribute],
         item_sp: Span,
         kind: AnnotationKind,
-        inherit_deprecation: bool,
+        inherit_deprecation: InheritDeprecation,
         visit_children: impl FnOnce(&mut Self),
     ) {
         // Emit errors for non-staged-api crates.
@@ -239,7 +253,7 @@ impl<'a, 'tcx> Annotator<'a, 'tcx> {
         // Propagate unstability.  This can happen even for non-staged-api crates in case
         // -Zforce-unstable-if-unmarked is set.
         if let Some(stab) = self.parent_stab {
-            if inherit_deprecation && stab.level.is_unstable() {
+            if inherit_deprecation.yes() && stab.level.is_unstable() {
                 self.index.stab_map.insert(hir_id, stab);
             }
         }
@@ -297,7 +311,7 @@ impl<'a, 'tcx> Visitor<'tcx> for Annotator<'a, 'tcx> {
                         &i.attrs,
                         i.span,
                         AnnotationKind::Required,
-                        true,
+                        InheritDeprecation::Yes,
                         |_| {},
                     )
                 }
@@ -305,55 +319,92 @@ impl<'a, 'tcx> Visitor<'tcx> for Annotator<'a, 'tcx> {
             _ => {}
         }
 
-        self.annotate(i.hir_id, &i.attrs, i.span, kind, true, |v| intravisit::walk_item(v, i));
+        self.annotate(i.hir_id, &i.attrs, i.span, kind, InheritDeprecation::Yes, |v| {
+            intravisit::walk_item(v, i)
+        });
         self.in_trait_impl = orig_in_trait_impl;
     }
 
     fn visit_trait_item(&mut self, ti: &'tcx hir::TraitItem<'tcx>) {
-        self.annotate(ti.hir_id, &ti.attrs, ti.span, AnnotationKind::Required, true, |v| {
-            intravisit::walk_trait_item(v, ti);
-        });
+        self.annotate(
+            ti.hir_id,
+            &ti.attrs,
+            ti.span,
+            AnnotationKind::Required,
+            InheritDeprecation::Yes,
+            |v| {
+                intravisit::walk_trait_item(v, ti);
+            },
+        );
     }
 
     fn visit_impl_item(&mut self, ii: &'tcx hir::ImplItem<'tcx>) {
         let kind =
             if self.in_trait_impl { AnnotationKind::Prohibited } else { AnnotationKind::Required };
-        self.annotate(ii.hir_id, &ii.attrs, ii.span, kind, true, |v| {
+        self.annotate(ii.hir_id, &ii.attrs, ii.span, kind, InheritDeprecation::Yes, |v| {
             intravisit::walk_impl_item(v, ii);
         });
     }
 
     fn visit_variant(&mut self, var: &'tcx Variant<'tcx>, g: &'tcx Generics<'tcx>, item_id: HirId) {
-        self.annotate(var.id, &var.attrs, var.span, AnnotationKind::Required, true, |v| {
-            if let Some(ctor_hir_id) = var.data.ctor_hir_id() {
-                v.annotate(
-                    ctor_hir_id,
-                    &var.attrs,
-                    var.span,
-                    AnnotationKind::Required,
-                    true,
-                    |_| {},
-                );
-            }
+        self.annotate(
+            var.id,
+            &var.attrs,
+            var.span,
+            AnnotationKind::Required,
+            InheritDeprecation::Yes,
+            |v| {
+                if let Some(ctor_hir_id) = var.data.ctor_hir_id() {
+                    v.annotate(
+                        ctor_hir_id,
+                        &var.attrs,
+                        var.span,
+                        AnnotationKind::Required,
+                        InheritDeprecation::Yes,
+                        |_| {},
+                    );
+                }
 
-            intravisit::walk_variant(v, var, g, item_id)
-        })
+                intravisit::walk_variant(v, var, g, item_id)
+            },
+        )
     }
 
     fn visit_struct_field(&mut self, s: &'tcx StructField<'tcx>) {
-        self.annotate(s.hir_id, &s.attrs, s.span, AnnotationKind::Required, true, |v| {
-            intravisit::walk_struct_field(v, s);
-        });
+        self.annotate(
+            s.hir_id,
+            &s.attrs,
+            s.span,
+            AnnotationKind::Required,
+            InheritDeprecation::Yes,
+            |v| {
+                intravisit::walk_struct_field(v, s);
+            },
+        );
     }
 
     fn visit_foreign_item(&mut self, i: &'tcx hir::ForeignItem<'tcx>) {
-        self.annotate(i.hir_id, &i.attrs, i.span, AnnotationKind::Required, true, |v| {
-            intravisit::walk_foreign_item(v, i);
-        });
+        self.annotate(
+            i.hir_id,
+            &i.attrs,
+            i.span,
+            AnnotationKind::Required,
+            InheritDeprecation::Yes,
+            |v| {
+                intravisit::walk_foreign_item(v, i);
+            },
+        );
     }
 
     fn visit_macro_def(&mut self, md: &'tcx hir::MacroDef<'tcx>) {
-        self.annotate(md.hir_id, &md.attrs, md.span, AnnotationKind::Required, true, |_| {});
+        self.annotate(
+            md.hir_id,
+            &md.attrs,
+            md.span,
+            AnnotationKind::Required,
+            InheritDeprecation::Yes,
+            |_| {},
+        );
     }
 
     fn visit_generic_param(&mut self, p: &'tcx hir::GenericParam<'tcx>) {
@@ -365,7 +416,7 @@ impl<'a, 'tcx> Visitor<'tcx> for Annotator<'a, 'tcx> {
             _ => AnnotationKind::Prohibited,
         };
 
-        self.annotate(p.hir_id, &p.attrs, p.span, kind, false, |v| {
+        self.annotate(p.hir_id, &p.attrs, p.span, kind, InheritDeprecation::No, |v| {
             intravisit::walk_generic_param(v, p);
         });
     }
@@ -508,7 +559,7 @@ fn new_index(tcx: TyCtxt<'tcx>) -> Index<'tcx> {
             &krate.item.attrs,
             krate.item.span,
             AnnotationKind::Required,
-            true,
+            InheritDeprecation::Yes,
             |v| intravisit::walk_crate(v, krate),
         );
     }

--- a/src/librustc_passes/stability.rs
+++ b/src/librustc_passes/stability.rs
@@ -55,7 +55,6 @@ impl<'a, 'tcx> Annotator<'a, 'tcx> {
         attrs: &[Attribute],
         item_sp: Span,
         kind: AnnotationKind,
-        inherit_deprecation: bool,
         visit_children: F,
     ) where
         F: FnOnce(&mut Self),
@@ -66,7 +65,6 @@ impl<'a, 'tcx> Annotator<'a, 'tcx> {
                 attrs,
                 item_sp,
                 kind,
-                inherit_deprecation,
                 visit_children,
             );
             return;
@@ -114,8 +112,8 @@ impl<'a, 'tcx> Annotator<'a, 'tcx> {
             // If parent is deprecated and we're not, inherit this by merging
             // deprecated_since and its reason.
             if let Some(parent_stab) = self.parent_stab {
-                if inherit_deprecation
-                    && parent_stab.rustc_depr.is_some()
+                if
+                    parent_stab.rustc_depr.is_some()
                     && stab.rustc_depr.is_none()
                 {
                     stab.rustc_depr = parent_stab.rustc_depr.clone()
@@ -168,7 +166,7 @@ impl<'a, 'tcx> Annotator<'a, 'tcx> {
         if stab.is_none() {
             debug!("annotate: stab not found, parent = {:?}", self.parent_stab);
             if let Some(stab) = self.parent_stab {
-                if inherit_deprecation && stab.level.is_unstable() {
+                if stab.level.is_unstable() {
                     self.index.stab_map.insert(hir_id, stab);
                 }
             }
@@ -211,7 +209,6 @@ impl<'a, 'tcx> Annotator<'a, 'tcx> {
         attrs: &[Attribute],
         item_sp: Span,
         kind: AnnotationKind,
-        inherit_deprecation: bool,
         visit_children: impl FnOnce(&mut Self),
     ) {
         // Emit errors for non-staged-api crates.
@@ -239,7 +236,7 @@ impl<'a, 'tcx> Annotator<'a, 'tcx> {
         // Propagate unstability.  This can happen even for non-staged-api crates in case
         // -Zforce-unstable-if-unmarked is set.
         if let Some(stab) = self.parent_stab {
-            if inherit_deprecation && stab.level.is_unstable() {
+            if stab.level.is_unstable() {
                 self.index.stab_map.insert(hir_id, stab);
             }
         }
@@ -297,7 +294,6 @@ impl<'a, 'tcx> Visitor<'tcx> for Annotator<'a, 'tcx> {
                         &i.attrs,
                         i.span,
                         AnnotationKind::Required,
-                        true,
                         |_| {},
                     )
                 }
@@ -305,12 +301,12 @@ impl<'a, 'tcx> Visitor<'tcx> for Annotator<'a, 'tcx> {
             _ => {}
         }
 
-        self.annotate(i.hir_id, &i.attrs, i.span, kind, true, |v| intravisit::walk_item(v, i));
+        self.annotate(i.hir_id, &i.attrs, i.span, kind, |v| intravisit::walk_item(v, i));
         self.in_trait_impl = orig_in_trait_impl;
     }
 
     fn visit_trait_item(&mut self, ti: &'tcx hir::TraitItem<'tcx>) {
-        self.annotate(ti.hir_id, &ti.attrs, ti.span, AnnotationKind::Required, true, |v| {
+        self.annotate(ti.hir_id, &ti.attrs, ti.span, AnnotationKind::Required, |v| {
             intravisit::walk_trait_item(v, ti);
         });
     }
@@ -318,20 +314,19 @@ impl<'a, 'tcx> Visitor<'tcx> for Annotator<'a, 'tcx> {
     fn visit_impl_item(&mut self, ii: &'tcx hir::ImplItem<'tcx>) {
         let kind =
             if self.in_trait_impl { AnnotationKind::Prohibited } else { AnnotationKind::Required };
-        self.annotate(ii.hir_id, &ii.attrs, ii.span, kind, true, |v| {
+        self.annotate(ii.hir_id, &ii.attrs, ii.span, kind, |v| {
             intravisit::walk_impl_item(v, ii);
         });
     }
 
     fn visit_variant(&mut self, var: &'tcx Variant<'tcx>, g: &'tcx Generics<'tcx>, item_id: HirId) {
-        self.annotate(var.id, &var.attrs, var.span, AnnotationKind::Required, true, |v| {
+        self.annotate(var.id, &var.attrs, var.span, AnnotationKind::Required, |v| {
             if let Some(ctor_hir_id) = var.data.ctor_hir_id() {
                 v.annotate(
                     ctor_hir_id,
                     &var.attrs,
                     var.span,
                     AnnotationKind::Required,
-                    true,
                     |_| {},
                 );
             }
@@ -341,19 +336,19 @@ impl<'a, 'tcx> Visitor<'tcx> for Annotator<'a, 'tcx> {
     }
 
     fn visit_struct_field(&mut self, s: &'tcx StructField<'tcx>) {
-        self.annotate(s.hir_id, &s.attrs, s.span, AnnotationKind::Required, true, |v| {
+        self.annotate(s.hir_id, &s.attrs, s.span, AnnotationKind::Required, |v| {
             intravisit::walk_struct_field(v, s);
         });
     }
 
     fn visit_foreign_item(&mut self, i: &'tcx hir::ForeignItem<'tcx>) {
-        self.annotate(i.hir_id, &i.attrs, i.span, AnnotationKind::Required, true, |v| {
+        self.annotate(i.hir_id, &i.attrs, i.span, AnnotationKind::Required, |v| {
             intravisit::walk_foreign_item(v, i);
         });
     }
 
     fn visit_macro_def(&mut self, md: &'tcx hir::MacroDef<'tcx>) {
-        self.annotate(md.hir_id, &md.attrs, md.span, AnnotationKind::Required, true, |_| {});
+        self.annotate(md.hir_id, &md.attrs, md.span, AnnotationKind::Required, |_| {});
     }
 
     fn visit_generic_param(&mut self, p: &'tcx hir::GenericParam<'tcx>) {
@@ -365,7 +360,7 @@ impl<'a, 'tcx> Visitor<'tcx> for Annotator<'a, 'tcx> {
             _ => AnnotationKind::Prohibited,
         };
 
-        self.annotate(p.hir_id, &p.attrs, p.span, kind, false, |v| {
+        self.annotate(p.hir_id, &p.attrs, p.span, kind, |v| {
             intravisit::walk_generic_param(v, p);
         });
     }
@@ -508,7 +503,6 @@ fn new_index(tcx: TyCtxt<'tcx>) -> Index<'tcx> {
             &krate.item.attrs,
             krate.item.span,
             AnnotationKind::Required,
-            true,
             |v| intravisit::walk_crate(v, krate),
         );
     }

--- a/src/librustc_passes/stability.rs
+++ b/src/librustc_passes/stability.rs
@@ -55,12 +55,20 @@ impl<'a, 'tcx> Annotator<'a, 'tcx> {
         attrs: &[Attribute],
         item_sp: Span,
         kind: AnnotationKind,
+        inherit_deprecation: bool,
         visit_children: F,
     ) where
         F: FnOnce(&mut Self),
     {
         if !self.tcx.features().staged_api {
-            self.forbid_staged_api_attrs(hir_id, attrs, item_sp, kind, visit_children);
+            self.forbid_staged_api_attrs(
+                hir_id,
+                attrs,
+                item_sp,
+                kind,
+                inherit_deprecation,
+                visit_children,
+            );
             return;
         }
 
@@ -106,8 +114,11 @@ impl<'a, 'tcx> Annotator<'a, 'tcx> {
             // If parent is deprecated and we're not, inherit this by merging
             // deprecated_since and its reason.
             if let Some(parent_stab) = self.parent_stab {
-                if parent_stab.rustc_depr.is_some() && stab.rustc_depr.is_none() {
-                    stab.rustc_depr = parent_stab.rustc_depr
+                if inherit_deprecation
+                    && parent_stab.rustc_depr.is_some()
+                    && stab.rustc_depr.is_none()
+                {
+                    stab.rustc_depr = parent_stab.rustc_depr.clone()
                 }
             }
 
@@ -157,7 +168,7 @@ impl<'a, 'tcx> Annotator<'a, 'tcx> {
         if stab.is_none() {
             debug!("annotate: stab not found, parent = {:?}", self.parent_stab);
             if let Some(stab) = self.parent_stab {
-                if stab.level.is_unstable() {
+                if inherit_deprecation && stab.level.is_unstable() {
                     self.index.stab_map.insert(hir_id, stab);
                 }
             }
@@ -200,6 +211,7 @@ impl<'a, 'tcx> Annotator<'a, 'tcx> {
         attrs: &[Attribute],
         item_sp: Span,
         kind: AnnotationKind,
+        inherit_deprecation: bool,
         visit_children: impl FnOnce(&mut Self),
     ) {
         // Emit errors for non-staged-api crates.
@@ -227,7 +239,7 @@ impl<'a, 'tcx> Annotator<'a, 'tcx> {
         // Propagate unstability.  This can happen even for non-staged-api crates in case
         // -Zforce-unstable-if-unmarked is set.
         if let Some(stab) = self.parent_stab {
-            if stab.level.is_unstable() {
+            if inherit_deprecation && stab.level.is_unstable() {
                 self.index.stab_map.insert(hir_id, stab);
             }
         }
@@ -280,18 +292,25 @@ impl<'a, 'tcx> Visitor<'tcx> for Annotator<'a, 'tcx> {
             }
             hir::ItemKind::Struct(ref sd, _) => {
                 if let Some(ctor_hir_id) = sd.ctor_hir_id() {
-                    self.annotate(ctor_hir_id, &i.attrs, i.span, AnnotationKind::Required, |_| {})
+                    self.annotate(
+                        ctor_hir_id,
+                        &i.attrs,
+                        i.span,
+                        AnnotationKind::Required,
+                        true,
+                        |_| {},
+                    )
                 }
             }
             _ => {}
         }
 
-        self.annotate(i.hir_id, &i.attrs, i.span, kind, |v| intravisit::walk_item(v, i));
+        self.annotate(i.hir_id, &i.attrs, i.span, kind, true, |v| intravisit::walk_item(v, i));
         self.in_trait_impl = orig_in_trait_impl;
     }
 
     fn visit_trait_item(&mut self, ti: &'tcx hir::TraitItem<'tcx>) {
-        self.annotate(ti.hir_id, &ti.attrs, ti.span, AnnotationKind::Required, |v| {
+        self.annotate(ti.hir_id, &ti.attrs, ti.span, AnnotationKind::Required, true, |v| {
             intravisit::walk_trait_item(v, ti);
         });
     }
@@ -299,15 +318,22 @@ impl<'a, 'tcx> Visitor<'tcx> for Annotator<'a, 'tcx> {
     fn visit_impl_item(&mut self, ii: &'tcx hir::ImplItem<'tcx>) {
         let kind =
             if self.in_trait_impl { AnnotationKind::Prohibited } else { AnnotationKind::Required };
-        self.annotate(ii.hir_id, &ii.attrs, ii.span, kind, |v| {
+        self.annotate(ii.hir_id, &ii.attrs, ii.span, kind, true, |v| {
             intravisit::walk_impl_item(v, ii);
         });
     }
 
     fn visit_variant(&mut self, var: &'tcx Variant<'tcx>, g: &'tcx Generics<'tcx>, item_id: HirId) {
-        self.annotate(var.id, &var.attrs, var.span, AnnotationKind::Required, |v| {
+        self.annotate(var.id, &var.attrs, var.span, AnnotationKind::Required, true, |v| {
             if let Some(ctor_hir_id) = var.data.ctor_hir_id() {
-                v.annotate(ctor_hir_id, &var.attrs, var.span, AnnotationKind::Required, |_| {});
+                v.annotate(
+                    ctor_hir_id,
+                    &var.attrs,
+                    var.span,
+                    AnnotationKind::Required,
+                    true,
+                    |_| {},
+                );
             }
 
             intravisit::walk_variant(v, var, g, item_id)
@@ -315,19 +341,33 @@ impl<'a, 'tcx> Visitor<'tcx> for Annotator<'a, 'tcx> {
     }
 
     fn visit_struct_field(&mut self, s: &'tcx StructField<'tcx>) {
-        self.annotate(s.hir_id, &s.attrs, s.span, AnnotationKind::Required, |v| {
+        self.annotate(s.hir_id, &s.attrs, s.span, AnnotationKind::Required, true, |v| {
             intravisit::walk_struct_field(v, s);
         });
     }
 
     fn visit_foreign_item(&mut self, i: &'tcx hir::ForeignItem<'tcx>) {
-        self.annotate(i.hir_id, &i.attrs, i.span, AnnotationKind::Required, |v| {
+        self.annotate(i.hir_id, &i.attrs, i.span, AnnotationKind::Required, true, |v| {
             intravisit::walk_foreign_item(v, i);
         });
     }
 
     fn visit_macro_def(&mut self, md: &'tcx hir::MacroDef<'tcx>) {
-        self.annotate(md.hir_id, &md.attrs, md.span, AnnotationKind::Required, |_| {});
+        self.annotate(md.hir_id, &md.attrs, md.span, AnnotationKind::Required, true, |_| {});
+    }
+
+    fn visit_generic_param(&mut self, p: &'tcx hir::GenericParam<'tcx>) {
+        let kind = match &p.kind {
+            // FIXME(const_generics:defaults)
+            hir::GenericParamKind::Type { default, .. } if default.is_some() => {
+                AnnotationKind::Container
+            }
+            _ => AnnotationKind::Prohibited,
+        };
+
+        self.annotate(p.hir_id, &p.attrs, p.span, kind, false, |v| {
+            intravisit::walk_generic_param(v, p);
+        });
     }
 }
 
@@ -401,6 +441,10 @@ impl<'a, 'tcx> Visitor<'tcx> for MissingStabilityAnnotations<'a, 'tcx> {
     fn visit_macro_def(&mut self, md: &'tcx hir::MacroDef<'tcx>) {
         self.check_missing_stability(md.hir_id, md.span);
     }
+
+    // Note that we don't need to `check_missing_stability` for default generic parameters,
+    // as we assume that any default generic parameters without attributes are automatically
+    // stable (assuming they have not inherited instability from their parent).
 }
 
 fn new_index(tcx: TyCtxt<'tcx>) -> Index<'tcx> {
@@ -464,6 +508,7 @@ fn new_index(tcx: TyCtxt<'tcx>) -> Index<'tcx> {
             &krate.item.attrs,
             krate.item.span,
             AnnotationKind::Required,
+            true,
             |v| intravisit::walk_crate(v, krate),
         );
     }

--- a/src/librustc_passes/stability.rs
+++ b/src/librustc_passes/stability.rs
@@ -42,7 +42,6 @@ enum AnnotationKind {
 /// have separate deprecation attributes from their parents, so we do not wish to inherit
 /// deprecation in this case. For example, inheriting deprecation for `T` in `Foo<T>`
 /// would cause a duplicate warning arising from both `Foo` and `T` being deprecated.
-#[derive(PartialEq, Copy, Clone)]
 enum InheritDeprecation {
     Yes,
     No,
@@ -50,7 +49,7 @@ enum InheritDeprecation {
 
 impl InheritDeprecation {
     fn yes(&self) -> bool {
-        *self == InheritDeprecation::Yes
+        matches!(self, InheritDeprecation::Yes)
     }
 }
 

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -782,7 +782,13 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                             param.def_id,
                             Some(arg.id()),
                             arg.span(),
-                            |_, _| (),
+                            |_, _| {
+                                // Default generic parameters may not be marked
+                                // with stability attributes, i.e. when the
+                                // default parameter was defined at the same time
+                                // as the rest of the type. As such, we ignore missing
+                                // stability attributes.
+                            },
                         )
                     }
                     if let (hir::TyKind::Infer, false) = (&ty.kind, self.allow_ty_infer()) {

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -778,7 +778,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                 }
                 (GenericParamDefKind::Type { has_default, .. }, GenericArg::Type(ty)) => {
                     if *has_default {
-                        tcx.check_stability_internal(
+                        tcx.check_optional_stability(
                             param.def_id,
                             Some(arg.id()),
                             arg.span(),

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -776,7 +776,16 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                 (GenericParamDefKind::Lifetime, GenericArg::Lifetime(lt)) => {
                     self.ast_region_to_region(&lt, Some(param)).into()
                 }
-                (GenericParamDefKind::Type { .. }, GenericArg::Type(ty)) => {
+                (GenericParamDefKind::Type { has_default, .. }, GenericArg::Type(ty)) => {
+                    if *has_default {
+                        tcx.check_stability_internal(
+                            param.def_id,
+                            Some(arg.id()),
+                            arg.span(),
+                            false,
+                            |_, _| (),
+                        )
+                    }
                     if let (hir::TyKind::Infer, false) = (&ty.kind, self.allow_ty_infer()) {
                         inferred_params.push(ty.span);
                         tcx.types.err.into()

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -782,7 +782,6 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                             param.def_id,
                             Some(arg.id()),
                             arg.span(),
-                            false,
                             |_, _| (),
                         )
                     }

--- a/src/librustc_typeck/check/method/probe.rs
+++ b/src/librustc_typeck/check/method/probe.rs
@@ -1220,7 +1220,7 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
         if let Some(uc) = unstable_candidates {
             applicable_candidates.retain(|&(p, _)| {
                 if let stability::EvalResult::Deny { feature, .. } =
-                    self.tcx.eval_stability(p.item.def_id, None, self.span, true)
+                    self.tcx.eval_stability(p.item.def_id, None, self.span)
                 {
                     uc.push((p, feature));
                     return false;

--- a/src/librustc_typeck/check/method/probe.rs
+++ b/src/librustc_typeck/check/method/probe.rs
@@ -1220,7 +1220,7 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
         if let Some(uc) = unstable_candidates {
             applicable_candidates.retain(|&(p, _)| {
                 if let stability::EvalResult::Deny { feature, .. } =
-                    self.tcx.eval_stability(p.item.def_id, None, self.span)
+                    self.tcx.eval_stability(p.item.def_id, None, self.span, true)
                 {
                     uc.push((p, feature));
                     return false;

--- a/src/test/ui/stability-attribute/auxiliary/unstable_generic_param.rs
+++ b/src/test/ui/stability-attribute/auxiliary/unstable_generic_param.rs
@@ -56,6 +56,12 @@ pub struct Struct5<#[unstable(feature = "unstable_default", issue = "none")] A =
 }
 
 #[stable(feature = "stable_test_feature", since = "1.0.0")]
+pub struct Struct6<#[unstable(feature = "unstable_default6", issue = "none")] T = usize> {
+    #[stable(feature = "stable_test_feature", since = "1.0.0")]
+    pub field: T,
+}
+
+#[stable(feature = "stable_test_feature", since = "1.0.0")]
 pub const STRUCT1: Struct1 = Struct1 { field: 1 };
 
 #[stable(feature = "stable_test_feature", since = "1.0.0")]

--- a/src/test/ui/stability-attribute/auxiliary/unstable_generic_param.rs
+++ b/src/test/ui/stability-attribute/auxiliary/unstable_generic_param.rs
@@ -41,6 +41,20 @@ pub struct Struct3<A = isize, #[unstable(feature = "unstable_default", issue = "
     pub field2: B,
 }
 
+#[rustc_deprecated(since = "1.1.0", reason = "test")]
+#[stable(feature = "stable_test_feature", since = "1.0.0")]
+pub struct Struct4<A = usize> {
+    #[stable(feature = "stable_test_feature", since = "1.0.0")]
+    pub field: A,
+}
+
+#[rustc_deprecated(since = "1.1.0", reason = "test")]
+#[stable(feature = "stable_test_feature", since = "1.0.0")]
+pub struct Struct5<#[unstable(feature = "unstable_default", issue = "none")] A = usize> {
+    #[stable(feature = "stable_test_feature", since = "1.0.0")]
+    pub field: A,
+}
+
 #[stable(feature = "stable_test_feature", since = "1.0.0")]
 pub const STRUCT1: Struct1 = Struct1 { field: 1 };
 
@@ -49,3 +63,9 @@ pub const STRUCT2: Struct2 = Struct2 { field: 1 };
 
 #[stable(feature = "stable_test_feature", since = "1.0.0")]
 pub const STRUCT3: Struct3 = Struct3 { field1: 1, field2: 2 };
+
+#[stable(feature = "stable_test_feature", since = "1.0.0")]
+pub const STRUCT4: Struct4 = Struct4 { field: 1 };
+
+#[stable(feature = "stable_test_feature", since = "1.0.0")]
+pub const STRUCT5: Struct5 = Struct5 { field: 1 };

--- a/src/test/ui/stability-attribute/auxiliary/unstable_generic_param.rs
+++ b/src/test/ui/stability-attribute/auxiliary/unstable_generic_param.rs
@@ -109,3 +109,15 @@ impl<T> Box2<T, System> {
         Self { ptr: &mut t, alloc: System {} }
     }
 }
+
+#[stable(feature = "stable_test_feature", since = "1.0.0")]
+pub struct Box3<T> {
+    ptr: *mut T,
+}
+
+impl<T> Box3<T> {
+    #[stable(feature = "stable_test_feature", since = "1.0.0")]
+    pub fn new(mut t: T) -> Self {
+        Self { ptr: &mut t }
+    }
+}

--- a/src/test/ui/stability-attribute/auxiliary/unstable_generic_param.rs
+++ b/src/test/ui/stability-attribute/auxiliary/unstable_generic_param.rs
@@ -1,0 +1,41 @@
+#![crate_type = "lib"]
+#![feature(staged_api)]
+
+#![stable(feature = "stable_test_feature", since = "1.0.0")]
+
+#[stable(feature = "stable_test_feature", since = "1.0.0")]
+pub trait Trait1<#[unstable(feature = "unstable_default", issue = "none")] T = ()> {
+    #[stable(feature = "stable_test_feature", since = "1.0.0")]
+    fn foo() -> T;
+}
+
+#[stable(feature = "stable_test_feature", since = "1.0.0")]
+pub trait Trait2<#[unstable(feature = "unstable_default", issue = "none")] T = usize> {
+    #[stable(feature = "stable_test_feature", since = "1.0.0")]
+    fn foo() -> T;
+}
+
+#[stable(feature = "stable_test_feature", since = "1.0.0")]
+pub trait Trait3<T = ()> {
+    #[stable(feature = "stable_test_feature", since = "1.0.0")]
+    fn foo() -> T;
+}
+
+#[stable(feature = "stable_test_feature", since = "1.0.0")]
+pub struct Struct1<#[unstable(feature = "unstable_default", issue = "none")] T = usize> {
+    #[stable(feature = "stable_test_feature", since = "1.0.0")]
+    pub field: T,
+}
+
+#[stable(feature = "stable_test_feature", since = "1.0.0")]
+pub struct Struct2<T = usize> {
+    #[stable(feature = "stable_test_feature", since = "1.0.0")]
+    pub field: T,
+}
+
+
+#[stable(feature = "stable_test_feature", since = "1.0.0")]
+pub const STRUCT1: Struct1 = Struct1 { field: 1 };
+
+#[stable(feature = "stable_test_feature", since = "1.0.0")]
+pub const STRUCT2: Struct2 = Struct2 { field: 1 };

--- a/src/test/ui/stability-attribute/auxiliary/unstable_generic_param.rs
+++ b/src/test/ui/stability-attribute/auxiliary/unstable_generic_param.rs
@@ -33,9 +33,19 @@ pub struct Struct2<T = usize> {
     pub field: T,
 }
 
+#[stable(feature = "stable_test_feature", since = "1.0.0")]
+pub struct Struct3<A = isize, #[unstable(feature = "unstable_default", issue = "none")] B = usize> {
+    #[stable(feature = "stable_test_feature", since = "1.0.0")]
+    pub field1: A,
+    #[stable(feature = "stable_test_feature", since = "1.0.0")]
+    pub field2: B,
+}
 
 #[stable(feature = "stable_test_feature", since = "1.0.0")]
 pub const STRUCT1: Struct1 = Struct1 { field: 1 };
 
 #[stable(feature = "stable_test_feature", since = "1.0.0")]
 pub const STRUCT2: Struct2 = Struct2 { field: 1 };
+
+#[stable(feature = "stable_test_feature", since = "1.0.0")]
+pub const STRUCT3: Struct3 = Struct3 { field1: 1, field2: 2 };

--- a/src/test/ui/stability-attribute/auxiliary/unstable_generic_param.rs
+++ b/src/test/ui/stability-attribute/auxiliary/unstable_generic_param.rs
@@ -1,6 +1,5 @@
 #![crate_type = "lib"]
 #![feature(staged_api)]
-
 #![stable(feature = "stable_test_feature", since = "1.0.0")]
 
 #[stable(feature = "stable_test_feature", since = "1.0.0")]
@@ -75,3 +74,38 @@ pub const STRUCT4: Struct4 = Struct4 { field: 1 };
 
 #[stable(feature = "stable_test_feature", since = "1.0.0")]
 pub const STRUCT5: Struct5 = Struct5 { field: 1 };
+
+#[stable(feature = "stable_test_feature", since = "1.0.0")]
+pub trait Alloc {}
+
+#[stable(feature = "stable_test_feature", since = "1.0.0")]
+pub struct System {}
+
+#[stable(feature = "stable_test_feature", since = "1.0.0")]
+impl Alloc for System {}
+
+#[stable(feature = "stable_test_feature", since = "1.0.0")]
+pub struct Box1<T, #[unstable(feature = "box_alloc_param", issue = "none")] A: Alloc = System> {
+    ptr: *mut T,
+    alloc: A,
+}
+
+impl<T> Box1<T, System> {
+    #[stable(feature = "stable_test_feature", since = "1.0.0")]
+    pub fn new(mut t: T) -> Self {
+        unsafe { Self { ptr: &mut t, alloc: System {} } }
+    }
+}
+
+#[stable(feature = "stable_test_feature", since = "1.0.0")]
+pub struct Box2<T, A: Alloc = System> {
+    ptr: *mut T,
+    alloc: A,
+}
+
+impl<T> Box2<T, System> {
+    #[stable(feature = "stable_test_feature", since = "1.0.0")]
+    pub fn new(mut t: T) -> Self {
+        Self { ptr: &mut t, alloc: System {} }
+    }
+}

--- a/src/test/ui/stability-attribute/generics-default-stability-where.rs
+++ b/src/test/ui/stability-attribute/generics-default-stability-where.rs
@@ -1,0 +1,12 @@
+// ignore-tidy-linelength
+// aux-build:unstable_generic_param.rs
+
+extern crate unstable_generic_param;
+
+use unstable_generic_param::*;
+
+impl<T> Trait3<usize> for T where T: Trait2<usize> { //~ ERROR use of unstable library feature 'unstable_default'
+    fn foo() -> usize { T::foo() }
+}
+
+fn main() {}

--- a/src/test/ui/stability-attribute/generics-default-stability-where.stderr
+++ b/src/test/ui/stability-attribute/generics-default-stability-where.stderr
@@ -1,0 +1,11 @@
+error[E0658]: use of unstable library feature 'unstable_default'
+  --> $DIR/generics-default-stability-where.rs:8:45
+   |
+LL | impl<T> Trait3<usize> for T where T: Trait2<usize> {
+   |                                             ^^^^^
+   |
+   = help: add `#![feature(unstable_default)]` to the crate attributes to enable
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/stability-attribute/generics-default-stability.rs
+++ b/src/test/ui/stability-attribute/generics-default-stability.rs
@@ -37,7 +37,7 @@ fn main() {
     let _ = STRUCT1; // ok
     let _: Struct1 = STRUCT1; // ok
     let _: Struct1<usize> = STRUCT1; //~ ERROR use of unstable library feature 'unstable_default'
-    let _: Struct1<isize> = STRUCT1; //~ ERROR use of unstable library feature 'unstable_default'
+    let _: Struct1<isize> = Struct1 { field: 0 }; //~ ERROR use of unstable library feature 'unstable_default'
 
     // Instability is not enforced for generic type parameters used in public fields.
     // Note how the unstable type default `usize` leaks,
@@ -56,7 +56,7 @@ fn main() {
     let _ = STRUCT2;
     let _: Struct2 = STRUCT2; // ok
     let _: Struct2<usize> = STRUCT2; // ok
-    let _: Struct2<usize> = STRUCT2; // ok
+    let _: Struct2<isize> = Struct2 { field: 0 }; // ok
     let _ = STRUCT2.field; // ok
     let _: usize = STRUCT2.field; // ok
     let _ = STRUCT2.field + 1; // ok

--- a/src/test/ui/stability-attribute/generics-default-stability.rs
+++ b/src/test/ui/stability-attribute/generics-default-stability.rs
@@ -109,4 +109,10 @@ fn main() {
 
     let _: Struct6<isize> = Struct6 { field: 1 }; // ok
     let _: Struct6<isize> = Struct6 { field: 0 }; // ok
+
+    let _: Box1<isize, System> = Box1::new(1); //~ ERROR use of unstable library feature 'box_alloc_param'
+    let _: Box1<isize> = Box1::new(1); // ok
+
+    let _: Box2<isize, System> = Box2::new(1); // ok
+    let _: Box2<isize> = Box2::new(1); // ok
 }

--- a/src/test/ui/stability-attribute/generics-default-stability.rs
+++ b/src/test/ui/stability-attribute/generics-default-stability.rs
@@ -1,5 +1,6 @@
 // ignore-tidy-linelength
 // aux-build:unstable_generic_param.rs
+#![feature(unstable_default6)]
 
 extern crate unstable_generic_param;
 
@@ -105,4 +106,7 @@ fn main() {
     //~^ use of deprecated item 'unstable_generic_param::Struct5': test [deprecated]
     //~^^ use of deprecated item 'unstable_generic_param::Struct5': test [deprecated]
     //~^^^ use of deprecated item 'unstable_generic_param::Struct5::field': test [deprecated]
+
+    let _: Struct6<isize> = Struct6 { field: 1 }; // ok
+    let _: Struct6<isize> = Struct6 { field: 0 }; // ok
 }

--- a/src/test/ui/stability-attribute/generics-default-stability.rs
+++ b/src/test/ui/stability-attribute/generics-default-stability.rs
@@ -30,31 +30,31 @@ impl Trait3<usize> for S {
 }
 
 fn main() {
-    // let _ = S;
+    let _ = S;
 
-    // let _ = Struct1 { field: 1 }; //~ ERROR use of unstable library feature 'unstable_default'
-    // let _: Struct1 = Struct1 { field: 1 }; //~ ERROR use of unstable library feature 'unstable_default'
-    // let _: Struct1<isize> = Struct1 { field: 1 }; //~ ERROR use of unstable library feature 'unstable_default'
+    let _ = Struct1 { field: 1 }; //~ ERROR use of unstable library feature 'unstable_default'
+    let _: Struct1 = Struct1 { field: 1 }; //~ ERROR use of unstable library feature 'unstable_default'
+    let _: Struct1<isize> = Struct1 { field: 1 }; //~ ERROR use of unstable library feature 'unstable_default'
 
-    // let _ = STRUCT1; // ok
-    // let _: Struct1 = STRUCT1; // ok
-    // let _: Struct1<usize> = STRUCT1; //~ ERROR use of unstable library feature 'unstable_default'
-    // let _: Struct1<usize> = STRUCT1; //~ ERROR use of unstable library feature 'unstable_default'
-    // let _ = STRUCT1.field; // ok
-    // let _: usize = STRUCT1.field; //~ ERROR use of unstable library feature 'unstable_default'
-    // let _ = STRUCT1.field + 1; //~ ERROR use of unstable library feature 'unstable_default'
-    // let _ = STRUCT1.field + 1usize; //~ ERROR use of unstable library feature 'unstable_default'
+    let _ = STRUCT1; // ok
+    let _: Struct1 = STRUCT1; // ok
+    let _: Struct1<usize> = STRUCT1; //~ ERROR use of unstable library feature 'unstable_default'
+    let _: Struct1<usize> = STRUCT1; //~ ERROR use of unstable library feature 'unstable_default'
+    let _ = STRUCT1.field; // ok
+    let _: usize = STRUCT1.field; //~ ERROR use of unstable library feature 'unstable_default'
+    let _ = STRUCT1.field + 1; //~ ERROR use of unstable library feature 'unstable_default'
+    let _ = STRUCT1.field + 1usize; //~ ERROR use of unstable library feature 'unstable_default'
 
-    // let _ = Struct2 { field: 1 }; // ok
-    // let _: Struct2 = Struct2 { field: 1 }; // ok
-    // let _: Struct2<usize> = Struct2 { field: 1 }; // ok
+    let _ = Struct2 { field: 1 }; // ok
+    let _: Struct2 = Struct2 { field: 1 }; // ok
+    let _: Struct2<usize> = Struct2 { field: 1 }; // ok
 
-    // let _ = STRUCT2;
-    // let _: Struct2 = STRUCT2; // ok
-    // let _: Struct2<usize> = STRUCT2; // ok
-    // let _: Struct2<usize> = STRUCT2; // ok
-    // let _ = STRUCT2.field; // ok
-    // let _: usize = STRUCT2.field; // ok
-    // let _ = STRUCT2.field + 1; // ok
-    // let _ = STRUCT2.field + 1usize; // ok
+    let _ = STRUCT2;
+    let _: Struct2 = STRUCT2; // ok
+    let _: Struct2<usize> = STRUCT2; // ok
+    let _: Struct2<usize> = STRUCT2; // ok
+    let _ = STRUCT2.field; // ok
+    let _: usize = STRUCT2.field; // ok
+    let _ = STRUCT2.field + 1; // ok
+    let _ = STRUCT2.field + 1usize; // ok
 }

--- a/src/test/ui/stability-attribute/generics-default-stability.rs
+++ b/src/test/ui/stability-attribute/generics-default-stability.rs
@@ -32,8 +32,8 @@ impl Trait3<usize> for S {
 fn main() {
     let _ = S;
 
-    let _ = Struct1 { field: 1 }; //~ ERROR use of unstable library feature 'unstable_default'
-    let _: Struct1 = Struct1 { field: 1 }; //~ ERROR use of unstable library feature 'unstable_default'
+    let _ = Struct1 { field: 1 }; // ERROR use of unstable library feature 'unstable_default'
+    let _: Struct1 = Struct1 { field: 1 }; // ERROR use of unstable library feature 'unstable_default'
     let _: Struct1<isize> = Struct1 { field: 1 }; //~ ERROR use of unstable library feature 'unstable_default'
 
     let _ = STRUCT1; // ok
@@ -41,9 +41,9 @@ fn main() {
     let _: Struct1<usize> = STRUCT1; //~ ERROR use of unstable library feature 'unstable_default'
     let _: Struct1<usize> = STRUCT1; //~ ERROR use of unstable library feature 'unstable_default'
     let _ = STRUCT1.field; // ok
-    let _: usize = STRUCT1.field; //~ ERROR use of unstable library feature 'unstable_default'
-    let _ = STRUCT1.field + 1; //~ ERROR use of unstable library feature 'unstable_default'
-    let _ = STRUCT1.field + 1usize; //~ ERROR use of unstable library feature 'unstable_default'
+    let _: usize = STRUCT1.field; // ERROR use of unstable library feature 'unstable_default'
+    let _ = STRUCT1.field + 1; // ERROR use of unstable library feature 'unstable_default'
+    let _ = STRUCT1.field + 1usize; // ERROR use of unstable library feature 'unstable_default'
 
     let _ = Struct2 { field: 1 }; // ok
     let _: Struct2 = Struct2 { field: 1 }; // ok

--- a/src/test/ui/stability-attribute/generics-default-stability.rs
+++ b/src/test/ui/stability-attribute/generics-default-stability.rs
@@ -1,3 +1,4 @@
+// ignore-tidy-linelength
 // aux-build:unstable_generic_param.rs
 
 extern crate unstable_generic_param;

--- a/src/test/ui/stability-attribute/generics-default-stability.rs
+++ b/src/test/ui/stability-attribute/generics-default-stability.rs
@@ -32,18 +32,22 @@ impl Trait3<usize> for S {
 fn main() {
     let _ = S;
 
-    let _ = Struct1 { field: 1 }; // ERROR use of unstable library feature 'unstable_default'
-    let _: Struct1 = Struct1 { field: 1 }; // ERROR use of unstable library feature 'unstable_default'
     let _: Struct1<isize> = Struct1 { field: 1 }; //~ ERROR use of unstable library feature 'unstable_default'
 
     let _ = STRUCT1; // ok
     let _: Struct1 = STRUCT1; // ok
     let _: Struct1<usize> = STRUCT1; //~ ERROR use of unstable library feature 'unstable_default'
-    let _: Struct1<usize> = STRUCT1; //~ ERROR use of unstable library feature 'unstable_default'
-    let _ = STRUCT1.field; // ok
-    let _: usize = STRUCT1.field; // ERROR use of unstable library feature 'unstable_default'
-    let _ = STRUCT1.field + 1; // ERROR use of unstable library feature 'unstable_default'
-    let _ = STRUCT1.field + 1usize; // ERROR use of unstable library feature 'unstable_default'
+    let _: Struct1<isize> = STRUCT1; //~ ERROR use of unstable library feature 'unstable_default'
+
+    // Instability is not enforced for generic type parameters used in public fields.
+    // Note how the unstable type default `usize` leaks,
+    // and can be used without the 'unstable_default' feature.
+    let _ = STRUCT1.field;
+    let _ = Struct1 { field: 1 };
+    let _: Struct1 = Struct1 { field: 1 };
+    let _: usize = STRUCT1.field;
+    let _ = STRUCT1.field + 1;
+    let _ = STRUCT1.field + 1usize;
 
     let _ = Struct2 { field: 1 }; // ok
     let _: Struct2 = Struct2 { field: 1 }; // ok

--- a/src/test/ui/stability-attribute/generics-default-stability.rs
+++ b/src/test/ui/stability-attribute/generics-default-stability.rs
@@ -44,6 +44,8 @@ fn main() {
     // and can be used without the 'unstable_default' feature.
     let _ = STRUCT1.field;
     let _ = Struct1 { field: 1 };
+    let _ = Struct1 { field: () };
+    let _ = Struct1 { field: 1isize };
     let _: Struct1 = Struct1 { field: 1 };
     let _: usize = STRUCT1.field;
     let _ = STRUCT1.field + 1;

--- a/src/test/ui/stability-attribute/generics-default-stability.rs
+++ b/src/test/ui/stability-attribute/generics-default-stability.rs
@@ -61,4 +61,19 @@ fn main() {
     let _: usize = STRUCT2.field; // ok
     let _ = STRUCT2.field + 1; // ok
     let _ = STRUCT2.field + 1usize; // ok
+
+    let _ = STRUCT3;
+    let _: Struct3 = STRUCT3; // ok
+    let _: Struct3<isize, usize> = STRUCT3; //~ ERROR use of unstable library feature 'unstable_default'
+    let _: Struct3<isize> = STRUCT3; // ok
+    let _: Struct3<isize, isize> = Struct3 { field1: 0, field2: 0 }; //~ ERROR use of unstable library feature 'unstable_default'
+    let _: Struct3<usize, usize> = Struct3 { field1: 0, field2: 0 }; //~ ERROR use of unstable library feature 'unstable_default'
+    let _ = STRUCT3.field1; // ok
+    let _: isize = STRUCT3.field1; // ok
+    let _ = STRUCT3.field1 + 1; // ok
+    // Note the aforementioned leak.
+    let _: usize = STRUCT3.field2; // ok
+    let _: Struct3<usize> = Struct3 { field1: 0, field2: 0 }; // ok
+    let _ = STRUCT3.field2 + 1; // ok
+    let _ = STRUCT3.field2 + 1usize; // ok
 }

--- a/src/test/ui/stability-attribute/generics-default-stability.rs
+++ b/src/test/ui/stability-attribute/generics-default-stability.rs
@@ -1,0 +1,59 @@
+// aux-build:unstable_generic_param.rs
+
+extern crate unstable_generic_param;
+
+use unstable_generic_param::*;
+
+struct R;
+
+impl Trait1 for S {
+    fn foo() -> () { () } // ok
+}
+
+struct S;
+
+impl Trait1<usize> for S { //~ ERROR use of unstable library feature 'unstable_default'
+    fn foo() -> usize { 0 }
+}
+
+impl Trait1<isize> for S { //~ ERROR use of unstable library feature 'unstable_default'
+    fn foo() -> isize { 0 }
+}
+
+impl Trait2<usize> for S { //~ ERROR use of unstable library feature 'unstable_default'
+    fn foo() -> usize { 0 }
+}
+
+impl Trait3<usize> for S {
+    fn foo() -> usize { 0 } // ok
+}
+
+fn main() {
+    // let _ = S;
+
+    // let _ = Struct1 { field: 1 }; //~ ERROR use of unstable library feature 'unstable_default'
+    // let _: Struct1 = Struct1 { field: 1 }; //~ ERROR use of unstable library feature 'unstable_default'
+    // let _: Struct1<isize> = Struct1 { field: 1 }; //~ ERROR use of unstable library feature 'unstable_default'
+
+    // let _ = STRUCT1; // ok
+    // let _: Struct1 = STRUCT1; // ok
+    // let _: Struct1<usize> = STRUCT1; //~ ERROR use of unstable library feature 'unstable_default'
+    // let _: Struct1<usize> = STRUCT1; //~ ERROR use of unstable library feature 'unstable_default'
+    // let _ = STRUCT1.field; // ok
+    // let _: usize = STRUCT1.field; //~ ERROR use of unstable library feature 'unstable_default'
+    // let _ = STRUCT1.field + 1; //~ ERROR use of unstable library feature 'unstable_default'
+    // let _ = STRUCT1.field + 1usize; //~ ERROR use of unstable library feature 'unstable_default'
+
+    // let _ = Struct2 { field: 1 }; // ok
+    // let _: Struct2 = Struct2 { field: 1 }; // ok
+    // let _: Struct2<usize> = Struct2 { field: 1 }; // ok
+
+    // let _ = STRUCT2;
+    // let _: Struct2 = STRUCT2; // ok
+    // let _: Struct2<usize> = STRUCT2; // ok
+    // let _: Struct2<usize> = STRUCT2; // ok
+    // let _ = STRUCT2.field; // ok
+    // let _: usize = STRUCT2.field; // ok
+    // let _ = STRUCT2.field + 1; // ok
+    // let _ = STRUCT2.field + 1usize; // ok
+}

--- a/src/test/ui/stability-attribute/generics-default-stability.rs
+++ b/src/test/ui/stability-attribute/generics-default-stability.rs
@@ -115,4 +115,6 @@ fn main() {
 
     let _: Box2<isize, System> = Box2::new(1); // ok
     let _: Box2<isize> = Box2::new(1); // ok
+
+    let _: Box3<isize> = Box3::new(1); // ok
 }

--- a/src/test/ui/stability-attribute/generics-default-stability.rs
+++ b/src/test/ui/stability-attribute/generics-default-stability.rs
@@ -76,4 +76,31 @@ fn main() {
     let _: Struct3<usize> = Struct3 { field1: 0, field2: 0 }; // ok
     let _ = STRUCT3.field2 + 1; // ok
     let _ = STRUCT3.field2 + 1usize; // ok
+
+    let _ = STRUCT4;
+    let _: Struct4<isize> = Struct4 { field: 1 };
+    //~^ use of deprecated item 'unstable_generic_param::Struct4': test [deprecated]
+    //~^^ use of deprecated item 'unstable_generic_param::Struct4': test [deprecated]
+    //~^^^ use of deprecated item 'unstable_generic_param::Struct4::field': test [deprecated]
+    let _ = STRUCT4;
+    let _: Struct4 = STRUCT4; //~ use of deprecated item 'unstable_generic_param::Struct4': test [deprecated]
+    let _: Struct4<usize> = STRUCT4; //~ use of deprecated item 'unstable_generic_param::Struct4': test [deprecated]
+    let _: Struct4<isize> = Struct4 { field: 0 };
+    //~^ use of deprecated item 'unstable_generic_param::Struct4': test [deprecated]
+    //~^^ use of deprecated item 'unstable_generic_param::Struct4': test [deprecated]
+    //~^^^ use of deprecated item 'unstable_generic_param::Struct4::field': test [deprecated]
+
+    let _ = STRUCT5;
+    let _: Struct5<isize> = Struct5 { field: 1 }; //~ ERROR use of unstable library feature 'unstable_default'
+    //~^ use of deprecated item 'unstable_generic_param::Struct5': test [deprecated]
+    //~^^ use of deprecated item 'unstable_generic_param::Struct5': test [deprecated]
+    //~^^^ use of deprecated item 'unstable_generic_param::Struct5::field': test [deprecated]
+    let _ = STRUCT5;
+    let _: Struct5 = STRUCT5; //~ use of deprecated item 'unstable_generic_param::Struct5': test [deprecated]
+    let _: Struct5<usize> = STRUCT5; //~ ERROR use of unstable library feature 'unstable_default'
+    //~^ use of deprecated item 'unstable_generic_param::Struct5': test [deprecated]
+    let _: Struct5<isize> = Struct5 { field: 0 }; //~ ERROR use of unstable library feature 'unstable_default'
+    //~^ use of deprecated item 'unstable_generic_param::Struct5': test [deprecated]
+    //~^^ use of deprecated item 'unstable_generic_param::Struct5': test [deprecated]
+    //~^^^ use of deprecated item 'unstable_generic_param::Struct5::field': test [deprecated]
 }

--- a/src/test/ui/stability-attribute/generics-default-stability.rs
+++ b/src/test/ui/stability-attribute/generics-default-stability.rs
@@ -95,15 +95,12 @@ fn main() {
     //~^ use of deprecated item 'unstable_generic_param::Struct5': test [deprecated]
     //~^^ use of deprecated item 'unstable_generic_param::Struct5': test [deprecated]
     //~^^^ use of deprecated item 'unstable_generic_param::Struct5::field': test [deprecated]
-    //~^^^^ use of deprecated item 'unstable_generic_param::Struct5::A': test [deprecated]
     let _ = STRUCT5;
     let _: Struct5 = STRUCT5; //~ use of deprecated item 'unstable_generic_param::Struct5': test [deprecated]
     let _: Struct5<usize> = STRUCT5; //~ ERROR use of unstable library feature 'unstable_default'
     //~^ use of deprecated item 'unstable_generic_param::Struct5': test [deprecated]
-    //~^^ use of deprecated item 'unstable_generic_param::Struct5::A': test [deprecated]
     let _: Struct5<isize> = Struct5 { field: 0 }; //~ ERROR use of unstable library feature 'unstable_default'
     //~^ use of deprecated item 'unstable_generic_param::Struct5': test [deprecated]
     //~^^ use of deprecated item 'unstable_generic_param::Struct5': test [deprecated]
     //~^^^ use of deprecated item 'unstable_generic_param::Struct5::field': test [deprecated]
-    //~^^^^ use of deprecated item 'unstable_generic_param::Struct5::A': test [deprecated]
 }

--- a/src/test/ui/stability-attribute/generics-default-stability.rs
+++ b/src/test/ui/stability-attribute/generics-default-stability.rs
@@ -95,12 +95,15 @@ fn main() {
     //~^ use of deprecated item 'unstable_generic_param::Struct5': test [deprecated]
     //~^^ use of deprecated item 'unstable_generic_param::Struct5': test [deprecated]
     //~^^^ use of deprecated item 'unstable_generic_param::Struct5::field': test [deprecated]
+    //~^^^^ use of deprecated item 'unstable_generic_param::Struct5::A': test [deprecated]
     let _ = STRUCT5;
     let _: Struct5 = STRUCT5; //~ use of deprecated item 'unstable_generic_param::Struct5': test [deprecated]
     let _: Struct5<usize> = STRUCT5; //~ ERROR use of unstable library feature 'unstable_default'
     //~^ use of deprecated item 'unstable_generic_param::Struct5': test [deprecated]
+    //~^^ use of deprecated item 'unstable_generic_param::Struct5::A': test [deprecated]
     let _: Struct5<isize> = Struct5 { field: 0 }; //~ ERROR use of unstable library feature 'unstable_default'
     //~^ use of deprecated item 'unstable_generic_param::Struct5': test [deprecated]
     //~^^ use of deprecated item 'unstable_generic_param::Struct5': test [deprecated]
     //~^^^ use of deprecated item 'unstable_generic_param::Struct5::field': test [deprecated]
+    //~^^^^ use of deprecated item 'unstable_generic_param::Struct5::A': test [deprecated]
 }

--- a/src/test/ui/stability-attribute/generics-default-stability.stderr
+++ b/src/test/ui/stability-attribute/generics-default-stability.stderr
@@ -22,6 +22,80 @@ LL | impl Trait2<usize> for S {
    |
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
 
+warning: use of deprecated item 'unstable_generic_param::Struct4': test
+  --> $DIR/generics-default-stability.rs:81:29
+   |
+LL |     let _: Struct4<isize> = Struct4 { field: 1 };
+   |                             ^^^^^^^
+   |
+   = note: `#[warn(deprecated)]` on by default
+
+warning: use of deprecated item 'unstable_generic_param::Struct4': test
+  --> $DIR/generics-default-stability.rs:81:12
+   |
+LL |     let _: Struct4<isize> = Struct4 { field: 1 };
+   |            ^^^^^^^^^^^^^^
+
+warning: use of deprecated item 'unstable_generic_param::Struct4': test
+  --> $DIR/generics-default-stability.rs:86:12
+   |
+LL |     let _: Struct4 = STRUCT4;
+   |            ^^^^^^^
+
+warning: use of deprecated item 'unstable_generic_param::Struct4': test
+  --> $DIR/generics-default-stability.rs:87:12
+   |
+LL |     let _: Struct4<usize> = STRUCT4;
+   |            ^^^^^^^^^^^^^^
+
+warning: use of deprecated item 'unstable_generic_param::Struct4': test
+  --> $DIR/generics-default-stability.rs:88:29
+   |
+LL |     let _: Struct4<isize> = Struct4 { field: 0 };
+   |                             ^^^^^^^
+
+warning: use of deprecated item 'unstable_generic_param::Struct4': test
+  --> $DIR/generics-default-stability.rs:88:12
+   |
+LL |     let _: Struct4<isize> = Struct4 { field: 0 };
+   |            ^^^^^^^^^^^^^^
+
+warning: use of deprecated item 'unstable_generic_param::Struct5': test
+  --> $DIR/generics-default-stability.rs:94:29
+   |
+LL |     let _: Struct5<isize> = Struct5 { field: 1 };
+   |                             ^^^^^^^
+
+warning: use of deprecated item 'unstable_generic_param::Struct5': test
+  --> $DIR/generics-default-stability.rs:94:12
+   |
+LL |     let _: Struct5<isize> = Struct5 { field: 1 };
+   |            ^^^^^^^^^^^^^^
+
+warning: use of deprecated item 'unstable_generic_param::Struct5': test
+  --> $DIR/generics-default-stability.rs:99:12
+   |
+LL |     let _: Struct5 = STRUCT5;
+   |            ^^^^^^^
+
+warning: use of deprecated item 'unstable_generic_param::Struct5': test
+  --> $DIR/generics-default-stability.rs:100:12
+   |
+LL |     let _: Struct5<usize> = STRUCT5;
+   |            ^^^^^^^^^^^^^^
+
+warning: use of deprecated item 'unstable_generic_param::Struct5': test
+  --> $DIR/generics-default-stability.rs:102:29
+   |
+LL |     let _: Struct5<isize> = Struct5 { field: 0 };
+   |                             ^^^^^^^
+
+warning: use of deprecated item 'unstable_generic_param::Struct5': test
+  --> $DIR/generics-default-stability.rs:102:12
+   |
+LL |     let _: Struct5<isize> = Struct5 { field: 0 };
+   |            ^^^^^^^^^^^^^^
+
 error[E0658]: use of unstable library feature 'unstable_default'
   --> $DIR/generics-default-stability.rs:35:20
    |
@@ -70,6 +144,54 @@ LL |     let _: Struct3<usize, usize> = Struct3 { field1: 0, field2: 0 };
    |
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
 
-error: aborting due to 9 previous errors
+error[E0658]: use of unstable library feature 'unstable_default'
+  --> $DIR/generics-default-stability.rs:94:20
+   |
+LL |     let _: Struct5<isize> = Struct5 { field: 1 };
+   |                    ^^^^^
+   |
+   = help: add `#![feature(unstable_default)]` to the crate attributes to enable
+
+error[E0658]: use of unstable library feature 'unstable_default'
+  --> $DIR/generics-default-stability.rs:100:20
+   |
+LL |     let _: Struct5<usize> = STRUCT5;
+   |                    ^^^^^
+   |
+   = help: add `#![feature(unstable_default)]` to the crate attributes to enable
+
+error[E0658]: use of unstable library feature 'unstable_default'
+  --> $DIR/generics-default-stability.rs:102:20
+   |
+LL |     let _: Struct5<isize> = Struct5 { field: 0 };
+   |                    ^^^^^
+   |
+   = help: add `#![feature(unstable_default)]` to the crate attributes to enable
+
+warning: use of deprecated item 'unstable_generic_param::Struct4::field': test
+  --> $DIR/generics-default-stability.rs:81:39
+   |
+LL |     let _: Struct4<isize> = Struct4 { field: 1 };
+   |                                       ^^^^^^^^
+
+warning: use of deprecated item 'unstable_generic_param::Struct4::field': test
+  --> $DIR/generics-default-stability.rs:88:39
+   |
+LL |     let _: Struct4<isize> = Struct4 { field: 0 };
+   |                                       ^^^^^^^^
+
+warning: use of deprecated item 'unstable_generic_param::Struct5::field': test
+  --> $DIR/generics-default-stability.rs:94:39
+   |
+LL |     let _: Struct5<isize> = Struct5 { field: 1 };
+   |                                       ^^^^^^^^
+
+warning: use of deprecated item 'unstable_generic_param::Struct5::field': test
+  --> $DIR/generics-default-stability.rs:102:39
+   |
+LL |     let _: Struct5<isize> = Struct5 { field: 0 };
+   |                                       ^^^^^^^^
+
+error: aborting due to 12 previous errors; 16 warnings emitted
 
 For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/stability-attribute/generics-default-stability.stderr
+++ b/src/test/ui/stability-attribute/generics-default-stability.stderr
@@ -1,5 +1,5 @@
 error[E0658]: use of unstable library feature 'unstable_default'
-  --> $DIR/generics-default-stability.rs:16:13
+  --> $DIR/generics-default-stability.rs:17:13
    |
 LL | impl Trait1<usize> for S {
    |             ^^^^^
@@ -7,7 +7,7 @@ LL | impl Trait1<usize> for S {
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_default'
-  --> $DIR/generics-default-stability.rs:20:13
+  --> $DIR/generics-default-stability.rs:21:13
    |
 LL | impl Trait1<isize> for S {
    |             ^^^^^
@@ -15,7 +15,7 @@ LL | impl Trait1<isize> for S {
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_default'
-  --> $DIR/generics-default-stability.rs:24:13
+  --> $DIR/generics-default-stability.rs:25:13
    |
 LL | impl Trait2<usize> for S {
    |             ^^^^^
@@ -23,7 +23,7 @@ LL | impl Trait2<usize> for S {
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
 
 warning: use of deprecated item 'unstable_generic_param::Struct4': test
-  --> $DIR/generics-default-stability.rs:83:29
+  --> $DIR/generics-default-stability.rs:84:29
    |
 LL |     let _: Struct4<isize> = Struct4 { field: 1 };
    |                             ^^^^^^^
@@ -31,73 +31,73 @@ LL |     let _: Struct4<isize> = Struct4 { field: 1 };
    = note: `#[warn(deprecated)]` on by default
 
 warning: use of deprecated item 'unstable_generic_param::Struct4': test
-  --> $DIR/generics-default-stability.rs:83:12
+  --> $DIR/generics-default-stability.rs:84:12
    |
 LL |     let _: Struct4<isize> = Struct4 { field: 1 };
    |            ^^^^^^^^^^^^^^
 
 warning: use of deprecated item 'unstable_generic_param::Struct4': test
-  --> $DIR/generics-default-stability.rs:88:12
+  --> $DIR/generics-default-stability.rs:89:12
    |
 LL |     let _: Struct4 = STRUCT4;
    |            ^^^^^^^
 
 warning: use of deprecated item 'unstable_generic_param::Struct4': test
-  --> $DIR/generics-default-stability.rs:89:12
+  --> $DIR/generics-default-stability.rs:90:12
    |
 LL |     let _: Struct4<usize> = STRUCT4;
    |            ^^^^^^^^^^^^^^
 
 warning: use of deprecated item 'unstable_generic_param::Struct4': test
-  --> $DIR/generics-default-stability.rs:90:29
+  --> $DIR/generics-default-stability.rs:91:29
    |
 LL |     let _: Struct4<isize> = Struct4 { field: 0 };
    |                             ^^^^^^^
 
 warning: use of deprecated item 'unstable_generic_param::Struct4': test
-  --> $DIR/generics-default-stability.rs:90:12
+  --> $DIR/generics-default-stability.rs:91:12
    |
 LL |     let _: Struct4<isize> = Struct4 { field: 0 };
    |            ^^^^^^^^^^^^^^
 
 warning: use of deprecated item 'unstable_generic_param::Struct5': test
-  --> $DIR/generics-default-stability.rs:96:29
+  --> $DIR/generics-default-stability.rs:97:29
    |
 LL |     let _: Struct5<isize> = Struct5 { field: 1 };
    |                             ^^^^^^^
 
 warning: use of deprecated item 'unstable_generic_param::Struct5': test
-  --> $DIR/generics-default-stability.rs:96:12
+  --> $DIR/generics-default-stability.rs:97:12
    |
 LL |     let _: Struct5<isize> = Struct5 { field: 1 };
    |            ^^^^^^^^^^^^^^
 
 warning: use of deprecated item 'unstable_generic_param::Struct5': test
-  --> $DIR/generics-default-stability.rs:101:12
+  --> $DIR/generics-default-stability.rs:102:12
    |
 LL |     let _: Struct5 = STRUCT5;
    |            ^^^^^^^
 
 warning: use of deprecated item 'unstable_generic_param::Struct5': test
-  --> $DIR/generics-default-stability.rs:102:12
+  --> $DIR/generics-default-stability.rs:103:12
    |
 LL |     let _: Struct5<usize> = STRUCT5;
    |            ^^^^^^^^^^^^^^
 
 warning: use of deprecated item 'unstable_generic_param::Struct5': test
-  --> $DIR/generics-default-stability.rs:104:29
+  --> $DIR/generics-default-stability.rs:105:29
    |
 LL |     let _: Struct5<isize> = Struct5 { field: 0 };
    |                             ^^^^^^^
 
 warning: use of deprecated item 'unstable_generic_param::Struct5': test
-  --> $DIR/generics-default-stability.rs:104:12
+  --> $DIR/generics-default-stability.rs:105:12
    |
 LL |     let _: Struct5<isize> = Struct5 { field: 0 };
    |            ^^^^^^^^^^^^^^
 
 error[E0658]: use of unstable library feature 'unstable_default'
-  --> $DIR/generics-default-stability.rs:35:20
+  --> $DIR/generics-default-stability.rs:36:20
    |
 LL |     let _: Struct1<isize> = Struct1 { field: 1 };
    |                    ^^^^^
@@ -105,7 +105,7 @@ LL |     let _: Struct1<isize> = Struct1 { field: 1 };
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_default'
-  --> $DIR/generics-default-stability.rs:39:20
+  --> $DIR/generics-default-stability.rs:40:20
    |
 LL |     let _: Struct1<usize> = STRUCT1;
    |                    ^^^^^
@@ -113,7 +113,7 @@ LL |     let _: Struct1<usize> = STRUCT1;
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_default'
-  --> $DIR/generics-default-stability.rs:40:20
+  --> $DIR/generics-default-stability.rs:41:20
    |
 LL |     let _: Struct1<isize> = Struct1 { field: 0 };
    |                    ^^^^^
@@ -121,7 +121,7 @@ LL |     let _: Struct1<isize> = Struct1 { field: 0 };
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_default'
-  --> $DIR/generics-default-stability.rs:69:27
+  --> $DIR/generics-default-stability.rs:70:27
    |
 LL |     let _: Struct3<isize, usize> = STRUCT3;
    |                           ^^^^^
@@ -129,7 +129,7 @@ LL |     let _: Struct3<isize, usize> = STRUCT3;
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_default'
-  --> $DIR/generics-default-stability.rs:71:27
+  --> $DIR/generics-default-stability.rs:72:27
    |
 LL |     let _: Struct3<isize, isize> = Struct3 { field1: 0, field2: 0 };
    |                           ^^^^^
@@ -137,7 +137,7 @@ LL |     let _: Struct3<isize, isize> = Struct3 { field1: 0, field2: 0 };
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_default'
-  --> $DIR/generics-default-stability.rs:72:27
+  --> $DIR/generics-default-stability.rs:73:27
    |
 LL |     let _: Struct3<usize, usize> = Struct3 { field1: 0, field2: 0 };
    |                           ^^^^^
@@ -145,7 +145,7 @@ LL |     let _: Struct3<usize, usize> = Struct3 { field1: 0, field2: 0 };
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_default'
-  --> $DIR/generics-default-stability.rs:96:20
+  --> $DIR/generics-default-stability.rs:97:20
    |
 LL |     let _: Struct5<isize> = Struct5 { field: 1 };
    |                    ^^^^^
@@ -153,7 +153,7 @@ LL |     let _: Struct5<isize> = Struct5 { field: 1 };
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_default'
-  --> $DIR/generics-default-stability.rs:102:20
+  --> $DIR/generics-default-stability.rs:103:20
    |
 LL |     let _: Struct5<usize> = STRUCT5;
    |                    ^^^^^
@@ -161,7 +161,7 @@ LL |     let _: Struct5<usize> = STRUCT5;
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_default'
-  --> $DIR/generics-default-stability.rs:104:20
+  --> $DIR/generics-default-stability.rs:105:20
    |
 LL |     let _: Struct5<isize> = Struct5 { field: 0 };
    |                    ^^^^^
@@ -169,25 +169,25 @@ LL |     let _: Struct5<isize> = Struct5 { field: 0 };
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
 
 warning: use of deprecated item 'unstable_generic_param::Struct4::field': test
-  --> $DIR/generics-default-stability.rs:83:39
+  --> $DIR/generics-default-stability.rs:84:39
    |
 LL |     let _: Struct4<isize> = Struct4 { field: 1 };
    |                                       ^^^^^^^^
 
 warning: use of deprecated item 'unstable_generic_param::Struct4::field': test
-  --> $DIR/generics-default-stability.rs:90:39
+  --> $DIR/generics-default-stability.rs:91:39
    |
 LL |     let _: Struct4<isize> = Struct4 { field: 0 };
    |                                       ^^^^^^^^
 
 warning: use of deprecated item 'unstable_generic_param::Struct5::field': test
-  --> $DIR/generics-default-stability.rs:96:39
+  --> $DIR/generics-default-stability.rs:97:39
    |
 LL |     let _: Struct5<isize> = Struct5 { field: 1 };
    |                                       ^^^^^^^^
 
 warning: use of deprecated item 'unstable_generic_param::Struct5::field': test
-  --> $DIR/generics-default-stability.rs:104:39
+  --> $DIR/generics-default-stability.rs:105:39
    |
 LL |     let _: Struct5<isize> = Struct5 { field: 0 };
    |                                       ^^^^^^^^

--- a/src/test/ui/stability-attribute/generics-default-stability.stderr
+++ b/src/test/ui/stability-attribute/generics-default-stability.stderr
@@ -23,7 +23,7 @@ LL | impl Trait2<usize> for S {
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_default'
-  --> $DIR/generics-default-stability.rs:37:20
+  --> $DIR/generics-default-stability.rs:35:20
    |
 LL |     let _: Struct1<isize> = Struct1 { field: 1 };
    |                    ^^^^^
@@ -31,7 +31,7 @@ LL |     let _: Struct1<isize> = Struct1 { field: 1 };
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_default'
-  --> $DIR/generics-default-stability.rs:41:20
+  --> $DIR/generics-default-stability.rs:39:20
    |
 LL |     let _: Struct1<usize> = STRUCT1;
    |                    ^^^^^
@@ -39,9 +39,9 @@ LL |     let _: Struct1<usize> = STRUCT1;
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_default'
-  --> $DIR/generics-default-stability.rs:42:20
+  --> $DIR/generics-default-stability.rs:40:20
    |
-LL |     let _: Struct1<usize> = STRUCT1;
+LL |     let _: Struct1<isize> = Struct1 { field: 0 };
    |                    ^^^^^
    |
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable

--- a/src/test/ui/stability-attribute/generics-default-stability.stderr
+++ b/src/test/ui/stability-attribute/generics-default-stability.stderr
@@ -23,7 +23,7 @@ LL | impl Trait2<usize> for S {
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
 
 warning: use of deprecated item 'unstable_generic_param::Struct4': test
-  --> $DIR/generics-default-stability.rs:81:29
+  --> $DIR/generics-default-stability.rs:83:29
    |
 LL |     let _: Struct4<isize> = Struct4 { field: 1 };
    |                             ^^^^^^^
@@ -31,67 +31,67 @@ LL |     let _: Struct4<isize> = Struct4 { field: 1 };
    = note: `#[warn(deprecated)]` on by default
 
 warning: use of deprecated item 'unstable_generic_param::Struct4': test
-  --> $DIR/generics-default-stability.rs:81:12
+  --> $DIR/generics-default-stability.rs:83:12
    |
 LL |     let _: Struct4<isize> = Struct4 { field: 1 };
    |            ^^^^^^^^^^^^^^
 
 warning: use of deprecated item 'unstable_generic_param::Struct4': test
-  --> $DIR/generics-default-stability.rs:86:12
+  --> $DIR/generics-default-stability.rs:88:12
    |
 LL |     let _: Struct4 = STRUCT4;
    |            ^^^^^^^
 
 warning: use of deprecated item 'unstable_generic_param::Struct4': test
-  --> $DIR/generics-default-stability.rs:87:12
+  --> $DIR/generics-default-stability.rs:89:12
    |
 LL |     let _: Struct4<usize> = STRUCT4;
    |            ^^^^^^^^^^^^^^
 
 warning: use of deprecated item 'unstable_generic_param::Struct4': test
-  --> $DIR/generics-default-stability.rs:88:29
+  --> $DIR/generics-default-stability.rs:90:29
    |
 LL |     let _: Struct4<isize> = Struct4 { field: 0 };
    |                             ^^^^^^^
 
 warning: use of deprecated item 'unstable_generic_param::Struct4': test
-  --> $DIR/generics-default-stability.rs:88:12
+  --> $DIR/generics-default-stability.rs:90:12
    |
 LL |     let _: Struct4<isize> = Struct4 { field: 0 };
    |            ^^^^^^^^^^^^^^
 
 warning: use of deprecated item 'unstable_generic_param::Struct5': test
-  --> $DIR/generics-default-stability.rs:94:29
+  --> $DIR/generics-default-stability.rs:96:29
    |
 LL |     let _: Struct5<isize> = Struct5 { field: 1 };
    |                             ^^^^^^^
 
 warning: use of deprecated item 'unstable_generic_param::Struct5': test
-  --> $DIR/generics-default-stability.rs:94:12
+  --> $DIR/generics-default-stability.rs:96:12
    |
 LL |     let _: Struct5<isize> = Struct5 { field: 1 };
    |            ^^^^^^^^^^^^^^
 
 warning: use of deprecated item 'unstable_generic_param::Struct5': test
-  --> $DIR/generics-default-stability.rs:99:12
+  --> $DIR/generics-default-stability.rs:101:12
    |
 LL |     let _: Struct5 = STRUCT5;
    |            ^^^^^^^
 
 warning: use of deprecated item 'unstable_generic_param::Struct5': test
-  --> $DIR/generics-default-stability.rs:100:12
+  --> $DIR/generics-default-stability.rs:102:12
    |
 LL |     let _: Struct5<usize> = STRUCT5;
    |            ^^^^^^^^^^^^^^
 
 warning: use of deprecated item 'unstable_generic_param::Struct5': test
-  --> $DIR/generics-default-stability.rs:102:29
+  --> $DIR/generics-default-stability.rs:104:29
    |
 LL |     let _: Struct5<isize> = Struct5 { field: 0 };
    |                             ^^^^^^^
 
 warning: use of deprecated item 'unstable_generic_param::Struct5': test
-  --> $DIR/generics-default-stability.rs:102:12
+  --> $DIR/generics-default-stability.rs:104:12
    |
 LL |     let _: Struct5<isize> = Struct5 { field: 0 };
    |            ^^^^^^^^^^^^^^
@@ -121,7 +121,7 @@ LL |     let _: Struct1<isize> = Struct1 { field: 0 };
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_default'
-  --> $DIR/generics-default-stability.rs:67:27
+  --> $DIR/generics-default-stability.rs:69:27
    |
 LL |     let _: Struct3<isize, usize> = STRUCT3;
    |                           ^^^^^
@@ -129,7 +129,7 @@ LL |     let _: Struct3<isize, usize> = STRUCT3;
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_default'
-  --> $DIR/generics-default-stability.rs:69:27
+  --> $DIR/generics-default-stability.rs:71:27
    |
 LL |     let _: Struct3<isize, isize> = Struct3 { field1: 0, field2: 0 };
    |                           ^^^^^
@@ -137,7 +137,7 @@ LL |     let _: Struct3<isize, isize> = Struct3 { field1: 0, field2: 0 };
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_default'
-  --> $DIR/generics-default-stability.rs:70:27
+  --> $DIR/generics-default-stability.rs:72:27
    |
 LL |     let _: Struct3<usize, usize> = Struct3 { field1: 0, field2: 0 };
    |                           ^^^^^
@@ -145,17 +145,9 @@ LL |     let _: Struct3<usize, usize> = Struct3 { field1: 0, field2: 0 };
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_default'
-  --> $DIR/generics-default-stability.rs:94:20
+  --> $DIR/generics-default-stability.rs:96:20
    |
 LL |     let _: Struct5<isize> = Struct5 { field: 1 };
-   |                    ^^^^^
-   |
-   = help: add `#![feature(unstable_default)]` to the crate attributes to enable
-
-error[E0658]: use of unstable library feature 'unstable_default'
-  --> $DIR/generics-default-stability.rs:100:20
-   |
-LL |     let _: Struct5<usize> = STRUCT5;
    |                    ^^^^^
    |
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
@@ -163,31 +155,39 @@ LL |     let _: Struct5<usize> = STRUCT5;
 error[E0658]: use of unstable library feature 'unstable_default'
   --> $DIR/generics-default-stability.rs:102:20
    |
+LL |     let _: Struct5<usize> = STRUCT5;
+   |                    ^^^^^
+   |
+   = help: add `#![feature(unstable_default)]` to the crate attributes to enable
+
+error[E0658]: use of unstable library feature 'unstable_default'
+  --> $DIR/generics-default-stability.rs:104:20
+   |
 LL |     let _: Struct5<isize> = Struct5 { field: 0 };
    |                    ^^^^^
    |
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
 
 warning: use of deprecated item 'unstable_generic_param::Struct4::field': test
-  --> $DIR/generics-default-stability.rs:81:39
+  --> $DIR/generics-default-stability.rs:83:39
    |
 LL |     let _: Struct4<isize> = Struct4 { field: 1 };
    |                                       ^^^^^^^^
 
 warning: use of deprecated item 'unstable_generic_param::Struct4::field': test
-  --> $DIR/generics-default-stability.rs:88:39
+  --> $DIR/generics-default-stability.rs:90:39
    |
 LL |     let _: Struct4<isize> = Struct4 { field: 0 };
    |                                       ^^^^^^^^
 
 warning: use of deprecated item 'unstable_generic_param::Struct5::field': test
-  --> $DIR/generics-default-stability.rs:94:39
+  --> $DIR/generics-default-stability.rs:96:39
    |
 LL |     let _: Struct5<isize> = Struct5 { field: 1 };
    |                                       ^^^^^^^^
 
 warning: use of deprecated item 'unstable_generic_param::Struct5::field': test
-  --> $DIR/generics-default-stability.rs:102:39
+  --> $DIR/generics-default-stability.rs:104:39
    |
 LL |     let _: Struct5<isize> = Struct5 { field: 0 };
    |                                       ^^^^^^^^

--- a/src/test/ui/stability-attribute/generics-default-stability.stderr
+++ b/src/test/ui/stability-attribute/generics-default-stability.stderr
@@ -168,6 +168,14 @@ LL |     let _: Struct5<isize> = Struct5 { field: 0 };
    |
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
 
+error[E0658]: use of unstable library feature 'box_alloc_param'
+  --> $DIR/generics-default-stability.rs:113:24
+   |
+LL |     let _: Box1<isize, System> = Box1::new(1);
+   |                        ^^^^^^
+   |
+   = help: add `#![feature(box_alloc_param)]` to the crate attributes to enable
+
 warning: use of deprecated item 'unstable_generic_param::Struct4::field': test
   --> $DIR/generics-default-stability.rs:84:39
    |
@@ -192,6 +200,6 @@ warning: use of deprecated item 'unstable_generic_param::Struct5::field': test
 LL |     let _: Struct5<isize> = Struct5 { field: 0 };
    |                                       ^^^^^^^^
 
-error: aborting due to 12 previous errors; 16 warnings emitted
+error: aborting due to 13 previous errors; 16 warnings emitted
 
 For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/stability-attribute/generics-default-stability.stderr
+++ b/src/test/ui/stability-attribute/generics-default-stability.stderr
@@ -1,5 +1,5 @@
 error[E0658]: use of unstable library feature 'unstable_default'
-  --> $DIR/generics-default-stability.rs:15:13
+  --> $DIR/generics-default-stability.rs:16:13
    |
 LL | impl Trait1<usize> for S {
    |             ^^^^^
@@ -7,7 +7,7 @@ LL | impl Trait1<usize> for S {
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_default'
-  --> $DIR/generics-default-stability.rs:19:13
+  --> $DIR/generics-default-stability.rs:20:13
    |
 LL | impl Trait1<isize> for S {
    |             ^^^^^
@@ -15,13 +15,37 @@ LL | impl Trait1<isize> for S {
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_default'
-  --> $DIR/generics-default-stability.rs:23:13
+  --> $DIR/generics-default-stability.rs:24:13
    |
 LL | impl Trait2<usize> for S {
    |             ^^^^^
    |
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
 
-error: aborting due to 3 previous errors
+error[E0658]: use of unstable library feature 'unstable_default'
+  --> $DIR/generics-default-stability.rs:37:20
+   |
+LL |     let _: Struct1<isize> = Struct1 { field: 1 };
+   |                    ^^^^^
+   |
+   = help: add `#![feature(unstable_default)]` to the crate attributes to enable
+
+error[E0658]: use of unstable library feature 'unstable_default'
+  --> $DIR/generics-default-stability.rs:41:20
+   |
+LL |     let _: Struct1<usize> = STRUCT1;
+   |                    ^^^^^
+   |
+   = help: add `#![feature(unstable_default)]` to the crate attributes to enable
+
+error[E0658]: use of unstable library feature 'unstable_default'
+  --> $DIR/generics-default-stability.rs:42:20
+   |
+LL |     let _: Struct1<usize> = STRUCT1;
+   |                    ^^^^^
+   |
+   = help: add `#![feature(unstable_default)]` to the crate attributes to enable
+
+error: aborting due to 6 previous errors
 
 For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/stability-attribute/generics-default-stability.stderr
+++ b/src/test/ui/stability-attribute/generics-default-stability.stderr
@@ -1,0 +1,27 @@
+error[E0658]: use of unstable library feature 'unstable_default'
+  --> $DIR/generics-default-stability.rs:15:13
+   |
+LL | impl Trait1<usize> for S {
+   |             ^^^^^
+   |
+   = help: add `#![feature(unstable_default)]` to the crate attributes to enable
+
+error[E0658]: use of unstable library feature 'unstable_default'
+  --> $DIR/generics-default-stability.rs:19:13
+   |
+LL | impl Trait1<isize> for S {
+   |             ^^^^^
+   |
+   = help: add `#![feature(unstable_default)]` to the crate attributes to enable
+
+error[E0658]: use of unstable library feature 'unstable_default'
+  --> $DIR/generics-default-stability.rs:23:13
+   |
+LL | impl Trait2<usize> for S {
+   |             ^^^^^
+   |
+   = help: add `#![feature(unstable_default)]` to the crate attributes to enable
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/stability-attribute/generics-default-stability.stderr
+++ b/src/test/ui/stability-attribute/generics-default-stability.stderr
@@ -46,6 +46,30 @@ LL |     let _: Struct1<isize> = Struct1 { field: 0 };
    |
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
 
-error: aborting due to 6 previous errors
+error[E0658]: use of unstable library feature 'unstable_default'
+  --> $DIR/generics-default-stability.rs:67:27
+   |
+LL |     let _: Struct3<isize, usize> = STRUCT3;
+   |                           ^^^^^
+   |
+   = help: add `#![feature(unstable_default)]` to the crate attributes to enable
+
+error[E0658]: use of unstable library feature 'unstable_default'
+  --> $DIR/generics-default-stability.rs:69:27
+   |
+LL |     let _: Struct3<isize, isize> = Struct3 { field1: 0, field2: 0 };
+   |                           ^^^^^
+   |
+   = help: add `#![feature(unstable_default)]` to the crate attributes to enable
+
+error[E0658]: use of unstable library feature 'unstable_default'
+  --> $DIR/generics-default-stability.rs:70:27
+   |
+LL |     let _: Struct3<usize, usize> = Struct3 { field1: 0, field2: 0 };
+   |                           ^^^^^
+   |
+   = help: add `#![feature(unstable_default)]` to the crate attributes to enable
+
+error: aborting due to 9 previous errors
 
 For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/stability-attribute/generics-default-stability.stderr
+++ b/src/test/ui/stability-attribute/generics-default-stability.stderr
@@ -73,25 +73,25 @@ LL |     let _: Struct5<isize> = Struct5 { field: 1 };
    |            ^^^^^^^^^^^^^^
 
 warning: use of deprecated item 'unstable_generic_param::Struct5': test
-  --> $DIR/generics-default-stability.rs:99:12
+  --> $DIR/generics-default-stability.rs:100:12
    |
 LL |     let _: Struct5 = STRUCT5;
    |            ^^^^^^^
 
 warning: use of deprecated item 'unstable_generic_param::Struct5': test
-  --> $DIR/generics-default-stability.rs:100:12
+  --> $DIR/generics-default-stability.rs:101:12
    |
 LL |     let _: Struct5<usize> = STRUCT5;
    |            ^^^^^^^^^^^^^^
 
 warning: use of deprecated item 'unstable_generic_param::Struct5': test
-  --> $DIR/generics-default-stability.rs:102:29
+  --> $DIR/generics-default-stability.rs:104:29
    |
 LL |     let _: Struct5<isize> = Struct5 { field: 0 };
    |                             ^^^^^^^
 
 warning: use of deprecated item 'unstable_generic_param::Struct5': test
-  --> $DIR/generics-default-stability.rs:102:12
+  --> $DIR/generics-default-stability.rs:104:12
    |
 LL |     let _: Struct5<isize> = Struct5 { field: 0 };
    |            ^^^^^^^^^^^^^^
@@ -144,6 +144,12 @@ LL |     let _: Struct3<usize, usize> = Struct3 { field1: 0, field2: 0 };
    |
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
 
+warning: use of deprecated item 'unstable_generic_param::Struct5::A': test
+  --> $DIR/generics-default-stability.rs:94:20
+   |
+LL |     let _: Struct5<isize> = Struct5 { field: 1 };
+   |                    ^^^^^
+
 error[E0658]: use of unstable library feature 'unstable_default'
   --> $DIR/generics-default-stability.rs:94:20
    |
@@ -152,16 +158,28 @@ LL |     let _: Struct5<isize> = Struct5 { field: 1 };
    |
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
 
+warning: use of deprecated item 'unstable_generic_param::Struct5::A': test
+  --> $DIR/generics-default-stability.rs:101:20
+   |
+LL |     let _: Struct5<usize> = STRUCT5;
+   |                    ^^^^^
+
 error[E0658]: use of unstable library feature 'unstable_default'
-  --> $DIR/generics-default-stability.rs:100:20
+  --> $DIR/generics-default-stability.rs:101:20
    |
 LL |     let _: Struct5<usize> = STRUCT5;
    |                    ^^^^^
    |
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
 
+warning: use of deprecated item 'unstable_generic_param::Struct5::A': test
+  --> $DIR/generics-default-stability.rs:104:20
+   |
+LL |     let _: Struct5<isize> = Struct5 { field: 0 };
+   |                    ^^^^^
+
 error[E0658]: use of unstable library feature 'unstable_default'
-  --> $DIR/generics-default-stability.rs:102:20
+  --> $DIR/generics-default-stability.rs:104:20
    |
 LL |     let _: Struct5<isize> = Struct5 { field: 0 };
    |                    ^^^^^
@@ -187,11 +205,11 @@ LL |     let _: Struct5<isize> = Struct5 { field: 1 };
    |                                       ^^^^^^^^
 
 warning: use of deprecated item 'unstable_generic_param::Struct5::field': test
-  --> $DIR/generics-default-stability.rs:102:39
+  --> $DIR/generics-default-stability.rs:104:39
    |
 LL |     let _: Struct5<isize> = Struct5 { field: 0 };
    |                                       ^^^^^^^^
 
-error: aborting due to 12 previous errors; 16 warnings emitted
+error: aborting due to 12 previous errors; 19 warnings emitted
 
 For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/stability-attribute/generics-default-stability.stderr
+++ b/src/test/ui/stability-attribute/generics-default-stability.stderr
@@ -73,25 +73,25 @@ LL |     let _: Struct5<isize> = Struct5 { field: 1 };
    |            ^^^^^^^^^^^^^^
 
 warning: use of deprecated item 'unstable_generic_param::Struct5': test
-  --> $DIR/generics-default-stability.rs:100:12
+  --> $DIR/generics-default-stability.rs:99:12
    |
 LL |     let _: Struct5 = STRUCT5;
    |            ^^^^^^^
 
 warning: use of deprecated item 'unstable_generic_param::Struct5': test
-  --> $DIR/generics-default-stability.rs:101:12
+  --> $DIR/generics-default-stability.rs:100:12
    |
 LL |     let _: Struct5<usize> = STRUCT5;
    |            ^^^^^^^^^^^^^^
 
 warning: use of deprecated item 'unstable_generic_param::Struct5': test
-  --> $DIR/generics-default-stability.rs:104:29
+  --> $DIR/generics-default-stability.rs:102:29
    |
 LL |     let _: Struct5<isize> = Struct5 { field: 0 };
    |                             ^^^^^^^
 
 warning: use of deprecated item 'unstable_generic_param::Struct5': test
-  --> $DIR/generics-default-stability.rs:104:12
+  --> $DIR/generics-default-stability.rs:102:12
    |
 LL |     let _: Struct5<isize> = Struct5 { field: 0 };
    |            ^^^^^^^^^^^^^^
@@ -144,12 +144,6 @@ LL |     let _: Struct3<usize, usize> = Struct3 { field1: 0, field2: 0 };
    |
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
 
-warning: use of deprecated item 'unstable_generic_param::Struct5::A': test
-  --> $DIR/generics-default-stability.rs:94:20
-   |
-LL |     let _: Struct5<isize> = Struct5 { field: 1 };
-   |                    ^^^^^
-
 error[E0658]: use of unstable library feature 'unstable_default'
   --> $DIR/generics-default-stability.rs:94:20
    |
@@ -158,28 +152,16 @@ LL |     let _: Struct5<isize> = Struct5 { field: 1 };
    |
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
 
-warning: use of deprecated item 'unstable_generic_param::Struct5::A': test
-  --> $DIR/generics-default-stability.rs:101:20
-   |
-LL |     let _: Struct5<usize> = STRUCT5;
-   |                    ^^^^^
-
 error[E0658]: use of unstable library feature 'unstable_default'
-  --> $DIR/generics-default-stability.rs:101:20
+  --> $DIR/generics-default-stability.rs:100:20
    |
 LL |     let _: Struct5<usize> = STRUCT5;
    |                    ^^^^^
    |
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
 
-warning: use of deprecated item 'unstable_generic_param::Struct5::A': test
-  --> $DIR/generics-default-stability.rs:104:20
-   |
-LL |     let _: Struct5<isize> = Struct5 { field: 0 };
-   |                    ^^^^^
-
 error[E0658]: use of unstable library feature 'unstable_default'
-  --> $DIR/generics-default-stability.rs:104:20
+  --> $DIR/generics-default-stability.rs:102:20
    |
 LL |     let _: Struct5<isize> = Struct5 { field: 0 };
    |                    ^^^^^
@@ -205,11 +187,11 @@ LL |     let _: Struct5<isize> = Struct5 { field: 1 };
    |                                       ^^^^^^^^
 
 warning: use of deprecated item 'unstable_generic_param::Struct5::field': test
-  --> $DIR/generics-default-stability.rs:104:39
+  --> $DIR/generics-default-stability.rs:102:39
    |
 LL |     let _: Struct5<isize> = Struct5 { field: 0 };
    |                                       ^^^^^^^^
 
-error: aborting due to 12 previous errors; 19 warnings emitted
+error: aborting due to 12 previous errors; 16 warnings emitted
 
 For more information about this error, try `rustc --explain E0658`.


### PR DESCRIPTION
This is a followup of #65083 as an implementation of https://github.com/rust-lang/wg-allocators/issues/2.
It's the same logic, but in one commit (to avoid rebasing).
It does not contain all of @varkor's clarifying comments and typo fixes.

This is still WIP, I'll summarize what works and followup on https://github.com/rust-lang/rust/pull/65083#issuecomment-623454469 soon.