### PR TITLE
Provide suggestion to convert numeric op LHS rather than unwrapping RHS

### DIFF
--- a/src/librustc_typeck/check/coercion.rs
+++ b/src/librustc_typeck/check/coercion.rs
@@ -1377,7 +1377,7 @@ impl<'tcx, 'exprs, E: AsCoercionSite> CoerceMany<'tcx, 'exprs, E> {
                 }
 
                 if let Some(expr) = expression {
-                    fcx.emit_coerce_suggestions(&mut err, expr, found, expected);
+                    fcx.emit_coerce_suggestions(&mut err, expr, found, expected, None);
                 }
 
                 // Error possibly reported in `check_assign` so avoid emitting error again.

--- a/src/test/ui/numeric/numeric-cast-binop.fixed
+++ b/src/test/ui/numeric/numeric-cast-binop.fixed
@@ -20,301 +20,301 @@ fn main() {
 
     /* u<->u */
     {
-        x_u8 > x_u16;
+        u16::from(x_u8) > x_u16;
         //~^ ERROR mismatched types
-        x_u8 > x_u32;
+        u32::from(x_u8) > x_u32;
         //~^ ERROR mismatched types
-        x_u8 > x_u64;
+        u64::from(x_u8) > x_u64;
         //~^ ERROR mismatched types
-        x_u8 > x_u128;
+        u128::from(x_u8) > x_u128;
         //~^ ERROR mismatched types
-        x_u8 > x_usize;
-        //~^ ERROR mismatched types
-
-        x_u16 > x_u8;
-        //~^ ERROR mismatched types
-        x_u16 > x_u32;
-        //~^ ERROR mismatched types
-        x_u16 > x_u64;
-        //~^ ERROR mismatched types
-        x_u16 > x_u128;
-        //~^ ERROR mismatched types
-        x_u16 > x_usize;
+        usize::from(x_u8) > x_usize;
         //~^ ERROR mismatched types
 
-        x_u32 > x_u8;
+        x_u16 > x_u8.into();
         //~^ ERROR mismatched types
-        x_u32 > x_u16;
+        u32::from(x_u16) > x_u32;
         //~^ ERROR mismatched types
-        x_u32 > x_u64;
+        u64::from(x_u16) > x_u64;
         //~^ ERROR mismatched types
-        x_u32 > x_u128;
+        u128::from(x_u16) > x_u128;
         //~^ ERROR mismatched types
-        x_u32 > x_usize;
-        //~^ ERROR mismatched types
-
-        x_u64 > x_u8;
-        //~^ ERROR mismatched types
-        x_u64 > x_u16;
-        //~^ ERROR mismatched types
-        x_u64 > x_u32;
-        //~^ ERROR mismatched types
-        x_u64 > x_u128;
-        //~^ ERROR mismatched types
-        x_u64 > x_usize;
+        usize::from(x_u16) > x_usize;
         //~^ ERROR mismatched types
 
-        x_u128 > x_u8;
+        x_u32 > x_u8.into();
         //~^ ERROR mismatched types
-        x_u128 > x_u16;
+        x_u32 > x_u16.into();
         //~^ ERROR mismatched types
-        x_u128 > x_u32;
+        u64::from(x_u32) > x_u64;
         //~^ ERROR mismatched types
-        x_u128 > x_u64;
+        u128::from(x_u32) > x_u128;
         //~^ ERROR mismatched types
-        x_u128 > x_usize;
+        x_u32 > x_usize.try_into().unwrap();
         //~^ ERROR mismatched types
 
-        x_usize > x_u8;
+        x_u64 > x_u8.into();
         //~^ ERROR mismatched types
-        x_usize > x_u16;
+        x_u64 > x_u16.into();
         //~^ ERROR mismatched types
-        x_usize > x_u32;
+        x_u64 > x_u32.into();
         //~^ ERROR mismatched types
-        x_usize > x_u64;
+        u128::from(x_u64) > x_u128;
         //~^ ERROR mismatched types
-        x_usize > x_u128;
+        x_u64 > x_usize.try_into().unwrap();
+        //~^ ERROR mismatched types
+
+        x_u128 > x_u8.into();
+        //~^ ERROR mismatched types
+        x_u128 > x_u16.into();
+        //~^ ERROR mismatched types
+        x_u128 > x_u32.into();
+        //~^ ERROR mismatched types
+        x_u128 > x_u64.into();
+        //~^ ERROR mismatched types
+        x_u128 > x_usize.try_into().unwrap();
+        //~^ ERROR mismatched types
+
+        x_usize > x_u8.into();
+        //~^ ERROR mismatched types
+        x_usize > x_u16.into();
+        //~^ ERROR mismatched types
+        x_usize > x_u32.try_into().unwrap();
+        //~^ ERROR mismatched types
+        x_usize > x_u64.try_into().unwrap();
+        //~^ ERROR mismatched types
+        x_usize > x_u128.try_into().unwrap();
         //~^ ERROR mismatched types
     }
 
     /* i<->i */
     {
-        x_i8 > x_i16;
+        i16::from(x_i8) > x_i16;
         //~^ ERROR mismatched types
-        x_i8 > x_i32;
+        i32::from(x_i8) > x_i32;
         //~^ ERROR mismatched types
-        x_i8 > x_i64;
+        i64::from(x_i8) > x_i64;
         //~^ ERROR mismatched types
-        x_i8 > x_i128;
+        i128::from(x_i8) > x_i128;
         //~^ ERROR mismatched types
-        x_i8 > x_isize;
-        //~^ ERROR mismatched types
-
-        x_i16 > x_i8;
-        //~^ ERROR mismatched types
-        x_i16 > x_i32;
-        //~^ ERROR mismatched types
-        x_i16 > x_i64;
-        //~^ ERROR mismatched types
-        x_i16 > x_i128;
-        //~^ ERROR mismatched types
-        x_i16 > x_isize;
+        isize::from(x_i8) > x_isize;
         //~^ ERROR mismatched types
 
-        x_i32 > x_i8;
+        x_i16 > x_i8.into();
         //~^ ERROR mismatched types
-        x_i32 > x_i16;
+        i32::from(x_i16) > x_i32;
         //~^ ERROR mismatched types
-        x_i32 > x_i64;
+        i64::from(x_i16) > x_i64;
         //~^ ERROR mismatched types
-        x_i32 > x_i128;
+        i128::from(x_i16) > x_i128;
         //~^ ERROR mismatched types
-        x_i32 > x_isize;
-        //~^ ERROR mismatched types
-
-        x_i64 > x_i8;
-        //~^ ERROR mismatched types
-        x_i64 > x_i16;
-        //~^ ERROR mismatched types
-        x_i64 > x_i32;
-        //~^ ERROR mismatched types
-        x_i64 > x_i128;
-        //~^ ERROR mismatched types
-        x_i64 > x_isize;
+        isize::from(x_i16) > x_isize;
         //~^ ERROR mismatched types
 
-        x_i128 > x_i8;
+        x_i32 > x_i8.into();
         //~^ ERROR mismatched types
-        x_i128 > x_i16;
+        x_i32 > x_i16.into();
         //~^ ERROR mismatched types
-        x_i128 > x_i32;
+        i64::from(x_i32) > x_i64;
         //~^ ERROR mismatched types
-        x_i128 > x_i64;
+        i128::from(x_i32) > x_i128;
         //~^ ERROR mismatched types
-        x_i128 > x_isize;
+        x_i32 > x_isize.try_into().unwrap();
         //~^ ERROR mismatched types
 
-        x_isize > x_i8;
+        x_i64 > x_i8.into();
         //~^ ERROR mismatched types
-        x_isize > x_i16;
+        x_i64 > x_i16.into();
         //~^ ERROR mismatched types
-        x_isize > x_i32;
+        x_i64 > x_i32.into();
         //~^ ERROR mismatched types
-        x_isize > x_i64;
+        i128::from(x_i64) > x_i128;
         //~^ ERROR mismatched types
-        x_isize > x_i128;
+        x_i64 > x_isize.try_into().unwrap();
+        //~^ ERROR mismatched types
+
+        x_i128 > x_i8.into();
+        //~^ ERROR mismatched types
+        x_i128 > x_i16.into();
+        //~^ ERROR mismatched types
+        x_i128 > x_i32.into();
+        //~^ ERROR mismatched types
+        x_i128 > x_i64.into();
+        //~^ ERROR mismatched types
+        x_i128 > x_isize.try_into().unwrap();
+        //~^ ERROR mismatched types
+
+        x_isize > x_i8.into();
+        //~^ ERROR mismatched types
+        x_isize > x_i16.into();
+        //~^ ERROR mismatched types
+        x_isize > x_i32.try_into().unwrap();
+        //~^ ERROR mismatched types
+        x_isize > x_i64.try_into().unwrap();
+        //~^ ERROR mismatched types
+        x_isize > x_i128.try_into().unwrap();
         //~^ ERROR mismatched types
     }
 
     /* u<->i */
     {
-        x_u8 > x_i8;
+        x_u8 > x_i8.try_into().unwrap();
         //~^ ERROR mismatched types
-        x_u8 > x_i16;
+        i16::from(x_u8) > x_i16;
         //~^ ERROR mismatched types
-        x_u8 > x_i32;
+        i32::from(x_u8) > x_i32;
         //~^ ERROR mismatched types
-        x_u8 > x_i64;
+        i64::from(x_u8) > x_i64;
         //~^ ERROR mismatched types
-        x_u8 > x_i128;
+        i128::from(x_u8) > x_i128;
         //~^ ERROR mismatched types
-        x_u8 > x_isize;
-        //~^ ERROR mismatched types
-
-        x_u16 > x_i8;
-        //~^ ERROR mismatched types
-        x_u16 > x_i16;
-        //~^ ERROR mismatched types
-        x_u16 > x_i32;
-        //~^ ERROR mismatched types
-        x_u16 > x_i64;
-        //~^ ERROR mismatched types
-        x_u16 > x_i128;
-        //~^ ERROR mismatched types
-        x_u16 > x_isize;
+        isize::from(x_u8) > x_isize;
         //~^ ERROR mismatched types
 
-        x_u32 > x_i8;
+        x_u16 > x_i8.try_into().unwrap();
         //~^ ERROR mismatched types
-        x_u32 > x_i16;
+        x_u16 > x_i16.try_into().unwrap();
         //~^ ERROR mismatched types
-        x_u32 > x_i32;
+        i32::from(x_u16) > x_i32;
         //~^ ERROR mismatched types
-        x_u32 > x_i64;
+        i64::from(x_u16) > x_i64;
         //~^ ERROR mismatched types
-        x_u32 > x_i128;
+        i128::from(x_u16) > x_i128;
         //~^ ERROR mismatched types
-        x_u32 > x_isize;
-        //~^ ERROR mismatched types
-
-        x_u64 > x_i8;
-        //~^ ERROR mismatched types
-        x_u64 > x_i16;
-        //~^ ERROR mismatched types
-        x_u64 > x_i32;
-        //~^ ERROR mismatched types
-        x_u64 > x_i64;
-        //~^ ERROR mismatched types
-        x_u64 > x_i128;
-        //~^ ERROR mismatched types
-        x_u64 > x_isize;
+        x_u16 > x_isize.try_into().unwrap();
         //~^ ERROR mismatched types
 
-        x_u128 > x_i8;
+        x_u32 > x_i8.try_into().unwrap();
         //~^ ERROR mismatched types
-        x_u128 > x_i16;
+        x_u32 > x_i16.try_into().unwrap();
         //~^ ERROR mismatched types
-        x_u128 > x_i32;
+        x_u32 > x_i32.try_into().unwrap();
         //~^ ERROR mismatched types
-        x_u128 > x_i64;
+        i64::from(x_u32) > x_i64;
         //~^ ERROR mismatched types
-        x_u128 > x_i128;
+        i128::from(x_u32) > x_i128;
         //~^ ERROR mismatched types
-        x_u128 > x_isize;
+        x_u32 > x_isize.try_into().unwrap();
         //~^ ERROR mismatched types
 
-        x_usize > x_i8;
+        x_u64 > x_i8.try_into().unwrap();
         //~^ ERROR mismatched types
-        x_usize > x_i16;
+        x_u64 > x_i16.try_into().unwrap();
         //~^ ERROR mismatched types
-        x_usize > x_i32;
+        x_u64 > x_i32.try_into().unwrap();
         //~^ ERROR mismatched types
-        x_usize > x_i64;
+        x_u64 > x_i64.try_into().unwrap();
         //~^ ERROR mismatched types
-        x_usize > x_i128;
+        i128::from(x_u64) > x_i128;
         //~^ ERROR mismatched types
-        x_usize > x_isize;
+        x_u64 > x_isize.try_into().unwrap();
+        //~^ ERROR mismatched types
+
+        x_u128 > x_i8.try_into().unwrap();
+        //~^ ERROR mismatched types
+        x_u128 > x_i16.try_into().unwrap();
+        //~^ ERROR mismatched types
+        x_u128 > x_i32.try_into().unwrap();
+        //~^ ERROR mismatched types
+        x_u128 > x_i64.try_into().unwrap();
+        //~^ ERROR mismatched types
+        x_u128 > x_i128.try_into().unwrap();
+        //~^ ERROR mismatched types
+        x_u128 > x_isize.try_into().unwrap();
+        //~^ ERROR mismatched types
+
+        x_usize > x_i8.try_into().unwrap();
+        //~^ ERROR mismatched types
+        x_usize > x_i16.try_into().unwrap();
+        //~^ ERROR mismatched types
+        x_usize > x_i32.try_into().unwrap();
+        //~^ ERROR mismatched types
+        x_usize > x_i64.try_into().unwrap();
+        //~^ ERROR mismatched types
+        x_usize > x_i128.try_into().unwrap();
+        //~^ ERROR mismatched types
+        x_usize > x_isize.try_into().unwrap();
         //~^ ERROR mismatched types
     }
 
     /* i<->u */
     {
-        x_i8 > x_u8;
+        x_i8 > x_u8.try_into().unwrap();
         //~^ ERROR mismatched types
-        x_i8 > x_u16;
+        x_i8 > x_u16.try_into().unwrap();
         //~^ ERROR mismatched types
-        x_i8 > x_u32;
+        x_i8 > x_u32.try_into().unwrap();
         //~^ ERROR mismatched types
-        x_i8 > x_u64;
+        x_i8 > x_u64.try_into().unwrap();
         //~^ ERROR mismatched types
-        x_i8 > x_u128;
+        x_i8 > x_u128.try_into().unwrap();
         //~^ ERROR mismatched types
-        x_i8 > x_usize;
-        //~^ ERROR mismatched types
-
-        x_i16 > x_u8;
-        //~^ ERROR mismatched types
-        x_i16 > x_u16;
-        //~^ ERROR mismatched types
-        x_i16 > x_u32;
-        //~^ ERROR mismatched types
-        x_i16 > x_u64;
-        //~^ ERROR mismatched types
-        x_i16 > x_u128;
-        //~^ ERROR mismatched types
-        x_i16 > x_usize;
+        x_i8 > x_usize.try_into().unwrap();
         //~^ ERROR mismatched types
 
-        x_i32 > x_u8;
+        x_i16 > x_u8.into();
         //~^ ERROR mismatched types
-        x_i32 > x_u16;
+        x_i16 > x_u16.try_into().unwrap();
         //~^ ERROR mismatched types
-        x_i32 > x_u32;
+        x_i16 > x_u32.try_into().unwrap();
         //~^ ERROR mismatched types
-        x_i32 > x_u64;
+        x_i16 > x_u64.try_into().unwrap();
         //~^ ERROR mismatched types
-        x_i32 > x_u128;
+        x_i16 > x_u128.try_into().unwrap();
         //~^ ERROR mismatched types
-        x_i32 > x_usize;
-        //~^ ERROR mismatched types
-
-        x_i64 > x_u8;
-        //~^ ERROR mismatched types
-        x_i64 > x_u16;
-        //~^ ERROR mismatched types
-        x_i64 > x_u32;
-        //~^ ERROR mismatched types
-        x_i64 > x_u64;
-        //~^ ERROR mismatched types
-        x_i64 > x_u128;
-        //~^ ERROR mismatched types
-        x_i64 > x_usize;
+        x_i16 > x_usize.try_into().unwrap();
         //~^ ERROR mismatched types
 
-        x_i128 > x_u8;
+        x_i32 > x_u8.into();
         //~^ ERROR mismatched types
-        x_i128 > x_u16;
+        x_i32 > x_u16.into();
         //~^ ERROR mismatched types
-        x_i128 > x_u32;
+        x_i32 > x_u32.try_into().unwrap();
         //~^ ERROR mismatched types
-        x_i128 > x_u64;
+        x_i32 > x_u64.try_into().unwrap();
         //~^ ERROR mismatched types
-        x_i128 > x_u128;
+        x_i32 > x_u128.try_into().unwrap();
         //~^ ERROR mismatched types
-        x_i128 > x_usize;
+        x_i32 > x_usize.try_into().unwrap();
         //~^ ERROR mismatched types
 
-        x_isize > x_u8;
+        x_i64 > x_u8.into();
         //~^ ERROR mismatched types
-        x_isize > x_u16;
+        x_i64 > x_u16.into();
         //~^ ERROR mismatched types
-        x_isize > x_u32;
+        x_i64 > x_u32.into();
         //~^ ERROR mismatched types
-        x_isize > x_u64;
+        x_i64 > x_u64.try_into().unwrap();
         //~^ ERROR mismatched types
-        x_isize > x_u128;
+        x_i64 > x_u128.try_into().unwrap();
         //~^ ERROR mismatched types
-        x_isize > x_usize;
+        x_i64 > x_usize.try_into().unwrap();
+        //~^ ERROR mismatched types
+
+        x_i128 > x_u8.into();
+        //~^ ERROR mismatched types
+        x_i128 > x_u16.into();
+        //~^ ERROR mismatched types
+        x_i128 > x_u32.into();
+        //~^ ERROR mismatched types
+        x_i128 > x_u64.into();
+        //~^ ERROR mismatched types
+        x_i128 > x_u128.try_into().unwrap();
+        //~^ ERROR mismatched types
+        x_i128 > x_usize.try_into().unwrap();
+        //~^ ERROR mismatched types
+
+        x_isize > x_u8.into();
+        //~^ ERROR mismatched types
+        x_isize > x_u16.try_into().unwrap();
+        //~^ ERROR mismatched types
+        x_isize > x_u32.try_into().unwrap();
+        //~^ ERROR mismatched types
+        x_isize > x_u64.try_into().unwrap();
+        //~^ ERROR mismatched types
+        x_isize > x_u128.try_into().unwrap();
+        //~^ ERROR mismatched types
+        x_isize > x_usize.try_into().unwrap();
         //~^ ERROR mismatched types
     }
 }

