### PR TITLE
Use `Span`s to identify unreachable subpatterns in or-patterns

### DIFF
--- a/src/librustc_mir_build/hair/pattern/check_match.rs
+++ b/src/librustc_mir_build/hair/pattern/check_match.rs
@@ -392,8 +392,8 @@ fn check_arms<'p, 'tcx>(
                 }
             }
             Useful(unreachable_subpatterns) => {
-                for pat in unreachable_subpatterns {
-                    unreachable_pattern(cx.tcx, pat.span, id, None);
+                for span in unreachable_subpatterns {
+                    unreachable_pattern(cx.tcx, span, id, None);
                 }
             }
             UsefulWithWitness(_) => bug!(),

--- a/src/test/ui/or-patterns/exhaustiveness-unreachable-pattern.rs
+++ b/src/test/ui/or-patterns/exhaustiveness-unreachable-pattern.rs
@@ -29,6 +29,9 @@ fn main() {
         (1, 4 | 5) => {} //~ ERROR unreachable pattern
         _ => {}
     }
+    match (true, true) {
+        (false | true, false | true) => (),
+    }
     match (Some(0u8),) {
         (None | Some(1 | 2),) => {}
         (Some(1),) => {} //~ ERROR unreachable pattern
@@ -66,5 +69,30 @@ fn main() {
         Some(0 //~ ERROR unreachable
              | 1) => {}
         _ => {}
+    }
+
+    // A subpattern that is only unreachable in one branch is overall reachable.
+    match (true, true) {
+        (true, true) => {}
+        (false | true, false | true) => {}
+    }
+    match (true, true) {
+        (true, false) => {}
+        (false, true) => {}
+        (false | true, false | true) => {}
+    }
+    // A subpattern that is unreachable in all branches is overall unreachable.
+    match (true, true) {
+        (false, true) => {}
+        (true, true) => {}
+        (false | true, false
+            | true) => {} //~ ERROR unreachable
+    }
+    match (true, true) {
+        (true, false) => {}
+        (true, true) => {}
+        (false
+            | true, //~ ERROR unreachable
+            false | true) => {}
     }
 }

--- a/src/test/ui/or-patterns/exhaustiveness-unreachable-pattern.stderr
+++ b/src/test/ui/or-patterns/exhaustiveness-unreachable-pattern.stderr
@@ -53,52 +53,64 @@ LL |         (1, 4 | 5) => {}
    |         ^^^^^^^^^^
 
 error: unreachable pattern
-  --> $DIR/exhaustiveness-unreachable-pattern.rs:34:9
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:37:9
    |
 LL |         (Some(1),) => {}
    |         ^^^^^^^^^^
 
 error: unreachable pattern
-  --> $DIR/exhaustiveness-unreachable-pattern.rs:35:9
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:38:9
    |
 LL |         (None,) => {}
    |         ^^^^^^^
 
 error: unreachable pattern
-  --> $DIR/exhaustiveness-unreachable-pattern.rs:40:9
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:43:9
    |
 LL |         ((1..=4,),) => {}
    |         ^^^^^^^^^^^
 
 error: unreachable pattern
-  --> $DIR/exhaustiveness-unreachable-pattern.rs:45:14
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:48:14
    |
 LL |         (1 | 1,) => {}
    |              ^
 
 error: unreachable pattern
-  --> $DIR/exhaustiveness-unreachable-pattern.rs:52:15
-   |
-LL |             | 0] => {}
-   |               ^
-
-error: unreachable pattern
-  --> $DIR/exhaustiveness-unreachable-pattern.rs:50:15
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:53:15
    |
 LL |             | 0
    |               ^
 
 error: unreachable pattern
-  --> $DIR/exhaustiveness-unreachable-pattern.rs:60:10
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:55:15
+   |
+LL |             | 0] => {}
+   |               ^
+
+error: unreachable pattern
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:63:10
    |
 LL |         [1
    |          ^
 
 error: unreachable pattern
-  --> $DIR/exhaustiveness-unreachable-pattern.rs:66:14
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:69:14
    |
 LL |         Some(0
    |              ^
 
-error: aborting due to 16 previous errors
+error: unreachable pattern
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:89:15
+   |
+LL |             | true) => {}
+   |               ^^^^
+
+error: unreachable pattern
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:95:15
+   |
+LL |             | true,
+   |               ^^^^
+
+error: aborting due to 18 previous errors
 

--- a/src/test/ui/or-patterns/search-via-bindings.rs
+++ b/src/test/ui/or-patterns/search-via-bindings.rs
@@ -3,7 +3,6 @@
 // run-pass
 
 #![feature(or_patterns)]
-#![allow(unreachable_patterns)] // FIXME(or-patterns) this shouldn't trigger
 
 fn search(target: (bool, bool, bool)) -> u32 {
     let x = ((false, true), (false, true), (false, true));


### PR DESCRIPTION
Fixes #71977