### PR TITLE
Improve `assert_eq` message

### DIFF
--- a/src/libcore/macros/mod.rs
+++ b/src/libcore/macros/mod.rs
@@ -44,12 +44,20 @@ macro_rules! assert_eq {
         match (&$left, &$right) {
             (left_val, right_val) => {
                 if !(*left_val == *right_val) {
+                    let left = stringify!($left);
+                    let right = stringify!($right);
+                    let width = if left.len() > right.len() {
+                        left.len()
+                    } else {
+                        right.len()
+                    };
+
                     // The reborrows below are intentional. Without them, the stack slot for the
                     // borrow is initialized even before the values are compared, leading to a
                     // noticeable slow down.
-                    panic!(r#"assertion failed: `(left == right)`
-  left: `{:?}`,
- right: `{:?}`"#, &*left_val, &*right_val)
+                    panic!(r#"assertion failed: `({left}) == ({right})`
+{left:>width$}: `{:?}`,
+{right:>width$}: `{:?}`"#, &*left_val, &*right_val, left=left, right=right, width=width)
                 }
             }
         }
@@ -61,13 +69,22 @@ macro_rules! assert_eq {
         match (&($left), &($right)) {
             (left_val, right_val) => {
                 if !(*left_val == *right_val) {
+                    let left = stringify!($left);
+                    let right = stringify!($right);
+                    let width = if left.len() > right.len() {
+                        left.len()
+                    } else {
+                        right.len()
+                    };
+
                     // The reborrows below are intentional. Without them, the stack slot for the
                     // borrow is initialized even before the values are compared, leading to a
                     // noticeable slow down.
-                    panic!(r#"assertion failed: `(left == right)`
-  left: `{:?}`,
- right: `{:?}`: {}"#, &*left_val, &*right_val,
-                           $crate::format_args!($($arg)+))
+                    panic!(r#"assertion failed: `({left}) == ({right})`
+{left:>width$}: `{:?}`,
+{right:>width$}: `{:?}`: {}"#, &*left_val, &*right_val,
+                           $crate::format_args!($($arg)+),
+                           left=left, right=right, width=width)
                 }
             }
         }
@@ -101,12 +118,20 @@ macro_rules! assert_ne {
         match (&$left, &$right) {
             (left_val, right_val) => {
                 if *left_val == *right_val {
+                    let left = stringify!($left);
+                    let right = stringify!($right);
+                    let width = if left.len() > right.len() {
+                        left.len()
+                    } else {
+                        right.len()
+                    };
+
                     // The reborrows below are intentional. Without them, the stack slot for the
                     // borrow is initialized even before the values are compared, leading to a
                     // noticeable slow down.
-                    panic!(r#"assertion failed: `(left != right)`
-  left: `{:?}`,
- right: `{:?}`"#, &*left_val, &*right_val)
+                    panic!(r#"assertion failed: `({left}) != ({right})`
+{left:>width$}: `{:?}`,
+{right:>width$}: `{:?}`"#, &*left_val, &*right_val, left=left, right=right, width=width)
                 }
             }
         }
@@ -118,13 +143,22 @@ macro_rules! assert_ne {
         match (&($left), &($right)) {
             (left_val, right_val) => {
                 if *left_val == *right_val {
+                    let left = stringify!($left);
+                    let right = stringify!($right);
+                    let width = if left.len() > right.len() {
+                        left.len()
+                    } else {
+                        right.len()
+                    };
+
                     // The reborrows below are intentional. Without them, the stack slot for the
                     // borrow is initialized even before the values are compared, leading to a
                     // noticeable slow down.
-                    panic!(r#"assertion failed: `(left != right)`
-  left: `{:?}`,
- right: `{:?}`: {}"#, &*left_val, &*right_val,
-                           $crate::format_args!($($arg)+))
+                    panic!(r#"assertion failed: `({left}) != ({right})`
+{left:>width$}: `{:?}`,
+{right:>width$}: `{:?}`: {}"#, &*left_val, &*right_val,
+                           $crate::format_args!($($arg)+),
+                           left=left, right=right, width=width)
                 }
             }
         }

--- a/src/test/ui/macros/assert-eq-macro-panic.rs
+++ b/src/test/ui/macros/assert-eq-macro-panic.rs
@@ -1,7 +1,7 @@
 // run-fail
-// error-pattern:assertion failed: `(left == right)`
-// error-pattern: left: `14`
-// error-pattern:right: `15`
+// error-pattern:assertion failed: `(14) == (15)`
+// error-pattern:14: `14`
+// error-pattern:15: `15`
 // ignore-emscripten no processes
 
 fn main() {

--- a/src/test/ui/macros/assert-ne-macro-panic.rs
+++ b/src/test/ui/macros/assert-ne-macro-panic.rs
@@ -1,7 +1,7 @@
 // run-fail
-// error-pattern:assertion failed: `(left != right)`
-// error-pattern: left: `14`
-// error-pattern:right: `14`
+// error-pattern:assertion failed: `(14) != (14)`
+// error-pattern:14: `14`
+// error-pattern:14: `14`
 // ignore-emscripten no processes
 
 fn main() {

--- a/src/test/ui/test-panic-abort-nocapture.run.stderr
+++ b/src/test/ui/test-panic-abort-nocapture.run.stderr
@@ -1,9 +1,9 @@
-thread 'main' panicked at 'assertion failed: `(left == right)`
-  left: `2`,
- right: `4`', $DIR/test-panic-abort-nocapture.rs:32:5
+thread 'main' panicked at 'assertion failed: `(1 + 1) == (4)`
+1 + 1: `2`,
+    4: `4`', $DIR/test-panic-abort-nocapture.rs:32:5
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
-thread 'main' panicked at 'assertion failed: `(left == right)`
-  left: `2`,
- right: `4`', $DIR/test-panic-abort-nocapture.rs:26:5
+thread 'main' panicked at 'assertion failed: `(1 + 1) == (4)`
+1 + 1: `2`,
+    4: `4`', $DIR/test-panic-abort-nocapture.rs:26:5
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 testing321

--- a/src/test/ui/test-panic-abort.run.stdout
+++ b/src/test/ui/test-panic-abort.run.stdout
@@ -16,9 +16,9 @@ hello, world
 testing123
 ---- it_fails stderr ----
 testing321
-thread 'main' panicked at 'assertion failed: `(left == right)`
-  left: `2`,
- right: `5`', $DIR/test-panic-abort.rs:33:5
+thread 'main' panicked at 'assertion failed: `(1 + 1) == (5)`
+1 + 1: `2`,
+    5: `5`', $DIR/test-panic-abort.rs:33:5
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 
 


### PR DESCRIPTION
Improve error message for `assert_eq` and `assert_ne` macros, by printing the expressions instead of `left` and `right`.

Example:
```rust
assert_eq!(1 + 1, 5);
```
now gives
```
thread 'main' panicked at 'assertion failed: `(1 + 1) == (5)`
1 + 1: `2`,
    5: `5`
```
instead of
```
thread 'main' panicked at 'assertion failed: `(left == right)`
  left: `2`,
 right: `5`,
```

This may greatly improve debugging experience.