### PR TITLE
Fix trait alias inherent impl resolution

### DIFF
--- a/src/librustc_typeck/check/method/probe.rs
+++ b/src/librustc_typeck/check/method/probe.rs
@@ -795,6 +795,7 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
 
     fn assemble_inherent_candidates_from_param(&mut self, param_ty: ty::ParamTy) {
         // FIXME: do we want to commit to this behavior for param bounds?
+        debug!("assemble_inherent_candidates_from_param(param_ty={:?})", param_ty);
 
         let bounds = self.param_env.caller_bounds.iter().filter_map(|predicate| match *predicate {
             ty::Predicate::Trait(ref trait_predicate, _) => {
@@ -949,7 +950,7 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
                         import_ids: import_ids.clone(),
                         kind: TraitCandidate(new_trait_ref),
                     },
-                    true,
+                    false,
                 );
             });
         } else {

--- a/src/test/ui/traits/trait-alias/issue-60021-assoc-method-resolve.rs
+++ b/src/test/ui/traits/trait-alias/issue-60021-assoc-method-resolve.rs
@@ -1,0 +1,19 @@
+// check-pass
+
+#![feature(trait_alias)]
+
+trait SomeTrait {
+    fn map(&self) {}
+}
+
+impl<T> SomeTrait for Option<T> {}
+
+trait SomeAlias = SomeTrait;
+
+fn main() {
+    let x = Some(123);
+    // This should resolve to the trait impl for Option
+    Option::map(x, |z| z);
+    // This should resolve to the trait impl for SomeTrait
+    SomeTrait::map(&x);
+}

--- a/src/test/ui/traits/trait-alias/issue-72415-assoc-const-resolve.rs
+++ b/src/test/ui/traits/trait-alias/issue-72415-assoc-const-resolve.rs
@@ -1,0 +1,14 @@
+// check-pass
+
+#![feature(trait_alias)]
+
+trait Bounded { const MAX: Self; }
+
+impl Bounded for u32 {
+    // This should correctly resolve to the associated const in the inherent impl of u32.
+    const MAX: Self = u32::MAX;
+}
+
+trait Num = Bounded + Copy;
+
+fn main() {}


### PR DESCRIPTION
Fixes #60021 and fixes #72415.

Obviously, the fix was very easy, but getting started with the testing and debugging rust compiler was an interesting experience. Now I can cross it off my bucket list!