### PR TITLE
Prefer the associated constants for pattern matching error

### DIFF
--- a/src/librustc_middle/ty/print/pretty.rs
+++ b/src/librustc_middle/ty/print/pretty.rs
@@ -986,7 +986,7 @@ pub trait PrettyPrinter<'tcx>:
 
                 let ui_str = ui.name_str();
                 if data == max {
-                    p!(write("std::{}::MAX", ui_str))
+                    p!(write("{}::MAX", ui_str))
                 } else {
                     if print_ty { p!(write("{}{}", data, ui_str)) } else { p!(write("{}", data)) }
                 };
@@ -999,8 +999,8 @@ pub trait PrettyPrinter<'tcx>:
 
                 let i_str = i.name_str();
                 match data {
-                    d if d == min => p!(write("std::{}::MIN", i_str)),
-                    d if d == max => p!(write("std::{}::MAX", i_str)),
+                    d if d == min => p!(write("{}::MIN", i_str)),
+                    d if d == max => p!(write("{}::MAX", i_str)),
                     _ => {
                         let data = sign_extend(data, size) as i128;
                         if print_ty {

--- a/src/test/mir-opt/const_prop/bad_op_div_by_zero/rustc.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/bad_op_div_by_zero/rustc.main.ConstProp.diff
@@ -59,7 +59,7 @@
                                            // mir::Constant
                                            // + span: $DIR/bad_op_div_by_zero.rs:5:14: 5:19
 -                                          // + literal: Const { ty: i32, val: Value(Scalar(0xffffffff)) }
--         _6 = Eq(const 1i32, const std::i32::MIN); // scope 1 at $DIR/bad_op_div_by_zero.rs:5:14: 5:19
+-         _6 = Eq(const 1i32, const i32::MIN); // scope 1 at $DIR/bad_op_div_by_zero.rs:5:14: 5:19
 +                                          // + literal: Const { ty: bool, val: Value(Scalar(0x00)) }
 +         _6 = const false;                // scope 1 at $DIR/bad_op_div_by_zero.rs:5:14: 5:19
                                            // ty::Const

--- a/src/test/mir-opt/const_prop/bad_op_mod_by_zero/rustc.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/bad_op_mod_by_zero/rustc.main.ConstProp.diff
@@ -59,7 +59,7 @@
                                            // mir::Constant
                                            // + span: $DIR/bad_op_mod_by_zero.rs:5:14: 5:19
 -                                          // + literal: Const { ty: i32, val: Value(Scalar(0xffffffff)) }
--         _6 = Eq(const 1i32, const std::i32::MIN); // scope 1 at $DIR/bad_op_mod_by_zero.rs:5:14: 5:19
+-         _6 = Eq(const 1i32, const i32::MIN); // scope 1 at $DIR/bad_op_mod_by_zero.rs:5:14: 5:19
 +                                          // + literal: Const { ty: bool, val: Value(Scalar(0x00)) }
 +         _6 = const false;                // scope 1 at $DIR/bad_op_mod_by_zero.rs:5:14: 5:19
                                            // ty::Const

--- a/src/test/ui/consts/const-match-check.eval1.stderr
+++ b/src/test/ui/consts/const-match-check.eval1.stderr
@@ -1,8 +1,8 @@
-error[E0005]: refutable pattern in local binding: `std::i32::MIN..=-1i32` and `1i32..=std::i32::MAX` not covered
+error[E0005]: refutable pattern in local binding: `i32::MIN..=-1i32` and `1i32..=i32::MAX` not covered
   --> $DIR/const-match-check.rs:25:15
    |
 LL |     A = { let 0 = 0; 0 },
-   |               ^ patterns `std::i32::MIN..=-1i32` and `1i32..=std::i32::MAX` not covered
+   |               ^ patterns `i32::MIN..=-1i32` and `1i32..=i32::MAX` not covered
    |
    = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
    = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html

--- a/src/test/ui/consts/const-match-check.eval2.stderr
+++ b/src/test/ui/consts/const-match-check.eval2.stderr
@@ -1,8 +1,8 @@
-error[E0005]: refutable pattern in local binding: `std::i32::MIN..=-1i32` and `1i32..=std::i32::MAX` not covered
+error[E0005]: refutable pattern in local binding: `i32::MIN..=-1i32` and `1i32..=i32::MAX` not covered
   --> $DIR/const-match-check.rs:31:24
    |
 LL |     let x: [i32; { let 0 = 0; 0 }] = [];
-   |                        ^ patterns `std::i32::MIN..=-1i32` and `1i32..=std::i32::MAX` not covered
+   |                        ^ patterns `i32::MIN..=-1i32` and `1i32..=i32::MAX` not covered
    |
    = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
    = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html

--- a/src/test/ui/consts/const-match-check.matchck.stderr
+++ b/src/test/ui/consts/const-match-check.matchck.stderr
@@ -1,8 +1,8 @@
-error[E0005]: refutable pattern in local binding: `std::i32::MIN..=-1i32` and `1i32..=std::i32::MAX` not covered
+error[E0005]: refutable pattern in local binding: `i32::MIN..=-1i32` and `1i32..=i32::MAX` not covered
   --> $DIR/const-match-check.rs:4:22
    |
 LL | const X: i32 = { let 0 = 0; 0 };
-   |                      ^ patterns `std::i32::MIN..=-1i32` and `1i32..=std::i32::MAX` not covered
+   |                      ^ patterns `i32::MIN..=-1i32` and `1i32..=i32::MAX` not covered
    |
    = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
    = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
@@ -12,11 +12,11 @@ help: you might want to use `if let` to ignore the variant that isn't matched
 LL | const X: i32 = { if let 0 = 0 { /* */ } 0 };
    |                  ^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0005]: refutable pattern in local binding: `std::i32::MIN..=-1i32` and `1i32..=std::i32::MAX` not covered
+error[E0005]: refutable pattern in local binding: `i32::MIN..=-1i32` and `1i32..=i32::MAX` not covered
   --> $DIR/const-match-check.rs:8:23
    |
 LL | static Y: i32 = { let 0 = 0; 0 };
-   |                       ^ patterns `std::i32::MIN..=-1i32` and `1i32..=std::i32::MAX` not covered
+   |                       ^ patterns `i32::MIN..=-1i32` and `1i32..=i32::MAX` not covered
    |
    = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
    = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
@@ -26,11 +26,11 @@ help: you might want to use `if let` to ignore the variant that isn't matched
 LL | static Y: i32 = { if let 0 = 0 { /* */ } 0 };
    |                   ^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0005]: refutable pattern in local binding: `std::i32::MIN..=-1i32` and `1i32..=std::i32::MAX` not covered
+error[E0005]: refutable pattern in local binding: `i32::MIN..=-1i32` and `1i32..=i32::MAX` not covered
   --> $DIR/const-match-check.rs:13:26
    |
 LL |     const X: i32 = { let 0 = 0; 0 };
-   |                          ^ patterns `std::i32::MIN..=-1i32` and `1i32..=std::i32::MAX` not covered
+   |                          ^ patterns `i32::MIN..=-1i32` and `1i32..=i32::MAX` not covered
    |
    = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
    = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
@@ -40,11 +40,11 @@ help: you might want to use `if let` to ignore the variant that isn't matched
 LL |     const X: i32 = { if let 0 = 0 { /* */ } 0 };
    |                      ^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0005]: refutable pattern in local binding: `std::i32::MIN..=-1i32` and `1i32..=std::i32::MAX` not covered
