### PR TITLE
Stabilize str_strip feature

### DIFF
--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -4052,15 +4052,13 @@ impl str {
     /// # Examples
     ///
     /// ```
-    /// #![feature(str_strip)]
-    ///
     /// assert_eq!("foo:bar".strip_prefix("foo:"), Some("bar"));
     /// assert_eq!("foo:bar".strip_prefix("bar"), None);
     /// assert_eq!("foofoo".strip_prefix("foo"), Some("foo"));
     /// ```
     #[must_use = "this returns the remaining substring as a new slice, \
                   without modifying the original"]
-    #[unstable(feature = "str_strip", reason = "newly added", issue = "67302")]
+    #[stable(feature = "str_strip", since = "1.45.0")]
     pub fn strip_prefix<'a, P: Pattern<'a>>(&'a self, prefix: P) -> Option<&'a str> {
         prefix.strip_prefix_of(self)
     }
@@ -4082,14 +4080,13 @@ impl str {
     /// # Examples
     ///
     /// ```
-    /// #![feature(str_strip)]
     /// assert_eq!("bar:foo".strip_suffix(":foo"), Some("bar"));
     /// assert_eq!("bar:foo".strip_suffix("bar"), None);
     /// assert_eq!("foofoo".strip_suffix("foo"), Some("foo"));
     /// ```
     #[must_use = "this returns the remaining substring as a new slice, \
                   without modifying the original"]
-    #[unstable(feature = "str_strip", reason = "newly added", issue = "67302")]
+    #[stable(feature = "str_strip", since = "1.45.0")]
     pub fn strip_suffix<'a, P>(&'a self, suffix: P) -> Option<&'a str>
     where
         P: Pattern<'a>,

--- a/src/librustc_trait_selection/lib.rs
+++ b/src/librustc_trait_selection/lib.rs
@@ -16,7 +16,6 @@
 #![feature(in_band_lifetimes)]
 #![feature(crate_visibility_modifier)]
 #![feature(or_patterns)]
-#![feature(str_strip)]
 #![feature(option_zip)]
 #![recursion_limit = "512"] // For rustdoc
 

--- a/src/tools/clippy/src/driver.rs
+++ b/src/tools/clippy/src/driver.rs
@@ -1,6 +1,5 @@
 #![cfg_attr(feature = "deny-warnings", deny(warnings))]
 #![feature(rustc_private)]
-#![feature(str_strip)]
 
 // FIXME: switch to something more ergonomic here, once available.
 // (Currently there is no way to opt into sysroot crates without `extern crate`.)


### PR DESCRIPTION
This PR stabilizes these APIs:

```rust
impl str {
    /// Returns a string slice with the prefix removed.
    ///
    /// If the string starts with the pattern `prefix`, `Some` is returned with the substring where
    /// the prefix is removed. Unlike `trim_start_matches`, this method removes the prefix exactly
    /// once.
    pub fn strip_prefix<'a, P: Pattern<'a>>(&'a self, prefix: P) -> Option<&'a str>;

    /// Returns a string slice with the suffix removed.
    ///
    /// If the string ends with the pattern `suffix`, `Some` is returned with the substring where
    /// the suffix is removed. Unlike `trim_end_matches`, this method removes the suffix exactly
    /// once.
    pub fn strip_suffix<'a, P>(&'a self, suffix: P) -> Option<&'a str>
    where
        P: Pattern<'a>,
        <P as Pattern<'a>>::Searcher: ReverseSearcher<'a>;
}
```

Closes  #67302