### PR TITLE
[experiment] Measure performance effect of creating DefIds for macro invocations

### DIFF
--- a/src/librustc_expand/base.rs
+++ b/src/librustc_expand/base.rs
@@ -13,7 +13,7 @@ use rustc_data_structures::sync::{self, Lrc};
 use rustc_errors::{DiagnosticBuilder, ErrorReported};
 use rustc_parse::{self, parser, MACRO_ARGUMENTS};
 use rustc_session::{parse::ParseSess, Limit};
-use rustc_span::def_id::DefId;
+use rustc_span::def_id::{DefId, CRATE_DEF_INDEX};
 use rustc_span::edition::Edition;
 use rustc_span::hygiene::{AstPass, ExpnData, ExpnId, ExpnKind};
 use rustc_span::source_map::SourceMap;
@@ -870,6 +870,7 @@ impl SyntaxExtension {
             kind: ExpnKind::Macro(self.macro_kind(), descr),
             parent,
             call_site,
+            def_id: DefId::local(CRATE_DEF_INDEX),
             def_site: self.span,
             allow_internal_unstable: self.allow_internal_unstable.clone(),
             allow_internal_unsafe: self.allow_internal_unsafe,

--- a/src/librustc_resolve/def_collector.rs
+++ b/src/librustc_resolve/def_collector.rs
@@ -8,7 +8,7 @@ use rustc_hir::def_id::LocalDefId;
 use rustc_hir::definitions::*;
 use rustc_span::hygiene::ExpnId;
 use rustc_span::symbol::{kw, sym};
-use rustc_span::Span;
+use rustc_span::{Span, DUMMY_SP};
 
 crate fn collect_definitions(
     definitions: &mut Definitions,
@@ -58,7 +58,10 @@ impl<'a> DefCollector<'a> {
     }
 
     fn visit_macro_invoc(&mut self, id: NodeId) {
-        self.definitions.set_invocation_parent(id.placeholder_to_expn_id(), self.parent_def);
+        let expn_id = id.placeholder_to_expn_id();
+        self.definitions.set_invocation_parent(expn_id, self.parent_def);
+        let def_id = self.create_def(DUMMY_NODE_ID, DefPathData::Misc, DUMMY_SP);
+        expn_id.set_def_id(def_id);
     }
 }
 


### PR DESCRIPTION
cc https://github.com/rust-lang/rust/pull/72121#issuecomment-633305710

I'm not sure we really need to put this `DefId` into global data (the `set_def_id` part), but let's think of this as slightly pessimistic estimate.

r? @ghost