### PR TITLE
Use &raw in A|Rc::as_ptr

### DIFF
--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -109,6 +109,7 @@
 #![feature(pattern)]
 #![feature(ptr_internals)]
 #![feature(ptr_offset_from)]
+#![feature(raw_ref_op)]
 #![feature(rustc_attrs)]
 #![feature(receiver_trait)]
 #![feature(min_specialization)]

--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -100,6 +100,7 @@
 #![feature(fundamental)]
 #![feature(internal_uninit_const)]
 #![feature(lang_items)]
+#![feature(layout_for_ptr)]
 #![feature(libc)]
 #![feature(negative_impls)]
 #![feature(new_uninit)]

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -245,7 +245,7 @@ use core::hash::{Hash, Hasher};
 use core::intrinsics::abort;
 use core::iter;
 use core::marker::{self, PhantomData, Unpin, Unsize};
-use core::mem::{self, align_of, align_of_val, forget, size_of_val};
+use core::mem::{self, align_of, align_of_val_raw, forget, size_of_val};
 use core::ops::{CoerceUnsized, Deref, DispatchFromDyn, Receiver};
 use core::pin::Pin;
 use core::ptr::{self, NonNull};
@@ -2114,7 +2114,7 @@ unsafe fn data_offset<T: ?Sized>(ptr: *const T) -> isize {
     // Because it is ?Sized, it will always be the last field in memory.
     // Note: This is a detail of the current implementation of the compiler,
     // and is not a guaranteed language detail. Do not rely on it outside of std.
-    unsafe { data_offset_align(align_of_val(&*ptr)) }
+    unsafe { data_offset_align(align_of_val_raw(ptr)) }
 }
 
 /// Computes the offset of the data field within `RcBox`.

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -2116,6 +2116,16 @@ impl<T: ?Sized> AsRef<T> for Rc<T> {
 #[stable(feature = "pin", since = "1.33.0")]
 impl<T: ?Sized> Unpin for Rc<T> {}
 
+/// Get the offset within an `ArcInner` for
+/// a payload of type described by a pointer.
+///
+/// # Safety
+///
+/// This has the same safety requirements as `align_of_val_raw`. In effect:
+///
+/// - This function is safe for any argument if `T` is sized, and
+/// - if `T` is unsized, the pointer must have appropriate pointer metadata
+///   aquired from the real instance that you are getting this offset for.
 unsafe fn data_offset<T: ?Sized>(ptr: *const T) -> isize {
     // Align the unsized value to the end of the `RcBox`.
     // Because it is ?Sized, it will always be the last field in memory.

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -592,11 +592,9 @@ impl<T: ?Sized> Rc<T> {
     pub fn as_ptr(this: &Self) -> *const T {
         let ptr: *mut RcBox<T> = NonNull::as_ptr(this.ptr);
 
-        // SAFETY: This cannot go through Deref::deref.
-        // Instead, we manually offset the pointer rather than manifesting a reference.
-        // This is so that the returned pointer retains the same provenance as our pointer.
-        // This is required so that e.g. `get_mut` can write through the pointer
-        // after the Rc is recovered through `from_raw`.
+        // SAFETY: This cannot go through Deref::deref or Rc::inner.
+        // This is required to retain raw/mut provenance such that e.g. `get_mut` can
+        // write through the pointer after the Rc is recovered through `from_raw`.
         unsafe { &raw const (*ptr).value }
     }
 

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -1705,9 +1705,9 @@ impl<T> Weak<T> {
         let ptr: *mut RcBox<T> = NonNull::as_ptr(self.ptr);
 
         // SAFETY: we must offset the pointer manually, and said pointer may be
-        // a dangling weak (usize::MAX). data_offset is safe to call, because we
-        // know a pointer to unsized T must be derived from a real unsized T,
-        // because dangling weaks are only created for sized T. wrapping_offset
+        // a dangling weak (usize::MAX) if T is sized. data_offset is safe to call,
+        // because we know that a pointer to unsized T was derived from a real
+        // unsized T, as dangling weaks are only created for sized T. wrapping_offset
         // is used so that we can use the same code path for the non-dangling
         // unsized case and the potentially dangling sized case.
         unsafe {

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -245,7 +245,7 @@ use core::hash::{Hash, Hasher};
 use core::intrinsics::abort;
 use core::iter;
 use core::marker::{self, PhantomData, Unpin, Unsize};
-use core::mem::{self, align_of, align_of_val_raw, forget, size_of_val};
+use core::mem::{self, align_of_val_raw, forget, size_of_val};
 use core::ops::{CoerceUnsized, Deref, DispatchFromDyn, Receiver};
 use core::pin::Pin;
 use core::ptr::{self, NonNull};
@@ -1704,9 +1704,18 @@ impl<T> Weak<T> {
     /// [`null`]: ../../std/ptr/fn.null.html
     #[stable(feature = "weak_into_raw", since = "1.45.0")]
     pub fn as_ptr(&self) -> *const T {
-        let offset = data_offset_sized::<T>();
-        let ptr = self.ptr.cast::<u8>().as_ptr().wrapping_offset(offset);
-        ptr as *const T
+        let ptr: *mut RcBox<T> = NonNull::as_ptr(self.ptr);
+        let fake_ptr = ptr as *mut T;
+
+        // SAFETY: we must offset the pointer manually, and said pointer may be
+        // a dangling weak (usize::MAX). data_offset is safe to call, because we
+        // know a pointer to unsized T must be derived from a real unsized T,
+        // because dangling weaks are only created for sized T. wrapping_offset
+        // is used so that we can use the same code path for dangling weak refs.
+        unsafe {
+            let offset = data_offset(&raw const (*ptr).value);
+            set_data_ptr(fake_ptr, (ptr as *mut u8).wrapping_offset(offset))
+        }
     }
 
     /// Consumes the `Weak<T>` and turns it into a raw pointer.
@@ -2115,13 +2124,6 @@ unsafe fn data_offset<T: ?Sized>(ptr: *const T) -> isize {
     // Note: This is a detail of the current implementation of the compiler,
     // and is not a guaranteed language detail. Do not rely on it outside of std.
     unsafe { data_offset_align(align_of_val_raw(ptr)) }
-}
-
-/// Computes the offset of the data field within `RcBox`.
-///
-/// Unlike [`data_offset`], this doesn't need the pointer, but it works only on `T: Sized`.
-fn data_offset_sized<T>() -> isize {
-    data_offset_align(align_of::<T>())
 }
 
 #[inline]

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -1711,7 +1711,7 @@ impl<T> Weak<T> {
         // because dangling weaks are only created for sized T. wrapping_offset
         // is used so that we can use the same code path for dangling weak refs.
         unsafe {
-            let offset = data_offset(&raw const (*ptr).value);
+            let offset = data_offset(fake_ptr);
             set_data_ptr(fake_ptr, (ptr as *mut u8).wrapping_offset(offset))
         }
     }

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -591,17 +591,13 @@ impl<T: ?Sized> Rc<T> {
     #[stable(feature = "weak_into_raw", since = "1.45.0")]
     pub fn as_ptr(this: &Self) -> *const T {
         let ptr: *mut RcBox<T> = NonNull::as_ptr(this.ptr);
-        let fake_ptr = ptr as *mut T;
 
         // SAFETY: This cannot go through Deref::deref.
         // Instead, we manually offset the pointer rather than manifesting a reference.
         // This is so that the returned pointer retains the same provenance as our pointer.
         // This is required so that e.g. `get_mut` can write through the pointer
         // after the Rc is recovered through `from_raw`.
-        unsafe {
-            let offset = data_offset(&(*ptr).value);
-            set_data_ptr(fake_ptr, (ptr as *mut u8).offset(offset))
-        }
+        unsafe { &raw const (*ptr).value }
     }
 
     /// Constructs an `Rc<T>` from a raw pointer.

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -1641,6 +1641,7 @@ pub struct Weak<T: ?Sized> {
     // `Weak::new` sets this to `usize::MAX` so that it doesn’t need
     // to allocate space on the heap.  That's not a value a real pointer
     // will ever have because RcBox has alignment at least 2.
+    // This is only possible when `T: Sized`; unsized `T` never dangle.
     ptr: NonNull<RcBox<T>>,
 }
 

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -1703,7 +1703,6 @@ impl<T> Weak<T> {
     #[stable(feature = "weak_into_raw", since = "1.45.0")]
     pub fn as_ptr(&self) -> *const T {
         let ptr: *mut RcBox<T> = NonNull::as_ptr(self.ptr);
-        let fake_ptr = ptr as *mut T;
 
         // SAFETY: we must offset the pointer manually, and said pointer may be
         // a dangling weak (usize::MAX). data_offset is safe to call, because we
@@ -1712,8 +1711,8 @@ impl<T> Weak<T> {
         // is used so that we can use the same code path for the non-dangling
         // unsized case and the potentially dangling sized case.
         unsafe {
-            let offset = data_offset(fake_ptr);
-            set_data_ptr(fake_ptr, (ptr as *mut u8).wrapping_offset(offset))
+            let offset = data_offset(ptr as *mut T);
+            set_data_ptr(ptr as *mut T, (ptr as *mut u8).wrapping_offset(offset))
         }
     }
 

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -592,8 +592,8 @@ impl<T: ?Sized> Rc<T> {
     pub fn as_ptr(this: &Self) -> *const T {
         let ptr: *mut RcBox<T> = NonNull::as_ptr(this.ptr);
 
-        // SAFETY: This cannot go through Deref::deref or Rc::inner.
-        // This is required to retain raw/mut provenance such that e.g. `get_mut` can
+        // SAFETY: This cannot go through Deref::deref or Rc::inner because
+        // this is required to retain raw/mut provenance such that e.g. `get_mut` can
         // write through the pointer after the Rc is recovered through `from_raw`.
         unsafe { &raw const (*ptr).value }
     }
@@ -1709,7 +1709,8 @@ impl<T> Weak<T> {
         // a dangling weak (usize::MAX). data_offset is safe to call, because we
         // know a pointer to unsized T must be derived from a real unsized T,
         // because dangling weaks are only created for sized T. wrapping_offset
-        // is used so that we can use the same code path for dangling weak refs.
+        // is used so that we can use the same code path for the non-dangling
+        // unsized case and the potentially dangling sized case.
         unsafe {
             let offset = data_offset(fake_ptr);
             set_data_ptr(fake_ptr, (ptr as *mut u8).wrapping_offset(offset))

--- a/src/liballoc/sync.rs
+++ b/src/liballoc/sync.rs
@@ -591,11 +591,9 @@ impl<T: ?Sized> Arc<T> {
     pub fn as_ptr(this: &Self) -> *const T {
         let ptr: *mut ArcInner<T> = NonNull::as_ptr(this.ptr);
 
-        // SAFETY: This cannot go through Deref::deref.
-        // Instead, we manually offset the pointer rather than manifesting a reference.
-        // This is so that the returned pointer retains the same provenance as our pointer.
-        // This is required so that e.g. `get_mut` can write through the pointer
-        // after the Arc is recovered through `from_raw`.
+        // SAFETY: This cannot go through Deref::deref or RcBoxPtr::inner.
+        // This is required to retain raw/mut provenance such that e.g. `get_mut` can
+        // write through the pointer after the Rc is recovered through `from_raw`.
         unsafe { &raw const (*ptr).data }
     }
 

--- a/src/liballoc/sync.rs
+++ b/src/liballoc/sync.rs
@@ -590,17 +590,13 @@ impl<T: ?Sized> Arc<T> {
     #[stable(feature = "weak_into_raw", since = "1.45.0")]
     pub fn as_ptr(this: &Self) -> *const T {
         let ptr: *mut ArcInner<T> = NonNull::as_ptr(this.ptr);
-        let fake_ptr = ptr as *mut T;
 
         // SAFETY: This cannot go through Deref::deref.
         // Instead, we manually offset the pointer rather than manifesting a reference.
         // This is so that the returned pointer retains the same provenance as our pointer.
         // This is required so that e.g. `get_mut` can write through the pointer
         // after the Arc is recovered through `from_raw`.
-        unsafe {
-            let offset = data_offset(&(*ptr).data);
-            set_data_ptr(fake_ptr, (ptr as *mut u8).offset(offset))
-        }
+        unsafe { &raw const (*ptr).data }
     }
 
     /// Constructs an `Arc<T>` from a raw pointer.

--- a/src/liballoc/sync.rs
+++ b/src/liballoc/sync.rs
@@ -1479,7 +1479,7 @@ impl<T> Weak<T> {
         // because dangling weaks are only created for sized T. wrapping_offset
         // is used so that we can use the same code path for dangling weak refs.
         unsafe {
-            let offset = data_offset(&raw const (*ptr).data);
+            let offset = data_offset(fake_ptr);
             set_data_ptr(fake_ptr, (ptr as *mut u8).wrapping_offset(offset))
         }
     }

--- a/src/liballoc/sync.rs
+++ b/src/liballoc/sync.rs
@@ -1473,9 +1473,9 @@ impl<T> Weak<T> {
         let ptr: *mut ArcInner<T> = NonNull::as_ptr(self.ptr);
 
         // SAFETY: we must offset the pointer manually, and said pointer may be
-        // a dangling weak (usize::MAX). data_offset is safe to call, because we
-        // know a pointer to unsized T must be derived from a real unsized T,
-        // because dangling weaks are only created for sized T. wrapping_offset
+        // a dangling weak (usize::MAX) if T is sized. data_offset is safe to call,
+        // because we know that a pointer to unsized T was derived from a real
+        // unsized T, as dangling weaks are only created for sized T. wrapping_offset
         // is used so that we can use the same code path for the non-dangling
         // unsized case and the potentially dangling sized case.
         unsafe {

--- a/src/liballoc/sync.rs
+++ b/src/liballoc/sync.rs
@@ -2273,7 +2273,16 @@ impl<T: ?Sized> AsRef<T> for Arc<T> {
 #[stable(feature = "pin", since = "1.33.0")]
 impl<T: ?Sized> Unpin for Arc<T> {}
 
-/// Computes the offset of the data field within `ArcInner`.
+/// Get the offset within an `ArcInner` for
+/// a payload of type described by a pointer.
+///
+/// # Safety
+///
+/// This has the same safety requirements as `align_of_val_raw`. In effect:
+///
+/// - This function is safe for any argument if `T` is sized, and
+/// - if `T` is unsized, the pointer must have appropriate pointer metadata
+///   aquired from the real instance that you are getting this offset for.
 unsafe fn data_offset<T: ?Sized>(ptr: *const T) -> isize {
     // Align the unsized value to the end of the `ArcInner`.
     // Because it is `?Sized`, it will always be the last field in memory.

--- a/src/liballoc/sync.rs
+++ b/src/liballoc/sync.rs
@@ -267,6 +267,7 @@ pub struct Weak<T: ?Sized> {
     // `Weak::new` sets this to `usize::MAX` so that it doesn’t need
     // to allocate space on the heap.  That's not a value a real pointer
     // will ever have because RcBox has alignment at least 2.
+    // This is only possible when `T: Sized`; unsized `T` never dangle.
     ptr: NonNull<ArcInner<T>>,
 }
 

--- a/src/liballoc/sync.rs
+++ b/src/liballoc/sync.rs
@@ -1471,7 +1471,6 @@ impl<T> Weak<T> {
     #[stable(feature = "weak_into_raw", since = "1.45.0")]
     pub fn as_ptr(&self) -> *const T {
         let ptr: *mut ArcInner<T> = NonNull::as_ptr(self.ptr);
-        let fake_ptr = ptr as *mut T;
 
         // SAFETY: we must offset the pointer manually, and said pointer may be
         // a dangling weak (usize::MAX). data_offset is safe to call, because we
@@ -1480,8 +1479,8 @@ impl<T> Weak<T> {
         // is used so that we can use the same code path for the non-dangling
         // unsized case and the potentially dangling sized case.
         unsafe {
-            let offset = data_offset(fake_ptr);
-            set_data_ptr(fake_ptr, (ptr as *mut u8).wrapping_offset(offset))
+            let offset = data_offset(ptr as *mut T);
+            set_data_ptr(ptr as *mut T, (ptr as *mut u8).wrapping_offset(offset))
         }
     }
 

--- a/src/liballoc/sync.rs
+++ b/src/liballoc/sync.rs
@@ -591,8 +591,8 @@ impl<T: ?Sized> Arc<T> {
     pub fn as_ptr(this: &Self) -> *const T {
         let ptr: *mut ArcInner<T> = NonNull::as_ptr(this.ptr);
 
-        // SAFETY: This cannot go through Deref::deref or RcBoxPtr::inner.
-        // This is required to retain raw/mut provenance such that e.g. `get_mut` can
+        // SAFETY: This cannot go through Deref::deref or RcBoxPtr::inner because
+        // this is required to retain raw/mut provenance such that e.g. `get_mut` can
         // write through the pointer after the Rc is recovered through `from_raw`.
         unsafe { &raw const (*ptr).data }
     }
@@ -1477,7 +1477,8 @@ impl<T> Weak<T> {
         // a dangling weak (usize::MAX). data_offset is safe to call, because we
         // know a pointer to unsized T must be derived from a real unsized T,
         // because dangling weaks are only created for sized T. wrapping_offset
-        // is used so that we can use the same code path for dangling weak refs.
+        // is used so that we can use the same code path for the non-dangling
+        // unsized case and the potentially dangling sized case.
         unsafe {
             let offset = data_offset(fake_ptr);
             set_data_ptr(fake_ptr, (ptr as *mut u8).wrapping_offset(offset))


### PR DESCRIPTION
This PR uses `&raw` for offsetting `*mut [A]RcInner<T> -> *mut T`.

Additionally, this updates the implementation of `Weak::as_ptr` to support unsized `T`, though it does not yet relax the bounds of `Weak::as_ptr`/`into_raw`/`from_raw` to accept unsized `T`.