### PR TITLE
stabilize const mem::forget

### DIFF
--- a/src/libcore/mem/mod.rs
+++ b/src/libcore/mem/mod.rs
@@ -142,7 +142,7 @@ pub use crate::intrinsics::transmute;
 /// [ub]: ../../reference/behavior-considered-undefined.html
 /// [`ManuallyDrop`]: struct.ManuallyDrop.html
 #[inline]
-#[rustc_const_unstable(feature = "const_forget", issue = "69616")]
+#[rustc_const_stable(feature = "const_forget", since = "1.46.0")]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub const fn forget<T>(t: T) {
     ManuallyDrop::new(t);

--- a/src/libcore/tests/lib.rs
+++ b/src/libcore/tests/lib.rs
@@ -40,7 +40,6 @@
 #![feature(const_raw_ptr_deref)]
 #![feature(never_type)]
 #![feature(unwrap_infallible)]
-#![feature(const_forget)]
 #![feature(option_unwrap_none)]
 #![feature(peekable_next_if)]
 #![feature(partition_point)]

--- a/src/test/ui/consts/const_forget.rs
+++ b/src/test/ui/consts/const_forget.rs
@@ -1,7 +1,5 @@
 // check-pass
 
-#![feature(const_forget)]
-
 use std::mem::forget;
 
 const _: () = forget(0i32);


### PR DESCRIPTION
Stabilizes const `mem::forget` as implemented in https://github.com/rust-lang/rust/pull/69617 and tracked in https://github.com/rust-lang/rust/issues/69616.

Closes https://github.com/rust-lang/rust/issues/69616