### PR TITLE
deny(unsafe_op_in_unsafe_fn) in libstd/process.rs

### DIFF
--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -105,6 +105,7 @@
 //! [`Read`]: ../io/trait.Read.html
 
 #![stable(feature = "process", since = "1.0.0")]
+#![deny(unsafe_op_in_unsafe_fn)]
 
 use crate::io::prelude::*;
 
@@ -311,7 +312,8 @@ impl Read for ChildStdout {
 
     #[inline]
     unsafe fn initializer(&self) -> Initializer {
-        Initializer::nop()
+        // SAFETY: Read is guaranteed to work on uninitialized memory
+        unsafe { Initializer::nop() }
     }
 }
 
@@ -372,7 +374,8 @@ impl Read for ChildStderr {
 
     #[inline]
     unsafe fn initializer(&self) -> Initializer {
-        Initializer::nop()
+        // SAFETY: Read is guaranteed to work on uninitialized memory
+        unsafe { Initializer::nop() }
     }
 }
 


### PR DESCRIPTION
The libstd/process.rs part of #73904 . Wraps the two calls to an unsafe fn Initializer::nop() in an unsafe block.

Will have to wait for #73909 to be merged, because of the feature in the libstd/lib.rs