### PR TITLE
Rewrite a few manual index loops with while-let

### DIFF
--- a/src/librustc_data_structures/obligation_forest/mod.rs
+++ b/src/librustc_data_structures/obligation_forest/mod.rs
@@ -412,9 +412,7 @@ impl<O: ForestObligation> ObligationForest<O> {
         // be computed with the initial length, and we would miss the appended
         // nodes. Therefore we use a `while` loop.
         let mut index = 0;
-        while index < self.nodes.len() {
-            let node = &mut self.nodes[index];
-
+        while let Some(node) = self.nodes.get_mut(index) {
             // `processor.process_obligation` can modify the predicate within
             // `node.obligation`, and that predicate is the key used for
             // `self.active_cache`. This means that `self.active_cache` can get
@@ -666,8 +664,8 @@ impl<O: ForestObligation> ObligationForest<O> {
 
         for node in &mut self.nodes {
             let mut i = 0;
-            while i < node.dependents.len() {
-                let new_index = node_rewrites[node.dependents[i]];
+            while let Some(dependent) = node.dependents.get_mut(i) {
+                let new_index = node_rewrites[*dependent];
                 if new_index >= orig_nodes_len {
                     node.dependents.swap_remove(i);
                     if i == 0 && node.has_parent {
@@ -675,7 +673,7 @@ impl<O: ForestObligation> ObligationForest<O> {
                         node.has_parent = false;
                     }
                 } else {
-                    node.dependents[i] = new_index;
+                    *dependent = new_index;
                     i += 1;
                 }
             }

--- a/src/librustc_data_structures/transitive_relation.rs
+++ b/src/librustc_data_structures/transitive_relation.rs
@@ -391,14 +391,12 @@ impl<T: Clone + Debug + Eq + Hash> TransitiveRelation<T> {
 /// - Input: `[a, x, b, y]`. Output: `[a, x]`.
 fn pare_down(candidates: &mut Vec<usize>, closure: &BitMatrix<usize, usize>) {
     let mut i = 0;
-    while i < candidates.len() {
-        let candidate_i = candidates[i];
+    while let Some(&candidate_i) = candidates.get(i) {
         i += 1;
 
         let mut j = i;
         let mut dead = 0;
-        while j < candidates.len() {
-            let candidate_j = candidates[j];
+        while let Some(&candidate_j) = candidates.get(j) {
             if closure.contains(candidate_i, candidate_j) {
                 // If `i` can reach `j`, then we can remove `j`. So just
                 // mark it as dead and move on; subsequent indices will be


### PR DESCRIPTION
There were a few instances of this pattern:

```rust
while index < vec.len() {
    let item = &vec[index];
    // ...
}
```

These can be indexed at once:

```rust
while let Some(item) = vec.get(index) {
    // ...
}
```

Particularly in `ObligationForest::process_obligations`, this mitigates
a codegen regression found with LLVM 11 (#73526).