### PR TITLE
core/time: Add Duration methods for zero

### DIFF
--- a/src/libcore/time.rs
+++ b/src/libcore/time.rs
@@ -228,6 +228,7 @@ impl Duration {
     /// # Examples
     ///
     /// ```
+    /// #![feature(duration_zero)]
     /// use std::time::Duration;
     ///
     /// let duration = Duration::zero();
@@ -247,6 +248,7 @@ impl Duration {
     /// # Examples
     ///
     /// ```
+    /// #![feature(duration_zero)]
     /// use std::time::Duration;
     ///
     /// assert!(Duration::zero().is_zero());

--- a/src/libcore/time.rs
+++ b/src/libcore/time.rs
@@ -31,7 +31,7 @@ const MICROS_PER_SEC: u64 = 1_000_000;
 /// the number of nanoseconds.
 ///
 /// `Duration`s implement many common traits, including [`Add`], [`Sub`], and other
-/// [`ops`] traits.
+/// [`ops`] traits. It implements `Default` by returning a zero-length `Duration`.
 ///
 /// [`Add`]: ../../std/ops/trait.Add.html
 /// [`Sub`]: ../../std/ops/trait.Sub.html
@@ -221,6 +221,47 @@ impl Duration {
             secs: nanos / (NANOS_PER_SEC as u64),
             nanos: (nanos % (NANOS_PER_SEC as u64)) as u32,
         }
+    }
+
+    /// Creates a new `Duration` that spans no time.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::time::Duration;
+    ///
+    /// let duration = Duration::zero();
+    /// assert!(duration.is_zero());
+    ///
+    /// const IMMEDIATELY: Duration = Duration::zero();
+    /// assert!(IMMEDIATELY.is_zero());
+    /// ```
+    #[unstable(feature = "duration_zero", issue = "none")]
+    #[inline]
+    pub const fn zero() -> Duration {
+        Duration { secs: 0, nanos: 0 }
+    }
+
+    /// Returns true if this `Duration` spans no time.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::time::Duration;
+    ///
+    /// assert!(Duration::zero().is_zero());
+    /// assert!(Duration::new(0, 0).is_zero());
+    /// assert!(Duration::from_nanos(0).is_zero());
+    /// assert!(Duration::from_secs(0).is_zero());
+    ///
+    /// assert!(!Duration::new(1, 1).is_zero());
+    /// assert!(!Duration::from_nanos(1).is_zero());
+    /// assert!(!Duration::from_secs(1).is_zero());
+    /// ```
+    #[unstable(feature = "duration_zero", issue = "none")]
+    #[inline]
+    pub const fn is_zero(&self) -> bool {
+        self.secs == 0 && self.nanos == 0
     }
 
     /// Returns the number of _whole_ seconds contained by this `Duration`.

--- a/src/libcore/time.rs
+++ b/src/libcore/time.rs
@@ -138,6 +138,24 @@ impl Duration {
         Duration { secs, nanos }
     }
 
+    /// Creates a new `Duration` that spans no time.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(duration_zero)]
+    /// use std::time::Duration;
+    ///
+    /// let duration = Duration::zero();
+    /// assert!(duration.is_zero());
+    /// assert_eq!(duration.as_nanos(), 0);
+    /// ```
+    #[unstable(feature = "duration_zero", issue = "73544")]
+    #[inline]
+    pub const fn zero() -> Duration {
+        Duration { secs: 0, nanos: 0 }
+    }
+
     /// Creates a new `Duration` from the specified number of whole seconds.
     ///
     /// # Examples
@@ -223,26 +241,6 @@ impl Duration {
         }
     }
 
-    /// Creates a new `Duration` that spans no time.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// #![feature(duration_zero)]
-    /// use std::time::Duration;
-    ///
-    /// let duration = Duration::zero();
-    /// assert!(duration.is_zero());
-    ///
-    /// const IMMEDIATELY: Duration = Duration::zero();
-    /// assert!(IMMEDIATELY.is_zero());
-    /// ```
-    #[unstable(feature = "duration_zero", issue = "none")]
-    #[inline]
-    pub const fn zero() -> Duration {
-        Duration { secs: 0, nanos: 0 }
-    }
-
     /// Returns true if this `Duration` spans no time.
     ///
     /// # Examples
@@ -260,7 +258,7 @@ impl Duration {
     /// assert!(!Duration::from_nanos(1).is_zero());
     /// assert!(!Duration::from_secs(1).is_zero());
     /// ```
-    #[unstable(feature = "duration_zero", issue = "none")]
+    #[unstable(feature = "duration_zero", issue = "73544")]
     #[inline]
     pub const fn is_zero(&self) -> bool {
         self.secs == 0 && self.nanos == 0


### PR DESCRIPTION
This patch adds two methods to `Duration`. The first, `Duration::zero`,
provides a `const` constructor for getting an zero-length duration. This
is also what `Default` provides (this was clarified in the docs), though
`default` is not `const`.

The second, `Duration::is_zero`, returns true if a `Duration` spans no
time (i.e., because its components are all zero). Previously, the way to
do this was either to compare both `as_secs` and `subsec_nanos` to 0, to
compare against `Duration::new(0, 0)`, or to use the `u128` method
`as_nanos`, none of which were particularly elegant.