### PR TITLE
Deprecate `Vec::remove_item`

### DIFF
--- a/src/liballoc/tests/lib.rs
+++ b/src/liballoc/tests/lib.rs
@@ -12,7 +12,6 @@
 #![feature(associated_type_bounds)]
 #![feature(binary_heap_into_iter_sorted)]
 #![feature(binary_heap_drain_sorted)]
-#![feature(vec_remove_item)]
 #![feature(split_inclusive)]
 #![feature(binary_heap_retain)]
 

--- a/src/liballoc/tests/vec.rs
+++ b/src/liballoc/tests/vec.rs
@@ -132,21 +132,6 @@ fn test_extend_ref() {
 }
 
 #[test]
-fn test_remove_item() {
-    let mut v = vec![1, 2, 3];
-    v.remove_item(&1);
-
-    assert_eq!(v.len(), 2);
-    assert_eq!(v, [2, 3]);
-
-    let mut w = vec![1, 2, 3];
-    w.remove_item(&4);
-
-    assert_eq!(w.len(), 3);
-    w.remove_item(&4);
-}
-
-#[test]
 fn test_slice_from_mut() {
     let mut values = vec![1, 2, 3, 4, 5];
     {

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -1760,17 +1760,15 @@ impl<T: PartialEq> Vec<T> {
 impl<T> Vec<T> {
     /// Removes the first instance of `item` from the vector if the item exists.
     ///
-    /// # Examples
-    ///
-    /// ```
-    /// # #![feature(vec_remove_item)]
-    /// let mut vec = vec![1, 2, 3, 1];
-    ///
-    /// vec.remove_item(&1);
-    ///
-    /// assert_eq!(vec, vec![2, 3, 1]);
-    /// ```
+    /// This method will be removed soon.
     #[unstable(feature = "vec_remove_item", reason = "recently added", issue = "40062")]
+    #[rustc_deprecated(
+        reason = "Removing the first item equal to a needle is already easily possible \
+            with iterators and the current Vec methods. Furthermore, having a method for \
+            one particular case of removal (linear search, only the first item, no swap remove) \
+            but not for others is inconsistent. This method will be removed soon.",
+        since = "1.46.0"
+    )]
     pub fn remove_item<V>(&mut self, item: &V) -> Option<T>
     where
         T: PartialEq<V>,

--- a/src/librustc_middle/lib.rs
+++ b/src/librustc_middle/lib.rs
@@ -45,7 +45,6 @@
 #![feature(min_specialization)]
 #![feature(track_caller)]
 #![feature(trusted_len)]
-#![feature(vec_remove_item)]
 #![feature(stmt_expr_attributes)]
 #![feature(test)]
 #![feature(in_band_lifetimes)]

--- a/src/librustc_query_system/lib.rs
+++ b/src/librustc_query_system/lib.rs
@@ -6,7 +6,6 @@
 #![feature(hash_raw_entry)]
 #![feature(min_specialization)]
 #![feature(stmt_expr_attributes)]
-#![feature(vec_remove_item)]
 
 #[macro_use]
 extern crate log;

--- a/src/librustc_query_system/query/job.rs
+++ b/src/librustc_query_system/query/job.rs
@@ -452,7 +452,9 @@ fn remove_cycle<CTX: QueryContext>(
 
         // Remove the queries in our cycle from the list of jobs to look at
         for r in &stack {
-            jobs.remove_item(&r.1);
+            if let Some(pos) = jobs.iter().position(|j| j == &r.1) {
+                jobs.remove(pos);
+            }
         }
 
         // Find the queries in the cycle which are

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -9,7 +9,6 @@
 #![feature(nll)]
 #![feature(or_patterns)]
 #![feature(test)]
-#![feature(vec_remove_item)]
 #![feature(ptr_offset_from)]
 #![feature(crate_visibility_modifier)]
 #![feature(never_type)]

--- a/src/tools/compiletest/src/main.rs
+++ b/src/tools/compiletest/src/main.rs
@@ -1,5 +1,4 @@
 #![crate_name = "compiletest"]
-#![feature(vec_remove_item)]
 #![deny(warnings)]
 // The `test` crate is the only unstable feature
 // allowed here, just to share similar code.


### PR DESCRIPTION
In #40062 we decided to remove that method. In #71834 it was said that we want to deprecate it for a few cycles before removing it. That's what this PR does.
