### PR TITLE
Fix (what I believe is) a typo in OpenOptionsExt

### DIFF
--- a/src/libstd/sys/windows/ext/fs.rs
+++ b/src/libstd/sys/windows/ext/fs.rs
@@ -259,7 +259,7 @@ pub trait OpenOptionsExt {
     /// [Impersonation Levels]:
     ///     https://docs.microsoft.com/en-us/windows/win32/api/winnt/ne-winnt-security_impersonation_level
     #[stable(feature = "open_options_ext", since = "1.10.0")]
-    fn security_qos_flags(&mut self, flags: u32) -> &mut OpenOptions;
+    fn security_qos_flags(&mut self, flags: u32) -> &mut Self;
 }
 
 #[stable(feature = "open_options_ext", since = "1.10.0")]


### PR DESCRIPTION
This commit fixes what I believe is a typo in `OpenOptionsExt` trait on Windows. `security_qos_flags` trait method mysteriously, as the only method, returns a concrete type instead a `&mut Self`.

EDIT: apologies if this is a duplicate.