### PR TITLE
Deny unsafe ops in unsafe fns in `std::sys_common`

### DIFF
--- a/library/std/src/sys_common/at_exit_imp.rs
+++ b/library/std/src/sys_common/at_exit_imp.rs
@@ -26,10 +26,14 @@ const DONE: *mut Queue = 1_usize as *mut _;
 const ITERS: usize = 10;
 
 unsafe fn init() -> bool {
-    if QUEUE.is_null() {
+    // SAFETY: the caller must ensure that `QUEUE` is not in use anywhere else,
+    // which `push` below does by locking `LOCK`.
+    if unsafe { QUEUE.is_null() } {
         let state: Box<Queue> = box Vec::new();
-        QUEUE = Box::into_raw(state);
-    } else if QUEUE == DONE {
+        unsafe {
+            QUEUE = Box::into_raw(state);
+        }
+    } else if unsafe { QUEUE == DONE } {
         // can't re-init after a cleanup
         return false;
     }

--- a/library/std/src/sys_common/condvar.rs
+++ b/library/std/src/sys_common/condvar.rs
@@ -25,19 +25,22 @@ impl Condvar {
     /// address.
     #[inline]
     pub unsafe fn init(&mut self) {
-        self.0.init()
+        // SAFETY: the caller must uphold the safety contract for `init`.
+        unsafe { self.0.init() }
     }
 
     /// Signals one waiter on this condition variable to wake up.
     #[inline]
     pub unsafe fn notify_one(&self) {
-        self.0.notify_one()
+        // SAFETY: the caller must uphold the safety contract for `notify_one`.
+        unsafe { self.0.notify_one() }
     }
 
     /// Awakens all current waiters on this condition variable.
     #[inline]
     pub unsafe fn notify_all(&self) {
-        self.0.notify_all()
+        // SAFETY: the caller must uphold the safety contract for `notify_all`.
+        unsafe { self.0.notify_all() }
     }
 
     /// Waits for a signal on the specified mutex.
@@ -47,7 +50,8 @@ impl Condvar {
     /// on this condition variable.
     #[inline]
     pub unsafe fn wait(&self, mutex: &Mutex) {
-        self.0.wait(mutex::raw(mutex))
+        // SAFETY: the caller must uphold the safety contract for `wait`.
+        unsafe { self.0.wait(mutex::raw(mutex)) }
     }
 
     /// Waits for a signal on the specified mutex with a timeout duration
@@ -58,7 +62,8 @@ impl Condvar {
     /// on this condition variable.
     #[inline]
     pub unsafe fn wait_timeout(&self, mutex: &Mutex, dur: Duration) -> bool {
-        self.0.wait_timeout(mutex::raw(mutex), dur)
+        // SAFETY: the caller must uphold the safety contract for `wait_timeout`.
+        unsafe { self.0.wait_timeout(mutex::raw(mutex), dur) }
     }
 
     /// Deallocates all resources associated with this condition variable.
@@ -67,6 +72,7 @@ impl Condvar {
     /// this condition variable.
     #[inline]
     pub unsafe fn destroy(&self) {
-        self.0.destroy()
+        // SAFETY: the caller must uphold the safety contract for `destroy`.
+        unsafe { self.0.destroy() }
     }
 }

--- a/library/std/src/sys_common/mod.rs
+++ b/library/std/src/sys_common/mod.rs
@@ -14,6 +14,7 @@
 
 #![allow(missing_docs)]
 #![allow(missing_debug_implementations)]
+#![deny(unsafe_op_in_unsafe_fn)]
 
 #[cfg(test)]
 mod tests;

--- a/library/std/src/sys_common/mutex.rs
+++ b/library/std/src/sys_common/mutex.rs
@@ -30,7 +30,8 @@ impl Mutex {
     /// `init()`) is undefined behavior.
     #[inline]
     pub unsafe fn init(&mut self) {
-        self.0.init()
+        // SAFETY: the caller must uphold the safety contract for `init`.
+        unsafe { self.0.init() }
     }
 
     /// Locks the mutex blocking the current thread until it is available.
@@ -39,14 +40,18 @@ impl Mutex {
     /// previous function call.
     #[inline]
     pub unsafe fn raw_lock(&self) {
-        self.0.lock()
+        // SAFETY: the caller must uphold the safety contract for `lock`.
+        unsafe { self.0.lock() }
     }
 
     /// Calls raw_lock() and then returns an RAII guard to guarantee the mutex
     /// will be unlocked.
     #[inline]
     pub unsafe fn lock(&self) -> MutexGuard<'_> {
-        self.raw_lock();
+        // SAFETY: the caller must uphold the safety contract for `raw_lock`.
+        unsafe {
+            self.raw_lock();
+        }
         MutexGuard(&self.0)
     }
 
@@ -57,7 +62,8 @@ impl Mutex {
     /// previous function call.
     #[inline]
     pub unsafe fn try_lock(&self) -> bool {
-        self.0.try_lock()
+        // SAFETY: the caller must uphold the safety contract for `try_lock`.
+        unsafe { self.0.try_lock() }
     }
 
     /// Unlocks the mutex.
@@ -69,7 +75,8 @@ impl Mutex {
     /// lock() whenever possible.
     #[inline]
     pub unsafe fn raw_unlock(&self) {
-        self.0.unlock()
+        // SAFETY: the caller must uphold the safety contract for `unlock`.
+        unsafe { self.0.unlock() }
     }
 
     /// Deallocates all resources associated with this mutex.
@@ -78,7 +85,8 @@ impl Mutex {
     /// this mutex.
     #[inline]
     pub unsafe fn destroy(&self) {
-        self.0.destroy()
+        // SAFETY: the caller must uphold the safety contract for `destroy`.
+        unsafe { self.0.destroy() }
     }
 }
 

--- a/library/std/src/sys_common/rwlock.rs
+++ b/library/std/src/sys_common/rwlock.rs
@@ -23,7 +23,8 @@ impl RWLock {
     /// previous method call.
     #[inline]
     pub unsafe fn read(&self) {
-        self.0.read()
+        // SAFETY: the caller must uphold the safety contract for `read`.
+        unsafe { self.0.read() }
     }
 
     /// Attempts to acquire shared access to this lock, returning whether it
@@ -35,7 +36,8 @@ impl RWLock {
     /// previous method call.
     #[inline]
     pub unsafe fn try_read(&self) -> bool {
-        self.0.try_read()
+        // SAFETY: the caller must uphold the safety contract for `try_read`.
+        unsafe { self.0.try_read() }
     }
 
     /// Acquires write access to the underlying lock, blocking the current thread
@@ -45,7 +47,8 @@ impl RWLock {
     /// previous method call.
     #[inline]
     pub unsafe fn write(&self) {
-        self.0.write()
+        // SAFETY: the caller must uphold the safety contract for `write`.
+        unsafe { self.0.write() }
     }
 
     /// Attempts to acquire exclusive access to this lock, returning whether it
@@ -57,7 +60,8 @@ impl RWLock {
     /// previous method call.
     #[inline]
     pub unsafe fn try_write(&self) -> bool {
-        self.0.try_write()
+        // SAFETY: the caller must uphold the safety contract for `try_write`.
+        unsafe { self.0.try_write() }
     }
 
     /// Unlocks previously acquired shared access to this lock.
@@ -65,7 +69,8 @@ impl RWLock {
     /// Behavior is undefined if the current thread does not have shared access.
     #[inline]
     pub unsafe fn read_unlock(&self) {
-        self.0.read_unlock()
+        // SAFETY: the caller must uphold the safety contract for `read_unlock`.
+        unsafe { self.0.read_unlock() }
     }
 
     /// Unlocks previously acquired exclusive access to this lock.
@@ -74,7 +79,8 @@ impl RWLock {
     /// exclusive access.
     #[inline]
     pub unsafe fn write_unlock(&self) {
-        self.0.write_unlock()
+        // SAFETY: the caller must uphold the safety contract for `write_unlock`.
+        unsafe { self.0.write_unlock() }
     }
 
     /// Destroys OS-related resources with this RWLock.
@@ -83,6 +89,7 @@ impl RWLock {
     /// lock.
     #[inline]
     pub unsafe fn destroy(&self) {
-        self.0.destroy()
+        // SAFETY: the caller must uphold the safety contract for `destroy`.
+        unsafe { self.0.destroy() }
     }
 }

--- a/library/std/src/sys_common/thread_info.rs
+++ b/library/std/src/sys_common/thread_info.rs
@@ -1,4 +1,8 @@
-#![allow(dead_code)] // stack_guard isn't used right now on all platforms
+// stack_guard isn't used right now on all platforms
+#![allow(dead_code)]
+// FIXME: this should be removed once `thread_local!` denies unsafe ops in unsafe
+// fns. This cannot be done yet because the macro is also used in libproc_macro.
+#![allow(unsafe_op_in_unsafe_fn)]
 
 use crate::cell::RefCell;
 use crate::sys::thread::guard::Guard;

--- a/library/std/src/sys_common/wtf8.rs
+++ b/library/std/src/sys_common/wtf8.rs
@@ -480,7 +480,8 @@ impl Wtf8 {
     /// marked unsafe.
     #[inline]
     unsafe fn from_bytes_unchecked(value: &[u8]) -> &Wtf8 {
-        mem::transmute(value)
+        // SAFETY: the caller must guarantee that `value` is a valid WTF-8 value.
+        unsafe { mem::transmute(value) }
     }
 
     /// Creates a mutable WTF-8 slice from a mutable WTF-8 byte slice.
@@ -489,7 +490,8 @@ impl Wtf8 {
     /// marked unsafe.
     #[inline]
     unsafe fn from_mut_bytes_unchecked(value: &mut [u8]) -> &mut Wtf8 {
-        mem::transmute(value)
+        // SAFETY: the caller must guarantee that `value` is a valid WTF-8 value.
+        unsafe { mem::transmute(value) }
     }
 
     /// Returns the length, in WTF-8 bytes.
@@ -785,8 +787,10 @@ pub fn is_code_point_boundary(slice: &Wtf8, index: usize) -> bool {
 /// Copied from core::str::raw::slice_unchecked
 #[inline]
 pub unsafe fn slice_unchecked(s: &Wtf8, begin: usize, end: usize) -> &Wtf8 {
-    // memory layout of an &[u8] and &Wtf8 are the same
-    Wtf8::from_bytes_unchecked(slice::from_raw_parts(s.bytes.as_ptr().add(begin), end - begin))
+    // SAFETY: the memory layout of an &[u8] and &Wtf8 are the same
+    unsafe {
+        Wtf8::from_bytes_unchecked(slice::from_raw_parts(s.bytes.as_ptr().add(begin), end - begin))
+    }
 }
 
 /// Copied from core::str::raw::slice_error_fail


### PR DESCRIPTION
Helps with #73904.

I wasn't able to properly document some unsafety used in `thread_local.rs`, because the system-dependent unsafe functions it uses aren't documented. I'll be happy to help if any team member has some time to walk me through those functions, but I think that can be done in a separate PR.

This should be merged after (or alongside) #73909 because #73909 enables the `#![feature(unsafe_block_in_unsafe_fn)]` needed for this PR.