### PR TITLE
Bump libc dependency to latest version (0.2.71)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1853,9 +1853,9 @@ checksum = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
 
 [[package]]
 name = "libc"
-version = "0.2.69"
+version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99e85c08494b21a9054e7fe1374a732aeadaff3980b6990b94bfd3a70f690005"
+checksum = "9457b06509d27052635f90d6466700c65095fdf75409b3fbdd903e988b886f49"
 dependencies = [
  "rustc-std-workspace-core",
 ]


### PR DESCRIPTION
Hello, 

Just a quick version bump PR. The rust-psp group had some changes merged to libc recently but they haven't made it into the compiler. We're looking to remove our forked version from our Xargo.toml. Thanks.