### PR TITLE
rustc_lexer: Simplify shebang parsing once more

### DIFF
--- a/src/test/ui/parser/shebang/shebang-empty.rs
+++ b/src/test/ui/parser/shebang/shebang-empty.rs
@@ -1,0 +1,4 @@
+#!
+
+// check-pass
+fn main() {}

--- a/src/test/ui/parser/shebang/shebang-space.rs
+++ b/src/test/ui/parser/shebang/shebang-space.rs
@@ -1,0 +1,5 @@
+#!    
+
+// check-pass
+// ignore-tidy-end-whitespace
+fn main() {}

--- a/src/test/ui/shebang.rs
+++ b/src/test/ui/shebang.rs
@@ -1,5 +1,0 @@
-#!/usr/bin/env rustx
-
-// run-pass
-
-pub fn main() { println!("Hello World"); }


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/73250 (beta regression)

Treat any line starting with `!#` as a shebang candidate, not only lines with something non-whitespace.
This way we no longer need to define what `is_whitespace` means ([Linux shebang whitespace](https://github.com/torvalds/linux/blob/master/fs/binfmt_script.c), ASCII whitespace, Rust lexer whitespace, etc), which is nice.

This change makes some invalid Rust code valid (see the regression above), but still never interprets a fragment of valid Rust code as a shebang.

(This PR also removes one duplicate test.)