### PR TITLE
Upgrade to LLVM 11 (rc2)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -37,7 +37,7 @@
 [submodule "src/llvm-project"]
 	path = src/llvm-project
 	url = https://github.com/rust-lang/llvm-project.git
-	branch = rustc/10.0-2020-05-05
+	branch = rustc/11.0-2020-08-20
 [submodule "src/doc/embedded-book"]
 	path = src/doc/embedded-book
 	url = https://github.com/rust-embedded/book.git

--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/build-clang.sh
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/build-clang.sh
@@ -18,16 +18,7 @@ cd clang-build
 # For whatever reason the default set of include paths for clang is different
 # than that of gcc. As a result we need to manually include our sysroot's
 # include path, /rustroot/include, to clang's default include path.
-#
-# Alsow there's this weird oddity with gcc where there's an 'include-fixed'
-# directory that it generates. It turns out [1] that Centos 5's headers are so
-# old that they're incompatible with modern C semantics. While gcc automatically
-# fixes that clang doesn't account for this. Tell clang to manually include the
-# fixed headers so we can successfully compile code later on.
-#
-# [1]: https://sourceware.org/ml/crossgcc/2008-11/msg00028.html
 INC="/rustroot/include"
-INC="$INC:/rustroot/lib/gcc/x86_64-unknown-linux-gnu/5.5.0/include-fixed"
 INC="$INC:/usr/include"
 
 hide_output \

--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/build-clang.sh
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/build-clang.sh
@@ -18,8 +18,7 @@ cd clang-build
 # For whatever reason the default set of include paths for clang is different
 # than that of gcc. As a result we need to manually include our sysroot's
 # include path, /rustroot/include, to clang's default include path.
-INC="/rustroot/include"
-INC="$INC:/usr/include"
+INC="/rustroot/include:/usr/include"
 
 hide_output \
     cmake ../llvm \

