### PR TITLE
Disallow loading crates with non-ascii identifier name.

### DIFF
--- a/src/librustc_metadata/creader.rs
+++ b/src/librustc_metadata/creader.rs
@@ -452,6 +452,14 @@ impl<'a> CrateLoader<'a> {
         if dep.is_none() {
             self.used_extern_options.insert(name);
         }
+        if !name.as_str().is_ascii() {
+            self.sess
+                .struct_span_err(
+                    span,
+                    &format!("cannot load a crate with a non-ascii name `{}`", name,),
+                )
+                .emit();
+        }
         self.maybe_resolve_crate(name, span, dep_kind, dep).unwrap_or_else(|err| err.report())
     }
 

--- a/src/test/ui/rfc-2457/crate_name_nonascii_forbidden-1.rs
+++ b/src/test/ui/rfc-2457/crate_name_nonascii_forbidden-1.rs
@@ -1,0 +1,6 @@
+#![feature(non_ascii_idents)]
+
+extern crate ьаг; //~ ERROR cannot load a crate with a non-ascii name `ьаг`
+//~| ERROR can't find crate for `ьаг`
+
+fn main() {}

--- a/src/test/ui/rfc-2457/crate_name_nonascii_forbidden-1.stderr
+++ b/src/test/ui/rfc-2457/crate_name_nonascii_forbidden-1.stderr
@@ -1,0 +1,15 @@
+error: cannot load a crate with a non-ascii name `ьаг`
+  --> $DIR/crate_name_nonascii_forbidden-1.rs:3:1
+   |
+LL | extern crate ьаг;
+   | ^^^^^^^^^^^^^^^^^
+
+error[E0463]: can't find crate for `ьаг`
+  --> $DIR/crate_name_nonascii_forbidden-1.rs:3:1
+   |
+LL | extern crate ьаг;
+   | ^^^^^^^^^^^^^^^^^ can't find crate
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0463`.

--- a/src/test/ui/rfc-2457/crate_name_nonascii_forbidden-2.rs
+++ b/src/test/ui/rfc-2457/crate_name_nonascii_forbidden-2.rs
@@ -1,0 +1,9 @@
+// compile-flags:--extern му_сгате
+// edition:2018
+#![feature(non_ascii_idents)]
+
+use му_сгате::baz; //~  ERROR cannot load a crate with a non-ascii name `му_сгате`
+                   //~| can't find crate for `му_сгате`
+
+
+fn main() {}

--- a/src/test/ui/rfc-2457/crate_name_nonascii_forbidden-2.stderr
+++ b/src/test/ui/rfc-2457/crate_name_nonascii_forbidden-2.stderr
@@ -1,0 +1,15 @@
+error: cannot load a crate with a non-ascii name `му_сгате`
+  --> $DIR/crate_name_nonascii_forbidden-2.rs:5:5
+   |
+LL | use му_сгате::baz;
+   |     ^^^^^^^^
+
+error[E0463]: can't find crate for `му_сгате`
+  --> $DIR/crate_name_nonascii_forbidden-2.rs:5:5
+   |
+LL | use му_сгате::baz;
+   |     ^^^^^^^^ can't find crate
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0463`.


### PR DESCRIPTION
This turns off external crate loading with non-ascii identifier names.

cc #55467.