### PR TITLE
Clarify terms in doc comments

### DIFF
--- a/src/libcore/slice/mod.rs
+++ b/src/libcore/slice/mod.rs
@@ -2173,7 +2173,7 @@ impl<T> [T] {
     ///
     /// The length of `src` must be the same as `self`.
     ///
-    /// If `src` implements `Copy`, it can be more performant to use
+    /// If `T` implements `Copy`, it can be more performant to use
     /// [`copy_from_slice`].
     ///
     /// # Panics
@@ -2244,7 +2244,7 @@ impl<T> [T] {
     ///
     /// The length of `src` must be the same as `self`.
     ///
-    /// If `src` does not implement `Copy`, use [`clone_from_slice`].
+    /// If `T` does not implement `Copy`, use [`clone_from_slice`].
     ///
     /// # Panics
     ///


### PR DESCRIPTION
Doc comments of `copy_from_slice` say that people should use `clone_from_slice`
when 'src' doesn't implement `Copy`. However, 'src' is a reference and
it always implements `Copy`. The term 'src' should be fixed to `T`(element type of slice 'src') in
the doc comments.

Thank you for reviewing this PR :)  :smiley_cat: 