### PR TITLE
doc: Alias skip_while with drop_while

### DIFF
--- a/src/libcore/iter/traits/iterator.rs
+++ b/src/libcore/iter/traits/iterator.rs
@@ -942,6 +942,8 @@ pub trait Iterator {
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[doc(alias = "drop_while")]
+    #[doc(alias = "dropwhile")]
     fn skip_while<P>(self, predicate: P) -> SkipWhile<Self, P>
     where
         Self: Sized,

--- a/src/libcore/iter/traits/iterator.rs
+++ b/src/libcore/iter/traits/iterator.rs
@@ -889,6 +889,8 @@ pub trait Iterator {
     ///
     /// [`skip`]: #method.skip
     ///
+    /// *Note: Some languages call this method: "drop_while" or "dropwhile".*
+    ///
     /// `skip_while()` takes a closure as an argument. It will call this
     /// closure on each element of the iterator, and ignore elements
     /// until it returns `false`.
@@ -942,8 +944,6 @@ pub trait Iterator {
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[doc(alias = "drop_while")]
-    #[doc(alias = "dropwhile")]
     fn skip_while<P>(self, predicate: P) -> SkipWhile<Self, P>
     where
         Self: Sized,


### PR DESCRIPTION
Many other programming languages use `dropwhile` instead of `skip_while` like Rust.

For example:

Language 	| Name
---------	| ------
Python 		| [dropwhile](https://docs.python.org/3/library/itertools.html#itertools.dropwhile)
Ruby 		| [drop_while](https://ruby-doc.org/core-2.7.1/Enumerable.html#method-i-drop_while)
Haskell 	| [dropWhile](https://hackage.haskell.org/package/base-4.14.0.0/docs/Prelude.html#v:takeWhile)
Java?		| [dropWhile](https://docs.oracle.com/javase/9/docs/api/java/util/stream/Stream.html#dropWhile-java.util.function.Predicate-)

