### PR TITLE
Add test for #66930

### DIFF
--- a/src/test/ui/mir/issue-66930.rs
+++ b/src/test/ui/mir/issue-66930.rs
@@ -1,0 +1,11 @@
+// check-pass
+// compile-flags: --emit=mir,link
+// Regression test for #66930, this ICE requires `--emit=mir` flag.
+
+static UTF8_CHAR_WIDTH: [u8; 0] = [];
+
+pub fn utf8_char_width(b: u8) -> usize {
+    UTF8_CHAR_WIDTH[b as usize] as usize
+}
+
+fn main() {}


### PR DESCRIPTION
Closes #66930 
Closes #67558

They're fixed by #72424.
I skipped adding `--emit=mir` flag to src/test/ui/issues/issue-25145.rs as a regression test since the root cause seems the same and it should be run with `check-pass`, not `run-pass` so we should duplicate that test.

r? @RalfJung
