### PR TITLE
Fix documentation example for gcov profiling

### DIFF
--- a/src/doc/unstable-book/src/compiler-flags/profile.md
+++ b/src/doc/unstable-book/src/compiler-flags/profile.md
@@ -12,10 +12,15 @@ For example:
 ```Bash
 cargo new testgcov --bin
 cd testgcov
-export RUSTFLAGS="-Zprofile"
+export RUSTFLAGS="-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort"
+export CARGO_INCREMENTAL=0
 cargo build
 cargo run
 ```
 
 Once you've built and run your program, files with the `gcno` (after build) and `gcda` (after execution) extensions will be created.
 You can parse them with [llvm-cov gcov](https://llvm.org/docs/CommandGuide/llvm-cov.html#llvm-cov-gcov) or [grcov](https://github.com/mozilla/grcov).
+
+Please note that `RUSTFLAGS` apply to everything that cargo builds and runs during a build, including build scripts!
+To avoid this, pass a `RUSTC_WRAPPER` program to cargo that only adds the profiling flags to rustc for the specific 
+crates you want to profile.

--- a/src/doc/unstable-book/src/compiler-flags/profile.md
+++ b/src/doc/unstable-book/src/compiler-flags/profile.md
@@ -21,6 +21,7 @@ cargo run
 Once you've built and run your program, files with the `gcno` (after build) and `gcda` (after execution) extensions will be created.
 You can parse them with [llvm-cov gcov](https://llvm.org/docs/CommandGuide/llvm-cov.html#llvm-cov-gcov) or [grcov](https://github.com/mozilla/grcov).
 
-Please note that `RUSTFLAGS` apply to everything that cargo builds and runs during a build, including build scripts!
-To avoid this, pass a `RUSTC_WRAPPER` program to cargo that only adds the profiling flags to rustc for the specific 
-crates you want to profile.
+Please note that `RUSTFLAGS` by default applies to everything that cargo builds and runs during a build!
+When the `--target` flag is explicitly passed to cargo, the `RUSTFLAGS` no longer apply to build scripts and procedural macros. 
+For more fine-grained control consider passing a `RUSTC_WRAPPER` program to cargo that only adds the profiling flags to 
+rustc for the specific crates you want to profile.


### PR DESCRIPTION
closes #72546 
Improves the documentation for the unstable Rustflag `-Zprofile` by:
- stating that Incremental compilation must be turned off.
- Adding the other `RUSTFLAGS` that should/need to be turned on (taken from [grcov documentation](https://github.com/mozilla/grcov#example-how-to-generate-gcda-files-for-a-rust-project))
- Mentioning `RUSTC_WRAPPER` to prevent everything getting instrumented.


r? @steveklabnik