### PR TITLE
Rename clashing_extern_decl to clashing_extern_declarations.

### DIFF
--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -279,9 +279,9 @@ pub mod primitive;
 // crate uses the this crate as its libcore.
 #[path = "../stdarch/crates/core_arch/src/mod.rs"]
 #[allow(missing_docs, missing_debug_implementations, dead_code, unused_imports)]
-// FIXME: This annotation should be moved into rust-lang/stdarch after clashing_extern_decl is
+// FIXME: This annotation should be moved into rust-lang/stdarch after clashing_extern_declarations is
 // merged. It currently cannot because bootstrap fails as the lint hasn't been defined yet.
-#[cfg_attr(not(bootstrap), allow(clashing_extern_decl))]
+#[cfg_attr(not(bootstrap), allow(clashing_extern_declarations))]
 #[unstable(feature = "stdsimd", issue = "48556")]
 mod core_arch;
 

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -2055,12 +2055,12 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for InvalidValue {
 }
 
 declare_lint! {
-    pub CLASHING_EXTERN_DECL,
+    pub CLASHING_EXTERN_DECLARATIONS,
     Warn,
     "detects when an extern fn has been declared with the same name but different types"
 }
 
-pub struct ClashingExternDecl {
+pub struct ClashingExternDeclarations {
     seen_decls: FxHashMap<Symbol, HirId>,
 }
 
@@ -2083,9 +2083,9 @@ impl SymbolName {
     }
 }
 
