### PR TITLE
Make liveness more precise for assignments to fields

### DIFF
--- a/src/test/ui/mir-dataflow/liveness-projection.rs
+++ b/src/test/ui/mir-dataflow/liveness-projection.rs
@@ -21,7 +21,7 @@ fn foo() {
     {
         let mut x = 42;
 
-        // Derefs are treated like a read of a local even if they are on the RHS of an assignment.
+        // Derefs are treated like a read of a local even if they are on the LHS of an assignment.
         let p = &mut x;
         unsafe { rustc_peek(&p); }
         *p = 24;

--- a/src/test/ui/mir-dataflow/liveness-projection.rs
+++ b/src/test/ui/mir-dataflow/liveness-projection.rs
@@ -1,0 +1,32 @@
+#![feature(core_intrinsics, rustc_attrs)]
+
+use std::intrinsics::rustc_peek;
+
+#[rustc_mir(rustc_peek_liveness, stop_after_dataflow)]
+fn foo() {
+    {
+        let mut x: (i32, i32) = (42, 0);
+
+        // Assignment to a projection does not cause `x` to become live
+        unsafe { rustc_peek(x); } //~ ERROR bit not set
+        x.1 = 42;
+
+        x = (0, 42);
+
+        // ...but a read from a projection does.
+        unsafe { rustc_peek(x); }
+        println!("{}", x.1);
+    }
+
+    {
+        let mut x = 42;
+
+        // Derefs are treated like a read of a local even if they are on the RHS of an assignment.
+        let p = &mut x;
+        unsafe { rustc_peek(&p); }
+        *p = 24;
+        unsafe { rustc_peek(&p); } //~ ERROR bit not set
+    }
+}
+
+fn main() {}

--- a/src/test/ui/mir-dataflow/liveness-projection.stderr
+++ b/src/test/ui/mir-dataflow/liveness-projection.stderr
@@ -1,0 +1,16 @@
+error: rustc_peek: bit not set
+  --> $DIR/liveness-projection.rs:11:18
+   |
+LL |         unsafe { rustc_peek(x); }
+   |                  ^^^^^^^^^^^^^
+
+error: rustc_peek: bit not set
+  --> $DIR/liveness-projection.rs:28:18
+   |
+LL |         unsafe { rustc_peek(&p); }
+   |                  ^^^^^^^^^^^^^^
+
+error: stop_after_dataflow ended compilation
+
+error: aborting due to 3 previous errors
+


### PR DESCRIPTION
Previously, we were too conservative and `x.field = 4` was treated as a "use" of `x`. Now it neither kills `x` (since other fields of `x` may still be live) nor marks it as live.

cc @jonas-schievink, who ran into this problem.
