### PR TITLE
Count the beta prerelease number just from master

### DIFF
--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -963,29 +963,15 @@ impl Build {
             return s;
         }
 
-        let beta = output(
-            Command::new("git").arg("ls-remote").arg("origin").arg("beta").current_dir(&self.src),
-        );
-        let beta = beta.trim().split_whitespace().next().unwrap();
-        let master = output(
-            Command::new("git").arg("ls-remote").arg("origin").arg("master").current_dir(&self.src),
-        );
-        let master = master.trim().split_whitespace().next().unwrap();
-
-        // Figure out where the current beta branch started.
-        let base = output(
-            Command::new("git").arg("merge-base").arg(beta).arg(master).current_dir(&self.src),
-        );
-        let base = base.trim();
-
-        // Next figure out how many merge commits happened since we branched off
-        // beta. That's our beta number!
+        // Figure out how many merge commits happened since we branched off master.
+        // That's our beta number!
+        // (Note that we use a `..` range, not the `...` symmetric difference.)
         let count = output(
             Command::new("git")
                 .arg("rev-list")
                 .arg("--count")
                 .arg("--merges")
-                .arg(format!("{}...HEAD", base))
+                .arg("refs/remotes/origin/master..HEAD")
                 .current_dir(&self.src),
         );
         let n = count.trim().parse().unwrap();


### PR DESCRIPTION
We were computing a merge-base between the remote beta and master
branches, but this was giving incorrect answers for the first beta if
the remote hadn't been pushed yet. For instance, `1.45.0-beta.3359`
corresponds to the number of merges since the 1.44 beta, but we really
want just `.1` for the sole 1.45 beta promotion merge.

We don't really need to query the remote beta at all -- `master..HEAD`
suffices if we assume that we're on the intended beta branch already.