### PR TITLE
Add rust-analyzer to the build manifest

### DIFF
--- a/src/tools/build-manifest/README.md
+++ b/src/tools/build-manifest/README.md
@@ -22,7 +22,7 @@ Then, you can generate the manifest and all the packages from `path/to/dist` to
 ```
 $ BUILD_MANIFEST_DISABLE_SIGNING=1 cargo +nightly run \
     path/to/dist path/to/output 1970-01-01 \
-    nightly nightly nightly nightly nightly nightly nightly \
+    nightly nightly nightly nightly nightly nightly nightly nightly \
     http://example.com
 ```
 


### PR DESCRIPTION
Does not die locally, produces `rust-analyzer-0.1.0-dev-x86_64-unknown-linux-gnu.tar.gz.sha256` and add something about rust-analyzer to some `.toml` file. Seems like a success? 