### PR TITLE
Fallback to xml.etree.ElementTree

### DIFF
--- a/src/etc/htmldocck.py
+++ b/src/etc/htmldocck.py
@@ -114,7 +114,10 @@ try:
     from html.parser import HTMLParser
 except ImportError:
     from HTMLParser import HTMLParser
-from xml.etree import cElementTree as ET
+try:
+    from xml.etree import cElementTree as ET
+except ImportError:
+    from xml.etree import ElementTree as ET
 
 try:
     from html.entities import name2codepoint


### PR DESCRIPTION
The xml.etree.cElementTree has been deprecated since Python 3.3
and removed in Python 3.9 https://bugs.python.org/issue36543.