### PR TITLE
Avoid "blacklist"

### DIFF
--- a/src/librustc_error_codes/error_codes/E0570.md
+++ b/src/librustc_error_codes/error_codes/E0570.md
@@ -1,6 +1,6 @@
 The requested ABI is unsupported by the current target.
 
-The rust compiler maintains for each target a blacklist of ABIs unsupported on
+The rust compiler maintains for each target a list of unsupported ABIs on
 that target. If an ABI is present in such a list this usually means that the
 target / ABI combination is currently unsupported by llvm.
 

--- a/src/librustc_resolve/late.rs
+++ b/src/librustc_resolve/late.rs
@@ -842,14 +842,14 @@ impl<'a, 'b, 'ast> LateResolutionVisitor<'a, 'b, 'ast> {
                         report_error(self, ns);
                     }
                     Some(LexicalScopeBinding::Item(binding)) => {
-                        let orig_blacklisted_binding =
-                            replace(&mut self.r.blacklisted_binding, Some(binding));
+                        let orig_unusable_binding =
+                            replace(&mut self.r.unusable_binding, Some(binding));
                         if let Some(LexicalScopeBinding::Res(..)) = self
                             .resolve_ident_in_lexical_scope(ident, ns, None, use_tree.prefix.span)
                         {
                             report_error(self, ns);
                         }
-                        self.r.blacklisted_binding = orig_blacklisted_binding;
+                        self.r.unusable_binding = orig_unusable_binding;
                     }
                     None => {}
                 }

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -867,7 +867,7 @@ pub struct Resolver<'a> {
     last_import_segment: bool,
     /// This binding should be ignored during in-module resolution, so that we don't get
     /// "self-confirming" import resolutions during import validation.
-    blacklisted_binding: Option<&'a NameBinding<'a>>,
+    unusable_binding: Option<&'a NameBinding<'a>>,
 
     /// The idents for the primitive types.
     primitive_type_table: PrimitiveTypeTable,
@@ -1266,7 +1266,7 @@ impl<'a> Resolver<'a> {
             indeterminate_imports: Vec::new(),
 
             last_import_segment: false,
-            blacklisted_binding: None,
+            unusable_binding: None,
 
             primitive_type_table: PrimitiveTypeTable::new(),
 

--- a/src/librustc_target/spec/aarch64_apple_ios.rs
+++ b/src/librustc_target/spec/aarch64_apple_ios.rs
@@ -18,7 +18,7 @@ pub fn target() -> TargetResult {
             features: "+neon,+fp-armv8,+apple-a7".to_string(),
             eliminate_frame_pointer: false,
             max_atomic_width: Some(128),
-            abi_blacklist: super::arm_base::abi_blacklist(),
+            unsupported_abis: super::arm_base::unsupported_abis(),
             forces_embed_bitcode: true,
             // Taken from a clang build on Xcode 11.4.1.
             // These arguments are not actually invoked - they just have

--- a/src/librustc_target/spec/aarch64_apple_tvos.rs
+++ b/src/librustc_target/spec/aarch64_apple_tvos.rs
@@ -18,7 +18,7 @@ pub fn target() -> TargetResult {
             features: "+neon,+fp-armv8,+apple-a7".to_string(),
             eliminate_frame_pointer: false,
             max_atomic_width: Some(128),
-            abi_blacklist: super::arm_base::abi_blacklist(),
+            unsupported_abis: super::arm_base::unsupported_abis(),
             forces_embed_bitcode: true,
             ..base
         },

--- a/src/librustc_target/spec/aarch64_fuchsia.rs
+++ b/src/librustc_target/spec/aarch64_fuchsia.rs
@@ -15,6 +15,6 @@ pub fn target() -> TargetResult {
         target_env: String::new(),
         target_vendor: String::new(),
         linker_flavor: LinkerFlavor::Lld(LldFlavor::Ld),
-        options: TargetOptions { abi_blacklist: super::arm_base::abi_blacklist(), ..base },
+        options: TargetOptions { unsupported_abis: super::arm_base::unsupported_abis(), ..base },
     })
 }

--- a/src/librustc_target/spec/aarch64_linux_android.rs
+++ b/src/librustc_target/spec/aarch64_linux_android.rs
@@ -20,6 +20,6 @@ pub fn target() -> TargetResult {
         target_env: String::new(),
         target_vendor: "unknown".to_string(),
         linker_flavor: LinkerFlavor::Gcc,
-        options: TargetOptions { abi_blacklist: super::arm_base::abi_blacklist(), ..base },
+        options: TargetOptions { unsupported_abis: super::arm_base::unsupported_abis(), ..base },
     })
 }

