### PR TITLE
Allow types (with lifetimes/generics) in impl_lint_pass

### DIFF
--- a/src/librustc_session/lint.rs
+++ b/src/librustc_session/lint.rs
@@ -347,14 +347,14 @@ pub trait LintPass {
     fn name(&self) -> &'static str;
 }
 
-/// Implements `LintPass for $name` with the given list of `Lint` statics.
+/// Implements `LintPass for $ty` with the given list of `Lint` statics.
 #[macro_export]
 macro_rules! impl_lint_pass {
-    ($name:ident => [$($lint:expr),* $(,)?]) => {
-        impl $crate::lint::LintPass for $name {
-            fn name(&self) -> &'static str { stringify!($name) }
+    ($ty:ty => [$($lint:expr),* $(,)?]) => {
+        impl $crate::lint::LintPass for $ty {
+            fn name(&self) -> &'static str { stringify!($ty) }
         }
-        impl $name {
+        impl $ty {
             pub fn get_lints() -> $crate::lint::LintArray { $crate::lint_array!($($lint),*) }
         }
     };

--- a/src/test/ui-fulldeps/lint-pass-macros.rs
+++ b/src/test/ui-fulldeps/lint-pass-macros.rs
@@ -1,0 +1,26 @@
+// compile-flags: -Z unstable-options
+// check-pass
+
+#![feature(rustc_private)]
+
+extern crate rustc_session;
+
+use rustc_session::lint::{LintArray, LintPass};
+use rustc_session::{declare_lint, declare_lint_pass, impl_lint_pass};
+
+declare_lint! {
+    pub TEST_LINT,
+    Allow,
+    "test"
+}
+
+struct Foo;
+
+struct Bar<'a>(&'a u32);
+
+impl_lint_pass!(Foo => [TEST_LINT]);
+impl_lint_pass!(Bar<'_> => [TEST_LINT]);
+
+declare_lint_pass!(Baz => [TEST_LINT]);
+
+fn main() {}


### PR DESCRIPTION
cc https://github.com/rust-lang/rust-clippy/pull/5279#discussion_r430790267

This allows to implement `LintPass` for types with lifetimes and/or generics. The only thing, I'm not sure of is the `LintPass::name` function, which now includes the lifetime(s) (which will be `'_` most of the time) in the name returned for the lint pass, if it exists. But I don't think that this should be a problem, since the `LintPass::name` is never used for output for the user (?).