### PR TITLE
emitter: column width defaults to 140

### DIFF
--- a/src/librustc_errors/emitter.rs
+++ b/src/librustc_errors/emitter.rs
@@ -31,6 +31,9 @@ use std::path::Path;
 use termcolor::{Ansi, BufferWriter, ColorChoice, ColorSpec, StandardStream};
 use termcolor::{Buffer, Color, WriteColor};
 
+/// Default column width, used in tests and when terminal dimensions cannot be determined.
+const DEFAULT_COLUMN_WIDTH: usize = 140;
+
 /// Describes the way the content of the `rendered` field of the json output is generated
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum HumanReadableErrorType {
@@ -74,7 +77,8 @@ struct Margin {
     pub computed_left: usize,
     /// The end of the line to be displayed.
     pub computed_right: usize,
-    /// The current width of the terminal. 140 by default and in tests.
+    /// The current width of the terminal. Uses value of `DEFAULT_COLUMN_WIDTH` constant by default
+    /// and in tests.
     pub column_width: usize,
     /// The end column of a span label, including the span. Doesn't account for labels not in the
     /// same line as the span.
@@ -1414,11 +1418,11 @@ impl EmitterWriter {
                 let column_width = if let Some(width) = self.terminal_width {
                     width.saturating_sub(code_offset)
                 } else if self.ui_testing {
-                    140
+                    DEFAULT_COLUMN_WIDTH
                 } else {
                     termize::dimensions()
                         .map(|(w, _)| w.saturating_sub(code_offset))
-                        .unwrap_or(usize::MAX)
+                        .unwrap_or(DEFAULT_COLUMN_WIDTH)
                 };
 
                 let margin = Margin::new(


### PR DESCRIPTION
Fixes #72509.

This PR modifies the column width computation in the emitter when `termize::dimensions` returns `None` so that it uses the default value of 140 (which is used in UI testing currently) instead of `usize::MAX` which just ends up causing overflows in later computations. 

I also tried changing the computations which used `column_width` with their saturating equivalent, but the output appeared the same - so I decided to go with this approach because I feel like it's less likely to accidentally re-introduce an ICE like this in future (e.g. adding a non-saturating operation on `column_width` in future).

I haven't added a test because I couldn't come up with a MCVE. I stumbled upon this running rustc-perf with the `piston-image` benchmark (running in tmux; it only happened with stage two builds only; and only when running through Cargo, not rustc directly with the same flags). In addition, given the nature of the issue, I don't know that we *could* write a UI test for this. Open to suggestions here though.

r? @estebank 