### PR TITLE
ty: projections in `transparent_newtype_field`

### DIFF
--- a/src/librustc_lint/types.rs
+++ b/src/librustc_lint/types.rs
@@ -627,7 +627,7 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
         if def.repr.transparent() {
             // Can assume that only one field is not a ZST, so only check
             // that field's type for FFI-safety.
-            if let Some(field) = variant.transparent_newtype_field(self.cx.tcx, self.cx.param_env) {
+            if let Some(field) = variant.transparent_newtype_field(self.cx.tcx) {
                 self.check_field_type_for_ffi(cache, field, substs)
             } else {
                 bug!("malformed transparent type");

--- a/src/librustc_middle/ty/mod.rs
+++ b/src/librustc_middle/ty/mod.rs
@@ -1810,21 +1810,9 @@ impl<'tcx> VariantDef {
 
     /// `repr(transparent)` structs can have a single non-ZST field, this function returns that
     /// field.
-    pub fn transparent_newtype_field(
-        &self,
-        tcx: TyCtxt<'tcx>,
-        param_env: ParamEnv<'tcx>,
-    ) -> Option<&FieldDef> {
+    pub fn transparent_newtype_field(&self, tcx: TyCtxt<'tcx>) -> Option<&FieldDef> {
         for field in &self.fields {
             let field_ty = field.ty(tcx, InternalSubsts::identity_for_item(tcx, self.def_id));
-
-            // `normalize_erasing_regions` will fail for projections that contain generic
-            // parameters, so check these before normalizing.
-            if field_ty.has_projections() && field_ty.needs_subst() {
-                return Some(field);
-            }
-
-            let field_ty = tcx.normalize_erasing_regions(param_env, field_ty);
             if !field_ty.is_zst(tcx, self.def_id) {
                 return Some(field);
             }

--- a/src/test/ui/lint/lint-ctypes-73249-1.rs
+++ b/src/test/ui/lint/lint-ctypes-73249-1.rs
@@ -1,0 +1,21 @@
+// check-pass
+#![deny(improper_ctypes)]
+
+pub trait Foo {
+    type Assoc: 'static;
+}
+
+impl Foo for () {
+    type Assoc = u32;
+}
+
+extern "C" {
+    pub fn lint_me(x: Bar<()>);
+}
+
+#[repr(transparent)]
+pub struct Bar<T: Foo> {
+    value: &'static <T as Foo>::Assoc,
+}
+
+fn main() {}

--- a/src/test/ui/lint/lint-ctypes-73249-2.rs
+++ b/src/test/ui/lint/lint-ctypes-73249-2.rs
@@ -1,0 +1,29 @@
+#![feature(type_alias_impl_trait)]
+#![deny(improper_ctypes)]
+
+pub trait Baz { }
+
+impl Baz for () { }
+
+type Qux = impl Baz;
+
+fn assign() -> Qux {}
+
+pub trait Foo {
+    type Assoc: 'static;
+}
+
+impl Foo for () {
+    type Assoc = Qux;
+}
+
+#[repr(transparent)]
+pub struct A<T: Foo> {
+    x: &'static <T as Foo>::Assoc,
+}
+
+extern "C" {
+    pub fn lint_me() -> A<()>; //~ ERROR: uses type `impl Baz`
+}
+
+fn main() {}

--- a/src/test/ui/lint/lint-ctypes-73249-2.stderr
+++ b/src/test/ui/lint/lint-ctypes-73249-2.stderr
@@ -1,0 +1,15 @@
+error: `extern` block uses type `impl Baz`, which is not FFI-safe
+  --> $DIR/lint-ctypes-73249-2.rs:26:25
+   |
+LL |     pub fn lint_me() -> A<()>;
+   |                         ^^^^^ not FFI-safe
+   |
+note: the lint level is defined here
+  --> $DIR/lint-ctypes-73249-2.rs:2:9
+   |
+LL | #![deny(improper_ctypes)]
+   |         ^^^^^^^^^^^^^^^
+   = note: opaque types have no C equivalent
+
+error: aborting due to previous error
+

--- a/src/test/ui/lint/lint-ctypes-73249-3.rs
+++ b/src/test/ui/lint/lint-ctypes-73249-3.rs
@@ -1,0 +1,21 @@
+#![feature(type_alias_impl_trait)]
+#![deny(improper_ctypes)]
+
+pub trait Baz { }
+
+impl Baz for u32 { }
+
+type Qux = impl Baz;
+
+fn assign() -> Qux { 3 }
+
+#[repr(C)]
+pub struct A {
+    x: Qux,
+}
+
+extern "C" {
+    pub fn lint_me() -> A; //~ ERROR: uses type `impl Baz`
+}
+
+fn main() {}

--- a/src/test/ui/lint/lint-ctypes-73249-3.stderr
+++ b/src/test/ui/lint/lint-ctypes-73249-3.stderr
@@ -1,0 +1,15 @@
+error: `extern` block uses type `impl Baz`, which is not FFI-safe
+  --> $DIR/lint-ctypes-73249-3.rs:18:25
+   |
+LL |     pub fn lint_me() -> A;
+   |                         ^ not FFI-safe
+   |
+note: the lint level is defined here
+  --> $DIR/lint-ctypes-73249-3.rs:2:9
+   |
+LL | #![deny(improper_ctypes)]
+   |         ^^^^^^^^^^^^^^^
+   = note: opaque types have no C equivalent
+
+error: aborting due to previous error
+

--- a/src/test/ui/lint/lint-ctypes-73249-4.rs
+++ b/src/test/ui/lint/lint-ctypes-73249-4.rs
@@ -1,0 +1,24 @@
+// check-pass
+#![deny(improper_ctypes)]
+
+use std::marker::PhantomData;
+
+trait Foo {
+    type Assoc;
+}
+
+impl Foo for () {
+    type Assoc = PhantomData<()>;
+}
+
+#[repr(transparent)]
+struct Wow<T> where T: Foo<Assoc = PhantomData<T>> {
+    x: <T as Foo>::Assoc,
+    v: u32,
+}
+
+extern "C" {
+    fn test(v: Wow<()>);
+}
+
+fn main() {}

--- a/src/test/ui/lint/lint-ctypes-73249-5.rs
+++ b/src/test/ui/lint/lint-ctypes-73249-5.rs
@@ -1,0 +1,21 @@
+#![feature(type_alias_impl_trait)]
+#![deny(improper_ctypes)]
+
+pub trait Baz { }
+
+impl Baz for u32 { }
+
+type Qux = impl Baz;
+
+fn assign() -> Qux { 3 }
+
+#[repr(transparent)]
+pub struct A {
+    x: Qux,
+}
+
+extern "C" {
+    pub fn lint_me() -> A; //~ ERROR: uses type `impl Baz`
+}
+
+fn main() {}

--- a/src/test/ui/lint/lint-ctypes-73249-5.stderr
+++ b/src/test/ui/lint/lint-ctypes-73249-5.stderr
@@ -1,0 +1,15 @@
+error: `extern` block uses type `impl Baz`, which is not FFI-safe
+  --> $DIR/lint-ctypes-73249-5.rs:18:25
+   |
+LL |     pub fn lint_me() -> A;
+   |                         ^ not FFI-safe
+   |
+note: the lint level is defined here
+  --> $DIR/lint-ctypes-73249-5.rs:2:9
+   |
+LL | #![deny(improper_ctypes)]
+   |         ^^^^^^^^^^^^^^^
+   = note: opaque types have no C equivalent
+
+error: aborting due to previous error
+

--- a/src/test/ui/lint/lint-ctypes-73249.rs
+++ b/src/test/ui/lint/lint-ctypes-73249.rs
@@ -1,0 +1,21 @@
+// check-pass
+#![deny(improper_ctypes)]
+
+pub trait Foo {
+    type Assoc;
+}
+
+impl Foo for () {
+    type Assoc = u32;
+}
+
+extern "C" {
+    pub fn lint_me(x: Bar<()>);
+}
+
+#[repr(transparent)]
+pub struct Bar<T: Foo> {
+    value: <T as Foo>::Assoc,
+}
+
+fn main() {}


### PR DESCRIPTION
Fixes #73249.

This PR modifies `transparent_newtype_field` so that it handles
projections with generic parameters, where `normalize_erasing_regions`
would ICE.