### PR TITLE
lint: normalize projections using opaque types

### DIFF
--- a/src/test/ui/lint/lint-ctypes-73251-1.rs
+++ b/src/test/ui/lint/lint-ctypes-73251-1.rs
@@ -1,0 +1,24 @@
+#![feature(type_alias_impl_trait)]
+#![deny(improper_ctypes)]
+
+pub trait Baz { }
+
+impl Baz for u32 { }
+
+type Qux = impl Baz;
+
+pub trait Foo {
+    type Assoc;
+}
+
+impl Foo for u32 {
+    type Assoc = Qux;
+}
+
+fn assign() -> Qux { 1 }
+
+extern "C" {
+    pub fn lint_me() -> <u32 as Foo>::Assoc; //~ ERROR: uses type `impl Baz`
+}
+
+fn main() {}

--- a/src/test/ui/lint/lint-ctypes-73251-1.stderr
+++ b/src/test/ui/lint/lint-ctypes-73251-1.stderr
@@ -1,0 +1,15 @@
+error: `extern` block uses type `impl Baz`, which is not FFI-safe
+  --> $DIR/lint-ctypes-73251-1.rs:21:25
+   |
+LL |     pub fn lint_me() -> <u32 as Foo>::Assoc;
+   |                         ^^^^^^^^^^^^^^^^^^^ not FFI-safe
+   |
+note: the lint level is defined here
+  --> $DIR/lint-ctypes-73251-1.rs:2:9
+   |
+LL | #![deny(improper_ctypes)]
+   |         ^^^^^^^^^^^^^^^
+   = note: opaque types have no C equivalent
+
+error: aborting due to previous error
+

--- a/src/test/ui/lint/lint-ctypes-73251-2.rs
+++ b/src/test/ui/lint/lint-ctypes-73251-2.rs
@@ -1,0 +1,32 @@
+#![feature(type_alias_impl_trait)]
+#![deny(improper_ctypes)]
+
+pub trait TraitA {
+    type Assoc;
+}
+
+impl TraitA for u32 {
+    type Assoc = u32;
+}
+
+pub trait TraitB {
+    type Assoc;
+}
+
+impl<T> TraitB for T where T: TraitA {
+    type Assoc = <T as TraitA>::Assoc;
+}
+
+type AliasA = impl TraitA<Assoc = u32>;
+
+type AliasB = impl TraitB<Assoc = AliasA>;
+
+fn use_of_a() -> AliasA { 3 }
+
+fn use_of_b() -> AliasB { 3 }
+
+extern "C" {
+    pub fn lint_me() -> <AliasB as TraitB>::Assoc; //~ ERROR: uses type `impl TraitA`
+}
+
+fn main() {}

--- a/src/test/ui/lint/lint-ctypes-73251-2.stderr
+++ b/src/test/ui/lint/lint-ctypes-73251-2.stderr
@@ -1,0 +1,15 @@
+error: `extern` block uses type `impl TraitA`, which is not FFI-safe
+  --> $DIR/lint-ctypes-73251-2.rs:29:25
+   |
+LL |     pub fn lint_me() -> <AliasB as TraitB>::Assoc;
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
+   |
+note: the lint level is defined here
+  --> $DIR/lint-ctypes-73251-2.rs:2:9
+   |
+LL | #![deny(improper_ctypes)]
+   |         ^^^^^^^^^^^^^^^
+   = note: opaque types have no C equivalent
+
+error: aborting due to previous error
+

--- a/src/test/ui/lint/lint-ctypes-73251.rs
+++ b/src/test/ui/lint/lint-ctypes-73251.rs
@@ -1,0 +1,22 @@
+// check-pass
+
+#![feature(type_alias_impl_trait)]
+#![deny(improper_ctypes)]
+
+pub trait Foo {
+    type Assoc;
+}
+
+impl Foo for () {
+    type Assoc = u32;
+}
+
+type Bar = impl Foo<Assoc = u32>;
+
+fn assign() -> Bar {}
+
+extern "C" {
+    pub fn lint_me() -> <Bar as Foo>::Assoc;
+}
+
+fn main() {}


### PR DESCRIPTION
Fixes #73251.

This PR normalizes projections which use opaque types (opaque types are otherwise linted against, which is would have previously made the test cases added in this PR fail).