### PR TITLE
Exhaustiveness checking: work around type normalization issues

### DIFF
--- a/src/librustc_mir_build/hair/pattern/_match.rs
+++ b/src/librustc_mir_build/hair/pattern/_match.rs
@@ -1870,7 +1870,9 @@ crate fn is_useful<'p, 'tcx>(
         return if any_is_useful { Useful(unreachable_pats) } else { NotUseful };
     }
 
-    let pcx = PatCtxt { ty: v.head().ty, span: v.head().span };
+    // FIXME(Nadrieril): Hack to work around type normalization issues (see #72476).
+    let ty = matrix.heads().next().map(|r| r.ty).unwrap_or(v.head().ty);
+    let pcx = PatCtxt { ty, span: v.head().span };
 
     debug!("is_useful_expand_first_col: pcx={:#?}, expanding {:#?}", pcx, v.head());
 

--- a/src/test/ui/pattern/usefulness/issue-72476-associated-type.rs
+++ b/src/test/ui/pattern/usefulness/issue-72476-associated-type.rs
@@ -1,0 +1,23 @@
+// check-pass
+
+// From https://github.com/rust-lang/rust/issues/72476
+
+trait A {
+    type Projection;
+}
+
+impl A for () {
+    type Projection = bool;
+    // using () instead of bool here does compile though
+}
+
+struct Next<T: A>(T::Projection);
+
+fn f(item: Next<()>) {
+    match item {
+        Next(true) => {}
+        Next(false) => {}
+    }
+}
+
+fn main() {}

--- a/src/test/ui/pattern/usefulness/issue-72476-associated-type.rs
+++ b/src/test/ui/pattern/usefulness/issue-72476-associated-type.rs
@@ -8,7 +8,6 @@ trait A {
 
 impl A for () {
     type Projection = bool;
-    // using () instead of bool here does compile though
 }
 
 struct Next<T: A>(T::Projection);


### PR DESCRIPTION
This should resolve https://github.com/rust-lang/rust/issues/72476 and probably https://github.com/rust-lang/rust/issues/72467.
This is a bit hacky but that's actually what the code was doing before https://github.com/rust-lang/rust/pull/71930. I'm essentially reverting https://github.com/rust-lang/rust/commit/e5a2cd526a6ad92b90dda81104abc7adf4c83495. So despite being hacky, it's been tried and tested (so much so that code relies on it now x)).
Only the third commit does anything interesting. 