### PR TITLE
Add test for old compiler ICE when using `Borrow`

### DIFF
--- a/src/test/ui/issues/issue-50687-ice-on-borrow.rs
+++ b/src/test/ui/issues/issue-50687-ice-on-borrow.rs
@@ -1,0 +1,41 @@
+// This previously caused an ICE at:
+// librustc/traits/structural_impls.rs:180: impossible case reached
+
+#![no_main]
+
+use std::borrow::Borrow;
+use std::io;
+use std::io::Write;
+
+trait Constraint {}
+
+struct Container<T> {
+    t: T,
+}
+
+struct Borrowed;
+struct Owned;
+
+impl<'a, T> Write for &'a Container<T>
+where
+    T: Constraint,
+    &'a T: Write,
+{
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl Borrow<Borrowed> for Owned {
+    fn borrow(&self) -> &Borrowed {
+        &Borrowed
+    }
+}
+
+fn func(owned: Owned) {
+    let _: () = Borrow::borrow(&owned); //~ ERROR mismatched types
+}

--- a/src/test/ui/issues/issue-50687-ice-on-borrow.stderr
+++ b/src/test/ui/issues/issue-50687-ice-on-borrow.stderr
@@ -1,0 +1,16 @@
+error[E0308]: mismatched types
+  --> $DIR/issue-50687-ice-on-borrow.rs:40:17
+   |
+LL |     let _: () = Borrow::borrow(&owned);
+   |            --   ^^^^^^^^^^^^^^^^^^^^^^
+   |            |    |
+   |            |    expected `()`, found reference
+   |            |    help: consider dereferencing the borrow: `*Borrow::borrow(&owned)`
+   |            expected due to this
+   |
+   = note: expected unit type `()`
+              found reference `&_`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
The original issue was caused by implementing `Borrow` on a local type and using the tokio-reactor crate which had this impl: https://github.com/tokio-rs/tokio/blob/tokio-0.1.4/tokio-reactor/src/poll_evented.rs#L547-L577

This causes an ICE on Rust 1.27.0:

```console
$ RUSTUP_TOOLCHAIN=1.27.0 rustc src/test/ui/issues/issue-50687-ice-on-borrow.rs
error: internal compiler error: librustc/traits/structural_impls.rs:180: impossible case reached

thread 'main' panicked at 'Box<Any>', librustc_errors/lib.rs:554:9
note: Run with `RUST_BACKTRACE=1` for a backtrace.
error: aborting due to previous error


note: the compiler unexpectedly panicked. this is a bug.

note: we would appreciate a bug report: https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md#bug-reports

note: rustc 1.27.0 (3eda71b00 2018-06-19) running on x86_64-apple-darwin
```

Closes #50687