### PR TITLE
Use step_unchecked more liberally in range iter impls

### DIFF
--- a/src/libcore/iter/range.rs
+++ b/src/libcore/iter/range.rs
@@ -490,9 +490,6 @@ impl<A: Step> Iterator for ops::Range<A> {
     fn next(&mut self) -> Option<A> {
         if self.start < self.end {
             // SAFETY: just checked precondition
-            // We use the unchecked version here, because
-            // this helps LLVM vectorize loops for some ranges
-            // that don't get vectorized otherwise.
             let n = unsafe { Step::forward_unchecked(self.start.clone(), 1) };
             Some(mem::replace(&mut self.start, n))
         } else {
@@ -514,7 +511,8 @@ impl<A: Step> Iterator for ops::Range<A> {
     fn nth(&mut self, n: usize) -> Option<A> {
         if let Some(plus_n) = Step::forward_checked(self.start.clone(), n) {
             if plus_n < self.end {
-                self.start = Step::forward(plus_n.clone(), 1);
+                // SAFETY: just checked precondition
+                self.start = unsafe { Step::forward_unchecked(plus_n.clone(), 1) };
                 return Some(plus_n);
             }
         }
@@ -575,7 +573,8 @@ impl<A: Step> DoubleEndedIterator for ops::Range<A> {
     #[inline]
     fn next_back(&mut self) -> Option<A> {
         if self.start < self.end {
-            self.end = Step::backward(self.end.clone(), 1);
+            // SAFETY: just checked precondition
+            self.end = unsafe { Step::backward_unchecked(self.end.clone(), 1) };
             Some(self.end.clone())
         } else {
             None
@@ -586,7 +585,8 @@ impl<A: Step> DoubleEndedIterator for ops::Range<A> {
     fn nth_back(&mut self, n: usize) -> Option<A> {
         if let Some(minus_n) = Step::backward_checked(self.end.clone(), n) {
             if minus_n > self.start {
-                self.end = Step::backward(minus_n, 1);
+                // SAFETY: just checked precondition
+                self.end = unsafe { Step::backward_unchecked(minus_n, 1) };
                 return Some(self.end.clone());
             }
         }
@@ -643,9 +643,6 @@ impl<A: Step> Iterator for ops::RangeInclusive<A> {
         let is_iterating = self.start < self.end;
         Some(if is_iterating {
             // SAFETY: just checked precondition
-            // We use the unchecked version here, because
-            // otherwise `for _ in '\0'..=char::MAX`
-            // does not successfully remove panicking code.
             let n = unsafe { Step::forward_unchecked(self.start.clone(), 1) };
             mem::replace(&mut self.start, n)
         } else {
@@ -708,7 +705,8 @@ impl<A: Step> Iterator for ops::RangeInclusive<A> {
         let mut accum = init;
 
         while self.start < self.end {
-            let n = Step::forward(self.start.clone(), 1);
+            // SAFETY: just checked precondition
+            let n = unsafe { Step::forward_unchecked(self.start.clone(), 1) };
             let n = mem::replace(&mut self.start, n);
             accum = f(accum, n)?;
         }
@@ -761,7 +759,8 @@ impl<A: Step> DoubleEndedIterator for ops::RangeInclusive<A> {
         }
         let is_iterating = self.start < self.end;
         Some(if is_iterating {
-            let n = Step::backward(self.end.clone(), 1);
+            // SAFETY: just checked precondition
+            let n = unsafe { Step::backward_unchecked(self.end.clone(), 1) };
             mem::replace(&mut self.end, n)
         } else {
             self.exhausted = true;
@@ -811,7 +810,8 @@ impl<A: Step> DoubleEndedIterator for ops::RangeInclusive<A> {
         let mut accum = init;
 
         while self.start < self.end {
-            let n = Step::backward(self.end.clone(), 1);
+            // SAFETY: just checked precondition
+            let n = unsafe { Step::backward_unchecked(self.end.clone(), 1) };
             let n = mem::replace(&mut self.end, n);
             accum = f(accum, n)?;
         }


### PR DESCRIPTION
Without these `_unchecked`, these operations on iterators of `char` fail to optimize out the unreachable panicking condition on overflow.

cc @cuviper https://github.com/rayon-rs/rayon/pull/771 where this was discovered.