### PR TITLE
Properly encode AnonConst into crate metadata

### DIFF
--- a/src/librustc_metadata/rmeta/decoder.rs
+++ b/src/librustc_metadata/rmeta/decoder.rs
@@ -564,6 +564,7 @@ impl MetadataBlob {
 impl EntryKind {
     fn def_kind(&self) -> DefKind {
         match *self {
+            EntryKind::AnonConst(..) => DefKind::AnonConst,
             EntryKind::Const(..) => DefKind::Const,
             EntryKind::AssocConst(..) => DefKind::AssocConst,
             EntryKind::ImmStatic
@@ -1121,7 +1122,8 @@ impl<'a, 'tcx> CrateMetadataRef<'a> {
 
     fn mir_const_qualif(&self, id: DefIndex) -> mir::ConstQualifs {
         match self.kind(id) {
-            EntryKind::Const(qualif, _)
+            EntryKind::AnonConst(qualif, _)
+            | EntryKind::Const(qualif, _)
             | EntryKind::AssocConst(
                 AssocContainer::ImplDefault
                 | AssocContainer::ImplFinal
@@ -1341,7 +1343,9 @@ impl<'a, 'tcx> CrateMetadataRef<'a> {
 
     fn get_rendered_const(&self, id: DefIndex) -> String {
         match self.kind(id) {
-            EntryKind::Const(_, data) | EntryKind::AssocConst(_, _, data) => data.decode(self).0,
+            EntryKind::AnonConst(_, data)
+            | EntryKind::Const(_, data)
+            | EntryKind::AssocConst(_, _, data) => data.decode(self).0,
             _ => bug!(),
         }
     }

--- a/src/librustc_metadata/rmeta/encoder.rs
+++ b/src/librustc_metadata/rmeta/encoder.rs
@@ -1342,7 +1342,7 @@ impl EncodeContext<'tcx> {
         let const_data = self.encode_rendered_const_for_body(body_id);
         let qualifs = self.tcx.mir_const_qualif(def_id);
 
-        record!(self.tables.kind[def_id.to_def_id()] <- EntryKind::Const(qualifs, const_data));
+        record!(self.tables.kind[def_id.to_def_id()] <- EntryKind::AnonConst(qualifs, const_data));
         record!(self.tables.visibility[def_id.to_def_id()] <- ty::Visibility::Public);
         record!(self.tables.span[def_id.to_def_id()] <- self.tcx.def_span(def_id));
         self.encode_item_type(def_id.to_def_id());

--- a/src/librustc_metadata/rmeta/mod.rs
+++ b/src/librustc_metadata/rmeta/mod.rs
@@ -281,6 +281,7 @@ define_tables! {
 
 #[derive(Copy, Clone, RustcEncodable, RustcDecodable)]
 enum EntryKind {
+    AnonConst(mir::ConstQualifs, Lazy<RenderedConst>),
     Const(mir::ConstQualifs, Lazy<RenderedConst>),
     ImmStatic,
     MutStatic,

--- a/src/test/ui/const-generics/auxiliary/impl-const.rs
+++ b/src/test/ui/const-generics/auxiliary/impl-const.rs
@@ -1,0 +1,9 @@
+#![feature(const_generics)]
+
+pub struct Num<const N: usize>;
+
+// Braces around const expression causes crash
+impl Num<{5}> {
+    pub fn five(&self) {
+    }
+}

--- a/src/test/ui/const-generics/issue-68104-print-stack-overflow.rs
+++ b/src/test/ui/const-generics/issue-68104-print-stack-overflow.rs
@@ -1,0 +1,14 @@
+// aux-build:impl-const.rs
+// run-pass
+
+#![feature(const_generics)]
+#![allow(incomplete_features)]
+
+extern crate impl_const;
+
+use impl_const::*;
+
+pub fn main() {
+    let n = Num::<5>;
+    n.five();
+}


### PR DESCRIPTION
Fixes #68104

Previous, we were encoding AnonConst as a regular Const, causing us to
treat them differently after being deserialized in another compilation
session.