### PR TITLE
Add PartialEq and PartialOrd for NonZeroInt to Int

### DIFF
--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -4,6 +4,7 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
+use crate::cmp::Ordering;
 use crate::convert::Infallible;
 use crate::fmt;
 use crate::intrinsics;
@@ -167,6 +168,34 @@ assert_eq!(size_of::<Option<core::num::", stringify!($Ty), ">>(), size_of::<", s
                 #[inline]
                 fn bitor_assign(&mut self, rhs: $Int) {
                     *self = *self | rhs;
+                }
+            }
+
+            #[stable(feature = "nonzero_cmp_to_int", since = "1.47.0")]
+            impl PartialEq<$Int> for $Ty {
+                fn eq(&self, rhs: &$Int) -> bool {
+                    self.0 == *rhs
+                }
+            }
+
+            #[stable(feature = "nonzero_cmp_to_int", since = "1.47.0")]
+            impl PartialOrd<$Int> for $Ty {
+                fn partial_cmp(&self, rhs: &$Int) -> Option<Ordering> {
+                    Some(self.0.cmp(rhs))
+                }
+            }
+
+            #[stable(feature = "nonzero_cmp_to_int", since = "1.47.0")]
+            impl PartialEq<$Ty> for $Int {
+                fn eq(&self, rhs: &$Ty) -> bool {
+                    *self == rhs.0
+                }
+            }
+
+            #[stable(feature = "nonzero_cmp_to_int", since = "1.47.0")]
+            impl PartialOrd<$Ty> for $Int {
+                fn partial_cmp(&self, rhs: &$Ty) -> Option<Ordering> {
+                    Some(self.cmp(&rhs.0))
                 }
             }
 

--- a/library/core/tests/nonzero.rs
+++ b/library/core/tests/nonzero.rs
@@ -195,3 +195,49 @@ fn test_nonzero_from_int_on_err() {
     assert!(NonZeroI8::try_from(0).is_err());
     assert!(NonZeroI32::try_from(0).is_err());
 }
+
+#[test]
+fn test_compare_regular_int() {
+    let nonzero = NonZeroI32::new(125).unwrap();
+
+    assert_eq!(nonzero, 125);
+    assert_ne!(nonzero, 0);
+    assert_ne!(nonzero, -125);
+
+    assert!(nonzero == 125);
+    assert!(nonzero != 0);
+    assert!(nonzero != -125);
+
+    assert!(nonzero < 200);
+    assert!(nonzero <= 125);
+    assert!(nonzero <= 200);
+
+    assert!(nonzero > 0);
+    assert!(nonzero > -200);
+    assert!(nonzero >= 125);
+    assert!(nonzero >= 0);
+    assert!(nonzero >= -100);
+}
+
+#[test]
+fn test_compare_regular_int_reversed() {
+    let nonzero = NonZeroI32::new(125).unwrap();
+
+    assert_eq!(125, nonzero);
+    assert_ne!(0, nonzero);
+    assert_ne!(-125, nonzero);
+
+    assert!(125 == nonzero);
+    assert!(0 != nonzero);
+    assert!(-125 != nonzero);
+
+    assert!(200 > nonzero);
+    assert!(125 >= nonzero);
+    assert!(200 >= nonzero);
+
+    assert!(0 < nonzero);
+    assert!(-200 < nonzero);
+    assert!(125 <= nonzero);
+    assert!(0 <= nonzero);
+    assert!(-100 <= nonzero);
+}


### PR DESCRIPTION
Propose adding `PartialEq` and `PartialOrd` to the `NonZeroInt` types to compare to their inner types. Seems like a pretty obvious change, but I'm obviously open to any feedback or suggestions.

I'd also like to implement `PartialEq<NonZeroInt> for Int`, but I wasn't sure what the implications were for implementing traits on primitive types like that.

Retry of #70855 