### PR TITLE
Account for trailing comma when suggesting `where` clauses

### DIFF
--- a/src/librustc_hir/hir.rs
+++ b/src/librustc_hir/hir.rs
@@ -525,6 +525,13 @@ impl WhereClause<'_> {
     pub fn span_for_predicates_or_empty_place(&self) -> Span {
         self.span
     }
+
+    /// `Span` where further predicates would be suggested, accounting for trailing commas, like
+    ///  in `fn foo<T>(t: T) where T: Foo,` so we don't suggest two trailing commas.
+    pub fn tail_span_for_suggestion(&self) -> Span {
+        let end = self.span_for_predicates_or_empty_place().shrink_to_hi();
+        self.predicates.last().map(|p| p.span()).unwrap_or(end).shrink_to_hi().to(end)
+    }
 }
 
 /// A single predicate in a where-clause.

--- a/src/librustc_middle/ty/diagnostics.rs
+++ b/src/librustc_middle/ty/diagnostics.rs
@@ -220,22 +220,11 @@ pub fn suggest_constraining_type_param(
             }
         }
 
-        // Account for `fn foo<T>(t: T) where T: Foo,` so we don't suggest two trailing commas.
-        let end = generics.where_clause.span_for_predicates_or_empty_place().shrink_to_hi();
-        let where_clause_span = generics
-            .where_clause
-            .predicates
-            .last()
-            .map(|p| p.span())
-            .unwrap_or(end)
-            .shrink_to_hi()
-            .to(end);
-
         match &param_spans[..] {
             &[&param_span] => suggest_restrict(param_span.shrink_to_hi()),
             _ => {
                 err.span_suggestion_verbose(
-                    where_clause_span,
+                    generics.where_clause.tail_span_for_suggestion(),
                     &msg_restrict_type_further,
                     format!(", {}: {}", param_name, constraint),
                     Applicability::MachineApplicable,

--- a/src/librustc_trait_selection/traits/error_reporting/suggestions.rs
+++ b/src/librustc_trait_selection/traits/error_reporting/suggestions.rs
@@ -169,17 +169,8 @@ pub trait InferCtxtExt<'tcx> {
 }
 
 fn predicate_constraint(generics: &hir::Generics<'_>, pred: String) -> (Span, String) {
-    let end = generics.where_clause.span_for_predicates_or_empty_place().shrink_to_hi();
     (
-        // Account for `where T: Foo,` so we don't suggest two trailing commas.
-        generics
-            .where_clause
-            .predicates
-            .last()
-            .map(|p| p.span())
-            .unwrap_or(end)
-            .shrink_to_hi()
-            .to(end),
+        generics.where_clause.tail_span_for_suggestion(),
         format!(
             "{} {}",
             if !generics.where_clause.predicates.is_empty() { "," } else { " where" },

--- a/src/librustc_trait_selection/traits/error_reporting/suggestions.rs
+++ b/src/librustc_trait_selection/traits/error_reporting/suggestions.rs
@@ -169,8 +169,17 @@ pub trait InferCtxtExt<'tcx> {
 }
 
 fn predicate_constraint(generics: &hir::Generics<'_>, pred: String) -> (Span, String) {
+    let end = generics.where_clause.span_for_predicates_or_empty_place().shrink_to_hi();
     (
-        generics.where_clause.span_for_predicates_or_empty_place().shrink_to_hi(),
+        // Account for `where T: Foo,` so we don't suggest two trailing commas.
+        generics
+            .where_clause
+            .predicates
+            .last()
+            .map(|p| p.span())
+            .unwrap_or(end)
+            .shrink_to_hi()
+            .to(end),
         format!(
             "{} {}",
             if !generics.where_clause.predicates.is_empty() { "," } else { " where" },

--- a/src/test/ui/bound-suggestions.rs
+++ b/src/test/ui/bound-suggestions.rs
@@ -19,7 +19,7 @@ fn test_one_bound<T: Sized>(t: T) {
 }
 
 #[allow(dead_code)]
-fn test_no_bounds_where<X, Y>(x: X, y: Y) where X: std::fmt::Debug {
+fn test_no_bounds_where<X, Y>(x: X, y: Y) where X: std::fmt::Debug, {
     println!("{:?} {:?}", x, y);
     //~^ ERROR doesn't implement
 }


### PR DESCRIPTION
Fix #72693.