### PR TITLE
Add links to fs::DirEntry::metadata

### DIFF
--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -1429,7 +1429,10 @@ impl DirEntry {
     /// Returns the metadata for the file that this entry points at.
     ///
     /// This function will not traverse symlinks if this entry points at a
-    /// symlink.
+    /// symlink. To traverse symlinks use [`fs::metadata`] or [`fs::File::metadata`].
+    ///
+    /// [`fs::metadata`]: fn.metadata.html
+    /// [`fs::File::metadata`]: struct.File.html#method.metadata
     ///
     /// # Platform-specific behavior
     ///


### PR DESCRIPTION
`fs::DirEntry::metadata` doesn't traverse symlinks. It is not immediately clear what to do if you do want to traverse symlinks. This change adds links to the two other `metadata` functions that will follow symlinks.