### PR TITLE
test miri-unleash TLS accesses

### DIFF
--- a/src/librustc_middle/mir/interpret/error.rs
+++ b/src/librustc_middle/mir/interpret/error.rs
@@ -523,12 +523,12 @@ impl fmt::Display for UnsupportedOpInfo {
         match self {
             Unsupported(ref msg) => write!(f, "{}", msg),
             ReadForeignStatic(did) => {
-                write!(f, "cannot read from foreign (extern) static {:?}", did)
+                write!(f, "cannot read from foreign (extern) static ({:?})", did)
             }
             NoMirFor(did) => write!(f, "no MIR body is available for {:?}", did),
             ReadPointerAsBytes => write!(f, "unable to turn pointer into raw bytes",),
             ReadBytesAsPointer => write!(f, "unable to turn bytes into a pointer"),
-            ThreadLocalStatic(did) => write!(f, "accessing thread local static {:?}", did),
+            ThreadLocalStatic(did) => write!(f, "cannot access thread local static ({:?})", did),
         }
     }
 }

--- a/src/librustc_mir/transform/check_consts/ops.rs
+++ b/src/librustc_mir/transform/check_consts/ops.rs
@@ -12,9 +12,6 @@ use super::ConstCx;
 
 /// An operation that is not *always* allowed in a const context.
 pub trait NonConstOp: std::fmt::Debug {
-    /// Whether this operation can be evaluated by miri.
-    const IS_SUPPORTED_IN_MIRI: bool = true;
-
     /// Returns the `Symbol` corresponding to the feature gate that would enable this operation,
     /// or `None` if such a feature gate does not exist.
     fn feature_gate() -> Option<Symbol> {
@@ -356,8 +353,6 @@ impl NonConstOp for StaticAccess {
 #[derive(Debug)]
 pub struct ThreadLocalAccess;
 impl NonConstOp for ThreadLocalAccess {
-    const IS_SUPPORTED_IN_MIRI: bool = false;
-
     fn emit_error(&self, ccx: &ConstCx<'_, '_>, span: Span) {
         struct_span_err!(
             ccx.tcx.sess,

--- a/src/librustc_mir/transform/check_consts/validation.rs
+++ b/src/librustc_mir/transform/check_consts/validation.rs
@@ -244,11 +244,7 @@ impl Validator<'mir, 'tcx> {
             return;
         }
 
-        // If an operation is supported in miri it can be turned on with
-        // `-Zunleash-the-miri-inside-of-you`.
-        let is_unleashable = O::IS_SUPPORTED_IN_MIRI;
-
-        if is_unleashable && self.tcx.sess.opts.debugging_opts.unleash_the_miri_inside_of_you {
+        if self.tcx.sess.opts.debugging_opts.unleash_the_miri_inside_of_you {
             self.tcx.sess.miri_unleashed_feature(span, O::feature_gate());
             return;
         }

--- a/src/test/ui/consts/miri_unleashed/inline_asm.rs
+++ b/src/test/ui/consts/miri_unleashed/inline_asm.rs
@@ -1,15 +1,22 @@
 // compile-flags: -Zunleash-the-miri-inside-of-you
 // only-x86_64
-#![feature(llvm_asm)]
+#![feature(asm,llvm_asm)]
 #![allow(const_err)]
 
 fn main() {}
 
 // Make sure we catch executing inline assembly.
-static TEST_BAD: () = {
+static TEST_BAD1: () = {
     unsafe { llvm_asm!("xor %eax, %eax" ::: "eax"); }
     //~^ ERROR could not evaluate static initializer
     //~| NOTE inline assembly is not supported
     //~| NOTE in this expansion of llvm_asm!
     //~| NOTE in this expansion of llvm_asm!
+};
+
+// Make sure we catch executing inline assembly.
+static TEST_BAD2: () = {
+    unsafe { asm!("nop"); }
+    //~^ ERROR could not evaluate static initializer
+    //~| NOTE inline assembly is not supported
 };

--- a/src/test/ui/consts/miri_unleashed/inline_asm.stderr
+++ b/src/test/ui/consts/miri_unleashed/inline_asm.stderr
@@ -6,6 +6,12 @@ LL |     unsafe { llvm_asm!("xor %eax, %eax" ::: "eax"); }
    |
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
+error[E0080]: could not evaluate static initializer
+  --> $DIR/inline_asm.rs:19:14
+   |
+LL |     unsafe { asm!("nop"); }
+   |              ^^^^^^^^^^^^ inline assembly is not supported
+
 warning: skipping const checks
    |
 help: skipping check that does not even have a feature gate
@@ -13,8 +19,13 @@ help: skipping check that does not even have a feature gate
    |
 LL |     unsafe { llvm_asm!("xor %eax, %eax" ::: "eax"); }
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: skipping check that does not even have a feature gate
+  --> $DIR/inline_asm.rs:19:14
+   |
+LL |     unsafe { asm!("nop"); }
+   |              ^^^^^^^^^^^^
    = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to previous error; 1 warning emitted
+error: aborting due to 2 previous errors; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/miri_unleashed/tls.rs
+++ b/src/test/ui/consts/miri_unleashed/tls.rs
@@ -7,7 +7,7 @@ use std::thread;
 #[thread_local]
 static A: u8 = 0;
 
-// Make sure we catch executing inline assembly.
+// Make sure we catch accessing thread-local storage.
 static TEST_BAD: () = {
     unsafe { let _val = A; }
     //~^ ERROR could not evaluate static initializer

--- a/src/test/ui/consts/miri_unleashed/tls.rs
+++ b/src/test/ui/consts/miri_unleashed/tls.rs
@@ -1,0 +1,17 @@
+// compile-flags: -Zunleash-the-miri-inside-of-you
+#![feature(thread_local)]
+#![allow(const_err)]
+
+use std::thread;
+
+#[thread_local]
+static A: u8 = 0;
+
+// Make sure we catch executing inline assembly.
+static TEST_BAD: () = {
+    unsafe { let _val = A; }
+    //~^ ERROR could not evaluate static initializer
+    //~| NOTE cannot access thread local static
+};
+
+fn main() {}

--- a/src/test/ui/consts/miri_unleashed/tls.stderr
+++ b/src/test/ui/consts/miri_unleashed/tls.stderr
@@ -1,0 +1,17 @@
+error[E0080]: could not evaluate static initializer
+  --> $DIR/tls.rs:12:25
+   |
+LL |     unsafe { let _val = A; }
+   |                         ^ cannot access thread local static (DefId(0:4 ~ tls[317d]::A[0]))
+
+warning: skipping const checks
+   |
+help: skipping check that does not even have a feature gate
+  --> $DIR/tls.rs:12:25
+   |
+LL |     unsafe { let _val = A; }
+   |                         ^
+
+error: aborting due to previous error; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0080`.


### PR DESCRIPTION
Finally gets rid of `IS_SUPPORTED_IN_MIRI`. :-)

I also added a test for the new `asm!` while I am at it.

r? @ecstatic-morse Cc @rust-lang/wg-const-eval 