### PR TITLE
RELEASES.md: Expand `cargo tree` note to mention `cargo tree -d`

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -85,6 +85,8 @@ Cargo
   │   │       │           └── version_check v0.1.5
   ...
   ```
+  You can also display dependencies on multiple versions of the same crate with
+  `cargo tree -d` (short for `cargo tree --duplicates`).
 
 Misc
 ----


### PR DESCRIPTION
Useful feature that people might not automatically associate with `cargo
tree`.