### PR TITLE
Warn about unused crate deps

### DIFF
--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -276,6 +276,7 @@ fn register_builtins(store: &mut LintStore, no_interleave_lints: bool) {
         UNUSED_ALLOCATION,
         UNUSED_DOC_COMMENTS,
         UNUSED_EXTERN_CRATES,
+        UNUSED_CRATE_DEPENDENCIES,
         UNUSED_FEATURES,
         UNUSED_LABELS,
         UNUSED_PARENS,

--- a/src/librustc_session/lint/builtin.rs
+++ b/src/librustc_session/lint/builtin.rs
@@ -72,6 +72,12 @@ declare_lint! {
 }
 
 declare_lint! {
+    pub UNUSED_CRATE_DEPENDENCIES,
+    Allow,
+    "crate dependencies that are never used"
+}
+
+declare_lint! {
     pub UNUSED_QUALIFICATIONS,
     Allow,
     "detects unnecessarily qualified names"
@@ -523,6 +529,7 @@ declare_lint_pass! {
         UNCONDITIONAL_PANIC,
         UNUSED_IMPORTS,
         UNUSED_EXTERN_CRATES,
+        UNUSED_CRATE_DEPENDENCIES,
         UNUSED_QUALIFICATIONS,
         UNKNOWN_LINTS,
         UNUSED_VARIABLES,

--- a/src/test/ui/unused-crate-deps/auxiliary/bar.rs
+++ b/src/test/ui/unused-crate-deps/auxiliary/bar.rs
@@ -1,0 +1,1 @@
+pub const BAR: &str = "bar";

--- a/src/test/ui/unused-crate-deps/auxiliary/foo.rs
+++ b/src/test/ui/unused-crate-deps/auxiliary/foo.rs
@@ -1,0 +1,5 @@
+// edition:2018
+// aux-crate:bar=bar.rs
+
+pub const FOO: &str = "foo";
+pub use bar::BAR;

--- a/src/test/ui/unused-crate-deps/libfib.rs
+++ b/src/test/ui/unused-crate-deps/libfib.rs
@@ -1,0 +1,21 @@
+// Test warnings for a library crate
+
+// check-pass
+// aux-crate:bar=bar.rs
+// compile-flags:--crate-type lib -Wunused-crate-dependencies
+
+pub fn fib(n: u32) -> Vec<u32> {
+//~^ WARNING external crate `bar` unused in
+let mut prev = 0;
+    let mut cur = 1;
+    let mut v = vec![];
+
+    for _ in 0..n {
+        v.push(prev);
+        let n = prev + cur;
+        prev = cur;
+        cur = n;
+    }
+
+    v
+}

--- a/src/test/ui/unused-crate-deps/libfib.stderr
+++ b/src/test/ui/unused-crate-deps/libfib.stderr
@@ -1,0 +1,10 @@
+warning: external crate `bar` unused in `libfib`: remove the dependency or add `use bar as _;`
+  --> $DIR/libfib.rs:7:1
+   |
+LL | pub fn fib(n: u32) -> Vec<u32> {
+   | ^
+   |
+   = note: requested on the command line with `-W unused-crate-dependencies`
+
+warning: 1 warning emitted
+

--- a/src/test/ui/unused-crate-deps/suppress.rs
+++ b/src/test/ui/unused-crate-deps/suppress.rs
@@ -1,0 +1,11 @@
+// Suppress by using crate
+
+// edition:2018
+// check-pass
+// aux-crate:bar=bar.rs
+
+#![warn(unused_crate_dependencies)]
+
+use bar as _;
+
+fn main() {}

--- a/src/test/ui/unused-crate-deps/unused-aliases.rs
+++ b/src/test/ui/unused-crate-deps/unused-aliases.rs
@@ -1,0 +1,13 @@
+// Warn about unused aliased for the crate
+
+// edition:2018
+// check-pass
+// aux-crate:bar=bar.rs
+// aux-crate:barbar=bar.rs
+
+#![warn(unused_crate_dependencies)]
+//~^ WARNING external crate `barbar` unused in
+
+use bar as _;
+
+fn main() {}

--- a/src/test/ui/unused-crate-deps/unused-aliases.stderr
+++ b/src/test/ui/unused-crate-deps/unused-aliases.stderr
@@ -1,0 +1,14 @@
+warning: external crate `barbar` unused in `unused_aliases`: remove the dependency or add `use barbar as _;`
+  --> $DIR/unused-aliases.rs:8:1
+   |
+LL | #![warn(unused_crate_dependencies)]
+   | ^
+   |
+note: the lint level is defined here
+  --> $DIR/unused-aliases.rs:8:9
+   |
+LL | #![warn(unused_crate_dependencies)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: 1 warning emitted
+

--- a/src/test/ui/unused-crate-deps/use_extern_crate_2015.rs
+++ b/src/test/ui/unused-crate-deps/use_extern_crate_2015.rs
@@ -1,0 +1,13 @@
+// Suppress by using crate
+
+// edition:2015
+// check-pass
+// aux-crate:bar=bar.rs
+
+#![warn(unused_crate_dependencies)]
+
+extern crate bar;
+
+fn main() {
+    println!("bar {}", bar::BAR);
+}

--- a/src/test/ui/unused-crate-deps/warn-attr.rs
+++ b/src/test/ui/unused-crate-deps/warn-attr.rs
@@ -1,0 +1,10 @@
+// Check for unused crate dep, no path
+
+// edition:2018
+// check-pass
+// aux-crate:bar=bar.rs
+
+#![warn(unused_crate_dependencies)]
+//~^ WARNING external crate `bar` unused in
+
+fn main() {}

--- a/src/test/ui/unused-crate-deps/warn-attr.stderr
+++ b/src/test/ui/unused-crate-deps/warn-attr.stderr
@@ -1,0 +1,14 @@
+warning: external crate `bar` unused in `warn_attr`: remove the dependency or add `use bar as _;`
+  --> $DIR/warn-attr.rs:7:1
+   |
+LL | #![warn(unused_crate_dependencies)]
+   | ^
+   |
+note: the lint level is defined here
+  --> $DIR/warn-attr.rs:7:9
+   |
+LL | #![warn(unused_crate_dependencies)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: 1 warning emitted
+

--- a/src/test/ui/unused-crate-deps/warn-cmdline-static.rs
+++ b/src/test/ui/unused-crate-deps/warn-cmdline-static.rs
@@ -1,0 +1,10 @@
+// Check for unused crate dep, no path
+
+// edition:2018
+// check-pass
+// compile-flags: -Wunused-crate-dependencies
+// aux-crate:bar=bar.rs
+// no-prefer-dynamic
+
+fn main() {}
+//~^ WARNING external crate `bar` unused in

--- a/src/test/ui/unused-crate-deps/warn-cmdline-static.stderr
+++ b/src/test/ui/unused-crate-deps/warn-cmdline-static.stderr
@@ -1,0 +1,10 @@
+warning: external crate `bar` unused in `warn_cmdline_static`: remove the dependency or add `use bar as _;`
+  --> $DIR/warn-cmdline-static.rs:9:1
+   |
+LL | fn main() {}
+   | ^
+   |
+   = note: requested on the command line with `-W unused-crate-dependencies`
+
+warning: 1 warning emitted
+

--- a/src/test/ui/unused-crate-deps/warn-cmdline.rs
+++ b/src/test/ui/unused-crate-deps/warn-cmdline.rs
@@ -1,0 +1,9 @@
+// Check for unused crate dep, no path
+
+// edition:2018
+// check-pass
+// compile-flags: -Wunused-crate-dependencies
+// aux-crate:bar=bar.rs
+
+fn main() {}
+//~^ WARNING external crate `bar` unused in

--- a/src/test/ui/unused-crate-deps/warn-cmdline.stderr
+++ b/src/test/ui/unused-crate-deps/warn-cmdline.stderr
@@ -1,0 +1,10 @@
+warning: external crate `bar` unused in `warn_cmdline`: remove the dependency or add `use bar as _;`
+  --> $DIR/warn-cmdline.rs:8:1
+   |
+LL | fn main() {}
+   | ^
+   |
+   = note: requested on the command line with `-W unused-crate-dependencies`
+
+warning: 1 warning emitted
+


### PR DESCRIPTION
Implements #57274 by adding -Wunused-crate-dependencies. This will warn about any `--extern` option on the command line which isn't referenced by the crate source either via `use` or `extern crate`.

Crates which are added for some side effect but are otherwise unreferenced - such as for symbols they define - the warning can be suppressed with `use somecrate as _;`.

If a crate has multiple aliases (eg using `foo = { package = "bar" }` in `Cargo.toml`), then it will warn about each unused alias.

This does not consider crate added by some other means than `--extern`, including the standard library. It also doesn't consider any crate without `add_prelude` set (though I'm not sure about this).

Unfortunately this probably [does not yet work well with Cargo](https://github.com/rust-lang/rust/issues/57274#issuecomment-624839355) as it will over-specify crates, causing spurious warnings. As a result, this lint is "allow" by default and must be explicitly enabled either via `#![warn(unused_crate_dependencies)]` or with `-Wunused-crate-dependencies`.