### PR TITLE
Handle assembler warnings properly

### DIFF
--- a/src/librustc_codegen_llvm/llvm/diagnostic.rs
+++ b/src/librustc_codegen_llvm/llvm/diagnostic.rs
@@ -88,6 +88,7 @@ impl OptimizationDiagnostic<'ll> {
 
 #[derive(Copy, Clone)]
 pub struct InlineAsmDiagnostic<'ll> {
+    pub level: super::DiagnosticLevel,
     pub cookie: c_uint,
     pub message: &'ll Twine,
     pub instruction: Option<&'ll Value>,
@@ -98,10 +99,17 @@ impl InlineAsmDiagnostic<'ll> {
         let mut cookie = 0;
         let mut message = None;
         let mut instruction = None;
+        let mut level = super::DiagnosticLevel::Error;
 
-        super::LLVMRustUnpackInlineAsmDiagnostic(di, &mut cookie, &mut message, &mut instruction);
+        super::LLVMRustUnpackInlineAsmDiagnostic(
+            di,
+            &mut level,
+            &mut cookie,
+            &mut message,
+            &mut instruction,
+        );
 
-        InlineAsmDiagnostic { cookie, message: message.unwrap(), instruction }
+        InlineAsmDiagnostic { level, cookie, message: message.unwrap(), instruction }
     }
 }
 

--- a/src/librustc_codegen_llvm/llvm/ffi.rs
+++ b/src/librustc_codegen_llvm/llvm/ffi.rs
@@ -489,6 +489,17 @@ pub enum DiagnosticKind {
     Linker,
 }
 
+/// LLVMRustDiagnosticLevel
+#[derive(Copy, Clone)]
+#[repr(C)]
+#[allow(dead_code)] // Variants constructed by C++.
+pub enum DiagnosticLevel {
+    Error,
+    Warning,
+    Note,
+    Remark,
+}
+
 /// LLVMRustArchiveKind
 #[derive(Copy, Clone)]
 #[repr(C)]
@@ -2054,6 +2065,7 @@ extern "C" {
 
     pub fn LLVMRustUnpackInlineAsmDiagnostic(
         DI: &'a DiagnosticInfo,
+        level_out: &mut DiagnosticLevel,
         cookie_out: &mut c_uint,
         message_out: &mut Option<&'a Twine>,
         instruction_out: &mut Option<&'a Value>,
@@ -2074,6 +2086,7 @@ extern "C" {
         d: &SMDiagnostic,
         message_out: &RustString,
         buffer_out: &RustString,
+        level_out: &mut DiagnosticLevel,
         loc_out: &mut c_uint,
         ranges_out: *mut c_uint,
         num_ranges: &mut usize,

--- a/src/librustc_errors/lib.rs
+++ b/src/librustc_errors/lib.rs
@@ -581,6 +581,11 @@ impl Handler {
         DiagnosticBuilder::new(self, Level::Help, msg)
     }
 
+    /// Construct a builder at the `Note` level with the `msg`.
+    pub fn struct_note_without_error(&self, msg: &str) -> DiagnosticBuilder<'_> {
+        DiagnosticBuilder::new(self, Level::Note, msg)
+    }
+
     pub fn span_fatal(&self, span: impl Into<MultiSpan>, msg: &str) -> FatalError {
         self.emit_diag_at_span(Diagnostic::new(Fatal, msg), span);
         FatalError

--- a/src/librustc_session/session.rs
+++ b/src/librustc_session/session.rs
@@ -441,6 +441,9 @@ impl Session {
     pub fn span_note_without_error<S: Into<MultiSpan>>(&self, sp: S, msg: &str) {
         self.diagnostic().span_note_without_error(sp, msg)
     }
+    pub fn struct_note_without_error(&self, msg: &str) -> DiagnosticBuilder<'_> {
+        self.diagnostic().struct_note_without_error(msg)
+    }
 
     pub fn diagnostic(&self) -> &rustc_errors::Handler {
         &self.parse_sess.span_diagnostic

--- a/src/test/ui/asm/srcloc.rs
+++ b/src/test/ui/asm/srcloc.rs
@@ -37,5 +37,8 @@ fn main() {
 
         asm!(concat!("invalid", "_", "instruction"));
         //~^ ERROR: invalid instruction mnemonic 'invalid_instruction'
+
+        asm!("movaps %xmm3, (%esi, 2)", options(att_syntax));
+        //~^ WARN: scale factor without index register is ignored
     }
 }

--- a/src/test/ui/asm/srcloc.stderr
+++ b/src/test/ui/asm/srcloc.stderr
@@ -70,5 +70,17 @@ note: instantiated into assembly here
 LL |     invalid_instruction
    |     ^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 6 previous errors
+warning: scale factor without index register is ignored
+  --> $DIR/srcloc.rs:41:15
+   |
+LL |         asm!("movaps %xmm3, (%esi, 2)", options(att_syntax));
+   |               ^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:1:23
+   |
+LL |     movaps %xmm3, (%esi, 2)
+   |                          ^
+
+error: aborting due to 6 previous errors; 1 warning emitted
 


### PR DESCRIPTION
Previously all inline asm diagnostics were treated as errors, but LLVM sometimes emits warnings and notes as well.

Fixes #73160 

r? @petrochenkov 