### PR TITLE
[WIP] Implement shim for types that transitively derive Clone

### DIFF
--- a/src/libcore/clone.rs
+++ b/src/libcore/clone.rs
@@ -136,7 +136,7 @@ pub trait Clone: Sized {
 /// Derive macro generating an impl of the trait `Clone`.
 #[rustc_builtin_macro]
 #[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
-#[allow_internal_unstable(core_intrinsics, derive_clone_copy)]
+#[allow_internal_unstable(core_intrinsics, derive_clone_copy, structural_match)]
 pub macro Clone($item:item) {
     /* compiler built-in */
 }

--- a/src/libcore/marker.rs
+++ b/src/libcore/marker.rs
@@ -205,6 +205,12 @@ pub trait StructuralEq {
     // Empty.
 }
 
+/// Temp
+#[cfg(not(bootstrap))]
+#[unstable(feature = "structural_match", issue = "31434")]
+#[lang = "derived_clone"]
+pub trait DerivedClone {}
+
 /// Types whose values can be duplicated simply by copying bits.
 ///
 /// By default, variable bindings have 'move semantics.' In other

--- a/src/librustc_builtin_macros/deriving/clone.rs
+++ b/src/librustc_builtin_macros/deriving/clone.rs
@@ -73,6 +73,14 @@ pub fn expand_deriving_clone(
         _ => cx.span_bug(span, "`#[derive(Clone)]` on trait item or impl item"),
     }
 
+    super::inject_impl_of_structural_trait(
+        cx,
+        span,
+        item,
+        path_std!(cx, marker::DerivedClone),
+        push,
+    );
+
     let inline = cx.meta_word(span, sym::inline);
     let attrs = vec![cx.attribute(inline)];
     let trait_def = TraitDef {

--- a/src/librustc_hir/lang_items.rs
+++ b/src/librustc_hir/lang_items.rs
@@ -160,6 +160,7 @@ language_item_table! {
     StructuralPeqTraitLangItem,  "structural_peq",     structural_peq_trait,    Target::Trait;
     // trait injected by #[derive(Eq)], (i.e. "Total EQ"; no, I will not apologize).
     StructuralTeqTraitLangItem,  "structural_teq",     structural_teq_trait,    Target::Trait;
+    DerivedClone,                "derived_clone",      derived_clone_trait,     Target::Trait;
     CopyTraitLangItem,           "copy",               copy_trait,              Target::Trait;
     CloneTraitLangItem,          "clone",              clone_trait,             Target::Trait;
     SyncTraitLangItem,           "sync",               sync_trait,              Target::Trait;

--- a/src/librustc_middle/query/mod.rs
+++ b/src/librustc_middle/query/mod.rs
@@ -1296,5 +1296,9 @@ rustc_queries! {
         ) -> Result<Option<ty::Instance<'tcx>>, ErrorReported> {
             desc { "resolving instance `{}`", ty::Instance::new(key.value.0, key.value.1) }
         }
+
+        query is_transitive_derive_clone(key: Ty<'tcx>) -> bool {
+            desc { "determining if item {:?} transitively derives Clone", key }
+        }
     }
 }

--- a/src/librustc_middle/ty/instance.rs
+++ b/src/librustc_middle/ty/instance.rs
@@ -72,7 +72,7 @@ pub enum InstanceDef<'tcx> {
     /// NB: the type must currently be monomorphic to avoid double substitution
     /// problems with the MIR shim bodies. `Instance::resolve` enforces this.
     // FIXME(#69925) support polymorphic MIR shim bodies properly instead.
-    CloneShim(DefId, Ty<'tcx>),
+    CloneShim(DefId, Ty<'tcx>, bool),
 }
 
 impl<'tcx> Instance<'tcx> {
@@ -151,7 +151,7 @@ impl<'tcx> InstanceDef<'tcx> {
             | InstanceDef::Intrinsic(def_id)
             | InstanceDef::ClosureOnceShim { call_once: def_id }
             | InstanceDef::DropGlue(def_id, _)
-            | InstanceDef::CloneShim(def_id, _) => def_id,
+            | InstanceDef::CloneShim(def_id, _, _) => def_id,
         }
     }
 
@@ -240,7 +240,8 @@ impl<'tcx> fmt::Display for Instance<'tcx> {
             InstanceDef::FnPtrShim(_, ty) => write!(f, " - shim({:?})", ty),
             InstanceDef::ClosureOnceShim { .. } => write!(f, " - shim"),
             InstanceDef::DropGlue(_, ty) => write!(f, " - shim({:?})", ty),
-            InstanceDef::CloneShim(_, ty) => write!(f, " - shim({:?})", ty),
+            InstanceDef::CloneShim(_, ty, from_derive) => write!(f, " - shim({:?}, from_derive={:?})", ty,
+            from_derive),
         }
     }
 }

--- a/src/librustc_middle/ty/structural_impls.rs
+++ b/src/librustc_middle/ty/structural_impls.rs
@@ -676,8 +676,8 @@ impl<'a, 'tcx> Lift<'tcx> for ty::InstanceDef<'a> {
             ty::InstanceDef::DropGlue(def_id, ref ty) => {
                 Some(ty::InstanceDef::DropGlue(def_id, tcx.lift(ty)?))
             }
-            ty::InstanceDef::CloneShim(def_id, ref ty) => {
-                Some(ty::InstanceDef::CloneShim(def_id, tcx.lift(ty)?))
+            ty::InstanceDef::CloneShim(def_id, ref ty, from_derive) => {
+                Some(ty::InstanceDef::CloneShim(def_id, tcx.lift(ty)?, from_derive))
             }
         }
     }
@@ -844,7 +844,7 @@ impl<'tcx> TypeFoldable<'tcx> for ty::instance::Instance<'tcx> {
                     ClosureOnceShim { call_once: call_once.fold_with(folder) }
                 }
                 DropGlue(did, ty) => DropGlue(did.fold_with(folder), ty.fold_with(folder)),
-                CloneShim(did, ty) => CloneShim(did.fold_with(folder), ty.fold_with(folder)),
+                CloneShim(did, ty, from_derive) => CloneShim(did.fold_with(folder), ty.fold_with(folder), from_derive),
             },
         }
     }
@@ -856,7 +856,7 @@ impl<'tcx> TypeFoldable<'tcx> for ty::instance::Instance<'tcx> {
                 Item(did) | VtableShim(did) | ReifyShim(did) | Intrinsic(did) | Virtual(did, _) => {
                     did.visit_with(visitor)
                 }
-                FnPtrShim(did, ty) | CloneShim(did, ty) => {
+                FnPtrShim(did, ty) | CloneShim(did, ty, _) => {
                     did.visit_with(visitor) || ty.visit_with(visitor)
                 }
                 DropGlue(did, ty) => did.visit_with(visitor) || ty.visit_with(visitor),


### PR DESCRIPTION
If a type is `#[derive(Clone)]`, and all of its transitive fields
are also `#[derive(Clone)]`, we skip generating the actual `clone`
function. Instead, we generate a 'clone shim', which just acts like the
trivial `Clone` impl for a `Copy` type. We do this even if the type
itself is not `Copy`.