### PR TITLE
Add missing ASM arena declarations to librustc_middle

### DIFF
--- a/src/librustc_middle/arena.rs
+++ b/src/librustc_middle/arena.rs
@@ -76,6 +76,12 @@ macro_rules! arena_types {
             [few] hir_definitions: rustc_hir::definitions::Definitions,
             [] hir_owner: rustc_middle::hir::Owner<$tcx>,
             [] hir_owner_nodes: rustc_middle::hir::OwnerNodes<$tcx>,
+
+            // Note that this deliberately duplicates items in the `rustc_hir::arena`,
+            // since we need to allocate this type on both the `rustc_hir` arena
+            // (during lowering) and the `librustc_middle` arena (for decoding MIR)
+            [decode] asm_template: rustc_ast::ast::InlineAsmTemplatePiece,
+
         ], $tcx);
     )
 }

--- a/src/test/incremental/issue-72386.rs
+++ b/src/test/incremental/issue-72386.rs
@@ -1,0 +1,22 @@
+// revisions: rpass1 cfail1 rpass3
+// only-x86_64
+// Regression test for issue #72386
+// Checks that we don't ICE when switching to an invalid register
+// and back again
+
+#![feature(asm)]
+
+#[cfg(any(rpass1, rpass3))]
+fn main() {
+    unsafe {
+        asm!("nop")
+    }
+}
+
+#[cfg(cfail1)]
+fn main() {
+    unsafe {
+        asm!("nop",out("invalid_reg")_)
+        //[cfail1]~^ ERROR invalid register
+    }
+}


### PR DESCRIPTION
Fixes #72386

These types also need to get allocated on the `librustc_middle` arena
when we deserialize MIR.

@Amanieu: If we end up using your approach in https://github.com/rust-lang/rust/pull/72392 instead, feel free to copy the test I added over to your PR.