### PR TITLE
rustbuild: Move compiler-builtins build logic to manifest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,16 +33,16 @@ exclude = [
   "obj",
 ]
 
-# These options are controlled from our rustc wrapper script, so turn them off
-# here and have them controlled elsewhere.
-[profile.dev]
-debug = false
-debug-assertions = false
-[profile.test]
-debug = false
-debug-assertions = false
-
 [profile.release.package.compiler_builtins]
+# The compiler-builtins crate cannot reference libcore, and it's own CI will
+# verify that this is the case. This requires, however, that the crate is built
+# without overflow checks and debug assertions. Forcefully disable debug
+# assertions and overflow checks here which should ensure that even if these
+# assertions are enabled for libstd we won't enable then for compiler_builtins
+# which should ensure we still link everything correctly.
+debug-assertions = false
+overflow-checks = false
+
 # For compiler-builtins we always use a high number of codegen units.
 # The goal here is to place every single intrinsic into its own object
 # file to avoid symbol clashes with the system libgcc if possible. Note

--- a/src/bootstrap/bin/rustc.rs
+++ b/src/bootstrap/bin/rustc.rs
@@ -101,30 +101,6 @@ fn main() {
         {
             cmd.arg("-C").arg("panic=abort");
         }
-
-        // Set various options from config.toml to configure how we're building
-        // code.
-        let debug_assertions = match env::var("RUSTC_DEBUG_ASSERTIONS") {
-            Ok(s) => {
-                if s == "true" {
-                    "y"
-                } else {
-                    "n"
-                }
-            }
-            Err(..) => "n",
-        };
-
-        // The compiler builtins are pretty sensitive to symbols referenced in
-        // libcore and such, so we never compile them with debug assertions.
-        //
-        // FIXME(rust-lang/cargo#7253) we should be doing this in `builder.rs`
-        // with env vars instead of doing it here in this script.
-        if crate_name == Some("compiler_builtins") {
-            cmd.arg("-C").arg("debug-assertions=no");
-        } else {
-            cmd.arg("-C").arg(format!("debug-assertions={}", debug_assertions));
-        }
     } else {
         // FIXME(rust-lang/cargo#5754) we shouldn't be using special env vars
         // here, but rather Cargo should know what flags to pass rustc itself.

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -950,14 +950,6 @@ impl<'a> Builder<'a> {
             .env("RUSTC", self.out.join("bootstrap/debug/rustc"))
             .env("RUSTC_REAL", self.rustc(compiler))
             .env("RUSTC_STAGE", stage.to_string())
-            .env(
-                "RUSTC_DEBUG_ASSERTIONS",
-                if mode == Mode::Std {
-                    self.config.rust_debug_assertions_std.to_string()
-                } else {
-                    self.config.rust_debug_assertions.to_string()
-                },
-            )
             .env("RUSTC_SYSROOT", &sysroot)
             .env("RUSTC_LIBDIR", &libdir)
             .env("RUSTDOC", self.out.join("bootstrap/debug/rustdoc"))
@@ -1041,6 +1033,14 @@ impl<'a> Builder<'a> {
             }
         };
         cargo.env(profile_var("DEBUG"), debuginfo_level.to_string());
+        cargo.env(
+            profile_var("DEBUG_ASSERTIONS"),
+            if mode == Mode::Std {
+                self.config.rust_debug_assertions_std.to_string()
+            } else {
+                self.config.rust_debug_assertions.to_string()
+            },
+        );
 
         if !mode.is_tool() {
             cargo.env("RUSTC_FORCE_UNSTABLE", "1");


### PR DESCRIPTION
This commit moves the compiler-builtins-specific build logic from
`src/bootstrap/bin/rustc.rs` into the workspace `Cargo.toml`'s
`[profile]` configuration. Now that rust-lang/cargo#7253 is fixed we can
ensure that Cargo knows about debug assertions settings, and it can also
be configured to specifically disable debug assertions unconditionally
for compiler-builtins. This should improve rebuild logic when
debug-assertions settings change and also improve build-std integration
where Cargo externally now has an avenue to learn how to build
compiler-builtins as well.