### PR TITLE
Revert MSYS2 CI workaround

### DIFF
--- a/src/ci/scripts/install-msys2-packages.sh
+++ b/src/ci/scripts/install-msys2-packages.sh
@@ -6,17 +6,6 @@ IFS=$'\n\t'
 source "$(cd "$(dirname "$0")" && pwd)/../shared.sh"
 
 if isWindows; then
-    # FIXME(mati865): temporary workaround until chocolatey updates their MSYS2
-    base_url='https://ci-mirrors.rust-lang.org/rustc/msys2-repo/msys/x86_64'
-    curl ${base_url}/libzstd-1.4.4-2-x86_64.pkg.tar.xz -o libzstd-1.4.4-2-x86_64.pkg.tar.xz
-    curl ${base_url}/pacman-5.2.1-6-x86_64.pkg.tar.xz -o pacman-5.2.1-6-x86_64.pkg.tar.xz
-    curl ${base_url}/zstd-1.4.4-2-x86_64.pkg.tar.xz -o zstd-1.4.4-2-x86_64.pkg.tar.xz
-    pacman -U --noconfirm libzstd-1.4.4-2-x86_64.pkg.tar.xz pacman-5.2.1-6-x86_64.pkg.tar.xz \
-        zstd-1.4.4-2-x86_64.pkg.tar.xz
-    rm libzstd-1.4.4-2-x86_64.pkg.tar.xz pacman-5.2.1-6-x86_64.pkg.tar.xz \
-        zstd-1.4.4-2-x86_64.pkg.tar.xz
-    pacman -Sy
-
     pacman -S --noconfirm --needed base-devel ca-certificates make diffutils tar \
         binutils
 

--- a/src/ci/scripts/install-msys2.sh
+++ b/src/ci/scripts/install-msys2.sh
@@ -17,9 +17,8 @@ if isWindows; then
         msys2.nupkg
     curl -sSL https://packages.chocolatey.org/chocolatey-core.extension.1.3.5.1.nupkg > \
         chocolatey-core.extension.nupkg
-    # FIXME(mati865): remove `/NoUpdate` once chocolatey updates MSYS2
     choco install -s . msys2 \
-        --params="/InstallDir:$(ciCheckoutPath)/msys2 /NoPath /NoUpdate" -y --no-progress
+        --params="/InstallDir:$(ciCheckoutPath)/msys2 /NoPath" -y --no-progress
     rm msys2.nupkg chocolatey-core.extension.nupkg
     mkdir -p "$(ciCheckoutPath)/msys2/home/${USERNAME}"
     ciCommandAddPath "$(ciCheckoutPath)/msys2/usr/bin"


### PR DESCRIPTION
MSYS2 has made workaround for critical packages so older installers like one used by chocolatey can work again. 
Fixes https://github.com/rust-lang/rust/issues/72333