### PR TITLE
Example about explicit mutex dropping

### DIFF
--- a/src/libstd/sync/mutex.rs
+++ b/src/libstd/sync/mutex.rs
@@ -108,8 +108,8 @@ use crate::sys_common::poison::{self, LockResult, TryLockError, TryLockResult};
 /// *guard += 1;
 /// ```
 ///
-/// It is sometimes a good idea (or even necessary) to manually drop the mutex
-/// to unlock it as soon as possible. If you need the resource until the end of
+/// It is sometimes necessary to manually drop the mutex
+/// guard to unlock it as soon as possible. If you need the resource until the end of
 /// the scope, this is not needed.
 ///
 /// ```
@@ -140,16 +140,16 @@ use crate::sys_common::poison::{self, LockResult, TryLockError, TryLockResult};
 /// // This is the result of some important and long-ish work.
 /// let result = data.iter().fold(0, |acc, x| acc + x * 2);
 /// data.push(result);
-/// // We drop the `data` explicitely because it's not necessary anymore
+/// // We drop the `data` explicitly because it's not necessary anymore
 /// // and the thread still has work to do. This allow other threads to
 /// // start working on the data immediately, without waiting
 /// // for the rest of the unrelated work to be done here.
 /// //
 /// // It's even more important here than in the threads because we `.join` the
-/// // threads after that. If we had not dropped the lock, a thread could be
+/// // threads after that. If we had not dropped the mutex guard, a thread could be
 /// // waiting forever for it, causing a deadlock.
 /// drop(data);
-/// // Here the lock is not assigned to a variable and so, even if the scope
+/// // Here the mutex guard is not assigned to a variable and so, even if the scope
 /// // does not end after this line, the mutex is still released:
 /// // there is no deadlock.
 /// *res_mutex.lock().unwrap() += result;

--- a/src/libstd/sync/mutex.rs
+++ b/src/libstd/sync/mutex.rs
@@ -118,15 +118,11 @@ use crate::sys_common::poison::{self, LockResult, TryLockError, TryLockResult};
 ///
 /// const N: usize = 3;
 ///
-/// // Some data to work with in multiple threads.
 /// let data_mutex = Arc::new(Mutex::new(vec![1, 2, 3, 4]));
-/// // The result of all the work across all threads.
 /// let res_mutex = Arc::new(Mutex::new(0));
 ///
-/// // Threads other than the main thread.
 /// let mut threads = Vec::with_capacity(N);
 /// (0..N).for_each(|_| {
-///     // Getting clones for the mutexes.
 ///     let data_mutex_clone = Arc::clone(&data_mutex);
 ///     let res_mutex_clone = Arc::clone(&res_mutex);
 ///
@@ -135,10 +131,6 @@ use crate::sys_common::poison::{self, LockResult, TryLockError, TryLockResult};
 ///         // This is the result of some important and long-ish work.
 ///         let result = data.iter().fold(0, |acc, x| acc + x * 2);
 ///         data.push(result);
-///         // We drop the `data` explicitely because it's not necessary anymore
-///         // and the thread still has work to do. This allow other threads to
-///         // start working on the data immediately, without waiting
-///         // for the rest of the unrelated work to be done here.
 ///         drop(data);
 ///         *res_mutex_clone.lock().unwrap() += result;
 ///     }));
@@ -153,9 +145,9 @@ use crate::sys_common::poison::{self, LockResult, TryLockError, TryLockResult};
 /// // start working on the data immediately, without waiting
 /// // for the rest of the unrelated work to be done here.
 /// //
-/// // It's even more important here because we `.join` the threads after that.
-/// // If we had not dropped the lock, a thread could be waiting forever for
-/// // it, causing a deadlock.
+/// // It's even more important here than in the threads because we `.join` the
+/// // threads after that. If we had not dropped the lock, a thread could be
+/// // waiting forever for it, causing a deadlock.
 /// drop(data);
 /// // Here the lock is not assigned to a variable and so, even if the scope
 /// // does not end after this line, the mutex is still released:

--- a/src/libstd/sync/mutex.rs
+++ b/src/libstd/sync/mutex.rs
@@ -139,7 +139,7 @@ use crate::sys_common::poison::{self, LockResult, TryLockError, TryLockResult};
 ///         // and the thread still has work to do. This allow other threads to
 ///         // start working on the data immediately, without waiting
 ///         // for the rest of the unrelated work to be done here.
-///         std::mem::drop(data);
+///         drop(data);
 ///         *res_mutex_clone.lock().unwrap() += result;
 ///     }));
 /// });
@@ -156,7 +156,7 @@ use crate::sys_common::poison::{self, LockResult, TryLockError, TryLockResult};
 /// // It's even more important here because we `.join` the threads after that.
 /// // If we had not dropped the lock, a thread could be waiting forever for
 /// // it, causing a deadlock.
-/// std::mem::drop(data);
+/// drop(data);
 /// // Here the lock is not assigned to a variable and so, even if the scope
 /// // does not end after this line, the mutex is still released:
 /// // there is no deadlock.

--- a/src/libstd/sync/mutex.rs
+++ b/src/libstd/sync/mutex.rs
@@ -119,7 +119,7 @@ use crate::sys_common::poison::{self, LockResult, TryLockError, TryLockResult};
 /// const N: usize = 3;
 ///
 /// // Some data to work with in multiple threads.
