### PR TITLE
Remove Spans from HIR -- 1/N -- Span collection

### DIFF
--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -1600,15 +1600,15 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                 intravisit::NestedVisitorMap::None
             }
 
-            fn visit_generic_args(&mut self, span: Span, parameters: &'v hir::GenericArgs<'v>) {
+            fn visit_generic_args(&mut self, parameters: &'v hir::GenericArgs<'v>) {
                 // Don't collect elided lifetimes used inside of `Fn()` syntax.
                 if parameters.parenthesized {
                     let old_collect_elided_lifetimes = self.collect_elided_lifetimes;
                     self.collect_elided_lifetimes = false;
-                    intravisit::walk_generic_args(self, span, parameters);
+                    intravisit::walk_generic_args(self, parameters);
                     self.collect_elided_lifetimes = old_collect_elided_lifetimes;
                 } else {
-                    intravisit::walk_generic_args(self, span, parameters);
+                    intravisit::walk_generic_args(self, parameters);
                 }
             }
 

--- a/compiler/rustc_ast_lowering/src/pat.rs
+++ b/compiler/rustc_ast_lowering/src/pat.rs
@@ -57,7 +57,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                         );
 
                         let fs = self.arena.alloc_from_iter(fields.iter().map(|f| hir::FieldPat {
-                            hir_id: self.next_id(),
+                            hir_id: self.next_id(f.span),
                             ident: f.ident,
                             pat: self.lower_pat(&f.pat),
                             is_shorthand: f.is_shorthand,
@@ -242,7 +242,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
 
                 hir::PatKind::Binding(
                     self.lower_binding_mode(binding_mode),
-                    self.lower_node_id(canonical_id),
+                    self.lower_node_id(canonical_id, rustc_span::DUMMY_SP),
                     ident,
                     lower_sub(self),
                 )
@@ -274,7 +274,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
     /// Construct a `Pat` with the `HirId` of `p.id` lowered.
     fn pat_with_node_id_of(&mut self, p: &Pat, kind: hir::PatKind<'hir>) -> &'hir hir::Pat<'hir> {
         self.arena.alloc(hir::Pat {
-            hir_id: self.lower_node_id(p.id),
+            hir_id: self.lower_node_id(p.id, p.span),
             kind,
             span: p.span,
             default_binding_modes: true,

--- a/compiler/rustc_ast_lowering/src/path.rs
+++ b/compiler/rustc_ast_lowering/src/path.rs
@@ -126,7 +126,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
             // Otherwise, the base path is an implicit `Self` type path,
             // e.g., `Vec` in `Vec::new` or `<I as Iterator>::Item` in
             // `<I as Iterator>::Item::default`.
-            let new_id = self.next_id();
+            let new_id = self.next_id(p.span);
             self.arena.alloc(self.ty_path(new_id, p.span, hir::QPath::Resolved(qself, path)))
         };
 
@@ -158,7 +158,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
             }
 
             // Wrap the associated extension in another type node.
-            let new_id = self.next_id();
+            let new_id = self.next_id(p.span);
             ty = self.arena.alloc(self.ty_path(new_id, p.span, qpath));
         }
 
@@ -340,9 +340,9 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
 
         let res = self.expect_full_res(segment.id);
         let id = if let Some(owner) = explicit_owner {
-            self.lower_node_id_with_owner(segment.id, owner)
+            self.lower_node_id_with_owner(segment.id, owner, segment.ident.span)
         } else {
-            self.lower_node_id(segment.id)
+            self.lower_node_id(segment.id, segment.ident.span)
         };
         debug!(
             "lower_path_segment: ident={:?} original-id={:?} new-id={:?}",
@@ -426,6 +426,6 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
     ) -> hir::TypeBinding<'hir> {
         let ident = Ident::with_dummy_span(hir::FN_OUTPUT_NAME);
         let kind = hir::TypeBindingKind::Equality { ty };
-        hir::TypeBinding { hir_id: self.next_id(), span, ident, kind }
+        hir::TypeBinding { hir_id: self.next_id(span), span, ident, kind }
     }
 }

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -1,6 +1,7 @@
 use crate::def::{DefKind, Namespace, Res};
 use crate::def_id::DefId;
 crate use crate::hir_id::HirId;
+use crate::hir_id::HirIdVec;
 use crate::{itemlikevisit, LangItem};
 
 use rustc_ast::util::parser::ExprPrecedence;
@@ -641,6 +642,9 @@ pub struct Crate<'hir> {
     pub proc_macros: Vec<HirId>,
 
     pub trait_map: BTreeMap<HirId, Vec<TraitCandidate>>,
+
+    /// Collected spans from the AST.
+    pub spans: HirIdVec<Span>,
 }
 
 impl Crate<'hir> {

--- a/compiler/rustc_index/src/vec.rs
+++ b/compiler/rustc_index/src/vec.rs
@@ -694,9 +694,7 @@ impl<I: Idx, T> IndexVec<I, T> {
     pub fn convert_index_type<Ix: Idx>(self) -> IndexVec<Ix, T> {
         IndexVec { raw: self.raw, _marker: PhantomData }
     }
-}
 
-impl<I: Idx, T: Clone> IndexVec<I, T> {
     /// Grows the index vector so that it contains an entry for
     /// `elem`; if that is already true, then has no
     /// effect. Otherwise, inserts new values as needed by invoking
@@ -710,14 +708,16 @@ impl<I: Idx, T: Clone> IndexVec<I, T> {
     }
 
     #[inline]
-    pub fn resize(&mut self, new_len: usize, value: T) {
-        self.raw.resize(new_len, value)
-    }
-
-    #[inline]
     pub fn resize_to_elem(&mut self, elem: I, fill_value: impl FnMut() -> T) {
         let min_new_len = elem.index() + 1;
         self.raw.resize_with(min_new_len, fill_value);
+    }
+}
+
+impl<I: Idx, T: Clone> IndexVec<I, T> {
+    #[inline]
+    pub fn resize(&mut self, new_len: usize, value: T) {
+        self.raw.resize(new_len, value)
     }
 }
 

--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -1378,36 +1378,42 @@ impl TypeAliasBounds {
         }
     }
 
