### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/src/librustc_error_codes/error_codes/E0601.md
+++ b/src/librustc_error_codes/error_codes/E0601.md
@@ -1,5 +1,6 @@
-No `main` function was found in a binary crate. To fix this error, add a
-`main` function. For example:
+No `main` function was found in a binary crate.
+
+To fix this error, add a `main` function:
 
 ```
 fn main() {

--- a/src/librustc_mir/interpret/cast.rs
+++ b/src/librustc_mir/interpret/cast.rs
@@ -189,7 +189,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
         cast_ty: Ty<'tcx>,
     ) -> Scalar<M::PointerTag> {
         // Let's make sure v is sign-extended *if* it has a signed type.
-        let signed = src_layout.abi.is_signed(); // also checks that abi is `Scalar`.
+        let signed = src_layout.abi.is_signed(); // Also asserts that abi is `Scalar`.
         let v = if signed { self.sign_extend(v, src_layout) } else { v };
         trace!("cast_from_scalar: {}, {} -> {}", v, src_layout.ty, cast_ty);
         use rustc_middle::ty::TyKind::*;

--- a/src/librustc_mir/interpret/step.rs
+++ b/src/librustc_mir/interpret/step.rs
@@ -253,9 +253,10 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 self.write_scalar(Scalar::from_machine_usize(layout.size.bytes(), self), dest)?;
             }
 
-            Cast(kind, ref operand, _) => {
+            Cast(cast_kind, ref operand, cast_ty) => {
                 let src = self.eval_operand(operand, None)?;
-                self.cast(src, kind, dest)?;
+                let cast_ty = self.subst_from_current_frame_and_normalize_erasing_regions(cast_ty);
+                self.cast(src, cast_kind, cast_ty, dest)?;
             }
 
             Discriminant(place) => {

--- a/src/librustc_passes/liveness.rs
+++ b/src/librustc_passes/liveness.rs
@@ -1460,26 +1460,20 @@ fn check_expr<'tcx>(this: &mut Liveness<'_, 'tcx>, expr: &'tcx Expr<'tcx>) {
         hir::ExprKind::InlineAsm(ref asm) => {
             for op in asm.operands {
                 match op {
-                    hir::InlineAsmOperand::In { expr, .. }
-                    | hir::InlineAsmOperand::Const { expr, .. }
-                    | hir::InlineAsmOperand::Sym { expr, .. } => this.visit_expr(expr),
                     hir::InlineAsmOperand::Out { expr, .. } => {
                         if let Some(expr) = expr {
                             this.check_place(expr);
-                            this.visit_expr(expr);
                         }
                     }
                     hir::InlineAsmOperand::InOut { expr, .. } => {
                         this.check_place(expr);
-                        this.visit_expr(expr);
                     }
-                    hir::InlineAsmOperand::SplitInOut { in_expr, out_expr, .. } => {
-                        this.visit_expr(in_expr);
+                    hir::InlineAsmOperand::SplitInOut { out_expr, .. } => {
                         if let Some(out_expr) = out_expr {
                             this.check_place(out_expr);
-                            this.visit_expr(out_expr);
                         }
                     }
+                    _ => {}
                 }
             }
         }

--- a/src/libstd/process.rs
+++ b/src/libstd/process.rs
@@ -2105,8 +2105,8 @@ mod tests {
     }
 
     #[test]
-    fn test_command_implements_send() {
-        fn take_send_type<T: Send>(_: T) {}
-        take_send_type(Command::new(""))
+    fn test_command_implements_send_sync() {
+        fn take_send_sync_type<T: Send + Sync>(_: T) {}
+        take_send_sync_type(Command::new(""))
     }
 }

--- a/src/libstd/sys/unix/process/process_common.rs
+++ b/src/libstd/sys/unix/process/process_common.rs
@@ -86,11 +86,13 @@ pub struct Command {
     stderr: Option<Stdio>,
 }
 
-// Create a new type for argv, so that we can make it `Send`
+// Create a new type for argv, so that we can make it `Send` and `Sync`
 struct Argv(Vec<*const c_char>);
 
-// It is safe to make Argv Send, because it contains pointers to memory owned by `Command.args`
+// It is safe to make `Argv` `Send` and `Sync`, because it contains
+// pointers to memory owned by `Command.args`
 unsafe impl Send for Argv {}
+unsafe impl Sync for Argv {}
 
 // passed back to std::process with the pipes connected to the child, if any
 // were requested

--- a/src/libstd/sys/vxworks/process/process_common.rs
+++ b/src/libstd/sys/vxworks/process/process_common.rs
@@ -49,11 +49,13 @@ pub struct Command {
     stderr: Option<Stdio>,
 }
 
-// Create a new type for argv, so that we can make it `Send`
+// Create a new type for `Argv`, so that we can make it `Send` and `Sync`
 struct Argv(Vec<*const c_char>);
 
-// It is safe to make Argv Send, because it contains pointers to memory owned by `Command.args`
+// It is safe to make `Argv` `Send` and `Sync`, because it contains
+// pointers to memory owned by `Command.args`
 unsafe impl Send for Argv {}
+unsafe impl Sync for Argv {}
 
 // passed back to std::process with the pipes connected to the child, if any
 // were requested


### PR DESCRIPTION
Successful merges:

 - #72472 (Implement `Sync` for `process::Command on unix and vxworks)
 - #72495 (Improve E0601 explanation)
 - #72525 (Miri casts: do not blindly rely on dest type)
 - #72537 (Fix InlineAsmOperand expresions being visited twice during liveness checking)

Failed merges:


r? @ghost