### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/src/libcore/slice/mod.rs
+++ b/src/libcore/slice/mod.rs
@@ -1169,7 +1169,7 @@ impl<T> [T] {
     /// assert_eq!(iter.next().unwrap(), &[10, 40, 33]);
     /// assert!(iter.next().is_none());
     /// ```
-    #[unstable(feature = "split_inclusive", issue = "none")]
+    #[unstable(feature = "split_inclusive", issue = "72360")]
     #[inline]
     pub fn split_inclusive<F>(&self, pred: F) -> SplitInclusive<'_, T, F>
     where
@@ -1194,7 +1194,7 @@ impl<T> [T] {
     /// }
     /// assert_eq!(v, [10, 40, 1, 20, 1, 1]);
     /// ```
-    #[unstable(feature = "split_inclusive", issue = "none")]
+    #[unstable(feature = "split_inclusive", issue = "72360")]
     #[inline]
     pub fn split_inclusive_mut<F>(&mut self, pred: F) -> SplitInclusiveMut<'_, T, F>
     where
@@ -3852,7 +3852,7 @@ impl<T, P> FusedIterator for Split<'_, T, P> where P: FnMut(&T) -> bool {}
 ///
 /// [`split_inclusive`]: ../../std/primitive.slice.html#method.split_inclusive
 /// [slices]: ../../std/primitive.slice.html
-#[unstable(feature = "split_inclusive", issue = "none")]
+#[unstable(feature = "split_inclusive", issue = "72360")]
 pub struct SplitInclusive<'a, T: 'a, P>
 where
     P: FnMut(&T) -> bool,
@@ -3862,7 +3862,7 @@ where
     finished: bool,
 }
 
-#[unstable(feature = "split_inclusive", issue = "none")]
+#[unstable(feature = "split_inclusive", issue = "72360")]
 impl<T: fmt::Debug, P> fmt::Debug for SplitInclusive<'_, T, P>
 where
     P: FnMut(&T) -> bool,
@@ -3876,7 +3876,7 @@ where
 }
 
 // FIXME(#26925) Remove in favor of `#[derive(Clone)]`
-#[unstable(feature = "split_inclusive", issue = "none")]
+#[unstable(feature = "split_inclusive", issue = "72360")]
 impl<T, P> Clone for SplitInclusive<'_, T, P>
 where
     P: Clone + FnMut(&T) -> bool,
@@ -3886,7 +3886,7 @@ where
     }
 }
 
-#[unstable(feature = "split_inclusive", issue = "none")]
+#[unstable(feature = "split_inclusive", issue = "72360")]
 impl<'a, T, P> Iterator for SplitInclusive<'a, T, P>
 where
     P: FnMut(&T) -> bool,
@@ -3915,7 +3915,7 @@ where
     }
 }
 
-#[unstable(feature = "split_inclusive", issue = "none")]
+#[unstable(feature = "split_inclusive", issue = "72360")]
 impl<'a, T, P> DoubleEndedIterator for SplitInclusive<'a, T, P>
 where
     P: FnMut(&T) -> bool,
@@ -3940,7 +3940,7 @@ where
     }
 }
 
-#[unstable(feature = "split_inclusive", issue = "none")]
+#[unstable(feature = "split_inclusive", issue = "72360")]
 impl<T, P> FusedIterator for SplitInclusive<'_, T, P> where P: FnMut(&T) -> bool {}
 
 /// An iterator over the mutable subslices of the vector which are separated
@@ -4065,7 +4065,7 @@ impl<T, P> FusedIterator for SplitMut<'_, T, P> where P: FnMut(&T) -> bool {}
 ///
 /// [`split_inclusive_mut`]: ../../std/primitive.slice.html#method.split_inclusive_mut
 /// [slices]: ../../std/primitive.slice.html
-#[unstable(feature = "split_inclusive", issue = "none")]
+#[unstable(feature = "split_inclusive", issue = "72360")]
 pub struct SplitInclusiveMut<'a, T: 'a, P>
 where
     P: FnMut(&T) -> bool,
@@ -4075,7 +4075,7 @@ where
     finished: bool,
 }
 
-#[unstable(feature = "split_inclusive", issue = "none")]
+#[unstable(feature = "split_inclusive", issue = "72360")]
 impl<T: fmt::Debug, P> fmt::Debug for SplitInclusiveMut<'_, T, P>
 where
     P: FnMut(&T) -> bool,
@@ -4088,7 +4088,7 @@ where
     }
 }
 
-#[unstable(feature = "split_inclusive", issue = "none")]
+#[unstable(feature = "split_inclusive", issue = "72360")]
 impl<'a, T, P> Iterator for SplitInclusiveMut<'a, T, P>
 where
     P: FnMut(&T) -> bool,
@@ -4128,7 +4128,7 @@ where
     }
 }
 
-#[unstable(feature = "split_inclusive", issue = "none")]
+#[unstable(feature = "split_inclusive", issue = "72360")]
 impl<'a, T, P> DoubleEndedIterator for SplitInclusiveMut<'a, T, P>
 where
     P: FnMut(&T) -> bool,
@@ -4162,7 +4162,7 @@ where
     }
 }
 
-#[unstable(feature = "split_inclusive", issue = "none")]
+#[unstable(feature = "split_inclusive", issue = "72360")]
 impl<T, P> FusedIterator for SplitInclusiveMut<'_, T, P> where P: FnMut(&T) -> bool {}
 
 /// An iterator over subslices separated by elements that match a predicate

