### PR TITLE
Implement associated lang items

### DIFF
--- a/src/libcore/ops/function.rs
+++ b/src/libcore/ops/function.rs
@@ -224,6 +224,7 @@ pub trait FnMut<Args>: FnOnce<Args> {
 #[must_use = "closures are lazy and do nothing unless called"]
 pub trait FnOnce<Args> {
     /// The returned type after the call operator is used.
+    #[cfg_attr(not(bootstrap), lang = "fn_once_output")]
     #[stable(feature = "fn_once_output", since = "1.12.0")]
     type Output;
 

--- a/src/librustc_hir/lang_items.rs
+++ b/src/librustc_hir/lang_items.rs
@@ -25,7 +25,7 @@ use lazy_static::lazy_static;
 // So you probably just want to nip down to the end.
 macro_rules! language_item_table {
     (
-        $( $variant:ident, $name:expr, $method:ident, $target:path; )*
+        $( $variant:ident, $name:expr, $method:ident, $target:expr; )*
     ) => {
 
         enum_from_u32! {
@@ -206,6 +206,8 @@ language_item_table! {
     FnTraitLangItem,             "fn",                 fn_trait,                Target::Trait;
     FnMutTraitLangItem,          "fn_mut",             fn_mut_trait,            Target::Trait;
     FnOnceTraitLangItem,         "fn_once",            fn_once_trait,           Target::Trait;
+
+    FnOnceOutputLangItem,        "fn_once_output",     fn_once_output,          Target::AssocTy;
 
     FutureTraitLangItem,         "future_trait",       future_trait,            Target::Trait;
     GeneratorStateLangItem,      "generator_state",    gen_state,               Target::Enum;

--- a/src/librustc_passes/check_attr.rs
+++ b/src/librustc_passes/check_attr.rs
@@ -21,7 +21,10 @@ use rustc_session::parse::feature_err;
 use rustc_span::symbol::sym;
 use rustc_span::Span;
 
-fn target_from_impl_item<'tcx>(tcx: TyCtxt<'tcx>, impl_item: &hir::ImplItem<'_>) -> Target {
+pub(crate) fn target_from_impl_item<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    impl_item: &hir::ImplItem<'_>,
+) -> Target {
     match impl_item.kind {
         hir::ImplItemKind::Const(..) => Target::AssocConst,
         hir::ImplItemKind::Fn(..) => {

--- a/src/test/ui/assoc-lang-items.rs
+++ b/src/test/ui/assoc-lang-items.rs
@@ -1,0 +1,21 @@
+#![feature(lang_items)]
+
+trait Foo {
+    #[lang = "dummy_lang_item_1"] //~ ERROR definition
+    fn foo() {}
+
+    #[lang = "dummy_lang_item_2"] //~ ERROR definition
+    fn bar();
+
+    #[lang = "dummy_lang_item_3"] //~ ERROR definition
+    type MyType;
+}
+
+struct Bar;
+
+impl Bar {
+    #[lang = "dummy_lang_item_4"] //~ ERROR definition
+    fn test() {}
+}
+
+fn main() {}

--- a/src/test/ui/assoc-lang-items.stderr
+++ b/src/test/ui/assoc-lang-items.stderr
@@ -1,0 +1,27 @@
+error[E0522]: definition of an unknown language item: `dummy_lang_item_1`
+  --> $DIR/assoc-lang-items.rs:4:5
+   |
+LL |     #[lang = "dummy_lang_item_1"]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition of unknown language item `dummy_lang_item_1`
+
+error[E0522]: definition of an unknown language item: `dummy_lang_item_2`
+  --> $DIR/assoc-lang-items.rs:7:5
+   |
+LL |     #[lang = "dummy_lang_item_2"]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition of unknown language item `dummy_lang_item_2`
+
+error[E0522]: definition of an unknown language item: `dummy_lang_item_3`
+  --> $DIR/assoc-lang-items.rs:10:5
+   |
+LL |     #[lang = "dummy_lang_item_3"]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition of unknown language item `dummy_lang_item_3`
+
+error[E0522]: definition of an unknown language item: `dummy_lang_item_4`
+  --> $DIR/assoc-lang-items.rs:17:5
+   |
+LL |     #[lang = "dummy_lang_item_4"]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition of unknown language item `dummy_lang_item_4`
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0522`.


### PR DESCRIPTION
Fixes #70718

This commit allows making associated items (e.g. associated functions
and types) into lang items via the `#[lang]` attribute. This allows such
items to be accessed directly, rather than by iterating over the parent
item's associated items.

I've added `FnOnce::Output` as a lang item, and updated one old usage to
use the new lang item. The remaining uses can be updated separately.