### PR TITLE
Liballoc remove PartialEq Vec fn ne

### DIFF
--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -2351,8 +2351,6 @@ macro_rules! __impl_slice_eq1 {
         {
             #[inline]
             fn eq(&self, other: &$rhs) -> bool { self[..] == other[..] }
-            #[inline]
-            fn ne(&self, other: &$rhs) -> bool { self[..] != other[..] }
         }
     }
 }


### PR DESCRIPTION
ne is just the opposite of eq, clippy lint suggest to remove it.