--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -3335,7 +3335,7 @@ impl str {
     ///     .split_inclusive('\n').collect();
     /// assert_eq!(v, ["Mary had a little lamb\n", "little lamb\n", "little lamb.\n"]);
     /// ```
-    #[unstable(feature = "split_inclusive", issue = "none")]
+    #[unstable(feature = "split_inclusive", issue = "72360")]
     #[inline]
     pub fn split_inclusive<'a, P: Pattern<'a>>(&'a self, pat: P) -> SplitInclusive<'a, P> {
         SplitInclusive(SplitInternal {
@@ -4575,7 +4575,7 @@ pub struct SplitAsciiWhitespace<'a> {
 ///
 /// [`split_inclusive`]: ../../std/primitive.str.html#method.split_inclusive
 /// [`str`]: ../../std/primitive.str.html
-#[unstable(feature = "split_inclusive", issue = "none")]
+#[unstable(feature = "split_inclusive", issue = "72360")]
 pub struct SplitInclusive<'a, P: Pattern<'a>>(SplitInternal<'a, P>);
 
 impl_fn_for_zst! {
@@ -4668,7 +4668,7 @@ impl<'a> DoubleEndedIterator for SplitAsciiWhitespace<'a> {
 #[stable(feature = "split_ascii_whitespace", since = "1.34.0")]
 impl FusedIterator for SplitAsciiWhitespace<'_> {}
 
-#[unstable(feature = "split_inclusive", issue = "none")]
+#[unstable(feature = "split_inclusive", issue = "72360")]
 impl<'a, P: Pattern<'a>> Iterator for SplitInclusive<'a, P> {
     type Item = &'a str;
 
@@ -4678,7 +4678,7 @@ impl<'a, P: Pattern<'a>> Iterator for SplitInclusive<'a, P> {
     }
 }
 
-#[unstable(feature = "split_inclusive", issue = "none")]
+#[unstable(feature = "split_inclusive", issue = "72360")]
 impl<'a, P: Pattern<'a, Searcher: fmt::Debug>> fmt::Debug for SplitInclusive<'a, P> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("SplitInclusive").field("0", &self.0).finish()
@@ -4686,14 +4686,14 @@ impl<'a, P: Pattern<'a, Searcher: fmt::Debug>> fmt::Debug for SplitInclusive<'a,
 }
 
 // FIXME(#26925) Remove in favor of `#[derive(Clone)]`
-#[unstable(feature = "split_inclusive", issue = "none")]
+#[unstable(feature = "split_inclusive", issue = "72360")]
 impl<'a, P: Pattern<'a, Searcher: Clone>> Clone for SplitInclusive<'a, P> {
     fn clone(&self) -> Self {
         SplitInclusive(self.0.clone())
     }
 }
 
-#[unstable(feature = "split_inclusive", issue = "none")]
+#[unstable(feature = "split_inclusive", issue = "72360")]
 impl<'a, P: Pattern<'a, Searcher: ReverseSearcher<'a>>> DoubleEndedIterator
     for SplitInclusive<'a, P>
 {
@@ -4703,7 +4703,7 @@ impl<'a, P: Pattern<'a, Searcher: ReverseSearcher<'a>>> DoubleEndedIterator
     }
 }
 
-#[unstable(feature = "split_inclusive", issue = "none")]
+#[unstable(feature = "split_inclusive", issue = "72360")]
 impl<'a, P: Pattern<'a>> FusedIterator for SplitInclusive<'a, P> {}
 
 /// An iterator of [`u16`] over the string encoded as UTF-16.

--- a/src/librustc_ast_lowering/expr.rs
+++ b/src/librustc_ast_lowering/expr.rs
@@ -1021,7 +1021,6 @@ impl<'hir> LoweringContext<'_, 'hir> {
                     "`async` generators are not yet supported"
                 )
                 .emit();
-                return hir::ExprKind::Err;
             }
             None => self.generator_kind = Some(hir::GeneratorKind::Gen),
         }

--- a/src/librustc_middle/ty/context.rs
+++ b/src/librustc_middle/ty/context.rs
@@ -1114,16 +1114,13 @@ impl<'tcx> TyCtxt<'tcx> {
 
         let mut trait_map: FxHashMap<_, FxHashMap<_, _>> = FxHashMap::default();
         for (k, v) in resolutions.trait_map {
-            // FIXME(#71104) Should really be using just `node_id_to_hir_id` but
-            // some `NodeId` do not seem to have a corresponding HirId.
-            if let Some(hir_id) = definitions.opt_node_id_to_hir_id(k) {
-                let map = trait_map.entry(hir_id.owner).or_default();
-                let v = v
-                    .into_iter()
-                    .map(|tc| tc.map_import_ids(|id| definitions.node_id_to_hir_id(id)))
-                    .collect();
-                map.insert(hir_id.local_id, StableVec::new(v));
-            }
+            let hir_id = definitions.node_id_to_hir_id(k);
+            let map = trait_map.entry(hir_id.owner).or_default();
+            let v = v
+                .into_iter()
+                .map(|tc| tc.map_import_ids(|id| definitions.node_id_to_hir_id(id)))
+                .collect();
+            map.insert(hir_id.local_id, StableVec::new(v));
         }
 
         GlobalCtxt {

--- a/src/librustc_middle/ty/context.rs
+++ b/src/librustc_middle/ty/context.rs
@@ -305,7 +305,7 @@ pub struct GeneratorInteriorTypeCause<'tcx> {
     /// Span of the scope of the captured binding.
     pub scope_span: Option<Span>,
     /// Span of `.await` or `yield` expression.
-    pub yield_span: Span,
+    pub yield_span: Option<Span>,
     /// Expr which the type evaluated from.
     pub expr: Option<hir::HirId>,
 }

--- a/src/librustc_middle/ty/context.rs
+++ b/src/librustc_middle/ty/context.rs
@@ -305,7 +305,7 @@ pub struct GeneratorInteriorTypeCause<'tcx> {
     /// Span of the scope of the captured binding.
     pub scope_span: Option<Span>,
     /// Span of `.await` or `yield` expression.
-    pub yield_span: Option<Span>,
+    pub yield_span: Span,
     /// Expr which the type evaluated from.
     pub expr: Option<hir::HirId>,
 }

--- a/src/librustc_mir_build/hair/pattern/const_to_pat.rs
+++ b/src/librustc_mir_build/hair/pattern/const_to_pat.rs
@@ -124,7 +124,10 @@ impl<'a, 'tcx> ConstToPat<'a, 'tcx> {
                         "trait objects cannot be used in patterns".to_string()
                     }
                     traits::NonStructuralMatchTy::Param => {
-                        bug!("use of constant whose type is a parameter inside a pattern")
+                        bug!("use of a constant whose type is a parameter inside a pattern")
+                    }
+                    traits::NonStructuralMatchTy::Foreign => {
+                        bug!("use of a value of a foreign type inside a pattern")
                     }
                 };
 

