### PR TITLE
Doc alias checks: ensure only items appearing in search index can use it

### DIFF
--- a/src/librustc_passes/check_attr.rs
+++ b/src/librustc_passes/check_attr.rs
@@ -70,7 +70,7 @@ impl CheckAttrVisitor<'tcx> {
             } else if self.tcx.sess.check_name(attr, sym::track_caller) {
                 self.check_track_caller(&attr.span, attrs, span, target)
             } else if self.tcx.sess.check_name(attr, sym::doc) {
-                self.check_doc_alias(attr)
+                self.check_doc_alias(attr, hir_id, target)
             } else {
                 true
             };
@@ -217,7 +217,7 @@ impl CheckAttrVisitor<'tcx> {
         }
     }
 
-    fn check_doc_alias(&self, attr: &Attribute) -> bool {
+    fn check_doc_alias(&self, attr: &Attribute, hir_id: HirId, target: Target) -> bool {
         if let Some(mi) = attr.meta() {
             if let Some(list) = mi.meta_item_list() {
                 for meta in list {
@@ -237,6 +237,32 @@ impl CheckAttrVisitor<'tcx> {
                                 )
                                 .emit();
                             return false;
+                        }
+                        if let Some(err) = match target {
+                            Target::Impl => Some("implementation block"),
+                            Target::ForeignMod => Some("extern block"),
+                            Target::AssocConst | Target::AssocTy => {
+                                let parent_hir_id = self.tcx.hir().get_parent_item(hir_id);
+                                let containing_item = self.tcx.hir().expect_item(parent_hir_id);
+                                if Target::from_item(containing_item) == Target::Impl {
+                                    Some(if target == Target::AssocConst {
+                                        "const in implementation block"
+                                    } else {
+                                        "type alias in implementation block"
+                                    })
+                                } else {
+                                    None
+                                }
+                            }
+                            _ => None,
+                        } {
+                            self.tcx
+                                .sess
+                                .struct_span_err(
+                                    meta.span(),
+                                    &format!("`#[doc(alias = \"...\")]` isn't allowed on {}", err,),
+                                )
+                                .emit();
                         }
                     }
                 }

--- a/src/librustc_passes/check_attr.rs
+++ b/src/librustc_passes/check_attr.rs
@@ -241,15 +241,11 @@ impl CheckAttrVisitor<'tcx> {
                         if let Some(err) = match target {
                             Target::Impl => Some("implementation block"),
                             Target::ForeignMod => Some("extern block"),
-                            Target::AssocConst | Target::AssocTy => {
+                            Target::AssocTy => {
                                 let parent_hir_id = self.tcx.hir().get_parent_item(hir_id);
                                 let containing_item = self.tcx.hir().expect_item(parent_hir_id);
                                 if Target::from_item(containing_item) == Target::Impl {
-                                    Some(if target == Target::AssocConst {
-                                        "const in implementation block"
-                                    } else {
-                                        "type alias in implementation block"
-                                    })
+                                    Some("type alias in implementation block")
                                 } else {
                                     None
                                 }

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -470,6 +470,10 @@ pub fn run_core(options: RustdocOptions) -> (clean::Crate, RenderInfo, RenderOpt
                 sess.time("missing_docs", || {
                     rustc_lint::check_crate(tcx, rustc_lint::builtin::MissingDoc::new);
                 });
+                for &module in tcx.hir().krate().modules.keys() {
+                    let local_def_id = tcx.hir().local_def_id(module);
+                    tcx.ensure().check_mod_attrs(local_def_id);
+                }
 
                 let access_levels = tcx.privacy_access_levels(LOCAL_CRATE);
                 // Convert from a HirId set to a DefId set since we don't always have easy access

--- a/src/test/rustdoc-js/doc-alias.js
+++ b/src/test/rustdoc-js/doc-alias.js
@@ -5,7 +5,7 @@ const QUERY = [
     'StructFieldItem',
     'StructMethodItem',
     'ImplTraitItem',
-    'ImplAssociatedConstItem',
+    'StructImplConstItem',
     'ImplTraitFunction',
     'EnumItem',
     'VariantItem',
@@ -64,8 +64,16 @@ const EXPECTED = [
         'others': [],
     },
     {
-        // ImplAssociatedConstItem
-        'others': [],
+        // StructImplConstItem
+        'others': [
+            {
+                'path': 'doc_alias::Struct',
+                'name': 'ImplConstItem',
+                'alias': 'StructImplConstItem',
+                'href': '../doc_alias/struct.Struct.html#associatedconstant.ImplConstItem',
+                'is_alias': true
+            },
+        ],
     },
     {
         'others': [
@@ -196,6 +204,10 @@ const EXPECTED = [
                 'alias': 'ConstItem',
                 'href': '../doc_alias/constant.Const.html',
                 'is_alias': true
+            },
+            {
+                'path': 'doc_alias::Struct',
+                'name': 'ImplConstItem',
             },
         ],
     },

--- a/src/test/rustdoc-js/doc-alias.rs
+++ b/src/test/rustdoc-js/doc-alias.rs
@@ -12,11 +12,7 @@ impl Struct {
 }
 
 impl Trait for Struct {
-    // Shouldn't be listed in aliases!
-    #[doc(alias = "ImplTraitItem")]
     type Target = u32;
-    // Shouldn't be listed in aliases!
-    #[doc(alias = "ImplAssociatedConstItem")]
     const AssociatedConst: i32 = 12;
 
     #[doc(alias = "ImplTraitFunction")]

--- a/src/test/rustdoc-js/doc-alias.rs
+++ b/src/test/rustdoc-js/doc-alias.rs
@@ -7,6 +7,8 @@ pub struct Struct {
 }
 
 impl Struct {
+    #[doc(alias = "StructImplConstItem")]
+    pub const ImplConstItem: i32 = 0;
     #[doc(alias = "StructMethodItem")]
     pub fn method(&self) {}
 }

--- a/src/test/rustdoc-ui/check-doc-alias-attr-location.rs
+++ b/src/test/rustdoc-ui/check-doc-alias-attr-location.rs
@@ -1,0 +1,13 @@
+#![feature(doc_alias)]
+
+pub struct Bar;
+pub trait Foo {}
+
+#[doc(alias = "foo")] //~ ERROR
+extern {}
+
+#[doc(alias = "bar")] //~ ERROR
+impl Bar {}
+
+#[doc(alias = "foobar")] //~ ERROR
+impl Foo for Bar {}

--- a/src/test/rustdoc-ui/check-doc-alias-attr-location.rs
+++ b/src/test/rustdoc-ui/check-doc-alias-attr-location.rs
@@ -1,13 +1,23 @@
 #![feature(doc_alias)]
 
 pub struct Bar;
-pub trait Foo {}
+pub trait Foo {
+    type X;
+    fn foo() -> Self::X;
+}
 
 #[doc(alias = "foo")] //~ ERROR
 extern {}
 
 #[doc(alias = "bar")] //~ ERROR
-impl Bar {}
+impl Bar {
+    #[doc(alias = "const")] //~ ERROR
+    const A: u32 = 0;
+}
 
 #[doc(alias = "foobar")] //~ ERROR
-impl Foo for Bar {}
+impl Foo for Bar {
+    #[doc(alias = "assoc")] //~ ERROR
+    type X = i32;
+    fn foo() -> Self::X { 0 }
+}

--- a/src/test/rustdoc-ui/check-doc-alias-attr-location.rs
+++ b/src/test/rustdoc-ui/check-doc-alias-attr-location.rs
@@ -11,8 +11,8 @@ extern {}
 
 #[doc(alias = "bar")] //~ ERROR
 impl Bar {
-    #[doc(alias = "const")] //~ ERROR
-    const A: u32 = 0;
+    #[doc(alias = "const")]
+    pub const A: u32 = 0;
 }
 
 #[doc(alias = "foobar")] //~ ERROR

--- a/src/test/rustdoc-ui/check-doc-alias-attr-location.stderr
+++ b/src/test/rustdoc-ui/check-doc-alias-attr-location.stderr
@@ -16,17 +16,11 @@ error: `#[doc(alias = "...")]` isn't allowed on implementation block
 LL | #[doc(alias = "foobar")]
    |       ^^^^^^^^^^^^^^^^
 
-error: `#[doc(alias = "...")]` isn't allowed on const in implementation block
-  --> $DIR/check-doc-alias-attr-location.rs:14:11
-   |
-LL |     #[doc(alias = "const")]
-   |           ^^^^^^^^^^^^^^^
-
 error: `#[doc(alias = "...")]` isn't allowed on type alias in implementation block
   --> $DIR/check-doc-alias-attr-location.rs:20:11
    |
 LL |     #[doc(alias = "assoc")]
    |           ^^^^^^^^^^^^^^^
 
-error: aborting due to 5 previous errors
+error: aborting due to 4 previous errors
 

--- a/src/test/rustdoc-ui/check-doc-alias-attr-location.stderr
+++ b/src/test/rustdoc-ui/check-doc-alias-attr-location.stderr
@@ -1,0 +1,20 @@
+error: `#[doc(alias = "...")]` isn't allowed on extern block
+  --> $DIR/check-doc-alias-attr-location.rs:6:7
+   |
+LL | #[doc(alias = "foo")]
+   |       ^^^^^^^^^^^^^
+
+error: `#[doc(alias = "...")]` isn't allowed on implementation block
+  --> $DIR/check-doc-alias-attr-location.rs:9:7
+   |
+LL | #[doc(alias = "bar")]
+   |       ^^^^^^^^^^^^^
+
+error: `#[doc(alias = "...")]` isn't allowed on implementation block
+  --> $DIR/check-doc-alias-attr-location.rs:12:7
+   |
+LL | #[doc(alias = "foobar")]
+   |       ^^^^^^^^^^^^^^^^
+
+error: aborting due to 3 previous errors
+

--- a/src/test/rustdoc-ui/check-doc-alias-attr-location.stderr
+++ b/src/test/rustdoc-ui/check-doc-alias-attr-location.stderr
@@ -1,20 +1,32 @@
 error: `#[doc(alias = "...")]` isn't allowed on extern block
-  --> $DIR/check-doc-alias-attr-location.rs:6:7
+  --> $DIR/check-doc-alias-attr-location.rs:9:7
    |
 LL | #[doc(alias = "foo")]
    |       ^^^^^^^^^^^^^
 
 error: `#[doc(alias = "...")]` isn't allowed on implementation block
-  --> $DIR/check-doc-alias-attr-location.rs:9:7
+  --> $DIR/check-doc-alias-attr-location.rs:12:7
    |
 LL | #[doc(alias = "bar")]
    |       ^^^^^^^^^^^^^
 
+error: `#[doc(alias = "...")]` isn't allowed on const in implementation block
+  --> $DIR/check-doc-alias-attr-location.rs:14:11
+   |
+LL |     #[doc(alias = "const")]
+   |           ^^^^^^^^^^^^^^^
+
 error: `#[doc(alias = "...")]` isn't allowed on implementation block
-  --> $DIR/check-doc-alias-attr-location.rs:12:7
+  --> $DIR/check-doc-alias-attr-location.rs:18:7
    |
 LL | #[doc(alias = "foobar")]
    |       ^^^^^^^^^^^^^^^^
 
-error: aborting due to 3 previous errors
+error: `#[doc(alias = "...")]` isn't allowed on type alias in implementation block
+  --> $DIR/check-doc-alias-attr-location.rs:20:11
+   |
+LL |     #[doc(alias = "assoc")]
+   |           ^^^^^^^^^^^^^^^
+
+error: aborting due to 5 previous errors
 

--- a/src/test/rustdoc-ui/check-doc-alias-attr.rs
+++ b/src/test/rustdoc-ui/check-doc-alias-attr.rs
@@ -1,0 +1,10 @@
+#![crate_type = "lib"]
+#![feature(doc_alias)]
+
+#[doc(alias = "foo")] // ok!
+pub struct Bar;
+
+#[doc(alias)] //~ ERROR
+#[doc(alias = 0)] //~ ERROR
+#[doc(alias("bar"))] //~ ERROR
+pub struct Foo;

--- a/src/test/rustdoc-ui/check-doc-alias-attr.stderr
+++ b/src/test/rustdoc-ui/check-doc-alias-attr.stderr
@@ -1,0 +1,20 @@
+error: doc alias attribute expects a string: #[doc(alias = "0")]
+  --> $DIR/check-doc-alias-attr.rs:7:7
+   |
+LL | #[doc(alias)]
+   |       ^^^^^
+
+error: doc alias attribute expects a string: #[doc(alias = "0")]
+  --> $DIR/check-doc-alias-attr.rs:8:7
+   |
+LL | #[doc(alias = 0)]
+   |       ^^^^^^^^^
+
+error: doc alias attribute expects a string: #[doc(alias = "0")]
+  --> $DIR/check-doc-alias-attr.rs:9:7
+   |
+LL | #[doc(alias("bar"))]
+   |       ^^^^^^^^^^^^
+
+error: aborting due to 3 previous errors
+

--- a/src/test/ui/check-doc-alias-attr-location.rs
+++ b/src/test/ui/check-doc-alias-attr-location.rs
@@ -12,7 +12,7 @@ extern {}
 
 #[doc(alias = "bar")] //~ ERROR
 impl Bar {
-    #[doc(alias = "const")] //~ ERROR
+    #[doc(alias = "const")]
     const A: u32 = 0;
 }
 

--- a/src/test/ui/check-doc-alias-attr-location.rs
+++ b/src/test/ui/check-doc-alias-attr-location.rs
@@ -1,0 +1,24 @@
+#![crate_type="lib"]
+#![feature(doc_alias)]
+
+pub struct Bar;
+pub trait Foo {
+    type X;
+    fn foo() -> Self::X;
+}
+
+#[doc(alias = "foo")] //~ ERROR
+extern {}
+
+#[doc(alias = "bar")] //~ ERROR
+impl Bar {
+    #[doc(alias = "const")] //~ ERROR
+    const A: u32 = 0;
+}
+
+#[doc(alias = "foobar")] //~ ERROR
+impl Foo for Bar {
+    #[doc(alias = "assoc")] //~ ERROR
+    type X = i32;
+    fn foo() -> Self::X { 0 }
+}

--- a/src/test/ui/check-doc-alias-attr-location.stderr
+++ b/src/test/ui/check-doc-alias-attr-location.stderr
@@ -1,29 +1,29 @@
 error: `#[doc(alias = "...")]` isn't allowed on extern block
-  --> $DIR/check-doc-alias-attr-location.rs:9:7
+  --> $DIR/check-doc-alias-attr-location.rs:10:7
    |
 LL | #[doc(alias = "foo")]
    |       ^^^^^^^^^^^^^
 
 error: `#[doc(alias = "...")]` isn't allowed on implementation block
-  --> $DIR/check-doc-alias-attr-location.rs:12:7
+  --> $DIR/check-doc-alias-attr-location.rs:13:7
    |
 LL | #[doc(alias = "bar")]
    |       ^^^^^^^^^^^^^
 
 error: `#[doc(alias = "...")]` isn't allowed on implementation block
-  --> $DIR/check-doc-alias-attr-location.rs:18:7
+  --> $DIR/check-doc-alias-attr-location.rs:19:7
    |
 LL | #[doc(alias = "foobar")]
    |       ^^^^^^^^^^^^^^^^
 
 error: `#[doc(alias = "...")]` isn't allowed on const in implementation block
-  --> $DIR/check-doc-alias-attr-location.rs:14:11
+  --> $DIR/check-doc-alias-attr-location.rs:15:11
    |
 LL |     #[doc(alias = "const")]
    |           ^^^^^^^^^^^^^^^
 
 error: `#[doc(alias = "...")]` isn't allowed on type alias in implementation block
-  --> $DIR/check-doc-alias-attr-location.rs:20:11
+  --> $DIR/check-doc-alias-attr-location.rs:21:11
    |
 LL |     #[doc(alias = "assoc")]
    |           ^^^^^^^^^^^^^^^

--- a/src/test/ui/check-doc-alias-attr-location.stderr
+++ b/src/test/ui/check-doc-alias-attr-location.stderr
@@ -16,17 +16,11 @@ error: `#[doc(alias = "...")]` isn't allowed on implementation block
 LL | #[doc(alias = "foobar")]
    |       ^^^^^^^^^^^^^^^^
 
-error: `#[doc(alias = "...")]` isn't allowed on const in implementation block
-  --> $DIR/check-doc-alias-attr-location.rs:15:11
-   |
-LL |     #[doc(alias = "const")]
-   |           ^^^^^^^^^^^^^^^
-
 error: `#[doc(alias = "...")]` isn't allowed on type alias in implementation block
   --> $DIR/check-doc-alias-attr-location.rs:21:11
    |
 LL |     #[doc(alias = "assoc")]
    |           ^^^^^^^^^^^^^^^
 
-error: aborting due to 5 previous errors
+error: aborting due to 4 previous errors
 


### PR DESCRIPTION
Following the discussion in #73721, I added checks to ensure that only items appearing in the search are allowed to have doc alias.

r? @ollie27 