### PR TITLE
multiple Return terminators are possible

### DIFF
--- a/src/librustc_middle/mir/mod.rs
+++ b/src/librustc_middle/mir/mod.rs
@@ -1072,7 +1072,8 @@ pub enum TerminatorKind<'tcx> {
     Abort,
 
     /// Indicates a normal return. The return place should have
-    /// been filled in by now. This should occur at most once.
+    /// been filled in before this executes. This can occur multiple times
+    /// in different basic blocks.
     Return,
 
     /// Indicates a terminator that can never be reached.


### PR DESCRIPTION
@ecstatic-morse mentioned in https://github.com/rust-lang/rust/issues/72515 that multiple `Return` terminators are possible. Update the docs accordingly.

Cc @rust-lang/wg-mir-opt 