### PR TITLE
rustc_lint: Remove `unused_crate_dependencies` from the `unused` group

### DIFF
--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -276,7 +276,6 @@ fn register_builtins(store: &mut LintStore, no_interleave_lints: bool) {
         UNUSED_ALLOCATION,
         UNUSED_DOC_COMMENTS,
         UNUSED_EXTERN_CRATES,
-        UNUSED_CRATE_DEPENDENCIES,
         UNUSED_FEATURES,
         UNUSED_LABELS,
         UNUSED_PARENS,

--- a/src/test/ui/unused-crate-deps/lint-group.rs
+++ b/src/test/ui/unused-crate-deps/lint-group.rs
@@ -1,0 +1,9 @@
+// `unused_crate_dependencies` is not currently in the `unused` group
+// due to false positives from Cargo.
+
+// check-pass
+// aux-crate:bar=bar.rs
+
+#![deny(unused)]
+
+fn main() {}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/72686

It's undesirable to enable `unused_crate_dependencies` with blanket `#![deny(unused)]` due to the amount of redundant `--extern` options passed by Cargo.