### PR TITLE
save_analysis: work on HIR tree instead of AST

### DIFF
--- a/src/librustc_hir_pretty/lib.rs
+++ b/src/librustc_hir_pretty/lib.rs
@@ -203,6 +203,30 @@ pub fn visibility_qualified<S: Into<Cow<'static, str>>>(vis: &hir::Visibility<'_
     })
 }
 
+pub fn generic_params_to_string(generic_params: &[GenericParam<'_>]) -> String {
+    to_string(NO_ANN, |s| s.print_generic_params(generic_params))
+}
+
+pub fn bounds_to_string<'b>(bounds: impl IntoIterator<Item = &'b hir::GenericBound<'b>>) -> String {
+    to_string(NO_ANN, |s| s.print_bounds("", bounds))
+}
+
+pub fn param_to_string(arg: &hir::Param<'_>) -> String {
+    to_string(NO_ANN, |s| s.print_param(arg))
+}
+
+pub fn ty_to_string(ty: &hir::Ty<'_>) -> String {
+    to_string(NO_ANN, |s| s.print_type(ty))
+}
+
+pub fn path_segment_to_string(segment: &hir::PathSegment<'_>) -> String {
+    to_string(NO_ANN, |s| s.print_path_segment(segment))
+}
+
+pub fn path_to_string(segment: &hir::Path<'_>) -> String {
+    to_string(NO_ANN, |s| s.print_path(segment, false))
+}
+
 impl<'a> State<'a> {
     pub fn cbox(&mut self, u: usize) {
         self.s.cbox(u);

--- a/src/librustc_save_analysis/sig.rs
+++ b/src/librustc_save_analysis/sig.rs
@@ -25,16 +25,18 @@
 //
 // FIXME where clauses need implementing, defs/refs in generics are mostly missing.
 
-use crate::{id_from_def_id, id_from_node_id, SaveContext};
+use crate::{id_from_def_id, id_from_hir_id, SaveContext};
 
 use rls_data::{SigElement, Signature};
 
-use rustc_ast::ast::{self, Extern, NodeId};
-use rustc_ast_pretty::pprust;
+use rustc_ast::ast::Mutability;
+use rustc_hir as hir;
 use rustc_hir::def::{DefKind, Res};
+use rustc_hir_pretty::id_to_string;
+use rustc_hir_pretty::{bounds_to_string, path_segment_to_string, path_to_string, ty_to_string};
 use rustc_span::symbol::{Ident, Symbol};
 
-pub fn item_signature(item: &ast::Item, scx: &SaveContext<'_, '_>) -> Option<Signature> {
+pub fn item_signature(item: &hir::Item<'_>, scx: &SaveContext<'_, '_>) -> Option<Signature> {
     if !scx.config.signatures {
         return None;
     }
@@ -42,7 +44,7 @@ pub fn item_signature(item: &ast::Item, scx: &SaveContext<'_, '_>) -> Option<Sig
 }
 
 pub fn foreign_item_signature(
-    item: &ast::ForeignItem,
+    item: &hir::ForeignItem<'_>,
     scx: &SaveContext<'_, '_>,
 ) -> Option<Signature> {
     if !scx.config.signatures {
@@ -53,7 +55,10 @@ pub fn foreign_item_signature(
 
 /// Signature for a struct or tuple field declaration.
 /// Does not include a trailing comma.
-pub fn field_signature(field: &ast::StructField, scx: &SaveContext<'_, '_>) -> Option<Signature> {
+pub fn field_signature(
+    field: &hir::StructField<'_>,
+    scx: &SaveContext<'_, '_>,
+) -> Option<Signature> {
     if !scx.config.signatures {
         return None;
     }
@@ -61,7 +66,10 @@ pub fn field_signature(field: &ast::StructField, scx: &SaveContext<'_, '_>) -> O
 }
 
 /// Does not include a trailing comma.
-pub fn variant_signature(variant: &ast::Variant, scx: &SaveContext<'_, '_>) -> Option<Signature> {
+pub fn variant_signature(
+    variant: &hir::Variant<'_>,
+    scx: &SaveContext<'_, '_>,
+) -> Option<Signature> {
     if !scx.config.signatures {
         return None;
     }
@@ -69,10 +77,10 @@ pub fn variant_signature(variant: &ast::Variant, scx: &SaveContext<'_, '_>) -> O
 }
 
 pub fn method_signature(
-    id: NodeId,
+    id: hir::HirId,
     ident: Ident,
-    generics: &ast::Generics,
-    m: &ast::FnSig,
+    generics: &hir::Generics<'_>,
+    m: &hir::FnSig<'_>,
     scx: &SaveContext<'_, '_>,
 ) -> Option<Signature> {
     if !scx.config.signatures {
@@ -82,10 +90,10 @@ pub fn method_signature(
 }
 
 pub fn assoc_const_signature(
-    id: NodeId,
+    id: hir::HirId,
     ident: Symbol,
-    ty: &ast::Ty,
-    default: Option<&ast::Expr>,
+    ty: &hir::Ty<'_>,
+    default: Option<&hir::Expr<'_>>,
     scx: &SaveContext<'_, '_>,
 ) -> Option<Signature> {
     if !scx.config.signatures {
@@ -95,10 +103,10 @@ pub fn assoc_const_signature(
 }
 
 pub fn assoc_type_signature(
-    id: NodeId,
+    id: hir::HirId,
     ident: Ident,
-    bounds: Option<&ast::GenericBounds>,
-    default: Option<&ast::Ty>,
+    bounds: Option<hir::GenericBounds<'_>>,
+    default: Option<&hir::Ty<'_>>,
     scx: &SaveContext<'_, '_>,
 ) -> Option<Signature> {
     if !scx.config.signatures {
@@ -110,7 +118,7 @@ pub fn assoc_type_signature(
 type Result = std::result::Result<Signature, &'static str>;
 
 trait Sig {
-    fn make(&self, offset: usize, id: Option<NodeId>, scx: &SaveContext<'_, '_>) -> Result;
+    fn make(&self, offset: usize, id: Option<hir::HirId>, scx: &SaveContext<'_, '_>) -> Result;
 }
 
 fn extend_sig(
@@ -145,39 +153,34 @@ fn text_sig(text: String) -> Signature {
     Signature { text, defs: vec![], refs: vec![] }
 }
 
-fn push_extern(text: &mut String, ext: Extern) {
-    match ext {
-        Extern::None => {}
-        Extern::Implicit => text.push_str("extern "),
-        Extern::Explicit(abi) => text.push_str(&format!("extern \"{}\" ", abi.symbol)),
-    }
-}
-
-impl Sig for ast::Ty {
-    fn make(&self, offset: usize, _parent_id: Option<NodeId>, scx: &SaveContext<'_, '_>) -> Result {
-        let id = Some(self.id);
+impl<'hir> Sig for hir::Ty<'hir> {
+    fn make(
+        &self,
+        offset: usize,
+        _parent_id: Option<hir::HirId>,
+        scx: &SaveContext<'_, '_>,
+    ) -> Result {
+        let id = Some(self.hir_id);
         match self.kind {
-            ast::TyKind::Slice(ref ty) => {
+            hir::TyKind::Slice(ref ty) => {
                 let nested = ty.make(offset + 1, id, scx)?;
                 let text = format!("[{}]", nested.text);
                 Ok(replace_text(nested, text))
             }
-            ast::TyKind::Ptr(ref mt) => {
+            hir::TyKind::Ptr(ref mt) => {
                 let prefix = match mt.mutbl {
-                    ast::Mutability::Mut => "*mut ",
-                    ast::Mutability::Not => "*const ",
+                    hir::Mutability::Mut => "*mut ",
+                    hir::Mutability::Not => "*const ",
                 };
                 let nested = mt.ty.make(offset + prefix.len(), id, scx)?;
                 let text = format!("{}{}", prefix, nested.text);
                 Ok(replace_text(nested, text))
             }
-            ast::TyKind::Rptr(ref lifetime, ref mt) => {
+            hir::TyKind::Rptr(ref lifetime, ref mt) => {
                 let mut prefix = "&".to_owned();
-                if let &Some(ref l) = lifetime {
-                    prefix.push_str(&l.ident.to_string());
-                    prefix.push(' ');
-                }
-                if let ast::Mutability::Mut = mt.mutbl {
+                prefix.push_str(&lifetime.name.ident().to_string());
+                prefix.push(' ');
+                if let hir::Mutability::Mut = mt.mutbl {
                     prefix.push_str("mut ");
                 };
 
@@ -185,9 +188,8 @@ impl Sig for ast::Ty {
                 let text = format!("{}{}", prefix, nested.text);
                 Ok(replace_text(nested, text))
             }
-            ast::TyKind::Never => Ok(text_sig("!".to_owned())),
-            ast::TyKind::CVarArgs => Ok(text_sig("...".to_owned())),
-            ast::TyKind::Tup(ref ts) => {
+            hir::TyKind::Never => Ok(text_sig("!".to_owned())),
+            hir::TyKind::Tup(ts) => {
                 let mut text = "(".to_owned();
                 let mut defs = vec![];
                 let mut refs = vec![];
@@ -201,12 +203,7 @@ impl Sig for ast::Ty {
                 text.push(')');
                 Ok(Signature { text, defs, refs })
             }
-            ast::TyKind::Paren(ref ty) => {
-                let nested = ty.make(offset + 1, id, scx)?;
-                let text = format!("({})", nested.text);
-                Ok(replace_text(nested, text))
-            }
-            ast::TyKind::BareFn(ref f) => {
+            hir::TyKind::BareFn(ref f) => {
                 let mut text = String::new();
                 if !f.generic_params.is_empty() {
                     // FIXME defs, bounds on lifetimes
@@ -215,8 +212,8 @@ impl Sig for ast::Ty {
                         &f.generic_params
                             .iter()
                             .filter_map(|param| match param.kind {
-                                ast::GenericParamKind::Lifetime { .. } => {
-                                    Some(param.ident.to_string())
+                                hir::GenericParamKind::Lifetime { .. } => {
+                                    Some(param.name.ident().to_string())
                                 }
                                 _ => None,
                             })
@@ -226,23 +223,22 @@ impl Sig for ast::Ty {
                     text.push('>');
                 }
 
-                if let ast::Unsafe::Yes(_) = f.unsafety {
+                if let hir::Unsafety::Unsafe = f.unsafety {
                     text.push_str("unsafe ");
                 }
-                push_extern(&mut text, f.ext);
                 text.push_str("fn(");
 
                 let mut defs = vec![];
                 let mut refs = vec![];
-                for i in &f.decl.inputs {
-                    let nested = i.ty.make(offset + text.len(), Some(i.id), scx)?;
+                for i in f.decl.inputs {
+                    let nested = i.make(offset + text.len(), Some(i.hir_id), scx)?;
                     text.push_str(&nested.text);
                     text.push(',');
                     defs.extend(nested.defs.into_iter());
                     refs.extend(nested.refs.into_iter());
                 }
                 text.push(')');
-                if let ast::FnRetTy::Ty(ref t) = f.decl.output {
+                if let hir::FnRetTy::Return(ref t) = f.decl.output {
                     text.push_str(" -> ");
                     let nested = t.make(offset + text.len(), None, scx)?;
                     text.push_str(&nested.text);
@@ -253,23 +249,19 @@ impl Sig for ast::Ty {
 
                 Ok(Signature { text, defs, refs })
             }
-            ast::TyKind::Path(None, ref path) => path.make(offset, id, scx),
-            ast::TyKind::Path(Some(ref qself), ref path) => {
-                let nested_ty = qself.ty.make(offset + 1, id, scx)?;
-                let prefix = if qself.position == 0 {
-                    format!("<{}>::", nested_ty.text)
-                } else if qself.position == 1 {
-                    let first = pprust::path_segment_to_string(&path.segments[0]);
-                    format!("<{} as {}>::", nested_ty.text, first)
-                } else {
-                    // FIXME handle path instead of elipses.
-                    format!("<{} as ...>::", nested_ty.text)
-                };
+            hir::TyKind::Path(hir::QPath::Resolved(None, ref path)) => path.make(offset, id, scx),
+            hir::TyKind::Path(hir::QPath::Resolved(Some(ref qself), ref path)) => {
+                let nested_ty = qself.make(offset + 1, id, scx)?;
+                let prefix = format!(
+                    "<{} as {}>::",
+                    nested_ty.text,
+                    path_segment_to_string(&path.segments[0])
+                );
 
-                let name = pprust::path_segment_to_string(path.segments.last().ok_or("Bad path")?);
+                let name = path_segment_to_string(path.segments.last().ok_or("Bad path")?);
                 let res = scx.get_path_res(id.ok_or("Missing id for Path")?);
                 let id = id_from_def_id(res.def_id());
-                if path.segments.len() - qself.position == 1 {
+                if path.segments.len() == 2 {
                     let start = offset + prefix.len();
                     let end = start + name.len();
 
@@ -289,44 +281,60 @@ impl Sig for ast::Ty {
                     })
                 }
             }
-            ast::TyKind::TraitObject(ref bounds, ..) => {
+            hir::TyKind::TraitObject(bounds, ..) => {
                 // FIXME recurse into bounds
-                let nested = pprust::bounds_to_string(bounds);
+                let bounds: Vec<hir::GenericBound<'_>> = bounds
+                    .iter()
+                    .map(|hir::PolyTraitRef { bound_generic_params, trait_ref, span }| {
+                        hir::GenericBound::Trait(
+                            hir::PolyTraitRef {
+                                bound_generic_params,
+                                trait_ref: hir::TraitRef {
+                                    path: trait_ref.path,
+                                    hir_ref_id: trait_ref.hir_ref_id,
+                                },
+                                span: *span,
+                            },
+                            hir::TraitBoundModifier::None,
+                        )
+                    })
+                    .collect();
+                let nested = bounds_to_string(&bounds);
                 Ok(text_sig(nested))
             }
-            ast::TyKind::ImplTrait(_, ref bounds) => {
-                // FIXME recurse into bounds
-                let nested = pprust::bounds_to_string(bounds);
-                Ok(text_sig(format!("impl {}", nested)))
-            }
-            ast::TyKind::Array(ref ty, ref v) => {
+            hir::TyKind::Array(ref ty, ref anon_const) => {
                 let nested_ty = ty.make(offset + 1, id, scx)?;
-                let expr = pprust::expr_to_string(&v.value).replace('\n', " ");
+                let expr = id_to_string(&scx.tcx.hir(), anon_const.body.hir_id).replace('\n', " ");
                 let text = format!("[{}; {}]", nested_ty.text, expr);
                 Ok(replace_text(nested_ty, text))
             }
-            ast::TyKind::Typeof(_)
-            | ast::TyKind::Infer
-            | ast::TyKind::Err
-            | ast::TyKind::ImplicitSelf
-            | ast::TyKind::MacCall(_) => Err("Ty"),
+            hir::TyKind::Typeof(_)
+            | hir::TyKind::Infer
+            | hir::TyKind::Def(..)
+            | hir::TyKind::Path(..)
+            | hir::TyKind::Err => Err("Ty"),
         }
     }
 }
 
-impl Sig for ast::Item {
-    fn make(&self, offset: usize, _parent_id: Option<NodeId>, scx: &SaveContext<'_, '_>) -> Result {
-        let id = Some(self.id);
+impl<'hir> Sig for hir::Item<'hir> {
+    fn make(
+        &self,
+        offset: usize,
+        _parent_id: Option<hir::HirId>,
+        scx: &SaveContext<'_, '_>,
+    ) -> Result {
+        let id = Some(self.hir_id);
 
         match self.kind {
-            ast::ItemKind::Static(ref ty, m, ref expr) => {
+            hir::ItemKind::Static(ref ty, m, ref body) => {
                 let mut text = "static ".to_owned();
-                if m == ast::Mutability::Mut {
+                if m == hir::Mutability::Mut {
                     text.push_str("mut ");
                 }
                 let name = self.ident.to_string();
                 let defs = vec![SigElement {
-                    id: id_from_node_id(self.id, scx),
+                    id: id_from_hir_id(self.hir_id, scx),
                     start: offset + text.len(),
                     end: offset + text.len() + name.len(),
                 }];
@@ -336,21 +344,19 @@ impl Sig for ast::Item {
                 let ty = ty.make(offset + text.len(), id, scx)?;
                 text.push_str(&ty.text);
 
-                if let Some(expr) = expr {
-                    text.push_str(" = ");
-                    let expr = pprust::expr_to_string(expr).replace('\n', " ");
-                    text.push_str(&expr);
-                }
+                text.push_str(" = ");
+                let expr = id_to_string(&scx.tcx.hir(), body.hir_id).replace('\n', " ");
+                text.push_str(&expr);
 
                 text.push(';');
 
                 Ok(extend_sig(ty, text, defs, vec![]))
             }
-            ast::ItemKind::Const(_, ref ty, ref expr) => {
+            hir::ItemKind::Const(ref ty, ref body) => {
                 let mut text = "const ".to_owned();
                 let name = self.ident.to_string();
                 let defs = vec![SigElement {
-                    id: id_from_node_id(self.id, scx),
+                    id: id_from_hir_id(self.hir_id, scx),
                     start: offset + text.len(),
                     end: offset + text.len() + name.len(),
                 }];
@@ -360,38 +366,35 @@ impl Sig for ast::Item {
                 let ty = ty.make(offset + text.len(), id, scx)?;
                 text.push_str(&ty.text);
 
-                if let Some(expr) = expr {
-                    text.push_str(" = ");
-                    let expr = pprust::expr_to_string(expr).replace('\n', " ");
-                    text.push_str(&expr);
-                }
+                text.push_str(" = ");
+                let expr = id_to_string(&scx.tcx.hir(), body.hir_id).replace('\n', " ");
+                text.push_str(&expr);
 
                 text.push(';');
 
                 Ok(extend_sig(ty, text, defs, vec![]))
             }
-            ast::ItemKind::Fn(_, ast::FnSig { ref decl, header }, ref generics, _) => {
+            hir::ItemKind::Fn(hir::FnSig { ref decl, header }, ref generics, _) => {
                 let mut text = String::new();
-                if let ast::Const::Yes(_) = header.constness {
+                if let hir::Constness::Const = header.constness {
                     text.push_str("const ");
                 }
-                if header.asyncness.is_async() {
+                if hir::IsAsync::Async == header.asyncness {
                     text.push_str("async ");
                 }
-                if let ast::Unsafe::Yes(_) = header.unsafety {
+                if let hir::Unsafety::Unsafe = header.unsafety {
                     text.push_str("unsafe ");
                 }
-                push_extern(&mut text, header.ext);
                 text.push_str("fn ");
 
-                let mut sig = name_and_generics(text, offset, generics, self.id, self.ident, scx)?;
+                let mut sig =
+                    name_and_generics(text, offset, generics, self.hir_id, self.ident, scx)?;
 
                 sig.text.push('(');
-                for i in &decl.inputs {
+                for i in decl.inputs {
                     // FIXME should descend into patterns to add defs.
-                    sig.text.push_str(&pprust::pat_to_string(&i.pat));
                     sig.text.push_str(": ");
-                    let nested = i.ty.make(offset + sig.text.len(), Some(i.id), scx)?;
+                    let nested = i.make(offset + sig.text.len(), Some(i.hir_id), scx)?;
                     sig.text.push_str(&nested.text);
                     sig.text.push(',');
                     sig.defs.extend(nested.defs.into_iter());
@@ -399,7 +402,7 @@ impl Sig for ast::Item {
                 }
                 sig.text.push(')');
 
-                if let ast::FnRetTy::Ty(ref t) = decl.output {
+                if let hir::FnRetTy::Return(ref t) = decl.output {
                     sig.text.push_str(" -> ");
                     let nested = t.make(offset + sig.text.len(), None, scx)?;
                     sig.text.push_str(&nested.text);
@@ -410,11 +413,11 @@ impl Sig for ast::Item {
 
                 Ok(sig)
             }
-            ast::ItemKind::Mod(ref _mod) => {
+            hir::ItemKind::Mod(ref _mod) => {
                 let mut text = "mod ".to_owned();
                 let name = self.ident.to_string();
                 let defs = vec![SigElement {
-                    id: id_from_node_id(self.id, scx),
+                    id: id_from_hir_id(self.hir_id, scx),
                     start: offset + text.len(),
                     end: offset + text.len() + name.len(),
                 }];
@@ -424,78 +427,82 @@ impl Sig for ast::Item {
 
                 Ok(Signature { text, defs, refs: vec![] })
             }
-            ast::ItemKind::TyAlias(_, ref generics, _, ref ty) => {
+            hir::ItemKind::TyAlias(ref ty, ref generics) => {
                 let text = "type ".to_owned();
-                let mut sig = name_and_generics(text, offset, generics, self.id, self.ident, scx)?;
+                let mut sig =
+                    name_and_generics(text, offset, generics, self.hir_id, self.ident, scx)?;
 
                 sig.text.push_str(" = ");
-                let ty = match ty {
-                    Some(ty) => ty.make(offset + sig.text.len(), id, scx)?,
-                    None => return Err("Ty"),
-                };
+                let ty = ty.make(offset + sig.text.len(), id, scx)?;
                 sig.text.push_str(&ty.text);
                 sig.text.push(';');
 
                 Ok(merge_sigs(sig.text.clone(), vec![sig, ty]))
             }
-            ast::ItemKind::Enum(_, ref generics) => {
+            hir::ItemKind::Enum(_, ref generics) => {
                 let text = "enum ".to_owned();
-                let mut sig = name_and_generics(text, offset, generics, self.id, self.ident, scx)?;
+                let mut sig =
+                    name_and_generics(text, offset, generics, self.hir_id, self.ident, scx)?;
                 sig.text.push_str(" {}");
                 Ok(sig)
             }
-            ast::ItemKind::Struct(_, ref generics) => {
+            hir::ItemKind::Struct(_, ref generics) => {
                 let text = "struct ".to_owned();
-                let mut sig = name_and_generics(text, offset, generics, self.id, self.ident, scx)?;
+                let mut sig =
+                    name_and_generics(text, offset, generics, self.hir_id, self.ident, scx)?;
                 sig.text.push_str(" {}");
                 Ok(sig)
             }
-            ast::ItemKind::Union(_, ref generics) => {
+            hir::ItemKind::Union(_, ref generics) => {
                 let text = "union ".to_owned();
-                let mut sig = name_and_generics(text, offset, generics, self.id, self.ident, scx)?;
+                let mut sig =
+                    name_and_generics(text, offset, generics, self.hir_id, self.ident, scx)?;
                 sig.text.push_str(" {}");
                 Ok(sig)
             }
-            ast::ItemKind::Trait(is_auto, unsafety, ref generics, ref bounds, _) => {
+            hir::ItemKind::Trait(is_auto, unsafety, ref generics, bounds, _) => {
                 let mut text = String::new();
 
-                if is_auto == ast::IsAuto::Yes {
+                if is_auto == hir::IsAuto::Yes {
                     text.push_str("auto ");
                 }
 
-                if let ast::Unsafe::Yes(_) = unsafety {
+                if let hir::Unsafety::Unsafe = unsafety {
                     text.push_str("unsafe ");
                 }
                 text.push_str("trait ");
-                let mut sig = name_and_generics(text, offset, generics, self.id, self.ident, scx)?;
+                let mut sig =
+                    name_and_generics(text, offset, generics, self.hir_id, self.ident, scx)?;
 
                 if !bounds.is_empty() {
                     sig.text.push_str(": ");
-                    sig.text.push_str(&pprust::bounds_to_string(bounds));
+                    sig.text.push_str(&bounds_to_string(bounds));
                 }
                 // FIXME where clause
                 sig.text.push_str(" {}");
 
                 Ok(sig)
             }
-            ast::ItemKind::TraitAlias(ref generics, ref bounds) => {
+            hir::ItemKind::TraitAlias(ref generics, bounds) => {
                 let mut text = String::new();
                 text.push_str("trait ");
-                let mut sig = name_and_generics(text, offset, generics, self.id, self.ident, scx)?;
+                let mut sig =
+                    name_and_generics(text, offset, generics, self.hir_id, self.ident, scx)?;
 
                 if !bounds.is_empty() {
                     sig.text.push_str(" = ");
-                    sig.text.push_str(&pprust::bounds_to_string(bounds));
+                    sig.text.push_str(&bounds_to_string(bounds));
                 }
                 // FIXME where clause
                 sig.text.push_str(";");
 
                 Ok(sig)
             }
-            ast::ItemKind::Impl {
+            hir::ItemKind::Impl {
                 unsafety,
                 polarity,
                 defaultness,
+                defaultness_span: _,
                 constness,
                 ref generics,
                 ref of_trait,
@@ -503,14 +510,14 @@ impl Sig for ast::Item {
                 items: _,
             } => {
                 let mut text = String::new();
-                if let ast::Defaultness::Default(_) = defaultness {
+                if let hir::Defaultness::Default { .. } = defaultness {
                     text.push_str("default ");
                 }
-                if let ast::Unsafe::Yes(_) = unsafety {
+                if let hir::Unsafety::Unsafe = unsafety {
                     text.push_str("unsafe ");
                 }
                 text.push_str("impl");
-                if let ast::Const::Yes(_) = constness {
+                if let hir::Constness::Const = constness {
                     text.push_str(" const");
                 }
 
@@ -520,7 +527,7 @@ impl Sig for ast::Item {
                 text.push(' ');
 
                 let trait_sig = if let Some(ref t) = *of_trait {
-                    if let ast::ImplPolarity::Negative(_) = polarity {
+                    if let hir::ImplPolarity::Negative(_) = polarity {
                         text.push('!');
                     }
                     let trait_sig = t.path.make(offset + text.len(), id, scx)?;
@@ -540,27 +547,23 @@ impl Sig for ast::Item {
 
                 // FIXME where clause
             }
-            ast::ItemKind::ForeignMod(_) => Err("extern mod"),
-            ast::ItemKind::GlobalAsm(_) => Err("glboal asm"),
-            ast::ItemKind::ExternCrate(_) => Err("extern crate"),
+            hir::ItemKind::ForeignMod(_) => Err("extern mod"),
+            hir::ItemKind::GlobalAsm(_) => Err("glboal asm"),
+            hir::ItemKind::ExternCrate(_) => Err("extern crate"),
+            hir::ItemKind::OpaqueTy(..) => Err("opaque type"),
             // FIXME should implement this (e.g., pub use).
-            ast::ItemKind::Use(_) => Err("import"),
-            ast::ItemKind::MacCall(..) | ast::ItemKind::MacroDef(_) => Err("Macro"),
+            hir::ItemKind::Use(..) => Err("import"),
         }
     }
 }
 
-impl Sig for ast::Path {
-    fn make(&self, offset: usize, id: Option<NodeId>, scx: &SaveContext<'_, '_>) -> Result {
+impl<'hir> Sig for hir::Path<'hir> {
+    fn make(&self, offset: usize, id: Option<hir::HirId>, scx: &SaveContext<'_, '_>) -> Result {
         let res = scx.get_path_res(id.ok_or("Missing id for Path")?);
 
         let (name, start, end) = match res {
             Res::PrimTy(..) | Res::SelfTy(..) | Res::Err => {
-                return Ok(Signature {
-                    text: pprust::path_to_string(self),
-                    defs: vec![],
-                    refs: vec![],
-                });
+                return Ok(Signature { text: path_to_string(self), defs: vec![], refs: vec![] });
             }
             Res::Def(DefKind::AssocConst | DefKind::Variant | DefKind::Ctor(..), _) => {
                 let len = self.segments.len();
@@ -570,13 +573,13 @@ impl Sig for ast::Path {
                 // FIXME: really we should descend into the generics here and add SigElements for
                 // them.
                 // FIXME: would be nice to have a def for the first path segment.
-                let seg1 = pprust::path_segment_to_string(&self.segments[len - 2]);
-                let seg2 = pprust::path_segment_to_string(&self.segments[len - 1]);
+                let seg1 = path_segment_to_string(&self.segments[len - 2]);
+                let seg2 = path_segment_to_string(&self.segments[len - 1]);
                 let start = offset + seg1.len() + 2;
                 (format!("{}::{}", seg1, seg2), start, start + seg2.len())
             }
             _ => {
-                let name = pprust::path_segment_to_string(self.segments.last().ok_or("Bad path")?);
+                let name = path_segment_to_string(self.segments.last().ok_or("Bad path")?);
                 let end = offset + name.len();
                 (name, offset, end)
             }
@@ -588,8 +591,13 @@ impl Sig for ast::Path {
 }
 
 // This does not cover the where clause, which must be processed separately.
-impl Sig for ast::Generics {
-    fn make(&self, offset: usize, _parent_id: Option<NodeId>, scx: &SaveContext<'_, '_>) -> Result {
+impl<'hir> Sig for hir::Generics<'hir> {
+    fn make(
+        &self,
+        offset: usize,
+        _parent_id: Option<hir::HirId>,
+        scx: &SaveContext<'_, '_>,
+    ) -> Result {
         if self.params.is_empty() {
             return Ok(text_sig(String::new()));
         }
@@ -597,30 +605,30 @@ impl Sig for ast::Generics {
         let mut text = "<".to_owned();
 
         let mut defs = Vec::with_capacity(self.params.len());
-        for param in &self.params {
+        for param in self.params {
             let mut param_text = String::new();
-            if let ast::GenericParamKind::Const { .. } = param.kind {
+            if let hir::GenericParamKind::Const { .. } = param.kind {
                 param_text.push_str("const ");
             }
-            param_text.push_str(&param.ident.as_str());
+            param_text.push_str(&param.name.ident().as_str());
             defs.push(SigElement {
-                id: id_from_node_id(param.id, scx),
+                id: id_from_hir_id(param.hir_id, scx),
                 start: offset + text.len(),
                 end: offset + text.len() + param_text.as_str().len(),
             });
-            if let ast::GenericParamKind::Const { ref ty } = param.kind {
+            if let hir::GenericParamKind::Const { ref ty } = param.kind {
                 param_text.push_str(": ");
-                param_text.push_str(&pprust::ty_to_string(&ty));
+                param_text.push_str(&ty_to_string(&ty));
             }
             if !param.bounds.is_empty() {
                 param_text.push_str(": ");
                 match param.kind {
-                    ast::GenericParamKind::Lifetime { .. } => {
+                    hir::GenericParamKind::Lifetime { .. } => {
                         let bounds = param
                             .bounds
                             .iter()
                             .map(|bound| match bound {
-                                ast::GenericBound::Outlives(lt) => lt.ident.to_string(),
+                                hir::GenericBound::Outlives(lt) => lt.name.ident().to_string(),
                                 _ => panic!(),
                             })
                             .collect::<Vec<_>>()
@@ -628,11 +636,11 @@ impl Sig for ast::Generics {
                         param_text.push_str(&bounds);
                         // FIXME add lifetime bounds refs.
                     }
-                    ast::GenericParamKind::Type { .. } => {
-                        param_text.push_str(&pprust::bounds_to_string(&param.bounds));
+                    hir::GenericParamKind::Type { .. } => {
+                        param_text.push_str(&bounds_to_string(param.bounds));
                         // FIXME descend properly into bounds.
                     }
-                    ast::GenericParamKind::Const { .. } => {
+                    hir::GenericParamKind::Const { .. } => {
                         // Const generics cannot contain bounds.
                     }
                 }
@@ -646,21 +654,24 @@ impl Sig for ast::Generics {
     }
 }
 
-impl Sig for ast::StructField {
-    fn make(&self, offset: usize, _parent_id: Option<NodeId>, scx: &SaveContext<'_, '_>) -> Result {
+impl<'hir> Sig for hir::StructField<'hir> {
+    fn make(
+        &self,
+        offset: usize,
+        _parent_id: Option<hir::HirId>,
+        scx: &SaveContext<'_, '_>,
+    ) -> Result {
         let mut text = String::new();
-        let mut defs = None;
-        if let Some(ident) = self.ident {
-            text.push_str(&ident.to_string());
-            defs = Some(SigElement {
-                id: id_from_node_id(self.id, scx),
-                start: offset,
-                end: offset + text.len(),
-            });
-            text.push_str(": ");
-        }
 
-        let mut ty_sig = self.ty.make(offset + text.len(), Some(self.id), scx)?;
+        text.push_str(&self.ident.to_string());
+        let defs = Some(SigElement {
+            id: id_from_hir_id(self.hir_id, scx),
+            start: offset,
+            end: offset + text.len(),
+        });
+        text.push_str(": ");
+
+        let mut ty_sig = self.ty.make(offset + text.len(), Some(self.hir_id), scx)?;
         text.push_str(&ty_sig.text);
         ty_sig.text = text;
         ty_sig.defs.extend(defs.into_iter());
@@ -668,14 +679,19 @@ impl Sig for ast::StructField {
     }
 }
 
-impl Sig for ast::Variant {
-    fn make(&self, offset: usize, parent_id: Option<NodeId>, scx: &SaveContext<'_, '_>) -> Result {
+impl<'hir> Sig for hir::Variant<'hir> {
+    fn make(
+        &self,
+        offset: usize,
+        parent_id: Option<hir::HirId>,
+        scx: &SaveContext<'_, '_>,
+    ) -> Result {
         let mut text = self.ident.to_string();
         match self.data {
-            ast::VariantData::Struct(ref fields, r) => {
+            hir::VariantData::Struct(fields, r) => {
                 let id = parent_id.unwrap();
                 let name_def = SigElement {
-                    id: id_from_node_id(id, scx),
+                    id: id_from_hir_id(id, scx),
                     start: offset,
                     end: offset + text.len(),
                 };
@@ -696,9 +712,9 @@ impl Sig for ast::Variant {
                 text.push('}');
                 Ok(Signature { text, defs, refs })
             }
-            ast::VariantData::Tuple(ref fields, id) => {
+            hir::VariantData::Tuple(fields, id) => {
                 let name_def = SigElement {
-                    id: id_from_node_id(id, scx),
+                    id: id_from_hir_id(id, scx),
                     start: offset,
                     end: offset + text.len(),
                 };
@@ -715,9 +731,9 @@ impl Sig for ast::Variant {
                 text.push(')');
                 Ok(Signature { text, defs, refs })
             }
-            ast::VariantData::Unit(id) => {
+            hir::VariantData::Unit(id) => {
                 let name_def = SigElement {
-                    id: id_from_node_id(id, scx),
+                    id: id_from_hir_id(id, scx),
                     start: offset,
                     end: offset + text.len(),
                 };
@@ -727,23 +743,26 @@ impl Sig for ast::Variant {
     }
 }
 
-impl Sig for ast::ForeignItem {
-    fn make(&self, offset: usize, _parent_id: Option<NodeId>, scx: &SaveContext<'_, '_>) -> Result {
-        let id = Some(self.id);
+impl<'hir> Sig for hir::ForeignItem<'hir> {
+    fn make(
+        &self,
+        offset: usize,
+        _parent_id: Option<hir::HirId>,
+        scx: &SaveContext<'_, '_>,
+    ) -> Result {
+        let id = Some(self.hir_id);
         match self.kind {
-            ast::ForeignItemKind::Fn(_, ref sig, ref generics, _) => {
-                let decl = &sig.decl;
+            hir::ForeignItemKind::Fn(decl, _, ref generics) => {
                 let mut text = String::new();
                 text.push_str("fn ");
 
-                let mut sig = name_and_generics(text, offset, generics, self.id, self.ident, scx)?;
+                let mut sig =
+                    name_and_generics(text, offset, generics, self.hir_id, self.ident, scx)?;
 
                 sig.text.push('(');
-                for i in &decl.inputs {
-                    // FIXME should descend into patterns to add defs.
-                    sig.text.push_str(&pprust::pat_to_string(&i.pat));
+                for i in decl.inputs {
                     sig.text.push_str(": ");
-                    let nested = i.ty.make(offset + sig.text.len(), Some(i.id), scx)?;
+                    let nested = i.make(offset + sig.text.len(), Some(i.hir_id), scx)?;
                     sig.text.push_str(&nested.text);
                     sig.text.push(',');
                     sig.defs.extend(nested.defs.into_iter());
@@ -751,7 +770,7 @@ impl Sig for ast::ForeignItem {
                 }
                 sig.text.push(')');
 
-                if let ast::FnRetTy::Ty(ref t) = decl.output {
+                if let hir::FnRetTy::Return(ref t) = decl.output {
                     sig.text.push_str(" -> ");
                     let nested = t.make(offset + sig.text.len(), None, scx)?;
                     sig.text.push_str(&nested.text);
@@ -762,14 +781,14 @@ impl Sig for ast::ForeignItem {
 
                 Ok(sig)
             }
-            ast::ForeignItemKind::Static(ref ty, m, _) => {
+            hir::ForeignItemKind::Static(ref ty, m) => {
                 let mut text = "static ".to_owned();
-                if m == ast::Mutability::Mut {
+                if m == Mutability::Mut {
                     text.push_str("mut ");
                 }
                 let name = self.ident.to_string();
                 let defs = vec![SigElement {
-                    id: id_from_node_id(self.id, scx),
+                    id: id_from_hir_id(self.hir_id, scx),
                     start: offset + text.len(),
                     end: offset + text.len() + name.len(),
                 }];
@@ -781,11 +800,11 @@ impl Sig for ast::ForeignItem {
 
                 Ok(extend_sig(ty_sig, text, defs, vec![]))
             }
-            ast::ForeignItemKind::TyAlias(..) => {
+            hir::ForeignItemKind::Type => {
                 let mut text = "type ".to_owned();
                 let name = self.ident.to_string();
                 let defs = vec![SigElement {
-                    id: id_from_node_id(self.id, scx),
+                    id: id_from_hir_id(self.hir_id, scx),
                     start: offset + text.len(),
                     end: offset + text.len() + name.len(),
                 }];
@@ -794,7 +813,6 @@ impl Sig for ast::ForeignItem {
 
                 Ok(Signature { text, defs, refs: vec![] })
             }
-            ast::ForeignItemKind::MacCall(..) => Err("macro"),
         }
     }
 }
@@ -802,14 +820,14 @@ impl Sig for ast::ForeignItem {
 fn name_and_generics(
     mut text: String,
     offset: usize,
-    generics: &ast::Generics,
-    id: NodeId,
+    generics: &hir::Generics<'_>,
+    id: hir::HirId,
     name: Ident,
     scx: &SaveContext<'_, '_>,
 ) -> Result {
     let name = name.to_string();
     let def = SigElement {
-        id: id_from_node_id(id, scx),
+        id: id_from_hir_id(id, scx),
         start: offset + text.len(),
         end: offset + text.len() + name.len(),
     };
@@ -821,16 +839,16 @@ fn name_and_generics(
 }
 
 fn make_assoc_type_signature(
-    id: NodeId,
+    id: hir::HirId,
     ident: Ident,
-    bounds: Option<&ast::GenericBounds>,
-    default: Option<&ast::Ty>,
+    bounds: Option<hir::GenericBounds<'_>>,
+    default: Option<&hir::Ty<'_>>,
     scx: &SaveContext<'_, '_>,
 ) -> Result {
     let mut text = "type ".to_owned();
     let name = ident.to_string();
     let mut defs = vec![SigElement {
-        id: id_from_node_id(id, scx),
+        id: id_from_hir_id(id, scx),
         start: text.len(),
         end: text.len() + name.len(),
     }];
@@ -839,7 +857,7 @@ fn make_assoc_type_signature(
     if let Some(bounds) = bounds {
         text.push_str(": ");
         // FIXME should descend into bounds
-        text.push_str(&pprust::bounds_to_string(bounds));
+        text.push_str(&bounds_to_string(bounds));
     }
     if let Some(default) = default {
         text.push_str(" = ");
@@ -853,16 +871,16 @@ fn make_assoc_type_signature(
 }
 
 fn make_assoc_const_signature(
-    id: NodeId,
+    id: hir::HirId,
     ident: Symbol,
-    ty: &ast::Ty,
-    default: Option<&ast::Expr>,
+    ty: &hir::Ty<'_>,
+    default: Option<&hir::Expr<'_>>,
     scx: &SaveContext<'_, '_>,
 ) -> Result {
     let mut text = "const ".to_owned();
     let name = ident.to_string();
     let mut defs = vec![SigElement {
-        id: id_from_node_id(id, scx),
+        id: id_from_hir_id(id, scx),
         start: text.len(),
         end: text.len() + name.len(),
     }];
@@ -877,41 +895,38 @@ fn make_assoc_const_signature(
 
     if let Some(default) = default {
         text.push_str(" = ");
-        text.push_str(&pprust::expr_to_string(default));
+        text.push_str(&id_to_string(&scx.tcx.hir(), default.hir_id));
     }
     text.push(';');
     Ok(Signature { text, defs, refs })
 }
 
 fn make_method_signature(
-    id: NodeId,
+    id: hir::HirId,
     ident: Ident,
-    generics: &ast::Generics,
-    m: &ast::FnSig,
+    generics: &hir::Generics<'_>,
+    m: &hir::FnSig<'_>,
     scx: &SaveContext<'_, '_>,
 ) -> Result {
     // FIXME code dup with function signature
     let mut text = String::new();
-    if let ast::Const::Yes(_) = m.header.constness {
+    if let hir::Constness::Const = m.header.constness {
         text.push_str("const ");
     }
-    if m.header.asyncness.is_async() {
+    if hir::IsAsync::Async == m.header.asyncness {
         text.push_str("async ");
     }
-    if let ast::Unsafe::Yes(_) = m.header.unsafety {
+    if let hir::Unsafety::Unsafe = m.header.unsafety {
         text.push_str("unsafe ");
     }
-    push_extern(&mut text, m.header.ext);
     text.push_str("fn ");
 
     let mut sig = name_and_generics(text, 0, generics, id, ident, scx)?;
 
     sig.text.push('(');
-    for i in &m.decl.inputs {
-        // FIXME should descend into patterns to add defs.
-        sig.text.push_str(&pprust::pat_to_string(&i.pat));
+    for i in m.decl.inputs {
         sig.text.push_str(": ");
-        let nested = i.ty.make(sig.text.len(), Some(i.id), scx)?;
+        let nested = i.make(sig.text.len(), Some(i.hir_id), scx)?;
         sig.text.push_str(&nested.text);
         sig.text.push(',');
         sig.defs.extend(nested.defs.into_iter());
@@ -919,7 +934,7 @@ fn make_method_signature(
     }
     sig.text.push(')');
 
-    if let ast::FnRetTy::Ty(ref t) = m.decl.output {
+    if let hir::FnRetTy::Return(ref t) = m.decl.output {
         sig.text.push_str(" -> ");
         let nested = t.make(sig.text.len(), None, scx)?;
         sig.text.push_str(&nested.text);


### PR DESCRIPTION
In order to reduce the uses of `NodeId`s in the compiler, `save_analysis` crate has been reworked to operate on the HIR tree instead of the AST.

cc #50928 