### PR TITLE
disable BTree min_max test in Miri for now

### DIFF
--- a/src/liballoc/tests/btree/map.rs
+++ b/src/liballoc/tests/btree/map.rs
@@ -310,6 +310,7 @@ fn test_iter_mixed() {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)] // FIXME: fails in Miri <https://github.com/rust-lang/rust/issues/73915>
 fn test_iter_min_max() {
     let mut a = BTreeMap::new();
     assert_eq!(a.iter().min(), None);


### PR DESCRIPTION
Until https://github.com/rust-lang/rust/issues/73915 is fixed, better skip this test in Miri so that we can test the others at least.