### PR TITLE
Don't count pathless --extern for unused-crate-dependencies warnings

### DIFF
--- a/src/test/ui/unused-crate-deps/ignore-pathless-extern.rs
+++ b/src/test/ui/unused-crate-deps/ignore-pathless-extern.rs
@@ -1,0 +1,12 @@
+// Pathless --extern references don't count
+
+// edition:2018
+// check-pass
+// aux-crate:bar=bar.rs
+// compile-flags:--extern proc_macro
+
+#![warn(unused_crate_dependencies)]
+
+use bar as _;
+
+fn main() {}


### PR DESCRIPTION
`--extern proc_macro` is used to add the proc_macro crate to the extern
prelude for all procmacros. In general pathless `--extern` only references
sysroot/standard libraries and so should be exempt from
unused-crate-dependencies warnings.

r? @petrochenkov 