### PR TITLE
resolve: disallow labelled breaks/continues through closures/async blocks

### DIFF
--- a/src/librustc_error_codes/error_codes.rs
+++ b/src/librustc_error_codes/error_codes.rs
@@ -448,6 +448,7 @@ E0763: include_str!("./error_codes/E0763.md"),
 E0764: include_str!("./error_codes/E0764.md"),
 E0765: include_str!("./error_codes/E0765.md"),
 E0766: include_str!("./error_codes/E0766.md"),
+E0767: include_str!("./error_codes/E0767.md"),
 ;
 //  E0006, // merged with E0005
 //  E0008, // cannot bind by-move into a pattern guard

--- a/src/librustc_error_codes/error_codes/E0767.md
+++ b/src/librustc_error_codes/error_codes/E0767.md
@@ -1,0 +1,20 @@
+An unreachable label was used.
+
+Erroneous code example:
+
+```compile_fail,E0767
+'a: loop {
+    || {
+        loop { break 'a } // error: use of unreachable label `'a`
+    };
+}
+```
+
+Ensure that the label is within scope. Labels are not reachable through
+functions, closures, async blocks or modules. Example:
+
+```
+'a: loop {
+    break 'a; // ok!
+}
+```

--- a/src/librustc_passes/liveness.rs
+++ b/src/librustc_passes/liveness.rs
@@ -1123,16 +1123,7 @@ impl<'a, 'tcx> Liveness<'a, 'tcx> {
 
                 match target {
                     Some(b) => self.propagate_through_opt_expr(opt_expr.as_ref().map(|e| &**e), b),
-                    None => {
-                        // FIXME: This should have been checked earlier. Once this is fixed,
-                        // replace with `delay_span_bug`. (#62480)
-                        self.ir
-                            .tcx
-                            .sess
-                            .struct_span_err(expr.span, "`break` to unknown label")
-                            .emit();
-                        rustc_errors::FatalError.raise()
-                    }
+                    None => span_bug!(expr.span, "`break` to unknown label"),
                 }
             }
 

--- a/src/test/ui/break-outside-loop.rs
+++ b/src/test/ui/break-outside-loop.rs
@@ -27,7 +27,9 @@ fn main() {
     // not the `loop`, which failed in the call to `find_breakable`. (#65383)
     'lab: loop {
         || {
-            break 'lab; //~ ERROR `break` inside of a closure
+            break 'lab;
+            //~^ ERROR use of unreachable label `'lab`
+            //~| ERROR `break` inside of a closure
         };
     }
 }

