### PR TITLE
resolve: Sort E0408 errors by Symbol str

### DIFF
--- a/src/librustc_resolve/late.rs
+++ b/src/librustc_resolve/late.rs
@@ -1323,7 +1323,8 @@ impl<'a, 'b, 'ast> LateResolutionVisitor<'a, 'b, 'ast> {
 
         // 3) Report all missing variables we found.
         let mut missing_vars = missing_vars.iter_mut().collect::<Vec<_>>();
-        missing_vars.sort();
+        missing_vars.sort_by_key(|(sym, _err)| sym.as_str());
+
         for (name, mut v) in missing_vars {
             if inconsistent_vars.contains_key(name) {
                 v.could_be_path = false;

--- a/src/test/ui/borrowck/borrowck-asm.rs
+++ b/src/test/ui/borrowck/borrowck-asm.rs
@@ -3,6 +3,7 @@
 // ignore-powerpc
 // ignore-powerpc64
 // ignore-powerpc64le
+// ignore-riscv64
 // ignore-sparc
 // ignore-sparc64
 

--- a/src/test/ui/borrowck/borrowck-asm.stderr
+++ b/src/test/ui/borrowck/borrowck-asm.stderr
@@ -1,5 +1,5 @@
 error[E0382]: use of moved value: `x`
-  --> $DIR/borrowck-asm.rs:24:17
+  --> $DIR/borrowck-asm.rs:25:17
    |
 LL |         let x = &mut 0isize;
    |             - move occurs because `x` has type `&mut isize`, which does not implement the `Copy` trait
@@ -11,7 +11,7 @@ LL |         let z = x;
    |                 ^ value used here after move
 
 error[E0503]: cannot use `x` because it was mutably borrowed
-  --> $DIR/borrowck-asm.rs:31:37
+  --> $DIR/borrowck-asm.rs:32:37
    |
 LL |         let y = &mut x;
    |                 ------ borrow of `x` occurs here
@@ -23,7 +23,7 @@ LL |         let z = y;
    |                 - borrow later used here
 
 error[E0384]: cannot assign twice to immutable variable `x`
-  --> $DIR/borrowck-asm.rs:39:36
+  --> $DIR/borrowck-asm.rs:40:36
    |
 LL |         let x = 3;
    |             -
@@ -35,7 +35,7 @@ LL |             llvm_asm!("nop" : "=r"(x));
    |                                    ^ cannot assign twice to immutable variable
 
 error[E0384]: cannot assign twice to immutable variable `x`
-  --> $DIR/borrowck-asm.rs:53:36
+  --> $DIR/borrowck-asm.rs:54:36
    |
 LL |         let x = 3;
    |             -
@@ -47,13 +47,13 @@ LL |             llvm_asm!("nop" : "+r"(x));
    |                                    ^ cannot assign twice to immutable variable
 
 error[E0381]: use of possibly-uninitialized variable: `x`
-  --> $DIR/borrowck-asm.rs:60:37
+  --> $DIR/borrowck-asm.rs:61:37
    |
 LL |             llvm_asm!("nop" : "=*r"(x));
    |                                     ^ use of possibly-uninitialized `x`
 
 error[E0506]: cannot assign to `x` because it is borrowed
-  --> $DIR/borrowck-asm.rs:68:36
+  --> $DIR/borrowck-asm.rs:69:36
    |
 LL |         let y = &*x;
    |                 --- borrow of `x` occurs here
@@ -65,7 +65,7 @@ LL |         let z = y;
    |                 - borrow later used here
 
 error[E0382]: use of moved value: `x`
-  --> $DIR/borrowck-asm.rs:76:45
+  --> $DIR/borrowck-asm.rs:77:45
    |
 LL |         let x = &mut 2;
    |             - move occurs because `x` has type `&mut i32`, which does not implement the `Copy` trait

--- a/src/test/ui/c-variadic/variadic-ffi-1.rs
+++ b/src/test/ui/c-variadic/variadic-ffi-1.rs
@@ -1,5 +1,6 @@
 // ignore-arm stdcall isn't supported
 // ignore-aarch64 stdcall isn't supported
+// ignore-riscv64 stdcall isn't supported
 
 extern "stdcall" {
     fn printf(_: *const u8, ...); //~ ERROR: variadic function must have C or cdecl calling

--- a/src/test/ui/c-variadic/variadic-ffi-1.stderr
+++ b/src/test/ui/c-variadic/variadic-ffi-1.stderr
@@ -1,11 +1,11 @@
 error[E0045]: C-variadic function must have C or cdecl calling convention
-  --> $DIR/variadic-ffi-1.rs:5:5
+  --> $DIR/variadic-ffi-1.rs:6:5
    |
 LL |     fn printf(_: *const u8, ...);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ C-variadics require C or cdecl calling convention
 
 error[E0060]: this function takes at least 2 arguments but 0 arguments were supplied
-  --> $DIR/variadic-ffi-1.rs:16:9
+  --> $DIR/variadic-ffi-1.rs:17:9
    |
 LL |     fn foo(f: isize, x: u8, ...);
    |     ----------------------------- defined here
@@ -16,7 +16,7 @@ LL |         foo();
    |         expected at least 2 arguments
 
 error[E0060]: this function takes at least 2 arguments but 1 argument was supplied
-  --> $DIR/variadic-ffi-1.rs:17:9
+  --> $DIR/variadic-ffi-1.rs:18:9
    |
 LL |     fn foo(f: isize, x: u8, ...);
    |     ----------------------------- defined here
@@ -27,7 +27,7 @@ LL |         foo(1);
    |         expected at least 2 arguments
 
 error[E0308]: mismatched types
-  --> $DIR/variadic-ffi-1.rs:19:56
+  --> $DIR/variadic-ffi-1.rs:20:56
    |
 LL |         let x: unsafe extern "C" fn(f: isize, x: u8) = foo;
    |                -------------------------------------   ^^^ expected non-variadic fn, found variadic function
@@ -38,7 +38,7 @@ LL |         let x: unsafe extern "C" fn(f: isize, x: u8) = foo;
                  found fn item `unsafe extern "C" fn(_, _, ...) {foo}`
 
 error[E0308]: mismatched types
-  --> $DIR/variadic-ffi-1.rs:20:54
+  --> $DIR/variadic-ffi-1.rs:21:54
    |
 LL |         let y: extern "C" fn(f: isize, x: u8, ...) = bar;
    |                -----------------------------------   ^^^ expected variadic fn, found non-variadic function
@@ -49,37 +49,37 @@ LL |         let y: extern "C" fn(f: isize, x: u8, ...) = bar;
                  found fn item `extern "C" fn(_, _) {bar}`
 
 error[E0617]: can't pass `f32` to variadic function
-  --> $DIR/variadic-ffi-1.rs:22:19
+  --> $DIR/variadic-ffi-1.rs:23:19
    |
 LL |         foo(1, 2, 3f32);
    |                   ^^^^ help: cast the value to `c_double`: `3f32 as c_double`
 
 error[E0617]: can't pass `bool` to variadic function
-  --> $DIR/variadic-ffi-1.rs:23:19
+  --> $DIR/variadic-ffi-1.rs:24:19
    |
 LL |         foo(1, 2, true);
    |                   ^^^^ help: cast the value to `c_int`: `true as c_int`
 
 error[E0617]: can't pass `i8` to variadic function
-  --> $DIR/variadic-ffi-1.rs:24:19
+  --> $DIR/variadic-ffi-1.rs:25:19
    |
 LL |         foo(1, 2, 1i8);
    |                   ^^^ help: cast the value to `c_int`: `1i8 as c_int`
 
 error[E0617]: can't pass `u8` to variadic function
-  --> $DIR/variadic-ffi-1.rs:25:19
+  --> $DIR/variadic-ffi-1.rs:26:19
    |
 LL |         foo(1, 2, 1u8);
    |                   ^^^ help: cast the value to `c_uint`: `1u8 as c_uint`
 
 error[E0617]: can't pass `i16` to variadic function
-  --> $DIR/variadic-ffi-1.rs:26:19
+  --> $DIR/variadic-ffi-1.rs:27:19
    |
 LL |         foo(1, 2, 1i16);
    |                   ^^^^ help: cast the value to `c_int`: `1i16 as c_int`
 
 error[E0617]: can't pass `u16` to variadic function
-  --> $DIR/variadic-ffi-1.rs:27:19
+  --> $DIR/variadic-ffi-1.rs:28:19
    |
 LL |         foo(1, 2, 1u16);
    |                   ^^^^ help: cast the value to `c_uint`: `1u16 as c_uint`

--- a/src/test/ui/cfg/conditional-compile-arch.rs
+++ b/src/test/ui/cfg/conditional-compile-arch.rs
@@ -36,3 +36,6 @@ pub fn main() { }
 
 #[cfg(target_arch = "sparc64")]
 pub fn main() { }
+
+#[cfg(target_arch = "riscv64")]
+pub fn main() { }

--- a/src/test/ui/extern/extern-methods.rs
+++ b/src/test/ui/extern/extern-methods.rs
@@ -1,6 +1,7 @@
 // run-pass
 // ignore-arm
 // ignore-aarch64
+// ignore-riscv64 fastcall isn't supported
 
 trait A {
     extern "fastcall" fn test1(i: i32);

--- a/src/test/ui/extern/extern-thiscall.rs
+++ b/src/test/ui/extern/extern-thiscall.rs
@@ -1,6 +1,7 @@
 // run-pass
 // ignore-arm
 // ignore-aarch64
+// ignore-riscv64 thiscall isn't supported
 
 #![feature(abi_thiscall)]
 

--- a/src/test/ui/extern/extern-vectorcall.rs
+++ b/src/test/ui/extern/extern-vectorcall.rs
@@ -1,6 +1,7 @@
 // run-pass
 // ignore-arm
 // ignore-aarch64
+// ignore-riscv64 vectorcall isn't supported
 
 #![feature(abi_vectorcall)]
 

--- a/src/test/ui/feature-gates/feature-gate-abi-msp430-interrupt.rs
+++ b/src/test/ui/feature-gates/feature-gate-abi-msp430-interrupt.rs
@@ -1,6 +1,8 @@
 // Test that the MSP430 interrupt ABI cannot be used when msp430_interrupt
 // feature gate is not used.
 
+// ignore-riscv64 msp430 is not supported
+
 extern "msp430-interrupt" fn foo() {}
 //~^ ERROR msp430-interrupt ABI is experimental and subject to change
 

--- a/src/test/ui/feature-gates/feature-gate-abi-msp430-interrupt.stderr
+++ b/src/test/ui/feature-gates/feature-gate-abi-msp430-interrupt.stderr
@@ -1,5 +1,5 @@
 error[E0658]: msp430-interrupt ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi-msp430-interrupt.rs:4:8
+  --> $DIR/feature-gate-abi-msp430-interrupt.rs:6:8
    |
 LL | extern "msp430-interrupt" fn foo() {}
    |        ^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/llvm-asm/llvm-asm-bad-clobber.rs
+++ b/src/test/ui/llvm-asm/llvm-asm-bad-clobber.rs
@@ -6,6 +6,7 @@
 // ignore-powerpc
 // ignore-powerpc64
 // ignore-powerpc64le
+// ignore-riscv64
 // ignore-sparc
 // ignore-sparc64
 // ignore-mips

--- a/src/test/ui/llvm-asm/llvm-asm-bad-clobber.stderr
+++ b/src/test/ui/llvm-asm/llvm-asm-bad-clobber.stderr
@@ -1,5 +1,5 @@
 error[E0664]: clobber should not be surrounded by braces
-  --> $DIR/llvm-asm-bad-clobber.rs:22:42
+  --> $DIR/llvm-asm-bad-clobber.rs:23:42
    |
 LL |         llvm_asm!("xor %eax, %eax" : : : "{eax}");
    |                                          ^^^^^^^

--- a/src/test/ui/llvm-asm/llvm-asm-in-bad-modifier.rs
+++ b/src/test/ui/llvm-asm/llvm-asm-in-bad-modifier.rs
@@ -3,6 +3,7 @@
 // ignore-powerpc
 // ignore-powerpc64
 // ignore-powerpc64le
+// ignore-riscv64
 // ignore-sparc
 // ignore-sparc64
 // ignore-mips

--- a/src/test/ui/llvm-asm/llvm-asm-in-bad-modifier.stderr
+++ b/src/test/ui/llvm-asm/llvm-asm-in-bad-modifier.stderr
@@ -1,11 +1,11 @@
 error[E0662]: input operand constraint contains '='
-  --> $DIR/llvm-asm-in-bad-modifier.rs:23:44
+  --> $DIR/llvm-asm-in-bad-modifier.rs:24:44
    |
 LL |         llvm_asm!("mov $1, $0" : "=r"(x) : "=r"(5));
    |                                            ^^^^
 
 error[E0663]: input operand constraint contains '+'
-  --> $DIR/llvm-asm-in-bad-modifier.rs:24:44
+  --> $DIR/llvm-asm-in-bad-modifier.rs:25:44
    |
 LL |         llvm_asm!("mov $1, $0" : "=r"(y) : "+r"(5));
    |                                            ^^^^

--- a/src/test/ui/llvm-asm/llvm-asm-misplaced-option.rs
+++ b/src/test/ui/llvm-asm/llvm-asm-misplaced-option.rs
@@ -7,6 +7,7 @@
 // ignore-powerpc
 // ignore-powerpc64
 // ignore-powerpc64le
+// ignore-riscv64
 // ignore-sparc
 // ignore-sparc64
 // ignore-mips

--- a/src/test/ui/llvm-asm/llvm-asm-misplaced-option.stderr
+++ b/src/test/ui/llvm-asm/llvm-asm-misplaced-option.stderr
@@ -1,11 +1,11 @@
 warning: unrecognized option
-  --> $DIR/llvm-asm-misplaced-option.rs:24:69
+  --> $DIR/llvm-asm-misplaced-option.rs:25:69
    |
 LL |         llvm_asm!("mov $1, $0" : "=r"(x) : "r"(5_usize), "0"(x) : : "cc");
    |                                                                     ^^^^
 
 warning: expected a clobber, found an option
-  --> $DIR/llvm-asm-misplaced-option.rs:31:85
+  --> $DIR/llvm-asm-misplaced-option.rs:32:85
    |
 LL |         llvm_asm!("add $2, $1; mov $1, $0" : "=r"(x) : "r"(x), "r"(8_usize) : "cc", "volatile");
    |                                                                                     ^^^^^^^^^^

--- a/src/test/ui/llvm-asm/llvm-asm-out-assign-imm.rs
+++ b/src/test/ui/llvm-asm/llvm-asm-out-assign-imm.rs
@@ -3,6 +3,7 @@
 // ignore-powerpc
 // ignore-powerpc64
 // ignore-powerpc64le
+// ignore-riscv64
 // ignore-sparc
 // ignore-sparc64
 // ignore-mips

--- a/src/test/ui/llvm-asm/llvm-asm-out-assign-imm.stderr
+++ b/src/test/ui/llvm-asm/llvm-asm-out-assign-imm.stderr
@@ -1,5 +1,5 @@
 error[E0384]: cannot assign twice to immutable variable `x`
-  --> $DIR/llvm-asm-out-assign-imm.rs:24:39
+  --> $DIR/llvm-asm-out-assign-imm.rs:25:39
    |
 LL |     let x: isize;
    |         - help: make this binding mutable: `mut x`

--- a/src/test/ui/llvm-asm/llvm-asm-out-no-modifier.rs
+++ b/src/test/ui/llvm-asm/llvm-asm-out-no-modifier.rs
@@ -3,6 +3,7 @@
 // ignore-powerpc
 // ignore-powerpc64
 // ignore-powerpc64le
+// ignore-riscv64
 // ignore-sparc
 // ignore-sparc64
 // ignore-mips

--- a/src/test/ui/llvm-asm/llvm-asm-out-no-modifier.stderr
+++ b/src/test/ui/llvm-asm/llvm-asm-out-no-modifier.stderr
@@ -1,5 +1,5 @@
 error[E0661]: output operand constraint lacks '=' or '+'
-  --> $DIR/llvm-asm-out-no-modifier.rs:22:34
+  --> $DIR/llvm-asm-out-no-modifier.rs:23:34
    |
 LL |         llvm_asm!("mov $1, $0" : "r"(x) : "r"(5));
    |                                  ^^^

--- a/src/test/ui/llvm-asm/llvm-asm-out-read-uninit.rs
+++ b/src/test/ui/llvm-asm/llvm-asm-out-read-uninit.rs
@@ -3,6 +3,7 @@
 // ignore-powerpc
 // ignore-powerpc64
 // ignore-powerpc64le
+// ignore-riscv64
 // ignore-sparc
 // ignore-sparc64
 // ignore-mips

--- a/src/test/ui/llvm-asm/llvm-asm-out-read-uninit.stderr
+++ b/src/test/ui/llvm-asm/llvm-asm-out-read-uninit.stderr
@@ -1,5 +1,5 @@
 error[E0381]: use of possibly-uninitialized variable: `x`
-  --> $DIR/llvm-asm-out-read-uninit.rs:22:48
+  --> $DIR/llvm-asm-out-read-uninit.rs:23:48
    |
 LL |         llvm_asm!("mov $1, $0" : "=r"(x) : "r"(x));
    |                                                ^ use of possibly-uninitialized `x`

--- a/src/test/ui/or-patterns/mismatched-bindings-async-fn.stderr
+++ b/src/test/ui/or-patterns/mismatched-bindings-async-fn.stderr
@@ -1,11 +1,3 @@
-error[E0408]: variable `x` is not bound in all patterns
-  --> $DIR/mismatched-bindings-async-fn.rs:6:17
-   |
-LL | async fn a((x | s): String) {}
-   |             -   ^ pattern doesn't bind `x`
-   |             |
-   |             variable not in all patterns
-
 error[E0408]: variable `s` is not bound in all patterns
   --> $DIR/mismatched-bindings-async-fn.rs:6:13
    |
@@ -15,12 +7,12 @@ LL | async fn a((x | s): String) {}
    |             pattern doesn't bind `s`
 
 error[E0408]: variable `x` is not bound in all patterns
-  --> $DIR/mismatched-bindings-async-fn.rs:11:13
+  --> $DIR/mismatched-bindings-async-fn.rs:6:17
    |
-LL |     let x | s = String::new();
-   |         -   ^ pattern doesn't bind `x`
-   |         |
-   |         variable not in all patterns
+LL | async fn a((x | s): String) {}
+   |             -   ^ pattern doesn't bind `x`
+   |             |
+   |             variable not in all patterns
 
 error[E0408]: variable `s` is not bound in all patterns
   --> $DIR/mismatched-bindings-async-fn.rs:11:9
@@ -29,6 +21,14 @@ LL |     let x | s = String::new();
    |         ^   - variable not in all patterns
    |         |
    |         pattern doesn't bind `s`
+
+error[E0408]: variable `x` is not bound in all patterns
+  --> $DIR/mismatched-bindings-async-fn.rs:11:13
+   |
+LL |     let x | s = String::new();
+   |         -   ^ pattern doesn't bind `x`
+   |         |
+   |         variable not in all patterns
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/span/issue-39698.stderr
+++ b/src/test/ui/span/issue-39698.stderr
@@ -8,16 +8,6 @@ LL |         T::T1(a, d) | T::T2(d, b) | T::T3(c) | T::T4(a) => { println!("{:?}
    |               |       pattern doesn't bind `a`
    |               variable not in all patterns
 
-error[E0408]: variable `d` is not bound in all patterns
-  --> $DIR/issue-39698.rs:10:37
-   |
-LL |         T::T1(a, d) | T::T2(d, b) | T::T3(c) | T::T4(a) => { println!("{:?}", a); }
-   |                  -          -       ^^^^^^^^   ^^^^^^^^ pattern doesn't bind `d`
-   |                  |          |       |
-   |                  |          |       pattern doesn't bind `d`
-   |                  |          variable not in all patterns
-   |                  variable not in all patterns
-
 error[E0408]: variable `b` is not bound in all patterns
   --> $DIR/issue-39698.rs:10:9
    |
@@ -37,6 +27,16 @@ LL |         T::T1(a, d) | T::T2(d, b) | T::T3(c) | T::T4(a) => { println!("{:?}
    |         |             |                   variable not in all patterns
    |         |             pattern doesn't bind `c`
    |         pattern doesn't bind `c`
+
+error[E0408]: variable `d` is not bound in all patterns
+  --> $DIR/issue-39698.rs:10:37
+   |
+LL |         T::T1(a, d) | T::T2(d, b) | T::T3(c) | T::T4(a) => { println!("{:?}", a); }
+   |                  -          -       ^^^^^^^^   ^^^^^^^^ pattern doesn't bind `d`
+   |                  |          |       |
+   |                  |          |       pattern doesn't bind `d`
+   |                  |          variable not in all patterns
+   |                  variable not in all patterns
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/target-feature/gate.rs
+++ b/src/test/ui/target-feature/gate.rs
@@ -7,6 +7,7 @@
 // ignore-powerpc
 // ignore-powerpc64
 // ignore-powerpc64le
+// ignore-riscv64
 // ignore-sparc
 // ignore-sparc64
 // ignore-s390x

--- a/src/test/ui/target-feature/gate.stderr
+++ b/src/test/ui/target-feature/gate.stderr
@@ -1,5 +1,5 @@
 error[E0658]: the target feature `avx512bw` is currently unstable
-  --> $DIR/gate.rs:30:18
+  --> $DIR/gate.rs:31:18
    |
 LL | #[target_feature(enable = "avx512bw")]
    |                  ^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/target-feature/invalid-attribute.rs
+++ b/src/test/ui/target-feature/invalid-attribute.rs
@@ -7,6 +7,7 @@
 // ignore-powerpc
 // ignore-powerpc64
 // ignore-powerpc64le
+// ignore-riscv64
 // ignore-s390x
 // ignore-sparc
 // ignore-sparc64

--- a/src/test/ui/target-feature/invalid-attribute.stderr
+++ b/src/test/ui/target-feature/invalid-attribute.stderr
@@ -1,29 +1,29 @@
 error: malformed `target_feature` attribute input
-  --> $DIR/invalid-attribute.rs:16:1
+  --> $DIR/invalid-attribute.rs:17:1
    |
 LL | #[target_feature = "+sse2"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: must be of the form: `#[target_feature(enable = "name")]`
 
 error: the feature named `foo` is not valid for this target
-  --> $DIR/invalid-attribute.rs:18:18
+  --> $DIR/invalid-attribute.rs:19:18
    |
 LL | #[target_feature(enable = "foo")]
    |                  ^^^^^^^^^^^^^^ `foo` is not valid for this target
 
 error: malformed `target_feature` attribute input
-  --> $DIR/invalid-attribute.rs:21:18
+  --> $DIR/invalid-attribute.rs:22:18
    |
 LL | #[target_feature(bar)]
    |                  ^^^ help: must be of the form: `enable = ".."`
 
 error: malformed `target_feature` attribute input
-  --> $DIR/invalid-attribute.rs:23:18
+  --> $DIR/invalid-attribute.rs:24:18
    |
 LL | #[target_feature(disable = "baz")]
    |                  ^^^^^^^^^^^^^^^ help: must be of the form: `enable = ".."`
 
 error[E0658]: `#[target_feature(..)]` can only be applied to `unsafe` functions
-  --> $DIR/invalid-attribute.rs:27:1
+  --> $DIR/invalid-attribute.rs:28:1
    |
 LL | #[target_feature(enable = "sse2")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -35,7 +35,7 @@ LL | fn bar() {}
    = help: add `#![feature(target_feature_11)]` to the crate attributes to enable
 
 error: attribute should be applied to a function
-  --> $DIR/invalid-attribute.rs:33:1
+  --> $DIR/invalid-attribute.rs:34:1
    |
 LL | #[target_feature(enable = "sse2")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -44,7 +44,7 @@ LL | mod another {}
    | -------------- not a function
 
 error: attribute should be applied to a function
-  --> $DIR/invalid-attribute.rs:38:1
+  --> $DIR/invalid-attribute.rs:39:1
    |
 LL | #[target_feature(enable = "sse2")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -53,7 +53,7 @@ LL | const FOO: usize = 7;
    | --------------------- not a function
 
 error: attribute should be applied to a function
-  --> $DIR/invalid-attribute.rs:43:1
+  --> $DIR/invalid-attribute.rs:44:1
    |
 LL | #[target_feature(enable = "sse2")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -62,7 +62,7 @@ LL | struct Foo;
    | ----------- not a function
 
 error: attribute should be applied to a function
-  --> $DIR/invalid-attribute.rs:48:1
+  --> $DIR/invalid-attribute.rs:49:1
    |
 LL | #[target_feature(enable = "sse2")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -71,7 +71,7 @@ LL | enum Bar { }
    | ------------ not a function
 
 error: attribute should be applied to a function
-  --> $DIR/invalid-attribute.rs:53:1
+  --> $DIR/invalid-attribute.rs:54:1
    |
 LL | #[target_feature(enable = "sse2")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -80,7 +80,7 @@ LL | union Qux { f1: u16, f2: u16 }
    | ------------------------------ not a function
 
 error: attribute should be applied to a function
-  --> $DIR/invalid-attribute.rs:58:1
+  --> $DIR/invalid-attribute.rs:59:1
    |
 LL | #[target_feature(enable = "sse2")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -89,13 +89,13 @@ LL | trait Baz { }
    | ------------- not a function
 
 error: cannot use `#[inline(always)]` with `#[target_feature]`
-  --> $DIR/invalid-attribute.rs:63:1
+  --> $DIR/invalid-attribute.rs:64:1
    |
 LL | #[inline(always)]
    | ^^^^^^^^^^^^^^^^^
 
 error[E0658]: `#[target_feature(..)]` can only be applied to `unsafe` functions
-  --> $DIR/invalid-attribute.rs:85:5
+  --> $DIR/invalid-attribute.rs:86:5
    |
 LL |     #[target_feature(enable = "sse2")]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -107,7 +107,7 @@ LL |     || {};
    = help: add `#![feature(target_feature_11)]` to the crate attributes to enable
 
 error[E0658]: `#[target_feature(..)]` can only be applied to `unsafe` functions
-  --> $DIR/invalid-attribute.rs:73:5
+  --> $DIR/invalid-attribute.rs:74:5
    |
 LL |     #[target_feature(enable = "sse2")]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
This is a request for comments implementing my suggested solution to https://github.com/rust-lang/rust/issues/72913

Previously errors were sorted by Symbol index instead of the string. The indexes are not the same between architectures because Symbols for architecture extensions (e.g. x86 AVX or RISC-V d) are interned before the source file is parsed. RISC-V's naming of extensions after single letters led to it having errors sorted differently for test cases using single letter variable names. Instead sort the errors by the Symbol string so that it is stable across architectures.

While I was at it, there's also 8edb05c2  skipping some ui tests which I think are irrelevant for risc-v.