### PR TITLE
Fix try_print_visible_def_path for Rust 2018

### DIFF
--- a/src/librustc_middle/ty/print/pretty.rs
+++ b/src/librustc_middle/ty/print/pretty.rs
@@ -282,26 +282,27 @@ pub trait PrettyPrinter<'tcx>:
             //    where there is no explicit `extern crate`, we just prepend
             //    the crate name.
             match self.tcx().extern_crate(def_id) {
-                Some(&ExternCrate {
-                    src: ExternCrateSource::Extern(def_id),
-                    dependency_of: LOCAL_CRATE,
-                    span,
-                    ..
-                }) => {
-                    debug!("try_print_visible_def_path: def_id={:?}", def_id);
-                    return Ok((
-                        if !span.is_dummy() {
-                            self.print_def_path(def_id, &[])?
-                        } else {
-                            self.path_crate(cnum)?
-                        },
-                        true,
-                    ));
-                }
+                Some(&ExternCrate { src, dependency_of, span, .. }) => match (src, dependency_of) {
+                    (ExternCrateSource::Extern(def_id), LOCAL_CRATE) => {
+                        debug!("try_print_visible_def_path: def_id={:?}", def_id);
+                        return Ok((
+                            if !span.is_dummy() {
+                                self.print_def_path(def_id, &[])?
+                            } else {
+                                self.path_crate(cnum)?
+                            },
+                            true,
+                        ));
+                    }
+                    (ExternCrateSource::Path, LOCAL_CRATE) if self.tcx().sess.rust_2018() => {
+                        debug!("try_print_visible_def_path: def_id={:?}", def_id);
+                        return Ok((self.path_crate(cnum)?, true));
+                    }
+                    _ => {}
+                },
                 None => {
                     return Ok((self.path_crate(cnum)?, true));
                 }
-                _ => {}
             }
         }
 

--- a/src/librustc_middle/ty/print/pretty.rs
+++ b/src/librustc_middle/ty/print/pretty.rs
@@ -294,7 +294,7 @@ pub trait PrettyPrinter<'tcx>:
                             true,
                         ));
                     }
-                    (ExternCrateSource::Path, LOCAL_CRATE) if self.tcx().sess.rust_2018() => {
+                    (ExternCrateSource::Path, LOCAL_CRATE) => {
                         debug!("try_print_visible_def_path: def_id={:?}", def_id);
                         return Ok((self.path_crate(cnum)?, true));
                     }

--- a/src/test/ui/issues/auxiliary/reexported-trait.rs
+++ b/src/test/ui/issues/auxiliary/reexported-trait.rs
@@ -1,0 +1,17 @@
+mod private {
+    pub trait Trait {
+        fn trait_method(&self) {
+        }
+    }
+    pub trait TraitB {
+        fn trait_method_b(&self) {
+        }
+    }
+}
+
+pub struct FooStruct;
+pub use crate::private::Trait;
+impl crate::private::Trait for FooStruct {}
+
+pub use crate::private::TraitB as TraitBRename;
+impl crate::private::TraitB for FooStruct {}

--- a/src/test/ui/issues/issue-56175.rs
+++ b/src/test/ui/issues/issue-56175.rs
@@ -1,0 +1,9 @@
+// edition:2018
+// aux-crate:reexported_trait=reexported-trait.rs
+
+fn main() {
+    reexported_trait::FooStruct.trait_method();
+    //~^ ERROR
+    reexported_trait::FooStruct.trait_method_b();
+    //~^ ERROR
+}

--- a/src/test/ui/issues/issue-56175.stderr
+++ b/src/test/ui/issues/issue-56175.stderr
@@ -1,0 +1,27 @@
+error[E0599]: no method named `trait_method` found for struct `reexported_trait::FooStruct` in the current scope
+  --> $DIR/issue-56175.rs:5:33
+   |
+LL |     reexported_trait::FooStruct.trait_method();
+   |                                 ^^^^^^^^^^^^ method not found in `reexported_trait::FooStruct`
+   |
+   = help: items from traits can only be used if the trait is in scope
+help: the following trait is implemented but not in scope; perhaps add a `use` for it:
+   |
+LL | use reexported_trait::private::Trait;
+   |
+
+error[E0599]: no method named `trait_method_b` found for struct `reexported_trait::FooStruct` in the current scope
+  --> $DIR/issue-56175.rs:7:33
+   |
+LL |     reexported_trait::FooStruct.trait_method_b();
+   |                                 ^^^^^^^^^^^^^^ method not found in `reexported_trait::FooStruct`
+   |
+   = help: items from traits can only be used if the trait is in scope
+help: the following trait is implemented but not in scope; perhaps add a `use` for it:
+   |
+LL | use reexported_trait::private::TraitB;
+   |
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0599`.

--- a/src/test/ui/issues/issue-56175.stderr
+++ b/src/test/ui/issues/issue-56175.stderr
@@ -7,7 +7,7 @@ LL |     reexported_trait::FooStruct.trait_method();
    = help: items from traits can only be used if the trait is in scope
 help: the following trait is implemented but not in scope; perhaps add a `use` for it:
    |
-LL | use reexported_trait::private::Trait;
+LL | use reexported_trait::Trait;
    |
 
 error[E0599]: no method named `trait_method_b` found for struct `reexported_trait::FooStruct` in the current scope
@@ -19,7 +19,7 @@ LL |     reexported_trait::FooStruct.trait_method_b();
    = help: items from traits can only be used if the trait is in scope
 help: the following trait is implemented but not in scope; perhaps add a `use` for it:
    |
-LL | use reexported_trait::private::TraitB;
+LL | use reexported_trait::TraitBRename;
    |
 
 error: aborting due to 2 previous errors


### PR DESCRIPTION
The recursive check of `try_print_visible_def_path` did not properly handle the Rust 2018 case of crate-paths without 'extern crate'. Instead, it returned a "not found" via (false, self).

 This fixes #56175.