### PR TITLE
Do not add external libraries to libstd stamp file

### DIFF
--- a/src/bootstrap/check.rs
+++ b/src/bootstrap/check.rs
@@ -53,7 +53,6 @@ impl Step for Std {
             cargo,
             args(builder.kind),
             &libstd_stamp(builder, compiler, target),
-            vec![],
             true,
         );
 
@@ -102,7 +101,6 @@ impl Step for Rustc {
             cargo,
             args(builder.kind),
             &librustc_stamp(builder, compiler, target),
-            vec![],
             true,
         );
 
@@ -160,7 +158,6 @@ macro_rules! tool_check_step {
                     cargo,
                     args(builder.kind),
                     &stamp(builder, compiler, target),
-                    vec![],
                     true,
                 );
 

--- a/src/ci/azure-pipelines/try.yml
+++ b/src/ci/azure-pipelines/try.yml
@@ -26,59 +26,17 @@ jobs:
   strategy:
     matrix:
       dist-x86_64-linux: {}
-      dist-x86_64-linux-alt:
-        IMAGE: dist-x86_64-linux
-
-# The macOS and Windows builds here are currently disabled due to them not being
-# overly necessary on `try` builds. We also don't actually have anything that
-# consumes the artifacts currently. Perhaps one day we can re-enable, but for now
-# it helps free up capacity on Azure.
-# - job: macOS
-#   timeoutInMinutes: 600
-#   pool:
-#     vmImage: macos-10.15
-#   steps:
-#   - template: steps/run.yml
-#   strategy:
-#     matrix:
-#       dist-x86_64-apple:
-#         SCRIPT: ./x.py dist
-#         INITIAL_RUST_CONFIGURE_ARGS: --target=aarch64-apple-ios,armv7-apple-ios,armv7s-apple-ios,i386-apple-ios,x86_64-apple-ios --enable-full-tools --enable-sanitizers --enable-profiler --set rust.jemalloc
-#         DEPLOY: 1
-#         RUSTC_RETRY_LINKER_ON_SEGFAULT: 1
-#         MACOSX_DEPLOYMENT_TARGET: 10.7
-#         NO_LLVM_ASSERTIONS: 1
-#         NO_DEBUG_ASSERTIONS: 1
-#         DIST_REQUIRE_ALL_TOOLS: 1
-#
-#       dist-x86_64-apple-alt:
-#         SCRIPT: ./x.py dist
-#         INITIAL_RUST_CONFIGURE_ARGS: --enable-extended --enable-profiler --set rust.jemalloc
-#         DEPLOY_ALT: 1
-#         RUSTC_RETRY_LINKER_ON_SEGFAULT: 1
-#         MACOSX_DEPLOYMENT_TARGET: 10.7
-#         NO_LLVM_ASSERTIONS: 1
-#         NO_DEBUG_ASSERTIONS: 1
-#
-# - job: Windows
-#   timeoutInMinutes: 600
-#   pool:
-#     vmImage: 'vs2017-win2016'
-#   steps:
-#   - template: steps/run.yml
-#   strategy:
-#     matrix:
-#       dist-x86_64-msvc:
-#         INITIAL_RUST_CONFIGURE_ARGS: >
-#           --build=x86_64-pc-windows-msvc
-#           --target=x86_64-pc-windows-msvc,aarch64-pc-windows-msvc
-#           --enable-full-tools
-#           --enable-profiler
-#         SCRIPT: python x.py dist
-#         DIST_REQUIRE_ALL_TOOLS: 1
-#         DEPLOY: 1
-#
-#       dist-x86_64-msvc-alt:
-#         INITIAL_RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc --enable-extended --enable-profiler
-#         SCRIPT: python x.py dist
-#         DEPLOY_ALT: 1
+      dist-i586-gnu-i586-i686-musl: {}
+- job: Windows
+  timeoutInMinutes: 600
+  pool:
+    vmImage: 'vs2017-win2016'
+  steps:
+  - template: steps/run.yml
+  strategy:
+    matrix:
+      dist-x86_64-mingw:
+        SCRIPT: python x.py dist
+        INITIAL_RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-gnu --enable-full-tools --enable-profiler
+        CUSTOM_MINGW: 1
+        DIST_REQUIRE_ALL_TOOLS: 1


### PR DESCRIPTION
Currently they are present in `.libstd.stamp` and point to target sysroot:
```
tD:\Projekty\rust\build\x86_64-pc-windows-gnu\stage1\lib\rustlib\x86_64-pc-windows-gnu\lib\crt2.o
```
while normal objects point to non sysroot locations:
```
tD:\Projekty\rust\build\x86_64-pc-windows-gnu\stage1-std\x86_64-pc-windows-gnu\release\deps\liballoc-eb2e01dae1fd9cc7.rlib
```

Now `add_to_sysroot(...)` function reads stamp file and copies everything listed to the target or host sysroot. So in case of those objects we are effectively copying the inplace (from `target_sysroot/lib/X` to `target_sysroot/lib/X`).

This PR also prepares ground for moving those objects to different location: https://github.com/rust-lang/rust/issues/68887#issuecomment-633048380