### PR TITLE
Update Chalk to 0.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -434,9 +434,9 @@ dependencies = [
 
 [[package]]
 name = "chalk-derive"
-version = "0.11.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b9bd01eab87277d973183a1d2e56bace1c11f8242c52c20636fb7dddf343ac9"
+checksum = "d463e01905d607e181de72e8608721d3269f29176c9a14ce037011316ae7131d"
 dependencies = [
  "proc-macro2 1.0.3",
  "quote 1.0.2",
@@ -446,20 +446,21 @@ dependencies = [
 
 [[package]]
 name = "chalk-engine"
-version = "0.11.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c7a637c3d17ed555aef16e16952a5d1e127bd55178cc30be22afeb92da90c7d"
+checksum = "efaf428f5398d36284f79690cf988762b7c091249f50a6c11db613a46c057000"
 dependencies = [
  "chalk-derive",
  "chalk-ir",
  "rustc-hash",
+ "tracing",
 ]
 
 [[package]]
 name = "chalk-ir"
-version = "0.11.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595e5735ded16c3f3dc348f7b15bbb2521a0080b1863cac38ad5271589944670"
+checksum = "fd3fdc1e9f68498ffe80f4a23b0b95f1ca6fb21d5a4c9b0c085fab3ca712bdbe"
 dependencies = [
  "chalk-derive",
  "lazy_static",
@@ -467,9 +468,9 @@ dependencies = [
 
 [[package]]
 name = "chalk-solve"
-version = "0.11.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d9d938139db425867a30cc0cfec0269406d8238d0571d829041eaa7a8455d11"
+checksum = "5b9fd4102807b7ebe8fb034fa0f488c5656e1966d3261b558b81a08d519cdb29"
 dependencies = [
  "chalk-derive",
  "chalk-engine",
@@ -478,6 +479,7 @@ dependencies = [
  "itertools 0.9.0",
  "petgraph",
  "rustc-hash",
+ "tracing",
 ]
 
 [[package]]
@@ -5330,6 +5332,37 @@ dependencies = [
  "darling",
  "quote 0.6.12",
  "syn 0.15.35",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a41f40ed0e162c911ac6fcb53ecdc8134c46905fdbbae8c50add462a538b495f"
+dependencies = [
+ "cfg-if",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99bbad0de3fd923c9c3232ead88510b783e5a4d16a6154adffa3d53308de984c"
+dependencies = [
+ "proc-macro2 1.0.3",
+ "quote 1.0.2",
+ "syn 1.0.11",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aa83a9a47081cd522c09c81b31aec2c9273424976f922ad61c053b58350b715"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]

--- a/src/librustc_middle/Cargo.toml
+++ b/src/librustc_middle/Cargo.toml
@@ -30,7 +30,7 @@ rustc_serialize = { path = "../librustc_serialize" }
 rustc_ast = { path = "../librustc_ast" }
 rustc_span = { path = "../librustc_span" }
 byteorder = { version = "1.3" }
-chalk-ir = "0.11.0"
+chalk-ir = "0.14.0"
 smallvec = { version = "1.0", features = ["union", "may_dangle"] }
 measureme = "0.7.1"
 rustc_session = { path = "../librustc_session" }

--- a/src/librustc_middle/traits/chalk.rs
+++ b/src/librustc_middle/traits/chalk.rs
@@ -10,6 +10,7 @@ use rustc_middle::ty::fold::{TypeFoldable, TypeFolder, TypeVisitor};
 use rustc_middle::ty::{self, AdtDef, Ty, TyCtxt};
 
 use rustc_hir::def_id::DefId;
+use rustc_target::spec::abi::Abi;
 
 use smallvec::SmallVec;
 
@@ -77,6 +78,7 @@ impl<'tcx> chalk_ir::interner::Interner for RustInterner<'tcx> {
     type DefId = DefId;
     type InternedAdtId = &'tcx AdtDef;
     type Identifier = ();
+    type FnAbi = Abi;
 
     fn debug_program_clause_implication(
         pci: &chalk_ir::ProgramClauseImplication<Self>,

--- a/src/librustc_traits/Cargo.toml
+++ b/src/librustc_traits/Cargo.toml
@@ -16,8 +16,8 @@ rustc_hir = { path = "../librustc_hir" }
 rustc_index = { path = "../librustc_index" }
 rustc_ast = { path = "../librustc_ast" }
 rustc_span = { path = "../librustc_span" }
-chalk-ir = "0.11.0"
-chalk-solve = "0.11.0"
+chalk-ir = "0.14.0"
+chalk-solve = "0.14.0"
 smallvec = { version = "1.0", features = ["union", "may_dangle"] }
 rustc_infer = { path = "../librustc_infer" }
 rustc_trait_selection = { path = "../librustc_trait_selection" }

--- a/src/librustc_traits/chalk/mod.rs
+++ b/src/librustc_traits/chalk/mod.rs
@@ -133,6 +133,7 @@ crate fn evaluate_goal<'tcx>(
                             },
                             chalk_ir::TypeName::Array => unimplemented!(),
                             chalk_ir::TypeName::FnDef(_) => unimplemented!(),
+                            chalk_ir::TypeName::Closure(_) => unimplemented!(),
                             chalk_ir::TypeName::Never => unimplemented!(),
                             chalk_ir::TypeName::Tuple(_size) => unimplemented!(),
                             chalk_ir::TypeName::Slice => unimplemented!(),

--- a/src/test/ui/chalkify/closure.rs
+++ b/src/test/ui/chalkify/closure.rs
@@ -1,0 +1,39 @@
+// check-fail
+// compile-flags: -Z chalk
+
+fn main() -> () {
+    let t = || {};
+    t();
+
+    let mut a = 0;
+    let mut b = move || {
+        a = 1;
+    };
+    b();
+
+    let mut c = b;
+
+    c();
+    b();
+
+    let mut a = 0;
+    let mut b = || {
+        a = 1;
+    };
+    b();
+
+    let mut c = b;
+
+    c();
+    b(); //~ ERROR
+
+    // FIXME(chalk): this doesn't quite work
+    /*
+    let b = |c| {
+        c
+    };
+
+    let a = &32;
+    b(a);
+    */
+}

--- a/src/test/ui/chalkify/closure.stderr
+++ b/src/test/ui/chalkify/closure.stderr
@@ -1,0 +1,18 @@
+error[E0382]: borrow of moved value: `b`
+  --> $DIR/closure.rs:28:5
+   |
+LL |     let mut c = b;
+   |                 - value moved here
+...
+LL |     b();
+   |     ^ value borrowed here after move
+   |
+note: closure cannot be moved more than once as it is not `Copy` due to moving the variable `a` out of its environment
+  --> $DIR/closure.rs:21:9
+   |
+LL |         a = 1;
+   |         ^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0382`.

--- a/src/test/ui/chalkify/impl_wf.rs
+++ b/src/test/ui/chalkify/impl_wf.rs
@@ -23,15 +23,10 @@ impl<T> Bar for Option<T> {
     type Item = Option<T>;
 }
 
-// FIXME(chalk): the ordering of these two errors differs between CI and local
-// We need to figure out why its non-deterministic
-/*
 impl Bar for f32 {
-//^ ERROR the trait bound `f32: Foo` is not satisfied
     type Item = f32;
-    //^ ERROR the trait bound `f32: Foo` is not satisfied
+    //~^ ERROR the trait bound `f32: Foo` is not satisfied
 }
-*/
 
 trait Baz<U: ?Sized> where U: Foo { }
 

--- a/src/test/ui/chalkify/impl_wf.stderr
+++ b/src/test/ui/chalkify/impl_wf.stderr
@@ -11,7 +11,18 @@ LL | impl Foo for str { }
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
 
 error[E0277]: the trait bound `f32: Foo` is not satisfied
-  --> $DIR/impl_wf.rs:40:6
+  --> $DIR/impl_wf.rs:27:17
+   |
+LL | trait Bar {
+   |       --- required by a bound in this
+LL |     type Item: Foo;
+   |                --- required by this bound in `Bar`
+...
+LL |     type Item = f32;
+   |                 ^^^ the trait `Foo` is not implemented for `f32`
+
+error[E0277]: the trait bound `f32: Foo` is not satisfied
+  --> $DIR/impl_wf.rs:35:6
    |
 LL | trait Baz<U: ?Sized> where U: Foo { }
    |                               --- required by this bound in `Baz`
@@ -19,6 +30,6 @@ LL | trait Baz<U: ?Sized> where U: Foo { }
 LL | impl Baz<f32> for f32 { }
    |      ^^^^^^^^ the trait `Foo` is not implemented for `f32`
 
-error: aborting due to 2 previous errors
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/chalkify/inherent_impl.rs
+++ b/src/test/ui/chalkify/inherent_impl.rs
@@ -1,7 +1,5 @@
 // run-pass
 // compile-flags: -Z chalk
-// FIXME(chalk): remove when uncommented
-#![allow(dead_code, unused_variables)]
 
 trait Foo { }
 
@@ -11,8 +9,6 @@ struct S<T: Foo> {
     x: T,
 }
 
-// FIXME(chalk): need late-bound regions on FnDefs
-/*
 fn only_foo<T: Foo>(_x: &T) { }
 
 impl<T> S<T> {
@@ -21,7 +17,6 @@ impl<T> S<T> {
         only_foo(&self.x)
     }
 }
-*/
 
 trait Bar { }
 impl Bar for u32 { }
@@ -31,14 +26,8 @@ fn only_bar<T: Bar>() { }
 impl<T> S<T> {
     // Test that the environment of `dummy_bar` adds up with the environment
     // of the inherent impl.
-    // FIXME(chalk): need late-bound regions on FnDefs
-    /*
     fn dummy_bar<U: Bar>(&self) {
         only_foo(&self.x);
-        only_bar::<U>();
-    }
-    */
-    fn dummy_bar<U: Bar>() {
         only_bar::<U>();
     }
 }
@@ -48,10 +37,6 @@ fn main() {
         x: 5,
     };
 
-    // FIXME(chalk): need late-bound regions on FnDefs
-    /*
-    s.dummy_foo();
     s.dummy_bar::<u32>();
-    */
-    S::<i32>::dummy_bar::<u32>();
+    s.dummy_foo();
 }

--- a/src/test/ui/chalkify/recursive_where_clause_on_type.rs
+++ b/src/test/ui/chalkify/recursive_where_clause_on_type.rs
@@ -1,5 +1,5 @@
 // FIXME(chalk): should fail, see comments
-// check-pass
+// check-fail
 // compile-flags: -Z chalk
 
 #![feature(trivial_bounds)]
@@ -10,7 +10,6 @@ trait Bar {
 trait Foo: Bar { }
 
 struct S where S: Foo;
-//~^ WARN Trait bound S: Foo does not depend on any type or lifetime parameters
 
 impl Foo for S {
 }
@@ -26,10 +25,6 @@ fn foo<T: Foo>() {
 fn main() {
     // For some reason, the error is duplicated...
 
-    // FIXME(chalk): this order of this duplicate error seems non-determistic
-    // and causes test to fail
-    /*
-    foo::<S>() // ERROR the type `S` is not well-formed (chalk)
-    //^ ERROR the type `S` is not well-formed (chalk)
-    */
+    foo::<S>() //~ ERROR the type `S` is not well-formed (chalk)
+    //~^ ERROR the type `S` is not well-formed (chalk)
 }

--- a/src/test/ui/chalkify/recursive_where_clause_on_type.stderr
+++ b/src/test/ui/chalkify/recursive_where_clause_on_type.stderr
@@ -1,10 +1,14 @@
-warning: Trait bound S: Foo does not depend on any type or lifetime parameters
-  --> $DIR/recursive_where_clause_on_type.rs:12:19
+error: the type `S` is not well-formed (chalk)
+  --> $DIR/recursive_where_clause_on_type.rs:28:11
    |
-LL | struct S where S: Foo;
-   |                   ^^^
-   |
-   = note: `#[warn(trivial_bounds)]` on by default
+LL |     foo::<S>()
+   |           ^
 
-warning: 1 warning emitted
+error: the type `S` is not well-formed (chalk)
+  --> $DIR/recursive_where_clause_on_type.rs:28:5
+   |
+LL |     foo::<S>()
+   |     ^^^^^^^^
+
+error: aborting due to 2 previous errors
 


### PR DESCRIPTION
Not a ton here. Notable changes:
- Update to `0.14.0`
  - New dependency on `tracing`, in `librustc_traits` only
  - `FnAbi` from Chalk is `rustc_target::spec::abi::Abi`
  - `Dynamic` actually lowers region
  - Actually lower closures, with some tests. This doesn't 100% work, but can't confirm that's *only* because of closure lowering.
- Use `FxIndexSet` instead of `FxHashSet` in `chalk_fulfill`, which seems to have fixed the non-deterministic test error ordering. Guess we'll see on CI
- Actually implement `opaque_ty_data`, though I don't think this is sufficient for tests for them (I haven't added any)
- Uncomment some of the chalk tests that now work

r? @nikomatsakis 