### PR TITLE
Remove some `ignore-stage1` annotations.

### DIFF
--- a/src/test/compile-fail/asm-src-loc-codegen-units.rs
+++ b/src/test/compile-fail/asm-src-loc-codegen-units.rs
@@ -1,5 +1,3 @@
-// WONTFIX(#20184) Needs landing pads (not present in stage1) or the compiler hangs.
-// ignore-stage1
 // compile-flags: -C codegen-units=2
 // ignore-emscripten
 

--- a/src/test/run-make-fulldeps/issue-37839/Makefile
+++ b/src/test/run-make-fulldeps/issue-37839/Makefile
@@ -1,7 +1,5 @@
 -include ../tools.mk
 
-# ignore-stage1
-
 all:
 	$(RUSTC) a.rs && $(RUSTC) b.rs
 	$(BARE_RUSTC) c.rs -L dependency=$(TMPDIR) --extern b=$(TMPDIR)/libb.rlib \

--- a/src/test/run-make-fulldeps/issue-37893/Makefile
+++ b/src/test/run-make-fulldeps/issue-37893/Makefile
@@ -1,6 +1,4 @@
 -include ../tools.mk
 
-# ignore-stage1
-
 all:
 	$(RUSTC) a.rs && $(RUSTC) b.rs && $(RUSTC) c.rs


### PR DESCRIPTION
These tests appear to no longer need the `ignore-stage1` marker.

- `run-make-fulldeps/issue-37839` and `run-make-fulldeps/issue-37893`: I believe these were due to the use of proc-macros, and probably were just missed in #49219 which fixed the proc-macro compatibility.

- `compile-fail/asm-src-loc-codegen-units.rs`: This was due to an old issue with landing pads (as mentioned in the linked issue #20184). `-Zno-landing-pads` was an option when building the first stage (it was much faster), but somewhere along the way (I think the switch from makefiles to rustbuild), the option was removed.
  - NOTE: This test doesn't actually test what it was originally written for, and is probably mostly pointless now. This test was asserting the message "build without -C codegen-units for more exact errors", but that was removed in #42682. It is now in essence identical to `asm-src-loc.rs`.
