### PR TITLE
Added io forwarding methods to the stdio structs

### DIFF
--- a/src/libstd/io/stdio.rs
+++ b/src/libstd/io/stdio.rs
@@ -652,9 +652,6 @@ impl Write for Stdout {
     fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
         self.lock().write_all(buf)
     }
-    fn write_fmt(&mut self, args: fmt::Arguments<'_>) -> io::Result<()> {
-        self.lock().write_fmt(args)
-    }
     fn write_all_vectored(&mut self, bufs: &mut [IoSlice<'_>]) -> io::Result<()> {
         self.lock().write_all_vectored(bufs)
     }
@@ -679,9 +676,6 @@ impl Write for StdoutLock<'_> {
     }
     fn write_all_vectored(&mut self, bufs: &mut [IoSlice<'_>]) -> io::Result<()> {
         self.inner.borrow_mut().write_all_vectored(bufs)
-    }
-    fn write_fmt(&mut self, fmt: fmt::Arguments<'_>) -> io::Result<()> {
-        self.inner.borrow_mut().write_fmt(fmt)
     }
 }
 
@@ -838,9 +832,6 @@ impl Write for Stderr {
     fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
         self.lock().write_all(buf)
     }
-    fn write_fmt(&mut self, args: fmt::Arguments<'_>) -> io::Result<()> {
-        self.lock().write_fmt(args)
-    }
     fn write_all_vectored(&mut self, bufs: &mut [IoSlice<'_>]) -> io::Result<()> {
         self.lock().write_all_vectored(bufs)
     }
@@ -865,9 +856,6 @@ impl Write for StderrLock<'_> {
     }
     fn write_all_vectored(&mut self, bufs: &mut [IoSlice<'_>]) -> io::Result<()> {
         self.inner.borrow_mut().write_all_vectored(bufs)
-    }
-    fn write_fmt(&mut self, fmt: fmt::Arguments<'_>) -> io::Result<()> {
-        self.inner.borrow_mut().write_fmt(fmt)
     }
 }
 

