### PR TITLE
Rollup of 9 pull requests

### DIFF
--- a/src/libcore/time.rs
+++ b/src/libcore/time.rs
@@ -152,7 +152,6 @@ impl Duration {
     /// ```
     #[stable(feature = "duration", since = "1.3.0")]
     #[inline]
-    #[rustc_promotable]
     #[rustc_const_stable(feature = "duration_consts", since = "1.32.0")]
     pub const fn from_secs(secs: u64) -> Duration {
         Duration { secs, nanos: 0 }

--- a/src/librustc_expand/expand.rs
+++ b/src/librustc_expand/expand.rs
@@ -1789,6 +1789,7 @@ pub struct ExpansionConfig<'feat> {
     pub trace_mac: bool,
     pub should_test: bool, // If false, strip `#[test]` nodes
     pub keep_macs: bool,
+    pub span_debug: bool, // If true, use verbose debugging for `proc_macro::Span`
 }
 
 impl<'feat> ExpansionConfig<'feat> {
@@ -1800,6 +1801,7 @@ impl<'feat> ExpansionConfig<'feat> {
             trace_mac: false,
             should_test: false,
             keep_macs: false,
+            span_debug: false,
         }
     }
 

--- a/src/librustc_expand/proc_macro_server.rs
+++ b/src/librustc_expand/proc_macro_server.rs
@@ -352,6 +352,7 @@ pub(crate) struct Rustc<'a> {
     def_site: Span,
     call_site: Span,
     mixed_site: Span,
+    span_debug: bool,
 }
 
 impl<'a> Rustc<'a> {
@@ -362,6 +363,7 @@ impl<'a> Rustc<'a> {
             def_site: cx.with_def_site_ctxt(expn_data.def_site),
             call_site: cx.with_call_site_ctxt(expn_data.call_site),
             mixed_site: cx.with_mixed_site_ctxt(expn_data.call_site),
+            span_debug: cx.ecfg.span_debug,
         }
     }
 
@@ -646,7 +648,11 @@ impl server::Diagnostic for Rustc<'_> {
 
 impl server::Span for Rustc<'_> {
     fn debug(&mut self, span: Self::Span) -> String {
-        format!("{:?} bytes({}..{})", span.ctxt(), span.lo().0, span.hi().0)
+        if self.span_debug {
+            format!("{:?}", span)
+        } else {
+            format!("{:?} bytes({}..{})", span.ctxt(), span.lo().0, span.hi().0)
+        }
     }
     fn def_site(&mut self) -> Self::Span {
         self.def_site

--- a/src/librustc_interface/passes.rs
+++ b/src/librustc_interface/passes.rs
@@ -291,6 +291,7 @@ fn configure_and_expand_inner<'a>(
             recursion_limit: sess.recursion_limit(),
             trace_mac: sess.opts.debugging_opts.trace_macros,
             should_test: sess.opts.test,
+            span_debug: sess.opts.debugging_opts.span_debug,
             ..rustc_expand::expand::ExpansionConfig::default(crate_name.to_string())
         };
 

--- a/src/librustc_interface/tests.rs
+++ b/src/librustc_interface/tests.rs
@@ -506,6 +506,7 @@ fn test_debugging_options_tracking_hash() {
     untracked!(save_analysis, true);
     untracked!(self_profile, SwitchWithOptPath::Enabled(None));
     untracked!(self_profile_events, Some(vec![String::new()]));
+    untracked!(span_debug, true);
     untracked!(span_free_formats, true);
     untracked!(strip, Strip::None);
     untracked!(terminal_width, Some(80));

--- a/src/librustc_middle/ty/sty.rs
+++ b/src/librustc_middle/ty/sty.rs
@@ -724,10 +724,6 @@ impl<'tcx> Binder<&'tcx List<ExistentialPredicate<'tcx>>> {
 ///
 /// Trait references also appear in object types like `Foo<U>`, but in
 /// that case the `Self` parameter is absent from the substitutions.
-///
-/// Note that a `TraitRef` introduces a level of region binding, to
-/// account for higher-ranked trait bounds like `T: for<'a> Foo<&'a U>`
-/// or higher-ranked object types.
 #[derive(Copy, Clone, PartialEq, Eq, Hash, RustcEncodable, RustcDecodable)]
 #[derive(HashStable, TypeFoldable)]
 pub struct TraitRef<'tcx> {

--- a/src/librustc_middle/ty/sty.rs
+++ b/src/librustc_middle/ty/sty.rs
@@ -765,8 +765,8 @@ impl<'tcx> TraitRef<'tcx> {
 pub type PolyTraitRef<'tcx> = Binder<TraitRef<'tcx>>;
 
 impl<'tcx> PolyTraitRef<'tcx> {
-    pub fn self_ty(&self) -> Ty<'tcx> {
-        self.skip_binder().self_ty()
+    pub fn self_ty(&self) -> Binder<Ty<'tcx>> {
+        self.map_bound_ref(|tr| tr.self_ty())
     }
 
     pub fn def_id(&self) -> DefId {

--- a/src/librustc_mir/transform/generator.rs
+++ b/src/librustc_mir/transform/generator.rs
@@ -669,6 +669,51 @@ fn compute_storage_conflicts(
     storage_conflicts
 }
 
+/// Validates the typeck view of the generator against the actual set of types retained between
+/// yield points.
+fn sanitize_witness<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    body: &Body<'tcx>,
+    did: DefId,
+    witness: Ty<'tcx>,
+    upvars: &Vec<Ty<'tcx>>,
+    retained: &BitSet<Local>,
+) {
+    let allowed_upvars = tcx.erase_regions(upvars);
+    let allowed = match witness.kind {
+        ty::GeneratorWitness(s) => tcx.erase_late_bound_regions(&s),
+        _ => {
+            tcx.sess.delay_span_bug(
+                body.span,
+                &format!("unexpected generator witness type {:?}", witness.kind),
+            );
+            return;
+        }
+    };
+
+    let param_env = tcx.param_env(did);
+
+    for (local, decl) in body.local_decls.iter_enumerated() {
+        // Ignore locals which are internal or not retained between yields.
+        if !retained.contains(local) || decl.internal {
+            continue;
+        }
+        let decl_ty = tcx.normalize_erasing_regions(param_env, decl.ty);
+
+        // Sanity check that typeck knows about the type of locals which are
+        // live across a suspension point
+        if !allowed.contains(&decl_ty) && !allowed_upvars.contains(&decl_ty) {
+            span_bug!(
+                body.span,
+                "Broken MIR: generator contains type {} in MIR, \
+                       but typeck only knows about {}",
+                decl.ty,
+                witness,
+            );
+        }
+    }
+}
+
 fn compute_layout<'tcx>(
     tcx: TyCtxt<'tcx>,
     source: MirSource<'tcx>,
@@ -690,35 +735,7 @@ fn compute_layout<'tcx>(
         storage_liveness,
     } = locals_live_across_suspend_points(tcx, body, source, always_live_locals, movable);
 
-    // Erase regions from the types passed in from typeck so we can compare them with
-    // MIR types
-    let allowed_upvars = tcx.erase_regions(upvars);
-    let allowed = match interior.kind {
-        ty::GeneratorWitness(s) => tcx.erase_late_bound_regions(&s),
-        _ => bug!(),
-    };
-
-    let param_env = tcx.param_env(source.def_id());
-
-    for (local, decl) in body.local_decls.iter_enumerated() {
-        // Ignore locals which are internal or not live
-        if !live_locals.contains(local) || decl.internal {
-            continue;
-        }
-        let decl_ty = tcx.normalize_erasing_regions(param_env, decl.ty);
-
-        // Sanity check that typeck knows about the type of locals which are
-        // live across a suspension point
-        if !allowed.contains(&decl_ty) && !allowed_upvars.contains(&decl_ty) {
-            span_bug!(
-                body.span,
-                "Broken MIR: generator contains type {} in MIR, \
-                       but typeck only knows about {}",
-                decl.ty,
-                interior
-            );
-        }
-    }
+    sanitize_witness(tcx, body, source.def_id(), interior, upvars, &live_locals);
 
     // Gather live local types and their indices.
     let mut locals = IndexVec::<GeneratorSavedLocal, _>::new();

--- a/src/librustc_session/options.rs
+++ b/src/librustc_session/options.rs
@@ -996,6 +996,8 @@ options! {DebuggingOptions, DebuggingSetter, basic_debugging_options,
         "make the current crate share its generic instantiations"),
     show_span: Option<String> = (None, parse_opt_string, [TRACKED],
         "show spans for compiler debugging (expr|pat|ty)"),
+    span_debug: bool = (false, parse_bool, [UNTRACKED],
+        "forward proc_macro::Span's `Debug` impl to `Span`"),
     // o/w tests have closure@path
     span_free_formats: bool = (false, parse_bool, [UNTRACKED],
         "exclude spans when debug-printing compiler state (default: no)"),

--- a/src/librustc_target/spec/tests/tests_impl.rs
+++ b/src/librustc_target/spec/tests/tests_impl.rs
@@ -39,5 +39,10 @@ impl Target {
                 assert_eq!(self.options.lld_flavor, LldFlavor::Link);
             }
         }
