### PR TITLE
Add a test to ensure Fuse stays covariant

### DIFF
--- a/src/test/ui/variance-iterators-in-libcore.rs
+++ b/src/test/ui/variance-iterators-in-libcore.rs
@@ -1,9 +1,10 @@
 // run-pass
 
-#![allow(warnings)]
+#![allow(dead_code)]
 
-use std::iter::Zip;
+use std::iter::{Fuse, Zip};
 
+fn fuse_covariant<'a, I>(iter: Fuse<&'static I>) -> Fuse<&'a I> { iter }
 fn zip_covariant<'a, A, B>(iter: Zip<&'static A, &'static B>) -> Zip<&'a A, &'a B> { iter }
 
 fn main() { }


### PR DESCRIPTION
When #70502 attempted to specialize the data types in `Fuse`, one of the problems we found was that it broke variance. This was also realized when `Fuse` was first added, https://github.com/rust-lang/rust/pull/35656#discussion-diff-74995079, but now this PR adds a test so we don't forget again.