### PR TITLE
errors: use `-Z terminal-width` in JSON emitter

### DIFF
--- a/src/librustc_errors/json.rs
+++ b/src/librustc_errors/json.rs
@@ -36,6 +36,7 @@ pub struct JsonEmitter {
     pretty: bool,
     ui_testing: bool,
     json_rendered: HumanReadableErrorType,
+    terminal_width: Option<usize>,
     macro_backtrace: bool,
 }
 
@@ -45,6 +46,7 @@ impl JsonEmitter {
         source_map: Lrc<SourceMap>,
         pretty: bool,
         json_rendered: HumanReadableErrorType,
+        terminal_width: Option<usize>,
         macro_backtrace: bool,
     ) -> JsonEmitter {
         JsonEmitter {
@@ -54,6 +56,7 @@ impl JsonEmitter {
             pretty,
             ui_testing: false,
             json_rendered,
+            terminal_width,
             macro_backtrace,
         }
     }
@@ -61,6 +64,7 @@ impl JsonEmitter {
     pub fn basic(
         pretty: bool,
         json_rendered: HumanReadableErrorType,
+        terminal_width: Option<usize>,
         macro_backtrace: bool,
     ) -> JsonEmitter {
         let file_path_mapping = FilePathMapping::empty();
@@ -69,6 +73,7 @@ impl JsonEmitter {
             Lrc::new(SourceMap::new(file_path_mapping)),
             pretty,
             json_rendered,
+            terminal_width,
             macro_backtrace,
         )
     }
@@ -79,6 +84,7 @@ impl JsonEmitter {
         source_map: Lrc<SourceMap>,
         pretty: bool,
         json_rendered: HumanReadableErrorType,
+        terminal_width: Option<usize>,
         macro_backtrace: bool,
     ) -> JsonEmitter {
         JsonEmitter {
@@ -88,6 +94,7 @@ impl JsonEmitter {
             pretty,
             ui_testing: false,
             json_rendered,
+            terminal_width,
             macro_backtrace,
         }
     }
@@ -247,7 +254,13 @@ impl Diagnostic {
         let buf = BufWriter::default();
         let output = buf.clone();
         je.json_rendered
-            .new_emitter(Box::new(buf), Some(je.sm.clone()), false, None, je.macro_backtrace)
+            .new_emitter(
+                Box::new(buf),
+                Some(je.sm.clone()),
+                false,
+                je.terminal_width,
+                je.macro_backtrace,
+            )
             .ui_testing(je.ui_testing)
             .emit_diagnostic(diag);
         let output = Arc::try_unwrap(output.0).unwrap().into_inner().unwrap();

--- a/src/librustc_session/session.rs
+++ b/src/librustc_session/session.rs
@@ -1061,8 +1061,15 @@ fn default_emitter(
             }
         }
         (config::ErrorOutputType::Json { pretty, json_rendered }, None) => Box::new(
-            JsonEmitter::stderr(Some(registry), source_map, pretty, json_rendered, macro_backtrace)
-                .ui_testing(sopts.debugging_opts.ui_testing),
+            JsonEmitter::stderr(
+                Some(registry),
+                source_map,
+                pretty,
+                json_rendered,
+                sopts.debugging_opts.terminal_width,
+                macro_backtrace,
+            )
+            .ui_testing(sopts.debugging_opts.ui_testing),
         ),
         (config::ErrorOutputType::Json { pretty, json_rendered }, Some(dst)) => Box::new(
             JsonEmitter::new(
@@ -1071,6 +1078,7 @@ fn default_emitter(
                 source_map,
                 pretty,
                 json_rendered,
+                sopts.debugging_opts.terminal_width,
                 macro_backtrace,
             )
             .ui_testing(sopts.debugging_opts.ui_testing),
@@ -1416,7 +1424,7 @@ pub fn early_error(output: config::ErrorOutputType, msg: &str) -> ! {
             Box::new(EmitterWriter::stderr(color_config, None, short, false, None, false))
         }
         config::ErrorOutputType::Json { pretty, json_rendered } => {
-            Box::new(JsonEmitter::basic(pretty, json_rendered, false))
+            Box::new(JsonEmitter::basic(pretty, json_rendered, None, false))
         }
     };
     let handler = rustc_errors::Handler::with_emitter(true, None, emitter);
@@ -1431,7 +1439,7 @@ pub fn early_warn(output: config::ErrorOutputType, msg: &str) {
             Box::new(EmitterWriter::stderr(color_config, None, short, false, None, false))
         }
         config::ErrorOutputType::Json { pretty, json_rendered } => {
-            Box::new(JsonEmitter::basic(pretty, json_rendered, false))
+            Box::new(JsonEmitter::basic(pretty, json_rendered, None, false))
         }
     };
     let handler = rustc_errors::Handler::with_emitter(true, None, emitter);

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -191,8 +191,15 @@ pub fn new_handler(
                 Lrc::new(source_map::SourceMap::new(source_map::FilePathMapping::empty()))
             });
             Box::new(
-                JsonEmitter::stderr(None, source_map, pretty, json_rendered, false)
-                    .ui_testing(debugging_opts.ui_testing),
+                JsonEmitter::stderr(
+                    None,
+                    source_map,
+                    pretty,
+                    json_rendered,
+                    debugging_opts.terminal_width,
+                    false,
+                )
+                .ui_testing(debugging_opts.ui_testing),
             )
         }
     };

