### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -984,7 +984,7 @@ impl<T> Vec<T> {
             // bounds check above succeeds there must be a last element (which
             // can be self[index] itself).
             let last = ptr::read(self.as_ptr().add(len - 1));
-            let hole: *mut T = self.as_mut_ptr().add(index);
+            let hole = self.as_mut_ptr().add(index);
             self.set_len(len - 1);
             ptr::replace(hole, last)
         }

--- a/src/libcore/sync/atomic.rs
+++ b/src/libcore/sync/atomic.rs
@@ -153,6 +153,8 @@ pub fn spin_loop_hint() {
 ///
 /// This type has the same in-memory representation as a [`bool`].
 ///
+/// **Note**: This type may not be available on some platforms.
+///
 /// [`bool`]: ../../../std/primitive.bool.html
 #[cfg(target_has_atomic_load_store = "8")]
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -178,6 +180,9 @@ unsafe impl Sync for AtomicBool {}
 /// A raw pointer type which can be safely shared between threads.
 ///
 /// This type has the same in-memory representation as a `*mut T`.
+///
+/// **Note**: This type may not be available on some platforms. Its size depends
+/// on the target pointer's size.
 #[cfg(target_has_atomic_load_store = "ptr")]
 #[stable(feature = "rust1", since = "1.0.0")]
 #[cfg_attr(target_pointer_width = "16", repr(C, align(2)))]
@@ -462,6 +467,8 @@ impl AtomicBool {
     /// assert_eq!(some_bool.swap(false, Ordering::Relaxed), true);
     /// assert_eq!(some_bool.load(Ordering::Relaxed), false);
     /// ```
+    ///
+    /// **Note**: This method may not be available on some platforms.
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[cfg(target_has_atomic = "8")]
@@ -501,6 +508,8 @@ impl AtomicBool {
     /// assert_eq!(some_bool.compare_and_swap(true, true, Ordering::Relaxed), false);
     /// assert_eq!(some_bool.load(Ordering::Relaxed), false);
     /// ```
+    ///
+    /// **Note**: This method may not be available on some platforms.
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[cfg(target_has_atomic = "8")]
@@ -552,6 +561,8 @@ impl AtomicBool {
     ///            Err(false));
     /// assert_eq!(some_bool.load(Ordering::Relaxed), false);
     /// ```
+    ///
+    /// **Note**: This method may not be available on some platforms.
     #[inline]
     #[stable(feature = "extended_compare_and_swap", since = "1.10.0")]
     #[cfg(target_has_atomic = "8")]
@@ -610,6 +621,8 @@ impl AtomicBool {
     ///     }
     /// }
     /// ```
+    ///
+    /// **Note**: This method may not be available on some platforms.
     #[inline]
     #[stable(feature = "extended_compare_and_swap", since = "1.10.0")]
     #[cfg(target_has_atomic = "8")]
@@ -663,6 +676,8 @@ impl AtomicBool {
     /// assert_eq!(foo.fetch_and(false, Ordering::SeqCst), false);
     /// assert_eq!(foo.load(Ordering::SeqCst), false);
     /// ```
+    ///
+    /// **Note**: This method may not be available on some platforms.
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[cfg(target_has_atomic = "8")]
@@ -706,6 +721,8 @@ impl AtomicBool {
     /// assert_eq!(foo.fetch_nand(false, Ordering::SeqCst), false);
     /// assert_eq!(foo.load(Ordering::SeqCst), true);
     /// ```
+    ///
+    /// **Note**: This method may not be available on some platforms.
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[cfg(target_has_atomic = "8")]
@@ -759,6 +776,8 @@ impl AtomicBool {
     /// assert_eq!(foo.fetch_or(false, Ordering::SeqCst), false);
     /// assert_eq!(foo.load(Ordering::SeqCst), false);
     /// ```
+    ///
+    /// **Note**: This method may not be available on some platforms.
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[cfg(target_has_atomic = "8")]
@@ -801,6 +820,8 @@ impl AtomicBool {
     /// assert_eq!(foo.fetch_xor(false, Ordering::SeqCst), false);
     /// assert_eq!(foo.load(Ordering::SeqCst), false);
     /// ```
+    ///
+    /// **Note**: This method may not be available on some platforms.
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[cfg(target_has_atomic = "8")]
@@ -998,6 +1019,8 @@ impl<T> AtomicPtr<T> {
     ///
     /// let value = some_ptr.swap(other_ptr, Ordering::Relaxed);
     /// ```
+    ///
+    /// **Note**: This method may not be available on some platforms.
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[cfg(target_has_atomic = "ptr")]
@@ -1035,6 +1058,8 @@ impl<T> AtomicPtr<T> {
     ///
     /// let value = some_ptr.compare_and_swap(ptr, other_ptr, Ordering::Relaxed);
     /// ```
+    ///
+    /// **Note**: This method may not be available on some platforms.
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[cfg(target_has_atomic = "ptr")]
@@ -1077,6 +1102,8 @@ impl<T> AtomicPtr<T> {
     /// let value = some_ptr.compare_exchange(ptr, other_ptr,
     ///                                       Ordering::SeqCst, Ordering::Relaxed);
     /// ```
+    ///
+    /// **Note**: This method may not be available on some platforms.
     #[inline]
     #[stable(feature = "extended_compare_and_swap", since = "1.10.0")]
     #[cfg(target_has_atomic = "ptr")]
@@ -1141,6 +1168,8 @@ impl<T> AtomicPtr<T> {
     ///     }
     /// }
     /// ```
+    ///
+    /// **Note**: This method may not be available on some platforms.
     #[inline]
     #[stable(feature = "extended_compare_and_swap", since = "1.10.0")]
     #[cfg(target_has_atomic = "ptr")]
@@ -1222,6 +1251,8 @@ macro_rules! atomic_int {
         /// ). For more about the differences between atomic types and
         /// non-atomic types as well as information about the portability of
         /// this type, please see the [module-level documentation].
+        ///
+        /// **Note**: This type may not be available on some platforms.
         ///
         /// [module-level documentation]: index.html
         #[$stable]
@@ -1421,7 +1452,9 @@ using [`Release`] makes the load part [`Relaxed`].
 let some_var = ", stringify!($atomic_type), "::new(5);
 
 assert_eq!(some_var.swap(10, Ordering::Relaxed), 5);
-```"),
+```
+
+**Note**: This method may not be available on some platforms."),
                 #[inline]
                 #[$stable]
                 #[$cfg_cas]
@@ -1462,7 +1495,9 @@ assert_eq!(some_var.load(Ordering::Relaxed), 10);
 
 assert_eq!(some_var.compare_and_swap(6, 12, Ordering::Relaxed), 10);
 assert_eq!(some_var.load(Ordering::Relaxed), 10);
-```"),
+```
+
+**Note**: This method may not be available on some platforms."),
                 #[inline]
                 #[$stable]
                 #[$cfg_cas]
@@ -1520,7 +1555,9 @@ assert_eq!(some_var.compare_exchange(6, 12,
                                      Ordering::Acquire),
            Err(10));
 assert_eq!(some_var.load(Ordering::Relaxed), 10);
-```"),
+```
+
+**Note**: This method may not be available on some platforms."),
                 #[inline]
                 #[$stable_cxchg]
                 #[$cfg_cas]
@@ -1573,7 +1610,9 @@ loop {
         Err(x) => old = x,
     }
 }
-```"),
+```
+
+**Note**: This method may not be available on some platforms."),
                 #[inline]
                 #[$stable_cxchg]
                 #[$cfg_cas]
@@ -1612,7 +1651,9 @@ using [`Release`] makes the load part [`Relaxed`].
 let foo = ", stringify!($atomic_type), "::new(0);
 assert_eq!(foo.fetch_add(10, Ordering::SeqCst), 0);
 assert_eq!(foo.load(Ordering::SeqCst), 10);
-```"),
+```
+
+**Note**: This method may not be available on some platforms."),
                 #[inline]
                 #[$stable]
                 #[$cfg_cas]
@@ -1645,7 +1686,9 @@ using [`Release`] makes the load part [`Relaxed`].
 let foo = ", stringify!($atomic_type), "::new(20);
 assert_eq!(foo.fetch_sub(10, Ordering::SeqCst), 20);
 assert_eq!(foo.load(Ordering::SeqCst), 10);
-```"),
+```
+
+**Note**: This method may not be available on some platforms."),
                 #[inline]
                 #[$stable]
                 #[$cfg_cas]
@@ -1681,7 +1724,9 @@ using [`Release`] makes the load part [`Relaxed`].
 let foo = ", stringify!($atomic_type), "::new(0b101101);
 assert_eq!(foo.fetch_and(0b110011, Ordering::SeqCst), 0b101101);
 assert_eq!(foo.load(Ordering::SeqCst), 0b100001);
-```"),
+```
+
+**Note**: This method may not be available on some platforms."),
                 #[inline]
                 #[$stable]
                 #[$cfg_cas]
@@ -1718,7 +1763,9 @@ use std::sync::atomic::{", stringify!($atomic_type), ", Ordering};
 let foo = ", stringify!($atomic_type), "::new(0x13);
 assert_eq!(foo.fetch_nand(0x31, Ordering::SeqCst), 0x13);
 assert_eq!(foo.load(Ordering::SeqCst), !(0x13 & 0x31));
-```"),
+```
+
+**Note**: This method may not be available on some platforms."),
                 #[inline]
                 #[$stable_nand]
                 #[$cfg_cas]
@@ -1754,7 +1801,9 @@ using [`Release`] makes the load part [`Relaxed`].
 let foo = ", stringify!($atomic_type), "::new(0b101101);
 assert_eq!(foo.fetch_or(0b110011, Ordering::SeqCst), 0b101101);
 assert_eq!(foo.load(Ordering::SeqCst), 0b111111);
-```"),
+```
+
+**Note**: This method may not be available on some platforms."),
                 #[inline]
                 #[$stable]
                 #[$cfg_cas]
@@ -1790,7 +1839,9 @@ using [`Release`] makes the load part [`Relaxed`].
 let foo = ", stringify!($atomic_type), "::new(0b101101);
 assert_eq!(foo.fetch_xor(0b110011, Ordering::SeqCst), 0b101101);
 assert_eq!(foo.load(Ordering::SeqCst), 0b011110);
-```"),
+```
+
+**Note**: This method may not be available on some platforms."),
                 #[inline]
                 #[$stable]
                 #[$cfg_cas]
@@ -1837,7 +1888,9 @@ assert_eq!(x.fetch_update(Ordering::SeqCst, Ordering::SeqCst, |_| None), Err(7))
 assert_eq!(x.fetch_update(Ordering::SeqCst, Ordering::SeqCst, |x| Some(x + 1)), Ok(7));
 assert_eq!(x.fetch_update(Ordering::SeqCst, Ordering::SeqCst, |x| Some(x + 1)), Ok(8));
 assert_eq!(x.load(Ordering::SeqCst), 9);
-```"),
+```
+
+**Note**: This method may not be available on some platforms."),
                 #[inline]
                 #[stable(feature = "no_more_cas", since = "1.45.0")]
                 #[$cfg_cas]
@@ -1894,7 +1947,9 @@ let foo = ", stringify!($atomic_type), "::new(23);
 let bar = 42;
 let max_foo = foo.fetch_max(bar, Ordering::SeqCst).max(bar);
 assert!(max_foo == 42);
-```"),
+```
+
+**Note**: This method may not be available on some platforms."),
                 #[inline]
                 #[stable(feature = "atomic_min_max", since = "1.45.0")]
                 #[$cfg_cas]
@@ -1943,7 +1998,9 @@ let foo = ", stringify!($atomic_type), "::new(23);
 let bar = 12;
 let min_foo = foo.fetch_min(bar, Ordering::SeqCst).min(bar);
 assert_eq!(min_foo, 12);
-```"),
+```
+
+**Note**: This method may not be available on some platforms."),
                 #[inline]
                 #[stable(feature = "atomic_min_max", since = "1.45.0")]
                 #[$cfg_cas]

--- a/src/libcore/sync/atomic.rs
+++ b/src/libcore/sync/atomic.rs
@@ -154,7 +154,7 @@ pub fn spin_loop_hint() {
 /// This type has the same in-memory representation as a [`bool`].
 ///
 /// **Note**: This type is only available on platforms that support atomic
-/// loads and stores of booleans (as `u8`).
+/// loads and stores of `u8`.
 ///
 /// [`bool`]: ../../../std/primitive.bool.html
 #[cfg(target_has_atomic_load_store = "8")]

--- a/src/libcore/sync/atomic.rs
+++ b/src/libcore/sync/atomic.rs
@@ -153,7 +153,8 @@ pub fn spin_loop_hint() {
 ///
 /// This type has the same in-memory representation as a [`bool`].
 ///
-/// **Note**: This type may not be available on some platforms.
+/// **Note**: This type is only available on platforms that support atomic
+/// loads and stores of booleans (as `u8`).
 ///
 /// [`bool`]: ../../../std/primitive.bool.html
 #[cfg(target_has_atomic_load_store = "8")]
@@ -181,8 +182,8 @@ unsafe impl Sync for AtomicBool {}
 ///
 /// This type has the same in-memory representation as a `*mut T`.
 ///
-/// **Note**: This type may not be available on some platforms. Its size depends
-/// on the target pointer's size.
+/// **Note**: This type is only available on platforms that support atomic
+/// loads and stores of pointers. Its size depends on the target pointer's size.
 #[cfg(target_has_atomic_load_store = "ptr")]
 #[stable(feature = "rust1", since = "1.0.0")]
 #[cfg_attr(target_pointer_width = "16", repr(C, align(2)))]
@@ -452,6 +453,9 @@ impl AtomicBool {
     /// [`Acquire`] makes the store part of this operation [`Relaxed`], and
     /// using [`Release`] makes the load part [`Relaxed`].
     ///
+    /// **Note:** This method is only available on platforms that support atomic
+    /// operations on `u8`.
+    ///
     /// [`Ordering`]: enum.Ordering.html
     /// [`Relaxed`]: enum.Ordering.html#variant.Relaxed
     /// [`Release`]: enum.Ordering.html#variant.Release
@@ -467,8 +471,6 @@ impl AtomicBool {
     /// assert_eq!(some_bool.swap(false, Ordering::Relaxed), true);
     /// assert_eq!(some_bool.load(Ordering::Relaxed), false);
     /// ```
-    ///
-    /// **Note**: This method may not be available on some platforms.
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[cfg(target_has_atomic = "8")]
@@ -487,6 +489,9 @@ impl AtomicBool {
     /// might fail and hence just perform an `Acquire` load, but not have `Release` semantics.
     /// Using [`Acquire`] makes the store part of this operation [`Relaxed`] if it
     /// happens, and using [`Release`] makes the load part [`Relaxed`].
+    ///
+    /// **Note:** This method is only available on platforms that support atomic
+    /// operations on `u8`.
     ///
     /// [`Ordering`]: enum.Ordering.html
     /// [`Relaxed`]: enum.Ordering.html#variant.Relaxed
@@ -508,8 +513,6 @@ impl AtomicBool {
     /// assert_eq!(some_bool.compare_and_swap(true, true, Ordering::Relaxed), false);
     /// assert_eq!(some_bool.load(Ordering::Relaxed), false);
     /// ```
-    ///
-    /// **Note**: This method may not be available on some platforms.
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[cfg(target_has_atomic = "8")]
@@ -533,6 +536,8 @@ impl AtomicBool {
     /// [`Relaxed`]. The failure ordering can only be [`SeqCst`], [`Acquire`] or [`Relaxed`]
     /// and must be equivalent to or weaker than the success ordering.
     ///
+    /// **Note:** This method is only available on platforms that support atomic
+    /// operations on `u8`.
     ///
     /// [`bool`]: ../../../std/primitive.bool.html
     /// [`Ordering`]: enum.Ordering.html
@@ -561,8 +566,6 @@ impl AtomicBool {
     ///            Err(false));
     /// assert_eq!(some_bool.load(Ordering::Relaxed), false);
     /// ```
-    ///
-    /// **Note**: This method may not be available on some platforms.
     #[inline]
     #[stable(feature = "extended_compare_and_swap", since = "1.10.0")]
     #[cfg(target_has_atomic = "8")]
@@ -597,6 +600,9 @@ impl AtomicBool {
     /// [`Relaxed`]. The failure ordering can only be [`SeqCst`], [`Acquire`] or [`Relaxed`]
     /// and must be equivalent to or weaker than the success ordering.
     ///
+    /// **Note:** This method is only available on platforms that support atomic
+    /// operations on `u8`.
+    ///
     /// [`bool`]: ../../../std/primitive.bool.html
     /// [`compare_exchange`]: #method.compare_exchange
     /// [`Ordering`]: enum.Ordering.html
@@ -621,8 +627,6 @@ impl AtomicBool {
     ///     }
     /// }
     /// ```
-    ///
-    /// **Note**: This method may not be available on some platforms.
     #[inline]
     #[stable(feature = "extended_compare_and_swap", since = "1.10.0")]
     #[cfg(target_has_atomic = "8")]
@@ -659,6 +663,9 @@ impl AtomicBool {
     /// [`Release`]: enum.Ordering.html#variant.Release
     /// [`Acquire`]: enum.Ordering.html#variant.Acquire
     ///
+    /// **Note:** This method is only available on platforms that support atomic
+    /// operations on `u8`.
+    ///
     /// # Examples
     ///
     /// ```
@@ -676,8 +683,6 @@ impl AtomicBool {
     /// assert_eq!(foo.fetch_and(false, Ordering::SeqCst), false);
     /// assert_eq!(foo.load(Ordering::SeqCst), false);
     /// ```
-    ///
-    /// **Note**: This method may not be available on some platforms.
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[cfg(target_has_atomic = "8")]
@@ -697,6 +702,9 @@ impl AtomicBool {
     /// of this operation. All ordering modes are possible. Note that using
     /// [`Acquire`] makes the store part of this operation [`Relaxed`], and
     /// using [`Release`] makes the load part [`Relaxed`].
+    ///
+    /// **Note:** This method is only available on platforms that support atomic
+    /// operations on `u8`.
     ///
     /// [`Ordering`]: enum.Ordering.html
     /// [`Relaxed`]: enum.Ordering.html#variant.Relaxed
@@ -721,8 +729,6 @@ impl AtomicBool {
     /// assert_eq!(foo.fetch_nand(false, Ordering::SeqCst), false);
     /// assert_eq!(foo.load(Ordering::SeqCst), true);
     /// ```
-    ///
-    /// **Note**: This method may not be available on some platforms.
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[cfg(target_has_atomic = "8")]
@@ -754,6 +760,9 @@ impl AtomicBool {
     /// [`Acquire`] makes the store part of this operation [`Relaxed`], and
     /// using [`Release`] makes the load part [`Relaxed`].
     ///
+    /// **Note:** This method is only available on platforms that support atomic
+    /// operations on `u8`.
+    ///
     /// [`Ordering`]: enum.Ordering.html
     /// [`Relaxed`]: enum.Ordering.html#variant.Relaxed
     /// [`Release`]: enum.Ordering.html#variant.Release
@@ -776,8 +785,6 @@ impl AtomicBool {
     /// assert_eq!(foo.fetch_or(false, Ordering::SeqCst), false);
     /// assert_eq!(foo.load(Ordering::SeqCst), false);
     /// ```
-    ///
-    /// **Note**: This method may not be available on some platforms.
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[cfg(target_has_atomic = "8")]
@@ -797,6 +804,9 @@ impl AtomicBool {
     /// of this operation. All ordering modes are possible. Note that using
     /// [`Acquire`] makes the store part of this operation [`Relaxed`], and
     /// using [`Release`] makes the load part [`Relaxed`].
+    ///
+    /// **Note:** This method is only available on platforms that support atomic
+    /// operations on `u8`.
     ///
     /// [`Ordering`]: enum.Ordering.html
     /// [`Relaxed`]: enum.Ordering.html#variant.Relaxed
@@ -820,8 +830,6 @@ impl AtomicBool {
     /// assert_eq!(foo.fetch_xor(false, Ordering::SeqCst), false);
     /// assert_eq!(foo.load(Ordering::SeqCst), false);
     /// ```
-    ///
-    /// **Note**: This method may not be available on some platforms.
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[cfg(target_has_atomic = "8")]
@@ -1002,6 +1010,9 @@ impl<T> AtomicPtr<T> {
     /// [`Acquire`] makes the store part of this operation [`Relaxed`], and
     /// using [`Release`] makes the load part [`Relaxed`].
     ///
+    /// **Note:** This method is only available on platforms that support atomic
+    /// operations on pointers.
+    ///
     /// [`Ordering`]: enum.Ordering.html
     /// [`Relaxed`]: enum.Ordering.html#variant.Relaxed
     /// [`Release`]: enum.Ordering.html#variant.Release
@@ -1019,8 +1030,6 @@ impl<T> AtomicPtr<T> {
     ///
     /// let value = some_ptr.swap(other_ptr, Ordering::Relaxed);
     /// ```
-    ///
-    /// **Note**: This method may not be available on some platforms.
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[cfg(target_has_atomic = "ptr")]
@@ -1040,6 +1049,9 @@ impl<T> AtomicPtr<T> {
     /// Using [`Acquire`] makes the store part of this operation [`Relaxed`] if it
     /// happens, and using [`Release`] makes the load part [`Relaxed`].
     ///
+    /// **Note:** This method is only available on platforms that support atomic
+    /// operations on pointers.
+    ///
     /// [`Ordering`]: enum.Ordering.html
     /// [`Relaxed`]: enum.Ordering.html#variant.Relaxed
     /// [`Release`]: enum.Ordering.html#variant.Release
@@ -1058,8 +1070,6 @@ impl<T> AtomicPtr<T> {
     ///
     /// let value = some_ptr.compare_and_swap(ptr, other_ptr, Ordering::Relaxed);
     /// ```
-    ///
-    /// **Note**: This method may not be available on some platforms.
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[cfg(target_has_atomic = "ptr")]
@@ -1083,6 +1093,9 @@ impl<T> AtomicPtr<T> {
     /// [`Relaxed`]. The failure ordering can only be [`SeqCst`], [`Acquire`] or [`Relaxed`]
     /// and must be equivalent to or weaker than the success ordering.
     ///
+    /// **Note:** This method is only available on platforms that support atomic
+    /// operations on pointers.
+    ///
     /// [`Ordering`]: enum.Ordering.html
     /// [`Relaxed`]: enum.Ordering.html#variant.Relaxed
     /// [`Release`]: enum.Ordering.html#variant.Release
@@ -1102,8 +1115,6 @@ impl<T> AtomicPtr<T> {
     /// let value = some_ptr.compare_exchange(ptr, other_ptr,
     ///                                       Ordering::SeqCst, Ordering::Relaxed);
     /// ```
-    ///
-    /// **Note**: This method may not be available on some platforms.
     #[inline]
     #[stable(feature = "extended_compare_and_swap", since = "1.10.0")]
     #[cfg(target_has_atomic = "ptr")]
@@ -1145,6 +1156,9 @@ impl<T> AtomicPtr<T> {
     /// [`Relaxed`]. The failure ordering can only be [`SeqCst`], [`Acquire`] or [`Relaxed`]
     /// and must be equivalent to or weaker than the success ordering.
     ///
+    /// **Note:** This method is only available on platforms that support atomic
+    /// operations on pointers.
+    ///
     /// [`compare_exchange`]: #method.compare_exchange
     /// [`Ordering`]: enum.Ordering.html
     /// [`Relaxed`]: enum.Ordering.html#variant.Relaxed
@@ -1168,8 +1182,6 @@ impl<T> AtomicPtr<T> {
     ///     }
     /// }
     /// ```
-    ///
-    /// **Note**: This method may not be available on some platforms.
     #[inline]
     #[stable(feature = "extended_compare_and_swap", since = "1.10.0")]
     #[cfg(target_has_atomic = "ptr")]
@@ -1252,7 +1264,12 @@ macro_rules! atomic_int {
         /// non-atomic types as well as information about the portability of
         /// this type, please see the [module-level documentation].
         ///
-        /// **Note**: This type may not be available on some platforms.
+        /// **Note:** This type is only available on platforms that support
+        /// atomic loads and stores of [`
+        #[doc = $s_int_type]
+        /// `](
+        #[doc = $int_ref]
+        /// ).
         ///
         /// [module-level documentation]: index.html
         #[$stable]
@@ -1439,6 +1456,9 @@ of this operation. All ordering modes are possible. Note that using
 [`Acquire`] makes the store part of this operation [`Relaxed`], and
 using [`Release`] makes the load part [`Relaxed`].
 
+**Note**: This method is only available on platforms that support atomic
+operations on [`", $s_int_type, "`](", $int_ref, ").
+
 [`Ordering`]: enum.Ordering.html
 [`Relaxed`]: enum.Ordering.html#variant.Relaxed
 [`Release`]: enum.Ordering.html#variant.Release
@@ -1452,9 +1472,7 @@ using [`Release`] makes the load part [`Relaxed`].
 let some_var = ", stringify!($atomic_type), "::new(5);
 
 assert_eq!(some_var.swap(10, Ordering::Relaxed), 5);
-```
-
-**Note**: This method may not be available on some platforms."),
+```"),
                 #[inline]
                 #[$stable]
                 #[$cfg_cas]
@@ -1477,6 +1495,9 @@ might fail and hence just perform an `Acquire` load, but not have `Release` sema
 Using [`Acquire`] makes the store part of this operation [`Relaxed`] if it
 happens, and using [`Release`] makes the load part [`Relaxed`].
 
+**Note**: This method is only available on platforms that support atomic
+operations on [`", $s_int_type, "`](", $int_ref, ").
+
 [`Ordering`]: enum.Ordering.html
 [`Relaxed`]: enum.Ordering.html#variant.Relaxed
 [`Release`]: enum.Ordering.html#variant.Release
@@ -1495,9 +1516,7 @@ assert_eq!(some_var.load(Ordering::Relaxed), 10);
 
 assert_eq!(some_var.compare_and_swap(6, 12, Ordering::Relaxed), 10);
 assert_eq!(some_var.load(Ordering::Relaxed), 10);
-```
-
-**Note**: This method may not be available on some platforms."),
+```"),
                 #[inline]
                 #[$stable]
                 #[$cfg_cas]
@@ -1531,6 +1550,9 @@ of this operation [`Relaxed`], and using [`Release`] makes the successful load
 [`Relaxed`]. The failure ordering can only be [`SeqCst`], [`Acquire`] or [`Relaxed`]
 and must be equivalent to or weaker than the success ordering.
 
+**Note**: This method is only available on platforms that support atomic
+operations on [`", $s_int_type, "`](", $int_ref, ").
+
 [`Ordering`]: enum.Ordering.html
 [`Relaxed`]: enum.Ordering.html#variant.Relaxed
 [`Release`]: enum.Ordering.html#variant.Release
@@ -1555,9 +1577,7 @@ assert_eq!(some_var.compare_exchange(6, 12,
                                      Ordering::Acquire),
            Err(10));
 assert_eq!(some_var.load(Ordering::Relaxed), 10);
-```
-
-**Note**: This method may not be available on some platforms."),
+```"),
                 #[inline]
                 #[$stable_cxchg]
                 #[$cfg_cas]
@@ -1595,6 +1615,9 @@ and must be equivalent to or weaker than the success ordering.
 [`Acquire`]: enum.Ordering.html#variant.Acquire
 [`SeqCst`]: enum.Ordering.html#variant.SeqCst
 
+**Note**: This method is only available on platforms that support atomic
+operations on [`", $s_int_type, "`](", $int_ref, ").
+
 # Examples
 
 ```
@@ -1610,9 +1633,7 @@ loop {
         Err(x) => old = x,
     }
 }
-```
-
-**Note**: This method may not be available on some platforms."),
+```"),
                 #[inline]
                 #[$stable_cxchg]
                 #[$cfg_cas]
@@ -1638,6 +1659,9 @@ of this operation. All ordering modes are possible. Note that using
 [`Acquire`] makes the store part of this operation [`Relaxed`], and
 using [`Release`] makes the load part [`Relaxed`].
 
+**Note**: This method is only available on platforms that support atomic
+operations on [`", $s_int_type, "`](", $int_ref, ").
+
 [`Ordering`]: enum.Ordering.html
 [`Relaxed`]: enum.Ordering.html#variant.Relaxed
 [`Release`]: enum.Ordering.html#variant.Release
@@ -1651,9 +1675,7 @@ using [`Release`] makes the load part [`Relaxed`].
 let foo = ", stringify!($atomic_type), "::new(0);
 assert_eq!(foo.fetch_add(10, Ordering::SeqCst), 0);
 assert_eq!(foo.load(Ordering::SeqCst), 10);
-```
-
-**Note**: This method may not be available on some platforms."),
+```"),
                 #[inline]
                 #[$stable]
                 #[$cfg_cas]
@@ -1673,6 +1695,9 @@ of this operation. All ordering modes are possible. Note that using
 [`Acquire`] makes the store part of this operation [`Relaxed`], and
 using [`Release`] makes the load part [`Relaxed`].
 
+**Note**: This method is only available on platforms that support atomic
+operations on [`", $s_int_type, "`](", $int_ref, ").
+
 [`Ordering`]: enum.Ordering.html
 [`Relaxed`]: enum.Ordering.html#variant.Relaxed
 [`Release`]: enum.Ordering.html#variant.Release
@@ -1686,9 +1711,7 @@ using [`Release`] makes the load part [`Relaxed`].
 let foo = ", stringify!($atomic_type), "::new(20);
 assert_eq!(foo.fetch_sub(10, Ordering::SeqCst), 20);
 assert_eq!(foo.load(Ordering::SeqCst), 10);
-```
-
-**Note**: This method may not be available on some platforms."),
+```"),
                 #[inline]
                 #[$stable]
                 #[$cfg_cas]
@@ -1711,6 +1734,9 @@ of this operation. All ordering modes are possible. Note that using
 [`Acquire`] makes the store part of this operation [`Relaxed`], and
 using [`Release`] makes the load part [`Relaxed`].
 
+**Note**: This method is only available on platforms that support atomic
+operations on [`", $s_int_type, "`](", $int_ref, ").
+
 [`Ordering`]: enum.Ordering.html
 [`Relaxed`]: enum.Ordering.html#variant.Relaxed
 [`Release`]: enum.Ordering.html#variant.Release
@@ -1724,9 +1750,7 @@ using [`Release`] makes the load part [`Relaxed`].
 let foo = ", stringify!($atomic_type), "::new(0b101101);
 assert_eq!(foo.fetch_and(0b110011, Ordering::SeqCst), 0b101101);
 assert_eq!(foo.load(Ordering::SeqCst), 0b100001);
-```
-
-**Note**: This method may not be available on some platforms."),
+```"),
                 #[inline]
                 #[$stable]
                 #[$cfg_cas]
@@ -1749,6 +1773,9 @@ of this operation. All ordering modes are possible. Note that using
 [`Acquire`] makes the store part of this operation [`Relaxed`], and
 using [`Release`] makes the load part [`Relaxed`].
 
+**Note**: This method is only available on platforms that support atomic
+operations on [`", $s_int_type, "`](", $int_ref, ").
+
 [`Ordering`]: enum.Ordering.html
 [`Relaxed`]: enum.Ordering.html#variant.Relaxed
 [`Release`]: enum.Ordering.html#variant.Release
@@ -1763,9 +1790,7 @@ use std::sync::atomic::{", stringify!($atomic_type), ", Ordering};
 let foo = ", stringify!($atomic_type), "::new(0x13);
 assert_eq!(foo.fetch_nand(0x31, Ordering::SeqCst), 0x13);
 assert_eq!(foo.load(Ordering::SeqCst), !(0x13 & 0x31));
-```
-
-**Note**: This method may not be available on some platforms."),
+```"),
                 #[inline]
                 #[$stable_nand]
                 #[$cfg_cas]
@@ -1788,6 +1813,9 @@ of this operation. All ordering modes are possible. Note that using
 [`Acquire`] makes the store part of this operation [`Relaxed`], and
 using [`Release`] makes the load part [`Relaxed`].
 
+**Note**: This method is only available on platforms that support atomic
+operations on [`", $s_int_type, "`](", $int_ref, ").
+
 [`Ordering`]: enum.Ordering.html
 [`Relaxed`]: enum.Ordering.html#variant.Relaxed
 [`Release`]: enum.Ordering.html#variant.Release
@@ -1801,9 +1829,7 @@ using [`Release`] makes the load part [`Relaxed`].
 let foo = ", stringify!($atomic_type), "::new(0b101101);
 assert_eq!(foo.fetch_or(0b110011, Ordering::SeqCst), 0b101101);
 assert_eq!(foo.load(Ordering::SeqCst), 0b111111);
-```
-
-**Note**: This method may not be available on some platforms."),
+```"),
                 #[inline]
                 #[$stable]
                 #[$cfg_cas]
@@ -1826,6 +1852,9 @@ of this operation. All ordering modes are possible. Note that using
 [`Acquire`] makes the store part of this operation [`Relaxed`], and
 using [`Release`] makes the load part [`Relaxed`].
 
+**Note**: This method is only available on platforms that support atomic
+operations on [`", $s_int_type, "`](", $int_ref, ").
+
 [`Ordering`]: enum.Ordering.html
 [`Relaxed`]: enum.Ordering.html#variant.Relaxed
 [`Release`]: enum.Ordering.html#variant.Release
@@ -1839,9 +1868,7 @@ using [`Release`] makes the load part [`Relaxed`].
 let foo = ", stringify!($atomic_type), "::new(0b101101);
 assert_eq!(foo.fetch_xor(0b110011, Ordering::SeqCst), 0b101101);
 assert_eq!(foo.load(Ordering::SeqCst), 0b011110);
-```
-
-**Note**: This method may not be available on some platforms."),
+```"),
                 #[inline]
                 #[$stable]
                 #[$cfg_cas]
@@ -1870,6 +1897,9 @@ of this operation [`Relaxed`], and using [`Release`] makes the final successful 
 [`Relaxed`]. The (failed) load ordering can only be [`SeqCst`], [`Acquire`] or [`Relaxed`]
 and must be equivalent to or weaker than the success ordering.
 
+**Note**: This method is only available on platforms that support atomic
+operations on [`", $s_int_type, "`](", $int_ref, ").
+
 [`bool`]: ../../../std/primitive.bool.html
 [`compare_exchange`]: #method.compare_exchange
 [`Ordering`]: enum.Ordering.html
@@ -1888,9 +1918,7 @@ assert_eq!(x.fetch_update(Ordering::SeqCst, Ordering::SeqCst, |_| None), Err(7))
 assert_eq!(x.fetch_update(Ordering::SeqCst, Ordering::SeqCst, |x| Some(x + 1)), Ok(7));
 assert_eq!(x.fetch_update(Ordering::SeqCst, Ordering::SeqCst, |x| Some(x + 1)), Ok(8));
 assert_eq!(x.load(Ordering::SeqCst), 9);
-```
-
-**Note**: This method may not be available on some platforms."),
+```"),
                 #[inline]
                 #[stable(feature = "no_more_cas", since = "1.45.0")]
                 #[$cfg_cas]
@@ -1923,6 +1951,9 @@ of this operation. All ordering modes are possible. Note that using
 [`Acquire`] makes the store part of this operation [`Relaxed`], and
 using [`Release`] makes the load part [`Relaxed`].
 
+**Note**: This method is only available on platforms that support atomic
+operations on [`", $s_int_type, "`](", $int_ref, ").
+
 [`Ordering`]: enum.Ordering.html
 [`Relaxed`]: enum.Ordering.html#variant.Relaxed
 [`Release`]: enum.Ordering.html#variant.Release
@@ -1947,9 +1978,7 @@ let foo = ", stringify!($atomic_type), "::new(23);
 let bar = 42;
 let max_foo = foo.fetch_max(bar, Ordering::SeqCst).max(bar);
 assert!(max_foo == 42);
-```
-
-**Note**: This method may not be available on some platforms."),
+```"),
                 #[inline]
                 #[stable(feature = "atomic_min_max", since = "1.45.0")]
                 #[$cfg_cas]
@@ -1971,6 +2000,9 @@ Returns the previous value.
 of this operation. All ordering modes are possible. Note that using
 [`Acquire`] makes the store part of this operation [`Relaxed`], and
 using [`Release`] makes the load part [`Relaxed`].
+
+**Note**: This method is only available on platforms that support atomic
+operations on [`", $s_int_type, "`](", $int_ref, ").
 
 [`Ordering`]: enum.Ordering.html
 [`Relaxed`]: enum.Ordering.html#variant.Relaxed
@@ -1998,9 +2030,7 @@ let foo = ", stringify!($atomic_type), "::new(23);
 let bar = 12;
 let min_foo = foo.fetch_min(bar, Ordering::SeqCst).min(bar);
 assert_eq!(min_foo, 12);
-```
-
-**Note**: This method may not be available on some platforms."),
+```"),
                 #[inline]
                 #[stable(feature = "atomic_min_max", since = "1.45.0")]
                 #[$cfg_cas]

--- a/src/librustc_codegen_ssa/mir/analyze.rs
+++ b/src/librustc_codegen_ssa/mir/analyze.rs
@@ -357,7 +357,7 @@ pub fn cleanup_kinds(mir: &mir::Body<'_>) -> IndexVec<mir::BasicBlock, CleanupKi
                 | TerminatorKind::Unreachable
                 | TerminatorKind::SwitchInt { .. }
                 | TerminatorKind::Yield { .. }
-                | TerminatorKind::FalseEdges { .. }
+                | TerminatorKind::FalseEdge { .. }
                 | TerminatorKind::FalseUnwind { .. }
                 | TerminatorKind::InlineAsm { .. } => { /* nothing to do */ }
                 TerminatorKind::Call { cleanup: unwind, .. }

--- a/src/librustc_codegen_ssa/mir/block.rs
+++ b/src/librustc_codegen_ssa/mir/block.rs
@@ -1030,7 +1030,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
             mir::TerminatorKind::GeneratorDrop | mir::TerminatorKind::Yield { .. } => {
                 bug!("generator ops in codegen")
             }
-            mir::TerminatorKind::FalseEdges { .. } | mir::TerminatorKind::FalseUnwind { .. } => {
+            mir::TerminatorKind::FalseEdge { .. } | mir::TerminatorKind::FalseUnwind { .. } => {
                 bug!("borrowck false edges in codegen")
             }
 

--- a/src/librustc_middle/mir/mod.rs
+++ b/src/librustc_middle/mir/mod.rs
@@ -1160,7 +1160,7 @@ pub enum TerminatorKind<'tcx> {
 
     /// A block where control flow only ever takes one real path, but borrowck
     /// needs to be more conservative.
-    FalseEdges {
+    FalseEdge {
         /// The target normal control flow will take.
         real_target: BasicBlock,
         /// A block control flow could conceptually jump to, but won't in
@@ -1314,7 +1314,7 @@ impl<'tcx> TerminatorKind<'tcx> {
                 Some(t).into_iter().chain(slice::from_ref(u))
             }
             SwitchInt { ref targets, .. } => None.into_iter().chain(&targets[..]),
-            FalseEdges { ref real_target, ref imaginary_target } => {
+            FalseEdge { ref real_target, ref imaginary_target } => {
                 Some(real_target).into_iter().chain(slice::from_ref(imaginary_target))
             }
         }
@@ -1348,7 +1348,7 @@ impl<'tcx> TerminatorKind<'tcx> {
                 Some(t).into_iter().chain(slice::from_mut(u))
             }
             SwitchInt { ref mut targets, .. } => None.into_iter().chain(&mut targets[..]),
-            FalseEdges { ref mut real_target, ref mut imaginary_target } => {
+            FalseEdge { ref mut real_target, ref mut imaginary_target } => {
                 Some(real_target).into_iter().chain(slice::from_mut(imaginary_target))
             }
         }
@@ -1364,7 +1364,7 @@ impl<'tcx> TerminatorKind<'tcx> {
             | TerminatorKind::GeneratorDrop
             | TerminatorKind::Yield { .. }
             | TerminatorKind::SwitchInt { .. }
-            | TerminatorKind::FalseEdges { .. }
+            | TerminatorKind::FalseEdge { .. }
             | TerminatorKind::InlineAsm { .. } => None,
             TerminatorKind::Call { cleanup: ref unwind, .. }
             | TerminatorKind::Assert { cleanup: ref unwind, .. }
@@ -1384,7 +1384,7 @@ impl<'tcx> TerminatorKind<'tcx> {
             | TerminatorKind::GeneratorDrop
             | TerminatorKind::Yield { .. }
             | TerminatorKind::SwitchInt { .. }
-            | TerminatorKind::FalseEdges { .. }
+            | TerminatorKind::FalseEdge { .. }
             | TerminatorKind::InlineAsm { .. } => None,
             TerminatorKind::Call { cleanup: ref mut unwind, .. }
             | TerminatorKind::Assert { cleanup: ref mut unwind, .. }
@@ -1598,7 +1598,7 @@ impl<'tcx> TerminatorKind<'tcx> {
                 msg.fmt_assert_args(fmt)?;
                 write!(fmt, ")")
             }
-            FalseEdges { .. } => write!(fmt, "falseEdges"),
+            FalseEdge { .. } => write!(fmt, "falseEdge"),
             FalseUnwind { .. } => write!(fmt, "falseUnwind"),
             InlineAsm { template, ref operands, options, .. } => {
                 write!(fmt, "asm!(\"{}\"", InlineAsmTemplatePiece::to_string(template))?;
@@ -1683,7 +1683,7 @@ impl<'tcx> TerminatorKind<'tcx> {
             }
             Assert { cleanup: None, .. } => vec!["".into()],
             Assert { .. } => vec!["success".into(), "unwind".into()],
-            FalseEdges { .. } => vec!["real".into(), "imaginary".into()],
+            FalseEdge { .. } => vec!["real".into(), "imaginary".into()],
             FalseUnwind { unwind: Some(_), .. } => vec!["real".into(), "cleanup".into()],
             FalseUnwind { unwind: None, .. } => vec!["real".into()],
             InlineAsm { destination: Some(_), .. } => vec!["".into()],

--- a/src/librustc_middle/mir/type_foldable.rs
+++ b/src/librustc_middle/mir/type_foldable.rs
@@ -74,8 +74,8 @@ impl<'tcx> TypeFoldable<'tcx> for Terminator<'tcx> {
             Abort => Abort,
             Return => Return,
             Unreachable => Unreachable,
-            FalseEdges { real_target, imaginary_target } => {
-                FalseEdges { real_target, imaginary_target }
+            FalseEdge { real_target, imaginary_target } => {
+                FalseEdge { real_target, imaginary_target }
             }
             FalseUnwind { real_target, unwind } => FalseUnwind { real_target, unwind },
             InlineAsm { template, ref operands, options, line_spans, destination } => InlineAsm {
@@ -134,7 +134,7 @@ impl<'tcx> TypeFoldable<'tcx> for Terminator<'tcx> {
             | Return
             | GeneratorDrop
             | Unreachable
-            | FalseEdges { .. }
+            | FalseEdge { .. }
             | FalseUnwind { .. } => false,
         }
     }

--- a/src/librustc_middle/mir/visit.rs
+++ b/src/librustc_middle/mir/visit.rs
@@ -429,7 +429,7 @@ macro_rules! make_mir_visitor {
                     TerminatorKind::Abort |
                     TerminatorKind::GeneratorDrop |
                     TerminatorKind::Unreachable |
-                    TerminatorKind::FalseEdges { .. } |
+                    TerminatorKind::FalseEdge { .. } |
                     TerminatorKind::FalseUnwind { .. } => {
                     }
 

--- a/src/librustc_mir/borrow_check/invalidation.rs
+++ b/src/librustc_mir/borrow_check/invalidation.rs
@@ -215,7 +215,7 @@ impl<'cx, 'tcx> Visitor<'tcx> for InvalidationGenerator<'cx, 'tcx> {
             TerminatorKind::Goto { target: _ }
             | TerminatorKind::Abort
             | TerminatorKind::Unreachable
-            | TerminatorKind::FalseEdges { real_target: _, imaginary_target: _ }
+            | TerminatorKind::FalseEdge { real_target: _, imaginary_target: _ }
             | TerminatorKind::FalseUnwind { real_target: _, unwind: _ } => {
                 // no data used, thus irrelevant to borrowck
             }

--- a/src/librustc_mir/borrow_check/mod.rs
+++ b/src/librustc_mir/borrow_check/mod.rs
@@ -770,7 +770,7 @@ impl<'cx, 'tcx> dataflow::ResultsVisitor<'cx, 'tcx> for MirBorrowckCtxt<'cx, 'tc
             | TerminatorKind::Resume
             | TerminatorKind::Return
             | TerminatorKind::GeneratorDrop
-            | TerminatorKind::FalseEdges { real_target: _, imaginary_target: _ }
+            | TerminatorKind::FalseEdge { real_target: _, imaginary_target: _ }
             | TerminatorKind::FalseUnwind { real_target: _, unwind: _ } => {
                 // no data used, thus irrelevant to borrowck
             }
@@ -814,7 +814,7 @@ impl<'cx, 'tcx> dataflow::ResultsVisitor<'cx, 'tcx> for MirBorrowckCtxt<'cx, 'tc
             | TerminatorKind::Call { .. }
             | TerminatorKind::Drop { .. }
             | TerminatorKind::DropAndReplace { .. }
-            | TerminatorKind::FalseEdges { real_target: _, imaginary_target: _ }
+            | TerminatorKind::FalseEdge { real_target: _, imaginary_target: _ }
             | TerminatorKind::FalseUnwind { real_target: _, unwind: _ }
             | TerminatorKind::Goto { .. }
             | TerminatorKind::SwitchInt { .. }

--- a/src/librustc_mir/borrow_check/type_check/mod.rs
+++ b/src/librustc_mir/borrow_check/type_check/mod.rs
@@ -1547,7 +1547,7 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
             | TerminatorKind::GeneratorDrop
             | TerminatorKind::Unreachable
             | TerminatorKind::Drop { .. }
-            | TerminatorKind::FalseEdges { .. }
+            | TerminatorKind::FalseEdge { .. }
             | TerminatorKind::FalseUnwind { .. }
             | TerminatorKind::InlineAsm { .. } => {
                 // no checks needed for these
@@ -1843,7 +1843,7 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
                     self.assert_iscleanup(body, block_data, cleanup, true);
                 }
             }
-            TerminatorKind::FalseEdges { real_target, imaginary_target } => {
+            TerminatorKind::FalseEdge { real_target, imaginary_target } => {
                 self.assert_iscleanup(body, block_data, real_target, is_cleanup);
                 self.assert_iscleanup(body, block_data, imaginary_target, is_cleanup);
             }

--- a/src/librustc_mir/dataflow/framework/direction.rs
+++ b/src/librustc_mir/dataflow/framework/direction.rs
@@ -453,7 +453,7 @@ impl Direction for Forward {
                 propagate(target, exit_state);
             }
 
-            FalseEdges { real_target, imaginary_target } => {
+            FalseEdge { real_target, imaginary_target } => {
                 propagate(real_target, exit_state);
                 propagate(imaginary_target, exit_state);
             }

--- a/src/librustc_mir/dataflow/impls/borrowed_locals.rs
+++ b/src/librustc_mir/dataflow/impls/borrowed_locals.rs
@@ -203,7 +203,7 @@ where
             TerminatorKind::Abort
             | TerminatorKind::Assert { .. }
             | TerminatorKind::Call { .. }
-            | TerminatorKind::FalseEdges { .. }
+            | TerminatorKind::FalseEdge { .. }
             | TerminatorKind::FalseUnwind { .. }
             | TerminatorKind::GeneratorDrop
             | TerminatorKind::Goto { .. }

--- a/src/librustc_mir/dataflow/move_paths/builder.rs
+++ b/src/librustc_mir/dataflow/move_paths/builder.rs
@@ -365,7 +365,7 @@ impl<'b, 'a, 'tcx> Gatherer<'b, 'a, 'tcx> {
             | TerminatorKind::Resume
             | TerminatorKind::Abort
             | TerminatorKind::GeneratorDrop
-            | TerminatorKind::FalseEdges { .. }
+            | TerminatorKind::FalseEdge { .. }
             | TerminatorKind::FalseUnwind { .. }
             | TerminatorKind::Unreachable => {}
 

--- a/src/librustc_mir/interpret/terminator.rs
+++ b/src/librustc_mir/interpret/terminator.rs
@@ -129,7 +129,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
 
             // These should never occur for MIR we actually run.
             DropAndReplace { .. }
-            | FalseEdges { .. }
+            | FalseEdge { .. }
             | FalseUnwind { .. }
             | Yield { .. }
             | GeneratorDrop => span_bug!(

--- a/src/librustc_mir/monomorphize/collector.rs
+++ b/src/librustc_mir/monomorphize/collector.rs
@@ -649,7 +649,7 @@ impl<'a, 'tcx> MirVisitor<'tcx> for MirNeighborCollector<'a, 'tcx> {
             | mir::TerminatorKind::Assert { .. } => {}
             mir::TerminatorKind::GeneratorDrop
             | mir::TerminatorKind::Yield { .. }
-            | mir::TerminatorKind::FalseEdges { .. }
+            | mir::TerminatorKind::FalseEdge { .. }
             | mir::TerminatorKind::FalseUnwind { .. } => bug!(),
         }
 

--- a/src/librustc_mir/transform/check_consts/validation.rs
+++ b/src/librustc_mir/transform/check_consts/validation.rs
@@ -609,7 +609,7 @@ impl Visitor<'tcx> for Validator<'mir, 'tcx> {
             // instead.
             TerminatorKind::Abort
             | TerminatorKind::Assert { .. }
-            | TerminatorKind::FalseEdges { .. }
+            | TerminatorKind::FalseEdge { .. }
             | TerminatorKind::FalseUnwind { .. }
             | TerminatorKind::GeneratorDrop
             | TerminatorKind::Goto { .. }

--- a/src/librustc_mir/transform/check_unsafety.rs
+++ b/src/librustc_mir/transform/check_unsafety.rs
@@ -76,7 +76,7 @@ impl<'a, 'tcx> Visitor<'tcx> for UnsafetyChecker<'a, 'tcx> {
             | TerminatorKind::Abort
             | TerminatorKind::Return
             | TerminatorKind::Unreachable
-            | TerminatorKind::FalseEdges { .. }
+            | TerminatorKind::FalseEdge { .. }
             | TerminatorKind::FalseUnwind { .. } => {
                 // safe (at least as emitted during MIR construction)
             }

--- a/src/librustc_mir/transform/const_prop.rs
+++ b/src/librustc_mir/transform/const_prop.rs
@@ -1013,7 +1013,7 @@ impl<'mir, 'tcx> MutVisitor<'tcx> for ConstPropagator<'mir, 'tcx> {
             | TerminatorKind::DropAndReplace { .. }
             | TerminatorKind::Yield { .. }
             | TerminatorKind::GeneratorDrop
-            | TerminatorKind::FalseEdges { .. }
+            | TerminatorKind::FalseEdge { .. }
             | TerminatorKind::FalseUnwind { .. }
             | TerminatorKind::InlineAsm { .. } => {}
             // Every argument in our function calls can be const propagated.

--- a/src/librustc_mir/transform/generator.rs
+++ b/src/librustc_mir/transform/generator.rs
@@ -669,6 +669,51 @@ fn compute_storage_conflicts(
     storage_conflicts
 }
 
+/// Validates the typeck view of the generator against the actual set of types retained between
+/// yield points.
+fn sanitize_witness<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    body: &Body<'tcx>,
+    did: DefId,
+    witness: Ty<'tcx>,
+    upvars: &Vec<Ty<'tcx>>,
+    retained: &BitSet<Local>,
+) {
+    let allowed_upvars = tcx.erase_regions(upvars);
+    let allowed = match witness.kind {
+        ty::GeneratorWitness(s) => tcx.erase_late_bound_regions(&s),
+        _ => {
+            tcx.sess.delay_span_bug(
+                body.span,
+                &format!("unexpected generator witness type {:?}", witness.kind),
+            );
+            return;
+        }
+    };
+
+    let param_env = tcx.param_env(did);
+
+    for (local, decl) in body.local_decls.iter_enumerated() {
+        // Ignore locals which are internal or not retained between yields.
+        if !retained.contains(local) || decl.internal {
+            continue;
+        }
+        let decl_ty = tcx.normalize_erasing_regions(param_env, decl.ty);
+
+        // Sanity check that typeck knows about the type of locals which are
+        // live across a suspension point
+        if !allowed.contains(&decl_ty) && !allowed_upvars.contains(&decl_ty) {
+            span_bug!(
+                body.span,
+                "Broken MIR: generator contains type {} in MIR, \
+                       but typeck only knows about {}",
+                decl.ty,
+                witness,
+            );
+        }
+    }
+}
+
 fn compute_layout<'tcx>(
     tcx: TyCtxt<'tcx>,
     source: MirSource<'tcx>,
@@ -690,35 +735,7 @@ fn compute_layout<'tcx>(
         storage_liveness,
     } = locals_live_across_suspend_points(tcx, body, source, always_live_locals, movable);
 
-    // Erase regions from the types passed in from typeck so we can compare them with
-    // MIR types
-    let allowed_upvars = tcx.erase_regions(upvars);
-    let allowed = match interior.kind {
-        ty::GeneratorWitness(s) => tcx.erase_late_bound_regions(&s),
-        _ => bug!(),
-    };
-
-    let param_env = tcx.param_env(source.def_id());
-
-    for (local, decl) in body.local_decls.iter_enumerated() {
-        // Ignore locals which are internal or not live
-        if !live_locals.contains(local) || decl.internal {
-            continue;
-        }
-        let decl_ty = tcx.normalize_erasing_regions(param_env, decl.ty);
-
-        // Sanity check that typeck knows about the type of locals which are
-        // live across a suspension point
-        if !allowed.contains(&decl_ty) && !allowed_upvars.contains(&decl_ty) {
-            span_bug!(
-                body.span,
-                "Broken MIR: generator contains type {} in MIR, \
-                       but typeck only knows about {}",
-                decl.ty,
-                interior
-            );
-        }
-    }
+    sanitize_witness(tcx, body, source.def_id(), interior, upvars, &live_locals);
 
     // Gather live local types and their indices.
     let mut locals = IndexVec::<GeneratorSavedLocal, _>::new();

--- a/src/librustc_mir/transform/generator.rs
+++ b/src/librustc_mir/transform/generator.rs
@@ -971,7 +971,7 @@ fn can_unwind<'tcx>(tcx: TyCtxt<'tcx>, body: &Body<'tcx>) -> bool {
             | TerminatorKind::Return
             | TerminatorKind::Unreachable
             | TerminatorKind::GeneratorDrop
-            | TerminatorKind::FalseEdges { .. }
+            | TerminatorKind::FalseEdge { .. }
             | TerminatorKind::FalseUnwind { .. }
             | TerminatorKind::InlineAsm { .. } => {}
 

--- a/src/librustc_mir/transform/inline.rs
+++ b/src/librustc_mir/transform/inline.rs
@@ -791,7 +791,7 @@ impl<'a, 'tcx> MutVisitor<'tcx> for Integrator<'a, 'tcx> {
             }
             TerminatorKind::Abort => {}
             TerminatorKind::Unreachable => {}
-            TerminatorKind::FalseEdges { ref mut real_target, ref mut imaginary_target } => {
+            TerminatorKind::FalseEdge { ref mut real_target, ref mut imaginary_target } => {
                 *real_target = self.update_target(*real_target);
                 *imaginary_target = self.update_target(*imaginary_target);
             }

--- a/src/librustc_mir/transform/qualify_min_const_fn.rs
+++ b/src/librustc_mir/transform/qualify_min_const_fn.rs
@@ -342,7 +342,7 @@ fn check_terminator(
 ) -> McfResult {
     let span = terminator.source_info.span;
     match &terminator.kind {
-        TerminatorKind::FalseEdges { .. }
+        TerminatorKind::FalseEdge { .. }
         | TerminatorKind::FalseUnwind { .. }
         | TerminatorKind::Goto { .. }
         | TerminatorKind::Return

--- a/src/librustc_mir/transform/remove_noop_landing_pads.rs
+++ b/src/librustc_mir/transform/remove_noop_landing_pads.rs
@@ -65,7 +65,7 @@ impl RemoveNoopLandingPads {
             TerminatorKind::Goto { .. }
             | TerminatorKind::Resume
             | TerminatorKind::SwitchInt { .. }
-            | TerminatorKind::FalseEdges { .. }
+            | TerminatorKind::FalseEdge { .. }
             | TerminatorKind::FalseUnwind { .. } => {
                 terminator.successors().all(|&succ| nop_landing_pads.contains(succ))
             }

--- a/src/librustc_mir/transform/simplify_branches.rs
+++ b/src/librustc_mir/transform/simplify_branches.rs
@@ -53,7 +53,7 @@ impl<'tcx> MirPass<'tcx> for SimplifyBranches {
                 } if (c.literal.try_eval_bool(tcx, param_env) == Some(true)) == expected => {
                     TerminatorKind::Goto { target }
                 }
-                TerminatorKind::FalseEdges { real_target, .. } => {
+                TerminatorKind::FalseEdge { real_target, .. } => {
                     TerminatorKind::Goto { target: real_target }
                 }
                 TerminatorKind::FalseUnwind { real_target, .. } => {

--- a/src/librustc_mir/transform/validate.rs
+++ b/src/librustc_mir/transform/validate.rs
@@ -159,7 +159,7 @@ impl<'a, 'tcx> Visitor<'tcx> for TypeChecker<'a, 'tcx> {
                     self.check_bb(location, *drop);
                 }
             }
-            TerminatorKind::FalseEdges { real_target, imaginary_target } => {
+            TerminatorKind::FalseEdge { real_target, imaginary_target } => {
                 self.check_bb(location, *real_target);
                 self.check_bb(location, *imaginary_target);
             }

--- a/src/librustc_mir_build/build/matches/util.rs
+++ b/src/librustc_mir_build/build/matches/util.rs
@@ -85,7 +85,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 self.cfg.terminate(
                     from_block,
                     source_info,
-                    TerminatorKind::FalseEdges { real_target, imaginary_target: target },
+                    TerminatorKind::FalseEdge { real_target, imaginary_target: target },
                 );
             }
             _ => self.cfg.goto(from_block, source_info, real_target),

--- a/src/librustc_mir_build/lints.rs
+++ b/src/librustc_mir_build/lints.rs
@@ -128,7 +128,7 @@ impl<'mir, 'tcx> TriColorVisitor<&'mir Body<'tcx>> for Search<'mir, 'tcx> {
             | TerminatorKind::Call { .. }
             | TerminatorKind::Drop { .. }
             | TerminatorKind::DropAndReplace { .. }
-            | TerminatorKind::FalseEdges { .. }
+            | TerminatorKind::FalseEdge { .. }
             | TerminatorKind::FalseUnwind { .. }
             | TerminatorKind::Goto { .. }
             | TerminatorKind::SwitchInt { .. } => ControlFlow::Continue,
@@ -153,7 +153,7 @@ impl<'mir, 'tcx> TriColorVisitor<&'mir Body<'tcx>> for Search<'mir, 'tcx> {
             TerminatorKind::Call { ref func, .. } => self.is_recursive_call(func),
 
             TerminatorKind::FalseUnwind { unwind: Some(imaginary_target), .. }
-            | TerminatorKind::FalseEdges { imaginary_target, .. } => imaginary_target == target,
+            | TerminatorKind::FalseEdge { imaginary_target, .. } => imaginary_target == target,
 
             _ => false,
         }

--- a/src/librustc_session/lint.rs
+++ b/src/librustc_session/lint.rs
@@ -85,6 +85,9 @@ pub struct Lint {
     pub future_incompatible: Option<FutureIncompatibleInfo>,
 
     pub is_plugin: bool,
+
+    /// `Some` if this lint is feature gated, otherwise `None`.
+    pub feature_gate: Option<Symbol>,
 }
 
 /// Extra information for a future incompatibility lint.
@@ -107,6 +110,7 @@ impl Lint {
             is_plugin: false,
             report_in_external_macro: false,
             future_incompatible: None,
+            feature_gate: None,
         }
     }
 
@@ -276,7 +280,9 @@ macro_rules! declare_lint {
         );
     );
     ($vis: vis $NAME: ident, $Level: ident, $desc: expr,
-     $(@future_incompatible = $fi:expr;)? $($v:ident),*) => (
+     $(@future_incompatible = $fi:expr;)?
+     $(@feature_gate = $gate:expr;)?
+     $($v:ident),*) => (
         $vis static $NAME: &$crate::lint::Lint = &$crate::lint::Lint {
             name: stringify!($NAME),
             default_level: $crate::lint::$Level,
@@ -285,6 +291,7 @@ macro_rules! declare_lint {
             is_plugin: false,
             $($v: true,)*
             $(future_incompatible: Some($fi),)*
+            $(feature_gate: Some($gate),)*
             ..$crate::lint::Lint::default_fields_for_macro()
         };
     );
@@ -328,6 +335,7 @@ macro_rules! declare_tool_lint {
             report_in_external_macro: $external,
             future_incompatible: None,
             is_plugin: true,
+            feature_gate: None,
         };
     );
 }

--- a/src/librustc_session/lint/builtin.rs
+++ b/src/librustc_session/lint/builtin.rs
@@ -7,6 +7,7 @@
 use crate::lint::FutureIncompatibleInfo;
 use crate::{declare_lint, declare_lint_pass};
 use rustc_span::edition::Edition;
+use rustc_span::symbol::sym;
 
 declare_lint! {
     pub ILL_FORMED_ATTRIBUTE_INPUT,
@@ -530,6 +531,7 @@ declare_lint! {
     pub UNSAFE_OP_IN_UNSAFE_FN,
     Allow,
     "unsafe operations in unsafe functions without an explicit unsafe block are deprecated",
+    @feature_gate = sym::unsafe_block_in_unsafe_fn;
 }
 
 declare_lint_pass! {

--- a/src/librustc_ty/needs_drop.rs
+++ b/src/librustc_ty/needs_drop.rs
@@ -98,7 +98,7 @@ where
                         }
                     }
 
-                    ty::Generator(_, substs, _) => {
+                    ty::Generator(def_id, substs, _) => {
                         let substs = substs.as_generator();
                         for upvar_ty in substs.upvar_tys() {
                             queue_type(self, upvar_ty);
@@ -107,7 +107,13 @@ where
                         let witness = substs.witness();
                         let interior_tys = match &witness.kind {
                             ty::GeneratorWitness(tys) => tcx.erase_late_bound_regions(tys),
-                            _ => bug!(),
+                            _ => {
+                                tcx.sess.delay_span_bug(
+                                    tcx.hir().span_if_local(def_id).unwrap_or(DUMMY_SP),
+                                    &format!("unexpected generator witness type {:?}", witness),
+                                );
+                                return Some(Err(AlwaysRequiresDrop));
+                            }
                         };
 
                         for interior_ty in interior_tys {

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -225,11 +225,6 @@ where
 {
     let warnings_lint_name = lint::builtin::WARNINGS.name;
 
-    // Whitelist feature-gated lints to avoid feature errors when trying to
-    // allow all lints.
-    // FIXME(#72694): handle feature-gated lints properly.
-    let unsafe_op_in_unsafe_fn_name = rustc_lint::builtin::UNSAFE_OP_IN_UNSAFE_FN.name;
-
     whitelisted_lints.push(warnings_lint_name.to_owned());
     whitelisted_lints.extend(lint_opts.iter().map(|(lint, _)| lint).cloned());
 
@@ -241,7 +236,9 @@ where
 
     let lint_opts = lints()
         .filter_map(|lint| {
-            if lint.name == warnings_lint_name || lint.name == unsafe_op_in_unsafe_fn_name {
+            // Whitelist feature-gated lints to avoid feature errors when trying to
+            // allow all lints.
+            if lint.name == warnings_lint_name || lint.feature_gate.is_some() {
                 None
             } else {
                 filter_call(lint)

--- a/src/test/mir-opt/exponential-or/rustc.match_tuple.SimplifyCfg-initial.after.mir
+++ b/src/test/mir-opt/exponential-or/rustc.match_tuple.SimplifyCfg-initial.after.mir
@@ -87,7 +87,7 @@ fn match_tuple(_1: (u32, bool, std::option::Option<i32>, u32)) -> u32 {
     }
 
     bb8: {
-        falseEdges -> [real: bb9, imaginary: bb1]; // scope 0 at $DIR/exponential-or.rs:8:9: 8:79
+        falseEdge -> [real: bb9, imaginary: bb1]; // scope 0 at $DIR/exponential-or.rs:8:9: 8:79
     }
 
     bb9: {

--- a/src/test/mir-opt/issue-38669/rustc.main.SimplifyCfg-initial.after.mir
+++ b/src/test/mir-opt/issue-38669/rustc.main.SimplifyCfg-initial.after.mir
@@ -41,7 +41,7 @@ fn main() -> () {
     }
 
     bb4: {
-        falseEdges -> [real: bb6, imaginary: bb5]; // scope 1 at $DIR/issue-38669.rs:7:9: 9:10
+        falseEdge -> [real: bb6, imaginary: bb5]; // scope 1 at $DIR/issue-38669.rs:7:9: 9:10
     }
 
     bb5: {

--- a/src/test/mir-opt/issue-49232/rustc.main.mir_map.0.mir
+++ b/src/test/mir-opt/issue-49232/rustc.main.mir_map.0.mir
@@ -43,7 +43,7 @@ fn main() -> () {
     }
 
     bb5: {
-        falseEdges -> [real: bb7, imaginary: bb6]; // scope 0 at $DIR/issue-49232.rs:9:17: 9:22
+        falseEdge -> [real: bb7, imaginary: bb6]; // scope 0 at $DIR/issue-49232.rs:9:17: 9:22
     }
 
     bb6: {

--- a/src/test/mir-opt/loop_test/rustc.main.SimplifyCfg-qualify-consts.after.mir
+++ b/src/test/mir-opt/loop_test/rustc.main.SimplifyCfg-qualify-consts.after.mir
@@ -31,7 +31,7 @@ fn main() -> () {
     }
 
     bb2: {
-        falseEdges -> [real: bb4, imaginary: bb3]; // scope 0 at $DIR/loop_test.rs:10:5: 12:6
+        falseEdge -> [real: bb4, imaginary: bb3]; // scope 0 at $DIR/loop_test.rs:10:5: 12:6
     }
 
     bb3: {

--- a/src/test/mir-opt/match-arm-scopes/rustc.complicated_match.SimplifyCfg-initial.after.mir
+++ b/src/test/mir-opt/match-arm-scopes/rustc.complicated_match.SimplifyCfg-initial.after.mir
@@ -39,7 +39,7 @@ fn complicated_match(_1: bool, _2: (bool, bool, std::string::String)) -> i32 {
     }
 
     bb2: {
-        falseEdges -> [real: bb9, imaginary: bb4]; // scope 0 at $DIR/match-arm-scopes.rs:16:9: 16:22
+        falseEdge -> [real: bb9, imaginary: bb4]; // scope 0 at $DIR/match-arm-scopes.rs:16:9: 16:22
     }
 
     bb3: {
@@ -47,7 +47,7 @@ fn complicated_match(_1: bool, _2: (bool, bool, std::string::String)) -> i32 {
     }
 
     bb4: {
-        falseEdges -> [real: bb18, imaginary: bb6]; // scope 0 at $DIR/match-arm-scopes.rs:16:25: 16:38
+        falseEdge -> [real: bb18, imaginary: bb6]; // scope 0 at $DIR/match-arm-scopes.rs:16:25: 16:38
     }
 
     bb5: {
@@ -55,7 +55,7 @@ fn complicated_match(_1: bool, _2: (bool, bool, std::string::String)) -> i32 {
     }
 
     bb6: {
-        falseEdges -> [real: bb26, imaginary: bb7]; // scope 0 at $DIR/match-arm-scopes.rs:17:9: 17:21
+        falseEdge -> [real: bb26, imaginary: bb7]; // scope 0 at $DIR/match-arm-scopes.rs:17:9: 17:21
     }
 
     bb7: {
@@ -92,7 +92,7 @@ fn complicated_match(_1: bool, _2: (bool, bool, std::string::String)) -> i32 {
     }
 
     bb10: {
-        falseEdges -> [real: bb12, imaginary: bb11]; // scope 0 at $DIR/match-arm-scopes.rs:16:42: 16:73
+        falseEdge -> [real: bb12, imaginary: bb11]; // scope 0 at $DIR/match-arm-scopes.rs:16:42: 16:73
     }
 
     bb11: {
@@ -145,7 +145,7 @@ fn complicated_match(_1: bool, _2: (bool, bool, std::string::String)) -> i32 {
         StorageDead(_9);                 // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
         StorageDead(_8);                 // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
         StorageDead(_6);                 // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
-        falseEdges -> [real: bb3, imaginary: bb4]; // scope 0 at $DIR/match-arm-scopes.rs:16:42: 16:73
+        falseEdge -> [real: bb3, imaginary: bb4]; // scope 0 at $DIR/match-arm-scopes.rs:16:42: 16:73
     }
 
     bb18: {
@@ -163,7 +163,7 @@ fn complicated_match(_1: bool, _2: (bool, bool, std::string::String)) -> i32 {
     }
 
     bb19: {
-        falseEdges -> [real: bb21, imaginary: bb20]; // scope 0 at $DIR/match-arm-scopes.rs:16:42: 16:73
+        falseEdge -> [real: bb21, imaginary: bb20]; // scope 0 at $DIR/match-arm-scopes.rs:16:42: 16:73
     }
 
     bb20: {
@@ -204,7 +204,7 @@ fn complicated_match(_1: bool, _2: (bool, bool, std::string::String)) -> i32 {
         StorageDead(_12);                // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
         StorageDead(_8);                 // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
         StorageDead(_6);                 // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
-        falseEdges -> [real: bb5, imaginary: bb6]; // scope 0 at $DIR/match-arm-scopes.rs:16:42: 16:73
+        falseEdge -> [real: bb5, imaginary: bb6]; // scope 0 at $DIR/match-arm-scopes.rs:16:42: 16:73
     }
 
     bb24: {

--- a/src/test/mir-opt/match_false_edges/rustc.full_tested_match.PromoteTemps.after.mir
+++ b/src/test/mir-opt/match_false_edges/rustc.full_tested_match.PromoteTemps.after.mir
@@ -60,11 +60,11 @@ fn full_tested_match() -> () {
     }
 
     bb3: {
-        falseEdges -> [real: bb6, imaginary: bb4]; // scope 0 at $DIR/match_false_edges.rs:16:9: 16:16
+        falseEdge -> [real: bb6, imaginary: bb4]; // scope 0 at $DIR/match_false_edges.rs:16:9: 16:16
     }
 
     bb4: {
-        falseEdges -> [real: bb10, imaginary: bb2]; // scope 0 at $DIR/match_false_edges.rs:17:9: 17:16
+        falseEdge -> [real: bb10, imaginary: bb2]; // scope 0 at $DIR/match_false_edges.rs:17:9: 17:16
     }
 
     bb5: {

--- a/src/test/mir-opt/match_false_edges/rustc.full_tested_match2.PromoteTemps.before.mir
+++ b/src/test/mir-opt/match_false_edges/rustc.full_tested_match2.PromoteTemps.before.mir
@@ -42,11 +42,11 @@ fn full_tested_match2() -> () {
     }
 
     bb2: {
-        falseEdges -> [real: bb10, imaginary: bb4]; // scope 0 at $DIR/match_false_edges.rs:28:9: 28:13
+        falseEdge -> [real: bb10, imaginary: bb4]; // scope 0 at $DIR/match_false_edges.rs:28:9: 28:13
     }
 
     bb3: {
-        falseEdges -> [real: bb6, imaginary: bb2]; // scope 0 at $DIR/match_false_edges.rs:27:9: 27:16
+        falseEdge -> [real: bb6, imaginary: bb2]; // scope 0 at $DIR/match_false_edges.rs:27:9: 27:16
     }
 
     bb4: {
@@ -112,7 +112,7 @@ fn full_tested_match2() -> () {
     bb9: {
         StorageDead(_7);                 // scope 0 at $DIR/match_false_edges.rs:27:37: 27:38
         StorageDead(_6);                 // scope 0 at $DIR/match_false_edges.rs:27:37: 27:38
-        falseEdges -> [real: bb4, imaginary: bb2]; // scope 0 at $DIR/match_false_edges.rs:27:20: 27:27
+        falseEdge -> [real: bb4, imaginary: bb2]; // scope 0 at $DIR/match_false_edges.rs:27:20: 27:27
     }
 
     bb10: {

--- a/src/test/mir-opt/match_false_edges/rustc.main.PromoteTemps.before.mir
+++ b/src/test/mir-opt/match_false_edges/rustc.main.PromoteTemps.before.mir
@@ -53,11 +53,11 @@ fn main() -> () {
     }
 
     bb2: {
-        falseEdges -> [real: bb10, imaginary: bb5]; // scope 0 at $DIR/match_false_edges.rs:37:9: 37:11
+        falseEdge -> [real: bb10, imaginary: bb5]; // scope 0 at $DIR/match_false_edges.rs:37:9: 37:11
     }
 
     bb3: {
-        falseEdges -> [real: bb6, imaginary: bb2]; // scope 0 at $DIR/match_false_edges.rs:36:9: 36:17
+        falseEdge -> [real: bb6, imaginary: bb2]; // scope 0 at $DIR/match_false_edges.rs:36:9: 36:17
     }
 
     bb4: {
@@ -75,7 +75,7 @@ fn main() -> () {
     }
 
     bb5: {
-        falseEdges -> [real: bb11, imaginary: bb4]; // scope 0 at $DIR/match_false_edges.rs:38:9: 38:16
+        falseEdge -> [real: bb11, imaginary: bb4]; // scope 0 at $DIR/match_false_edges.rs:38:9: 38:16
     }
 
     bb6: {
@@ -117,7 +117,7 @@ fn main() -> () {
     bb9: {
         StorageDead(_8);                 // scope 0 at $DIR/match_false_edges.rs:36:33: 36:34
         StorageDead(_7);                 // scope 0 at $DIR/match_false_edges.rs:36:33: 36:34
-        falseEdges -> [real: bb2, imaginary: bb2]; // scope 0 at $DIR/match_false_edges.rs:36:21: 36:28
+        falseEdge -> [real: bb2, imaginary: bb2]; // scope 0 at $DIR/match_false_edges.rs:36:21: 36:28
     }
 
     bb10: {
@@ -176,7 +176,7 @@ fn main() -> () {
     bb14: {
         StorageDead(_12);                // scope 0 at $DIR/match_false_edges.rs:38:34: 38:35
         StorageDead(_11);                // scope 0 at $DIR/match_false_edges.rs:38:34: 38:35
-        falseEdges -> [real: bb4, imaginary: bb4]; // scope 0 at $DIR/match_false_edges.rs:38:20: 38:29
+        falseEdge -> [real: bb4, imaginary: bb4]; // scope 0 at $DIR/match_false_edges.rs:38:20: 38:29
     }
 
     bb15: {

--- a/src/test/mir-opt/match_test/rustc.main.SimplifyCfg-initial.after.mir
+++ b/src/test/mir-opt/match_test/rustc.main.SimplifyCfg-initial.after.mir
@@ -61,7 +61,7 @@ fn main() -> () {
     }
 
     bb2: {
-        falseEdges -> [real: bb9, imaginary: bb6]; // scope 2 at $DIR/match_test.rs:13:9: 13:14
+        falseEdge -> [real: bb9, imaginary: bb6]; // scope 2 at $DIR/match_test.rs:13:9: 13:14
     }
 
     bb3: {
@@ -98,7 +98,7 @@ fn main() -> () {
     }
 
     bb6: {
-        falseEdges -> [real: bb12, imaginary: bb8]; // scope 2 at $DIR/match_test.rs:14:9: 14:16
+        falseEdge -> [real: bb12, imaginary: bb8]; // scope 2 at $DIR/match_test.rs:14:9: 14:16
     }
 
     bb7: {
@@ -106,7 +106,7 @@ fn main() -> () {
     }
 
     bb8: {
-        falseEdges -> [real: bb13, imaginary: bb3]; // scope 2 at $DIR/match_test.rs:15:9: 15:11
+        falseEdge -> [real: bb13, imaginary: bb3]; // scope 2 at $DIR/match_test.rs:15:9: 15:11
     }
 
     bb9: {
@@ -131,7 +131,7 @@ fn main() -> () {
 
     bb11: {
         StorageDead(_9);                 // scope 2 at $DIR/match_test.rs:13:24: 13:25
-        falseEdges -> [real: bb3, imaginary: bb6]; // scope 2 at $DIR/match_test.rs:13:18: 13:19
+        falseEdge -> [real: bb3, imaginary: bb6]; // scope 2 at $DIR/match_test.rs:13:18: 13:19
     }
 
     bb12: {

--- a/src/test/mir-opt/nll/region-subtyping-basic/32bit/rustc.main.nll.0.mir
+++ b/src/test/mir-opt/nll/region-subtyping-basic/32bit/rustc.main.nll.0.mir
@@ -102,7 +102,7 @@ fn main() -> () {
     }
 
     bb3: {
-        falseEdges -> [real: bb5, imaginary: bb4]; // bb3[0]: scope 3 at $DIR/region-subtyping-basic.rs:20:5: 24:6
+        falseEdge -> [real: bb5, imaginary: bb4]; // bb3[0]: scope 3 at $DIR/region-subtyping-basic.rs:20:5: 24:6
     }
 
     bb4: {

--- a/src/test/mir-opt/nll/region-subtyping-basic/64bit/rustc.main.nll.0.mir
+++ b/src/test/mir-opt/nll/region-subtyping-basic/64bit/rustc.main.nll.0.mir
@@ -102,7 +102,7 @@ fn main() -> () {
     }
 
     bb3: {
-        falseEdges -> [real: bb5, imaginary: bb4]; // bb3[0]: scope 3 at $DIR/region-subtyping-basic.rs:20:5: 24:6
+        falseEdge -> [real: bb5, imaginary: bb4]; // bb3[0]: scope 3 at $DIR/region-subtyping-basic.rs:20:5: 24:6
     }
 
     bb4: {

--- a/src/test/mir-opt/simple-match/32bit/rustc.match_bool.mir_map.0.mir
+++ b/src/test/mir-opt/simple-match/32bit/rustc.match_bool.mir_map.0.mir
@@ -14,7 +14,7 @@ fn match_bool(_1: bool) -> usize {
     }
 
     bb2: {
-        falseEdges -> [real: bb4, imaginary: bb3]; // scope 0 at $DIR/simple-match.rs:7:9: 7:13
+        falseEdge -> [real: bb4, imaginary: bb3]; // scope 0 at $DIR/simple-match.rs:7:9: 7:13
     }
 
     bb3: {

--- a/src/test/mir-opt/simple-match/64bit/rustc.match_bool.mir_map.0.mir
+++ b/src/test/mir-opt/simple-match/64bit/rustc.match_bool.mir_map.0.mir
@@ -14,7 +14,7 @@ fn match_bool(_1: bool) -> usize {
     }
 
     bb2: {
-        falseEdges -> [real: bb4, imaginary: bb3]; // scope 0 at $DIR/simple-match.rs:7:9: 7:13
+        falseEdge -> [real: bb4, imaginary: bb3]; // scope 0 at $DIR/simple-match.rs:7:9: 7:13
     }
 
     bb3: {

--- a/src/test/mir-opt/simplify_cfg/rustc.main.SimplifyCfg-initial.diff
+++ b/src/test/mir-opt/simplify_cfg/rustc.main.SimplifyCfg-initial.diff
@@ -45,9 +45,9 @@
       }
   
 -     bb6: {
--         falseEdges -> [real: bb8, imaginary: bb7]; // scope 0 at $DIR/simplify_cfg.rs:7:9: 9:10
+-         falseEdge -> [real: bb8, imaginary: bb7]; // scope 0 at $DIR/simplify_cfg.rs:7:9: 9:10
 +     bb4: {
-+         falseEdges -> [real: bb6, imaginary: bb5]; // scope 0 at $DIR/simplify_cfg.rs:7:9: 9:10
++         falseEdge -> [real: bb6, imaginary: bb5]; // scope 0 at $DIR/simplify_cfg.rs:7:9: 9:10
       }
   
 -     bb7: {


### PR DESCRIPTION
Successful merges:

 - #72764 (Be more careful around ty::Error in generators)
 - #72908 (rename FalseEdges -> FalseEdge)
 - #72970 (Properly handle feature-gated lints)
 - #72998 (Mention that some atomic operations may not be available on some platforms)
 - #73063 (Elide type on liballoc vec)

Failed merges:


r? @ghost