### PR TITLE
Eliminate confusing "globals" terminology.

### DIFF
--- a/src/librustc_ast/lib.rs
+++ b/src/librustc_ast/lib.rs
@@ -43,7 +43,7 @@ pub mod util {
 
 pub mod ast;
 pub mod attr;
-pub use attr::{with_default_globals, with_globals, GLOBALS};
+pub use attr::{with_default_session_globals, with_session_globals, SESSION_GLOBALS};
 pub mod crate_disambiguator;
 pub mod entry;
 pub mod expand;

--- a/src/librustc_ast/util/lev_distance/tests.rs
+++ b/src/librustc_ast/util/lev_distance/tests.rs
@@ -21,8 +21,8 @@ fn test_lev_distance() {
 
 #[test]
 fn test_find_best_match_for_name() {
-    use crate::with_default_globals;
-    with_default_globals(|| {
+    use crate::with_default_session_globals;
+    with_default_session_globals(|| {
         let input = vec![Symbol::intern("aaab"), Symbol::intern("aaabc")];
         assert_eq!(
             find_best_match_for_name(input.iter(), "aaaa", None),

--- a/src/librustc_ast_pretty/pprust/tests.rs
+++ b/src/librustc_ast_pretty/pprust/tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 use rustc_ast::ast;
-use rustc_ast::with_default_globals;
+use rustc_ast::with_default_session_globals;
 use rustc_span::source_map::respan;
 use rustc_span::symbol::Ident;
 
@@ -25,7 +25,7 @@ fn variant_to_string(var: &ast::Variant) -> String {
 
 #[test]
 fn test_fun_to_string() {
-    with_default_globals(|| {
+    with_default_session_globals(|| {
         let abba_ident = Ident::from_str("abba");
 
         let decl =
@@ -40,7 +40,7 @@ fn test_fun_to_string() {
 
 #[test]
 fn test_variant_to_string() {
-    with_default_globals(|| {
+    with_default_session_globals(|| {
         let ident = Ident::from_str("principal_skinner");
 
         let var = ast::Variant {

--- a/src/librustc_errors/json/tests.rs
+++ b/src/librustc_errors/json/tests.rs
@@ -39,16 +39,16 @@ impl<T: Write> Write for Shared<T> {
     }
 }
 
-fn with_default_globals(f: impl FnOnce()) {
-    let globals = rustc_span::Globals::new(rustc_span::edition::DEFAULT_EDITION);
-    rustc_span::GLOBALS.set(&globals, || rustc_span::GLOBALS.set(&globals, f))
+fn with_default_session_globals(f: impl FnOnce()) {
+    let session_globals = rustc_span::SessionGlobals::new(rustc_span::edition::DEFAULT_EDITION);
+    rustc_span::SESSION_GLOBALS.set(&session_globals, f);
 }
 
 /// Test the span yields correct positions in JSON.
 fn test_positions(code: &str, span: (u32, u32), expected_output: SpanTestData) {
     let expected_output = TestData { spans: vec![expected_output] };
 
-    with_default_globals(|| {
+    with_default_session_globals(|| {
         let sm = Lrc::new(SourceMap::new(FilePathMapping::empty()));
         sm.new_source_file(Path::new("test.rs").to_owned().into(), code.to_owned());
 

--- a/src/librustc_expand/mut_visit/tests.rs
+++ b/src/librustc_expand/mut_visit/tests.rs
@@ -2,7 +2,7 @@ use crate::tests::{matches_codepattern, string_to_crate};
 
 use rustc_ast::ast;
 use rustc_ast::mut_visit::{self, MutVisitor};
-use rustc_ast::with_default_globals;
+use rustc_ast::with_default_session_globals;
 use rustc_ast_pretty::pprust;
 use rustc_span::symbol::Ident;
 
@@ -38,7 +38,7 @@ macro_rules! assert_pred {
 // Make sure idents get transformed everywhere.
 #[test]
 fn ident_transformation() {
-    with_default_globals(|| {
+    with_default_session_globals(|| {
         let mut zz_visitor = ToZzIdentMutVisitor;
         let mut krate =
             string_to_crate("#[a] mod b {fn c (d : e, f : g) {h!(i,j,k);l;m}}".to_string());
@@ -55,7 +55,7 @@ fn ident_transformation() {
 // Make sure idents get transformed even inside macro defs.
 #[test]
 fn ident_transformation_in_defs() {
-    with_default_globals(|| {
+    with_default_session_globals(|| {
         let mut zz_visitor = ToZzIdentMutVisitor;
         let mut krate = string_to_crate(
             "macro_rules! a {(b $c:expr $(d $e:token)f+ => \

--- a/src/librustc_expand/parse/lexer/tests.rs
+++ b/src/librustc_expand/parse/lexer/tests.rs
@@ -1,6 +1,6 @@
 use rustc_ast::token::{self, Token, TokenKind};
 use rustc_ast::util::comments::is_doc_comment;
-use rustc_ast::with_default_globals;
+use rustc_ast::with_default_session_globals;
 use rustc_data_structures::sync::Lrc;
 use rustc_errors::{emitter::EmitterWriter, Handler};
 use rustc_parse::lexer::StringReader;
@@ -33,7 +33,7 @@ fn setup<'a>(sm: &SourceMap, sess: &'a ParseSess, teststr: String) -> StringRead
 
 #[test]
 fn t1() {
-    with_default_globals(|| {
+    with_default_session_globals(|| {
         let sm = Lrc::new(SourceMap::new(FilePathMapping::empty()));
         let sh = mk_sess(sm.clone());
         let mut string_reader = setup(
@@ -79,7 +79,7 @@ fn mk_lit(kind: token::LitKind, symbol: &str, suffix: Option<&str>) -> TokenKind
 
 #[test]
 fn doublecolon_parsing() {
-    with_default_globals(|| {
+    with_default_session_globals(|| {
         let sm = Lrc::new(SourceMap::new(FilePathMapping::empty()));
         let sh = mk_sess(sm.clone());
         check_tokenization(
@@ -91,7 +91,7 @@ fn doublecolon_parsing() {
 
 #[test]
 fn doublecolon_parsing_2() {
-    with_default_globals(|| {
+    with_default_session_globals(|| {
         let sm = Lrc::new(SourceMap::new(FilePathMapping::empty()));
         let sh = mk_sess(sm.clone());
         check_tokenization(
@@ -103,7 +103,7 @@ fn doublecolon_parsing_2() {
 
 #[test]
 fn doublecolon_parsing_3() {
-    with_default_globals(|| {
+    with_default_session_globals(|| {
         let sm = Lrc::new(SourceMap::new(FilePathMapping::empty()));
         let sh = mk_sess(sm.clone());
         check_tokenization(
@@ -115,7 +115,7 @@ fn doublecolon_parsing_3() {
 
 #[test]
 fn doublecolon_parsing_4() {
-    with_default_globals(|| {
+    with_default_session_globals(|| {
         let sm = Lrc::new(SourceMap::new(FilePathMapping::empty()));
         let sh = mk_sess(sm.clone());
         check_tokenization(
@@ -127,7 +127,7 @@ fn doublecolon_parsing_4() {
 
 #[test]
 fn character_a() {
-    with_default_globals(|| {
+    with_default_session_globals(|| {
         let sm = Lrc::new(SourceMap::new(FilePathMapping::empty()));
         let sh = mk_sess(sm.clone());
         assert_eq!(setup(&sm, &sh, "'a'".to_string()).next_token(), mk_lit(token::Char, "a", None),);
@@ -136,7 +136,7 @@ fn character_a() {
 
 #[test]
 fn character_space() {
-    with_default_globals(|| {
+    with_default_session_globals(|| {
         let sm = Lrc::new(SourceMap::new(FilePathMapping::empty()));
         let sh = mk_sess(sm.clone());
         assert_eq!(setup(&sm, &sh, "' '".to_string()).next_token(), mk_lit(token::Char, " ", None),);
@@ -145,7 +145,7 @@ fn character_space() {
 
 #[test]
 fn character_escaped() {
-    with_default_globals(|| {
+    with_default_session_globals(|| {
         let sm = Lrc::new(SourceMap::new(FilePathMapping::empty()));
         let sh = mk_sess(sm.clone());
         assert_eq!(
@@ -157,7 +157,7 @@ fn character_escaped() {
 
 #[test]
 fn lifetime_name() {
-    with_default_globals(|| {
+    with_default_session_globals(|| {
         let sm = Lrc::new(SourceMap::new(FilePathMapping::empty()));
         let sh = mk_sess(sm.clone());
         assert_eq!(
@@ -169,7 +169,7 @@ fn lifetime_name() {
 
 #[test]
 fn raw_string() {
-    with_default_globals(|| {
+    with_default_session_globals(|| {
         let sm = Lrc::new(SourceMap::new(FilePathMapping::empty()));
         let sh = mk_sess(sm.clone());
         assert_eq!(
@@ -181,7 +181,7 @@ fn raw_string() {
 
 #[test]
 fn literal_suffixes() {
-    with_default_globals(|| {
+    with_default_session_globals(|| {
         let sm = Lrc::new(SourceMap::new(FilePathMapping::empty()));
         let sh = mk_sess(sm.clone());
         macro_rules! test {
@@ -232,7 +232,7 @@ fn line_doc_comments() {
 
 #[test]
 fn nested_block_comments() {
-    with_default_globals(|| {
+    with_default_session_globals(|| {
         let sm = Lrc::new(SourceMap::new(FilePathMapping::empty()));
         let sh = mk_sess(sm.clone());
         let mut lexer = setup(&sm, &sh, "/* /* */ */'a'".to_string());
@@ -243,7 +243,7 @@ fn nested_block_comments() {
 
 #[test]
 fn crlf_comments() {
-    with_default_globals(|| {
+    with_default_session_globals(|| {
         let sm = Lrc::new(SourceMap::new(FilePathMapping::empty()));
         let sh = mk_sess(sm.clone());
         let mut lexer = setup(&sm, &sh, "// test\r\n/// test\r\n".to_string());

--- a/src/librustc_expand/parse/tests.rs
+++ b/src/librustc_expand/parse/tests.rs
@@ -5,7 +5,7 @@ use rustc_ast::ptr::P;
 use rustc_ast::token::{self, Token};
 use rustc_ast::tokenstream::{DelimSpan, TokenStream, TokenTree};
 use rustc_ast::visit;
-use rustc_ast::with_default_globals;
+use rustc_ast::with_default_session_globals;
 use rustc_ast_pretty::pprust::item_to_string;
 use rustc_errors::PResult;
 use rustc_parse::new_parser_from_source_str;
@@ -50,7 +50,7 @@ fn string_to_item(source_str: String) -> Option<P<ast::Item>> {
 #[should_panic]
 #[test]
 fn bad_path_expr_1() {
-    with_default_globals(|| {
+    with_default_session_globals(|| {
         string_to_expr("::abc::def::return".to_string());
     })
 }
@@ -58,7 +58,7 @@ fn bad_path_expr_1() {
 // Checks the token-tree-ization of macros.
 #[test]
 fn string_to_tts_macro() {
-    with_default_globals(|| {
+    with_default_session_globals(|| {
         let tts: Vec<_> =
             string_to_stream("macro_rules! zip (($a)=>($a))".to_string()).trees().collect();
         let tts: &[TokenTree] = &tts[..];
@@ -95,7 +95,7 @@ fn string_to_tts_macro() {
 
 #[test]
 fn string_to_tts_1() {
-    with_default_globals(|| {
+    with_default_session_globals(|| {
         let tts = string_to_stream("fn a (b : i32) { b; }".to_string());
 
         let expected = TokenStream::new(vec![
@@ -130,7 +130,7 @@ fn string_to_tts_1() {
 
 #[test]
 fn parse_use() {
-    with_default_globals(|| {
+    with_default_session_globals(|| {
         let use_s = "use foo::bar::baz;";
         let vitem = string_to_item(use_s.to_string()).unwrap();
         let vitem_s = item_to_string(&vitem);
@@ -145,7 +145,7 @@ fn parse_use() {
 
 #[test]
 fn parse_extern_crate() {
-    with_default_globals(|| {
+    with_default_session_globals(|| {
         let ex_s = "extern crate foo;";
         let vitem = string_to_item(ex_s.to_string()).unwrap();
         let vitem_s = item_to_string(&vitem);
@@ -183,7 +183,7 @@ fn get_spans_of_pat_idents(src: &str) -> Vec<Span> {
 
 #[test]
 fn span_of_self_arg_pat_idents_are_correct() {
-    with_default_globals(|| {
+    with_default_session_globals(|| {
         let srcs = [
             "impl z { fn a (&self, &myarg: i32) {} }",
             "impl z { fn a (&mut self, &myarg: i32) {} }",
@@ -207,7 +207,7 @@ fn span_of_self_arg_pat_idents_are_correct() {
 
 #[test]
 fn parse_exprs() {
-    with_default_globals(|| {
+    with_default_session_globals(|| {
         // just make sure that they parse....
         string_to_expr("3 + 4".to_string());
         string_to_expr("a::z.froob(b,&(987+3))".to_string());
@@ -216,7 +216,7 @@ fn parse_exprs() {
 
 #[test]
 fn attrs_fix_bug() {
-    with_default_globals(|| {
+    with_default_session_globals(|| {
         string_to_item(
             "pub fn mk_file_writer(path: &Path, flags: &[FileFlag])
                 -> Result<Box<Writer>, String> {
@@ -237,7 +237,7 @@ let mut fflags: c_int = wb();
 
 #[test]
 fn crlf_doc_comments() {
-    with_default_globals(|| {
+    with_default_session_globals(|| {
         let sess = sess();
 
         let name_1 = FileName::Custom("crlf_source_1".to_string());
@@ -271,7 +271,7 @@ fn ttdelim_span() {
         new_parser_from_source_str(sess, name, source).parse_expr()
     }
 
-    with_default_globals(|| {
+    with_default_session_globals(|| {
         let sess = sess();
         let expr = parse_expr_from_source_str(
             PathBuf::from("foo").into(),
@@ -299,7 +299,7 @@ fn ttdelim_span() {
 // See `recurse_into_file_modules` in the parser.
 #[test]
 fn out_of_line_mod() {
-    with_default_globals(|| {
+    with_default_session_globals(|| {
         let item = parse_item_from_source_str(
             PathBuf::from("foo").into(),
             "mod foo { struct S; mod this_does_not_exist; }".to_owned(),

--- a/src/librustc_expand/tests.rs
+++ b/src/librustc_expand/tests.rs
@@ -1,6 +1,6 @@
 use rustc_ast::ast;
 use rustc_ast::tokenstream::TokenStream;
-use rustc_ast::with_default_globals;
+use rustc_ast::with_default_session_globals;
 use rustc_parse::{new_parser_from_source_str, parser::Parser, source_file_to_stream};
 use rustc_session::parse::ParseSess;
 use rustc_span::source_map::{FilePathMapping, SourceMap};
@@ -124,7 +124,7 @@ impl<T: Write> Write for Shared<T> {
 }
 
 fn test_harness(file_text: &str, span_labels: Vec<SpanLabel>, expected_output: &str) {
-    with_default_globals(|| {
+    with_default_session_globals(|| {
         let output = Arc::new(Mutex::new(Vec::new()));
 
         let source_map = Lrc::new(SourceMap::new(FilePathMapping::empty()));

--- a/src/librustc_expand/tokenstream/tests.rs
+++ b/src/librustc_expand/tokenstream/tests.rs
@@ -2,7 +2,7 @@ use crate::tests::string_to_stream;
 
 use rustc_ast::token;
 use rustc_ast::tokenstream::{TokenStream, TokenStreamBuilder, TokenTree};
-use rustc_ast::with_default_globals;
+use rustc_ast::with_default_session_globals;
 use rustc_span::{BytePos, Span, Symbol};
 use smallvec::smallvec;
 
@@ -16,7 +16,7 @@ fn sp(a: u32, b: u32) -> Span {
 
 #[test]
 fn test_concat() {
-    with_default_globals(|| {
+    with_default_session_globals(|| {
         let test_res = string_to_ts("foo::bar::baz");
         let test_fst = string_to_ts("foo::bar");
         let test_snd = string_to_ts("::baz");
@@ -29,7 +29,7 @@ fn test_concat() {
 
 #[test]
 fn test_to_from_bijection() {
-    with_default_globals(|| {
+    with_default_session_globals(|| {
         let test_start = string_to_ts("foo::bar(baz)");
         let test_end = test_start.trees().collect();
         assert_eq!(test_start, test_end)
@@ -38,7 +38,7 @@ fn test_to_from_bijection() {
 
 #[test]
 fn test_eq_0() {
-    with_default_globals(|| {
+    with_default_session_globals(|| {
         let test_res = string_to_ts("foo");
         let test_eqs = string_to_ts("foo");
         assert_eq!(test_res, test_eqs)
@@ -47,7 +47,7 @@ fn test_eq_0() {
 
 #[test]
 fn test_eq_1() {
-    with_default_globals(|| {
+    with_default_session_globals(|| {
         let test_res = string_to_ts("::bar::baz");
         let test_eqs = string_to_ts("::bar::baz");
         assert_eq!(test_res, test_eqs)
@@ -56,7 +56,7 @@ fn test_eq_1() {
 
 #[test]
 fn test_eq_3() {
-    with_default_globals(|| {
+    with_default_session_globals(|| {
         let test_res = string_to_ts("");
         let test_eqs = string_to_ts("");
         assert_eq!(test_res, test_eqs)
@@ -65,7 +65,7 @@ fn test_eq_3() {
 
 #[test]
 fn test_diseq_0() {
-    with_default_globals(|| {
+    with_default_session_globals(|| {
         let test_res = string_to_ts("::bar::baz");
         let test_eqs = string_to_ts("bar::baz");
         assert_eq!(test_res == test_eqs, false)
@@ -74,7 +74,7 @@ fn test_diseq_0() {
 
 #[test]
 fn test_diseq_1() {
-    with_default_globals(|| {
+    with_default_session_globals(|| {
         let test_res = string_to_ts("(bar,baz)");
         let test_eqs = string_to_ts("bar,baz");
         assert_eq!(test_res == test_eqs, false)
@@ -83,7 +83,7 @@ fn test_diseq_1() {
 
 #[test]
 fn test_is_empty() {
-    with_default_globals(|| {
+    with_default_session_globals(|| {
         let test0: TokenStream = Vec::<TokenTree>::new().into_iter().collect();
         let test1: TokenStream =
             TokenTree::token(token::Ident(Symbol::intern("a"), false), sp(0, 1)).into();
@@ -97,7 +97,7 @@ fn test_is_empty() {
 
 #[test]
 fn test_dotdotdot() {
-    with_default_globals(|| {
+    with_default_session_globals(|| {
         let mut builder = TokenStreamBuilder::new();
         builder.push(TokenTree::token(token::Dot, sp(0, 1)).joint());
         builder.push(TokenTree::token(token::Dot, sp(1, 2)).joint());

--- a/src/librustc_interface/interface.rs
+++ b/src/librustc_interface/interface.rs
@@ -74,7 +74,7 @@ impl Compiler {
 
 /// Converts strings provided as `--cfg [cfgspec]` into a `crate_cfg`.
 pub fn parse_cfgspecs(cfgspecs: Vec<String>) -> FxHashSet<(String, Option<String>)> {
-    rustc_ast::with_default_globals(move || {
+    rustc_ast::with_default_session_globals(move || {
         let cfg = cfgspecs
             .into_iter()
             .map(|s| {

--- a/src/librustc_interface/tests.rs
+++ b/src/librustc_interface/tests.rs
@@ -73,7 +73,7 @@ fn mk_map<K: Ord, V>(entries: Vec<(K, V)>) -> BTreeMap<K, V> {
 // When the user supplies --test we should implicitly supply --cfg test
 #[test]
 fn test_switch_implies_cfg_test() {
-    rustc_ast::with_default_globals(|| {
+    rustc_ast::with_default_session_globals(|| {
         let matches = optgroups().parse(&["--test".to_string()]).unwrap();
         let (sess, cfg) = mk_session(matches);
         let cfg = build_configuration(&sess, to_crate_config(cfg));
@@ -84,7 +84,7 @@ fn test_switch_implies_cfg_test() {
 // When the user supplies --test and --cfg test, don't implicitly add another --cfg test
 #[test]
 fn test_switch_implies_cfg_test_unless_cfg_test() {
-    rustc_ast::with_default_globals(|| {
+    rustc_ast::with_default_session_globals(|| {
         let matches = optgroups().parse(&["--test".to_string(), "--cfg=test".to_string()]).unwrap();
         let (sess, cfg) = mk_session(matches);
         let cfg = build_configuration(&sess, to_crate_config(cfg));
@@ -96,20 +96,20 @@ fn test_switch_implies_cfg_test_unless_cfg_test() {
 
 #[test]
 fn test_can_print_warnings() {
-    rustc_ast::with_default_globals(|| {
+    rustc_ast::with_default_session_globals(|| {
         let matches = optgroups().parse(&["-Awarnings".to_string()]).unwrap();
         let (sess, _) = mk_session(matches);
         assert!(!sess.diagnostic().can_emit_warnings());
     });
 
-    rustc_ast::with_default_globals(|| {
+    rustc_ast::with_default_session_globals(|| {
         let matches =
             optgroups().parse(&["-Awarnings".to_string(), "-Dwarnings".to_string()]).unwrap();
         let (sess, _) = mk_session(matches);
         assert!(sess.diagnostic().can_emit_warnings());
     });
 
-    rustc_ast::with_default_globals(|| {
+    rustc_ast::with_default_session_globals(|| {
         let matches = optgroups().parse(&["-Adead_code".to_string()]).unwrap();
         let (sess, _) = mk_session(matches);
         assert!(sess.diagnostic().can_emit_warnings());

--- a/src/librustc_middle/ty/query/job.rs
+++ b/src/librustc_middle/ty/query/job.rs
@@ -13,16 +13,15 @@ pub unsafe fn handle_deadlock() {
     let gcx_ptr = tls::GCX_PTR.with(|gcx_ptr| gcx_ptr as *const _);
     let gcx_ptr = &*gcx_ptr;
 
-    let rustc_span_globals =
-        rustc_span::GLOBALS.with(|rustc_span_globals| rustc_span_globals as *const _);
-    let rustc_span_globals = &*rustc_span_globals;
-    let syntax_globals = rustc_ast::attr::GLOBALS.with(|syntax_globals| syntax_globals as *const _);
-    let syntax_globals = &*syntax_globals;
+    let span_session_globals = rustc_span::SESSION_GLOBALS.with(|ssg| ssg as *const _);
+    let span_session_globals = &*span_session_globals;
+    let ast_session_globals = rustc_ast::attr::SESSION_GLOBALS.with(|asg| asg as *const _);
+    let ast_session_globals = &*ast_session_globals;
     thread::spawn(move || {
         tls::GCX_PTR.set(gcx_ptr, || {
-            rustc_ast::attr::GLOBALS.set(syntax_globals, || {
-                rustc_span::GLOBALS
-                    .set(rustc_span_globals, || tls::with_global(|tcx| deadlock(tcx, &registry)))
+            rustc_ast::attr::SESSION_GLOBALS.set(ast_session_globals, || {
+                rustc_span::SESSION_GLOBALS
+                    .set(span_session_globals, || tls::with_global(|tcx| deadlock(tcx, &registry)))
             });
         })
     });

--- a/src/librustc_parse_format/tests.rs
+++ b/src/librustc_parse_format/tests.rs
@@ -144,8 +144,8 @@ fn format_align_fill() {
 }
 #[test]
 fn format_counts() {
-    use rustc_span::{edition, Globals, GLOBALS};
-    GLOBALS.set(&Globals::new(edition::DEFAULT_EDITION), || {
+    use rustc_span::{edition, SessionGlobals, SESSION_GLOBALS};
+    SESSION_GLOBALS.set(&SessionGlobals::new(edition::DEFAULT_EDITION), || {
         same(
             "{:10x}",
             &[NextArgument(Argument {

--- a/src/librustc_span/hygiene.rs
+++ b/src/librustc_span/hygiene.rs
@@ -27,7 +27,7 @@
 use crate::def_id::{DefId, CRATE_DEF_INDEX};
 use crate::edition::Edition;
 use crate::symbol::{kw, sym, Symbol};
-use crate::GLOBALS;
+use crate::SESSION_GLOBALS;
 use crate::{Span, DUMMY_SP};
 
 use rustc_data_structures::fx::FxHashMap;
@@ -174,7 +174,7 @@ impl HygieneData {
     }
 
     fn with<T, F: FnOnce(&mut HygieneData) -> T>(f: F) -> T {
-        GLOBALS.with(|globals| f(&mut *globals.hygiene_data.borrow_mut()))
+        SESSION_GLOBALS.with(|session_globals| f(&mut *session_globals.hygiene_data.borrow_mut()))
     }
 
     fn fresh_expn(&mut self, expn_data: Option<ExpnData>) -> ExpnId {

--- a/src/librustc_span/span_encoding.rs
+++ b/src/librustc_span/span_encoding.rs
@@ -5,7 +5,7 @@
 // See https://internals.rust-lang.org/t/rfc-compiler-refactoring-spans/1357/28
 
 use crate::hygiene::SyntaxContext;
-use crate::GLOBALS;
+use crate::SESSION_GLOBALS;
 use crate::{BytePos, SpanData};
 
 use rustc_data_structures::fx::FxHashMap;
@@ -136,5 +136,5 @@ impl SpanInterner {
 // If an interner exists, return it. Otherwise, prepare a fresh one.
 #[inline]
 fn with_span_interner<T, F: FnOnce(&mut SpanInterner) -> T>(f: F) -> T {
-    GLOBALS.with(|globals| f(&mut *globals.span_interner.lock()))
+    SESSION_GLOBALS.with(|session_globals| f(&mut *session_globals.span_interner.lock()))
 }

--- a/src/librustc_span/symbol.rs
+++ b/src/librustc_span/symbol.rs
@@ -14,7 +14,7 @@ use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::str;
 
-use crate::{Span, DUMMY_SP, GLOBALS};
+use crate::{Span, DUMMY_SP, SESSION_GLOBALS};
 
 #[cfg(test)]
 mod tests;
@@ -1307,7 +1307,7 @@ impl Ident {
 
 #[inline]
 fn with_interner<T, F: FnOnce(&mut Interner) -> T>(f: F) -> T {
-    GLOBALS.with(|globals| f(&mut *globals.symbol_interner.lock()))
+    SESSION_GLOBALS.with(|session_globals| f(&mut *session_globals.symbol_interner.lock()))
 }
 
 /// An alternative to `Symbol`, useful when the chars within the symbol need to

--- a/src/librustc_span/symbol/tests.rs
+++ b/src/librustc_span/symbol/tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-use crate::{edition, Globals};
+use crate::{edition, SessionGlobals};
 
 #[test]
 fn interner_tests() {
@@ -18,7 +18,7 @@ fn interner_tests() {
 
 #[test]
 fn without_first_quote_test() {
-    GLOBALS.set(&Globals::new(edition::DEFAULT_EDITION), || {
+    SESSION_GLOBALS.set(&SessionGlobals::new(edition::DEFAULT_EDITION), || {
         let i = Ident::from_str("'break");
         assert_eq!(i.without_first_quote().name, kw::Break);
     });

--- a/src/librustdoc/clean/cfg/tests.rs
+++ b/src/librustdoc/clean/cfg/tests.rs
@@ -2,7 +2,7 @@ use super::*;
 
 use rustc_ast::ast::*;
 use rustc_ast::attr;
-use rustc_ast::with_default_globals;
+use rustc_ast::with_default_session_globals;
 use rustc_span::symbol::{Ident, Symbol};
 use rustc_span::DUMMY_SP;
 
@@ -52,7 +52,7 @@ macro_rules! dummy_meta_item_list {
 
 #[test]
 fn test_cfg_not() {
-    with_default_globals(|| {
+    with_default_session_globals(|| {
         assert_eq!(!Cfg::False, Cfg::True);
         assert_eq!(!Cfg::True, Cfg::False);
         assert_eq!(!word_cfg("test"), Cfg::Not(Box::new(word_cfg("test"))));
@@ -70,7 +70,7 @@ fn test_cfg_not() {
 
 #[test]
 fn test_cfg_and() {
-    with_default_globals(|| {
+    with_default_session_globals(|| {
         let mut x = Cfg::False;
         x &= Cfg::True;
         assert_eq!(x, Cfg::False);
@@ -154,7 +154,7 @@ fn test_cfg_and() {
 
 #[test]
 fn test_cfg_or() {
-    with_default_globals(|| {
+    with_default_session_globals(|| {
         let mut x = Cfg::True;
         x |= Cfg::False;
         assert_eq!(x, Cfg::True);
@@ -238,7 +238,7 @@ fn test_cfg_or() {
 
 #[test]
 fn test_parse_ok() {
-    with_default_globals(|| {
+    with_default_session_globals(|| {
         let mi = dummy_meta_item_word("all");
         assert_eq!(Cfg::parse(&mi), Ok(word_cfg("all")));
 
@@ -271,7 +271,7 @@ fn test_parse_ok() {
 
 #[test]
 fn test_parse_err() {
-    with_default_globals(|| {
+    with_default_session_globals(|| {
         let mi = attr::mk_name_value_item(Ident::from_str("foo"), LitKind::Bool(false), DUMMY_SP);
         assert!(Cfg::parse(&mi).is_err());
 
@@ -303,7 +303,7 @@ fn test_parse_err() {
 
 #[test]
 fn test_render_short_html() {
-    with_default_globals(|| {
+    with_default_session_globals(|| {
         assert_eq!(word_cfg("unix").render_short_html(), "Unix");
         assert_eq!(name_value_cfg("target_os", "macos").render_short_html(), "macOS");
         assert_eq!(name_value_cfg("target_pointer_width", "16").render_short_html(), "16-bit");
@@ -358,7 +358,7 @@ fn test_render_short_html() {
 
 #[test]
 fn test_render_long_html() {
-    with_default_globals(|| {
+    with_default_session_globals(|| {
         assert_eq!(
             word_cfg("unix").render_long_html(),
             "This is supported on <strong>Unix</strong> only."

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -1,5 +1,4 @@
 use rustc_ast::ast;
-use rustc_ast::with_globals;
 use rustc_data_structures::sync::Lrc;
 use rustc_errors::ErrorReported;
 use rustc_feature::UnstableFeatures;
@@ -399,7 +398,7 @@ pub fn make_test(
     // Uses librustc_ast to parse the doctest and find if there's a main fn and the extern
     // crate already is included.
     let result = rustc_driver::catch_fatal_errors(|| {
-        with_globals(edition, || {
+        rustc_ast::with_session_globals(edition, || {
             use rustc_errors::emitter::EmitterWriter;
             use rustc_errors::Handler;
             use rustc_parse::maybe_new_parser_from_source_str;

--- a/src/test/ui-fulldeps/mod_dir_path_canonicalized.rs
+++ b/src/test/ui-fulldeps/mod_dir_path_canonicalized.rs
@@ -19,7 +19,7 @@ use std::path::Path;
 mod gravy;
 
 pub fn main() {
-    rustc_ast::with_default_globals(|| parse());
+    rustc_ast::with_default_session_globals(|| parse());
 
     assert_eq!(gravy::foo(), 10);
 }

--- a/src/test/ui-fulldeps/pprust-expr-roundtrip.rs
+++ b/src/test/ui-fulldeps/pprust-expr-roundtrip.rs
@@ -208,7 +208,7 @@ impl MutVisitor for AddParens {
 }
 
 fn main() {
-    rustc_ast::with_default_globals(|| run());
+    rustc_ast::with_default_session_globals(|| run());
 }
 
 fn run() {

--- a/src/tools/error_index_generator/main.rs
+++ b/src/tools/error_index_generator/main.rs
@@ -284,7 +284,7 @@ fn parse_args() -> (OutputFormat, PathBuf) {
 fn main() {
     env_logger::init();
     let (format, dst) = parse_args();
-    let result = rustc_ast::with_default_globals(move || main_with_result(format, &dst));
+    let result = rustc_ast::with_default_session_globals(move || main_with_result(format, &dst));
     if let Err(e) = result {
         panic!("{}", e.to_string());
     }


### PR DESCRIPTION
There are some structures that are called "globals", but are they global
to a compilation session, and not truly global. I have always found this
highly confusing, so this commit renames them as "session globals" and
adds a comment explaining things.

Also, the commit fixes an unnecessary nesting of `set()` calls
`src/librustc_errors/json/tests.rs`

r? @Aaron1011