### PR TITLE
Fix anchor display when hovering impl

### DIFF
--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -625,7 +625,7 @@ a {
 	display: initial;
 }
 
-.in-band:hover > .anchor {
+.in-band:hover > .anchor, .impl:hover > .anchor {
 	display: inline-block;
 	position: absolute;
 }


### PR DESCRIPTION
A little gif for the fixed behaviour:

![hover-anchor](https://user-images.githubusercontent.com/3050060/82549808-cfdf4080-9b5d-11ea-9495-2b1d90b2a791.gif)

r? @kinnison 