### PR TITLE
Update compiler-builtins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -631,9 +631,9 @@ dependencies = [
 
 [[package]]
 name = "compiler_builtins"
-version = "0.1.28"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439a6fab343b1dab347823537734a5cd4ae6ae2000b465ab886f64cdb723bd14"
+checksum = "702af8463c84fd83dd76a307ebd47ab3cc866e847bebd4a1deeb6bcc4a658327"
 dependencies = [
  "cc",
  "rustc-std-workspace-core",

--- a/src/libstd/Cargo.toml
+++ b/src/libstd/Cargo.toml
@@ -20,7 +20,7 @@ panic_unwind = { path = "../libpanic_unwind", optional = true }
 panic_abort = { path = "../libpanic_abort" }
 core = { path = "../libcore" }
 libc = { version = "0.2.51", default-features = false, features = ['rustc-dep-of-std'] }
-compiler_builtins = { version = "0.1.16" }
+compiler_builtins = { version = "0.1.31" }
 profiler_builtins = { path = "../libprofiler_builtins", optional = true }
 unwind = { path = "../libunwind" }
 hashbrown = { version = "0.6.2", default-features = false, features = ['rustc-dep-of-std'] }


### PR DESCRIPTION
Pulls in a fix for #72758, more details on the linked issue.

[Crate changes included here][changes]

[changes]: https://github.com/rust-lang/compiler-builtins/compare/0.1.28...0.1.31

Closes #72758 