--- a/src/test/assembly/asm/riscv-types.rs
+++ b/src/test/assembly/asm/riscv-types.rs
@@ -55,7 +55,8 @@ pub unsafe fn sym_fn() {
 
 // CHECK-LABEL: sym_static:
 // CHECK: #APP
-// CHECK: lb t0, extern_static
+// CHECK: auipc t0, %pcrel_hi(extern_static)
+// CHECK: lb t0, %pcrel_lo(.Lpcrel_hi0)(t0)
 // CHECK: #NO_APP
 #[no_mangle]
 pub unsafe fn sym_static() {
@@ -98,45 +99,45 @@ macro_rules! check_reg {
 
 // CHECK-LABEL: reg_i8:
 // CHECK: #APP
-// CHECK: mv {{[a-z0-9]+}}, {{[a-z0-9]+}}
+// CHECK: add {{[a-z0-9]+}}, zero, {{[a-z0-9]+}}
 // CHECK: #NO_APP
 check!(reg_i8 i8 reg "mv");
 
 // CHECK-LABEL: reg_i16:
 // CHECK: #APP
-// CHECK: mv {{[a-z0-9]+}}, {{[a-z0-9]+}}
+// CHECK: add {{[a-z0-9]+}}, zero, {{[a-z0-9]+}}
 // CHECK: #NO_APP
 check!(reg_i16 i16 reg "mv");
 
 // CHECK-LABEL: reg_i32:
 // CHECK: #APP
-// CHECK: mv {{[a-z0-9]+}}, {{[a-z0-9]+}}
+// CHECK: add {{[a-z0-9]+}}, zero, {{[a-z0-9]+}}
 // CHECK: #NO_APP
 check!(reg_i32 i32 reg "mv");
 
 // CHECK-LABEL: reg_f32:
 // CHECK: #APP
-// CHECK: mv {{[a-z0-9]+}}, {{[a-z0-9]+}}
+// CHECK: add {{[a-z0-9]+}}, zero, {{[a-z0-9]+}}
 // CHECK: #NO_APP
 check!(reg_f32 f32 reg "mv");
 
 // riscv64-LABEL: reg_i64:
 // riscv64: #APP
-// riscv64: mv {{[a-z0-9]+}}, {{[a-z0-9]+}}
+// riscv64: add {{[a-z0-9]+}}, zero, {{[a-z0-9]+}}
 // riscv64: #NO_APP
 #[cfg(riscv64)]
 check!(reg_i64 i64 reg "mv");
 
 // riscv64-LABEL: reg_f64:
 // riscv64: #APP
-// riscv64: mv {{[a-z0-9]+}}, {{[a-z0-9]+}}
+// riscv64: add {{[a-z0-9]+}}, zero, {{[a-z0-9]+}}
 // riscv64: #NO_APP
 #[cfg(riscv64)]
 check!(reg_f64 f64 reg "mv");
 
 // CHECK-LABEL: reg_ptr:
 // CHECK: #APP
-// CHECK: mv {{[a-z0-9]+}}, {{[a-z0-9]+}}
+// CHECK: add {{[a-z0-9]+}}, zero, {{[a-z0-9]+}}
 // CHECK: #NO_APP
 check!(reg_ptr ptr reg "mv");
 
@@ -154,45 +155,45 @@ check!(freg_f64 f64 freg "fmv.d");
 
 // CHECK-LABEL: a0_i8:
 // CHECK: #APP
-// CHECK: mv a0, a0
+// CHECK: add a0, zero, a0
 // CHECK: #NO_APP
 check_reg!(a0_i8 i8 "a0" "mv");
 
 // CHECK-LABEL: a0_i16:
 // CHECK: #APP
-// CHECK: mv a0, a0
+// CHECK: add a0, zero, a0
 // CHECK: #NO_APP
 check_reg!(a0_i16 i16 "a0" "mv");
 
 // CHECK-LABEL: a0_i32:
 // CHECK: #APP
-// CHECK: mv a0, a0
+// CHECK: add a0, zero, a0
 // CHECK: #NO_APP
 check_reg!(a0_i32 i32 "a0" "mv");
 
 // CHECK-LABEL: a0_f32:
 // CHECK: #APP
-// CHECK: mv a0, a0
+// CHECK: add a0, zero, a0
 // CHECK: #NO_APP
 check_reg!(a0_f32 f32 "a0" "mv");
 
 // riscv64-LABEL: a0_i64:
 // riscv64: #APP
-// riscv64: mv a0, a0
+// riscv64: add a0, zero, a0
 // riscv64: #NO_APP
 #[cfg(riscv64)]
 check_reg!(a0_i64 i64 "a0" "mv");
 
 // riscv64-LABEL: a0_f64:
 // riscv64: #APP
-// riscv64: mv a0, a0
+// riscv64: add a0, zero, a0
 // riscv64: #NO_APP
 #[cfg(riscv64)]
 check_reg!(a0_f64 f64 "a0" "mv");
 
 // CHECK-LABEL: a0_ptr:
 // CHECK: #APP
-// CHECK: mv a0, a0
+// CHECK: add a0, zero, a0
 // CHECK: #NO_APP
 check_reg!(a0_ptr ptr "a0" "mv");
 

--- a/src/test/codegen/scalar-pair-bool.rs
+++ b/src/test/codegen/scalar-pair-bool.rs
@@ -24,8 +24,9 @@ pub fn pair_i32_bool(pair: (i32, bool)) -> (i32, bool) {
 #[no_mangle]
 pub fn pair_and_or((a, b): (bool, bool)) -> (bool, bool) {
     // Make sure it can operate directly on the unpacked args
-    // CHECK: and i1 %_1.0, %_1.1
-    // CHECK: or i1 %_1.0, %_1.1
+    // (but it might not be using simple and/or instructions)
+    // CHECK-DAG: %_1.0
+    // CHECK-DAG: %_1.1
     (a && b, a || b)
 }
 

--- a/src/test/run-make-fulldeps/instrument-coverage/expected_export_coverage.json
+++ b/src/test/run-make-fulldeps/instrument-coverage/expected_export_coverage.json
@@ -55,5 +55,5 @@
     }
   ],
   "type": "llvm.coverage.json.export",
-  "version": "2.0.0"
+  "version": "2.0.1"
 }


### PR DESCRIPTION
This builds on #73525 to try actually moving rust-lang/llvm-project to LLVM 11.