### PR TITLE
compare consts using ptr equality

### DIFF
--- a/src/librustc_data_structures/stable_hasher.rs
+++ b/src/librustc_data_structures/stable_hasher.rs
@@ -218,14 +218,14 @@ impl<CTX> HashStable<CTX> for ::std::num::NonZeroUsize {
 
 impl<CTX> HashStable<CTX> for f32 {
     fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
-        let val: u32 = unsafe { ::std::mem::transmute(*self) };
+        let val: u32 = self.to_bits();
         val.hash_stable(ctx, hasher);
     }
 }
 
 impl<CTX> HashStable<CTX> for f64 {
     fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
-        let val: u64 = unsafe { ::std::mem::transmute(*self) };
+        let val: u64 = self.to_bits();
         val.hash_stable(ctx, hasher);
     }
 }

--- a/src/librustc_infer/infer/canonical/canonicalizer.rs
+++ b/src/librustc_infer/infer/canonical/canonicalizer.rs
@@ -658,10 +658,8 @@ impl<'cx, 'tcx> Canonicalizer<'cx, 'tcx> {
             self.fold_const(bound_to)
         } else {
             let var = self.canonical_var(info, const_var.into());
-            self.tcx().mk_const(ty::Const {
-                val: ty::ConstKind::Bound(self.binder_index, var),
-                ty: self.fold_ty(const_var.ty),
-            })
+            self.tcx()
+                .mk_const(self.fold_ty(const_var.ty), ty::ConstKind::Bound(self.binder_index, var))
         }
     }
 }

--- a/src/librustc_infer/infer/canonical/mod.rs
+++ b/src/librustc_infer/infer/canonical/mod.rs
@@ -152,10 +152,10 @@ impl<'cx, 'tcx> InferCtxt<'cx, 'tcx> {
                 let universe_mapped = universe_map(universe);
                 let placeholder_mapped = ty::PlaceholderConst { universe: universe_mapped, name };
                 self.tcx
-                    .mk_const(ty::Const {
-                        val: ty::ConstKind::Placeholder(placeholder_mapped),
-                        ty: self.tcx.types.err, // FIXME(const_generics)
-                    })
+                    .mk_const(
+                        self.tcx.types.err, // FIXME(const_generics)
+                        ty::ConstKind::Placeholder(placeholder_mapped),
+                    )
                     .into()
             }
         }

