### PR TITLE
rustdoc: Fix doc aliases with crate filtering

### DIFF
--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -1015,12 +1015,13 @@ function defocusSearchBar() {
                 var aliases = [];
                 var crateAliases = [];
                 var i;
-                if (filterCrates !== undefined &&
-                        ALIASES[filterCrates] &&
-                        ALIASES[filterCrates][query.search]) {
-                    for (i = 0; i < ALIASES[crate][query.search].length; ++i) {
-                        aliases.push(
-                            createAliasFromItem(searchIndex[ALIASES[filterCrates][query.search]]));
+                if (filterCrates !== undefined) {
+                    if (ALIASES[filterCrates] && ALIASES[filterCrates][query.search]) {
+                        for (i = 0; i < ALIASES[filterCrates][query.search].length; ++i) {
+                            aliases.push(
+                                createAliasFromItem(
+                                    searchIndex[ALIASES[filterCrates][query.search][i]]));
+                        }
                     }
                 } else {
                     Object.keys(ALIASES).forEach(function(crate) {

--- a/src/test/rustdoc-js/doc-alias-filter-out.js
+++ b/src/test/rustdoc-js/doc-alias-filter-out.js
@@ -1,0 +1,9 @@
+// exact-check
+
+const QUERY = 'true';
+
+const FILTER_CRATE = 'some_other_crate';
+
+const EXPECTED = {
+    'others': [],
+};

--- a/src/test/rustdoc-js/doc-alias-filter-out.rs
+++ b/src/test/rustdoc-js/doc-alias-filter-out.rs
@@ -1,0 +1,4 @@
+#![feature(doc_alias)]
+
+#[doc(alias = "true")]
+pub struct Foo;

--- a/src/test/rustdoc-js/doc-alias-filter.js
+++ b/src/test/rustdoc-js/doc-alias-filter.js
@@ -1,0 +1,17 @@
+// exact-check
+
+const QUERY = 'true';
+
+const FILTER_CRATE = 'doc_alias_filter';
+
+const EXPECTED = {
+    'others': [
+        {
+            'path': 'doc_alias_filter',
+            'name': 'Foo',
+            'alias': 'true',
+            'href': '../doc_alias_filter/struct.Foo.html',
+            'is_alias': true
+        },
+    ],
+};

--- a/src/test/rustdoc-js/doc-alias-filter.rs
+++ b/src/test/rustdoc-js/doc-alias-filter.rs
@@ -1,0 +1,7 @@
+#![feature(doc_alias)]
+
+#[doc(alias = "true")]
+pub struct Foo;
+
+#[doc(alias = "false")]
+pub struct Bar;

--- a/src/tools/rustdoc-js/tester.js
+++ b/src/tools/rustdoc-js/tester.js
@@ -269,6 +269,12 @@ function runSearch(query, expected, index, loaded, loadedFile, queryName) {
             break;
         }
         var entry = expected[key];
+
+        if (exact_check == true && entry.length !== results[key].length) {
+            error_text.push(queryName + "==> Expected exactly " + entry.length +
+                            " results but found " + results[key].length + " in '" + key + "'");
+        }
+
         var prev_pos = -1;
         for (var i = 0; i < entry.length; ++i) {
             var entry_pos = lookForEntry(entry[i], results[key]);
@@ -307,8 +313,11 @@ function checkResult(error_text, loadedFile, displaySuccess) {
 }
 
 function runChecks(testFile, loaded, index) {
-    var loadedFile = loadContent(
-        readFile(testFile) + 'exports.QUERY = QUERY;exports.EXPECTED = EXPECTED;');
+    var testFileContent = readFile(testFile) + 'exports.QUERY = QUERY;exports.EXPECTED = EXPECTED;';
+    if (testFileContent.indexOf("FILTER_CRATE") !== -1) {
+        testFileContent += "exports.FILTER_CRATE = FILTER_CRATE;";
+    }
+    var loadedFile = loadContent(testFileContent);
 
     const expected = loadedFile.EXPECTED;
     const query = loadedFile.QUERY;


### PR DESCRIPTION
Fix a crash when searching for an alias contained in the currently selected filter crate.

Also remove alias search results for crates that should be filtered out.

The test suite needed to be fixed to actually take into account the crate filtering and check that there are no results when none are expected.

Needs to be backported to beta to fix the `std` docs.

Fixes #73620

r? @GuillaumeGomez