### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/src/librustc_codegen_llvm/back/write.rs
+++ b/src/librustc_codegen_llvm/back/write.rs
@@ -6,7 +6,6 @@ use crate::back::profiling::{
 use crate::base;
 use crate::common;
 use crate::consts;
-use crate::context::all_outputs_are_pic_executables;
 use crate::llvm::{self, DiagnosticInfo, PassManager, SMDiagnostic};
 use crate::llvm_util;
 use crate::type_::Type;
@@ -150,7 +149,6 @@ pub fn target_machine_factory(
     let features = features.join(",");
     let features = CString::new(features).unwrap();
     let abi = SmallCStr::new(&sess.target.target.options.llvm_abiname);
-    let pic_is_pie = all_outputs_are_pic_executables(sess);
     let trap_unreachable = sess.target.target.options.trap_unreachable;
     let emit_stack_size_section = sess.opts.debugging_opts.emit_stack_sizes;
 
@@ -174,7 +172,6 @@ pub fn target_machine_factory(
                 reloc_model,
                 opt_level,
                 use_softfp,
-                pic_is_pie,
                 ffunction_sections,
                 fdata_sections,
                 trap_unreachable,

--- a/src/librustc_codegen_llvm/base.rs
+++ b/src/librustc_codegen_llvm/base.rs
@@ -100,7 +100,7 @@ pub fn compile_codegen_unit(
     tcx: TyCtxt<'tcx>,
     cgu_name: Symbol,
 ) -> (ModuleCodegen<ModuleLlvm>, u64) {
-    let prof_timer = tcx.prof.generic_activity("codegen_module");
+    let prof_timer = tcx.prof.generic_activity_with_arg("codegen_module", cgu_name.to_string());
     let start_time = Instant::now();
 
     let dep_node = tcx.codegen_unit(cgu_name).codegen_dep_node(tcx);

--- a/src/librustc_codegen_llvm/debuginfo/metadata.rs
+++ b/src/librustc_codegen_llvm/debuginfo/metadata.rs
@@ -447,7 +447,6 @@ fn subroutine_type_metadata(
         unsafe {
             llvm::LLVMRustDIBuilderCreateSubroutineType(
                 DIB(cx),
-                unknown_file_metadata(cx),
                 create_DIArray(DIB(cx), &signature_metadata[..]),
             )
         },
@@ -635,14 +634,12 @@ pub fn type_metadata(cx: &CodegenCx<'ll, 'tcx>, t: Ty<'tcx>, usage_site_span: Sp
                     // anything reading the debuginfo for a recursive
                     // type is going to see *something* weird - the only
                     // question is what exactly it will see.
-                    let (size, align) = cx.size_and_align_of(t);
                     let name = "<recur_type>";
                     llvm::LLVMRustDIBuilderCreateBasicType(
                         DIB(cx),
                         name.as_ptr().cast(),
                         name.len(),
-                        size.bits(),
-                        align.bits() as u32,
+                        cx.size_of(t).bits(),
                         DW_ATE_unsigned,
                     )
                 }
@@ -841,14 +838,12 @@ fn basic_type_metadata(cx: &CodegenCx<'ll, 'tcx>, t: Ty<'tcx>) -> &'ll DIType {
         _ => bug!("debuginfo::basic_type_metadata - `t` is invalid type"),
     };
 
-    let (size, align) = cx.size_and_align_of(t);
     let ty_metadata = unsafe {
         llvm::LLVMRustDIBuilderCreateBasicType(
             DIB(cx),
             name.as_ptr().cast(),
             name.len(),
-            size.bits(),
-            align.bits() as u32,
+            cx.size_of(t).bits(),
             encoding,
         )
     };
@@ -2187,9 +2182,6 @@ fn compute_type_parameters(cx: &CodegenCx<'ll, 'tcx>, ty: Ty<'tcx>) -> Option<&'
                                 name.as_ptr().cast(),
                                 name.len(),
                                 actual_type_metadata,
-                                unknown_file_metadata(cx),
-                                0,
-                                0,
                             ))
                         })
                     } else {

--- a/src/librustc_codegen_llvm/debuginfo/mod.rs
+++ b/src/librustc_codegen_llvm/debuginfo/mod.rs
@@ -252,7 +252,7 @@ impl DebugInfoMethods<'tcx> for CodegenCx<'ll, 'tcx> {
 
         let function_type_metadata = unsafe {
             let fn_signature = get_function_signature(self, fn_abi);
-            llvm::LLVMRustDIBuilderCreateSubroutineType(DIB(self), file_metadata, fn_signature)
+            llvm::LLVMRustDIBuilderCreateSubroutineType(DIB(self), fn_signature)
         };
 
         // Find the enclosing function, in case this is a closure.
@@ -265,8 +265,7 @@ impl DebugInfoMethods<'tcx> for CodegenCx<'ll, 'tcx> {
         // name if necessary.
         let generics = self.tcx().generics_of(enclosing_fn_def_id);
         let substs = instance.substs.truncate_to(self.tcx(), generics);
-        let template_parameters =
-            get_template_parameters(self, &generics, substs, file_metadata, &mut name);
+        let template_parameters = get_template_parameters(self, &generics, substs, &mut name);
 
         // Get the linkage_name, which is just the symbol name
         let linkage_name = mangled_name_of_instance(self, instance);
@@ -388,7 +387,6 @@ impl DebugInfoMethods<'tcx> for CodegenCx<'ll, 'tcx> {
             cx: &CodegenCx<'ll, 'tcx>,
             generics: &ty::Generics,
             substs: SubstsRef<'tcx>,
-            file_metadata: &'ll DIFile,
             name_to_append_suffix_to: &mut String,
         ) -> &'ll DIArray {
             if substs.types().next().is_none() {
@@ -429,9 +427,6 @@ impl DebugInfoMethods<'tcx> for CodegenCx<'ll, 'tcx> {
                                     name.as_ptr().cast(),
                                     name.len(),
                                     actual_type_metadata,
-                                    file_metadata,
-                                    0,
-                                    0,
                                 ))
                             })
                         } else {

--- a/src/librustc_codegen_llvm/llvm/ffi.rs
+++ b/src/librustc_codegen_llvm/llvm/ffi.rs
@@ -1655,7 +1655,6 @@ extern "C" {
 
     pub fn LLVMRustDIBuilderCreateSubroutineType(
         Builder: &DIBuilder<'a>,
-        File: &'a DIFile,
         ParameterTypes: &'a DIArray,
     ) -> &'a DICompositeType;
 
@@ -1682,7 +1681,6 @@ extern "C" {
         Name: *const c_char,
         NameLen: size_t,
         SizeInBits: u64,
-        AlignInBits: u32,
         Encoding: c_uint,
     ) -> &'a DIBasicType;
 
@@ -1880,9 +1878,6 @@ extern "C" {
         Name: *const c_char,
         NameLen: size_t,
         Ty: &'a DIType,
-        File: &'a DIFile,
-        LineNo: c_uint,
-        ColumnNo: c_uint,
     ) -> &'a DITemplateTypeParameter;
 
     pub fn LLVMRustDIBuilderCreateNameSpace(
@@ -1948,7 +1943,6 @@ extern "C" {
         Reloc: RelocModel,
         Level: CodeGenOptLevel,
         UseSoftFP: bool,
-        PositionIndependentExecutable: bool,
         FunctionSections: bool,
         DataSections: bool,
         TrapUnreachable: bool,

--- a/src/librustc_error_codes/error_codes/E0590.md
+++ b/src/librustc_error_codes/error_codes/E0590.md
@@ -1,13 +1,17 @@
-`break` or `continue` must include a label when used in the condition of a
-`while` loop.
+`break` or `continue` keywords were used in a condition of a `while` loop
+without a label.
 
-Example of erroneous code:
+Erroneous code code:
 
 ```compile_fail,E0590
 while break {}
 ```
 
+`break` or `continue` must include a label when used in the condition of a
+`while` loop.
+
 To fix this, add a label specifying which loop is being broken out of:
+
 ```
 'foo: while break 'foo {}
 ```

--- a/src/librustc_error_codes/error_codes/E0593.md
+++ b/src/librustc_error_codes/error_codes/E0593.md
@@ -11,3 +11,14 @@ fn main() {
     foo(|y| { });
 }
 ```
+
+You have to provide the same number of arguments as expected by the `Fn`-based
+type. So to fix the previous example, we need to remove the `y` argument:
+
+```
+fn foo<F: Fn()>(x: F) { }
+
+fn main() {
+    foo(|| { }); // ok!
+}
+```

--- a/src/librustc_trait_selection/traits/error_reporting/suggestions.rs
+++ b/src/librustc_trait_selection/traits/error_reporting/suggestions.rs
@@ -570,33 +570,30 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                     // original type obligation, not the last one that failed, which is arbitrary.
                     // Because of this, we modify the error to refer to the original obligation and
                     // return early in the caller.
-                    
 
                     let has_colon = self
-                            .tcx
-                            .sess
-                            .source_map()
-                            .span_to_snippet(span)
-                            .map(|w| w.contains(":"))
-                            .unwrap_or(false);
+                        .tcx
+                        .sess
+                        .source_map()
+                        .span_to_snippet(span)
+                        .map(|w| w.contains(":"))
+                        .unwrap_or(false);
 
                     let has_double_colon = self
-                            .tcx
-                            .sess
-                            .source_map()
-                            .span_to_snippet(span)
-                            .map(|w| w.contains("::"))
-                            .unwrap_or(false);
+                        .tcx
+                        .sess
+                        .source_map()
+                        .span_to_snippet(span)
+                        .map(|w| w.contains("::"))
+                        .unwrap_or(false);
 
                     let has_bracket = self
-                            .tcx
-                            .sess
-                            .source_map()
-                            .span_to_snippet(span)
-                            .map(|w| w.contains("{"))
-                            .unwrap_or(false);
-
-                   
+                        .tcx
+                        .sess
+                        .source_map()
+                        .span_to_snippet(span)
+                        .map(|w| w.contains("{"))
+                        .unwrap_or(false);
 
                     let msg = format!(
                         "the trait bound `{}: {}` is not satisfied",
@@ -620,7 +617,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                             obligation.parent_trait_ref.skip_binder().print_only_trait_path(),
                         ),
                     );
-                
+
                     // This if is to prevent a special edge-case
                     if !has_colon || has_double_colon || has_bracket {
                         // We don't want a borrowing suggestion on the fields in structs,

--- a/src/librustc_trait_selection/traits/error_reporting/suggestions.rs
+++ b/src/librustc_trait_selection/traits/error_reporting/suggestions.rs
@@ -571,30 +571,6 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                     // Because of this, we modify the error to refer to the original obligation and
                     // return early in the caller.
 
-                    let has_colon = self
-                        .tcx
-                        .sess
-                        .source_map()
-                        .span_to_snippet(span)
-                        .map(|w| w.contains(":"))
-                        .unwrap_or(false);
-
-                    let has_double_colon = self
-                        .tcx
-                        .sess
-                        .source_map()
-                        .span_to_snippet(span)
-                        .map(|w| w.contains("::"))
-                        .unwrap_or(false);
-
-                    let has_bracket = self
-                        .tcx
-                        .sess
-                        .source_map()
-                        .span_to_snippet(span)
-                        .map(|w| w.contains("{"))
-                        .unwrap_or(false);
-
                     let msg = format!(
                         "the trait bound `{}: {}` is not satisfied",
                         found,
@@ -619,7 +595,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                     );
 
                     // This if is to prevent a special edge-case
-                    if !has_colon || has_double_colon || has_bracket {
+                    if !span.from_expansion() {
                         // We don't want a borrowing suggestion on the fields in structs,
                         // ```
                         // struct Foo {

--- a/src/librustc_trait_selection/traits/error_reporting/suggestions.rs
+++ b/src/librustc_trait_selection/traits/error_reporting/suggestions.rs
@@ -562,6 +562,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                 param_env,
                 new_trait_ref.without_const().to_predicate(),
             );
+
             if self.predicate_must_hold_modulo_regions(&new_obligation) {
                 if let Ok(snippet) = self.tcx.sess.source_map().span_to_snippet(span) {
                     // We have a very specific type of error, where just borrowing this argument
@@ -569,6 +570,34 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                     // original type obligation, not the last one that failed, which is arbitrary.
                     // Because of this, we modify the error to refer to the original obligation and
                     // return early in the caller.
+                    
+
+                    let has_colon = self
+                            .tcx
+                            .sess
+                            .source_map()
+                            .span_to_snippet(span)
+                            .map(|w| w.contains(":"))
+                            .unwrap_or(false);
+
+                    let has_double_colon = self
+                            .tcx
+                            .sess
+                            .source_map()
+                            .span_to_snippet(span)
+                            .map(|w| w.contains("::"))
+                            .unwrap_or(false);
+
+                    let has_bracket = self
+                            .tcx
+                            .sess
+                            .source_map()
+                            .span_to_snippet(span)
+                            .map(|w| w.contains("{"))
+                            .unwrap_or(false);
+
+                   
+
                     let msg = format!(
                         "the trait bound `{}: {}` is not satisfied",
                         found,
@@ -591,12 +620,23 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                             obligation.parent_trait_ref.skip_binder().print_only_trait_path(),
                         ),
                     );
-                    err.span_suggestion(
-                        span,
-                        "consider borrowing here",
-                        format!("&{}", snippet),
-                        Applicability::MaybeIncorrect,
-                    );
+                
+                    // This if is to prevent a special edge-case
+                    if !has_colon || has_double_colon || has_bracket {
+                        // We don't want a borrowing suggestion on the fields in structs,
+                        // ```
+                        // struct Foo {
+                        //  the_foos: Vec<Foo>
+                        // }
+                        // ```
+
+                        err.span_suggestion(
+                            span,
+                            "consider borrowing here",
+                            format!("&{}", snippet),
+                            Applicability::MaybeIncorrect,
+                        );
+                    }
                     return true;
                 }
             }

--- a/src/libstd/sys/unix/ext/process.rs
+++ b/src/libstd/sys/unix/ext/process.rs
@@ -111,7 +111,7 @@ pub trait CommandExt {
     ///
     /// Set the first process argument, `argv[0]`, to something other than the
     /// default executable path.
-    #[unstable(feature = "process_set_argv0", issue = "66510")]
+    #[stable(feature = "process_set_argv0", since = "1.45.0")]
     fn arg0<S>(&mut self, arg: S) -> &mut process::Command
     where
         S: AsRef<OsStr>;

--- a/src/libstd/sys/vxworks/ext/process.rs
+++ b/src/libstd/sys/vxworks/ext/process.rs
@@ -111,7 +111,7 @@ pub trait CommandExt {
     ///
     /// Set the first process argument, `argv[0]`, to something other than the
     /// default executable path.
-    #[unstable(feature = "process_set_argv0", issue = "66510")]
+    #[stable(feature = "process_set_argv0", since = "1.45.0")]
     fn arg0<S>(&mut self, arg: S) -> &mut process::Command
     where
         S: AsRef<OsStr>;

--- a/src/rustllvm/PassWrapper.cpp
+++ b/src/rustllvm/PassWrapper.cpp
@@ -445,7 +445,7 @@ extern "C" LLVMTargetMachineRef LLVMRustCreateTargetMachine(
     const char *TripleStr, const char *CPU, const char *Feature,
     const char *ABIStr, LLVMRustCodeModel RustCM, LLVMRustRelocModel RustReloc,
     LLVMRustCodeGenOptLevel RustOptLevel, bool UseSoftFloat,
-    bool PositionIndependentExecutable, bool FunctionSections,
+    bool FunctionSections,
     bool DataSections,
     bool TrapUnreachable,
     bool Singlethread,

--- a/src/rustllvm/RustWrapper.cpp
+++ b/src/rustllvm/RustWrapper.cpp
@@ -720,7 +720,6 @@ extern "C" LLVMMetadataRef LLVMRustDIBuilderCreateFile(
 
 extern "C" LLVMMetadataRef
 LLVMRustDIBuilderCreateSubroutineType(LLVMRustDIBuilderRef Builder,
-                                      LLVMMetadataRef File,
                                       LLVMMetadataRef ParameterTypes) {
   return wrap(Builder->createSubroutineType(
       DITypeRefArray(unwrap<MDTuple>(ParameterTypes))));
@@ -755,7 +754,7 @@ extern "C" LLVMMetadataRef LLVMRustDIBuilderCreateFunction(
 
 extern "C" LLVMMetadataRef LLVMRustDIBuilderCreateBasicType(
     LLVMRustDIBuilderRef Builder, const char *Name, size_t NameLen,
-    uint64_t SizeInBits, uint32_t AlignInBits, unsigned Encoding) {
+    uint64_t SizeInBits, unsigned Encoding) {
   return wrap(Builder->createBasicType(StringRef(Name, NameLen), SizeInBits, Encoding));
 }
 
@@ -964,9 +963,7 @@ extern "C" LLVMMetadataRef LLVMRustDIBuilderCreateUnionType(
 
 extern "C" LLVMMetadataRef LLVMRustDIBuilderCreateTemplateTypeParameter(
     LLVMRustDIBuilderRef Builder, LLVMMetadataRef Scope,
-    const char *Name, size_t NameLen,
-    LLVMMetadataRef Ty, LLVMMetadataRef File, unsigned LineNo,
-    unsigned ColumnNo) {
+    const char *Name, size_t NameLen, LLVMMetadataRef Ty) {
   return wrap(Builder->createTemplateTypeParameter(
       unwrapDI<DIDescriptor>(Scope), StringRef(Name, NameLen), unwrapDI<DIType>(Ty)));
 }

--- a/src/test/ui/command/command-argv0-debug.rs
+++ b/src/test/ui/command/command-argv0-debug.rs
@@ -4,8 +4,6 @@
 // ignore-cloudabi no processes
 // ignore-emscripten no processes
 // ignore-sgx no processes
-#![feature(process_set_argv0)]
-
 use std::os::unix::process::CommandExt;
 use std::process::Command;
 

--- a/src/test/ui/command/command-argv0.rs
+++ b/src/test/ui/command/command-argv0.rs
@@ -4,8 +4,6 @@
 // ignore-cloudabi no processes
 // ignore-emscripten no processes
 // ignore-sgx no processes
-#![feature(process_set_argv0)]
-
 use std::env;
 use std::os::unix::process::CommandExt;
 use std::process::Command;

--- a/src/test/ui/traits/traits-issue-71136.rs
+++ b/src/test/ui/traits/traits-issue-71136.rs
@@ -1,0 +1,8 @@
+struct Foo(u8);
+
+#[derive(Clone)]
+struct FooHolster {
+    the_foos: Vec<Foo>, //~ERROR Clone
+}
+
+fn main() {}

--- a/src/test/ui/traits/traits-issue-71136.stderr
+++ b/src/test/ui/traits/traits-issue-71136.stderr
@@ -1,0 +1,13 @@
+error[E0277]: the trait bound `Foo: std::clone::Clone` is not satisfied
+  --> $DIR/traits-issue-71136.rs:5:5
+   |
+LL |     the_foos: Vec<Foo>,
+   |     ^^^^^^^^^^^^^^^^^^ expected an implementor of trait `std::clone::Clone`
+   |
+   = note: required because of the requirements on the impl of `std::clone::Clone` for `std::vec::Vec<Foo>`
+   = note: required by `std::clone::Clone::clone`
+   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Successful merges:

 - #71829 (Fix suggestion to borrow in struct)
 - #72123 (Stabilize process_set_argv0 feature for Unix)
 - #72235 (Clean up E0590 explanation)
 - #72345 (Clean up E0593 explanation)
 - #72376 ([self-profling] Record the cgu name when doing codegen for a module)
 - #72399 (Add fast-path optimization for Ipv4Addr::fmt)
 - #72435 (rustllvm: Fix warnings about unused function parameters)

Failed merges:


r? @ghost