### PR TITLE
?Sized bounds for rc::Weak::as_ptr and friends

### DIFF
--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -1675,7 +1675,14 @@ impl<T> Weak<T> {
     pub fn new() -> Weak<T> {
         Weak { ptr: NonNull::new(usize::MAX as *mut RcBox<T>).expect("MAX is not 0") }
     }
+}
 
+pub(crate) fn is_dangling<T: ?Sized>(ptr: NonNull<T>) -> bool {
+    let address = ptr.as_ptr() as *mut () as usize;
+    address == usize::MAX
+}
+
+impl<T: ?Sized> Weak<T> {
     /// Returns a raw pointer to the object `T` pointed to by this `Weak<T>`.
     ///
     /// The pointer is valid only if there are some strong references. The pointer may be dangling,
@@ -1808,14 +1815,7 @@ impl<T> Weak<T> {
             }
         }
     }
-}
 
-pub(crate) fn is_dangling<T: ?Sized>(ptr: NonNull<T>) -> bool {
-    let address = ptr.as_ptr() as *mut () as usize;
-    address == usize::MAX
-}
-
-impl<T: ?Sized> Weak<T> {
     /// Attempts to upgrade the `Weak` pointer to an [`Rc`], delaying
     /// dropping of the inner value if successful.
     ///


### PR DESCRIPTION
Specifically, this relaxes the bounds on `rc::Weak::as_ptr`, `into_raw`, and `from_raw` from `impl<T> Weak<T>` to `impl<T: ?Sized> Weak<T>`.

This is a follow-up to #73845, which did the impl work required to be able to relax these bounds.

IIUC, this technically stabilizes that "something like [`size_of_val_raw`](https://doc.rust-lang.org/nightly/core/mem/fn.size_of_val_raw.html)" is possible to do. However, I believe the part of the functionality required by these methods here -- specifically, getting the size of a pointee from a pointer where it may be dangling iff the pointee is `Sized` -- is uncontroversial enough to stabilize these methods without a way to implement them on stable Rust.

ATTN: This changes (relaxes) the (input) generic bounds on stable `fn`!