### PR TITLE
rustc_lexer: Optimize shebang detection slightly

### DIFF
--- a/src/test/ui/parser/shebang/shebang-doc-comment.rs
+++ b/src/test/ui/parser/shebang/shebang-doc-comment.rs
@@ -1,0 +1,6 @@
+#!///bin/bash
+[allow(unused_variables)]
+//~^^ ERROR expected `[`, found doc comment
+
+// Doc comment is misinterpreted as a whitespace (regular comment) during shebang detection.
+// Even if it wasn't, it would still result in an error, just a different one.

--- a/src/test/ui/parser/shebang/shebang-doc-comment.stderr
+++ b/src/test/ui/parser/shebang/shebang-doc-comment.stderr
@@ -1,0 +1,8 @@
+error: expected `[`, found doc comment `///bin/bash`
+  --> $DIR/shebang-doc-comment.rs:1:3
+   |
+LL | #!///bin/bash
+   |   ^^^^^^^^^^^ expected `[`
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Sorry, I just couldn't resist.
It shouldn't make any difference in practice.

Also, documented a previously unnoticed case with doc comments treated as regular comments during shebang detection.