### PR TITLE
Fix spurious 'value moved here in previous iteration of loop' messages

### DIFF
--- a/src/librustc_mir/borrow_check/diagnostics/conflict_errors.rs
+++ b/src/librustc_mir/borrow_check/diagnostics/conflict_errors.rs
@@ -139,7 +139,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
 
                 let move_msg = if move_spans.for_closure() { " into closure" } else { "" };
 
-                if span == move_span {
+                if location == move_out.source {
                     err.span_label(
                         span,
                         format!("value moved{} here, in previous iteration of loop", move_msg),

--- a/src/test/ui/moves/issue-46099-move-in-macro.rs
+++ b/src/test/ui/moves/issue-46099-move-in-macro.rs
@@ -1,0 +1,15 @@
+// Regression test for issue #46099
+// Tests that we don't emit spurious
+// 'value moved in previous iteration of loop' message
+
+macro_rules! test {
+    ($v:expr) => {{
+        drop(&$v);
+        $v
+    }}
+}
+
+fn main() {
+    let b = Box::new(true);
+    test!({b}); //~ ERROR use of moved value
+}

--- a/src/test/ui/moves/issue-46099-move-in-macro.stderr
+++ b/src/test/ui/moves/issue-46099-move-in-macro.stderr
@@ -1,0 +1,14 @@
+error[E0382]: use of moved value: `b`
+  --> $DIR/issue-46099-move-in-macro.rs:14:12
+   |
+LL |     let b = Box::new(true);
+   |         - move occurs because `b` has type `std::boxed::Box<bool>`, which does not implement the `Copy` trait
+LL |     test!({b});
+   |            ^
+   |            |
+   |            value moved here
+   |            value used here after move
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0382`.

--- a/src/test/ui/moves/move-in-guard-2.stderr
+++ b/src/test/ui/moves/move-in-guard-2.stderr
@@ -5,7 +5,10 @@ LL |     let x: Box<_> = box 1;
    |         - move occurs because `x` has type `std::boxed::Box<i32>`, which does not implement the `Copy` trait
 ...
 LL |         (_, 2) if take(x) => (),
-   |                        ^ value moved here, in previous iteration of loop
+   |                        ^
+   |                        |
+   |                        value moved here
+   |                        value used here after move
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Fixes #46099

Previously, we would check the 'move' and 'use' spans to see if we
should emit this message. However, this can give false positives when
macros are involved, since two distinct expressions may end up with the
same span.

Instead, we check the actual MIR `Location`, which eliminates false
positives.