### PR TITLE
Avoid hashing length for ty::List

### DIFF
--- a/src/librustc_middle/ich/impls_ty.rs
+++ b/src/librustc_middle/ich/impls_ty.rs
@@ -17,12 +17,12 @@ where
 {
     fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
         thread_local! {
-            static CACHE: RefCell<FxHashMap<(usize, usize), Fingerprint>> =
+            static CACHE: RefCell<FxHashMap<usize, Fingerprint>> =
                 RefCell::new(Default::default());
         }
 
         let hash = CACHE.with(|cache| {
-            let key = (self.as_ptr() as usize, self.len());
+            let key = *self as *const ty::List<T> as usize;
             if let Some(&hash) = cache.borrow().get(&key) {
                 return hash;
             }


### PR DESCRIPTION
r? @ghost -- let's gather perf stats first, see also https://rust-lang.zulipchat.com/#narrow/stream/131828-t-compiler/topic/ty.3A.3AList.20StableHash