### PR TITLE
Await on mismatched future types

### DIFF
--- a/src/librustc_infer/infer/error_reporting/mod.rs
+++ b/src/librustc_infer/infer/error_reporting/mod.rs
@@ -50,6 +50,7 @@ use super::region_constraints::GenericKind;
 use super::{InferCtxt, RegionVariableOrigin, SubregionOrigin, TypeTrace, ValuePairs};
 
 use crate::infer;
+use crate::infer::OriginalQueryValues;
 use crate::traits::error_reporting::report_object_safety_error;
 use crate::traits::{
     IfExpressionCause, MatchExpressionArmCause, ObligationCause, ObligationCauseCode,
@@ -60,8 +61,10 @@ use rustc_errors::{pluralize, struct_span_err};
 use rustc_errors::{Applicability, DiagnosticBuilder, DiagnosticStyledString};
 use rustc_hir as hir;
 use rustc_hir::def_id::DefId;
+use rustc_hir::lang_items::LangItem;
 use rustc_hir::{Item, ItemKind, Node};
 use rustc_middle::ty::error::TypeError;
+use rustc_middle::ty::ParamEnvAnd;
 use rustc_middle::ty::{
     self,
     subst::{Subst, SubstsRef},
@@ -1529,6 +1532,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
         };
         if let Some(exp_found) = exp_found {
             self.suggest_as_ref_where_appropriate(span, &exp_found, diag);
+            self.suggest_await_on_expect_found(cause, span, &exp_found, diag);
         }
 
         // In some (most?) cases cause.body_id points to actual body, but in some cases
@@ -1545,6 +1549,72 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
         // It reads better to have the error origin as the final
         // thing.
         self.note_error_origin(diag, cause, exp_found);
+    }
+
+    fn suggest_await_on_expect_found(
+        &self,
+        cause: &ObligationCause<'tcx>,
+        exp_span: Span,
+        exp_found: &ty::error::ExpectedFound<Ty<'tcx>>,
+        diag: &mut DiagnosticBuilder<'tcx>,
+    ) {
+        debug!(
+            "suggest_await_on_expect_found: exp_span={:?}, expected_ty={:?}, found_ty={:?}",
+            exp_span, exp_found.expected, exp_found.found
+        );
+
+        if let ty::Opaque(def_id, _) = exp_found.expected.kind {
+            let future_trait = self.tcx.require_lang_item(LangItem::Future, None);
+            // Future::Output
+            let item_def_id = self
+                .tcx
+                .associated_items(future_trait)
+                .in_definition_order()
+                .next()
+                .unwrap()
+                .def_id;
+
+            let mut projection_ty = None;
+            for (predicate, _) in self.tcx.predicates_of(def_id).predicates {
+                if let ty::PredicateAtom::Projection(projection_predicate) =
+                    predicate.skip_binders()
+                {
+                    if item_def_id == projection_predicate.projection_ty.item_def_id {
+                        projection_ty = Some(projection_predicate.projection_ty);
+                        break;
+                    }
+                }
+            }
+            if let Some(projection_ty) = projection_ty {
+                let projection_query = self.canonicalize_query(
+                    &ParamEnvAnd { param_env: self.tcx.param_env(def_id), value: projection_ty },
+                    &mut OriginalQueryValues::default(),
+                );
+                if let Ok(resp) = self.tcx.normalize_projection_ty(projection_query) {
+                    let normalized_ty = resp.value.value.normalized_ty;
+                    debug!("suggest_await_on_expect_found: normalized={:?}", normalized_ty);
+                    if ty::TyS::same_type(normalized_ty, exp_found.found) {
+                        let span = if let ObligationCauseCode::Pattern {
+                            span,
+                            origin_expr: _,
+                            root_ty: _,
+                        } = cause.code
+                        {
+                            // scrutinee's span
+                            span.unwrap_or(exp_span)
+                        } else {
+                            exp_span
+                        };
+                        diag.span_suggestion_verbose(
+                            span.shrink_to_hi(),
+                            "consider awaiting on the future",
+                            ".await".to_string(),
+                            Applicability::MaybeIncorrect,
+                        );
+                    }
+                }
+            }
+        }
     }
 
     /// When encountering a case where `.as_ref()` on a `Result` or `Option` would be appropriate,

