### PR TITLE
Bump mingw-check CI image from Ubuntu 16.04 to 18.04.

### DIFF
--- a/src/ci/docker/mingw-check/Dockerfile
+++ b/src/ci/docker/mingw-check/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
   g++ \


### PR DESCRIPTION
I chose 18.04 because we use it for other builders, and it's enough to get a version of MinGW that can build `libssh2-sys`.

This is a prereq for #73902, where `libssh2-sys` shows up as an indirect dependency of `x.py check src/tools/semverver` (through `src/tools/cargo`, which we don't currently `x.py check` because it's not in-tree). See also https://github.com/rust-lang/rust/pull/73902#issuecomment-652414502.

r? @Mark-Simulacrum cc @mati865