### PR TITLE
Fix wording for anonymous parameter name help

### DIFF
--- a/src/librustc_parse/parser/diagnostics.rs
+++ b/src/librustc_parse/parser/diagnostics.rs
@@ -1415,7 +1415,7 @@ impl<'a> Parser<'a> {
                 if self.token != token::Lt {
                     err.span_suggestion(
                         pat.span,
-                        "if this was a parameter name, give it a type",
+                        "if this is a parameter name, give it a type",
                         format!("{}: TypeName", ident),
                         Applicability::HasPlaceholders,
                     );

--- a/src/test/ui/anon-params/anon-params-denied-2018.stderr
+++ b/src/test/ui/anon-params/anon-params-denied-2018.stderr
@@ -9,7 +9,7 @@ help: if this is a `self` type, give it a parameter name
    |
 LL |     fn foo(self: i32);
    |            ^^^^^^^^^
-help: if this was a parameter name, give it a type
+help: if this is a parameter name, give it a type
    |
 LL |     fn foo(i32: TypeName);
    |            ^^^^^^^^^^^^^
@@ -29,7 +29,7 @@ help: if this is a `self` type, give it a parameter name
    |
 LL |     fn bar_with_default_impl(self: String, String) {}
    |                              ^^^^^^^^^^^^
-help: if this was a parameter name, give it a type
+help: if this is a parameter name, give it a type
    |
 LL |     fn bar_with_default_impl(String: TypeName, String) {}
    |                              ^^^^^^^^^^^^^^^^
@@ -45,7 +45,7 @@ LL |     fn bar_with_default_impl(String, String) {}
    |                                            ^ expected one of `:`, `@`, or `|`
    |
    = note: anonymous parameters are removed in the 2018 edition (see RFC 1685)
-help: if this was a parameter name, give it a type
+help: if this is a parameter name, give it a type
    |
 LL |     fn bar_with_default_impl(String, String: TypeName) {}
    |                                      ^^^^^^^^^^^^^^^^
@@ -61,7 +61,7 @@ LL |     fn baz(a:usize, b, c: usize) -> usize {
    |                      ^ expected one of `:`, `@`, or `|`
    |
    = note: anonymous parameters are removed in the 2018 edition (see RFC 1685)
-help: if this was a parameter name, give it a type
+help: if this is a parameter name, give it a type
    |
 LL |     fn baz(a:usize, b: TypeName, c: usize) -> usize {
    |                     ^^^^^^^^^^^

--- a/src/test/ui/parser/inverted-parameters.rs
+++ b/src/test/ui/parser/inverted-parameters.rs
@@ -20,7 +20,7 @@ fn pattern((i32, i32) (a, b)) {}
 
 fn fizz(i32) {}
 //~^ ERROR expected one of `:`, `@`
-//~| HELP if this was a parameter name, give it a type
+//~| HELP if this is a parameter name, give it a type
 //~| HELP if this is a `self` type, give it a parameter name
 //~| HELP if this is a type, explicitly ignore the parameter name
 

--- a/src/test/ui/parser/inverted-parameters.stderr
+++ b/src/test/ui/parser/inverted-parameters.stderr
@@ -39,7 +39,7 @@ help: if this is a `self` type, give it a parameter name
    |
 LL | fn fizz(self: i32) {}
    |         ^^^^^^^^^
-help: if this was a parameter name, give it a type
+help: if this is a parameter name, give it a type
    |
 LL | fn fizz(i32: TypeName) {}
    |         ^^^^^^^^^^^^^

--- a/src/test/ui/parser/omitted-arg-in-item-fn.stderr
+++ b/src/test/ui/parser/omitted-arg-in-item-fn.stderr
@@ -9,7 +9,7 @@ help: if this is a `self` type, give it a parameter name
    |
 LL | fn foo(self: x) {
    |        ^^^^^^^
-help: if this was a parameter name, give it a type
+help: if this is a parameter name, give it a type
    |
 LL | fn foo(x: TypeName) {
    |        ^^^^^^^^^^^

--- a/src/test/ui/rfc-2565-param-attrs/param-attrs-2018.stderr
+++ b/src/test/ui/rfc-2565-param-attrs/param-attrs-2018.stderr
@@ -9,7 +9,7 @@ help: if this is a `self` type, give it a parameter name
    |
 LL | trait Trait2015 { fn foo(#[allow(C)] self: i32); }
    |                                      ^^^^^^^^^
-help: if this was a parameter name, give it a type
+help: if this is a parameter name, give it a type
    |
 LL | trait Trait2015 { fn foo(#[allow(C)] i32: TypeName); }
    |                                      ^^^^^^^^^^^^^

--- a/src/test/ui/span/issue-34264.stderr
+++ b/src/test/ui/span/issue-34264.stderr
@@ -21,7 +21,7 @@ LL | fn foo(Option<i32>, String) {}
    |                           ^ expected one of `:`, `@`, or `|`
    |
    = note: anonymous parameters are removed in the 2018 edition (see RFC 1685)
-help: if this was a parameter name, give it a type
+help: if this is a parameter name, give it a type
    |
 LL | fn foo(Option<i32>, String: TypeName) {}
    |                     ^^^^^^^^^^^^^^^^
@@ -41,7 +41,7 @@ help: if this is a `self` type, give it a parameter name
    |
 LL | fn bar(self: x, y: usize) {}
    |        ^^^^^^^
-help: if this was a parameter name, give it a type
+help: if this is a parameter name, give it a type
    |
 LL | fn bar(x: TypeName, y: usize) {}
    |        ^^^^^^^^^^^


### PR DESCRIPTION
```
 --> exercises/functions/functions2.rs:8:15
  |
8 | fn call_me(num) {
  |               ^ expected one of `:`, `@`, or `|`
  |
  = note: anonymous parameters are removed in the 2018 edition (see RFC 1685)
help: if this is a `self` type, give it a parameter name
  |
8 | fn call_me(self: num) {
  |            ^^^^^^^^^
help: if this was a parameter name, give it a type
  |
8 | fn call_me(num: TypeName) {
  |            ^^^^^^^^^^^^^
help: if this is a type, explicitly ignore the parameter name
  |
8 | fn call_me(_: num) {
  |
```
This commit changes "if this was a parameter name" to "if this is a parameter name" to match the wording of similar errors.