--- a/src/librustc_infer/infer/error_reporting/mod.rs
+++ b/src/librustc_infer/infer/error_reporting/mod.rs
@@ -1574,17 +1574,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 .unwrap()
                 .def_id;
 
-            let mut projection_ty = None;
-            for (predicate, _) in self.tcx.predicates_of(def_id).predicates {
-                if let ty::PredicateAtom::Projection(projection_predicate) =
-                    predicate.skip_binders()
-                {
-                    if item_def_id == projection_predicate.projection_ty.item_def_id {
-                        projection_ty = Some(projection_predicate.projection_ty);
-                        break;
-                    }
-                }
-            }
+            let projection_ty = self.tcx.projection_ty_from_predicates((def_id, item_def_id));
             if let Some(projection_ty) = projection_ty {
                 let projection_query = self.canonicalize_query(
                     &ParamEnvAnd { param_env: self.tcx.param_env(def_id), value: projection_ty },

--- a/src/librustc_middle/query/mod.rs
+++ b/src/librustc_middle/query/mod.rs
@@ -173,6 +173,10 @@ rustc_queries! {
             desc { |tcx| "finding projection predicates for `{}`", tcx.def_path_str(key) }
         }
 
+        query projection_ty_from_predicates(key: (DefId, DefId)) -> Option<ty::ProjectionTy<'tcx>> {
+            desc { |tcx| "finding projection type inside predicates of `{}`", tcx.def_path_str(key.0) }
+        }
+
         query native_libraries(_: CrateNum) -> Lrc<Vec<NativeLib>> {
             desc { "looking up the native libraries of a linked crate" }
         }

--- a/src/librustc_typeck/check/_match.rs
+++ b/src/librustc_typeck/check/_match.rs
@@ -28,7 +28,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         };
 
         // Type check the descriminant and get its type.
-        let scrut_ty = if force_scrutinee_bool {
+        let scrutinee_ty = if force_scrutinee_bool {
             // Here we want to ensure:
             //
             // 1. That default match bindings are *not* accepted in the condition of an
@@ -55,7 +55,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         // #55810: Type check patterns first so we get types for all bindings.
         for arm in arms {
-            self.check_pat_top(&arm.pat, scrut_ty, Some(scrut.span), true);
+            self.check_pat_top(&arm.pat, scrutinee_ty, Some(scrut.span), true);
         }
 
         // Now typecheck the blocks.

--- a/src/librustc_typeck/check/expr.rs
+++ b/src/librustc_typeck/check/expr.rs
@@ -1518,7 +1518,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         def_id: DefId,
     ) {
         let param_env = self.tcx().param_env(def_id);
-        let future_trait = self.tcx.require_lang_item(lang_items::FutureTraitLangItem, None);
+        let future_trait = self.tcx.require_lang_item(LangItem::Future, None);
         // Future::Output
         let item_def_id =
             self.tcx.associated_items(future_trait).in_definition_order().next().unwrap().def_id;
@@ -1554,15 +1554,12 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             );
             if let ty::Adt(def, _) = normalized_ty.kind {
                 if def.non_enum_variant().fields.iter().any(|field| field.ident == field_ident) {
-                    if let Ok(base) = self.tcx.sess.source_map().span_to_snippet(base.span) {
-                        let suggestion = format!("{}.await.{}", base, field_ident);
-                        err.span_suggestion(
-                            expr.span,
-                            "consider await before field access",
-                            suggestion,
-                            Applicability::MaybeIncorrect,
-                        );
-                    }
+                    err.span_suggestion_verbose(
+                        base.span.shrink_to_hi(),
+                        "consider awaiting before field access",
+                        ".await".to_string(),
+                        Applicability::MaybeIncorrect,
+                    );
                 }
             }
         }