--- a/src/test/ui/numeric/numeric-cast-binop.rs
+++ b/src/test/ui/numeric/numeric-cast-binop.rs
@@ -1,0 +1,315 @@
+fn main() {
+    let x_usize: usize = 1;
+    let x_u128: u128 = 2;
+    let x_u64: u64 = 3;
+    let x_u32: u32 = 4;
+    let x_u16: u16 = 5;
+    let x_u8: u8 = 6;
+    let x_isize: isize = 7;
+    let x_i128: i128 = 8;
+    let x_i64: i64 = 9;
+    let x_i32: i32 = 10;
+    let x_i16: i16 = 11;
+    let x_i8: i8 = 12;
+    let x_i128: i128 = 13;
+
+    /* u<->u */
+    {
+        x_u8 > x_u16;
+        //~^ ERROR mismatched types
+        x_u8 > x_u32;
+        //~^ ERROR mismatched types
+        x_u8 > x_u64;
+        //~^ ERROR mismatched types
+        x_u8 > x_u128;
+        //~^ ERROR mismatched types
+        x_u8 > x_usize;
+        //~^ ERROR mismatched types
+
+        x_u16 > x_u8;
+        //~^ ERROR mismatched types
+        x_u16 > x_u32;
+        //~^ ERROR mismatched types
+        x_u16 > x_u64;
+        //~^ ERROR mismatched types
+        x_u16 > x_u128;
+        //~^ ERROR mismatched types
+        x_u16 > x_usize;
+        //~^ ERROR mismatched types
+
+        x_u32 > x_u8;
+        //~^ ERROR mismatched types
+        x_u32 > x_u16;
+        //~^ ERROR mismatched types
+        x_u32 > x_u64;
+        //~^ ERROR mismatched types
+        x_u32 > x_u128;
+        //~^ ERROR mismatched types
+        x_u32 > x_usize;
+        //~^ ERROR mismatched types
+
+        x_u64 > x_u8;
+        //~^ ERROR mismatched types
+        x_u64 > x_u16;
+        //~^ ERROR mismatched types
+        x_u64 > x_u32;
+        //~^ ERROR mismatched types
+        x_u64 > x_u128;
+        //~^ ERROR mismatched types
+        x_u64 > x_usize;
+        //~^ ERROR mismatched types
+
+        x_u128 > x_u8;
+        //~^ ERROR mismatched types
+        x_u128 > x_u16;
+        //~^ ERROR mismatched types
+        x_u128 > x_u32;
+        //~^ ERROR mismatched types
+        x_u128 > x_u64;
+        //~^ ERROR mismatched types
+        x_u128 > x_usize;
+        //~^ ERROR mismatched types
+
+        x_usize > x_u8;
+        //~^ ERROR mismatched types
+        x_usize > x_u16;
+        //~^ ERROR mismatched types
+        x_usize > x_u32;
+        //~^ ERROR mismatched types
+        x_usize > x_u64;
+        //~^ ERROR mismatched types
+        x_usize > x_u128;
+        //~^ ERROR mismatched types
+    }
+
+    /* i<->i */
+    {
+        x_i8 > x_i16;
+        //~^ ERROR mismatched types
+        x_i8 > x_i32;
+        //~^ ERROR mismatched types
+        x_i8 > x_i64;
+        //~^ ERROR mismatched types
+        x_i8 > x_i128;
+        //~^ ERROR mismatched types
+        x_i8 > x_isize;
+        //~^ ERROR mismatched types
+
+        x_i16 > x_i8;
+        //~^ ERROR mismatched types
+        x_i16 > x_i32;
+        //~^ ERROR mismatched types
+        x_i16 > x_i64;
+        //~^ ERROR mismatched types
+        x_i16 > x_i128;
+        //~^ ERROR mismatched types
+        x_i16 > x_isize;
+        //~^ ERROR mismatched types
+
+        x_i32 > x_i8;
+        //~^ ERROR mismatched types
+        x_i32 > x_i16;
+        //~^ ERROR mismatched types
+        x_i32 > x_i64;
+        //~^ ERROR mismatched types
+        x_i32 > x_i128;
+        //~^ ERROR mismatched types
+        x_i32 > x_isize;
+        //~^ ERROR mismatched types
+
+        x_i64 > x_i8;
+        //~^ ERROR mismatched types
+        x_i64 > x_i16;
+        //~^ ERROR mismatched types
+        x_i64 > x_i32;
+        //~^ ERROR mismatched types
+        x_i64 > x_i128;
+        //~^ ERROR mismatched types
+        x_i64 > x_isize;
+        //~^ ERROR mismatched types
+
+        x_i128 > x_i8;
+        //~^ ERROR mismatched types
+        x_i128 > x_i16;
+        //~^ ERROR mismatched types
+        x_i128 > x_i32;
+        //~^ ERROR mismatched types
+        x_i128 > x_i64;
+        //~^ ERROR mismatched types
+        x_i128 > x_isize;
+        //~^ ERROR mismatched types
+
+        x_isize > x_i8;
+        //~^ ERROR mismatched types
+        x_isize > x_i16;
+        //~^ ERROR mismatched types
+        x_isize > x_i32;
+        //~^ ERROR mismatched types
+        x_isize > x_i64;
+        //~^ ERROR mismatched types
+        x_isize > x_i128;
+        //~^ ERROR mismatched types
+    }
+
+    /* u<->i */
+    {
+        x_u8 > x_i8;
+        //~^ ERROR mismatched types
+        x_u8 > x_i16;
+        //~^ ERROR mismatched types
+        x_u8 > x_i32;
+        //~^ ERROR mismatched types
+        x_u8 > x_i64;
+        //~^ ERROR mismatched types
+        x_u8 > x_i128;
+        //~^ ERROR mismatched types
+        x_u8 > x_isize;
+        //~^ ERROR mismatched types
+
+        x_u16 > x_i8;
+        //~^ ERROR mismatched types
+        x_u16 > x_i16;
+        //~^ ERROR mismatched types
+        x_u16 > x_i32;
+        //~^ ERROR mismatched types
+        x_u16 > x_i64;
+        //~^ ERROR mismatched types
+        x_u16 > x_i128;
+        //~^ ERROR mismatched types
+        x_u16 > x_isize;
+        //~^ ERROR mismatched types
+
+        x_u32 > x_i8;
+        //~^ ERROR mismatched types
+        x_u32 > x_i16;
+        //~^ ERROR mismatched types
+        x_u32 > x_i32;
+        //~^ ERROR mismatched types
+        x_u32 > x_i64;
+        //~^ ERROR mismatched types
+        x_u32 > x_i128;
+        //~^ ERROR mismatched types
+        x_u32 > x_isize;
+        //~^ ERROR mismatched types
+
+        x_u64 > x_i8;
+        //~^ ERROR mismatched types
+        x_u64 > x_i16;
+        //~^ ERROR mismatched types
+        x_u64 > x_i32;
+        //~^ ERROR mismatched types
+        x_u64 > x_i64;
+        //~^ ERROR mismatched types
+        x_u64 > x_i128;
+        //~^ ERROR mismatched types
+        x_u64 > x_isize;
+        //~^ ERROR mismatched types
+
+        x_u128 > x_i8;
+        //~^ ERROR mismatched types
+        x_u128 > x_i16;
+        //~^ ERROR mismatched types
+        x_u128 > x_i32;
+        //~^ ERROR mismatched types
+        x_u128 > x_i64;
+        //~^ ERROR mismatched types
+        x_u128 > x_i128;
+        //~^ ERROR mismatched types
+        x_u128 > x_isize;
+        //~^ ERROR mismatched types
+
+        x_usize > x_i8;
+        //~^ ERROR mismatched types
+        x_usize > x_i16;
+        //~^ ERROR mismatched types
+        x_usize > x_i32;
+        //~^ ERROR mismatched types
+        x_usize > x_i64;
+        //~^ ERROR mismatched types
+        x_usize > x_i128;
+        //~^ ERROR mismatched types
+        x_usize > x_isize;
+        //~^ ERROR mismatched types
+    }
+
+    /* i<->u */
+    {
+        x_i8 > x_u8;
+        //~^ ERROR mismatched types
+        x_i8 > x_u16;
+        //~^ ERROR mismatched types
+        x_i8 > x_u32;
+        //~^ ERROR mismatched types
+        x_i8 > x_u64;
+        //~^ ERROR mismatched types
+        x_i8 > x_u128;
+        //~^ ERROR mismatched types
+        x_i8 > x_usize;
+        //~^ ERROR mismatched types
+
+        x_i16 > x_u8;
+        //~^ ERROR mismatched types
+        x_i16 > x_u16;
+        //~^ ERROR mismatched types
+        x_i16 > x_u32;
+        //~^ ERROR mismatched types
+        x_i16 > x_u64;
+        //~^ ERROR mismatched types
+        x_i16 > x_u128;
+        //~^ ERROR mismatched types
+        x_i16 > x_usize;
+        //~^ ERROR mismatched types
+
+        x_i32 > x_u8;
+        //~^ ERROR mismatched types
+        x_i32 > x_u16;
+        //~^ ERROR mismatched types
+        x_i32 > x_u32;
+        //~^ ERROR mismatched types
+        x_i32 > x_u64;
+        //~^ ERROR mismatched types
+        x_i32 > x_u128;
+        //~^ ERROR mismatched types
+        x_i32 > x_usize;
+        //~^ ERROR mismatched types
+
+        x_i64 > x_u8;
+        //~^ ERROR mismatched types
+        x_i64 > x_u16;
+        //~^ ERROR mismatched types
+        x_i64 > x_u32;
+        //~^ ERROR mismatched types
+        x_i64 > x_u64;
+        //~^ ERROR mismatched types
+        x_i64 > x_u128;
+        //~^ ERROR mismatched types
+        x_i64 > x_usize;
+        //~^ ERROR mismatched types
+
+        x_i128 > x_u8;
+        //~^ ERROR mismatched types
+        x_i128 > x_u16;
+        //~^ ERROR mismatched types
+        x_i128 > x_u32;
+        //~^ ERROR mismatched types
+        x_i128 > x_u64;
+        //~^ ERROR mismatched types
+        x_i128 > x_u128;
+        //~^ ERROR mismatched types
+        x_i128 > x_usize;
+        //~^ ERROR mismatched types
+
+        x_isize > x_u8;
+        //~^ ERROR mismatched types
+        x_isize > x_u16;
+        //~^ ERROR mismatched types
+        x_isize > x_u32;
+        //~^ ERROR mismatched types
+        x_isize > x_u64;
+        //~^ ERROR mismatched types
+        x_isize > x_u128;
+        //~^ ERROR mismatched types
+        x_isize > x_usize;
+        //~^ ERROR mismatched types
+    }
+}

