### PR TITLE
Stabilize the backtrace feature.

### DIFF
--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -4,7 +4,6 @@
 
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
 #![feature(crate_visibility_modifier)]
-#![feature(backtrace)]
 #![feature(nll)]
 
 #[macro_use]

--- a/compiler/rustc_middle/src/lib.rs
+++ b/compiler/rustc_middle/src/lib.rs
@@ -25,7 +25,6 @@
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
 #![feature(array_windows)]
 #![feature(assoc_char_funcs)]
-#![feature(backtrace)]
 #![feature(bool_to_option)]
 #![feature(box_patterns)]
 #![feature(box_syntax)]

--- a/library/std/src/backtrace.rs
+++ b/library/std/src/backtrace.rs
@@ -58,7 +58,7 @@
 //! `RUST_LIB_BACKTRACE` or `RUST_BACKTRACE` at runtime may not actually change
 //! how backtraces are captured.
 
-#![stable(feature = "backtrace", since = "1.50.0")]
+#![stable(feature = "backtrace", since = "1.51.0")]
 
 #[cfg(test)]
 mod tests;
@@ -103,7 +103,7 @@ use crate::vec::Vec;
 /// previous point in time. In some instances the `Backtrace` type may
 /// internally be empty due to configuration. For more information see
 /// `Backtrace::capture`.
-#[stable(feature = "backtrace", since = "1.50.0")]
+#[stable(feature = "backtrace", since = "1.51.0")]
 pub struct Backtrace {
     inner: Inner,
 }
