### PR TITLE
Allow multiple `asm!` options groups and report an error on duplicate options

### DIFF
--- a/src/librustc_builtin_macros/asm.rs
+++ b/src/librustc_builtin_macros/asm.rs
@@ -292,20 +292,23 @@ fn err_duplicate_option<'a>(p: &mut Parser<'a>, symbol: Symbol, span: Span) {
         .sess
         .span_diagnostic
         .struct_span_err(span, &format!("the `{}` option was already provided", symbol));
-    err.span_suggestion(
+    err.span_label(
         span,
+        "this option was already provided",
+    );
+
+    // Tool-only output
+    let mut full_span = span;
+    if p.token.kind == token::Comma {
+        full_span = full_span.to(p.token.span);
+    }
+    err.tool_only_span_suggestion(
+        full_span,
         "remove this option",
         String::new(),
         Applicability::MachineApplicable,
     );
-    if p.token.kind == token::Comma {
-        err.tool_only_span_suggestion(
-            p.token.span,
-            "remove this comma",
-            String::new(),
-            Applicability::MachineApplicable,
-        );
-    }
+
     err.emit();
 }
 

--- a/src/librustc_builtin_macros/asm.rs
+++ b/src/librustc_builtin_macros/asm.rs
@@ -283,6 +283,10 @@ fn parse_args<'a>(
     Ok(args)
 }
 
+/// Report a duplicate option error.
+///
+/// This function must be called immediately after the option token is parsed.
+/// Otherwise, the suggestion will be incorrect.
 fn err_duplicate_option<'a>(p: &mut Parser<'a>, symbol: Symbol, span: Span) {
     let mut err = p
         .sess
@@ -305,6 +309,11 @@ fn err_duplicate_option<'a>(p: &mut Parser<'a>, symbol: Symbol, span: Span) {
     err.emit();
 }
 
+/// Try to set the provided option in the provided `AsmArgs`.
+/// If it is already set, report a duplicate option error.
+///
+/// This function must be called immediately after the option token is parsed.
+/// Otherwise, the error will not point to the correct spot.
 fn try_set_option<'a>(
     p: &mut Parser<'a>,
     args: &mut AsmArgs,

--- a/src/librustc_builtin_macros/asm.rs
+++ b/src/librustc_builtin_macros/asm.rs
@@ -288,7 +288,12 @@ fn err_duplicate_option<'a>(p: &mut Parser<'a>, symbol: Symbol, span: Span) {
         .sess
         .span_diagnostic
         .struct_span_err(span, &format!("the `{}` option was already provided", symbol));
-    err.span_suggestion(span, "remove this option", String::new(), Applicability::Unspecified);
+    err.span_suggestion(
+        span,
+        "remove this option",
+        String::new(),
+        Applicability::MachineApplicable,
+    );
     err.emit();
 }
 
@@ -301,7 +306,11 @@ fn try_set_option<'a>(
     if !args.options.contains(option) {
         args.options |= option;
     } else {
-        err_duplicate_option(p, symbol, p.prev_token.span);
+        let mut span = p.prev_token.span;
+        if p.look_ahead(0, |t| t == &token::Comma) {
+            span = span.to(p.token.span);
+        }
+        err_duplicate_option(p, symbol, span);
     }
 }
 

--- a/src/librustc_builtin_macros/asm.rs
+++ b/src/librustc_builtin_macros/asm.rs
@@ -19,12 +19,6 @@ struct AsmArgs {
     options_spans: Vec<Span>,
 }
 
-impl AsmArgs {
-    fn option_is_set(&self, option: ast::InlineAsmOptions) -> bool {
-        (self.options & option) == option
-    }
-}
-
 fn parse_args<'a>(
     ecx: &mut ExtCtxt<'a>,
     sp: Span,
@@ -304,7 +298,7 @@ fn try_set_option<'a>(
     symbol: Symbol,
     option: ast::InlineAsmOptions,
 ) {
-    if !args.option_is_set(option) {
+    if !args.options.contains(option) {
         args.options |= option;
     } else {
         err_duplicate_option(p, symbol, p.prev_token.span);

--- a/src/librustc_builtin_macros/asm.rs
+++ b/src/librustc_builtin_macros/asm.rs
@@ -294,6 +294,14 @@ fn err_duplicate_option<'a>(p: &mut Parser<'a>, symbol: Symbol, span: Span) {
         String::new(),
         Applicability::MachineApplicable,
     );
+    if p.look_ahead(0, |t| t == &token::Comma) {
+        err.tool_only_span_suggestion(
+            p.token.span,
+            "remove this comma",
+            String::new(),
+            Applicability::MachineApplicable,
+        );
+    }
     err.emit();
 }
 
@@ -306,11 +314,7 @@ fn try_set_option<'a>(
     if !args.options.contains(option) {
         args.options |= option;
     } else {
-        let mut span = p.prev_token.span;
-        if p.look_ahead(0, |t| t == &token::Comma) {
-            span = span.to(p.token.span);
-        }
-        err_duplicate_option(p, symbol, span);
+        err_duplicate_option(p, symbol, p.prev_token.span);
     }
 }
 

--- a/src/librustc_builtin_macros/asm.rs
+++ b/src/librustc_builtin_macros/asm.rs
@@ -297,7 +297,7 @@ fn err_duplicate_option<'a>(p: &mut Parser<'a>, span: Span) {
     } else {
         p.sess.span_diagnostic.struct_span_err(span, "this option was already provided")
     };
