### PR TITLE
Optional too optional, apparently

### DIFF
--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -3,12 +3,14 @@
 	font-family: 'Fira Sans';
 	font-style: normal;
 	font-weight: 400;
+	font-display: swap;
 	src: local('Fira Sans'), url("FiraSans-Regular.woff") format('woff');
 }
 @font-face {
 	font-family: 'Fira Sans';
 	font-style: normal;
 	font-weight: 500;
+	font-display: swap;
 	src: local('Fira Sans Medium'), url("FiraSans-Medium.woff") format('woff');
 }
 
@@ -17,18 +19,21 @@
 	font-family: 'Source Serif Pro';
 	font-style: normal;
 	font-weight: 400;
+	font-display: fallback;
 	src: local('Source Serif Pro'), url("SourceSerifPro-Regular.ttf.woff") format('woff');
 }
 @font-face {
 	font-family: 'Source Serif Pro';
 	font-style: italic;
 	font-weight: 400;
+	font-display: fallback;
 	src: local('Source Serif Pro Italic'), url("SourceSerifPro-It.ttf.woff") format('woff');
 }
 @font-face {
 	font-family: 'Source Serif Pro';
 	font-style: normal;
 	font-weight: 700;
+	font-display: fallback;
 	src: local('Source Serif Pro Bold'), url("SourceSerifPro-Bold.ttf.woff") format('woff');
 }
 
@@ -37,6 +42,7 @@
 	font-family: 'Source Code Pro';
 	font-style: normal;
 	font-weight: 400;
+	font-display: fallback;
 	/* Avoid using locally installed font because bad versions are in circulation:
 	 * see https://github.com/rust-lang/rust/issues/24355 */
 	src: url("SourceCodePro-Regular.woff") format('woff');
@@ -45,6 +51,7 @@
 	font-family: 'Source Code Pro';
 	font-style: normal;
 	font-weight: 600;
+	font-display: swap;
 	src: url("SourceCodePro-Semibold.woff") format('woff');
 }
 

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -10,7 +10,7 @@
 	font-family: 'Fira Sans';
 	font-style: normal;
 	font-weight: 500;
-	font-display: swap;
+	font-display: fallback;
 	src: local('Fira Sans Medium'), url("FiraSans-Medium.woff") format('woff');
 }
 
@@ -19,7 +19,9 @@
 	font-family: 'Source Serif Pro';
 	font-style: normal;
 	font-weight: 400;
-	font-display: fallback;
+	/* This is currently the base font for the entire cascade. It is important
+	 * that it loads in order for rustdoc to look even slightly correct. */
+	font-display: swap;
 	src: local('Source Serif Pro'), url("SourceSerifPro-Regular.ttf.woff") format('woff');
 }
 @font-face {
@@ -42,7 +44,7 @@
 	font-family: 'Source Code Pro';
 	font-style: normal;
 	font-weight: 400;
-	font-display: fallback;
+	font-display: swap;
 	/* Avoid using locally installed font because bad versions are in circulation:
 	 * see https://github.com/rust-lang/rust/issues/24355 */
 	src: url("SourceCodePro-Regular.woff") format('woff');
@@ -51,7 +53,7 @@
 	font-family: 'Source Code Pro';
 	font-style: normal;
 	font-weight: 600;
-	font-display: swap;
+	font-display: fallback;
 	src: url("SourceCodePro-Semibold.woff") format('woff');
 }
 


### PR DESCRIPTION
Local testing did not reveal that "optional" is incredibly eagerly skipped
if it involves network transit, so successive page loads didn't actually
load the fonts. "fallback" behaved as-predicted (success on next page
load). Some styles set to "swap" to guarantee better readability.

In a word: "Oops."
Partially backs off the change in #72092 