### PR TITLE
Make libunwind build hermetic

### DIFF
--- a/src/libunwind/build.rs
+++ b/src/libunwind/build.rs
@@ -90,6 +90,8 @@ mod llvm_libunwind {
             cfg.flag("-fstrict-aliasing");
             cfg.flag("-funwind-tables");
             cfg.flag("-fvisibility=hidden");
+            cfg.flag_if_supported("-fvisibility-global-new-delete-hidden");
+            cfg.define("_LIBUNWIND_DISABLE_VISIBILITY_ANNOTATIONS", None);
         }
 
         let mut unwind_sources = vec![


### PR DESCRIPTION
We want to avoid exporting any symbols from Rust's version of libunwind,
and to do so we need to disable visibility annotations to make sure that
the -fvisibility=hidden has effect, and also hide global new/delete.

This matches the CMake build of libunwind.