### PR TITLE
Advertise correct stable version for const control flow

### DIFF
--- a/src/librustc_feature/accepted.rs
+++ b/src/librustc_feature/accepted.rs
@@ -262,9 +262,9 @@ declare_features! (
     /// Allows using subslice patterns, `[a, .., b]` and `[a, xs @ .., b]`.
     (accepted, slice_patterns, "1.42.0", Some(62254), None),
     /// Allows the use of `if` and `match` in constants.
-    (accepted, const_if_match, "1.45.0", Some(49146), None),
+    (accepted, const_if_match, "1.46.0", Some(49146), None),
     /// Allows the use of `loop` and `while` in constants.
-    (accepted, const_loop, "1.45.0", Some(52000), None),
+    (accepted, const_loop, "1.46.0", Some(52000), None),
     /// Allows `#[track_caller]` to be used which provides
     /// accurate caller location reporting during panic (RFC 2091).
     (accepted, track_caller, "1.46.0", Some(47809), None),


### PR DESCRIPTION
#72437 was opened before the 1.45 release but merged afterwards. These will be stable in 1.46.