### PR TITLE
[DO NOT MERGE] [crater experiment] make unaligned_referenced deny-by-default

### DIFF
--- a/src/librustc_session/lint/builtin.rs
+++ b/src/librustc_session/lint/builtin.rs
@@ -224,7 +224,7 @@ declare_lint! {
 
 declare_lint! {
     pub UNALIGNED_REFERENCES,
-    Allow,
+    Deny,
     "detects unaligned references to fields of packed structs",
 }
 


### PR DESCRIPTION
@joshtriplett suggested we make a crater experiment to figure out how much code out there is creating bad references to packed fields.