### PR TITLE
Use relative path for local links to primitives

### DIFF
--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -628,6 +628,7 @@ impl Attributes {
     /// Cache must be populated before call
     pub fn links(&self, krate: &CrateNum) -> Vec<(String, String)> {
         use crate::html::format::href;
+        use crate::html::render::CURRENT_DEPTH;
 
         self.links
             .iter()
@@ -648,12 +649,13 @@ impl Attributes {
                         if let Some(ref fragment) = *fragment {
                             let cache = cache();
                             let url = match cache.extern_locations.get(krate) {
-                                Some(&(_, ref src, ExternalLocation::Local)) => {
-                                    src.to_str().expect("invalid file path")
+                                Some(&(_, _, ExternalLocation::Local)) => {
+                                    let depth = CURRENT_DEPTH.with(|l| l.get());
+                                    "../".repeat(depth)
                                 }
-                                Some(&(_, _, ExternalLocation::Remote(ref s))) => s,
+                                Some(&(_, _, ExternalLocation::Remote(ref s))) => s.to_string(),
                                 Some(&(_, _, ExternalLocation::Unknown)) | None => {
-                                    "https://doc.rust-lang.org/nightly"
+                                    String::from("https://doc.rust-lang.org/nightly")
                                 }
                             };
                             // This is a primitive so the url is done "by hand".

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -649,14 +649,16 @@ impl Attributes {
                         if let Some(ref fragment) = *fragment {
                             let cache = cache();
                             let url = match cache.extern_locations.get(krate) {
-                                Some(&(_, _, ExternalLocation::Local)) => {
+                                Some(&(ref krate_name, _, ExternalLocation::Local))
+                                    if krate_name == "core" =>
+                                {
                                     let depth = CURRENT_DEPTH.with(|l| l.get());
                                     "../".repeat(depth)
                                 }
                                 Some(&(_, _, ExternalLocation::Remote(ref s))) => s.to_string(),
-                                Some(&(_, _, ExternalLocation::Unknown)) | None => {
-                                    String::from("https://doc.rust-lang.org/nightly")
-                                }
+                                Some(&(_, _, ExternalLocation::Local))
+                                | Some(&(_, _, ExternalLocation::Unknown))
+                                | None => String::from("https://doc.rust-lang.org/nightly"),
                             };
                             // This is a primitive so the url is done "by hand".
                             let tail = fragment.find('#').unwrap_or_else(|| fragment.len());

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -649,16 +649,14 @@ impl Attributes {
                         if let Some(ref fragment) = *fragment {
                             let cache = cache();
                             let url = match cache.extern_locations.get(krate) {
-                                Some(&(ref krate_name, _, ExternalLocation::Local))
-                                    if krate_name == "core" =>
-                                {
+                                Some(&(_, _, ExternalLocation::Local)) => {
                                     let depth = CURRENT_DEPTH.with(|l| l.get());
                                     "../".repeat(depth)
                                 }
                                 Some(&(_, _, ExternalLocation::Remote(ref s))) => s.to_string(),
-                                Some(&(_, _, ExternalLocation::Local))
-                                | Some(&(_, _, ExternalLocation::Unknown))
-                                | None => String::from("https://doc.rust-lang.org/nightly"),
+                                Some(&(_, _, ExternalLocation::Unknown)) | None => {
+                                    String::from("https://doc.rust-lang.org/nightly")
+                                }
                             };
                             // This is a primitive so the url is done "by hand".
                             let tail = fragment.find('#').unwrap_or_else(|| fragment.len());

--- a/src/test/rustdoc/auxiliary/my-core.rs
+++ b/src/test/rustdoc/auxiliary/my-core.rs
@@ -1,5 +1,6 @@
 #![feature(no_core, lang_items)]
 #![no_core]
+#![crate_type="rlib"]
 
 #[lang = "char"]
 impl char {

--- a/src/test/rustdoc/auxiliary/my-core.rs
+++ b/src/test/rustdoc/auxiliary/my-core.rs
@@ -1,0 +1,18 @@
+#![feature(no_core, lang_items)]
+#![no_core]
+
+#[lang = "char"]
+impl char {
+    pub fn len_utf8(self) -> usize {
+        42
+    }
+}
+
+#[lang = "sized"]
+pub trait Sized {}
+
+#[lang = "clone"]
+pub trait Clone: Sized {}
+
+#[lang = "copy"]
+pub trait Copy: Clone {}

--- a/src/test/rustdoc/intra-link-prim-methods-external-core.rs
+++ b/src/test/rustdoc/intra-link-prim-methods-external-core.rs
@@ -1,4 +1,5 @@
 // aux-build:my-core.rs
+// build-aux-docs
 // ignore-cross-compile
 
 #![deny(intra_doc_link_resolution_failure)]

--- a/src/test/rustdoc/intra-link-prim-methods-external-core.rs
+++ b/src/test/rustdoc/intra-link-prim-methods-external-core.rs
@@ -1,0 +1,10 @@
+// aux-build:my-core.rs
+// ignore-cross-compile
+
+#![deny(intra_doc_link_resolution_failure)]
+#![feature(no_core, lang_items)]
+#![no_core]
+
+//! A [`char`] and its [`char::len_utf8`].
+
+extern crate my_core;

--- a/src/test/rustdoc/intra-link-prim-methods-external-core.rs
+++ b/src/test/rustdoc/intra-link-prim-methods-external-core.rs
@@ -1,6 +1,7 @@
 // aux-build:my-core.rs
 // build-aux-docs
 // ignore-cross-compile
+// ignore-tidy-linelength
 
 #![deny(intra_doc_link_resolution_failure)]
 #![feature(no_core, lang_items)]

--- a/src/test/rustdoc/intra-link-prim-methods-external-core.rs
+++ b/src/test/rustdoc/intra-link-prim-methods-external-core.rs
@@ -1,6 +1,7 @@
 // aux-build:my-core.rs
 // build-aux-docs
 // ignore-cross-compile
+// ignore-windows
 // ignore-tidy-linelength
 
 #![deny(intra_doc_link_resolution_failure)]

--- a/src/test/rustdoc/intra-link-prim-methods-external-core.rs
+++ b/src/test/rustdoc/intra-link-prim-methods-external-core.rs
@@ -6,6 +6,10 @@
 #![feature(no_core, lang_items)]
 #![no_core]
 
+// @has intra_link_prim_methods_external_core/index.html
+// @has - '//*[@id="main"]//a[@href="https://doc.rust-lang.org/nightly/std/primitive.char.html"]' 'char'
+// @has - '//*[@id="main"]//a[@href="https://doc.rust-lang.org/nightly/std/primitive.char.html#method.len_utf8"]' 'char::len_utf8'
+
 //! A [`char`] and its [`char::len_utf8`].
 
 extern crate my_core;

--- a/src/test/rustdoc/intra-link-prim-methods-external-core.rs
+++ b/src/test/rustdoc/intra-link-prim-methods-external-core.rs
@@ -6,6 +6,7 @@
 #![deny(intra_doc_link_resolution_failure)]
 #![feature(no_core, lang_items)]
 #![no_core]
+#![crate_type = "rlib"]
 
 // @has intra_link_prim_methods_external_core/index.html
 // @has - '//*[@id="main"]//a[@href="https://doc.rust-lang.org/nightly/std/primitive.char.html"]' 'char'

--- a/src/test/rustdoc/intra-link-prim-methods-local.rs
+++ b/src/test/rustdoc/intra-link-prim-methods-local.rs
@@ -1,0 +1,21 @@
+#![deny(intra_doc_link_resolution_failure)]
+#![feature(no_core, lang_items)]
+#![no_core]
+
+//! A [`char`] and its [`char::len_utf8`].
+
+#[lang = "char"]
+impl char {
+    pub fn len_utf8(self) -> usize {
+        42
+    }
+}
+
+#[lang = "sized"]
+pub trait Sized {}
+
+#[lang = "clone"]
+pub trait Clone: Sized {}
+
+#[lang = "copy"]
+pub trait Copy: Clone {}

--- a/src/test/rustdoc/intra-link-prim-methods-local.rs
+++ b/src/test/rustdoc/intra-link-prim-methods-local.rs
@@ -2,6 +2,8 @@
 #![feature(no_core, lang_items)]
 #![no_core]
 
+// ignore-tidy-linelength
+
 // @has intra_link_prim_methods_local/index.html
 // @has - '//*[@id="main"]//a[@href="https://doc.rust-lang.org/nightly/std/primitive.char.html"]' 'char'
 // @has - '//*[@id="main"]//a[@href="https://doc.rust-lang.org/nightly/std/primitive.char.html#method.len_utf8"]' 'char::len_utf8'

--- a/src/test/rustdoc/intra-link-prim-methods-local.rs
+++ b/src/test/rustdoc/intra-link-prim-methods-local.rs
@@ -1,6 +1,7 @@
 #![deny(intra_doc_link_resolution_failure)]
 #![feature(no_core, lang_items)]
 #![no_core]
+#![crate_type = "rlib"]
 
 // ignore-tidy-linelength
 

--- a/src/test/rustdoc/intra-link-prim-methods-local.rs
+++ b/src/test/rustdoc/intra-link-prim-methods-local.rs
@@ -2,6 +2,10 @@
 #![feature(no_core, lang_items)]
 #![no_core]
 
+// @has intra_link_prim_methods_local/index.html
+// @has - '//*[@id="main"]//a[@href="https://doc.rust-lang.org/nightly/std/primitive.char.html"]' 'char'
+// @has - '//*[@id="main"]//a[@href="https://doc.rust-lang.org/nightly/std/primitive.char.html#method.len_utf8"]' 'char::len_utf8'
+
 //! A [`char`] and its [`char::len_utf8`].
 
 #[lang = "char"]

--- a/src/test/rustdoc/intra-link-prim-methods.rs
+++ b/src/test/rustdoc/intra-link-prim-methods.rs
@@ -1,3 +1,7 @@
 #![deny(intra_doc_link_resolution_failure)]
 
+// @has intra_link_prim_methods/index.html
+// @has - '//*[@id="main"]//a[@href="https://doc.rust-lang.org/nightly/std/primitive.char.html"]' 'char'
+// @has - '//*[@id="main"]//a[@href="https://doc.rust-lang.org/nightly/std/primitive.char.html#method.len_utf8"]' 'char::len_utf8'
+
 //! A [`char`] and its [`char::len_utf8`].

--- a/src/test/rustdoc/intra-link-prim-methods.rs
+++ b/src/test/rustdoc/intra-link-prim-methods.rs
@@ -1,5 +1,7 @@
 #![deny(intra_doc_link_resolution_failure)]
 
+// ignore-tidy-linelength
+
 // @has intra_link_prim_methods/index.html
 // @has - '//*[@id="main"]//a[@href="https://doc.rust-lang.org/nightly/std/primitive.char.html"]' 'char'
 // @has - '//*[@id="main"]//a[@href="https://doc.rust-lang.org/nightly/std/primitive.char.html#method.len_utf8"]' 'char::len_utf8'


### PR DESCRIPTION
Else, links to `char::foo` would point into `/path/to/src/libcore/std/primitive.char.html#method.foo`.

Split out from #73804.