-/// let data_mutex = Arc::new(Mutex::new([1, 2, 3, 4]));
+/// let data_mutex = Arc::new(Mutex::new(vec![1, 2, 3, 4]));
 /// // The result of all the work across all threads.
 /// let res_mutex = Arc::new(Mutex::new(0));
 ///
@@ -131,9 +131,10 @@ use crate::sys_common::poison::{self, LockResult, TryLockError, TryLockResult};
 ///     let res_mutex_clone = Arc::clone(&res_mutex);
 ///
 ///     threads.push(thread::spawn(move || {
-///         let data = *data_mutex_clone.lock().unwrap();
+///         let mut data = data_mutex_clone.lock().unwrap();
 ///         // This is the result of some important and long-ish work.
 ///         let result = data.iter().fold(0, |acc, x| acc + x * 2);
+///         data.push(result);
 ///         // We drop the `data` explicitely because it's not necessary anymore
 ///         // and the thread still has work to do. This allow other threads to
 ///         // start working on the data immediately, without waiting
@@ -143,9 +144,10 @@ use crate::sys_common::poison::{self, LockResult, TryLockError, TryLockResult};
 ///     }));
 /// });
 ///
-/// let data = *data_mutex.lock().unwrap();
+/// let mut data = data_mutex.lock().unwrap();
 /// // This is the result of some important and long-ish work.
 /// let result = data.iter().fold(0, |acc, x| acc + x * 2);
+/// data.push(result);
 /// // We drop the `data` explicitely because it's not necessary anymore
 /// // and the thread still has work to do. This allow other threads to
 /// // start working on the data immediately, without waiting
@@ -166,7 +168,7 @@ use crate::sys_common::poison::{self, LockResult, TryLockError, TryLockResult};
 ///         .expect("The thread creating or execution failed !")
 /// });
 ///
-/// assert_eq!(*res_mutex.lock().unwrap(), 80);
+/// assert_eq!(*res_mutex.lock().unwrap(), 800);
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 #[cfg_attr(not(test), rustc_diagnostic_item = "mutex_type")]

--- a/src/libstd/sync/mutex.rs
+++ b/src/libstd/sync/mutex.rs
@@ -108,8 +108,8 @@ use crate::sys_common::poison::{self, LockResult, TryLockError, TryLockResult};
 /// *guard += 1;
 /// ```
 ///
-/// It is sometimes necessary to manually drop the mutex guard
-/// to unlock it sooner than the end of the enclosing scope.
+/// It is sometimes necessary to manually drop the mutex guard to unlock it
+/// sooner than the end of the enclosing scope.
 ///
 /// ```
 /// use std::sync::{Arc, Mutex};
@@ -139,18 +139,18 @@ use crate::sys_common::poison::{self, LockResult, TryLockError, TryLockResult};
 /// // This is the result of some important and long-ish work.
 /// let result = data.iter().fold(0, |acc, x| acc + x * 2);
 /// data.push(result);
-/// // We drop the `data` explicitly because it's not necessary anymore
-/// // and the thread still has work to do. This allow other threads to
-/// // start working on the data immediately, without waiting
-/// // for the rest of the unrelated work to be done here.
+/// // We drop the `data` explicitly because it's not necessary anymore and the
+/// // thread still has work to do. This allow other threads to start working on
+/// // the data immediately, without waiting for the rest of the unrelated work
+/// // to be done here.
 /// //
 /// // It's even more important here than in the threads because we `.join` the
-/// // threads after that. If we had not dropped the mutex guard, a thread could be
-/// // waiting forever for it, causing a deadlock.
+/// // threads after that. If we had not dropped the mutex guard, a thread could
+/// // be waiting forever for it, causing a deadlock.
 /// drop(data);
-/// // Here the mutex guard is not assigned to a variable and so, even if the scope
-/// // does not end after this line, the mutex is still released:
-/// // there is no deadlock.
+/// // Here the mutex guard is not assigned to a variable and so, even if the
+/// // scope does not end after this line, the mutex is still released: there is
+/// // no deadlock.
 /// *res_mutex.lock().unwrap() += result;
 ///
 /// threads.into_iter().for_each(|thread| {

--- a/src/libstd/sync/mutex.rs
+++ b/src/libstd/sync/mutex.rs
@@ -108,9 +108,8 @@ use crate::sys_common::poison::{self, LockResult, TryLockError, TryLockResult};
 /// *guard += 1;
 /// ```
 ///
-/// It is sometimes necessary to manually drop the mutex
-/// guard to unlock it as soon as possible. If you need the resource until the end of
-/// the scope, this is not needed.
+/// It is sometimes necessary to manually drop the mutex guard
+/// to unlock it sooner than the end of the enclosing scope.
 ///
 /// ```
 /// use std::sync::{Arc, Mutex};


### PR DESCRIPTION
Fixes #67457.

Following the remarks made in #73074, I added an example on the main `Mutex` type, with a situation where there is mutable data and a computation result.

In my testing it is effectively needed to explicitly drop the lock, else it deadlocks.

r? @dtolnay because you were the one to review the previous PR.