--- a/src/test/ui/numeric/numeric-cast-binop.stderr
+++ b/src/test/ui/numeric/numeric-cast-binop.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:18:16
+  --> $DIR/numeric-cast-binop.rs:23:16
    |
 LL |         x_u8 > x_u16;
    |                ^^^^^ expected `u8`, found `u16`
@@ -10,7 +10,7 @@ LL |         u16::from(x_u8) > x_u16;
    |         ^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:20:16
+  --> $DIR/numeric-cast-binop.rs:25:16
    |
 LL |         x_u8 > x_u32;
    |                ^^^^^ expected `u8`, found `u32`
@@ -21,7 +21,7 @@ LL |         u32::from(x_u8) > x_u32;
    |         ^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:22:16
+  --> $DIR/numeric-cast-binop.rs:27:16
    |
 LL |         x_u8 > x_u64;
    |                ^^^^^ expected `u8`, found `u64`
@@ -32,7 +32,7 @@ LL |         u64::from(x_u8) > x_u64;
    |         ^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:24:16
+  --> $DIR/numeric-cast-binop.rs:29:16
    |
 LL |         x_u8 > x_u128;
    |                ^^^^^^ expected `u8`, found `u128`
@@ -43,7 +43,7 @@ LL |         u128::from(x_u8) > x_u128;
    |         ^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:26:16
+  --> $DIR/numeric-cast-binop.rs:31:16
    |
 LL |         x_u8 > x_usize;
    |                ^^^^^^^ expected `u8`, found `usize`
@@ -54,7 +54,7 @@ LL |         usize::from(x_u8) > x_usize;
    |         ^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:29:17
+  --> $DIR/numeric-cast-binop.rs:34:17
    |
 LL |         x_u16 > x_u8;
    |                 ^^^^
@@ -63,7 +63,7 @@ LL |         x_u16 > x_u8;
    |                 help: you can convert an `u8` to `u16`: `x_u8.into()`
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:31:17
+  --> $DIR/numeric-cast-binop.rs:36:17
    |
 LL |         x_u16 > x_u32;
    |                 ^^^^^ expected `u16`, found `u32`
@@ -74,7 +74,7 @@ LL |         u32::from(x_u16) > x_u32;
    |         ^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:33:17
+  --> $DIR/numeric-cast-binop.rs:38:17
    |
 LL |         x_u16 > x_u64;
    |                 ^^^^^ expected `u16`, found `u64`
@@ -85,7 +85,7 @@ LL |         u64::from(x_u16) > x_u64;
    |         ^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:35:17
+  --> $DIR/numeric-cast-binop.rs:40:17
    |
 LL |         x_u16 > x_u128;
    |                 ^^^^^^ expected `u16`, found `u128`
@@ -96,7 +96,7 @@ LL |         u128::from(x_u16) > x_u128;
    |         ^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:37:17
+  --> $DIR/numeric-cast-binop.rs:42:17
    |
 LL |         x_u16 > x_usize;
    |                 ^^^^^^^ expected `u16`, found `usize`
@@ -107,7 +107,7 @@ LL |         usize::from(x_u16) > x_usize;
    |         ^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:40:17
+  --> $DIR/numeric-cast-binop.rs:45:17
    |
 LL |         x_u32 > x_u8;
    |                 ^^^^
@@ -116,7 +116,7 @@ LL |         x_u32 > x_u8;
    |                 help: you can convert an `u8` to `u32`: `x_u8.into()`
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:42:17
+  --> $DIR/numeric-cast-binop.rs:47:17
    |
 LL |         x_u32 > x_u16;
    |                 ^^^^^
@@ -125,7 +125,7 @@ LL |         x_u32 > x_u16;
    |                 help: you can convert an `u16` to `u32`: `x_u16.into()`
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:44:17
+  --> $DIR/numeric-cast-binop.rs:49:17
    |
 LL |         x_u32 > x_u64;
    |                 ^^^^^ expected `u32`, found `u64`
@@ -136,7 +136,7 @@ LL |         u64::from(x_u32) > x_u64;
    |         ^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:46:17
+  --> $DIR/numeric-cast-binop.rs:51:17
    |
 LL |         x_u32 > x_u128;
    |                 ^^^^^^ expected `u32`, found `u128`
@@ -147,7 +147,7 @@ LL |         u128::from(x_u32) > x_u128;
    |         ^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:48:17
+  --> $DIR/numeric-cast-binop.rs:53:17
    |
 LL |         x_u32 > x_usize;
    |                 ^^^^^^^ expected `u32`, found `usize`
@@ -158,7 +158,7 @@ LL |         x_u32 > x_usize.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:51:17
+  --> $DIR/numeric-cast-binop.rs:56:17
    |
 LL |         x_u64 > x_u8;
    |                 ^^^^
@@ -167,7 +167,7 @@ LL |         x_u64 > x_u8;
    |                 help: you can convert an `u8` to `u64`: `x_u8.into()`
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:53:17
+  --> $DIR/numeric-cast-binop.rs:58:17
    |
 LL |         x_u64 > x_u16;
    |                 ^^^^^
@@ -176,7 +176,7 @@ LL |         x_u64 > x_u16;
    |                 help: you can convert an `u16` to `u64`: `x_u16.into()`
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:55:17
+  --> $DIR/numeric-cast-binop.rs:60:17
    |
 LL |         x_u64 > x_u32;
    |                 ^^^^^
@@ -185,7 +185,7 @@ LL |         x_u64 > x_u32;
    |                 help: you can convert an `u32` to `u64`: `x_u32.into()`
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:57:17
+  --> $DIR/numeric-cast-binop.rs:62:17
    |
 LL |         x_u64 > x_u128;
    |                 ^^^^^^ expected `u64`, found `u128`
@@ -196,7 +196,7 @@ LL |         u128::from(x_u64) > x_u128;
    |         ^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:59:17
+  --> $DIR/numeric-cast-binop.rs:64:17
    |
 LL |         x_u64 > x_usize;
    |                 ^^^^^^^ expected `u64`, found `usize`
@@ -207,7 +207,7 @@ LL |         x_u64 > x_usize.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:62:18
+  --> $DIR/numeric-cast-binop.rs:67:18
    |
 LL |         x_u128 > x_u8;
    |                  ^^^^
@@ -216,7 +216,7 @@ LL |         x_u128 > x_u8;
    |                  help: you can convert an `u8` to `u128`: `x_u8.into()`
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:64:18
+  --> $DIR/numeric-cast-binop.rs:69:18
    |
 LL |         x_u128 > x_u16;
    |                  ^^^^^
@@ -225,7 +225,7 @@ LL |         x_u128 > x_u16;
    |                  help: you can convert an `u16` to `u128`: `x_u16.into()`
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:66:18
+  --> $DIR/numeric-cast-binop.rs:71:18
    |
 LL |         x_u128 > x_u32;
    |                  ^^^^^
@@ -234,7 +234,7 @@ LL |         x_u128 > x_u32;
    |                  help: you can convert an `u32` to `u128`: `x_u32.into()`
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:68:18
+  --> $DIR/numeric-cast-binop.rs:73:18
    |
 LL |         x_u128 > x_u64;
    |                  ^^^^^
@@ -243,7 +243,7 @@ LL |         x_u128 > x_u64;
    |                  help: you can convert an `u64` to `u128`: `x_u64.into()`
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:70:18
+  --> $DIR/numeric-cast-binop.rs:75:18
    |
 LL |         x_u128 > x_usize;
    |                  ^^^^^^^ expected `u128`, found `usize`
@@ -254,7 +254,7 @@ LL |         x_u128 > x_usize.try_into().unwrap();
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:73:19
+  --> $DIR/numeric-cast-binop.rs:78:19
    |
 LL |         x_usize > x_u8;
    |                   ^^^^
@@ -263,7 +263,7 @@ LL |         x_usize > x_u8;
    |                   help: you can convert an `u8` to `usize`: `x_u8.into()`
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:75:19
+  --> $DIR/numeric-cast-binop.rs:80:19
    |
 LL |         x_usize > x_u16;
    |                   ^^^^^
@@ -272,7 +272,7 @@ LL |         x_usize > x_u16;
    |                   help: you can convert an `u16` to `usize`: `x_u16.into()`
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:77:19
+  --> $DIR/numeric-cast-binop.rs:82:19
    |
 LL |         x_usize > x_u32;
    |                   ^^^^^ expected `usize`, found `u32`
@@ -283,7 +283,7 @@ LL |         x_usize > x_u32.try_into().unwrap();
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:79:19
+  --> $DIR/numeric-cast-binop.rs:84:19
    |
 LL |         x_usize > x_u64;
    |                   ^^^^^ expected `usize`, found `u64`
@@ -294,7 +294,7 @@ LL |         x_usize > x_u64.try_into().unwrap();
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:81:19
+  --> $DIR/numeric-cast-binop.rs:86:19
    |
 LL |         x_usize > x_u128;
    |                   ^^^^^^ expected `usize`, found `u128`
@@ -305,7 +305,7 @@ LL |         x_usize > x_u128.try_into().unwrap();
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:87:16
+  --> $DIR/numeric-cast-binop.rs:92:16
    |
 LL |         x_i8 > x_i16;
    |                ^^^^^ expected `i8`, found `i16`
@@ -316,7 +316,7 @@ LL |         i16::from(x_i8) > x_i16;
    |         ^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:89:16
+  --> $DIR/numeric-cast-binop.rs:94:16
    |
 LL |         x_i8 > x_i32;
    |                ^^^^^ expected `i8`, found `i32`
@@ -327,7 +327,7 @@ LL |         i32::from(x_i8) > x_i32;
    |         ^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:91:16
+  --> $DIR/numeric-cast-binop.rs:96:16
    |
 LL |         x_i8 > x_i64;
    |                ^^^^^ expected `i8`, found `i64`
@@ -338,7 +338,7 @@ LL |         i64::from(x_i8) > x_i64;
    |         ^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:93:16
+  --> $DIR/numeric-cast-binop.rs:98:16
    |
 LL |         x_i8 > x_i128;
    |                ^^^^^^ expected `i8`, found `i128`
