### PR TITLE
Update E0446.md

### DIFF
--- a/src/librustc_error_codes/error_codes/E0446.md
+++ b/src/librustc_error_codes/error_codes/E0446.md
@@ -4,10 +4,10 @@ Erroneous code example:
 
 ```compile_fail,E0446
 #![deny(private_in_public)]
+struct Bar(u32);
 
-mod Foo {
-    struct Bar(u32);
-
+mod foo {
+    use crate::Bar;
     pub fn bar() -> Bar { // error: private type in public interface
         Bar(0)
     }
@@ -16,15 +16,31 @@ mod Foo {
 fn main() {}
 ```
 
-To solve this error, please ensure that the type is also public. The type
-can be made inaccessible if necessary by placing it into a private inner
-module, but it still has to be marked with `pub`.
+There are two ways to solve this error. The first is to make the public type
+signature only public to a module that also has access to the private type.
+This is done by using pub(crate) or pub(in crate::my_mod::etc)
 Example:
 
 ```
-mod Foo {
-    pub struct Bar(u32); // we set the Bar type public
+struct Bar(u32);
 
+mod foo {
+    use crate::Bar;
+    pub(crate) fn bar() -> Bar { // only public to crate root
+        Bar(0)
+    }
+}
+
+fn main() {}
+```
+
+The other way to solve this error is to make the private type public.
+Example:
+
+```
+pub struct Bar(u32); // we set the Bar type public
+mod foo {
+    use crate::Bar;
     pub fn bar() -> Bar { // ok!
         Bar(0)
     }


### PR DESCRIPTION
The existing error documentation did not show how to use a child module's functions if the types used in those functions are private. These are some other places this problem has popped up that did not present a solution (these are from before the solution existed, 2016-2017. The solution was released in the Rust 2018 edition. However these were the places I was pointed to when I encountered the problem myself):
https://github.com/rust-lang/rust/issues/30905
https://stackoverflow.com/questions/39334430/how-to-reference-private-types-from-public-functions-in-private-modules/62374958#62374958