### PR TITLE
Add src/librustdoc as an alias for src/tools/rustdoc

### DIFF
--- a/src/bootstrap/tool.rs
+++ b/src/bootstrap/tool.rs
@@ -481,7 +481,7 @@ impl Step for Rustdoc {
     const ONLY_HOSTS: bool = true;
 
     fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
-        run.path("src/tools/rustdoc")
+        run.path("src/tools/rustdoc").path("src/librustdoc")
     }
 
     fn make_run(run: RunConfig<'_>) {


### PR DESCRIPTION
No one actually works with src/tools/rustdoc, it's almost empty.

Closes https://github.com/rust-lang/rust/issues/73439