### PR TITLE
Add From<E: Error + Send> for Box<dyn Error + Send> impl

### DIFF
--- a/src/libstd/error.rs
+++ b/src/libstd/error.rs
@@ -194,6 +194,43 @@ impl<'a, E: Error + 'a> From<E> for Box<dyn Error + 'a> {
     }
 }
 
+#[unstable(feature = "box_error_send", issue = "none")]
+impl<'a, E: Error + Send + 'a> From<E> for Box<dyn Error + Send + 'a> {
+    /// Converts a type of [`Error`] + [`Send`] into a box of dyn [`Error`] + [`Send`].
+    ///
+    /// [`Error`]: ../error/trait.Error.html
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::error::Error;
+    /// use std::fmt;
+    /// use std::mem;
+    ///
+    /// #[derive(Debug)]
+    /// struct AnError;
+    ///
+    /// impl fmt::Display for AnError {
+    ///     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    ///         write!(f , "An error")
+    ///     }
+    /// }
+    ///
+    /// impl Error for AnError {}
+    ///
+    /// unsafe impl Send for AnError {}
+    ///
+    /// let an_error = AnError;
+    /// assert!(0 == mem::size_of_val(&an_error));
+    /// let a_boxed_error = Box::<dyn Error + Send>::from(an_error);
+    /// assert!(
+    ///     mem::size_of::<Box<dyn Error + Send>>() == mem::size_of_val(&a_boxed_error))
+    /// ```
+    fn from(err: E) -> Box<dyn Error + Send + 'a> {
+        Box::new(err)
+    }
+}
+
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<'a, E: Error + Send + Sync + 'a> From<E> for Box<dyn Error + Send + Sync + 'a> {
     /// Converts a type of [`Error`] + [`Send`] + [`Sync`] into a box of

--- a/src/test/ui/const-generics/array-impls/alloc-types-no-impls-length-33.stderr
+++ b/src/test/ui/const-generics/array-impls/alloc-types-no-impls-length-33.stderr
@@ -18,7 +18,7 @@ LL |     let boxed_array = <Box<[i32; 33]>>::try_from(boxed_slice);
              <std::boxed::Box<(dyn std::error::Error + 'static)> as std::convert::From<&str>>
              <std::boxed::Box<(dyn std::error::Error + 'static)> as std::convert::From<std::borrow::Cow<'a, str>>>
              <std::boxed::Box<(dyn std::error::Error + 'static)> as std::convert::From<std::string::String>>
-           and 22 others
+           and 23 others
    = note: required because of the requirements on the impl of `std::convert::Into<std::boxed::Box<[i32; 33]>>` for `std::boxed::Box<[i32]>`
    = note: required because of the requirements on the impl of `std::convert::TryFrom<std::boxed::Box<[i32]>>` for `std::boxed::Box<[i32; 33]>`
 


### PR DESCRIPTION
Adds the following implementation:

```rust
 impl<'a, E: Error + Send + 'a> From<E> for Box<dyn Error + Send + 'a>;
```

Partially fixes #62824 

Said issue also mentions adding an `impl<'a, E: Error + Sync + 'a> From<E> for Box<dyn Error + Sync + 'a> {}`, but I doubt its usefulness. AFAIK, a type that is `Sync + !Send` is extremely rare/shouldn't happen. Thus, `Send + Sync` and `Sync` are much the same.