### PR TITLE
typeck: check for infer before type impls trait

### DIFF
--- a/src/librustc_typeck/check/cast.rs
+++ b/src/librustc_typeck/check/cast.rs
@@ -387,6 +387,7 @@ impl<'a, 'tcx> CastCheck<'tcx> {
                             // Check for infer types because cases like `Option<{integer}>` would
                             // panic otherwise.
                             if !expr_ty.has_infer_types()
+                                && !ty.has_infer_types()
                                 && fcx.tcx.type_implements_trait((
                                     from_trait,
                                     ty,

--- a/src/test/ui/issues/issue-73886.rs
+++ b/src/test/ui/issues/issue-73886.rs
@@ -1,0 +1,6 @@
+fn main() {
+    let _ = &&[0] as &[_];
+    //~^ ERROR non-primitive cast: `&&[i32; 1]` as `&[_]`
+    let _ = 7u32 as Option<_>;
+    //~^ ERROR non-primitive cast: `u32` as `std::option::Option<_>`
+}

--- a/src/test/ui/issues/issue-73886.stderr
+++ b/src/test/ui/issues/issue-73886.stderr
@@ -1,0 +1,15 @@
+error[E0605]: non-primitive cast: `&&[i32; 1]` as `&[_]`
+  --> $DIR/issue-73886.rs:2:13
+   |
+LL |     let _ = &&[0] as &[_];
+   |             ^^^^^^^^^^^^^ an `as` expression can only be used to convert between primitive types or to coerce to a specific trait object
+
+error[E0605]: non-primitive cast: `u32` as `std::option::Option<_>`
+  --> $DIR/issue-73886.rs:4:13
+   |
+LL |     let _ = 7u32 as Option<_>;
+   |             ^^^^^^^^^^^^^^^^^ an `as` expression can only be used to convert between primitive types or to coerce to a specific trait object
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0605`.


### PR DESCRIPTION
Fixes #73886.

This PR checks that the target type of the cast (an error related to which is being reported) does not have types to be inferred before checking if it implements the `From` trait.

r? @estebank 

