### PR TITLE
Don't emit structure padding members if no padding is required.

### DIFF
--- a/src/librustc_codegen_llvm/type_.rs
+++ b/src/librustc_codegen_llvm/type_.rs
@@ -129,6 +129,18 @@ impl CodegenCx<'ll, 'tcx> {
         self.type_array(self.type_from_integer(unit), size / unit_size)
     }
 
+    /// Return a LLVM type that has at most the required alignment,
+    /// and exactly the required size, as a best-effort padding array.
+    /// This returns `None` if no padding is required.
+    crate fn opt_type_padding_filler(&self, size: Size, align: Align) -> Option<&'ll Type> {
+        let unit = Integer::approximate_align(self, align);
+        let size = size.bytes();
+        let unit_size = unit.size().bytes();
+        assert_eq!(size % unit_size, 0);
+        let len = size / unit_size;
+        if size == 0 { None } else { Some(self.type_array(self.type_from_integer(unit), len)) }
+    }
+
     crate fn type_variadic_func(&self, args: &[&'ll Type], ret: &'ll Type) -> &'ll Type {
         unsafe { llvm::LLVMFunctionType(ret, args.as_ptr(), args.len() as c_uint, True) }
     }

--- a/src/librustc_target/abi/mod.rs
+++ b/src/librustc_target/abi/mod.rs
@@ -741,8 +741,10 @@ impl FieldsShape {
         match self {
             FieldsShape::Arbitrary { padded_indices: Some((count, _)), .. } => *count as _,
             FieldsShape::Arbitrary { ref offsets, .. } => {
-                // + 1 for the padding.
-                offsets.len() + 1
+                // + 1 for the padding, but only if there are no fields (prevent unnecessary
+                // allocation in librustc_codegen_llvm for empty structures).
+                let count = offsets.len();
+                if count != 0 { count + 1 } else { count }
             }
             _ => unreachable!(
                 "FieldsShape::padded_field_count: only applicable to FieldsShape::Arbitrary"

--- a/src/test/codegen/align-enum.rs
+++ b/src/test/codegen/align-enum.rs
@@ -8,7 +8,7 @@ pub enum Align64 {
     A(u32),
     B(u32),
 }
-// CHECK: %Align64 = type { [0 x i32], i32, [15 x i32] }
+// CHECK: %Align64 = type { i32, [15 x i32] }
 
 pub struct Nested64 {
     a: u8,

--- a/src/test/codegen/align-struct.rs
+++ b/src/test/codegen/align-struct.rs
@@ -5,7 +5,7 @@
 
 #[repr(align(64))]
 pub struct Align64(i32);
-// CHECK: %Align64 = type { [0 x i32], i32, [15 x i32] }
+// CHECK: %Align64 = type { i32, [15 x i32] }
 
 pub struct Nested64 {
     a: Align64,
@@ -13,20 +13,20 @@ pub struct Nested64 {
     c: i32,
     d: i8,
 }
-// CHECK: %Nested64 = type { [0 x i64], %Align64, [0 x i32], i32, [0 x i32], i32, [0 x i8], i8, [55 x i8] }
+// CHECK: %Nested64 = type { %Align64, i32, i32, i8, [55 x i8] }
 
 pub enum Enum4 {
     A(i32),
     B(i32),
 }
-// CHECK: %"Enum4::A" = type { [1 x i32], i32, [0 x i32] }
+// CHECK: %"Enum4::A" = type { [1 x i32], i32 }
 
 pub enum Enum64 {
     A(Align64),
     B(i32),
 }
-// CHECK: %Enum64 = type { [0 x i32], i32, [31 x i32] }
-// CHECK: %"Enum64::A" = type { [8 x i64], %Align64, [0 x i64] }
+// CHECK: %Enum64 = type { i32, [31 x i32] }
+// CHECK: %"Enum64::A" = type { [8 x i64], %Align64 }
 
 // CHECK-LABEL: @align64
 #[no_mangle]

--- a/src/test/ui/layout/debug.stderr
+++ b/src/test/ui/layout/debug.stderr
@@ -8,6 +8,7 @@ error: layout_of(E) = Layout {
         memory_index: [
             0,
         ],
+        padded_indices: None,
     },
     variants: Multiple {
         discr: Scalar {
@@ -24,6 +25,7 @@ error: layout_of(E) = Layout {
                 fields: Arbitrary {
                     offsets: [],
                     memory_index: [],
+                    padded_indices: None,
                 },
                 variants: Single {
                     index: 0,
@@ -60,6 +62,16 @@ error: layout_of(E) = Layout {
                         1,
                         2,
                     ],
+                    padded_indices: Some(
+                        (
+                            4,
+                            [
+                                1,
+                                2,
+                                3,
+                            ],
+                        ),
+                    ),
                 },
                 variants: Single {
                     index: 1,
@@ -128,6 +140,16 @@ error: layout_of(S) = Layout {
             0,
             2,
         ],
+        padded_indices: Some(
+            (
+                3,
+                [
+                    1,
+                    0,
+                    2,
+                ],
+            ),
+        ),
     },
     variants: Single {
         index: 0,
@@ -200,6 +222,7 @@ error: layout_of(std::result::Result<i32, i32>) = Layout {
         memory_index: [
             0,
         ],
+        padded_indices: None,
     },
     variants: Multiple {
         discr: Scalar {
@@ -222,6 +245,14 @@ error: layout_of(std::result::Result<i32, i32>) = Layout {
                     memory_index: [
                         0,
                     ],
+                    padded_indices: Some(
+                        (
+                            2,
+                            [
+                                1,
+                            ],
+                        ),
+                    ),
                 },
                 variants: Single {
                     index: 0,
@@ -250,6 +281,14 @@ error: layout_of(std::result::Result<i32, i32>) = Layout {
                     memory_index: [
                         0,
                     ],
+                    padded_indices: Some(
+                        (
+                            2,
+                            [
+                                1,
+                            ],
+                        ),
+                    ),
                 },
                 variants: Single {
                     index: 1,


### PR DESCRIPTION
Previously, we would include an array in between every structure member + another before the first member. The vast majority of the time these array types would be zero sized, and would serve no purpose to LLVM, as we already ensure proper member alignment.

This change *might* be faster, due to fewer structure members, but I didn't bench.

(Zero length arrays are disallowed in SPIR-V. Avoiding them here is slightly easier than trying to patch things up on the LLVM side.)