### PR TITLE
[validate-mir] validate that all accessed locals are initialized

### DIFF
--- a/src/librustc_mir/transform/generator.rs
+++ b/src/librustc_mir/transform/generator.rs
@@ -452,7 +452,7 @@ fn locals_live_across_suspend_points(
         .iterate_to_fixpoint()
         .into_results_cursor(body);
 
-    let mut init = MaybeInitializedLocals
+    let mut init = MaybeInitializedLocals::new()
         .into_engine(tcx, body, def_id)
         .iterate_to_fixpoint()
         .into_results_cursor(body);


### PR DESCRIPTION
This uses the `MaybeInitializedLocals` dataflow analysis to validate that every use of a local happens while that local is initialized.

Currently this has to ignore moves out of locals due to bugs in other passes (ie. still treat moved-out-of locals as initialized). These issues are tracked in https://github.com/rust-lang/rust/issues/72797 and https://github.com/rust-lang/rust/issues/72800.

cc @RalfJung 