+error[E0005]: refutable pattern in local binding: `i32::MIN..=-1i32` and `1i32..=i32::MAX` not covered
   --> $DIR/const-match-check.rs:19:26
    |
 LL |     const X: i32 = { let 0 = 0; 0 };
-   |                          ^ patterns `std::i32::MIN..=-1i32` and `1i32..=std::i32::MAX` not covered
+   |                          ^ patterns `i32::MIN..=-1i32` and `1i32..=i32::MAX` not covered
    |
    = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
    = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html

--- a/src/test/ui/consts/const-pattern-irrefutable.rs
+++ b/src/test/ui/consts/const-pattern-irrefutable.rs
@@ -9,8 +9,8 @@ use foo::d;
 const a: u8 = 2;
 
 fn main() {
-    let a = 4; //~ ERROR refutable pattern in local binding: `0u8..=1u8` and `3u8..=std::u8::MAX
-    let c = 4; //~ ERROR refutable pattern in local binding: `0u8..=1u8` and `3u8..=std::u8::MAX
-    let d = 4; //~ ERROR refutable pattern in local binding: `0u8..=1u8` and `3u8..=std::u8::MAX
+    let a = 4; //~ ERROR refutable pattern in local binding: `0u8..=1u8` and `3u8..=u8::MAX
+    let c = 4; //~ ERROR refutable pattern in local binding: `0u8..=1u8` and `3u8..=u8::MAX
+    let d = 4; //~ ERROR refutable pattern in local binding: `0u8..=1u8` and `3u8..=u8::MAX
     fn f() {} // Check that the `NOTE`s still work with an item here (cf. issue #35115).
 }

--- a/src/test/ui/consts/const-pattern-irrefutable.stderr
+++ b/src/test/ui/consts/const-pattern-irrefutable.stderr
@@ -1,4 +1,4 @@
-error[E0005]: refutable pattern in local binding: `0u8..=1u8` and `3u8..=std::u8::MAX` not covered
+error[E0005]: refutable pattern in local binding: `0u8..=1u8` and `3u8..=u8::MAX` not covered
   --> $DIR/const-pattern-irrefutable.rs:12:9
    |
 LL | const a: u8 = 2;
@@ -12,7 +12,7 @@ LL |     let a = 4;
    |
    = note: the matched value is of type `u8`
 
-error[E0005]: refutable pattern in local binding: `0u8..=1u8` and `3u8..=std::u8::MAX` not covered
+error[E0005]: refutable pattern in local binding: `0u8..=1u8` and `3u8..=u8::MAX` not covered
   --> $DIR/const-pattern-irrefutable.rs:13:9
    |
 LL |     pub const b: u8 = 2;
@@ -26,7 +26,7 @@ LL |     let c = 4;
    |
    = note: the matched value is of type `u8`
 
-error[E0005]: refutable pattern in local binding: `0u8..=1u8` and `3u8..=std::u8::MAX` not covered
+error[E0005]: refutable pattern in local binding: `0u8..=1u8` and `3u8..=u8::MAX` not covered
   --> $DIR/const-pattern-irrefutable.rs:14:9
    |
 LL |     pub const d: u8 = 2;

--- a/src/test/ui/for/for-loop-refutable-pattern-error-message.stderr
+++ b/src/test/ui/for/for-loop-refutable-pattern-error-message.stderr
@@ -1,8 +1,8 @@
-error[E0005]: refutable pattern in `for` loop binding: `&std::i32::MIN..=0i32` and `&2i32..=std::i32::MAX` not covered
+error[E0005]: refutable pattern in `for` loop binding: `&i32::MIN..=0i32` and `&2i32..=i32::MAX` not covered
   --> $DIR/for-loop-refutable-pattern-error-message.rs:2:9
    |
 LL |     for &1 in [1].iter() {}
