### PR TITLE
Pass more `Copy` types by value.

### DIFF
--- a/src/librustc_codegen_ssa/debuginfo/type_names.rs
+++ b/src/librustc_codegen_ssa/debuginfo/type_names.rs
@@ -48,7 +48,7 @@ pub fn push_debuginfo_type_name<'tcx>(
         }
         ty::Tuple(component_types) => {
             output.push('(');
-            for &component_type in component_types {
+            for component_type in component_types {
                 push_debuginfo_type_name(tcx, component_type.expect_ty(), true, output, visited);
                 output.push_str(", ");
             }

--- a/src/librustc_codegen_ssa/mir/analyze.rs
+++ b/src/librustc_codegen_ssa/mir/analyze.rs
@@ -104,7 +104,7 @@ impl<Bx: BuilderMethods<'a, 'tcx>> LocalAnalyzer<'mir, 'a, 'tcx, Bx> {
     ) {
         let cx = self.fx.cx;
 
-        if let [proj_base @ .., elem] = place_ref.projection {
+        if let &[ref proj_base @ .., elem] = place_ref.projection {
             let mut base_context = if context.is_mutating_use() {
                 PlaceContext::MutatingUse(MutatingUseContext::Projection)
             } else {
@@ -186,7 +186,7 @@ impl<Bx: BuilderMethods<'a, 'tcx>> LocalAnalyzer<'mir, 'a, 'tcx, Bx> {
             // now that we have moved to the "slice of projections" representation.
             if let mir::ProjectionElem::Index(local) = elem {
                 self.visit_local(
-                    local,
+                    &local,
                     PlaceContext::NonMutatingUse(NonMutatingUseContext::Copy),
                     location,
                 );

--- a/src/librustc_infer/infer/canonical/mod.rs
+++ b/src/librustc_infer/infer/canonical/mod.rs
@@ -87,7 +87,7 @@ impl<'cx, 'tcx> InferCtxt<'cx, 'tcx> {
     ) -> CanonicalVarValues<'tcx> {
         let var_values: IndexVec<BoundVar, GenericArg<'tcx>> = variables
             .iter()
-            .map(|info| self.instantiate_canonical_var(span, *info, &universe_map))
+            .map(|info| self.instantiate_canonical_var(span, info, &universe_map))
             .collect();
 
         CanonicalVarValues { var_values }

--- a/src/librustc_infer/infer/canonical/query_response.rs
+++ b/src/librustc_infer/infer/canonical/query_response.rs
@@ -464,12 +464,12 @@ impl<'cx, 'tcx> InferCtxt<'cx, 'tcx> {
                     if info.is_existential() {
                         match opt_values[BoundVar::new(index)] {
                             Some(k) => k,
-                            None => self.instantiate_canonical_var(cause.span, *info, |u| {
+                            None => self.instantiate_canonical_var(cause.span, info, |u| {
                                 universe_map[u.as_usize()]
                             }),
                         }
                     } else {
-                        self.instantiate_canonical_var(cause.span, *info, |u| {
+                        self.instantiate_canonical_var(cause.span, info, |u| {
                             universe_map[u.as_usize()]
                         })
                     }

--- a/src/librustc_infer/infer/mod.rs
+++ b/src/librustc_infer/infer/mod.rs
@@ -1011,7 +1011,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
         &self,
         cause: &ObligationCause<'tcx>,
         param_env: ty::ParamEnv<'tcx>,
-        predicate: &ty::PolySubtypePredicate<'tcx>,
+        predicate: ty::PolySubtypePredicate<'tcx>,
     ) -> Option<InferResult<'tcx, ()>> {
         // Subtle: it's ok to skip the binder here and resolve because
         // `shallow_resolve` just ignores anything that is not a type
@@ -1034,7 +1034,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
 
         Some(self.commit_if_ok(|snapshot| {
             let (ty::SubtypePredicate { a_is_expected, a, b }, placeholder_map) =
-                self.replace_bound_vars_with_placeholders(predicate);
+                self.replace_bound_vars_with_placeholders(&predicate);
 
             let ok = self.at(cause, param_env).sub_exp(a_is_expected, a, b)?;
 
@@ -1047,11 +1047,11 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
     pub fn region_outlives_predicate(
         &self,
         cause: &traits::ObligationCause<'tcx>,
-        predicate: &ty::PolyRegionOutlivesPredicate<'tcx>,
+        predicate: ty::PolyRegionOutlivesPredicate<'tcx>,
     ) -> UnitResult<'tcx> {
         self.commit_if_ok(|snapshot| {
             let (ty::OutlivesPredicate(r_a, r_b), placeholder_map) =
-                self.replace_bound_vars_with_placeholders(predicate);
+                self.replace_bound_vars_with_placeholders(&predicate);
             let origin = SubregionOrigin::from_obligation_cause(cause, || {
                 RelateRegionParamBound(cause.span)
             });

--- a/src/librustc_infer/infer/outlives/verify.rs
+++ b/src/librustc_infer/infer/outlives/verify.rs
@@ -223,7 +223,8 @@ impl<'cx, 'tcx> VerifyBoundCx<'cx, 'tcx> {
         // like `T` and `T::Item`. It may not work as well for things
         // like `<T as Foo<'a>>::Item`.
         let c_b = self.param_env.caller_bounds;
-        let param_bounds = self.collect_outlives_from_predicate_list(&compare_ty, c_b.into_iter());
+        let param_bounds =
+            self.collect_outlives_from_predicate_list(&compare_ty, c_b.into_iter().copied());
 
         // Next, collect regions we scraped from the well-formedness
         // constraints in the fn signature. To do that, we walk the list
@@ -334,10 +335,10 @@ impl<'cx, 'tcx> VerifyBoundCx<'cx, 'tcx> {
     fn collect_outlives_from_predicate_list(
         &self,
         compare_ty: impl Fn(Ty<'tcx>) -> bool,
-        predicates: impl Iterator<Item = impl AsRef<ty::Predicate<'tcx>>>,
+        predicates: impl Iterator<Item = ty::Predicate<'tcx>>,
     ) -> impl Iterator<Item = ty::OutlivesPredicate<Ty<'tcx>, ty::Region<'tcx>>> {
         predicates
-            .filter_map(|p| p.as_ref().to_opt_type_outlives())
+            .filter_map(|p| p.to_opt_type_outlives())
             .filter_map(|p| p.no_bound_vars())
             .filter(move |p| compare_ty(p.0))
     }

--- a/src/librustc_infer/infer/outlives/verify.rs
+++ b/src/librustc_infer/infer/outlives/verify.rs
@@ -50,7 +50,7 @@ impl<'cx, 'tcx> VerifyBoundCx<'cx, 'tcx> {
                 // for further background and discussion.
                 let mut bounds = substs
                     .iter()
-                    .filter_map(|&child| match child.unpack() {
+                    .filter_map(|child| match child.unpack() {
                         GenericArgKind::Type(ty) => Some(self.type_bound(ty)),
                         GenericArgKind::Lifetime(_) => None,
                         GenericArgKind::Const(_) => Some(self.recursive_bound(child)),
@@ -223,8 +223,7 @@ impl<'cx, 'tcx> VerifyBoundCx<'cx, 'tcx> {
         // like `T` and `T::Item`. It may not work as well for things
         // like `<T as Foo<'a>>::Item`.
         let c_b = self.param_env.caller_bounds;
-        let param_bounds =
-            self.collect_outlives_from_predicate_list(&compare_ty, c_b.into_iter().copied());
+        let param_bounds = self.collect_outlives_from_predicate_list(&compare_ty, c_b.into_iter());
 
         // Next, collect regions we scraped from the well-formedness
         // constraints in the fn signature. To do that, we walk the list

--- a/src/librustc_infer/traits/util.rs
+++ b/src/librustc_infer/traits/util.rs
@@ -8,7 +8,7 @@ use rustc_span::Span;
 
 pub fn anonymize_predicate<'tcx>(
     tcx: TyCtxt<'tcx>,
-    pred: &ty::Predicate<'tcx>,
+    pred: ty::Predicate<'tcx>,
 ) -> ty::Predicate<'tcx> {
     match pred.kind() {
         &ty::PredicateKind::Trait(ref data, constness) => {
@@ -66,7 +66,7 @@ impl PredicateSet<'tcx> {
         Self { tcx, set: Default::default() }
     }
 
-    fn insert(&mut self, pred: &ty::Predicate<'tcx>) -> bool {
+    fn insert(&mut self, pred: ty::Predicate<'tcx>) -> bool {
         // We have to be careful here because we want
         //
         //    for<'a> Foo<&'a int>
@@ -81,10 +81,10 @@ impl PredicateSet<'tcx> {
     }
 }
 
-impl<T: AsRef<ty::Predicate<'tcx>>> Extend<T> for PredicateSet<'tcx> {
-    fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
+impl Extend<ty::Predicate<'tcx>> for PredicateSet<'tcx> {
+    fn extend<I: IntoIterator<Item = ty::Predicate<'tcx>>>(&mut self, iter: I) {
         for pred in iter {
-            self.insert(pred.as_ref());
+            self.insert(pred);
         }
     }
 }
@@ -132,7 +132,7 @@ pub fn elaborate_obligations<'tcx>(
     mut obligations: Vec<PredicateObligation<'tcx>>,
 ) -> Elaborator<'tcx> {
     let mut visited = PredicateSet::new(tcx);
-    obligations.retain(|obligation| visited.insert(&obligation.predicate));
+    obligations.retain(|obligation| visited.insert(obligation.predicate));
     Elaborator { stack: obligations, visited }
 }
 
@@ -172,7 +172,7 @@ impl Elaborator<'tcx> {
                 // cases. One common case is when people define
                 // `trait Sized: Sized { }` rather than `trait Sized { }`.
                 let visited = &mut self.visited;
-                let obligations = obligations.filter(|o| visited.insert(&o.predicate));
+                let obligations = obligations.filter(|o| visited.insert(o.predicate));
 
                 self.stack.extend(obligations);
             }
@@ -260,7 +260,7 @@ impl Elaborator<'tcx> {
                             }
                         })
                         .map(|predicate_kind| predicate_kind.to_predicate(tcx))
-                        .filter(|predicate| visited.insert(predicate))
+                        .filter(|&predicate| visited.insert(predicate))
                         .map(|predicate| predicate_obligation(predicate, None)),
                 );
             }

--- a/src/librustc_infer/traits/util.rs
+++ b/src/librustc_infer/traits/util.rs
@@ -10,50 +10,44 @@ pub fn anonymize_predicate<'tcx>(
     tcx: TyCtxt<'tcx>,
     pred: ty::Predicate<'tcx>,
 ) -> ty::Predicate<'tcx> {
-    match pred.kind() {
+    let kind = pred.kind();
+    let new = match kind {
         &ty::PredicateKind::Trait(ref data, constness) => {
             ty::PredicateKind::Trait(tcx.anonymize_late_bound_regions(data), constness)
-                .to_predicate(tcx)
         }
 
         ty::PredicateKind::RegionOutlives(data) => {
             ty::PredicateKind::RegionOutlives(tcx.anonymize_late_bound_regions(data))
-                .to_predicate(tcx)
         }
 
         ty::PredicateKind::TypeOutlives(data) => {
             ty::PredicateKind::TypeOutlives(tcx.anonymize_late_bound_regions(data))
-                .to_predicate(tcx)
         }
 
         ty::PredicateKind::Projection(data) => {
-            ty::PredicateKind::Projection(tcx.anonymize_late_bound_regions(data)).to_predicate(tcx)
+            ty::PredicateKind::Projection(tcx.anonymize_late_bound_regions(data))
         }
 
-        &ty::PredicateKind::WellFormed(data) => {
-            ty::PredicateKind::WellFormed(data).to_predicate(tcx)
-        }
+        &ty::PredicateKind::WellFormed(data) => ty::PredicateKind::WellFormed(data),
 
-        &ty::PredicateKind::ObjectSafe(data) => {
-            ty::PredicateKind::ObjectSafe(data).to_predicate(tcx)
-        }
+        &ty::PredicateKind::ObjectSafe(data) => ty::PredicateKind::ObjectSafe(data),
 
         &ty::PredicateKind::ClosureKind(closure_def_id, closure_substs, kind) => {
-            ty::PredicateKind::ClosureKind(closure_def_id, closure_substs, kind).to_predicate(tcx)
+            ty::PredicateKind::ClosureKind(closure_def_id, closure_substs, kind)
         }
 
         ty::PredicateKind::Subtype(data) => {
-            ty::PredicateKind::Subtype(tcx.anonymize_late_bound_regions(data)).to_predicate(tcx)
+            ty::PredicateKind::Subtype(tcx.anonymize_late_bound_regions(data))
         }
 
         &ty::PredicateKind::ConstEvaluatable(def_id, substs) => {
-            ty::PredicateKind::ConstEvaluatable(def_id, substs).to_predicate(tcx)
+            ty::PredicateKind::ConstEvaluatable(def_id, substs)
         }
 
-        ty::PredicateKind::ConstEquate(c1, c2) => {
-            ty::PredicateKind::ConstEquate(c1, c2).to_predicate(tcx)
-        }
-    }
+        ty::PredicateKind::ConstEquate(c1, c2) => ty::PredicateKind::ConstEquate(c1, c2),
+    };
+
+    if new != *kind { new.to_predicate(tcx) } else { pred }
 }
 
 struct PredicateSet<'tcx> {

--- a/src/librustc_middle/mir/mod.rs
+++ b/src/librustc_middle/mir/mod.rs
@@ -2077,10 +2077,10 @@ impl Debug for Place<'_> {
                 ProjectionElem::ConstantIndex { offset, min_length, from_end: true } => {
                     write!(fmt, "[-{:?} of {:?}]", offset, min_length)?;
                 }
-                ProjectionElem::Subslice { from, to, from_end: true } if *to == 0 => {
+                ProjectionElem::Subslice { from, to, from_end: true } if to == 0 => {
                     write!(fmt, "[{:?}:]", from)?;
                 }
-                ProjectionElem::Subslice { from, to, from_end: true } if *from == 0 => {
+                ProjectionElem::Subslice { from, to, from_end: true } if from == 0 => {
                     write!(fmt, "[:-{:?}]", to)?;
                 }
                 ProjectionElem::Subslice { from, to, from_end: true } => {

--- a/src/librustc_middle/mir/tcx.rs
+++ b/src/librustc_middle/mir/tcx.rs
@@ -56,8 +56,8 @@ impl<'tcx> PlaceTy<'tcx> {
     /// Convenience wrapper around `projection_ty_core` for
     /// `PlaceElem`, where we can just use the `Ty` that is already
     /// stored inline on field projection elems.
-    pub fn projection_ty(self, tcx: TyCtxt<'tcx>, elem: &PlaceElem<'tcx>) -> PlaceTy<'tcx> {
-        self.projection_ty_core(tcx, ty::ParamEnv::empty(), elem, |_, _, ty| ty)
+    pub fn projection_ty(self, tcx: TyCtxt<'tcx>, elem: PlaceElem<'tcx>) -> PlaceTy<'tcx> {
+        self.projection_ty_core(tcx, ty::ParamEnv::empty(), &elem, |_, _, ty| ty)
     }
 
     /// `place_ty.projection_ty_core(tcx, elem, |...| { ... })`
@@ -124,7 +124,7 @@ impl<'tcx> Place<'tcx> {
     {
         projection
             .iter()
-            .fold(PlaceTy::from_ty(local_decls.local_decls()[local].ty), |place_ty, elem| {
+            .fold(PlaceTy::from_ty(local_decls.local_decls()[local].ty), |place_ty, &elem| {
                 place_ty.projection_ty(tcx, elem)
             })
     }

--- a/src/librustc_middle/mir/visit.rs
+++ b/src/librustc_middle/mir/visit.rs
@@ -903,7 +903,7 @@ macro_rules! visit_place_fns {
             let mut projection = Cow::Borrowed(projection);
 
             for i in 0..projection.len() {
-                if let Some(elem) = projection.get(i) {
+                if let Some(&elem) = projection.get(i) {
                     if let Some(elem) = self.process_projection_elem(elem, location) {
                         // This converts the borrowed projection into `Cow::Owned(_)` and returns a
                         // clone of the projection so we can mutate and reintern later.
@@ -921,19 +921,19 @@ macro_rules! visit_place_fns {
 
         fn process_projection_elem(
             &mut self,
-            elem: &PlaceElem<'tcx>,
+            elem: PlaceElem<'tcx>,
             location: Location,
         ) -> Option<PlaceElem<'tcx>> {
             match elem {
                 PlaceElem::Index(local) => {
-                    let mut new_local = *local;
+                    let mut new_local = local;
                     self.visit_local(
                         &mut new_local,
                         PlaceContext::NonMutatingUse(NonMutatingUseContext::Copy),
                         location,
                     );
 
-                    if new_local == *local { None } else { Some(PlaceElem::Index(new_local)) }
+                    if new_local == local { None } else { Some(PlaceElem::Index(new_local)) }
                 }
                 PlaceElem::Deref
                 | PlaceElem::Field(..)
@@ -959,7 +959,7 @@ macro_rules! visit_place_fns {
             &mut self,
             local: Local,
             proj_base: &[PlaceElem<'tcx>],
-            elem: &PlaceElem<'tcx>,
+            elem: PlaceElem<'tcx>,
             context: PlaceContext,
             location: Location,
         ) {
@@ -990,7 +990,7 @@ macro_rules! visit_place_fns {
             location: Location,
         ) {
             let mut cursor = projection;
-            while let [proj_base @ .., elem] = cursor {
+            while let &[ref proj_base @ .., elem] = cursor {
                 cursor = proj_base;
                 self.visit_projection_elem(local, cursor, elem, context, location);
             }
@@ -1000,7 +1000,7 @@ macro_rules! visit_place_fns {
             &mut self,
             _local: Local,
             _proj_base: &[PlaceElem<'tcx>],
-            elem: &PlaceElem<'tcx>,
+            elem: PlaceElem<'tcx>,
             _context: PlaceContext,
             location: Location,
         ) {
@@ -1010,7 +1010,7 @@ macro_rules! visit_place_fns {
                 }
                 ProjectionElem::Index(local) => {
                     self.visit_local(
-                        local,
+                        &local,
                         PlaceContext::NonMutatingUse(NonMutatingUseContext::Copy),
                         location,
                     );

--- a/src/librustc_middle/ty/flags.rs
+++ b/src/librustc_middle/ty/flags.rs
@@ -129,7 +129,7 @@ impl FlagComputation {
             &ty::Dynamic(ref obj, r) => {
                 let mut computation = FlagComputation::new();
                 for predicate in obj.skip_binder().iter() {
-                    match *predicate {
+                    match predicate {
                         ty::ExistentialPredicate::Trait(tr) => computation.add_substs(tr.substs),
                         ty::ExistentialPredicate::Projection(p) => {
                             let mut proj_computation = FlagComputation::new();

--- a/src/librustc_middle/ty/mod.rs
+++ b/src/librustc_middle/ty/mod.rs
@@ -1094,12 +1094,6 @@ pub struct CratePredicatesMap<'tcx> {
     pub predicates: FxHashMap<DefId, &'tcx [(ty::Predicate<'tcx>, Span)]>,
 }
 
-impl<'tcx> AsRef<Predicate<'tcx>> for Predicate<'tcx> {
-    fn as_ref(&self) -> &Predicate<'tcx> {
-        self
-    }
-}
-
 impl<'tcx> Predicate<'tcx> {
     /// Performs a substitution suitable for going from a
     /// poly-trait-ref to supertraits that must hold if that
@@ -1214,17 +1208,17 @@ pub struct TraitPredicate<'tcx> {
 pub type PolyTraitPredicate<'tcx> = ty::Binder<TraitPredicate<'tcx>>;
 
 impl<'tcx> TraitPredicate<'tcx> {
-    pub fn def_id(&self) -> DefId {
+    pub fn def_id(self) -> DefId {
         self.trait_ref.def_id
     }
 
-    pub fn self_ty(&self) -> Ty<'tcx> {
+    pub fn self_ty(self) -> Ty<'tcx> {
         self.trait_ref.self_ty()
     }
 }
 
 impl<'tcx> PolyTraitPredicate<'tcx> {
-    pub fn def_id(&self) -> DefId {
+    pub fn def_id(self) -> DefId {
         // Ok to skip binder since trait `DefId` does not care about regions.
         self.skip_binder().def_id()
     }

--- a/src/librustc_middle/ty/mod.rs
+++ b/src/librustc_middle/ty/mod.rs
@@ -1032,6 +1032,7 @@ impl<'tcx> PartialEq for Predicate<'tcx> {
 impl<'tcx> Eq for Predicate<'tcx> {}
 
 impl<'tcx> Predicate<'tcx> {
+    #[inline(always)]
     pub fn kind(self) -> &'tcx PredicateKind<'tcx> {
         self.kind
     }
@@ -1166,7 +1167,8 @@ impl<'tcx> Predicate<'tcx> {
         // this trick achieves that).
 
         let substs = &trait_ref.skip_binder().substs;
-        let predicate = match self.kind() {
+        let kind = self.kind();
+        let new = match kind {
             &PredicateKind::Trait(ref binder, constness) => {
                 PredicateKind::Trait(binder.map_bound(|data| data.subst(tcx, substs)), constness)
             }
@@ -1195,7 +1197,7 @@ impl<'tcx> Predicate<'tcx> {
             }
         };
 
-        predicate.to_predicate(tcx)
+        if new != *kind { new.to_predicate(tcx) } else { self }
     }
 }
 
@@ -1314,6 +1316,7 @@ pub trait ToPredicate<'tcx> {
 }
 
 impl ToPredicate<'tcx> for PredicateKind<'tcx> {
+    #[inline(always)]
     fn to_predicate(&self, tcx: TyCtxt<'tcx>) -> Predicate<'tcx> {
         tcx.mk_predicate(*self)
     }

--- a/src/librustc_middle/ty/outlives.rs
+++ b/src/librustc_middle/ty/outlives.rs
@@ -70,7 +70,7 @@ fn compute_components(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>, out: &mut SmallVec<[Compo
                 // consistent with previous (accidental) behavior.
                 // See https://github.com/rust-lang/rust/issues/70917
                 // for further background and discussion.
-                for &child in substs {
+                for child in substs {
                     match child.unpack() {
                         GenericArgKind::Type(ty) => {
                             compute_components(tcx, ty, out);

--- a/src/librustc_middle/ty/print/obsolete.rs
+++ b/src/librustc_middle/ty/print/obsolete.rs
@@ -47,7 +47,7 @@ impl DefPathBasedNames<'tcx> {
             }
             ty::Tuple(component_types) => {
                 output.push('(');
-                for &component_type in component_types {
+                for component_type in component_types {
                     self.push_type_name(component_type.expect_ty(), output, debug);
                     output.push_str(", ");
                 }

--- a/src/librustc_middle/ty/print/pretty.rs
+++ b/src/librustc_middle/ty/print/pretty.rs
@@ -495,7 +495,7 @@ pub trait PrettyPrinter<'tcx>:
             }
             ty::Never => p!(write("!")),
             ty::Tuple(ref tys) => {
-                p!(write("("), comma_sep(tys.iter().copied()));
+                p!(write("("), comma_sep(tys.iter()));
                 if tys.len() == 1 {
                     p!(write(","));
                 }
@@ -560,7 +560,7 @@ pub trait PrettyPrinter<'tcx>:
                         // FIXME(eddyb) print this with `print_def_path`.
                         if !substs.is_empty() {
                             p!(write("::"));
-                            p!(generic_delimiters(|cx| cx.comma_sep(substs.iter().copied())));
+                            p!(generic_delimiters(|cx| cx.comma_sep(substs.iter())));
                         }
                         return Ok(self);
                     }
@@ -1935,7 +1935,7 @@ define_print_and_forward_display! {
     (self, cx):
 
     &'tcx ty::List<Ty<'tcx>> {
-        p!(write("{{"), comma_sep(self.iter().copied()), write("}}"))
+        p!(write("{{"), comma_sep(self.iter()), write("}}"))
     }
 
     ty::TypeAndMut<'tcx> {

--- a/src/librustc_middle/ty/relate.rs
+++ b/src/librustc_middle/ty/relate.rs
@@ -143,7 +143,7 @@ pub fn relate_substs<R: TypeRelation<'tcx>>(
 
     let params = a_subst.iter().zip(b_subst).enumerate().map(|(i, (a, b))| {
         let variance = variances.map_or(ty::Invariant, |v| v[i]);
-        relation.relate_with_variance(variance, a, b)
+        relation.relate_with_variance(variance, &a, &b)
     });
 
     Ok(tcx.mk_substs(params)?)
@@ -319,7 +319,7 @@ impl<'tcx> Relate<'tcx> for GeneratorWitness<'tcx> {
     ) -> RelateResult<'tcx, GeneratorWitness<'tcx>> {
         assert_eq!(a.0.len(), b.0.len());
         let tcx = relation.tcx();
-        let types = tcx.mk_type_list(a.0.iter().zip(b.0).map(|(a, b)| relation.relate(a, b)))?;
+        let types = tcx.mk_type_list(a.0.iter().zip(b.0).map(|(a, b)| relation.relate(&a, &b)))?;
         Ok(GeneratorWitness(types))
     }
 }
@@ -633,7 +633,7 @@ impl<'tcx> Relate<'tcx> for &'tcx ty::List<ty::ExistentialPredicate<'tcx>> {
         let tcx = relation.tcx();
         let v = a.iter().zip(b.iter()).map(|(ep_a, ep_b)| {
             use crate::ty::ExistentialPredicate::*;
-            match (*ep_a, *ep_b) {
+            match (ep_a, ep_b) {
                 (Trait(ref a), Trait(ref b)) => Ok(Trait(relation.relate(a, b)?)),
                 (Projection(ref a), Projection(ref b)) => Ok(Projection(relation.relate(a, b)?)),
                 (AutoTrait(ref a), AutoTrait(ref b)) if a == b => Ok(AutoTrait(*a)),

--- a/src/librustc_middle/ty/structural_impls.rs
+++ b/src/librustc_middle/ty/structural_impls.rs
@@ -1093,7 +1093,7 @@ where
     // Look for the first element that changed
     if let Some((i, new_t)) = iter.by_ref().enumerate().find_map(|(i, t)| {
         let new_t = t.fold_with(folder);
-        if new_t == *t { None } else { Some((i, new_t)) }
+        if new_t == t { None } else { Some((i, new_t)) }
     }) {
         // An element changed, prepare to intern the resulting list
         let mut new_list = SmallVec::<[_; 8]>::with_capacity(list.len());

--- a/src/librustc_middle/ty/sty.rs
+++ b/src/librustc_middle/ty/sty.rs
@@ -670,7 +670,7 @@ impl<'tcx> List<ExistentialPredicate<'tcx>> {
     pub fn projection_bounds<'a>(
         &'a self,
     ) -> impl Iterator<Item = ExistentialProjection<'tcx>> + 'a {
-        self.iter().filter_map(|predicate| match *predicate {
+        self.iter().filter_map(|predicate| match predicate {
             ExistentialPredicate::Projection(projection) => Some(projection),
             _ => None,
         })
@@ -678,7 +678,7 @@ impl<'tcx> List<ExistentialPredicate<'tcx>> {
 
     #[inline]
     pub fn auto_traits<'a>(&'a self) -> impl Iterator<Item = DefId> + 'a {
-        self.iter().filter_map(|predicate| match *predicate {
+        self.iter().filter_map(|predicate| match predicate {
             ExistentialPredicate::AutoTrait(did) => Some(did),
             _ => None,
         })
@@ -709,7 +709,7 @@ impl<'tcx> Binder<&'tcx List<ExistentialPredicate<'tcx>>> {
     pub fn iter<'a>(
         &'a self,
     ) -> impl DoubleEndedIterator<Item = Binder<ExistentialPredicate<'tcx>>> + 'tcx {
-        self.skip_binder().iter().cloned().map(Binder::bind)
+        self.skip_binder().iter().map(Binder::bind)
     }
 }
 

--- a/src/librustc_middle/ty/subst.rs
+++ b/src/librustc_middle/ty/subst.rs
@@ -340,11 +340,11 @@ impl<'a, 'tcx> InternalSubsts<'tcx> {
         target_substs: SubstsRef<'tcx>,
     ) -> SubstsRef<'tcx> {
         let defs = tcx.generics_of(source_ancestor);
-        tcx.mk_substs(target_substs.iter().chain(&self[defs.params.len()..]).cloned())
+        tcx.mk_substs(target_substs.iter().chain(self.iter().skip(defs.params.len())))
     }
 
     pub fn truncate_to(&self, tcx: TyCtxt<'tcx>, generics: &ty::Generics) -> SubstsRef<'tcx> {
-        tcx.mk_substs(self.iter().take(generics.count()).cloned())
+        tcx.mk_substs(self.iter().take(generics.count()))
     }
 }
 

--- a/src/librustc_middle/ty/util.rs
+++ b/src/librustc_middle/ty/util.rs
@@ -413,7 +413,7 @@ impl<'tcx> TyCtxt<'tcx> {
         let result = item_substs
             .iter()
             .zip(impl_substs.iter())
-            .filter(|&(_, &k)| {
+            .filter(|&(_, k)| {
                 match k.unpack() {
                     GenericArgKind::Lifetime(&ty::RegionKind::ReEarlyBound(ref ebr)) => {
                         !impl_generics.region_param(ebr, self).pure_wrt_drop
@@ -433,7 +433,7 @@ impl<'tcx> TyCtxt<'tcx> {
                     }
                 }
             })
-            .map(|(&item_param, _)| item_param)
+            .map(|(item_param, _)| item_param)
             .collect();
         debug!("destructor_constraint({:?}) = {:?}", def.did, result);
         result

--- a/src/librustc_middle/ty/walk.rs
+++ b/src/librustc_middle/ty/walk.rs
@@ -128,7 +128,7 @@ fn push_inner<'tcx>(stack: &mut TypeWalkerStack<'tcx>, parent: GenericArg<'tcx>)
                 stack.push(lt.into());
             }
             ty::Projection(data) => {
-                stack.extend(data.substs.iter().copied().rev());
+                stack.extend(data.substs.iter().rev());
             }
             ty::Dynamic(obj, lt) => {
                 stack.push(lt.into());
@@ -143,7 +143,7 @@ fn push_inner<'tcx>(stack: &mut TypeWalkerStack<'tcx>, parent: GenericArg<'tcx>)
                         }
                     };
 
-                    substs.iter().copied().rev().chain(opt_ty.map(|ty| ty.into()))
+                    substs.iter().rev().chain(opt_ty.map(|ty| ty.into()))
                 }));
             }
             ty::Adt(_, substs)
@@ -152,14 +152,14 @@ fn push_inner<'tcx>(stack: &mut TypeWalkerStack<'tcx>, parent: GenericArg<'tcx>)
             | ty::Generator(_, substs, _)
             | ty::Tuple(substs)
             | ty::FnDef(_, substs) => {
-                stack.extend(substs.iter().copied().rev());
+                stack.extend(substs.iter().rev());
             }
             ty::GeneratorWitness(ts) => {
-                stack.extend(ts.skip_binder().iter().cloned().rev().map(|ty| ty.into()));
+                stack.extend(ts.skip_binder().iter().rev().map(|ty| ty.into()));
             }
             ty::FnPtr(sig) => {
                 stack.push(sig.skip_binder().output().into());
-                stack.extend(sig.skip_binder().inputs().iter().cloned().rev().map(|ty| ty.into()));
+                stack.extend(sig.skip_binder().inputs().iter().copied().rev().map(|ty| ty.into()));
             }
         },
         GenericArgKind::Lifetime(_) => {}
@@ -174,7 +174,7 @@ fn push_inner<'tcx>(stack: &mut TypeWalkerStack<'tcx>, parent: GenericArg<'tcx>)
                 | ty::ConstKind::Error => {}
 
                 ty::ConstKind::Unevaluated(_, substs, _) => {
-                    stack.extend(substs.iter().copied().rev());
+                    stack.extend(substs.iter().rev());
                 }
             }
         }

--- a/src/librustc_mir/borrow_check/place_ext.rs
+++ b/src/librustc_mir/borrow_check/place_ext.rs
@@ -47,7 +47,7 @@ impl<'tcx> PlaceExt<'tcx> for Place<'tcx> {
         for (i, elem) in self.projection.iter().enumerate() {
             let proj_base = &self.projection[..i];
 
-            if *elem == ProjectionElem::Deref {
+            if elem == ProjectionElem::Deref {
                 let ty = Place::ty_from(self.local, proj_base, body, tcx).ty;
                 match ty.kind {
                     ty::Ref(_, _, hir::Mutability::Not) if i == 0 => {

--- a/src/librustc_mir/borrow_check/places_conflict.rs
+++ b/src/librustc_mir/borrow_check/places_conflict.rs
@@ -138,7 +138,7 @@ fn place_components_conflict<'tcx>(
     }
 
     // loop invariant: borrow_c is always either equal to access_c or disjoint from it.
-    for (i, (borrow_c, access_c)) in
+    for (i, (borrow_c, &access_c)) in
         borrow_place.projection.iter().zip(access_place.projection.iter()).enumerate()
     {
         debug!("borrow_conflicts_with_place: borrow_c = {:?}", borrow_c);
@@ -163,8 +163,8 @@ fn place_components_conflict<'tcx>(
             body,
             borrow_local,
             borrow_proj_base,
-            &borrow_c,
-            &access_c,
+            borrow_c,
+            access_c,
             bias,
         ) {
             Overlap::Arbitrary => {
@@ -313,8 +313,8 @@ fn place_projection_conflict<'tcx>(
     body: &Body<'tcx>,
     pi1_local: Local,
     pi1_proj_base: &[PlaceElem<'tcx>],
-    pi1_elem: &PlaceElem<'tcx>,
-    pi2_elem: &PlaceElem<'tcx>,
+    pi1_elem: PlaceElem<'tcx>,
+    pi2_elem: PlaceElem<'tcx>,
     bias: PlaceConflictBias,
 ) -> Overlap {
     match (pi1_elem, pi2_elem) {
@@ -420,24 +420,24 @@ fn place_projection_conflict<'tcx>(
             }
         }
         (
-            &ProjectionElem::ConstantIndex {
+            ProjectionElem::ConstantIndex {
                 offset: offset_from_begin,
                 min_length: min_length1,
                 from_end: false,
             },
-            &ProjectionElem::ConstantIndex {
+            ProjectionElem::ConstantIndex {
                 offset: offset_from_end,
                 min_length: min_length2,
                 from_end: true,
             },
         )
         | (
-            &ProjectionElem::ConstantIndex {
+            ProjectionElem::ConstantIndex {
                 offset: offset_from_end,
                 min_length: min_length1,
                 from_end: true,
             },
-            &ProjectionElem::ConstantIndex {
+            ProjectionElem::ConstantIndex {
                 offset: offset_from_begin,
                 min_length: min_length2,
                 from_end: false,

--- a/src/librustc_mir/borrow_check/places_conflict.rs
+++ b/src/librustc_mir/borrow_check/places_conflict.rs
@@ -163,8 +163,8 @@ fn place_components_conflict<'tcx>(
             body,
             borrow_local,
             borrow_proj_base,
-            borrow_c,
-            access_c,
+            &borrow_c,
+            &access_c,
             bias,
         ) {
             Overlap::Arbitrary => {
@@ -420,24 +420,24 @@ fn place_projection_conflict<'tcx>(
             }
         }
         (
-            ProjectionElem::ConstantIndex {
+            &ProjectionElem::ConstantIndex {
                 offset: offset_from_begin,
                 min_length: min_length1,
                 from_end: false,
             },
-            ProjectionElem::ConstantIndex {
+            &ProjectionElem::ConstantIndex {
                 offset: offset_from_end,
                 min_length: min_length2,
                 from_end: true,
             },
         )
         | (
-            ProjectionElem::ConstantIndex {
+            &ProjectionElem::ConstantIndex {
                 offset: offset_from_end,
                 min_length: min_length1,
                 from_end: true,
             },
-            ProjectionElem::ConstantIndex {
+            &ProjectionElem::ConstantIndex {
                 offset: offset_from_begin,
                 min_length: min_length2,
                 from_end: false,
@@ -449,7 +449,7 @@ fn place_projection_conflict<'tcx>(
             // element (like -1 in Python) and `min_length` the first.
             // Therefore, `min_length - offset_from_end` gives the minimal possible
             // offset from the beginning
-            if *offset_from_begin >= *min_length - *offset_from_end {
+            if offset_from_begin >= min_length - offset_from_end {
                 debug!("place_element_conflict: DISJOINT-OR-EQ-ARRAY-CONSTANT-INDEX-FE");
                 Overlap::EqualOrDisjoint
             } else {

--- a/src/librustc_mir/borrow_check/renumber.rs
+++ b/src/librustc_mir/borrow_check/renumber.rs
@@ -66,14 +66,14 @@ impl<'a, 'tcx> MutVisitor<'tcx> for NLLVisitor<'a, 'tcx> {
 
     fn process_projection_elem(
         &mut self,
-        elem: &PlaceElem<'tcx>,
+        elem: PlaceElem<'tcx>,
         _: Location,
     ) -> Option<PlaceElem<'tcx>> {
         if let PlaceElem::Field(field, ty) = elem {
-            let new_ty = self.renumber_regions(ty);
+            let new_ty = self.renumber_regions(&ty);
 
-            if new_ty != *ty {
-                return Some(PlaceElem::Field(*field, new_ty));
+            if new_ty != ty {
+                return Some(PlaceElem::Field(field, new_ty));
             }
         }
 

--- a/src/librustc_mir/borrow_check/type_check/mod.rs
+++ b/src/librustc_mir/borrow_check/type_check/mod.rs
@@ -497,7 +497,7 @@ impl<'a, 'b, 'tcx> TypeVerifier<'a, 'b, 'tcx> {
                     return PlaceTy::from_ty(self.tcx().types.err);
                 }
             }
-            place_ty = self.sanitize_projection(place_ty, elem, place, location)
+            place_ty = self.sanitize_projection(place_ty, &elem, place, location)
         }
 
         if let PlaceContext::NonMutatingUse(NonMutatingUseContext::Copy) = context {

--- a/src/librustc_mir/borrow_check/type_check/mod.rs
+++ b/src/librustc_mir/borrow_check/type_check/mod.rs
@@ -497,7 +497,7 @@ impl<'a, 'b, 'tcx> TypeVerifier<'a, 'b, 'tcx> {
                     return PlaceTy::from_ty(self.tcx().types.err);
                 }
             }
-            place_ty = self.sanitize_projection(place_ty, &elem, place, location)
+            place_ty = self.sanitize_projection(place_ty, elem, place, location)
         }
 
         if let PlaceContext::NonMutatingUse(NonMutatingUseContext::Copy) = context {
@@ -611,14 +611,14 @@ impl<'a, 'b, 'tcx> TypeVerifier<'a, 'b, 'tcx> {
     fn sanitize_projection(
         &mut self,
         base: PlaceTy<'tcx>,
-        pi: &PlaceElem<'tcx>,
+        pi: PlaceElem<'tcx>,
         place: &Place<'tcx>,
         location: Location,
     ) -> PlaceTy<'tcx> {
         debug!("sanitize_projection: {:?} {:?} {:?}", base, pi, place);
         let tcx = self.tcx();
         let base_ty = base.ty;
-        match *pi {
+        match pi {
             ProjectionElem::Deref => {
                 let deref_ty = base_ty.builtin_deref(true);
                 PlaceTy::from_ty(deref_ty.map(|t| t.ty).unwrap_or_else(|| {

--- a/src/librustc_mir/dataflow/drop_flag_effects.rs
+++ b/src/librustc_mir/dataflow/drop_flag_effects.rs
@@ -12,12 +12,12 @@ pub fn move_path_children_matching<'tcx, F>(
     mut cond: F,
 ) -> Option<MovePathIndex>
 where
-    F: FnMut(&mir::PlaceElem<'tcx>) -> bool,
+    F: FnMut(mir::PlaceElem<'tcx>) -> bool,
 {
     let mut next_child = move_data.move_paths[path].first_child;
     while let Some(child_index) = next_child {
         let move_path_children = &move_data.move_paths[child_index];
-        if let Some(elem) = move_path_children.place.projection.last() {
+        if let Some(&elem) = move_path_children.place.projection.last() {
             if cond(elem) {
                 return Some(child_index);
             }

--- a/src/librustc_mir/dataflow/move_paths/builder.rs
+++ b/src/librustc_mir/dataflow/move_paths/builder.rs
@@ -158,7 +158,7 @@ impl<'b, 'a, 'tcx> Gatherer<'b, 'a, 'tcx> {
             };
 
             if union_path.is_none() {
-                base = self.add_move_path(base, &elem, |tcx| Place {
+                base = self.add_move_path(base, elem, |tcx| Place {
                     local: place.local,
                     projection: tcx.intern_place_elems(&place.projection[..i + 1]),
                 });
@@ -176,7 +176,7 @@ impl<'b, 'a, 'tcx> Gatherer<'b, 'a, 'tcx> {
     fn add_move_path(
         &mut self,
         base: MovePathIndex,
-        elem: &PlaceElem<'tcx>,
+        elem: PlaceElem<'tcx>,
         mk_place: impl FnOnce(TyCtxt<'tcx>) -> Place<'tcx>,
     ) -> MovePathIndex {
         let MoveDataBuilder {
@@ -485,7 +485,7 @@ impl<'b, 'a, 'tcx> Gatherer<'b, 'a, 'tcx> {
                 let elem =
                     ProjectionElem::ConstantIndex { offset, min_length: len, from_end: false };
                 let path =
-                    self.add_move_path(base_path, &elem, |tcx| tcx.mk_place_elem(base_place, elem));
+                    self.add_move_path(base_path, elem, |tcx| tcx.mk_place_elem(base_place, elem));
                 self.record_move(place, path);
             }
         } else {

--- a/src/librustc_mir/dataflow/move_paths/builder.rs
+++ b/src/librustc_mir/dataflow/move_paths/builder.rs
@@ -158,7 +158,7 @@ impl<'b, 'a, 'tcx> Gatherer<'b, 'a, 'tcx> {
             };
 
             if union_path.is_none() {
-                base = self.add_move_path(base, elem, |tcx| Place {
+                base = self.add_move_path(base, &elem, |tcx| Place {
                     local: place.local,
                     projection: tcx.intern_place_elems(&place.projection[..i + 1]),
                 });

--- a/src/librustc_mir/interpret/operand.rs
+++ b/src/librustc_mir/interpret/operand.rs
@@ -400,10 +400,10 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
     pub fn operand_projection(
         &self,
         base: OpTy<'tcx, M::PointerTag>,
-        proj_elem: &mir::PlaceElem<'tcx>,
+        proj_elem: mir::PlaceElem<'tcx>,
     ) -> InterpResult<'tcx, OpTy<'tcx, M::PointerTag>> {
         use rustc_middle::mir::ProjectionElem::*;
-        Ok(match *proj_elem {
+        Ok(match proj_elem {
             Field(field, _) => self.operand_field(base, field.index())?,
             Downcast(_, variant) => self.operand_downcast(base, variant)?,
             Deref => self.deref_operand(base)?.into(),
@@ -466,7 +466,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
         let op = place
             .projection
             .iter()
-            .try_fold(base_op, |op, elem| self.operand_projection(op, &elem))?;
+            .try_fold(base_op, |op, elem| self.operand_projection(op, elem))?;
 
         trace!("eval_place_to_op: got {:?}", *op);
         Ok(op)

--- a/src/librustc_mir/interpret/operand.rs
+++ b/src/librustc_mir/interpret/operand.rs
@@ -466,7 +466,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
         let op = place
             .projection
             .iter()
-            .try_fold(base_op, |op, elem| self.operand_projection(op, elem))?;
+            .try_fold(base_op, |op, elem| self.operand_projection(op, &elem))?;
 
         trace!("eval_place_to_op: got {:?}", *op);
         Ok(op)

--- a/src/librustc_mir/interpret/place.rs
+++ b/src/librustc_mir/interpret/place.rs
@@ -517,10 +517,10 @@ where
     pub(super) fn mplace_projection(
         &self,
         base: MPlaceTy<'tcx, M::PointerTag>,
-        proj_elem: &mir::PlaceElem<'tcx>,
+        proj_elem: mir::PlaceElem<'tcx>,
     ) -> InterpResult<'tcx, MPlaceTy<'tcx, M::PointerTag>> {
         use rustc_middle::mir::ProjectionElem::*;
-        Ok(match *proj_elem {
+        Ok(match proj_elem {
             Field(field, _) => self.mplace_field(base, field.index())?,
             Downcast(_, variant) => self.mplace_downcast(base, variant)?,
             Deref => self.deref_operand(base.into())?,
@@ -605,10 +605,10 @@ where
     pub fn place_projection(
         &mut self,
         base: PlaceTy<'tcx, M::PointerTag>,
-        proj_elem: &mir::ProjectionElem<mir::Local, Ty<'tcx>>,
+        &proj_elem: &mir::ProjectionElem<mir::Local, Ty<'tcx>>,
     ) -> InterpResult<'tcx, PlaceTy<'tcx, M::PointerTag>> {
         use rustc_middle::mir::ProjectionElem::*;
-        Ok(match *proj_elem {
+        Ok(match proj_elem {
             Field(field, _) => self.place_field(base, field.index())?,
             Downcast(_, variant) => self.place_downcast(base, variant)?,
             Deref => self.deref_operand(self.place_to_op(base)?)?.into(),

--- a/src/librustc_mir/interpret/place.rs
+++ b/src/librustc_mir/interpret/place.rs
@@ -634,7 +634,7 @@ where
         };
 
         for elem in place.projection.iter() {
-            place_ty = self.place_projection(place_ty, elem)?
+            place_ty = self.place_projection(place_ty, &elem)?
         }
 
         self.dump_place(place_ty.place);

--- a/src/librustc_mir/monomorphize/collector.rs
+++ b/src/librustc_mir/monomorphize/collector.rs
@@ -449,7 +449,7 @@ fn check_type_length_limit<'tcx>(tcx: TyCtxt<'tcx>, instance: Instance<'tcx>) {
     let type_length = instance
         .substs
         .iter()
-        .flat_map(|&arg| arg.walk())
+        .flat_map(|arg| arg.walk())
         .filter(|arg| match arg.unpack() {
             GenericArgKind::Type(_) | GenericArgKind::Const(_) => true,
             GenericArgKind::Lifetime(_) => false,

--- a/src/librustc_mir/transform/check_consts/qualifs.rs
+++ b/src/librustc_mir/transform/check_consts/qualifs.rs
@@ -206,8 +206,8 @@ where
     F: FnMut(Local) -> bool,
 {
     let mut projection = place.projection;
-    while let [ref proj_base @ .., proj_elem] = projection {
-        match *proj_elem {
+    while let &[ref proj_base @ .., proj_elem] = projection {
+        match proj_elem {
             ProjectionElem::Index(index) if in_local(index) => return true,
 
             ProjectionElem::Deref

--- a/src/librustc_mir/transform/check_consts/validation.rs
+++ b/src/librustc_mir/transform/check_consts/validation.rs
@@ -432,7 +432,7 @@ impl Visitor<'tcx> for Validator<'mir, 'tcx> {
         &mut self,
         place_local: Local,
         proj_base: &[PlaceElem<'tcx>],
-        elem: &PlaceElem<'tcx>,
+        elem: PlaceElem<'tcx>,
         context: PlaceContext,
         location: Location,
     ) {

--- a/src/librustc_mir/transform/elaborate_drops.rs
+++ b/src/librustc_mir/transform/elaborate_drops.rs
@@ -213,7 +213,7 @@ impl<'a, 'b, 'tcx> DropElaborator<'a, 'tcx> for Elaborator<'a, 'b, 'tcx> {
 
     fn field_subpath(&self, path: Self::Path, field: Field) -> Option<Self::Path> {
         dataflow::move_path_children_matching(self.ctxt.move_data(), path, |e| match e {
-            ProjectionElem::Field(idx, _) => *idx == field,
+            ProjectionElem::Field(idx, _) => idx == field,
             _ => false,
         })
     }
@@ -221,9 +221,9 @@ impl<'a, 'b, 'tcx> DropElaborator<'a, 'tcx> for Elaborator<'a, 'b, 'tcx> {
     fn array_subpath(&self, path: Self::Path, index: u32, size: u32) -> Option<Self::Path> {
         dataflow::move_path_children_matching(self.ctxt.move_data(), path, |e| match e {
             ProjectionElem::ConstantIndex { offset, min_length, from_end } => {
-                debug_assert!(size == *min_length, "min_length should be exact for arrays");
+                debug_assert!(size == min_length, "min_length should be exact for arrays");
                 assert!(!from_end, "from_end should not be used for array element ConstantIndex");
-                *offset == index
+                offset == index
             }
             _ => false,
         })
@@ -231,13 +231,13 @@ impl<'a, 'b, 'tcx> DropElaborator<'a, 'tcx> for Elaborator<'a, 'b, 'tcx> {
 
     fn deref_subpath(&self, path: Self::Path) -> Option<Self::Path> {
         dataflow::move_path_children_matching(self.ctxt.move_data(), path, |e| {
-            *e == ProjectionElem::Deref
+            e == ProjectionElem::Deref
         })
     }
 
     fn downcast_subpath(&self, path: Self::Path, variant: VariantIdx) -> Option<Self::Path> {
         dataflow::move_path_children_matching(self.ctxt.move_data(), path, |e| match e {
-            ProjectionElem::Downcast(_, idx) => *idx == variant,
+            ProjectionElem::Downcast(_, idx) => idx == variant,
             _ => false,
         })
     }

--- a/src/librustc_mir/transform/generator.rs
+++ b/src/librustc_mir/transform/generator.rs
@@ -132,7 +132,7 @@ impl<'tcx> MutVisitor<'tcx> for DerefArgVisitor<'tcx> {
 
             for elem in place.projection.iter() {
                 if let PlaceElem::Index(local) = elem {
-                    assert_ne!(*local, SELF_ARG);
+                    assert_ne!(local, SELF_ARG);
                 }
             }
         }
@@ -171,7 +171,7 @@ impl<'tcx> MutVisitor<'tcx> for PinArgVisitor<'tcx> {
 
             for elem in place.projection.iter() {
                 if let PlaceElem::Index(local) = elem {
-                    assert_ne!(*local, SELF_ARG);
+                    assert_ne!(local, SELF_ARG);
                 }
             }
         }

--- a/src/librustc_mir/transform/promote_consts.rs
+++ b/src/librustc_mir/transform/promote_consts.rs
@@ -340,7 +340,7 @@ impl<'tcx> Validator<'_, 'tcx> {
                             // `let _: &'static _ = &(Cell::new(1), 2).1;`
                             let mut place_projection = &place.projection[..];
                             // FIXME(eddyb) use a forward loop instead of a reverse one.
-                            while let [proj_base @ .., elem] = place_projection {
+                            while let &[ref proj_base @ .., elem] = place_projection {
                                 // FIXME(eddyb) this is probably excessive, with
                                 // the exception of `union` member accesses.
                                 let ty =
@@ -676,7 +676,7 @@ impl<'tcx> Validator<'_, 'tcx> {
                 if has_mut_interior {
                     let mut place_projection = place.projection;
                     // FIXME(eddyb) use a forward loop instead of a reverse one.
-                    while let [proj_base @ .., elem] = place_projection {
+                    while let &[ref proj_base @ .., elem] = place_projection {
                         // FIXME(eddyb) this is probably excessive, with
                         // the exception of `union` member accesses.
                         let ty = Place::ty_from(place.local, proj_base, self.body, self.tcx)

--- a/src/librustc_mir_build/build/matches/mod.rs
+++ b/src/librustc_mir_build/build/matches/mod.rs
@@ -1042,7 +1042,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 matched_candidates.iter().flat_map(|candidate| &candidate.bindings)
             {
                 if let Some(i) =
-                    source.projection.iter().rposition(|elem| *elem == ProjectionElem::Deref)
+                    source.projection.iter().rposition(|elem| elem == ProjectionElem::Deref)
                 {
                     let proj_base = &source.projection[..i];
 

--- a/src/librustc_privacy/lib.rs
+++ b/src/librustc_privacy/lib.rs
@@ -176,7 +176,7 @@ where
                 // All traits in the list are considered the "primary" part of the type
                 // and are visited by shallow visitors.
                 for predicate in *predicates.skip_binder() {
-                    let trait_ref = match *predicate {
+                    let trait_ref = match predicate {
                         ty::ExistentialPredicate::Trait(trait_ref) => trait_ref,
                         ty::ExistentialPredicate::Projection(proj) => proj.trait_ref(tcx),
                         ty::ExistentialPredicate::AutoTrait(def_id) => {

--- a/src/librustc_symbol_mangling/v0.rs
+++ b/src/librustc_symbol_mangling/v0.rs
@@ -477,7 +477,7 @@ impl Printer<'tcx> for SymbolMangler<'tcx> {
         predicates: &'tcx ty::List<ty::ExistentialPredicate<'tcx>>,
     ) -> Result<Self::DynExistential, Self::Error> {
         for predicate in predicates {
-            match *predicate {
+            match predicate {
                 ty::ExistentialPredicate::Trait(trait_ref) => {
                     // Use a type that can't appear in defaults of type parameters.
                     let dummy_self = self.tcx.mk_ty_infer(ty::FreshTy(0));

--- a/src/librustc_trait_selection/opaque_types.rs
+++ b/src/librustc_trait_selection/opaque_types.rs
@@ -647,7 +647,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
         // shifting.
         let id_substs = InternalSubsts::identity_for_item(self.tcx, def_id);
         let map: FxHashMap<GenericArg<'tcx>, GenericArg<'tcx>> =
-            substs.iter().enumerate().map(|(index, subst)| (*subst, id_substs[index])).collect();
+            substs.iter().enumerate().map(|(index, subst)| (subst, id_substs[index])).collect();
 
         // Convert the type from the function into a type valid outside
         // the function, by replacing invalid regions with 'static,
@@ -891,7 +891,7 @@ impl TypeFolder<'tcx> for ReverseMapper<'tcx> {
                 // during codegen.
 
                 let generics = self.tcx.generics_of(def_id);
-                let substs = self.tcx.mk_substs(substs.iter().enumerate().map(|(index, &kind)| {
+                let substs = self.tcx.mk_substs(substs.iter().enumerate().map(|(index, kind)| {
                     if index < generics.parent_count {
                         // Accommodate missing regions in the parent kinds...
                         self.fold_kind_mapping_missing_regions_to_empty(kind)
@@ -906,7 +906,7 @@ impl TypeFolder<'tcx> for ReverseMapper<'tcx> {
 
             ty::Generator(def_id, substs, movability) => {
                 let generics = self.tcx.generics_of(def_id);
-                let substs = self.tcx.mk_substs(substs.iter().enumerate().map(|(index, &kind)| {
+                let substs = self.tcx.mk_substs(substs.iter().enumerate().map(|(index, kind)| {
                     if index < generics.parent_count {
                         // Accommodate missing regions in the parent kinds...
                         self.fold_kind_mapping_missing_regions_to_empty(kind)

--- a/src/librustc_trait_selection/traits/auto_trait.rs
+++ b/src/librustc_trait_selection/traits/auto_trait.rs
@@ -768,12 +768,12 @@ impl AutoTraitFinder<'tcx> {
                         }
                     }
                 }
-                ty::PredicateKind::RegionOutlives(ref binder) => {
+                &ty::PredicateKind::RegionOutlives(binder) => {
                     if select.infcx().region_outlives_predicate(&dummy_cause, binder).is_err() {
                         return false;
                     }
                 }
-                ty::PredicateKind::TypeOutlives(ref binder) => {
+                &ty::PredicateKind::TypeOutlives(binder) => {
                     match (
                         binder.no_bound_vars(),
                         binder.map_bound_ref(|pred| pred.0).no_bound_vars(),

--- a/src/librustc_trait_selection/traits/auto_trait.rs
+++ b/src/librustc_trait_selection/traits/auto_trait.rs
@@ -281,9 +281,8 @@ impl AutoTraitFinder<'tcx> {
             },
         }));
 
-        let computed_preds = param_env.caller_bounds.iter().cloned();
-        let mut user_computed_preds: FxHashSet<_> =
-            user_env.caller_bounds.iter().cloned().collect();
+        let computed_preds = param_env.caller_bounds.iter();
+        let mut user_computed_preds: FxHashSet<_> = user_env.caller_bounds.iter().collect();
 
         let mut new_env = param_env;
         let dummy_cause = ObligationCause::dummy();

--- a/src/librustc_trait_selection/traits/chalk_fulfill.rs
+++ b/src/librustc_trait_selection/traits/chalk_fulfill.rs
@@ -87,7 +87,7 @@ fn environment<'tcx>(
         NodeKind::TraitImpl => {
             let trait_ref = tcx.impl_trait_ref(def_id).expect("not an impl");
 
-            inputs.extend(trait_ref.substs.iter().flat_map(|&arg| arg.walk()));
+            inputs.extend(trait_ref.substs.iter().flat_map(|arg| arg.walk()));
         }
 
         // In an inherent impl, we assume that the receiver type and all its

--- a/src/librustc_trait_selection/traits/error_reporting/mod.rs
+++ b/src/librustc_trait_selection/traits/error_reporting/mod.rs
@@ -146,9 +146,9 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                             continue;
                         }
 
-                        if self.error_implies(&error2.predicate, &error.predicate)
+                        if self.error_implies(error2.predicate, error.predicate)
                             && !(error2.index >= error.index
-                                && self.error_implies(&error.predicate, &error2.predicate))
+                                && self.error_implies(error.predicate, error2.predicate))
                         {
                             info!("skipping {:?} (implied by {:?})", error, error2);
                             is_suppressed[index] = true;
@@ -500,7 +500,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                     ty::PredicateKind::RegionOutlives(ref predicate) => {
                         let predicate = self.resolve_vars_if_possible(predicate);
                         let err = self
-                            .region_outlives_predicate(&obligation.cause, &predicate)
+                            .region_outlives_predicate(&obligation.cause, predicate)
                             .err()
                             .unwrap();
                         struct_span_err!(
@@ -955,7 +955,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
 trait InferCtxtPrivExt<'tcx> {
     // returns if `cond` not occurring implies that `error` does not occur - i.e., that
     // `error` occurring implies that `cond` occurs.
-    fn error_implies(&self, cond: &ty::Predicate<'tcx>, error: &ty::Predicate<'tcx>) -> bool;
+    fn error_implies(&self, cond: ty::Predicate<'tcx>, error: ty::Predicate<'tcx>) -> bool;
 
     fn report_fulfillment_error(
         &self,
@@ -1042,7 +1042,7 @@ trait InferCtxtPrivExt<'tcx> {
 impl<'a, 'tcx> InferCtxtPrivExt<'tcx> for InferCtxt<'a, 'tcx> {
     // returns if `cond` not occurring implies that `error` does not occur - i.e., that
     // `error` occurring implies that `cond` occurs.
-    fn error_implies(&self, cond: &ty::Predicate<'tcx>, error: &ty::Predicate<'tcx>) -> bool {
+    fn error_implies(&self, cond: ty::Predicate<'tcx>, error: ty::Predicate<'tcx>) -> bool {
         if cond == error {
             return true;
         }
@@ -1055,7 +1055,7 @@ impl<'a, 'tcx> InferCtxtPrivExt<'tcx> for InferCtxt<'a, 'tcx> {
             }
         };
 
-        for obligation in super::elaborate_predicates(self.tcx, std::iter::once(*cond)) {
+        for obligation in super::elaborate_predicates(self.tcx, std::iter::once(cond)) {
             if let ty::PredicateKind::Trait(implication, _) = obligation.predicate.kind() {
                 let error = error.to_poly_trait_ref();
                 let implication = implication.to_poly_trait_ref();

--- a/src/librustc_trait_selection/traits/fulfill.rs
+++ b/src/librustc_trait_selection/traits/fulfill.rs
@@ -378,7 +378,7 @@ impl<'a, 'b, 'tcx> ObligationProcessor for FulfillProcessor<'a, 'b, 'tcx> {
                 }
             }
 
-            ty::PredicateKind::RegionOutlives(ref binder) => {
+            &ty::PredicateKind::RegionOutlives(binder) => {
                 match infcx.region_outlives_predicate(&obligation.cause, binder) {
                     Ok(()) => ProcessResult::Changed(vec![]),
                     Err(_) => ProcessResult::Error(CodeSelectionError(Unimplemented)),
@@ -481,7 +481,7 @@ impl<'a, 'b, 'tcx> ObligationProcessor for FulfillProcessor<'a, 'b, 'tcx> {
                 }
             }
 
-            ty::PredicateKind::Subtype(subtype) => {
+            &ty::PredicateKind::Subtype(subtype) => {
                 match self.selcx.infcx().subtype_predicate(
                     &obligation.cause,
                     obligation.param_env,

--- a/src/librustc_trait_selection/traits/mod.rs
+++ b/src/librustc_trait_selection/traits/mod.rs
@@ -302,7 +302,7 @@ pub fn normalize_param_env_or_error<'tcx>(
     );
 
     let mut predicates: Vec<_> =
-        util::elaborate_predicates(tcx, unnormalized_env.caller_bounds.into_iter().cloned())
+        util::elaborate_predicates(tcx, unnormalized_env.caller_bounds.into_iter())
             .map(|obligation| obligation.predicate)
             .collect();
 

--- a/src/librustc_trait_selection/traits/object_safety.rs
+++ b/src/librustc_trait_selection/traits/object_safety.rs
@@ -658,7 +658,6 @@ fn receiver_is_dispatchable<'tcx>(
         let caller_bounds: Vec<Predicate<'tcx>> = param_env
             .caller_bounds
             .iter()
-            .cloned()
             .chain(iter::once(unsize_predicate))
             .chain(iter::once(trait_predicate))
             .collect();

--- a/src/librustc_trait_selection/traits/project.rs
+++ b/src/librustc_trait_selection/traits/project.rs
@@ -1541,14 +1541,14 @@ fn assoc_ty_def(
 crate trait ProjectionCacheKeyExt<'tcx>: Sized {
     fn from_poly_projection_predicate(
         selcx: &mut SelectionContext<'cx, 'tcx>,
-        predicate: &ty::PolyProjectionPredicate<'tcx>,
+        predicate: ty::PolyProjectionPredicate<'tcx>,
     ) -> Option<Self>;
 }
 
 impl<'tcx> ProjectionCacheKeyExt<'tcx> for ProjectionCacheKey<'tcx> {
     fn from_poly_projection_predicate(
         selcx: &mut SelectionContext<'cx, 'tcx>,
-        predicate: &ty::PolyProjectionPredicate<'tcx>,
+        predicate: ty::PolyProjectionPredicate<'tcx>,
     ) -> Option<Self> {
         let infcx = selcx.infcx();
         // We don't do cross-snapshot caching of obligations with escaping regions,

--- a/src/librustc_trait_selection/traits/project.rs
+++ b/src/librustc_trait_selection/traits/project.rs
@@ -872,7 +872,7 @@ fn assemble_candidates_from_param_env<'cx, 'tcx>(
         obligation_trait_ref,
         candidate_set,
         ProjectionTyCandidate::ParamEnv,
-        obligation.param_env.caller_bounds.iter().cloned(),
+        obligation.param_env.caller_bounds.iter(),
     );
 }
 

--- a/src/librustc_trait_selection/traits/select.rs
+++ b/src/librustc_trait_selection/traits/select.rs
@@ -3154,7 +3154,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
 
                 // Check that the source struct with the target's
                 // unsizing parameters is equal to the target.
-                let substs = tcx.mk_substs(substs_a.iter().enumerate().map(|(i, &k)| {
+                let substs = tcx.mk_substs(substs_a.iter().enumerate().map(|(i, k)| {
                     if unsizing_params.contains(i as u32) { substs_b[i] } else { k }
                 }));
                 let new_struct = tcx.mk_adt(def, substs);

--- a/src/librustc_trait_selection/traits/select.rs
+++ b/src/librustc_trait_selection/traits/select.rs
@@ -415,13 +415,13 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         }
 
         match obligation.predicate.kind() {
-            ty::PredicateKind::Trait(t, _) => {
+            &ty::PredicateKind::Trait(t, _) => {
                 debug_assert!(!t.has_escaping_bound_vars());
-                let obligation = obligation.with(*t);
+                let obligation = obligation.with(t);
                 self.evaluate_trait_predicate_recursively(previous_stack, obligation)
             }
 
-            ty::PredicateKind::Subtype(p) => {
+            &ty::PredicateKind::Subtype(p) => {
                 // Does this code ever run?
                 match self.infcx.subtype_predicate(&obligation.cause, obligation.param_env, p) {
                     Some(Ok(InferOk { mut obligations, .. })) => {
@@ -463,8 +463,8 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                 }
             }
 
-            ty::PredicateKind::Projection(data) => {
-                let project_obligation = obligation.with(*data);
+            &ty::PredicateKind::Projection(data) => {
+                let project_obligation = obligation.with(data);
                 match project::poly_project_and_unify_type(self, &project_obligation) {
                     Ok(Some(mut subobligations)) => {
                         self.add_depth(subobligations.iter_mut(), obligation.recursion_depth);
@@ -962,7 +962,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         debug_assert!(!stack.obligation.predicate.has_escaping_bound_vars());
 
         if let Some(c) =
-            self.check_candidate_cache(stack.obligation.param_env, &cache_fresh_trait_pred)
+            self.check_candidate_cache(stack.obligation.param_env, cache_fresh_trait_pred)
         {
             debug!("CACHE HIT: SELECT({:?})={:?}", cache_fresh_trait_pred, c);
             return c;
@@ -1247,7 +1247,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
     fn check_candidate_cache(
         &mut self,
         param_env: ty::ParamEnv<'tcx>,
-        cache_fresh_trait_pred: &ty::PolyTraitPredicate<'tcx>,
+        cache_fresh_trait_pred: ty::PolyTraitPredicate<'tcx>,
     ) -> Option<SelectionResult<'tcx, SelectionCandidate<'tcx>>> {
         let tcx = self.tcx();
         let trait_ref = &cache_fresh_trait_pred.skip_binder().trait_ref;

--- a/src/librustc_trait_selection/traits/util.rs
+++ b/src/librustc_trait_selection/traits/util.rs
@@ -108,9 +108,9 @@ impl<'tcx> TraitAliasExpander<'tcx> {
         }
 
         // Don't recurse if this trait alias is already on the stack for the DFS search.
-        let anon_pred = anonymize_predicate(tcx, &pred);
+        let anon_pred = anonymize_predicate(tcx, pred);
         if item.path.iter().rev().skip(1).any(|(tr, _)| {
-            anonymize_predicate(tcx, &tr.without_const().to_predicate(tcx)) == anon_pred
+            anonymize_predicate(tcx, tr.without_const().to_predicate(tcx)) == anon_pred
         }) {
             return false;
         }

--- a/src/librustc_trait_selection/traits/wf.rs
+++ b/src/librustc_trait_selection/traits/wf.rs
@@ -66,7 +66,7 @@ pub fn predicate_obligations<'a, 'tcx>(
     infcx: &InferCtxt<'a, 'tcx>,
     param_env: ty::ParamEnv<'tcx>,
     body_id: hir::HirId,
-    predicate: &ty::Predicate<'tcx>,
+    predicate: ty::Predicate<'tcx>,
     span: Span,
 ) -> Vec<traits::PredicateObligation<'tcx>> {
     let mut wf = WfPredicates { infcx, param_env, body_id, span, out: vec![], item: None };

--- a/src/librustc_ty/needs_drop.rs
+++ b/src/librustc_ty/needs_drop.rs
@@ -11,7 +11,7 @@ type NeedsDropResult<T> = Result<T, AlwaysRequiresDrop>;
 
 fn needs_drop_raw<'tcx>(tcx: TyCtxt<'tcx>, query: ty::ParamEnvAnd<'tcx, Ty<'tcx>>) -> bool {
     let adt_fields =
-        move |adt_def: &ty::AdtDef| tcx.adt_drop_tys(adt_def.did).map(|tys| tys.iter().copied());
+        move |adt_def: &ty::AdtDef| tcx.adt_drop_tys(adt_def.did).map(|tys| tys.iter());
     // If we don't know a type doesn't need drop, for example if it's a type
     // parameter without a `Copy` bound, then we conservatively return that it
     // needs drop.

--- a/src/librustc_typeck/check/closure.rs
+++ b/src/librustc_typeck/check/closure.rs
@@ -179,7 +179,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             ty::Dynamic(ref object_type, ..) => {
                 let sig = object_type.projection_bounds().find_map(|pb| {
                     let pb = pb.with_self_ty(self.tcx, self.tcx.types.trait_object_dummy_self);
-                    self.deduce_sig_from_projection(None, &pb)
+                    self.deduce_sig_from_projection(None, pb)
                 });
                 let kind = object_type
                     .principal_def_id()
@@ -206,8 +206,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     obligation.predicate
                 );
 
-                if let ty::PredicateKind::Projection(ref proj_predicate) =
-                    obligation.predicate.kind()
+                if let &ty::PredicateKind::Projection(proj_predicate) = obligation.predicate.kind()
                 {
                     // Given a Projection predicate, we can potentially infer
                     // the complete signature.
@@ -238,7 +237,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     fn deduce_sig_from_projection(
         &self,
         cause_span: Option<Span>,
-        projection: &ty::PolyProjectionPredicate<'tcx>,
+        projection: ty::PolyProjectionPredicate<'tcx>,
     ) -> Option<ExpectedSig<'tcx>> {
         let tcx = self.tcx;
 
@@ -644,7 +643,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         // where R is the return type we are expecting. This type `T`
         // will be our output.
         let output_ty = self.obligations_for_self_ty(ret_vid).find_map(|(_, obligation)| {
-            if let ty::PredicateKind::Projection(ref proj_predicate) = obligation.predicate.kind() {
+            if let &ty::PredicateKind::Projection(proj_predicate) = obligation.predicate.kind() {
                 self.deduce_future_output_from_projection(obligation.cause.span, proj_predicate)
             } else {
                 None
@@ -665,7 +664,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     fn deduce_future_output_from_projection(
         &self,
         cause_span: Span,
-        predicate: &ty::PolyProjectionPredicate<'tcx>,
+        predicate: ty::PolyProjectionPredicate<'tcx>,
     ) -> Option<Ty<'tcx>> {
         debug!("deduce_future_output_from_projection(predicate={:?})", predicate);
 

--- a/src/librustc_typeck/check/dropck.rs
+++ b/src/librustc_typeck/check/dropck.rs
@@ -205,7 +205,7 @@ fn ensure_drop_predicates_are_implied_by_item_defn<'tcx>(
     // just to look for all the predicates directly.
 
     assert_eq!(dtor_predicates.parent, None);
-    for (predicate, predicate_sp) in dtor_predicates.predicates {
+    for &(predicate, predicate_sp) in dtor_predicates.predicates {
         // (We do not need to worry about deep analysis of type
         // expressions etc because the Drop impls are already forced
         // to take on a structure that is roughly an alpha-renaming of
@@ -228,7 +228,7 @@ fn ensure_drop_predicates_are_implied_by_item_defn<'tcx>(
         // This implementation solves (Issue #59497) and (Issue #58311).
         // It is unclear to me at the moment whether the approach based on `relate`
         // could be extended easily also to the other `Predicate`.
-        let predicate_matches_closure = |p: &'_ Predicate<'tcx>| {
+        let predicate_matches_closure = |p: Predicate<'tcx>| {
             let mut relator: SimpleEqRelation<'tcx> = SimpleEqRelation::new(tcx, self_param_env);
             match (predicate.kind(), p.kind()) {
                 (ty::PredicateKind::Trait(a, _), ty::PredicateKind::Trait(b, _)) => {
@@ -241,12 +241,12 @@ fn ensure_drop_predicates_are_implied_by_item_defn<'tcx>(
             }
         };
 
-        if !assumptions_in_impl_context.iter().any(predicate_matches_closure) {
+        if !assumptions_in_impl_context.iter().copied().any(predicate_matches_closure) {
             let item_span = tcx.hir().span(self_type_hir_id);
             let self_descr = tcx.def_kind(self_type_did).descr(self_type_did.to_def_id());
             struct_span_err!(
                 tcx.sess,
-                *predicate_sp,
+                predicate_sp,
                 E0367,
                 "`Drop` impl requires `{}` but the {} it is implemented for does not",
                 predicate,

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -2769,7 +2769,7 @@ impl<'a, 'tcx> AstConv<'tcx> for FnCtxt<'a, 'tcx> {
         ty::GenericPredicates {
             parent: None,
             predicates: tcx.arena.alloc_from_iter(self.param_env.caller_bounds.iter().filter_map(
-                |&predicate| match predicate.kind() {
+                |predicate| match predicate.kind() {
                     ty::PredicateKind::Trait(ref data, _)
                         if data.skip_binder().self_ty().is_param(index) =>
                     {

--- a/src/librustc_typeck/check/wfcheck.rs
+++ b/src/librustc_typeck/check/wfcheck.rs
@@ -819,8 +819,8 @@ fn check_where_clauses<'tcx, 'fcx>(
     debug!("check_where_clauses: predicates={:?}", predicates.predicates);
     assert_eq!(predicates.predicates.len(), predicates.spans.len());
     let wf_obligations =
-        predicates.predicates.iter().zip(predicates.spans.iter()).flat_map(|(p, sp)| {
-            traits::wf::predicate_obligations(fcx, fcx.param_env, fcx.body_id, p, *sp)
+        predicates.predicates.iter().zip(predicates.spans.iter()).flat_map(|(&p, &sp)| {
+            traits::wf::predicate_obligations(fcx, fcx.param_env, fcx.body_id, p, sp)
         });
 
     for obligation in wf_obligations.chain(default_obligations) {

--- a/src/librustc_typeck/check/wfcheck.rs
+++ b/src/librustc_typeck/check/wfcheck.rs
@@ -900,7 +900,7 @@ fn check_opaque_types<'fcx, 'tcx>(
                     if may_define_opaque_type(tcx, fn_def_id, opaque_hir_id) {
                         trace!("check_opaque_types: may define, generics={:#?}", generics);
                         let mut seen_params: FxHashMap<_, Vec<_>> = FxHashMap::default();
-                        for (i, &arg) in substs.iter().enumerate() {
+                        for (i, arg) in substs.iter().enumerate() {
                             let arg_is_param = match arg.unpack() {
                                 GenericArgKind::Type(ty) => matches!(ty.kind, ty::Param(_)),
 

--- a/src/librustc_typeck/impl_wf_check/min_specialization.rs
+++ b/src/librustc_typeck/impl_wf_check/min_specialization.rs
@@ -229,7 +229,7 @@ fn unconstrained_parent_impl_substs<'tcx>(
         .iter()
         .enumerate()
         .filter(|&(idx, _)| !constrained_params.contains(&(idx as u32)))
-        .map(|(_, arg)| *arg)
+        .map(|(_, arg)| arg)
         .collect()
 }
 

--- a/src/librustc_typeck/variance/constraints.rs
+++ b/src/librustc_typeck/variance/constraints.rs
@@ -291,7 +291,7 @@ impl<'a, 'tcx> ConstraintContext<'a, 'tcx> {
             }
 
             ty::Tuple(subtys) => {
-                for &subty in subtys {
+                for subty in subtys {
                     self.add_constraints_from_ty(current, subty.expect_ty(), variance);
                 }
             }

--- a/src/tools/clippy/clippy_lints/src/needless_pass_by_value.rs
+++ b/src/tools/clippy/clippy_lints/src/needless_pass_by_value.rs
@@ -111,7 +111,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NeedlessPassByValue {
 
         let fn_def_id = cx.tcx.hir().local_def_id(hir_id);
 
-        let preds = traits::elaborate_predicates(cx.tcx, cx.param_env.caller_bounds.iter().copied())
+        let preds = traits::elaborate_predicates(cx.tcx, cx.param_env.caller_bounds.iter())
             .filter(|p| !p.is_global())
             .filter_map(|obligation| {
                 if let ty::PredicateKind::Trait(poly_trait_ref, _) = obligation.predicate.kind() {
@@ -179,7 +179,6 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NeedlessPassByValue {
                                 .substs
                                 .iter()
                                 .skip(1)
-                                .cloned()
                                 .collect::<Vec<_>>();
                             implements_trait(cx, ty_empty_region, t.def_id(), ty_params)
                         })


### PR DESCRIPTION
There are a lot of locations where we pass `&T where T: Copy` by reference,
which should both be slightly less performant and less readable IMO.

This PR currently consists of three fairly self contained commits:

- passes `ty::Predicate` by value and stops depending on `AsRef<ty::Predicate>`.
- changes `<&List<_>>::into_iter` to iterate over the elements by value. This would break `List`s
  of non copy types. But as the only list constructor requires `T` to be copy anyways, I think
  the improved readability is worth this potential future restriction.
- passes `mir::PlaceElem` by value. Mir currently has quite a few copy types which are passed by reference, e.g. `Local`. As I don't have a lot of experience working with MIR, I mostly did this to get some feedback from people who use MIR more frequently
- tries to reuse `ty::Predicate` in case it did not change in some places, which should hopefully
  fix the regression caused by #72055

r? @nikomatsakis for the first commit, which continues the work of #72055 and makes adding `PredicateKind::ForAll` slightly more pleasant. Feel free to reassign though