### PR TITLE
impl AsRef<[T]> for vec::IntoIter<T>

### DIFF
--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -2603,6 +2603,13 @@ impl<T> IntoIter<T> {
     }
 }
 
+#[stable(feature = "vec_intoiter_as_ref", since = "1.46.0")]
+impl<T> AsRef<[T]> for IntoIter<T> {
+    fn as_ref(&self) -> &[T] {
+        self.as_slice()
+    }
+}
+
 #[stable(feature = "rust1", since = "1.0.0")]
 unsafe impl<T: Send> Send for IntoIter<T> {}
 #[stable(feature = "rust1", since = "1.0.0")]


### PR DESCRIPTION
Adds `impl<T> AsRef<[T]> for vec::IntoIter<T>`. This mirrors the same trait impl for [`slice::Iter`](https://doc.rust-lang.org/nightly/std/slice/struct.Iter.html). Both types already offer `fn as_slice(&self) -> &[T]`, this just adds the trait impl for `vec::IntoIter`.

If/when `fn as_slice(&self) -> &[T]` stabilizes for `vec::Drain` and `slice::IterMut`, they should get `AsRef<[T]>` impls as well. As thus, tangentially related to #58957.

My ultimate goal here: being able to use `for<T, I: Iterator<Item=T> + AsRef<[T]>> I` to refer to `vec::IntoIter`, `vec::Drain`, and eventually `array::IntoIter`, as an approximation of the set of by-value iterators that can be "previewed" as by-ref iterators. (Actually expressing that as a trait requires GAT.)