-    fn suggest_changing_assoc_types(ty: &hir::Ty<'_>, err: &mut DiagnosticBuilder<'_>) {
+    fn suggest_changing_assoc_types(
+        tcx: TyCtxt<'_>,
+        ty: &hir::Ty<'_>,
+        err: &mut DiagnosticBuilder<'_>,
+    ) {
         // Access to associates types should use `<T as Bound>::Assoc`, which does not need a
         // bound.  Let's see if this type does that.
 
         // We use a HIR visitor to walk the type.
         use rustc_hir::intravisit::{self, Visitor};
-        struct WalkAssocTypes<'a, 'db> {
+        struct WalkAssocTypes<'a, 'db, 'tcx> {
             err: &'a mut DiagnosticBuilder<'db>,
+            tcx: TyCtxt<'tcx>,
         }
-        impl<'a, 'db, 'v> Visitor<'v> for WalkAssocTypes<'a, 'db> {
+        impl<'a, 'db, 'tcx, 'v> Visitor<'v> for WalkAssocTypes<'a, 'db, 'tcx> {
             type Map = intravisit::ErasedMap<'v>;
 
             fn nested_visit_map(&mut self) -> intravisit::NestedVisitorMap<Self::Map> {
                 intravisit::NestedVisitorMap::None
             }
 
-            fn visit_qpath(&mut self, qpath: &'v hir::QPath<'v>, id: hir::HirId, span: Span) {
+            fn visit_qpath(&mut self, qpath: &'v hir::QPath<'v>, id: hir::HirId) {
                 if TypeAliasBounds::is_type_variable_assoc(qpath) {
+                    let span = self.tcx.hir().span(id);
                     self.err.span_help(
                         span,
                         "use fully disambiguated paths (i.e., `<T as Trait>::Assoc`) to refer to \
                          associated types in type aliases",
                     );
                 }
-                intravisit::walk_qpath(self, qpath, id, span)
+                intravisit::walk_qpath(self, qpath, id)
             }
         }
 
         // Let's go for a walk!
-        let mut visitor = WalkAssocTypes { err };
+        let mut visitor = WalkAssocTypes { err, tcx };
         visitor.visit_ty(ty);
     }
 }
@@ -1443,7 +1449,7 @@ impl<'tcx> LateLintPass<'tcx> for TypeAliasBounds {
                         Applicability::MachineApplicable,
                     );
                     if !suggested_changing_assoc_types {
-                        TypeAliasBounds::suggest_changing_assoc_types(ty, &mut err);
+                        TypeAliasBounds::suggest_changing_assoc_types(cx.tcx, ty, &mut err);
                         suggested_changing_assoc_types = true;
                     }
                     err.emit();
@@ -1468,7 +1474,7 @@ impl<'tcx> LateLintPass<'tcx> for TypeAliasBounds {
                                    and should be removed";
                     err.multipart_suggestion(&msg, suggestion, Applicability::MachineApplicable);
                     if !suggested_changing_assoc_types {
-                        TypeAliasBounds::suggest_changing_assoc_types(ty, &mut err);
+                        TypeAliasBounds::suggest_changing_assoc_types(cx.tcx, ty, &mut err);
                         suggested_changing_assoc_types = true;
                     }
                     err.emit();

--- a/compiler/rustc_lint/src/late.rs
+++ b/compiler/rustc_lint/src/late.rs
@@ -26,7 +26,6 @@ use rustc_middle::hir::map::Map;
 use rustc_middle::ty::{self, TyCtxt};
 use rustc_session::lint::LintPass;
 use rustc_span::symbol::Symbol;
-use rustc_span::Span;
 
 use std::any::Any;
 use std::cell::Cell;
@@ -76,10 +75,10 @@ impl<'tcx, T: LateLintPass<'tcx>> LateContextAndPass<'tcx, T> {
         self.context.param_env = old_param_env;
     }
 
-    fn process_mod(&mut self, m: &'tcx hir::Mod<'tcx>, s: Span, n: hir::HirId) {
-        lint_callback!(self, check_mod, m, s, n);
+    fn process_mod(&mut self, m: &'tcx hir::Mod<'tcx>, n: hir::HirId) {
+        lint_callback!(self, check_mod, m, n);
         hir_visit::walk_mod(self, m, n);
-        lint_callback!(self, check_mod_post, m, s, n);
+        lint_callback!(self, check_mod_post, m, n);
     }
 
     fn enter_attrs(&mut self, attrs: &'tcx [ast::Attribute]) {
@@ -189,7 +188,6 @@ impl<'tcx, T: LateLintPass<'tcx>> hir_visit::Visitor<'tcx> for LateContextAndPas
         fk: hir_visit::FnKind<'tcx>,
         decl: &'tcx hir::FnDecl<'tcx>,
         body_id: hir::BodyId,
-        span: Span,
         id: hir::HirId,
     ) {
         // Wrap in typeck results here, not just in visit_nested_body,
@@ -197,9 +195,9 @@ impl<'tcx, T: LateLintPass<'tcx>> hir_visit::Visitor<'tcx> for LateContextAndPas
         let old_enclosing_body = self.context.enclosing_body.replace(body_id);
         let old_cached_typeck_results = self.context.cached_typeck_results.take();
         let body = self.context.tcx.hir().body(body_id);
-        lint_callback!(self, check_fn, fk, decl, body, span, id);
-        hir_visit::walk_fn(self, fk, decl, body_id, span, id);
-        lint_callback!(self, check_fn_post, fk, decl, body, span, id);
+        lint_callback!(self, check_fn, fk, decl, body, id);
+        hir_visit::walk_fn(self, fk, decl, body_id, id);
+        lint_callback!(self, check_fn_post, fk, decl, body, id);
         self.context.enclosing_body = old_enclosing_body;
         self.context.cached_typeck_results.set(old_cached_typeck_results);
     }
@@ -210,7 +208,6 @@ impl<'tcx, T: LateLintPass<'tcx>> hir_visit::Visitor<'tcx> for LateContextAndPas
         _: Symbol,
         _: &'tcx hir::Generics<'tcx>,
         _: hir::HirId,
-        _: Span,
     ) {
         lint_callback!(self, check_struct_def, s);
         hir_visit::walk_struct_def(self, s);
@@ -242,13 +239,9 @@ impl<'tcx, T: LateLintPass<'tcx>> hir_visit::Visitor<'tcx> for LateContextAndPas
         hir_visit::walk_ty(self, t);
     }
 
-    fn visit_name(&mut self, sp: Span, name: Symbol) {
-        lint_callback!(self, check_name, sp, name);
-    }
-
-    fn visit_mod(&mut self, m: &'tcx hir::Mod<'tcx>, s: Span, n: hir::HirId) {
+    fn visit_mod(&mut self, m: &'tcx hir::Mod<'tcx>, n: hir::HirId) {
         if !self.context.only_module {
-            self.process_mod(m, s, n);
+            self.process_mod(m, n);
         }
     }
 
@@ -387,8 +380,8 @@ fn late_lint_mod_pass<'tcx, T: LateLintPass<'tcx>>(
 
     let mut cx = LateContextAndPass { context, pass };
 
-    let (module, span, hir_id) = tcx.hir().get_module(module_def_id);
-    cx.process_mod(module, span, hir_id);
+    let (module, hir_id) = tcx.hir().get_module(module_def_id);
+    cx.process_mod(module, hir_id);
 
     // Visit the crate attributes
     if hir_id == hir::CRATE_HIR_ID {

--- a/compiler/rustc_lint/src/lib.rs
+++ b/compiler/rustc_lint/src/lib.rs
@@ -72,7 +72,7 @@ use rustc_session::lint::builtin::{
     EXPLICIT_OUTLIVES_REQUIREMENTS, INVALID_CODEBLOCK_ATTRIBUTES, INVALID_HTML_TAGS,
     MISSING_DOC_CODE_EXAMPLES, NON_AUTOLINKS, PRIVATE_DOC_TESTS,
 };
-use rustc_span::symbol::{Ident, Symbol};
+use rustc_span::symbol::Ident;
 use rustc_span::Span;
 
 use array_into_iter::ArrayIntoIter;

--- a/compiler/rustc_lint/src/nonstandard_style.rs
+++ b/compiler/rustc_lint/src/nonstandard_style.rs
@@ -8,7 +8,7 @@ use rustc_hir::intravisit::FnKind;
 use rustc_hir::{GenericParamKind, PatKind};
 use rustc_middle::ty;
 use rustc_span::symbol::sym;
-use rustc_span::{symbol::Ident, BytePos, Span};
+use rustc_span::{symbol::Ident, BytePos};
 use rustc_target::spec::abi::Abi;
 
 #[derive(PartialEq)]
@@ -308,13 +308,7 @@ impl NonSnakeCase {
 }
 
 impl<'tcx> LateLintPass<'tcx> for NonSnakeCase {
-    fn check_mod(
-        &mut self,
-        cx: &LateContext<'_>,
-        _: &'tcx hir::Mod<'tcx>,
-        _: Span,
-        id: hir::HirId,
-    ) {
+    fn check_mod(&mut self, cx: &LateContext<'_>, _: &'tcx hir::Mod<'tcx>, id: hir::HirId) {
         if id != hir::CRATE_HIR_ID {
             return;
         }
@@ -372,7 +366,6 @@ impl<'tcx> LateLintPass<'tcx> for NonSnakeCase {
         fk: FnKind<'_>,
         _: &hir::FnDecl<'_>,
         _: &hir::Body<'_>,
-        _: Span,
         id: hir::HirId,
     ) {
         match &fk {

--- a/compiler/rustc_lint/src/passes.rs
+++ b/compiler/rustc_lint/src/passes.rs
@@ -5,7 +5,7 @@ use rustc_data_structures::sync;
 use rustc_hir as hir;
 use rustc_session::lint::builtin::HardwiredLints;
 use rustc_session::lint::LintPass;
-use rustc_span::symbol::{Ident, Symbol};
+use rustc_span::symbol::Ident;
 use rustc_span::Span;
 
 #[macro_export]
@@ -15,11 +15,10 @@ macro_rules! late_lint_methods {
             fn check_param(a: &$hir hir::Param<$hir>);
             fn check_body(a: &$hir hir::Body<$hir>);
             fn check_body_post(a: &$hir hir::Body<$hir>);
-            fn check_name(a: Span, b: Symbol);
             fn check_crate(a: &$hir hir::Crate<$hir>);
             fn check_crate_post(a: &$hir hir::Crate<$hir>);
-            fn check_mod(a: &$hir hir::Mod<$hir>, b: Span, c: hir::HirId);
-            fn check_mod_post(a: &$hir hir::Mod<$hir>, b: Span, c: hir::HirId);
+            fn check_mod(a: &$hir hir::Mod<$hir>, c: hir::HirId);
+            fn check_mod_post(a: &$hir hir::Mod<$hir>, c: hir::HirId);
             fn check_foreign_item(a: &$hir hir::ForeignItem<$hir>);
             fn check_foreign_item_post(a: &$hir hir::ForeignItem<$hir>);
             fn check_item(a: &$hir hir::Item<$hir>);
@@ -42,13 +41,11 @@ macro_rules! late_lint_methods {
                 a: rustc_hir::intravisit::FnKind<$hir>,
                 b: &$hir hir::FnDecl<$hir>,
                 c: &$hir hir::Body<$hir>,
-                d: Span,
                 e: hir::HirId);
             fn check_fn_post(
                 a: rustc_hir::intravisit::FnKind<$hir>,
                 b: &$hir hir::FnDecl<$hir>,
                 c: &$hir hir::Body<$hir>,
-                d: Span,
                 e: hir::HirId
             );
             fn check_trait_item(a: &$hir hir::TraitItem<$hir>);

--- a/compiler/rustc_lint/src/types.rs
+++ b/compiler/rustc_lint/src/types.rs
@@ -1266,7 +1266,6 @@ impl<'tcx> LateLintPass<'tcx> for ImproperCTypesDefinitions {
         kind: hir::intravisit::FnKind<'tcx>,
         decl: &'tcx hir::FnDecl<'_>,
         _: &'tcx hir::Body<'_>,
-        _: Span,
         hir_id: hir::HirId,
     ) {
         use hir::intravisit::FnKind;

--- a/compiler/rustc_middle/src/hir/map/blocks.rs
+++ b/compiler/rustc_middle/src/hir/map/blocks.rs
@@ -17,7 +17,6 @@ use rustc_hir as hir;
 use rustc_hir::intravisit::FnKind;
 use rustc_hir::{Expr, FnDecl, Node};
 use rustc_span::symbol::Ident;
-use rustc_span::Span;
 
 /// An FnLikeNode is a Node that is like a fn, in that it has a decl
 /// and a body (as well as a NodeId, a span, etc).
@@ -104,7 +103,6 @@ struct ItemFnParts<'a> {
     generics: &'a hir::Generics<'a>,
     body: hir::BodyId,
     id: hir::HirId,
-    span: Span,
     attrs: &'a [Attribute],
 }
 
@@ -114,19 +112,12 @@ struct ClosureParts<'a> {
     decl: &'a FnDecl<'a>,
     body: hir::BodyId,
     id: hir::HirId,
-    span: Span,
     attrs: &'a [Attribute],
 }
 
 impl<'a> ClosureParts<'a> {
-    fn new(
-        d: &'a FnDecl<'a>,
-        b: hir::BodyId,
-        id: hir::HirId,
-        s: Span,
-        attrs: &'a [Attribute],
-    ) -> Self {
-        ClosureParts { decl: d, body: b, id, span: s, attrs }
+    fn new(d: &'a FnDecl<'a>, b: hir::BodyId, id: hir::HirId, attrs: &'a [Attribute]) -> Self {
+        ClosureParts { decl: d, body: b, id, attrs }
     }
 }
 
@@ -146,7 +137,7 @@ impl<'a> FnLikeNode<'a> {
     pub fn body(self) -> hir::BodyId {
         self.handle(
             |i: ItemFnParts<'a>| i.body,
-            |_, _, _: &'a hir::FnSig<'a>, _, body: hir::BodyId, _, _| body,
+            |_, _, _: &'a hir::FnSig<'a>, _, body: hir::BodyId, _| body,
             |c: ClosureParts<'a>| c.body,
         )
     }
@@ -154,23 +145,15 @@ impl<'a> FnLikeNode<'a> {
     pub fn decl(self) -> &'a FnDecl<'a> {
         self.handle(
             |i: ItemFnParts<'a>| &*i.decl,
-            |_, _, sig: &'a hir::FnSig<'a>, _, _, _, _| &sig.decl,
+            |_, _, sig: &'a hir::FnSig<'a>, _, _, _| &sig.decl,
             |c: ClosureParts<'a>| c.decl,
-        )
-    }
-
-    pub fn span(self) -> Span {
-        self.handle(
-            |i: ItemFnParts<'_>| i.span,
-            |_, _, _: &'a hir::FnSig<'a>, _, _, span, _| span,
-            |c: ClosureParts<'_>| c.span,
         )
     }
 
     pub fn id(self) -> hir::HirId {
         self.handle(
             |i: ItemFnParts<'_>| i.id,
-            |id, _, _: &'a hir::FnSig<'a>, _, _, _, _| id,
+            |id, _, _: &'a hir::FnSig<'a>, _, _, _| id,
             |c: ClosureParts<'_>| c.id,
         )
     }
@@ -192,7 +175,7 @@ impl<'a> FnLikeNode<'a> {
             FnKind::ItemFn(p.ident, p.generics, p.header, p.vis, p.attrs)
         };
         let closure = |c: ClosureParts<'a>| FnKind::Closure(c.attrs);
-        let method = |_, ident: Ident, sig: &'a hir::FnSig<'a>, vis, _, _, attrs| {
+        let method = |_, ident: Ident, sig: &'a hir::FnSig<'a>, vis, _, attrs| {
             FnKind::Method(ident, sig, vis, attrs)
         };
         self.handle(item, method, closure)
@@ -207,7 +190,6 @@ impl<'a> FnLikeNode<'a> {
             &'a hir::FnSig<'a>,
             Option<&'a hir::Visibility<'a>>,
             hir::BodyId,
-            Span,
             &'a [Attribute],
         ) -> A,
         C: FnOnce(ClosureParts<'a>) -> A,
@@ -220,7 +202,6 @@ impl<'a> FnLikeNode<'a> {
                     decl: &sig.decl,
                     body: block,
                     vis: &i.vis,
-                    span: i.span,
                     attrs: &i.attrs,
                     header: sig.header,
                     generics,
@@ -229,19 +210,19 @@ impl<'a> FnLikeNode<'a> {
             },
             Node::TraitItem(ti) => match ti.kind {
                 hir::TraitItemKind::Fn(ref sig, hir::TraitFn::Provided(body)) => {
-                    method(ti.hir_id, ti.ident, sig, None, body, ti.span, &ti.attrs)
+                    method(ti.hir_id, ti.ident, sig, None, body, &ti.attrs)
                 }
                 _ => bug!("trait method FnLikeNode that is not fn-like"),
             },
             Node::ImplItem(ii) => match ii.kind {
                 hir::ImplItemKind::Fn(ref sig, body) => {
-                    method(ii.hir_id, ii.ident, sig, Some(&ii.vis), body, ii.span, &ii.attrs)
+                    method(ii.hir_id, ii.ident, sig, Some(&ii.vis), body, &ii.attrs)
                 }
                 _ => bug!("impl method FnLikeNode that is not fn-like"),
             },
             Node::Expr(e) => match e.kind {
                 hir::ExprKind::Closure(_, ref decl, block, _fn_decl_span, _gen) => {
-                    closure(ClosureParts::new(&decl, block, e.hir_id, e.span, &e.attrs))
+                    closure(ClosureParts::new(&decl, block, e.hir_id, &e.attrs))
                 }
                 _ => bug!("expr FnLikeNode that is not fn-like"),
             },

--- a/compiler/rustc_middle/src/hir/map/collector.rs
+++ b/compiler/rustc_middle/src/hir/map/collector.rs
@@ -16,7 +16,7 @@ use rustc_hir::*;
 use rustc_index::vec::{Idx, IndexVec};
 use rustc_session::{CrateDisambiguator, Session};
 use rustc_span::source_map::SourceMap;
-use rustc_span::{Span, Symbol, DUMMY_SP};
+use rustc_span::Symbol;
 
 use std::iter::repeat;
 
@@ -234,11 +234,11 @@ impl<'a, 'hir> NodeCollector<'a, 'hir> {
         }
     }
 
-    fn insert(&mut self, span: Span, hir_id: HirId, node: Node<'hir>) {
-        self.insert_with_hash(span, hir_id, node, Fingerprint::ZERO)
+    fn insert(&mut self, hir_id: HirId, node: Node<'hir>) {
+        self.insert_with_hash(hir_id, node, Fingerprint::ZERO)
     }
 
-    fn insert_with_hash(&mut self, span: Span, hir_id: HirId, node: Node<'hir>, hash: Fingerprint) {
+    fn insert_with_hash(&mut self, hir_id: HirId, node: Node<'hir>, hash: Fingerprint) {
         let entry = Entry { parent: self.parent_node, node };
 
         // Make sure that the DepNode of some node coincides with the HirId
@@ -250,6 +250,7 @@ impl<'a, 'hir> NodeCollector<'a, 'hir> {
                     None => format!("{:?}", node),
                 };
 
+                let span = self.krate.spans[hir_id];
                 span_bug!(
                     span,
                     "inconsistent DepNode at `{:?}` for `{}`: \
@@ -331,7 +332,7 @@ impl<'a, 'hir> Visitor<'hir> for NodeCollector<'a, 'hir> {
 
     fn visit_param(&mut self, param: &'hir Param<'hir>) {
         let node = Node::Param(param);
-        self.insert(param.pat.span, param.hir_id, node);
+        self.insert(param.hir_id, node);
         self.with_parent(param.hir_id, |this| {
             intravisit::walk_param(this, param);
         });
@@ -344,12 +345,13 @@ impl<'a, 'hir> Visitor<'hir> for NodeCollector<'a, 'hir> {
             self.definitions.opt_hir_id_to_local_def_id(i.hir_id).unwrap()
         );
         self.with_dep_node_owner(i.hir_id.owner, i, |this, hash| {
-            this.insert_with_hash(i.span, i.hir_id, Node::Item(i), hash);
+            this.insert_with_hash(i.hir_id, Node::Item(i), hash);
+
             this.with_parent(i.hir_id, |this| {
                 if let ItemKind::Struct(ref struct_def, _) = i.kind {
                     // If this is a tuple or unit-like struct, register the constructor.
                     if let Some(ctor_hir_id) = struct_def.ctor_hir_id() {
-                        this.insert(i.span, ctor_hir_id, Node::Ctor(struct_def));
+                        this.insert(ctor_hir_id, Node::Ctor(struct_def));
                     }
                 }
                 intravisit::walk_item(this, i);
@@ -363,7 +365,7 @@ impl<'a, 'hir> Visitor<'hir> for NodeCollector<'a, 'hir> {
             self.definitions.opt_hir_id_to_local_def_id(fi.hir_id).unwrap()
         );
         self.with_dep_node_owner(fi.hir_id.owner, fi, |this, hash| {
-            this.insert_with_hash(fi.span, fi.hir_id, Node::ForeignItem(fi), hash);
+            this.insert_with_hash(fi.hir_id, Node::ForeignItem(fi), hash);
 
             this.with_parent(fi.hir_id, |this| {
                 intravisit::walk_foreign_item(this, fi);
@@ -382,14 +384,14 @@ impl<'a, 'hir> Visitor<'hir> for NodeCollector<'a, 'hir> {
                 self.definitions.opt_hir_id_to_local_def_id(param.hir_id).unwrap()
             );
             self.with_dep_node_owner(param.hir_id.owner, param, |this, hash| {
-                this.insert_with_hash(param.span, param.hir_id, Node::GenericParam(param), hash);
+                this.insert_with_hash(param.hir_id, Node::GenericParam(param), hash);
 
                 this.with_parent(param.hir_id, |this| {
                     intravisit::walk_generic_param(this, param);
                 });
             });
         } else {
-            self.insert(param.span, param.hir_id, Node::GenericParam(param));
+            self.insert(param.hir_id, Node::GenericParam(param));
             intravisit::walk_generic_param(self, param);
         }
     }
@@ -400,7 +402,7 @@ impl<'a, 'hir> Visitor<'hir> for NodeCollector<'a, 'hir> {
             self.definitions.opt_hir_id_to_local_def_id(ti.hir_id).unwrap()
         );
         self.with_dep_node_owner(ti.hir_id.owner, ti, |this, hash| {
-            this.insert_with_hash(ti.span, ti.hir_id, Node::TraitItem(ti), hash);
+            this.insert_with_hash(ti.hir_id, Node::TraitItem(ti), hash);
 
             this.with_parent(ti.hir_id, |this| {
                 intravisit::walk_trait_item(this, ti);
@@ -414,7 +416,7 @@ impl<'a, 'hir> Visitor<'hir> for NodeCollector<'a, 'hir> {
             self.definitions.opt_hir_id_to_local_def_id(ii.hir_id).unwrap()
         );
         self.with_dep_node_owner(ii.hir_id.owner, ii, |this, hash| {
-            this.insert_with_hash(ii.span, ii.hir_id, Node::ImplItem(ii), hash);
+            this.insert_with_hash(ii.hir_id, Node::ImplItem(ii), hash);
 
             this.with_parent(ii.hir_id, |this| {
                 intravisit::walk_impl_item(this, ii);
@@ -425,7 +427,7 @@ impl<'a, 'hir> Visitor<'hir> for NodeCollector<'a, 'hir> {
     fn visit_pat(&mut self, pat: &'hir Pat<'hir>) {
         let node =
             if let PatKind::Binding(..) = pat.kind { Node::Binding(pat) } else { Node::Pat(pat) };
-        self.insert(pat.span, pat.hir_id, node);
+        self.insert(pat.hir_id, node);
 
         self.with_parent(pat.hir_id, |this| {
             intravisit::walk_pat(this, pat);
@@ -435,7 +437,7 @@ impl<'a, 'hir> Visitor<'hir> for NodeCollector<'a, 'hir> {
     fn visit_arm(&mut self, arm: &'hir Arm<'hir>) {
         let node = Node::Arm(arm);
 
-        self.insert(arm.span, arm.hir_id, node);
+        self.insert(arm.hir_id, node);
 
         self.with_parent(arm.hir_id, |this| {
             intravisit::walk_arm(this, arm);
@@ -443,7 +445,7 @@ impl<'a, 'hir> Visitor<'hir> for NodeCollector<'a, 'hir> {
     }
 
     fn visit_anon_const(&mut self, constant: &'hir AnonConst) {
-        self.insert(DUMMY_SP, constant.hir_id, Node::AnonConst(constant));
+        self.insert(constant.hir_id, Node::AnonConst(constant));
 
         self.with_parent(constant.hir_id, |this| {
             intravisit::walk_anon_const(this, constant);
@@ -451,7 +453,7 @@ impl<'a, 'hir> Visitor<'hir> for NodeCollector<'a, 'hir> {
     }
 
     fn visit_expr(&mut self, expr: &'hir Expr<'hir>) {
-        self.insert(expr.span, expr.hir_id, Node::Expr(expr));
+        self.insert(expr.hir_id, Node::Expr(expr));
 
         self.with_parent(expr.hir_id, |this| {
             intravisit::walk_expr(this, expr);
@@ -459,7 +461,7 @@ impl<'a, 'hir> Visitor<'hir> for NodeCollector<'a, 'hir> {
     }
 
     fn visit_stmt(&mut self, stmt: &'hir Stmt<'hir>) {
-        self.insert(stmt.span, stmt.hir_id, Node::Stmt(stmt));
+        self.insert(stmt.hir_id, Node::Stmt(stmt));
 
         self.with_parent(stmt.hir_id, |this| {
             intravisit::walk_stmt(this, stmt);
@@ -468,13 +470,13 @@ impl<'a, 'hir> Visitor<'hir> for NodeCollector<'a, 'hir> {
 
     fn visit_path_segment(&mut self, path_segment: &'hir PathSegment<'hir>) {
         if let Some(hir_id) = path_segment.hir_id {
-            self.insert(DUMMY_SP, hir_id, Node::PathSegment(path_segment));
+            self.insert(hir_id, Node::PathSegment(path_segment));
         }
         intravisit::walk_path_segment(self, path_segment);
     }
 
     fn visit_ty(&mut self, ty: &'hir Ty<'hir>) {
-        self.insert(ty.span, ty.hir_id, Node::Ty(ty));
+        self.insert(ty.hir_id, Node::Ty(ty));
 
         self.with_parent(ty.hir_id, |this| {
             intravisit::walk_ty(this, ty);
@@ -482,7 +484,7 @@ impl<'a, 'hir> Visitor<'hir> for NodeCollector<'a, 'hir> {
     }
 
     fn visit_trait_ref(&mut self, tr: &'hir TraitRef<'hir>) {
-        self.insert(tr.path.span, tr.hir_ref_id, Node::TraitRef(tr));
+        self.insert(tr.hir_ref_id, Node::TraitRef(tr));
 
         self.with_parent(tr.hir_ref_id, |this| {
             intravisit::walk_trait_ref(this, tr);
@@ -501,26 +503,26 @@ impl<'a, 'hir> Visitor<'hir> for NodeCollector<'a, 'hir> {
     }
 
     fn visit_block(&mut self, block: &'hir Block<'hir>) {
-        self.insert(block.span, block.hir_id, Node::Block(block));
+        self.insert(block.hir_id, Node::Block(block));
         self.with_parent(block.hir_id, |this| {
             intravisit::walk_block(this, block);
         });
     }
 
     fn visit_local(&mut self, l: &'hir Local<'hir>) {
-        self.insert(l.span, l.hir_id, Node::Local(l));
+        self.insert(l.hir_id, Node::Local(l));
         self.with_parent(l.hir_id, |this| intravisit::walk_local(this, l))
     }
 
     fn visit_lifetime(&mut self, lifetime: &'hir Lifetime) {
-        self.insert(lifetime.span, lifetime.hir_id, Node::Lifetime(lifetime));
+        self.insert(lifetime.hir_id, Node::Lifetime(lifetime));
     }
 
     fn visit_vis(&mut self, visibility: &'hir Visibility<'hir>) {
         match visibility.node {
             VisibilityKind::Public | VisibilityKind::Crate(_) | VisibilityKind::Inherited => {}
             VisibilityKind::Restricted { hir_id, .. } => {
-                self.insert(visibility.span, hir_id, Node::Visibility(visibility));
+                self.insert(hir_id, Node::Visibility(visibility));
                 self.with_parent(hir_id, |this| {
                     intravisit::walk_vis(this, visibility);
                 });
@@ -538,29 +540,24 @@ impl<'a, 'hir> Visitor<'hir> for NodeCollector<'a, 'hir> {
         });
         self.with_parent(parent, |this| {
             this.with_dep_node_owner(macro_def.hir_id.owner, macro_def, |this, hash| {
-                this.insert_with_hash(
-                    macro_def.span,
-                    macro_def.hir_id,
-                    Node::MacroDef(macro_def),
-                    hash,
-                );
+                this.insert_with_hash(macro_def.hir_id, Node::MacroDef(macro_def), hash);
             })
         });
     }
 
     fn visit_variant(&mut self, v: &'hir Variant<'hir>, g: &'hir Generics<'hir>, item_id: HirId) {
-        self.insert(v.span, v.id, Node::Variant(v));
+        self.insert(v.id, Node::Variant(v));
         self.with_parent(v.id, |this| {
             // Register the constructor of this variant.
             if let Some(ctor_hir_id) = v.data.ctor_hir_id() {
-                this.insert(v.span, ctor_hir_id, Node::Ctor(&v.data));
+                this.insert(ctor_hir_id, Node::Ctor(&v.data));
             }
             intravisit::walk_variant(this, v, g, item_id);
         });
     }
 
     fn visit_struct_field(&mut self, field: &'hir StructField<'hir>) {
-        self.insert(field.span, field.hir_id, Node::Field(field));
+        self.insert(field.hir_id, Node::Field(field));
         self.with_parent(field.hir_id, |this| {
             intravisit::walk_struct_field(this, field);
         });

--- a/compiler/rustc_middle/src/hir/map/collector.rs
+++ b/compiler/rustc_middle/src/hir/map/collector.rs
@@ -466,11 +466,11 @@ impl<'a, 'hir> Visitor<'hir> for NodeCollector<'a, 'hir> {
         });
     }
 
-    fn visit_path_segment(&mut self, path_span: Span, path_segment: &'hir PathSegment<'hir>) {
+    fn visit_path_segment(&mut self, path_segment: &'hir PathSegment<'hir>) {
         if let Some(hir_id) = path_segment.hir_id {
-            self.insert(path_span, hir_id, Node::PathSegment(path_segment));
+            self.insert(DUMMY_SP, hir_id, Node::PathSegment(path_segment));
         }
-        intravisit::walk_path_segment(self, path_span, path_segment);
+        intravisit::walk_path_segment(self, path_segment);
     }
 
     fn visit_ty(&mut self, ty: &'hir Ty<'hir>) {
@@ -494,11 +494,10 @@ impl<'a, 'hir> Visitor<'hir> for NodeCollector<'a, 'hir> {
         fk: intravisit::FnKind<'hir>,
         fd: &'hir FnDecl<'hir>,
         b: BodyId,
-        s: Span,
         id: HirId,
     ) {
         assert_eq!(self.parent_node, id);
-        intravisit::walk_fn(self, fk, fd, b, s, id);
+        intravisit::walk_fn(self, fk, fd, b, id);
     }
 
     fn visit_block(&mut self, block: &'hir Block<'hir>) {

--- a/compiler/rustc_middle/src/hir/map/collector.rs
+++ b/compiler/rustc_middle/src/hir/map/collector.rs
@@ -119,6 +119,7 @@ impl<'a, 'hir> NodeCollector<'a, 'hir> {
                 modules: _,
                 proc_macros: _,
                 trait_map: _,
+                spans: _,
             } = *krate;
 
             hash_body(&mut hcx, root_mod_def_path_hash, item, &mut hir_body_nodes)

--- a/compiler/rustc_middle/src/hir/map/mod.rs
+++ b/compiler/rustc_middle/src/hir/map/mod.rs
@@ -451,11 +451,11 @@ impl<'hir> Map<'hir> {
         }
     }
 
-    pub fn get_module(&self, module: LocalDefId) -> (&'hir Mod<'hir>, Span, HirId) {
+    pub fn get_module(&self, module: LocalDefId) -> (&'hir Mod<'hir>, HirId) {
         let hir_id = self.local_def_id_to_hir_id(module);
         match self.get_entry(hir_id).node {
-            Node::Item(&Item { span, kind: ItemKind::Mod(ref m), .. }) => (m, span, hir_id),
-            Node::Crate(item) => (&item.module, item.span, hir_id),
+            Node::Item(&Item { kind: ItemKind::Mod(ref m), .. }) => (m, hir_id),
+            Node::Crate(item) => (&item.module, hir_id),
             node => panic!("not a module: {:?}", node),
         }
     }

--- a/compiler/rustc_middle/src/hir/mod.rs
+++ b/compiler/rustc_middle/src/hir/mod.rs
@@ -77,6 +77,7 @@ pub fn provide(providers: &mut Providers) {
     };
     providers.hir_owner = |tcx, id| tcx.index_hir(LOCAL_CRATE).map[id].signature;
     providers.hir_owner_nodes = |tcx, id| tcx.index_hir(LOCAL_CRATE).map[id].with_bodies.as_deref();
+    providers.hir_owner_spans = |tcx, id| tcx.hir_crate(LOCAL_CRATE).spans.get_owner(id);
     providers.fn_arg_names = |tcx, id| {
         let hir = tcx.hir();
         let hir_id = hir.local_def_id_to_hir_id(id.expect_local());

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -89,6 +89,15 @@ rustc_queries! {
             desc { |tcx| "HIR owner items in `{}`", tcx.def_path_str(key.to_def_id()) }
         }
 
+        // Gives access to the HIR spans inside the HIR owner `key`.
+        //
+        // This can be conveniently accessed by methods on `tcx.hir()`.
+        // Avoid calling this query directly.
+        query hir_owner_spans(key: LocalDefId) -> &'tcx IndexVec<ItemLocalId, Span> {
+            eval_always
+            desc { |tcx| "HIR owner spans in `{}`", tcx.def_path_str(key.to_def_id()) }
+        }
+
         /// Computes the `DefId` of the corresponding const parameter in case the `key` is a
         /// const argument and returns `None` otherwise.
         ///

--- a/compiler/rustc_mir/src/transform/mod.rs
+++ b/compiler/rustc_mir/src/transform/mod.rs
@@ -10,7 +10,7 @@ use rustc_middle::mir::visit::Visitor as _;
 use rustc_middle::mir::{traversal, Body, ConstQualifs, MirPhase, Promoted};
 use rustc_middle::ty::query::Providers;
 use rustc_middle::ty::{self, TyCtxt, TypeFoldable};
-use rustc_span::{Span, Symbol};
+use rustc_span::Symbol;
 use std::borrow::Cow;
 
 pub mod add_call_guards;
@@ -117,7 +117,6 @@ fn mir_keys(tcx: TyCtxt<'_>, krate: CrateNum) -> FxHashSet<LocalDefId> {
             _: Symbol,
             _: &'tcx hir::Generics<'tcx>,
             _: hir::HirId,
-            _: Span,
         ) {
             if let hir::VariantData::Tuple(_, hir_id) = *v {
                 self.set.insert(self.tcx.hir().local_def_id(hir_id));

--- a/compiler/rustc_passes/src/dead.rs
+++ b/compiler/rustc_passes/src/dead.rs
@@ -241,7 +241,6 @@ impl<'tcx> Visitor<'tcx> for MarkSymbolVisitor<'tcx> {
         _: Symbol,
         _: &hir::Generics<'_>,
         _: hir::HirId,
-        _: rustc_span::Span,
     ) {
         let has_repr_c = self.repr_has_repr_c;
         let inherited_pub_visibility = self.inherited_pub_visibility;

--- a/compiler/rustc_passes/src/hir_stats.rs
+++ b/compiler/rustc_passes/src/hir_stats.rs
@@ -124,7 +124,7 @@ impl<'v> hir_visit::Visitor<'v> for StatCollector<'v> {
         hir_visit::walk_item(self, i)
     }
 
-    fn visit_mod(&mut self, m: &'v hir::Mod<'v>, _s: Span, n: hir::HirId) {
+    fn visit_mod(&mut self, m: &'v hir::Mod<'v>, n: hir::HirId) {
         self.record("Mod", Id::None, m);
         hir_visit::walk_mod(self, m, n)
     }
@@ -174,11 +174,10 @@ impl<'v> hir_visit::Visitor<'v> for StatCollector<'v> {
         fk: hir_visit::FnKind<'v>,
         fd: &'v hir::FnDecl<'v>,
         b: hir::BodyId,
-        s: Span,
         id: hir::HirId,
     ) {
         self.record("FnDecl", Id::None, fd);
-        hir_visit::walk_fn(self, fk, fd, b, s, id)
+        hir_visit::walk_fn(self, fk, fd, b, id)
     }
 
     fn visit_where_predicate(&mut self, predicate: &'v hir::WherePredicate<'v>) {
@@ -221,9 +220,9 @@ impl<'v> hir_visit::Visitor<'v> for StatCollector<'v> {
         hir_visit::walk_lifetime(self, lifetime)
     }
 
-    fn visit_qpath(&mut self, qpath: &'v hir::QPath<'v>, id: hir::HirId, span: Span) {
+    fn visit_qpath(&mut self, qpath: &'v hir::QPath<'v>, id: hir::HirId) {
         self.record("QPath", Id::None, qpath);
-        hir_visit::walk_qpath(self, qpath, id, span)
+        hir_visit::walk_qpath(self, qpath, id)
     }
 
     fn visit_path(&mut self, path: &'v hir::Path<'v>, _id: hir::HirId) {
@@ -231,9 +230,9 @@ impl<'v> hir_visit::Visitor<'v> for StatCollector<'v> {
         hir_visit::walk_path(self, path)
     }
 
-    fn visit_path_segment(&mut self, path_span: Span, path_segment: &'v hir::PathSegment<'v>) {
+    fn visit_path_segment(&mut self, path_segment: &'v hir::PathSegment<'v>) {
         self.record("PathSegment", Id::None, path_segment);
-        hir_visit::walk_path_segment(self, path_span, path_segment)
+        hir_visit::walk_path_segment(self, path_segment)
     }
 
     fn visit_assoc_type_binding(&mut self, type_binding: &'v hir::TypeBinding<'v>) {

--- a/compiler/rustc_passes/src/naked_functions.rs
+++ b/compiler/rustc_passes/src/naked_functions.rs
@@ -39,7 +39,6 @@ impl<'tcx> Visitor<'tcx> for CheckNakedFunctions<'tcx> {
         fk: FnKind<'v>,
         _fd: &'tcx hir::FnDecl<'tcx>,
         body_id: hir::BodyId,
-        span: Span,
         hir_id: HirId,
     ) {
         let ident_span;
@@ -68,7 +67,7 @@ impl<'tcx> Visitor<'tcx> for CheckNakedFunctions<'tcx> {
             check_abi(self.tcx, hir_id, fn_header.abi, ident_span);
             check_no_patterns(self.tcx, body.params);
             check_no_parameters_use(self.tcx, body);
-            check_asm(self.tcx, hir_id, body, span);
+            check_asm(self.tcx, hir_id, body);
         }
     }
 }
@@ -146,12 +145,13 @@ impl<'tcx> Visitor<'tcx> for CheckParameters<'tcx> {
 }
 
 /// Checks that function body contains a single inline assembly block.
-fn check_asm<'tcx>(tcx: TyCtxt<'tcx>, hir_id: HirId, body: &'tcx hir::Body<'tcx>, fn_span: Span) {
+fn check_asm<'tcx>(tcx: TyCtxt<'tcx>, hir_id: HirId, body: &'tcx hir::Body<'tcx>) {
     let mut this = CheckInlineAssembly { tcx, items: Vec::new() };
     this.visit_body(body);
     if let [(ItemKind::Asm, _)] = this.items[..] {
         // Ok.
     } else {
+        let fn_span = tcx.hir().span_with_body(hir_id);
         tcx.struct_span_lint_hir(UNSUPPORTED_NAKED_FUNCTIONS, hir_id, fn_span, |lint| {
             let mut diag = lint.build("naked functions must contain a single asm block");
             let mut has_asm = false;

--- a/compiler/rustc_privacy/src/lib.rs
+++ b/compiler/rustc_privacy/src/lib.rs
@@ -809,7 +809,7 @@ impl Visitor<'tcx> for EmbargoVisitor<'tcx> {
         self.prev_level = orig_level;
     }
 
-    fn visit_mod(&mut self, m: &'tcx hir::Mod<'tcx>, _sp: Span, id: hir::HirId) {
+    fn visit_mod(&mut self, m: &'tcx hir::Mod<'tcx>, id: hir::HirId) {
         // This code is here instead of in visit_item so that the
         // crate module gets processed as well.
         if self.prev_level.is_some() {
@@ -991,7 +991,7 @@ impl<'tcx> Visitor<'tcx> for NamePrivacyVisitor<'tcx> {
         NestedVisitorMap::All(self.tcx.hir())
     }
 
-    fn visit_mod(&mut self, _m: &'tcx hir::Mod<'tcx>, _s: Span, _n: hir::HirId) {
+    fn visit_mod(&mut self, _m: &'tcx hir::Mod<'tcx>, _n: hir::HirId) {
         // Don't visit nested modules, since we run a separate visitor walk
         // for each module in `privacy_access_levels`
     }
@@ -1120,7 +1120,7 @@ impl<'tcx> Visitor<'tcx> for TypePrivacyVisitor<'tcx> {
         NestedVisitorMap::All(self.tcx.hir())
     }
 
-    fn visit_mod(&mut self, _m: &'tcx hir::Mod<'tcx>, _s: Span, _n: hir::HirId) {
+    fn visit_mod(&mut self, _m: &'tcx hir::Mod<'tcx>, _n: hir::HirId) {
         // Don't visit nested modules, since we run a separate visitor walk
         // for each module in `privacy_access_levels`
     }
@@ -1224,7 +1224,7 @@ impl<'tcx> Visitor<'tcx> for TypePrivacyVisitor<'tcx> {
     // we prohibit access to private statics from other crates, this allows to give
     // more code internal visibility at link time. (Access to private functions
     // is already prohibited by type privacy for function types.)
-    fn visit_qpath(&mut self, qpath: &'tcx hir::QPath<'tcx>, id: hir::HirId, span: Span) {
+    fn visit_qpath(&mut self, qpath: &'tcx hir::QPath<'tcx>, id: hir::HirId) {
         let def = match qpath {
             hir::QPath::Resolved(_, path) => match path.res {
                 Res::Def(kind, def_id) => Some((kind, def_id)),
@@ -1257,6 +1257,7 @@ impl<'tcx> Visitor<'tcx> for TypePrivacyVisitor<'tcx> {
                     Some(name) => format!("{} `{}` is private", kind, name),
                     None => format!("{} is private", kind),
                 };
+                let span = self.tcx.hir().span(id);
                 sess.struct_span_err(span, &msg)
                     .span_label(span, &format!("private {}", kind))
                     .emit();
@@ -1264,7 +1265,7 @@ impl<'tcx> Visitor<'tcx> for TypePrivacyVisitor<'tcx> {
             }
         }
 
-        intravisit::walk_qpath(self, qpath, id, span);
+        intravisit::walk_qpath(self, qpath, id);
     }
 
     // Check types of patterns.
@@ -2052,7 +2053,8 @@ fn visibility(tcx: TyCtxt<'_>, def_id: DefId) -> ty::Visibility {
 fn check_mod_privacy(tcx: TyCtxt<'_>, module_def_id: LocalDefId) {
     // Check privacy of names not checked in previous compilation stages.
     let mut visitor = NamePrivacyVisitor { tcx, maybe_typeck_results: None, current_item: None };
-    let (module, span, hir_id) = tcx.hir().get_module(module_def_id);
+    let (module, hir_id) = tcx.hir().get_module(module_def_id);
+    let span = tcx.hir().span(hir_id);
 
     intravisit::walk_mod(&mut visitor, module, hir_id);
 

--- a/compiler/rustc_resolve/src/late/lifetimes.rs
+++ b/compiler/rustc_resolve/src/late/lifetimes.rs
@@ -2866,7 +2866,7 @@ fn insert_late_bound_lifetimes(
                     // is, those would be potentially inputs to
                     // projections
                     if let Some(last_segment) = path.segments.last() {
-                        self.visit_path_segment(path.span, last_segment);
+                        self.visit_path_segment(last_segment);
                     }
                 }
 

--- a/compiler/rustc_save_analysis/src/dump_visitor.rs
+++ b/compiler/rustc_save_analysis/src/dump_visitor.rs
@@ -128,7 +128,7 @@ impl<'tcx> DumpVisitor<'tcx> {
         self.save_ctxt.lookup_def_id(ref_id)
     }
 
-    pub fn dump_crate_info(&mut self, name: &str, krate: &hir::Crate<'_>) {
+    pub fn dump_crate_info(&mut self, name: &str, _krate: &hir::Crate<'_>) {
         let source_file = self.tcx.sess.local_crate_source_file.as_ref();
         let crate_root = source_file.map(|source_file| {
             let source_file = Path::new(source_file);
@@ -151,7 +151,7 @@ impl<'tcx> DumpVisitor<'tcx> {
             },
             crate_root: crate_root.unwrap_or_else(|| "<no source>".to_owned()),
             external_crates: self.save_ctxt.get_external_crates(),
-            span: self.span_from_span(krate.item.span),
+            span: self.span_from_span(self.tcx.hir().span(hir::CRATE_HIR_ID)),
         };
 
         self.dumper.crate_prelude(data);
@@ -376,7 +376,7 @@ impl<'tcx> DumpVisitor<'tcx> {
         self.nest_typeck_results(map.local_def_id(item.hir_id), |v| {
             let body = map.body(body);
             if let Some(fn_data) = v.save_ctxt.get_item_data(item) {
-                down_cast_data!(fn_data, DefData, item.span);
+                down_cast_data!(fn_data, DefData, v.tcx.hir().span(item.hir_id));
                 v.process_formals(body.params, &fn_data.qualname);
                 v.process_generic_params(ty_params, &fn_data.qualname, item.hir_id);
 
@@ -403,7 +403,7 @@ impl<'tcx> DumpVisitor<'tcx> {
     ) {
         self.nest_typeck_results(self.tcx.hir().local_def_id(item.hir_id), |v| {
             if let Some(var_data) = v.save_ctxt.get_item_data(item) {
-                down_cast_data!(var_data, DefData, item.span);
+                down_cast_data!(var_data, DefData, v.tcx.hir().span(item.hir_id));
                 v.dumper.dump_def(&access_from!(v.save_ctxt, item, item.hir_id), var_data);
             }
             v.visit_ty(&typ);
@@ -463,7 +463,7 @@ impl<'tcx> DumpVisitor<'tcx> {
         def: &'tcx hir::VariantData<'tcx>,
         ty_params: &'tcx hir::Generics<'tcx>,
     ) {
-        debug!("process_struct {:?} {:?}", item, item.span);
+        debug!("process_struct {:?} {:?}", item, self.tcx.hir().span(item.hir_id));
         let name = item.ident.to_string();
         let qualname = format!(
             "::{}",
@@ -539,7 +539,7 @@ impl<'tcx> DumpVisitor<'tcx> {
             None => return,
             Some(data) => data,
         };
-        down_cast_data!(enum_data, DefData, item.span);
+        down_cast_data!(enum_data, DefData, self.tcx.hir().span(item.hir_id));
 
         let access = access_from!(self.save_ctxt, item, item.hir_id);
 
@@ -640,12 +640,13 @@ impl<'tcx> DumpVisitor<'tcx> {
         impl_items: &'tcx [hir::ImplItemRef<'tcx>],
     ) {
         if let Some(impl_data) = self.save_ctxt.get_item_data(item) {
-            if !self.span.filter_generated(item.span) {
+            let item_span = self.tcx.hir().span(item.hir_id);
+            if !self.span.filter_generated(item_span) {
                 if let super::Data::RelationData(rel, imp) = impl_data {
                     self.dumper.dump_relation(rel);
                     self.dumper.dump_impl(imp);
                 } else {
-                    span_bug!(item.span, "unexpected data kind: {:?}", impl_data);
+                    span_bug!(item_span, "unexpected data kind: {:?}", impl_data);
                 }
             }
         }
@@ -756,7 +757,7 @@ impl<'tcx> DumpVisitor<'tcx> {
     // `item` is the module in question, represented as an( item.
     fn process_mod(&mut self, item: &'tcx hir::Item<'tcx>) {
         if let Some(mod_data) = self.save_ctxt.get_item_data(item) {
-            down_cast_data!(mod_data, DefData, item.span);
+            down_cast_data!(mod_data, DefData, self.tcx.hir().span(item.hir_id));
             self.dumper.dump_def(&access_from!(self.save_ctxt, item, item.hir_id), mod_data);
         }
     }
@@ -822,8 +823,8 @@ impl<'tcx> DumpVisitor<'tcx> {
             if let hir::QPath::Resolved(_, path) = path {
                 self.write_sub_paths_truncated(path);
             }
-            down_cast_data!(struct_lit_data, RefData, ex.span);
-            if !generated_code(ex.span) {
+            down_cast_data!(struct_lit_data, RefData, self.tcx.hir().span(ex.hir_id));
+            if !generated_code(self.tcx.hir().span(ex.hir_id)) {
                 self.dumper.dump_ref(struct_lit_data);
             }
 
@@ -847,10 +848,11 @@ impl<'tcx> DumpVisitor<'tcx> {
         seg: &'tcx hir::PathSegment<'tcx>,
         args: &'tcx [hir::Expr<'tcx>],
     ) {
-        debug!("process_method_call {:?} {:?}", ex, ex.span);
+        let ex_span = self.tcx.hir().span(ex.hir_id);
+        debug!("process_method_call {:?} {:?}", ex, ex_span);
         if let Some(mcd) = self.save_ctxt.get_expr_data(ex) {
-            down_cast_data!(mcd, RefData, ex.span);
-            if !generated_code(ex.span) {
+            down_cast_data!(mcd, RefData, ex_span);
+            if !generated_code(ex_span) {
                 self.dumper.dump_ref(mcd);
             }
         }
@@ -974,7 +976,9 @@ impl<'tcx> DumpVisitor<'tcx> {
     /// If the span is not macro-generated, do nothing, else use callee and
     /// callsite spans to record macro definition and use data, using the
     /// mac_uses and mac_defs sets to prevent multiples.
-    fn process_macro_use(&mut self, _span: Span) {
+    fn process_macro_use(&mut self, _hir_id: hir::HirId) {
+        //let span = self.tcx.hir().span(_hir_id);
+        //
         // FIXME if we're not dumping the defs (see below), there is no point
         // dumping refs either.
         // let source_span = span.source_callsite();
@@ -1011,8 +1015,8 @@ impl<'tcx> DumpVisitor<'tcx> {
     }
 
     fn process_trait_item(&mut self, trait_item: &'tcx hir::TraitItem<'tcx>, trait_id: DefId) {
-        self.process_macro_use(trait_item.span);
-        let vis_span = trait_item.span.shrink_to_lo();
+        self.process_macro_use(trait_item.hir_id);
+        let vis_span = self.tcx.hir().span(trait_item.hir_id).shrink_to_lo();
         match trait_item.kind {
             hir::TraitItemKind::Const(ref ty, body) => {
                 let body = body.map(|b| &self.tcx.hir().body(b).value);
@@ -1038,7 +1042,7 @@ impl<'tcx> DumpVisitor<'tcx> {
                     trait_item.ident,
                     &trait_item.generics,
                     &respan,
-                    trait_item.span,
+                    self.tcx.hir().span(trait_item.hir_id),
                 );
             }
             hir::TraitItemKind::Type(ref bounds, ref default_ty) => {
@@ -1062,7 +1066,7 @@ impl<'tcx> DumpVisitor<'tcx> {
                             span,
                             name,
                             qualname,
-                            value: self.span.snippet(trait_item.span),
+                            value: self.span.snippet(self.tcx.hir().span(trait_item.hir_id)),
                             parent: Some(id_from_def_id(trait_id)),
                             children: vec![],
                             decl_id: None,
@@ -1090,7 +1094,7 @@ impl<'tcx> DumpVisitor<'tcx> {
     }
 
     fn process_impl_item(&mut self, impl_item: &'tcx hir::ImplItem<'tcx>, impl_id: DefId) {
-        self.process_macro_use(impl_item.span);
+        self.process_macro_use(impl_item.hir_id);
         match impl_item.kind {
             hir::ImplItemKind::Const(ref ty, body) => {
                 let body = self.tcx.hir().body(body);
@@ -1112,7 +1116,7 @@ impl<'tcx> DumpVisitor<'tcx> {
                     impl_item.ident,
                     &impl_item.generics,
                     &impl_item.vis,
-                    impl_item.span,
+                    self.tcx.hir().span(impl_item.hir_id),
                 );
             }
             hir::ImplItemKind::TyAlias(ref ty) => {
@@ -1130,7 +1134,9 @@ impl<'tcx> DumpVisitor<'tcx> {
             format!("::{}", self.tcx.def_path_str(self.tcx.hir().local_def_id(id).to_def_id()));
 
         let sm = self.tcx.sess.source_map();
-        let filename = sm.span_to_filename(krate.item.span);
+        let span = self.tcx.hir().span(hir::CRATE_HIR_ID);
+        let filename = sm.span_to_filename(span);
+        let span = self.span_from_span(span);
         let data_id = id_from_hir_id(id, &self.save_ctxt);
         let children = krate
             .item
@@ -1139,7 +1145,6 @@ impl<'tcx> DumpVisitor<'tcx> {
             .iter()
             .map(|i| id_from_hir_id(i.id, &self.save_ctxt))
             .collect();
-        let span = self.span_from_span(krate.item.span);
 
         self.dumper.dump_def(
             &Access { public: true, reachable: true },
@@ -1181,7 +1186,7 @@ impl<'tcx> Visitor<'tcx> for DumpVisitor<'tcx> {
     }
 
     fn visit_item(&mut self, item: &'tcx hir::Item<'tcx>) {
-        self.process_macro_use(item.span);
+        self.process_macro_use(item.hir_id);
         match item.kind {
             hir::ItemKind::Use(path, hir::UseKind::Single) => {
                 let sub_span = path.segments.last().unwrap().ident.span;
@@ -1219,8 +1224,9 @@ impl<'tcx> Visitor<'tcx> for DumpVisitor<'tcx> {
 
                 // Otherwise it's a span with wrong macro expansion info, which
                 // we don't want to track anyway, since it's probably macro-internal `use`
-                if let Some(sub_span) = self.span.sub_span_of_star(item.span) {
-                    if !self.span.filter_generated(item.span) {
+                let item_span = self.tcx.hir().span(item.hir_id);
+                if let Some(sub_span) = self.span.sub_span_of_star(item_span) {
+                    if !self.span.filter_generated(item_span) {
                         let access = access_from!(self.save_ctxt, item, item.hir_id);
                         let span = self.span_from_span(sub_span);
                         let parent = self
@@ -1361,10 +1367,10 @@ impl<'tcx> Visitor<'tcx> for DumpVisitor<'tcx> {
     }
 
     fn visit_ty(&mut self, t: &'tcx hir::Ty<'tcx>) {
-        self.process_macro_use(t.span);
+        self.process_macro_use(t.hir_id);
         match t.kind {
             hir::TyKind::Path(ref path) => {
-                if generated_code(t.span) {
+                if generated_code(self.tcx.hir().span(t.hir_id)) {
                     return;
                 }
 
@@ -1402,7 +1408,7 @@ impl<'tcx> Visitor<'tcx> for DumpVisitor<'tcx> {
 
     fn visit_expr(&mut self, ex: &'tcx hir::Expr<'tcx>) {
         debug!("visit_expr {:?}", ex.kind);
-        self.process_macro_use(ex.span);
+        self.process_macro_use(ex.hir_id);
         match ex.kind {
             hir::ExprKind::Struct(ref path, ref fields, ref rest) => {
                 let hir_expr = self.save_ctxt.tcx.hir().expect_expr(ex.hir_id);
@@ -1423,8 +1429,9 @@ impl<'tcx> Visitor<'tcx> for DumpVisitor<'tcx> {
                 self.visit_expr(&sub_ex);
 
                 if let Some(field_data) = self.save_ctxt.get_expr_data(ex) {
-                    down_cast_data!(field_data, RefData, ex.span);
-                    if !generated_code(ex.span) {
+                    let ex_span = self.tcx.hir().span(ex.hir_id);
+                    down_cast_data!(field_data, RefData, ex_span);
+                    if !generated_code(ex_span) {
                         self.dumper.dump_ref(field_data);
                     }
                 }
@@ -1463,7 +1470,7 @@ impl<'tcx> Visitor<'tcx> for DumpVisitor<'tcx> {
     }
 
     fn visit_pat(&mut self, p: &'tcx hir::Pat<'tcx>) {
-        self.process_macro_use(p.span);
+        self.process_macro_use(p.hir_id);
         self.process_pat(p);
     }
 
@@ -1480,12 +1487,12 @@ impl<'tcx> Visitor<'tcx> for DumpVisitor<'tcx> {
     }
 
     fn visit_stmt(&mut self, s: &'tcx hir::Stmt<'tcx>) {
-        self.process_macro_use(s.span);
+        self.process_macro_use(s.hir_id);
         intravisit::walk_stmt(self, s)
     }
 
     fn visit_local(&mut self, l: &'tcx hir::Local<'tcx>) {
-        self.process_macro_use(l.span);
+        self.process_macro_use(l.hir_id);
         self.process_var_decl(&l.pat);
 
         // Just walk the initialiser and type (don't want to walk the pattern again).
@@ -1499,7 +1506,7 @@ impl<'tcx> Visitor<'tcx> for DumpVisitor<'tcx> {
         match item.kind {
             hir::ForeignItemKind::Fn(decl, _, ref generics) => {
                 if let Some(fn_data) = self.save_ctxt.get_extern_item_data(item) {
-                    down_cast_data!(fn_data, DefData, item.span);
+                    down_cast_data!(fn_data, DefData, self.tcx.hir().span(item.hir_id));
 
                     self.process_generic_params(generics, &fn_data.qualname, item.hir_id);
                     self.dumper.dump_def(&access, fn_data);
@@ -1515,7 +1522,7 @@ impl<'tcx> Visitor<'tcx> for DumpVisitor<'tcx> {
             }
             hir::ForeignItemKind::Static(ref ty, _) => {
                 if let Some(var_data) = self.save_ctxt.get_extern_item_data(item) {
-                    down_cast_data!(var_data, DefData, item.span);
+                    down_cast_data!(var_data, DefData, self.tcx.hir().span(item.hir_id));
                     self.dumper.dump_def(&access, var_data);
                 }
 
@@ -1523,7 +1530,7 @@ impl<'tcx> Visitor<'tcx> for DumpVisitor<'tcx> {
             }
             hir::ForeignItemKind::Type => {
                 if let Some(var_data) = self.save_ctxt.get_extern_item_data(item) {
-                    down_cast_data!(var_data, DefData, item.span);
+                    down_cast_data!(var_data, DefData, self.tcx.hir().span(item.hir_id));
                     self.dumper.dump_def(&access, var_data);
                 }
             }

--- a/compiler/rustc_save_analysis/src/dump_visitor.rs
+++ b/compiler/rustc_save_analysis/src/dump_visitor.rs
@@ -1381,7 +1381,7 @@ impl<'tcx> Visitor<'tcx> for DumpVisitor<'tcx> {
                 if let hir::QPath::Resolved(_, path) = path {
                     self.write_sub_paths_truncated(path);
                 }
-                intravisit::walk_qpath(self, path, t.hir_id, t.span);
+                intravisit::walk_qpath(self, path, t.hir_id);
             }
             hir::TyKind::Array(ref ty, ref anon_const) => {
                 self.visit_ty(ty);
@@ -1475,7 +1475,7 @@ impl<'tcx> Visitor<'tcx> for DumpVisitor<'tcx> {
         self.visit_expr(&arm.body);
     }
 
-    fn visit_qpath(&mut self, path: &'tcx hir::QPath<'tcx>, id: hir::HirId, _: Span) {
+    fn visit_qpath(&mut self, path: &'tcx hir::QPath<'tcx>, id: hir::HirId) {
         self.process_path(id, path);
     }
 

--- a/compiler/rustc_save_analysis/src/lib.rs
+++ b/compiler/rustc_save_analysis/src/lib.rs
@@ -301,8 +301,13 @@ impl<'tcx> SaveContext<'tcx> {
                 let name = item.ident.to_string();
                 let qualname = format!("::{}", self.tcx.def_path_str(def_id));
                 filter!(self.span_utils, item.ident.span);
-                let value =
-                    enum_def_to_string(def, generics, item.ident.name, item.span, &item.vis);
+                let value = enum_def_to_string(
+                    def,
+                    generics,
+                    item.ident.name,
+                    self.tcx.hir().span(item.hir_id),
+                    &item.vis,
+                );
                 Some(Data::DefData(Def {
                     kind: DefKind::Enum,
                     id: id_from_def_id(def_id),
@@ -892,7 +897,9 @@ impl<'l> Visitor<'l> for PathCollector<'l> {
             hir::PatKind::Binding(bm, _, ident, _) => {
                 debug!(
                     "PathCollector, visit ident in pat {}: {:?} {:?}",
-                    ident, p.span, ident.span
+                    ident,
+                    self.tcx.hir().span(p.hir_id),
+                    ident.span
                 );
                 let immut = match bm {
                     // Even if the ref is mut, you can't change the ref, only

--- a/compiler/rustc_typeck/src/check/gather_locals.rs
+++ b/compiler/rustc_typeck/src/check/gather_locals.rs
@@ -133,7 +133,6 @@ impl<'a, 'tcx> Visitor<'tcx> for GatherLocalsVisitor<'a, 'tcx> {
         _: intravisit::FnKind<'tcx>,
         _: &'tcx hir::FnDecl<'tcx>,
         _: hir::BodyId,
-        _: Span,
         _: hir::HirId,
     ) {
     }

--- a/compiler/rustc_typeck/src/check/method/suggest.rs
+++ b/compiler/rustc_typeck/src/check/method/suggest.rs
@@ -1425,7 +1425,7 @@ impl UsePlacementFinder<'tcx> {
 }
 
 impl intravisit::Visitor<'tcx> for UsePlacementFinder<'tcx> {
-    fn visit_mod(&mut self, module: &'tcx hir::Mod<'tcx>, _: Span, hir_id: hir::HirId) {
+    fn visit_mod(&mut self, module: &'tcx hir::Mod<'tcx>, hir_id: hir::HirId) {
         if self.span.is_some() {
             return;
         }

--- a/compiler/rustc_typeck/src/check/regionck.rs
+++ b/compiler/rustc_typeck/src/check/regionck.rs
@@ -350,7 +350,6 @@ impl<'a, 'tcx> Visitor<'tcx> for RegionCtxt<'a, 'tcx> {
         fk: intravisit::FnKind<'tcx>,
         _: &'tcx hir::FnDecl<'tcx>,
         body_id: hir::BodyId,
-        span: Span,
         hir_id: hir::HirId,
     ) {
         assert!(
@@ -365,6 +364,7 @@ impl<'a, 'tcx> Visitor<'tcx> for RegionCtxt<'a, 'tcx> {
         let env_snapshot = self.outlives_environment.push_snapshot_pre_closure();
 
         let body = self.tcx.hir().body(body_id);
+        let span = self.tcx.hir().span(hir_id);
         self.visit_fn_body(hir_id, body, span);
 
         // Restore state from previous function.

--- a/src/test/ui-fulldeps/auxiliary/issue-40001-plugin.rs
+++ b/src/test/ui-fulldeps/auxiliary/issue-40001-plugin.rs
@@ -40,7 +40,6 @@ impl<'tcx> LateLintPass<'tcx> for MissingAllowedAttrPass {
         _: intravisit::FnKind<'tcx>,
         _: &'tcx hir::FnDecl,
         _: &'tcx hir::Body,
-        span: source_map::Span,
         id: hir::HirId,
     ) {
         let item = match cx.tcx.hir().get(id) {
@@ -51,6 +50,7 @@ impl<'tcx> LateLintPass<'tcx> for MissingAllowedAttrPass {
         let allowed = |attr| pprust::attribute_to_string(attr).contains("allowed_attr");
         if !item.attrs.iter().any(allowed) {
             cx.lint(MISSING_ALLOWED_ATTR, |lint| {
+                let span = cx.tcx.hir().span(id);
                 lint.build("Missing 'allowed_attr' attribute").set_span(span).emit()
             });
         }

--- a/src/tools/clippy/clippy_lints/src/booleans.rs
+++ b/src/tools/clippy/clippy_lints/src/booleans.rs
@@ -10,7 +10,6 @@ use rustc_hir::{BinOpKind, Body, Expr, ExprKind, FnDecl, HirId, UnOp};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::hir::map::Map;
 use rustc_session::{declare_lint_pass, declare_tool_lint};
-use rustc_span::source_map::Span;
 use rustc_span::sym;
 
 declare_clippy_lint! {
@@ -63,7 +62,6 @@ impl<'tcx> LateLintPass<'tcx> for NonminimalBool {
         _: FnKind<'tcx>,
         _: &'tcx FnDecl<'_>,
         body: &'tcx Body<'_>,
-        _: Span,
         _: HirId,
     ) {
         NonminimalBoolVisitor { cx }.visit_body(body)

--- a/src/tools/clippy/clippy_lints/src/cognitive_complexity.rs
+++ b/src/tools/clippy/clippy_lints/src/cognitive_complexity.rs
@@ -119,11 +119,11 @@ impl<'tcx> LateLintPass<'tcx> for CognitiveComplexity {
         kind: FnKind<'tcx>,
         decl: &'tcx FnDecl<'_>,
         body: &'tcx Body<'_>,
-        span: Span,
         hir_id: HirId,
     ) {
         let def_id = cx.tcx.hir().local_def_id(hir_id);
         if !cx.tcx.has_attr(def_id.to_def_id(), sym::test) {
+            let span = cx.tcx.hir().span(hir_id);
             self.check(cx, kind, decl, body, span);
         }
     }

--- a/src/tools/clippy/clippy_lints/src/derive.rs
+++ b/src/tools/clippy/clippy_lints/src/derive.rs
@@ -382,7 +382,7 @@ struct UnsafeVisitor<'a, 'tcx> {
 impl<'tcx> Visitor<'tcx> for UnsafeVisitor<'_, 'tcx> {
     type Map = Map<'tcx>;
 
-    fn visit_fn(&mut self, kind: FnKind<'tcx>, decl: &'tcx FnDecl<'_>, body_id: BodyId, span: Span, id: HirId) {
+    fn visit_fn(&mut self, kind: FnKind<'tcx>, decl: &'tcx FnDecl<'_>, body_id: BodyId, id: HirId) {
         if self.has_unsafe {
             return;
         }
@@ -395,7 +395,7 @@ impl<'tcx> Visitor<'tcx> for UnsafeVisitor<'_, 'tcx> {
             }
         }
 
-        walk_fn(self, kind, decl, body_id, span, id);
+        walk_fn(self, kind, decl, body_id, id);
     }
 
     fn visit_expr(&mut self, expr: &'tcx Expr<'_>) {

--- a/src/tools/clippy/clippy_lints/src/escape.rs
+++ b/src/tools/clippy/clippy_lints/src/escape.rs
@@ -4,7 +4,6 @@ use rustc_infer::infer::TyCtxtInferExt;
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty::{self, Ty};
 use rustc_session::{declare_tool_lint, impl_lint_pass};
-use rustc_span::source_map::Span;
 use rustc_target::abi::LayoutOf;
 use rustc_target::spec::abi::Abi;
 use rustc_typeck::expr_use_visitor::{ConsumeMode, Delegate, ExprUseVisitor, PlaceBase, PlaceWithHirId};
@@ -63,7 +62,6 @@ impl<'tcx> LateLintPass<'tcx> for BoxedLocal {
         fn_kind: intravisit::FnKind<'tcx>,
         _: &'tcx FnDecl<'_>,
         body: &'tcx Body<'_>,
-        _: Span,
         hir_id: HirId,
     ) {
         if let Some(header) = fn_kind.header() {

--- a/src/tools/clippy/clippy_lints/src/functions.rs
+++ b/src/tools/clippy/clippy_lints/src/functions.rs
@@ -255,7 +255,7 @@ impl<'tcx> LateLintPass<'tcx> for Functions {
             intravisit::FnKind::Closure(_) => return,
         };
 
-        let span = cx.tcx.hir().span(hir_id);
+        let span = cx.tcx.hir().span_with_body(hir_id);
 
         // don't warn for implementations, it's not their fault
         if !is_trait_impl_item(cx, hir_id) {

--- a/src/tools/clippy/clippy_lints/src/functions.rs
+++ b/src/tools/clippy/clippy_lints/src/functions.rs
@@ -247,7 +247,6 @@ impl<'tcx> LateLintPass<'tcx> for Functions {
         kind: intravisit::FnKind<'tcx>,
         decl: &'tcx hir::FnDecl<'_>,
         body: &'tcx hir::Body<'_>,
-        span: Span,
         hir_id: hir::HirId,
     ) {
         let unsafety = match kind {
@@ -255,6 +254,8 @@ impl<'tcx> LateLintPass<'tcx> for Functions {
             intravisit::FnKind::Method(_, sig, _, _) => sig.header.unsafety,
             intravisit::FnKind::Closure(_) => return,
         };
+
+        let span = cx.tcx.hir().span(hir_id);
 
         // don't warn for implementations, it's not their fault
         if !is_trait_impl_item(cx, hir_id) {

--- a/src/tools/clippy/clippy_lints/src/future_not_send.rs
+++ b/src/tools/clippy/clippy_lints/src/future_not_send.rs
@@ -6,7 +6,7 @@ use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty::subst::Subst;
 use rustc_middle::ty::{Opaque, PredicateAtom::Trait};
 use rustc_session::{declare_lint_pass, declare_tool_lint};
-use rustc_span::{sym, Span};
+use rustc_span::sym;
 use rustc_trait_selection::traits::error_reporting::suggestions::InferCtxtExt;
 use rustc_trait_selection::traits::{self, FulfillmentError, TraitEngine};
 
@@ -55,7 +55,6 @@ impl<'tcx> LateLintPass<'tcx> for FutureNotSend {
         kind: FnKind<'tcx>,
         decl: &'tcx FnDecl<'tcx>,
         _: &'tcx Body<'tcx>,
-        _: Span,
         hir_id: HirId,
     ) {
         if let FnKind::Closure(_) = kind {

--- a/src/tools/clippy/clippy_lints/src/implicit_return.rs
+++ b/src/tools/clippy/clippy_lints/src/implicit_return.rs
@@ -123,8 +123,7 @@ impl<'tcx> LateLintPass<'tcx> for ImplicitReturn {
         _: FnKind<'tcx>,
         _: &'tcx FnDecl<'_>,
         body: &'tcx Body<'_>,
-        span: Span,
-        _: HirId,
+        hir_id: HirId,
     ) {
         let def_id = cx.tcx.hir().body_owner_def_id(body.id());
 
@@ -134,6 +133,7 @@ impl<'tcx> LateLintPass<'tcx> for ImplicitReturn {
         }
 
         let mir = cx.tcx.optimized_mir(def_id.to_def_id());
+        let span = cx.tcx.hir().span(hir_id);
 
         // checking return type through MIR, HIR is not able to determine inferred closure return types
         // make sure it's not a macro

--- a/src/tools/clippy/clippy_lints/src/manual_async_fn.rs
+++ b/src/tools/clippy/clippy_lints/src/manual_async_fn.rs
@@ -9,7 +9,6 @@ use rustc_hir::{
 };
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_session::{declare_lint_pass, declare_tool_lint};
-use rustc_span::Span;
 
 declare_clippy_lint! {
     /// **What it does:** It checks for manual implementations of `async` functions.
@@ -43,8 +42,7 @@ impl<'tcx> LateLintPass<'tcx> for ManualAsyncFn {
         kind: FnKind<'tcx>,
         decl: &'tcx FnDecl<'_>,
         body: &'tcx Body<'_>,
-        span: Span,
-        _: HirId,
+        hir_id: HirId,
     ) {
         if_chain! {
             if let Some(header) = kind.header();
@@ -59,6 +57,7 @@ impl<'tcx> LateLintPass<'tcx> for ManualAsyncFn {
             if block.stmts.is_empty();
             if let Some(closure_body) = desugared_async_block(cx, block);
             then {
+                let span = cx.tcx.hir().span(hir_id);
                 let header_span = span.with_hi(ret_ty.span.hi());
 
                 span_lint_and_then(

--- a/src/tools/clippy/clippy_lints/src/misc.rs
+++ b/src/tools/clippy/clippy_lints/src/misc.rs
@@ -275,13 +275,13 @@ impl<'tcx> LateLintPass<'tcx> for MiscLints {
         k: FnKind<'tcx>,
         decl: &'tcx FnDecl<'_>,
         body: &'tcx Body<'_>,
-        span: Span,
-        _: HirId,
+        hir_id: HirId,
     ) {
         if let FnKind::Closure(_) = k {
             // Does not apply to closures
             return;
         }
+        let span = cx.tcx.hir().span(hir_id);
         if in_external_macro(cx.tcx.sess, span) {
             return;
         }

--- a/src/tools/clippy/clippy_lints/src/missing_const_for_fn.rs
+++ b/src/tools/clippy/clippy_lints/src/missing_const_for_fn.rs
@@ -100,7 +100,7 @@ impl<'tcx> LateLintPass<'tcx> for MissingConstForFn {
         }
 
         let def_id = cx.tcx.hir().local_def_id(hir_id);
-        let span = cx.tcx.hir().span(hir_id);
+        let span = cx.tcx.hir().span_with_body(hir_id);
 
         if in_external_macro(cx.tcx.sess, span) || is_entrypoint_fn(cx, def_id.to_def_id()) {
             return;

--- a/src/tools/clippy/clippy_lints/src/missing_const_for_fn.rs
+++ b/src/tools/clippy/clippy_lints/src/missing_const_for_fn.rs
@@ -9,7 +9,6 @@ use rustc_lint::{LateContext, LateLintPass, LintContext};
 use rustc_middle::lint::in_external_macro;
 use rustc_semver::RustcVersion;
 use rustc_session::{declare_tool_lint, impl_lint_pass};
-use rustc_span::Span;
 use rustc_typeck::hir_ty_to_ty;
 
 const MISSING_CONST_FOR_FN_MSRV: RustcVersion = RustcVersion::new(1, 37, 0);
@@ -94,7 +93,6 @@ impl<'tcx> LateLintPass<'tcx> for MissingConstForFn {
         kind: FnKind<'_>,
         _: &FnDecl<'_>,
         _: &Body<'_>,
-        span: Span,
         hir_id: HirId,
     ) {
         if !meets_msrv(self.msrv.as_ref(), &MISSING_CONST_FOR_FN_MSRV) {
@@ -102,6 +100,7 @@ impl<'tcx> LateLintPass<'tcx> for MissingConstForFn {
         }
 
         let def_id = cx.tcx.hir().local_def_id(hir_id);
+        let span = cx.tcx.hir().span(hir_id);
 
         if in_external_macro(cx.tcx.sess, span) || is_entrypoint_fn(cx, def_id.to_def_id()) {
             return;

--- a/src/tools/clippy/clippy_lints/src/needless_pass_by_value.rs
+++ b/src/tools/clippy/clippy_lints/src/needless_pass_by_value.rs
@@ -71,9 +71,9 @@ impl<'tcx> LateLintPass<'tcx> for NeedlessPassByValue {
         kind: FnKind<'tcx>,
         decl: &'tcx FnDecl<'_>,
         body: &'tcx Body<'_>,
-        span: Span,
         hir_id: HirId,
     ) {
+        let span = cx.tcx.hir().span(hir_id);
         if span.from_expansion() {
             return;
         }

--- a/src/tools/clippy/clippy_lints/src/panic_in_result_fn.rs
+++ b/src/tools/clippy/clippy_lints/src/panic_in_result_fn.rs
@@ -40,12 +40,12 @@ impl<'tcx> LateLintPass<'tcx> for PanicInResultFn {
         fn_kind: FnKind<'tcx>,
         _: &'tcx hir::FnDecl<'tcx>,
         body: &'tcx hir::Body<'tcx>,
-        span: Span,
         hir_id: hir::HirId,
     ) {
         if !matches!(fn_kind, FnKind::Closure(_))
             && is_type_diagnostic_item(cx, return_ty(cx, hir_id), sym::result_type)
         {
+            let span = cx.tcx.hir().span(hir_id);
             lint_impl_body(cx, span, body);
         }
     }

--- a/src/tools/clippy/clippy_lints/src/panic_in_result_fn.rs
+++ b/src/tools/clippy/clippy_lints/src/panic_in_result_fn.rs
@@ -45,7 +45,7 @@ impl<'tcx> LateLintPass<'tcx> for PanicInResultFn {
         if !matches!(fn_kind, FnKind::Closure(_))
             && is_type_diagnostic_item(cx, return_ty(cx, hir_id), sym::result_type)
         {
-            let span = cx.tcx.hir().span(hir_id);
+            let span = cx.tcx.hir().span_with_body(hir_id);
             lint_impl_body(cx, span, body);
         }
     }

--- a/src/tools/clippy/clippy_lints/src/pass_by_ref_or_value.rs
+++ b/src/tools/clippy/clippy_lints/src/pass_by_ref_or_value.rs
@@ -216,9 +216,9 @@ impl<'tcx> LateLintPass<'tcx> for PassByRefOrValue {
         kind: FnKind<'tcx>,
         decl: &'tcx FnDecl<'_>,
         _body: &'tcx Body<'_>,
-        span: Span,
         hir_id: HirId,
     ) {
+        let span = cx.tcx.hir().span(hir_id);
         if span.from_expansion() {
             return;
         }

--- a/src/tools/clippy/clippy_lints/src/pattern_type_mismatch.rs
+++ b/src/tools/clippy/clippy_lints/src/pattern_type_mismatch.rs
@@ -129,7 +129,6 @@ impl<'tcx> LateLintPass<'tcx> for PatternTypeMismatch {
         _: intravisit::FnKind<'tcx>,
         _: &'tcx FnDecl<'_>,
         body: &'tcx Body<'_>,
-        _: Span,
         hir_id: HirId,
     ) {
         if let Some(fn_sig) = cx.typeck_results().liberated_fn_sigs().get(hir_id) {

--- a/src/tools/clippy/clippy_lints/src/redundant_clone.rs
+++ b/src/tools/clippy/clippy_lints/src/redundant_clone.rs
@@ -16,7 +16,7 @@ use rustc_middle::mir::{
 use rustc_middle::ty::{self, fold::TypeVisitor, Ty};
 use rustc_mir::dataflow::{Analysis, AnalysisDomain, GenKill, GenKillAnalysis, ResultsCursor};
 use rustc_session::{declare_lint_pass, declare_tool_lint};
-use rustc_span::source_map::{BytePos, Span};
+use rustc_span::source_map::BytePos;
 use rustc_span::sym;
 use std::convert::TryFrom;
 use std::ops::ControlFlow;
@@ -75,7 +75,6 @@ impl<'tcx> LateLintPass<'tcx> for RedundantClone {
         _: FnKind<'tcx>,
         _: &'tcx FnDecl<'_>,
         body: &'tcx Body<'_>,
-        _: Span,
         _: HirId,
     ) {
         let def_id = cx.tcx.hir().body_owner_def_id(body.id());

--- a/src/tools/clippy/clippy_lints/src/returns.rs
+++ b/src/tools/clippy/clippy_lints/src/returns.rs
@@ -127,7 +127,6 @@ impl<'tcx> LateLintPass<'tcx> for Return {
         kind: FnKind<'tcx>,
         _: &'tcx FnDecl<'tcx>,
         body: &'tcx Body<'tcx>,
-        _: Span,
         _: HirId,
     ) {
         match kind {

--- a/src/tools/clippy/clippy_lints/src/shadow.rs
+++ b/src/tools/clippy/clippy_lints/src/shadow.rs
@@ -104,7 +104,6 @@ impl<'tcx> LateLintPass<'tcx> for Shadow {
         _: FnKind<'tcx>,
         decl: &'tcx FnDecl<'_>,
         body: &'tcx Body<'_>,
-        _: Span,
         _: HirId,
     ) {
         if in_external_macro(cx.sess(), body.value.span) {

--- a/src/tools/clippy/clippy_lints/src/types.rs
+++ b/src/tools/clippy/clippy_lints/src/types.rs
@@ -255,7 +255,7 @@ pub struct Types {
 impl_lint_pass!(Types => [BOX_VEC, VEC_BOX, OPTION_OPTION, LINKEDLIST, BORROWED_BOX, REDUNDANT_ALLOCATION, RC_BUFFER]);
 
 impl<'tcx> LateLintPass<'tcx> for Types {
-    fn check_fn(&mut self, cx: &LateContext<'_>, _: FnKind<'_>, decl: &FnDecl<'_>, _: &Body<'_>, _: Span, id: HirId) {
+    fn check_fn(&mut self, cx: &LateContext<'_>, _: FnKind<'_>, decl: &FnDecl<'_>, _: &Body<'_>, id: HirId) {
         // Skip trait implementations; see issue #605.
         if let Some(hir::Node::Item(item)) = cx.tcx.hir().find(cx.tcx.hir().get_parent_item(id)) {
             if let ItemKind::Impl { of_trait: Some(_), .. } = item.kind {
@@ -1902,7 +1902,6 @@ impl<'tcx> LateLintPass<'tcx> for TypeComplexity {
         _: FnKind<'tcx>,
         decl: &'tcx FnDecl<'_>,
         _: &'tcx Body<'_>,
-        _: Span,
         _: HirId,
     ) {
         self.check_fndecl(cx, decl);

--- a/src/tools/clippy/clippy_lints/src/unnecessary_wraps.rs
+++ b/src/tools/clippy/clippy_lints/src/unnecessary_wraps.rs
@@ -10,7 +10,6 @@ use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty::subst::GenericArgKind;
 use rustc_session::{declare_lint_pass, declare_tool_lint};
 use rustc_span::symbol::sym;
-use rustc_span::Span;
 
 declare_clippy_lint! {
     /// **What it does:** Checks for private functions that only return `Ok` or `Some`.
@@ -61,7 +60,6 @@ impl<'tcx> LateLintPass<'tcx> for UnnecessaryWraps {
         fn_kind: FnKind<'tcx>,
         fn_decl: &FnDecl<'tcx>,
         body: &Body<'tcx>,
-        span: Span,
         hir_id: HirId,
     ) {
         match fn_kind {
@@ -110,6 +108,7 @@ impl<'tcx> LateLintPass<'tcx> for UnnecessaryWraps {
         });
 
         if can_sugg && !suggs.is_empty() {
+            let span = cx.tcx.hir().span(hir_id);
             span_lint_and_then(
                 cx,
                 UNNECESSARY_WRAPS,

--- a/src/tools/clippy/clippy_lints/src/unnecessary_wraps.rs
+++ b/src/tools/clippy/clippy_lints/src/unnecessary_wraps.rs
@@ -108,11 +108,10 @@ impl<'tcx> LateLintPass<'tcx> for UnnecessaryWraps {
         });
 
         if can_sugg && !suggs.is_empty() {
-            let span = cx.tcx.hir().span(hir_id);
             span_lint_and_then(
                 cx,
                 UNNECESSARY_WRAPS,
-                span,
+                cx.tcx.hir().span_with_body(hir_id),
                 format!(
                     "this function's return value is unnecessarily wrapped by `{}`",
                     return_type

--- a/src/tools/clippy/clippy_lints/src/unwrap.rs
+++ b/src/tools/clippy/clippy_lints/src/unwrap.rs
@@ -10,7 +10,6 @@ use rustc_middle::hir::map::Map;
 use rustc_middle::lint::in_external_macro;
 use rustc_middle::ty::Ty;
 use rustc_session::{declare_lint_pass, declare_tool_lint};
-use rustc_span::source_map::Span;
 use rustc_span::sym;
 
 declare_clippy_lint! {
@@ -217,9 +216,9 @@ impl<'tcx> LateLintPass<'tcx> for Unwrap {
         kind: FnKind<'tcx>,
         decl: &'tcx FnDecl<'_>,
         body: &'tcx Body<'_>,
-        span: Span,
         fn_id: HirId,
     ) {
+        let span = cx.tcx.hir().span(fn_id);
         if span.from_expansion() {
             return;
         }
@@ -229,6 +228,6 @@ impl<'tcx> LateLintPass<'tcx> for Unwrap {
             unwrappables: Vec::new(),
         };
 
-        walk_fn(&mut v, kind, decl, body.id(), span, fn_id);
+        walk_fn(&mut v, kind, decl, body.id(), fn_id);
     }
 }

--- a/src/tools/clippy/clippy_lints/src/utils/mod.rs
+++ b/src/tools/clippy/clippy_lints/src/utils/mod.rs
@@ -556,7 +556,7 @@ struct ContainsName {
 impl<'tcx> Visitor<'tcx> for ContainsName {
     type Map = Map<'tcx>;
 
-    fn visit_name(&mut self, _: Span, name: Symbol) {
+    fn visit_name(&mut self, name: Symbol) {
         if self.name == name {
             self.result = true;
         }


### PR DESCRIPTION
First step in https://github.com/rust-lang/compiler-team/issues/294
Split out of https://github.com/rust-lang/rust/pull/72015

This PR collects the spans in the AST when lowering it to HIR.
This collection constructs a `HirId -> Span` map as each `HirId` is assigned.
This map is rendered accessible to the world through a query,
and replaces the implementation of `tcx.hir().span(...)`.

This PR needs a perf run.

r? @pnkfelix 