### PR TITLE
Remove `.md` to avoid going to a 404 page

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,5 +4,5 @@ Thank you for your interest in contributing to Rust!
 
 To get started, read the [Getting Started] guide in the [rustc-dev-guide].
 
-[Getting Started]: https://rustc-dev-guide.rust-lang.org/getting-started.md
+[Getting Started]: https://rustc-dev-guide.rust-lang.org/getting-started
 [rustc-dev-guide]: https://rustc-dev-guide.rust-lang.org/


### PR DESCRIPTION
A minor one, but I just found this link broken when trying to reach the contributing page :smile: 