### PR TITLE
Resolve E0584 conflict

### DIFF
--- a/src/librustc_error_codes/error_codes.rs
+++ b/src/librustc_error_codes/error_codes.rs
@@ -438,6 +438,7 @@ E0752: include_str!("./error_codes/E0752.md"),
 E0753: include_str!("./error_codes/E0753.md"),
 E0754: include_str!("./error_codes/E0754.md"),
 E0760: include_str!("./error_codes/E0760.md"),
+E0761: include_str!("./error_codes/E0761.md"),
 ;
 //  E0006, // merged with E0005
 //  E0008, // cannot bind by-move into a pattern guard

--- a/src/librustc_error_codes/error_codes/E0583.md
+++ b/src/librustc_error_codes/error_codes/E0583.md
@@ -2,7 +2,7 @@ A file wasn't found for an out-of-line module.
 
 Erroneous code example:
 
-```ignore (compile_fail not working here; see Issue #43707)
+```compile_fail,E0583
 mod file_that_doesnt_exist; // error: file not found for module
 
 fn main() {}

--- a/src/librustc_error_codes/error_codes/E0761.md
+++ b/src/librustc_error_codes/error_codes/E0761.md
@@ -14,7 +14,7 @@ fn foo() {}
 fn foo() {}
 ```
 
-```ignore (compile_fail not working here; see Issue #43707)
+```ignore (multiple source files required for compile_fail)
 mod ambiguous_module; // error: file for module `ambiguous_module`
                       // found at both ambiguous_module.rs and
                       // ambiguous_module.rs/mod.rs

--- a/src/librustc_error_codes/error_codes/E0761.md
+++ b/src/librustc_error_codes/error_codes/E0761.md
@@ -1,0 +1,25 @@
+Multiple candidate files were found for an out-of-line module.
+
+Erroneous code example:
+
+```rust
+// file: ambiguous_module/mod.rs
+
+fn foo() {}
+```
+
+```rust
+// file: ambiguous_module.rs
+
+fn foo() {}
+```
+
+```ignore (compile_fail not working here; see Issue #43707)
+mod ambiguous_module; // error: file for module `ambiguous_module`
+                      // found at both ambiguous_module.rs and
+                      // ambiguous_module.rs/mod.rs
+
+fn main() {}
+```
+
+Please remove this ambiguity by deleting/renaming one of the candidate files.

--- a/src/librustc_expand/module.rs
+++ b/src/librustc_expand/module.rs
@@ -291,7 +291,7 @@ pub fn default_submod_path<'a>(
             let mut err = struct_span_err!(
                 sess.span_diagnostic,
                 span,
-                E0584,
+                E0761,
                 "file for module `{}` found at both {} and {}",
                 mod_name,
                 default_path_str,

--- a/src/test/ui/mod/mod_file_disambig.stderr
+++ b/src/test/ui/mod/mod_file_disambig.stderr
@@ -1,4 +1,4 @@
-error[E0584]: file for module `mod_file_disambig_aux` found at both mod_file_disambig_aux.rs and mod_file_disambig_aux/mod.rs
+error[E0761]: file for module `mod_file_disambig_aux` found at both mod_file_disambig_aux.rs and mod_file_disambig_aux/mod.rs
   --> $DIR/mod_file_disambig.rs:1:1
    |
 LL | mod mod_file_disambig_aux;
@@ -14,5 +14,5 @@ LL |     assert_eq!(mod_file_aux::bar(), 10);
 
 error: aborting due to 2 previous errors
 
-Some errors have detailed explanations: E0433, E0584.
+Some errors have detailed explanations: E0433, E0761.
 For more information about an error, try `rustc --explain E0433`.


### PR DESCRIPTION
Adds a new error code (`E0761`) to indicate ambiguity in module file names and an accompanying expanded description to resolve a conflict over `E0584`.

Resolves #73116 