### PR TITLE
Use shorthand linker strip arguments in order to support MacOS

### DIFF
--- a/src/librustc_codegen_ssa/back/linker.rs
+++ b/src/librustc_codegen_ssa/back/linker.rs
@@ -481,10 +481,12 @@ impl<'a> Linker for GccLinker<'a> {
         match strip {
             Strip::None => {}
             Strip::Debuginfo => {
-                self.linker_arg("--strip-debug");
+                // MacOS linker does not support longhand argument --strip-debug
+                self.linker_arg("-S");
             }
             Strip::Symbols => {
-                self.linker_arg("--strip-all");
+                // MacOS linker does not support longhand argument --strip-all
+                self.linker_arg("-s");
             }
         }
     }


### PR DESCRIPTION
Per discussion from https://github.com/rust-lang/rust/issues/72110#issuecomment-636609419 onward, the current `-Z strip` options aren't supported by the MacOS linker, but I think only because it doesn't support the longhand arguments `--strip-debug` and `--strip-all`.

This PR switches to using the shorthand arguments `-s` and `-S` instead, which (I believe) are supported by all GCC linkers.