### PR TITLE
Impl Ord for proc_macro::LineColumn

### DIFF
--- a/src/libproc_macro/lib.rs
+++ b/src/libproc_macro/lib.rs
@@ -39,6 +39,7 @@ mod diagnostic;
 #[unstable(feature = "proc_macro_diagnostic", issue = "54140")]
 pub use diagnostic::{Diagnostic, Level, MultiSpan};
 
+use std::cmp::Ordering;
 use std::ops::{Bound, RangeBounds};
 use std::path::PathBuf;
 use std::str::FromStr;
@@ -419,6 +420,20 @@ pub struct LineColumn {
 impl !Send for LineColumn {}
 #[unstable(feature = "proc_macro_span", issue = "54725")]
 impl !Sync for LineColumn {}
+
+#[unstable(feature = "proc_macro_span", issue = "54725")]
+impl Ord for LineColumn {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.line.cmp(&other.line).then(self.column.cmp(&other.column))
+    }
+}
+
+#[unstable(feature = "proc_macro_span", issue = "54725")]
+impl PartialOrd for LineColumn {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
 
 /// The source file of a given `Span`.
 #[unstable(feature = "proc_macro_span", issue = "54725")]

--- a/src/libproc_macro/tests/test.rs
+++ b/src/libproc_macro/tests/test.rs
@@ -1,0 +1,12 @@
+#![feature(proc_macro_span)]
+
+use proc_macro::LineColumn;
+
+#[test]
+fn test_line_column_ord() {
+    let line0_column0 = LineColumn { line: 0, column: 0 };
+    let line0_column1 = LineColumn { line: 0, column: 1 };
+    let line1_column0 = LineColumn { line: 1, column: 0 };
+    assert!(line0_column0 < line0_column1);
+    assert!(line0_column1 < line1_column0);
+}


### PR DESCRIPTION
```rust
impl Ord for LineColumn {...}
impl PartialOrd for LineColumn {...}
```

for https://doc.rust-lang.org/nightly/proc_macro/struct.LineColumn.html.

The ordering is the natural one you would get by writing one line after another, where we compare line first, then compare columns within the same line.