### PR TITLE
Fix confusing error message for comma typo in multiline statement

### DIFF
--- a/src/librustc_parse/parser/diagnostics.rs
+++ b/src/librustc_parse/parser/diagnostics.rs
@@ -934,6 +934,19 @@ impl<'a> Parser<'a> {
             return self.expect(&token::Semi).map(drop);
         } else if !sm.is_multiline(self.prev_token.span.until(self.token.span)) {
             // The current token is in the same line as the prior token, not recoverable.
+        } else if [token::Comma, token::Colon].contains(&self.token.kind)
+            && &self.prev_token.kind == &token::CloseDelim(token::Paren)
+        {
+            // Likely typo: The current token is on a new line and is expected to be
+            // `.`, `;`, `?`, or an operator after a close delimiter token.
+            //
+            // let a = std::process::Command::new("echo")
+            //         .arg("1")
+            //         ,arg("2")
+            //         ^
+            // https://github.com/rust-lang/rust/issues/72253
+            self.expect(&token::Semi)?;
+            return Ok(());
         } else if self.look_ahead(1, |t| {
             t == &token::CloseDelim(token::Brace) || t.can_begin_expr() && t.kind != token::Colon
         }) && [token::Comma, token::Colon].contains(&self.token.kind)

--- a/src/test/ui/issues/issue-72253.rs
+++ b/src/test/ui/issues/issue-72253.rs
@@ -1,0 +1,6 @@
+fn main() {
+    let a = std::process::Command::new("echo")
+        .arg("1")
+        ,arg("2") //~ ERROR expected one of `.`, `;`, `?`, or an operator, found `,`
+        .output();
+}

--- a/src/test/ui/issues/issue-72253.stderr
+++ b/src/test/ui/issues/issue-72253.stderr
@@ -1,0 +1,10 @@
+error: expected one of `.`, `;`, `?`, or an operator, found `,`
+  --> $DIR/issue-72253.rs:4:9
+   |
+LL |         .arg("1")
+   |                  - expected one of `.`, `;`, `?`, or an operator
+LL |         ,arg("2")
+   |         ^ unexpected token
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Fixes #72253.  Expands on the issue with a colon typo check.

r? @estebank 

cc @ehuss 