### PR TITLE
Fix markdown rendering in librustc_lexer docs

### DIFF
--- a/src/librustc_lexer/src/lib.rs
+++ b/src/librustc_lexer/src/lib.rs
@@ -51,8 +51,9 @@ pub enum TokenKind {
     // Multi-char tokens:
     /// "// comment"
     LineComment,
-    /// "/* block comment */"
-    /// Block comments can be recursive, so the sequence like "/* /* */"
+    /// `/* block comment */`
+    ///
+    /// Block comments can be recursive, so the sequence like `/* /* */`
     /// will not be considered terminated and will result in a parsing error.
     BlockComment { terminated: bool },
     /// Any whitespace characters sequence.


### PR DESCRIPTION
Use back-ticks instead of quotation marks in docs for the block comment variant of TokenKind.

## [Before](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_lexer/enum.TokenKind.html#variant.BlockComment) and after

<img width="1103" alt="Screen Shot 2020-06-28 at 1 22 30 PM" src="https://user-images.githubusercontent.com/19642016/85957562-446a8380-b943-11ea-913a-442cf7744083.png">

<img width="1015" alt="Screen Shot 2020-06-28 at 1 28 29 PM" src="https://user-images.githubusercontent.com/19642016/85957566-4af8fb00-b943-11ea-8fef-a09c1d586772.png">

## Question

For visual consistency, should we use back-ticks throughout the docs for these enum variants?