### PR TITLE
impl From<LocalDefId> for DefId

### DIFF
--- a/src/librustc_span/def_id.rs
+++ b/src/librustc_span/def_id.rs
@@ -231,6 +231,12 @@ impl LocalDefId {
     }
 }
 
+impl From<LocalDefId> for DefId {
+    fn from(local: LocalDefId) -> Self {
+        local.to_def_id()
+    }
+}
+
 impl fmt::Debug for LocalDefId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.to_def_id().fmt(f)


### PR DESCRIPTION
This makes it easier for new contributors (a.k.a me) to convert between types without having to look up https://doc.rust-lang.org/nightly/nightly-rustc/rustc_hir/def_id/struct.LocalDefId.html#method.to_def_id.
I think in some cases it will also cause rustc to suggest `.into()` when the types don't match which may be helpful even to experienced contributors.