### PR TITLE
variant_count: avoid incorrect dummy implementation

### DIFF
--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -2004,12 +2004,6 @@ extern "rust-intrinsic" {
     pub fn ptr_guaranteed_ne<T>(ptr: *const T, other: *const T) -> bool;
 }
 
-#[rustc_const_unstable(feature = "variant_count", issue = "73662")]
-#[cfg(bootstrap)]
-pub const fn variant_count<T>() -> usize {
-    0
-}
-
 // Some functions are defined here because they accidentally got made
 // available in this module on stable. See <https://github.com/rust-lang/rust/issues/15702>.
 // (`transmute` also falls into this category, but it cannot be wrapped due to the

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -125,7 +125,7 @@
 #![feature(unsized_locals)]
 #![feature(untagged_unions)]
 #![feature(unwind_attributes)]
-#![feature(variant_count)]
+#![cfg_attr(not(bootstrap), feature(variant_count))]
 #![feature(doc_alias)]
 #![feature(mmx_target_feature)]
 #![feature(tbm_target_feature)]

--- a/src/libcore/mem/mod.rs
+++ b/src/libcore/mem/mod.rs
@@ -1037,6 +1037,7 @@ pub const fn discriminant<T>(v: &T) -> Discriminant<T> {
 /// assert_eq!(mem::variant_count::<Result<!, !>>(), 2);
 /// ```
 #[inline(always)]
+#[cfg(not(bootstrap))]
 #[unstable(feature = "variant_count", issue = "73662")]
 #[rustc_const_unstable(feature = "variant_count", issue = "73662")]
 pub const fn variant_count<T>() -> usize {


### PR DESCRIPTION
This also avoids a stage 0 doctest failure.