### PR TITLE
bootstrap/install.rs: support a nonexistent `prefix` in `x.py install`

### DIFF
--- a/src/bootstrap/install.rs
+++ b/src/bootstrap/install.rs
@@ -70,7 +70,10 @@ fn install_sh(
     let libdir_default = PathBuf::from("lib");
     let mandir_default = datadir_default.join("man");
     let prefix = builder.config.prefix.as_ref().map_or(prefix_default, |p| {
-        fs::canonicalize(p).unwrap_or_else(|_| panic!("could not canonicalize {}", p.display()))
+        fs::create_dir_all(p)
+            .unwrap_or_else(|err| panic!("could not create {}: {}", p.display(), err));
+        fs::canonicalize(p)
+            .unwrap_or_else(|err| panic!("could not canonicalize {}: {}", p.display(), err))
     });
     let sysconfdir = builder.config.sysconfdir.as_ref().unwrap_or(&sysconfdir_default);
     let datadir = builder.config.datadir.as_ref().unwrap_or(&datadir_default);


### PR DESCRIPTION
PR #49778 introduced fs::canonicalize() which fails for a nonexistent path.
This is a surprise for someone used to GNU Autotools' configure which can create any necessary intermediate directories in prefix.

This change makes it run fs::create_dir_all() before canonicalize().