### PR TITLE
Add methods to go from a nul-terminated Vec<u8> to a CString

### DIFF
--- a/src/libstd/ffi/c_str.rs
+++ b/src/libstd/ffi/c_str.rs
@@ -1,7 +1,6 @@
 use crate::ascii;
 use crate::borrow::{Borrow, Cow};
 use crate::cmp::Ordering;
-use crate::convert::TryFrom;
 use crate::error::Error;
 use crate::fmt::{self, Write};
 use crate::io;
@@ -851,19 +850,6 @@ impl From<Vec<NonZeroU8>> for CString {
             // invariant of `NonZeroU8`.
             CString::from_vec_unchecked(v)
         }
-    }
-}
-
-#[unstable(feature = "cstring_from_vec_with_nul", issue = "73179")]
-impl TryFrom<Vec<u8>> for CString {
-    type Error = FromBytesWithNulError;
-
-    /// See the document about [`from_vec_with_nul`] for more
-    /// informations about the behaviour of this method.
-    ///
-    /// [`from_vec_with_nul`]: CString::from_vec_with_nul
-    fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
-        Self::from_vec_with_nul(value)
     }
 }
 

--- a/src/libstd/ffi/c_str.rs
+++ b/src/libstd/ffi/c_str.rs
@@ -653,7 +653,7 @@ impl CString {
     ///     unsafe { CString::from_vec_unchecked(b"abc".to_vec()) }
     /// );
     /// ```
-    #[stable(feature = "cstring_from_vec_with_nul", since = "1.46.0")]
+    #[unstable(feature = "cstring_from_vec_with_nul", issue = "73179")]
     pub unsafe fn from_vec_with_nul_unchecked(v: Vec<u8>) -> Self {
         Self { inner: v.into_boxed_slice() }
     }
@@ -693,7 +693,7 @@ impl CString {
     /// ```
     ///
     /// [`new`]: #method.new
-    #[stable(feature = "cstring_from_vec_with_nul", since = "1.46.0")]
+    #[unstable(feature = "cstring_from_vec_with_nul", issue = "73179")]
     pub fn from_vec_with_nul(v: Vec<u8>) -> Result<Self, FromBytesWithNulError> {
         let nul_pos = memchr::memchr(0, &v);
         match nul_pos {

--- a/src/libstd/ffi/c_str.rs
+++ b/src/libstd/ffi/c_str.rs
@@ -861,7 +861,7 @@ impl TryFrom<Vec<u8>> for CString {
     /// See the document about [`from_vec_with_nul`] for more
     /// informations about the behaviour of this method.
     ///
-    /// [`from_vec_with_nul`]: struct.CString.html#method.from_vec_with_nul
+    /// [`from_vec_with_nul`]: CString::from_vec_with_nul
     fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
         Self::from_vec_with_nul(value)
     }

--- a/src/libstd/ffi/c_str.rs
+++ b/src/libstd/ffi/c_str.rs
@@ -1,6 +1,7 @@
 use crate::ascii;
 use crate::borrow::{Borrow, Cow};
 use crate::cmp::Ordering;
+use crate::convert::TryFrom;
 use crate::error::Error;
 use crate::fmt::{self, Write};
 use crate::io;
@@ -850,6 +851,19 @@ impl From<Vec<NonZeroU8>> for CString {
             // invariant of `NonZeroU8`.
             CString::from_vec_unchecked(v)
         }
+    }
+}
+
+#[unstable(feature = "cstring_from_vec_with_nul", issue = "73179")]
+impl TryFrom<Vec<u8>> for CString {
+    type Error = FromBytesWithNulError;
+
+    /// See the document about [`from_vec_with_nul`] for more
+    /// informations about the behaviour of this method.
+    ///
+    /// [`from_vec_with_nul`]: struct.CString.html#method.from_vec_with_nul
+    fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
+        Self::from_vec_with_nul(value)
     }
 }
 

--- a/src/libstd/ffi/mod.rs
+++ b/src/libstd/ffi/mod.rs
@@ -157,6 +157,8 @@
 
 #[stable(feature = "cstr_from_bytes", since = "1.10.0")]
 pub use self::c_str::FromBytesWithNulError;
+#[unstable(feature = "cstring_from_vec_with_nul", issue = "73179")]
+pub use self::c_str::FromVecWithNulError;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::c_str::{CStr, CString, IntoStringError, NulError};
 


### PR DESCRIPTION
Fixes #73100.

Doc tests have been written and the documentation on the error type
updated too.

I used `#[stable(feature = "cstring_from_vec_with_nul", since = "1.46.0")]` but I don't know if the version is correct.