### PR TITLE
Use correct function for detecting `const fn` in unsafety checking

### DIFF
--- a/src/librustc_mir/transform/check_unsafety.rs
+++ b/src/librustc_mir/transform/check_unsafety.rs
@@ -14,7 +14,7 @@ use rustc_span::symbol::{sym, Symbol};
 
 use std::ops::Bound;
 
-use crate::const_eval::{is_const_fn, is_min_const_fn};
+use crate::const_eval::is_min_const_fn;
 use crate::util;
 
 pub struct UnsafetyChecker<'a, 'tcx> {
@@ -527,7 +527,7 @@ fn unsafety_check_result(tcx: TyCtxt<'_>, def_id: LocalDefId) -> UnsafetyCheckRe
     let (const_context, min_const_fn) = match tcx.hir().body_owner_kind(id) {
         hir::BodyOwnerKind::Closure => (false, false),
         hir::BodyOwnerKind::Fn => {
-            (is_const_fn(tcx, def_id.to_def_id()), is_min_const_fn(tcx, def_id.to_def_id()))
+            (tcx.is_const_fn_raw(def_id.to_def_id()), is_min_const_fn(tcx, def_id.to_def_id()))
         }
         hir::BodyOwnerKind::Const | hir::BodyOwnerKind::Static(_) => (true, false),
     };

--- a/src/test/ui/unsafe/unsafe-unstable-const-fn.rs
+++ b/src/test/ui/unsafe/unsafe-unstable-const-fn.rs
@@ -1,0 +1,13 @@
+#![stable(feature = "foo", since = "1.33.0")]
+#![feature(staged_api)]
+#![feature(const_compare_raw_pointers)]
+#![feature(const_fn)]
+
+#[stable(feature = "foo", since = "1.33.0")]
+#[rustc_const_unstable(feature = "const_foo", issue = "none")]
+const fn unstable(a: *const i32, b: *const i32) -> bool {
+    a == b
+    //~^ pointer operation is unsafe
+}
+
+fn main() {}

--- a/src/test/ui/unsafe/unsafe-unstable-const-fn.stderr
+++ b/src/test/ui/unsafe/unsafe-unstable-const-fn.stderr
@@ -1,0 +1,11 @@
+error[E0133]: pointer operation is unsafe and requires unsafe function or block
+  --> $DIR/unsafe-unstable-const-fn.rs:9:5
+   |
+LL |     a == b
+   |     ^^^^^^ pointer operation
+   |
+   = note: operations on pointers in constants
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0133`.


### PR DESCRIPTION
Resolves #72394.

