### PR TITLE
Add license fields to all crates.

### DIFF
--- a/compiler/rustc/Cargo.toml
+++ b/compiler/rustc/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "rustc-main"
 version = "0.0.0"
+license = "MIT OR Apache-2.0"
 edition = '2018'
 
 [[bin]]

--- a/compiler/rustc_apfloat/Cargo.toml
+++ b/compiler/rustc_apfloat/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "rustc_apfloat"
 version = "0.0.0"
+license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [dependencies]

--- a/compiler/rustc_arena/Cargo.toml
+++ b/compiler/rustc_arena/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "rustc_arena"
 version = "0.0.0"
+license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [dependencies]

--- a/compiler/rustc_ast/Cargo.toml
+++ b/compiler/rustc_ast/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "rustc_ast"
 version = "0.0.0"
+license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [lib]

--- a/compiler/rustc_ast_lowering/Cargo.toml
+++ b/compiler/rustc_ast_lowering/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "rustc_ast_lowering"
 version = "0.0.0"
+license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [lib]

--- a/compiler/rustc_ast_passes/Cargo.toml
+++ b/compiler/rustc_ast_passes/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "rustc_ast_passes"
 version = "0.0.0"
+license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [dependencies]

--- a/compiler/rustc_ast_pretty/Cargo.toml
+++ b/compiler/rustc_ast_pretty/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "rustc_ast_pretty"
 version = "0.0.0"
+license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [lib]

--- a/compiler/rustc_attr/Cargo.toml
+++ b/compiler/rustc_attr/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "rustc_attr"
 version = "0.0.0"
+license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [lib]

--- a/compiler/rustc_builtin_macros/Cargo.toml
+++ b/compiler/rustc_builtin_macros/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "rustc_builtin_macros"
 version = "0.0.0"
+license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [lib]

--- a/compiler/rustc_codegen_llvm/Cargo.toml
+++ b/compiler/rustc_codegen_llvm/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "rustc_codegen_llvm"
 version = "0.0.0"
+license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [lib]

--- a/compiler/rustc_codegen_ssa/Cargo.toml
+++ b/compiler/rustc_codegen_ssa/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "rustc_codegen_ssa"
 version = "0.0.0"
+license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [lib]

--- a/compiler/rustc_data_structures/Cargo.toml
+++ b/compiler/rustc_data_structures/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "rustc_data_structures"
 version = "0.0.0"
+license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [lib]

--- a/compiler/rustc_driver/Cargo.toml
+++ b/compiler/rustc_driver/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "rustc_driver"
 version = "0.0.0"
+license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [lib]

--- a/compiler/rustc_error_codes/Cargo.toml
+++ b/compiler/rustc_error_codes/Cargo.toml
@@ -2,4 +2,5 @@
 authors = ["The Rust Project Developers"]
 name = "rustc_error_codes"
 version = "0.0.0"
+license = "MIT OR Apache-2.0"
 edition = "2018"

--- a/compiler/rustc_errors/Cargo.toml
+++ b/compiler/rustc_errors/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "rustc_errors"
 version = "0.0.0"
+license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [lib]

--- a/compiler/rustc_expand/Cargo.toml
+++ b/compiler/rustc_expand/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "rustc_expand"
 version = "0.0.0"
+license = "MIT OR Apache-2.0"
 edition = "2018"
 build = false
 

--- a/compiler/rustc_feature/Cargo.toml
+++ b/compiler/rustc_feature/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "rustc_feature"
 version = "0.0.0"
+license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [lib]

--- a/compiler/rustc_fs_util/Cargo.toml
+++ b/compiler/rustc_fs_util/Cargo.toml
@@ -2,4 +2,5 @@
 authors = ["The Rust Project Developers"]
 name = "rustc_fs_util"
 version = "0.0.0"
+license = "MIT OR Apache-2.0"
 edition = "2018"

--- a/compiler/rustc_graphviz/Cargo.toml
+++ b/compiler/rustc_graphviz/Cargo.toml
@@ -2,4 +2,5 @@
 authors = ["The Rust Project Developers"]
 name = "rustc_graphviz"
 version = "0.0.0"
+license = "MIT OR Apache-2.0"
 edition = "2018"

--- a/compiler/rustc_hir/Cargo.toml
+++ b/compiler/rustc_hir/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "rustc_hir"
 version = "0.0.0"
+license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [lib]

--- a/compiler/rustc_hir_pretty/Cargo.toml
+++ b/compiler/rustc_hir_pretty/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "rustc_hir_pretty"
 version = "0.0.0"
+license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [lib]

--- a/compiler/rustc_incremental/Cargo.toml
+++ b/compiler/rustc_incremental/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "rustc_incremental"
 version = "0.0.0"
+license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [lib]

--- a/compiler/rustc_index/Cargo.toml
+++ b/compiler/rustc_index/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "rustc_index"
 version = "0.0.0"
+license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [lib]

--- a/compiler/rustc_infer/Cargo.toml
+++ b/compiler/rustc_infer/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "rustc_infer"
 version = "0.0.0"
+license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [lib]

