### PR TITLE
Add documentation to point to `File::open` or `OpenOptions::open` instead of `is_file` to check read/write possibility

### DIFF
--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -1033,6 +1033,12 @@ impl Metadata {
     /// [`is_dir`], and will be false for symlink metadata
     /// obtained from [`symlink_metadata`].
     ///
+    /// This property means it is often more useful to use `!file_type.is_dir()`
+    /// than `file_type.is_file()` when your goal is to read bytes from a
+    /// source: the former includes symlink and pipes when the latter does not,
+    /// meaning you will break workflows like `diff <( prog_a ) <( prog_b )` on
+    /// a Unix-like system for example.
+    ///
     /// [`is_dir`]: struct.Metadata.html#method.is_dir
     /// [`symlink_metadata`]: fn.symlink_metadata.html
     ///

--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -1033,14 +1033,16 @@ impl Metadata {
     /// [`is_dir`], and will be false for symlink metadata
     /// obtained from [`symlink_metadata`].
     ///
-    /// This property means it is often more useful to use `!file_type.is_dir()`
-    /// than `file_type.is_file()` when your goal is to read bytes from a
-    /// source: the former includes symlink and pipes when the latter does not,
-    /// meaning you will break workflows like `diff <( prog_a ) <( prog_b )` on
-    /// a Unix-like system for example.
+    /// When the goal is simply to read from (or write to) the source, the most
+    /// reliable way to test the source can be read (or written to) is to open
+    /// it. Only using `is_file` can break workflows like `diff <( prog_a )` on
+    /// a Unix-like system for example. See [`File::open`] or
+    /// [`OpenOptions::open`] for more information.
     ///
     /// [`is_dir`]: struct.Metadata.html#method.is_dir
     /// [`symlink_metadata`]: fn.symlink_metadata.html
+    /// [`File::open`]: struct.File.html#method.open
+    /// [`OpenOptions::open`]: struct.OpenOptions.html#method.open
     ///
     /// # Examples
     ///
@@ -1313,14 +1315,16 @@ impl FileType {
     /// [`is_dir`] and [`is_symlink`]; only zero or one of these
     /// tests may pass.
     ///
-    /// This property means it is often more useful to use `!file_type.is_dir()`
-    /// than `file_type.is_file()` when your goal is to read bytes from a
-    /// source: the former includes symlink and pipes when the latter does not,
-    /// meaning you will break workflows like `diff <( prog_a ) <( prog_b )` on
-    /// a Unix-like system for example.
+    /// When the goal is simply to read from (or write to) the source, the most
+    /// reliable way to test the source can be read (or written to) is to open
+    /// it. Only using `is_file` can break workflows like `diff <( prog_a )` on
+    /// a Unix-like system for example. See [`File::open`] or
+    /// [`OpenOptions::open`] for more information.
     ///
     /// [`is_dir`]: struct.FileType.html#method.is_dir
     /// [`is_symlink`]: struct.FileType.html#method.is_symlink
+    /// [`File::open`]: struct.File.html#method.open
+    /// [`OpenOptions::open`]: struct.OpenOptions.html#method.open
     ///
     /// # Examples
     ///

--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -1307,6 +1307,12 @@ impl FileType {
     /// [`is_dir`] and [`is_symlink`]; only zero or one of these
     /// tests may pass.
     ///
+    /// This property means it is often more useful to use `!file_type.is_dir()`
+    /// than `file_type.is_file()` when your goal is to read bytes from a
+    /// source: the former includes symlink and pipes when the latter does not,
+    /// meaning you will break workflows like `diff <( prog_a ) <( prog_b )` on
+    /// a Unix-like system for example.
+    ///
     /// [`is_dir`]: struct.FileType.html#method.is_dir
     /// [`is_symlink`]: struct.FileType.html#method.is_symlink
     ///

--- a/src/libstd/path.rs
+++ b/src/libstd/path.rs
@@ -2506,12 +2506,17 @@ impl Path {
     /// check errors, call [`fs::metadata`] and handle its Result. Then call
     /// [`fs::Metadata::is_file`] if it was Ok.
     ///
-    /// Note that the explanation about using `open` instead of `is_file`
-    /// that is present in the [`fs::Metadata`] documentation also applies here.
+    /// When the goal is simply to read from (or write to) the source, the most
+    /// reliable way to test the source can be read (or written to) is to open
+    /// it. Only using `is_file` can break workflows like `diff <( prog_a )` on
+    /// a Unix-like system for example. See [`File::open`] or
+    /// [`OpenOptions::open`] for more information.
     ///
     /// [`fs::metadata`]: ../../std/fs/fn.metadata.html
     /// [`fs::Metadata`]: ../../std/fs/struct.Metadata.html
     /// [`fs::Metadata::is_file`]: ../../std/fs/struct.Metadata.html#method.is_file
+    /// [`File::open`]: ../../std/fs/struct.File.html#method.open
+    /// [`OpenOptions::open`]: ../../std/fs/struct.OpenOptions.html#method.open
     #[stable(feature = "path_ext", since = "1.5.0")]
     pub fn is_file(&self) -> bool {
         fs::metadata(self).map(|m| m.is_file()).unwrap_or(false)

--- a/src/libstd/path.rs
+++ b/src/libstd/path.rs
@@ -2506,7 +2506,7 @@ impl Path {
     /// check errors, call [`fs::metadata`] and handle its Result. Then call
     /// [`fs::Metadata::is_file`] if it was Ok.
     ///
-    /// Note that the explanation about using `!is_dir` instead of `is_file`
+    /// Note that the explanation about using `open` instead of `is_file`
     /// that is present in the [`fs::Metadata`] documentation also applies here.
     ///
     /// [`fs::metadata`]: ../../std/fs/fn.metadata.html

--- a/src/libstd/path.rs
+++ b/src/libstd/path.rs
@@ -2503,11 +2503,15 @@ impl Path {
     /// # See Also
     ///
     /// This is a convenience function that coerces errors to false. If you want to
-    /// check errors, call [fs::metadata] and handle its Result. Then call
-    /// [fs::Metadata::is_file] if it was Ok.
+    /// check errors, call [`fs::metadata`] and handle its Result. Then call
+    /// [`fs::Metadata::is_file`] if it was Ok.
     ///
-    /// [fs::metadata]: ../../std/fs/fn.metadata.html
-    /// [fs::Metadata::is_file]: ../../std/fs/struct.Metadata.html#method.is_file
+    /// Note that the explanation about using `!is_dir` instead of `is_file`
+    /// that is present in the [`fs::Metadata`] documentation also applies here.
+    ///
+    /// [`fs::metadata`]: ../../std/fs/fn.metadata.html
+    /// [`fs::Metadata`]: ../../std/fs/struct.Metadata.html
+    /// [`fs::Metadata::is_file`]: ../../std/fs/struct.Metadata.html#method.is_file
     #[stable(feature = "path_ext", since = "1.5.0")]
     pub fn is_file(&self) -> bool {
         fs::metadata(self).map(|m| m.is_file()).unwrap_or(false)


### PR DESCRIPTION
Fixes #64170.

This adds documentation to point user towards `!is_dir` instead of `is_file` when all they want to is read from a source.

I ran `rg "fn is_file\("` to find all `is_file` methods, I hope I did not miss one.