### PR TITLE
Fix codegen tests for RISC-V

### DIFF
--- a/src/test/codegen/abi-main-signature-16bit-c-int.rs
+++ b/src/test/codegen/abi-main-signature-16bit-c-int.rs
@@ -10,6 +10,7 @@
 // ignore-mips64
 // ignore-powerpc
 // ignore-powerpc64
+// ignore-riscv64
 // ignore-s390x
 // ignore-sparc
 // ignore-sparc64

--- a/src/test/codegen/abi-sysv64.rs
+++ b/src/test/codegen/abi-sysv64.rs
@@ -4,6 +4,7 @@
 
 // ignore-arm
 // ignore-aarch64
+// ignore-riscv64 sysv64 not supported
 
 // compile-flags: -C no-prepopulate-passes
 

--- a/src/test/codegen/abi-x86-interrupt.rs
+++ b/src/test/codegen/abi-x86-interrupt.rs
@@ -4,6 +4,7 @@
 
 // ignore-arm
 // ignore-aarch64
+// ignore-riscv64 x86-interrupt is not supported
 
 // compile-flags: -C no-prepopulate-passes
 

--- a/src/test/codegen/catch-unwind.rs
+++ b/src/test/codegen/catch-unwind.rs
@@ -1,5 +1,14 @@
 // compile-flags: -O
 
