### PR TITLE
Use min_specialization in libcore

### DIFF
--- a/library/core/src/iter/adapters/fuse.rs
+++ b/library/core/src/iter/adapters/fuse.rs
@@ -1,7 +1,7 @@
 use crate::intrinsics;
-use crate::iter::{
-    DoubleEndedIterator, ExactSizeIterator, FusedIterator, Iterator, TrustedRandomAccess,
-};
+use crate::iter::adapters::zip::try_get_unchecked;
+use crate::iter::TrustedRandomAccess;
+use crate::iter::{DoubleEndedIterator, ExactSizeIterator, FusedIterator, Iterator};
 use crate::ops::Try;
 
 /// An iterator that yields `None` forever after the underlying iterator
@@ -114,6 +114,19 @@ where
     {
         FuseImpl::find(self, predicate)
     }
+
+    #[inline]
+    unsafe fn get_unchecked(&mut self, idx: usize) -> Self::Item
+    where
+        Self: TrustedRandomAccess,
+    {
+        match self.iter {
+            // SAFETY: the caller must uphold the contract for `Iterator::get_unchecked`.
+            Some(ref mut iter) => unsafe { try_get_unchecked(iter, idx) },
+            // SAFETY: the caller asserts there is an item at `i`, so we're not exhausted.
+            None => unsafe { intrinsics::unreachable() },
+        }
+    }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -172,19 +185,12 @@ where
     }
 }
 
