### PR TITLE
First draft documenting Debug stability.

### DIFF
--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -441,6 +441,13 @@ impl Display for Arguments<'_> {
 /// `enum`s, it will use the name of the variant and, if applicable, `(`, then the
 /// `Debug` values of the fields, then `)`.
 ///
+/// # Stability
+///
+/// Derived `Debug` formats are not stable, and so may change with future Rust
+/// versions. Additionally, `Debug` implementations of types provided by the
+/// standard library (`libstd`, `libcore`, `liballoc`, etc.) are not stable, and
+/// may also change with future Rust versions.
+///
 /// # Examples
 ///
 /// Deriving an implementation:


### PR DESCRIPTION
Debug implementations of std types aren't stable, and neither are derived Debug implementations for any types, including user-defined types. This commit adds a section to the Debug documentation noting this stability status.

This issue is tracked by #62794.