### PR TITLE
added .collect() into String from Box<str>

### DIFF
--- a/src/liballoc/string.rs
+++ b/src/liballoc/string.rs
@@ -1772,6 +1772,15 @@ impl FromIterator<String> for String {
     }
 }
 
+#[stable(feature = "box_str2", since = "1.45.0")]
+impl FromIterator<Box<str>> for String {
+    fn from_iter<I: IntoIterator<Item = Box<str>>>(iter: I) -> String {
+        let mut buf = String::new();
+        buf.extend(iter);
+        buf
+    }
+}
+
 #[stable(feature = "herd_cows", since = "1.19.0")]
 impl<'a> FromIterator<Cow<'a, str>> for String {
     fn from_iter<I: IntoIterator<Item = Cow<'a, str>>>(iter: I) -> String {
@@ -1812,6 +1821,13 @@ impl<'a> Extend<&'a char> for String {
 impl<'a> Extend<&'a str> for String {
     fn extend<I: IntoIterator<Item = &'a str>>(&mut self, iter: I) {
         iter.into_iter().for_each(move |s| self.push_str(s));
+    }
+}
+
+#[stable(feature = "box_str2", since = "1.45.0")]
+impl Extend<Box<str>> for String {
+    fn extend<I: IntoIterator<Item = Box<str>>>(&mut self, iter: I) {
+        iter.into_iter().for_each(move |s| self.push_str(&s));
     }
 }
 


### PR DESCRIPTION
I have not created an rfc, because i felt like this is a very minor change.

i have just set a random feature name and rust version as stability attribute, i expect to have to change that, i just don't know what the policy on that is. all guides i could find focused on contributing to the compiler, not contributing to the standard library.

drawbacks: more code in the standard library, could be replaced with specialization: base-implementation for AsRef\<str> and specialization for String and Cow. i can write that code if ppl want it.

advantages: using "real strings" i.e. Box\<str> is as ergonomic as string slices (&str) and string buffers (String) with iterators.