+#[doc(hidden)]
+#[unstable(feature = "trusted_random_access", issue = "none")]
 unsafe impl<I> TrustedRandomAccess for Fuse<I>
 where
     I: TrustedRandomAccess,
 {
-    unsafe fn get_unchecked(&mut self, i: usize) -> I::Item {
-        match self.iter {
-            // SAFETY: the caller must uphold the contract for `TrustedRandomAccess::get_unchecked`.
-            Some(ref mut iter) => unsafe { iter.get_unchecked(i) },
-            // SAFETY: the caller asserts there is an item at `i`, so we're not exhausted.
-            None => unsafe { intrinsics::unreachable() },
-        }
-    }
-
     fn may_have_side_effect() -> bool {
         I::may_have_side_effect()
     }

--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -6,6 +6,7 @@ use crate::cmp::{self, Ordering};
 use crate::ops::{Add, Try};
 
 use super::super::LoopState;
+use super::super::TrustedRandomAccess;
 use super::super::{Chain, Cloned, Copied, Cycle, Enumerate, Filter, FilterMap, Fuse};
 use super::super::{FlatMap, Flatten};
 use super::super::{FromIterator, Product, Sum, Zip};
@@ -3243,6 +3244,17 @@ pub trait Iterator {
         K: PartialOrd,
     {
         self.map(f).is_sorted()
+    }
+
+    /// See [TrustedRandomAccess]
+    #[inline]
+    #[doc(hidden)]
+    #[unstable(feature = "trusted_random_access", issue = "none")]
+    unsafe fn get_unchecked(&mut self, _idx: usize) -> Self::Item
+    where
+        Self: TrustedRandomAccess,
+    {
+        unreachable!("Always specialized");
     }
 }
 

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -117,7 +117,7 @@
 #![feature(repr_simd, platform_intrinsics)]
 #![feature(rustc_attrs)]
 #![feature(simd_ffi)]
-#![feature(specialization)]
+#![feature(min_specialization)]
 #![feature(staged_api)]
 #![feature(std_internals)]
 #![feature(stmt_expr_attributes)]

--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -13,8 +13,9 @@ use self::pattern::{DoubleEndedSearcher, ReverseSearcher, Searcher};
 
 use crate::char;
 use crate::fmt::{self, Write};
+use crate::iter::TrustedRandomAccess;
 use crate::iter::{Chain, FlatMap, Flatten};
-use crate::iter::{Copied, Filter, FusedIterator, Map, TrustedLen, TrustedRandomAccess};
+use crate::iter::{Copied, Filter, FusedIterator, Map, TrustedLen};
 use crate::mem;
 use crate::ops::Try;
 use crate::option;
@@ -819,6 +820,13 @@ impl Iterator for Bytes<'_> {
     {
         self.0.rposition(predicate)
     }
+
+    #[inline]
+    unsafe fn get_unchecked(&mut self, idx: usize) -> u8 {
+        // SAFETY: the caller must uphold the safety contract
+        // for `Iterator::get_unchecked`.
+        unsafe { self.0.get_unchecked(idx) }
+    }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -862,12 +870,8 @@ impl FusedIterator for Bytes<'_> {}
 unsafe impl TrustedLen for Bytes<'_> {}
 
 #[doc(hidden)]
+#[unstable(feature = "trusted_random_access", issue = "none")]
 unsafe impl TrustedRandomAccess for Bytes<'_> {
-    unsafe fn get_unchecked(&mut self, i: usize) -> u8 {
-        // SAFETY: the caller must uphold the safety contract
-        // for `TrustedRandomAccess::get_unchecked`.
-        unsafe { self.0.get_unchecked(i) }
-    }
     fn may_have_side_effect() -> bool {
         false
     }

--- a/library/core/tests/iter.rs
+++ b/library/core/tests/iter.rs
@@ -305,6 +305,103 @@ fn test_zip_nth_side_effects() {
 }
 
 #[test]
+fn test_zip_next_back_side_effects() {
+    let mut a = Vec::new();
+    let mut b = Vec::new();
+    let mut iter = [1, 2, 3, 4, 5, 6]
+        .iter()
+        .cloned()
+        .map(|n| {
+            a.push(n);
+            n * 10
+        })
+        .zip([2, 3, 4, 5, 6, 7, 8].iter().cloned().map(|n| {
+            b.push(n * 100);
+            n * 1000
+        }));
+
+    // The second iterator is one item longer, so `next_back` is called on it
+    // one more time.
+    assert_eq!(iter.next_back(), Some((60, 7000)));
+    assert_eq!(iter.next_back(), Some((50, 6000)));
+    assert_eq!(iter.next_back(), Some((40, 5000)));
+    assert_eq!(iter.next_back(), Some((30, 4000)));
+    assert_eq!(a, vec![6, 5, 4, 3]);
+    assert_eq!(b, vec![800, 700, 600, 500, 400]);
+}
+
+#[test]
+fn test_zip_nth_back_side_effects() {
+    let mut a = Vec::new();
+    let mut b = Vec::new();
+    let value = [1, 2, 3, 4, 5, 6]
+        .iter()
+        .cloned()
+        .map(|n| {
+            a.push(n);
+            n * 10
+        })
+        .zip([2, 3, 4, 5, 6, 7, 8].iter().cloned().map(|n| {
+            b.push(n * 100);
+            n * 1000
+        }))
+        .nth_back(3);
+    assert_eq!(value, Some((30, 4000)));
+    assert_eq!(a, vec![6, 5, 4, 3]);
+    assert_eq!(b, vec![800, 700, 600, 500, 400]);
+}
+
+#[test]
+fn test_zip_next_back_side_effects_exhausted() {
+    let mut a = Vec::new();
+    let mut b = Vec::new();
+    let mut iter = [1, 2, 3, 4, 5, 6]
+        .iter()
+        .cloned()
+        .map(|n| {
+            a.push(n);
+            n * 10
+        })
+        .zip([2, 3, 4].iter().cloned().map(|n| {
+            b.push(n * 100);
+            n * 1000
+        }));
+
+    iter.next();
+    iter.next();
+    iter.next();
+    iter.next();
+    assert_eq!(iter.next_back(), None);
+    assert_eq!(a, vec![1, 2, 3, 4, 6, 5]);
+    assert_eq!(b, vec![200, 300, 400]);
+}
+
+#[test]
+fn test_zip_nth_back_side_effects_exhausted() {
+    let mut a = Vec::new();
+    let mut b = Vec::new();
+    let mut iter = [1, 2, 3, 4, 5, 6]
+        .iter()
+        .cloned()
+        .map(|n| {
+            a.push(n);
+            n * 10
+        })
+        .zip([2, 3, 4].iter().cloned().map(|n| {
+            b.push(n * 100);
+            n * 1000
+        }));
+
+    iter.next();
+    iter.next();
+    iter.next();
+    iter.next();
+    assert_eq!(iter.nth_back(0), None);
+    assert_eq!(a, vec![1, 2, 3, 4, 6, 5]);
+    assert_eq!(b, vec![200, 300, 400]);
+}
+
+#[test]
 fn test_iterator_step_by() {
     // Identity
     let mut it = (0..).step_by(1).take(3);


### PR DESCRIPTION
Getting `TrustedRandomAccess` to work is the main interesting thing here.

- `get_unchecked` is now an unstable, hidden method on `Iterator`
- The contract for `TrustedRandomAccess` is made clearer in documentation
- Fixed a bug where `Debug` would create aliasing references when using the specialized zip impl
- Added tests for the side effects of `next_back` and `nth`.

closes #68536