### PR TITLE
bootstrap: propagate test-args to miri and clippy test suites

### DIFF
--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -439,6 +439,8 @@ impl Step for Miri {
             cargo.env("RUSTC_LIB_PATH", builder.rustc_libdir(compiler));
             cargo.env("MIRI_PATH", miri);
 
+            cargo.arg("--").args(builder.config.cmd.test_args());
+
             builder.add_rustc_lib_path(compiler, &mut cargo);
 
             if !try_run(builder, &mut cargo.into()) {
@@ -544,6 +546,8 @@ impl Step for Clippy {
             cargo.env("TARGET_LIBS", target_libs);
             // clippy tests need to find the driver
             cargo.env("CLIPPY_DRIVER_PATH", clippy);
+
+            cargo.arg("--").args(builder.config.cmd.test_args());
 
             builder.add_rustc_lib_path(compiler, &mut cargo);
 


### PR DESCRIPTION
For Miri I verified this works. For clippy, unfortunately it doesn't seem to work as a stage 0 tool:
```
./x.py --stage 0 test src/tools/clippy --test-args init
```
gives
```
   Compiling clippy-mini-macro-test v0.2.0 (/home/r/src/rust/rustc.3/src/tools/clippy/mini-macro)
error[E0658]: procedural macros cannot be expanded to expressions
  --> src/tools/clippy/mini-macro/src/lib.rs:11:5
   |
11 | /     quote!(
12 | |         #[allow(unused)]
13 | |         fn needless_take_by_value(s: String) {
14 | |             println!("{}", s.len());
...  |
24 | |         }
25 | |     )
   | |_____^
   |
   = note: see issue #54727 <https://github.com/rust-lang/rust/issues/54727> for more information
   = help: add `#![feature(proc_macro_hygiene)]` to the crate attributes to enable

   Compiling proc-macro2 v1.0.3
   Compiling syn v1.0.11
error: aborting due to previous error

For more information about this error, try `rustc --explain E0658`.
error: could not compile `clippy-mini-macro-test`.
```
But propagating `--test-args` to the test suite seems to make sense regardless.
Cc @rust-lang/clippy 