### PR TITLE
Fix wasm32 being broken due to a NodeJS version bump

### DIFF
--- a/src/ci/docker/wasm32/Dockerfile
+++ b/src/ci/docker/wasm32/Dockerfile
@@ -25,7 +25,18 @@ RUN ln `which python3` /usr/bin/python
 
 ENV PATH=$PATH:/emsdk-portable
 ENV PATH=$PATH:/emsdk-portable/upstream/emscripten/
-ENV PATH=$PATH:/emsdk-portable/node/12.9.1_64bit/bin/
+
+# Rust's build system requires NodeJS to be in the path, but the directory in
+# which emsdk stores it contains the version number. This caused breakages in
+# the past when emsdk bumped the node version causing the path to point to a
+# missing directory.
+#
+# To avoid the problem this symlinks the latest NodeJs version available to
+# "latest", and adds that to the path.
+RUN ln -s /emsdk-portable/node/$(ls /emsdk-portable/node | sort -V | tail -n 1) \
+          /emsdk-portable/node/latest
+ENV PATH=$PATH:/emsdk-portable/node/latest/bin/
+
 ENV BINARYEN_ROOT=/emsdk-portable/upstream/
 ENV EMSDK=/emsdk-portable
 ENV EM_CONFIG=/emsdk-portable/.emscripten


### PR DESCRIPTION
Emscripten's SDK [recently bumped the version of NodeJS they shipped](https://github.com/emscripten-core/emsdk/pull/529), but our Dockerfile for the wasm32 builder hardcoded the version number. This will cause consistent CI failures once the currently cached image is rebuilt (either due to a change or due to the cache expiring).

This PR fixes the problem by finding the latest version of NodeJS in the Emscripten SDK and symlinking it to a "latest" directory, which is then added to the `PATH`.