### PR TITLE
test/codegen: add UEFI cross-compilation test

### DIFF
--- a/src/test/codegen/uefi-cross-compile.rs
+++ b/src/test/codegen/uefi-cross-compile.rs
@@ -1,0 +1,30 @@
+// Checks whether UEFI targets cross-compile successfully.
+//
+// This test contains a simple UEFI program that simply exits with return code
+// 0. It can be easily run from the UEFI shell (but any other UEFI environment
+// works as well). This program is not run as part of the test. The test merely
+// verifies the cross-compilation does not fail and an entry-point is emitted.
+//
+// The imported definitions from the UEFI specification are intentionally left
+// incomplete. Only the bits that are actually used by this test are defined.
+
+// min-llvm-version 9.0
+
+// compile-flags: --target x86_64-unknown-uefi
+
+#![feature(abi_efiapi, lang_items, no_core)]
+#![no_core]
+#![no_main]
+
+#[lang = "sized"]
+pub trait Sized {}
+#[lang = "freeze"]
+pub trait Freeze {}
+#[lang = "copy"]
+pub trait Copy {}
+
+// CHECK: define win64cc i64 @efi_main{{.*}}
+#[export_name = "efi_main"]
+pub extern "efiapi" fn main(_h: *mut usize, _st: *mut usize) -> usize {
+    return 0;
+}


### PR DESCRIPTION
Add a new codegen test which cross-compiles a UEFI Hello-World program and verifies that an entry-point is emitted.

The UEFI code-generation has broken in nightly before, see for instance:

    commit c1b2fd2121091df67d6a298f535b2db83e67dde5
    Merge: faccb0f07a5 6e77729ed5a
    Author: Dylan DPC <dylan.dpc@gmail.com>
    Date:   Tue May 5 01:49:44 2020 +0200

        Rollup merge of #71881 - IsaacWoods:master, r=petrochenkov

        Correctly handle UEFI targets as Windows-like when emitting sections for LLVM bitcode

This commit adds a very simple UEFI program and verifies that cross-compilation with the built-in `x86_64-unknown-uefi` target works. No runtime testing, nor any elaborate code-validation is done. This simply serves as base test that verifies compilation works and an entry point is emitted.

Usually, you would use `libcore`, but in this test we do not want to trigger re-compilation of `libcore` for `x86_64-unknown-uefi`. Hence, we pull in just enough of `libcore` to make the test compile.

This UEFI program is fully functional and prints `Hello World\n` to the console (UEFI standard output console). You can run it from your UEFI BootManager or from EfiShell. You might want to add `loop {}` before returning from `main()` to actually see the message (from EfiShell it works unchanged).

The imported UEFI definitions are explicitly kept simple. For more elaborate use-cases you would want the full UEFI specification (see the `r_efi` crate for a standalone import of the base UEFI specification).