### PR TITLE
Add various Zulip notifications for prioritization

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -58,7 +58,9 @@ label = "O-ARM"
 
 [prioritize]
 label = "I-prioritize"
-prioritize_on = [
+
+[autolabel."I-prioritize"]
+trigger_labels = [
     "regression-from-stable-to-stable",
     "regression-from-stable-to-beta",
     "regression-from-stable-to-nightly",
@@ -70,4 +72,46 @@ exclude_labels = [
     "T-release",
     "requires-nightly",
 ]
-zulip_stream = 227806
+
+[notify-zulip."I-prioritize"]
+zulip_stream = 227806 # #t-compiler/wg-prioritization
+topic = "I-prioritize #{number} {title}"
+message_on_add = "@**WG-prioritization** issue #{number} has been requested for prioritization."
+message_on_remove = "Issue #{number}'s prioritization request has been removed."
+
+[notify-zulip."I-nominated"]
+required_labels = ["T-compiler"]
+zulip_stream = 227806 # #t-compiler/wg-prioritization
+topic = "I-prioritize #{number} {title}"
+message_on_add = "@**WG-prioritization** #{number} has been nominated for discussion in `T-compiler` meeting."
+message_on_remove = "#{number}'s nomination has been removed."
+
+[notify-zulip."beta-nominated"]
+zulip_stream = 227806 # #t-compiler/wg-prioritization
+topic = "Backport #{number} {title}"
+message_on_add = "@**WG-prioritization** PR #{number} has been requested for beta backport."
+message_on_remove = "PR #{number}'s beta backport request has been removed."
+
+[notify-zulip."stable-nominated"]
+zulip_stream = 227806 # #t-compiler/wg-prioritization
+topic = "Backport #{number} {title}"
+message_on_add = "@**WG-prioritization** PR #{number} has been requested for stable backport."
+message_on_remove = "PR #{number}'s stable backport request has been removed."
+
+[notify-zulip."S-waiting-on-team"]
+required_labels = ["T-compiler"]
+zulip_stream = 227806 # #t-compiler/wg-prioritization
+topic = "S-waiting-on-team #{number} {title}"
+message_on_add = "@**WG-prioritization** PR #{number} is waiting on `T-compiler`."
+message_on_remove = "PR #{number}'s is no longer waiting on `T-compiler`."
+
+[notify-zulip."P-critical"]
+zulip_stream = 227806 # #t-compiler/wg-prioritization
+topic = "P-critical #{number} {title}"
+message_on_add = "@**WG-prioritization** issue #{number} has been assigned `P-critical`."
+
+[notify-zulip."P-high"]
+required_labels = ["regression-from-stable-to-*"]
+zulip_stream = 227806 # #t-compiler/wg-prioritization
+topic = "P-high regression #{number} {title}"
+message_on_add = "@**WG-prioritization** issue #{number} has been assigned `P-high` and is a regression."


### PR DESCRIPTION
Adapts `triagebot.toml` for rust-lang/triagebot#616 and adds various Zulip notifications for the Prioritization WG workflow.
We should also add indications about the procedure for handling those events, cc @rust-lang/wg-prioritization.

r? @spastorino 
This should be merged as soon as possible after rust-lang/triagebot#616 is merged, cc @Mark-Simulacrum