### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/src/doc/unstable-book/src/library-features/default-free-fn.md
+++ b/src/doc/unstable-book/src/library-features/default-free-fn.md
@@ -1,0 +1,45 @@
+# `default_free_fn`
+
+The tracking issue for this feature is: [#73014]
+
+[#73014]: https://github.com/rust-lang/rust/issues/73014
+
+------------------------
+
+Adds a free `default()` function to the `std::default` module.  This function
+just forwards to [`Default::default()`], but may remove repetition of the word
+"default" from the call site.
+
+Here is an example:
+
+```rust
+#![feature(default_free_fn)]
+use std::default::default;
+
+#[derive(Default)]
+struct AppConfig {
+    foo: FooConfig,
+    bar: BarConfig,
+}
+
+#[derive(Default)]
+struct FooConfig {
+    foo: i32,
+}
+
+#[derive(Default)]
+struct BarConfig {
+    bar: f32,
+    baz: u8,
+}
+
+fn main() {
+    let options = AppConfig {
+        foo: default(),
+        bar: BarConfig {
+            bar: 10.1,
+            ..default()
+        },
+    };
+}
+```

--- a/src/libcore/default.rs
+++ b/src/libcore/default.rs
@@ -115,6 +115,50 @@ pub trait Default: Sized {
     fn default() -> Self;
 }
 
+/// Return the default value of a type according to the `Default` trait.
+///
+/// The type to return is inferred from context; this is equivalent to
+/// `Default::default()` but shorter to type.
+///
+/// For example:
+/// ```
+/// #![feature(default_free_fn)]
+///
+/// use std::default::default;
+///
+/// #[derive(Default)]
+/// struct AppConfig {
+///     foo: FooConfig,
+///     bar: BarConfig,
+/// }
+///
+/// #[derive(Default)]
+/// struct FooConfig {
+///     foo: i32,
+/// }
+///
+/// #[derive(Default)]
+/// struct BarConfig {
+///     bar: f32,
+///     baz: u8,
+/// }
+///
+/// fn main() {
+///     let options = AppConfig {
+///         foo: default(),
+///         bar: BarConfig {
+///             bar: 10.1,
+///             ..default()
+///         },
+///     };
+/// }
+/// ```
+#[unstable(feature = "default_free_fn", issue = "73014")]
+#[inline]
+pub fn default<T: Default>() -> T {
+    Default::default()
+}
+
 /// Derive macro generating an impl of the trait `Default`.
 #[rustc_builtin_macro]
 #[stable(feature = "builtin_macro_prelude", since = "1.38.0")]

--- a/src/librustc_error_codes/error_codes/E0646.md
+++ b/src/librustc_error_codes/error_codes/E0646.md
@@ -1,4 +1,5 @@
 It is not possible to define `main` with a where clause.
+
 Erroneous code example:
 
 ```compile_fail,E0646

--- a/src/librustc_middle/hir/exports.rs
+++ b/src/librustc_middle/hir/exports.rs
@@ -1,7 +1,8 @@
 use crate::ty;
 
+use rustc_data_structures::fx::FxHashMap;
 use rustc_hir::def::Res;
-use rustc_hir::def_id::DefIdMap;
+use rustc_hir::def_id::LocalDefId;
 use rustc_macros::HashStable;
 use rustc_span::symbol::Ident;
 use rustc_span::Span;
@@ -10,7 +11,7 @@ use std::fmt::Debug;
 
 /// This is the replacement export map. It maps a module to all of the exports
 /// within.
-pub type ExportMap<Id> = DefIdMap<Vec<Export<Id>>>;
+pub type ExportMap<Id> = FxHashMap<LocalDefId, Vec<Export<Id>>>;
 
 #[derive(Copy, Clone, Debug, RustcEncodable, RustcDecodable, HashStable)]
 pub struct Export<Id> {

--- a/src/librustc_middle/query/mod.rs
+++ b/src/librustc_middle/query/mod.rs
@@ -865,8 +865,8 @@ rustc_queries! {
     }
 
     Other {
-        query module_exports(def_id: DefId) -> Option<&'tcx [Export<hir::HirId>]> {
-            desc { |tcx| "looking up items exported by `{}`", tcx.def_path_str(def_id) }
+        query module_exports(def_id: LocalDefId) -> Option<&'tcx [Export<LocalDefId>]> {
+            desc { |tcx| "looking up items exported by `{}`", tcx.def_path_str(def_id.to_def_id()) }
             eval_always
         }
     }

--- a/src/librustc_middle/ty/context.rs
+++ b/src/librustc_middle/ty/context.rs
@@ -2,7 +2,7 @@
 
 use crate::arena::Arena;
 use crate::dep_graph::{self, DepConstructor, DepGraph};
-use crate::hir::exports::Export;
+use crate::hir::exports::ExportMap;
 use crate::ich::{NodeIdHashingMode, StableHashingContext};
 use crate::infer::canonical::{Canonical, CanonicalVarInfo, CanonicalVarInfos};
 use crate::lint::{struct_lint_level, LintDiagnosticBuilder, LintSource};
@@ -919,7 +919,7 @@ pub struct GlobalCtxt<'tcx> {
     trait_map: FxHashMap<LocalDefId, FxHashMap<ItemLocalId, StableVec<TraitCandidate>>>,
 
     /// Export map produced by name resolution.
-    export_map: FxHashMap<DefId, Vec<Export<hir::HirId>>>,
+    export_map: ExportMap<LocalDefId>,
 
     pub(crate) untracked_crate: &'tcx hir::Crate<'tcx>,
     pub(crate) definitions: &'tcx Definitions,

--- a/src/librustc_middle/ty/mod.rs
+++ b/src/librustc_middle/ty/mod.rs
@@ -124,7 +124,7 @@ pub struct ResolverOutputs {
     pub trait_map: FxHashMap<hir::HirId, Vec<hir::TraitCandidate<hir::HirId>>>,
     pub maybe_unused_trait_imports: FxHashSet<LocalDefId>,
     pub maybe_unused_extern_crates: Vec<(LocalDefId, Span)>,
-    pub export_map: ExportMap<hir::HirId>,
+    pub export_map: ExportMap<LocalDefId>,
     pub glob_map: FxHashMap<LocalDefId, FxHashSet<Symbol>>,
     /// Extern prelude entries. The value is `true` if the entry was introduced
     /// via `extern crate` item and not `--extern` option or compiler built-in.

--- a/src/librustc_resolve/imports.rs
+++ b/src/librustc_resolve/imports.rs
@@ -1393,8 +1393,8 @@ impl<'a, 'b> ImportResolver<'a, 'b> {
             let is_good_import =
                 binding.is_import() && !binding.is_ambiguity() && !ident.span.from_expansion();
             if is_good_import || binding.is_macro_def() {
-                let res = binding.res();
-                if res != Res::Err {
+                let res = binding.res().map_id(|id| this.definitions.local_def_id(id));
+                if res != def::Res::Err {
                     reexports.push(Export { ident, res, span: binding.span, vis: binding.vis });
                 }
             }
@@ -1467,7 +1467,9 @@ impl<'a, 'b> ImportResolver<'a, 'b> {
 
         if !reexports.is_empty() {
             if let Some(def_id) = module.def_id() {
-                self.r.export_map.insert(def_id, reexports);
+                // Call to `expect_local` should be fine because current
+                // code is only called for local modules.
+                self.r.export_map.insert(def_id.expect_local(), reexports);
             }
         }
     }

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -878,7 +878,7 @@ pub struct Resolver<'a> {
 
     /// `CrateNum` resolutions of `extern crate` items.
     extern_crate_map: FxHashMap<LocalDefId, CrateNum>,
-    export_map: ExportMap<NodeId>,
+    export_map: ExportMap<LocalDefId>,
     trait_map: TraitMap<NodeId>,
 
     /// A map from nodes to anonymous modules.
@@ -1281,18 +1281,7 @@ impl<'a> Resolver<'a> {
     pub fn into_outputs(self) -> ResolverOutputs {
         let definitions = self.definitions;
         let extern_crate_map = self.extern_crate_map;
-        let export_map = self
-            .export_map
-            .into_iter()
-            .map(|(k, v)| {
-                (
-                    k,
-                    v.into_iter()
-                        .map(|e| e.map_id(|id| definitions.node_id_to_hir_id(id)))
-                        .collect(),
-                )
-            })
-            .collect();
+        let export_map = self.export_map;
         let trait_map = self
             .trait_map
             .into_iter()
@@ -1330,18 +1319,7 @@ impl<'a> Resolver<'a> {
             definitions: self.definitions.clone(),
             cstore: Box::new(self.cstore().clone()),
             extern_crate_map: self.extern_crate_map.clone(),
-            export_map: self
-                .export_map
-                .iter()
-                .map(|(&k, v)| {
-                    (
-                        k,
-                        v.iter()
-                            .map(|e| e.map_id(|id| self.definitions.node_id_to_hir_id(id)))
-                            .collect(),
-                    )
-                })
-                .collect(),
+            export_map: self.export_map.clone(),
             trait_map: self
                 .trait_map
                 .iter()

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -85,9 +85,7 @@ pub struct Item {
 
 impl fmt::Debug for Item {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let fake = MAX_DEF_ID.with(|m| {
-            m.borrow().get(&self.def_id.krate).map(|id| self.def_id >= *id).unwrap_or(false)
-        });
+        let fake = self.is_fake();
         let def_id: &dyn fmt::Debug = if fake { &"**FAKE**" } else { &self.def_id };
 
         fmt.debug_struct("Item")
@@ -237,6 +235,13 @@ impl Item {
             }
             _ => false,
         }
+    }
+
+    /// See comments on next_def_id
+    pub fn is_fake(&self) -> bool {
+        MAX_DEF_ID.with(|m| {
+            m.borrow().get(&self.def_id.krate).map(|id| self.def_id >= *id).unwrap_or(false)
+        })
     }
 }
 

--- a/src/test/ui/resolve/issue-2356.stderr
+++ b/src/test/ui/resolve/issue-2356.stderr
@@ -14,7 +14,16 @@ error[E0425]: cannot find function `default` in this scope
   --> $DIR/issue-2356.rs:31:5
    |
 LL |     default();
-   |     ^^^^^^^ help: try: `Self::default`
+   |     ^^^^^^^
+   |
+help: try
+   |
+LL |     Self::default();
+   |     ^^^^^^^^^^^^^
+help: consider importing this function
+   |
+LL | use std::default::default;
+   |
 
 error[E0425]: cannot find value `whiskers` in this scope
   --> $DIR/issue-2356.rs:39:5


### PR DESCRIPTION
Successful merges:

 - #73001 (Free `default()` forwarding to `Default::default()`)
 - #73075 (Add comments to `Resolve::get_module`)
 - #73090 (Use `LocalDefId` directly in `Resolver::export_map`)
 - #73092 (Clean up E0646)
 - #73098 (Add Item::is_fake for rustdoc)

Failed merges:


r? @ghost