### PR TITLE
Suppress debuginfo on naked function arguments

### DIFF
--- a/src/test/codegen/naked-functions.rs
+++ b/src/test/codegen/naked-functions.rs
@@ -18,7 +18,7 @@ pub fn naked_empty() {
 // CHECK-NEXT: define void @naked_with_args(i{{[0-9]+( %0)?}})
 pub fn naked_with_args(a: isize) {
     // CHECK-NEXT: {{.+}}:
-    // CHECK-NEXT: %a = alloca i{{[0-9]+}}
+    // CHECK-NEXT: %_1 = alloca i{{[0-9]+}}
     &a; // keep variable in an alloca
     // CHECK: ret void
 }
@@ -39,7 +39,7 @@ pub fn naked_with_return() -> isize {
 #[naked]
 pub fn naked_with_args_and_return(a: isize) -> isize {
     // CHECK-NEXT: {{.+}}:
-    // CHECK-NEXT: %a = alloca i{{[0-9]+}}
+    // CHECK-NEXT: %_1 = alloca i{{[0-9]+}}
     &a; // keep variable in an alloca
     // CHECK: ret i{{[0-9]+}} %{{[0-9]+}}
     a

--- a/src/test/debuginfo/function-arguments-naked.rs
+++ b/src/test/debuginfo/function-arguments-naked.rs
@@ -1,0 +1,40 @@
+// min-lldb-version: 310
+
+// We have to ignore android because of this issue:
+// https://github.com/rust-lang/rust/issues/74847
+// ignore-android
+
+// compile-flags:-g
+
+// === GDB TESTS ===================================================================================
+
+// gdb-command:run
+
+// gdb-command:info args
+// gdb-check:No arguments.
+// gdb-command:continue
+
+// === LLDB TESTS ==================================================================================
+
+// lldb-command:run
+
+// lldb-command:frame variable
+// lldbg-check:(unsigned long) = 111 (unsigned long) = 222
+// lldbr-check:(unsigned long) = 111 (unsigned long) = 222
+// lldb-command:continue
+
+
+#![feature(naked_functions)]
+#![feature(omit_gdb_pretty_printer_section)]
+#![omit_gdb_pretty_printer_section]
+
+fn main() {
+    naked(111, 222);
+}
+
+#[naked]
+fn naked(x: usize, y: usize) {
+    zzz(); // #break
+}
+
+fn zzz() { () }


### PR DESCRIPTION
A function that has no prologue cannot be reasonably expected to support
debuginfo. In fact, the existing code (before this patch) would generate
invalid instructions that caused crashes. We can solve this easily by
just not emitting the debuginfo in this case.

Fixes https://github.com/rust-lang/rust/issues/42779
cc https://github.com/rust-lang/rust/issues/32408