### PR TITLE
Add support for storing code model to LLVM module IR

### DIFF
--- a/src/librustc_codegen_llvm/back/write.rs
+++ b/src/librustc_codegen_llvm/back/write.rs
@@ -108,7 +108,7 @@ fn to_llvm_relocation_model(relocation_model: RelocModel) -> llvm::RelocModel {
     }
 }
 
-fn to_llvm_code_model(code_model: Option<CodeModel>) -> llvm::CodeModel {
+pub fn to_llvm_code_model(code_model: Option<CodeModel>) -> llvm::CodeModel {
     match code_model {
         Some(CodeModel::Tiny) => llvm::CodeModel::Tiny,
         Some(CodeModel::Small) => llvm::CodeModel::Small,

--- a/src/librustc_codegen_llvm/back/write.rs
+++ b/src/librustc_codegen_llvm/back/write.rs
@@ -108,7 +108,7 @@ fn to_llvm_relocation_model(relocation_model: RelocModel) -> llvm::RelocModel {
     }
 }
 
-pub fn to_llvm_code_model(code_model: Option<CodeModel>) -> llvm::CodeModel {
+pub(crate) fn to_llvm_code_model(code_model: Option<CodeModel>) -> llvm::CodeModel {
     match code_model {
         Some(CodeModel::Tiny) => llvm::CodeModel::Tiny,
         Some(CodeModel::Small) => llvm::CodeModel::Small,

--- a/src/librustc_codegen_llvm/context.rs
+++ b/src/librustc_codegen_llvm/context.rs
@@ -182,6 +182,11 @@ pub unsafe fn create_module(
         }
     }
 
+    // Linking object files with different code models is undefined behavior
+    // because the compiler would have to generate additional code (to span
+    // longer jumps) if a larger code model is used with a smaller one.
+    //
+    // See https://reviews.llvm.org/D52322 and https://reviews.llvm.org/D52323.
     llvm::LLVMRustSetModuleCodeModel(llmod, to_llvm_code_model(sess.code_model()));
 
     // If skipping the PLT is enabled, we need to add some module metadata

--- a/src/librustc_codegen_llvm/llvm/ffi.rs
+++ b/src/librustc_codegen_llvm/llvm/ffi.rs
@@ -2129,6 +2129,7 @@ extern "C" {
     pub fn LLVMRustUnsetComdat(V: &Value);
     pub fn LLVMRustSetModulePICLevel(M: &Module);
     pub fn LLVMRustSetModulePIELevel(M: &Module);
+    pub fn LLVMRustSetModuleCodeModel(M: &Module, Model: CodeModel);
     pub fn LLVMRustModuleBufferCreate(M: &Module) -> &'static mut ModuleBuffer;
     pub fn LLVMRustModuleBufferPtr(p: &ModuleBuffer) -> *const u8;
     pub fn LLVMRustModuleBufferLen(p: &ModuleBuffer) -> usize;

--- a/src/rustllvm/PassWrapper.cpp
+++ b/src/rustllvm/PassWrapper.cpp
@@ -1163,12 +1163,6 @@ extern "C" void LLVMRustSetModulePIELevel(LLVMModuleRef M) {
   unwrap(M)->setPIELevel(PIELevel::Level::Large);
 }
 
-//  Linking object files with different code models is undefined behavior
-//  because the compiler would have to generate additional code (to span
-//  longer jumps) if a larger code model is used with a smaller one.
-//  Therefore we will treat attempts to mix code models as an error.
-//
-// See https://reviews.llvm.org/D52322 and https://reviews.llvm.org/D52323.
 extern "C" void LLVMRustSetModuleCodeModel(LLVMModuleRef M,
                                            LLVMRustCodeModel Model) {
   auto CM = fromRust(Model);

--- a/src/rustllvm/PassWrapper.cpp
+++ b/src/rustllvm/PassWrapper.cpp
@@ -1163,6 +1163,20 @@ extern "C" void LLVMRustSetModulePIELevel(LLVMModuleRef M) {
   unwrap(M)->setPIELevel(PIELevel::Level::Large);
 }
 
+//  Linking object files with different code models is undefined behavior
+//  because the compiler would have to generate additional code (to span
+//  longer jumps) if a larger code model is used with a smaller one.
+//  Therefore we will treat attempts to mix code models as an error.
+//
+// See https://reviews.llvm.org/D52322 and https://reviews.llvm.org/D52323.
+extern "C" void LLVMRustSetModuleCodeModel(LLVMModuleRef M,
+                                           LLVMRustCodeModel Model) {
+  auto CM = fromRust(Model);
+  if (!CM.hasValue())
+    return;
+  unwrap(M)->setCodeModel(*CM);
+}
+
 // Here you'll find an implementation of ThinLTO as used by the Rust compiler
 // right now. This ThinLTO support is only enabled on "recent ish" versions of
 // LLVM, and otherwise it's just blanket rejected from other compilers.

--- a/src/test/codegen/codemodels.rs
+++ b/src/test/codegen/codemodels.rs
@@ -1,0 +1,21 @@
+// revisions: NOMODEL MODEL-TINY MODEL-SMALL MODEL-KERNEL MODEL-MEDIUM MODEL-LARGE
+//[NOMODEL] compile-flags:
+//[MODEL-TINY] compile-flags: --target=riscv32i-unknown-none-elf -C code-model=tiny
+//[MODEL-SMALL] compile-flags: -C code-model=small
+//[MODEL-KERNEL] compile-flags: --target=x86_64-unknown-linux-gnu -C code-model=kernel
+//[MODEL-MEDIUM] compile-flags: --target=x86_64-unknown-linux-gnu -C code-model=medium
+//[MODEL-LARGE] compile-flags: -C code-model=large
+
+#![crate_type = "lib"]
+
+// MODEL-TINY: !llvm.module.flags = !{{{.*}}}
+// MODEL-TINY: !(([0-9]+)) = !(i32 1, !"Code-Model", i32 0)
+// MODEL-SMALL: !llvm.module.flags = !{{{.*}}}
+// MODEL-SMALL: !{{[0-9]+}} = !{i32 1, !"Code Model", i32 1}
+// MODEL-KERNEL: !llvm.module.flags = !{{{.*}}}
+// MODEL-KERNEL: !{{[0-9]+}} = !{i32 1, !"Code Model", i32 2}
+// MODEL-MEDIUM: !llvm.module.flags = !{{{.*}}}
+// MODEL-MEDIUM: !{{[0-9]+}} = !{i32 1, !"Code Model", i32 3}
+// MODEL-LARGE: !llvm.module.flags = !{{{.*}}}
+// MODEL-LARGE: !{{[0-9]+}} = !{i32 1, !"Code Model", i32 4}
+// NOMODEL-NOT: Code Model

--- a/src/test/codegen/codemodels.rs
+++ b/src/test/codegen/codemodels.rs
@@ -1,8 +1,8 @@
 // revisions: NOMODEL MODEL-SMALL MODEL-KERNEL MODEL-MEDIUM MODEL-LARGE
 //[NOMODEL] compile-flags:
 //[MODEL-SMALL] compile-flags: -C code-model=small
-//[MODEL-KERNEL] compile-flags: --target=x86_64-unknown-linux-gnu -C code-model=kernel
-//[MODEL-MEDIUM] compile-flags: --target=x86_64-unknown-linux-gnu -C code-model=medium
+//[MODEL-KERNEL] compile-flags: -C code-model=kernel
+//[MODEL-MEDIUM] compile-flags: -C code-model=medium
 //[MODEL-LARGE] compile-flags: -C code-model=large
 
 #![crate_type = "lib"]

--- a/src/test/codegen/codemodels.rs
+++ b/src/test/codegen/codemodels.rs
@@ -1,6 +1,5 @@
-// revisions: NOMODEL MODEL-TINY MODEL-SMALL MODEL-KERNEL MODEL-MEDIUM MODEL-LARGE
+// revisions: NOMODEL MODEL-SMALL MODEL-KERNEL MODEL-MEDIUM MODEL-LARGE
 //[NOMODEL] compile-flags:
-//[MODEL-TINY] compile-flags: --target=riscv32i-unknown-none-elf -C code-model=tiny
 //[MODEL-SMALL] compile-flags: -C code-model=small
 //[MODEL-KERNEL] compile-flags: --target=x86_64-unknown-linux-gnu -C code-model=kernel
 //[MODEL-MEDIUM] compile-flags: --target=x86_64-unknown-linux-gnu -C code-model=medium
@@ -8,8 +7,6 @@
 
 #![crate_type = "lib"]
 
-// MODEL-TINY: !llvm.module.flags = !{{{.*}}}
-// MODEL-TINY: !(([0-9]+)) = !(i32 1, !"Code-Model", i32 0)
 // MODEL-SMALL: !llvm.module.flags = !{{{.*}}}
 // MODEL-SMALL: !{{[0-9]+}} = !{i32 1, !"Code Model", i32 1}
 // MODEL-KERNEL: !llvm.module.flags = !{{{.*}}}


### PR DESCRIPTION
This patch avoids undefined behavior by linking different object files.
Also this would it could be propagated properly to LTO.

See https://reviews.llvm.org/D52322 and https://reviews.llvm.org/D52323.