### PR TITLE
Change default Discord Channel for help

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ To contribute to Rust, please see [CONTRIBUTING](CONTRIBUTING.md).
 Most real-time collaboration happens in a variety of channels on the
 [Rust Discord server][rust-discord], with channels dedicated for getting help,
 community, documentation, and all major contribution areas in the Rust ecosystem.
-A good place to ask for help would be the #help channel.
+A good place to ask for help would be the #contribute channel.
 
 The [rustc dev guide] might be a good place to start if you want to find out how
 various parts of the compiler work.

--- a/src/liballoc/raw_vec.rs
+++ b/src/liballoc/raw_vec.rs
@@ -150,6 +150,7 @@ impl<T, A: AllocRef> RawVec<T, A> {
             alloc_guard(layout.size()).unwrap_or_else(|_| capacity_overflow());
 
             let memory = alloc.alloc(layout, init).unwrap_or_else(|_| handle_alloc_error(layout));
+//            println!("{} {} {}\n", layout, capacity, memory);
             Self {
                 ptr: unsafe { Unique::new_unchecked(memory.ptr.cast().as_ptr()) },
                 cap: Self::capacity_from_bytes(memory.size),


### PR DESCRIPTION
There is no #help channel on discord. I am guessing that #contribute is the best channel for people wanting to contribute, although I am guessing.