### PR TITLE
Ensure std benchmarks get tested.

### DIFF
--- a/src/liballoc/Cargo.toml
+++ b/src/liballoc/Cargo.toml
@@ -25,6 +25,7 @@ path = "../liballoc/tests/lib.rs"
 [[bench]]
 name = "collectionsbenches"
 path = "../liballoc/benches/lib.rs"
+test = true
 
 [[bench]]
 name = "vec_deque_append_bench"

--- a/src/libcore/Cargo.toml
+++ b/src/libcore/Cargo.toml
@@ -19,6 +19,7 @@ path = "../libcore/tests/lib.rs"
 [[bench]]
 name = "corebenches"
 path = "../libcore/benches/lib.rs"
+test = true
 
 [dev-dependencies]
 rand = "0.7"

--- a/src/libcore/benches/lib.rs
+++ b/src/libcore/benches/lib.rs
@@ -1,3 +1,5 @@
+// wasm32 does not support benches (no time).
+#![cfg(not(target_arch = "wasm32"))]
 #![feature(flt2dec)]
 #![feature(test)]
 

--- a/src/libstd/Cargo.toml
+++ b/src/libstd/Cargo.toml
@@ -74,3 +74,8 @@ std_detect_dlsym_getauxval = []
 threads = 125
 # Maximum heap size
 heap_size = 0x8000000
+
+[[bench]]
+name = "stdbenches"
+path = "benches/lib.rs"
+test = true


### PR DESCRIPTION
This ensures that the std benchmarks don't break in the future. Currently they aren't compiled or tested on CI, so they can easily bitrot.  Testing a benchmark runs it with one iteration. Adding these should only add a few seconds to CI.

Closes #54176
Closes #61913
