### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/src/doc/rustc/src/codegen-options/index.md
+++ b/src/doc/rustc/src/codegen-options/index.md
@@ -21,7 +21,7 @@ specification.
 
 Supported values for this option are:
 
-<!-- - `tiny` - Tiny code model. -->
+- `tiny` - Tiny code model.
 - `small` - Small code model. This is the default model for majority of supported targets.
 - `kernel` - Kernel code model.
 - `medium` - Medium code model.

--- a/src/doc/unstable-book/src/compiler-flags/strip.md
+++ b/src/doc/unstable-book/src/compiler-flags/strip.md
@@ -1,0 +1,17 @@
+# `strip`
+
+The tracking issue for this feature is: [#72110](https://github.com/rust-lang/rust/issues/72110).
+
+------------------------
+
+Option `-Z strip=val` controls stripping of debuginfo and similar auxiliary data from binaries
+during linking.
+
+Supported values for this option are:
+
+- `none` - debuginfo and symbols (if they exist) are copied to the produced binary or separate files
+depending on the target (e.g. `.pdb` files in case of MSVC).
+- `debuginfo` - debuginfo sections and debuginfo symbols from the symbol table section
+are stripped at link time and are not copied to the produced binary or separate files.
+- `symbols` - same as `debuginfo`, but the rest of the symbol table section is stripped as well
+if the linker supports it.

--- a/src/libcore/char/methods.rs
+++ b/src/libcore/char/methods.rs
@@ -575,8 +575,9 @@ impl char {
     /// assert!(!'A'.is_lowercase());
     /// assert!(!'Δ'.is_lowercase());
     ///
-    /// // The various Chinese scripts do not have case, and so:
+    /// // The various Chinese scripts and punctuation do not have case, and so:
     /// assert!(!'中'.is_lowercase());
+    /// assert!(!' '.is_lowercase());
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
@@ -606,8 +607,9 @@ impl char {
     /// assert!('A'.is_uppercase());
     /// assert!('Δ'.is_uppercase());
     ///
-    /// // The various Chinese scripts do not have case, and so:
+    /// // The various Chinese scripts and punctuation do not have case, and so:
     /// assert!(!'中'.is_uppercase());
+    /// assert!(!' '.is_uppercase());
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]

--- a/src/libcore/char/methods.rs
+++ b/src/libcore/char/methods.rs
@@ -9,6 +9,246 @@ use super::*;
 
 #[lang = "char"]
 impl char {
+    /// The highest valid code point a `char` can have.
+    ///
+    /// A [`char`] is a [Unicode Scalar Value], which means that it is a [Code
+    /// Point], but only ones within a certain range. `MAX` is the highest valid
+    /// code point that's a valid [Unicode Scalar Value].
+    ///
+    /// [`char`]: ../../std/primitive.char.html
+    /// [Unicode Scalar Value]: http://www.unicode.org/glossary/#unicode_scalar_value
+    /// [Code Point]: http://www.unicode.org/glossary/#code_point
+    #[unstable(feature = "assoc_char_consts", reason = "recently added", issue = "71763")]
+    pub const MAX: char = '\u{10ffff}';
+
+    /// `U+FFFD REPLACEMENT CHARACTER` (�) is used in Unicode to represent a
+    /// decoding error.
+    ///
+    /// It can occur, for example, when giving ill-formed UTF-8 bytes to
+    /// [`String::from_utf8_lossy`](../../std/string/struct.String.html#method.from_utf8_lossy).
+    #[unstable(feature = "assoc_char_consts", reason = "recently added", issue = "71763")]
+    pub const REPLACEMENT_CHARACTER: char = '\u{FFFD}';
+
+    /// The version of [Unicode](http://www.unicode.org/) that the Unicode parts of
+    /// `char` and `str` methods are based on.
+    ///
+    /// New versions of Unicode are released regularly and subsequently all methods
+    /// in the standard library depending on Unicode are updated. Therefore the
+    /// behavior of some `char` and `str` methods and the value of this constant
+    /// changes over time. This is *not* considered to be a breaking change.
+    ///
+    /// The version numbering scheme is explained in
+    /// [Unicode 11.0 or later, Section 3.1 Versions of the Unicode Standard](https://www.unicode.org/versions/Unicode11.0.0/ch03.pdf#page=4).
+    #[unstable(feature = "assoc_char_consts", reason = "recently added", issue = "71763")]
+    pub const UNICODE_VERSION: (u8, u8, u8) = crate::unicode::UNICODE_VERSION;
+
+    /// Creates an iterator over the UTF-16 encoded code points in `iter`,
+    /// returning unpaired surrogates as `Err`s.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// use std::char::decode_utf16;
+    ///
+    /// // 𝄞mus<invalid>ic<invalid>
+    /// let v = [
+    ///     0xD834, 0xDD1E, 0x006d, 0x0075, 0x0073, 0xDD1E, 0x0069, 0x0063, 0xD834,
+    /// ];
+    ///
+    /// assert_eq!(
+    ///     decode_utf16(v.iter().cloned())
+    ///         .map(|r| r.map_err(|e| e.unpaired_surrogate()))
+    ///         .collect::<Vec<_>>(),
+    ///     vec![
+    ///         Ok('𝄞'),
+    ///         Ok('m'), Ok('u'), Ok('s'),
+    ///         Err(0xDD1E),
+    ///         Ok('i'), Ok('c'),
+    ///         Err(0xD834)
+    ///     ]
+    /// );
+    /// ```
+    ///
+    /// A lossy decoder can be obtained by replacing `Err` results with the replacement character:
+    ///
+    /// ```
+    /// use std::char::{decode_utf16, REPLACEMENT_CHARACTER};
+    ///
+    /// // 𝄞mus<invalid>ic<invalid>
+    /// let v = [
+    ///     0xD834, 0xDD1E, 0x006d, 0x0075, 0x0073, 0xDD1E, 0x0069, 0x0063, 0xD834,
+    /// ];
+    ///
+    /// assert_eq!(
+    ///     decode_utf16(v.iter().cloned())
+    ///        .map(|r| r.unwrap_or(REPLACEMENT_CHARACTER))
+    ///        .collect::<String>(),
+    ///     "𝄞mus�ic�"
+    /// );
+    /// ```
+    #[unstable(feature = "assoc_char_funcs", reason = "recently added", issue = "71763")]
+    #[inline]
+    pub fn decode_utf16<I: IntoIterator<Item = u16>>(iter: I) -> DecodeUtf16<I::IntoIter> {
+        super::decode::decode_utf16(iter)
+    }
+
+    /// Converts a `u32` to a `char`.
+    ///
+    /// Note that all [`char`]s are valid [`u32`]s, and can be cast to one with
+    /// `as`:
+    ///
+    /// ```
+    /// let c = '💯';
+    /// let i = c as u32;
+    ///
+    /// assert_eq!(128175, i);
+    /// ```
+    ///
+    /// However, the reverse is not true: not all valid [`u32`]s are valid
+    /// [`char`]s. `from_u32()` will return `None` if the input is not a valid value
+    /// for a [`char`].
+    ///
+    /// [`char`]: ../../std/primitive.char.html
+    /// [`u32`]: ../../std/primitive.u32.html
+    ///
+    /// For an unsafe version of this function which ignores these checks, see
+    /// [`from_u32_unchecked`].
+    ///
+    /// [`from_u32_unchecked`]: fn.from_u32_unchecked.html
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// use std::char;
+    ///
+    /// let c = char::from_u32(0x2764);
+    ///
+    /// assert_eq!(Some('❤'), c);
+    /// ```
+    ///
+    /// Returning `None` when the input is not a valid [`char`]:
+    ///
+    /// ```
+    /// use std::char;
+    ///
+    /// let c = char::from_u32(0x110000);
+    ///
+    /// assert_eq!(None, c);
+    /// ```
+    #[unstable(feature = "assoc_char_funcs", reason = "recently added", issue = "71763")]
+    #[inline]
+    pub fn from_u32(i: u32) -> Option<char> {
+        super::convert::from_u32(i)
+    }
+
+    /// Converts a `u32` to a `char`, ignoring validity.
+    ///
+    /// Note that all [`char`]s are valid [`u32`]s, and can be cast to one with
+    /// `as`:
+    ///
+    /// ```
+    /// let c = '💯';
+    /// let i = c as u32;
+    ///
+    /// assert_eq!(128175, i);
+    /// ```
+    ///
+    /// However, the reverse is not true: not all valid [`u32`]s are valid
+    /// [`char`]s. `from_u32_unchecked()` will ignore this, and blindly cast to
+    /// [`char`], possibly creating an invalid one.
+    ///
+    /// [`char`]: ../../std/primitive.char.html
+    /// [`u32`]: ../../std/primitive.u32.html
+    ///
+    /// # Safety
+    ///
+    /// This function is unsafe, as it may construct invalid `char` values.
+    ///
+    /// For a safe version of this function, see the [`from_u32`] function.
+    ///
+    /// [`from_u32`]: fn.from_u32.html
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// use std::char;
+    ///
+    /// let c = unsafe { char::from_u32_unchecked(0x2764) };
+    ///
+    /// assert_eq!('❤', c);
+    /// ```
+    #[unstable(feature = "assoc_char_funcs", reason = "recently added", issue = "71763")]
+    #[inline]
+    pub unsafe fn from_u32_unchecked(i: u32) -> char {
+        super::convert::from_u32_unchecked(i)
+    }
+
+    /// Converts a digit in the given radix to a `char`.
+    ///
+    /// A 'radix' here is sometimes also called a 'base'. A radix of two
+    /// indicates a binary number, a radix of ten, decimal, and a radix of
+    /// sixteen, hexadecimal, to give some common values. Arbitrary
+    /// radices are supported.
+    ///
+    /// `from_digit()` will return `None` if the input is not a digit in
+    /// the given radix.
+    ///
+    /// # Panics
+    ///
+    /// Panics if given a radix larger than 36.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// use std::char;
+    ///
+    /// let c = char::from_digit(4, 10);
+    ///
+    /// assert_eq!(Some('4'), c);
+    ///
+    /// // Decimal 11 is a single digit in base 16
+    /// let c = char::from_digit(11, 16);
+    ///
+    /// assert_eq!(Some('b'), c);
+    /// ```
+    ///
+    /// Returning `None` when the input is not a digit:
+    ///
+    /// ```
+    /// use std::char;
+    ///
+    /// let c = char::from_digit(20, 10);
+    ///
+    /// assert_eq!(None, c);
+    /// ```
+    ///
+    /// Passing a large radix, causing a panic:
+    ///
+    /// ```
+    /// use std::thread;
+    /// use std::char;
+    ///
+    /// let result = thread::spawn(|| {
+    ///     // this panics
+    ///     let c = char::from_digit(1, 37);
+    /// }).join();
+    ///
+    /// assert!(result.is_err());
+    /// ```
+    #[unstable(feature = "assoc_char_funcs", reason = "recently added", issue = "71763")]
+    #[inline]
+    pub fn from_digit(num: u32, radix: u32) -> Option<char> {
+        super::convert::from_digit(num, radix)
+    }
+
     /// Checks if a `char` is a digit in the given radix.
     ///
     /// A 'radix' here is sometimes also called a 'base'. A radix of two

--- a/src/libcore/char/methods.rs
+++ b/src/libcore/char/methods.rs
@@ -11,11 +11,10 @@ use super::*;
 impl char {
     /// The highest valid code point a `char` can have.
     ///
-    /// A [`char`] is a [Unicode Scalar Value], which means that it is a [Code
+    /// A `char` is a [Unicode Scalar Value], which means that it is a [Code
     /// Point], but only ones within a certain range. `MAX` is the highest valid
     /// code point that's a valid [Unicode Scalar Value].
     ///
-    /// [`char`]: ../../std/primitive.char.html
     /// [Unicode Scalar Value]: http://www.unicode.org/glossary/#unicode_scalar_value
     /// [Code Point]: http://www.unicode.org/glossary/#code_point
     #[unstable(feature = "assoc_char_consts", reason = "recently added", issue = "71763")]
@@ -25,7 +24,7 @@ impl char {
     /// decoding error.
     ///
     /// It can occur, for example, when giving ill-formed UTF-8 bytes to
-    /// [`String::from_utf8_lossy`](../../std/string/struct.String.html#method.from_utf8_lossy).
+    /// [`String::from_utf8_lossy`](string/struct.String.html#method.from_utf8_lossy).
     #[unstable(feature = "assoc_char_consts", reason = "recently added", issue = "71763")]
     pub const REPLACEMENT_CHARACTER: char = '\u{FFFD}';
 
@@ -96,7 +95,7 @@ impl char {
 
     /// Converts a `u32` to a `char`.
     ///
-    /// Note that all [`char`]s are valid [`u32`]s, and can be cast to one with
+    /// Note that all `char`s are valid [`u32`]s, and can be cast to one with
     /// `as`:
     ///
     /// ```
@@ -107,16 +106,15 @@ impl char {
     /// ```
     ///
     /// However, the reverse is not true: not all valid [`u32`]s are valid
-    /// [`char`]s. `from_u32()` will return `None` if the input is not a valid value
-    /// for a [`char`].
+    /// `char`s. `from_u32()` will return `None` if the input is not a valid value
+    /// for a `char`.
     ///
-    /// [`char`]: ../../std/primitive.char.html
-    /// [`u32`]: ../../std/primitive.u32.html
+    /// [`u32`]: primitive.u32.html
     ///
     /// For an unsafe version of this function which ignores these checks, see
     /// [`from_u32_unchecked`].
     ///
-    /// [`from_u32_unchecked`]: fn.from_u32_unchecked.html
+    /// [`from_u32_unchecked`]: #method.from_u32_unchecked
     ///
     /// # Examples
     ///
@@ -130,7 +128,7 @@ impl char {
     /// assert_eq!(Some('❤'), c);
     /// ```
     ///
-    /// Returning `None` when the input is not a valid [`char`]:
+    /// Returning `None` when the input is not a valid `char`:
     ///
     /// ```
     /// use std::char;
@@ -147,7 +145,7 @@ impl char {
 
     /// Converts a `u32` to a `char`, ignoring validity.
     ///
-    /// Note that all [`char`]s are valid [`u32`]s, and can be cast to one with
+    /// Note that all `char`s are valid [`u32`]s, and can be cast to one with
     /// `as`:
     ///
     /// ```
@@ -158,11 +156,10 @@ impl char {
     /// ```
     ///
     /// However, the reverse is not true: not all valid [`u32`]s are valid
-    /// [`char`]s. `from_u32_unchecked()` will ignore this, and blindly cast to
-    /// [`char`], possibly creating an invalid one.
+    /// `char`s. `from_u32_unchecked()` will ignore this, and blindly cast to
+    /// `char`, possibly creating an invalid one.
     ///
-    /// [`char`]: ../../std/primitive.char.html
-    /// [`u32`]: ../../std/primitive.u32.html
+    /// [`u32`]: primitive.u32.html
     ///
     /// # Safety
     ///
@@ -170,7 +167,7 @@ impl char {
     ///
     /// For a safe version of this function, see the [`from_u32`] function.
     ///
-    /// [`from_u32`]: fn.from_u32.html
+    /// [`from_u32`]: #method.from_u32
     ///
     /// # Examples
     ///

--- a/src/libcore/char/mod.rs
+++ b/src/libcore/char/mod.rs
@@ -92,7 +92,7 @@ const MAX_THREE_B: u32 = 0x10000;
 /// [Unicode Scalar Value]: http://www.unicode.org/glossary/#unicode_scalar_value
 /// [Code Point]: http://www.unicode.org/glossary/#code_point
 #[stable(feature = "rust1", since = "1.0.0")]
-pub const MAX: char = '\u{10ffff}';
+pub const MAX: char = char::MAX;
 
 /// `U+FFFD REPLACEMENT CHARACTER` (�) is used in Unicode to represent a
 /// decoding error.
@@ -100,7 +100,7 @@ pub const MAX: char = '\u{10ffff}';
 /// It can occur, for example, when giving ill-formed UTF-8 bytes to
 /// [`String::from_utf8_lossy`](../../std/string/struct.String.html#method.from_utf8_lossy).
 #[stable(feature = "decode_utf16", since = "1.9.0")]
-pub const REPLACEMENT_CHARACTER: char = '\u{FFFD}';
+pub const REPLACEMENT_CHARACTER: char = char::REPLACEMENT_CHARACTER;
 
 /// Returns an iterator that yields the hexadecimal Unicode escape of a
 /// character, as `char`s.

--- a/src/librustc_codegen_llvm/lib.rs
+++ b/src/librustc_codegen_llvm/lib.rs
@@ -208,7 +208,7 @@ impl CodegenBackend for LlvmCodegenBackend {
             }
             PrintRequest::CodeModels => {
                 println!("Available code models:");
-                for name in &["small", "kernel", "medium", "large"] {
+                for name in &["tiny", "small", "kernel", "medium", "large"] {
                     println!("    {}", name);
                 }
                 println!();

--- a/src/librustc_codegen_ssa/back/link.rs
+++ b/src/librustc_codegen_ssa/back/link.rs
@@ -609,6 +609,55 @@ fn link_natively<'a, B: ArchiveBuilder<'a>>(
                 .note(&format!("{:?}", &cmd))
                 .note(&escape_string(&output))
                 .emit();
+
+                // If MSVC's `link.exe` was expected but the return code
+                // is not a Microsoft LNK error then suggest a way to fix or
+                // install the Visual Studio build tools.
+                if let Some(code) = prog.status.code() {
+                    if sess.target.target.options.is_like_msvc
+                        && flavor == LinkerFlavor::Msvc
+                        // Respect the command line override
+                        && sess.opts.cg.linker.is_none()
+                        // Match exactly "link.exe"
+                        && linker_path.to_str() == Some("link.exe")
+                        // All Microsoft `link.exe` linking error codes are
+                        // four digit numbers in the range 1000 to 9999 inclusive
+                        && (code < 1000 || code > 9999)
+                    {
+                        let is_vs_installed = windows_registry::find_vs_version().is_ok();
+                        let has_linker = windows_registry::find_tool(
+                            &sess.opts.target_triple.triple(),
+                            "link.exe",
+                        )
+                        .is_some();
+
+                        sess.note_without_error("`link.exe` returned an unexpected error");
+                        if is_vs_installed && has_linker {
+                            // the linker is broken
+                            sess.note_without_error(
+                                "the Visual Studio build tools may need to be repaired \
+                                using the Visual Studio installer",
+                            );
+                            sess.note_without_error(
+                                "or a necessary component may be missing from the \
+                                \"C++ build tools\" workload",
+                            );
+                        } else if is_vs_installed {
+                            // the linker is not installed
+                            sess.note_without_error(
+                                "in the Visual Studio installer, ensure the \
+                                \"C++ build tools\" workload is selected",
+                            );
+                        } else {
+                            // visual studio is not installed
+                            sess.note_without_error(
+                                "you may need to install Visual Studio build tools with the \
+                                \"C++ build tools\" workload",
+                            );
+                        }
+                    }
+                }
+
                 sess.abort_if_errors();
             }
             info!("linker stderr:\n{}", escape_string(&prog.stderr));

--- a/src/librustc_middle/ich/hcx.rs
+++ b/src/librustc_middle/ich/hcx.rs
@@ -136,11 +136,6 @@ impl<'a> StableHashingContext<'a> {
     }
 
     #[inline]
-    pub fn node_to_hir_id(&self, node_id: ast::NodeId) -> hir::HirId {
-        self.definitions.node_id_to_hir_id(node_id)
-    }
-
-    #[inline]
     pub fn hash_bodies(&self) -> bool {
         self.hash_bodies
     }

--- a/src/librustc_target/spec/mod.rs
+++ b/src/librustc_target/spec/mod.rs
@@ -322,7 +322,7 @@ impl FromStr for CodeModel {
 
     fn from_str(s: &str) -> Result<CodeModel, ()> {
         Ok(match s {
-            // "tiny" => CodeModel::Tiny, // Not exposed to users right now.
+            "tiny" => CodeModel::Tiny,
             "small" => CodeModel::Small,
             "kernel" => CodeModel::Kernel,
             "medium" => CodeModel::Medium,

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -2703,3 +2703,9 @@ function focusSearchBar() {
 function defocusSearchBar() {
     getSearchInput().blur();
 }
+
+// This is required in firefox. Explanations: when going back in the history, firefox doesn't re-run
+// the JS, therefore preventing rustdoc from setting a few things required to be able to reload the
+// previous search results (if you navigated to a search result with the keyboard, pressed enter on
+// it to navigate to that result, and then came back to this page).
+window.onunload = function(){};


### PR DESCRIPTION
Successful merges:

 - #71854 (Make `std::char` functions and constants associated to `char`.)
 - #72111 (rustc-book: Document `-Z strip=val` option)
 - #72272 (Fix going back in history to a search result page on firefox)
 - #72296 (Suggest installing VS Build Tools in more situations)
 - #72365 (Remove unused `StableHashingContext::node_to_hir_id` method)
 - #72371 (FIX - Char documentation for unexperienced users)
 - #72397 (llvm: Expose tiny code model to users)

Failed merges:


r? @ghost