### PR TITLE
Update the doc for std::prelude to the correct behavior

### DIFF
--- a/src/libstd/prelude/mod.rs
+++ b/src/libstd/prelude/mod.rs
@@ -10,22 +10,6 @@
 //! things, particularly traits, which are used in almost every single Rust
 //! program.
 //!
-//! On a technical level, Rust inserts
-//!
-//! ```
-//! # #[allow(unused_extern_crates)]
-//! extern crate std;
-//! ```
-//!
-//! into the crate root of every crate, and
-//!
-//! ```
-//! # #[allow(unused_imports)]
-//! use std::prelude::v1::*;
-//! ```
-//!
-//! into every module.
-//!
 //! # Other preludes
 //!
 //! Preludes can be seen as a pattern to make using multiple types more


### PR DESCRIPTION
Fixes #64686.

One line change to ensure the docs are correct about the behavior of the compiler when inserting`std::prelude::v1`.

I don't think examples are necessary but I can add some (especially those from the original issue) if needed.