### PR TITLE
Update cargo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,7 +282,7 @@ checksum = "716960a18f978640f25101b5cbf1c6f6b0d3192fab36a2d98ca96f0ecbe41010"
 
 [[package]]
 name = "cargo"
-version = "0.46.0"
+version = "0.47.0"
 dependencies = [
  "anyhow",
  "atty",
@@ -1848,9 +1848,9 @@ dependencies = [
 
 [[package]]
 name = "libgit2-sys"
-version = "0.12.5+1.0.0"
+version = "0.12.7+1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eadeec65514971355bf7134967a543f71372f35b53ac6c7143e7bd157f07535"
+checksum = "bcd07968649bcb7b9351ecfde53ca4d27673cccfdf57c84255ec18710f3153e0"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
15 commits in 40ebd52206e25c7a576ee42c137cc06a745a167a..1ec223effbbbf9fddd3453cdcae3a96a967608eb
2020-06-01 22:35:00 +0000 to 2020-06-09 20:03:14 +0000
- Default values for `readme` if not specified (rust-lang/cargo#8277)
- Fix tree completions. (rust-lang/cargo#8342)
- Support `{prefix}` and `{lowerprefix}` markers in `config.json` `dl` key (rust-lang/cargo#8267)
- Add environment variables to identify the binary and crate name (rust-lang/cargo#8270)
- Bump to 0.47.0, update changelog (rust-lang/cargo#8336)
- Nits: Remove unneeded mut and loop (rust-lang/cargo#8334)
- 1.45 beta backports (rust-lang/cargo#8331)
- Better error message when passing in relative path to Workspace::new (rust-lang/cargo#8321)
- Don't hash executable filenames on apple platforms. (rust-lang/cargo#8329)
- fix clippy warnings (rust-lang/cargo#8324)
- Require latest libgit2 to pull in bugfixes (rust-lang/cargo#8320)
- Fix an accidental raw access of field (rust-lang/cargo#8319)
- Use mem::take to replace with Default values (rust-lang/cargo#8314)
- Allow Windows dylibs without dll suffix. (rust-lang/cargo#8310)
- Show alias in help message (rust-lang/cargo#8307)