### PR TITLE
Ignoring test case: [codegen] repr-transparent-aggregates-1.rs for aarch64

### DIFF
--- a/src/test/codegen/repr-transparent-aggregates-1.rs
+++ b/src/test/codegen/repr-transparent-aggregates-1.rs
@@ -3,6 +3,7 @@
 
 // min-system-llvm-version: 9.0
 // ignore-arm
+// ignore-aarch64
 // ignore-mips
 // ignore-mips64
 // ignore-powerpc


### PR DESCRIPTION
Ignoring test case: [codegen] repr-transparent-aggregates-1.rs for aarch64.

Copyright (c) 2020, Arm Limited.