### PR TITLE
Preserve place context through projections

### DIFF
--- a/src/librustc_codegen_ssa/mir/analyze.rs
+++ b/src/librustc_codegen_ssa/mir/analyze.rs
@@ -160,7 +160,13 @@ impl<'mir, 'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> Visitor<'tcx>
         self.seen_disqualifying_projection = false;
     }
 
-    fn visit_local(&mut self, &local: &mir::Local, context: PlaceContext, _: bool, location: Location) {
+    fn visit_local(
+        &mut self,
+        &local: &mir::Local,
+        context: PlaceContext,
+        _: bool,
+        location: Location,
+    ) {
         if self.seen_disqualifying_projection {
             self.not_ssa(local);
         }
@@ -173,9 +179,11 @@ impl<'mir, 'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> Visitor<'tcx>
 
             PlaceContext::NonUse(_) | PlaceContext::MutatingUse(MutatingUseContext::Retag) => {}
 
-            PlaceContext::MutatingUse(MutatingUseContext::Deref) |
-            PlaceContext::NonMutatingUse(
-                NonMutatingUseContext::Copy | NonMutatingUseContext::Move | NonMutatingUseContext::Deref,
+            PlaceContext::MutatingUse(MutatingUseContext::Deref)
+            | PlaceContext::NonMutatingUse(
+                NonMutatingUseContext::Copy
+                | NonMutatingUseContext::Move
+                | NonMutatingUseContext::Deref,
             ) => {
                 // Reads from uninitialized variables (e.g., in dead code, after
                 // optimizations) require locals to be in (uninitialized) memory.

--- a/src/librustc_mir/borrow_check/def_use.rs
+++ b/src/librustc_mir/borrow_check/def_use.rs
@@ -40,8 +40,8 @@ pub fn categorize(context: PlaceContext) -> Option<DefUse> {
         // purposes of NLL, these are special in that **all** the
         // lifetimes appearing in the variable must be live for each regular use.
 
-        PlaceContext::NonMutatingUse(NonMutatingUseContext::Projection) |
-        PlaceContext::MutatingUse(MutatingUseContext::Projection) |
+        PlaceContext::NonMutatingUse(NonMutatingUseContext::Deref) |
+        PlaceContext::MutatingUse(MutatingUseContext::Deref) |
 
         // Borrows only consider their local used at the point of the borrow.
         // This won't affect the results since we use this analysis for generators

--- a/src/librustc_mir/borrow_check/type_check/liveness/local_use_map.rs
+++ b/src/librustc_mir/borrow_check/type_check/liveness/local_use_map.rs
@@ -157,9 +157,19 @@ impl LocalUseMapBuild<'_> {
 }
 
 impl Visitor<'tcx> for LocalUseMapBuild<'_> {
-    fn visit_local(&mut self, &local: &Local, context: PlaceContext, location: Location) {
+    fn visit_local(
+        &mut self,
+        &local: &Local,
+        context: PlaceContext,
+        has_projections: bool,
+        location: Location,
+    ) {
         if self.locals_with_use_data[local] {
             match def_use::categorize(context) {
+                // FIXME: This is to preserve the old behavior when `PlaceContext::Projection` was
+                // a thing.
+                _ if has_projections => self.insert_use(local, location),
+
                 Some(DefUse::Def) => self.insert_def(local, location),
                 Some(DefUse::Use) => self.insert_use(local, location),
                 Some(DefUse::Drop) => self.insert_drop(local, location),

--- a/src/librustc_mir/borrow_check/type_check/liveness/polonius.rs
+++ b/src/librustc_mir/borrow_check/type_check/liveness/polonius.rs
@@ -55,8 +55,18 @@ impl UseFactsExtractor<'_> {
 }
 
 impl Visitor<'tcx> for UseFactsExtractor<'_> {
-    fn visit_local(&mut self, &local: &Local, context: PlaceContext, location: Location) {
+    fn visit_local(
+        &mut self,
+        &local: &Local,
+        context: PlaceContext,
+        has_projections: bool,
+        location: Location,
+    ) {
         match def_use::categorize(context) {
+            // FIXME: This is to preserve the old behavior when `PlaceContext::Projection` was
+            // a thing.
+            _ if has_projections => self.insert_use(local, location),
+
             Some(DefUse::Def) => self.insert_def(local, location),
             Some(DefUse::Use) => self.insert_use(local, location),
             Some(DefUse::Drop) => self.insert_drop_use(local, location),

--- a/src/librustc_mir/borrow_check/used_muts.rs
+++ b/src/librustc_mir/borrow_check/used_muts.rs
@@ -92,8 +92,17 @@ impl<'visit, 'cx, 'tcx> Visitor<'tcx> for GatherUsedMutsVisitor<'visit, 'cx, 'tc
         self.super_statement(statement, location);
     }
 
-    fn visit_local(&mut self, local: &Local, place_context: PlaceContext, location: Location) {
-        if place_context.is_place_assignment() && self.temporary_used_locals.contains(local) {
+    fn visit_local(
+        &mut self,
+        local: &Local,
+        place_context: PlaceContext,
+        has_projections: bool,
+        location: Location,
+    ) {
+        if place_context.is_place_assignment()
+            && self.temporary_used_locals.contains(local)
+            && !has_projections
+        {
             // Propagate the Local assigned at this Location as a used mutable local variable
             for moi in &self.mbcx.move_data.loc_map[location] {
                 let mpi = &self.mbcx.move_data.moves[*moi].path;

--- a/src/librustc_mir/dataflow/impls/storage_liveness.rs
+++ b/src/librustc_mir/dataflow/impls/storage_liveness.rs
@@ -298,8 +298,15 @@ impl<'a, 'mir, 'tcx, T> Visitor<'tcx> for MoveVisitor<'a, 'mir, 'tcx, T>
 where
     T: GenKill<Local>,
 {
-    fn visit_local(&mut self, local: &Local, context: PlaceContext, loc: Location) {
-        if PlaceContext::NonMutatingUse(NonMutatingUseContext::Move) == context {
+    fn visit_local(
+        &mut self,
+        local: &Local,
+        context: PlaceContext,
+        has_projections: bool,
+        loc: Location,
+    ) {
+        if PlaceContext::NonMutatingUse(NonMutatingUseContext::Move) == context && !has_projections
+        {
             let mut borrowed_locals = self.borrowed_locals.borrow_mut();
             borrowed_locals.seek_before_primary_effect(loc);
             if !borrowed_locals.contains(*local) {

--- a/src/librustc_mir/monomorphize/collector.rs
+++ b/src/librustc_mir/monomorphize/collector.rs
@@ -678,6 +678,7 @@ impl<'a, 'tcx> MirVisitor<'tcx> for MirNeighborCollector<'a, 'tcx> {
         &mut self,
         _place_local: &Local,
         _context: mir::visit::PlaceContext,
+        _has_projections: bool,
         _location: Location,
     ) {
     }

--- a/src/librustc_mir/transform/generator.rs
+++ b/src/librustc_mir/transform/generator.rs
@@ -87,7 +87,7 @@ impl<'tcx> MutVisitor<'tcx> for RenameLocalVisitor<'tcx> {
         self.tcx
     }
 
-    fn visit_local(&mut self, local: &mut Local, _: PlaceContext, _: Location) {
+    fn visit_local(&mut self, local: &mut Local, _: PlaceContext, _: bool, _: Location) {
         if *local == self.from {
             *local = self.to;
         }
@@ -113,7 +113,7 @@ impl<'tcx> MutVisitor<'tcx> for DerefArgVisitor<'tcx> {
         self.tcx
     }
 
-    fn visit_local(&mut self, local: &mut Local, _: PlaceContext, _: Location) {
+    fn visit_local(&mut self, local: &mut Local, _: PlaceContext, _: bool, _: Location) {
         assert_ne!(*local, SELF_ARG);
     }
 
@@ -128,7 +128,7 @@ impl<'tcx> MutVisitor<'tcx> for DerefArgVisitor<'tcx> {
                 self.tcx,
             );
         } else {
-            self.visit_local(&mut place.local, context, location);
+            self.visit_local(&mut place.local, context, !place.projection.is_empty(), location);
 
             for elem in place.projection.iter() {
                 if let PlaceElem::Index(local) = elem {
@@ -149,7 +149,7 @@ impl<'tcx> MutVisitor<'tcx> for PinArgVisitor<'tcx> {
         self.tcx
     }
 
-    fn visit_local(&mut self, local: &mut Local, _: PlaceContext, _: Location) {
+    fn visit_local(&mut self, local: &mut Local, _: PlaceContext, _: bool, _: Location) {
         assert_ne!(*local, SELF_ARG);
     }
 
@@ -167,7 +167,7 @@ impl<'tcx> MutVisitor<'tcx> for PinArgVisitor<'tcx> {
                 self.tcx,
             );
         } else {
-            self.visit_local(&mut place.local, context, location);
+            self.visit_local(&mut place.local, context, !place.projection.is_empty(), location);
 
             for elem in place.projection.iter() {
                 if let PlaceElem::Index(local) = elem {
@@ -284,7 +284,7 @@ impl MutVisitor<'tcx> for TransformVisitor<'tcx> {
         self.tcx
     }
 
-    fn visit_local(&mut self, local: &mut Local, _: PlaceContext, _: Location) {
+    fn visit_local(&mut self, local: &mut Local, _: PlaceContext, _: bool, _: Location) {
         assert_eq!(self.remap.get(local), None);
     }
 

--- a/src/librustc_mir/transform/inline.rs
+++ b/src/librustc_mir/transform/inline.rs
@@ -679,7 +679,13 @@ impl<'a, 'tcx> MutVisitor<'tcx> for Integrator<'a, 'tcx> {
         self.tcx
     }
 
-    fn visit_local(&mut self, local: &mut Local, _ctxt: PlaceContext, _location: Location) {
+    fn visit_local(
+        &mut self,
+        local: &mut Local,
+        _ctxt: PlaceContext,
+        _: bool,
+        _location: Location,
+    ) {
         *local = self.make_integrate_local(*local);
     }
 

--- a/src/librustc_mir/transform/nrvo.rs
+++ b/src/librustc_mir/transform/nrvo.rs
@@ -196,7 +196,7 @@ impl MutVisitor<'tcx> for RenameToReturnPlace<'tcx> {
         self.super_terminator(terminator, loc);
     }
 
-    fn visit_local(&mut self, l: &mut Local, _: PlaceContext, _: Location) {
+    fn visit_local(&mut self, l: &mut Local, _: PlaceContext, _: bool, _: Location) {
         assert_ne!(*l, mir::RETURN_PLACE);
         if *l == self.to_rename {
             *l = mir::RETURN_PLACE;
@@ -215,7 +215,7 @@ impl IsReturnPlaceRead {
 }
 
 impl Visitor<'tcx> for IsReturnPlaceRead {
-    fn visit_local(&mut self, &l: &Local, ctxt: PlaceContext, _: Location) {
+    fn visit_local(&mut self, &l: &Local, ctxt: PlaceContext, _: bool, _: Location) {
         if l == mir::RETURN_PLACE && ctxt.is_use() && !ctxt.is_place_assignment() {
             self.0 = true;
         }

--- a/src/librustc_mir/util/collect_writes.rs
+++ b/src/librustc_mir/util/collect_writes.rs
@@ -24,7 +24,13 @@ struct FindLocalAssignmentVisitor {
 }
 
 impl<'tcx> Visitor<'tcx> for FindLocalAssignmentVisitor {
-    fn visit_local(&mut self, local: &Local, place_context: PlaceContext, location: Location) {
+    fn visit_local(
+        &mut self,
+        local: &Local,
+        place_context: PlaceContext,
+        _: bool,
+        location: Location,
+    ) {
         if self.needle != *local {
             return;
         }

--- a/src/librustc_mir/util/def_use.rs
+++ b/src/librustc_mir/util/def_use.rs
@@ -87,7 +87,13 @@ struct DefUseFinder {
 }
 
 impl Visitor<'_> for DefUseFinder {
-    fn visit_local(&mut self, &local: &Local, context: PlaceContext, location: Location) {
+    fn visit_local(
+        &mut self,
+        &local: &Local,
+        context: PlaceContext,
+        _has_projections: bool,
+        location: Location,
+    ) {
         let info = &mut self.info[local];
         if self.in_var_debug_info {
             info.var_debug_info_indices.push(self.var_debug_info_index);
@@ -150,7 +156,13 @@ impl MutVisitor<'tcx> for MutateUseVisitor<'tcx> {
         self.tcx
     }
 
-    fn visit_local(&mut self, local: &mut Local, _context: PlaceContext, _location: Location) {
+    fn visit_local(
+        &mut self,
+        local: &mut Local,
+        _context: PlaceContext,
+        _: bool,
+        _location: Location,
+    ) {
         if *local == self.query {
             *local = self.new_local;
         }


### PR DESCRIPTION
Resolves #72931. Implements rust-lang/compiler-team#300.

This removes `PlaceContext::MutatingUse(Projection)`, which was used for `x.y = 42`, `*x = 42` and `&mut x.y`, as well as `PlaceContext::NonMutatingUse(Projection)`, which was used for `let _ = x.y`, `let _ = *x`, and `&x.y`. Now, these places receive their original `PlaceContext` unless there is a `Deref` projection.

Unfortunately, there's a lot of code that relies on a context only appearing in `visit_local` when the *entire* local is being assigned. Originally, I was going to switch these visitors to use `visit_place`. However, `visit_place` is not called for every use of a `Local` in the MIR, notably `Index` projections and `Storage{Live,Dead}` will result in a call to `visit_local` without one to `visit_place`. Instead I added an extra parameter to `visit_local` that is set when the `Local` was in a `Place` with projections.

This is not very clean, and the other solutions all have problems as well. I'm starting to wonder if we would be better off with a MIR Visitor 2.0 that was designed specifically for traversing the CFG instead of the current, one-size-fits-all trait. That way, we could make small quality-of-life improvements without worrying about subtly breaking old code that relies on a certain visitation order.

r? @oli-obk, although I'm not very proud of the current state of this.