### PR TITLE
fix discriminant type in generator transform

### DIFF
--- a/src/librustc_mir/transform/generator.rs
+++ b/src/librustc_mir/transform/generator.rs
@@ -266,7 +266,7 @@ impl TransformVisitor<'tcx> {
 
     // Create a statement which reads the discriminant into a temporary
     fn get_discr(&self, body: &mut Body<'tcx>) -> (Statement<'tcx>, Place<'tcx>) {
-        let temp_decl = LocalDecl::new(self.tcx.types.isize, body.span).internal();
+        let temp_decl = LocalDecl::new(self.discr_ty, body.span).internal();
         let local_decls_len = body.local_decls.push(temp_decl);
         let temp = Place::from(local_decls_len);
 

--- a/src/test/mir-opt/generator-drop-cleanup/rustc.main-{{closure}}.generator_drop.0.mir
+++ b/src/test/mir-opt/generator-drop-cleanup/rustc.main-{{closure}}.generator_drop.0.mir
@@ -9,7 +9,7 @@ fn main::{{closure}}#0(_1: *mut [generator@$DIR/generator-drop-cleanup.rs:10:15:
     let mut _5: ();                      // in scope 0 at $DIR/generator-drop-cleanup.rs:12:9: 12:14
     let mut _7: ();                      // in scope 0 at $DIR/generator-drop-cleanup.rs:10:18: 10:18
     let mut _8: ();                      // in scope 0 at $DIR/generator-drop-cleanup.rs:10:15: 13:6
-    let mut _9: isize;                   // in scope 0 at $DIR/generator-drop-cleanup.rs:10:15: 13:6
+    let mut _9: u32;                     // in scope 0 at $DIR/generator-drop-cleanup.rs:10:15: 13:6
     scope 1 {
         debug _s => (((*_1) as variant#3).0: std::string::String); // in scope 1 at $DIR/generator-drop-cleanup.rs:11:13: 11:15
     }

--- a/src/test/mir-opt/generator-tiny/rustc.main-{{closure}}.generator_resume.0.mir
+++ b/src/test/mir-opt/generator-tiny/rustc.main-{{closure}}.generator_resume.0.mir
@@ -12,7 +12,7 @@ fn main::{{closure}}#0(_1: std::pin::Pin<&mut [generator@$DIR/generator-tiny.rs:
     let _8: ();                          // in scope 0 at $DIR/generator-tiny.rs:23:13: 23:21
     let mut _9: ();                      // in scope 0 at $DIR/generator-tiny.rs:19:25: 19:25
     let _10: u8;                         // in scope 0 at $DIR/generator-tiny.rs:19:17: 19:19
-    let mut _11: isize;                  // in scope 0 at $DIR/generator-tiny.rs:19:16: 25:6
+    let mut _11: u32;                    // in scope 0 at $DIR/generator-tiny.rs:19:16: 25:6
     scope 1 {
         debug _d => (((*(_1.0: &mut [generator@$DIR/generator-tiny.rs:19:16: 25:6 {u8, HasDrop, ()}])) as variant#3).0: HasDrop); // in scope 1 at $DIR/generator-tiny.rs:20:13: 20:15
     }


### PR DESCRIPTION
The generator transform assumed that the discriminant type is always `isize`, which is not correct, leading to [ICEs in Miri](https://github.com/rust-lang/rust/pull/72419/files#r429543536) when some extra sanity checking got enabled.

r? @jonas-schievink @eddyb