### PR TITLE
Fix emcc failure for wasm32.

### DIFF
--- a/src/ci/docker/wasm32/Dockerfile
+++ b/src/ci/docker/wasm32/Dockerfile
@@ -27,6 +27,9 @@ ENV PATH=$PATH:/emsdk-portable
 ENV PATH=$PATH:/emsdk-portable/upstream/emscripten/
 ENV PATH=$PATH:/emsdk-portable/node/12.9.1_64bit/bin/
 ENV BINARYEN_ROOT=/emsdk-portable/upstream/
+ENV EMSDK=/emsdk-portable
+ENV EM_CONFIG=/emsdk-portable/.emscripten
+ENV EM_CACHE=/emsdk-portable/upstream/emscripten/cache
 
 ENV TARGETS=wasm32-unknown-emscripten
 


### PR DESCRIPTION
The wasm32 job is currently failing on CI with the error `ERROR: llc executable not found at /usr/bin/llc`.  The issue is that https://github.com/emscripten-core/emsdk/pull/472 has changed how emsdk discovers its configuration.  We were relying on the global behavior that would use a configuration from the home directory.  However, it looks like emsdk is moving away from that approach.  This change adds the necessary env var for emcc to find the correct configuration.

There are a few alternate approaches this could take.  The `--no-embedded` option could be passed to `emsdk activate` to use the old behavior, but it seems like they want to move away from that.  Another option is to source `emsdk_env.sh`, which is how these env vars normally get set.  I'm not entirely sure how to do that easily in a Dockerfile, though.
