### PR TITLE
Revert "Try_run must only be used if toolstate is populated"

### DIFF
--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -553,7 +553,7 @@ impl Step for Clippy {
 
         builder.add_rustc_lib_path(compiler, &mut cargo);
 
-        builder.run(&mut cargo.into());
+        try_run(builder, &mut cargo.into());
     }
 }
 


### PR DESCRIPTION
This reverts commit 6f015768c28a6e4cf163967cb62b70c645791858.

#73097 made a change that appears to have broken toolstate although I can't tell what happened. Let's revert it for now so we get toolstate tracking back and don't ship broken tools.

r? @Mark-Simulacrum @RalfJung @rust-lang/infra 

fixes #73274