### PR TITLE
Clarified the documentation for Formatter::precision

### DIFF
--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -1611,7 +1611,8 @@ impl<'a> Formatter<'a> {
         self.width
     }
 
-    /// Optionally specified precision for numeric types.
+    /// Optionally specified precision for numeric types. Alternatively, the
+    /// maximum width for string types.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
Added a note that `precision` is interpreted as max-width when formatting strings