--- a/src/librustc_mir_build/hair/pattern/const_to_pat.rs
+++ b/src/librustc_mir_build/hair/pattern/const_to_pat.rs
@@ -123,8 +123,17 @@ impl<'a, 'tcx> ConstToPat<'a, 'tcx> {
                     traits::NonStructuralMatchTy::Dynamic => {
                         "trait objects cannot be used in patterns".to_string()
                     }
+                    traits::NonStructuralMatchTy::Opaque => {
+                        "opaque types cannot be used in patterns".to_string()
+                    }
+                    traits::NonStructuralMatchTy::Generator => {
+                        "generators cannot be used in patterns".to_string()
+                    }
                     traits::NonStructuralMatchTy::Param => {
                         bug!("use of a constant whose type is a parameter inside a pattern")
+                    }
+                    traits::NonStructuralMatchTy::Projection => {
+                        bug!("use of a constant whose type is a projection inside a pattern")
                     }
                     traits::NonStructuralMatchTy::Foreign => {
                         bug!("use of a value of a foreign type inside a pattern")

--- a/src/librustc_trait_selection/traits/error_reporting/suggestions.rs
+++ b/src/librustc_trait_selection/traits/error_reporting/suggestions.rs
@@ -1454,26 +1454,27 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                     format!("{} occurs here, with `{}` maybe used later", await_or_yield, snippet),
                 );
 
-            span.push_span_label(
-                target_span,
-                format!("has type `{}` which {}", target_ty, trait_explanation),
-            );
-
-            // If available, use the scope span to annotate the drop location.
-            if let Some(scope_span) = scope_span {
                 span.push_span_label(
-                    source_map.end_point(*scope_span),
-                    format!("`{}` is later dropped here", snippet),
+                    target_span,
+                    format!("has type `{}` which {}", target_ty, trait_explanation),
+                );
+
+                // If available, use the scope span to annotate the drop location.
+                if let Some(scope_span) = scope_span {
+                    span.push_span_label(
+                        source_map.end_point(*scope_span),
+                        format!("`{}` is later dropped here", snippet),
+                    );
+                }
+
+                err.span_note(
+                    span,
+                    &format!(
+                        "{} {} as this value is used across {}",
+                        future_or_generator, trait_explanation, an_await_or_yield
+                    ),
                 );
             }
-
-            err.span_note(
-                span,
-                &format!(
-                    "{} {} as this value is used across {}",
-                    future_or_generator, trait_explanation, an_await_or_yield
-                ),
-            );
         }
 
         if let Some(expr_id) = expr {

--- a/src/librustc_trait_selection/traits/error_reporting/suggestions.rs
+++ b/src/librustc_trait_selection/traits/error_reporting/suggestions.rs
@@ -22,6 +22,14 @@ use std::fmt;
 use super::InferCtxtPrivExt;
 use crate::traits::query::evaluate_obligation::InferCtxtExt as _;
 
+#[derive(Debug)]
+pub enum GeneratorInteriorOrUpvar {
+    // span of interior type
+    Interior(Span),
+    // span of upvar
+    Upvar(Span),
+}
+
 // This trait is public to expose the diagnostics methods to clippy.
 pub trait InferCtxtExt<'tcx> {
     fn suggest_restricting_param_bound(
@@ -125,8 +133,8 @@ pub trait InferCtxtExt<'tcx> {
     fn note_obligation_cause_for_async_await(
         &self,
         err: &mut DiagnosticBuilder<'_>,
-        interior: Option<(Span, Option<Span>, Option<Span>, Option<hir::HirId>, Option<Span>)>,
-        upvar: Option<(Ty<'tcx>, Span)>,
+        interior_or_upvar_span: GeneratorInteriorOrUpvar,
+        interior_extra_info: Option<(Option<Span>, Span, Option<hir::HirId>, Option<Span>)>,
         inner_generator_body: Option<&hir::Body<'_>>,
         outer_generator: Option<DefId>,
         trait_ref: ty::TraitRef<'_>,
@@ -1280,7 +1288,23 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
             );
             eq
         };
-        let interior = tables
+
+        let mut interior_or_upvar_span = None;
+        let mut interior_extra_info = None;
+
+        if let Some(upvars) = self.tcx.upvars(generator_did) {
+            interior_or_upvar_span = upvars.iter().find_map(|(upvar_id, upvar)| {
+                let upvar_ty = tables.node_type(*upvar_id);
+                let upvar_ty = self.resolve_vars_if_possible(&upvar_ty);
+                if ty_matches(&upvar_ty) {
+                    Some(GeneratorInteriorOrUpvar::Upvar(upvar.span))
+                } else {
+                    None
+                }
+            });
+        };
+
+        tables
             .generator_interior_types
             .iter()
             .find(|ty::GeneratorInteriorTypeCause { ty, .. }| ty_matches(ty))
@@ -1301,29 +1325,21 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                     .map(|expr| expr.span);
                 let ty::GeneratorInteriorTypeCause { span, scope_span, yield_span, expr, .. } =
                     cause;
-                (*span, *scope_span, *yield_span, *expr, from_awaited_ty)
+
+                interior_or_upvar_span = Some(GeneratorInteriorOrUpvar::Interior(*span));
+                interior_extra_info = Some((*scope_span, *yield_span, *expr, from_awaited_ty));
             });
 
