### PR TITLE
Check substs of ConstKind::Unevaluated in generalize

### DIFF
--- a/src/librustc_middle/ty/structural_impls.rs
+++ b/src/librustc_middle/ty/structural_impls.rs
@@ -885,6 +885,7 @@ impl<'tcx> TypeFoldable<'tcx> for interpret::GlobalId<'tcx> {
 
 impl<'tcx> TypeFoldable<'tcx> for Ty<'tcx> {
     fn super_fold_with<F: TypeFolder<'tcx>>(&self, folder: &mut F) -> Self {
+        debug!("Ty::super_fold_with({:?})", self);
         let kind = match self.kind {
             ty::RawPtr(tm) => ty::RawPtr(tm.fold_with(folder)),
             ty::Array(typ, sz) => ty::Array(typ.fold_with(folder), sz.fold_with(folder)),
@@ -1040,6 +1041,7 @@ impl<'tcx, T: TypeFoldable<'tcx>, I: Idx> TypeFoldable<'tcx> for IndexVec<I, T> 
 
 impl<'tcx> TypeFoldable<'tcx> for &'tcx ty::Const<'tcx> {
     fn super_fold_with<F: TypeFolder<'tcx>>(&self, folder: &mut F) -> Self {
+        debug!("Const::super_fold_with({:?})", self);
         let ty = self.ty.fold_with(folder);
         let val = self.val.fold_with(folder);
         if ty != self.ty || val != self.val {

--- a/src/test/ui/const-generics/issues/issue-69654-run-pass.rs
+++ b/src/test/ui/const-generics/issues/issue-69654-run-pass.rs
@@ -1,0 +1,19 @@
+#![feature(const_generics)]
+#![allow(incomplete_features, unused_braces)]
+
+trait Bar<T> {}
+impl<T> Bar<T> for [u8; {7}] {}
+
+struct Foo<const N: usize> {}
+impl<const N: usize> Foo<N>
+where
+    [u8; N]: Bar<[(); N]>,
+{
+    fn foo() {}
+}
+
+fn main() {
+    Foo::foo();
+    //~^ ERROR no function or associated item named `foo`
+    // FIXME(const_generics): The above should not error
+}

--- a/src/test/ui/const-generics/issues/issue-69654-run-pass.stderr
+++ b/src/test/ui/const-generics/issues/issue-69654-run-pass.stderr
@@ -1,0 +1,15 @@
+error[E0599]: no function or associated item named `foo` found for struct `Foo<{_: usize}>` in the current scope
+  --> $DIR/issue-69654-run-pass.rs:16:10
+   |
+LL | struct Foo<const N: usize> {}
+   | -------------------------- function or associated item `foo` not found for this
+...
+LL |     Foo::foo();
+   |          ^^^ function or associated item not found in `Foo<{_: usize}>`
+   |
+   = note: the method `foo` exists but the following trait bounds were not satisfied:
+           `[u8; _]: Bar<[(); _]>`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0599`.

--- a/src/test/ui/const-generics/issues/issue-69654.rs
+++ b/src/test/ui/const-generics/issues/issue-69654.rs
@@ -1,0 +1,19 @@
+#![feature(const_generics)]
+#![allow(incomplete_features)]
+
+trait Bar<T> {}
+impl<T> Bar<T> for [u8; T] {}
+//~^ ERROR expected value, found type parameter `T`
+
+struct Foo<const N: usize> {}
+impl<const N: usize> Foo<N>
+where
+    [u8; N]: Bar<[(); N]>,
+{
+    fn foo() {}
+}
+
+fn main() {
+    Foo::foo();
+    //~^ ERROR no function or associated item named `foo`
+}

--- a/src/test/ui/const-generics/issues/issue-69654.stderr
+++ b/src/test/ui/const-generics/issues/issue-69654.stderr
@@ -1,0 +1,22 @@
+error[E0423]: expected value, found type parameter `T`
+  --> $DIR/issue-69654.rs:5:25
+   |
+LL | impl<T> Bar<T> for [u8; T] {}
+   |                         ^ not a value
+
+error[E0599]: no function or associated item named `foo` found for struct `Foo<{_: usize}>` in the current scope
+  --> $DIR/issue-69654.rs:17:10
+   |
+LL | struct Foo<const N: usize> {}
+   | -------------------------- function or associated item `foo` not found for this
+...
+LL |     Foo::foo();
+   |          ^^^ function or associated item not found in `Foo<{_: usize}>`
+   |
+   = note: the method `foo` exists but the following trait bounds were not satisfied:
+           `[u8; _]: Bar<[(); _]>`
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0423, E0599.
+For more information about an error, try `rustc --explain E0423`.

--- a/src/test/ui/const-generics/unused-substs/unused-substs-1.rs
+++ b/src/test/ui/const-generics/unused-substs/unused-substs-1.rs
@@ -1,0 +1,12 @@
+#![feature(const_generics)] //~ WARN the feature `const_generics` is incomplete
+trait Bar<const M: usize> {}
+impl<const N: usize> Bar<N> for A<{ 6 + 1 }> {}
+
+struct A<const N: usize>
+where
+    A<N>: Bar<N>;
+
+fn main() {
+    let _ = A;
+    //~^ ERROR mismatched types
+}

--- a/src/test/ui/const-generics/unused-substs/unused-substs-2.rs
+++ b/src/test/ui/const-generics/unused-substs/unused-substs-2.rs
@@ -1,0 +1,26 @@
+#![feature(const_generics)] //~ WARN the feature `const_generics` is incomplete
+
+// The goal is is to get an unevaluated const `ct` with a `Ty::Infer(TyVar(_#1t)` subst.
+//
+// If we are then able to infer `ty::Infer(TyVar(_#1t) := Ty<ct>` we introduced an
+// artificial inference cycle.
+struct Foo<const N: usize>;
+
+trait Bind<T> {
+    fn bind() -> (T, Self);
+}
+
+// `N` has to be `ConstKind::Unevaluated`.
+impl<T> Bind<T> for Foo<{ 6 + 1 }> {
+    fn bind() -> (T, Self) {
+        (panic!(), Foo)
+    }
+}
+
+fn main() {
+    let (mut t, foo) = Foo::bind();
+    // `t` is `ty::Infer(TyVar(_#1t))`
+    // `foo` contains `ty::Infer(TyVar(_#1t))` in its substs
+    t = foo;
+    //~^ ERROR mismatched types
+}

--- a/src/test/ui/const-generics/unused-substs/unused-substs-2.stderr
+++ b/src/test/ui/const-generics/unused-substs/unused-substs-2.stderr
@@ -1,0 +1,18 @@
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/unused-substs-2.rs:1:12
+   |
+LL | #![feature(const_generics)]
+   |            ^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
+
+error[E0308]: mismatched types
+  --> $DIR/unused-substs-2.rs:24:9
+   |
+LL |     t = foo;
+   |         ^^^ cyclic type of infinite size
+
+error: aborting due to previous error; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/const-generics/unused-substs/unused-substs-3.rs
+++ b/src/test/ui/const-generics/unused-substs/unused-substs-3.rs
@@ -1,0 +1,18 @@
+
+#![feature(const_generics)] //~ WARN the feature `const_generics` is incomplete
+
+// The goal is is to get an unevaluated const `ct` with a `Ty::Infer(TyVar(_#1t)` subst.
+//
+// If we are then able to infer `ty::Infer(TyVar(_#1t) := Ty<ct>` we introduced an
+// artificial inference cycle.
+fn bind<T>() -> (T, [u8; 6 + 1]) {
+    todo!()
+} 
+
+fn main() {
+    let (mut t, foo) = bind();
+    // `t` is `ty::Infer(TyVar(_#1t))`
+    // `foo` contains `ty::Infer(TyVar(_#1t))` in its substs
+    t = foo;
+    //~^ ERROR mismatched types
+}

--- a/src/test/ui/const-generics/unused-substs/unused-substs-3.stderr
+++ b/src/test/ui/const-generics/unused-substs/unused-substs-3.stderr
@@ -1,0 +1,21 @@
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/unused-substs-3.rs:2:12
+   |
+LL | #![feature(const_generics)]
+   |            ^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
+
+error[E0308]: mismatched types
+  --> $DIR/unused-substs-3.rs:16:9
+   |
+LL |     t = foo;
+   |         ^^^
+   |         |
+   |         cyclic type of infinite size
+   |         help: try using a conversion method: `foo.to_vec()`
+
+error: aborting due to previous error; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
This prevents the stack overflow mentioned in https://github.com/rust-lang/rust/issues/72129#issuecomment-627181925.

While I think this change makes sense, I am not completely certain and there may be a better solution I am missing.

The stack overflow was caused by unifying a type inference variable with an unevaluated const which had exactly this inference variable in it's substitutions. Meaning something has probably already gone wrong when reaching this.

i.e: we previously ended up with
```
TyVar(_#1t) := [
    ();
    Const { ty: usize, val: Unevaluated(DefId(0:7 ~ issue_69654_run_pass[317d]::{{impl}}[0]::{{constant}}[0]), [TyVar(_#1t)], None) }
]
```
 in the `TypeVariableTable`.

r? @nikomatsakis @varkor 