### PR TITLE
Enable `glacier` command via triagebot

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -10,6 +10,8 @@ allow-unauthenticated = [
 
 [assign]
 
+[glacier]
+
 [ping.icebreakers-llvm]
 alias = ["llvm", "llvms"]
 message = """\


### PR DESCRIPTION
I noticed this was required by https://github.com/rust-lang/rust/issues/72554#issuecomment-633393847.