@@ -112,19 +112,19 @@ pub struct Backtrace {
 /// whether it is empty for some other reason.
 #[non_exhaustive]
 #[derive(Debug, PartialEq, Eq)]
-#[stable(feature = "backtrace", since = "1.50.0")]
+#[stable(feature = "backtrace", since = "1.51.0")]
 pub enum BacktraceStatus {
     /// Capturing a backtrace is not supported, likely because it's not
     /// implemented for the current platform.
-    #[stable(feature = "backtrace", since = "1.50.0")]
+    #[stable(feature = "backtrace", since = "1.51.0")]
     Unsupported,
     /// Capturing a backtrace has been disabled through either the
     /// `RUST_LIB_BACKTRACE` or `RUST_BACKTRACE` environment variables.
-    #[stable(feature = "backtrace", since = "1.50.0")]
+    #[stable(feature = "backtrace", since = "1.51.0")]
     Disabled,
     /// A backtrace has been captured and the `Backtrace` should print
     /// reasonable information when rendered.
-    #[stable(feature = "backtrace", since = "1.50.0")]
+    #[stable(feature = "backtrace", since = "1.51.0")]
     Captured,
 }
 
@@ -168,7 +168,7 @@ enum BytesOrWide {
     Wide(Vec<u16>),
 }
 
-#[stable(feature = "backtrace", since = "1.50.0")]
+#[stable(feature = "backtrace", since = "1.51.0")]
 impl fmt::Debug for Backtrace {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut capture = match &self.inner {
@@ -276,7 +276,7 @@ impl Backtrace {
     ///
     /// To forcibly capture a backtrace regardless of environment variables, use
     /// the `Backtrace::force_capture` function.
-    #[stable(feature = "backtrace", since = "1.50.0")]
+    #[stable(feature = "backtrace", since = "1.51.0")]
     #[inline(never)] // want to make sure there's a frame here to remove
     pub fn capture() -> Backtrace {
         if !Backtrace::enabled() {
@@ -295,7 +295,7 @@ impl Backtrace {
     /// Note that capturing a backtrace can be an expensive operation on some
     /// platforms, so this should be used with caution in performance-sensitive
     /// parts of code.
-    #[stable(feature = "backtrace", since = "1.50.0")]
+    #[stable(feature = "backtrace", since = "1.51.0")]
     #[inline(never)] // want to make sure there's a frame here to remove
     pub fn force_capture() -> Backtrace {
         Backtrace::create(Backtrace::force_capture as usize)
@@ -346,7 +346,7 @@ impl Backtrace {
     /// Returns the status of this backtrace, indicating whether this backtrace
     /// request was unsupported, disabled, or a stack trace was actually
     /// captured.
-    #[stable(feature = "backtrace", since = "1.50.0")]
+    #[stable(feature = "backtrace", since = "1.51.0")]
     pub fn status(&self) -> BacktraceStatus {
         match self.inner {
             Inner::Unsupported => BacktraceStatus::Unsupported,
@@ -356,7 +356,7 @@ impl Backtrace {
     }
 }
 
-#[stable(feature = "backtrace", since = "1.50.0")]
+#[stable(feature = "backtrace", since = "1.51.0")]
 impl fmt::Display for Backtrace {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut capture = match &self.inner {

--- a/library/std/src/backtrace.rs
+++ b/library/std/src/backtrace.rs
@@ -303,6 +303,7 @@ impl Backtrace {
 
     /// Forcibly captures a disabled backtrace, regardless of environment
     /// variable configuration.
+    #[stable(feature = "backtrace", since = "1.51.0")]
     pub const fn disabled() -> Backtrace {
         Backtrace { inner: Inner::Disabled }
     }

--- a/library/std/src/backtrace.rs
+++ b/library/std/src/backtrace.rs
@@ -9,12 +9,6 @@
 //! implementing `std::error::Error`) to get a causal chain of where an error
 //! was generated.
 //!
-//! > **Note**: this module is unstable and is designed in [RFC 2504], and you
-//! > can learn more about its status in the [tracking issue].
-//!
-//! [RFC 2504]: https://github.com/rust-lang/rfcs/blob/master/text/2504-fix-error.md
-//! [tracking issue]: https://github.com/rust-lang/rust/issues/53487
-//!
 //! ## Accuracy
 //!
 //! Backtraces are attempted to be as accurate as possible, but no guarantees
@@ -64,7 +58,7 @@
 //! `RUST_LIB_BACKTRACE` or `RUST_BACKTRACE` at runtime may not actually change
 //! how backtraces are captured.
 
-#![unstable(feature = "backtrace", issue = "53487")]
+#![stable(feature = "backtrace", since = "1.50.0")]
 
 #[cfg(test)]
 mod tests;
@@ -109,6 +103,7 @@ use crate::vec::Vec;
 /// previous point in time. In some instances the `Backtrace` type may
 /// internally be empty due to configuration. For more information see
 /// `Backtrace::capture`.
+#[stable(feature = "backtrace", since = "1.50.0")]
 pub struct Backtrace {
     inner: Inner,
 }
@@ -117,15 +112,19 @@ pub struct Backtrace {
 /// whether it is empty for some other reason.
 #[non_exhaustive]
 #[derive(Debug, PartialEq, Eq)]
+#[stable(feature = "backtrace", since = "1.50.0")]
 pub enum BacktraceStatus {
     /// Capturing a backtrace is not supported, likely because it's not
     /// implemented for the current platform.
+    #[stable(feature = "backtrace", since = "1.50.0")]
     Unsupported,
     /// Capturing a backtrace has been disabled through either the
     /// `RUST_LIB_BACKTRACE` or `RUST_BACKTRACE` environment variables.
+    #[stable(feature = "backtrace", since = "1.50.0")]
     Disabled,
     /// A backtrace has been captured and the `Backtrace` should print
     /// reasonable information when rendered.
+    #[stable(feature = "backtrace", since = "1.50.0")]
     Captured,
 }
 
@@ -169,6 +168,7 @@ enum BytesOrWide {
     Wide(Vec<u16>),
 }
 
+#[stable(feature = "backtrace", since = "1.50.0")]
 impl fmt::Debug for Backtrace {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut capture = match &self.inner {
@@ -276,6 +276,7 @@ impl Backtrace {
     ///
     /// To forcibly capture a backtrace regardless of environment variables, use
     /// the `Backtrace::force_capture` function.
+    #[stable(feature = "backtrace", since = "1.50.0")]
     #[inline(never)] // want to make sure there's a frame here to remove
     pub fn capture() -> Backtrace {
         if !Backtrace::enabled() {
@@ -294,6 +295,7 @@ impl Backtrace {
     /// Note that capturing a backtrace can be an expensive operation on some
     /// platforms, so this should be used with caution in performance-sensitive
     /// parts of code.
+    #[stable(feature = "backtrace", since = "1.50.0")]
     #[inline(never)] // want to make sure there's a frame here to remove
     pub fn force_capture() -> Backtrace {
         Backtrace::create(Backtrace::force_capture as usize)
@@ -344,6 +346,7 @@ impl Backtrace {
     /// Returns the status of this backtrace, indicating whether this backtrace
     /// request was unsupported, disabled, or a stack trace was actually
     /// captured.
+    #[stable(feature = "backtrace", since = "1.50.0")]
     pub fn status(&self) -> BacktraceStatus {
         match self.inner {
             Inner::Unsupported => BacktraceStatus::Unsupported,
@@ -353,6 +356,7 @@ impl Backtrace {
     }
 }
 
+#[stable(feature = "backtrace", since = "1.50.0")]
 impl fmt::Display for Backtrace {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut capture = match &self.inner {

--- a/library/std/src/backtrace.rs
+++ b/library/std/src/backtrace.rs
@@ -304,6 +304,7 @@ impl Backtrace {
     /// Forcibly captures a disabled backtrace, regardless of environment
     /// variable configuration.
     #[stable(feature = "backtrace", since = "1.51.0")]
+    #[rustc_const_stable(feature = "const_backtrace_disabled", since = "1.51.0")]
     pub const fn disabled() -> Backtrace {
         Backtrace { inner: Inner::Disabled }
     }

--- a/library/std/src/error.rs
+++ b/library/std/src/error.rs
@@ -122,7 +122,7 @@ pub trait Error: Debug + Display {
     /// Note that not all errors contain a `Backtrace`. Also note that a
     /// `Backtrace` may actually be empty. For more information consult the
     /// `Backtrace` type itself.
-    #[unstable(feature = "backtrace", issue = "53487")]
+    #[stable(feature = "backtrace", since = "1.50.0")]
     fn backtrace(&self) -> Option<&Backtrace> {
         None
     }

--- a/library/std/src/error.rs
+++ b/library/std/src/error.rs
@@ -122,7 +122,7 @@ pub trait Error: Debug + Display {
     /// Note that not all errors contain a `Backtrace`. Also note that a
     /// `Backtrace` may actually be empty. For more information consult the
     /// `Backtrace` type itself.
-    #[stable(feature = "backtrace", since = "1.50.0")]
+    #[stable(feature = "backtrace", since = "1.51.0")]
     fn backtrace(&self) -> Option<&Backtrace> {
         None
     }

--- a/src/test/ui/std-backtrace.rs
+++ b/src/test/ui/std-backtrace.rs
@@ -6,8 +6,6 @@
 // ignore-msvc see #62897 and `backtrace-debuginfo.rs` test
 // compile-flags:-g
 
-#![feature(backtrace)]
-
 use std::env;
 use std::process::Command;
 use std::str;


### PR DESCRIPTION
## Stabilization Report

This is a proposal to stabilize the `backtrace` feature in libstd. It would make these additional APIs available on stable:

```rust
pub mod backtrace {
    pub struct Backtrace {
    }

    enum BacktraceStatus {
        Unsupported,
        Disabled,
        Captured,
    }

    impl Backtrace {
        pub fn capture() -> Backtrace { }

        pub fn force_capture() -> Backtrace { }

        pub fn disabled() -> Backtrace { }

        pub fn status(&self) -> BacktraceState { }
    }

    impl Display for Backtrace { }
    impl Debug for Backtrace { }
}

pub mod error {
    pub trait Error {
        fn backtrace(&self) -> Option<&Backtrace> {
            None
        }
    }
}
```

The behavior of the backtrace type, especially as it connects to certain environment variables, is better documented in the module documentation: https://doc.rust-lang.org/std/backtrace/index.html

The internal details of how backtraces are captured and represented are platform specific and unspecified. A platform may not support backtraces at all. Libstd's backtrace type will do its best to report a backtrace to the caller of `Backtrace::capture` and `Backtrace::force_capture`.

### Background and Motivation

This API was proposed as part of RFC 2504, which was merged in August 2018. The API was based on experience with the failure crate, released November 2017, and motivated by a longstanding user request for a standardized way to access backtraces, especially in connection with errors that have been raised. This API was implemented actually in September 2019.

In late 2019, many users began migrating from the `failure` crate to crates based on `std::error::Error`, because most of the API changes proposed in RFC 2504 had been stabilized, and new crates similar to failure but based on std Error had been implemented, most notably thiserror and anyhow by dtolnay. In early 2020, the failure crate was deprecated, and users were recommended to use anyhow and thiserror instead.

*However*, on stable, the user experience of anyhow and thiserror is not equivalent to the user experience of failure, because the backtrace component of RFC 2504 has not been stabilized. Some users have been left in the frustrating and confusing experience of watching the ecosystem move around them to a solution that does not have feature parity for them, because they were depending on the backtrace feature of failure. They are forced to either migrate from stable to nightly or manage compatibility issues with the rest of the ecosystem while staying on failure.

Even the anyhow crate only has meaningful backtraces with the backtrace feature of the crate turned on, which in turn depends on the backtrace feature of std.

### Unresolved questions from RFC

One unresolved question was left over from the RFC regarding the API of `capture`: some proposed that rather than have backtraces which return a non-`Captured` status, the capture API return an Option. This was discussed at length on the RFC, and the RFC was ultimately merged with an unresolved question to confirm that the current design worked well. There has since been no discussion of that aspect of the RFC.

Two aspects complicate the idea of having a backtrace's non-pressence indicated with an option:

- A backtrace can be absent for two reasons: the backtrace is disabled or the platform does not support backtraces. An Option could not represent that, requiring a new enum type, or a result and a new error type.
- Use cases like `Error::backtrace` introduce a third reason a backtrace wouldn't be present: the concrete implementation did not try to capture a backtrace.

Combined we would be looking at an API like `fn backtrace(&self) -> Option<&Result<Backtrace, BacktraceError>>`, which becomes very unwieldy. For users who need to interrogate a backtrace's materiality, the `BacktraceStatus` provides a means of determining if the backtrace they've captured is not meaningful and why.

### Issues raised during implementation period

#### Fmt representation #65280

Changes were made to the representation of the backtrace type, removing the header from the display representation & providing a debug implementation which is consistent with other Debug implementations.

However, #65280 also proposes providing a means of limiting the backtrace using something like the precision syntax. This has not been implemented. I propose that this is a desirable feature, but it is strictly add-on and it should not be a blocker on stabilizing backtrace.

#### Backtrace and Error in core

The main issue raised during implementation was the relationship of `Error::backtrace` and `Error` not being in core. The `Error` trait is already not in core for another reason: an inherent method on `dyn Error` requires the `Box` type, which is not in core, but stabilizing `Error::backtrace` would add a second dependence on a non-core type.

It is desirable for the `Error` trait to be available from core, and therefore users have expressed concern about adding a new dependency on a non-core type. However, this stabilization would not present any new challenge that could not be resolved as easily as the existing challenges:

1. In order to add Error to core, we would need some "hook" that makes the non-core methods on Error not available in core, without breaking coherence. Such a "hook" could also be imagined for making the backtrace method not available in core.
2. Alternatively (and probably better) we could make the backtrace type available in core, but its backtrace functionality disabled without std, with some hook to provide the platform-specific functionality that std fulfills, similar to global allocators, panic handlers, etc.
3. Finally, we could do the *proper* thing and merge std and core into one library, instead of piling up an increasing tower of hacks to work aroud the misdesigned core/std split.

Because the existing issue with Error would already require a language-level change to allow std to add an inherent method to `dyn Error`, which multiple team members (me included) have expressed concern about doing, this does not seem to me to present a substantial increase in the amount of work needed to make Error available in core.

#### RFC 2895 and "generic member access"

Finally, there is the idea that RFC 2895 could supercede the Error::backtrace method. RFC 2895 provides an API for essentially a specialized dynamically dispatched "generic member" that errors could have, which is core-compatible. Such an API could then be used to provide the backtrace, or any other dynamically dispatched type, that an error could contain.

However, this RFC is not merged or in FCP, and is still in the early phases of design. We have already soft-regressed users, who have been relying on an existing API that has been in design for several years. Blocking the resolution of those users' problems on an RFC in early design stages would not be prudent.

The basic motivation of RFC 2895 is that it allows errors to provide many different kinds of contexts, not just a backtrace, and in a way which is open ended and extensible. This may be a desirable property for the std error trait, and RFC 2895 may eventually be merged, stabilized, etc. However, I would contend that even in such a case, preferential treatment for backtraces is still desirable. Backtraces are a standard feature provided not only in Rust but in many language ecosystems, which users have come to expect. Providing a first-class method for getting the backtrace, called backtrace, even if it delegates to a more generic "request for context" method in the long term, makes sense for the optimal user experience.

### Future work

Other than the future work on the error trait discussed above, there is future work to be done on the backtrace type. In particular, the backtrace type currently provides no method of analysis other than debug and display printing the backtrace. It would be beneficial to provide a platform agnostic, standard API for iterating over the frames of the backtrace and the members of the frames in the long term. Such an API would justify a separate RFC.