-   |         ^^ patterns `&std::i32::MIN..=0i32` and `&2i32..=std::i32::MAX` not covered
+   |         ^^ patterns `&i32::MIN..=0i32` and `&2i32..=i32::MAX` not covered
    |
    = note: the matched value is of type `&i32`
 

--- a/src/test/ui/half-open-range-patterns/half-open-range-pats-exhaustive-fail.stderr
+++ b/src/test/ui/half-open-range-patterns/half-open-range-pats-exhaustive-fail.stderr
@@ -70,20 +70,20 @@ LL |     m!('a', ..VAL_1 | VAL_2..);
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `char`
 
-error[E0004]: non-exhaustive patterns: `std::u8::MAX` not covered
+error[E0004]: non-exhaustive patterns: `u8::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:41:12
    |
 LL |         m!(0, ..core::u8::MAX);
-   |            ^ pattern `std::u8::MAX` not covered
+   |            ^ pattern `u8::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `u8`
 
-error[E0004]: non-exhaustive patterns: `254u8..=std::u8::MAX` not covered
+error[E0004]: non-exhaustive patterns: `254u8..=u8::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:42:12
    |
 LL |         m!(0, ..ALMOST_MAX);
-   |            ^ pattern `254u8..=std::u8::MAX` not covered
+   |            ^ pattern `254u8..=u8::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `u8`
@@ -97,11 +97,11 @@ LL |         m!(0, ALMOST_MIN..);
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `u8`
 
-error[E0004]: non-exhaustive patterns: `std::u8::MAX` not covered
+error[E0004]: non-exhaustive patterns: `u8::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:44:12
    |
 LL |         m!(0, ..=ALMOST_MAX);
-   |            ^ pattern `std::u8::MAX` not covered
+   |            ^ pattern `u8::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `u8`
@@ -124,20 +124,20 @@ LL |         m!(0, ..VAL_1 | VAL_2..);
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `u8`
 
-error[E0004]: non-exhaustive patterns: `std::u16::MAX` not covered
+error[E0004]: non-exhaustive patterns: `u16::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:54:12
    |
 LL |         m!(0, ..core::u16::MAX);
-   |            ^ pattern `std::u16::MAX` not covered
+   |            ^ pattern `u16::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `u16`
 
-error[E0004]: non-exhaustive patterns: `65534u16..=std::u16::MAX` not covered
+error[E0004]: non-exhaustive patterns: `65534u16..=u16::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:55:12
    |
 LL |         m!(0, ..ALMOST_MAX);
-   |            ^ pattern `65534u16..=std::u16::MAX` not covered
+   |            ^ pattern `65534u16..=u16::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `u16`
@@ -151,11 +151,11 @@ LL |         m!(0, ALMOST_MIN..);
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `u16`
 
-error[E0004]: non-exhaustive patterns: `std::u16::MAX` not covered
+error[E0004]: non-exhaustive patterns: `u16::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:57:12
    |
 LL |         m!(0, ..=ALMOST_MAX);
-   |            ^ pattern `std::u16::MAX` not covered
+   |            ^ pattern `u16::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `u16`
@@ -178,20 +178,20 @@ LL |         m!(0, ..VAL_1 | VAL_2..);
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `u16`
 
-error[E0004]: non-exhaustive patterns: `std::u32::MAX` not covered
+error[E0004]: non-exhaustive patterns: `u32::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:67:12
    |
 LL |         m!(0, ..core::u32::MAX);
-   |            ^ pattern `std::u32::MAX` not covered
+   |            ^ pattern `u32::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `u32`
 
-error[E0004]: non-exhaustive patterns: `4294967294u32..=std::u32::MAX` not covered
+error[E0004]: non-exhaustive patterns: `4294967294u32..=u32::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:68:12
    |
 LL |         m!(0, ..ALMOST_MAX);
-   |            ^ pattern `4294967294u32..=std::u32::MAX` not covered
+   |            ^ pattern `4294967294u32..=u32::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `u32`
@@ -205,11 +205,11 @@ LL |         m!(0, ALMOST_MIN..);
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `u32`
 
-error[E0004]: non-exhaustive patterns: `std::u32::MAX` not covered
+error[E0004]: non-exhaustive patterns: `u32::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:70:12
    |
 LL |         m!(0, ..=ALMOST_MAX);
-   |            ^ pattern `std::u32::MAX` not covered
+   |            ^ pattern `u32::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `u32`
@@ -232,20 +232,20 @@ LL |         m!(0, ..VAL_1 | VAL_2..);
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `u32`
 
-error[E0004]: non-exhaustive patterns: `std::u64::MAX` not covered
+error[E0004]: non-exhaustive patterns: `u64::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:80:12
    |
 LL |         m!(0, ..core::u64::MAX);
-   |            ^ pattern `std::u64::MAX` not covered
+   |            ^ pattern `u64::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `u64`
 
-error[E0004]: non-exhaustive patterns: `18446744073709551614u64..=std::u64::MAX` not covered
+error[E0004]: non-exhaustive patterns: `18446744073709551614u64..=u64::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:81:12
    |
 LL |         m!(0, ..ALMOST_MAX);
-   |            ^ pattern `18446744073709551614u64..=std::u64::MAX` not covered
+   |            ^ pattern `18446744073709551614u64..=u64::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `u64`
@@ -259,11 +259,11 @@ LL |         m!(0, ALMOST_MIN..);
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `u64`
 
