### PR TITLE
Add myself to mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -153,6 +153,10 @@ Kang Seonghoon <kang.seonghoon@mearie.org> <public+git@mearie.org>
 Keegan McAllister <mcallister.keegan@gmail.com> <kmcallister@mozilla.com>
 Kevin Butler <haqkrs@gmail.com>
 Kyeongwoon Lee <kyeongwoon.lee@samsung.com>
+Kyle J Strand <batmanaod@gmail.com> <BatmanAoD@users.noreply.github.com>
+Kyle J Strand <batmanaod@gmail.com> <kyle.j.strand@gmail.com>
+Kyle J Strand <batmanaod@gmail.com> <kyle.strand@pieinsurance.com>
+Kyle J Strand <batmanaod@gmail.com> <kyle.strand@rms.com>
 Laurențiu Nicola <lnicola@dend.ro>
 Lee Jeffery <leejeffery@gmail.com> Lee Jeffery <lee@leejeffery.co.uk>
 Lee Wondong <wdlee91@gmail.com>


### PR DESCRIPTION
Now that I have (accidentally) made contributions using two separate email addresses, I've added the rest of the addresses I typical use.