### PR TITLE
Omit DW_AT_linkage_name when it is the same as DW_AT_name

### DIFF
--- a/src/librustc_codegen_llvm/debuginfo/metadata.rs
+++ b/src/librustc_codegen_llvm/debuginfo/metadata.rs
@@ -29,7 +29,6 @@ use rustc_hir::def::CtorKind;
 use rustc_hir::def_id::{CrateNum, DefId, LOCAL_CRATE};
 use rustc_index::vec::{Idx, IndexVec};
 use rustc_middle::ich::NodeIdHashingMode;
-use rustc_middle::middle::codegen_fn_attrs::CodegenFnAttrFlags;
 use rustc_middle::mir::interpret::truncate;
 use rustc_middle::mir::{self, Field, GeneratorLayout};
 use rustc_middle::ty::layout::{self, IntegerExt, PrimitiveExt, TyAndLayout};
@@ -2299,9 +2298,7 @@ pub fn create_global_var_metadata(cx: &CodegenCx<'ll, '_>, def_id: DefId, global
     }
 
     let tcx = cx.tcx;
-    let attrs = tcx.codegen_fn_attrs(def_id);
 
-    let no_mangle = attrs.flags.contains(CodegenFnAttrFlags::NO_MANGLE);
     // We may want to remove the namespace scope if we're in an extern block (see
     // https://github.com/rust-lang/rust/pull/46457#issuecomment-351750952).
     let var_scope = get_namespace_for_item(cx, def_id);
@@ -2318,14 +2315,11 @@ pub fn create_global_var_metadata(cx: &CodegenCx<'ll, '_>, def_id: DefId, global
     let variable_type = Instance::mono(cx.tcx, def_id).monomorphic_ty(cx.tcx);
     let type_metadata = type_metadata(cx, variable_type, span);
     let var_name = tcx.item_name(def_id).as_str();
-    let linkage_name = if no_mangle {
-        None
-    } else {
-        Some(mangled_name_of_instance(cx, Instance::mono(tcx, def_id)).name.as_str())
-    };
+    let linkage_name: &str =
+        &mangled_name_of_instance(cx, Instance::mono(tcx, def_id)).name.as_str();
     // When empty, linkage_name field is omitted,
     // which is what we want for no_mangle statics
-    let linkage_name = linkage_name.as_deref().unwrap_or("");
+    let linkage_name = if var_name == linkage_name { "" } else { linkage_name };
 
     let global_align = cx.align_of(variable_type);
 

--- a/src/librustc_codegen_llvm/debuginfo/mod.rs
+++ b/src/librustc_codegen_llvm/debuginfo/mod.rs
@@ -267,9 +267,9 @@ impl DebugInfoMethods<'tcx> for CodegenCx<'ll, 'tcx> {
         let substs = instance.substs.truncate_to(self.tcx(), generics);
         let template_parameters = get_template_parameters(self, &generics, substs, &mut name);
 
-        // Get the linkage_name, which is just the symbol name
-        let linkage_name = mangled_name_of_instance(self, instance);
-        let linkage_name = linkage_name.name.as_str();
+        let linkage_name: &str = &mangled_name_of_instance(self, instance).name.as_str();
+        // Omit the linkage_name if it is the same as subprogram name.
+        let linkage_name = if &name == linkage_name { "" } else { linkage_name };
 
         // FIXME(eddyb) does this need to be separate from `loc.line` for some reason?
         let scope_line = loc.line;

--- a/src/test/codegen/debug-linkage-name.rs
+++ b/src/test/codegen/debug-linkage-name.rs
@@ -1,0 +1,42 @@
+// Verifies that linkage name is omitted when it is
+// the same as variable / function name.
+//
+// compile-flags: -C no-prepopulate-passes
+// compile-flags: -C debuginfo=2
+#![crate_type = "lib"]
+
+pub mod xyz {
+    // CHECK: !DIGlobalVariable(name: "A",
+    // CHECK:                   linkageName:
+    // CHECK-SAME:              line: 12,
+    pub static A: u32 = 1;
+
+    // CHECK: !DIGlobalVariable(name: "B",
+    // CHECK-NOT:               linkageName:
+    // CHECK-SAME:              line: 18,
+    #[no_mangle]
+    pub static B: u32 = 2;
+
+    // CHECK: !DIGlobalVariable(name: "C",
+    // CHECK-NOT:               linkageName:
+    // CHECK-SAME:              line: 24,
+    #[export_name = "C"]
+    pub static C: u32 = 2;
+
+    // CHECK: !DISubprogram(name: "e",
+    // CHECK:               linkageName:
+    // CHECK-SAME:          line: 29,
+    pub extern fn e() {}
+
+    // CHECK: !DISubprogram(name: "f",
+    // CHECK-NOT:           linkageName:
+    // CHECK-SAME:          line: 35,
+    #[no_mangle]
+    pub extern fn f() {}
+
+    // CHECK: !DISubprogram(name: "g",
+    // CHECK-NOT:           linkageName:
+    // CHECK-SAME:          line: 41,
+    #[export_name = "g"]
+    pub extern fn g() {}
+}


### PR DESCRIPTION
The DWARF standard suggests that it might be useful to include
`DW_AT_linkage_name` when it is *distinct* from the identifier name.

Fixes #46487.
Fixes #59422.