-error[E0004]: non-exhaustive patterns: `std::u64::MAX` not covered
+error[E0004]: non-exhaustive patterns: `u64::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:83:12
    |
 LL |         m!(0, ..=ALMOST_MAX);
-   |            ^ pattern `std::u64::MAX` not covered
+   |            ^ pattern `u64::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `u64`
@@ -286,20 +286,20 @@ LL |         m!(0, ..VAL_1 | VAL_2..);
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `u64`
 
-error[E0004]: non-exhaustive patterns: `std::u128::MAX` not covered
+error[E0004]: non-exhaustive patterns: `u128::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:93:12
    |
 LL |         m!(0, ..core::u128::MAX);
-   |            ^ pattern `std::u128::MAX` not covered
+   |            ^ pattern `u128::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `u128`
 
-error[E0004]: non-exhaustive patterns: `340282366920938463463374607431768211454u128..=std::u128::MAX` not covered
+error[E0004]: non-exhaustive patterns: `340282366920938463463374607431768211454u128..=u128::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:94:12
    |
 LL |         m!(0, ..ALMOST_MAX);
-   |            ^ pattern `340282366920938463463374607431768211454u128..=std::u128::MAX` not covered
+   |            ^ pattern `340282366920938463463374607431768211454u128..=u128::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `u128`
@@ -313,11 +313,11 @@ LL |         m!(0, ALMOST_MIN..);
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `u128`
 
-error[E0004]: non-exhaustive patterns: `std::u128::MAX` not covered
+error[E0004]: non-exhaustive patterns: `u128::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:96:12
    |
 LL |         m!(0, ..=ALMOST_MAX);
-   |            ^ pattern `std::u128::MAX` not covered
+   |            ^ pattern `u128::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `u128`
@@ -340,38 +340,38 @@ LL |         m!(0, ..VAL_1 | VAL_2..);
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `u128`
 
-error[E0004]: non-exhaustive patterns: `std::i8::MAX` not covered
+error[E0004]: non-exhaustive patterns: `i8::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:109:12
    |
 LL |         m!(0, ..core::i8::MAX);
-   |            ^ pattern `std::i8::MAX` not covered
+   |            ^ pattern `i8::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `i8`
 
-error[E0004]: non-exhaustive patterns: `126i8..=std::i8::MAX` not covered
+error[E0004]: non-exhaustive patterns: `126i8..=i8::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:110:12
    |
 LL |         m!(0, ..ALMOST_MAX);
-   |            ^ pattern `126i8..=std::i8::MAX` not covered
+   |            ^ pattern `126i8..=i8::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `i8`
 
-error[E0004]: non-exhaustive patterns: `std::i8::MIN` not covered
+error[E0004]: non-exhaustive patterns: `i8::MIN` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:111:12
    |
 LL |         m!(0, ALMOST_MIN..);
-   |            ^ pattern `std::i8::MIN` not covered
+   |            ^ pattern `i8::MIN` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `i8`
 
-error[E0004]: non-exhaustive patterns: `std::i8::MAX` not covered
+error[E0004]: non-exhaustive patterns: `i8::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:112:12
    |
 LL |         m!(0, ..=ALMOST_MAX);
-   |            ^ pattern `std::i8::MAX` not covered
+   |            ^ pattern `i8::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `i8`
@@ -394,38 +394,38 @@ LL |         m!(0, ..VAL_1 | VAL_2..);
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `i8`
 
-error[E0004]: non-exhaustive patterns: `std::i16::MAX` not covered
+error[E0004]: non-exhaustive patterns: `i16::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:122:12
    |
 LL |         m!(0, ..core::i16::MAX);
-   |            ^ pattern `std::i16::MAX` not covered
+   |            ^ pattern `i16::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `i16`
 
-error[E0004]: non-exhaustive patterns: `32766i16..=std::i16::MAX` not covered
+error[E0004]: non-exhaustive patterns: `32766i16..=i16::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:123:12
    |
 LL |         m!(0, ..ALMOST_MAX);
-   |            ^ pattern `32766i16..=std::i16::MAX` not covered
+   |            ^ pattern `32766i16..=i16::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `i16`
 
-error[E0004]: non-exhaustive patterns: `std::i16::MIN` not covered
+error[E0004]: non-exhaustive patterns: `i16::MIN` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:124:12
    |
 LL |         m!(0, ALMOST_MIN..);
-   |            ^ pattern `std::i16::MIN` not covered
+   |            ^ pattern `i16::MIN` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `i16`
 
-error[E0004]: non-exhaustive patterns: `std::i16::MAX` not covered
+error[E0004]: non-exhaustive patterns: `i16::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:125:12
    |
 LL |         m!(0, ..=ALMOST_MAX);
-   |            ^ pattern `std::i16::MAX` not covered
+   |            ^ pattern `i16::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `i16`
@@ -448,38 +448,38 @@ LL |         m!(0, ..VAL_1 | VAL_2..);
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `i16`
 
-error[E0004]: non-exhaustive patterns: `std::i32::MAX` not covered
+error[E0004]: non-exhaustive patterns: `i32::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:135:12
    |
 LL |         m!(0, ..core::i32::MAX);
-   |            ^ pattern `std::i32::MAX` not covered
+   |            ^ pattern `i32::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `i32`
 
