### PR TITLE
Add a warning about infinite reading in read_(until|line)

### DIFF
--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -1883,6 +1883,10 @@ pub trait BufRead: Read {
     ///
     /// If successful, this function will return the total number of bytes read.
     ///
+    /// This function is blocking and should be used carefully: it is possible for
+    /// an attacker to continuously send bytes without ever sending the delimiter
+    /// or EOF.
+    ///
     /// # Errors
     ///
     /// This function will ignore all instances of [`ErrorKind::Interrupted`] and
@@ -1944,6 +1948,10 @@ pub trait BufRead: Read {
     /// If successful, this function will return the total number of bytes read.
     ///
     /// If this function returns `Ok(0)`, the stream has reached EOF.
+    ///
+    /// This function is blocking and should be used carefully: it is possible for
+    /// an attacker to continuously send bytes without ever sending a newline
+    /// or EOF.
     ///
     /// # Errors
     ///


### PR DESCRIPTION
Fix for #48788.

This PR adds a warning to [`BufRead::read_line`](https://doc.rust-lang.org/stable/std/io/trait.BufRead.html#method.read_line) and [`BufRead::read_until`](https://doc.rust-lang.org/stable/std/io/trait.BufRead.html#method.read_until) about the possibility of an attack using the behaviour of these functions.

I did not mention a possible fix (using [`Read::take`](https://doc.rust-lang.org/stable/std/io/trait.Read.html#method.take), should I ?