### PR TITLE
Remote testing fixes

### DIFF
--- a/src/test/ui-fulldeps/compiler-calls.rs
+++ b/src/test/ui-fulldeps/compiler-calls.rs
@@ -3,6 +3,7 @@
 
 // ignore-cross-compile
 // ignore-stage1
+// ignore-remote
 
 #![feature(rustc_private)]
 

--- a/src/test/ui-fulldeps/mod_dir_path_canonicalized.rs
+++ b/src/test/ui-fulldeps/mod_dir_path_canonicalized.rs
@@ -1,6 +1,7 @@
 // run-pass
 // Testing that a librustc_ast can parse modules with canonicalized base path
 // ignore-cross-compile
+// ignore-remote
 
 #![feature(rustc_private)]
 

--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -853,6 +853,7 @@ impl Config {
             name == util::get_pointer_width(&self.target) ||    // pointer width
             name == self.stage_id.split('-').next().unwrap() || // stage
             (self.target != self.host && name == "cross-compile") ||
+            (self.remote_test_client.is_some() && name == "remote") ||
             match self.compare_mode {
                 Some(CompareMode::Nll) => name == "compare-mode-nll",
                 Some(CompareMode::Polonius) => name == "compare-mode-polonius",

--- a/src/tools/remote-test-client/src/main.rs
+++ b/src/tools/remote-test-client/src/main.rs
@@ -224,7 +224,7 @@ fn run(support_lib_count: usize, exe: String, all_args: Vec<String>) {
     // by the client.
     for (k, v) in env::vars() {
         match &k[..] {
-            "PATH" | "LD_LIBRARY_PATH" | "PWD" => continue,
+            "PATH" | "LD_LIBRARY_PATH" | "PWD" | "RUST_TEST_TMPDIR" => continue,
             _ => {}
         }
         t!(client.write_all(k.as_bytes()));


### PR DESCRIPTION
Improvements for remote testing

- Create a `RUST_TEST_TMPDIR` directory on the remote testing host
- Verbose mode for remote-test-server
- Skip tests which don't support remote testing using `// ignore-remote`

To test:
- Build `remote-test-server` for the target machine and copy it over
- On the target:
``` sh
remote-test-server remote
```
- On the build machine
``` sh
export TEST_DEVICE_ADDR="1.2.3.4:12345"
./x.py test
```