### PR TITLE
stabilize const mem::discriminant

### DIFF
--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -1914,7 +1914,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is
     /// [`std::mem::discriminant`](../../std/mem/fn.discriminant.html)
-    #[rustc_const_unstable(feature = "const_discriminant", issue = "69821")]
+    #[rustc_const_stable(feature = "const_discriminant", since = "1.46.0")]
     pub fn discriminant_value<T>(v: &T) -> <T as DiscriminantKind>::Discriminant;
 
     /// Rust's "try catch" construct which invokes the function pointer `try_fn`

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -72,7 +72,6 @@
 #![feature(concat_idents)]
 #![feature(const_ascii_ctype_on_intrinsics)]
 #![feature(const_alloc_layout)]
-#![feature(const_discriminant)]
 #![feature(const_if_match)]
 #![feature(const_loop)]
 #![feature(const_checked_int_methods)]

--- a/src/libcore/mem/mod.rs
+++ b/src/libcore/mem/mod.rs
@@ -993,7 +993,7 @@ impl<T> fmt::Debug for Discriminant<T> {
 /// assert_ne!(mem::discriminant(&Foo::B(3)), mem::discriminant(&Foo::C(3)));
 /// ```
 #[stable(feature = "discriminant_value", since = "1.21.0")]
-#[rustc_const_unstable(feature = "const_discriminant", issue = "69821")]
+#[rustc_const_stable(feature = "const_discriminant", since = "1.46.0")]
 pub const fn discriminant<T>(v: &T) -> Discriminant<T> {
     Discriminant(intrinsics::discriminant_value(v))
 }

--- a/src/test/ui/consts/const_discriminant.rs
+++ b/src/test/ui/consts/const_discriminant.rs
@@ -1,5 +1,4 @@
 // run-pass
-#![feature(const_discriminant)]
 #![allow(dead_code)]
 
 use std::mem::{discriminant, Discriminant};
@@ -20,6 +19,8 @@ const TEST_A: Discriminant<Test> = discriminant(&Test::A(5));
 const TEST_A_OTHER: Discriminant<Test> = discriminant(&Test::A(17));
 const TEST_B: Discriminant<Test> = discriminant(&Test::B);
 
+const TEST_TRIVIAL: Discriminant<u32> = discriminant(&42);
+
 enum Void {}
 
 enum SingleVariant {
@@ -37,4 +38,6 @@ fn main() {
     assert_ne!(TEST_B, discriminant(identity(&Test::C { a: 42, b: 7 })));
 
     assert_eq!(TEST_V, discriminant(identity(&SingleVariant::V)));
+
+    assert_eq!(TEST_TRIVIAL, discriminant(identity(&42)));
 }


### PR DESCRIPTION
Changes `mem::discriminant` to be const stable starting at version 1.46.0

closes #69821