### PR TITLE
remove visit_terminator_kind from MIR visitor

### DIFF
--- a/src/librustc_codegen_ssa/mir/analyze.rs
+++ b/src/librustc_codegen_ssa/mir/analyze.rs
@@ -234,8 +234,8 @@ impl<'mir, 'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> Visitor<'tcx>
         self.visit_rvalue(rvalue, location);
     }
 
-    fn visit_terminator_kind(&mut self, kind: &mir::TerminatorKind<'tcx>, location: Location) {
-        let check = match *kind {
+    fn visit_terminator(&mut self, terminator: &mir::Terminator<'tcx>, location: Location) {
+        let check = match terminator.kind {
             mir::TerminatorKind::Call { func: mir::Operand::Constant(ref c), ref args, .. } => {
                 match c.literal.ty.kind {
                     ty::FnDef(did, _) => Some((did, args)),
@@ -259,7 +259,7 @@ impl<'mir, 'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> Visitor<'tcx>
             }
         }
 
-        self.super_terminator_kind(kind, location);
+        self.super_terminator(terminator, location);
     }
 
     fn visit_place(&mut self, place: &mir::Place<'tcx>, context: PlaceContext, location: Location) {

--- a/src/librustc_codegen_ssa/mir/block.rs
+++ b/src/librustc_codegen_ssa/mir/block.rs
@@ -998,8 +998,8 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                 bx.unreachable();
             }
 
-            mir::TerminatorKind::Drop { location, target, unwind } => {
-                self.codegen_drop_terminator(helper, bx, location, target, unwind);
+            mir::TerminatorKind::Drop { place, target, unwind } => {
+                self.codegen_drop_terminator(helper, bx, place, target, unwind);
             }
 
             mir::TerminatorKind::Assert { ref cond, expected, ref msg, target, cleanup } => {

--- a/src/librustc_middle/mir/mod.rs
+++ b/src/librustc_middle/mir/mod.rs
@@ -1112,7 +1112,7 @@ pub enum TerminatorKind<'tcx> {
     Unreachable,
 
     /// Drop the `Place`.
-    Drop { location: Place<'tcx>, target: BasicBlock, unwind: Option<BasicBlock> },
+    Drop { place: Place<'tcx>, target: BasicBlock, unwind: Option<BasicBlock> },
 
     /// Drop the `Place` and assign the new value over it. This ensures
     /// that the assignment to `P` occurs *even if* the destructor for
@@ -1141,7 +1141,7 @@ pub enum TerminatorKind<'tcx> {
     /// }
     /// ```
     DropAndReplace {
-        location: Place<'tcx>,
+        place: Place<'tcx>,
         value: Operand<'tcx>,
         target: BasicBlock,
         unwind: Option<BasicBlock>,
@@ -1607,9 +1607,9 @@ impl<'tcx> TerminatorKind<'tcx> {
             Abort => write!(fmt, "abort"),
             Yield { value, resume_arg, .. } => write!(fmt, "{:?} = yield({:?})", resume_arg, value),
             Unreachable => write!(fmt, "unreachable"),
-            Drop { location, .. } => write!(fmt, "drop({:?})", location),
-            DropAndReplace { location, value, .. } => {
-                write!(fmt, "replace({:?} <- {:?})", location, value)
+            Drop { place, .. } => write!(fmt, "drop({:?})", place),
+            DropAndReplace { place, value, .. } => {
+                write!(fmt, "replace({:?} <- {:?})", place, value)
             }
             Call { func, args, destination, .. } => {
                 if let Some((destination, _)) = destination {

--- a/src/librustc_middle/mir/type_foldable.rs
+++ b/src/librustc_middle/mir/type_foldable.rs
@@ -27,11 +27,11 @@ impl<'tcx> TypeFoldable<'tcx> for Terminator<'tcx> {
                 values: values.clone(),
                 targets: targets.clone(),
             },
-            Drop { ref location, target, unwind } => {
-                Drop { location: location.fold_with(folder), target, unwind }
+            Drop { ref place, target, unwind } => {
+                Drop { place: place.fold_with(folder), target, unwind }
             }
-            DropAndReplace { ref location, ref value, target, unwind } => DropAndReplace {
-                location: location.fold_with(folder),
+            DropAndReplace { ref place, ref value, target, unwind } => DropAndReplace {
+                place: place.fold_with(folder),
                 value: value.fold_with(folder),
                 target,
                 unwind,
@@ -97,9 +97,9 @@ impl<'tcx> TypeFoldable<'tcx> for Terminator<'tcx> {
             SwitchInt { ref discr, switch_ty, .. } => {
                 discr.visit_with(visitor) || switch_ty.visit_with(visitor)
             }
-            Drop { ref location, .. } => location.visit_with(visitor),
-            DropAndReplace { ref location, ref value, .. } => {
-                location.visit_with(visitor) || value.visit_with(visitor)
+            Drop { ref place, .. } => place.visit_with(visitor),
+            DropAndReplace { ref place, ref value, .. } => {
+                place.visit_with(visitor) || value.visit_with(visitor)
             }
             Yield { ref value, .. } => value.visit_with(visitor),
             Call { ref func, ref args, ref destination, .. } => {

--- a/src/librustc_middle/mir/visit.rs
+++ b/src/librustc_middle/mir/visit.rs
@@ -407,7 +407,7 @@ macro_rules! make_mir_visitor {
 
             fn super_terminator(&mut self,
                                 terminator: &$($mutability)? Terminator<'tcx>,
-                                source_location: Location) {
+                                location: Location) {
                 let Terminator { source_info, kind } = terminator;
 
                 self.visit_source_info(source_info);
@@ -428,7 +428,7 @@ macro_rules! make_mir_visitor {
                         self.visit_local(
                             & $($mutability)? local,
                             PlaceContext::NonMutatingUse(NonMutatingUseContext::Move),
-                            source_location,
+                            location,
                         );
 
                         assert_eq!(
@@ -444,8 +444,8 @@ macro_rules! make_mir_visitor {
                         values: _,
                         targets: _
                     } => {
-                        self.visit_operand(discr, source_location);
-                        self.visit_ty(switch_ty, TyContext::Location(source_location));
+                        self.visit_operand(discr, location);
+                        self.visit_ty(switch_ty, TyContext::Location(location));
                     }
 
                     TerminatorKind::Drop {
@@ -456,7 +456,7 @@ macro_rules! make_mir_visitor {
                         self.visit_place(
                             place,
                             PlaceContext::MutatingUse(MutatingUseContext::Drop),
-                            source_location
+                            location
                         );
                     }
 
@@ -469,9 +469,9 @@ macro_rules! make_mir_visitor {
                         self.visit_place(
                             place,
                             PlaceContext::MutatingUse(MutatingUseContext::Drop),
-                            source_location
+                            location
                         );
-                        self.visit_operand(value, source_location);
+                        self.visit_operand(value, location);
                     }
 
                     TerminatorKind::Call {
@@ -482,15 +482,15 @@ macro_rules! make_mir_visitor {
                         from_hir_call: _,
                         fn_span: _
                     } => {
-                        self.visit_operand(func, source_location);
+                        self.visit_operand(func, location);
                         for arg in args {
-                            self.visit_operand(arg, source_location);
+                            self.visit_operand(arg, location);
                         }
                         if let Some((destination, _)) = destination {
                             self.visit_place(
                                 destination,
                                 PlaceContext::MutatingUse(MutatingUseContext::Call),
-                                source_location
+                                location
                             );
                         }
                     }
@@ -502,8 +502,8 @@ macro_rules! make_mir_visitor {
                         target: _,
                         cleanup: _,
                     } => {
-                        self.visit_operand(cond, source_location);
-                        self.visit_assert_message(msg, source_location);
+                        self.visit_operand(cond, location);
+                        self.visit_assert_message(msg, location);
                     }
 
                     TerminatorKind::Yield {
@@ -512,11 +512,11 @@ macro_rules! make_mir_visitor {
                         resume_arg,
                         drop: _,
                     } => {
-                        self.visit_operand(value, source_location);
+                        self.visit_operand(value, location);
                         self.visit_place(
                             resume_arg,
                             PlaceContext::MutatingUse(MutatingUseContext::Yield),
-                            source_location,
+                            location,
                         );
                     }
 
@@ -531,29 +531,29 @@ macro_rules! make_mir_visitor {
                             match op {
                                 InlineAsmOperand::In { value, .. }
                                 | InlineAsmOperand::Const { value } => {
-                                    self.visit_operand(value, source_location);
+                                    self.visit_operand(value, location);
                                 }
                                 InlineAsmOperand::Out { place, .. } => {
                                     if let Some(place) = place {
                                         self.visit_place(
                                             place,
                                             PlaceContext::MutatingUse(MutatingUseContext::Store),
-                                            source_location,
+                                            location,
                                         );
                                     }
                                 }
                                 InlineAsmOperand::InOut { in_value, out_place, .. } => {
-                                    self.visit_operand(in_value, source_location);
+                                    self.visit_operand(in_value, location);
                                     if let Some(out_place) = out_place {
                                         self.visit_place(
                                             out_place,
                                             PlaceContext::MutatingUse(MutatingUseContext::Store),
-                                            source_location,
+                                            location,
                                         );
                                     }
                                 }
                                 InlineAsmOperand::SymFn { value } => {
-                                    self.visit_constant(value, source_location);
+                                    self.visit_constant(value, location);
                                 }
                                 InlineAsmOperand::SymStatic { def_id: _ } => {}
                             }

--- a/src/librustc_middle/mir/visit.rs
+++ b/src/librustc_middle/mir/visit.rs
@@ -108,12 +108,6 @@ macro_rules! make_mir_visitor {
                 self.super_terminator(terminator, location);
             }
 
-            fn visit_terminator_kind(&mut self,
-                                     kind: & $($mutability)? TerminatorKind<'tcx>,
-                                     location: Location) {
-                self.super_terminator_kind(kind, location);
-            }
-
             fn visit_assert_message(&mut self,
                                     msg: & $($mutability)? AssertMessage<'tcx>,
                                     location: Location) {
@@ -413,16 +407,10 @@ macro_rules! make_mir_visitor {
 
             fn super_terminator(&mut self,
                                 terminator: &$($mutability)? Terminator<'tcx>,
-                                location: Location) {
+                                source_location: Location) {
                 let Terminator { source_info, kind } = terminator;
 
                 self.visit_source_info(source_info);
-                self.visit_terminator_kind(kind, location);
-            }
-
-            fn super_terminator_kind(&mut self,
-                                     kind: & $($mutability)? TerminatorKind<'tcx>,
-                                     source_location: Location) {
                 match kind {
                     TerminatorKind::Goto { .. } |
                     TerminatorKind::Resume |

--- a/src/librustc_middle/mir/visit.rs
+++ b/src/librustc_middle/mir/visit.rs
@@ -449,25 +449,25 @@ macro_rules! make_mir_visitor {
                     }
 
                     TerminatorKind::Drop {
-                        location,
+                        place,
                         target: _,
                         unwind: _,
                     } => {
                         self.visit_place(
-                            location,
+                            place,
                             PlaceContext::MutatingUse(MutatingUseContext::Drop),
                             source_location
                         );
                     }
 
                     TerminatorKind::DropAndReplace {
-                        location,
+                        place,
                         value,
                         target: _,
                         unwind: _,
                     } => {
                         self.visit_place(
-                            location,
+                            place,
                             PlaceContext::MutatingUse(MutatingUseContext::Drop),
                             source_location
                         );

--- a/src/librustc_mir/borrow_check/invalidation.rs
+++ b/src/librustc_mir/borrow_check/invalidation.rs
@@ -119,7 +119,7 @@ impl<'cx, 'tcx> Visitor<'tcx> for InvalidationGenerator<'cx, 'tcx> {
             TerminatorKind::SwitchInt { ref discr, switch_ty: _, values: _, targets: _ } => {
                 self.consume_operand(location, discr);
             }
-            TerminatorKind::Drop { location: drop_place, target: _, unwind: _ } => {
+            TerminatorKind::Drop { place: drop_place, target: _, unwind: _ } => {
                 self.access_place(
                     location,
                     *drop_place,
@@ -128,7 +128,7 @@ impl<'cx, 'tcx> Visitor<'tcx> for InvalidationGenerator<'cx, 'tcx> {
                 );
             }
             TerminatorKind::DropAndReplace {
-                location: drop_place,
+                place: drop_place,
                 value: ref new_value,
                 target: _,
                 unwind: _,

--- a/src/librustc_mir/borrow_check/invalidation.rs
+++ b/src/librustc_mir/borrow_check/invalidation.rs
@@ -2,7 +2,7 @@ use rustc_data_structures::graph::dominators::Dominators;
 use rustc_middle::mir::visit::Visitor;
 use rustc_middle::mir::{BasicBlock, Body, Location, Place, Rvalue};
 use rustc_middle::mir::{BorrowKind, Mutability, Operand};
-use rustc_middle::mir::{InlineAsmOperand, TerminatorKind};
+use rustc_middle::mir::{InlineAsmOperand, Terminator, TerminatorKind};
 use rustc_middle::mir::{Statement, StatementKind};
 use rustc_middle::ty::TyCtxt;
 
@@ -112,10 +112,10 @@ impl<'cx, 'tcx> Visitor<'tcx> for InvalidationGenerator<'cx, 'tcx> {
         self.super_statement(statement, location);
     }
 
-    fn visit_terminator_kind(&mut self, kind: &TerminatorKind<'tcx>, location: Location) {
+    fn visit_terminator(&mut self, terminator: &Terminator<'tcx>, location: Location) {
         self.check_activations(location);
 
-        match kind {
+        match &terminator.kind {
             TerminatorKind::SwitchInt { ref discr, switch_ty: _, values: _, targets: _ } => {
                 self.consume_operand(location, discr);
             }
@@ -222,7 +222,7 @@ impl<'cx, 'tcx> Visitor<'tcx> for InvalidationGenerator<'cx, 'tcx> {
             }
         }
 
-        self.super_terminator_kind(kind, location);
+        self.super_terminator(terminator, location);
     }
 }
 

--- a/src/librustc_mir/borrow_check/mod.rs
+++ b/src/librustc_mir/borrow_check/mod.rs
@@ -663,7 +663,7 @@ impl<'cx, 'tcx> dataflow::ResultsVisitor<'cx, 'tcx> for MirBorrowckCtxt<'cx, 'tc
             TerminatorKind::SwitchInt { ref discr, switch_ty: _, values: _, targets: _ } => {
                 self.consume_operand(loc, (discr, span), flow_state);
             }
-            TerminatorKind::Drop { location: ref drop_place, target: _, unwind: _ } => {
+            TerminatorKind::Drop { place: ref drop_place, target: _, unwind: _ } => {
                 let tcx = self.infcx.tcx;
 
                 // Compute the type with accurate region information.
@@ -692,7 +692,7 @@ impl<'cx, 'tcx> dataflow::ResultsVisitor<'cx, 'tcx> for MirBorrowckCtxt<'cx, 'tc
                 );
             }
             TerminatorKind::DropAndReplace {
-                location: drop_place,
+                place: drop_place,
                 value: ref new_value,
                 target: _,
                 unwind: _,

--- a/src/librustc_mir/borrow_check/type_check/mod.rs
+++ b/src/librustc_mir/borrow_check/type_check/mod.rs
@@ -1558,8 +1558,8 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
                 // no checks needed for these
             }
 
-            TerminatorKind::DropAndReplace { ref location, ref value, target: _, unwind: _ } => {
-                let place_ty = location.ty(body, tcx).ty;
+            TerminatorKind::DropAndReplace { ref place, ref value, target: _, unwind: _ } => {
+                let place_ty = place.ty(body, tcx).ty;
                 let rv_ty = value.ty(body, tcx);
 
                 let locations = term_location.to_locations();

--- a/src/librustc_mir/borrow_check/used_muts.rs
+++ b/src/librustc_mir/borrow_check/used_muts.rs
@@ -70,8 +70,8 @@ impl<'visit, 'cx, 'tcx> Visitor<'tcx> for GatherUsedMutsVisitor<'visit, 'cx, 'tc
             TerminatorKind::Call { destination: Some((into, _)), .. } => {
                 self.remove_never_initialized_mut_locals(*into);
             }
-            TerminatorKind::DropAndReplace { location, .. } => {
-                self.remove_never_initialized_mut_locals(*location);
+            TerminatorKind::DropAndReplace { place, .. } => {
+                self.remove_never_initialized_mut_locals(*place);
             }
             _ => {}
         }

--- a/src/librustc_mir/borrow_check/used_muts.rs
+++ b/src/librustc_mir/borrow_check/used_muts.rs
@@ -64,7 +64,7 @@ impl GatherUsedMutsVisitor<'_, '_, '_> {
 }
 
 impl<'visit, 'cx, 'tcx> Visitor<'tcx> for GatherUsedMutsVisitor<'visit, 'cx, 'tcx> {
-    fn visit_terminator(&mut self, terminator: &Terminator<'tcx>, _location: Location) {
+    fn visit_terminator(&mut self, terminator: &Terminator<'tcx>, location: Location) {
         debug!("visit_terminator: terminator={:?}", terminator);
         match &terminator.kind {
             TerminatorKind::Call { destination: Some((into, _)), .. } => {
@@ -76,10 +76,10 @@ impl<'visit, 'cx, 'tcx> Visitor<'tcx> for GatherUsedMutsVisitor<'visit, 'cx, 'tc
             _ => {}
         }
 
-        // FIXME: no super_terminator?
+        self.super_terminator(terminator, location);
     }
 
-    fn visit_statement(&mut self, statement: &Statement<'tcx>, _location: Location) {
+    fn visit_statement(&mut self, statement: &Statement<'tcx>, location: Location) {
         if let StatementKind::Assign(box (into, _)) = &statement.kind {
             debug!(
                 "visit_statement: statement={:?} local={:?} \
@@ -89,7 +89,7 @@ impl<'visit, 'cx, 'tcx> Visitor<'tcx> for GatherUsedMutsVisitor<'visit, 'cx, 'tc
             self.remove_never_initialized_mut_locals(*into);
         }
 
-        // FIXME: no super_statement?
+        self.super_statement(statement, location);
     }
 
     fn visit_local(&mut self, local: &Local, place_context: PlaceContext, location: Location) {
@@ -107,7 +107,5 @@ impl<'visit, 'cx, 'tcx> Visitor<'tcx> for GatherUsedMutsVisitor<'visit, 'cx, 'tc
                 }
             }
         }
-
-        // FIXME: no super_local?
     }
 }

--- a/src/librustc_mir/borrow_check/used_muts.rs
+++ b/src/librustc_mir/borrow_check/used_muts.rs
@@ -1,5 +1,7 @@
 use rustc_middle::mir::visit::{PlaceContext, Visitor};
-use rustc_middle::mir::{Local, Location, Place, Statement, StatementKind, TerminatorKind};
+use rustc_middle::mir::{
+    Local, Location, Place, Statement, StatementKind, Terminator, TerminatorKind,
+};
 
 use rustc_data_structures::fx::FxHashSet;
 
@@ -62,9 +64,9 @@ impl GatherUsedMutsVisitor<'_, '_, '_> {
 }
 
 impl<'visit, 'cx, 'tcx> Visitor<'tcx> for GatherUsedMutsVisitor<'visit, 'cx, 'tcx> {
-    fn visit_terminator_kind(&mut self, kind: &TerminatorKind<'tcx>, _location: Location) {
-        debug!("visit_terminator_kind: kind={:?}", kind);
-        match &kind {
+    fn visit_terminator(&mut self, terminator: &Terminator<'tcx>, _location: Location) {
+        debug!("visit_terminator: terminator={:?}", terminator);
+        match &terminator.kind {
             TerminatorKind::Call { destination: Some((into, _)), .. } => {
                 self.remove_never_initialized_mut_locals(*into);
             }
@@ -73,6 +75,8 @@ impl<'visit, 'cx, 'tcx> Visitor<'tcx> for GatherUsedMutsVisitor<'visit, 'cx, 'tc
             }
             _ => {}
         }
+
+        // FIXME: no super_terminator?
     }
 
     fn visit_statement(&mut self, statement: &Statement<'tcx>, _location: Location) {
@@ -84,6 +88,8 @@ impl<'visit, 'cx, 'tcx> Visitor<'tcx> for GatherUsedMutsVisitor<'visit, 'cx, 'tc
             );
             self.remove_never_initialized_mut_locals(*into);
         }
+
+        // FIXME: no super_statement?
     }
 
     fn visit_local(&mut self, local: &Local, place_context: PlaceContext, location: Location) {
@@ -101,5 +107,7 @@ impl<'visit, 'cx, 'tcx> Visitor<'tcx> for GatherUsedMutsVisitor<'visit, 'cx, 'tc
                 }
             }
         }
+
+        // FIXME: no super_local?
     }
 }

--- a/src/librustc_mir/dataflow/framework/direction.rs
+++ b/src/librustc_mir/dataflow/framework/direction.rs
@@ -441,8 +441,8 @@ impl Direction for Forward {
             Goto { target } => propagate(target, exit_state),
 
             Assert { target, cleanup: unwind, expected: _, msg: _, cond: _ }
-            | Drop { target, unwind, location: _ }
-            | DropAndReplace { target, unwind, value: _, location: _ }
+            | Drop { target, unwind, place: _ }
+            | DropAndReplace { target, unwind, value: _, place: _ }
             | FalseUnwind { real_target: target, unwind } => {
                 if let Some(unwind) = unwind {
                     if dead_unwinds.map_or(true, |dead| !dead.contains(bb)) {

--- a/src/librustc_mir/dataflow/impls/borrowed_locals.rs
+++ b/src/librustc_mir/dataflow/impls/borrowed_locals.rs
@@ -189,8 +189,8 @@ where
         self.super_terminator(terminator, location);
 
         match terminator.kind {
-            mir::TerminatorKind::Drop { location: dropped_place, .. }
-            | mir::TerminatorKind::DropAndReplace { location: dropped_place, .. } => {
+            mir::TerminatorKind::Drop { place: dropped_place, .. }
+            | mir::TerminatorKind::DropAndReplace { place: dropped_place, .. } => {
                 // See documentation for `unsound_ignore_borrow_on_drop` for an explanation.
                 if !self.ignore_borrow_on_drop {
                     self.trans.gen(dropped_place.local);

--- a/src/librustc_mir/dataflow/move_paths/builder.rs
+++ b/src/librustc_mir/dataflow/move_paths/builder.rs
@@ -387,13 +387,13 @@ impl<'b, 'a, 'tcx> Gatherer<'b, 'a, 'tcx> {
                 self.gather_init(place.as_ref(), InitKind::Deep);
             }
 
-            TerminatorKind::Drop { location, target: _, unwind: _ } => {
-                self.gather_move(location);
+            TerminatorKind::Drop { place, target: _, unwind: _ } => {
+                self.gather_move(place);
             }
-            TerminatorKind::DropAndReplace { location, ref value, .. } => {
-                self.create_move_path(location);
+            TerminatorKind::DropAndReplace { place, ref value, .. } => {
+                self.create_move_path(place);
                 self.gather_operand(value);
-                self.gather_init(location.as_ref(), InitKind::Deep);
+                self.gather_init(place.as_ref(), InitKind::Deep);
             }
             TerminatorKind::Call {
                 ref func,

--- a/src/librustc_mir/interpret/terminator.rs
+++ b/src/librustc_mir/interpret/terminator.rs
@@ -91,10 +91,10 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 }
             }
 
-            Drop { location, target, unwind } => {
-                let place = self.eval_place(location)?;
+            Drop { place, target, unwind } => {
+                let place = self.eval_place(place)?;
                 let ty = place.layout.ty;
-                trace!("TerminatorKind::drop: {:?}, type {}", location, ty);
+                trace!("TerminatorKind::drop: {:?}, type {}", place, ty);
 
                 let instance = Instance::resolve_drop_in_place(*self.tcx, ty);
                 self.drop_in_place(place, instance, target, unwind)?;

--- a/src/librustc_mir/monomorphize/collector.rs
+++ b/src/librustc_mir/monomorphize/collector.rs
@@ -616,11 +616,11 @@ impl<'a, 'tcx> MirVisitor<'tcx> for MirNeighborCollector<'a, 'tcx> {
         self.super_const(constant);
     }
 
-    fn visit_terminator_kind(&mut self, kind: &mir::TerminatorKind<'tcx>, location: Location) {
-        debug!("visiting terminator {:?} @ {:?}", kind, location);
+    fn visit_terminator(&mut self, terminator: &mir::Terminator<'tcx>, location: Location) {
+        debug!("visiting terminator {:?} @ {:?}", terminator, location);
 
         let tcx = self.tcx;
-        match *kind {
+        match terminator.kind {
             mir::TerminatorKind::Call { ref func, .. } => {
                 let callee_ty = func.ty(self.body, tcx);
                 let callee_ty = self.monomorphize(callee_ty);
@@ -663,7 +663,7 @@ impl<'a, 'tcx> MirVisitor<'tcx> for MirNeighborCollector<'a, 'tcx> {
             | mir::TerminatorKind::FalseUnwind { .. } => bug!(),
         }
 
-        self.super_terminator_kind(kind, location);
+        self.super_terminator(terminator, location);
     }
 
     fn visit_local(

--- a/src/librustc_mir/monomorphize/collector.rs
+++ b/src/librustc_mir/monomorphize/collector.rs
@@ -626,9 +626,9 @@ impl<'a, 'tcx> MirVisitor<'tcx> for MirNeighborCollector<'a, 'tcx> {
                 let callee_ty = self.monomorphize(callee_ty);
                 visit_fn_use(self.tcx, callee_ty, true, &mut self.output);
             }
-            mir::TerminatorKind::Drop { ref location, .. }
-            | mir::TerminatorKind::DropAndReplace { ref location, .. } => {
-                let ty = location.ty(self.body, self.tcx).ty;
+            mir::TerminatorKind::Drop { ref place, .. }
+            | mir::TerminatorKind::DropAndReplace { ref place, .. } => {
+                let ty = place.ty(self.body, self.tcx).ty;
                 let ty = self.monomorphize(ty);
                 visit_drop_use(self.tcx, ty, true, self.output);
             }

--- a/src/librustc_mir/shim.rs
+++ b/src/librustc_mir/shim.rs
@@ -582,7 +582,7 @@ impl CloneShimBuilder<'tcx> {
         self.block(
             vec![],
             TerminatorKind::Drop {
-                location: self.tcx.mk_place_index(dest, beg),
+                place: self.tcx.mk_place_index(dest, beg),
                 target: BasicBlock::new(8),
                 unwind: None,
             },
@@ -634,7 +634,7 @@ impl CloneShimBuilder<'tcx> {
                 self.block(
                     vec![],
                     TerminatorKind::Drop {
-                        location: previous_field,
+                        place: previous_field,
                         target: previous_cleanup,
                         unwind: None,
                     },
@@ -799,11 +799,7 @@ fn build_call_shim<'tcx>(
         block(
             &mut blocks,
             vec![],
-            TerminatorKind::Drop {
-                location: rcvr_place(),
-                target: BasicBlock::new(2),
-                unwind: None,
-            },
+            TerminatorKind::Drop { place: rcvr_place(), target: BasicBlock::new(2), unwind: None },
             false,
         );
     }
@@ -814,11 +810,7 @@ fn build_call_shim<'tcx>(
         block(
             &mut blocks,
             vec![],
-            TerminatorKind::Drop {
-                location: rcvr_place(),
-                target: BasicBlock::new(4),
-                unwind: None,
-            },
+            TerminatorKind::Drop { place: rcvr_place(), target: BasicBlock::new(4), unwind: None },
             true,
         );
 

--- a/src/librustc_mir/transform/check_consts/post_drop_elaboration.rs
+++ b/src/librustc_mir/transform/check_consts/post_drop_elaboration.rs
@@ -78,7 +78,7 @@ impl Visitor<'tcx> for CheckLiveDrops<'mir, 'tcx> {
         trace!("visit_terminator: terminator={:?} location={:?}", terminator, location);
 
         match &terminator.kind {
-            mir::TerminatorKind::Drop { location: dropped_place, .. } => {
+            mir::TerminatorKind::Drop { place: dropped_place, .. } => {
                 let dropped_ty = dropped_place.ty(self.body, self.tcx).ty;
                 if !NeedsDrop::in_any_value_of_ty(self.ccx, dropped_ty) {
                     return;

--- a/src/librustc_mir/transform/check_consts/resolver.rs
+++ b/src/librustc_mir/transform/check_consts/resolver.rs
@@ -125,16 +125,15 @@ where
         // The effect of assignment to the return place in `TerminatorKind::Call` is not applied
         // here; that occurs in `apply_call_return_effect`.
 
-        if let mir::TerminatorKind::DropAndReplace { value, location: dest, .. } = &terminator.kind
-        {
+        if let mir::TerminatorKind::DropAndReplace { value, place, .. } = &terminator.kind {
             let qualif = qualifs::in_operand::<Q, _>(
                 self.ccx,
                 &mut |l| self.qualifs_per_local.contains(l),
                 value,
             );
 
-            if !dest.is_indirect() {
-                self.assign_qualif_direct(dest, qualif);
+            if !place.is_indirect() {
+                self.assign_qualif_direct(place, qualif);
             }
         }
 

--- a/src/librustc_mir/transform/check_consts/resolver.rs
+++ b/src/librustc_mir/transform/check_consts/resolver.rs
@@ -121,11 +121,12 @@ where
         self.super_assign(place, rvalue, location);
     }
 
-    fn visit_terminator_kind(&mut self, kind: &mir::TerminatorKind<'tcx>, location: Location) {
+    fn visit_terminator(&mut self, terminator: &mir::Terminator<'tcx>, location: Location) {
         // The effect of assignment to the return place in `TerminatorKind::Call` is not applied
         // here; that occurs in `apply_call_return_effect`.
 
-        if let mir::TerminatorKind::DropAndReplace { value, location: dest, .. } = kind {
+        if let mir::TerminatorKind::DropAndReplace { value, location: dest, .. } = &terminator.kind
+        {
             let qualif = qualifs::in_operand::<Q, _>(
                 self.ccx,
                 &mut |l| self.qualifs_per_local.contains(l),
@@ -139,7 +140,7 @@ where
 
         // We need to assign qualifs to the dropped location before visiting the operand that
         // replaces it since qualifs can be cleared on move.
-        self.super_terminator_kind(kind, location);
+        self.super_terminator(terminator, location);
     }
 }
 

--- a/src/librustc_mir/transform/check_consts/validation.rs
+++ b/src/librustc_mir/transform/check_consts/validation.rs
@@ -560,8 +560,8 @@ impl Visitor<'tcx> for Validator<'mir, 'tcx> {
 
             // Forbid all `Drop` terminators unless the place being dropped is a local with no
             // projections that cannot be `NeedsDrop`.
-            TerminatorKind::Drop { location: dropped_place, .. }
-            | TerminatorKind::DropAndReplace { location: dropped_place, .. } => {
+            TerminatorKind::Drop { place: dropped_place, .. }
+            | TerminatorKind::DropAndReplace { place: dropped_place, .. } => {
                 // If we are checking live drops after drop-elaboration, don't emit duplicate
                 // errors here.
                 if super::post_drop_elaboration::checking_enabled(self.tcx) {

--- a/src/librustc_mir/transform/elaborate_drops.rs
+++ b/src/librustc_mir/transform/elaborate_drops.rs
@@ -85,15 +85,15 @@ fn find_dead_unwinds<'tcx>(
         .iterate_to_fixpoint()
         .into_results_cursor(body);
     for (bb, bb_data) in body.basic_blocks().iter_enumerated() {
-        let location = match bb_data.terminator().kind {
-            TerminatorKind::Drop { ref location, unwind: Some(_), .. }
-            | TerminatorKind::DropAndReplace { ref location, unwind: Some(_), .. } => location,
+        let place = match bb_data.terminator().kind {
+            TerminatorKind::Drop { ref place, unwind: Some(_), .. }
+            | TerminatorKind::DropAndReplace { ref place, unwind: Some(_), .. } => place,
             _ => continue,
         };
 
         debug!("find_dead_unwinds @ {:?}: {:?}", bb, bb_data);
 
-        let path = match env.move_data.rev_lookup.find(location.as_ref()) {
+        let path = match env.move_data.rev_lookup.find(place.as_ref()) {
             LookupResult::Exact(e) => e,
             LookupResult::Parent(..) => {
                 debug!("find_dead_unwinds: has parent; skipping");
@@ -105,7 +105,7 @@ fn find_dead_unwinds<'tcx>(
         debug!(
             "find_dead_unwinds @ {:?}: path({:?})={:?}; init_data={:?}",
             bb,
-            location,
+            place,
             path,
             flow_inits.get()
         );
@@ -294,16 +294,16 @@ impl<'b, 'tcx> ElaborateDropsCtxt<'b, 'tcx> {
     fn collect_drop_flags(&mut self) {
         for (bb, data) in self.body.basic_blocks().iter_enumerated() {
             let terminator = data.terminator();
-            let location = match terminator.kind {
-                TerminatorKind::Drop { ref location, .. }
-                | TerminatorKind::DropAndReplace { ref location, .. } => location,
+            let place = match terminator.kind {
+                TerminatorKind::Drop { ref place, .. }
+                | TerminatorKind::DropAndReplace { ref place, .. } => place,
                 _ => continue,
             };
 
             self.init_data.seek_before(self.body.terminator_loc(bb));
 
-            let path = self.move_data().rev_lookup.find(location.as_ref());
-            debug!("collect_drop_flags: {:?}, place {:?} ({:?})", bb, location, path);
+            let path = self.move_data().rev_lookup.find(place.as_ref());
+            debug!("collect_drop_flags: {:?}, place {:?} ({:?})", bb, place, path);
 
             let path = match path {
                 LookupResult::Exact(e) => e,
@@ -315,7 +315,7 @@ impl<'b, 'tcx> ElaborateDropsCtxt<'b, 'tcx> {
                             terminator.source_info.span,
                             "drop of untracked, uninitialized value {:?}, place {:?} ({:?})",
                             bb,
-                            location,
+                            place,
                             path
                         );
                     }
@@ -328,7 +328,7 @@ impl<'b, 'tcx> ElaborateDropsCtxt<'b, 'tcx> {
                 debug!(
                     "collect_drop_flags: collecting {:?} from {:?}@{:?} - {:?}",
                     child,
-                    location,
+                    place,
                     path,
                     (maybe_live, maybe_dead)
                 );
@@ -346,13 +346,13 @@ impl<'b, 'tcx> ElaborateDropsCtxt<'b, 'tcx> {
 
             let resume_block = self.patch.resume_block();
             match terminator.kind {
-                TerminatorKind::Drop { location, target, unwind } => {
+                TerminatorKind::Drop { place, target, unwind } => {
                     self.init_data.seek_before(loc);
-                    match self.move_data().rev_lookup.find(location.as_ref()) {
+                    match self.move_data().rev_lookup.find(place.as_ref()) {
                         LookupResult::Exact(path) => elaborate_drop(
                             &mut Elaborator { ctxt: self },
                             terminator.source_info,
-                            location,
+                            place,
                             path,
                             target,
                             if data.is_cleanup {
@@ -371,10 +371,10 @@ impl<'b, 'tcx> ElaborateDropsCtxt<'b, 'tcx> {
                         }
                     }
                 }
-                TerminatorKind::DropAndReplace { location, ref value, target, unwind } => {
+                TerminatorKind::DropAndReplace { place, ref value, target, unwind } => {
                     assert!(!data.is_cleanup);
 
-                    self.elaborate_replace(loc, location, value, target, unwind);
+                    self.elaborate_replace(loc, place, value, target, unwind);
                 }
                 _ => continue,
             }
@@ -396,7 +396,7 @@ impl<'b, 'tcx> ElaborateDropsCtxt<'b, 'tcx> {
     fn elaborate_replace(
         &mut self,
         loc: Location,
-        location: Place<'tcx>,
+        place: Place<'tcx>,
         value: &Operand<'tcx>,
         target: BasicBlock,
         unwind: Option<BasicBlock>,
@@ -407,7 +407,7 @@ impl<'b, 'tcx> ElaborateDropsCtxt<'b, 'tcx> {
         assert!(!data.is_cleanup, "DropAndReplace in unwind path not supported");
 
         let assign = Statement {
-            kind: StatementKind::Assign(box (location, Rvalue::Use(value.clone()))),
+            kind: StatementKind::Assign(box (place, Rvalue::Use(value.clone()))),
             source_info: terminator.source_info,
         };
 
@@ -427,14 +427,14 @@ impl<'b, 'tcx> ElaborateDropsCtxt<'b, 'tcx> {
             is_cleanup: false,
         });
 
-        match self.move_data().rev_lookup.find(location.as_ref()) {
+        match self.move_data().rev_lookup.find(place.as_ref()) {
             LookupResult::Exact(path) => {
                 debug!("elaborate_drop_and_replace({:?}) - tracked {:?}", terminator, path);
                 self.init_data.seek_before(loc);
                 elaborate_drop(
                     &mut Elaborator { ctxt: self },
                     terminator.source_info,
-                    location,
+                    place,
                     path,
                     target,
                     Unwind::To(unwind),
@@ -459,7 +459,7 @@ impl<'b, 'tcx> ElaborateDropsCtxt<'b, 'tcx> {
                 debug!("elaborate_drop_and_replace({:?}) - untracked {:?}", terminator, parent);
                 self.patch.patch_terminator(
                     bb,
-                    TerminatorKind::Drop { location, target, unwind: Some(unwind) },
+                    TerminatorKind::Drop { place, target, unwind: Some(unwind) },
                 );
             }
         }

--- a/src/librustc_mir/transform/generator.rs
+++ b/src/librustc_mir/transform/generator.rs
@@ -93,13 +93,13 @@ impl<'tcx> MutVisitor<'tcx> for RenameLocalVisitor<'tcx> {
         }
     }
 
-    fn visit_terminator_kind(&mut self, kind: &mut TerminatorKind<'tcx>, location: Location) {
-        match kind {
+    fn visit_terminator(&mut self, terminator: &mut Terminator<'tcx>, location: Location) {
+        match terminator.kind {
             TerminatorKind::Return => {
                 // Do not replace the implicit `_0` access here, as that's not possible. The
                 // transform already handles `return` correctly.
             }
-            _ => self.super_terminator_kind(kind, location),
+            _ => self.super_terminator(terminator, location),
         }
     }
 }

--- a/src/librustc_mir/transform/generator.rs
+++ b/src/librustc_mir/transform/generator.rs
@@ -835,8 +835,8 @@ fn elaborate_generator_drops<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId, body: &mut 
 
     for (block, block_data) in body.basic_blocks().iter_enumerated() {
         let (target, unwind, source_info) = match block_data.terminator() {
-            Terminator { source_info, kind: TerminatorKind::Drop { location, target, unwind } } => {
-                if let Some(local) = location.as_local() {
+            Terminator { source_info, kind: TerminatorKind::Drop { place, target, unwind } } => {
+                if let Some(local) = place.as_local() {
                     if local == SELF_ARG {
                         (target, unwind, source_info)
                     } else {
@@ -1102,11 +1102,8 @@ fn create_generator_resume_function<'tcx>(
 fn insert_clean_drop(body: &mut Body<'_>) -> BasicBlock {
     let return_block = insert_term_block(body, TerminatorKind::Return);
 
-    let term = TerminatorKind::Drop {
-        location: Place::from(SELF_ARG),
-        target: return_block,
-        unwind: None,
-    };
+    let term =
+        TerminatorKind::Drop { place: Place::from(SELF_ARG), target: return_block, unwind: None };
     let source_info = SourceInfo::outermost(body.span);
 
     // Create a block to destroy an unresumed generators. This can only destroy upvars.

--- a/src/librustc_mir/transform/inline.rs
+++ b/src/librustc_mir/transform/inline.rs
@@ -319,13 +319,13 @@ impl Inliner<'tcx> {
             let term = blk.terminator();
             let mut is_drop = false;
             match term.kind {
-                TerminatorKind::Drop { ref location, target, unwind }
-                | TerminatorKind::DropAndReplace { ref location, target, unwind, .. } => {
+                TerminatorKind::Drop { ref place, target, unwind }
+                | TerminatorKind::DropAndReplace { ref place, target, unwind, .. } => {
                     is_drop = true;
                     work_list.push(target);
-                    // If the location doesn't actually need dropping, treat it like
+                    // If the place doesn't actually need dropping, treat it like
                     // a regular goto.
-                    let ty = location.ty(callee_body, tcx).subst(tcx, callsite.substs).ty;
+                    let ty = place.ty(callee_body, tcx).subst(tcx, callsite.substs).ty;
                     if ty.needs_drop(tcx, param_env) {
                         cost += CALL_PENALTY;
                         if let Some(unwind) = unwind {

--- a/src/librustc_mir/transform/no_landing_pads.rs
+++ b/src/librustc_mir/transform/no_landing_pads.rs
@@ -34,10 +34,10 @@ impl<'tcx> MutVisitor<'tcx> for NoLandingPads<'tcx> {
         self.tcx
     }
 
-    fn visit_terminator_kind(&mut self, kind: &mut TerminatorKind<'tcx>, location: Location) {
-        if let Some(unwind) = kind.unwind_mut() {
+    fn visit_terminator(&mut self, terminator: &mut Terminator<'tcx>, location: Location) {
+        if let Some(unwind) = terminator.kind.unwind_mut() {
             unwind.take();
         }
-        self.super_terminator_kind(kind, location);
+        self.super_terminator(terminator, location);
     }
 }

--- a/src/librustc_mir/transform/promote_consts.rs
+++ b/src/librustc_mir/transform/promote_consts.rs
@@ -1186,7 +1186,7 @@ pub fn promote_candidates<'tcx>(
             _ => true,
         });
         let terminator = block.terminator_mut();
-        if let TerminatorKind::Drop { location: place, target, .. } = &terminator.kind {
+        if let TerminatorKind::Drop { place, target, .. } = &terminator.kind {
             if let Some(index) = place.as_local() {
                 if promoted(index) {
                     terminator.kind = TerminatorKind::Goto { target: *target };

--- a/src/librustc_mir/transform/promote_consts.rs
+++ b/src/librustc_mir/transform/promote_consts.rs
@@ -216,10 +216,10 @@ impl<'tcx> Visitor<'tcx> for Collector<'_, 'tcx> {
         }
     }
 
-    fn visit_terminator_kind(&mut self, kind: &TerminatorKind<'tcx>, location: Location) {
-        self.super_terminator_kind(kind, location);
+    fn visit_terminator(&mut self, terminator: &Terminator<'tcx>, location: Location) {
+        self.super_terminator(terminator, location);
 
-        match *kind {
+        match terminator.kind {
             TerminatorKind::Call { ref func, .. } => {
                 if let ty::FnDef(def_id, _) = func.ty(self.ccx.body, self.ccx.tcx).kind {
                     let fn_sig = self.ccx.tcx.fn_sig(def_id);

--- a/src/librustc_mir/transform/promote_consts.rs
+++ b/src/librustc_mir/transform/promote_consts.rs
@@ -147,7 +147,6 @@ struct Collector<'a, 'tcx> {
     ccx: &'a ConstCx<'a, 'tcx>,
     temps: IndexVec<Local, TempState>,
     candidates: Vec<Candidate>,
-    span: Span,
 }
 
 impl<'tcx> Visitor<'tcx> for Collector<'_, 'tcx> {
@@ -254,10 +253,6 @@ impl<'tcx> Visitor<'tcx> for Collector<'_, 'tcx> {
             _ => {}
         }
     }
-
-    fn visit_source_info(&mut self, source_info: &SourceInfo) {
-        self.span = source_info.span;
-    }
 }
 
 pub fn collect_temps_and_candidates(
@@ -267,7 +262,6 @@ pub fn collect_temps_and_candidates(
     let mut collector = Collector {
         temps: IndexVec::from_elem(TempState::Undefined, &ccx.body.local_decls),
         candidates: vec![],
-        span: ccx.body.span,
         ccx,
     };
     for (bb, data) in rpo {

--- a/src/librustc_mir/transform/qualify_min_const_fn.rs
+++ b/src/librustc_mir/transform/qualify_min_const_fn.rs
@@ -349,9 +349,9 @@ fn check_terminator(
         | TerminatorKind::Resume
         | TerminatorKind::Unreachable => Ok(()),
 
-        TerminatorKind::Drop { location, .. } => check_place(tcx, *location, span, def_id, body),
-        TerminatorKind::DropAndReplace { location, value, .. } => {
-            check_place(tcx, *location, span, def_id, body)?;
+        TerminatorKind::Drop { place, .. } => check_place(tcx, *place, span, def_id, body),
+        TerminatorKind::DropAndReplace { place, value, .. } => {
+            check_place(tcx, *place, span, def_id, body)?;
             check_operand(tcx, value, span, def_id, body)
         }
 

--- a/src/librustc_mir/util/elaborate_drops.rs
+++ b/src/librustc_mir/util/elaborate_drops.rs
@@ -238,7 +238,7 @@ where
                 self.elaborator.patch().patch_terminator(
                     bb,
                     TerminatorKind::Drop {
-                        location: self.place,
+                        place: self.place,
                         target: self.succ,
                         unwind: self.unwind.into_option(),
                     },
@@ -723,7 +723,7 @@ where
         self.elaborator.patch().patch_terminator(
             drop_block,
             TerminatorKind::Drop {
-                location: tcx.mk_place_deref(ptr),
+                place: tcx.mk_place_deref(ptr),
                 target: loop_block,
                 unwind: unwind.into_option(),
             },
@@ -1000,7 +1000,7 @@ where
 
     fn drop_block(&mut self, target: BasicBlock, unwind: Unwind) -> BasicBlock {
         let block =
-            TerminatorKind::Drop { location: self.place, target, unwind: unwind.into_option() };
+            TerminatorKind::Drop { place: self.place, target, unwind: unwind.into_option() };
         self.new_block(unwind, block)
     }
 

--- a/src/librustc_mir_build/build/scope.rs
+++ b/src/librustc_mir_build/build/scope.rs
@@ -1037,7 +1037,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         &mut self,
         block: BasicBlock,
         span: Span,
-        location: Place<'tcx>,
+        place: Place<'tcx>,
         value: Operand<'tcx>,
     ) -> BlockAnd<()> {
         let source_info = self.source_info(span);
@@ -1047,7 +1047,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             block,
             source_info,
             TerminatorKind::DropAndReplace {
-                location,
+                place,
                 value,
                 target: next_target,
                 unwind: Some(diverge_target),
@@ -1158,7 +1158,7 @@ fn build_scope_drops<'tcx>(
                     block,
                     source_info,
                     TerminatorKind::Drop {
-                        location: local.into(),
+                        place: local.into(),
                         target: next,
                         unwind: Some(unwind_to),
                     },
@@ -1272,7 +1272,7 @@ fn build_diverge_scope<'tcx>(
                         block,
                         source_info(drop_data.span),
                         TerminatorKind::Drop {
-                            location: drop_data.local.into(),
+                            place: drop_data.local.into(),
                             target,
                             unwind: None,
                         },


### PR DESCRIPTION
For some reason, we had both `visit_terminator` and `visit_terminator_kind`. In contrast, for `Statement` we just have `visit_statement`. So this cleans things up by removing `visit_terminator_kind` and porting its users to `visit_terminator`.