### PR TITLE
Use `insert_same` in `insert_evaluation_cache`

### DIFF
--- a/compiler/rustc_data_structures/src/sync.rs
+++ b/compiler/rustc_data_structures/src/sync.rs
@@ -423,8 +423,8 @@ pub fn assert_send_val<T: ?Sized + Send>(_t: &T) {}
 pub fn assert_send_sync_val<T: ?Sized + Sync + Send>(_t: &T) {}
 
 pub trait HashMapExt<K, V> {
-    /// Same as HashMap::insert, but it may panic if there's already an
-    /// entry for `key` with a value not equal to `value`
+    /// Same as [HashMap::insert], but it may panic if there's already an
+    /// entry for `key` with a value not equal to `value`.
     fn insert_same(&mut self, key: K, value: V);
 }
 

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -906,10 +906,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                     trait_ref, result,
                 );
                 // This may overwrite the cache with the same value
-                // FIXME: Due to #50507 this overwrites the different values
-                // This should be changed to use HashMapExt::insert_same
-                // when that is fixed
-                self.tcx().evaluation_cache.insert(param_env.and(trait_ref), dep_node, result);
+                self.tcx().evaluation_cache.insert_same(param_env.and(trait_ref), dep_node, result);
                 return;
             }
         }


### PR DESCRIPTION
Closes #50507.

I was trying to fix this issue, but it seems the reported crash doesn't happen anymore.