### PR TITLE
Update CFGuard syntax

### DIFF
--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -1176,7 +1176,7 @@ impl<'a> Builder<'a> {
             );
         }
 
-        // If Control Flow Guard is enabled, pass the `control_flow_guard=checks` flag to rustc
+        // If Control Flow Guard is enabled, pass the `control-flow-guard` flag to rustc
         // when compiling the standard library, since this might be linked into the final outputs
         // produced by rustc. Since this mitigation is only available on Windows, only enable it
         // for the standard library in case the compiler is run on a non-Windows platform.
@@ -1187,7 +1187,7 @@ impl<'a> Builder<'a> {
             && self.config.control_flow_guard
             && compiler.stage >= 1
         {
-            rustflags.arg("-Zcontrol_flow_guard=checks");
+            rustflags.arg("-Zcontrol-flow-guard");
         }
 
         // For `cargo doc` invocations, make rustdoc print the Rust version into the docs

--- a/src/doc/unstable-book/src/compiler-flags/control-flow-guard.md
+++ b/src/doc/unstable-book/src/compiler-flags/control-flow-guard.md
@@ -1,10 +1,10 @@
-# `control_flow_guard`
+# `control-flow-guard`
 
 The tracking issue for this feature is: [#68793](https://github.com/rust-lang/rust/issues/68793).
 
 ------------------------
 
-The rustc flag `-Z control_flow_guard=checks` enables the Windows [Control Flow Guard](https://docs.microsoft.com/en-us/windows/win32/secbp/control-flow-guard) (CFG) platform security feature.
+The rustc flag `-Z control-flow-guard` enables the Windows [Control Flow Guard](https://docs.microsoft.com/en-us/windows/win32/secbp/control-flow-guard) (CFG) platform security feature.
 
 CFG is an exploit mitigation designed to enforce control-flow integrity for software running on supported Windows platforms (Windows 8.1 onwards). Specifically, CFG uses runtime checks to validate the target address of every indirect call/jump before allowing the call to complete. 
 
@@ -29,7 +29,7 @@ The CFG checks and metadata can potentially increase binary size and runtime ove
 
 ## Testing Control Flow Guard
 
-The rustc flag `-Z control_flow_guard=nochecks` instructs LLVM to emit the list of valid call targets without inserting runtime checks. This flag should only be used for testing purposes as it does not provide security enforcement.
+The rustc flag `-Z control-flow-guard=nochecks` instructs LLVM to emit the list of valid call targets without inserting runtime checks. This flag should only be used for testing purposes as it does not provide security enforcement.
 
 
 ## Control Flow Guard in libraries
@@ -44,14 +44,14 @@ For example:
 ```cmd
 rustup toolchain install --force nightly
 rustup component add rust-src
-SET RUSTFLAGS=-Z control_flow_guard=checks
+SET RUSTFLAGS=-Z control-flow-guard
 cargo +nightly build -Z build-std --target x86_64-pc-windows-msvc
 ```
 
 ```PowerShell
 rustup toolchain install --force nightly
 rustup component add rust-src
-$Env:RUSTFLAGS = "-Z control_flow_guard=checks"
+$Env:RUSTFLAGS = "-Z control-flow-guard"
 cargo +nightly build -Z build-std --target x86_64-pc-windows-msvc
 ```
 

--- a/src/librustc_interface/tests.rs
+++ b/src/librustc_interface/tests.rs
@@ -463,7 +463,6 @@ fn test_debugging_options_tracking_hash() {
     untracked!(ast_json_noexpand, true);
     untracked!(borrowck, String::from("other"));
     untracked!(borrowck_stats, true);
-    untracked!(control_flow_guard, CFGuard::Checks);
     untracked!(deduplicate_diagnostics, true);
     untracked!(dep_tasks, true);
     untracked!(dont_buffer_diagnostics, true);
@@ -537,6 +536,7 @@ fn test_debugging_options_tracking_hash() {
     tracked!(binary_dep_depinfo, true);
     tracked!(chalk, true);
     tracked!(codegen_backend, Some("abc".to_string()));
+    tracked!(control_flow_guard, CFGuard::Checks);
     tracked!(crate_attr, vec!["abc".to_string()]);
     tracked!(debug_macros, true);
     tracked!(dep_info_omit_d_target, true);

--- a/src/librustc_session/config.rs
+++ b/src/librustc_session/config.rs
@@ -82,7 +82,7 @@ pub enum Strip {
     Symbols,
 }
 
-/// The different settings that the `-Z control_flow_guard` flag can have.
+/// The different settings that the `-Z control-flow-guard` flag can have.
 #[derive(Clone, Copy, PartialEq, Hash, Debug)]
 pub enum CFGuard {
     /// Do not emit Control Flow Guard metadata or checks.

--- a/src/librustc_session/options.rs
+++ b/src/librustc_session/options.rs
@@ -251,7 +251,8 @@ macro_rules! options {
         pub const parse_sanitizer: &str = "one of: `address`, `leak`, `memory` or `thread`";
         pub const parse_sanitizer_list: &str = "comma separated list of sanitizers";
         pub const parse_sanitizer_memory_track_origins: &str = "0, 1, or 2";
-        pub const parse_cfguard: &str = "either `disabled`, `nochecks`, or `checks`";
+        pub const parse_cfguard: &str =
+            "either a boolean (`yes`, `no`, `on`, `off`, etc), `checks`, or `nochecks`";
         pub const parse_strip: &str = "either `none`, `debuginfo`, or `symbols`";
         pub const parse_linker_flavor: &str = ::rustc_target::spec::LinkerFlavor::one_of();
         pub const parse_optimization_fuel: &str = "crate=integer";
@@ -505,12 +506,24 @@ macro_rules! options {
         }
 
         fn parse_cfguard(slot: &mut CFGuard, v: Option<&str>) -> bool {
-            match v {
-                Some("disabled") => *slot = CFGuard::Disabled,
-                Some("nochecks") => *slot = CFGuard::NoChecks,
-                Some("checks") => *slot = CFGuard::Checks,
-                _ => return false,
+            if v.is_some() {
+                let mut bool_arg = None;
+                if parse_opt_bool(&mut bool_arg, v) {
+                    *slot = if bool_arg.unwrap() {
+                        CFGuard::Checks
+                    } else {
+                        CFGuard::Disabled
+                    };
+                    return true
+                }
             }
+
+            *slot = match v {
+                None => CFGuard::Checks,
+                Some("checks") => CFGuard::Checks,
+                Some("nochecks") => CFGuard::NoChecks,
+                Some(_) => return false,
+            };
             true
         }
 
@@ -806,8 +819,8 @@ options! {DebuggingOptions, DebuggingSetter, basic_debugging_options,
         "enable the experimental Chalk-based trait solving engine"),
     codegen_backend: Option<String> = (None, parse_opt_string, [TRACKED],
         "the backend to use"),
-    control_flow_guard: CFGuard = (CFGuard::Disabled, parse_cfguard, [UNTRACKED],
-        "use Windows Control Flow Guard (`disabled`, `nochecks` or `checks`)"),
+    control_flow_guard: CFGuard = (CFGuard::Disabled, parse_cfguard, [TRACKED],
+        "use Windows Control Flow Guard (default: no)"),
     crate_attr: Vec<String> = (Vec::new(), parse_string_push, [TRACKED],
         "inject the given attribute in the crate"),
     debug_macros: bool = (false, parse_bool, [TRACKED],

--- a/src/test/codegen/cfguard_checks.rs
+++ b/src/test/codegen/cfguard_checks.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Z control_flow_guard=checks
+// compile-flags: -Z control-flow-guard=checks
 
 #![crate_type = "lib"]
 

--- a/src/test/codegen/cfguard_disabled.rs
+++ b/src/test/codegen/cfguard_disabled.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Z control_flow_guard=disabled
+// compile-flags: -Z control-flow-guard=no
 
 #![crate_type = "lib"]
 

--- a/src/test/codegen/cfguard_nochecks.rs
+++ b/src/test/codegen/cfguard_nochecks.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Z control_flow_guard=nochecks
+// compile-flags: -Z control-flow-guard=nochecks
 
 #![crate_type = "lib"]
 


### PR DESCRIPTION
Update the naming and syntax of the control-flow-guard option, as discussed in #68793.

r? @Mark-Simulacrum 