### PR TITLE
Add `Duration::MAX` associated constant

### DIFF
--- a/src/libcore/time.rs
+++ b/src/libcore/time.rs
@@ -130,10 +130,12 @@ impl Duration {
     /// ```
     #[stable(feature = "duration", since = "1.3.0")]
     #[inline]
-    #[rustc_const_stable(feature = "duration_consts", since = "1.32.0")]
-    pub fn new(secs: u64, nanos: u32) -> Duration {
-        let secs =
-            secs.checked_add((nanos / NANOS_PER_SEC) as u64).expect("overflow in Duration::new");
+    #[rustc_const_unstable(feature = "const_checked_int_methods", issue = "53718")]
+    pub const fn new(secs: u64, nanos: u32) -> Duration {
+        let secs = match secs.checked_add((nanos / NANOS_PER_SEC) as u64) {
+            Some(secs) => secs,
+            None => panic!("overflow in Duration::new"),
+        };
         let nanos = nanos % NANOS_PER_SEC;
         Duration { secs, nanos }
     }

--- a/src/libcore/time.rs
+++ b/src/libcore/time.rs
@@ -110,6 +110,19 @@ impl Duration {
     #[unstable(feature = "duration_constants", issue = "57391")]
     pub const NANOSECOND: Duration = Duration::from_nanos(1);
 
+    /// The largest value a duration can hold.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(duration_constants)]
+    /// use std::time::Duration;
+    ///
+    /// assert_eq!(Duration::MAX, Duration::from_new(u64::MAX, 1_000_000_000-1));
+    /// ```
+    #[unstable(feature = "duration_constants", issue = "57391")]
+    pub const MAX: Duration = Duration::new(u64::MAX, NANOS_PER_SEC-1);
+
     /// Creates a new `Duration` from the specified number of whole seconds and
     /// additional nanoseconds.
     ///


### PR DESCRIPTION
(To merge after https://github.com/rust-lang/rust/pull/72434)

This change introduce `Duration::MAX` as associated constant on the same model as `u64::MAX` etc.

I re-used `const_checked_int_methods` feature gate to constify `Duration::new`, it might not be the best approach but i thought this PR would help start the discussion.