+        assert!(
+            (self.options.pre_link_objects_fallback.is_empty()
+                && self.options.post_link_objects_fallback.is_empty())
+                || self.options.crt_objects_fallback.is_some()
+        );
     }
 }

--- a/src/librustc_trait_selection/traits/error_reporting/mod.rs
+++ b/src/librustc_trait_selection/traits/error_reporting/mod.rs
@@ -289,7 +289,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                             (
                                 Some(format!(
                                     "`?` couldn't convert the error to `{}`",
-                                    trait_ref.self_ty(),
+                                    trait_ref.skip_binder().self_ty(),
                                 )),
                                 Some(
                                     "the question mark operation (`?`) implicitly performs a \
@@ -339,7 +339,10 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                             if let Some(ret_span) = self.return_type_span(obligation) {
                                 err.span_label(
                                     ret_span,
-                                    &format!("expected `{}` because of this", trait_ref.self_ty()),
+                                    &format!(
+                                        "expected `{}` because of this",
+                                        trait_ref.skip_binder().self_ty()
+                                    ),
                                 );
                             }
                         }
@@ -352,7 +355,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                                     "{}the trait `{}` is not implemented for `{}`",
                                     pre_message,
                                     trait_ref.print_only_trait_path(),
-                                    trait_ref.self_ty(),
+                                    trait_ref.skip_binder().self_ty(),
                                 )
                             };
 
@@ -642,7 +645,10 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                     return;
                 }
 