--- a/src/libstd/io/stdio.rs
+++ b/src/libstd/io/stdio.rs
@@ -655,6 +655,9 @@ impl Write for Stdout {
     fn write_all_vectored(&mut self, bufs: &mut [IoSlice<'_>]) -> io::Result<()> {
         self.lock().write_all_vectored(bufs)
     }
+    fn write_fmt(&mut self, args: fmt::Arguments<'_>) -> io::Result<()> {
+        self.lock().write_fmt(args)
+    }
 }
 #[stable(feature = "rust1", since = "1.0.0")]
 impl Write for StdoutLock<'_> {
@@ -834,6 +837,9 @@ impl Write for Stderr {
     }
     fn write_all_vectored(&mut self, bufs: &mut [IoSlice<'_>]) -> io::Result<()> {
         self.lock().write_all_vectored(bufs)
+    }
+    fn write_fmt(&mut self, args: fmt::Arguments<'_>) -> io::Result<()> {
+        self.lock().write_fmt(args)
     }
 }
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/libstd/io/stdio.rs
+++ b/src/libstd/io/stdio.rs
@@ -96,7 +96,20 @@ impl Read for StdinRaw {
     unsafe fn initializer(&self) -> Initializer {
         Initializer::nop()
     }
+
+    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> io::Result<usize> {
+        self.0.read_to_end(buf)
+    }
+
+    fn read_to_string(&mut self, buf: &mut String) -> io::Result<usize> {
+        self.0.read_to_string(buf)
+    }
+
+    fn read_exact(&mut self, buf: &mut [u8]) -> io::Result<()> {
+        self.0.read_exact(buf)
+    }
 }
+
 impl Write for StdoutRaw {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         self.0.write(buf)
@@ -114,7 +127,20 @@ impl Write for StdoutRaw {
     fn flush(&mut self) -> io::Result<()> {
         self.0.flush()
     }
+
+    fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
+        self.0.write_all(buf)
+    }
+
+    fn write_all_vectored(&mut self, bufs: &mut [IoSlice<'_>]) -> io::Result<()> {
+        self.0.write_all_vectored(bufs)
+    }
+
+    fn write_fmt(&mut self, fmt: fmt::Arguments<'_>) -> io::Result<()> {
+        self.0.write_fmt(fmt)
+    }
 }
+
 impl Write for StderrRaw {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         self.0.write(buf)
@@ -131,6 +157,18 @@ impl Write for StderrRaw {
 
     fn flush(&mut self) -> io::Result<()> {
         self.0.flush()
+    }
+
+    fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
+        self.0.write_all(buf)
+    }
+
+    fn write_all_vectored(&mut self, bufs: &mut [IoSlice<'_>]) -> io::Result<()> {
+        self.0.write_all_vectored(bufs)
+    }
+
+    fn write_fmt(&mut self, fmt: fmt::Arguments<'_>) -> io::Result<()> {
+        self.0.write_fmt(fmt)
     }
 }
 
@@ -420,6 +458,18 @@ impl Read for StdinLock<'_> {
     unsafe fn initializer(&self) -> Initializer {
         Initializer::nop()
     }
+
+    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> io::Result<usize> {
+        self.inner.read_to_end(buf)
+    }
+
+    fn read_to_string(&mut self, buf: &mut String) -> io::Result<usize> {
+        self.inner.read_to_string(buf)
+    }
+
+    fn read_exact(&mut self, buf: &mut [u8]) -> io::Result<()> {
+        self.inner.read_exact(buf)
+    }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -427,8 +477,17 @@ impl BufRead for StdinLock<'_> {
     fn fill_buf(&mut self) -> io::Result<&[u8]> {
         self.inner.fill_buf()
     }
+
     fn consume(&mut self, n: usize) {
         self.inner.consume(n)
+    }
+
+    fn read_until(&mut self, byte: u8, buf: &mut Vec<u8>) -> io::Result<usize> {
+        self.inner.read_until(byte, buf)
+    }
+
+    fn read_line(&mut self, buf: &mut String) -> io::Result<usize> {
+        self.inner.read_line(buf)
     }
 }
 
@@ -596,6 +655,9 @@ impl Write for Stdout {
     fn write_fmt(&mut self, args: fmt::Arguments<'_>) -> io::Result<()> {
         self.lock().write_fmt(args)
     }
+    fn write_all_vectored(&mut self, bufs: &mut [IoSlice<'_>]) -> io::Result<()> {
+        self.lock().write_all_vectored(bufs)
+    }
 }
 #[stable(feature = "rust1", since = "1.0.0")]
 impl Write for StdoutLock<'_> {
@@ -611,6 +673,15 @@ impl Write for StdoutLock<'_> {
     }
     fn flush(&mut self) -> io::Result<()> {
         self.inner.borrow_mut().flush()
+    }
+    fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
+        self.inner.borrow_mut().write_all(buf)
+    }
+    fn write_all_vectored(&mut self, bufs: &mut [IoSlice<'_>]) -> io::Result<()> {
+        self.inner.borrow_mut().write_all_vectored(bufs)
+    }
+    fn write_fmt(&mut self, fmt: fmt::Arguments<'_>) -> io::Result<()> {
+        self.inner.borrow_mut().write_fmt(fmt)
     }
 }
 
@@ -770,6 +841,9 @@ impl Write for Stderr {
     fn write_fmt(&mut self, args: fmt::Arguments<'_>) -> io::Result<()> {
         self.lock().write_fmt(args)
     }
+    fn write_all_vectored(&mut self, bufs: &mut [IoSlice<'_>]) -> io::Result<()> {
+        self.lock().write_all_vectored(bufs)
+    }
 }
 #[stable(feature = "rust1", since = "1.0.0")]
 impl Write for StderrLock<'_> {
@@ -785,6 +859,15 @@ impl Write for StderrLock<'_> {
     }
     fn flush(&mut self) -> io::Result<()> {
         self.inner.borrow_mut().flush()
+    }
+    fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
+        self.inner.borrow_mut().write_all(buf)
+    }
+    fn write_all_vectored(&mut self, bufs: &mut [IoSlice<'_>]) -> io::Result<()> {
+        self.inner.borrow_mut().write_all_vectored(bufs)
+    }
+    fn write_fmt(&mut self, fmt: fmt::Arguments<'_>) -> io::Result<()> {
+        self.inner.borrow_mut().write_fmt(fmt)
     }
 }
 


### PR DESCRIPTION
Added methods to forward the `io::Read` and `io::Write` methods of the myriad wrapper structs in `stdio.rs` to their underlying readers / writers. This is especially important for the structs on the outside of a locking boundary, to ensure that the lock isn't being dropped and re-acquired in a loop.

