### PR TITLE
Improve missing `@` in slice binding pattern diagnostics

### DIFF
--- a/src/test/ui/issues/issue-72373.rs
+++ b/src/test/ui/issues/issue-72373.rs
@@ -1,0 +1,9 @@
+fn foo(c: &[u32], n: u32) -> u32 {
+    match *c {
+        [h, ..] if h > n => 0,
+        [h, ..] if h == n => 1,
+        [h, ref ts..] => foo(c, n - h) + foo(ts, n),
+        //~^ ERROR expected one of `,`, `@`, `]`, or `|`, found `..`
+        [] => 0,
+    }
+}

--- a/src/test/ui/issues/issue-72373.stderr
+++ b/src/test/ui/issues/issue-72373.stderr
@@ -1,0 +1,13 @@
+error: expected one of `,`, `@`, `]`, or `|`, found `..`
+  --> $DIR/issue-72373.rs:5:19
+   |
+LL |         [h, ref ts..] => foo(c, n - h) + foo(ts, n),
+   |                   ^^ expected one of `,`, `@`, `]`, or `|`
+   |
+help: if you meant to bind the contents of the rest of the array pattern into `ts`, use `@`
+   |
+LL |         [h, ref ts @ ..] => foo(c, n - h) + foo(ts, n),
+   |                    ^
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Closes https://github.com/rust-lang/rust/issues/72373

Includes a new suggestion with `Applicability::MaybeIncorrect` confidence level.

Before:

```
 --> src/main.rs:5:19
  |
5 |         [h, ref ts..] => foo(c, n - h) + foo(ts, n),
  |                   -^
  |                   |
  |                   expected one of `,`, `@`, `]`, or `|`
  |                   help: missing `,`

error[E0308]: mismatched types
 --> src/main.rs:5:46
  |
5 |         [h, ref ts..] => foo(c, n - h) + foo(ts, n),
  |                                              ^^ expected slice `[u32]`, found `u32`
  |
  = note: expected reference `&[u32]`
             found reference `&u32`

error: aborting due to 2 previous errors
```

After:

```
error: expected one of `,`, `@`, `]`, or `|`, found `..`
 --> src/main.rs:5:20
  |
5 |         [h, ref ts..] => foo(c, n - h) + foo(ts, n),
  |                    ^^ expected one of `,`, `@`, `]`, or `|`
  |
help: if you meant to bind the contents of the rest of the array pattern into `ts`, use `@`
  |
5 |         [h, ref ts @ ..] => foo(c, n - h) + foo(ts, n),
  |                    ^

error: aborting due to previous error
```

r? @estebank 