### PR TITLE
Fix the return type of Windows' `OpenOptionsExt::security_qos_flags`.

### DIFF
--- a/src/libstd/sys/windows/ext/fs.rs
+++ b/src/libstd/sys/windows/ext/fs.rs
@@ -259,7 +259,7 @@ pub trait OpenOptionsExt {
     /// [Impersonation Levels]:
     ///     https://docs.microsoft.com/en-us/windows/win32/api/winnt/ne-winnt-security_impersonation_level
     #[stable(feature = "open_options_ext", since = "1.10.0")]
-    fn security_qos_flags(&mut self, flags: u32) -> &mut OpenOptions;
+    fn security_qos_flags(&mut self, flags: u32) -> &mut Self;
 }
 
 #[stable(feature = "open_options_ext", since = "1.10.0")]


### PR DESCRIPTION
This adjusts the return type of Windows' `OpenOptionsExt::security_qos_flags`
to be consistent with the other functions in the trait.