### PR TITLE
x.py: do not build Miri by default on stable/beta

### DIFF
--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -52,6 +52,8 @@ pub trait Step: 'static + Clone + Debug + PartialEq + Eq + Hash {
     /// it's been assembled.
     type Output: Clone;
 
+    /// Whether this step is run by default as part of its respective phase.
+    /// `true` here can still be overwritten by `should_run` calling `default_condition`.
     const DEFAULT: bool = false;
 
     /// If true, then this rule should be skipped if --target was specified, but --host was not


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/73117

Do I need to do anything to make sure Miri is still built by the tools CI builder? Are there other tools that should be off-by-default?

Also, unfortunately the `DEFAULT` associated const has no doc comment, so I have no idea what it does, or why there are semmingly two places where the default build of tools is controlled.