### PR TITLE
Allow inference regions when relating consts

### DIFF
--- a/src/librustc_middle/ty/relate.rs
+++ b/src/librustc_middle/ty/relate.rs
@@ -508,16 +508,7 @@ pub fn super_relate_consts<R: TypeRelation<'tcx>>(
     debug!("{}.super_relate_consts(a = {:?}, b = {:?})", relation.tag(), a, b);
     let tcx = relation.tcx();
 
-    let eagerly_eval = |x: &'tcx ty::Const<'tcx>| {
-        // FIXME(eddyb) this doesn't account for lifetime inference variables
-        // being erased by `eval`, *nor* for the polymorphic aspect of `eval`.
-        // That is, we could always use `eval` and it will just return the
-        // old value back if it doesn't succeed.
-        if !x.val.needs_infer() {
-            return x.eval(tcx, relation.param_env()).val;
-        }
-        x.val
-    };
+    let eagerly_eval = |x: &'tcx ty::Const<'tcx>| x.eval(tcx, relation.param_env()).val;
 
     // FIXME(eddyb) doesn't look like everything below checks that `a.ty == b.ty`.
     // We could probably always assert it early, as `const` generic parameters

--- a/src/test/ui/async-await/issue-73050.rs
+++ b/src/test/ui/async-await/issue-73050.rs
@@ -1,0 +1,12 @@
+// check-pass
+// edition:2018
+
+#[allow(unused)]
+async fn foo<'a>() {
+    let _data = &mut [0u8; { 1 + 4 }];
+    bar().await
+}
+
+async fn bar() {}
+
+fn main() {}


### PR DESCRIPTION
As first noticed by @eddyb, `super_relate_consts` doesn't need to check for inference vars since `eval` does it already (and handles lifetimes correctly by erasing them).

Fixes #73050

r? @oli-obk