### PR TITLE
Don't use `DesugaringKind` to track desugared operators

### DIFF
--- a/src/librustc_ast_lowering/expr.rs
+++ b/src/librustc_ast_lowering/expr.rs
@@ -25,7 +25,6 @@ impl<'hir> LoweringContext<'_, 'hir> {
     }
 
     pub(super) fn lower_expr_mut(&mut self, e: &Expr) -> hir::Expr<'hir> {
-        let mut span = e.span;
         ensure_sufficient_stack(|| {
             let kind = match e.kind {
                 ExprKind::Box(ref inner) => hir::ExprKind::Box(self.lower_expr(inner)),
@@ -54,7 +53,6 @@ impl<'hir> LoweringContext<'_, 'hir> {
                     hir::ExprKind::MethodCall(hir_seg, seg.ident.span, args, span)
                 }
                 ExprKind::Binary(binop, ref lhs, ref rhs) => {
-                    span = self.mark_span_with_reason(DesugaringKind::Operator, e.span, None);
                     let binop = self.lower_binop(binop);
                     let lhs = self.lower_expr(lhs);
                     let rhs = self.lower_expr(rhs);
@@ -224,7 +222,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
             hir::Expr {
                 hir_id: self.lower_node_id(e.id),
                 kind,
-                span,
+                span: e.span,
                 attrs: e.attrs.iter().map(|a| self.lower_attr(a)).collect::<Vec<_>>().into(),
             }
         })
@@ -239,7 +237,6 @@ impl<'hir> LoweringContext<'_, 'hir> {
     }
 
     fn lower_binop(&mut self, b: BinOp) -> hir::BinOp {
-        let span = self.mark_span_with_reason(DesugaringKind::Operator, b.span, None);
         Spanned {
             node: match b.node {
                 BinOpKind::Add => hir::BinOpKind::Add,
@@ -261,7 +258,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 BinOpKind::Ge => hir::BinOpKind::Ge,
                 BinOpKind::Gt => hir::BinOpKind::Gt,
             },
-            span,
+            span: b.span,
         }
     }
 

