### PR TITLE
Fix x.py test for librustc crates.

### DIFF
--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -1562,7 +1562,7 @@ impl Step for CrateLibrustc {
         let compiler = builder.compiler(builder.top_stage, run.host);
 
         for krate in builder.in_tree_crates("rustc-main") {
-            if run.path.ends_with(&krate.path) {
+            if krate.path.ends_with(&run.path) {
                 let test_kind = builder.kind.into();
 
                 builder.ensure(CrateLibrustc {
@@ -1669,7 +1669,7 @@ impl Step for Crate {
         };
 
         for krate in builder.in_tree_crates("test") {
-            if run.path.ends_with(&krate.local_path(&builder)) {
+            if krate.path.ends_with(&run.path) {
                 make(Mode::Std, krate);
             }
         }

--- a/src/librustc_errors/json/tests.rs
+++ b/src/librustc_errors/json/tests.rs
@@ -59,6 +59,7 @@ fn test_positions(code: &str, span: (u32, u32), expected_output: SpanTestData) {
             sm,
             true,
             HumanReadableErrorType::Short(ColorConfig::Never),
+            None,
             false,
         );
 


### PR DESCRIPTION
#73352 introduced a bug where `x.py test src/librustc_ast` would fail to actually run the tests. The issue is that `krate` and `all_krates` were changed to return relative paths. This caused the code to do a test of "relative_path ends with absolute path" which is always false.  The solution is to swap that around.

The change to `Crate` isn't necessary, it just simplifies the code and makes it uniform with `CrateLibrustc`.
