### PR TITLE
`#[deny(unsafe_op_in_unsafe_fn)]` in libstd/fs.rs

### DIFF
--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -666,7 +666,8 @@ impl Read for File {
 
     #[inline]
     unsafe fn initializer(&self) -> Initializer {
-        Initializer::nop()
+        // SAFETY: Read is guaranteed to work on uninitialized memory
+        unsafe { Initializer::nop() }
     }
 }
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -711,7 +712,8 @@ impl Read for &File {
 
     #[inline]
     unsafe fn initializer(&self) -> Initializer {
-        Initializer::nop()
+        // SAFETY: Read is guaranteed to work on uninitialized memory
+        unsafe { Initializer::nop() }
     }
 }
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -8,6 +8,7 @@
 //! extension traits of `std::os::$platform`.
 
 #![stable(feature = "rust1", since = "1.0.0")]
+#![deny(unsafe_op_in_unsafe_fn)]
 
 use crate::ffi::OsString;
 use crate::fmt;

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -319,6 +319,7 @@
 #![feature(track_caller)]
 #![feature(try_reserve)]
 #![feature(unboxed_closures)]
+#![feature(unsafe_block_in_unsafe_fn)]
 #![feature(untagged_unions)]
 #![feature(unwind_attributes)]
 #![feature(vec_into_raw_parts)]


### PR DESCRIPTION
The `libstd/fs.rs` part of https://github.com/rust-lang/rust/issues/73904 . Wraps the two calls to an unsafe fn `Initializer::nop()` in an `unsafe` block.

Followed instructions in parent issue, ran `./x.py check src/libstd/` after adding the lint and two warnings were given. After adding these changes, those disappear.