### PR TITLE
Fix ICE with explicit late-bound lifetimes

### DIFF
--- a/src/librustc_typeck/check/method/confirm.rs
+++ b/src/librustc_typeck/check/method/confirm.rs
@@ -312,7 +312,7 @@ impl<'a, 'tcx> ConfirmContext<'a, 'tcx> {
             parent_substs,
             false,
             None,
-            arg_count_correct.is_ok(),
+            arg_count_correct,
             // Provide the generic args, and whether types should be inferred.
             |def_id| {
                 // The last component of the returned tuple here is unimportant.

--- a/src/test/ui/issues/issue-72278.rs
+++ b/src/test/ui/issues/issue-72278.rs
@@ -1,0 +1,19 @@
+// run-pass
+
+#![allow(unused)]
+
+struct S;
+
+impl S {
+    fn func<'a, U>(&'a self) -> U {
+        todo!()
+    }
+}
+
+fn dont_crash<'a, U>() -> U {
+    S.func::<'a, U>()
+    //~^ WARN cannot specify lifetime arguments explicitly
+    //~| WARN this was previously accepted
+}
+
+fn main() {}

--- a/src/test/ui/issues/issue-72278.stderr
+++ b/src/test/ui/issues/issue-72278.stderr
@@ -1,0 +1,15 @@
+warning: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
+  --> $DIR/issue-72278.rs:14:14
+   |
+LL |     fn func<'a, U>(&'a self) -> U {
+   |             -- the late bound lifetime parameter is introduced here
+...
+LL |     S.func::<'a, U>()
+   |              ^^
+   |
+   = note: `#[warn(late_bound_lifetime_arguments)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #42868 <https://github.com/rust-lang/rust/issues/42868>
+
+warning: 1 warning emitted
+


### PR DESCRIPTION
Rather than returning an explicit late-bound lifetime as a generic argument count mismatch (which is not necessarily true), this PR propagates the presence of explicit late-bound lifetimes.

This avoids an ICE that can occur due to the presence of explicit late-bound lifetimes when building generic substitutions by explicitly ignoring them.

r? @varkor

cc @davidtwco (this removes a check you introduced in #60892)

Resolves #72278