@@ -349,7 +349,7 @@ LL |         i128::from(x_i8) > x_i128;
    |         ^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:95:16
+  --> $DIR/numeric-cast-binop.rs:100:16
    |
 LL |         x_i8 > x_isize;
    |                ^^^^^^^ expected `i8`, found `isize`
@@ -360,7 +360,7 @@ LL |         isize::from(x_i8) > x_isize;
    |         ^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:98:17
+  --> $DIR/numeric-cast-binop.rs:103:17
    |
 LL |         x_i16 > x_i8;
    |                 ^^^^
@@ -369,7 +369,7 @@ LL |         x_i16 > x_i8;
    |                 help: you can convert an `i8` to `i16`: `x_i8.into()`
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:100:17
+  --> $DIR/numeric-cast-binop.rs:105:17
    |
 LL |         x_i16 > x_i32;
    |                 ^^^^^ expected `i16`, found `i32`
@@ -380,7 +380,7 @@ LL |         i32::from(x_i16) > x_i32;
    |         ^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:102:17
+  --> $DIR/numeric-cast-binop.rs:107:17
    |
 LL |         x_i16 > x_i64;
    |                 ^^^^^ expected `i16`, found `i64`
@@ -391,7 +391,7 @@ LL |         i64::from(x_i16) > x_i64;
    |         ^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:104:17
+  --> $DIR/numeric-cast-binop.rs:109:17
    |
 LL |         x_i16 > x_i128;
    |                 ^^^^^^ expected `i16`, found `i128`
@@ -402,7 +402,7 @@ LL |         i128::from(x_i16) > x_i128;
    |         ^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:106:17
+  --> $DIR/numeric-cast-binop.rs:111:17
    |
 LL |         x_i16 > x_isize;
    |                 ^^^^^^^ expected `i16`, found `isize`
@@ -413,7 +413,7 @@ LL |         isize::from(x_i16) > x_isize;
    |         ^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:109:17
+  --> $DIR/numeric-cast-binop.rs:114:17
    |
 LL |         x_i32 > x_i8;
    |                 ^^^^
@@ -422,7 +422,7 @@ LL |         x_i32 > x_i8;
    |                 help: you can convert an `i8` to `i32`: `x_i8.into()`
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:111:17
+  --> $DIR/numeric-cast-binop.rs:116:17
    |
 LL |         x_i32 > x_i16;
    |                 ^^^^^
@@ -431,7 +431,7 @@ LL |         x_i32 > x_i16;
    |                 help: you can convert an `i16` to `i32`: `x_i16.into()`
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:113:17
+  --> $DIR/numeric-cast-binop.rs:118:17
    |
 LL |         x_i32 > x_i64;
    |                 ^^^^^ expected `i32`, found `i64`
@@ -442,7 +442,7 @@ LL |         i64::from(x_i32) > x_i64;
    |         ^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:115:17
+  --> $DIR/numeric-cast-binop.rs:120:17
    |
 LL |         x_i32 > x_i128;
    |                 ^^^^^^ expected `i32`, found `i128`
@@ -453,7 +453,7 @@ LL |         i128::from(x_i32) > x_i128;
    |         ^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:117:17
+  --> $DIR/numeric-cast-binop.rs:122:17
    |
 LL |         x_i32 > x_isize;
    |                 ^^^^^^^ expected `i32`, found `isize`
@@ -464,7 +464,7 @@ LL |         x_i32 > x_isize.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:120:17
+  --> $DIR/numeric-cast-binop.rs:125:17
    |
 LL |         x_i64 > x_i8;
    |                 ^^^^
@@ -473,7 +473,7 @@ LL |         x_i64 > x_i8;
    |                 help: you can convert an `i8` to `i64`: `x_i8.into()`
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:122:17
+  --> $DIR/numeric-cast-binop.rs:127:17
    |
 LL |         x_i64 > x_i16;
    |                 ^^^^^
@@ -482,7 +482,7 @@ LL |         x_i64 > x_i16;
    |                 help: you can convert an `i16` to `i64`: `x_i16.into()`
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:124:17
+  --> $DIR/numeric-cast-binop.rs:129:17
    |
 LL |         x_i64 > x_i32;
    |                 ^^^^^
@@ -491,7 +491,7 @@ LL |         x_i64 > x_i32;
    |                 help: you can convert an `i32` to `i64`: `x_i32.into()`
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:126:17
+  --> $DIR/numeric-cast-binop.rs:131:17
    |
 LL |         x_i64 > x_i128;
    |                 ^^^^^^ expected `i64`, found `i128`
@@ -502,7 +502,7 @@ LL |         i128::from(x_i64) > x_i128;
    |         ^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:128:17
+  --> $DIR/numeric-cast-binop.rs:133:17
    |
 LL |         x_i64 > x_isize;
    |                 ^^^^^^^ expected `i64`, found `isize`
@@ -513,7 +513,7 @@ LL |         x_i64 > x_isize.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:131:18
+  --> $DIR/numeric-cast-binop.rs:136:18
    |
 LL |         x_i128 > x_i8;
    |                  ^^^^
@@ -522,7 +522,7 @@ LL |         x_i128 > x_i8;
    |                  help: you can convert an `i8` to `i128`: `x_i8.into()`
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:133:18
+  --> $DIR/numeric-cast-binop.rs:138:18
    |
 LL |         x_i128 > x_i16;
    |                  ^^^^^
@@ -531,7 +531,7 @@ LL |         x_i128 > x_i16;
    |                  help: you can convert an `i16` to `i128`: `x_i16.into()`
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:135:18
+  --> $DIR/numeric-cast-binop.rs:140:18
    |
 LL |         x_i128 > x_i32;
    |                  ^^^^^
@@ -540,7 +540,7 @@ LL |         x_i128 > x_i32;
    |                  help: you can convert an `i32` to `i128`: `x_i32.into()`
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:137:18
+  --> $DIR/numeric-cast-binop.rs:142:18
    |
 LL |         x_i128 > x_i64;
    |                  ^^^^^
@@ -549,7 +549,7 @@ LL |         x_i128 > x_i64;
    |                  help: you can convert an `i64` to `i128`: `x_i64.into()`
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:139:18
+  --> $DIR/numeric-cast-binop.rs:144:18
    |
 LL |         x_i128 > x_isize;
    |                  ^^^^^^^ expected `i128`, found `isize`
@@ -560,7 +560,7 @@ LL |         x_i128 > x_isize.try_into().unwrap();
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:142:19
+  --> $DIR/numeric-cast-binop.rs:147:19
    |
 LL |         x_isize > x_i8;
    |                   ^^^^
@@ -569,7 +569,7 @@ LL |         x_isize > x_i8;
    |                   help: you can convert an `i8` to `isize`: `x_i8.into()`
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:144:19
+  --> $DIR/numeric-cast-binop.rs:149:19
    |
 LL |         x_isize > x_i16;
    |                   ^^^^^
@@ -578,7 +578,7 @@ LL |         x_isize > x_i16;
    |                   help: you can convert an `i16` to `isize`: `x_i16.into()`
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:146:19
+  --> $DIR/numeric-cast-binop.rs:151:19
    |
 LL |         x_isize > x_i32;
    |                   ^^^^^ expected `isize`, found `i32`
@@ -589,7 +589,7 @@ LL |         x_isize > x_i32.try_into().unwrap();
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:148:19
+  --> $DIR/numeric-cast-binop.rs:153:19
    |
 LL |         x_isize > x_i64;
    |                   ^^^^^ expected `isize`, found `i64`
@@ -600,7 +600,7 @@ LL |         x_isize > x_i64.try_into().unwrap();
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:150:19
+  --> $DIR/numeric-cast-binop.rs:155:19
    |
 LL |         x_isize > x_i128;
    |                   ^^^^^^ expected `isize`, found `i128`
@@ -611,7 +611,7 @@ LL |         x_isize > x_i128.try_into().unwrap();
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:156:16
+  --> $DIR/numeric-cast-binop.rs:161:16
    |
 LL |         x_u8 > x_i8;
    |                ^^^^ expected `u8`, found `i8`
@@ -622,7 +622,7 @@ LL |         x_u8 > x_i8.try_into().unwrap();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:158:16
+  --> $DIR/numeric-cast-binop.rs:163:16
    |
 LL |         x_u8 > x_i16;
    |                ^^^^^ expected `u8`, found `i16`
@@ -633,7 +633,7 @@ LL |         i16::from(x_u8) > x_i16;
    |         ^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:160:16
+  --> $DIR/numeric-cast-binop.rs:165:16
    |
 LL |         x_u8 > x_i32;
    |                ^^^^^ expected `u8`, found `i32`
@@ -644,7 +644,7 @@ LL |         i32::from(x_u8) > x_i32;
    |         ^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:162:16
+  --> $DIR/numeric-cast-binop.rs:167:16
    |
 LL |         x_u8 > x_i64;
    |                ^^^^^ expected `u8`, found `i64`
@@ -655,7 +655,7 @@ LL |         i64::from(x_u8) > x_i64;
    |         ^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:164:16
+  --> $DIR/numeric-cast-binop.rs:169:16
    |
 LL |         x_u8 > x_i128;
    |                ^^^^^^ expected `u8`, found `i128`
@@ -666,7 +666,7 @@ LL |         i128::from(x_u8) > x_i128;
    |         ^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:166:16
+  --> $DIR/numeric-cast-binop.rs:171:16
    |
 LL |         x_u8 > x_isize;
    |                ^^^^^^^ expected `u8`, found `isize`
@@ -677,7 +677,7 @@ LL |         isize::from(x_u8) > x_isize;
    |         ^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:169:17
+  --> $DIR/numeric-cast-binop.rs:174:17
    |
 LL |         x_u16 > x_i8;
    |                 ^^^^ expected `u16`, found `i8`
@@ -688,7 +688,7 @@ LL |         x_u16 > x_i8.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:171:17
+  --> $DIR/numeric-cast-binop.rs:176:17
    |
 LL |         x_u16 > x_i16;
    |                 ^^^^^ expected `u16`, found `i16`
@@ -699,7 +699,7 @@ LL |         x_u16 > x_i16.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:173:17
+  --> $DIR/numeric-cast-binop.rs:178:17
    |
 LL |         x_u16 > x_i32;
    |                 ^^^^^ expected `u16`, found `i32`
@@ -710,7 +710,7 @@ LL |         i32::from(x_u16) > x_i32;
    |         ^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:175:17
+  --> $DIR/numeric-cast-binop.rs:180:17
    |
 LL |         x_u16 > x_i64;
    |                 ^^^^^ expected `u16`, found `i64`
@@ -721,7 +721,7 @@ LL |         i64::from(x_u16) > x_i64;
    |         ^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:177:17
+  --> $DIR/numeric-cast-binop.rs:182:17
    |
 LL |         x_u16 > x_i128;
    |                 ^^^^^^ expected `u16`, found `i128`
@@ -732,7 +732,7 @@ LL |         i128::from(x_u16) > x_i128;
    |         ^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:179:17
+  --> $DIR/numeric-cast-binop.rs:184:17
    |
 LL |         x_u16 > x_isize;
    |                 ^^^^^^^ expected `u16`, found `isize`
@@ -743,7 +743,7 @@ LL |         x_u16 > x_isize.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:182:17
+  --> $DIR/numeric-cast-binop.rs:187:17
    |
 LL |         x_u32 > x_i8;
    |                 ^^^^ expected `u32`, found `i8`
@@ -754,7 +754,7 @@ LL |         x_u32 > x_i8.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:184:17
+  --> $DIR/numeric-cast-binop.rs:189:17
    |
 LL |         x_u32 > x_i16;
    |                 ^^^^^ expected `u32`, found `i16`
@@ -765,7 +765,7 @@ LL |         x_u32 > x_i16.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:186:17
+  --> $DIR/numeric-cast-binop.rs:191:17
    |
 LL |         x_u32 > x_i32;
    |                 ^^^^^ expected `u32`, found `i32`
@@ -776,7 +776,7 @@ LL |         x_u32 > x_i32.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:188:17
+  --> $DIR/numeric-cast-binop.rs:193:17
    |
 LL |         x_u32 > x_i64;
    |                 ^^^^^ expected `u32`, found `i64`
@@ -787,7 +787,7 @@ LL |         i64::from(x_u32) > x_i64;
    |         ^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:190:17
+  --> $DIR/numeric-cast-binop.rs:195:17
    |
 LL |         x_u32 > x_i128;
    |                 ^^^^^^ expected `u32`, found `i128`
@@ -798,7 +798,7 @@ LL |         i128::from(x_u32) > x_i128;
    |         ^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:192:17
+  --> $DIR/numeric-cast-binop.rs:197:17
    |
 LL |         x_u32 > x_isize;
    |                 ^^^^^^^ expected `u32`, found `isize`
@@ -809,7 +809,7 @@ LL |         x_u32 > x_isize.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:195:17
+  --> $DIR/numeric-cast-binop.rs:200:17
    |
 LL |         x_u64 > x_i8;
    |                 ^^^^ expected `u64`, found `i8`
