### PR TITLE
Show the values and computation that would overflow a const evaluation or propagation

### DIFF
--- a/src/librustc_codegen_ssa/mir/block.rs
+++ b/src/librustc_codegen_ssa/mir/block.rs
@@ -380,7 +380,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
         // checked operation, just a comparison with the minimum
         // value, so we have to check for the assert message.
         if !bx.check_overflow() {
-            if let AssertKind::OverflowNeg = *msg {
+            if let AssertKind::OverflowNeg(_) = *msg {
                 const_cond = Some(expected);
             }
         }

--- a/src/librustc_middle/mir/visit.rs
+++ b/src/librustc_middle/mir/visit.rs
@@ -571,7 +571,13 @@ macro_rules! make_mir_visitor {
                         self.visit_operand(len, location);
                         self.visit_operand(index, location);
                     }
-                    Overflow(_) | OverflowNeg | DivisionByZero | RemainderByZero |
+                    Overflow(_, l, r) => {
+                        self.visit_operand(l, location);
+                        self.visit_operand(r, location);
+                    }
+                    OverflowNeg(op) | DivisionByZero(op) | RemainderByZero(op) => {
+                        self.visit_operand(op, location);
+                    }
                     ResumedAfterReturn(_) | ResumedAfterPanic(_) => {
                         // Nothing to visit
                     }

--- a/src/librustc_middle/ty/consts.rs
+++ b/src/librustc_middle/ty/consts.rs
@@ -1,0 +1,111 @@
+use crate::mir::interpret::truncate;
+use rustc_target::abi::Size;
+
+#[derive(Copy, Clone)]
+/// A type for representing any integer. Only used for printing.
+// FIXME: Use this for the integer-tree representation needed for type level ints and
+// const generics?
+pub struct ConstInt {
+    /// Number of bytes of the integer. Only 1, 2, 4, 8, 16 are legal values.
+    size: u8,
+    /// Whether the value is of a signed integer type.
+    signed: bool,
+    /// Whether the value is a `usize` or `isize` type.
+    is_ptr_sized_integral: bool,
+    /// Raw memory of the integer. All bytes beyond the `size` are unused and must be zero.
+    raw: u128,
+}
+
+impl ConstInt {
+    pub fn new(raw: u128, size: Size, signed: bool, is_ptr_sized_integral: bool) -> Self {
+        assert!(raw <= truncate(u128::MAX, size));
+        Self { raw, size: size.bytes() as u8, signed, is_ptr_sized_integral }
+    }
+}
+
+impl std::fmt::Debug for ConstInt {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let Self { size, signed, raw, is_ptr_sized_integral } = *self;
+        if signed {
+            let bit_size = size * 8;
+            let min = 1u128 << (bit_size - 1);
+            let max = min - 1;
+            if raw == min {
+                match (size, is_ptr_sized_integral) {
+                    (_, true) => write!(fmt, "isize::MIN"),
+                    (1, _) => write!(fmt, "i8::MIN"),
+                    (2, _) => write!(fmt, "i16::MIN"),
+                    (4, _) => write!(fmt, "i32::MIN"),
+                    (8, _) => write!(fmt, "i64::MIN"),
+                    (16, _) => write!(fmt, "i128::MIN"),
+                    _ => bug!("ConstInt 0x{:x} with size = {} and signed = {}", raw, size, signed),
+                }
+            } else if raw == max {
+                match (size, is_ptr_sized_integral) {
+                    (_, true) => write!(fmt, "isize::MAX"),
+                    (1, _) => write!(fmt, "i8::MAX"),
+                    (2, _) => write!(fmt, "i16::MAX"),
+                    (4, _) => write!(fmt, "i32::MAX"),
+                    (8, _) => write!(fmt, "i64::MAX"),
+                    (16, _) => write!(fmt, "i128::MAX"),
+                    _ => bug!("ConstInt 0x{:x} with size = {} and signed = {}", raw, size, signed),
+                }
+            } else {
+                match size {
+                    1 => write!(fmt, "{}", raw as i8)?,
+                    2 => write!(fmt, "{}", raw as i16)?,
+                    4 => write!(fmt, "{}", raw as i32)?,
+                    8 => write!(fmt, "{}", raw as i64)?,
+                    16 => write!(fmt, "{}", raw as i128)?,
+                    _ => bug!("ConstInt 0x{:x} with size = {} and signed = {}", raw, size, signed),
+                }
+                if fmt.alternate() {
+                    match (size, is_ptr_sized_integral) {
+                        (_, true) => write!(fmt, "_isize")?,
+                        (1, _) => write!(fmt, "_i8")?,
+                        (2, _) => write!(fmt, "_i16")?,
+                        (4, _) => write!(fmt, "_i32")?,
+                        (8, _) => write!(fmt, "_i64")?,
+                        (16, _) => write!(fmt, "_i128")?,
+                        _ => bug!(),
+                    }
+                }
+                Ok(())
+            }
+        } else {
+            let max = truncate(u128::MAX, Size::from_bytes(size));
+            if raw == max {
+                match (size, is_ptr_sized_integral) {
+                    (_, true) => write!(fmt, "usize::MAX"),
+                    (1, _) => write!(fmt, "u8::MAX"),
+                    (2, _) => write!(fmt, "u16::MAX"),
+                    (4, _) => write!(fmt, "u32::MAX"),
+                    (8, _) => write!(fmt, "u64::MAX"),
+                    (16, _) => write!(fmt, "u128::MAX"),
+                    _ => bug!("ConstInt 0x{:x} with size = {} and signed = {}", raw, size, signed),
+                }
+            } else {
+                match size {
+                    1 => write!(fmt, "{}", raw as u8)?,
+                    2 => write!(fmt, "{}", raw as u16)?,
+                    4 => write!(fmt, "{}", raw as u32)?,
+                    8 => write!(fmt, "{}", raw as u64)?,
+                    16 => write!(fmt, "{}", raw as u128)?,
+                    _ => bug!("ConstInt 0x{:x} with size = {} and signed = {}", raw, size, signed),
+                }
+                if fmt.alternate() {
+                    match (size, is_ptr_sized_integral) {
+                        (_, true) => write!(fmt, "_usize")?,
+                        (1, _) => write!(fmt, "_u8")?,
+                        (2, _) => write!(fmt, "_u16")?,
+                        (4, _) => write!(fmt, "_u32")?,
+                        (8, _) => write!(fmt, "_u64")?,
+                        (16, _) => write!(fmt, "_u128")?,
+                        _ => bug!(),
+                    }
+                }
+                Ok(())
+            }
+        }
+    }
+}

--- a/src/librustc_middle/ty/mod.rs
+++ b/src/librustc_middle/ty/mod.rs
@@ -84,6 +84,8 @@ pub use self::trait_def::TraitDef;
 
 pub use self::query::queries;
 
+pub use self::consts::ConstInt;
+
 pub mod adjustment;
 pub mod binding;
 pub mod cast;
@@ -108,6 +110,7 @@ pub mod trait_def;
 pub mod util;
 pub mod walk;
 
+mod consts;
 mod context;
 mod diagnostics;
 mod instance;

--- a/src/librustc_mir/const_eval/error.rs
+++ b/src/librustc_mir/const_eval/error.rs
@@ -2,6 +2,7 @@ use std::error::Error;
 use std::fmt;
 
 use rustc_middle::mir::AssertKind;
+use rustc_middle::ty::ConstInt;
 use rustc_span::{Span, Symbol};
 
 use super::InterpCx;
@@ -13,7 +14,7 @@ pub enum ConstEvalErrKind {
     NeedsRfc(String),
     ConstAccessesStatic,
     ModifiedGlobal,
-    AssertFailure(AssertKind<u64>),
+    AssertFailure(AssertKind<ConstInt>),
     Panic { msg: Symbol, line: u32, col: u32, file: Symbol },
 }
 

--- a/src/librustc_mir/interpret/operand.rs
+++ b/src/librustc_mir/interpret/operand.rs
@@ -9,7 +9,7 @@ use rustc_hir::def::Namespace;
 use rustc_macros::HashStable;
 use rustc_middle::ty::layout::{PrimitiveExt, TyAndLayout};
 use rustc_middle::ty::print::{FmtPrinter, PrettyPrinter, Printer};
-use rustc_middle::ty::Ty;
+use rustc_middle::ty::{ConstInt, Ty};
 use rustc_middle::{mir, ty};
 use rustc_target::abi::{Abi, HasDataLayout, LayoutOf, Size, TagEncoding};
 use rustc_target::abi::{VariantIdx, Variants};
@@ -206,6 +206,19 @@ impl<'tcx, Tag: Copy> ImmTy<'tcx, Tag> {
     #[inline]
     pub fn from_int(i: impl Into<i128>, layout: TyAndLayout<'tcx>) -> Self {
         Self::from_scalar(Scalar::from_int(i, layout.size), layout)
+    }
+
+    #[inline]
+    pub fn to_const_int(self) -> ConstInt {
+        assert!(self.layout.ty.is_integral());
+        ConstInt::new(
+            self.to_scalar()
+                .expect("to_const_int doesn't work on scalar pairs")
+                .assert_bits(self.layout.size),
+            self.layout.size,
+            self.layout.ty.is_signed(),
+            self.layout.ty.is_ptr_sized_integral(),
+        )
     }
 }
 

--- a/src/librustc_mir_build/build/expr/as_rvalue.rs
+++ b/src/librustc_mir_build/build/expr/as_rvalue.rs
@@ -87,7 +87,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                         block,
                         Operand::Move(is_min),
                         false,
-                        AssertKind::OverflowNeg,
+                        AssertKind::OverflowNeg(arg.to_copy()),
                         expr_span,
                     );
                 }
@@ -288,7 +288,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 block,
                 source_info,
                 result_value,
-                Rvalue::CheckedBinaryOp(op, lhs, rhs),
+                Rvalue::CheckedBinaryOp(op, lhs.to_copy(), rhs.to_copy()),
             );
             let val_fld = Field::new(0);
             let of_fld = Field::new(1);
@@ -297,7 +297,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             let val = tcx.mk_place_field(result_value, val_fld, ty);
             let of = tcx.mk_place_field(result_value, of_fld, bool_ty);
 
-            let err = AssertKind::Overflow(op);
+            let err = AssertKind::Overflow(op, lhs, rhs);
 
             block = self.assert(block, Operand::Move(of), false, err, span);
 
@@ -308,11 +308,11 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 // and 2. there are two possible failure cases, divide-by-zero and overflow.
 
                 let zero_err = if op == BinOp::Div {
-                    AssertKind::DivisionByZero
+                    AssertKind::DivisionByZero(lhs.to_copy())
                 } else {
-                    AssertKind::RemainderByZero
+                    AssertKind::RemainderByZero(lhs.to_copy())
                 };
-                let overflow_err = AssertKind::Overflow(op);
+                let overflow_err = AssertKind::Overflow(op, lhs.to_copy(), rhs.to_copy());
 
                 // Check for / 0
                 let is_zero = self.temp(bool_ty, span);

--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -481,8 +481,8 @@ pub fn print_const(cx: &DocContext<'_>, n: &'tcx ty::Const<'_>) -> String {
         _ => {
             let mut s = n.to_string();
             // array lengths are obviously usize
-            if s.ends_with("usize") {
-                let n = s.len() - "usize".len();
+            if s.ends_with("_usize") {
+                let n = s.len() - "_usize".len();
                 s.truncate(n);
                 if s.ends_with(": ") {
                     let n = s.len() - ": ".len();

--- a/src/test/mir-opt/address-of/rustc.address_of_reborrow.SimplifyCfg-initial.after.mir
+++ b/src/test/mir-opt/address-of/rustc.address_of_reborrow.SimplifyCfg-initial.after.mir
@@ -128,7 +128,7 @@ fn address_of_reborrow() -> () {
     bb0: {
         StorageLive(_1);                 // scope 0 at $DIR/address-of.rs:4:9: 4:10
         StorageLive(_2);                 // scope 0 at $DIR/address-of.rs:4:14: 4:21
-        _2 = [const 0i32; 10];           // scope 0 at $DIR/address-of.rs:4:14: 4:21
+        _2 = [const 0_i32; 10];          // scope 0 at $DIR/address-of.rs:4:14: 4:21
                                          // ty::Const
                                          // + ty: i32
                                          // + val: Value(Scalar(0x00000000))
@@ -139,7 +139,7 @@ fn address_of_reborrow() -> () {
         FakeRead(ForLet, _1);            // scope 0 at $DIR/address-of.rs:4:9: 4:10
         StorageLive(_3);                 // scope 1 at $DIR/address-of.rs:5:9: 5:14
         StorageLive(_4);                 // scope 1 at $DIR/address-of.rs:5:22: 5:29
-        _4 = [const 0i32; 10];           // scope 1 at $DIR/address-of.rs:5:22: 5:29
+        _4 = [const 0_i32; 10];          // scope 1 at $DIR/address-of.rs:5:22: 5:29
                                          // ty::Const
                                          // + ty: i32
                                          // + val: Value(Scalar(0x00000000))

--- a/src/test/mir-opt/array-index-is-temporary/32bit/rustc.main.SimplifyCfg-elaborate-drops.after.mir
+++ b/src/test/mir-opt/array-index-is-temporary/32bit/rustc.main.SimplifyCfg-elaborate-drops.after.mir
@@ -25,7 +25,7 @@ fn main() -> () {
 
     bb0: {
         StorageLive(_1);                 // scope 0 at $DIR/array-index-is-temporary.rs:13:9: 13:14
-        _1 = [const 42u32, const 43u32, const 44u32]; // scope 0 at $DIR/array-index-is-temporary.rs:13:17: 13:29
+        _1 = [const 42_u32, const 43_u32, const 44_u32]; // scope 0 at $DIR/array-index-is-temporary.rs:13:17: 13:29
                                          // ty::Const
                                          // + ty: u32
                                          // + val: Value(Scalar(0x0000002a))
@@ -45,7 +45,7 @@ fn main() -> () {
                                          // + span: $DIR/array-index-is-temporary.rs:13:26: 13:28
                                          // + literal: Const { ty: u32, val: Value(Scalar(0x0000002c)) }
         StorageLive(_2);                 // scope 1 at $DIR/array-index-is-temporary.rs:14:9: 14:14
-        _2 = const 1usize;               // scope 1 at $DIR/array-index-is-temporary.rs:14:17: 14:18
+        _2 = const 1_usize;              // scope 1 at $DIR/array-index-is-temporary.rs:14:17: 14:18
                                          // ty::Const
                                          // + ty: usize
                                          // + val: Value(Scalar(0x00000001))

--- a/src/test/mir-opt/array-index-is-temporary/64bit/rustc.main.SimplifyCfg-elaborate-drops.after.mir
+++ b/src/test/mir-opt/array-index-is-temporary/64bit/rustc.main.SimplifyCfg-elaborate-drops.after.mir
@@ -25,7 +25,7 @@ fn main() -> () {
 
     bb0: {
         StorageLive(_1);                 // scope 0 at $DIR/array-index-is-temporary.rs:13:9: 13:14
-        _1 = [const 42u32, const 43u32, const 44u32]; // scope 0 at $DIR/array-index-is-temporary.rs:13:17: 13:29
+        _1 = [const 42_u32, const 43_u32, const 44_u32]; // scope 0 at $DIR/array-index-is-temporary.rs:13:17: 13:29
                                          // ty::Const
                                          // + ty: u32
                                          // + val: Value(Scalar(0x0000002a))
@@ -45,7 +45,7 @@ fn main() -> () {
                                          // + span: $DIR/array-index-is-temporary.rs:13:26: 13:28
                                          // + literal: Const { ty: u32, val: Value(Scalar(0x0000002c)) }
         StorageLive(_2);                 // scope 1 at $DIR/array-index-is-temporary.rs:14:9: 14:14
-        _2 = const 1usize;               // scope 1 at $DIR/array-index-is-temporary.rs:14:17: 14:18
+        _2 = const 1_usize;              // scope 1 at $DIR/array-index-is-temporary.rs:14:17: 14:18
                                          // ty::Const
                                          // + ty: usize
                                          // + val: Value(Scalar(0x0000000000000001))

--- a/src/test/mir-opt/byte_slice/rustc.main.SimplifyCfg-elaborate-drops.after.mir
+++ b/src/test/mir-opt/byte_slice/rustc.main.SimplifyCfg-elaborate-drops.after.mir
@@ -21,7 +21,7 @@ fn main() -> () {
                                          // + span: $DIR/byte_slice.rs:5:13: 5:19
                                          // + literal: Const { ty: &[u8; 3], val: Value(Scalar(alloc0)) }
         StorageLive(_2);                 // scope 1 at $DIR/byte_slice.rs:6:9: 6:10
-        _2 = [const 5u8, const 120u8];   // scope 1 at $DIR/byte_slice.rs:6:13: 6:24
+        _2 = [const 5_u8, const 120_u8]; // scope 1 at $DIR/byte_slice.rs:6:13: 6:24
                                          // ty::Const
                                          // + ty: u8
                                          // + val: Value(Scalar(0x05))

--- a/src/test/mir-opt/combine_array_len/32bit/rustc.norm2.InstCombine.diff
+++ b/src/test/mir-opt/combine_array_len/32bit/rustc.norm2.InstCombine.diff
@@ -28,7 +28,7 @@
       bb0: {
           StorageLive(_2);                 // scope 0 at $DIR/combine_array_len.rs:5:9: 5:10
           StorageLive(_3);                 // scope 0 at $DIR/combine_array_len.rs:5:15: 5:16
-          _3 = const 0usize;               // scope 0 at $DIR/combine_array_len.rs:5:15: 5:16
+          _3 = const 0_usize;              // scope 0 at $DIR/combine_array_len.rs:5:15: 5:16
                                            // ty::Const
                                            // + ty: usize
                                            // + val: Value(Scalar(0x00000000))
@@ -36,7 +36,7 @@
                                            // + span: $DIR/combine_array_len.rs:5:15: 5:16
                                            // + literal: Const { ty: usize, val: Value(Scalar(0x00000000)) }
 -         _4 = Len(_1);                    // scope 0 at $DIR/combine_array_len.rs:5:13: 5:17
-+         _4 = const 2usize;               // scope 0 at $DIR/combine_array_len.rs:5:13: 5:17
++         _4 = const 2_usize;              // scope 0 at $DIR/combine_array_len.rs:5:13: 5:17
 +                                          // ty::Const
 +                                          // + ty: usize
 +                                          // + val: Value(Scalar(0x00000002))
@@ -52,7 +52,7 @@
           StorageDead(_3);                 // scope 0 at $DIR/combine_array_len.rs:5:17: 5:18
           StorageLive(_6);                 // scope 1 at $DIR/combine_array_len.rs:6:9: 6:10
           StorageLive(_7);                 // scope 1 at $DIR/combine_array_len.rs:6:15: 6:16
-          _7 = const 1usize;               // scope 1 at $DIR/combine_array_len.rs:6:15: 6:16
+          _7 = const 1_usize;              // scope 1 at $DIR/combine_array_len.rs:6:15: 6:16
                                            // ty::Const
                                            // + ty: usize
                                            // + val: Value(Scalar(0x00000001))
@@ -60,7 +60,7 @@
                                            // + span: $DIR/combine_array_len.rs:6:15: 6:16
                                            // + literal: Const { ty: usize, val: Value(Scalar(0x00000001)) }
 -         _8 = Len(_1);                    // scope 1 at $DIR/combine_array_len.rs:6:13: 6:17
-+         _8 = const 2usize;               // scope 1 at $DIR/combine_array_len.rs:6:13: 6:17
++         _8 = const 2_usize;              // scope 1 at $DIR/combine_array_len.rs:6:13: 6:17
 +                                          // ty::Const
 +                                          // + ty: usize
 +                                          // + val: Value(Scalar(0x00000002))

--- a/src/test/mir-opt/combine_array_len/64bit/rustc.norm2.InstCombine.diff
+++ b/src/test/mir-opt/combine_array_len/64bit/rustc.norm2.InstCombine.diff
@@ -28,7 +28,7 @@
       bb0: {
           StorageLive(_2);                 // scope 0 at $DIR/combine_array_len.rs:5:9: 5:10
           StorageLive(_3);                 // scope 0 at $DIR/combine_array_len.rs:5:15: 5:16
-          _3 = const 0usize;               // scope 0 at $DIR/combine_array_len.rs:5:15: 5:16
+          _3 = const 0_usize;              // scope 0 at $DIR/combine_array_len.rs:5:15: 5:16
                                            // ty::Const
                                            // + ty: usize
                                            // + val: Value(Scalar(0x0000000000000000))
@@ -36,7 +36,7 @@
                                            // + span: $DIR/combine_array_len.rs:5:15: 5:16
                                            // + literal: Const { ty: usize, val: Value(Scalar(0x0000000000000000)) }
 -         _4 = Len(_1);                    // scope 0 at $DIR/combine_array_len.rs:5:13: 5:17
-+         _4 = const 2usize;               // scope 0 at $DIR/combine_array_len.rs:5:13: 5:17
++         _4 = const 2_usize;              // scope 0 at $DIR/combine_array_len.rs:5:13: 5:17
 +                                          // ty::Const
 +                                          // + ty: usize
 +                                          // + val: Value(Scalar(0x0000000000000002))
@@ -52,7 +52,7 @@
           StorageDead(_3);                 // scope 0 at $DIR/combine_array_len.rs:5:17: 5:18
           StorageLive(_6);                 // scope 1 at $DIR/combine_array_len.rs:6:9: 6:10
           StorageLive(_7);                 // scope 1 at $DIR/combine_array_len.rs:6:15: 6:16
-          _7 = const 1usize;               // scope 1 at $DIR/combine_array_len.rs:6:15: 6:16
+          _7 = const 1_usize;              // scope 1 at $DIR/combine_array_len.rs:6:15: 6:16
                                            // ty::Const
                                            // + ty: usize
                                            // + val: Value(Scalar(0x0000000000000001))
@@ -60,7 +60,7 @@
                                            // + span: $DIR/combine_array_len.rs:6:15: 6:16
                                            // + literal: Const { ty: usize, val: Value(Scalar(0x0000000000000001)) }
 -         _8 = Len(_1);                    // scope 1 at $DIR/combine_array_len.rs:6:13: 6:17
-+         _8 = const 2usize;               // scope 1 at $DIR/combine_array_len.rs:6:13: 6:17
++         _8 = const 2_usize;              // scope 1 at $DIR/combine_array_len.rs:6:13: 6:17
 +                                          // ty::Const
 +                                          // + ty: usize
 +                                          // + val: Value(Scalar(0x0000000000000002))

--- a/src/test/mir-opt/const_prop/aggregate/rustc.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/aggregate/rustc.main.ConstProp.diff
@@ -14,7 +14,7 @@
           StorageLive(_1);                 // scope 0 at $DIR/aggregate.rs:5:9: 5:10
           StorageLive(_2);                 // scope 0 at $DIR/aggregate.rs:5:13: 5:24
           StorageLive(_3);                 // scope 0 at $DIR/aggregate.rs:5:13: 5:22
-          _3 = (const 0i32, const 1i32, const 2i32); // scope 0 at $DIR/aggregate.rs:5:13: 5:22
+          _3 = (const 0_i32, const 1_i32, const 2_i32); // scope 0 at $DIR/aggregate.rs:5:13: 5:22
                                            // ty::Const
                                            // + ty: i32
                                            // + val: Value(Scalar(0x00000000))
@@ -34,8 +34,8 @@
                                            // + span: $DIR/aggregate.rs:5:20: 5:21
                                            // + literal: Const { ty: i32, val: Value(Scalar(0x00000002)) }
 -         _2 = (_3.1: i32);                // scope 0 at $DIR/aggregate.rs:5:13: 5:24
--         _1 = Add(move _2, const 0i32);   // scope 0 at $DIR/aggregate.rs:5:13: 5:28
-+         _2 = const 1i32;                 // scope 0 at $DIR/aggregate.rs:5:13: 5:24
+-         _1 = Add(move _2, const 0_i32);  // scope 0 at $DIR/aggregate.rs:5:13: 5:28
++         _2 = const 1_i32;                // scope 0 at $DIR/aggregate.rs:5:13: 5:24
                                            // ty::Const
                                            // + ty: i32
 -                                          // + val: Value(Scalar(0x00000000))
@@ -45,7 +45,7 @@
 -                                          // + literal: Const { ty: i32, val: Value(Scalar(0x00000000)) }
 +                                          // + span: $DIR/aggregate.rs:5:13: 5:24
 +                                          // + literal: Const { ty: i32, val: Value(Scalar(0x00000001)) }
-+         _1 = const 1i32;                 // scope 0 at $DIR/aggregate.rs:5:13: 5:28
++         _1 = const 1_i32;                // scope 0 at $DIR/aggregate.rs:5:13: 5:28
 +                                          // ty::Const
 +                                          // + ty: i32
 +                                          // + val: Value(Scalar(0x00000001))

--- a/src/test/mir-opt/const_prop/array_index/32bit/rustc.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/array_index/32bit/rustc.main.ConstProp.diff
@@ -15,7 +15,7 @@
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/array_index.rs:5:9: 5:10
           StorageLive(_2);                 // scope 0 at $DIR/array_index.rs:5:18: 5:30
-          _2 = [const 0u32, const 1u32, const 2u32, const 3u32]; // scope 0 at $DIR/array_index.rs:5:18: 5:30
+          _2 = [const 0_u32, const 1_u32, const 2_u32, const 3_u32]; // scope 0 at $DIR/array_index.rs:5:18: 5:30
                                            // ty::Const
                                            // + ty: u32
                                            // + val: Value(Scalar(0x00000000))
@@ -41,14 +41,14 @@
                                            // + span: $DIR/array_index.rs:5:28: 5:29
                                            // + literal: Const { ty: u32, val: Value(Scalar(0x00000003)) }
           StorageLive(_3);                 // scope 0 at $DIR/array_index.rs:5:31: 5:32
-          _3 = const 2usize;               // scope 0 at $DIR/array_index.rs:5:31: 5:32
+          _3 = const 2_usize;              // scope 0 at $DIR/array_index.rs:5:31: 5:32
                                            // ty::Const
                                            // + ty: usize
                                            // + val: Value(Scalar(0x00000002))
                                            // mir::Constant
                                            // + span: $DIR/array_index.rs:5:31: 5:32
                                            // + literal: Const { ty: usize, val: Value(Scalar(0x00000002)) }
-          _4 = const 4usize;               // scope 0 at $DIR/array_index.rs:5:18: 5:33
+          _4 = const 4_usize;              // scope 0 at $DIR/array_index.rs:5:18: 5:33
                                            // ty::Const
                                            // + ty: usize
                                            // + val: Value(Scalar(0x00000004))
@@ -75,7 +75,7 @@
   
       bb1: {
 -         _1 = _2[_3];                     // scope 0 at $DIR/array_index.rs:5:18: 5:33
-+         _1 = const 2u32;                 // scope 0 at $DIR/array_index.rs:5:18: 5:33
++         _1 = const 2_u32;                // scope 0 at $DIR/array_index.rs:5:18: 5:33
 +                                          // ty::Const
 +                                          // + ty: u32
 +                                          // + val: Value(Scalar(0x00000002))

--- a/src/test/mir-opt/const_prop/array_index/64bit/rustc.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/array_index/64bit/rustc.main.ConstProp.diff
@@ -15,7 +15,7 @@
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/array_index.rs:5:9: 5:10
           StorageLive(_2);                 // scope 0 at $DIR/array_index.rs:5:18: 5:30
-          _2 = [const 0u32, const 1u32, const 2u32, const 3u32]; // scope 0 at $DIR/array_index.rs:5:18: 5:30
+          _2 = [const 0_u32, const 1_u32, const 2_u32, const 3_u32]; // scope 0 at $DIR/array_index.rs:5:18: 5:30
                                            // ty::Const
                                            // + ty: u32
                                            // + val: Value(Scalar(0x00000000))
@@ -41,14 +41,14 @@
                                            // + span: $DIR/array_index.rs:5:28: 5:29
                                            // + literal: Const { ty: u32, val: Value(Scalar(0x00000003)) }
           StorageLive(_3);                 // scope 0 at $DIR/array_index.rs:5:31: 5:32
-          _3 = const 2usize;               // scope 0 at $DIR/array_index.rs:5:31: 5:32
+          _3 = const 2_usize;              // scope 0 at $DIR/array_index.rs:5:31: 5:32
                                            // ty::Const
                                            // + ty: usize
                                            // + val: Value(Scalar(0x0000000000000002))
                                            // mir::Constant
                                            // + span: $DIR/array_index.rs:5:31: 5:32
                                            // + literal: Const { ty: usize, val: Value(Scalar(0x0000000000000002)) }
-          _4 = const 4usize;               // scope 0 at $DIR/array_index.rs:5:18: 5:33
+          _4 = const 4_usize;              // scope 0 at $DIR/array_index.rs:5:18: 5:33
                                            // ty::Const
                                            // + ty: usize
                                            // + val: Value(Scalar(0x0000000000000004))
@@ -75,7 +75,7 @@
   
       bb1: {
 -         _1 = _2[_3];                     // scope 0 at $DIR/array_index.rs:5:18: 5:33
-+         _1 = const 2u32;                 // scope 0 at $DIR/array_index.rs:5:18: 5:33
++         _1 = const 2_u32;                // scope 0 at $DIR/array_index.rs:5:18: 5:33
 +                                          // ty::Const
 +                                          // + ty: u32
 +                                          // + val: Value(Scalar(0x00000002))

--- a/src/test/mir-opt/const_prop/bad_op_div_by_zero/rustc.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/bad_op_div_by_zero/rustc.main.ConstProp.diff
@@ -19,7 +19,7 @@
   
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/bad_op_div_by_zero.rs:4:9: 4:10
-          _1 = const 0i32;                 // scope 0 at $DIR/bad_op_div_by_zero.rs:4:13: 4:14
+          _1 = const 0_i32;                // scope 0 at $DIR/bad_op_div_by_zero.rs:4:13: 4:14
                                            // ty::Const
                                            // + ty: i32
                                            // + val: Value(Scalar(0x00000000))
@@ -29,8 +29,8 @@
           StorageLive(_2);                 // scope 1 at $DIR/bad_op_div_by_zero.rs:5:9: 5:11
           StorageLive(_3);                 // scope 1 at $DIR/bad_op_div_by_zero.rs:5:18: 5:19
 -         _3 = _1;                         // scope 1 at $DIR/bad_op_div_by_zero.rs:5:18: 5:19
--         _4 = Eq(_3, const 0i32);         // scope 1 at $DIR/bad_op_div_by_zero.rs:5:14: 5:19
-+         _3 = const 0i32;                 // scope 1 at $DIR/bad_op_div_by_zero.rs:5:18: 5:19
+-         _4 = Eq(_3, const 0_i32);        // scope 1 at $DIR/bad_op_div_by_zero.rs:5:14: 5:19
++         _3 = const 0_i32;                // scope 1 at $DIR/bad_op_div_by_zero.rs:5:18: 5:19
                                            // ty::Const
                                            // + ty: i32
                                            // + val: Value(Scalar(0x00000000))
@@ -45,11 +45,17 @@
 +                                          // mir::Constant
 +                                          // + span: $DIR/bad_op_div_by_zero.rs:5:14: 5:19
 +                                          // + literal: Const { ty: bool, val: Value(Scalar(0x01)) }
-          assert(!move _4, "attempt to divide by zero") -> bb1; // scope 1 at $DIR/bad_op_div_by_zero.rs:5:14: 5:19
+          assert(!move _4, "attempt to divide {} by zero", const 1_i32) -> bb1; // scope 1 at $DIR/bad_op_div_by_zero.rs:5:14: 5:19
+                                           // ty::Const
+                                           // + ty: i32
+                                           // + val: Value(Scalar(0x00000001))
+                                           // mir::Constant
+                                           // + span: $DIR/bad_op_div_by_zero.rs:5:14: 5:15
+                                           // + literal: Const { ty: i32, val: Value(Scalar(0x00000001)) }
       }
   
       bb1: {
--         _5 = Eq(_3, const -1i32);        // scope 1 at $DIR/bad_op_div_by_zero.rs:5:14: 5:19
+-         _5 = Eq(_3, const -1_i32);       // scope 1 at $DIR/bad_op_div_by_zero.rs:5:14: 5:19
 +         _5 = const false;                // scope 1 at $DIR/bad_op_div_by_zero.rs:5:14: 5:19
                                            // ty::Const
 -                                          // + ty: i32
@@ -59,7 +65,7 @@
                                            // mir::Constant
                                            // + span: $DIR/bad_op_div_by_zero.rs:5:14: 5:19
 -                                          // + literal: Const { ty: i32, val: Value(Scalar(0xffffffff)) }
--         _6 = Eq(const 1i32, const i32::MIN); // scope 1 at $DIR/bad_op_div_by_zero.rs:5:14: 5:19
+-         _6 = Eq(const 1_i32, const i32::MIN); // scope 1 at $DIR/bad_op_div_by_zero.rs:5:14: 5:19
 +                                          // + literal: Const { ty: bool, val: Value(Scalar(0x00)) }
 +         _6 = const false;                // scope 1 at $DIR/bad_op_div_by_zero.rs:5:14: 5:19
                                            // ty::Const
@@ -82,19 +88,25 @@
                                            // + span: $DIR/bad_op_div_by_zero.rs:5:14: 5:19
 -                                          // + literal: Const { ty: i32, val: Value(Scalar(0x80000000)) }
 -         _7 = BitAnd(move _5, move _6);   // scope 1 at $DIR/bad_op_div_by_zero.rs:5:14: 5:19
--         assert(!move _7, "attempt to divide with overflow") -> bb2; // scope 1 at $DIR/bad_op_div_by_zero.rs:5:14: 5:19
+-         assert(!move _7, "attempt to compute `{} / {}` which would overflow", const 1_i32, _3) -> bb2; // scope 1 at $DIR/bad_op_div_by_zero.rs:5:14: 5:19
 +                                          // + literal: Const { ty: bool, val: Value(Scalar(0x00)) }
-+         assert(!const false, "attempt to divide with overflow") -> bb2; // scope 1 at $DIR/bad_op_div_by_zero.rs:5:14: 5:19
++         assert(!const false, "attempt to compute `{} / {}` which would overflow", const 1_i32, _3) -> bb2; // scope 1 at $DIR/bad_op_div_by_zero.rs:5:14: 5:19
 +                                          // ty::Const
 +                                          // + ty: bool
 +                                          // + val: Value(Scalar(0x00))
 +                                          // mir::Constant
 +                                          // + span: $DIR/bad_op_div_by_zero.rs:5:14: 5:19
 +                                          // + literal: Const { ty: bool, val: Value(Scalar(0x00)) }
+                                           // ty::Const
+                                           // + ty: i32
+                                           // + val: Value(Scalar(0x00000001))
+                                           // mir::Constant
+                                           // + span: $DIR/bad_op_div_by_zero.rs:5:14: 5:15
+                                           // + literal: Const { ty: i32, val: Value(Scalar(0x00000001)) }
       }
   
       bb2: {
-          _2 = Div(const 1i32, move _3);   // scope 1 at $DIR/bad_op_div_by_zero.rs:5:14: 5:19
+          _2 = Div(const 1_i32, move _3);  // scope 1 at $DIR/bad_op_div_by_zero.rs:5:14: 5:19
                                            // ty::Const
                                            // + ty: i32
                                            // + val: Value(Scalar(0x00000001))

--- a/src/test/mir-opt/const_prop/bad_op_mod_by_zero/rustc.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/bad_op_mod_by_zero/rustc.main.ConstProp.diff
@@ -19,7 +19,7 @@
   
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/bad_op_mod_by_zero.rs:4:9: 4:10
-          _1 = const 0i32;                 // scope 0 at $DIR/bad_op_mod_by_zero.rs:4:13: 4:14
+          _1 = const 0_i32;                // scope 0 at $DIR/bad_op_mod_by_zero.rs:4:13: 4:14
                                            // ty::Const
                                            // + ty: i32
                                            // + val: Value(Scalar(0x00000000))
@@ -29,8 +29,8 @@
           StorageLive(_2);                 // scope 1 at $DIR/bad_op_mod_by_zero.rs:5:9: 5:11
           StorageLive(_3);                 // scope 1 at $DIR/bad_op_mod_by_zero.rs:5:18: 5:19
 -         _3 = _1;                         // scope 1 at $DIR/bad_op_mod_by_zero.rs:5:18: 5:19
--         _4 = Eq(_3, const 0i32);         // scope 1 at $DIR/bad_op_mod_by_zero.rs:5:14: 5:19
-+         _3 = const 0i32;                 // scope 1 at $DIR/bad_op_mod_by_zero.rs:5:18: 5:19
+-         _4 = Eq(_3, const 0_i32);        // scope 1 at $DIR/bad_op_mod_by_zero.rs:5:14: 5:19
++         _3 = const 0_i32;                // scope 1 at $DIR/bad_op_mod_by_zero.rs:5:18: 5:19
                                            // ty::Const
                                            // + ty: i32
                                            // + val: Value(Scalar(0x00000000))
@@ -45,11 +45,17 @@
 +                                          // mir::Constant
 +                                          // + span: $DIR/bad_op_mod_by_zero.rs:5:14: 5:19
 +                                          // + literal: Const { ty: bool, val: Value(Scalar(0x01)) }
-          assert(!move _4, "attempt to calculate the remainder with a divisor of zero") -> bb1; // scope 1 at $DIR/bad_op_mod_by_zero.rs:5:14: 5:19
+          assert(!move _4, "attempt to calculate the remainder of {} with a divisor of zero", const 1_i32) -> bb1; // scope 1 at $DIR/bad_op_mod_by_zero.rs:5:14: 5:19
+                                           // ty::Const
+                                           // + ty: i32
+                                           // + val: Value(Scalar(0x00000001))
+                                           // mir::Constant
+                                           // + span: $DIR/bad_op_mod_by_zero.rs:5:14: 5:15
+                                           // + literal: Const { ty: i32, val: Value(Scalar(0x00000001)) }
       }
   
       bb1: {
--         _5 = Eq(_3, const -1i32);        // scope 1 at $DIR/bad_op_mod_by_zero.rs:5:14: 5:19
+-         _5 = Eq(_3, const -1_i32);       // scope 1 at $DIR/bad_op_mod_by_zero.rs:5:14: 5:19
 +         _5 = const false;                // scope 1 at $DIR/bad_op_mod_by_zero.rs:5:14: 5:19
                                            // ty::Const
 -                                          // + ty: i32
@@ -59,7 +65,7 @@
                                            // mir::Constant
                                            // + span: $DIR/bad_op_mod_by_zero.rs:5:14: 5:19
 -                                          // + literal: Const { ty: i32, val: Value(Scalar(0xffffffff)) }
--         _6 = Eq(const 1i32, const i32::MIN); // scope 1 at $DIR/bad_op_mod_by_zero.rs:5:14: 5:19
+-         _6 = Eq(const 1_i32, const i32::MIN); // scope 1 at $DIR/bad_op_mod_by_zero.rs:5:14: 5:19
 +                                          // + literal: Const { ty: bool, val: Value(Scalar(0x00)) }
 +         _6 = const false;                // scope 1 at $DIR/bad_op_mod_by_zero.rs:5:14: 5:19
                                            // ty::Const
@@ -82,19 +88,25 @@
                                            // + span: $DIR/bad_op_mod_by_zero.rs:5:14: 5:19
 -                                          // + literal: Const { ty: i32, val: Value(Scalar(0x80000000)) }
 -         _7 = BitAnd(move _5, move _6);   // scope 1 at $DIR/bad_op_mod_by_zero.rs:5:14: 5:19
--         assert(!move _7, "attempt to calculate the remainder with overflow") -> bb2; // scope 1 at $DIR/bad_op_mod_by_zero.rs:5:14: 5:19
+-         assert(!move _7, "attempt to compute the remainder of `{} % {}` which would overflow", const 1_i32, _3) -> bb2; // scope 1 at $DIR/bad_op_mod_by_zero.rs:5:14: 5:19
 +                                          // + literal: Const { ty: bool, val: Value(Scalar(0x00)) }
-+         assert(!const false, "attempt to calculate the remainder with overflow") -> bb2; // scope 1 at $DIR/bad_op_mod_by_zero.rs:5:14: 5:19
++         assert(!const false, "attempt to compute the remainder of `{} % {}` which would overflow", const 1_i32, _3) -> bb2; // scope 1 at $DIR/bad_op_mod_by_zero.rs:5:14: 5:19
 +                                          // ty::Const
 +                                          // + ty: bool
 +                                          // + val: Value(Scalar(0x00))
 +                                          // mir::Constant
 +                                          // + span: $DIR/bad_op_mod_by_zero.rs:5:14: 5:19
 +                                          // + literal: Const { ty: bool, val: Value(Scalar(0x00)) }
+                                           // ty::Const
+                                           // + ty: i32
+                                           // + val: Value(Scalar(0x00000001))
+                                           // mir::Constant
+                                           // + span: $DIR/bad_op_mod_by_zero.rs:5:14: 5:15
+                                           // + literal: Const { ty: i32, val: Value(Scalar(0x00000001)) }
       }
   
       bb2: {
-          _2 = Rem(const 1i32, move _3);   // scope 1 at $DIR/bad_op_mod_by_zero.rs:5:14: 5:19
+          _2 = Rem(const 1_i32, move _3);  // scope 1 at $DIR/bad_op_mod_by_zero.rs:5:14: 5:19
                                            // ty::Const
                                            // + ty: i32
                                            // + val: Value(Scalar(0x00000001))

--- a/src/test/mir-opt/const_prop/bad_op_unsafe_oob_for_slices/32bit/rustc.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/bad_op_unsafe_oob_for_slices/32bit/rustc.main.ConstProp.diff
@@ -39,7 +39,7 @@
           StorageDead(_3);                 // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:5:35: 5:36
           StorageLive(_5);                 // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:7:13: 7:15
           StorageLive(_6);                 // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:7:23: 7:24
-          _6 = const 3usize;               // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:7:23: 7:24
+          _6 = const 3_usize;              // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:7:23: 7:24
                                            // ty::Const
                                            // + ty: usize
                                            // + val: Value(Scalar(0x00000003))

--- a/src/test/mir-opt/const_prop/bad_op_unsafe_oob_for_slices/64bit/rustc.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/bad_op_unsafe_oob_for_slices/64bit/rustc.main.ConstProp.diff
@@ -39,7 +39,7 @@
           StorageDead(_3);                 // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:5:35: 5:36
           StorageLive(_5);                 // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:7:13: 7:15
           StorageLive(_6);                 // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:7:23: 7:24
-          _6 = const 3usize;               // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:7:23: 7:24
+          _6 = const 3_usize;              // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:7:23: 7:24
                                            // ty::Const
                                            // + ty: usize
                                            // + val: Value(Scalar(0x0000000000000003))

--- a/src/test/mir-opt/const_prop/boxes/rustc.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/boxes/rustc.main.ConstProp.diff
@@ -17,7 +17,7 @@
           StorageLive(_3);                 // scope 0 at $DIR/boxes.rs:12:14: 12:22
           StorageLive(_4);                 // scope 0 at $DIR/boxes.rs:12:14: 12:22
           _4 = Box(i32);                   // scope 0 at $DIR/boxes.rs:12:14: 12:22
-          (*_4) = const 42i32;             // scope 0 at $DIR/boxes.rs:12:19: 12:21
+          (*_4) = const 42_i32;            // scope 0 at $DIR/boxes.rs:12:19: 12:21
                                            // ty::Const
                                            // + ty: i32
                                            // + val: Value(Scalar(0x0000002a))
@@ -27,7 +27,7 @@
           _3 = move _4;                    // scope 0 at $DIR/boxes.rs:12:14: 12:22
           StorageDead(_4);                 // scope 0 at $DIR/boxes.rs:12:21: 12:22
           _2 = (*_3);                      // scope 0 at $DIR/boxes.rs:12:13: 12:22
-          _1 = Add(move _2, const 0i32);   // scope 0 at $DIR/boxes.rs:12:13: 12:26
+          _1 = Add(move _2, const 0_i32);  // scope 0 at $DIR/boxes.rs:12:13: 12:26
                                            // ty::Const
                                            // + ty: i32
                                            // + val: Value(Scalar(0x00000000))

--- a/src/test/mir-opt/const_prop/cast/rustc.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/cast/rustc.main.ConstProp.diff
@@ -14,8 +14,8 @@
   
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/cast.rs:4:9: 4:10
--         _1 = const 42u8 as u32 (Misc);   // scope 0 at $DIR/cast.rs:4:13: 4:24
-+         _1 = const 42u32;                // scope 0 at $DIR/cast.rs:4:13: 4:24
+-         _1 = const 42_u8 as u32 (Misc);  // scope 0 at $DIR/cast.rs:4:13: 4:24
++         _1 = const 42_u32;               // scope 0 at $DIR/cast.rs:4:13: 4:24
                                            // ty::Const
 -                                          // + ty: u8
 -                                          // + val: Value(Scalar(0x2a))
@@ -23,7 +23,7 @@
 -                                          // + span: $DIR/cast.rs:4:13: 4:17
 -                                          // + literal: Const { ty: u8, val: Value(Scalar(0x2a)) }
 -         StorageLive(_2);                 // scope 1 at $DIR/cast.rs:6:9: 6:10
--         _2 = const 42u32 as u8 (Misc);   // scope 1 at $DIR/cast.rs:6:13: 6:24
+-         _2 = const 42_u32 as u8 (Misc);  // scope 1 at $DIR/cast.rs:6:13: 6:24
 -                                          // ty::Const
                                            // + ty: u32
                                            // + val: Value(Scalar(0x0000002a))
@@ -32,7 +32,7 @@
 +                                          // + span: $DIR/cast.rs:4:13: 4:24
                                            // + literal: Const { ty: u32, val: Value(Scalar(0x0000002a)) }
 +         StorageLive(_2);                 // scope 1 at $DIR/cast.rs:6:9: 6:10
-+         _2 = const 42u8;                 // scope 1 at $DIR/cast.rs:6:13: 6:24
++         _2 = const 42_u8;                // scope 1 at $DIR/cast.rs:6:13: 6:24
 +                                          // ty::Const
 +                                          // + ty: u8
 +                                          // + val: Value(Scalar(0x2a))

--- a/src/test/mir-opt/const_prop/checked_add/rustc.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/checked_add/rustc.main.ConstProp.diff
@@ -11,8 +11,8 @@
   
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/checked_add.rs:5:9: 5:10
--         _2 = CheckedAdd(const 1u32, const 1u32); // scope 0 at $DIR/checked_add.rs:5:18: 5:23
-+         _2 = (const 2u32, const false);  // scope 0 at $DIR/checked_add.rs:5:18: 5:23
+-         _2 = CheckedAdd(const 1_u32, const 1_u32); // scope 0 at $DIR/checked_add.rs:5:18: 5:23
++         _2 = (const 2_u32, const false); // scope 0 at $DIR/checked_add.rs:5:18: 5:23
                                            // ty::Const
                                            // + ty: u32
 -                                          // + val: Value(Scalar(0x00000001))
@@ -30,21 +30,33 @@
                                            // mir::Constant
 -                                          // + span: $DIR/checked_add.rs:5:22: 5:23
 -                                          // + literal: Const { ty: u32, val: Value(Scalar(0x00000001)) }
--         assert(!move (_2.1: bool), "attempt to add with overflow") -> bb1; // scope 0 at $DIR/checked_add.rs:5:18: 5:23
+-         assert(!move (_2.1: bool), "attempt to compute `{} + {}` which would overflow", const 1_u32, const 1_u32) -> bb1; // scope 0 at $DIR/checked_add.rs:5:18: 5:23
 +                                          // + span: $DIR/checked_add.rs:5:18: 5:23
 +                                          // + literal: Const { ty: bool, val: Value(Scalar(0x00)) }
-+         assert(!const false, "attempt to add with overflow") -> bb1; // scope 0 at $DIR/checked_add.rs:5:18: 5:23
-+                                          // ty::Const
++         assert(!const false, "attempt to compute `{} + {}` which would overflow", const 1_u32, const 1_u32) -> bb1; // scope 0 at $DIR/checked_add.rs:5:18: 5:23
+                                           // ty::Const
 +                                          // + ty: bool
 +                                          // + val: Value(Scalar(0x00))
 +                                          // mir::Constant
 +                                          // + span: $DIR/checked_add.rs:5:18: 5:23
 +                                          // + literal: Const { ty: bool, val: Value(Scalar(0x00)) }
++                                          // ty::Const
+                                           // + ty: u32
+                                           // + val: Value(Scalar(0x00000001))
+                                           // mir::Constant
+                                           // + span: $DIR/checked_add.rs:5:18: 5:19
+                                           // + literal: Const { ty: u32, val: Value(Scalar(0x00000001)) }
+                                           // ty::Const
+                                           // + ty: u32
+                                           // + val: Value(Scalar(0x00000001))
+                                           // mir::Constant
+                                           // + span: $DIR/checked_add.rs:5:22: 5:23
+                                           // + literal: Const { ty: u32, val: Value(Scalar(0x00000001)) }
       }
   
       bb1: {
 -         _1 = move (_2.0: u32);           // scope 0 at $DIR/checked_add.rs:5:18: 5:23
-+         _1 = const 2u32;                 // scope 0 at $DIR/checked_add.rs:5:18: 5:23
++         _1 = const 2_u32;                // scope 0 at $DIR/checked_add.rs:5:18: 5:23
 +                                          // ty::Const
 +                                          // + ty: u32
 +                                          // + val: Value(Scalar(0x00000002))

--- a/src/test/mir-opt/const_prop/discriminant/32bit/rustc.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/discriminant/32bit/rustc.main.ConstProp.diff
@@ -25,17 +25,17 @@
 -                                          // + span: $DIR/discriminant.rs:11:39: 11:43
 -                                          // + literal: Const { ty: bool, val: Value(Scalar(0x01)) }
 -         _4 = discriminant(_3);           // scope 0 at $DIR/discriminant.rs:11:21: 11:31
--         switchInt(move _4) -> [1isize: bb2, otherwise: bb1]; // scope 0 at $DIR/discriminant.rs:11:21: 11:31
+-         switchInt(move _4) -> [1_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/discriminant.rs:11:21: 11:31
 +                                          // + span: $DIR/discriminant.rs:11:34: 11:44
 +                                          // + literal: Const { ty: std::option::Option<bool>, val: Value(Scalar(0x01)) }
-+         _4 = const 1isize;               // scope 0 at $DIR/discriminant.rs:11:21: 11:31
++         _4 = const 1_isize;              // scope 0 at $DIR/discriminant.rs:11:21: 11:31
 +                                          // ty::Const
 +                                          // + ty: isize
 +                                          // + val: Value(Scalar(0x00000001))
 +                                          // mir::Constant
 +                                          // + span: $DIR/discriminant.rs:11:21: 11:31
 +                                          // + literal: Const { ty: isize, val: Value(Scalar(0x00000001)) }
-+         switchInt(const 1isize) -> [1isize: bb2, otherwise: bb1]; // scope 0 at $DIR/discriminant.rs:11:21: 11:31
++         switchInt(const 1_isize) -> [1_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/discriminant.rs:11:21: 11:31
 +                                          // ty::Const
 +                                          // + ty: isize
 +                                          // + val: Value(Scalar(0x00000001))
@@ -45,7 +45,7 @@
       }
   
       bb1: {
-          _2 = const 10i32;                // scope 0 at $DIR/discriminant.rs:11:59: 11:61
+          _2 = const 10_i32;               // scope 0 at $DIR/discriminant.rs:11:59: 11:61
                                            // ty::Const
                                            // + ty: i32
                                            // + val: Value(Scalar(0x0000000a))
@@ -60,7 +60,7 @@
       }
   
       bb3: {
-          _2 = const 42i32;                // scope 0 at $DIR/discriminant.rs:11:47: 11:49
+          _2 = const 42_i32;               // scope 0 at $DIR/discriminant.rs:11:47: 11:49
                                            // ty::Const
                                            // + ty: i32
                                            // + val: Value(Scalar(0x0000002a))
@@ -71,7 +71,7 @@
       }
   
       bb4: {
-          _1 = Add(move _2, const 0i32);   // scope 0 at $DIR/discriminant.rs:11:13: 11:68
+          _1 = Add(move _2, const 0_i32);  // scope 0 at $DIR/discriminant.rs:11:13: 11:68
                                            // ty::Const
                                            // + ty: i32
                                            // + val: Value(Scalar(0x00000000))

--- a/src/test/mir-opt/const_prop/discriminant/64bit/rustc.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/discriminant/64bit/rustc.main.ConstProp.diff
@@ -25,17 +25,17 @@
 -                                          // + span: $DIR/discriminant.rs:11:39: 11:43
 -                                          // + literal: Const { ty: bool, val: Value(Scalar(0x01)) }
 -         _4 = discriminant(_3);           // scope 0 at $DIR/discriminant.rs:11:21: 11:31
--         switchInt(move _4) -> [1isize: bb2, otherwise: bb1]; // scope 0 at $DIR/discriminant.rs:11:21: 11:31
+-         switchInt(move _4) -> [1_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/discriminant.rs:11:21: 11:31
 +                                          // + span: $DIR/discriminant.rs:11:34: 11:44
 +                                          // + literal: Const { ty: std::option::Option<bool>, val: Value(Scalar(0x01)) }
-+         _4 = const 1isize;               // scope 0 at $DIR/discriminant.rs:11:21: 11:31
++         _4 = const 1_isize;              // scope 0 at $DIR/discriminant.rs:11:21: 11:31
 +                                          // ty::Const
 +                                          // + ty: isize
 +                                          // + val: Value(Scalar(0x0000000000000001))
 +                                          // mir::Constant
 +                                          // + span: $DIR/discriminant.rs:11:21: 11:31
 +                                          // + literal: Const { ty: isize, val: Value(Scalar(0x0000000000000001)) }
-+         switchInt(const 1isize) -> [1isize: bb2, otherwise: bb1]; // scope 0 at $DIR/discriminant.rs:11:21: 11:31
++         switchInt(const 1_isize) -> [1_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/discriminant.rs:11:21: 11:31
 +                                          // ty::Const
 +                                          // + ty: isize
 +                                          // + val: Value(Scalar(0x0000000000000001))
@@ -45,7 +45,7 @@
       }
   
       bb1: {
-          _2 = const 10i32;                // scope 0 at $DIR/discriminant.rs:11:59: 11:61
+          _2 = const 10_i32;               // scope 0 at $DIR/discriminant.rs:11:59: 11:61
                                            // ty::Const
                                            // + ty: i32
                                            // + val: Value(Scalar(0x0000000a))
@@ -60,7 +60,7 @@
       }
   
       bb3: {
-          _2 = const 42i32;                // scope 0 at $DIR/discriminant.rs:11:47: 11:49
+          _2 = const 42_i32;               // scope 0 at $DIR/discriminant.rs:11:47: 11:49
                                            // ty::Const
                                            // + ty: i32
                                            // + val: Value(Scalar(0x0000002a))
@@ -71,7 +71,7 @@
       }
   
       bb4: {
-          _1 = Add(move _2, const 0i32);   // scope 0 at $DIR/discriminant.rs:11:13: 11:68
+          _1 = Add(move _2, const 0_i32);  // scope 0 at $DIR/discriminant.rs:11:13: 11:68
                                            // ty::Const
                                            // + ty: i32
                                            // + val: Value(Scalar(0x00000000))

--- a/src/test/mir-opt/const_prop/indirect/rustc.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/indirect/rustc.main.ConstProp.diff
@@ -13,8 +13,8 @@
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/indirect.rs:5:9: 5:10
           StorageLive(_2);                 // scope 0 at $DIR/indirect.rs:5:13: 5:25
--         _2 = const 2u32 as u8 (Misc);    // scope 0 at $DIR/indirect.rs:5:13: 5:25
-+         _2 = const 2u8;                  // scope 0 at $DIR/indirect.rs:5:13: 5:25
+-         _2 = const 2_u32 as u8 (Misc);   // scope 0 at $DIR/indirect.rs:5:13: 5:25
++         _2 = const 2_u8;                 // scope 0 at $DIR/indirect.rs:5:13: 5:25
                                            // ty::Const
 -                                          // + ty: u32
 -                                          // + val: Value(Scalar(0x00000002))
@@ -23,10 +23,10 @@
                                            // mir::Constant
 -                                          // + span: $DIR/indirect.rs:5:14: 5:18
 -                                          // + literal: Const { ty: u32, val: Value(Scalar(0x00000002)) }
--         _3 = CheckedAdd(move _2, const 1u8); // scope 0 at $DIR/indirect.rs:5:13: 5:29
+-         _3 = CheckedAdd(_2, const 1_u8); // scope 0 at $DIR/indirect.rs:5:13: 5:29
 +                                          // + span: $DIR/indirect.rs:5:13: 5:25
 +                                          // + literal: Const { ty: u8, val: Value(Scalar(0x02)) }
-+         _3 = (const 3u8, const false);   // scope 0 at $DIR/indirect.rs:5:13: 5:29
++         _3 = (const 3_u8, const false);  // scope 0 at $DIR/indirect.rs:5:13: 5:29
                                            // ty::Const
                                            // + ty: u8
 -                                          // + val: Value(Scalar(0x01))
@@ -34,27 +34,33 @@
                                            // mir::Constant
 -                                          // + span: $DIR/indirect.rs:5:28: 5:29
 -                                          // + literal: Const { ty: u8, val: Value(Scalar(0x01)) }
--         assert(!move (_3.1: bool), "attempt to add with overflow") -> bb1; // scope 0 at $DIR/indirect.rs:5:13: 5:29
+-         assert(!move (_3.1: bool), "attempt to compute `{} + {}` which would overflow", move _2, const 1_u8) -> bb1; // scope 0 at $DIR/indirect.rs:5:13: 5:29
 +                                          // + span: $DIR/indirect.rs:5:13: 5:29
 +                                          // + literal: Const { ty: u8, val: Value(Scalar(0x03)) }
+                                           // ty::Const
++                                          // + ty: bool
++                                          // + val: Value(Scalar(0x00))
++                                          // mir::Constant
++                                          // + span: $DIR/indirect.rs:5:13: 5:29
++                                          // + literal: Const { ty: bool, val: Value(Scalar(0x00)) }
++         assert(!const false, "attempt to compute `{} + {}` which would overflow", move _2, const 1_u8) -> bb1; // scope 0 at $DIR/indirect.rs:5:13: 5:29
 +                                          // ty::Const
 +                                          // + ty: bool
 +                                          // + val: Value(Scalar(0x00))
 +                                          // mir::Constant
 +                                          // + span: $DIR/indirect.rs:5:13: 5:29
 +                                          // + literal: Const { ty: bool, val: Value(Scalar(0x00)) }
-+         assert(!const false, "attempt to add with overflow") -> bb1; // scope 0 at $DIR/indirect.rs:5:13: 5:29
 +                                          // ty::Const
-+                                          // + ty: bool
-+                                          // + val: Value(Scalar(0x00))
-+                                          // mir::Constant
-+                                          // + span: $DIR/indirect.rs:5:13: 5:29
-+                                          // + literal: Const { ty: bool, val: Value(Scalar(0x00)) }
+                                           // + ty: u8
+                                           // + val: Value(Scalar(0x01))
+                                           // mir::Constant
+                                           // + span: $DIR/indirect.rs:5:28: 5:29
+                                           // + literal: Const { ty: u8, val: Value(Scalar(0x01)) }
       }
   
       bb1: {
 -         _1 = move (_3.0: u8);            // scope 0 at $DIR/indirect.rs:5:13: 5:29
-+         _1 = const 3u8;                  // scope 0 at $DIR/indirect.rs:5:13: 5:29
++         _1 = const 3_u8;                 // scope 0 at $DIR/indirect.rs:5:13: 5:29
 +                                          // ty::Const
 +                                          // + ty: u8
 +                                          // + val: Value(Scalar(0x03))

--- a/src/test/mir-opt/const_prop/issue-66971/rustc.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/issue-66971/rustc.main.ConstProp.diff
@@ -19,7 +19,7 @@
 +                                          // mir::Constant
 +                                          // + span: $DIR/issue-66971.rs:16:13: 16:15
 +                                          // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
-          _2 = (move _3, const 0u8, const 0u8); // scope 0 at $DIR/issue-66971.rs:16:12: 16:22
+          _2 = (move _3, const 0_u8, const 0_u8); // scope 0 at $DIR/issue-66971.rs:16:12: 16:22
                                            // ty::Const
                                            // + ty: u8
                                            // + val: Value(Scalar(0x00))

--- a/src/test/mir-opt/const_prop/issue-67019/rustc.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/issue-67019/rustc.main.ConstProp.diff
@@ -11,7 +11,7 @@
           StorageLive(_1);                 // scope 0 at $DIR/issue-67019.rs:11:5: 11:20
           StorageLive(_2);                 // scope 0 at $DIR/issue-67019.rs:11:10: 11:19
           StorageLive(_3);                 // scope 0 at $DIR/issue-67019.rs:11:11: 11:17
-          _3 = (const 1u8, const 2u8);     // scope 0 at $DIR/issue-67019.rs:11:11: 11:17
+          _3 = (const 1_u8, const 2_u8);   // scope 0 at $DIR/issue-67019.rs:11:11: 11:17
                                            // ty::Const
                                            // + ty: u8
                                            // + val: Value(Scalar(0x01))

--- a/src/test/mir-opt/const_prop/mutable_variable/rustc.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/mutable_variable/rustc.main.ConstProp.diff
@@ -14,14 +14,14 @@
   
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/mutable_variable.rs:5:9: 5:14
-          _1 = const 42i32;                // scope 0 at $DIR/mutable_variable.rs:5:17: 5:19
+          _1 = const 42_i32;               // scope 0 at $DIR/mutable_variable.rs:5:17: 5:19
                                            // ty::Const
                                            // + ty: i32
                                            // + val: Value(Scalar(0x0000002a))
                                            // mir::Constant
                                            // + span: $DIR/mutable_variable.rs:5:17: 5:19
                                            // + literal: Const { ty: i32, val: Value(Scalar(0x0000002a)) }
-          _1 = const 99i32;                // scope 1 at $DIR/mutable_variable.rs:6:5: 6:11
+          _1 = const 99_i32;               // scope 1 at $DIR/mutable_variable.rs:6:5: 6:11
                                            // ty::Const
                                            // + ty: i32
                                            // + val: Value(Scalar(0x00000063))
@@ -30,7 +30,7 @@
                                            // + literal: Const { ty: i32, val: Value(Scalar(0x00000063)) }
           StorageLive(_2);                 // scope 1 at $DIR/mutable_variable.rs:7:9: 7:10
 -         _2 = _1;                         // scope 1 at $DIR/mutable_variable.rs:7:13: 7:14
-+         _2 = const 99i32;                // scope 1 at $DIR/mutable_variable.rs:7:13: 7:14
++         _2 = const 99_i32;               // scope 1 at $DIR/mutable_variable.rs:7:13: 7:14
 +                                          // ty::Const
 +                                          // + ty: i32
 +                                          // + val: Value(Scalar(0x00000063))

--- a/src/test/mir-opt/const_prop/mutable_variable_aggregate/rustc.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/mutable_variable_aggregate/rustc.main.ConstProp.diff
@@ -14,7 +14,7 @@
   
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/mutable_variable_aggregate.rs:5:9: 5:14
-          _1 = (const 42i32, const 43i32); // scope 0 at $DIR/mutable_variable_aggregate.rs:5:17: 5:25
+          _1 = (const 42_i32, const 43_i32); // scope 0 at $DIR/mutable_variable_aggregate.rs:5:17: 5:25
                                            // ty::Const
                                            // + ty: i32
                                            // + val: Value(Scalar(0x0000002a))
@@ -29,7 +29,7 @@
 -                                          // + span: $DIR/mutable_variable_aggregate.rs:5:22: 5:24
 +                                          // + span: $DIR/mutable_variable_aggregate.rs:5:17: 5:25
                                            // + literal: Const { ty: i32, val: Value(Scalar(0x0000002b)) }
-          (_1.1: i32) = const 99i32;       // scope 1 at $DIR/mutable_variable_aggregate.rs:6:5: 6:13
+          (_1.1: i32) = const 99_i32;      // scope 1 at $DIR/mutable_variable_aggregate.rs:6:5: 6:13
                                            // ty::Const
                                            // + ty: i32
                                            // + val: Value(Scalar(0x00000063))
@@ -38,7 +38,7 @@
                                            // + literal: Const { ty: i32, val: Value(Scalar(0x00000063)) }
           StorageLive(_2);                 // scope 1 at $DIR/mutable_variable_aggregate.rs:7:9: 7:10
 -         _2 = _1;                         // scope 1 at $DIR/mutable_variable_aggregate.rs:7:13: 7:14
-+         _2 = (const 42i32, const 99i32); // scope 1 at $DIR/mutable_variable_aggregate.rs:7:13: 7:14
++         _2 = (const 42_i32, const 99_i32); // scope 1 at $DIR/mutable_variable_aggregate.rs:7:13: 7:14
 +                                          // ty::Const
 +                                          // + ty: i32
 +                                          // + val: Value(Scalar(0x0000002a))

--- a/src/test/mir-opt/const_prop/mutable_variable_aggregate_mut_ref/rustc.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/mutable_variable_aggregate_mut_ref/rustc.main.ConstProp.diff
@@ -18,7 +18,7 @@
   
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/mutable_variable_aggregate_mut_ref.rs:5:9: 5:14
-          _1 = (const 42i32, const 43i32); // scope 0 at $DIR/mutable_variable_aggregate_mut_ref.rs:5:17: 5:25
+          _1 = (const 42_i32, const 43_i32); // scope 0 at $DIR/mutable_variable_aggregate_mut_ref.rs:5:17: 5:25
                                            // ty::Const
                                            // + ty: i32
                                            // + val: Value(Scalar(0x0000002a))
@@ -35,7 +35,7 @@
                                            // + literal: Const { ty: i32, val: Value(Scalar(0x0000002b)) }
           StorageLive(_2);                 // scope 1 at $DIR/mutable_variable_aggregate_mut_ref.rs:6:9: 6:10
           _2 = &mut _1;                    // scope 1 at $DIR/mutable_variable_aggregate_mut_ref.rs:6:13: 6:19
-          ((*_2).1: i32) = const 99i32;    // scope 2 at $DIR/mutable_variable_aggregate_mut_ref.rs:7:5: 7:13
+          ((*_2).1: i32) = const 99_i32;   // scope 2 at $DIR/mutable_variable_aggregate_mut_ref.rs:7:5: 7:13
                                            // ty::Const
                                            // + ty: i32
                                            // + val: Value(Scalar(0x00000063))

--- a/src/test/mir-opt/const_prop/mutable_variable_aggregate_partial_read/rustc.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/mutable_variable_aggregate_partial_read/rustc.main.ConstProp.diff
@@ -24,14 +24,14 @@
       }
   
       bb1: {
-          (_1.1: i32) = const 99i32;       // scope 1 at $DIR/mutable_variable_aggregate_partial_read.rs:6:5: 6:13
+          (_1.1: i32) = const 99_i32;      // scope 1 at $DIR/mutable_variable_aggregate_partial_read.rs:6:5: 6:13
                                            // ty::Const
                                            // + ty: i32
                                            // + val: Value(Scalar(0x00000063))
                                            // mir::Constant
                                            // + span: $DIR/mutable_variable_aggregate_partial_read.rs:6:11: 6:13
                                            // + literal: Const { ty: i32, val: Value(Scalar(0x00000063)) }
-          (_1.0: i32) = const 42i32;       // scope 1 at $DIR/mutable_variable_aggregate_partial_read.rs:7:5: 7:13
+          (_1.0: i32) = const 42_i32;      // scope 1 at $DIR/mutable_variable_aggregate_partial_read.rs:7:5: 7:13
                                            // ty::Const
                                            // + ty: i32
                                            // + val: Value(Scalar(0x0000002a))
@@ -40,7 +40,7 @@
                                            // + literal: Const { ty: i32, val: Value(Scalar(0x0000002a)) }
           StorageLive(_2);                 // scope 1 at $DIR/mutable_variable_aggregate_partial_read.rs:8:9: 8:10
 -         _2 = (_1.1: i32);                // scope 1 at $DIR/mutable_variable_aggregate_partial_read.rs:8:13: 8:16
-+         _2 = const 99i32;                // scope 1 at $DIR/mutable_variable_aggregate_partial_read.rs:8:13: 8:16
++         _2 = const 99_i32;               // scope 1 at $DIR/mutable_variable_aggregate_partial_read.rs:8:13: 8:16
 +                                          // ty::Const
 +                                          // + ty: i32
 +                                          // + val: Value(Scalar(0x00000063))

--- a/src/test/mir-opt/const_prop/mutable_variable_no_prop/rustc.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/mutable_variable_no_prop/rustc.main.ConstProp.diff
@@ -19,7 +19,7 @@
   
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/mutable_variable_no_prop.rs:7:9: 7:14
-          _1 = const 42u32;                // scope 0 at $DIR/mutable_variable_no_prop.rs:7:17: 7:19
+          _1 = const 42_u32;               // scope 0 at $DIR/mutable_variable_no_prop.rs:7:17: 7:19
                                            // ty::Const
                                            // + ty: u32
                                            // + val: Value(Scalar(0x0000002a))

--- a/src/test/mir-opt/const_prop/mutable_variable_unprop_assign/rustc.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/mutable_variable_unprop_assign/rustc.main.ConstProp.diff
@@ -34,7 +34,7 @@
   
       bb1: {
           StorageLive(_2);                 // scope 1 at $DIR/mutable_variable_unprop_assign.rs:6:9: 6:14
-          _2 = (const 1i32, const 2i32);   // scope 1 at $DIR/mutable_variable_unprop_assign.rs:6:29: 6:35
+          _2 = (const 1_i32, const 2_i32); // scope 1 at $DIR/mutable_variable_unprop_assign.rs:6:29: 6:35
                                            // ty::Const
                                            // + ty: i32
                                            // + val: Value(Scalar(0x00000001))

--- a/src/test/mir-opt/const_prop/optimizes_into_variable/32bit/rustc.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/optimizes_into_variable/32bit/rustc.main.ConstProp.diff
@@ -24,8 +24,8 @@
   
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/optimizes_into_variable.rs:12:9: 12:10
--         _2 = CheckedAdd(const 2i32, const 2i32); // scope 0 at $DIR/optimizes_into_variable.rs:12:13: 12:18
-+         _2 = (const 4i32, const false);  // scope 0 at $DIR/optimizes_into_variable.rs:12:13: 12:18
+-         _2 = CheckedAdd(const 2_i32, const 2_i32); // scope 0 at $DIR/optimizes_into_variable.rs:12:13: 12:18
++         _2 = (const 4_i32, const false); // scope 0 at $DIR/optimizes_into_variable.rs:12:13: 12:18
                                            // ty::Const
                                            // + ty: i32
 -                                          // + val: Value(Scalar(0x00000002))
@@ -43,21 +43,33 @@
                                            // mir::Constant
 -                                          // + span: $DIR/optimizes_into_variable.rs:12:17: 12:18
 -                                          // + literal: Const { ty: i32, val: Value(Scalar(0x00000002)) }
--         assert(!move (_2.1: bool), "attempt to add with overflow") -> bb1; // scope 0 at $DIR/optimizes_into_variable.rs:12:13: 12:18
+-         assert(!move (_2.1: bool), "attempt to compute `{} + {}` which would overflow", const 2_i32, const 2_i32) -> bb1; // scope 0 at $DIR/optimizes_into_variable.rs:12:13: 12:18
 +                                          // + span: $DIR/optimizes_into_variable.rs:12:13: 12:18
 +                                          // + literal: Const { ty: bool, val: Value(Scalar(0x00)) }
-+         assert(!const false, "attempt to add with overflow") -> bb1; // scope 0 at $DIR/optimizes_into_variable.rs:12:13: 12:18
-+                                          // ty::Const
++         assert(!const false, "attempt to compute `{} + {}` which would overflow", const 2_i32, const 2_i32) -> bb1; // scope 0 at $DIR/optimizes_into_variable.rs:12:13: 12:18
+                                           // ty::Const
 +                                          // + ty: bool
 +                                          // + val: Value(Scalar(0x00))
 +                                          // mir::Constant
 +                                          // + span: $DIR/optimizes_into_variable.rs:12:13: 12:18
 +                                          // + literal: Const { ty: bool, val: Value(Scalar(0x00)) }
++                                          // ty::Const
+                                           // + ty: i32
+                                           // + val: Value(Scalar(0x00000002))
+                                           // mir::Constant
+                                           // + span: $DIR/optimizes_into_variable.rs:12:13: 12:14
+                                           // + literal: Const { ty: i32, val: Value(Scalar(0x00000002)) }
+                                           // ty::Const
+                                           // + ty: i32
+                                           // + val: Value(Scalar(0x00000002))
+                                           // mir::Constant
+                                           // + span: $DIR/optimizes_into_variable.rs:12:17: 12:18
+                                           // + literal: Const { ty: i32, val: Value(Scalar(0x00000002)) }
       }
   
       bb1: {
 -         _1 = move (_2.0: i32);           // scope 0 at $DIR/optimizes_into_variable.rs:12:13: 12:18
-+         _1 = const 4i32;                 // scope 0 at $DIR/optimizes_into_variable.rs:12:13: 12:18
++         _1 = const 4_i32;                // scope 0 at $DIR/optimizes_into_variable.rs:12:13: 12:18
 +                                          // ty::Const
 +                                          // + ty: i32
 +                                          // + val: Value(Scalar(0x00000004))
@@ -66,7 +78,7 @@
 +                                          // + literal: Const { ty: i32, val: Value(Scalar(0x00000004)) }
           StorageLive(_3);                 // scope 1 at $DIR/optimizes_into_variable.rs:13:9: 13:10
           StorageLive(_4);                 // scope 1 at $DIR/optimizes_into_variable.rs:13:13: 13:31
-          _4 = [const 0i32, const 1i32, const 2i32, const 3i32, const 4i32, const 5i32]; // scope 1 at $DIR/optimizes_into_variable.rs:13:13: 13:31
+          _4 = [const 0_i32, const 1_i32, const 2_i32, const 3_i32, const 4_i32, const 5_i32]; // scope 1 at $DIR/optimizes_into_variable.rs:13:13: 13:31
                                            // ty::Const
                                            // + ty: i32
                                            // + val: Value(Scalar(0x00000000))
@@ -104,14 +116,14 @@
                                            // + span: $DIR/optimizes_into_variable.rs:13:29: 13:30
                                            // + literal: Const { ty: i32, val: Value(Scalar(0x00000005)) }
           StorageLive(_5);                 // scope 1 at $DIR/optimizes_into_variable.rs:13:32: 13:33
-          _5 = const 3usize;               // scope 1 at $DIR/optimizes_into_variable.rs:13:32: 13:33
+          _5 = const 3_usize;              // scope 1 at $DIR/optimizes_into_variable.rs:13:32: 13:33
                                            // ty::Const
                                            // + ty: usize
                                            // + val: Value(Scalar(0x00000003))
                                            // mir::Constant
                                            // + span: $DIR/optimizes_into_variable.rs:13:32: 13:33
                                            // + literal: Const { ty: usize, val: Value(Scalar(0x00000003)) }
-          _6 = const 6usize;               // scope 1 at $DIR/optimizes_into_variable.rs:13:13: 13:34
+          _6 = const 6_usize;              // scope 1 at $DIR/optimizes_into_variable.rs:13:13: 13:34
                                            // ty::Const
                                            // + ty: usize
                                            // + val: Value(Scalar(0x00000006))
@@ -138,7 +150,7 @@
   
       bb2: {
 -         _3 = _4[_5];                     // scope 1 at $DIR/optimizes_into_variable.rs:13:13: 13:34
-+         _3 = const 3i32;                 // scope 1 at $DIR/optimizes_into_variable.rs:13:13: 13:34
++         _3 = const 3_i32;                // scope 1 at $DIR/optimizes_into_variable.rs:13:13: 13:34
 +                                          // ty::Const
 +                                          // + ty: i32
 +                                          // + val: Value(Scalar(0x00000003))
@@ -149,7 +161,7 @@
           StorageDead(_4);                 // scope 1 at $DIR/optimizes_into_variable.rs:13:34: 13:35
           StorageLive(_8);                 // scope 2 at $DIR/optimizes_into_variable.rs:14:9: 14:10
           StorageLive(_9);                 // scope 2 at $DIR/optimizes_into_variable.rs:14:13: 14:36
-          _9 = Point { x: const 12u32, y: const 42u32 }; // scope 2 at $DIR/optimizes_into_variable.rs:14:13: 14:36
+          _9 = Point { x: const 12_u32, y: const 42_u32 }; // scope 2 at $DIR/optimizes_into_variable.rs:14:13: 14:36
                                            // ty::Const
                                            // + ty: u32
                                            // + val: Value(Scalar(0x0000000c))
@@ -163,7 +175,7 @@
                                            // + span: $DIR/optimizes_into_variable.rs:14:32: 14:34
                                            // + literal: Const { ty: u32, val: Value(Scalar(0x0000002a)) }
 -         _8 = (_9.1: u32);                // scope 2 at $DIR/optimizes_into_variable.rs:14:13: 14:38
-+         _8 = const 42u32;                // scope 2 at $DIR/optimizes_into_variable.rs:14:13: 14:38
++         _8 = const 42_u32;               // scope 2 at $DIR/optimizes_into_variable.rs:14:13: 14:38
 +                                          // ty::Const
 +                                          // + ty: u32
 +                                          // + val: Value(Scalar(0x0000002a))

--- a/src/test/mir-opt/const_prop/optimizes_into_variable/32bit/rustc.main.SimplifyLocals.after.mir
+++ b/src/test/mir-opt/const_prop/optimizes_into_variable/32bit/rustc.main.SimplifyLocals.after.mir
@@ -17,7 +17,7 @@ fn main() -> () {
 
     bb0: {
         StorageLive(_1);                 // scope 0 at $DIR/optimizes_into_variable.rs:12:9: 12:10
-        _1 = const 4i32;                 // scope 0 at $DIR/optimizes_into_variable.rs:12:13: 12:18
+        _1 = const 4_i32;                // scope 0 at $DIR/optimizes_into_variable.rs:12:13: 12:18
                                          // ty::Const
                                          // + ty: i32
                                          // + val: Value(Scalar(0x00000004))
@@ -25,7 +25,7 @@ fn main() -> () {
                                          // + span: $DIR/optimizes_into_variable.rs:12:13: 12:18
                                          // + literal: Const { ty: i32, val: Value(Scalar(0x00000004)) }
         StorageLive(_2);                 // scope 1 at $DIR/optimizes_into_variable.rs:13:9: 13:10
-        _2 = const 3i32;                 // scope 1 at $DIR/optimizes_into_variable.rs:13:13: 13:34
+        _2 = const 3_i32;                // scope 1 at $DIR/optimizes_into_variable.rs:13:13: 13:34
                                          // ty::Const
                                          // + ty: i32
                                          // + val: Value(Scalar(0x00000003))
@@ -33,7 +33,7 @@ fn main() -> () {
                                          // + span: $DIR/optimizes_into_variable.rs:13:13: 13:34
                                          // + literal: Const { ty: i32, val: Value(Scalar(0x00000003)) }
         StorageLive(_3);                 // scope 2 at $DIR/optimizes_into_variable.rs:14:9: 14:10
-        _3 = const 42u32;                // scope 2 at $DIR/optimizes_into_variable.rs:14:13: 14:38
+        _3 = const 42_u32;               // scope 2 at $DIR/optimizes_into_variable.rs:14:13: 14:38
                                          // ty::Const
                                          // + ty: u32
                                          // + val: Value(Scalar(0x0000002a))

--- a/src/test/mir-opt/const_prop/optimizes_into_variable/64bit/rustc.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/optimizes_into_variable/64bit/rustc.main.ConstProp.diff
@@ -24,8 +24,8 @@
   
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/optimizes_into_variable.rs:12:9: 12:10
--         _2 = CheckedAdd(const 2i32, const 2i32); // scope 0 at $DIR/optimizes_into_variable.rs:12:13: 12:18
-+         _2 = (const 4i32, const false);  // scope 0 at $DIR/optimizes_into_variable.rs:12:13: 12:18
+-         _2 = CheckedAdd(const 2_i32, const 2_i32); // scope 0 at $DIR/optimizes_into_variable.rs:12:13: 12:18
++         _2 = (const 4_i32, const false); // scope 0 at $DIR/optimizes_into_variable.rs:12:13: 12:18
                                            // ty::Const
                                            // + ty: i32
 -                                          // + val: Value(Scalar(0x00000002))
@@ -43,21 +43,33 @@
                                            // mir::Constant
 -                                          // + span: $DIR/optimizes_into_variable.rs:12:17: 12:18
 -                                          // + literal: Const { ty: i32, val: Value(Scalar(0x00000002)) }
--         assert(!move (_2.1: bool), "attempt to add with overflow") -> bb1; // scope 0 at $DIR/optimizes_into_variable.rs:12:13: 12:18
+-         assert(!move (_2.1: bool), "attempt to compute `{} + {}` which would overflow", const 2_i32, const 2_i32) -> bb1; // scope 0 at $DIR/optimizes_into_variable.rs:12:13: 12:18
 +                                          // + span: $DIR/optimizes_into_variable.rs:12:13: 12:18
 +                                          // + literal: Const { ty: bool, val: Value(Scalar(0x00)) }
-+         assert(!const false, "attempt to add with overflow") -> bb1; // scope 0 at $DIR/optimizes_into_variable.rs:12:13: 12:18
-+                                          // ty::Const
++         assert(!const false, "attempt to compute `{} + {}` which would overflow", const 2_i32, const 2_i32) -> bb1; // scope 0 at $DIR/optimizes_into_variable.rs:12:13: 12:18
+                                           // ty::Const
 +                                          // + ty: bool
 +                                          // + val: Value(Scalar(0x00))
 +                                          // mir::Constant
 +                                          // + span: $DIR/optimizes_into_variable.rs:12:13: 12:18
 +                                          // + literal: Const { ty: bool, val: Value(Scalar(0x00)) }
++                                          // ty::Const
+                                           // + ty: i32
+                                           // + val: Value(Scalar(0x00000002))
+                                           // mir::Constant
+                                           // + span: $DIR/optimizes_into_variable.rs:12:13: 12:14
+                                           // + literal: Const { ty: i32, val: Value(Scalar(0x00000002)) }
+                                           // ty::Const
+                                           // + ty: i32
+                                           // + val: Value(Scalar(0x00000002))
+                                           // mir::Constant
+                                           // + span: $DIR/optimizes_into_variable.rs:12:17: 12:18
+                                           // + literal: Const { ty: i32, val: Value(Scalar(0x00000002)) }
       }
   
       bb1: {
 -         _1 = move (_2.0: i32);           // scope 0 at $DIR/optimizes_into_variable.rs:12:13: 12:18
-+         _1 = const 4i32;                 // scope 0 at $DIR/optimizes_into_variable.rs:12:13: 12:18
++         _1 = const 4_i32;                // scope 0 at $DIR/optimizes_into_variable.rs:12:13: 12:18
 +                                          // ty::Const
 +                                          // + ty: i32
 +                                          // + val: Value(Scalar(0x00000004))
@@ -66,7 +78,7 @@
 +                                          // + literal: Const { ty: i32, val: Value(Scalar(0x00000004)) }
           StorageLive(_3);                 // scope 1 at $DIR/optimizes_into_variable.rs:13:9: 13:10
           StorageLive(_4);                 // scope 1 at $DIR/optimizes_into_variable.rs:13:13: 13:31
-          _4 = [const 0i32, const 1i32, const 2i32, const 3i32, const 4i32, const 5i32]; // scope 1 at $DIR/optimizes_into_variable.rs:13:13: 13:31
+          _4 = [const 0_i32, const 1_i32, const 2_i32, const 3_i32, const 4_i32, const 5_i32]; // scope 1 at $DIR/optimizes_into_variable.rs:13:13: 13:31
                                            // ty::Const
                                            // + ty: i32
                                            // + val: Value(Scalar(0x00000000))
@@ -104,14 +116,14 @@
                                            // + span: $DIR/optimizes_into_variable.rs:13:29: 13:30
                                            // + literal: Const { ty: i32, val: Value(Scalar(0x00000005)) }
           StorageLive(_5);                 // scope 1 at $DIR/optimizes_into_variable.rs:13:32: 13:33
-          _5 = const 3usize;               // scope 1 at $DIR/optimizes_into_variable.rs:13:32: 13:33
+          _5 = const 3_usize;              // scope 1 at $DIR/optimizes_into_variable.rs:13:32: 13:33
                                            // ty::Const
                                            // + ty: usize
                                            // + val: Value(Scalar(0x0000000000000003))
                                            // mir::Constant
                                            // + span: $DIR/optimizes_into_variable.rs:13:32: 13:33
                                            // + literal: Const { ty: usize, val: Value(Scalar(0x0000000000000003)) }
-          _6 = const 6usize;               // scope 1 at $DIR/optimizes_into_variable.rs:13:13: 13:34
+          _6 = const 6_usize;              // scope 1 at $DIR/optimizes_into_variable.rs:13:13: 13:34
                                            // ty::Const
                                            // + ty: usize
                                            // + val: Value(Scalar(0x0000000000000006))
@@ -138,7 +150,7 @@
   
       bb2: {
 -         _3 = _4[_5];                     // scope 1 at $DIR/optimizes_into_variable.rs:13:13: 13:34
-+         _3 = const 3i32;                 // scope 1 at $DIR/optimizes_into_variable.rs:13:13: 13:34
++         _3 = const 3_i32;                // scope 1 at $DIR/optimizes_into_variable.rs:13:13: 13:34
 +                                          // ty::Const
 +                                          // + ty: i32
 +                                          // + val: Value(Scalar(0x00000003))
@@ -149,7 +161,7 @@
           StorageDead(_4);                 // scope 1 at $DIR/optimizes_into_variable.rs:13:34: 13:35
           StorageLive(_8);                 // scope 2 at $DIR/optimizes_into_variable.rs:14:9: 14:10
           StorageLive(_9);                 // scope 2 at $DIR/optimizes_into_variable.rs:14:13: 14:36
-          _9 = Point { x: const 12u32, y: const 42u32 }; // scope 2 at $DIR/optimizes_into_variable.rs:14:13: 14:36
+          _9 = Point { x: const 12_u32, y: const 42_u32 }; // scope 2 at $DIR/optimizes_into_variable.rs:14:13: 14:36
                                            // ty::Const
                                            // + ty: u32
                                            // + val: Value(Scalar(0x0000000c))
@@ -163,7 +175,7 @@
                                            // + span: $DIR/optimizes_into_variable.rs:14:32: 14:34
                                            // + literal: Const { ty: u32, val: Value(Scalar(0x0000002a)) }
 -         _8 = (_9.1: u32);                // scope 2 at $DIR/optimizes_into_variable.rs:14:13: 14:38
-+         _8 = const 42u32;                // scope 2 at $DIR/optimizes_into_variable.rs:14:13: 14:38
++         _8 = const 42_u32;               // scope 2 at $DIR/optimizes_into_variable.rs:14:13: 14:38
 +                                          // ty::Const
 +                                          // + ty: u32
 +                                          // + val: Value(Scalar(0x0000002a))

--- a/src/test/mir-opt/const_prop/optimizes_into_variable/64bit/rustc.main.SimplifyLocals.after.mir
+++ b/src/test/mir-opt/const_prop/optimizes_into_variable/64bit/rustc.main.SimplifyLocals.after.mir
@@ -17,7 +17,7 @@ fn main() -> () {
 
     bb0: {
         StorageLive(_1);                 // scope 0 at $DIR/optimizes_into_variable.rs:12:9: 12:10
-        _1 = const 4i32;                 // scope 0 at $DIR/optimizes_into_variable.rs:12:13: 12:18
+        _1 = const 4_i32;                // scope 0 at $DIR/optimizes_into_variable.rs:12:13: 12:18
                                          // ty::Const
                                          // + ty: i32
                                          // + val: Value(Scalar(0x00000004))
@@ -25,7 +25,7 @@ fn main() -> () {
                                          // + span: $DIR/optimizes_into_variable.rs:12:13: 12:18
                                          // + literal: Const { ty: i32, val: Value(Scalar(0x00000004)) }
         StorageLive(_2);                 // scope 1 at $DIR/optimizes_into_variable.rs:13:9: 13:10
-        _2 = const 3i32;                 // scope 1 at $DIR/optimizes_into_variable.rs:13:13: 13:34
+        _2 = const 3_i32;                // scope 1 at $DIR/optimizes_into_variable.rs:13:13: 13:34
                                          // ty::Const
                                          // + ty: i32
                                          // + val: Value(Scalar(0x00000003))
@@ -33,7 +33,7 @@ fn main() -> () {
                                          // + span: $DIR/optimizes_into_variable.rs:13:13: 13:34
                                          // + literal: Const { ty: i32, val: Value(Scalar(0x00000003)) }
         StorageLive(_3);                 // scope 2 at $DIR/optimizes_into_variable.rs:14:9: 14:10
-        _3 = const 42u32;                // scope 2 at $DIR/optimizes_into_variable.rs:14:13: 14:38
+        _3 = const 42_u32;               // scope 2 at $DIR/optimizes_into_variable.rs:14:13: 14:38
                                          // ty::Const
                                          // + ty: u32
                                          // + val: Value(Scalar(0x0000002a))

--- a/src/test/mir-opt/const_prop/read_immutable_static/rustc.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/read_immutable_static/rustc.main.ConstProp.diff
@@ -24,7 +24,7 @@
                                            // + span: $DIR/read_immutable_static.rs:7:13: 7:16
                                            // + literal: Const { ty: &u8, val: Value(Scalar(alloc0)) }
 -         _2 = (*_3);                      // scope 0 at $DIR/read_immutable_static.rs:7:13: 7:16
-+         _2 = const 2u8;                  // scope 0 at $DIR/read_immutable_static.rs:7:13: 7:16
++         _2 = const 2_u8;                 // scope 0 at $DIR/read_immutable_static.rs:7:13: 7:16
 +                                          // ty::Const
 +                                          // + ty: u8
 +                                          // + val: Value(Scalar(0x02))
@@ -42,14 +42,14 @@
                                            // + literal: Const { ty: &u8, val: Value(Scalar(alloc0)) }
 -         _4 = (*_5);                      // scope 0 at $DIR/read_immutable_static.rs:7:19: 7:22
 -         _1 = Add(move _2, move _4);      // scope 0 at $DIR/read_immutable_static.rs:7:13: 7:22
-+         _4 = const 2u8;                  // scope 0 at $DIR/read_immutable_static.rs:7:19: 7:22
++         _4 = const 2_u8;                 // scope 0 at $DIR/read_immutable_static.rs:7:19: 7:22
 +                                          // ty::Const
 +                                          // + ty: u8
 +                                          // + val: Value(Scalar(0x02))
 +                                          // mir::Constant
 +                                          // + span: $DIR/read_immutable_static.rs:7:19: 7:22
 +                                          // + literal: Const { ty: u8, val: Value(Scalar(0x02)) }
-+         _1 = const 4u8;                  // scope 0 at $DIR/read_immutable_static.rs:7:13: 7:22
++         _1 = const 4_u8;                 // scope 0 at $DIR/read_immutable_static.rs:7:13: 7:22
 +                                          // ty::Const
 +                                          // + ty: u8
 +                                          // + val: Value(Scalar(0x04))

--- a/src/test/mir-opt/const_prop/ref_deref/rustc.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/ref_deref/rustc.main.ConstProp.diff
@@ -20,7 +20,7 @@
                                            // + literal: Const { ty: &i32, val: Unevaluated(DefId(0:3 ~ ref_deref[317d]::main[0]), [], Some(promoted[0])) }
           _2 = _4;                         // scope 0 at $DIR/ref_deref.rs:5:6: 5:10
 -         _1 = (*_2);                      // scope 0 at $DIR/ref_deref.rs:5:5: 5:10
-+         _1 = const 4i32;                 // scope 0 at $DIR/ref_deref.rs:5:5: 5:10
++         _1 = const 4_i32;                // scope 0 at $DIR/ref_deref.rs:5:5: 5:10
 +                                          // ty::Const
 +                                          // + ty: i32
 +                                          // + val: Value(Scalar(0x00000004))

--- a/src/test/mir-opt/const_prop/ref_deref/rustc.main.PromoteTemps.diff
+++ b/src/test/mir-opt/const_prop/ref_deref/rustc.main.PromoteTemps.diff
@@ -12,7 +12,7 @@
           StorageLive(_1);                 // scope 0 at $DIR/ref_deref.rs:5:5: 5:10
           StorageLive(_2);                 // scope 0 at $DIR/ref_deref.rs:5:6: 5:10
 -         StorageLive(_3);                 // scope 0 at $DIR/ref_deref.rs:5:8: 5:9
--         _3 = const 4i32;                 // scope 0 at $DIR/ref_deref.rs:5:8: 5:9
+-         _3 = const 4_i32;                // scope 0 at $DIR/ref_deref.rs:5:8: 5:9
 +         _4 = const main::promoted[0];    // scope 0 at $DIR/ref_deref.rs:5:6: 5:10
                                            // ty::Const
 -                                          // + ty: i32

--- a/src/test/mir-opt/const_prop/ref_deref_project/rustc.main.PromoteTemps.diff
+++ b/src/test/mir-opt/const_prop/ref_deref_project/rustc.main.PromoteTemps.diff
@@ -12,7 +12,7 @@
           StorageLive(_1);                 // scope 0 at $DIR/ref_deref_project.rs:5:5: 5:17
           StorageLive(_2);                 // scope 0 at $DIR/ref_deref_project.rs:5:6: 5:17
 -         StorageLive(_3);                 // scope 0 at $DIR/ref_deref_project.rs:5:8: 5:14
--         _3 = (const 4i32, const 5i32);   // scope 0 at $DIR/ref_deref_project.rs:5:8: 5:14
+-         _3 = (const 4_i32, const 5_i32); // scope 0 at $DIR/ref_deref_project.rs:5:8: 5:14
 +         _4 = const main::promoted[0];    // scope 0 at $DIR/ref_deref_project.rs:5:6: 5:17
                                            // ty::Const
 -                                          // + ty: i32

--- a/src/test/mir-opt/const_prop/repeat/32bit/rustc.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/repeat/32bit/rustc.main.ConstProp.diff
@@ -17,7 +17,7 @@
           StorageLive(_1);                 // scope 0 at $DIR/repeat.rs:6:9: 6:10
           StorageLive(_2);                 // scope 0 at $DIR/repeat.rs:6:18: 6:28
           StorageLive(_3);                 // scope 0 at $DIR/repeat.rs:6:18: 6:25
-          _3 = [const 42u32; 8];           // scope 0 at $DIR/repeat.rs:6:18: 6:25
+          _3 = [const 42_u32; 8];          // scope 0 at $DIR/repeat.rs:6:18: 6:25
                                            // ty::Const
                                            // + ty: u32
                                            // + val: Value(Scalar(0x0000002a))
@@ -25,14 +25,14 @@
                                            // + span: $DIR/repeat.rs:6:19: 6:21
                                            // + literal: Const { ty: u32, val: Value(Scalar(0x0000002a)) }
           StorageLive(_4);                 // scope 0 at $DIR/repeat.rs:6:26: 6:27
-          _4 = const 2usize;               // scope 0 at $DIR/repeat.rs:6:26: 6:27
+          _4 = const 2_usize;              // scope 0 at $DIR/repeat.rs:6:26: 6:27
                                            // ty::Const
                                            // + ty: usize
                                            // + val: Value(Scalar(0x00000002))
                                            // mir::Constant
                                            // + span: $DIR/repeat.rs:6:26: 6:27
                                            // + literal: Const { ty: usize, val: Value(Scalar(0x00000002)) }
-          _5 = const 8usize;               // scope 0 at $DIR/repeat.rs:6:18: 6:28
+          _5 = const 8_usize;              // scope 0 at $DIR/repeat.rs:6:18: 6:28
                                            // ty::Const
                                            // + ty: usize
                                            // + val: Value(Scalar(0x00000008))
@@ -59,8 +59,8 @@
   
       bb1: {
 -         _2 = _3[_4];                     // scope 0 at $DIR/repeat.rs:6:18: 6:28
--         _1 = Add(move _2, const 0u32);   // scope 0 at $DIR/repeat.rs:6:18: 6:32
-+         _2 = const 42u32;                // scope 0 at $DIR/repeat.rs:6:18: 6:28
+-         _1 = Add(move _2, const 0_u32);  // scope 0 at $DIR/repeat.rs:6:18: 6:32
++         _2 = const 42_u32;               // scope 0 at $DIR/repeat.rs:6:18: 6:28
                                            // ty::Const
                                            // + ty: u32
 -                                          // + val: Value(Scalar(0x00000000))
@@ -70,7 +70,7 @@
 -                                          // + literal: Const { ty: u32, val: Value(Scalar(0x00000000)) }
 +                                          // + span: $DIR/repeat.rs:6:18: 6:28
 +                                          // + literal: Const { ty: u32, val: Value(Scalar(0x0000002a)) }
-+         _1 = const 42u32;                // scope 0 at $DIR/repeat.rs:6:18: 6:32
++         _1 = const 42_u32;               // scope 0 at $DIR/repeat.rs:6:18: 6:32
 +                                          // ty::Const
 +                                          // + ty: u32
 +                                          // + val: Value(Scalar(0x0000002a))

--- a/src/test/mir-opt/const_prop/repeat/64bit/rustc.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/repeat/64bit/rustc.main.ConstProp.diff
@@ -17,7 +17,7 @@
           StorageLive(_1);                 // scope 0 at $DIR/repeat.rs:6:9: 6:10
           StorageLive(_2);                 // scope 0 at $DIR/repeat.rs:6:18: 6:28
           StorageLive(_3);                 // scope 0 at $DIR/repeat.rs:6:18: 6:25
-          _3 = [const 42u32; 8];           // scope 0 at $DIR/repeat.rs:6:18: 6:25
+          _3 = [const 42_u32; 8];          // scope 0 at $DIR/repeat.rs:6:18: 6:25
                                            // ty::Const
                                            // + ty: u32
                                            // + val: Value(Scalar(0x0000002a))
@@ -25,14 +25,14 @@
                                            // + span: $DIR/repeat.rs:6:19: 6:21
                                            // + literal: Const { ty: u32, val: Value(Scalar(0x0000002a)) }
           StorageLive(_4);                 // scope 0 at $DIR/repeat.rs:6:26: 6:27
-          _4 = const 2usize;               // scope 0 at $DIR/repeat.rs:6:26: 6:27
+          _4 = const 2_usize;              // scope 0 at $DIR/repeat.rs:6:26: 6:27
                                            // ty::Const
                                            // + ty: usize
                                            // + val: Value(Scalar(0x0000000000000002))
                                            // mir::Constant
                                            // + span: $DIR/repeat.rs:6:26: 6:27
                                            // + literal: Const { ty: usize, val: Value(Scalar(0x0000000000000002)) }
-          _5 = const 8usize;               // scope 0 at $DIR/repeat.rs:6:18: 6:28
+          _5 = const 8_usize;              // scope 0 at $DIR/repeat.rs:6:18: 6:28
                                            // ty::Const
                                            // + ty: usize
                                            // + val: Value(Scalar(0x0000000000000008))
@@ -59,8 +59,8 @@
   
       bb1: {
 -         _2 = _3[_4];                     // scope 0 at $DIR/repeat.rs:6:18: 6:28
--         _1 = Add(move _2, const 0u32);   // scope 0 at $DIR/repeat.rs:6:18: 6:32
-+         _2 = const 42u32;                // scope 0 at $DIR/repeat.rs:6:18: 6:28
+-         _1 = Add(move _2, const 0_u32);  // scope 0 at $DIR/repeat.rs:6:18: 6:32
++         _2 = const 42_u32;               // scope 0 at $DIR/repeat.rs:6:18: 6:28
                                            // ty::Const
                                            // + ty: u32
 -                                          // + val: Value(Scalar(0x00000000))
@@ -70,7 +70,7 @@
 -                                          // + literal: Const { ty: u32, val: Value(Scalar(0x00000000)) }
 +                                          // + span: $DIR/repeat.rs:6:18: 6:28
 +                                          // + literal: Const { ty: u32, val: Value(Scalar(0x0000002a)) }
-+         _1 = const 42u32;                // scope 0 at $DIR/repeat.rs:6:18: 6:32
++         _1 = const 42_u32;               // scope 0 at $DIR/repeat.rs:6:18: 6:32
 +                                          // ty::Const
 +                                          // + ty: u32
 +                                          // + val: Value(Scalar(0x0000002a))

--- a/src/test/mir-opt/const_prop/return_place/rustc.add.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/return_place/rustc.add.ConstProp.diff
@@ -6,8 +6,8 @@
       let mut _1: (u32, bool);             // in scope 0 at $DIR/return_place.rs:6:5: 6:10
   
       bb0: {
--         _1 = CheckedAdd(const 2u32, const 2u32); // scope 0 at $DIR/return_place.rs:6:5: 6:10
-+         _1 = (const 4u32, const false);  // scope 0 at $DIR/return_place.rs:6:5: 6:10
+-         _1 = CheckedAdd(const 2_u32, const 2_u32); // scope 0 at $DIR/return_place.rs:6:5: 6:10
++         _1 = (const 4_u32, const false); // scope 0 at $DIR/return_place.rs:6:5: 6:10
                                            // ty::Const
                                            // + ty: u32
 -                                          // + val: Value(Scalar(0x00000002))
@@ -25,21 +25,33 @@
                                            // mir::Constant
 -                                          // + span: $DIR/return_place.rs:6:9: 6:10
 -                                          // + literal: Const { ty: u32, val: Value(Scalar(0x00000002)) }
--         assert(!move (_1.1: bool), "attempt to add with overflow") -> bb1; // scope 0 at $DIR/return_place.rs:6:5: 6:10
+-         assert(!move (_1.1: bool), "attempt to compute `{} + {}` which would overflow", const 2_u32, const 2_u32) -> bb1; // scope 0 at $DIR/return_place.rs:6:5: 6:10
 +                                          // + span: $DIR/return_place.rs:6:5: 6:10
 +                                          // + literal: Const { ty: bool, val: Value(Scalar(0x00)) }
-+         assert(!const false, "attempt to add with overflow") -> bb1; // scope 0 at $DIR/return_place.rs:6:5: 6:10
-+                                          // ty::Const
++         assert(!const false, "attempt to compute `{} + {}` which would overflow", const 2_u32, const 2_u32) -> bb1; // scope 0 at $DIR/return_place.rs:6:5: 6:10
+                                           // ty::Const
 +                                          // + ty: bool
 +                                          // + val: Value(Scalar(0x00))
 +                                          // mir::Constant
 +                                          // + span: $DIR/return_place.rs:6:5: 6:10
 +                                          // + literal: Const { ty: bool, val: Value(Scalar(0x00)) }
++                                          // ty::Const
+                                           // + ty: u32
+                                           // + val: Value(Scalar(0x00000002))
+                                           // mir::Constant
+                                           // + span: $DIR/return_place.rs:6:5: 6:6
+                                           // + literal: Const { ty: u32, val: Value(Scalar(0x00000002)) }
+                                           // ty::Const
+                                           // + ty: u32
+                                           // + val: Value(Scalar(0x00000002))
+                                           // mir::Constant
+                                           // + span: $DIR/return_place.rs:6:9: 6:10
+                                           // + literal: Const { ty: u32, val: Value(Scalar(0x00000002)) }
       }
   
       bb1: {
 -         _0 = move (_1.0: u32);           // scope 0 at $DIR/return_place.rs:6:5: 6:10
-+         _0 = const 4u32;                 // scope 0 at $DIR/return_place.rs:6:5: 6:10
++         _0 = const 4_u32;                // scope 0 at $DIR/return_place.rs:6:5: 6:10
 +                                          // ty::Const
 +                                          // + ty: u32
 +                                          // + val: Value(Scalar(0x00000004))

--- a/src/test/mir-opt/const_prop/return_place/rustc.add.PreCodegen.before.mir
+++ b/src/test/mir-opt/const_prop/return_place/rustc.add.PreCodegen.before.mir
@@ -4,7 +4,7 @@ fn add() -> u32 {
     let mut _0: u32;                     // return place in scope 0 at $DIR/return_place.rs:5:13: 5:16
 
     bb0: {
-        _0 = const 4u32;                 // scope 0 at $DIR/return_place.rs:6:5: 6:10
+        _0 = const 4_u32;                // scope 0 at $DIR/return_place.rs:6:5: 6:10
                                          // ty::Const
                                          // + ty: u32
                                          // + val: Value(Scalar(0x00000004))

--- a/src/test/mir-opt/const_prop/scalar_literal_propagation/rustc.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/scalar_literal_propagation/rustc.main.ConstProp.diff
@@ -12,7 +12,7 @@
   
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/scalar_literal_propagation.rs:3:9: 3:10
-          _1 = const 1u32;                 // scope 0 at $DIR/scalar_literal_propagation.rs:3:13: 3:14
+          _1 = const 1_u32;                // scope 0 at $DIR/scalar_literal_propagation.rs:3:13: 3:14
                                            // ty::Const
                                            // + ty: u32
                                            // + val: Value(Scalar(0x00000001))
@@ -23,14 +23,14 @@
           StorageLive(_3);                 // scope 1 at $DIR/scalar_literal_propagation.rs:4:13: 4:14
 -         _3 = _1;                         // scope 1 at $DIR/scalar_literal_propagation.rs:4:13: 4:14
 -         _2 = const consume(move _3) -> bb1; // scope 1 at $DIR/scalar_literal_propagation.rs:4:5: 4:15
-+         _3 = const 1u32;                 // scope 1 at $DIR/scalar_literal_propagation.rs:4:13: 4:14
++         _3 = const 1_u32;                // scope 1 at $DIR/scalar_literal_propagation.rs:4:13: 4:14
                                            // ty::Const
 +                                          // + ty: u32
 +                                          // + val: Value(Scalar(0x00000001))
 +                                          // mir::Constant
 +                                          // + span: $DIR/scalar_literal_propagation.rs:4:13: 4:14
 +                                          // + literal: Const { ty: u32, val: Value(Scalar(0x00000001)) }
-+         _2 = const consume(const 1u32) -> bb1; // scope 1 at $DIR/scalar_literal_propagation.rs:4:5: 4:15
++         _2 = const consume(const 1_u32) -> bb1; // scope 1 at $DIR/scalar_literal_propagation.rs:4:5: 4:15
 +                                          // ty::Const
                                            // + ty: fn(u32) {consume}
                                            // + val: Value(Scalar(<ZST>))

--- a/src/test/mir-opt/const_prop/slice_len/32bit/rustc.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/slice_len/32bit/rustc.main.ConstProp.diff
@@ -30,7 +30,7 @@
           _2 = move _3 as &[u32] (Pointer(Unsize)); // scope 0 at $DIR/slice_len.rs:5:6: 5:19
           StorageDead(_3);                 // scope 0 at $DIR/slice_len.rs:5:18: 5:19
           StorageLive(_6);                 // scope 0 at $DIR/slice_len.rs:5:31: 5:32
-          _6 = const 1usize;               // scope 0 at $DIR/slice_len.rs:5:31: 5:32
+          _6 = const 1_usize;              // scope 0 at $DIR/slice_len.rs:5:31: 5:32
                                            // ty::Const
                                            // + ty: usize
                                            // + val: Value(Scalar(0x00000001))
@@ -40,7 +40,7 @@
 -         _7 = Len((*_2));                 // scope 0 at $DIR/slice_len.rs:5:5: 5:33
 -         _8 = Lt(_6, _7);                 // scope 0 at $DIR/slice_len.rs:5:5: 5:33
 -         assert(move _8, "index out of bounds: the len is {} but the index is {}", move _7, _6) -> bb1; // scope 0 at $DIR/slice_len.rs:5:5: 5:33
-+         _7 = const 3usize;               // scope 0 at $DIR/slice_len.rs:5:5: 5:33
++         _7 = const 3_usize;              // scope 0 at $DIR/slice_len.rs:5:5: 5:33
 +                                          // ty::Const
 +                                          // + ty: usize
 +                                          // + val: Value(Scalar(0x00000003))
@@ -65,7 +65,7 @@
   
       bb1: {
 -         _1 = (*_2)[_6];                  // scope 0 at $DIR/slice_len.rs:5:5: 5:33
-+         _1 = const 2u32;                 // scope 0 at $DIR/slice_len.rs:5:5: 5:33
++         _1 = const 2_u32;                // scope 0 at $DIR/slice_len.rs:5:5: 5:33
 +                                          // ty::Const
 +                                          // + ty: u32
 +                                          // + val: Value(Scalar(0x00000002))

--- a/src/test/mir-opt/const_prop/slice_len/64bit/rustc.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/slice_len/64bit/rustc.main.ConstProp.diff
@@ -30,7 +30,7 @@
           _2 = move _3 as &[u32] (Pointer(Unsize)); // scope 0 at $DIR/slice_len.rs:5:6: 5:19
           StorageDead(_3);                 // scope 0 at $DIR/slice_len.rs:5:18: 5:19
           StorageLive(_6);                 // scope 0 at $DIR/slice_len.rs:5:31: 5:32
-          _6 = const 1usize;               // scope 0 at $DIR/slice_len.rs:5:31: 5:32
+          _6 = const 1_usize;              // scope 0 at $DIR/slice_len.rs:5:31: 5:32
                                            // ty::Const
                                            // + ty: usize
                                            // + val: Value(Scalar(0x0000000000000001))
@@ -40,7 +40,7 @@
 -         _7 = Len((*_2));                 // scope 0 at $DIR/slice_len.rs:5:5: 5:33
 -         _8 = Lt(_6, _7);                 // scope 0 at $DIR/slice_len.rs:5:5: 5:33
 -         assert(move _8, "index out of bounds: the len is {} but the index is {}", move _7, _6) -> bb1; // scope 0 at $DIR/slice_len.rs:5:5: 5:33
-+         _7 = const 3usize;               // scope 0 at $DIR/slice_len.rs:5:5: 5:33
++         _7 = const 3_usize;              // scope 0 at $DIR/slice_len.rs:5:5: 5:33
 +                                          // ty::Const
 +                                          // + ty: usize
 +                                          // + val: Value(Scalar(0x0000000000000003))
@@ -65,7 +65,7 @@
   
       bb1: {
 -         _1 = (*_2)[_6];                  // scope 0 at $DIR/slice_len.rs:5:5: 5:33
-+         _1 = const 2u32;                 // scope 0 at $DIR/slice_len.rs:5:5: 5:33
++         _1 = const 2_u32;                // scope 0 at $DIR/slice_len.rs:5:5: 5:33
 +                                          // ty::Const
 +                                          // + ty: u32
 +                                          // + val: Value(Scalar(0x00000002))

--- a/src/test/mir-opt/const_prop/switch_int/rustc.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/switch_int/rustc.main.ConstProp.diff
@@ -7,15 +7,15 @@
   
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/switch_int.rs:7:11: 7:12
-          _1 = const 1i32;                 // scope 0 at $DIR/switch_int.rs:7:11: 7:12
+          _1 = const 1_i32;                // scope 0 at $DIR/switch_int.rs:7:11: 7:12
                                            // ty::Const
                                            // + ty: i32
                                            // + val: Value(Scalar(0x00000001))
                                            // mir::Constant
                                            // + span: $DIR/switch_int.rs:7:11: 7:12
                                            // + literal: Const { ty: i32, val: Value(Scalar(0x00000001)) }
--         switchInt(_1) -> [1i32: bb2, otherwise: bb1]; // scope 0 at $DIR/switch_int.rs:8:9: 8:10
-+         switchInt(const 1i32) -> [1i32: bb2, otherwise: bb1]; // scope 0 at $DIR/switch_int.rs:8:9: 8:10
+-         switchInt(_1) -> [1_i32: bb2, otherwise: bb1]; // scope 0 at $DIR/switch_int.rs:8:9: 8:10
++         switchInt(const 1_i32) -> [1_i32: bb2, otherwise: bb1]; // scope 0 at $DIR/switch_int.rs:8:9: 8:10
 +                                          // ty::Const
 +                                          // + ty: i32
 +                                          // + val: Value(Scalar(0x00000001))
@@ -25,7 +25,7 @@
       }
   
       bb1: {
-          _0 = const foo(const -1i32) -> bb3; // scope 0 at $DIR/switch_int.rs:9:14: 9:21
+          _0 = const foo(const -1_i32) -> bb3; // scope 0 at $DIR/switch_int.rs:9:14: 9:21
                                            // ty::Const
                                            // + ty: fn(i32) {foo}
                                            // + val: Value(Scalar(<ZST>))
@@ -41,7 +41,7 @@
       }
   
       bb2: {
-          _0 = const foo(const 0i32) -> bb3; // scope 0 at $DIR/switch_int.rs:8:14: 8:20
+          _0 = const foo(const 0_i32) -> bb3; // scope 0 at $DIR/switch_int.rs:8:14: 8:20
                                            // ty::Const
                                            // + ty: fn(i32) {foo}
                                            // + val: Value(Scalar(<ZST>))

--- a/src/test/mir-opt/const_prop/switch_int/rustc.main.SimplifyBranches-after-const-prop.diff
+++ b/src/test/mir-opt/const_prop/switch_int/rustc.main.SimplifyBranches-after-const-prop.diff
@@ -7,14 +7,14 @@
   
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/switch_int.rs:7:11: 7:12
-          _1 = const 1i32;                 // scope 0 at $DIR/switch_int.rs:7:11: 7:12
+          _1 = const 1_i32;                // scope 0 at $DIR/switch_int.rs:7:11: 7:12
                                            // ty::Const
                                            // + ty: i32
                                            // + val: Value(Scalar(0x00000001))
                                            // mir::Constant
                                            // + span: $DIR/switch_int.rs:7:11: 7:12
                                            // + literal: Const { ty: i32, val: Value(Scalar(0x00000001)) }
--         switchInt(const 1i32) -> [1i32: bb2, otherwise: bb1]; // scope 0 at $DIR/switch_int.rs:8:9: 8:10
+-         switchInt(const 1_i32) -> [1_i32: bb2, otherwise: bb1]; // scope 0 at $DIR/switch_int.rs:8:9: 8:10
 -                                          // ty::Const
 -                                          // + ty: i32
 -                                          // + val: Value(Scalar(0x00000001))
@@ -25,7 +25,7 @@
       }
   
       bb1: {
-          _0 = const foo(const -1i32) -> bb3; // scope 0 at $DIR/switch_int.rs:9:14: 9:21
+          _0 = const foo(const -1_i32) -> bb3; // scope 0 at $DIR/switch_int.rs:9:14: 9:21
                                            // ty::Const
                                            // + ty: fn(i32) {foo}
                                            // + val: Value(Scalar(<ZST>))
@@ -41,7 +41,7 @@
       }
   
       bb2: {
-          _0 = const foo(const 0i32) -> bb3; // scope 0 at $DIR/switch_int.rs:8:14: 8:20
+          _0 = const foo(const 0_i32) -> bb3; // scope 0 at $DIR/switch_int.rs:8:14: 8:20
                                            // ty::Const
                                            // + ty: fn(i32) {foo}
                                            // + val: Value(Scalar(<ZST>))

--- a/src/test/mir-opt/const_prop/tuple_literal_propagation/rustc.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/tuple_literal_propagation/rustc.main.ConstProp.diff
@@ -12,7 +12,7 @@
   
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/tuple_literal_propagation.rs:3:9: 3:10
-          _1 = (const 1u32, const 2u32);   // scope 0 at $DIR/tuple_literal_propagation.rs:3:13: 3:19
+          _1 = (const 1_u32, const 2_u32); // scope 0 at $DIR/tuple_literal_propagation.rs:3:13: 3:19
                                            // ty::Const
                                            // + ty: u32
                                            // + val: Value(Scalar(0x00000001))
@@ -30,7 +30,7 @@
           StorageLive(_2);                 // scope 1 at $DIR/tuple_literal_propagation.rs:5:5: 5:15
           StorageLive(_3);                 // scope 1 at $DIR/tuple_literal_propagation.rs:5:13: 5:14
 -         _3 = _1;                         // scope 1 at $DIR/tuple_literal_propagation.rs:5:13: 5:14
-+         _3 = (const 1u32, const 2u32);   // scope 1 at $DIR/tuple_literal_propagation.rs:5:13: 5:14
++         _3 = (const 1_u32, const 2_u32); // scope 1 at $DIR/tuple_literal_propagation.rs:5:13: 5:14
 +                                          // ty::Const
 +                                          // + ty: u32
 +                                          // + val: Value(Scalar(0x00000001))

--- a/src/test/mir-opt/const_prop_miscompile/rustc.bar.ConstProp.diff
+++ b/src/test/mir-opt/const_prop_miscompile/rustc.bar.ConstProp.diff
@@ -19,8 +19,8 @@
   
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/const_prop_miscompile.rs:12:9: 12:14
--         _1 = (const 1i32,);              // scope 0 at $DIR/const_prop_miscompile.rs:12:17: 12:21
-+         _1 = const (1i32,);              // scope 0 at $DIR/const_prop_miscompile.rs:12:17: 12:21
+-         _1 = (const 1_i32,);             // scope 0 at $DIR/const_prop_miscompile.rs:12:17: 12:21
++         _1 = const (1_i32,);             // scope 0 at $DIR/const_prop_miscompile.rs:12:17: 12:21
                                            // ty::Const
 -                                          // + ty: i32
 +                                          // + ty: (i32,)
@@ -33,7 +33,7 @@
           StorageLive(_2);                 // scope 1 at $DIR/const_prop_miscompile.rs:13:5: 15:6
           StorageLive(_3);                 // scope 2 at $DIR/const_prop_miscompile.rs:14:10: 14:22
           _3 = &raw mut (_1.0: i32);       // scope 2 at $DIR/const_prop_miscompile.rs:14:10: 14:22
-          (*_3) = const 5i32;              // scope 2 at $DIR/const_prop_miscompile.rs:14:9: 14:26
+          (*_3) = const 5_i32;             // scope 2 at $DIR/const_prop_miscompile.rs:14:9: 14:26
                                            // ty::Const
                                            // + ty: i32
                                            // + val: Value(Scalar(0x00000005))
@@ -52,7 +52,7 @@
           StorageLive(_4);                 // scope 1 at $DIR/const_prop_miscompile.rs:16:9: 16:10
           StorageLive(_5);                 // scope 1 at $DIR/const_prop_miscompile.rs:16:13: 16:20
           _5 = (_1.0: i32);                // scope 1 at $DIR/const_prop_miscompile.rs:16:15: 16:18
-          _4 = Eq(move _5, const 5i32);    // scope 1 at $DIR/const_prop_miscompile.rs:16:13: 16:25
+          _4 = Eq(move _5, const 5_i32);   // scope 1 at $DIR/const_prop_miscompile.rs:16:13: 16:25
                                            // ty::Const
                                            // + ty: i32
                                            // + val: Value(Scalar(0x00000005))

--- a/src/test/mir-opt/const_prop_miscompile/rustc.foo.ConstProp.diff
+++ b/src/test/mir-opt/const_prop_miscompile/rustc.foo.ConstProp.diff
@@ -16,8 +16,8 @@
   
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/const_prop_miscompile.rs:5:9: 5:14
--         _1 = (const 1i32,);              // scope 0 at $DIR/const_prop_miscompile.rs:5:17: 5:21
-+         _1 = const (1i32,);              // scope 0 at $DIR/const_prop_miscompile.rs:5:17: 5:21
+-         _1 = (const 1_i32,);             // scope 0 at $DIR/const_prop_miscompile.rs:5:17: 5:21
++         _1 = const (1_i32,);             // scope 0 at $DIR/const_prop_miscompile.rs:5:17: 5:21
                                            // ty::Const
 -                                          // + ty: i32
 +                                          // + ty: (i32,)
@@ -29,7 +29,7 @@
 +                                          // + literal: Const { ty: (i32,), val: Value(Scalar(0x00000001)) }
           StorageLive(_2);                 // scope 1 at $DIR/const_prop_miscompile.rs:6:6: 6:14
           _2 = &mut (_1.0: i32);           // scope 1 at $DIR/const_prop_miscompile.rs:6:6: 6:14
-          (*_2) = const 5i32;              // scope 1 at $DIR/const_prop_miscompile.rs:6:5: 6:18
+          (*_2) = const 5_i32;             // scope 1 at $DIR/const_prop_miscompile.rs:6:5: 6:18
                                            // ty::Const
                                            // + ty: i32
                                            // + val: Value(Scalar(0x00000005))
@@ -40,7 +40,7 @@
           StorageLive(_3);                 // scope 1 at $DIR/const_prop_miscompile.rs:7:9: 7:10
           StorageLive(_4);                 // scope 1 at $DIR/const_prop_miscompile.rs:7:13: 7:20
           _4 = (_1.0: i32);                // scope 1 at $DIR/const_prop_miscompile.rs:7:15: 7:18
-          _3 = Eq(move _4, const 5i32);    // scope 1 at $DIR/const_prop_miscompile.rs:7:13: 7:25
+          _3 = Eq(move _4, const 5_i32);   // scope 1 at $DIR/const_prop_miscompile.rs:7:13: 7:25
                                            // ty::Const
                                            // + ty: i32
                                            // + val: Value(Scalar(0x00000005))

--- a/src/test/mir-opt/copy_propagation_arg/rustc.arg_src.CopyPropagation.diff
+++ b/src/test/mir-opt/copy_propagation_arg/rustc.arg_src.CopyPropagation.diff
@@ -12,7 +12,7 @@
       bb0: {
           StorageLive(_2);                 // scope 0 at $DIR/copy_propagation_arg.rs:28:9: 28:10
           _2 = _1;                         // scope 0 at $DIR/copy_propagation_arg.rs:28:13: 28:14
-          _1 = const 123i32;               // scope 1 at $DIR/copy_propagation_arg.rs:29:5: 29:12
+          _1 = const 123_i32;              // scope 1 at $DIR/copy_propagation_arg.rs:29:5: 29:12
                                            // ty::Const
                                            // + ty: i32
                                            // + val: Value(Scalar(0x0000007b))

--- a/src/test/mir-opt/copy_propagation_arg/rustc.bar.CopyPropagation.diff
+++ b/src/test/mir-opt/copy_propagation_arg/rustc.bar.CopyPropagation.diff
@@ -23,7 +23,7 @@
       bb1: {
           StorageDead(_3);                 // scope 0 at $DIR/copy_propagation_arg.rs:16:12: 16:13
           StorageDead(_2);                 // scope 0 at $DIR/copy_propagation_arg.rs:16:13: 16:14
-          _1 = const 5u8;                  // scope 0 at $DIR/copy_propagation_arg.rs:17:5: 17:10
+          _1 = const 5_u8;                 // scope 0 at $DIR/copy_propagation_arg.rs:17:5: 17:10
                                            // ty::Const
                                            // + ty: u8
                                            // + val: Value(Scalar(0x05))

--- a/src/test/mir-opt/exponential-or/rustc.match_tuple.SimplifyCfg-initial.after.mir
+++ b/src/test/mir-opt/exponential-or/rustc.match_tuple.SimplifyCfg-initial.after.mir
@@ -19,11 +19,11 @@ fn match_tuple(_1: (u32, bool, std::option::Option<i32>, u32)) -> u32 {
 
     bb0: {
         FakeRead(ForMatchedPlace, _1);   // scope 0 at $DIR/exponential-or.rs:7:11: 7:12
-        switchInt((_1.0: u32)) -> [1u32: bb2, 4u32: bb2, otherwise: bb1]; // scope 0 at $DIR/exponential-or.rs:8:15: 8:16
+        switchInt((_1.0: u32)) -> [1_u32: bb2, 4_u32: bb2, otherwise: bb1]; // scope 0 at $DIR/exponential-or.rs:8:15: 8:16
     }
 
     bb1: {
-        _0 = const 0u32;                 // scope 0 at $DIR/exponential-or.rs:9:14: 9:15
+        _0 = const 0_u32;                // scope 0 at $DIR/exponential-or.rs:9:14: 9:15
                                          // ty::Const
                                          // + ty: u32
                                          // + val: Value(Scalar(0x00000000))
@@ -35,15 +35,15 @@ fn match_tuple(_1: (u32, bool, std::option::Option<i32>, u32)) -> u32 {
 
     bb2: {
         _2 = discriminant((_1.2: std::option::Option<i32>)); // scope 0 at $DIR/exponential-or.rs:8:37: 8:48
-        switchInt(move _2) -> [0isize: bb4, 1isize: bb3, otherwise: bb1]; // scope 0 at $DIR/exponential-or.rs:8:37: 8:48
+        switchInt(move _2) -> [0_isize: bb4, 1_isize: bb3, otherwise: bb1]; // scope 0 at $DIR/exponential-or.rs:8:37: 8:48
     }
 
     bb3: {
-        switchInt((((_1.2: std::option::Option<i32>) as Some).0: i32)) -> [1i32: bb4, 8i32: bb4, otherwise: bb1]; // scope 0 at $DIR/exponential-or.rs:8:42: 8:43
+        switchInt((((_1.2: std::option::Option<i32>) as Some).0: i32)) -> [1_i32: bb4, 8_i32: bb4, otherwise: bb1]; // scope 0 at $DIR/exponential-or.rs:8:42: 8:43
     }
 
     bb4: {
-        _5 = Le(const 6u32, (_1.3: u32)); // scope 0 at $DIR/exponential-or.rs:8:62: 8:67
+        _5 = Le(const 6_u32, (_1.3: u32)); // scope 0 at $DIR/exponential-or.rs:8:62: 8:67
                                          // ty::Const
                                          // + ty: u32
                                          // + val: Value(Scalar(0x00000006))
@@ -54,7 +54,7 @@ fn match_tuple(_1: (u32, bool, std::option::Option<i32>, u32)) -> u32 {
     }
 
     bb5: {
-        _6 = Le((_1.3: u32), const 9u32); // scope 0 at $DIR/exponential-or.rs:8:62: 8:67
+        _6 = Le((_1.3: u32), const 9_u32); // scope 0 at $DIR/exponential-or.rs:8:62: 8:67
                                          // ty::Const
                                          // + ty: u32
                                          // + val: Value(Scalar(0x00000009))
@@ -65,7 +65,7 @@ fn match_tuple(_1: (u32, bool, std::option::Option<i32>, u32)) -> u32 {
     }
 
     bb6: {
-        _3 = Le(const 13u32, (_1.3: u32)); // scope 0 at $DIR/exponential-or.rs:8:70: 8:77
+        _3 = Le(const 13_u32, (_1.3: u32)); // scope 0 at $DIR/exponential-or.rs:8:70: 8:77
                                          // ty::Const
                                          // + ty: u32
                                          // + val: Value(Scalar(0x0000000d))
@@ -76,7 +76,7 @@ fn match_tuple(_1: (u32, bool, std::option::Option<i32>, u32)) -> u32 {
     }
 
     bb7: {
-        _4 = Le((_1.3: u32), const 16u32); // scope 0 at $DIR/exponential-or.rs:8:70: 8:77
+        _4 = Le((_1.3: u32), const 16_u32); // scope 0 at $DIR/exponential-or.rs:8:70: 8:77
                                          // ty::Const
                                          // + ty: u32
                                          // + val: Value(Scalar(0x00000010))

--- a/src/test/mir-opt/generator-drop-cleanup/rustc.main-{{closure}}.generator_drop.0.mir
+++ b/src/test/mir-opt/generator-drop-cleanup/rustc.main-{{closure}}.generator_drop.0.mir
@@ -34,7 +34,7 @@ fn main::{{closure}}#0(_1: *mut [generator@$DIR/generator-drop-cleanup.rs:10:15:
 
     bb0: {
         _9 = discriminant((*_1));        // scope 0 at $DIR/generator-drop-cleanup.rs:10:15: 13:6
-        switchInt(move _9) -> [0u32: bb7, 3u32: bb11, otherwise: bb12]; // scope 0 at $DIR/generator-drop-cleanup.rs:10:15: 13:6
+        switchInt(move _9) -> [0_u32: bb7, 3_u32: bb11, otherwise: bb12]; // scope 0 at $DIR/generator-drop-cleanup.rs:10:15: 13:6
     }
 
     bb1 (cleanup): {

--- a/src/test/mir-opt/generator-storage-dead-unwind/rustc.main-{{closure}}.StateTransform.before.mir
+++ b/src/test/mir-opt/generator-storage-dead-unwind/rustc.main-{{closure}}.StateTransform.before.mir
@@ -21,7 +21,7 @@ yields ()
 
     bb0: {
         StorageLive(_3);                 // scope 0 at $DIR/generator-storage-dead-unwind.rs:23:13: 23:14
-        _3 = Foo(const 5i32);            // scope 0 at $DIR/generator-storage-dead-unwind.rs:23:17: 23:23
+        _3 = Foo(const 5_i32);           // scope 0 at $DIR/generator-storage-dead-unwind.rs:23:17: 23:23
                                          // ty::Const
                                          // + ty: i32
                                          // + val: Value(Scalar(0x00000005))
@@ -29,7 +29,7 @@ yields ()
                                          // + span: $DIR/generator-storage-dead-unwind.rs:23:21: 23:22
                                          // + literal: Const { ty: i32, val: Value(Scalar(0x00000005)) }
         StorageLive(_4);                 // scope 1 at $DIR/generator-storage-dead-unwind.rs:24:13: 24:14
-        _4 = Bar(const 6i32);            // scope 1 at $DIR/generator-storage-dead-unwind.rs:24:17: 24:23
+        _4 = Bar(const 6_i32);           // scope 1 at $DIR/generator-storage-dead-unwind.rs:24:17: 24:23
                                          // ty::Const
                                          // + ty: i32
                                          // + val: Value(Scalar(0x00000006))

--- a/src/test/mir-opt/generator-tiny/rustc.main-{{closure}}.generator_resume.0.mir
+++ b/src/test/mir-opt/generator-tiny/rustc.main-{{closure}}.generator_resume.0.mir
@@ -32,7 +32,7 @@ fn main::{{closure}}#0(_1: std::pin::Pin<&mut [generator@$DIR/generator-tiny.rs:
 
     bb0: {
         _11 = discriminant((*(_1.0: &mut [generator@$DIR/generator-tiny.rs:19:16: 25:6 {u8, HasDrop, ()}]))); // scope 0 at $DIR/generator-tiny.rs:19:16: 25:6
-        switchInt(move _11) -> [0u32: bb1, 3u32: bb5, otherwise: bb6]; // scope 0 at $DIR/generator-tiny.rs:19:16: 25:6
+        switchInt(move _11) -> [0_u32: bb1, 3_u32: bb5, otherwise: bb6]; // scope 0 at $DIR/generator-tiny.rs:19:16: 25:6
     }
 
     bb1: {

--- a/src/test/mir-opt/inline/inline-any-operand/rustc.bar.Inline.after.mir
+++ b/src/test/mir-opt/inline/inline-any-operand/rustc.bar.Inline.after.mir
@@ -25,14 +25,14 @@ fn bar() -> bool {
                                          // + literal: Const { ty: fn(i32, i32) -> bool {foo}, val: Value(Scalar(<ZST>)) }
         StorageLive(_2);                 // scope 1 at $DIR/inline-any-operand.rs:12:5: 12:6
         _2 = _1;                         // scope 1 at $DIR/inline-any-operand.rs:12:5: 12:6
-        _3 = const 1i32;                 // scope 1 at $DIR/inline-any-operand.rs:12:5: 12:13
+        _3 = const 1_i32;                // scope 1 at $DIR/inline-any-operand.rs:12:5: 12:13
                                          // ty::Const
                                          // + ty: i32
                                          // + val: Value(Scalar(0x00000001))
                                          // mir::Constant
                                          // + span: $DIR/inline-any-operand.rs:12:7: 12:8
                                          // + literal: Const { ty: i32, val: Value(Scalar(0x00000001)) }
-        _4 = const -1i32;                // scope 1 at $DIR/inline-any-operand.rs:12:5: 12:13
+        _4 = const -1_i32;               // scope 1 at $DIR/inline-any-operand.rs:12:5: 12:13
                                          // ty::Const
                                          // + ty: i32
                                          // + val: Value(Scalar(0xffffffff))

--- a/src/test/mir-opt/inline/inline-into-box-place/32bit/rustc.main.Inline.diff
+++ b/src/test/mir-opt/inline/inline-into-box-place/32bit/rustc.main.Inline.diff
@@ -19,7 +19,7 @@
           _2 = Box(std::vec::Vec<u32>);    // scope 0 at $DIR/inline-into-box-place.rs:8:29: 8:43
 -         (*_2) = const std::vec::Vec::<u32>::new() -> [return: bb2, unwind: bb4]; // scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
 +         _4 = &mut (*_2);                 // scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
-+         ((*_4).0: alloc::raw_vec::RawVec<u32>) = const alloc::raw_vec::RawVec::<u32> { ptr: std::ptr::Unique::<u32> { pointer: {0x4 as *const u32}, _marker: std::marker::PhantomData::<u32> }, cap: 0usize, alloc: std::alloc::Global }; // scope 2 at $SRC_DIR/liballoc/vec.rs:LL:COL
++         ((*_4).0: alloc::raw_vec::RawVec<u32>) = const alloc::raw_vec::RawVec::<u32> { ptr: std::ptr::Unique::<u32> { pointer: {0x4 as *const u32}, _marker: std::marker::PhantomData::<u32> }, cap: 0_usize, alloc: std::alloc::Global }; // scope 2 at $SRC_DIR/liballoc/vec.rs:LL:COL
                                            // ty::Const
 -                                          // + ty: fn() -> std::vec::Vec<u32> {std::vec::Vec::<u32>::new}
 -                                          // + val: Value(Scalar(<ZST>))
@@ -39,7 +39,7 @@
 +                                          // + span: $SRC_DIR/liballoc/vec.rs:LL:COL
 +                                          // + user_ty: UserType(0)
 +                                          // + literal: Const { ty: alloc::raw_vec::RawVec<u32>, val: Value(ByRef { alloc: Allocation { bytes: [4, 0, 0, 0, 0, 0, 0, 0], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [255], len: Size { raw: 8 } }, size: Size { raw: 8 }, align: Align { pow2: 2 }, mutability: Not, extra: () }, offset: Size { raw: 0 } }) }
-+         ((*_4).1: usize) = const 0usize; // scope 2 at $SRC_DIR/liballoc/vec.rs:LL:COL
++         ((*_4).1: usize) = const 0_usize; // scope 2 at $SRC_DIR/liballoc/vec.rs:LL:COL
 +                                          // ty::Const
 +                                          // + ty: usize
 +                                          // + val: Value(Scalar(0x00000000))

--- a/src/test/mir-opt/inline/inline-into-box-place/64bit/rustc.main.Inline.diff
+++ b/src/test/mir-opt/inline/inline-into-box-place/64bit/rustc.main.Inline.diff
@@ -19,7 +19,7 @@
           _2 = Box(std::vec::Vec<u32>);    // scope 0 at $DIR/inline-into-box-place.rs:8:29: 8:43
 -         (*_2) = const std::vec::Vec::<u32>::new() -> [return: bb2, unwind: bb4]; // scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
 +         _4 = &mut (*_2);                 // scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
-+         ((*_4).0: alloc::raw_vec::RawVec<u32>) = const alloc::raw_vec::RawVec::<u32> { ptr: std::ptr::Unique::<u32> { pointer: {0x4 as *const u32}, _marker: std::marker::PhantomData::<u32> }, cap: 0usize, alloc: std::alloc::Global }; // scope 2 at $SRC_DIR/liballoc/vec.rs:LL:COL
++         ((*_4).0: alloc::raw_vec::RawVec<u32>) = const alloc::raw_vec::RawVec::<u32> { ptr: std::ptr::Unique::<u32> { pointer: {0x4 as *const u32}, _marker: std::marker::PhantomData::<u32> }, cap: 0_usize, alloc: std::alloc::Global }; // scope 2 at $SRC_DIR/liballoc/vec.rs:LL:COL
                                            // ty::Const
 -                                          // + ty: fn() -> std::vec::Vec<u32> {std::vec::Vec::<u32>::new}
 -                                          // + val: Value(Scalar(<ZST>))
@@ -39,7 +39,7 @@
 +                                          // + span: $SRC_DIR/liballoc/vec.rs:LL:COL
 +                                          // + user_ty: UserType(0)
 +                                          // + literal: Const { ty: alloc::raw_vec::RawVec<u32>, val: Value(ByRef { alloc: Allocation { bytes: [4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [65535], len: Size { raw: 16 } }, size: Size { raw: 16 }, align: Align { pow2: 3 }, mutability: Not, extra: () }, offset: Size { raw: 0 } }) }
-+         ((*_4).1: usize) = const 0usize; // scope 2 at $SRC_DIR/liballoc/vec.rs:LL:COL
++         ((*_4).1: usize) = const 0_usize; // scope 2 at $SRC_DIR/liballoc/vec.rs:LL:COL
 +                                          // ty::Const
 +                                          // + ty: usize
 +                                          // + val: Value(Scalar(0x0000000000000000))

--- a/src/test/mir-opt/inline/inline-specialization/rustc.main.Inline.diff
+++ b/src/test/mir-opt/inline/inline-specialization/rustc.main.Inline.diff
@@ -13,7 +13,7 @@
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/inline-specialization.rs:5:9: 5:10
 -         _1 = const <std::vec::Vec<()> as Foo>::bar() -> bb1; // scope 0 at $DIR/inline-specialization.rs:5:13: 5:38
-+         _1 = const 123u32;               // scope 2 at $DIR/inline-specialization.rs:14:31: 14:34
++         _1 = const 123_u32;              // scope 2 at $DIR/inline-specialization.rs:14:31: 14:34
                                            // ty::Const
 -                                          // + ty: fn() -> u32 {<std::vec::Vec<()> as Foo>::bar}
 -                                          // + val: Value(Scalar(<ZST>))

--- a/src/test/mir-opt/instrument_coverage/rustc.bar.InstrumentCoverage.diff
+++ b/src/test/mir-opt/instrument_coverage/rustc.bar.InstrumentCoverage.diff
@@ -7,7 +7,7 @@
   
       bb0: {
 +         StorageLive(_1);                 // scope 0 at $DIR/instrument_coverage.rs:18:1: 20:2
-+         _1 = const std::intrinsics::count_code_region(const 0u32) -> bb2; // scope 0 at $DIR/instrument_coverage.rs:18:1: 20:2
++         _1 = const std::intrinsics::count_code_region(const 0_u32) -> bb2; // scope 0 at $DIR/instrument_coverage.rs:18:1: 20:2
 +                                          // ty::Const
 +                                          // + ty: unsafe extern "rust-intrinsic" fn(u32) {std::intrinsics::count_code_region}
 +                                          // + val: Value(Scalar(<ZST>))

--- a/src/test/mir-opt/instrument_coverage/rustc.main.InstrumentCoverage.diff
+++ b/src/test/mir-opt/instrument_coverage/rustc.main.InstrumentCoverage.diff
@@ -11,7 +11,7 @@
       bb0: {
 -         falseUnwind -> [real: bb1, cleanup: bb2]; // scope 0 at $DIR/instrument_coverage.rs:10:5: 14:6
 +         StorageLive(_4);                 // scope 0 at $DIR/instrument_coverage.rs:9:1: 15:2
-+         _4 = const std::intrinsics::count_code_region(const 0u32) -> bb7; // scope 0 at $DIR/instrument_coverage.rs:9:1: 15:2
++         _4 = const std::intrinsics::count_code_region(const 0_u32) -> bb7; // scope 0 at $DIR/instrument_coverage.rs:9:1: 15:2
 +                                          // ty::Const
 +                                          // + ty: unsafe extern "rust-intrinsic" fn(u32) {std::intrinsics::count_code_region}
 +                                          // + val: Value(Scalar(<ZST>))

--- a/src/test/mir-opt/issue-41697/32bit/rustc.{{impl}}-{{constant}}.SimplifyCfg-qualify-consts.after.mir
+++ b/src/test/mir-opt/issue-41697/32bit/rustc.{{impl}}-{{constant}}.SimplifyCfg-qualify-consts.after.mir
@@ -5,7 +5,7 @@
     let mut _1: (usize, bool);           // in scope 0 at $DIR/issue-41697.rs:18:19: 18:22
 
     bb0: {
-        _1 = CheckedAdd(const 1usize, const 1usize); // scope 0 at $DIR/issue-41697.rs:18:19: 18:22
+        _1 = CheckedAdd(const 1_usize, const 1_usize); // scope 0 at $DIR/issue-41697.rs:18:19: 18:22
                                          // ty::Const
                                          // + ty: usize
                                          // + val: Value(Scalar(0x00000001))
@@ -18,7 +18,19 @@
                                          // mir::Constant
                                          // + span: $DIR/issue-41697.rs:18:21: 18:22
                                          // + literal: Const { ty: usize, val: Value(Scalar(0x00000001)) }
-        assert(!move (_1.1: bool), "attempt to add with overflow") -> [success: bb2, unwind: bb1]; // scope 0 at $DIR/issue-41697.rs:18:19: 18:22
+        assert(!move (_1.1: bool), "attempt to compute `{} + {}` which would overflow", const 1_usize, const 1_usize) -> [success: bb2, unwind: bb1]; // scope 0 at $DIR/issue-41697.rs:18:19: 18:22
+                                         // ty::Const
+                                         // + ty: usize
+                                         // + val: Value(Scalar(0x00000001))
+                                         // mir::Constant
+                                         // + span: $DIR/issue-41697.rs:18:19: 18:20
+                                         // + literal: Const { ty: usize, val: Value(Scalar(0x00000001)) }
+                                         // ty::Const
+                                         // + ty: usize
+                                         // + val: Value(Scalar(0x00000001))
+                                         // mir::Constant
+                                         // + span: $DIR/issue-41697.rs:18:21: 18:22
+                                         // + literal: Const { ty: usize, val: Value(Scalar(0x00000001)) }
     }
 
     bb1 (cleanup): {

--- a/src/test/mir-opt/issue-41697/64bit/rustc.{{impl}}-{{constant}}.SimplifyCfg-qualify-consts.after.mir
+++ b/src/test/mir-opt/issue-41697/64bit/rustc.{{impl}}-{{constant}}.SimplifyCfg-qualify-consts.after.mir
@@ -5,7 +5,7 @@
     let mut _1: (usize, bool);           // in scope 0 at $DIR/issue-41697.rs:18:19: 18:22
 
     bb0: {
-        _1 = CheckedAdd(const 1usize, const 1usize); // scope 0 at $DIR/issue-41697.rs:18:19: 18:22
+        _1 = CheckedAdd(const 1_usize, const 1_usize); // scope 0 at $DIR/issue-41697.rs:18:19: 18:22
                                          // ty::Const
                                          // + ty: usize
                                          // + val: Value(Scalar(0x0000000000000001))
@@ -18,7 +18,19 @@
                                          // mir::Constant
                                          // + span: $DIR/issue-41697.rs:18:21: 18:22
                                          // + literal: Const { ty: usize, val: Value(Scalar(0x0000000000000001)) }
-        assert(!move (_1.1: bool), "attempt to add with overflow") -> [success: bb2, unwind: bb1]; // scope 0 at $DIR/issue-41697.rs:18:19: 18:22
+        assert(!move (_1.1: bool), "attempt to compute `{} + {}` which would overflow", const 1_usize, const 1_usize) -> [success: bb2, unwind: bb1]; // scope 0 at $DIR/issue-41697.rs:18:19: 18:22
+                                         // ty::Const
+                                         // + ty: usize
+                                         // + val: Value(Scalar(0x0000000000000001))
+                                         // mir::Constant
+                                         // + span: $DIR/issue-41697.rs:18:19: 18:20
+                                         // + literal: Const { ty: usize, val: Value(Scalar(0x0000000000000001)) }
+                                         // ty::Const
+                                         // + ty: usize
+                                         // + val: Value(Scalar(0x0000000000000001))
+                                         // mir::Constant
+                                         // + span: $DIR/issue-41697.rs:18:21: 18:22
+                                         // + literal: Const { ty: usize, val: Value(Scalar(0x0000000000000001)) }
     }
 
     bb1 (cleanup): {

--- a/src/test/mir-opt/issue-41888/rustc.main.ElaborateDrops.after.mir
+++ b/src/test/mir-opt/issue-41888/rustc.main.ElaborateDrops.after.mir
@@ -96,7 +96,7 @@ fn main() -> () {
     bb8: {
         StorageDead(_3);                 // scope 1 at $DIR/issue-41888.rs:9:19: 9:20
         _5 = discriminant(_1);           // scope 1 at $DIR/issue-41888.rs:10:16: 10:24
-        switchInt(move _5) -> [0isize: bb10, otherwise: bb9]; // scope 1 at $DIR/issue-41888.rs:10:16: 10:24
+        switchInt(move _5) -> [0_isize: bb10, otherwise: bb9]; // scope 1 at $DIR/issue-41888.rs:10:16: 10:24
     }
 
     bb9: {
@@ -250,7 +250,7 @@ fn main() -> () {
 
     bb20: {
         _10 = discriminant(_1);          // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
-        switchInt(move _10) -> [0isize: bb15, otherwise: bb18]; // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
+        switchInt(move _10) -> [0_isize: bb15, otherwise: bb18]; // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
     }
 
     bb21: {
@@ -259,7 +259,7 @@ fn main() -> () {
 
     bb22 (cleanup): {
         _11 = discriminant(_1);          // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
-        switchInt(move _11) -> [0isize: bb17, otherwise: bb19]; // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
+        switchInt(move _11) -> [0_isize: bb17, otherwise: bb19]; // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
     }
 
     bb23 (cleanup): {

--- a/src/test/mir-opt/issue-49232/rustc.main.mir_map.0.mir
+++ b/src/test/mir-opt/issue-49232/rustc.main.mir_map.0.mir
@@ -58,7 +58,7 @@ fn main() -> () {
     }
 
     bb7: {
-        _2 = const 4i32;                 // scope 0 at $DIR/issue-49232.rs:9:26: 9:27
+        _2 = const 4_i32;                // scope 0 at $DIR/issue-49232.rs:9:26: 9:27
                                          // ty::Const
                                          // + ty: i32
                                          // + val: Value(Scalar(0x00000004))

--- a/src/test/mir-opt/issue-62289/rustc.test.ElaborateDrops.before.mir
+++ b/src/test/mir-opt/issue-62289/rustc.test.ElaborateDrops.before.mir
@@ -46,7 +46,7 @@ fn test() -> std::option::Option<std::boxed::Box<u32>> {
     bb2: {
         StorageDead(_4);                 // scope 0 at $DIR/issue-62289.rs:9:19: 9:20
         _5 = discriminant(_3);           // scope 0 at $DIR/issue-62289.rs:9:19: 9:20
-        switchInt(move _5) -> [0isize: bb4, 1isize: bb6, otherwise: bb5]; // scope 0 at $DIR/issue-62289.rs:9:19: 9:20
+        switchInt(move _5) -> [0_isize: bb4, 1_isize: bb6, otherwise: bb5]; // scope 0 at $DIR/issue-62289.rs:9:19: 9:20
     }
 
     bb3 (cleanup): {

--- a/src/test/mir-opt/issue-72181/32bit/rustc.foo.mir_map.0.mir
+++ b/src/test/mir-opt/issue-72181/32bit/rustc.foo.mir_map.0.mir
@@ -9,7 +9,7 @@ fn foo(_1: [(Never, u32); 1]) -> u32 {
 
     bb0: {
         StorageLive(_2);                 // scope 0 at $DIR/issue-72181.rs:16:43: 16:44
-        _2 = const 0usize;               // scope 0 at $DIR/issue-72181.rs:16:43: 16:44
+        _2 = const 0_usize;              // scope 0 at $DIR/issue-72181.rs:16:43: 16:44
                                          // ty::Const
                                          // + ty: usize
                                          // + val: Value(Scalar(0x00000000))

--- a/src/test/mir-opt/issue-72181/32bit/rustc.main.mir_map.0.mir
+++ b/src/test/mir-opt/issue-72181/32bit/rustc.main.mir_map.0.mir
@@ -39,7 +39,7 @@ fn main() -> () {
         StorageDead(_1);                 // scope 0 at $DIR/issue-72181.rs:24:34: 24:35
         StorageLive(_2);                 // scope 1 at $DIR/issue-72181.rs:26:9: 26:10
         StorageLive(_3);                 // scope 1 at $DIR/issue-72181.rs:26:14: 26:27
-        _3 = Foo { a: const 42u64 };     // scope 1 at $DIR/issue-72181.rs:26:14: 26:27
+        _3 = Foo { a: const 42_u64 };    // scope 1 at $DIR/issue-72181.rs:26:14: 26:27
                                          // ty::Const
                                          // + ty: u64
                                          // + val: Value(Scalar(0x000000000000002a))
@@ -47,7 +47,7 @@ fn main() -> () {
                                          // + span: $DIR/issue-72181.rs:26:23: 26:25
                                          // + literal: Const { ty: u64, val: Value(Scalar(0x000000000000002a)) }
         StorageLive(_4);                 // scope 1 at $DIR/issue-72181.rs:26:29: 26:42
-        _4 = Foo { a: const 10u64 };     // scope 1 at $DIR/issue-72181.rs:26:29: 26:42
+        _4 = Foo { a: const 10_u64 };    // scope 1 at $DIR/issue-72181.rs:26:29: 26:42
                                          // ty::Const
                                          // + ty: u64
                                          // + val: Value(Scalar(0x000000000000000a))
@@ -60,7 +60,7 @@ fn main() -> () {
         FakeRead(ForLet, _2);            // scope 1 at $DIR/issue-72181.rs:26:9: 26:10
         StorageLive(_5);                 // scope 2 at $DIR/issue-72181.rs:27:13: 27:30
         StorageLive(_6);                 // scope 4 at $DIR/issue-72181.rs:27:24: 27:25
-        _6 = const 0usize;               // scope 4 at $DIR/issue-72181.rs:27:24: 27:25
+        _6 = const 0_usize;              // scope 4 at $DIR/issue-72181.rs:27:24: 27:25
                                          // ty::Const
                                          // + ty: usize
                                          // + val: Value(Scalar(0x00000000))

--- a/src/test/mir-opt/issue-72181/64bit/rustc.foo.mir_map.0.mir
+++ b/src/test/mir-opt/issue-72181/64bit/rustc.foo.mir_map.0.mir
@@ -9,7 +9,7 @@ fn foo(_1: [(Never, u32); 1]) -> u32 {
 
     bb0: {
         StorageLive(_2);                 // scope 0 at $DIR/issue-72181.rs:16:43: 16:44
-        _2 = const 0usize;               // scope 0 at $DIR/issue-72181.rs:16:43: 16:44
+        _2 = const 0_usize;              // scope 0 at $DIR/issue-72181.rs:16:43: 16:44
                                          // ty::Const
                                          // + ty: usize
                                          // + val: Value(Scalar(0x0000000000000000))

--- a/src/test/mir-opt/issue-72181/64bit/rustc.main.mir_map.0.mir
+++ b/src/test/mir-opt/issue-72181/64bit/rustc.main.mir_map.0.mir
@@ -39,7 +39,7 @@ fn main() -> () {
         StorageDead(_1);                 // scope 0 at $DIR/issue-72181.rs:24:34: 24:35
         StorageLive(_2);                 // scope 1 at $DIR/issue-72181.rs:26:9: 26:10
         StorageLive(_3);                 // scope 1 at $DIR/issue-72181.rs:26:14: 26:27
-        _3 = Foo { a: const 42u64 };     // scope 1 at $DIR/issue-72181.rs:26:14: 26:27
+        _3 = Foo { a: const 42_u64 };    // scope 1 at $DIR/issue-72181.rs:26:14: 26:27
                                          // ty::Const
                                          // + ty: u64
                                          // + val: Value(Scalar(0x000000000000002a))
@@ -47,7 +47,7 @@ fn main() -> () {
                                          // + span: $DIR/issue-72181.rs:26:23: 26:25
                                          // + literal: Const { ty: u64, val: Value(Scalar(0x000000000000002a)) }
         StorageLive(_4);                 // scope 1 at $DIR/issue-72181.rs:26:29: 26:42
-        _4 = Foo { a: const 10u64 };     // scope 1 at $DIR/issue-72181.rs:26:29: 26:42
+        _4 = Foo { a: const 10_u64 };    // scope 1 at $DIR/issue-72181.rs:26:29: 26:42
                                          // ty::Const
                                          // + ty: u64
                                          // + val: Value(Scalar(0x000000000000000a))
@@ -60,7 +60,7 @@ fn main() -> () {
         FakeRead(ForLet, _2);            // scope 1 at $DIR/issue-72181.rs:26:9: 26:10
         StorageLive(_5);                 // scope 2 at $DIR/issue-72181.rs:27:13: 27:30
         StorageLive(_6);                 // scope 4 at $DIR/issue-72181.rs:27:24: 27:25
-        _6 = const 0usize;               // scope 4 at $DIR/issue-72181.rs:27:24: 27:25
+        _6 = const 0_usize;              // scope 4 at $DIR/issue-72181.rs:27:24: 27:25
                                          // ty::Const
                                          // + ty: usize
                                          // + val: Value(Scalar(0x0000000000000000))

--- a/src/test/mir-opt/loop_test/rustc.main.SimplifyCfg-qualify-consts.after.mir
+++ b/src/test/mir-opt/loop_test/rustc.main.SimplifyCfg-qualify-consts.after.mir
@@ -67,7 +67,7 @@ fn main() -> () {
 
     bb6: {
         StorageLive(_6);                 // scope 0 at $DIR/loop_test.rs:14:13: 14:14
-        _6 = const 1i32;                 // scope 0 at $DIR/loop_test.rs:14:17: 14:18
+        _6 = const 1_i32;                // scope 0 at $DIR/loop_test.rs:14:17: 14:18
                                          // ty::Const
                                          // + ty: i32
                                          // + val: Value(Scalar(0x00000001))

--- a/src/test/mir-opt/match-arm-scopes/rustc.complicated_match.ElaborateDrops.after.mir
+++ b/src/test/mir-opt/match-arm-scopes/rustc.complicated_match.ElaborateDrops.after.mir
@@ -54,7 +54,7 @@ fn complicated_match(_1: bool, _2: (bool, bool, std::string::String)) -> i32 {
     }
 
     bb5: {
-        _0 = const 1i32;                 // scope 1 at $DIR/match-arm-scopes.rs:16:77: 16:78
+        _0 = const 1_i32;                // scope 1 at $DIR/match-arm-scopes.rs:16:77: 16:78
                                          // ty::Const
                                          // + ty: i32
                                          // + val: Value(Scalar(0x00000001))
@@ -82,7 +82,7 @@ fn complicated_match(_1: bool, _2: (bool, bool, std::string::String)) -> i32 {
     }
 
     bb8: {
-        _0 = const 3i32;                 // scope 0 at $DIR/match-arm-scopes.rs:16:59: 16:60
+        _0 = const 3_i32;                // scope 0 at $DIR/match-arm-scopes.rs:16:59: 16:60
                                          // ty::Const
                                          // + ty: i32
                                          // + val: Value(Scalar(0x00000003))
@@ -142,7 +142,7 @@ fn complicated_match(_1: bool, _2: (bool, bool, std::string::String)) -> i32 {
     }
 
     bb16: {
-        _0 = const 3i32;                 // scope 0 at $DIR/match-arm-scopes.rs:16:59: 16:60
+        _0 = const 3_i32;                // scope 0 at $DIR/match-arm-scopes.rs:16:59: 16:60
                                          // ty::Const
                                          // + ty: i32
                                          // + val: Value(Scalar(0x00000003))
@@ -181,7 +181,7 @@ fn complicated_match(_1: bool, _2: (bool, bool, std::string::String)) -> i32 {
     }
 
     bb20: {
-        _0 = const 2i32;                 // scope 2 at $DIR/match-arm-scopes.rs:17:41: 17:42
+        _0 = const 2_i32;                // scope 2 at $DIR/match-arm-scopes.rs:17:41: 17:42
                                          // ty::Const
                                          // + ty: i32
                                          // + val: Value(Scalar(0x00000002))

--- a/src/test/mir-opt/match-arm-scopes/rustc.complicated_match.SimplifyCfg-initial.after.mir
+++ b/src/test/mir-opt/match-arm-scopes/rustc.complicated_match.SimplifyCfg-initial.after.mir
@@ -67,7 +67,7 @@ fn complicated_match(_1: bool, _2: (bool, bool, std::string::String)) -> i32 {
     }
 
     bb8: {
-        _0 = const 1i32;                 // scope 1 at $DIR/match-arm-scopes.rs:16:77: 16:78
+        _0 = const 1_i32;                // scope 1 at $DIR/match-arm-scopes.rs:16:77: 16:78
                                          // ty::Const
                                          // + ty: i32
                                          // + val: Value(Scalar(0x00000001))
@@ -102,7 +102,7 @@ fn complicated_match(_1: bool, _2: (bool, bool, std::string::String)) -> i32 {
     }
 
     bb12: {
-        _0 = const 3i32;                 // scope 0 at $DIR/match-arm-scopes.rs:16:59: 16:60
+        _0 = const 3_i32;                // scope 0 at $DIR/match-arm-scopes.rs:16:59: 16:60
                                          // ty::Const
                                          // + ty: i32
                                          // + val: Value(Scalar(0x00000003))
@@ -173,7 +173,7 @@ fn complicated_match(_1: bool, _2: (bool, bool, std::string::String)) -> i32 {
     }
 
     bb21: {
-        _0 = const 3i32;                 // scope 0 at $DIR/match-arm-scopes.rs:16:59: 16:60
+        _0 = const 3_i32;                // scope 0 at $DIR/match-arm-scopes.rs:16:59: 16:60
                                          // ty::Const
                                          // + ty: i32
                                          // + val: Value(Scalar(0x00000003))
@@ -216,7 +216,7 @@ fn complicated_match(_1: bool, _2: (bool, bool, std::string::String)) -> i32 {
     }
 
     bb25: {
-        _0 = const 2i32;                 // scope 2 at $DIR/match-arm-scopes.rs:17:41: 17:42
+        _0 = const 2_i32;                // scope 2 at $DIR/match-arm-scopes.rs:17:41: 17:42
                                          // ty::Const
                                          // + ty: i32
                                          // + val: Value(Scalar(0x00000002))

--- a/src/test/mir-opt/match_false_edges/rustc.full_tested_match.PromoteTemps.after.mir
+++ b/src/test/mir-opt/match_false_edges/rustc.full_tested_match.PromoteTemps.after.mir
@@ -26,7 +26,7 @@ fn full_tested_match() -> () {
     bb0: {
         StorageLive(_1);                 // scope 0 at $DIR/match_false_edges.rs:15:13: 19:6
         StorageLive(_2);                 // scope 0 at $DIR/match_false_edges.rs:15:19: 15:27
-        _2 = std::option::Option::<i32>::Some(const 42i32); // scope 0 at $DIR/match_false_edges.rs:15:19: 15:27
+        _2 = std::option::Option::<i32>::Some(const 42_i32); // scope 0 at $DIR/match_false_edges.rs:15:19: 15:27
                                          // ty::Const
                                          // + ty: i32
                                          // + val: Value(Scalar(0x0000002a))
@@ -35,7 +35,7 @@ fn full_tested_match() -> () {
                                          // + literal: Const { ty: i32, val: Value(Scalar(0x0000002a)) }
         FakeRead(ForMatchedPlace, _2);   // scope 0 at $DIR/match_false_edges.rs:15:19: 15:27
         _3 = discriminant(_2);           // scope 0 at $DIR/match_false_edges.rs:16:9: 16:16
-        switchInt(move _3) -> [0isize: bb2, 1isize: bb3, otherwise: bb5]; // scope 0 at $DIR/match_false_edges.rs:16:9: 16:16
+        switchInt(move _3) -> [0_isize: bb2, 1_isize: bb3, otherwise: bb5]; // scope 0 at $DIR/match_false_edges.rs:16:9: 16:16
     }
 
     bb1 (cleanup): {
@@ -43,7 +43,7 @@ fn full_tested_match() -> () {
     }
 
     bb2: {
-        _1 = (const 3i32, const 3i32);   // scope 0 at $DIR/match_false_edges.rs:18:17: 18:23
+        _1 = (const 3_i32, const 3_i32); // scope 0 at $DIR/match_false_edges.rs:18:17: 18:23
                                          // ty::Const
                                          // + ty: i32
                                          // + val: Value(Scalar(0x00000003))
@@ -104,7 +104,7 @@ fn full_tested_match() -> () {
         _5 = ((_2 as Some).0: i32);      // scope 0 at $DIR/match_false_edges.rs:16:14: 16:15
         StorageLive(_8);                 // scope 2 at $DIR/match_false_edges.rs:16:35: 16:36
         _8 = _5;                         // scope 2 at $DIR/match_false_edges.rs:16:35: 16:36
-        _1 = (const 1i32, move _8);      // scope 2 at $DIR/match_false_edges.rs:16:31: 16:37
+        _1 = (const 1_i32, move _8);     // scope 2 at $DIR/match_false_edges.rs:16:31: 16:37
                                          // ty::Const
                                          // + ty: i32
                                          // + val: Value(Scalar(0x00000001))
@@ -128,7 +128,7 @@ fn full_tested_match() -> () {
         _9 = ((_2 as Some).0: i32);      // scope 0 at $DIR/match_false_edges.rs:17:14: 17:15
         StorageLive(_10);                // scope 3 at $DIR/match_false_edges.rs:17:24: 17:25
         _10 = _9;                        // scope 3 at $DIR/match_false_edges.rs:17:24: 17:25
-        _1 = (const 2i32, move _10);     // scope 3 at $DIR/match_false_edges.rs:17:20: 17:26
+        _1 = (const 2_i32, move _10);    // scope 3 at $DIR/match_false_edges.rs:17:20: 17:26
                                          // ty::Const
                                          // + ty: i32
                                          // + val: Value(Scalar(0x00000002))

--- a/src/test/mir-opt/match_false_edges/rustc.full_tested_match2.PromoteTemps.before.mir
+++ b/src/test/mir-opt/match_false_edges/rustc.full_tested_match2.PromoteTemps.before.mir
@@ -25,7 +25,7 @@ fn full_tested_match2() -> () {
     bb0: {
         StorageLive(_1);                 // scope 0 at $DIR/match_false_edges.rs:26:13: 30:6
         StorageLive(_2);                 // scope 0 at $DIR/match_false_edges.rs:26:19: 26:27
-        _2 = std::option::Option::<i32>::Some(const 42i32); // scope 0 at $DIR/match_false_edges.rs:26:19: 26:27
+        _2 = std::option::Option::<i32>::Some(const 42_i32); // scope 0 at $DIR/match_false_edges.rs:26:19: 26:27
                                          // ty::Const
                                          // + ty: i32
                                          // + val: Value(Scalar(0x0000002a))
@@ -34,7 +34,7 @@ fn full_tested_match2() -> () {
                                          // + literal: Const { ty: i32, val: Value(Scalar(0x0000002a)) }
         FakeRead(ForMatchedPlace, _2);   // scope 0 at $DIR/match_false_edges.rs:26:19: 26:27
         _3 = discriminant(_2);           // scope 0 at $DIR/match_false_edges.rs:27:9: 27:16
-        switchInt(move _3) -> [0isize: bb2, 1isize: bb3, otherwise: bb5]; // scope 0 at $DIR/match_false_edges.rs:27:9: 27:16
+        switchInt(move _3) -> [0_isize: bb2, 1_isize: bb3, otherwise: bb5]; // scope 0 at $DIR/match_false_edges.rs:27:9: 27:16
     }
 
     bb1 (cleanup): {
@@ -54,7 +54,7 @@ fn full_tested_match2() -> () {
         _9 = ((_2 as Some).0: i32);      // scope 0 at $DIR/match_false_edges.rs:29:14: 29:15
         StorageLive(_10);                // scope 3 at $DIR/match_false_edges.rs:29:24: 29:25
         _10 = _9;                        // scope 3 at $DIR/match_false_edges.rs:29:24: 29:25
-        _1 = (const 2i32, move _10);     // scope 3 at $DIR/match_false_edges.rs:29:20: 29:26
+        _1 = (const 2_i32, move _10);    // scope 3 at $DIR/match_false_edges.rs:29:20: 29:26
                                          // ty::Const
                                          // + ty: i32
                                          // + val: Value(Scalar(0x00000002))
@@ -96,7 +96,7 @@ fn full_tested_match2() -> () {
         _5 = ((_2 as Some).0: i32);      // scope 0 at $DIR/match_false_edges.rs:27:14: 27:15
         StorageLive(_8);                 // scope 2 at $DIR/match_false_edges.rs:27:35: 27:36
         _8 = _5;                         // scope 2 at $DIR/match_false_edges.rs:27:35: 27:36
-        _1 = (const 1i32, move _8);      // scope 2 at $DIR/match_false_edges.rs:27:31: 27:37
+        _1 = (const 1_i32, move _8);     // scope 2 at $DIR/match_false_edges.rs:27:31: 27:37
                                          // ty::Const
                                          // + ty: i32
                                          // + val: Value(Scalar(0x00000001))
@@ -116,7 +116,7 @@ fn full_tested_match2() -> () {
     }
 
     bb10: {
-        _1 = (const 3i32, const 3i32);   // scope 0 at $DIR/match_false_edges.rs:28:17: 28:23
+        _1 = (const 3_i32, const 3_i32); // scope 0 at $DIR/match_false_edges.rs:28:17: 28:23
                                          // ty::Const
                                          // + ty: i32
                                          // + val: Value(Scalar(0x00000003))

--- a/src/test/mir-opt/match_false_edges/rustc.main.PromoteTemps.before.mir
+++ b/src/test/mir-opt/match_false_edges/rustc.main.PromoteTemps.before.mir
@@ -36,7 +36,7 @@ fn main() -> () {
     bb0: {
         StorageLive(_1);                 // scope 0 at $DIR/match_false_edges.rs:35:13: 40:6
         StorageLive(_2);                 // scope 0 at $DIR/match_false_edges.rs:35:19: 35:26
-        _2 = std::option::Option::<i32>::Some(const 1i32); // scope 0 at $DIR/match_false_edges.rs:35:19: 35:26
+        _2 = std::option::Option::<i32>::Some(const 1_i32); // scope 0 at $DIR/match_false_edges.rs:35:19: 35:26
                                          // ty::Const
                                          // + ty: i32
                                          // + val: Value(Scalar(0x00000001))
@@ -45,7 +45,7 @@ fn main() -> () {
                                          // + literal: Const { ty: i32, val: Value(Scalar(0x00000001)) }
         FakeRead(ForMatchedPlace, _2);   // scope 0 at $DIR/match_false_edges.rs:35:19: 35:26
         _4 = discriminant(_2);           // scope 0 at $DIR/match_false_edges.rs:36:9: 36:17
-        switchInt(move _4) -> [1isize: bb3, otherwise: bb2]; // scope 0 at $DIR/match_false_edges.rs:36:9: 36:17
+        switchInt(move _4) -> [1_isize: bb3, otherwise: bb2]; // scope 0 at $DIR/match_false_edges.rs:36:9: 36:17
     }
 
     bb1 (cleanup): {
@@ -63,7 +63,7 @@ fn main() -> () {
     bb4: {
         StorageLive(_14);                // scope 0 at $DIR/match_false_edges.rs:39:9: 39:11
         _14 = _2;                        // scope 0 at $DIR/match_false_edges.rs:39:9: 39:11
-        _1 = const 4i32;                 // scope 5 at $DIR/match_false_edges.rs:39:15: 39:16
+        _1 = const 4_i32;                // scope 5 at $DIR/match_false_edges.rs:39:15: 39:16
                                          // ty::Const
                                          // + ty: i32
                                          // + val: Value(Scalar(0x00000004))
@@ -102,7 +102,7 @@ fn main() -> () {
         FakeRead(ForGuardBinding, _7);   // scope 0 at $DIR/match_false_edges.rs:36:27: 36:28
         StorageLive(_6);                 // scope 0 at $DIR/match_false_edges.rs:36:14: 36:16
         _6 = ((_2 as Some).0: i32);      // scope 0 at $DIR/match_false_edges.rs:36:14: 36:16
-        _1 = const 1i32;                 // scope 2 at $DIR/match_false_edges.rs:36:32: 36:33
+        _1 = const 1_i32;                // scope 2 at $DIR/match_false_edges.rs:36:32: 36:33
                                          // ty::Const
                                          // + ty: i32
                                          // + val: Value(Scalar(0x00000001))
@@ -123,7 +123,7 @@ fn main() -> () {
     bb10: {
         StorageLive(_9);                 // scope 0 at $DIR/match_false_edges.rs:37:9: 37:11
         _9 = _2;                         // scope 0 at $DIR/match_false_edges.rs:37:9: 37:11
-        _1 = const 2i32;                 // scope 3 at $DIR/match_false_edges.rs:37:15: 37:16
+        _1 = const 2_i32;                // scope 3 at $DIR/match_false_edges.rs:37:15: 37:16
                                          // ty::Const
                                          // + ty: i32
                                          // + val: Value(Scalar(0x00000002))
@@ -161,7 +161,7 @@ fn main() -> () {
         FakeRead(ForGuardBinding, _11);  // scope 0 at $DIR/match_false_edges.rs:38:28: 38:29
         StorageLive(_10);                // scope 0 at $DIR/match_false_edges.rs:38:14: 38:15
         _10 = ((_2 as Some).0: i32);     // scope 0 at $DIR/match_false_edges.rs:38:14: 38:15
-        _1 = const 3i32;                 // scope 4 at $DIR/match_false_edges.rs:38:33: 38:34
+        _1 = const 3_i32;                // scope 4 at $DIR/match_false_edges.rs:38:33: 38:34
                                          // ty::Const
                                          // + ty: i32
                                          // + val: Value(Scalar(0x00000003))

--- a/src/test/mir-opt/match_test/rustc.main.SimplifyCfg-initial.after.mir
+++ b/src/test/mir-opt/match_test/rustc.main.SimplifyCfg-initial.after.mir
@@ -20,7 +20,7 @@ fn main() -> () {
 
     bb0: {
         StorageLive(_1);                 // scope 0 at $DIR/match_test.rs:7:9: 7:10
-        _1 = const 3i32;                 // scope 0 at $DIR/match_test.rs:7:13: 7:14
+        _1 = const 3_i32;                // scope 0 at $DIR/match_test.rs:7:13: 7:14
                                          // ty::Const
                                          // + ty: i32
                                          // + val: Value(Scalar(0x00000003))
@@ -39,7 +39,7 @@ fn main() -> () {
         FakeRead(ForLet, _2);            // scope 1 at $DIR/match_test.rs:8:9: 8:10
         StorageLive(_3);                 // scope 2 at $DIR/match_test.rs:12:5: 17:6
         FakeRead(ForMatchedPlace, _1);   // scope 2 at $DIR/match_test.rs:12:11: 12:12
-        _6 = Le(const 0i32, _1);         // scope 2 at $DIR/match_test.rs:13:9: 13:14
+        _6 = Le(const 0_i32, _1);        // scope 2 at $DIR/match_test.rs:13:9: 13:14
                                          // ty::Const
                                          // + ty: i32
                                          // + val: Value(Scalar(0x00000000))
@@ -50,7 +50,7 @@ fn main() -> () {
     }
 
     bb1: {
-        _7 = Lt(_1, const 10i32);        // scope 2 at $DIR/match_test.rs:13:9: 13:14
+        _7 = Lt(_1, const 10_i32);       // scope 2 at $DIR/match_test.rs:13:9: 13:14
                                          // ty::Const
                                          // + ty: i32
                                          // + val: Value(Scalar(0x0000000a))
@@ -65,7 +65,7 @@ fn main() -> () {
     }
 
     bb3: {
-        _3 = const 3i32;                 // scope 2 at $DIR/match_test.rs:16:14: 16:15
+        _3 = const 3_i32;                // scope 2 at $DIR/match_test.rs:16:14: 16:15
                                          // ty::Const
                                          // + ty: i32
                                          // + val: Value(Scalar(0x00000003))
@@ -76,7 +76,7 @@ fn main() -> () {
     }
 
     bb4: {
-        _4 = Le(const 10i32, _1);        // scope 2 at $DIR/match_test.rs:14:9: 14:16
+        _4 = Le(const 10_i32, _1);       // scope 2 at $DIR/match_test.rs:14:9: 14:16
                                          // ty::Const
                                          // + ty: i32
                                          // + val: Value(Scalar(0x0000000a))
@@ -87,7 +87,7 @@ fn main() -> () {
     }
 
     bb5: {
-        _5 = Le(_1, const 20i32);        // scope 2 at $DIR/match_test.rs:14:9: 14:16
+        _5 = Le(_1, const 20_i32);       // scope 2 at $DIR/match_test.rs:14:9: 14:16
                                          // ty::Const
                                          // + ty: i32
                                          // + val: Value(Scalar(0x00000014))
@@ -102,7 +102,7 @@ fn main() -> () {
     }
 
     bb7: {
-        switchInt(_1) -> [-1i32: bb8, otherwise: bb3]; // scope 2 at $DIR/match_test.rs:15:9: 15:11
+        switchInt(_1) -> [-1_i32: bb8, otherwise: bb3]; // scope 2 at $DIR/match_test.rs:15:9: 15:11
     }
 
     bb8: {
@@ -119,7 +119,7 @@ fn main() -> () {
     bb10: {
         StorageDead(_9);                 // scope 2 at $DIR/match_test.rs:13:24: 13:25
         FakeRead(ForMatchGuard, _8);     // scope 2 at $DIR/match_test.rs:13:18: 13:19
-        _3 = const 0i32;                 // scope 2 at $DIR/match_test.rs:13:23: 13:24
+        _3 = const 0_i32;                // scope 2 at $DIR/match_test.rs:13:23: 13:24
                                          // ty::Const
                                          // + ty: i32
                                          // + val: Value(Scalar(0x00000000))
@@ -135,7 +135,7 @@ fn main() -> () {
     }
 
     bb12: {
-        _3 = const 1i32;                 // scope 2 at $DIR/match_test.rs:14:20: 14:21
+        _3 = const 1_i32;                // scope 2 at $DIR/match_test.rs:14:20: 14:21
                                          // ty::Const
                                          // + ty: i32
                                          // + val: Value(Scalar(0x00000001))
@@ -146,7 +146,7 @@ fn main() -> () {
     }
 
     bb13: {
-        _3 = const 2i32;                 // scope 2 at $DIR/match_test.rs:15:15: 15:16
+        _3 = const 2_i32;                // scope 2 at $DIR/match_test.rs:15:15: 15:16
                                          // ty::Const
                                          // + ty: i32
                                          // + val: Value(Scalar(0x00000002))

--- a/src/test/mir-opt/no-drop-for-inactive-variant/rustc.unwrap.SimplifyCfg-elaborate-drops.after.mir
+++ b/src/test/mir-opt/no-drop-for-inactive-variant/rustc.unwrap.SimplifyCfg-elaborate-drops.after.mir
@@ -14,7 +14,7 @@ fn unwrap(_1: std::option::Option<T>) -> T {
 
     bb0: {
         _2 = discriminant(_1);           // scope 0 at $DIR/no-drop-for-inactive-variant.rs:9:9: 9:16
-        switchInt(move _2) -> [0isize: bb2, 1isize: bb4, otherwise: bb3]; // scope 0 at $DIR/no-drop-for-inactive-variant.rs:9:9: 9:16
+        switchInt(move _2) -> [0_isize: bb2, 1_isize: bb4, otherwise: bb3]; // scope 0 at $DIR/no-drop-for-inactive-variant.rs:9:9: 9:16
     }
 
     bb1 (cleanup): {

--- a/src/test/mir-opt/nrvo-simple/rustc.nrvo.RenameReturnPlace.diff
+++ b/src/test/mir-opt/nrvo-simple/rustc.nrvo.RenameReturnPlace.diff
@@ -17,8 +17,8 @@
   
       bb0: {
 -         StorageLive(_2);                 // scope 0 at $DIR/nrvo-simple.rs:3:9: 3:16
--         _2 = [const 0u8; 1024];          // scope 0 at $DIR/nrvo-simple.rs:3:19: 3:28
-+         _0 = [const 0u8; 1024];          // scope 0 at $DIR/nrvo-simple.rs:3:19: 3:28
+-         _2 = [const 0_u8; 1024];         // scope 0 at $DIR/nrvo-simple.rs:3:19: 3:28
++         _0 = [const 0_u8; 1024];         // scope 0 at $DIR/nrvo-simple.rs:3:19: 3:28
                                            // ty::Const
                                            // + ty: u8
                                            // + val: Value(Scalar(0x00))

--- a/src/test/mir-opt/packed-struct-drop-aligned/32bit/rustc.main.SimplifyCfg-elaborate-drops.after.mir
+++ b/src/test/mir-opt/packed-struct-drop-aligned/32bit/rustc.main.SimplifyCfg-elaborate-drops.after.mir
@@ -16,7 +16,7 @@ fn main() -> () {
         StorageLive(_1);                 // scope 0 at $DIR/packed-struct-drop-aligned.rs:6:9: 6:14
         StorageLive(_2);                 // scope 0 at $DIR/packed-struct-drop-aligned.rs:6:24: 6:42
         StorageLive(_3);                 // scope 0 at $DIR/packed-struct-drop-aligned.rs:6:32: 6:41
-        _3 = Droppy(const 0usize);       // scope 0 at $DIR/packed-struct-drop-aligned.rs:6:32: 6:41
+        _3 = Droppy(const 0_usize);      // scope 0 at $DIR/packed-struct-drop-aligned.rs:6:32: 6:41
                                          // ty::Const
                                          // + ty: usize
                                          // + val: Value(Scalar(0x00000000))
@@ -29,7 +29,7 @@ fn main() -> () {
         StorageDead(_2);                 // scope 0 at $DIR/packed-struct-drop-aligned.rs:6:42: 6:43
         StorageLive(_4);                 // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:11: 7:29
         StorageLive(_5);                 // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:19: 7:28
-        _5 = Droppy(const 0usize);       // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:19: 7:28
+        _5 = Droppy(const 0_usize);      // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:19: 7:28
                                          // ty::Const
                                          // + ty: usize
                                          // + val: Value(Scalar(0x00000000))

--- a/src/test/mir-opt/packed-struct-drop-aligned/64bit/rustc.main.SimplifyCfg-elaborate-drops.after.mir
+++ b/src/test/mir-opt/packed-struct-drop-aligned/64bit/rustc.main.SimplifyCfg-elaborate-drops.after.mir
@@ -16,7 +16,7 @@ fn main() -> () {
         StorageLive(_1);                 // scope 0 at $DIR/packed-struct-drop-aligned.rs:6:9: 6:14
         StorageLive(_2);                 // scope 0 at $DIR/packed-struct-drop-aligned.rs:6:24: 6:42
         StorageLive(_3);                 // scope 0 at $DIR/packed-struct-drop-aligned.rs:6:32: 6:41
-        _3 = Droppy(const 0usize);       // scope 0 at $DIR/packed-struct-drop-aligned.rs:6:32: 6:41
+        _3 = Droppy(const 0_usize);      // scope 0 at $DIR/packed-struct-drop-aligned.rs:6:32: 6:41
                                          // ty::Const
                                          // + ty: usize
                                          // + val: Value(Scalar(0x0000000000000000))
@@ -29,7 +29,7 @@ fn main() -> () {
         StorageDead(_2);                 // scope 0 at $DIR/packed-struct-drop-aligned.rs:6:42: 6:43
         StorageLive(_4);                 // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:11: 7:29
         StorageLive(_5);                 // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:19: 7:28
-        _5 = Droppy(const 0usize);       // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:19: 7:28
+        _5 = Droppy(const 0_usize);      // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:19: 7:28
                                          // ty::Const
                                          // + ty: usize
                                          // + val: Value(Scalar(0x0000000000000000))

--- a/src/test/mir-opt/remove_fake_borrows/rustc.match_guard.CleanupNonCodegenStatements.diff
+++ b/src/test/mir-opt/remove_fake_borrows/rustc.match_guard.CleanupNonCodegenStatements.diff
@@ -16,11 +16,11 @@
 -         FakeRead(ForMatchedPlace, _1);   // scope 0 at $DIR/remove_fake_borrows.rs:7:11: 7:12
 +         nop;                             // scope 0 at $DIR/remove_fake_borrows.rs:7:11: 7:12
           _3 = discriminant(_1);           // scope 0 at $DIR/remove_fake_borrows.rs:8:9: 8:16
-          switchInt(move _3) -> [1isize: bb2, otherwise: bb1]; // scope 0 at $DIR/remove_fake_borrows.rs:8:9: 8:16
+          switchInt(move _3) -> [1_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/remove_fake_borrows.rs:8:9: 8:16
       }
   
       bb1: {
-          _0 = const 1i32;                 // scope 0 at $DIR/remove_fake_borrows.rs:9:14: 9:15
+          _0 = const 1_i32;                // scope 0 at $DIR/remove_fake_borrows.rs:9:14: 9:15
                                            // ty::Const
                                            // + ty: i32
                                            // + val: Value(Scalar(0x00000001))
@@ -31,7 +31,7 @@
       }
   
       bb2: {
-          switchInt((*(*((_1 as Some).0: &&i32)))) -> [0i32: bb3, otherwise: bb1]; // scope 0 at $DIR/remove_fake_borrows.rs:8:14: 8:15
+          switchInt((*(*((_1 as Some).0: &&i32)))) -> [0_i32: bb3, otherwise: bb1]; // scope 0 at $DIR/remove_fake_borrows.rs:8:14: 8:15
       }
   
       bb3: {
@@ -62,7 +62,7 @@
 +         nop;                             // scope 0 at $DIR/remove_fake_borrows.rs:8:20: 8:21
 +         nop;                             // scope 0 at $DIR/remove_fake_borrows.rs:8:20: 8:21
 +         nop;                             // scope 0 at $DIR/remove_fake_borrows.rs:8:20: 8:21
-          _0 = const 0i32;                 // scope 0 at $DIR/remove_fake_borrows.rs:8:25: 8:26
+          _0 = const 0_i32;                // scope 0 at $DIR/remove_fake_borrows.rs:8:25: 8:26
                                            // ty::Const
                                            // + ty: i32
                                            // + val: Value(Scalar(0x00000000))

--- a/src/test/mir-opt/retag/rustc.main.SimplifyCfg-elaborate-drops.after.mir
+++ b/src/test/mir-opt/retag/rustc.main.SimplifyCfg-elaborate-drops.after.mir
@@ -56,7 +56,7 @@ fn main() -> () {
 
     bb0: {
         StorageLive(_1);                 // scope 0 at $DIR/retag.rs:30:9: 30:14
-        _1 = const 0i32;                 // scope 0 at $DIR/retag.rs:30:17: 30:18
+        _1 = const 0_i32;                // scope 0 at $DIR/retag.rs:30:17: 30:18
                                          // ty::Const
                                          // + ty: i32
                                          // + val: Value(Scalar(0x00000000))
@@ -67,7 +67,7 @@ fn main() -> () {
         StorageLive(_3);                 // scope 1 at $DIR/retag.rs:32:13: 32:14
         StorageLive(_4);                 // scope 1 at $DIR/retag.rs:32:17: 32:24
         StorageLive(_5);                 // scope 1 at $DIR/retag.rs:32:17: 32:24
-        _5 = Test(const 0i32);           // scope 1 at $DIR/retag.rs:32:17: 32:24
+        _5 = Test(const 0_i32);          // scope 1 at $DIR/retag.rs:32:17: 32:24
                                          // ty::Const
                                          // + ty: i32
                                          // + val: Value(Scalar(0x00000000))
@@ -170,7 +170,7 @@ fn main() -> () {
         StorageLive(_19);                // scope 7 at $DIR/retag.rs:47:5: 47:24
         StorageLive(_20);                // scope 7 at $DIR/retag.rs:47:5: 47:12
         StorageLive(_21);                // scope 7 at $DIR/retag.rs:47:5: 47:12
-        _21 = Test(const 0i32);          // scope 7 at $DIR/retag.rs:47:5: 47:12
+        _21 = Test(const 0_i32);         // scope 7 at $DIR/retag.rs:47:5: 47:12
                                          // ty::Const
                                          // + ty: i32
                                          // + val: Value(Scalar(0x00000000))

--- a/src/test/mir-opt/simple-match/32bit/rustc.match_bool.mir_map.0.mir
+++ b/src/test/mir-opt/simple-match/32bit/rustc.match_bool.mir_map.0.mir
@@ -18,7 +18,7 @@ fn match_bool(_1: bool) -> usize {
     }
 
     bb3: {
-        _0 = const 20usize;              // scope 0 at $DIR/simple-match.rs:8:14: 8:16
+        _0 = const 20_usize;             // scope 0 at $DIR/simple-match.rs:8:14: 8:16
                                          // ty::Const
                                          // + ty: usize
                                          // + val: Value(Scalar(0x00000014))
@@ -29,7 +29,7 @@ fn match_bool(_1: bool) -> usize {
     }
 
     bb4: {
-        _0 = const 10usize;              // scope 0 at $DIR/simple-match.rs:7:17: 7:19
+        _0 = const 10_usize;             // scope 0 at $DIR/simple-match.rs:7:17: 7:19
                                          // ty::Const
                                          // + ty: usize
                                          // + val: Value(Scalar(0x0000000a))

--- a/src/test/mir-opt/simple-match/64bit/rustc.match_bool.mir_map.0.mir
+++ b/src/test/mir-opt/simple-match/64bit/rustc.match_bool.mir_map.0.mir
@@ -18,7 +18,7 @@ fn match_bool(_1: bool) -> usize {
     }
 
     bb3: {
-        _0 = const 20usize;              // scope 0 at $DIR/simple-match.rs:8:14: 8:16
+        _0 = const 20_usize;             // scope 0 at $DIR/simple-match.rs:8:14: 8:16
                                          // ty::Const
                                          // + ty: usize
                                          // + val: Value(Scalar(0x0000000000000014))
@@ -29,7 +29,7 @@ fn match_bool(_1: bool) -> usize {
     }
 
     bb4: {
-        _0 = const 10usize;              // scope 0 at $DIR/simple-match.rs:7:17: 7:19
+        _0 = const 10_usize;             // scope 0 at $DIR/simple-match.rs:7:17: 7:19
                                          // ty::Const
                                          // + ty: usize
                                          // + val: Value(Scalar(0x000000000000000a))

--- a/src/test/mir-opt/simplify-arm-identity/32bit/rustc.main.SimplifyArmIdentity.diff
+++ b/src/test/mir-opt/simplify-arm-identity/32bit/rustc.main.SimplifyArmIdentity.diff
@@ -19,7 +19,7 @@
   
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/simplify-arm-identity.rs:18:9: 18:10
-          ((_1 as Foo).0: u8) = const 0u8; // scope 0 at $DIR/simplify-arm-identity.rs:18:18: 18:29
+          ((_1 as Foo).0: u8) = const 0_u8; // scope 0 at $DIR/simplify-arm-identity.rs:18:18: 18:29
                                            // ty::Const
                                            // + ty: u8
                                            // + val: Value(Scalar(0x00))
@@ -28,7 +28,7 @@
                                            // + literal: Const { ty: u8, val: Value(Scalar(0x00)) }
           discriminant(_1) = 0;            // scope 0 at $DIR/simplify-arm-identity.rs:18:18: 18:29
           StorageLive(_2);                 // scope 1 at $DIR/simplify-arm-identity.rs:19:18: 22:6
-          _3 = const 0isize;               // scope 1 at $DIR/simplify-arm-identity.rs:20:9: 20:20
+          _3 = const 0_isize;              // scope 1 at $DIR/simplify-arm-identity.rs:20:9: 20:20
                                            // ty::Const
                                            // + ty: isize
                                            // + val: Value(Scalar(0x00000000))
@@ -39,7 +39,7 @@
       }
   
       bb1: {
-          _2 = const Dst::Foo(0u8);        // scope 1 at $DIR/simplify-arm-identity.rs:21:21: 21:32
+          _2 = const Dst::Foo(0_u8);       // scope 1 at $DIR/simplify-arm-identity.rs:21:21: 21:32
                                            // ty::Const
                                            // + ty: Dst
                                            // + val: Value(Scalar(0x00))

--- a/src/test/mir-opt/simplify-arm-identity/64bit/rustc.main.SimplifyArmIdentity.diff
+++ b/src/test/mir-opt/simplify-arm-identity/64bit/rustc.main.SimplifyArmIdentity.diff
@@ -19,7 +19,7 @@
   
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/simplify-arm-identity.rs:18:9: 18:10
-          ((_1 as Foo).0: u8) = const 0u8; // scope 0 at $DIR/simplify-arm-identity.rs:18:18: 18:29
+          ((_1 as Foo).0: u8) = const 0_u8; // scope 0 at $DIR/simplify-arm-identity.rs:18:18: 18:29
                                            // ty::Const
                                            // + ty: u8
                                            // + val: Value(Scalar(0x00))
@@ -28,7 +28,7 @@
                                            // + literal: Const { ty: u8, val: Value(Scalar(0x00)) }
           discriminant(_1) = 0;            // scope 0 at $DIR/simplify-arm-identity.rs:18:18: 18:29
           StorageLive(_2);                 // scope 1 at $DIR/simplify-arm-identity.rs:19:18: 22:6
-          _3 = const 0isize;               // scope 1 at $DIR/simplify-arm-identity.rs:20:9: 20:20
+          _3 = const 0_isize;              // scope 1 at $DIR/simplify-arm-identity.rs:20:9: 20:20
                                            // ty::Const
                                            // + ty: isize
                                            // + val: Value(Scalar(0x0000000000000000))
@@ -39,7 +39,7 @@
       }
   
       bb1: {
-          _2 = const Dst::Foo(0u8);        // scope 1 at $DIR/simplify-arm-identity.rs:21:21: 21:32
+          _2 = const Dst::Foo(0_u8);       // scope 1 at $DIR/simplify-arm-identity.rs:21:21: 21:32
                                            // ty::Const
                                            // + ty: Dst
                                            // + val: Value(Scalar(0x00))

--- a/src/test/mir-opt/simplify-arm/rustc.id.SimplifyArmIdentity.diff
+++ b/src/test/mir-opt/simplify-arm/rustc.id.SimplifyArmIdentity.diff
@@ -13,7 +13,7 @@
   
       bb0: {
           _2 = discriminant(_1);           // scope 0 at $DIR/simplify-arm.rs:11:9: 11:16
-          switchInt(move _2) -> [0isize: bb1, 1isize: bb3, otherwise: bb2]; // scope 0 at $DIR/simplify-arm.rs:11:9: 11:16
+          switchInt(move _2) -> [0_isize: bb1, 1_isize: bb3, otherwise: bb2]; // scope 0 at $DIR/simplify-arm.rs:11:9: 11:16
       }
   
       bb1: {

--- a/src/test/mir-opt/simplify-arm/rustc.id.SimplifyBranchSame.diff
+++ b/src/test/mir-opt/simplify-arm/rustc.id.SimplifyBranchSame.diff
@@ -13,7 +13,7 @@
   
       bb0: {
           _2 = discriminant(_1);           // scope 0 at $DIR/simplify-arm.rs:11:9: 11:16
-          switchInt(move _2) -> [0isize: bb1, 1isize: bb3, otherwise: bb2]; // scope 0 at $DIR/simplify-arm.rs:11:9: 11:16
+          switchInt(move _2) -> [0_isize: bb1, 1_isize: bb3, otherwise: bb2]; // scope 0 at $DIR/simplify-arm.rs:11:9: 11:16
       }
   
       bb1: {

--- a/src/test/mir-opt/simplify-arm/rustc.id_result.SimplifyArmIdentity.diff
+++ b/src/test/mir-opt/simplify-arm/rustc.id_result.SimplifyArmIdentity.diff
@@ -18,7 +18,7 @@
   
       bb0: {
           _2 = discriminant(_1);           // scope 0 at $DIR/simplify-arm.rs:18:9: 18:14
-          switchInt(move _2) -> [0isize: bb3, 1isize: bb1, otherwise: bb2]; // scope 0 at $DIR/simplify-arm.rs:18:9: 18:14
+          switchInt(move _2) -> [0_isize: bb3, 1_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/simplify-arm.rs:18:9: 18:14
       }
   
       bb1: {

--- a/src/test/mir-opt/simplify-arm/rustc.id_result.SimplifyBranchSame.diff
+++ b/src/test/mir-opt/simplify-arm/rustc.id_result.SimplifyBranchSame.diff
@@ -18,7 +18,7 @@
   
       bb0: {
           _2 = discriminant(_1);           // scope 0 at $DIR/simplify-arm.rs:18:9: 18:14
-          switchInt(move _2) -> [0isize: bb3, 1isize: bb1, otherwise: bb2]; // scope 0 at $DIR/simplify-arm.rs:18:9: 18:14
+          switchInt(move _2) -> [0_isize: bb3, 1_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/simplify-arm.rs:18:9: 18:14
       }
   
       bb1: {

--- a/src/test/mir-opt/simplify-arm/rustc.id_try.SimplifyArmIdentity.diff
+++ b/src/test/mir-opt/simplify-arm/rustc.id_try.SimplifyArmIdentity.diff
@@ -45,7 +45,7 @@
       bb1: {
           StorageDead(_4);                 // scope 0 at $DIR/simplify-arm.rs:24:14: 24:15
           _5 = discriminant(_3);           // scope 0 at $DIR/simplify-arm.rs:24:14: 24:15
-          switchInt(move _5) -> [0isize: bb2, 1isize: bb4, otherwise: bb3]; // scope 0 at $DIR/simplify-arm.rs:24:14: 24:15
+          switchInt(move _5) -> [0_isize: bb2, 1_isize: bb4, otherwise: bb3]; // scope 0 at $DIR/simplify-arm.rs:24:14: 24:15
       }
   
       bb2: {

--- a/src/test/mir-opt/simplify-arm/rustc.id_try.SimplifyBranchSame.diff
+++ b/src/test/mir-opt/simplify-arm/rustc.id_try.SimplifyBranchSame.diff
@@ -45,7 +45,7 @@
       bb1: {
           StorageDead(_4);                 // scope 0 at $DIR/simplify-arm.rs:24:14: 24:15
           _5 = discriminant(_3);           // scope 0 at $DIR/simplify-arm.rs:24:14: 24:15
-          switchInt(move _5) -> [0isize: bb2, 1isize: bb4, otherwise: bb3]; // scope 0 at $DIR/simplify-arm.rs:24:14: 24:15
+          switchInt(move _5) -> [0_isize: bb2, 1_isize: bb4, otherwise: bb3]; // scope 0 at $DIR/simplify-arm.rs:24:14: 24:15
       }
   
       bb2: {

--- a/src/test/mir-opt/simplify-locals-fixedpoint/rustc.foo.SimplifyLocals.diff
+++ b/src/test/mir-opt/simplify-locals-fixedpoint/rustc.foo.SimplifyLocals.diff
@@ -26,7 +26,7 @@
           StorageDead(_3);                 // scope 0 at $DIR/simplify-locals-fixedpoint.rs:4:68: 4:69
           StorageDead(_2);                 // scope 0 at $DIR/simplify-locals-fixedpoint.rs:4:68: 4:69
           _5 = discriminant((_1.0: std::option::Option<u8>)); // scope 0 at $DIR/simplify-locals-fixedpoint.rs:4:13: 4:20
-          switchInt(move _5) -> [1isize: bb2, otherwise: bb1]; // scope 0 at $DIR/simplify-locals-fixedpoint.rs:4:13: 4:20
+          switchInt(move _5) -> [1_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/simplify-locals-fixedpoint.rs:4:13: 4:20
       }
   
       bb1: {
@@ -42,7 +42,7 @@
   
       bb2: {
           _4 = discriminant((_1.1: std::option::Option<T>)); // scope 0 at $DIR/simplify-locals-fixedpoint.rs:4:22: 4:26
-          switchInt(move _4) -> [0isize: bb3, otherwise: bb1]; // scope 0 at $DIR/simplify-locals-fixedpoint.rs:4:22: 4:26
+          switchInt(move _4) -> [0_isize: bb3, otherwise: bb1]; // scope 0 at $DIR/simplify-locals-fixedpoint.rs:4:22: 4:26
       }
   
       bb3: {
@@ -51,7 +51,7 @@
           StorageLive(_7);                 // scope 1 at $DIR/simplify-locals-fixedpoint.rs:5:12: 5:20
           StorageLive(_8);                 // scope 1 at $DIR/simplify-locals-fixedpoint.rs:5:12: 5:13
           _8 = _6;                         // scope 1 at $DIR/simplify-locals-fixedpoint.rs:5:12: 5:13
-          _7 = Gt(move _8, const 42u8);    // scope 1 at $DIR/simplify-locals-fixedpoint.rs:5:12: 5:20
+          _7 = Gt(move _8, const 42_u8);   // scope 1 at $DIR/simplify-locals-fixedpoint.rs:5:12: 5:20
                                            // ty::Const
                                            // + ty: u8
                                            // + val: Value(Scalar(0x2a))

--- a/src/test/mir-opt/simplify-locals-removes-unused-consts/rustc.main.SimplifyLocals.diff
+++ b/src/test/mir-opt/simplify-locals-removes-unused-consts/rustc.main.SimplifyLocals.diff
@@ -98,24 +98,24 @@
 -         StorageLive(_9);                 // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:16:12: 16:34
 -         StorageLive(_10);                // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:16:12: 16:30
 -         StorageLive(_11);                // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:16:12: 16:28
--         _11 = const Temp { x: 40u8 };    // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:16:12: 16:28
+-         _11 = const Temp { x: 40_u8 };   // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:16:12: 16:28
 +         StorageDead(_1);                 // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:14:22: 14:23
 +         StorageLive(_2);                 // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:16:5: 16:35
-+         _2 = const use_u8(const 42u8) -> bb2; // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:16:5: 16:35
++         _2 = const use_u8(const 42_u8) -> bb2; // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:16:5: 16:35
                                            // ty::Const
 -                                          // + ty: Temp
 -                                          // + val: Value(Scalar(0x28))
 -                                          // mir::Constant
 -                                          // + span: $DIR/simplify-locals-removes-unused-consts.rs:16:12: 16:28
 -                                          // + literal: Const { ty: Temp, val: Value(Scalar(0x28)) }
--         _10 = const 40u8;                // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:16:12: 16:30
+-         _10 = const 40_u8;               // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:16:12: 16:30
 -                                          // ty::Const
 -                                          // + ty: u8
 -                                          // + val: Value(Scalar(0x28))
 -                                          // mir::Constant
 -                                          // + span: $DIR/simplify-locals-removes-unused-consts.rs:16:12: 16:30
 -                                          // + literal: Const { ty: u8, val: Value(Scalar(0x28)) }
--         _9 = const 42u8;                 // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:16:12: 16:34
+-         _9 = const 42_u8;                // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:16:12: 16:34
 -                                          // ty::Const
 -                                          // + ty: u8
 -                                          // + val: Value(Scalar(0x2a))
@@ -123,7 +123,7 @@
 -                                          // + span: $DIR/simplify-locals-removes-unused-consts.rs:16:12: 16:34
 -                                          // + literal: Const { ty: u8, val: Value(Scalar(0x2a)) }
 -         StorageDead(_10);                // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:16:33: 16:34
--         _8 = const use_u8(const 42u8) -> bb2; // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:16:5: 16:35
+-         _8 = const use_u8(const 42_u8) -> bb2; // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:16:5: 16:35
 -                                          // ty::Const
                                            // + ty: fn(u8) {use_u8}
                                            // + val: Value(Scalar(<ZST>))

--- a/src/test/mir-opt/simplify-locals-removes-unused-discriminant-reads/32bit/rustc.map.SimplifyLocals.diff
+++ b/src/test/mir-opt/simplify-locals-removes-unused-discriminant-reads/32bit/rustc.map.SimplifyLocals.diff
@@ -15,7 +15,7 @@
   
       bb0: {
           _2 = discriminant(_1);           // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:3:9: 3:13
-          switchInt(move _2) -> [0isize: bb2, otherwise: bb1]; // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:3:9: 3:13
+          switchInt(move _2) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:3:9: 3:13
       }
   
       bb1: {

--- a/src/test/mir-opt/simplify-locals-removes-unused-discriminant-reads/64bit/rustc.map.SimplifyLocals.diff
+++ b/src/test/mir-opt/simplify-locals-removes-unused-discriminant-reads/64bit/rustc.map.SimplifyLocals.diff
@@ -15,7 +15,7 @@
   
       bb0: {
           _2 = discriminant(_1);           // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:3:9: 3:13
-          switchInt(move _2) -> [0isize: bb2, otherwise: bb1]; // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:3:9: 3:13
+          switchInt(move _2) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:3:9: 3:13
       }
   
       bb1: {

--- a/src/test/mir-opt/simplify_try/rustc.try_identity.SimplifyArmIdentity.diff
+++ b/src/test/mir-opt/simplify_try/rustc.try_identity.SimplifyArmIdentity.diff
@@ -46,7 +46,7 @@
           _3 = move _4;                    // scope 6 at $SRC_DIR/libcore/result.rs:LL:COL
           StorageDead(_4);                 // scope 0 at $DIR/simplify_try.rs:6:14: 6:15
           _5 = discriminant(_3);           // scope 0 at $DIR/simplify_try.rs:6:14: 6:15
-          switchInt(move _5) -> [0isize: bb1, otherwise: bb2]; // scope 0 at $DIR/simplify_try.rs:6:14: 6:15
+          switchInt(move _5) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/simplify_try.rs:6:14: 6:15
       }
   
       bb1: {

--- a/src/test/mir-opt/simplify_try_if_let/rustc.{{impl}}-append.SimplifyArmIdentity.diff
+++ b/src/test/mir-opt/simplify_try_if_let/rustc.{{impl}}-append.SimplifyArmIdentity.diff
@@ -26,7 +26,7 @@
   
       bb0: {
           _3 = discriminant(((*_1).1: std::option::Option<std::ptr::NonNull<Node>>)); // scope 0 at $DIR/simplify_try_if_let.rs:22:13: 22:17
-          switchInt(move _3) -> [0isize: bb3, 1isize: bb1, otherwise: bb2]; // scope 0 at $DIR/simplify_try_if_let.rs:22:13: 22:17
+          switchInt(move _3) -> [0_isize: bb3, 1_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/simplify_try_if_let.rs:22:13: 22:17
       }
   
       bb1: {
@@ -62,7 +62,7 @@
       bb4: {
           StorageDead(_6);                 // scope 1 at $DIR/simplify_try_if_let.rs:26:59: 26:60
           _7 = discriminant(_5);           // scope 1 at $DIR/simplify_try_if_let.rs:26:24: 26:40
-          switchInt(move _7) -> [1isize: bb6, otherwise: bb5]; // scope 1 at $DIR/simplify_try_if_let.rs:26:24: 26:40
+          switchInt(move _7) -> [1_isize: bb6, otherwise: bb5]; // scope 1 at $DIR/simplify_try_if_let.rs:26:24: 26:40
       }
   
       bb5: {

--- a/src/test/mir-opt/slice-drop-shim/32bit/rustc.ptr-drop_in_place.[std__string__String].AddMovesForPackedDrops.before.mir
+++ b/src/test/mir-opt/slice-drop-shim/32bit/rustc.ptr-drop_in_place.[std__string__String].AddMovesForPackedDrops.before.mir
@@ -31,7 +31,7 @@ fn std::intrinsics::drop_in_place(_1: *mut [std::string::String]) -> () {
 
     bb3 (cleanup): {
         _5 = &raw mut (*_1)[_4];         // scope 0 at $SRC_DIR/libcore/ptr/mod.rs:LL:COL
-        _4 = Add(move _4, const 1usize); // scope 0 at $SRC_DIR/libcore/ptr/mod.rs:LL:COL
+        _4 = Add(move _4, const 1_usize); // scope 0 at $SRC_DIR/libcore/ptr/mod.rs:LL:COL
                                          // ty::Const
                                          // + ty: usize
                                          // + val: Value(Scalar(0x00000001))
@@ -48,7 +48,7 @@ fn std::intrinsics::drop_in_place(_1: *mut [std::string::String]) -> () {
 
     bb5: {
         _7 = &raw mut (*_1)[_4];         // scope 0 at $SRC_DIR/libcore/ptr/mod.rs:LL:COL
-        _4 = Add(move _4, const 1usize); // scope 0 at $SRC_DIR/libcore/ptr/mod.rs:LL:COL
+        _4 = Add(move _4, const 1_usize); // scope 0 at $SRC_DIR/libcore/ptr/mod.rs:LL:COL
                                          // ty::Const
                                          // + ty: usize
                                          // + val: Value(Scalar(0x00000001))
@@ -64,7 +64,7 @@ fn std::intrinsics::drop_in_place(_1: *mut [std::string::String]) -> () {
     }
 
     bb7: {
-        _4 = const 0usize;               // scope 0 at $SRC_DIR/libcore/ptr/mod.rs:LL:COL
+        _4 = const 0_usize;              // scope 0 at $SRC_DIR/libcore/ptr/mod.rs:LL:COL
                                          // ty::Const
                                          // + ty: usize
                                          // + val: Value(Scalar(0x00000000))
@@ -80,7 +80,7 @@ fn std::intrinsics::drop_in_place(_1: *mut [std::string::String]) -> () {
 
     bb9 (cleanup): {
         _11 = _9;                        // scope 0 at $SRC_DIR/libcore/ptr/mod.rs:LL:COL
-        _9 = Offset(move _9, const 1usize); // scope 0 at $SRC_DIR/libcore/ptr/mod.rs:LL:COL
+        _9 = Offset(move _9, const 1_usize); // scope 0 at $SRC_DIR/libcore/ptr/mod.rs:LL:COL
                                          // ty::Const
                                          // + ty: usize
                                          // + val: Value(Scalar(0x00000001))
@@ -97,7 +97,7 @@ fn std::intrinsics::drop_in_place(_1: *mut [std::string::String]) -> () {
 
     bb11: {
         _13 = _9;                        // scope 0 at $SRC_DIR/libcore/ptr/mod.rs:LL:COL
-        _9 = Offset(move _9, const 1usize); // scope 0 at $SRC_DIR/libcore/ptr/mod.rs:LL:COL
+        _9 = Offset(move _9, const 1_usize); // scope 0 at $SRC_DIR/libcore/ptr/mod.rs:LL:COL
                                          // ty::Const
                                          // + ty: usize
                                          // + val: Value(Scalar(0x00000001))
@@ -126,6 +126,6 @@ fn std::intrinsics::drop_in_place(_1: *mut [std::string::String]) -> () {
     bb15: {
         _2 = SizeOf(std::string::String); // scope 0 at $SRC_DIR/libcore/ptr/mod.rs:LL:COL
         _3 = Len((*_1));                 // scope 0 at $SRC_DIR/libcore/ptr/mod.rs:LL:COL
-        switchInt(move _2) -> [0usize: bb8, otherwise: bb14]; // scope 0 at $SRC_DIR/libcore/ptr/mod.rs:LL:COL
+        switchInt(move _2) -> [0_usize: bb8, otherwise: bb14]; // scope 0 at $SRC_DIR/libcore/ptr/mod.rs:LL:COL
     }
 }

--- a/src/test/mir-opt/slice-drop-shim/64bit/rustc.ptr-drop_in_place.[std__string__String].AddMovesForPackedDrops.before.mir
+++ b/src/test/mir-opt/slice-drop-shim/64bit/rustc.ptr-drop_in_place.[std__string__String].AddMovesForPackedDrops.before.mir
@@ -31,7 +31,7 @@ fn std::intrinsics::drop_in_place(_1: *mut [std::string::String]) -> () {
 
     bb3 (cleanup): {
         _5 = &raw mut (*_1)[_4];         // scope 0 at $SRC_DIR/libcore/ptr/mod.rs:LL:COL
-        _4 = Add(move _4, const 1usize); // scope 0 at $SRC_DIR/libcore/ptr/mod.rs:LL:COL
+        _4 = Add(move _4, const 1_usize); // scope 0 at $SRC_DIR/libcore/ptr/mod.rs:LL:COL
                                          // ty::Const
                                          // + ty: usize
                                          // + val: Value(Scalar(0x0000000000000001))
@@ -48,7 +48,7 @@ fn std::intrinsics::drop_in_place(_1: *mut [std::string::String]) -> () {
 
     bb5: {
         _7 = &raw mut (*_1)[_4];         // scope 0 at $SRC_DIR/libcore/ptr/mod.rs:LL:COL
-        _4 = Add(move _4, const 1usize); // scope 0 at $SRC_DIR/libcore/ptr/mod.rs:LL:COL
+        _4 = Add(move _4, const 1_usize); // scope 0 at $SRC_DIR/libcore/ptr/mod.rs:LL:COL
                                          // ty::Const
                                          // + ty: usize
                                          // + val: Value(Scalar(0x0000000000000001))
@@ -64,7 +64,7 @@ fn std::intrinsics::drop_in_place(_1: *mut [std::string::String]) -> () {
     }
 
     bb7: {
-        _4 = const 0usize;               // scope 0 at $SRC_DIR/libcore/ptr/mod.rs:LL:COL
+        _4 = const 0_usize;              // scope 0 at $SRC_DIR/libcore/ptr/mod.rs:LL:COL
                                          // ty::Const
                                          // + ty: usize
                                          // + val: Value(Scalar(0x0000000000000000))
@@ -80,7 +80,7 @@ fn std::intrinsics::drop_in_place(_1: *mut [std::string::String]) -> () {
 
     bb9 (cleanup): {
         _11 = _9;                        // scope 0 at $SRC_DIR/libcore/ptr/mod.rs:LL:COL
-        _9 = Offset(move _9, const 1usize); // scope 0 at $SRC_DIR/libcore/ptr/mod.rs:LL:COL
+        _9 = Offset(move _9, const 1_usize); // scope 0 at $SRC_DIR/libcore/ptr/mod.rs:LL:COL
                                          // ty::Const
                                          // + ty: usize
                                          // + val: Value(Scalar(0x0000000000000001))
@@ -97,7 +97,7 @@ fn std::intrinsics::drop_in_place(_1: *mut [std::string::String]) -> () {
 
     bb11: {
         _13 = _9;                        // scope 0 at $SRC_DIR/libcore/ptr/mod.rs:LL:COL
-        _9 = Offset(move _9, const 1usize); // scope 0 at $SRC_DIR/libcore/ptr/mod.rs:LL:COL
+        _9 = Offset(move _9, const 1_usize); // scope 0 at $SRC_DIR/libcore/ptr/mod.rs:LL:COL
                                          // ty::Const
                                          // + ty: usize
                                          // + val: Value(Scalar(0x0000000000000001))
@@ -126,6 +126,6 @@ fn std::intrinsics::drop_in_place(_1: *mut [std::string::String]) -> () {
     bb15: {
         _2 = SizeOf(std::string::String); // scope 0 at $SRC_DIR/libcore/ptr/mod.rs:LL:COL
         _3 = Len((*_1));                 // scope 0 at $SRC_DIR/libcore/ptr/mod.rs:LL:COL
-        switchInt(move _2) -> [0usize: bb8, otherwise: bb14]; // scope 0 at $SRC_DIR/libcore/ptr/mod.rs:LL:COL
+        switchInt(move _2) -> [0_usize: bb8, otherwise: bb14]; // scope 0 at $SRC_DIR/libcore/ptr/mod.rs:LL:COL
     }
 }

--- a/src/test/mir-opt/storage_live_dead_in_statics/rustc.XXX.mir_map.0.mir
+++ b/src/test/mir-opt/storage_live_dead_in_statics/rustc.XXX.mir_map.0.mir
@@ -59,7 +59,7 @@ static XXX: &Foo = {
         StorageLive(_5);                 // scope 0 at $DIR/storage_live_dead_in_statics.rs:7:11: 22:6
         StorageLive(_6);                 // scope 0 at $DIR/storage_live_dead_in_statics.rs:7:12: 22:6
         StorageLive(_7);                 // scope 0 at $DIR/storage_live_dead_in_statics.rs:8:9: 8:15
-        _7 = (const 0u32, const 1u32);   // scope 0 at $DIR/storage_live_dead_in_statics.rs:8:9: 8:15
+        _7 = (const 0_u32, const 1_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:8:9: 8:15
                                          // ty::Const
                                          // + ty: u32
                                          // + val: Value(Scalar(0x00000000))
@@ -73,7 +73,7 @@ static XXX: &Foo = {
                                          // + span: $DIR/storage_live_dead_in_statics.rs:8:13: 8:14
                                          // + literal: Const { ty: u32, val: Value(Scalar(0x00000001)) }
         StorageLive(_8);                 // scope 0 at $DIR/storage_live_dead_in_statics.rs:8:17: 8:23
-        _8 = (const 0u32, const 2u32);   // scope 0 at $DIR/storage_live_dead_in_statics.rs:8:17: 8:23
+        _8 = (const 0_u32, const 2_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:8:17: 8:23
                                          // ty::Const
                                          // + ty: u32
                                          // + val: Value(Scalar(0x00000000))
@@ -87,7 +87,7 @@ static XXX: &Foo = {
                                          // + span: $DIR/storage_live_dead_in_statics.rs:8:21: 8:22
                                          // + literal: Const { ty: u32, val: Value(Scalar(0x00000002)) }
         StorageLive(_9);                 // scope 0 at $DIR/storage_live_dead_in_statics.rs:8:25: 8:31
-        _9 = (const 0u32, const 3u32);   // scope 0 at $DIR/storage_live_dead_in_statics.rs:8:25: 8:31
+        _9 = (const 0_u32, const 3_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:8:25: 8:31
                                          // ty::Const
                                          // + ty: u32
                                          // + val: Value(Scalar(0x00000000))
@@ -101,7 +101,7 @@ static XXX: &Foo = {
                                          // + span: $DIR/storage_live_dead_in_statics.rs:8:29: 8:30
                                          // + literal: Const { ty: u32, val: Value(Scalar(0x00000003)) }
         StorageLive(_10);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:9:9: 9:15
-        _10 = (const 0u32, const 1u32);  // scope 0 at $DIR/storage_live_dead_in_statics.rs:9:9: 9:15
+        _10 = (const 0_u32, const 1_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:9:9: 9:15
                                          // ty::Const
                                          // + ty: u32
                                          // + val: Value(Scalar(0x00000000))
@@ -115,7 +115,7 @@ static XXX: &Foo = {
                                          // + span: $DIR/storage_live_dead_in_statics.rs:9:13: 9:14
                                          // + literal: Const { ty: u32, val: Value(Scalar(0x00000001)) }
         StorageLive(_11);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:9:17: 9:23
-        _11 = (const 0u32, const 2u32);  // scope 0 at $DIR/storage_live_dead_in_statics.rs:9:17: 9:23
+        _11 = (const 0_u32, const 2_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:9:17: 9:23
                                          // ty::Const
                                          // + ty: u32
                                          // + val: Value(Scalar(0x00000000))
@@ -129,7 +129,7 @@ static XXX: &Foo = {
                                          // + span: $DIR/storage_live_dead_in_statics.rs:9:21: 9:22
                                          // + literal: Const { ty: u32, val: Value(Scalar(0x00000002)) }
         StorageLive(_12);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:9:25: 9:31
-        _12 = (const 0u32, const 3u32);  // scope 0 at $DIR/storage_live_dead_in_statics.rs:9:25: 9:31
+        _12 = (const 0_u32, const 3_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:9:25: 9:31
                                          // ty::Const
                                          // + ty: u32
                                          // + val: Value(Scalar(0x00000000))
@@ -143,7 +143,7 @@ static XXX: &Foo = {
                                          // + span: $DIR/storage_live_dead_in_statics.rs:9:29: 9:30
                                          // + literal: Const { ty: u32, val: Value(Scalar(0x00000003)) }
         StorageLive(_13);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:10:9: 10:15
-        _13 = (const 0u32, const 1u32);  // scope 0 at $DIR/storage_live_dead_in_statics.rs:10:9: 10:15
+        _13 = (const 0_u32, const 1_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:10:9: 10:15
                                          // ty::Const
                                          // + ty: u32
                                          // + val: Value(Scalar(0x00000000))
@@ -157,7 +157,7 @@ static XXX: &Foo = {
                                          // + span: $DIR/storage_live_dead_in_statics.rs:10:13: 10:14
                                          // + literal: Const { ty: u32, val: Value(Scalar(0x00000001)) }
         StorageLive(_14);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:10:17: 10:23
-        _14 = (const 0u32, const 2u32);  // scope 0 at $DIR/storage_live_dead_in_statics.rs:10:17: 10:23
+        _14 = (const 0_u32, const 2_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:10:17: 10:23
                                          // ty::Const
                                          // + ty: u32
                                          // + val: Value(Scalar(0x00000000))
@@ -171,7 +171,7 @@ static XXX: &Foo = {
                                          // + span: $DIR/storage_live_dead_in_statics.rs:10:21: 10:22
                                          // + literal: Const { ty: u32, val: Value(Scalar(0x00000002)) }
         StorageLive(_15);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:10:25: 10:31
-        _15 = (const 0u32, const 3u32);  // scope 0 at $DIR/storage_live_dead_in_statics.rs:10:25: 10:31
+        _15 = (const 0_u32, const 3_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:10:25: 10:31
                                          // ty::Const
                                          // + ty: u32
                                          // + val: Value(Scalar(0x00000000))
@@ -185,7 +185,7 @@ static XXX: &Foo = {
                                          // + span: $DIR/storage_live_dead_in_statics.rs:10:29: 10:30
                                          // + literal: Const { ty: u32, val: Value(Scalar(0x00000003)) }
         StorageLive(_16);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:11:9: 11:15
-        _16 = (const 0u32, const 1u32);  // scope 0 at $DIR/storage_live_dead_in_statics.rs:11:9: 11:15
+        _16 = (const 0_u32, const 1_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:11:9: 11:15
                                          // ty::Const
                                          // + ty: u32
                                          // + val: Value(Scalar(0x00000000))
@@ -199,7 +199,7 @@ static XXX: &Foo = {
                                          // + span: $DIR/storage_live_dead_in_statics.rs:11:13: 11:14
                                          // + literal: Const { ty: u32, val: Value(Scalar(0x00000001)) }
         StorageLive(_17);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:11:17: 11:23
-        _17 = (const 0u32, const 2u32);  // scope 0 at $DIR/storage_live_dead_in_statics.rs:11:17: 11:23
+        _17 = (const 0_u32, const 2_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:11:17: 11:23
                                          // ty::Const
                                          // + ty: u32
                                          // + val: Value(Scalar(0x00000000))
@@ -213,7 +213,7 @@ static XXX: &Foo = {
                                          // + span: $DIR/storage_live_dead_in_statics.rs:11:21: 11:22
                                          // + literal: Const { ty: u32, val: Value(Scalar(0x00000002)) }
         StorageLive(_18);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:11:25: 11:31
-        _18 = (const 0u32, const 3u32);  // scope 0 at $DIR/storage_live_dead_in_statics.rs:11:25: 11:31
+        _18 = (const 0_u32, const 3_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:11:25: 11:31
                                          // ty::Const
                                          // + ty: u32
                                          // + val: Value(Scalar(0x00000000))
@@ -227,7 +227,7 @@ static XXX: &Foo = {
                                          // + span: $DIR/storage_live_dead_in_statics.rs:11:29: 11:30
                                          // + literal: Const { ty: u32, val: Value(Scalar(0x00000003)) }
         StorageLive(_19);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:12:9: 12:15
-        _19 = (const 0u32, const 1u32);  // scope 0 at $DIR/storage_live_dead_in_statics.rs:12:9: 12:15
+        _19 = (const 0_u32, const 1_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:12:9: 12:15
                                          // ty::Const
                                          // + ty: u32
                                          // + val: Value(Scalar(0x00000000))
@@ -241,7 +241,7 @@ static XXX: &Foo = {
                                          // + span: $DIR/storage_live_dead_in_statics.rs:12:13: 12:14
                                          // + literal: Const { ty: u32, val: Value(Scalar(0x00000001)) }
         StorageLive(_20);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:12:17: 12:23
-        _20 = (const 0u32, const 2u32);  // scope 0 at $DIR/storage_live_dead_in_statics.rs:12:17: 12:23
+        _20 = (const 0_u32, const 2_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:12:17: 12:23
                                          // ty::Const
                                          // + ty: u32
                                          // + val: Value(Scalar(0x00000000))
@@ -255,7 +255,7 @@ static XXX: &Foo = {
                                          // + span: $DIR/storage_live_dead_in_statics.rs:12:21: 12:22
                                          // + literal: Const { ty: u32, val: Value(Scalar(0x00000002)) }
         StorageLive(_21);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:12:25: 12:31
-        _21 = (const 0u32, const 3u32);  // scope 0 at $DIR/storage_live_dead_in_statics.rs:12:25: 12:31
+        _21 = (const 0_u32, const 3_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:12:25: 12:31
                                          // ty::Const
                                          // + ty: u32
                                          // + val: Value(Scalar(0x00000000))
@@ -269,7 +269,7 @@ static XXX: &Foo = {
                                          // + span: $DIR/storage_live_dead_in_statics.rs:12:29: 12:30
                                          // + literal: Const { ty: u32, val: Value(Scalar(0x00000003)) }
         StorageLive(_22);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:13:9: 13:15
-        _22 = (const 0u32, const 1u32);  // scope 0 at $DIR/storage_live_dead_in_statics.rs:13:9: 13:15
+        _22 = (const 0_u32, const 1_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:13:9: 13:15
                                          // ty::Const
                                          // + ty: u32
                                          // + val: Value(Scalar(0x00000000))
@@ -283,7 +283,7 @@ static XXX: &Foo = {
                                          // + span: $DIR/storage_live_dead_in_statics.rs:13:13: 13:14
                                          // + literal: Const { ty: u32, val: Value(Scalar(0x00000001)) }
         StorageLive(_23);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:13:17: 13:23
-        _23 = (const 0u32, const 2u32);  // scope 0 at $DIR/storage_live_dead_in_statics.rs:13:17: 13:23
+        _23 = (const 0_u32, const 2_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:13:17: 13:23
                                          // ty::Const
                                          // + ty: u32
                                          // + val: Value(Scalar(0x00000000))
@@ -297,7 +297,7 @@ static XXX: &Foo = {
                                          // + span: $DIR/storage_live_dead_in_statics.rs:13:21: 13:22
                                          // + literal: Const { ty: u32, val: Value(Scalar(0x00000002)) }
         StorageLive(_24);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:13:25: 13:31
-        _24 = (const 0u32, const 3u32);  // scope 0 at $DIR/storage_live_dead_in_statics.rs:13:25: 13:31
+        _24 = (const 0_u32, const 3_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:13:25: 13:31
                                          // ty::Const
                                          // + ty: u32
                                          // + val: Value(Scalar(0x00000000))
@@ -311,7 +311,7 @@ static XXX: &Foo = {
                                          // + span: $DIR/storage_live_dead_in_statics.rs:13:29: 13:30
                                          // + literal: Const { ty: u32, val: Value(Scalar(0x00000003)) }
         StorageLive(_25);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:14:9: 14:15
-        _25 = (const 0u32, const 1u32);  // scope 0 at $DIR/storage_live_dead_in_statics.rs:14:9: 14:15
+        _25 = (const 0_u32, const 1_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:14:9: 14:15
                                          // ty::Const
                                          // + ty: u32
                                          // + val: Value(Scalar(0x00000000))
@@ -325,7 +325,7 @@ static XXX: &Foo = {
                                          // + span: $DIR/storage_live_dead_in_statics.rs:14:13: 14:14
                                          // + literal: Const { ty: u32, val: Value(Scalar(0x00000001)) }
         StorageLive(_26);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:14:17: 14:23
-        _26 = (const 0u32, const 2u32);  // scope 0 at $DIR/storage_live_dead_in_statics.rs:14:17: 14:23
+        _26 = (const 0_u32, const 2_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:14:17: 14:23
                                          // ty::Const
                                          // + ty: u32
                                          // + val: Value(Scalar(0x00000000))
@@ -339,7 +339,7 @@ static XXX: &Foo = {
                                          // + span: $DIR/storage_live_dead_in_statics.rs:14:21: 14:22
                                          // + literal: Const { ty: u32, val: Value(Scalar(0x00000002)) }
         StorageLive(_27);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:14:25: 14:31
-        _27 = (const 0u32, const 3u32);  // scope 0 at $DIR/storage_live_dead_in_statics.rs:14:25: 14:31
+        _27 = (const 0_u32, const 3_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:14:25: 14:31
                                          // ty::Const
                                          // + ty: u32
                                          // + val: Value(Scalar(0x00000000))
@@ -353,7 +353,7 @@ static XXX: &Foo = {
                                          // + span: $DIR/storage_live_dead_in_statics.rs:14:29: 14:30
                                          // + literal: Const { ty: u32, val: Value(Scalar(0x00000003)) }
         StorageLive(_28);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:15:9: 15:15
-        _28 = (const 0u32, const 1u32);  // scope 0 at $DIR/storage_live_dead_in_statics.rs:15:9: 15:15
+        _28 = (const 0_u32, const 1_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:15:9: 15:15
                                          // ty::Const
                                          // + ty: u32
                                          // + val: Value(Scalar(0x00000000))
@@ -367,7 +367,7 @@ static XXX: &Foo = {
                                          // + span: $DIR/storage_live_dead_in_statics.rs:15:13: 15:14
                                          // + literal: Const { ty: u32, val: Value(Scalar(0x00000001)) }
         StorageLive(_29);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:15:17: 15:23
-        _29 = (const 0u32, const 2u32);  // scope 0 at $DIR/storage_live_dead_in_statics.rs:15:17: 15:23
+        _29 = (const 0_u32, const 2_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:15:17: 15:23
                                          // ty::Const
                                          // + ty: u32
                                          // + val: Value(Scalar(0x00000000))
@@ -381,7 +381,7 @@ static XXX: &Foo = {
                                          // + span: $DIR/storage_live_dead_in_statics.rs:15:21: 15:22
                                          // + literal: Const { ty: u32, val: Value(Scalar(0x00000002)) }
         StorageLive(_30);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:15:25: 15:31
-        _30 = (const 0u32, const 3u32);  // scope 0 at $DIR/storage_live_dead_in_statics.rs:15:25: 15:31
+        _30 = (const 0_u32, const 3_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:15:25: 15:31
                                          // ty::Const
                                          // + ty: u32
                                          // + val: Value(Scalar(0x00000000))
@@ -395,7 +395,7 @@ static XXX: &Foo = {
                                          // + span: $DIR/storage_live_dead_in_statics.rs:15:29: 15:30
                                          // + literal: Const { ty: u32, val: Value(Scalar(0x00000003)) }
         StorageLive(_31);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:16:9: 16:15
-        _31 = (const 0u32, const 1u32);  // scope 0 at $DIR/storage_live_dead_in_statics.rs:16:9: 16:15
+        _31 = (const 0_u32, const 1_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:16:9: 16:15
                                          // ty::Const
                                          // + ty: u32
                                          // + val: Value(Scalar(0x00000000))
@@ -409,7 +409,7 @@ static XXX: &Foo = {
                                          // + span: $DIR/storage_live_dead_in_statics.rs:16:13: 16:14
                                          // + literal: Const { ty: u32, val: Value(Scalar(0x00000001)) }
         StorageLive(_32);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:16:17: 16:23
-        _32 = (const 0u32, const 2u32);  // scope 0 at $DIR/storage_live_dead_in_statics.rs:16:17: 16:23
+        _32 = (const 0_u32, const 2_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:16:17: 16:23
                                          // ty::Const
                                          // + ty: u32
                                          // + val: Value(Scalar(0x00000000))
@@ -423,7 +423,7 @@ static XXX: &Foo = {
                                          // + span: $DIR/storage_live_dead_in_statics.rs:16:21: 16:22
                                          // + literal: Const { ty: u32, val: Value(Scalar(0x00000002)) }
         StorageLive(_33);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:16:25: 16:31
-        _33 = (const 0u32, const 3u32);  // scope 0 at $DIR/storage_live_dead_in_statics.rs:16:25: 16:31
+        _33 = (const 0_u32, const 3_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:16:25: 16:31
                                          // ty::Const
                                          // + ty: u32
                                          // + val: Value(Scalar(0x00000000))
@@ -437,7 +437,7 @@ static XXX: &Foo = {
                                          // + span: $DIR/storage_live_dead_in_statics.rs:16:29: 16:30
                                          // + literal: Const { ty: u32, val: Value(Scalar(0x00000003)) }
         StorageLive(_34);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:17:9: 17:15
-        _34 = (const 0u32, const 1u32);  // scope 0 at $DIR/storage_live_dead_in_statics.rs:17:9: 17:15
+        _34 = (const 0_u32, const 1_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:17:9: 17:15
                                          // ty::Const
                                          // + ty: u32
                                          // + val: Value(Scalar(0x00000000))
@@ -451,7 +451,7 @@ static XXX: &Foo = {
                                          // + span: $DIR/storage_live_dead_in_statics.rs:17:13: 17:14
                                          // + literal: Const { ty: u32, val: Value(Scalar(0x00000001)) }
         StorageLive(_35);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:17:17: 17:23
-        _35 = (const 0u32, const 2u32);  // scope 0 at $DIR/storage_live_dead_in_statics.rs:17:17: 17:23
+        _35 = (const 0_u32, const 2_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:17:17: 17:23
                                          // ty::Const
                                          // + ty: u32
                                          // + val: Value(Scalar(0x00000000))
@@ -465,7 +465,7 @@ static XXX: &Foo = {
                                          // + span: $DIR/storage_live_dead_in_statics.rs:17:21: 17:22
                                          // + literal: Const { ty: u32, val: Value(Scalar(0x00000002)) }
         StorageLive(_36);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:17:25: 17:31
-        _36 = (const 0u32, const 3u32);  // scope 0 at $DIR/storage_live_dead_in_statics.rs:17:25: 17:31
+        _36 = (const 0_u32, const 3_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:17:25: 17:31
                                          // ty::Const
                                          // + ty: u32
                                          // + val: Value(Scalar(0x00000000))
@@ -479,7 +479,7 @@ static XXX: &Foo = {
                                          // + span: $DIR/storage_live_dead_in_statics.rs:17:29: 17:30
                                          // + literal: Const { ty: u32, val: Value(Scalar(0x00000003)) }
         StorageLive(_37);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:18:9: 18:15
-        _37 = (const 0u32, const 1u32);  // scope 0 at $DIR/storage_live_dead_in_statics.rs:18:9: 18:15
+        _37 = (const 0_u32, const 1_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:18:9: 18:15
                                          // ty::Const
                                          // + ty: u32
                                          // + val: Value(Scalar(0x00000000))
@@ -493,7 +493,7 @@ static XXX: &Foo = {
                                          // + span: $DIR/storage_live_dead_in_statics.rs:18:13: 18:14
                                          // + literal: Const { ty: u32, val: Value(Scalar(0x00000001)) }
         StorageLive(_38);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:18:17: 18:23
-        _38 = (const 0u32, const 2u32);  // scope 0 at $DIR/storage_live_dead_in_statics.rs:18:17: 18:23
+        _38 = (const 0_u32, const 2_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:18:17: 18:23
                                          // ty::Const
                                          // + ty: u32
                                          // + val: Value(Scalar(0x00000000))
@@ -507,7 +507,7 @@ static XXX: &Foo = {
                                          // + span: $DIR/storage_live_dead_in_statics.rs:18:21: 18:22
                                          // + literal: Const { ty: u32, val: Value(Scalar(0x00000002)) }
         StorageLive(_39);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:18:25: 18:31
-        _39 = (const 0u32, const 3u32);  // scope 0 at $DIR/storage_live_dead_in_statics.rs:18:25: 18:31
+        _39 = (const 0_u32, const 3_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:18:25: 18:31
                                          // ty::Const
                                          // + ty: u32
                                          // + val: Value(Scalar(0x00000000))
@@ -521,7 +521,7 @@ static XXX: &Foo = {
                                          // + span: $DIR/storage_live_dead_in_statics.rs:18:29: 18:30
                                          // + literal: Const { ty: u32, val: Value(Scalar(0x00000003)) }
         StorageLive(_40);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:19:9: 19:15
-        _40 = (const 0u32, const 1u32);  // scope 0 at $DIR/storage_live_dead_in_statics.rs:19:9: 19:15
+        _40 = (const 0_u32, const 1_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:19:9: 19:15
                                          // ty::Const
                                          // + ty: u32
                                          // + val: Value(Scalar(0x00000000))
@@ -535,7 +535,7 @@ static XXX: &Foo = {
                                          // + span: $DIR/storage_live_dead_in_statics.rs:19:13: 19:14
                                          // + literal: Const { ty: u32, val: Value(Scalar(0x00000001)) }
         StorageLive(_41);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:19:17: 19:23
-        _41 = (const 0u32, const 2u32);  // scope 0 at $DIR/storage_live_dead_in_statics.rs:19:17: 19:23
+        _41 = (const 0_u32, const 2_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:19:17: 19:23
                                          // ty::Const
                                          // + ty: u32
                                          // + val: Value(Scalar(0x00000000))
@@ -549,7 +549,7 @@ static XXX: &Foo = {
                                          // + span: $DIR/storage_live_dead_in_statics.rs:19:21: 19:22
                                          // + literal: Const { ty: u32, val: Value(Scalar(0x00000002)) }
         StorageLive(_42);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:19:25: 19:31
-        _42 = (const 0u32, const 3u32);  // scope 0 at $DIR/storage_live_dead_in_statics.rs:19:25: 19:31
+        _42 = (const 0_u32, const 3_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:19:25: 19:31
                                          // ty::Const
                                          // + ty: u32
                                          // + val: Value(Scalar(0x00000000))
@@ -563,7 +563,7 @@ static XXX: &Foo = {
                                          // + span: $DIR/storage_live_dead_in_statics.rs:19:29: 19:30
                                          // + literal: Const { ty: u32, val: Value(Scalar(0x00000003)) }
         StorageLive(_43);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:20:9: 20:15
-        _43 = (const 0u32, const 1u32);  // scope 0 at $DIR/storage_live_dead_in_statics.rs:20:9: 20:15
+        _43 = (const 0_u32, const 1_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:20:9: 20:15
                                          // ty::Const
                                          // + ty: u32
                                          // + val: Value(Scalar(0x00000000))
@@ -577,7 +577,7 @@ static XXX: &Foo = {
                                          // + span: $DIR/storage_live_dead_in_statics.rs:20:13: 20:14
                                          // + literal: Const { ty: u32, val: Value(Scalar(0x00000001)) }
         StorageLive(_44);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:20:17: 20:23
-        _44 = (const 0u32, const 2u32);  // scope 0 at $DIR/storage_live_dead_in_statics.rs:20:17: 20:23
+        _44 = (const 0_u32, const 2_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:20:17: 20:23
                                          // ty::Const
                                          // + ty: u32
                                          // + val: Value(Scalar(0x00000000))
@@ -591,7 +591,7 @@ static XXX: &Foo = {
                                          // + span: $DIR/storage_live_dead_in_statics.rs:20:21: 20:22
                                          // + literal: Const { ty: u32, val: Value(Scalar(0x00000002)) }
         StorageLive(_45);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:20:25: 20:31
-        _45 = (const 0u32, const 3u32);  // scope 0 at $DIR/storage_live_dead_in_statics.rs:20:25: 20:31
+        _45 = (const 0_u32, const 3_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:20:25: 20:31
                                          // ty::Const
                                          // + ty: u32
                                          // + val: Value(Scalar(0x00000000))
@@ -605,7 +605,7 @@ static XXX: &Foo = {
                                          // + span: $DIR/storage_live_dead_in_statics.rs:20:29: 20:30
                                          // + literal: Const { ty: u32, val: Value(Scalar(0x00000003)) }
         StorageLive(_46);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:21:9: 21:15
-        _46 = (const 0u32, const 1u32);  // scope 0 at $DIR/storage_live_dead_in_statics.rs:21:9: 21:15
+        _46 = (const 0_u32, const 1_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:21:9: 21:15
                                          // ty::Const
                                          // + ty: u32
                                          // + val: Value(Scalar(0x00000000))
@@ -619,7 +619,7 @@ static XXX: &Foo = {
                                          // + span: $DIR/storage_live_dead_in_statics.rs:21:13: 21:14
                                          // + literal: Const { ty: u32, val: Value(Scalar(0x00000001)) }
         StorageLive(_47);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:21:17: 21:23
-        _47 = (const 0u32, const 2u32);  // scope 0 at $DIR/storage_live_dead_in_statics.rs:21:17: 21:23
+        _47 = (const 0_u32, const 2_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:21:17: 21:23
                                          // ty::Const
                                          // + ty: u32
                                          // + val: Value(Scalar(0x00000000))
@@ -633,7 +633,7 @@ static XXX: &Foo = {
                                          // + span: $DIR/storage_live_dead_in_statics.rs:21:21: 21:22
                                          // + literal: Const { ty: u32, val: Value(Scalar(0x00000002)) }
         StorageLive(_48);                // scope 0 at $DIR/storage_live_dead_in_statics.rs:21:25: 21:31
-        _48 = (const 0u32, const 3u32);  // scope 0 at $DIR/storage_live_dead_in_statics.rs:21:25: 21:31
+        _48 = (const 0_u32, const 3_u32); // scope 0 at $DIR/storage_live_dead_in_statics.rs:21:25: 21:31
                                          // ty::Const
                                          // + ty: u32
                                          // + val: Value(Scalar(0x00000000))

--- a/src/test/mir-opt/storage_ranges/rustc.main.nll.0.mir
+++ b/src/test/mir-opt/storage_ranges/rustc.main.nll.0.mir
@@ -38,7 +38,7 @@ fn main() -> () {
 
     bb0: {
         StorageLive(_1);                 // scope 0 at $DIR/storage_ranges.rs:4:9: 4:10
-        _1 = const 0i32;                 // scope 0 at $DIR/storage_ranges.rs:4:13: 4:14
+        _1 = const 0_i32;                // scope 0 at $DIR/storage_ranges.rs:4:13: 4:14
                                          // ty::Const
                                          // + ty: i32
                                          // + val: Value(Scalar(0x00000000))
@@ -66,7 +66,7 @@ fn main() -> () {
         StorageDead(_3);                 // scope 1 at $DIR/storage_ranges.rs:7:5: 7:6
         StorageDead(_2);                 // scope 1 at $DIR/storage_ranges.rs:7:5: 7:6
         StorageLive(_6);                 // scope 1 at $DIR/storage_ranges.rs:8:9: 8:10
-        _6 = const 1i32;                 // scope 1 at $DIR/storage_ranges.rs:8:13: 8:14
+        _6 = const 1_i32;                // scope 1 at $DIR/storage_ranges.rs:8:13: 8:14
                                          // ty::Const
                                          // + ty: i32
                                          // + val: Value(Scalar(0x00000001))

--- a/src/test/mir-opt/tls-access/rustc.main.SimplifyCfg-final.after.mir
+++ b/src/test/mir-opt/tls-access/rustc.main.SimplifyCfg-final.after.mir
@@ -18,7 +18,7 @@ fn main() -> () {
         _1 = &(*_2);                     // scope 1 at $DIR/tls-access.rs:8:17: 8:21
         StorageLive(_3);                 // scope 2 at $DIR/tls-access.rs:9:9: 9:12
         _3 = &/*tls*/ mut FOO;           // scope 2 at $DIR/tls-access.rs:9:9: 9:12
-        (*_3) = const 42u8;              // scope 2 at $DIR/tls-access.rs:9:9: 9:17
+        (*_3) = const 42_u8;             // scope 2 at $DIR/tls-access.rs:9:9: 9:17
                                          // ty::Const
                                          // + ty: u8
                                          // + val: Value(Scalar(0x2a))

--- a/src/test/mir-opt/uniform_array_move_out/rustc.move_out_by_subslice.mir_map.0.mir
+++ b/src/test/mir-opt/uniform_array_move_out/rustc.move_out_by_subslice.mir_map.0.mir
@@ -20,7 +20,7 @@ fn move_out_by_subslice() -> () {
         StorageLive(_2);                 // scope 0 at $DIR/uniform_array_move_out.rs:11:14: 11:19
         StorageLive(_3);                 // scope 0 at $DIR/uniform_array_move_out.rs:11:14: 11:19
         _3 = Box(i32);                   // scope 0 at $DIR/uniform_array_move_out.rs:11:14: 11:19
-        (*_3) = const 1i32;              // scope 0 at $DIR/uniform_array_move_out.rs:11:18: 11:19
+        (*_3) = const 1_i32;             // scope 0 at $DIR/uniform_array_move_out.rs:11:18: 11:19
                                          // ty::Const
                                          // + ty: i32
                                          // + val: Value(Scalar(0x00000001))
@@ -48,7 +48,7 @@ fn move_out_by_subslice() -> () {
         StorageLive(_4);                 // scope 0 at $DIR/uniform_array_move_out.rs:11:21: 11:26
         StorageLive(_5);                 // scope 0 at $DIR/uniform_array_move_out.rs:11:21: 11:26
         _5 = Box(i32);                   // scope 0 at $DIR/uniform_array_move_out.rs:11:21: 11:26
-        (*_5) = const 2i32;              // scope 0 at $DIR/uniform_array_move_out.rs:11:25: 11:26
+        (*_5) = const 2_i32;             // scope 0 at $DIR/uniform_array_move_out.rs:11:25: 11:26
                                          // ty::Const
                                          // + ty: i32
                                          // + val: Value(Scalar(0x00000002))

--- a/src/test/mir-opt/uniform_array_move_out/rustc.move_out_from_end.mir_map.0.mir
+++ b/src/test/mir-opt/uniform_array_move_out/rustc.move_out_from_end.mir_map.0.mir
@@ -20,7 +20,7 @@ fn move_out_from_end() -> () {
         StorageLive(_2);                 // scope 0 at $DIR/uniform_array_move_out.rs:5:14: 5:19
         StorageLive(_3);                 // scope 0 at $DIR/uniform_array_move_out.rs:5:14: 5:19
         _3 = Box(i32);                   // scope 0 at $DIR/uniform_array_move_out.rs:5:14: 5:19
-        (*_3) = const 1i32;              // scope 0 at $DIR/uniform_array_move_out.rs:5:18: 5:19
+        (*_3) = const 1_i32;             // scope 0 at $DIR/uniform_array_move_out.rs:5:18: 5:19
                                          // ty::Const
                                          // + ty: i32
                                          // + val: Value(Scalar(0x00000001))
@@ -48,7 +48,7 @@ fn move_out_from_end() -> () {
         StorageLive(_4);                 // scope 0 at $DIR/uniform_array_move_out.rs:5:21: 5:26
         StorageLive(_5);                 // scope 0 at $DIR/uniform_array_move_out.rs:5:21: 5:26
         _5 = Box(i32);                   // scope 0 at $DIR/uniform_array_move_out.rs:5:21: 5:26
-        (*_5) = const 2i32;              // scope 0 at $DIR/uniform_array_move_out.rs:5:25: 5:26
+        (*_5) = const 2_i32;             // scope 0 at $DIR/uniform_array_move_out.rs:5:25: 5:26
                                          // ty::Const
                                          // + ty: i32
                                          // + val: Value(Scalar(0x00000002))

--- a/src/test/mir-opt/uninhabited_enum_branching/rustc.main.SimplifyCfg-after-uninhabited-enum-branching.after.mir
+++ b/src/test/mir-opt/uninhabited_enum_branching/rustc.main.SimplifyCfg-after-uninhabited-enum-branching.after.mir
@@ -33,7 +33,7 @@ fn main() -> () {
         StorageLive(_7);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:26:11: 26:19
         _7 = Test2::D;                   // scope 0 at $DIR/uninhabited_enum_branching.rs:26:11: 26:19
         _8 = discriminant(_7);           // scope 0 at $DIR/uninhabited_enum_branching.rs:27:9: 27:17
-        switchInt(move _8) -> [4isize: bb2, otherwise: bb1]; // scope 0 at $DIR/uninhabited_enum_branching.rs:27:9: 27:17
+        switchInt(move _8) -> [4_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/uninhabited_enum_branching.rs:27:9: 27:17
     }
 
     bb1: {

--- a/src/test/mir-opt/uninhabited_enum_branching/rustc.main.UninhabitedEnumBranching.diff
+++ b/src/test/mir-opt/uninhabited_enum_branching/rustc.main.UninhabitedEnumBranching.diff
@@ -18,7 +18,7 @@
           StorageLive(_2);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:20:11: 20:19
           _2 = Test1::C;                   // scope 0 at $DIR/uninhabited_enum_branching.rs:20:11: 20:19
           _3 = discriminant(_2);           // scope 0 at $DIR/uninhabited_enum_branching.rs:21:9: 21:20
--         switchInt(move _3) -> [0isize: bb2, 1isize: bb3, otherwise: bb1]; // scope 0 at $DIR/uninhabited_enum_branching.rs:21:9: 21:20
+-         switchInt(move _3) -> [0_isize: bb2, 1_isize: bb3, otherwise: bb1]; // scope 0 at $DIR/uninhabited_enum_branching.rs:21:9: 21:20
 +         switchInt(move _3) -> bb1;       // scope 0 at $DIR/uninhabited_enum_branching.rs:21:9: 21:20
       }
   
@@ -68,7 +68,7 @@
           StorageLive(_7);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:26:11: 26:19
           _7 = Test2::D;                   // scope 0 at $DIR/uninhabited_enum_branching.rs:26:11: 26:19
           _8 = discriminant(_7);           // scope 0 at $DIR/uninhabited_enum_branching.rs:27:9: 27:17
-          switchInt(move _8) -> [4isize: bb6, otherwise: bb5]; // scope 0 at $DIR/uninhabited_enum_branching.rs:27:9: 27:17
+          switchInt(move _8) -> [4_isize: bb6, otherwise: bb5]; // scope 0 at $DIR/uninhabited_enum_branching.rs:27:9: 27:17
       }
   
       bb5: {

--- a/src/test/mir-opt/unreachable/rustc.main.UnreachablePropagation.diff
+++ b/src/test/mir-opt/unreachable/rustc.main.UnreachablePropagation.diff
@@ -30,7 +30,7 @@
   
       bb1: {
           _2 = discriminant(_1);           // scope 0 at $DIR/unreachable.rs:9:12: 9:20
--         switchInt(move _2) -> [1isize: bb3, otherwise: bb2]; // scope 0 at $DIR/unreachable.rs:9:12: 9:20
+-         switchInt(move _2) -> [1_isize: bb3, otherwise: bb2]; // scope 0 at $DIR/unreachable.rs:9:12: 9:20
 +         goto -> bb2;                     // scope 0 at $DIR/unreachable.rs:9:12: 9:20
       }
   
@@ -63,7 +63,7 @@
 -     }
 - 
 -     bb4: {
--         _4 = const 42i32;                // scope 2 at $DIR/unreachable.rs:15:13: 15:20
+-         _4 = const 42_i32;               // scope 2 at $DIR/unreachable.rs:15:13: 15:20
 -                                          // ty::Const
 -                                          // + ty: i32
 -                                          // + val: Value(Scalar(0x0000002a))
@@ -81,7 +81,7 @@
 -     }
 - 
 -     bb5: {
--         _4 = const 21i32;                // scope 2 at $DIR/unreachable.rs:13:13: 13:20
+-         _4 = const 21_i32;               // scope 2 at $DIR/unreachable.rs:13:13: 13:20
 -                                          // ty::Const
 -                                          // + ty: i32
 -                                          // + val: Value(Scalar(0x00000015))

--- a/src/test/mir-opt/unreachable_asm/rustc.main.UnreachablePropagation.diff
+++ b/src/test/mir-opt/unreachable_asm/rustc.main.UnreachablePropagation.diff
@@ -33,7 +33,7 @@
   
       bb1: {
           _2 = discriminant(_1);           // scope 0 at $DIR/unreachable_asm.rs:11:12: 11:20
-          switchInt(move _2) -> [1isize: bb3, otherwise: bb2]; // scope 0 at $DIR/unreachable_asm.rs:11:12: 11:20
+          switchInt(move _2) -> [1_isize: bb3, otherwise: bb2]; // scope 0 at $DIR/unreachable_asm.rs:11:12: 11:20
       }
   
       bb2: {
@@ -65,7 +65,7 @@
       }
   
       bb4: {
-          _4 = const 42i32;                // scope 2 at $DIR/unreachable_asm.rs:17:13: 17:20
+          _4 = const 42_i32;               // scope 2 at $DIR/unreachable_asm.rs:17:13: 17:20
                                            // ty::Const
                                            // + ty: i32
                                            // + val: Value(Scalar(0x0000002a))
@@ -83,7 +83,7 @@
       }
   
       bb5: {
-          _4 = const 21i32;                // scope 2 at $DIR/unreachable_asm.rs:15:13: 15:20
+          _4 = const 21_i32;               // scope 2 at $DIR/unreachable_asm.rs:15:13: 15:20
                                            // ty::Const
                                            // + ty: i32
                                            // + val: Value(Scalar(0x00000015))

--- a/src/test/mir-opt/unreachable_asm_2/rustc.main.UnreachablePropagation.diff
+++ b/src/test/mir-opt/unreachable_asm_2/rustc.main.UnreachablePropagation.diff
@@ -36,7 +36,7 @@
   
       bb1: {
           _2 = discriminant(_1);           // scope 0 at $DIR/unreachable_asm_2.rs:11:12: 11:20
-          switchInt(move _2) -> [1isize: bb3, otherwise: bb2]; // scope 0 at $DIR/unreachable_asm_2.rs:11:12: 11:20
+          switchInt(move _2) -> [1_isize: bb3, otherwise: bb2]; // scope 0 at $DIR/unreachable_asm_2.rs:11:12: 11:20
       }
   
       bb2: {
@@ -78,7 +78,7 @@
                                            // + span: $DIR/unreachable_asm_2.rs:20:13: 20:41
                                            // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           StorageDead(_8);                 // scope 2 at $DIR/unreachable_asm_2.rs:20:40: 20:41
-          _4 = const 42i32;                // scope 2 at $DIR/unreachable_asm_2.rs:21:13: 21:20
+          _4 = const 42_i32;               // scope 2 at $DIR/unreachable_asm_2.rs:21:13: 21:20
                                            // ty::Const
                                            // + ty: i32
                                            // + val: Value(Scalar(0x0000002a))
@@ -107,7 +107,7 @@
                                            // + span: $DIR/unreachable_asm_2.rs:16:13: 16:41
                                            // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           StorageDead(_7);                 // scope 2 at $DIR/unreachable_asm_2.rs:16:40: 16:41
-          _4 = const 21i32;                // scope 2 at $DIR/unreachable_asm_2.rs:17:13: 17:20
+          _4 = const 21_i32;               // scope 2 at $DIR/unreachable_asm_2.rs:17:13: 17:20
                                            // ty::Const
                                            // + ty: i32
                                            // + val: Value(Scalar(0x00000015))

--- a/src/test/mir-opt/unreachable_diverging/rustc.main.UnreachablePropagation.diff
+++ b/src/test/mir-opt/unreachable_diverging/rustc.main.UnreachablePropagation.diff
@@ -38,7 +38,7 @@
   
       bb1: {
           _3 = discriminant(_2);           // scope 1 at $DIR/unreachable_diverging.rs:14:12: 14:22
-          switchInt(move _3) -> [1isize: bb3, otherwise: bb2]; // scope 1 at $DIR/unreachable_diverging.rs:14:12: 14:22
+          switchInt(move _3) -> [1_isize: bb3, otherwise: bb2]; // scope 1 at $DIR/unreachable_diverging.rs:14:12: 14:22
       }
   
       bb2: {

--- a/src/test/mir-opt/unusual-item-types/32bit/rustc.E-V-{{constant}}.mir_map.0.mir
+++ b/src/test/mir-opt/unusual-item-types/32bit/rustc.E-V-{{constant}}.mir_map.0.mir
@@ -4,7 +4,7 @@ E::V::{{constant}}#0: isize = {
     let mut _0: isize;                   // return place in scope 0 at $DIR/unusual-item-types.rs:22:9: 22:10
 
     bb0: {
-        _0 = const 5isize;               // scope 0 at $DIR/unusual-item-types.rs:22:9: 22:10
+        _0 = const 5_isize;              // scope 0 at $DIR/unusual-item-types.rs:22:9: 22:10
                                          // ty::Const
                                          // + ty: isize
                                          // + val: Value(Scalar(0x00000005))

--- a/src/test/mir-opt/unusual-item-types/32bit/rustc.{{impl}}-ASSOCIATED_CONSTANT.mir_map.0.mir
+++ b/src/test/mir-opt/unusual-item-types/32bit/rustc.{{impl}}-ASSOCIATED_CONSTANT.mir_map.0.mir
@@ -4,7 +4,7 @@ const <impl at $DIR/unusual-item-types.rs:9:1: 11:2>::ASSOCIATED_CONSTANT: i32 =
     let mut _0: i32;                     // return place in scope 0 at $DIR/unusual-item-types.rs:10:32: 10:35
 
     bb0: {
-        _0 = const 2i32;                 // scope 0 at $DIR/unusual-item-types.rs:10:38: 10:39
+        _0 = const 2_i32;                // scope 0 at $DIR/unusual-item-types.rs:10:38: 10:39
                                          // ty::Const
                                          // + ty: i32
                                          // + val: Value(Scalar(0x00000002))

--- a/src/test/mir-opt/unusual-item-types/64bit/rustc.E-V-{{constant}}.mir_map.0.mir
+++ b/src/test/mir-opt/unusual-item-types/64bit/rustc.E-V-{{constant}}.mir_map.0.mir
@@ -4,7 +4,7 @@ E::V::{{constant}}#0: isize = {
     let mut _0: isize;                   // return place in scope 0 at $DIR/unusual-item-types.rs:22:9: 22:10
 
     bb0: {
-        _0 = const 5isize;               // scope 0 at $DIR/unusual-item-types.rs:22:9: 22:10
+        _0 = const 5_isize;              // scope 0 at $DIR/unusual-item-types.rs:22:9: 22:10
                                          // ty::Const
                                          // + ty: isize
                                          // + val: Value(Scalar(0x0000000000000005))

--- a/src/test/mir-opt/unusual-item-types/64bit/rustc.{{impl}}-ASSOCIATED_CONSTANT.mir_map.0.mir
+++ b/src/test/mir-opt/unusual-item-types/64bit/rustc.{{impl}}-ASSOCIATED_CONSTANT.mir_map.0.mir
@@ -4,7 +4,7 @@ const <impl at $DIR/unusual-item-types.rs:9:1: 11:2>::ASSOCIATED_CONSTANT: i32 =
     let mut _0: i32;                     // return place in scope 0 at $DIR/unusual-item-types.rs:10:32: 10:35
 
     bb0: {
-        _0 = const 2i32;                 // scope 0 at $DIR/unusual-item-types.rs:10:38: 10:39
+        _0 = const 2_i32;                // scope 0 at $DIR/unusual-item-types.rs:10:38: 10:39
                                          // ty::Const
                                          // + ty: i32
                                          // + val: Value(Scalar(0x00000002))

--- a/src/test/rustdoc/const-generics/add-impl.rs
+++ b/src/test/rustdoc/const-generics/add-impl.rs
@@ -1,7 +1,6 @@
 // ignore-tidy-linelength
 
 #![feature(const_generics)]
-
 #![crate_name = "foo"]
 
 use std::ops::Add;
@@ -11,7 +10,7 @@ pub struct Simd<T, const WIDTH: usize> {
     inner: T,
 }
 
-// @has foo/struct.Simd.html '//div[@id="trait-implementations-list"]/h3/code' 'impl Add<Simd<u8, 16usize>> for Simd<u8, 16>'
+// @has foo/struct.Simd.html '//div[@id="trait-implementations-list"]/h3/code' 'impl Add<Simd<u8, 16_usize>> for Simd<u8, 16>'
 impl Add for Simd<u8, 16> {
     type Output = Self;
 

--- a/src/test/ui/array-slice-vec/match_arr_unknown_len.stderr
+++ b/src/test/ui/array-slice-vec/match_arr_unknown_len.stderr
@@ -11,7 +11,7 @@ error[E0308]: mismatched types
   --> $DIR/match_arr_unknown_len.rs:6:9
    |
 LL |         [1, 2] => true,
-   |         ^^^^^^ expected `2usize`, found `N`
+   |         ^^^^^^ expected `2_usize`, found `N`
    |
    = note: expected array `[u32; 2]`
               found array `[u32; N]`

--- a/src/test/ui/associated-const/defaults-not-assumed-fail.stderr
+++ b/src/test/ui/associated-const/defaults-not-assumed-fail.stderr
@@ -4,7 +4,7 @@ error: any use of this value will cause an error
 LL |     const B: u8 = Self::A + 1;
    |     --------------^^^^^^^^^^^-
    |                   |
-   |                   attempt to add with overflow
+   |                   attempt to compute `u8::MAX + 1_u8` which would overflow
    |
    = note: `#[deny(const_err)]` on by default
 

--- a/src/test/ui/associated-const/issue-69020-assoc-const-arith-overflow.noopt.stderr
+++ b/src/test/ui/associated-const/issue-69020-assoc-const-arith-overflow.noopt.stderr
@@ -2,7 +2,7 @@ error: this arithmetic operation will overflow
   --> $DIR/issue-69020-assoc-const-arith-overflow.rs:29:22
    |
 LL |     const NEG: i32 = -i32::MIN + T::NEG;
-   |                      ^^^^^^^^^ attempt to negate with overflow
+   |                      ^^^^^^^^^ attempt to negate i32::MIN which would overflow
    |
    = note: `#[deny(arithmetic_overflow)]` on by default
 
@@ -10,25 +10,25 @@ error: this arithmetic operation will overflow
   --> $DIR/issue-69020-assoc-const-arith-overflow.rs:31:35
    |
 LL |     const NEG_REV: i32 = T::NEG + (-i32::MIN);
-   |                                   ^^^^^^^^^^^ attempt to negate with overflow
+   |                                   ^^^^^^^^^^^ attempt to negate i32::MIN which would overflow
 
 error: this arithmetic operation will overflow
   --> $DIR/issue-69020-assoc-const-arith-overflow.rs:34:22
    |
 LL |     const ADD: i32 = (i32::MAX+1) + T::ADD;
-   |                      ^^^^^^^^^^^^ attempt to add with overflow
+   |                      ^^^^^^^^^^^^ attempt to compute `i32::MAX + 1_i32` which would overflow
 
 error: this arithmetic operation will overflow
   --> $DIR/issue-69020-assoc-const-arith-overflow.rs:36:36
    |
 LL |     const ADD_REV: i32 =  T::ADD + (i32::MAX+1);
-   |                                    ^^^^^^^^^^^^ attempt to add with overflow
+   |                                    ^^^^^^^^^^^^ attempt to compute `i32::MAX + 1_i32` which would overflow
 
 error: this operation will panic at runtime
   --> $DIR/issue-69020-assoc-const-arith-overflow.rs:39:22
    |
 LL |     const DIV: i32 = (1/0) + T::DIV;
-   |                      ^^^^^ attempt to divide by zero
+   |                      ^^^^^ attempt to divide 1_i32 by zero
    |
    = note: `#[deny(unconditional_panic)]` on by default
 
@@ -36,7 +36,7 @@ error: this operation will panic at runtime
   --> $DIR/issue-69020-assoc-const-arith-overflow.rs:41:35
    |
 LL |     const DIV_REV: i32 = T::DIV + (1/0);
-   |                                   ^^^^^ attempt to divide by zero
+   |                                   ^^^^^ attempt to divide 1_i32 by zero
 
 error: this operation will panic at runtime
   --> $DIR/issue-69020-assoc-const-arith-overflow.rs:44:22

--- a/src/test/ui/associated-const/issue-69020-assoc-const-arith-overflow.opt.stderr
+++ b/src/test/ui/associated-const/issue-69020-assoc-const-arith-overflow.opt.stderr
@@ -2,7 +2,7 @@ error: this arithmetic operation will overflow
   --> $DIR/issue-69020-assoc-const-arith-overflow.rs:29:22
    |
 LL |     const NEG: i32 = -i32::MIN + T::NEG;
-   |                      ^^^^^^^^^ attempt to negate with overflow
+   |                      ^^^^^^^^^ attempt to negate i32::MIN which would overflow
    |
    = note: `#[deny(arithmetic_overflow)]` on by default
 
@@ -10,25 +10,25 @@ error: this arithmetic operation will overflow
   --> $DIR/issue-69020-assoc-const-arith-overflow.rs:31:35
    |
 LL |     const NEG_REV: i32 = T::NEG + (-i32::MIN);
-   |                                   ^^^^^^^^^^^ attempt to negate with overflow
+   |                                   ^^^^^^^^^^^ attempt to negate i32::MIN which would overflow
 
 error: this arithmetic operation will overflow
   --> $DIR/issue-69020-assoc-const-arith-overflow.rs:34:22
    |
 LL |     const ADD: i32 = (i32::MAX+1) + T::ADD;
-   |                      ^^^^^^^^^^^^ attempt to add with overflow
+   |                      ^^^^^^^^^^^^ attempt to compute `i32::MAX + 1_i32` which would overflow
 
 error: this arithmetic operation will overflow
   --> $DIR/issue-69020-assoc-const-arith-overflow.rs:36:36
    |
 LL |     const ADD_REV: i32 =  T::ADD + (i32::MAX+1);
-   |                                    ^^^^^^^^^^^^ attempt to add with overflow
+   |                                    ^^^^^^^^^^^^ attempt to compute `i32::MAX + 1_i32` which would overflow
 
 error: this operation will panic at runtime
   --> $DIR/issue-69020-assoc-const-arith-overflow.rs:39:22
    |
 LL |     const DIV: i32 = (1/0) + T::DIV;
-   |                      ^^^^^ attempt to divide by zero
+   |                      ^^^^^ attempt to divide 1_i32 by zero
    |
    = note: `#[deny(unconditional_panic)]` on by default
 
@@ -36,7 +36,7 @@ error: this operation will panic at runtime
   --> $DIR/issue-69020-assoc-const-arith-overflow.rs:41:35
    |
 LL |     const DIV_REV: i32 = T::DIV + (1/0);
-   |                                   ^^^^^ attempt to divide by zero
+   |                                   ^^^^^ attempt to divide 1_i32 by zero
 
 error: this operation will panic at runtime
   --> $DIR/issue-69020-assoc-const-arith-overflow.rs:44:22

--- a/src/test/ui/associated-const/issue-69020-assoc-const-arith-overflow.opt_with_overflow_checks.stderr
+++ b/src/test/ui/associated-const/issue-69020-assoc-const-arith-overflow.opt_with_overflow_checks.stderr
@@ -2,7 +2,7 @@ error: this arithmetic operation will overflow
   --> $DIR/issue-69020-assoc-const-arith-overflow.rs:29:22
    |
 LL |     const NEG: i32 = -i32::MIN + T::NEG;
-   |                      ^^^^^^^^^ attempt to negate with overflow
+   |                      ^^^^^^^^^ attempt to negate i32::MIN which would overflow
    |
    = note: `#[deny(arithmetic_overflow)]` on by default
 
@@ -10,25 +10,25 @@ error: this arithmetic operation will overflow
   --> $DIR/issue-69020-assoc-const-arith-overflow.rs:31:35
    |
 LL |     const NEG_REV: i32 = T::NEG + (-i32::MIN);
-   |                                   ^^^^^^^^^^^ attempt to negate with overflow
+   |                                   ^^^^^^^^^^^ attempt to negate i32::MIN which would overflow
 
 error: this arithmetic operation will overflow
   --> $DIR/issue-69020-assoc-const-arith-overflow.rs:34:22
    |
 LL |     const ADD: i32 = (i32::MAX+1) + T::ADD;
-   |                      ^^^^^^^^^^^^ attempt to add with overflow
+   |                      ^^^^^^^^^^^^ attempt to compute `i32::MAX + 1_i32` which would overflow
 
 error: this arithmetic operation will overflow
   --> $DIR/issue-69020-assoc-const-arith-overflow.rs:36:36
    |
 LL |     const ADD_REV: i32 =  T::ADD + (i32::MAX+1);
-   |                                    ^^^^^^^^^^^^ attempt to add with overflow
+   |                                    ^^^^^^^^^^^^ attempt to compute `i32::MAX + 1_i32` which would overflow
 
 error: this operation will panic at runtime
   --> $DIR/issue-69020-assoc-const-arith-overflow.rs:39:22
    |
 LL |     const DIV: i32 = (1/0) + T::DIV;
-   |                      ^^^^^ attempt to divide by zero
+   |                      ^^^^^ attempt to divide 1_i32 by zero
    |
    = note: `#[deny(unconditional_panic)]` on by default
 
@@ -36,7 +36,7 @@ error: this operation will panic at runtime
   --> $DIR/issue-69020-assoc-const-arith-overflow.rs:41:35
    |
 LL |     const DIV_REV: i32 = T::DIV + (1/0);
-   |                                   ^^^^^ attempt to divide by zero
+   |                                   ^^^^^ attempt to divide 1_i32 by zero
 
 error: this operation will panic at runtime
   --> $DIR/issue-69020-assoc-const-arith-overflow.rs:44:22

--- a/src/test/ui/const-generics/array-impls/into-iter-no-impls-length-33.stderr
+++ b/src/test/ui/const-generics/array-impls/into-iter-no-impls-length-33.stderr
@@ -13,9 +13,9 @@ LL | pub fn no_iterator() -> impl Iterator<Item = i32> {
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::array::LengthAtMost32` is not implemented for `[i32; 33]`
 LL |
 LL |     IntoIter::new([0i32; 33])
-   |     ------------------------- this returned value is of type `std::array::IntoIter<i32, 33usize>`
+   |     ------------------------- this returned value is of type `std::array::IntoIter<i32, 33_usize>`
    |
-   = note: required because of the requirements on the impl of `std::iter::Iterator` for `std::array::IntoIter<i32, 33usize>`
+   = note: required because of the requirements on the impl of `std::iter::Iterator` for `std::array::IntoIter<i32, 33_usize>`
    = note: the return type of a function must have a statically known size
 
 error[E0277]: arrays only have std trait implementations for lengths 0..=32
@@ -33,9 +33,9 @@ LL | pub fn no_double_ended_iterator() -> impl DoubleEndedIterator {
    |                                      ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::array::LengthAtMost32` is not implemented for `[i32; 33]`
 LL |
 LL |     IntoIter::new([0i32; 33])
-   |     ------------------------- this returned value is of type `std::array::IntoIter<i32, 33usize>`
+   |     ------------------------- this returned value is of type `std::array::IntoIter<i32, 33_usize>`
    |
-   = note: required because of the requirements on the impl of `std::iter::DoubleEndedIterator` for `std::array::IntoIter<i32, 33usize>`
+   = note: required because of the requirements on the impl of `std::iter::DoubleEndedIterator` for `std::array::IntoIter<i32, 33_usize>`
    = note: the return type of a function must have a statically known size
 
 error[E0277]: arrays only have std trait implementations for lengths 0..=32
@@ -53,9 +53,9 @@ LL | pub fn no_exact_size_iterator() -> impl ExactSizeIterator {
    |                                    ^^^^^^^^^^^^^^^^^^^^^^ the trait `std::array::LengthAtMost32` is not implemented for `[i32; 33]`
 LL |
 LL |     IntoIter::new([0i32; 33])
-   |     ------------------------- this returned value is of type `std::array::IntoIter<i32, 33usize>`
+   |     ------------------------- this returned value is of type `std::array::IntoIter<i32, 33_usize>`
    |
-   = note: required because of the requirements on the impl of `std::iter::ExactSizeIterator` for `std::array::IntoIter<i32, 33usize>`
+   = note: required because of the requirements on the impl of `std::iter::ExactSizeIterator` for `std::array::IntoIter<i32, 33_usize>`
    = note: the return type of a function must have a statically known size
 
 error[E0277]: arrays only have std trait implementations for lengths 0..=32
@@ -73,9 +73,9 @@ LL | pub fn no_fused_iterator() -> impl FusedIterator {
    |                               ^^^^^^^^^^^^^^^^^^ the trait `std::array::LengthAtMost32` is not implemented for `[i32; 33]`
 LL |
 LL |     IntoIter::new([0i32; 33])
-   |     ------------------------- this returned value is of type `std::array::IntoIter<i32, 33usize>`
+   |     ------------------------- this returned value is of type `std::array::IntoIter<i32, 33_usize>`
    |
-   = note: required because of the requirements on the impl of `std::iter::FusedIterator` for `std::array::IntoIter<i32, 33usize>`
+   = note: required because of the requirements on the impl of `std::iter::FusedIterator` for `std::array::IntoIter<i32, 33_usize>`
    = note: the return type of a function must have a statically known size
 
 error[E0277]: arrays only have std trait implementations for lengths 0..=32
@@ -93,9 +93,9 @@ LL | pub fn no_trusted_len() -> impl TrustedLen {
    |                            ^^^^^^^^^^^^^^^ the trait `std::array::LengthAtMost32` is not implemented for `[i32; 33]`
 LL |
 LL |     IntoIter::new([0i32; 33])
-   |     ------------------------- this returned value is of type `std::array::IntoIter<i32, 33usize>`
+   |     ------------------------- this returned value is of type `std::array::IntoIter<i32, 33_usize>`
    |
-   = note: required because of the requirements on the impl of `std::iter::TrustedLen` for `std::array::IntoIter<i32, 33usize>`
+   = note: required because of the requirements on the impl of `std::iter::TrustedLen` for `std::array::IntoIter<i32, 33_usize>`
    = note: the return type of a function must have a statically known size
 
 error[E0277]: arrays only have std trait implementations for lengths 0..=32
@@ -113,9 +113,9 @@ LL | pub fn no_clone() -> impl Clone {
    |                      ^^^^^^^^^^ the trait `std::array::LengthAtMost32` is not implemented for `[i32; 33]`
 LL |
 LL |     IntoIter::new([0i32; 33])
-   |     ------------------------- this returned value is of type `std::array::IntoIter<i32, 33usize>`
+   |     ------------------------- this returned value is of type `std::array::IntoIter<i32, 33_usize>`
    |
-   = note: required because of the requirements on the impl of `std::clone::Clone` for `std::array::IntoIter<i32, 33usize>`
+   = note: required because of the requirements on the impl of `std::clone::Clone` for `std::array::IntoIter<i32, 33_usize>`
    = note: the return type of a function must have a statically known size
 
 error[E0277]: arrays only have std trait implementations for lengths 0..=32
@@ -133,9 +133,9 @@ LL | pub fn no_debug() -> impl Debug {
    |                      ^^^^^^^^^^ the trait `std::array::LengthAtMost32` is not implemented for `[i32; 33]`
 LL |
 LL |     IntoIter::new([0i32; 33])
-   |     ------------------------- this returned value is of type `std::array::IntoIter<i32, 33usize>`
+   |     ------------------------- this returned value is of type `std::array::IntoIter<i32, 33_usize>`
    |
-   = note: required because of the requirements on the impl of `std::fmt::Debug` for `std::array::IntoIter<i32, 33usize>`
+   = note: required because of the requirements on the impl of `std::fmt::Debug` for `std::array::IntoIter<i32, 33_usize>`
    = note: the return type of a function must have a statically known size
 
 error: aborting due to 14 previous errors

--- a/src/test/ui/const-generics/different_byref.stderr
+++ b/src/test/ui/const-generics/different_byref.stderr
@@ -11,10 +11,10 @@ error[E0308]: mismatched types
   --> $DIR/different_byref.rs:8:9
    |
 LL |     x = Const::<{ [4] }> {};
-   |         ^^^^^^^^^^^^^^^^^^^ expected `3usize`, found `4usize`
+   |         ^^^^^^^^^^^^^^^^^^^ expected `3_usize`, found `4_usize`
    |
-   = note: expected type `[3usize]`
-              found type `[4usize]`
+   = note: expected type `[3_usize]`
+              found type `[4_usize]`
 
 error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui/const-generics/types-mismatch-const-args.stderr
+++ b/src/test/ui/const-generics/types-mismatch-const-args.stderr
@@ -11,10 +11,10 @@ error[E0308]: mismatched types
   --> $DIR/types-mismatch-const-args.rs:13:41
    |
 LL |     let _: A<'a, u32, {2u32}, {3u32}> = A::<'a, u32, {4u32}, {3u32}> { data: PhantomData };
-   |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `2u32`, found `4u32`
+   |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `2_u32`, found `4_u32`
    |
-   = note: expected type `2u32`
-              found type `4u32`
+   = note: expected type `2_u32`
+              found type `4_u32`
 
 error[E0308]: mismatched types
   --> $DIR/types-mismatch-const-args.rs:15:41

--- a/src/test/ui/consts/const-err-early.stderr
+++ b/src/test/ui/consts/const-err-early.stderr
@@ -4,7 +4,7 @@ error: any use of this value will cause an error
 LL | pub const A: i8 = -std::i8::MIN;
    | ------------------^^^^^^^^^^^^^-
    |                   |
-   |                   attempt to negate with overflow
+   |                   attempt to negate i8::MIN which would overflow
    |
 note: the lint level is defined here
   --> $DIR/const-err-early.rs:1:9
@@ -18,7 +18,7 @@ error: any use of this value will cause an error
 LL | pub const B: u8 = 200u8 + 200u8;
    | ------------------^^^^^^^^^^^^^-
    |                   |
-   |                   attempt to add with overflow
+   |                   attempt to compute `200_u8 + 200_u8` which would overflow
 
 error: any use of this value will cause an error
   --> $DIR/const-err-early.rs:5:19
@@ -26,7 +26,7 @@ error: any use of this value will cause an error
 LL | pub const C: u8 = 200u8 * 4;
    | ------------------^^^^^^^^^-
    |                   |
-   |                   attempt to multiply with overflow
+   |                   attempt to compute `200_u8 * 4_u8` which would overflow
 
 error: any use of this value will cause an error
   --> $DIR/const-err-early.rs:6:19
@@ -34,7 +34,7 @@ error: any use of this value will cause an error
 LL | pub const D: u8 = 42u8 - (42u8 + 1);
    | ------------------^^^^^^^^^^^^^^^^^-
    |                   |
-   |                   attempt to subtract with overflow
+   |                   attempt to compute `42_u8 - 43_u8` which would overflow
 
 error: any use of this value will cause an error
   --> $DIR/const-err-early.rs:7:19

--- a/src/test/ui/consts/const-err-multi.stderr
+++ b/src/test/ui/consts/const-err-multi.stderr
@@ -4,7 +4,7 @@ error: any use of this value will cause an error
 LL | pub const A: i8 = -std::i8::MIN;
    | ------------------^^^^^^^^^^^^^-
    |                   |
-   |                   attempt to negate with overflow
+   |                   attempt to negate i8::MIN which would overflow
    |
 note: the lint level is defined here
   --> $DIR/const-err-multi.rs:1:9

--- a/src/test/ui/consts/const-err2.noopt.stderr
+++ b/src/test/ui/consts/const-err2.noopt.stderr
@@ -2,7 +2,7 @@ error: this arithmetic operation will overflow
   --> $DIR/const-err2.rs:19:13
    |
 LL |     let a = -std::i8::MIN;
-   |             ^^^^^^^^^^^^^ attempt to negate with overflow
+   |             ^^^^^^^^^^^^^ attempt to negate i8::MIN which would overflow
    |
    = note: `#[deny(arithmetic_overflow)]` on by default
 
@@ -10,31 +10,31 @@ error: this arithmetic operation will overflow
   --> $DIR/const-err2.rs:21:18
    |
 LL |     let a_i128 = -std::i128::MIN;
-   |                  ^^^^^^^^^^^^^^^ attempt to negate with overflow
+   |                  ^^^^^^^^^^^^^^^ attempt to negate i128::MIN which would overflow
 
 error: this arithmetic operation will overflow
   --> $DIR/const-err2.rs:23:13
    |
 LL |     let b = 200u8 + 200u8 + 200u8;
-   |             ^^^^^^^^^^^^^ attempt to add with overflow
+   |             ^^^^^^^^^^^^^ attempt to compute `200_u8 + 200_u8` which would overflow
 
 error: this arithmetic operation will overflow
   --> $DIR/const-err2.rs:25:18
    |
 LL |     let b_i128 = std::i128::MIN - std::i128::MAX;
-   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attempt to subtract with overflow
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attempt to compute `i128::MIN - i128::MAX` which would overflow
 
 error: this arithmetic operation will overflow
   --> $DIR/const-err2.rs:27:13
    |
 LL |     let c = 200u8 * 4;
-   |             ^^^^^^^^^ attempt to multiply with overflow
+   |             ^^^^^^^^^ attempt to compute `200_u8 * 4_u8` which would overflow
 
 error: this arithmetic operation will overflow
   --> $DIR/const-err2.rs:29:13
    |
 LL |     let d = 42u8 - (42u8 + 1);
-   |             ^^^^^^^^^^^^^^^^^ attempt to subtract with overflow
+   |             ^^^^^^^^^^^^^^^^^ attempt to compute `42_u8 - 43_u8` which would overflow
 
 error: this operation will panic at runtime
   --> $DIR/const-err2.rs:31:14

--- a/src/test/ui/consts/const-err2.opt.stderr
+++ b/src/test/ui/consts/const-err2.opt.stderr
@@ -2,7 +2,7 @@ error: this arithmetic operation will overflow
   --> $DIR/const-err2.rs:19:13
    |
 LL |     let a = -std::i8::MIN;
-   |             ^^^^^^^^^^^^^ attempt to negate with overflow
+   |             ^^^^^^^^^^^^^ attempt to negate i8::MIN which would overflow
    |
    = note: `#[deny(arithmetic_overflow)]` on by default
 
@@ -10,31 +10,31 @@ error: this arithmetic operation will overflow
   --> $DIR/const-err2.rs:21:18
    |
 LL |     let a_i128 = -std::i128::MIN;
-   |                  ^^^^^^^^^^^^^^^ attempt to negate with overflow
+   |                  ^^^^^^^^^^^^^^^ attempt to negate i128::MIN which would overflow
 
 error: this arithmetic operation will overflow
   --> $DIR/const-err2.rs:23:13
    |
 LL |     let b = 200u8 + 200u8 + 200u8;
-   |             ^^^^^^^^^^^^^ attempt to add with overflow
+   |             ^^^^^^^^^^^^^ attempt to compute `200_u8 + 200_u8` which would overflow
 
 error: this arithmetic operation will overflow
   --> $DIR/const-err2.rs:25:18
    |
 LL |     let b_i128 = std::i128::MIN - std::i128::MAX;
-   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attempt to subtract with overflow
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attempt to compute `i128::MIN - i128::MAX` which would overflow
 
 error: this arithmetic operation will overflow
   --> $DIR/const-err2.rs:27:13
    |
 LL |     let c = 200u8 * 4;
-   |             ^^^^^^^^^ attempt to multiply with overflow
+   |             ^^^^^^^^^ attempt to compute `200_u8 * 4_u8` which would overflow
 
 error: this arithmetic operation will overflow
   --> $DIR/const-err2.rs:29:13
    |
 LL |     let d = 42u8 - (42u8 + 1);
-   |             ^^^^^^^^^^^^^^^^^ attempt to subtract with overflow
+   |             ^^^^^^^^^^^^^^^^^ attempt to compute `42_u8 - 43_u8` which would overflow
 
 error: this operation will panic at runtime
   --> $DIR/const-err2.rs:31:14

--- a/src/test/ui/consts/const-err2.opt_with_overflow_checks.stderr
+++ b/src/test/ui/consts/const-err2.opt_with_overflow_checks.stderr
@@ -2,7 +2,7 @@ error: this arithmetic operation will overflow
   --> $DIR/const-err2.rs:19:13
    |
 LL |     let a = -std::i8::MIN;
-   |             ^^^^^^^^^^^^^ attempt to negate with overflow
+   |             ^^^^^^^^^^^^^ attempt to negate i8::MIN which would overflow
    |
    = note: `#[deny(arithmetic_overflow)]` on by default
 
@@ -10,31 +10,31 @@ error: this arithmetic operation will overflow
   --> $DIR/const-err2.rs:21:18
    |
 LL |     let a_i128 = -std::i128::MIN;
-   |                  ^^^^^^^^^^^^^^^ attempt to negate with overflow
+   |                  ^^^^^^^^^^^^^^^ attempt to negate i128::MIN which would overflow
 
 error: this arithmetic operation will overflow
   --> $DIR/const-err2.rs:23:13
    |
 LL |     let b = 200u8 + 200u8 + 200u8;
-   |             ^^^^^^^^^^^^^ attempt to add with overflow
+   |             ^^^^^^^^^^^^^ attempt to compute `200_u8 + 200_u8` which would overflow
 
 error: this arithmetic operation will overflow
   --> $DIR/const-err2.rs:25:18
    |
 LL |     let b_i128 = std::i128::MIN - std::i128::MAX;
-   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attempt to subtract with overflow
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attempt to compute `i128::MIN - i128::MAX` which would overflow
 
 error: this arithmetic operation will overflow
   --> $DIR/const-err2.rs:27:13
    |
 LL |     let c = 200u8 * 4;
-   |             ^^^^^^^^^ attempt to multiply with overflow
+   |             ^^^^^^^^^ attempt to compute `200_u8 * 4_u8` which would overflow
 
 error: this arithmetic operation will overflow
   --> $DIR/const-err2.rs:29:13
    |
 LL |     let d = 42u8 - (42u8 + 1);
-   |             ^^^^^^^^^^^^^^^^^ attempt to subtract with overflow
+   |             ^^^^^^^^^^^^^^^^^ attempt to compute `42_u8 - 43_u8` which would overflow
 
 error: this operation will panic at runtime
   --> $DIR/const-err2.rs:31:14

--- a/src/test/ui/consts/const-eval/conditional_array_execution.stderr
+++ b/src/test/ui/consts/const-eval/conditional_array_execution.stderr
@@ -4,7 +4,7 @@ warning: any use of this value will cause an error
 LL | const FOO: u32 = [X - Y, Y - X][(X < Y) as usize];
    | ------------------^^^^^---------------------------
    |                   |
-   |                   attempt to subtract with overflow
+   |                   attempt to compute `5_u32 - 6_u32` which would overflow
    |
 note: the lint level is defined here
   --> $DIR/conditional_array_execution.rs:3:9

--- a/src/test/ui/consts/const-eval/const-eval-overflow-3.stderr
+++ b/src/test/ui/consts/const-eval/const-eval-overflow-3.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const-eval-overflow-3.rs:20:11
    |
 LL |     = [0; (i8::MAX + 1) as usize];
-   |           ^^^^^^^^^^^^^ attempt to add with overflow
+   |           ^^^^^^^^^^^^^ attempt to compute `i8::MAX + 1_i8` which would overflow
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/const-eval/const-eval-overflow-4.stderr
+++ b/src/test/ui/consts/const-eval/const-eval-overflow-4.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const-eval-overflow-4.rs:13:13
    |
 LL |     : [u32; (i8::MAX as i8 + 1i8) as usize]
-   |             ^^^^^^^^^^^^^^^^^^^^^ attempt to add with overflow
+   |             ^^^^^^^^^^^^^^^^^^^^^ attempt to compute `i8::MAX + 1_i8` which would overflow
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/const-eval/const-eval-overflow2.stderr
+++ b/src/test/ui/consts/const-eval/const-eval-overflow2.stderr
@@ -4,7 +4,7 @@ error: any use of this value will cause an error
 LL | / const VALS_I8: (i8,) =
 LL | |     (
 LL | |      i8::MIN - 1,
-   | |      ^^^^^^^^^^^ attempt to subtract with overflow
+   | |      ^^^^^^^^^^^ attempt to compute `i8::MIN - 1_i8` which would overflow
 LL | |      );
    | |_______-
    |
@@ -20,7 +20,7 @@ error: any use of this value will cause an error
 LL | / const VALS_I16: (i16,) =
 LL | |     (
 LL | |      i16::MIN - 1,
-   | |      ^^^^^^^^^^^^ attempt to subtract with overflow
+   | |      ^^^^^^^^^^^^ attempt to compute `i16::MIN - 1_i16` which would overflow
 LL | |      );
    | |_______-
 
@@ -30,7 +30,7 @@ error: any use of this value will cause an error
 LL | / const VALS_I32: (i32,) =
 LL | |     (
 LL | |      i32::MIN - 1,
-   | |      ^^^^^^^^^^^^ attempt to subtract with overflow
+   | |      ^^^^^^^^^^^^ attempt to compute `i32::MIN - 1_i32` which would overflow
 LL | |      );
    | |_______-
 
@@ -40,7 +40,7 @@ error: any use of this value will cause an error
 LL | / const VALS_I64: (i64,) =
 LL | |     (
 LL | |      i64::MIN - 1,
-   | |      ^^^^^^^^^^^^ attempt to subtract with overflow
+   | |      ^^^^^^^^^^^^ attempt to compute `i64::MIN - 1_i64` which would overflow
 LL | |      );
    | |_______-
 
@@ -50,7 +50,7 @@ error: any use of this value will cause an error
 LL | / const VALS_U8: (u8,) =
 LL | |     (
 LL | |      u8::MIN - 1,
-   | |      ^^^^^^^^^^^ attempt to subtract with overflow
+   | |      ^^^^^^^^^^^ attempt to compute `0_u8 - 1_u8` which would overflow
 LL | |      );
    | |_______-
 
@@ -59,7 +59,7 @@ error: any use of this value will cause an error
    |
 LL | / const VALS_U16: (u16,) = (
 LL | |      u16::MIN - 1,
-   | |      ^^^^^^^^^^^^ attempt to subtract with overflow
+   | |      ^^^^^^^^^^^^ attempt to compute `0_u16 - 1_u16` which would overflow
 LL | |      );
    | |_______-
 
@@ -68,7 +68,7 @@ error: any use of this value will cause an error
    |
 LL | / const VALS_U32: (u32,) = (
 LL | |      u32::MIN - 1,
-   | |      ^^^^^^^^^^^^ attempt to subtract with overflow
+   | |      ^^^^^^^^^^^^ attempt to compute `0_u32 - 1_u32` which would overflow
 LL | |      );
    | |_______-
 
@@ -78,7 +78,7 @@ error: any use of this value will cause an error
 LL | / const VALS_U64: (u64,) =
 LL | |     (
 LL | |      u64::MIN - 1,
-   | |      ^^^^^^^^^^^^ attempt to subtract with overflow
+   | |      ^^^^^^^^^^^^ attempt to compute `0_u64 - 1_u64` which would overflow
 LL | |      );
    | |_______-
 

--- a/src/test/ui/consts/const-eval/const-eval-overflow2b.stderr
+++ b/src/test/ui/consts/const-eval/const-eval-overflow2b.stderr
@@ -4,7 +4,7 @@ error: any use of this value will cause an error
 LL | / const VALS_I8: (i8,) =
 LL | |     (
 LL | |      i8::MAX + 1,
-   | |      ^^^^^^^^^^^ attempt to add with overflow
+   | |      ^^^^^^^^^^^ attempt to compute `i8::MAX + 1_i8` which would overflow
 LL | |      );
    | |_______-
    |
@@ -20,7 +20,7 @@ error: any use of this value will cause an error
 LL | / const VALS_I16: (i16,) =
 LL | |     (
 LL | |      i16::MAX + 1,
-   | |      ^^^^^^^^^^^^ attempt to add with overflow
+   | |      ^^^^^^^^^^^^ attempt to compute `i16::MAX + 1_i16` which would overflow
 LL | |      );
    | |_______-
 
@@ -30,7 +30,7 @@ error: any use of this value will cause an error
 LL | / const VALS_I32: (i32,) =
 LL | |     (
 LL | |      i32::MAX + 1,
-   | |      ^^^^^^^^^^^^ attempt to add with overflow
+   | |      ^^^^^^^^^^^^ attempt to compute `i32::MAX + 1_i32` which would overflow
 LL | |      );
    | |_______-
 
@@ -40,7 +40,7 @@ error: any use of this value will cause an error
 LL | / const VALS_I64: (i64,) =
 LL | |     (
 LL | |      i64::MAX + 1,
-   | |      ^^^^^^^^^^^^ attempt to add with overflow
+   | |      ^^^^^^^^^^^^ attempt to compute `i64::MAX + 1_i64` which would overflow
 LL | |      );
    | |_______-
 
@@ -50,7 +50,7 @@ error: any use of this value will cause an error
 LL | / const VALS_U8: (u8,) =
 LL | |     (
 LL | |      u8::MAX + 1,
-   | |      ^^^^^^^^^^^ attempt to add with overflow
+   | |      ^^^^^^^^^^^ attempt to compute `u8::MAX + 1_u8` which would overflow
 LL | |      );
    | |_______-
 
@@ -59,7 +59,7 @@ error: any use of this value will cause an error
    |
 LL | / const VALS_U16: (u16,) = (
 LL | |      u16::MAX + 1,
-   | |      ^^^^^^^^^^^^ attempt to add with overflow
+   | |      ^^^^^^^^^^^^ attempt to compute `u16::MAX + 1_u16` which would overflow
 LL | |      );
    | |_______-
 
@@ -68,7 +68,7 @@ error: any use of this value will cause an error
    |
 LL | / const VALS_U32: (u32,) = (
 LL | |      u32::MAX + 1,
-   | |      ^^^^^^^^^^^^ attempt to add with overflow
+   | |      ^^^^^^^^^^^^ attempt to compute `u32::MAX + 1_u32` which would overflow
 LL | |      );
    | |_______-
 
@@ -78,7 +78,7 @@ error: any use of this value will cause an error
 LL | / const VALS_U64: (u64,) =
 LL | |     (
 LL | |      u64::MAX + 1,
-   | |      ^^^^^^^^^^^^ attempt to add with overflow
+   | |      ^^^^^^^^^^^^ attempt to compute `u64::MAX + 1_u64` which would overflow
 LL | |      );
    | |_______-
 

--- a/src/test/ui/consts/const-eval/const-eval-overflow2c.stderr
+++ b/src/test/ui/consts/const-eval/const-eval-overflow2c.stderr
@@ -4,7 +4,7 @@ error: any use of this value will cause an error
 LL | / const VALS_I8: (i8,) =
 LL | |     (
 LL | |      i8::MIN * 2,
-   | |      ^^^^^^^^^^^ attempt to multiply with overflow
+   | |      ^^^^^^^^^^^ attempt to compute `i8::MIN * 2_i8` which would overflow
 LL | |      );
    | |_______-
    |
@@ -20,7 +20,7 @@ error: any use of this value will cause an error
 LL | / const VALS_I16: (i16,) =
 LL | |     (
 LL | |      i16::MIN * 2,
-   | |      ^^^^^^^^^^^^ attempt to multiply with overflow
+   | |      ^^^^^^^^^^^^ attempt to compute `i16::MIN * 2_i16` which would overflow
 LL | |      );
    | |_______-
 
@@ -30,7 +30,7 @@ error: any use of this value will cause an error
 LL | / const VALS_I32: (i32,) =
 LL | |     (
 LL | |      i32::MIN * 2,
-   | |      ^^^^^^^^^^^^ attempt to multiply with overflow
+   | |      ^^^^^^^^^^^^ attempt to compute `i32::MIN * 2_i32` which would overflow
 LL | |      );
    | |_______-
 
@@ -40,7 +40,7 @@ error: any use of this value will cause an error
 LL | / const VALS_I64: (i64,) =
 LL | |     (
 LL | |      i64::MIN * 2,
-   | |      ^^^^^^^^^^^^ attempt to multiply with overflow
+   | |      ^^^^^^^^^^^^ attempt to compute `i64::MIN * 2_i64` which would overflow
 LL | |      );
    | |_______-
 
@@ -50,7 +50,7 @@ error: any use of this value will cause an error
 LL | / const VALS_U8: (u8,) =
 LL | |     (
 LL | |      u8::MAX * 2,
-   | |      ^^^^^^^^^^^ attempt to multiply with overflow
+   | |      ^^^^^^^^^^^ attempt to compute `u8::MAX * 2_u8` which would overflow
 LL | |      );
    | |_______-
 
@@ -59,7 +59,7 @@ error: any use of this value will cause an error
    |
 LL | / const VALS_U16: (u16,) = (
 LL | |      u16::MAX * 2,
-   | |      ^^^^^^^^^^^^ attempt to multiply with overflow
+   | |      ^^^^^^^^^^^^ attempt to compute `u16::MAX * 2_u16` which would overflow
 LL | |      );
    | |_______-
 
@@ -68,7 +68,7 @@ error: any use of this value will cause an error
    |
 LL | / const VALS_U32: (u32,) = (
 LL | |      u32::MAX * 2,
-   | |      ^^^^^^^^^^^^ attempt to multiply with overflow
+   | |      ^^^^^^^^^^^^ attempt to compute `u32::MAX * 2_u32` which would overflow
 LL | |      );
    | |_______-
 
@@ -78,7 +78,7 @@ error: any use of this value will cause an error
 LL | / const VALS_U64: (u64,) =
 LL | |     (
 LL | |      u64::MAX * 2,
-   | |      ^^^^^^^^^^^^ attempt to multiply with overflow
+   | |      ^^^^^^^^^^^^ attempt to compute `u64::MAX * 2_u64` which would overflow
 LL | |      );
    | |_______-
 

--- a/src/test/ui/consts/const-eval/issue-43197.stderr
+++ b/src/test/ui/consts/const-eval/issue-43197.stderr
@@ -4,7 +4,7 @@ warning: any use of this value will cause an error
 LL |     const X: u32 = 0 - 1;
    |     ---------------^^^^^-
    |                    |
-   |                    attempt to subtract with overflow
+   |                    attempt to compute `0_u32 - 1_u32` which would overflow
    |
 note: the lint level is defined here
   --> $DIR/issue-43197.rs:3:9
@@ -18,7 +18,7 @@ warning: any use of this value will cause an error
 LL |     const Y: u32 = foo(0 - 1);
    |     -------------------^^^^^--
    |                        |
-   |                        attempt to subtract with overflow
+   |                        attempt to compute `0_u32 - 1_u32` which would overflow
 
 error[E0080]: evaluation of constant expression failed
   --> $DIR/issue-43197.rs:14:23

--- a/src/test/ui/consts/const-eval/issue-50814.stderr
+++ b/src/test/ui/consts/const-eval/issue-50814.stderr
@@ -4,7 +4,7 @@ error: any use of this value will cause an error
 LL |     const MAX: u8 = A::MAX + B::MAX;
    |     ----------------^^^^^^^^^^^^^^^-
    |                     |
-   |                     attempt to add with overflow
+   |                     attempt to compute `u8::MAX + u8::MAX` which would overflow
    |
    = note: `#[deny(const_err)]` on by default
 

--- a/src/test/ui/consts/const-eval/promoted_errors.noopt.stderr
+++ b/src/test/ui/consts/const-eval/promoted_errors.noopt.stderr
@@ -2,7 +2,7 @@ warning: this arithmetic operation will overflow
   --> $DIR/promoted_errors.rs:12:20
    |
 LL |     println!("{}", 0u32 - 1);
-   |                    ^^^^^^^^ attempt to subtract with overflow
+   |                    ^^^^^^^^ attempt to compute `0_u32 - 1_u32` which would overflow
    |
 note: the lint level is defined here
   --> $DIR/promoted_errors.rs:9:20
@@ -14,13 +14,13 @@ warning: this arithmetic operation will overflow
   --> $DIR/promoted_errors.rs:14:14
    |
 LL |     let _x = 0u32 - 1;
-   |              ^^^^^^^^ attempt to subtract with overflow
+   |              ^^^^^^^^ attempt to compute `0_u32 - 1_u32` which would overflow
 
 warning: this operation will panic at runtime
   --> $DIR/promoted_errors.rs:16:20
    |
 LL |     println!("{}", 1 / (1 - 1));
-   |                    ^^^^^^^^^^^ attempt to divide by zero
+   |                    ^^^^^^^^^^^ attempt to divide 1_i32 by zero
    |
 note: the lint level is defined here
   --> $DIR/promoted_errors.rs:9:41
@@ -50,13 +50,13 @@ warning: this operation will panic at runtime
   --> $DIR/promoted_errors.rs:20:14
    |
 LL |     let _x = 1 / (1 - 1);
-   |              ^^^^^^^^^^^ attempt to divide by zero
+   |              ^^^^^^^^^^^ attempt to divide 1_i32 by zero
 
 warning: this operation will panic at runtime
   --> $DIR/promoted_errors.rs:22:20
    |
 LL |     println!("{}", 1 / (false as u32));
-   |                    ^^^^^^^^^^^^^^^^^^ attempt to divide by zero
+   |                    ^^^^^^^^^^^^^^^^^^ attempt to divide 1_u32 by zero
 
 warning: reaching this expression at runtime will panic or abort
   --> $DIR/promoted_errors.rs:22:20
@@ -74,7 +74,7 @@ warning: this operation will panic at runtime
   --> $DIR/promoted_errors.rs:26:14
    |
 LL |     let _x = 1 / (false as u32);
-   |              ^^^^^^^^^^^^^^^^^^ attempt to divide by zero
+   |              ^^^^^^^^^^^^^^^^^^ attempt to divide 1_u32 by zero
 
 warning: 10 warnings emitted
 

--- a/src/test/ui/consts/const-eval/promoted_errors.opt.stderr
+++ b/src/test/ui/consts/const-eval/promoted_errors.opt.stderr
@@ -2,7 +2,7 @@ warning: this arithmetic operation will overflow
   --> $DIR/promoted_errors.rs:14:14
    |
 LL |     let _x = 0u32 - 1;
-   |              ^^^^^^^^ attempt to subtract with overflow
+   |              ^^^^^^^^ attempt to compute `0_u32 - 1_u32` which would overflow
    |
 note: the lint level is defined here
   --> $DIR/promoted_errors.rs:9:20
@@ -14,7 +14,7 @@ warning: this operation will panic at runtime
   --> $DIR/promoted_errors.rs:16:20
    |
 LL |     println!("{}", 1 / (1 - 1));
-   |                    ^^^^^^^^^^^ attempt to divide by zero
+   |                    ^^^^^^^^^^^ attempt to divide 1_i32 by zero
    |
 note: the lint level is defined here
   --> $DIR/promoted_errors.rs:9:41
@@ -44,13 +44,13 @@ warning: this operation will panic at runtime
   --> $DIR/promoted_errors.rs:20:14
    |
 LL |     let _x = 1 / (1 - 1);
-   |              ^^^^^^^^^^^ attempt to divide by zero
+   |              ^^^^^^^^^^^ attempt to divide 1_i32 by zero
 
 warning: this operation will panic at runtime
   --> $DIR/promoted_errors.rs:22:20
    |
 LL |     println!("{}", 1 / (false as u32));
-   |                    ^^^^^^^^^^^^^^^^^^ attempt to divide by zero
+   |                    ^^^^^^^^^^^^^^^^^^ attempt to divide 1_u32 by zero
 
 warning: reaching this expression at runtime will panic or abort
   --> $DIR/promoted_errors.rs:22:20
@@ -68,7 +68,7 @@ warning: this operation will panic at runtime
   --> $DIR/promoted_errors.rs:26:14
    |
 LL |     let _x = 1 / (false as u32);
-   |              ^^^^^^^^^^^^^^^^^^ attempt to divide by zero
+   |              ^^^^^^^^^^^^^^^^^^ attempt to divide 1_u32 by zero
 
 warning: 9 warnings emitted
 

--- a/src/test/ui/consts/const-eval/promoted_errors.opt_with_overflow_checks.stderr
+++ b/src/test/ui/consts/const-eval/promoted_errors.opt_with_overflow_checks.stderr
@@ -2,7 +2,7 @@ warning: this arithmetic operation will overflow
   --> $DIR/promoted_errors.rs:12:20
    |
 LL |     println!("{}", 0u32 - 1);
-   |                    ^^^^^^^^ attempt to subtract with overflow
+   |                    ^^^^^^^^ attempt to compute `0_u32 - 1_u32` which would overflow
    |
 note: the lint level is defined here
   --> $DIR/promoted_errors.rs:9:20
@@ -14,13 +14,13 @@ warning: this arithmetic operation will overflow
   --> $DIR/promoted_errors.rs:14:14
    |
 LL |     let _x = 0u32 - 1;
-   |              ^^^^^^^^ attempt to subtract with overflow
+   |              ^^^^^^^^ attempt to compute `0_u32 - 1_u32` which would overflow
 
 warning: this operation will panic at runtime
   --> $DIR/promoted_errors.rs:16:20
    |
 LL |     println!("{}", 1 / (1 - 1));
-   |                    ^^^^^^^^^^^ attempt to divide by zero
+   |                    ^^^^^^^^^^^ attempt to divide 1_i32 by zero
    |
 note: the lint level is defined here
   --> $DIR/promoted_errors.rs:9:41
@@ -50,13 +50,13 @@ warning: this operation will panic at runtime
   --> $DIR/promoted_errors.rs:20:14
    |
 LL |     let _x = 1 / (1 - 1);
-   |              ^^^^^^^^^^^ attempt to divide by zero
+   |              ^^^^^^^^^^^ attempt to divide 1_i32 by zero
 
 warning: this operation will panic at runtime
   --> $DIR/promoted_errors.rs:22:20
    |
 LL |     println!("{}", 1 / (false as u32));
-   |                    ^^^^^^^^^^^^^^^^^^ attempt to divide by zero
+   |                    ^^^^^^^^^^^^^^^^^^ attempt to divide 1_u32 by zero
 
 warning: reaching this expression at runtime will panic or abort
   --> $DIR/promoted_errors.rs:22:20
@@ -74,7 +74,7 @@ warning: this operation will panic at runtime
   --> $DIR/promoted_errors.rs:26:14
    |
 LL |     let _x = 1 / (false as u32);
-   |              ^^^^^^^^^^^^^^^^^^ attempt to divide by zero
+   |              ^^^^^^^^^^^^^^^^^^ attempt to divide 1_u32 by zero
 
 warning: 10 warnings emitted
 

--- a/src/test/ui/consts/const-eval/pub_const_err.stderr
+++ b/src/test/ui/consts/const-eval/pub_const_err.stderr
@@ -4,7 +4,7 @@ warning: any use of this value will cause an error
 LL | pub const Z: u32 = 0 - 1;
    | -------------------^^^^^-
    |                    |
-   |                    attempt to subtract with overflow
+   |                    attempt to compute `0_u32 - 1_u32` which would overflow
    |
 note: the lint level is defined here
   --> $DIR/pub_const_err.rs:2:9

--- a/src/test/ui/consts/const-eval/pub_const_err_bin.stderr
+++ b/src/test/ui/consts/const-eval/pub_const_err_bin.stderr
@@ -4,7 +4,7 @@ warning: any use of this value will cause an error
 LL | pub const Z: u32 = 0 - 1;
    | -------------------^^^^^-
    |                    |
-   |                    attempt to subtract with overflow
+   |                    attempt to compute `0_u32 - 1_u32` which would overflow
    |
 note: the lint level is defined here
   --> $DIR/pub_const_err_bin.rs:2:9

--- a/src/test/ui/consts/const-eval/shift_overflow.stderr
+++ b/src/test/ui/consts/const-eval/shift_overflow.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/shift_overflow.rs:3:9
    |
 LL |     X = 1 << ((u32::MAX as u64) + 1),
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attempt to shift left with overflow
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attempt to shift left by 4294967296_u64 which would overflow
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/const-len-underflow-separate-spans.stderr
+++ b/src/test/ui/consts/const-len-underflow-separate-spans.stderr
@@ -4,7 +4,7 @@ error: any use of this value will cause an error
 LL | const LEN: usize = ONE - TWO;
    | -------------------^^^^^^^^^-
    |                    |
-   |                    attempt to subtract with overflow
+   |                    attempt to compute `1_usize - 2_usize` which would overflow
    |
    = note: `#[deny(const_err)]` on by default
 

--- a/src/test/ui/consts/const-len-underflow-subspans.rs
+++ b/src/test/ui/consts/const-len-underflow-subspans.rs
@@ -7,5 +7,5 @@ const TWO: usize = 2;
 fn main() {
     let a: [i8; ONE - TWO] = unimplemented!();
     //~^ ERROR evaluation of constant value failed
-    //~| attempt to subtract with overflow
+    //~| attempt to compute `1_usize - 2_usize` which would overflow
 }

--- a/src/test/ui/consts/const-len-underflow-subspans.stderr
+++ b/src/test/ui/consts/const-len-underflow-subspans.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const-len-underflow-subspans.rs:8:17
    |
 LL |     let a: [i8; ONE - TWO] = unimplemented!();
-   |                 ^^^^^^^^^ attempt to subtract with overflow
+   |                 ^^^^^^^^^ attempt to compute `1_usize - 2_usize` which would overflow
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/const-match-check.eval1.stderr
+++ b/src/test/ui/consts/const-match-check.eval1.stderr
@@ -1,8 +1,8 @@
-error[E0005]: refutable pattern in local binding: `i32::MIN..=-1i32` and `1i32..=i32::MAX` not covered
+error[E0005]: refutable pattern in local binding: `i32::MIN..=-1_i32` and `1_i32..=i32::MAX` not covered
   --> $DIR/const-match-check.rs:25:15
    |
 LL |     A = { let 0 = 0; 0 },
-   |               ^ patterns `i32::MIN..=-1i32` and `1i32..=i32::MAX` not covered
+   |               ^ patterns `i32::MIN..=-1_i32` and `1_i32..=i32::MAX` not covered
    |
    = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
    = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html

--- a/src/test/ui/consts/const-match-check.eval2.stderr
+++ b/src/test/ui/consts/const-match-check.eval2.stderr
@@ -1,8 +1,8 @@
-error[E0005]: refutable pattern in local binding: `i32::MIN..=-1i32` and `1i32..=i32::MAX` not covered
+error[E0005]: refutable pattern in local binding: `i32::MIN..=-1_i32` and `1_i32..=i32::MAX` not covered
   --> $DIR/const-match-check.rs:31:24
    |
 LL |     let x: [i32; { let 0 = 0; 0 }] = [];
-   |                        ^ patterns `i32::MIN..=-1i32` and `1i32..=i32::MAX` not covered
+   |                        ^ patterns `i32::MIN..=-1_i32` and `1_i32..=i32::MAX` not covered
    |
    = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
    = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html

--- a/src/test/ui/consts/const-match-check.matchck.stderr
+++ b/src/test/ui/consts/const-match-check.matchck.stderr
@@ -1,8 +1,8 @@
-error[E0005]: refutable pattern in local binding: `i32::MIN..=-1i32` and `1i32..=i32::MAX` not covered
+error[E0005]: refutable pattern in local binding: `i32::MIN..=-1_i32` and `1_i32..=i32::MAX` not covered
   --> $DIR/const-match-check.rs:4:22
    |
 LL | const X: i32 = { let 0 = 0; 0 };
-   |                      ^ patterns `i32::MIN..=-1i32` and `1i32..=i32::MAX` not covered
+   |                      ^ patterns `i32::MIN..=-1_i32` and `1_i32..=i32::MAX` not covered
    |
    = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
    = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
@@ -12,11 +12,11 @@ help: you might want to use `if let` to ignore the variant that isn't matched
 LL | const X: i32 = { if let 0 = 0 { /* */ } 0 };
    |                  ^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0005]: refutable pattern in local binding: `i32::MIN..=-1i32` and `1i32..=i32::MAX` not covered
+error[E0005]: refutable pattern in local binding: `i32::MIN..=-1_i32` and `1_i32..=i32::MAX` not covered
   --> $DIR/const-match-check.rs:8:23
    |
 LL | static Y: i32 = { let 0 = 0; 0 };
-   |                       ^ patterns `i32::MIN..=-1i32` and `1i32..=i32::MAX` not covered
+   |                       ^ patterns `i32::MIN..=-1_i32` and `1_i32..=i32::MAX` not covered
    |
    = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
    = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
@@ -26,11 +26,11 @@ help: you might want to use `if let` to ignore the variant that isn't matched
 LL | static Y: i32 = { if let 0 = 0 { /* */ } 0 };
    |                   ^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0005]: refutable pattern in local binding: `i32::MIN..=-1i32` and `1i32..=i32::MAX` not covered
+error[E0005]: refutable pattern in local binding: `i32::MIN..=-1_i32` and `1_i32..=i32::MAX` not covered
   --> $DIR/const-match-check.rs:13:26
    |
 LL |     const X: i32 = { let 0 = 0; 0 };
-   |                          ^ patterns `i32::MIN..=-1i32` and `1i32..=i32::MAX` not covered
+   |                          ^ patterns `i32::MIN..=-1_i32` and `1_i32..=i32::MAX` not covered
    |
    = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
    = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
@@ -40,11 +40,11 @@ help: you might want to use `if let` to ignore the variant that isn't matched
 LL |     const X: i32 = { if let 0 = 0 { /* */ } 0 };
    |                      ^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0005]: refutable pattern in local binding: `i32::MIN..=-1i32` and `1i32..=i32::MAX` not covered
+error[E0005]: refutable pattern in local binding: `i32::MIN..=-1_i32` and `1_i32..=i32::MAX` not covered
   --> $DIR/const-match-check.rs:19:26
    |
 LL |     const X: i32 = { let 0 = 0; 0 };
-   |                          ^ patterns `i32::MIN..=-1i32` and `1i32..=i32::MAX` not covered
+   |                          ^ patterns `i32::MIN..=-1_i32` and `1_i32..=i32::MAX` not covered
    |
    = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
    = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html

--- a/src/test/ui/consts/const-pattern-irrefutable.rs
+++ b/src/test/ui/consts/const-pattern-irrefutable.rs
@@ -9,8 +9,8 @@ use foo::d;
 const a: u8 = 2;
 
 fn main() {
-    let a = 4; //~ ERROR refutable pattern in local binding: `0u8..=1u8` and `3u8..=u8::MAX
-    let c = 4; //~ ERROR refutable pattern in local binding: `0u8..=1u8` and `3u8..=u8::MAX
-    let d = 4; //~ ERROR refutable pattern in local binding: `0u8..=1u8` and `3u8..=u8::MAX
+    let a = 4; //~ ERROR refutable pattern in local binding: `0_u8..=1_u8` and `3_u8..=u8::MAX
+    let c = 4; //~ ERROR refutable pattern in local binding: `0_u8..=1_u8` and `3_u8..=u8::MAX
+    let d = 4; //~ ERROR refutable pattern in local binding: `0_u8..=1_u8` and `3_u8..=u8::MAX
     fn f() {} // Check that the `NOTE`s still work with an item here (cf. issue #35115).
 }

--- a/src/test/ui/consts/const-pattern-irrefutable.stderr
+++ b/src/test/ui/consts/const-pattern-irrefutable.stderr
@@ -1,4 +1,4 @@
-error[E0005]: refutable pattern in local binding: `0u8..=1u8` and `3u8..=u8::MAX` not covered
+error[E0005]: refutable pattern in local binding: `0_u8..=1_u8` and `3_u8..=u8::MAX` not covered
   --> $DIR/const-pattern-irrefutable.rs:12:9
    |
 LL | const a: u8 = 2;
@@ -12,7 +12,7 @@ LL |     let a = 4;
    |
    = note: the matched value is of type `u8`
 
-error[E0005]: refutable pattern in local binding: `0u8..=1u8` and `3u8..=u8::MAX` not covered
+error[E0005]: refutable pattern in local binding: `0_u8..=1_u8` and `3_u8..=u8::MAX` not covered
   --> $DIR/const-pattern-irrefutable.rs:13:9
    |
 LL |     pub const b: u8 = 2;
@@ -26,7 +26,7 @@ LL |     let c = 4;
    |
    = note: the matched value is of type `u8`
 
-error[E0005]: refutable pattern in local binding: `0u8..=1u8` and `3u8..=u8::MAX` not covered
+error[E0005]: refutable pattern in local binding: `0_u8..=1_u8` and `3_u8..=u8::MAX` not covered
   --> $DIR/const-pattern-irrefutable.rs:14:9
    |
 LL |     pub const d: u8 = 2;

--- a/src/test/ui/consts/offset_from_ub.stderr
+++ b/src/test/ui/consts/offset_from_ub.stderr
@@ -45,7 +45,7 @@ error: any use of this value will cause an error
 LL |           intrinsics::ptr_offset_from(self, origin)
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |           |
-   |           exact_div: 1isize cannot be divided by 2isize without remainder
+   |           exact_div: 1_isize cannot be divided by 2_isize without remainder
    |           inside `std::ptr::const_ptr::<impl *const u16>::offset_from` at $SRC_DIR/libcore/ptr/const_ptr.rs:LL:COL
    |           inside `NOT_MULTIPLE_OF_SIZE` at $DIR/offset_from_ub.rs:31:14
    | 

--- a/src/test/ui/error-codes/E0080.rs
+++ b/src/test/ui/error-codes/E0080.rs
@@ -1,6 +1,6 @@
 enum Enum {
     X = (1 << 500), //~ ERROR E0080
-    //~| shift left with overflow
+    //~| attempt to shift left by 500_i32 which would overflow
     Y = (1 / 0) //~ ERROR E0080
 }
 

--- a/src/test/ui/error-codes/E0080.stderr
+++ b/src/test/ui/error-codes/E0080.stderr
@@ -2,13 +2,13 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/E0080.rs:2:9
    |
 LL |     X = (1 << 500),
-   |         ^^^^^^^^^^ attempt to shift left with overflow
+   |         ^^^^^^^^^^ attempt to shift left by 500_i32 which would overflow
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/E0080.rs:4:9
    |
 LL |     Y = (1 / 0)
-   |         ^^^^^^^ attempt to divide by zero
+   |         ^^^^^^^ attempt to divide 1_isize by zero
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/eval-enum.rs
+++ b/src/test/ui/eval-enum.rs
@@ -1,9 +1,9 @@
 enum Test {
     DivZero = 1/0,
-    //~^ attempt to divide by zero
+    //~^ attempt to divide 1_isize by zero
     //~| ERROR evaluation of constant value failed
     RemZero = 1%0,
-    //~^ attempt to calculate the remainder with a divisor of zero
+    //~^ attempt to calculate the remainder of 1_isize with a divisor of zero
     //~| ERROR evaluation of constant value failed
 }
 

--- a/src/test/ui/eval-enum.stderr
+++ b/src/test/ui/eval-enum.stderr
@@ -2,13 +2,13 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/eval-enum.rs:2:15
    |
 LL |     DivZero = 1/0,
-   |               ^^^ attempt to divide by zero
+   |               ^^^ attempt to divide 1_isize by zero
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/eval-enum.rs:5:15
    |
 LL |     RemZero = 1%0,
-   |               ^^^ attempt to calculate the remainder with a divisor of zero
+   |               ^^^ attempt to calculate the remainder of 1_isize with a divisor of zero
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/for/for-loop-refutable-pattern-error-message.stderr
+++ b/src/test/ui/for/for-loop-refutable-pattern-error-message.stderr
@@ -1,8 +1,8 @@
-error[E0005]: refutable pattern in `for` loop binding: `&i32::MIN..=0i32` and `&2i32..=i32::MAX` not covered
+error[E0005]: refutable pattern in `for` loop binding: `&i32::MIN..=0_i32` and `&2_i32..=i32::MAX` not covered
   --> $DIR/for-loop-refutable-pattern-error-message.rs:2:9
    |
 LL |     for &1 in [1].iter() {}
-   |         ^^ patterns `&i32::MIN..=0i32` and `&2i32..=i32::MAX` not covered
+   |         ^^ patterns `&i32::MIN..=0_i32` and `&2_i32..=i32::MAX` not covered
    |
    = note: the matched value is of type `&i32`
 

--- a/src/test/ui/half-open-range-patterns/half-open-range-pats-exhaustive-fail.stderr
+++ b/src/test/ui/half-open-range-patterns/half-open-range-pats-exhaustive-fail.stderr
@@ -79,20 +79,20 @@ LL |         m!(0, ..core::u8::MAX);
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `u8`
 
-error[E0004]: non-exhaustive patterns: `254u8..=u8::MAX` not covered
+error[E0004]: non-exhaustive patterns: `254_u8..=u8::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:42:12
    |
 LL |         m!(0, ..ALMOST_MAX);
-   |            ^ pattern `254u8..=u8::MAX` not covered
+   |            ^ pattern `254_u8..=u8::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `u8`
 
-error[E0004]: non-exhaustive patterns: `0u8` not covered
+error[E0004]: non-exhaustive patterns: `0_u8` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:43:12
    |
 LL |         m!(0, ALMOST_MIN..);
-   |            ^ pattern `0u8` not covered
+   |            ^ pattern `0_u8` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `u8`
@@ -106,20 +106,20 @@ LL |         m!(0, ..=ALMOST_MAX);
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `u8`
 
-error[E0004]: non-exhaustive patterns: `43u8` not covered
+error[E0004]: non-exhaustive patterns: `43_u8` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:45:12
    |
 LL |         m!(0, ..=VAL | VAL_2..);
-   |            ^ pattern `43u8` not covered
+   |            ^ pattern `43_u8` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `u8`
 
-error[E0004]: non-exhaustive patterns: `43u8` not covered
+error[E0004]: non-exhaustive patterns: `43_u8` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:46:12
    |
 LL |         m!(0, ..VAL_1 | VAL_2..);
-   |            ^ pattern `43u8` not covered
+   |            ^ pattern `43_u8` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `u8`
@@ -133,20 +133,20 @@ LL |         m!(0, ..core::u16::MAX);
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `u16`
 
-error[E0004]: non-exhaustive patterns: `65534u16..=u16::MAX` not covered
+error[E0004]: non-exhaustive patterns: `65534_u16..=u16::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:55:12
    |
 LL |         m!(0, ..ALMOST_MAX);
-   |            ^ pattern `65534u16..=u16::MAX` not covered
+   |            ^ pattern `65534_u16..=u16::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `u16`
 
-error[E0004]: non-exhaustive patterns: `0u16` not covered
+error[E0004]: non-exhaustive patterns: `0_u16` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:56:12
    |
 LL |         m!(0, ALMOST_MIN..);
-   |            ^ pattern `0u16` not covered
+   |            ^ pattern `0_u16` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `u16`
@@ -160,20 +160,20 @@ LL |         m!(0, ..=ALMOST_MAX);
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `u16`
 
-error[E0004]: non-exhaustive patterns: `43u16` not covered
+error[E0004]: non-exhaustive patterns: `43_u16` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:58:12
    |
 LL |         m!(0, ..=VAL | VAL_2..);
-   |            ^ pattern `43u16` not covered
+   |            ^ pattern `43_u16` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `u16`
 
-error[E0004]: non-exhaustive patterns: `43u16` not covered
+error[E0004]: non-exhaustive patterns: `43_u16` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:59:12
    |
 LL |         m!(0, ..VAL_1 | VAL_2..);
-   |            ^ pattern `43u16` not covered
+   |            ^ pattern `43_u16` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `u16`
@@ -187,20 +187,20 @@ LL |         m!(0, ..core::u32::MAX);
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `u32`
 
-error[E0004]: non-exhaustive patterns: `4294967294u32..=u32::MAX` not covered
+error[E0004]: non-exhaustive patterns: `4294967294_u32..=u32::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:68:12
    |
 LL |         m!(0, ..ALMOST_MAX);
-   |            ^ pattern `4294967294u32..=u32::MAX` not covered
+   |            ^ pattern `4294967294_u32..=u32::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `u32`
 
-error[E0004]: non-exhaustive patterns: `0u32` not covered
+error[E0004]: non-exhaustive patterns: `0_u32` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:69:12
    |
 LL |         m!(0, ALMOST_MIN..);
-   |            ^ pattern `0u32` not covered
+   |            ^ pattern `0_u32` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `u32`
@@ -214,20 +214,20 @@ LL |         m!(0, ..=ALMOST_MAX);
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `u32`
 
-error[E0004]: non-exhaustive patterns: `43u32` not covered
+error[E0004]: non-exhaustive patterns: `43_u32` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:71:12
    |
 LL |         m!(0, ..=VAL | VAL_2..);
-   |            ^ pattern `43u32` not covered
+   |            ^ pattern `43_u32` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `u32`
 
-error[E0004]: non-exhaustive patterns: `43u32` not covered
+error[E0004]: non-exhaustive patterns: `43_u32` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:72:12
    |
 LL |         m!(0, ..VAL_1 | VAL_2..);
-   |            ^ pattern `43u32` not covered
+   |            ^ pattern `43_u32` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `u32`
@@ -241,20 +241,20 @@ LL |         m!(0, ..core::u64::MAX);
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `u64`
 
-error[E0004]: non-exhaustive patterns: `18446744073709551614u64..=u64::MAX` not covered
+error[E0004]: non-exhaustive patterns: `18446744073709551614_u64..=u64::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:81:12
    |
 LL |         m!(0, ..ALMOST_MAX);
-   |            ^ pattern `18446744073709551614u64..=u64::MAX` not covered
+   |            ^ pattern `18446744073709551614_u64..=u64::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `u64`
 
-error[E0004]: non-exhaustive patterns: `0u64` not covered
+error[E0004]: non-exhaustive patterns: `0_u64` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:82:12
    |
 LL |         m!(0, ALMOST_MIN..);
-   |            ^ pattern `0u64` not covered
+   |            ^ pattern `0_u64` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `u64`
@@ -268,20 +268,20 @@ LL |         m!(0, ..=ALMOST_MAX);
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `u64`
 
-error[E0004]: non-exhaustive patterns: `43u64` not covered
+error[E0004]: non-exhaustive patterns: `43_u64` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:84:12
    |
 LL |         m!(0, ..=VAL | VAL_2..);
-   |            ^ pattern `43u64` not covered
+   |            ^ pattern `43_u64` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `u64`
 
-error[E0004]: non-exhaustive patterns: `43u64` not covered
+error[E0004]: non-exhaustive patterns: `43_u64` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:85:12
    |
 LL |         m!(0, ..VAL_1 | VAL_2..);
-   |            ^ pattern `43u64` not covered
+   |            ^ pattern `43_u64` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `u64`
@@ -295,20 +295,20 @@ LL |         m!(0, ..core::u128::MAX);
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `u128`
 
-error[E0004]: non-exhaustive patterns: `340282366920938463463374607431768211454u128..=u128::MAX` not covered
+error[E0004]: non-exhaustive patterns: `340282366920938463463374607431768211454_u128..=u128::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:94:12
    |
 LL |         m!(0, ..ALMOST_MAX);
-   |            ^ pattern `340282366920938463463374607431768211454u128..=u128::MAX` not covered
+   |            ^ pattern `340282366920938463463374607431768211454_u128..=u128::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `u128`
 
-error[E0004]: non-exhaustive patterns: `0u128` not covered
+error[E0004]: non-exhaustive patterns: `0_u128` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:95:12
    |
 LL |         m!(0, ALMOST_MIN..);
-   |            ^ pattern `0u128` not covered
+   |            ^ pattern `0_u128` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `u128`
@@ -322,20 +322,20 @@ LL |         m!(0, ..=ALMOST_MAX);
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `u128`
 
-error[E0004]: non-exhaustive patterns: `43u128` not covered
+error[E0004]: non-exhaustive patterns: `43_u128` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:97:12
    |
 LL |         m!(0, ..=VAL | VAL_2..);
-   |            ^ pattern `43u128` not covered
+   |            ^ pattern `43_u128` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `u128`
 
-error[E0004]: non-exhaustive patterns: `43u128` not covered
+error[E0004]: non-exhaustive patterns: `43_u128` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:98:12
    |
 LL |         m!(0, ..VAL_1 | VAL_2..);
-   |            ^ pattern `43u128` not covered
+   |            ^ pattern `43_u128` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `u128`
@@ -349,11 +349,11 @@ LL |         m!(0, ..core::i8::MAX);
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `i8`
 
-error[E0004]: non-exhaustive patterns: `126i8..=i8::MAX` not covered
+error[E0004]: non-exhaustive patterns: `126_i8..=i8::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:110:12
    |
 LL |         m!(0, ..ALMOST_MAX);
-   |            ^ pattern `126i8..=i8::MAX` not covered
+   |            ^ pattern `126_i8..=i8::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `i8`
@@ -376,20 +376,20 @@ LL |         m!(0, ..=ALMOST_MAX);
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `i8`
 
-error[E0004]: non-exhaustive patterns: `43i8` not covered
+error[E0004]: non-exhaustive patterns: `43_i8` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:113:12
    |
 LL |         m!(0, ..=VAL | VAL_2..);
-   |            ^ pattern `43i8` not covered
+   |            ^ pattern `43_i8` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `i8`
 
-error[E0004]: non-exhaustive patterns: `43i8` not covered
+error[E0004]: non-exhaustive patterns: `43_i8` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:114:12
    |
 LL |         m!(0, ..VAL_1 | VAL_2..);
-   |            ^ pattern `43i8` not covered
+   |            ^ pattern `43_i8` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `i8`
@@ -403,11 +403,11 @@ LL |         m!(0, ..core::i16::MAX);
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `i16`
 
-error[E0004]: non-exhaustive patterns: `32766i16..=i16::MAX` not covered
+error[E0004]: non-exhaustive patterns: `32766_i16..=i16::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:123:12
    |
 LL |         m!(0, ..ALMOST_MAX);
-   |            ^ pattern `32766i16..=i16::MAX` not covered
+   |            ^ pattern `32766_i16..=i16::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `i16`
@@ -430,20 +430,20 @@ LL |         m!(0, ..=ALMOST_MAX);
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `i16`
 
-error[E0004]: non-exhaustive patterns: `43i16` not covered
+error[E0004]: non-exhaustive patterns: `43_i16` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:126:12
    |
 LL |         m!(0, ..=VAL | VAL_2..);
-   |            ^ pattern `43i16` not covered
+   |            ^ pattern `43_i16` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `i16`
 
-error[E0004]: non-exhaustive patterns: `43i16` not covered
+error[E0004]: non-exhaustive patterns: `43_i16` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:127:12
    |
 LL |         m!(0, ..VAL_1 | VAL_2..);
-   |            ^ pattern `43i16` not covered
+   |            ^ pattern `43_i16` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `i16`
@@ -457,11 +457,11 @@ LL |         m!(0, ..core::i32::MAX);
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `i32`
 
-error[E0004]: non-exhaustive patterns: `2147483646i32..=i32::MAX` not covered
+error[E0004]: non-exhaustive patterns: `2147483646_i32..=i32::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:136:12
    |
 LL |         m!(0, ..ALMOST_MAX);
-   |            ^ pattern `2147483646i32..=i32::MAX` not covered
+   |            ^ pattern `2147483646_i32..=i32::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `i32`
@@ -484,20 +484,20 @@ LL |         m!(0, ..=ALMOST_MAX);
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `i32`
 
-error[E0004]: non-exhaustive patterns: `43i32` not covered
+error[E0004]: non-exhaustive patterns: `43_i32` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:139:12
    |
 LL |         m!(0, ..=VAL | VAL_2..);
-   |            ^ pattern `43i32` not covered
+   |            ^ pattern `43_i32` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `i32`
 
-error[E0004]: non-exhaustive patterns: `43i32` not covered
+error[E0004]: non-exhaustive patterns: `43_i32` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:140:12
    |
 LL |         m!(0, ..VAL_1 | VAL_2..);
-   |            ^ pattern `43i32` not covered
+   |            ^ pattern `43_i32` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `i32`
@@ -511,11 +511,11 @@ LL |         m!(0, ..core::i64::MAX);
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `i64`
 
-error[E0004]: non-exhaustive patterns: `9223372036854775806i64..=i64::MAX` not covered
+error[E0004]: non-exhaustive patterns: `9223372036854775806_i64..=i64::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:149:12
    |
 LL |         m!(0, ..ALMOST_MAX);
-   |            ^ pattern `9223372036854775806i64..=i64::MAX` not covered
+   |            ^ pattern `9223372036854775806_i64..=i64::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `i64`
@@ -538,20 +538,20 @@ LL |         m!(0, ..=ALMOST_MAX);
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `i64`
 
-error[E0004]: non-exhaustive patterns: `43i64` not covered
+error[E0004]: non-exhaustive patterns: `43_i64` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:152:12
    |
 LL |         m!(0, ..=VAL | VAL_2..);
-   |            ^ pattern `43i64` not covered
+   |            ^ pattern `43_i64` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `i64`
 
-error[E0004]: non-exhaustive patterns: `43i64` not covered
+error[E0004]: non-exhaustive patterns: `43_i64` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:153:12
    |
 LL |         m!(0, ..VAL_1 | VAL_2..);
-   |            ^ pattern `43i64` not covered
+   |            ^ pattern `43_i64` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `i64`
@@ -565,11 +565,11 @@ LL |         m!(0, ..core::i128::MAX);
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `i128`
 
-error[E0004]: non-exhaustive patterns: `170141183460469231731687303715884105726i128..=i128::MAX` not covered
+error[E0004]: non-exhaustive patterns: `170141183460469231731687303715884105726_i128..=i128::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:162:12
    |
 LL |         m!(0, ..ALMOST_MAX);
-   |            ^ pattern `170141183460469231731687303715884105726i128..=i128::MAX` not covered
+   |            ^ pattern `170141183460469231731687303715884105726_i128..=i128::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `i128`
@@ -592,20 +592,20 @@ LL |         m!(0, ..=ALMOST_MAX);
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `i128`
 
-error[E0004]: non-exhaustive patterns: `43i128` not covered
+error[E0004]: non-exhaustive patterns: `43_i128` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:165:12
    |
 LL |         m!(0, ..=VAL | VAL_2..);
-   |            ^ pattern `43i128` not covered
+   |            ^ pattern `43_i128` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `i128`
 
-error[E0004]: non-exhaustive patterns: `43i128` not covered
+error[E0004]: non-exhaustive patterns: `43_i128` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:166:12
    |
 LL |         m!(0, ..VAL_1 | VAL_2..);
-   |            ^ pattern `43i128` not covered
+   |            ^ pattern `43_i128` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `i128`

--- a/src/test/ui/issues/issue-8460-const.noopt.stderr
+++ b/src/test/ui/issues/issue-8460-const.noopt.stderr
@@ -2,7 +2,7 @@ error: this arithmetic operation will overflow
   --> $DIR/issue-8460-const.rs:14:36
    |
 LL |     assert!(thread::spawn(move|| { isize::MIN / -1; }).join().is_err());
-   |                                    ^^^^^^^^^^^^^^^ attempt to divide with overflow
+   |                                    ^^^^^^^^^^^^^^^ attempt to compute `isize::MIN / -1_isize` which would overflow
    |
    = note: `#[deny(arithmetic_overflow)]` on by default
 
@@ -10,37 +10,37 @@ error: this arithmetic operation will overflow
   --> $DIR/issue-8460-const.rs:16:36
    |
 LL |     assert!(thread::spawn(move|| { i8::MIN / -1; }).join().is_err());
-   |                                    ^^^^^^^^^^^^ attempt to divide with overflow
+   |                                    ^^^^^^^^^^^^ attempt to compute `i8::MIN / -1_i8` which would overflow
 
 error: this arithmetic operation will overflow
   --> $DIR/issue-8460-const.rs:18:36
    |
 LL |     assert!(thread::spawn(move|| { i16::MIN / -1; }).join().is_err());
-   |                                    ^^^^^^^^^^^^^ attempt to divide with overflow
+   |                                    ^^^^^^^^^^^^^ attempt to compute `i16::MIN / -1_i16` which would overflow
 
 error: this arithmetic operation will overflow
   --> $DIR/issue-8460-const.rs:20:36
    |
 LL |     assert!(thread::spawn(move|| { i32::MIN / -1; }).join().is_err());
-   |                                    ^^^^^^^^^^^^^ attempt to divide with overflow
+   |                                    ^^^^^^^^^^^^^ attempt to compute `i32::MIN / -1_i32` which would overflow
 
 error: this arithmetic operation will overflow
   --> $DIR/issue-8460-const.rs:22:36
    |
 LL |     assert!(thread::spawn(move|| { i64::MIN / -1; }).join().is_err());
-   |                                    ^^^^^^^^^^^^^ attempt to divide with overflow
+   |                                    ^^^^^^^^^^^^^ attempt to compute `i64::MIN / -1_i64` which would overflow
 
 error: this arithmetic operation will overflow
   --> $DIR/issue-8460-const.rs:24:36
    |
 LL |     assert!(thread::spawn(move|| { i128::MIN / -1; }).join().is_err());
-   |                                    ^^^^^^^^^^^^^^ attempt to divide with overflow
+   |                                    ^^^^^^^^^^^^^^ attempt to compute `i128::MIN / -1_i128` which would overflow
 
 error: this operation will panic at runtime
   --> $DIR/issue-8460-const.rs:26:36
    |
 LL |     assert!(thread::spawn(move|| { 1isize / 0; }).join().is_err());
-   |                                    ^^^^^^^^^^ attempt to divide by zero
+   |                                    ^^^^^^^^^^ attempt to divide 1_isize by zero
    |
    = note: `#[deny(unconditional_panic)]` on by default
 
@@ -48,103 +48,103 @@ error: this operation will panic at runtime
   --> $DIR/issue-8460-const.rs:28:36
    |
 LL |     assert!(thread::spawn(move|| { 1i8 / 0; }).join().is_err());
-   |                                    ^^^^^^^ attempt to divide by zero
+   |                                    ^^^^^^^ attempt to divide 1_i8 by zero
 
 error: this operation will panic at runtime
   --> $DIR/issue-8460-const.rs:30:36
    |
 LL |     assert!(thread::spawn(move|| { 1i16 / 0; }).join().is_err());
-   |                                    ^^^^^^^^ attempt to divide by zero
+   |                                    ^^^^^^^^ attempt to divide 1_i16 by zero
 
 error: this operation will panic at runtime
   --> $DIR/issue-8460-const.rs:32:36
    |
 LL |     assert!(thread::spawn(move|| { 1i32 / 0; }).join().is_err());
-   |                                    ^^^^^^^^ attempt to divide by zero
+   |                                    ^^^^^^^^ attempt to divide 1_i32 by zero
 
 error: this operation will panic at runtime
   --> $DIR/issue-8460-const.rs:34:36
    |
 LL |     assert!(thread::spawn(move|| { 1i64 / 0; }).join().is_err());
-   |                                    ^^^^^^^^ attempt to divide by zero
+   |                                    ^^^^^^^^ attempt to divide 1_i64 by zero
 
 error: this operation will panic at runtime
   --> $DIR/issue-8460-const.rs:36:36
    |
 LL |     assert!(thread::spawn(move|| { 1i128 / 0; }).join().is_err());
-   |                                    ^^^^^^^^^ attempt to divide by zero
+   |                                    ^^^^^^^^^ attempt to divide 1_i128 by zero
 
 error: this arithmetic operation will overflow
   --> $DIR/issue-8460-const.rs:38:36
    |
 LL |     assert!(thread::spawn(move|| { isize::MIN % -1; }).join().is_err());
-   |                                    ^^^^^^^^^^^^^^^ attempt to calculate the remainder with overflow
+   |                                    ^^^^^^^^^^^^^^^ attempt to compute the remainder of `isize::MIN % -1_isize` which would overflow
 
 error: this arithmetic operation will overflow
   --> $DIR/issue-8460-const.rs:40:36
    |
 LL |     assert!(thread::spawn(move|| { i8::MIN % -1; }).join().is_err());
-   |                                    ^^^^^^^^^^^^ attempt to calculate the remainder with overflow
+   |                                    ^^^^^^^^^^^^ attempt to compute the remainder of `i8::MIN % -1_i8` which would overflow
 
 error: this arithmetic operation will overflow
   --> $DIR/issue-8460-const.rs:42:36
    |
 LL |     assert!(thread::spawn(move|| { i16::MIN % -1; }).join().is_err());
-   |                                    ^^^^^^^^^^^^^ attempt to calculate the remainder with overflow
+   |                                    ^^^^^^^^^^^^^ attempt to compute the remainder of `i16::MIN % -1_i16` which would overflow
 
 error: this arithmetic operation will overflow
   --> $DIR/issue-8460-const.rs:44:36
    |
 LL |     assert!(thread::spawn(move|| { i32::MIN % -1; }).join().is_err());
-   |                                    ^^^^^^^^^^^^^ attempt to calculate the remainder with overflow
+   |                                    ^^^^^^^^^^^^^ attempt to compute the remainder of `i32::MIN % -1_i32` which would overflow
 
 error: this arithmetic operation will overflow
   --> $DIR/issue-8460-const.rs:46:36
    |
 LL |     assert!(thread::spawn(move|| { i64::MIN % -1; }).join().is_err());
-   |                                    ^^^^^^^^^^^^^ attempt to calculate the remainder with overflow
+   |                                    ^^^^^^^^^^^^^ attempt to compute the remainder of `i64::MIN % -1_i64` which would overflow
 
 error: this arithmetic operation will overflow
   --> $DIR/issue-8460-const.rs:48:36
    |
 LL |     assert!(thread::spawn(move|| { i128::MIN % -1; }).join().is_err());
-   |                                    ^^^^^^^^^^^^^^ attempt to calculate the remainder with overflow
+   |                                    ^^^^^^^^^^^^^^ attempt to compute the remainder of `i128::MIN % -1_i128` which would overflow
 
 error: this operation will panic at runtime
   --> $DIR/issue-8460-const.rs:50:36
    |
 LL |     assert!(thread::spawn(move|| { 1isize % 0; }).join().is_err());
-   |                                    ^^^^^^^^^^ attempt to calculate the remainder with a divisor of zero
+   |                                    ^^^^^^^^^^ attempt to calculate the remainder of 1_isize with a divisor of zero
 
 error: this operation will panic at runtime
   --> $DIR/issue-8460-const.rs:52:36
    |
 LL |     assert!(thread::spawn(move|| { 1i8 % 0; }).join().is_err());
-   |                                    ^^^^^^^ attempt to calculate the remainder with a divisor of zero
+   |                                    ^^^^^^^ attempt to calculate the remainder of 1_i8 with a divisor of zero
 
 error: this operation will panic at runtime
   --> $DIR/issue-8460-const.rs:54:36
    |
 LL |     assert!(thread::spawn(move|| { 1i16 % 0; }).join().is_err());
-   |                                    ^^^^^^^^ attempt to calculate the remainder with a divisor of zero
+   |                                    ^^^^^^^^ attempt to calculate the remainder of 1_i16 with a divisor of zero
 
 error: this operation will panic at runtime
   --> $DIR/issue-8460-const.rs:56:36
    |
 LL |     assert!(thread::spawn(move|| { 1i32 % 0; }).join().is_err());
-   |                                    ^^^^^^^^ attempt to calculate the remainder with a divisor of zero
+   |                                    ^^^^^^^^ attempt to calculate the remainder of 1_i32 with a divisor of zero
 
 error: this operation will panic at runtime
   --> $DIR/issue-8460-const.rs:58:36
    |
 LL |     assert!(thread::spawn(move|| { 1i64 % 0; }).join().is_err());
-   |                                    ^^^^^^^^ attempt to calculate the remainder with a divisor of zero
+   |                                    ^^^^^^^^ attempt to calculate the remainder of 1_i64 with a divisor of zero
 
 error: this operation will panic at runtime
   --> $DIR/issue-8460-const.rs:60:36
    |
 LL |     assert!(thread::spawn(move|| { 1i128 % 0; }).join().is_err());
-   |                                    ^^^^^^^^^ attempt to calculate the remainder with a divisor of zero
+   |                                    ^^^^^^^^^ attempt to calculate the remainder of 1_i128 with a divisor of zero
 
 error: aborting due to 24 previous errors
 

--- a/src/test/ui/issues/issue-8460-const.opt.stderr
+++ b/src/test/ui/issues/issue-8460-const.opt.stderr
@@ -2,7 +2,7 @@ error: this arithmetic operation will overflow
   --> $DIR/issue-8460-const.rs:14:36
    |
 LL |     assert!(thread::spawn(move|| { isize::MIN / -1; }).join().is_err());
-   |                                    ^^^^^^^^^^^^^^^ attempt to divide with overflow
+   |                                    ^^^^^^^^^^^^^^^ attempt to compute `isize::MIN / -1_isize` which would overflow
    |
    = note: `#[deny(arithmetic_overflow)]` on by default
 
@@ -10,37 +10,37 @@ error: this arithmetic operation will overflow
   --> $DIR/issue-8460-const.rs:16:36
    |
 LL |     assert!(thread::spawn(move|| { i8::MIN / -1; }).join().is_err());
-   |                                    ^^^^^^^^^^^^ attempt to divide with overflow
+   |                                    ^^^^^^^^^^^^ attempt to compute `i8::MIN / -1_i8` which would overflow
 
 error: this arithmetic operation will overflow
   --> $DIR/issue-8460-const.rs:18:36
    |
 LL |     assert!(thread::spawn(move|| { i16::MIN / -1; }).join().is_err());
-   |                                    ^^^^^^^^^^^^^ attempt to divide with overflow
+   |                                    ^^^^^^^^^^^^^ attempt to compute `i16::MIN / -1_i16` which would overflow
 
 error: this arithmetic operation will overflow
   --> $DIR/issue-8460-const.rs:20:36
    |
 LL |     assert!(thread::spawn(move|| { i32::MIN / -1; }).join().is_err());
-   |                                    ^^^^^^^^^^^^^ attempt to divide with overflow
+   |                                    ^^^^^^^^^^^^^ attempt to compute `i32::MIN / -1_i32` which would overflow
 
 error: this arithmetic operation will overflow
   --> $DIR/issue-8460-const.rs:22:36
    |
 LL |     assert!(thread::spawn(move|| { i64::MIN / -1; }).join().is_err());
-   |                                    ^^^^^^^^^^^^^ attempt to divide with overflow
+   |                                    ^^^^^^^^^^^^^ attempt to compute `i64::MIN / -1_i64` which would overflow
 
 error: this arithmetic operation will overflow
   --> $DIR/issue-8460-const.rs:24:36
    |
 LL |     assert!(thread::spawn(move|| { i128::MIN / -1; }).join().is_err());
-   |                                    ^^^^^^^^^^^^^^ attempt to divide with overflow
+   |                                    ^^^^^^^^^^^^^^ attempt to compute `i128::MIN / -1_i128` which would overflow
 
 error: this operation will panic at runtime
   --> $DIR/issue-8460-const.rs:26:36
    |
 LL |     assert!(thread::spawn(move|| { 1isize / 0; }).join().is_err());
-   |                                    ^^^^^^^^^^ attempt to divide by zero
+   |                                    ^^^^^^^^^^ attempt to divide 1_isize by zero
    |
    = note: `#[deny(unconditional_panic)]` on by default
 
@@ -48,103 +48,103 @@ error: this operation will panic at runtime
   --> $DIR/issue-8460-const.rs:28:36
    |
 LL |     assert!(thread::spawn(move|| { 1i8 / 0; }).join().is_err());
-   |                                    ^^^^^^^ attempt to divide by zero
+   |                                    ^^^^^^^ attempt to divide 1_i8 by zero
 
 error: this operation will panic at runtime
   --> $DIR/issue-8460-const.rs:30:36
    |
 LL |     assert!(thread::spawn(move|| { 1i16 / 0; }).join().is_err());
-   |                                    ^^^^^^^^ attempt to divide by zero
+   |                                    ^^^^^^^^ attempt to divide 1_i16 by zero
 
 error: this operation will panic at runtime
   --> $DIR/issue-8460-const.rs:32:36
    |
 LL |     assert!(thread::spawn(move|| { 1i32 / 0; }).join().is_err());
-   |                                    ^^^^^^^^ attempt to divide by zero
+   |                                    ^^^^^^^^ attempt to divide 1_i32 by zero
 
 error: this operation will panic at runtime
   --> $DIR/issue-8460-const.rs:34:36
    |
 LL |     assert!(thread::spawn(move|| { 1i64 / 0; }).join().is_err());
-   |                                    ^^^^^^^^ attempt to divide by zero
+   |                                    ^^^^^^^^ attempt to divide 1_i64 by zero
 
 error: this operation will panic at runtime
   --> $DIR/issue-8460-const.rs:36:36
    |
 LL |     assert!(thread::spawn(move|| { 1i128 / 0; }).join().is_err());
-   |                                    ^^^^^^^^^ attempt to divide by zero
+   |                                    ^^^^^^^^^ attempt to divide 1_i128 by zero
 
 error: this arithmetic operation will overflow
   --> $DIR/issue-8460-const.rs:38:36
    |
 LL |     assert!(thread::spawn(move|| { isize::MIN % -1; }).join().is_err());
-   |                                    ^^^^^^^^^^^^^^^ attempt to calculate the remainder with overflow
+   |                                    ^^^^^^^^^^^^^^^ attempt to compute the remainder of `isize::MIN % -1_isize` which would overflow
 
 error: this arithmetic operation will overflow
   --> $DIR/issue-8460-const.rs:40:36
    |
 LL |     assert!(thread::spawn(move|| { i8::MIN % -1; }).join().is_err());
-   |                                    ^^^^^^^^^^^^ attempt to calculate the remainder with overflow
+   |                                    ^^^^^^^^^^^^ attempt to compute the remainder of `i8::MIN % -1_i8` which would overflow
 
 error: this arithmetic operation will overflow
   --> $DIR/issue-8460-const.rs:42:36
    |
 LL |     assert!(thread::spawn(move|| { i16::MIN % -1; }).join().is_err());
-   |                                    ^^^^^^^^^^^^^ attempt to calculate the remainder with overflow
+   |                                    ^^^^^^^^^^^^^ attempt to compute the remainder of `i16::MIN % -1_i16` which would overflow
 
 error: this arithmetic operation will overflow
   --> $DIR/issue-8460-const.rs:44:36
    |
 LL |     assert!(thread::spawn(move|| { i32::MIN % -1; }).join().is_err());
-   |                                    ^^^^^^^^^^^^^ attempt to calculate the remainder with overflow
+   |                                    ^^^^^^^^^^^^^ attempt to compute the remainder of `i32::MIN % -1_i32` which would overflow
 
 error: this arithmetic operation will overflow
   --> $DIR/issue-8460-const.rs:46:36
    |
 LL |     assert!(thread::spawn(move|| { i64::MIN % -1; }).join().is_err());
-   |                                    ^^^^^^^^^^^^^ attempt to calculate the remainder with overflow
+   |                                    ^^^^^^^^^^^^^ attempt to compute the remainder of `i64::MIN % -1_i64` which would overflow
 
 error: this arithmetic operation will overflow
   --> $DIR/issue-8460-const.rs:48:36
    |
 LL |     assert!(thread::spawn(move|| { i128::MIN % -1; }).join().is_err());
-   |                                    ^^^^^^^^^^^^^^ attempt to calculate the remainder with overflow
+   |                                    ^^^^^^^^^^^^^^ attempt to compute the remainder of `i128::MIN % -1_i128` which would overflow
 
 error: this operation will panic at runtime
   --> $DIR/issue-8460-const.rs:50:36
    |
 LL |     assert!(thread::spawn(move|| { 1isize % 0; }).join().is_err());
-   |                                    ^^^^^^^^^^ attempt to calculate the remainder with a divisor of zero
+   |                                    ^^^^^^^^^^ attempt to calculate the remainder of 1_isize with a divisor of zero
 
 error: this operation will panic at runtime
   --> $DIR/issue-8460-const.rs:52:36
    |
 LL |     assert!(thread::spawn(move|| { 1i8 % 0; }).join().is_err());
-   |                                    ^^^^^^^ attempt to calculate the remainder with a divisor of zero
+   |                                    ^^^^^^^ attempt to calculate the remainder of 1_i8 with a divisor of zero
 
 error: this operation will panic at runtime
   --> $DIR/issue-8460-const.rs:54:36
    |
 LL |     assert!(thread::spawn(move|| { 1i16 % 0; }).join().is_err());
-   |                                    ^^^^^^^^ attempt to calculate the remainder with a divisor of zero
+   |                                    ^^^^^^^^ attempt to calculate the remainder of 1_i16 with a divisor of zero
 
 error: this operation will panic at runtime
   --> $DIR/issue-8460-const.rs:56:36
    |
 LL |     assert!(thread::spawn(move|| { 1i32 % 0; }).join().is_err());
-   |                                    ^^^^^^^^ attempt to calculate the remainder with a divisor of zero
+   |                                    ^^^^^^^^ attempt to calculate the remainder of 1_i32 with a divisor of zero
 
 error: this operation will panic at runtime
   --> $DIR/issue-8460-const.rs:58:36
    |
 LL |     assert!(thread::spawn(move|| { 1i64 % 0; }).join().is_err());
-   |                                    ^^^^^^^^ attempt to calculate the remainder with a divisor of zero
+   |                                    ^^^^^^^^ attempt to calculate the remainder of 1_i64 with a divisor of zero
 
 error: this operation will panic at runtime
   --> $DIR/issue-8460-const.rs:60:36
    |
 LL |     assert!(thread::spawn(move|| { 1i128 % 0; }).join().is_err());
-   |                                    ^^^^^^^^^ attempt to calculate the remainder with a divisor of zero
+   |                                    ^^^^^^^^^ attempt to calculate the remainder of 1_i128 with a divisor of zero
 
 error: aborting due to 24 previous errors
 

--- a/src/test/ui/issues/issue-8460-const.opt_with_overflow_checks.stderr
+++ b/src/test/ui/issues/issue-8460-const.opt_with_overflow_checks.stderr
@@ -2,7 +2,7 @@ error: this arithmetic operation will overflow
   --> $DIR/issue-8460-const.rs:14:36
    |
 LL |     assert!(thread::spawn(move|| { isize::MIN / -1; }).join().is_err());
-   |                                    ^^^^^^^^^^^^^^^ attempt to divide with overflow
+   |                                    ^^^^^^^^^^^^^^^ attempt to compute `isize::MIN / -1_isize` which would overflow
    |
    = note: `#[deny(arithmetic_overflow)]` on by default
 
@@ -10,37 +10,37 @@ error: this arithmetic operation will overflow
   --> $DIR/issue-8460-const.rs:16:36
    |
 LL |     assert!(thread::spawn(move|| { i8::MIN / -1; }).join().is_err());
-   |                                    ^^^^^^^^^^^^ attempt to divide with overflow
+   |                                    ^^^^^^^^^^^^ attempt to compute `i8::MIN / -1_i8` which would overflow
 
 error: this arithmetic operation will overflow
   --> $DIR/issue-8460-const.rs:18:36
    |
 LL |     assert!(thread::spawn(move|| { i16::MIN / -1; }).join().is_err());
-   |                                    ^^^^^^^^^^^^^ attempt to divide with overflow
+   |                                    ^^^^^^^^^^^^^ attempt to compute `i16::MIN / -1_i16` which would overflow
 
 error: this arithmetic operation will overflow
   --> $DIR/issue-8460-const.rs:20:36
    |
 LL |     assert!(thread::spawn(move|| { i32::MIN / -1; }).join().is_err());
-   |                                    ^^^^^^^^^^^^^ attempt to divide with overflow
+   |                                    ^^^^^^^^^^^^^ attempt to compute `i32::MIN / -1_i32` which would overflow
 
 error: this arithmetic operation will overflow
   --> $DIR/issue-8460-const.rs:22:36
    |
 LL |     assert!(thread::spawn(move|| { i64::MIN / -1; }).join().is_err());
-   |                                    ^^^^^^^^^^^^^ attempt to divide with overflow
+   |                                    ^^^^^^^^^^^^^ attempt to compute `i64::MIN / -1_i64` which would overflow
 
 error: this arithmetic operation will overflow
   --> $DIR/issue-8460-const.rs:24:36
    |
 LL |     assert!(thread::spawn(move|| { i128::MIN / -1; }).join().is_err());
-   |                                    ^^^^^^^^^^^^^^ attempt to divide with overflow
+   |                                    ^^^^^^^^^^^^^^ attempt to compute `i128::MIN / -1_i128` which would overflow
 
 error: this operation will panic at runtime
   --> $DIR/issue-8460-const.rs:26:36
    |
 LL |     assert!(thread::spawn(move|| { 1isize / 0; }).join().is_err());
-   |                                    ^^^^^^^^^^ attempt to divide by zero
+   |                                    ^^^^^^^^^^ attempt to divide 1_isize by zero
    |
    = note: `#[deny(unconditional_panic)]` on by default
 
@@ -48,103 +48,103 @@ error: this operation will panic at runtime
   --> $DIR/issue-8460-const.rs:28:36
    |
 LL |     assert!(thread::spawn(move|| { 1i8 / 0; }).join().is_err());
-   |                                    ^^^^^^^ attempt to divide by zero
+   |                                    ^^^^^^^ attempt to divide 1_i8 by zero
 
 error: this operation will panic at runtime
   --> $DIR/issue-8460-const.rs:30:36
    |
 LL |     assert!(thread::spawn(move|| { 1i16 / 0; }).join().is_err());
-   |                                    ^^^^^^^^ attempt to divide by zero
+   |                                    ^^^^^^^^ attempt to divide 1_i16 by zero
 
 error: this operation will panic at runtime
   --> $DIR/issue-8460-const.rs:32:36
    |
 LL |     assert!(thread::spawn(move|| { 1i32 / 0; }).join().is_err());
-   |                                    ^^^^^^^^ attempt to divide by zero
+   |                                    ^^^^^^^^ attempt to divide 1_i32 by zero
 
 error: this operation will panic at runtime
   --> $DIR/issue-8460-const.rs:34:36
    |
 LL |     assert!(thread::spawn(move|| { 1i64 / 0; }).join().is_err());
-   |                                    ^^^^^^^^ attempt to divide by zero
+   |                                    ^^^^^^^^ attempt to divide 1_i64 by zero
 
 error: this operation will panic at runtime
   --> $DIR/issue-8460-const.rs:36:36
    |
 LL |     assert!(thread::spawn(move|| { 1i128 / 0; }).join().is_err());
-   |                                    ^^^^^^^^^ attempt to divide by zero
+   |                                    ^^^^^^^^^ attempt to divide 1_i128 by zero
 
 error: this arithmetic operation will overflow
   --> $DIR/issue-8460-const.rs:38:36
    |
 LL |     assert!(thread::spawn(move|| { isize::MIN % -1; }).join().is_err());
-   |                                    ^^^^^^^^^^^^^^^ attempt to calculate the remainder with overflow
+   |                                    ^^^^^^^^^^^^^^^ attempt to compute the remainder of `isize::MIN % -1_isize` which would overflow
 
 error: this arithmetic operation will overflow
   --> $DIR/issue-8460-const.rs:40:36
    |
 LL |     assert!(thread::spawn(move|| { i8::MIN % -1; }).join().is_err());
-   |                                    ^^^^^^^^^^^^ attempt to calculate the remainder with overflow
+   |                                    ^^^^^^^^^^^^ attempt to compute the remainder of `i8::MIN % -1_i8` which would overflow
 
 error: this arithmetic operation will overflow
   --> $DIR/issue-8460-const.rs:42:36
    |
 LL |     assert!(thread::spawn(move|| { i16::MIN % -1; }).join().is_err());
-   |                                    ^^^^^^^^^^^^^ attempt to calculate the remainder with overflow
+   |                                    ^^^^^^^^^^^^^ attempt to compute the remainder of `i16::MIN % -1_i16` which would overflow
 
 error: this arithmetic operation will overflow
   --> $DIR/issue-8460-const.rs:44:36
    |
 LL |     assert!(thread::spawn(move|| { i32::MIN % -1; }).join().is_err());
-   |                                    ^^^^^^^^^^^^^ attempt to calculate the remainder with overflow
+   |                                    ^^^^^^^^^^^^^ attempt to compute the remainder of `i32::MIN % -1_i32` which would overflow
 
 error: this arithmetic operation will overflow
   --> $DIR/issue-8460-const.rs:46:36
    |
 LL |     assert!(thread::spawn(move|| { i64::MIN % -1; }).join().is_err());
-   |                                    ^^^^^^^^^^^^^ attempt to calculate the remainder with overflow
+   |                                    ^^^^^^^^^^^^^ attempt to compute the remainder of `i64::MIN % -1_i64` which would overflow
 
 error: this arithmetic operation will overflow
   --> $DIR/issue-8460-const.rs:48:36
    |
 LL |     assert!(thread::spawn(move|| { i128::MIN % -1; }).join().is_err());
-   |                                    ^^^^^^^^^^^^^^ attempt to calculate the remainder with overflow
+   |                                    ^^^^^^^^^^^^^^ attempt to compute the remainder of `i128::MIN % -1_i128` which would overflow
 
 error: this operation will panic at runtime
   --> $DIR/issue-8460-const.rs:50:36
    |
 LL |     assert!(thread::spawn(move|| { 1isize % 0; }).join().is_err());
-   |                                    ^^^^^^^^^^ attempt to calculate the remainder with a divisor of zero
+   |                                    ^^^^^^^^^^ attempt to calculate the remainder of 1_isize with a divisor of zero
 
 error: this operation will panic at runtime
   --> $DIR/issue-8460-const.rs:52:36
    |
 LL |     assert!(thread::spawn(move|| { 1i8 % 0; }).join().is_err());
-   |                                    ^^^^^^^ attempt to calculate the remainder with a divisor of zero
+   |                                    ^^^^^^^ attempt to calculate the remainder of 1_i8 with a divisor of zero
 
 error: this operation will panic at runtime
   --> $DIR/issue-8460-const.rs:54:36
    |
 LL |     assert!(thread::spawn(move|| { 1i16 % 0; }).join().is_err());
-   |                                    ^^^^^^^^ attempt to calculate the remainder with a divisor of zero
+   |                                    ^^^^^^^^ attempt to calculate the remainder of 1_i16 with a divisor of zero
 
 error: this operation will panic at runtime
   --> $DIR/issue-8460-const.rs:56:36
    |
 LL |     assert!(thread::spawn(move|| { 1i32 % 0; }).join().is_err());
-   |                                    ^^^^^^^^ attempt to calculate the remainder with a divisor of zero
+   |                                    ^^^^^^^^ attempt to calculate the remainder of 1_i32 with a divisor of zero
 
 error: this operation will panic at runtime
   --> $DIR/issue-8460-const.rs:58:36
    |
 LL |     assert!(thread::spawn(move|| { 1i64 % 0; }).join().is_err());
-   |                                    ^^^^^^^^ attempt to calculate the remainder with a divisor of zero
+   |                                    ^^^^^^^^ attempt to calculate the remainder of 1_i64 with a divisor of zero
 
 error: this operation will panic at runtime
   --> $DIR/issue-8460-const.rs:60:36
    |
 LL |     assert!(thread::spawn(move|| { 1i128 % 0; }).join().is_err());
-   |                                    ^^^^^^^^^ attempt to calculate the remainder with a divisor of zero
+   |                                    ^^^^^^^^^ attempt to calculate the remainder of 1_i128 with a divisor of zero
 
 error: aborting due to 24 previous errors
 

--- a/src/test/ui/lint/lint-exceeding-bitshifts.noopt.stderr
+++ b/src/test/ui/lint/lint-exceeding-bitshifts.noopt.stderr
@@ -1,152 +1,152 @@
 warning: this arithmetic operation will overflow
-  --> $DIR/lint-exceeding-bitshifts.rs:17:20
+  --> $DIR/lint-exceeding-bitshifts.rs:18:20
    |
 LL |     const N: i32 = T::N << 42;
-   |                    ^^^^^^^^^^ attempt to shift left with overflow
+   |                    ^^^^^^^^^^ attempt to shift left by 42_i32 which would overflow
    |
 note: the lint level is defined here
-  --> $DIR/lint-exceeding-bitshifts.rs:9:9
+  --> $DIR/lint-exceeding-bitshifts.rs:10:9
    |
 LL | #![warn(arithmetic_overflow, const_err)]
    |         ^^^^^^^^^^^^^^^^^^^
 
 warning: this arithmetic operation will overflow
-  --> $DIR/lint-exceeding-bitshifts.rs:21:13
+  --> $DIR/lint-exceeding-bitshifts.rs:22:13
    |
 LL |     let _ = x << 42;
-   |             ^^^^^^^ attempt to shift left with overflow
+   |             ^^^^^^^ attempt to shift left by 42_i32 which would overflow
 
 warning: this arithmetic operation will overflow
-  --> $DIR/lint-exceeding-bitshifts.rs:26:15
+  --> $DIR/lint-exceeding-bitshifts.rs:27:15
    |
 LL |       let n = 1u8 << 8;
-   |               ^^^^^^^^ attempt to shift left with overflow
+   |               ^^^^^^^^ attempt to shift left by 8_i32 which would overflow
 
 warning: this arithmetic operation will overflow
-  --> $DIR/lint-exceeding-bitshifts.rs:28:15
+  --> $DIR/lint-exceeding-bitshifts.rs:29:15
    |
 LL |       let n = 1u16 << 16;
-   |               ^^^^^^^^^^ attempt to shift left with overflow
+   |               ^^^^^^^^^^ attempt to shift left by 16_i32 which would overflow
 
 warning: this arithmetic operation will overflow
-  --> $DIR/lint-exceeding-bitshifts.rs:30:15
+  --> $DIR/lint-exceeding-bitshifts.rs:31:15
    |
 LL |       let n = 1u32 << 32;
-   |               ^^^^^^^^^^ attempt to shift left with overflow
+   |               ^^^^^^^^^^ attempt to shift left by 32_i32 which would overflow
 
 warning: this arithmetic operation will overflow
-  --> $DIR/lint-exceeding-bitshifts.rs:32:15
+  --> $DIR/lint-exceeding-bitshifts.rs:33:15
    |
 LL |       let n = 1u64 << 64;
-   |               ^^^^^^^^^^ attempt to shift left with overflow
+   |               ^^^^^^^^^^ attempt to shift left by 64_i32 which would overflow
 
 warning: this arithmetic operation will overflow
-  --> $DIR/lint-exceeding-bitshifts.rs:34:15
+  --> $DIR/lint-exceeding-bitshifts.rs:35:15
    |
 LL |       let n = 1i8 << 8;
-   |               ^^^^^^^^ attempt to shift left with overflow
+   |               ^^^^^^^^ attempt to shift left by 8_i32 which would overflow
 
 warning: this arithmetic operation will overflow
-  --> $DIR/lint-exceeding-bitshifts.rs:36:15
+  --> $DIR/lint-exceeding-bitshifts.rs:37:15
    |
 LL |       let n = 1i16 << 16;
-   |               ^^^^^^^^^^ attempt to shift left with overflow
+   |               ^^^^^^^^^^ attempt to shift left by 16_i32 which would overflow
 
 warning: this arithmetic operation will overflow
-  --> $DIR/lint-exceeding-bitshifts.rs:38:15
+  --> $DIR/lint-exceeding-bitshifts.rs:39:15
    |
 LL |       let n = 1i32 << 32;
-   |               ^^^^^^^^^^ attempt to shift left with overflow
+   |               ^^^^^^^^^^ attempt to shift left by 32_i32 which would overflow
 
 warning: this arithmetic operation will overflow
-  --> $DIR/lint-exceeding-bitshifts.rs:40:15
+  --> $DIR/lint-exceeding-bitshifts.rs:41:15
    |
 LL |       let n = 1i64 << 64;
-   |               ^^^^^^^^^^ attempt to shift left with overflow
+   |               ^^^^^^^^^^ attempt to shift left by 64_i32 which would overflow
 
 warning: this arithmetic operation will overflow
-  --> $DIR/lint-exceeding-bitshifts.rs:43:15
+  --> $DIR/lint-exceeding-bitshifts.rs:44:15
    |
 LL |       let n = 1u8 >> 8;
-   |               ^^^^^^^^ attempt to shift right with overflow
+   |               ^^^^^^^^ attempt to shift right by 8_i32 which would overflow
 
 warning: this arithmetic operation will overflow
-  --> $DIR/lint-exceeding-bitshifts.rs:45:15
+  --> $DIR/lint-exceeding-bitshifts.rs:46:15
    |
 LL |       let n = 1u16 >> 16;
-   |               ^^^^^^^^^^ attempt to shift right with overflow
+   |               ^^^^^^^^^^ attempt to shift right by 16_i32 which would overflow
 
 warning: this arithmetic operation will overflow
-  --> $DIR/lint-exceeding-bitshifts.rs:47:15
+  --> $DIR/lint-exceeding-bitshifts.rs:48:15
    |
 LL |       let n = 1u32 >> 32;
-   |               ^^^^^^^^^^ attempt to shift right with overflow
+   |               ^^^^^^^^^^ attempt to shift right by 32_i32 which would overflow
 
 warning: this arithmetic operation will overflow
-  --> $DIR/lint-exceeding-bitshifts.rs:49:15
+  --> $DIR/lint-exceeding-bitshifts.rs:50:15
    |
 LL |       let n = 1u64 >> 64;
-   |               ^^^^^^^^^^ attempt to shift right with overflow
+   |               ^^^^^^^^^^ attempt to shift right by 64_i32 which would overflow
 
 warning: this arithmetic operation will overflow
-  --> $DIR/lint-exceeding-bitshifts.rs:51:15
+  --> $DIR/lint-exceeding-bitshifts.rs:52:15
    |
 LL |       let n = 1i8 >> 8;
-   |               ^^^^^^^^ attempt to shift right with overflow
+   |               ^^^^^^^^ attempt to shift right by 8_i32 which would overflow
 
 warning: this arithmetic operation will overflow
-  --> $DIR/lint-exceeding-bitshifts.rs:53:15
+  --> $DIR/lint-exceeding-bitshifts.rs:54:15
    |
 LL |       let n = 1i16 >> 16;
-   |               ^^^^^^^^^^ attempt to shift right with overflow
+   |               ^^^^^^^^^^ attempt to shift right by 16_i32 which would overflow
 
 warning: this arithmetic operation will overflow
-  --> $DIR/lint-exceeding-bitshifts.rs:55:15
+  --> $DIR/lint-exceeding-bitshifts.rs:56:15
    |
 LL |       let n = 1i32 >> 32;
-   |               ^^^^^^^^^^ attempt to shift right with overflow
+   |               ^^^^^^^^^^ attempt to shift right by 32_i32 which would overflow
 
 warning: this arithmetic operation will overflow
-  --> $DIR/lint-exceeding-bitshifts.rs:57:15
+  --> $DIR/lint-exceeding-bitshifts.rs:58:15
    |
 LL |       let n = 1i64 >> 64;
-   |               ^^^^^^^^^^ attempt to shift right with overflow
+   |               ^^^^^^^^^^ attempt to shift right by 64_i32 which would overflow
 
 warning: this arithmetic operation will overflow
-  --> $DIR/lint-exceeding-bitshifts.rs:61:15
+  --> $DIR/lint-exceeding-bitshifts.rs:62:15
    |
 LL |       let n = n << 8;
-   |               ^^^^^^ attempt to shift left with overflow
+   |               ^^^^^^ attempt to shift left by 8_i32 which would overflow
 
 warning: this arithmetic operation will overflow
-  --> $DIR/lint-exceeding-bitshifts.rs:63:15
+  --> $DIR/lint-exceeding-bitshifts.rs:64:15
    |
 LL |       let n = 1u8 << -8;
-   |               ^^^^^^^^^ attempt to shift left with overflow
+   |               ^^^^^^^^^ attempt to shift left by -8_i32 which would overflow
 
 warning: this arithmetic operation will overflow
-  --> $DIR/lint-exceeding-bitshifts.rs:68:15
+  --> $DIR/lint-exceeding-bitshifts.rs:69:15
    |
 LL |       let n = 1u8 << (4+4);
-   |               ^^^^^^^^^^^^ attempt to shift left with overflow
+   |               ^^^^^^^^^^^^ attempt to shift left by 8_i32 which would overflow
 
 warning: this arithmetic operation will overflow
-  --> $DIR/lint-exceeding-bitshifts.rs:70:15
+  --> $DIR/lint-exceeding-bitshifts.rs:71:15
    |
 LL |       let n = 1i64 >> [64][0];
-   |               ^^^^^^^^^^^^^^^ attempt to shift right with overflow
-
-warning: this arithmetic operation will overflow
-  --> $DIR/lint-exceeding-bitshifts.rs:76:15
-   |
-LL |       let n = 1_isize << BITS;
-   |               ^^^^^^^^^^^^^^^ attempt to shift left with overflow
+   |               ^^^^^^^^^^^^^^^ attempt to shift right by 64_i32 which would overflow
 
 warning: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:77:15
    |
+LL |       let n = 1_isize << BITS;
+   |               ^^^^^^^^^^^^^^^ attempt to shift left by %BITS% which would overflow
+
+warning: this arithmetic operation will overflow
+  --> $DIR/lint-exceeding-bitshifts.rs:78:15
+   |
 LL |       let n = 1_usize << BITS;
-   |               ^^^^^^^^^^^^^^^ attempt to shift left with overflow
+   |               ^^^^^^^^^^^^^^^ attempt to shift left by %BITS% which would overflow
 
 warning: 24 warnings emitted
 

--- a/src/test/ui/lint/lint-exceeding-bitshifts.opt.stderr
+++ b/src/test/ui/lint/lint-exceeding-bitshifts.opt.stderr
@@ -1,152 +1,152 @@
 warning: this arithmetic operation will overflow
-  --> $DIR/lint-exceeding-bitshifts.rs:17:20
+  --> $DIR/lint-exceeding-bitshifts.rs:18:20
    |
 LL |     const N: i32 = T::N << 42;
-   |                    ^^^^^^^^^^ attempt to shift left with overflow
+   |                    ^^^^^^^^^^ attempt to shift left by 42_i32 which would overflow
    |
 note: the lint level is defined here
-  --> $DIR/lint-exceeding-bitshifts.rs:9:9
+  --> $DIR/lint-exceeding-bitshifts.rs:10:9
    |
 LL | #![warn(arithmetic_overflow, const_err)]
    |         ^^^^^^^^^^^^^^^^^^^
 
 warning: this arithmetic operation will overflow
-  --> $DIR/lint-exceeding-bitshifts.rs:21:13
+  --> $DIR/lint-exceeding-bitshifts.rs:22:13
    |
 LL |     let _ = x << 42;
-   |             ^^^^^^^ attempt to shift left with overflow
+   |             ^^^^^^^ attempt to shift left by 42_i32 which would overflow
 
 warning: this arithmetic operation will overflow
-  --> $DIR/lint-exceeding-bitshifts.rs:26:15
+  --> $DIR/lint-exceeding-bitshifts.rs:27:15
    |
 LL |       let n = 1u8 << 8;
-   |               ^^^^^^^^ attempt to shift left with overflow
+   |               ^^^^^^^^ attempt to shift left by 8_i32 which would overflow
 
 warning: this arithmetic operation will overflow
-  --> $DIR/lint-exceeding-bitshifts.rs:28:15
+  --> $DIR/lint-exceeding-bitshifts.rs:29:15
    |
 LL |       let n = 1u16 << 16;
-   |               ^^^^^^^^^^ attempt to shift left with overflow
+   |               ^^^^^^^^^^ attempt to shift left by 16_i32 which would overflow
 
 warning: this arithmetic operation will overflow
-  --> $DIR/lint-exceeding-bitshifts.rs:30:15
+  --> $DIR/lint-exceeding-bitshifts.rs:31:15
    |
 LL |       let n = 1u32 << 32;
-   |               ^^^^^^^^^^ attempt to shift left with overflow
+   |               ^^^^^^^^^^ attempt to shift left by 32_i32 which would overflow
 
 warning: this arithmetic operation will overflow
-  --> $DIR/lint-exceeding-bitshifts.rs:32:15
+  --> $DIR/lint-exceeding-bitshifts.rs:33:15
    |
 LL |       let n = 1u64 << 64;
-   |               ^^^^^^^^^^ attempt to shift left with overflow
+   |               ^^^^^^^^^^ attempt to shift left by 64_i32 which would overflow
 
 warning: this arithmetic operation will overflow
-  --> $DIR/lint-exceeding-bitshifts.rs:34:15
+  --> $DIR/lint-exceeding-bitshifts.rs:35:15
    |
 LL |       let n = 1i8 << 8;
-   |               ^^^^^^^^ attempt to shift left with overflow
+   |               ^^^^^^^^ attempt to shift left by 8_i32 which would overflow
 
 warning: this arithmetic operation will overflow
-  --> $DIR/lint-exceeding-bitshifts.rs:36:15
+  --> $DIR/lint-exceeding-bitshifts.rs:37:15
    |
 LL |       let n = 1i16 << 16;
-   |               ^^^^^^^^^^ attempt to shift left with overflow
+   |               ^^^^^^^^^^ attempt to shift left by 16_i32 which would overflow
 
 warning: this arithmetic operation will overflow
-  --> $DIR/lint-exceeding-bitshifts.rs:38:15
+  --> $DIR/lint-exceeding-bitshifts.rs:39:15
    |
 LL |       let n = 1i32 << 32;
-   |               ^^^^^^^^^^ attempt to shift left with overflow
+   |               ^^^^^^^^^^ attempt to shift left by 32_i32 which would overflow
 
 warning: this arithmetic operation will overflow
-  --> $DIR/lint-exceeding-bitshifts.rs:40:15
+  --> $DIR/lint-exceeding-bitshifts.rs:41:15
    |
 LL |       let n = 1i64 << 64;
-   |               ^^^^^^^^^^ attempt to shift left with overflow
+   |               ^^^^^^^^^^ attempt to shift left by 64_i32 which would overflow
 
 warning: this arithmetic operation will overflow
-  --> $DIR/lint-exceeding-bitshifts.rs:43:15
+  --> $DIR/lint-exceeding-bitshifts.rs:44:15
    |
 LL |       let n = 1u8 >> 8;
-   |               ^^^^^^^^ attempt to shift right with overflow
+   |               ^^^^^^^^ attempt to shift right by 8_i32 which would overflow
 
 warning: this arithmetic operation will overflow
-  --> $DIR/lint-exceeding-bitshifts.rs:45:15
+  --> $DIR/lint-exceeding-bitshifts.rs:46:15
    |
 LL |       let n = 1u16 >> 16;
-   |               ^^^^^^^^^^ attempt to shift right with overflow
+   |               ^^^^^^^^^^ attempt to shift right by 16_i32 which would overflow
 
 warning: this arithmetic operation will overflow
-  --> $DIR/lint-exceeding-bitshifts.rs:47:15
+  --> $DIR/lint-exceeding-bitshifts.rs:48:15
    |
 LL |       let n = 1u32 >> 32;
-   |               ^^^^^^^^^^ attempt to shift right with overflow
+   |               ^^^^^^^^^^ attempt to shift right by 32_i32 which would overflow
 
 warning: this arithmetic operation will overflow
-  --> $DIR/lint-exceeding-bitshifts.rs:49:15
+  --> $DIR/lint-exceeding-bitshifts.rs:50:15
    |
 LL |       let n = 1u64 >> 64;
-   |               ^^^^^^^^^^ attempt to shift right with overflow
+   |               ^^^^^^^^^^ attempt to shift right by 64_i32 which would overflow
 
 warning: this arithmetic operation will overflow
-  --> $DIR/lint-exceeding-bitshifts.rs:51:15
+  --> $DIR/lint-exceeding-bitshifts.rs:52:15
    |
 LL |       let n = 1i8 >> 8;
-   |               ^^^^^^^^ attempt to shift right with overflow
+   |               ^^^^^^^^ attempt to shift right by 8_i32 which would overflow
 
 warning: this arithmetic operation will overflow
-  --> $DIR/lint-exceeding-bitshifts.rs:53:15
+  --> $DIR/lint-exceeding-bitshifts.rs:54:15
    |
 LL |       let n = 1i16 >> 16;
-   |               ^^^^^^^^^^ attempt to shift right with overflow
+   |               ^^^^^^^^^^ attempt to shift right by 16_i32 which would overflow
 
 warning: this arithmetic operation will overflow
-  --> $DIR/lint-exceeding-bitshifts.rs:55:15
+  --> $DIR/lint-exceeding-bitshifts.rs:56:15
    |
 LL |       let n = 1i32 >> 32;
-   |               ^^^^^^^^^^ attempt to shift right with overflow
+   |               ^^^^^^^^^^ attempt to shift right by 32_i32 which would overflow
 
 warning: this arithmetic operation will overflow
-  --> $DIR/lint-exceeding-bitshifts.rs:57:15
+  --> $DIR/lint-exceeding-bitshifts.rs:58:15
    |
 LL |       let n = 1i64 >> 64;
-   |               ^^^^^^^^^^ attempt to shift right with overflow
+   |               ^^^^^^^^^^ attempt to shift right by 64_i32 which would overflow
 
 warning: this arithmetic operation will overflow
-  --> $DIR/lint-exceeding-bitshifts.rs:61:15
+  --> $DIR/lint-exceeding-bitshifts.rs:62:15
    |
 LL |       let n = n << 8;
-   |               ^^^^^^ attempt to shift left with overflow
+   |               ^^^^^^ attempt to shift left by 8_i32 which would overflow
 
 warning: this arithmetic operation will overflow
-  --> $DIR/lint-exceeding-bitshifts.rs:63:15
+  --> $DIR/lint-exceeding-bitshifts.rs:64:15
    |
 LL |       let n = 1u8 << -8;
-   |               ^^^^^^^^^ attempt to shift left with overflow
+   |               ^^^^^^^^^ attempt to shift left by -8_i32 which would overflow
 
 warning: this arithmetic operation will overflow
-  --> $DIR/lint-exceeding-bitshifts.rs:68:15
+  --> $DIR/lint-exceeding-bitshifts.rs:69:15
    |
 LL |       let n = 1u8 << (4+4);
-   |               ^^^^^^^^^^^^ attempt to shift left with overflow
+   |               ^^^^^^^^^^^^ attempt to shift left by 8_i32 which would overflow
 
 warning: this arithmetic operation will overflow
-  --> $DIR/lint-exceeding-bitshifts.rs:70:15
+  --> $DIR/lint-exceeding-bitshifts.rs:71:15
    |
 LL |       let n = 1i64 >> [64][0];
-   |               ^^^^^^^^^^^^^^^ attempt to shift right with overflow
-
-warning: this arithmetic operation will overflow
-  --> $DIR/lint-exceeding-bitshifts.rs:76:15
-   |
-LL |       let n = 1_isize << BITS;
-   |               ^^^^^^^^^^^^^^^ attempt to shift left with overflow
+   |               ^^^^^^^^^^^^^^^ attempt to shift right by 64_i32 which would overflow
 
 warning: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:77:15
    |
+LL |       let n = 1_isize << BITS;
+   |               ^^^^^^^^^^^^^^^ attempt to shift left by %BITS% which would overflow
+
+warning: this arithmetic operation will overflow
+  --> $DIR/lint-exceeding-bitshifts.rs:78:15
+   |
 LL |       let n = 1_usize << BITS;
-   |               ^^^^^^^^^^^^^^^ attempt to shift left with overflow
+   |               ^^^^^^^^^^^^^^^ attempt to shift left by %BITS% which would overflow
 
 warning: 24 warnings emitted
 

--- a/src/test/ui/lint/lint-exceeding-bitshifts.opt_with_overflow_checks.stderr
+++ b/src/test/ui/lint/lint-exceeding-bitshifts.opt_with_overflow_checks.stderr
@@ -1,152 +1,152 @@
 warning: this arithmetic operation will overflow
-  --> $DIR/lint-exceeding-bitshifts.rs:17:20
+  --> $DIR/lint-exceeding-bitshifts.rs:18:20
    |
 LL |     const N: i32 = T::N << 42;
-   |                    ^^^^^^^^^^ attempt to shift left with overflow
+   |                    ^^^^^^^^^^ attempt to shift left by 42_i32 which would overflow
    |
 note: the lint level is defined here
-  --> $DIR/lint-exceeding-bitshifts.rs:9:9
+  --> $DIR/lint-exceeding-bitshifts.rs:10:9
    |
 LL | #![warn(arithmetic_overflow, const_err)]
    |         ^^^^^^^^^^^^^^^^^^^
 
 warning: this arithmetic operation will overflow
-  --> $DIR/lint-exceeding-bitshifts.rs:21:13
+  --> $DIR/lint-exceeding-bitshifts.rs:22:13
    |
 LL |     let _ = x << 42;
-   |             ^^^^^^^ attempt to shift left with overflow
+   |             ^^^^^^^ attempt to shift left by 42_i32 which would overflow
 
 warning: this arithmetic operation will overflow
-  --> $DIR/lint-exceeding-bitshifts.rs:26:15
+  --> $DIR/lint-exceeding-bitshifts.rs:27:15
    |
 LL |       let n = 1u8 << 8;
-   |               ^^^^^^^^ attempt to shift left with overflow
+   |               ^^^^^^^^ attempt to shift left by 8_i32 which would overflow
 
 warning: this arithmetic operation will overflow
-  --> $DIR/lint-exceeding-bitshifts.rs:28:15
+  --> $DIR/lint-exceeding-bitshifts.rs:29:15
    |
 LL |       let n = 1u16 << 16;
-   |               ^^^^^^^^^^ attempt to shift left with overflow
+   |               ^^^^^^^^^^ attempt to shift left by 16_i32 which would overflow
 
 warning: this arithmetic operation will overflow
-  --> $DIR/lint-exceeding-bitshifts.rs:30:15
+  --> $DIR/lint-exceeding-bitshifts.rs:31:15
    |
 LL |       let n = 1u32 << 32;
-   |               ^^^^^^^^^^ attempt to shift left with overflow
+   |               ^^^^^^^^^^ attempt to shift left by 32_i32 which would overflow
 
 warning: this arithmetic operation will overflow
-  --> $DIR/lint-exceeding-bitshifts.rs:32:15
+  --> $DIR/lint-exceeding-bitshifts.rs:33:15
    |
 LL |       let n = 1u64 << 64;
-   |               ^^^^^^^^^^ attempt to shift left with overflow
+   |               ^^^^^^^^^^ attempt to shift left by 64_i32 which would overflow
 
 warning: this arithmetic operation will overflow
-  --> $DIR/lint-exceeding-bitshifts.rs:34:15
+  --> $DIR/lint-exceeding-bitshifts.rs:35:15
    |
 LL |       let n = 1i8 << 8;
-   |               ^^^^^^^^ attempt to shift left with overflow
+   |               ^^^^^^^^ attempt to shift left by 8_i32 which would overflow
 
 warning: this arithmetic operation will overflow
-  --> $DIR/lint-exceeding-bitshifts.rs:36:15
+  --> $DIR/lint-exceeding-bitshifts.rs:37:15
    |
 LL |       let n = 1i16 << 16;
-   |               ^^^^^^^^^^ attempt to shift left with overflow
+   |               ^^^^^^^^^^ attempt to shift left by 16_i32 which would overflow
 
 warning: this arithmetic operation will overflow
-  --> $DIR/lint-exceeding-bitshifts.rs:38:15
+  --> $DIR/lint-exceeding-bitshifts.rs:39:15
    |
 LL |       let n = 1i32 << 32;
-   |               ^^^^^^^^^^ attempt to shift left with overflow
+   |               ^^^^^^^^^^ attempt to shift left by 32_i32 which would overflow
 
 warning: this arithmetic operation will overflow
-  --> $DIR/lint-exceeding-bitshifts.rs:40:15
+  --> $DIR/lint-exceeding-bitshifts.rs:41:15
    |
 LL |       let n = 1i64 << 64;
-   |               ^^^^^^^^^^ attempt to shift left with overflow
+   |               ^^^^^^^^^^ attempt to shift left by 64_i32 which would overflow
 
 warning: this arithmetic operation will overflow
-  --> $DIR/lint-exceeding-bitshifts.rs:43:15
+  --> $DIR/lint-exceeding-bitshifts.rs:44:15
    |
 LL |       let n = 1u8 >> 8;
-   |               ^^^^^^^^ attempt to shift right with overflow
+   |               ^^^^^^^^ attempt to shift right by 8_i32 which would overflow
 
 warning: this arithmetic operation will overflow
-  --> $DIR/lint-exceeding-bitshifts.rs:45:15
+  --> $DIR/lint-exceeding-bitshifts.rs:46:15
    |
 LL |       let n = 1u16 >> 16;
-   |               ^^^^^^^^^^ attempt to shift right with overflow
+   |               ^^^^^^^^^^ attempt to shift right by 16_i32 which would overflow
 
 warning: this arithmetic operation will overflow
-  --> $DIR/lint-exceeding-bitshifts.rs:47:15
+  --> $DIR/lint-exceeding-bitshifts.rs:48:15
    |
 LL |       let n = 1u32 >> 32;
-   |               ^^^^^^^^^^ attempt to shift right with overflow
+   |               ^^^^^^^^^^ attempt to shift right by 32_i32 which would overflow
 
 warning: this arithmetic operation will overflow
-  --> $DIR/lint-exceeding-bitshifts.rs:49:15
+  --> $DIR/lint-exceeding-bitshifts.rs:50:15
    |
 LL |       let n = 1u64 >> 64;
-   |               ^^^^^^^^^^ attempt to shift right with overflow
+   |               ^^^^^^^^^^ attempt to shift right by 64_i32 which would overflow
 
 warning: this arithmetic operation will overflow
-  --> $DIR/lint-exceeding-bitshifts.rs:51:15
+  --> $DIR/lint-exceeding-bitshifts.rs:52:15
    |
 LL |       let n = 1i8 >> 8;
-   |               ^^^^^^^^ attempt to shift right with overflow
+   |               ^^^^^^^^ attempt to shift right by 8_i32 which would overflow
 
 warning: this arithmetic operation will overflow
-  --> $DIR/lint-exceeding-bitshifts.rs:53:15
+  --> $DIR/lint-exceeding-bitshifts.rs:54:15
    |
 LL |       let n = 1i16 >> 16;
-   |               ^^^^^^^^^^ attempt to shift right with overflow
+   |               ^^^^^^^^^^ attempt to shift right by 16_i32 which would overflow
 
 warning: this arithmetic operation will overflow
-  --> $DIR/lint-exceeding-bitshifts.rs:55:15
+  --> $DIR/lint-exceeding-bitshifts.rs:56:15
    |
 LL |       let n = 1i32 >> 32;
-   |               ^^^^^^^^^^ attempt to shift right with overflow
+   |               ^^^^^^^^^^ attempt to shift right by 32_i32 which would overflow
 
 warning: this arithmetic operation will overflow
-  --> $DIR/lint-exceeding-bitshifts.rs:57:15
+  --> $DIR/lint-exceeding-bitshifts.rs:58:15
    |
 LL |       let n = 1i64 >> 64;
-   |               ^^^^^^^^^^ attempt to shift right with overflow
+   |               ^^^^^^^^^^ attempt to shift right by 64_i32 which would overflow
 
 warning: this arithmetic operation will overflow
-  --> $DIR/lint-exceeding-bitshifts.rs:61:15
+  --> $DIR/lint-exceeding-bitshifts.rs:62:15
    |
 LL |       let n = n << 8;
-   |               ^^^^^^ attempt to shift left with overflow
+   |               ^^^^^^ attempt to shift left by 8_i32 which would overflow
 
 warning: this arithmetic operation will overflow
-  --> $DIR/lint-exceeding-bitshifts.rs:63:15
+  --> $DIR/lint-exceeding-bitshifts.rs:64:15
    |
 LL |       let n = 1u8 << -8;
-   |               ^^^^^^^^^ attempt to shift left with overflow
+   |               ^^^^^^^^^ attempt to shift left by -8_i32 which would overflow
 
 warning: this arithmetic operation will overflow
-  --> $DIR/lint-exceeding-bitshifts.rs:68:15
+  --> $DIR/lint-exceeding-bitshifts.rs:69:15
    |
 LL |       let n = 1u8 << (4+4);
-   |               ^^^^^^^^^^^^ attempt to shift left with overflow
+   |               ^^^^^^^^^^^^ attempt to shift left by 8_i32 which would overflow
 
 warning: this arithmetic operation will overflow
-  --> $DIR/lint-exceeding-bitshifts.rs:70:15
+  --> $DIR/lint-exceeding-bitshifts.rs:71:15
    |
 LL |       let n = 1i64 >> [64][0];
-   |               ^^^^^^^^^^^^^^^ attempt to shift right with overflow
-
-warning: this arithmetic operation will overflow
-  --> $DIR/lint-exceeding-bitshifts.rs:76:15
-   |
-LL |       let n = 1_isize << BITS;
-   |               ^^^^^^^^^^^^^^^ attempt to shift left with overflow
+   |               ^^^^^^^^^^^^^^^ attempt to shift right by 64_i32 which would overflow
 
 warning: this arithmetic operation will overflow
   --> $DIR/lint-exceeding-bitshifts.rs:77:15
    |
+LL |       let n = 1_isize << BITS;
+   |               ^^^^^^^^^^^^^^^ attempt to shift left by %BITS% which would overflow
+
+warning: this arithmetic operation will overflow
+  --> $DIR/lint-exceeding-bitshifts.rs:78:15
+   |
 LL |       let n = 1_usize << BITS;
-   |               ^^^^^^^^^^^^^^^ attempt to shift left with overflow
+   |               ^^^^^^^^^^^^^^^ attempt to shift left by %BITS% which would overflow
 
 warning: 24 warnings emitted
 

--- a/src/test/ui/lint/lint-exceeding-bitshifts.rs
+++ b/src/test/ui/lint/lint-exceeding-bitshifts.rs
@@ -4,6 +4,7 @@
 //[opt_with_overflow_checks]compile-flags: -C overflow-checks=on -O
 // build-pass
 // ignore-pass (test emits codegen-time warnings and verifies that they are not errors)
+// normalize-stderr-test "shift left by (64|32)_usize which" -> "shift left by %BITS% which"
 
 #![crate_type="lib"]
 #![warn(arithmetic_overflow, const_err)]

--- a/src/test/ui/mir/mir_detects_invalid_ops.stderr
+++ b/src/test/ui/mir/mir_detects_invalid_ops.stderr
@@ -2,7 +2,7 @@ error: this operation will panic at runtime
   --> $DIR/mir_detects_invalid_ops.rs:11:14
    |
 LL |     let _z = 1 / y;
-   |              ^^^^^ attempt to divide by zero
+   |              ^^^^^ attempt to divide 1_i32 by zero
    |
    = note: `#[deny(unconditional_panic)]` on by default
 
@@ -10,7 +10,7 @@ error: this operation will panic at runtime
   --> $DIR/mir_detects_invalid_ops.rs:16:14
    |
 LL |     let _z = 1 % y;
-   |              ^^^^^ attempt to calculate the remainder with a divisor of zero
+   |              ^^^^^ attempt to calculate the remainder of 1_i32 with a divisor of zero
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/numbers-arithmetic/overflowing-lsh-1.stderr
+++ b/src/test/ui/numbers-arithmetic/overflowing-lsh-1.stderr
@@ -2,7 +2,7 @@ error: this arithmetic operation will overflow
   --> $DIR/overflowing-lsh-1.rs:7:14
    |
 LL |     let _x = 1_i32 << 32;
-   |              ^^^^^^^^^^^ attempt to shift left with overflow
+   |              ^^^^^^^^^^^ attempt to shift left by 32_i32 which would overflow
    |
 note: the lint level is defined here
   --> $DIR/overflowing-lsh-1.rs:4:9

--- a/src/test/ui/numbers-arithmetic/overflowing-lsh-2.stderr
+++ b/src/test/ui/numbers-arithmetic/overflowing-lsh-2.stderr
@@ -2,7 +2,7 @@ error: this arithmetic operation will overflow
   --> $DIR/overflowing-lsh-2.rs:7:14
    |
 LL |     let _x = 1 << -1;
-   |              ^^^^^^^ attempt to shift left with overflow
+   |              ^^^^^^^ attempt to shift left by -1_i32 which would overflow
    |
 note: the lint level is defined here
   --> $DIR/overflowing-lsh-2.rs:4:9

--- a/src/test/ui/numbers-arithmetic/overflowing-lsh-3.stderr
+++ b/src/test/ui/numbers-arithmetic/overflowing-lsh-3.stderr
@@ -2,7 +2,7 @@ error: this arithmetic operation will overflow
   --> $DIR/overflowing-lsh-3.rs:7:14
    |
 LL |     let _x = 1_u64 << 64;
-   |              ^^^^^^^^^^^ attempt to shift left with overflow
+   |              ^^^^^^^^^^^ attempt to shift left by 64_i32 which would overflow
    |
 note: the lint level is defined here
   --> $DIR/overflowing-lsh-3.rs:4:9

--- a/src/test/ui/numbers-arithmetic/overflowing-lsh-4.stderr
+++ b/src/test/ui/numbers-arithmetic/overflowing-lsh-4.stderr
@@ -2,7 +2,7 @@ error: this arithmetic operation will overflow
   --> $DIR/overflowing-lsh-4.rs:11:13
    |
 LL |     let x = 1_i8 << 17;
-   |             ^^^^^^^^^^ attempt to shift left with overflow
+   |             ^^^^^^^^^^ attempt to shift left by 17_i32 which would overflow
    |
 note: the lint level is defined here
   --> $DIR/overflowing-lsh-4.rs:7:9

--- a/src/test/ui/numbers-arithmetic/overflowing-rsh-1.stderr
+++ b/src/test/ui/numbers-arithmetic/overflowing-rsh-1.stderr
@@ -2,7 +2,7 @@ error: this arithmetic operation will overflow
   --> $DIR/overflowing-rsh-1.rs:7:14
    |
 LL |     let _x = -1_i32 >> 32;
-   |              ^^^^^^^^^^^^ attempt to shift right with overflow
+   |              ^^^^^^^^^^^^ attempt to shift right by 32_i32 which would overflow
    |
 note: the lint level is defined here
   --> $DIR/overflowing-rsh-1.rs:4:9

--- a/src/test/ui/numbers-arithmetic/overflowing-rsh-2.stderr
+++ b/src/test/ui/numbers-arithmetic/overflowing-rsh-2.stderr
@@ -2,7 +2,7 @@ error: this arithmetic operation will overflow
   --> $DIR/overflowing-rsh-2.rs:7:14
    |
 LL |     let _x = -1_i32 >> -1;
-   |              ^^^^^^^^^^^^ attempt to shift right with overflow
+   |              ^^^^^^^^^^^^ attempt to shift right by -1_i32 which would overflow
    |
 note: the lint level is defined here
   --> $DIR/overflowing-rsh-2.rs:4:9

--- a/src/test/ui/numbers-arithmetic/overflowing-rsh-3.stderr
+++ b/src/test/ui/numbers-arithmetic/overflowing-rsh-3.stderr
@@ -2,7 +2,7 @@ error: this arithmetic operation will overflow
   --> $DIR/overflowing-rsh-3.rs:7:14
    |
 LL |     let _x = -1_i64 >> 64;
-   |              ^^^^^^^^^^^^ attempt to shift right with overflow
+   |              ^^^^^^^^^^^^ attempt to shift right by 64_i32 which would overflow
    |
 note: the lint level is defined here
   --> $DIR/overflowing-rsh-3.rs:4:9

--- a/src/test/ui/numbers-arithmetic/overflowing-rsh-4.stderr
+++ b/src/test/ui/numbers-arithmetic/overflowing-rsh-4.stderr
@@ -2,7 +2,7 @@ error: this arithmetic operation will overflow
   --> $DIR/overflowing-rsh-4.rs:11:13
    |
 LL |     let x = 2_i8 >> 17;
-   |             ^^^^^^^^^^ attempt to shift right with overflow
+   |             ^^^^^^^^^^ attempt to shift right by 17_i32 which would overflow
    |
 note: the lint level is defined here
   --> $DIR/overflowing-rsh-4.rs:7:9

--- a/src/test/ui/numbers-arithmetic/overflowing-rsh-5.stderr
+++ b/src/test/ui/numbers-arithmetic/overflowing-rsh-5.stderr
@@ -2,7 +2,7 @@ error: this arithmetic operation will overflow
   --> $DIR/overflowing-rsh-5.rs:7:14
    |
 LL |     let _n = 1i64 >> [64][0];
-   |              ^^^^^^^^^^^^^^^ attempt to shift right with overflow
+   |              ^^^^^^^^^^^^^^^ attempt to shift right by 64_i32 which would overflow
    |
 note: the lint level is defined here
   --> $DIR/overflowing-rsh-5.rs:4:9

--- a/src/test/ui/numbers-arithmetic/overflowing-rsh-6.stderr
+++ b/src/test/ui/numbers-arithmetic/overflowing-rsh-6.stderr
@@ -2,7 +2,7 @@ error: this arithmetic operation will overflow
   --> $DIR/overflowing-rsh-6.rs:7:14
    |
 LL |     let _n = 1i64 >> [64][0];
-   |              ^^^^^^^^^^^^^^^ attempt to shift right with overflow
+   |              ^^^^^^^^^^^^^^^ attempt to shift right by 64_i32 which would overflow
    |
 note: the lint level is defined here
   --> $DIR/overflowing-rsh-6.rs:4:9

--- a/src/test/ui/or-patterns/exhaustiveness-non-exhaustive.rs
+++ b/src/test/ui/or-patterns/exhaustiveness-non-exhaustive.rs
@@ -4,15 +4,15 @@
 // We wrap patterns in a tuple because top-level or-patterns were special-cased.
 fn main() {
     match (0u8, 0u8) {
-        //~^ ERROR non-exhaustive patterns: `(2u8..=u8::MAX, _)`
+        //~^ ERROR non-exhaustive patterns: `(2_u8..=u8::MAX, _)`
         (0 | 1, 2 | 3) => {}
     }
     match ((0u8,),) {
-        //~^ ERROR non-exhaustive patterns: `((4u8..=u8::MAX))`
+        //~^ ERROR non-exhaustive patterns: `((4_u8..=u8::MAX))`
         ((0 | 1,) | (2 | 3,),) => {}
     }
     match (Some(0u8),) {
-        //~^ ERROR non-exhaustive patterns: `(Some(2u8..=u8::MAX))`
+        //~^ ERROR non-exhaustive patterns: `(Some(2_u8..=u8::MAX))`
         (None | Some(0 | 1),) => {}
     }
 }

--- a/src/test/ui/or-patterns/exhaustiveness-non-exhaustive.stderr
+++ b/src/test/ui/or-patterns/exhaustiveness-non-exhaustive.stderr
@@ -1,26 +1,26 @@
-error[E0004]: non-exhaustive patterns: `(2u8..=u8::MAX, _)` not covered
+error[E0004]: non-exhaustive patterns: `(2_u8..=u8::MAX, _)` not covered
   --> $DIR/exhaustiveness-non-exhaustive.rs:6:11
    |
 LL |     match (0u8, 0u8) {
-   |           ^^^^^^^^^^ pattern `(2u8..=u8::MAX, _)` not covered
+   |           ^^^^^^^^^^ pattern `(2_u8..=u8::MAX, _)` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `(u8, u8)`
 
-error[E0004]: non-exhaustive patterns: `((4u8..=u8::MAX))` not covered
+error[E0004]: non-exhaustive patterns: `((4_u8..=u8::MAX))` not covered
   --> $DIR/exhaustiveness-non-exhaustive.rs:10:11
    |
 LL |     match ((0u8,),) {
-   |           ^^^^^^^^^ pattern `((4u8..=u8::MAX))` not covered
+   |           ^^^^^^^^^ pattern `((4_u8..=u8::MAX))` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `((u8,),)`
 
-error[E0004]: non-exhaustive patterns: `(Some(2u8..=u8::MAX))` not covered
+error[E0004]: non-exhaustive patterns: `(Some(2_u8..=u8::MAX))` not covered
   --> $DIR/exhaustiveness-non-exhaustive.rs:14:11
    |
 LL |     match (Some(0u8),) {
-   |           ^^^^^^^^^^^^ pattern `(Some(2u8..=u8::MAX))` not covered
+   |           ^^^^^^^^^^^^ pattern `(Some(2_u8..=u8::MAX))` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `(std::option::Option<u8>,)`

--- a/src/test/ui/or-patterns/issue-69875-should-have-been-expanded-earlier-non-exhaustive.stderr
+++ b/src/test/ui/or-patterns/issue-69875-should-have-been-expanded-earlier-non-exhaustive.stderr
@@ -1,8 +1,8 @@
-error[E0005]: refutable pattern in local binding: `i32::MIN..=-1i32` and `3i32..=i32::MAX` not covered
+error[E0005]: refutable pattern in local binding: `i32::MIN..=-1_i32` and `3_i32..=i32::MAX` not covered
   --> $DIR/issue-69875-should-have-been-expanded-earlier-non-exhaustive.rs:4:9
    |
 LL |     let 0 | (1 | 2) = 0;
-   |         ^^^^^^^^^^^ patterns `i32::MIN..=-1i32` and `3i32..=i32::MAX` not covered
+   |         ^^^^^^^^^^^ patterns `i32::MIN..=-1_i32` and `3_i32..=i32::MAX` not covered
    |
    = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
    = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
@@ -12,11 +12,11 @@ help: you might want to use `if let` to ignore the variant that isn't matched
 LL |     if let 0 | (1 | 2) = 0 { /* */ }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0004]: non-exhaustive patterns: `i32::MIN..=-1i32` and `3i32..=i32::MAX` not covered
+error[E0004]: non-exhaustive patterns: `i32::MIN..=-1_i32` and `3_i32..=i32::MAX` not covered
   --> $DIR/issue-69875-should-have-been-expanded-earlier-non-exhaustive.rs:5:11
    |
 LL |     match 0 {
-   |           ^ patterns `i32::MIN..=-1i32` and `3i32..=i32::MAX` not covered
+   |           ^ patterns `i32::MIN..=-1_i32` and `3_i32..=i32::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `i32`

--- a/src/test/ui/pattern/usefulness/exhaustive_integer_patterns.stderr
+++ b/src/test/ui/pattern/usefulness/exhaustive_integer_patterns.stderr
@@ -10,20 +10,20 @@ note: the lint level is defined here
 LL | #![deny(unreachable_patterns)]
    |         ^^^^^^^^^^^^^^^^^^^^
 
-error[E0004]: non-exhaustive patterns: `128u8..=u8::MAX` not covered
+error[E0004]: non-exhaustive patterns: `128_u8..=u8::MAX` not covered
   --> $DIR/exhaustive_integer_patterns.rs:28:11
    |
 LL |     match x {
-   |           ^ pattern `128u8..=u8::MAX` not covered
+   |           ^ pattern `128_u8..=u8::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `u8`
 
-error[E0004]: non-exhaustive patterns: `11u8..=19u8`, `31u8..=34u8`, `36u8..=69u8` and 1 more not covered
+error[E0004]: non-exhaustive patterns: `11_u8..=19_u8`, `31_u8..=34_u8`, `36_u8..=69_u8` and 1 more not covered
   --> $DIR/exhaustive_integer_patterns.rs:33:11
    |
 LL |     match x {
-   |           ^ patterns `11u8..=19u8`, `31u8..=34u8`, `36u8..=69u8` and 1 more not covered
+   |           ^ patterns `11_u8..=19_u8`, `31_u8..=34_u8`, `36_u8..=69_u8` and 1 more not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `u8`
@@ -34,11 +34,11 @@ error: unreachable pattern
 LL |         -2..=20 => {}
    |         ^^^^^^^
 
-error[E0004]: non-exhaustive patterns: `i8::MIN..=-8i8`, `-6i8`, `121i8..=124i8` and 1 more not covered
+error[E0004]: non-exhaustive patterns: `i8::MIN..=-8_i8`, `-6_i8`, `121_i8..=124_i8` and 1 more not covered
   --> $DIR/exhaustive_integer_patterns.rs:41:11
    |
 LL |     match x {
-   |           ^ patterns `i8::MIN..=-8i8`, `-6i8`, `121i8..=124i8` and 1 more not covered
+   |           ^ patterns `i8::MIN..=-8_i8`, `-6_i8`, `121_i8..=124_i8` and 1 more not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `i8`
@@ -52,38 +52,38 @@ LL |     match 0i8 {
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `i8`
 
-error[E0004]: non-exhaustive patterns: `0i16` not covered
+error[E0004]: non-exhaustive patterns: `0_i16` not covered
   --> $DIR/exhaustive_integer_patterns.rs:91:11
    |
 LL |     match 0i16 {
-   |           ^^^^ pattern `0i16` not covered
+   |           ^^^^ pattern `0_i16` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `i16`
 
-error[E0004]: non-exhaustive patterns: `128u8..=u8::MAX` not covered
+error[E0004]: non-exhaustive patterns: `128_u8..=u8::MAX` not covered
   --> $DIR/exhaustive_integer_patterns.rs:109:11
    |
 LL |     match 0u8 {
-   |           ^^^ pattern `128u8..=u8::MAX` not covered
+   |           ^^^ pattern `128_u8..=u8::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `u8`
 
-error[E0004]: non-exhaustive patterns: `(0u8, Some(_))` and `(2u8..=u8::MAX, Some(_))` not covered
+error[E0004]: non-exhaustive patterns: `(0_u8, Some(_))` and `(2_u8..=u8::MAX, Some(_))` not covered
   --> $DIR/exhaustive_integer_patterns.rs:121:11
    |
 LL |     match (0u8, Some(())) {
-   |           ^^^^^^^^^^^^^^^ patterns `(0u8, Some(_))` and `(2u8..=u8::MAX, Some(_))` not covered
+   |           ^^^^^^^^^^^^^^^ patterns `(0_u8, Some(_))` and `(2_u8..=u8::MAX, Some(_))` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `(u8, std::option::Option<()>)`
 
-error[E0004]: non-exhaustive patterns: `(126u8..=127u8, false)` not covered
+error[E0004]: non-exhaustive patterns: `(126_u8..=127_u8, false)` not covered
   --> $DIR/exhaustive_integer_patterns.rs:126:11
    |
 LL |     match (0u8, true) {
-   |           ^^^^^^^^^^^ pattern `(126u8..=127u8, false)` not covered
+   |           ^^^^^^^^^^^ pattern `(126_u8..=127_u8, false)` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `(u8, bool)`
@@ -92,7 +92,7 @@ error: multiple patterns covering the same range
   --> $DIR/exhaustive_integer_patterns.rs:141:9
    |
 LL |         0 .. 2 => {}
-   |         ------ this range overlaps on `1u8`
+   |         ------ this range overlaps on `1_u8`
 LL |         1 ..= 2 => {}
    |         ^^^^^^^ overlapping patterns
    |
@@ -111,20 +111,20 @@ LL |     match 0u128 {
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `u128`
 
-error[E0004]: non-exhaustive patterns: `5u128..=u128::MAX` not covered
+error[E0004]: non-exhaustive patterns: `5_u128..=u128::MAX` not covered
   --> $DIR/exhaustive_integer_patterns.rs:150:11
    |
 LL |     match 0u128 {
-   |           ^^^^^ pattern `5u128..=u128::MAX` not covered
+   |           ^^^^^ pattern `5_u128..=u128::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `u128`
 
-error[E0004]: non-exhaustive patterns: `0u128..=3u128` not covered
+error[E0004]: non-exhaustive patterns: `0_u128..=3_u128` not covered
   --> $DIR/exhaustive_integer_patterns.rs:154:11
    |
 LL |     match 0u128 {
-   |           ^^^^^ pattern `0u128..=3u128` not covered
+   |           ^^^^^ pattern `0_u128..=3_u128` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `u128`

--- a/src/test/ui/pattern/usefulness/issue-43253.stderr
+++ b/src/test/ui/pattern/usefulness/issue-43253.stderr
@@ -2,7 +2,7 @@ warning: multiple patterns covering the same range
   --> $DIR/issue-43253.rs:16:9
    |
 LL |         1..10 => {},
-   |         ----- this range overlaps on `9i32`
+   |         ----- this range overlaps on `9_i32`
 LL |         9..=10 => {},
    |         ^^^^^^ overlapping patterns
    |

--- a/src/test/ui/pattern/usefulness/match-byte-array-patterns-2.stderr
+++ b/src/test/ui/pattern/usefulness/match-byte-array-patterns-2.stderr
@@ -1,8 +1,8 @@
-error[E0004]: non-exhaustive patterns: `&[0u8..=64u8, _, _, _]` and `&[66u8..=u8::MAX, _, _, _]` not covered
+error[E0004]: non-exhaustive patterns: `&[0_u8..=64_u8, _, _, _]` and `&[66_u8..=u8::MAX, _, _, _]` not covered
   --> $DIR/match-byte-array-patterns-2.rs:4:11
    |
 LL |     match buf {
-   |           ^^^ patterns `&[0u8..=64u8, _, _, _]` and `&[66u8..=u8::MAX, _, _, _]` not covered
+   |           ^^^ patterns `&[0_u8..=64_u8, _, _, _]` and `&[66_u8..=u8::MAX, _, _, _]` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `&[u8; 4]`

--- a/src/test/ui/pattern/usefulness/match-non-exhaustive.stderr
+++ b/src/test/ui/pattern/usefulness/match-non-exhaustive.stderr
@@ -1,8 +1,8 @@
-error[E0004]: non-exhaustive patterns: `i32::MIN..=0i32` and `2i32..=i32::MAX` not covered
+error[E0004]: non-exhaustive patterns: `i32::MIN..=0_i32` and `2_i32..=i32::MAX` not covered
   --> $DIR/match-non-exhaustive.rs:2:11
    |
 LL |     match 0 { 1 => () }
-   |           ^ patterns `i32::MIN..=0i32` and `2i32..=i32::MAX` not covered
+   |           ^ patterns `i32::MIN..=0_i32` and `2_i32..=i32::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `i32`

--- a/src/test/ui/pattern/usefulness/non-exhaustive-match.rs
+++ b/src/test/ui/pattern/usefulness/non-exhaustive-match.rs
@@ -11,8 +11,8 @@ fn main() {
     match Some(10) { //~ ERROR non-exhaustive patterns: `Some(_)` not covered
       None => {}
     }
-    match (2, 3, 4) { //~ ERROR non-exhaustive patterns: `(_, _, i32::MIN..=3i32)`
-                      //  and `(_, _, 5i32..=i32::MAX)` not covered
+    match (2, 3, 4) { //~ ERROR non-exhaustive patterns: `(_, _, i32::MIN..=3_i32)`
+                      //  and `(_, _, 5_i32..=i32::MAX)` not covered
       (_, _, 4) => {}
     }
     match (T::A, T::A) { //~ ERROR non-exhaustive patterns: `(A, A)` not covered

--- a/src/test/ui/pattern/usefulness/non-exhaustive-match.stderr
+++ b/src/test/ui/pattern/usefulness/non-exhaustive-match.stderr
@@ -36,11 +36,11 @@ LL |     Some(#[stable(feature = "rust1", since = "1.0.0")] T),
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `std::option::Option<i32>`
 
-error[E0004]: non-exhaustive patterns: `(_, _, i32::MIN..=3i32)` and `(_, _, 5i32..=i32::MAX)` not covered
+error[E0004]: non-exhaustive patterns: `(_, _, i32::MIN..=3_i32)` and `(_, _, 5_i32..=i32::MAX)` not covered
   --> $DIR/non-exhaustive-match.rs:14:11
    |
 LL |     match (2, 3, 4) {
-   |           ^^^^^^^^^ patterns `(_, _, i32::MIN..=3i32)` and `(_, _, 5i32..=i32::MAX)` not covered
+   |           ^^^^^^^^^ patterns `(_, _, i32::MIN..=3_i32)` and `(_, _, 5_i32..=i32::MAX)` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `(i32, i32, i32)`

--- a/src/test/ui/pattern/usefulness/refutable-pattern-errors.rs
+++ b/src/test/ui/pattern/usefulness/refutable-pattern-errors.rs
@@ -5,5 +5,5 @@ fn func((1, (Some(1), 2..=3)): (isize, (Option<isize>, isize))) { }
 
 fn main() {
     let (1, (Some(1), 2..=3)) = (1, (None, 2));
-    //~^ ERROR refutable pattern in local binding: `(i32::MIN..=0i32, _)` and `(2i32..=i32::MAX, _)` not covered
+    //~^ ERROR refutable pattern in local binding: `(i32::MIN..=0_i32, _)` and `(2_i32..=i32::MAX, _)` not covered
 }

--- a/src/test/ui/pattern/usefulness/refutable-pattern-errors.stderr
+++ b/src/test/ui/pattern/usefulness/refutable-pattern-errors.stderr
@@ -6,11 +6,11 @@ LL | fn func((1, (Some(1), 2..=3)): (isize, (Option<isize>, isize))) { }
    |
    = note: the matched value is of type `(isize, (std::option::Option<isize>, isize))`
 
-error[E0005]: refutable pattern in local binding: `(i32::MIN..=0i32, _)` and `(2i32..=i32::MAX, _)` not covered
+error[E0005]: refutable pattern in local binding: `(i32::MIN..=0_i32, _)` and `(2_i32..=i32::MAX, _)` not covered
   --> $DIR/refutable-pattern-errors.rs:7:9
    |
 LL |     let (1, (Some(1), 2..=3)) = (1, (None, 2));
-   |         ^^^^^^^^^^^^^^^^^^^^^ patterns `(i32::MIN..=0i32, _)` and `(2i32..=i32::MAX, _)` not covered
+   |         ^^^^^^^^^^^^^^^^^^^^^ patterns `(i32::MIN..=0_i32, _)` and `(2_i32..=i32::MAX, _)` not covered
    |
    = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
    = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html

--- a/src/test/ui/precise_pointer_size_matching.stderr
+++ b/src/test/ui/precise_pointer_size_matching.stderr
@@ -1,17 +1,17 @@
-error[E0004]: non-exhaustive patterns: `isize::MIN..=-6isize` and `21isize..=isize::MAX` not covered
+error[E0004]: non-exhaustive patterns: `isize::MIN..=-6_isize` and `21_isize..=isize::MAX` not covered
   --> $DIR/precise_pointer_size_matching.rs:24:11
    |
 LL |     match 0isize {
-   |           ^^^^^^ patterns `isize::MIN..=-6isize` and `21isize..=isize::MAX` not covered
+   |           ^^^^^^ patterns `isize::MIN..=-6_isize` and `21_isize..=isize::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `isize`
 
-error[E0004]: non-exhaustive patterns: `0usize` and `21usize..=usize::MAX` not covered
+error[E0004]: non-exhaustive patterns: `0_usize` and `21_usize..=usize::MAX` not covered
   --> $DIR/precise_pointer_size_matching.rs:29:11
    |
 LL |     match 0usize {
-   |           ^^^^^^ patterns `0usize` and `21usize..=usize::MAX` not covered
+   |           ^^^^^^ patterns `0_usize` and `21_usize..=usize::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `usize`

--- a/src/test/ui/suggestions/const-pat-non-exaustive-let-new-var.rs
+++ b/src/test/ui/suggestions/const-pat-non-exaustive-let-new-var.rs
@@ -1,6 +1,6 @@
 fn main() {
     let A = 3;
-    //~^ ERROR refutable pattern in local binding: `i32::MIN..=1i32` and
+    //~^ ERROR refutable pattern in local binding: `i32::MIN..=1_i32` and
     //~| interpreted as a constant pattern, not a new variable
     //~| HELP introduce a variable instead
     //~| SUGGESTION a_var

--- a/src/test/ui/suggestions/const-pat-non-exaustive-let-new-var.stderr
+++ b/src/test/ui/suggestions/const-pat-non-exaustive-let-new-var.stderr
@@ -1,4 +1,4 @@
-error[E0005]: refutable pattern in local binding: `i32::MIN..=1i32` and `3i32..=i32::MAX` not covered
+error[E0005]: refutable pattern in local binding: `i32::MIN..=1_i32` and `3_i32..=i32::MAX` not covered
   --> $DIR/const-pat-non-exaustive-let-new-var.rs:2:9
    |
 LL |     let A = 3;


### PR DESCRIPTION
Fixes #71134

In contrast to the example in the issue it doesn't use individual spans for each operand. The effort required to implement that is quite high compared to the little (if at all) benefit it would bring to diagnostics.

cc @shepmaster 

The way this is implemented it is also fairly easy to do the same for overflow panics at runtime, but that should be done in a separate PR since it may have runtime performance implications.