### PR TITLE
run-make regression test for issue #70924.

### DIFF
--- a/src/test/run-make-fulldeps/incr-add-rust-src-component/Makefile
+++ b/src/test/run-make-fulldeps/incr-add-rust-src-component/Makefile
@@ -1,0 +1,39 @@
+-include ../tools.mk
+
+# rust-lang/rust#70924: Test that if we add rust-src component in between two
+# incremetnal compiles, the compiler does not ICE on the second.
+
+SYSROOT:=$(shell $(RUSTC) --print sysroot)
+FAKEROOT=$(TMPDIR)/fakeroot
+INCR=$(TMPDIR)/incr
+
+# Make a local copy of the sysroot; then remove the rust-src part of it, if
+# present, for the *first* build. Then put in a facsimile of the rust-src
+# component for the second build, in order to expose the ICE from issue #70924.
+#
+# Note that it is much easier to just do `cp -a $(SYSROOT)/* $(FAKEROOT)` as a
+# first step, but I am concerned that would be too expensive in a unit test
+# compared to making symbolic links.
+#
+# Anyway, the pattern you'll see here is: For every prefix in
+# root/lib/rustlib/src, link all of prefix parent content, then remove the
+# prefix, then loop on the next prefix. This way, we basically create a copy of
+# the context around root/lib/rustlib/src, and can freely add/remove the src
+# component itself.
+all:
+	mkdir $(FAKEROOT)
+	ln -s $(SYSROOT)/* $(FAKEROOT)
+	rm -f $(FAKEROOT)/lib
+	mkdir $(FAKEROOT)/lib
+	ln -s $(SYSROOT)/lib/* $(FAKEROOT)/lib
+	rm -f $(FAKEROOT)/lib/rustlib
+	mkdir $(FAKEROOT)/lib/rustlib
+	ln -s $(SYSROOT)/lib/rustlib/* $(FAKEROOT)/lib/rustlib
+	rm -f $(FAKEROOT)/lib/rustlib/src
+	mkdir $(FAKEROOT)/lib/rustlib/src
+	ln -s $(SYSROOT)/lib/rustlib/src/* $(FAKEROOT)/lib/rustlib/src
+	rm -f $(FAKEROOT)/lib/rustlib/src/rust
+	$(RUSTC) --sysroot $(FAKEROOT) -C incremental=$(INCR) main.rs
+	mkdir -p $(FAKEROOT)/lib/rustlib/src/rust/src/libstd
+	touch $(FAKEROOT)/lib/rustlib/src/rust/src/libstd/lib.rs
+	$(RUSTC) --sysroot $(FAKEROOT) -C incremental=$(INCR) main.rs

--- a/src/test/run-make-fulldeps/incr-add-rust-src-component/Makefile
+++ b/src/test/run-make-fulldeps/incr-add-rust-src-component/Makefile
@@ -3,6 +3,11 @@
 # rust-lang/rust#70924: Test that if we add rust-src component in between two
 # incremetnal compiles, the compiler does not ICE on the second.
 
+# This test uses `ln -s` rather than copying to save testing time, but its
+# usage doesn't work on windows. So ignore windows.
+
+# ignore-windows
+
 SYSROOT:=$(shell $(RUSTC) --print sysroot)
 FAKEROOT=$(TMPDIR)/fakeroot
 INCR=$(TMPDIR)/incr

--- a/src/test/run-make-fulldeps/incr-add-rust-src-component/main.rs
+++ b/src/test/run-make-fulldeps/incr-add-rust-src-component/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello World");
+}


### PR DESCRIPTION
Sometime after my PR #72767 (to fix issue #70924) landed, I realized that I *could* make a local regression test, thanks to `rustc --print sysroot`: I can make a fresh "copy" (really mostly symlinks) of the sysroot, and then modify it to recreate the terms of this bug.