--- a/src/librustc_infer/infer/fudge.rs
+++ b/src/librustc_infer/infer/fudge.rs
@@ -232,13 +232,13 @@ impl<'a, 'tcx> TypeFolder<'tcx> for InferenceFudger<'a, 'tcx> {
     }
 
     fn fold_const(&mut self, ct: &'tcx ty::Const<'tcx>) -> &'tcx ty::Const<'tcx> {
-        if let ty::Const { val: ty::ConstKind::Infer(ty::InferConst::Var(vid)), ty } = ct {
+        if let ty::ConstKind::Infer(ty::InferConst::Var(vid)) = ct.val {
             if self.const_vars.0.contains(&vid) {
                 // This variable was created during the fudging.
                 // Recreate it with a fresh variable here.
                 let idx = (vid.index - self.const_vars.0.start.index) as usize;
                 let origin = self.const_vars.1[idx];
-                self.infcx.next_const_var(ty, origin)
+                self.infcx.next_const_var(ct.ty, origin)
             } else {
                 ct
             }

--- a/src/librustc_infer/infer/higher_ranked/mod.rs
+++ b/src/librustc_infer/infer/higher_ranked/mod.rs
@@ -98,13 +98,13 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
         };
 
         let fld_c = |bound_var: ty::BoundVar, ty| {
-            self.tcx.mk_const(ty::Const {
-                val: ty::ConstKind::Placeholder(ty::PlaceholderConst {
+            self.tcx.mk_const(
+                ty,
+                ty::ConstKind::Placeholder(ty::PlaceholderConst {
                     universe: next_universe,
                     name: bound_var,
                 }),
-                ty,
-            })
+            )
         };
 
         let (result, map) = self.tcx.replace_bound_vars(binder, fld_r, fld_t, fld_c);

--- a/src/librustc_infer/infer/resolve.rs
+++ b/src/librustc_infer/infer/resolve.rs
@@ -228,7 +228,7 @@ impl<'a, 'tcx> TypeFolder<'tcx> for FullTypeResolver<'a, 'tcx> {
             match c.val {
                 ty::ConstKind::Infer(InferConst::Var(vid)) => {
                     self.err = Some(FixupError::UnresolvedConst(vid));
-                    return self.tcx().mk_const(ty::Const { val: ty::ConstKind::Error, ty: c.ty });
+                    return self.tcx().mk_const(c.ty, ty::ConstKind::Error);
                 }
                 ty::ConstKind::Infer(InferConst::Fresh(_)) => {
                     bug!("Unexpected const in full const resolver: {:?}", c);

--- a/src/librustc_middle/arena.rs
+++ b/src/librustc_middle/arena.rs
@@ -71,6 +71,8 @@ macro_rules! arena_types {
             // Interned types
             [] tys: rustc_middle::ty::TyS<$tcx>,
 
+            [] const_: rustc_middle::ty::Const<$tcx>,
+
             // HIR query types
             [few] indexed_hir: rustc_middle::hir::map::IndexedHir<$tcx>,
             [few] hir_definitions: rustc_hir::definitions::Definitions,

--- a/src/librustc_middle/infer/canonical.rs
+++ b/src/librustc_middle/infer/canonical.rs
@@ -328,10 +328,10 @@ impl<'tcx> CanonicalVarValues<'tcx> {
                         .mk_region(ty::ReLateBound(ty::INNERMOST, ty::BoundRegion::BrAnon(i)))
                         .into(),
                     GenericArgKind::Const(ct) => tcx
-                        .mk_const(ty::Const {
-                            ty: ct.ty,
-                            val: ty::ConstKind::Bound(ty::INNERMOST, ty::BoundVar::from_u32(i)),
-                        })
+                        .mk_const(
+                            ct.ty,
+                            ty::ConstKind::Bound(ty::INNERMOST, ty::BoundVar::from_u32(i)),
+                        )
                         .into(),
                 })
                 .collect(),

--- a/src/librustc_middle/ty/codec.rs
+++ b/src/librustc_middle/ty/codec.rs
@@ -291,7 +291,10 @@ pub fn decode_const<D>(decoder: &mut D) -> Result<&'tcx ty::Const<'tcx>, D::Erro
 where
     D: TyDecoder<'tcx>,
 {
-    Ok(decoder.tcx().mk_const(Decodable::decode(decoder)?))
+    // FIXME: we temporarily have a `Const` on the stack here,
+    // as we compare `Const`s using ptr equality, this is dangerous.
+    let ct: ty::Const<'tcx> = Decodable::decode(decoder)?;
+    Ok(decoder.tcx().mk_const(ct.ty, ct.val))
 }
 
 #[inline]

--- a/src/librustc_middle/ty/codec.rs
+++ b/src/librustc_middle/ty/codec.rs
@@ -293,7 +293,7 @@ where
 {
     // FIXME: we temporarily have a `Const` on the stack here,
     // as we compare `Const`s using ptr equality, this is dangerous.
-    let ct: ty::Const<'tcx> = Decodable::decode(decoder)?;
+    let ct: ty::InternedConst<'tcx> = Decodable::decode(decoder)?;
     Ok(decoder.tcx().mk_const(ct.ty, ct.val))
 }
 

--- a/src/librustc_middle/ty/codec.rs
+++ b/src/librustc_middle/ty/codec.rs
@@ -490,6 +490,13 @@ macro_rules! implement_ty_decoder {
                 }
             }
 
+            impl<$($typaram),*> SpecializedDecoder<&'tcx $crate::ty::InternedConst<'tcx>>
+            for $DecoderName<$($typaram),*> {
+                fn specialized_decode(&mut self) -> Result<&'tcx ty::InternedConst<'tcx>, Self::Error> {
+                    decode_const(self).map(|ct| unsafe { std::mem::transmute(ct) })
+                }
+            }
+
             impl<$($typaram),*> SpecializedDecoder<&'tcx $crate::mir::interpret::Allocation>
             for $DecoderName<$($typaram),*> {
                 fn specialized_decode(

--- a/src/librustc_middle/ty/context.rs
+++ b/src/librustc_middle/ty/context.rs
@@ -856,7 +856,7 @@ impl<'tcx> CommonConsts<'tcx> {
         let mk_const = |ct| interners.const_.intern(ct, |ct| Interned(interners.arena.alloc(unsafe { std::mem::transmute(ct) }))).0;
 
         CommonConsts {
-            unit: mk_const(super::sty::InternedConst { ty: types.unit, val: ty::ConstKind::Value(ConstValue::Scalar(Scalar::zst())) }),
+            unit: mk_const(super::InternedConst { ty: types.unit, val: ty::ConstKind::Value(ConstValue::Scalar(Scalar::zst())) }),
         }
     }
 }

--- a/src/librustc_middle/ty/mod.rs
+++ b/src/librustc_middle/ty/mod.rs
@@ -57,7 +57,7 @@ pub use self::sty::{Binder, BoundTy, BoundTyKind, BoundVar, DebruijnIndex, INNER
 pub use self::sty::{BoundRegion, EarlyBoundRegion, FreeRegion, Region};
 pub use self::sty::{CanonicalPolyFnSig, FnSig, GenSig, PolyFnSig, PolyGenSig};
 pub use self::sty::{ClosureSubsts, GeneratorSubsts, TypeAndMut, UpvarSubsts};
-pub use self::sty::{Const, ConstKind, ExistentialProjection, PolyExistentialProjection};
+pub use self::sty::{Const, InternedConst, ConstKind, ExistentialProjection, PolyExistentialProjection};
 pub use self::sty::{ConstVid, FloatVid, IntVid, RegionVid, TyVid};
 pub use self::sty::{ExistentialPredicate, InferConst, InferTy, ParamConst, ParamTy, ProjectionTy};
 pub use self::sty::{ExistentialTraitRef, PolyExistentialTraitRef};

--- a/src/librustc_middle/ty/print/pretty.rs
+++ b/src/librustc_middle/ty/print/pretty.rs
@@ -1160,7 +1160,7 @@ pub trait PrettyPrinter<'tcx>:
             (_, ty::Array(..) | ty::Tuple(..) | ty::Adt(..)) if !ty.has_param_types_or_consts() => {
                 let contents = self.tcx().destructure_const(
                     ty::ParamEnv::reveal_all()
-                        .and(self.tcx().mk_const(ty::Const { val: ty::ConstKind::Value(ct), ty })),
+                        .and(self.tcx().mk_const(ty, ty::ConstKind::Value(ct))),
                 );
                 let fields = contents.fields.iter().copied();
 

--- a/src/librustc_middle/ty/relate.rs
+++ b/src/librustc_middle/ty/relate.rs
@@ -617,7 +617,7 @@ pub fn super_relate_consts<R: TypeRelation<'tcx>>(
         }
         _ => Err(TypeError::ConstMismatch(expected_found(relation, &a, &b))),
     };
-    new_const_val.map(|val| tcx.mk_const(ty::Const { val, ty: a.ty }))
+    new_const_val.map(|val| tcx.mk_const(a.ty, val))
 }
 
 impl<'tcx> Relate<'tcx> for &'tcx ty::List<ty::ExistentialPredicate<'tcx>> {

--- a/src/librustc_middle/ty/structural_impls.rs
+++ b/src/librustc_middle/ty/structural_impls.rs
@@ -1019,7 +1019,7 @@ impl<'tcx> TypeFoldable<'tcx> for &'tcx ty::Const<'tcx> {
     fn super_fold_with<F: TypeFolder<'tcx>>(&self, folder: &mut F) -> Self {
         let ty = self.ty.fold_with(folder);
         let val = self.val.fold_with(folder);
-        folder.tcx().mk_const(ty::Const { ty, val })
+        folder.tcx().mk_const(ty, val)
     }
 
     fn fold_with<F: TypeFolder<'tcx>>(&self, folder: &mut F) -> Self {

--- a/src/librustc_middle/ty/sty.rs
+++ b/src/librustc_middle/ty/sty.rs
@@ -2406,6 +2406,7 @@ impl<'tcx> Const<'tcx> {
 }
 
 impl<'tcx> rustc_serialize::UseSpecializedDecodable for &'tcx Const<'tcx> {}
+impl<'tcx> rustc_serialize::UseSpecializedDecodable for &'tcx InternedConst<'tcx> {}
 
 /// Represents a constant in Rust.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord, RustcEncodable, RustcDecodable, Hash)]

--- a/src/librustc_middle/ty/sty.rs
+++ b/src/librustc_middle/ty/sty.rs
@@ -30,7 +30,6 @@ use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::marker::PhantomData;
 use std::ops::Range;
-use std::ptr;
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, RustcEncodable, RustcDecodable)]
 #[derive(HashStable, TypeFoldable, Lift)]
@@ -2180,30 +2179,24 @@ impl<'tcx> TyS<'tcx> {
 }
 
 /// Typed constant value.
-#[derive(Debug, Hash, RustcEncodable, RustcDecodable, Eq, Ord, PartialOrd)]
+#[derive(Debug, Hash, RustcEncodable, RustcDecodable, PartialEq, Eq, Ord, PartialOrd)]
 #[derive(HashStable)]
+#[repr(C)]
 pub struct Const<'tcx> {
     pub ty: Ty<'tcx>,
 
     pub val: ConstKind<'tcx>,
-
-    /// We compare `Const` by pointer equality. This would be incorrect
-    /// if we were able to create Const values on the stack.
-    ///
-    /// Only allow the creation of consts using `tcx.mk_const(ty, val)`.
-    pub _priv: PrivateMarker,
 }
 
-impl<'tcx> PartialEq for Const<'tcx> {
-    fn eq(&self, other: &Const<'tcx>) -> bool {
-        // All `Const` should be interned.
-        ptr::eq(self, other)
-    }
-}
-
-#[derive(Debug, Hash, RustcEncodable, RustcDecodable, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Debug, Hash, RustcEncodable, RustcDecodable, PartialEq, Eq, Ord, PartialOrd)]
 #[derive(HashStable)]
-pub struct PrivateMarker(pub(super) ());
+#[repr(C)]
+pub struct InternedConst<'tcx> {
+    pub ty: Ty<'tcx>,
+    pub val: ConstKind<'tcx>,
+}
+
+
 
 #[cfg(target_arch = "x86_64")]
 static_assert_size!(Const<'_>, 48);

--- a/src/librustc_mir/interpret/eval_context.rs
+++ b/src/librustc_mir/interpret/eval_context.rs
@@ -849,8 +849,8 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
         // recursion deeper than one level, because the `tcx.const_eval` above is guaranteed to not
         // return `ConstValue::Unevaluated`, which is the only way that `eval_const_to_op` will call
         // `ecx.const_eval`.
-        let const_ = ty::Const { val: ty::ConstKind::Value(val), ty };
-        self.eval_const_to_op(&const_, None)
+        let const_ = self.tcx.mk_const(ty, ty::ConstKind::Value(val));
+        self.eval_const_to_op(const_, None)
     }
 
     pub fn const_eval_raw(

--- a/src/librustc_mir/transform/const_prop.rs
+++ b/src/librustc_mir/transform/const_prop.rs
@@ -606,7 +606,7 @@ impl<'mir, 'tcx> ConstPropagator<'mir, 'tcx> {
         Operand::Constant(Box::new(Constant {
             span,
             user_ty: None,
-            literal: self.tcx.mk_const(*ty::Const::from_scalar(self.tcx, scalar, ty)),
+            literal: ty::Const::from_scalar(self.tcx, scalar, ty),
         }))
     }
 

--- a/src/librustc_mir/transform/promote_consts.rs
+++ b/src/librustc_mir/transform/promote_consts.rs
@@ -954,9 +954,9 @@ impl<'a, 'tcx> Promoter<'a, 'tcx> {
                 Operand::Constant(Box::new(Constant {
                     span,
                     user_ty: None,
-                    literal: tcx.mk_const(ty::Const {
+                    literal: tcx.mk_const(
                         ty,
-                        val: ty::ConstKind::Unevaluated(
+                        ty::ConstKind::Unevaluated(
                             def_id,
                             InternalSubsts::for_item(tcx, def_id, |param, _| {
                                 if let ty::GenericParamDefKind::Lifetime = param.kind {
@@ -967,7 +967,7 @@ impl<'a, 'tcx> Promoter<'a, 'tcx> {
                             }),
                             Some(promoted_id),
                         ),
-                    }),
+                    ),
                 }))
             };
             let (blocks, local_decls) = self.source.basic_blocks_and_local_decls_mut();

--- a/src/librustc_mir_build/hair/cx/expr.rs
+++ b/src/librustc_mir_build/hair/cx/expr.rs
@@ -627,10 +627,11 @@ fn make_mirror_unadjusted<'a, 'tcx>(
                             // in case we are offsetting from a computed discriminant
                             // and not the beginning of discriminants (which is always `0`)
                             let substs = InternalSubsts::identity_for_item(cx.tcx(), did);
-                            let lhs = mk_const(cx.tcx().mk_const(ty::Const {
-                                val: ty::ConstKind::Unevaluated(did, substs, None),
-                                ty: var_ty,
-                            }));
+                            let lhs =
+                                mk_const(cx.tcx().mk_const(
+                                    var_ty,
+                                    ty::ConstKind::Unevaluated(did, substs, None),
+                                ));
                             let bin = ExprKind::Binary { op: BinOp::Add, lhs, rhs: offset };
                             Expr { temp_lifetime, ty: var_ty, span: expr.span, kind: bin }.to_ref()
                         }
@@ -814,7 +815,7 @@ fn convert_path_expr<'a, 'tcx>(
             let name = cx.tcx.hir().name(hir_id);
             let val = ty::ConstKind::Param(ty::ParamConst::new(index, name));
             ExprKind::Literal {
-                literal: cx.tcx.mk_const(ty::Const { val, ty: cx.tables().node_type(expr.hir_id) }),
+                literal: cx.tcx.mk_const(cx.tables().node_type(expr.hir_id), val),
                 user_ty: None,
             }
         }
@@ -823,10 +824,10 @@ fn convert_path_expr<'a, 'tcx>(
             let user_ty = user_substs_applied_to_res(cx, expr.hir_id, res);
             debug!("convert_path_expr: (const) user_ty={:?}", user_ty);
             ExprKind::Literal {
-                literal: cx.tcx.mk_const(ty::Const {
-                    val: ty::ConstKind::Unevaluated(def_id, substs, None),
-                    ty: cx.tables().node_type(expr.hir_id),
-                }),
+                literal: cx.tcx.mk_const(
+                    cx.tables().node_type(expr.hir_id),
+                    ty::ConstKind::Unevaluated(def_id, substs, None),
+                ),
                 user_ty,
             }
         }

--- a/src/librustc_mir_build/hair/pattern/_match.rs
+++ b/src/librustc_mir_build/hair/pattern/_match.rs
@@ -376,6 +376,7 @@ impl<'tcx> PatternFolder<'tcx> for LiteralExpander<'tcx> {
                         Const {
                             val: ty::ConstKind::Value(val),
                             ty: ty::TyS { kind: ty::Ref(_, crty, _), .. },
+                            ..
                         },
                 },
             ) => Pat {
@@ -399,7 +400,7 @@ impl<'tcx> PatternFolder<'tcx> for LiteralExpander<'tcx> {
             (
                 &ty::Ref(_, rty, _),
                 &PatKind::Constant {
-                    value: Const { val, ty: ty::TyS { kind: ty::Ref(_, crty, _), .. } },
+                    value: Const { val, ty: ty::TyS { kind: ty::Ref(_, crty, _), .. }, .. },
                 },
             ) => bug!("cannot deref {:#?}, {} -> {}", val, crty, rty),
 

--- a/src/librustc_mir_build/hair/pattern/mod.rs
+++ b/src/librustc_mir_build/hair/pattern/mod.rs
@@ -936,7 +936,7 @@ macro_rules! CloneImpls {
 }
 
 CloneImpls! { <'tcx>
-    Span, Field, Mutability, Symbol, hir::HirId, usize, ty::Const<'tcx>,
+    Span, Field, Mutability, Symbol, hir::HirId, usize, &'tcx ty::Const<'tcx>,
     Region<'tcx>, Ty<'tcx>, BindingMode, &'tcx AdtDef,
     SubstsRef<'tcx>, &'tcx GenericArg<'tcx>, UserType<'tcx>,
     UserTypeProjection, PatTyProj<'tcx>

--- a/src/librustc_trait_selection/opaque_types.rs
+++ b/src/librustc_trait_selection/opaque_types.rs
@@ -971,7 +971,7 @@ impl TypeFolder<'tcx> for ReverseMapper<'tcx> {
                             )
                             .emit();
 
-                        self.tcx().mk_const(ty::Const { val: ty::ConstKind::Error, ty: ct.ty })
+                        self.tcx().mk_const(ct.ty, ty::ConstKind::Error)
                     }
                 }
             }

--- a/src/librustc_trait_selection/traits/wf.rs
+++ b/src/librustc_trait_selection/traits/wf.rs
@@ -309,7 +309,7 @@ impl<'a, 'tcx> WfPredicates<'a, 'tcx> {
 
     /// Pushes the obligations required for an array length to be WF
     /// into `self.out`.
-    fn compute_array_len(&mut self, constant: ty::Const<'tcx>) {
+    fn compute_array_len(&mut self, constant: &ty::Const<'tcx>) {
         if let ty::ConstKind::Unevaluated(def_id, substs, promoted) = constant.val {
             assert!(promoted.is_none());
 
@@ -385,7 +385,7 @@ impl<'a, 'tcx> WfPredicates<'a, 'tcx> {
                 ty::Array(subty, len) => {
                     self.require_sized(subty, traits::SliceOrArrayElem);
                     // FIXME(eddyb) handle `GenericArgKind::Const` above instead.
-                    self.compute_array_len(*len);
+                    self.compute_array_len(len);
                 }
 
                 ty::Tuple(ref tys) => {

--- a/src/librustc_traits/chalk/db.rs
+++ b/src/librustc_traits/chalk/db.rs
@@ -494,10 +494,10 @@ fn bound_vars_for_item(tcx: TyCtxt<'tcx>, def_id: DefId) -> SubstsRef<'tcx> {
             .into(),
 
         ty::GenericParamDefKind::Const => tcx
-            .mk_const(ty::Const {
-                val: ty::ConstKind::Bound(ty::INNERMOST, ty::BoundVar::from(param.index)),
-                ty: tcx.type_of(param.def_id),
-            })
+            .mk_const(
+                tcx.type_of(param.def_id),
+                ty::ConstKind::Bound(ty::INNERMOST, ty::BoundVar::from(param.index)),
+            )
             .into(),
     })
 }

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -836,7 +836,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                             self.ct_infer(ty, Some(param), span).into()
                         } else {
                             // We've already errored above about the mismatch.
-                            tcx.mk_const(ty::Const { val: ty::ConstKind::Error, ty }).into()
+                            tcx.mk_const(ty, ty::ConstKind::Error).into()
                         }
                     }
                 }

--- a/src/librustc_typeck/check/writeback.rs
+++ b/src/librustc_typeck/check/writeback.rs
@@ -698,7 +698,7 @@ impl<'cx, 'tcx> TypeFolder<'tcx> for Resolver<'cx, 'tcx> {
                 debug!("Resolver::fold_const: input const `{:?}` not fully resolvable", ct);
                 self.report_const_error(ct);
                 self.replaced_with_error = true;
-                self.tcx().mk_const(ty::Const { val: ty::ConstKind::Error, ty: ct.ty })
+                self.tcx().mk_const(ct.ty, ty::ConstKind::Error)
             }
         }
     }

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -319,7 +319,7 @@ impl AstConv<'tcx> for ItemCtxt<'tcx> {
     ) -> &'tcx Const<'tcx> {
         bad_placeholder_type(self.tcx(), vec![span]).emit();
 
-        self.tcx().mk_const(ty::Const { val: ty::ConstKind::Error, ty })
+        self.tcx().mk_const(ty, ty::ConstKind::Error)
     }
 
     fn projected_ty_from_poly_trait_ref(
@@ -2043,8 +2043,7 @@ fn associated_item_predicates(
             }
             ty::GenericParamDefKind::Const => {
                 unimplemented_error("const");
-                tcx.mk_const(ty::Const { val: ty::ConstKind::Error, ty: tcx.type_of(param.def_id) })
-                    .into()
+                tcx.mk_const(tcx.type_of(param.def_id), ty::ConstKind::Error).into()
             }
         }
     };


### PR DESCRIPTION
Similar to `Ty<'tcx>` this PR now compares `Const`s using pointer equality.

To prevent ourselves from accidentally creating a const on the stack I added a new
zero sized field to `Const`. This field has to be `public`, to allow pattern matching on consts
and has a private field, to prevent construction outside of `rustc_middle::ty`.

Let's see if this actually changes perf in any meaningful way :shrug:
I did not yet update the test output.