-                let found_trait_ty = found_trait_ref.self_ty();
+                let found_trait_ty = match found_trait_ref.self_ty().no_bound_vars() {
+                    Some(ty) => ty,
+                    None => return,
+                };
 
                 let found_did = match found_trait_ty.kind {
                     ty::Closure(did, _) | ty::Foreign(did) | ty::FnDef(did, _) => Some(did),
@@ -1359,11 +1365,15 @@ impl<'a, 'tcx> InferCtxtPrivExt<'tcx> for InferCtxt<'a, 'tcx> {
     ) {
         let get_trait_impl = |trait_def_id| {
             let mut trait_impl = None;
-            self.tcx.for_each_relevant_impl(trait_def_id, trait_ref.self_ty(), |impl_def_id| {
-                if trait_impl.is_none() {
-                    trait_impl = Some(impl_def_id);
-                }
-            });
+            self.tcx.for_each_relevant_impl(
+                trait_def_id,
+                trait_ref.skip_binder().self_ty(),
+                |impl_def_id| {
+                    if trait_impl.is_none() {
+                        trait_impl = Some(impl_def_id);
+                    }
+                },
+            );
             trait_impl
         };
         let required_trait_path = self.tcx.def_path_str(trait_ref.def_id());
@@ -1434,7 +1444,7 @@ impl<'a, 'tcx> InferCtxtPrivExt<'tcx> for InferCtxt<'a, 'tcx> {
         let mut err = match predicate.kind() {
             ty::PredicateKind::Trait(ref data, _) => {
                 let trait_ref = data.to_poly_trait_ref();
-                let self_ty = trait_ref.self_ty();
+                let self_ty = trait_ref.skip_binder().self_ty();
                 debug!("self_ty {:?} {:?} trait_ref {:?}", self_ty, self_ty.kind, trait_ref);
 
                 if predicate.references_error() {
@@ -1552,7 +1562,7 @@ impl<'a, 'tcx> InferCtxtPrivExt<'tcx> for InferCtxt<'a, 'tcx> {
             }
             ty::PredicateKind::Projection(ref data) => {
                 let trait_ref = data.to_poly_trait_ref(self.tcx);
-                let self_ty = trait_ref.self_ty();
+                let self_ty = trait_ref.skip_binder().self_ty();
                 let ty = data.skip_binder().ty;
                 if predicate.references_error() {
                     return;

--- a/src/librustc_trait_selection/traits/error_reporting/suggestions.rs
+++ b/src/librustc_trait_selection/traits/error_reporting/suggestions.rs
@@ -318,7 +318,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
         trait_ref: ty::PolyTraitRef<'tcx>,
         body_id: hir::HirId,
     ) {
-        let self_ty = trait_ref.self_ty();
+        let self_ty = trait_ref.skip_binder().self_ty();
         let (param_ty, projection) = match &self_ty.kind {
             ty::Param(_) => (true, None),
             ty::Projection(projection) => (false, Some(projection)),
@@ -524,7 +524,11 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
         trait_ref: &ty::Binder<ty::TraitRef<'tcx>>,
         points_at_arg: bool,
     ) {
-        let self_ty = trait_ref.self_ty();
+        let self_ty = match trait_ref.self_ty().no_bound_vars() {
+            None => return,
+            Some(ty) => ty,
+        };
+
         let (def_id, output_ty, callable) = match self_ty.kind {
             ty::Closure(def_id, substs) => (def_id, substs.as_closure().sig().output(), "closure"),
             ty::FnDef(def_id, _) => (def_id, self_ty.fn_sig(self.tcx).output(), "function"),
@@ -707,7 +711,10 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                 return;
             }
 
-            let mut suggested_ty = trait_ref.self_ty();
+            let mut suggested_ty = match trait_ref.self_ty().no_bound_vars() {
+                Some(ty) => ty,
+                None => return,
+            };
 
             for refs_remaining in 0..refs_number {
                 if let ty::Ref(_, inner_ty, _) = suggested_ty.kind {
@@ -829,6 +836,9 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
         span: Span,
         trait_ref: &ty::Binder<ty::TraitRef<'tcx>>,
     ) {
+        let is_empty_tuple =
+            |ty: ty::Binder<Ty<'_>>| ty.skip_binder().kind == ty::Tuple(ty::List::empty());
+
         let hir = self.tcx.hir();
         let parent_node = hir.get_parent_node(obligation.cause.body_id);
         let node = hir.find(parent_node);
@@ -840,7 +850,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
             if let hir::ExprKind::Block(blk, _) = &body.value.kind {
                 if sig.decl.output.span().overlaps(span)
                     && blk.expr.is_none()
-                    && "()" == &trait_ref.self_ty().to_string()
+                    && is_empty_tuple(trait_ref.self_ty())
                 {
                     // FIXME(estebank): When encountering a method with a trait
                     // bound not satisfied in the return type with a body that has
@@ -1271,7 +1281,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                 ObligationCauseCode::DerivedObligation(derived_obligation)
                 | ObligationCauseCode::BuiltinDerivedObligation(derived_obligation)
                 | ObligationCauseCode::ImplDerivedObligation(derived_obligation) => {
-                    let ty = derived_obligation.parent_trait_ref.self_ty();
+                    let ty = derived_obligation.parent_trait_ref.skip_binder().self_ty();
                     debug!(
                         "maybe_note_obligation_cause_for_async_await: \
                             parent_trait_ref={:?} self_ty.kind={:?}",
@@ -1911,7 +1921,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
 
                 let impls_future = self.tcx.type_implements_trait((
                     future_trait,
-                    self_ty,
+                    self_ty.skip_binder(),
                     ty::List::empty(),
                     obligation.param_env,
                 ));
@@ -1927,7 +1937,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                 let projection_ty = ty::ProjectionTy {
                     // `T`
                     substs: self.tcx.mk_substs_trait(
-                        trait_ref.self_ty(),
+                        trait_ref.self_ty().skip_binder(),
                         self.fresh_substs_for_item(span, item_def_id),
                     ),
                     // `Future::Output`

--- a/src/librustc_trait_selection/traits/specialize/mod.rs
+++ b/src/librustc_trait_selection/traits/specialize/mod.rs
@@ -496,7 +496,7 @@ fn to_pretty_impl_header(tcx: TyCtxt<'_>, impl_def_id: DefId) -> Option<String> 
     for (p, _) in predicates {
         if let Some(poly_trait_ref) = p.to_opt_poly_trait_ref() {
             if Some(poly_trait_ref.def_id()) == sized_trait {
-                types_without_default_bounds.remove(poly_trait_ref.self_ty());
+                types_without_default_bounds.remove(poly_trait_ref.self_ty().skip_binder());
                 continue;
             }
         }

--- a/src/librustc_ty/needs_drop.rs
+++ b/src/librustc_ty/needs_drop.rs
@@ -98,7 +98,7 @@ where
                         }
                     }
 
-                    ty::Generator(_, substs, _) => {
+                    ty::Generator(def_id, substs, _) => {
                         let substs = substs.as_generator();
                         for upvar_ty in substs.upvar_tys() {
                             queue_type(self, upvar_ty);
@@ -107,7 +107,13 @@ where
                         let witness = substs.witness();
                         let interior_tys = match &witness.kind {
                             ty::GeneratorWitness(tys) => tcx.erase_late_bound_regions(tys),
-                            _ => bug!(),
+                            _ => {
+                                tcx.sess.delay_span_bug(
+                                    tcx.hir().span_if_local(def_id).unwrap_or(DUMMY_SP),
+                                    &format!("unexpected generator witness type {:?}", witness),
+                                );
+                                return Some(Err(AlwaysRequiresDrop));
+                            }
                         };
 
                         for interior_ty in interior_tys {

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -3812,7 +3812,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         trait_ref: ty::PolyTraitRef<'tcx>,
         expected_vid: ty::TyVid,
     ) -> bool {
-        let self_ty = self.shallow_resolve(trait_ref.self_ty());
+        let self_ty = self.shallow_resolve(trait_ref.skip_binder().self_ty());
         debug!(
             "self_type_matches_expected_vid(trait_ref={:?}, self_ty={:?}, expected_vid={:?})",
             trait_ref, self_ty, expected_vid

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -500,7 +500,7 @@ impl<'a> Clean<WherePredicate> for ty::PolyTraitPredicate<'a> {
     fn clean(&self, cx: &DocContext<'_>) -> WherePredicate {
         let poly_trait_ref = self.map_bound(|pred| pred.trait_ref);
         WherePredicate::BoundPredicate {
-            ty: poly_trait_ref.self_ty().clean(cx),
+            ty: poly_trait_ref.skip_binder().self_ty().clean(cx),
             bounds: vec![poly_trait_ref.clean(cx)],
         }
     }
@@ -755,7 +755,7 @@ impl<'a, 'tcx> Clean<Generics> for (&'a ty::Generics, ty::GenericPredicates<'tcx
                 let mut projection = None;
                 let param_idx = (|| {
                     if let Some(trait_ref) = p.to_opt_poly_trait_ref() {
-                        if let ty::Param(param) = trait_ref.self_ty().kind {
+                        if let ty::Param(param) = trait_ref.skip_binder().self_ty().kind {
                             return Some(param.index);
                         }
                     } else if let Some(outlives) = p.to_opt_type_outlives() {

--- a/src/libstd/net/addr.rs
+++ b/src/libstd/net/addr.rs
@@ -1000,6 +1000,14 @@ impl ToSocketAddrs for (&str, u16) {
     }
 }
 
+#[stable(feature = "string_u16_to_socket_addrs", since = "1.46.0")]
+impl ToSocketAddrs for (String, u16) {
+    type Iter = vec::IntoIter<SocketAddr>;
+    fn to_socket_addrs(&self) -> io::Result<vec::IntoIter<SocketAddr>> {
+        (&*self.0, self.1).to_socket_addrs()
+    }
+}
+
 // accepts strings like 'localhost:12345'
 #[stable(feature = "rust1", since = "1.0.0")]
 impl ToSocketAddrs for str {

--- a/src/test/codegen/abi-main-signature-16bit-c-int.rs
+++ b/src/test/codegen/abi-main-signature-16bit-c-int.rs
@@ -10,6 +10,7 @@
 // ignore-mips64
 // ignore-powerpc
 // ignore-powerpc64
+// ignore-riscv64
 // ignore-s390x
 // ignore-sparc
 // ignore-sparc64

--- a/src/test/codegen/abi-sysv64.rs
+++ b/src/test/codegen/abi-sysv64.rs
@@ -4,6 +4,7 @@
 
 // ignore-arm
 // ignore-aarch64
+// ignore-riscv64 sysv64 not supported
 
 // compile-flags: -C no-prepopulate-passes
 

--- a/src/test/codegen/abi-x86-interrupt.rs
+++ b/src/test/codegen/abi-x86-interrupt.rs
@@ -4,6 +4,7 @@
 
 // ignore-arm
 // ignore-aarch64
+// ignore-riscv64 x86-interrupt is not supported
 
 // compile-flags: -C no-prepopulate-passes
 

--- a/src/test/codegen/catch-unwind.rs
+++ b/src/test/codegen/catch-unwind.rs
@@ -1,5 +1,14 @@
 // compile-flags: -O
 
+// On x86 the closure is inlined in foo() producting something like
+// define i32 @foo() [...] {
+// tail call void @bar() [...]
+// ret i32 0
+// }
+// On riscv the closure is another function, placed before fn foo so CHECK can't
+// find it
+// ignore-riscv64 FIXME
+
 #![crate_type = "lib"]
 
 extern "C" {

--- a/src/test/codegen/fastcall-inreg.rs
+++ b/src/test/codegen/fastcall-inreg.rs
@@ -17,6 +17,7 @@
 // ignore-powerpc64le
 // ignore-powerpc
 // ignore-r600
+// ignore-riscv64
 // ignore-amdgcn
 // ignore-sparc
 // ignore-sparc64

--- a/src/test/codegen/repr-transparent-aggregates-1.rs
+++ b/src/test/codegen/repr-transparent-aggregates-1.rs
@@ -7,6 +7,7 @@
 // ignore-mips64
 // ignore-powerpc
 // ignore-powerpc64
+// ignore-riscv64 see codegen/riscv-abi
 // ignore-windows
 // See repr-transparent.rs
 

--- a/src/test/codegen/repr-transparent-aggregates-2.rs
+++ b/src/test/codegen/repr-transparent-aggregates-2.rs
@@ -6,6 +6,7 @@
 // ignore-powerpc
 // ignore-powerpc64
 // ignore-powerpc64le
+// ignore-riscv64 see codegen/riscv-abi
 // ignore-s390x
 // ignore-sparc
 // ignore-sparc64

--- a/src/test/codegen/repr-transparent.rs
+++ b/src/test/codegen/repr-transparent.rs
@@ -1,5 +1,8 @@
 // compile-flags: -C no-prepopulate-passes
 
+// ignore-riscv64 riscv64 has an i128 type used with test_Vector
+// see codegen/riscv-abi for riscv functiona call tests
+
 #![crate_type="lib"]
 #![feature(repr_simd, transparent_unions)]
 

--- a/src/test/codegen/riscv-abi/call-llvm-intrinsics.rs
+++ b/src/test/codegen/riscv-abi/call-llvm-intrinsics.rs
@@ -1,6 +1,6 @@
 // compile-flags: -C no-prepopulate-passes
 
-// ignore-riscv64
+// only-riscv64
 
 #![feature(link_llvm_intrinsics)]
 #![crate_type = "lib"]
@@ -23,7 +23,8 @@ pub fn do_call() {
 
     unsafe {
         // Ensure that we `call` LLVM intrinsics instead of trying to `invoke` them
-        // CHECK: call float @llvm.sqrt.f32(float 4.000000e+00
+        // CHECK: store float 4.000000e+00, float* %{{.}}, align 4
+        // CHECK: call float @llvm.sqrt.f32(float %{{.}}
         sqrt(4.0);
     }
 }

--- a/src/test/codegen/riscv-abi/riscv64-lp64-lp64f-lp64d-abi.rs
+++ b/src/test/codegen/riscv-abi/riscv64-lp64-lp64f-lp64d-abi.rs
@@ -39,12 +39,12 @@ pub extern "C" fn f_scalar_4(x: i64) -> i64 {
     x
 }
 
-// CHECK: define float @f_fp_scalar_1(float)
+// CHECK: define float @f_fp_scalar_1(float %0)
 #[no_mangle]
 pub extern "C" fn f_fp_scalar_1(x: f32) -> f32 {
     x
 }
-// CHECK: define double @f_fp_scalar_2(double)
+// CHECK: define double @f_fp_scalar_2(double %0)
 #[no_mangle]
 pub extern "C" fn f_fp_scalar_2(x: f64) -> f64 {
     x
@@ -67,7 +67,7 @@ pub struct Tiny {
     d: u16,
 }
 
-// CHECK: define void @f_agg_tiny(i64)
+// CHECK: define void @f_agg_tiny(i64 %0)
 #[no_mangle]
 pub extern "C" fn f_agg_tiny(mut e: Tiny) {
     e.a += e.b;
@@ -86,7 +86,7 @@ pub struct Small {
     b: *mut i64,
 }
 
-// CHECK: define void @f_agg_small([2 x i64])
+// CHECK: define void @f_agg_small([2 x i64] %0)
 #[no_mangle]
 pub extern "C" fn f_agg_small(mut x: Small) {
     x.a += unsafe { *x.b };
@@ -104,7 +104,7 @@ pub struct SmallAligned {
     a: i128,
 }
 
-// CHECK: define void @f_agg_small_aligned(i128)
+// CHECK: define void @f_agg_small_aligned(i128 %0)
 #[no_mangle]
 pub extern "C" fn f_agg_small_aligned(mut x: SmallAligned) {
     x.a += x.a;
@@ -130,7 +130,7 @@ pub extern "C" fn f_agg_large_ret(i: i32, j: i8) -> Large {
     Large { a: 1, b: 2, c: 3, d: 4 }
 }
 
-// CHECK: define void @f_scalar_stack_1(i64, [2 x i64], i128, %Large* {{.*}}%d, i8 zeroext %e, i8 signext %f, i8 %g, i8 %h)
+// CHECK: define void @f_scalar_stack_1(i64 %0, [2 x i64] %1, i128 %2, %Large* {{.*}}%d, i8 zeroext %e, i8 signext %f, i8 %g, i8 %h)
 #[no_mangle]
 pub extern "C" fn f_scalar_stack_1(
     a: Tiny,
@@ -144,7 +144,7 @@ pub extern "C" fn f_scalar_stack_1(
 ) {
 }
 
-// CHECK: define void @f_scalar_stack_2(%Large* {{.*}}sret{{.*}}, i64 %a, i128, i128, i64 %d, i8 zeroext %e, i8 %f, i8 %g)
+// CHECK: define void @f_scalar_stack_2(%Large* {{.*}}sret{{.*}} %0, i64 %a, i128 %1, i128 %2, i64 %d, i8 zeroext %e, i8 %f, i8 %g)
 #[no_mangle]
 pub extern "C" fn f_scalar_stack_2(
     a: u64,

--- a/src/test/codegen/riscv-abi/riscv64-lp64d-abi.rs
+++ b/src/test/codegen/riscv-abi/riscv64-lp64d-abi.rs
@@ -4,7 +4,7 @@
 // only-linux
 #![crate_type = "lib"]
 
-// CHECK: define void @f_fpr_tracking(double, double, double, double, double, double, double, double, i8 zeroext %i)
+// CHECK: define void @f_fpr_tracking(double %0, double %1, double %2, double %3, double %4, double %5, double %6, double %7, i8 zeroext %i)
 #[no_mangle]
 pub extern "C" fn f_fpr_tracking(
     a: f64,
@@ -36,7 +36,7 @@ pub struct DoubleFloat {
     g: f32,
 }
 
-// CHECK: define void @f_double_s_arg(double)
+// CHECK: define void @f_double_s_arg(double %0)
 #[no_mangle]
 pub extern "C" fn f_double_s_arg(a: Double) {}
 
@@ -46,7 +46,7 @@ pub extern "C" fn f_ret_double_s() -> Double {
     Double { f: 1. }
 }
 
-// CHECK: define void @f_double_double_s_arg({ double, double })
+// CHECK: define void @f_double_double_s_arg({ double, double } %0)
 #[no_mangle]
 pub extern "C" fn f_double_double_s_arg(a: DoubleDouble) {}
 
@@ -56,7 +56,7 @@ pub extern "C" fn f_ret_double_double_s() -> DoubleDouble {
     DoubleDouble { f: 1., g: 2. }
 }
 
-// CHECK: define void @f_double_float_s_arg({ double, float })
+// CHECK: define void @f_double_float_s_arg({ double, float } %0)
 #[no_mangle]
 pub extern "C" fn f_double_float_s_arg(a: DoubleFloat) {}
 
@@ -66,7 +66,7 @@ pub extern "C" fn f_ret_double_float_s() -> DoubleFloat {
     DoubleFloat { f: 1., g: 2. }
 }
 
-// CHECK: define void @f_double_double_s_arg_insufficient_fprs(double, double, double, double, double, double, double, [2 x i64])
+// CHECK: define void @f_double_double_s_arg_insufficient_fprs(double %0, double %1, double %2, double %3, double %4, double %5, double %6, [2 x i64] %7)
 #[no_mangle]
 pub extern "C" fn f_double_double_s_arg_insufficient_fprs(
     a: f64,
@@ -104,7 +104,7 @@ pub struct DoubleInt64 {
     i: i64,
 }
 
-// CHECK: define void @f_double_int8_s_arg({ double, i8 })
+// CHECK: define void @f_double_int8_s_arg({ double, i8 } %0)
 #[no_mangle]
 pub extern "C" fn f_double_int8_s_arg(a: DoubleInt8) {}
 
@@ -114,7 +114,7 @@ pub extern "C" fn f_ret_double_int8_s() -> DoubleInt8 {
     DoubleInt8 { f: 1., i: 2 }
 }
 
-// CHECK: define void @f_double_int32_s_arg({ double, i32 })
+// CHECK: define void @f_double_int32_s_arg({ double, i32 } %0)
 #[no_mangle]
 pub extern "C" fn f_double_int32_s_arg(a: DoubleInt32) {}
 
@@ -124,7 +124,7 @@ pub extern "C" fn f_ret_double_int32_s() -> DoubleInt32 {
     DoubleInt32 { f: 1., i: 2 }
 }
 
-// CHECK: define void @f_double_uint8_s_arg({ double, i8 })
+// CHECK: define void @f_double_uint8_s_arg({ double, i8 } %0)
 #[no_mangle]
 pub extern "C" fn f_double_uint8_s_arg(a: DoubleUInt8) {}
 
@@ -134,7 +134,7 @@ pub extern "C" fn f_ret_double_uint8_s() -> DoubleUInt8 {
     DoubleUInt8 { f: 1., i: 2 }
 }
 
-// CHECK: define void @f_double_int64_s_arg({ double, i64 })
+// CHECK: define void @f_double_int64_s_arg({ double, i64 } %0)
 #[no_mangle]
 pub extern "C" fn f_double_int64_s_arg(a: DoubleInt64) {}
 
@@ -144,7 +144,7 @@ pub extern "C" fn f_ret_double_int64_s() -> DoubleInt64 {
     DoubleInt64 { f: 1., i: 2 }
 }
 
-// CHECK: define void @f_double_int8_s_arg_insufficient_gprs(i32 signext %a, i32 signext %b, i32 signext %c, i32 signext %d, i32 signext %e, i32 signext %f, i32 signext %g, i32 signext %h, [2 x i64])
+// CHECK: define void @f_double_int8_s_arg_insufficient_gprs(i32 signext %a, i32 signext %b, i32 signext %c, i32 signext %d, i32 signext %e, i32 signext %f, i32 signext %g, i32 signext %h, [2 x i64] %0)
 #[no_mangle]
 pub extern "C" fn f_double_int8_s_arg_insufficient_gprs(
     a: i32,
@@ -159,7 +159,7 @@ pub extern "C" fn f_double_int8_s_arg_insufficient_gprs(
 ) {
 }
 
-// CHECK: define void @f_struct_double_int8_insufficient_fprs(float, double, double, double, double, double, double, double, [2 x i64])
+// CHECK: define void @f_struct_double_int8_insufficient_fprs(float %0, double %1, double %2, double %3, double %4, double %5, double %6, double %7, [2 x i64] %8)
 #[no_mangle]
 pub extern "C" fn f_struct_double_int8_insufficient_fprs(
     a: f32,
@@ -179,7 +179,7 @@ pub struct DoubleArr1 {
     a: [f64; 1],
 }
 
-// CHECK: define void @f_doublearr1_s_arg(double)
+// CHECK: define void @f_doublearr1_s_arg(double %0)
 #[no_mangle]
 pub extern "C" fn f_doublearr1_s_arg(a: DoubleArr1) {}
 
@@ -194,7 +194,7 @@ pub struct DoubleArr2 {
     a: [f64; 2],
 }
 
-// CHECK: define void @f_doublearr2_s_arg({ double, double })
+// CHECK: define void @f_doublearr2_s_arg({ double, double } %0)
 #[no_mangle]
 pub extern "C" fn f_doublearr2_s_arg(a: DoubleArr2) {}
 
@@ -214,7 +214,7 @@ pub struct DoubleArr2Tricky1 {
     g: [Tricky1; 2],
 }
 
-// CHECK: define void @f_doublearr2_tricky1_s_arg({ double, double })
+// CHECK: define void @f_doublearr2_tricky1_s_arg({ double, double } %0)
 #[no_mangle]
 pub extern "C" fn f_doublearr2_tricky1_s_arg(a: DoubleArr2Tricky1) {}
 
@@ -233,7 +233,7 @@ pub struct DoubleArr2Tricky2 {
     g: [Tricky1; 2],
 }
 
-// CHECK: define void @f_doublearr2_tricky2_s_arg({ double, double })
+// CHECK: define void @f_doublearr2_tricky2_s_arg({ double, double } %0)
 #[no_mangle]
 pub extern "C" fn f_doublearr2_tricky2_s_arg(a: DoubleArr2Tricky2) {}
 
@@ -267,7 +267,7 @@ pub struct CharCharDouble {
     c: f64,
 }
 
-// CHECK: define void @f_char_char_double_s_arg([2 x i64])
+// CHECK: define void @f_char_char_double_s_arg([2 x i64] %0)
 #[no_mangle]
 pub extern "C" fn f_char_char_double_s_arg(a: CharCharDouble) {}
 
@@ -282,7 +282,7 @@ pub union DoubleU {
     a: f64,
 }
 
-// CHECK: define void @f_double_u_arg(i64)
+// CHECK: define void @f_double_u_arg(i64 %0)
 #[no_mangle]
 pub extern "C" fn f_double_u_arg(a: DoubleU) {}
 

--- a/src/test/codegen/riscv-abi/riscv64-lp64f-lp64d-abi.rs
+++ b/src/test/codegen/riscv-abi/riscv64-lp64f-lp64d-abi.rs
@@ -4,7 +4,7 @@
 // only-linux
 #![crate_type = "lib"]
 
-// CHECK: define void @f_fpr_tracking(float, float, float, float, float, float, float, float, i8 zeroext %i)
+// CHECK: define void @f_fpr_tracking(float %0, float %1, float %2, float %3, float %4, float %5, float %6, float %7, i8 zeroext %i)
 #[no_mangle]
 pub extern "C" fn f_fpr_tracking(
     a: f32,
@@ -30,7 +30,7 @@ pub struct FloatFloat {
     g: f32,
 }
 
-// CHECK: define void @f_float_s_arg(float)
+// CHECK: define void @f_float_s_arg(float %0)
 #[no_mangle]
 pub extern "C" fn f_float_s_arg(a: Float) {}
 
@@ -40,7 +40,7 @@ pub extern "C" fn f_ret_float_s() -> Float {
     Float { f: 1. }
 }
 
-// CHECK: define void @f_float_float_s_arg({ float, float })
+// CHECK: define void @f_float_float_s_arg({ float, float } %0)
 #[no_mangle]
 pub extern "C" fn f_float_float_s_arg(a: FloatFloat) {}
 
@@ -50,7 +50,7 @@ pub extern "C" fn f_ret_float_float_s() -> FloatFloat {
     FloatFloat { f: 1., g: 2. }
 }
 
-// CHECK: define void @f_float_float_s_arg_insufficient_fprs(float, float, float, float, float, float, float, i64)
+// CHECK: define void @f_float_float_s_arg_insufficient_fprs(float %0, float %1, float %2, float %3, float %4, float %5, float %6, i64 %7)
 #[no_mangle]
 pub extern "C" fn f_float_float_s_arg_insufficient_fprs(
     a: f32,
@@ -88,7 +88,7 @@ pub struct FloatInt64 {
     i: i64,
 }
 
-// CHECK: define void @f_float_int8_s_arg({ float, i8 })
+// CHECK: define void @f_float_int8_s_arg({ float, i8 } %0)
 #[no_mangle]
 pub extern "C" fn f_float_int8_s_arg(a: FloatInt8) {}
 
@@ -98,7 +98,7 @@ pub extern "C" fn f_ret_float_int8_s() -> FloatInt8 {
     FloatInt8 { f: 1., i: 2 }
 }
 
-// CHECK: define void @f_float_int32_s_arg({ float, i32 })
+// CHECK: define void @f_float_int32_s_arg({ float, i32 } %0)
 #[no_mangle]
 pub extern "C" fn f_float_int32_s_arg(a: FloatInt32) {}
 
@@ -108,7 +108,7 @@ pub extern "C" fn f_ret_float_int32_s() -> FloatInt32 {
     FloatInt32 { f: 1., i: 2 }
 }
 
-// CHECK: define void @f_float_uint8_s_arg({ float, i8 })
+// CHECK: define void @f_float_uint8_s_arg({ float, i8 } %0)
 #[no_mangle]
 pub extern "C" fn f_float_uint8_s_arg(a: FloatUInt8) {}
 
@@ -118,7 +118,7 @@ pub extern "C" fn f_ret_float_uint8_s() -> FloatUInt8 {
     FloatUInt8 { f: 1., i: 2 }
 }
 
-// CHECK: define void @f_float_int64_s_arg({ float, i64 })
+// CHECK: define void @f_float_int64_s_arg({ float, i64 } %0)
 #[no_mangle]
 pub extern "C" fn f_float_int64_s_arg(a: FloatInt64) {}
 
@@ -128,7 +128,7 @@ pub extern "C" fn f_ret_float_int64_s() -> FloatInt64 {
     FloatInt64 { f: 1., i: 2 }
 }
 
-// CHECK: define void @f_float_int8_s_arg_insufficient_gprs(i32 signext %a, i32 signext %b, i32 signext %c, i32 signext %d, i32 signext %e, i32 signext %f, i32 signext %g, i32 signext %h, i64)
+// CHECK: define void @f_float_int8_s_arg_insufficient_gprs(i32 signext %a, i32 signext %b, i32 signext %c, i32 signext %d, i32 signext %e, i32 signext %f, i32 signext %g, i32 signext %h, i64 %0)
 #[no_mangle]
 pub extern "C" fn f_float_int8_s_arg_insufficient_gprs(
     a: i32,
@@ -143,7 +143,7 @@ pub extern "C" fn f_float_int8_s_arg_insufficient_gprs(
 ) {
 }
 
-// CHECK: define void @f_struct_float_int8_insufficient_fprs(float, float, float, float, float, float, float, float, i64)
+// CHECK: define void @f_struct_float_int8_insufficient_fprs(float %0, float %1, float %2,  float %3, float %4, float %5, float %6, float %7, i64 %8)
 #[no_mangle]
 pub extern "C" fn f_struct_float_int8_insufficient_fprs(
     a: f32,
@@ -163,7 +163,7 @@ pub struct FloatArr1 {
     a: [f32; 1],
 }
 
-// CHECK: define void @f_floatarr1_s_arg(float)
+// CHECK: define void @f_floatarr1_s_arg(float %0)
 #[no_mangle]
 pub extern "C" fn f_floatarr1_s_arg(a: FloatArr1) {}
 
@@ -178,7 +178,7 @@ pub struct FloatArr2 {
     a: [f32; 2],
 }
 
-// CHECK: define void @f_floatarr2_s_arg({ float, float })
+// CHECK: define void @f_floatarr2_s_arg({ float, float } %0)
 #[no_mangle]
 pub extern "C" fn f_floatarr2_s_arg(a: FloatArr2) {}
 
@@ -198,7 +198,7 @@ pub struct FloatArr2Tricky1 {
     g: [Tricky1; 2],
 }
 
-// CHECK: define void @f_floatarr2_tricky1_s_arg({ float, float })
+// CHECK: define void @f_floatarr2_tricky1_s_arg({ float, float } %0)
 #[no_mangle]
 pub extern "C" fn f_floatarr2_tricky1_s_arg(a: FloatArr2Tricky1) {}
 
@@ -217,7 +217,7 @@ pub struct FloatArr2Tricky2 {
     g: [Tricky1; 2],
 }
 
-// CHECK: define void @f_floatarr2_tricky2_s_arg({ float, float })
+// CHECK: define void @f_floatarr2_tricky2_s_arg({ float, float } %0)
 #[no_mangle]
 pub extern "C" fn f_floatarr2_tricky2_s_arg(a: FloatArr2Tricky2) {}
 
@@ -234,7 +234,7 @@ pub struct IntFloatInt {
     c: i32,
 }
 
-// CHECK: define void @f_int_float_int_s_arg([2 x i64])
+// CHECK: define void @f_int_float_int_s_arg([2 x i64] %0)
 #[no_mangle]
 pub extern "C" fn f_int_float_int_s_arg(a: IntFloatInt) {}
 
@@ -251,7 +251,7 @@ pub struct CharCharFloat {
     c: f32,
 }
 
-// CHECK: define void @f_char_char_float_s_arg(i64)
+// CHECK: define void @f_char_char_float_s_arg(i64 %0)
 #[no_mangle]
 pub extern "C" fn f_char_char_float_s_arg(a: CharCharFloat) {}
 
@@ -266,7 +266,7 @@ pub union FloatU {
     a: f32,
 }
 
-// CHECK: define void @f_float_u_arg(i64)
+// CHECK: define void @f_float_u_arg(i64 %0)
 #[no_mangle]
 pub extern "C" fn f_float_u_arg(a: FloatU) {}
 

--- a/src/test/codegen/stack-probes.rs
+++ b/src/test/codegen/stack-probes.rs
@@ -5,6 +5,7 @@
 // ignore-powerpc
 // ignore-powerpc64
 // ignore-powerpc64le
+// ignore-riscv64
 // ignore-s390x
 // ignore-sparc
 // ignore-sparc64

--- a/src/test/codegen/x86_mmx.rs
+++ b/src/test/codegen/x86_mmx.rs
@@ -6,6 +6,7 @@
 // ignore-powerpc
 // ignore-powerpc64
 // ignore-powerpc64le
+// ignore-riscv64
 // ignore-sparc
 // ignore-sparc64
 // ignore-s390x

--- a/src/test/run-make-fulldeps/incr-add-rust-src-component/Makefile
+++ b/src/test/run-make-fulldeps/incr-add-rust-src-component/Makefile
@@ -1,0 +1,39 @@
+-include ../tools.mk
+
+# rust-lang/rust#70924: Test that if we add rust-src component in between two
+# incremetnal compiles, the compiler does not ICE on the second.
+
+SYSROOT:=$(shell $(RUSTC) --print sysroot)
+FAKEROOT=$(TMPDIR)/fakeroot
+INCR=$(TMPDIR)/incr
+
+# Make a local copy of the sysroot; then remove the rust-src part of it, if
+# present, for the *first* build. Then put in a facsimile of the rust-src
+# component for the second build, in order to expose the ICE from issue #70924.
+#
+# Note that it is much easier to just do `cp -a $(SYSROOT)/* $(FAKEROOT)` as a
+# first step, but I am concerned that would be too expensive in a unit test
+# compared to making symbolic links.
+#
+# Anyway, the pattern you'll see here is: For every prefix in
+# root/lib/rustlib/src, link all of prefix parent content, then remove the
+# prefix, then loop on the next prefix. This way, we basically create a copy of
+# the context around root/lib/rustlib/src, and can freely add/remove the src
+# component itself.
+all:
+	mkdir $(FAKEROOT)
+	ln -s $(SYSROOT)/* $(FAKEROOT)
+	rm -f $(FAKEROOT)/lib
+	mkdir $(FAKEROOT)/lib
+	ln -s $(SYSROOT)/lib/* $(FAKEROOT)/lib
+	rm -f $(FAKEROOT)/lib/rustlib
+	mkdir $(FAKEROOT)/lib/rustlib
+	ln -s $(SYSROOT)/lib/rustlib/* $(FAKEROOT)/lib/rustlib
+	rm -f $(FAKEROOT)/lib/rustlib/src
+	mkdir $(FAKEROOT)/lib/rustlib/src
+	ln -s $(SYSROOT)/lib/rustlib/src/* $(FAKEROOT)/lib/rustlib/src
+	rm -f $(FAKEROOT)/lib/rustlib/src/rust
+	$(RUSTC) --sysroot $(FAKEROOT) -C incremental=$(INCR) main.rs
+	mkdir -p $(FAKEROOT)/lib/rustlib/src/rust/src/libstd
+	touch $(FAKEROOT)/lib/rustlib/src/rust/src/libstd/lib.rs
+	$(RUSTC) --sysroot $(FAKEROOT) -C incremental=$(INCR) main.rs

--- a/src/test/run-make-fulldeps/incr-add-rust-src-component/Makefile
+++ b/src/test/run-make-fulldeps/incr-add-rust-src-component/Makefile
@@ -3,6 +3,11 @@
 # rust-lang/rust#70924: Test that if we add rust-src component in between two
 # incremetnal compiles, the compiler does not ICE on the second.
 
+# This test uses `ln -s` rather than copying to save testing time, but its
+# usage doesn't work on windows. So ignore windows.
+
+# ignore-windows
+
 SYSROOT:=$(shell $(RUSTC) --print sysroot)
 FAKEROOT=$(TMPDIR)/fakeroot
 INCR=$(TMPDIR)/incr

--- a/src/test/run-make-fulldeps/incr-add-rust-src-component/main.rs
+++ b/src/test/run-make-fulldeps/incr-add-rust-src-component/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello World");
+}

--- a/src/test/ui/proc-macro/debug/dump-debug-span-debug.rs
+++ b/src/test/ui/proc-macro/debug/dump-debug-span-debug.rs
@@ -1,0 +1,41 @@
+// run-pass
+// aux-build:macro-dump-debug.rs
+// compile-flags: -Z span-debug
+
+extern crate macro_dump_debug;
+use macro_dump_debug::dump_debug;
+
+dump_debug! {
+    ident   // ident
+    r#ident // raw ident
+    ,       // alone punct
+    ==>     // joint punct
+    ()      // empty group
+    [_]     // nonempty group
+
+    // unsuffixed literals
+    0
+    1.0
+    "S"
+    b"B"
+    r"R"
+    r##"R"##
+    br"BR"
+    br##"BR"##
+    'C'
+    b'B'
+
+    // suffixed literals
+    0q
+    1.0q
+    "S"q
+    b"B"q
+    r"R"q
+    r##"R"##q
+    br"BR"q
+    br##"BR"##q
+    'C'q
+    b'B'q
+}
+
+fn main() {}

--- a/src/test/ui/proc-macro/debug/dump-debug-span-debug.stderr
+++ b/src/test/ui/proc-macro/debug/dump-debug-span-debug.stderr
@@ -1,0 +1,166 @@
+TokenStream [Ident { ident: "ident", span: $DIR/dump-debug-span-debug.rs:9:5: 9:10 }, Ident { ident: "r#ident", span: $DIR/dump-debug-span-debug.rs:10:5: 10:12 }, Punct { ch: ',', spacing: Alone, span: $DIR/dump-debug-span-debug.rs:11:5: 11:6 }, Punct { ch: '=', spacing: Joint, span: $DIR/dump-debug-span-debug.rs:12:5: 12:7 }, Punct { ch: '=', spacing: Joint, span: $DIR/dump-debug-span-debug.rs:12:5: 12:7 }, Punct { ch: '>', spacing: Alone, span: $DIR/dump-debug-span-debug.rs:12:7: 12:8 }, Group { delimiter: Parenthesis, stream: TokenStream [], span: $DIR/dump-debug-span-debug.rs:13:5: 13:7 }, Group { delimiter: Bracket, stream: TokenStream [Ident { ident: "_", span: $DIR/dump-debug-span-debug.rs:14:6: 14:7 }], span: $DIR/dump-debug-span-debug.rs:14:5: 14:8 }, Literal { kind: Integer, symbol: "0", suffix: None, span: $DIR/dump-debug-span-debug.rs:17:5: 17:6 }, Literal { kind: Float, symbol: "1.0", suffix: None, span: $DIR/dump-debug-span-debug.rs:18:5: 18:8 }, Literal { kind: Str, symbol: "S", suffix: None, span: $DIR/dump-debug-span-debug.rs:19:5: 19:8 }, Literal { kind: ByteStr, symbol: "B", suffix: None, span: $DIR/dump-debug-span-debug.rs:20:5: 20:9 }, Literal { kind: StrRaw(0), symbol: "R", suffix: None, span: $DIR/dump-debug-span-debug.rs:21:5: 21:9 }, Literal { kind: StrRaw(2), symbol: "R", suffix: None, span: $DIR/dump-debug-span-debug.rs:22:5: 22:13 }, Literal { kind: ByteStrRaw(0), symbol: "BR", suffix: None, span: $DIR/dump-debug-span-debug.rs:23:5: 23:11 }, Literal { kind: ByteStrRaw(2), symbol: "BR", suffix: None, span: $DIR/dump-debug-span-debug.rs:24:5: 24:15 }, Literal { kind: Char, symbol: "C", suffix: None, span: $DIR/dump-debug-span-debug.rs:25:5: 25:8 }, Literal { kind: Byte, symbol: "B", suffix: None, span: $DIR/dump-debug-span-debug.rs:26:5: 26:9 }, Literal { kind: Integer, symbol: "0", suffix: Some("q"), span: $DIR/dump-debug-span-debug.rs:29:5: 29:7 }, Literal { kind: Float, symbol: "1.0", suffix: Some("q"), span: $DIR/dump-debug-span-debug.rs:30:5: 30:9 }, Literal { kind: Str, symbol: "S", suffix: Some("q"), span: $DIR/dump-debug-span-debug.rs:31:5: 31:9 }, Literal { kind: ByteStr, symbol: "B", suffix: Some("q"), span: $DIR/dump-debug-span-debug.rs:32:5: 32:10 }, Literal { kind: StrRaw(0), symbol: "R", suffix: Some("q"), span: $DIR/dump-debug-span-debug.rs:33:5: 33:10 }, Literal { kind: StrRaw(2), symbol: "R", suffix: Some("q"), span: $DIR/dump-debug-span-debug.rs:34:5: 34:14 }, Literal { kind: ByteStrRaw(0), symbol: "BR", suffix: Some("q"), span: $DIR/dump-debug-span-debug.rs:35:5: 35:12 }, Literal { kind: ByteStrRaw(2), symbol: "BR", suffix: Some("q"), span: $DIR/dump-debug-span-debug.rs:36:5: 36:16 }, Literal { kind: Char, symbol: "C", suffix: Some("q"), span: $DIR/dump-debug-span-debug.rs:37:5: 37:9 }, Literal { kind: Byte, symbol: "B", suffix: Some("q"), span: $DIR/dump-debug-span-debug.rs:38:5: 38:10 }]
+TokenStream [
+    Ident {
+        ident: "ident",
+        span: $DIR/dump-debug-span-debug.rs:9:5: 9:10,
+    },
+    Ident {
+        ident: "r#ident",
+        span: $DIR/dump-debug-span-debug.rs:10:5: 10:12,
+    },
+    Punct {
+        ch: ',',
+        spacing: Alone,
+        span: $DIR/dump-debug-span-debug.rs:11:5: 11:6,
+    },
+    Punct {
+        ch: '=',
+        spacing: Joint,
+        span: $DIR/dump-debug-span-debug.rs:12:5: 12:7,
+    },
+    Punct {
+        ch: '=',
+        spacing: Joint,
+        span: $DIR/dump-debug-span-debug.rs:12:5: 12:7,
+    },
+    Punct {
+        ch: '>',
+        spacing: Alone,
+        span: $DIR/dump-debug-span-debug.rs:12:7: 12:8,
+    },
+    Group {
+        delimiter: Parenthesis,
+        stream: TokenStream [],
+        span: $DIR/dump-debug-span-debug.rs:13:5: 13:7,
+    },
+    Group {
+        delimiter: Bracket,
+        stream: TokenStream [
+            Ident {
+                ident: "_",
+                span: $DIR/dump-debug-span-debug.rs:14:6: 14:7,
+            },
+        ],
+        span: $DIR/dump-debug-span-debug.rs:14:5: 14:8,
+    },
+    Literal {
+        kind: Integer,
+        symbol: "0",
+        suffix: None,
+        span: $DIR/dump-debug-span-debug.rs:17:5: 17:6,
+    },
+    Literal {
+        kind: Float,
+        symbol: "1.0",
+        suffix: None,
+        span: $DIR/dump-debug-span-debug.rs:18:5: 18:8,
+    },
+    Literal {
+        kind: Str,
+        symbol: "S",
+        suffix: None,
+        span: $DIR/dump-debug-span-debug.rs:19:5: 19:8,
+    },
+    Literal {
+        kind: ByteStr,
+        symbol: "B",
+        suffix: None,
+        span: $DIR/dump-debug-span-debug.rs:20:5: 20:9,
+    },
+    Literal {
+        kind: StrRaw(0),
+        symbol: "R",
+        suffix: None,
+        span: $DIR/dump-debug-span-debug.rs:21:5: 21:9,
+    },
+    Literal {
+        kind: StrRaw(2),
+        symbol: "R",
+        suffix: None,
+        span: $DIR/dump-debug-span-debug.rs:22:5: 22:13,
+    },
+    Literal {
+        kind: ByteStrRaw(0),
+        symbol: "BR",
+        suffix: None,
+        span: $DIR/dump-debug-span-debug.rs:23:5: 23:11,
+    },
+    Literal {
+        kind: ByteStrRaw(2),
+        symbol: "BR",
+        suffix: None,
+        span: $DIR/dump-debug-span-debug.rs:24:5: 24:15,
+    },
+    Literal {
+        kind: Char,
+        symbol: "C",
+        suffix: None,
+        span: $DIR/dump-debug-span-debug.rs:25:5: 25:8,
+    },
+    Literal {
+        kind: Byte,
+        symbol: "B",
+        suffix: None,
+        span: $DIR/dump-debug-span-debug.rs:26:5: 26:9,
+    },
+    Literal {
+        kind: Integer,
+        symbol: "0",
+        suffix: Some("q"),
+        span: $DIR/dump-debug-span-debug.rs:29:5: 29:7,
+    },
+    Literal {
+        kind: Float,
+        symbol: "1.0",
+        suffix: Some("q"),
+        span: $DIR/dump-debug-span-debug.rs:30:5: 30:9,
+    },
+    Literal {
+        kind: Str,
+        symbol: "S",
+        suffix: Some("q"),
+        span: $DIR/dump-debug-span-debug.rs:31:5: 31:9,
+    },
+    Literal {
+        kind: ByteStr,
+        symbol: "B",
+        suffix: Some("q"),
+        span: $DIR/dump-debug-span-debug.rs:32:5: 32:10,
+    },
+    Literal {
+        kind: StrRaw(0),
+        symbol: "R",
+        suffix: Some("q"),
+        span: $DIR/dump-debug-span-debug.rs:33:5: 33:10,
+    },
+    Literal {
+        kind: StrRaw(2),
+        symbol: "R",
+        suffix: Some("q"),
+        span: $DIR/dump-debug-span-debug.rs:34:5: 34:14,
+    },
+    Literal {
+        kind: ByteStrRaw(0),
+        symbol: "BR",
+        suffix: Some("q"),
+        span: $DIR/dump-debug-span-debug.rs:35:5: 35:12,
+    },
+    Literal {
+        kind: ByteStrRaw(2),
+        symbol: "BR",
+        suffix: Some("q"),
+        span: $DIR/dump-debug-span-debug.rs:36:5: 36:16,
+    },
+    Literal {
+        kind: Char,
+        symbol: "C",
+        suffix: Some("q"),
+        span: $DIR/dump-debug-span-debug.rs:37:5: 37:9,
+    },
+    Literal {
+        kind: Byte,
+        symbol: "B",
+        suffix: Some("q"),
+        span: $DIR/dump-debug-span-debug.rs:38:5: 38:10,
+    },
+]

--- a/src/tools/clippy/clippy_lints/src/future_not_send.rs
+++ b/src/tools/clippy/clippy_lints/src/future_not_send.rs
@@ -95,7 +95,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for FutureNotSend {
                                         let trait_ref = trait_pred.to_poly_trait_ref();
                                         db.note(&*format!(
                                             "`{}` doesn't implement `{}`",
-                                            trait_ref.self_ty(),
+                                            trait_ref.skip_binder().self_ty(),
                                             trait_ref.print_only_trait_path(),
                                         ));
                                     }


### PR DESCRIPTION
Successful merges:

 - #71796 (de-promote Duration::from_secs)
 - #72508 (Make `PolyTraitRef::self_ty` return `Binder<Ty>`)
 - #72708 (linker: Add a linker rerun hack for gcc versions not supporting -static-pie)
 - #72764 (Be more careful around ty::Error in generators)
 - #72799 (Add `-Z span-debug` to allow for easier debugging of proc macros)
 - #72952 (run-make regression test for issue #70924.)
 - #72977 (Fix codegen tests for RISC-V)
 - #73007 (impl ToSocketAddrs for (String, u16))
 - #73059 (remove outdated comment)

Failed merges:


r? @ghost