### PR TITLE
linker: Add a linker rerun hack for gcc versions not supporting -static-pie

### DIFF
--- a/src/librustc_target/spec/tests/tests_impl.rs
+++ b/src/librustc_target/spec/tests/tests_impl.rs
@@ -39,5 +39,10 @@ impl Target {
                 assert_eq!(self.options.lld_flavor, LldFlavor::Link);
             }
         }
+        assert!(
+            (self.options.pre_link_objects_fallback.is_empty()
+                && self.options.post_link_objects_fallback.is_empty())
+                || self.options.crt_objects_fallback.is_some()
+        );
     }
 }


### PR DESCRIPTION
Which mirrors the existing `-no-pie` linker rerun hack, but the logic is a bit more elaborated in this case.

If the linker (gcc or clang) errors on `-static-pie` we rerun in with `-static` instead.
We must also replace CRT objects corresponding to `-static-pie` with ones corresponding to `-static` in this case.

(One sanity check for CRT objects in target specs is also added as a drive-by fix.)

To do in the future: refactor all linker rerun hacks into separate functions and share more code with `add_(pre,post)_link_objects`.

This PR accompanies https://github.com/rust-lang/rust/pull/71804 and unblocks https://github.com/rust-lang/rust/pull/70740.