--- a/src/librustc_target/spec/aarch64_unknown_cloudabi.rs
+++ b/src/librustc_target/spec/aarch64_unknown_cloudabi.rs
@@ -3,7 +3,7 @@ use crate::spec::{LinkerFlavor, Target, TargetResult};
 pub fn target() -> TargetResult {
     let mut base = super::cloudabi_base::opts();
     base.max_atomic_width = Some(128);
-    base.abi_blacklist = super::arm_base::abi_blacklist();
+    base.unsupported_abis = super::arm_base::unsupported_abis();
     base.linker = Some("aarch64-unknown-cloudabi-cc".to_string());
 
     Ok(Target {

--- a/src/librustc_target/spec/aarch64_unknown_freebsd.rs
+++ b/src/librustc_target/spec/aarch64_unknown_freebsd.rs
@@ -15,6 +15,6 @@ pub fn target() -> TargetResult {
         target_env: String::new(),
         target_vendor: "unknown".to_string(),
         linker_flavor: LinkerFlavor::Gcc,
-        options: TargetOptions { abi_blacklist: super::arm_base::abi_blacklist(), ..base },
+        options: TargetOptions { unsupported_abis: super::arm_base::unsupported_abis(), ..base },
     })
 }

--- a/src/librustc_target/spec/aarch64_unknown_hermit.rs
+++ b/src/librustc_target/spec/aarch64_unknown_hermit.rs
@@ -3,7 +3,7 @@ use crate::spec::{LinkerFlavor, Target, TargetResult};
 pub fn target() -> TargetResult {
     let mut base = super::hermit_base::opts();
     base.max_atomic_width = Some(128);
-    base.abi_blacklist = super::arm_base::abi_blacklist();
+    base.unsupported_abis = super::arm_base::unsupported_abis();
     base.linker = Some("aarch64-hermit-gcc".to_string());
 
     Ok(Target {

--- a/src/librustc_target/spec/aarch64_unknown_linux_gnu.rs
+++ b/src/librustc_target/spec/aarch64_unknown_linux_gnu.rs
@@ -16,7 +16,7 @@ pub fn target() -> TargetResult {
         target_vendor: "unknown".to_string(),
         linker_flavor: LinkerFlavor::Gcc,
         options: TargetOptions {
-            abi_blacklist: super::arm_base::abi_blacklist(),
+            unsupported_abis: super::arm_base::unsupported_abis(),
             target_mcount: "\u{1}_mcount".to_string(),
             ..base
         },

--- a/src/librustc_target/spec/aarch64_unknown_linux_musl.rs
+++ b/src/librustc_target/spec/aarch64_unknown_linux_musl.rs
@@ -16,7 +16,7 @@ pub fn target() -> TargetResult {
         target_vendor: "unknown".to_string(),
         linker_flavor: LinkerFlavor::Gcc,
         options: TargetOptions {
-            abi_blacklist: super::arm_base::abi_blacklist(),
+            unsupported_abis: super::arm_base::unsupported_abis(),
             target_mcount: "\u{1}_mcount".to_string(),
             ..base
         },

--- a/src/librustc_target/spec/aarch64_unknown_netbsd.rs
+++ b/src/librustc_target/spec/aarch64_unknown_netbsd.rs
@@ -3,7 +3,7 @@ use crate::spec::{LinkerFlavor, Target, TargetOptions, TargetResult};
 pub fn target() -> TargetResult {
     let mut base = super::netbsd_base::opts();
     base.max_atomic_width = Some(128);
-    base.abi_blacklist = super::arm_base::abi_blacklist();
+    base.unsupported_abis = super::arm_base::unsupported_abis();
 
     Ok(Target {
         llvm_target: "aarch64-unknown-netbsd".to_string(),

--- a/src/librustc_target/spec/aarch64_unknown_none.rs
+++ b/src/librustc_target/spec/aarch64_unknown_none.rs
@@ -18,7 +18,7 @@ pub fn target() -> Result<Target, String> {
         linker_is_gnu: true,
         max_atomic_width: Some(128),
         panic_strategy: PanicStrategy::Abort,
-        abi_blacklist: super::arm_base::abi_blacklist(),
+        unsupported_abis: super::arm_base::unsupported_abis(),
         ..Default::default()
     };
     Ok(Target {

--- a/src/librustc_target/spec/aarch64_unknown_none_softfloat.rs
+++ b/src/librustc_target/spec/aarch64_unknown_none_softfloat.rs
@@ -18,7 +18,7 @@ pub fn target() -> Result<Target, String> {
         linker_is_gnu: true,
         max_atomic_width: Some(128),
         panic_strategy: PanicStrategy::Abort,
-        abi_blacklist: super::arm_base::abi_blacklist(),
+        unsupported_abis: super::arm_base::unsupported_abis(),
         ..Default::default()
     };
     Ok(Target {

--- a/src/librustc_target/spec/aarch64_unknown_openbsd.rs
+++ b/src/librustc_target/spec/aarch64_unknown_openbsd.rs
@@ -3,7 +3,7 @@ use crate::spec::{LinkerFlavor, Target, TargetResult};
 pub fn target() -> TargetResult {
     let mut base = super::openbsd_base::opts();
     base.max_atomic_width = Some(128);
-    base.abi_blacklist = super::arm_base::abi_blacklist();
+    base.unsupported_abis = super::arm_base::unsupported_abis();
 
     Ok(Target {
         llvm_target: "aarch64-unknown-openbsd".to_string(),

--- a/src/librustc_target/spec/aarch64_wrs_vxworks.rs
+++ b/src/librustc_target/spec/aarch64_wrs_vxworks.rs
@@ -15,6 +15,6 @@ pub fn target() -> TargetResult {
         target_env: "gnu".to_string(),
         target_vendor: "wrs".to_string(),
         linker_flavor: LinkerFlavor::Gcc,
-        options: TargetOptions { abi_blacklist: super::arm_base::abi_blacklist(), ..base },
+        options: TargetOptions { unsupported_abis: super::arm_base::unsupported_abis(), ..base },
     })
 }

--- a/src/librustc_target/spec/arm_base.rs
+++ b/src/librustc_target/spec/arm_base.rs
@@ -1,6 +1,6 @@
 use crate::spec::abi::Abi;
 
 // All the calling conventions trigger an assertion(Unsupported calling convention) in llvm on arm
-pub fn abi_blacklist() -> Vec<Abi> {
+pub fn unsupported_abis() -> Vec<Abi> {
     vec![Abi::Stdcall, Abi::Fastcall, Abi::Vectorcall, Abi::Thiscall, Abi::Win64, Abi::SysV64]
 }

--- a/src/librustc_target/spec/arm_linux_androideabi.rs
+++ b/src/librustc_target/spec/arm_linux_androideabi.rs
@@ -17,6 +17,6 @@ pub fn target() -> TargetResult {
         target_env: String::new(),
         target_vendor: "unknown".to_string(),
         linker_flavor: LinkerFlavor::Gcc,
-        options: TargetOptions { abi_blacklist: super::arm_base::abi_blacklist(), ..base },
+        options: TargetOptions { unsupported_abis: super::arm_base::unsupported_abis(), ..base },
     })
 }

--- a/src/librustc_target/spec/arm_unknown_linux_gnueabi.rs
+++ b/src/librustc_target/spec/arm_unknown_linux_gnueabi.rs
@@ -17,7 +17,7 @@ pub fn target() -> TargetResult {
 
         options: TargetOptions {
             features: "+strict-align,+v6".to_string(),
-            abi_blacklist: super::arm_base::abi_blacklist(),
+            unsupported_abis: super::arm_base::unsupported_abis(),
             target_mcount: "\u{1}__gnu_mcount_nc".to_string(),
             ..base
         },

--- a/src/librustc_target/spec/arm_unknown_linux_gnueabihf.rs
+++ b/src/librustc_target/spec/arm_unknown_linux_gnueabihf.rs
@@ -17,7 +17,7 @@ pub fn target() -> TargetResult {
 
         options: TargetOptions {
             features: "+strict-align,+v6,+vfp2,-d32".to_string(),
-            abi_blacklist: super::arm_base::abi_blacklist(),
+            unsupported_abis: super::arm_base::unsupported_abis(),
             target_mcount: "\u{1}__gnu_mcount_nc".to_string(),
             ..base
         },

--- a/src/librustc_target/spec/arm_unknown_linux_musleabi.rs
+++ b/src/librustc_target/spec/arm_unknown_linux_musleabi.rs
@@ -22,7 +22,7 @@ pub fn target() -> TargetResult {
         target_vendor: "unknown".to_string(),
         linker_flavor: LinkerFlavor::Gcc,
         options: TargetOptions {
-            abi_blacklist: super::arm_base::abi_blacklist(),
+            unsupported_abis: super::arm_base::unsupported_abis(),
             target_mcount: "\u{1}mcount".to_string(),
             ..base
         },

--- a/src/librustc_target/spec/arm_unknown_linux_musleabihf.rs
+++ b/src/librustc_target/spec/arm_unknown_linux_musleabihf.rs
@@ -22,7 +22,7 @@ pub fn target() -> TargetResult {
         target_vendor: "unknown".to_string(),
         linker_flavor: LinkerFlavor::Gcc,
         options: TargetOptions {
-            abi_blacklist: super::arm_base::abi_blacklist(),
+            unsupported_abis: super::arm_base::unsupported_abis(),
             target_mcount: "\u{1}mcount".to_string(),
             ..base
         },

--- a/src/librustc_target/spec/armebv7r_none_eabi.rs
+++ b/src/librustc_target/spec/armebv7r_none_eabi.rs
@@ -22,7 +22,7 @@ pub fn target() -> TargetResult {
             relocation_model: RelocModel::Static,
             panic_strategy: PanicStrategy::Abort,
             max_atomic_width: Some(32),
-            abi_blacklist: super::arm_base::abi_blacklist(),
+            unsupported_abis: super::arm_base::unsupported_abis(),
             emit_debug_gdb_scripts: false,
             ..Default::default()
         },

--- a/src/librustc_target/spec/armebv7r_none_eabihf.rs
+++ b/src/librustc_target/spec/armebv7r_none_eabihf.rs
@@ -23,7 +23,7 @@ pub fn target() -> TargetResult {
             panic_strategy: PanicStrategy::Abort,
             features: "+vfp3,-d32,-fp16".to_string(),
             max_atomic_width: Some(32),
-            abi_blacklist: super::arm_base::abi_blacklist(),
+            unsupported_abis: super::arm_base::unsupported_abis(),
             emit_debug_gdb_scripts: false,
             ..Default::default()
         },

--- a/src/librustc_target/spec/armv4t_unknown_linux_gnueabi.rs
+++ b/src/librustc_target/spec/armv4t_unknown_linux_gnueabi.rs
@@ -18,7 +18,7 @@ pub fn target() -> TargetResult {
             features: "+soft-float,+strict-align".to_string(),
             // Atomic operations provided by compiler-builtins
             max_atomic_width: Some(32),
-            abi_blacklist: super::arm_base::abi_blacklist(),
+            unsupported_abis: super::arm_base::unsupported_abis(),
             target_mcount: "\u{1}__gnu_mcount_nc".to_string(),
             ..base
         },

--- a/src/librustc_target/spec/armv5te_unknown_linux_gnueabi.rs
+++ b/src/librustc_target/spec/armv5te_unknown_linux_gnueabi.rs
@@ -18,7 +18,7 @@ pub fn target() -> TargetResult {
             features: "+soft-float,+strict-align".to_string(),
             // Atomic operations provided by compiler-builtins
             max_atomic_width: Some(32),
-            abi_blacklist: super::arm_base::abi_blacklist(),
+            unsupported_abis: super::arm_base::unsupported_abis(),
             target_mcount: "\u{1}__gnu_mcount_nc".to_string(),
             ..base
         },

--- a/src/librustc_target/spec/armv5te_unknown_linux_musleabi.rs
+++ b/src/librustc_target/spec/armv5te_unknown_linux_musleabi.rs
@@ -21,7 +21,7 @@ pub fn target() -> TargetResult {
             features: "+soft-float,+strict-align".to_string(),
             // Atomic operations provided by compiler-builtins
             max_atomic_width: Some(32),
-            abi_blacklist: super::arm_base::abi_blacklist(),
+            unsupported_abis: super::arm_base::unsupported_abis(),
             target_mcount: "\u{1}mcount".to_string(),
             ..base
         },

--- a/src/librustc_target/spec/armv6_unknown_freebsd.rs
+++ b/src/librustc_target/spec/armv6_unknown_freebsd.rs
@@ -17,7 +17,7 @@ pub fn target() -> TargetResult {
         options: TargetOptions {
             features: "+v6,+vfp2,-d32".to_string(),
             max_atomic_width: Some(64),
-            abi_blacklist: super::arm_base::abi_blacklist(),
+            unsupported_abis: super::arm_base::unsupported_abis(),
             target_mcount: "\u{1}__gnu_mcount_nc".to_string(),
             ..base
         },

--- a/src/librustc_target/spec/armv6_unknown_netbsd_eabihf.rs
+++ b/src/librustc_target/spec/armv6_unknown_netbsd_eabihf.rs
@@ -17,7 +17,7 @@ pub fn target() -> TargetResult {
 
         options: TargetOptions {
             features: "+v6,+vfp2,-d32".to_string(),
-            abi_blacklist: super::arm_base::abi_blacklist(),
+            unsupported_abis: super::arm_base::unsupported_abis(),
             target_mcount: "__mcount".to_string(),
             ..base
         },

--- a/src/librustc_target/spec/armv7_apple_ios.rs
+++ b/src/librustc_target/spec/armv7_apple_ios.rs
@@ -17,7 +17,7 @@ pub fn target() -> TargetResult {
         options: TargetOptions {
             features: "+v7,+vfp3,+neon".to_string(),
             max_atomic_width: Some(64),
-            abi_blacklist: super::arm_base::abi_blacklist(),
+            unsupported_abis: super::arm_base::unsupported_abis(),
             ..base
         },
     })

--- a/src/librustc_target/spec/armv7_linux_androideabi.rs
+++ b/src/librustc_target/spec/armv7_linux_androideabi.rs
@@ -25,6 +25,6 @@ pub fn target() -> TargetResult {
         target_env: String::new(),
         target_vendor: "unknown".to_string(),
         linker_flavor: LinkerFlavor::Gcc,
-        options: TargetOptions { abi_blacklist: super::arm_base::abi_blacklist(), ..base },
+        options: TargetOptions { unsupported_abis: super::arm_base::unsupported_abis(), ..base },
     })
 }

--- a/src/librustc_target/spec/armv7_unknown_cloudabi_eabihf.rs
+++ b/src/librustc_target/spec/armv7_unknown_cloudabi_eabihf.rs
@@ -5,7 +5,7 @@ pub fn target() -> TargetResult {
     base.cpu = "cortex-a8".to_string();
     base.max_atomic_width = Some(64);
     base.features = "+v7,+vfp3,+neon".to_string();
-    base.abi_blacklist = super::arm_base::abi_blacklist();
+    base.unsupported_abis = super::arm_base::unsupported_abis();
     base.linker = Some("armv7-unknown-cloudabi-eabihf-cc".to_string());
 
     Ok(Target {

--- a/src/librustc_target/spec/armv7_unknown_freebsd.rs
+++ b/src/librustc_target/spec/armv7_unknown_freebsd.rs
@@ -17,7 +17,7 @@ pub fn target() -> TargetResult {
         options: TargetOptions {
             features: "+v7,+vfp3,-d32,+thumb2,-neon".to_string(),
             max_atomic_width: Some(64),
-            abi_blacklist: super::arm_base::abi_blacklist(),
+            unsupported_abis: super::arm_base::unsupported_abis(),
             target_mcount: "\u{1}__gnu_mcount_nc".to_string(),
             ..base
         },

--- a/src/librustc_target/spec/armv7_unknown_linux_gnueabi.rs
+++ b/src/librustc_target/spec/armv7_unknown_linux_gnueabi.rs
@@ -21,7 +21,7 @@ pub fn target() -> TargetResult {
             features: "+v7,+thumb2,+soft-float,-neon".to_string(),
             cpu: "generic".to_string(),
             max_atomic_width: Some(64),
-            abi_blacklist: super::arm_base::abi_blacklist(),
+            unsupported_abis: super::arm_base::unsupported_abis(),
             target_mcount: "\u{1}__gnu_mcount_nc".to_string(),
             ..base
         },

--- a/src/librustc_target/spec/armv7_unknown_linux_gnueabihf.rs
+++ b/src/librustc_target/spec/armv7_unknown_linux_gnueabihf.rs
@@ -22,7 +22,7 @@ pub fn target() -> TargetResult {
             features: "+v7,+vfp3,-d32,+thumb2,-neon".to_string(),
             cpu: "generic".to_string(),
             max_atomic_width: Some(64),
-            abi_blacklist: super::arm_base::abi_blacklist(),
+            unsupported_abis: super::arm_base::unsupported_abis(),
             target_mcount: "\u{1}__gnu_mcount_nc".to_string(),
             ..base
         },

--- a/src/librustc_target/spec/armv7_unknown_linux_musleabi.rs
+++ b/src/librustc_target/spec/armv7_unknown_linux_musleabi.rs
@@ -26,7 +26,7 @@ pub fn target() -> TargetResult {
             features: "+v7,+thumb2,+soft-float,-neon".to_string(),
             cpu: "generic".to_string(),
             max_atomic_width: Some(64),
-            abi_blacklist: super::arm_base::abi_blacklist(),
+            unsupported_abis: super::arm_base::unsupported_abis(),
             target_mcount: "\u{1}mcount".to_string(),
             ..base
         },

--- a/src/librustc_target/spec/armv7_unknown_linux_musleabihf.rs
+++ b/src/librustc_target/spec/armv7_unknown_linux_musleabihf.rs
@@ -25,7 +25,7 @@ pub fn target() -> TargetResult {
             features: "+v7,+vfp3,-d32,+thumb2,-neon".to_string(),
             cpu: "generic".to_string(),
             max_atomic_width: Some(64),
-            abi_blacklist: super::arm_base::abi_blacklist(),
+            unsupported_abis: super::arm_base::unsupported_abis(),
             target_mcount: "\u{1}mcount".to_string(),
             ..base
         },

--- a/src/librustc_target/spec/armv7_unknown_netbsd_eabihf.rs
+++ b/src/librustc_target/spec/armv7_unknown_netbsd_eabihf.rs
@@ -18,7 +18,7 @@ pub fn target() -> TargetResult {
             features: "+v7,+vfp3,-d32,+thumb2,-neon".to_string(),
             cpu: "generic".to_string(),
             max_atomic_width: Some(64),
-            abi_blacklist: super::arm_base::abi_blacklist(),
+            unsupported_abis: super::arm_base::unsupported_abis(),
             target_mcount: "__mcount".to_string(),
             ..base
         },

--- a/src/librustc_target/spec/armv7_wrs_vxworks_eabihf.rs
+++ b/src/librustc_target/spec/armv7_wrs_vxworks_eabihf.rs
@@ -18,7 +18,7 @@ pub fn target() -> TargetResult {
             features: "+v7,+vfp3,-d32,+thumb2,-neon".to_string(),
             cpu: "generic".to_string(),
             max_atomic_width: Some(64),
-            abi_blacklist: super::arm_base::abi_blacklist(),
+            unsupported_abis: super::arm_base::unsupported_abis(),
             ..base
         },
     })

--- a/src/librustc_target/spec/armv7a_none_eabi.rs
+++ b/src/librustc_target/spec/armv7a_none_eabi.rs
@@ -28,7 +28,7 @@ pub fn target() -> Result<Target, String> {
         disable_redzone: true,
         max_atomic_width: Some(64),
         panic_strategy: PanicStrategy::Abort,
-        abi_blacklist: super::arm_base::abi_blacklist(),
+        unsupported_abis: super::arm_base::unsupported_abis(),
         emit_debug_gdb_scripts: false,
         ..Default::default()
     };

--- a/src/librustc_target/spec/armv7a_none_eabihf.rs
+++ b/src/librustc_target/spec/armv7a_none_eabihf.rs
@@ -16,7 +16,7 @@ pub fn target() -> Result<Target, String> {
         disable_redzone: true,
         max_atomic_width: Some(64),
         panic_strategy: PanicStrategy::Abort,
-        abi_blacklist: super::arm_base::abi_blacklist(),
+        unsupported_abis: super::arm_base::unsupported_abis(),
         emit_debug_gdb_scripts: false,
         ..Default::default()
     };

--- a/src/librustc_target/spec/armv7r_none_eabi.rs
+++ b/src/librustc_target/spec/armv7r_none_eabi.rs
@@ -22,7 +22,7 @@ pub fn target() -> TargetResult {
             relocation_model: RelocModel::Static,
             panic_strategy: PanicStrategy::Abort,
             max_atomic_width: Some(32),
-            abi_blacklist: super::arm_base::abi_blacklist(),
+            unsupported_abis: super::arm_base::unsupported_abis(),
             emit_debug_gdb_scripts: false,
             ..Default::default()
         },

--- a/src/librustc_target/spec/armv7r_none_eabihf.rs
+++ b/src/librustc_target/spec/armv7r_none_eabihf.rs
@@ -23,7 +23,7 @@ pub fn target() -> TargetResult {
             panic_strategy: PanicStrategy::Abort,
             features: "+vfp3,-d32,-fp16".to_string(),
             max_atomic_width: Some(32),
-            abi_blacklist: super::arm_base::abi_blacklist(),
+            unsupported_abis: super::arm_base::unsupported_abis(),
             emit_debug_gdb_scripts: false,
             ..Default::default()
         },

--- a/src/librustc_target/spec/armv7s_apple_ios.rs
+++ b/src/librustc_target/spec/armv7s_apple_ios.rs
@@ -17,7 +17,7 @@ pub fn target() -> TargetResult {
         options: TargetOptions {
             features: "+v7,+vfp4,+neon".to_string(),
             max_atomic_width: Some(64),
-            abi_blacklist: super::arm_base::abi_blacklist(),
+            unsupported_abis: super::arm_base::unsupported_abis(),
             ..base
         },
     })

--- a/src/librustc_target/spec/nvptx64_nvidia_cuda.rs
+++ b/src/librustc_target/spec/nvptx64_nvidia_cuda.rs
@@ -55,7 +55,7 @@ pub fn target() -> TargetResult {
 
             // FIXME: enable compilation tests for the target and
             // create the tests for this.
-            abi_blacklist: vec![
+            unsupported_abis: vec![
                 Abi::Cdecl,
                 Abi::Stdcall,
                 Abi::Fastcall,

--- a/src/librustc_target/spec/riscv32i_unknown_none_elf.rs
+++ b/src/librustc_target/spec/riscv32i_unknown_none_elf.rs
@@ -24,7 +24,7 @@ pub fn target() -> TargetResult {
             panic_strategy: PanicStrategy::Abort,
             relocation_model: RelocModel::Static,
             emit_debug_gdb_scripts: false,
-            abi_blacklist: super::riscv_base::abi_blacklist(),
+            unsupported_abis: super::riscv_base::unsupported_abis(),
             ..Default::default()
         },
     })

--- a/src/librustc_target/spec/riscv32imac_unknown_none_elf.rs
+++ b/src/librustc_target/spec/riscv32imac_unknown_none_elf.rs
@@ -24,7 +24,7 @@ pub fn target() -> TargetResult {
             panic_strategy: PanicStrategy::Abort,
             relocation_model: RelocModel::Static,
             emit_debug_gdb_scripts: false,
-            abi_blacklist: super::riscv_base::abi_blacklist(),
+            unsupported_abis: super::riscv_base::unsupported_abis(),
             ..Default::default()
         },
     })

--- a/src/librustc_target/spec/riscv32imc_unknown_none_elf.rs
+++ b/src/librustc_target/spec/riscv32imc_unknown_none_elf.rs
@@ -24,7 +24,7 @@ pub fn target() -> TargetResult {
             panic_strategy: PanicStrategy::Abort,
             relocation_model: RelocModel::Static,
             emit_debug_gdb_scripts: false,
-            abi_blacklist: super::riscv_base::abi_blacklist(),
+            unsupported_abis: super::riscv_base::unsupported_abis(),
             ..Default::default()
         },
     })

--- a/src/librustc_target/spec/riscv64gc_unknown_linux_gnu.rs
+++ b/src/librustc_target/spec/riscv64gc_unknown_linux_gnu.rs
@@ -13,7 +13,7 @@ pub fn target() -> TargetResult {
         target_vendor: "unknown".to_string(),
         linker_flavor: LinkerFlavor::Gcc,
         options: TargetOptions {
-            abi_blacklist: super::riscv_base::abi_blacklist(),
+            unsupported_abis: super::riscv_base::unsupported_abis(),
             code_model: Some(CodeModel::Medium),
             cpu: "generic-rv64".to_string(),
             features: "+m,+a,+f,+d,+c".to_string(),

--- a/src/librustc_target/spec/riscv64gc_unknown_none_elf.rs
+++ b/src/librustc_target/spec/riscv64gc_unknown_none_elf.rs
@@ -25,7 +25,7 @@ pub fn target() -> TargetResult {
             relocation_model: RelocModel::Static,
             code_model: Some(CodeModel::Medium),
             emit_debug_gdb_scripts: false,
-            abi_blacklist: super::riscv_base::abi_blacklist(),
+            unsupported_abis: super::riscv_base::unsupported_abis(),
             ..Default::default()
         },
     })

--- a/src/librustc_target/spec/riscv64imac_unknown_none_elf.rs
+++ b/src/librustc_target/spec/riscv64imac_unknown_none_elf.rs
@@ -25,7 +25,7 @@ pub fn target() -> TargetResult {
             relocation_model: RelocModel::Static,
             code_model: Some(CodeModel::Medium),
             emit_debug_gdb_scripts: false,
-            abi_blacklist: super::riscv_base::abi_blacklist(),
+            unsupported_abis: super::riscv_base::unsupported_abis(),
             ..Default::default()
         },
     })

--- a/src/librustc_target/spec/riscv_base.rs
+++ b/src/librustc_target/spec/riscv_base.rs
@@ -2,7 +2,7 @@ use crate::spec::abi::Abi;
 
 // All the calling conventions trigger an assertion(Unsupported calling
 // convention) in llvm on RISCV
-pub fn abi_blacklist() -> Vec<Abi> {
+pub fn unsupported_abis() -> Vec<Abi> {
     vec![
         Abi::Cdecl,
         Abi::Stdcall,

--- a/src/librustc_target/spec/thumb_base.rs
+++ b/src/librustc_target/spec/thumb_base.rs
@@ -41,7 +41,7 @@ pub fn opts() -> TargetOptions {
         // Similarly, one almost always never wants to use relocatable code because of the extra
         // costs it involves.
         relocation_model: RelocModel::Static,
-        abi_blacklist: super::arm_base::abi_blacklist(),
+        unsupported_abis: super::arm_base::unsupported_abis(),
         // When this section is added a volatile load to its start address is also generated. This
         // volatile load is a footgun as it can end up loading an invalid memory address, depending
         // on how the user set up their linker scripts. This section adds pretty printer for stuff

--- a/src/librustc_target/spec/thumbv7a_pc_windows_msvc.rs
+++ b/src/librustc_target/spec/thumbv7a_pc_windows_msvc.rs
@@ -37,7 +37,7 @@ pub fn target() -> TargetResult {
             features: "+vfp3,+neon".to_string(),
             cpu: "generic".to_string(),
             max_atomic_width: Some(64),
-            abi_blacklist: super::arm_base::abi_blacklist(),
+            unsupported_abis: super::arm_base::unsupported_abis(),
             ..base
         },
     })

--- a/src/librustc_target/spec/thumbv7a_uwp_windows_msvc.rs
+++ b/src/librustc_target/spec/thumbv7a_uwp_windows_msvc.rs
@@ -23,7 +23,7 @@ pub fn target() -> TargetResult {
         options: TargetOptions {
             features: "+vfp3,+neon".to_string(),
             cpu: "generic".to_string(),
-            abi_blacklist: super::arm_base::abi_blacklist(),
+            unsupported_abis: super::arm_base::unsupported_abis(),
             ..base
         },
     })

--- a/src/librustc_target/spec/thumbv7neon_linux_androideabi.rs
+++ b/src/librustc_target/spec/thumbv7neon_linux_androideabi.rs
@@ -25,6 +25,6 @@ pub fn target() -> TargetResult {
         target_env: "".to_string(),
         target_vendor: "unknown".to_string(),
         linker_flavor: LinkerFlavor::Gcc,
-        options: TargetOptions { abi_blacklist: super::arm_base::abi_blacklist(), ..base },
+        options: TargetOptions { unsupported_abis: super::arm_base::unsupported_abis(), ..base },
     })
 }

--- a/src/librustc_target/spec/thumbv7neon_unknown_linux_gnueabihf.rs
+++ b/src/librustc_target/spec/thumbv7neon_unknown_linux_gnueabihf.rs
@@ -25,7 +25,7 @@ pub fn target() -> TargetResult {
             features: "+v7,+thumb-mode,+thumb2,+vfp3,+neon".to_string(),
             cpu: "generic".to_string(),
             max_atomic_width: Some(64),
-            abi_blacklist: super::arm_base::abi_blacklist(),
+            unsupported_abis: super::arm_base::unsupported_abis(),
             ..base
         },
     })

--- a/src/librustc_target/spec/thumbv7neon_unknown_linux_musleabihf.rs
+++ b/src/librustc_target/spec/thumbv7neon_unknown_linux_musleabihf.rs
@@ -29,7 +29,7 @@ pub fn target() -> TargetResult {
             features: "+v7,+thumb-mode,+thumb2,+vfp3,+neon".to_string(),
             cpu: "generic".to_string(),
             max_atomic_width: Some(64),
-            abi_blacklist: super::arm_base::abi_blacklist(),
+            unsupported_abis: super::arm_base::unsupported_abis(),
             target_mcount: "\u{1}mcount".to_string(),
             ..base
         },

--- a/src/test/ui/issues/issue-29540.rs
+++ b/src/test/ui/issues/issue-29540.rs
@@ -283,7 +283,7 @@ pub struct Config {
     pub mds_beacon_interval: String,
     pub mds_beacon_grace: String,
     pub mds_enforce_unique_name: String,
-    pub mds_blacklist_interval: String,
+    pub mds_interval: String,
     pub mds_session_timeout: String,
     pub mds_freeze_tree_timeout: String,
     pub mds_session_autoclose: String,

--- a/src/tools/compiletest/src/main.rs
+++ b/src/tools/compiletest/src/main.rs
@@ -401,7 +401,7 @@ fn configure_lldb(config: &Config) -> Option<Config> {
     }
 
     if let Some(lldb_version) = config.lldb_version.as_ref() {
-        if is_blacklisted_lldb_version(&lldb_version) {
+        if lldb_version == "350" {
             println!(
                 "WARNING: The used version of LLDB ({}) has a \
                  known issue that breaks debuginfo tests. See \
@@ -978,8 +978,4 @@ fn extract_lldb_version(full_version_line: Option<String>) -> (Option<String>, b
         }
     }
     (None, false)
-}
-
-fn is_blacklisted_lldb_version(version: &str) -> bool {
-    version == "350"
 }


### PR DESCRIPTION
Other terms are more inclusive and precise.

Clippy still has a lint named "blacklisted-name", but renaming it would
be a breaking change, so is left for future work.

The target configuration option "abi-blacklist" has been depreciated and
renamed to "unsupported-abis". The old name continues to work.