### PR TITLE
Serialize all foreign `SourceFile`s into proc-macro crate metadata

### DIFF
--- a/src/librustc_metadata/rmeta/mod.rs
+++ b/src/librustc_metadata/rmeta/mod.rs
@@ -192,7 +192,6 @@ crate struct CrateRoot<'tcx> {
     diagnostic_items: Lazy<[(Symbol, DefIndex)]>,
     native_libraries: Lazy<[NativeLib]>,
     foreign_modules: Lazy<[ForeignModule]>,
-    source_map: Lazy<[rustc_span::SourceFile]>,
     def_path_table: Lazy<rustc_hir::definitions::DefPathTable>,
     impls: Lazy<[TraitImpls]>,
     interpret_alloc_index: Lazy<[u32]>,
@@ -203,6 +202,7 @@ crate struct CrateRoot<'tcx> {
     proc_macro_data: Option<Lazy<[DefIndex]>>,
 
     exported_symbols: Lazy!([(ExportedSymbol<'tcx>, SymbolExportLevel)]),
+    source_map: Lazy<[rustc_span::SourceFile]>,
 
     compiler_builtins: bool,
     needs_allocator: bool,

--- a/src/librustc_span/hygiene.rs
+++ b/src/librustc_span/hygiene.rs
@@ -395,10 +395,11 @@ pub fn debug_hygiene_data(verbose: bool) -> String {
             data.expn_data.iter().enumerate().for_each(|(id, expn_info)| {
                 let expn_info = expn_info.as_ref().expect("no expansion data for an expansion ID");
                 s.push_str(&format!(
-                    "\n{}: parent: {:?}, call_site_ctxt: {:?}, kind: {:?}",
+                    "\n{}: parent: {:?}, call_site_ctxt: {:?}, def_site_ctxt: {:?}, kind: {:?}",
                     id,
                     expn_info.parent,
                     expn_info.call_site.ctxt(),
+                    expn_info.def_site.ctxt(),
                     expn_info.kind,
                 ));
             });

--- a/src/test/ui/hygiene/unpretty-debug.stdout
+++ b/src/test/ui/hygiene/unpretty-debug.stdout
@@ -16,8 +16,8 @@ fn y /* 0#0 */() { }
 
 /*
 Expansions:
-0: parent: ExpnId(0), call_site_ctxt: #0, kind: Root
-1: parent: ExpnId(0), call_site_ctxt: #0, kind: Macro(Bang, "foo")
+0: parent: ExpnId(0), call_site_ctxt: #0, def_site_ctxt: #0, kind: Root
+1: parent: ExpnId(0), call_site_ctxt: #0, def_site_ctxt: #0, kind: Macro(Bang, "foo")
 
 SyntaxContexts:
 #0: parent: #0, outer_mark: (ExpnId(0), Opaque)

--- a/src/test/ui/proc-macro/auxiliary/make-macro.rs
+++ b/src/test/ui/proc-macro/auxiliary/make-macro.rs
@@ -1,3 +1,5 @@
+// force-host
+
 #[macro_export]
 macro_rules! make_it {
     ($name:ident) => {

--- a/src/test/ui/proc-macro/auxiliary/make-macro.rs
+++ b/src/test/ui/proc-macro/auxiliary/make-macro.rs
@@ -1,0 +1,10 @@
+#[macro_export]
+macro_rules! make_it {
+    ($name:ident) => {
+        #[proc_macro]
+        pub fn $name(input: TokenStream) -> TokenStream {
+            println!("Def site: {:?}", Span::def_site());
+            input
+        }
+    };
+}

--- a/src/test/ui/proc-macro/auxiliary/meta-macro.rs
+++ b/src/test/ui/proc-macro/auxiliary/meta-macro.rs
@@ -1,0 +1,12 @@
+// force-host
+// no-prefer-dynamic
+// edition:2018
+
+#![feature(proc_macro_def_site)]
+#![crate_type = "proc-macro"]
+
+extern crate proc_macro;
+extern crate make_macro;
+use proc_macro::{TokenStream, Span};
+
+make_macro::make_it!(print_def_site);

--- a/src/test/ui/proc-macro/disappearing-resolution.stderr
+++ b/src/test/ui/proc-macro/disappearing-resolution.stderr
@@ -10,11 +10,16 @@ error[E0603]: derive macro import `Empty` is private
 LL | use m::Empty;
    |        ^^^^^ private derive macro import
    |
-note: the derive macro import `Empty` is defined here
+note: the derive macro import `Empty` is defined here...
   --> $DIR/disappearing-resolution.rs:9:9
    |
 LL |     use test_macros::Empty;
    |         ^^^^^^^^^^^^^^^^^^
+note: ...and refers to the derive macro `Empty` which is defined here
+  --> $DIR/auxiliary/test-macros.rs:25:1
+   |
+LL | pub fn empty_derive(_: TokenStream) -> TokenStream {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ consider importing it directly
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/proc-macro/meta-macro-hygiene.rs
+++ b/src/test/ui/proc-macro/meta-macro-hygiene.rs
@@ -1,0 +1,11 @@
+// aux-build:make-macro.rs
+// aux-build:meta-macro.rs
+// edition:2018
+// compile-flags: -Z span-debug -Z unpretty=expanded,hygiene
+// check-pass
+
+extern crate meta_macro;
+
+fn main() {
+    meta_macro::print_def_site!();
+}

--- a/src/test/ui/proc-macro/meta-macro-hygiene.rs
+++ b/src/test/ui/proc-macro/meta-macro-hygiene.rs
@@ -3,7 +3,9 @@
 // edition:2018
 // compile-flags: -Z span-debug -Z unpretty=expanded,hygiene
 // check-pass
-
+// normalize-stdout-test "\d+#" -> "0#"
+// ^ We don't care about symbol ids, so set them all to 0
+// in the stdout
 extern crate meta_macro;
 
 fn main() {

--- a/src/test/ui/proc-macro/meta-macro-hygiene.stdout
+++ b/src/test/ui/proc-macro/meta-macro-hygiene.stdout
@@ -1,18 +1,20 @@
 Def site: $DIR/auxiliary/make-macro.rs:5:9: 8:10 (#3)
-#![feature /* 280#0 */(prelude_import)]
-#[prelude_import /* 527#1 */]
-use std /* 687#1 */::prelude /* 526#1 */::v1 /* 783#1 */::*;
-#[macro_use /* 404#1 */]
-extern crate std /* 687#1 */;
+#![feature /* 0#0 */(prelude_import)]
+#[prelude_import /* 0#1 */]
+use std /* 0#1 */::prelude /* 0#1 */::v1 /* 0#1 */::*;
+#[macro_use /* 0#1 */]
+extern crate std /* 0#1 */;
 // aux-build:make-macro.rs
 // aux-build:meta-macro.rs
 // edition:2018
 // compile-flags: -Z span-debug -Z unpretty=expanded,hygiene
 // check-pass
+// normalize-stdout-test "\d+#" -> "0#"
+// ^ We don't care about symbol ids, so set them all to 0
+// in the stdout
+extern crate meta_macro /* 0#0 */;
 
-extern crate meta_macro /* 834#0 */;
-
-fn main /* 406#0 */() { }
+fn main /* 0#0 */() { }
 
 /*
 Expansions:

--- a/src/test/ui/proc-macro/meta-macro-hygiene.stdout
+++ b/src/test/ui/proc-macro/meta-macro-hygiene.stdout
@@ -1,0 +1,30 @@
+Def site: $DIR/auxiliary/make-macro.rs:5:9: 8:10 (#3)
+#![feature /* 280#0 */(prelude_import)]
+#[prelude_import /* 527#1 */]
+use std /* 687#1 */::prelude /* 526#1 */::v1 /* 783#1 */::*;
+#[macro_use /* 404#1 */]
+extern crate std /* 687#1 */;
+// aux-build:make-macro.rs
+// aux-build:meta-macro.rs
+// edition:2018
+// compile-flags: -Z span-debug -Z unpretty=expanded,hygiene
+// check-pass
+
+extern crate meta_macro /* 834#0 */;
+
+fn main /* 406#0 */() { }
+
+/*
+Expansions:
+0: parent: ExpnId(0), call_site_ctxt: #0, def_site_ctxt: #0, kind: Root
+1: parent: ExpnId(0), call_site_ctxt: #0, def_site_ctxt: #0, kind: AstPass(StdImports)
+2: parent: ExpnId(0), call_site_ctxt: #0, def_site_ctxt: #0, kind: Macro(Bang, "meta_macro::print_def_site")
+
+SyntaxContexts:
+#0: parent: #0, outer_mark: (ExpnId(0), Opaque)
+#1: parent: #0, outer_mark: (ExpnId(1), Opaque)
+#2: parent: #0, outer_mark: (ExpnId(1), Transparent)
+#3: parent: #0, outer_mark: (ExpnId(2), Opaque)
+#4: parent: #0, outer_mark: (ExpnId(2), Transparent)
+#5: parent: #0, outer_mark: (ExpnId(2), SemiTransparent)
+*/

--- a/src/test/ui/proc-macro/meta-macro-hygiene.stdout
+++ b/src/test/ui/proc-macro/meta-macro-hygiene.stdout
@@ -1,4 +1,4 @@
-Def site: $DIR/auxiliary/make-macro.rs:5:9: 8:10 (#3)
+Def site: $DIR/auxiliary/make-macro.rs:7:9: 10:10 (#3)
 #![feature /* 0#0 */(prelude_import)]
 #[prelude_import /* 0#1 */]
 use std /* 0#1 */::prelude /* 0#1 */::v1 /* 0#1 */::*;

--- a/src/test/ui/proc-macro/meta-macro.rs
+++ b/src/test/ui/proc-macro/meta-macro.rs
@@ -1,0 +1,11 @@
+// aux-build:make-macro.rs
+// aux-build:meta-macro.rs
+// edition:2018
+// compile-flags: -Z span-debug
+// run-pass
+
+extern crate meta_macro;
+
+fn main() {
+    meta_macro::print_def_site!();
+}

--- a/src/test/ui/proc-macro/meta-macro.stdout
+++ b/src/test/ui/proc-macro/meta-macro.stdout
@@ -1,1 +1,1 @@
-Def site: $DIR/auxiliary/make-macro.rs:5:9: 8:10 (#3)
+Def site: $DIR/auxiliary/make-macro.rs:7:9: 10:10 (#3)

--- a/src/test/ui/proc-macro/meta-macro.stdout
+++ b/src/test/ui/proc-macro/meta-macro.stdout
@@ -1,0 +1,1 @@
+Def site: $DIR/auxiliary/make-macro.rs:5:9: 8:10 (#3)


### PR DESCRIPTION
Normally, we encode a `Span` that references a foreign `SourceFile` by
encoding information about the foreign crate. When we decode this
`Span`, we lookup the foreign crate in order to decode the `SourceFile`.

However, this approach does not work for proc-macro crates. When we load
a proc-macro crate, we do not deserialzie any of its dependencies (since
a proc-macro crate can only export proc-macros). This means that we
cannot serialize a reference to an upstream crate, since the associated
metadata will not be available when we try to deserialize it.

This commit modifies foreign span handling so that we treat all foreign
`SourceFile`s as local `SourceFile`s when serializing a proc-macro.
All `SourceFile`s will be stored into the metadata of a proc-macro
crate, allowing us to cotinue to deserialize a proc-macro crate without
needing to load any of its dependencies.

Since the number of foreign `SourceFile`s that we load during a
compilation session may be very large, we only serialize a `SourceFile`
if we have also serialized a `Span` which requires it.