### PR TITLE
Liballoc use vec instead of vector

### DIFF
--- a/src/liballoc/slice.rs
+++ b/src/liballoc/slice.rs
@@ -156,9 +156,9 @@ mod hack {
     where
         T: Clone,
     {
-        let mut vector = Vec::with_capacity(s.len());
-        vector.extend_from_slice(s);
-        vector
+        let mut vec = Vec::with_capacity(s.len());
+        vec.extend_from_slice(s);
+        vec
     }
 }
 


### PR DESCRIPTION
Keep congruency with other parts, full word vector is rarely used.