### PR TITLE
llvm: Expose tiny code model to users

### DIFF
--- a/src/doc/rustc/src/codegen-options/index.md
+++ b/src/doc/rustc/src/codegen-options/index.md
@@ -21,7 +21,7 @@ specification.
 
 Supported values for this option are:
 
-<!-- - `tiny` - Tiny code model. -->
+- `tiny` - Tiny code model.
 - `small` - Small code model. This is the default model for majority of supported targets.
 - `kernel` - Kernel code model.
 - `medium` - Medium code model.

--- a/src/librustc_codegen_llvm/lib.rs
+++ b/src/librustc_codegen_llvm/lib.rs
@@ -208,7 +208,7 @@ impl CodegenBackend for LlvmCodegenBackend {
             }
             PrintRequest::CodeModels => {
                 println!("Available code models:");
-                for name in &["small", "kernel", "medium", "large"] {
+                for name in &["tiny", "small", "kernel", "medium", "large"] {
                     println!("    {}", name);
                 }
                 println!();

--- a/src/librustc_target/spec/mod.rs
+++ b/src/librustc_target/spec/mod.rs
@@ -322,7 +322,7 @@ impl FromStr for CodeModel {
 
     fn from_str(s: &str) -> Result<CodeModel, ()> {
         Ok(match s {
-            // "tiny" => CodeModel::Tiny, // Not exposed to users right now.
+            "tiny" => CodeModel::Tiny,
             "small" => CodeModel::Small,
             "kernel" => CodeModel::Kernel,
             "medium" => CodeModel::Medium,


### PR DESCRIPTION
This model is relevant to embedded AArch64 targets and was added to LLVM relatively recently (https://reviews.llvm.org/D49673, mid 2018), so rustc frontend didn't provide access to it with `-C code-model`. The gcc analogue is [`-mcmodel=tiny`](https://gcc.gnu.org/onlinedocs/gcc/AArch64-Options.html).
(This is one of the options that are passed directly to LLVM without being interpreted by rustc.)

Follow up to https://github.com/rust-lang/rust/pull/72248.