### PR TITLE
Allow unused arguments in asm!

### DIFF
--- a/src/doc/unstable-book/src/library-features/asm.md
+++ b/src/doc/unstable-book/src/library-features/asm.md
@@ -201,7 +201,7 @@ fn mul(a: u64, b: u64) -> u128 {
         );
     }
 
-    (hi as u128) << 64 + lo as u128
+    ((hi as u128) << 64) + lo as u128
 }
 ```
 
@@ -382,7 +382,9 @@ The macro will initially be supported only on ARM, AArch64, x86, x86-64 and RISC
 
 The assembler template uses the same syntax as [format strings][format-syntax] (i.e. placeholders are specified by curly braces). The corresponding arguments are accessed in order, by index, or by name. However, implicit named arguments (introduced by [RFC #2795][rfc-2795]) are not supported.
 
-As with format strings, named arguments must appear after positional arguments. Explicit register operands must appear at the end of the operand list, after any named arguments if any. Explicit register operands cannot be used by placeholders in the template string. All other operands must appear at least once in the template string, otherwise a compiler error is generated.
+As with format strings, named arguments must appear after positional arguments. Explicit register operands must appear at the end of the operand list, after named arguments if any.
+
+Explicit register operands cannot be used by placeholders in the template string. All other named and positional operands must appear at least once in the template string, otherwise a compiler error is generated.
 
 The exact assembly code syntax is target-specific and opaque to the compiler except for the way operands are substituted into the template string to form the code passed to the assembler.
 

--- a/src/doc/unstable-book/src/library-features/asm.md
+++ b/src/doc/unstable-book/src/library-features/asm.md
@@ -384,7 +384,7 @@ The assembler template uses the same syntax as [format strings][format-syntax] (
 
 As with format strings, named arguments must appear after positional arguments. Explicit register operands must appear at the end of the operand list, after named arguments if any.
 
-Explicit register operands cannot be used by placeholders in the template string. All other named and positional operands must appear at least once in the template string, otherwise a compiler error is generated.
+Explicit register operands cannot be used by placeholders in the template string. All other named and positional operands must appear at least once in the template string, otherwise the compiler will emit a warning.
 
 The exact assembly code syntax is target-specific and opaque to the compiler except for the way operands are substituted into the template string to form the code passed to the assembler.
 

--- a/src/librustc_session/lint/builtin.rs
+++ b/src/librustc_session/lint/builtin.rs
@@ -532,6 +532,12 @@ declare_lint! {
     "unsafe operations in unsafe functions without an explicit unsafe block are deprecated",
 }
 
+declare_lint! {
+    pub UNUSED_ASM_ARGUMENTS,
+    Warn,
+    "inline asm arguments not used in the template string",
+}
+
 declare_lint_pass! {
     /// Does nothing as a lint pass, but registers some `Lint`s
     /// that are used by other parts of the compiler.

--- a/src/librustc_session/lint/builtin.rs
+++ b/src/librustc_session/lint/builtin.rs
@@ -610,6 +610,7 @@ declare_lint_pass! {
         INLINE_NO_SANITIZE,
         ASM_SUB_REGISTER,
         UNSAFE_OP_IN_UNSAFE_FN,
+        UNUSED_ASM_ARGUMENTS,
     ]
 }
 

--- a/src/test/ui/asm/bad-template.rs
+++ b/src/test/ui/asm/bad-template.rs
@@ -24,5 +24,7 @@ fn main() {
         //~^ ERROR asm template modifier must be a single character
         asm!("", in(reg) 0, in(reg) 1);
         //~^ WARN asm arguments not used in template
+        #[allow(unused_asm_arguments)]
+        asm!("", in(reg) 0, in(reg) 1);
     }
 }

--- a/src/test/ui/asm/bad-template.rs
+++ b/src/test/ui/asm/bad-template.rs
@@ -9,18 +9,20 @@ fn main() {
         //~^ ERROR invalid reference to argument at index 0
         asm!("{1}", in(reg) foo);
         //~^ ERROR invalid reference to argument at index 1
-        //~^^ ERROR argument never used
+        //~^^ WARN asm argument not used in template
         asm!("{a}");
         //~^ ERROR there is no argument named `a`
         asm!("{}", a = in(reg) foo);
         //~^ ERROR invalid reference to argument at index 0
-        //~^^ ERROR argument never used
+        //~^^ WARN asm argument not used in template
         asm!("{1}", a = in(reg) foo);
         //~^ ERROR invalid reference to argument at index 1
-        //~^^ ERROR named argument never used
+        //~^^ WARN asm argument not used in template
         asm!("{}", in("eax") foo);
         //~^ ERROR invalid reference to argument at index 0
         asm!("{:foo}", in(reg) foo);
         //~^ ERROR asm template modifier must be a single character
+        asm!("", in(reg) 0, in(reg) 1);
+        //~^ WARN asm arguments not used in template
     }
 }

--- a/src/test/ui/asm/bad-template.stderr
+++ b/src/test/ui/asm/bad-template.stderr
@@ -14,12 +14,6 @@ LL |         asm!("{1}", in(reg) foo);
    |
    = note: there is 1 argument
 
-error: argument never used
-  --> $DIR/bad-template.rs:10:21
-   |
-LL |         asm!("{1}", in(reg) foo);
-   |                     ^^^^^^^^^^^ argument never used
-
 error: there is no argument named `a`
   --> $DIR/bad-template.rs:13:15
    |
@@ -41,12 +35,6 @@ note: named arguments cannot be referenced by position
 LL |         asm!("{}", a = in(reg) foo);
    |                    ^^^^^^^^^^^^^^^
 
-error: named argument never used
-  --> $DIR/bad-template.rs:15:20
-   |
-LL |         asm!("{}", a = in(reg) foo);
-   |                    ^^^^^^^^^^^^^^^ named argument never used
-
 error: invalid reference to argument at index 1
   --> $DIR/bad-template.rs:18:15
    |
@@ -54,12 +42,6 @@ LL |         asm!("{1}", a = in(reg) foo);
    |               ^^^ from here
    |
    = note: no positional arguments were given
-
-error: named argument never used
-  --> $DIR/bad-template.rs:18:21
-   |
-LL |         asm!("{1}", a = in(reg) foo);
-   |                     ^^^^^^^^^^^^^^^ named argument never used
 
 error: invalid reference to argument at index 0
   --> $DIR/bad-template.rs:21:15
@@ -82,5 +64,31 @@ error: asm template modifier must be a single character
 LL |         asm!("{:foo}", in(reg) foo);
    |                 ^^^
 
-error: aborting due to 10 previous errors
+warning: asm argument not used in template
+  --> $DIR/bad-template.rs:10:21
+   |
+LL |         asm!("{1}", in(reg) foo);
+   |                     ^^^^^^^^^^^
+   |
+   = note: `#[warn(unused_asm_arguments)]` on by default
+
+warning: asm argument not used in template
+  --> $DIR/bad-template.rs:15:20
+   |
+LL |         asm!("{}", a = in(reg) foo);
+   |                    ^^^^^^^^^^^^^^^
+
+warning: asm argument not used in template
+  --> $DIR/bad-template.rs:18:21
+   |
+LL |         asm!("{1}", a = in(reg) foo);
+   |                     ^^^^^^^^^^^^^^^
+
+warning: asm arguments not used in template
+  --> $DIR/bad-template.rs:25:18
+   |
+LL |         asm!("", in(reg) 0, in(reg) 1);
+   |                  ^^^^^^^^^  ^^^^^^^^^
+
+error: aborting due to 7 previous errors; 4 warnings emitted
 

