### PR TITLE
memory access sanity checks: abort instead of panic

### DIFF
--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -2057,9 +2057,14 @@ pub unsafe fn copy_nonoverlapping<T>(src: *const T, dst: *mut T, count: usize) {
         fn copy_nonoverlapping<T>(src: *const T, dst: *mut T, count: usize);
     }
 
-    debug_assert!(is_aligned_and_not_null(src), "attempt to copy from unaligned or null pointer");
-    debug_assert!(is_aligned_and_not_null(dst), "attempt to copy to unaligned or null pointer");
-    debug_assert!(is_nonoverlapping(src, dst, count), "attempt to copy to overlapping memory");
+    if cfg!(debug_assertions)
+        && !(is_aligned_and_not_null(src)
+            && is_aligned_and_not_null(dst)
+            && is_nonoverlapping(src, dst, count))
+    {
+        // Not panicking to keep codegen impact smaller.
+        abort();
+    }
     copy_nonoverlapping(src, dst, count)
 }
 
@@ -2122,8 +2127,10 @@ pub unsafe fn copy<T>(src: *const T, dst: *mut T, count: usize) {
         fn copy<T>(src: *const T, dst: *mut T, count: usize);
     }
 
-    debug_assert!(is_aligned_and_not_null(src), "attempt to copy from unaligned or null pointer");
-    debug_assert!(is_aligned_and_not_null(dst), "attempt to copy to unaligned or null pointer");
+    if cfg!(debug_assertions) && !(is_aligned_and_not_null(src) && is_aligned_and_not_null(dst)) {
+        // Not panicking to keep codegen impact smaller.
+        abort();
+    }
     copy(src, dst, count)
 }
 

--- a/src/test/codegen/vec-clear.rs
+++ b/src/test/codegen/vec-clear.rs
@@ -1,4 +1,3 @@
-// ignore-debug: the debug assertions get in the way
 // compile-flags: -O
 
 #![crate_type = "lib"]

--- a/src/test/codegen/vec-optimizes-away.rs
+++ b/src/test/codegen/vec-optimizes-away.rs
@@ -1,4 +1,3 @@
-//
 // ignore-debug: the debug assertions get in the way
 // no-system-llvm
 // compile-flags: -O


### PR DESCRIPTION
Suggested by @Mark-Simulacrum, this should help reduce the performance impact of these checks.