### PR TITLE
Use `strip_{prefix,suffix}` in rustdoc

### DIFF
--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -461,8 +461,8 @@ impl Step for Std {
 
             builder.run(&mut cargo.into());
         };
-        let krates = ["alloc", "core", "std", "proc_macro", "test"];
-        for krate in &krates {
+        static KRATES: &[&str] = &["alloc", "core", "std", "proc_macro", "test"];
+        for krate in KRATES {
             run_cargo_rustdoc_for(krate);
         }
         builder.cp_r(&my_out, &out);
@@ -470,13 +470,12 @@ impl Step for Std {
         // Look for src/libstd, src/libcore etc in the `x.py doc` arguments and
         // open the corresponding rendered docs.
         for path in builder.paths.iter().map(components_simplified) {
-            if path.get(0) == Some(&"src")
-                && path.get(1).map_or(false, |dir| dir.starts_with("lib"))
-            {
-                let requested_crate = &path[1][3..];
-                if krates.contains(&requested_crate) {
-                    let index = out.join(requested_crate).join("index.html");
-                    open(builder, &index);
+            if let ["src", path, ..] = path.as_slice() {
+                if let Some(krate) = path.strip_prefix("lib") {
+                    if KRATES.contains(&krate) {
+                        let index = out.join(krate).join("index.html");
+                        open(builder, &index);
+                    }
                 }
             }
         }

--- a/src/librustc_ast/util/comments.rs
+++ b/src/librustc_ast/util/comments.rs
@@ -29,27 +29,31 @@ pub struct Comment {
 }
 
 pub fn is_line_doc_comment(s: &str) -> bool {
-    let res = (s.starts_with("///") && *s.as_bytes().get(3).unwrap_or(&b' ') != b'/')
-        || s.starts_with("//!");
-    debug!("is {:?} a doc comment? {}", s, res);
-    res
+    let yes = match s.as_bytes() {
+        [b'/', b'/', b'/', c, ..] => *c != b'/',
+        [b'/', b'/', b'/', ..] => true,
+        [b'/', b'/', b'!', ..] => true,
+        _ => false,
+    };
+    debug!("is {:?} a line doc comment? {}", s, yes);
+    yes
 }
 
 pub fn is_block_doc_comment(s: &str) -> bool {
-    // Prevent `/**/` from being parsed as a doc comment
-    let res = ((s.starts_with("/**") && *s.as_bytes().get(3).unwrap_or(&b' ') != b'*')
-        || s.starts_with("/*!"))
-        && s.len() >= 5;
-    debug!("is {:?} a doc comment? {}", s, res);
-    res
+    // Previously, `/**/` was incorrectly regarded as a doc comment because it
+    // starts with `/**` and ends with `*/`. However, this caused an ICE
+    // because some code assumed that the length of a doc comment is at least 5.
+    let yes = match s.as_bytes() {
+        [b'/', b'*', b'*', c, _, ..] => *c != b'*',
+        [b'/', b'*', b'!', _, _, ..] => true,
+        _ => false,
+    };
+    debug!("is {:?} a block doc comment? {}", s, yes);
+    yes
 }
 
-// FIXME(#64197): Try to privatize this again.
-pub fn is_doc_comment(s: &str) -> bool {
-    (s.starts_with("///") && is_line_doc_comment(s))
-        || s.starts_with("//!")
-        || (s.starts_with("/**") && is_block_doc_comment(s))
-        || s.starts_with("/*!")
+fn is_doc_comment(s: &str) -> bool {
+    is_line_doc_comment(s) || is_block_doc_comment(s)
 }
 
 pub fn doc_comment_style(comment: &str) -> ast::AttrStyle {
@@ -127,22 +131,26 @@ pub fn strip_doc_comment_decoration(comment: &str) -> String {
     const ONELINERS: &[&str] = &["///!", "///", "//!", "//"];
 
     for prefix in ONELINERS {
-        if comment.starts_with(*prefix) {
-            return (&comment[prefix.len()..]).to_string();
+        if let Some(tail) = comment.strip_prefix(*prefix) {
+            return tail.to_owned();
         }
     }
 
-    if comment.starts_with("/*") {
-        let lines =
-            comment[3..comment.len() - 2].lines().map(|s| s.to_string()).collect::<Vec<String>>();
+    match comment
+        .strip_prefix("/**")
+        .or_else(|| comment.strip_prefix("/*!"))
+        .and_then(|s| s.strip_suffix("*/"))
+    {
+        Some(doc) => {
+            let lines = doc.lines().map(|s| s.to_string()).collect::<Vec<String>>();
 
-        let lines = vertical_trim(lines);
-        let lines = horizontal_trim(lines);
+            let lines = vertical_trim(lines);
+            let lines = horizontal_trim(lines);
 
-        return lines.join("\n");
+            lines.join("\n")
+        }
+        _ => panic!("not a doc-comment: {}", comment),
     }
-
-    panic!("not a doc-comment: {}", comment);
 }
 
 /// Returns `None` if the first `col` chars of `s` contain a non-whitespace char.

--- a/src/librustc_expand/parse/lexer/tests.rs
+++ b/src/librustc_expand/parse/lexer/tests.rs
@@ -1,5 +1,5 @@
 use rustc_ast::token::{self, Token, TokenKind};
-use rustc_ast::util::comments::is_doc_comment;
+use rustc_ast::util::comments::is_line_doc_comment;
 use rustc_ast::with_default_globals;
 use rustc_data_structures::sync::Lrc;
 use rustc_errors::{emitter::EmitterWriter, Handler};
@@ -225,9 +225,9 @@ fn literal_suffixes() {
 
 #[test]
 fn line_doc_comments() {
-    assert!(is_doc_comment("///"));
-    assert!(is_doc_comment("/// blah"));
-    assert!(!is_doc_comment("////"));
+    assert!(is_line_doc_comment("///"));
+    assert!(is_line_doc_comment("/// blah"));
+    assert!(!is_line_doc_comment("////"));
 }
 
 #[test]

--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -481,12 +481,14 @@ pub fn print_const(cx: &DocContext<'_>, n: &'tcx ty::Const<'_>) -> String {
         _ => {
             let mut s = n.to_string();
             // array lengths are obviously usize
-            if s.ends_with("_usize") {
-                let n = s.len() - "_usize".len();
-                s.truncate(n);
-                if s.ends_with(": ") {
-                    let n = s.len() - ": ".len();
-                    s.truncate(n);
+            if let Some(head) = s.strip_suffix("_usize") {
+                let new_len = match head.strip_suffix(": ") {
+                    None => head.len(),
+                    Some(hhead) => hhead.len(),
+                };
+                // SAFETY: `new_len` should be in between char boundary
+                unsafe {
+                    s.as_mut_vec().set_len(new_len);
                 }
             }
             s

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -810,11 +810,9 @@ themePicker.onblur = handleThemeButtonsBlur;
                 if line.starts_with(&format!("\"{}\"", krate)) {
                     continue;
                 }
-                if line.ends_with(",\\") {
-                    ret.push(line[..line.len() - 2].to_string());
-                } else {
-                    // Ends with "\\" (it's the case for the last added crate line)
-                    ret.push(line[..line.len() - 1].to_string());
+                // Ends with "\\" (it's the case for the last added crate line)
+                if let Some(head) = line.strip_suffix(",\\").or_else(|| line.strip_suffix("\\")) {
+                    ret.push(head.to_string());
                 }
                 krates.push(
                     line.split('"')

--- a/src/librustdoc/html/sources.rs
+++ b/src/librustdoc/html/sources.rs
@@ -83,8 +83,7 @@ impl<'a> SourceCollector<'a> {
         };
 
         // Remove the utf-8 BOM if any
-        let contents =
-            if contents.starts_with("\u{feff}") { &contents[3..] } else { &contents[..] };
+        let contents = contents.strip_prefix("\u{feff}").unwrap_or(&contents[..]);
 
         // Create the intermediate directories
         let mut cur = self.dst.clone();

--- a/src/librustdoc/markdown.rs
+++ b/src/librustdoc/markdown.rs
@@ -18,9 +18,9 @@ fn extract_leading_metadata(s: &str) -> (Vec<&str>, &str) {
     let mut count = 0;
 
     for line in s.lines() {
-        if line.starts_with("# ") || line.starts_with('%') {
+        if let Some(tail) = line.strip_prefix("# ").or_else(|| line.strip_prefix('%')) {
             // trim the whitespace after the symbol
-            metadata.push(line[1..].trim_start());
+            metadata.push(tail.trim_start());
             count += line.len() + 1;
         } else {
             return (metadata, &s[count..]);

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -541,38 +541,31 @@ impl<'a, 'tcx> DocFolder for LinkCollector<'a, 'tcx> {
 
             let link = ori_link.replace("`", "");
             let parts = link.split('#').collect::<Vec<_>>();
-            let (link, extra_fragment) = if parts.len() > 2 {
-                build_diagnostic(
-                    cx,
-                    &item,
-                    &link,
-                    &dox,
-                    link_range,
-                    "has an issue with the link anchor.",
-                    "only one `#` is allowed in a link",
-                    None,
-                );
-                continue;
-            } else if parts.len() == 2 {
-                if parts[0].trim().is_empty() {
-                    // This is an anchor to an element of the current page, nothing to do in here!
+            let (link, extra_fragment) = match *parts {
+                [] => unreachable!("`str::split` always returns a non-empty list"),
+                [a] => (a.to_owned(), None),
+                // This is an anchor to an element of the current page, nothing to do in here!
+                [a, _] if a.trim().is_empty() => continue,
+                [a, b] => (a.to_owned(), Some(b.to_owned())),
+                [_, _, _, ..] => {
+                    build_diagnostic(
+                        cx,
+                        &item,
+                        &link,
+                        &dox,
+                        link_range,
+                        "has an issue with the link anchor.",
+                        "only one `#` is allowed in a link",
+                        None,
+                    );
                     continue;
                 }
-                (parts[0].to_owned(), Some(parts[1].to_owned()))
-            } else {
-                (parts[0].to_owned(), None)
             };
             let resolved_self;
             let mut path_str;
             let (res, fragment) = {
-                let mut kind = None;
-                path_str = if let Some(prefix) = ["struct@", "enum@", "type@", "trait@", "union@"]
-                    .iter()
-                    .find(|p| link.starts_with(**p))
-                {
-                    kind = Some(TypeNS);
-                    link.trim_start_matches(prefix)
-                } else if let Some(prefix) = [
+                static TYPES: &[&str] = &["struct@", "enum@", "type@", "trait@", "union@"];
+                static TY_KINDS: &[&str] = &[
                     "const@",
                     "static@",
                     "value@",
@@ -581,28 +574,27 @@ impl<'a, 'tcx> DocFolder for LinkCollector<'a, 'tcx> {
                     "fn@",
                     "module@",
                     "method@",
-                ]
-                .iter()
-                .find(|p| link.starts_with(**p))
-                {
-                    kind = Some(ValueNS);
-                    link.trim_start_matches(prefix)
-                } else if link.ends_with("()") {
-                    kind = Some(ValueNS);
-                    link.trim_end_matches("()")
-                } else if link.starts_with("macro@") {
-                    kind = Some(MacroNS);
-                    link.trim_start_matches("macro@")
-                } else if link.starts_with("derive@") {
-                    kind = Some(MacroNS);
-                    link.trim_start_matches("derive@")
-                } else if link.ends_with('!') {
-                    kind = Some(MacroNS);
-                    link.trim_end_matches('!')
-                } else {
-                    &link[..]
-                }
-                .trim();
+                ];
+                let (kind, path) =
+                    if let Some(tail) = TYPES.iter().filter_map(|&p| link.strip_prefix(p)).next() {
+                        (Some(TypeNS), tail)
+                    } else if let Some(tail) =
+                        TY_KINDS.iter().filter_map(|&p| link.strip_prefix(p)).next()
+                    {
+                        (Some(ValueNS), tail)
+                    } else if let Some(head) = link.strip_suffix("()") {
+                        (Some(ValueNS), head)
+                    } else if let Some(tail) =
+                        link.strip_prefix("macro@").or_else(|| link.strip_prefix("derive@"))
+                    {
+                        (Some(MacroNS), tail)
+                    } else if let Some(head) = link.strip_suffix('!') {
+                        (Some(MacroNS), head)
+                    } else {
+                        (None, &link[..])
+                    };
+
+                path_str = path.trim();
 
                 if path_str.contains(|ch: char| !(ch.is_alphanumeric() || ch == ':' || ch == '_')) {
                     continue;
@@ -623,9 +615,9 @@ impl<'a, 'tcx> DocFolder for LinkCollector<'a, 'tcx> {
                     if item.is_mod() && item.attrs.inner_docs { None } else { parent_node };
 
                 // replace `Self` with suitable item's parent name
-                if path_str.starts_with("Self::") {
+                if let Some(item) = path_str.strip_prefix("Self::") {
                     if let Some(ref name) = parent_name {
-                        resolved_self = format!("{}::{}", name, &path_str[6..]);
+                        resolved_self = format!("{}::{}", name, item);
                         path_str = &resolved_self;
                     }
                 }


### PR DESCRIPTION
cc @Mark-Simulacrum @jyn514 for rustdoc part

Part of #74048