### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -312,11 +312,11 @@
 
 # Whether or not debug assertions are enabled for the compiler and standard
 # library.
-#debug-assertions = false
+#debug-assertions = debug
 
 # Whether or not debug assertions are enabled for the standard library.
 # Overrides the `debug-assertions` option, if defined.
-#debug-assertions-std = false
+#debug-assertions-std = debug-assertions
 
 # Debuginfo level for most of Rust code, corresponds to the `-C debuginfo=N` option of `rustc`.
 # `0` - no debug info

--- a/src/libcore/slice/mod.rs
+++ b/src/libcore/slice/mod.rs
@@ -5740,7 +5740,8 @@ unsafe impl<'a, T> TrustedRandomAccess for RChunksExactMut<'a, T> {
 ///   and it must be properly aligned. This means in particular:
 ///
 ///     * The entire memory range of this slice must be contained within a single allocated object!
-///       Slices can never span across multiple allocated objects.
+///       Slices can never span across multiple allocated objects. See [below](#incorrect-usage)
+///       for an example incorrectly not taking this into account.
 ///     * `data` must be non-null and aligned even for zero-length slices. One
 ///       reason for this is that enum layout optimizations may rely on references
 ///       (including slices of any length) being aligned and non-null to distinguish
@@ -5771,6 +5772,34 @@ unsafe impl<'a, T> TrustedRandomAccess for RChunksExactMut<'a, T> {
 /// let ptr = &x as *const _;
 /// let slice = unsafe { slice::from_raw_parts(ptr, 1) };
 /// assert_eq!(slice[0], 42);
+/// ```
+///
+/// ### Incorrect usage
+///
+/// The following `join_slices` function is **unsound** ⚠️
+///
+/// ```rust,no_run
+/// use std::slice;
+///
+/// fn join_slices<'a, T>(fst: &'a [T], snd: &'a [T]) -> &'a [T] {
+///     let fst_end = fst.as_ptr().wrapping_add(fst.len());
+///     let snd_start = snd.as_ptr();
+///     assert_eq!(fst_end, snd_start, "Slices must be contiguous!");
+///     unsafe {
+///         // The assertion above ensures `fst` and `snd` are contiguous, but they might
+///         // still be contained within _different allocated objects_, in which case
+///         // creating this slice is undefined behavior.
+///         slice::from_raw_parts(fst.as_ptr(), fst.len() + snd.len())
+///     }
+/// }
+///
+/// fn main() {
+///     // `a` and `b` are different allocated objects...
+///     let a = 42;
+///     let b = 27;
+///     // ... which may nevertheless be laid out contiguous in memory: | a | b |
+///     let _ = join_slices(slice::from_ref(&a), slice::from_ref(&b)); // UB
+/// }
 /// ```
 ///
 /// [valid]: ../../std/ptr/index.html#safety

--- a/src/libcore/slice/mod.rs
+++ b/src/libcore/slice/mod.rs
@@ -5797,7 +5797,7 @@ unsafe impl<'a, T> TrustedRandomAccess for RChunksExactMut<'a, T> {
 ///     // `a` and `b` are different allocated objects...
 ///     let a = 42;
 ///     let b = 27;
-///     // ... which may nevertheless be laid out contiguous in memory: | a | b |
+///     // ... which may nevertheless be laid out contiguously in memory: | a | b |
 ///     let _ = join_slices(slice::from_ref(&a), slice::from_ref(&b)); // UB
 /// }
 /// ```

--- a/src/librustc_middle/ty/error.rs
+++ b/src/librustc_middle/ty/error.rs
@@ -817,19 +817,18 @@ fn foo(&self) -> Self::T { String::new() }
                 for item in &items[..] {
                     match item.kind {
                         hir::AssocItemKind::Type | hir::AssocItemKind::OpaqueTy => {
-                            if self.type_of(self.hir().local_def_id(item.id.hir_id)) == found {
-                                if let hir::Defaultness::Default { has_value: true } =
-                                    item.defaultness
-                                {
+                            // FIXME: account for returning some type in a trait fn impl that has
+                            // an assoc type as a return type (#72076).
+                            if let hir::Defaultness::Default { has_value: true } = item.defaultness
+                            {
+                                if self.type_of(self.hir().local_def_id(item.id.hir_id)) == found {
                                     db.span_label(
                                         item.span,
                                         "associated type defaults can't be assumed inside the \
                                             trait defining them",
                                     );
-                                } else {
-                                    db.span_label(item.span, "expected this associated type");
+                                    return true;
                                 }
-                                return true;
                             }
                         }
                         _ => {}

--- a/src/librustc_mir/interpret/intrinsics.rs
+++ b/src/librustc_mir/interpret/intrinsics.rs
@@ -219,7 +219,10 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 let place = self.deref_operand(args[0])?;
                 let discr_val = self.read_discriminant(place.into())?.0;
                 let scalar = match dest.layout.ty.kind {
-                    ty::Int(_) => Scalar::from_int(discr_val as i128, dest.layout.size),
+                    ty::Int(_) => Scalar::from_int(
+                        self.sign_extend(discr_val, dest.layout) as i128,
+                        dest.layout.size,
+                    ),
                     ty::Uint(_) => Scalar::from_uint(discr_val, dest.layout.size),
                     _ => bug!("invalid `discriminant_value` return layout: {:?}", dest.layout),
                 };

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -625,7 +625,7 @@ a {
 	display: initial;
 }
 
-.in-band:hover > .anchor {
+.in-band:hover > .anchor, .impl:hover > .anchor {
 	display: inline-block;
 	position: absolute;
 }

--- a/src/test/rustdoc/issue-72340.rs
+++ b/src/test/rustdoc/issue-72340.rs
@@ -1,0 +1,19 @@
+#![crate_name = "foo"]
+
+pub struct Body;
+
+impl Body {
+    pub fn empty() -> Self {
+        Body
+    }
+
+}
+
+impl Default for Body {
+    // @has foo/struct.Body.html '//a/@href' '../foo/struct.Body.html#method.empty'
+
+    /// Returns [`Body::empty()`](Body::empty).
+    fn default() -> Body {
+        Body::empty()
+    }
+}

--- a/src/test/ui/issues/issue-72076.rs
+++ b/src/test/ui/issues/issue-72076.rs
@@ -1,0 +1,6 @@
+trait X {
+    type S;
+    fn f() -> Self::S {} //~ ERROR mismatched types
+}
+
+fn main() {}

--- a/src/test/ui/issues/issue-72076.stderr
+++ b/src/test/ui/issues/issue-72076.stderr
@@ -1,0 +1,14 @@
+error[E0308]: mismatched types
+  --> $DIR/issue-72076.rs:3:23
+   |
+LL |     fn f() -> Self::S {}
+   |                       ^^ expected associated type, found `()`
+   |
+   = note: expected associated type `<Self as X>::S`
+                    found unit type `()`
+   = help: consider constraining the associated type `<Self as X>::S` to `()` or calling a method that returns `<Self as X>::S`
+   = note: for more information, visit https://doc.rust-lang.org/book/ch19-03-advanced-traits.html
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/suggestions/trait-with-missing-associated-type-restriction.rs
+++ b/src/test/ui/suggestions/trait-with-missing-associated-type-restriction.rs
@@ -7,6 +7,7 @@ trait Trait<T = Self> {
 
     fn func(&self) -> Self::A;
     fn funk(&self, _: Self::A);
+    fn funq(&self) -> Self::A {} //~ ERROR mismatched types
 }
 
 fn foo(_: impl Trait, x: impl Trait) {

--- a/src/test/ui/suggestions/trait-with-missing-associated-type-restriction.stderr
+++ b/src/test/ui/suggestions/trait-with-missing-associated-type-restriction.stderr
@@ -1,5 +1,19 @@
 error[E0308]: mismatched types
-  --> $DIR/trait-with-missing-associated-type-restriction.rs:13:9
+  --> $DIR/trait-with-missing-associated-type-restriction.rs:10:31
+   |
+LL |     fn funq(&self) -> Self::A {}
+   |                               ^^ expected associated type, found `()`
+   |
+   = note: expected associated type `<Self as Trait<T>>::A`
+                    found unit type `()`
+help: a method is available that returns `<Self as Trait<T>>::A`
+  --> $DIR/trait-with-missing-associated-type-restriction.rs:8:5
+   |
+LL |     fn func(&self) -> Self::A;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ consider calling `Trait::func`
+
+error[E0308]: mismatched types
+  --> $DIR/trait-with-missing-associated-type-restriction.rs:14:9
    |
 LL |     qux(x.func())
    |         ^^^^^^^^ expected `usize`, found associated type
@@ -12,7 +26,7 @@ LL | fn foo(_: impl Trait, x: impl Trait<A = usize>) {
    |                                    ^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/trait-with-missing-associated-type-restriction.rs:17:9
+  --> $DIR/trait-with-missing-associated-type-restriction.rs:18:9
    |
 LL |     qux(x.func())
    |         ^^^^^^^^ expected `usize`, found associated type
@@ -25,7 +39,7 @@ LL | fn bar<T: Trait<A = usize>>(x: T) {
    |                ^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/trait-with-missing-associated-type-restriction.rs:21:9
+  --> $DIR/trait-with-missing-associated-type-restriction.rs:22:9
    |
 LL |     qux(x.func())
    |         ^^^^^^^^ expected `usize`, found associated type
@@ -38,25 +52,28 @@ LL | fn foo2(x: impl Trait<i32, A = usize>) {
    |                          ^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/trait-with-missing-associated-type-restriction.rs:25:12
+  --> $DIR/trait-with-missing-associated-type-restriction.rs:26:12
    |
 LL |     x.funk(3);
    |            ^ expected associated type, found integer
    |
    = note: expected associated type `<T as Trait<i32>>::A`
                          found type `{integer}`
-help: a method is available that returns `<T as Trait<i32>>::A`
+help: some methods are available that return `<T as Trait<i32>>::A`
   --> $DIR/trait-with-missing-associated-type-restriction.rs:8:5
    |
 LL |     fn func(&self) -> Self::A;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ consider calling `Trait::func`
+LL |     fn funk(&self, _: Self::A);
+LL |     fn funq(&self) -> Self::A {}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ consider calling `Trait::funq`
 help: consider constraining the associated type `<T as Trait<i32>>::A` to `{integer}`
    |
 LL | fn bar2<T: Trait<i32, A = {integer}>>(x: T) {
    |                     ^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/trait-with-missing-associated-type-restriction.rs:26:9
+  --> $DIR/trait-with-missing-associated-type-restriction.rs:27:9
    |
 LL |     qux(x.func())
    |         ^^^^^^^^ expected `usize`, found associated type
@@ -69,7 +86,7 @@ LL | fn bar2<T: Trait<i32, A = usize>>(x: T) {
    |                     ^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/trait-with-missing-associated-type-restriction.rs:30:9
+  --> $DIR/trait-with-missing-associated-type-restriction.rs:31:9
    |
 LL | fn baz<D: std::fmt::Debug, T: Trait<A = D>>(x: T) {
    |        - this type parameter
@@ -80,13 +97,13 @@ LL |     qux(x.func())
            found type parameter `D`
 
 error[E0308]: mismatched types
-  --> $DIR/trait-with-missing-associated-type-restriction.rs:34:9
+  --> $DIR/trait-with-missing-associated-type-restriction.rs:35:9
    |
 LL |     qux(x.func())
    |         ^^^^^^^^ expected `usize`, found `()`
 
 error[E0308]: mismatched types
-  --> $DIR/trait-with-missing-associated-type-restriction.rs:38:9
+  --> $DIR/trait-with-missing-associated-type-restriction.rs:39:9
    |
 LL |     qux(x.func())
    |         ^^^^^^^^ expected `usize`, found associated type
@@ -98,6 +115,6 @@ help: consider constraining the associated type `<T as Trait>::A` to `usize`
 LL | fn ban<T>(x: T) where T: Trait<A = usize> {
    |                               ^^^^^^^^^^^
 
-error: aborting due to 8 previous errors
+error: aborting due to 9 previous errors
 
 For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Successful merges:

 - #72149 (Don't `type_of` on trait assoc ty without default)
 - #72347 (Make intra-link resolve links for both trait and impl items)
 - #72350 (Improve documentation of `slice::from_raw_parts`)
 - #72382 (Show default values for debug-assertions & debug-assertions-std)
 - #72421 (Fix anchor display when hovering impl)
 - #72425 (fix discriminant_value sign extension)

Failed merges:


r? @ghost