### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/src/libcore/macros/mod.rs
+++ b/src/libcore/macros/mod.rs
@@ -1243,7 +1243,7 @@ pub(crate) mod builtin {
     /// be disabled. See [`debug_assert!`] for assertions that are not enabled in
     /// release builds by default.
     ///
-    /// Unsafe code relies on `assert!` to enforce run-time invariants that, if
+    /// Unsafe code may rely on `assert!` to enforce run-time invariants that, if
     /// violated could lead to unsafety.
     ///
     /// Other use-cases of `assert!` include testing and enforcing run-time

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -1114,8 +1114,7 @@ instead of overflowing.
 Basic usage:
 
 ```
-", $Feature, "#![feature(saturating_neg)]
-assert_eq!(100", stringify!($SelfT), ".saturating_neg(), -100);
+", $Feature, "assert_eq!(100", stringify!($SelfT), ".saturating_neg(), -100);
 assert_eq!((-100", stringify!($SelfT), ").saturating_neg(), 100);
 assert_eq!(", stringify!($SelfT), "::MIN.saturating_neg(), ", stringify!($SelfT),
 "::MAX);
@@ -1124,7 +1123,7 @@ assert_eq!(", stringify!($SelfT), "::MAX.saturating_neg(), ", stringify!($SelfT)
 $EndFeature, "
 ```"),
 
-            #[unstable(feature = "saturating_neg", issue = "59983")]
+            #[stable(feature = "saturating_neg", since = "1.45.0")]
             #[rustc_const_unstable(feature = "const_saturating_int_methods", issue = "53718")]
             #[inline]
             pub const fn saturating_neg(self) -> Self {
@@ -1141,8 +1140,7 @@ MIN` instead of overflowing.
 Basic usage:
 
 ```
-", $Feature, "#![feature(saturating_neg)]
-assert_eq!(100", stringify!($SelfT), ".saturating_abs(), 100);
+", $Feature, "assert_eq!(100", stringify!($SelfT), ".saturating_abs(), 100);
 assert_eq!((-100", stringify!($SelfT), ").saturating_abs(), 100);
 assert_eq!(", stringify!($SelfT), "::MIN.saturating_abs(), ", stringify!($SelfT),
 "::MAX);
@@ -1151,7 +1149,7 @@ assert_eq!((", stringify!($SelfT), "::MIN + 1).saturating_abs(), ", stringify!($
 $EndFeature, "
 ```"),
 
-            #[unstable(feature = "saturating_neg", issue = "59983")]
+            #[stable(feature = "saturating_neg", since = "1.45.0")]
             #[rustc_const_unstable(feature = "const_saturating_int_methods", issue = "53718")]
             #[inline]
             pub const fn saturating_abs(self) -> Self {

--- a/src/libcore/tests/lib.rs
+++ b/src/libcore/tests/lib.rs
@@ -17,7 +17,6 @@
 #![feature(pattern)]
 #![feature(range_is_empty)]
 #![feature(raw)]
-#![feature(saturating_neg)]
 #![feature(sort_internals)]
 #![feature(slice_partition_at_index)]
 #![feature(specialization)]

--- a/src/librustc_save_analysis/lib.rs
+++ b/src/librustc_save_analysis/lib.rs
@@ -620,7 +620,11 @@ impl<'l, 'tcx> SaveContext<'l, 'tcx> {
     }
 
     pub fn get_path_res(&self, id: NodeId) -> Res {
-        let hir_id = self.tcx.hir().node_id_to_hir_id(id);
+        // FIXME(#71104)
+        let hir_id = match self.tcx.hir().opt_node_id_to_hir_id(id) {
+            Some(id) => id,
+            None => return Res::Err,
+        };
         match self.tcx.hir().get(hir_id) {
             Node::TraitRef(tr) => tr.path.res,
 

--- a/src/librustc_typeck/check/method/confirm.rs
+++ b/src/librustc_typeck/check/method/confirm.rs
@@ -468,7 +468,9 @@ impl<'a, 'tcx> ConfirmContext<'a, 'tcx> {
 
             match expr.kind {
                 hir::ExprKind::Index(ref base_expr, ref index_expr) => {
-                    let index_expr_ty = self.node_ty(index_expr.hir_id);
+                    // We need to get the final type in case dereferences were needed for the trait
+                    // to apply (#72002).
+                    let index_expr_ty = self.tables.borrow().expr_ty_adjusted(index_expr);
                     self.convert_place_op_to_mutable(
                         PlaceOp::Index,
                         expr,

--- a/src/test/ui/const-generics/uninferred-consts.rs
+++ b/src/test/ui/const-generics/uninferred-consts.rs
@@ -1,0 +1,12 @@
+#![feature(const_generics)]
+//~^ WARN the feature `const_generics` is incomplete
+
+// taken from https://github.com/rust-lang/rust/issues/70507#issuecomment-615268893
+struct Foo;
+impl Foo {
+    fn foo<const N: usize>(self) {}
+}
+fn main() {
+    Foo.foo();
+    //~^ ERROR type annotations needed
+}

--- a/src/test/ui/const-generics/uninferred-consts.stderr
+++ b/src/test/ui/const-generics/uninferred-consts.stderr
@@ -1,0 +1,20 @@
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/uninferred-consts.rs:1:12
+   |
+LL | #![feature(const_generics)]
+   |            ^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
+
+error[E0282]: type annotations needed
+  --> $DIR/uninferred-consts.rs:10:5
+   |
+LL |     Foo.foo();
+   |     ^^^^^^^^^
+   |
+   = note: unable to infer the value of a const parameter
+
+error: aborting due to previous error; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0282`.

--- a/src/test/ui/consts/const-int-arithmetic.rs
+++ b/src/test/ui/consts/const-int-arithmetic.rs
@@ -1,6 +1,5 @@
 // run-pass
 
-#![feature(saturating_neg)]
 #![feature(const_checked_int_methods)]
 #![feature(const_euclidean_int_methods)]
 #![feature(const_overflowing_int_methods)]

--- a/src/test/ui/issues/issue-72002.rs
+++ b/src/test/ui/issues/issue-72002.rs
@@ -1,0 +1,29 @@
+// check-pass
+struct Indexable;
+
+impl Indexable {
+    fn boo(&mut self) {}
+}
+
+impl std::ops::Index<&str> for Indexable {
+    type Output = Indexable;
+
+    fn index(&self, field: &str) -> &Indexable {
+        self
+    }
+}
+
+impl std::ops::IndexMut<&str> for Indexable {
+    fn index_mut(&mut self, field: &str) -> &mut Indexable {
+        self
+    }
+}
+
+fn main() {
+    let mut v = Indexable;
+    let field = "hello".to_string();
+
+    v[field.as_str()].boo();
+
+    v[&field].boo(); // < This should work
+}

--- a/src/test/ui/save-analysis/issue-72267.rs
+++ b/src/test/ui/save-analysis/issue-72267.rs
@@ -1,0 +1,7 @@
+// compile-flags: -Z save-analysis
+
+fn main() {
+    let _: Box<(dyn ?Sized)>;
+    //~^ ERROR `?Trait` is not permitted in trait object types
+    //~| ERROR at least one trait is required for an object type
+}

--- a/src/test/ui/save-analysis/issue-72267.stderr
+++ b/src/test/ui/save-analysis/issue-72267.stderr
@@ -1,0 +1,15 @@
+error: `?Trait` is not permitted in trait object types
+  --> $DIR/issue-72267.rs:4:21
+   |
+LL |     let _: Box<(dyn ?Sized)>;
+   |                     ^^^^^^
+
+error[E0224]: at least one trait is required for an object type
+  --> $DIR/issue-72267.rs:4:17
+   |
+LL |     let _: Box<(dyn ?Sized)>;
+   |                 ^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0224`.


### PR DESCRIPTION
Successful merges:

 - #71886 (Stabilize saturating_abs and saturating_neg)
 - #72066 (correctly handle uninferred consts)
 - #72068 (Ignore arguments when looking for `IndexMut` for subsequent `mut` obligation)
 - #72338 (Fix ICE in -Zsave-analysis)
 - #72344 (Assert doc wording)

Failed merges:


r? @ghost