### PR TITLE
Expand libstd struct case misspelling diagnostics

### DIFF
--- a/src/librustc_resolve/late/diagnostics.rs
+++ b/src/librustc_resolve/late/diagnostics.rs
@@ -365,13 +365,13 @@ impl<'a> LateResolutionVisitor<'a, '_, '_> {
                         if structs.len() == 1 {
                             err.span_suggestion(
                                 ident_span,
-                                &format!("found a libstd struct with a similar name"),
+                                &format!("found a std struct with a similar name"),
                                 format!("{}", structs[0]),
                                 Applicability::MaybeIncorrect,
                             );
                         } else if structs.len() > 1 {
                             let mut struct_suggestions = Vec::new();
-                            let message = "found libstd structs with a similar name:";
+                            let message = "found std structs with similar names:";
                             for a_struct in structs.iter() {
                                 struct_suggestions.push(format!("{}", a_struct));
                             }

--- a/src/librustc_resolve/late/diagnostics.rs
+++ b/src/librustc_resolve/late/diagnostics.rs
@@ -363,15 +363,15 @@ impl<'a> LateResolutionVisitor<'a, '_, '_> {
                             &ident.name.to_ident_string(),
                         );
                         if structs.len() == 1 {
-                            err.span_suggestion_verbose(
+                            err.span_suggestion(
                                 ident_span,
-                                &format!("did you mean `{}`?", structs[0]),
+                                &format!("found a libstd struct with a similar name"),
                                 format!("{}", structs[0]),
                                 Applicability::MaybeIncorrect,
                             );
                         } else if structs.len() > 1 {
                             let mut struct_suggestions = Vec::new();
-                            let message = "did you mean one of these?:";
+                            let message = "found libstd structs with a similar name:";
                             for a_struct in structs.iter() {
                                 struct_suggestions.push(format!("{}", a_struct));
                             }

--- a/src/test/ui/libstd-case-typo/alloc.rs
+++ b/src/test/ui/libstd-case-typo/alloc.rs
@@ -1,0 +1,7 @@
+// checks case typos with libstd::alloc structs
+fn main(){}
+
+fn test_layout(_x: LayOut){}
+//~^ ERROR: cannot find type `LayOut` in this scope
+fn test_system(_x: system){}
+//~^ ERROR: cannot find type `system` in this scope

--- a/src/test/ui/libstd-case-typo/alloc.stderr
+++ b/src/test/ui/libstd-case-typo/alloc.stderr
@@ -5,7 +5,7 @@ LL | fn test_layout(_x: LayOut){}
    |                    ^^^^^^
    |                    |
    |                    not found in this scope
-   |                    help: found a libstd struct with a similar name: `std::alloc::Layout`
+   |                    help: found a std struct with a similar name: `std::alloc::Layout`
 
 error[E0412]: cannot find type `system` in this scope
   --> $DIR/alloc.rs:6:20
@@ -14,7 +14,7 @@ LL | fn test_system(_x: system){}
    |                    ^^^^^^
    |                    |
    |                    not found in this scope
-   |                    help: found a libstd struct with a similar name: `std::alloc::System`
+   |                    help: found a std struct with a similar name: `std::alloc::System`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/libstd-case-typo/alloc.stderr
+++ b/src/test/ui/libstd-case-typo/alloc.stderr
@@ -2,23 +2,19 @@ error[E0412]: cannot find type `LayOut` in this scope
   --> $DIR/alloc.rs:4:20
    |
 LL | fn test_layout(_x: LayOut){}
-   |                    ^^^^^^ not found in this scope
-   |
-help: did you mean `std::alloc::Layout`?
-   |
-LL | fn test_layout(_x: std::alloc::Layout){}
-   |                    ^^^^^^^^^^^^^^^^^^
+   |                    ^^^^^^
+   |                    |
+   |                    not found in this scope
+   |                    help: found a libstd struct with a similar name: `std::alloc::Layout`
 
 error[E0412]: cannot find type `system` in this scope
   --> $DIR/alloc.rs:6:20
    |
 LL | fn test_system(_x: system){}
-   |                    ^^^^^^ not found in this scope
-   |
-help: did you mean `std::alloc::System`?
-   |
-LL | fn test_system(_x: std::alloc::System){}
-   |                    ^^^^^^^^^^^^^^^^^^
+   |                    ^^^^^^
+   |                    |
+   |                    not found in this scope
+   |                    help: found a libstd struct with a similar name: `std::alloc::System`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/libstd-case-typo/alloc.stderr
+++ b/src/test/ui/libstd-case-typo/alloc.stderr
@@ -1,0 +1,25 @@
+error[E0412]: cannot find type `LayOut` in this scope
+  --> $DIR/alloc.rs:4:20
+   |
+LL | fn test_layout(_x: LayOut){}
+   |                    ^^^^^^ not found in this scope
+   |
+help: did you mean `std::alloc::Layout`?
+   |
+LL | fn test_layout(_x: std::alloc::Layout){}
+   |                    ^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `system` in this scope
+  --> $DIR/alloc.rs:6:20
+   |
+LL | fn test_system(_x: system){}
+   |                    ^^^^^^ not found in this scope
+   |
+help: did you mean `std::alloc::System`?
+   |
+LL | fn test_system(_x: std::alloc::System){}
+   |                    ^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0412`.

--- a/src/test/ui/libstd-case-typo/any.rs
+++ b/src/test/ui/libstd-case-typo/any.rs
@@ -1,0 +1,5 @@
+// checks case typos with libstd::any structs
+fn main(){}
+
+fn test_typeid(_x: Typeid){}
+//~^ ERROR: cannot find type `Typeid` in this scope

--- a/src/test/ui/libstd-case-typo/any.stderr
+++ b/src/test/ui/libstd-case-typo/any.stderr
@@ -5,7 +5,7 @@ LL | fn test_typeid(_x: Typeid){}
    |                    ^^^^^^
    |                    |
    |                    not found in this scope
-   |                    help: found a libstd struct with a similar name: `std::any::TypeId`
+   |                    help: found a std struct with a similar name: `std::any::TypeId`
 
 error: aborting due to previous error
 

--- a/src/test/ui/libstd-case-typo/any.stderr
+++ b/src/test/ui/libstd-case-typo/any.stderr
@@ -2,12 +2,10 @@ error[E0412]: cannot find type `Typeid` in this scope
   --> $DIR/any.rs:4:20
    |
 LL | fn test_typeid(_x: Typeid){}
-   |                    ^^^^^^ not found in this scope
-   |
-help: did you mean `std::any::TypeId`?
-   |
-LL | fn test_typeid(_x: std::any::TypeId){}
-   |                    ^^^^^^^^^^^^^^^^
+   |                    ^^^^^^
+   |                    |
+   |                    not found in this scope
+   |                    help: found a libstd struct with a similar name: `std::any::TypeId`
 
 error: aborting due to previous error
 

--- a/src/test/ui/libstd-case-typo/any.stderr
+++ b/src/test/ui/libstd-case-typo/any.stderr
@@ -1,0 +1,14 @@
+error[E0412]: cannot find type `Typeid` in this scope
+  --> $DIR/any.rs:4:20
+   |
+LL | fn test_typeid(_x: Typeid){}
+   |                    ^^^^^^ not found in this scope
+   |
+help: did you mean `std::any::TypeId`?
+   |
+LL | fn test_typeid(_x: std::any::TypeId){}
+   |                    ^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0412`.

--- a/src/test/ui/libstd-case-typo/ascii.rs
+++ b/src/test/ui/libstd-case-typo/ascii.rs
@@ -1,0 +1,5 @@
+// checks case typos with libstd::ascii structs
+fn main(){}
+
+fn test_escdef(_x: Escapedefault){}
+//~^ ERROR: cannot find type `Escapedefault` in this scope

--- a/src/test/ui/libstd-case-typo/ascii.stderr
+++ b/src/test/ui/libstd-case-typo/ascii.stderr
@@ -1,0 +1,18 @@
+error[E0412]: cannot find type `Escapedefault` in this scope
+  --> $DIR/ascii.rs:4:20
+   |
+LL | fn test_escdef(_x: Escapedefault){}
+   |                    ^^^^^^^^^^^^^ not found in this scope
+   |
+help: did you mean one of these?:
+   |
+LL | fn test_escdef(_x: std::ascii::EscapeDefault){}
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | fn test_escdef(_x: std::char::EscapeDefault){}
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^^
+LL | fn test_escdef(_x: std::str::EscapeDefault){}
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0412`.

--- a/src/test/ui/libstd-case-typo/ascii.stderr
+++ b/src/test/ui/libstd-case-typo/ascii.stderr
@@ -4,7 +4,7 @@ error[E0412]: cannot find type `Escapedefault` in this scope
 LL | fn test_escdef(_x: Escapedefault){}
    |                    ^^^^^^^^^^^^^ not found in this scope
    |
-help: found libstd structs with a similar name:
+help: found std structs with similar names:
    |
 LL | fn test_escdef(_x: std::ascii::EscapeDefault){}
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/libstd-case-typo/ascii.stderr
+++ b/src/test/ui/libstd-case-typo/ascii.stderr
@@ -4,7 +4,7 @@ error[E0412]: cannot find type `Escapedefault` in this scope
 LL | fn test_escdef(_x: Escapedefault){}
    |                    ^^^^^^^^^^^^^ not found in this scope
    |
-help: did you mean one of these?:
+help: found libstd structs with a similar name:
    |
 LL | fn test_escdef(_x: std::ascii::EscapeDefault){}
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/libstd-case-typo/cell.rs
+++ b/src/test/ui/libstd-case-typo/cell.rs
@@ -1,0 +1,5 @@
+// checks case typos with libstd::cell structs
+fn main(){}
+
+fn test_cell(_x: cell<()>){}
+//~^ ERROR: cannot find type `cell` in this scope

--- a/src/test/ui/libstd-case-typo/cell.stderr
+++ b/src/test/ui/libstd-case-typo/cell.stderr
@@ -1,0 +1,14 @@
+error[E0412]: cannot find type `cell` in this scope
+  --> $DIR/cell.rs:4:18
+   |
+LL | fn test_cell(_x: cell<()>){}
+   |                  ^^^^ not found in this scope
+   |
+help: did you mean `std::cell::Cell`?
+   |
+LL | fn test_cell(_x: std::cell::Cell<()>){}
+   |                  ^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0412`.

--- a/src/test/ui/libstd-case-typo/cell.stderr
+++ b/src/test/ui/libstd-case-typo/cell.stderr
@@ -5,7 +5,7 @@ LL | fn test_cell(_x: cell<()>){}
    |                  ^^^^
    |                  |
    |                  not found in this scope
-   |                  help: found a libstd struct with a similar name: `std::cell::Cell`
+   |                  help: found a std struct with a similar name: `std::cell::Cell`
 
 error: aborting due to previous error
 

--- a/src/test/ui/libstd-case-typo/cell.stderr
+++ b/src/test/ui/libstd-case-typo/cell.stderr
@@ -2,12 +2,10 @@ error[E0412]: cannot find type `cell` in this scope
   --> $DIR/cell.rs:4:18
    |
 LL | fn test_cell(_x: cell<()>){}
-   |                  ^^^^ not found in this scope
-   |
-help: did you mean `std::cell::Cell`?
-   |
-LL | fn test_cell(_x: std::cell::Cell<()>){}
-   |                  ^^^^^^^^^^^^^^^
+   |                  ^^^^
+   |                  |
+   |                  not found in this scope
+   |                  help: found a libstd struct with a similar name: `std::cell::Cell`
 
 error: aborting due to previous error
 

--- a/src/test/ui/libstd-case-typo/char.rs
+++ b/src/test/ui/libstd-case-typo/char.rs
@@ -1,0 +1,17 @@
+// checks case typos with libstd::char structs
+fn main(){}
+
+fn test_du16(_x: DecodeUTF16<()>){}
+//~^ ERROR: cannot find type `DecodeUTF16` in this scope
+
+fn test_edflt(_x: Escapedefault){}
+//~^ ERROR: cannot find type `Escapedefault` in this scope
+
+fn test_euni(_x: Escapeunicode){}
+//~^ ERROR: cannot find type `Escapeunicode` in this scope
+
+fn test_tolow(_x: Tolowercase){}
+//~^ ERROR: cannot find type `Tolowercase` in this scope
+
+fn test_toupper(_x: Touppercase){}
+//~^ ERROR: cannot find type `Touppercase` in this scope

--- a/src/test/ui/libstd-case-typo/char.stderr
+++ b/src/test/ui/libstd-case-typo/char.stderr
@@ -1,0 +1,64 @@
+error[E0412]: cannot find type `DecodeUTF16` in this scope
+  --> $DIR/char.rs:4:18
+   |
+LL | fn test_du16(_x: DecodeUTF16<()>){}
+   |                  ^^^^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::char::DecodeUtf16`?
+   |
+LL | fn test_du16(_x: std::char::DecodeUtf16<()>){}
+   |                  ^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `Escapedefault` in this scope
+  --> $DIR/char.rs:7:19
+   |
+LL | fn test_edflt(_x: Escapedefault){}
+   |                   ^^^^^^^^^^^^^ not found in this scope
+   |
+help: did you mean one of these?:
+   |
+LL | fn test_edflt(_x: std::ascii::EscapeDefault){}
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | fn test_edflt(_x: std::char::EscapeDefault){}
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^
+LL | fn test_edflt(_x: std::str::EscapeDefault){}
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `Escapeunicode` in this scope
+  --> $DIR/char.rs:10:18
+   |
+LL | fn test_euni(_x: Escapeunicode){}
+   |                  ^^^^^^^^^^^^^ not found in this scope
+   |
+help: did you mean one of these?:
+   |
+LL | fn test_euni(_x: std::char::EscapeUnicode){}
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^
+LL | fn test_euni(_x: std::str::EscapeUnicode){}
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `Tolowercase` in this scope
+  --> $DIR/char.rs:13:19
+   |
+LL | fn test_tolow(_x: Tolowercase){}
+   |                   ^^^^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::char::ToLowercase`?
+   |
+LL | fn test_tolow(_x: std::char::ToLowercase){}
+   |                   ^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `Touppercase` in this scope
+  --> $DIR/char.rs:16:21
+   |
+LL | fn test_toupper(_x: Touppercase){}
+   |                     ^^^^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::char::ToUppercase`?
+   |
+LL | fn test_toupper(_x: std::char::ToUppercase){}
+   |                     ^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 5 previous errors
+
+For more information about this error, try `rustc --explain E0412`.

--- a/src/test/ui/libstd-case-typo/char.stderr
+++ b/src/test/ui/libstd-case-typo/char.stderr
@@ -2,12 +2,10 @@ error[E0412]: cannot find type `DecodeUTF16` in this scope
   --> $DIR/char.rs:4:18
    |
 LL | fn test_du16(_x: DecodeUTF16<()>){}
-   |                  ^^^^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::char::DecodeUtf16`?
-   |
-LL | fn test_du16(_x: std::char::DecodeUtf16<()>){}
-   |                  ^^^^^^^^^^^^^^^^^^^^^^
+   |                  ^^^^^^^^^^^
+   |                  |
+   |                  not found in this scope
+   |                  help: found a libstd struct with a similar name: `std::char::DecodeUtf16`
 
 error[E0412]: cannot find type `Escapedefault` in this scope
   --> $DIR/char.rs:7:19
@@ -15,7 +13,7 @@ error[E0412]: cannot find type `Escapedefault` in this scope
 LL | fn test_edflt(_x: Escapedefault){}
    |                   ^^^^^^^^^^^^^ not found in this scope
    |
-help: did you mean one of these?:
+help: found libstd structs with a similar name:
    |
 LL | fn test_edflt(_x: std::ascii::EscapeDefault){}
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -30,7 +28,7 @@ error[E0412]: cannot find type `Escapeunicode` in this scope
 LL | fn test_euni(_x: Escapeunicode){}
    |                  ^^^^^^^^^^^^^ not found in this scope
    |
-help: did you mean one of these?:
+help: found libstd structs with a similar name:
    |
 LL | fn test_euni(_x: std::char::EscapeUnicode){}
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -41,23 +39,19 @@ error[E0412]: cannot find type `Tolowercase` in this scope
   --> $DIR/char.rs:13:19
    |
 LL | fn test_tolow(_x: Tolowercase){}
-   |                   ^^^^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::char::ToLowercase`?
-   |
-LL | fn test_tolow(_x: std::char::ToLowercase){}
-   |                   ^^^^^^^^^^^^^^^^^^^^^^
+   |                   ^^^^^^^^^^^
+   |                   |
+   |                   not found in this scope
+   |                   help: found a libstd struct with a similar name: `std::char::ToLowercase`
 
 error[E0412]: cannot find type `Touppercase` in this scope
   --> $DIR/char.rs:16:21
    |
 LL | fn test_toupper(_x: Touppercase){}
-   |                     ^^^^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::char::ToUppercase`?
-   |
-LL | fn test_toupper(_x: std::char::ToUppercase){}
-   |                     ^^^^^^^^^^^^^^^^^^^^^^
+   |                     ^^^^^^^^^^^
+   |                     |
+   |                     not found in this scope
+   |                     help: found a libstd struct with a similar name: `std::char::ToUppercase`
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/libstd-case-typo/char.stderr
+++ b/src/test/ui/libstd-case-typo/char.stderr
@@ -5,7 +5,7 @@ LL | fn test_du16(_x: DecodeUTF16<()>){}
    |                  ^^^^^^^^^^^
    |                  |
    |                  not found in this scope
-   |                  help: found a libstd struct with a similar name: `std::char::DecodeUtf16`
+   |                  help: found a std struct with a similar name: `std::char::DecodeUtf16`
 
 error[E0412]: cannot find type `Escapedefault` in this scope
   --> $DIR/char.rs:7:19
@@ -13,7 +13,7 @@ error[E0412]: cannot find type `Escapedefault` in this scope
 LL | fn test_edflt(_x: Escapedefault){}
    |                   ^^^^^^^^^^^^^ not found in this scope
    |
-help: found libstd structs with a similar name:
+help: found std structs with similar names:
    |
 LL | fn test_edflt(_x: std::ascii::EscapeDefault){}
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -28,7 +28,7 @@ error[E0412]: cannot find type `Escapeunicode` in this scope
 LL | fn test_euni(_x: Escapeunicode){}
    |                  ^^^^^^^^^^^^^ not found in this scope
    |
-help: found libstd structs with a similar name:
+help: found std structs with similar names:
    |
 LL | fn test_euni(_x: std::char::EscapeUnicode){}
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -42,7 +42,7 @@ LL | fn test_tolow(_x: Tolowercase){}
    |                   ^^^^^^^^^^^
    |                   |
    |                   not found in this scope
-   |                   help: found a libstd struct with a similar name: `std::char::ToLowercase`
+   |                   help: found a std struct with a similar name: `std::char::ToLowercase`
 
 error[E0412]: cannot find type `Touppercase` in this scope
   --> $DIR/char.rs:16:21
@@ -51,7 +51,7 @@ LL | fn test_toupper(_x: Touppercase){}
    |                     ^^^^^^^^^^^
    |                     |
    |                     not found in this scope
-   |                     help: found a libstd struct with a similar name: `std::char::ToUppercase`
+   |                     help: found a std struct with a similar name: `std::char::ToUppercase`
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/libstd-case-typo/cmp.rs
+++ b/src/test/ui/libstd-case-typo/cmp.rs
@@ -1,0 +1,5 @@
+// checks case typos with libstd::cmp structs
+fn main(){}
+
+fn test_rev(_x: reverse<()>){}
+//~^ ERROR: cannot find type `reverse` in this scope

--- a/src/test/ui/libstd-case-typo/cmp.stderr
+++ b/src/test/ui/libstd-case-typo/cmp.stderr
@@ -1,0 +1,14 @@
+error[E0412]: cannot find type `reverse` in this scope
+  --> $DIR/cmp.rs:4:17
+   |
+LL | fn test_rev(_x: reverse<()>){}
+   |                 ^^^^^^^ not found in this scope
+   |
+help: did you mean `std::cmp::Reverse`?
+   |
+LL | fn test_rev(_x: std::cmp::Reverse<()>){}
+   |                 ^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0412`.

--- a/src/test/ui/libstd-case-typo/cmp.stderr
+++ b/src/test/ui/libstd-case-typo/cmp.stderr
@@ -2,12 +2,10 @@ error[E0412]: cannot find type `reverse` in this scope
   --> $DIR/cmp.rs:4:17
    |
 LL | fn test_rev(_x: reverse<()>){}
-   |                 ^^^^^^^ not found in this scope
-   |
-help: did you mean `std::cmp::Reverse`?
-   |
-LL | fn test_rev(_x: std::cmp::Reverse<()>){}
-   |                 ^^^^^^^^^^^^^^^^^
+   |                 ^^^^^^^
+   |                 |
+   |                 not found in this scope
+   |                 help: found a libstd struct with a similar name: `std::cmp::Reverse`
 
 error: aborting due to previous error
 

--- a/src/test/ui/libstd-case-typo/cmp.stderr
+++ b/src/test/ui/libstd-case-typo/cmp.stderr
@@ -5,7 +5,7 @@ LL | fn test_rev(_x: reverse<()>){}
    |                 ^^^^^^^
    |                 |
    |                 not found in this scope
-   |                 help: found a libstd struct with a similar name: `std::cmp::Reverse`
+   |                 help: found a std struct with a similar name: `std::cmp::Reverse`
 
 error: aborting due to previous error
 

--- a/src/test/ui/libstd-case-typo/collections.rs
+++ b/src/test/ui/libstd-case-typo/collections.rs
@@ -1,0 +1,17 @@
+// checks case typos with libstd::collections structs
+fn main(){}
+
+fn test_btm(_x: BtreeMap<(), ()>){}
+//~^ ERROR: cannot find type `BtreeMap` in this scope
+fn test_bts(_x: BtreeSet<()>){}
+//~^ ERROR: cannot find type `BtreeSet` in this scope
+fn test_binh(_x: Binaryheap<()>){}
+//~^ ERROR: cannot find type `Binaryheap` in this scope
+fn test_hashm(_x: Hashmap<String, ()>){}
+//~^ ERROR: cannot find type `Hashmap` in this scope
+fn test_hashs(_x: Hashset<()>){}
+//~^ ERROR: cannot find type `Hashset` in this scope
+fn test_llist(_x: Linkedlist<()>){}
+//~^ ERROR: cannot find type `Linkedlist` in this scope
+fn test_vd(_x: Vecdeque<()>){}
+//~^ ERROR: cannot find type `Vecdeque` in this scope

--- a/src/test/ui/libstd-case-typo/collections.stderr
+++ b/src/test/ui/libstd-case-typo/collections.stderr
@@ -1,0 +1,80 @@
+error[E0412]: cannot find type `BtreeMap` in this scope
+  --> $DIR/collections.rs:4:17
+   |
+LL | fn test_btm(_x: BtreeMap<(), ()>){}
+   |                 ^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::collections::BTreeMap`?
+   |
+LL | fn test_btm(_x: std::collections::BTreeMap<(), ()>){}
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `BtreeSet` in this scope
+  --> $DIR/collections.rs:6:17
+   |
+LL | fn test_bts(_x: BtreeSet<()>){}
+   |                 ^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::collections::BTreeSet`?
+   |
+LL | fn test_bts(_x: std::collections::BTreeSet<()>){}
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `Binaryheap` in this scope
+  --> $DIR/collections.rs:8:18
+   |
+LL | fn test_binh(_x: Binaryheap<()>){}
+   |                  ^^^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::collections::BinaryHeap`?
+   |
+LL | fn test_binh(_x: std::collections::BinaryHeap<()>){}
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `Hashmap` in this scope
+  --> $DIR/collections.rs:10:19
+   |
+LL | fn test_hashm(_x: Hashmap<String, ()>){}
+   |                   ^^^^^^^ not found in this scope
+   |
+help: did you mean `std::collections::HashMap`?
+   |
+LL | fn test_hashm(_x: std::collections::HashMap<String, ()>){}
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `Hashset` in this scope
+  --> $DIR/collections.rs:12:19
+   |
+LL | fn test_hashs(_x: Hashset<()>){}
+   |                   ^^^^^^^ not found in this scope
+   |
+help: did you mean `std::collections::HashSet`?
+   |
+LL | fn test_hashs(_x: std::collections::HashSet<()>){}
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `Linkedlist` in this scope
+  --> $DIR/collections.rs:14:19
+   |
+LL | fn test_llist(_x: Linkedlist<()>){}
+   |                   ^^^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::collections::LinkedList`?
+   |
+LL | fn test_llist(_x: std::collections::LinkedList<()>){}
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `Vecdeque` in this scope
+  --> $DIR/collections.rs:16:16
+   |
+LL | fn test_vd(_x: Vecdeque<()>){}
+   |                ^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::collections::VecDeque`?
+   |
+LL | fn test_vd(_x: std::collections::VecDeque<()>){}
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 7 previous errors
+
+For more information about this error, try `rustc --explain E0412`.

--- a/src/test/ui/libstd-case-typo/collections.stderr
+++ b/src/test/ui/libstd-case-typo/collections.stderr
@@ -5,7 +5,7 @@ LL | fn test_btm(_x: BtreeMap<(), ()>){}
    |                 ^^^^^^^^
    |                 |
    |                 not found in this scope
-   |                 help: found a libstd struct with a similar name: `std::collections::BTreeMap`
+   |                 help: found a std struct with a similar name: `std::collections::BTreeMap`
 
 error[E0412]: cannot find type `BtreeSet` in this scope
   --> $DIR/collections.rs:6:17
@@ -14,7 +14,7 @@ LL | fn test_bts(_x: BtreeSet<()>){}
    |                 ^^^^^^^^
    |                 |
    |                 not found in this scope
-   |                 help: found a libstd struct with a similar name: `std::collections::BTreeSet`
+   |                 help: found a std struct with a similar name: `std::collections::BTreeSet`
 
 error[E0412]: cannot find type `Binaryheap` in this scope
   --> $DIR/collections.rs:8:18
@@ -23,7 +23,7 @@ LL | fn test_binh(_x: Binaryheap<()>){}
    |                  ^^^^^^^^^^
    |                  |
    |                  not found in this scope
-   |                  help: found a libstd struct with a similar name: `std::collections::BinaryHeap`
+   |                  help: found a std struct with a similar name: `std::collections::BinaryHeap`
 
 error[E0412]: cannot find type `Hashmap` in this scope
   --> $DIR/collections.rs:10:19
@@ -32,7 +32,7 @@ LL | fn test_hashm(_x: Hashmap<String, ()>){}
    |                   ^^^^^^^
    |                   |
    |                   not found in this scope
-   |                   help: found a libstd struct with a similar name: `std::collections::HashMap`
+   |                   help: found a std struct with a similar name: `std::collections::HashMap`
 
 error[E0412]: cannot find type `Hashset` in this scope
   --> $DIR/collections.rs:12:19
@@ -41,7 +41,7 @@ LL | fn test_hashs(_x: Hashset<()>){}
    |                   ^^^^^^^
    |                   |
    |                   not found in this scope
-   |                   help: found a libstd struct with a similar name: `std::collections::HashSet`
+   |                   help: found a std struct with a similar name: `std::collections::HashSet`
 
 error[E0412]: cannot find type `Linkedlist` in this scope
   --> $DIR/collections.rs:14:19
@@ -50,7 +50,7 @@ LL | fn test_llist(_x: Linkedlist<()>){}
    |                   ^^^^^^^^^^
    |                   |
    |                   not found in this scope
-   |                   help: found a libstd struct with a similar name: `std::collections::LinkedList`
+   |                   help: found a std struct with a similar name: `std::collections::LinkedList`
 
 error[E0412]: cannot find type `Vecdeque` in this scope
   --> $DIR/collections.rs:16:16
@@ -59,7 +59,7 @@ LL | fn test_vd(_x: Vecdeque<()>){}
    |                ^^^^^^^^
    |                |
    |                not found in this scope
-   |                help: found a libstd struct with a similar name: `std::collections::VecDeque`
+   |                help: found a std struct with a similar name: `std::collections::VecDeque`
 
 error: aborting due to 7 previous errors
 

--- a/src/test/ui/libstd-case-typo/collections.stderr
+++ b/src/test/ui/libstd-case-typo/collections.stderr
@@ -2,78 +2,64 @@ error[E0412]: cannot find type `BtreeMap` in this scope
   --> $DIR/collections.rs:4:17
    |
 LL | fn test_btm(_x: BtreeMap<(), ()>){}
-   |                 ^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::collections::BTreeMap`?
-   |
-LL | fn test_btm(_x: std::collections::BTreeMap<(), ()>){}
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                 ^^^^^^^^
+   |                 |
+   |                 not found in this scope
+   |                 help: found a libstd struct with a similar name: `std::collections::BTreeMap`
 
 error[E0412]: cannot find type `BtreeSet` in this scope
   --> $DIR/collections.rs:6:17
    |
 LL | fn test_bts(_x: BtreeSet<()>){}
-   |                 ^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::collections::BTreeSet`?
-   |
-LL | fn test_bts(_x: std::collections::BTreeSet<()>){}
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                 ^^^^^^^^
+   |                 |
+   |                 not found in this scope
+   |                 help: found a libstd struct with a similar name: `std::collections::BTreeSet`
 
 error[E0412]: cannot find type `Binaryheap` in this scope
   --> $DIR/collections.rs:8:18
    |
 LL | fn test_binh(_x: Binaryheap<()>){}
-   |                  ^^^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::collections::BinaryHeap`?
-   |
-LL | fn test_binh(_x: std::collections::BinaryHeap<()>){}
-   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                  ^^^^^^^^^^
+   |                  |
+   |                  not found in this scope
+   |                  help: found a libstd struct with a similar name: `std::collections::BinaryHeap`
 
 error[E0412]: cannot find type `Hashmap` in this scope
   --> $DIR/collections.rs:10:19
    |
 LL | fn test_hashm(_x: Hashmap<String, ()>){}
-   |                   ^^^^^^^ not found in this scope
-   |
-help: did you mean `std::collections::HashMap`?
-   |
-LL | fn test_hashm(_x: std::collections::HashMap<String, ()>){}
-   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                   ^^^^^^^
+   |                   |
+   |                   not found in this scope
+   |                   help: found a libstd struct with a similar name: `std::collections::HashMap`
 
 error[E0412]: cannot find type `Hashset` in this scope
   --> $DIR/collections.rs:12:19
    |
 LL | fn test_hashs(_x: Hashset<()>){}
-   |                   ^^^^^^^ not found in this scope
-   |
-help: did you mean `std::collections::HashSet`?
-   |
-LL | fn test_hashs(_x: std::collections::HashSet<()>){}
-   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                   ^^^^^^^
+   |                   |
+   |                   not found in this scope
+   |                   help: found a libstd struct with a similar name: `std::collections::HashSet`
 
 error[E0412]: cannot find type `Linkedlist` in this scope
   --> $DIR/collections.rs:14:19
    |
 LL | fn test_llist(_x: Linkedlist<()>){}
-   |                   ^^^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::collections::LinkedList`?
-   |
-LL | fn test_llist(_x: std::collections::LinkedList<()>){}
-   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                   ^^^^^^^^^^
+   |                   |
+   |                   not found in this scope
+   |                   help: found a libstd struct with a similar name: `std::collections::LinkedList`
 
 error[E0412]: cannot find type `Vecdeque` in this scope
   --> $DIR/collections.rs:16:16
    |
 LL | fn test_vd(_x: Vecdeque<()>){}
-   |                ^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::collections::VecDeque`?
-   |
-LL | fn test_vd(_x: std::collections::VecDeque<()>){}
-   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                ^^^^^^^^
+   |                |
+   |                not found in this scope
+   |                help: found a libstd struct with a similar name: `std::collections::VecDeque`
 
 error: aborting due to 7 previous errors
 

--- a/src/test/ui/libstd-case-typo/env.rs
+++ b/src/test/ui/libstd-case-typo/env.rs
@@ -1,0 +1,13 @@
+// checks case typos with libstd::env structs
+fn main(){}
+
+fn test_args(_x: args){}
+//~^ ERROR: cannot find type `args` in this scope
+fn test_argsos(_x: Argsos){}
+//~^ ERROR: cannot find type `Argsos` in this scope
+fn test_sp(_x: Splitpaths<'_>){}
+//~^ ERROR: cannot find type `Splitpaths` in this scope
+fn test_vars(_x: vars){}
+//~^ ERROR: cannot find type `vars` in this scope
+fn test_varsos(_x: Varsos){}
+//~^ ERROR: cannot find type `Varsos` in this scope

--- a/src/test/ui/libstd-case-typo/env.stderr
+++ b/src/test/ui/libstd-case-typo/env.stderr
@@ -1,0 +1,58 @@
+error[E0412]: cannot find type `args` in this scope
+  --> $DIR/env.rs:4:18
+   |
+LL | fn test_args(_x: args){}
+   |                  ^^^^ not found in this scope
+   |
+help: did you mean `std::env::Args`?
+   |
+LL | fn test_args(_x: std::env::Args){}
+   |                  ^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `Argsos` in this scope
+  --> $DIR/env.rs:6:20
+   |
+LL | fn test_argsos(_x: Argsos){}
+   |                    ^^^^^^ not found in this scope
+   |
+help: did you mean `std::env::ArgsOs`?
+   |
+LL | fn test_argsos(_x: std::env::ArgsOs){}
+   |                    ^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `Splitpaths` in this scope
+  --> $DIR/env.rs:8:16
+   |
+LL | fn test_sp(_x: Splitpaths<'_>){}
+   |                ^^^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::env::SplitPaths`?
+   |
+LL | fn test_sp(_x: std::env::SplitPaths<'_>){}
+   |                ^^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `vars` in this scope
+  --> $DIR/env.rs:10:18
+   |
+LL | fn test_vars(_x: vars){}
+   |                  ^^^^ not found in this scope
+   |
+help: did you mean `std::env::Vars`?
+   |
+LL | fn test_vars(_x: std::env::Vars){}
+   |                  ^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `Varsos` in this scope
+  --> $DIR/env.rs:12:20
+   |
+LL | fn test_varsos(_x: Varsos){}
+   |                    ^^^^^^ not found in this scope
+   |
+help: did you mean `std::env::VarsOs`?
+   |
+LL | fn test_varsos(_x: std::env::VarsOs){}
+   |                    ^^^^^^^^^^^^^^^^
+
+error: aborting due to 5 previous errors
+
+For more information about this error, try `rustc --explain E0412`.

--- a/src/test/ui/libstd-case-typo/env.stderr
+++ b/src/test/ui/libstd-case-typo/env.stderr
@@ -5,7 +5,7 @@ LL | fn test_args(_x: args){}
    |                  ^^^^
    |                  |
    |                  not found in this scope
-   |                  help: found a libstd struct with a similar name: `std::env::Args`
+   |                  help: found a std struct with a similar name: `std::env::Args`
 
 error[E0412]: cannot find type `Argsos` in this scope
   --> $DIR/env.rs:6:20
@@ -14,7 +14,7 @@ LL | fn test_argsos(_x: Argsos){}
    |                    ^^^^^^
    |                    |
    |                    not found in this scope
-   |                    help: found a libstd struct with a similar name: `std::env::ArgsOs`
+   |                    help: found a std struct with a similar name: `std::env::ArgsOs`
 
 error[E0412]: cannot find type `Splitpaths` in this scope
   --> $DIR/env.rs:8:16
@@ -23,7 +23,7 @@ LL | fn test_sp(_x: Splitpaths<'_>){}
    |                ^^^^^^^^^^
    |                |
    |                not found in this scope
-   |                help: found a libstd struct with a similar name: `std::env::SplitPaths`
+   |                help: found a std struct with a similar name: `std::env::SplitPaths`
 
 error[E0412]: cannot find type `vars` in this scope
   --> $DIR/env.rs:10:18
@@ -32,7 +32,7 @@ LL | fn test_vars(_x: vars){}
    |                  ^^^^
    |                  |
    |                  not found in this scope
-   |                  help: found a libstd struct with a similar name: `std::env::Vars`
+   |                  help: found a std struct with a similar name: `std::env::Vars`
 
 error[E0412]: cannot find type `Varsos` in this scope
   --> $DIR/env.rs:12:20
@@ -41,7 +41,7 @@ LL | fn test_varsos(_x: Varsos){}
    |                    ^^^^^^
    |                    |
    |                    not found in this scope
-   |                    help: found a libstd struct with a similar name: `std::env::VarsOs`
+   |                    help: found a std struct with a similar name: `std::env::VarsOs`
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/libstd-case-typo/env.stderr
+++ b/src/test/ui/libstd-case-typo/env.stderr
@@ -2,56 +2,46 @@ error[E0412]: cannot find type `args` in this scope
   --> $DIR/env.rs:4:18
    |
 LL | fn test_args(_x: args){}
-   |                  ^^^^ not found in this scope
-   |
-help: did you mean `std::env::Args`?
-   |
-LL | fn test_args(_x: std::env::Args){}
-   |                  ^^^^^^^^^^^^^^
+   |                  ^^^^
+   |                  |
+   |                  not found in this scope
+   |                  help: found a libstd struct with a similar name: `std::env::Args`
 
 error[E0412]: cannot find type `Argsos` in this scope
   --> $DIR/env.rs:6:20
    |
 LL | fn test_argsos(_x: Argsos){}
-   |                    ^^^^^^ not found in this scope
-   |
-help: did you mean `std::env::ArgsOs`?
-   |
-LL | fn test_argsos(_x: std::env::ArgsOs){}
-   |                    ^^^^^^^^^^^^^^^^
+   |                    ^^^^^^
+   |                    |
+   |                    not found in this scope
+   |                    help: found a libstd struct with a similar name: `std::env::ArgsOs`
 
 error[E0412]: cannot find type `Splitpaths` in this scope
   --> $DIR/env.rs:8:16
    |
 LL | fn test_sp(_x: Splitpaths<'_>){}
-   |                ^^^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::env::SplitPaths`?
-   |
-LL | fn test_sp(_x: std::env::SplitPaths<'_>){}
-   |                ^^^^^^^^^^^^^^^^^^^^
+   |                ^^^^^^^^^^
+   |                |
+   |                not found in this scope
+   |                help: found a libstd struct with a similar name: `std::env::SplitPaths`
 
 error[E0412]: cannot find type `vars` in this scope
   --> $DIR/env.rs:10:18
    |
 LL | fn test_vars(_x: vars){}
-   |                  ^^^^ not found in this scope
-   |
-help: did you mean `std::env::Vars`?
-   |
-LL | fn test_vars(_x: std::env::Vars){}
-   |                  ^^^^^^^^^^^^^^
+   |                  ^^^^
+   |                  |
+   |                  not found in this scope
+   |                  help: found a libstd struct with a similar name: `std::env::Vars`
 
 error[E0412]: cannot find type `Varsos` in this scope
   --> $DIR/env.rs:12:20
    |
 LL | fn test_varsos(_x: Varsos){}
-   |                    ^^^^^^ not found in this scope
-   |
-help: did you mean `std::env::VarsOs`?
-   |
-LL | fn test_varsos(_x: std::env::VarsOs){}
-   |                    ^^^^^^^^^^^^^^^^
+   |                    ^^^^^^
+   |                    |
+   |                    not found in this scope
+   |                    help: found a libstd struct with a similar name: `std::env::VarsOs`
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/libstd-case-typo/ffi.rs
+++ b/src/test/ui/libstd-case-typo/ffi.rs
@@ -1,0 +1,9 @@
+// checks case typos with libstd::ffi structs
+fn main(){}
+
+fn test_cstr(_x: cStr){}
+//~^ ERROR: cannot find type `cStr` in this scope
+fn test_osstr(_x: Osstr){}
+//~^ ERROR: cannot find type `Osstr` in this scope
+fn test_osstring(_x: Osstring){}
+//~^ ERROR: cannot find type `Osstring` in this scope

--- a/src/test/ui/libstd-case-typo/ffi.stderr
+++ b/src/test/ui/libstd-case-typo/ffi.stderr
@@ -2,34 +2,28 @@ error[E0412]: cannot find type `cStr` in this scope
   --> $DIR/ffi.rs:4:18
    |
 LL | fn test_cstr(_x: cStr){}
-   |                  ^^^^ not found in this scope
-   |
-help: did you mean `std::ffi::CStr`?
-   |
-LL | fn test_cstr(_x: std::ffi::CStr){}
-   |                  ^^^^^^^^^^^^^^
+   |                  ^^^^
+   |                  |
+   |                  not found in this scope
+   |                  help: found a libstd struct with a similar name: `std::ffi::CStr`
 
 error[E0412]: cannot find type `Osstr` in this scope
   --> $DIR/ffi.rs:6:19
    |
 LL | fn test_osstr(_x: Osstr){}
-   |                   ^^^^^ not found in this scope
-   |
-help: did you mean `std::ffi::OsStr`?
-   |
-LL | fn test_osstr(_x: std::ffi::OsStr){}
-   |                   ^^^^^^^^^^^^^^^
+   |                   ^^^^^
+   |                   |
+   |                   not found in this scope
+   |                   help: found a libstd struct with a similar name: `std::ffi::OsStr`
 
 error[E0412]: cannot find type `Osstring` in this scope
   --> $DIR/ffi.rs:8:22
    |
 LL | fn test_osstring(_x: Osstring){}
-   |                      ^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::ffi::OsString`?
-   |
-LL | fn test_osstring(_x: std::ffi::OsString){}
-   |                      ^^^^^^^^^^^^^^^^^^
+   |                      ^^^^^^^^
+   |                      |
+   |                      not found in this scope
+   |                      help: found a libstd struct with a similar name: `std::ffi::OsString`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/libstd-case-typo/ffi.stderr
+++ b/src/test/ui/libstd-case-typo/ffi.stderr
@@ -1,0 +1,36 @@
+error[E0412]: cannot find type `cStr` in this scope
+  --> $DIR/ffi.rs:4:18
+   |
+LL | fn test_cstr(_x: cStr){}
+   |                  ^^^^ not found in this scope
+   |
+help: did you mean `std::ffi::CStr`?
+   |
+LL | fn test_cstr(_x: std::ffi::CStr){}
+   |                  ^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `Osstr` in this scope
+  --> $DIR/ffi.rs:6:19
+   |
+LL | fn test_osstr(_x: Osstr){}
+   |                   ^^^^^ not found in this scope
+   |
+help: did you mean `std::ffi::OsStr`?
+   |
+LL | fn test_osstr(_x: std::ffi::OsStr){}
+   |                   ^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `Osstring` in this scope
+  --> $DIR/ffi.rs:8:22
+   |
+LL | fn test_osstring(_x: Osstring){}
+   |                      ^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::ffi::OsString`?
+   |
+LL | fn test_osstring(_x: std::ffi::OsString){}
+   |                      ^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0412`.

--- a/src/test/ui/libstd-case-typo/ffi.stderr
+++ b/src/test/ui/libstd-case-typo/ffi.stderr
@@ -5,7 +5,7 @@ LL | fn test_cstr(_x: cStr){}
    |                  ^^^^
    |                  |
    |                  not found in this scope
-   |                  help: found a libstd struct with a similar name: `std::ffi::CStr`
+   |                  help: found a std struct with a similar name: `std::ffi::CStr`
 
 error[E0412]: cannot find type `Osstr` in this scope
   --> $DIR/ffi.rs:6:19
@@ -14,7 +14,7 @@ LL | fn test_osstr(_x: Osstr){}
    |                   ^^^^^
    |                   |
    |                   not found in this scope
-   |                   help: found a libstd struct with a similar name: `std::ffi::OsStr`
+   |                   help: found a std struct with a similar name: `std::ffi::OsStr`
 
 error[E0412]: cannot find type `Osstring` in this scope
   --> $DIR/ffi.rs:8:22
@@ -23,7 +23,7 @@ LL | fn test_osstring(_x: Osstring){}
    |                      ^^^^^^^^
    |                      |
    |                      not found in this scope
-   |                      help: found a libstd struct with a similar name: `std::ffi::OsString`
+   |                      help: found a std struct with a similar name: `std::ffi::OsString`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/libstd-case-typo/fmt.rs
+++ b/src/test/ui/libstd-case-typo/fmt.rs
@@ -1,0 +1,15 @@
+// checks case typos with libstd::fmt structs
+fn main(){}
+
+fn test_dbglist(_x: Debuglist){}
+//~^ ERROR: cannot find type `Debuglist` in this scope
+fn test_dbgmap(_x: Debugmap){}
+//~^ ERROR: cannot find type `Debugmap` in this scope
+fn test_dbgset(_x: Debugset){}
+//~^ ERROR: cannot find type `Debugset` in this scope
+fn test_dbgstruct(_x: Debugstruct){}
+//~^ ERROR: cannot find type `Debugstruct` in this scope
+fn test_dbgtuple(_x: Debugtuple){}
+//~^ ERROR: cannot find type `Debugtuple` in this scope
+fn test_fmter(mut _x: formatter){}
+//~^ ERROR: cannot find type `formatter` in this scope

--- a/src/test/ui/libstd-case-typo/fmt.stderr
+++ b/src/test/ui/libstd-case-typo/fmt.stderr
@@ -2,67 +2,55 @@ error[E0412]: cannot find type `Debuglist` in this scope
   --> $DIR/fmt.rs:4:21
    |
 LL | fn test_dbglist(_x: Debuglist){}
-   |                     ^^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::fmt::DebugList`?
-   |
-LL | fn test_dbglist(_x: std::fmt::DebugList){}
-   |                     ^^^^^^^^^^^^^^^^^^^
+   |                     ^^^^^^^^^
+   |                     |
+   |                     not found in this scope
+   |                     help: found a libstd struct with a similar name: `std::fmt::DebugList`
 
 error[E0412]: cannot find type `Debugmap` in this scope
   --> $DIR/fmt.rs:6:20
    |
 LL | fn test_dbgmap(_x: Debugmap){}
-   |                    ^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::fmt::DebugMap`?
-   |
-LL | fn test_dbgmap(_x: std::fmt::DebugMap){}
-   |                    ^^^^^^^^^^^^^^^^^^
+   |                    ^^^^^^^^
+   |                    |
+   |                    not found in this scope
+   |                    help: found a libstd struct with a similar name: `std::fmt::DebugMap`
 
 error[E0412]: cannot find type `Debugset` in this scope
   --> $DIR/fmt.rs:8:20
    |
 LL | fn test_dbgset(_x: Debugset){}
-   |                    ^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::fmt::DebugSet`?
-   |
-LL | fn test_dbgset(_x: std::fmt::DebugSet){}
-   |                    ^^^^^^^^^^^^^^^^^^
+   |                    ^^^^^^^^
+   |                    |
+   |                    not found in this scope
+   |                    help: found a libstd struct with a similar name: `std::fmt::DebugSet`
 
 error[E0412]: cannot find type `Debugstruct` in this scope
   --> $DIR/fmt.rs:10:23
    |
 LL | fn test_dbgstruct(_x: Debugstruct){}
-   |                       ^^^^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::fmt::DebugStruct`?
-   |
-LL | fn test_dbgstruct(_x: std::fmt::DebugStruct){}
-   |                       ^^^^^^^^^^^^^^^^^^^^^
+   |                       ^^^^^^^^^^^
+   |                       |
+   |                       not found in this scope
+   |                       help: found a libstd struct with a similar name: `std::fmt::DebugStruct`
 
 error[E0412]: cannot find type `Debugtuple` in this scope
   --> $DIR/fmt.rs:12:22
    |
 LL | fn test_dbgtuple(_x: Debugtuple){}
-   |                      ^^^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::fmt::DebugTuple`?
-   |
-LL | fn test_dbgtuple(_x: std::fmt::DebugTuple){}
-   |                      ^^^^^^^^^^^^^^^^^^^^
+   |                      ^^^^^^^^^^
+   |                      |
+   |                      not found in this scope
+   |                      help: found a libstd struct with a similar name: `std::fmt::DebugTuple`
 
 error[E0412]: cannot find type `formatter` in this scope
   --> $DIR/fmt.rs:14:23
    |
 LL | fn test_fmter(mut _x: formatter){}
-   |                       ^^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::fmt::Formatter`?
-   |
-LL | fn test_fmter(mut _x: std::fmt::Formatter){}
-   |                       ^^^^^^^^^^^^^^^^^^^
+   |                       ^^^^^^^^^
+   |                       |
+   |                       not found in this scope
+   |                       help: found a libstd struct with a similar name: `std::fmt::Formatter`
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/libstd-case-typo/fmt.stderr
+++ b/src/test/ui/libstd-case-typo/fmt.stderr
@@ -1,0 +1,69 @@
+error[E0412]: cannot find type `Debuglist` in this scope
+  --> $DIR/fmt.rs:4:21
+   |
+LL | fn test_dbglist(_x: Debuglist){}
+   |                     ^^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::fmt::DebugList`?
+   |
+LL | fn test_dbglist(_x: std::fmt::DebugList){}
+   |                     ^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `Debugmap` in this scope
+  --> $DIR/fmt.rs:6:20
+   |
+LL | fn test_dbgmap(_x: Debugmap){}
+   |                    ^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::fmt::DebugMap`?
+   |
+LL | fn test_dbgmap(_x: std::fmt::DebugMap){}
+   |                    ^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `Debugset` in this scope
+  --> $DIR/fmt.rs:8:20
+   |
+LL | fn test_dbgset(_x: Debugset){}
+   |                    ^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::fmt::DebugSet`?
+   |
+LL | fn test_dbgset(_x: std::fmt::DebugSet){}
+   |                    ^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `Debugstruct` in this scope
+  --> $DIR/fmt.rs:10:23
+   |
+LL | fn test_dbgstruct(_x: Debugstruct){}
+   |                       ^^^^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::fmt::DebugStruct`?
+   |
+LL | fn test_dbgstruct(_x: std::fmt::DebugStruct){}
+   |                       ^^^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `Debugtuple` in this scope
+  --> $DIR/fmt.rs:12:22
+   |
+LL | fn test_dbgtuple(_x: Debugtuple){}
+   |                      ^^^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::fmt::DebugTuple`?
+   |
+LL | fn test_dbgtuple(_x: std::fmt::DebugTuple){}
+   |                      ^^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `formatter` in this scope
+  --> $DIR/fmt.rs:14:23
+   |
+LL | fn test_fmter(mut _x: formatter){}
+   |                       ^^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::fmt::Formatter`?
+   |
+LL | fn test_fmter(mut _x: std::fmt::Formatter){}
+   |                       ^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 6 previous errors
+
+For more information about this error, try `rustc --explain E0412`.

--- a/src/test/ui/libstd-case-typo/fmt.stderr
+++ b/src/test/ui/libstd-case-typo/fmt.stderr
@@ -5,7 +5,7 @@ LL | fn test_dbglist(_x: Debuglist){}
    |                     ^^^^^^^^^
    |                     |
    |                     not found in this scope
-   |                     help: found a libstd struct with a similar name: `std::fmt::DebugList`
+   |                     help: found a std struct with a similar name: `std::fmt::DebugList`
 
 error[E0412]: cannot find type `Debugmap` in this scope
   --> $DIR/fmt.rs:6:20
@@ -14,7 +14,7 @@ LL | fn test_dbgmap(_x: Debugmap){}
    |                    ^^^^^^^^
    |                    |
    |                    not found in this scope
-   |                    help: found a libstd struct with a similar name: `std::fmt::DebugMap`
+   |                    help: found a std struct with a similar name: `std::fmt::DebugMap`
 
 error[E0412]: cannot find type `Debugset` in this scope
   --> $DIR/fmt.rs:8:20
@@ -23,7 +23,7 @@ LL | fn test_dbgset(_x: Debugset){}
    |                    ^^^^^^^^
    |                    |
    |                    not found in this scope
-   |                    help: found a libstd struct with a similar name: `std::fmt::DebugSet`
+   |                    help: found a std struct with a similar name: `std::fmt::DebugSet`
 
 error[E0412]: cannot find type `Debugstruct` in this scope
   --> $DIR/fmt.rs:10:23
@@ -32,7 +32,7 @@ LL | fn test_dbgstruct(_x: Debugstruct){}
    |                       ^^^^^^^^^^^
    |                       |
    |                       not found in this scope
-   |                       help: found a libstd struct with a similar name: `std::fmt::DebugStruct`
+   |                       help: found a std struct with a similar name: `std::fmt::DebugStruct`
 
 error[E0412]: cannot find type `Debugtuple` in this scope
   --> $DIR/fmt.rs:12:22
@@ -41,7 +41,7 @@ LL | fn test_dbgtuple(_x: Debugtuple){}
    |                      ^^^^^^^^^^
    |                      |
    |                      not found in this scope
-   |                      help: found a libstd struct with a similar name: `std::fmt::DebugTuple`
+   |                      help: found a std struct with a similar name: `std::fmt::DebugTuple`
 
 error[E0412]: cannot find type `formatter` in this scope
   --> $DIR/fmt.rs:14:23
@@ -50,7 +50,7 @@ LL | fn test_fmter(mut _x: formatter){}
    |                       ^^^^^^^^^
    |                       |
    |                       not found in this scope
-   |                       help: found a libstd struct with a similar name: `std::fmt::Formatter`
+   |                       help: found a std struct with a similar name: `std::fmt::Formatter`
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/libstd-case-typo/fs.rs
+++ b/src/test/ui/libstd-case-typo/fs.rs
@@ -1,0 +1,17 @@
+// checks case typos with libstd::fs structs
+fn main(){}
+
+fn test_dirbuild(_x: Dirbuilder){}
+//~^ ERROR: cannot find type `Dirbuilder` in this scope
+fn test_direntry(_x: Direntry){}
+//~^ ERROR: cannot find type `Direntry` in this scope
+fn test_filety(_x: Filetype){}
+//~^ ERROR: cannot find type `Filetype` in this scope
+fn test_metadata(_x: MetaData){}
+//~^ ERROR: cannot find type `MetaData` in this scope
+fn test_opop(_x: Openoptions){}
+//~^ ERROR: cannot find type `Openoptions` in this scope
+fn test_perm(_x: permissions){}
+//~^ ERROR: cannot find type `permissions` in this scope
+fn test_readdir(_x: Readdir){}
+//~^ ERROR: cannot find type `Readdir` in this scope

--- a/src/test/ui/libstd-case-typo/fs.stderr
+++ b/src/test/ui/libstd-case-typo/fs.stderr
@@ -5,7 +5,7 @@ LL | fn test_dirbuild(_x: Dirbuilder){}
    |                      ^^^^^^^^^^
    |                      |
    |                      not found in this scope
-   |                      help: found a libstd struct with a similar name: `std::fs::DirBuilder`
+   |                      help: found a std struct with a similar name: `std::fs::DirBuilder`
 
 error[E0412]: cannot find type `Direntry` in this scope
   --> $DIR/fs.rs:6:22
@@ -14,7 +14,7 @@ LL | fn test_direntry(_x: Direntry){}
    |                      ^^^^^^^^
    |                      |
    |                      not found in this scope
-   |                      help: found a libstd struct with a similar name: `std::fs::DirEntry`
+   |                      help: found a std struct with a similar name: `std::fs::DirEntry`
 
 error[E0412]: cannot find type `Filetype` in this scope
   --> $DIR/fs.rs:8:20
@@ -23,7 +23,7 @@ LL | fn test_filety(_x: Filetype){}
    |                    ^^^^^^^^
    |                    |
    |                    not found in this scope
-   |                    help: found a libstd struct with a similar name: `std::fs::FileType`
+   |                    help: found a std struct with a similar name: `std::fs::FileType`
 
 error[E0412]: cannot find type `MetaData` in this scope
   --> $DIR/fs.rs:10:22
@@ -32,7 +32,7 @@ LL | fn test_metadata(_x: MetaData){}
    |                      ^^^^^^^^
    |                      |
    |                      not found in this scope
-   |                      help: found a libstd struct with a similar name: `std::fs::Metadata`
+   |                      help: found a std struct with a similar name: `std::fs::Metadata`
 
 error[E0412]: cannot find type `Openoptions` in this scope
   --> $DIR/fs.rs:12:18
@@ -41,7 +41,7 @@ LL | fn test_opop(_x: Openoptions){}
    |                  ^^^^^^^^^^^
    |                  |
    |                  not found in this scope
-   |                  help: found a libstd struct with a similar name: `std::fs::OpenOptions`
+   |                  help: found a std struct with a similar name: `std::fs::OpenOptions`
 
 error[E0412]: cannot find type `permissions` in this scope
   --> $DIR/fs.rs:14:18
@@ -50,7 +50,7 @@ LL | fn test_perm(_x: permissions){}
    |                  ^^^^^^^^^^^
    |                  |
    |                  not found in this scope
-   |                  help: found a libstd struct with a similar name: `std::fs::Permissions`
+   |                  help: found a std struct with a similar name: `std::fs::Permissions`
 
 error[E0412]: cannot find type `Readdir` in this scope
   --> $DIR/fs.rs:16:21
@@ -59,7 +59,7 @@ LL | fn test_readdir(_x: Readdir){}
    |                     ^^^^^^^
    |                     |
    |                     not found in this scope
-   |                     help: found a libstd struct with a similar name: `std::fs::ReadDir`
+   |                     help: found a std struct with a similar name: `std::fs::ReadDir`
 
 error: aborting due to 7 previous errors
 

--- a/src/test/ui/libstd-case-typo/fs.stderr
+++ b/src/test/ui/libstd-case-typo/fs.stderr
@@ -1,0 +1,80 @@
+error[E0412]: cannot find type `Dirbuilder` in this scope
+  --> $DIR/fs.rs:4:22
+   |
+LL | fn test_dirbuild(_x: Dirbuilder){}
+   |                      ^^^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::fs::DirBuilder`?
+   |
+LL | fn test_dirbuild(_x: std::fs::DirBuilder){}
+   |                      ^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `Direntry` in this scope
+  --> $DIR/fs.rs:6:22
+   |
+LL | fn test_direntry(_x: Direntry){}
+   |                      ^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::fs::DirEntry`?
+   |
+LL | fn test_direntry(_x: std::fs::DirEntry){}
+   |                      ^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `Filetype` in this scope
+  --> $DIR/fs.rs:8:20
+   |
+LL | fn test_filety(_x: Filetype){}
+   |                    ^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::fs::FileType`?
+   |
+LL | fn test_filety(_x: std::fs::FileType){}
+   |                    ^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `MetaData` in this scope
+  --> $DIR/fs.rs:10:22
+   |
+LL | fn test_metadata(_x: MetaData){}
+   |                      ^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::fs::Metadata`?
+   |
+LL | fn test_metadata(_x: std::fs::Metadata){}
+   |                      ^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `Openoptions` in this scope
+  --> $DIR/fs.rs:12:18
+   |
+LL | fn test_opop(_x: Openoptions){}
+   |                  ^^^^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::fs::OpenOptions`?
+   |
+LL | fn test_opop(_x: std::fs::OpenOptions){}
+   |                  ^^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `permissions` in this scope
+  --> $DIR/fs.rs:14:18
+   |
+LL | fn test_perm(_x: permissions){}
+   |                  ^^^^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::fs::Permissions`?
+   |
+LL | fn test_perm(_x: std::fs::Permissions){}
+   |                  ^^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `Readdir` in this scope
+  --> $DIR/fs.rs:16:21
+   |
+LL | fn test_readdir(_x: Readdir){}
+   |                     ^^^^^^^ not found in this scope
+   |
+help: did you mean `std::fs::ReadDir`?
+   |
+LL | fn test_readdir(_x: std::fs::ReadDir){}
+   |                     ^^^^^^^^^^^^^^^^
+
+error: aborting due to 7 previous errors
+
+For more information about this error, try `rustc --explain E0412`.

--- a/src/test/ui/libstd-case-typo/fs.stderr
+++ b/src/test/ui/libstd-case-typo/fs.stderr
@@ -2,78 +2,64 @@ error[E0412]: cannot find type `Dirbuilder` in this scope
   --> $DIR/fs.rs:4:22
    |
 LL | fn test_dirbuild(_x: Dirbuilder){}
-   |                      ^^^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::fs::DirBuilder`?
-   |
-LL | fn test_dirbuild(_x: std::fs::DirBuilder){}
-   |                      ^^^^^^^^^^^^^^^^^^^
+   |                      ^^^^^^^^^^
+   |                      |
+   |                      not found in this scope
+   |                      help: found a libstd struct with a similar name: `std::fs::DirBuilder`
 
 error[E0412]: cannot find type `Direntry` in this scope
   --> $DIR/fs.rs:6:22
    |
 LL | fn test_direntry(_x: Direntry){}
-   |                      ^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::fs::DirEntry`?
-   |
-LL | fn test_direntry(_x: std::fs::DirEntry){}
-   |                      ^^^^^^^^^^^^^^^^^
+   |                      ^^^^^^^^
+   |                      |
+   |                      not found in this scope
+   |                      help: found a libstd struct with a similar name: `std::fs::DirEntry`
 
 error[E0412]: cannot find type `Filetype` in this scope
   --> $DIR/fs.rs:8:20
    |
 LL | fn test_filety(_x: Filetype){}
-   |                    ^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::fs::FileType`?
-   |
-LL | fn test_filety(_x: std::fs::FileType){}
-   |                    ^^^^^^^^^^^^^^^^^
+   |                    ^^^^^^^^
+   |                    |
+   |                    not found in this scope
+   |                    help: found a libstd struct with a similar name: `std::fs::FileType`
 
 error[E0412]: cannot find type `MetaData` in this scope
   --> $DIR/fs.rs:10:22
    |
 LL | fn test_metadata(_x: MetaData){}
-   |                      ^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::fs::Metadata`?
-   |
-LL | fn test_metadata(_x: std::fs::Metadata){}
-   |                      ^^^^^^^^^^^^^^^^^
+   |                      ^^^^^^^^
+   |                      |
+   |                      not found in this scope
+   |                      help: found a libstd struct with a similar name: `std::fs::Metadata`
 
 error[E0412]: cannot find type `Openoptions` in this scope
   --> $DIR/fs.rs:12:18
    |
 LL | fn test_opop(_x: Openoptions){}
-   |                  ^^^^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::fs::OpenOptions`?
-   |
-LL | fn test_opop(_x: std::fs::OpenOptions){}
-   |                  ^^^^^^^^^^^^^^^^^^^^
+   |                  ^^^^^^^^^^^
+   |                  |
+   |                  not found in this scope
+   |                  help: found a libstd struct with a similar name: `std::fs::OpenOptions`
 
 error[E0412]: cannot find type `permissions` in this scope
   --> $DIR/fs.rs:14:18
    |
 LL | fn test_perm(_x: permissions){}
-   |                  ^^^^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::fs::Permissions`?
-   |
-LL | fn test_perm(_x: std::fs::Permissions){}
-   |                  ^^^^^^^^^^^^^^^^^^^^
+   |                  ^^^^^^^^^^^
+   |                  |
+   |                  not found in this scope
+   |                  help: found a libstd struct with a similar name: `std::fs::Permissions`
 
 error[E0412]: cannot find type `Readdir` in this scope
   --> $DIR/fs.rs:16:21
    |
 LL | fn test_readdir(_x: Readdir){}
-   |                     ^^^^^^^ not found in this scope
-   |
-help: did you mean `std::fs::ReadDir`?
-   |
-LL | fn test_readdir(_x: std::fs::ReadDir){}
-   |                     ^^^^^^^^^^^^^^^^
+   |                     ^^^^^^^
+   |                     |
+   |                     not found in this scope
+   |                     help: found a libstd struct with a similar name: `std::fs::ReadDir`
 
 error: aborting due to 7 previous errors
 

--- a/src/test/ui/libstd-case-typo/hash.rs
+++ b/src/test/ui/libstd-case-typo/hash.rs
@@ -1,0 +1,5 @@
+// checks case typos with libstd::hash structs
+fn main(){}
+
+fn test_bhd(_x: BuildhasherDefault){}
+//~^ ERROR: cannot find type `BuildhasherDefault` in this scope

--- a/src/test/ui/libstd-case-typo/hash.stderr
+++ b/src/test/ui/libstd-case-typo/hash.stderr
@@ -1,0 +1,14 @@
+error[E0412]: cannot find type `BuildhasherDefault` in this scope
+  --> $DIR/hash.rs:4:17
+   |
+LL | fn test_bhd(_x: BuildhasherDefault){}
+   |                 ^^^^^^^^^^^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::hash::BuildHasherDefault`?
+   |
+LL | fn test_bhd(_x: std::hash::BuildHasherDefault){}
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0412`.

--- a/src/test/ui/libstd-case-typo/hash.stderr
+++ b/src/test/ui/libstd-case-typo/hash.stderr
@@ -2,12 +2,10 @@ error[E0412]: cannot find type `BuildhasherDefault` in this scope
   --> $DIR/hash.rs:4:17
    |
 LL | fn test_bhd(_x: BuildhasherDefault){}
-   |                 ^^^^^^^^^^^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::hash::BuildHasherDefault`?
-   |
-LL | fn test_bhd(_x: std::hash::BuildHasherDefault){}
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                 ^^^^^^^^^^^^^^^^^^
+   |                 |
+   |                 not found in this scope
+   |                 help: found a libstd struct with a similar name: `std::hash::BuildHasherDefault`
 
 error: aborting due to previous error
 

--- a/src/test/ui/libstd-case-typo/hash.stderr
+++ b/src/test/ui/libstd-case-typo/hash.stderr
@@ -5,7 +5,7 @@ LL | fn test_bhd(_x: BuildhasherDefault){}
    |                 ^^^^^^^^^^^^^^^^^^
    |                 |
    |                 not found in this scope
-   |                 help: found a libstd struct with a similar name: `std::hash::BuildHasherDefault`
+   |                 help: found a std struct with a similar name: `std::hash::BuildHasherDefault`
 
 error: aborting due to previous error
 

--- a/src/test/ui/libstd-case-typo/io.rs
+++ b/src/test/ui/libstd-case-typo/io.rs
@@ -1,0 +1,43 @@
+// checks case typos with libstd::io structs
+fn main(){}
+
+fn test_bufrd(_x: Bufreader<()>){}
+//~^ ERROR: cannot find type `Bufreader` in this scope
+fn test_bufwr(_x: Bufwriter<()>){}
+//~^ ERROR: cannot find type `Bufwriter` in this scope
+fn test_bytes(_x: bytes<()>){}
+//~^ ERROR: cannot find type `bytes` in this scope
+fn test_chain(_x: chain<(), ()>){}
+//~^ ERROR: cannot find type `chain` in this scope
+fn test_cursor(_x: cursor<()>){}
+//~^ ERROR: cannot find type `cursor` in this scope
+fn test_empty(_x: empty){}
+//~^ ERROR: cannot find type `empty` in this scope
+fn test_ios(_x: Ioslice){}
+//~^ ERROR: cannot find type `Ioslice` in this scope
+fn test_iosm(_x: IosliceMut){}
+//~^ ERROR: cannot find type `IosliceMut` in this scope
+fn test_linewr(_x: Linewriter<()>){}
+//~^ ERROR: cannot find type `Linewriter` in this scope
+fn test_lines(_x: lines<()>){}
+//~^ ERROR: cannot find type `lines` in this scope
+fn test_repeat(_x: repeat){}
+//~^ ERROR: cannot find type `repeat` in this scope
+fn test_sink(_x: sink){}
+//~^ ERROR: cannot find type `sink` in this scope
+fn test_split(_x: split<()>){}
+//~^ ERROR: cannot find type `split` in this scope
+fn test_stderr(_x: StdErr){}
+//~^ ERROR: cannot find type `StdErr` in this scope
+fn test_stderr_l(_x: StdErrLock){}
+//~^ ERROR: cannot find type `StdErrLock` in this scope
+fn test_stdind(_x: StdIn){}
+//~^ ERROR: cannot find type `StdIn` in this scope
+fn test_stdin_l(_x: StdInLock){}
+//~^ ERROR: cannot find type `StdInLock` in this scope
+fn test_stdout(_x: StdOut){}
+//~^ ERROR: cannot find type `StdOut` in this scope
+fn test_stdout_l(_x: StdOutLock){}
+//~^ ERROR: cannot find type `StdOutLock` in this scope
+fn test_take(_x: take){}
+//~^ ERROR: cannot find type `take` in this scope

--- a/src/test/ui/libstd-case-typo/io.stderr
+++ b/src/test/ui/libstd-case-typo/io.stderr
@@ -1,0 +1,237 @@
+error[E0412]: cannot find type `Bufreader` in this scope
+  --> $DIR/io.rs:4:19
+   |
+LL | fn test_bufrd(_x: Bufreader<()>){}
+   |                   ^^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::io::BufReader`?
+   |
+LL | fn test_bufrd(_x: std::io::BufReader<()>){}
+   |                   ^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `Bufwriter` in this scope
+  --> $DIR/io.rs:6:19
+   |
+LL | fn test_bufwr(_x: Bufwriter<()>){}
+   |                   ^^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::io::BufWriter`?
+   |
+LL | fn test_bufwr(_x: std::io::BufWriter<()>){}
+   |                   ^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `bytes` in this scope
+  --> $DIR/io.rs:8:19
+   |
+LL | fn test_bytes(_x: bytes<()>){}
+   |                   ^^^^^ not found in this scope
+   |
+help: did you mean one of these?:
+   |
+LL | fn test_bytes(_x: std::io::Bytes<()>){}
+   |                   ^^^^^^^^^^^^^^
+LL | fn test_bytes(_x: std::str::Bytes<()>){}
+   |                   ^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `chain` in this scope
+  --> $DIR/io.rs:10:19
+   |
+LL | fn test_chain(_x: chain<(), ()>){}
+   |                   ^^^^^ not found in this scope
+   |
+help: did you mean one of these?:
+   |
+LL | fn test_chain(_x: std::io::Chain<(), ()>){}
+   |                   ^^^^^^^^^^^^^^
+LL | fn test_chain(_x: std::iter::Chain<(), ()>){}
+   |                   ^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `cursor` in this scope
+  --> $DIR/io.rs:12:20
+   |
+LL | fn test_cursor(_x: cursor<()>){}
+   |                    ^^^^^^ not found in this scope
+   |
+help: did you mean `std::io::Cursor`?
+   |
+LL | fn test_cursor(_x: std::io::Cursor<()>){}
+   |                    ^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `empty` in this scope
+  --> $DIR/io.rs:14:19
+   |
+LL | fn test_empty(_x: empty){}
+   |                   ^^^^^ not found in this scope
+   |
+help: did you mean one of these?:
+   |
+LL | fn test_empty(_x: std::io::Empty){}
+   |                   ^^^^^^^^^^^^^^
+LL | fn test_empty(_x: std::iter::Empty){}
+   |                   ^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `Ioslice` in this scope
+  --> $DIR/io.rs:16:17
+   |
+LL | fn test_ios(_x: Ioslice){}
+   |                 ^^^^^^^ not found in this scope
+   |
+help: did you mean `std::io::IoSlice`?
+   |
+LL | fn test_ios(_x: std::io::IoSlice){}
+   |                 ^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `IosliceMut` in this scope
+  --> $DIR/io.rs:18:18
+   |
+LL | fn test_iosm(_x: IosliceMut){}
+   |                  ^^^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::io::IoSliceMut`?
+   |
+LL | fn test_iosm(_x: std::io::IoSliceMut){}
+   |                  ^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `Linewriter` in this scope
+  --> $DIR/io.rs:20:20
+   |
+LL | fn test_linewr(_x: Linewriter<()>){}
+   |                    ^^^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::io::LineWriter`?
+   |
+LL | fn test_linewr(_x: std::io::LineWriter<()>){}
+   |                    ^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `lines` in this scope
+  --> $DIR/io.rs:22:19
+   |
+LL | fn test_lines(_x: lines<()>){}
+   |                   ^^^^^ not found in this scope
+   |
+help: did you mean one of these?:
+   |
+LL | fn test_lines(_x: std::io::Lines<()>){}
+   |                   ^^^^^^^^^^^^^^
+LL | fn test_lines(_x: std::str::Lines<()>){}
+   |                   ^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `repeat` in this scope
+  --> $DIR/io.rs:24:20
+   |
+LL | fn test_repeat(_x: repeat){}
+   |                    ^^^^^^ not found in this scope
+   |
+help: did you mean one of these?:
+   |
+LL | fn test_repeat(_x: std::io::Repeat){}
+   |                    ^^^^^^^^^^^^^^^
+LL | fn test_repeat(_x: std::iter::Repeat){}
+   |                    ^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `sink` in this scope
+  --> $DIR/io.rs:26:18
+   |
+LL | fn test_sink(_x: sink){}
+   |                  ^^^^ not found in this scope
+   |
+help: did you mean `std::io::Sink`?
+   |
+LL | fn test_sink(_x: std::io::Sink){}
+   |                  ^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `split` in this scope
+  --> $DIR/io.rs:28:19
+   |
+LL | fn test_split(_x: split<()>){}
+   |                   ^^^^^ not found in this scope
+   |
+help: did you mean one of these?:
+   |
+LL | fn test_split(_x: std::io::Split<()>){}
+   |                   ^^^^^^^^^^^^^^
+LL | fn test_split(_x: std::str::Split<()>){}
+   |                   ^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `StdErr` in this scope
+  --> $DIR/io.rs:30:20
+   |
+LL | fn test_stderr(_x: StdErr){}
+   |                    ^^^^^^ not found in this scope
+   |
+help: did you mean `std::io::Stderr`?
+   |
+LL | fn test_stderr(_x: std::io::Stderr){}
+   |                    ^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `StdErrLock` in this scope
+  --> $DIR/io.rs:32:22
+   |
+LL | fn test_stderr_l(_x: StdErrLock){}
+   |                      ^^^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::io::StderrLock`?
+   |
+LL | fn test_stderr_l(_x: std::io::StderrLock){}
+   |                      ^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `StdIn` in this scope
+  --> $DIR/io.rs:34:20
+   |
+LL | fn test_stdind(_x: StdIn){}
+   |                    ^^^^^ not found in this scope
+   |
+help: did you mean `std::io::Stdin`?
+   |
+LL | fn test_stdind(_x: std::io::Stdin){}
+   |                    ^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `StdInLock` in this scope
+  --> $DIR/io.rs:36:21
+   |
+LL | fn test_stdin_l(_x: StdInLock){}
+   |                     ^^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::io::StdinLock`?
+   |
+LL | fn test_stdin_l(_x: std::io::StdinLock){}
+   |                     ^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `StdOut` in this scope
+  --> $DIR/io.rs:38:20
+   |
+LL | fn test_stdout(_x: StdOut){}
+   |                    ^^^^^^ not found in this scope
+   |
+help: did you mean `std::io::Stdout`?
+   |
+LL | fn test_stdout(_x: std::io::Stdout){}
+   |                    ^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `StdOutLock` in this scope
+  --> $DIR/io.rs:40:22
+   |
+LL | fn test_stdout_l(_x: StdOutLock){}
+   |                      ^^^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::io::StdoutLock`?
+   |
+LL | fn test_stdout_l(_x: std::io::StdoutLock){}
+   |                      ^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `take` in this scope
+  --> $DIR/io.rs:42:18
+   |
+LL | fn test_take(_x: take){}
+   |                  ^^^^ not found in this scope
+   |
+help: did you mean one of these?:
+   |
+LL | fn test_take(_x: std::io::Take){}
+   |                  ^^^^^^^^^^^^^
+LL | fn test_take(_x: std::iter::Take){}
+   |                  ^^^^^^^^^^^^^^^
+
+error: aborting due to 20 previous errors
+
+For more information about this error, try `rustc --explain E0412`.

--- a/src/test/ui/libstd-case-typo/io.stderr
+++ b/src/test/ui/libstd-case-typo/io.stderr
@@ -2,23 +2,19 @@ error[E0412]: cannot find type `Bufreader` in this scope
   --> $DIR/io.rs:4:19
    |
 LL | fn test_bufrd(_x: Bufreader<()>){}
-   |                   ^^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::io::BufReader`?
-   |
-LL | fn test_bufrd(_x: std::io::BufReader<()>){}
-   |                   ^^^^^^^^^^^^^^^^^^
+   |                   ^^^^^^^^^
+   |                   |
+   |                   not found in this scope
+   |                   help: found a libstd struct with a similar name: `std::io::BufReader`
 
 error[E0412]: cannot find type `Bufwriter` in this scope
   --> $DIR/io.rs:6:19
    |
 LL | fn test_bufwr(_x: Bufwriter<()>){}
-   |                   ^^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::io::BufWriter`?
-   |
-LL | fn test_bufwr(_x: std::io::BufWriter<()>){}
-   |                   ^^^^^^^^^^^^^^^^^^
+   |                   ^^^^^^^^^
+   |                   |
+   |                   not found in this scope
+   |                   help: found a libstd struct with a similar name: `std::io::BufWriter`
 
 error[E0412]: cannot find type `bytes` in this scope
   --> $DIR/io.rs:8:19
@@ -26,7 +22,7 @@ error[E0412]: cannot find type `bytes` in this scope
 LL | fn test_bytes(_x: bytes<()>){}
    |                   ^^^^^ not found in this scope
    |
-help: did you mean one of these?:
+help: found libstd structs with a similar name:
    |
 LL | fn test_bytes(_x: std::io::Bytes<()>){}
    |                   ^^^^^^^^^^^^^^
@@ -39,7 +35,7 @@ error[E0412]: cannot find type `chain` in this scope
 LL | fn test_chain(_x: chain<(), ()>){}
    |                   ^^^^^ not found in this scope
    |
-help: did you mean one of these?:
+help: found libstd structs with a similar name:
    |
 LL | fn test_chain(_x: std::io::Chain<(), ()>){}
    |                   ^^^^^^^^^^^^^^
@@ -50,12 +46,10 @@ error[E0412]: cannot find type `cursor` in this scope
   --> $DIR/io.rs:12:20
    |
 LL | fn test_cursor(_x: cursor<()>){}
-   |                    ^^^^^^ not found in this scope
-   |
-help: did you mean `std::io::Cursor`?
-   |
-LL | fn test_cursor(_x: std::io::Cursor<()>){}
-   |                    ^^^^^^^^^^^^^^^
+   |                    ^^^^^^
+   |                    |
+   |                    not found in this scope
+   |                    help: found a libstd struct with a similar name: `std::io::Cursor`
 
 error[E0412]: cannot find type `empty` in this scope
   --> $DIR/io.rs:14:19
@@ -63,7 +57,7 @@ error[E0412]: cannot find type `empty` in this scope
 LL | fn test_empty(_x: empty){}
    |                   ^^^^^ not found in this scope
    |
-help: did you mean one of these?:
+help: found libstd structs with a similar name:
    |
 LL | fn test_empty(_x: std::io::Empty){}
    |                   ^^^^^^^^^^^^^^
@@ -74,34 +68,28 @@ error[E0412]: cannot find type `Ioslice` in this scope
   --> $DIR/io.rs:16:17
    |
 LL | fn test_ios(_x: Ioslice){}
-   |                 ^^^^^^^ not found in this scope
-   |
-help: did you mean `std::io::IoSlice`?
-   |
-LL | fn test_ios(_x: std::io::IoSlice){}
-   |                 ^^^^^^^^^^^^^^^^
+   |                 ^^^^^^^
+   |                 |
+   |                 not found in this scope
+   |                 help: found a libstd struct with a similar name: `std::io::IoSlice`
 
 error[E0412]: cannot find type `IosliceMut` in this scope
   --> $DIR/io.rs:18:18
    |
 LL | fn test_iosm(_x: IosliceMut){}
-   |                  ^^^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::io::IoSliceMut`?
-   |
-LL | fn test_iosm(_x: std::io::IoSliceMut){}
-   |                  ^^^^^^^^^^^^^^^^^^^
+   |                  ^^^^^^^^^^
+   |                  |
+   |                  not found in this scope
+   |                  help: found a libstd struct with a similar name: `std::io::IoSliceMut`
 
 error[E0412]: cannot find type `Linewriter` in this scope
   --> $DIR/io.rs:20:20
    |
 LL | fn test_linewr(_x: Linewriter<()>){}
-   |                    ^^^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::io::LineWriter`?
-   |
-LL | fn test_linewr(_x: std::io::LineWriter<()>){}
-   |                    ^^^^^^^^^^^^^^^^^^^
+   |                    ^^^^^^^^^^
+   |                    |
+   |                    not found in this scope
+   |                    help: found a libstd struct with a similar name: `std::io::LineWriter`
 
 error[E0412]: cannot find type `lines` in this scope
   --> $DIR/io.rs:22:19
@@ -109,7 +97,7 @@ error[E0412]: cannot find type `lines` in this scope
 LL | fn test_lines(_x: lines<()>){}
    |                   ^^^^^ not found in this scope
    |
-help: did you mean one of these?:
+help: found libstd structs with a similar name:
    |
 LL | fn test_lines(_x: std::io::Lines<()>){}
    |                   ^^^^^^^^^^^^^^
@@ -122,7 +110,7 @@ error[E0412]: cannot find type `repeat` in this scope
 LL | fn test_repeat(_x: repeat){}
    |                    ^^^^^^ not found in this scope
    |
-help: did you mean one of these?:
+help: found libstd structs with a similar name:
    |
 LL | fn test_repeat(_x: std::io::Repeat){}
    |                    ^^^^^^^^^^^^^^^
@@ -133,12 +121,10 @@ error[E0412]: cannot find type `sink` in this scope
   --> $DIR/io.rs:26:18
    |
 LL | fn test_sink(_x: sink){}
-   |                  ^^^^ not found in this scope
-   |
-help: did you mean `std::io::Sink`?
-   |
-LL | fn test_sink(_x: std::io::Sink){}
-   |                  ^^^^^^^^^^^^^
+   |                  ^^^^
+   |                  |
+   |                  not found in this scope
+   |                  help: found a libstd struct with a similar name: `std::io::Sink`
 
 error[E0412]: cannot find type `split` in this scope
   --> $DIR/io.rs:28:19
@@ -146,7 +132,7 @@ error[E0412]: cannot find type `split` in this scope
 LL | fn test_split(_x: split<()>){}
    |                   ^^^^^ not found in this scope
    |
-help: did you mean one of these?:
+help: found libstd structs with a similar name:
    |
 LL | fn test_split(_x: std::io::Split<()>){}
    |                   ^^^^^^^^^^^^^^
@@ -157,67 +143,55 @@ error[E0412]: cannot find type `StdErr` in this scope
   --> $DIR/io.rs:30:20
    |
 LL | fn test_stderr(_x: StdErr){}
-   |                    ^^^^^^ not found in this scope
-   |
-help: did you mean `std::io::Stderr`?
-   |
-LL | fn test_stderr(_x: std::io::Stderr){}
-   |                    ^^^^^^^^^^^^^^^
+   |                    ^^^^^^
+   |                    |
+   |                    not found in this scope
+   |                    help: found a libstd struct with a similar name: `std::io::Stderr`
 
 error[E0412]: cannot find type `StdErrLock` in this scope
   --> $DIR/io.rs:32:22
    |
 LL | fn test_stderr_l(_x: StdErrLock){}
-   |                      ^^^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::io::StderrLock`?
-   |
-LL | fn test_stderr_l(_x: std::io::StderrLock){}
-   |                      ^^^^^^^^^^^^^^^^^^^
+   |                      ^^^^^^^^^^
+   |                      |
+   |                      not found in this scope
+   |                      help: found a libstd struct with a similar name: `std::io::StderrLock`
 
 error[E0412]: cannot find type `StdIn` in this scope
   --> $DIR/io.rs:34:20
    |
 LL | fn test_stdind(_x: StdIn){}
-   |                    ^^^^^ not found in this scope
-   |
-help: did you mean `std::io::Stdin`?
-   |
-LL | fn test_stdind(_x: std::io::Stdin){}
-   |                    ^^^^^^^^^^^^^^
+   |                    ^^^^^
+   |                    |
+   |                    not found in this scope
+   |                    help: found a libstd struct with a similar name: `std::io::Stdin`
 
 error[E0412]: cannot find type `StdInLock` in this scope
   --> $DIR/io.rs:36:21
    |
 LL | fn test_stdin_l(_x: StdInLock){}
-   |                     ^^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::io::StdinLock`?
-   |
-LL | fn test_stdin_l(_x: std::io::StdinLock){}
-   |                     ^^^^^^^^^^^^^^^^^^
+   |                     ^^^^^^^^^
+   |                     |
+   |                     not found in this scope
+   |                     help: found a libstd struct with a similar name: `std::io::StdinLock`
 
 error[E0412]: cannot find type `StdOut` in this scope
   --> $DIR/io.rs:38:20
    |
 LL | fn test_stdout(_x: StdOut){}
-   |                    ^^^^^^ not found in this scope
-   |
-help: did you mean `std::io::Stdout`?
-   |
-LL | fn test_stdout(_x: std::io::Stdout){}
-   |                    ^^^^^^^^^^^^^^^
+   |                    ^^^^^^
+   |                    |
+   |                    not found in this scope
+   |                    help: found a libstd struct with a similar name: `std::io::Stdout`
 
 error[E0412]: cannot find type `StdOutLock` in this scope
   --> $DIR/io.rs:40:22
    |
 LL | fn test_stdout_l(_x: StdOutLock){}
-   |                      ^^^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::io::StdoutLock`?
-   |
-LL | fn test_stdout_l(_x: std::io::StdoutLock){}
-   |                      ^^^^^^^^^^^^^^^^^^^
+   |                      ^^^^^^^^^^
+   |                      |
+   |                      not found in this scope
+   |                      help: found a libstd struct with a similar name: `std::io::StdoutLock`
 
 error[E0412]: cannot find type `take` in this scope
   --> $DIR/io.rs:42:18
@@ -225,7 +199,7 @@ error[E0412]: cannot find type `take` in this scope
 LL | fn test_take(_x: take){}
    |                  ^^^^ not found in this scope
    |
-help: did you mean one of these?:
+help: found libstd structs with a similar name:
    |
 LL | fn test_take(_x: std::io::Take){}
    |                  ^^^^^^^^^^^^^

--- a/src/test/ui/libstd-case-typo/io.stderr
+++ b/src/test/ui/libstd-case-typo/io.stderr
@@ -5,7 +5,7 @@ LL | fn test_bufrd(_x: Bufreader<()>){}
    |                   ^^^^^^^^^
    |                   |
    |                   not found in this scope
-   |                   help: found a libstd struct with a similar name: `std::io::BufReader`
+   |                   help: found a std struct with a similar name: `std::io::BufReader`
 
 error[E0412]: cannot find type `Bufwriter` in this scope
   --> $DIR/io.rs:6:19
@@ -14,7 +14,7 @@ LL | fn test_bufwr(_x: Bufwriter<()>){}
    |                   ^^^^^^^^^
    |                   |
    |                   not found in this scope
-   |                   help: found a libstd struct with a similar name: `std::io::BufWriter`
+   |                   help: found a std struct with a similar name: `std::io::BufWriter`
 
 error[E0412]: cannot find type `bytes` in this scope
   --> $DIR/io.rs:8:19
@@ -22,7 +22,7 @@ error[E0412]: cannot find type `bytes` in this scope
 LL | fn test_bytes(_x: bytes<()>){}
    |                   ^^^^^ not found in this scope
    |
-help: found libstd structs with a similar name:
+help: found std structs with similar names:
    |
 LL | fn test_bytes(_x: std::io::Bytes<()>){}
    |                   ^^^^^^^^^^^^^^
@@ -35,7 +35,7 @@ error[E0412]: cannot find type `chain` in this scope
 LL | fn test_chain(_x: chain<(), ()>){}
    |                   ^^^^^ not found in this scope
    |
-help: found libstd structs with a similar name:
+help: found std structs with similar names:
    |
 LL | fn test_chain(_x: std::io::Chain<(), ()>){}
    |                   ^^^^^^^^^^^^^^
@@ -49,7 +49,7 @@ LL | fn test_cursor(_x: cursor<()>){}
    |                    ^^^^^^
    |                    |
    |                    not found in this scope
-   |                    help: found a libstd struct with a similar name: `std::io::Cursor`
+   |                    help: found a std struct with a similar name: `std::io::Cursor`
 
 error[E0412]: cannot find type `empty` in this scope
   --> $DIR/io.rs:14:19
@@ -57,7 +57,7 @@ error[E0412]: cannot find type `empty` in this scope
 LL | fn test_empty(_x: empty){}
    |                   ^^^^^ not found in this scope
    |
-help: found libstd structs with a similar name:
+help: found std structs with similar names:
    |
 LL | fn test_empty(_x: std::io::Empty){}
    |                   ^^^^^^^^^^^^^^
@@ -71,7 +71,7 @@ LL | fn test_ios(_x: Ioslice){}
    |                 ^^^^^^^
    |                 |
    |                 not found in this scope
-   |                 help: found a libstd struct with a similar name: `std::io::IoSlice`
+   |                 help: found a std struct with a similar name: `std::io::IoSlice`
 
 error[E0412]: cannot find type `IosliceMut` in this scope
   --> $DIR/io.rs:18:18
@@ -80,7 +80,7 @@ LL | fn test_iosm(_x: IosliceMut){}
    |                  ^^^^^^^^^^
    |                  |
    |                  not found in this scope
-   |                  help: found a libstd struct with a similar name: `std::io::IoSliceMut`
+   |                  help: found a std struct with a similar name: `std::io::IoSliceMut`
 
 error[E0412]: cannot find type `Linewriter` in this scope
   --> $DIR/io.rs:20:20
@@ -89,7 +89,7 @@ LL | fn test_linewr(_x: Linewriter<()>){}
    |                    ^^^^^^^^^^
    |                    |
    |                    not found in this scope
-   |                    help: found a libstd struct with a similar name: `std::io::LineWriter`
+   |                    help: found a std struct with a similar name: `std::io::LineWriter`
 
 error[E0412]: cannot find type `lines` in this scope
   --> $DIR/io.rs:22:19
@@ -97,7 +97,7 @@ error[E0412]: cannot find type `lines` in this scope
 LL | fn test_lines(_x: lines<()>){}
    |                   ^^^^^ not found in this scope
    |
-help: found libstd structs with a similar name:
+help: found std structs with similar names:
    |
 LL | fn test_lines(_x: std::io::Lines<()>){}
    |                   ^^^^^^^^^^^^^^
@@ -110,7 +110,7 @@ error[E0412]: cannot find type `repeat` in this scope
 LL | fn test_repeat(_x: repeat){}
    |                    ^^^^^^ not found in this scope
    |
-help: found libstd structs with a similar name:
+help: found std structs with similar names:
    |
 LL | fn test_repeat(_x: std::io::Repeat){}
    |                    ^^^^^^^^^^^^^^^
@@ -124,7 +124,7 @@ LL | fn test_sink(_x: sink){}
    |                  ^^^^
    |                  |
    |                  not found in this scope
-   |                  help: found a libstd struct with a similar name: `std::io::Sink`
+   |                  help: found a std struct with a similar name: `std::io::Sink`
 
 error[E0412]: cannot find type `split` in this scope
   --> $DIR/io.rs:28:19
@@ -132,7 +132,7 @@ error[E0412]: cannot find type `split` in this scope
 LL | fn test_split(_x: split<()>){}
    |                   ^^^^^ not found in this scope
    |
-help: found libstd structs with a similar name:
+help: found std structs with similar names:
    |
 LL | fn test_split(_x: std::io::Split<()>){}
    |                   ^^^^^^^^^^^^^^
@@ -146,7 +146,7 @@ LL | fn test_stderr(_x: StdErr){}
    |                    ^^^^^^
    |                    |
    |                    not found in this scope
-   |                    help: found a libstd struct with a similar name: `std::io::Stderr`
+   |                    help: found a std struct with a similar name: `std::io::Stderr`
 
 error[E0412]: cannot find type `StdErrLock` in this scope
   --> $DIR/io.rs:32:22
@@ -155,7 +155,7 @@ LL | fn test_stderr_l(_x: StdErrLock){}
    |                      ^^^^^^^^^^
    |                      |
    |                      not found in this scope
-   |                      help: found a libstd struct with a similar name: `std::io::StderrLock`
+   |                      help: found a std struct with a similar name: `std::io::StderrLock`
 
 error[E0412]: cannot find type `StdIn` in this scope
   --> $DIR/io.rs:34:20
@@ -164,7 +164,7 @@ LL | fn test_stdind(_x: StdIn){}
    |                    ^^^^^
    |                    |
    |                    not found in this scope
-   |                    help: found a libstd struct with a similar name: `std::io::Stdin`
+   |                    help: found a std struct with a similar name: `std::io::Stdin`
 
 error[E0412]: cannot find type `StdInLock` in this scope
   --> $DIR/io.rs:36:21
@@ -173,7 +173,7 @@ LL | fn test_stdin_l(_x: StdInLock){}
    |                     ^^^^^^^^^
    |                     |
    |                     not found in this scope
-   |                     help: found a libstd struct with a similar name: `std::io::StdinLock`
+   |                     help: found a std struct with a similar name: `std::io::StdinLock`
 
 error[E0412]: cannot find type `StdOut` in this scope
   --> $DIR/io.rs:38:20
@@ -182,7 +182,7 @@ LL | fn test_stdout(_x: StdOut){}
    |                    ^^^^^^
    |                    |
    |                    not found in this scope
-   |                    help: found a libstd struct with a similar name: `std::io::Stdout`
+   |                    help: found a std struct with a similar name: `std::io::Stdout`
 
 error[E0412]: cannot find type `StdOutLock` in this scope
   --> $DIR/io.rs:40:22
@@ -191,7 +191,7 @@ LL | fn test_stdout_l(_x: StdOutLock){}
    |                      ^^^^^^^^^^
    |                      |
    |                      not found in this scope
-   |                      help: found a libstd struct with a similar name: `std::io::StdoutLock`
+   |                      help: found a std struct with a similar name: `std::io::StdoutLock`
 
 error[E0412]: cannot find type `take` in this scope
   --> $DIR/io.rs:42:18
@@ -199,7 +199,7 @@ error[E0412]: cannot find type `take` in this scope
 LL | fn test_take(_x: take){}
    |                  ^^^^ not found in this scope
    |
-help: found libstd structs with a similar name:
+help: found std structs with similar names:
    |
 LL | fn test_take(_x: std::io::Take){}
    |                  ^^^^^^^^^^^^^

--- a/src/test/ui/libstd-case-typo/iter.rs
+++ b/src/test/ui/libstd-case-typo/iter.rs
@@ -1,0 +1,57 @@
+// checks case typos with libstd::iter structs
+fn main(){}
+
+fn test_chain(_x: chain<(), ()>){}
+//~^ ERROR: cannot find type `chain` in this scope
+fn test_cloned(_x: cloned<(), ()>){}
+//~^ ERROR: cannot find type `cloned` in this scope
+fn test_copied(_x: copied<(), ()>){}
+//~^ ERROR: cannot find type `copied` in this scope
+fn test_cycle(_x: cycle<(), ()>){}
+//~^ ERROR: cannot find type `cycle` in this scope
+fn test_empty(_x: empty){}
+//~^ ERROR: cannot find type `empty` in this scope
+fn test_enumer(_x: enumerate<(), ()>){}
+//~^ ERROR: cannot find type `enumerate` in this scope
+fn test_filter(_x: filter<(), ()>){}
+//~^ ERROR: cannot find type `filter` in this scope
+fn test_filtermap(_x: Filtermap<(), ()>){}
+//~^ ERROR: cannot find type `Filtermap` in this scope
+fn test_flatten(_x: flatten<()>){}
+//~^ ERROR: cannot find type `flatten` in this scope
+fn test_fromfn(_x: Fromfn<()>){}
+//~^ ERROR: cannot find type `Fromfn` in this scope
+fn test_fuse(_x: fuse<()>){}
+//~^ ERROR: cannot find type `fuse` in this scope
+fn test_inspect(_x: inspect<(), ()>){}
+//~^ ERROR: cannot find type `inspect` in this scope
+fn test_map(_x: map<(), ()>){}
+//~^ ERROR: cannot find type `map` in this scope
+fn test_once(_x: once<()>){}
+//~^ ERROR: cannot find type `once` in this scope
+fn test_oncewith(_x: Oncewith<()>){}
+//~^ ERROR: cannot find type `Oncewith` in this scope
+fn test_peek(_x: peekable<()>){}
+//~^ ERROR: cannot find type `peekable` in this scope
+fn test_repeat(_x: repeat<()>){}
+//~^ ERROR: cannot find type `repeat` in this scope
+fn test_repeatw(_x: Repeatwith<()>){}
+//~^ ERROR: cannot find type `Repeatwith` in this scope
+fn test_rev(_x: rev<()>){}
+//~^ ERROR: cannot find type `rev` in this scope
+fn test_scan(_x: scan<(), (), ()>){}
+//~^ ERROR: cannot find type `scan` in this scope
+fn test_skip(_x: skip<()>){}
+//~^ ERROR: cannot find type `skip` in this scope
+fn test_skipw(_x: Skipwhile<(), ()>){}
+//~^ ERROR: cannot find type `Skipwhile` in this scope
+fn test_stepby(_x: Stepby<()>){}
+//~^ ERROR: cannot find type `Stepby` in this scope
+fn test_successors(_x: successors<()>){}
+//~^ ERROR: cannot find type `successors` in this scope
+fn test_take(_x: take<()>){}
+//~^ ERROR: cannot find type `take` in this scope
+fn test_takew(_x: Takewhile<(), ()>){}
+//~^ ERROR: cannot find type `Takewhile` in this scope
+fn test_zip(_x: zip<(), ()>){}
+//~^ ERROR: cannot find type `zip` in this scope

--- a/src/test/ui/libstd-case-typo/iter.stderr
+++ b/src/test/ui/libstd-case-typo/iter.stderr
@@ -4,7 +4,7 @@ error[E0412]: cannot find type `chain` in this scope
 LL | fn test_chain(_x: chain<(), ()>){}
    |                   ^^^^^ not found in this scope
    |
-help: did you mean one of these?:
+help: found libstd structs with a similar name:
    |
 LL | fn test_chain(_x: std::io::Chain<(), ()>){}
    |                   ^^^^^^^^^^^^^^
@@ -26,23 +26,19 @@ error[E0412]: cannot find type `copied` in this scope
   --> $DIR/iter.rs:8:20
    |
 LL | fn test_copied(_x: copied<(), ()>){}
-   |                    ^^^^^^ not found in this scope
-   |
-help: did you mean `std::iter::Copied`?
-   |
-LL | fn test_copied(_x: std::iter::Copied<(), ()>){}
-   |                    ^^^^^^^^^^^^^^^^^
+   |                    ^^^^^^
+   |                    |
+   |                    not found in this scope
+   |                    help: found a libstd struct with a similar name: `std::iter::Copied`
 
 error[E0412]: cannot find type `cycle` in this scope
   --> $DIR/iter.rs:10:19
    |
 LL | fn test_cycle(_x: cycle<(), ()>){}
-   |                   ^^^^^ not found in this scope
-   |
-help: did you mean `std::iter::Cycle`?
-   |
-LL | fn test_cycle(_x: std::iter::Cycle<(), ()>){}
-   |                   ^^^^^^^^^^^^^^^^
+   |                   ^^^^^
+   |                   |
+   |                   not found in this scope
+   |                   help: found a libstd struct with a similar name: `std::iter::Cycle`
 
 error[E0412]: cannot find type `empty` in this scope
   --> $DIR/iter.rs:12:19
@@ -50,7 +46,7 @@ error[E0412]: cannot find type `empty` in this scope
 LL | fn test_empty(_x: empty){}
    |                   ^^^^^ not found in this scope
    |
-help: did you mean one of these?:
+help: found libstd structs with a similar name:
    |
 LL | fn test_empty(_x: std::io::Empty){}
    |                   ^^^^^^^^^^^^^^
@@ -61,45 +57,37 @@ error[E0412]: cannot find type `enumerate` in this scope
   --> $DIR/iter.rs:14:20
    |
 LL | fn test_enumer(_x: enumerate<(), ()>){}
-   |                    ^^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::iter::Enumerate`?
-   |
-LL | fn test_enumer(_x: std::iter::Enumerate<(), ()>){}
-   |                    ^^^^^^^^^^^^^^^^^^^^
+   |                    ^^^^^^^^^
+   |                    |
+   |                    not found in this scope
+   |                    help: found a libstd struct with a similar name: `std::iter::Enumerate`
 
 error[E0412]: cannot find type `filter` in this scope
   --> $DIR/iter.rs:16:20
    |
 LL | fn test_filter(_x: filter<(), ()>){}
-   |                    ^^^^^^ not found in this scope
-   |
-help: did you mean `std::iter::Filter`?
-   |
-LL | fn test_filter(_x: std::iter::Filter<(), ()>){}
-   |                    ^^^^^^^^^^^^^^^^^
+   |                    ^^^^^^
+   |                    |
+   |                    not found in this scope
+   |                    help: found a libstd struct with a similar name: `std::iter::Filter`
 
 error[E0412]: cannot find type `Filtermap` in this scope
   --> $DIR/iter.rs:18:23
    |
 LL | fn test_filtermap(_x: Filtermap<(), ()>){}
-   |                       ^^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::iter::FilterMap`?
-   |
-LL | fn test_filtermap(_x: std::iter::FilterMap<(), ()>){}
-   |                       ^^^^^^^^^^^^^^^^^^^^
+   |                       ^^^^^^^^^
+   |                       |
+   |                       not found in this scope
+   |                       help: found a libstd struct with a similar name: `std::iter::FilterMap`
 
 error[E0412]: cannot find type `flatten` in this scope
   --> $DIR/iter.rs:20:21
    |
 LL | fn test_flatten(_x: flatten<()>){}
-   |                     ^^^^^^^ not found in this scope
-   |
-help: did you mean `std::iter::Flatten`?
-   |
-LL | fn test_flatten(_x: std::iter::Flatten<()>){}
-   |                     ^^^^^^^^^^^^^^^^^^
+   |                     ^^^^^^^
+   |                     |
+   |                     not found in this scope
+   |                     help: found a libstd struct with a similar name: `std::iter::Flatten`
 
 error[E0412]: cannot find type `Fromfn` in this scope
   --> $DIR/iter.rs:22:20
@@ -116,34 +104,28 @@ error[E0412]: cannot find type `fuse` in this scope
   --> $DIR/iter.rs:24:18
    |
 LL | fn test_fuse(_x: fuse<()>){}
-   |                  ^^^^ not found in this scope
-   |
-help: did you mean `std::iter::Fuse`?
-   |
-LL | fn test_fuse(_x: std::iter::Fuse<()>){}
-   |                  ^^^^^^^^^^^^^^^
+   |                  ^^^^
+   |                  |
+   |                  not found in this scope
+   |                  help: found a libstd struct with a similar name: `std::iter::Fuse`
 
 error[E0412]: cannot find type `inspect` in this scope
   --> $DIR/iter.rs:26:21
    |
 LL | fn test_inspect(_x: inspect<(), ()>){}
-   |                     ^^^^^^^ not found in this scope
-   |
-help: did you mean `std::iter::Inspect`?
-   |
-LL | fn test_inspect(_x: std::iter::Inspect<(), ()>){}
-   |                     ^^^^^^^^^^^^^^^^^^
+   |                     ^^^^^^^
+   |                     |
+   |                     not found in this scope
+   |                     help: found a libstd struct with a similar name: `std::iter::Inspect`
 
 error[E0412]: cannot find type `map` in this scope
   --> $DIR/iter.rs:28:17
    |
 LL | fn test_map(_x: map<(), ()>){}
-   |                 ^^^ not found in this scope
-   |
-help: did you mean `std::iter::Map`?
-   |
-LL | fn test_map(_x: std::iter::Map<(), ()>){}
-   |                 ^^^^^^^^^^^^^^
+   |                 ^^^
+   |                 |
+   |                 not found in this scope
+   |                 help: found a libstd struct with a similar name: `std::iter::Map`
 
 error[E0412]: cannot find type `once` in this scope
   --> $DIR/iter.rs:30:18
@@ -151,7 +133,7 @@ error[E0412]: cannot find type `once` in this scope
 LL | fn test_once(_x: once<()>){}
    |                  ^^^^ not found in this scope
    |
-help: did you mean one of these?:
+help: found libstd structs with a similar name:
    |
 LL | fn test_once(_x: std::iter::Once<()>){}
    |                  ^^^^^^^^^^^^^^^
@@ -162,23 +144,19 @@ error[E0412]: cannot find type `Oncewith` in this scope
   --> $DIR/iter.rs:32:22
    |
 LL | fn test_oncewith(_x: Oncewith<()>){}
-   |                      ^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::iter::OnceWith`?
-   |
-LL | fn test_oncewith(_x: std::iter::OnceWith<()>){}
-   |                      ^^^^^^^^^^^^^^^^^^^
+   |                      ^^^^^^^^
+   |                      |
+   |                      not found in this scope
+   |                      help: found a libstd struct with a similar name: `std::iter::OnceWith`
 
 error[E0412]: cannot find type `peekable` in this scope
   --> $DIR/iter.rs:34:18
    |
 LL | fn test_peek(_x: peekable<()>){}
-   |                  ^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::iter::Peekable`?
-   |
-LL | fn test_peek(_x: std::iter::Peekable<()>){}
-   |                  ^^^^^^^^^^^^^^^^^^^
+   |                  ^^^^^^^^
+   |                  |
+   |                  not found in this scope
+   |                  help: found a libstd struct with a similar name: `std::iter::Peekable`
 
 error[E0412]: cannot find type `repeat` in this scope
   --> $DIR/iter.rs:36:20
@@ -186,7 +164,7 @@ error[E0412]: cannot find type `repeat` in this scope
 LL | fn test_repeat(_x: repeat<()>){}
    |                    ^^^^^^ not found in this scope
    |
-help: did you mean one of these?:
+help: found libstd structs with a similar name:
    |
 LL | fn test_repeat(_x: std::io::Repeat<()>){}
    |                    ^^^^^^^^^^^^^^^
@@ -197,78 +175,64 @@ error[E0412]: cannot find type `Repeatwith` in this scope
   --> $DIR/iter.rs:38:21
    |
 LL | fn test_repeatw(_x: Repeatwith<()>){}
-   |                     ^^^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::iter::RepeatWith`?
-   |
-LL | fn test_repeatw(_x: std::iter::RepeatWith<()>){}
-   |                     ^^^^^^^^^^^^^^^^^^^^^
+   |                     ^^^^^^^^^^
+   |                     |
+   |                     not found in this scope
+   |                     help: found a libstd struct with a similar name: `std::iter::RepeatWith`
 
 error[E0412]: cannot find type `rev` in this scope
   --> $DIR/iter.rs:40:17
    |
 LL | fn test_rev(_x: rev<()>){}
-   |                 ^^^ not found in this scope
-   |
-help: did you mean `std::iter::Rev`?
-   |
-LL | fn test_rev(_x: std::iter::Rev<()>){}
-   |                 ^^^^^^^^^^^^^^
+   |                 ^^^
+   |                 |
+   |                 not found in this scope
+   |                 help: found a libstd struct with a similar name: `std::iter::Rev`
 
 error[E0412]: cannot find type `scan` in this scope
   --> $DIR/iter.rs:42:18
    |
 LL | fn test_scan(_x: scan<(), (), ()>){}
-   |                  ^^^^ not found in this scope
-   |
-help: did you mean `std::iter::Scan`?
-   |
-LL | fn test_scan(_x: std::iter::Scan<(), (), ()>){}
-   |                  ^^^^^^^^^^^^^^^
+   |                  ^^^^
+   |                  |
+   |                  not found in this scope
+   |                  help: found a libstd struct with a similar name: `std::iter::Scan`
 
 error[E0412]: cannot find type `skip` in this scope
   --> $DIR/iter.rs:44:18
    |
 LL | fn test_skip(_x: skip<()>){}
-   |                  ^^^^ not found in this scope
-   |
-help: did you mean `std::iter::Skip`?
-   |
-LL | fn test_skip(_x: std::iter::Skip<()>){}
-   |                  ^^^^^^^^^^^^^^^
+   |                  ^^^^
+   |                  |
+   |                  not found in this scope
+   |                  help: found a libstd struct with a similar name: `std::iter::Skip`
 
 error[E0412]: cannot find type `Skipwhile` in this scope
   --> $DIR/iter.rs:46:19
    |
 LL | fn test_skipw(_x: Skipwhile<(), ()>){}
-   |                   ^^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::iter::SkipWhile`?
-   |
-LL | fn test_skipw(_x: std::iter::SkipWhile<(), ()>){}
-   |                   ^^^^^^^^^^^^^^^^^^^^
+   |                   ^^^^^^^^^
+   |                   |
+   |                   not found in this scope
+   |                   help: found a libstd struct with a similar name: `std::iter::SkipWhile`
 
 error[E0412]: cannot find type `Stepby` in this scope
   --> $DIR/iter.rs:48:20
    |
 LL | fn test_stepby(_x: Stepby<()>){}
-   |                    ^^^^^^ not found in this scope
-   |
-help: did you mean `std::iter::StepBy`?
-   |
-LL | fn test_stepby(_x: std::iter::StepBy<()>){}
-   |                    ^^^^^^^^^^^^^^^^^
+   |                    ^^^^^^
+   |                    |
+   |                    not found in this scope
+   |                    help: found a libstd struct with a similar name: `std::iter::StepBy`
 
 error[E0412]: cannot find type `successors` in this scope
   --> $DIR/iter.rs:50:24
    |
 LL | fn test_successors(_x: successors<()>){}
-   |                        ^^^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::iter::Successors`?
-   |
-LL | fn test_successors(_x: std::iter::Successors<()>){}
-   |                        ^^^^^^^^^^^^^^^^^^^^^
+   |                        ^^^^^^^^^^
+   |                        |
+   |                        not found in this scope
+   |                        help: found a libstd struct with a similar name: `std::iter::Successors`
 
 error[E0412]: cannot find type `take` in this scope
   --> $DIR/iter.rs:52:18
@@ -276,7 +240,7 @@ error[E0412]: cannot find type `take` in this scope
 LL | fn test_take(_x: take<()>){}
    |                  ^^^^ not found in this scope
    |
-help: did you mean one of these?:
+help: found libstd structs with a similar name:
    |
 LL | fn test_take(_x: std::io::Take<()>){}
    |                  ^^^^^^^^^^^^^
@@ -287,23 +251,19 @@ error[E0412]: cannot find type `Takewhile` in this scope
   --> $DIR/iter.rs:54:19
    |
 LL | fn test_takew(_x: Takewhile<(), ()>){}
-   |                   ^^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::iter::TakeWhile`?
-   |
-LL | fn test_takew(_x: std::iter::TakeWhile<(), ()>){}
-   |                   ^^^^^^^^^^^^^^^^^^^^
+   |                   ^^^^^^^^^
+   |                   |
+   |                   not found in this scope
+   |                   help: found a libstd struct with a similar name: `std::iter::TakeWhile`
 
 error[E0412]: cannot find type `zip` in this scope
   --> $DIR/iter.rs:56:17
    |
 LL | fn test_zip(_x: zip<(), ()>){}
-   |                 ^^^ not found in this scope
-   |
-help: did you mean `std::iter::Zip`?
-   |
-LL | fn test_zip(_x: std::iter::Zip<(), ()>){}
-   |                 ^^^^^^^^^^^^^^
+   |                 ^^^
+   |                 |
+   |                 not found in this scope
+   |                 help: found a libstd struct with a similar name: `std::iter::Zip`
 
 error: aborting due to 27 previous errors
 

--- a/src/test/ui/libstd-case-typo/iter.stderr
+++ b/src/test/ui/libstd-case-typo/iter.stderr
@@ -1,0 +1,310 @@
+error[E0412]: cannot find type `chain` in this scope
+  --> $DIR/iter.rs:4:19
+   |
+LL | fn test_chain(_x: chain<(), ()>){}
+   |                   ^^^^^ not found in this scope
+   |
+help: did you mean one of these?:
+   |
+LL | fn test_chain(_x: std::io::Chain<(), ()>){}
+   |                   ^^^^^^^^^^^^^^
+LL | fn test_chain(_x: std::iter::Chain<(), ()>){}
+   |                   ^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `cloned` in this scope
+  --> $DIR/iter.rs:6:20
+   |
+LL | fn test_cloned(_x: cloned<(), ()>){}
+   |                    ^^^^^^ help: a trait with a similar name exists: `Clone`
+   | 
+  ::: $SRC_DIR/libcore/clone.rs:LL:COL
+   |
+LL | pub trait Clone: Sized {
+   | ---------------------- similarly named trait `Clone` defined here
+
+error[E0412]: cannot find type `copied` in this scope
+  --> $DIR/iter.rs:8:20
+   |
+LL | fn test_copied(_x: copied<(), ()>){}
+   |                    ^^^^^^ not found in this scope
+   |
+help: did you mean `std::iter::Copied`?
+   |
+LL | fn test_copied(_x: std::iter::Copied<(), ()>){}
+   |                    ^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `cycle` in this scope
+  --> $DIR/iter.rs:10:19
+   |
+LL | fn test_cycle(_x: cycle<(), ()>){}
+   |                   ^^^^^ not found in this scope
+   |
+help: did you mean `std::iter::Cycle`?
+   |
+LL | fn test_cycle(_x: std::iter::Cycle<(), ()>){}
+   |                   ^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `empty` in this scope
+  --> $DIR/iter.rs:12:19
+   |
+LL | fn test_empty(_x: empty){}
+   |                   ^^^^^ not found in this scope
+   |
+help: did you mean one of these?:
+   |
+LL | fn test_empty(_x: std::io::Empty){}
+   |                   ^^^^^^^^^^^^^^
+LL | fn test_empty(_x: std::iter::Empty){}
+   |                   ^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `enumerate` in this scope
+  --> $DIR/iter.rs:14:20
+   |
+LL | fn test_enumer(_x: enumerate<(), ()>){}
+   |                    ^^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::iter::Enumerate`?
+   |
+LL | fn test_enumer(_x: std::iter::Enumerate<(), ()>){}
+   |                    ^^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `filter` in this scope
+  --> $DIR/iter.rs:16:20
+   |
+LL | fn test_filter(_x: filter<(), ()>){}
+   |                    ^^^^^^ not found in this scope
+   |
+help: did you mean `std::iter::Filter`?
+   |
+LL | fn test_filter(_x: std::iter::Filter<(), ()>){}
+   |                    ^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `Filtermap` in this scope
+  --> $DIR/iter.rs:18:23
+   |
+LL | fn test_filtermap(_x: Filtermap<(), ()>){}
+   |                       ^^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::iter::FilterMap`?
+   |
+LL | fn test_filtermap(_x: std::iter::FilterMap<(), ()>){}
+   |                       ^^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `flatten` in this scope
+  --> $DIR/iter.rs:20:21
+   |
+LL | fn test_flatten(_x: flatten<()>){}
+   |                     ^^^^^^^ not found in this scope
+   |
+help: did you mean `std::iter::Flatten`?
+   |
+LL | fn test_flatten(_x: std::iter::Flatten<()>){}
+   |                     ^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `Fromfn` in this scope
+  --> $DIR/iter.rs:22:20
+   |
+LL | fn test_fromfn(_x: Fromfn<()>){}
+   |                    ^^^^^^ help: a trait with a similar name exists: `From`
+   | 
+  ::: $SRC_DIR/libcore/convert/mod.rs:LL:COL
+   |
+LL | pub trait From<T>: Sized {
+   | ------------------------ similarly named trait `From` defined here
+
+error[E0412]: cannot find type `fuse` in this scope
+  --> $DIR/iter.rs:24:18
+   |
+LL | fn test_fuse(_x: fuse<()>){}
+   |                  ^^^^ not found in this scope
+   |
+help: did you mean `std::iter::Fuse`?
+   |
+LL | fn test_fuse(_x: std::iter::Fuse<()>){}
+   |                  ^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `inspect` in this scope
+  --> $DIR/iter.rs:26:21
+   |
+LL | fn test_inspect(_x: inspect<(), ()>){}
+   |                     ^^^^^^^ not found in this scope
+   |
+help: did you mean `std::iter::Inspect`?
+   |
+LL | fn test_inspect(_x: std::iter::Inspect<(), ()>){}
+   |                     ^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `map` in this scope
+  --> $DIR/iter.rs:28:17
+   |
+LL | fn test_map(_x: map<(), ()>){}
+   |                 ^^^ not found in this scope
+   |
+help: did you mean `std::iter::Map`?
+   |
+LL | fn test_map(_x: std::iter::Map<(), ()>){}
+   |                 ^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `once` in this scope
+  --> $DIR/iter.rs:30:18
+   |
+LL | fn test_once(_x: once<()>){}
+   |                  ^^^^ not found in this scope
+   |
+help: did you mean one of these?:
+   |
+LL | fn test_once(_x: std::iter::Once<()>){}
+   |                  ^^^^^^^^^^^^^^^
+LL | fn test_once(_x: std::sync::Once<()>){}
+   |                  ^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `Oncewith` in this scope
+  --> $DIR/iter.rs:32:22
+   |
+LL | fn test_oncewith(_x: Oncewith<()>){}
+   |                      ^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::iter::OnceWith`?
+   |
+LL | fn test_oncewith(_x: std::iter::OnceWith<()>){}
+   |                      ^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `peekable` in this scope
+  --> $DIR/iter.rs:34:18
+   |
+LL | fn test_peek(_x: peekable<()>){}
+   |                  ^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::iter::Peekable`?
+   |
+LL | fn test_peek(_x: std::iter::Peekable<()>){}
+   |                  ^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `repeat` in this scope
+  --> $DIR/iter.rs:36:20
+   |
+LL | fn test_repeat(_x: repeat<()>){}
+   |                    ^^^^^^ not found in this scope
+   |
+help: did you mean one of these?:
+   |
+LL | fn test_repeat(_x: std::io::Repeat<()>){}
+   |                    ^^^^^^^^^^^^^^^
+LL | fn test_repeat(_x: std::iter::Repeat<()>){}
+   |                    ^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `Repeatwith` in this scope
+  --> $DIR/iter.rs:38:21
+   |
+LL | fn test_repeatw(_x: Repeatwith<()>){}
+   |                     ^^^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::iter::RepeatWith`?
+   |
+LL | fn test_repeatw(_x: std::iter::RepeatWith<()>){}
+   |                     ^^^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `rev` in this scope
+  --> $DIR/iter.rs:40:17
+   |
+LL | fn test_rev(_x: rev<()>){}
+   |                 ^^^ not found in this scope
+   |
+help: did you mean `std::iter::Rev`?
+   |
+LL | fn test_rev(_x: std::iter::Rev<()>){}
+   |                 ^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `scan` in this scope
+  --> $DIR/iter.rs:42:18
+   |
+LL | fn test_scan(_x: scan<(), (), ()>){}
+   |                  ^^^^ not found in this scope
+   |
+help: did you mean `std::iter::Scan`?
+   |
+LL | fn test_scan(_x: std::iter::Scan<(), (), ()>){}
+   |                  ^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `skip` in this scope
+  --> $DIR/iter.rs:44:18
+   |
+LL | fn test_skip(_x: skip<()>){}
+   |                  ^^^^ not found in this scope
+   |
+help: did you mean `std::iter::Skip`?
+   |
+LL | fn test_skip(_x: std::iter::Skip<()>){}
+   |                  ^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `Skipwhile` in this scope
+  --> $DIR/iter.rs:46:19
+   |
+LL | fn test_skipw(_x: Skipwhile<(), ()>){}
+   |                   ^^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::iter::SkipWhile`?
+   |
+LL | fn test_skipw(_x: std::iter::SkipWhile<(), ()>){}
+   |                   ^^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `Stepby` in this scope
+  --> $DIR/iter.rs:48:20
+   |
+LL | fn test_stepby(_x: Stepby<()>){}
+   |                    ^^^^^^ not found in this scope
+   |
+help: did you mean `std::iter::StepBy`?
+   |
+LL | fn test_stepby(_x: std::iter::StepBy<()>){}
+   |                    ^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `successors` in this scope
+  --> $DIR/iter.rs:50:24
+   |
+LL | fn test_successors(_x: successors<()>){}
+   |                        ^^^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::iter::Successors`?
+   |
+LL | fn test_successors(_x: std::iter::Successors<()>){}
+   |                        ^^^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `take` in this scope
+  --> $DIR/iter.rs:52:18
+   |
+LL | fn test_take(_x: take<()>){}
+   |                  ^^^^ not found in this scope
+   |
+help: did you mean one of these?:
+   |
+LL | fn test_take(_x: std::io::Take<()>){}
+   |                  ^^^^^^^^^^^^^
+LL | fn test_take(_x: std::iter::Take<()>){}
+   |                  ^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `Takewhile` in this scope
+  --> $DIR/iter.rs:54:19
+   |
+LL | fn test_takew(_x: Takewhile<(), ()>){}
+   |                   ^^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::iter::TakeWhile`?
+   |
+LL | fn test_takew(_x: std::iter::TakeWhile<(), ()>){}
+   |                   ^^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `zip` in this scope
+  --> $DIR/iter.rs:56:17
+   |
+LL | fn test_zip(_x: zip<(), ()>){}
+   |                 ^^^ not found in this scope
+   |
+help: did you mean `std::iter::Zip`?
+   |
+LL | fn test_zip(_x: std::iter::Zip<(), ()>){}
+   |                 ^^^^^^^^^^^^^^
+
+error: aborting due to 27 previous errors
+
+For more information about this error, try `rustc --explain E0412`.

--- a/src/test/ui/libstd-case-typo/iter.stderr
+++ b/src/test/ui/libstd-case-typo/iter.stderr
@@ -4,7 +4,7 @@ error[E0412]: cannot find type `chain` in this scope
 LL | fn test_chain(_x: chain<(), ()>){}
    |                   ^^^^^ not found in this scope
    |
-help: found libstd structs with a similar name:
+help: found std structs with similar names:
    |
 LL | fn test_chain(_x: std::io::Chain<(), ()>){}
    |                   ^^^^^^^^^^^^^^
@@ -29,7 +29,7 @@ LL | fn test_copied(_x: copied<(), ()>){}
    |                    ^^^^^^
    |                    |
    |                    not found in this scope
-   |                    help: found a libstd struct with a similar name: `std::iter::Copied`
+   |                    help: found a std struct with a similar name: `std::iter::Copied`
 
 error[E0412]: cannot find type `cycle` in this scope
   --> $DIR/iter.rs:10:19
@@ -38,7 +38,7 @@ LL | fn test_cycle(_x: cycle<(), ()>){}
    |                   ^^^^^
    |                   |
    |                   not found in this scope
-   |                   help: found a libstd struct with a similar name: `std::iter::Cycle`
+   |                   help: found a std struct with a similar name: `std::iter::Cycle`
 
 error[E0412]: cannot find type `empty` in this scope
   --> $DIR/iter.rs:12:19
@@ -46,7 +46,7 @@ error[E0412]: cannot find type `empty` in this scope
 LL | fn test_empty(_x: empty){}
    |                   ^^^^^ not found in this scope
    |
-help: found libstd structs with a similar name:
+help: found std structs with similar names:
    |
 LL | fn test_empty(_x: std::io::Empty){}
    |                   ^^^^^^^^^^^^^^
@@ -60,7 +60,7 @@ LL | fn test_enumer(_x: enumerate<(), ()>){}
    |                    ^^^^^^^^^
    |                    |
    |                    not found in this scope
-   |                    help: found a libstd struct with a similar name: `std::iter::Enumerate`
+   |                    help: found a std struct with a similar name: `std::iter::Enumerate`
 
 error[E0412]: cannot find type `filter` in this scope
   --> $DIR/iter.rs:16:20
@@ -69,7 +69,7 @@ LL | fn test_filter(_x: filter<(), ()>){}
    |                    ^^^^^^
    |                    |
    |                    not found in this scope
-   |                    help: found a libstd struct with a similar name: `std::iter::Filter`
+   |                    help: found a std struct with a similar name: `std::iter::Filter`
 
 error[E0412]: cannot find type `Filtermap` in this scope
   --> $DIR/iter.rs:18:23
@@ -78,7 +78,7 @@ LL | fn test_filtermap(_x: Filtermap<(), ()>){}
    |                       ^^^^^^^^^
    |                       |
    |                       not found in this scope
-   |                       help: found a libstd struct with a similar name: `std::iter::FilterMap`
+   |                       help: found a std struct with a similar name: `std::iter::FilterMap`
 
 error[E0412]: cannot find type `flatten` in this scope
   --> $DIR/iter.rs:20:21
@@ -87,7 +87,7 @@ LL | fn test_flatten(_x: flatten<()>){}
    |                     ^^^^^^^
    |                     |
    |                     not found in this scope
-   |                     help: found a libstd struct with a similar name: `std::iter::Flatten`
+   |                     help: found a std struct with a similar name: `std::iter::Flatten`
 
 error[E0412]: cannot find type `Fromfn` in this scope
   --> $DIR/iter.rs:22:20
@@ -107,7 +107,7 @@ LL | fn test_fuse(_x: fuse<()>){}
    |                  ^^^^
    |                  |
    |                  not found in this scope
-   |                  help: found a libstd struct with a similar name: `std::iter::Fuse`
+   |                  help: found a std struct with a similar name: `std::iter::Fuse`
 
 error[E0412]: cannot find type `inspect` in this scope
   --> $DIR/iter.rs:26:21
@@ -116,7 +116,7 @@ LL | fn test_inspect(_x: inspect<(), ()>){}
    |                     ^^^^^^^
    |                     |
    |                     not found in this scope
-   |                     help: found a libstd struct with a similar name: `std::iter::Inspect`
+   |                     help: found a std struct with a similar name: `std::iter::Inspect`
 
 error[E0412]: cannot find type `map` in this scope
   --> $DIR/iter.rs:28:17
@@ -125,7 +125,7 @@ LL | fn test_map(_x: map<(), ()>){}
    |                 ^^^
    |                 |
    |                 not found in this scope
-   |                 help: found a libstd struct with a similar name: `std::iter::Map`
+   |                 help: found a std struct with a similar name: `std::iter::Map`
 
 error[E0412]: cannot find type `once` in this scope
   --> $DIR/iter.rs:30:18
@@ -133,7 +133,7 @@ error[E0412]: cannot find type `once` in this scope
 LL | fn test_once(_x: once<()>){}
    |                  ^^^^ not found in this scope
    |
-help: found libstd structs with a similar name:
+help: found std structs with similar names:
    |
 LL | fn test_once(_x: std::iter::Once<()>){}
    |                  ^^^^^^^^^^^^^^^
@@ -147,7 +147,7 @@ LL | fn test_oncewith(_x: Oncewith<()>){}
    |                      ^^^^^^^^
    |                      |
    |                      not found in this scope
-   |                      help: found a libstd struct with a similar name: `std::iter::OnceWith`
+   |                      help: found a std struct with a similar name: `std::iter::OnceWith`
 
 error[E0412]: cannot find type `peekable` in this scope
   --> $DIR/iter.rs:34:18
@@ -156,7 +156,7 @@ LL | fn test_peek(_x: peekable<()>){}
    |                  ^^^^^^^^
    |                  |
    |                  not found in this scope
-   |                  help: found a libstd struct with a similar name: `std::iter::Peekable`
+   |                  help: found a std struct with a similar name: `std::iter::Peekable`
 
 error[E0412]: cannot find type `repeat` in this scope
   --> $DIR/iter.rs:36:20
@@ -164,7 +164,7 @@ error[E0412]: cannot find type `repeat` in this scope
 LL | fn test_repeat(_x: repeat<()>){}
    |                    ^^^^^^ not found in this scope
    |
-help: found libstd structs with a similar name:
+help: found std structs with similar names:
    |
 LL | fn test_repeat(_x: std::io::Repeat<()>){}
    |                    ^^^^^^^^^^^^^^^
@@ -178,7 +178,7 @@ LL | fn test_repeatw(_x: Repeatwith<()>){}
    |                     ^^^^^^^^^^
    |                     |
    |                     not found in this scope
-   |                     help: found a libstd struct with a similar name: `std::iter::RepeatWith`
+   |                     help: found a std struct with a similar name: `std::iter::RepeatWith`
 
 error[E0412]: cannot find type `rev` in this scope
   --> $DIR/iter.rs:40:17
@@ -187,7 +187,7 @@ LL | fn test_rev(_x: rev<()>){}
    |                 ^^^
    |                 |
    |                 not found in this scope
-   |                 help: found a libstd struct with a similar name: `std::iter::Rev`
+   |                 help: found a std struct with a similar name: `std::iter::Rev`
 
 error[E0412]: cannot find type `scan` in this scope
   --> $DIR/iter.rs:42:18
@@ -196,7 +196,7 @@ LL | fn test_scan(_x: scan<(), (), ()>){}
    |                  ^^^^
    |                  |
    |                  not found in this scope
-   |                  help: found a libstd struct with a similar name: `std::iter::Scan`
+   |                  help: found a std struct with a similar name: `std::iter::Scan`
 
 error[E0412]: cannot find type `skip` in this scope
   --> $DIR/iter.rs:44:18
@@ -205,7 +205,7 @@ LL | fn test_skip(_x: skip<()>){}
    |                  ^^^^
    |                  |
    |                  not found in this scope
-   |                  help: found a libstd struct with a similar name: `std::iter::Skip`
+   |                  help: found a std struct with a similar name: `std::iter::Skip`
 
 error[E0412]: cannot find type `Skipwhile` in this scope
   --> $DIR/iter.rs:46:19
@@ -214,7 +214,7 @@ LL | fn test_skipw(_x: Skipwhile<(), ()>){}
    |                   ^^^^^^^^^
    |                   |
    |                   not found in this scope
-   |                   help: found a libstd struct with a similar name: `std::iter::SkipWhile`
+   |                   help: found a std struct with a similar name: `std::iter::SkipWhile`
 
 error[E0412]: cannot find type `Stepby` in this scope
   --> $DIR/iter.rs:48:20
@@ -223,7 +223,7 @@ LL | fn test_stepby(_x: Stepby<()>){}
    |                    ^^^^^^
    |                    |
    |                    not found in this scope
-   |                    help: found a libstd struct with a similar name: `std::iter::StepBy`
+   |                    help: found a std struct with a similar name: `std::iter::StepBy`
 
 error[E0412]: cannot find type `successors` in this scope
   --> $DIR/iter.rs:50:24
@@ -232,7 +232,7 @@ LL | fn test_successors(_x: successors<()>){}
    |                        ^^^^^^^^^^
    |                        |
    |                        not found in this scope
-   |                        help: found a libstd struct with a similar name: `std::iter::Successors`
+   |                        help: found a std struct with a similar name: `std::iter::Successors`
 
 error[E0412]: cannot find type `take` in this scope
   --> $DIR/iter.rs:52:18
@@ -240,7 +240,7 @@ error[E0412]: cannot find type `take` in this scope
 LL | fn test_take(_x: take<()>){}
    |                  ^^^^ not found in this scope
    |
-help: found libstd structs with a similar name:
+help: found std structs with similar names:
    |
 LL | fn test_take(_x: std::io::Take<()>){}
    |                  ^^^^^^^^^^^^^
@@ -254,7 +254,7 @@ LL | fn test_takew(_x: Takewhile<(), ()>){}
    |                   ^^^^^^^^^
    |                   |
    |                   not found in this scope
-   |                   help: found a libstd struct with a similar name: `std::iter::TakeWhile`
+   |                   help: found a std struct with a similar name: `std::iter::TakeWhile`
 
 error[E0412]: cannot find type `zip` in this scope
   --> $DIR/iter.rs:56:17
@@ -263,7 +263,7 @@ LL | fn test_zip(_x: zip<(), ()>){}
    |                 ^^^
    |                 |
    |                 not found in this scope
-   |                 help: found a libstd struct with a similar name: `std::iter::Zip`
+   |                 help: found a std struct with a similar name: `std::iter::Zip`
 
 error: aborting due to 27 previous errors
 

--- a/src/test/ui/libstd-case-typo/marker.rs
+++ b/src/test/ui/libstd-case-typo/marker.rs
@@ -1,0 +1,7 @@
+// checks case typos with libstd::marker structs
+fn main(){}
+
+fn test_phandat(_x: Phantomdata){}
+//~^ ERROR: cannot find type `Phantomdata` in this scope
+fn test_phanpin(_x: Phantompinned){}
+//~^ ERROR: cannot find type `Phantompinned` in this scope

--- a/src/test/ui/libstd-case-typo/marker.stderr
+++ b/src/test/ui/libstd-case-typo/marker.stderr
@@ -1,0 +1,25 @@
+error[E0412]: cannot find type `Phantomdata` in this scope
+  --> $DIR/marker.rs:4:21
+   |
+LL | fn test_phandat(_x: Phantomdata){}
+   |                     ^^^^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::marker::PhantomData`?
+   |
+LL | fn test_phandat(_x: std::marker::PhantomData){}
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `Phantompinned` in this scope
+  --> $DIR/marker.rs:6:21
+   |
+LL | fn test_phanpin(_x: Phantompinned){}
+   |                     ^^^^^^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::marker::PhantomPinned`?
+   |
+LL | fn test_phanpin(_x: std::marker::PhantomPinned){}
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0412`.

--- a/src/test/ui/libstd-case-typo/marker.stderr
+++ b/src/test/ui/libstd-case-typo/marker.stderr
@@ -5,7 +5,7 @@ LL | fn test_phandat(_x: Phantomdata){}
    |                     ^^^^^^^^^^^
    |                     |
    |                     not found in this scope
-   |                     help: found a libstd struct with a similar name: `std::marker::PhantomData`
+   |                     help: found a std struct with a similar name: `std::marker::PhantomData`
 
 error[E0412]: cannot find type `Phantompinned` in this scope
   --> $DIR/marker.rs:6:21
@@ -14,7 +14,7 @@ LL | fn test_phanpin(_x: Phantompinned){}
    |                     ^^^^^^^^^^^^^
    |                     |
    |                     not found in this scope
-   |                     help: found a libstd struct with a similar name: `std::marker::PhantomPinned`
+   |                     help: found a std struct with a similar name: `std::marker::PhantomPinned`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/libstd-case-typo/marker.stderr
+++ b/src/test/ui/libstd-case-typo/marker.stderr
@@ -2,23 +2,19 @@ error[E0412]: cannot find type `Phantomdata` in this scope
   --> $DIR/marker.rs:4:21
    |
 LL | fn test_phandat(_x: Phantomdata){}
-   |                     ^^^^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::marker::PhantomData`?
-   |
-LL | fn test_phandat(_x: std::marker::PhantomData){}
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                     ^^^^^^^^^^^
+   |                     |
+   |                     not found in this scope
+   |                     help: found a libstd struct with a similar name: `std::marker::PhantomData`
 
 error[E0412]: cannot find type `Phantompinned` in this scope
   --> $DIR/marker.rs:6:21
    |
 LL | fn test_phanpin(_x: Phantompinned){}
-   |                     ^^^^^^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::marker::PhantomPinned`?
-   |
-LL | fn test_phanpin(_x: std::marker::PhantomPinned){}
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                     ^^^^^^^^^^^^^
+   |                     |
+   |                     not found in this scope
+   |                     help: found a libstd struct with a similar name: `std::marker::PhantomPinned`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/libstd-case-typo/mem.rs
+++ b/src/test/ui/libstd-case-typo/mem.rs
@@ -1,0 +1,7 @@
+// checks case typos with libstd::mem structs
+fn main(){}
+
+fn test_disc(_x: discriminant<()>){}
+//~^ ERROR: cannot find type `discriminant` in this scope
+fn test_mandrop(_x: Manuallydrop<()>){}
+//~^ ERROR: cannot find type `Manuallydrop` in this scope

--- a/src/test/ui/libstd-case-typo/mem.stderr
+++ b/src/test/ui/libstd-case-typo/mem.stderr
@@ -5,7 +5,7 @@ LL | fn test_disc(_x: discriminant<()>){}
    |                  ^^^^^^^^^^^^
    |                  |
    |                  not found in this scope
-   |                  help: found a libstd struct with a similar name: `std::mem::Discriminant`
+   |                  help: found a std struct with a similar name: `std::mem::Discriminant`
 
 error[E0412]: cannot find type `Manuallydrop` in this scope
   --> $DIR/mem.rs:6:21
@@ -14,7 +14,7 @@ LL | fn test_mandrop(_x: Manuallydrop<()>){}
    |                     ^^^^^^^^^^^^
    |                     |
    |                     not found in this scope
-   |                     help: found a libstd struct with a similar name: `std::mem::ManuallyDrop`
+   |                     help: found a std struct with a similar name: `std::mem::ManuallyDrop`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/libstd-case-typo/mem.stderr
+++ b/src/test/ui/libstd-case-typo/mem.stderr
@@ -1,0 +1,25 @@
+error[E0412]: cannot find type `discriminant` in this scope
+  --> $DIR/mem.rs:4:18
+   |
+LL | fn test_disc(_x: discriminant<()>){}
+   |                  ^^^^^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::mem::Discriminant`?
+   |
+LL | fn test_disc(_x: std::mem::Discriminant<()>){}
+   |                  ^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `Manuallydrop` in this scope
+  --> $DIR/mem.rs:6:21
+   |
+LL | fn test_mandrop(_x: Manuallydrop<()>){}
+   |                     ^^^^^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::mem::ManuallyDrop`?
+   |
+LL | fn test_mandrop(_x: std::mem::ManuallyDrop<()>){}
+   |                     ^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0412`.

--- a/src/test/ui/libstd-case-typo/mem.stderr
+++ b/src/test/ui/libstd-case-typo/mem.stderr
@@ -2,23 +2,19 @@ error[E0412]: cannot find type `discriminant` in this scope
   --> $DIR/mem.rs:4:18
    |
 LL | fn test_disc(_x: discriminant<()>){}
-   |                  ^^^^^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::mem::Discriminant`?
-   |
-LL | fn test_disc(_x: std::mem::Discriminant<()>){}
-   |                  ^^^^^^^^^^^^^^^^^^^^^^
+   |                  ^^^^^^^^^^^^
+   |                  |
+   |                  not found in this scope
+   |                  help: found a libstd struct with a similar name: `std::mem::Discriminant`
 
 error[E0412]: cannot find type `Manuallydrop` in this scope
   --> $DIR/mem.rs:6:21
    |
 LL | fn test_mandrop(_x: Manuallydrop<()>){}
-   |                     ^^^^^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::mem::ManuallyDrop`?
-   |
-LL | fn test_mandrop(_x: std::mem::ManuallyDrop<()>){}
-   |                     ^^^^^^^^^^^^^^^^^^^^^^
+   |                     ^^^^^^^^^^^^
+   |                     |
+   |                     not found in this scope
+   |                     help: found a libstd struct with a similar name: `std::mem::ManuallyDrop`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/libstd-case-typo/net.rs
+++ b/src/test/ui/libstd-case-typo/net.rs
@@ -1,0 +1,19 @@
+// checks case typos with libstd::net structs
+fn main(){}
+
+fn test_inc(_x: incoming){}
+//~^ ERROR: cannot find type `incoming` in this scope
+fn test_ipv4(_x: IPv4Addr){}
+//~^ ERROR: cannot find type `IPv4Addr` in this scope
+fn test_ipv6(_x: IPv6Addr){}
+//~^ ERROR: cannot find type `IPv6Addr` in this scope
+fn test_socv4(_x: SocketAddrv4){}
+//~^ ERROR: cannot find type `SocketAddrv4` in this scope
+fn test_socv6(_x: SocketAddrv6){}
+//~^ ERROR: cannot find type `SocketAddrv6` in this scope
+fn test_tcplist(_x: TCPListener){}
+//~^ ERROR: cannot find type `TCPListener` in this scope
+fn test_tcpstr(_x: TCPStream){}
+//~^ ERROR: cannot find type `TCPStream` in this scope
+fn test_udpsoc(_x: UDPSocket){}
+//~^ ERROR: cannot find type `UDPSocket` in this scope

--- a/src/test/ui/libstd-case-typo/net.stderr
+++ b/src/test/ui/libstd-case-typo/net.stderr
@@ -1,0 +1,91 @@
+error[E0412]: cannot find type `incoming` in this scope
+  --> $DIR/net.rs:4:17
+   |
+LL | fn test_inc(_x: incoming){}
+   |                 ^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::net::Incoming`?
+   |
+LL | fn test_inc(_x: std::net::Incoming){}
+   |                 ^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `IPv4Addr` in this scope
+  --> $DIR/net.rs:6:18
+   |
+LL | fn test_ipv4(_x: IPv4Addr){}
+   |                  ^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::net::Ipv4Addr`?
+   |
+LL | fn test_ipv4(_x: std::net::Ipv4Addr){}
+   |                  ^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `IPv6Addr` in this scope
+  --> $DIR/net.rs:8:18
+   |
+LL | fn test_ipv6(_x: IPv6Addr){}
+   |                  ^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::net::Ipv6Addr`?
+   |
+LL | fn test_ipv6(_x: std::net::Ipv6Addr){}
+   |                  ^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `SocketAddrv4` in this scope
+  --> $DIR/net.rs:10:19
+   |
+LL | fn test_socv4(_x: SocketAddrv4){}
+   |                   ^^^^^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::net::SocketAddrV4`?
+   |
+LL | fn test_socv4(_x: std::net::SocketAddrV4){}
+   |                   ^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `SocketAddrv6` in this scope
+  --> $DIR/net.rs:12:19
+   |
+LL | fn test_socv6(_x: SocketAddrv6){}
+   |                   ^^^^^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::net::SocketAddrV6`?
+   |
+LL | fn test_socv6(_x: std::net::SocketAddrV6){}
+   |                   ^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `TCPListener` in this scope
+  --> $DIR/net.rs:14:21
+   |
+LL | fn test_tcplist(_x: TCPListener){}
+   |                     ^^^^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::net::TcpListener`?
+   |
+LL | fn test_tcplist(_x: std::net::TcpListener){}
+   |                     ^^^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `TCPStream` in this scope
+  --> $DIR/net.rs:16:20
+   |
+LL | fn test_tcpstr(_x: TCPStream){}
+   |                    ^^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::net::TcpStream`?
+   |
+LL | fn test_tcpstr(_x: std::net::TcpStream){}
+   |                    ^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `UDPSocket` in this scope
+  --> $DIR/net.rs:18:20
+   |
+LL | fn test_udpsoc(_x: UDPSocket){}
+   |                    ^^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::net::UdpSocket`?
+   |
+LL | fn test_udpsoc(_x: std::net::UdpSocket){}
+   |                    ^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 8 previous errors
+
+For more information about this error, try `rustc --explain E0412`.

--- a/src/test/ui/libstd-case-typo/net.stderr
+++ b/src/test/ui/libstd-case-typo/net.stderr
@@ -5,7 +5,7 @@ LL | fn test_inc(_x: incoming){}
    |                 ^^^^^^^^
    |                 |
    |                 not found in this scope
-   |                 help: found a libstd struct with a similar name: `std::net::Incoming`
+   |                 help: found a std struct with a similar name: `std::net::Incoming`
 
 error[E0412]: cannot find type `IPv4Addr` in this scope
   --> $DIR/net.rs:6:18
@@ -14,7 +14,7 @@ LL | fn test_ipv4(_x: IPv4Addr){}
    |                  ^^^^^^^^
    |                  |
    |                  not found in this scope
-   |                  help: found a libstd struct with a similar name: `std::net::Ipv4Addr`
+   |                  help: found a std struct with a similar name: `std::net::Ipv4Addr`
 
 error[E0412]: cannot find type `IPv6Addr` in this scope
   --> $DIR/net.rs:8:18
@@ -23,7 +23,7 @@ LL | fn test_ipv6(_x: IPv6Addr){}
    |                  ^^^^^^^^
    |                  |
    |                  not found in this scope
-   |                  help: found a libstd struct with a similar name: `std::net::Ipv6Addr`
+   |                  help: found a std struct with a similar name: `std::net::Ipv6Addr`
 
 error[E0412]: cannot find type `SocketAddrv4` in this scope
   --> $DIR/net.rs:10:19
@@ -32,7 +32,7 @@ LL | fn test_socv4(_x: SocketAddrv4){}
    |                   ^^^^^^^^^^^^
    |                   |
    |                   not found in this scope
-   |                   help: found a libstd struct with a similar name: `std::net::SocketAddrV4`
+   |                   help: found a std struct with a similar name: `std::net::SocketAddrV4`
 
 error[E0412]: cannot find type `SocketAddrv6` in this scope
   --> $DIR/net.rs:12:19
@@ -41,7 +41,7 @@ LL | fn test_socv6(_x: SocketAddrv6){}
    |                   ^^^^^^^^^^^^
    |                   |
    |                   not found in this scope
-   |                   help: found a libstd struct with a similar name: `std::net::SocketAddrV6`
+   |                   help: found a std struct with a similar name: `std::net::SocketAddrV6`
 
 error[E0412]: cannot find type `TCPListener` in this scope
   --> $DIR/net.rs:14:21
@@ -50,7 +50,7 @@ LL | fn test_tcplist(_x: TCPListener){}
    |                     ^^^^^^^^^^^
    |                     |
    |                     not found in this scope
-   |                     help: found a libstd struct with a similar name: `std::net::TcpListener`
+   |                     help: found a std struct with a similar name: `std::net::TcpListener`
 
 error[E0412]: cannot find type `TCPStream` in this scope
   --> $DIR/net.rs:16:20
@@ -59,7 +59,7 @@ LL | fn test_tcpstr(_x: TCPStream){}
    |                    ^^^^^^^^^
    |                    |
    |                    not found in this scope
-   |                    help: found a libstd struct with a similar name: `std::net::TcpStream`
+   |                    help: found a std struct with a similar name: `std::net::TcpStream`
 
 error[E0412]: cannot find type `UDPSocket` in this scope
   --> $DIR/net.rs:18:20
@@ -68,7 +68,7 @@ LL | fn test_udpsoc(_x: UDPSocket){}
    |                    ^^^^^^^^^
    |                    |
    |                    not found in this scope
-   |                    help: found a libstd struct with a similar name: `std::net::UdpSocket`
+   |                    help: found a std struct with a similar name: `std::net::UdpSocket`
 
 error: aborting due to 8 previous errors
 

--- a/src/test/ui/libstd-case-typo/net.stderr
+++ b/src/test/ui/libstd-case-typo/net.stderr
@@ -2,89 +2,73 @@ error[E0412]: cannot find type `incoming` in this scope
   --> $DIR/net.rs:4:17
    |
 LL | fn test_inc(_x: incoming){}
-   |                 ^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::net::Incoming`?
-   |
-LL | fn test_inc(_x: std::net::Incoming){}
-   |                 ^^^^^^^^^^^^^^^^^^
+   |                 ^^^^^^^^
+   |                 |
+   |                 not found in this scope
+   |                 help: found a libstd struct with a similar name: `std::net::Incoming`
 
 error[E0412]: cannot find type `IPv4Addr` in this scope
   --> $DIR/net.rs:6:18
    |
 LL | fn test_ipv4(_x: IPv4Addr){}
-   |                  ^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::net::Ipv4Addr`?
-   |
-LL | fn test_ipv4(_x: std::net::Ipv4Addr){}
-   |                  ^^^^^^^^^^^^^^^^^^
+   |                  ^^^^^^^^
+   |                  |
+   |                  not found in this scope
+   |                  help: found a libstd struct with a similar name: `std::net::Ipv4Addr`
 
 error[E0412]: cannot find type `IPv6Addr` in this scope
   --> $DIR/net.rs:8:18
    |
 LL | fn test_ipv6(_x: IPv6Addr){}
-   |                  ^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::net::Ipv6Addr`?
-   |
-LL | fn test_ipv6(_x: std::net::Ipv6Addr){}
-   |                  ^^^^^^^^^^^^^^^^^^
+   |                  ^^^^^^^^
+   |                  |
+   |                  not found in this scope
+   |                  help: found a libstd struct with a similar name: `std::net::Ipv6Addr`
 
 error[E0412]: cannot find type `SocketAddrv4` in this scope
   --> $DIR/net.rs:10:19
    |
 LL | fn test_socv4(_x: SocketAddrv4){}
-   |                   ^^^^^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::net::SocketAddrV4`?
-   |
-LL | fn test_socv4(_x: std::net::SocketAddrV4){}
-   |                   ^^^^^^^^^^^^^^^^^^^^^^
+   |                   ^^^^^^^^^^^^
+   |                   |
+   |                   not found in this scope
+   |                   help: found a libstd struct with a similar name: `std::net::SocketAddrV4`
 
 error[E0412]: cannot find type `SocketAddrv6` in this scope
   --> $DIR/net.rs:12:19
    |
 LL | fn test_socv6(_x: SocketAddrv6){}
-   |                   ^^^^^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::net::SocketAddrV6`?
-   |
-LL | fn test_socv6(_x: std::net::SocketAddrV6){}
-   |                   ^^^^^^^^^^^^^^^^^^^^^^
+   |                   ^^^^^^^^^^^^
+   |                   |
+   |                   not found in this scope
+   |                   help: found a libstd struct with a similar name: `std::net::SocketAddrV6`
 
 error[E0412]: cannot find type `TCPListener` in this scope
   --> $DIR/net.rs:14:21
    |
 LL | fn test_tcplist(_x: TCPListener){}
-   |                     ^^^^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::net::TcpListener`?
-   |
-LL | fn test_tcplist(_x: std::net::TcpListener){}
-   |                     ^^^^^^^^^^^^^^^^^^^^^
+   |                     ^^^^^^^^^^^
+   |                     |
+   |                     not found in this scope
+   |                     help: found a libstd struct with a similar name: `std::net::TcpListener`
 
 error[E0412]: cannot find type `TCPStream` in this scope
   --> $DIR/net.rs:16:20
    |
 LL | fn test_tcpstr(_x: TCPStream){}
-   |                    ^^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::net::TcpStream`?
-   |
-LL | fn test_tcpstr(_x: std::net::TcpStream){}
-   |                    ^^^^^^^^^^^^^^^^^^^
+   |                    ^^^^^^^^^
+   |                    |
+   |                    not found in this scope
+   |                    help: found a libstd struct with a similar name: `std::net::TcpStream`
 
 error[E0412]: cannot find type `UDPSocket` in this scope
   --> $DIR/net.rs:18:20
    |
 LL | fn test_udpsoc(_x: UDPSocket){}
-   |                    ^^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::net::UdpSocket`?
-   |
-LL | fn test_udpsoc(_x: std::net::UdpSocket){}
-   |                    ^^^^^^^^^^^^^^^^^^^
+   |                    ^^^^^^^^^
+   |                    |
+   |                    not found in this scope
+   |                    help: found a libstd struct with a similar name: `std::net::UdpSocket`
 
 error: aborting due to 8 previous errors
 

--- a/src/test/ui/libstd-case-typo/num.rs
+++ b/src/test/ui/libstd-case-typo/num.rs
@@ -1,0 +1,27 @@
+// checks case typos with libstd::num structs
+fn main(){}
+
+fn test_nzi8(_x: NonZeroi8){}
+//~^ ERROR: cannot find type `NonZeroi8` in this scope
+fn test_nzi16(_x: NonZeroi16){}
+//~^ ERROR: cannot find type `NonZeroi16` in this scope
+fn test_nzi32(_x: NonZeroi32){}
+//~^ ERROR: cannot find type `NonZeroi32` in this scope
+fn test_nzi64(_x: NonZeroi64){}
+//~^ ERROR: cannot find type `NonZeroi64` in this scope
+fn test_nzi128(_x: NonZeroi128){}
+//~^ ERROR: cannot find type `NonZeroi128` in this scope
+fn test_nzu8(_x: NonZerou8){}
+//~^ ERROR: cannot find type `NonZerou8` in this scope
+fn test_nzu16(_x: NonZerou16){}
+//~^ ERROR: cannot find type `NonZerou16` in this scope
+fn test_nzu32(_x: NonZerou32){}
+//~^ ERROR: cannot find type `NonZerou32` in this scope
+fn test_nzu64(_x: NonZerou64){}
+//~^ ERROR: cannot find type `NonZerou64` in this scope
+fn test_nzu128(_x: NonZerou128){}
+//~^ ERROR: cannot find type `NonZerou128` in this scope
+fn test_nzus(_x: NonzeroUsize){}
+//~^ ERROR: cannot find type `NonzeroUsize` in this scope
+fn test_wrap(_x: wrapping){}
+//~^ ERROR: cannot find type `wrapping` in this scope

--- a/src/test/ui/libstd-case-typo/num.stderr
+++ b/src/test/ui/libstd-case-typo/num.stderr
@@ -5,7 +5,7 @@ LL | fn test_nzi8(_x: NonZeroi8){}
    |                  ^^^^^^^^^
    |                  |
    |                  not found in this scope
-   |                  help: found a libstd struct with a similar name: `std::num::NonZeroI8`
+   |                  help: found a std struct with a similar name: `std::num::NonZeroI8`
 
 error[E0412]: cannot find type `NonZeroi16` in this scope
   --> $DIR/num.rs:6:19
@@ -14,7 +14,7 @@ LL | fn test_nzi16(_x: NonZeroi16){}
    |                   ^^^^^^^^^^
    |                   |
    |                   not found in this scope
-   |                   help: found a libstd struct with a similar name: `std::num::NonZeroI16`
+   |                   help: found a std struct with a similar name: `std::num::NonZeroI16`
 
 error[E0412]: cannot find type `NonZeroi32` in this scope
   --> $DIR/num.rs:8:19
@@ -23,7 +23,7 @@ LL | fn test_nzi32(_x: NonZeroi32){}
    |                   ^^^^^^^^^^
    |                   |
    |                   not found in this scope
-   |                   help: found a libstd struct with a similar name: `std::num::NonZeroI32`
+   |                   help: found a std struct with a similar name: `std::num::NonZeroI32`
 
 error[E0412]: cannot find type `NonZeroi64` in this scope
   --> $DIR/num.rs:10:19
@@ -32,7 +32,7 @@ LL | fn test_nzi64(_x: NonZeroi64){}
    |                   ^^^^^^^^^^
    |                   |
    |                   not found in this scope
-   |                   help: found a libstd struct with a similar name: `std::num::NonZeroI64`
+   |                   help: found a std struct with a similar name: `std::num::NonZeroI64`
 
 error[E0412]: cannot find type `NonZeroi128` in this scope
   --> $DIR/num.rs:12:20
@@ -41,7 +41,7 @@ LL | fn test_nzi128(_x: NonZeroi128){}
    |                    ^^^^^^^^^^^
    |                    |
    |                    not found in this scope
-   |                    help: found a libstd struct with a similar name: `std::num::NonZeroI128`
+   |                    help: found a std struct with a similar name: `std::num::NonZeroI128`
 
 error[E0412]: cannot find type `NonZerou8` in this scope
   --> $DIR/num.rs:14:18
@@ -50,7 +50,7 @@ LL | fn test_nzu8(_x: NonZerou8){}
    |                  ^^^^^^^^^
    |                  |
    |                  not found in this scope
-   |                  help: found a libstd struct with a similar name: `std::num::NonZeroU8`
+   |                  help: found a std struct with a similar name: `std::num::NonZeroU8`
 
 error[E0412]: cannot find type `NonZerou16` in this scope
   --> $DIR/num.rs:16:19
@@ -59,7 +59,7 @@ LL | fn test_nzu16(_x: NonZerou16){}
    |                   ^^^^^^^^^^
    |                   |
    |                   not found in this scope
-   |                   help: found a libstd struct with a similar name: `std::num::NonZeroU16`
+   |                   help: found a std struct with a similar name: `std::num::NonZeroU16`
 
 error[E0412]: cannot find type `NonZerou32` in this scope
   --> $DIR/num.rs:18:19
@@ -68,7 +68,7 @@ LL | fn test_nzu32(_x: NonZerou32){}
    |                   ^^^^^^^^^^
    |                   |
    |                   not found in this scope
-   |                   help: found a libstd struct with a similar name: `std::num::NonZeroU32`
+   |                   help: found a std struct with a similar name: `std::num::NonZeroU32`
 
 error[E0412]: cannot find type `NonZerou64` in this scope
   --> $DIR/num.rs:20:19
@@ -77,7 +77,7 @@ LL | fn test_nzu64(_x: NonZerou64){}
    |                   ^^^^^^^^^^
    |                   |
    |                   not found in this scope
-   |                   help: found a libstd struct with a similar name: `std::num::NonZeroU64`
+   |                   help: found a std struct with a similar name: `std::num::NonZeroU64`
 
 error[E0412]: cannot find type `NonZerou128` in this scope
   --> $DIR/num.rs:22:20
@@ -86,7 +86,7 @@ LL | fn test_nzu128(_x: NonZerou128){}
    |                    ^^^^^^^^^^^
    |                    |
    |                    not found in this scope
-   |                    help: found a libstd struct with a similar name: `std::num::NonZeroU128`
+   |                    help: found a std struct with a similar name: `std::num::NonZeroU128`
 
 error[E0412]: cannot find type `NonzeroUsize` in this scope
   --> $DIR/num.rs:24:18
@@ -95,7 +95,7 @@ LL | fn test_nzus(_x: NonzeroUsize){}
    |                  ^^^^^^^^^^^^
    |                  |
    |                  not found in this scope
-   |                  help: found a libstd struct with a similar name: `std::num::NonZeroUsize`
+   |                  help: found a std struct with a similar name: `std::num::NonZeroUsize`
 
 error[E0412]: cannot find type `wrapping` in this scope
   --> $DIR/num.rs:26:18
@@ -104,7 +104,7 @@ LL | fn test_wrap(_x: wrapping){}
    |                  ^^^^^^^^
    |                  |
    |                  not found in this scope
-   |                  help: found a libstd struct with a similar name: `std::num::Wrapping`
+   |                  help: found a std struct with a similar name: `std::num::Wrapping`
 
 error: aborting due to 12 previous errors
 

--- a/src/test/ui/libstd-case-typo/num.stderr
+++ b/src/test/ui/libstd-case-typo/num.stderr
@@ -1,0 +1,135 @@
+error[E0412]: cannot find type `NonZeroi8` in this scope
+  --> $DIR/num.rs:4:18
+   |
+LL | fn test_nzi8(_x: NonZeroi8){}
+   |                  ^^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::num::NonZeroI8`?
+   |
+LL | fn test_nzi8(_x: std::num::NonZeroI8){}
+   |                  ^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `NonZeroi16` in this scope
+  --> $DIR/num.rs:6:19
+   |
+LL | fn test_nzi16(_x: NonZeroi16){}
+   |                   ^^^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::num::NonZeroI16`?
+   |
+LL | fn test_nzi16(_x: std::num::NonZeroI16){}
+   |                   ^^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `NonZeroi32` in this scope
+  --> $DIR/num.rs:8:19
+   |
+LL | fn test_nzi32(_x: NonZeroi32){}
+   |                   ^^^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::num::NonZeroI32`?
+   |
+LL | fn test_nzi32(_x: std::num::NonZeroI32){}
+   |                   ^^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `NonZeroi64` in this scope
+  --> $DIR/num.rs:10:19
+   |
+LL | fn test_nzi64(_x: NonZeroi64){}
+   |                   ^^^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::num::NonZeroI64`?
+   |
+LL | fn test_nzi64(_x: std::num::NonZeroI64){}
+   |                   ^^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `NonZeroi128` in this scope
+  --> $DIR/num.rs:12:20
+   |
+LL | fn test_nzi128(_x: NonZeroi128){}
+   |                    ^^^^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::num::NonZeroI128`?
+   |
+LL | fn test_nzi128(_x: std::num::NonZeroI128){}
+   |                    ^^^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `NonZerou8` in this scope
+  --> $DIR/num.rs:14:18
+   |
+LL | fn test_nzu8(_x: NonZerou8){}
+   |                  ^^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::num::NonZeroU8`?
+   |
+LL | fn test_nzu8(_x: std::num::NonZeroU8){}
+   |                  ^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `NonZerou16` in this scope
+  --> $DIR/num.rs:16:19
+   |
+LL | fn test_nzu16(_x: NonZerou16){}
+   |                   ^^^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::num::NonZeroU16`?
+   |
+LL | fn test_nzu16(_x: std::num::NonZeroU16){}
+   |                   ^^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `NonZerou32` in this scope
+  --> $DIR/num.rs:18:19
+   |
+LL | fn test_nzu32(_x: NonZerou32){}
+   |                   ^^^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::num::NonZeroU32`?
+   |
+LL | fn test_nzu32(_x: std::num::NonZeroU32){}
+   |                   ^^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `NonZerou64` in this scope
+  --> $DIR/num.rs:20:19
+   |
+LL | fn test_nzu64(_x: NonZerou64){}
+   |                   ^^^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::num::NonZeroU64`?
+   |
+LL | fn test_nzu64(_x: std::num::NonZeroU64){}
+   |                   ^^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `NonZerou128` in this scope
+  --> $DIR/num.rs:22:20
+   |
+LL | fn test_nzu128(_x: NonZerou128){}
+   |                    ^^^^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::num::NonZeroU128`?
+   |
+LL | fn test_nzu128(_x: std::num::NonZeroU128){}
+   |                    ^^^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `NonzeroUsize` in this scope
+  --> $DIR/num.rs:24:18
+   |
+LL | fn test_nzus(_x: NonzeroUsize){}
+   |                  ^^^^^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::num::NonZeroUsize`?
+   |
+LL | fn test_nzus(_x: std::num::NonZeroUsize){}
+   |                  ^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `wrapping` in this scope
+  --> $DIR/num.rs:26:18
+   |
+LL | fn test_wrap(_x: wrapping){}
+   |                  ^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::num::Wrapping`?
+   |
+LL | fn test_wrap(_x: std::num::Wrapping){}
+   |                  ^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 12 previous errors
+
+For more information about this error, try `rustc --explain E0412`.

--- a/src/test/ui/libstd-case-typo/num.stderr
+++ b/src/test/ui/libstd-case-typo/num.stderr
@@ -2,133 +2,109 @@ error[E0412]: cannot find type `NonZeroi8` in this scope
   --> $DIR/num.rs:4:18
    |
 LL | fn test_nzi8(_x: NonZeroi8){}
-   |                  ^^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::num::NonZeroI8`?
-   |
-LL | fn test_nzi8(_x: std::num::NonZeroI8){}
-   |                  ^^^^^^^^^^^^^^^^^^^
+   |                  ^^^^^^^^^
+   |                  |
+   |                  not found in this scope
+   |                  help: found a libstd struct with a similar name: `std::num::NonZeroI8`
 
 error[E0412]: cannot find type `NonZeroi16` in this scope
   --> $DIR/num.rs:6:19
    |
 LL | fn test_nzi16(_x: NonZeroi16){}
-   |                   ^^^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::num::NonZeroI16`?
-   |
-LL | fn test_nzi16(_x: std::num::NonZeroI16){}
-   |                   ^^^^^^^^^^^^^^^^^^^^
+   |                   ^^^^^^^^^^
+   |                   |
+   |                   not found in this scope
+   |                   help: found a libstd struct with a similar name: `std::num::NonZeroI16`
 
 error[E0412]: cannot find type `NonZeroi32` in this scope
   --> $DIR/num.rs:8:19
    |
 LL | fn test_nzi32(_x: NonZeroi32){}
-   |                   ^^^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::num::NonZeroI32`?
-   |
-LL | fn test_nzi32(_x: std::num::NonZeroI32){}
-   |                   ^^^^^^^^^^^^^^^^^^^^
+   |                   ^^^^^^^^^^
+   |                   |
+   |                   not found in this scope
+   |                   help: found a libstd struct with a similar name: `std::num::NonZeroI32`
 
 error[E0412]: cannot find type `NonZeroi64` in this scope
   --> $DIR/num.rs:10:19
    |
 LL | fn test_nzi64(_x: NonZeroi64){}
-   |                   ^^^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::num::NonZeroI64`?
-   |
-LL | fn test_nzi64(_x: std::num::NonZeroI64){}
-   |                   ^^^^^^^^^^^^^^^^^^^^
+   |                   ^^^^^^^^^^
+   |                   |
+   |                   not found in this scope
+   |                   help: found a libstd struct with a similar name: `std::num::NonZeroI64`
 
 error[E0412]: cannot find type `NonZeroi128` in this scope
   --> $DIR/num.rs:12:20
    |
 LL | fn test_nzi128(_x: NonZeroi128){}
-   |                    ^^^^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::num::NonZeroI128`?
-   |
-LL | fn test_nzi128(_x: std::num::NonZeroI128){}
-   |                    ^^^^^^^^^^^^^^^^^^^^^
+   |                    ^^^^^^^^^^^
+   |                    |
+   |                    not found in this scope
+   |                    help: found a libstd struct with a similar name: `std::num::NonZeroI128`
 
 error[E0412]: cannot find type `NonZerou8` in this scope
   --> $DIR/num.rs:14:18
    |
 LL | fn test_nzu8(_x: NonZerou8){}
-   |                  ^^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::num::NonZeroU8`?
-   |
-LL | fn test_nzu8(_x: std::num::NonZeroU8){}
-   |                  ^^^^^^^^^^^^^^^^^^^
+   |                  ^^^^^^^^^
+   |                  |
+   |                  not found in this scope
+   |                  help: found a libstd struct with a similar name: `std::num::NonZeroU8`
 
 error[E0412]: cannot find type `NonZerou16` in this scope
   --> $DIR/num.rs:16:19
    |
 LL | fn test_nzu16(_x: NonZerou16){}
-   |                   ^^^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::num::NonZeroU16`?
-   |
-LL | fn test_nzu16(_x: std::num::NonZeroU16){}
-   |                   ^^^^^^^^^^^^^^^^^^^^
+   |                   ^^^^^^^^^^
+   |                   |
+   |                   not found in this scope
+   |                   help: found a libstd struct with a similar name: `std::num::NonZeroU16`
 
 error[E0412]: cannot find type `NonZerou32` in this scope
   --> $DIR/num.rs:18:19
    |
 LL | fn test_nzu32(_x: NonZerou32){}
-   |                   ^^^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::num::NonZeroU32`?
-   |
-LL | fn test_nzu32(_x: std::num::NonZeroU32){}
-   |                   ^^^^^^^^^^^^^^^^^^^^
+   |                   ^^^^^^^^^^
+   |                   |
+   |                   not found in this scope
+   |                   help: found a libstd struct with a similar name: `std::num::NonZeroU32`
 
 error[E0412]: cannot find type `NonZerou64` in this scope
   --> $DIR/num.rs:20:19
    |
 LL | fn test_nzu64(_x: NonZerou64){}
-   |                   ^^^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::num::NonZeroU64`?
-   |
-LL | fn test_nzu64(_x: std::num::NonZeroU64){}
-   |                   ^^^^^^^^^^^^^^^^^^^^
+   |                   ^^^^^^^^^^
+   |                   |
+   |                   not found in this scope
+   |                   help: found a libstd struct with a similar name: `std::num::NonZeroU64`
 
 error[E0412]: cannot find type `NonZerou128` in this scope
   --> $DIR/num.rs:22:20
    |
 LL | fn test_nzu128(_x: NonZerou128){}
-   |                    ^^^^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::num::NonZeroU128`?
-   |
-LL | fn test_nzu128(_x: std::num::NonZeroU128){}
-   |                    ^^^^^^^^^^^^^^^^^^^^^
+   |                    ^^^^^^^^^^^
+   |                    |
+   |                    not found in this scope
+   |                    help: found a libstd struct with a similar name: `std::num::NonZeroU128`
 
 error[E0412]: cannot find type `NonzeroUsize` in this scope
   --> $DIR/num.rs:24:18
    |
 LL | fn test_nzus(_x: NonzeroUsize){}
-   |                  ^^^^^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::num::NonZeroUsize`?
-   |
-LL | fn test_nzus(_x: std::num::NonZeroUsize){}
-   |                  ^^^^^^^^^^^^^^^^^^^^^^
+   |                  ^^^^^^^^^^^^
+   |                  |
+   |                  not found in this scope
+   |                  help: found a libstd struct with a similar name: `std::num::NonZeroUsize`
 
 error[E0412]: cannot find type `wrapping` in this scope
   --> $DIR/num.rs:26:18
    |
 LL | fn test_wrap(_x: wrapping){}
-   |                  ^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::num::Wrapping`?
-   |
-LL | fn test_wrap(_x: std::num::Wrapping){}
-   |                  ^^^^^^^^^^^^^^^^^^
+   |                  ^^^^^^^^
+   |                  |
+   |                  not found in this scope
+   |                  help: found a libstd struct with a similar name: `std::num::Wrapping`
 
 error: aborting due to 12 previous errors
 

--- a/src/test/ui/libstd-case-typo/ops.rs
+++ b/src/test/ui/libstd-case-typo/ops.rs
@@ -1,0 +1,15 @@
+// checks case typos with libstd::ops structs
+fn main(){}
+
+fn test_range(_x: range<()>){}
+//~^ ERROR: cannot find type `range` in this scope
+fn test_rangefr(_x: Rangefrom<()>){}
+//~^ ERROR: cannot find type `Rangefrom` in this scope
+fn test_rangefu(_x: Rangefull<()>){}
+//~^ ERROR: cannot find type `Rangefull` in this scope
+fn test_rangeinc(_x: Rangeinclusive<()>){}
+//~^ ERROR: cannot find type `Rangeinclusive` in this scope
+fn test_rangeto(_x: Rangeto<()>){}
+//~^ ERROR: cannot find type `Rangeto` in this scope
+fn test_rangetoi(_x: RangetoInclusive<()>){}
+//~^ ERROR: cannot find type `RangetoInclusive` in this scope

--- a/src/test/ui/libstd-case-typo/ops.stderr
+++ b/src/test/ui/libstd-case-typo/ops.stderr
@@ -1,0 +1,69 @@
+error[E0412]: cannot find type `range` in this scope
+  --> $DIR/ops.rs:4:19
+   |
+LL | fn test_range(_x: range<()>){}
+   |                   ^^^^^ not found in this scope
+   |
+help: did you mean `std::ops::Range`?
+   |
+LL | fn test_range(_x: std::ops::Range<()>){}
+   |                   ^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `Rangefrom` in this scope
+  --> $DIR/ops.rs:6:21
+   |
+LL | fn test_rangefr(_x: Rangefrom<()>){}
+   |                     ^^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::ops::RangeFrom`?
+   |
+LL | fn test_rangefr(_x: std::ops::RangeFrom<()>){}
+   |                     ^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `Rangefull` in this scope
+  --> $DIR/ops.rs:8:21
+   |
+LL | fn test_rangefu(_x: Rangefull<()>){}
+   |                     ^^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::ops::RangeFull`?
+   |
+LL | fn test_rangefu(_x: std::ops::RangeFull<()>){}
+   |                     ^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `Rangeinclusive` in this scope
+  --> $DIR/ops.rs:10:22
+   |
+LL | fn test_rangeinc(_x: Rangeinclusive<()>){}
+   |                      ^^^^^^^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::ops::RangeInclusive`?
+   |
+LL | fn test_rangeinc(_x: std::ops::RangeInclusive<()>){}
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `Rangeto` in this scope
+  --> $DIR/ops.rs:12:21
+   |
+LL | fn test_rangeto(_x: Rangeto<()>){}
+   |                     ^^^^^^^ not found in this scope
+   |
+help: did you mean `std::ops::RangeTo`?
+   |
+LL | fn test_rangeto(_x: std::ops::RangeTo<()>){}
+   |                     ^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `RangetoInclusive` in this scope
+  --> $DIR/ops.rs:14:22
+   |
+LL | fn test_rangetoi(_x: RangetoInclusive<()>){}
+   |                      ^^^^^^^^^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::ops::RangeToInclusive`?
+   |
+LL | fn test_rangetoi(_x: std::ops::RangeToInclusive<()>){}
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 6 previous errors
+
+For more information about this error, try `rustc --explain E0412`.

--- a/src/test/ui/libstd-case-typo/ops.stderr
+++ b/src/test/ui/libstd-case-typo/ops.stderr
@@ -2,67 +2,55 @@ error[E0412]: cannot find type `range` in this scope
   --> $DIR/ops.rs:4:19
    |
 LL | fn test_range(_x: range<()>){}
-   |                   ^^^^^ not found in this scope
-   |
-help: did you mean `std::ops::Range`?
-   |
-LL | fn test_range(_x: std::ops::Range<()>){}
-   |                   ^^^^^^^^^^^^^^^
+   |                   ^^^^^
+   |                   |
+   |                   not found in this scope
+   |                   help: found a libstd struct with a similar name: `std::ops::Range`
 
 error[E0412]: cannot find type `Rangefrom` in this scope
   --> $DIR/ops.rs:6:21
    |
 LL | fn test_rangefr(_x: Rangefrom<()>){}
-   |                     ^^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::ops::RangeFrom`?
-   |
-LL | fn test_rangefr(_x: std::ops::RangeFrom<()>){}
-   |                     ^^^^^^^^^^^^^^^^^^^
+   |                     ^^^^^^^^^
+   |                     |
+   |                     not found in this scope
+   |                     help: found a libstd struct with a similar name: `std::ops::RangeFrom`
 
 error[E0412]: cannot find type `Rangefull` in this scope
   --> $DIR/ops.rs:8:21
    |
 LL | fn test_rangefu(_x: Rangefull<()>){}
-   |                     ^^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::ops::RangeFull`?
-   |
-LL | fn test_rangefu(_x: std::ops::RangeFull<()>){}
-   |                     ^^^^^^^^^^^^^^^^^^^
+   |                     ^^^^^^^^^
+   |                     |
+   |                     not found in this scope
+   |                     help: found a libstd struct with a similar name: `std::ops::RangeFull`
 
 error[E0412]: cannot find type `Rangeinclusive` in this scope
   --> $DIR/ops.rs:10:22
    |
 LL | fn test_rangeinc(_x: Rangeinclusive<()>){}
-   |                      ^^^^^^^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::ops::RangeInclusive`?
-   |
-LL | fn test_rangeinc(_x: std::ops::RangeInclusive<()>){}
-   |                      ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                      ^^^^^^^^^^^^^^
+   |                      |
+   |                      not found in this scope
+   |                      help: found a libstd struct with a similar name: `std::ops::RangeInclusive`
 
 error[E0412]: cannot find type `Rangeto` in this scope
   --> $DIR/ops.rs:12:21
    |
 LL | fn test_rangeto(_x: Rangeto<()>){}
-   |                     ^^^^^^^ not found in this scope
-   |
-help: did you mean `std::ops::RangeTo`?
-   |
-LL | fn test_rangeto(_x: std::ops::RangeTo<()>){}
-   |                     ^^^^^^^^^^^^^^^^^
+   |                     ^^^^^^^
+   |                     |
+   |                     not found in this scope
+   |                     help: found a libstd struct with a similar name: `std::ops::RangeTo`
 
 error[E0412]: cannot find type `RangetoInclusive` in this scope
   --> $DIR/ops.rs:14:22
    |
 LL | fn test_rangetoi(_x: RangetoInclusive<()>){}
-   |                      ^^^^^^^^^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::ops::RangeToInclusive`?
-   |
-LL | fn test_rangetoi(_x: std::ops::RangeToInclusive<()>){}
-   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                      ^^^^^^^^^^^^^^^^
+   |                      |
+   |                      not found in this scope
+   |                      help: found a libstd struct with a similar name: `std::ops::RangeToInclusive`
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/libstd-case-typo/ops.stderr
+++ b/src/test/ui/libstd-case-typo/ops.stderr
@@ -5,7 +5,7 @@ LL | fn test_range(_x: range<()>){}
    |                   ^^^^^
    |                   |
    |                   not found in this scope
-   |                   help: found a libstd struct with a similar name: `std::ops::Range`
+   |                   help: found a std struct with a similar name: `std::ops::Range`
 
 error[E0412]: cannot find type `Rangefrom` in this scope
   --> $DIR/ops.rs:6:21
@@ -14,7 +14,7 @@ LL | fn test_rangefr(_x: Rangefrom<()>){}
    |                     ^^^^^^^^^
    |                     |
    |                     not found in this scope
-   |                     help: found a libstd struct with a similar name: `std::ops::RangeFrom`
+   |                     help: found a std struct with a similar name: `std::ops::RangeFrom`
 
 error[E0412]: cannot find type `Rangefull` in this scope
   --> $DIR/ops.rs:8:21
@@ -23,7 +23,7 @@ LL | fn test_rangefu(_x: Rangefull<()>){}
    |                     ^^^^^^^^^
    |                     |
    |                     not found in this scope
-   |                     help: found a libstd struct with a similar name: `std::ops::RangeFull`
+   |                     help: found a std struct with a similar name: `std::ops::RangeFull`
 
 error[E0412]: cannot find type `Rangeinclusive` in this scope
   --> $DIR/ops.rs:10:22
@@ -32,7 +32,7 @@ LL | fn test_rangeinc(_x: Rangeinclusive<()>){}
    |                      ^^^^^^^^^^^^^^
    |                      |
    |                      not found in this scope
-   |                      help: found a libstd struct with a similar name: `std::ops::RangeInclusive`
+   |                      help: found a std struct with a similar name: `std::ops::RangeInclusive`
 
 error[E0412]: cannot find type `Rangeto` in this scope
   --> $DIR/ops.rs:12:21
@@ -41,7 +41,7 @@ LL | fn test_rangeto(_x: Rangeto<()>){}
    |                     ^^^^^^^
    |                     |
    |                     not found in this scope
-   |                     help: found a libstd struct with a similar name: `std::ops::RangeTo`
+   |                     help: found a std struct with a similar name: `std::ops::RangeTo`
 
 error[E0412]: cannot find type `RangetoInclusive` in this scope
   --> $DIR/ops.rs:14:22
@@ -50,7 +50,7 @@ LL | fn test_rangetoi(_x: RangetoInclusive<()>){}
    |                      ^^^^^^^^^^^^^^^^
    |                      |
    |                      not found in this scope
-   |                      help: found a libstd struct with a similar name: `std::ops::RangeToInclusive`
+   |                      help: found a std struct with a similar name: `std::ops::RangeToInclusive`
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/libstd-case-typo/panic.rs
+++ b/src/test/ui/libstd-case-typo/panic.rs
@@ -1,0 +1,9 @@
+// checks case typos with libstd::panic structs
+fn main(){}
+
+fn test_assertus(_x: AssertUnwindsafe<()>){}
+//~^ ERROR: cannot find type `AssertUnwindsafe` in this scope
+fn test_loc(_x: location<()>){}
+//~^ ERROR: cannot find type `location` in this scope
+fn test_pinfo(_x: Panicinfo<()>){}
+//~^ ERROR: cannot find type `Panicinfo` in this scope

--- a/src/test/ui/libstd-case-typo/panic.stderr
+++ b/src/test/ui/libstd-case-typo/panic.stderr
@@ -2,34 +2,28 @@ error[E0412]: cannot find type `AssertUnwindsafe` in this scope
   --> $DIR/panic.rs:4:22
    |
 LL | fn test_assertus(_x: AssertUnwindsafe<()>){}
-   |                      ^^^^^^^^^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::panic::AssertUnwindSafe`?
-   |
-LL | fn test_assertus(_x: std::panic::AssertUnwindSafe<()>){}
-   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                      ^^^^^^^^^^^^^^^^
+   |                      |
+   |                      not found in this scope
+   |                      help: found a libstd struct with a similar name: `std::panic::AssertUnwindSafe`
 
 error[E0412]: cannot find type `location` in this scope
   --> $DIR/panic.rs:6:17
    |
 LL | fn test_loc(_x: location<()>){}
-   |                 ^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::panic::Location`?
-   |
-LL | fn test_loc(_x: std::panic::Location<()>){}
-   |                 ^^^^^^^^^^^^^^^^^^^^
+   |                 ^^^^^^^^
+   |                 |
+   |                 not found in this scope
+   |                 help: found a libstd struct with a similar name: `std::panic::Location`
 
 error[E0412]: cannot find type `Panicinfo` in this scope
   --> $DIR/panic.rs:8:19
    |
 LL | fn test_pinfo(_x: Panicinfo<()>){}
-   |                   ^^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::panic::PanicInfo`?
-   |
-LL | fn test_pinfo(_x: std::panic::PanicInfo<()>){}
-   |                   ^^^^^^^^^^^^^^^^^^^^^
+   |                   ^^^^^^^^^
+   |                   |
+   |                   not found in this scope
+   |                   help: found a libstd struct with a similar name: `std::panic::PanicInfo`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/libstd-case-typo/panic.stderr
+++ b/src/test/ui/libstd-case-typo/panic.stderr
@@ -5,7 +5,7 @@ LL | fn test_assertus(_x: AssertUnwindsafe<()>){}
    |                      ^^^^^^^^^^^^^^^^
    |                      |
    |                      not found in this scope
-   |                      help: found a libstd struct with a similar name: `std::panic::AssertUnwindSafe`
+   |                      help: found a std struct with a similar name: `std::panic::AssertUnwindSafe`
 
 error[E0412]: cannot find type `location` in this scope
   --> $DIR/panic.rs:6:17
@@ -14,7 +14,7 @@ LL | fn test_loc(_x: location<()>){}
    |                 ^^^^^^^^
    |                 |
    |                 not found in this scope
-   |                 help: found a libstd struct with a similar name: `std::panic::Location`
+   |                 help: found a std struct with a similar name: `std::panic::Location`
 
 error[E0412]: cannot find type `Panicinfo` in this scope
   --> $DIR/panic.rs:8:19
@@ -23,7 +23,7 @@ LL | fn test_pinfo(_x: Panicinfo<()>){}
    |                   ^^^^^^^^^
    |                   |
    |                   not found in this scope
-   |                   help: found a libstd struct with a similar name: `std::panic::PanicInfo`
+   |                   help: found a std struct with a similar name: `std::panic::PanicInfo`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/libstd-case-typo/panic.stderr
+++ b/src/test/ui/libstd-case-typo/panic.stderr
@@ -1,0 +1,36 @@
+error[E0412]: cannot find type `AssertUnwindsafe` in this scope
+  --> $DIR/panic.rs:4:22
+   |
+LL | fn test_assertus(_x: AssertUnwindsafe<()>){}
+   |                      ^^^^^^^^^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::panic::AssertUnwindSafe`?
+   |
+LL | fn test_assertus(_x: std::panic::AssertUnwindSafe<()>){}
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `location` in this scope
+  --> $DIR/panic.rs:6:17
+   |
+LL | fn test_loc(_x: location<()>){}
+   |                 ^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::panic::Location`?
+   |
+LL | fn test_loc(_x: std::panic::Location<()>){}
+   |                 ^^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `Panicinfo` in this scope
+  --> $DIR/panic.rs:8:19
+   |
+LL | fn test_pinfo(_x: Panicinfo<()>){}
+   |                   ^^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::panic::PanicInfo`?
+   |
+LL | fn test_pinfo(_x: std::panic::PanicInfo<()>){}
+   |                   ^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0412`.

--- a/src/test/ui/libstd-case-typo/path.rs
+++ b/src/test/ui/libstd-case-typo/path.rs
@@ -1,0 +1,11 @@
+// checks case typos with libstd::path structs
+fn main(){}
+
+fn test_ances(_x: ancestors){}
+//~^ ERROR: cannot find type `ancestors` in this scope
+fn test_comp(_x: components){}
+//~^ ERROR: cannot find type `components` in this scope
+fn test_pathbuf(_x: Pathbuf){}
+//~^ ERROR: cannot find type `Pathbuf` in this scope
+fn test_pcomp(_x: Prefixcomponent){}
+//~^ ERROR: cannot find type `Prefixcomponent` in this scope

--- a/src/test/ui/libstd-case-typo/path.stderr
+++ b/src/test/ui/libstd-case-typo/path.stderr
@@ -2,45 +2,37 @@ error[E0412]: cannot find type `ancestors` in this scope
   --> $DIR/path.rs:4:19
    |
 LL | fn test_ances(_x: ancestors){}
-   |                   ^^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::path::Ancestors`?
-   |
-LL | fn test_ances(_x: std::path::Ancestors){}
-   |                   ^^^^^^^^^^^^^^^^^^^^
+   |                   ^^^^^^^^^
+   |                   |
+   |                   not found in this scope
+   |                   help: found a libstd struct with a similar name: `std::path::Ancestors`
 
 error[E0412]: cannot find type `components` in this scope
   --> $DIR/path.rs:6:18
    |
 LL | fn test_comp(_x: components){}
-   |                  ^^^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::path::Components`?
-   |
-LL | fn test_comp(_x: std::path::Components){}
-   |                  ^^^^^^^^^^^^^^^^^^^^^
+   |                  ^^^^^^^^^^
+   |                  |
+   |                  not found in this scope
+   |                  help: found a libstd struct with a similar name: `std::path::Components`
 
 error[E0412]: cannot find type `Pathbuf` in this scope
   --> $DIR/path.rs:8:21
    |
 LL | fn test_pathbuf(_x: Pathbuf){}
-   |                     ^^^^^^^ not found in this scope
-   |
-help: did you mean `std::path::PathBuf`?
-   |
-LL | fn test_pathbuf(_x: std::path::PathBuf){}
-   |                     ^^^^^^^^^^^^^^^^^^
+   |                     ^^^^^^^
+   |                     |
+   |                     not found in this scope
+   |                     help: found a libstd struct with a similar name: `std::path::PathBuf`
 
 error[E0412]: cannot find type `Prefixcomponent` in this scope
   --> $DIR/path.rs:10:19
    |
 LL | fn test_pcomp(_x: Prefixcomponent){}
-   |                   ^^^^^^^^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::path::PrefixComponent`?
-   |
-LL | fn test_pcomp(_x: std::path::PrefixComponent){}
-   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                   ^^^^^^^^^^^^^^^
+   |                   |
+   |                   not found in this scope
+   |                   help: found a libstd struct with a similar name: `std::path::PrefixComponent`
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/libstd-case-typo/path.stderr
+++ b/src/test/ui/libstd-case-typo/path.stderr
@@ -1,0 +1,47 @@
+error[E0412]: cannot find type `ancestors` in this scope
+  --> $DIR/path.rs:4:19
+   |
+LL | fn test_ances(_x: ancestors){}
+   |                   ^^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::path::Ancestors`?
+   |
+LL | fn test_ances(_x: std::path::Ancestors){}
+   |                   ^^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `components` in this scope
+  --> $DIR/path.rs:6:18
+   |
+LL | fn test_comp(_x: components){}
+   |                  ^^^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::path::Components`?
+   |
+LL | fn test_comp(_x: std::path::Components){}
+   |                  ^^^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `Pathbuf` in this scope
+  --> $DIR/path.rs:8:21
+   |
+LL | fn test_pathbuf(_x: Pathbuf){}
+   |                     ^^^^^^^ not found in this scope
+   |
+help: did you mean `std::path::PathBuf`?
+   |
+LL | fn test_pathbuf(_x: std::path::PathBuf){}
+   |                     ^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `Prefixcomponent` in this scope
+  --> $DIR/path.rs:10:19
+   |
+LL | fn test_pcomp(_x: Prefixcomponent){}
+   |                   ^^^^^^^^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::path::PrefixComponent`?
+   |
+LL | fn test_pcomp(_x: std::path::PrefixComponent){}
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0412`.

--- a/src/test/ui/libstd-case-typo/path.stderr
+++ b/src/test/ui/libstd-case-typo/path.stderr
@@ -5,7 +5,7 @@ LL | fn test_ances(_x: ancestors){}
    |                   ^^^^^^^^^
    |                   |
    |                   not found in this scope
-   |                   help: found a libstd struct with a similar name: `std::path::Ancestors`
+   |                   help: found a std struct with a similar name: `std::path::Ancestors`
 
 error[E0412]: cannot find type `components` in this scope
   --> $DIR/path.rs:6:18
@@ -14,7 +14,7 @@ LL | fn test_comp(_x: components){}
    |                  ^^^^^^^^^^
    |                  |
    |                  not found in this scope
-   |                  help: found a libstd struct with a similar name: `std::path::Components`
+   |                  help: found a std struct with a similar name: `std::path::Components`
 
 error[E0412]: cannot find type `Pathbuf` in this scope
   --> $DIR/path.rs:8:21
@@ -23,7 +23,7 @@ LL | fn test_pathbuf(_x: Pathbuf){}
    |                     ^^^^^^^
    |                     |
    |                     not found in this scope
-   |                     help: found a libstd struct with a similar name: `std::path::PathBuf`
+   |                     help: found a std struct with a similar name: `std::path::PathBuf`
 
 error[E0412]: cannot find type `Prefixcomponent` in this scope
   --> $DIR/path.rs:10:19
@@ -32,7 +32,7 @@ LL | fn test_pcomp(_x: Prefixcomponent){}
    |                   ^^^^^^^^^^^^^^^
    |                   |
    |                   not found in this scope
-   |                   help: found a libstd struct with a similar name: `std::path::PrefixComponent`
+   |                   help: found a std struct with a similar name: `std::path::PrefixComponent`
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/libstd-case-typo/pin.rs
+++ b/src/test/ui/libstd-case-typo/pin.rs
@@ -1,0 +1,5 @@
+// checks case typos with libstd::pin structs
+fn main(){}
+
+fn test_pin(_x: pin<()>){}
+//~^ ERROR: cannot find type `pin` in this scope

--- a/src/test/ui/libstd-case-typo/pin.stderr
+++ b/src/test/ui/libstd-case-typo/pin.stderr
@@ -1,0 +1,14 @@
+error[E0412]: cannot find type `pin` in this scope
+  --> $DIR/pin.rs:4:17
+   |
+LL | fn test_pin(_x: pin<()>){}
+   |                 ^^^ not found in this scope
+   |
+help: did you mean `std::pin::Pin`?
+   |
+LL | fn test_pin(_x: std::pin::Pin<()>){}
+   |                 ^^^^^^^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0412`.

--- a/src/test/ui/libstd-case-typo/pin.stderr
+++ b/src/test/ui/libstd-case-typo/pin.stderr
@@ -5,7 +5,7 @@ LL | fn test_pin(_x: pin<()>){}
    |                 ^^^
    |                 |
    |                 not found in this scope
-   |                 help: found a libstd struct with a similar name: `std::pin::Pin`
+   |                 help: found a std struct with a similar name: `std::pin::Pin`
 
 error: aborting due to previous error
 

--- a/src/test/ui/libstd-case-typo/pin.stderr
+++ b/src/test/ui/libstd-case-typo/pin.stderr
@@ -2,12 +2,10 @@ error[E0412]: cannot find type `pin` in this scope
   --> $DIR/pin.rs:4:17
    |
 LL | fn test_pin(_x: pin<()>){}
-   |                 ^^^ not found in this scope
-   |
-help: did you mean `std::pin::Pin`?
-   |
-LL | fn test_pin(_x: std::pin::Pin<()>){}
-   |                 ^^^^^^^^^^^^^
+   |                 ^^^
+   |                 |
+   |                 not found in this scope
+   |                 help: found a libstd struct with a similar name: `std::pin::Pin`
 
 error: aborting due to previous error
 

--- a/src/test/ui/libstd-case-typo/process.rs
+++ b/src/test/ui/libstd-case-typo/process.rs
@@ -1,0 +1,19 @@
+// checks case typos with libstd::process structs
+fn main(){}
+
+fn test_child(_x: child){}
+//~^ ERROR: cannot find type `child` in this scope
+fn test_childse(_x: ChildStdErr){}
+//~^ ERROR: cannot find type `ChildStdErr` in this scope
+fn test_childsi(_x: ChildStdIn){}
+//~^ ERROR: cannot find type `ChildStdIn` in this scope
+fn test_childso(_x: ChildStdOut){}
+//~^ ERROR: cannot find type `ChildStdOut` in this scope
+fn test_command(_x: command){}
+//~^ ERROR: cannot find type `command` in this scope
+fn test_exits(_x: Exitstatus){}
+//~^ ERROR: cannot find type `Exitstatus` in this scope
+fn test_output(_x: output){}
+//~^ ERROR: cannot find type `output` in this scope
+fn test_stdio(_x: StdIo){}
+//~^ ERROR: cannot find type `StdIo` in this scope

--- a/src/test/ui/libstd-case-typo/process.stderr
+++ b/src/test/ui/libstd-case-typo/process.stderr
@@ -2,89 +2,73 @@ error[E0412]: cannot find type `child` in this scope
   --> $DIR/process.rs:4:19
    |
 LL | fn test_child(_x: child){}
-   |                   ^^^^^ not found in this scope
-   |
-help: did you mean `std::process::Child`?
-   |
-LL | fn test_child(_x: std::process::Child){}
-   |                   ^^^^^^^^^^^^^^^^^^^
+   |                   ^^^^^
+   |                   |
+   |                   not found in this scope
+   |                   help: found a libstd struct with a similar name: `std::process::Child`
 
 error[E0412]: cannot find type `ChildStdErr` in this scope
   --> $DIR/process.rs:6:21
    |
 LL | fn test_childse(_x: ChildStdErr){}
-   |                     ^^^^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::process::ChildStderr`?
-   |
-LL | fn test_childse(_x: std::process::ChildStderr){}
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                     ^^^^^^^^^^^
+   |                     |
+   |                     not found in this scope
+   |                     help: found a libstd struct with a similar name: `std::process::ChildStderr`
 
 error[E0412]: cannot find type `ChildStdIn` in this scope
   --> $DIR/process.rs:8:21
    |
 LL | fn test_childsi(_x: ChildStdIn){}
-   |                     ^^^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::process::ChildStdin`?
-   |
-LL | fn test_childsi(_x: std::process::ChildStdin){}
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                     ^^^^^^^^^^
+   |                     |
+   |                     not found in this scope
+   |                     help: found a libstd struct with a similar name: `std::process::ChildStdin`
 
 error[E0412]: cannot find type `ChildStdOut` in this scope
   --> $DIR/process.rs:10:21
    |
 LL | fn test_childso(_x: ChildStdOut){}
-   |                     ^^^^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::process::ChildStdout`?
-   |
-LL | fn test_childso(_x: std::process::ChildStdout){}
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                     ^^^^^^^^^^^
+   |                     |
+   |                     not found in this scope
+   |                     help: found a libstd struct with a similar name: `std::process::ChildStdout`
 
 error[E0412]: cannot find type `command` in this scope
   --> $DIR/process.rs:12:21
    |
 LL | fn test_command(_x: command){}
-   |                     ^^^^^^^ not found in this scope
-   |
-help: did you mean `std::process::Command`?
-   |
-LL | fn test_command(_x: std::process::Command){}
-   |                     ^^^^^^^^^^^^^^^^^^^^^
+   |                     ^^^^^^^
+   |                     |
+   |                     not found in this scope
+   |                     help: found a libstd struct with a similar name: `std::process::Command`
 
 error[E0412]: cannot find type `Exitstatus` in this scope
   --> $DIR/process.rs:14:19
    |
 LL | fn test_exits(_x: Exitstatus){}
-   |                   ^^^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::process::ExitStatus`?
-   |
-LL | fn test_exits(_x: std::process::ExitStatus){}
-   |                   ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                   ^^^^^^^^^^
+   |                   |
+   |                   not found in this scope
+   |                   help: found a libstd struct with a similar name: `std::process::ExitStatus`
 
 error[E0412]: cannot find type `output` in this scope
   --> $DIR/process.rs:16:20
    |
 LL | fn test_output(_x: output){}
-   |                    ^^^^^^ not found in this scope
-   |
-help: did you mean `std::process::Output`?
-   |
-LL | fn test_output(_x: std::process::Output){}
-   |                    ^^^^^^^^^^^^^^^^^^^^
+   |                    ^^^^^^
+   |                    |
+   |                    not found in this scope
+   |                    help: found a libstd struct with a similar name: `std::process::Output`
 
 error[E0412]: cannot find type `StdIo` in this scope
   --> $DIR/process.rs:18:19
    |
 LL | fn test_stdio(_x: StdIo){}
-   |                   ^^^^^ not found in this scope
-   |
-help: did you mean `std::process::Stdio`?
-   |
-LL | fn test_stdio(_x: std::process::Stdio){}
-   |                   ^^^^^^^^^^^^^^^^^^^
+   |                   ^^^^^
+   |                   |
+   |                   not found in this scope
+   |                   help: found a libstd struct with a similar name: `std::process::Stdio`
 
 error: aborting due to 8 previous errors
 

--- a/src/test/ui/libstd-case-typo/process.stderr
+++ b/src/test/ui/libstd-case-typo/process.stderr
@@ -1,0 +1,91 @@
+error[E0412]: cannot find type `child` in this scope
+  --> $DIR/process.rs:4:19
+   |
+LL | fn test_child(_x: child){}
+   |                   ^^^^^ not found in this scope
+   |
+help: did you mean `std::process::Child`?
+   |
+LL | fn test_child(_x: std::process::Child){}
+   |                   ^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `ChildStdErr` in this scope
+  --> $DIR/process.rs:6:21
+   |
+LL | fn test_childse(_x: ChildStdErr){}
+   |                     ^^^^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::process::ChildStderr`?
+   |
+LL | fn test_childse(_x: std::process::ChildStderr){}
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `ChildStdIn` in this scope
+  --> $DIR/process.rs:8:21
+   |
+LL | fn test_childsi(_x: ChildStdIn){}
+   |                     ^^^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::process::ChildStdin`?
+   |
+LL | fn test_childsi(_x: std::process::ChildStdin){}
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `ChildStdOut` in this scope
+  --> $DIR/process.rs:10:21
+   |
+LL | fn test_childso(_x: ChildStdOut){}
+   |                     ^^^^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::process::ChildStdout`?
+   |
+LL | fn test_childso(_x: std::process::ChildStdout){}
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `command` in this scope
+  --> $DIR/process.rs:12:21
+   |
+LL | fn test_command(_x: command){}
+   |                     ^^^^^^^ not found in this scope
+   |
+help: did you mean `std::process::Command`?
+   |
+LL | fn test_command(_x: std::process::Command){}
+   |                     ^^^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `Exitstatus` in this scope
+  --> $DIR/process.rs:14:19
+   |
+LL | fn test_exits(_x: Exitstatus){}
+   |                   ^^^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::process::ExitStatus`?
+   |
+LL | fn test_exits(_x: std::process::ExitStatus){}
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `output` in this scope
+  --> $DIR/process.rs:16:20
+   |
+LL | fn test_output(_x: output){}
+   |                    ^^^^^^ not found in this scope
+   |
+help: did you mean `std::process::Output`?
+   |
+LL | fn test_output(_x: std::process::Output){}
+   |                    ^^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `StdIo` in this scope
+  --> $DIR/process.rs:18:19
+   |
+LL | fn test_stdio(_x: StdIo){}
+   |                   ^^^^^ not found in this scope
+   |
+help: did you mean `std::process::Stdio`?
+   |
+LL | fn test_stdio(_x: std::process::Stdio){}
+   |                   ^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 8 previous errors
+
+For more information about this error, try `rustc --explain E0412`.

--- a/src/test/ui/libstd-case-typo/process.stderr
+++ b/src/test/ui/libstd-case-typo/process.stderr
@@ -5,7 +5,7 @@ LL | fn test_child(_x: child){}
    |                   ^^^^^
    |                   |
    |                   not found in this scope
-   |                   help: found a libstd struct with a similar name: `std::process::Child`
+   |                   help: found a std struct with a similar name: `std::process::Child`
 
 error[E0412]: cannot find type `ChildStdErr` in this scope
   --> $DIR/process.rs:6:21
@@ -14,7 +14,7 @@ LL | fn test_childse(_x: ChildStdErr){}
    |                     ^^^^^^^^^^^
    |                     |
    |                     not found in this scope
-   |                     help: found a libstd struct with a similar name: `std::process::ChildStderr`
+   |                     help: found a std struct with a similar name: `std::process::ChildStderr`
 
 error[E0412]: cannot find type `ChildStdIn` in this scope
   --> $DIR/process.rs:8:21
@@ -23,7 +23,7 @@ LL | fn test_childsi(_x: ChildStdIn){}
    |                     ^^^^^^^^^^
    |                     |
    |                     not found in this scope
-   |                     help: found a libstd struct with a similar name: `std::process::ChildStdin`
+   |                     help: found a std struct with a similar name: `std::process::ChildStdin`
 
 error[E0412]: cannot find type `ChildStdOut` in this scope
   --> $DIR/process.rs:10:21
@@ -32,7 +32,7 @@ LL | fn test_childso(_x: ChildStdOut){}
    |                     ^^^^^^^^^^^
    |                     |
    |                     not found in this scope
-   |                     help: found a libstd struct with a similar name: `std::process::ChildStdout`
+   |                     help: found a std struct with a similar name: `std::process::ChildStdout`
 
 error[E0412]: cannot find type `command` in this scope
   --> $DIR/process.rs:12:21
@@ -41,7 +41,7 @@ LL | fn test_command(_x: command){}
    |                     ^^^^^^^
    |                     |
    |                     not found in this scope
-   |                     help: found a libstd struct with a similar name: `std::process::Command`
+   |                     help: found a std struct with a similar name: `std::process::Command`
 
 error[E0412]: cannot find type `Exitstatus` in this scope
   --> $DIR/process.rs:14:19
@@ -50,7 +50,7 @@ LL | fn test_exits(_x: Exitstatus){}
    |                   ^^^^^^^^^^
    |                   |
    |                   not found in this scope
-   |                   help: found a libstd struct with a similar name: `std::process::ExitStatus`
+   |                   help: found a std struct with a similar name: `std::process::ExitStatus`
 
 error[E0412]: cannot find type `output` in this scope
   --> $DIR/process.rs:16:20
@@ -59,7 +59,7 @@ LL | fn test_output(_x: output){}
    |                    ^^^^^^
    |                    |
    |                    not found in this scope
-   |                    help: found a libstd struct with a similar name: `std::process::Output`
+   |                    help: found a std struct with a similar name: `std::process::Output`
 
 error[E0412]: cannot find type `StdIo` in this scope
   --> $DIR/process.rs:18:19
@@ -68,7 +68,7 @@ LL | fn test_stdio(_x: StdIo){}
    |                   ^^^^^
    |                   |
    |                   not found in this scope
-   |                   help: found a libstd struct with a similar name: `std::process::Stdio`
+   |                   help: found a std struct with a similar name: `std::process::Stdio`
 
 error: aborting due to 8 previous errors
 

--- a/src/test/ui/libstd-case-typo/ptr.rs
+++ b/src/test/ui/libstd-case-typo/ptr.rs
@@ -1,0 +1,5 @@
+// checks case typos with libstd::ptr structs
+fn main(){}
+
+fn test_nonnull(_x: Nonnull<()>){}
+//~^ ERROR: cannot find type `Nonnull` in this scope

--- a/src/test/ui/libstd-case-typo/ptr.stderr
+++ b/src/test/ui/libstd-case-typo/ptr.stderr
@@ -2,12 +2,10 @@ error[E0412]: cannot find type `Nonnull` in this scope
   --> $DIR/ptr.rs:4:21
    |
 LL | fn test_nonnull(_x: Nonnull<()>){}
-   |                     ^^^^^^^ not found in this scope
-   |
-help: did you mean `std::ptr::NonNull`?
-   |
-LL | fn test_nonnull(_x: std::ptr::NonNull<()>){}
-   |                     ^^^^^^^^^^^^^^^^^
+   |                     ^^^^^^^
+   |                     |
+   |                     not found in this scope
+   |                     help: found a libstd struct with a similar name: `std::ptr::NonNull`
 
 error: aborting due to previous error
 

--- a/src/test/ui/libstd-case-typo/ptr.stderr
+++ b/src/test/ui/libstd-case-typo/ptr.stderr
@@ -1,0 +1,14 @@
+error[E0412]: cannot find type `Nonnull` in this scope
+  --> $DIR/ptr.rs:4:21
+   |
+LL | fn test_nonnull(_x: Nonnull<()>){}
+   |                     ^^^^^^^ not found in this scope
+   |
+help: did you mean `std::ptr::NonNull`?
+   |
+LL | fn test_nonnull(_x: std::ptr::NonNull<()>){}
+   |                     ^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0412`.

--- a/src/test/ui/libstd-case-typo/ptr.stderr
+++ b/src/test/ui/libstd-case-typo/ptr.stderr
@@ -5,7 +5,7 @@ LL | fn test_nonnull(_x: Nonnull<()>){}
    |                     ^^^^^^^
    |                     |
    |                     not found in this scope
-   |                     help: found a libstd struct with a similar name: `std::ptr::NonNull`
+   |                     help: found a std struct with a similar name: `std::ptr::NonNull`
 
 error: aborting due to previous error
 

--- a/src/test/ui/libstd-case-typo/rc.rs
+++ b/src/test/ui/libstd-case-typo/rc.rs
@@ -1,0 +1,7 @@
+// checks case typos with libstd::rc structs
+fn main(){}
+
+fn test_rc(_x: rc<()>){}
+//~^ ERROR: cannot find type `rc` in this scope
+fn test_weak(_x: weak<()>){}
+//~^ ERROR: cannot find type `weak` in this scope

--- a/src/test/ui/libstd-case-typo/rc.stderr
+++ b/src/test/ui/libstd-case-typo/rc.stderr
@@ -1,0 +1,27 @@
+error[E0412]: cannot find type `rc` in this scope
+  --> $DIR/rc.rs:4:16
+   |
+LL | fn test_rc(_x: rc<()>){}
+   |                ^^ not found in this scope
+   |
+help: did you mean `std::rc::Rc`?
+   |
+LL | fn test_rc(_x: std::rc::Rc<()>){}
+   |                ^^^^^^^^^^^
+
+error[E0412]: cannot find type `weak` in this scope
+  --> $DIR/rc.rs:6:18
+   |
+LL | fn test_weak(_x: weak<()>){}
+   |                  ^^^^ not found in this scope
+   |
+help: did you mean one of these?:
+   |
+LL | fn test_weak(_x: std::rc::Weak<()>){}
+   |                  ^^^^^^^^^^^^^
+LL | fn test_weak(_x: std::sync::Weak<()>){}
+   |                  ^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0412`.

--- a/src/test/ui/libstd-case-typo/rc.stderr
+++ b/src/test/ui/libstd-case-typo/rc.stderr
@@ -5,7 +5,7 @@ LL | fn test_rc(_x: rc<()>){}
    |                ^^
    |                |
    |                not found in this scope
-   |                help: found a libstd struct with a similar name: `std::rc::Rc`
+   |                help: found a std struct with a similar name: `std::rc::Rc`
 
 error[E0412]: cannot find type `weak` in this scope
   --> $DIR/rc.rs:6:18
@@ -13,7 +13,7 @@ error[E0412]: cannot find type `weak` in this scope
 LL | fn test_weak(_x: weak<()>){}
    |                  ^^^^ not found in this scope
    |
-help: found libstd structs with a similar name:
+help: found std structs with similar names:
    |
 LL | fn test_weak(_x: std::rc::Weak<()>){}
    |                  ^^^^^^^^^^^^^

--- a/src/test/ui/libstd-case-typo/rc.stderr
+++ b/src/test/ui/libstd-case-typo/rc.stderr
@@ -2,12 +2,10 @@ error[E0412]: cannot find type `rc` in this scope
   --> $DIR/rc.rs:4:16
    |
 LL | fn test_rc(_x: rc<()>){}
-   |                ^^ not found in this scope
-   |
-help: did you mean `std::rc::Rc`?
-   |
-LL | fn test_rc(_x: std::rc::Rc<()>){}
-   |                ^^^^^^^^^^^
+   |                ^^
+   |                |
+   |                not found in this scope
+   |                help: found a libstd struct with a similar name: `std::rc::Rc`
 
 error[E0412]: cannot find type `weak` in this scope
   --> $DIR/rc.rs:6:18
@@ -15,7 +13,7 @@ error[E0412]: cannot find type `weak` in this scope
 LL | fn test_weak(_x: weak<()>){}
    |                  ^^^^ not found in this scope
    |
-help: did you mean one of these?:
+help: found libstd structs with a similar name:
    |
 LL | fn test_weak(_x: std::rc::Weak<()>){}
    |                  ^^^^^^^^^^^^^

--- a/src/test/ui/libstd-case-typo/str.rs
+++ b/src/test/ui/libstd-case-typo/str.rs
@@ -1,0 +1,39 @@
+// checks case typos with libstd::str structs
+fn main(){}
+
+fn test_bytes(_x: bytes){}
+//~^ ERROR: cannot find type `bytes` in this scope
+fn test_charind(_x: Charindices){}
+//~^ ERROR: cannot find type `Charindices` in this scope
+fn test_chars(_x: chars){}
+//~^ ERROR: cannot find type `chars` in this scope
+fn test_encutf16(_x: EncodeUTF16){}
+//~^ ERROR: cannot find type `EncodeUTF16` in this scope
+fn test_escdflt(_x: Escapedefault){}
+//~^ ERROR: cannot find type `Escapedefault` in this scope
+fn test_escuni(_x: Escapeunicode){}
+//~^ ERROR: cannot find type `Escapeunicode` in this scope
+fn test_lines(_x: lines){}
+//~^ ERROR: cannot find type `lines` in this scope
+fn test_matchind(_x: Matchindices){}
+//~^ ERROR: cannot find type `Matchindices` in this scope
+fn test_rmatchind(_x: RmatchIndices){}
+//~^ ERROR: cannot find type `RmatchIndices` in this scope
+fn test_rmatch(_x: Rmatches){}
+//~^ ERROR: cannot find type `Rmatches` in this scope
+fn test_rsplit(_x: Rsplit){}
+//~^ ERROR: cannot find type `Rsplit` in this scope
+fn test_rsplitn(_x: RSplitn){}
+//~^ ERROR: cannot find type `RSplitn` in this scope
+fn test_rsplitterm(_x: RsplitTerminator){}
+//~^ ERROR: cannot find type `RsplitTerminator` in this scope
+fn test_split(_x: split){}
+//~^ ERROR: cannot find type `split` in this scope
+fn test_splitasciiws(_x: SplitASCIIWhitespace){}
+//~^ ERROR: cannot find type `SplitASCIIWhitespace` in this scope
+fn test_splitn(_x: Splitn){}
+//~^ ERROR: cannot find type `Splitn` in this scope
+fn test_splitterm(_x: Splitterminator){}
+//~^ ERROR: cannot find type `Splitterminator` in this scope
+fn test_splitws(_x: Splitwhitespace){}
+//~^ ERROR: cannot find type `Splitwhitespace` in this scope

--- a/src/test/ui/libstd-case-typo/str.stderr
+++ b/src/test/ui/libstd-case-typo/str.stderr
@@ -4,7 +4,7 @@ error[E0412]: cannot find type `bytes` in this scope
 LL | fn test_bytes(_x: bytes){}
    |                   ^^^^^ not found in this scope
    |
-help: found libstd structs with a similar name:
+help: found std structs with similar names:
    |
 LL | fn test_bytes(_x: std::io::Bytes){}
    |                   ^^^^^^^^^^^^^^
@@ -18,7 +18,7 @@ LL | fn test_charind(_x: Charindices){}
    |                     ^^^^^^^^^^^
    |                     |
    |                     not found in this scope
-   |                     help: found a libstd struct with a similar name: `std::str::CharIndices`
+   |                     help: found a std struct with a similar name: `std::str::CharIndices`
 
 error[E0412]: cannot find type `chars` in this scope
   --> $DIR/str.rs:8:19
@@ -33,7 +33,7 @@ LL | fn test_encutf16(_x: EncodeUTF16){}
    |                      ^^^^^^^^^^^
    |                      |
    |                      not found in this scope
-   |                      help: found a libstd struct with a similar name: `std::str::EncodeUtf16`
+   |                      help: found a std struct with a similar name: `std::str::EncodeUtf16`
 
 error[E0412]: cannot find type `Escapedefault` in this scope
   --> $DIR/str.rs:12:21
@@ -41,7 +41,7 @@ error[E0412]: cannot find type `Escapedefault` in this scope
 LL | fn test_escdflt(_x: Escapedefault){}
    |                     ^^^^^^^^^^^^^ not found in this scope
    |
-help: found libstd structs with a similar name:
+help: found std structs with similar names:
    |
 LL | fn test_escdflt(_x: std::ascii::EscapeDefault){}
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -56,7 +56,7 @@ error[E0412]: cannot find type `Escapeunicode` in this scope
 LL | fn test_escuni(_x: Escapeunicode){}
    |                    ^^^^^^^^^^^^^ not found in this scope
    |
-help: found libstd structs with a similar name:
+help: found std structs with similar names:
    |
 LL | fn test_escuni(_x: std::char::EscapeUnicode){}
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -69,7 +69,7 @@ error[E0412]: cannot find type `lines` in this scope
 LL | fn test_lines(_x: lines){}
    |                   ^^^^^ not found in this scope
    |
-help: found libstd structs with a similar name:
+help: found std structs with similar names:
    |
 LL | fn test_lines(_x: std::io::Lines){}
    |                   ^^^^^^^^^^^^^^
@@ -83,7 +83,7 @@ LL | fn test_matchind(_x: Matchindices){}
    |                      ^^^^^^^^^^^^
    |                      |
    |                      not found in this scope
-   |                      help: found a libstd struct with a similar name: `std::str::MatchIndices`
+   |                      help: found a std struct with a similar name: `std::str::MatchIndices`
 
 error[E0412]: cannot find type `RmatchIndices` in this scope
   --> $DIR/str.rs:20:23
@@ -92,7 +92,7 @@ LL | fn test_rmatchind(_x: RmatchIndices){}
    |                       ^^^^^^^^^^^^^
    |                       |
    |                       not found in this scope
-   |                       help: found a libstd struct with a similar name: `std::str::RMatchIndices`
+   |                       help: found a std struct with a similar name: `std::str::RMatchIndices`
 
 error[E0412]: cannot find type `Rmatches` in this scope
   --> $DIR/str.rs:22:20
@@ -101,7 +101,7 @@ LL | fn test_rmatch(_x: Rmatches){}
    |                    ^^^^^^^^
    |                    |
    |                    not found in this scope
-   |                    help: found a libstd struct with a similar name: `std::str::RMatches`
+   |                    help: found a std struct with a similar name: `std::str::RMatches`
 
 error[E0412]: cannot find type `Rsplit` in this scope
   --> $DIR/str.rs:24:20
@@ -110,7 +110,7 @@ LL | fn test_rsplit(_x: Rsplit){}
    |                    ^^^^^^
    |                    |
    |                    not found in this scope
-   |                    help: found a libstd struct with a similar name: `std::str::RSplit`
+   |                    help: found a std struct with a similar name: `std::str::RSplit`
 
 error[E0412]: cannot find type `RSplitn` in this scope
   --> $DIR/str.rs:26:21
@@ -119,7 +119,7 @@ LL | fn test_rsplitn(_x: RSplitn){}
    |                     ^^^^^^^
    |                     |
    |                     not found in this scope
-   |                     help: found a libstd struct with a similar name: `std::str::RSplitN`
+   |                     help: found a std struct with a similar name: `std::str::RSplitN`
 
 error[E0412]: cannot find type `RsplitTerminator` in this scope
   --> $DIR/str.rs:28:24
@@ -128,7 +128,7 @@ LL | fn test_rsplitterm(_x: RsplitTerminator){}
    |                        ^^^^^^^^^^^^^^^^
    |                        |
    |                        not found in this scope
-   |                        help: found a libstd struct with a similar name: `std::str::RSplitTerminator`
+   |                        help: found a std struct with a similar name: `std::str::RSplitTerminator`
 
 error[E0412]: cannot find type `split` in this scope
   --> $DIR/str.rs:30:19
@@ -136,7 +136,7 @@ error[E0412]: cannot find type `split` in this scope
 LL | fn test_split(_x: split){}
    |                   ^^^^^ not found in this scope
    |
-help: found libstd structs with a similar name:
+help: found std structs with similar names:
    |
 LL | fn test_split(_x: std::io::Split){}
    |                   ^^^^^^^^^^^^^^
@@ -150,7 +150,7 @@ LL | fn test_splitasciiws(_x: SplitASCIIWhitespace){}
    |                          ^^^^^^^^^^^^^^^^^^^^
    |                          |
    |                          not found in this scope
-   |                          help: found a libstd struct with a similar name: `std::str::SplitAsciiWhitespace`
+   |                          help: found a std struct with a similar name: `std::str::SplitAsciiWhitespace`
 
 error[E0412]: cannot find type `Splitn` in this scope
   --> $DIR/str.rs:34:20
@@ -159,7 +159,7 @@ LL | fn test_splitn(_x: Splitn){}
    |                    ^^^^^^
    |                    |
    |                    not found in this scope
-   |                    help: found a libstd struct with a similar name: `std::str::SplitN`
+   |                    help: found a std struct with a similar name: `std::str::SplitN`
 
 error[E0412]: cannot find type `Splitterminator` in this scope
   --> $DIR/str.rs:36:23
@@ -168,7 +168,7 @@ LL | fn test_splitterm(_x: Splitterminator){}
    |                       ^^^^^^^^^^^^^^^
    |                       |
    |                       not found in this scope
-   |                       help: found a libstd struct with a similar name: `std::str::SplitTerminator`
+   |                       help: found a std struct with a similar name: `std::str::SplitTerminator`
 
 error[E0412]: cannot find type `Splitwhitespace` in this scope
   --> $DIR/str.rs:38:21
@@ -177,7 +177,7 @@ LL | fn test_splitws(_x: Splitwhitespace){}
    |                     ^^^^^^^^^^^^^^^
    |                     |
    |                     not found in this scope
-   |                     help: found a libstd struct with a similar name: `std::str::SplitWhitespace`
+   |                     help: found a std struct with a similar name: `std::str::SplitWhitespace`
 
 error: aborting due to 18 previous errors
 

--- a/src/test/ui/libstd-case-typo/str.stderr
+++ b/src/test/ui/libstd-case-typo/str.stderr
@@ -1,0 +1,208 @@
+error[E0412]: cannot find type `bytes` in this scope
+  --> $DIR/str.rs:4:19
+   |
+LL | fn test_bytes(_x: bytes){}
+   |                   ^^^^^ not found in this scope
+   |
+help: did you mean one of these?:
+   |
+LL | fn test_bytes(_x: std::io::Bytes){}
+   |                   ^^^^^^^^^^^^^^
+LL | fn test_bytes(_x: std::str::Bytes){}
+   |                   ^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `Charindices` in this scope
+  --> $DIR/str.rs:6:21
+   |
+LL | fn test_charind(_x: Charindices){}
+   |                     ^^^^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::str::CharIndices`?
+   |
+LL | fn test_charind(_x: std::str::CharIndices){}
+   |                     ^^^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `chars` in this scope
+  --> $DIR/str.rs:8:19
+   |
+LL | fn test_chars(_x: chars){}
+   |                   ^^^^^ help: a builtin type with a similar name exists: `char`
+
+error[E0412]: cannot find type `EncodeUTF16` in this scope
+  --> $DIR/str.rs:10:22
+   |
+LL | fn test_encutf16(_x: EncodeUTF16){}
+   |                      ^^^^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::str::EncodeUtf16`?
+   |
+LL | fn test_encutf16(_x: std::str::EncodeUtf16){}
+   |                      ^^^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `Escapedefault` in this scope
+  --> $DIR/str.rs:12:21
+   |
+LL | fn test_escdflt(_x: Escapedefault){}
+   |                     ^^^^^^^^^^^^^ not found in this scope
+   |
+help: did you mean one of these?:
+   |
+LL | fn test_escdflt(_x: std::ascii::EscapeDefault){}
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | fn test_escdflt(_x: std::char::EscapeDefault){}
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^
+LL | fn test_escdflt(_x: std::str::EscapeDefault){}
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `Escapeunicode` in this scope
+  --> $DIR/str.rs:14:20
+   |
+LL | fn test_escuni(_x: Escapeunicode){}
+   |                    ^^^^^^^^^^^^^ not found in this scope
+   |
+help: did you mean one of these?:
+   |
+LL | fn test_escuni(_x: std::char::EscapeUnicode){}
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^^
+LL | fn test_escuni(_x: std::str::EscapeUnicode){}
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `lines` in this scope
+  --> $DIR/str.rs:16:19
+   |
+LL | fn test_lines(_x: lines){}
+   |                   ^^^^^ not found in this scope
+   |
+help: did you mean one of these?:
+   |
+LL | fn test_lines(_x: std::io::Lines){}
+   |                   ^^^^^^^^^^^^^^
+LL | fn test_lines(_x: std::str::Lines){}
+   |                   ^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `Matchindices` in this scope
+  --> $DIR/str.rs:18:22
+   |
+LL | fn test_matchind(_x: Matchindices){}
+   |                      ^^^^^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::str::MatchIndices`?
+   |
+LL | fn test_matchind(_x: std::str::MatchIndices){}
+   |                      ^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `RmatchIndices` in this scope
+  --> $DIR/str.rs:20:23
+   |
+LL | fn test_rmatchind(_x: RmatchIndices){}
+   |                       ^^^^^^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::str::RMatchIndices`?
+   |
+LL | fn test_rmatchind(_x: std::str::RMatchIndices){}
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `Rmatches` in this scope
+  --> $DIR/str.rs:22:20
+   |
+LL | fn test_rmatch(_x: Rmatches){}
+   |                    ^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::str::RMatches`?
+   |
+LL | fn test_rmatch(_x: std::str::RMatches){}
+   |                    ^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `Rsplit` in this scope
+  --> $DIR/str.rs:24:20
+   |
+LL | fn test_rsplit(_x: Rsplit){}
+   |                    ^^^^^^ not found in this scope
+   |
+help: did you mean `std::str::RSplit`?
+   |
+LL | fn test_rsplit(_x: std::str::RSplit){}
+   |                    ^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `RSplitn` in this scope
+  --> $DIR/str.rs:26:21
+   |
+LL | fn test_rsplitn(_x: RSplitn){}
+   |                     ^^^^^^^ not found in this scope
+   |
+help: did you mean `std::str::RSplitN`?
+   |
+LL | fn test_rsplitn(_x: std::str::RSplitN){}
+   |                     ^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `RsplitTerminator` in this scope
+  --> $DIR/str.rs:28:24
+   |
+LL | fn test_rsplitterm(_x: RsplitTerminator){}
+   |                        ^^^^^^^^^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::str::RSplitTerminator`?
+   |
+LL | fn test_rsplitterm(_x: std::str::RSplitTerminator){}
+   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `split` in this scope
+  --> $DIR/str.rs:30:19
+   |
+LL | fn test_split(_x: split){}
+   |                   ^^^^^ not found in this scope
+   |
+help: did you mean one of these?:
+   |
+LL | fn test_split(_x: std::io::Split){}
+   |                   ^^^^^^^^^^^^^^
+LL | fn test_split(_x: std::str::Split){}
+   |                   ^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `SplitASCIIWhitespace` in this scope
+  --> $DIR/str.rs:32:26
+   |
+LL | fn test_splitasciiws(_x: SplitASCIIWhitespace){}
+   |                          ^^^^^^^^^^^^^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::str::SplitAsciiWhitespace`?
+   |
+LL | fn test_splitasciiws(_x: std::str::SplitAsciiWhitespace){}
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `Splitn` in this scope
+  --> $DIR/str.rs:34:20
+   |
+LL | fn test_splitn(_x: Splitn){}
+   |                    ^^^^^^ not found in this scope
+   |
+help: did you mean `std::str::SplitN`?
+   |
+LL | fn test_splitn(_x: std::str::SplitN){}
+   |                    ^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `Splitterminator` in this scope
+  --> $DIR/str.rs:36:23
+   |
+LL | fn test_splitterm(_x: Splitterminator){}
+   |                       ^^^^^^^^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::str::SplitTerminator`?
+   |
+LL | fn test_splitterm(_x: std::str::SplitTerminator){}
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `Splitwhitespace` in this scope
+  --> $DIR/str.rs:38:21
+   |
+LL | fn test_splitws(_x: Splitwhitespace){}
+   |                     ^^^^^^^^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::str::SplitWhitespace`?
+   |
+LL | fn test_splitws(_x: std::str::SplitWhitespace){}
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 18 previous errors
+
+For more information about this error, try `rustc --explain E0412`.

--- a/src/test/ui/libstd-case-typo/str.stderr
+++ b/src/test/ui/libstd-case-typo/str.stderr
@@ -4,7 +4,7 @@ error[E0412]: cannot find type `bytes` in this scope
 LL | fn test_bytes(_x: bytes){}
    |                   ^^^^^ not found in this scope
    |
-help: did you mean one of these?:
+help: found libstd structs with a similar name:
    |
 LL | fn test_bytes(_x: std::io::Bytes){}
    |                   ^^^^^^^^^^^^^^
@@ -15,12 +15,10 @@ error[E0412]: cannot find type `Charindices` in this scope
   --> $DIR/str.rs:6:21
    |
 LL | fn test_charind(_x: Charindices){}
-   |                     ^^^^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::str::CharIndices`?
-   |
-LL | fn test_charind(_x: std::str::CharIndices){}
-   |                     ^^^^^^^^^^^^^^^^^^^^^
+   |                     ^^^^^^^^^^^
+   |                     |
+   |                     not found in this scope
+   |                     help: found a libstd struct with a similar name: `std::str::CharIndices`
 
 error[E0412]: cannot find type `chars` in this scope
   --> $DIR/str.rs:8:19
@@ -32,12 +30,10 @@ error[E0412]: cannot find type `EncodeUTF16` in this scope
   --> $DIR/str.rs:10:22
    |
 LL | fn test_encutf16(_x: EncodeUTF16){}
-   |                      ^^^^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::str::EncodeUtf16`?
-   |
-LL | fn test_encutf16(_x: std::str::EncodeUtf16){}
-   |                      ^^^^^^^^^^^^^^^^^^^^^
+   |                      ^^^^^^^^^^^
+   |                      |
+   |                      not found in this scope
+   |                      help: found a libstd struct with a similar name: `std::str::EncodeUtf16`
 
 error[E0412]: cannot find type `Escapedefault` in this scope
   --> $DIR/str.rs:12:21
@@ -45,7 +41,7 @@ error[E0412]: cannot find type `Escapedefault` in this scope
 LL | fn test_escdflt(_x: Escapedefault){}
    |                     ^^^^^^^^^^^^^ not found in this scope
    |
-help: did you mean one of these?:
+help: found libstd structs with a similar name:
    |
 LL | fn test_escdflt(_x: std::ascii::EscapeDefault){}
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -60,7 +56,7 @@ error[E0412]: cannot find type `Escapeunicode` in this scope
 LL | fn test_escuni(_x: Escapeunicode){}
    |                    ^^^^^^^^^^^^^ not found in this scope
    |
-help: did you mean one of these?:
+help: found libstd structs with a similar name:
    |
 LL | fn test_escuni(_x: std::char::EscapeUnicode){}
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -73,7 +69,7 @@ error[E0412]: cannot find type `lines` in this scope
 LL | fn test_lines(_x: lines){}
    |                   ^^^^^ not found in this scope
    |
-help: did you mean one of these?:
+help: found libstd structs with a similar name:
    |
 LL | fn test_lines(_x: std::io::Lines){}
    |                   ^^^^^^^^^^^^^^
@@ -84,67 +80,55 @@ error[E0412]: cannot find type `Matchindices` in this scope
   --> $DIR/str.rs:18:22
    |
 LL | fn test_matchind(_x: Matchindices){}
-   |                      ^^^^^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::str::MatchIndices`?
-   |
-LL | fn test_matchind(_x: std::str::MatchIndices){}
-   |                      ^^^^^^^^^^^^^^^^^^^^^^
+   |                      ^^^^^^^^^^^^
+   |                      |
+   |                      not found in this scope
+   |                      help: found a libstd struct with a similar name: `std::str::MatchIndices`
 
 error[E0412]: cannot find type `RmatchIndices` in this scope
   --> $DIR/str.rs:20:23
    |
 LL | fn test_rmatchind(_x: RmatchIndices){}
-   |                       ^^^^^^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::str::RMatchIndices`?
-   |
-LL | fn test_rmatchind(_x: std::str::RMatchIndices){}
-   |                       ^^^^^^^^^^^^^^^^^^^^^^^
+   |                       ^^^^^^^^^^^^^
+   |                       |
+   |                       not found in this scope
+   |                       help: found a libstd struct with a similar name: `std::str::RMatchIndices`
 
 error[E0412]: cannot find type `Rmatches` in this scope
   --> $DIR/str.rs:22:20
    |
 LL | fn test_rmatch(_x: Rmatches){}
-   |                    ^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::str::RMatches`?
-   |
-LL | fn test_rmatch(_x: std::str::RMatches){}
-   |                    ^^^^^^^^^^^^^^^^^^
+   |                    ^^^^^^^^
+   |                    |
+   |                    not found in this scope
+   |                    help: found a libstd struct with a similar name: `std::str::RMatches`
 
 error[E0412]: cannot find type `Rsplit` in this scope
   --> $DIR/str.rs:24:20
    |
 LL | fn test_rsplit(_x: Rsplit){}
-   |                    ^^^^^^ not found in this scope
-   |
-help: did you mean `std::str::RSplit`?
-   |
-LL | fn test_rsplit(_x: std::str::RSplit){}
-   |                    ^^^^^^^^^^^^^^^^
+   |                    ^^^^^^
+   |                    |
+   |                    not found in this scope
+   |                    help: found a libstd struct with a similar name: `std::str::RSplit`
 
 error[E0412]: cannot find type `RSplitn` in this scope
   --> $DIR/str.rs:26:21
    |
 LL | fn test_rsplitn(_x: RSplitn){}
-   |                     ^^^^^^^ not found in this scope
-   |
-help: did you mean `std::str::RSplitN`?
-   |
-LL | fn test_rsplitn(_x: std::str::RSplitN){}
-   |                     ^^^^^^^^^^^^^^^^^
+   |                     ^^^^^^^
+   |                     |
+   |                     not found in this scope
+   |                     help: found a libstd struct with a similar name: `std::str::RSplitN`
 
 error[E0412]: cannot find type `RsplitTerminator` in this scope
   --> $DIR/str.rs:28:24
    |
 LL | fn test_rsplitterm(_x: RsplitTerminator){}
-   |                        ^^^^^^^^^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::str::RSplitTerminator`?
-   |
-LL | fn test_rsplitterm(_x: std::str::RSplitTerminator){}
-   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                        ^^^^^^^^^^^^^^^^
+   |                        |
+   |                        not found in this scope
+   |                        help: found a libstd struct with a similar name: `std::str::RSplitTerminator`
 
 error[E0412]: cannot find type `split` in this scope
   --> $DIR/str.rs:30:19
@@ -152,7 +136,7 @@ error[E0412]: cannot find type `split` in this scope
 LL | fn test_split(_x: split){}
    |                   ^^^^^ not found in this scope
    |
-help: did you mean one of these?:
+help: found libstd structs with a similar name:
    |
 LL | fn test_split(_x: std::io::Split){}
    |                   ^^^^^^^^^^^^^^
@@ -163,45 +147,37 @@ error[E0412]: cannot find type `SplitASCIIWhitespace` in this scope
   --> $DIR/str.rs:32:26
    |
 LL | fn test_splitasciiws(_x: SplitASCIIWhitespace){}
-   |                          ^^^^^^^^^^^^^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::str::SplitAsciiWhitespace`?
-   |
-LL | fn test_splitasciiws(_x: std::str::SplitAsciiWhitespace){}
-   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                          ^^^^^^^^^^^^^^^^^^^^
+   |                          |
+   |                          not found in this scope
+   |                          help: found a libstd struct with a similar name: `std::str::SplitAsciiWhitespace`
 
 error[E0412]: cannot find type `Splitn` in this scope
   --> $DIR/str.rs:34:20
    |
 LL | fn test_splitn(_x: Splitn){}
-   |                    ^^^^^^ not found in this scope
-   |
-help: did you mean `std::str::SplitN`?
-   |
-LL | fn test_splitn(_x: std::str::SplitN){}
-   |                    ^^^^^^^^^^^^^^^^
+   |                    ^^^^^^
+   |                    |
+   |                    not found in this scope
+   |                    help: found a libstd struct with a similar name: `std::str::SplitN`
 
 error[E0412]: cannot find type `Splitterminator` in this scope
   --> $DIR/str.rs:36:23
    |
 LL | fn test_splitterm(_x: Splitterminator){}
-   |                       ^^^^^^^^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::str::SplitTerminator`?
-   |
-LL | fn test_splitterm(_x: std::str::SplitTerminator){}
-   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                       ^^^^^^^^^^^^^^^
+   |                       |
+   |                       not found in this scope
+   |                       help: found a libstd struct with a similar name: `std::str::SplitTerminator`
 
 error[E0412]: cannot find type `Splitwhitespace` in this scope
   --> $DIR/str.rs:38:21
    |
 LL | fn test_splitws(_x: Splitwhitespace){}
-   |                     ^^^^^^^^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::str::SplitWhitespace`?
-   |
-LL | fn test_splitws(_x: std::str::SplitWhitespace){}
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                     ^^^^^^^^^^^^^^^
+   |                     |
+   |                     not found in this scope
+   |                     help: found a libstd struct with a similar name: `std::str::SplitWhitespace`
 
 error: aborting due to 18 previous errors
 

--- a/src/test/ui/libstd-case-typo/string.rs
+++ b/src/test/ui/libstd-case-typo/string.rs
@@ -1,0 +1,5 @@
+// checks case typos with libstd::string structs
+fn main(){}
+
+fn test_drain(_x: drain){}
+//~^ ERROR: cannot find type `drain` in this scope

--- a/src/test/ui/libstd-case-typo/string.stderr
+++ b/src/test/ui/libstd-case-typo/string.stderr
@@ -5,7 +5,7 @@ LL | fn test_drain(_x: drain){}
    |                   ^^^^^
    |                   |
    |                   not found in this scope
-   |                   help: found a libstd struct with a similar name: `std::string::Drain`
+   |                   help: found a std struct with a similar name: `std::string::Drain`
 
 error: aborting due to previous error
 

--- a/src/test/ui/libstd-case-typo/string.stderr
+++ b/src/test/ui/libstd-case-typo/string.stderr
@@ -1,0 +1,14 @@
+error[E0412]: cannot find type `drain` in this scope
+  --> $DIR/string.rs:4:19
+   |
+LL | fn test_drain(_x: drain){}
+   |                   ^^^^^ not found in this scope
+   |
+help: did you mean `std::string::Drain`?
+   |
+LL | fn test_drain(_x: std::string::Drain){}
+   |                   ^^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0412`.

--- a/src/test/ui/libstd-case-typo/string.stderr
+++ b/src/test/ui/libstd-case-typo/string.stderr
@@ -2,12 +2,10 @@ error[E0412]: cannot find type `drain` in this scope
   --> $DIR/string.rs:4:19
    |
 LL | fn test_drain(_x: drain){}
-   |                   ^^^^^ not found in this scope
-   |
-help: did you mean `std::string::Drain`?
-   |
-LL | fn test_drain(_x: std::string::Drain){}
-   |                   ^^^^^^^^^^^^^^^^^^
+   |                   ^^^^^
+   |                   |
+   |                   not found in this scope
+   |                   help: found a libstd struct with a similar name: `std::string::Drain`
 
 error: aborting due to previous error
 

--- a/src/test/ui/libstd-case-typo/sync.rs
+++ b/src/test/ui/libstd-case-typo/sync.rs
@@ -1,0 +1,27 @@
+// checks case typos with libstd::sync structs
+fn main(){}
+
+fn test_arc(_x: arc<()>){}
+//~^ ERROR: cannot find type `arc` in this scope
+fn test_barrier(_x: barrier<()>){}
+//~^ ERROR: cannot find type `barrier` in this scope
+fn test_bwr(_x: BarrierwaitResult<()>){}
+//~^ ERROR: cannot find type `BarrierwaitResult` in this scope
+fn test_cvar(_x: CondVar<()>){}
+//~^ ERROR: cannot find type `CondVar` in this scope
+fn test_mutex(_x: mutex<()>){}
+//~^ ERROR: cannot find type `mutex` in this scope
+fn test_mutexguard(_x: Mutexguard<()>){}
+//~^ ERROR: cannot find type `Mutexguard` in this scope
+fn test_once(_x: once<()>){}
+//~^ ERROR: cannot find type `once` in this scope
+fn test_rwl(_x: RWlock<()>){}
+//~^ ERROR: cannot find type `RWlock` in this scope
+fn test_rwlrg(_x: RWlockReadGuard<()>){}
+//~^ ERROR: cannot find type `RWlockReadGuard` in this scope
+fn test_rwlwg(_x: RWlockWriteGuard<()>){}
+//~^ ERROR: cannot find type `RWlockWriteGuard` in this scope
+fn test_wtr(_x: WaittimeoutResult<()>){}
+//~^ ERROR: cannot find type `WaittimeoutResult` in this scope
+fn test_weak(_x: weak<()>){}
+//~^ ERROR: cannot find type `weak` in this scope

--- a/src/test/ui/libstd-case-typo/sync.stderr
+++ b/src/test/ui/libstd-case-typo/sync.stderr
@@ -5,7 +5,7 @@ LL | fn test_arc(_x: arc<()>){}
    |                 ^^^
    |                 |
    |                 not found in this scope
-   |                 help: found a libstd struct with a similar name: `std::sync::Arc`
+   |                 help: found a std struct with a similar name: `std::sync::Arc`
 
 error[E0412]: cannot find type `barrier` in this scope
   --> $DIR/sync.rs:6:21
@@ -14,7 +14,7 @@ LL | fn test_barrier(_x: barrier<()>){}
    |                     ^^^^^^^
    |                     |
    |                     not found in this scope
-   |                     help: found a libstd struct with a similar name: `std::sync::Barrier`
+   |                     help: found a std struct with a similar name: `std::sync::Barrier`
 
 error[E0412]: cannot find type `BarrierwaitResult` in this scope
   --> $DIR/sync.rs:8:17
@@ -23,7 +23,7 @@ LL | fn test_bwr(_x: BarrierwaitResult<()>){}
    |                 ^^^^^^^^^^^^^^^^^
    |                 |
    |                 not found in this scope
-   |                 help: found a libstd struct with a similar name: `std::sync::BarrierWaitResult`
+   |                 help: found a std struct with a similar name: `std::sync::BarrierWaitResult`
 
 error[E0412]: cannot find type `CondVar` in this scope
   --> $DIR/sync.rs:10:18
@@ -32,7 +32,7 @@ LL | fn test_cvar(_x: CondVar<()>){}
    |                  ^^^^^^^
    |                  |
    |                  not found in this scope
-   |                  help: found a libstd struct with a similar name: `std::sync::Condvar`
+   |                  help: found a std struct with a similar name: `std::sync::Condvar`
 
 error[E0412]: cannot find type `mutex` in this scope
   --> $DIR/sync.rs:12:19
@@ -41,7 +41,7 @@ LL | fn test_mutex(_x: mutex<()>){}
    |                   ^^^^^
    |                   |
    |                   not found in this scope
-   |                   help: found a libstd struct with a similar name: `std::sync::Mutex`
+   |                   help: found a std struct with a similar name: `std::sync::Mutex`
 
 error[E0412]: cannot find type `Mutexguard` in this scope
   --> $DIR/sync.rs:14:24
@@ -50,7 +50,7 @@ LL | fn test_mutexguard(_x: Mutexguard<()>){}
    |                        ^^^^^^^^^^
    |                        |
    |                        not found in this scope
-   |                        help: found a libstd struct with a similar name: `std::sync::MutexGuard`
+   |                        help: found a std struct with a similar name: `std::sync::MutexGuard`
 
 error[E0412]: cannot find type `once` in this scope
   --> $DIR/sync.rs:16:18
@@ -58,7 +58,7 @@ error[E0412]: cannot find type `once` in this scope
 LL | fn test_once(_x: once<()>){}
    |                  ^^^^ not found in this scope
    |
-help: found libstd structs with a similar name:
+help: found std structs with similar names:
    |
 LL | fn test_once(_x: std::iter::Once<()>){}
    |                  ^^^^^^^^^^^^^^^
@@ -72,7 +72,7 @@ LL | fn test_rwl(_x: RWlock<()>){}
    |                 ^^^^^^
    |                 |
    |                 not found in this scope
-   |                 help: found a libstd struct with a similar name: `std::sync::RwLock`
+   |                 help: found a std struct with a similar name: `std::sync::RwLock`
 
 error[E0412]: cannot find type `RWlockReadGuard` in this scope
   --> $DIR/sync.rs:20:19
@@ -81,7 +81,7 @@ LL | fn test_rwlrg(_x: RWlockReadGuard<()>){}
    |                   ^^^^^^^^^^^^^^^
    |                   |
    |                   not found in this scope
-   |                   help: found a libstd struct with a similar name: `std::sync::RwLockReadGuard`
+   |                   help: found a std struct with a similar name: `std::sync::RwLockReadGuard`
 
 error[E0412]: cannot find type `RWlockWriteGuard` in this scope
   --> $DIR/sync.rs:22:19
@@ -90,7 +90,7 @@ LL | fn test_rwlwg(_x: RWlockWriteGuard<()>){}
    |                   ^^^^^^^^^^^^^^^^
    |                   |
    |                   not found in this scope
-   |                   help: found a libstd struct with a similar name: `std::sync::RwLockWriteGuard`
+   |                   help: found a std struct with a similar name: `std::sync::RwLockWriteGuard`
 
 error[E0412]: cannot find type `WaittimeoutResult` in this scope
   --> $DIR/sync.rs:24:17
@@ -99,7 +99,7 @@ LL | fn test_wtr(_x: WaittimeoutResult<()>){}
    |                 ^^^^^^^^^^^^^^^^^
    |                 |
    |                 not found in this scope
-   |                 help: found a libstd struct with a similar name: `std::sync::WaitTimeoutResult`
+   |                 help: found a std struct with a similar name: `std::sync::WaitTimeoutResult`
 
 error[E0412]: cannot find type `weak` in this scope
   --> $DIR/sync.rs:26:18
@@ -107,7 +107,7 @@ error[E0412]: cannot find type `weak` in this scope
 LL | fn test_weak(_x: weak<()>){}
    |                  ^^^^ not found in this scope
    |
-help: found libstd structs with a similar name:
+help: found std structs with similar names:
    |
 LL | fn test_weak(_x: std::rc::Weak<()>){}
    |                  ^^^^^^^^^^^^^

--- a/src/test/ui/libstd-case-typo/sync.stderr
+++ b/src/test/ui/libstd-case-typo/sync.stderr
@@ -1,0 +1,139 @@
+error[E0412]: cannot find type `arc` in this scope
+  --> $DIR/sync.rs:4:17
+   |
+LL | fn test_arc(_x: arc<()>){}
+   |                 ^^^ not found in this scope
+   |
+help: did you mean `std::sync::Arc`?
+   |
+LL | fn test_arc(_x: std::sync::Arc<()>){}
+   |                 ^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `barrier` in this scope
+  --> $DIR/sync.rs:6:21
+   |
+LL | fn test_barrier(_x: barrier<()>){}
+   |                     ^^^^^^^ not found in this scope
+   |
+help: did you mean `std::sync::Barrier`?
+   |
+LL | fn test_barrier(_x: std::sync::Barrier<()>){}
+   |                     ^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `BarrierwaitResult` in this scope
+  --> $DIR/sync.rs:8:17
+   |
+LL | fn test_bwr(_x: BarrierwaitResult<()>){}
+   |                 ^^^^^^^^^^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::sync::BarrierWaitResult`?
+   |
+LL | fn test_bwr(_x: std::sync::BarrierWaitResult<()>){}
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `CondVar` in this scope
+  --> $DIR/sync.rs:10:18
+   |
+LL | fn test_cvar(_x: CondVar<()>){}
+   |                  ^^^^^^^ not found in this scope
+   |
+help: did you mean `std::sync::Condvar`?
+   |
+LL | fn test_cvar(_x: std::sync::Condvar<()>){}
+   |                  ^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `mutex` in this scope
+  --> $DIR/sync.rs:12:19
+   |
+LL | fn test_mutex(_x: mutex<()>){}
+   |                   ^^^^^ not found in this scope
+   |
+help: did you mean `std::sync::Mutex`?
+   |
+LL | fn test_mutex(_x: std::sync::Mutex<()>){}
+   |                   ^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `Mutexguard` in this scope
+  --> $DIR/sync.rs:14:24
+   |
+LL | fn test_mutexguard(_x: Mutexguard<()>){}
+   |                        ^^^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::sync::MutexGuard`?
+   |
+LL | fn test_mutexguard(_x: std::sync::MutexGuard<()>){}
+   |                        ^^^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `once` in this scope
+  --> $DIR/sync.rs:16:18
+   |
+LL | fn test_once(_x: once<()>){}
+   |                  ^^^^ not found in this scope
+   |
+help: did you mean one of these?:
+   |
+LL | fn test_once(_x: std::iter::Once<()>){}
+   |                  ^^^^^^^^^^^^^^^
+LL | fn test_once(_x: std::sync::Once<()>){}
+   |                  ^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `RWlock` in this scope
+  --> $DIR/sync.rs:18:17
+   |
+LL | fn test_rwl(_x: RWlock<()>){}
+   |                 ^^^^^^ not found in this scope
+   |
+help: did you mean `std::sync::RwLock`?
+   |
+LL | fn test_rwl(_x: std::sync::RwLock<()>){}
+   |                 ^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `RWlockReadGuard` in this scope
+  --> $DIR/sync.rs:20:19
+   |
+LL | fn test_rwlrg(_x: RWlockReadGuard<()>){}
+   |                   ^^^^^^^^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::sync::RwLockReadGuard`?
+   |
+LL | fn test_rwlrg(_x: std::sync::RwLockReadGuard<()>){}
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `RWlockWriteGuard` in this scope
+  --> $DIR/sync.rs:22:19
+   |
+LL | fn test_rwlwg(_x: RWlockWriteGuard<()>){}
+   |                   ^^^^^^^^^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::sync::RwLockWriteGuard`?
+   |
+LL | fn test_rwlwg(_x: std::sync::RwLockWriteGuard<()>){}
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `WaittimeoutResult` in this scope
+  --> $DIR/sync.rs:24:17
+   |
+LL | fn test_wtr(_x: WaittimeoutResult<()>){}
+   |                 ^^^^^^^^^^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::sync::WaitTimeoutResult`?
+   |
+LL | fn test_wtr(_x: std::sync::WaitTimeoutResult<()>){}
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `weak` in this scope
+  --> $DIR/sync.rs:26:18
+   |
+LL | fn test_weak(_x: weak<()>){}
+   |                  ^^^^ not found in this scope
+   |
+help: did you mean one of these?:
+   |
+LL | fn test_weak(_x: std::rc::Weak<()>){}
+   |                  ^^^^^^^^^^^^^
+LL | fn test_weak(_x: std::sync::Weak<()>){}
+   |                  ^^^^^^^^^^^^^^^
+
+error: aborting due to 12 previous errors
+
+For more information about this error, try `rustc --explain E0412`.

--- a/src/test/ui/libstd-case-typo/sync.stderr
+++ b/src/test/ui/libstd-case-typo/sync.stderr
@@ -2,67 +2,55 @@ error[E0412]: cannot find type `arc` in this scope
   --> $DIR/sync.rs:4:17
    |
 LL | fn test_arc(_x: arc<()>){}
-   |                 ^^^ not found in this scope
-   |
-help: did you mean `std::sync::Arc`?
-   |
-LL | fn test_arc(_x: std::sync::Arc<()>){}
-   |                 ^^^^^^^^^^^^^^
+   |                 ^^^
+   |                 |
+   |                 not found in this scope
+   |                 help: found a libstd struct with a similar name: `std::sync::Arc`
 
 error[E0412]: cannot find type `barrier` in this scope
   --> $DIR/sync.rs:6:21
    |
 LL | fn test_barrier(_x: barrier<()>){}
-   |                     ^^^^^^^ not found in this scope
-   |
-help: did you mean `std::sync::Barrier`?
-   |
-LL | fn test_barrier(_x: std::sync::Barrier<()>){}
-   |                     ^^^^^^^^^^^^^^^^^^
+   |                     ^^^^^^^
+   |                     |
+   |                     not found in this scope
+   |                     help: found a libstd struct with a similar name: `std::sync::Barrier`
 
 error[E0412]: cannot find type `BarrierwaitResult` in this scope
   --> $DIR/sync.rs:8:17
    |
 LL | fn test_bwr(_x: BarrierwaitResult<()>){}
-   |                 ^^^^^^^^^^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::sync::BarrierWaitResult`?
-   |
-LL | fn test_bwr(_x: std::sync::BarrierWaitResult<()>){}
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                 ^^^^^^^^^^^^^^^^^
+   |                 |
+   |                 not found in this scope
+   |                 help: found a libstd struct with a similar name: `std::sync::BarrierWaitResult`
 
 error[E0412]: cannot find type `CondVar` in this scope
   --> $DIR/sync.rs:10:18
    |
 LL | fn test_cvar(_x: CondVar<()>){}
-   |                  ^^^^^^^ not found in this scope
-   |
-help: did you mean `std::sync::Condvar`?
-   |
-LL | fn test_cvar(_x: std::sync::Condvar<()>){}
-   |                  ^^^^^^^^^^^^^^^^^^
+   |                  ^^^^^^^
+   |                  |
+   |                  not found in this scope
+   |                  help: found a libstd struct with a similar name: `std::sync::Condvar`
 
 error[E0412]: cannot find type `mutex` in this scope
   --> $DIR/sync.rs:12:19
    |
 LL | fn test_mutex(_x: mutex<()>){}
-   |                   ^^^^^ not found in this scope
-   |
-help: did you mean `std::sync::Mutex`?
-   |
-LL | fn test_mutex(_x: std::sync::Mutex<()>){}
-   |                   ^^^^^^^^^^^^^^^^
+   |                   ^^^^^
+   |                   |
+   |                   not found in this scope
+   |                   help: found a libstd struct with a similar name: `std::sync::Mutex`
 
 error[E0412]: cannot find type `Mutexguard` in this scope
   --> $DIR/sync.rs:14:24
    |
 LL | fn test_mutexguard(_x: Mutexguard<()>){}
-   |                        ^^^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::sync::MutexGuard`?
-   |
-LL | fn test_mutexguard(_x: std::sync::MutexGuard<()>){}
-   |                        ^^^^^^^^^^^^^^^^^^^^^
+   |                        ^^^^^^^^^^
+   |                        |
+   |                        not found in this scope
+   |                        help: found a libstd struct with a similar name: `std::sync::MutexGuard`
 
 error[E0412]: cannot find type `once` in this scope
   --> $DIR/sync.rs:16:18
@@ -70,7 +58,7 @@ error[E0412]: cannot find type `once` in this scope
 LL | fn test_once(_x: once<()>){}
    |                  ^^^^ not found in this scope
    |
-help: did you mean one of these?:
+help: found libstd structs with a similar name:
    |
 LL | fn test_once(_x: std::iter::Once<()>){}
    |                  ^^^^^^^^^^^^^^^
@@ -81,45 +69,37 @@ error[E0412]: cannot find type `RWlock` in this scope
   --> $DIR/sync.rs:18:17
    |
 LL | fn test_rwl(_x: RWlock<()>){}
-   |                 ^^^^^^ not found in this scope
-   |
-help: did you mean `std::sync::RwLock`?
-   |
-LL | fn test_rwl(_x: std::sync::RwLock<()>){}
-   |                 ^^^^^^^^^^^^^^^^^
+   |                 ^^^^^^
+   |                 |
+   |                 not found in this scope
+   |                 help: found a libstd struct with a similar name: `std::sync::RwLock`
 
 error[E0412]: cannot find type `RWlockReadGuard` in this scope
   --> $DIR/sync.rs:20:19
    |
 LL | fn test_rwlrg(_x: RWlockReadGuard<()>){}
-   |                   ^^^^^^^^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::sync::RwLockReadGuard`?
-   |
-LL | fn test_rwlrg(_x: std::sync::RwLockReadGuard<()>){}
-   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                   ^^^^^^^^^^^^^^^
+   |                   |
+   |                   not found in this scope
+   |                   help: found a libstd struct with a similar name: `std::sync::RwLockReadGuard`
 
 error[E0412]: cannot find type `RWlockWriteGuard` in this scope
   --> $DIR/sync.rs:22:19
    |
 LL | fn test_rwlwg(_x: RWlockWriteGuard<()>){}
-   |                   ^^^^^^^^^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::sync::RwLockWriteGuard`?
-   |
-LL | fn test_rwlwg(_x: std::sync::RwLockWriteGuard<()>){}
-   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                   ^^^^^^^^^^^^^^^^
+   |                   |
+   |                   not found in this scope
+   |                   help: found a libstd struct with a similar name: `std::sync::RwLockWriteGuard`
 
 error[E0412]: cannot find type `WaittimeoutResult` in this scope
   --> $DIR/sync.rs:24:17
    |
 LL | fn test_wtr(_x: WaittimeoutResult<()>){}
-   |                 ^^^^^^^^^^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::sync::WaitTimeoutResult`?
-   |
-LL | fn test_wtr(_x: std::sync::WaitTimeoutResult<()>){}
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                 ^^^^^^^^^^^^^^^^^
+   |                 |
+   |                 not found in this scope
+   |                 help: found a libstd struct with a similar name: `std::sync::WaitTimeoutResult`
 
 error[E0412]: cannot find type `weak` in this scope
   --> $DIR/sync.rs:26:18
@@ -127,7 +107,7 @@ error[E0412]: cannot find type `weak` in this scope
 LL | fn test_weak(_x: weak<()>){}
    |                  ^^^^ not found in this scope
    |
-help: did you mean one of these?:
+help: found libstd structs with a similar name:
    |
 LL | fn test_weak(_x: std::rc::Weak<()>){}
    |                  ^^^^^^^^^^^^^

--- a/src/test/ui/libstd-case-typo/task.rs
+++ b/src/test/ui/libstd-case-typo/task.rs
@@ -1,0 +1,11 @@
+// checks case typos with libstd::task structs
+fn main(){}
+
+fn test_context(_x: context){}
+//~^ ERROR: cannot find type `context` in this scope
+fn test_rwake(_x: Rawwaker){}
+//~^ ERROR: cannot find type `Rawwaker` in this scope
+fn test_rwakevt(_x: RawwakerVTable){}
+//~^ ERROR: cannot find type `RawwakerVTable` in this scope
+fn test_waker(_x: waker){}
+//~^ ERROR: cannot find type `waker` in this scope

--- a/src/test/ui/libstd-case-typo/task.stderr
+++ b/src/test/ui/libstd-case-typo/task.stderr
@@ -1,0 +1,47 @@
+error[E0412]: cannot find type `context` in this scope
+  --> $DIR/task.rs:4:21
+   |
+LL | fn test_context(_x: context){}
+   |                     ^^^^^^^ not found in this scope
+   |
+help: did you mean `std::task::Context`?
+   |
+LL | fn test_context(_x: std::task::Context){}
+   |                     ^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `Rawwaker` in this scope
+  --> $DIR/task.rs:6:19
+   |
+LL | fn test_rwake(_x: Rawwaker){}
+   |                   ^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::task::RawWaker`?
+   |
+LL | fn test_rwake(_x: std::task::RawWaker){}
+   |                   ^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `RawwakerVTable` in this scope
+  --> $DIR/task.rs:8:21
+   |
+LL | fn test_rwakevt(_x: RawwakerVTable){}
+   |                     ^^^^^^^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::task::RawWakerVTable`?
+   |
+LL | fn test_rwakevt(_x: std::task::RawWakerVTable){}
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `waker` in this scope
+  --> $DIR/task.rs:10:19
+   |
+LL | fn test_waker(_x: waker){}
+   |                   ^^^^^ not found in this scope
+   |
+help: did you mean `std::task::Waker`?
+   |
+LL | fn test_waker(_x: std::task::Waker){}
+   |                   ^^^^^^^^^^^^^^^^
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0412`.

--- a/src/test/ui/libstd-case-typo/task.stderr
+++ b/src/test/ui/libstd-case-typo/task.stderr
@@ -2,45 +2,37 @@ error[E0412]: cannot find type `context` in this scope
   --> $DIR/task.rs:4:21
    |
 LL | fn test_context(_x: context){}
-   |                     ^^^^^^^ not found in this scope
-   |
-help: did you mean `std::task::Context`?
-   |
-LL | fn test_context(_x: std::task::Context){}
-   |                     ^^^^^^^^^^^^^^^^^^
+   |                     ^^^^^^^
+   |                     |
+   |                     not found in this scope
+   |                     help: found a libstd struct with a similar name: `std::task::Context`
 
 error[E0412]: cannot find type `Rawwaker` in this scope
   --> $DIR/task.rs:6:19
    |
 LL | fn test_rwake(_x: Rawwaker){}
-   |                   ^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::task::RawWaker`?
-   |
-LL | fn test_rwake(_x: std::task::RawWaker){}
-   |                   ^^^^^^^^^^^^^^^^^^^
+   |                   ^^^^^^^^
+   |                   |
+   |                   not found in this scope
+   |                   help: found a libstd struct with a similar name: `std::task::RawWaker`
 
 error[E0412]: cannot find type `RawwakerVTable` in this scope
   --> $DIR/task.rs:8:21
    |
 LL | fn test_rwakevt(_x: RawwakerVTable){}
-   |                     ^^^^^^^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::task::RawWakerVTable`?
-   |
-LL | fn test_rwakevt(_x: std::task::RawWakerVTable){}
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                     ^^^^^^^^^^^^^^
+   |                     |
+   |                     not found in this scope
+   |                     help: found a libstd struct with a similar name: `std::task::RawWakerVTable`
 
 error[E0412]: cannot find type `waker` in this scope
   --> $DIR/task.rs:10:19
    |
 LL | fn test_waker(_x: waker){}
-   |                   ^^^^^ not found in this scope
-   |
-help: did you mean `std::task::Waker`?
-   |
-LL | fn test_waker(_x: std::task::Waker){}
-   |                   ^^^^^^^^^^^^^^^^
+   |                   ^^^^^
+   |                   |
+   |                   not found in this scope
+   |                   help: found a libstd struct with a similar name: `std::task::Waker`
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/libstd-case-typo/task.stderr
+++ b/src/test/ui/libstd-case-typo/task.stderr
@@ -5,7 +5,7 @@ LL | fn test_context(_x: context){}
    |                     ^^^^^^^
    |                     |
    |                     not found in this scope
-   |                     help: found a libstd struct with a similar name: `std::task::Context`
+   |                     help: found a std struct with a similar name: `std::task::Context`
 
 error[E0412]: cannot find type `Rawwaker` in this scope
   --> $DIR/task.rs:6:19
@@ -14,7 +14,7 @@ LL | fn test_rwake(_x: Rawwaker){}
    |                   ^^^^^^^^
    |                   |
    |                   not found in this scope
-   |                   help: found a libstd struct with a similar name: `std::task::RawWaker`
+   |                   help: found a std struct with a similar name: `std::task::RawWaker`
 
 error[E0412]: cannot find type `RawwakerVTable` in this scope
   --> $DIR/task.rs:8:21
@@ -23,7 +23,7 @@ LL | fn test_rwakevt(_x: RawwakerVTable){}
    |                     ^^^^^^^^^^^^^^
    |                     |
    |                     not found in this scope
-   |                     help: found a libstd struct with a similar name: `std::task::RawWakerVTable`
+   |                     help: found a std struct with a similar name: `std::task::RawWakerVTable`
 
 error[E0412]: cannot find type `waker` in this scope
   --> $DIR/task.rs:10:19
@@ -32,7 +32,7 @@ LL | fn test_waker(_x: waker){}
    |                   ^^^^^
    |                   |
    |                   not found in this scope
-   |                   help: found a libstd struct with a similar name: `std::task::Waker`
+   |                   help: found a std struct with a similar name: `std::task::Waker`
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/libstd-case-typo/thread.rs
+++ b/src/test/ui/libstd-case-typo/thread.rs
@@ -1,0 +1,13 @@
+// checks case typos with libstd::thread structs
+fn main(){}
+
+fn test_build(_x: builder){}
+//~^ ERROR: cannot find type `builder` in this scope
+fn test_jhand(_x: Joinhandle<()>){}
+//~^ ERROR: cannot find type `Joinhandle` in this scope
+fn test_lkey(_x: Localkey<()>){}
+//~^ ERROR: cannot find type `Localkey` in this scope
+fn test_thread(_x: thread){}
+//~^ ERROR: cannot find type `thread` in this scope
+fn test_threadid(_x: ThreadID){}
+//~^ ERROR: cannot find type `ThreadID` in this scope

--- a/src/test/ui/libstd-case-typo/thread.stderr
+++ b/src/test/ui/libstd-case-typo/thread.stderr
@@ -5,7 +5,7 @@ LL | fn test_build(_x: builder){}
    |                   ^^^^^^^
    |                   |
    |                   not found in this scope
-   |                   help: found a libstd struct with a similar name: `std::thread::Builder`
+   |                   help: found a std struct with a similar name: `std::thread::Builder`
 
 error[E0412]: cannot find type `Joinhandle` in this scope
   --> $DIR/thread.rs:6:19
@@ -14,7 +14,7 @@ LL | fn test_jhand(_x: Joinhandle<()>){}
    |                   ^^^^^^^^^^
    |                   |
    |                   not found in this scope
-   |                   help: found a libstd struct with a similar name: `std::thread::JoinHandle`
+   |                   help: found a std struct with a similar name: `std::thread::JoinHandle`
 
 error[E0412]: cannot find type `Localkey` in this scope
   --> $DIR/thread.rs:8:18
@@ -23,7 +23,7 @@ LL | fn test_lkey(_x: Localkey<()>){}
    |                  ^^^^^^^^
    |                  |
    |                  not found in this scope
-   |                  help: found a libstd struct with a similar name: `std::thread::LocalKey`
+   |                  help: found a std struct with a similar name: `std::thread::LocalKey`
 
 error[E0412]: cannot find type `thread` in this scope
   --> $DIR/thread.rs:10:20
@@ -32,7 +32,7 @@ LL | fn test_thread(_x: thread){}
    |                    ^^^^^^
    |                    |
    |                    not found in this scope
-   |                    help: found a libstd struct with a similar name: `std::thread::Thread`
+   |                    help: found a std struct with a similar name: `std::thread::Thread`
 
 error[E0412]: cannot find type `ThreadID` in this scope
   --> $DIR/thread.rs:12:22
@@ -41,7 +41,7 @@ LL | fn test_threadid(_x: ThreadID){}
    |                      ^^^^^^^^
    |                      |
    |                      not found in this scope
-   |                      help: found a libstd struct with a similar name: `std::thread::ThreadId`
+   |                      help: found a std struct with a similar name: `std::thread::ThreadId`
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/libstd-case-typo/thread.stderr
+++ b/src/test/ui/libstd-case-typo/thread.stderr
@@ -1,0 +1,58 @@
+error[E0412]: cannot find type `builder` in this scope
+  --> $DIR/thread.rs:4:19
+   |
+LL | fn test_build(_x: builder){}
+   |                   ^^^^^^^ not found in this scope
+   |
+help: did you mean `std::thread::Builder`?
+   |
+LL | fn test_build(_x: std::thread::Builder){}
+   |                   ^^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `Joinhandle` in this scope
+  --> $DIR/thread.rs:6:19
+   |
+LL | fn test_jhand(_x: Joinhandle<()>){}
+   |                   ^^^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::thread::JoinHandle`?
+   |
+LL | fn test_jhand(_x: std::thread::JoinHandle<()>){}
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `Localkey` in this scope
+  --> $DIR/thread.rs:8:18
+   |
+LL | fn test_lkey(_x: Localkey<()>){}
+   |                  ^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::thread::LocalKey`?
+   |
+LL | fn test_lkey(_x: std::thread::LocalKey<()>){}
+   |                  ^^^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `thread` in this scope
+  --> $DIR/thread.rs:10:20
+   |
+LL | fn test_thread(_x: thread){}
+   |                    ^^^^^^ not found in this scope
+   |
+help: did you mean `std::thread::Thread`?
+   |
+LL | fn test_thread(_x: std::thread::Thread){}
+   |                    ^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `ThreadID` in this scope
+  --> $DIR/thread.rs:12:22
+   |
+LL | fn test_threadid(_x: ThreadID){}
+   |                      ^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::thread::ThreadId`?
+   |
+LL | fn test_threadid(_x: std::thread::ThreadId){}
+   |                      ^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 5 previous errors
+
+For more information about this error, try `rustc --explain E0412`.

--- a/src/test/ui/libstd-case-typo/thread.stderr
+++ b/src/test/ui/libstd-case-typo/thread.stderr
@@ -2,56 +2,46 @@ error[E0412]: cannot find type `builder` in this scope
   --> $DIR/thread.rs:4:19
    |
 LL | fn test_build(_x: builder){}
-   |                   ^^^^^^^ not found in this scope
-   |
-help: did you mean `std::thread::Builder`?
-   |
-LL | fn test_build(_x: std::thread::Builder){}
-   |                   ^^^^^^^^^^^^^^^^^^^^
+   |                   ^^^^^^^
+   |                   |
+   |                   not found in this scope
+   |                   help: found a libstd struct with a similar name: `std::thread::Builder`
 
 error[E0412]: cannot find type `Joinhandle` in this scope
   --> $DIR/thread.rs:6:19
    |
 LL | fn test_jhand(_x: Joinhandle<()>){}
-   |                   ^^^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::thread::JoinHandle`?
-   |
-LL | fn test_jhand(_x: std::thread::JoinHandle<()>){}
-   |                   ^^^^^^^^^^^^^^^^^^^^^^^
+   |                   ^^^^^^^^^^
+   |                   |
+   |                   not found in this scope
+   |                   help: found a libstd struct with a similar name: `std::thread::JoinHandle`
 
 error[E0412]: cannot find type `Localkey` in this scope
   --> $DIR/thread.rs:8:18
    |
 LL | fn test_lkey(_x: Localkey<()>){}
-   |                  ^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::thread::LocalKey`?
-   |
-LL | fn test_lkey(_x: std::thread::LocalKey<()>){}
-   |                  ^^^^^^^^^^^^^^^^^^^^^
+   |                  ^^^^^^^^
+   |                  |
+   |                  not found in this scope
+   |                  help: found a libstd struct with a similar name: `std::thread::LocalKey`
 
 error[E0412]: cannot find type `thread` in this scope
   --> $DIR/thread.rs:10:20
    |
 LL | fn test_thread(_x: thread){}
-   |                    ^^^^^^ not found in this scope
-   |
-help: did you mean `std::thread::Thread`?
-   |
-LL | fn test_thread(_x: std::thread::Thread){}
-   |                    ^^^^^^^^^^^^^^^^^^^
+   |                    ^^^^^^
+   |                    |
+   |                    not found in this scope
+   |                    help: found a libstd struct with a similar name: `std::thread::Thread`
 
 error[E0412]: cannot find type `ThreadID` in this scope
   --> $DIR/thread.rs:12:22
    |
 LL | fn test_threadid(_x: ThreadID){}
-   |                      ^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::thread::ThreadId`?
-   |
-LL | fn test_threadid(_x: std::thread::ThreadId){}
-   |                      ^^^^^^^^^^^^^^^^^^^^^
+   |                      ^^^^^^^^
+   |                      |
+   |                      not found in this scope
+   |                      help: found a libstd struct with a similar name: `std::thread::ThreadId`
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/libstd-case-typo/time.rs
+++ b/src/test/ui/libstd-case-typo/time.rs
@@ -1,0 +1,9 @@
+// checks case typos with libstd::time structs
+fn main(){}
+
+fn test_dur(_x: duration){}
+//~^ ERROR: cannot find type `duration` in this scope
+fn test_ins(_x: instant){}
+//~^ ERROR: cannot find type `instant` in this scope
+fn test_systime(_x: Systemtime){}
+//~^ ERROR: cannot find type `Systemtime` in this scope

--- a/src/test/ui/libstd-case-typo/time.stderr
+++ b/src/test/ui/libstd-case-typo/time.stderr
@@ -1,0 +1,36 @@
+error[E0412]: cannot find type `duration` in this scope
+  --> $DIR/time.rs:4:17
+   |
+LL | fn test_dur(_x: duration){}
+   |                 ^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::time::Duration`?
+   |
+LL | fn test_dur(_x: std::time::Duration){}
+   |                 ^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `instant` in this scope
+  --> $DIR/time.rs:6:17
+   |
+LL | fn test_ins(_x: instant){}
+   |                 ^^^^^^^ not found in this scope
+   |
+help: did you mean `std::time::Instant`?
+   |
+LL | fn test_ins(_x: std::time::Instant){}
+   |                 ^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `Systemtime` in this scope
+  --> $DIR/time.rs:8:21
+   |
+LL | fn test_systime(_x: Systemtime){}
+   |                     ^^^^^^^^^^ not found in this scope
+   |
+help: did you mean `std::time::SystemTime`?
+   |
+LL | fn test_systime(_x: std::time::SystemTime){}
+   |                     ^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0412`.

--- a/src/test/ui/libstd-case-typo/time.stderr
+++ b/src/test/ui/libstd-case-typo/time.stderr
@@ -5,7 +5,7 @@ LL | fn test_dur(_x: duration){}
    |                 ^^^^^^^^
    |                 |
    |                 not found in this scope
-   |                 help: found a libstd struct with a similar name: `std::time::Duration`
+   |                 help: found a std struct with a similar name: `std::time::Duration`
 
 error[E0412]: cannot find type `instant` in this scope
   --> $DIR/time.rs:6:17
@@ -14,7 +14,7 @@ LL | fn test_ins(_x: instant){}
    |                 ^^^^^^^
    |                 |
    |                 not found in this scope
-   |                 help: found a libstd struct with a similar name: `std::time::Instant`
+   |                 help: found a std struct with a similar name: `std::time::Instant`
 
 error[E0412]: cannot find type `Systemtime` in this scope
   --> $DIR/time.rs:8:21
@@ -23,7 +23,7 @@ LL | fn test_systime(_x: Systemtime){}
    |                     ^^^^^^^^^^
    |                     |
    |                     not found in this scope
-   |                     help: found a libstd struct with a similar name: `std::time::SystemTime`
+   |                     help: found a std struct with a similar name: `std::time::SystemTime`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/libstd-case-typo/time.stderr
+++ b/src/test/ui/libstd-case-typo/time.stderr
@@ -2,34 +2,28 @@ error[E0412]: cannot find type `duration` in this scope
   --> $DIR/time.rs:4:17
    |
 LL | fn test_dur(_x: duration){}
-   |                 ^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::time::Duration`?
-   |
-LL | fn test_dur(_x: std::time::Duration){}
-   |                 ^^^^^^^^^^^^^^^^^^^
+   |                 ^^^^^^^^
+   |                 |
+   |                 not found in this scope
+   |                 help: found a libstd struct with a similar name: `std::time::Duration`
 
 error[E0412]: cannot find type `instant` in this scope
   --> $DIR/time.rs:6:17
    |
 LL | fn test_ins(_x: instant){}
-   |                 ^^^^^^^ not found in this scope
-   |
-help: did you mean `std::time::Instant`?
-   |
-LL | fn test_ins(_x: std::time::Instant){}
-   |                 ^^^^^^^^^^^^^^^^^^
+   |                 ^^^^^^^
+   |                 |
+   |                 not found in this scope
+   |                 help: found a libstd struct with a similar name: `std::time::Instant`
 
 error[E0412]: cannot find type `Systemtime` in this scope
   --> $DIR/time.rs:8:21
    |
 LL | fn test_systime(_x: Systemtime){}
-   |                     ^^^^^^^^^^ not found in this scope
-   |
-help: did you mean `std::time::SystemTime`?
-   |
-LL | fn test_systime(_x: std::time::SystemTime){}
-   |                     ^^^^^^^^^^^^^^^^^^^^^
+   |                     ^^^^^^^^^^
+   |                     |
+   |                     not found in this scope
+   |                     help: found a libstd struct with a similar name: `std::time::SystemTime`
 
 error: aborting due to 3 previous errors
 


### PR DESCRIPTION
Closes #72641 

This PR adds an additional fallback `librustc_resolve` diagnostic with libstd struct suggestions for case misspelling errors under the following conditions:

- libstd struct with correct spelling was not brought into scope (they are already handled with a different diagnostics approach)
- struct is not imported in the Rust prelude (they are already handled with a different diagnostics approach)
- not a primitive type (they are already handled with a different diagnostics approach)
- struct is not nightly-only
- case-insensitive struct name does not match a macro name (the macro name suggestion has precedence with the current approach here and these suggestions are not displayed)
- struct is not deprecated (e.g., `std::str::LinesAny`)
- struct is not an error type (arbitrary decision)

Behavior: A user who enters a struct name with a libstd struct case misspelling for a type that is not in scope will receive the matching libstd struct(s) in a new suggestion.  This approach was originally requested in #72641 for `Hashmap` -> `HashMap` only.  These changes broaden the scope of that report to cover many/most libstd structs with any case misspelling error, and support multiple struct suggestions when there are multiple case-insensitive name matches across the standard library. This is only used when the Levenshtein algorithm does not identify a typo candidate match.

Before:

```
error[E0412]: cannot find type `Hashmap` in this scope
 --> src/main.rs:4:9
  |
4 |     hm: Hashmap<String, ()>,
  |         ^^^^^^^ not found in this scope

error: aborting due to previous error

For more information about this error, try `rustc --explain E0412`.
```

After:

```
error[E0412]: cannot find type `Hashmap` in this scope
 --> src/main.rs:4:9
  |
4 |     hm: Hashmap<String, ()>,
  |         ^^^^^^^
  |         |
  |         not found in this scope
  |         help: found a std struct with a similar name: `std::collections::HashMap`

error: aborting due to previous error
```
