### PR TITLE
Don't generate fake IDs in ReplaceBodyWithLoop

### DIFF
--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -307,6 +307,7 @@ pub fn run_compiler(
                         compiler.output_file().as_ref().map(|p| &**p),
                     );
                 }
+                trace!("finished pretty-printing");
                 return early_exit();
             }
 

--- a/src/librustc_interface/interface.rs
+++ b/src/librustc_interface/interface.rs
@@ -202,6 +202,7 @@ pub fn run_compiler_in_existing_thread_pool<R>(
 }
 
 pub fn run_compiler<R: Send>(mut config: Config, f: impl FnOnce(&Compiler) -> R + Send) -> R {
+    log::trace!("run_compiler");
     let stderr = config.stderr.take();
     util::spawn_thread_pool(
         config.opts.edition,

--- a/src/librustc_interface/passes.rs
+++ b/src/librustc_interface/passes.rs
@@ -101,6 +101,7 @@ pub fn configure_and_expand(
     krate: ast::Crate,
     crate_name: &str,
 ) -> Result<(ast::Crate, BoxedResolver)> {
+    log::trace!("configure_and_expand");
     // Currently, we ignore the name resolution data structures for the purposes of dependency
     // tracking. Instead we will run name resolution and include its output in the hash of each
     // item, much like we do for macro expansion. In other words, the hash reflects not just
@@ -230,6 +231,7 @@ fn configure_and_expand_inner<'a>(
     resolver_arenas: &'a ResolverArenas<'a>,
     metadata_loader: &'a MetadataLoaderDyn,
 ) -> Result<(ast::Crate, Resolver<'a>)> {
+    log::trace!("configure_and_expand_inner");
     pre_expansion_lint(sess, lint_store, &krate);
 
     let mut resolver = Resolver::new(sess, &krate, crate_name, metadata_loader, &resolver_arenas);
@@ -357,6 +359,7 @@ fn configure_and_expand_inner<'a>(
         should_loop |= true;
     }
     if should_loop {
+        log::debug!("replacing bodies with loop {{}}");
         util::ReplaceBodyWithLoop::new(&mut resolver).visit_crate(&mut krate);
     }
 

--- a/src/librustc_interface/queries.rs
+++ b/src/librustc_interface/queries.rs
@@ -169,6 +169,7 @@ impl<'tcx> Queries<'tcx> {
     pub fn expansion(
         &self,
     ) -> Result<&Query<(ast::Crate, Steal<Rc<RefCell<BoxedResolver>>>, Lrc<LintStore>)>> {
+        log::trace!("expansion");
         self.expansion.compute(|| {
             let crate_name = self.crate_name()?.peek().clone();
             let (krate, lint_store) = self.register_plugins()?.take();

--- a/src/librustc_session/config.rs
+++ b/src/librustc_session/config.rs
@@ -1957,7 +1957,9 @@ impl PpMode {
         match *self {
             PpmSource(PpmNormal | PpmIdentified) => false,
 
-            PpmSource(PpmExpanded | PpmEveryBodyLoops | PpmExpandedIdentified | PpmExpandedHygiene)
+            PpmSource(
+                PpmExpanded | PpmEveryBodyLoops | PpmExpandedIdentified | PpmExpandedHygiene,
+            )
             | PpmHir(_)
             | PpmHirTree(_)
             | PpmMir

--- a/src/librustc_session/config.rs
+++ b/src/librustc_session/config.rs
@@ -1826,6 +1826,7 @@ fn parse_pretty(
                 }
             }
         };
+        log::debug!("got unpretty option: {:?}", first);
         first
     }
 }
@@ -1954,9 +1955,9 @@ impl PpMode {
         use PpMode::*;
         use PpSourceMode::*;
         match *self {
-            PpmSource(PpmNormal | PpmEveryBodyLoops | PpmIdentified) => false,
+            PpmSource(PpmNormal | PpmIdentified) => false,
 
-            PpmSource(PpmExpanded | PpmExpandedIdentified | PpmExpandedHygiene)
+            PpmSource(PpmExpanded | PpmEveryBodyLoops | PpmExpandedIdentified | PpmExpandedHygiene)
             | PpmHir(_)
             | PpmHirTree(_)
             | PpmMir

--- a/src/test/rustdoc/macro-in-async-block.rs
+++ b/src/test/rustdoc/macro-in-async-block.rs
@@ -1,0 +1,9 @@
+// Regression issue for rustdoc ICE encountered in PR #72088.
+// edition:2018
+#![feature(decl_macro)]
+
+fn main() {
+    async {
+        macro m() {}
+    };
+}

--- a/src/test/rustdoc/macro-in-closure.rs
+++ b/src/test/rustdoc/macro-in-closure.rs
@@ -6,4 +6,11 @@ fn main() {
     || {
         macro m() {}
     };
+
+    let _ = || {
+        macro n() {}
+    };
+
+    let cond = true;
+    let _ = || if cond { macro n() {} } else { panic!() };
 }


### PR DESCRIPTION
Follow up to https://github.com/rust-lang/rust/pull/73103 with less hackiness and special-casing.

Closes #71820, closes #71104. Should fix #73101, I'm testing locally now.

Currently this includes the changes from #73523 but I can remove those without trouble.

r? @ecstatic-morse