### PR TITLE
Ignore overflow when finding auto-trait impls in Rustdoc

### DIFF
--- a/src/test/rustdoc/synthetic_auto/overflow.rs
+++ b/src/test/rustdoc/synthetic_auto/overflow.rs
@@ -1,0 +1,35 @@
+// Tests that we don't fail with an overflow error for certain
+// strange types
+// See https://github.com/rust-lang/rust/pull/72936#issuecomment-643676915
+
+pub trait Interner {
+    type InternedType;
+}
+
+struct RustInterner<'tcx> {
+    foo: &'tcx ()
+}
+
+impl<'tcx> Interner for RustInterner<'tcx> {
+    type InternedType = Box<TyData<Self>>;
+}
+
+enum TyData<I: Interner> {
+    FnDef(I::InternedType)
+}
+
+struct VariableKind<I: Interner>(I::InternedType);
+
+// @has overflow/struct.BoundVarsCollector.html
+// @has - '//code' "impl<'tcx> Send for BoundVarsCollector<'tcx>"
+pub struct BoundVarsCollector<'tcx> {
+    val: VariableKind<RustInterner<'tcx>>
+}
+
+fn is_send<T: Send>() {}
+
+struct MyInterner<'tcx> {
+    val: &'tcx ()
+}
+
+fn main() {}


### PR DESCRIPTION
In https://github.com/rust-lang/rust/pull/72936#issuecomment-643686326,
it was determined that some unusual code could cause rustc to overflow
when evaluating a predicate of the form `T: AutoTrait`. Even if this is
a bug, it will still be possible to cause overflow through writing
explicit impls of auto traits, just like any other type of impl.

In rustdoc, this overflow can happen simply as a result of defining
certain types, since we will automatically generate and evaluate
auto-trait predicates when generating documentation.

For now, we just ignore overflow during selection if it occurs in
rustdoc. We should probably come up with a better way to handle this -
e.g. rendering some kind of error in the generated documentation.
However, this is a very unusual corner case, and this PR is sufficient
to unblock landing a Chalk update in PR #72936

This adds additional hacks to `librustc_trait_selection`. The
auto-trait-finding code should probably be completely rewritten, but I
think this is good enough for the time being.