### PR TITLE
Make novel structural match violations not a `bug`

### DIFF
--- a/src/librustc_mir_build/hair/pattern/const_to_pat.rs
+++ b/src/librustc_mir_build/hair/pattern/const_to_pat.rs
@@ -109,9 +109,12 @@ impl<'a, 'tcx> ConstToPat<'a, 'tcx> {
 
             // This can occur because const qualification treats all associated constants as
             // opaque, whereas `search_for_structural_match_violation` tries to monomorphize them
-            // before it runs. See #73431 for an example.
+            // before it runs.
+            //
+            // FIXME(#73448): Find a way to bring const qualification into parity with
+            // `search_for_structural_match_violation`.
             if structural.is_none() && mir_structural_match_violation {
-                warn!("MIR const-checker found novel structural match violation");
+                warn!("MIR const-checker found novel structural match violation. See #73448.");
                 return inlined_const_as_pat;
             }
 

--- a/src/librustc_mir_build/hair/pattern/const_to_pat.rs
+++ b/src/librustc_mir_build/hair/pattern/const_to_pat.rs
@@ -107,8 +107,12 @@ impl<'a, 'tcx> ConstToPat<'a, 'tcx> {
                 cv.ty, structural
             );
 
+            // This can occur because const qualification treats all associated constants as
+            // opaque, whereas `search_for_structural_match_violation` tries to monomorphize them
+            // before it runs. See #73431 for an example.
             if structural.is_none() && mir_structural_match_violation {
-                bug!("MIR const-checker found novel structural match violation");
+                warn!("MIR const-checker found novel structural match violation");
+                return inlined_const_as_pat;
             }
 
             if let Some(non_sm_ty) = structural {

--- a/src/test/ui/consts/const_in_pattern/issue-73431.rs
+++ b/src/test/ui/consts/const_in_pattern/issue-73431.rs
@@ -1,0 +1,29 @@
+// run-pass
+
+// Regression test for https://github.com/rust-lang/rust/issues/73431.
+
+pub trait Zero {
+    const ZERO: Self;
+}
+
+impl Zero for usize {
+    const ZERO: Self = 0;
+}
+
+impl<T: Zero> Zero for Wrapper<T> {
+    const ZERO: Self = Wrapper(T::ZERO);
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct Wrapper<T>(T);
+
+fn is_zero(x: Wrapper<usize>) -> bool {
+    match x {
+        Zero::ZERO => true,
+        _ => false,
+    }
+}
+
+fn main() {
+    let _ = is_zero(Wrapper(42));
+}


### PR DESCRIPTION
Fixes (on master) #73431.

Ideally, `CustomEq` would emit a strict subset of the structural match errors that are found by `search_for_structural_match_violation`, since it allows more cases due to value-based reasoning. However, const qualification is more conservative than `search_for_structural_match_violation` around associated constants, since qualification does not try to substitute type parameters.

In the long term, we should probably make const qualification work for generic associated constants, but I don't like extending its capabilities even further.

r? @pnkfelix 