### PR TITLE
Bump rustfmt to 1.4.17

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4475,7 +4475,7 @@ dependencies = [
 
 [[package]]
 name = "rustfmt-nightly"
-version = "1.4.15"
+version = "1.4.17"
 dependencies = [
  "annotate-snippets",
  "bytecount",


### PR DESCRIPTION
This PR updates rustfmt to 1.4.17, which includes a bug fix for the issue reported in https://github.com/rust-lang/rust/issues/73078.