### PR TITLE
shim.rs: avoid creating `Call` terminators calling `Self`

### DIFF
--- a/src/librustc_trait_selection/traits/util.rs
+++ b/src/librustc_trait_selection/traits/util.rs
@@ -302,7 +302,7 @@ pub fn get_vtable_index_of_object_method<N>(
 ) -> usize {
     // Count number of methods preceding the one we are selecting and
     // add them to the total offset.
-    // Skip over associated types and constants.
+    // Skip over associated types and constants, as those aren't stored in the vtable.
     let mut entries = object.vtable_base;
     for trait_item in tcx.associated_items(object.upcast_trait_ref.def_id()).in_definition_order() {
         if trait_item.def_id == method_def_id {

--- a/src/test/mir-opt/fn-ptr-shim.rs
+++ b/src/test/mir-opt/fn-ptr-shim.rs
@@ -1,0 +1,15 @@
+// compile-flags: -Zmir-opt-level=0 -Zvalidate-mir
+
+// Tests that the `<fn() as Fn>` shim does not create a `Call` terminator with a `Self` callee
+// (as only `FnDef` and `FnPtr` callees are allowed in MIR).
+
+// EMIT_MIR rustc.ops-function-Fn-call.AddMovesForPackedDrops.before.mir
+fn main() {
+    call(noop as fn());
+}
+
+fn noop() {}
+
+fn call<F: Fn()>(f: F) {
+    f();
+}

--- a/src/test/mir-opt/fn-ptr-shim/rustc.ops-function-Fn-call.AddMovesForPackedDrops.before.mir
+++ b/src/test/mir-opt/fn-ptr-shim/rustc.ops-function-Fn-call.AddMovesForPackedDrops.before.mir
@@ -1,0 +1,13 @@
+// MIR for `std::ops::Fn::call` before AddMovesForPackedDrops
+
+fn std::ops::Fn::call(_1: *const fn(), _2: Args) -> <Self as std::ops::FnOnce<Args>>::Output {
+    let mut _0: <Self as std::ops::FnOnce<Args>>::Output; // return place in scope 0 at $SRC_DIR/libcore/ops/function.rs:LL:COL
+
+    bb0: {
+        _0 = move (*_1)() -> bb1;        // scope 0 at $SRC_DIR/libcore/ops/function.rs:LL:COL
+    }
+
+    bb1: {
+        return;                          // scope 0 at $SRC_DIR/libcore/ops/function.rs:LL:COL
+    }
+}


### PR DESCRIPTION
Also contains some cleanup and doc comment additions so I could make sense of the code.

Fixes https://github.com/rust-lang/rust/issues/73109
Closes https://github.com/rust-lang/rust/pull/73175

r? @matthewjasper 