### PR TITLE
Don't move cursor in search box when using arrows to navigate results

### DIFF
--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -1396,6 +1396,7 @@ function defocusSearchBar() {
 
                     addClass(actives[currentTab][0].previousElementSibling, "highlighted");
                     removeClass(actives[currentTab][0], "highlighted");
+                    e.preventDefault();
                 } else if (e.which === 40) { // down
                     if (!actives[currentTab].length) {
                         var results = document.getElementById("results").childNodes;
@@ -1409,6 +1410,7 @@ function defocusSearchBar() {
                         addClass(actives[currentTab][0].nextElementSibling, "highlighted");
                         removeClass(actives[currentTab][0], "highlighted");
                     }
+                    e.preventDefault();
                 } else if (e.which === 13) { // return
                     if (actives[currentTab].length) {
                         document.location.href =


### PR DESCRIPTION
## What happens

- Go to https://doc.rust-lang.org/stable/std/index.html
- Press 's' to focus the search box
- Type a query like 'test'
- Press the down arrow one or more times to change which search result is highlighted
- Press the up arrow once to go up one search result
- Notice the cursor in the search box is now at the beginning of your query, such that if you now typed 'a' the search box would contain 'atest', when it would be expected that the cursor would have remained where it was and if you typed 'a' at this point it would result in 'testa'
- Press the down arrow once to go down one search result
- Now notice the cursor is at the end of your query again

## What I expected

I expected that changing which search result was highlighted using the up and down arrows would have no effect on where the cursor was in the search box. 

## The fix

This PR prevents the default action of the up and down arrows when the custom keydown events are happening during a search.
