### PR TITLE
Fix occasional bootstrap panic in docs.

### DIFF
--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -156,7 +156,7 @@ impl Step for RustbookSrc {
         let index = out.join("index.html");
         let rustbook = builder.tool_exe(Tool::Rustbook);
         let mut rustbook_cmd = builder.tool_cmd(Tool::Rustbook);
-        if up_to_date(&src, &index) && up_to_date(&rustbook, &index) {
+        if builder.config.dry_run || up_to_date(&src, &index) && up_to_date(&rustbook, &index) {
             return;
         }
         builder.info(&format!("Rustbook ({}) - {}", target, name));


### PR DESCRIPTION
I am occasionally running into this panic when running `x.py`:

> thread 'main' panicked at 'source "/Users/eric/Proj/rust/rust/build/x86_64-apple-darwin/md-doc/unstable-book" failed to get metadata: No such file or directory (os error 2)', src/build_helper/lib.rs:173:19

I have not been able to figure out the exact sequence of commands that leads to this error (I tried for quite a while to reproduce it). I think it may involve updating my tree, but I am uncertain.  An artificial way to trigger it is to build the documentation, and then delete the `md-doc` directory manually.

The cause is that bootstrap does a "dry run" before every command, and in this case `up_to_date` panics because the destination exists (`build/x86_64-apple-darwin/doc/unstable-book/index.html `) but the source does not (`build/x86_64-apple-darwin/md-doc/unstable-book`).

I am uncertain if it is important that the last line `builder.run(…)` needs to be called during the dry run. This patch seems to fix the issue, though.
