### PR TITLE
Record visibility of reexports for all items, not just type items

### DIFF
--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -303,26 +303,22 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
         if !res_did.is_local() && !is_no_inline {
             let attrs = clean::inline::load_attrs(self.cx, res_did);
             let self_is_hidden = attrs.lists(sym::doc).has_word(sym::hidden);
-            match res {
-                Res::Def(
-                    DefKind::Trait
-                    | DefKind::Struct
-                    | DefKind::Union
-                    | DefKind::Enum
-                    | DefKind::ForeignTy
-                    | DefKind::TyAlias,
-                    did,
-                ) if !self_is_hidden => {
-                    self.cx.renderinfo.get_mut().access_levels.map.insert(did, AccessLevel::Public);
-                }
-                Res::Def(DefKind::Mod, did) => {
-                    if !self_is_hidden {
-                        crate::visit_lib::LibEmbargoVisitor::new(self.cx).visit_mod(did);
+            if !self_is_hidden {
+                if let Res::Def(kind, did) = res {
+                    if kind == DefKind::Mod {
+                        crate::visit_lib::LibEmbargoVisitor::new(self.cx).visit_mod(did)
+                    } else {
+                        // All items need to be handled here in case someone wishes to link
+                        // to them with intra-doc links
+                        self.cx
+                            .renderinfo
+                            .get_mut()
+                            .access_levels
+                            .map
+                            .insert(did, AccessLevel::Public);
                     }
                 }
-                _ => {}
             }
-
             return false;
         }
 

--- a/src/test/rustdoc/intra-doc-crate/auxiliary/hidden.rs
+++ b/src/test/rustdoc/intra-doc-crate/auxiliary/hidden.rs
@@ -1,0 +1,19 @@
+#![crate_name = "hidden_dep"]
+#![deny(intra_doc_resolution_failure)]
+
+#[doc(hidden)]
+pub mod __reexport {
+    pub use crate::*;
+}
+
+pub mod future {
+    mod ready {
+
+        /// Link to [`ready`](function@ready)
+        pub struct Ready;
+        pub fn ready() {}
+
+    }
+    pub use self::ready::{ready, Ready};
+
+}

--- a/src/test/rustdoc/intra-doc-crate/auxiliary/hidden.rs
+++ b/src/test/rustdoc/intra-doc-crate/auxiliary/hidden.rs
@@ -1,5 +1,5 @@
 #![crate_name = "hidden_dep"]
-#![deny(intra_doc_resolution_failure)]
+#![deny(intra_doc_link_resolution_failure)]
 
 #[doc(hidden)]
 pub mod __reexport {

--- a/src/test/rustdoc/intra-doc-crate/hidden.rs
+++ b/src/test/rustdoc/intra-doc-crate/hidden.rs
@@ -1,6 +1,6 @@
 // aux-build:hidden.rs
 // build-aux-docs
-#![deny(intra_doc_resolution_failure)]
+#![deny(intra_doc_link_resolution_failure)]
 
 // tests https://github.com/rust-lang/rust/issues/73363
 

--- a/src/test/rustdoc/intra-doc-crate/hidden.rs
+++ b/src/test/rustdoc/intra-doc-crate/hidden.rs
@@ -1,0 +1,10 @@
+// aux-build:hidden.rs
+// build-aux-docs
+#![deny(intra_doc_resolution_failure)]
+
+// tests https://github.com/rust-lang/rust/issues/73363
+
+extern crate hidden_dep;
+
+// @has 'hidden/struct.Ready.html' '//a/@href' '../hidden/fn.ready.html'
+pub use hidden_dep::future::{ready, Ready};


### PR DESCRIPTION
This fixes https://github.com/rust-lang/rust/issues/73363

Unfortunately I can't add a test for this since this bug is obscured by the cross-crate bug, being fixed in https://github.com/rust-lang/rust/issues/73363 . Tests will be added later.


cc @jyn514

r? @GuillaumeGomez