### PR TITLE
Implement crate-level-only lints checking.

### DIFF
--- a/src/librustc_lint/early.rs
+++ b/src/librustc_lint/early.rs
@@ -55,7 +55,8 @@ impl<'a, T: EarlyLintPass> EarlyContextAndPass<'a, T> {
     where
         F: FnOnce(&mut Self),
     {
-        let push = self.context.builder.push(attrs, &self.context.lint_store);
+        let is_crate_node = id == ast::CRATE_NODE_ID;
+        let push = self.context.builder.push(attrs, &self.context.lint_store, is_crate_node);
         self.check_id(id);
         self.enter_attrs(attrs);
         f(self);

--- a/src/librustc_lint/non_ascii_idents.rs
+++ b/src/librustc_lint/non_ascii_idents.rs
@@ -8,20 +8,23 @@ use std::ops::Deref;
 declare_lint! {
     pub NON_ASCII_IDENTS,
     Allow,
-    "detects non-ASCII identifiers"
+    "detects non-ASCII identifiers",
+    crate_level_only
 }
 
 declare_lint! {
     pub UNCOMMON_CODEPOINTS,
     Warn,
-    "detects uncommon Unicode codepoints in identifiers"
+    "detects uncommon Unicode codepoints in identifiers",
+    crate_level_only
 }
 
 // FIXME: Change this to warn.
 declare_lint! {
     pub CONFUSABLE_IDENTS,
     Allow,
-    "detects visually confusable pairs between identifiers"
+    "detects visually confusable pairs between identifiers",
+    crate_level_only
 }
 
 declare_lint_pass!(NonAsciiIdents => [NON_ASCII_IDENTS, UNCOMMON_CODEPOINTS, CONFUSABLE_IDENTS]);

--- a/src/librustc_session/lint.rs
+++ b/src/librustc_session/lint.rs
@@ -88,6 +88,8 @@ pub struct Lint {
 
     /// `Some` if this lint is feature gated, otherwise `None`.
     pub feature_gate: Option<Symbol>,
+
+    pub crate_level_only: bool,
 }
 
 /// Extra information for a future incompatibility lint.
@@ -111,6 +113,7 @@ impl Lint {
             report_in_external_macro: false,
             future_incompatible: None,
             feature_gate: None,
+            crate_level_only: false,
         }
     }
 
@@ -336,6 +339,7 @@ macro_rules! declare_tool_lint {
             future_incompatible: None,
             is_plugin: true,
             feature_gate: None,
+            crate_level_only: false,
         };
     );
 }

--- a/src/librustc_session/lint/builtin.rs
+++ b/src/librustc_session/lint/builtin.rs
@@ -17,6 +17,7 @@ declare_lint! {
         reference: "issue #57571 <https://github.com/rust-lang/rust/issues/57571>",
         edition: None,
     };