-    err.span_help(span, "remove this option");
+    err.span_label(span, "remove this option");
     err.emit();
 }
 

--- a/src/librustc_builtin_macros/asm.rs
+++ b/src/librustc_builtin_macros/asm.rs
@@ -292,10 +292,7 @@ fn err_duplicate_option<'a>(p: &mut Parser<'a>, symbol: Symbol, span: Span) {
         .sess
         .span_diagnostic
         .struct_span_err(span, &format!("the `{}` option was already provided", symbol));
-    err.span_label(
-        span,
-        "this option was already provided",
-    );
+    err.span_label(span, "this option was already provided");
 
     // Tool-only output
     let mut full_span = span;

--- a/src/librustc_builtin_macros/asm.rs
+++ b/src/librustc_builtin_macros/asm.rs
@@ -288,7 +288,7 @@ fn err_duplicate_option<'a>(p: &mut Parser<'a>, symbol: Symbol, span: Span) {
         .sess
         .span_diagnostic
         .struct_span_err(span, &format!("the `{}` option was already provided", symbol));
-    err.span_label(span, "remove this option");
+    err.span_suggestion(span, "remove this option", String::new(), Applicability::Unspecified);
     err.emit();
 }
 

--- a/src/librustc_builtin_macros/asm.rs
+++ b/src/librustc_builtin_macros/asm.rs
@@ -174,7 +174,7 @@ fn parse_args<'a>(
 
         // Validate the order of named, positional & explicit register operands and options. We do
         // this at the end once we have the full span of the argument available.