+// On x86 the closure is inlined in foo() producting something like
+// define i32 @foo() [...] {
+// tail call void @bar() [...]
+// ret i32 0
+// }
+// On riscv the closure is another function, placed before fn foo so CHECK can't
+// find it
+// ignore-riscv64 FIXME
+
 #![crate_type = "lib"]
 
 extern "C" {

--- a/src/test/codegen/fastcall-inreg.rs
+++ b/src/test/codegen/fastcall-inreg.rs
@@ -17,6 +17,7 @@
 // ignore-powerpc64le
 // ignore-powerpc
 // ignore-r600
+// ignore-riscv64
 // ignore-amdgcn
 // ignore-sparc
 // ignore-sparc64

--- a/src/test/codegen/repr-transparent-aggregates-1.rs
+++ b/src/test/codegen/repr-transparent-aggregates-1.rs
@@ -7,6 +7,7 @@
 // ignore-mips64
 // ignore-powerpc
 // ignore-powerpc64
+// ignore-riscv64 see codegen/riscv-abi
 // ignore-windows
 // See repr-transparent.rs
 

--- a/src/test/codegen/repr-transparent-aggregates-2.rs
+++ b/src/test/codegen/repr-transparent-aggregates-2.rs
@@ -6,6 +6,7 @@
 // ignore-powerpc
 // ignore-powerpc64
 // ignore-powerpc64le
+// ignore-riscv64 see codegen/riscv-abi
 // ignore-s390x
 // ignore-sparc
 // ignore-sparc64

--- a/src/test/codegen/repr-transparent.rs
+++ b/src/test/codegen/repr-transparent.rs
@@ -1,5 +1,8 @@
 // compile-flags: -C no-prepopulate-passes
 
+// ignore-riscv64 riscv64 has an i128 type used with test_Vector
+// see codegen/riscv-abi for riscv functiona call tests
+
 #![crate_type="lib"]
 #![feature(repr_simd, transparent_unions)]
 

--- a/src/test/codegen/riscv-abi/call-llvm-intrinsics.rs
+++ b/src/test/codegen/riscv-abi/call-llvm-intrinsics.rs
@@ -1,6 +1,6 @@
 // compile-flags: -C no-prepopulate-passes
 
-// ignore-riscv64
+// only-riscv64
 
 #![feature(link_llvm_intrinsics)]
 #![crate_type = "lib"]
@@ -23,7 +23,8 @@ pub fn do_call() {
 
     unsafe {
         // Ensure that we `call` LLVM intrinsics instead of trying to `invoke` them
-        // CHECK: call float @llvm.sqrt.f32(float 4.000000e+00
+        // CHECK: store float 4.000000e+00, float* %{{.}}, align 4
+        // CHECK: call float @llvm.sqrt.f32(float %{{.}}
         sqrt(4.0);
     }
 }

--- a/src/test/codegen/riscv-abi/riscv64-lp64-lp64f-lp64d-abi.rs
+++ b/src/test/codegen/riscv-abi/riscv64-lp64-lp64f-lp64d-abi.rs
@@ -39,12 +39,12 @@ pub extern "C" fn f_scalar_4(x: i64) -> i64 {
     x
 }
 
-// CHECK: define float @f_fp_scalar_1(float)
+// CHECK: define float @f_fp_scalar_1(float %0)
 #[no_mangle]
 pub extern "C" fn f_fp_scalar_1(x: f32) -> f32 {
     x
 }
-// CHECK: define double @f_fp_scalar_2(double)
+// CHECK: define double @f_fp_scalar_2(double %0)
 #[no_mangle]
 pub extern "C" fn f_fp_scalar_2(x: f64) -> f64 {
     x
@@ -67,7 +67,7 @@ pub struct Tiny {
     d: u16,
 }
 
-// CHECK: define void @f_agg_tiny(i64)
+// CHECK: define void @f_agg_tiny(i64 %0)
 #[no_mangle]
 pub extern "C" fn f_agg_tiny(mut e: Tiny) {
     e.a += e.b;
@@ -86,7 +86,7 @@ pub struct Small {
     b: *mut i64,
 }
 
-// CHECK: define void @f_agg_small([2 x i64])
+// CHECK: define void @f_agg_small([2 x i64] %0)
 #[no_mangle]
 pub extern "C" fn f_agg_small(mut x: Small) {
     x.a += unsafe { *x.b };
@@ -104,7 +104,7 @@ pub struct SmallAligned {
     a: i128,
 }
 
-// CHECK: define void @f_agg_small_aligned(i128)
+// CHECK: define void @f_agg_small_aligned(i128 %0)
 #[no_mangle]
 pub extern "C" fn f_agg_small_aligned(mut x: SmallAligned) {
     x.a += x.a;
@@ -130,7 +130,7 @@ pub extern "C" fn f_agg_large_ret(i: i32, j: i8) -> Large {
     Large { a: 1, b: 2, c: 3, d: 4 }
 }
 
-// CHECK: define void @f_scalar_stack_1(i64, [2 x i64], i128, %Large* {{.*}}%d, i8 zeroext %e, i8 signext %f, i8 %g, i8 %h)
+// CHECK: define void @f_scalar_stack_1(i64 %0, [2 x i64] %1, i128 %2, %Large* {{.*}}%d, i8 zeroext %e, i8 signext %f, i8 %g, i8 %h)
 #[no_mangle]
 pub extern "C" fn f_scalar_stack_1(
     a: Tiny,
@@ -144,7 +144,7 @@ pub extern "C" fn f_scalar_stack_1(
 ) {
 }
 
-// CHECK: define void @f_scalar_stack_2(%Large* {{.*}}sret{{.*}}, i64 %a, i128, i128, i64 %d, i8 zeroext %e, i8 %f, i8 %g)
+// CHECK: define void @f_scalar_stack_2(%Large* {{.*}}sret{{.*}} %0, i64 %a, i128 %1, i128 %2, i64 %d, i8 zeroext %e, i8 %f, i8 %g)
 #[no_mangle]
 pub extern "C" fn f_scalar_stack_2(
     a: u64,

--- a/src/test/codegen/riscv-abi/riscv64-lp64d-abi.rs
+++ b/src/test/codegen/riscv-abi/riscv64-lp64d-abi.rs
@@ -4,7 +4,7 @@
 // only-linux
 #![crate_type = "lib"]
 
-// CHECK: define void @f_fpr_tracking(double, double, double, double, double, double, double, double, i8 zeroext %i)
+// CHECK: define void @f_fpr_tracking(double %0, double %1, double %2, double %3, double %4, double %5, double %6, double %7, i8 zeroext %i)
 #[no_mangle]
 pub extern "C" fn f_fpr_tracking(
     a: f64,
@@ -36,7 +36,7 @@ pub struct DoubleFloat {
     g: f32,
 }
 
-// CHECK: define void @f_double_s_arg(double)
+// CHECK: define void @f_double_s_arg(double %0)
 #[no_mangle]
 pub extern "C" fn f_double_s_arg(a: Double) {}
 
@@ -46,7 +46,7 @@ pub extern "C" fn f_ret_double_s() -> Double {
     Double { f: 1. }
 }
 
-// CHECK: define void @f_double_double_s_arg({ double, double })
+// CHECK: define void @f_double_double_s_arg({ double, double } %0)
 #[no_mangle]
 pub extern "C" fn f_double_double_s_arg(a: DoubleDouble) {}
 
@@ -56,7 +56,7 @@ pub extern "C" fn f_ret_double_double_s() -> DoubleDouble {
     DoubleDouble { f: 1., g: 2. }
 }
 
-// CHECK: define void @f_double_float_s_arg({ double, float })
+// CHECK: define void @f_double_float_s_arg({ double, float } %0)
 #[no_mangle]
 pub extern "C" fn f_double_float_s_arg(a: DoubleFloat) {}
 
@@ -66,7 +66,7 @@ pub extern "C" fn f_ret_double_float_s() -> DoubleFloat {
     DoubleFloat { f: 1., g: 2. }
 }
 
-// CHECK: define void @f_double_double_s_arg_insufficient_fprs(double, double, double, double, double, double, double, [2 x i64])
+// CHECK: define void @f_double_double_s_arg_insufficient_fprs(double %0, double %1, double %2, double %3, double %4, double %5, double %6, [2 x i64] %7)
 #[no_mangle]
 pub extern "C" fn f_double_double_s_arg_insufficient_fprs(
     a: f64,
@@ -104,7 +104,7 @@ pub struct DoubleInt64 {
     i: i64,
 }
 
-// CHECK: define void @f_double_int8_s_arg({ double, i8 })
+// CHECK: define void @f_double_int8_s_arg({ double, i8 } %0)
 #[no_mangle]
 pub extern "C" fn f_double_int8_s_arg(a: DoubleInt8) {}
 
@@ -114,7 +114,7 @@ pub extern "C" fn f_ret_double_int8_s() -> DoubleInt8 {
     DoubleInt8 { f: 1., i: 2 }
 }
 
-// CHECK: define void @f_double_int32_s_arg({ double, i32 })
+// CHECK: define void @f_double_int32_s_arg({ double, i32 } %0)
 #[no_mangle]
 pub extern "C" fn f_double_int32_s_arg(a: DoubleInt32) {}
 
@@ -124,7 +124,7 @@ pub extern "C" fn f_ret_double_int32_s() -> DoubleInt32 {
     DoubleInt32 { f: 1., i: 2 }
 }
 
-// CHECK: define void @f_double_uint8_s_arg({ double, i8 })
+// CHECK: define void @f_double_uint8_s_arg({ double, i8 } %0)
 #[no_mangle]
 pub extern "C" fn f_double_uint8_s_arg(a: DoubleUInt8) {}
 
@@ -134,7 +134,7 @@ pub extern "C" fn f_ret_double_uint8_s() -> DoubleUInt8 {
     DoubleUInt8 { f: 1., i: 2 }
 }
 
-// CHECK: define void @f_double_int64_s_arg({ double, i64 })
+// CHECK: define void @f_double_int64_s_arg({ double, i64 } %0)
 #[no_mangle]
 pub extern "C" fn f_double_int64_s_arg(a: DoubleInt64) {}
 
@@ -144,7 +144,7 @@ pub extern "C" fn f_ret_double_int64_s() -> DoubleInt64 {
     DoubleInt64 { f: 1., i: 2 }
 }
 
-// CHECK: define void @f_double_int8_s_arg_insufficient_gprs(i32 signext %a, i32 signext %b, i32 signext %c, i32 signext %d, i32 signext %e, i32 signext %f, i32 signext %g, i32 signext %h, [2 x i64])
+// CHECK: define void @f_double_int8_s_arg_insufficient_gprs(i32 signext %a, i32 signext %b, i32 signext %c, i32 signext %d, i32 signext %e, i32 signext %f, i32 signext %g, i32 signext %h, [2 x i64] %0)
 #[no_mangle]
 pub extern "C" fn f_double_int8_s_arg_insufficient_gprs(
     a: i32,
@@ -159,7 +159,7 @@ pub extern "C" fn f_double_int8_s_arg_insufficient_gprs(
 ) {
 }
 
-// CHECK: define void @f_struct_double_int8_insufficient_fprs(float, double, double, double, double, double, double, double, [2 x i64])
+// CHECK: define void @f_struct_double_int8_insufficient_fprs(float %0, double %1, double %2, double %3, double %4, double %5, double %6, double %7, [2 x i64] %8)
 #[no_mangle]
 pub extern "C" fn f_struct_double_int8_insufficient_fprs(
     a: f32,
@@ -179,7 +179,7 @@ pub struct DoubleArr1 {
     a: [f64; 1],
 }
 
-// CHECK: define void @f_doublearr1_s_arg(double)
+// CHECK: define void @f_doublearr1_s_arg(double %0)
 #[no_mangle]
 pub extern "C" fn f_doublearr1_s_arg(a: DoubleArr1) {}
 
@@ -194,7 +194,7 @@ pub struct DoubleArr2 {
     a: [f64; 2],
 }
 
-// CHECK: define void @f_doublearr2_s_arg({ double, double })
+// CHECK: define void @f_doublearr2_s_arg({ double, double } %0)
 #[no_mangle]
 pub extern "C" fn f_doublearr2_s_arg(a: DoubleArr2) {}
 
@@ -214,7 +214,7 @@ pub struct DoubleArr2Tricky1 {
     g: [Tricky1; 2],
 }
 
-// CHECK: define void @f_doublearr2_tricky1_s_arg({ double, double })
+// CHECK: define void @f_doublearr2_tricky1_s_arg({ double, double } %0)
 #[no_mangle]
 pub extern "C" fn f_doublearr2_tricky1_s_arg(a: DoubleArr2Tricky1) {}
 
@@ -233,7 +233,7 @@ pub struct DoubleArr2Tricky2 {
     g: [Tricky1; 2],
 }
 
-// CHECK: define void @f_doublearr2_tricky2_s_arg({ double, double })
+// CHECK: define void @f_doublearr2_tricky2_s_arg({ double, double } %0)
 #[no_mangle]
 pub extern "C" fn f_doublearr2_tricky2_s_arg(a: DoubleArr2Tricky2) {}
 
@@ -267,7 +267,7 @@ pub struct CharCharDouble {
     c: f64,
 }
 
-// CHECK: define void @f_char_char_double_s_arg([2 x i64])
+// CHECK: define void @f_char_char_double_s_arg([2 x i64] %0)
 #[no_mangle]
 pub extern "C" fn f_char_char_double_s_arg(a: CharCharDouble) {}
 
@@ -282,7 +282,7 @@ pub union DoubleU {
     a: f64,
 }
 
-// CHECK: define void @f_double_u_arg(i64)
+// CHECK: define void @f_double_u_arg(i64 %0)
 #[no_mangle]
 pub extern "C" fn f_double_u_arg(a: DoubleU) {}
 

--- a/src/test/codegen/riscv-abi/riscv64-lp64f-lp64d-abi.rs
+++ b/src/test/codegen/riscv-abi/riscv64-lp64f-lp64d-abi.rs
@@ -4,7 +4,7 @@
 // only-linux
 #![crate_type = "lib"]
 
-// CHECK: define void @f_fpr_tracking(float, float, float, float, float, float, float, float, i8 zeroext %i)
+// CHECK: define void @f_fpr_tracking(float %0, float %1, float %2, float %3, float %4, float %5, float %6, float %7, i8 zeroext %i)
 #[no_mangle]
 pub extern "C" fn f_fpr_tracking(
     a: f32,
@@ -30,7 +30,7 @@ pub struct FloatFloat {
     g: f32,
 }
 
-// CHECK: define void @f_float_s_arg(float)
+// CHECK: define void @f_float_s_arg(float %0)
 #[no_mangle]
 pub extern "C" fn f_float_s_arg(a: Float) {}
 
@@ -40,7 +40,7 @@ pub extern "C" fn f_ret_float_s() -> Float {
     Float { f: 1. }
 }
 
-// CHECK: define void @f_float_float_s_arg({ float, float })
+// CHECK: define void @f_float_float_s_arg({ float, float } %0)
 #[no_mangle]
 pub extern "C" fn f_float_float_s_arg(a: FloatFloat) {}
 
@@ -50,7 +50,7 @@ pub extern "C" fn f_ret_float_float_s() -> FloatFloat {
     FloatFloat { f: 1., g: 2. }
 }
 
-// CHECK: define void @f_float_float_s_arg_insufficient_fprs(float, float, float, float, float, float, float, i64)
+// CHECK: define void @f_float_float_s_arg_insufficient_fprs(float %0, float %1, float %2, float %3, float %4, float %5, float %6, i64 %7)
 #[no_mangle]
 pub extern "C" fn f_float_float_s_arg_insufficient_fprs(
     a: f32,
@@ -88,7 +88,7 @@ pub struct FloatInt64 {
     i: i64,
 }
 
-// CHECK: define void @f_float_int8_s_arg({ float, i8 })
+// CHECK: define void @f_float_int8_s_arg({ float, i8 } %0)
 #[no_mangle]
 pub extern "C" fn f_float_int8_s_arg(a: FloatInt8) {}
 
@@ -98,7 +98,7 @@ pub extern "C" fn f_ret_float_int8_s() -> FloatInt8 {
     FloatInt8 { f: 1., i: 2 }
 }
 
-// CHECK: define void @f_float_int32_s_arg({ float, i32 })
+// CHECK: define void @f_float_int32_s_arg({ float, i32 } %0)
 #[no_mangle]
 pub extern "C" fn f_float_int32_s_arg(a: FloatInt32) {}
 
@@ -108,7 +108,7 @@ pub extern "C" fn f_ret_float_int32_s() -> FloatInt32 {
     FloatInt32 { f: 1., i: 2 }
 }
 
-// CHECK: define void @f_float_uint8_s_arg({ float, i8 })
+// CHECK: define void @f_float_uint8_s_arg({ float, i8 } %0)
 #[no_mangle]
 pub extern "C" fn f_float_uint8_s_arg(a: FloatUInt8) {}
 
@@ -118,7 +118,7 @@ pub extern "C" fn f_ret_float_uint8_s() -> FloatUInt8 {
     FloatUInt8 { f: 1., i: 2 }
 }
 
-// CHECK: define void @f_float_int64_s_arg({ float, i64 })
+// CHECK: define void @f_float_int64_s_arg({ float, i64 } %0)
 #[no_mangle]
 pub extern "C" fn f_float_int64_s_arg(a: FloatInt64) {}
 
@@ -128,7 +128,7 @@ pub extern "C" fn f_ret_float_int64_s() -> FloatInt64 {
     FloatInt64 { f: 1., i: 2 }
 }
 
-// CHECK: define void @f_float_int8_s_arg_insufficient_gprs(i32 signext %a, i32 signext %b, i32 signext %c, i32 signext %d, i32 signext %e, i32 signext %f, i32 signext %g, i32 signext %h, i64)
+// CHECK: define void @f_float_int8_s_arg_insufficient_gprs(i32 signext %a, i32 signext %b, i32 signext %c, i32 signext %d, i32 signext %e, i32 signext %f, i32 signext %g, i32 signext %h, i64 %0)
 #[no_mangle]
 pub extern "C" fn f_float_int8_s_arg_insufficient_gprs(
     a: i32,
@@ -143,7 +143,7 @@ pub extern "C" fn f_float_int8_s_arg_insufficient_gprs(
 ) {
 }
 
-// CHECK: define void @f_struct_float_int8_insufficient_fprs(float, float, float, float, float, float, float, float, i64)
+// CHECK: define void @f_struct_float_int8_insufficient_fprs(float %0, float %1, float %2,  float %3, float %4, float %5, float %6, float %7, i64 %8)
 #[no_mangle]
 pub extern "C" fn f_struct_float_int8_insufficient_fprs(
     a: f32,
@@ -163,7 +163,7 @@ pub struct FloatArr1 {
     a: [f32; 1],
 }
 
-// CHECK: define void @f_floatarr1_s_arg(float)
+// CHECK: define void @f_floatarr1_s_arg(float %0)
 #[no_mangle]
 pub extern "C" fn f_floatarr1_s_arg(a: FloatArr1) {}
 
@@ -178,7 +178,7 @@ pub struct FloatArr2 {
     a: [f32; 2],
 }
 
-// CHECK: define void @f_floatarr2_s_arg({ float, float })
+// CHECK: define void @f_floatarr2_s_arg({ float, float } %0)
 #[no_mangle]
 pub extern "C" fn f_floatarr2_s_arg(a: FloatArr2) {}
 
@@ -198,7 +198,7 @@ pub struct FloatArr2Tricky1 {
     g: [Tricky1; 2],
 }
 
-// CHECK: define void @f_floatarr2_tricky1_s_arg({ float, float })
+// CHECK: define void @f_floatarr2_tricky1_s_arg({ float, float } %0)
 #[no_mangle]
 pub extern "C" fn f_floatarr2_tricky1_s_arg(a: FloatArr2Tricky1) {}
 
@@ -217,7 +217,7 @@ pub struct FloatArr2Tricky2 {
     g: [Tricky1; 2],
 }
 
-// CHECK: define void @f_floatarr2_tricky2_s_arg({ float, float })
+// CHECK: define void @f_floatarr2_tricky2_s_arg({ float, float } %0)
 #[no_mangle]
 pub extern "C" fn f_floatarr2_tricky2_s_arg(a: FloatArr2Tricky2) {}
 
@@ -234,7 +234,7 @@ pub struct IntFloatInt {
     c: i32,
 }
 
-// CHECK: define void @f_int_float_int_s_arg([2 x i64])
+// CHECK: define void @f_int_float_int_s_arg([2 x i64] %0)
 #[no_mangle]
 pub extern "C" fn f_int_float_int_s_arg(a: IntFloatInt) {}
 
@@ -251,7 +251,7 @@ pub struct CharCharFloat {
     c: f32,
 }
 
-// CHECK: define void @f_char_char_float_s_arg(i64)
+// CHECK: define void @f_char_char_float_s_arg(i64 %0)
 #[no_mangle]
 pub extern "C" fn f_char_char_float_s_arg(a: CharCharFloat) {}
 
@@ -266,7 +266,7 @@ pub union FloatU {
     a: f32,
 }
 
-// CHECK: define void @f_float_u_arg(i64)
+// CHECK: define void @f_float_u_arg(i64 %0)
 #[no_mangle]
 pub extern "C" fn f_float_u_arg(a: FloatU) {}
 

--- a/src/test/codegen/stack-probes.rs
+++ b/src/test/codegen/stack-probes.rs
@@ -5,6 +5,7 @@
 // ignore-powerpc
 // ignore-powerpc64
 // ignore-powerpc64le
+// ignore-riscv64
 // ignore-s390x
 // ignore-sparc
 // ignore-sparc64

--- a/src/test/codegen/x86_mmx.rs
+++ b/src/test/codegen/x86_mmx.rs
@@ -6,6 +6,7 @@
 // ignore-powerpc
 // ignore-powerpc64
 // ignore-powerpc64le
+// ignore-riscv64
 // ignore-sparc
 // ignore-sparc64
 // ignore-s390x


### PR DESCRIPTION
Some codegen tests didn't seem relevant (e.g. unsupported annotations).

The RISC-V abi tests were broken by LLVM 10, c872dcf fixes that (cc: @msizanoen1)

I'm not sure about skipping catch-unwind.rs and included that change here mostly as a request for comment - I can't tell if that's a bug.