@@ -820,7 +820,7 @@ LL |         x_u64 > x_i8.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:197:17
+  --> $DIR/numeric-cast-binop.rs:202:17
    |
 LL |         x_u64 > x_i16;
    |                 ^^^^^ expected `u64`, found `i16`
@@ -831,7 +831,7 @@ LL |         x_u64 > x_i16.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:199:17
+  --> $DIR/numeric-cast-binop.rs:204:17
    |
 LL |         x_u64 > x_i32;
    |                 ^^^^^ expected `u64`, found `i32`
@@ -842,7 +842,7 @@ LL |         x_u64 > x_i32.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:201:17
+  --> $DIR/numeric-cast-binop.rs:206:17
    |
 LL |         x_u64 > x_i64;
    |                 ^^^^^ expected `u64`, found `i64`
@@ -853,7 +853,7 @@ LL |         x_u64 > x_i64.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:203:17
+  --> $DIR/numeric-cast-binop.rs:208:17
    |
 LL |         x_u64 > x_i128;
    |                 ^^^^^^ expected `u64`, found `i128`
@@ -864,7 +864,7 @@ LL |         i128::from(x_u64) > x_i128;
    |         ^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:205:17
+  --> $DIR/numeric-cast-binop.rs:210:17
    |
 LL |         x_u64 > x_isize;
    |                 ^^^^^^^ expected `u64`, found `isize`
@@ -875,7 +875,7 @@ LL |         x_u64 > x_isize.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:208:18
+  --> $DIR/numeric-cast-binop.rs:213:18
    |
 LL |         x_u128 > x_i8;
    |                  ^^^^ expected `u128`, found `i8`
@@ -886,7 +886,7 @@ LL |         x_u128 > x_i8.try_into().unwrap();
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:210:18
+  --> $DIR/numeric-cast-binop.rs:215:18
    |
 LL |         x_u128 > x_i16;
    |                  ^^^^^ expected `u128`, found `i16`
@@ -897,7 +897,7 @@ LL |         x_u128 > x_i16.try_into().unwrap();
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:212:18
+  --> $DIR/numeric-cast-binop.rs:217:18
    |
 LL |         x_u128 > x_i32;
    |                  ^^^^^ expected `u128`, found `i32`
@@ -908,7 +908,7 @@ LL |         x_u128 > x_i32.try_into().unwrap();
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:214:18
+  --> $DIR/numeric-cast-binop.rs:219:18
    |
 LL |         x_u128 > x_i64;
    |                  ^^^^^ expected `u128`, found `i64`
@@ -919,7 +919,7 @@ LL |         x_u128 > x_i64.try_into().unwrap();
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:216:18
+  --> $DIR/numeric-cast-binop.rs:221:18
    |
 LL |         x_u128 > x_i128;
    |                  ^^^^^^ expected `u128`, found `i128`
@@ -930,7 +930,7 @@ LL |         x_u128 > x_i128.try_into().unwrap();
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:218:18
+  --> $DIR/numeric-cast-binop.rs:223:18
    |
 LL |         x_u128 > x_isize;
    |                  ^^^^^^^ expected `u128`, found `isize`
@@ -941,7 +941,7 @@ LL |         x_u128 > x_isize.try_into().unwrap();
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:221:19
+  --> $DIR/numeric-cast-binop.rs:226:19
    |
 LL |         x_usize > x_i8;
    |                   ^^^^ expected `usize`, found `i8`
@@ -952,7 +952,7 @@ LL |         x_usize > x_i8.try_into().unwrap();
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:223:19
+  --> $DIR/numeric-cast-binop.rs:228:19
    |
 LL |         x_usize > x_i16;
    |                   ^^^^^ expected `usize`, found `i16`
@@ -963,7 +963,7 @@ LL |         x_usize > x_i16.try_into().unwrap();
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:225:19
+  --> $DIR/numeric-cast-binop.rs:230:19
    |
 LL |         x_usize > x_i32;
    |                   ^^^^^ expected `usize`, found `i32`
@@ -974,7 +974,7 @@ LL |         x_usize > x_i32.try_into().unwrap();
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:227:19
+  --> $DIR/numeric-cast-binop.rs:232:19
    |
 LL |         x_usize > x_i64;
    |                   ^^^^^ expected `usize`, found `i64`
@@ -985,7 +985,7 @@ LL |         x_usize > x_i64.try_into().unwrap();
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:229:19
+  --> $DIR/numeric-cast-binop.rs:234:19
    |
 LL |         x_usize > x_i128;
    |                   ^^^^^^ expected `usize`, found `i128`
@@ -996,7 +996,7 @@ LL |         x_usize > x_i128.try_into().unwrap();
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:231:19
+  --> $DIR/numeric-cast-binop.rs:236:19
    |
 LL |         x_usize > x_isize;
    |                   ^^^^^^^ expected `usize`, found `isize`
@@ -1007,7 +1007,7 @@ LL |         x_usize > x_isize.try_into().unwrap();
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:237:16
+  --> $DIR/numeric-cast-binop.rs:242:16
    |
 LL |         x_i8 > x_u8;
    |                ^^^^ expected `i8`, found `u8`
@@ -1018,7 +1018,7 @@ LL |         x_i8 > x_u8.try_into().unwrap();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:239:16
+  --> $DIR/numeric-cast-binop.rs:244:16
    |
 LL |         x_i8 > x_u16;
    |                ^^^^^ expected `i8`, found `u16`
@@ -1029,7 +1029,7 @@ LL |         x_i8 > x_u16.try_into().unwrap();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:241:16
+  --> $DIR/numeric-cast-binop.rs:246:16
    |
 LL |         x_i8 > x_u32;
    |                ^^^^^ expected `i8`, found `u32`
@@ -1040,7 +1040,7 @@ LL |         x_i8 > x_u32.try_into().unwrap();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:243:16
+  --> $DIR/numeric-cast-binop.rs:248:16
    |
 LL |         x_i8 > x_u64;
    |                ^^^^^ expected `i8`, found `u64`
@@ -1051,7 +1051,7 @@ LL |         x_i8 > x_u64.try_into().unwrap();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:245:16
+  --> $DIR/numeric-cast-binop.rs:250:16
    |
 LL |         x_i8 > x_u128;
    |                ^^^^^^ expected `i8`, found `u128`
@@ -1062,7 +1062,7 @@ LL |         x_i8 > x_u128.try_into().unwrap();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:247:16
+  --> $DIR/numeric-cast-binop.rs:252:16
    |
 LL |         x_i8 > x_usize;
    |                ^^^^^^^ expected `i8`, found `usize`
@@ -1073,7 +1073,7 @@ LL |         x_i8 > x_usize.try_into().unwrap();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:250:17
+  --> $DIR/numeric-cast-binop.rs:255:17
    |
 LL |         x_i16 > x_u8;
    |                 ^^^^
@@ -1082,7 +1082,7 @@ LL |         x_i16 > x_u8;
    |                 help: you can convert an `u8` to `i16`: `x_u8.into()`
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:252:17
+  --> $DIR/numeric-cast-binop.rs:257:17
    |
 LL |         x_i16 > x_u16;
    |                 ^^^^^ expected `i16`, found `u16`
@@ -1093,7 +1093,7 @@ LL |         x_i16 > x_u16.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:254:17
+  --> $DIR/numeric-cast-binop.rs:259:17
    |
 LL |         x_i16 > x_u32;
    |                 ^^^^^ expected `i16`, found `u32`
@@ -1104,7 +1104,7 @@ LL |         x_i16 > x_u32.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:256:17
+  --> $DIR/numeric-cast-binop.rs:261:17
    |
 LL |         x_i16 > x_u64;
    |                 ^^^^^ expected `i16`, found `u64`
@@ -1115,7 +1115,7 @@ LL |         x_i16 > x_u64.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:258:17
+  --> $DIR/numeric-cast-binop.rs:263:17
    |
 LL |         x_i16 > x_u128;
    |                 ^^^^^^ expected `i16`, found `u128`
@@ -1126,7 +1126,7 @@ LL |         x_i16 > x_u128.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:260:17
+  --> $DIR/numeric-cast-binop.rs:265:17
    |
 LL |         x_i16 > x_usize;
    |                 ^^^^^^^ expected `i16`, found `usize`
@@ -1137,7 +1137,7 @@ LL |         x_i16 > x_usize.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:263:17
+  --> $DIR/numeric-cast-binop.rs:268:17
    |
 LL |         x_i32 > x_u8;
    |                 ^^^^
@@ -1146,7 +1146,7 @@ LL |         x_i32 > x_u8;
    |                 help: you can convert an `u8` to `i32`: `x_u8.into()`
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:265:17
+  --> $DIR/numeric-cast-binop.rs:270:17
    |
 LL |         x_i32 > x_u16;
    |                 ^^^^^
@@ -1155,7 +1155,7 @@ LL |         x_i32 > x_u16;
    |                 help: you can convert an `u16` to `i32`: `x_u16.into()`
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:267:17
+  --> $DIR/numeric-cast-binop.rs:272:17
    |
 LL |         x_i32 > x_u32;
    |                 ^^^^^ expected `i32`, found `u32`
@@ -1166,7 +1166,7 @@ LL |         x_i32 > x_u32.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:269:17
+  --> $DIR/numeric-cast-binop.rs:274:17
    |
 LL |         x_i32 > x_u64;
    |                 ^^^^^ expected `i32`, found `u64`
@@ -1177,7 +1177,7 @@ LL |         x_i32 > x_u64.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:271:17
+  --> $DIR/numeric-cast-binop.rs:276:17
    |
 LL |         x_i32 > x_u128;
    |                 ^^^^^^ expected `i32`, found `u128`
@@ -1188,7 +1188,7 @@ LL |         x_i32 > x_u128.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:273:17
+  --> $DIR/numeric-cast-binop.rs:278:17
    |
 LL |         x_i32 > x_usize;
    |                 ^^^^^^^ expected `i32`, found `usize`
@@ -1199,7 +1199,7 @@ LL |         x_i32 > x_usize.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:276:17
+  --> $DIR/numeric-cast-binop.rs:281:17
    |
 LL |         x_i64 > x_u8;
    |                 ^^^^
@@ -1208,7 +1208,7 @@ LL |         x_i64 > x_u8;
    |                 help: you can convert an `u8` to `i64`: `x_u8.into()`
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:278:17
+  --> $DIR/numeric-cast-binop.rs:283:17
    |
 LL |         x_i64 > x_u16;
    |                 ^^^^^
@@ -1217,7 +1217,7 @@ LL |         x_i64 > x_u16;
    |                 help: you can convert an `u16` to `i64`: `x_u16.into()`
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:280:17
+  --> $DIR/numeric-cast-binop.rs:285:17
    |
 LL |         x_i64 > x_u32;
    |                 ^^^^^
@@ -1226,7 +1226,7 @@ LL |         x_i64 > x_u32;
    |                 help: you can convert an `u32` to `i64`: `x_u32.into()`
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:282:17
+  --> $DIR/numeric-cast-binop.rs:287:17
    |
 LL |         x_i64 > x_u64;
    |                 ^^^^^ expected `i64`, found `u64`
@@ -1237,7 +1237,7 @@ LL |         x_i64 > x_u64.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:284:17
+  --> $DIR/numeric-cast-binop.rs:289:17
    |
 LL |         x_i64 > x_u128;
    |                 ^^^^^^ expected `i64`, found `u128`
@@ -1248,7 +1248,7 @@ LL |         x_i64 > x_u128.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:286:17
+  --> $DIR/numeric-cast-binop.rs:291:17
    |
 LL |         x_i64 > x_usize;
    |                 ^^^^^^^ expected `i64`, found `usize`
@@ -1259,7 +1259,7 @@ LL |         x_i64 > x_usize.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:289:18
+  --> $DIR/numeric-cast-binop.rs:294:18
    |
 LL |         x_i128 > x_u8;
    |                  ^^^^
@@ -1268,7 +1268,7 @@ LL |         x_i128 > x_u8;
    |                  help: you can convert an `u8` to `i128`: `x_u8.into()`
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:291:18
+  --> $DIR/numeric-cast-binop.rs:296:18
    |
 LL |         x_i128 > x_u16;
    |                  ^^^^^
@@ -1277,7 +1277,7 @@ LL |         x_i128 > x_u16;
    |                  help: you can convert an `u16` to `i128`: `x_u16.into()`
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:293:18
+  --> $DIR/numeric-cast-binop.rs:298:18
    |
 LL |         x_i128 > x_u32;
    |                  ^^^^^
@@ -1286,7 +1286,7 @@ LL |         x_i128 > x_u32;
    |                  help: you can convert an `u32` to `i128`: `x_u32.into()`
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:295:18
+  --> $DIR/numeric-cast-binop.rs:300:18
    |
 LL |         x_i128 > x_u64;
    |                  ^^^^^
@@ -1295,7 +1295,7 @@ LL |         x_i128 > x_u64;
    |                  help: you can convert an `u64` to `i128`: `x_u64.into()`
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:297:18
+  --> $DIR/numeric-cast-binop.rs:302:18
    |
 LL |         x_i128 > x_u128;
    |                  ^^^^^^ expected `i128`, found `u128`
