### PR TITLE
pretty/asm.rs should only be tested for x86_64 and not AArch64

### DIFF
--- a/src/test/pretty/asm.pp
+++ b/src/test/pretty/asm.pp
@@ -8,6 +8,7 @@ extern crate std;
 
 // pretty-mode:expanded
 // pp-exact:asm.pp
+// only-x86_64
 
 pub fn main() {
     let a: i32;

--- a/src/test/pretty/asm.rs
+++ b/src/test/pretty/asm.rs
@@ -2,6 +2,7 @@
 
 // pretty-mode:expanded
 // pp-exact:asm.pp
+// only-x86_64
 
 pub fn main() {
     let a: i32;


### PR DESCRIPTION
pretty/asm.rs should only be tested for x86_64 and not AArch64
closes #73134 
r?  @Amanieu 