### PR TITLE
Rewrite the `Visitor` for `non_ssa_locals`

### DIFF
--- a/src/librustc_codegen_ssa/mir/analyze.rs
+++ b/src/librustc_codegen_ssa/mir/analyze.rs
@@ -383,9 +383,6 @@ fn ty_requires_alloca<'a, 'tcx>(
     fx: &FunctionCx<'a, 'tcx, impl BuilderMethods<'a, 'tcx>>,
     ty: TyAndLayout<'tcx>,
 ) -> bool {
-    // Currently, this returns `true` for ADTs that are otherwise small enough to qualify. For
-    // example, `struct Newtype(i32)`. This way, every type has a single way to extract data
-    // (gep, extractvalue, etc.).
     !fx.cx.is_backend_immediate(ty) && !fx.cx.is_backend_scalar_pair(ty)
 }
 

--- a/src/librustc_codegen_ssa/mir/analyze.rs
+++ b/src/librustc_codegen_ssa/mir/analyze.rs
@@ -12,7 +12,7 @@ use rustc_middle::mir::visit::{
 };
 use rustc_middle::mir::{self, Location, TerminatorKind};
 use rustc_middle::ty;
-use rustc_middle::ty::layout::HasTyCtxt;
+use rustc_middle::ty::layout::{HasTyCtxt, TyAndLayout};
 use rustc_target::abi::LayoutOf;
 
 pub fn non_ssa_locals<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
@@ -27,18 +27,8 @@ pub fn non_ssa_locals<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
         let ty = fx.monomorphize(&decl.ty);
         debug!("local {:?} has type `{}`", local, ty);
         let layout = fx.cx.spanned_layout_of(ty, decl.source_info.span);
-        if fx.cx.is_backend_immediate(layout) {
-            // These sorts of types are immediates that we can store
-            // in an Value without an alloca.
-        } else if fx.cx.is_backend_scalar_pair(layout) {
-            // We allow pairs and uses of any of their 2 fields.
-        } else {
-            // These sorts of types require an alloca. Note that
-            // is_llvm_immediate() may *still* be true, particularly
-            // for newtypes, but we currently force some types
-            // (e.g., structs) into an alloca unconditionally, just so
-            // that we don't have to deal with having two pathways
-            // (gep vs extractvalue etc).
+
+        if ty_requires_alloca(&analyzer.fx, layout) {
             analyzer.not_ssa(local);
         }
     }
