### PR TITLE
Allow unlabeled breaks from desugared `?` in labeled blocks

### DIFF
--- a/src/librustc_passes/loops.rs
+++ b/src/librustc_passes/loops.rs
@@ -9,6 +9,7 @@ use rustc_middle::hir::map::Map;
 use rustc_middle::ty::query::Providers;
 use rustc_middle::ty::TyCtxt;
 use rustc_session::Session;
+use rustc_span::hygiene::DesugaringKind;
 use rustc_span::Span;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -203,7 +204,7 @@ impl<'a, 'hir> CheckLoopVisitor<'a, 'hir> {
         label: &Destination,
         cf_type: &str,
     ) -> bool {
-        if self.cx == LabeledBlock {
+        if !span.is_desugaring(DesugaringKind::QuestionMark) && self.cx == LabeledBlock {
             if label.label.is_none() {
                 struct_span_err!(
                     self.sess,

--- a/src/test/ui/label/label_break_value_desugared_break.rs
+++ b/src/test/ui/label/label_break_value_desugared_break.rs
@@ -1,0 +1,12 @@
+// compile-flags: --edition 2018
+#![feature(label_break_value, try_blocks)]
+
+// run-pass
+fn main() {
+    let _: Result<(), ()> = try {
+        'foo: {
+            Err(())?;
+            break 'foo;
+        }
+    };
+}


### PR DESCRIPTION
`?` is desugared into a `break` targeting the innermost `try` scope in which it resides. The `break` however will not have a label. https://github.com/rust-lang/rust/blob/master/src/librustc_ast_lowering/expr.rs#L1560

Since the `target` of the `break` is known, the compiler should not complain about an unlabeled jump for `break`s desugared from `?`.

Closes https://github.com/rust-lang/rust/issues/72483