### PR TITLE
Only allow `repr(i128/u128)` on enum

### DIFF
--- a/src/librustc_passes/check_attr.rs
+++ b/src/librustc_passes/check_attr.rs
@@ -292,6 +292,8 @@ impl CheckAttrVisitor<'tcx> {
                 | sym::u32
                 | sym::i64
                 | sym::u64
+                | sym::i128
+                | sym::u128
                 | sym::isize
                 | sym::usize => {
                     int_reprs += 1;

--- a/src/test/ui/issues/issue-74082.rs
+++ b/src/test/ui/issues/issue-74082.rs
@@ -1,0 +1,9 @@
+#![allow(dead_code)]
+
+#[repr(i128)] //~ ERROR: attribute should be applied to enum
+struct Foo;
+
+#[repr(u128)] //~ ERROR: attribute should be applied to enum
+struct Bar;
+
+fn main() {}

--- a/src/test/ui/issues/issue-74082.stderr
+++ b/src/test/ui/issues/issue-74082.stderr
@@ -1,0 +1,19 @@
+error[E0517]: attribute should be applied to enum
+  --> $DIR/issue-74082.rs:3:8
+   |
+LL | #[repr(i128)]
+   |        ^^^^
+LL | struct Foo;
+   | ----------- not an enum
+
+error[E0517]: attribute should be applied to enum
+  --> $DIR/issue-74082.rs:6:8
+   |
+LL | #[repr(u128)]
+   |        ^^^^
+LL | struct Bar;
+   | ----------- not an enum
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0517`.


### PR DESCRIPTION
Fixes #74082 