--- a/src/librustc_middle/lint.rs
+++ b/src/librustc_middle/lint.rs
@@ -339,9 +339,7 @@ pub fn struct_lint_level<'s, 'd>(
 pub fn in_external_macro(sess: &Session, span: Span) -> bool {
     let expn_data = span.ctxt().outer_expn_data();
     match expn_data.kind {
-        ExpnKind::Root
-        | ExpnKind::Desugaring(DesugaringKind::ForLoop(_))
-        | ExpnKind::Desugaring(DesugaringKind::Operator) => false,
+        ExpnKind::Root | ExpnKind::Desugaring(DesugaringKind::ForLoop(_)) => false,
         ExpnKind::AstPass(_) | ExpnKind::Desugaring(_) => true, // well, it's "external"
         ExpnKind::Macro(MacroKind::Bang, _) => {
             // Dummy span for the `def_site` means it's an external macro.

--- a/src/librustc_mir/borrow_check/diagnostics/mod.rs
+++ b/src/librustc_mir/borrow_check/diagnostics/mod.rs
@@ -568,7 +568,8 @@ pub(super) enum FnSelfUseKind {
     Normal { self_arg: Ident, implicit_into_iter: bool },
     /// A call to `FnOnce::call_once`, desugared from `my_closure(a, b, c)`
     FnOnceCall,
-    /// A call to an operator trait, desuraged from operator syntax (e.g. `a << b`)
+    /// A call to an operator trait, desugared from operator syntax (e.g. `a << b`)
+    #[allow(dead_code)] // FIXME: Detect desugared operators
     Operator { self_arg: Ident },
 }
 
@@ -823,8 +824,6 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
 
                     let kind = if is_fn_once {
                         FnSelfUseKind::FnOnceCall
-                    } else if fn_call_span.is_desugaring(DesugaringKind::Operator) {
-                        FnSelfUseKind::Operator { self_arg }
                     } else {
                         debug!(
                             "move_spans: method_did={:?}, fn_call_span={:?}",

--- a/src/librustc_span/hygiene.rs
+++ b/src/librustc_span/hygiene.rs
@@ -823,7 +823,6 @@ pub enum DesugaringKind {
     Async,
     Await,
     ForLoop(ForLoopLoc),
-    Operator,
 }
 
 /// A location in the desugaring of a `for` loop
@@ -844,7 +843,6 @@ impl DesugaringKind {
             DesugaringKind::TryBlock => "`try` block",
             DesugaringKind::OpaqueTy => "`impl Trait`",
             DesugaringKind::ForLoop(_) => "`for` loop",
-            DesugaringKind::Operator => "operator",
         }
     }
 }

--- a/src/test/ui/binop/binop-consume-args.stderr
+++ b/src/test/ui/binop/binop-consume-args.stderr
@@ -4,11 +4,11 @@ error[E0382]: use of moved value: `lhs`
 LL | fn add<A: Add<B, Output=()>, B>(lhs: A, rhs: B) {
    |                                 --- move occurs because `lhs` has type `A`, which does not implement the `Copy` trait
 LL |     lhs + rhs;
-   |     --------- `lhs` moved due to usage in operator
+   |     --------- `lhs` moved due to this method call
 LL |     drop(lhs);
    |          ^^^ value used here after move
    |
-note: calling this operator moves the left-hand side
+note: this function consumes the receiver `self` by taking ownership of it, which moves `lhs`
   --> $SRC_DIR/libcore/ops/arith.rs:LL:COL
    |
 LL |     fn add(self, rhs: Rhs) -> Self::Output;
@@ -40,11 +40,11 @@ error[E0382]: use of moved value: `lhs`
 LL | fn sub<A: Sub<B, Output=()>, B>(lhs: A, rhs: B) {
    |                                 --- move occurs because `lhs` has type `A`, which does not implement the `Copy` trait
 LL |     lhs - rhs;
-   |     --------- `lhs` moved due to usage in operator
+   |     --------- `lhs` moved due to this method call
 LL |     drop(lhs);
    |          ^^^ value used here after move
    |
-note: calling this operator moves the left-hand side
+note: this function consumes the receiver `self` by taking ownership of it, which moves `lhs`
   --> $SRC_DIR/libcore/ops/arith.rs:LL:COL
    |
 LL |     fn sub(self, rhs: Rhs) -> Self::Output;
@@ -76,11 +76,11 @@ error[E0382]: use of moved value: `lhs`
 LL | fn mul<A: Mul<B, Output=()>, B>(lhs: A, rhs: B) {
    |                                 --- move occurs because `lhs` has type `A`, which does not implement the `Copy` trait
 LL |     lhs * rhs;
-   |     --------- `lhs` moved due to usage in operator
+   |     --------- `lhs` moved due to this method call
 LL |     drop(lhs);
    |          ^^^ value used here after move
    |
-note: calling this operator moves the left-hand side
+note: this function consumes the receiver `self` by taking ownership of it, which moves `lhs`
   --> $SRC_DIR/libcore/ops/arith.rs:LL:COL
    |
 LL |     fn mul(self, rhs: Rhs) -> Self::Output;
@@ -112,11 +112,11 @@ error[E0382]: use of moved value: `lhs`
 LL | fn div<A: Div<B, Output=()>, B>(lhs: A, rhs: B) {
    |                                 --- move occurs because `lhs` has type `A`, which does not implement the `Copy` trait
 LL |     lhs / rhs;
-   |     --------- `lhs` moved due to usage in operator
+   |     --------- `lhs` moved due to this method call
 LL |     drop(lhs);
    |          ^^^ value used here after move
    |
-note: calling this operator moves the left-hand side
+note: this function consumes the receiver `self` by taking ownership of it, which moves `lhs`
   --> $SRC_DIR/libcore/ops/arith.rs:LL:COL
    |
 LL |     fn div(self, rhs: Rhs) -> Self::Output;
@@ -148,11 +148,11 @@ error[E0382]: use of moved value: `lhs`
 LL | fn rem<A: Rem<B, Output=()>, B>(lhs: A, rhs: B) {
    |                                 --- move occurs because `lhs` has type `A`, which does not implement the `Copy` trait
 LL |     lhs % rhs;
-   |     --------- `lhs` moved due to usage in operator
+   |     --------- `lhs` moved due to this method call
 LL |     drop(lhs);
    |          ^^^ value used here after move
    |
-note: calling this operator moves the left-hand side
+note: this function consumes the receiver `self` by taking ownership of it, which moves `lhs`
   --> $SRC_DIR/libcore/ops/arith.rs:LL:COL
    |
 LL |     fn rem(self, rhs: Rhs) -> Self::Output;
@@ -184,11 +184,11 @@ error[E0382]: use of moved value: `lhs`
 LL | fn bitand<A: BitAnd<B, Output=()>, B>(lhs: A, rhs: B) {
    |                                       --- move occurs because `lhs` has type `A`, which does not implement the `Copy` trait
 LL |     lhs & rhs;
-   |     --------- `lhs` moved due to usage in operator
+   |     --------- `lhs` moved due to this method call
 LL |     drop(lhs);
    |          ^^^ value used here after move
    |
-note: calling this operator moves the left-hand side
+note: this function consumes the receiver `self` by taking ownership of it, which moves `lhs`
   --> $SRC_DIR/libcore/ops/bit.rs:LL:COL
    |
 LL |     fn bitand(self, rhs: Rhs) -> Self::Output;
@@ -220,11 +220,11 @@ error[E0382]: use of moved value: `lhs`
 LL | fn bitor<A: BitOr<B, Output=()>, B>(lhs: A, rhs: B) {
    |                                     --- move occurs because `lhs` has type `A`, which does not implement the `Copy` trait
 LL |     lhs | rhs;
-   |     --------- `lhs` moved due to usage in operator
+   |     --------- `lhs` moved due to this method call
 LL |     drop(lhs);
    |          ^^^ value used here after move
    |
-note: calling this operator moves the left-hand side
+note: this function consumes the receiver `self` by taking ownership of it, which moves `lhs`
   --> $SRC_DIR/libcore/ops/bit.rs:LL:COL
    |
 LL |     fn bitor(self, rhs: Rhs) -> Self::Output;
@@ -256,11 +256,11 @@ error[E0382]: use of moved value: `lhs`
 LL | fn bitxor<A: BitXor<B, Output=()>, B>(lhs: A, rhs: B) {
    |                                       --- move occurs because `lhs` has type `A`, which does not implement the `Copy` trait
 LL |     lhs ^ rhs;
-   |     --------- `lhs` moved due to usage in operator
+   |     --------- `lhs` moved due to this method call
 LL |     drop(lhs);
    |          ^^^ value used here after move
    |
-note: calling this operator moves the left-hand side
+note: this function consumes the receiver `self` by taking ownership of it, which moves `lhs`
   --> $SRC_DIR/libcore/ops/bit.rs:LL:COL
    |
 LL |     fn bitxor(self, rhs: Rhs) -> Self::Output;
@@ -292,11 +292,11 @@ error[E0382]: use of moved value: `lhs`
 LL | fn shl<A: Shl<B, Output=()>, B>(lhs: A, rhs: B) {
    |                                 --- move occurs because `lhs` has type `A`, which does not implement the `Copy` trait
 LL |     lhs << rhs;
-   |     ---------- `lhs` moved due to usage in operator
+   |     ---------- `lhs` moved due to this method call
 LL |     drop(lhs);
    |          ^^^ value used here after move
    |
-note: calling this operator moves the left-hand side
+note: this function consumes the receiver `self` by taking ownership of it, which moves `lhs`
   --> $SRC_DIR/libcore/ops/bit.rs:LL:COL
    |
 LL |     fn shl(self, rhs: Rhs) -> Self::Output;
@@ -328,11 +328,11 @@ error[E0382]: use of moved value: `lhs`
 LL | fn shr<A: Shr<B, Output=()>, B>(lhs: A, rhs: B) {
    |                                 --- move occurs because `lhs` has type `A`, which does not implement the `Copy` trait
 LL |     lhs >> rhs;
-   |     ---------- `lhs` moved due to usage in operator
+   |     ---------- `lhs` moved due to this method call
 LL |     drop(lhs);
    |          ^^^ value used here after move
    |
-note: calling this operator moves the left-hand side
+note: this function consumes the receiver `self` by taking ownership of it, which moves `lhs`
   --> $SRC_DIR/libcore/ops/bit.rs:LL:COL
    |
 LL |     fn shr(self, rhs: Rhs) -> Self::Output;

--- a/src/test/ui/binop/binop-move-semantics.stderr
+++ b/src/test/ui/binop/binop-move-semantics.stderr
@@ -9,9 +9,9 @@ LL | |     x;
    | |     ^
    | |     |
    | |_____value used here after move
-   |       `x` moved due to usage in operator
+   |       `x` moved due to this method call
    |
-note: calling this operator moves the left-hand side
+note: this function consumes the receiver `self` by taking ownership of it, which moves `x`
   --> $SRC_DIR/libcore/ops/arith.rs:LL:COL
    |
 LL |     fn add(self, rhs: Rhs) -> Self::Output;

--- a/src/test/ui/consts/miri_unleashed/ptr_arith.rs
+++ b/src/test/ui/consts/miri_unleashed/ptr_arith.rs
@@ -6,15 +6,14 @@
 
 static CMP: () = {
     let x = &0 as *const _;
-    let _v = x == x; //~ NOTE in this
+    let _v = x == x;
     //~^ ERROR could not evaluate static initializer
     //~| NOTE pointer arithmetic or comparison
-    //~| NOTE in this
 };
 
 static INT_PTR_ARITH: () = unsafe {
     let x: usize = std::mem::transmute(&0);
-    let _v = x + 0; //~ NOTE in this
+    let _v = x + 0;
     //~^ ERROR could not evaluate static initializer
     //~| NOTE pointer-to-integer cast
 };

--- a/src/test/ui/consts/miri_unleashed/ptr_arith.stderr
+++ b/src/test/ui/consts/miri_unleashed/ptr_arith.stderr
@@ -5,7 +5,7 @@ LL |     let _v = x == x;
    |              ^^^^^^ "pointer arithmetic or comparison" needs an rfc before being allowed inside constants
 
 error[E0080]: could not evaluate static initializer
-  --> $DIR/ptr_arith.rs:17:14
+  --> $DIR/ptr_arith.rs:16:14
    |
 LL |     let _v = x + 0;
    |              ^^^^^ "pointer-to-integer cast" needs an rfc before being allowed inside constants
@@ -18,7 +18,7 @@ help: skipping check for `const_compare_raw_pointers` feature
 LL |     let _v = x == x;
    |              ^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/ptr_arith.rs:16:20
+  --> $DIR/ptr_arith.rs:15:20
    |
 LL |     let x: usize = std::mem::transmute(&0);
    |                    ^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/hygiene/unpretty-debug.stdout
+++ b/src/test/ui/hygiene/unpretty-debug.stdout
@@ -18,12 +18,8 @@ fn y /* 0#0 */() { }
 Expansions:
 0: parent: ExpnId(0), call_site_ctxt: #0, kind: Root
 1: parent: ExpnId(0), call_site_ctxt: #0, kind: Macro(Bang, "foo")
-2: parent: ExpnId(0), call_site_ctxt: #1, kind: Desugaring(Operator)
-3: parent: ExpnId(0), call_site_ctxt: #1, kind: Desugaring(Operator)
 
 SyntaxContexts:
 #0: parent: #0, outer_mark: (ExpnId(0), Opaque)
 #1: parent: #0, outer_mark: (ExpnId(1), SemiTransparent)
-#2: parent: #1, outer_mark: (ExpnId(2), Transparent)
-#3: parent: #1, outer_mark: (ExpnId(3), Transparent)
 */

--- a/src/test/ui/moves/move-fn-self-receiver.stderr
+++ b/src/test/ui/moves/move-fn-self-receiver.stderr
@@ -103,11 +103,11 @@ error[E0382]: use of moved value: `foo_add`
 LL |     let foo_add = Foo;
    |         ------- move occurs because `foo_add` has type `Foo`, which does not implement the `Copy` trait
 LL |     foo_add + Foo;
-   |     ------------- `foo_add` moved due to usage in operator
+   |     ------------- `foo_add` moved due to this method call
 LL |     foo_add;
    |     ^^^^^^^ value used here after move
    |
-note: calling this operator moves the left-hand side
+note: this function consumes the receiver `self` by taking ownership of it, which moves `foo_add`
   --> $SRC_DIR/libcore/ops/arith.rs:LL:COL
    |
 LL |     fn add(self, rhs: Rhs) -> Self::Output;


### PR DESCRIPTION
See https://github.com/rust-lang/rust/pull/73468#issuecomment-647048588

This removes the immediate need for PR #73468, since Clippy will no
longer be confused by the precense of a new `ExpnId` 'on top of' a
macro expansion `ExpnId`.

This makes some of the 'self move diagnostics' added by PR #72389
slightly worse. I've left the operator-related diagnostics code in
place, so it should be easy for a followup PR to plug in a new way of
detecting desugared operators.