### PR TITLE
expand unaligned_references test

### DIFF
--- a/src/test/ui/lint/unaligned_references.rs
+++ b/src/test/ui/lint/unaligned_references.rs
@@ -2,20 +2,27 @@
 
 #[repr(packed)]
 pub struct Good {
-    data: &'static u32,
-    data2: [&'static u32; 2],
+    data: u64,
+    ptr: &'static u64,
+    data2: [u64; 2],
     aligned: [u8; 32],
 }
 
 fn main() {
     unsafe {
-        let good = Good { data: &0, data2: [&0, &0], aligned: [0; 32] };
+        let good = Good { data: 0, ptr: &0, data2: [0, 0], aligned: [0; 32] };
 
+        let _ = &good.ptr; //~ ERROR reference to packed field
         let _ = &good.data; //~ ERROR reference to packed field
+        // Error even when turned into raw pointer immediately.
         let _ = &good.data as *const _; //~ ERROR reference to packed field
         let _: *const _ = &good.data; //~ ERROR reference to packed field
+        // Error on method call.
+        let _ = good.data.clone(); //~ ERROR reference to packed field
+        // Error for nested fields.
         let _ = &good.data2[0]; //~ ERROR reference to packed field
-        let _ = &*good.data; // ok, behind a pointer
+
+        let _ = &*good.ptr; // ok, behind a pointer
         let _ = &good.aligned; // ok, has align 1
         let _ = &good.aligned[2]; // ok, has align 1
     }

--- a/src/test/ui/lint/unaligned_references.stderr
+++ b/src/test/ui/lint/unaligned_references.stderr
@@ -1,8 +1,8 @@
 error: reference to packed field is unaligned
-  --> $DIR/unaligned_references.rs:14:17
+  --> $DIR/unaligned_references.rs:15:17
    |
-LL |         let _ = &good.data;
-   |                 ^^^^^^^^^^
+LL |         let _ = &good.ptr;
+   |                 ^^^^^^^^^
    |
 note: the lint level is defined here
   --> $DIR/unaligned_references.rs:1:9
@@ -12,7 +12,15 @@ LL | #![deny(unaligned_references)]
    = note: fields of packed structs are not properly aligned, and creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
 
 error: reference to packed field is unaligned
-  --> $DIR/unaligned_references.rs:15:17
+  --> $DIR/unaligned_references.rs:16:17
+   |
+LL |         let _ = &good.data;
+   |                 ^^^^^^^^^^
+   |
+   = note: fields of packed structs are not properly aligned, and creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
+
+error: reference to packed field is unaligned
+  --> $DIR/unaligned_references.rs:18:17
    |
 LL |         let _ = &good.data as *const _;
    |                 ^^^^^^^^^^
@@ -20,7 +28,7 @@ LL |         let _ = &good.data as *const _;
    = note: fields of packed structs are not properly aligned, and creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
 
 error: reference to packed field is unaligned
-  --> $DIR/unaligned_references.rs:16:27
+  --> $DIR/unaligned_references.rs:19:27
    |
 LL |         let _: *const _ = &good.data;
    |                           ^^^^^^^^^^
@@ -28,12 +36,20 @@ LL |         let _: *const _ = &good.data;
    = note: fields of packed structs are not properly aligned, and creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
 
 error: reference to packed field is unaligned
-  --> $DIR/unaligned_references.rs:17:17
+  --> $DIR/unaligned_references.rs:21:17
+   |
+LL |         let _ = good.data.clone();
+   |                 ^^^^^^^^^
+   |
+   = note: fields of packed structs are not properly aligned, and creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
+
+error: reference to packed field is unaligned
+  --> $DIR/unaligned_references.rs:23:17
    |
 LL |         let _ = &good.data2[0];
    |                 ^^^^^^^^^^^^^^
    |
    = note: fields of packed structs are not properly aligned, and creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
 
-error: aborting due to 4 previous errors
+error: aborting due to 6 previous errors
 


### PR DESCRIPTION
Also test implicit ref when having a field as a method receiver, as suggested by @bluss.