### PR TITLE
forbid mutable references in all constant contexts except for const-fns

### DIFF
--- a/src/librustc_error_codes/error_codes.rs
+++ b/src/librustc_error_codes/error_codes.rs
@@ -444,6 +444,7 @@ E0760: include_str!("./error_codes/E0760.md"),
 E0761: include_str!("./error_codes/E0761.md"),
 E0762: include_str!("./error_codes/E0762.md"),
 E0763: include_str!("./error_codes/E0763.md"),
+E0764: include_str!("./error_codes/E0764.md"),
 ;
 //  E0006, // merged with E0005
 //  E0008, // cannot bind by-move into a pattern guard

--- a/src/librustc_error_codes/error_codes/E0764.md
+++ b/src/librustc_error_codes/error_codes/E0764.md
@@ -1,0 +1,39 @@
+Mutable references (`&mut`) can only be used in constant functions, not statics
+or constants. This limitation exists to prevent the creation of constants that
+have a mutable reference in their final value. If you had a constant of `&mut
+i32` type, you could modify the value through that reference, making the
+constant essentially mutable. While there could be a more fine-grained scheme
+in the future that allows mutable references if they are not "leaked" to the
+final value, a more conservative approach was chosen for now. `const fn` do not
+have this problem, as the borrow checker will prevent the `const fn` from
+returning new mutable references.
+
+Erroneous code example:
+
+```compile_fail,E0764
+#![feature(const_fn)]
+#![feature(const_mut_refs)]
+
+fn main() {
+    const OH_NO: &'static mut usize = &mut 1; // error!
+}
+```
+
+Remember: you cannot use a function call inside a constant or static. However,
+you can totally use it in constant functions:
+
+```
+#![feature(const_fn)]
+#![feature(const_mut_refs)]
+
+const fn foo(x: usize) -> usize {
+    let mut y = 1;
+    let z = &mut y;
+    *z += x;
+    y
+}
+
+fn main() {
+    const FOO: usize = foo(10); // ok!
+}
+```