-error[E0004]: non-exhaustive patterns: `2147483646i32..=std::i32::MAX` not covered
+error[E0004]: non-exhaustive patterns: `2147483646i32..=i32::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:136:12
    |
 LL |         m!(0, ..ALMOST_MAX);
-   |            ^ pattern `2147483646i32..=std::i32::MAX` not covered
+   |            ^ pattern `2147483646i32..=i32::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `i32`
 
-error[E0004]: non-exhaustive patterns: `std::i32::MIN` not covered
+error[E0004]: non-exhaustive patterns: `i32::MIN` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:137:12
    |
 LL |         m!(0, ALMOST_MIN..);
-   |            ^ pattern `std::i32::MIN` not covered
+   |            ^ pattern `i32::MIN` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `i32`
 
-error[E0004]: non-exhaustive patterns: `std::i32::MAX` not covered
+error[E0004]: non-exhaustive patterns: `i32::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:138:12
    |
 LL |         m!(0, ..=ALMOST_MAX);
-   |            ^ pattern `std::i32::MAX` not covered
+   |            ^ pattern `i32::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `i32`
@@ -502,38 +502,38 @@ LL |         m!(0, ..VAL_1 | VAL_2..);
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `i32`
 
-error[E0004]: non-exhaustive patterns: `std::i64::MAX` not covered
+error[E0004]: non-exhaustive patterns: `i64::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:148:12
    |
 LL |         m!(0, ..core::i64::MAX);
-   |            ^ pattern `std::i64::MAX` not covered
+   |            ^ pattern `i64::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `i64`
 
-error[E0004]: non-exhaustive patterns: `9223372036854775806i64..=std::i64::MAX` not covered
+error[E0004]: non-exhaustive patterns: `9223372036854775806i64..=i64::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:149:12
    |
 LL |         m!(0, ..ALMOST_MAX);
-   |            ^ pattern `9223372036854775806i64..=std::i64::MAX` not covered
+   |            ^ pattern `9223372036854775806i64..=i64::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `i64`
 
-error[E0004]: non-exhaustive patterns: `std::i64::MIN` not covered
+error[E0004]: non-exhaustive patterns: `i64::MIN` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:150:12
    |
 LL |         m!(0, ALMOST_MIN..);
-   |            ^ pattern `std::i64::MIN` not covered
+   |            ^ pattern `i64::MIN` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `i64`
 
-error[E0004]: non-exhaustive patterns: `std::i64::MAX` not covered
+error[E0004]: non-exhaustive patterns: `i64::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:151:12
    |
 LL |         m!(0, ..=ALMOST_MAX);
-   |            ^ pattern `std::i64::MAX` not covered
+   |            ^ pattern `i64::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `i64`
@@ -556,38 +556,38 @@ LL |         m!(0, ..VAL_1 | VAL_2..);
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `i64`
 
-error[E0004]: non-exhaustive patterns: `std::i128::MAX` not covered
+error[E0004]: non-exhaustive patterns: `i128::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:161:12
    |
 LL |         m!(0, ..core::i128::MAX);
-   |            ^ pattern `std::i128::MAX` not covered
+   |            ^ pattern `i128::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `i128`
 
-error[E0004]: non-exhaustive patterns: `170141183460469231731687303715884105726i128..=std::i128::MAX` not covered
+error[E0004]: non-exhaustive patterns: `170141183460469231731687303715884105726i128..=i128::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:162:12
    |
 LL |         m!(0, ..ALMOST_MAX);
-   |            ^ pattern `170141183460469231731687303715884105726i128..=std::i128::MAX` not covered
+   |            ^ pattern `170141183460469231731687303715884105726i128..=i128::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `i128`
 
-error[E0004]: non-exhaustive patterns: `std::i128::MIN` not covered
+error[E0004]: non-exhaustive patterns: `i128::MIN` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:163:12
    |
 LL |         m!(0, ALMOST_MIN..);
-   |            ^ pattern `std::i128::MIN` not covered
+   |            ^ pattern `i128::MIN` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `i128`
 
-error[E0004]: non-exhaustive patterns: `std::i128::MAX` not covered
+error[E0004]: non-exhaustive patterns: `i128::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:164:12
    |
 LL |         m!(0, ..=ALMOST_MAX);
-   |            ^ pattern `std::i128::MAX` not covered
+   |            ^ pattern `i128::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `i128`

--- a/src/test/ui/or-patterns/exhaustiveness-non-exhaustive.rs
+++ b/src/test/ui/or-patterns/exhaustiveness-non-exhaustive.rs
@@ -4,15 +4,15 @@
 // We wrap patterns in a tuple because top-level or-patterns were special-cased.
 fn main() {
     match (0u8, 0u8) {
-        //~^ ERROR non-exhaustive patterns: `(2u8..=std::u8::MAX, _)`
+        //~^ ERROR non-exhaustive patterns: `(2u8..=u8::MAX, _)`
         (0 | 1, 2 | 3) => {}
     }
     match ((0u8,),) {
-        //~^ ERROR non-exhaustive patterns: `((4u8..=std::u8::MAX))`
+        //~^ ERROR non-exhaustive patterns: `((4u8..=u8::MAX))`
         ((0 | 1,) | (2 | 3,),) => {}
     }
     match (Some(0u8),) {
-        //~^ ERROR non-exhaustive patterns: `(Some(2u8..=std::u8::MAX))`
+        //~^ ERROR non-exhaustive patterns: `(Some(2u8..=u8::MAX))`
         (None | Some(0 | 1),) => {}
     }
 }

