### PR TITLE
Make more primitive integer methods const

### DIFF
--- a/src/libcore/char/methods.rs
+++ b/src/libcore/char/methods.rs
@@ -1225,8 +1225,7 @@ impl char {
     /// assert!(!esc.is_ascii_alphabetic());
     /// ```
     #[stable(feature = "ascii_ctype_on_intrinsics", since = "1.24.0")]
-    #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.46.0")]
-    #[cfg_attr(bootstrap, allow_internal_unstable(const_if_match))]
+    #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.47.0")]
     #[inline]
     pub const fn is_ascii_alphabetic(&self) -> bool {
         match *self {
@@ -1262,8 +1261,7 @@ impl char {
     /// assert!(!esc.is_ascii_uppercase());
     /// ```
     #[stable(feature = "ascii_ctype_on_intrinsics", since = "1.24.0")]
-    #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.46.0")]
-    #[cfg_attr(bootstrap, allow_internal_unstable(const_if_match))]
+    #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.47.0")]
     #[inline]
     pub const fn is_ascii_uppercase(&self) -> bool {
         match *self {
@@ -1299,8 +1297,7 @@ impl char {
     /// assert!(!esc.is_ascii_lowercase());
     /// ```
     #[stable(feature = "ascii_ctype_on_intrinsics", since = "1.24.0")]
-    #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.46.0")]
-    #[cfg_attr(bootstrap, allow_internal_unstable(const_if_match))]
+    #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.47.0")]
     #[inline]
     pub const fn is_ascii_lowercase(&self) -> bool {
         match *self {
@@ -1339,8 +1336,7 @@ impl char {
     /// assert!(!esc.is_ascii_alphanumeric());
     /// ```
     #[stable(feature = "ascii_ctype_on_intrinsics", since = "1.24.0")]
-    #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.46.0")]
-    #[cfg_attr(bootstrap, allow_internal_unstable(const_if_match))]
+    #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.47.0")]
     #[inline]
     pub const fn is_ascii_alphanumeric(&self) -> bool {
         match *self {
@@ -1376,8 +1372,7 @@ impl char {
     /// assert!(!esc.is_ascii_digit());
     /// ```
     #[stable(feature = "ascii_ctype_on_intrinsics", since = "1.24.0")]
-    #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.46.0")]
-    #[cfg_attr(bootstrap, allow_internal_unstable(const_if_match))]
+    #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.47.0")]
     #[inline]
     pub const fn is_ascii_digit(&self) -> bool {
         match *self {
@@ -1416,8 +1411,7 @@ impl char {
     /// assert!(!esc.is_ascii_hexdigit());
     /// ```
     #[stable(feature = "ascii_ctype_on_intrinsics", since = "1.24.0")]
-    #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.46.0")]
-    #[cfg_attr(bootstrap, allow_internal_unstable(const_if_match))]
+    #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.47.0")]
     #[inline]
     pub const fn is_ascii_hexdigit(&self) -> bool {
         match *self {
@@ -1457,8 +1451,7 @@ impl char {
     /// assert!(!esc.is_ascii_punctuation());
     /// ```
     #[stable(feature = "ascii_ctype_on_intrinsics", since = "1.24.0")]
-    #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.46.0")]
-    #[cfg_attr(bootstrap, allow_internal_unstable(const_if_match))]
+    #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.47.0")]
     #[inline]
     pub const fn is_ascii_punctuation(&self) -> bool {
         match *self {
@@ -1494,8 +1487,7 @@ impl char {
     /// assert!(!esc.is_ascii_graphic());
     /// ```
     #[stable(feature = "ascii_ctype_on_intrinsics", since = "1.24.0")]
-    #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.46.0")]
-    #[cfg_attr(bootstrap, allow_internal_unstable(const_if_match))]
+    #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.47.0")]
     #[inline]
     pub const fn is_ascii_graphic(&self) -> bool {
         match *self {
@@ -1548,8 +1540,7 @@ impl char {
     /// assert!(!esc.is_ascii_whitespace());
     /// ```
     #[stable(feature = "ascii_ctype_on_intrinsics", since = "1.24.0")]
-    #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.46.0")]
-    #[cfg_attr(bootstrap, allow_internal_unstable(const_if_match))]
+    #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.47.0")]
     #[inline]
     pub const fn is_ascii_whitespace(&self) -> bool {
         match *self {
@@ -1587,8 +1578,7 @@ impl char {
     /// assert!(esc.is_ascii_control());
     /// ```
     #[stable(feature = "ascii_ctype_on_intrinsics", since = "1.24.0")]
-    #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.46.0")]
-    #[cfg_attr(bootstrap, allow_internal_unstable(const_if_match))]
+    #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.47.0")]
     #[inline]
     pub const fn is_ascii_control(&self) -> bool {
         match *self {

--- a/src/libcore/char/methods.rs
+++ b/src/libcore/char/methods.rs
@@ -1225,7 +1225,8 @@ impl char {
     /// assert!(!esc.is_ascii_alphabetic());
     /// ```
     #[stable(feature = "ascii_ctype_on_intrinsics", since = "1.24.0")]
-    #[rustc_const_unstable(feature = "const_ascii_ctype_on_intrinsics", issue = "68983")]
+    #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.46.0")]
+    #[cfg_attr(bootstrap, allow_internal_unstable(const_if_match))]
     #[inline]
     pub const fn is_ascii_alphabetic(&self) -> bool {
         match *self {
@@ -1261,7 +1262,8 @@ impl char {
     /// assert!(!esc.is_ascii_uppercase());
     /// ```
     #[stable(feature = "ascii_ctype_on_intrinsics", since = "1.24.0")]
-    #[rustc_const_unstable(feature = "const_ascii_ctype_on_intrinsics", issue = "68983")]
+    #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.46.0")]
+    #[cfg_attr(bootstrap, allow_internal_unstable(const_if_match))]
     #[inline]
     pub const fn is_ascii_uppercase(&self) -> bool {
         match *self {
@@ -1297,7 +1299,8 @@ impl char {
     /// assert!(!esc.is_ascii_lowercase());
     /// ```
     #[stable(feature = "ascii_ctype_on_intrinsics", since = "1.24.0")]
-    #[rustc_const_unstable(feature = "const_ascii_ctype_on_intrinsics", issue = "68983")]
+    #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.46.0")]
+    #[cfg_attr(bootstrap, allow_internal_unstable(const_if_match))]
     #[inline]
     pub const fn is_ascii_lowercase(&self) -> bool {
         match *self {
@@ -1336,7 +1339,8 @@ impl char {
     /// assert!(!esc.is_ascii_alphanumeric());
     /// ```
     #[stable(feature = "ascii_ctype_on_intrinsics", since = "1.24.0")]
-    #[rustc_const_unstable(feature = "const_ascii_ctype_on_intrinsics", issue = "68983")]
+    #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.46.0")]
+    #[cfg_attr(bootstrap, allow_internal_unstable(const_if_match))]
     #[inline]
     pub const fn is_ascii_alphanumeric(&self) -> bool {
         match *self {
@@ -1372,7 +1376,8 @@ impl char {
     /// assert!(!esc.is_ascii_digit());
     /// ```
     #[stable(feature = "ascii_ctype_on_intrinsics", since = "1.24.0")]
-    #[rustc_const_unstable(feature = "const_ascii_ctype_on_intrinsics", issue = "68983")]
+    #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.46.0")]
+    #[cfg_attr(bootstrap, allow_internal_unstable(const_if_match))]
     #[inline]
     pub const fn is_ascii_digit(&self) -> bool {
         match *self {
@@ -1411,7 +1416,8 @@ impl char {
     /// assert!(!esc.is_ascii_hexdigit());
     /// ```
     #[stable(feature = "ascii_ctype_on_intrinsics", since = "1.24.0")]
-    #[rustc_const_unstable(feature = "const_ascii_ctype_on_intrinsics", issue = "68983")]
+    #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.46.0")]
+    #[cfg_attr(bootstrap, allow_internal_unstable(const_if_match))]
     #[inline]
     pub const fn is_ascii_hexdigit(&self) -> bool {
         match *self {
@@ -1451,7 +1457,8 @@ impl char {
     /// assert!(!esc.is_ascii_punctuation());
     /// ```
     #[stable(feature = "ascii_ctype_on_intrinsics", since = "1.24.0")]
-    #[rustc_const_unstable(feature = "const_ascii_ctype_on_intrinsics", issue = "68983")]
+    #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.46.0")]
+    #[cfg_attr(bootstrap, allow_internal_unstable(const_if_match))]
     #[inline]
     pub const fn is_ascii_punctuation(&self) -> bool {
         match *self {
@@ -1487,7 +1494,8 @@ impl char {
     /// assert!(!esc.is_ascii_graphic());
     /// ```
     #[stable(feature = "ascii_ctype_on_intrinsics", since = "1.24.0")]
-    #[rustc_const_unstable(feature = "const_ascii_ctype_on_intrinsics", issue = "68983")]
+    #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.46.0")]
+    #[cfg_attr(bootstrap, allow_internal_unstable(const_if_match))]
     #[inline]
     pub const fn is_ascii_graphic(&self) -> bool {
         match *self {
@@ -1540,7 +1548,8 @@ impl char {
     /// assert!(!esc.is_ascii_whitespace());
     /// ```
     #[stable(feature = "ascii_ctype_on_intrinsics", since = "1.24.0")]
-    #[rustc_const_unstable(feature = "const_ascii_ctype_on_intrinsics", issue = "68983")]
+    #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.46.0")]
+    #[cfg_attr(bootstrap, allow_internal_unstable(const_if_match))]
     #[inline]
     pub const fn is_ascii_whitespace(&self) -> bool {
         match *self {
@@ -1578,7 +1587,8 @@ impl char {
     /// assert!(esc.is_ascii_control());
     /// ```
     #[stable(feature = "ascii_ctype_on_intrinsics", since = "1.24.0")]
-    #[rustc_const_unstable(feature = "const_ascii_ctype_on_intrinsics", issue = "68983")]
+    #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.46.0")]
+    #[cfg_attr(bootstrap, allow_internal_unstable(const_if_match))]
     #[inline]
     pub const fn is_ascii_control(&self) -> bool {
         match *self {

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -78,7 +78,6 @@
 #![feature(const_checked_int_methods)]
 #![feature(const_euclidean_int_methods)]
 #![feature(const_overflowing_int_methods)]
-#![feature(const_saturating_int_methods)]
 #![feature(const_int_unchecked_arith)]
 #![feature(const_int_pow)]
 #![feature(constctlz)]

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -70,7 +70,6 @@
 #![feature(bound_cloned)]
 #![feature(cfg_target_has_atomic)]
 #![feature(concat_idents)]
-#![feature(const_ascii_ctype_on_intrinsics)]
 #![feature(const_alloc_layout)]
 #![feature(const_discriminant)]
 #![cfg_attr(bootstrap, feature(const_if_match))]

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -79,8 +79,7 @@ assert_eq!(size_of::<Option<core::num::", stringify!($Ty), ">>(), size_of::<", s
 
                 /// Creates a non-zero if the given value is not zero.
                 #[$stability]
-                #[rustc_const_stable(feature = "const_nonzero_int_methods", since = "1.46.0")]
-                #[cfg_attr(bootstrap, allow_internal_unstable(const_if_match))]
+                #[rustc_const_stable(feature = "const_nonzero_int_methods", since = "1.47.0")]
                 #[inline]
                 pub const fn new(n: $Int) -> Option<Self> {
                     if n != 0 {
@@ -740,10 +739,9 @@ assert_eq!((", stringify!($SelfT), "::MAX - 2).checked_add(3), None);",
 $EndFeature, "
 ```"),
             #[stable(feature = "rust1", since = "1.0.0")]
-            #[rustc_const_stable(feature = "const_checked_int_methods", since = "1.46.0")]
+            #[rustc_const_stable(feature = "const_checked_int_methods", since = "1.47.0")]
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
-            #[cfg_attr(bootstrap, allow_internal_unstable(const_if_match))]
             #[inline]
             pub const fn checked_add(self, rhs: Self) -> Option<Self> {
                 let (a, b) = self.overflowing_add(rhs);
@@ -783,10 +781,9 @@ assert_eq!((", stringify!($SelfT), "::MIN + 2).checked_sub(3), None);",
 $EndFeature, "
 ```"),
             #[stable(feature = "rust1", since = "1.0.0")]
-            #[rustc_const_stable(feature = "const_checked_int_methods", since = "1.46.0")]
+            #[rustc_const_stable(feature = "const_checked_int_methods", since = "1.47.0")]
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
-            #[cfg_attr(bootstrap, allow_internal_unstable(const_if_match))]
             #[inline]
             pub const fn checked_sub(self, rhs: Self) -> Option<Self> {
                 let (a, b) = self.overflowing_sub(rhs);
@@ -826,10 +823,9 @@ assert_eq!(", stringify!($SelfT), "::MAX.checked_mul(2), None);",
 $EndFeature, "
 ```"),
             #[stable(feature = "rust1", since = "1.0.0")]
-            #[rustc_const_stable(feature = "const_checked_int_methods", since = "1.46.0")]
+            #[rustc_const_stable(feature = "const_checked_int_methods", since = "1.47.0")]
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
-            #[cfg_attr(bootstrap, allow_internal_unstable(const_if_match))]
             #[inline]
             pub const fn checked_mul(self, rhs: Self) -> Option<Self> {
                 let (a, b) = self.overflowing_mul(rhs);
@@ -983,8 +979,7 @@ assert_eq!(", stringify!($SelfT), "::MIN.checked_neg(), None);",
 $EndFeature, "
 ```"),
             #[stable(feature = "wrapping", since = "1.7.0")]
-            #[rustc_const_stable(feature = "const_checked_int_methods", since = "1.46.0")]
-            #[cfg_attr(bootstrap, allow_internal_unstable(const_if_match))]
+            #[rustc_const_stable(feature = "const_checked_int_methods", since = "1.47.0")]
             #[inline]
             pub const fn checked_neg(self) -> Option<Self> {
                 let (a, b) = self.overflowing_neg();
@@ -1006,10 +1001,9 @@ assert_eq!(0x1", stringify!($SelfT), ".checked_shl(129), None);",
 $EndFeature, "
 ```"),
             #[stable(feature = "wrapping", since = "1.7.0")]
-            #[rustc_const_stable(feature = "const_checked_int_methods", since = "1.46.0")]
+            #[rustc_const_stable(feature = "const_checked_int_methods", since = "1.47.0")]
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
-            #[cfg_attr(bootstrap, allow_internal_unstable(const_if_match))]
             #[inline]
             pub const fn checked_shl(self, rhs: u32) -> Option<Self> {
                 let (a, b) = self.overflowing_shl(rhs);
@@ -1031,10 +1025,9 @@ assert_eq!(0x10", stringify!($SelfT), ".checked_shr(128), None);",
 $EndFeature, "
 ```"),
             #[stable(feature = "wrapping", since = "1.7.0")]
-            #[rustc_const_stable(feature = "const_checked_int_methods", since = "1.46.0")]
+            #[rustc_const_stable(feature = "const_checked_int_methods", since = "1.47.0")]
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
-            #[cfg_attr(bootstrap, allow_internal_unstable(const_if_match))]
             #[inline]
             pub const fn checked_shr(self, rhs: u32) -> Option<Self> {
                 let (a, b) = self.overflowing_shr(rhs);
@@ -1057,8 +1050,7 @@ assert_eq!(", stringify!($SelfT), "::MIN.checked_abs(), None);",
 $EndFeature, "
 ```"),
             #[stable(feature = "no_panic_abs", since = "1.13.0")]
-            #[rustc_const_stable(feature = "const_checked_int_methods", since = "1.46.0")]
-            #[cfg_attr(bootstrap, allow_internal_unstable(const_if_match))]
+            #[rustc_const_stable(feature = "const_checked_int_methods", since = "1.47.0")]
             #[inline]
             pub const fn checked_abs(self) -> Option<Self> {
                 if self.is_negative() {
@@ -1129,7 +1121,7 @@ $EndFeature, "
 ```"),
 
             #[stable(feature = "rust1", since = "1.0.0")]
-            #[rustc_const_stable(feature = "const_saturating_int_methods", since = "1.46.0")]
+            #[rustc_const_stable(feature = "const_saturating_int_methods", since = "1.47.0")]
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
             #[inline]
@@ -1155,7 +1147,7 @@ assert_eq!(", stringify!($SelfT), "::MAX.saturating_sub(-1), ", stringify!($Self
 $EndFeature, "
 ```"),
             #[stable(feature = "rust1", since = "1.0.0")]
-            #[rustc_const_stable(feature = "const_saturating_int_methods", since = "1.46.0")]
+            #[rustc_const_stable(feature = "const_saturating_int_methods", since = "1.47.0")]
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
             #[inline]
@@ -1183,7 +1175,7 @@ $EndFeature, "
 ```"),
 
             #[stable(feature = "saturating_neg", since = "1.45.0")]
-            #[rustc_const_stable(feature = "const_saturating_int_methods", since = "1.46.0")]
+            #[rustc_const_stable(feature = "const_saturating_int_methods", since = "1.47.0")]
             #[inline]
             pub const fn saturating_neg(self) -> Self {
                 intrinsics::saturating_sub(0, self)
@@ -1209,8 +1201,7 @@ $EndFeature, "
 ```"),
 
             #[stable(feature = "saturating_neg", since = "1.45.0")]
-            #[rustc_const_stable(feature = "const_saturating_int_methods", since = "1.46.0")]
-            #[cfg_attr(bootstrap, allow_internal_unstable(const_if_match))]
+            #[rustc_const_stable(feature = "const_saturating_int_methods", since = "1.47.0")]
             #[inline]
             pub const fn saturating_abs(self) -> Self {
                 if self.is_negative() {
@@ -1237,10 +1228,9 @@ assert_eq!(", stringify!($SelfT), "::MIN.saturating_mul(10), ", stringify!($Self
 $EndFeature, "
 ```"),
             #[stable(feature = "wrapping", since = "1.7.0")]
-            #[rustc_const_stable(feature = "const_saturating_int_methods", since = "1.46.0")]
+            #[rustc_const_stable(feature = "const_saturating_int_methods", since = "1.47.0")]
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
-            #[cfg_attr(bootstrap, allow_internal_unstable(const_if_match))]
             #[inline]
             pub const fn saturating_mul(self, rhs: Self) -> Self {
                 match self.checked_mul(rhs) {
@@ -2203,8 +2193,7 @@ assert_eq!((-10", stringify!($SelfT), ").signum(), -1);",
 $EndFeature, "
 ```"),
             #[stable(feature = "rust1", since = "1.0.0")]
-            #[rustc_const_stable(feature = "const_int_sign", since = "1.46.0")]
-            #[cfg_attr(bootstrap, allow_internal_unstable(const_if_match))]
+            #[rustc_const_stable(feature = "const_int_sign", since = "1.47.0")]
             #[inline]
             pub const fn signum(self) -> Self {
                 match self {
@@ -2986,10 +2975,9 @@ Basic usage:
 assert_eq!((", stringify!($SelfT), "::MAX - 2).checked_add(3), None);", $EndFeature, "
 ```"),
             #[stable(feature = "rust1", since = "1.0.0")]
-            #[rustc_const_stable(feature = "const_checked_int_methods", since = "1.46.0")]
+            #[rustc_const_stable(feature = "const_checked_int_methods", since = "1.47.0")]
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
-            #[cfg_attr(bootstrap, allow_internal_unstable(const_if_match))]
             #[inline]
             pub const fn checked_add(self, rhs: Self) -> Option<Self> {
                 let (a, b) = self.overflowing_add(rhs);
@@ -3027,10 +3015,9 @@ Basic usage:
 assert_eq!(0", stringify!($SelfT), ".checked_sub(1), None);", $EndFeature, "
 ```"),
             #[stable(feature = "rust1", since = "1.0.0")]
-            #[rustc_const_stable(feature = "const_checked_int_methods", since = "1.46.0")]
+            #[rustc_const_stable(feature = "const_checked_int_methods", since = "1.47.0")]
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
-            #[cfg_attr(bootstrap, allow_internal_unstable(const_if_match))]
             #[inline]
             pub const fn checked_sub(self, rhs: Self) -> Option<Self> {
                 let (a, b) = self.overflowing_sub(rhs);
@@ -3068,10 +3055,9 @@ Basic usage:
 assert_eq!(", stringify!($SelfT), "::MAX.checked_mul(2), None);", $EndFeature, "
 ```"),
             #[stable(feature = "rust1", since = "1.0.0")]
-            #[rustc_const_stable(feature = "const_checked_int_methods", since = "1.46.0")]
+            #[rustc_const_stable(feature = "const_checked_int_methods", since = "1.47.0")]
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
-            #[cfg_attr(bootstrap, allow_internal_unstable(const_if_match))]
             #[inline]
             pub const fn checked_mul(self, rhs: Self) -> Option<Self> {
                 let (a, b) = self.overflowing_mul(rhs);
@@ -3219,8 +3205,7 @@ Basic usage:
 assert_eq!(1", stringify!($SelfT), ".checked_neg(), None);", $EndFeature, "
 ```"),
             #[stable(feature = "wrapping", since = "1.7.0")]
-            #[rustc_const_stable(feature = "const_checked_int_methods", since = "1.46.0")]
-            #[cfg_attr(bootstrap, allow_internal_unstable(const_if_match))]
+            #[rustc_const_stable(feature = "const_checked_int_methods", since = "1.47.0")]
             #[inline]
             pub const fn checked_neg(self) -> Option<Self> {
                 let (a, b) = self.overflowing_neg();
@@ -3241,10 +3226,9 @@ Basic usage:
 assert_eq!(0x10", stringify!($SelfT), ".checked_shl(129), None);", $EndFeature, "
 ```"),
             #[stable(feature = "wrapping", since = "1.7.0")]
-            #[rustc_const_stable(feature = "const_checked_int_methods", since = "1.46.0")]
+            #[rustc_const_stable(feature = "const_checked_int_methods", since = "1.47.0")]
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
-            #[cfg_attr(bootstrap, allow_internal_unstable(const_if_match))]
             #[inline]
             pub const fn checked_shl(self, rhs: u32) -> Option<Self> {
                 let (a, b) = self.overflowing_shl(rhs);
@@ -3265,10 +3249,9 @@ Basic usage:
 assert_eq!(0x10", stringify!($SelfT), ".checked_shr(129), None);", $EndFeature, "
 ```"),
             #[stable(feature = "wrapping", since = "1.7.0")]
-            #[rustc_const_stable(feature = "const_checked_int_methods", since = "1.46.0")]
+            #[rustc_const_stable(feature = "const_checked_int_methods", since = "1.47.0")]
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
-            #[cfg_attr(bootstrap, allow_internal_unstable(const_if_match))]
             #[inline]
             pub const fn checked_shr(self, rhs: u32) -> Option<Self> {
                 let (a, b) = self.overflowing_shr(rhs);
@@ -3333,7 +3316,7 @@ $EndFeature, "
             #[stable(feature = "rust1", since = "1.0.0")]
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
-            #[rustc_const_stable(feature = "const_saturating_int_methods", since = "1.46.0")]
+            #[rustc_const_stable(feature = "const_saturating_int_methods", since = "1.47.0")]
             #[inline]
             pub const fn saturating_add(self, rhs: Self) -> Self {
                 intrinsics::saturating_add(self, rhs)
@@ -3355,7 +3338,7 @@ assert_eq!(13", stringify!($SelfT), ".saturating_sub(127), 0);", $EndFeature, "
             #[stable(feature = "rust1", since = "1.0.0")]
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
-            #[rustc_const_stable(feature = "const_saturating_int_methods", since = "1.46.0")]
+            #[rustc_const_stable(feature = "const_saturating_int_methods", since = "1.47.0")]
             #[inline]
             pub const fn saturating_sub(self, rhs: Self) -> Self {
                 intrinsics::saturating_sub(self, rhs)
@@ -3377,10 +3360,9 @@ assert_eq!((", stringify!($SelfT), "::MAX).saturating_mul(10), ", stringify!($Se
 "::MAX);", $EndFeature, "
 ```"),
             #[stable(feature = "wrapping", since = "1.7.0")]
-            #[rustc_const_stable(feature = "const_saturating_int_methods", since = "1.46.0")]
+            #[rustc_const_stable(feature = "const_saturating_int_methods", since = "1.47.0")]
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
-            #[cfg_attr(bootstrap, allow_internal_unstable(const_if_match))]
             #[inline]
             pub const fn saturating_mul(self, rhs: Self) -> Self {
                 match self.checked_mul(rhs) {
@@ -4671,8 +4653,7 @@ impl u8 {
     /// assert!(!esc.is_ascii_alphabetic());
     /// ```
     #[stable(feature = "ascii_ctype_on_intrinsics", since = "1.24.0")]
-    #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.46.0")]
-    #[cfg_attr(bootstrap, allow_internal_unstable(const_if_match))]
+    #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.47.0")]
     #[inline]
     pub const fn is_ascii_alphabetic(&self) -> bool {
         matches!(*self, b'A'..=b'Z' | b'a'..=b'z')
@@ -4705,8 +4686,7 @@ impl u8 {
     /// assert!(!esc.is_ascii_uppercase());
     /// ```
     #[stable(feature = "ascii_ctype_on_intrinsics", since = "1.24.0")]
-    #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.46.0")]
-    #[cfg_attr(bootstrap, allow_internal_unstable(const_if_match))]
+    #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.47.0")]
     #[inline]
     pub const fn is_ascii_uppercase(&self) -> bool {
         matches!(*self, b'A'..=b'Z')
@@ -4739,8 +4719,7 @@ impl u8 {
     /// assert!(!esc.is_ascii_lowercase());
     /// ```
     #[stable(feature = "ascii_ctype_on_intrinsics", since = "1.24.0")]
-    #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.46.0")]
-    #[cfg_attr(bootstrap, allow_internal_unstable(const_if_match))]
+    #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.47.0")]
     #[inline]
     pub const fn is_ascii_lowercase(&self) -> bool {
         matches!(*self, b'a'..=b'z')
@@ -4776,8 +4755,7 @@ impl u8 {
     /// assert!(!esc.is_ascii_alphanumeric());
     /// ```
     #[stable(feature = "ascii_ctype_on_intrinsics", since = "1.24.0")]
-    #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.46.0")]
-    #[cfg_attr(bootstrap, allow_internal_unstable(const_if_match))]
+    #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.47.0")]
     #[inline]
     pub const fn is_ascii_alphanumeric(&self) -> bool {
         matches!(*self, b'0'..=b'9' | b'A'..=b'Z' | b'a'..=b'z')
@@ -4810,8 +4788,7 @@ impl u8 {
     /// assert!(!esc.is_ascii_digit());
     /// ```
     #[stable(feature = "ascii_ctype_on_intrinsics", since = "1.24.0")]
-    #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.46.0")]
-    #[cfg_attr(bootstrap, allow_internal_unstable(const_if_match))]
+    #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.47.0")]
     #[inline]
     pub const fn is_ascii_digit(&self) -> bool {
         matches!(*self, b'0'..=b'9')
@@ -4847,8 +4824,7 @@ impl u8 {
     /// assert!(!esc.is_ascii_hexdigit());
     /// ```
     #[stable(feature = "ascii_ctype_on_intrinsics", since = "1.24.0")]
-    #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.46.0")]
-    #[cfg_attr(bootstrap, allow_internal_unstable(const_if_match))]
+    #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.47.0")]
     #[inline]
     pub const fn is_ascii_hexdigit(&self) -> bool {
         matches!(*self, b'0'..=b'9' | b'A'..=b'F' | b'a'..=b'f')
@@ -4885,8 +4861,7 @@ impl u8 {
     /// assert!(!esc.is_ascii_punctuation());
     /// ```
     #[stable(feature = "ascii_ctype_on_intrinsics", since = "1.24.0")]
-    #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.46.0")]
-    #[cfg_attr(bootstrap, allow_internal_unstable(const_if_match))]
+    #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.47.0")]
     #[inline]
     pub const fn is_ascii_punctuation(&self) -> bool {
         matches!(*self, b'!'..=b'/' | b':'..=b'@' | b'['..=b'`' | b'{'..=b'~')
@@ -4919,8 +4894,7 @@ impl u8 {
     /// assert!(!esc.is_ascii_graphic());
     /// ```
     #[stable(feature = "ascii_ctype_on_intrinsics", since = "1.24.0")]
-    #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.46.0")]
-    #[cfg_attr(bootstrap, allow_internal_unstable(const_if_match))]
+    #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.47.0")]
     #[inline]
     pub const fn is_ascii_graphic(&self) -> bool {
         matches!(*self, b'!'..=b'~')
@@ -4970,8 +4944,7 @@ impl u8 {
     /// assert!(!esc.is_ascii_whitespace());
     /// ```
     #[stable(feature = "ascii_ctype_on_intrinsics", since = "1.24.0")]
-    #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.46.0")]
-    #[cfg_attr(bootstrap, allow_internal_unstable(const_if_match))]
+    #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.47.0")]
     #[inline]
     pub const fn is_ascii_whitespace(&self) -> bool {
         matches!(*self, b'\t' | b'\n' | b'\x0C' | b'\r' | b' ')
@@ -5006,8 +4979,7 @@ impl u8 {
     /// assert!(esc.is_ascii_control());
     /// ```
     #[stable(feature = "ascii_ctype_on_intrinsics", since = "1.24.0")]
-    #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.46.0")]
-    #[cfg_attr(bootstrap, allow_internal_unstable(const_if_match))]
+    #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.47.0")]
     #[inline]
     pub const fn is_ascii_control(&self) -> bool {
         matches!(*self, b'\0'..=b'\x1F' | b'\x7F')

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -4671,7 +4671,8 @@ impl u8 {
     /// assert!(!esc.is_ascii_alphabetic());
     /// ```
     #[stable(feature = "ascii_ctype_on_intrinsics", since = "1.24.0")]
-    #[rustc_const_unstable(feature = "const_ascii_ctype_on_intrinsics", issue = "68983")]
+    #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.46.0")]
+    #[cfg_attr(bootstrap, allow_internal_unstable(const_if_match))]
     #[inline]
     pub const fn is_ascii_alphabetic(&self) -> bool {
         matches!(*self, b'A'..=b'Z' | b'a'..=b'z')
@@ -4704,7 +4705,8 @@ impl u8 {
     /// assert!(!esc.is_ascii_uppercase());
     /// ```
     #[stable(feature = "ascii_ctype_on_intrinsics", since = "1.24.0")]
-    #[rustc_const_unstable(feature = "const_ascii_ctype_on_intrinsics", issue = "68983")]
+    #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.46.0")]
+    #[cfg_attr(bootstrap, allow_internal_unstable(const_if_match))]
     #[inline]
     pub const fn is_ascii_uppercase(&self) -> bool {
         matches!(*self, b'A'..=b'Z')
@@ -4737,7 +4739,8 @@ impl u8 {
     /// assert!(!esc.is_ascii_lowercase());
     /// ```
     #[stable(feature = "ascii_ctype_on_intrinsics", since = "1.24.0")]
-    #[rustc_const_unstable(feature = "const_ascii_ctype_on_intrinsics", issue = "68983")]
+    #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.46.0")]
+    #[cfg_attr(bootstrap, allow_internal_unstable(const_if_match))]
     #[inline]
     pub const fn is_ascii_lowercase(&self) -> bool {
         matches!(*self, b'a'..=b'z')
@@ -4773,7 +4776,8 @@ impl u8 {
     /// assert!(!esc.is_ascii_alphanumeric());
     /// ```
     #[stable(feature = "ascii_ctype_on_intrinsics", since = "1.24.0")]
-    #[rustc_const_unstable(feature = "const_ascii_ctype_on_intrinsics", issue = "68983")]
+    #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.46.0")]
+    #[cfg_attr(bootstrap, allow_internal_unstable(const_if_match))]
     #[inline]
     pub const fn is_ascii_alphanumeric(&self) -> bool {
         matches!(*self, b'0'..=b'9' | b'A'..=b'Z' | b'a'..=b'z')
@@ -4806,7 +4810,8 @@ impl u8 {
     /// assert!(!esc.is_ascii_digit());
     /// ```
     #[stable(feature = "ascii_ctype_on_intrinsics", since = "1.24.0")]
-    #[rustc_const_unstable(feature = "const_ascii_ctype_on_intrinsics", issue = "68983")]
+    #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.46.0")]
+    #[cfg_attr(bootstrap, allow_internal_unstable(const_if_match))]
     #[inline]
     pub const fn is_ascii_digit(&self) -> bool {
         matches!(*self, b'0'..=b'9')
@@ -4842,7 +4847,8 @@ impl u8 {
     /// assert!(!esc.is_ascii_hexdigit());
     /// ```
     #[stable(feature = "ascii_ctype_on_intrinsics", since = "1.24.0")]
-    #[rustc_const_unstable(feature = "const_ascii_ctype_on_intrinsics", issue = "68983")]
+    #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.46.0")]
+    #[cfg_attr(bootstrap, allow_internal_unstable(const_if_match))]
     #[inline]
     pub const fn is_ascii_hexdigit(&self) -> bool {
         matches!(*self, b'0'..=b'9' | b'A'..=b'F' | b'a'..=b'f')
@@ -4879,7 +4885,8 @@ impl u8 {
     /// assert!(!esc.is_ascii_punctuation());
     /// ```
     #[stable(feature = "ascii_ctype_on_intrinsics", since = "1.24.0")]
-    #[rustc_const_unstable(feature = "const_ascii_ctype_on_intrinsics", issue = "68983")]
+    #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.46.0")]
+    #[cfg_attr(bootstrap, allow_internal_unstable(const_if_match))]
     #[inline]
     pub const fn is_ascii_punctuation(&self) -> bool {
         matches!(*self, b'!'..=b'/' | b':'..=b'@' | b'['..=b'`' | b'{'..=b'~')
@@ -4912,7 +4919,8 @@ impl u8 {
     /// assert!(!esc.is_ascii_graphic());
     /// ```
     #[stable(feature = "ascii_ctype_on_intrinsics", since = "1.24.0")]
-    #[rustc_const_unstable(feature = "const_ascii_ctype_on_intrinsics", issue = "68983")]
+    #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.46.0")]
+    #[cfg_attr(bootstrap, allow_internal_unstable(const_if_match))]
     #[inline]
     pub const fn is_ascii_graphic(&self) -> bool {
         matches!(*self, b'!'..=b'~')
@@ -4962,7 +4970,8 @@ impl u8 {
     /// assert!(!esc.is_ascii_whitespace());
     /// ```
     #[stable(feature = "ascii_ctype_on_intrinsics", since = "1.24.0")]
-    #[rustc_const_unstable(feature = "const_ascii_ctype_on_intrinsics", issue = "68983")]
+    #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.46.0")]
+    #[cfg_attr(bootstrap, allow_internal_unstable(const_if_match))]
     #[inline]
     pub const fn is_ascii_whitespace(&self) -> bool {
         matches!(*self, b'\t' | b'\n' | b'\x0C' | b'\r' | b' ')
@@ -4997,7 +5006,8 @@ impl u8 {
     /// assert!(esc.is_ascii_control());
     /// ```
     #[stable(feature = "ascii_ctype_on_intrinsics", since = "1.24.0")]
-    #[rustc_const_unstable(feature = "const_ascii_ctype_on_intrinsics", issue = "68983")]
+    #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.46.0")]
+    #[cfg_attr(bootstrap, allow_internal_unstable(const_if_match))]
     #[inline]
     pub const fn is_ascii_control(&self) -> bool {
         matches!(*self, b'\0'..=b'\x1F' | b'\x7F')

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -740,9 +740,10 @@ assert_eq!((", stringify!($SelfT), "::MAX - 2).checked_add(3), None);",
 $EndFeature, "
 ```"),
             #[stable(feature = "rust1", since = "1.0.0")]
-            #[rustc_const_unstable(feature = "const_checked_int_methods", issue = "53718")]
+            #[rustc_const_stable(feature = "const_checked_int_methods", since = "1.46.0")]
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
+            #[cfg_attr(bootstrap, allow_internal_unstable(const_if_match))]
             #[inline]
             pub const fn checked_add(self, rhs: Self) -> Option<Self> {
                 let (a, b) = self.overflowing_add(rhs);
@@ -782,9 +783,10 @@ assert_eq!((", stringify!($SelfT), "::MIN + 2).checked_sub(3), None);",
 $EndFeature, "
 ```"),
             #[stable(feature = "rust1", since = "1.0.0")]
-            #[rustc_const_unstable(feature = "const_checked_int_methods", issue = "53718")]
+            #[rustc_const_stable(feature = "const_checked_int_methods", since = "1.46.0")]
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
+            #[cfg_attr(bootstrap, allow_internal_unstable(const_if_match))]
             #[inline]
             pub const fn checked_sub(self, rhs: Self) -> Option<Self> {
                 let (a, b) = self.overflowing_sub(rhs);
@@ -824,9 +826,10 @@ assert_eq!(", stringify!($SelfT), "::MAX.checked_mul(2), None);",
 $EndFeature, "
 ```"),
             #[stable(feature = "rust1", since = "1.0.0")]
-            #[rustc_const_unstable(feature = "const_checked_int_methods", issue = "53718")]
+            #[rustc_const_stable(feature = "const_checked_int_methods", since = "1.46.0")]
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
+            #[cfg_attr(bootstrap, allow_internal_unstable(const_if_match))]
             #[inline]
             pub const fn checked_mul(self, rhs: Self) -> Option<Self> {
                 let (a, b) = self.overflowing_mul(rhs);
@@ -980,7 +983,8 @@ assert_eq!(", stringify!($SelfT), "::MIN.checked_neg(), None);",
 $EndFeature, "
 ```"),
             #[stable(feature = "wrapping", since = "1.7.0")]
-            #[rustc_const_unstable(feature = "const_checked_int_methods", issue = "53718")]
+            #[rustc_const_stable(feature = "const_checked_int_methods", since = "1.46.0")]
+            #[cfg_attr(bootstrap, allow_internal_unstable(const_if_match))]
             #[inline]
             pub const fn checked_neg(self) -> Option<Self> {
                 let (a, b) = self.overflowing_neg();
@@ -1002,9 +1006,10 @@ assert_eq!(0x1", stringify!($SelfT), ".checked_shl(129), None);",
 $EndFeature, "
 ```"),
             #[stable(feature = "wrapping", since = "1.7.0")]
-            #[rustc_const_unstable(feature = "const_checked_int_methods", issue = "53718")]
+            #[rustc_const_stable(feature = "const_checked_int_methods", since = "1.46.0")]
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
+            #[cfg_attr(bootstrap, allow_internal_unstable(const_if_match))]
             #[inline]
             pub const fn checked_shl(self, rhs: u32) -> Option<Self> {
                 let (a, b) = self.overflowing_shl(rhs);
@@ -1026,9 +1031,10 @@ assert_eq!(0x10", stringify!($SelfT), ".checked_shr(128), None);",
 $EndFeature, "
 ```"),
             #[stable(feature = "wrapping", since = "1.7.0")]
-            #[rustc_const_unstable(feature = "const_checked_int_methods", issue = "53718")]
+            #[rustc_const_stable(feature = "const_checked_int_methods", since = "1.46.0")]
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
+            #[cfg_attr(bootstrap, allow_internal_unstable(const_if_match))]
             #[inline]
             pub const fn checked_shr(self, rhs: u32) -> Option<Self> {
                 let (a, b) = self.overflowing_shr(rhs);
@@ -1051,7 +1057,8 @@ assert_eq!(", stringify!($SelfT), "::MIN.checked_abs(), None);",
 $EndFeature, "
 ```"),
             #[stable(feature = "no_panic_abs", since = "1.13.0")]
-            #[rustc_const_unstable(feature = "const_checked_int_methods", issue = "53718")]
+            #[rustc_const_stable(feature = "const_checked_int_methods", since = "1.46.0")]
+            #[cfg_attr(bootstrap, allow_internal_unstable(const_if_match))]
             #[inline]
             pub const fn checked_abs(self) -> Option<Self> {
                 if self.is_negative() {
@@ -2976,9 +2983,10 @@ Basic usage:
 assert_eq!((", stringify!($SelfT), "::MAX - 2).checked_add(3), None);", $EndFeature, "
 ```"),
             #[stable(feature = "rust1", since = "1.0.0")]
-            #[rustc_const_unstable(feature = "const_checked_int_methods", issue = "53718")]
+            #[rustc_const_stable(feature = "const_checked_int_methods", since = "1.46.0")]
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
+            #[cfg_attr(bootstrap, allow_internal_unstable(const_if_match))]
             #[inline]
             pub const fn checked_add(self, rhs: Self) -> Option<Self> {
                 let (a, b) = self.overflowing_add(rhs);
@@ -3016,9 +3024,10 @@ Basic usage:
 assert_eq!(0", stringify!($SelfT), ".checked_sub(1), None);", $EndFeature, "
 ```"),
             #[stable(feature = "rust1", since = "1.0.0")]
-            #[rustc_const_unstable(feature = "const_checked_int_methods", issue = "53718")]
+            #[rustc_const_stable(feature = "const_checked_int_methods", since = "1.46.0")]
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
+            #[cfg_attr(bootstrap, allow_internal_unstable(const_if_match))]
             #[inline]
             pub const fn checked_sub(self, rhs: Self) -> Option<Self> {
                 let (a, b) = self.overflowing_sub(rhs);
@@ -3056,9 +3065,10 @@ Basic usage:
 assert_eq!(", stringify!($SelfT), "::MAX.checked_mul(2), None);", $EndFeature, "
 ```"),
             #[stable(feature = "rust1", since = "1.0.0")]
-            #[rustc_const_unstable(feature = "const_checked_int_methods", issue = "53718")]
+            #[rustc_const_stable(feature = "const_checked_int_methods", since = "1.46.0")]
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
+            #[cfg_attr(bootstrap, allow_internal_unstable(const_if_match))]
             #[inline]
             pub const fn checked_mul(self, rhs: Self) -> Option<Self> {
                 let (a, b) = self.overflowing_mul(rhs);
@@ -3206,7 +3216,8 @@ Basic usage:
 assert_eq!(1", stringify!($SelfT), ".checked_neg(), None);", $EndFeature, "
 ```"),
             #[stable(feature = "wrapping", since = "1.7.0")]
-            #[rustc_const_unstable(feature = "const_checked_int_methods", issue = "53718")]
+            #[rustc_const_stable(feature = "const_checked_int_methods", since = "1.46.0")]
+            #[cfg_attr(bootstrap, allow_internal_unstable(const_if_match))]
             #[inline]
             pub const fn checked_neg(self) -> Option<Self> {
                 let (a, b) = self.overflowing_neg();
@@ -3227,9 +3238,10 @@ Basic usage:
 assert_eq!(0x10", stringify!($SelfT), ".checked_shl(129), None);", $EndFeature, "
 ```"),
             #[stable(feature = "wrapping", since = "1.7.0")]
-            #[rustc_const_unstable(feature = "const_checked_int_methods", issue = "53718")]
+            #[rustc_const_stable(feature = "const_checked_int_methods", since = "1.46.0")]
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
+            #[cfg_attr(bootstrap, allow_internal_unstable(const_if_match))]
             #[inline]
             pub const fn checked_shl(self, rhs: u32) -> Option<Self> {
                 let (a, b) = self.overflowing_shl(rhs);
@@ -3250,9 +3262,10 @@ Basic usage:
 assert_eq!(0x10", stringify!($SelfT), ".checked_shr(129), None);", $EndFeature, "
 ```"),
             #[stable(feature = "wrapping", since = "1.7.0")]
-            #[rustc_const_unstable(feature = "const_checked_int_methods", issue = "53718")]
+            #[rustc_const_stable(feature = "const_checked_int_methods", since = "1.46.0")]
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
+            #[cfg_attr(bootstrap, allow_internal_unstable(const_if_match))]
             #[inline]
             pub const fn checked_shr(self, rhs: u32) -> Option<Self> {
                 let (a, b) = self.overflowing_shr(rhs);

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -79,7 +79,8 @@ assert_eq!(size_of::<Option<core::num::", stringify!($Ty), ">>(), size_of::<", s
 
                 /// Creates a non-zero if the given value is not zero.
                 #[$stability]
-                #[rustc_const_unstable(feature = "const_nonzero_int_methods", issue = "53718")]
+                #[rustc_const_stable(feature = "const_nonzero_int_methods", since = "1.46.0")]
+                #[cfg_attr(bootstrap, allow_internal_unstable(const_if_match))]
                 #[inline]
                 pub const fn new(n: $Int) -> Option<Self> {
                     if n != 0 {

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -2203,7 +2203,8 @@ assert_eq!((-10", stringify!($SelfT), ").signum(), -1);",
 $EndFeature, "
 ```"),
             #[stable(feature = "rust1", since = "1.0.0")]
-            #[rustc_const_unstable(feature = "const_int_sign", issue = "53718")]
+            #[rustc_const_stable(feature = "const_int_sign", since = "1.46.0")]
+            #[cfg_attr(bootstrap, allow_internal_unstable(const_if_match))]
             #[inline]
             pub const fn signum(self) -> Self {
                 match self {

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -1129,7 +1129,7 @@ $EndFeature, "
 ```"),
 
             #[stable(feature = "rust1", since = "1.0.0")]
-            #[rustc_const_unstable(feature = "const_saturating_int_methods", issue = "53718")]
+            #[rustc_const_stable(feature = "const_saturating_int_methods", since = "1.46.0")]
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
             #[inline]
@@ -1155,7 +1155,7 @@ assert_eq!(", stringify!($SelfT), "::MAX.saturating_sub(-1), ", stringify!($Self
 $EndFeature, "
 ```"),
             #[stable(feature = "rust1", since = "1.0.0")]
-            #[rustc_const_unstable(feature = "const_saturating_int_methods", issue = "53718")]
+            #[rustc_const_stable(feature = "const_saturating_int_methods", since = "1.46.0")]
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
             #[inline]
@@ -1183,7 +1183,7 @@ $EndFeature, "
 ```"),
 
             #[stable(feature = "saturating_neg", since = "1.45.0")]
-            #[rustc_const_unstable(feature = "const_saturating_int_methods", issue = "53718")]
+            #[rustc_const_stable(feature = "const_saturating_int_methods", since = "1.46.0")]
             #[inline]
             pub const fn saturating_neg(self) -> Self {
                 intrinsics::saturating_sub(0, self)
@@ -1209,7 +1209,8 @@ $EndFeature, "
 ```"),
 
             #[stable(feature = "saturating_neg", since = "1.45.0")]
-            #[rustc_const_unstable(feature = "const_saturating_int_methods", issue = "53718")]
+            #[rustc_const_stable(feature = "const_saturating_int_methods", since = "1.46.0")]
+            #[cfg_attr(bootstrap, allow_internal_unstable(const_if_match))]
             #[inline]
             pub const fn saturating_abs(self) -> Self {
                 if self.is_negative() {
@@ -1236,9 +1237,10 @@ assert_eq!(", stringify!($SelfT), "::MIN.saturating_mul(10), ", stringify!($Self
 $EndFeature, "
 ```"),
             #[stable(feature = "wrapping", since = "1.7.0")]
-            #[rustc_const_unstable(feature = "const_saturating_int_methods", issue = "53718")]
+            #[rustc_const_stable(feature = "const_saturating_int_methods", since = "1.46.0")]
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
+            #[cfg_attr(bootstrap, allow_internal_unstable(const_if_match))]
             #[inline]
             pub const fn saturating_mul(self, rhs: Self) -> Self {
                 match self.checked_mul(rhs) {
@@ -3330,7 +3332,7 @@ $EndFeature, "
             #[stable(feature = "rust1", since = "1.0.0")]
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
-            #[rustc_const_unstable(feature = "const_saturating_int_methods", issue = "53718")]
+            #[rustc_const_stable(feature = "const_saturating_int_methods", since = "1.46.0")]
             #[inline]
             pub const fn saturating_add(self, rhs: Self) -> Self {
                 intrinsics::saturating_add(self, rhs)
@@ -3352,7 +3354,7 @@ assert_eq!(13", stringify!($SelfT), ".saturating_sub(127), 0);", $EndFeature, "
             #[stable(feature = "rust1", since = "1.0.0")]
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
-            #[rustc_const_unstable(feature = "const_saturating_int_methods", issue = "53718")]
+            #[rustc_const_stable(feature = "const_saturating_int_methods", since = "1.46.0")]
             #[inline]
             pub const fn saturating_sub(self, rhs: Self) -> Self {
                 intrinsics::saturating_sub(self, rhs)
@@ -3374,9 +3376,10 @@ assert_eq!((", stringify!($SelfT), "::MAX).saturating_mul(10), ", stringify!($Se
 "::MAX);", $EndFeature, "
 ```"),
             #[stable(feature = "wrapping", since = "1.7.0")]
-            #[rustc_const_unstable(feature = "const_saturating_int_methods", issue = "53718")]
+            #[rustc_const_stable(feature = "const_saturating_int_methods", since = "1.46.0")]
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
+            #[cfg_attr(bootstrap, allow_internal_unstable(const_if_match))]
             #[inline]
             pub const fn saturating_mul(self, rhs: Self) -> Self {
                 match self.checked_mul(rhs) {

--- a/src/test/ui/consts/ascii_ctype.rs
+++ b/src/test/ui/consts/ascii_ctype.rs
@@ -1,7 +1,5 @@
 // run-pass
 
-#![feature(const_ascii_ctype_on_intrinsics)]
-
 macro_rules! suite {
     ( $( $fn:ident => [$a:ident, $A:ident, $nine:ident, $dot:ident, $space:ident]; )* ) => {
         $(

--- a/src/test/ui/consts/const-int-arithmetic.rs
+++ b/src/test/ui/consts/const-int-arithmetic.rs
@@ -3,7 +3,6 @@
 #![feature(const_checked_int_methods)]
 #![feature(const_euclidean_int_methods)]
 #![feature(const_overflowing_int_methods)]
-#![feature(const_saturating_int_methods)]
 #![feature(const_wrapping_int_methods)]
 
 use std::{i8, i128};

--- a/src/test/ui/consts/const-int-saturating-arith.rs
+++ b/src/test/ui/consts/const-int-saturating-arith.rs
@@ -1,5 +1,4 @@
 // run-pass
-#![feature(const_saturating_int_methods)]
 
 const INT_U32_NO: u32 = (42 as u32).saturating_add(2);
 const INT_U32: u32 = u32::MAX.saturating_add(1);

--- a/src/test/ui/consts/const-int-sign-rpass.rs
+++ b/src/test/ui/consts/const-int-sign-rpass.rs
@@ -1,7 +1,5 @@
 // run-pass
 
-#![feature(const_int_sign)]
-
 const NEGATIVE_A: bool = (-10i32).is_negative();
 const NEGATIVE_B: bool = 10i32.is_negative();
 const POSITIVE_A: bool = (-10i32).is_positive();

--- a/src/test/ui/consts/const-nonzero.rs
+++ b/src/test/ui/consts/const-nonzero.rs
@@ -1,7 +1,5 @@
 // run-pass
 
-#![feature(const_nonzero_int_methods)]
-
 use std::num::NonZeroU8;
 
 const X: NonZeroU8 = unsafe { NonZeroU8::new_unchecked(5) };


### PR DESCRIPTION
Now that #72437 has been merged and `const_if_match` is stable, these methods can be stabilized const. The methods are grouped in commits according to feature names:

* `const_nonzero_int_methods`
    - `NonZero*::new`
* some `const_checked_int_methods`
    - `{i*,u*}::checked_add`
    - `{i*,u*}::checked_sub`
    - `{i*,u*}::checked_mul`
    - `{i*,u*}::checked_neg`
    - `{i*,u*}::checked_shl`
    - `{i*,u*}::checked_shr`
    - `i*::checked_abs`
* `const_saturating_int_methods`
    - `{i*,u*}::saturating_add`
    - `{i*,u*}::saturating_sub`
    - `{i*,u*}::saturating_mul`
    - `i*::saturating_neg`
    - `i*::saturating_abs`
* `const_int_sign`
    - `i*::signum`
* `const_ascii_ctype_on_intrinsics`
    - `{char,u8}::is_ascii_alphabetic`
    - `{char,u8}::is_ascii_uppercase`
    - `{char,u8}::is_ascii_lowercase`
    - `{char,u8}::is_ascii_alphanumeric`
    - `{char,u8}::is_ascii_digit`
    - `{char,u8}::is_ascii_hexdigit`
    - `{char,u8}::is_ascii_punctuation`
    - `{char,u8}::is_ascii_graphic`
    - `{char,u8}::is_ascii_whitespace`
    - `{char,u8}::is_ascii_control`
