### PR TITLE
Remove unused `StableHashingContext::node_to_hir_id` method

### DIFF
--- a/src/librustc_middle/ich/hcx.rs
+++ b/src/librustc_middle/ich/hcx.rs
@@ -136,11 +136,6 @@ impl<'a> StableHashingContext<'a> {
     }
 
     #[inline]
-    pub fn node_to_hir_id(&self, node_id: ast::NodeId) -> hir::HirId {
-        self.definitions.node_id_to_hir_id(node_id)
-    }
-
-    #[inline]
     pub fn hash_bodies(&self) -> bool {
         self.hash_bodies
     }


### PR DESCRIPTION
cc #50928 