### PR TITLE
Miri tests: skip parts of test_char_range

### DIFF
--- a/src/libcore/tests/iter.rs
+++ b/src/libcore/tests/iter.rs
@@ -1959,8 +1959,11 @@ fn test_range() {
 #[test]
 fn test_char_range() {
     use std::char;
-    assert!(('\0'..=char::MAX).eq((0..=char::MAX as u32).filter_map(char::from_u32)));
-    assert!(('\0'..=char::MAX).rev().eq((0..=char::MAX as u32).filter_map(char::from_u32).rev()));
+    // Miri is too slow
+    let from = if cfg!(miri) { char::from_u32(0xD800 - 10).unwrap() } else { '\0' };
+    let to = if cfg!(miri) { char::from_u32(0xDFFF + 10).unwrap() } else { char::MAX };
+    assert!((from..=to).eq((from as u32..=to as u32).filter_map(char::from_u32)));
+    assert!((from..=to).rev().eq((from as u32..=to as u32).filter_map(char::from_u32).rev()));
 
     assert_eq!(('\u{D7FF}'..='\u{E000}').count(), 2);
     assert_eq!(('\u{D7FF}'..='\u{E000}').size_hint(), (2, Some(2)));


### PR DESCRIPTION
The new `test_char_range` test takes forever in Miri as it loops over all values of `char`. This makes it skip most of them when being run in Miri.