@@ -132,7 +122,7 @@ impl<Bx: BuilderMethods<'a, 'tcx>> LocalAnalyzer<'mir, 'a, 'tcx, Bx> {
 
                 if let mir::ProjectionElem::Field(..) = elem {
                     let layout = cx.spanned_layout_of(base_ty.ty, span);
-                    if cx.is_backend_immediate(layout) || cx.is_backend_scalar_pair(layout) {
+                    if self.ty_requires_alloca(layout) {
                         // Recurse with the same context, instead of `Projection`,
                         // potentially stopping at non-operand projections,
                         // which would trigger `not_ssa` on locals.
@@ -445,4 +435,15 @@ pub fn cleanup_kinds(mir: &mir::Body<'_>) -> IndexVec<mir::BasicBlock, CleanupKi
     propagate(&mut result, mir);
     debug!("cleanup_kinds: result={:?}", result);
     result
+}
+
+/// Returns `true` if locals of this type need to be allocated on the stack.
+fn ty_requires_alloca<'a, 'tcx>(
+    fx: &FunctionCx<'a, 'tcx, impl BuilderMethods<'a, 'tcx>>,
+    ty: TyAndLayout<'tcx>,
+) -> bool {
+    // Currently, this returns `true` for ADTs that are otherwise small enough to qualify. For
+    // example, `struct Newtype(i32)`. This way, every type has a single way to extract data
+    // (gep, extractvalue, etc.).
+    !fx.cx.is_backend_immediate(ty) && !fx.cx.is_backend_scalar_pair(ty)
 }

--- a/src/librustc_codegen_ssa/mir/analyze.rs
+++ b/src/librustc_codegen_ssa/mir/analyze.rs
@@ -69,10 +69,6 @@ impl<Bx: BuilderMethods<'a, 'tcx>> LocalAnalyzer<'mir, 'a, 'tcx, Bx> {
         analyzer
     }
 
-    fn first_assignment(&self, local: mir::Local) -> Option<Location> {
-        self.first_assignment[local]
-    }
-
     fn not_ssa(&mut self, local: mir::Local) {
         debug!("marking {:?} as non-SSA", local);
         self.non_ssa_locals.insert(local);
@@ -220,7 +216,7 @@ impl<'mir, 'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> Visitor<'tcx>
                 // optimizations) require locals to be in (uninitialized) memory.
                 // N.B., there can be uninitialized reads of a local visited after
                 // an assignment to that local, if they happen on disjoint paths.
-                let ssa_read = match self.first_assignment(local) {
+                let ssa_read = match self.first_assignment[local] {
                     Some(assignment_location) => {
                         assignment_location.dominates(location, &self.dominators)
                     }

--- a/src/librustc_codegen_ssa/mir/analyze.rs
+++ b/src/librustc_codegen_ssa/mir/analyze.rs
@@ -5,7 +5,7 @@ use super::FunctionCx;
 use crate::traits::*;
 use rustc_data_structures::graph::dominators::Dominators;
 use rustc_index::bit_set::BitSet;
-use rustc_index::vec::{Idx, IndexVec};
+use rustc_index::vec::IndexVec;
 use rustc_middle::mir::traversal;
 use rustc_middle::mir::visit::{
     MutatingUseContext, NonMutatingUseContext, NonUseContext, PlaceContext, Visitor,
@@ -40,37 +40,31 @@ struct LocalAnalyzer<'mir, 'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> {
     fx: &'mir FunctionCx<'a, 'tcx, Bx>,
     dominators: Dominators<mir::BasicBlock>,
     non_ssa_locals: BitSet<mir::Local>,
-    // The location of the first visited direct assignment to each
-    // local, or an invalid location (out of bounds `block` index).
-    first_assignment: IndexVec<mir::Local, Location>,
+
+    /// The location of the first visited direct assignment to each local.
+    first_assignment: IndexVec<mir::Local, Option<Location>>,
 }
 
 impl<Bx: BuilderMethods<'a, 'tcx>> LocalAnalyzer<'mir, 'a, 'tcx, Bx> {
     fn new(fx: &'mir FunctionCx<'a, 'tcx, Bx>) -> Self {
-        let invalid_location = mir::BasicBlock::new(fx.mir.basic_blocks().len()).start_location();
         let dominators = fx.mir.dominators();
         let mut analyzer = LocalAnalyzer {
             fx,
             dominators,
             non_ssa_locals: BitSet::new_empty(fx.mir.local_decls.len()),
-            first_assignment: IndexVec::from_elem(invalid_location, &fx.mir.local_decls),
+            first_assignment: IndexVec::from_elem(None, &fx.mir.local_decls),
         };
 
         // Arguments get assigned to by means of the function being called
         for arg in fx.mir.args_iter() {
-            analyzer.first_assignment[arg] = mir::START_BLOCK.start_location();
+            analyzer.assign(arg, mir::START_BLOCK.start_location());
         }
 
         analyzer
     }
 
     fn first_assignment(&self, local: mir::Local) -> Option<Location> {
-        let location = self.first_assignment[local];
-        if location.block.index() < self.fx.mir.basic_blocks().len() {
-            Some(location)
-        } else {
-            None
-        }
+        self.first_assignment[local]
     }
 
     fn not_ssa(&mut self, local: mir::Local) {
@@ -79,10 +73,10 @@ impl<Bx: BuilderMethods<'a, 'tcx>> LocalAnalyzer<'mir, 'a, 'tcx, Bx> {
     }
 
     fn assign(&mut self, local: mir::Local, location: Location) {
-        if self.first_assignment(local).is_some() {
+        if self.first_assignment[local].is_some() {
             self.not_ssa(local);
         } else {
-            self.first_assignment[local] = location;
+            self.first_assignment[local] = Some(location);
         }
     }
 


### PR DESCRIPTION
Resolves #72931. Seems like we're not going to do #73732 anytime soon, so might as well clean this up while it's fresh in my head. This tries to implement what I perceived as the intent of the old code, since there were several bugs which I mention in #72931. Also, we  now only look for ZSTs in the final type of the `mir::Place`, not in all the types of its projections besides the base local. I couldn't see a good reason for the old behavior.