### PR TITLE
remove redundant `mk_const`

### DIFF
--- a/src/librustc_mir/transform/const_prop.rs
+++ b/src/librustc_mir/transform/const_prop.rs
@@ -606,7 +606,7 @@ impl<'mir, 'tcx> ConstPropagator<'mir, 'tcx> {
         Operand::Constant(Box::new(Constant {
             span,
             user_ty: None,
-            literal: self.tcx.mk_const(*ty::Const::from_scalar(self.tcx, scalar, ty)),
+            literal: ty::Const::from_scalar(self.tcx, scalar, ty),
         }))
     }
 


### PR DESCRIPTION
Taken from #72675 as this is fairly unrelated and that PR is more difficult than I imagined,
so it may take some time until it lands.