### PR TITLE
Allow dynamic linking for iOS/tvOS targets

### DIFF
--- a/src/librustc_target/spec/apple_sdk_base.rs
+++ b/src/librustc_target/spec/apple_sdk_base.rs
@@ -141,7 +141,6 @@ pub fn opts(arch: Arch, os: AppleOS) -> Result<TargetOptions, String> {
     let pre_link_args = build_pre_link_args(arch, os)?;
     Ok(TargetOptions {
         cpu: target_cpu(arch),
-        dynamic_linking: false,
         executables: true,
         pre_link_args,
         link_env_remove: link_env_remove(arch),


### PR DESCRIPTION
During the development and testing of the [Crabapple project](https://github.com/Crabapple-iOS/Crabapple), one obstacle was the lack of `cdylib` target support for iOS. Surprisingly, once `dynamic_linking` was enabled for iOS targets, it worked seemingly flawlessly.

I could not find any information on why this was initially or still is disabled.