-impl ClashingExternDecl {
+impl ClashingExternDeclarations {
     crate fn new() -> Self {
-        ClashingExternDecl { seen_decls: FxHashMap::default() }
+        ClashingExternDeclarations { seen_decls: FxHashMap::default() }
     }
     /// Insert a new foreign item into the seen set. If a symbol with the same name already exists
     /// for the item, return its HirId without updating the set.
@@ -2211,18 +2211,18 @@ impl ClashingExternDecl {
     }
 }
 
-impl_lint_pass!(ClashingExternDecl => [CLASHING_EXTERN_DECL]);
+impl_lint_pass!(ClashingExternDeclarations => [CLASHING_EXTERN_DECLARATIONS]);
 
-impl<'a, 'tcx> LateLintPass<'a, 'tcx> for ClashingExternDecl {
+impl<'a, 'tcx> LateLintPass<'a, 'tcx> for ClashingExternDeclarations {
     fn check_foreign_item(&mut self, cx: &LateContext<'a, 'tcx>, this_fi: &hir::ForeignItem<'_>) {
-        trace!("ClashingExternDecl: check_foreign_item: {:?}", this_fi);
+        trace!("ClashingExternDeclarations: check_foreign_item: {:?}", this_fi);
         if let ForeignItemKind::Fn(..) = this_fi.kind {
             let tcx = *&cx.tcx;
             if let Some(existing_hid) = self.insert(tcx, this_fi) {
                 let existing_decl_ty = tcx.type_of(tcx.hir().local_def_id(existing_hid));
                 let this_decl_ty = tcx.type_of(tcx.hir().local_def_id(this_fi.hir_id));
                 debug!(
-                    "ClashingExternDecl: Comparing existing {:?}: {:?} to this {:?}: {:?}",
+                    "ClashingExternDeclarations: Comparing existing {:?}: {:?} to this {:?}: {:?}",
                     existing_hid, existing_decl_ty, this_fi.hir_id, this_decl_ty
                 );
                 // Check that the declarations match.
@@ -2239,7 +2239,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for ClashingExternDecl {
                         };
                     // Finally, emit the diagnostic.
                     tcx.struct_span_lint_hir(
-                        CLASHING_EXTERN_DECL,
+                        CLASHING_EXTERN_DECLARATIONS,
                         this_fi.hir_id,
                         get_relevant_span(this_fi),
                         |lint| {

--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -155,7 +155,7 @@ macro_rules! late_lint_passes {
                 // and change this to a module lint pass
                 MissingDebugImplementations: MissingDebugImplementations::default(),
                 ArrayIntoIter: ArrayIntoIter,
-                ClashingExternDecl: ClashingExternDecl::new(),
+                ClashingExternDeclarations: ClashingExternDeclarations::new(),
             ]
         );
     };

--- a/src/libstd/sys/unix/args.rs
+++ b/src/libstd/sys/unix/args.rs
@@ -205,7 +205,7 @@ mod imp {
         #[cfg(target_arch = "aarch64")]
         extern "C" {
             fn objc_msgSend(obj: NsId, sel: Sel) -> NsId;
-            #[cfg_attr(not(bootstrap), allow(clashing_extern_decl))]
+            #[cfg_attr(not(bootstrap), allow(clashing_extern_declarations))]
             #[link_name = "objc_msgSend"]
             fn objc_msgSend_ul(obj: NsId, sel: Sel, i: libc::c_ulong) -> NsId;
         }
@@ -213,7 +213,7 @@ mod imp {
         #[cfg(not(target_arch = "aarch64"))]
         extern "C" {
             fn objc_msgSend(obj: NsId, sel: Sel, ...) -> NsId;
-            #[cfg_attr(not(bootstrap), allow(clashing_extern_decl))]
+            #[cfg_attr(not(bootstrap), allow(clashing_extern_declarations))]
             #[link_name = "objc_msgSend"]
             fn objc_msgSend_ul(obj: NsId, sel: Sel, ...) -> NsId;
         }

--- a/src/test/ui/issues/issue-1866.rs
+++ b/src/test/ui/issues/issue-1866.rs
@@ -1,7 +1,7 @@
 // build-pass
 #![allow(dead_code)]
 #![allow(non_camel_case_types)]
-#![warn(clashing_extern_decl)]
+#![warn(clashing_extern_declarations)]
 
 // pretty-expanded FIXME #23616
 

--- a/src/test/ui/issues/issue-1866.stderr
+++ b/src/test/ui/issues/issue-1866.stderr
@@ -10,8 +10,8 @@ LL |             pub fn rust_task_is_unwinding(rt: *const rust_task) -> bool;
 note: the lint level is defined here
   --> $DIR/issue-1866.rs:4:9
    |
-LL | #![warn(clashing_extern_decl)]
-   |         ^^^^^^^^^^^^^^^^^^^^
+LL | #![warn(clashing_extern_declarations)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: expected `unsafe extern "C" fn(*const usize) -> bool`
               found `unsafe extern "C" fn(*const bool) -> bool`
 

--- a/src/test/ui/issues/issue-5791.rs
+++ b/src/test/ui/issues/issue-5791.rs
@@ -1,6 +1,6 @@
 // run-pass
 #![allow(dead_code)]
-#![warn(clashing_extern_decl)]
+#![warn(clashing_extern_declarations)]
 // pretty-expanded FIXME #23616
 
 extern {

--- a/src/test/ui/issues/issue-5791.stderr
+++ b/src/test/ui/issues/issue-5791.stderr
@@ -12,8 +12,8 @@ LL | |     fn malloc2(len: i32, foo: i32) -> *const u8;
 note: the lint level is defined here
   --> $DIR/issue-5791.rs:3:9
    |
-LL | #![warn(clashing_extern_decl)]
-   |         ^^^^^^^^^^^^^^^^^^^^
+LL | #![warn(clashing_extern_declarations)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: expected `unsafe extern "C" fn(i32) -> *const u8`
               found `unsafe extern "C" fn(i32, i32) -> *const u8`
 

--- a/src/test/ui/lint/clashing-extern-fn.rs
+++ b/src/test/ui/lint/clashing-extern-fn.rs
@@ -1,17 +1,17 @@
 // check-pass
 // aux-build:external_extern_fn.rs
 #![crate_type = "lib"]
-#![warn(clashing_extern_decl)]
+#![warn(clashing_extern_declarations)]
 
 extern crate external_extern_fn;
 
-extern {
+extern "C" {
     fn clash(x: u8);
     fn no_clash(x: u8);
 }
 
 fn redeclared_different_signature() {
-    extern {
+    extern "C" {
         fn clash(x: u64); //~ WARN `clash` redeclared with a different signature
     }
 
@@ -22,7 +22,7 @@ fn redeclared_different_signature() {
 }
 
 fn redeclared_same_signature() {
-    extern {
+    extern "C" {
         fn no_clash(x: u8);
     }
     unsafe {
@@ -30,12 +30,12 @@ fn redeclared_same_signature() {
     }
 }
 
-extern {
+extern "C" {
     fn extern_fn(x: u64);
 }
 
 fn extern_clash() {
-    extern {
+    extern "C" {
         fn extern_fn(x: u32); //~ WARN `extern_fn` redeclared with a different signature
     }
     unsafe {
@@ -49,7 +49,7 @@ fn extern_no_clash() {
         crate::extern_fn(123);
     }
 }
-extern {
+extern "C" {
     fn some_other_new_name(x: i16);
 
     #[link_name = "extern_link_name"]
@@ -60,7 +60,7 @@ extern {
 }
 
 fn link_name_clash() {
-    extern {
+    extern "C" {
         fn extern_link_name(x: u32);
         //~^ WARN `extern_link_name` redeclared with a different signature
 
@@ -75,85 +75,112 @@ fn link_name_clash() {
 }
 
 mod a {
-    extern {
+    extern "C" {
         fn different_mod(x: u8);
     }
 }
 mod b {
-    extern {
+    extern "C" {
         fn different_mod(x: u64); //~ WARN `different_mod` redeclared with a different signature
     }
 }
 
-extern {
+extern "C" {
     fn variadic_decl(x: u8, ...);
 }
 
 fn variadic_clash() {
-    extern {
+    extern "C" {
         fn variadic_decl(x: u8); //~ WARN `variadic_decl` redeclared with a different signature
     }
 }
 
 #[no_mangle]
-fn no_mangle_name(x: u8) { }
+fn no_mangle_name(x: u8) {}
 
-extern {
+extern "C" {
     #[link_name = "unique_link_name"]
     fn link_name_specified(x: u8);
 }
 
 fn tricky_no_clash() {
-    extern {
+    extern "C" {
         // Shouldn't warn, because the declaration above actually declares a different symbol (and
         // Rust's name resolution rules around shadowing will handle this gracefully).
         fn link_name_specified() -> u32;
 
         // The case of a no_mangle name colliding with an extern decl (see #28179) is related but
-        // shouldn't be reported by ClashingExternDecl, because this is an example of unmangled
-        // name clash causing bad behaviour in functions with a defined body.
+        // shouldn't be reported by ClashingExternDeclarations, because this is an example of
+        // unmangled name clash causing bad behaviour in functions with a defined body.
         fn no_mangle_name() -> u32;
     }
 }
 
 mod banana {
     mod one {
-        #[repr(C)] struct Banana { weight: u32, length: u16 }
-        extern "C" { fn weigh_banana(count: *const Banana) -> u64; }
+        #[repr(C)]
+        struct Banana {
+            weight: u32,
+            length: u16,
+        }
+        extern "C" {
+            fn weigh_banana(count: *const Banana) -> u64;
+        }
     }
 
     mod two {
-        #[repr(C)] struct Banana { weight: u32, length: u16 } // note: distinct type
-        // This should not trigger the lint because two::Banana is structurally equivalent to
-        // one::Banana.
-        extern "C" { fn weigh_banana(count: *const Banana) -> u64; }
+        #[repr(C)]
+        struct Banana {
+            weight: u32,
+            length: u16,
+        } // note: distinct type
+        extern "C" {
+          // This should not trigger the lint because two::Banana is structurally equivalent to
+          // one::Banana.
+            fn weigh_banana(count: *const Banana) -> u64;
+        }
     }
 
     mod three {
         // This _should_ trigger the lint, because repr(packed) should generate a struct that has a
         // different layout.
-        #[repr(packed)] struct Banana { weight: u32, length: u16 }
+        #[repr(packed)]
+        struct Banana {
+            weight: u32,
+            length: u16,
+        }
         #[allow(improper_ctypes)]
-        extern "C" { fn weigh_banana(count: *const Banana) -> u64; }
-        //~^ WARN `weigh_banana` redeclared with a different signature
+        extern "C" {
+            fn weigh_banana(count: *const Banana) -> u64;
+            //~^ WARN `weigh_banana` redeclared with a different signature
+        }
     }
 }
 
 mod sameish_members {
     mod a {
         #[repr(C)]
-        struct Point { x: i16, y: i16 }
+        struct Point {
+            x: i16,
+            y: i16,
+        }
 
-        extern "C" { fn draw_point(p: Point); }
+        extern "C" {
+            fn draw_point(p: Point);
+        }
     }
     mod b {
         #[repr(C)]
-        struct Point { coordinates: [i16; 2] }
+        struct Point {
+            coordinates: [i16; 2],
+        }
 
         // It's possible we are overconservative for this case, as accessing the elements of the
         // coordinates array might end up correctly accessing `.x` and `.y`. However, this may not
         // always be the case, for every architecture and situation. This is also a really odd
         // thing to do anyway.
-        extern "C" { fn draw_point(p: Point); } //~ WARN `draw_point` redeclared with a different
+        extern "C" {
+            fn draw_point(p: Point); //~ WARN `draw_point` redeclared with a different
+        }
     }
 }

--- a/src/test/ui/lint/clashing-extern-fn.stderr
+++ b/src/test/ui/lint/clashing-extern-fn.stderr
@@ -10,8 +10,8 @@ LL |         fn clash(x: u64);
 note: the lint level is defined here
   --> $DIR/clashing-extern-fn.rs:4:9
    |
-LL | #![warn(clashing_extern_decl)]
-   |         ^^^^^^^^^^^^^^^^^^^^
+LL | #![warn(clashing_extern_declarations)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: expected `unsafe extern "C" fn(u8)`
               found `unsafe extern "C" fn(u64)`
 
@@ -94,25 +94,25 @@ LL |         fn variadic_decl(x: u8);
               found `unsafe extern "C" fn(u8)`
 
 warning: `weigh_banana` redeclared with a different signature
-  --> $DIR/clashing-extern-fn.rs:137:22
+  --> $DIR/clashing-extern-fn.rs:154:13
    |
-LL |         extern "C" { fn weigh_banana(count: *const Banana) -> u64; }
-   |                      --------------------------------------------- `weigh_banana` previously declared here
+LL |             fn weigh_banana(count: *const Banana) -> u64;
+   |             --------------------------------------------- `weigh_banana` previously declared here
 ...
-LL |         extern "C" { fn weigh_banana(count: *const Banana) -> u64; }
-   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this signature doesn't match the previous declaration
+LL |             fn weigh_banana(count: *const Banana) -> u64;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this signature doesn't match the previous declaration
    |
    = note: expected `unsafe extern "C" fn(*const banana::one::Banana) -> u64`
               found `unsafe extern "C" fn(*const banana::three::Banana) -> u64`
 
 warning: `draw_point` redeclared with a different signature
-  --> $DIR/clashing-extern-fn.rs:157:22
+  --> $DIR/clashing-extern-fn.rs:183:13
    |
-LL |         extern "C" { fn draw_point(p: Point); }
-   |                      ------------------------ `draw_point` previously declared here
+LL |             fn draw_point(p: Point);
+   |             ------------------------ `draw_point` previously declared here
 ...
-LL |         extern "C" { fn draw_point(p: Point); }
-   |                      ^^^^^^^^^^^^^^^^^^^^^^^^ this signature doesn't match the previous declaration
+LL |             fn draw_point(p: Point);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^ this signature doesn't match the previous declaration
    |
    = note: expected `unsafe extern "C" fn(sameish_members::a::Point)`
               found `unsafe extern "C" fn(sameish_members::b::Point)`

--- a/src/test/ui/lint/dead-code/lint-dead-code-3.rs
+++ b/src/test/ui/lint/dead-code/lint-dead-code-3.rs
@@ -1,6 +1,6 @@
 #![allow(unused_variables)]
 #![allow(non_camel_case_types)]
-#![allow(clashing_extern_decl)]
+#![allow(clashing_extern_declarations)]
 #![deny(dead_code)]
 
 #![crate_type="lib"]

--- a/src/test/ui/parser/extern-abi-from-mac-literal-frag.rs
+++ b/src/test/ui/parser/extern-abi-from-mac-literal-frag.rs
@@ -1,4 +1,4 @@
-#![allow(clashing_extern_decl)]
+#![allow(clashing_extern_declarations)]
 // check-pass
 
 // In this test we check that the parser accepts an ABI string when it


### PR DESCRIPTION
Rename clashing_extern_decl to clashing_extern_declarations to bring in-line with lint naming conventions.

Fixes #73802.

r? @petrochenkov 