### PR TITLE
Edit cursor.prev() method docs in lexer

### DIFF
--- a/src/librustc_lexer/src/cursor.rs
+++ b/src/librustc_lexer/src/cursor.rs
@@ -23,8 +23,8 @@ impl<'a> Cursor<'a> {
         }
     }
 
-    /// For debug assertions only
-    /// Returns the last eaten symbol (or '\0' in release builds).
+    /// Returns the last eaten symbol (or `'\0'` in release builds).
+    /// (For debug assertions only.)
     pub(crate) fn prev(&self) -> char {
         #[cfg(debug_assertions)]
         {


### PR DESCRIPTION
Fix missing punctuation