### PR TITLE
compiletest: Add directives to detect sanitizer support

### DIFF
--- a/src/test/codegen/sanitizer-memory-track-orgins.rs
+++ b/src/test/codegen/sanitizer-memory-track-orgins.rs
@@ -1,9 +1,7 @@
 // Verifies that MemorySanitizer track-origins level can be controlled
 // with -Zsanitizer-memory-track-origins option.
 //
-// needs-sanitizer-support
-// only-linux
-// only-x86_64
+// needs-sanitizer-memory
 // revisions:MSAN-0 MSAN-1 MSAN-2 MSAN-1-LTO MSAN-2-LTO
 //
 //[MSAN-0] compile-flags: -Zsanitizer=memory

--- a/src/test/codegen/sanitizer-no-sanitize-inlining.rs
+++ b/src/test/codegen/sanitizer-no-sanitize-inlining.rs
@@ -1,11 +1,9 @@
 // Verifies that no_sanitize attribute prevents inlining when
 // given sanitizer is enabled, but has no effect on inlining otherwise.
 //
-// needs-sanitizer-support
-// only-x86_64
-//
+// needs-sanitizer-address
+// needs-sanitizer-leak
 // revisions: ASAN LSAN
-//
 //[ASAN] compile-flags: -Zsanitizer=address -C opt-level=3 -Z mir-opt-level=3
 //[LSAN] compile-flags: -Zsanitizer=leak    -C opt-level=3 -Z mir-opt-level=3
 

--- a/src/test/codegen/sanitizer-no-sanitize.rs
+++ b/src/test/codegen/sanitizer-no-sanitize.rs
@@ -1,7 +1,7 @@
 // Verifies that no_sanitze attribute can be used to
 // selectively disable sanitizer instrumentation.
 //
-// needs-sanitizer-support
+// needs-sanitizer-address
 // compile-flags: -Zsanitizer=address
 
 #![crate_type="lib"]

--- a/src/test/codegen/sanitizer-recover.rs
+++ b/src/test/codegen/sanitizer-recover.rs
@@ -1,9 +1,8 @@
 // Verifies that AddressSanitizer and MemorySanitizer
 // recovery mode can be enabled with -Zsanitizer-recover.
 //
-// needs-sanitizer-support
-// only-linux
-// only-x86_64
+// needs-sanitizer-address
+// needs-sanitizer-memory
 // revisions:ASAN ASAN-RECOVER MSAN MSAN-RECOVER MSAN-RECOVER-LTO
 // no-prefer-dynamic
 //

--- a/src/test/run-make-fulldeps/sanitizer-cdylib-link/Makefile
+++ b/src/test/run-make-fulldeps/sanitizer-cdylib-link/Makefile
@@ -1,5 +1,5 @@
 # needs-sanitizer-support
-# only-x86_64
+# needs-sanitizer-address
 # only-linux
 
 -include ../tools.mk

--- a/src/test/run-make-fulldeps/sanitizer-dylib-link/Makefile
+++ b/src/test/run-make-fulldeps/sanitizer-dylib-link/Makefile
@@ -1,5 +1,5 @@
 # needs-sanitizer-support
-# only-x86_64
+# needs-sanitizer-address
 # only-linux
 
 -include ../tools.mk

--- a/src/test/run-make-fulldeps/sanitizer-staticlib-link/Makefile
+++ b/src/test/run-make-fulldeps/sanitizer-staticlib-link/Makefile
@@ -1,5 +1,5 @@
 # needs-sanitizer-support
-# only-x86_64
+# needs-sanitizer-address
 # only-linux
 
 -include ../tools.mk

--- a/src/test/rustdoc/sanitizer-option.rs
+++ b/src/test/rustdoc/sanitizer-option.rs
@@ -1,4 +1,5 @@
 // needs-sanitizer-support
+// needs-sanitizer-address
 // compile-flags: --test -Z sanitizer=address
 //
 // #43031: Verify that rustdoc passes `-Z` options to rustc. Use an extern

--- a/src/test/ui/sanitize/address.rs
+++ b/src/test/ui/sanitize/address.rs
@@ -1,5 +1,5 @@
 // needs-sanitizer-support
-// only-x86_64
+// needs-sanitizer-address
 //
 // compile-flags: -Z sanitizer=address -O -g
 //

--- a/src/test/ui/sanitize/badfree.rs
+++ b/src/test/ui/sanitize/badfree.rs
@@ -1,5 +1,5 @@
 // needs-sanitizer-support
-// only-x86_64
+// needs-sanitizer-address
 //
 // compile-flags: -Z sanitizer=address -O
 //

--- a/src/test/ui/sanitize/cfg.rs
+++ b/src/test/ui/sanitize/cfg.rs
@@ -2,8 +2,10 @@
 // the `#[cfg(sanitize = "option")]` attribute is configured.
 
 // needs-sanitizer-support
-// only-linux
-// only-x86_64
+// needs-sanitizer-address
+// needs-sanitizer-leak
+// needs-sanitizer-memory
+// needs-sanitizer-thread
 // check-pass
 // revisions: address leak memory thread
 //[address]compile-flags: -Zsanitizer=address --cfg address

