### PR TITLE
Cleanup MinGW LLVM linkage workaround

### DIFF
--- a/src/librustc_llvm/build.rs
+++ b/src/librustc_llvm/build.rs
@@ -293,11 +293,9 @@ fn main() {
         }
     }
 
-    // LLVM requires symbols from this library, but apparently they're not printed
-    // during llvm-config?
+    // Libstdc++ depends on pthread which Rust doesn't link on MinGW
+    // since nothing else requires it.
     if target.contains("windows-gnu") {
-        println!("cargo:rustc-link-lib=static-nobundle=gcc_s");
         println!("cargo:rustc-link-lib=static-nobundle=pthread");
-        println!("cargo:rustc-link-lib=dylib=uuid");
     }
 }


### PR DESCRIPTION
LLVM correctly passes `uuid` for a long time, GCC unwinding library (either static or dynamic) comes from [windows_gnu_base](https://github.com/rust-lang/rust/blob/06e47688bf15d0215edbe05b21603062f6d2eb5d/src/librustc_target/spec/windows_gnu_base.rs).