### PR TITLE
Mention that BTreeMap::new() doesn't allocate

### DIFF
--- a/src/liballoc/collections/btree/map.rs
+++ b/src/liballoc/collections/btree/map.rs
@@ -490,6 +490,8 @@ struct MergeIter<K, V, I: Iterator<Item = (K, V)>> {
 impl<K: Ord, V> BTreeMap<K, V> {
     /// Makes a new empty BTreeMap with a reasonable choice for B.
     ///
+    /// Does not allocate anything on its own.
+    ///
     /// # Examples
     ///
     /// Basic usage:


### PR DESCRIPTION
I think it would be nice to mention this, so you don't have to dig through the src to look at the definition of new().