### PR TITLE
Rollup of 11 pull requests

### DIFF
--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -397,8 +397,6 @@ impl Step for Miri {
             cargo.env("MIRI", &miri);
             // Debug things.
             cargo.env("RUST_BACKTRACE", "1");
-            // Overwrite bootstrap's `rustc` wrapper overwriting our flags.
-            cargo.env("RUSTC_DEBUG_ASSERTIONS", "true");
             // Let cargo-miri know where xargo ended up.
             cargo.env("XARGO_CHECK", builder.out.join("bin").join("xargo-check"));
 

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -1701,7 +1701,7 @@ impl<T> Weak<T> {
     /// ```
     ///
     /// [`null`]: ../../std/ptr/fn.null.html
-    #[stable(feature = "weak_into_raw", since = "1.45.0")]
+    #[stable(feature = "rc_as_ptr", since = "1.45.0")]
     pub fn as_ptr(&self) -> *const T {
         let ptr: *mut RcBox<T> = NonNull::as_ptr(self.ptr);
 

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -1706,7 +1706,7 @@ impl<T> Weak<T> {
     /// ```
     ///
     /// [`null`]: ../../std/ptr/fn.null.html
-    #[stable(feature = "weak_into_raw", since = "1.45.0")]
+    #[stable(feature = "rc_as_ptr", since = "1.45.0")]
     pub fn as_ptr(&self) -> *const T {
         let offset = data_offset_sized::<T>();
         let ptr = self.ptr.cast::<u8>().as_ptr().wrapping_offset(offset);

--- a/src/liballoc/sync.rs
+++ b/src/liballoc/sync.rs
@@ -587,7 +587,7 @@ impl<T: ?Sized> Arc<T> {
     /// assert_eq!(x_ptr, Arc::as_ptr(&y));
     /// assert_eq!(unsafe { &*x_ptr }, "hello");
     /// ```
-    #[stable(feature = "weak_into_raw", since = "1.45.0")]
+    #[stable(feature = "rc_as_ptr", since = "1.45.0")]
     pub fn as_ptr(this: &Self) -> *const T {
         let ptr: *mut ArcInner<T> = NonNull::as_ptr(this.ptr);
 

--- a/src/liballoc/sync.rs
+++ b/src/liballoc/sync.rs
@@ -587,7 +587,7 @@ impl<T: ?Sized> Arc<T> {
     /// assert_eq!(x_ptr, Arc::as_ptr(&y));
     /// assert_eq!(unsafe { &*x_ptr }, "hello");
     /// ```
-    #[stable(feature = "weak_into_raw", since = "1.45.0")]
+    #[stable(feature = "rc_as_ptr", since = "1.45.0")]
     pub fn as_ptr(this: &Self) -> *const T {
         let ptr: *mut ArcInner<T> = NonNull::as_ptr(this.ptr);
         let fake_ptr = ptr as *mut T;

--- a/src/librustc_builtin_macros/format.rs
+++ b/src/librustc_builtin_macros/format.rs
@@ -280,6 +280,8 @@ impl<'a, 'b> Context<'a, 'b> {
                                 ("x", "LowerHex"),
                                 ("X", "UpperHex"),
                             ] {
+                                // FIXME: rustfix (`run-rustfix`) fails to apply suggestions.
+                                // > "Cannot replace slice of data that was already replaced"
                                 err.tool_only_span_suggestion(
                                     sp,
                                     &format!("use the `{}` trait", name),

--- a/src/librustc_builtin_macros/format.rs
+++ b/src/librustc_builtin_macros/format.rs
@@ -277,6 +277,8 @@ impl<'a, 'b> Context<'a, 'b> {
                                 ("x", "LowerHex"),
                                 ("X", "UpperHex"),
                             ] {
+                                // FIXME: rustfix (`run-rustfix`) fails to apply suggestions.
+                                // > "Cannot replace slice of data that was already replaced"
                                 err.tool_only_span_suggestion(
                                     sp,
                                     &format!("use the `{}` trait", name),

--- a/src/librustc_mir_build/build/misc.rs
+++ b/src/librustc_mir_build/build/misc.rs
@@ -15,7 +15,9 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
     /// N.B., **No cleanup is scheduled for this temporary.** You should
     /// call `schedule_drop` once the temporary is initialized.
     crate fn temp(&mut self, ty: Ty<'tcx>, span: Span) -> Place<'tcx> {
-        let temp = self.local_decls.push(LocalDecl::new(ty, span));
+        // Mark this local as internal to avoid temporaries with types not present in the
+        // user's code resulting in ICEs from the generator transform.
+        let temp = self.local_decls.push(LocalDecl::new(ty, span).internal());
         let place = Place::from(temp);
         debug!("temp: created temp {:?} with type {:?}", place, self.local_decls[temp].ty);
         place

--- a/src/librustc_parse/parser/diagnostics.rs
+++ b/src/librustc_parse/parser/diagnostics.rs
@@ -1228,10 +1228,13 @@ impl<'a> Parser<'a> {
                 if let Some(sp) = unmatched.unclosed_span {
                     err.span_label(sp, "unclosed delimiter");
                 }
+                // Backticks should be removed to apply suggestions.
+                let mut delim = delim.to_string();
+                delim.retain(|c| c != '`');
                 err.span_suggestion_short(
                     self.prev_token.span.shrink_to_hi(),
-                    &format!("{} may belong here", delim.to_string()),
-                    delim.to_string(),
+                    &format!("`{}` may belong here", delim),
+                    delim,
                     Applicability::MaybeIncorrect,
                 );
                 if unmatched.found_delim.is_none() {

--- a/src/librustc_parse/parser/diagnostics.rs
+++ b/src/librustc_parse/parser/diagnostics.rs
@@ -1219,10 +1219,13 @@ impl<'a> Parser<'a> {
                 if let Some(sp) = unmatched.unclosed_span {
                     err.span_label(sp, "unclosed delimiter");
                 }
+                // Backticks should be removed to apply suggestions.
+                let mut delim = delim.to_string();
+                delim.retain(|c| c != '`');
                 err.span_suggestion_short(
                     self.prev_token.span.shrink_to_hi(),
-                    &format!("{} may belong here", delim.to_string()),
-                    delim.to_string(),
+                    &format!("`{}` may belong here", delim),
+                    delim,
                     Applicability::MaybeIncorrect,
                 );
                 if unmatched.found_delim.is_none() {

--- a/src/librustc_parse/parser/mod.rs
+++ b/src/librustc_parse/parser/mod.rs
@@ -699,7 +699,7 @@ impl<'a> Parser<'a> {
                                     // misses a separator.
                                     expect_err
                                         .span_suggestion_short(
-                                            sp,
+                                            self.sess.source_map().next_point(sp),
                                             &format!("missing `{}`", token_str),
                                             token_str,
                                             Applicability::MaybeIncorrect,

--- a/src/librustc_typeck/check/regionck.rs
+++ b/src/librustc_typeck/check/regionck.rs
@@ -488,7 +488,7 @@ impl<'a, 'tcx> RegionCtxt<'a, 'tcx> {
     ) {
         if let mc::PlaceBase::Rvalue = place_with_id.place.base {
             if place_with_id.place.projections.is_empty() {
-                let typ = self.resolve_type(place_with_id.place.ty);
+                let typ = self.resolve_type(place_with_id.place.ty());
                 let body_id = self.body_id;
                 let _ = dropck::check_drop_obligations(self, typ, span, body_id);
             }
@@ -640,8 +640,8 @@ impl<'a, 'tcx> RegionCtxt<'a, 'tcx> {
         borrow_kind: ty::BorrowKind,
         borrow_place: &mc::PlaceWithHirId<'tcx>,
     ) {
-        let origin = infer::DataBorrowed(borrow_place.place.ty, span);
-        self.type_must_outlive(origin, borrow_place.place.ty, borrow_region);
+        let origin = infer::DataBorrowed(borrow_place.place.ty(), span);
+        self.type_must_outlive(origin, borrow_place.place.ty(), borrow_region);
 
         for pointer_ty in borrow_place.place.deref_tys() {
             debug!(

--- a/src/librustc_typeck/expr_use_visitor.rs
+++ b/src/librustc_typeck/expr_use_visitor.rs
@@ -384,7 +384,7 @@ impl<'a, 'tcx> ExprUseVisitor<'a, 'tcx> {
 
         // Select just those fields of the `with`
         // expression that will actually be used
-        match with_place.place.ty.kind {
+        match with_place.place.ty().kind {
             ty::Adt(adt, substs) if adt.is_struct() => {
                 // Consume those fields of the with expression that are needed.
                 for (f_index, with_field) in adt.non_enum_variant().fields.iter().enumerate() {
@@ -583,7 +583,7 @@ fn copy_or_move<'a, 'tcx>(
     place_with_id: &PlaceWithHirId<'tcx>,
 ) -> ConsumeMode {
     if !mc.type_is_copy_modulo_regions(
-        place_with_id.place.ty,
+        place_with_id.place.ty(),
         mc.tcx().hir().span(place_with_id.hir_id),
     ) {
         Move

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -100,6 +100,9 @@ h1.fqn {
 	border-bottom: 1px dashed;
 	margin-top: 0;
 }
+h1.fqn > .in-band > a:hover {
+	text-decoration: underline;
+}
 h2, h3:not(.impl):not(.method):not(.type):not(.tymethod), h4:not(.method):not(.type):not(.tymethod):not(.associatedconstant) {
 	border-bottom: 1px solid;
 }

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -164,6 +164,7 @@ impl<'a, 'tcx> LinkCollector<'a, 'tcx> {
     fn resolve(
         &self,
         path_str: &str,
+        disambiguator: Option<&str>,
         ns: Namespace,
         current_item: &Option<String>,
         parent_id: Option<hir::HirId>,
@@ -203,11 +204,22 @@ impl<'a, 'tcx> LinkCollector<'a, 'tcx> {
                         }
                         return Ok((res, Some(path_str.to_owned())));
                     }
-                    other => {
-                        debug!(
-                            "failed to resolve {} in namespace {:?} (got {:?})",
-                            path_str, ns, other
-                        );
+                    Res::Def(DefKind::Mod, _) => {
+                        // This resolved to a module, but if we were passed `type@`,
+                        // we want primitive types to take precedence instead.
+                        if disambiguator == Some("type") {
+                            if let Some(prim) = is_primitive(path_str, ns) {
+                                if extra_fragment.is_some() {
+                                    return Err(ErrorKind::AnchorFailure(
+                                        "primitive types cannot be followed by anchors",
+                                    ));
+                                }
+                                return Ok((prim, Some(path_str.to_owned())));
+                            }
+                        }
+                        return Ok((res, extra_fragment.clone()));
+                    }
+                    _ => {
                         return Ok((res, extra_fragment.clone()));
                     }
                 };
@@ -566,11 +578,13 @@ impl<'a, 'tcx> DocFolder for LinkCollector<'a, 'tcx> {
             let mut path_str;
             let (res, fragment) = {
                 let mut kind = None;
+                let mut disambiguator = None;
                 path_str = if let Some(prefix) = ["struct@", "enum@", "type@", "trait@", "union@"]
                     .iter()
                     .find(|p| link.starts_with(**p))
                 {
                     kind = Some(TypeNS);
+                    disambiguator = Some(&prefix[..prefix.len() - 1]);
                     link.trim_start_matches(prefix)
                 } else if let Some(prefix) = [
                     "const@",
@@ -586,18 +600,23 @@ impl<'a, 'tcx> DocFolder for LinkCollector<'a, 'tcx> {
                 .find(|p| link.starts_with(**p))
                 {
                     kind = Some(ValueNS);
+                    disambiguator = Some(&prefix[..prefix.len() - 1]);
                     link.trim_start_matches(prefix)
                 } else if link.ends_with("()") {
                     kind = Some(ValueNS);
+                    disambiguator = Some("fn");
                     link.trim_end_matches("()")
                 } else if link.starts_with("macro@") {
                     kind = Some(MacroNS);
+                    disambiguator = Some("macro");
                     link.trim_start_matches("macro@")
                 } else if link.starts_with("derive@") {
                     kind = Some(MacroNS);
+                    disambiguator = Some("derive");
                     link.trim_start_matches("derive@")
                 } else if link.ends_with('!') {
                     kind = Some(MacroNS);
+                    disambiguator = Some("macro");
                     link.trim_end_matches('!')
                 } else {
                     &link[..]
@@ -634,6 +653,7 @@ impl<'a, 'tcx> DocFolder for LinkCollector<'a, 'tcx> {
                     Some(ns @ ValueNS) => {
                         match self.resolve(
                             path_str,
+                            disambiguator,
                             ns,
                             &current_item,
                             base_node,
@@ -657,6 +677,7 @@ impl<'a, 'tcx> DocFolder for LinkCollector<'a, 'tcx> {
                     Some(ns @ TypeNS) => {
                         match self.resolve(
                             path_str,
+                            disambiguator,
                             ns,
                             &current_item,
                             base_node,
@@ -683,6 +704,7 @@ impl<'a, 'tcx> DocFolder for LinkCollector<'a, 'tcx> {
                                 .map(|res| (res, extra_fragment.clone())),
                             type_ns: match self.resolve(
                                 path_str,
+                                disambiguator,
                                 TypeNS,
                                 &current_item,
                                 base_node,
@@ -697,6 +719,7 @@ impl<'a, 'tcx> DocFolder for LinkCollector<'a, 'tcx> {
                             },
                             value_ns: match self.resolve(
                                 path_str,
+                                disambiguator,
                                 ValueNS,
                                 &current_item,
                                 base_node,

--- a/src/libstd/net/tcp.rs
+++ b/src/libstd/net/tcp.rs
@@ -1,3 +1,4 @@
+#![deny(unsafe_op_in_unsafe_fn)]
 use crate::io::prelude::*;
 
 use crate::fmt;
@@ -583,7 +584,8 @@ impl Read for TcpStream {
 
     #[inline]
     unsafe fn initializer(&self) -> Initializer {
-        Initializer::nop()
+        // SAFETY: Read is guaranteed to work on uninitialized memory
+        unsafe { Initializer::nop() }
     }
 }
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -622,7 +624,8 @@ impl Read for &TcpStream {
 
     #[inline]
     unsafe fn initializer(&self) -> Initializer {
-        Initializer::nop()
+        // SAFETY: Read is guaranteed to work on uninitialized memory
+        unsafe { Initializer::nop() }
     }
 }
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/libstd/sys/windows/ext/fs.rs
+++ b/src/libstd/sys/windows/ext/fs.rs
@@ -259,7 +259,7 @@ pub trait OpenOptionsExt {
     /// [Impersonation Levels]:
     ///     https://docs.microsoft.com/en-us/windows/win32/api/winnt/ne-winnt-security_impersonation_level
     #[stable(feature = "open_options_ext", since = "1.10.0")]
-    fn security_qos_flags(&mut self, flags: u32) -> &mut OpenOptions;
+    fn security_qos_flags(&mut self, flags: u32) -> &mut Self;
 }
 
 #[stable(feature = "open_options_ext", since = "1.10.0")]

--- a/src/test/rustdoc/intra-link-prim-precedence.rs
+++ b/src/test/rustdoc/intra-link-prim-precedence.rs
@@ -1,0 +1,12 @@
+// ignore-tidy-linelength
+#![deny(intra_doc_resolution_failure)]
+
+pub mod char {}
+
+/// See also [type@char]
+// @has intra_link_prim_precedence/struct.MyString.html '//a/@href' 'https://doc.rust-lang.org/nightly/std/primitive.char.html'
+pub struct MyString;
+
+/// See also [char]
+// @has intra_link_prim_precedence/struct.MyString2.html '//a/@href' 'intra_link_prim_precedence/char/index.html'
+pub struct MyString2;

--- a/src/test/ui/block-expression-remove-semicolon.fixed
+++ b/src/test/ui/block-expression-remove-semicolon.fixed
@@ -1,0 +1,12 @@
+// run-rustfix
+
+fn foo() -> i32 {
+    0
+}
+
+fn main() {
+    let _x: i32 = {
+        //~^ ERROR mismatched types
+        foo() //~ HELP consider removing this semicolon
+    };
+}

--- a/src/test/ui/block-expression-remove-semicolon.rs
+++ b/src/test/ui/block-expression-remove-semicolon.rs
@@ -1,9 +1,11 @@
+// run-rustfix
+
 fn foo() -> i32 {
-   0
+    0
 }
 
 fn main() {
-    let x: i32 = {
+    let _x: i32 = {
         //~^ ERROR mismatched types
         foo(); //~ HELP consider removing this semicolon
     };

--- a/src/test/ui/block-expression-remove-semicolon.stderr
+++ b/src/test/ui/block-expression-remove-semicolon.stderr
@@ -1,8 +1,8 @@
 error[E0308]: mismatched types
-  --> $DIR/block-expression-remove-semicolon.rs:6:18
+  --> $DIR/block-expression-remove-semicolon.rs:8:19
    |
-LL |       let x: i32 = {
-   |  __________________^
+LL |       let _x: i32 = {
+   |  ___________________^
 LL | |
 LL | |         foo();
    | |              - help: consider removing this semicolon

--- a/src/test/ui/block-result/consider-removing-last-semi.fixed
+++ b/src/test/ui/block-result/consider-removing-last-semi.fixed
@@ -1,0 +1,13 @@
+// run-rustfix
+
+pub fn f() -> String {  //~ ERROR mismatched types
+    0u8;
+    "bla".to_string()
+}
+
+pub fn g() -> String {  //~ ERROR mismatched types
+    "this won't work".to_string();
+    "removeme".to_string()
+}
+
+fn main() {}

--- a/src/test/ui/block-result/consider-removing-last-semi.rs
+++ b/src/test/ui/block-result/consider-removing-last-semi.rs
@@ -1,9 +1,11 @@
-fn f() -> String {  //~ ERROR mismatched types
+// run-rustfix
+
+pub fn f() -> String {  //~ ERROR mismatched types
     0u8;
     "bla".to_string();
 }
 
-fn g() -> String {  //~ ERROR mismatched types
+pub fn g() -> String {  //~ ERROR mismatched types
     "this won't work".to_string();
     "removeme".to_string();
 }

--- a/src/test/ui/block-result/consider-removing-last-semi.stderr
+++ b/src/test/ui/block-result/consider-removing-last-semi.stderr
@@ -1,21 +1,21 @@
 error[E0308]: mismatched types
-  --> $DIR/consider-removing-last-semi.rs:1:11
+  --> $DIR/consider-removing-last-semi.rs:3:15
    |
-LL | fn f() -> String {
-   |    -      ^^^^^^ expected struct `std::string::String`, found `()`
-   |    |
-   |    implicitly returns `()` as its body has no tail or `return` expression
+LL | pub fn f() -> String {
+   |        -      ^^^^^^ expected struct `std::string::String`, found `()`
+   |        |
+   |        implicitly returns `()` as its body has no tail or `return` expression
 LL |     0u8;
 LL |     "bla".to_string();
    |                      - help: consider removing this semicolon
 
 error[E0308]: mismatched types
-  --> $DIR/consider-removing-last-semi.rs:6:11
+  --> $DIR/consider-removing-last-semi.rs:8:15
    |
-LL | fn g() -> String {
-   |    -      ^^^^^^ expected struct `std::string::String`, found `()`
-   |    |
-   |    implicitly returns `()` as its body has no tail or `return` expression
+LL | pub fn g() -> String {
+   |        -      ^^^^^^ expected struct `std::string::String`, found `()`
+   |        |
+   |        implicitly returns `()` as its body has no tail or `return` expression
 LL |     "this won't work".to_string();
 LL |     "removeme".to_string();
    |                           - help: consider removing this semicolon

--- a/src/test/ui/coercion/coercion-missing-tail-expected-type.fixed
+++ b/src/test/ui/coercion/coercion-missing-tail-expected-type.fixed
@@ -1,0 +1,16 @@
+// #41425 -- error message "mismatched types" has wrong types
+// run-rustfix
+
+fn plus_one(x: i32) -> i32 { //~ ERROR mismatched types
+    x + 1
+}
+
+fn foo() -> Result<u8, u64> { //~ ERROR mismatched types
+    Ok(1)
+}
+
+fn main() {
+    let x = plus_one(5);
+    let _ = foo();
+    println!("X = {}", x);
+}

--- a/src/test/ui/coercion/coercion-missing-tail-expected-type.rs
+++ b/src/test/ui/coercion/coercion-missing-tail-expected-type.rs
@@ -1,4 +1,5 @@
 // #41425 -- error message "mismatched types" has wrong types
+// run-rustfix
 
 fn plus_one(x: i32) -> i32 { //~ ERROR mismatched types
     x + 1;
@@ -10,5 +11,6 @@ fn foo() -> Result<u8, u64> { //~ ERROR mismatched types
 
 fn main() {
     let x = plus_one(5);
+    let _ = foo();
     println!("X = {}", x);
 }

--- a/src/test/ui/coercion/coercion-missing-tail-expected-type.stderr
+++ b/src/test/ui/coercion/coercion-missing-tail-expected-type.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/coercion-missing-tail-expected-type.rs:3:24
+  --> $DIR/coercion-missing-tail-expected-type.rs:4:24
    |
 LL | fn plus_one(x: i32) -> i32 {
    |    --------            ^^^ expected `i32`, found `()`
@@ -9,7 +9,7 @@ LL |     x + 1;
    |          - help: consider removing this semicolon
 
 error[E0308]: mismatched types
-  --> $DIR/coercion-missing-tail-expected-type.rs:7:13
+  --> $DIR/coercion-missing-tail-expected-type.rs:8:13
    |
 LL | fn foo() -> Result<u8, u64> {
    |    ---      ^^^^^^^^^^^^^^^ expected enum `std::result::Result`, found `()`

--- a/src/test/ui/const-generics/unused_braces.fixed
+++ b/src/test/ui/const-generics/unused_braces.fixed
@@ -1,0 +1,15 @@
+// check-pass
+// run-rustfix
+
+#![allow(incomplete_features)]
+#![warn(unused_braces)]
+
+#![feature(const_generics)]
+
+struct A<const N: usize>;
+
+fn main() {
+    let _: A<7>; // ok
+    let _: A< 7 >; //~ WARN unnecessary braces
+    let _: A<{ 3 + 5 }>; // ok
+}

--- a/src/test/ui/const-generics/unused_braces.rs
+++ b/src/test/ui/const-generics/unused_braces.rs
@@ -1,8 +1,10 @@
 // check-pass
+// run-rustfix
+
+#![allow(incomplete_features)]
 #![warn(unused_braces)]
 
 #![feature(const_generics)]
-//~^ WARN the feature `const_generics` is incomplete
 
 struct A<const N: usize>;
 

--- a/src/test/ui/const-generics/unused_braces.stderr
+++ b/src/test/ui/const-generics/unused_braces.stderr
@@ -1,23 +1,14 @@
-warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
-  --> $DIR/unused_braces.rs:4:12
-   |
-LL | #![feature(const_generics)]
-   |            ^^^^^^^^^^^^^^
-   |
-   = note: `#[warn(incomplete_features)]` on by default
-   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
-
 warning: unnecessary braces around const expression
-  --> $DIR/unused_braces.rs:11:14
+  --> $DIR/unused_braces.rs:13:14
    |
 LL |     let _: A<{ 7 }>;
    |              ^^^^^ help: remove these braces
    |
 note: the lint level is defined here
-  --> $DIR/unused_braces.rs:2:9
+  --> $DIR/unused_braces.rs:5:9
    |
 LL | #![warn(unused_braces)]
    |         ^^^^^^^^^^^^^
 
-warning: 2 warnings emitted
+warning: 1 warning emitted
 

--- a/src/test/ui/did_you_mean/issue-41679-tilde-bitwise-negation-attempt.fixed
+++ b/src/test/ui/did_you_mean/issue-41679-tilde-bitwise-negation-attempt.fixed
@@ -1,0 +1,5 @@
+// run-rustfix
+
+fn main() {
+    let _x = !1; //~ ERROR cannot be used as a unary operator
+}

--- a/src/test/ui/did_you_mean/issue-41679-tilde-bitwise-negation-attempt.rs
+++ b/src/test/ui/did_you_mean/issue-41679-tilde-bitwise-negation-attempt.rs
@@ -1,3 +1,5 @@
+// run-rustfix
+
 fn main() {
-    let x = ~1; //~ ERROR cannot be used as a unary operator
+    let _x = ~1; //~ ERROR cannot be used as a unary operator
 }

--- a/src/test/ui/did_you_mean/issue-41679-tilde-bitwise-negation-attempt.stderr
+++ b/src/test/ui/did_you_mean/issue-41679-tilde-bitwise-negation-attempt.stderr
@@ -1,8 +1,8 @@
 error: `~` cannot be used as a unary operator
-  --> $DIR/issue-41679-tilde-bitwise-negation-attempt.rs:2:13
+  --> $DIR/issue-41679-tilde-bitwise-negation-attempt.rs:4:14
    |
-LL |     let x = ~1;
-   |             ^ help: use `!` to perform bitwise not
+LL |     let _x = ~1;
+   |              ^ help: use `!` to perform bitwise not
 
 error: aborting due to previous error
 

--- a/src/test/ui/did_you_mean/issue-54109-without-witness.fixed
+++ b/src/test/ui/did_you_mean/issue-54109-without-witness.fixed
@@ -1,0 +1,69 @@
+// run-rustfix
+
+// This test is to check if suggestions can be applied automatically.
+
+#![allow(dead_code, unused_parens)]
+
+fn main() {}
+
+fn test_and() {
+    let a = true;
+    let b = false;
+
+    let _ = a && b; //~ ERROR `and` is not a logical operator
+                     //~| ERROR `and` is not a logical operator
+
+    if a && b { //~ ERROR `and` is not a logical operator
+                 //~| ERROR `and` is not a logical operator
+        println!("both");
+    }
+}
+
+fn test_or() {
+    let a = true;
+    let b = false;
+
+    let _ = a || b; //~ ERROR `or` is not a logical operator
+                    //~| ERROR `or` is not a logical operator
+
+    if a || b { //~ ERROR `or` is not a logical operator
+                //~| ERROR `or` is not a logical operator
+        println!("both");
+    }
+}
+
+fn test_and_par() {
+    let a = true;
+    let b = false;
+    if (a && b) {  //~ ERROR `and` is not a logical operator
+                    //~| ERROR `and` is not a logical operator
+        println!("both");
+    }
+}
+
+fn test_or_par() {
+    let a = true;
+    let b = false;
+    if (a || b) {  //~ ERROR `or` is not a logical operator
+                   //~| ERROR `or` is not a logical operator
+        println!("both");
+    }
+}
+
+fn test_while_and() {
+    let a = true;
+    let b = false;
+    while a && b {  //~ ERROR `and` is not a logical operator
+                     //~| ERROR `and` is not a logical operator
+        println!("both");
+    }
+}
+
+fn test_while_or() {
+    let a = true;
+    let b = false;
+    while a || b { //~ ERROR `or` is not a logical operator
+                   //~| ERROR `or` is not a logical operator
+        println!("both");
+    }
+}

--- a/src/test/ui/did_you_mean/issue-54109-without-witness.rs
+++ b/src/test/ui/did_you_mean/issue-54109-without-witness.rs
@@ -1,0 +1,69 @@
+// run-rustfix
+
+// This test is to check if suggestions can be applied automatically.
+
+#![allow(dead_code, unused_parens)]
+
+fn main() {}
+
+fn test_and() {
+    let a = true;
+    let b = false;
+
+    let _ = a and b; //~ ERROR `and` is not a logical operator
+                     //~| ERROR `and` is not a logical operator
+
+    if a and b { //~ ERROR `and` is not a logical operator
+                 //~| ERROR `and` is not a logical operator
+        println!("both");
+    }
+}
+
+fn test_or() {
+    let a = true;
+    let b = false;
+
+    let _ = a or b; //~ ERROR `or` is not a logical operator
+                    //~| ERROR `or` is not a logical operator
+
+    if a or b { //~ ERROR `or` is not a logical operator
+                //~| ERROR `or` is not a logical operator
+        println!("both");
+    }
+}
+
+fn test_and_par() {
+    let a = true;
+    let b = false;
+    if (a and b) {  //~ ERROR `and` is not a logical operator
+                    //~| ERROR `and` is not a logical operator
+        println!("both");
+    }
+}
+
+fn test_or_par() {
+    let a = true;
+    let b = false;
+    if (a or b) {  //~ ERROR `or` is not a logical operator
+                   //~| ERROR `or` is not a logical operator
+        println!("both");
+    }
+}
+
+fn test_while_and() {
+    let a = true;
+    let b = false;
+    while a and b {  //~ ERROR `and` is not a logical operator
+                     //~| ERROR `and` is not a logical operator
+        println!("both");
+    }
+}
+
+fn test_while_or() {
+    let a = true;
+    let b = false;
+    while a or b { //~ ERROR `or` is not a logical operator
+                   //~| ERROR `or` is not a logical operator
+        println!("both");
+    }
+}

--- a/src/test/ui/did_you_mean/issue-54109-without-witness.stderr
+++ b/src/test/ui/did_you_mean/issue-54109-without-witness.stderr
@@ -1,0 +1,130 @@
+error: `and` is not a logical operator
+  --> $DIR/issue-54109-without-witness.rs:13:15
+   |
+LL |     let _ = a and b;
+   |               ^^^ help: use `&&` to perform logical conjunction
+   |
+   = note: unlike in e.g., python and PHP, `&&` and `||` are used for logical operators
+
+error: `and` is not a logical operator
+  --> $DIR/issue-54109-without-witness.rs:13:15
+   |
+LL |     let _ = a and b;
+   |               ^^^ help: use `&&` to perform logical conjunction
+   |
+   = note: unlike in e.g., python and PHP, `&&` and `||` are used for logical operators
+
+error: `and` is not a logical operator
+  --> $DIR/issue-54109-without-witness.rs:16:10
+   |
+LL |     if a and b {
+   |          ^^^ help: use `&&` to perform logical conjunction
+   |
+   = note: unlike in e.g., python and PHP, `&&` and `||` are used for logical operators
+
+error: `and` is not a logical operator
+  --> $DIR/issue-54109-without-witness.rs:16:10
+   |
+LL |     if a and b {
+   |          ^^^ help: use `&&` to perform logical conjunction
+   |
+   = note: unlike in e.g., python and PHP, `&&` and `||` are used for logical operators
+
+error: `or` is not a logical operator
+  --> $DIR/issue-54109-without-witness.rs:26:15
+   |
+LL |     let _ = a or b;
+   |               ^^ help: use `||` to perform logical disjunction
+   |
+   = note: unlike in e.g., python and PHP, `&&` and `||` are used for logical operators
+
+error: `or` is not a logical operator
+  --> $DIR/issue-54109-without-witness.rs:26:15
+   |
+LL |     let _ = a or b;
+   |               ^^ help: use `||` to perform logical disjunction
+   |
+   = note: unlike in e.g., python and PHP, `&&` and `||` are used for logical operators
+
+error: `or` is not a logical operator
+  --> $DIR/issue-54109-without-witness.rs:29:10
+   |
+LL |     if a or b {
+   |          ^^ help: use `||` to perform logical disjunction
+   |
+   = note: unlike in e.g., python and PHP, `&&` and `||` are used for logical operators
+
+error: `or` is not a logical operator
+  --> $DIR/issue-54109-without-witness.rs:29:10
+   |
+LL |     if a or b {
+   |          ^^ help: use `||` to perform logical disjunction
+   |
+   = note: unlike in e.g., python and PHP, `&&` and `||` are used for logical operators
+
+error: `and` is not a logical operator
+  --> $DIR/issue-54109-without-witness.rs:38:11
+   |
+LL |     if (a and b) {
+   |           ^^^ help: use `&&` to perform logical conjunction
+   |
+   = note: unlike in e.g., python and PHP, `&&` and `||` are used for logical operators
+
+error: `and` is not a logical operator
+  --> $DIR/issue-54109-without-witness.rs:38:11
+   |
+LL |     if (a and b) {
+   |           ^^^ help: use `&&` to perform logical conjunction
+   |
+   = note: unlike in e.g., python and PHP, `&&` and `||` are used for logical operators
+
+error: `or` is not a logical operator
+  --> $DIR/issue-54109-without-witness.rs:47:11
+   |
+LL |     if (a or b) {
+   |           ^^ help: use `||` to perform logical disjunction
+   |
+   = note: unlike in e.g., python and PHP, `&&` and `||` are used for logical operators
+
+error: `or` is not a logical operator
+  --> $DIR/issue-54109-without-witness.rs:47:11
+   |
+LL |     if (a or b) {
+   |           ^^ help: use `||` to perform logical disjunction
+   |
+   = note: unlike in e.g., python and PHP, `&&` and `||` are used for logical operators
+
+error: `and` is not a logical operator
+  --> $DIR/issue-54109-without-witness.rs:56:13
+   |
+LL |     while a and b {
+   |             ^^^ help: use `&&` to perform logical conjunction
+   |
+   = note: unlike in e.g., python and PHP, `&&` and `||` are used for logical operators
+
+error: `and` is not a logical operator
+  --> $DIR/issue-54109-without-witness.rs:56:13
+   |
+LL |     while a and b {
+   |             ^^^ help: use `&&` to perform logical conjunction
+   |
+   = note: unlike in e.g., python and PHP, `&&` and `||` are used for logical operators
+
+error: `or` is not a logical operator
+  --> $DIR/issue-54109-without-witness.rs:65:13
+   |
+LL |     while a or b {
+   |             ^^ help: use `||` to perform logical disjunction
+   |
+   = note: unlike in e.g., python and PHP, `&&` and `||` are used for logical operators
+
+error: `or` is not a logical operator
+  --> $DIR/issue-54109-without-witness.rs:65:13
+   |
+LL |     while a or b {
+   |             ^^ help: use `||` to perform logical disjunction
+   |
+   = note: unlike in e.g., python and PHP, `&&` and `||` are used for logical operators
+
+error: aborting due to 16 previous errors
+

--- a/src/test/ui/error-codes/E0642.fixed
+++ b/src/test/ui/error-codes/E0642.fixed
@@ -1,0 +1,20 @@
+// run-rustfix
+
+#![allow(unused)] // for rustfix
+
+#[derive(Clone, Copy)]
+struct S;
+
+trait T {
+    fn foo(_: (i32, i32)); //~ ERROR patterns aren't allowed in methods without bodies
+
+    fn bar(_: (i32, i32)) {} //~ ERROR patterns aren't allowed in methods without bodies
+
+    fn method(_: S) {} //~ ERROR patterns aren't allowed in methods without bodies
+
+    fn f(&ident: &S) {} // ok
+    fn g(&&ident: &&S) {} // ok
+    fn h(mut ident: S) {} // ok
+}
+
+fn main() {}

--- a/src/test/ui/error-codes/E0642.rs
+++ b/src/test/ui/error-codes/E0642.rs
@@ -1,3 +1,7 @@
+// run-rustfix
+
+#![allow(unused)] // for rustfix
+
 #[derive(Clone, Copy)]
 struct S;
 

--- a/src/test/ui/error-codes/E0642.stderr
+++ b/src/test/ui/error-codes/E0642.stderr
@@ -1,5 +1,5 @@
 error[E0642]: patterns aren't allowed in methods without bodies
-  --> $DIR/E0642.rs:5:12
+  --> $DIR/E0642.rs:9:12
    |
 LL |     fn foo((x, y): (i32, i32));
    |            ^^^^^^
@@ -10,7 +10,7 @@ LL |     fn foo(_: (i32, i32));
    |            ^
 
 error[E0642]: patterns aren't allowed in methods without bodies
-  --> $DIR/E0642.rs:7:12
+  --> $DIR/E0642.rs:11:12
    |
 LL |     fn bar((x, y): (i32, i32)) {}
    |            ^^^^^^
@@ -21,7 +21,7 @@ LL |     fn bar(_: (i32, i32)) {}
    |            ^
 
 error[E0642]: patterns aren't allowed in methods without bodies
-  --> $DIR/E0642.rs:9:15
+  --> $DIR/E0642.rs:13:15
    |
 LL |     fn method(S { .. }: S) {}
    |               ^^^^^^^^

--- a/src/test/ui/generic/generic-no-mangle.fixed
+++ b/src/test/ui/generic/generic-no-mangle.fixed
@@ -1,0 +1,17 @@
+// run-rustfix
+
+#![deny(no_mangle_generic_items)]
+
+
+pub fn foo<T>() {} //~ ERROR functions generic over types or consts must be mangled
+
+
+pub extern fn bar<T>() {} //~ ERROR functions generic over types or consts must be mangled
+
+#[no_mangle]
+pub fn baz(x: &i32) -> &i32 { x }
+
+#[no_mangle]
+pub fn qux<'a>(x: &'a i32) -> &i32 { x }
+
+fn main() {}

--- a/src/test/ui/generic/generic-no-mangle.rs
+++ b/src/test/ui/generic/generic-no-mangle.rs
@@ -1,3 +1,5 @@
+// run-rustfix
+
 #![deny(no_mangle_generic_items)]
 
 #[no_mangle]

--- a/src/test/ui/generic/generic-no-mangle.stderr
+++ b/src/test/ui/generic/generic-no-mangle.stderr
@@ -1,5 +1,5 @@
 error: functions generic over types or consts must be mangled
-  --> $DIR/generic-no-mangle.rs:4:1
+  --> $DIR/generic-no-mangle.rs:6:1
    |
 LL | #[no_mangle]
    | ------------ help: remove this attribute
@@ -7,13 +7,13 @@ LL | pub fn foo<T>() {}
    | ^^^^^^^^^^^^^^^^^^
    |
 note: the lint level is defined here
-  --> $DIR/generic-no-mangle.rs:1:9
+  --> $DIR/generic-no-mangle.rs:3:9
    |
 LL | #![deny(no_mangle_generic_items)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: functions generic over types or consts must be mangled
-  --> $DIR/generic-no-mangle.rs:7:1
+  --> $DIR/generic-no-mangle.rs:9:1
    |
 LL | #[no_mangle]
    | ------------ help: remove this attribute

--- a/src/test/ui/impossible_range.fixed
+++ b/src/test/ui/impossible_range.fixed
@@ -1,0 +1,20 @@
+// run-rustfix
+// Make sure that invalid ranges generate an error during parsing, not an ICE
+
+#![allow(path_statements)]
+
+pub fn main() {
+    ..;
+    0..;
+    ..1;
+    0..1;
+    ..; //~ERROR inclusive range with no end
+         //~^HELP use `..` instead
+}
+
+fn _foo1() {
+    ..=1;
+    0..=1;
+    0..; //~ERROR inclusive range with no end
+          //~^HELP use `..` instead
+}

--- a/src/test/ui/impossible_range.rs
+++ b/src/test/ui/impossible_range.rs
@@ -1,4 +1,7 @@
+// run-rustfix
 // Make sure that invalid ranges generate an error during parsing, not an ICE
+
+#![allow(path_statements)]
 
 pub fn main() {
     ..;

--- a/src/test/ui/impossible_range.stderr
+++ b/src/test/ui/impossible_range.stderr
@@ -1,5 +1,5 @@
 error[E0586]: inclusive range with no end
-  --> $DIR/impossible_range.rs:8:5
+  --> $DIR/impossible_range.rs:11:5
    |
 LL |     ..=;
    |     ^^^ help: use `..` instead
@@ -7,7 +7,7 @@ LL |     ..=;
    = note: inclusive ranges must be bounded at the end (`..=b` or `a..=b`)
 
 error[E0586]: inclusive range with no end
-  --> $DIR/impossible_range.rs:15:6
+  --> $DIR/impossible_range.rs:18:6
    |
 LL |     0..=;
    |      ^^^ help: use `..` instead

--- a/src/test/ui/issue-73914.rs
+++ b/src/test/ui/issue-73914.rs
@@ -1,0 +1,30 @@
+// build-pass
+// compile-flags:-Copt-level=0
+// edition:2018
+
+struct S<T>(std::marker::PhantomData<T>);
+
+impl<T> std::ops::Deref for S<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        todo!()
+    }
+}
+impl<T> std::ops::DerefMut for S<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        todo!()
+    }
+}
+
+async fn new() -> S<u64> {
+    todo!()
+}
+
+async fn crash() {
+    *new().await = 1 + 1;
+}
+
+fn main() {
+    let _ = crash();
+}

--- a/src/test/ui/issues/issue-1962.fixed
+++ b/src/test/ui/issues/issue-1962.fixed
@@ -1,0 +1,10 @@
+// compile-flags: -D while-true
+// run-rustfix
+
+fn main() {
+    let mut i = 0;
+    loop { //~ ERROR denote infinite loops with `loop
+        i += 1;
+        if i == 5 { break; }
+    }
+}

--- a/src/test/ui/issues/issue-1962.rs
+++ b/src/test/ui/issues/issue-1962.rs
@@ -1,8 +1,10 @@
 // compile-flags: -D while-true
+// run-rustfix
+
 fn main() {
-  let mut i = 0;
-  while true  { //~ ERROR denote infinite loops with `loop
-    i += 1;
-    if i == 5 { break; }
-  }
+    let mut i = 0;
+    while true { //~ ERROR denote infinite loops with `loop
+        i += 1;
+        if i == 5 { break; }
+    }
 }

--- a/src/test/ui/issues/issue-1962.stderr
+++ b/src/test/ui/issues/issue-1962.stderr
@@ -1,8 +1,8 @@
 error: denote infinite loops with `loop { ... }`
-  --> $DIR/issue-1962.rs:4:3
+  --> $DIR/issue-1962.rs:6:5
    |
-LL |   while true  {
-   |   ^^^^^^^^^^ help: use `loop`
+LL |     while true {
+   |     ^^^^^^^^^^ help: use `loop`
    |
    = note: requested on the command line with `-D while-true`
 

--- a/src/test/ui/issues/issue-40782.fixed
+++ b/src/test/ui/issues/issue-40782.fixed
@@ -1,0 +1,6 @@
+// run-rustfix
+
+fn main() {
+    for _i in 0..2 { //~ ERROR missing `in`
+    }
+}

--- a/src/test/ui/issues/issue-40782.rs
+++ b/src/test/ui/issues/issue-40782.rs
@@ -1,4 +1,6 @@
+// run-rustfix
+
 fn main() {
-    for i 0..2 { //~ ERROR missing `in`
+    for _i 0..2 { //~ ERROR missing `in`
     }
 }

--- a/src/test/ui/issues/issue-40782.stderr
+++ b/src/test/ui/issues/issue-40782.stderr
@@ -1,8 +1,8 @@
 error: missing `in` in `for` loop
-  --> $DIR/issue-40782.rs:2:10
+  --> $DIR/issue-40782.rs:4:11
    |
-LL |     for i 0..2 {
-   |          ^ help: try adding `in` here
+LL |     for _i 0..2 {
+   |           ^ help: try adding `in` here
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-46186.fixed
+++ b/src/test/ui/issues/issue-46186.fixed
@@ -1,0 +1,8 @@
+// run-rustfix
+
+pub struct Struct {
+    pub a: usize,
+}
+//~^ ERROR expected item, found `;`
+
+fn main() {}

--- a/src/test/ui/issues/issue-46186.rs
+++ b/src/test/ui/issues/issue-46186.rs
@@ -1,5 +1,7 @@
-struct Struct {
-    a: usize,
+// run-rustfix
+
+pub struct Struct {
+    pub a: usize,
 };
 //~^ ERROR expected item, found `;`
 

--- a/src/test/ui/issues/issue-46186.stderr
+++ b/src/test/ui/issues/issue-46186.stderr
@@ -1,5 +1,5 @@
 error: expected item, found `;`
-  --> $DIR/issue-46186.rs:3:2
+  --> $DIR/issue-46186.rs:5:2
    |
 LL | };
    |  ^ help: remove this semicolon

--- a/src/test/ui/issues/issue-50571.fixed
+++ b/src/test/ui/issues/issue-50571.fixed
@@ -1,0 +1,8 @@
+// run-rustfix
+
+trait Foo {
+    fn foo(_: [i32; 2]) {}
+    //~^ ERROR: patterns aren't allowed in methods without bodies
+}
+
+fn main() {}

--- a/src/test/ui/issues/issue-50571.rs
+++ b/src/test/ui/issues/issue-50571.rs
@@ -1,3 +1,5 @@
+// run-rustfix
+
 trait Foo {
     fn foo([a, b]: [i32; 2]) {}
     //~^ ERROR: patterns aren't allowed in methods without bodies

--- a/src/test/ui/issues/issue-50571.stderr
+++ b/src/test/ui/issues/issue-50571.stderr
@@ -1,5 +1,5 @@
 error[E0642]: patterns aren't allowed in methods without bodies
-  --> $DIR/issue-50571.rs:2:12
+  --> $DIR/issue-50571.rs:4:12
    |
 LL |     fn foo([a, b]: [i32; 2]) {}
    |            ^^^^^^

--- a/src/test/ui/lint/issue-54538-unused-parens-lint.fixed
+++ b/src/test/ui/lint/issue-54538-unused-parens-lint.fixed
@@ -1,0 +1,107 @@
+// run-rustfix
+
+#![feature(box_patterns, stmt_expr_attributes)]
+#![feature(or_patterns)]
+
+#![allow(
+    dead_code,
+    ellipsis_inclusive_range_patterns,
+    irrefutable_let_patterns,
+    unreachable_patterns,
+    unused_mut,
+    unused_variables
+)]
+#![deny(unused_parens)]
+
+fn lint_on_top_level() {
+    let a = 0; //~ ERROR unnecessary parentheses around pattern
+    for a in 0..1 {} //~ ERROR unnecessary parentheses around pattern
+    if let a = 0 {} //~ ERROR unnecessary parentheses around pattern
+    while let a = 0 {} //~ ERROR unnecessary parentheses around pattern
+    fn foo(a: u8) {} //~ ERROR unnecessary parentheses around pattern
+    let _ = |a: u8| 0; //~ ERROR unnecessary parentheses around pattern
+}
+
+fn _no_lint_attr() {
+    let _x = #[allow(dead_code)] (1 + 2);
+}
+
+// Don't lint in these cases (#64106).
+fn or_patterns_no_lint() {
+    match Box::new(0) {
+        box (0 | 1) => {} // Should not lint as `box 0 | 1` binds as `(box 0) | 1`.
+        _ => {}
+    }
+
+    match 0 {
+        x @ (0 | 1) => {} // Should not lint as `x @ 0 | 1` binds as `(x @ 0) | 1`.
+        _ => {}
+    }
+
+    if let &(0 | 1) = &0 {} // Should also not lint.
+    if let &mut (0 | 1) = &mut 0 {} // Same.
+
+    fn foo((Ok(a) | Err(a)): Result<u8, u8>) {} // Doesn't parse if we remove parens for now.
+
+    let _ = |(Ok(a) | Err(a)): Result<u8, u8>| 1; // `|Ok(a) | Err(a)| 1` parses as bit-or.
+}
+
+fn or_patterns_will_lint() {
+    if let 0 | 1 = 0 {} //~ ERROR unnecessary parentheses around pattern
+    if let (0 | 1,) = (0,) {} //~ ERROR unnecessary parentheses around pattern
+    if let [0 | 1] = [0] {} //~ ERROR unnecessary parentheses around pattern
+    if let 0 | 1 | 2 = 0 {} //~ ERROR unnecessary parentheses around pattern
+    struct TS(u8);
+    if let TS(0 | 1) = TS(0) {} //~ ERROR unnecessary parentheses around pattern
+    struct NS { f: u8 }
+    if let NS { f: 0 | 1 } = (NS { f: 0 }) {} //~ ERROR unnecessary parentheses around pattern
+}
+
+// Don't lint on `&(mut x)` because `&mut x` means something else (#55342).
+fn deref_mut_binding_no_lint() {
+    let &(mut x) = &0;
+}
+
+fn main() {
+    match 1 {
+        _ => {} //~ ERROR unnecessary parentheses around pattern
+        y => {} //~ ERROR unnecessary parentheses around pattern
+        ref r => {} //~ ERROR unnecessary parentheses around pattern
+        e @ 1...2 => {} //~ ERROR unnecessary parentheses around pattern
+        (1...2) => {} // Non ambiguous range pattern should not warn
+        e @ (3...4) => {} // Non ambiguous range pattern should not warn
+    }
+
+    match &1 {
+        e @ &(1...2) => {} //~ ERROR unnecessary parentheses around pattern
+        &_ => {} //~ ERROR unnecessary parentheses around pattern
+        e @ &(1...2) => {} // Ambiguous range pattern should not warn
+        &(1...2) => {} // Ambiguous range pattern should not warn
+    }
+
+    match &1 {
+        e @ &(1...2) | e @ &(3...4) => {} // Complex ambiguous pattern should not warn
+        &_ => {}
+    }
+
+    match 1 {
+        _ => {} //~ ERROR unnecessary parentheses around pattern
+        y => {} //~ ERROR unnecessary parentheses around pattern
+        ref r => {} //~ ERROR unnecessary parentheses around pattern
+        e @ 1..=2 => {} //~ ERROR unnecessary parentheses around pattern
+        (1..=2) => {} // Non ambiguous range pattern should not warn
+        e @ (3..=4) => {} // Non ambiguous range pattern should not warn
+    }
+
+    match &1 {
+        e @ &(1..=2) => {} //~ ERROR unnecessary parentheses around pattern
+        &_ => {} //~ ERROR unnecessary parentheses around pattern
+        e @ &(1..=2) => {} // Ambiguous range pattern should not warn
+        &(1..=2) => {} // Ambiguous range pattern should not warn
+    }
+
+    match &1 {
+        e @ &(1..=2) | e @ &(3..=4) => {} // Complex ambiguous pattern should not warn
+        &_ => {}
+    }
+}

--- a/src/test/ui/lint/issue-54538-unused-parens-lint.rs
+++ b/src/test/ui/lint/issue-54538-unused-parens-lint.rs
@@ -1,10 +1,16 @@
-#![feature(box_patterns, stmt_expr_attributes)]
+// run-rustfix
 
+#![feature(box_patterns, stmt_expr_attributes)]
 #![feature(or_patterns)]
 
-#![allow(ellipsis_inclusive_range_patterns)]
-#![allow(unreachable_patterns)]
-#![allow(unused_variables)]
+#![allow(
+    dead_code,
+    ellipsis_inclusive_range_patterns,
+    irrefutable_let_patterns,
+    unreachable_patterns,
+    unused_mut,
+    unused_variables
+)]
 #![deny(unused_parens)]
 
 fn lint_on_top_level() {

--- a/src/test/ui/lint/issue-54538-unused-parens-lint.stderr
+++ b/src/test/ui/lint/issue-54538-unused-parens-lint.stderr
@@ -1,149 +1,149 @@
 error: unnecessary parentheses around pattern
-  --> $DIR/issue-54538-unused-parens-lint.rs:11:9
+  --> $DIR/issue-54538-unused-parens-lint.rs:17:9
    |
 LL |     let (a) = 0;
    |         ^^^ help: remove these parentheses
    |
 note: the lint level is defined here
-  --> $DIR/issue-54538-unused-parens-lint.rs:8:9
+  --> $DIR/issue-54538-unused-parens-lint.rs:14:9
    |
 LL | #![deny(unused_parens)]
    |         ^^^^^^^^^^^^^
 
 error: unnecessary parentheses around pattern
-  --> $DIR/issue-54538-unused-parens-lint.rs:12:9
+  --> $DIR/issue-54538-unused-parens-lint.rs:18:9
    |
 LL |     for (a) in 0..1 {}
    |         ^^^ help: remove these parentheses
 
 error: unnecessary parentheses around pattern
-  --> $DIR/issue-54538-unused-parens-lint.rs:13:12
+  --> $DIR/issue-54538-unused-parens-lint.rs:19:12
    |
 LL |     if let (a) = 0 {}
    |            ^^^ help: remove these parentheses
 
 error: unnecessary parentheses around pattern
-  --> $DIR/issue-54538-unused-parens-lint.rs:14:15
+  --> $DIR/issue-54538-unused-parens-lint.rs:20:15
    |
 LL |     while let (a) = 0 {}
    |               ^^^ help: remove these parentheses
 
 error: unnecessary parentheses around pattern
-  --> $DIR/issue-54538-unused-parens-lint.rs:15:12
+  --> $DIR/issue-54538-unused-parens-lint.rs:21:12
    |
 LL |     fn foo((a): u8) {}
    |            ^^^ help: remove these parentheses
 
 error: unnecessary parentheses around pattern
-  --> $DIR/issue-54538-unused-parens-lint.rs:16:14
+  --> $DIR/issue-54538-unused-parens-lint.rs:22:14
    |
 LL |     let _ = |(a): u8| 0;
    |              ^^^ help: remove these parentheses
 
 error: unnecessary parentheses around pattern
-  --> $DIR/issue-54538-unused-parens-lint.rs:44:12
+  --> $DIR/issue-54538-unused-parens-lint.rs:50:12
    |
 LL |     if let (0 | 1) = 0 {}
    |            ^^^^^^^ help: remove these parentheses
 
 error: unnecessary parentheses around pattern
-  --> $DIR/issue-54538-unused-parens-lint.rs:45:13
+  --> $DIR/issue-54538-unused-parens-lint.rs:51:13
    |
 LL |     if let ((0 | 1),) = (0,) {}
    |             ^^^^^^^ help: remove these parentheses
 
 error: unnecessary parentheses around pattern
-  --> $DIR/issue-54538-unused-parens-lint.rs:46:13
+  --> $DIR/issue-54538-unused-parens-lint.rs:52:13
    |
 LL |     if let [(0 | 1)] = [0] {}
    |             ^^^^^^^ help: remove these parentheses
 
 error: unnecessary parentheses around pattern
-  --> $DIR/issue-54538-unused-parens-lint.rs:47:16
+  --> $DIR/issue-54538-unused-parens-lint.rs:53:16
    |
 LL |     if let 0 | (1 | 2) = 0 {}
    |                ^^^^^^^ help: remove these parentheses
 
 error: unnecessary parentheses around pattern
-  --> $DIR/issue-54538-unused-parens-lint.rs:49:15
+  --> $DIR/issue-54538-unused-parens-lint.rs:55:15
    |
 LL |     if let TS((0 | 1)) = TS(0) {}
    |               ^^^^^^^ help: remove these parentheses
 
 error: unnecessary parentheses around pattern
-  --> $DIR/issue-54538-unused-parens-lint.rs:51:20
+  --> $DIR/issue-54538-unused-parens-lint.rs:57:20
    |
 LL |     if let NS { f: (0 | 1) } = (NS { f: 0 }) {}
    |                    ^^^^^^^ help: remove these parentheses
 
 error: unnecessary parentheses around pattern
-  --> $DIR/issue-54538-unused-parens-lint.rs:61:9
+  --> $DIR/issue-54538-unused-parens-lint.rs:67:9
    |
 LL |         (_) => {}
    |         ^^^ help: remove these parentheses
 
 error: unnecessary parentheses around pattern
-  --> $DIR/issue-54538-unused-parens-lint.rs:62:9
+  --> $DIR/issue-54538-unused-parens-lint.rs:68:9
    |
 LL |         (y) => {}
    |         ^^^ help: remove these parentheses
 
 error: unnecessary parentheses around pattern
-  --> $DIR/issue-54538-unused-parens-lint.rs:63:9
+  --> $DIR/issue-54538-unused-parens-lint.rs:69:9
    |
 LL |         (ref r) => {}
    |         ^^^^^^^ help: remove these parentheses
 
 error: unnecessary parentheses around pattern
-  --> $DIR/issue-54538-unused-parens-lint.rs:64:9
+  --> $DIR/issue-54538-unused-parens-lint.rs:70:9
    |
 LL |         (e @ 1...2) => {}
    |         ^^^^^^^^^^^ help: remove these parentheses
 
 error: unnecessary parentheses around pattern
-  --> $DIR/issue-54538-unused-parens-lint.rs:70:9
+  --> $DIR/issue-54538-unused-parens-lint.rs:76:9
    |
 LL |         (e @ &(1...2)) => {}
    |         ^^^^^^^^^^^^^^ help: remove these parentheses
 
 error: unnecessary parentheses around pattern
-  --> $DIR/issue-54538-unused-parens-lint.rs:71:10
+  --> $DIR/issue-54538-unused-parens-lint.rs:77:10
    |
 LL |         &(_) => {}
    |          ^^^ help: remove these parentheses
 
 error: unnecessary parentheses around pattern
-  --> $DIR/issue-54538-unused-parens-lint.rs:82:9
+  --> $DIR/issue-54538-unused-parens-lint.rs:88:9
    |
 LL |         (_) => {}
    |         ^^^ help: remove these parentheses
 
 error: unnecessary parentheses around pattern
-  --> $DIR/issue-54538-unused-parens-lint.rs:83:9
+  --> $DIR/issue-54538-unused-parens-lint.rs:89:9
    |
 LL |         (y) => {}
    |         ^^^ help: remove these parentheses
 
 error: unnecessary parentheses around pattern
-  --> $DIR/issue-54538-unused-parens-lint.rs:84:9
+  --> $DIR/issue-54538-unused-parens-lint.rs:90:9
    |
 LL |         (ref r) => {}
    |         ^^^^^^^ help: remove these parentheses
 
 error: unnecessary parentheses around pattern
-  --> $DIR/issue-54538-unused-parens-lint.rs:85:9
+  --> $DIR/issue-54538-unused-parens-lint.rs:91:9
    |
 LL |         (e @ 1..=2) => {}
    |         ^^^^^^^^^^^ help: remove these parentheses
 
 error: unnecessary parentheses around pattern
-  --> $DIR/issue-54538-unused-parens-lint.rs:91:9
+  --> $DIR/issue-54538-unused-parens-lint.rs:97:9
    |
 LL |         (e @ &(1..=2)) => {}
    |         ^^^^^^^^^^^^^^ help: remove these parentheses
 
 error: unnecessary parentheses around pattern
-  --> $DIR/issue-54538-unused-parens-lint.rs:92:10
+  --> $DIR/issue-54538-unused-parens-lint.rs:98:10
    |
 LL |         &(_) => {}
    |          ^^^ help: remove these parentheses

--- a/src/test/ui/lint/lint-unnecessary-parens.fixed
+++ b/src/test/ui/lint/lint-unnecessary-parens.fixed
@@ -1,0 +1,79 @@
+// run-rustfix
+
+#![deny(unused_parens)]
+#![allow(while_true)] // for rustfix
+
+#[derive(Eq, PartialEq)]
+struct X { y: bool }
+impl X {
+    fn foo(&self, conjunct: bool) -> bool { self.y && conjunct }
+}
+
+fn foo() -> isize {
+    return 1; //~ ERROR unnecessary parentheses around `return` value
+}
+fn bar(y: bool) -> X {
+    return X { y }; //~ ERROR unnecessary parentheses around `return` value
+}
+
+pub fn unused_parens_around_return_type() -> u32 { //~ ERROR unnecessary parentheses around type
+    panic!()
+}
+
+pub fn unused_parens_around_block_return() -> u32 {
+    let _foo = {
+        5 //~ ERROR unnecessary parentheses around block return value
+    };
+    5 //~ ERROR unnecessary parentheses around block return value
+}
+
+pub trait Trait {
+    fn test(&self);
+}
+
+pub fn passes_unused_parens_lint() -> &'static (dyn Trait) {
+    panic!()
+}
+
+macro_rules! baz {
+    ($($foo:expr),+) => {
+        ($($foo),*)
+    }
+}
+
+pub const CONST_ITEM: usize = 10; //~ ERROR unnecessary parentheses around assigned value
+pub static STATIC_ITEM: usize = 10; //~ ERROR unnecessary parentheses around assigned value
+
+fn main() {
+    foo();
+    bar(true); //~ ERROR unnecessary parentheses around function argument
+
+    if true {} //~ ERROR unnecessary parentheses around `if` condition
+    while true {} //~ ERROR unnecessary parentheses around `while` condition
+    match true { //~ ERROR unnecessary parentheses around `match` scrutinee expression
+        _ => {}
+    }
+    if let 1 = 1 {} //~ ERROR unnecessary parentheses around `let` scrutinee expression
+    while let 1 = 2 {} //~ ERROR unnecessary parentheses around `let` scrutinee expression
+    let v = X { y: false };
+    // struct lits needs parens, so these shouldn't warn.
+    if (v == X { y: true }) {}
+    if (X { y: true } == v) {}
+    if (X { y: false }.y) {}
+
+    while (X { y: false }.foo(true)) {}
+    while (true | X { y: false }.y) {}
+
+    match (X { y: false }) {
+        _ => {}
+    }
+
+    X { y: false }.foo(true); //~ ERROR unnecessary parentheses around method argument
+
+    let mut _a = 0; //~ ERROR unnecessary parentheses around assigned value
+    _a = 0; //~ ERROR unnecessary parentheses around assigned value
+    _a += 1; //~ ERROR unnecessary parentheses around assigned value
+
+    let _a = baz!(3, 4);
+    let _b = baz!(3);
+}

--- a/src/test/ui/lint/lint-unnecessary-parens.rs
+++ b/src/test/ui/lint/lint-unnecessary-parens.rs
@@ -1,4 +1,7 @@
+// run-rustfix
+
 #![deny(unused_parens)]
+#![allow(while_true)] // for rustfix
 
 #[derive(Eq, PartialEq)]
 struct X { y: bool }
@@ -13,22 +16,22 @@ fn bar(y: bool) -> X {
     return (X { y }); //~ ERROR unnecessary parentheses around `return` value
 }
 
-fn unused_parens_around_return_type() -> (u32) { //~ ERROR unnecessary parentheses around type
+pub fn unused_parens_around_return_type() -> (u32) { //~ ERROR unnecessary parentheses around type
     panic!()
 }
 
-fn unused_parens_around_block_return() -> u32 {
-    let foo = {
+pub fn unused_parens_around_block_return() -> u32 {
+    let _foo = {
         (5) //~ ERROR unnecessary parentheses around block return value
     };
     (5) //~ ERROR unnecessary parentheses around block return value
 }
 
-trait Trait {
+pub trait Trait {
     fn test(&self);
 }
 
-fn passes_unused_parens_lint() -> &'static (dyn Trait) {
+pub fn passes_unused_parens_lint() -> &'static (dyn Trait) {
     panic!()
 }
 
@@ -38,8 +41,8 @@ macro_rules! baz {
     }
 }
 
-const CONST_ITEM: usize = (10); //~ ERROR unnecessary parentheses around assigned value
-static STATIC_ITEM: usize = (10); //~ ERROR unnecessary parentheses around assigned value
+pub const CONST_ITEM: usize = (10); //~ ERROR unnecessary parentheses around assigned value
+pub static STATIC_ITEM: usize = (10); //~ ERROR unnecessary parentheses around assigned value
 
 fn main() {
     foo();
@@ -47,7 +50,6 @@ fn main() {
 
     if (true) {} //~ ERROR unnecessary parentheses around `if` condition
     while (true) {} //~ ERROR unnecessary parentheses around `while` condition
-    //~^ WARN denote infinite loops with
     match (true) { //~ ERROR unnecessary parentheses around `match` scrutinee expression
         _ => {}
     }

--- a/src/test/ui/lint/lint-unnecessary-parens.stderr
+++ b/src/test/ui/lint/lint-unnecessary-parens.stderr
@@ -1,118 +1,110 @@
 error: unnecessary parentheses around `return` value
-  --> $DIR/lint-unnecessary-parens.rs:10:12
+  --> $DIR/lint-unnecessary-parens.rs:13:12
    |
 LL |     return (1);
    |            ^^^ help: remove these parentheses
    |
 note: the lint level is defined here
-  --> $DIR/lint-unnecessary-parens.rs:1:9
+  --> $DIR/lint-unnecessary-parens.rs:3:9
    |
 LL | #![deny(unused_parens)]
    |         ^^^^^^^^^^^^^
 
 error: unnecessary parentheses around `return` value
-  --> $DIR/lint-unnecessary-parens.rs:13:12
+  --> $DIR/lint-unnecessary-parens.rs:16:12
    |
 LL |     return (X { y });
    |            ^^^^^^^^^ help: remove these parentheses
 
 error: unnecessary parentheses around type
-  --> $DIR/lint-unnecessary-parens.rs:16:42
+  --> $DIR/lint-unnecessary-parens.rs:19:46
    |
-LL | fn unused_parens_around_return_type() -> (u32) {
-   |                                          ^^^^^ help: remove these parentheses
+LL | pub fn unused_parens_around_return_type() -> (u32) {
+   |                                              ^^^^^ help: remove these parentheses
 
 error: unnecessary parentheses around block return value
-  --> $DIR/lint-unnecessary-parens.rs:22:9
+  --> $DIR/lint-unnecessary-parens.rs:25:9
    |
 LL |         (5)
    |         ^^^ help: remove these parentheses
 
 error: unnecessary parentheses around block return value
-  --> $DIR/lint-unnecessary-parens.rs:24:5
+  --> $DIR/lint-unnecessary-parens.rs:27:5
    |
 LL |     (5)
    |     ^^^ help: remove these parentheses
 
 error: unnecessary parentheses around assigned value
-  --> $DIR/lint-unnecessary-parens.rs:41:27
+  --> $DIR/lint-unnecessary-parens.rs:44:31
    |
-LL | const CONST_ITEM: usize = (10);
-   |                           ^^^^ help: remove these parentheses
+LL | pub const CONST_ITEM: usize = (10);
+   |                               ^^^^ help: remove these parentheses
 
 error: unnecessary parentheses around assigned value
-  --> $DIR/lint-unnecessary-parens.rs:42:29
+  --> $DIR/lint-unnecessary-parens.rs:45:33
    |
-LL | static STATIC_ITEM: usize = (10);
-   |                             ^^^^ help: remove these parentheses
+LL | pub static STATIC_ITEM: usize = (10);
+   |                                 ^^^^ help: remove these parentheses
 
 error: unnecessary parentheses around function argument
-  --> $DIR/lint-unnecessary-parens.rs:46:9
+  --> $DIR/lint-unnecessary-parens.rs:49:9
    |
 LL |     bar((true));
    |         ^^^^^^ help: remove these parentheses
 
 error: unnecessary parentheses around `if` condition
-  --> $DIR/lint-unnecessary-parens.rs:48:8
+  --> $DIR/lint-unnecessary-parens.rs:51:8
    |
 LL |     if (true) {}
    |        ^^^^^^ help: remove these parentheses
 
 error: unnecessary parentheses around `while` condition
-  --> $DIR/lint-unnecessary-parens.rs:49:11
+  --> $DIR/lint-unnecessary-parens.rs:52:11
    |
 LL |     while (true) {}
    |           ^^^^^^ help: remove these parentheses
 
-warning: denote infinite loops with `loop { ... }`
-  --> $DIR/lint-unnecessary-parens.rs:49:5
-   |
-LL |     while (true) {}
-   |     ^^^^^^^^^^^^ help: use `loop`
-   |
-   = note: `#[warn(while_true)]` on by default
-
 error: unnecessary parentheses around `match` scrutinee expression
-  --> $DIR/lint-unnecessary-parens.rs:51:11
+  --> $DIR/lint-unnecessary-parens.rs:53:11
    |
 LL |     match (true) {
    |           ^^^^^^ help: remove these parentheses
 
 error: unnecessary parentheses around `let` scrutinee expression
-  --> $DIR/lint-unnecessary-parens.rs:54:16
+  --> $DIR/lint-unnecessary-parens.rs:56:16
    |
 LL |     if let 1 = (1) {}
    |                ^^^ help: remove these parentheses
 
 error: unnecessary parentheses around `let` scrutinee expression
-  --> $DIR/lint-unnecessary-parens.rs:55:19
+  --> $DIR/lint-unnecessary-parens.rs:57:19
    |
 LL |     while let 1 = (2) {}
    |                   ^^^ help: remove these parentheses
 
 error: unnecessary parentheses around method argument
-  --> $DIR/lint-unnecessary-parens.rs:69:24
+  --> $DIR/lint-unnecessary-parens.rs:71:24
    |
 LL |     X { y: false }.foo((true));
    |                        ^^^^^^ help: remove these parentheses
 
 error: unnecessary parentheses around assigned value
-  --> $DIR/lint-unnecessary-parens.rs:71:18
+  --> $DIR/lint-unnecessary-parens.rs:73:18
    |
 LL |     let mut _a = (0);
    |                  ^^^ help: remove these parentheses
 
 error: unnecessary parentheses around assigned value
-  --> $DIR/lint-unnecessary-parens.rs:72:10
+  --> $DIR/lint-unnecessary-parens.rs:74:10
    |
 LL |     _a = (0);
    |          ^^^ help: remove these parentheses
 
 error: unnecessary parentheses around assigned value
-  --> $DIR/lint-unnecessary-parens.rs:73:11
+  --> $DIR/lint-unnecessary-parens.rs:75:11
    |
 LL |     _a += (1);
    |           ^^^ help: remove these parentheses
 
-error: aborting due to 17 previous errors; 1 warning emitted
+error: aborting due to 17 previous errors
 

--- a/src/test/ui/lint/lint-unused-mut-self.fixed
+++ b/src/test/ui/lint/lint-unused-mut-self.fixed
@@ -1,0 +1,14 @@
+// run-rustfix
+
+#![allow(unused_assignments)]
+#![allow(unused_variables)]
+#![allow(dead_code)]
+#![deny(unused_mut)]
+
+struct Foo;
+impl Foo {
+    fn foo(self) {} //~ ERROR: variable does not need to be mutable
+    fn bar(self: Box<Foo>) {} //~ ERROR: variable does not need to be mutable
+}
+
+fn main() {}

--- a/src/test/ui/lint/lint-unused-mut-self.rs
+++ b/src/test/ui/lint/lint-unused-mut-self.rs
@@ -1,3 +1,5 @@
+// run-rustfix
+
 #![allow(unused_assignments)]
 #![allow(unused_variables)]
 #![allow(dead_code)]

--- a/src/test/ui/lint/lint-unused-mut-self.stderr
+++ b/src/test/ui/lint/lint-unused-mut-self.stderr
@@ -1,5 +1,5 @@
 error: variable does not need to be mutable
-  --> $DIR/lint-unused-mut-self.rs:8:12
+  --> $DIR/lint-unused-mut-self.rs:10:12
    |
 LL |     fn foo(mut self) {}
    |            ----^^^^
@@ -7,13 +7,13 @@ LL |     fn foo(mut self) {}
    |            help: remove this `mut`
    |
 note: the lint level is defined here
-  --> $DIR/lint-unused-mut-self.rs:4:9
+  --> $DIR/lint-unused-mut-self.rs:6:9
    |
 LL | #![deny(unused_mut)]
    |         ^^^^^^^^^^
 
 error: variable does not need to be mutable
-  --> $DIR/lint-unused-mut-self.rs:9:12
+  --> $DIR/lint-unused-mut-self.rs:11:12
    |
 LL |     fn bar(mut self: Box<Foo>) {}
    |            ----^^^^

--- a/src/test/ui/lint/lint-unused-mut-variables.rs
+++ b/src/test/ui/lint/lint-unused-mut-variables.rs
@@ -92,13 +92,16 @@ fn main() {
         mut x => {} //~ WARN: variable does not need to be mutable
 
     }
-    match (30, 2) {
-      (mut x, 1) | //~ WARN: variable does not need to be mutable
 
-      (mut x, 2) |
-      (mut x, 3) => {
-      }
-      _ => {}
+    match (30, 2) {
+        // FIXME: Here's a false positive,
+        // shouldn't be removed `mut` not to be bound with a different way.
+        (mut x, 1) | //~ WARN: variable does not need to be mutable
+
+        (mut x, 2) |
+        (mut x, 3) => {
+        }
+        _ => {}
     }
 
     let x = |mut y: isize| 10; //~ WARN: variable does not need to be mutable

--- a/src/test/ui/lint/lint-unused-mut-variables.stderr
+++ b/src/test/ui/lint/lint-unused-mut-variables.stderr
@@ -69,7 +69,7 @@ LL |         mut a: i32,
    |         help: remove this `mut`
 
 warning: variable does not need to be mutable
-  --> $DIR/lint-unused-mut-variables.rs:104:14
+  --> $DIR/lint-unused-mut-variables.rs:107:14
    |
 LL |     let x = |mut y: isize| 10;
    |              ----^
@@ -141,15 +141,15 @@ LL |         mut x => {}
    |         help: remove this `mut`
 
 warning: variable does not need to be mutable
-  --> $DIR/lint-unused-mut-variables.rs:96:8
+  --> $DIR/lint-unused-mut-variables.rs:99:10
    |
-LL |       (mut x, 1) |
-   |        ----^
-   |        |
-   |        help: remove this `mut`
+LL |         (mut x, 1) |
+   |          ----^
+   |          |
+   |          help: remove this `mut`
 
 warning: variable does not need to be mutable
-  --> $DIR/lint-unused-mut-variables.rs:109:9
+  --> $DIR/lint-unused-mut-variables.rs:112:9
    |
 LL |     let mut a = &mut 5;
    |         ----^
@@ -157,7 +157,7 @@ LL |     let mut a = &mut 5;
    |         help: remove this `mut`
 
 warning: variable does not need to be mutable
-  --> $DIR/lint-unused-mut-variables.rs:114:9
+  --> $DIR/lint-unused-mut-variables.rs:117:9
    |
 LL |     let mut b = (&mut a,);
    |         ----^
@@ -165,7 +165,7 @@ LL |     let mut b = (&mut a,);
    |         help: remove this `mut`
 
 warning: variable does not need to be mutable
-  --> $DIR/lint-unused-mut-variables.rs:117:9
+  --> $DIR/lint-unused-mut-variables.rs:120:9
    |
 LL |     let mut x = &mut 1;
    |         ----^
@@ -173,7 +173,7 @@ LL |     let mut x = &mut 1;
    |         help: remove this `mut`
 
 warning: variable does not need to be mutable
-  --> $DIR/lint-unused-mut-variables.rs:129:9
+  --> $DIR/lint-unused-mut-variables.rs:132:9
    |
 LL |     let mut v : &mut Vec<()> = &mut vec![];
    |         ----^
@@ -181,7 +181,7 @@ LL |     let mut v : &mut Vec<()> = &mut vec![];
    |         help: remove this `mut`
 
 warning: variable does not need to be mutable
-  --> $DIR/lint-unused-mut-variables.rs:184:9
+  --> $DIR/lint-unused-mut-variables.rs:187:9
    |
 LL |     let mut raw_address_of_const = 1;
    |         ----^^^^^^^^^^^^^^^^^^^^
@@ -189,7 +189,7 @@ LL |     let mut raw_address_of_const = 1;
    |         help: remove this `mut`
 
 warning: variable does not need to be mutable
-  --> $DIR/lint-unused-mut-variables.rs:106:13
+  --> $DIR/lint-unused-mut-variables.rs:109:13
    |
 LL |     fn what(mut foo: isize) {}
    |             ----^^^
@@ -197,7 +197,7 @@ LL |     fn what(mut foo: isize) {}
    |             help: remove this `mut`
 
 warning: variable does not need to be mutable
-  --> $DIR/lint-unused-mut-variables.rs:124:20
+  --> $DIR/lint-unused-mut-variables.rs:127:20
    |
 LL |     fn mut_ref_arg(mut arg : &mut [u8]) -> &mut [u8] {
    |                    ----^^^
@@ -205,7 +205,7 @@ LL |     fn mut_ref_arg(mut arg : &mut [u8]) -> &mut [u8] {
    |                    help: remove this `mut`
 
 error: variable does not need to be mutable
-  --> $DIR/lint-unused-mut-variables.rs:202:9
+  --> $DIR/lint-unused-mut-variables.rs:205:9
    |
 LL |     let mut b = vec![2];
    |         ----^
@@ -213,7 +213,7 @@ LL |     let mut b = vec![2];
    |         help: remove this `mut`
    |
 note: the lint level is defined here
-  --> $DIR/lint-unused-mut-variables.rs:198:8
+  --> $DIR/lint-unused-mut-variables.rs:201:8
    |
 LL | #[deny(unused_mut)]
    |        ^^^^^^^^^^

--- a/src/test/ui/lint/suggestions.fixed
+++ b/src/test/ui/lint/suggestions.fixed
@@ -1,0 +1,66 @@
+// ignore-tidy-tab
+// run-rustfix
+
+#![warn(unused_mut, unused_parens)] // UI tests pass `-A unused`—see Issue #43896
+
+#[no_mangle] pub static DISCOVERY: usize = 1;
+//~^ ERROR const items should never be `#[no_mangle]`
+//~| HELP try a static value
+
+
+//~^ HELP remove this attribute
+pub fn defiant<T>(_t: T) {}
+//~^ WARN functions generic over types or consts must be mangled
+
+#[no_mangle]
+fn rio_grande() {}
+
+mod badlands {
+    // The private-no-mangle lints shouldn't suggest inserting `pub` when the
+    // item is already `pub` (but triggered the lint because, e.g., it's in a
+    // private module). (Issue #47383)
+    #[no_mangle] pub static DAUNTLESS: bool = true;
+    //~^ ERROR const items should never be `#[no_mangle]`
+    //~| HELP try a static value
+    #[allow(dead_code)] // for rustfix
+     pub fn val_jean<T>() {}
+    //~^ WARN functions generic over types or consts must be mangled
+    //~| HELP remove this attribute
+
+    // ... but we can suggest just-`pub` instead of restricted
+    #[no_mangle] pub static VETAR: bool = true;
+    //~^ ERROR const items should never be `#[no_mangle]`
+    //~| HELP try a static value
+    #[allow(dead_code)] // for rustfix
+     pub(crate) fn crossfield<T>() {}
+    //~^ WARN functions generic over types or consts must be mangled
+    //~| HELP remove this attribute
+}
+
+struct Equinox {
+    warp_factor: f32,
+}
+
+fn main() {
+    loop {
+    //~^ WARN denote infinite loops
+    //~| HELP use `loop`
+        let registry_no = format!("NX-{}", 74205);
+        //~^ WARN does not need to be mutable
+        //~| HELP remove this `mut`
+        //~| WARN unnecessary parentheses
+        //~| HELP remove these parentheses
+        // the line after `mut` has a `\t` at the beginning, this is on purpose
+        let b = 1;
+        //~^^ WARN does not need to be mutable
+        //~| HELP remove this `mut`
+        let d = Equinox { warp_factor: 9.975 };
+        match d {
+            #[allow(unused_variables)] // for rustfix
+            Equinox { warp_factor } => {}
+            //~^ WARN this pattern is redundant
+            //~| HELP use shorthand field pattern
+        }
+        println!("{} {}", registry_no, b);
+    }
+}

--- a/src/test/ui/lint/suggestions.rs
+++ b/src/test/ui/lint/suggestions.rs
@@ -1,4 +1,5 @@
 // ignore-tidy-tab
+// run-rustfix
 
 #![warn(unused_mut, unused_parens)] // UI tests pass `-A unused`—see Issue #43896
 
@@ -21,6 +22,7 @@ mod badlands {
     #[no_mangle] pub const DAUNTLESS: bool = true;
     //~^ ERROR const items should never be `#[no_mangle]`
     //~| HELP try a static value
+    #[allow(dead_code)] // for rustfix
     #[no_mangle] pub fn val_jean<T>() {}
     //~^ WARN functions generic over types or consts must be mangled
     //~| HELP remove this attribute
@@ -29,6 +31,7 @@ mod badlands {
     #[no_mangle] pub(crate) const VETAR: bool = true;
     //~^ ERROR const items should never be `#[no_mangle]`
     //~| HELP try a static value
+    #[allow(dead_code)] // for rustfix
     #[no_mangle] pub(crate) fn crossfield<T>() {}
     //~^ WARN functions generic over types or consts must be mangled
     //~| HELP remove this attribute
@@ -54,6 +57,7 @@ fn main() {
         //~| HELP remove this `mut`
         let d = Equinox { warp_factor: 9.975 };
         match d {
+            #[allow(unused_variables)] // for rustfix
             Equinox { warp_factor: warp_factor } => {}
             //~^ WARN this pattern is redundant
             //~| HELP use shorthand field pattern

--- a/src/test/ui/lint/suggestions.stderr
+++ b/src/test/ui/lint/suggestions.stderr
@@ -1,5 +1,5 @@
 warning: denote infinite loops with `loop { ... }`
-  --> $DIR/suggestions.rs:42:5
+  --> $DIR/suggestions.rs:45:5
    |
 LL |     while true {
    |     ^^^^^^^^^^ help: use `loop`
@@ -7,19 +7,19 @@ LL |     while true {
    = note: `#[warn(while_true)]` on by default
 
 warning: unnecessary parentheses around assigned value
-  --> $DIR/suggestions.rs:45:31
+  --> $DIR/suggestions.rs:48:31
    |
 LL |         let mut registry_no = (format!("NX-{}", 74205));
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove these parentheses
    |
 note: the lint level is defined here
-  --> $DIR/suggestions.rs:3:21
+  --> $DIR/suggestions.rs:4:21
    |
 LL | #![warn(unused_mut, unused_parens)] // UI tests pass `-A unused`—see Issue #43896
    |                     ^^^^^^^^^^^^^
 
 warning: variable does not need to be mutable
-  --> $DIR/suggestions.rs:45:13
+  --> $DIR/suggestions.rs:48:13
    |
 LL |         let mut registry_no = (format!("NX-{}", 74205));
    |             ----^^^^^^^^^^^
@@ -27,13 +27,13 @@ LL |         let mut registry_no = (format!("NX-{}", 74205));
    |             help: remove this `mut`
    |
 note: the lint level is defined here
-  --> $DIR/suggestions.rs:3:9
+  --> $DIR/suggestions.rs:4:9
    |
 LL | #![warn(unused_mut, unused_parens)] // UI tests pass `-A unused`—see Issue #43896
    |         ^^^^^^^^^^
 
 warning: variable does not need to be mutable
-  --> $DIR/suggestions.rs:51:13
+  --> $DIR/suggestions.rs:54:13
    |
 LL |            let mut
    |   _____________^
@@ -45,7 +45,7 @@ LL | ||             b = 1;
    |               help: remove this `mut`
 
 error: const items should never be `#[no_mangle]`
-  --> $DIR/suggestions.rs:5:14
+  --> $DIR/suggestions.rs:6:14
    |
 LL | #[no_mangle] const DISCOVERY: usize = 1;
    |              -----^^^^^^^^^^^^^^^^^^^^^^
@@ -55,7 +55,7 @@ LL | #[no_mangle] const DISCOVERY: usize = 1;
    = note: `#[deny(no_mangle_const_items)]` on by default
 
 warning: functions generic over types or consts must be mangled
-  --> $DIR/suggestions.rs:11:1
+  --> $DIR/suggestions.rs:12:1
    |
 LL | #[no_mangle]
    | ------------ help: remove this attribute
@@ -66,7 +66,7 @@ LL | pub fn defiant<T>(_t: T) {}
    = note: `#[warn(no_mangle_generic_items)]` on by default
 
 warning: the `warp_factor:` in this pattern is redundant
-  --> $DIR/suggestions.rs:57:23
+  --> $DIR/suggestions.rs:61:23
    |
 LL |             Equinox { warp_factor: warp_factor } => {}
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^ help: use shorthand field pattern: `warp_factor`
@@ -74,7 +74,7 @@ LL |             Equinox { warp_factor: warp_factor } => {}
    = note: `#[warn(non_shorthand_field_patterns)]` on by default
 
 error: const items should never be `#[no_mangle]`
-  --> $DIR/suggestions.rs:21:18
+  --> $DIR/suggestions.rs:22:18
    |
 LL |     #[no_mangle] pub const DAUNTLESS: bool = true;
    |                  ---------^^^^^^^^^^^^^^^^^^^^^^^^
@@ -82,7 +82,7 @@ LL |     #[no_mangle] pub const DAUNTLESS: bool = true;
    |                  help: try a static value: `pub static`
 
 warning: functions generic over types or consts must be mangled
-  --> $DIR/suggestions.rs:24:18
+  --> $DIR/suggestions.rs:26:18
    |
 LL |     #[no_mangle] pub fn val_jean<T>() {}
    |     ------------ ^^^^^^^^^^^^^^^^^^^^^^^
@@ -90,7 +90,7 @@ LL |     #[no_mangle] pub fn val_jean<T>() {}
    |     help: remove this attribute
 
 error: const items should never be `#[no_mangle]`
-  --> $DIR/suggestions.rs:29:18
+  --> $DIR/suggestions.rs:31:18
    |
 LL |     #[no_mangle] pub(crate) const VETAR: bool = true;
    |                  ----------------^^^^^^^^^^^^^^^^^^^^
@@ -98,7 +98,7 @@ LL |     #[no_mangle] pub(crate) const VETAR: bool = true;
    |                  help: try a static value: `pub static`
 
 warning: functions generic over types or consts must be mangled
-  --> $DIR/suggestions.rs:32:18
+  --> $DIR/suggestions.rs:35:18
    |
 LL |     #[no_mangle] pub(crate) fn crossfield<T>() {}
    |     ------------ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/lint/unused_braces.fixed
+++ b/src/test/ui/lint/unused_braces.fixed
@@ -1,0 +1,53 @@
+// check-pass
+// run-rustfix
+
+#![warn(unused_braces, unused_parens)]
+#![allow(unreachable_code, unused_unsafe)] // for rustfix
+
+fn consume<T>(_: T) {}
+
+fn main() {
+    let _ = 7;
+    //~^WARN unnecessary parentheses
+
+    // Do not emit a lint in these cases,
+    // as we have to be careful with
+    // `ref` patterns.
+    {
+        let _ = { 7 };
+
+        if let 7 = { 7 } { }
+
+        match { 7 } {
+            _ => (),
+        }
+    }
+
+    if  true  {
+        //~^ WARN unnecessary braces
+    }
+
+    while  false  {
+        //~^ WARN unnecessary braces
+    }
+
+    let _: [u8;  3 ];
+    //~^ WARN unnecessary braces
+
+    consume( 7 );
+    //~^ WARN unnecessary braces
+
+    // Do not emit lint for multiline blocks.
+    let _ = {
+        7
+    };
+
+    // Do not emit lint for unsafe blocks.
+    let _ = unsafe { 7 };
+
+    // Do not emit lint, as the `{` would then
+    // be parsed as part of the `return`.
+    if { return } {
+
+    }
+}

--- a/src/test/ui/lint/unused_braces.rs
+++ b/src/test/ui/lint/unused_braces.rs
@@ -1,5 +1,8 @@
 // check-pass
+// run-rustfix
+
 #![warn(unused_braces, unused_parens)]
+#![allow(unreachable_code, unused_unsafe)] // for rustfix
 
 fn consume<T>(_: T) {}
 

--- a/src/test/ui/lint/unused_braces.stderr
+++ b/src/test/ui/lint/unused_braces.stderr
@@ -1,41 +1,41 @@
 warning: unnecessary parentheses around assigned value
-  --> $DIR/unused_braces.rs:7:13
+  --> $DIR/unused_braces.rs:10:13
    |
 LL |     let _ = (7);
    |             ^^^ help: remove these parentheses
    |
 note: the lint level is defined here
-  --> $DIR/unused_braces.rs:2:24
+  --> $DIR/unused_braces.rs:4:24
    |
 LL | #![warn(unused_braces, unused_parens)]
    |                        ^^^^^^^^^^^^^
 
 warning: unnecessary braces around `if` condition
-  --> $DIR/unused_braces.rs:23:8
+  --> $DIR/unused_braces.rs:26:8
    |
 LL |     if { true } {
    |        ^^^^^^^^ help: remove these braces
    |
 note: the lint level is defined here
-  --> $DIR/unused_braces.rs:2:9
+  --> $DIR/unused_braces.rs:4:9
    |
 LL | #![warn(unused_braces, unused_parens)]
    |         ^^^^^^^^^^^^^
 
 warning: unnecessary braces around `while` condition
-  --> $DIR/unused_braces.rs:27:11
+  --> $DIR/unused_braces.rs:30:11
    |
 LL |     while { false } {
    |           ^^^^^^^^^ help: remove these braces
 
 warning: unnecessary braces around const expression
-  --> $DIR/unused_braces.rs:31:17
+  --> $DIR/unused_braces.rs:34:17
    |
 LL |     let _: [u8; { 3 }];
    |                 ^^^^^ help: remove these braces
 
 warning: unnecessary braces around function argument
-  --> $DIR/unused_braces.rs:34:13
+  --> $DIR/unused_braces.rs:37:13
    |
 LL |     consume({ 7 });
    |             ^^^^^ help: remove these braces

--- a/src/test/ui/lint/unused_braces_borrow.fixed
+++ b/src/test/ui/lint/unused_braces_borrow.fixed
@@ -1,0 +1,26 @@
+// check-pass
+// run-rustfix
+
+#![warn(unused_braces)]
+
+// changing `&{ expr }` to `&expr` changes the semantic of the program
+// so we should not warn this case
+
+#[repr(packed)]
+pub struct A {
+    pub a: u8,
+    pub b: u32,
+}
+
+fn consume<T>(_: T) {}
+
+fn main() {
+    let a = A {
+        a: 42,
+        b: 1729,
+    };
+
+    consume(&{ a.b });
+    consume( a.b );
+    //~^ WARN unnecessary braces
+}

--- a/src/test/ui/lint/unused_braces_borrow.rs
+++ b/src/test/ui/lint/unused_braces_borrow.rs
@@ -1,13 +1,15 @@
 // check-pass
+// run-rustfix
+
 #![warn(unused_braces)]
 
 // changing `&{ expr }` to `&expr` changes the semantic of the program
 // so we should not warn this case
 
 #[repr(packed)]
-struct A {
-    a: u8,
-    b: u32,
+pub struct A {
+    pub a: u8,
+    pub b: u32,
 }
 
 fn consume<T>(_: T) {}

--- a/src/test/ui/lint/unused_braces_borrow.stderr
+++ b/src/test/ui/lint/unused_braces_borrow.stderr
@@ -1,11 +1,11 @@
 warning: unnecessary braces around function argument
-  --> $DIR/unused_braces_borrow.rs:22:13
+  --> $DIR/unused_braces_borrow.rs:24:13
    |
 LL |     consume({ a.b });
    |             ^^^^^^^ help: remove these braces
    |
 note: the lint level is defined here
-  --> $DIR/unused_braces_borrow.rs:2:9
+  --> $DIR/unused_braces_borrow.rs:4:9
    |
 LL | #![warn(unused_braces)]
    |         ^^^^^^^^^^^^^

--- a/src/test/ui/nll/capture-mut-ref.fixed
+++ b/src/test/ui/nll/capture-mut-ref.fixed
@@ -1,0 +1,16 @@
+// run-rustfix
+
+// Check that capturing a mutable reference by move and assigning to its
+// referent doesn't make the unused mut lint think that it is mutable.
+
+#![deny(unused_mut)]
+
+pub fn mutable_upvar() {
+    let x = &mut 0;
+    //~^ ERROR
+    move || {
+        *x = 1;
+    };
+}
+
+fn main() {}

--- a/src/test/ui/nll/capture-mut-ref.rs
+++ b/src/test/ui/nll/capture-mut-ref.rs
@@ -1,9 +1,11 @@
+// run-rustfix
+
 // Check that capturing a mutable reference by move and assigning to its
 // referent doesn't make the unused mut lint think that it is mutable.
 
 #![deny(unused_mut)]
 
-fn mutable_upvar() {
+pub fn mutable_upvar() {
     let mut x = &mut 0;
     //~^ ERROR
     move || {

--- a/src/test/ui/nll/capture-mut-ref.stderr
+++ b/src/test/ui/nll/capture-mut-ref.stderr
@@ -1,5 +1,5 @@
 error: variable does not need to be mutable
-  --> $DIR/capture-mut-ref.rs:7:9
+  --> $DIR/capture-mut-ref.rs:9:9
    |
 LL |     let mut x = &mut 0;
    |         ----^
@@ -7,7 +7,7 @@ LL |     let mut x = &mut 0;
    |         help: remove this `mut`
    |
 note: the lint level is defined here
-  --> $DIR/capture-mut-ref.rs:4:9
+  --> $DIR/capture-mut-ref.rs:6:9
    |
 LL | #![deny(unused_mut)]
    |         ^^^^^^^^^^

--- a/src/test/ui/nll/issue-61424.fixed
+++ b/src/test/ui/nll/issue-61424.fixed
@@ -1,0 +1,9 @@
+// run-rustfix
+
+#![deny(unused_mut)]
+
+fn main() {
+    let x; //~ ERROR: variable does not need to be mutable
+    x = String::new();
+    dbg!(x);
+}

--- a/src/test/ui/nll/issue-61424.rs
+++ b/src/test/ui/nll/issue-61424.rs
@@ -1,3 +1,5 @@
+// run-rustfix
+
 #![deny(unused_mut)]
 
 fn main() {

--- a/src/test/ui/nll/issue-61424.stderr
+++ b/src/test/ui/nll/issue-61424.stderr
@@ -1,5 +1,5 @@
 error: variable does not need to be mutable
-  --> $DIR/issue-61424.rs:4:9
+  --> $DIR/issue-61424.rs:6:9
    |
 LL |     let mut x;
    |         ----^
@@ -7,7 +7,7 @@ LL |     let mut x;
    |         help: remove this `mut`
    |
 note: the lint level is defined here
-  --> $DIR/issue-61424.rs:1:9
+  --> $DIR/issue-61424.rs:3:9
    |
 LL | #![deny(unused_mut)]
    |         ^^^^^^^^^^

--- a/src/test/ui/nll/unused-mut-issue-50343.fixed
+++ b/src/test/ui/nll/unused-mut-issue-50343.fixed
@@ -1,0 +1,9 @@
+// run-rustfix
+
+#![deny(unused_mut)]
+#![allow(unused_variables)] // for rustfix
+
+fn main() {
+    vec![(42, 22)].iter().map(|(x, _y)| ()).count();
+    //~^ ERROR: variable does not need to be mutable
+}

--- a/src/test/ui/nll/unused-mut-issue-50343.rs
+++ b/src/test/ui/nll/unused-mut-issue-50343.rs
@@ -1,4 +1,7 @@
+// run-rustfix
+
 #![deny(unused_mut)]
+#![allow(unused_variables)] // for rustfix
 
 fn main() {
     vec![(42, 22)].iter().map(|(mut x, _y)| ()).count();

--- a/src/test/ui/nll/unused-mut-issue-50343.stderr
+++ b/src/test/ui/nll/unused-mut-issue-50343.stderr
@@ -1,5 +1,5 @@
 error: variable does not need to be mutable
-  --> $DIR/unused-mut-issue-50343.rs:4:33
+  --> $DIR/unused-mut-issue-50343.rs:7:33
    |
 LL |     vec![(42, 22)].iter().map(|(mut x, _y)| ()).count();
    |                                 ----^
@@ -7,7 +7,7 @@ LL |     vec![(42, 22)].iter().map(|(mut x, _y)| ()).count();
    |                                 help: remove this `mut`
    |
 note: the lint level is defined here
-  --> $DIR/unused-mut-issue-50343.rs:1:9
+  --> $DIR/unused-mut-issue-50343.rs:3:9
    |
 LL | #![deny(unused_mut)]
    |         ^^^^^^^^^^

--- a/src/test/ui/parser/bad-fn-ptr-qualifier.fixed
+++ b/src/test/ui/parser/bad-fn-ptr-qualifier.fixed
@@ -1,0 +1,26 @@
+// run-rustfix
+// edition:2018
+// Most of items are taken from ./recover-const-async-fn-ptr.rs but this is able to apply rustfix.
+
+pub type T0 =  fn(); //~ ERROR an `fn` pointer type cannot be `const`
+pub type T1 =  extern "C" fn(); //~ ERROR an `fn` pointer type cannot be `const`
+pub type T2 =  unsafe extern fn(); //~ ERROR an `fn` pointer type cannot be `const`
+pub type T3 =  fn(); //~ ERROR an `fn` pointer type cannot be `async`
+pub type T4 =  extern fn(); //~ ERROR an `fn` pointer type cannot be `async`
+pub type T5 =  unsafe extern "C" fn(); //~ ERROR an `fn` pointer type cannot be `async`
+pub type T6 =   unsafe extern "C" fn();
+//~^ ERROR an `fn` pointer type cannot be `const`
+//~| ERROR an `fn` pointer type cannot be `async`
+
+pub type FTT0 = for<'a>  fn(); //~ ERROR an `fn` pointer type cannot be `const`
+pub type FTT1 = for<'a>  extern "C" fn(); //~ ERROR an `fn` pointer type cannot be `const`
+pub type FTT2 = for<'a>  unsafe extern fn(); //~ ERROR an `fn` pointer type cannot be `const`
+pub type FTT3 = for<'a>  fn(); //~ ERROR an `fn` pointer type cannot be `async`
+pub type FTT4 = for<'a>  extern fn(); //~ ERROR an `fn` pointer type cannot be `async`
+pub type FTT5 = for<'a>  unsafe extern "C" fn();
+//~^ ERROR an `fn` pointer type cannot be `async`
+pub type FTT6 = for<'a>   unsafe extern "C" fn();
+//~^ ERROR an `fn` pointer type cannot be `const`
+//~| ERROR an `fn` pointer type cannot be `async`
+
+fn main() {}

--- a/src/test/ui/parser/bad-fn-ptr-qualifier.rs
+++ b/src/test/ui/parser/bad-fn-ptr-qualifier.rs
@@ -1,0 +1,26 @@
+// run-rustfix
+// edition:2018
+// Most of items are taken from ./recover-const-async-fn-ptr.rs but this is able to apply rustfix.
+
+pub type T0 = const fn(); //~ ERROR an `fn` pointer type cannot be `const`
+pub type T1 = const extern "C" fn(); //~ ERROR an `fn` pointer type cannot be `const`
+pub type T2 = const unsafe extern fn(); //~ ERROR an `fn` pointer type cannot be `const`
+pub type T3 = async fn(); //~ ERROR an `fn` pointer type cannot be `async`
+pub type T4 = async extern fn(); //~ ERROR an `fn` pointer type cannot be `async`
+pub type T5 = async unsafe extern "C" fn(); //~ ERROR an `fn` pointer type cannot be `async`
+pub type T6 = const async unsafe extern "C" fn();
+//~^ ERROR an `fn` pointer type cannot be `const`
+//~| ERROR an `fn` pointer type cannot be `async`
+
+pub type FTT0 = for<'a> const fn(); //~ ERROR an `fn` pointer type cannot be `const`
+pub type FTT1 = for<'a> const extern "C" fn(); //~ ERROR an `fn` pointer type cannot be `const`
+pub type FTT2 = for<'a> const unsafe extern fn(); //~ ERROR an `fn` pointer type cannot be `const`
+pub type FTT3 = for<'a> async fn(); //~ ERROR an `fn` pointer type cannot be `async`
+pub type FTT4 = for<'a> async extern fn(); //~ ERROR an `fn` pointer type cannot be `async`
+pub type FTT5 = for<'a> async unsafe extern "C" fn();
+//~^ ERROR an `fn` pointer type cannot be `async`
+pub type FTT6 = for<'a> const async unsafe extern "C" fn();
+//~^ ERROR an `fn` pointer type cannot be `const`
+//~| ERROR an `fn` pointer type cannot be `async`
+
+fn main() {}

--- a/src/test/ui/parser/bad-fn-ptr-qualifier.stderr
+++ b/src/test/ui/parser/bad-fn-ptr-qualifier.stderr
@@ -1,0 +1,146 @@
+error: an `fn` pointer type cannot be `const`
+  --> $DIR/bad-fn-ptr-qualifier.rs:5:15
+   |
+LL | pub type T0 = const fn();
+   |               -----^^^^^
+   |               |
+   |               `const` because of this
+   |               help: remove the `const` qualifier
+
+error: an `fn` pointer type cannot be `const`
+  --> $DIR/bad-fn-ptr-qualifier.rs:6:15
+   |
+LL | pub type T1 = const extern "C" fn();
+   |               -----^^^^^^^^^^^^^^^^
+   |               |
+   |               `const` because of this
+   |               help: remove the `const` qualifier
+
+error: an `fn` pointer type cannot be `const`
+  --> $DIR/bad-fn-ptr-qualifier.rs:7:15
+   |
+LL | pub type T2 = const unsafe extern fn();
+   |               -----^^^^^^^^^^^^^^^^^^^
+   |               |
+   |               `const` because of this
+   |               help: remove the `const` qualifier
+
+error: an `fn` pointer type cannot be `async`
+  --> $DIR/bad-fn-ptr-qualifier.rs:8:15
+   |
+LL | pub type T3 = async fn();
+   |               -----^^^^^
+   |               |
+   |               `async` because of this
+   |               help: remove the `async` qualifier
+
+error: an `fn` pointer type cannot be `async`
+  --> $DIR/bad-fn-ptr-qualifier.rs:9:15
+   |
+LL | pub type T4 = async extern fn();
+   |               -----^^^^^^^^^^^^
+   |               |
+   |               `async` because of this
+   |               help: remove the `async` qualifier
+
+error: an `fn` pointer type cannot be `async`
+  --> $DIR/bad-fn-ptr-qualifier.rs:10:15
+   |
+LL | pub type T5 = async unsafe extern "C" fn();
+   |               -----^^^^^^^^^^^^^^^^^^^^^^^
+   |               |
+   |               `async` because of this
+   |               help: remove the `async` qualifier
+
+error: an `fn` pointer type cannot be `const`
+  --> $DIR/bad-fn-ptr-qualifier.rs:11:15
+   |
+LL | pub type T6 = const async unsafe extern "C" fn();
+   |               -----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |               |
+   |               `const` because of this
+   |               help: remove the `const` qualifier
+
+error: an `fn` pointer type cannot be `async`
+  --> $DIR/bad-fn-ptr-qualifier.rs:11:15
+   |
+LL | pub type T6 = const async unsafe extern "C" fn();
+   |               ^^^^^^-----^^^^^^^^^^^^^^^^^^^^^^^
+   |                     |
+   |                     `async` because of this
+   |                     help: remove the `async` qualifier
+
+error: an `fn` pointer type cannot be `const`
+  --> $DIR/bad-fn-ptr-qualifier.rs:15:17
+   |
+LL | pub type FTT0 = for<'a> const fn();
+   |                 ^^^^^^^^-----^^^^^
+   |                         |
+   |                         `const` because of this
+   |                         help: remove the `const` qualifier
+
+error: an `fn` pointer type cannot be `const`
+  --> $DIR/bad-fn-ptr-qualifier.rs:16:17
+   |
+LL | pub type FTT1 = for<'a> const extern "C" fn();
+   |                 ^^^^^^^^-----^^^^^^^^^^^^^^^^
+   |                         |
+   |                         `const` because of this
+   |                         help: remove the `const` qualifier
+
+error: an `fn` pointer type cannot be `const`
+  --> $DIR/bad-fn-ptr-qualifier.rs:17:17
+   |
+LL | pub type FTT2 = for<'a> const unsafe extern fn();
+   |                 ^^^^^^^^-----^^^^^^^^^^^^^^^^^^^
+   |                         |
+   |                         `const` because of this
+   |                         help: remove the `const` qualifier
+
+error: an `fn` pointer type cannot be `async`
+  --> $DIR/bad-fn-ptr-qualifier.rs:18:17
+   |
+LL | pub type FTT3 = for<'a> async fn();
+   |                 ^^^^^^^^-----^^^^^
+   |                         |
+   |                         `async` because of this
+   |                         help: remove the `async` qualifier
+
+error: an `fn` pointer type cannot be `async`
+  --> $DIR/bad-fn-ptr-qualifier.rs:19:17
+   |
+LL | pub type FTT4 = for<'a> async extern fn();
+   |                 ^^^^^^^^-----^^^^^^^^^^^^
+   |                         |
+   |                         `async` because of this
+   |                         help: remove the `async` qualifier
+
+error: an `fn` pointer type cannot be `async`
+  --> $DIR/bad-fn-ptr-qualifier.rs:20:17
+   |
+LL | pub type FTT5 = for<'a> async unsafe extern "C" fn();
+   |                 ^^^^^^^^-----^^^^^^^^^^^^^^^^^^^^^^^
+   |                         |
+   |                         `async` because of this
+   |                         help: remove the `async` qualifier
+
+error: an `fn` pointer type cannot be `const`
+  --> $DIR/bad-fn-ptr-qualifier.rs:22:17
+   |
+LL | pub type FTT6 = for<'a> const async unsafe extern "C" fn();
+   |                 ^^^^^^^^-----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                         |
+   |                         `const` because of this
+   |                         help: remove the `const` qualifier
+
+error: an `fn` pointer type cannot be `async`
+  --> $DIR/bad-fn-ptr-qualifier.rs:22:17
+   |
+LL | pub type FTT6 = for<'a> const async unsafe extern "C" fn();
+   |                 ^^^^^^^^^^^^^^-----^^^^^^^^^^^^^^^^^^^^^^^
+   |                               |
+   |                               `async` because of this
+   |                               help: remove the `async` qualifier
+
+error: aborting due to 16 previous errors
+

--- a/src/test/ui/parser/if-in-in.fixed
+++ b/src/test/ui/parser/if-in-in.fixed
@@ -1,0 +1,7 @@
+// run-rustfix
+
+fn main() {
+    for i in 1..2 { //~ ERROR expected iterable, found keyword `in`
+        println!("{}", i);
+    }
+}

--- a/src/test/ui/parser/if-in-in.rs
+++ b/src/test/ui/parser/if-in-in.rs
@@ -1,3 +1,5 @@
+// run-rustfix
+
 fn main() {
     for i in in 1..2 { //~ ERROR expected iterable, found keyword `in`
         println!("{}", i);

--- a/src/test/ui/parser/if-in-in.stderr
+++ b/src/test/ui/parser/if-in-in.stderr
@@ -1,5 +1,5 @@
 error: expected iterable, found keyword `in`
-  --> $DIR/if-in-in.rs:2:14
+  --> $DIR/if-in-in.rs:4:14
    |
 LL |     for i in in 1..2 {
    |           ---^^

--- a/src/test/ui/parser/issue-10392-2.fixed
+++ b/src/test/ui/parser/issue-10392-2.fixed
@@ -1,0 +1,9 @@
+// run-rustfix
+
+pub struct A { pub foo: isize }
+
+fn a() -> A { panic!() }
+
+fn main() {
+    let A { .. } = a(); //~ ERROR: expected `}`
+}

--- a/src/test/ui/parser/issue-10392-2.rs
+++ b/src/test/ui/parser/issue-10392-2.rs
@@ -1,4 +1,6 @@
-struct A { foo: isize }
+// run-rustfix
+
+pub struct A { pub foo: isize }
 
 fn a() -> A { panic!() }
 

--- a/src/test/ui/parser/issue-10392-2.stderr
+++ b/src/test/ui/parser/issue-10392-2.stderr
@@ -1,5 +1,5 @@
 error: expected `}`, found `,`
-  --> $DIR/issue-10392-2.rs:6:15
+  --> $DIR/issue-10392-2.rs:8:15
    |
 LL |     let A { .., } = a();
    |             --^

--- a/src/test/ui/parser/issue-3036.fixed
+++ b/src/test/ui/parser/issue-3036.fixed
@@ -1,0 +1,7 @@
+// run-rustfix
+
+// Testing that semicolon tokens are printed correctly in errors
+
+fn main() {
+    let _x = 3; //~ ERROR: expected `;`
+}

--- a/src/test/ui/parser/issue-3036.rs
+++ b/src/test/ui/parser/issue-3036.rs
@@ -1,6 +1,7 @@
+// run-rustfix
+
 // Testing that semicolon tokens are printed correctly in errors
 
-fn main()
-{
-    let x = 3 //~ ERROR: expected `;`
+fn main() {
+    let _x = 3 //~ ERROR: expected `;`
 }

--- a/src/test/ui/parser/issue-3036.stderr
+++ b/src/test/ui/parser/issue-3036.stderr
@@ -1,8 +1,8 @@
 error: expected `;`, found `}`
-  --> $DIR/issue-3036.rs:5:14
+  --> $DIR/issue-3036.rs:6:15
    |
-LL |     let x = 3
-   |              ^ help: add `;` here
+LL |     let _x = 3
+   |               ^ help: add `;` here
 LL | }
    | - unexpected token
 

--- a/src/test/ui/parser/issue-67146-negative-outlives-bound-syntactic-fail.fixed
+++ b/src/test/ui/parser/issue-67146-negative-outlives-bound-syntactic-fail.fixed
@@ -1,0 +1,14 @@
+// run-rustfix
+
+// In this regression test for #67146, we check that the
+// negative outlives bound `!'a` is rejected by the parser.
+// This regression was first introduced in PR #57364.
+
+fn main() {}
+
+pub fn f1<T>() {}
+//~^ ERROR negative bounds are not supported
+pub fn f2<'a, T: Ord>() {}
+//~^ ERROR negative bounds are not supported
+pub fn f3<'a, T: Ord>() {}
+//~^ ERROR negative bounds are not supported

--- a/src/test/ui/parser/issue-67146-negative-outlives-bound-syntactic-fail.fixed
+++ b/src/test/ui/parser/issue-67146-negative-outlives-bound-syntactic-fail.fixed
@@ -6,9 +6,9 @@
 
 fn main() {}
 
-pub fn f1<T: !'static>() {}
+pub fn f1<T>() {}
 //~^ ERROR negative bounds are not supported
-pub fn f2<'a, T: Ord + !'a>() {}
+pub fn f2<'a, T: Ord>() {}
 //~^ ERROR negative bounds are not supported
-pub fn f3<'a, T: !'a + Ord>() {}
+pub fn f3<'a, T: Ord>() {}
 //~^ ERROR negative bounds are not supported

--- a/src/test/ui/parser/issue-67146-negative-outlives-bound-syntactic-fail.rs
+++ b/src/test/ui/parser/issue-67146-negative-outlives-bound-syntactic-fail.rs
@@ -1,12 +1,14 @@
+// run-rustfix
+
 // In this regression test for #67146, we check that the
 // negative outlives bound `!'a` is rejected by the parser.
 // This regression was first introduced in PR #57364.
 
 fn main() {}
 
-fn f1<T: !'static>() {}
+pub fn f1<T: !'static>() {}
 //~^ ERROR negative bounds are not supported
-fn f2<'a, T: Ord + !'a>() {}
+pub fn f2<'a, T: Ord + !'a>() {}
 //~^ ERROR negative bounds are not supported
-fn f3<'a, T: !'a + Ord>() {}
+pub fn f3<'a, T: !'a + Ord>() {}
 //~^ ERROR negative bounds are not supported

--- a/src/test/ui/parser/issue-67146-negative-outlives-bound-syntactic-fail.stderr
+++ b/src/test/ui/parser/issue-67146-negative-outlives-bound-syntactic-fail.stderr
@@ -1,20 +1,20 @@
 error: negative bounds are not supported
-  --> $DIR/issue-67146-negative-outlives-bound-syntactic-fail.rs:7:8
+  --> $DIR/issue-67146-negative-outlives-bound-syntactic-fail.rs:9:12
    |
-LL | fn f1<T: !'static>() {}
-   |        ^^^^^^^^^^ negative bounds are not supported
+LL | pub fn f1<T: !'static>() {}
+   |            ^^^^^^^^^^ negative bounds are not supported
 
 error: negative bounds are not supported
-  --> $DIR/issue-67146-negative-outlives-bound-syntactic-fail.rs:9:18
+  --> $DIR/issue-67146-negative-outlives-bound-syntactic-fail.rs:11:22
    |
-LL | fn f2<'a, T: Ord + !'a>() {}
-   |                  ^^^^^ negative bounds are not supported
+LL | pub fn f2<'a, T: Ord + !'a>() {}
+   |                      ^^^^^ negative bounds are not supported
 
 error: negative bounds are not supported
-  --> $DIR/issue-67146-negative-outlives-bound-syntactic-fail.rs:11:12
+  --> $DIR/issue-67146-negative-outlives-bound-syntactic-fail.rs:13:16
    |
-LL | fn f3<'a, T: !'a + Ord>() {}
-   |            ^^^^^ negative bounds are not supported
+LL | pub fn f3<'a, T: !'a + Ord>() {}
+   |                ^^^^^ negative bounds are not supported
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/parser/issue-70388-without-witness.fixed
+++ b/src/test/ui/parser/issue-70388-without-witness.fixed
@@ -1,0 +1,9 @@
+// run-rustfix
+// This is for checking if we can apply suggestions as-is.
+
+pub struct Foo(i32);
+
+fn main() {
+    let Foo(..) = Foo(0); //~ ERROR unexpected `...`
+    let [_, .., _] = [0, 1]; //~ ERROR unexpected `...`
+}

--- a/src/test/ui/parser/issue-70388-without-witness.rs
+++ b/src/test/ui/parser/issue-70388-without-witness.rs
@@ -1,0 +1,9 @@
+// run-rustfix
+// This is for checking if we can apply suggestions as-is.
+
+pub struct Foo(i32);
+
+fn main() {
+    let Foo(...) = Foo(0); //~ ERROR unexpected `...`
+    let [_, ..., _] = [0, 1]; //~ ERROR unexpected `...`
+}

--- a/src/test/ui/parser/issue-70388-without-witness.stderr
+++ b/src/test/ui/parser/issue-70388-without-witness.stderr
@@ -1,0 +1,20 @@
+error: unexpected `...`
+  --> $DIR/issue-70388-without-witness.rs:7:13
+   |
+LL |     let Foo(...) = Foo(0);
+   |             ^^^
+   |             |
+   |             not a valid pattern
+   |             help: for a rest pattern, use `..` instead of `...`
+
+error: unexpected `...`
+  --> $DIR/issue-70388-without-witness.rs:8:13
+   |
+LL |     let [_, ..., _] = [0, 1];
+   |             ^^^
+   |             |
+   |             not a valid pattern
+   |             help: for a rest pattern, use `..` instead of `...`
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/parser/let-binop.fixed
+++ b/src/test/ui/parser/let-binop.fixed
@@ -1,0 +1,10 @@
+// run-rustfix
+
+fn main() {
+    let a: i8 = 1; //~ ERROR can't reassign to an uninitialized variable
+    let _ = a;
+    let b = 1; //~ ERROR can't reassign to an uninitialized variable
+    let _ = b;
+    let c = 1; //~ ERROR can't reassign to an uninitialized variable
+    let _ = c;
+}

--- a/src/test/ui/parser/let-binop.rs
+++ b/src/test/ui/parser/let-binop.rs
@@ -1,3 +1,5 @@
+// run-rustfix
+
 fn main() {
     let a: i8 *= 1; //~ ERROR can't reassign to an uninitialized variable
     let _ = a;

--- a/src/test/ui/parser/let-binop.stderr
+++ b/src/test/ui/parser/let-binop.stderr
@@ -1,17 +1,17 @@
 error: can't reassign to an uninitialized variable
-  --> $DIR/let-binop.rs:2:15
+  --> $DIR/let-binop.rs:4:15
    |
 LL |     let a: i8 *= 1;
    |               ^^ help: initialize the variable
 
 error: can't reassign to an uninitialized variable
-  --> $DIR/let-binop.rs:4:11
+  --> $DIR/let-binop.rs:6:11
    |
 LL |     let b += 1;
    |           ^^ help: initialize the variable
 
 error: can't reassign to an uninitialized variable
-  --> $DIR/let-binop.rs:6:11
+  --> $DIR/let-binop.rs:8:11
    |
 LL |     let c *= 1;
    |           ^^ help: initialize the variable

--- a/src/test/ui/parser/match-refactor-to-expr.fixed
+++ b/src/test/ui/parser/match-refactor-to-expr.fixed
@@ -1,0 +1,12 @@
+// run-rustfix
+
+fn main() {
+    let foo =
+         //~ NOTE while parsing this match expression
+        Some(4).unwrap_or(5)
+        //~^ NOTE expected one of `.`, `?`, `{`, or an operator
+        ; //~ NOTE unexpected token
+        //~^ ERROR expected one of `.`, `?`, `{`, or an operator, found `;`
+
+    println!("{}", foo)
+}

--- a/src/test/ui/parser/match-refactor-to-expr.rs
+++ b/src/test/ui/parser/match-refactor-to-expr.rs
@@ -1,7 +1,9 @@
+// run-rustfix
+
 fn main() {
     let foo =
         match //~ NOTE while parsing this match expression
-        Some(4).unwrap_or_else(5)
+        Some(4).unwrap_or(5)
         //~^ NOTE expected one of `.`, `?`, `{`, or an operator
         ; //~ NOTE unexpected token
         //~^ ERROR expected one of `.`, `?`, `{`, or an operator, found `;`

--- a/src/test/ui/parser/match-refactor-to-expr.stderr
+++ b/src/test/ui/parser/match-refactor-to-expr.stderr
@@ -1,13 +1,13 @@
 error: expected one of `.`, `?`, `{`, or an operator, found `;`
-  --> $DIR/match-refactor-to-expr.rs:6:9
+  --> $DIR/match-refactor-to-expr.rs:8:9
    |
 LL |         match
    |         -----
    |         |
    |         while parsing this match expression
    |         help: try removing this `match`
-LL |         Some(4).unwrap_or_else(5)
-   |                                  - expected one of `.`, `?`, `{`, or an operator
+LL |         Some(4).unwrap_or(5)
+   |                             - expected one of `.`, `?`, `{`, or an operator
 LL |
 LL |         ;
    |         ^ unexpected token

--- a/src/test/ui/parser/range_inclusive.fixed
+++ b/src/test/ui/parser/range_inclusive.fixed
@@ -1,0 +1,7 @@
+// run-rustfix
+// Make sure that inclusive ranges with no end point don't parse.
+
+pub fn main() {
+    for _ in 1.. {} //~ERROR inclusive range with no end
+                     //~^HELP use `..` instead
+}

--- a/src/test/ui/parser/range_inclusive.rs
+++ b/src/test/ui/parser/range_inclusive.rs
@@ -1,3 +1,4 @@
+// run-rustfix
 // Make sure that inclusive ranges with no end point don't parse.
 
 pub fn main() {

--- a/src/test/ui/parser/range_inclusive.stderr
+++ b/src/test/ui/parser/range_inclusive.stderr
@@ -1,5 +1,5 @@
 error[E0586]: inclusive range with no end
-  --> $DIR/range_inclusive.rs:4:15
+  --> $DIR/range_inclusive.rs:5:15
    |
 LL |     for _ in 1..= {}
    |               ^^^ help: use `..` instead

--- a/src/test/ui/parser/trait-object-lifetime-parens.rs
+++ b/src/test/ui/parser/trait-object-lifetime-parens.rs
@@ -6,6 +6,7 @@ fn f<'a, T: Trait + ('a)>() {} //~ ERROR parenthesized lifetime bounds are not s
 
 fn check<'a>() {
     let _: Box<Trait + ('a)>; //~ ERROR parenthesized lifetime bounds are not supported
+    // FIXME: It'd be great if we could add suggestion to the following case.
     let _: Box<('a) + Trait>; //~ ERROR lifetime in trait object type must be followed by `+`
 }
 

--- a/src/test/ui/parser/trait-object-lifetime-parens.stderr
+++ b/src/test/ui/parser/trait-object-lifetime-parens.stderr
@@ -11,7 +11,7 @@ LL |     let _: Box<Trait + ('a)>;
    |                        ^^^^ help: remove the parentheses
 
 error: lifetime in trait object type must be followed by `+`
-  --> $DIR/trait-object-lifetime-parens.rs:9:17
+  --> $DIR/trait-object-lifetime-parens.rs:10:17
    |
 LL |     let _: Box<('a) + Trait>;
    |                 ^^

--- a/src/test/ui/path-lookahead.fixed
+++ b/src/test/ui/path-lookahead.fixed
@@ -1,0 +1,17 @@
+// run-pass
+// run-rustfix
+
+#![allow(dead_code)]
+#![warn(unused_parens)]
+
+// Parser test for #37765
+
+fn with_parens<T: ToString>(arg: T) -> String {
+    return <T as ToString>::to_string(&arg); //~WARN unnecessary parentheses around `return` value
+}
+
+fn no_parens<T: ToString>(arg: T) -> String {
+    return <T as ToString>::to_string(&arg);
+}
+
+fn main() {}

--- a/src/test/ui/path-lookahead.rs
+++ b/src/test/ui/path-lookahead.rs
@@ -1,17 +1,17 @@
 // run-pass
+// run-rustfix
+
 #![allow(dead_code)]
 #![warn(unused_parens)]
 
 // Parser test for #37765
 
 fn with_parens<T: ToString>(arg: T) -> String {
-  return (<T as ToString>::to_string(&arg)); //~WARN unnecessary parentheses around `return` value
+    return (<T as ToString>::to_string(&arg)); //~WARN unnecessary parentheses around `return` value
 }
 
 fn no_parens<T: ToString>(arg: T) -> String {
-  return <T as ToString>::to_string(&arg);
+    return <T as ToString>::to_string(&arg);
 }
 
-fn main() {
-
-}
+fn main() {}

--- a/src/test/ui/path-lookahead.stderr
+++ b/src/test/ui/path-lookahead.stderr
@@ -1,11 +1,11 @@
 warning: unnecessary parentheses around `return` value
-  --> $DIR/path-lookahead.rs:8:10
+  --> $DIR/path-lookahead.rs:10:12
    |
-LL |   return (<T as ToString>::to_string(&arg));
-   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove these parentheses
+LL |     return (<T as ToString>::to_string(&arg));
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove these parentheses
    |
 note: the lint level is defined here
-  --> $DIR/path-lookahead.rs:3:9
+  --> $DIR/path-lookahead.rs:5:9
    |
 LL | #![warn(unused_parens)]
    |         ^^^^^^^^^^^^^

--- a/src/test/ui/pub/pub-ident-fn-2.fixed
+++ b/src/test/ui/pub/pub-ident-fn-2.fixed
@@ -1,0 +1,10 @@
+// run-rustfix
+
+pub fn foo(_s: usize) { bar() }
+//~^ ERROR missing `fn` for function definition
+
+fn bar() {}
+
+fn main() {
+    foo(2);
+}

--- a/src/test/ui/pub/pub-ident-fn-2.rs
+++ b/src/test/ui/pub/pub-ident-fn-2.rs
@@ -1,5 +1,9 @@
-pub foo(s: usize) { bar() }
+// run-rustfix
+
+pub foo(_s: usize) { bar() }
 //~^ ERROR missing `fn` for function definition
+
+fn bar() {}
 
 fn main() {
     foo(2);

--- a/src/test/ui/pub/pub-ident-fn-2.stderr
+++ b/src/test/ui/pub/pub-ident-fn-2.stderr
@@ -1,12 +1,12 @@
 error: missing `fn` for function definition
-  --> $DIR/pub-ident-fn-2.rs:1:4
+  --> $DIR/pub-ident-fn-2.rs:3:4
    |
-LL | pub foo(s: usize) { bar() }
+LL | pub foo(_s: usize) { bar() }
    |    ^
    |
 help: add `fn` here to parse `foo` as a public function
    |
-LL | pub fn foo(s: usize) { bar() }
+LL | pub fn foo(_s: usize) { bar() }
    |     ^^
 
 error: aborting due to previous error

--- a/src/test/ui/pub/pub-ident-fn-with-lifetime.fixed
+++ b/src/test/ui/pub/pub-ident-fn-with-lifetime.fixed
@@ -1,0 +1,8 @@
+// run-rustfix
+
+pub fn foo<'a>(_s: &'a usize) -> bool { true }
+//~^ ERROR missing `fn` for function definition
+
+fn main() {
+    foo(&2);
+}

--- a/src/test/ui/pub/pub-ident-fn-with-lifetime.rs
+++ b/src/test/ui/pub/pub-ident-fn-with-lifetime.rs
@@ -1,6 +1,8 @@
+// run-rustfix
+
 pub   foo<'a>(_s: &'a usize) -> bool { true }
 //~^ ERROR missing `fn` for function definition
 
 fn main() {
-    foo(2);
+    foo(&2);
 }

--- a/src/test/ui/pub/pub-ident-fn-with-lifetime.stderr
+++ b/src/test/ui/pub/pub-ident-fn-with-lifetime.stderr
@@ -1,5 +1,5 @@
 error: missing `fn` for function definition
-  --> $DIR/pub-ident-fn-with-lifetime.rs:1:4
+  --> $DIR/pub-ident-fn-with-lifetime.rs:3:4
    |
 LL | pub   foo<'a>(_s: &'a usize) -> bool { true }
    |    ^^^

--- a/src/test/ui/pub/pub-ident-struct.fixed
+++ b/src/test/ui/pub/pub-ident-struct.fixed
@@ -1,0 +1,6 @@
+// run-rustfix
+
+pub struct S {
+//~^ ERROR missing `struct` for struct definition
+}
+fn main() {}

--- a/src/test/ui/pub/pub-ident-struct.rs
+++ b/src/test/ui/pub/pub-ident-struct.rs
@@ -1,3 +1,5 @@
+// run-rustfix
+
 pub S {
 //~^ ERROR missing `struct` for struct definition
 }

--- a/src/test/ui/pub/pub-ident-struct.stderr
+++ b/src/test/ui/pub/pub-ident-struct.stderr
@@ -1,5 +1,5 @@
 error: missing `struct` for struct definition
-  --> $DIR/pub-ident-struct.rs:1:4
+  --> $DIR/pub-ident-struct.rs:3:4
    |
 LL | pub S {
    |    ^

--- a/src/test/ui/range/range-inclusive-pattern-precedence.fixed
+++ b/src/test/ui/range/range-inclusive-pattern-precedence.fixed
@@ -1,0 +1,20 @@
+// In expression, `&a..=b` is treated as `(&a)..=(b)` and `box a..=b` is
+// `(box a)..=(b)`. In a pattern, however, `&a..=b` means `&(a..=b)`. This may
+// lead to confusion.
+
+// run-rustfix
+
+#![warn(ellipsis_inclusive_range_patterns)]
+
+pub fn main() {
+    match &12 {
+        &(0..=9) => {}
+        //~^ WARN `...` range patterns are deprecated
+        //~| HELP use `..=` for an inclusive range
+        &(10 ..=15) => {}
+        //~^ ERROR the range pattern here has ambiguous interpretation
+        //~^^ HELP add parentheses to clarify the precedence
+        &(16..=20) => {}
+        _ => {}
+    }
+}

--- a/src/test/ui/range/range-inclusive-pattern-precedence.rs
+++ b/src/test/ui/range/range-inclusive-pattern-precedence.rs
@@ -1,13 +1,10 @@
 // In expression, `&a..=b` is treated as `(&a)..=(b)` and `box a..=b` is
 // `(box a)..=(b)`. In a pattern, however, `&a..=b` means `&(a..=b)`. This may
 // lead to confusion.
-//
-// We are going to disallow `&a..=b` and `box a..=b` in a pattern. However, the
-// older ... syntax is still allowed as a stability guarantee.
 
-#![feature(box_patterns)]
+// run-rustfix
+
 #![warn(ellipsis_inclusive_range_patterns)]
-
 
 pub fn main() {
     match &12 {
@@ -18,17 +15,6 @@ pub fn main() {
         //~^ ERROR the range pattern here has ambiguous interpretation
         //~^^ HELP add parentheses to clarify the precedence
         &(16..=20) => {}
-        _ => {}
-    }
-
-    match Box::new(12) {
-        box 0...9 => {}
-        //~^ WARN `...` range patterns are deprecated
-        //~| HELP use `..=` for an inclusive range
-        box 10..=15 => {}
-        //~^ ERROR the range pattern here has ambiguous interpretation
-        //~^^ HELP add parentheses to clarify the precedence
-        box (16..=20) => {}
         _ => {}
     }
 }

--- a/src/test/ui/range/range-inclusive-pattern-precedence.stderr
+++ b/src/test/ui/range/range-inclusive-pattern-precedence.stderr
@@ -1,32 +1,20 @@
 error: the range pattern here has ambiguous interpretation
-  --> $DIR/range-inclusive-pattern-precedence.rs:17:10
+  --> $DIR/range-inclusive-pattern-precedence.rs:14:10
    |
 LL |         &10..=15 => {}
    |          ^^^^^^^ help: add parentheses to clarify the precedence: `(10 ..=15)`
 
-error: the range pattern here has ambiguous interpretation
-  --> $DIR/range-inclusive-pattern-precedence.rs:28:13
-   |
-LL |         box 10..=15 => {}
-   |             ^^^^^^^ help: add parentheses to clarify the precedence: `(10 ..=15)`
-
 warning: `...` range patterns are deprecated
-  --> $DIR/range-inclusive-pattern-precedence.rs:14:9
+  --> $DIR/range-inclusive-pattern-precedence.rs:11:9
    |
 LL |         &0...9 => {}
    |         ^^^^^^ help: use `..=` for an inclusive range: `&(0..=9)`
    |
 note: the lint level is defined here
-  --> $DIR/range-inclusive-pattern-precedence.rs:9:9
+  --> $DIR/range-inclusive-pattern-precedence.rs:7:9
    |
 LL | #![warn(ellipsis_inclusive_range_patterns)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: `...` range patterns are deprecated
-  --> $DIR/range-inclusive-pattern-precedence.rs:25:14
-   |
-LL |         box 0...9 => {}
-   |              ^^^ help: use `..=` for an inclusive range
-
-error: aborting due to 2 previous errors; 2 warnings emitted
+error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui/range/range-inclusive-pattern-precedence2.rs
+++ b/src/test/ui/range/range-inclusive-pattern-precedence2.rs
@@ -1,0 +1,19 @@
+// We are going to disallow `&a..=b` and `box a..=b` in a pattern. However, the
+// older ... syntax is still allowed as a stability guarantee.
+
+#![feature(box_patterns)]
+#![warn(ellipsis_inclusive_range_patterns)]
+
+fn main() {
+    match Box::new(12) {
+        // FIXME: can we add suggestions like `&(0..=9)`?
+        box 0...9 => {}
+        //~^ WARN `...` range patterns are deprecated
+        //~| HELP use `..=` for an inclusive range
+        box 10..=15 => {}
+        //~^ ERROR the range pattern here has ambiguous interpretation
+        //~^^ HELP add parentheses to clarify the precedence
+        box (16..=20) => {}
+        _ => {}
+    }
+}

--- a/src/test/ui/range/range-inclusive-pattern-precedence2.stderr
+++ b/src/test/ui/range/range-inclusive-pattern-precedence2.stderr
@@ -1,0 +1,20 @@
+error: the range pattern here has ambiguous interpretation
+  --> $DIR/range-inclusive-pattern-precedence2.rs:13:13
+   |
+LL |         box 10..=15 => {}
+   |             ^^^^^^^ help: add parentheses to clarify the precedence: `(10 ..=15)`
+
+warning: `...` range patterns are deprecated
+  --> $DIR/range-inclusive-pattern-precedence2.rs:10:14
+   |
+LL |         box 0...9 => {}
+   |              ^^^ help: use `..=` for an inclusive range
+   |
+note: the lint level is defined here
+  --> $DIR/range-inclusive-pattern-precedence2.rs:5:9
+   |
+LL | #![warn(ellipsis_inclusive_range_patterns)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error; 1 warning emitted
+

--- a/src/test/ui/resolve/resolve-conflict-import-vs-import.fixed
+++ b/src/test/ui/resolve/resolve-conflict-import-vs-import.fixed
@@ -1,0 +1,9 @@
+// run-rustfix
+
+#[allow(unused_imports)]
+use std::mem::transmute;
+
+//~^ ERROR the name `transmute` is defined multiple times
+
+fn main() {
+}

--- a/src/test/ui/resolve/resolve-conflict-import-vs-import.fixed
+++ b/src/test/ui/resolve/resolve-conflict-import-vs-import.fixed
@@ -2,7 +2,7 @@
 
 #[allow(unused_imports)]
 use std::mem::transmute;
-use std::mem::transmute;
+
 //~^ ERROR the name `transmute` is defined multiple times
 
 fn main() {

--- a/src/test/ui/resolve/resolve-conflict-import-vs-import.rs
+++ b/src/test/ui/resolve/resolve-conflict-import-vs-import.rs
@@ -1,3 +1,6 @@
+// run-rustfix
+
+#[allow(unused_imports)]
 use std::mem::transmute;
 use std::mem::transmute;
 //~^ ERROR the name `transmute` is defined multiple times

--- a/src/test/ui/resolve/resolve-conflict-import-vs-import.stderr
+++ b/src/test/ui/resolve/resolve-conflict-import-vs-import.stderr
@@ -1,5 +1,5 @@
 error[E0252]: the name `transmute` is defined multiple times
-  --> $DIR/resolve-conflict-import-vs-import.rs:2:5
+  --> $DIR/resolve-conflict-import-vs-import.rs:5:5
    |
 LL | use std::mem::transmute;
    |     ------------------- previous import of the value `transmute` here

--- a/src/test/ui/resolve/token-error-correct-4.fixed
+++ b/src/test/ui/resolve/token-error-correct-4.fixed
@@ -1,0 +1,10 @@
+// run-rustfix
+// Test that we do some basic error correction in the tokeniser and apply suggestions.
+
+fn setsuna(_: ()) {}
+
+fn kazusa() {}
+
+fn main() {
+    setsuna(kazusa()); //~ ERROR: expected one of
+} //~ ERROR: expected expression

--- a/src/test/ui/resolve/token-error-correct-4.rs
+++ b/src/test/ui/resolve/token-error-correct-4.rs
@@ -1,0 +1,10 @@
+// run-rustfix
+// Test that we do some basic error correction in the tokeniser and apply suggestions.
+
+fn setsuna(_: ()) {}
+
+fn kazusa() {}
+
+fn main() {
+    setsuna(kazusa(); //~ ERROR: expected one of
+} //~ ERROR: expected expression

--- a/src/test/ui/resolve/token-error-correct-4.stderr
+++ b/src/test/ui/resolve/token-error-correct-4.stderr
@@ -1,0 +1,16 @@
+error: expected one of `)`, `,`, `.`, `?`, or an operator, found `;`
+  --> $DIR/token-error-correct-4.rs:9:21
+   |
+LL |     setsuna(kazusa();
+   |            -        ^ help: `)` may belong here
+   |            |
+   |            unclosed delimiter
+
+error: expected expression, found `)`
+  --> $DIR/token-error-correct-4.rs:10:1
+   |
+LL | }
+   | ^ expected expression
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/similar-tokens.fixed
+++ b/src/test/ui/similar-tokens.fixed
@@ -1,0 +1,13 @@
+// run-rustfix
+
+#![allow(unused_imports)]
+
+pub mod x {
+    pub struct A;
+    pub struct B;
+}
+
+// `.` is similar to `,` so list parsing should continue to closing `}`
+use x::{A, B}; //~ ERROR expected one of `,`, `::`, `as`, or `}`, found `.`
+
+fn main() {}

--- a/src/test/ui/similar-tokens.rs
+++ b/src/test/ui/similar-tokens.rs
@@ -1,4 +1,8 @@
-mod x {
+// run-rustfix
+
+#![allow(unused_imports)]
+
+pub mod x {
     pub struct A;
     pub struct B;
 }

--- a/src/test/ui/similar-tokens.stderr
+++ b/src/test/ui/similar-tokens.stderr
@@ -1,5 +1,5 @@
 error: expected one of `,`, `::`, `as`, or `}`, found `.`
-  --> $DIR/similar-tokens.rs:7:10
+  --> $DIR/similar-tokens.rs:11:10
    |
 LL | use x::{A. B};
    |          ^

--- a/src/test/ui/structs/struct-duplicate-comma.fixed
+++ b/src/test/ui/structs/struct-duplicate-comma.fixed
@@ -1,0 +1,15 @@
+// run-rustfix
+// Issue #50974
+
+pub struct Foo {
+    pub a: u8,
+    pub b: u8
+}
+
+fn main() {
+    let _ = Foo {
+        a: 0,
+          //~^ ERROR expected identifier
+        b: 42
+    };
+}

--- a/src/test/ui/structs/struct-duplicate-comma.rs
+++ b/src/test/ui/structs/struct-duplicate-comma.rs
@@ -1,12 +1,13 @@
+// run-rustfix
 // Issue #50974
 
-struct Foo {
-    a: u8,
-    b: u8
+pub struct Foo {
+    pub a: u8,
+    pub b: u8
 }
 
 fn main() {
-    let bar = Foo {
+    let _ = Foo {
         a: 0,,
           //~^ ERROR expected identifier
         b: 42

--- a/src/test/ui/structs/struct-duplicate-comma.stderr
+++ b/src/test/ui/structs/struct-duplicate-comma.stderr
@@ -1,8 +1,8 @@
 error: expected identifier, found `,`
-  --> $DIR/struct-duplicate-comma.rs:10:14
+  --> $DIR/struct-duplicate-comma.rs:11:14
    |
-LL |     let bar = Foo {
-   |               --- while parsing this struct
+LL |     let _ = Foo {
+   |             --- while parsing this struct
 LL |         a: 0,,
    |              ^
    |              |

--- a/src/test/ui/structs/struct-missing-comma.fixed
+++ b/src/test/ui/structs/struct-missing-comma.fixed
@@ -1,0 +1,12 @@
+// Issue #50636
+// run-rustfix
+
+pub struct S {
+    pub foo: u32, //~ expected `,`, or `}`, found keyword `pub`
+    //     ~^ HELP try adding a comma: ','
+    pub bar: u32
+}
+
+fn main() {
+    let _ = S { foo: 5, bar: 6 };
+}

--- a/src/test/ui/structs/struct-missing-comma.rs
+++ b/src/test/ui/structs/struct-missing-comma.rs
@@ -1,11 +1,12 @@
 // Issue #50636
+// run-rustfix
 
-struct S {
-    foo: u32 //~ expected `,`, or `}`, found `bar`
+pub struct S {
+    pub foo: u32 //~ expected `,`, or `}`, found keyword `pub`
     //     ~^ HELP try adding a comma: ','
-    bar: u32
+    pub bar: u32
 }
 
 fn main() {
-    let s = S { foo: 5, bar: 6 };
+    let _ = S { foo: 5, bar: 6 };
 }

--- a/src/test/ui/structs/struct-missing-comma.stderr
+++ b/src/test/ui/structs/struct-missing-comma.stderr
@@ -1,8 +1,8 @@
-error: expected `,`, or `}`, found `bar`
-  --> $DIR/struct-missing-comma.rs:4:13
+error: expected `,`, or `}`, found keyword `pub`
+  --> $DIR/struct-missing-comma.rs:5:17
    |
-LL |     foo: u32
-   |             ^ help: try adding a comma: `,`
+LL |     pub foo: u32
+   |                 ^ help: try adding a comma: `,`
 
 error: aborting due to previous error
 

--- a/src/test/ui/suggestions/struct-initializer-comma.fixed
+++ b/src/test/ui/suggestions/struct-initializer-comma.fixed
@@ -1,0 +1,15 @@
+// run-rustfix
+
+pub struct Foo {
+    pub first: bool,
+    pub second: u8,
+}
+
+fn main() {
+    let _ = Foo {
+        //~^ ERROR missing field
+        first: true,
+        second: 25
+        //~^ ERROR expected one of
+    };
+}

--- a/src/test/ui/suggestions/struct-initializer-comma.rs
+++ b/src/test/ui/suggestions/struct-initializer-comma.rs
@@ -1,10 +1,12 @@
-struct Foo {
-    first: bool,
-    second: u8,
+// run-rustfix
+
+pub struct Foo {
+    pub first: bool,
+    pub second: u8,
 }
 
 fn main() {
-    let a = Foo {
+    let _ = Foo {
         //~^ ERROR missing field
         first: true
         second: 25

--- a/src/test/ui/suggestions/struct-initializer-comma.stderr
+++ b/src/test/ui/suggestions/struct-initializer-comma.stderr
@@ -1,7 +1,7 @@
 error: expected one of `,`, `.`, `?`, `}`, or an operator, found `second`
-  --> $DIR/struct-initializer-comma.rs:10:9
+  --> $DIR/struct-initializer-comma.rs:12:9
    |
-LL |     let a = Foo {
+LL |     let _ = Foo {
    |             --- while parsing this struct
 LL |
 LL |         first: true
@@ -13,9 +13,9 @@ LL |         second: 25
    |         ^^^^^^ unexpected token
 
 error[E0063]: missing field `second` in initializer of `Foo`
-  --> $DIR/struct-initializer-comma.rs:7:13
+  --> $DIR/struct-initializer-comma.rs:9:13
    |
-LL |     let a = Foo {
+LL |     let _ = Foo {
    |             ^^^ missing `second`
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/suggestions/suggest-remove-refs-1.fixed
+++ b/src/test/ui/suggestions/suggest-remove-refs-1.fixed
@@ -1,0 +1,10 @@
+// run-rustfix
+
+fn main() {
+    let v = vec![0, 1, 2, 3];
+
+    for (i, _) in v.iter().enumerate() {
+        //~^ ERROR `&std::iter::Enumerate<std::slice::Iter<'_, {integer}>>` is not an iterator
+        println!("{}", i);
+    }
+}

--- a/src/test/ui/suggestions/suggest-remove-refs-1.rs
+++ b/src/test/ui/suggestions/suggest-remove-refs-1.rs
@@ -1,7 +1,9 @@
+// run-rustfix
+
 fn main() {
     let v = vec![0, 1, 2, 3];
 
-    for (i, n) in &v.iter().enumerate() {
+    for (i, _) in &v.iter().enumerate() {
         //~^ ERROR `&std::iter::Enumerate<std::slice::Iter<'_, {integer}>>` is not an iterator
         println!("{}", i);
     }

--- a/src/test/ui/suggestions/suggest-remove-refs-1.stderr
+++ b/src/test/ui/suggestions/suggest-remove-refs-1.stderr
@@ -1,7 +1,7 @@
 error[E0277]: `&std::iter::Enumerate<std::slice::Iter<'_, {integer}>>` is not an iterator
-  --> $DIR/suggest-remove-refs-1.rs:4:19
+  --> $DIR/suggest-remove-refs-1.rs:6:19
    |
-LL |     for (i, n) in &v.iter().enumerate() {
+LL |     for (i, _) in &v.iter().enumerate() {
    |                   -^^^^^^^^^^^^^^^^^^^^
    |                   |
    |                   `&std::iter::Enumerate<std::slice::Iter<'_, {integer}>>` is not an iterator

--- a/src/test/ui/suggestions/suggest-remove-refs-2.fixed
+++ b/src/test/ui/suggestions/suggest-remove-refs-2.fixed
@@ -1,0 +1,10 @@
+// run-rustfix
+
+fn main() {
+    let v = vec![0, 1, 2, 3];
+
+    for (i, _) in v.iter().enumerate() {
+        //~^ ERROR `&&&&&std::iter::Enumerate<std::slice::Iter<'_, {integer}>>` is not an iterator
+        println!("{}", i);
+    }
+}

--- a/src/test/ui/suggestions/suggest-remove-refs-2.rs
+++ b/src/test/ui/suggestions/suggest-remove-refs-2.rs
@@ -1,7 +1,9 @@
+// run-rustfix
+
 fn main() {
     let v = vec![0, 1, 2, 3];
 
-    for (i, n) in & & & & &v.iter().enumerate() {
+    for (i, _) in & & & & &v.iter().enumerate() {
         //~^ ERROR `&&&&&std::iter::Enumerate<std::slice::Iter<'_, {integer}>>` is not an iterator
         println!("{}", i);
     }

--- a/src/test/ui/suggestions/suggest-remove-refs-2.stderr
+++ b/src/test/ui/suggestions/suggest-remove-refs-2.stderr
@@ -1,7 +1,7 @@
 error[E0277]: `&&&&&std::iter::Enumerate<std::slice::Iter<'_, {integer}>>` is not an iterator
-  --> $DIR/suggest-remove-refs-2.rs:4:19
+  --> $DIR/suggest-remove-refs-2.rs:6:19
    |
-LL |     for (i, n) in & & & & &v.iter().enumerate() {
+LL |     for (i, _) in & & & & &v.iter().enumerate() {
    |                   ---------^^^^^^^^^^^^^^^^^^^^
    |                   |
    |                   `&&&&&std::iter::Enumerate<std::slice::Iter<'_, {integer}>>` is not an iterator

--- a/src/test/ui/suggestions/suggest-remove-refs-3.fixed
+++ b/src/test/ui/suggestions/suggest-remove-refs-3.fixed
@@ -1,0 +1,12 @@
+// run-rustfix
+
+fn main() {
+    let v = vec![0, 1, 2, 3];
+
+    for (i, _) in v
+        .iter()
+        .enumerate() {
+        //~^^^^ ERROR `&&&&&std::iter::Enumerate<std::slice::Iter<'_, {integer}>>` is not an
+        println!("{}", i);
+    }
+}

--- a/src/test/ui/suggestions/suggest-remove-refs-3.rs
+++ b/src/test/ui/suggestions/suggest-remove-refs-3.rs
@@ -1,7 +1,9 @@
+// run-rustfix
+
 fn main() {
     let v = vec![0, 1, 2, 3];
 
-    for (i, n) in & & &
+    for (i, _) in & & &
         & &v
         .iter()
         .enumerate() {

--- a/src/test/ui/suggestions/suggest-remove-refs-3.stderr
+++ b/src/test/ui/suggestions/suggest-remove-refs-3.stderr
@@ -1,7 +1,7 @@
 error[E0277]: `&&&&&std::iter::Enumerate<std::slice::Iter<'_, {integer}>>` is not an iterator
-  --> $DIR/suggest-remove-refs-3.rs:4:19
+  --> $DIR/suggest-remove-refs-3.rs:6:19
    |
-LL |        for (i, n) in & & &
+LL |        for (i, _) in & & &
    |   ___________________^
    |  |___________________|
    | ||

--- a/src/test/ui/try-block/try-block-unused-delims.fixed
+++ b/src/test/ui/try-block/try-block-unused-delims.fixed
@@ -1,0 +1,29 @@
+// check-pass
+// compile-flags: --edition 2018
+// run-rustfix
+
+#![feature(try_blocks)]
+#![warn(unused_parens, unused_braces)]
+
+fn consume<T>(_: Result<T, T>) -> T { todo!() }
+
+fn main() {
+    consume(try {});
+    //~^ WARN unnecessary parentheses
+
+    consume( try {} );
+    //~^ WARN unnecessary braces
+
+    match try {} {
+        //~^ WARN unnecessary parentheses
+        Ok(()) | Err(()) => (),
+    }
+
+    if let Err(()) = try {} {}
+    //~^ WARN unnecessary parentheses
+
+    match try {} {
+        //~^ WARN unnecessary parentheses
+        Ok(()) | Err(()) => (),
+    }
+}

--- a/src/test/ui/try-block/try-block-unused-delims.rs
+++ b/src/test/ui/try-block/try-block-unused-delims.rs
@@ -1,5 +1,6 @@
 // check-pass
 // compile-flags: --edition 2018
+// run-rustfix
 
 #![feature(try_blocks)]
 #![warn(unused_parens, unused_braces)]

--- a/src/test/ui/try-block/try-block-unused-delims.stderr
+++ b/src/test/ui/try-block/try-block-unused-delims.stderr
@@ -1,41 +1,41 @@
 warning: unnecessary parentheses around function argument
-  --> $DIR/try-block-unused-delims.rs:10:13
+  --> $DIR/try-block-unused-delims.rs:11:13
    |
 LL |     consume((try {}));
    |             ^^^^^^^^ help: remove these parentheses
    |
 note: the lint level is defined here
-  --> $DIR/try-block-unused-delims.rs:5:9
+  --> $DIR/try-block-unused-delims.rs:6:9
    |
 LL | #![warn(unused_parens, unused_braces)]
    |         ^^^^^^^^^^^^^
 
 warning: unnecessary braces around function argument
-  --> $DIR/try-block-unused-delims.rs:13:13
+  --> $DIR/try-block-unused-delims.rs:14:13
    |
 LL |     consume({ try {} });
    |             ^^^^^^^^^^ help: remove these braces
    |
 note: the lint level is defined here
-  --> $DIR/try-block-unused-delims.rs:5:24
+  --> $DIR/try-block-unused-delims.rs:6:24
    |
 LL | #![warn(unused_parens, unused_braces)]
    |                        ^^^^^^^^^^^^^
 
 warning: unnecessary parentheses around `match` scrutinee expression
-  --> $DIR/try-block-unused-delims.rs:16:11
+  --> $DIR/try-block-unused-delims.rs:17:11
    |
 LL |     match (try {}) {
    |           ^^^^^^^^ help: remove these parentheses
 
 warning: unnecessary parentheses around `let` scrutinee expression
-  --> $DIR/try-block-unused-delims.rs:21:22
+  --> $DIR/try-block-unused-delims.rs:22:22
    |
 LL |     if let Err(()) = (try {}) {}
    |                      ^^^^^^^^ help: remove these parentheses
 
 warning: unnecessary parentheses around `match` scrutinee expression
-  --> $DIR/try-block-unused-delims.rs:24:11
+  --> $DIR/try-block-unused-delims.rs:25:11
    |
 LL |     match (try {}) {
    |           ^^^^^^^^ help: remove these parentheses

--- a/src/test/ui/typeck/issue-73592-borrow_mut-through-deref.fixed
+++ b/src/test/ui/typeck/issue-73592-borrow_mut-through-deref.fixed
@@ -1,0 +1,59 @@
+// check-pass
+// run-rustfix
+//
+// rust-lang/rust#73592: borrow_mut through Deref should work.
+//
+// Before #72280, when we see something like `&mut *rcvr.method()`, we
+// incorrectly requires `rcvr` to be type-checked as a mut place. While this
+// requirement is usually correct for smart pointers, it is overly restrictive
+// for types like `Mutex` or `RefCell` which can produce a guard that
+// implements `DerefMut` from `&self`.
+//
+// Making it more confusing, because we use Deref as the fallback when DerefMut
+// is implemented, we won't see an issue when the smart pointer does not
+// implement `DerefMut`. It only causes an issue when `rcvr` is obtained via a
+// type that implements both `Deref` or `DerefMut`.
+//
+// This bug is only discovered in #73592 after it is already fixed as a side-effect
+// of a refactoring made in #72280.
+
+#![warn(unused_mut)]
+
+use std::pin::Pin;
+use std::cell::RefCell;
+
+struct S(RefCell<()>);
+
+fn test_pin(s: Pin<&S>) {
+    // This works before #72280.
+    let _ = &mut *s.0.borrow_mut();
+}
+
+fn test_pin_mut(s: Pin<&mut S>) {
+    // This should compile but didn't before #72280.
+    let _ = &mut *s.0.borrow_mut();
+}
+
+fn test_vec(s: &Vec<RefCell<()>>) {
+    // This should compile but didn't before #72280.
+    let _ = &mut *s[0].borrow_mut();
+}
+
+fn test_mut_pin(s: Pin<&S>) {
+    //~^ WARN variable does not need to be mutable
+    let _ = &mut *s.0.borrow_mut();
+}
+
+fn test_mut_pin_mut(s: Pin<&mut S>) {
+    //~^ WARN variable does not need to be mutable
+    let _ = &mut *s.0.borrow_mut();
+}
+
+fn main() {
+    let mut s = S(RefCell::new(()));
+    test_pin(Pin::new(&s));
+    test_pin_mut(Pin::new(&mut s));
+    test_mut_pin(Pin::new(&s));
+    test_mut_pin_mut(Pin::new(&mut s));
+    test_vec(&vec![s.0]);
+}

--- a/src/test/ui/typeck/issue-73592-borrow_mut-through-deref.rs
+++ b/src/test/ui/typeck/issue-73592-borrow_mut-through-deref.rs
@@ -1,4 +1,5 @@
 // check-pass
+// run-rustfix
 //
 // rust-lang/rust#73592: borrow_mut through Deref should work.
 //

--- a/src/test/ui/typeck/issue-73592-borrow_mut-through-deref.stderr
+++ b/src/test/ui/typeck/issue-73592-borrow_mut-through-deref.stderr
@@ -1,5 +1,5 @@
 warning: variable does not need to be mutable
-  --> $DIR/issue-73592-borrow_mut-through-deref.rs:41:17
+  --> $DIR/issue-73592-borrow_mut-through-deref.rs:42:17
    |
 LL | fn test_mut_pin(mut s: Pin<&S>) {
    |                 ----^
@@ -7,13 +7,13 @@ LL | fn test_mut_pin(mut s: Pin<&S>) {
    |                 help: remove this `mut`
    |
 note: the lint level is defined here
-  --> $DIR/issue-73592-borrow_mut-through-deref.rs:19:9
+  --> $DIR/issue-73592-borrow_mut-through-deref.rs:20:9
    |
 LL | #![warn(unused_mut)]
    |         ^^^^^^^^^^
 
 warning: variable does not need to be mutable
-  --> $DIR/issue-73592-borrow_mut-through-deref.rs:46:21
+  --> $DIR/issue-73592-borrow_mut-through-deref.rs:47:21
    |
 LL | fn test_mut_pin_mut(mut s: Pin<&mut S>) {
    |                     ----^

--- a/src/test/ui/unused/unused-mut-warning-captured-var.fixed
+++ b/src/test/ui/unused/unused-mut-warning-captured-var.fixed
@@ -1,0 +1,9 @@
+// run-rustfix
+
+#![forbid(unused_mut)]
+
+fn main() {
+    let x = 1;
+    //~^ ERROR: variable does not need to be mutable
+    move|| { println!("{}", x); };
+}

--- a/src/test/ui/unused/unused-mut-warning-captured-var.rs
+++ b/src/test/ui/unused/unused-mut-warning-captured-var.rs
@@ -1,3 +1,5 @@
+// run-rustfix
+
 #![forbid(unused_mut)]
 
 fn main() {

--- a/src/test/ui/unused/unused-mut-warning-captured-var.stderr
+++ b/src/test/ui/unused/unused-mut-warning-captured-var.stderr
@@ -1,5 +1,5 @@
 error: variable does not need to be mutable
-  --> $DIR/unused-mut-warning-captured-var.rs:4:9
+  --> $DIR/unused-mut-warning-captured-var.rs:6:9
    |
 LL |     let mut x = 1;
    |         ----^
@@ -7,7 +7,7 @@ LL |     let mut x = 1;
    |         help: remove this `mut`
    |
 note: the lint level is defined here
-  --> $DIR/unused-mut-warning-captured-var.rs:1:11
+  --> $DIR/unused-mut-warning-captured-var.rs:3:11
    |
 LL | #![forbid(unused_mut)]
    |           ^^^^^^^^^^

--- a/src/tools/build-manifest/README.md
+++ b/src/tools/build-manifest/README.md
@@ -22,7 +22,7 @@ Then, you can generate the manifest and all the packages from `path/to/dist` to
 ```
 $ BUILD_MANIFEST_DISABLE_SIGNING=1 cargo +nightly run \
     path/to/dist path/to/output 1970-01-01 \
-    nightly nightly nightly nightly nightly nightly nightly \
+    nightly nightly nightly nightly nightly nightly nightly nightly \
     http://example.com
 ```
 

--- a/src/tools/clippy/clippy_lints/src/escape.rs
+++ b/src/tools/clippy/clippy_lints/src/escape.rs
@@ -150,7 +150,7 @@ impl<'a, 'tcx> Delegate<'tcx> for EscapeDelegate<'a, 'tcx> {
                     return;
                 }
 
-                if is_non_trait_box(cmt.place.ty) && !self.is_large_box(cmt.place.ty) {
+                if is_non_trait_box(cmt.place.ty()) && !self.is_large_box(cmt.place.ty()) {
                     self.set.insert(cmt.hir_id);
                 }
                 return;


### PR DESCRIPTION
Successful merges:

 - #73870 (typeck: adding type information to projection)
 - #73953 (Audit hidden/short code suggestions)
 - #73962 (libstd/net/tcp.rs: #![deny(unsafe_op_in_unsafe_fn)])
 - #73969 (mir: mark mir construction temporaries as internal)
 - #73974 (Move A|Rc::as_ptr from feature(weak_into_raw) to feature(rc_as_ptr))
 - #74067 (rustdoc: Restore underline text decoration on hover for FQN in header)
 - #74074 (Fix the return type of Windows' `OpenOptionsExt::security_qos_flags`.)
 - #74076 (Add `read_exact_at` and `write_all_at` to WASI's `FileExt`)
 - #74078 (Always resolve type@primitive as a primitive, not a module)
 - #74089 (Add rust-analyzer to the build manifest)
 - #74090 (Remove unused RUSTC_DEBUG_ASSERTIONS)

Failed merges:


r? @ghost