### PR TITLE
normalize adt fields during structural match checking

### DIFF
--- a/src/librustc_trait_selection/traits/structural_match.rs
+++ b/src/librustc_trait_selection/traits/structural_match.rs
@@ -251,7 +251,11 @@ impl<'a, 'tcx> TypeVisitor<'tcx> for Search<'a, 'tcx> {
         // fields of ADT.
         let tcx = self.tcx();
         for field_ty in adt_def.all_fields().map(|field| field.ty(tcx, substs)) {
-            if field_ty.visit_with(self) {
+            assert!(!field_ty.needs_subst());
+            let ty = self.tcx().normalize_erasing_regions(ty::ParamEnv::reveal_all(), field_ty);
+            debug!("structural-match ADT: field_ty={:?}, ty={:?}", field_ty, ty);
+
+            if ty.visit_with(self) {
                 // found an ADT without structural-match; halt visiting!
                 assert!(self.found.is_some());
                 return true;

--- a/src/librustc_trait_selection/traits/structural_match.rs
+++ b/src/librustc_trait_selection/traits/structural_match.rs
@@ -251,8 +251,7 @@ impl<'a, 'tcx> TypeVisitor<'tcx> for Search<'a, 'tcx> {
         // fields of ADT.
         let tcx = self.tcx();
         for field_ty in adt_def.all_fields().map(|field| field.ty(tcx, substs)) {
-            assert!(!field_ty.needs_subst());
-            let ty = self.tcx().normalize_erasing_regions(ty::ParamEnv::reveal_all(), field_ty);
+            let ty = self.tcx().normalize_erasing_regions(ty::ParamEnv::empty(), field_ty);
             debug!("structural-match ADT: field_ty={:?}, ty={:?}", field_ty, ty);
 
             if ty.visit_with(self) {

--- a/src/test/ui/match/issue-72896.rs
+++ b/src/test/ui/match/issue-72896.rs
@@ -1,0 +1,23 @@
+// run-pass
+trait EnumSetType {
+    type Repr;
+}
+
+enum Enum8 { }
+impl EnumSetType for Enum8 {
+    type Repr = u8;
+}
+
+#[derive(PartialEq, Eq)]
+struct EnumSet<T: EnumSetType> {
+    __enumset_underlying: T::Repr,
+}
+
+const CONST_SET: EnumSet<Enum8> = EnumSet { __enumset_underlying: 3 };
+
+fn main() {
+    match CONST_SET {
+        CONST_SET => { /* ok */ }
+        _ => panic!("match fell through?"),
+    }
+}


### PR DESCRIPTION
fixes #72896 

currently only fixes the issue itself and compiles stage 1 libs.
I believe we have to use something else to normalize the adt fields here,
as I expect some partially resolved adts to cause problems :thinking: 

stage 1 libs and the test itself pass, not sure about the rest...
Will spend some more time looking into it tomorrow.

r? @pnkfelix cc @eddyb 