### PR TITLE
Make some Option methods const

### DIFF
--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -85,6 +85,7 @@
 #![feature(const_panic)]
 #![feature(const_fn_union)]
 #![feature(const_generics)]
+#![feature(const_option)]
 #![feature(const_ptr_offset)]
 #![feature(const_ptr_offset_from)]
 #![cfg_attr(not(bootstrap), feature(const_raw_ptr_comparison))]

--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -179,8 +179,9 @@ impl<T> Option<T> {
     /// [`Some`]: #variant.Some
     #[must_use = "if you intended to assert that this has a value, consider `.unwrap()` instead"]
     #[inline]
+    #[rustc_const_unstable(feature = "const_option", issue = "67441")]
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn is_some(&self) -> bool {
+    pub const fn is_some(&self) -> bool {
         matches!(*self, Some(_))
     }
 
@@ -200,8 +201,9 @@ impl<T> Option<T> {
     #[must_use = "if you intended to assert that this doesn't have a value, consider \
                   `.and_then(|| panic!(\"`Option` had a value when expected `None`\"))` instead"]
     #[inline]
+    #[rustc_const_unstable(feature = "const_option", issue = "67441")]
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn is_none(&self) -> bool {
+    pub const fn is_none(&self) -> bool {
         !self.is_some()
     }
 
@@ -259,8 +261,9 @@ impl<T> Option<T> {
     /// println!("still can print text: {:?}", text);
     /// ```
     #[inline]
+    #[rustc_const_unstable(feature = "const_option", issue = "67441")]
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn as_ref(&self) -> Option<&T> {
+    pub const fn as_ref(&self) -> Option<&T> {
         match *self {
             Some(ref x) => Some(x),
             None => None,
@@ -580,8 +583,9 @@ impl<T> Option<T> {
     /// assert_eq!(x.iter().next(), None);
     /// ```
     #[inline]
+    #[rustc_const_unstable(feature = "const_option", issue = "67441")]
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn iter(&self) -> Iter<'_, T> {
+    pub const fn iter(&self) -> Iter<'_, T> {
         Iter { inner: Item { opt: self.as_ref() } }
     }
 

--- a/src/test/ui/consts/const-option.rs
+++ b/src/test/ui/consts/const-option.rs
@@ -1,0 +1,14 @@
+// run-pass
+
+#![feature(const_option)]
+
+const X: Option<i32> = Some(32);
+const Y: Option<&i32> = X.as_ref();
+
+const IS_SOME: bool = X.is_some();
+const IS_NONE: bool = Y.is_none();
+
+fn main() {
+    assert!(IS_SOME);
+    assert!(!IS_NONE)
+}


### PR DESCRIPTION
Tracking issue: #67441

Constantify the following methods of `Option`:
- `as_ref`
- `is_some`
- `is_none`
- `iter` (not sure about this one, but it is possible, and will be useful when const traits are a thing)

cc @rust-lang/wg-const-eval @rust-lang/libs