### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/src/librustc_error_codes/error_codes/E0493.md
+++ b/src/librustc_error_codes/error_codes/E0493.md
@@ -1,5 +1,4 @@
-A type with a `Drop` implementation was destructured when trying to initialize
-a static item.
+A value with a custom `Drop` implementation may be dropped during const-eval.
 
 Erroneous code example:
 
@@ -16,13 +15,14 @@ struct Foo {
     field1: DropType,
 }
 
-static FOO: Foo = Foo { ..Foo { field1: DropType::A } }; // error!
+static FOO: Foo = Foo { field1: (DropType::A, DropType::A).1 }; // error!
 ```
 
 The problem here is that if the given type or one of its fields implements the
-`Drop` trait, this `Drop` implementation cannot be called during the static
-type initialization which might cause a memory leak. To prevent this issue,
-you need to instantiate all the static type's fields by hand.
+`Drop` trait, this `Drop` implementation cannot be called within a const
+context since it may run arbitrary, non-const-checked code. To prevent this
+issue, ensure all values with custom a custom `Drop` implementation escape the
+initializer.
 
 ```
 enum DropType {

--- a/src/librustc_errors/diagnostic.rs
+++ b/src/librustc_errors/diagnostic.rs
@@ -296,6 +296,29 @@ impl Diagnostic {
         self
     }
 
+    pub fn multipart_suggestions(
+        &mut self,
+        msg: &str,
+        suggestions: Vec<Vec<(Span, String)>>,
+        applicability: Applicability,
+    ) -> &mut Self {
+        self.suggestions.push(CodeSuggestion {
+            substitutions: suggestions
+                .into_iter()
+                .map(|suggestion| Substitution {
+                    parts: suggestion
+                        .into_iter()
+                        .map(|(span, snippet)| SubstitutionPart { snippet, span })
+                        .collect(),
+                })
+                .collect(),
+            msg: msg.to_owned(),
+            style: SuggestionStyle::ShowCode,
+            applicability,
+        });
+        self
+    }
+
     /// Prints out a message with for a multipart suggestion without showing the suggested code.
     ///
     /// This is intended to be used for suggestions that are obvious in what the changes need to

--- a/src/librustc_errors/diagnostic_builder.rs
+++ b/src/librustc_errors/diagnostic_builder.rs
@@ -260,6 +260,19 @@ impl<'a> DiagnosticBuilder<'a> {
         self
     }
 
+    pub fn multipart_suggestions(
+        &mut self,
+        msg: &str,
+        suggestions: Vec<Vec<(Span, String)>>,
+        applicability: Applicability,
+    ) -> &mut Self {
+        if !self.0.allow_suggestions {
+            return self;
+        }
+        self.0.diagnostic.multipart_suggestions(msg, suggestions, applicability);
+        self
+    }
+
     pub fn tool_only_multipart_suggestion(
         &mut self,
         msg: &str,

--- a/src/librustc_feature/active.rs
+++ b/src/librustc_feature/active.rs
@@ -577,6 +577,9 @@ declare_features! (
     /// Allows `extern "avr-interrupt" fn()` and `extern "avr-non-blocking-interrupt" fn()`.
     (active, abi_avr_interrupt, "1.45.0", Some(69664), None),
 
+    /// Be more precise when looking for live drops in a const context.
+    (active, const_precise_live_drops, "1.46.0", Some(73255), None),
+
     // -------------------------------------------------------------------------
     // feature-group-end: actual feature gates
     // -------------------------------------------------------------------------

--- a/src/librustc_interface/passes.rs
+++ b/src/librustc_interface/passes.rs
@@ -847,7 +847,11 @@ fn analysis(tcx: TyCtxt<'_>, cnum: CrateNum) -> Result<()> {
 
     sess.time("MIR_effect_checking", || {
         for def_id in tcx.body_owners() {
-            mir::transform::check_unsafety::check_unsafety(tcx, def_id)
+            mir::transform::check_unsafety::check_unsafety(tcx, def_id);
+
+            if tcx.hir().body_const_context(def_id).is_some() {
+                tcx.ensure().mir_drops_elaborated_and_const_checked(def_id);
+            }
         }
     });
 

--- a/src/librustc_lint/types.rs
+++ b/src/librustc_lint/types.rs
@@ -927,22 +927,33 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
     fn check_for_opaque_ty(&mut self, sp: Span, ty: Ty<'tcx>) -> bool {
         use rustc_middle::ty::TypeFoldable;
 
-        struct ProhibitOpaqueTypes<'tcx> {
+        struct ProhibitOpaqueTypes<'a, 'tcx> {
+            cx: &'a LateContext<'a, 'tcx>,
             ty: Option<Ty<'tcx>>,
         };
 
-        impl<'tcx> ty::fold::TypeVisitor<'tcx> for ProhibitOpaqueTypes<'tcx> {
+        impl<'a, 'tcx> ty::fold::TypeVisitor<'tcx> for ProhibitOpaqueTypes<'a, 'tcx> {
             fn visit_ty(&mut self, ty: Ty<'tcx>) -> bool {
-                if let ty::Opaque(..) = ty.kind {
-                    self.ty = Some(ty);
-                    true
-                } else {
-                    ty.super_visit_with(self)
+                match ty.kind {
+                    ty::Opaque(..) => {
+                        self.ty = Some(ty);
+                        true
+                    }
+                    // Consider opaque types within projections FFI-safe if they do not normalize
+                    // to more opaque types.
+                    ty::Projection(..) => {
+                        let ty = self.cx.tcx.normalize_erasing_regions(self.cx.param_env, ty);
+
+                        // If `ty` is a opaque type directly then `super_visit_with` won't invoke
+                        // this function again.
+                        if ty.has_opaque_types() { self.visit_ty(ty) } else { false }
+                    }
+                    _ => ty.super_visit_with(self),
                 }
             }
         }
 
-        let mut visitor = ProhibitOpaqueTypes { ty: None };
+        let mut visitor = ProhibitOpaqueTypes { cx: self.cx, ty: None };
         ty.visit_with(&mut visitor);
         if let Some(ty) = visitor.ty {
             self.emit_ffi_unsafe_type_lint(ty, sp, "opaque types have no C equivalent", None);

--- a/src/librustc_middle/mir/mod.rs
+++ b/src/librustc_middle/mir/mod.rs
@@ -76,7 +76,8 @@ pub enum MirPhase {
     Build = 0,
     Const = 1,
     Validated = 2,
-    Optimized = 3,
+    DropElab = 3,
+    Optimized = 4,
 }
 
 impl MirPhase {

--- a/src/librustc_middle/query/mod.rs
+++ b/src/librustc_middle/query/mod.rs
@@ -190,6 +190,12 @@ rustc_queries! {
             no_hash
         }
 
+        query mir_drops_elaborated_and_const_checked(key: LocalDefId) -> Steal<mir::Body<'tcx>> {
+            storage(ArenaCacheSelector<'tcx>)
+            no_hash
+            desc { |tcx| "elaborating drops for `{}`", tcx.def_path_str(key.to_def_id()) }
+        }
+
         query mir_validated(key: LocalDefId) ->
             (
                 Steal<mir::Body<'tcx>>,

--- a/src/librustc_middle/ty/util.rs
+++ b/src/librustc_middle/ty/util.rs
@@ -827,7 +827,15 @@ impl<'tcx> ty::TyS<'tcx> {
                     // Find non representable fields with their spans
                     fold_repr(def.all_fields().map(|field| {
                         let ty = field.ty(tcx, substs);
-                        let span = tcx.hir().span_if_local(field.did).unwrap_or(sp);
+                        let span = match field
+                            .did
+                            .as_local()
+                            .map(|id| tcx.hir().as_local_hir_id(id))
+                            .and_then(|id| tcx.hir().find(id))
+                        {
+                            Some(hir::Node::Field(field)) => field.ty.span,
+                            _ => sp,
+                        };
                         match is_type_structurally_recursive(
                             tcx,
                             span,

--- a/src/librustc_mir/transform/check_consts/mod.rs
+++ b/src/librustc_mir/transform/check_consts/mod.rs
@@ -12,6 +12,7 @@ use rustc_middle::ty::{self, TyCtxt};
 pub use self::qualifs::Qualif;
 
 mod ops;
+pub mod post_drop_elaboration;
 pub mod qualifs;
 mod resolver;
 pub mod validation;

--- a/src/librustc_mir/transform/check_consts/post_drop_elaboration.rs
+++ b/src/librustc_mir/transform/check_consts/post_drop_elaboration.rs
@@ -1,0 +1,119 @@
+use rustc_hir::def_id::LocalDefId;
+use rustc_middle::mir::visit::Visitor;
+use rustc_middle::mir::{self, BasicBlock, Location};
+use rustc_middle::ty::TyCtxt;
+use rustc_span::Span;
+
+use super::ops;
+use super::qualifs::{NeedsDrop, Qualif};
+use super::validation::Qualifs;
+use super::ConstCx;
+
+/// Returns `true` if we should use the more precise live drop checker that runs after drop
+/// elaboration.
+pub fn checking_enabled(tcx: TyCtxt<'tcx>) -> bool {
+    tcx.features().const_precise_live_drops
+}
+
+/// Look for live drops in a const context.
+///
+/// This is separate from the rest of the const checking logic because it must run after drop
+/// elaboration.
+pub fn check_live_drops(tcx: TyCtxt<'tcx>, def_id: LocalDefId, body: &mir::Body<'tcx>) {
+    let const_kind = tcx.hir().body_const_context(def_id);
+    if const_kind.is_none() {
+        return;
+    }
+
+    if !checking_enabled(tcx) {
+        return;
+    }
+
+    let ccx = ConstCx {
+        body,
+        tcx,
+        def_id: def_id.to_def_id(),
+        const_kind,
+        param_env: tcx.param_env(def_id),
+    };
+
+    let mut visitor = CheckLiveDrops { ccx: &ccx, qualifs: Qualifs::default() };
+
+    visitor.visit_body(body);
+}
+
+struct CheckLiveDrops<'mir, 'tcx> {
+    ccx: &'mir ConstCx<'mir, 'tcx>,
+    qualifs: Qualifs<'mir, 'tcx>,
+}
+
+// So we can access `body` and `tcx`.
+impl std::ops::Deref for CheckLiveDrops<'mir, 'tcx> {
+    type Target = ConstCx<'mir, 'tcx>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.ccx
+    }
+}
+
+impl CheckLiveDrops<'mir, 'tcx> {
+    fn check_live_drop(&self, span: Span) {
+        ops::non_const(self.ccx, ops::LiveDrop, span);
+    }
+}
+
+impl Visitor<'tcx> for CheckLiveDrops<'mir, 'tcx> {
+    fn visit_basic_block_data(&mut self, bb: BasicBlock, block: &mir::BasicBlockData<'tcx>) {
+        trace!("visit_basic_block_data: bb={:?} is_cleanup={:?}", bb, block.is_cleanup);
+
+        // Ignore drop terminators in cleanup blocks.
+        if block.is_cleanup {
+            return;
+        }
+
+        self.super_basic_block_data(bb, block);
+    }
+
+    fn visit_terminator(&mut self, terminator: &mir::Terminator<'tcx>, location: Location) {
+        trace!("visit_terminator: terminator={:?} location={:?}", terminator, location);
+
+        match &terminator.kind {
+            mir::TerminatorKind::Drop { location: dropped_place, .. } => {
+                let dropped_ty = dropped_place.ty(self.body, self.tcx).ty;
+                if !NeedsDrop::in_any_value_of_ty(self.ccx, dropped_ty) {
+                    return;
+                }
+
+                if dropped_place.is_indirect() {
+                    self.check_live_drop(terminator.source_info.span);
+                    return;
+                }
+
+                if self.qualifs.needs_drop(self.ccx, dropped_place.local, location) {
+                    // Use the span where the dropped local was declared for the error.
+                    let span = self.body.local_decls[dropped_place.local].source_info.span;
+                    self.check_live_drop(span);
+                }
+            }
+
+            mir::TerminatorKind::DropAndReplace { .. } => span_bug!(
+                terminator.source_info.span,
+                "`DropAndReplace` should be removed by drop elaboration",
+            ),
+
+            mir::TerminatorKind::Abort
+            | mir::TerminatorKind::Call { .. }
+            | mir::TerminatorKind::Assert { .. }
+            | mir::TerminatorKind::FalseEdge { .. }
+            | mir::TerminatorKind::FalseUnwind { .. }
+            | mir::TerminatorKind::GeneratorDrop
+            | mir::TerminatorKind::Goto { .. }
+            | mir::TerminatorKind::InlineAsm { .. }
+            | mir::TerminatorKind::Resume
+            | mir::TerminatorKind::Return
+            | mir::TerminatorKind::SwitchInt { .. }
+            | mir::TerminatorKind::Unreachable
+            | mir::TerminatorKind::Yield { .. } => {}
+        }
+    }
+}

--- a/src/librustc_mir/transform/check_consts/validation.rs
+++ b/src/librustc_mir/transform/check_consts/validation.rs
@@ -562,6 +562,12 @@ impl Visitor<'tcx> for Validator<'mir, 'tcx> {
             // projections that cannot be `NeedsDrop`.
             TerminatorKind::Drop { location: dropped_place, .. }
             | TerminatorKind::DropAndReplace { location: dropped_place, .. } => {
+                // If we are checking live drops after drop-elaboration, don't emit duplicate
+                // errors here.
+                if super::post_drop_elaboration::checking_enabled(self.tcx) {
+                    return;
+                }
+
                 let mut err_span = self.span;
 
                 // Check to see if the type of this place can ever have a drop impl. If not, this

--- a/src/librustc_mir/transform/check_consts/validation.rs
+++ b/src/librustc_mir/transform/check_consts/validation.rs
@@ -40,7 +40,7 @@ pub struct Qualifs<'mir, 'tcx> {
 }
 
 impl Qualifs<'mir, 'tcx> {
-    fn indirectly_mutable(
+    pub fn indirectly_mutable(
         &mut self,
         ccx: &'mir ConstCx<'mir, 'tcx>,
         local: Local,
@@ -68,7 +68,7 @@ impl Qualifs<'mir, 'tcx> {
     /// Returns `true` if `local` is `NeedsDrop` at the given `Location`.
     ///
     /// Only updates the cursor if absolutely necessary
-    fn needs_drop(
+    pub fn needs_drop(
         &mut self,
         ccx: &'mir ConstCx<'mir, 'tcx>,
         local: Local,
@@ -95,7 +95,7 @@ impl Qualifs<'mir, 'tcx> {
     /// Returns `true` if `local` is `HasMutInterior` at the given `Location`.
     ///
     /// Only updates the cursor if absolutely necessary.
-    fn has_mut_interior(
+    pub fn has_mut_interior(
         &mut self,
         ccx: &'mir ConstCx<'mir, 'tcx>,
         local: Local,

--- a/src/librustc_mir/transform/check_consts/validation.rs
+++ b/src/librustc_mir/transform/check_consts/validation.rs
@@ -232,30 +232,15 @@ impl Validator<'mir, 'tcx> {
         self.qualifs.in_return_place(self.ccx)
     }
 
-    /// Emits an error at the given `span` if an expression cannot be evaluated in the current
-    /// context.
-    pub fn check_op_spanned<O>(&mut self, op: O, span: Span)
-    where
-        O: NonConstOp,
-    {
-        debug!("check_op: op={:?}", op);
-
-        if op.is_allowed_in_item(self) {
-            return;
-        }
-
-        if self.tcx.sess.opts.debugging_opts.unleash_the_miri_inside_of_you {
-            self.tcx.sess.miri_unleashed_feature(span, O::feature_gate());
-            return;
-        }
-
-        op.emit_error(self, span);
-    }
-
     /// Emits an error if an expression cannot be evaluated in the current context.
     pub fn check_op(&mut self, op: impl NonConstOp) {
-        let span = self.span;
-        self.check_op_spanned(op, span)
+        ops::non_const(self.ccx, op, self.span);
+    }
+
+    /// Emits an error at the given `span` if an expression cannot be evaluated in the current
+    /// context.
+    pub fn check_op_spanned(&mut self, op: impl NonConstOp, span: Span) {
+        ops::non_const(self.ccx, op, span);
     }
 
     fn check_static(&mut self, def_id: DefId, span: Span) {

--- a/src/librustc_mir/transform/mod.rs
+++ b/src/librustc_mir/transform/mod.rs
@@ -49,6 +49,7 @@ pub(crate) fn provide(providers: &mut Providers<'_>) {
         mir_const,
         mir_const_qualif,
         mir_validated,
+        mir_drops_elaborated_and_const_checked,
         optimized_mir,
         is_mir_available,
         promoted_mir,
@@ -294,12 +295,31 @@ fn mir_validated(
     (tcx.alloc_steal_mir(body), tcx.alloc_steal_promoted(promoted))
 }
 
-fn run_optimization_passes<'tcx>(
+fn mir_drops_elaborated_and_const_checked<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    def_id: LocalDefId,
+) -> Steal<Body<'tcx>> {
+    // (Mir-)Borrowck uses `mir_validated`, so we have to force it to
+    // execute before we can steal.
+    tcx.ensure().mir_borrowck(def_id);
+
+    let (body, _) = tcx.mir_validated(def_id);
+    let mut body = body.steal();
+
+    run_post_borrowck_cleanup_passes(tcx, &mut body, def_id, None);
+    check_consts::post_drop_elaboration::check_live_drops(tcx, def_id, &body);
+    tcx.alloc_steal_mir(body)
+}
+
+/// After this series of passes, no lifetime analysis based on borrowing can be done.
+fn run_post_borrowck_cleanup_passes<'tcx>(
     tcx: TyCtxt<'tcx>,
     body: &mut Body<'tcx>,
     def_id: LocalDefId,
     promoted: Option<Promoted>,
 ) {
+    debug!("post_borrowck_cleanup({:?})", def_id);
+
     let post_borrowck_cleanup: &[&dyn MirPass<'tcx>] = &[
         // Remove all things only needed by analysis
         &no_landing_pads::NoLandingPads::new(tcx),
@@ -318,9 +338,24 @@ fn run_optimization_passes<'tcx>(
         // but before optimizations begin.
         &add_retag::AddRetag,
         &simplify::SimplifyCfg::new("elaborate-drops"),
-        // No lifetime analysis based on borrowing can be done from here on out.
     ];
 
+    run_passes(
+        tcx,
+        body,
+        InstanceDef::Item(def_id.to_def_id()),
+        promoted,
+        MirPhase::DropElab,
+        &[post_borrowck_cleanup],
+    );
+}
+
+fn run_optimization_passes<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    body: &mut Body<'tcx>,
+    def_id: LocalDefId,
+    promoted: Option<Promoted>,
+) {
     let optimizations: &[&dyn MirPass<'tcx>] = &[
         &unreachable_prop::UnreachablePropagation,
         &uninhabited_enum_branching::UninhabitedEnumBranching,
@@ -368,6 +403,7 @@ fn run_optimization_passes<'tcx>(
 
     let mir_opt_level = tcx.sess.opts.debugging_opts.mir_opt_level;
 
+    #[rustfmt::skip]
     run_passes(
         tcx,
         body,
@@ -375,7 +411,6 @@ fn run_optimization_passes<'tcx>(
         promoted,
         MirPhase::Optimized,
         &[
-            post_borrowck_cleanup,
             if mir_opt_level > 0 { optimizations } else { no_optimizations },
             pre_codegen_cleanup,
         ],
@@ -393,12 +428,7 @@ fn optimized_mir(tcx: TyCtxt<'_>, def_id: DefId) -> Body<'_> {
 
     let def_id = def_id.expect_local();
 
-    // (Mir-)Borrowck uses `mir_validated`, so we have to force it to
-    // execute before we can steal.
-    tcx.ensure().mir_borrowck(def_id);
-
-    let (body, _) = tcx.mir_validated(def_id);
-    let mut body = body.steal();
+    let mut body = tcx.mir_drops_elaborated_and_const_checked(def_id).steal();
     run_optimization_passes(tcx, &mut body, def_id, None);
 
     debug_assert!(!body.has_free_regions(), "Free regions in optimized MIR");
@@ -418,6 +448,7 @@ fn promoted_mir(tcx: TyCtxt<'_>, def_id: DefId) -> IndexVec<Promoted, Body<'_>> 
     let mut promoted = promoted.steal();
 
     for (p, mut body) in promoted.iter_enumerated_mut() {
+        run_post_borrowck_cleanup_passes(tcx, &mut body, def_id, Some(p));
         run_optimization_passes(tcx, &mut body, def_id, Some(p));
     }
 

--- a/src/librustc_span/symbol.rs
+++ b/src/librustc_span/symbol.rs
@@ -227,6 +227,7 @@ symbols! {
         const_loop,
         const_mut_refs,
         const_panic,
+        const_precise_live_drops,
         const_raw_ptr_deref,
         const_raw_ptr_to_usize_cast,
         const_transmute,

--- a/src/librustc_trait_selection/traits/error_reporting/mod.rs
+++ b/src/librustc_trait_selection/traits/error_reporting/mod.rs
@@ -1747,24 +1747,62 @@ impl<'a, 'tcx> InferCtxtPrivExt<'tcx> for InferCtxt<'a, 'tcx> {
 pub fn recursive_type_with_infinite_size_error(
     tcx: TyCtxt<'tcx>,
     type_def_id: DefId,
-) -> DiagnosticBuilder<'tcx> {
+    spans: Vec<Span>,
+) {
     assert!(type_def_id.is_local());
     let span = tcx.hir().span_if_local(type_def_id).unwrap();
     let span = tcx.sess.source_map().guess_head_span(span);
-    let mut err = struct_span_err!(
-        tcx.sess,
-        span,
-        E0072,
-        "recursive type `{}` has infinite size",
-        tcx.def_path_str(type_def_id)
-    );
+    let path = tcx.def_path_str(type_def_id);
+    let mut err =
+        struct_span_err!(tcx.sess, span, E0072, "recursive type `{}` has infinite size", path);
     err.span_label(span, "recursive type has infinite size");
-    err.help(&format!(
-        "insert indirection (e.g., a `Box`, `Rc`, or `&`) \
-                           at some point to make `{}` representable",
-        tcx.def_path_str(type_def_id)
-    ));
-    err
+    for &span in &spans {
+        err.span_label(span, "recursive without indirection");
+    }
+    let short_msg = format!("insert some indirection to make `{}` representable", path);
+    let msg = format!(
+        "insert some indirection (e.g., a `Box`, `Rc`, or `&`) to make `{}` representable",
+        path,
+    );
+    match &spans[..] {
+        [span] => {
+            err.multipart_suggestions(
+                &short_msg,
+                vec![
+                    vec![
+                        (span.shrink_to_lo(), "Box<".to_string()),
+                        (span.shrink_to_hi(), ">".to_string()),
+                    ],
+                    vec![
+                        (span.shrink_to_lo(), "Rc<".to_string()),
+                        (span.shrink_to_hi(), ">".to_string()),
+                    ],
+                    vec![(span.shrink_to_lo(), "&".to_string())],
+                ],
+                Applicability::HasPlaceholders,
+            );
+        }
+        _ if spans.len() <= 4 => {
+            err.multipart_suggestion(
+                &msg,
+                spans
+                    .iter()
+                    .flat_map(|&span| {
+                        vec![
+                            (span.shrink_to_lo(), "Box<".to_string()),
+                            (span.shrink_to_hi(), ">".to_string()),
+                        ]
+                        .into_iter()
+                    })
+                    .collect(),
+                Applicability::HasPlaceholders,
+            );
+        }
+        _ => {
+            err.help(&msg);
+        }
+    }
+    err.emit();
 }
 
 /// Summarizes information

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -2390,11 +2390,7 @@ fn check_representable(tcx: TyCtxt<'_>, sp: Span, item_def_id: LocalDefId) -> bo
     // caught by case 1.
     match rty.is_representable(tcx, sp) {
         Representability::SelfRecursive(spans) => {
-            let mut err = recursive_type_with_infinite_size_error(tcx, item_def_id.to_def_id());
-            for span in spans {
-                err.span_label(span, "recursive without indirection");
-            }
-            err.emit();
+            recursive_type_with_infinite_size_error(tcx, item_def_id.to_def_id(), spans);
             return false;
         }
         Representability::Representable | Representability::ContainsRecursive => (),

--- a/src/libstd/net/addr.rs
+++ b/src/libstd/net/addr.rs
@@ -1228,5 +1228,10 @@ mod tests {
         assert!(v6_1 < v6_3);
         assert!(v4_3 > v4_1);
         assert!(v6_3 > v6_1);
+
+        // compare with an inferred right-hand side
+        assert_eq!(v4_1, "224.120.45.1:23456".parse().unwrap());
+        assert_eq!(v6_1, "[2001:db8:f00::1002]:23456".parse().unwrap());
+        assert_eq!(SocketAddr::V4(v4_1), "224.120.45.1:23456".parse().unwrap());
     }
 }

--- a/src/libstd/net/addr.rs
+++ b/src/libstd/net/addr.rs
@@ -694,42 +694,6 @@ impl PartialEq for SocketAddrV6 {
             && self.inner.sin6_scope_id == other.inner.sin6_scope_id
     }
 }
-#[stable(feature = "socketaddr_ordering", since = "1.45.0")]
-impl PartialEq<SocketAddrV4> for SocketAddr {
-    fn eq(&self, other: &SocketAddrV4) -> bool {
-        match self {
-            SocketAddr::V4(v4) => v4 == other,
-            SocketAddr::V6(_) => false,
-        }
-    }
-}
-#[stable(feature = "socketaddr_ordering", since = "1.45.0")]
-impl PartialEq<SocketAddrV6> for SocketAddr {
-    fn eq(&self, other: &SocketAddrV6) -> bool {
-        match self {
-            SocketAddr::V4(_) => false,
-            SocketAddr::V6(v6) => v6 == other,
-        }
-    }
-}
-#[stable(feature = "socketaddr_ordering", since = "1.45.0")]
-impl PartialEq<SocketAddr> for SocketAddrV4 {
-    fn eq(&self, other: &SocketAddr) -> bool {
-        match other {
-            SocketAddr::V4(v4) => self == v4,
-            SocketAddr::V6(_) => false,
-        }
-    }
-}
-#[stable(feature = "socketaddr_ordering", since = "1.45.0")]
-impl PartialEq<SocketAddr> for SocketAddrV6 {
-    fn eq(&self, other: &SocketAddr) -> bool {
-        match other {
-            SocketAddr::V4(_) => false,
-            SocketAddr::V6(v6) => self == v6,
-        }
-    }
-}
 #[stable(feature = "rust1", since = "1.0.0")]
 impl Eq for SocketAddrV4 {}
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -1242,12 +1206,8 @@ mod tests {
         // equality
         assert_eq!(v4_1, v4_1);
         assert_eq!(v6_1, v6_1);
-        assert_eq!(v4_1, SocketAddr::V4(v4_1));
-        assert_eq!(v6_1, SocketAddr::V6(v6_1));
         assert_eq!(SocketAddr::V4(v4_1), SocketAddr::V4(v4_1));
         assert_eq!(SocketAddr::V6(v6_1), SocketAddr::V6(v6_1));
-        assert!(v4_1 != SocketAddr::V6(v6_1));
-        assert!(v6_1 != SocketAddr::V4(v4_1));
         assert!(v4_1 != v4_2);
         assert!(v6_1 != v6_2);
 

--- a/src/libstd/sync/mutex.rs
+++ b/src/libstd/sync/mutex.rs
@@ -108,8 +108,8 @@ use crate::sys_common::poison::{self, LockResult, TryLockError, TryLockResult};
 /// *guard += 1;
 /// ```
 ///
-/// It is sometimes a good idea (or even necessary) to manually drop the mutex
-/// to unlock it as soon as possible. If you need the resource until the end of
+/// It is sometimes necessary to manually drop the mutex
+/// guard to unlock it as soon as possible. If you need the resource until the end of
 /// the scope, this is not needed.
 ///
 /// ```
@@ -140,16 +140,16 @@ use crate::sys_common::poison::{self, LockResult, TryLockError, TryLockResult};
 /// // This is the result of some important and long-ish work.
 /// let result = data.iter().fold(0, |acc, x| acc + x * 2);
 /// data.push(result);
-/// // We drop the `data` explicitely because it's not necessary anymore
+/// // We drop the `data` explicitly because it's not necessary anymore
 /// // and the thread still has work to do. This allow other threads to
 /// // start working on the data immediately, without waiting
 /// // for the rest of the unrelated work to be done here.
 /// //
 /// // It's even more important here than in the threads because we `.join` the
-/// // threads after that. If we had not dropped the lock, a thread could be
+/// // threads after that. If we had not dropped the mutex guard, a thread could be
 /// // waiting forever for it, causing a deadlock.
 /// drop(data);
-/// // Here the lock is not assigned to a variable and so, even if the scope
+/// // Here the mutex guard is not assigned to a variable and so, even if the scope
 /// // does not end after this line, the mutex is still released:
 /// // there is no deadlock.
 /// *res_mutex.lock().unwrap() += result;

--- a/src/libstd/sync/mutex.rs
+++ b/src/libstd/sync/mutex.rs
@@ -118,15 +118,11 @@ use crate::sys_common::poison::{self, LockResult, TryLockError, TryLockResult};
 ///
 /// const N: usize = 3;
 ///
-/// // Some data to work with in multiple threads.
 /// let data_mutex = Arc::new(Mutex::new(vec![1, 2, 3, 4]));
-/// // The result of all the work across all threads.
 /// let res_mutex = Arc::new(Mutex::new(0));
 ///
-/// // Threads other than the main thread.
 /// let mut threads = Vec::with_capacity(N);
 /// (0..N).for_each(|_| {
-///     // Getting clones for the mutexes.
 ///     let data_mutex_clone = Arc::clone(&data_mutex);
 ///     let res_mutex_clone = Arc::clone(&res_mutex);
 ///
@@ -135,10 +131,6 @@ use crate::sys_common::poison::{self, LockResult, TryLockError, TryLockResult};
 ///         // This is the result of some important and long-ish work.
 ///         let result = data.iter().fold(0, |acc, x| acc + x * 2);
 ///         data.push(result);
-///         // We drop the `data` explicitely because it's not necessary anymore
-///         // and the thread still has work to do. This allow other threads to
-///         // start working on the data immediately, without waiting
-///         // for the rest of the unrelated work to be done here.
 ///         drop(data);
 ///         *res_mutex_clone.lock().unwrap() += result;
 ///     }));
@@ -153,9 +145,9 @@ use crate::sys_common::poison::{self, LockResult, TryLockError, TryLockResult};
 /// // start working on the data immediately, without waiting
 /// // for the rest of the unrelated work to be done here.
 /// //
-/// // It's even more important here because we `.join` the threads after that.
-/// // If we had not dropped the lock, a thread could be waiting forever for
-/// // it, causing a deadlock.
+/// // It's even more important here than in the threads because we `.join` the
+/// // threads after that. If we had not dropped the lock, a thread could be
+/// // waiting forever for it, causing a deadlock.
 /// drop(data);
 /// // Here the lock is not assigned to a variable and so, even if the scope
 /// // does not end after this line, the mutex is still released:

--- a/src/libstd/sync/mutex.rs
+++ b/src/libstd/sync/mutex.rs
@@ -139,7 +139,7 @@ use crate::sys_common::poison::{self, LockResult, TryLockError, TryLockResult};
 ///         // and the thread still has work to do. This allow other threads to
 ///         // start working on the data immediately, without waiting
 ///         // for the rest of the unrelated work to be done here.
-///         std::mem::drop(data);
+///         drop(data);
 ///         *res_mutex_clone.lock().unwrap() += result;
 ///     }));
 /// });
@@ -156,7 +156,7 @@ use crate::sys_common::poison::{self, LockResult, TryLockError, TryLockResult};
 /// // It's even more important here because we `.join` the threads after that.
 /// // If we had not dropped the lock, a thread could be waiting forever for
 /// // it, causing a deadlock.
-/// std::mem::drop(data);
+/// drop(data);
 /// // Here the lock is not assigned to a variable and so, even if the scope
 /// // does not end after this line, the mutex is still released:
 /// // there is no deadlock.

--- a/src/libstd/sync/mutex.rs
+++ b/src/libstd/sync/mutex.rs
@@ -119,7 +119,7 @@ use crate::sys_common::poison::{self, LockResult, TryLockError, TryLockResult};
 /// const N: usize = 3;
 ///
 /// // Some data to work with in multiple threads.
-/// let data_mutex = Arc::new(Mutex::new([1, 2, 3, 4]));
+/// let data_mutex = Arc::new(Mutex::new(vec![1, 2, 3, 4]));
 /// // The result of all the work across all threads.
 /// let res_mutex = Arc::new(Mutex::new(0));
 ///
@@ -131,9 +131,10 @@ use crate::sys_common::poison::{self, LockResult, TryLockError, TryLockResult};
 ///     let res_mutex_clone = Arc::clone(&res_mutex);
 ///
 ///     threads.push(thread::spawn(move || {
-///         let data = *data_mutex_clone.lock().unwrap();
+///         let mut data = data_mutex_clone.lock().unwrap();
 ///         // This is the result of some important and long-ish work.
 ///         let result = data.iter().fold(0, |acc, x| acc + x * 2);
+///         data.push(result);
 ///         // We drop the `data` explicitely because it's not necessary anymore
 ///         // and the thread still has work to do. This allow other threads to
 ///         // start working on the data immediately, without waiting
@@ -143,9 +144,10 @@ use crate::sys_common::poison::{self, LockResult, TryLockError, TryLockResult};
 ///     }));
 /// });
 ///
-/// let data = *data_mutex.lock().unwrap();
+/// let mut data = data_mutex.lock().unwrap();
 /// // This is the result of some important and long-ish work.
 /// let result = data.iter().fold(0, |acc, x| acc + x * 2);
+/// data.push(result);
 /// // We drop the `data` explicitely because it's not necessary anymore
 /// // and the thread still has work to do. This allow other threads to
 /// // start working on the data immediately, without waiting
@@ -166,7 +168,7 @@ use crate::sys_common::poison::{self, LockResult, TryLockError, TryLockResult};
 ///         .expect("The thread creating or execution failed !")
 /// });
 ///
-/// assert_eq!(*res_mutex.lock().unwrap(), 80);
+/// assert_eq!(*res_mutex.lock().unwrap(), 800);
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 #[cfg_attr(not(test), rustc_diagnostic_item = "mutex_type")]

--- a/src/libstd/sync/mutex.rs
+++ b/src/libstd/sync/mutex.rs
@@ -108,8 +108,8 @@ use crate::sys_common::poison::{self, LockResult, TryLockError, TryLockResult};
 /// *guard += 1;
 /// ```
 ///
-/// It is sometimes necessary to manually drop the mutex guard
-/// to unlock it sooner than the end of the enclosing scope.
+/// It is sometimes necessary to manually drop the mutex guard to unlock it
+/// sooner than the end of the enclosing scope.
 ///
 /// ```
 /// use std::sync::{Arc, Mutex};
@@ -139,18 +139,18 @@ use crate::sys_common::poison::{self, LockResult, TryLockError, TryLockResult};
 /// // This is the result of some important and long-ish work.
 /// let result = data.iter().fold(0, |acc, x| acc + x * 2);
 /// data.push(result);
-/// // We drop the `data` explicitly because it's not necessary anymore
-/// // and the thread still has work to do. This allow other threads to
-/// // start working on the data immediately, without waiting
-/// // for the rest of the unrelated work to be done here.
+/// // We drop the `data` explicitly because it's not necessary anymore and the
+/// // thread still has work to do. This allow other threads to start working on
+/// // the data immediately, without waiting for the rest of the unrelated work
+/// // to be done here.
 /// //
 /// // It's even more important here than in the threads because we `.join` the
-/// // threads after that. If we had not dropped the mutex guard, a thread could be
-/// // waiting forever for it, causing a deadlock.
+/// // threads after that. If we had not dropped the mutex guard, a thread could
+/// // be waiting forever for it, causing a deadlock.
 /// drop(data);
-/// // Here the mutex guard is not assigned to a variable and so, even if the scope
-/// // does not end after this line, the mutex is still released:
-/// // there is no deadlock.
+/// // Here the mutex guard is not assigned to a variable and so, even if the
+/// // scope does not end after this line, the mutex is still released: there is
+/// // no deadlock.
 /// *res_mutex.lock().unwrap() += result;
 ///
 /// threads.into_iter().for_each(|thread| {

--- a/src/libstd/sync/mutex.rs
+++ b/src/libstd/sync/mutex.rs
@@ -108,9 +108,8 @@ use crate::sys_common::poison::{self, LockResult, TryLockError, TryLockResult};
 /// *guard += 1;
 /// ```
 ///
-/// It is sometimes necessary to manually drop the mutex
-/// guard to unlock it as soon as possible. If you need the resource until the end of
-/// the scope, this is not needed.
+/// It is sometimes necessary to manually drop the mutex guard
+/// to unlock it sooner than the end of the enclosing scope.
 ///
 /// ```
 /// use std::sync::{Arc, Mutex};

--- a/src/test/ui/consts/control-flow/drop-fail.precise.stderr
+++ b/src/test/ui/consts/control-flow/drop-fail.precise.stderr
@@ -1,0 +1,15 @@
+error[E0493]: destructors cannot be evaluated at compile-time
+  --> $DIR/drop-fail.rs:10:9
+   |
+LL |     let x = Some(Vec::new());
+   |         ^ constants cannot evaluate destructors
+
+error[E0493]: destructors cannot be evaluated at compile-time
+  --> $DIR/drop-fail.rs:41:9
+   |
+LL |     let mut tmp = None;
+   |         ^^^^^^^ constants cannot evaluate destructors
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0493`.

--- a/src/test/ui/consts/control-flow/drop-fail.rs
+++ b/src/test/ui/consts/control-flow/drop-fail.rs
@@ -1,11 +1,14 @@
+// revisions: stock precise
+
 #![feature(const_if_match)]
 #![feature(const_loop)]
+#![cfg_attr(precise, feature(const_precise_live_drops))]
 
-// `x` is *not* always moved into the final value may be dropped inside the initializer.
+// `x` is *not* always moved into the final value and may be dropped inside the initializer.
 const _: Option<Vec<i32>> = {
     let y: Option<Vec<i32>> = None;
     let x = Some(Vec::new());
-    //~^ ERROR destructors cannot be evaluated at compile-time
+    //[stock,precise]~^ ERROR destructors cannot be evaluated at compile-time
 
     if true {
         x
@@ -18,7 +21,7 @@ const _: Option<Vec<i32>> = {
 // existing analysis.
 const _: Vec<i32> = {
     let vec_tuple = (Vec::new(),);
-    //~^ ERROR destructors cannot be evaluated at compile-time
+    //[stock]~^ ERROR destructors cannot be evaluated at compile-time
 
     vec_tuple.0
 };
@@ -26,7 +29,7 @@ const _: Vec<i32> = {
 // This applies to single-field enum variants as well.
 const _: Vec<i32> = {
     let x: Result<_, Vec<i32>> = Ok(Vec::new());
-    //~^ ERROR destructors cannot be evaluated at compile-time
+    //[stock]~^ ERROR destructors cannot be evaluated at compile-time
 
     match x {
         Ok(x) | Err(x) => x,
@@ -36,7 +39,7 @@ const _: Vec<i32> = {
 const _: Option<Vec<i32>> = {
     let mut some = Some(Vec::new());
     let mut tmp = None;
-    //~^ ERROR destructors cannot be evaluated at compile-time
+    //[stock,precise]~^ ERROR destructors cannot be evaluated at compile-time
 
     let mut i = 0;
     while i < 10 {

--- a/src/test/ui/consts/control-flow/drop-fail.stock.stderr
+++ b/src/test/ui/consts/control-flow/drop-fail.stock.stderr
@@ -1,23 +1,23 @@
 error[E0493]: destructors cannot be evaluated at compile-time
-  --> $DIR/drop-failure.rs:7:9
+  --> $DIR/drop-fail.rs:10:9
    |
 LL |     let x = Some(Vec::new());
    |         ^ constants cannot evaluate destructors
 
 error[E0493]: destructors cannot be evaluated at compile-time
-  --> $DIR/drop-failure.rs:20:9
+  --> $DIR/drop-fail.rs:23:9
    |
 LL |     let vec_tuple = (Vec::new(),);
    |         ^^^^^^^^^ constants cannot evaluate destructors
 
 error[E0493]: destructors cannot be evaluated at compile-time
-  --> $DIR/drop-failure.rs:28:9
+  --> $DIR/drop-fail.rs:31:9
    |
 LL |     let x: Result<_, Vec<i32>> = Ok(Vec::new());
    |         ^ constants cannot evaluate destructors
 
 error[E0493]: destructors cannot be evaluated at compile-time
-  --> $DIR/drop-failure.rs:38:9
+  --> $DIR/drop-fail.rs:41:9
    |
 LL |     let mut tmp = None;
    |         ^^^^^^^ constants cannot evaluate destructors

--- a/src/test/ui/consts/control-flow/drop-pass.rs
+++ b/src/test/ui/consts/control-flow/drop-pass.rs
@@ -1,7 +1,9 @@
 // run-pass
+// revisions: stock precise
 
 #![feature(const_if_match)]
 #![feature(const_loop)]
+#![cfg_attr(precise, feature(const_precise_live_drops))]
 
 // `x` is always moved into the final value and is not dropped inside the initializer.
 const _: Option<Vec<i32>> = {

--- a/src/test/ui/consts/control-flow/drop-precise.rs
+++ b/src/test/ui/consts/control-flow/drop-precise.rs
@@ -1,0 +1,20 @@
+// run-pass
+// gate-test-const_precise_live_drops
+
+#![feature(const_if_match)]
+#![feature(const_loop)]
+#![feature(const_precise_live_drops)]
+
+const _: Vec<i32> = {
+    let vec_tuple = (Vec::new(),);
+    vec_tuple.0
+};
+
+const _: Vec<i32> = {
+    let x: Result<_, Vec<i32>> = Ok(Vec::new());
+    match x {
+        Ok(x) | Err(x) => x,
+    }
+};
+
+fn main() {}

--- a/src/test/ui/infinite/infinite-tag-type-recursion.stderr
+++ b/src/test/ui/infinite/infinite-tag-type-recursion.stderr
@@ -6,14 +6,10 @@ LL | enum MList { Cons(isize, MList), Nil }
    | |
    | recursive type has infinite size
    |
-help: insert some indirection to make `MList` representable
+help: insert some indirection (e.g., a `Box`, `Rc`, or `&`) to make `MList` representable
    |
 LL | enum MList { Cons(isize, Box<MList>), Nil }
    |                          ^^^^     ^
-LL | enum MList { Cons(isize, Rc<MList>), Nil }
-   |                          ^^^     ^
-LL | enum MList { Cons(isize, &MList), Nil }
-   |                          ^
 
 error[E0391]: cycle detected when computing drop-check constraints for `MList`
   --> $DIR/infinite-tag-type-recursion.rs:1:1

--- a/src/test/ui/infinite/infinite-tag-type-recursion.stderr
+++ b/src/test/ui/infinite/infinite-tag-type-recursion.stderr
@@ -6,7 +6,14 @@ LL | enum MList { Cons(isize, MList), Nil }
    | |
    | recursive type has infinite size
    |
-   = help: insert indirection (e.g., a `Box`, `Rc`, or `&`) at some point to make `MList` representable
+help: insert some indirection to make `MList` representable
+   |
+LL | enum MList { Cons(isize, Box<MList>), Nil }
+   |                          ^^^^     ^
+LL | enum MList { Cons(isize, Rc<MList>), Nil }
+   |                          ^^^     ^
+LL | enum MList { Cons(isize, &MList), Nil }
+   |                          ^
 
 error[E0391]: cycle detected when computing drop-check constraints for `MList`
   --> $DIR/infinite-tag-type-recursion.rs:1:1

--- a/src/test/ui/issues/issue-17431-1.stderr
+++ b/src/test/ui/issues/issue-17431-1.stderr
@@ -2,11 +2,18 @@ error[E0072]: recursive type `Foo` has infinite size
   --> $DIR/issue-17431-1.rs:1:1
    |
 LL | struct Foo { foo: Option<Option<Foo>> }
-   | ^^^^^^^^^^   ------------------------ recursive without indirection
+   | ^^^^^^^^^^        ------------------- recursive without indirection
    | |
    | recursive type has infinite size
    |
-   = help: insert indirection (e.g., a `Box`, `Rc`, or `&`) at some point to make `Foo` representable
+help: insert some indirection to make `Foo` representable
+   |
+LL | struct Foo { foo: Box<Option<Option<Foo>>> }
+   |                   ^^^^                   ^
+LL | struct Foo { foo: Rc<Option<Option<Foo>>> }
+   |                   ^^^                   ^
+LL | struct Foo { foo: &Option<Option<Foo>> }
+   |                   ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-17431-1.stderr
+++ b/src/test/ui/issues/issue-17431-1.stderr
@@ -6,14 +6,10 @@ LL | struct Foo { foo: Option<Option<Foo>> }
    | |
    | recursive type has infinite size
    |
-help: insert some indirection to make `Foo` representable
+help: insert some indirection (e.g., a `Box`, `Rc`, or `&`) to make `Foo` representable
    |
 LL | struct Foo { foo: Box<Option<Option<Foo>>> }
    |                   ^^^^                   ^
-LL | struct Foo { foo: Rc<Option<Option<Foo>>> }
-   |                   ^^^                   ^
-LL | struct Foo { foo: &Option<Option<Foo>> }
-   |                   ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-17431-2.stderr
+++ b/src/test/ui/issues/issue-17431-2.stderr
@@ -6,14 +6,10 @@ LL | struct Baz { q: Option<Foo> }
    | |
    | recursive type has infinite size
    |
-help: insert some indirection to make `Baz` representable
+help: insert some indirection (e.g., a `Box`, `Rc`, or `&`) to make `Baz` representable
    |
 LL | struct Baz { q: Box<Option<Foo>> }
    |                 ^^^^           ^
-LL | struct Baz { q: Rc<Option<Foo>> }
-   |                 ^^^           ^
-LL | struct Baz { q: &Option<Foo> }
-   |                 ^
 
 error[E0072]: recursive type `Foo` has infinite size
   --> $DIR/issue-17431-2.rs:4:1
@@ -23,14 +19,10 @@ LL | struct Foo { q: Option<Baz> }
    | |
    | recursive type has infinite size
    |
-help: insert some indirection to make `Foo` representable
+help: insert some indirection (e.g., a `Box`, `Rc`, or `&`) to make `Foo` representable
    |
 LL | struct Foo { q: Box<Option<Baz>> }
    |                 ^^^^           ^
-LL | struct Foo { q: Rc<Option<Baz>> }
-   |                 ^^^           ^
-LL | struct Foo { q: &Option<Baz> }
-   |                 ^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-17431-2.stderr
+++ b/src/test/ui/issues/issue-17431-2.stderr
@@ -2,21 +2,35 @@ error[E0072]: recursive type `Baz` has infinite size
   --> $DIR/issue-17431-2.rs:1:1
    |
 LL | struct Baz { q: Option<Foo> }
-   | ^^^^^^^^^^   -------------- recursive without indirection
+   | ^^^^^^^^^^      ----------- recursive without indirection
    | |
    | recursive type has infinite size
    |
-   = help: insert indirection (e.g., a `Box`, `Rc`, or `&`) at some point to make `Baz` representable
+help: insert some indirection to make `Baz` representable
+   |
+LL | struct Baz { q: Box<Option<Foo>> }
+   |                 ^^^^           ^
+LL | struct Baz { q: Rc<Option<Foo>> }
+   |                 ^^^           ^
+LL | struct Baz { q: &Option<Foo> }
+   |                 ^
 
 error[E0072]: recursive type `Foo` has infinite size
   --> $DIR/issue-17431-2.rs:4:1
    |
 LL | struct Foo { q: Option<Baz> }
-   | ^^^^^^^^^^   -------------- recursive without indirection
+   | ^^^^^^^^^^      ----------- recursive without indirection
    | |
    | recursive type has infinite size
    |
-   = help: insert indirection (e.g., a `Box`, `Rc`, or `&`) at some point to make `Foo` representable
+help: insert some indirection to make `Foo` representable
+   |
+LL | struct Foo { q: Box<Option<Baz>> }
+   |                 ^^^^           ^
+LL | struct Foo { q: Rc<Option<Baz>> }
+   |                 ^^^           ^
+LL | struct Foo { q: &Option<Baz> }
+   |                 ^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-17431-3.stderr
+++ b/src/test/ui/issues/issue-17431-3.stderr
@@ -6,14 +6,10 @@ LL | struct Foo { foo: Mutex<Option<Foo>> }
    | |
    | recursive type has infinite size
    |
-help: insert some indirection to make `Foo` representable
+help: insert some indirection (e.g., a `Box`, `Rc`, or `&`) to make `Foo` representable
    |
 LL | struct Foo { foo: Box<Mutex<Option<Foo>>> }
    |                   ^^^^                  ^
-LL | struct Foo { foo: Rc<Mutex<Option<Foo>>> }
-   |                   ^^^                  ^
-LL | struct Foo { foo: &Mutex<Option<Foo>> }
-   |                   ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-17431-3.stderr
+++ b/src/test/ui/issues/issue-17431-3.stderr
@@ -2,11 +2,18 @@ error[E0072]: recursive type `Foo` has infinite size
   --> $DIR/issue-17431-3.rs:3:1
    |
 LL | struct Foo { foo: Mutex<Option<Foo>> }
-   | ^^^^^^^^^^   ----------------------- recursive without indirection
+   | ^^^^^^^^^^        ------------------ recursive without indirection
    | |
    | recursive type has infinite size
    |
-   = help: insert indirection (e.g., a `Box`, `Rc`, or `&`) at some point to make `Foo` representable
+help: insert some indirection to make `Foo` representable
+   |
+LL | struct Foo { foo: Box<Mutex<Option<Foo>>> }
+   |                   ^^^^                  ^
+LL | struct Foo { foo: Rc<Mutex<Option<Foo>>> }
+   |                   ^^^                  ^
+LL | struct Foo { foo: &Mutex<Option<Foo>> }
+   |                   ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-17431-4.stderr
+++ b/src/test/ui/issues/issue-17431-4.stderr
@@ -6,14 +6,10 @@ LL | struct Foo<T> { foo: Option<Option<Foo<T>>>, marker: marker::PhantomData<T>
    | |
    | recursive type has infinite size
    |
-help: insert some indirection to make `Foo` representable
+help: insert some indirection (e.g., a `Box`, `Rc`, or `&`) to make `Foo` representable
    |
 LL | struct Foo<T> { foo: Box<Option<Option<Foo<T>>>>, marker: marker::PhantomData<T> }
    |                      ^^^^                      ^
-LL | struct Foo<T> { foo: Rc<Option<Option<Foo<T>>>>, marker: marker::PhantomData<T> }
-   |                      ^^^                      ^
-LL | struct Foo<T> { foo: &Option<Option<Foo<T>>>, marker: marker::PhantomData<T> }
-   |                      ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-17431-4.stderr
+++ b/src/test/ui/issues/issue-17431-4.stderr
@@ -2,11 +2,18 @@ error[E0072]: recursive type `Foo` has infinite size
   --> $DIR/issue-17431-4.rs:3:1
    |
 LL | struct Foo<T> { foo: Option<Option<Foo<T>>>, marker: marker::PhantomData<T> }
-   | ^^^^^^^^^^^^^   --------------------------- recursive without indirection
+   | ^^^^^^^^^^^^^        ---------------------- recursive without indirection
    | |
    | recursive type has infinite size
    |
-   = help: insert indirection (e.g., a `Box`, `Rc`, or `&`) at some point to make `Foo` representable
+help: insert some indirection to make `Foo` representable
+   |
+LL | struct Foo<T> { foo: Box<Option<Option<Foo<T>>>>, marker: marker::PhantomData<T> }
+   |                      ^^^^                      ^
+LL | struct Foo<T> { foo: Rc<Option<Option<Foo<T>>>>, marker: marker::PhantomData<T> }
+   |                      ^^^                      ^
+LL | struct Foo<T> { foo: &Option<Option<Foo<T>>>, marker: marker::PhantomData<T> }
+   |                      ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-17431-5.stderr
+++ b/src/test/ui/issues/issue-17431-5.stderr
@@ -2,11 +2,18 @@ error[E0072]: recursive type `Bar` has infinite size
   --> $DIR/issue-17431-5.rs:5:1
    |
 LL | struct Bar<T> { x: Bar<Foo> , marker: marker::PhantomData<T> }
-   | ^^^^^^^^^^^^^   ----------- recursive without indirection
+   | ^^^^^^^^^^^^^      -------- recursive without indirection
    | |
    | recursive type has infinite size
    |
-   = help: insert indirection (e.g., a `Box`, `Rc`, or `&`) at some point to make `Bar` representable
+help: insert some indirection to make `Bar` representable
+   |
+LL | struct Bar<T> { x: Box<Bar<Foo>> , marker: marker::PhantomData<T> }
+   |                    ^^^^        ^
+LL | struct Bar<T> { x: Rc<Bar<Foo>> , marker: marker::PhantomData<T> }
+   |                    ^^^        ^
+LL | struct Bar<T> { x: &Bar<Foo> , marker: marker::PhantomData<T> }
+   |                    ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-17431-5.stderr
+++ b/src/test/ui/issues/issue-17431-5.stderr
@@ -6,14 +6,10 @@ LL | struct Bar<T> { x: Bar<Foo> , marker: marker::PhantomData<T> }
    | |
    | recursive type has infinite size
    |
-help: insert some indirection to make `Bar` representable
+help: insert some indirection (e.g., a `Box`, `Rc`, or `&`) to make `Bar` representable
    |
 LL | struct Bar<T> { x: Box<Bar<Foo>> , marker: marker::PhantomData<T> }
    |                    ^^^^        ^
-LL | struct Bar<T> { x: Rc<Bar<Foo>> , marker: marker::PhantomData<T> }
-   |                    ^^^        ^
-LL | struct Bar<T> { x: &Bar<Foo> , marker: marker::PhantomData<T> }
-   |                    ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-17431-6.stderr
+++ b/src/test/ui/issues/issue-17431-6.stderr
@@ -6,14 +6,10 @@ LL | enum Foo { X(Mutex<Option<Foo>>) }
    | |
    | recursive type has infinite size
    |
-help: insert some indirection to make `Foo` representable
+help: insert some indirection (e.g., a `Box`, `Rc`, or `&`) to make `Foo` representable
    |
 LL | enum Foo { X(Box<Mutex<Option<Foo>>>) }
    |              ^^^^                  ^
-LL | enum Foo { X(Rc<Mutex<Option<Foo>>>) }
-   |              ^^^                  ^
-LL | enum Foo { X(&Mutex<Option<Foo>>) }
-   |              ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-17431-6.stderr
+++ b/src/test/ui/issues/issue-17431-6.stderr
@@ -6,7 +6,14 @@ LL | enum Foo { X(Mutex<Option<Foo>>) }
    | |
    | recursive type has infinite size
    |
-   = help: insert indirection (e.g., a `Box`, `Rc`, or `&`) at some point to make `Foo` representable
+help: insert some indirection to make `Foo` representable
+   |
+LL | enum Foo { X(Box<Mutex<Option<Foo>>>) }
+   |              ^^^^                  ^
+LL | enum Foo { X(Rc<Mutex<Option<Foo>>>) }
+   |              ^^^                  ^
+LL | enum Foo { X(&Mutex<Option<Foo>>) }
+   |              ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-17431-7.stderr
+++ b/src/test/ui/issues/issue-17431-7.stderr
@@ -6,7 +6,14 @@ LL | enum Foo { Voo(Option<Option<Foo>>) }
    | |
    | recursive type has infinite size
    |
-   = help: insert indirection (e.g., a `Box`, `Rc`, or `&`) at some point to make `Foo` representable
+help: insert some indirection to make `Foo` representable
+   |
+LL | enum Foo { Voo(Box<Option<Option<Foo>>>) }
+   |                ^^^^                   ^
+LL | enum Foo { Voo(Rc<Option<Option<Foo>>>) }
+   |                ^^^                   ^
+LL | enum Foo { Voo(&Option<Option<Foo>>) }
+   |                ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-17431-7.stderr
+++ b/src/test/ui/issues/issue-17431-7.stderr
@@ -6,14 +6,10 @@ LL | enum Foo { Voo(Option<Option<Foo>>) }
    | |
    | recursive type has infinite size
    |
-help: insert some indirection to make `Foo` representable
+help: insert some indirection (e.g., a `Box`, `Rc`, or `&`) to make `Foo` representable
    |
 LL | enum Foo { Voo(Box<Option<Option<Foo>>>) }
    |                ^^^^                   ^
-LL | enum Foo { Voo(Rc<Option<Option<Foo>>>) }
-   |                ^^^                   ^
-LL | enum Foo { Voo(&Option<Option<Foo>>) }
-   |                ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-2718-a.stderr
+++ b/src/test/ui/issues/issue-2718-a.stderr
@@ -7,14 +7,10 @@ LL |     pub struct Pong(SendPacket<Ping>);
    |     |               recursive without indirection
    |     recursive type has infinite size
    |
-help: insert some indirection to make `pingpong::Pong` representable
+help: insert some indirection (e.g., a `Box`, `Rc`, or `&`) to make `pingpong::Pong` representable
    |
 LL |     pub struct Pong(Box<SendPacket<Ping>>);
    |                     ^^^^                ^
-LL |     pub struct Pong(Rc<SendPacket<Ping>>);
-   |                     ^^^                ^
-LL |     pub struct Pong(&SendPacket<Ping>);
-   |                     ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-2718-a.stderr
+++ b/src/test/ui/issues/issue-2718-a.stderr
@@ -7,7 +7,14 @@ LL |     pub struct Pong(SendPacket<Ping>);
    |     |               recursive without indirection
    |     recursive type has infinite size
    |
-   = help: insert indirection (e.g., a `Box`, `Rc`, or `&`) at some point to make `pingpong::Pong` representable
+help: insert some indirection to make `pingpong::Pong` representable
+   |
+LL |     pub struct Pong(Box<SendPacket<Ping>>);
+   |                     ^^^^                ^
+LL |     pub struct Pong(Rc<SendPacket<Ping>>);
+   |                     ^^^                ^
+LL |     pub struct Pong(&SendPacket<Ping>);
+   |                     ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-3008-1.stderr
+++ b/src/test/ui/issues/issue-3008-1.stderr
@@ -7,14 +7,10 @@ LL | enum Bar {
 LL |     BarSome(Bar)
    |             --- recursive without indirection
    |
-help: insert some indirection to make `Bar` representable
+help: insert some indirection (e.g., a `Box`, `Rc`, or `&`) to make `Bar` representable
    |
 LL |     BarSome(Box<Bar>)
    |             ^^^^   ^
-LL |     BarSome(Rc<Bar>)
-   |             ^^^   ^
-LL |     BarSome(&Bar)
-   |             ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-3008-1.stderr
+++ b/src/test/ui/issues/issue-3008-1.stderr
@@ -7,7 +7,14 @@ LL | enum Bar {
 LL |     BarSome(Bar)
    |             --- recursive without indirection
    |
-   = help: insert indirection (e.g., a `Box`, `Rc`, or `&`) at some point to make `Bar` representable
+help: insert some indirection to make `Bar` representable
+   |
+LL |     BarSome(Box<Bar>)
+   |             ^^^^   ^
+LL |     BarSome(Rc<Bar>)
+   |             ^^^   ^
+LL |     BarSome(&Bar)
+   |             ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-3008-2.stderr
+++ b/src/test/ui/issues/issue-3008-2.stderr
@@ -6,14 +6,10 @@ LL | struct Bar { x: Bar }
    | |
    | recursive type has infinite size
    |
-help: insert some indirection to make `Bar` representable
+help: insert some indirection (e.g., a `Box`, `Rc`, or `&`) to make `Bar` representable
    |
 LL | struct Bar { x: Box<Bar> }
    |                 ^^^^   ^
-LL | struct Bar { x: Rc<Bar> }
-   |                 ^^^   ^
-LL | struct Bar { x: &Bar }
-   |                 ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-3008-2.stderr
+++ b/src/test/ui/issues/issue-3008-2.stderr
@@ -2,11 +2,18 @@ error[E0072]: recursive type `Bar` has infinite size
   --> $DIR/issue-3008-2.rs:2:1
    |
 LL | struct Bar { x: Bar }
-   | ^^^^^^^^^^   ------ recursive without indirection
+   | ^^^^^^^^^^      --- recursive without indirection
    | |
    | recursive type has infinite size
    |
-   = help: insert indirection (e.g., a `Box`, `Rc`, or `&`) at some point to make `Bar` representable
+help: insert some indirection to make `Bar` representable
+   |
+LL | struct Bar { x: Box<Bar> }
+   |                 ^^^^   ^
+LL | struct Bar { x: Rc<Bar> }
+   |                 ^^^   ^
+LL | struct Bar { x: &Bar }
+   |                 ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-3008-3.stderr
+++ b/src/test/ui/issues/issue-3008-3.stderr
@@ -6,7 +6,14 @@ LL | enum E2<T> { V2(E2<E1>, marker::PhantomData<T>), }
    | |
    | recursive type has infinite size
    |
-   = help: insert indirection (e.g., a `Box`, `Rc`, or `&`) at some point to make `E2` representable
+help: insert some indirection to make `E2` representable
+   |
+LL | enum E2<T> { V2(Box<E2<E1>>, marker::PhantomData<T>), }
+   |                 ^^^^      ^
+LL | enum E2<T> { V2(Rc<E2<E1>>, marker::PhantomData<T>), }
+   |                 ^^^      ^
+LL | enum E2<T> { V2(&E2<E1>, marker::PhantomData<T>), }
+   |                 ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-3008-3.stderr
+++ b/src/test/ui/issues/issue-3008-3.stderr
@@ -6,14 +6,10 @@ LL | enum E2<T> { V2(E2<E1>, marker::PhantomData<T>), }
    | |
    | recursive type has infinite size
    |
-help: insert some indirection to make `E2` representable
+help: insert some indirection (e.g., a `Box`, `Rc`, or `&`) to make `E2` representable
    |
 LL | enum E2<T> { V2(Box<E2<E1>>, marker::PhantomData<T>), }
    |                 ^^^^      ^
-LL | enum E2<T> { V2(Rc<E2<E1>>, marker::PhantomData<T>), }
-   |                 ^^^      ^
-LL | enum E2<T> { V2(&E2<E1>, marker::PhantomData<T>), }
-   |                 ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-32326.stderr
+++ b/src/test/ui/issues/issue-32326.stderr
@@ -8,7 +8,10 @@ LL |     Plus(Expr, Expr),
    |          |
    |          recursive without indirection
    |
-   = help: insert indirection (e.g., a `Box`, `Rc`, or `&`) at some point to make `Expr` representable
+help: insert some indirection (e.g., a `Box`, `Rc`, or `&`) to make `Expr` representable
+   |
+LL |     Plus(Box<Expr>, Box<Expr>),
+   |          ^^^^    ^  ^^^^    ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-3779.stderr
+++ b/src/test/ui/issues/issue-3779.stderr
@@ -7,14 +7,10 @@ LL |
 LL |     element: Option<S>
    |              --------- recursive without indirection
    |
-help: insert some indirection to make `S` representable
+help: insert some indirection (e.g., a `Box`, `Rc`, or `&`) to make `S` representable
    |
 LL |     element: Box<Option<S>>
    |              ^^^^         ^
-LL |     element: Rc<Option<S>>
-   |              ^^^         ^
-LL |     element: &Option<S>
-   |              ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-3779.stderr
+++ b/src/test/ui/issues/issue-3779.stderr
@@ -5,9 +5,16 @@ LL | struct S {
    | ^^^^^^^^ recursive type has infinite size
 LL |
 LL |     element: Option<S>
-   |     ------------------ recursive without indirection
+   |              --------- recursive without indirection
    |
-   = help: insert indirection (e.g., a `Box`, `Rc`, or `&`) at some point to make `S` representable
+help: insert some indirection to make `S` representable
+   |
+LL |     element: Box<Option<S>>
+   |              ^^^^         ^
+LL |     element: Rc<Option<S>>
+   |              ^^^         ^
+LL |     element: &Option<S>
+   |              ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-57271.stderr
+++ b/src/test/ui/issues/issue-57271.stderr
@@ -7,7 +7,14 @@ LL |     Class(ClassTypeSignature),
 LL |     Array(TypeSignature),
    |           ------------- recursive without indirection
    |
-   = help: insert indirection (e.g., a `Box`, `Rc`, or `&`) at some point to make `ObjectType` representable
+help: insert some indirection to make `ObjectType` representable
+   |
+LL |     Array(Box<TypeSignature>),
+   |           ^^^^             ^
+LL |     Array(Rc<TypeSignature>),
+   |           ^^^             ^
+LL |     Array(&TypeSignature),
+   |           ^
 
 error[E0072]: recursive type `TypeSignature` has infinite size
   --> $DIR/issue-57271.rs:19:1
@@ -18,7 +25,14 @@ LL |     Base(BaseType),
 LL |     Object(ObjectType),
    |            ---------- recursive without indirection
    |
-   = help: insert indirection (e.g., a `Box`, `Rc`, or `&`) at some point to make `TypeSignature` representable
+help: insert some indirection to make `TypeSignature` representable
+   |
+LL |     Object(Box<ObjectType>),
+   |            ^^^^          ^
+LL |     Object(Rc<ObjectType>),
+   |            ^^^          ^
+LL |     Object(&ObjectType),
+   |            ^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-57271.stderr
+++ b/src/test/ui/issues/issue-57271.stderr
@@ -7,14 +7,10 @@ LL |     Class(ClassTypeSignature),
 LL |     Array(TypeSignature),
    |           ------------- recursive without indirection
    |
-help: insert some indirection to make `ObjectType` representable
+help: insert some indirection (e.g., a `Box`, `Rc`, or `&`) to make `ObjectType` representable
    |
 LL |     Array(Box<TypeSignature>),
    |           ^^^^             ^
-LL |     Array(Rc<TypeSignature>),
-   |           ^^^             ^
-LL |     Array(&TypeSignature),
-   |           ^
 
 error[E0072]: recursive type `TypeSignature` has infinite size
   --> $DIR/issue-57271.rs:19:1
@@ -25,14 +21,10 @@ LL |     Base(BaseType),
 LL |     Object(ObjectType),
    |            ---------- recursive without indirection
    |
-help: insert some indirection to make `TypeSignature` representable
+help: insert some indirection (e.g., a `Box`, `Rc`, or `&`) to make `TypeSignature` representable
    |
 LL |     Object(Box<ObjectType>),
    |            ^^^^          ^
-LL |     Object(Rc<ObjectType>),
-   |            ^^^          ^
-LL |     Object(&ObjectType),
-   |            ^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-72554.stderr
+++ b/src/test/ui/issues/issue-72554.stderr
@@ -6,7 +6,10 @@ LL | pub enum ElemDerived {
 LL |     A(ElemDerived)
    |       ----------- recursive without indirection
    |
-   = help: insert indirection (e.g., a `Box`, `Rc`, or `&`) at some point to make `ElemDerived` representable
+help: insert some indirection (e.g., a `Box`, `Rc`, or `&`) to make `ElemDerived` representable
+   |
+LL |     A(Box<ElemDerived>)
+   |       ^^^^           ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/lint/lint-ctypes-73251-1.rs
+++ b/src/test/ui/lint/lint-ctypes-73251-1.rs
@@ -1,0 +1,24 @@
+#![feature(type_alias_impl_trait)]
+#![deny(improper_ctypes)]
+
+pub trait Baz { }
+
+impl Baz for u32 { }
+
+type Qux = impl Baz;
+
+pub trait Foo {
+    type Assoc;
+}
+
+impl Foo for u32 {
+    type Assoc = Qux;
+}
+
+fn assign() -> Qux { 1 }
+
+extern "C" {
+    pub fn lint_me() -> <u32 as Foo>::Assoc; //~ ERROR: uses type `Qux`
+}
+
+fn main() {}

--- a/src/test/ui/lint/lint-ctypes-73251-1.stderr
+++ b/src/test/ui/lint/lint-ctypes-73251-1.stderr
@@ -1,0 +1,15 @@
+error: `extern` block uses type `Qux`, which is not FFI-safe
+  --> $DIR/lint-ctypes-73251-1.rs:21:25
+   |
+LL |     pub fn lint_me() -> <u32 as Foo>::Assoc;
+   |                         ^^^^^^^^^^^^^^^^^^^ not FFI-safe
+   |
+note: the lint level is defined here
+  --> $DIR/lint-ctypes-73251-1.rs:2:9
+   |
+LL | #![deny(improper_ctypes)]
+   |         ^^^^^^^^^^^^^^^
+   = note: opaque types have no C equivalent
+
+error: aborting due to previous error
+

--- a/src/test/ui/lint/lint-ctypes-73251-2.rs
+++ b/src/test/ui/lint/lint-ctypes-73251-2.rs
@@ -1,0 +1,32 @@
+#![feature(type_alias_impl_trait)]
+#![deny(improper_ctypes)]
+
+pub trait TraitA {
+    type Assoc;
+}
+
+impl TraitA for u32 {
+    type Assoc = u32;
+}
+
+pub trait TraitB {
+    type Assoc;
+}
+
+impl<T> TraitB for T where T: TraitA {
+    type Assoc = <T as TraitA>::Assoc;
+}
+
+type AliasA = impl TraitA<Assoc = u32>;
+
+type AliasB = impl TraitB<Assoc = AliasA>;
+
+fn use_of_a() -> AliasA { 3 }
+
+fn use_of_b() -> AliasB { 3 }
+
+extern "C" {
+    pub fn lint_me() -> <AliasB as TraitB>::Assoc; //~ ERROR: uses type `AliasA`
+}
+
+fn main() {}

--- a/src/test/ui/lint/lint-ctypes-73251-2.stderr
+++ b/src/test/ui/lint/lint-ctypes-73251-2.stderr
@@ -1,0 +1,15 @@
+error: `extern` block uses type `AliasA`, which is not FFI-safe
+  --> $DIR/lint-ctypes-73251-2.rs:29:25
+   |
+LL |     pub fn lint_me() -> <AliasB as TraitB>::Assoc;
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
+   |
+note: the lint level is defined here
+  --> $DIR/lint-ctypes-73251-2.rs:2:9
+   |
+LL | #![deny(improper_ctypes)]
+   |         ^^^^^^^^^^^^^^^
+   = note: opaque types have no C equivalent
+
+error: aborting due to previous error
+

--- a/src/test/ui/lint/lint-ctypes-73251.rs
+++ b/src/test/ui/lint/lint-ctypes-73251.rs
@@ -1,0 +1,22 @@
+// check-pass
+
+#![feature(type_alias_impl_trait)]
+#![deny(improper_ctypes)]
+
+pub trait Foo {
+    type Assoc;
+}
+
+impl Foo for () {
+    type Assoc = u32;
+}
+
+type Bar = impl Foo<Assoc = u32>;
+
+fn assign() -> Bar {}
+
+extern "C" {
+    pub fn lint_me() -> <Bar as Foo>::Assoc;
+}
+
+fn main() {}

--- a/src/test/ui/recursion/recursive-enum.stderr
+++ b/src/test/ui/recursion/recursive-enum.stderr
@@ -6,7 +6,14 @@ LL | enum List<T> { Cons(T, List<T>), Nil }
    | |
    | recursive type has infinite size
    |
-   = help: insert indirection (e.g., a `Box`, `Rc`, or `&`) at some point to make `List` representable
+help: insert some indirection to make `List` representable
+   |
+LL | enum List<T> { Cons(T, Box<List<T>>), Nil }
+   |                        ^^^^       ^
+LL | enum List<T> { Cons(T, Rc<List<T>>), Nil }
+   |                        ^^^       ^
+LL | enum List<T> { Cons(T, &List<T>), Nil }
+   |                        ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/recursion/recursive-enum.stderr
+++ b/src/test/ui/recursion/recursive-enum.stderr
@@ -6,14 +6,10 @@ LL | enum List<T> { Cons(T, List<T>), Nil }
    | |
    | recursive type has infinite size
    |
-help: insert some indirection to make `List` representable
+help: insert some indirection (e.g., a `Box`, `Rc`, or `&`) to make `List` representable
    |
 LL | enum List<T> { Cons(T, Box<List<T>>), Nil }
    |                        ^^^^       ^
-LL | enum List<T> { Cons(T, Rc<List<T>>), Nil }
-   |                        ^^^       ^
-LL | enum List<T> { Cons(T, &List<T>), Nil }
-   |                        ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/sized-cycle-note.stderr
+++ b/src/test/ui/sized-cycle-note.stderr
@@ -2,21 +2,35 @@ error[E0072]: recursive type `Baz` has infinite size
   --> $DIR/sized-cycle-note.rs:9:1
    |
 LL | struct Baz { q: Option<Foo> }
-   | ^^^^^^^^^^   -------------- recursive without indirection
+   | ^^^^^^^^^^      ----------- recursive without indirection
    | |
    | recursive type has infinite size
    |
-   = help: insert indirection (e.g., a `Box`, `Rc`, or `&`) at some point to make `Baz` representable
+help: insert some indirection to make `Baz` representable
+   |
+LL | struct Baz { q: Box<Option<Foo>> }
+   |                 ^^^^           ^
+LL | struct Baz { q: Rc<Option<Foo>> }
+   |                 ^^^           ^
+LL | struct Baz { q: &Option<Foo> }
+   |                 ^
 
 error[E0072]: recursive type `Foo` has infinite size
   --> $DIR/sized-cycle-note.rs:11:1
    |
 LL | struct Foo { q: Option<Baz> }
-   | ^^^^^^^^^^   -------------- recursive without indirection
+   | ^^^^^^^^^^      ----------- recursive without indirection
    | |
    | recursive type has infinite size
    |
-   = help: insert indirection (e.g., a `Box`, `Rc`, or `&`) at some point to make `Foo` representable
+help: insert some indirection to make `Foo` representable
+   |
+LL | struct Foo { q: Box<Option<Baz>> }
+   |                 ^^^^           ^
+LL | struct Foo { q: Rc<Option<Baz>> }
+   |                 ^^^           ^
+LL | struct Foo { q: &Option<Baz> }
+   |                 ^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/sized-cycle-note.stderr
+++ b/src/test/ui/sized-cycle-note.stderr
@@ -6,14 +6,10 @@ LL | struct Baz { q: Option<Foo> }
    | |
    | recursive type has infinite size
    |
-help: insert some indirection to make `Baz` representable
+help: insert some indirection (e.g., a `Box`, `Rc`, or `&`) to make `Baz` representable
    |
 LL | struct Baz { q: Box<Option<Foo>> }
    |                 ^^^^           ^
-LL | struct Baz { q: Rc<Option<Foo>> }
-   |                 ^^^           ^
-LL | struct Baz { q: &Option<Foo> }
-   |                 ^
 
 error[E0072]: recursive type `Foo` has infinite size
   --> $DIR/sized-cycle-note.rs:11:1
@@ -23,14 +19,10 @@ LL | struct Foo { q: Option<Baz> }
    | |
    | recursive type has infinite size
    |
-help: insert some indirection to make `Foo` representable
+help: insert some indirection (e.g., a `Box`, `Rc`, or `&`) to make `Foo` representable
    |
 LL | struct Foo { q: Box<Option<Baz>> }
    |                 ^^^^           ^
-LL | struct Foo { q: Rc<Option<Baz>> }
-   |                 ^^^           ^
-LL | struct Foo { q: &Option<Baz> }
-   |                 ^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/span/E0072.stderr
+++ b/src/test/ui/span/E0072.stderr
@@ -5,9 +5,16 @@ LL | struct ListNode {
    | ^^^^^^^^^^^^^^^ recursive type has infinite size
 LL |     head: u8,
 LL |     tail: Option<ListNode>,
-   |     ---------------------- recursive without indirection
+   |           ---------------- recursive without indirection
    |
-   = help: insert indirection (e.g., a `Box`, `Rc`, or `&`) at some point to make `ListNode` representable
+help: insert some indirection to make `ListNode` representable
+   |
+LL |     tail: Box<Option<ListNode>>,
+   |           ^^^^                ^
+LL |     tail: Rc<Option<ListNode>>,
+   |           ^^^                ^
+LL |     tail: &Option<ListNode>,
+   |           ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/span/E0072.stderr
+++ b/src/test/ui/span/E0072.stderr
@@ -7,14 +7,10 @@ LL |     head: u8,
 LL |     tail: Option<ListNode>,
    |           ---------------- recursive without indirection
    |
-help: insert some indirection to make `ListNode` representable
+help: insert some indirection (e.g., a `Box`, `Rc`, or `&`) to make `ListNode` representable
    |
 LL |     tail: Box<Option<ListNode>>,
    |           ^^^^                ^
-LL |     tail: Rc<Option<ListNode>>,
-   |           ^^^                ^
-LL |     tail: &Option<ListNode>,
-   |           ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/span/multiline-span-E0072.stderr
+++ b/src/test/ui/span/multiline-span-E0072.stderr
@@ -10,14 +10,10 @@ LL | |     tail: Option<ListNode>,
 LL | | }
    | |_^ recursive type has infinite size
    |
-help: insert some indirection to make `ListNode` representable
+help: insert some indirection (e.g., a `Box`, `Rc`, or `&`) to make `ListNode` representable
    |
 LL |     tail: Box<Option<ListNode>>,
    |           ^^^^                ^
-LL |     tail: Rc<Option<ListNode>>,
-   |           ^^^                ^
-LL |     tail: &Option<ListNode>,
-   |           ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/span/multiline-span-E0072.stderr
+++ b/src/test/ui/span/multiline-span-E0072.stderr
@@ -6,11 +6,18 @@ LL | | ListNode
 LL | | {
 LL | |     head: u8,
 LL | |     tail: Option<ListNode>,
-   | |     ---------------------- recursive without indirection
+   | |           ---------------- recursive without indirection
 LL | | }
    | |_^ recursive type has infinite size
    |
-   = help: insert indirection (e.g., a `Box`, `Rc`, or `&`) at some point to make `ListNode` representable
+help: insert some indirection to make `ListNode` representable
+   |
+LL |     tail: Box<Option<ListNode>>,
+   |           ^^^^                ^
+LL |     tail: Rc<Option<ListNode>>,
+   |           ^^^                ^
+LL |     tail: &Option<ListNode>,
+   |           ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/span/recursive-type-field.stderr
+++ b/src/test/ui/span/recursive-type-field.stderr
@@ -4,9 +4,16 @@ error[E0072]: recursive type `Foo` has infinite size
 LL | struct Foo<'a> {
    | ^^^^^^^^^^^^^^ recursive type has infinite size
 LL |     bar: Bar<'a>,
-   |     ------------ recursive without indirection
+   |          ------- recursive without indirection
    |
-   = help: insert indirection (e.g., a `Box`, `Rc`, or `&`) at some point to make `Foo` representable
+help: insert some indirection to make `Foo` representable
+   |
+LL |     bar: Box<Bar<'a>>,
+   |          ^^^^       ^
+LL |     bar: Rc<Bar<'a>>,
+   |          ^^^       ^
+LL |     bar: &Bar<'a>,
+   |          ^
 
 error[E0072]: recursive type `Bar` has infinite size
   --> $DIR/recursive-type-field.rs:8:1
@@ -14,18 +21,18 @@ error[E0072]: recursive type `Bar` has infinite size
 LL | struct Bar<'a> {
    | ^^^^^^^^^^^^^^ recursive type has infinite size
 LL |     y: (Foo<'a>, Foo<'a>),
-   |     --------------------- recursive without indirection
+   |        ------------------ recursive without indirection
 LL |     z: Option<Bar<'a>>,
-   |     ------------------ recursive without indirection
+   |        --------------- recursive without indirection
 ...
 LL |     d: [Bar<'a>; 1],
-   |     --------------- recursive without indirection
+   |        ------------ recursive without indirection
 LL |     e: Foo<'a>,
-   |     ---------- recursive without indirection
+   |        ------- recursive without indirection
 LL |     x: Bar<'a>,
-   |     ---------- recursive without indirection
+   |        ------- recursive without indirection
    |
-   = help: insert indirection (e.g., a `Box`, `Rc`, or `&`) at some point to make `Bar` representable
+   = help: insert some indirection (e.g., a `Box`, `Rc`, or `&`) to make `Bar` representable
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/span/recursive-type-field.stderr
+++ b/src/test/ui/span/recursive-type-field.stderr
@@ -6,14 +6,10 @@ LL | struct Foo<'a> {
 LL |     bar: Bar<'a>,
    |          ------- recursive without indirection
    |
-help: insert some indirection to make `Foo` representable
+help: insert some indirection (e.g., a `Box`, `Rc`, or `&`) to make `Foo` representable
    |
 LL |     bar: Box<Bar<'a>>,
    |          ^^^^       ^
-LL |     bar: Rc<Bar<'a>>,
-   |          ^^^       ^
-LL |     bar: &Bar<'a>,
-   |          ^
 
 error[E0072]: recursive type `Bar` has infinite size
   --> $DIR/recursive-type-field.rs:8:1

--- a/src/test/ui/type/type-recursive.stderr
+++ b/src/test/ui/type/type-recursive.stderr
@@ -7,14 +7,10 @@ LL |     foo: isize,
 LL |     foolish: T1
    |              -- recursive without indirection
    |
-help: insert some indirection to make `T1` representable
+help: insert some indirection (e.g., a `Box`, `Rc`, or `&`) to make `T1` representable
    |
 LL |     foolish: Box<T1>
    |              ^^^^  ^
-LL |     foolish: Rc<T1>
-   |              ^^^  ^
-LL |     foolish: &T1
-   |              ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/type/type-recursive.stderr
+++ b/src/test/ui/type/type-recursive.stderr
@@ -5,9 +5,16 @@ LL | struct T1 {
    | ^^^^^^^^^ recursive type has infinite size
 LL |     foo: isize,
 LL |     foolish: T1
-   |     ----------- recursive without indirection
+   |              -- recursive without indirection
    |
-   = help: insert indirection (e.g., a `Box`, `Rc`, or `&`) at some point to make `T1` representable
+help: insert some indirection to make `T1` representable
+   |
+LL |     foolish: Box<T1>
+   |              ^^^^  ^
+LL |     foolish: Rc<T1>
+   |              ^^^  ^
+LL |     foolish: &T1
+   |              ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/union/union-nonrepresentable.stderr
+++ b/src/test/ui/union/union-nonrepresentable.stderr
@@ -7,14 +7,10 @@ LL |     a: u8,
 LL |     b: U,
    |        - recursive without indirection
    |
-help: insert some indirection to make `U` representable
+help: insert some indirection (e.g., a `Box`, `Rc`, or `&`) to make `U` representable
    |
 LL |     b: Box<U>,
    |        ^^^^ ^
-LL |     b: Rc<U>,
-   |        ^^^ ^
-LL |     b: &U,
-   |        ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/union/union-nonrepresentable.stderr
+++ b/src/test/ui/union/union-nonrepresentable.stderr
@@ -5,9 +5,16 @@ LL | union U {
    | ^^^^^^^ recursive type has infinite size
 LL |     a: u8,
 LL |     b: U,
-   |     ---- recursive without indirection
+   |        - recursive without indirection
    |
-   = help: insert indirection (e.g., a `Box`, `Rc`, or `&`) at some point to make `U` representable
+help: insert some indirection to make `U` representable
+   |
+LL |     b: Box<U>,
+   |        ^^^^ ^
+LL |     b: Rc<U>,
+   |        ^^^ ^
+LL |     b: &U,
+   |        ^
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Successful merges:

 - #71824 (Check for live drops in constants after drop elaboration)
 - #72740 (On recursive ADT, provide indirection structured suggestion)
 - #73104 (Example about explicit mutex dropping)
 - #73287 (lint: normalize projections using opaque types)
 - #73304 (Revert heterogeneous SocketAddr PartialEq impls)

Failed merges:


r? @ghost