### PR TITLE
Documentation for the false keyword

### DIFF
--- a/src/libstd/keyword_docs.rs
+++ b/src/libstd/keyword_docs.rs
@@ -392,7 +392,6 @@ mod extern_keyword {}
 /// See the documentation for [`true`] for more information.
 ///
 /// [`true`]: keyword.true.html
-/// [`bool`]: primitive.bool.html
 mod false_keyword {}
 
 #[doc(keyword = "fn")]

--- a/src/libstd/keyword_docs.rs
+++ b/src/libstd/keyword_docs.rs
@@ -387,7 +387,7 @@ mod extern_keyword {}
 //
 /// A value of type [`bool`] representing logical **false**.
 ///
-/// Logically `false` is not equal to [`true`].
+/// `false` is the logical opposite of [`true`].
 ///
 /// See the documentation for [`true`] for more information.
 ///

--- a/src/libstd/keyword_docs.rs
+++ b/src/libstd/keyword_docs.rs
@@ -387,10 +387,12 @@ mod extern_keyword {}
 //
 /// A value of type [`bool`] representing logical **false**.
 ///
-/// The documentation for this keyword is [not yet complete]. Pull requests welcome!
+/// Logically `false` is not equal to [`true`].
 ///
+/// See the documentation for [`true`] for more information.
+///
+/// [`true`]: keyword.true.html
 /// [`bool`]: primitive.bool.html
-/// [not yet complete]: https://github.com/rust-lang/rust/issues/34601
 mod false_keyword {}
 
 #[doc(keyword = "fn")]


### PR DESCRIPTION
Partial fix of #34601.

Short documentation for the false keyword mainly pointing to the `true` keyword.