### PR TITLE
fulfill: try using SmallVec or Box for stalled_on

### DIFF
--- a/src/librustc_trait_selection/traits/fulfill.rs
+++ b/src/librustc_trait_selection/traits/fulfill.rs
@@ -75,9 +75,10 @@ pub struct FulfillmentContext<'tcx> {
 #[derive(Clone, Debug)]
 pub struct PendingPredicateObligation<'tcx> {
     pub obligation: PredicateObligation<'tcx>,
-    // FIXME(eddyb) look into whether this could be a `SmallVec`.
-    // Judging by the comment in `process_obligation`, the 1-element case
-    // is common so this could be a `SmallVec<[TyOrConstInferVar<'tcx>; 1]>`.
+    // This is far more often read than modified, meaning that we
+    // should mostly optimize for reading speed, while modifying is not as relevant.
+    //
+    // For whatever reason using a boxed slice is slower than using a `Vec` here.
     pub stalled_on: Vec<TyOrConstInferVar<'tcx>>,
 }
 


### PR DESCRIPTION
Tested both `Box` and `SmallVec` for `stalled_on`, with both resulting in a perf loss.
Adds a comment mentioning this and removes an now outdated FIXME.

Logging the length of `stalled_on` resulted in the following distribution while building a part of stage 1 libs:
```
22627647 counts:
(  1) 20983696 (92.7%, 92.7%): process_obligation_len: 1
(  2)   959711 ( 4.2%, 97.0%): process_obligation_len: 2
(  3)   682326 ( 3.0%,100.0%): process_obligation_len: 0
(  4)     1914 ( 0.0%,100.0%): process_obligation_len: 3
```
cc @eddyb 
r? @nnethercote