### PR TITLE
Avoid setting wrong obligation cause span of associated type mismatch

### DIFF
--- a/src/test/ui/associated-types/issue-72806.rs
+++ b/src/test/ui/associated-types/issue-72806.rs
@@ -1,0 +1,20 @@
+trait Bar {
+    type Ok;
+    type Sibling: Bar2<Ok=char>;
+}
+trait Bar2 {
+    type Ok;
+}
+
+struct Foo;
+struct Foo2;
+
+impl Bar for Foo {  //~ ERROR type mismatch resolving `<Foo2 as Bar2>::Ok == char`
+    type Ok = ();
+    type Sibling = Foo2;
+}
+impl Bar2 for Foo2 {
+    type Ok = u32;
+}
+
+fn main() {}

--- a/src/test/ui/associated-types/issue-72806.stderr
+++ b/src/test/ui/associated-types/issue-72806.stderr
@@ -1,0 +1,9 @@
+error[E0271]: type mismatch resolving `<Foo2 as Bar2>::Ok == char`
+  --> $DIR/issue-72806.rs:12:6
+   |
+LL | impl Bar for Foo {
+   |      ^^^ expected `u32`, found `char`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0271`.


### PR DESCRIPTION
Removes code that sets wrong obligation cause span of associated type mismatch. See the linked issue for details.

Closes #72806.