-        if args.options_spans.len() > 0 {
+        if !args.options_spans.is_empty() {
             ecx.struct_span_err(span, "arguments are not allowed after options")
                 .span_labels(args.options_spans.clone(), "previous options")
                 .span_label(span, "argument")
@@ -241,9 +241,9 @@ fn parse_args<'a>(
     if args.options.contains(ast::InlineAsmOptions::PURE)
         && !args.options.intersects(ast::InlineAsmOptions::NOMEM | ast::InlineAsmOptions::READONLY)
     {
-        let span = args.options_spans.clone();
+        let spans = args.options_spans.clone();
         ecx.struct_span_err(
-            span,
+            spans,
             "the `pure` option must be combined with either `nomem` or `readonly`",
         )
         .emit();

--- a/src/librustc_builtin_macros/asm.rs
+++ b/src/librustc_builtin_macros/asm.rs
@@ -298,7 +298,7 @@ fn err_duplicate_option<'a>(p: &mut Parser<'a>, symbol: Symbol, span: Span) {
         String::new(),
         Applicability::MachineApplicable,
     );
-    if p.look_ahead(0, |t| t == &token::Comma) {
+    if p.token.kind == token::Comma {
         err.tool_only_span_suggestion(
             p.token.span,
             "remove this comma",

--- a/src/librustc_builtin_macros/asm.rs
+++ b/src/librustc_builtin_macros/asm.rs
@@ -16,7 +16,7 @@ struct AsmArgs {
     named_args: FxHashMap<Symbol, usize>,
     reg_args: FxHashSet<usize>,
     options: ast::InlineAsmOptions,
-    options_spans: Option<Vec<Span>>,
+    options_spans: Vec<Span>,
 }
 
 fn parse_args<'a>(
@@ -59,7 +59,7 @@ fn parse_args<'a>(
         named_args: FxHashMap::default(),
         reg_args: FxHashSet::default(),
         options: ast::InlineAsmOptions::empty(),
-        options_spans: None,
+        options_spans: vec![],
     };
 
     let mut allow_templates = true;
@@ -174,9 +174,9 @@ fn parse_args<'a>(
 
         // Validate the order of named, positional & explicit register operands and options. We do
         // this at the end once we have the full span of the argument available.
-        if let Some(ref options_spans) = args.options_spans {
+        if args.options_spans.len() > 0 {
             ecx.struct_span_err(span, "arguments are not allowed after options")
-                .span_labels(options_spans.clone(), "previous options")
+                .span_labels(args.options_spans.clone(), "previous options")
                 .span_label(span, "argument")
                 .emit();
         }
@@ -227,21 +227,21 @@ fn parse_args<'a>(
     if args.options.contains(ast::InlineAsmOptions::NOMEM)
         && args.options.contains(ast::InlineAsmOptions::READONLY)
     {
-        let spans = args.options_spans.clone().unwrap();
+        let spans = args.options_spans.clone();
         ecx.struct_span_err(spans, "the `nomem` and `readonly` options are mutually exclusive")
             .emit();
     }
     if args.options.contains(ast::InlineAsmOptions::PURE)
         && args.options.contains(ast::InlineAsmOptions::NORETURN)
     {
-        let spans = args.options_spans.clone().unwrap();
+        let spans = args.options_spans.clone();
         ecx.struct_span_err(spans, "the `pure` and `noreturn` options are mutually exclusive")
             .emit();
     }
     if args.options.contains(ast::InlineAsmOptions::PURE)
         && !args.options.intersects(ast::InlineAsmOptions::NOMEM | ast::InlineAsmOptions::READONLY)
     {
-        let span = args.options_spans.clone().unwrap();
+        let span = args.options_spans.clone();
         ecx.struct_span_err(
             span,
             "the `pure` option must be combined with either `nomem` or `readonly`",
@@ -267,7 +267,7 @@ fn parse_args<'a>(
     }
     if args.options.contains(ast::InlineAsmOptions::PURE) && !have_real_output {
         ecx.struct_span_err(
-            args.options_spans.clone().unwrap(),
+            args.options_spans.clone(),
             "asm with `pure` option must have at least one output",
         )
         .emit();
@@ -314,11 +314,7 @@ fn parse_options<'a>(p: &mut Parser<'a>, args: &mut AsmArgs) -> Result<(), Diagn
     }
 
     let new_span = span_start.to(p.prev_token.span);
-    if let Some(options_spans) = &mut args.options_spans {
-        options_spans.push(new_span);
-    } else {
-        args.options_spans = Some(vec![new_span]);
-    }
+    args.options_spans.push(new_span);
 
     Ok(())
 }

--- a/src/test/codegen/asm-multiple-options.rs
+++ b/src/test/codegen/asm-multiple-options.rs
@@ -1,0 +1,53 @@
+// compile-flags: -O
+// only-x86_64
+
+#![crate_type = "rlib"]
+#![feature(asm)]
+
+// CHECK-LABEL: @pure
+// CHECK-NOT: asm
+// CHECK: ret void
+#[no_mangle]
+pub unsafe fn pure(x: i32) {
+    let y: i32;
+    asm!("", out("ax") y, in("bx") x, options(pure), options(nomem));
+}
+
+pub static mut VAR: i32 = 0;
+pub static mut DUMMY_OUTPUT: i32 = 0;
+
+// CHECK-LABEL: @readonly
+// CHECK: call i32 asm
+// CHECK: ret i32 1
+#[no_mangle]
+pub unsafe fn readonly() -> i32 {
+    VAR = 1;
+    asm!("", out("ax") DUMMY_OUTPUT, options(pure), options(readonly));
+    VAR
+}
+
+// CHECK-LABEL: @nomem
+// CHECK-NOT: store
+// CHECK: call i32 asm
+// CHECK: store
+// CHECK: ret i32 2
+#[no_mangle]
+pub unsafe fn nomem() -> i32 {
+    VAR = 1;
+    asm!("", out("ax") DUMMY_OUTPUT, options(pure), options(nomem));
+    VAR = 2;
+    VAR
+}
+
+// CHECK-LABEL: @not_nomem
+// CHECK: store
+// CHECK: call i32 asm
+// CHECK: store
+// CHECK: ret i32 2
+#[no_mangle]
+pub unsafe fn not_nomem() -> i32 {
+    VAR = 1;
+    asm!("", out("ax") DUMMY_OUTPUT, options(pure), options(readonly));
+    VAR = 2;
+    VAR
+}

--- a/src/test/ui/asm/duplicate-options.fixed
+++ b/src/test/ui/asm/duplicate-options.fixed
@@ -5,22 +5,22 @@
 
 fn main() {
     unsafe {
-        asm!("", options(nomem, nomem));
+        asm!("", options(nomem, ));
         //~^ ERROR the `nomem` option was already provided
-        asm!("", options(att_syntax, att_syntax));
+        asm!("", options(att_syntax, ));
         //~^ ERROR the `att_syntax` option was already provided
-        asm!("", options(nostack, att_syntax), options(nostack));
+        asm!("", options(nostack, att_syntax), options());
         //~^ ERROR the `nostack` option was already provided
-        asm!("", options(nostack, nostack), options(nostack), options(nostack));
+        asm!("", options(nostack, ), options(), options());
         //~^ ERROR the `nostack` option was already provided
         //~| ERROR the `nostack` option was already provided
         //~| ERROR the `nostack` option was already provided
         asm!(
             "",
             options(nomem, noreturn),
-            options(att_syntax, noreturn), //~ ERROR the `noreturn` option was already provided
-            options(nomem, nostack), //~ ERROR the `nomem` option was already provided
-            options(noreturn), //~ ERROR the `noreturn` option was already provided
+            options(att_syntax, ), //~ ERROR the `noreturn` option was already provided
+            options( nostack), //~ ERROR the `nomem` option was already provided
+            options(), //~ ERROR the `noreturn` option was already provided
         );
     }
 }

--- a/src/test/ui/asm/duplicate-options.rs
+++ b/src/test/ui/asm/duplicate-options.rs
@@ -1,0 +1,19 @@
+// only-x86_64
+// build-pass
+
+#![feature(asm)]
+
+fn main() {
+    unsafe {
+        asm!("", options(nomem, nomem));
+        //~^ WARNING the `nomem` option was already provided
+        asm!("", options(att_syntax, att_syntax));
+        //~^ WARNING the `att_syntax` option was already provided
+        asm!("", options(nostack, att_syntax), options(nostack));
+        //~^ WARNING the `nostack` option was already provided
+        asm!("", options(nostack, nostack), options(nostack), options(nostack));
+        //~^ WARNING the `nostack` option was already provided
+        //~| WARNING the `nostack` option was already provided
+        //~| WARNING the `nostack` option was already provided
+    }
+}

--- a/src/test/ui/asm/duplicate-options.rs
+++ b/src/test/ui/asm/duplicate-options.rs
@@ -1,19 +1,24 @@
 // only-x86_64
-// build-pass
 
 #![feature(asm)]
 
 fn main() {
     unsafe {
         asm!("", options(nomem, nomem));
-        //~^ WARNING the `nomem` option was already provided
+        //~^ ERROR the `nomem` option was already provided
+        //~| HELP remove this option
         asm!("", options(att_syntax, att_syntax));
-        //~^ WARNING the `att_syntax` option was already provided
+        //~^ ERROR the `att_syntax` option was already provided
+        //~| HELP remove this option
         asm!("", options(nostack, att_syntax), options(nostack));
-        //~^ WARNING the `nostack` option was already provided
+        //~^ ERROR the `nostack` option was already provided
+        //~| HELP remove this option
         asm!("", options(nostack, nostack), options(nostack), options(nostack));
-        //~^ WARNING the `nostack` option was already provided
-        //~| WARNING the `nostack` option was already provided
-        //~| WARNING the `nostack` option was already provided
+        //~^ ERROR the `nostack` option was already provided
+        //~| HELP remove this option
+        //~| ERROR the `nostack` option was already provided
+        //~| HELP remove this option
+        //~| ERROR the `nostack` option was already provided
+        //~| HELP remove this option
     }
 }

--- a/src/test/ui/asm/duplicate-options.rs
+++ b/src/test/ui/asm/duplicate-options.rs
@@ -6,19 +6,13 @@ fn main() {
     unsafe {
         asm!("", options(nomem, nomem));
         //~^ ERROR the `nomem` option was already provided
-        //~| HELP remove this option
         asm!("", options(att_syntax, att_syntax));
         //~^ ERROR the `att_syntax` option was already provided
-        //~| HELP remove this option
         asm!("", options(nostack, att_syntax), options(nostack));
         //~^ ERROR the `nostack` option was already provided
-        //~| HELP remove this option
         asm!("", options(nostack, nostack), options(nostack), options(nostack));
         //~^ ERROR the `nostack` option was already provided
-        //~| HELP remove this option
         //~| ERROR the `nostack` option was already provided
-        //~| HELP remove this option
         //~| ERROR the `nostack` option was already provided
-        //~| HELP remove this option
     }
 }

--- a/src/test/ui/asm/duplicate-options.rs
+++ b/src/test/ui/asm/duplicate-options.rs
@@ -14,5 +14,12 @@ fn main() {
         //~^ ERROR the `nostack` option was already provided
         //~| ERROR the `nostack` option was already provided
         //~| ERROR the `nostack` option was already provided
+        asm!(
+            "",
+            options(nomem, noreturn),
+            options(att_syntax, noreturn), //~ ERROR the `noreturn` option was already provided
+            options(nomem, nostack), //~ ERROR the `nomem` option was already provided
+            options(noreturn), //~ ERROR the `noreturn` option was already provided
+        );
     }
 }

--- a/src/test/ui/asm/duplicate-options.stderr
+++ b/src/test/ui/asm/duplicate-options.stderr
@@ -2,37 +2,37 @@ error: the `nomem` option was already provided
   --> $DIR/duplicate-options.rs:7:33
    |
 LL |         asm!("", options(nomem, nomem));
-   |                                 ^^^^^ remove this option
+   |                                 ^^^^^ help: remove this option
 
 error: the `att_syntax` option was already provided
   --> $DIR/duplicate-options.rs:9:38
    |
 LL |         asm!("", options(att_syntax, att_syntax));
-   |                                      ^^^^^^^^^^ remove this option
+   |                                      ^^^^^^^^^^ help: remove this option
 
 error: the `nostack` option was already provided
   --> $DIR/duplicate-options.rs:11:56
    |
 LL |         asm!("", options(nostack, att_syntax), options(nostack));
-   |                                                        ^^^^^^^ remove this option
+   |                                                        ^^^^^^^ help: remove this option
 
 error: the `nostack` option was already provided
   --> $DIR/duplicate-options.rs:13:35
    |
 LL |         asm!("", options(nostack, nostack), options(nostack), options(nostack));
-   |                                   ^^^^^^^ remove this option
+   |                                   ^^^^^^^ help: remove this option
 
 error: the `nostack` option was already provided
   --> $DIR/duplicate-options.rs:13:53
    |
 LL |         asm!("", options(nostack, nostack), options(nostack), options(nostack));
-   |                                                     ^^^^^^^ remove this option
+   |                                                     ^^^^^^^ help: remove this option
 
 error: the `nostack` option was already provided
   --> $DIR/duplicate-options.rs:13:71
    |
 LL |         asm!("", options(nostack, nostack), options(nostack), options(nostack));
-   |                                                                       ^^^^^^^ remove this option
+   |                                                                       ^^^^^^^ help: remove this option
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/asm/duplicate-options.stderr
+++ b/src/test/ui/asm/duplicate-options.stderr
@@ -2,55 +2,55 @@ error: the `nomem` option was already provided
   --> $DIR/duplicate-options.rs:8:33
    |
 LL |         asm!("", options(nomem, nomem));
-   |                                 ^^^^^ help: remove this option
+   |                                 ^^^^^ this option was already provided
 
 error: the `att_syntax` option was already provided
   --> $DIR/duplicate-options.rs:10:38
    |
 LL |         asm!("", options(att_syntax, att_syntax));
-   |                                      ^^^^^^^^^^ help: remove this option
+   |                                      ^^^^^^^^^^ this option was already provided
 
 error: the `nostack` option was already provided
   --> $DIR/duplicate-options.rs:12:56
    |
 LL |         asm!("", options(nostack, att_syntax), options(nostack));
-   |                                                        ^^^^^^^ help: remove this option
+   |                                                        ^^^^^^^ this option was already provided
 
 error: the `nostack` option was already provided
   --> $DIR/duplicate-options.rs:14:35
    |
 LL |         asm!("", options(nostack, nostack), options(nostack), options(nostack));
-   |                                   ^^^^^^^ help: remove this option
+   |                                   ^^^^^^^ this option was already provided
 
 error: the `nostack` option was already provided
   --> $DIR/duplicate-options.rs:14:53
    |
 LL |         asm!("", options(nostack, nostack), options(nostack), options(nostack));
-   |                                                     ^^^^^^^ help: remove this option
+   |                                                     ^^^^^^^ this option was already provided
 
 error: the `nostack` option was already provided
   --> $DIR/duplicate-options.rs:14:71
    |
 LL |         asm!("", options(nostack, nostack), options(nostack), options(nostack));
-   |                                                                       ^^^^^^^ help: remove this option
+   |                                                                       ^^^^^^^ this option was already provided
 
 error: the `noreturn` option was already provided
   --> $DIR/duplicate-options.rs:21:33
    |
 LL |             options(att_syntax, noreturn),
-   |                                 ^^^^^^^^ help: remove this option
+   |                                 ^^^^^^^^ this option was already provided
 
 error: the `nomem` option was already provided
   --> $DIR/duplicate-options.rs:22:21
    |
 LL |             options(nomem, nostack),
-   |                     ^^^^^^ help: remove this option
+   |                     ^^^^^ this option was already provided
 
 error: the `noreturn` option was already provided
   --> $DIR/duplicate-options.rs:23:21
    |
 LL |             options(noreturn),
-   |                     ^^^^^^^^ help: remove this option
+   |                     ^^^^^^^^ this option was already provided
 
 error: aborting due to 9 previous errors
 

--- a/src/test/ui/asm/duplicate-options.stderr
+++ b/src/test/ui/asm/duplicate-options.stderr
@@ -1,0 +1,38 @@
+warning: the `nomem` option was already provided
+  --> $DIR/duplicate-options.rs:8:33
+   |
+LL |         asm!("", options(nomem, nomem));
+   |                                 ^^^^^ help: remove this option
+
+warning: the `att_syntax` option was already provided
+  --> $DIR/duplicate-options.rs:10:38
+   |
+LL |         asm!("", options(att_syntax, att_syntax));
+   |                                      ^^^^^^^^^^ help: remove this option
+
+warning: the `nostack` option was already provided
+  --> $DIR/duplicate-options.rs:12:56
+   |
+LL |         asm!("", options(nostack, att_syntax), options(nostack));
+   |                                                        ^^^^^^^ help: remove this option
+
+warning: the `nostack` option was already provided
+  --> $DIR/duplicate-options.rs:14:35
+   |
+LL |         asm!("", options(nostack, nostack), options(nostack), options(nostack));
+   |                                   ^^^^^^^ help: remove this option
+
+warning: the `nostack` option was already provided
+  --> $DIR/duplicate-options.rs:14:53
+   |
+LL |         asm!("", options(nostack, nostack), options(nostack), options(nostack));
+   |                                                     ^^^^^^^ help: remove this option
+
+warning: the `nostack` option was already provided
+  --> $DIR/duplicate-options.rs:14:71
+   |
+LL |         asm!("", options(nostack, nostack), options(nostack), options(nostack));
+   |                                                                       ^^^^^^^ help: remove this option
+
+warning: 6 warnings emitted
+

--- a/src/test/ui/asm/duplicate-options.stderr
+++ b/src/test/ui/asm/duplicate-options.stderr
@@ -1,38 +1,74 @@
-warning: the `nomem` option was already provided
-  --> $DIR/duplicate-options.rs:8:33
+error: the `nomem` option was already provided
+  --> $DIR/duplicate-options.rs:7:33
    |
 LL |         asm!("", options(nomem, nomem));
-   |                                 ^^^^^ help: remove this option
+   |                                 ^^^^^
+   |
+help: remove this option
+  --> $DIR/duplicate-options.rs:7:33
+   |
+LL |         asm!("", options(nomem, nomem));
+   |                                 ^^^^^
 
-warning: the `att_syntax` option was already provided
+error: the `att_syntax` option was already provided
   --> $DIR/duplicate-options.rs:10:38
    |
 LL |         asm!("", options(att_syntax, att_syntax));
-   |                                      ^^^^^^^^^^ help: remove this option
+   |                                      ^^^^^^^^^^
+   |
+help: remove this option
+  --> $DIR/duplicate-options.rs:10:38
+   |
+LL |         asm!("", options(att_syntax, att_syntax));
+   |                                      ^^^^^^^^^^
 
-warning: the `nostack` option was already provided
-  --> $DIR/duplicate-options.rs:12:56
+error: the `nostack` option was already provided
+  --> $DIR/duplicate-options.rs:13:56
    |
 LL |         asm!("", options(nostack, att_syntax), options(nostack));
-   |                                                        ^^^^^^^ help: remove this option
+   |                                                        ^^^^^^^
+   |
+help: remove this option
+  --> $DIR/duplicate-options.rs:13:56
+   |
+LL |         asm!("", options(nostack, att_syntax), options(nostack));
+   |                                                        ^^^^^^^
 
-warning: the `nostack` option was already provided
-  --> $DIR/duplicate-options.rs:14:35
+error: the `nostack` option was already provided
+  --> $DIR/duplicate-options.rs:16:35
    |
 LL |         asm!("", options(nostack, nostack), options(nostack), options(nostack));
-   |                                   ^^^^^^^ help: remove this option
-
-warning: the `nostack` option was already provided
-  --> $DIR/duplicate-options.rs:14:53
+   |                                   ^^^^^^^
+   |
+help: remove this option
+  --> $DIR/duplicate-options.rs:16:35
    |
 LL |         asm!("", options(nostack, nostack), options(nostack), options(nostack));
-   |                                                     ^^^^^^^ help: remove this option
+   |                                   ^^^^^^^
 
-warning: the `nostack` option was already provided
-  --> $DIR/duplicate-options.rs:14:71
+error: the `nostack` option was already provided
+  --> $DIR/duplicate-options.rs:16:53
    |
 LL |         asm!("", options(nostack, nostack), options(nostack), options(nostack));
-   |                                                                       ^^^^^^^ help: remove this option
+   |                                                     ^^^^^^^
+   |
+help: remove this option
+  --> $DIR/duplicate-options.rs:16:53
+   |
+LL |         asm!("", options(nostack, nostack), options(nostack), options(nostack));
+   |                                                     ^^^^^^^
 
-warning: 6 warnings emitted
+error: the `nostack` option was already provided
+  --> $DIR/duplicate-options.rs:16:71
+   |
+LL |         asm!("", options(nostack, nostack), options(nostack), options(nostack));
+   |                                                                       ^^^^^^^
+   |
+help: remove this option
+  --> $DIR/duplicate-options.rs:16:71
+   |
+LL |         asm!("", options(nostack, nostack), options(nostack), options(nostack));
+   |                                                                       ^^^^^^^
+
+error: aborting due to 6 previous errors
 

--- a/src/test/ui/asm/duplicate-options.stderr
+++ b/src/test/ui/asm/duplicate-options.stderr
@@ -1,53 +1,53 @@
 error: the `nomem` option was already provided
-  --> $DIR/duplicate-options.rs:7:33
+  --> $DIR/duplicate-options.rs:8:33
    |
 LL |         asm!("", options(nomem, nomem));
    |                                 ^^^^^ help: remove this option
 
 error: the `att_syntax` option was already provided
-  --> $DIR/duplicate-options.rs:9:38
+  --> $DIR/duplicate-options.rs:10:38
    |
 LL |         asm!("", options(att_syntax, att_syntax));
    |                                      ^^^^^^^^^^ help: remove this option
 
 error: the `nostack` option was already provided
-  --> $DIR/duplicate-options.rs:11:56
+  --> $DIR/duplicate-options.rs:12:56
    |
 LL |         asm!("", options(nostack, att_syntax), options(nostack));
    |                                                        ^^^^^^^ help: remove this option
 
 error: the `nostack` option was already provided
-  --> $DIR/duplicate-options.rs:13:35
+  --> $DIR/duplicate-options.rs:14:35
    |
 LL |         asm!("", options(nostack, nostack), options(nostack), options(nostack));
    |                                   ^^^^^^^ help: remove this option
 
 error: the `nostack` option was already provided
-  --> $DIR/duplicate-options.rs:13:53
+  --> $DIR/duplicate-options.rs:14:53
    |
 LL |         asm!("", options(nostack, nostack), options(nostack), options(nostack));
    |                                                     ^^^^^^^ help: remove this option
 
 error: the `nostack` option was already provided
-  --> $DIR/duplicate-options.rs:13:71
+  --> $DIR/duplicate-options.rs:14:71
    |
 LL |         asm!("", options(nostack, nostack), options(nostack), options(nostack));
    |                                                                       ^^^^^^^ help: remove this option
 
 error: the `noreturn` option was already provided
-  --> $DIR/duplicate-options.rs:20:33
+  --> $DIR/duplicate-options.rs:21:33
    |
 LL |             options(att_syntax, noreturn),
    |                                 ^^^^^^^^ help: remove this option
 
 error: the `nomem` option was already provided
-  --> $DIR/duplicate-options.rs:21:21
+  --> $DIR/duplicate-options.rs:22:21
    |
 LL |             options(nomem, nostack),
-   |                     ^^^^^ help: remove this option
+   |                     ^^^^^^ help: remove this option
 
 error: the `noreturn` option was already provided
-  --> $DIR/duplicate-options.rs:22:21
+  --> $DIR/duplicate-options.rs:23:21
    |
 LL |             options(noreturn),
    |                     ^^^^^^^^ help: remove this option

--- a/src/test/ui/asm/duplicate-options.stderr
+++ b/src/test/ui/asm/duplicate-options.stderr
@@ -34,5 +34,23 @@ error: the `nostack` option was already provided
 LL |         asm!("", options(nostack, nostack), options(nostack), options(nostack));
    |                                                                       ^^^^^^^ help: remove this option
 
-error: aborting due to 6 previous errors
+error: the `noreturn` option was already provided
+  --> $DIR/duplicate-options.rs:20:33
+   |
+LL |             options(att_syntax, noreturn),
+   |                                 ^^^^^^^^ help: remove this option
+
+error: the `nomem` option was already provided
+  --> $DIR/duplicate-options.rs:21:21
+   |
+LL |             options(nomem, nostack),
+   |                     ^^^^^ help: remove this option
+
+error: the `noreturn` option was already provided
+  --> $DIR/duplicate-options.rs:22:21
+   |
+LL |             options(noreturn),
+   |                     ^^^^^^^^ help: remove this option
+
+error: aborting due to 9 previous errors
 

--- a/src/test/ui/asm/duplicate-options.stderr
+++ b/src/test/ui/asm/duplicate-options.stderr
@@ -2,73 +2,37 @@ error: the `nomem` option was already provided
   --> $DIR/duplicate-options.rs:7:33
    |
 LL |         asm!("", options(nomem, nomem));
-   |                                 ^^^^^
-   |
-help: remove this option
-  --> $DIR/duplicate-options.rs:7:33
-   |
-LL |         asm!("", options(nomem, nomem));
-   |                                 ^^^^^
+   |                                 ^^^^^ remove this option
 
 error: the `att_syntax` option was already provided
-  --> $DIR/duplicate-options.rs:10:38
+  --> $DIR/duplicate-options.rs:9:38
    |
 LL |         asm!("", options(att_syntax, att_syntax));
-   |                                      ^^^^^^^^^^
-   |
-help: remove this option
-  --> $DIR/duplicate-options.rs:10:38
-   |
-LL |         asm!("", options(att_syntax, att_syntax));
-   |                                      ^^^^^^^^^^
+   |                                      ^^^^^^^^^^ remove this option
 
 error: the `nostack` option was already provided
-  --> $DIR/duplicate-options.rs:13:56
+  --> $DIR/duplicate-options.rs:11:56
    |
 LL |         asm!("", options(nostack, att_syntax), options(nostack));
-   |                                                        ^^^^^^^
-   |
-help: remove this option
-  --> $DIR/duplicate-options.rs:13:56
-   |
-LL |         asm!("", options(nostack, att_syntax), options(nostack));
-   |                                                        ^^^^^^^
+   |                                                        ^^^^^^^ remove this option
 
 error: the `nostack` option was already provided
-  --> $DIR/duplicate-options.rs:16:35
+  --> $DIR/duplicate-options.rs:13:35
    |
 LL |         asm!("", options(nostack, nostack), options(nostack), options(nostack));
-   |                                   ^^^^^^^
-   |
-help: remove this option
-  --> $DIR/duplicate-options.rs:16:35
-   |
-LL |         asm!("", options(nostack, nostack), options(nostack), options(nostack));
-   |                                   ^^^^^^^
+   |                                   ^^^^^^^ remove this option
 
 error: the `nostack` option was already provided
-  --> $DIR/duplicate-options.rs:16:53
+  --> $DIR/duplicate-options.rs:13:53
    |
 LL |         asm!("", options(nostack, nostack), options(nostack), options(nostack));
-   |                                                     ^^^^^^^
-   |
-help: remove this option
-  --> $DIR/duplicate-options.rs:16:53
-   |
-LL |         asm!("", options(nostack, nostack), options(nostack), options(nostack));
-   |                                                     ^^^^^^^
+   |                                                     ^^^^^^^ remove this option
 
 error: the `nostack` option was already provided
-  --> $DIR/duplicate-options.rs:16:71
+  --> $DIR/duplicate-options.rs:13:71
    |
 LL |         asm!("", options(nostack, nostack), options(nostack), options(nostack));
-   |                                                                       ^^^^^^^
-   |
-help: remove this option
-  --> $DIR/duplicate-options.rs:16:71
-   |
-LL |         asm!("", options(nostack, nostack), options(nostack), options(nostack));
-   |                                                                       ^^^^^^^
+   |                                                                       ^^^^^^^ remove this option
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/asm/parse-error.rs
+++ b/src/test/ui/asm/parse-error.rs
@@ -34,11 +34,6 @@ fn main() {
         //~^ ERROR expected one of
         asm!("", options(nomem, foo));
         //~^ ERROR expected one of
-        asm!("", options(), options());
-        //~^ ERROR asm options cannot be specified multiple times
-        asm!("", options(), options(), options());
-        //~^ ERROR asm options cannot be specified multiple times
-        //~^^ ERROR asm options cannot be specified multiple times
         asm!("{}", options(), const foo);
         //~^ ERROR arguments are not allowed after options
         asm!("{a}", a = const foo, a = const bar);

--- a/src/test/ui/asm/parse-error.stderr
+++ b/src/test/ui/asm/parse-error.stderr
@@ -82,32 +82,8 @@ error: expected one of `)`, `att_syntax`, `nomem`, `noreturn`, `nostack`, `prese
 LL |         asm!("", options(nomem, foo));
    |                                 ^^^ expected one of 8 possible tokens
 
-error: asm options cannot be specified multiple times
-  --> $DIR/parse-error.rs:37:29
-   |
-LL |         asm!("", options(), options());
-   |                  ---------  ^^^^^^^^^ duplicate options
-   |                  |
-   |                  previously here
-
-error: asm options cannot be specified multiple times
-  --> $DIR/parse-error.rs:39:29
-   |
-LL |         asm!("", options(), options(), options());
-   |                  ---------  ^^^^^^^^^ duplicate options
-   |                  |
-   |                  previously here
-
-error: asm options cannot be specified multiple times
-  --> $DIR/parse-error.rs:39:40
-   |
-LL |         asm!("", options(), options(), options());
-   |                  ---------             ^^^^^^^^^ duplicate options
-   |                  |
-   |                  previously here
-
 error: arguments are not allowed after options
-  --> $DIR/parse-error.rs:42:31
+  --> $DIR/parse-error.rs:37:31
    |
 LL |         asm!("{}", options(), const foo);
    |                    ---------  ^^^^^^^^^ argument
@@ -115,7 +91,7 @@ LL |         asm!("{}", options(), const foo);
    |                    previous options
 
 error: duplicate argument named `a`
-  --> $DIR/parse-error.rs:44:36
+  --> $DIR/parse-error.rs:39:36
    |
 LL |         asm!("{a}", a = const foo, a = const bar);
    |                     -------------  ^^^^^^^^^^^^^ duplicate argument
@@ -123,7 +99,7 @@ LL |         asm!("{a}", a = const foo, a = const bar);
    |                     previously here
 
 error: argument never used
-  --> $DIR/parse-error.rs:44:36
+  --> $DIR/parse-error.rs:39:36
    |
 LL |         asm!("{a}", a = const foo, a = const bar);
    |                                    ^^^^^^^^^^^^^ argument never used
@@ -131,13 +107,13 @@ LL |         asm!("{a}", a = const foo, a = const bar);
    = help: if this argument is intentionally unused, consider using it in an asm comment: `"/* {1} */"`
 
 error: explicit register arguments cannot have names
-  --> $DIR/parse-error.rs:47:18
+  --> $DIR/parse-error.rs:42:18
    |
 LL |         asm!("", a = in("eax") foo);
    |                  ^^^^^^^^^^^^^^^^^
 
 error: named arguments cannot follow explicit register arguments
-  --> $DIR/parse-error.rs:49:36
+  --> $DIR/parse-error.rs:44:36
    |
 LL |         asm!("{a}", in("eax") foo, a = const bar);
    |                     -------------  ^^^^^^^^^^^^^ named argument
@@ -145,7 +121,7 @@ LL |         asm!("{a}", in("eax") foo, a = const bar);
    |                     explicit register argument
 
 error: named arguments cannot follow explicit register arguments
-  --> $DIR/parse-error.rs:51:36
+  --> $DIR/parse-error.rs:46:36
    |
 LL |         asm!("{a}", in("eax") foo, a = const bar);
    |                     -------------  ^^^^^^^^^^^^^ named argument
@@ -153,7 +129,7 @@ LL |         asm!("{a}", in("eax") foo, a = const bar);
    |                     explicit register argument
 
 error: positional arguments cannot follow named arguments or explicit register arguments
-  --> $DIR/parse-error.rs:53:36
+  --> $DIR/parse-error.rs:48:36
    |
 LL |         asm!("{1}", in("eax") foo, const bar);
    |                     -------------  ^^^^^^^^^ positional argument
@@ -161,19 +137,19 @@ LL |         asm!("{1}", in("eax") foo, const bar);
    |                     explicit register argument
 
 error: expected one of `const`, `in`, `inlateout`, `inout`, `lateout`, `options`, `out`, or `sym`, found `""`
-  --> $DIR/parse-error.rs:55:29
+  --> $DIR/parse-error.rs:50:29
    |
 LL |         asm!("", options(), "");
    |                             ^^ expected one of 8 possible tokens
 
 error: expected one of `const`, `in`, `inlateout`, `inout`, `lateout`, `options`, `out`, or `sym`, found `"{}"`
-  --> $DIR/parse-error.rs:57:33
+  --> $DIR/parse-error.rs:52:33
    |
 LL |         asm!("{}", in(reg) foo, "{}", out(reg) foo);
    |                                 ^^^^ expected one of 8 possible tokens
 
 error: asm template must be a string literal
-  --> $DIR/parse-error.rs:59:14
+  --> $DIR/parse-error.rs:54:14
    |
 LL |         asm!(format!("{{{}}}", 0), in(reg) foo);
    |              ^^^^^^^^^^^^^^^^^^^^
@@ -181,12 +157,12 @@ LL |         asm!(format!("{{{}}}", 0), in(reg) foo);
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: asm template must be a string literal
-  --> $DIR/parse-error.rs:61:21
+  --> $DIR/parse-error.rs:56:21
    |
 LL |         asm!("{1}", format!("{{{}}}", 0), in(reg) foo, out(reg) bar);
    |                     ^^^^^^^^^^^^^^^^^^^^
    |
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 28 previous errors
+error: aborting due to 25 previous errors
 


### PR DESCRIPTION
Fixes #73193

Cc @joshtriplett @Amanieu

- [x] Allow multiple options
- [x] Update existing test
- [x] Add new tests
- [x] Check for duplicate options
- [x] Add duplicate options tests
- [x] Finalize suggestion format for duplicate options error