--- a/compiler/rustc_interface/Cargo.toml
+++ b/compiler/rustc_interface/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "rustc_interface"
 version = "0.0.0"
+license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [lib]

--- a/compiler/rustc_lint/Cargo.toml
+++ b/compiler/rustc_lint/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "rustc_lint"
 version = "0.0.0"
+license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [dependencies]

--- a/compiler/rustc_macros/Cargo.toml
+++ b/compiler/rustc_macros/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rustc_macros"
 version = "0.1.0"
 authors = ["The Rust Project Developers"]
+license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [lib]

--- a/compiler/rustc_metadata/Cargo.toml
+++ b/compiler/rustc_metadata/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "rustc_metadata"
 version = "0.0.0"
+license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [lib]

--- a/compiler/rustc_middle/Cargo.toml
+++ b/compiler/rustc_middle/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "rustc_middle"
 version = "0.0.0"
+license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [lib]

--- a/compiler/rustc_mir/Cargo.toml
+++ b/compiler/rustc_mir/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "rustc_mir"
 version = "0.0.0"
+license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [lib]

--- a/compiler/rustc_mir_build/Cargo.toml
+++ b/compiler/rustc_mir_build/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "rustc_mir_build"
 version = "0.0.0"
+license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [lib]

--- a/compiler/rustc_parse/Cargo.toml
+++ b/compiler/rustc_parse/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "rustc_parse"
 version = "0.0.0"
+license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [lib]

--- a/compiler/rustc_parse_format/Cargo.toml
+++ b/compiler/rustc_parse_format/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "rustc_parse_format"
 version = "0.0.0"
+license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [dependencies]

--- a/compiler/rustc_passes/Cargo.toml
+++ b/compiler/rustc_passes/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "rustc_passes"
 version = "0.0.0"
+license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [dependencies]

--- a/compiler/rustc_plugin_impl/Cargo.toml
+++ b/compiler/rustc_plugin_impl/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "rustc_plugin_impl"
 version = "0.0.0"
+license = "MIT OR Apache-2.0"
 build = false
 edition = "2018"
 

--- a/compiler/rustc_privacy/Cargo.toml
+++ b/compiler/rustc_privacy/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "rustc_privacy"
 version = "0.0.0"
+license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [dependencies]

--- a/compiler/rustc_query_system/Cargo.toml
+++ b/compiler/rustc_query_system/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "rustc_query_system"
 version = "0.0.0"
+license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [lib]

--- a/compiler/rustc_resolve/Cargo.toml
+++ b/compiler/rustc_resolve/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "rustc_resolve"
 version = "0.0.0"
+license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [lib]

--- a/compiler/rustc_save_analysis/Cargo.toml
+++ b/compiler/rustc_save_analysis/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "rustc_save_analysis"
 version = "0.0.0"
+license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [dependencies]

--- a/compiler/rustc_serialize/Cargo.toml
+++ b/compiler/rustc_serialize/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "rustc_serialize"
 version = "0.0.0"
+license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [dependencies]

--- a/compiler/rustc_session/Cargo.toml
+++ b/compiler/rustc_session/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "rustc_session"
 version = "0.0.0"
+license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [dependencies]

--- a/compiler/rustc_span/Cargo.toml
+++ b/compiler/rustc_span/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "rustc_span"
 version = "0.0.0"
+license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [lib]

--- a/compiler/rustc_symbol_mangling/Cargo.toml
+++ b/compiler/rustc_symbol_mangling/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "rustc_symbol_mangling"
 version = "0.0.0"
+license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [lib]

--- a/compiler/rustc_target/Cargo.toml
+++ b/compiler/rustc_target/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "rustc_target"
 version = "0.0.0"
+license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [dependencies]

--- a/compiler/rustc_trait_selection/Cargo.toml
+++ b/compiler/rustc_trait_selection/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "rustc_trait_selection"
 version = "0.0.0"
+license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [lib]

--- a/compiler/rustc_traits/Cargo.toml
+++ b/compiler/rustc_traits/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "rustc_traits"
 version = "0.0.0"
+license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [dependencies]

--- a/compiler/rustc_ty/Cargo.toml
+++ b/compiler/rustc_ty/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "rustc_ty"
 version = "0.0.0"
+license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [dependencies]

--- a/compiler/rustc_typeck/Cargo.toml
+++ b/compiler/rustc_typeck/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "rustc_typeck"
 version = "0.0.0"
+license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [lib]

--- a/library/alloc/Cargo.toml
+++ b/library/alloc/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "alloc"
 version = "0.0.0"
+license = "MIT OR Apache-2.0"
 autotests = false
 autobenches = false
 edition = "2018"

--- a/library/core/Cargo.toml
+++ b/library/core/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "core"
 version = "0.0.0"
+license = "MIT OR Apache-2.0"
 autotests = false
 autobenches = false
 edition = "2018"

--- a/library/panic_abort/Cargo.toml
+++ b/library/panic_abort/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "panic_abort"
 version = "0.0.0"
+license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [lib]

--- a/library/panic_unwind/Cargo.toml
+++ b/library/panic_unwind/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "panic_unwind"
 version = "0.0.0"
+license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [lib]