--- a/src/test/ui/asm/bad-template.stderr
+++ b/src/test/ui/asm/bad-template.stderr
@@ -90,5 +90,11 @@ warning: asm arguments not used in template
 LL |         asm!("", in(reg) 0, in(reg) 1);
    |                  ^^^^^^^^^  ^^^^^^^^^
 
-error: aborting due to 7 previous errors; 4 warnings emitted
+warning: asm arguments not used in template
+  --> $DIR/bad-template.rs:28:18
+   |
+LL |         asm!("", in(reg) 0, in(reg) 1);
+   |                  ^^^^^^^^^  ^^^^^^^^^
+
+error: aborting due to 7 previous errors; 5 warnings emitted
 

--- a/src/test/ui/asm/parse-error.rs
+++ b/src/test/ui/asm/parse-error.rs
@@ -43,7 +43,7 @@ fn main() {
         //~^ ERROR arguments are not allowed after options
         asm!("{a}", a = const foo, a = const bar);
         //~^ ERROR duplicate argument named `a`
-        //~^^ ERROR argument never used
+        //~^^ WARN asm argument not used in template
         asm!("", a = in("eax") foo);
         //~^ ERROR explicit register arguments cannot have names
         asm!("{a}", in("eax") foo, a = const bar);

--- a/src/test/ui/asm/parse-error.stderr
+++ b/src/test/ui/asm/parse-error.stderr
@@ -122,12 +122,6 @@ LL |         asm!("{a}", a = const foo, a = const bar);
    |                     |
    |                     previously here
 
-error: argument never used
-  --> $DIR/parse-error.rs:44:36
-   |
-LL |         asm!("{a}", a = const foo, a = const bar);
-   |                                    ^^^^^^^^^^^^^ argument never used
-
 error: explicit register arguments cannot have names
   --> $DIR/parse-error.rs:47:18
    |
@@ -158,5 +152,13 @@ LL |         asm!("{1}", in("eax") foo, const bar);
    |                     |
    |                     explicit register argument
 
-error: aborting due to 24 previous errors
+warning: asm argument not used in template
+  --> $DIR/parse-error.rs:44:36
+   |
+LL |         asm!("{a}", a = const foo, a = const bar);
+   |                                    ^^^^^^^^^^^^^
+   |
+   = note: `#[warn(unused_asm_arguments)]` on by default
+
+error: aborting due to 23 previous errors; 1 warning emitted
 


### PR DESCRIPTION
This PR changes the "unused arguments" error for `asm!` to a warn-by-default lint.

Fixes #72965