--- a/src/librustc_mir/transform/check_consts/ops.rs
+++ b/src/librustc_mir/transform/check_consts/ops.rs
@@ -227,7 +227,7 @@ impl NonConstOp for MutBorrow {
             struct_span_err!(
                 ccx.tcx.sess,
                 span,
-                E0019,
+                E0764,
                 "mutable references are not allowed in {}s",
                 ccx.const_kind(),
             )

--- a/src/librustc_mir/transform/check_consts/ops.rs
+++ b/src/librustc_mir/transform/check_consts/ops.rs
@@ -205,6 +205,12 @@ impl NonConstOp for CellBorrow {
 #[derive(Debug)]
 pub struct MutBorrow;
 impl NonConstOp for MutBorrow {
+    fn is_allowed_in_item(&self, ccx: &ConstCx<'_, '_>) -> bool {
+        // Forbid everywhere except in const fn
+        ccx.const_kind() == hir::ConstContext::ConstFn
+            && ccx.tcx.features().enabled(Self::feature_gate().unwrap())
+    }
+
     fn feature_gate() -> Option<Symbol> {
         Some(sym::const_mut_refs)
     }

--- a/src/librustc_mir/transform/check_consts/ops.rs
+++ b/src/librustc_mir/transform/check_consts/ops.rs
@@ -216,17 +216,23 @@ impl NonConstOp for MutBorrow {
     }
 
     fn emit_error(&self, ccx: &ConstCx<'_, '_>, span: Span) {
-        let mut err = feature_err(
-            &ccx.tcx.sess.parse_sess,
-            sym::const_mut_refs,
-            span,
-            &format!(
-                "references in {}s may only refer \
-                      to immutable values",
-                ccx.const_kind()
-            ),
-        );
-        err.span_label(span, format!("{}s require immutable values", ccx.const_kind()));
+        let mut err = if ccx.const_kind() == hir::ConstContext::ConstFn {
+            feature_err(
+                &ccx.tcx.sess.parse_sess,
+                sym::const_mut_refs,
+                span,
+                &format!("mutable references are not allowed in {}s", ccx.const_kind()),
+            )
+        } else {
+            struct_span_err!(
+                ccx.tcx.sess,
+                span,
+                E0019,
+                "mutable references are not allowed in {}s",
+                ccx.const_kind(),
+            )
+        };
+        err.span_label(span, "`&mut` is only allowed in `const fn`".to_string());
         if ccx.tcx.sess.teach(&err.get_code().unwrap()) {
             err.note(
                 "References in statics and constants may only refer \

--- a/src/test/compile-fail/issue-52443.rs
+++ b/src/test/compile-fail/issue-52443.rs
@@ -9,7 +9,7 @@ fn main() {
     [(); { for _ in 0usize.. {}; 0}];
     //~^ ERROR `for` is not allowed in a `const`
     //~| ERROR calls in constants are limited to constant functions
-    //~| ERROR references in constants may only refer to immutable values
+    //~| ERROR mutable references are not allowed in constants
     //~| ERROR calls in constants are limited to constant functions
     //~| ERROR evaluation of constant value failed
 }

--- a/src/test/ui/check-static-immutable-mut-slices.rs
+++ b/src/test/ui/check-static-immutable-mut-slices.rs
@@ -1,6 +1,6 @@
 // Checks that immutable static items can't have mutable slices
 
 static TEST: &'static mut [isize] = &mut [];
-//~^ ERROR references in statics may only refer to immutable values
+//~^ ERROR mutable references are not allowed in statics
 
 pub fn main() { }

--- a/src/test/ui/check-static-immutable-mut-slices.stderr
+++ b/src/test/ui/check-static-immutable-mut-slices.stderr
@@ -1,12 +1,9 @@
-error[E0658]: references in statics may only refer to immutable values
+error[E0019]: mutable references are not allowed in statics
   --> $DIR/check-static-immutable-mut-slices.rs:3:37
    |
 LL | static TEST: &'static mut [isize] = &mut [];
-   |                                     ^^^^^^^ statics require immutable values
-   |
-   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
-   = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   |                                     ^^^^^^^ `&mut` is only allowed in `const fn`
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0658`.
+For more information about this error, try `rustc --explain E0019`.

--- a/src/test/ui/check-static-immutable-mut-slices.stderr
+++ b/src/test/ui/check-static-immutable-mut-slices.stderr
@@ -1,4 +1,4 @@
-error[E0019]: mutable references are not allowed in statics
+error[E0764]: mutable references are not allowed in statics
   --> $DIR/check-static-immutable-mut-slices.rs:3:37
    |
 LL | static TEST: &'static mut [isize] = &mut [];
@@ -6,4 +6,4 @@ LL | static TEST: &'static mut [isize] = &mut [];
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0019`.
+For more information about this error, try `rustc --explain E0764`.

--- a/src/test/ui/consts/const-eval/issue-65394.rs
+++ b/src/test/ui/consts/const-eval/issue-65394.rs
@@ -5,7 +5,7 @@
 
 const _: Vec<i32> = {
     let mut x = Vec::<i32>::new(); //~ ERROR destructors cannot be evaluated at compile-time
-    let r = &mut x; //~ ERROR references in constants may only refer to immutable values
+    let r = &mut x; //~ ERROR mutable references are not allowed in constants
     let y = x;
     y
 };

--- a/src/test/ui/consts/const-eval/issue-65394.stderr
+++ b/src/test/ui/consts/const-eval/issue-65394.stderr
@@ -1,11 +1,8 @@
-error[E0658]: references in constants may only refer to immutable values
+error[E0019]: mutable references are not allowed in constants
   --> $DIR/issue-65394.rs:8:13
    |
 LL |     let r = &mut x;
-   |             ^^^^^^ constants require immutable values
-   |
-   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
-   = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   |             ^^^^^^ `&mut` is only allowed in `const fn`
 
 error[E0493]: destructors cannot be evaluated at compile-time
   --> $DIR/issue-65394.rs:7:9
@@ -15,5 +12,5 @@ LL |     let mut x = Vec::<i32>::new();
 
 error: aborting due to 2 previous errors
 
-Some errors have detailed explanations: E0493, E0658.
-For more information about an error, try `rustc --explain E0493`.
+Some errors have detailed explanations: E0019, E0493.
+For more information about an error, try `rustc --explain E0019`.

--- a/src/test/ui/consts/const-eval/issue-65394.stderr
+++ b/src/test/ui/consts/const-eval/issue-65394.stderr
@@ -1,4 +1,4 @@
-error[E0019]: mutable references are not allowed in constants
+error[E0764]: mutable references are not allowed in constants
   --> $DIR/issue-65394.rs:8:13
    |
 LL |     let r = &mut x;
@@ -12,5 +12,5 @@ LL |     let mut x = Vec::<i32>::new();
 
 error: aborting due to 2 previous errors
 
-Some errors have detailed explanations: E0019, E0493.
-For more information about an error, try `rustc --explain E0019`.
+Some errors have detailed explanations: E0493, E0764.
+For more information about an error, try `rustc --explain E0493`.

--- a/src/test/ui/consts/const-multi-ref.rs
+++ b/src/test/ui/consts/const-multi-ref.rs
@@ -3,7 +3,7 @@
 
 const _: i32 = {
     let mut a = 5;
-    let p = &mut a; //~ ERROR references in constants may only refer to immutable values
+    let p = &mut a; //~ ERROR mutable references are not allowed in constants
 
     let reborrow = {p};
     let pp = &reborrow;

--- a/src/test/ui/consts/const-multi-ref.stderr
+++ b/src/test/ui/consts/const-multi-ref.stderr
@@ -1,11 +1,8 @@
-error[E0658]: references in constants may only refer to immutable values
+error[E0019]: mutable references are not allowed in constants
   --> $DIR/const-multi-ref.rs:6:13
    |
 LL |     let p = &mut a;
-   |             ^^^^^^ constants require immutable values
-   |
-   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
-   = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   |             ^^^^^^ `&mut` is only allowed in `const fn`
 
 error[E0492]: cannot borrow a constant which may contain interior mutability, create a static instead
   --> $DIR/const-multi-ref.rs:16:13
@@ -15,5 +12,5 @@ LL |     let p = &a;
 
 error: aborting due to 2 previous errors
 
-Some errors have detailed explanations: E0492, E0658.
-For more information about an error, try `rustc --explain E0492`.
+Some errors have detailed explanations: E0019, E0492.
+For more information about an error, try `rustc --explain E0019`.

--- a/src/test/ui/consts/const-multi-ref.stderr
+++ b/src/test/ui/consts/const-multi-ref.stderr
@@ -1,4 +1,4 @@
-error[E0019]: mutable references are not allowed in constants
+error[E0764]: mutable references are not allowed in constants
   --> $DIR/const-multi-ref.rs:6:13
    |
 LL |     let p = &mut a;
@@ -12,5 +12,5 @@ LL |     let p = &a;
 
 error: aborting due to 2 previous errors
 
-Some errors have detailed explanations: E0019, E0492.
-For more information about an error, try `rustc --explain E0019`.
+Some errors have detailed explanations: E0492, E0764.
+For more information about an error, try `rustc --explain E0492`.

--- a/src/test/ui/consts/const-mut-refs/const_mut_address_of.rs
+++ b/src/test/ui/consts/const-mut-refs/const_mut_address_of.rs
@@ -22,9 +22,9 @@ const fn baz(foo: &mut Foo)-> *mut usize {
 
 const _: () = {
     foo().bar();
-    //~^ ERROR references in constants may only refer to immutable values
+    //~^ ERROR mutable references are not allowed in constants
     baz(&mut foo());
-    //~^ ERROR references in constants may only refer to immutable values
+    //~^ ERROR mutable references are not allowed in constants
 };
 
 fn main() {}

--- a/src/test/ui/consts/const-mut-refs/const_mut_address_of.rs
+++ b/src/test/ui/consts/const-mut-refs/const_mut_address_of.rs
@@ -1,5 +1,3 @@
-// check-pass
-
 #![feature(const_mut_refs)]
 #![feature(const_fn)]
 #![feature(raw_ref_op)]
@@ -24,7 +22,9 @@ const fn baz(foo: &mut Foo)-> *mut usize {
 
 const _: () = {
     foo().bar();
+    //~^ ERROR references in constants may only refer to immutable values
     baz(&mut foo());
+    //~^ ERROR references in constants may only refer to immutable values
 };
 
 fn main() {}

--- a/src/test/ui/consts/const-mut-refs/const_mut_address_of.stderr
+++ b/src/test/ui/consts/const-mut-refs/const_mut_address_of.stderr
@@ -1,0 +1,21 @@
+error[E0658]: references in constants may only refer to immutable values
+  --> $DIR/const_mut_address_of.rs:24:5
+   |
+LL |     foo().bar();
+   |     ^^^^^ constants require immutable values
+   |
+   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
+   = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+
+error[E0658]: references in constants may only refer to immutable values
+  --> $DIR/const_mut_address_of.rs:26:9
+   |
+LL |     baz(&mut foo());
+   |         ^^^^^^^^^^ constants require immutable values
+   |
+   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
+   = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/consts/const-mut-refs/const_mut_address_of.stderr
+++ b/src/test/ui/consts/const-mut-refs/const_mut_address_of.stderr
@@ -1,21 +1,15 @@
-error[E0658]: references in constants may only refer to immutable values
+error[E0019]: mutable references are not allowed in constants
   --> $DIR/const_mut_address_of.rs:24:5
    |
 LL |     foo().bar();
-   |     ^^^^^ constants require immutable values
-   |
-   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
-   = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   |     ^^^^^ `&mut` is only allowed in `const fn`
 
-error[E0658]: references in constants may only refer to immutable values
+error[E0019]: mutable references are not allowed in constants
   --> $DIR/const_mut_address_of.rs:26:9
    |
 LL |     baz(&mut foo());
-   |         ^^^^^^^^^^ constants require immutable values
-   |
-   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
-   = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   |         ^^^^^^^^^^ `&mut` is only allowed in `const fn`
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0658`.
+For more information about this error, try `rustc --explain E0019`.

--- a/src/test/ui/consts/const-mut-refs/const_mut_address_of.stderr
+++ b/src/test/ui/consts/const-mut-refs/const_mut_address_of.stderr
@@ -1,10 +1,10 @@
-error[E0019]: mutable references are not allowed in constants
+error[E0764]: mutable references are not allowed in constants
   --> $DIR/const_mut_address_of.rs:24:5
    |
 LL |     foo().bar();
    |     ^^^^^ `&mut` is only allowed in `const fn`
 
-error[E0019]: mutable references are not allowed in constants
+error[E0764]: mutable references are not allowed in constants
   --> $DIR/const_mut_address_of.rs:26:9
    |
 LL |     baz(&mut foo());
@@ -12,4 +12,4 @@ LL |     baz(&mut foo());
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0019`.
+For more information about this error, try `rustc --explain E0764`.

--- a/src/test/ui/consts/const-mut-refs/const_mut_refs.rs
+++ b/src/test/ui/consts/const-mut-refs/const_mut_refs.rs
@@ -1,5 +1,3 @@
-// run-pass
-
 #![feature(const_mut_refs)]
 
 struct Foo {
@@ -31,6 +29,9 @@ const fn bazz(foo: &mut Foo) -> usize {
 
 fn main() {
     let _: [(); foo().bar()] = [(); 1];
+    //~^ ERROR references in constants may only refer to immutable values
     let _: [(); baz(&mut foo())] = [(); 2];
+    //~^ ERROR references in constants may only refer to immutable values
     let _: [(); bazz(&mut foo())] = [(); 3];
+    //~^ ERROR references in constants may only refer to immutable values
 }

--- a/src/test/ui/consts/const-mut-refs/const_mut_refs.rs
+++ b/src/test/ui/consts/const-mut-refs/const_mut_refs.rs
@@ -29,9 +29,9 @@ const fn bazz(foo: &mut Foo) -> usize {
 
 fn main() {
     let _: [(); foo().bar()] = [(); 1];
-    //~^ ERROR references in constants may only refer to immutable values
+    //~^ ERROR mutable references are not allowed in constants
     let _: [(); baz(&mut foo())] = [(); 2];
-    //~^ ERROR references in constants may only refer to immutable values
+    //~^ ERROR mutable references are not allowed in constants
     let _: [(); bazz(&mut foo())] = [(); 3];
-    //~^ ERROR references in constants may only refer to immutable values
+    //~^ ERROR mutable references are not allowed in constants
 }

--- a/src/test/ui/consts/const-mut-refs/const_mut_refs.stderr
+++ b/src/test/ui/consts/const-mut-refs/const_mut_refs.stderr
@@ -1,0 +1,30 @@
+error[E0658]: references in constants may only refer to immutable values
+  --> $DIR/const_mut_refs.rs:31:17
+   |
+LL |     let _: [(); foo().bar()] = [(); 1];
+   |                 ^^^^^ constants require immutable values
+   |
+   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
+   = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+
+error[E0658]: references in constants may only refer to immutable values
+  --> $DIR/const_mut_refs.rs:33:21
+   |
+LL |     let _: [(); baz(&mut foo())] = [(); 2];
+   |                     ^^^^^^^^^^ constants require immutable values
+   |
+   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
+   = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+
+error[E0658]: references in constants may only refer to immutable values
+  --> $DIR/const_mut_refs.rs:35:22
+   |
+LL |     let _: [(); bazz(&mut foo())] = [(); 3];
+   |                      ^^^^^^^^^^ constants require immutable values
+   |
+   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
+   = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/consts/const-mut-refs/const_mut_refs.stderr
+++ b/src/test/ui/consts/const-mut-refs/const_mut_refs.stderr
@@ -1,30 +1,21 @@
-error[E0658]: references in constants may only refer to immutable values
+error[E0019]: mutable references are not allowed in constants
   --> $DIR/const_mut_refs.rs:31:17
    |
 LL |     let _: [(); foo().bar()] = [(); 1];
-   |                 ^^^^^ constants require immutable values
-   |
-   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
-   = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   |                 ^^^^^ `&mut` is only allowed in `const fn`
 
-error[E0658]: references in constants may only refer to immutable values
+error[E0019]: mutable references are not allowed in constants
   --> $DIR/const_mut_refs.rs:33:21
    |
 LL |     let _: [(); baz(&mut foo())] = [(); 2];
-   |                     ^^^^^^^^^^ constants require immutable values
-   |
-   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
-   = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   |                     ^^^^^^^^^^ `&mut` is only allowed in `const fn`
 
-error[E0658]: references in constants may only refer to immutable values
+error[E0019]: mutable references are not allowed in constants
   --> $DIR/const_mut_refs.rs:35:22
    |
 LL |     let _: [(); bazz(&mut foo())] = [(); 3];
-   |                      ^^^^^^^^^^ constants require immutable values
-   |
-   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
-   = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   |                      ^^^^^^^^^^ `&mut` is only allowed in `const fn`
 
 error: aborting due to 3 previous errors
 
-For more information about this error, try `rustc --explain E0658`.
+For more information about this error, try `rustc --explain E0019`.

--- a/src/test/ui/consts/const-mut-refs/const_mut_refs.stderr
+++ b/src/test/ui/consts/const-mut-refs/const_mut_refs.stderr
@@ -1,16 +1,16 @@
-error[E0019]: mutable references are not allowed in constants
+error[E0764]: mutable references are not allowed in constants
   --> $DIR/const_mut_refs.rs:31:17
    |
 LL |     let _: [(); foo().bar()] = [(); 1];
    |                 ^^^^^ `&mut` is only allowed in `const fn`
 
-error[E0019]: mutable references are not allowed in constants
+error[E0764]: mutable references are not allowed in constants
   --> $DIR/const_mut_refs.rs:33:21
    |
 LL |     let _: [(); baz(&mut foo())] = [(); 2];
    |                     ^^^^^^^^^^ `&mut` is only allowed in `const fn`
 
-error[E0019]: mutable references are not allowed in constants
+error[E0764]: mutable references are not allowed in constants
   --> $DIR/const_mut_refs.rs:35:22
    |
 LL |     let _: [(); bazz(&mut foo())] = [(); 3];
@@ -18,4 +18,4 @@ LL |     let _: [(); bazz(&mut foo())] = [(); 3];
 
 error: aborting due to 3 previous errors
 
-For more information about this error, try `rustc --explain E0019`.
+For more information about this error, try `rustc --explain E0764`.

--- a/src/test/ui/consts/const_let_assign3.rs
+++ b/src/test/ui/consts/const_let_assign3.rs
@@ -13,14 +13,14 @@ impl S {
 
 const FOO: S = {
     let mut s = S { state: 42 };
-    s.foo(3); //~ ERROR references in constants may only refer to immutable values
+    s.foo(3); //~ ERROR mutable references are not allowed in constants
     s
 };
 
 type Array = [u32; {
     let mut x = 2;
     let y = &mut x;
-//~^ ERROR references in constants may only refer to immutable values
+//~^ ERROR mutable references are not allowed in constants
     *y = 42;
 //~^ ERROR constant contains unimplemented expression type
     *y

--- a/src/test/ui/consts/const_let_assign3.stderr
+++ b/src/test/ui/consts/const_let_assign3.stderr
@@ -6,23 +6,17 @@ LL |         self.state = x;
    |
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
 
-error[E0658]: references in constants may only refer to immutable values
+error[E0019]: mutable references are not allowed in constants
   --> $DIR/const_let_assign3.rs:16:5
    |
 LL |     s.foo(3);
-   |     ^ constants require immutable values
-   |
-   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
-   = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   |     ^ `&mut` is only allowed in `const fn`
 
-error[E0658]: references in constants may only refer to immutable values
+error[E0019]: mutable references are not allowed in constants
   --> $DIR/const_let_assign3.rs:22:13
    |
 LL |     let y = &mut x;
-   |             ^^^^^^ constants require immutable values
-   |
-   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
-   = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   |             ^^^^^^ `&mut` is only allowed in `const fn`
 
 error[E0019]: constant contains unimplemented expression type
   --> $DIR/const_let_assign3.rs:24:5
@@ -34,5 +28,4 @@ LL |     *y = 42;
 
 error: aborting due to 4 previous errors
 
-Some errors have detailed explanations: E0019, E0658.
-For more information about an error, try `rustc --explain E0019`.
+For more information about this error, try `rustc --explain E0019`.

--- a/src/test/ui/consts/const_let_assign3.stderr
+++ b/src/test/ui/consts/const_let_assign3.stderr
@@ -6,13 +6,13 @@ LL |         self.state = x;
    |
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
 
-error[E0019]: mutable references are not allowed in constants
+error[E0764]: mutable references are not allowed in constants
   --> $DIR/const_let_assign3.rs:16:5
    |
 LL |     s.foo(3);
    |     ^ `&mut` is only allowed in `const fn`
 
-error[E0019]: mutable references are not allowed in constants
+error[E0764]: mutable references are not allowed in constants
   --> $DIR/const_let_assign3.rs:22:13
    |
 LL |     let y = &mut x;
@@ -28,4 +28,5 @@ LL |     *y = 42;
 
 error: aborting due to 4 previous errors
 
-For more information about this error, try `rustc --explain E0019`.
+Some errors have detailed explanations: E0019, E0764.
+For more information about an error, try `rustc --explain E0019`.

--- a/src/test/ui/consts/projection_qualif.mut_refs.stderr
+++ b/src/test/ui/consts/projection_qualif.mut_refs.stderr
@@ -1,3 +1,12 @@
+error[E0658]: references in constants may only refer to immutable values
+  --> $DIR/projection_qualif.rs:10:27
+   |
+LL |         let b: *mut u32 = &mut a;
+   |                           ^^^^^^ constants require immutable values
+   |
+   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
+   = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+
 error[E0658]: dereferencing raw pointers in constants is unstable
   --> $DIR/projection_qualif.rs:11:18
    |
@@ -7,6 +16,6 @@ LL |         unsafe { *b = 5; }
    = note: see issue #51911 <https://github.com/rust-lang/rust/issues/51911> for more information
    = help: add `#![feature(const_raw_ptr_deref)]` to the crate attributes to enable
 
-error: aborting due to previous error
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/consts/projection_qualif.mut_refs.stderr
+++ b/src/test/ui/consts/projection_qualif.mut_refs.stderr
@@ -1,4 +1,4 @@
-error[E0019]: mutable references are not allowed in constants
+error[E0764]: mutable references are not allowed in constants
   --> $DIR/projection_qualif.rs:10:27
    |
 LL |         let b: *mut u32 = &mut a;
@@ -15,5 +15,5 @@ LL |         unsafe { *b = 5; }
 
 error: aborting due to 2 previous errors
 
-Some errors have detailed explanations: E0019, E0658.
-For more information about an error, try `rustc --explain E0019`.
+Some errors have detailed explanations: E0658, E0764.
+For more information about an error, try `rustc --explain E0658`.

--- a/src/test/ui/consts/projection_qualif.mut_refs.stderr
+++ b/src/test/ui/consts/projection_qualif.mut_refs.stderr
@@ -1,11 +1,8 @@
-error[E0658]: references in constants may only refer to immutable values
+error[E0019]: mutable references are not allowed in constants
   --> $DIR/projection_qualif.rs:10:27
    |
 LL |         let b: *mut u32 = &mut a;
-   |                           ^^^^^^ constants require immutable values
-   |
-   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
-   = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   |                           ^^^^^^ `&mut` is only allowed in `const fn`
 
 error[E0658]: dereferencing raw pointers in constants is unstable
   --> $DIR/projection_qualif.rs:11:18
@@ -18,4 +15,5 @@ LL |         unsafe { *b = 5; }
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0658`.
+Some errors have detailed explanations: E0019, E0658.
+For more information about an error, try `rustc --explain E0019`.

--- a/src/test/ui/consts/projection_qualif.rs
+++ b/src/test/ui/consts/projection_qualif.rs
@@ -7,7 +7,7 @@ use std::cell::Cell;
 const FOO: &u32 = {
     let mut a = 42;
     {
-        let b: *mut u32 = &mut a; //~ ERROR may only refer to immutable values
+        let b: *mut u32 = &mut a; //~ ERROR mutable references are not allowed in constants
         unsafe { *b = 5; } //~ ERROR dereferencing raw pointers in constants
         //[stock]~^ contains unimplemented expression
     }

--- a/src/test/ui/consts/projection_qualif.rs
+++ b/src/test/ui/consts/projection_qualif.rs
@@ -7,7 +7,7 @@ use std::cell::Cell;
 const FOO: &u32 = {
     let mut a = 42;
     {
-        let b: *mut u32 = &mut a; //[stock]~ ERROR may only refer to immutable values
+        let b: *mut u32 = &mut a; //~ ERROR may only refer to immutable values
         unsafe { *b = 5; } //~ ERROR dereferencing raw pointers in constants
         //[stock]~^ contains unimplemented expression
     }

--- a/src/test/ui/consts/projection_qualif.stock.stderr
+++ b/src/test/ui/consts/projection_qualif.stock.stderr
@@ -1,4 +1,4 @@
-error[E0019]: mutable references are not allowed in constants
+error[E0764]: mutable references are not allowed in constants
   --> $DIR/projection_qualif.rs:10:27
    |
 LL |         let b: *mut u32 = &mut a;
@@ -23,5 +23,5 @@ LL |         unsafe { *b = 5; }
 
 error: aborting due to 3 previous errors
 
-Some errors have detailed explanations: E0019, E0658.
+Some errors have detailed explanations: E0019, E0658, E0764.
 For more information about an error, try `rustc --explain E0019`.

--- a/src/test/ui/consts/projection_qualif.stock.stderr
+++ b/src/test/ui/consts/projection_qualif.stock.stderr
@@ -1,11 +1,8 @@
-error[E0658]: references in constants may only refer to immutable values
+error[E0019]: mutable references are not allowed in constants
   --> $DIR/projection_qualif.rs:10:27
    |
 LL |         let b: *mut u32 = &mut a;
-   |                           ^^^^^^ constants require immutable values
-   |
-   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
-   = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   |                           ^^^^^^ `&mut` is only allowed in `const fn`
 
 error[E0658]: dereferencing raw pointers in constants is unstable
   --> $DIR/projection_qualif.rs:11:18

--- a/src/test/ui/consts/read_from_static_mut_ref.rs
+++ b/src/test/ui/consts/read_from_static_mut_ref.rs
@@ -1,8 +1,9 @@
+// We are keeping this test in case we decide to allow mutable references in statics again
 #![feature(const_mut_refs)]
 #![allow(const_err)]
 
 static OH_NO: &mut i32 = &mut 42;
-//~^ ERROR references in statics may only refer to immutable values
+//~^ ERROR mutable references are not allowed in statics
 fn main() {
     assert_eq!(*OH_NO, 42);
 }

--- a/src/test/ui/consts/read_from_static_mut_ref.rs
+++ b/src/test/ui/consts/read_from_static_mut_ref.rs
@@ -1,10 +1,8 @@
-// run-pass
 #![feature(const_mut_refs)]
 #![allow(const_err)]
 
-static OH_YES: &mut i32 = &mut 42;
-
+static OH_NO: &mut i32 = &mut 42;
+//~^ ERROR references in statics may only refer to immutable values
 fn main() {
-    // Make sure `OH_YES` can be read.
-    assert_eq!(*OH_YES, 42);
+    assert_eq!(*OH_NO, 42);
 }

--- a/src/test/ui/consts/read_from_static_mut_ref.stderr
+++ b/src/test/ui/consts/read_from_static_mut_ref.stderr
@@ -1,8 +1,8 @@
 error[E0658]: references in statics may only refer to immutable values
-  --> $DIR/static_mut_containing_mut_ref2.rs:7:46
+  --> $DIR/read_from_static_mut_ref.rs:4:26
    |
-LL | pub static mut STDERR_BUFFER: () = unsafe { *(&mut STDERR_BUFFER_SPACE) = 42; };
-   |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^ statics require immutable values
+LL | static OH_NO: &mut i32 = &mut 42;
+   |                          ^^^^^^^ statics require immutable values
    |
    = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable

--- a/src/test/ui/consts/read_from_static_mut_ref.stderr
+++ b/src/test/ui/consts/read_from_static_mut_ref.stderr
@@ -1,12 +1,9 @@
-error[E0658]: references in statics may only refer to immutable values
-  --> $DIR/read_from_static_mut_ref.rs:4:26
+error[E0019]: mutable references are not allowed in statics
+  --> $DIR/read_from_static_mut_ref.rs:5:26
    |
 LL | static OH_NO: &mut i32 = &mut 42;
-   |                          ^^^^^^^ statics require immutable values
-   |
-   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
-   = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   |                          ^^^^^^^ `&mut` is only allowed in `const fn`
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0658`.
+For more information about this error, try `rustc --explain E0019`.

--- a/src/test/ui/consts/read_from_static_mut_ref.stderr
+++ b/src/test/ui/consts/read_from_static_mut_ref.stderr
@@ -1,4 +1,4 @@
-error[E0019]: mutable references are not allowed in statics
+error[E0764]: mutable references are not allowed in statics
   --> $DIR/read_from_static_mut_ref.rs:5:26
    |
 LL | static OH_NO: &mut i32 = &mut 42;
@@ -6,4 +6,4 @@ LL | static OH_NO: &mut i32 = &mut 42;
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0019`.
+For more information about this error, try `rustc --explain E0764`.

--- a/src/test/ui/consts/static_mut_containing_mut_ref2.mut_refs.stderr
+++ b/src/test/ui/consts/static_mut_containing_mut_ref2.mut_refs.stderr
@@ -1,12 +1,9 @@
-error[E0658]: references in statics may only refer to immutable values
+error[E0019]: mutable references are not allowed in statics
   --> $DIR/static_mut_containing_mut_ref2.rs:7:46
    |
 LL | pub static mut STDERR_BUFFER: () = unsafe { *(&mut STDERR_BUFFER_SPACE) = 42; };
-   |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^ statics require immutable values
-   |
-   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
-   = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^ `&mut` is only allowed in `const fn`
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0658`.
+For more information about this error, try `rustc --explain E0019`.

--- a/src/test/ui/consts/static_mut_containing_mut_ref2.mut_refs.stderr
+++ b/src/test/ui/consts/static_mut_containing_mut_ref2.mut_refs.stderr
@@ -1,4 +1,4 @@
-error[E0019]: mutable references are not allowed in statics
+error[E0764]: mutable references are not allowed in statics
   --> $DIR/static_mut_containing_mut_ref2.rs:7:46
    |
 LL | pub static mut STDERR_BUFFER: () = unsafe { *(&mut STDERR_BUFFER_SPACE) = 42; };
@@ -6,4 +6,4 @@ LL | pub static mut STDERR_BUFFER: () = unsafe { *(&mut STDERR_BUFFER_SPACE) = 4
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0019`.
+For more information about this error, try `rustc --explain E0764`.

--- a/src/test/ui/consts/static_mut_containing_mut_ref2.rs
+++ b/src/test/ui/consts/static_mut_containing_mut_ref2.rs
@@ -5,7 +5,7 @@
 static mut STDERR_BUFFER_SPACE: u8 = 0;
 
 pub static mut STDERR_BUFFER: () = unsafe { *(&mut STDERR_BUFFER_SPACE) = 42; };
-//~^ ERROR references in statics may only refer to immutable values
+//~^ ERROR  mutable references are not allowed in statics
 //[stock]~| ERROR static contains unimplemented expression type
 
 fn main() {}

--- a/src/test/ui/consts/static_mut_containing_mut_ref2.rs
+++ b/src/test/ui/consts/static_mut_containing_mut_ref2.rs
@@ -5,8 +5,7 @@
 static mut STDERR_BUFFER_SPACE: u8 = 0;
 
 pub static mut STDERR_BUFFER: () = unsafe { *(&mut STDERR_BUFFER_SPACE) = 42; };
-//[mut_refs]~^ ERROR could not evaluate static initializer
-//[stock]~^^ ERROR references in statics may only refer to immutable values
+//~^ ERROR references in statics may only refer to immutable values
 //[stock]~| ERROR static contains unimplemented expression type
 
 fn main() {}

--- a/src/test/ui/consts/static_mut_containing_mut_ref2.stock.stderr
+++ b/src/test/ui/consts/static_mut_containing_mut_ref2.stock.stderr
@@ -1,11 +1,8 @@
-error[E0658]: references in statics may only refer to immutable values
+error[E0019]: mutable references are not allowed in statics
   --> $DIR/static_mut_containing_mut_ref2.rs:7:46
    |
 LL | pub static mut STDERR_BUFFER: () = unsafe { *(&mut STDERR_BUFFER_SPACE) = 42; };
-   |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^ statics require immutable values
-   |
-   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
-   = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^ `&mut` is only allowed in `const fn`
 
 error[E0019]: static contains unimplemented expression type
   --> $DIR/static_mut_containing_mut_ref2.rs:7:45
@@ -17,5 +14,4 @@ LL | pub static mut STDERR_BUFFER: () = unsafe { *(&mut STDERR_BUFFER_SPACE) = 4
 
 error: aborting due to 2 previous errors
 
-Some errors have detailed explanations: E0019, E0658.
-For more information about an error, try `rustc --explain E0019`.
+For more information about this error, try `rustc --explain E0019`.

--- a/src/test/ui/consts/static_mut_containing_mut_ref2.stock.stderr
+++ b/src/test/ui/consts/static_mut_containing_mut_ref2.stock.stderr
@@ -1,4 +1,4 @@
-error[E0019]: mutable references are not allowed in statics
+error[E0764]: mutable references are not allowed in statics
   --> $DIR/static_mut_containing_mut_ref2.rs:7:46
    |
 LL | pub static mut STDERR_BUFFER: () = unsafe { *(&mut STDERR_BUFFER_SPACE) = 42; };
@@ -14,4 +14,5 @@ LL | pub static mut STDERR_BUFFER: () = unsafe { *(&mut STDERR_BUFFER_SPACE) = 4
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0019`.
+Some errors have detailed explanations: E0019, E0764.
+For more information about an error, try `rustc --explain E0019`.

--- a/src/test/ui/error-codes/E0017.rs
+++ b/src/test/ui/error-codes/E0017.rs
@@ -2,10 +2,10 @@ static X: i32 = 1;
 const C: i32 = 2;
 static mut M: i32 = 3;
 
-const CR: &'static mut i32 = &mut C; //~ ERROR E0019
-static STATIC_REF: &'static mut i32 = &mut X; //~ ERROR E0019
+const CR: &'static mut i32 = &mut C; //~ ERROR E0764
+static STATIC_REF: &'static mut i32 = &mut X; //~ ERROR E0764
                                               //~| ERROR E0019
                                               //~| ERROR cannot borrow
-static CONST_REF: &'static mut i32 = &mut C; //~ ERROR E0019
-static STATIC_MUT_REF: &'static mut i32 = unsafe { &mut M }; //~ ERROR E0019
+static CONST_REF: &'static mut i32 = &mut C; //~ ERROR E0764
+static STATIC_MUT_REF: &'static mut i32 = unsafe { &mut M }; //~ ERROR E0764
 fn main() {}

--- a/src/test/ui/error-codes/E0017.rs
+++ b/src/test/ui/error-codes/E0017.rs
@@ -2,10 +2,10 @@ static X: i32 = 1;
 const C: i32 = 2;
 static mut M: i32 = 3;
 
-const CR: &'static mut i32 = &mut C; //~ ERROR E0658
-static STATIC_REF: &'static mut i32 = &mut X; //~ ERROR E0658
+const CR: &'static mut i32 = &mut C; //~ ERROR E0019
+static STATIC_REF: &'static mut i32 = &mut X; //~ ERROR E0019
                                               //~| ERROR E0019
                                               //~| ERROR cannot borrow
-static CONST_REF: &'static mut i32 = &mut C; //~ ERROR E0658
-static STATIC_MUT_REF: &'static mut i32 = unsafe { &mut M }; //~ ERROR E0658
+static CONST_REF: &'static mut i32 = &mut C; //~ ERROR E0019
+static STATIC_MUT_REF: &'static mut i32 = unsafe { &mut M }; //~ ERROR E0019
 fn main() {}

--- a/src/test/ui/error-codes/E0017.stderr
+++ b/src/test/ui/error-codes/E0017.stderr
@@ -1,4 +1,4 @@
-error[E0019]: mutable references are not allowed in constants
+error[E0764]: mutable references are not allowed in constants
   --> $DIR/E0017.rs:5:30
    |
 LL | const CR: &'static mut i32 = &mut C;
@@ -12,7 +12,7 @@ LL | static STATIC_REF: &'static mut i32 = &mut X;
    |
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
 
-error[E0019]: mutable references are not allowed in statics
+error[E0764]: mutable references are not allowed in statics
   --> $DIR/E0017.rs:6:39
    |
 LL | static STATIC_REF: &'static mut i32 = &mut X;
@@ -24,13 +24,13 @@ error[E0596]: cannot borrow immutable static item `X` as mutable
 LL | static STATIC_REF: &'static mut i32 = &mut X;
    |                                       ^^^^^^ cannot borrow as mutable
 
-error[E0019]: mutable references are not allowed in statics
+error[E0764]: mutable references are not allowed in statics
   --> $DIR/E0017.rs:9:38
    |
 LL | static CONST_REF: &'static mut i32 = &mut C;
    |                                      ^^^^^^ `&mut` is only allowed in `const fn`
 
-error[E0019]: mutable references are not allowed in statics
+error[E0764]: mutable references are not allowed in statics
   --> $DIR/E0017.rs:10:52
    |
 LL | static STATIC_MUT_REF: &'static mut i32 = unsafe { &mut M };
@@ -38,5 +38,5 @@ LL | static STATIC_MUT_REF: &'static mut i32 = unsafe { &mut M };
 
 error: aborting due to 6 previous errors
 
-Some errors have detailed explanations: E0019, E0596.
+Some errors have detailed explanations: E0019, E0596, E0764.
 For more information about an error, try `rustc --explain E0019`.

--- a/src/test/ui/error-codes/E0017.stderr
+++ b/src/test/ui/error-codes/E0017.stderr
@@ -1,11 +1,8 @@
-error[E0658]: references in constants may only refer to immutable values
+error[E0019]: mutable references are not allowed in constants
   --> $DIR/E0017.rs:5:30
    |
 LL | const CR: &'static mut i32 = &mut C;
-   |                              ^^^^^^ constants require immutable values
-   |
-   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
-   = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   |                              ^^^^^^ `&mut` is only allowed in `const fn`
 
 error[E0019]: static contains unimplemented expression type
   --> $DIR/E0017.rs:6:39
@@ -15,14 +12,11 @@ LL | static STATIC_REF: &'static mut i32 = &mut X;
    |
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
 
-error[E0658]: references in statics may only refer to immutable values
+error[E0019]: mutable references are not allowed in statics
   --> $DIR/E0017.rs:6:39
    |
 LL | static STATIC_REF: &'static mut i32 = &mut X;
-   |                                       ^^^^^^ statics require immutable values
-   |
-   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
-   = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   |                                       ^^^^^^ `&mut` is only allowed in `const fn`
 
 error[E0596]: cannot borrow immutable static item `X` as mutable
   --> $DIR/E0017.rs:6:39
@@ -30,25 +24,19 @@ error[E0596]: cannot borrow immutable static item `X` as mutable
 LL | static STATIC_REF: &'static mut i32 = &mut X;
    |                                       ^^^^^^ cannot borrow as mutable
 
-error[E0658]: references in statics may only refer to immutable values
+error[E0019]: mutable references are not allowed in statics
   --> $DIR/E0017.rs:9:38
    |
 LL | static CONST_REF: &'static mut i32 = &mut C;
-   |                                      ^^^^^^ statics require immutable values
-   |
-   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
-   = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   |                                      ^^^^^^ `&mut` is only allowed in `const fn`
 
-error[E0658]: references in statics may only refer to immutable values
+error[E0019]: mutable references are not allowed in statics
   --> $DIR/E0017.rs:10:52
    |
 LL | static STATIC_MUT_REF: &'static mut i32 = unsafe { &mut M };
-   |                                                    ^^^^^^ statics require immutable values
-   |
-   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
-   = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   |                                                    ^^^^^^ `&mut` is only allowed in `const fn`
 
 error: aborting due to 6 previous errors
 
-Some errors have detailed explanations: E0019, E0596, E0658.
+Some errors have detailed explanations: E0019, E0596.
 For more information about an error, try `rustc --explain E0019`.

--- a/src/test/ui/error-codes/E0388.rs
+++ b/src/test/ui/error-codes/E0388.rs
@@ -1,10 +1,10 @@
 static X: i32 = 1;
 const C: i32 = 2;
 
-const CR: &'static mut i32 = &mut C; //~ ERROR E0658
-static STATIC_REF: &'static mut i32 = &mut X; //~ ERROR E0658
+const CR: &'static mut i32 = &mut C; //~ ERROR E0019
+static STATIC_REF: &'static mut i32 = &mut X; //~ ERROR E0019
                                               //~| ERROR cannot borrow
                                               //~| ERROR E0019
-static CONST_REF: &'static mut i32 = &mut C; //~ ERROR E0658
+static CONST_REF: &'static mut i32 = &mut C; //~ ERROR E0019
 
 fn main() {}

--- a/src/test/ui/error-codes/E0388.rs
+++ b/src/test/ui/error-codes/E0388.rs
@@ -1,10 +1,10 @@
 static X: i32 = 1;
 const C: i32 = 2;
 
-const CR: &'static mut i32 = &mut C; //~ ERROR E0019
+const CR: &'static mut i32 = &mut C; //~ ERROR E0764
 static STATIC_REF: &'static mut i32 = &mut X; //~ ERROR E0019
                                               //~| ERROR cannot borrow
-                                              //~| ERROR E0019
-static CONST_REF: &'static mut i32 = &mut C; //~ ERROR E0019
+                                              //~| ERROR E0764
+static CONST_REF: &'static mut i32 = &mut C; //~ ERROR E0764
 
 fn main() {}

--- a/src/test/ui/error-codes/E0388.stderr
+++ b/src/test/ui/error-codes/E0388.stderr
@@ -1,11 +1,8 @@
-error[E0658]: references in constants may only refer to immutable values
+error[E0019]: mutable references are not allowed in constants
   --> $DIR/E0388.rs:4:30
    |
 LL | const CR: &'static mut i32 = &mut C;
-   |                              ^^^^^^ constants require immutable values
-   |
-   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
-   = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   |                              ^^^^^^ `&mut` is only allowed in `const fn`
 
 error[E0019]: static contains unimplemented expression type
   --> $DIR/E0388.rs:5:39
@@ -15,14 +12,11 @@ LL | static STATIC_REF: &'static mut i32 = &mut X;
    |
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
 
-error[E0658]: references in statics may only refer to immutable values
+error[E0019]: mutable references are not allowed in statics
   --> $DIR/E0388.rs:5:39
    |
 LL | static STATIC_REF: &'static mut i32 = &mut X;
-   |                                       ^^^^^^ statics require immutable values
-   |
-   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
-   = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   |                                       ^^^^^^ `&mut` is only allowed in `const fn`
 
 error[E0596]: cannot borrow immutable static item `X` as mutable
   --> $DIR/E0388.rs:5:39
@@ -30,16 +24,13 @@ error[E0596]: cannot borrow immutable static item `X` as mutable
 LL | static STATIC_REF: &'static mut i32 = &mut X;
    |                                       ^^^^^^ cannot borrow as mutable
 
-error[E0658]: references in statics may only refer to immutable values
+error[E0019]: mutable references are not allowed in statics
   --> $DIR/E0388.rs:8:38
    |
 LL | static CONST_REF: &'static mut i32 = &mut C;
-   |                                      ^^^^^^ statics require immutable values
-   |
-   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
-   = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   |                                      ^^^^^^ `&mut` is only allowed in `const fn`
 
 error: aborting due to 5 previous errors
 
-Some errors have detailed explanations: E0019, E0596, E0658.
+Some errors have detailed explanations: E0019, E0596.
 For more information about an error, try `rustc --explain E0019`.

--- a/src/test/ui/error-codes/E0388.stderr
+++ b/src/test/ui/error-codes/E0388.stderr
@@ -1,4 +1,4 @@
-error[E0019]: mutable references are not allowed in constants
+error[E0764]: mutable references are not allowed in constants
   --> $DIR/E0388.rs:4:30
    |
 LL | const CR: &'static mut i32 = &mut C;
@@ -12,7 +12,7 @@ LL | static STATIC_REF: &'static mut i32 = &mut X;
    |
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
 
-error[E0019]: mutable references are not allowed in statics
+error[E0764]: mutable references are not allowed in statics
   --> $DIR/E0388.rs:5:39
    |
 LL | static STATIC_REF: &'static mut i32 = &mut X;
@@ -24,7 +24,7 @@ error[E0596]: cannot borrow immutable static item `X` as mutable
 LL | static STATIC_REF: &'static mut i32 = &mut X;
    |                                       ^^^^^^ cannot borrow as mutable
 
-error[E0019]: mutable references are not allowed in statics
+error[E0764]: mutable references are not allowed in statics
   --> $DIR/E0388.rs:8:38
    |
 LL | static CONST_REF: &'static mut i32 = &mut C;
@@ -32,5 +32,5 @@ LL | static CONST_REF: &'static mut i32 = &mut C;
 
 error: aborting due to 5 previous errors
 
-Some errors have detailed explanations: E0019, E0596.
+Some errors have detailed explanations: E0019, E0596, E0764.
 For more information about an error, try `rustc --explain E0019`.

--- a/src/test/ui/issues/issue-17718-const-bad-values.rs
+++ b/src/test/ui/issues/issue-17718-const-bad-values.rs
@@ -1,10 +1,10 @@
 const C1: &'static mut [usize] = &mut [];
-//~^ ERROR: references in constants may only refer to immutable values
+//~^ ERROR: mutable references are not allowed in constants
 
 static mut S: usize = 3;
 const C2: &'static mut usize = unsafe { &mut S };
 //~^ ERROR: constants cannot refer to statics
 //~| ERROR: constants cannot refer to statics
-//~| ERROR: references in constants may only refer to immutable values
+//~| ERROR: mutable references are not allowed in constants
 
 fn main() {}

--- a/src/test/ui/issues/issue-17718-const-bad-values.stderr
+++ b/src/test/ui/issues/issue-17718-const-bad-values.stderr
@@ -1,11 +1,8 @@
-error[E0658]: references in constants may only refer to immutable values
+error[E0019]: mutable references are not allowed in constants
   --> $DIR/issue-17718-const-bad-values.rs:1:34
    |
 LL | const C1: &'static mut [usize] = &mut [];
-   |                                  ^^^^^^^ constants require immutable values
-   |
-   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
-   = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   |                                  ^^^^^^^ `&mut` is only allowed in `const fn`
 
 error[E0013]: constants cannot refer to statics
   --> $DIR/issue-17718-const-bad-values.rs:5:46
@@ -23,16 +20,13 @@ LL | const C2: &'static mut usize = unsafe { &mut S };
    |
    = help: consider extracting the value of the `static` to a `const`, and referring to that
 
-error[E0658]: references in constants may only refer to immutable values
+error[E0019]: mutable references are not allowed in constants
   --> $DIR/issue-17718-const-bad-values.rs:5:41
    |
 LL | const C2: &'static mut usize = unsafe { &mut S };
-   |                                         ^^^^^^ constants require immutable values
-   |
-   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
-   = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   |                                         ^^^^^^ `&mut` is only allowed in `const fn`
 
 error: aborting due to 4 previous errors
 
-Some errors have detailed explanations: E0013, E0658.
+Some errors have detailed explanations: E0013, E0019.
 For more information about an error, try `rustc --explain E0013`.

--- a/src/test/ui/issues/issue-17718-const-bad-values.stderr
+++ b/src/test/ui/issues/issue-17718-const-bad-values.stderr
@@ -1,4 +1,4 @@
-error[E0019]: mutable references are not allowed in constants
+error[E0764]: mutable references are not allowed in constants
   --> $DIR/issue-17718-const-bad-values.rs:1:34
    |
 LL | const C1: &'static mut [usize] = &mut [];
@@ -20,7 +20,7 @@ LL | const C2: &'static mut usize = unsafe { &mut S };
    |
    = help: consider extracting the value of the `static` to a `const`, and referring to that
 
-error[E0019]: mutable references are not allowed in constants
+error[E0764]: mutable references are not allowed in constants
   --> $DIR/issue-17718-const-bad-values.rs:5:41
    |
 LL | const C2: &'static mut usize = unsafe { &mut S };
@@ -28,5 +28,5 @@ LL | const C2: &'static mut usize = unsafe { &mut S };
 
 error: aborting due to 4 previous errors
 
-Some errors have detailed explanations: E0013, E0019.
+Some errors have detailed explanations: E0013, E0764.
 For more information about an error, try `rustc --explain E0013`.

--- a/src/test/ui/issues/issue-46604.rs
+++ b/src/test/ui/issues/issue-46604.rs
@@ -1,4 +1,4 @@
-static buf: &mut [u8] = &mut [1u8,2,3,4,5,7];   //~ ERROR E0658
+static buf: &mut [u8] = &mut [1u8,2,3,4,5,7];   //~ ERROR E0019
 fn write<T: AsRef<[u8]>>(buffer: T) { }
 
 fn main() {

--- a/src/test/ui/issues/issue-46604.rs
+++ b/src/test/ui/issues/issue-46604.rs
@@ -1,4 +1,4 @@
-static buf: &mut [u8] = &mut [1u8,2,3,4,5,7];   //~ ERROR E0019
+static buf: &mut [u8] = &mut [1u8,2,3,4,5,7];   //~ ERROR E0764
 fn write<T: AsRef<[u8]>>(buffer: T) { }
 
 fn main() {

--- a/src/test/ui/issues/issue-46604.stderr
+++ b/src/test/ui/issues/issue-46604.stderr
@@ -1,4 +1,4 @@
-error[E0019]: mutable references are not allowed in statics
+error[E0764]: mutable references are not allowed in statics
   --> $DIR/issue-46604.rs:1:25
    |
 LL | static buf: &mut [u8] = &mut [1u8,2,3,4,5,7];
@@ -12,5 +12,5 @@ LL |     buf[0]=2;
 
 error: aborting due to 2 previous errors
 
-Some errors have detailed explanations: E0019, E0594.
-For more information about an error, try `rustc --explain E0019`.
+Some errors have detailed explanations: E0594, E0764.
+For more information about an error, try `rustc --explain E0594`.

--- a/src/test/ui/issues/issue-46604.stderr
+++ b/src/test/ui/issues/issue-46604.stderr
@@ -1,11 +1,8 @@
-error[E0658]: references in statics may only refer to immutable values
+error[E0019]: mutable references are not allowed in statics
   --> $DIR/issue-46604.rs:1:25
    |
 LL | static buf: &mut [u8] = &mut [1u8,2,3,4,5,7];
-   |                         ^^^^^^^^^^^^^^^^^^^^ statics require immutable values
-   |
-   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
-   = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   |                         ^^^^^^^^^^^^^^^^^^^^ `&mut` is only allowed in `const fn`
 
 error[E0594]: cannot assign to `buf[_]`, as `buf` is an immutable static item
   --> $DIR/issue-46604.rs:6:5
@@ -15,5 +12,5 @@ LL |     buf[0]=2;
 
 error: aborting due to 2 previous errors
 
-Some errors have detailed explanations: E0594, E0658.
-For more information about an error, try `rustc --explain E0594`.
+Some errors have detailed explanations: E0019, E0594.
+For more information about an error, try `rustc --explain E0019`.


### PR DESCRIPTION
PR to address #71212

cc: @ecstatic-morse 