### PR TITLE
[WIP] Add set_nonblocking method on Stdin

### DIFF
--- a/src/libstd/io/stdio.rs
+++ b/src/libstd/io/stdio.rs
@@ -98,7 +98,6 @@ impl Read for StdinRaw {
     }
 }
 impl StdinRaw {
-    #[cfg(any(unix, windows))]
     #[stable(since = "1.46.0", feature = "stdin_nonblocking")]
     pub unsafe fn set_nonblocking(&self, nonblocking: bool) -> io::Result<()> {
         self.0.set_nonblocking(nonblocking)
@@ -394,7 +393,6 @@ impl Stdin {
     ///     Ok(())
     /// }
     /// ```
-    #[cfg(any(unix, windows))]
     #[stable(since = "1.46.0", feature = "stdin_nonblocking")]
     pub unsafe fn set_nonblocking(&self, nonblocking: bool) -> io::Result<()> {
         self.lock().set_nonblocking(nonblocking)
@@ -495,7 +493,6 @@ impl StdinLock<'_> {
     ///     Ok(())
     /// }
     /// ```
-    #[cfg(any(unix, windows))]
     #[stable(since = "1.46.0", feature = "stdin_nonblocking")]
     pub unsafe fn set_nonblocking(&self, nonblocking: bool) -> io::Result<()> {
         match self.inner.get_ref() {

--- a/src/libstd/sys/unix/stdio.rs
+++ b/src/libstd/sys/unix/stdio.rs
@@ -1,5 +1,6 @@
 use crate::io::{self, IoSlice, IoSliceMut};
 use crate::mem::ManuallyDrop;
+use crate::sys::cvt;
 use crate::sys::fd::FileDesc;
 
 pub struct Stdin(());
@@ -9,6 +10,16 @@ pub struct Stderr(());
 impl Stdin {
     pub fn new() -> io::Result<Stdin> {
         Ok(Stdin(()))
+    }
+    pub unsafe fn set_nonblocking(&self, nonblocking: bool) -> io::Result<()> {
+        let mut flags = libc::fcntl(libc::STDIN_FILENO, libc::F_GETFL);
+        if nonblocking {
+            flags |= libc::O_NONBLOCK;
+        } else {
+            flags &= !libc::O_NONBLOCK;
+        }
+        cvt(libc::fcntl(libc::STDIN_FILENO, libc::F_SETFL, flags))?;
+        Ok(())
     }
 }
 

--- a/src/libstd/sys/windows/c.rs
+++ b/src/libstd/sys/windows/c.rs
@@ -669,6 +669,7 @@ if #[cfg(not(target_vendor = "uwp"))] {
     pub const HANDLE_FLAG_INHERIT: DWORD = 0x00000001;
 
     pub const TOKEN_READ: DWORD = 0x20008;
+    pub const ENABLE_LINE_INPUT: DWORD = 0x0002;
 
     extern "system" {
         #[link_name = "SystemFunction036"]
@@ -688,6 +689,8 @@ if #[cfg(not(target_vendor = "uwp"))] {
 
         pub fn GetConsoleMode(hConsoleHandle: HANDLE,
                               lpMode: LPDWORD) -> BOOL;
+        pub fn SetConsoleMode(hConsoleHandle: HANDLE,
+                              lpMode: DWORD) -> BOOL;
         // Allowed but unused by UWP
         pub fn OpenProcessToken(ProcessHandle: HANDLE,
                                 DesiredAccess: DWORD,

--- a/src/libstd/sys/windows/stdio.rs
+++ b/src/libstd/sys/windows/stdio.rs
@@ -134,6 +134,28 @@ impl Stdin {
     pub fn new() -> io::Result<Stdin> {
         Ok(Stdin { surrogate: 0 })
     }
+    pub unsafe fn set_nonblocking(&self, nonblocking: bool) -> io::Result<()> {
+        let handle = get_handle(c::STD_INPUT_HANDLE)?;
+        let mut mode = 0;
+        if c::GetConsoleMode(handle, &mut mode) == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "Cannot get console mode for the given handle",
+            ));
+        }
+        if nonblocking {
+            mode &= !c::ENABLE_LINE_INPUT;
+        } else {
+            mode |= c::ENABLE_LINE_INPUT;
+        }
+        if c::SetConsoleMode(handle, mode) == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "Cannot set console mode for the given handle",
+            ));
+        }
+        Ok(())
+    }
 }
 
 impl io::Read for Stdin {


### PR DESCRIPTION
We have `set_nonblocking` method on sockets, but not on stdin, which is very useful. So I guess it might makes sense to have it in the stdlib as well. What do you think?