### PR TITLE
Add preloading hints for default fonts

### DIFF
--- a/src/librustdoc/html/layout.rs
+++ b/src/librustdoc/html/layout.rs
@@ -129,7 +129,14 @@ pub fn render<T: Print, S: Print>(
                 suffix = page.resource_suffix
             )
         } else {
-            String::new()
+            // No CSS extension means there's probably no font overrides, so
+            // we add a preloading hint for fonts we always load remotely.
+            format!(
+                "<link {font_attrs} href='{static_root_path}SourceCodePro-Regular.woff'>\
+                <link {font_attrs} href='{static_root_path}SourceCodePro-Semibold.woff'>",
+                font_attrs = "rel='preload' type='font/woff' as='font'",
+                static_root_path = static_root_path
+            )
         },
         content = Buffer::html().to_display(t),
         static_root_path = static_root_path,


### PR DESCRIPTION
This adds preloading hints to rustdoc's HTML for certain fonts
that are always loaded from the server. This enables browsers
to improve loading performance of the page.

This is an attempt to improve on the situation discussed in #20962 and also for historical interest it is following up on lessons learned in https://github.com/rust-lang/rust/pull/72557#issuecomment-635001406

Browsers lazy-load fonts in `@font-face` rules. The generation, calculation, and styling of a `std` doc page takes entire seconds, whereas loading a font takes milliseconds. It's hard to know when exactly the fonts are requested, but examining [results from webpagetest.org](https://webpagetest.org/result/200531_B2_0f61f8683ddabff3ccea09a9d84e6ebf/5/details/#waterfall_view_step1) suggests it could take entire seconds into the page load. Using `<link>` for all of rustdoc's webfonts might be unwise (it would be wasted loads if the fonts are local), and CSS extensions can override these, but as long as the CSS is unaltered we can be confident a visitor to a rustdoc page will want these fonts.