### PR TITLE
Add rust specific features to print target features

### DIFF
--- a/src/rustllvm/PassWrapper.cpp
+++ b/src/rustllvm/PassWrapper.cpp
@@ -425,7 +425,11 @@ extern "C" void LLVMRustPrintTargetFeatures(LLVMTargetMachineRef TM) {
   for (auto &Feature : FeatTable)
     printf("    %-*s - %s.\n", MaxFeatLen, Feature.Key, Feature.Desc);
   printf("Rust-specific features:\n");
-  printf("    %-*s - %s.\n", MaxFeatLen, "crt-static", "Enables libraries with C Run-time Libraries(CRT) to be statically linked");
+  printf("    %-*s - %s.\n", 
+    MaxFeatLen, 
+    "crt-static", 
+    "Enables libraries with C Run-time Libraries(CRT) to be statically linked"
+  );
   printf("\n");
 
   printf("Use +feature to enable a feature, or -feature to disable it.\n"

--- a/src/rustllvm/PassWrapper.cpp
+++ b/src/rustllvm/PassWrapper.cpp
@@ -425,9 +425,9 @@ extern "C" void LLVMRustPrintTargetFeatures(LLVMTargetMachineRef TM) {
   for (auto &Feature : FeatTable)
     printf("    %-*s - %s.\n", MaxFeatLen, Feature.Key, Feature.Desc);
   printf("Rust-specific features:\n");
-  printf("    %-*s - %s.\n", 
-    MaxFeatLen, 
-    "crt-static", 
+  printf("    %-*s - %s.\n",
+    MaxFeatLen,
+    "crt-static",
     "Enables libraries with C Run-time Libraries(CRT) to be statically linked"
   );
   printf("\n");

--- a/src/rustllvm/PassWrapper.cpp
+++ b/src/rustllvm/PassWrapper.cpp
@@ -424,7 +424,7 @@ extern "C" void LLVMRustPrintTargetFeatures(LLVMTargetMachineRef TM) {
   printf("Available features for this target:\n");
   for (auto &Feature : FeatTable)
     printf("    %-*s - %s.\n", MaxFeatLen, Feature.Key, Feature.Desc);
-  printf("Rust-specific features:\n");
+  printf("\nRust-specific features:\n");
   printf("    %-*s - %s.\n",
     MaxFeatLen,
     "crt-static",

--- a/src/rustllvm/PassWrapper.cpp
+++ b/src/rustllvm/PassWrapper.cpp
@@ -424,8 +424,7 @@ extern "C" void LLVMRustPrintTargetFeatures(LLVMTargetMachineRef TM) {
   printf("Available features for this target:\n");
   for (auto &Feature : FeatTable)
     printf("    %-*s - %s.\n", MaxFeatLen, Feature.Key, Feature.Desc);
-  printf("\n");
-  // Rust specific target features
+  printf("Rust-specific features:\n");
   printf("    %-*s - %s.\n", MaxFeatLen, "crt-static", "Enables libraries with C Run-time Libraries(CRT) to be statically linked");
   printf("\n");
 

--- a/src/rustllvm/PassWrapper.cpp
+++ b/src/rustllvm/PassWrapper.cpp
@@ -425,6 +425,9 @@ extern "C" void LLVMRustPrintTargetFeatures(LLVMTargetMachineRef TM) {
   for (auto &Feature : FeatTable)
     printf("    %-*s - %s.\n", MaxFeatLen, Feature.Key, Feature.Desc);
   printf("\n");
+  // Rust specific target features
+  printf("    %-*s - %s.\n", MaxFeatLen, "crt-static", "Enables libraries with C Run-time Libraries(CRT) to be statically linked");
+  printf("\n");
 
   printf("Use +feature to enable a feature, or -feature to disable it.\n"
          "For example, rustc -C -target-cpu=mycpu -C "


### PR DESCRIPTION
Fixes #71583

`crt-static` is a rust specific target feature that's absent from llvm feature table, adding it there so that it shows under `rustc --print target-features`.

Probably the most native implementation I could think of, would love to get feedback.