--- a/src/test/ui/terminal-width/flag-human.rs
+++ b/src/test/ui/terminal-width/flag-human.rs
@@ -1,0 +1,9 @@
+// compile-flags: -Z terminal-width=20
+
+// This test checks that `-Z terminal-width` effects the human error output by restricting it to an
+// arbitrarily low value so that the effect is visible.
+
+fn main() {
+    let _: () = 42;
+    //~^ ERROR mismatched types
+}

--- a/src/test/ui/terminal-width/flag-human.stderr
+++ b/src/test/ui/terminal-width/flag-human.stderr
@@ -1,0 +1,11 @@
+error[E0308]: mismatched types
+  --> $DIR/flag-human.rs:7:17
+   |
+LL | ..._: () = 42;
+   |       --   ^^ expected `()`, found integer
+   |       |
+   |       expected due to this
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/terminal-width/flag-json.rs
+++ b/src/test/ui/terminal-width/flag-json.rs
@@ -1,0 +1,9 @@
+// compile-flags: -Z terminal-width=20 --error-format=json
+
+// This test checks that `-Z terminal-width` effects the JSON error output by restricting it to an
+// arbitrarily low value so that the effect is visible.
+
+fn main() {
+    let _: () = 42;
+    //~^ ERROR mismatched types
+}

--- a/src/test/ui/terminal-width/flag-json.stderr
+++ b/src/test/ui/terminal-width/flag-json.stderr
@@ -1,0 +1,32 @@
+{"message":"mismatched types","code":{"code":"E0308","explanation":"Expected type did not match the received type.
+
+Erroneous code example:
+
+```compile_fail,E0308
+let x: i32 = \"I am not a number!\";
+//     ~~~   ~~~~~~~~~~~~~~~~~~~~
+//      |             |
+//      |    initializing expression;
+//      |    compiler infers type `&str`
+//      |
+//    type `i32` assigned to variable `x`
+```
+
+This error occurs when the compiler is unable to infer the concrete type of a
+variable. It can occur in several cases, the most common being a mismatch
+between two types: the type the author explicitly assigned, and the type the
+compiler inferred.
+"},"level":"error","spans":[{"file_name":"$DIR/flag-json.rs","byte_start":244,"byte_end":246,"line_start":7,"line_end":7,"column_start":17,"column_end":19,"is_primary":true,"text":[{"text":"    let _: () = 42;","highlight_start":17,"highlight_end":19}],"label":"expected `()`, found integer","suggested_replacement":null,"suggestion_applicability":null,"expansion":null},{"file_name":"$DIR/flag-json.rs","byte_start":239,"byte_end":241,"line_start":7,"line_end":7,"column_start":12,"column_end":14,"is_primary":false,"text":[{"text":"    let _: () = 42;","highlight_start":12,"highlight_end":14}],"label":"expected due to this","suggested_replacement":null,"suggestion_applicability":null,"expansion":null}],"children":[],"rendered":"error[E0308]: mismatched types
+  --> $DIR/flag-json.rs:7:17
+   |
+LL | ..._: () = 42;
+   |       --   ^^ expected `()`, found integer
+   |       |
+   |       expected due to this
+
+"}
+{"message":"aborting due to previous error","code":null,"level":"error","spans":[],"children":[],"rendered":"error: aborting due to previous error
+
+"}
+{"message":"For more information about this error, try `rustc --explain E0308`.","code":null,"level":"failure-note","spans":[],"children":[],"rendered":"For more information about this error, try `rustc --explain E0308`.
+"}


### PR DESCRIPTION
This PR makes the JSON emitter use `-Z terminal-width` in the "rendered" field of the JSON output.

r? @estebank