### PR TITLE
Only add CFGuard on `windows-msvc` targets

### DIFF
--- a/src/librustc_codegen_llvm/context.rs
+++ b/src/librustc_codegen_llvm/context.rs
@@ -188,14 +188,19 @@ pub unsafe fn create_module(
         llvm::LLVMRustAddModuleFlag(llmod, avoid_plt, 1);
     }
 
-    // Set module flags to enable Windows Control Flow Guard (/guard:cf) metadata
-    // only (`cfguard=1`) or metadata and checks (`cfguard=2`).
-    match sess.opts.debugging_opts.control_flow_guard {
-        CFGuard::Disabled => {}
-        CFGuard::NoChecks => {
-            llvm::LLVMRustAddModuleFlag(llmod, "cfguard\0".as_ptr() as *const _, 1)
+    // Control Flow Guard is currently only supported by the MSVC linker on Windows.
+    if sess.target.target.options.is_like_msvc {
+        match sess.opts.debugging_opts.control_flow_guard {
+            CFGuard::Disabled => {}
+            CFGuard::NoChecks => {
+                // Set `cfguard=1` module flag to emit metadata only.
+                llvm::LLVMRustAddModuleFlag(llmod, "cfguard\0".as_ptr() as *const _, 1)
+            }
+            CFGuard::Checks => {
+                // Set `cfguard=2` module flag to emit metadata and checks.
+                llvm::LLVMRustAddModuleFlag(llmod, "cfguard\0".as_ptr() as *const _, 2)
+            }
         }
-        CFGuard::Checks => llvm::LLVMRustAddModuleFlag(llmod, "cfguard\0".as_ptr() as *const _, 2),
     }
 
     llmod

--- a/src/librustc_codegen_ssa/back/linker.rs
+++ b/src/librustc_codegen_ssa/back/linker.rs
@@ -475,9 +475,7 @@ impl<'a> Linker for GccLinker<'a> {
         self.cmd.arg("__llvm_profile_runtime");
     }
 
-    fn control_flow_guard(&mut self) {
-        self.sess.warn("Windows Control Flow Guard is not supported by this linker.");
-    }
+    fn control_flow_guard(&mut self) {}
 
     fn debuginfo(&mut self, strip: Strip) {
         match strip {
@@ -959,9 +957,7 @@ impl<'a> Linker for EmLinker<'a> {
         // noop, but maybe we need something like the gnu linker?
     }
 
-    fn control_flow_guard(&mut self) {
-        self.sess.warn("Windows Control Flow Guard is not supported by this linker.");
-    }
+    fn control_flow_guard(&mut self) {}
 
     fn debuginfo(&mut self, _strip: Strip) {
         // Preserve names or generate source maps depending on debug info
@@ -1163,9 +1159,7 @@ impl<'a> Linker for WasmLd<'a> {
         }
     }
 
-    fn control_flow_guard(&mut self) {
-        self.sess.warn("Windows Control Flow Guard is not supported by this linker.");
-    }
+    fn control_flow_guard(&mut self) {}
 
     fn no_crt_objects(&mut self) {}
 
@@ -1330,9 +1324,7 @@ impl<'a> Linker for PtxLinker<'a> {
 
     fn no_default_libraries(&mut self) {}
 
-    fn control_flow_guard(&mut self) {
-        self.sess.warn("Windows Control Flow Guard is not supported by this linker.");
-    }
+    fn control_flow_guard(&mut self) {}
 
     fn export_symbols(&mut self, _tmpdir: &Path, _crate_type: CrateType) {}
 

--- a/src/test/codegen/cfguard-checks.rs
+++ b/src/test/codegen/cfguard-checks.rs
@@ -1,4 +1,5 @@
 // compile-flags: -Z control-flow-guard=checks
+// only-msvc
 
 #![crate_type = "lib"]
 

--- a/src/test/codegen/cfguard-disabled.rs
+++ b/src/test/codegen/cfguard-disabled.rs
@@ -1,4 +1,5 @@
 // compile-flags: -Z control-flow-guard=no
+// only-msvc
 
 #![crate_type = "lib"]
 

--- a/src/test/codegen/cfguard-nochecks.rs
+++ b/src/test/codegen/cfguard-nochecks.rs
@@ -1,4 +1,5 @@
 // compile-flags: -Z control-flow-guard=nochecks
+// only-msvc
 
 #![crate_type = "lib"]
 

--- a/src/test/codegen/cfguard-non-msvc.rs
+++ b/src/test/codegen/cfguard-non-msvc.rs
@@ -1,0 +1,11 @@
+// compile-flags: -Z control-flow-guard
+// ignore-msvc
+
+#![crate_type = "lib"]
+
+// A basic test function.
+pub fn test() {
+}
+
+// Ensure the cfguard module flag is not added for non-MSVC targets.
+// CHECK-NOT: !"cfguard"

--- a/src/test/ui/cfguard-run.rs
+++ b/src/test/ui/cfguard-run.rs
@@ -1,0 +1,6 @@
+// run-pass
+// compile-flags: -Z control-flow-guard
+
+pub fn main() {
+    println!("hello, world");
+}


### PR DESCRIPTION
As @ollie27 pointed out in #73893, the `cfguard` module flag causes incorrect behavior on `windows-gnu` targets. This patch restricts rustc to only add this flag for `windows-msvc` targets (this may need to be changed if other linkers gain support for CFGuard).