### PR TITLE
Make AssocOp Copy

### DIFF
--- a/src/librustc_ast/util/parser.rs
+++ b/src/librustc_ast/util/parser.rs
@@ -5,7 +5,7 @@ use rustc_span::symbol::kw;
 /// Associative operator with precedence.
 ///
 /// This is the enum which specifies operator precedence and fixity to the parser.
-#[derive(PartialEq, Debug)]
+#[derive(Copy, Clone, PartialEq, Debug)]
 pub enum AssocOp {
     /// `+`
     Add,


### PR DESCRIPTION
Found that this enum is not `Copy` while reviewing this Clippy PR: https://github.com/rust-lang/rust-clippy/pull/5727#discussion_r443761621

There shouldn't be a reason why this should not be `Copy`.