### PR TITLE
Add second message for LiveDrop errors

### DIFF
--- a/src/librustc_mir/transform/check_consts/post_drop_elaboration.rs
+++ b/src/librustc_mir/transform/check_consts/post_drop_elaboration.rs
@@ -58,7 +58,7 @@ impl std::ops::Deref for CheckLiveDrops<'mir, 'tcx> {
 
 impl CheckLiveDrops<'mir, 'tcx> {
     fn check_live_drop(&self, span: Span) {
-        ops::non_const(self.ccx, ops::LiveDrop, span);
+        ops::non_const(self.ccx, ops::LiveDrop(None), span);
     }
 }
 

--- a/src/librustc_mir/transform/check_consts/validation.rs
+++ b/src/librustc_mir/transform/check_consts/validation.rs
@@ -588,7 +588,10 @@ impl Visitor<'tcx> for Validator<'mir, 'tcx> {
                 };
 
                 if needs_drop {
-                    self.check_op_spanned(ops::LiveDrop, err_span);
+                    self.check_op_spanned(
+                        ops::LiveDrop(Some(terminator.source_info.span)),
+                        err_span,
+                    );
                 }
             }
 

--- a/src/test/ui/check-static-values-constraints.stderr
+++ b/src/test/ui/check-static-values-constraints.stderr
@@ -5,7 +5,9 @@ LL |                                           ..SafeStruct{field1: SafeEnum::Va
    |  ___________________________________________^
 LL | |
 LL | |                                                      field2: SafeEnum::Variant1}};
-   | |________________________________________________________________________________^ statics cannot evaluate destructors
+   | |                                                                                ^- value is dropped here
+   | |________________________________________________________________________________|
+   |                                                                                  statics cannot evaluate destructors
 
 error[E0010]: allocations are not allowed in statics
   --> $DIR/check-static-values-constraints.rs:79:33

--- a/src/test/ui/consts/const-eval/const_let.stderr
+++ b/src/test/ui/consts/const-eval/const_let.stderr
@@ -2,25 +2,33 @@ error[E0493]: destructors cannot be evaluated at compile-time
   --> $DIR/const_let.rs:16:32
    |
 LL | const Y: FakeNeedsDrop = { let mut x = FakeNeedsDrop; x = FakeNeedsDrop; x };
-   |                                ^^^^^ constants cannot evaluate destructors
+   |                                ^^^^^                  - value is dropped here
+   |                                |
+   |                                constants cannot evaluate destructors
 
 error[E0493]: destructors cannot be evaluated at compile-time
   --> $DIR/const_let.rs:20:33
    |
 LL | const Y2: FakeNeedsDrop = { let mut x; x = FakeNeedsDrop; x = FakeNeedsDrop; x };
-   |                                 ^^^^^ constants cannot evaluate destructors
+   |                                 ^^^^^                     - value is dropped here
+   |                                 |
+   |                                 constants cannot evaluate destructors
 
 error[E0493]: destructors cannot be evaluated at compile-time
   --> $DIR/const_let.rs:24:21
    |
 LL | const Z: () = { let mut x = None; x = Some(FakeNeedsDrop); };
-   |                     ^^^^^ constants cannot evaluate destructors
+   |                     ^^^^^                                  - value is dropped here
+   |                     |
+   |                     constants cannot evaluate destructors
 
 error[E0493]: destructors cannot be evaluated at compile-time
   --> $DIR/const_let.rs:28:22
    |
 LL | const Z2: () = { let mut x; x = None; x = Some(FakeNeedsDrop); };
-   |                      ^^^^^ constants cannot evaluate destructors
+   |                      ^^^^^                                     - value is dropped here
+   |                      |
+   |                      constants cannot evaluate destructors
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/consts/const-eval/issue-65394.stderr
+++ b/src/test/ui/consts/const-eval/issue-65394.stderr
@@ -12,6 +12,9 @@ error[E0493]: destructors cannot be evaluated at compile-time
    |
 LL |     let mut x = Vec::<i32>::new();
    |         ^^^^^ constants cannot evaluate destructors
+...
+LL | };
+   | - value is dropped here
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/consts/const-eval/livedrop.rs
+++ b/src/test/ui/consts/const-eval/livedrop.rs
@@ -1,0 +1,20 @@
+#![feature(const_if_match)]
+#![feature(const_loop)]
+
+const _: Option<Vec<i32>> = {
+    let mut never_returned = Some(Vec::new());
+    let mut always_returned = None; //~ ERROR destructors cannot be evaluated at compile-time
+
+    let mut i = 0;
+    loop {
+        always_returned = never_returned;
+        never_returned = None;
+
+        i += 1;
+        if i == 10 {
+            break always_returned;
+        }
+    }
+};
+
+fn main() {}

