### PR TITLE
ClosureSubsts/GeneratorSubsts refactoring

### DIFF
--- a/src/librustc_codegen_llvm/type_of.rs
+++ b/src/librustc_codegen_llvm/type_of.rs
@@ -70,10 +70,10 @@ fn uncached_llvm_type<'a, 'tcx>(
                     write!(&mut name, "::{}", def.variants[index].ident).unwrap();
                 }
             }
-            if let (&ty::Generator(_, substs, _), &Variants::Single { index })
+            if let (&ty::Generator(_, generator_substs, _), &Variants::Single { index })
                  = (&layout.ty.kind, &layout.variants)
             {
-                write!(&mut name, "::{}", substs.as_generator().variant_name(index)).unwrap();
+                write!(&mut name, "::{}", generator_substs.variant_name(index)).unwrap();
             }
             Some(name)
         }

--- a/src/librustc_codegen_ssa/mir/rvalue.rs
+++ b/src/librustc_codegen_ssa/mir/rvalue.rs
@@ -207,11 +207,11 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                     }
                     mir::CastKind::Pointer(PointerCast::ClosureFnPointer(_)) => {
                         match operand.layout.ty.kind {
-                            ty::Closure(def_id, substs) => {
+                            ty::Closure(def_id, closure_substs) => {
                                 let instance = Instance::resolve_closure(
                                     bx.cx().tcx(),
                                     def_id,
-                                    substs,
+                                    closure_substs,
                                     ty::ClosureKind::FnOnce,
                                 );
                                 OperandValue::Immediate(bx.cx().get_fn_addr(instance))

--- a/src/librustc_infer/infer/error_reporting/need_type_info.rs
+++ b/src/librustc_infer/infer/error_reporting/need_type_info.rs
@@ -318,8 +318,8 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
 
         let ty_msg = match (local_visitor.found_node_ty, local_visitor.found_exact_method_call) {
             (_, Some(_)) => String::new(),
-            (Some(ty::TyS { kind: ty::Closure(_, substs), .. }), _) => {
-                let fn_sig = substs.as_closure().sig();
+            (Some(ty::TyS { kind: ty::Closure(_, closure_substs), .. }), _) => {
+                let fn_sig = closure_substs.sig();
                 let args = closure_args(&fn_sig);
                 let ret = fn_sig.output().skip_binder().to_string();
                 format!(" for the closure `fn({}) -> {}`", args, ret)
@@ -352,8 +352,8 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
         );
 
         let suffix = match local_visitor.found_node_ty {
-            Some(ty::TyS { kind: ty::Closure(_, substs), .. }) => {
-                let fn_sig = substs.as_closure().sig();
+            Some(ty::TyS { kind: ty::Closure(_, closure_substs), .. }) => {
+                let fn_sig = closure_substs.sig();
                 let ret = fn_sig.output().skip_binder().to_string();
 
                 let closure_decl_and_body_id =

--- a/src/librustc_infer/infer/mod.rs
+++ b/src/librustc_infer/infer/mod.rs
@@ -29,7 +29,7 @@ use rustc_middle::ty::fold::{TypeFoldable, TypeFolder};
 use rustc_middle::ty::relate::RelateResult;
 use rustc_middle::ty::subst::{GenericArg, GenericArgKind, InternalSubsts, SubstsRef};
 pub use rustc_middle::ty::IntVarValue;
-use rustc_middle::ty::{self, GenericParamDefKind, InferConst, Ty, TyCtxt};
+use rustc_middle::ty::{self, ClosureSubsts, GenericParamDefKind, InferConst, Ty, TyCtxt};
 use rustc_middle::ty::{ConstVid, FloatVid, IntVid, TyVid};
 use rustc_session::config::BorrowckMode;
 use rustc_span::symbol::Symbol;
@@ -1545,8 +1545,8 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
     /// Obtains the latest type of the given closure; this may be a
     /// closure in the current function, in which case its
     /// `ClosureKind` may not yet be known.
-    pub fn closure_kind(&self, closure_substs: SubstsRef<'tcx>) -> Option<ty::ClosureKind> {
-        let closure_kind_ty = closure_substs.as_closure().kind_ty();
+    pub fn closure_kind(&self, closure_substs: ClosureSubsts<'tcx>) -> Option<ty::ClosureKind> {
+        let closure_kind_ty = closure_substs.kind_ty();
         let closure_kind_ty = self.shallow_resolve(closure_kind_ty);
         closure_kind_ty.to_opt_closure_kind()
     }

--- a/src/librustc_metadata/rmeta/encoder.rs
+++ b/src/librustc_metadata/rmeta/encoder.rs
@@ -1329,8 +1329,8 @@ impl EncodeContext<'tcx> {
         record!(self.tables.span[def_id.to_def_id()] <- self.tcx.def_span(def_id));
         record!(self.tables.attributes[def_id.to_def_id()] <- &self.tcx.get_attrs(def_id.to_def_id())[..]);
         self.encode_item_type(def_id.to_def_id());
-        if let ty::Closure(def_id, substs) = ty.kind {
-            record!(self.tables.fn_sig[def_id] <- substs.as_closure().sig());
+        if let ty::Closure(def_id, closure_substs) = ty.kind {
+            record!(self.tables.fn_sig[def_id] <- closure_substs.sig());
         }
         self.encode_generics(def_id.to_def_id());
         self.encode_optimized_mir(def_id);

--- a/src/librustc_middle/mir/tcx.rs
+++ b/src/librustc_middle/mir/tcx.rs
@@ -178,7 +178,7 @@ impl<'tcx> Rvalue<'tcx> {
                 let ty = place.ty(local_decls, tcx).ty;
                 match ty.kind {
                     ty::Adt(adt_def, _) => adt_def.repr.discr_type().to_ty(tcx),
-                    ty::Generator(_, substs, _) => substs.as_generator().discr_ty(tcx),
+                    ty::Generator(_, generator_substs, _) => generator_substs.discr_ty(tcx),
                     _ => {
                         // This can only be `0`, for now, so `u8` will suffice.
                         tcx.types.u8
@@ -191,9 +191,9 @@ impl<'tcx> Rvalue<'tcx> {
                 AggregateKind::Array(ty) => tcx.mk_array(ty, ops.len() as u64),
                 AggregateKind::Tuple => tcx.mk_tup(ops.iter().map(|op| op.ty(local_decls, tcx))),
                 AggregateKind::Adt(def, _, substs, _, _) => tcx.type_of(def.did).subst(tcx, substs),
-                AggregateKind::Closure(did, substs) => tcx.mk_closure(did, substs),
-                AggregateKind::Generator(did, substs, movability) => {
-                    tcx.mk_generator(did, substs, movability)
+                AggregateKind::Closure(did, closure_substs) => tcx.mk_closure(did, closure_substs),
+                AggregateKind::Generator(did, generator_substs, movability) => {
+                    tcx.mk_generator(did, generator_substs, movability)
                 }
             },
         }

--- a/src/librustc_middle/mir/visit.rs
+++ b/src/librustc_middle/mir/visit.rs
@@ -684,16 +684,16 @@ macro_rules! make_mir_visitor {
                             }
                             AggregateKind::Closure(
                                 _,
-                                closure_substs
+                                ClosureSubsts { substs }
                             ) => {
-                                self.visit_substs(closure_substs, location);
+                                self.visit_substs(substs, location);
                             }
                             AggregateKind::Generator(
                                 _,
-                                generator_substs,
+                                GeneratorSubsts { substs },
                                 _movability,
                             ) => {
-                                self.visit_substs(generator_substs, location);
+                                self.visit_substs(substs, location);
                             }
                         }
 

--- a/src/librustc_middle/traits/mod.rs
+++ b/src/librustc_middle/traits/mod.rs
@@ -11,7 +11,7 @@ mod structural_impls;
 use crate::infer::canonical::Canonical;
 use crate::mir::interpret::ErrorHandled;
 use crate::ty::subst::SubstsRef;
-use crate::ty::{self, AdtKind, Ty, TyCtxt};
+use crate::ty::{self, AdtKind, ClosureSubsts, GeneratorSubsts, Ty, TyCtxt};
 
 use rustc_hir as hir;
 use rustc_hir::def_id::DefId;
@@ -472,12 +472,12 @@ impl<'tcx, N> Vtable<'tcx, N> {
             }),
             VtableClosure(c) => VtableClosure(VtableClosureData {
                 closure_def_id: c.closure_def_id,
-                substs: c.substs,
+                closure_substs: c.closure_substs,
                 nested: c.nested.into_iter().map(f).collect(),
             }),
             VtableGenerator(c) => VtableGenerator(VtableGeneratorData {
                 generator_def_id: c.generator_def_id,
-                substs: c.substs,
+                generator_substs: c.generator_substs,
                 nested: c.nested.into_iter().map(f).collect(),
             }),
             VtableFnPointer(p) => VtableFnPointer(VtableFnPointerData {
@@ -513,7 +513,7 @@ pub struct VtableImplData<'tcx, N> {
 #[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, HashStable, TypeFoldable)]
 pub struct VtableGeneratorData<'tcx, N> {
     pub generator_def_id: DefId,
-    pub substs: SubstsRef<'tcx>,
+    pub generator_substs: GeneratorSubsts<'tcx>,
     /// Nested obligations. This can be non-empty if the generator
     /// signature contains associated types.
     pub nested: Vec<N>,
@@ -522,7 +522,7 @@ pub struct VtableGeneratorData<'tcx, N> {
 #[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, HashStable, TypeFoldable)]
 pub struct VtableClosureData<'tcx, N> {
     pub closure_def_id: DefId,
-    pub substs: SubstsRef<'tcx>,
+    pub closure_substs: ClosureSubsts<'tcx>,
     /// Nested obligations. This can be non-empty if the closure
     /// signature contains associated types.
     pub nested: Vec<N>,

--- a/src/librustc_middle/traits/query.rs
+++ b/src/librustc_middle/traits/query.rs
@@ -229,8 +229,8 @@ pub fn trivial_dropck_outlives<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> bool {
         // (T1..Tn) and closures have same properties as T1..Tn --
         // check if *any* of those are trivial.
         ty::Tuple(ref tys) => tys.iter().all(|t| trivial_dropck_outlives(tcx, t.expect_ty())),
-        ty::Closure(_, ref substs) => {
-            substs.as_closure().upvar_tys().all(|t| trivial_dropck_outlives(tcx, t))
+        ty::Closure(_, ref closure_substs) => {
+            closure_substs.upvar_tys().all(|t| trivial_dropck_outlives(tcx, t))
         }
 
         ty::Adt(def, _) => {

--- a/src/librustc_middle/traits/structural_impls.rs
+++ b/src/librustc_middle/traits/structural_impls.rs
@@ -45,7 +45,7 @@ impl<'tcx, N: fmt::Debug> fmt::Debug for traits::VtableGeneratorData<'tcx, N> {
         write!(
             f,
             "VtableGeneratorData(generator_def_id={:?}, substs={:?}, nested={:?})",
-            self.generator_def_id, self.substs, self.nested
+            self.generator_def_id, self.generator_substs, self.nested
         )
     }
 }
@@ -55,7 +55,7 @@ impl<'tcx, N: fmt::Debug> fmt::Debug for traits::VtableClosureData<'tcx, N> {
         write!(
             f,
             "VtableClosureData(closure_def_id={:?}, substs={:?}, nested={:?})",
-            self.closure_def_id, self.substs, self.nested
+            self.closure_def_id, self.closure_substs, self.nested
         )
     }
 }
@@ -251,24 +251,26 @@ impl<'a, 'tcx> Lift<'tcx> for traits::Vtable<'a, ()> {
             traits::VtableAutoImpl(t) => Some(traits::VtableAutoImpl(t)),
             traits::VtableGenerator(traits::VtableGeneratorData {
                 generator_def_id,
-                substs,
+                generator_substs,
                 nested,
-            }) => tcx.lift(&substs).map(|substs| {
+            }) => tcx.lift(&generator_substs).map(|generator_substs| {
                 traits::VtableGenerator(traits::VtableGeneratorData {
                     generator_def_id,
-                    substs,
+                    generator_substs,
                     nested,
                 })
             }),
-            traits::VtableClosure(traits::VtableClosureData { closure_def_id, substs, nested }) => {
-                tcx.lift(&substs).map(|substs| {
-                    traits::VtableClosure(traits::VtableClosureData {
-                        closure_def_id,
-                        substs,
-                        nested,
-                    })
+            traits::VtableClosure(traits::VtableClosureData {
+                closure_def_id,
+                closure_substs,
+                nested,
+            }) => tcx.lift(&closure_substs).map(|closure_substs| {
+                traits::VtableClosure(traits::VtableClosureData {
+                    closure_def_id,
+                    closure_substs,
+                    nested,
                 })
-            }
+            }),
             traits::VtableFnPointer(traits::VtableFnPointerData { fn_ty, nested }) => {
                 tcx.lift(&fn_ty).map(|fn_ty| {
                     traits::VtableFnPointer(traits::VtableFnPointerData { fn_ty, nested })

--- a/src/librustc_middle/ty/context.rs
+++ b/src/librustc_middle/ty/context.rs
@@ -28,6 +28,7 @@ use crate::ty::TyKind::*;
 use crate::ty::{self, DefIdTree, Ty, TypeAndMut};
 use crate::ty::{AdtDef, AdtKind, Const, Region};
 use crate::ty::{BindingMode, BoundVar};
+use crate::ty::{ClosureSubsts, GeneratorSubsts};
 use crate::ty::{ConstVid, FloatVar, FloatVid, IntVar, IntVid, TyVar, TyVid};
 use crate::ty::{ExistentialPredicate, InferTy, ParamTy, PolyFnSig, Predicate, ProjectionTy};
 use crate::ty::{InferConst, ParamConst};
@@ -2289,7 +2290,7 @@ impl<'tcx> TyCtxt<'tcx> {
     }
 
     #[inline]
-    pub fn mk_closure(self, closure_id: DefId, closure_substs: SubstsRef<'tcx>) -> Ty<'tcx> {
+    pub fn mk_closure(self, closure_id: DefId, closure_substs: ClosureSubsts<'tcx>) -> Ty<'tcx> {
         self.mk_ty(Closure(closure_id, closure_substs))
     }
 
@@ -2297,7 +2298,7 @@ impl<'tcx> TyCtxt<'tcx> {
     pub fn mk_generator(
         self,
         id: DefId,
-        generator_substs: SubstsRef<'tcx>,
+        generator_substs: GeneratorSubsts<'tcx>,
         movability: hir::Movability,
     ) -> Ty<'tcx> {
         self.mk_ty(Generator(id, generator_substs, movability))

--- a/src/librustc_middle/ty/flags.rs
+++ b/src/librustc_middle/ty/flags.rs
@@ -1,5 +1,5 @@
 use crate::ty::subst::{GenericArg, GenericArgKind};
-use crate::ty::{self, InferConst, Ty, TypeFlags};
+use crate::ty::{self, ClosureSubsts, GeneratorSubsts, InferConst, Ty, TypeFlags};
 
 #[derive(Debug)]
 pub struct FlagComputation {
@@ -77,7 +77,7 @@ impl FlagComputation {
                 self.add_flags(TypeFlags::STILL_FURTHER_SPECIALIZABLE);
             }
 
-            &ty::Generator(_, ref substs, _) => {
+            &ty::Generator(_, GeneratorSubsts { ref substs }, _) => {
                 self.add_substs(substs);
             }
 
@@ -87,7 +87,7 @@ impl FlagComputation {
                 self.add_bound_computation(&computation);
             }
 
-            &ty::Closure(_, ref substs) => {
+            &ty::Closure(_, ClosureSubsts { ref substs }) => {
                 self.add_substs(substs);
             }
 

--- a/src/librustc_middle/ty/instance.rs
+++ b/src/librustc_middle/ty/instance.rs
@@ -352,14 +352,14 @@ impl<'tcx> Instance<'tcx> {
     pub fn resolve_closure(
         tcx: TyCtxt<'tcx>,
         def_id: DefId,
-        substs: ty::SubstsRef<'tcx>,
+        closure_substs: ty::ClosureSubsts<'tcx>,
         requested_kind: ty::ClosureKind,
     ) -> Instance<'tcx> {
-        let actual_kind = substs.as_closure().kind();
+        let actual_kind = closure_substs.kind();
 
         match needs_fn_once_adapter_shim(actual_kind, requested_kind) {
-            Ok(true) => Instance::fn_once_adapter_instance(tcx, def_id, substs),
-            _ => Instance::new(def_id, substs),
+            Ok(true) => Instance::fn_once_adapter_instance(tcx, def_id, closure_substs),
+            _ => Instance::new(def_id, closure_substs.substs),
         }
     }
 
@@ -372,9 +372,9 @@ impl<'tcx> Instance<'tcx> {
     pub fn fn_once_adapter_instance(
         tcx: TyCtxt<'tcx>,
         closure_did: DefId,
-        substs: ty::SubstsRef<'tcx>,
+        closure_substs: ty::ClosureSubsts<'tcx>,
     ) -> Instance<'tcx> {
-        debug!("fn_once_adapter_shim({:?}, {:?})", closure_did, substs);
+        debug!("fn_once_adapter_shim({:?}, {:?})", closure_did, closure_substs);
         let fn_once = tcx.require_lang_item(FnOnceTraitLangItem, None);
         let call_once = tcx
             .associated_items(fn_once)
@@ -384,9 +384,9 @@ impl<'tcx> Instance<'tcx> {
             .def_id;
         let def = ty::InstanceDef::ClosureOnceShim { call_once };
 
-        let self_ty = tcx.mk_closure(closure_did, substs);
+        let self_ty = tcx.mk_closure(closure_did, closure_substs);
 
-        let sig = substs.as_closure().sig();
+        let sig = closure_substs.sig();
         let sig = tcx.normalize_erasing_late_bound_regions(ty::ParamEnv::reveal_all(), &sig);
         assert_eq!(sig.inputs().len(), 1);
         let substs = tcx.mk_substs_trait(self_ty, &[sig.inputs()[0].into()]);

--- a/src/librustc_middle/ty/mod.rs
+++ b/src/librustc_middle/ty/mod.rs
@@ -1047,7 +1047,7 @@ pub enum Predicate<'tcx> {
     /// No direct syntax. May be thought of as `where T: FnFoo<...>`
     /// for some substitutions `...` and `T` being a closure type.
     /// Satisfied (or refuted) once we know the closure's kind.
-    ClosureKind(DefId, SubstsRef<'tcx>, ClosureKind),
+    ClosureKind(DefId, ClosureSubsts<'tcx>, ClosureKind),
 
     /// `T1 <: T2`
     Subtype(PolySubtypePredicate<'tcx>),

--- a/src/librustc_middle/ty/outlives.rs
+++ b/src/librustc_middle/ty/outlives.rs
@@ -88,15 +88,15 @@ fn compute_components(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>, out: &mut SmallVec<[Compo
                 compute_components(tcx, element, out);
             }
 
-            ty::Closure(_, ref substs) => {
-                for upvar_ty in substs.as_closure().upvar_tys() {
+            ty::Closure(_, ref closure_substs) => {
+                for upvar_ty in closure_substs.upvar_tys() {
                     compute_components(tcx, upvar_ty, out);
                 }
             }
 
-            ty::Generator(_, ref substs, _) => {
+            ty::Generator(_, ref generator_substs, _) => {
                 // Same as the closure case
-                for upvar_ty in substs.as_generator().upvar_tys() {
+                for upvar_ty in generator_substs.upvar_tys() {
                     compute_components(tcx, upvar_ty, out);
                 }
 

--- a/src/librustc_middle/ty/print/obsolete.rs
+++ b/src/librustc_middle/ty/print/obsolete.rs
@@ -138,7 +138,8 @@ impl DefPathBasedNames<'tcx> {
                     self.push_type_name(sig.output(), output, debug);
                 }
             }
-            ty::Generator(def_id, substs, _) | ty::Closure(def_id, substs) => {
+            ty::Generator(def_id, ty::GeneratorSubsts { substs }, _)
+            | ty::Closure(def_id, ty::ClosureSubsts { substs }) => {
                 self.push_def_path(def_id, output);
                 let generics = self.tcx.generics_of(self.tcx.closure_base_def_id(def_id));
                 let substs = substs.truncate_to(self.tcx, generics);

--- a/src/librustc_middle/ty/print/pretty.rs
+++ b/src/librustc_middle/ty/print/pretty.rs
@@ -595,7 +595,7 @@ pub trait PrettyPrinter<'tcx>:
                 })?);
             }
             ty::Str => p!(write("str")),
-            ty::Generator(did, substs, movability) => {
+            ty::Generator(did, generator_substs, movability) => {
                 match movability {
                     hir::Movability::Movable => p!(write("[generator")),
                     hir::Movability::Static => p!(write("[static generator")),
@@ -606,8 +606,8 @@ pub trait PrettyPrinter<'tcx>:
                     let hir_id = self.tcx().hir().as_local_hir_id(did);
                     p!(write("@{:?}", self.tcx().hir().span(hir_id)));
 
-                    if substs.as_generator().is_valid() {
-                        let upvar_tys = substs.as_generator().upvar_tys();
+                    if generator_substs.is_valid() {
+                        let upvar_tys = generator_substs.upvar_tys();
                         let mut sep = " ";
                         for (&var_id, upvar_ty) in self
                             .tcx()
@@ -624,8 +624,8 @@ pub trait PrettyPrinter<'tcx>:
                 } else {
                     p!(write("@{}", self.tcx().def_path_str(did)));
 
-                    if substs.as_generator().is_valid() {
-                        let upvar_tys = substs.as_generator().upvar_tys();
+                    if generator_substs.is_valid() {
+                        let upvar_tys = generator_substs.upvar_tys();
                         let mut sep = " ";
                         for (index, upvar_ty) in upvar_tys.enumerate() {
                             p!(write("{}{}:", sep, index), print(upvar_ty));
@@ -634,8 +634,8 @@ pub trait PrettyPrinter<'tcx>:
                     }
                 }
 
-                if substs.as_generator().is_valid() {
-                    p!(write(" "), print(substs.as_generator().witness()));
+                if generator_substs.is_valid() {
+                    p!(write(" "), print(generator_substs.witness()));
                 }
 
                 p!(write("]"))
@@ -643,20 +643,20 @@ pub trait PrettyPrinter<'tcx>:
             ty::GeneratorWitness(types) => {
                 p!(in_binder(&types));
             }
-            ty::Closure(did, substs) => {
+            ty::Closure(did, closure_substs) => {
                 p!(write("[closure"));
 
                 // FIXME(eddyb) should use `def_span`.
                 if let Some(did) = did.as_local() {
                     let hir_id = self.tcx().hir().as_local_hir_id(did);
                     if self.tcx().sess.opts.debugging_opts.span_free_formats {
-                        p!(write("@"), print_def_path(did.to_def_id(), substs));
+                        p!(write("@"), print_def_path(did.to_def_id(), closure_substs.substs));
                     } else {
                         p!(write("@{:?}", self.tcx().hir().span(hir_id)));
                     }
 
-                    if substs.as_closure().is_valid() {
-                        let upvar_tys = substs.as_closure().upvar_tys();
+                    if closure_substs.is_valid() {
+                        let upvar_tys = closure_substs.upvar_tys();
                         let mut sep = " ";
                         for (&var_id, upvar_ty) in self
                             .tcx()
@@ -673,8 +673,8 @@ pub trait PrettyPrinter<'tcx>:
                 } else {
                     p!(write("@{}", self.tcx().def_path_str(did)));
 
-                    if substs.as_closure().is_valid() {
-                        let upvar_tys = substs.as_closure().upvar_tys();
+                    if closure_substs.is_valid() {
+                        let upvar_tys = closure_substs.upvar_tys();
                         let mut sep = " ";
                         for (index, upvar_ty) in upvar_tys.enumerate() {
                             p!(write("{}{}:", sep, index), print(upvar_ty));
@@ -683,11 +683,11 @@ pub trait PrettyPrinter<'tcx>:
                     }
                 }
 
-                if self.tcx().sess.verbose() && substs.as_closure().is_valid() {
-                    p!(write(" closure_kind_ty="), print(substs.as_closure().kind_ty()));
+                if self.tcx().sess.verbose() && closure_substs.is_valid() {
+                    p!(write(" closure_kind_ty="), print(closure_substs.kind_ty()));
                     p!(
                         write(" closure_sig_as_fn_ptr_ty="),
-                        print(substs.as_closure().sig_as_fn_ptr_ty())
+                        print(closure_substs.sig_as_fn_ptr_ty())
                     );
                 }
 

--- a/src/librustc_middle/ty/relate.rs
+++ b/src/librustc_middle/ty/relate.rs
@@ -411,7 +411,7 @@ pub fn super_relate_tys<R: TypeRelation<'tcx>>(
             // the (anonymous) type of the same closure expression. So
             // all of their regions should be equated.
             let substs = relation.relate(&a_substs, &b_substs)?;
-            Ok(tcx.mk_closure(a_id, &substs))
+            Ok(tcx.mk_closure(a_id, substs))
         }
 
         (&ty::RawPtr(ref a_mt), &ty::RawPtr(ref b_mt)) => {

--- a/src/librustc_middle/ty/structural_impls.rs
+++ b/src/librustc_middle/ty/structural_impls.rs
@@ -889,11 +889,11 @@ impl<'tcx> TypeFoldable<'tcx> for Ty<'tcx> {
             ty::FnDef(def_id, substs) => ty::FnDef(def_id, substs.fold_with(folder)),
             ty::FnPtr(f) => ty::FnPtr(f.fold_with(folder)),
             ty::Ref(ref r, ty, mutbl) => ty::Ref(r.fold_with(folder), ty.fold_with(folder), mutbl),
-            ty::Generator(did, substs, movability) => {
-                ty::Generator(did, substs.fold_with(folder), movability)
+            ty::Generator(did, generator_substs, movability) => {
+                ty::Generator(did, generator_substs.fold_with(folder), movability)
             }
             ty::GeneratorWitness(types) => ty::GeneratorWitness(types.fold_with(folder)),
-            ty::Closure(did, substs) => ty::Closure(did, substs.fold_with(folder)),
+            ty::Closure(did, closure_substs) => ty::Closure(did, closure_substs.fold_with(folder)),
             ty::Projection(ref data) => ty::Projection(data.fold_with(folder)),
             ty::Opaque(did, substs) => ty::Opaque(did, substs.fold_with(folder)),
 
@@ -932,9 +932,9 @@ impl<'tcx> TypeFoldable<'tcx> for Ty<'tcx> {
             ty::FnDef(_, substs) => substs.visit_with(visitor),
             ty::FnPtr(ref f) => f.visit_with(visitor),
             ty::Ref(r, ty, _) => r.visit_with(visitor) || ty.visit_with(visitor),
-            ty::Generator(_did, ref substs, _) => substs.visit_with(visitor),
+            ty::Generator(_did, ref generator_substs, _) => generator_substs.visit_with(visitor),
             ty::GeneratorWitness(ref types) => types.visit_with(visitor),
-            ty::Closure(_did, ref substs) => substs.visit_with(visitor),
+            ty::Closure(_did, ref closure_substs) => closure_substs.visit_with(visitor),
             ty::Projection(ref data) => data.visit_with(visitor),
             ty::Opaque(_, ref substs) => substs.visit_with(visitor),
 

--- a/src/librustc_middle/ty/subst.rs
+++ b/src/librustc_middle/ty/subst.rs
@@ -2,7 +2,6 @@
 
 use crate::infer::canonical::Canonical;
 use crate::ty::fold::{TypeFoldable, TypeFolder, TypeVisitor};
-use crate::ty::sty::{ClosureSubsts, GeneratorSubsts};
 use crate::ty::{self, Lift, List, ParamConst, Ty, TyCtxt};
 
 use rustc_hir::def_id::DefId;
@@ -186,22 +185,6 @@ pub type InternalSubsts<'tcx> = List<GenericArg<'tcx>>;
 pub type SubstsRef<'tcx> = &'tcx InternalSubsts<'tcx>;
 
 impl<'a, 'tcx> InternalSubsts<'tcx> {
-    /// Interpret these substitutions as the substitutions of a closure type.
-    /// Closure substitutions have a particular structure controlled by the
-    /// compiler that encodes information like the signature and closure kind;
-    /// see `ty::ClosureSubsts` struct for more comments.
-    pub fn as_closure(&'a self) -> ClosureSubsts<'a> {
-        ClosureSubsts { substs: self }
-    }
-
-    /// Interpret these substitutions as the substitutions of a generator type.
-    /// Closure substitutions have a particular structure controlled by the
-    /// compiler that encodes information like the signature and generator kind;
-    /// see `ty::GeneratorSubsts` struct for more comments.
-    pub fn as_generator(&'tcx self) -> GeneratorSubsts<'tcx> {
-        GeneratorSubsts { substs: self }
-    }
-
     /// Creates a `InternalSubsts` that maps each generic parameter to itself.
     pub fn identity_for_item(tcx: TyCtxt<'tcx>, def_id: DefId) -> SubstsRef<'tcx> {
         Self::for_item(tcx, def_id, |param, _| tcx.mk_param_from_def(param))

--- a/src/librustc_middle/ty/util.rs
+++ b/src/librustc_middle/ty/util.rs
@@ -7,7 +7,7 @@ use crate::ty::layout::IntegerExt;
 use crate::ty::query::TyCtxtAt;
 use crate::ty::subst::{GenericArgKind, InternalSubsts, Subst, SubstsRef};
 use crate::ty::TyKind::*;
-use crate::ty::{self, DefIdTree, GenericParamDefKind, Ty, TyCtxt, TypeFoldable};
+use crate::ty::{self, ClosureSubsts, DefIdTree, GenericParamDefKind, Ty, TyCtxt, TypeFoldable};
 use rustc_apfloat::Float as _;
 use rustc_ast::ast;
 use rustc_attr::{self as attr, SignedInt, UnsignedInt};
@@ -496,11 +496,11 @@ impl<'tcx> TyCtxt<'tcx> {
     pub fn closure_env_ty(
         self,
         closure_def_id: DefId,
-        closure_substs: SubstsRef<'tcx>,
+        closure_substs: ClosureSubsts<'tcx>,
     ) -> Option<ty::Binder<Ty<'tcx>>> {
         let closure_ty = self.mk_closure(closure_def_id, closure_substs);
         let env_region = ty::ReLateBound(ty::INNERMOST, ty::BrEnv);
-        let closure_kind_ty = closure_substs.as_closure().kind_ty();
+        let closure_kind_ty = closure_substs.kind_ty();
         let closure_kind = closure_kind_ty.to_opt_closure_kind()?;
         let env_ty = match closure_kind {
             ty::ClosureKind::Fn => self.mk_imm_ref(self.mk_region(env_region), closure_ty),

--- a/src/librustc_middle/ty/walk.rs
+++ b/src/librustc_middle/ty/walk.rs
@@ -148,8 +148,8 @@ fn push_inner<'tcx>(stack: &mut TypeWalkerStack<'tcx>, parent: GenericArg<'tcx>)
             }
             ty::Adt(_, substs)
             | ty::Opaque(_, substs)
-            | ty::Closure(_, substs)
-            | ty::Generator(_, substs, _)
+            | ty::Closure(_, ty::ClosureSubsts { substs })
+            | ty::Generator(_, ty::GeneratorSubsts { substs }, _)
             | ty::Tuple(substs)
             | ty::FnDef(_, substs) => {
                 stack.extend(substs.iter().copied().rev());

--- a/src/librustc_mir/borrow_check/diagnostics/conflict_errors.rs
+++ b/src/librustc_mir/borrow_check/diagnostics/conflict_errors.rs
@@ -1620,7 +1620,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                         );
                         // Check if our `target` was captured by a closure.
                         if let Rvalue::Aggregate(
-                            box AggregateKind::Closure(def_id, substs),
+                            box AggregateKind::Closure(def_id, closure_substs),
                             operands,
                         ) = rvalue
                         {
@@ -1651,7 +1651,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                                 // into a place then we should annotate the closure in
                                 // case it ends up being assigned into the return place.
                                 annotated_closure =
-                                    self.annotate_fn_sig(*def_id, substs.as_closure().sig());
+                                    self.annotate_fn_sig(*def_id, closure_substs.sig());
                                 debug!(
                                     "annotate_argument_and_return_for_borrow: \
                                      annotated_closure={:?} assigned_from_local={:?} \

--- a/src/librustc_mir/borrow_check/diagnostics/move_errors.rs
+++ b/src/librustc_mir/borrow_check/diagnostics/move_errors.rs
@@ -333,7 +333,7 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
             ty::Closure(def_id, closure_substs)
                 if def_id == self.mir_def_id && upvar_field.is_some() =>
             {
-                let closure_kind_ty = closure_substs.as_closure().kind_ty();
+                let closure_kind_ty = closure_substs.kind_ty();
                 let closure_kind = closure_kind_ty.to_opt_closure_kind();
                 let capture_description = match closure_kind {
                     Some(ty::ClosureKind::Fn) => "captured variable in an `Fn` closure",

--- a/src/librustc_mir/borrow_check/diagnostics/region_errors.rs
+++ b/src/librustc_mir/borrow_check/diagnostics/region_errors.rs
@@ -135,10 +135,10 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
     fn is_closure_fn_mut(&self, fr: RegionVid) -> bool {
         if let Some(ty::ReFree(free_region)) = self.to_error_region(fr) {
             if let ty::BoundRegion::BrEnv = free_region.bound_region {
-                if let DefiningTy::Closure(_, substs) =
+                if let DefiningTy::Closure(_, closure_substs) =
                     self.regioncx.universal_regions().defining_ty
                 {
-                    return substs.as_closure().kind() == ty::ClosureKind::FnMut;
+                    return closure_substs.kind() == ty::ClosureKind::FnMut;
                 }
             }
         }

--- a/src/librustc_mir/borrow_check/diagnostics/region_name.rs
+++ b/src/librustc_mir/borrow_check/diagnostics/region_name.rs
@@ -241,7 +241,7 @@ impl<'tcx> MirBorrowckCtxt<'_, 'tcx> {
                         self.infcx.tcx.hir().as_local_hir_id(self.mir_def_id.expect_local());
                     let def_ty = self.regioncx.universal_regions().defining_ty;
 
-                    if let DefiningTy::Closure(_, substs) = def_ty {
+                    if let DefiningTy::Closure(_, closure_substs) = def_ty {
                         let args_span = if let hir::ExprKind::Closure(_, _, _, span, _) =
                             tcx.hir().expect_expr(mir_hir_id).kind
                         {
@@ -251,7 +251,7 @@ impl<'tcx> MirBorrowckCtxt<'_, 'tcx> {
                         };
                         let region_name = self.synthesize_region_name();
 
-                        let closure_kind_ty = substs.as_closure().kind_ty();
+                        let closure_kind_ty = closure_substs.kind_ty();
                         let note = match closure_kind_ty.to_opt_closure_kind() {
                             Some(ty::ClosureKind::Fn) => {
                                 "closure implements `Fn`, so references to captured variables \

--- a/src/librustc_mir/interpret/cast.rs
+++ b/src/librustc_mir/interpret/cast.rs
@@ -73,7 +73,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             Pointer(PointerCast::ClosureFnPointer(_)) => {
                 // The src operand does not matter, just its type
                 match src.layout.ty.kind {
-                    ty::Closure(def_id, substs) => {
+                    ty::Closure(def_id, closure_substs) => {
                         // All reifications must be monomorphic, bail out otherwise.
                         if src.layout.ty.needs_subst() {
                             throw_inval!(TooGeneric);
@@ -82,7 +82,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                         let instance = ty::Instance::resolve_closure(
                             *self.tcx,
                             def_id,
-                            substs,
+                            closure_substs,
                             ty::ClosureKind::FnOnce,
                         );
                         let fn_ptr = self.memory.create_fn_alloc(FnVal::Instance(instance));

--- a/src/librustc_mir/interpret/intrinsics/type_name.rs
+++ b/src/librustc_mir/interpret/intrinsics/type_name.rs
@@ -5,7 +5,7 @@ use rustc_middle::ty::{
     self,
     print::{PrettyPrinter, Print, Printer},
     subst::{GenericArg, GenericArgKind},
-    Ty, TyCtxt,
+    ClosureSubsts, GeneratorSubsts, Ty, TyCtxt,
 };
 use std::fmt::Write;
 
@@ -60,8 +60,10 @@ impl<'tcx> Printer<'tcx> for AbsolutePathPrinter<'tcx> {
             | ty::FnDef(def_id, substs)
             | ty::Opaque(def_id, substs)
             | ty::Projection(ty::ProjectionTy { item_def_id: def_id, substs })
-            | ty::Closure(def_id, substs)
-            | ty::Generator(def_id, substs, _) => self.print_def_path(def_id, substs),
+            | ty::Closure(def_id, ClosureSubsts { substs })
+            | ty::Generator(def_id, GeneratorSubsts { substs }, _) => {
+                self.print_def_path(def_id, substs)
+            }
             ty::Foreign(def_id) => self.print_def_path(def_id, &[]),
 
             ty::GeneratorWitness(_) => bug!("type_name: unexpected `GeneratorWitness`"),

--- a/src/librustc_mir/interpret/operand.rs
+++ b/src/librustc_mir/interpret/operand.rs
@@ -628,12 +628,9 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                     ty::Adt(adt, _) => {
                         adt.discriminants(self.tcx.tcx).find(|(_, var)| var.val == real_discr)
                     }
-                    ty::Generator(def_id, substs, _) => {
-                        let substs = substs.as_generator();
-                        substs
-                            .discriminants(def_id, self.tcx.tcx)
-                            .find(|(_, var)| var.val == real_discr)
-                    }
+                    ty::Generator(def_id, generator_substs, _) => generator_substs
+                        .discriminants(def_id, self.tcx.tcx)
+                        .find(|(_, var)| var.val == real_discr),
                     _ => bug!("tagged layout for non-adt non-generator"),
                 }
                 .ok_or_else(|| err_ub!(InvalidDiscriminant(raw_discr.erase_tag())))?;

--- a/src/librustc_mir/monomorphize/collector.rs
+++ b/src/librustc_mir/monomorphize/collector.rs
@@ -564,11 +564,11 @@ impl<'a, 'tcx> MirVisitor<'tcx> for MirNeighborCollector<'a, 'tcx> {
                 let source_ty = operand.ty(self.body, self.tcx);
                 let source_ty = self.monomorphize(source_ty);
                 match source_ty.kind {
-                    ty::Closure(def_id, substs) => {
+                    ty::Closure(def_id, closure_substs) => {
                         let instance = Instance::resolve_closure(
                             self.tcx,
                             def_id,
-                            substs,
+                            closure_substs,
                             ty::ClosureKind::FnOnce,
                         );
                         if should_monomorphize_locally(self.tcx, &instance) {

--- a/src/librustc_mir/transform/generator.rs
+++ b/src/librustc_mir/transform/generator.rs
@@ -1196,15 +1196,12 @@ impl<'tcx> MirPass<'tcx> for StateTransform {
 
         // Get the interior types and substs which typeck computed
         let (upvars, interior, discr_ty, movable) = match gen_ty.kind {
-            ty::Generator(_, substs, movability) => {
-                let substs = substs.as_generator();
-                (
-                    substs.upvar_tys().collect(),
-                    substs.witness(),
-                    substs.discr_ty(tcx),
-                    movability == hir::Movability::Movable,
-                )
-            }
+            ty::Generator(_, generator_substs, movability) => (
+                generator_substs.upvar_tys().collect(),
+                generator_substs.witness(),
+                generator_substs.discr_ty(tcx),
+                movability == hir::Movability::Movable,
+            ),
             _ => bug!(),
         };
 

--- a/src/librustc_mir/util/elaborate_drops.rs
+++ b/src/librustc_mir/util/elaborate_drops.rs
@@ -853,8 +853,8 @@ where
     fn open_drop(&mut self) -> BasicBlock {
         let ty = self.place_ty(self.place);
         match ty.kind {
-            ty::Closure(_, substs) => {
-                let tys: Vec<_> = substs.as_closure().upvar_tys().collect();
+            ty::Closure(_, closure_substs) => {
+                let tys: Vec<_> = closure_substs.upvar_tys().collect();
                 self.open_drop_for_tuple(&tys)
             }
             // Note that `elaborate_drops` only drops the upvars of a generator,
@@ -863,8 +863,8 @@ where
             // This should only happen for the self argument on the resume function.
             // It effetively only contains upvars until the generator transformation runs.
             // See librustc_body/transform/generator.rs for more details.
-            ty::Generator(_, substs, _) => {
-                let tys: Vec<_> = substs.as_generator().upvar_tys().collect();
+            ty::Generator(_, generator_substs, _) => {
+                let tys: Vec<_> = generator_substs.upvar_tys().collect();
                 self.open_drop_for_tuple(&tys)
             }
             ty::Tuple(..) => {

--- a/src/librustc_mir/util/pretty.rs
+++ b/src/librustc_mir/util/pretty.rs
@@ -16,7 +16,7 @@ use rustc_middle::mir::interpret::{
 };
 use rustc_middle::mir::visit::Visitor;
 use rustc_middle::mir::*;
-use rustc_middle::ty::{self, TyCtxt, TypeFoldable, TypeVisitor};
+use rustc_middle::ty::{self, ClosureSubsts, GeneratorSubsts, TyCtxt, TypeFoldable, TypeVisitor};
 use rustc_target::abi::Size;
 
 const INDENT: &str = "    ";
@@ -396,13 +396,13 @@ impl Visitor<'tcx> for ExtraComments<'tcx> {
         self.super_rvalue(rvalue, location);
         if let Rvalue::Aggregate(kind, _) = rvalue {
             match **kind {
-                AggregateKind::Closure(def_id, substs) => {
+                AggregateKind::Closure(def_id, ClosureSubsts { substs }) => {
                     self.push("closure");
                     self.push(&format!("+ def_id: {:?}", def_id));
                     self.push(&format!("+ substs: {:#?}", substs));
                 }
 
-                AggregateKind::Generator(def_id, substs, movability) => {
+                AggregateKind::Generator(def_id, GeneratorSubsts { substs }, movability) => {
                     self.push("generator");
                     self.push(&format!("+ def_id: {:?}", def_id));
                     self.push(&format!("+ substs: {:#?}", substs));

--- a/src/librustc_mir_build/build/expr/as_rvalue.rs
+++ b/src/librustc_mir_build/build/expr/as_rvalue.rs
@@ -213,13 +213,13 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     })
                     .collect();
                 let result = match substs {
-                    UpvarSubsts::Generator(substs) => {
+                    UpvarSubsts::Generator(generator_substs) => {
                         // We implicitly set the discriminant to 0. See
                         // librustc_mir/transform/deaggregator.rs for details.
                         let movability = movability.unwrap();
-                        box AggregateKind::Generator(closure_id, substs, movability)
+                        box AggregateKind::Generator(closure_id, generator_substs, movability)
                     }
-                    UpvarSubsts::Closure(substs) => box AggregateKind::Closure(closure_id, substs),
+                    UpvarSubsts::Closure(closure_substs) => box AggregateKind::Closure(closure_id, closure_substs),
                 };
                 block.and(Rvalue::Aggregate(result, operands))
             }

--- a/src/librustc_mir_build/build/mod.rs
+++ b/src/librustc_mir_build/build/mod.rs
@@ -143,7 +143,7 @@ fn mir_build(tcx: TyCtxt<'_>, def_id: LocalDefId) -> Body<'_> {
             let (yield_ty, return_ty) = if body.generator_kind.is_some() {
                 let gen_ty = tcx.body_tables(body_id).node_type(id);
                 let gen_sig = match gen_ty.kind {
-                    ty::Generator(_, gen_substs, ..) => gen_substs.as_generator().sig(),
+                    ty::Generator(_, gen_substs, ..) => gen_substs.sig(),
                     _ => span_bug!(tcx.hir().span(id), "generator w/o generator type: {:?}", ty),
                 };
                 (Some(gen_sig.yield_ty), gen_sig.return_ty)
@@ -803,8 +803,8 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 closure_ty = ty;
             }
             let upvar_substs = match closure_ty.kind {
-                ty::Closure(_, substs) => ty::UpvarSubsts::Closure(substs),
-                ty::Generator(_, substs, _) => ty::UpvarSubsts::Generator(substs),
+                ty::Closure(_, closure_substs) => ty::UpvarSubsts::Closure(closure_substs),
+                ty::Generator(_, generator_substs, _) => ty::UpvarSubsts::Generator(generator_substs),
                 _ => span_bug!(self.fn_span, "upvars with non-closure env ty {:?}", closure_ty),
             };
             let upvar_tys = upvar_substs.upvar_tys();

--- a/src/librustc_mir_build/hair/cx/expr.rs
+++ b/src/librustc_mir_build/hair/cx/expr.rs
@@ -376,9 +376,11 @@ fn make_mirror_unadjusted<'a, 'tcx>(
         hir::ExprKind::Closure(..) => {
             let closure_ty = cx.tables().expr_ty(expr);
             let (def_id, substs, movability) = match closure_ty.kind {
-                ty::Closure(def_id, substs) => (def_id, UpvarSubsts::Closure(substs), None),
-                ty::Generator(def_id, substs, movability) => {
-                    (def_id, UpvarSubsts::Generator(substs), Some(movability))
+                ty::Closure(def_id, closure_substs) => {
+                    (def_id, UpvarSubsts::Closure(closure_substs), None)
+                }
+                ty::Generator(def_id, generator_substs, movability) => {
+                    (def_id, UpvarSubsts::Generator(generator_substs), Some(movability))
                 }
                 _ => {
                     span_bug!(expr.span, "closure expr w/o closure type: {:?}", closure_ty);

--- a/src/librustc_symbol_mangling/legacy.rs
+++ b/src/librustc_symbol_mangling/legacy.rs
@@ -5,7 +5,7 @@ use rustc_middle::ich::NodeIdHashingMode;
 use rustc_middle::mir::interpret::{ConstValue, Scalar};
 use rustc_middle::ty::print::{PrettyPrinter, Print, Printer};
 use rustc_middle::ty::subst::{GenericArg, GenericArgKind};
-use rustc_middle::ty::{self, Instance, Ty, TyCtxt, TypeFoldable};
+use rustc_middle::ty::{self, ClosureSubsts, GeneratorSubsts, Instance, Ty, TyCtxt, TypeFoldable};
 use rustc_middle::util::common::record_time;
 
 use log::debug;
@@ -216,8 +216,10 @@ impl Printer<'tcx> for SymbolPrinter<'tcx> {
             ty::FnDef(def_id, substs)
             | ty::Opaque(def_id, substs)
             | ty::Projection(ty::ProjectionTy { item_def_id: def_id, substs })
-            | ty::Closure(def_id, substs)
-            | ty::Generator(def_id, substs, _) => self.print_def_path(def_id, substs),
+            | ty::Closure(def_id, ClosureSubsts { substs })
+            | ty::Generator(def_id, GeneratorSubsts { substs }, _) => {
+                self.print_def_path(def_id, substs)
+            }
             _ => self.pretty_print_type(ty),
         }
     }

--- a/src/librustc_symbol_mangling/v0.rs
+++ b/src/librustc_symbol_mangling/v0.rs
@@ -6,7 +6,7 @@ use rustc_hir::def_id::{CrateNum, DefId};
 use rustc_hir::definitions::{DefPathData, DisambiguatedDefPathData};
 use rustc_middle::ty::print::{Print, Printer};
 use rustc_middle::ty::subst::{GenericArg, GenericArgKind, Subst};
-use rustc_middle::ty::{self, Instance, Ty, TyCtxt, TypeFoldable};
+use rustc_middle::ty::{self, ClosureSubsts, GeneratorSubsts, Instance, Ty, TyCtxt, TypeFoldable};
 use rustc_target::spec::abi::Abi;
 
 use std::fmt::Write;
@@ -413,8 +413,8 @@ impl Printer<'tcx> for SymbolMangler<'tcx> {
             | ty::FnDef(def_id, substs)
             | ty::Opaque(def_id, substs)
             | ty::Projection(ty::ProjectionTy { item_def_id: def_id, substs })
-            | ty::Closure(def_id, substs)
-            | ty::Generator(def_id, substs, _) => {
+            | ty::Closure(def_id, ClosureSubsts { substs })
+            | ty::Generator(def_id, GeneratorSubsts { substs }, _) => {
                 self = self.print_def_path(def_id, substs)?;
             }
             ty::Foreign(def_id) => {

--- a/src/librustc_trait_selection/traits/error_reporting/suggestions.rs
+++ b/src/librustc_trait_selection/traits/error_reporting/suggestions.rs
@@ -521,7 +521,9 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
     ) {
         let self_ty = trait_ref.self_ty();
         let (def_id, output_ty, callable) = match self_ty.kind {
-            ty::Closure(def_id, substs) => (def_id, substs.as_closure().sig().output(), "closure"),
+            ty::Closure(def_id, closure_substs) => {
+                (def_id, closure_substs.sig().output(), "closure")
+            }
             ty::FnDef(def_id, _) => (def_id, self_ty.fn_sig(self.tcx).output(), "function"),
             _ => return,
         };

--- a/src/librustc_trait_selection/traits/project.rs
+++ b/src/librustc_trait_selection/traits/project.rs
@@ -1211,7 +1211,7 @@ fn confirm_generator_candidate<'cx, 'tcx>(
     obligation: &ProjectionTyObligation<'tcx>,
     vtable: VtableGeneratorData<'tcx, PredicateObligation<'tcx>>,
 ) -> Progress<'tcx> {
-    let gen_sig = vtable.substs.as_generator().poly_sig();
+    let gen_sig = vtable.generator_substs.poly_sig();
     let Normalized { value: gen_sig, obligations } = normalize_with_depth(
         selcx,
         obligation.param_env,
@@ -1284,7 +1284,7 @@ fn confirm_closure_candidate<'cx, 'tcx>(
     obligation: &ProjectionTyObligation<'tcx>,
     vtable: VtableClosureData<'tcx, PredicateObligation<'tcx>>,
 ) -> Progress<'tcx> {
-    let closure_sig = vtable.substs.as_closure().sig();
+    let closure_sig = vtable.closure_substs.sig();
     let Normalized { value: closure_sig, obligations } = normalize_with_depth(
         selcx,
         obligation.param_env,

--- a/src/librustc_trait_selection/traits/query/dropck_outlives.rs
+++ b/src/librustc_trait_selection/traits/query/dropck_outlives.rs
@@ -109,8 +109,8 @@ pub fn trivial_dropck_outlives<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> bool {
         // (T1..Tn) and closures have same properties as T1..Tn --
         // check if *any* of those are trivial.
         ty::Tuple(ref tys) => tys.iter().all(|t| trivial_dropck_outlives(tcx, t.expect_ty())),
-        ty::Closure(_, ref substs) => {
-            substs.as_closure().upvar_tys().all(|t| trivial_dropck_outlives(tcx, t))
+        ty::Closure(_, ref closure_substs) => {
+            closure_substs.upvar_tys().all(|t| trivial_dropck_outlives(tcx, t))
         }
 
         ty::Adt(def, _) => {

--- a/src/librustc_trait_selection/traits/wf.rs
+++ b/src/librustc_trait_selection/traits/wf.rs
@@ -428,7 +428,7 @@ impl<'a, 'tcx> WfPredicates<'a, 'tcx> {
                     // generators don't take arguments.
                 }
 
-                ty::Closure(_, substs) => {
+                ty::Closure(_, closure_substs) => {
                     // Only check the upvar types for WF, not the rest
                     // of the types within. This is needed because we
                     // capture the signature and it may not be WF
@@ -459,7 +459,7 @@ impl<'a, 'tcx> WfPredicates<'a, 'tcx> {
                     // anyway, except via auto trait matching (which
                     // only inspects the upvar types).
                     walker.skip_current_subtree(); // subtree handled below
-                    for upvar_ty in substs.as_closure().upvar_tys() {
+                    for upvar_ty in closure_substs.upvar_tys() {
                         // FIXME(eddyb) add the type to `walker` instead of recursing.
                         self.compute(upvar_ty);
                     }

--- a/src/librustc_ty/instance.rs
+++ b/src/librustc_ty/instance.rs
@@ -183,14 +183,14 @@ fn resolve_associated_item<'tcx>(
         }
         traits::VtableGenerator(generator_data) => Some(Instance {
             def: ty::InstanceDef::Item(generator_data.generator_def_id),
-            substs: generator_data.substs,
+            substs: generator_data.generator_substs.substs,
         }),
         traits::VtableClosure(closure_data) => {
             let trait_closure_kind = tcx.fn_trait_kind_from_lang_item(trait_id).unwrap();
             Some(Instance::resolve_closure(
                 tcx,
                 closure_data.closure_def_id,
-                closure_data.substs,
+                closure_data.closure_substs,
                 trait_closure_kind,
             ))
         }

--- a/src/librustc_ty/needs_drop.rs
+++ b/src/librustc_ty/needs_drop.rs
@@ -93,19 +93,18 @@ where
                 match component.kind {
                     _ if component.is_copy_modulo_regions(tcx, self.param_env, DUMMY_SP) => (),
 
-                    ty::Closure(_, substs) => {
-                        for upvar_ty in substs.as_closure().upvar_tys() {
+                    ty::Closure(_, closure_substs) => {
+                        for upvar_ty in closure_substs.upvar_tys() {
                             queue_type(self, upvar_ty);
                         }
                     }
 
-                    ty::Generator(_, substs, _) => {
-                        let substs = substs.as_generator();
-                        for upvar_ty in substs.upvar_tys() {
+                    ty::Generator(_, generator_substs, _) => {
+                        for upvar_ty in generator_substs.upvar_tys() {
                             queue_type(self, upvar_ty);
                         }
 
-                        let witness = substs.witness();
+                        let witness = generator_substs.witness();
                         let interior_tys = match &witness.kind {
                             ty::GeneratorWitness(tys) => tcx.erase_late_bound_regions(tys),
                             _ => bug!(),

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -4907,7 +4907,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let hir = self.tcx.hir();
         let (def_id, sig) = match found.kind {
             ty::FnDef(def_id, _) => (def_id, found.fn_sig(self.tcx)),
-            ty::Closure(def_id, substs) => (def_id, substs.as_closure().sig()),
+            ty::Closure(def_id, closure_substs) => (def_id, closure_substs.sig()),
             _ => return false,
         };
 

--- a/src/librustc_typeck/check/regionck.rs
+++ b/src/librustc_typeck/check/regionck.rs
@@ -1230,8 +1230,8 @@ impl<'a, 'tcx> RegionCtxt<'a, 'tcx> {
 
         // A closure capture can't be borrowed for longer than the
         // reference to the closure.
-        if let ty::Closure(_, substs) = ty.kind {
-            match self.infcx.closure_kind(substs) {
+        if let ty::Closure(_, closure_substs) = ty.kind {
+            match self.infcx.closure_kind(closure_substs) {
                 Some(ty::ClosureKind::Fn | ty::ClosureKind::FnMut) => {
                     // Region of environment pointer
                     let env_region = self.tcx.mk_region(ty::ReFree(ty::FreeRegion {

--- a/src/librustc_typeck/check/upvar.rs
+++ b/src/librustc_typeck/check/upvar.rs
@@ -89,8 +89,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         // Extract the type of the closure.
         let ty = self.node_ty(closure_hir_id);
         let (closure_def_id, substs) = match ty.kind {
-            ty::Closure(def_id, substs) => (def_id, UpvarSubsts::Closure(substs)),
-            ty::Generator(def_id, substs, _) => (def_id, UpvarSubsts::Generator(substs)),
+            ty::Closure(def_id, closure_substs) => (def_id, UpvarSubsts::Closure(closure_substs)),
+            ty::Generator(def_id, generator_substs, _) => {
+                (def_id, UpvarSubsts::Generator(generator_substs))
+            }
             ty::Error => {
                 // #51714: skip analysis when we have already encountered type errors
                 return;
@@ -167,7 +169,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             // Unify the (as yet unbound) type variable in the closure
             // substs with the kind we inferred.
             let inferred_kind = delegate.current_closure_kind;
-            let closure_kind_ty = closure_substs.as_closure().kind_ty();
+            let closure_kind_ty = closure_substs.kind_ty();
             self.demand_eqtype(span, inferred_kind.to_ty(self.tcx), closure_kind_ty);
 
             // If we have an origin, store it.

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -1537,10 +1537,8 @@ fn fn_sig(tcx: TyCtxt<'_>, def_id: DefId) -> ty::PolyFnSig<'_> {
             // To get the signature of a closure, you should use the
             // `sig` method on the `ClosureSubsts`:
             //
-            //    substs.as_closure().sig(def_id, tcx)
-            bug!(
-                "to get the signature of a closure, use `substs.as_closure().sig()` not `fn_sig()`",
-            );
+            //    closure_substs.sig(def_id, tcx)
+            bug!("to get the signature of a closure, use `closure_substs.sig()` not `fn_sig()`",);
         }
 
         x => {

--- a/src/librustc_typeck/collect/type_of.rs
+++ b/src/librustc_typeck/collect/type_of.rs
@@ -9,7 +9,7 @@ use rustc_hir::Node;
 use rustc_middle::hir::map::Map;
 use rustc_middle::ty::subst::{GenericArgKind, InternalSubsts};
 use rustc_middle::ty::util::IntTypeExt;
-use rustc_middle::ty::{self, DefIdTree, Ty, TyCtxt, TypeFoldable};
+use rustc_middle::ty::{self, ClosureSubsts, DefIdTree, GeneratorSubsts, Ty, TyCtxt, TypeFoldable};
 use rustc_session::parse::feature_err;
 use rustc_span::symbol::{sym, Ident};
 use rustc_span::{Span, DUMMY_SP};
@@ -204,9 +204,9 @@ pub(super) fn type_of(tcx: TyCtxt<'_>, def_id: DefId) -> Ty<'_> {
         Node::Expr(&Expr { kind: ExprKind::Closure(.., gen), .. }) => {
             let substs = InternalSubsts::identity_for_item(tcx, def_id);
             if let Some(movability) = gen {
-                tcx.mk_generator(def_id, substs, movability)
+                tcx.mk_generator(def_id, GeneratorSubsts { substs }, movability)
             } else {
-                tcx.mk_closure(def_id, substs)
+                tcx.mk_closure(def_id, ClosureSubsts { substs })
             }
         }
 

--- a/src/tools/clippy/clippy_lints/src/doc.rs
+++ b/src/tools/clippy/clippy_lints/src/doc.rs
@@ -235,7 +235,7 @@ fn lint_for_missing_headers<'a, 'tcx>(
                 if let ty::Opaque(_, subs) = ret_ty.kind;
                 if let Some(gen) = subs.types().next();
                 if let ty::Generator(_, subs, _) = gen.kind;
-                if is_type_diagnostic_item(cx, subs.as_generator().return_ty(), sym!(result_type));
+                if is_type_diagnostic_item(cx, subs.return_ty(), sym!(result_type));
                 then {
                     span_lint(
                         cx,


### PR DESCRIPTION
Now stored directly instead of requiring a cast.

As a result `as_closure`/`as_generator` casts are removed.

This change allows to encapsulate synthetic generic args handling inside of `ClosureSbusts`/`GeneratorSubsts` instead of leaking implementation details in `SubstsRef`.

Didn't expect this change to blow up this big. Please let me know if there is interest in this change before I start rebasing it.