### PR TITLE
remove pointless rustc_const_stable attribute

### DIFF
--- a/src/libcore/time.rs
+++ b/src/libcore/time.rs
@@ -130,7 +130,6 @@ impl Duration {
     /// ```
     #[stable(feature = "duration", since = "1.3.0")]
     #[inline]
-    #[rustc_const_stable(feature = "duration_consts", since = "1.32.0")]
     pub fn new(secs: u64, nanos: u32) -> Duration {
         let secs =
             secs.checked_add((nanos / NANOS_PER_SEC) as u64).expect("overflow in Duration::new");


### PR DESCRIPTION
This was probably [added here](https://github.com/rust-lang/rust/commit/5e17e3988165d3245e38af0b1c40cde47699f6a7#diff-c16c61d2e12bfae3aea872c45795de13) by mistake.

r? @oli-obk 