### PR TITLE
Fix links to Getting Started page

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,5 +4,5 @@ Thank you for your interest in contributing to Rust!
 
 To get started, read the [Getting Started] guide in the [rustc-dev-guide].
 
-[Getting Started]: https://rustc-dev-guide.rust-lang.org/getting-started.md
+[Getting Started]: https://rustc-dev-guide.rust-lang.org/getting-started.html
 [rustc-dev-guide]: https://rustc-dev-guide.rust-lang.org/

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The Rust build system uses a Python script called `x.py` to build the compiler,
 which manages the bootstrapping process. More information about it can be found 
 by running `./x.py --help` or reading the [rustc dev guide][rustcguidebuild].
 
-[gettingstarted]: https://rustc-dev-guide.rust-lang.org/getting-started.md
+[gettingstarted]: https://rustc-dev-guide.rust-lang.org/getting-started.html
 [rustcguidebuild]: https://rustc-dev-guide.rust-lang.org/building/how-to-build-and-run.html
 
 ### Building on a Unix-like system


### PR DESCRIPTION
The `*.md` links go to a 404, so I assume they're meant to be `*.html`. First commit so let me know if I'm doing anything incorrectly!