### PR TITLE
Fix ICE in -Zsave-analysis

### DIFF
--- a/src/librustc_save_analysis/lib.rs
+++ b/src/librustc_save_analysis/lib.rs
@@ -620,7 +620,11 @@ impl<'l, 'tcx> SaveContext<'l, 'tcx> {
     }
 
     pub fn get_path_res(&self, id: NodeId) -> Res {
-        let hir_id = self.tcx.hir().node_id_to_hir_id(id);
+        // FIXME(#71104)
+        let hir_id = match self.tcx.hir().opt_node_id_to_hir_id(id) {
+            Some(id) => id,
+            None => return Res::Err,
+        };
         match self.tcx.hir().get(hir_id) {
             Node::TraitRef(tr) => tr.path.res,
 

--- a/src/test/ui/save-analysis/issue-72267.rs
+++ b/src/test/ui/save-analysis/issue-72267.rs
@@ -1,0 +1,7 @@
+// compile-flags: -Z save-analysis
+
+fn main() {
+    let _: Box<(dyn ?Sized)>;
+    //~^ ERROR `?Trait` is not permitted in trait object types
+    //~| ERROR at least one trait is required for an object type
+}

--- a/src/test/ui/save-analysis/issue-72267.stderr
+++ b/src/test/ui/save-analysis/issue-72267.stderr
@@ -1,0 +1,15 @@
+error: `?Trait` is not permitted in trait object types
+  --> $DIR/issue-72267.rs:4:21
+   |
+LL |     let _: Box<(dyn ?Sized)>;
+   |                     ^^^^^^
+
+error[E0224]: at least one trait is required for an object type
+  --> $DIR/issue-72267.rs:4:17
+   |
+LL |     let _: Box<(dyn ?Sized)>;
+   |                 ^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0224`.


### PR DESCRIPTION
Puts a short-circuit in to avoid an ICE in `-Zsave-analysis`.

r? @ecstatic-morse 

Resolves #72267