### PR TITLE
Add slice::contains_ref to supplement slice::contains

### DIFF
--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -1412,6 +1412,7 @@ impl<T> [T] {
     /// # Examples
     ///
     /// ```
+    /// # #![feature(contains_ref)]
     /// let v = [String::from("Hello"), String::from("world")];
     /// assert!(v.contains_ref("Hello"));
     /// assert!(!v.contains_ref("Rust"));
@@ -1420,6 +1421,7 @@ impl<T> [T] {
     pub fn contains_ref<U>(&self, x: &U) -> bool
     where
         T: PartialEq<U>,
+        U: ?Sized,
     {
         self.iter().any(|e| e == x)
     }

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -1407,6 +1407,23 @@ impl<T> [T] {
         x.slice_contains(self)
     }
 
+    /// Returns `true` if the slice contains an element with the given value.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let v = [String::from("Hello"), String::from("world")];
+    /// assert!(v.contains_ref("Hello"));
+    /// assert!(!v.contains_ref("Rust"));
+    /// ```
+    #[unstable(feature = "contains_ref", issue = "none")]
+    pub fn contains_ref<U>(&self, x: &U) -> bool
+    where
+        T: PartialEq<U>,
+    {
+        self.iter().any(|e| e == x)
+    }
+
     /// Returns `true` if `needle` is a prefix of the slice.
     ///
     /// # Examples

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -1412,7 +1412,7 @@ impl<T> [T] {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(contains_ref)]
+    /// #![feature(contains_ref)]
     /// let v = [String::from("Hello"), String::from("world")];
     /// assert!(v.contains_ref("Hello"));
     /// assert!(!v.contains_ref("Rust"));


### PR DESCRIPTION
Fixes #42671.

This adds the last function proposed in #42671:

```rust
pub fn contains_ref<U>(&self, x: &U) -> bool where T: PartialEq<U>, U: ?Sized { /* ... */ }
```

I simply used `self.iter().any(|e| e == x)` as a first implementation, I don't know if there is a more optimised version possible.

I put an `unstable` flag, should I create a tracking issue for this ? I don't know if this is a "big enough" feature for it ?

@rustbot modify labels: A-collections,C-enhancement,T-doc,T-libs