### PR TITLE
Override Box::<[T]>::clone_from

### DIFF
--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -1090,6 +1090,14 @@ impl<T: Clone> Clone for Box<[T]> {
     fn clone(&self) -> Self {
         self.to_vec().into_boxed_slice()
     }
+
+    fn clone_from(&mut self, other: &Self) {
+        if self.len() == other.len() {
+            self.clone_from_slice(&other);
+        } else {
+            *self = other.clone();
+        }
+    }
 }
 
 #[stable(feature = "box_borrow", since = "1.1.0")]

--- a/src/liballoc/tests/boxed.rs
+++ b/src/liballoc/tests/boxed.rs
@@ -34,6 +34,11 @@ fn box_clone_and_clone_from_equivalence() {
     }
 }
 
+/// This test might give a false positive in case the box realocates, but the alocator keeps the
+/// original pointer.
+///
+/// On the other hand it won't give a false negative, if it fails than the memory was definitly not
+/// reused
 #[test]
 fn box_clone_from_ptr_stability() {
     for size in (0..8).map(|i| 2usize.pow(i)) {
@@ -42,13 +47,5 @@ fn box_clone_from_ptr_stability() {
         let copy_raw = copy.as_ptr() as usize;
         copy.clone_from(&control);
         assert_eq!(copy.as_ptr() as usize, copy_raw);
-    }
-
-    for size in (0..8).map(|i| 2usize.pow(i)) {
-        let control = vec![Dummy { _data: 42 }; size].into_boxed_slice();
-        let mut copy = vec![Dummy { _data: 84 }; size + 1].into_boxed_slice();
-        let copy_raw = copy.as_ptr() as usize;
-        copy.clone_from(&control);
-        assert_ne!(copy.as_ptr() as usize, copy_raw);
     }
 }


### PR DESCRIPTION
Avoid dropping and reallocating when cloning to an existing box if the lengths are the same.

It would be nice if this could also be specialized for `Copy` but I don't know how that works since it's not on stable. Will gladly look into it if it's deemed as a good idea.

This is my first PR with code, hope I did everything right :smile: 