+    crate_level_only
 }
 
 declare_lint! {
@@ -75,7 +76,8 @@ declare_lint! {
 declare_lint! {
     pub UNUSED_CRATE_DEPENDENCIES,
     Allow,
-    "crate dependencies that are never used"
+    "crate dependencies that are never used",
+    crate_level_only
 }
 
 declare_lint! {
@@ -166,7 +168,8 @@ declare_lint! {
 declare_lint! {
     pub UNKNOWN_CRATE_TYPES,
     Deny,
-    "unknown crate type found in `#[crate_type]` directive"
+    "unknown crate type found in `#[crate_type]` directive",
+    crate_level_only
 }
 
 declare_lint! {
@@ -339,7 +342,8 @@ declare_lint! {
 declare_lint! {
     pub ELIDED_LIFETIMES_IN_PATHS,
     Allow,
-    "hidden lifetime parameters in types are deprecated"
+    "hidden lifetime parameters in types are deprecated",
+    crate_level_only
 }
 
 declare_lint! {
@@ -459,6 +463,7 @@ declare_lint! {
         reference: "issue #52234 <https://github.com/rust-lang/rust/issues/52234>",
         edition: None,
     };
+    crate_level_only
 }
 
 declare_lint! {

--- a/src/test/ui/issues/issue-48508.rs
+++ b/src/test/ui/issues/issue-48508.rs
@@ -11,7 +11,7 @@
 // ignore-asmjs wasm2js does not support source maps yet
 
 #![feature(non_ascii_idents)]
-#[allow(uncommon_codepoints)]
+#![allow(uncommon_codepoints)]
 
 #[path = "issue-48508-aux.rs"]
 mod other_file;

--- a/src/test/ui/lint/crate_level_only_lint.rs
+++ b/src/test/ui/lint/crate_level_only_lint.rs
@@ -1,0 +1,22 @@
+#![deny(uncommon_codepoints, unused_attributes)]
+
+mod foo {
+#![allow(uncommon_codepoints)]
+//~^ ERROR allow(uncommon_codepoints) is ignored unless specified at crate level [unused_attributes]
+//~| ERROR allow(uncommon_codepoints) is ignored unless specified at crate level [unused_attributes]
+//~| ERROR allow(uncommon_codepoints) is ignored unless specified at crate level [unused_attributes]
+
+#[allow(uncommon_codepoints)]
+//~^ ERROR allow(uncommon_codepoints) is ignored unless specified at crate level [unused_attributes]
+//~| ERROR allow(uncommon_codepoints) is ignored unless specified at crate level [unused_attributes]
+//~| ERROR allow(uncommon_codepoints) is ignored unless specified at crate level [unused_attributes]
+const BAR: f64 = 0.000001;
+
+}
+
+#[allow(uncommon_codepoints)]
+//~^ ERROR allow(uncommon_codepoints) is ignored unless specified at crate level [unused_attributes]
+//~| ERROR allow(uncommon_codepoints) is ignored unless specified at crate level [unused_attributes]
+//~| ERROR allow(uncommon_codepoints) is ignored unless specified at crate level [unused_attributes]
+fn main() {
+}

--- a/src/test/ui/lint/crate_level_only_lint.stderr
+++ b/src/test/ui/lint/crate_level_only_lint.stderr
@@ -1,0 +1,62 @@
+error: allow(uncommon_codepoints) is ignored unless specified at crate level
+  --> $DIR/crate_level_only_lint.rs:4:10
+   |
+LL | #![allow(uncommon_codepoints)]
+   |          ^^^^^^^^^^^^^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/crate_level_only_lint.rs:1:30
+   |
+LL | #![deny(uncommon_codepoints, unused_attributes)]
+   |                              ^^^^^^^^^^^^^^^^^
+
+error: allow(uncommon_codepoints) is ignored unless specified at crate level
+  --> $DIR/crate_level_only_lint.rs:9:9
+   |
+LL | #[allow(uncommon_codepoints)]
+   |         ^^^^^^^^^^^^^^^^^^^
+
+error: allow(uncommon_codepoints) is ignored unless specified at crate level
+  --> $DIR/crate_level_only_lint.rs:17:9
+   |
+LL | #[allow(uncommon_codepoints)]
+   |         ^^^^^^^^^^^^^^^^^^^
+
+error: allow(uncommon_codepoints) is ignored unless specified at crate level
+  --> $DIR/crate_level_only_lint.rs:4:10
+   |
+LL | #![allow(uncommon_codepoints)]
+   |          ^^^^^^^^^^^^^^^^^^^
+
+error: allow(uncommon_codepoints) is ignored unless specified at crate level
+  --> $DIR/crate_level_only_lint.rs:9:9
+   |
+LL | #[allow(uncommon_codepoints)]
+   |         ^^^^^^^^^^^^^^^^^^^
+
+error: allow(uncommon_codepoints) is ignored unless specified at crate level
+  --> $DIR/crate_level_only_lint.rs:17:9
+   |
+LL | #[allow(uncommon_codepoints)]
+   |         ^^^^^^^^^^^^^^^^^^^
+
+error: allow(uncommon_codepoints) is ignored unless specified at crate level
+  --> $DIR/crate_level_only_lint.rs:4:10
+   |
+LL | #![allow(uncommon_codepoints)]
+   |          ^^^^^^^^^^^^^^^^^^^
+
+error: allow(uncommon_codepoints) is ignored unless specified at crate level
+  --> $DIR/crate_level_only_lint.rs:9:9
+   |
+LL | #[allow(uncommon_codepoints)]
+   |         ^^^^^^^^^^^^^^^^^^^
+
+error: allow(uncommon_codepoints) is ignored unless specified at crate level
+  --> $DIR/crate_level_only_lint.rs:17:9
+   |
+LL | #[allow(uncommon_codepoints)]
+   |         ^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 9 previous errors
+


### PR DESCRIPTION
This implements a crate_level_only flag on lints, and when it is true, it becomes an error when user tries  to specify this flag upon nodes other than crate node.

This also turns on this flag for all non_ascii_ident lints.