### PR TITLE
Rephrase term 'non-pointer type'

### DIFF
--- a/src/libcore/ops/deref.rs
+++ b/src/libcore/ops/deref.rs
@@ -18,8 +18,8 @@
 ///
 /// If `T` implements `Deref<Target = U>`, and `x` is a value of type `T`, then:
 ///
-/// * In immutable contexts, `*x` on non-pointer types is equivalent to
-///   `*Deref::deref(&x)`.
+/// * In immutable contexts, `*x` (where `T` is neither a reference nor a raw pointer)
+///   is equivalent to `*Deref::deref(&x)`.
 /// * Values of type `&T` are coerced to values of type `&U`
 /// * `T` implicitly implements all the (immutable) methods of the type `U`.
 ///
@@ -115,8 +115,8 @@ impl<T: ?Sized> Deref for &mut T {
 /// If `T` implements `DerefMut<Target = U>`, and `x` is a value of type `T`,
 /// then:
 ///
-/// * In mutable contexts, `*x` on non-pointer types is equivalent to
-///   `*DerefMut::deref_mut(&mut x)`.
+/// * In mutable contexts, `*x` (where `T` is neither a reference nor a raw pointer)
+///   is equivalent to `*DerefMut::deref_mut(&mut x)`.
 /// * Values of type `&mut T` are coerced to values of type `&mut U`
 /// * `T` implicitly implements all the (mutable) methods of the type `U`.
 ///


### PR DESCRIPTION
Hello :cat2: ,

If the reader assumes that 'pointer type's include 'smart pointer's,
the term 'non-pointer type' could mislead the reader to assume that
x should not be a smart pointer type. I tried to rephrase the term
'non-pointer type' to remove ambiguity in the doc comments.

closes #72335

Thank you for reviewing this PR! :superhero_woman: 