### PR TITLE
Fix missing parentheses Fn notation error

### DIFF
--- a/src/test/ui/suggestions/fn-trait-notation.fixed
+++ b/src/test/ui/suggestions/fn-trait-notation.fixed
@@ -1,0 +1,19 @@
+// run-rustfix
+fn e0658<F, G, H>(f: F, g: G, h: H) -> i32
+where
+    F: Fn(i32) -> i32, //~ ERROR E0658
+    G: Fn(i32, i32) -> (i32, i32), //~ ERROR E0658
+    H: Fn(i32) -> i32, //~ ERROR E0658
+{
+    f(3);
+    g(3, 4);
+    h(3)
+}
+
+fn main() {
+    e0658(
+        |a| a,
+        |a, b| (b, a),
+        |a| a,
+    );
+}

--- a/src/test/ui/suggestions/fn-trait-notation.rs
+++ b/src/test/ui/suggestions/fn-trait-notation.rs
@@ -1,0 +1,19 @@
+// run-rustfix
+fn e0658<F, G, H>(f: F, g: G, h: H) -> i32
+where
+    F: Fn<i32, Output = i32>, //~ ERROR E0658
+    G: Fn<(i32, i32, ), Output = (i32, i32)>, //~ ERROR E0658
+    H: Fn<(i32,), Output = i32>, //~ ERROR E0658
+{
+    f(3);
+    g(3, 4);
+    h(3)
+}
+
+fn main() {
+    e0658(
+        |a| a,
+        |a, b| (b, a),
+        |a| a,
+    );
+}

--- a/src/test/ui/suggestions/fn-trait-notation.stderr
+++ b/src/test/ui/suggestions/fn-trait-notation.stderr
@@ -1,0 +1,30 @@
+error[E0658]: the precise format of `Fn`-family traits' type parameters is subject to change
+  --> $DIR/fn-trait-notation.rs:4:8
+   |
+LL |     F: Fn<i32, Output = i32>,
+   |        ^^^^^^^^^^^^^^^^^^^^^ help: use parenthetical notation instead: `Fn(i32) -> i32`
+   |
+   = note: see issue #29625 <https://github.com/rust-lang/rust/issues/29625> for more information
+   = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
+
+error[E0658]: the precise format of `Fn`-family traits' type parameters is subject to change
+  --> $DIR/fn-trait-notation.rs:5:8
+   |
+LL |     G: Fn<(i32, i32, ), Output = (i32, i32)>,
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use parenthetical notation instead: `Fn(i32, i32) -> (i32, i32)`
+   |
+   = note: see issue #29625 <https://github.com/rust-lang/rust/issues/29625> for more information
+   = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
+
+error[E0658]: the precise format of `Fn`-family traits' type parameters is subject to change
+  --> $DIR/fn-trait-notation.rs:6:8
+   |
+LL |     H: Fn<(i32,), Output = i32>,
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^ help: use parenthetical notation instead: `Fn(i32) -> i32`
+   |
+   = note: see issue #29625 <https://github.com/rust-lang/rust/issues/29625> for more information
+   = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0658`.


### PR DESCRIPTION
Fixes  #72611
Well, fixes the error output, I think E0658 is the right error to throw in this case so I didn't change that