### PR TITLE
Avoid stack overflow when printing unevaluated const

### DIFF
--- a/src/test/ui/const-generics/auxiliary/impl-const.rs
+++ b/src/test/ui/const-generics/auxiliary/impl-const.rs
@@ -1,0 +1,9 @@
+#![feature(const_generics)]
+
+pub struct Num<const N: usize>;
+
+// Braces around const expression causes crash
+impl Num<{5}> {
+    pub fn five(&self) {
+    }
+}

--- a/src/test/ui/const-generics/issue-68104-print-stack-overflow.rs
+++ b/src/test/ui/const-generics/issue-68104-print-stack-overflow.rs
@@ -1,0 +1,14 @@
+// aux-build:impl-const.rs
+// run-pass
+
+#![feature(const_generics)]
+#![allow(incomplete_features)]
+
+extern crate impl_const;
+
+use impl_const::*;
+
+pub fn main() {
+    let n = Num::<5>;
+    n.five();
+}


### PR DESCRIPTION
Fixes #68104

When printing the DefPath for an unevaluated const, we may end up trying
to print the same const again. To avoid infinite recursion, we use the
'verbose' format when we try to re-entrantly print a const. This ensures
that the pretty-printing process will always terminate.