### PR TITLE
Do not send a notification for P-high stable regressions

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -113,7 +113,7 @@ topic = "P-critical #{number} {title}"
 message_on_add = "@*WG-prioritization* issue #{number} has been assigned `P-critical`."
 
 [notify-zulip."P-high"]
-required_labels = ["regression-from-stable-to-*"]
+required_labels = ["regression-from-stable-to-[bn]*"] # only nightly and beta regressions
 zulip_stream = 227806 # #t-compiler/wg-prioritization
 topic = "P-high regression #{number} {title}"
 message_on_add = "@*WG-prioritization* issue #{number} has been assigned `P-high` and is a regression."


### PR DESCRIPTION
This is kind of a hack to only match nightly and beta regressions, but not stable regressions. See my tests [on the playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=6ff8a809162118aa2951f2ff12400067).

r? @spastorino cc @Mark-Simulacrum