### PR TITLE
Hide `&mut self` methods from Deref in sidebar if there are no `DerefMut` impl for the type.

### DIFF
--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -4095,6 +4095,10 @@ fn sidebar_assoc_items(it: &clean::Item) -> String {
                         _ => None,
                     })
                 {
+                    let deref_mut = v
+                        .iter()
+                        .filter(|i| i.inner_impl().trait_.is_some())
+                        .any(|i| i.inner_impl().trait_.def_id() == c.deref_mut_trait_did);
                     let inner_impl = target
                         .def_id()
                         .or(target
@@ -4115,7 +4119,9 @@ fn sidebar_assoc_items(it: &clean::Item) -> String {
                         let mut ret = impls
                             .iter()
                             .filter(|i| i.inner_impl().trait_.is_none())
-                            .flat_map(|i| get_methods(i.inner_impl(), true, &mut used_links, true))
+                            .flat_map(|i| {
+                                get_methods(i.inner_impl(), true, &mut used_links, deref_mut)
+                            })
                             .collect::<Vec<_>>();
                         // We want links' order to be reproducible so we don't use unstable sort.
                         ret.sort();

--- a/src/test/rustdoc/issue-74083.rs
+++ b/src/test/rustdoc/issue-74083.rs
@@ -1,0 +1,21 @@
+use std::ops::Deref;
+
+pub struct Foo;
+
+impl Foo {
+    pub fn foo(&mut self) {}
+}
+
+// @has issue_74083/struct.Bar.html
+// !@has - '//div[@class="sidebar-links"]/a[@href="#method.foo"]' 'foo'
+pub struct Bar {
+    foo: Foo,
+}
+
+impl Deref for Bar {
+    type Target = Foo;
+
+    fn deref(&self) -> &Foo {
+        &self.foo
+    }
+}


### PR DESCRIPTION
This partially addresses #74083.