### PR TITLE
Improve the wording in documentation of std::mem::drop

### DIFF
--- a/src/libcore/mem/mod.rs
+++ b/src/libcore/mem/mod.rs
@@ -808,7 +808,7 @@ pub fn replace<T>(dest: &mut T, mut src: T) -> T {
 
 /// Disposes of a value.
 ///
-/// This does call the argument's implementation of [`Drop`][drop].
+/// This does so by calling the argument's implementation of [`Drop`][drop].
 ///
 /// This effectively does nothing for types which implement `Copy`, e.g.
 /// integers. Such values are copied and _then_ moved into the function, so the


### PR DESCRIPTION
I thought the original phrasing was somewhat awkward compared to rest of the (very well written) documentation, so figured I would propose a change to improve it. 