### PR TITLE
Enable LLVM zlib

### DIFF
--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -158,7 +158,6 @@ impl Step for Llvm {
             .define("LLVM_INCLUDE_TESTS", "OFF")
             .define("LLVM_INCLUDE_DOCS", "OFF")
             .define("LLVM_INCLUDE_BENCHMARKS", "OFF")
-            .define("LLVM_ENABLE_ZLIB", "OFF")
             .define("WITH_POLLY", "OFF")
             .define("LLVM_ENABLE_TERMINFO", "OFF")
             .define("LLVM_ENABLE_LIBEDIT", "OFF")
@@ -167,6 +166,14 @@ impl Step for Llvm {
             .define("LLVM_PARALLEL_COMPILE_JOBS", builder.jobs().to_string())
             .define("LLVM_TARGET_ARCH", target.split('-').next().unwrap())
             .define("LLVM_DEFAULT_TARGET_TRIPLE", target);
+
+        if !target.contains("netbsd") {
+            cfg.define("LLVM_ENABLE_ZLIB", "ON");
+        } else {
+            // FIXME: Enable zlib on NetBSD too
+            // https://github.com/rust-lang/rust/pull/72696#issuecomment-641517185
+            cfg.define("LLVM_ENABLE_ZLIB", "OFF");
+        }
 
         if builder.config.llvm_thin_lto {
             cfg.define("LLVM_ENABLE_LTO", "Thin");


### PR DESCRIPTION
Compilers may generate ELF objects with compressed sections (although rustc currently doesn't do this). Currently, when linking these with `rust-lld`, you'll get this error:

`rust-lld: error: ...: contains a compressed section, but zlib is not available`

This enables zlib when building LLVM.