### PR TITLE
Support proc macros in intra doc link resolution

### DIFF
--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -585,6 +585,9 @@ impl<'a, 'tcx> DocFolder for LinkCollector<'a, 'tcx> {
                 } else if link.starts_with("macro@") {
                     kind = Some(MacroNS);
                     link.trim_start_matches("macro@")
+                } else if link.starts_with("derive@") {
+                    kind = Some(MacroNS);
+                    link.trim_start_matches("derive@")
                 } else if link.ends_with('!') {
                     kind = Some(MacroNS);
                     link.trim_end_matches('!')
@@ -954,7 +957,7 @@ fn ambiguity_error(
                             Res::Def(DefKind::AssocFn | DefKind::Fn, _) => {
                                 ("add parentheses", format!("{}()", path_str))
                             }
-                            Res::Def(DefKind::Macro(..), _) => {
+                            Res::Def(DefKind::Macro(MacroKind::Bang), _) => {
                                 ("add an exclamation mark", format!("{}!", path_str))
                             }
                             _ => {
@@ -968,6 +971,9 @@ fn ambiguity_error(
                                     (Res::Def(DefKind::Mod, _), _) => "module",
                                     (_, TypeNS) => "type",
                                     (_, ValueNS) => "value",
+                                    (Res::Def(DefKind::Macro(MacroKind::Derive), _), MacroNS) => {
+                                        "derive"
+                                    }
                                     (_, MacroNS) => "macro",
                                 };
 

--- a/src/test/rustdoc/auxiliary/intra-link-proc-macro-macro.rs
+++ b/src/test/rustdoc/auxiliary/intra-link-proc-macro-macro.rs
@@ -1,0 +1,30 @@
+// force-host
+// no-prefer-dynamic
+// compile-flags: --crate-type proc-macro
+
+#![crate_type="proc-macro"]
+#![crate_name="intra_link_proc_macro_macro"]
+
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+
+#[proc_macro_derive(DeriveA)]
+pub fn a_derive(input: TokenStream) -> TokenStream {
+    input
+}
+
+#[proc_macro_derive(DeriveB)]
+pub fn b_derive(input: TokenStream) -> TokenStream {
+    input
+}
+
+#[proc_macro_attribute]
+pub fn attr_a(input: TokenStream, _args: TokenStream) -> TokenStream {
+    input
+}
+
+#[proc_macro_attribute]
+pub fn attr_b(input: TokenStream, _args: TokenStream) -> TokenStream {
+    input
+}

--- a/src/test/rustdoc/auxiliary/intra-link-proc-macro-macro.rs
+++ b/src/test/rustdoc/auxiliary/intra-link-proc-macro-macro.rs
@@ -19,6 +19,11 @@ pub fn b_derive(input: TokenStream) -> TokenStream {
     input
 }
 
+#[proc_macro_derive(DeriveTrait)]
+pub fn trait_derive(input: TokenStream) -> TokenStream {
+    input
+}
+
 #[proc_macro_attribute]
 pub fn attr_a(input: TokenStream, _args: TokenStream) -> TokenStream {
     input

--- a/src/test/rustdoc/intra-link-proc-macro.rs
+++ b/src/test/rustdoc/intra-link-proc-macro.rs
@@ -11,7 +11,11 @@ use intra_link_proc_macro_macro::{DeriveB, attr_b};
 
 // @has - '//a/@href' '../intra_link_proc_macro/derive.DeriveA.html'
 // @has - '//a/@href' '../intra_link_proc_macro/attr.attr_a.html'
+// @has - '//a/@href' '../intra_link_proc_macro/trait.DeriveTrait.html'
 // @has - '//a/@href' '../intra_link_proc_macro_macro/derive.DeriveB.html'
 // @has - '//a/@href' '../intra_link_proc_macro_macro/attr.attr_b.html'
-/// Link to [DeriveA], [attr_a], [DeriveB], [attr_b]
+/// Link to [DeriveA], [attr_a], [DeriveB], [attr_b], [DeriveTrait]
 pub struct Foo;
+
+// this should not cause ambiguity errors
+pub trait DeriveTrait {}

--- a/src/test/rustdoc/intra-link-proc-macro.rs
+++ b/src/test/rustdoc/intra-link-proc-macro.rs
@@ -1,0 +1,17 @@
+// aux-build:intra-link-proc-macro-macro.rs
+// build-aux-docs
+// @has intra_link_proc_macro/index.html
+#![deny(intra_doc_link_resolution_failure)]
+
+extern crate intra_link_proc_macro_macro;
+
+
+pub use intra_link_proc_macro_macro::{DeriveA, attr_a};
+use intra_link_proc_macro_macro::{DeriveB, attr_b};
+
+// @has - '//a/@href' '../intra_link_proc_macro/derive.DeriveA.html'
+// @has - '//a/@href' '../intra_link_proc_macro/attr.attr_a.html'
+// @has - '//a/@href' '../intra_link_proc_macro_macro/derive.DeriveB.html'
+// @has - '//a/@href' '../intra_link_proc_macro_macro/attr.attr_b.html'
+/// Link to [DeriveA], [attr_a], [DeriveB], [attr_b]
+pub struct Foo;

--- a/src/test/rustdoc/intra-link-proc-macro.rs
+++ b/src/test/rustdoc/intra-link-proc-macro.rs
@@ -1,6 +1,5 @@
 // aux-build:intra-link-proc-macro-macro.rs
 // build-aux-docs
-// @has intra_link_proc_macro/index.html
 #![deny(intra_doc_link_resolution_failure)]
 
 extern crate intra_link_proc_macro_macro;
@@ -9,6 +8,7 @@ extern crate intra_link_proc_macro_macro;
 pub use intra_link_proc_macro_macro::{DeriveA, attr_a};
 use intra_link_proc_macro_macro::{DeriveB, attr_b};
 
+// @has intra_link_proc_macro/struct.Foo.html
 // @has - '//a/@href' '../intra_link_proc_macro/derive.DeriveA.html'
 // @has - '//a/@href' '../intra_link_proc_macro/attr.attr_a.html'
 // @has - '//a/@href' '../intra_link_proc_macro/trait.DeriveTrait.html'
@@ -16,6 +16,12 @@ use intra_link_proc_macro_macro::{DeriveB, attr_b};
 // @has - '//a/@href' '../intra_link_proc_macro_macro/attr.attr_b.html'
 /// Link to [DeriveA], [attr_a], [DeriveB], [attr_b], [DeriveTrait]
 pub struct Foo;
+
+// @has intra_link_proc_macro/struct.Bar.html
+// @has - '//a/@href' '../intra_link_proc_macro/derive.DeriveA.html'
+// @has - '//a/@href' '../intra_link_proc_macro/attr.attr_a.html'
+/// Link to [deriveA](derive@DeriveA) [attr](macro@attr_a)
+pub struct Bar;
 
 // this should not cause ambiguity errors
 pub trait DeriveTrait {}


### PR DESCRIPTION
The feature was written pre-proc macro resolution, so it only supported the wacky MBE resolution rules. This adds support for proc macros as well.

cc @GuillaumeGomez

Fixes #73173