### PR TITLE
Add `RawFd` to WASI's `std::os::wasi::prelude`.

### DIFF
--- a/src/libstd/sys/wasi/ext/mod.rs
+++ b/src/libstd/sys/wasi/ext/mod.rs
@@ -18,5 +18,5 @@ pub mod prelude {
     pub use crate::sys::ext::fs::{DirEntryExt, FileExt, MetadataExt, OpenOptionsExt};
     #[doc(no_inline)]
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub use crate::sys::ext::io::{AsRawFd, FromRawFd, IntoRawFd};
+    pub use crate::sys::ext::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 }


### PR DESCRIPTION
Add `RawFd` to WASI's `std::os::wasi::prelude`, making it consistent
with all other platforms which also have `AsRawFd`, `FromRawFd`, and
`IntoRawFd` in their respective preludes.