--- a/library/proc_macro/Cargo.toml
+++ b/library/proc_macro/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "proc_macro"
 version = "0.0.0"
+license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [dependencies]

--- a/library/profiler_builtins/Cargo.toml
+++ b/library/profiler_builtins/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "profiler_builtins"
 version = "0.0.0"
+license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [lib]

--- a/library/term/Cargo.toml
+++ b/library/term/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "term"
 version = "0.0.0"
+license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [dependencies]

--- a/library/test/Cargo.toml
+++ b/library/test/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "test"
 version = "0.0.0"
+license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [lib]

--- a/library/unwind/Cargo.toml
+++ b/library/unwind/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "unwind"
 version = "0.0.0"
+license = "MIT OR Apache-2.0"
 edition = "2018"
 include = [
   '/libunwind/*',

--- a/src/bootstrap/Cargo.toml
+++ b/src/bootstrap/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "bootstrap"
 version = "0.0.0"
+license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [lib]

--- a/src/build_helper/Cargo.toml
+++ b/src/build_helper/Cargo.toml
@@ -2,6 +2,7 @@
 name = "build_helper"
 version = "0.1.0"
 authors = ["The Rust Project Developers"]
+license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [lib]

--- a/src/librustc_llvm/Cargo.toml
+++ b/src/librustc_llvm/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "rustc_llvm"
 version = "0.0.0"
+license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [lib]

--- a/src/librustdoc/Cargo.toml
+++ b/src/librustdoc/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "rustdoc"
 version = "0.0.0"
+license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [lib]

--- a/src/tools/build-manifest/Cargo.toml
+++ b/src/tools/build-manifest/Cargo.toml
@@ -2,6 +2,7 @@
 name = "build-manifest"
 version = "0.1.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
+license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [dependencies]

--- a/src/tools/cargotest/Cargo.toml
+++ b/src/tools/cargotest/Cargo.toml
@@ -2,6 +2,7 @@
 name = "cargotest2"
 version = "0.1.0"
 authors = ["Brian Anderson <banderson@mozilla.com>"]
+license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [[bin]]

--- a/src/tools/compiletest/Cargo.toml
+++ b/src/tools/compiletest/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "compiletest"
 version = "0.0.0"
+license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [dependencies]

--- a/src/tools/error_index_generator/Cargo.toml
+++ b/src/tools/error_index_generator/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "error_index_generator"
 version = "0.0.0"
+license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [dependencies]

--- a/src/tools/expand-yaml-anchors/Cargo.toml
+++ b/src/tools/expand-yaml-anchors/Cargo.toml
@@ -2,6 +2,7 @@
 name = "expand-yaml-anchors"
 version = "0.1.0"
 authors = ["Pietro Albini <pietro@pietroalbini.org>"]
+license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [dependencies]

--- a/src/tools/linkchecker/Cargo.toml
+++ b/src/tools/linkchecker/Cargo.toml
@@ -2,6 +2,7 @@
 name = "linkchecker"
 version = "0.1.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
+license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [[bin]]

--- a/src/tools/remote-test-client/Cargo.toml
+++ b/src/tools/remote-test-client/Cargo.toml
@@ -2,6 +2,7 @@
 name = "remote-test-client"
 version = "0.1.0"
 authors = ["The Rust Project Developers"]
+license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [dependencies]

--- a/src/tools/remote-test-server/Cargo.toml
+++ b/src/tools/remote-test-server/Cargo.toml
@@ -2,6 +2,7 @@
 name = "remote-test-server"
 version = "0.1.0"
 authors = ["The Rust Project Developers"]
+license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [dependencies]

--- a/src/tools/rust-demangler/Cargo.toml
+++ b/src/tools/rust-demangler/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "rust-demangler"
 version = "0.0.0"
+license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [dependencies]

--- a/src/tools/rustdoc-themes/Cargo.toml
+++ b/src/tools/rustdoc-themes/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rustdoc-themes"
 version = "0.1.0"
 authors = ["Guillaume Gomez <guillaume1.gomez@gmail.com>"]
+license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [[bin]]

--- a/src/tools/rustdoc/Cargo.toml
+++ b/src/tools/rustdoc/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rustdoc-tool"
 version = "0.0.0"
 authors = ["The Rust Project Developers"]
+license = "MIT OR Apache-2.0"
 edition = "2018"
 
 # Cargo adds a number of paths to the dylib search path on windows, which results in

--- a/src/tools/tidy/Cargo.toml
+++ b/src/tools/tidy/Cargo.toml
@@ -2,6 +2,7 @@
 name = "tidy"
 version = "0.1.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
+license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [dependencies]

--- a/src/tools/unicode-table-generator/Cargo.toml
+++ b/src/tools/unicode-table-generator/Cargo.toml
@@ -2,6 +2,7 @@
 name = "unicode-bdd"
 version = "0.1.0"
 authors = ["Mark Rousskov <mark.simulacrum@gmail.com>"]
+license = "MIT OR Apache-2.0"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
I'm playing with the `cargo-deny` tool and it reports that all these crates are `unlicensed`, so i figure maybe i can just add all of them.

r? @Mark-Simulacrum 