--- a/src/test/ui/or-patterns/exhaustiveness-non-exhaustive.stderr
+++ b/src/test/ui/or-patterns/exhaustiveness-non-exhaustive.stderr
@@ -1,26 +1,26 @@
-error[E0004]: non-exhaustive patterns: `(2u8..=std::u8::MAX, _)` not covered
+error[E0004]: non-exhaustive patterns: `(2u8..=u8::MAX, _)` not covered
   --> $DIR/exhaustiveness-non-exhaustive.rs:6:11
    |
 LL |     match (0u8, 0u8) {
-   |           ^^^^^^^^^^ pattern `(2u8..=std::u8::MAX, _)` not covered
+   |           ^^^^^^^^^^ pattern `(2u8..=u8::MAX, _)` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `(u8, u8)`
 
-error[E0004]: non-exhaustive patterns: `((4u8..=std::u8::MAX))` not covered
+error[E0004]: non-exhaustive patterns: `((4u8..=u8::MAX))` not covered
   --> $DIR/exhaustiveness-non-exhaustive.rs:10:11
    |
 LL |     match ((0u8,),) {
-   |           ^^^^^^^^^ pattern `((4u8..=std::u8::MAX))` not covered
+   |           ^^^^^^^^^ pattern `((4u8..=u8::MAX))` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `((u8,),)`
 
-error[E0004]: non-exhaustive patterns: `(Some(2u8..=std::u8::MAX))` not covered
+error[E0004]: non-exhaustive patterns: `(Some(2u8..=u8::MAX))` not covered
   --> $DIR/exhaustiveness-non-exhaustive.rs:14:11
    |
 LL |     match (Some(0u8),) {
-   |           ^^^^^^^^^^^^ pattern `(Some(2u8..=std::u8::MAX))` not covered
+   |           ^^^^^^^^^^^^ pattern `(Some(2u8..=u8::MAX))` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `(std::option::Option<u8>,)`

--- a/src/test/ui/or-patterns/issue-69875-should-have-been-expanded-earlier-non-exhaustive.stderr
+++ b/src/test/ui/or-patterns/issue-69875-should-have-been-expanded-earlier-non-exhaustive.stderr
@@ -1,8 +1,8 @@
-error[E0005]: refutable pattern in local binding: `std::i32::MIN..=-1i32` and `3i32..=std::i32::MAX` not covered
+error[E0005]: refutable pattern in local binding: `i32::MIN..=-1i32` and `3i32..=i32::MAX` not covered
   --> $DIR/issue-69875-should-have-been-expanded-earlier-non-exhaustive.rs:4:9
    |
 LL |     let 0 | (1 | 2) = 0;
-   |         ^^^^^^^^^^^ patterns `std::i32::MIN..=-1i32` and `3i32..=std::i32::MAX` not covered
+   |         ^^^^^^^^^^^ patterns `i32::MIN..=-1i32` and `3i32..=i32::MAX` not covered
    |
    = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
    = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
@@ -12,11 +12,11 @@ help: you might want to use `if let` to ignore the variant that isn't matched
 LL |     if let 0 | (1 | 2) = 0 { /* */ }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0004]: non-exhaustive patterns: `std::i32::MIN..=-1i32` and `3i32..=std::i32::MAX` not covered
+error[E0004]: non-exhaustive patterns: `i32::MIN..=-1i32` and `3i32..=i32::MAX` not covered
   --> $DIR/issue-69875-should-have-been-expanded-earlier-non-exhaustive.rs:5:11
    |
 LL |     match 0 {
-   |           ^ patterns `std::i32::MIN..=-1i32` and `3i32..=std::i32::MAX` not covered
+   |           ^ patterns `i32::MIN..=-1i32` and `3i32..=i32::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `i32`

--- a/src/test/ui/pattern/usefulness/exhaustive_integer_patterns.stderr
+++ b/src/test/ui/pattern/usefulness/exhaustive_integer_patterns.stderr
@@ -10,11 +10,11 @@ note: the lint level is defined here
 LL | #![deny(unreachable_patterns)]
    |         ^^^^^^^^^^^^^^^^^^^^
 
-error[E0004]: non-exhaustive patterns: `128u8..=std::u8::MAX` not covered
+error[E0004]: non-exhaustive patterns: `128u8..=u8::MAX` not covered
   --> $DIR/exhaustive_integer_patterns.rs:28:11
    |
 LL |     match x {
-   |           ^ pattern `128u8..=std::u8::MAX` not covered
+   |           ^ pattern `128u8..=u8::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `u8`
@@ -34,20 +34,20 @@ error: unreachable pattern
 LL |         -2..=20 => {}
    |         ^^^^^^^
 
-error[E0004]: non-exhaustive patterns: `std::i8::MIN..=-8i8`, `-6i8`, `121i8..=124i8` and 1 more not covered
+error[E0004]: non-exhaustive patterns: `i8::MIN..=-8i8`, `-6i8`, `121i8..=124i8` and 1 more not covered
   --> $DIR/exhaustive_integer_patterns.rs:41:11
    |
 LL |     match x {
-   |           ^ patterns `std::i8::MIN..=-8i8`, `-6i8`, `121i8..=124i8` and 1 more not covered
+   |           ^ patterns `i8::MIN..=-8i8`, `-6i8`, `121i8..=124i8` and 1 more not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `i8`
 
-error[E0004]: non-exhaustive patterns: `std::i8::MIN` not covered
+error[E0004]: non-exhaustive patterns: `i8::MIN` not covered
   --> $DIR/exhaustive_integer_patterns.rs:83:11
    |
 LL |     match 0i8 {
-   |           ^^^ pattern `std::i8::MIN` not covered
+   |           ^^^ pattern `i8::MIN` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `i8`
@@ -61,20 +61,20 @@ LL |     match 0i16 {
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `i16`
 
-error[E0004]: non-exhaustive patterns: `128u8..=std::u8::MAX` not covered
+error[E0004]: non-exhaustive patterns: `128u8..=u8::MAX` not covered
   --> $DIR/exhaustive_integer_patterns.rs:109:11
    |
 LL |     match 0u8 {
-   |           ^^^ pattern `128u8..=std::u8::MAX` not covered
+   |           ^^^ pattern `128u8..=u8::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `u8`
 
-error[E0004]: non-exhaustive patterns: `(0u8, Some(_))` and `(2u8..=std::u8::MAX, Some(_))` not covered
+error[E0004]: non-exhaustive patterns: `(0u8, Some(_))` and `(2u8..=u8::MAX, Some(_))` not covered
   --> $DIR/exhaustive_integer_patterns.rs:121:11
    |
 LL |     match (0u8, Some(())) {
-   |           ^^^^^^^^^^^^^^^ patterns `(0u8, Some(_))` and `(2u8..=std::u8::MAX, Some(_))` not covered
+   |           ^^^^^^^^^^^^^^^ patterns `(0u8, Some(_))` and `(2u8..=u8::MAX, Some(_))` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `(u8, std::option::Option<()>)`
@@ -102,20 +102,20 @@ note: the lint level is defined here
 LL | #![deny(overlapping_patterns)]
    |         ^^^^^^^^^^^^^^^^^^^^
 
-error[E0004]: non-exhaustive patterns: `std::u128::MAX` not covered
+error[E0004]: non-exhaustive patterns: `u128::MAX` not covered
   --> $DIR/exhaustive_integer_patterns.rs:146:11
    |
 LL |     match 0u128 {
-   |           ^^^^^ pattern `std::u128::MAX` not covered
+   |           ^^^^^ pattern `u128::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `u128`
 
-error[E0004]: non-exhaustive patterns: `5u128..=std::u128::MAX` not covered
+error[E0004]: non-exhaustive patterns: `5u128..=u128::MAX` not covered
   --> $DIR/exhaustive_integer_patterns.rs:150:11
    |
 LL |     match 0u128 {
-   |           ^^^^^ pattern `5u128..=std::u128::MAX` not covered
+   |           ^^^^^ pattern `5u128..=u128::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `u128`

--- a/src/test/ui/pattern/usefulness/match-byte-array-patterns-2.stderr
+++ b/src/test/ui/pattern/usefulness/match-byte-array-patterns-2.stderr
@@ -1,8 +1,8 @@
-error[E0004]: non-exhaustive patterns: `&[0u8..=64u8, _, _, _]` and `&[66u8..=std::u8::MAX, _, _, _]` not covered
+error[E0004]: non-exhaustive patterns: `&[0u8..=64u8, _, _, _]` and `&[66u8..=u8::MAX, _, _, _]` not covered
   --> $DIR/match-byte-array-patterns-2.rs:4:11
    |
 LL |     match buf {
-   |           ^^^ patterns `&[0u8..=64u8, _, _, _]` and `&[66u8..=std::u8::MAX, _, _, _]` not covered
+   |           ^^^ patterns `&[0u8..=64u8, _, _, _]` and `&[66u8..=u8::MAX, _, _, _]` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `&[u8; 4]`

--- a/src/test/ui/pattern/usefulness/match-non-exhaustive.stderr
+++ b/src/test/ui/pattern/usefulness/match-non-exhaustive.stderr
@@ -1,8 +1,8 @@
-error[E0004]: non-exhaustive patterns: `std::i32::MIN..=0i32` and `2i32..=std::i32::MAX` not covered
+error[E0004]: non-exhaustive patterns: `i32::MIN..=0i32` and `2i32..=i32::MAX` not covered
   --> $DIR/match-non-exhaustive.rs:2:11
    |
 LL |     match 0 { 1 => () }
-   |           ^ patterns `std::i32::MIN..=0i32` and `2i32..=std::i32::MAX` not covered
+   |           ^ patterns `i32::MIN..=0i32` and `2i32..=i32::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `i32`

--- a/src/test/ui/pattern/usefulness/non-exhaustive-match.rs
+++ b/src/test/ui/pattern/usefulness/non-exhaustive-match.rs
@@ -11,8 +11,8 @@ fn main() {
     match Some(10) { //~ ERROR non-exhaustive patterns: `Some(_)` not covered
       None => {}
     }
-    match (2, 3, 4) { //~ ERROR non-exhaustive patterns: `(_, _, std::i32::MIN..=3i32)`
-                      //  and `(_, _, 5i32..=std::i32::MAX)` not covered
+    match (2, 3, 4) { //~ ERROR non-exhaustive patterns: `(_, _, i32::MIN..=3i32)`
+                      //  and `(_, _, 5i32..=i32::MAX)` not covered
       (_, _, 4) => {}
     }
     match (T::A, T::A) { //~ ERROR non-exhaustive patterns: `(A, A)` not covered

--- a/src/test/ui/pattern/usefulness/non-exhaustive-match.stderr
+++ b/src/test/ui/pattern/usefulness/non-exhaustive-match.stderr
@@ -36,11 +36,11 @@ LL |     Some(#[stable(feature = "rust1", since = "1.0.0")] T),
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `std::option::Option<i32>`
 
-error[E0004]: non-exhaustive patterns: `(_, _, std::i32::MIN..=3i32)` and `(_, _, 5i32..=std::i32::MAX)` not covered
+error[E0004]: non-exhaustive patterns: `(_, _, i32::MIN..=3i32)` and `(_, _, 5i32..=i32::MAX)` not covered
   --> $DIR/non-exhaustive-match.rs:14:11
    |
 LL |     match (2, 3, 4) {
-   |           ^^^^^^^^^ patterns `(_, _, std::i32::MIN..=3i32)` and `(_, _, 5i32..=std::i32::MAX)` not covered
+   |           ^^^^^^^^^ patterns `(_, _, i32::MIN..=3i32)` and `(_, _, 5i32..=i32::MAX)` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `(i32, i32, i32)`

--- a/src/test/ui/pattern/usefulness/refutable-pattern-errors.rs
+++ b/src/test/ui/pattern/usefulness/refutable-pattern-errors.rs
@@ -5,5 +5,5 @@ fn func((1, (Some(1), 2..=3)): (isize, (Option<isize>, isize))) { }
 
 fn main() {
     let (1, (Some(1), 2..=3)) = (1, (None, 2));
-    //~^ ERROR refutable pattern in local binding: `(std::i32::MIN..=0i32, _)` and `(2i32..=std::i32::MAX, _)` not covered
+    //~^ ERROR refutable pattern in local binding: `(i32::MIN..=0i32, _)` and `(2i32..=i32::MAX, _)` not covered
 }

--- a/src/test/ui/pattern/usefulness/refutable-pattern-errors.stderr
+++ b/src/test/ui/pattern/usefulness/refutable-pattern-errors.stderr
@@ -6,11 +6,11 @@ LL | fn func((1, (Some(1), 2..=3)): (isize, (Option<isize>, isize))) { }
    |
    = note: the matched value is of type `(isize, (std::option::Option<isize>, isize))`
 
-error[E0005]: refutable pattern in local binding: `(std::i32::MIN..=0i32, _)` and `(2i32..=std::i32::MAX, _)` not covered
+error[E0005]: refutable pattern in local binding: `(i32::MIN..=0i32, _)` and `(2i32..=i32::MAX, _)` not covered
   --> $DIR/refutable-pattern-errors.rs:7:9
    |
 LL |     let (1, (Some(1), 2..=3)) = (1, (None, 2));
-   |         ^^^^^^^^^^^^^^^^^^^^^ patterns `(std::i32::MIN..=0i32, _)` and `(2i32..=std::i32::MAX, _)` not covered
+   |         ^^^^^^^^^^^^^^^^^^^^^ patterns `(i32::MIN..=0i32, _)` and `(2i32..=i32::MAX, _)` not covered
    |
    = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
    = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html

--- a/src/test/ui/precise_pointer_size_matching.stderr
+++ b/src/test/ui/precise_pointer_size_matching.stderr
@@ -1,17 +1,17 @@
-error[E0004]: non-exhaustive patterns: `std::isize::MIN..=-6isize` and `21isize..=std::isize::MAX` not covered
+error[E0004]: non-exhaustive patterns: `isize::MIN..=-6isize` and `21isize..=isize::MAX` not covered
   --> $DIR/precise_pointer_size_matching.rs:24:11
    |
 LL |     match 0isize {
-   |           ^^^^^^ patterns `std::isize::MIN..=-6isize` and `21isize..=std::isize::MAX` not covered
+   |           ^^^^^^ patterns `isize::MIN..=-6isize` and `21isize..=isize::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `isize`
 
-error[E0004]: non-exhaustive patterns: `0usize` and `21usize..=std::usize::MAX` not covered
+error[E0004]: non-exhaustive patterns: `0usize` and `21usize..=usize::MAX` not covered
   --> $DIR/precise_pointer_size_matching.rs:29:11
    |
 LL |     match 0usize {
-   |           ^^^^^^ patterns `0usize` and `21usize..=std::usize::MAX` not covered
+   |           ^^^^^^ patterns `0usize` and `21usize..=usize::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `usize`

--- a/src/test/ui/suggestions/const-pat-non-exaustive-let-new-var.rs
+++ b/src/test/ui/suggestions/const-pat-non-exaustive-let-new-var.rs
@@ -1,6 +1,6 @@
 fn main() {
     let A = 3;
-    //~^ ERROR refutable pattern in local binding: `std::i32::MIN..=1i32` and
+    //~^ ERROR refutable pattern in local binding: `i32::MIN..=1i32` and
     //~| interpreted as a constant pattern, not a new variable
     //~| HELP introduce a variable instead
     //~| SUGGESTION a_var

--- a/src/test/ui/suggestions/const-pat-non-exaustive-let-new-var.stderr
+++ b/src/test/ui/suggestions/const-pat-non-exaustive-let-new-var.stderr
@@ -1,4 +1,4 @@
-error[E0005]: refutable pattern in local binding: `std::i32::MIN..=1i32` and `3i32..=std::i32::MAX` not covered
+error[E0005]: refutable pattern in local binding: `i32::MIN..=1i32` and `3i32..=i32::MAX` not covered
   --> $DIR/const-pat-non-exaustive-let-new-var.rs:2:9
    |
 LL |     let A = 3;


### PR DESCRIPTION
Resolved this comment: https://github.com/rust-lang/rust/issues/68490#issuecomment-641614383