--- a/src/test/ui/break-outside-loop.stderr
+++ b/src/test/ui/break-outside-loop.stderr
@@ -1,3 +1,14 @@
+error[E0767]: use of unreachable label `'lab`
+  --> $DIR/break-outside-loop.rs:30:19
+   |
+LL |     'lab: loop {
+   |     ---- unreachable label defined here
+LL |         || {
+LL |             break 'lab;
+   |                   ^^^^ unreachable label `'lab`
+   |
+   = note: labels are unreachable through functions, closures, async blocks and modules
+
 error[E0268]: `break` outside of a loop
   --> $DIR/break-outside-loop.rs:10:15
    |
@@ -41,7 +52,7 @@ LL |         || {
 LL |             break 'lab;
    |             ^^^^^^^^^^ cannot `break` inside of a closure
 
-error: aborting due to 6 previous errors
+error: aborting due to 7 previous errors
 
-Some errors have detailed explanations: E0267, E0268.
+Some errors have detailed explanations: E0267, E0268, E0767.
 For more information about an error, try `rustc --explain E0267`.

--- a/src/test/ui/error-codes/E0767.rs
+++ b/src/test/ui/error-codes/E0767.rs
@@ -1,0 +1,7 @@
+fn main () {
+    'a: loop {
+        || {
+            loop { break 'a; } //~ ERROR E0767
+        }
+    }
+}

--- a/src/test/ui/error-codes/E0767.stderr
+++ b/src/test/ui/error-codes/E0767.stderr
@@ -1,11 +1,11 @@
-error[E0767]: use of unreachable label `'l`
-  --> $DIR/resolve-label.rs:5:23
+error[E0767]: use of unreachable label `'a`
+  --> $DIR/E0767.rs:4:26
    |
-LL |     'l: loop {
+LL |     'a: loop {
    |     -- unreachable label defined here
-...
-LL |                 break 'l;
-   |                       ^^ unreachable label `'l`
+LL |         || {
+LL |             loop { break 'a; }
+   |                          ^^ unreachable label `'a`
    |
    = note: labels are unreachable through functions, closures, async blocks and modules
 

--- a/src/test/ui/issues/issue-62480.rs
+++ b/src/test/ui/issues/issue-62480.rs
@@ -5,6 +5,8 @@ fn main() {
     // `propagate_through_expr` would be the closure and not the `loop`, which wouldn't be found in
     // `self.break_ln`. (#62480)
     'a: {
-        || break 'a //~ ERROR `break` to unknown label
+        || break 'a
+        //~^ ERROR use of unreachable label `'a`
+        //~| ERROR `break` inside of a closure
     }
 }

--- a/src/test/ui/issues/issue-62480.stderr
+++ b/src/test/ui/issues/issue-62480.stderr
@@ -1,8 +1,22 @@
-error: `break` to unknown label
+error[E0767]: use of unreachable label `'a`
+  --> $DIR/issue-62480.rs:8:18
+   |
+LL |     'a: {
+   |     -- unreachable label defined here
+LL |         || break 'a
+   |                  ^^ unreachable label `'a`
+   |
+   = note: labels are unreachable through functions, closures, async blocks and modules
+
+error[E0267]: `break` inside of a closure
   --> $DIR/issue-62480.rs:8:12
    |
 LL |         || break 'a
-   |            ^^^^^^^^
+   |         -- ^^^^^^^^ cannot `break` inside of a closure
+   |         |
+   |         enclosing closure
 
-error: aborting due to previous error
+error: aborting due to 2 previous errors
 
+Some errors have detailed explanations: E0267, E0767.
+For more information about an error, try `rustc --explain E0267`.

--- a/src/test/ui/issues/issue-66702-break-outside-loop-val.rs
+++ b/src/test/ui/issues/issue-66702-break-outside-loop-val.rs
@@ -2,6 +2,8 @@
 
 fn main() {
     'some_label: loop {
-        || break 'some_label (); //~ ERROR: `break` inside of a closure
+        || break 'some_label ();
+        //~^ ERROR: use of unreachable label `'some_label`
+        //~| ERROR: `break` inside of a closure
     }
 }

--- a/src/test/ui/issues/issue-66702-break-outside-loop-val.stderr
+++ b/src/test/ui/issues/issue-66702-break-outside-loop-val.stderr
@@ -1,3 +1,13 @@
+error[E0767]: use of unreachable label `'some_label`
+  --> $DIR/issue-66702-break-outside-loop-val.rs:5:18
+   |
+LL |     'some_label: loop {
+   |     ----------- unreachable label defined here
+LL |         || break 'some_label ();
+   |                  ^^^^^^^^^^^ unreachable label `'some_label`
+   |
+   = note: labels are unreachable through functions, closures, async blocks and modules
+
 error[E0267]: `break` inside of a closure
   --> $DIR/issue-66702-break-outside-loop-val.rs:5:12
    |
@@ -6,6 +16,7 @@ LL |         || break 'some_label ();
    |         |
    |         enclosing closure
 
-error: aborting due to previous error
+error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0267`.
+Some errors have detailed explanations: E0267, E0767.
+For more information about an error, try `rustc --explain E0267`.

--- a/src/test/ui/issues/issue-73541-1.rs
+++ b/src/test/ui/issues/issue-73541-1.rs
@@ -1,0 +1,12 @@
+// edition:2018
+
+fn main() {
+    'a: loop {
+        async {
+            loop {
+                continue 'a
+                //~^ ERROR use of unreachable label `'a`
+            }
+        };
+    }
+}

--- a/src/test/ui/issues/issue-73541-1.stderr
+++ b/src/test/ui/issues/issue-73541-1.stderr
@@ -1,11 +1,11 @@
-error[E0767]: use of unreachable label `'l`
-  --> $DIR/resolve-label.rs:5:23
+error[E0767]: use of unreachable label `'a`
+  --> $DIR/issue-73541-1.rs:7:26
    |
-LL |     'l: loop {
+LL |     'a: loop {
    |     -- unreachable label defined here
 ...
-LL |                 break 'l;
-   |                       ^^ unreachable label `'l`
+LL |                 continue 'a
+   |                          ^^ unreachable label `'a`
    |
    = note: labels are unreachable through functions, closures, async blocks and modules
 

--- a/src/test/ui/issues/issue-73541-2.rs
+++ b/src/test/ui/issues/issue-73541-2.rs
@@ -1,0 +1,20 @@
+// edition:2018
+
+async fn c() {
+    'a: loop {
+        macro_rules! b {
+            () => {
+                continue 'a
+                //~^ ERROR use of unreachable label `'a`
+            }
+        }
+
+        async {
+            loop {
+                b!();
+            }
+        };
+    }
+}
+
+fn main() { }