@@ -1306,7 +1306,7 @@ LL |         x_i128 > x_u128.try_into().unwrap();
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:299:18
+  --> $DIR/numeric-cast-binop.rs:304:18
    |
 LL |         x_i128 > x_usize;
    |                  ^^^^^^^ expected `i128`, found `usize`
@@ -1317,7 +1317,7 @@ LL |         x_i128 > x_usize.try_into().unwrap();
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:302:19
+  --> $DIR/numeric-cast-binop.rs:307:19
    |
 LL |         x_isize > x_u8;
    |                   ^^^^
@@ -1326,7 +1326,7 @@ LL |         x_isize > x_u8;
    |                   help: you can convert an `u8` to `isize`: `x_u8.into()`
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:304:19
+  --> $DIR/numeric-cast-binop.rs:309:19
    |
 LL |         x_isize > x_u16;
    |                   ^^^^^ expected `isize`, found `u16`
@@ -1337,7 +1337,7 @@ LL |         x_isize > x_u16.try_into().unwrap();
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:306:19
+  --> $DIR/numeric-cast-binop.rs:311:19
    |
 LL |         x_isize > x_u32;
    |                   ^^^^^ expected `isize`, found `u32`
@@ -1348,7 +1348,7 @@ LL |         x_isize > x_u32.try_into().unwrap();
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:308:19
+  --> $DIR/numeric-cast-binop.rs:313:19
    |
 LL |         x_isize > x_u64;
    |                   ^^^^^ expected `isize`, found `u64`
@@ -1359,7 +1359,7 @@ LL |         x_isize > x_u64.try_into().unwrap();
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:310:19
+  --> $DIR/numeric-cast-binop.rs:315:19
    |
 LL |         x_isize > x_u128;
    |                   ^^^^^^ expected `isize`, found `u128`
@@ -1370,7 +1370,7 @@ LL |         x_isize > x_u128.try_into().unwrap();
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/numeric-cast-binop.rs:312:19
+  --> $DIR/numeric-cast-binop.rs:317:19
    |
 LL |         x_isize > x_usize;
    |                   ^^^^^^^ expected `isize`, found `usize`

