### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -441,6 +441,13 @@ impl Display for Arguments<'_> {
 /// `enum`s, it will use the name of the variant and, if applicable, `(`, then the
 /// `Debug` values of the fields, then `)`.
 ///
+/// # Stability
+///
+/// Derived `Debug` formats are not stable, and so may change with future Rust
+/// versions. Additionally, `Debug` implementations of types provided by the
+/// standard library (`libstd`, `libcore`, `liballoc`, etc.) are not stable, and
+/// may also change with future Rust versions.
+///
 /// # Examples
 ///
 /// Deriving an implementation:

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -87,6 +87,8 @@
 #![feature(const_generics)]
 #![feature(const_ptr_offset_from)]
 #![feature(const_result)]
+#![feature(const_slice_from_raw_parts)]
+#![feature(const_slice_ptr_len)]
 #![feature(const_type_name)]
 #![feature(custom_inner_attributes)]
 #![feature(decl_macro)]

--- a/src/libcore/ptr/non_null.rs
+++ b/src/libcore/ptr/non_null.rs
@@ -143,7 +143,7 @@ impl<T: ?Sized> NonNull<T> {
 }
 
 impl<T> NonNull<[T]> {
-    /// Create a non-null raw slice from a thin pointer and a length.
+    /// Creates a non-null raw slice from a thin pointer and a length.
     ///
     /// The `len` argument is the number of **elements**, not the number of bytes.
     ///
@@ -171,12 +171,12 @@ impl<T> NonNull<[T]> {
     #[unstable(feature = "nonnull_slice_from_raw_parts", issue = "71941")]
     #[rustc_const_unstable(feature = "const_nonnull_slice_from_raw_parts", issue = "71941")]
     #[inline]
-    pub const fn slice_from_raw_parts(data: NonNull<T>, size: usize) -> Self {
+    pub const fn slice_from_raw_parts(data: NonNull<T>, len: usize) -> Self {
         // SAFETY: `data` is a `NonNull` pointer which is necessarily non-null
-        unsafe { Self::new_unchecked(super::slice_from_raw_parts_mut(data.as_ptr(), size)) }
+        unsafe { Self::new_unchecked(super::slice_from_raw_parts_mut(data.as_ptr(), len)) }
     }
 
-    /// Return the length and a non-null raw slice.
+    /// Returns the length of a non-null raw slice.
     ///
     /// The returned value is the number of **elements**, not the number of bytes.
     ///

--- a/src/libcore/ptr/non_null.rs
+++ b/src/libcore/ptr/non_null.rs
@@ -142,6 +142,65 @@ impl<T: ?Sized> NonNull<T> {
     }
 }
 
+impl<T> NonNull<[T]> {
+    /// Create a non-null raw slice from a thin pointer and a length.
+    ///
+    /// The `len` argument is the number of **elements**, not the number of bytes.
+    ///
+    /// This function is safe, but dereferencing the return value is unsafe.
+    /// See the documentation of [`slice::from_raw_parts`] for slice safety requirements.
+    ///
+    /// [`slice::from_raw_parts`]: ../../std/slice/fn.from_raw_parts.html
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// #![feature(nonnull_slice_from_raw_parts)]
+    ///
+    /// use std::ptr::NonNull;
+    ///
+    /// // create a slice pointer when starting out with a pointer to the first element
+    /// let mut x = [5, 6, 7];
+    /// let nonnull_pointer = NonNull::new(x.as_mut_ptr()).unwrap();
+    /// let slice = NonNull::slice_from_raw_parts(nonnull_pointer, 3);
+    /// assert_eq!(unsafe { slice.as_ref()[2] }, 7);
+    /// ```
+    ///
+    /// (Note that this example artifically demonstrates a use of this method,
+    /// but `let slice = NonNull::from(&x[..]);` would be a better way to write code like this.)
+    #[unstable(feature = "nonnull_slice_from_raw_parts", issue = "71941")]
+    #[rustc_const_unstable(feature = "const_nonnull_slice_from_raw_parts", issue = "71941")]
+    #[inline]
+    pub const fn slice_from_raw_parts(data: NonNull<T>, size: usize) -> Self {
+        // SAFETY: `data` is a `NonNull` pointer which is necessarily non-null
+        unsafe { Self::new_unchecked(super::slice_from_raw_parts_mut(data.as_ptr(), size)) }
+    }
+
+    /// Return the length and a non-null raw slice.
+    ///
+    /// The returned value is the number of **elements**, not the number of bytes.
+    ///
+    /// This function is safe, even when the non-null raw slice cannot be dereferenced to a slice
+    /// because the pointer does not have a valid address.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// #![feature(slice_ptr_len, nonnull_slice_from_raw_parts)]
+    ///
+    /// use std::ptr::NonNull;
+    ///
+    /// let slice: NonNull<[i8]> = NonNull::slice_from_raw_parts(NonNull::dangling(), 3);
+    /// assert_eq!(slice.len(), 3);
+    /// ```
+    #[unstable(feature = "slice_ptr_len", issue = "71146")]
+    #[rustc_const_unstable(feature = "const_slice_ptr_len", issue = "71146")]
+    #[inline]
+    pub const fn len(self) -> usize {
+        self.as_ptr().len()
+    }
+}
+
 #[stable(feature = "nonnull", since = "1.25.0")]
 impl<T: ?Sized> Clone for NonNull<T> {
     #[inline]

--- a/src/librustc_middle/arena.rs
+++ b/src/librustc_middle/arena.rs
@@ -61,7 +61,7 @@ macro_rules! arena_types {
             [few] privacy_access_levels: rustc_middle::middle::privacy::AccessLevels,
             [few] foreign_module: rustc_middle::middle::cstore::ForeignModule,
             [few] foreign_modules: Vec<rustc_middle::middle::cstore::ForeignModule>,
-            [] upvars: rustc_data_structures::fx::FxIndexMap<rustc_hir::HirId, rustc_hir::Upvar>,
+            [] upvars_mentioned: rustc_data_structures::fx::FxIndexMap<rustc_hir::HirId, rustc_hir::Upvar>,
             [] object_safety_violations: rustc_middle::traits::ObjectSafetyViolation,
             [] codegen_unit: rustc_middle::mir::mono::CodegenUnit<$tcx>,
             [] attribute: rustc_ast::ast::Attribute,

--- a/src/librustc_middle/mir/mod.rs
+++ b/src/librustc_middle/mir/mod.rs
@@ -2439,7 +2439,7 @@ impl<'tcx> Debug for Rvalue<'tcx> {
                             };
                             let mut struct_fmt = fmt.debug_struct(&name);
 
-                            if let Some(upvars) = tcx.upvars(def_id) {
+                            if let Some(upvars) = tcx.upvars_mentioned(def_id) {
                                 for (&var_id, place) in upvars.keys().zip(places) {
                                     let var_name = tcx.hir().name(var_id);
                                     struct_fmt.field(&var_name.as_str(), place);
@@ -2458,7 +2458,7 @@ impl<'tcx> Debug for Rvalue<'tcx> {
                             let name = format!("[generator@{:?}]", tcx.hir().span(hir_id));
                             let mut struct_fmt = fmt.debug_struct(&name);
 
-                            if let Some(upvars) = tcx.upvars(def_id) {
+                            if let Some(upvars) = tcx.upvars_mentioned(def_id) {
                                 for (&var_id, place) in upvars.keys().zip(places) {
                                     let var_name = tcx.hir().name(var_id);
                                     struct_fmt.field(&var_name.as_str(), place);

--- a/src/librustc_middle/query/mod.rs
+++ b/src/librustc_middle/query/mod.rs
@@ -1040,7 +1040,7 @@ rustc_queries! {
             desc { "generating a postorder list of CrateNums" }
         }
 
-        query upvars(_: DefId) -> Option<&'tcx FxIndexMap<hir::HirId, hir::Upvar>> {
+        query upvars_mentioned(_: DefId) -> Option<&'tcx FxIndexMap<hir::HirId, hir::Upvar>> {
             eval_always
         }
         query maybe_unused_trait_import(def_id: LocalDefId) -> bool {

--- a/src/librustc_middle/ty/print/pretty.rs
+++ b/src/librustc_middle/ty/print/pretty.rs
@@ -611,7 +611,7 @@ pub trait PrettyPrinter<'tcx>:
                         let mut sep = " ";
                         for (&var_id, upvar_ty) in self
                             .tcx()
-                            .upvars(did)
+                            .upvars_mentioned(did)
                             .as_ref()
                             .iter()
                             .flat_map(|v| v.keys())
@@ -660,7 +660,7 @@ pub trait PrettyPrinter<'tcx>:
                         let mut sep = " ";
                         for (&var_id, upvar_ty) in self
                             .tcx()
-                            .upvars(did)
+                            .upvars_mentioned(did)
                             .as_ref()
                             .iter()
                             .flat_map(|v| v.keys())

--- a/src/librustc_mir/interpret/cast.rs
+++ b/src/librustc_mir/interpret/cast.rs
@@ -189,7 +189,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
         cast_ty: Ty<'tcx>,
     ) -> Scalar<M::PointerTag> {
         // Let's make sure v is sign-extended *if* it has a signed type.
-        let signed = src_layout.abi.is_signed(); // also checks that abi is `Scalar`.
+        let signed = src_layout.abi.is_signed(); // Also asserts that abi is `Scalar`.
         let v = if signed { self.sign_extend(v, src_layout) } else { v };
         trace!("cast_from_scalar: {}, {} -> {}", v, src_layout.ty, cast_ty);
         use rustc_middle::ty::TyKind::*;

--- a/src/librustc_mir/interpret/step.rs
+++ b/src/librustc_mir/interpret/step.rs
@@ -253,9 +253,10 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 self.write_scalar(Scalar::from_machine_usize(layout.size.bytes(), self), dest)?;
             }
 
-            Cast(kind, ref operand, _) => {
+            Cast(cast_kind, ref operand, cast_ty) => {
                 let src = self.eval_operand(operand, None)?;
-                self.cast(src, kind, dest)?;
+                let cast_ty = self.subst_from_current_frame_and_normalize_erasing_regions(cast_ty);
+                self.cast(src, cast_kind, cast_ty, dest)?;
             }
 
             Discriminant(place) => {

--- a/src/librustc_mir_build/hair/cx/expr.rs
+++ b/src/librustc_mir_build/hair/cx/expr.rs
@@ -386,7 +386,7 @@ fn make_mirror_unadjusted<'a, 'tcx>(
             };
             let upvars = cx
                 .tcx
-                .upvars(def_id)
+                .upvars_mentioned(def_id)
                 .iter()
                 .flat_map(|upvars| upvars.iter())
                 .zip(substs.upvar_tys())

--- a/src/librustc_passes/liveness.rs
+++ b/src/librustc_passes/liveness.rs
@@ -1460,26 +1460,20 @@ fn check_expr<'tcx>(this: &mut Liveness<'_, 'tcx>, expr: &'tcx Expr<'tcx>) {
         hir::ExprKind::InlineAsm(ref asm) => {
             for op in asm.operands {
                 match op {
-                    hir::InlineAsmOperand::In { expr, .. }
-                    | hir::InlineAsmOperand::Const { expr, .. }
-                    | hir::InlineAsmOperand::Sym { expr, .. } => this.visit_expr(expr),
                     hir::InlineAsmOperand::Out { expr, .. } => {
                         if let Some(expr) = expr {
                             this.check_place(expr);
-                            this.visit_expr(expr);
                         }
                     }
                     hir::InlineAsmOperand::InOut { expr, .. } => {
                         this.check_place(expr);
-                        this.visit_expr(expr);
                     }
-                    hir::InlineAsmOperand::SplitInOut { in_expr, out_expr, .. } => {
-                        this.visit_expr(in_expr);
+                    hir::InlineAsmOperand::SplitInOut { out_expr, .. } => {
                         if let Some(out_expr) = out_expr {
                             this.check_place(out_expr);
-                            this.visit_expr(out_expr);
                         }
                     }
+                    _ => {}
                 }
             }
         }

--- a/src/librustc_passes/liveness.rs
+++ b/src/librustc_passes/liveness.rs
@@ -463,7 +463,7 @@ fn visit_expr<'tcx>(ir: &mut IrMaps<'tcx>, expr: &'tcx Expr<'tcx>) {
         hir::ExprKind::Path(hir::QPath::Resolved(_, ref path)) => {
             debug!("expr {}: path that leads to {:?}", expr.hir_id, path.res);
             if let Res::Local(var_hir_id) = path.res {
-                let upvars = ir.tcx.upvars(ir.body_owner);
+                let upvars = ir.tcx.upvars_mentioned(ir.body_owner);
                 if !upvars.map_or(false, |upvars| upvars.contains_key(&var_hir_id)) {
                     ir.add_live_node_for_node(expr.hir_id, ExprNode(expr.span));
                 }
@@ -481,8 +481,8 @@ fn visit_expr<'tcx>(ir: &mut IrMaps<'tcx>, expr: &'tcx Expr<'tcx>) {
             // construction site.
             let mut call_caps = Vec::new();
             let closure_def_id = ir.tcx.hir().local_def_id(expr.hir_id);
-            if let Some(upvars) = ir.tcx.upvars(closure_def_id) {
-                let parent_upvars = ir.tcx.upvars(ir.body_owner);
+            if let Some(upvars) = ir.tcx.upvars_mentioned(closure_def_id) {
+                let parent_upvars = ir.tcx.upvars_mentioned(ir.body_owner);
                 call_caps.extend(upvars.iter().filter_map(|(&var_id, upvar)| {
                     let has_parent =
                         parent_upvars.map_or(false, |upvars| upvars.contains_key(&var_id));
@@ -1364,7 +1364,7 @@ impl<'a, 'tcx> Liveness<'a, 'tcx> {
     ) -> LiveNode {
         match path.res {
             Res::Local(hid) => {
-                let upvars = self.ir.tcx.upvars(self.ir.body_owner);
+                let upvars = self.ir.tcx.upvars_mentioned(self.ir.body_owner);
                 if !upvars.map_or(false, |upvars| upvars.contains_key(&hid)) {
                     self.access_var(hir_id, hid, succ, acc, path.span)
                 } else {
@@ -1535,7 +1535,7 @@ impl<'tcx> Liveness<'_, 'tcx> {
         match expr.kind {
             hir::ExprKind::Path(hir::QPath::Resolved(_, ref path)) => {
                 if let Res::Local(var_hid) = path.res {
-                    let upvars = self.ir.tcx.upvars(self.ir.body_owner);
+                    let upvars = self.ir.tcx.upvars_mentioned(self.ir.body_owner);
                     if !upvars.map_or(false, |upvars| upvars.contains_key(&var_hid)) {
                         // Assignment to an immutable variable or argument: only legal
                         // if there is no later assignment. If this local is actually

--- a/src/librustc_passes/upvars.rs
+++ b/src/librustc_passes/upvars.rs
@@ -10,7 +10,7 @@ use rustc_middle::ty::TyCtxt;
 use rustc_span::Span;
 
 pub fn provide(providers: &mut Providers<'_>) {
-    providers.upvars = |tcx, def_id| {
+    providers.upvars_mentioned = |tcx, def_id| {
         if !tcx.is_closure(def_id) {
             return None;
         }
@@ -89,7 +89,7 @@ impl Visitor<'tcx> for CaptureCollector<'a, 'tcx> {
     fn visit_expr(&mut self, expr: &'tcx hir::Expr<'tcx>) {
         if let hir::ExprKind::Closure(..) = expr.kind {
             let closure_def_id = self.tcx.hir().local_def_id(expr.hir_id);
-            if let Some(upvars) = self.tcx.upvars(closure_def_id) {
+            if let Some(upvars) = self.tcx.upvars_mentioned(closure_def_id) {
                 // Every capture of a closure expression is a local in scope,
                 // that is moved/copied/borrowed into the closure value, and
                 // for this analysis they are like any other access to a local.

--- a/src/librustc_trait_selection/traits/error_reporting/suggestions.rs
+++ b/src/librustc_trait_selection/traits/error_reporting/suggestions.rs
@@ -1380,7 +1380,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
         let mut interior_or_upvar_span = None;
         let mut interior_extra_info = None;
 
-        if let Some(upvars) = self.tcx.upvars(generator_did) {
+        if let Some(upvars) = self.tcx.upvars_mentioned(generator_did) {
             interior_or_upvar_span = upvars.iter().find_map(|(upvar_id, upvar)| {
                 let upvar_ty = tables.node_type(*upvar_id);
                 let upvar_ty = self.resolve_vars_if_possible(&upvar_ty);

--- a/src/librustc_typeck/check/closure.rs
+++ b/src/librustc_typeck/check/closure.rs
@@ -92,18 +92,20 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             base_substs.extend_to(self.tcx, expr_def_id.to_def_id(), |param, _| match param.kind {
                 GenericParamDefKind::Lifetime => span_bug!(expr.span, "closure has lifetime param"),
                 GenericParamDefKind::Type { .. } => if param.index as usize == tupled_upvars_idx {
-                    self.tcx.mk_tup(self.tcx.upvars(expr_def_id).iter().flat_map(|upvars| {
-                        upvars.iter().map(|(&var_hir_id, _)| {
-                            // Create type variables (for now) to represent the transformed
-                            // types of upvars. These will be unified during the upvar
-                            // inference phase (`upvar.rs`).
-                            self.infcx.next_ty_var(TypeVariableOrigin {
-                                // FIXME(eddyb) distinguish upvar inference variables from the rest.
-                                kind: TypeVariableOriginKind::ClosureSynthetic,
-                                span: self.tcx.hir().span(var_hir_id),
+                    self.tcx.mk_tup(self.tcx.upvars_mentioned(expr_def_id).iter().flat_map(
+                        |upvars| {
+                            upvars.iter().map(|(&var_hir_id, _)| {
+                                // Create type variables (for now) to represent the transformed
+                                // types of upvars. These will be unified during the upvar
+                                // inference phase (`upvar.rs`).
+                                self.infcx.next_ty_var(TypeVariableOrigin {
+                                    // FIXME(eddyb) distinguish upvar inference variables from the rest.
+                                    kind: TypeVariableOriginKind::ClosureSynthetic,
+                                    span: self.tcx.hir().span(var_hir_id),
+                                })
                             })
-                        })
-                    }))
+                        },
+                    ))
                 } else {
                     // Create type variables (for now) to represent the various
                     // pieces of information kept in `{Closure,Generic}Substs`.

--- a/src/librustc_typeck/check/upvar.rs
+++ b/src/librustc_typeck/check/upvar.rs
@@ -111,7 +111,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             None
         };
 
-        if let Some(upvars) = self.tcx.upvars(closure_def_id) {
+        if let Some(upvars) = self.tcx.upvars_mentioned(closure_def_id) {
             let mut upvar_list: FxIndexMap<hir::HirId, ty::UpvarId> =
                 FxIndexMap::with_capacity_and_hasher(upvars.len(), Default::default());
             for (&var_hir_id, _) in upvars.iter() {
@@ -218,7 +218,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let tcx = self.tcx;
         let closure_def_id = tcx.hir().local_def_id(closure_id);
 
-        tcx.upvars(closure_def_id)
+        tcx.upvars_mentioned(closure_def_id)
             .iter()
             .flat_map(|upvars| {
                 upvars.iter().map(|(&var_hir_id, _)| {

--- a/src/librustc_typeck/expr_use_visitor.rs
+++ b/src/librustc_typeck/expr_use_visitor.rs
@@ -539,7 +539,7 @@ impl<'a, 'tcx> ExprUseVisitor<'a, 'tcx> {
         debug!("walk_captures({:?})", closure_expr);
 
         let closure_def_id = self.tcx().hir().local_def_id(closure_expr.hir_id);
-        if let Some(upvars) = self.tcx().upvars(closure_def_id) {
+        if let Some(upvars) = self.tcx().upvars_mentioned(closure_def_id) {
             for &var_id in upvars.keys() {
                 let upvar_id = ty::UpvarId {
                     var_path: ty::UpvarPath { hir_id: var_id },

--- a/src/librustc_typeck/mem_categorization.rs
+++ b/src/librustc_typeck/mem_categorization.rs
@@ -159,7 +159,7 @@ impl<'a, 'tcx> MemCategorizationContext<'a, 'tcx> {
             infcx,
             param_env,
             body_owner,
-            upvars: infcx.tcx.upvars(body_owner),
+            upvars: infcx.tcx.upvars_mentioned(body_owner),
         }
     }
 


### PR DESCRIPTION
Successful merges:

 - #71940 (Add `len` and `slice_from_raw_parts` to `NonNull<[T]>`)
 - #72525 (Miri casts: do not blindly rely on dest type)
 - #72537 (Fix InlineAsmOperand expresions being visited twice during liveness checking)
 - #72544 (librustc_middle: Rename upvars query to upvars_mentioned)
 - #72551 (First draft documenting Debug stability.)

Failed merges:


r? @ghost