--- a/src/librustc_typeck/check/expr.rs
+++ b/src/librustc_typeck/check/expr.rs
@@ -1523,15 +1523,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let item_def_id =
             self.tcx.associated_items(future_trait).in_definition_order().next().unwrap().def_id;
 
-        let mut projection_ty = None;
-        for (predicate, _) in self.tcx.predicates_of(def_id).predicates {
-            if let ty::PredicateAtom::Projection(projection_predicate) = predicate.skip_binders() {
-                if item_def_id == projection_predicate.projection_ty.item_def_id {
-                    projection_ty = Some(projection_predicate.projection_ty);
-                    break;
-                }
-            }
-        }
+        let projection_ty = self.tcx.projection_ty_from_predicates((def_id, item_def_id));
         debug!("suggest_await_on_field_access: projection_ty={:?}", projection_ty);
 
         let cause = self.misc(expr.span);

--- a/src/librustc_typeck/check/method/suggest.rs
+++ b/src/librustc_typeck/check/method/suggest.rs
@@ -870,7 +870,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         call: &hir::Expr<'_>,
         span: Span,
     ) {
-        if let ty::Opaque(def_id, _substs) = ty.kind {
+        if let ty::Opaque(def_id, _) = ty.kind {
             let future_trait = self.tcx.require_lang_item(LangItem::Future, None);
             // Future::Output
             let item_def_id = self
@@ -881,17 +881,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 .unwrap()
                 .def_id;
 
-            let mut projection_ty = None;
-            for (predicate, _) in self.tcx.predicates_of(def_id).predicates {
-                if let ty::PredicateAtom::Projection(projection_predicate) =
-                    predicate.skip_binders()
-                {
-                    if item_def_id == projection_predicate.projection_ty.item_def_id {
-                        projection_ty = Some(projection_predicate.projection_ty);
-                        break;
-                    }
-                }
-            }
+            let projection_ty = self.tcx.projection_ty_from_predicates((def_id, item_def_id));
             let cause = self.misc(span);
             let mut selcx = SelectionContext::new(&self.infcx);
             let mut obligations = vec![];

--- a/src/librustc_typeck/check/method/suggest.rs
+++ b/src/librustc_typeck/check/method/suggest.rs
@@ -911,15 +911,13 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 );
                 let method_exists = self.method_exists(item_name, normalized_ty, call.hir_id, true);
                 debug!("suggest_await_before_method: is_method_exist={}", method_exists);
-                if let Ok(sp) = self.tcx.sess.source_map().span_to_snippet(span) {
-                    if method_exists {
-                        err.span_suggestion(
-                            span,
-                            "consider await before this method call",
-                            format!("await.{}", sp),
-                            Applicability::MaybeIncorrect,
-                        );
-                    }
+                if method_exists {
+                    err.span_suggestion_verbose(
+                        span.shrink_to_lo(),
+                        "consider awaiting before this method call",
+                        "await.".to_string(),
+                        Applicability::MaybeIncorrect,
+                    );
                 }
             }
         }

--- a/src/test/ui/async-await/issue-61076.rs
+++ b/src/test/ui/async-await/issue-61076.rs
@@ -64,5 +64,10 @@ async fn baz() -> Result<(), ()> {
     Ok(())
 }
 
+async fn match_() {
+    match tuple() {
+        Tuple(_) => {} //~ ERROR mismatched types
+    }
+}
 
 fn main() {}

--- a/src/test/ui/async-await/issue-61076.rs
+++ b/src/test/ui/async-await/issue-61076.rs
@@ -6,6 +6,16 @@ use core::task::{Context, Poll};
 
 struct T;
 
+struct UnionStruct(i32);
+
+struct Struct {
+    a: i32
+}
+
+enum Enum {
+    A
+}
+
 impl Future for T {
     type Output = Result<(), ()>;
 
@@ -26,7 +36,19 @@ async fn bar() -> Result<(), ()> {
 async fn baz() -> Result<(), ()> {
     let t = T;
     t?; //~ ERROR the `?` operator can only be applied to values that implement `std::ops::Try`
+
+    let _: i32 = async {
+        UnionStruct(1i32)
+    }.0; //~ ERROR no field `0`
+
+    let _: i32 = async {
+        Struct { a: 1i32 }
+    }.a; //~ ERROR no field `a`
+
+    if let Enum::A = async { Enum::A } {} //~ ERROR mismatched type
+
     Ok(())
 }
+
 
 fn main() {}

--- a/src/test/ui/async-await/issue-61076.rs
+++ b/src/test/ui/async-await/issue-61076.rs
@@ -12,6 +12,10 @@ struct Struct {
     a: i32
 }
 
+impl Struct {
+    fn method(&self) {}
+}
+
 impl Future for Struct {
     type Output = Struct;
     fn poll(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Self::Output> { Poll::Pending }
@@ -54,6 +58,8 @@ async fn baz() -> Result<(), ()> {
     let _: i32 = tuple().0; //~ ERROR no field `0`
 
     let _: i32 = struct_().a; //~ ERROR no field `a`
+
+    struct_().method(); //~ ERROR no method named
 
     Ok(())
 }

--- a/src/test/ui/async-await/issue-61076.rs
+++ b/src/test/ui/async-await/issue-61076.rs
@@ -6,14 +6,20 @@ use core::task::{Context, Poll};
 
 struct T;
 
-struct UnionStruct(i32);
+struct Tuple(i32);
 
 struct Struct {
     a: i32
 }
 
-enum Enum {
-    A
+impl Future for Struct {
+    type Output = Struct;
+    fn poll(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Self::Output> { Poll::Pending }
+}
+
+impl Future for Tuple {
+    type Output = Tuple;
+    fn poll(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Self::Output> { Poll::Pending }
 }
 
 impl Future for T {
@@ -33,19 +39,21 @@ async fn bar() -> Result<(), ()> {
     Ok(())
 }
 
+async fn struct_() -> Struct {
+    Struct { a: 1 }
+}
+
+async fn tuple() -> Tuple {
+    Tuple(1i32)
+}
+
 async fn baz() -> Result<(), ()> {
     let t = T;
     t?; //~ ERROR the `?` operator can only be applied to values that implement `std::ops::Try`
 
-    let _: i32 = async {
-        UnionStruct(1i32)
-    }.0; //~ ERROR no field `0`
+    let _: i32 = tuple().0; //~ ERROR no field `0`
 
-    let _: i32 = async {
-        Struct { a: 1i32 }
-    }.a; //~ ERROR no field `a`
-
-    if let Enum::A = async { Enum::A } {} //~ ERROR mismatched type
+    let _: i32 = struct_().a; //~ ERROR no field `a`
 
     Ok(())
 }

--- a/src/test/ui/async-await/issue-61076.stderr
+++ b/src/test/ui/async-await/issue-61076.stderr
@@ -26,28 +26,52 @@ error[E0609]: no field `0` on type `impl std::future::Future`
   --> $DIR/issue-61076.rs:58:26
    |
 LL |     let _: i32 = tuple().0;
-   |                  --------^
-   |                  |
-   |                  help: consider await before field access: `tuple().await.0`
+   |                          ^
+   |
+help: consider awaiting before field access
+   |
+LL |     let _: i32 = tuple().await.0;
+   |                         ^^^^^^
 
 error[E0609]: no field `a` on type `impl std::future::Future`
   --> $DIR/issue-61076.rs:60:28
    |
 LL |     let _: i32 = struct_().a;
-   |                  ----------^
-   |                  |
-   |                  help: consider await before field access: `struct_().await.a`
+   |                            ^
+   |
+help: consider awaiting before field access
+   |
+LL |     let _: i32 = struct_().await.a;
+   |                           ^^^^^^
 
 error[E0599]: no method named `method` found for opaque type `impl std::future::Future` in the current scope
   --> $DIR/issue-61076.rs:62:15
    |
 LL |     struct_().method();
+   |               ^^^^^^ method not found in `impl std::future::Future`
+   |
+help: consider awaiting before this method call
+   |
+LL |     struct_().await.method();
    |               ^^^^^^
-   |               |
-   |               method not found in `impl std::future::Future`
-   |               help: consider await before this method call: `await.method`
 
-error: aborting due to 5 previous errors
+error[E0308]: mismatched types
+  --> $DIR/issue-61076.rs:69:9
+   |
+LL | async fn tuple() -> Tuple {
+   |                     ----- the `Output` of this `async fn`'s expected opaque type
+...
+LL |         Tuple(_) => {}
+   |         ^^^^^^^^ expected opaque type, found struct `Tuple`
+   |
+   = note: expected opaque type `impl std::future::Future`
+                   found struct `Tuple`
+help: consider awaiting on the future
+   |
+LL |     match tuple().await {
+   |                  ^^^^^^
 
-Some errors have detailed explanations: E0277, E0599, E0609.
+error: aborting due to 6 previous errors
+
+Some errors have detailed explanations: E0277, E0308, E0599, E0609.
 For more information about an error, try `rustc --explain E0277`.

--- a/src/test/ui/async-await/issue-61076.stderr
+++ b/src/test/ui/async-await/issue-61076.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the `?` operator can only be applied to values that implement `std::ops::Try`
-  --> $DIR/issue-61076.rs:38:5
+  --> $DIR/issue-61076.rs:42:5
    |
 LL |     foo()?;
    |     ^^^^^^
@@ -11,7 +11,7 @@ LL |     foo()?;
    = note: required by `std::ops::Try::into_result`
 
 error[E0277]: the `?` operator can only be applied to values that implement `std::ops::Try`
-  --> $DIR/issue-61076.rs:52:5
+  --> $DIR/issue-61076.rs:56:5
    |
 LL |     t?;
    |     ^^
@@ -23,7 +23,7 @@ LL |     t?;
    = note: required by `std::ops::Try::into_result`
 
 error[E0609]: no field `0` on type `impl std::future::Future`
-  --> $DIR/issue-61076.rs:54:26
+  --> $DIR/issue-61076.rs:58:26
    |
 LL |     let _: i32 = tuple().0;
    |                  --------^
@@ -31,14 +31,23 @@ LL |     let _: i32 = tuple().0;
    |                  help: consider await before field access: `tuple().await.0`
 
 error[E0609]: no field `a` on type `impl std::future::Future`
-  --> $DIR/issue-61076.rs:56:28
+  --> $DIR/issue-61076.rs:60:28
    |
 LL |     let _: i32 = struct_().a;
    |                  ----------^
    |                  |
    |                  help: consider await before field access: `struct_().await.a`
 
-error: aborting due to 4 previous errors
+error[E0599]: no method named `method` found for opaque type `impl std::future::Future` in the current scope
+  --> $DIR/issue-61076.rs:62:15
+   |
+LL |     struct_().method();
+   |               ^^^^^^
+   |               |
+   |               method not found in `impl std::future::Future`
+   |               help: consider await before this method call: `await.method`
 
-Some errors have detailed explanations: E0277, E0609.
+error: aborting due to 5 previous errors
+
+Some errors have detailed explanations: E0277, E0599, E0609.
 For more information about an error, try `rustc --explain E0277`.

--- a/src/test/ui/async-await/issue-61076.stderr
+++ b/src/test/ui/async-await/issue-61076.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the `?` operator can only be applied to values that implement `std::ops::Try`
-  --> $DIR/issue-61076.rs:32:5
+  --> $DIR/issue-61076.rs:38:5
    |
 LL |     foo()?;
    |     ^^^^^^
@@ -11,7 +11,7 @@ LL |     foo()?;
    = note: required by `std::ops::Try::into_result`
 
 error[E0277]: the `?` operator can only be applied to values that implement `std::ops::Try`
-  --> $DIR/issue-61076.rs:38:5
+  --> $DIR/issue-61076.rs:52:5
    |
 LL |     t?;
    |     ^^
@@ -23,37 +23,22 @@ LL |     t?;
    = note: required by `std::ops::Try::into_result`
 
 error[E0609]: no field `0` on type `impl std::future::Future`
-  --> $DIR/issue-61076.rs:42:7
+  --> $DIR/issue-61076.rs:54:26
    |
-LL |     }.0;
-   |       ^
+LL |     let _: i32 = tuple().0;
+   |                  --------^
+   |                  |
+   |                  help: consider await before field access: `tuple().await.0`
 
 error[E0609]: no field `a` on type `impl std::future::Future`
-  --> $DIR/issue-61076.rs:46:7
+  --> $DIR/issue-61076.rs:56:28
    |
-LL |     }.a;
-   |       ^
+LL |     let _: i32 = struct_().a;
+   |                  ----------^
+   |                  |
+   |                  help: consider await before field access: `struct_().await.a`
 
-error[E0308]: mismatched types
-  --> $DIR/issue-61076.rs:48:12
-   |
-LL |     A
-   |     - unit variant defined here
-...
-LL |     if let Enum::A = async { Enum::A } {}
-   |            ^^^^^^^         ----------- the expected generator
-   |            |
-   |            expected opaque type, found enum `Enum`
-   | 
-  ::: $SRC_DIR/libcore/future/mod.rs:LL:COL
-   |
-LL | pub const fn from_generator<T>(gen: T) -> impl Future<Output = T::Return>
-   |                                           ------------------------------- the expected opaque type
-   |
-   = note: expected opaque type `impl std::future::Future`
-                     found enum `Enum`
+error: aborting due to 4 previous errors
 
-error: aborting due to 5 previous errors
-
-Some errors have detailed explanations: E0277, E0308, E0609.
+Some errors have detailed explanations: E0277, E0609.
 For more information about an error, try `rustc --explain E0277`.

--- a/src/test/ui/async-await/issue-61076.stderr
+++ b/src/test/ui/async-await/issue-61076.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the `?` operator can only be applied to values that implement `std::ops::Try`
-  --> $DIR/issue-61076.rs:22:5
+  --> $DIR/issue-61076.rs:32:5
    |
 LL |     foo()?;
    |     ^^^^^^
@@ -11,7 +11,7 @@ LL |     foo()?;
    = note: required by `std::ops::Try::into_result`
 
 error[E0277]: the `?` operator can only be applied to values that implement `std::ops::Try`
-  --> $DIR/issue-61076.rs:28:5
+  --> $DIR/issue-61076.rs:38:5
    |
 LL |     t?;
    |     ^^
@@ -22,6 +22,38 @@ LL |     t?;
    = help: the trait `std::ops::Try` is not implemented for `T`
    = note: required by `std::ops::Try::into_result`
 
-error: aborting due to 2 previous errors
+error[E0609]: no field `0` on type `impl std::future::Future`
+  --> $DIR/issue-61076.rs:42:7
+   |
+LL |     }.0;
+   |       ^
 
-For more information about this error, try `rustc --explain E0277`.
+error[E0609]: no field `a` on type `impl std::future::Future`
+  --> $DIR/issue-61076.rs:46:7
+   |
+LL |     }.a;
+   |       ^
+
+error[E0308]: mismatched types
+  --> $DIR/issue-61076.rs:48:12
+   |
+LL |     A
+   |     - unit variant defined here
+...
+LL |     if let Enum::A = async { Enum::A } {}
+   |            ^^^^^^^         ----------- the expected generator
+   |            |
+   |            expected opaque type, found enum `Enum`
+   | 
+  ::: $SRC_DIR/libcore/future/mod.rs:LL:COL
+   |
+LL | pub const fn from_generator<T>(gen: T) -> impl Future<Output = T::Return>
+   |                                           ------------------------------- the expected opaque type
+   |
+   = note: expected opaque type `impl std::future::Future`
+                     found enum `Enum`
+
+error: aborting due to 5 previous errors
+
+Some errors have detailed explanations: E0277, E0308, E0609.
+For more information about an error, try `rustc --explain E0277`.


### PR DESCRIPTION
Closes #61076
This PR suggests to `await` on:
1. `async_fn().bar() => async_fn().await.bar()`
2. `async_fn().field => async_fn().await.field`
3. ` if let x = async() {} => if let x = async().await {}`

r? @tmandry @estebank 