-        let upvar = if let Some(upvars) = self.tcx.upvars(generator_did) {
-            upvars.iter().find_map(|(upvar_id, upvar)| {
-                let upvar_ty = tables.node_type(*upvar_id);
-                let upvar_ty = self.resolve_vars_if_possible(&upvar_ty);
-                if ty_matches(&upvar_ty) { Some((upvar_ty, upvar.span)) } else { None }
-            })
-        } else {
-            None
-        };
-
         debug!(
-            "maybe_note_obligation_cause_for_async_await: interior={:?} \
-                generator_interior_types={:?} upvar: {:?}",
-            interior, tables.generator_interior_types, upvar
+            "maybe_note_obligation_cause_for_async_await: interior_or_upvar={:?} \
+                generator_interior_types={:?}",
+            interior_or_upvar_span, tables.generator_interior_types
         );
-        if interior.is_some() || upvar.is_some() {
+        if let Some(interior_or_upvar_span) = interior_or_upvar_span {
             self.note_obligation_cause_for_async_await(
                 err,
-                interior,
-                upvar,
+                interior_or_upvar_span,
+                interior_extra_info,
                 generator_body,
                 outer_generator,
                 trait_ref,
@@ -1343,8 +1359,8 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
     fn note_obligation_cause_for_async_await(
         &self,
         err: &mut DiagnosticBuilder<'_>,
-        interior: Option<(Span, Option<Span>, Option<Span>, Option<hir::HirId>, Option<Span>)>,
-        upvar: Option<(Ty<'tcx>, Span)>,
+        interior_or_upvar_span: GeneratorInteriorOrUpvar,
+        interior_extra_info: Option<(Option<Span>, Span, Option<hir::HirId>, Option<Span>)>,
         inner_generator_body: Option<&hir::Body<'_>>,
         outer_generator: Option<DefId>,
         trait_ref: ty::TraitRef<'_>,
@@ -1412,121 +1428,118 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
             format!("does not implement `{}`", trait_ref.print_only_trait_path())
         };
 
-        if let Some((target_span, scope_span, yield_span, expr, from_awaited_ty)) = interior {
-            if let Some(await_span) = from_awaited_ty {
-                // The type causing this obligation is one being awaited at await_span.
-                let mut span = MultiSpan::from_span(await_span);
-
+        let mut explain_yield = |interior_span: Span,
+                                 yield_span: Span,
+                                 scope_span: Option<Span>| {
+            let mut span = MultiSpan::from_span(yield_span);
+            if let Ok(snippet) = source_map.span_to_snippet(interior_span) {
                 span.push_span_label(
-                    await_span,
-                    format!(
-                        "await occurs here on type `{}`, which {}",
-                        target_ty, trait_explanation
-                    ),
+                    yield_span,
+                    format!("{} occurs here, with `{}` maybe used later", await_or_yield, snippet),
                 );
+                // If available, use the scope span to annotate the drop location.
+                if let Some(scope_span) = scope_span {
+                    span.push_span_label(
+                        source_map.end_point(scope_span),
+                        format!("`{}` is later dropped here", snippet),
+                    );
+                }
+            }
+            span.push_span_label(
+                interior_span,
+                format!("has type `{}` which {}", target_ty, trait_explanation),
+            );
 
-                err.span_note(
-                    span,
-                    &format!(
-                        "future {not_trait} as it awaits another future which {not_trait}",
-                        not_trait = trait_explanation
-                    ),
-                );
-            } else {
-                // Look at the last interior type to get a span for the `.await`.
-                debug!(
-                    "note_obligation_cause_for_async_await generator_interior_types: {:#?}",
-                    tables.generator_interior_types
-                );
-
-                if let Some(yield_span) = yield_span {
-                    let mut span = MultiSpan::from_span(yield_span);
-                    if let Ok(snippet) = source_map.span_to_snippet(target_span) {
+            err.span_note(
+                span,
+                &format!(
+                    "{} {} as this value is used across {}",
+                    future_or_generator, trait_explanation, an_await_or_yield
+                ),
+            );
+        };
+        match interior_or_upvar_span {
+            GeneratorInteriorOrUpvar::Interior(interior_span) => {
+                if let Some((scope_span, yield_span, expr, from_awaited_ty)) = interior_extra_info {
+                    if let Some(await_span) = from_awaited_ty {
+                        // The type causing this obligation is one being awaited at await_span.
+                        let mut span = MultiSpan::from_span(await_span);
                         span.push_span_label(
-                            yield_span,
+                            await_span,
                             format!(
-                                "{} occurs here, with `{}` maybe used later",
-                                await_or_yield, snippet
+                                "await occurs here on type `{}`, which {}",
+                                target_ty, trait_explanation
                             ),
                         );
-                        // If available, use the scope span to annotate the drop location.
-                        if let Some(scope_span) = scope_span {
-                            span.push_span_label(
-                                source_map.end_point(scope_span),
-                                format!("`{}` is later dropped here", snippet),
-                            );
+                        err.span_note(
+                            span,
+                            &format!(
+                                "future {not_trait} as it awaits another future which {not_trait}",
+                                not_trait = trait_explanation
+                            ),
+                        );
+                    } else {
+                        // Look at the last interior type to get a span for the `.await`.
+                        debug!(
+                            "note_obligation_cause_for_async_await generator_interior_types: {:#?}",
+                            tables.generator_interior_types
+                        );
+                        explain_yield(interior_span, yield_span, scope_span);
+                    }
+
+                    if let Some(expr_id) = expr {
+                        let expr = hir.expect_expr(expr_id);
+                        debug!("target_ty evaluated from {:?}", expr);
+
+                        let parent = hir.get_parent_node(expr_id);
+                        if let Some(hir::Node::Expr(e)) = hir.find(parent) {
+                            let parent_span = hir.span(parent);
+                            let parent_did = parent.owner.to_def_id();
+                            // ```rust
+                            // impl T {
+                            //     fn foo(&self) -> i32 {}
+                            // }
+                            // T.foo();
+                            // ^^^^^^^ a temporary `&T` created inside this method call due to `&self`
+                            // ```
+                            //
+                            let is_region_borrow = tables
+                                .expr_adjustments(expr)
+                                .iter()
+                                .any(|adj| adj.is_region_borrow());
+
+                            // ```rust
+                            // struct Foo(*const u8);
+                            // bar(Foo(std::ptr::null())).await;
+                            //     ^^^^^^^^^^^^^^^^^^^^^ raw-ptr `*T` created inside this struct ctor.
+                            // ```
+                            debug!("parent_def_kind: {:?}", self.tcx.def_kind(parent_did));
+                            let is_raw_borrow_inside_fn_like_call =
+                                match self.tcx.def_kind(parent_did) {
+                                    DefKind::Fn | DefKind::Ctor(..) => target_ty.is_unsafe_ptr(),
+                                    _ => false,
+                                };
+
+                            if (tables.is_method_call(e) && is_region_borrow)
+                                || is_raw_borrow_inside_fn_like_call
+                            {
+                                err.span_help(
+                                    parent_span,
+                                    "consider moving this into a `let` \
+                        binding to create a shorter lived borrow",
+                                );
+                            }
                         }
                     }
-                    span.push_span_label(
-                        target_span,
-                        format!("has type `{}` which {}", target_ty, trait_explanation),
-                    );
-
-                    err.span_note(
-                        span,
-                        &format!(
-                            "{} {} as this value is used across {}",
-                            future_or_generator, trait_explanation, an_await_or_yield
-                        ),
-                    );
                 }
             }
-            if let Some((_, upvar_span)) = upvar {
+            GeneratorInteriorOrUpvar::Upvar(upvar_span) => {
                 let mut span = MultiSpan::from_span(upvar_span);
                 span.push_span_label(
                     upvar_span,
                     format!("has type `{}` which {}", target_ty, trait_explanation),
                 );
-            }
-            if let Some(expr_id) = expr {
-                let expr = hir.expect_expr(expr_id);
-                debug!("target_ty evaluated from {:?}", expr);
-
-                let parent = hir.get_parent_node(expr_id);
-                if let Some(hir::Node::Expr(e)) = hir.find(parent) {
-                    let parent_span = hir.span(parent);
-                    let parent_did = parent.owner.to_def_id();
-                    // ```rust
-                    // impl T {
-                    //     fn foo(&self) -> i32 {}
-                    // }
-                    // T.foo();
-                    // ^^^^^^^ a temporary `&T` created inside this method call due to `&self`
-                    // ```
-                    //
-                    let is_region_borrow =
-                        tables.expr_adjustments(expr).iter().any(|adj| adj.is_region_borrow());
-
-                    // ```rust
-                    // struct Foo(*const u8);
-                    // bar(Foo(std::ptr::null())).await;
-                    //     ^^^^^^^^^^^^^^^^^^^^^ raw-ptr `*T` created inside this struct ctor.
-                    // ```
-                    debug!("parent_def_kind: {:?}", self.tcx.def_kind(parent_did));
-                    let is_raw_borrow_inside_fn_like_call = match self.tcx.def_kind(parent_did) {
-                        DefKind::Fn | DefKind::Ctor(..) => target_ty.is_unsafe_ptr(),
-                        _ => false,
-                    };
-
-                    if (tables.is_method_call(e) && is_region_borrow)
-                        || is_raw_borrow_inside_fn_like_call
-                    {
-                        err.span_help(
-                            parent_span,
-                            "consider moving this into a `let` \
-                        binding to create a shorter lived borrow",
-                        );
-                    }
-                }
-            }
-        } else {
-            if let Some((_, upvar_span)) = upvar {
-                let mut span = MultiSpan::from_span(upvar_span);
-                span.push_span_label(
-                    upvar_span,
-                    format!("has type `{}` which {}", target_ty, trait_explanation),
-                );
-                err.span_note(span, &format!("captured outer value {}", trait_explanation));
+                err.span_note(span, &format!("captured value {}", trait_explanation));
             }
         }
 

--- a/src/librustc_trait_selection/traits/error_reporting/suggestions.rs
+++ b/src/librustc_trait_selection/traits/error_reporting/suggestions.rs
@@ -127,7 +127,7 @@ pub trait InferCtxtExt<'tcx> {
         err: &mut DiagnosticBuilder<'_>,
         target_span: Span,
         scope_span: &Option<Span>,
-        await_span: Span,
+        yield_span: Option<Span>,
         expr: Option<hir::HirId>,
         snippet: String,
         inner_generator_body: Option<&hir::Body<'_>>,
@@ -1353,7 +1353,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
         err: &mut DiagnosticBuilder<'_>,
         target_span: Span,
         scope_span: &Option<Span>,
-        yield_span: Span,
+        yield_span: Option<Span>,
         expr: Option<hir::HirId>,
         snippet: String,
         inner_generator_body: Option<&hir::Body<'_>>,
@@ -1446,11 +1446,13 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                 "note_obligation_cause_for_async_await generator_interior_types: {:#?}",
                 tables.generator_interior_types
             );
-            let mut span = MultiSpan::from_span(yield_span);
-            span.push_span_label(
-                yield_span,
-                format!("{} occurs here, with `{}` maybe used later", await_or_yield, snippet),
-            );
+
+            if let Some(yield_span) = yield_span {
+                let mut span = MultiSpan::from_span(yield_span);
+                span.push_span_label(
+                    yield_span,
+                    format!("{} occurs here, with `{}` maybe used later", await_or_yield, snippet),
+                );
 
             span.push_span_label(
                 target_span,

--- a/src/librustc_trait_selection/traits/structural_match.rs
+++ b/src/librustc_trait_selection/traits/structural_match.rs
@@ -148,19 +148,19 @@ impl<'a, 'tcx> TypeVisitor<'tcx> for Search<'a, 'tcx> {
             }
             ty::Foreign(_) => {
                 self.found = Some(NonStructuralMatchTy::Foreign);
-                return true; // Stop visiting
+                return true; // Stop visiting.
             }
             ty::Opaque(..) => {
                 self.found = Some(NonStructuralMatchTy::Opaque);
-                return true;
+                return true; // Stop visiting.
             }
             ty::Projection(..) => {
                 self.found = Some(NonStructuralMatchTy::Projection);
-                return true;
+                return true; // Stop visiting.
             }
             ty::Generator(..) | ty::GeneratorWitness(..) => {
                 self.found = Some(NonStructuralMatchTy::Generator);
-                return true;
+                return true; // Stop visiting.
             }
             ty::RawPtr(..) => {
                 // structural-match ignores substructure of
@@ -178,14 +178,14 @@ impl<'a, 'tcx> TypeVisitor<'tcx> for Search<'a, 'tcx> {
                 // structural equality on `T` does not recur into the raw
                 // pointer. Therefore, one can still use `C` in a pattern.
 
-                // (But still tell caller to continue search.)
+                // (But still tell the caller to continue search.)
                 return false;
             }
             ty::FnDef(..) | ty::FnPtr(..) => {
                 // Types of formals and return in `fn(_) -> _` are also irrelevant;
                 // so we do not recur into them via `super_visit_with`
                 //
-                // (But still tell caller to continue search.)
+                // (But still tell the caller to continue search.)
                 return false;
             }
             ty::Array(_, n)
@@ -193,16 +193,21 @@ impl<'a, 'tcx> TypeVisitor<'tcx> for Search<'a, 'tcx> {
             {
                 // rust-lang/rust#62336: ignore type of contents
                 // for empty array.
+                //
+                // (But still tell the caller to continue search.)
                 return false;
             }
             ty::Bool | ty::Char | ty::Int(_) | ty::Uint(_) | ty::Float(_) | ty::Str | ty::Never => {
                 // These primitive types are always structural match.
                 //
                 // `Never` is kind of special here, but as it is not inhabitable, this should be fine.
+                //
+                // (But still tell the caller to continue search.)
                 return false;
             }
 
             ty::Array(..) | ty::Slice(_) | ty::Ref(..) | ty::Tuple(..) => {
+                // First check all contained types and then tell the caller to continue searching.
                 ty.super_visit_with(self);
                 return false;
             }
@@ -217,13 +222,15 @@ impl<'a, 'tcx> TypeVisitor<'tcx> for Search<'a, 'tcx> {
                 self.tcx().sess.delay_span_bug(self.span, "ty::Error in structural-match check");
                 // We still want to check other types after encountering an error,
                 // as this may still emit relevant errors.
+                //
+                // So we continue searching here.
                 return false;
             }
         };
 
         if !self.seen.insert(adt_def.did) {
             debug!("Search already seen adt_def: {:?}", adt_def);
-            // let caller continue its search
+            // Let caller continue its search.
             return false;
         }
 

--- a/src/librustc_trait_selection/traits/structural_match.rs
+++ b/src/librustc_trait_selection/traits/structural_match.rs
@@ -186,8 +186,7 @@ impl<'a, 'tcx> TypeVisitor<'tcx> for Search<'a, 'tcx> {
             | ty::Uint(_)
             | ty::Float(_)
             | ty::Str
-            | ty::Never
-            | ty::Error => {
+            | ty::Never => {
                 // These primitive types are always structural match.
                 //
                 // `Never` is kind of special here, but as it is not inhabitable, this should be fine.
@@ -199,15 +198,23 @@ impl<'a, 'tcx> TypeVisitor<'tcx> for Search<'a, 'tcx> {
             | ty::Ref(..)
             | ty::Closure(..)
             | ty::Generator(..)
-            | ty::GeneratorWitness(..)
             | ty::Tuple(..)
             | ty::Projection(..)
-            | ty::UnnormalizedProjection(..)
             | ty::Opaque(..)
-            | ty::Bound(..)
-            | ty::Placeholder(_)
-            | ty::Infer(_) => {
+            | ty::GeneratorWitness(..) => {
                 ty.super_visit_with(self);
+                return false;
+            }
+            | ty::Infer(_)
+            | ty::Placeholder(_)
+            | ty::UnnormalizedProjection(..)
+            | ty::Bound(..) => {
+                bug!("unexpected type during structural-match checking: {:?}", ty);
+            }
+            ty::Error => {
+                self.tcx().delay_span_bug(self.span, "ty::Error in structural-match check");
+                // We still want to check other types after encountering an error,
+                // as this may still emit relevant errors.
                 return false;
             }
         };

--- a/src/librustc_trait_selection/traits/structural_match.rs
+++ b/src/librustc_trait_selection/traits/structural_match.rs
@@ -12,6 +12,7 @@ pub enum NonStructuralMatchTy<'tcx> {
     Adt(&'tcx AdtDef),
     Param,
     Dynamic,
+    Foreign,
 }
 
 /// This method traverses the structure of `ty`, trying to find an
@@ -142,6 +143,10 @@ impl<'a, 'tcx> TypeVisitor<'tcx> for Search<'a, 'tcx> {
                 self.found = Some(NonStructuralMatchTy::Dynamic);
                 return true; // Stop visiting.
             }
+            ty::Foreign(_) => {
+                self.found = Some(NonStructuralMatchTy::Foreign);
+                return true; // Stop visiting
+            }
             ty::RawPtr(..) => {
                 // structural-match ignores substructure of
                 // `*const _`/`*mut _`, so skip `super_visit_with`.
@@ -162,7 +167,7 @@ impl<'a, 'tcx> TypeVisitor<'tcx> for Search<'a, 'tcx> {
                 return false;
             }
             ty::FnDef(..) | ty::FnPtr(..) => {
-                // types of formals and return in `fn(_) -> _` are also irrelevant;
+                // Types of formals and return in `fn(_) -> _` are also irrelevant;
                 // so we do not recur into them via `super_visit_with`
                 //
                 // (But still tell caller to continue search.)
@@ -175,7 +180,33 @@ impl<'a, 'tcx> TypeVisitor<'tcx> for Search<'a, 'tcx> {
                 // for empty array.
                 return false;
             }
-            _ => {
+            ty::Bool
+            | ty::Char
+            | ty::Int(_)
+            | ty::Uint(_)
+            | ty::Float(_)
+            | ty::Str
+            | ty::Never
+            | ty::Error => {
+                // These primitive types are always structural match.
+                //
+                // `Never` is kind of special here, but as it is not inhabitable, this should be fine.
+                return false;
+            }
+
+            ty::Array(..)
+            | ty::Slice(_)
+            | ty::Ref(..)
+            | ty::Closure(..)
+            | ty::Generator(..)
+            | ty::GeneratorWitness(..)
+            | ty::Tuple(..)
+            | ty::Projection(..)
+            | ty::UnnormalizedProjection(..)
+            | ty::Opaque(..)
+            | ty::Bound(..)
+            | ty::Placeholder(_)
+            | ty::Infer(_) => {
                 ty.super_visit_with(self);
                 return false;
             }

--- a/src/librustc_typeck/check/generator_interior.rs
+++ b/src/librustc_typeck/check/generator_interior.rs
@@ -96,7 +96,7 @@ impl<'a, 'tcx> InteriorVisitor<'a, 'tcx> {
                         span: source_span,
                         ty: &ty,
                         scope_span,
-                        yield_span: Some(yield_data.span),
+                        yield_span: yield_data.span,
                         expr: expr.map(|e| e.hir_id),
                     })
                     .or_insert(entries);
@@ -130,7 +130,6 @@ pub fn resolve_interior<'a, 'tcx>(
     kind: hir::GeneratorKind,
 ) {
     let body = fcx.tcx.hir().body(body_id);
-
     let mut visitor = InteriorVisitor {
         fcx,
         types: FxHashMap::default(),

--- a/src/librustc_typeck/check/generator_interior.rs
+++ b/src/librustc_typeck/check/generator_interior.rs
@@ -16,6 +16,7 @@ use rustc_span::Span;
 
 struct InteriorVisitor<'a, 'tcx> {
     fcx: &'a FnCtxt<'a, 'tcx>,
+    closure_def_id: DefId,
     types: FxHashMap<ty::GeneratorInteriorTypeCause<'tcx>, usize>,
     region_scope_tree: &'tcx region::ScopeTree,
     expr_count: usize,
@@ -30,6 +31,7 @@ impl<'a, 'tcx> InteriorVisitor<'a, 'tcx> {
         scope: Option<region::Scope>,
         expr: Option<&'tcx Expr<'tcx>>,
         source_span: Span,
+        is_upvar: bool,
     ) {
         use rustc_span::DUMMY_SP;
 
@@ -96,7 +98,7 @@ impl<'a, 'tcx> InteriorVisitor<'a, 'tcx> {
                         span: source_span,
                         ty: &ty,
                         scope_span,
-                        yield_span: yield_data.span,
+                        yield_span: Some(yield_data.span),
                         expr: expr.map(|e| e.hir_id),
                     })
                     .or_insert(entries);
@@ -117,6 +119,20 @@ impl<'a, 'tcx> InteriorVisitor<'a, 'tcx> {
                     unresolved_type, unresolved_type_span
                 );
                 self.prev_unresolved_span = unresolved_type_span;
+            } else {
+                if is_upvar {
+                    let entries = self.types.len();
+                    let scope_span = scope.map(|s| s.span(self.fcx.tcx, self.region_scope_tree));
+                    self.types
+                        .entry(ty::GeneratorInteriorTypeCause {
+                            span: source_span,
+                            ty: &ty,
+                            scope_span,
+                            yield_span: None,
+                            expr: expr.map(|e| e.hir_id),
+                        })
+                        .or_insert(entries);
+                }
             }
         }
     }
@@ -130,8 +146,12 @@ pub fn resolve_interior<'a, 'tcx>(
     kind: hir::GeneratorKind,
 ) {
     let body = fcx.tcx.hir().body(body_id);
+
+    let closure_def_id = fcx.tcx.hir().body_owner_def_id(body_id).to_def_id();
+
     let mut visitor = InteriorVisitor {
         fcx,
+        closure_def_id,
         types: FxHashMap::default(),
         region_scope_tree: fcx.tcx.region_scope_tree(def_id),
         expr_count: 0,
@@ -223,7 +243,7 @@ impl<'a, 'tcx> Visitor<'tcx> for InteriorVisitor<'a, 'tcx> {
         if let PatKind::Binding(..) = pat.kind {
             let scope = self.region_scope_tree.var_scope(pat.hir_id.local_id);
             let ty = self.fcx.tables.borrow().pat_ty(pat);
-            self.record(ty, Some(scope), None, pat.span);
+            self.record(ty, Some(scope), None, pat.span, false);
         }
     }
 
@@ -264,7 +284,7 @@ impl<'a, 'tcx> Visitor<'tcx> for InteriorVisitor<'a, 'tcx> {
         // If there are adjustments, then record the final type --
         // this is the actual value that is being produced.
         if let Some(adjusted_ty) = self.fcx.tables.borrow().expr_ty_adjusted_opt(expr) {
-            self.record(adjusted_ty, scope, Some(expr), expr.span);
+            self.record(adjusted_ty, scope, Some(expr), expr.span, false);
         }
 
         // Also record the unadjusted type (which is the only type if
@@ -292,9 +312,17 @@ impl<'a, 'tcx> Visitor<'tcx> for InteriorVisitor<'a, 'tcx> {
         // The type table might not have information for this expression
         // if it is in a malformed scope. (#66387)
         if let Some(ty) = self.fcx.tables.borrow().expr_ty_opt(expr) {
-            self.record(ty, scope, Some(expr), expr.span);
+            self.record(ty, scope, Some(expr), expr.span, false);
         } else {
             self.fcx.tcx.sess.delay_span_bug(expr.span, "no type for node");
+        }
+
+        if let Some(upvars) = self.fcx.tcx.upvars(self.closure_def_id) {
+            for (upvar_id, upvar) in upvars.iter() {
+                let upvar_ty = self.fcx.tables.borrow().node_type(*upvar_id);
+                debug!("type of upvar: {:?}", upvar_ty);
+                self.record(upvar_ty, scope, Some(expr), upvar.span, true);
+            }
         }
     }
 }

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -2703,3 +2703,9 @@ function focusSearchBar() {
 function defocusSearchBar() {
     getSearchInput().blur();
 }
+
+// This is required in firefox. Explanations: when going back in the history, firefox doesn't re-run
+// the JS, therefore preventing rustdoc from setting a few things required to be able to reload the
+// previous search results (if you navigated to a search result with the keyboard, pressed enter on
+// it to navigate to that result, and then came back to this page).
+window.onunload = function(){};

--- a/src/test/ui/async-await/issue-70818.rs
+++ b/src/test/ui/async-await/issue-70818.rs
@@ -1,0 +1,5 @@
+// edition 2018
+
+fn d<T: Sized>(t: T) -> impl std::future::Future<Output = T> + Send { //~ Error `T` cannot be sent between threads safely
+    async { t }
+}

--- a/src/test/ui/async-await/issue-70818.rs
+++ b/src/test/ui/async-await/issue-70818.rs
@@ -1,5 +1,7 @@
 // edition 2018
 
-fn d<T: Sized>(t: T) -> impl std::future::Future<Output = T> + Send { //~ Error `T` cannot be sent between threads safely
-    async { t }
+fn foo<T: Sized>(ty: T) -> impl std::future::Future<Output = T> + Send { //~ Error `T` cannot be sent between threads safely
+    async { ty }
 }
+
+fn main() {}

--- a/src/test/ui/async-await/issue-70818.rs
+++ b/src/test/ui/async-await/issue-70818.rs
@@ -1,7 +1,9 @@
-// edition 2018
+// edition:2018
 
-fn foo<T: Sized>(ty: T) -> impl std::future::Future<Output = T> + Send { //~ Error `T` cannot be sent between threads safely
-    async { ty }
+use std::future::Future;
+fn foo<T: Send, U>(ty: T, ty1: U) -> impl Future<Output = (T, U)> + Send {
+//~^ Error future cannot be sent between threads safely
+    async { (ty, ty1) }
 }
 
 fn main() {}

--- a/src/test/ui/async-await/issue-70818.stderr
+++ b/src/test/ui/async-await/issue-70818.stderr
@@ -1,0 +1,23 @@
+error: future cannot be sent between threads safely
+  --> $DIR/issue-70818.rs:4:38
+   |
+LL | fn foo<T: Send, U>(ty: T, ty1: U) -> impl Future<Output = (T, U)> + Send {
+   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ future created by async block is not `Send`
+LL |
+LL |     async { (ty, ty1) }
+   |     ------------------- this returned value is of type `impl std::future::Future`
+   |
+   = help: within `impl std::future::Future`, the trait `std::marker::Send` is not implemented for `U`
+note: captured outer value is not `Send`
+  --> $DIR/issue-70818.rs:6:18
+   |
+LL |     async { (ty, ty1) }
+   |                  ^^^ has type `U` which is not `Send`
+   = note: the return type of a function must have a statically known size
+help: consider restricting type parameter `U`
+   |
+LL | fn foo<T: Send, U: std::marker::Send>(ty: T, ty1: U) -> impl Future<Output = (T, U)> + Send {
+   |                  ^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+

--- a/src/test/ui/async-await/issue-70818.stderr
+++ b/src/test/ui/async-await/issue-70818.stderr
@@ -8,7 +8,7 @@ LL |     async { (ty, ty1) }
    |     ------------------- this returned value is of type `impl std::future::Future`
    |
    = help: within `impl std::future::Future`, the trait `std::marker::Send` is not implemented for `U`
-note: captured outer value is not `Send`
+note: captured value is not `Send`
   --> $DIR/issue-70818.rs:6:18
    |
 LL |     async { (ty, ty1) }

--- a/src/test/ui/type-alias-impl-trait/structural-match-no-leak.rs
+++ b/src/test/ui/type-alias-impl-trait/structural-match-no-leak.rs
@@ -1,0 +1,20 @@
+#![feature(const_fn, type_alias_impl_trait)]
+
+type Bar = impl Send;
+
+// While i32 is structural-match, we do not want to leak this information.
+// (See https://github.com/rust-lang/rust/issues/72156)
+const fn leak_free() -> Bar {
+    7i32
+}
+const LEAK_FREE: Bar = leak_free();
+
+fn leak_free_test() {
+    match todo!() {
+        LEAK_FREE => (),
+        //~^ opaque types cannot be used in patterns
+        _ => (),
+    }
+}
+
+fn main() { }

--- a/src/test/ui/type-alias-impl-trait/structural-match-no-leak.stderr
+++ b/src/test/ui/type-alias-impl-trait/structural-match-no-leak.stderr
@@ -1,0 +1,8 @@
+error: opaque types cannot be used in patterns
+  --> $DIR/structural-match-no-leak.rs:14:9
+   |
+LL |         LEAK_FREE => (),
+   |         ^^^^^^^^^
+
+error: aborting due to previous error
+

--- a/src/test/ui/type-alias-impl-trait/structural-match.rs
+++ b/src/test/ui/type-alias-impl-trait/structural-match.rs
@@ -1,0 +1,21 @@
+#![feature(const_fn, type_alias_impl_trait)]
+
+type Foo = impl Send;
+
+// This is not structural-match
+struct A;
+
+const fn value() -> Foo {
+    A
+}
+const VALUE: Foo = value();
+
+fn test() {
+    match todo!() {
+        VALUE => (),
+        //~^ opaque types cannot be used in patterns
+        _ => (),
+    }
+}
+
+fn main() { }

--- a/src/test/ui/type-alias-impl-trait/structural-match.stderr
+++ b/src/test/ui/type-alias-impl-trait/structural-match.stderr
@@ -1,0 +1,8 @@
+error: opaque types cannot be used in patterns
+  --> $DIR/structural-match.rs:15:9
+   |
+LL |         VALUE => (),
+   |         ^^^^^
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Successful merges:

 - #71923 (Check non-Send/Sync upvars captured by generator)
 - #72153 (exhaustively check `ty::Kind` during structural match checking)
 - #72272 (Fix going back in history to a search result page on firefox)
 - #72275 (Continue lowering for unsupported async generator instead of returning an error.)
 - #72361 (split_inclusive: add tracking issue number (72360))

Failed merges:


r? @ghost