--- a/src/test/ui/issues/issue-73541-2.stderr
+++ b/src/test/ui/issues/issue-73541-2.stderr
@@ -1,0 +1,18 @@
+error[E0767]: use of unreachable label `'a`
+  --> $DIR/issue-73541-2.rs:7:26
+   |
+LL |     'a: loop {
+   |     -- unreachable label defined here
+...
+LL |                 continue 'a
+   |                          ^^ unreachable label `'a`
+...
+LL |                 b!();
+   |                 ----- in this macro invocation
+   |
+   = note: labels are unreachable through functions, closures, async blocks and modules
+   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0767`.

--- a/src/test/ui/issues/issue-73541-3.rs
+++ b/src/test/ui/issues/issue-73541-3.rs
@@ -1,0 +1,9 @@
+fn main() {
+    'aaaaab: loop {
+        || {
+            loop { continue 'aaaaaa }
+            //~^ ERROR use of undeclared label `'aaaaaa`
+        };
+
+    }
+}

--- a/src/test/ui/issues/issue-73541-3.stderr
+++ b/src/test/ui/issues/issue-73541-3.stderr
@@ -1,0 +1,12 @@
+error[E0426]: use of undeclared label `'aaaaaa`
+  --> $DIR/issue-73541-3.rs:4:29
+   |
+LL |     'aaaaab: loop {
+   |     ------- a label with a similar name exists but is unreachable
+LL |         || {
+LL |             loop { continue 'aaaaaa }
+   |                             ^^^^^^^ undeclared label `'aaaaaa`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0426`.

--- a/src/test/ui/issues/issue-73541.rs
+++ b/src/test/ui/issues/issue-73541.rs
@@ -1,0 +1,9 @@
+fn main() {
+    'a: loop {
+        || {
+            loop { continue 'a }
+            //~^ ERROR use of unreachable label `'a`
+        };
+
+    }
+}

--- a/src/test/ui/issues/issue-73541.stderr
+++ b/src/test/ui/issues/issue-73541.stderr
@@ -1,11 +1,11 @@
-error[E0767]: use of unreachable label `'l`
-  --> $DIR/resolve-label.rs:5:23
+error[E0767]: use of unreachable label `'a`
+  --> $DIR/issue-73541.rs:4:29
    |
-LL |     'l: loop {
+LL |     'a: loop {
    |     -- unreachable label defined here
-...
-LL |                 break 'l;
-   |                       ^^ unreachable label `'l`
+LL |         || {
+LL |             loop { continue 'a }
+   |                             ^^ unreachable label `'a`
    |
    = note: labels are unreachable through functions, closures, async blocks and modules
 

--- a/src/test/ui/resolve/resolve-label.rs
+++ b/src/test/ui/resolve/resolve-label.rs
@@ -2,7 +2,7 @@ fn f() {
     'l: loop {
         fn g() {
             loop {
-                break 'l; //~ ERROR use of undeclared label
+                break 'l; //~ ERROR use of unreachable label
             }
         }
     }

--- a/src/test/ui/suggestions/suggest-labels.stderr
+++ b/src/test/ui/suggestions/suggest-labels.stderr
@@ -1,35 +1,35 @@
 error[E0426]: use of undeclared label `'fo`
   --> $DIR/suggest-labels.rs:4:15
    |
+LL |     'foo: loop {
+   |     ---- a label with a similar name is reachable
 LL |         break 'fo;
    |               ^^^
-   |
-help: a label with a similar name exists in this scope
-   |
-LL |         break 'foo;
-   |               ^^^^
+   |               |
+   |               undeclared label `'fo`
+   |               help: try using similarly named label: `'foo`
 
 error[E0426]: use of undeclared label `'bor`
   --> $DIR/suggest-labels.rs:8:18
    |
+LL |     'bar: loop {
+   |     ---- a label with a similar name is reachable
 LL |         continue 'bor;
    |                  ^^^^
-   |
-help: a label with a similar name exists in this scope
-   |
-LL |         continue 'bar;
-   |                  ^^^^
+   |                  |
+   |                  undeclared label `'bor`
+   |                  help: try using similarly named label: `'bar`
 
 error[E0426]: use of undeclared label `'longlable`
   --> $DIR/suggest-labels.rs:13:19
    |
+LL |         'longlabel1: loop {
+   |         ----------- a label with a similar name is reachable
 LL |             break 'longlable;
    |                   ^^^^^^^^^^
-   |
-help: a label with a similar name exists in this scope
-   |
-LL |             break 'longlabel1;
-   |                   ^^^^^^^^^^^
+   |                   |
+   |                   undeclared label `'longlable`
+   |                   help: try using similarly named label: `'longlabel1`
 
 error: aborting due to 3 previous errors
 


### PR DESCRIPTION
Fixes #73541.

This PR modifies name resolution to prohibit labelled breaks/continues through closures or async blocks, fixing an ICE. In addition, it improves the diagnostics surrounding labelled breaks/continues through closures or async blocks by informing the user if the label exists in an parent scope and telling them that won't work.

r? @petrochenkov (resolve)
cc @estebank (diagnostic changes) @tmandry (issue is from `wg-async-foundations`)