### PR TITLE
Add test to make sure -Wunused-crate-dependencies works with tests

### DIFF
--- a/src/test/ui/unused-crate-deps/test-use-ok.rs
+++ b/src/test/ui/unused-crate-deps/test-use-ok.rs
@@ -1,0 +1,15 @@
+// Test-only use OK
+
+// edition:2018
+// check-pass
+// aux-crate:bar=bar.rs
+// compile-flags:--test
+
+#![deny(unused_crate_dependencies)]
+
+fn main() {}
+
+#[test]
+fn test_bar() {
+    assert_eq!(bar::BAR, "bar");
+}


### PR DESCRIPTION
Make sure code in `#[test]` blocks counts as a use of a crate.