--- a/src/test/ui/numeric/numeric-cast-binop.stderr
+++ b/src/test/ui/numeric/numeric-cast-binop.stderr
@@ -1,0 +1,1385 @@
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:18:16
+   |
+LL |         x_u8 > x_u16;
+   |                ^^^^^ expected `u8`, found `u16`
+   |
+help: you can convert `x_u8` from `u8` to `u16`, matching the type of `x_u16`
+   |
+LL |         u16::from(x_u8) > x_u16;
+   |         ^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:20:16
+   |
+LL |         x_u8 > x_u32;
+   |                ^^^^^ expected `u8`, found `u32`
+   |
+help: you can convert `x_u8` from `u8` to `u32`, matching the type of `x_u32`
+   |
+LL |         u32::from(x_u8) > x_u32;
+   |         ^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:22:16
+   |
+LL |         x_u8 > x_u64;
+   |                ^^^^^ expected `u8`, found `u64`
+   |
+help: you can convert `x_u8` from `u8` to `u64`, matching the type of `x_u64`
+   |
+LL |         u64::from(x_u8) > x_u64;
+   |         ^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:24:16
+   |
+LL |         x_u8 > x_u128;
+   |                ^^^^^^ expected `u8`, found `u128`
+   |
+help: you can convert `x_u8` from `u8` to `u128`, matching the type of `x_u128`
+   |
+LL |         u128::from(x_u8) > x_u128;
+   |         ^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:26:16
+   |
+LL |         x_u8 > x_usize;
+   |                ^^^^^^^ expected `u8`, found `usize`
+   |
+help: you can convert `x_u8` from `u8` to `usize`, matching the type of `x_usize`
+   |
+LL |         usize::from(x_u8) > x_usize;
+   |         ^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:29:17
+   |
+LL |         x_u16 > x_u8;
+   |                 ^^^^
+   |                 |
+   |                 expected `u16`, found `u8`
+   |                 help: you can convert an `u8` to `u16`: `x_u8.into()`
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:31:17
+   |
+LL |         x_u16 > x_u32;
+   |                 ^^^^^ expected `u16`, found `u32`
+   |
+help: you can convert `x_u16` from `u16` to `u32`, matching the type of `x_u32`
+   |
+LL |         u32::from(x_u16) > x_u32;
+   |         ^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:33:17
+   |
+LL |         x_u16 > x_u64;
+   |                 ^^^^^ expected `u16`, found `u64`
+   |
+help: you can convert `x_u16` from `u16` to `u64`, matching the type of `x_u64`
+   |
+LL |         u64::from(x_u16) > x_u64;
+   |         ^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:35:17
+   |
+LL |         x_u16 > x_u128;
+   |                 ^^^^^^ expected `u16`, found `u128`
+   |
+help: you can convert `x_u16` from `u16` to `u128`, matching the type of `x_u128`
+   |
+LL |         u128::from(x_u16) > x_u128;
+   |         ^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:37:17
+   |
+LL |         x_u16 > x_usize;
+   |                 ^^^^^^^ expected `u16`, found `usize`
+   |
+help: you can convert `x_u16` from `u16` to `usize`, matching the type of `x_usize`
+   |
+LL |         usize::from(x_u16) > x_usize;
+   |         ^^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:40:17
+   |
+LL |         x_u32 > x_u8;
+   |                 ^^^^
+   |                 |
+   |                 expected `u32`, found `u8`
+   |                 help: you can convert an `u8` to `u32`: `x_u8.into()`
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:42:17
+   |
+LL |         x_u32 > x_u16;
+   |                 ^^^^^
+   |                 |
+   |                 expected `u32`, found `u16`
+   |                 help: you can convert an `u16` to `u32`: `x_u16.into()`
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:44:17
+   |
+LL |         x_u32 > x_u64;
+   |                 ^^^^^ expected `u32`, found `u64`
+   |
+help: you can convert `x_u32` from `u32` to `u64`, matching the type of `x_u64`
+   |
+LL |         u64::from(x_u32) > x_u64;
+   |         ^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:46:17
+   |
+LL |         x_u32 > x_u128;
+   |                 ^^^^^^ expected `u32`, found `u128`
+   |
+help: you can convert `x_u32` from `u32` to `u128`, matching the type of `x_u128`
+   |
+LL |         u128::from(x_u32) > x_u128;
+   |         ^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:48:17
+   |
+LL |         x_u32 > x_usize;
+   |                 ^^^^^^^ expected `u32`, found `usize`
+   |
+help: you can convert an `usize` to `u32` and panic if the converted value wouldn't fit
+   |
+LL |         x_u32 > x_usize.try_into().unwrap();
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:51:17
+   |
+LL |         x_u64 > x_u8;
+   |                 ^^^^
+   |                 |
+   |                 expected `u64`, found `u8`
+   |                 help: you can convert an `u8` to `u64`: `x_u8.into()`
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:53:17
+   |
+LL |         x_u64 > x_u16;
+   |                 ^^^^^
+   |                 |
+   |                 expected `u64`, found `u16`
+   |                 help: you can convert an `u16` to `u64`: `x_u16.into()`
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:55:17
+   |
+LL |         x_u64 > x_u32;
+   |                 ^^^^^
+   |                 |
+   |                 expected `u64`, found `u32`
+   |                 help: you can convert an `u32` to `u64`: `x_u32.into()`
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:57:17
+   |
+LL |         x_u64 > x_u128;
+   |                 ^^^^^^ expected `u64`, found `u128`
+   |
+help: you can convert `x_u64` from `u64` to `u128`, matching the type of `x_u128`
+   |
+LL |         u128::from(x_u64) > x_u128;
+   |         ^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:59:17
+   |
+LL |         x_u64 > x_usize;
+   |                 ^^^^^^^ expected `u64`, found `usize`
+   |
+help: you can convert an `usize` to `u64` and panic if the converted value wouldn't fit
+   |
+LL |         x_u64 > x_usize.try_into().unwrap();
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:62:18
+   |
+LL |         x_u128 > x_u8;
+   |                  ^^^^
+   |                  |
+   |                  expected `u128`, found `u8`
+   |                  help: you can convert an `u8` to `u128`: `x_u8.into()`
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:64:18
+   |
+LL |         x_u128 > x_u16;
+   |                  ^^^^^
+   |                  |
+   |                  expected `u128`, found `u16`
+   |                  help: you can convert an `u16` to `u128`: `x_u16.into()`
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:66:18
+   |
+LL |         x_u128 > x_u32;
+   |                  ^^^^^
+   |                  |
+   |                  expected `u128`, found `u32`
+   |                  help: you can convert an `u32` to `u128`: `x_u32.into()`
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:68:18
+   |
+LL |         x_u128 > x_u64;
+   |                  ^^^^^
+   |                  |
+   |                  expected `u128`, found `u64`
+   |                  help: you can convert an `u64` to `u128`: `x_u64.into()`
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:70:18
+   |
+LL |         x_u128 > x_usize;
+   |                  ^^^^^^^ expected `u128`, found `usize`
+   |
+help: you can convert an `usize` to `u128` and panic if the converted value wouldn't fit
+   |
+LL |         x_u128 > x_usize.try_into().unwrap();
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:73:19
+   |
+LL |         x_usize > x_u8;
+   |                   ^^^^
+   |                   |
+   |                   expected `usize`, found `u8`
+   |                   help: you can convert an `u8` to `usize`: `x_u8.into()`
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:75:19
+   |
+LL |         x_usize > x_u16;
+   |                   ^^^^^
+   |                   |
+   |                   expected `usize`, found `u16`
+   |                   help: you can convert an `u16` to `usize`: `x_u16.into()`
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:77:19
+   |
+LL |         x_usize > x_u32;
+   |                   ^^^^^ expected `usize`, found `u32`
+   |
+help: you can convert an `u32` to `usize` and panic if the converted value wouldn't fit
+   |
+LL |         x_usize > x_u32.try_into().unwrap();
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:79:19
+   |
+LL |         x_usize > x_u64;
+   |                   ^^^^^ expected `usize`, found `u64`
+   |
+help: you can convert an `u64` to `usize` and panic if the converted value wouldn't fit
+   |
+LL |         x_usize > x_u64.try_into().unwrap();
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:81:19
+   |
+LL |         x_usize > x_u128;
+   |                   ^^^^^^ expected `usize`, found `u128`
+   |
+help: you can convert an `u128` to `usize` and panic if the converted value wouldn't fit
+   |
+LL |         x_usize > x_u128.try_into().unwrap();
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:87:16
+   |
+LL |         x_i8 > x_i16;
+   |                ^^^^^ expected `i8`, found `i16`
+   |
+help: you can convert `x_i8` from `i8` to `i16`, matching the type of `x_i16`
+   |
+LL |         i16::from(x_i8) > x_i16;
+   |         ^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:89:16
+   |
+LL |         x_i8 > x_i32;
+   |                ^^^^^ expected `i8`, found `i32`
+   |
+help: you can convert `x_i8` from `i8` to `i32`, matching the type of `x_i32`
+   |
+LL |         i32::from(x_i8) > x_i32;
+   |         ^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:91:16
+   |
+LL |         x_i8 > x_i64;
+   |                ^^^^^ expected `i8`, found `i64`
+   |
+help: you can convert `x_i8` from `i8` to `i64`, matching the type of `x_i64`
+   |
+LL |         i64::from(x_i8) > x_i64;
+   |         ^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:93:16
+   |
+LL |         x_i8 > x_i128;
+   |                ^^^^^^ expected `i8`, found `i128`
+   |
+help: you can convert `x_i8` from `i8` to `i128`, matching the type of `x_i128`
+   |
+LL |         i128::from(x_i8) > x_i128;
+   |         ^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:95:16
+   |
+LL |         x_i8 > x_isize;
+   |                ^^^^^^^ expected `i8`, found `isize`
+   |
+help: you can convert `x_i8` from `i8` to `isize`, matching the type of `x_isize`
+   |
+LL |         isize::from(x_i8) > x_isize;
+   |         ^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:98:17
+   |
+LL |         x_i16 > x_i8;
+   |                 ^^^^
+   |                 |
+   |                 expected `i16`, found `i8`
+   |                 help: you can convert an `i8` to `i16`: `x_i8.into()`
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:100:17
+   |
+LL |         x_i16 > x_i32;
+   |                 ^^^^^ expected `i16`, found `i32`
+   |
+help: you can convert `x_i16` from `i16` to `i32`, matching the type of `x_i32`
+   |
+LL |         i32::from(x_i16) > x_i32;
+   |         ^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:102:17
+   |
+LL |         x_i16 > x_i64;
+   |                 ^^^^^ expected `i16`, found `i64`
+   |
+help: you can convert `x_i16` from `i16` to `i64`, matching the type of `x_i64`
+   |
+LL |         i64::from(x_i16) > x_i64;
+   |         ^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:104:17
+   |
+LL |         x_i16 > x_i128;
+   |                 ^^^^^^ expected `i16`, found `i128`
+   |
+help: you can convert `x_i16` from `i16` to `i128`, matching the type of `x_i128`
+   |
+LL |         i128::from(x_i16) > x_i128;
+   |         ^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:106:17
+   |
+LL |         x_i16 > x_isize;
+   |                 ^^^^^^^ expected `i16`, found `isize`
+   |
+help: you can convert `x_i16` from `i16` to `isize`, matching the type of `x_isize`
+   |
+LL |         isize::from(x_i16) > x_isize;
+   |         ^^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:109:17
+   |
+LL |         x_i32 > x_i8;
+   |                 ^^^^
+   |                 |
+   |                 expected `i32`, found `i8`
+   |                 help: you can convert an `i8` to `i32`: `x_i8.into()`
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:111:17
+   |
+LL |         x_i32 > x_i16;
+   |                 ^^^^^
+   |                 |
+   |                 expected `i32`, found `i16`
+   |                 help: you can convert an `i16` to `i32`: `x_i16.into()`
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:113:17
+   |
+LL |         x_i32 > x_i64;
+   |                 ^^^^^ expected `i32`, found `i64`
+   |
+help: you can convert `x_i32` from `i32` to `i64`, matching the type of `x_i64`
+   |
+LL |         i64::from(x_i32) > x_i64;
+   |         ^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:115:17
+   |
+LL |         x_i32 > x_i128;
+   |                 ^^^^^^ expected `i32`, found `i128`
+   |
+help: you can convert `x_i32` from `i32` to `i128`, matching the type of `x_i128`
+   |
+LL |         i128::from(x_i32) > x_i128;
+   |         ^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:117:17
+   |
+LL |         x_i32 > x_isize;
+   |                 ^^^^^^^ expected `i32`, found `isize`
+   |
+help: you can convert an `isize` to `i32` and panic if the converted value wouldn't fit
+   |
+LL |         x_i32 > x_isize.try_into().unwrap();
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:120:17
+   |
+LL |         x_i64 > x_i8;
+   |                 ^^^^
+   |                 |
+   |                 expected `i64`, found `i8`
+   |                 help: you can convert an `i8` to `i64`: `x_i8.into()`
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:122:17
+   |
+LL |         x_i64 > x_i16;
+   |                 ^^^^^
+   |                 |
+   |                 expected `i64`, found `i16`
+   |                 help: you can convert an `i16` to `i64`: `x_i16.into()`
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:124:17
+   |
+LL |         x_i64 > x_i32;
+   |                 ^^^^^
+   |                 |
+   |                 expected `i64`, found `i32`
+   |                 help: you can convert an `i32` to `i64`: `x_i32.into()`
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:126:17
+   |
+LL |         x_i64 > x_i128;
+   |                 ^^^^^^ expected `i64`, found `i128`
+   |
+help: you can convert `x_i64` from `i64` to `i128`, matching the type of `x_i128`
+   |
+LL |         i128::from(x_i64) > x_i128;
+   |         ^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:128:17
+   |
+LL |         x_i64 > x_isize;
+   |                 ^^^^^^^ expected `i64`, found `isize`
+   |
+help: you can convert an `isize` to `i64` and panic if the converted value wouldn't fit
+   |
+LL |         x_i64 > x_isize.try_into().unwrap();
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:131:18
+   |
+LL |         x_i128 > x_i8;
+   |                  ^^^^
+   |                  |
+   |                  expected `i128`, found `i8`
+   |                  help: you can convert an `i8` to `i128`: `x_i8.into()`
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:133:18
+   |
+LL |         x_i128 > x_i16;
+   |                  ^^^^^
+   |                  |
+   |                  expected `i128`, found `i16`
+   |                  help: you can convert an `i16` to `i128`: `x_i16.into()`
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:135:18
+   |
+LL |         x_i128 > x_i32;
+   |                  ^^^^^
+   |                  |
+   |                  expected `i128`, found `i32`
+   |                  help: you can convert an `i32` to `i128`: `x_i32.into()`
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:137:18
+   |
+LL |         x_i128 > x_i64;
+   |                  ^^^^^
+   |                  |
+   |                  expected `i128`, found `i64`
+   |                  help: you can convert an `i64` to `i128`: `x_i64.into()`
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:139:18
+   |
+LL |         x_i128 > x_isize;
+   |                  ^^^^^^^ expected `i128`, found `isize`
+   |
+help: you can convert an `isize` to `i128` and panic if the converted value wouldn't fit
+   |
+LL |         x_i128 > x_isize.try_into().unwrap();
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:142:19
+   |
+LL |         x_isize > x_i8;
+   |                   ^^^^
+   |                   |
+   |                   expected `isize`, found `i8`
+   |                   help: you can convert an `i8` to `isize`: `x_i8.into()`
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:144:19
+   |
+LL |         x_isize > x_i16;
+   |                   ^^^^^
+   |                   |
+   |                   expected `isize`, found `i16`
+   |                   help: you can convert an `i16` to `isize`: `x_i16.into()`
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:146:19
+   |
+LL |         x_isize > x_i32;
+   |                   ^^^^^ expected `isize`, found `i32`
+   |
+help: you can convert an `i32` to `isize` and panic if the converted value wouldn't fit
+   |
+LL |         x_isize > x_i32.try_into().unwrap();
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:148:19
+   |
+LL |         x_isize > x_i64;
+   |                   ^^^^^ expected `isize`, found `i64`
+   |
+help: you can convert an `i64` to `isize` and panic if the converted value wouldn't fit
+   |
+LL |         x_isize > x_i64.try_into().unwrap();
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:150:19
+   |
+LL |         x_isize > x_i128;
+   |                   ^^^^^^ expected `isize`, found `i128`
+   |
+help: you can convert an `i128` to `isize` and panic if the converted value wouldn't fit
+   |
+LL |         x_isize > x_i128.try_into().unwrap();
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:156:16
+   |
+LL |         x_u8 > x_i8;
+   |                ^^^^ expected `u8`, found `i8`
+   |
+help: you can convert an `i8` to `u8` and panic if the converted value wouldn't fit
+   |
+LL |         x_u8 > x_i8.try_into().unwrap();
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:158:16
+   |
+LL |         x_u8 > x_i16;
+   |                ^^^^^ expected `u8`, found `i16`
+   |
+help: you can convert `x_u8` from `u8` to `i16`, matching the type of `x_i16`
+   |
+LL |         i16::from(x_u8) > x_i16;
+   |         ^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:160:16
+   |
+LL |         x_u8 > x_i32;
+   |                ^^^^^ expected `u8`, found `i32`
+   |
+help: you can convert `x_u8` from `u8` to `i32`, matching the type of `x_i32`
+   |
+LL |         i32::from(x_u8) > x_i32;
+   |         ^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:162:16
+   |
+LL |         x_u8 > x_i64;
+   |                ^^^^^ expected `u8`, found `i64`
+   |
+help: you can convert `x_u8` from `u8` to `i64`, matching the type of `x_i64`
+   |
+LL |         i64::from(x_u8) > x_i64;
+   |         ^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:164:16
+   |
+LL |         x_u8 > x_i128;
+   |                ^^^^^^ expected `u8`, found `i128`
+   |
+help: you can convert `x_u8` from `u8` to `i128`, matching the type of `x_i128`
+   |
+LL |         i128::from(x_u8) > x_i128;
+   |         ^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:166:16
+   |
+LL |         x_u8 > x_isize;
+   |                ^^^^^^^ expected `u8`, found `isize`
+   |
+help: you can convert `x_u8` from `u8` to `isize`, matching the type of `x_isize`
+   |
+LL |         isize::from(x_u8) > x_isize;
+   |         ^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:169:17
+   |
+LL |         x_u16 > x_i8;
+   |                 ^^^^ expected `u16`, found `i8`
+   |
+help: you can convert an `i8` to `u16` and panic if the converted value wouldn't fit
+   |
+LL |         x_u16 > x_i8.try_into().unwrap();
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:171:17
+   |
+LL |         x_u16 > x_i16;
+   |                 ^^^^^ expected `u16`, found `i16`
+   |
+help: you can convert an `i16` to `u16` and panic if the converted value wouldn't fit
+   |
+LL |         x_u16 > x_i16.try_into().unwrap();
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:173:17
+   |
+LL |         x_u16 > x_i32;
+   |                 ^^^^^ expected `u16`, found `i32`
+   |
+help: you can convert `x_u16` from `u16` to `i32`, matching the type of `x_i32`
+   |
+LL |         i32::from(x_u16) > x_i32;
+   |         ^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:175:17
+   |
+LL |         x_u16 > x_i64;
+   |                 ^^^^^ expected `u16`, found `i64`
+   |
+help: you can convert `x_u16` from `u16` to `i64`, matching the type of `x_i64`
+   |
+LL |         i64::from(x_u16) > x_i64;
+   |         ^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:177:17
+   |
+LL |         x_u16 > x_i128;
+   |                 ^^^^^^ expected `u16`, found `i128`
+   |
+help: you can convert `x_u16` from `u16` to `i128`, matching the type of `x_i128`
+   |
+LL |         i128::from(x_u16) > x_i128;
+   |         ^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:179:17
+   |
+LL |         x_u16 > x_isize;
+   |                 ^^^^^^^ expected `u16`, found `isize`
+   |
+help: you can convert an `isize` to `u16` and panic if the converted value wouldn't fit
+   |
+LL |         x_u16 > x_isize.try_into().unwrap();
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:182:17
+   |
+LL |         x_u32 > x_i8;
+   |                 ^^^^ expected `u32`, found `i8`
+   |
+help: you can convert an `i8` to `u32` and panic if the converted value wouldn't fit
+   |
+LL |         x_u32 > x_i8.try_into().unwrap();
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:184:17
+   |
+LL |         x_u32 > x_i16;
+   |                 ^^^^^ expected `u32`, found `i16`
+   |
+help: you can convert an `i16` to `u32` and panic if the converted value wouldn't fit
+   |
+LL |         x_u32 > x_i16.try_into().unwrap();
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:186:17
+   |
+LL |         x_u32 > x_i32;
+   |                 ^^^^^ expected `u32`, found `i32`
+   |
+help: you can convert an `i32` to `u32` and panic if the converted value wouldn't fit
+   |
+LL |         x_u32 > x_i32.try_into().unwrap();
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:188:17
+   |
+LL |         x_u32 > x_i64;
+   |                 ^^^^^ expected `u32`, found `i64`
+   |
+help: you can convert `x_u32` from `u32` to `i64`, matching the type of `x_i64`
+   |
+LL |         i64::from(x_u32) > x_i64;
+   |         ^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:190:17
+   |
+LL |         x_u32 > x_i128;
+   |                 ^^^^^^ expected `u32`, found `i128`
+   |
+help: you can convert `x_u32` from `u32` to `i128`, matching the type of `x_i128`
+   |
+LL |         i128::from(x_u32) > x_i128;
+   |         ^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:192:17
+   |
+LL |         x_u32 > x_isize;
+   |                 ^^^^^^^ expected `u32`, found `isize`
+   |
+help: you can convert an `isize` to `u32` and panic if the converted value wouldn't fit
+   |
+LL |         x_u32 > x_isize.try_into().unwrap();
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:195:17
+   |
+LL |         x_u64 > x_i8;
+   |                 ^^^^ expected `u64`, found `i8`
+   |
+help: you can convert an `i8` to `u64` and panic if the converted value wouldn't fit
+   |
+LL |         x_u64 > x_i8.try_into().unwrap();
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:197:17
+   |
+LL |         x_u64 > x_i16;
+   |                 ^^^^^ expected `u64`, found `i16`
+   |
+help: you can convert an `i16` to `u64` and panic if the converted value wouldn't fit
+   |
+LL |         x_u64 > x_i16.try_into().unwrap();
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:199:17
+   |
+LL |         x_u64 > x_i32;
+   |                 ^^^^^ expected `u64`, found `i32`
+   |
+help: you can convert an `i32` to `u64` and panic if the converted value wouldn't fit
+   |
+LL |         x_u64 > x_i32.try_into().unwrap();
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:201:17
+   |
+LL |         x_u64 > x_i64;
+   |                 ^^^^^ expected `u64`, found `i64`
+   |
+help: you can convert an `i64` to `u64` and panic if the converted value wouldn't fit
+   |
+LL |         x_u64 > x_i64.try_into().unwrap();
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:203:17
+   |
+LL |         x_u64 > x_i128;
+   |                 ^^^^^^ expected `u64`, found `i128`
+   |
+help: you can convert `x_u64` from `u64` to `i128`, matching the type of `x_i128`
+   |
+LL |         i128::from(x_u64) > x_i128;
+   |         ^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:205:17
+   |
+LL |         x_u64 > x_isize;
+   |                 ^^^^^^^ expected `u64`, found `isize`
+   |
+help: you can convert an `isize` to `u64` and panic if the converted value wouldn't fit
+   |
+LL |         x_u64 > x_isize.try_into().unwrap();
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:208:18
+   |
+LL |         x_u128 > x_i8;
+   |                  ^^^^ expected `u128`, found `i8`
+   |
+help: you can convert an `i8` to `u128` and panic if the converted value wouldn't fit
+   |
+LL |         x_u128 > x_i8.try_into().unwrap();
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:210:18
+   |
+LL |         x_u128 > x_i16;
+   |                  ^^^^^ expected `u128`, found `i16`
+   |
+help: you can convert an `i16` to `u128` and panic if the converted value wouldn't fit
+   |
+LL |         x_u128 > x_i16.try_into().unwrap();
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:212:18
+   |
+LL |         x_u128 > x_i32;
+   |                  ^^^^^ expected `u128`, found `i32`
+   |
+help: you can convert an `i32` to `u128` and panic if the converted value wouldn't fit
+   |
+LL |         x_u128 > x_i32.try_into().unwrap();
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:214:18
+   |
+LL |         x_u128 > x_i64;
+   |                  ^^^^^ expected `u128`, found `i64`
+   |
+help: you can convert an `i64` to `u128` and panic if the converted value wouldn't fit
+   |
+LL |         x_u128 > x_i64.try_into().unwrap();
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:216:18
+   |
+LL |         x_u128 > x_i128;
+   |                  ^^^^^^ expected `u128`, found `i128`
+   |
+help: you can convert an `i128` to `u128` and panic if the converted value wouldn't fit
+   |
+LL |         x_u128 > x_i128.try_into().unwrap();
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:218:18
+   |
+LL |         x_u128 > x_isize;
+   |                  ^^^^^^^ expected `u128`, found `isize`
+   |
+help: you can convert an `isize` to `u128` and panic if the converted value wouldn't fit
+   |
+LL |         x_u128 > x_isize.try_into().unwrap();
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:221:19
+   |
+LL |         x_usize > x_i8;
+   |                   ^^^^ expected `usize`, found `i8`
+   |
+help: you can convert an `i8` to `usize` and panic if the converted value wouldn't fit
+   |
+LL |         x_usize > x_i8.try_into().unwrap();
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:223:19
+   |
+LL |         x_usize > x_i16;
+   |                   ^^^^^ expected `usize`, found `i16`
+   |
+help: you can convert an `i16` to `usize` and panic if the converted value wouldn't fit
+   |
+LL |         x_usize > x_i16.try_into().unwrap();
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:225:19
+   |
+LL |         x_usize > x_i32;
+   |                   ^^^^^ expected `usize`, found `i32`
+   |
+help: you can convert an `i32` to `usize` and panic if the converted value wouldn't fit
+   |
+LL |         x_usize > x_i32.try_into().unwrap();
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:227:19
+   |
+LL |         x_usize > x_i64;
+   |                   ^^^^^ expected `usize`, found `i64`
+   |
+help: you can convert an `i64` to `usize` and panic if the converted value wouldn't fit
+   |
+LL |         x_usize > x_i64.try_into().unwrap();
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:229:19
+   |
+LL |         x_usize > x_i128;
+   |                   ^^^^^^ expected `usize`, found `i128`
+   |
+help: you can convert an `i128` to `usize` and panic if the converted value wouldn't fit
+   |
+LL |         x_usize > x_i128.try_into().unwrap();
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:231:19
+   |
+LL |         x_usize > x_isize;
+   |                   ^^^^^^^ expected `usize`, found `isize`
+   |
+help: you can convert an `isize` to `usize` and panic if the converted value wouldn't fit
+   |
+LL |         x_usize > x_isize.try_into().unwrap();
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:237:16
+   |
+LL |         x_i8 > x_u8;
+   |                ^^^^ expected `i8`, found `u8`
+   |
+help: you can convert an `u8` to `i8` and panic if the converted value wouldn't fit
+   |
+LL |         x_i8 > x_u8.try_into().unwrap();
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:239:16
+   |
+LL |         x_i8 > x_u16;
+   |                ^^^^^ expected `i8`, found `u16`
+   |
+help: you can convert an `u16` to `i8` and panic if the converted value wouldn't fit
+   |
+LL |         x_i8 > x_u16.try_into().unwrap();
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:241:16
+   |
+LL |         x_i8 > x_u32;
+   |                ^^^^^ expected `i8`, found `u32`
+   |
+help: you can convert an `u32` to `i8` and panic if the converted value wouldn't fit
+   |
+LL |         x_i8 > x_u32.try_into().unwrap();
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:243:16
+   |
+LL |         x_i8 > x_u64;
+   |                ^^^^^ expected `i8`, found `u64`
+   |
+help: you can convert an `u64` to `i8` and panic if the converted value wouldn't fit
+   |
+LL |         x_i8 > x_u64.try_into().unwrap();
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:245:16
+   |
+LL |         x_i8 > x_u128;
+   |                ^^^^^^ expected `i8`, found `u128`
+   |
+help: you can convert an `u128` to `i8` and panic if the converted value wouldn't fit
+   |
+LL |         x_i8 > x_u128.try_into().unwrap();
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:247:16
+   |
+LL |         x_i8 > x_usize;
+   |                ^^^^^^^ expected `i8`, found `usize`
+   |
+help: you can convert an `usize` to `i8` and panic if the converted value wouldn't fit
+   |
+LL |         x_i8 > x_usize.try_into().unwrap();
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:250:17
+   |
+LL |         x_i16 > x_u8;
+   |                 ^^^^
+   |                 |
+   |                 expected `i16`, found `u8`
+   |                 help: you can convert an `u8` to `i16`: `x_u8.into()`
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:252:17
+   |
+LL |         x_i16 > x_u16;
+   |                 ^^^^^ expected `i16`, found `u16`
+   |
+help: you can convert an `u16` to `i16` and panic if the converted value wouldn't fit
+   |
+LL |         x_i16 > x_u16.try_into().unwrap();
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:254:17
+   |
+LL |         x_i16 > x_u32;
+   |                 ^^^^^ expected `i16`, found `u32`
+   |
+help: you can convert an `u32` to `i16` and panic if the converted value wouldn't fit
+   |
+LL |         x_i16 > x_u32.try_into().unwrap();
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:256:17
+   |
+LL |         x_i16 > x_u64;
+   |                 ^^^^^ expected `i16`, found `u64`
+   |
+help: you can convert an `u64` to `i16` and panic if the converted value wouldn't fit
+   |
+LL |         x_i16 > x_u64.try_into().unwrap();
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:258:17
+   |
+LL |         x_i16 > x_u128;
+   |                 ^^^^^^ expected `i16`, found `u128`
+   |
+help: you can convert an `u128` to `i16` and panic if the converted value wouldn't fit
+   |
+LL |         x_i16 > x_u128.try_into().unwrap();
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:260:17
+   |
+LL |         x_i16 > x_usize;
+   |                 ^^^^^^^ expected `i16`, found `usize`
+   |
+help: you can convert an `usize` to `i16` and panic if the converted value wouldn't fit
+   |
+LL |         x_i16 > x_usize.try_into().unwrap();
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:263:17
+   |
+LL |         x_i32 > x_u8;
+   |                 ^^^^
+   |                 |
+   |                 expected `i32`, found `u8`
+   |                 help: you can convert an `u8` to `i32`: `x_u8.into()`
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:265:17
+   |
+LL |         x_i32 > x_u16;
+   |                 ^^^^^
+   |                 |
+   |                 expected `i32`, found `u16`
+   |                 help: you can convert an `u16` to `i32`: `x_u16.into()`
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:267:17
+   |
+LL |         x_i32 > x_u32;
+   |                 ^^^^^ expected `i32`, found `u32`
+   |
+help: you can convert an `u32` to `i32` and panic if the converted value wouldn't fit
+   |
+LL |         x_i32 > x_u32.try_into().unwrap();
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:269:17
+   |
+LL |         x_i32 > x_u64;
+   |                 ^^^^^ expected `i32`, found `u64`
+   |
+help: you can convert an `u64` to `i32` and panic if the converted value wouldn't fit
+   |
+LL |         x_i32 > x_u64.try_into().unwrap();
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:271:17
+   |
+LL |         x_i32 > x_u128;
+   |                 ^^^^^^ expected `i32`, found `u128`
+   |
+help: you can convert an `u128` to `i32` and panic if the converted value wouldn't fit
+   |
+LL |         x_i32 > x_u128.try_into().unwrap();
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:273:17
+   |
+LL |         x_i32 > x_usize;
+   |                 ^^^^^^^ expected `i32`, found `usize`
+   |
+help: you can convert an `usize` to `i32` and panic if the converted value wouldn't fit
+   |
+LL |         x_i32 > x_usize.try_into().unwrap();
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:276:17
+   |
+LL |         x_i64 > x_u8;
+   |                 ^^^^
+   |                 |
+   |                 expected `i64`, found `u8`
+   |                 help: you can convert an `u8` to `i64`: `x_u8.into()`
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:278:17
+   |
+LL |         x_i64 > x_u16;
+   |                 ^^^^^
+   |                 |
+   |                 expected `i64`, found `u16`
+   |                 help: you can convert an `u16` to `i64`: `x_u16.into()`
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:280:17
+   |
+LL |         x_i64 > x_u32;
+   |                 ^^^^^
+   |                 |
+   |                 expected `i64`, found `u32`
+   |                 help: you can convert an `u32` to `i64`: `x_u32.into()`
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:282:17
+   |
+LL |         x_i64 > x_u64;
+   |                 ^^^^^ expected `i64`, found `u64`
+   |
+help: you can convert an `u64` to `i64` and panic if the converted value wouldn't fit
+   |
+LL |         x_i64 > x_u64.try_into().unwrap();
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:284:17
+   |
+LL |         x_i64 > x_u128;
+   |                 ^^^^^^ expected `i64`, found `u128`
+   |
+help: you can convert an `u128` to `i64` and panic if the converted value wouldn't fit
+   |
+LL |         x_i64 > x_u128.try_into().unwrap();
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:286:17
+   |
+LL |         x_i64 > x_usize;
+   |                 ^^^^^^^ expected `i64`, found `usize`
+   |
+help: you can convert an `usize` to `i64` and panic if the converted value wouldn't fit
+   |
+LL |         x_i64 > x_usize.try_into().unwrap();
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:289:18
+   |
+LL |         x_i128 > x_u8;
+   |                  ^^^^
+   |                  |
+   |                  expected `i128`, found `u8`
+   |                  help: you can convert an `u8` to `i128`: `x_u8.into()`
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:291:18
+   |
+LL |         x_i128 > x_u16;
+   |                  ^^^^^
+   |                  |
+   |                  expected `i128`, found `u16`
+   |                  help: you can convert an `u16` to `i128`: `x_u16.into()`
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:293:18
+   |
+LL |         x_i128 > x_u32;
+   |                  ^^^^^
+   |                  |
+   |                  expected `i128`, found `u32`
+   |                  help: you can convert an `u32` to `i128`: `x_u32.into()`
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:295:18
+   |
+LL |         x_i128 > x_u64;
+   |                  ^^^^^
+   |                  |
+   |                  expected `i128`, found `u64`
+   |                  help: you can convert an `u64` to `i128`: `x_u64.into()`
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:297:18
+   |
+LL |         x_i128 > x_u128;
+   |                  ^^^^^^ expected `i128`, found `u128`
+   |
+help: you can convert an `u128` to `i128` and panic if the converted value wouldn't fit
+   |
+LL |         x_i128 > x_u128.try_into().unwrap();
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:299:18
+   |
+LL |         x_i128 > x_usize;
+   |                  ^^^^^^^ expected `i128`, found `usize`
+   |
+help: you can convert an `usize` to `i128` and panic if the converted value wouldn't fit
+   |
+LL |         x_i128 > x_usize.try_into().unwrap();
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:302:19
+   |
+LL |         x_isize > x_u8;
+   |                   ^^^^
+   |                   |
+   |                   expected `isize`, found `u8`
+   |                   help: you can convert an `u8` to `isize`: `x_u8.into()`
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:304:19
+   |
+LL |         x_isize > x_u16;
+   |                   ^^^^^ expected `isize`, found `u16`
+   |
+help: you can convert an `u16` to `isize` and panic if the converted value wouldn't fit
+   |
+LL |         x_isize > x_u16.try_into().unwrap();
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:306:19
+   |
+LL |         x_isize > x_u32;
+   |                   ^^^^^ expected `isize`, found `u32`
+   |
+help: you can convert an `u32` to `isize` and panic if the converted value wouldn't fit
+   |
+LL |         x_isize > x_u32.try_into().unwrap();
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:308:19
+   |
+LL |         x_isize > x_u64;
+   |                   ^^^^^ expected `isize`, found `u64`
+   |
+help: you can convert an `u64` to `isize` and panic if the converted value wouldn't fit
+   |
+LL |         x_isize > x_u64.try_into().unwrap();
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:310:19
+   |
+LL |         x_isize > x_u128;
+   |                   ^^^^^^ expected `isize`, found `u128`
+   |
+help: you can convert an `u128` to `isize` and panic if the converted value wouldn't fit
+   |
+LL |         x_isize > x_u128.try_into().unwrap();
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/numeric-cast-binop.rs:312:19
+   |
+LL |         x_isize > x_usize;
+   |                   ^^^^^^^ expected `isize`, found `usize`
+   |
+help: you can convert an `usize` to `isize` and panic if the converted value wouldn't fit
+   |
+LL |         x_isize > x_usize.try_into().unwrap();
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 132 previous errors
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Given a code

```rust
fn foo(x: u8, y: u32) -> bool {
    x > y
}
fn main() {}
```

it could be more helpful to provide a suggestion to do "u32::from(x)"
rather than "y.try_into().unwrap()", since the latter may panic.

We do this by passing the LHS of a binary expression up the stack into
the coercion checker.

Closes #73145