### PR TITLE
Don't run generator transform when there's a TyErr

### DIFF
--- a/src/librustc_mir/transform/generator.rs
+++ b/src/librustc_mir/transform/generator.rs
@@ -1222,7 +1222,11 @@ impl<'tcx> MirPass<'tcx> for StateTransform {
                     movability == hir::Movability::Movable,
                 )
             }
-            _ => bug!(),
+            _ => {
+                tcx.sess
+                    .delay_span_bug(body.span, &format!("unexpected generator type {}", gen_ty));
+                return;
+            }
         };
 
         // Compute GeneratorState<yield_ty, return_ty>


### PR DESCRIPTION
Not sure if this might cause any problems later on, but we shouldn't be hitting codegen or const eval for the produced MIR anyways, so it should be fine.

cc https://github.com/rust-lang/rust/issues/72685#issuecomment-643749020