### PR TITLE
InstCombine: Don't optimize `&mut *x` into `x`

### DIFF
--- a/src/test/mir-opt/inline/issue-58867-inline-as-ref-as-mut/rustc.a.Inline.after.mir
+++ b/src/test/mir-opt/inline/issue-58867-inline-as-ref-as-mut/rustc.a.Inline.after.mir
@@ -8,6 +8,7 @@ fn a(_1: &mut [T]) -> &mut [T] {
     let mut _4: &mut [T];                // in scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:3:5: 3:6
     scope 1 {
         debug self => _4;                // in scope 1 at $SRC_DIR/libcore/convert/mod.rs:LL:COL
+        let mut _5: &mut [T];            // in scope 1 at $DIR/issue-58867-inline-as-ref-as-mut.rs:3:5: 3:15
     }
 
     bb0: {
@@ -15,7 +16,10 @@ fn a(_1: &mut [T]) -> &mut [T] {
         StorageLive(_3);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:3:5: 3:15
         StorageLive(_4);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:3:5: 3:6
         _4 = &mut (*_1);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:3:5: 3:6
-        _3 = move _4;                    // scope 1 at $SRC_DIR/libcore/convert/mod.rs:LL:COL
+        StorageLive(_5);                 // scope 1 at $SRC_DIR/libcore/convert/mod.rs:LL:COL
+        _5 = &mut (*_4);                 // scope 1 at $SRC_DIR/libcore/convert/mod.rs:LL:COL
+        _3 = &mut (*_5);                 // scope 1 at $SRC_DIR/libcore/convert/mod.rs:LL:COL
+        StorageDead(_5);                 // scope 1 at $SRC_DIR/libcore/convert/mod.rs:LL:COL
         _2 = &mut (*_3);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:3:5: 3:15
         StorageDead(_4);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:3:14: 3:15
         _0 = &mut (*_2);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:3:5: 3:15

--- a/src/test/mir-opt/inline/issue-58867-inline-as-ref-as-mut/rustc.b.Inline.after.mir
+++ b/src/test/mir-opt/inline/issue-58867-inline-as-ref-as-mut/rustc.b.Inline.after.mir
@@ -9,6 +9,7 @@ fn b(_1: &mut std::boxed::Box<T>) -> &mut T {
     scope 1 {
         debug self => _4;                // in scope 1 at $SRC_DIR/liballoc/boxed.rs:LL:COL
         let mut _5: &mut T;              // in scope 1 at $DIR/issue-58867-inline-as-ref-as-mut.rs:8:5: 8:15
+        let mut _6: &mut T;              // in scope 1 at $DIR/issue-58867-inline-as-ref-as-mut.rs:8:5: 8:15
     }
 
     bb0: {
@@ -17,8 +18,11 @@ fn b(_1: &mut std::boxed::Box<T>) -> &mut T {
         StorageLive(_4);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:8:5: 8:6
         _4 = &mut (*_1);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:8:5: 8:6
         StorageLive(_5);                 // scope 1 at $SRC_DIR/liballoc/boxed.rs:LL:COL
-        _5 = &mut (*(*_4));              // scope 1 at $SRC_DIR/liballoc/boxed.rs:LL:COL
-        _3 = move _5;                    // scope 1 at $SRC_DIR/liballoc/boxed.rs:LL:COL
+        StorageLive(_6);                 // scope 1 at $SRC_DIR/liballoc/boxed.rs:LL:COL
+        _6 = &mut (*(*_4));              // scope 1 at $SRC_DIR/liballoc/boxed.rs:LL:COL
+        _5 = &mut (*_6);                 // scope 1 at $SRC_DIR/liballoc/boxed.rs:LL:COL
+        _3 = &mut (*_5);                 // scope 1 at $SRC_DIR/liballoc/boxed.rs:LL:COL
+        StorageDead(_6);                 // scope 1 at $SRC_DIR/liballoc/boxed.rs:LL:COL
         StorageDead(_5);                 // scope 1 at $SRC_DIR/liballoc/boxed.rs:LL:COL
         _2 = &mut (*_3);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:8:5: 8:15
         StorageDead(_4);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:8:14: 8:15

--- a/src/test/mir-opt/nrvo-simple/rustc.nrvo.RenameReturnPlace.diff
+++ b/src/test/mir-opt/nrvo-simple/rustc.nrvo.RenameReturnPlace.diff
@@ -26,12 +26,17 @@
                                            // + span: $DIR/nrvo-simple.rs:3:20: 3:21
                                            // + literal: Const { ty: u8, val: Value(Scalar(0x00)) }
           StorageLive(_3);                 // scope 1 at $DIR/nrvo-simple.rs:4:5: 4:19
+          StorageLive(_5);                 // scope 1 at $DIR/nrvo-simple.rs:4:10: 4:18
+          StorageLive(_6);                 // scope 1 at $DIR/nrvo-simple.rs:4:10: 4:18
 -         _6 = &mut _2;                    // scope 1 at $DIR/nrvo-simple.rs:4:10: 4:18
 +         _6 = &mut _0;                    // scope 1 at $DIR/nrvo-simple.rs:4:10: 4:18
-          _3 = move _1(move _6) -> bb1;    // scope 1 at $DIR/nrvo-simple.rs:4:5: 4:19
+          _5 = &mut (*_6);                 // scope 1 at $DIR/nrvo-simple.rs:4:10: 4:18
+          _3 = move _1(move _5) -> bb1;    // scope 1 at $DIR/nrvo-simple.rs:4:5: 4:19
       }
   
       bb1: {
+          StorageDead(_5);                 // scope 1 at $DIR/nrvo-simple.rs:4:18: 4:19
+          StorageDead(_6);                 // scope 1 at $DIR/nrvo-simple.rs:4:19: 4:20
           StorageDead(_3);                 // scope 1 at $DIR/nrvo-simple.rs:4:19: 4:20
 -         _0 = _2;                         // scope 1 at $DIR/nrvo-simple.rs:5:5: 5:8
 -         StorageDead(_2);                 // scope 0 at $DIR/nrvo-simple.rs:6:1: 6:2


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/72797