--- a/src/test/ui/consts/const-eval/livedrop.stderr
+++ b/src/test/ui/consts/const-eval/livedrop.stderr
@@ -1,0 +1,12 @@
+error[E0493]: destructors cannot be evaluated at compile-time
+  --> $DIR/livedrop.rs:6:9
+   |
+LL |     let mut always_returned = None;
+   |         ^^^^^^^^^^^^^^^^^^^ constants cannot evaluate destructors
+...
+LL |         always_returned = never_returned;
+   |         --------------- value is dropped here
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0493`.

--- a/src/test/ui/consts/control-flow/drop-fail.stock.stderr
+++ b/src/test/ui/consts/control-flow/drop-fail.stock.stderr
@@ -3,24 +3,36 @@ error[E0493]: destructors cannot be evaluated at compile-time
    |
 LL |     let x = Some(Vec::new());
    |         ^ constants cannot evaluate destructors
+...
+LL | };
+   | - value is dropped here
 
 error[E0493]: destructors cannot be evaluated at compile-time
   --> $DIR/drop-fail.rs:23:9
    |
 LL |     let vec_tuple = (Vec::new(),);
    |         ^^^^^^^^^ constants cannot evaluate destructors
+...
+LL | };
+   | - value is dropped here
 
 error[E0493]: destructors cannot be evaluated at compile-time
   --> $DIR/drop-fail.rs:31:9
    |
 LL |     let x: Result<_, Vec<i32>> = Ok(Vec::new());
    |         ^ constants cannot evaluate destructors
+...
+LL | };
+   | - value is dropped here
 
 error[E0493]: destructors cannot be evaluated at compile-time
   --> $DIR/drop-fail.rs:41:9
    |
 LL |     let mut tmp = None;
    |         ^^^^^^^ constants cannot evaluate destructors
+...
+LL | };
+   | - value is dropped here
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/consts/min_const_fn/min_const_fn.stderr
+++ b/src/test/ui/consts/min_const_fn/min_const_fn.stderr
@@ -2,7 +2,9 @@ error[E0493]: destructors cannot be evaluated at compile-time
   --> $DIR/min_const_fn.rs:37:25
    |
 LL |     const fn into_inner(self) -> T { self.0 }
-   |                         ^^^^ constant functions cannot evaluate destructors
+   |                         ^^^^                - value is dropped here
+   |                         |
+   |                         constant functions cannot evaluate destructors
 
 error[E0723]: mutable references in const fn are unstable
   --> $DIR/min_const_fn.rs:39:36
@@ -17,7 +19,9 @@ error[E0493]: destructors cannot be evaluated at compile-time
   --> $DIR/min_const_fn.rs:44:28
    |
 LL |     const fn into_inner_lt(self) -> T { self.0 }
-   |                            ^^^^ constant functions cannot evaluate destructors
+   |                            ^^^^                - value is dropped here
+   |                            |
+   |                            constant functions cannot evaluate destructors
 
 error[E0723]: mutable references in const fn are unstable
   --> $DIR/min_const_fn.rs:46:42
@@ -32,7 +36,9 @@ error[E0493]: destructors cannot be evaluated at compile-time
   --> $DIR/min_const_fn.rs:51:27
    |
 LL |     const fn into_inner_s(self) -> T { self.0 }
-   |                           ^^^^ constant functions cannot evaluate destructors
+   |                           ^^^^                - value is dropped here
+   |                           |
+   |                           constant functions cannot evaluate destructors
 
 error[E0723]: mutable references in const fn are unstable
   --> $DIR/min_const_fn.rs:53:38

--- a/src/test/ui/consts/miri_unleashed/feature-gate-unleash_the_miri_inside_of_you.stderr
+++ b/src/test/ui/consts/miri_unleashed/feature-gate-unleash_the_miri_inside_of_you.stderr
@@ -2,7 +2,9 @@ error[E0493]: destructors cannot be evaluated at compile-time
   --> $DIR/feature-gate-unleash_the_miri_inside_of_you.rs:11:20
    |
 LL |     const F: u32 = (U::X, 42).1;
-   |                    ^^^^^^^^^^ constants cannot evaluate destructors
+   |                    ^^^^^^^^^^ - value is dropped here
+   |                    |
+   |                    constants cannot evaluate destructors
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/unstable-const-fn-in-libcore.stderr
+++ b/src/test/ui/consts/unstable-const-fn-in-libcore.stderr
@@ -9,12 +9,18 @@ error[E0493]: destructors cannot be evaluated at compile-time
    |
 LL |     const fn unwrap_or_else<F: FnOnce() -> T>(self, f: F) -> T {
    |                                                     ^ constant functions cannot evaluate destructors
+...
+LL |     }
+   |     - value is dropped here
 
 error[E0493]: destructors cannot be evaluated at compile-time
   --> $DIR/unstable-const-fn-in-libcore.rs:19:47
    |
 LL |     const fn unwrap_or_else<F: FnOnce() -> T>(self, f: F) -> T {
    |                                               ^^^^ constant functions cannot evaluate destructors
+...
+LL |     }
+   |     - value is dropped here
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/span/E0493.stderr
+++ b/src/test/ui/span/E0493.stderr
@@ -2,7 +2,9 @@ error[E0493]: destructors cannot be evaluated at compile-time
   --> $DIR/E0493.rs:17:17
    |
 LL | const F : Foo = (Foo { a : 0 }, Foo { a : 1 }).1;
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constants cannot evaluate destructors
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - value is dropped here
+   |                 |
+   |                 constants cannot evaluate destructors
 
 error: aborting due to previous error
 

--- a/src/test/ui/static/static-drop-scope.stderr
+++ b/src/test/ui/static/static-drop-scope.stderr
@@ -2,7 +2,9 @@ error[E0493]: destructors cannot be evaluated at compile-time
   --> $DIR/static-drop-scope.rs:9:60
    |
 LL | static PROMOTION_FAIL_S: Option<&'static WithDtor> = Some(&WithDtor);
-   |                                                            ^^^^^^^^ statics cannot evaluate destructors
+   |                                                            ^^^^^^^^- value is dropped here
+   |                                                            |
+   |                                                            statics cannot evaluate destructors
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/static-drop-scope.rs:9:60
@@ -18,7 +20,9 @@ error[E0493]: destructors cannot be evaluated at compile-time
   --> $DIR/static-drop-scope.rs:13:59
    |
 LL | const PROMOTION_FAIL_C: Option<&'static WithDtor> = Some(&WithDtor);
-   |                                                           ^^^^^^^^ constants cannot evaluate destructors
+   |                                                           ^^^^^^^^- value is dropped here
+   |                                                           |
+   |                                                           constants cannot evaluate destructors
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/static-drop-scope.rs:13:59
@@ -34,37 +38,50 @@ error[E0493]: destructors cannot be evaluated at compile-time
   --> $DIR/static-drop-scope.rs:17:28
    |
 LL | static EARLY_DROP_S: i32 = (WithDtor, 0).1;
-   |                            ^^^^^^^^^^^^^ statics cannot evaluate destructors
+   |                            ^^^^^^^^^^^^^ - value is dropped here
+   |                            |
+   |                            statics cannot evaluate destructors
 
 error[E0493]: destructors cannot be evaluated at compile-time
   --> $DIR/static-drop-scope.rs:20:27
    |
 LL | const EARLY_DROP_C: i32 = (WithDtor, 0).1;
-   |                           ^^^^^^^^^^^^^ constants cannot evaluate destructors
+   |                           ^^^^^^^^^^^^^ - value is dropped here
+   |                           |
+   |                           constants cannot evaluate destructors
 
 error[E0493]: destructors cannot be evaluated at compile-time
   --> $DIR/static-drop-scope.rs:23:24
    |
 LL | const fn const_drop<T>(_: T) {}
-   |                        ^ constant functions cannot evaluate destructors
+   |                        ^      - value is dropped here
+   |                        |
+   |                        constant functions cannot evaluate destructors
 
 error[E0493]: destructors cannot be evaluated at compile-time
   --> $DIR/static-drop-scope.rs:27:5
    |
 LL |     (x, ()).1
    |     ^^^^^^^ constant functions cannot evaluate destructors
+LL |
+LL | }
+   | - value is dropped here
 
 error[E0493]: destructors cannot be evaluated at compile-time
   --> $DIR/static-drop-scope.rs:31:34
    |
 LL | const EARLY_DROP_C_OPTION: i32 = (Some(WithDtor), 0).1;
-   |                                  ^^^^^^^^^^^^^^^^^^^ constants cannot evaluate destructors
+   |                                  ^^^^^^^^^^^^^^^^^^^ - value is dropped here
+   |                                  |
+   |                                  constants cannot evaluate destructors
 
 error[E0493]: destructors cannot be evaluated at compile-time
   --> $DIR/static-drop-scope.rs:36:43
    |
 LL | const EARLY_DROP_C_OPTION_CONSTANT: i32 = (HELPER, 0).1;
-   |                                           ^^^^^^^^^^^ constants cannot evaluate destructors
+   |                                           ^^^^^^^^^^^ - value is dropped here
+   |                                           |
+   |                                           constants cannot evaluate destructors
 
 error: aborting due to 10 previous errors
 


### PR DESCRIPTION
This is an attempt to fix https://github.com/rust-lang/rust/issues/72907 by adding a second message to the `LiveDrop` diagnostics. Changing from this
```
error[E0493]: destructors cannot be evaluated at compile-time
 --> src/lib.rs:7:9
  |
7 |     let mut always_returned = None;
  |         ^^^^^^^^^^^^^^^^^^^ constants cannot evaluate destructors

error: aborting due to previous error
```
to this
```
error[E0493]: destructors cannot be evaluated at compile-time
  --> foo.rs:6:9
   |
6  |     let mut always_returned = None;
   |         ^^^^^^^^^^^^^^^^^^^ constants cannot evaluate destructors
...
10 |         always_returned = never_returned;
   |         --------------- value is dropped here

error: aborting due to previous error
```
r? @RalfJung @ecstatic-morse 