### PR TITLE
rustdoc: insert newlines between attributes

### DIFF
--- a/src/test/rustdoc/attributes.rs
+++ b/src/test/rustdoc/attributes.rs
@@ -8,8 +8,8 @@ pub extern "C" fn f() {}
 #[export_name = "bar"]
 pub extern "C" fn g() {}
 
-// @has foo/enum.Foo.html '//*[@class="docblock attributes top-attr"]' '#[repr(i64)]'
-// @has foo/enum.Foo.html '//*[@class="docblock attributes top-attr"]' '#[must_use]'
+// @matches foo/enum.Foo.html '//*[@class="docblock attributes top-attr"]' \
+//      '(?m)\A#\[repr\(i64\)\]\n#\[must_use\]\Z'
 #[repr(i64)]
 #[must_use]
 pub enum Foo {


### PR DESCRIPTION
Fixes #73205.