### PR TITLE
rustdoc: Restore underline text decoration on hover for FQN in header

### DIFF
--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -100,6 +100,9 @@ h1.fqn {
 	border-bottom: 1px dashed;
 	margin-top: 0;
 }
+h1.fqn > .in-band > a:hover {
+	text-decoration: underline;
+}
 h2, h3:not(.impl):not(.method):not(.type):not(.tymethod), h4:not(.method):not(.type):not(.tymethod):not(.associatedconstant) {
 	border-bottom: 1px solid;
 }


### PR DESCRIPTION
This causes the components of FQN's (e.g. `std`, `net`, and `Ipv4Addr` of the FQN `std::net::Ipv4Addr`) to behave similarly to other links in the contents of rustdoc-styled pages. When the user hovers over them, more clearly indicating that they can be used for navigation.

I (and I hope others at least in part) have found the prior design to be somewhat confusing, as it is not clear (upon hovering) that the various parts of the FQN are actually links that the user can navigate to.

<details><summary>📸 Before, mouse hovered over "net" in the FQN</summary>
<img alt="A rustdoc page with the mouse hovered over the fully-qualified name in the page header, producing no visual change" src="https://user-images.githubusercontent.com/1566689/86538363-4c827000-bebb-11ea-8291-5ea6b85d7e19.png" />
</details>
<details><summary>📸 After, mouse hovered over "net" in the FQN</summary>
<img alt="A rustdoc page with the mouse hovered over the fully-qualified name in the page header, now with an underline showing up under the word hovered over by the mouse" src="https://user-images.githubusercontent.com/1566689/86538471-d3374d00-bebb-11ea-9bb3-7aa2d7a4800b.png" />
</details>