### PR TITLE
update data layout for illumos x86

### DIFF
--- a/src/librustc_target/spec/x86_64_unknown_illumos.rs
+++ b/src/librustc_target/spec/x86_64_unknown_illumos.rs
@@ -13,7 +13,8 @@ pub fn target() -> TargetResult {
         target_endian: "little".to_string(),
         target_pointer_width: "64".to_string(),
         target_c_int_width: "32".to_string(),
-        data_layout: "e-m:e-i64:64-f80:128-n8:16:32:64-S128".to_string(),
+        data_layout: "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+            .to_string(),
         arch: "x86_64".to_string(),
         target_os: "illumos".to_string(),
         target_env: String::new(),


### PR DESCRIPTION
In a recent change, 8b199222cc92667cd0e57595ad435cd0a7526af8,
adjustments were made to the data layout we pass to LLVM.
Unfortunately, the illumos target was missed in this change.
See also: https://github.com/rust-lang/rust/pull/67900