### PR TITLE
Changes required for rustc/cargo to build for iOS targets

### DIFF
--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -811,6 +811,11 @@ impl Build {
         if target.contains("apple-darwin") {
             base.push("-stdlib=libc++".into());
         }
+        
+        // Required for LLVM to properly compile.
+        if target.contains("apple-ios") {
+            base.push("-miphoneos-version-min=10.0".into());
+        }
 
         // Work around an apparently bad MinGW / GCC optimization,
         // See: http://lists.llvm.org/pipermail/cfe-dev/2016-December/051980.html

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -811,11 +811,6 @@ impl Build {
         if target.contains("apple-darwin") {
             base.push("-stdlib=libc++".into());
         }
-        
-        // Required for LLVM to properly compile.
-        if target.contains("apple-ios") {
-            base.push("-miphoneos-version-min=10.0".into());
-        }
 
         // Work around an apparently bad MinGW / GCC optimization,
         // See: http://lists.llvm.org/pipermail/cfe-dev/2016-December/051980.html

--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -421,7 +421,11 @@ fn configure_cmake(
         cflags.push_str(&format!(" {}", s));
     }
     if target.contains("apple-ios") {
-        cflags.push_str(" -miphoneos-version-min=10.0");
+        if target.contains("86-") {
+            cflags.push_str(" -miphonesimulator-version-min=10.0");
+        } else {
+            cflags.push_str(" -miphoneos-version-min=10.0");
+        }
     }
     cfg.define("CMAKE_C_FLAGS", cflags);
     let mut cxxflags = builder.cflags(target, GitRepo::Llvm).join(" ");

--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -423,6 +423,7 @@ fn configure_cmake(
     if let Some(ref s) = builder.config.llvm_cflags {
         cflags.push_str(&format!(" {}", s));
     }
+    // Some compiler features used by LLVM (such as thread locals) will not work on a min version below iOS 10.
     if target.contains("apple-ios") {
         if target.contains("86-") {
             cflags.push_str(" -miphonesimulator-version-min=10.0");

--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -176,7 +176,7 @@ impl Step for Llvm {
         }
 
         // Are we compiling for iOS/tvOS?
-        if target.contains("apple") && !target.contains("darwin") {
+        if target.contains("apple-ios") || target.contains("apple-tvos") {
             // These two defines prevent CMake from automatically trying to add a MacOSX sysroot, which leads to a compiler error.
             cfg.define("CMAKE_OSX_SYSROOT", "/");
             cfg.define("CMAKE_OSX_DEPLOYMENT_TARGET", "");

--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -175,6 +175,14 @@ impl Step for Llvm {
             cfg.define("LLVM_ENABLE_ZLIB", "OFF");
         }
 
+        // Are we compiling for iOS/tvOS?
+        if target.contains("apple") && !target.contains("darwin") {
+            cfg.define("CMAKE_OSX_SYSROOT", "/");
+            cfg.define("CMAKE_OSX_DEPLOYMENT_TARGET", "");
+            cfg.define("LLVM_ENABLE_PLUGINS", "OFF"); // Prevent cmake from adding -bundle to CFLAGS automatically.
+            cfg.define("LLVM_ENABLE_ZLIB", "OFF");
+        }
+
         if builder.config.llvm_thin_lto {
             cfg.define("LLVM_ENABLE_LTO", "Thin");
             if !target.contains("apple") {

--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -420,6 +420,9 @@ fn configure_cmake(
     if let Some(ref s) = builder.config.llvm_cflags {
         cflags.push_str(&format!(" {}", s));
     }
+    if target.contains("apple-ios") {
+        cflags.push_str(" -miphoneos-version-min=10.0");
+    }
     cfg.define("CMAKE_C_FLAGS", cflags);
     let mut cxxflags = builder.cflags(target, GitRepo::Llvm).join(" ");
     if builder.config.llvm_static_stdcpp && !target.contains("msvc") && !target.contains("netbsd") {

--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -177,9 +177,12 @@ impl Step for Llvm {
 
         // Are we compiling for iOS/tvOS?
         if target.contains("apple") && !target.contains("darwin") {
+            // These two defines prevent CMake from automatically trying to add a MacOSX sysroot, which leads to a compiler error.
             cfg.define("CMAKE_OSX_SYSROOT", "/");
             cfg.define("CMAKE_OSX_DEPLOYMENT_TARGET", "");
-            cfg.define("LLVM_ENABLE_PLUGINS", "OFF"); // Prevent cmake from adding -bundle to CFLAGS automatically.
+            // Prevent cmake from adding -bundle to CFLAGS automatically, which leads to a compiler error because "-bitcode_bundle" also gets added.
+            cfg.define("LLVM_ENABLE_PLUGINS", "OFF");
+            // Zlib fails to link properly, leading to a compiler error.
             cfg.define("LLVM_ENABLE_ZLIB", "OFF");
         }
 


### PR DESCRIPTION
cargo, rustc, clippy, rust-src, and rust-analysis successfully build for `aarch64-apple-ios` with these changes.

NOTE: cargo required arm64-ios openssl/libcurl to be linked.

![image](https://user-images.githubusercontent.com/65794972/86178510-75d78080-baf6-11ea-9c17-b74bd6c85272.png)
![image](https://user-images.githubusercontent.com/65794972/86178525-7bcd6180-baf6-11ea-9974-f99980cbdb24.png)
