### PR TITLE
mir: mark mir construction temporaries as internal

### DIFF
--- a/src/librustc_mir_build/build/misc.rs
+++ b/src/librustc_mir_build/build/misc.rs
@@ -15,7 +15,9 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
     /// N.B., **No cleanup is scheduled for this temporary.** You should
     /// call `schedule_drop` once the temporary is initialized.
     crate fn temp(&mut self, ty: Ty<'tcx>, span: Span) -> Place<'tcx> {
-        let temp = self.local_decls.push(LocalDecl::new(ty, span));
+        // Mark this local as internal to avoid temporaries with types not present in the
+        // user's code resulting in ICEs from the generator transform.
+        let temp = self.local_decls.push(LocalDecl::new(ty, span).internal());
         let place = Place::from(temp);
         debug!("temp: created temp {:?} with type {:?}", place, self.local_decls[temp].ty);
         place

--- a/src/test/ui/issue-73914.rs
+++ b/src/test/ui/issue-73914.rs
@@ -1,0 +1,30 @@
+// build-pass
+// compile-flags:-Copt-level=0
+// edition:2018
+
+struct S<T>(std::marker::PhantomData<T>);
+
+impl<T> std::ops::Deref for S<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        todo!()
+    }
+}
+impl<T> std::ops::DerefMut for S<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        todo!()
+    }
+}
+
+async fn new() -> S<u64> {
+    todo!()
+}
+
+async fn crash() {
+    *new().await = 1 + 1;
+}
+
+fn main() {
+    let _ = crash();
+}


### PR DESCRIPTION
Fixes #73914.

This PR marks temporaries from MIR construction as internal such that they are skipped in `sanitize_witness` (where each MIR local is checked to have been contained within the generator interior computed during typeck). This resolves an ICE whereby the construction of checked addition introduced a `(u64, bool)` temporary which was not in the HIR and thus not in the generator interior.

r? @matthewjasper 