### PR TITLE
Update musl to 1.1.24

### DIFF
--- a/src/ci/docker/scripts/musl-toolchain.sh
+++ b/src/ci/docker/scripts/musl-toolchain.sh
@@ -3,7 +3,7 @@
 #
 # Versions of the toolchain components are configurable in `musl-cross-make/Makefile` and
 # musl unlike GLIBC is forward compatible so upgrading it shouldn't break old distributions.
-# Right now we have: Binutils 2.27, GCC 6.4.0, musl 1.1.22.
+# Right now we have: Binutils 2.31.1, GCC 9.2.0, musl 1.1.24.
 set -ex
 
 hide_output() {
@@ -33,11 +33,13 @@ shift
 # Apparently applying `-fPIC` everywhere allows them to link successfully.
 export CFLAGS="-fPIC $CFLAGS"
 
-git clone https://github.com/richfelker/musl-cross-make -b v0.9.8
+git clone https://github.com/richfelker/musl-cross-make # -b v0.9.9
 cd musl-cross-make
+# A few commits ahead of v0.9.9 to include the cowpatch fix:
+git checkout a54eb56f33f255dfca60be045f12a5cfaf5a72a9
 
-hide_output make -j$(nproc) TARGET=$TARGET
-hide_output make install TARGET=$TARGET OUTPUT=$OUTPUT
+hide_output make -j$(nproc) TARGET=$TARGET MUSL_VER=1.1.24
+hide_output make install TARGET=$TARGET MUSL_VER=1.1.24 OUTPUT=$OUTPUT
 
 cd -
 

--- a/src/ci/docker/scripts/musl.sh
+++ b/src/ci/docker/scripts/musl.sh
@@ -24,7 +24,7 @@ shift
 # Apparently applying `-fPIC` everywhere allows them to link successfully.
 export CFLAGS="-fPIC $CFLAGS"
 
-MUSL=musl-1.1.22
+MUSL=musl-1.1.24
 
 # may have been downloaded in a previous run
 if [ ! -d $MUSL ]; then


### PR DESCRIPTION
Release notes since previous version 1.1.22:

## 1.1.23 release notes

### new features:
- riscv64 port
- configure now allows customizing AR and RANLIB vars
- header-level support for new linux features in 5.1

### major internal changes:
- removed extern __syscall; syscall header code is now fully self-contained

### performance:
- new math library implementation for log/exp/pow
- aarch64 dynamic tlsdesc function is streamlined

### compatibility & conformance:
- O_TTY_INIT is now defined
- sys/types.h no longer pollutes namespace with sys/sysmacros.h in any profile
- powerpc asm is now compatible with clang internal assembler

### changes for new POSIX interpretations:
- fgetwc now sets stream error indicator on encoding errors
- fmemopen no longer rejects 0 size

### bugs fixed:
- static TLS for shared libraries was allocated wrong on "Variant I" archs
- crash in dladdr reading through uninitialized pointer on non-match
- sigaltstack wrongly errored out on invalid ss_size when doing SS_DISABLE
- getdents function misbehaved with buffer length larger than INT_MAX
- set*id could deadlock after fork from multithreaded process

### arch-specfic bugs fixed:
- s390x SO_PEERSEC definition was wrong
- passing of 64-bit syscall arguments was broken on microblaze
- posix_fadvise was broken on mips due to missing 7-arg syscall support
- vrregset_t layout and member naming was wrong on powerpc64

## 1.1.24 release notes

### new features:
- GLOB_TILDE extension to glob
- non-stub catgets localization API, using netbsd binary catalog format
- posix_spawn file actions for [f]chdir (extension, pending future standard)
- secure_getenv function (extension)
- copy_file_range syscall wrapper (Linux extension)
- header-level support for new linux features in 5.2

### performance:
- new fast path for lrint (generic C version) on 32-bit archs

### major internal changes:
- functions involving time are overhauled to be time64-ready in 32-bit archs
- x32 uses the new time64 code paths to replace nasty hacks in syscall glue

### compatibility & conformance:
- support for powerpc[64] unaligned relocation types
- powerpc[64] and sh sys/user.h no longer clash with kernel asm/ptrace.h
- select no longer modifies timeout on failure (or at all)
- mips64 stat results are no longer limited to 32-bit time range
- optreset (BSD extension) now has a public declaration
- support for clang inconsistencies in wchar_t type vs some 32-bit archs
- mips r6 syscall asm no longer has invalid lo/hi register clobbers
- vestigial asm declarations of __tls_get_new are removed (broke some tooling)
- riscv64 mcontext_t mismatch glibc's member naming is corrected

### bugs fixed:
- glob failed to match broken symlinks consistently
- invalid use of interposed calloc to allocate initial TLS
- various dlsym symbol resolution logic errors
- semctl with SEM_STAT_ANY didn't work
- pthread_create with explicit scheduling was subject to priority inversion
- pthread_create failure path had data race for thread count
- timer_create with SIGEV_THREAD notification had data race getting timer id
- wide printf family failed to support l modifier for float formats

### arch-specific bugs fixed:
- x87 floating point stack imbalance in math asm (i386-only CVE-2019-14697)
- x32 clock_adjtime, getrusage, wait3, wait4 produced junk (struct mismatches)
- lseek broken on x32 and mipsn32 with large file offsets
- riscv64 atomics weren't compiler barriers
- riscv64 atomics had broken asm constraints (missing earlyclobber flag)
- arm clone() was broken when compiled as thumb if start function returned
- mipsr6 setjmp/longjmp did not preserve fpu register state correctly

Fixes #71099.