### PR TITLE
Make libcore pass -Zvalidate-mir

### DIFF
--- a/src/librustc_mir/transform/validate.rs
+++ b/src/librustc_mir/transform/validate.rs
@@ -93,9 +93,11 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
         if let ty::FnPtr(..) | ty::FnDef(..) = ty.kind {
             // We have a `FnPtr` or `FnDef` which is trivially safe to call.
         } else {
-            let fn_once_trait = self.tcx.require_lang_item(FnOnceTrait, None);
+            // FIXME(doctorn): call shims shouldn't reference unnormalized types, so
+            // this case should be removed.
             // We haven't got a `FnPtr` or `FnDef` but we are still safe to call it if it
             // implements `FnOnce` (as `Fn: FnMut` and `FnMut: FnOnce`).
+            let fn_once_trait = self.tcx.require_lang_item(FnOnceTrait, None);
             let item_def_id = self
                 .tcx
                 .associated_items(fn_once_trait)

--- a/src/librustc_mir/transform/validate.rs
+++ b/src/librustc_mir/transform/validate.rs
@@ -1,8 +1,8 @@
 //! Validates the MIR to ensure that invariants are upheld.
 
 use super::{MirPass, MirSource};
+use rustc_hir::lang_items::FnOnceTraitLangItem;
 use rustc_hir::Constness;
-use rustc_hir::lang_items::FnOnceTrait;
 use rustc_infer::infer::TyCtxtInferExt;
 use rustc_middle::mir::visit::Visitor;
 use rustc_middle::{
@@ -97,7 +97,7 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
             // this case should be removed.
             // We haven't got a `FnPtr` or `FnDef` but we are still safe to call it if it
             // implements `FnOnce` (as `Fn: FnMut` and `FnMut: FnOnce`).
-            let fn_once_trait = self.tcx.require_lang_item(FnOnceTrait, None);
+            let fn_once_trait = self.tcx.require_lang_item(FnOnceTraitLangItem, None);
             let item_def_id = self
                 .tcx
                 .associated_items(fn_once_trait)


### PR DESCRIPTION
Extends call-ability for a type `T` to pass whenever `T: FnOnce`.

r? @jonas-schievink

Resolves #73109