--- a/src/test/ui/sanitize/issue-72154-lifetime-markers.rs
+++ b/src/test/ui/sanitize/issue-72154-lifetime-markers.rs
@@ -4,7 +4,7 @@
 // miscompilation which was subsequently detected by AddressSanitizer as UB.
 //
 // needs-sanitizer-support
-// only-x86_64
+// needs-sanitizer-address
 //
 // compile-flags: -Copt-level=0 -Zsanitizer=address
 // run-pass

--- a/src/test/ui/sanitize/leak.rs
+++ b/src/test/ui/sanitize/leak.rs
@@ -1,5 +1,5 @@
 // needs-sanitizer-support
-// only-x86_64
+// needs-sanitizer-leak
 //
 // compile-flags: -Z sanitizer=leak -O
 //

--- a/src/test/ui/sanitize/memory.rs
+++ b/src/test/ui/sanitize/memory.rs
@@ -1,6 +1,5 @@
 // needs-sanitizer-support
-// only-linux
-// only-x86_64
+// needs-sanitizer-memory
 //
 // compile-flags: -Z sanitizer=memory -Zsanitizer-memory-track-origins -O
 //

--- a/src/test/ui/sanitize/new-llvm-pass-manager-thin-lto.rs
+++ b/src/test/ui/sanitize/new-llvm-pass-manager-thin-lto.rs
@@ -4,7 +4,7 @@
 //
 // min-llvm-version 9.0
 // needs-sanitizer-support
-// only-x86_64
+// needs-sanitizer-address
 //
 // no-prefer-dynamic
 // revisions: opt0 opt1

--- a/src/test/ui/sanitize/thread.rs
+++ b/src/test/ui/sanitize/thread.rs
@@ -11,7 +11,7 @@
 // would occasionally fail, making test flaky.
 //
 // needs-sanitizer-support
-// only-x86_64
+// needs-sanitizer-thread
 //
 // compile-flags: -Z sanitizer=thread -O
 //

--- a/src/test/ui/sanitize/use-after-scope.rs
+++ b/src/test/ui/sanitize/use-after-scope.rs
@@ -1,5 +1,5 @@
 // needs-sanitizer-support
-// only-x86_64
+// needs-sanitizer-address
 //
 // compile-flags: -Zsanitizer=address
 // run-fail

--- a/src/tools/compiletest/src/header/tests.rs
+++ b/src/tools/compiletest/src/header/tests.rs
@@ -195,3 +195,22 @@ fn debugger() {
     config.debugger = Some(Debugger::Lldb);
     assert!(parse_rs(&config, "// ignore-lldb").ignore);
 }
+
+#[test]
+fn sanitizers() {
+    let mut config = config();
+
+    // Target that supports all sanitizers:
+    config.target = "x86_64-unknown-linux-gnu".to_owned();
+    assert!(!parse_rs(&config, "// needs-sanitizer-address").ignore);
+    assert!(!parse_rs(&config, "// needs-sanitizer-leak").ignore);
+    assert!(!parse_rs(&config, "// needs-sanitizer-memory").ignore);
+    assert!(!parse_rs(&config, "// needs-sanitizer-thread").ignore);
+
+    // Target that doesn't support sanitizers:
+    config.target = "wasm32-unknown-emscripten".to_owned();
+    assert!(parse_rs(&config, "// needs-sanitizer-address").ignore);
+    assert!(parse_rs(&config, "// needs-sanitizer-leak").ignore);
+    assert!(parse_rs(&config, "// needs-sanitizer-memory").ignore);
+    assert!(parse_rs(&config, "// needs-sanitizer-thread").ignore);
+}

--- a/src/tools/compiletest/src/util.rs
+++ b/src/tools/compiletest/src/util.rs
@@ -81,6 +81,17 @@ const ARCH_TABLE: &'static [(&'static str, &'static str)] = &[
     ("xcore", "xcore"),
 ];
 
+pub const ASAN_SUPPORTED_TARGETS: &'static [&'static str] =
+    &["aarch64-fuchsia", "x86_64-apple-darwin", "x86_64-fuchsia", "x86_64-unknown-linux-gnu"];
+
+pub const LSAN_SUPPORTED_TARGETS: &'static [&'static str] =
+    &["x86_64-apple-darwin", "x86_64-unknown-linux-gnu"];
+
+pub const MSAN_SUPPORTED_TARGETS: &'static [&'static str] = &["x86_64-unknown-linux-gnu"];
+
+pub const TSAN_SUPPORTED_TARGETS: &'static [&'static str] =
+    &["x86_64-apple-darwin", "x86_64-unknown-linux-gnu"];
+
 pub fn matches_os(triple: &str, name: &str) -> bool {
     // For the wasm32 bare target we ignore anything also ignored on emscripten
     // and then we also recognize `wasm32-bare` as the os for the target


### PR DESCRIPTION
Add needs-sanitizer-{address,leak,memory,thread} directive indicating
that test requires target with support for specific sanitizer.

This is an addition to the existing needs-sanitizer-support directive
indicating that test requires a sanitizer runtime library.

The existing needs-sanitizer-support directive could be incorporated into the
new ones, but I decided to retain it, since it enables running sanitizer
codegen tests even when building of sanitizer runtime libraries is disabled.