### PR TITLE
Rollup of 13 pull requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -404,9 +404,9 @@ version = "0.1.0"
 
 [[package]]
 name = "cc"
-version = "1.0.54"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bbb73db36c1246e9034e307d0fba23f9a2e251faa47ade70c1bd252220c8311"
+checksum = "0fde55d2a2bfaa4c9668bbc63f531fbdeee3ffe188f4662511ce2c22b3eedebe"
 dependencies = [
  "jobserver",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1366,8 +1366,8 @@ checksum = "7e81a7c05f79578dbc15793d8b619db9ba32b4577003ef3af1a91c416798c58d"
 name = "installer"
 version = "0.0.0"
 dependencies = [
+ "anyhow",
  "clap",
- "failure",
  "flate2",
  "lazy_static",
  "num_cpus",

--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -9,6 +9,7 @@
 //! ensure that they're always in place if needed.
 
 use std::env;
+use std::env::consts::EXE_EXTENSION;
 use std::ffi::OsString;
 use std::fs::{self, File};
 use std::io;
@@ -252,8 +253,14 @@ impl Step for Llvm {
             // FIXME: if the llvm root for the build triple is overridden then we
             //        should use llvm-tblgen from there, also should verify that it
             //        actually exists most of the time in normal installs of LLVM.
-            let host = builder.llvm_out(builder.config.build).join("bin/llvm-tblgen");
-            cfg.define("CMAKE_CROSSCOMPILING", "True").define("LLVM_TABLEGEN", &host);
+            let host_bin = builder.llvm_out(builder.config.build).join("bin");
+            cfg.define("CMAKE_CROSSCOMPILING", "True");
+            cfg.define("LLVM_TABLEGEN", host_bin.join("llvm-tblgen").with_extension(EXE_EXTENSION));
+            cfg.define("LLVM_NM", host_bin.join("llvm-nm").with_extension(EXE_EXTENSION));
+            cfg.define(
+                "LLVM_CONFIG_PATH",
+                host_bin.join("llvm-config").with_extension(EXE_EXTENSION),
+            );
 
             if target.contains("netbsd") {
                 cfg.define("CMAKE_SYSTEM_NAME", "NetBSD");
@@ -262,8 +269,6 @@ impl Step for Llvm {
             } else if target.contains("windows") {
                 cfg.define("CMAKE_SYSTEM_NAME", "Windows");
             }
-
-            cfg.define("LLVM_NATIVE_BUILD", builder.llvm_out(builder.config.build).join("build"));
         }
 
         if let Some(ref suffix) = builder.config.llvm_version_suffix {
@@ -431,6 +436,9 @@ fn configure_cmake(
             cflags.push_str(" -miphoneos-version-min=10.0");
         }
     }
+    if builder.config.llvm_clang_cl.is_some() {
+        cflags.push_str(&format!(" --target={}", target))
+    }
     cfg.define("CMAKE_C_FLAGS", cflags);
     let mut cxxflags = builder.cflags(target, GitRepo::Llvm).join(" ");
     if builder.config.llvm_static_stdcpp && !target.contains("msvc") && !target.contains("netbsd") {
@@ -438,6 +446,9 @@ fn configure_cmake(
     }
     if let Some(ref s) = builder.config.llvm_cxxflags {
         cxxflags.push_str(&format!(" {}", s));
+    }
+    if builder.config.llvm_clang_cl.is_some() {
+        cxxflags.push_str(&format!(" --target={}", target))
     }
     cfg.define("CMAKE_CXX_FLAGS", cxxflags);
     if let Some(ar) = builder.ar(target) {
@@ -484,7 +495,7 @@ impl Step for Lld {
         run.builder.ensure(Lld { target: run.target });
     }
 
-    /// Compile LLVM for `target`.
+    /// Compile LLD for `target`.
     fn run(self, builder: &Builder<'_>) -> PathBuf {
         if builder.config.dry_run {
             return PathBuf::from("lld-out-dir-test-gen");
@@ -521,6 +532,7 @@ impl Step for Lld {
         // can't build on a system where your paths require `\` on Windows, but
         // there's probably a lot of reasons you can't do that other than this.
         let llvm_config_shim = env::current_exe().unwrap().with_file_name("llvm-config-wrapper");
+
         cfg.out_dir(&out_dir)
             .profile("Release")
             .env("LLVM_CONFIG_REAL", &llvm_config)
@@ -543,7 +555,10 @@ impl Step for Lld {
         if target != builder.config.build {
             cfg.env("LLVM_CONFIG_SHIM_REPLACE", &builder.config.build)
                 .env("LLVM_CONFIG_SHIM_REPLACE_WITH", &target)
-                .define("LLVM_TABLEGEN_EXE", llvm_config.with_file_name("llvm-tblgen"));
+                .define(
+                    "LLVM_TABLEGEN_EXE",
+                    llvm_config.with_file_name("llvm-tblgen").with_extension(EXE_EXTENSION),
+                );
         }
 
         // Explicitly set C++ standard, because upstream doesn't do so
@@ -595,8 +610,8 @@ impl Step for TestHelpers {
         }
 
         // We may have found various cross-compilers a little differently due to our
-        // extra configuration, so inform gcc of these compilers. Note, though, that
-        // on MSVC we still need gcc's detection of env vars (ugh).
+        // extra configuration, so inform cc of these compilers. Note, though, that
+        // on MSVC we still need cc's detection of env vars (ugh).
         if !target.contains("msvc") {
             if let Some(ar) = builder.ar(target) {
                 cfg.archiver(ar);

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -1562,7 +1562,7 @@ impl Step for CrateLibrustc {
         let compiler = builder.compiler(builder.top_stage, run.host);
 
         for krate in builder.in_tree_crates("rustc-main") {
-            if run.path.ends_with(&krate.path) {
+            if krate.path.ends_with(&run.path) {
                 let test_kind = builder.kind.into();
 
                 builder.ensure(CrateLibrustc {
@@ -1669,7 +1669,7 @@ impl Step for Crate {
         };
 
         for krate in builder.in_tree_crates("test") {
-            if run.path.ends_with(&krate.local_path(&builder)) {
+            if krate.path.ends_with(&run.path) {
                 make(Mode::Std, krate);
             }
         }

--- a/src/doc/rustdoc/src/unstable-features.md
+++ b/src/doc/rustdoc/src/unstable-features.md
@@ -321,7 +321,7 @@ library, as an equivalent command-line argument is provided to `rustc` when buil
 ### `--index-page`: provide a top-level landing page for docs
 
 This feature allows you to generate an index-page with a given markdown file. A good example of it
-is the [rust documentation index](https://doc.rust-lang.org/index.html).
+is the [rust documentation index](https://doc.rust-lang.org/nightly/index.html).
 
 With this, you'll have a page which you can custom as much as you want at the top of your crates.
 

--- a/src/liballoc/slice.rs
+++ b/src/liballoc/slice.rs
@@ -156,9 +156,9 @@ mod hack {
     where
         T: Clone,
     {
-        let mut vector = Vec::with_capacity(s.len());
-        vector.extend_from_slice(s);
-        vector
+        let mut vec = Vec::with_capacity(s.len());
+        vec.extend_from_slice(s);
+        vec
     }
 }
 

--- a/src/liballoc/slice.rs
+++ b/src/liballoc/slice.rs
@@ -136,8 +136,6 @@ pub use hack::to_vec;
 // `test_permutations` test
 mod hack {
     use crate::boxed::Box;
-    #[cfg(test)]
-    use crate::string::ToString;
     use crate::vec::Vec;
 
     // We shouldn't add inline attribute to this since this is used in

--- a/src/librustc_error_codes/error_codes/E0570.md
+++ b/src/librustc_error_codes/error_codes/E0570.md
@@ -1,6 +1,6 @@
 The requested ABI is unsupported by the current target.
 
-The rust compiler maintains for each target a blacklist of ABIs unsupported on
+The rust compiler maintains for each target a list of unsupported ABIs on
 that target. If an ABI is present in such a list this usually means that the
 target / ABI combination is currently unsupported by llvm.
 

--- a/src/librustc_errors/json/tests.rs
+++ b/src/librustc_errors/json/tests.rs
@@ -59,6 +59,7 @@ fn test_positions(code: &str, span: (u32, u32), expected_output: SpanTestData) {
             sm,
             true,
             HumanReadableErrorType::Short(ColorConfig::Never),
+            None,
             false,
         );
 

--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -62,7 +62,7 @@ use rustc_middle::ty::query::Providers;
 use rustc_middle::ty::TyCtxt;
 use rustc_session::lint::builtin::{
     BARE_TRAIT_OBJECTS, ELIDED_LIFETIMES_IN_PATHS, EXPLICIT_OUTLIVES_REQUIREMENTS,
-    INTRA_DOC_LINK_RESOLUTION_FAILURE, INVALID_CODEBLOCK_ATTRIBUTE, MISSING_DOC_CODE_EXAMPLES,
+    INTRA_DOC_LINK_RESOLUTION_FAILURE, INVALID_CODEBLOCK_ATTRIBUTES, MISSING_DOC_CODE_EXAMPLES,
     PRIVATE_DOC_TESTS,
 };
 use rustc_span::symbol::{Ident, Symbol};
@@ -304,7 +304,7 @@ fn register_builtins(store: &mut LintStore, no_interleave_lints: bool) {
     add_lint_group!(
         "rustdoc",
         INTRA_DOC_LINK_RESOLUTION_FAILURE,
-        INVALID_CODEBLOCK_ATTRIBUTE,
+        INVALID_CODEBLOCK_ATTRIBUTES,
         MISSING_DOC_CODE_EXAMPLES,
         PRIVATE_DOC_TESTS
     );

--- a/src/librustc_mir_build/build/mod.rs
+++ b/src/librustc_mir_build/build/mod.rs
@@ -10,6 +10,7 @@ use rustc_hir::lang_items;
 use rustc_hir::{GeneratorKind, HirIdMap, Node};
 use rustc_index::vec::{Idx, IndexVec};
 use rustc_infer::infer::TyCtxtInferExt;
+use rustc_middle::middle::codegen_fn_attrs::CodegenFnAttrFlags;
 use rustc_middle::middle::region;
 use rustc_middle::mir::*;
 use rustc_middle::ty::subst::Subst;
@@ -790,11 +791,21 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         argument_scope: region::Scope,
         ast_body: &'tcx hir::Expr<'tcx>,
     ) -> BlockAnd<()> {
+        let tcx = self.hir.tcx();
+        let attrs = tcx.codegen_fn_attrs(fn_def_id);
+        let naked = attrs.flags.contains(CodegenFnAttrFlags::NAKED);
+
         // Allocate locals for the function arguments
         for &ArgInfo(ty, _, arg_opt, _) in arguments.iter() {
             let source_info =
                 SourceInfo::outermost(arg_opt.map_or(self.fn_span, |arg| arg.pat.span));
             let arg_local = self.local_decls.push(LocalDecl::with_source_info(ty, source_info));
+
+            // Emit function argument debuginfo only for non-naked functions.
+            // See: https://github.com/rust-lang/rust/issues/42779
+            if naked {
+                continue;
+            }
 
             // If this is a simple binding pattern, give debuginfo a nice name.
             if let Some(arg) = arg_opt {
@@ -808,7 +819,6 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             }
         }
 
-        let tcx = self.hir.tcx();
         let tcx_hir = tcx.hir();
         let hir_tables = self.hir.tables();
 

--- a/src/librustc_parse/parser/expr.rs
+++ b/src/librustc_parse/parser/expr.rs
@@ -1790,7 +1790,7 @@ impl<'a> Parser<'a> {
         let require_comma = classify::expr_requires_semi_to_be_stmt(&expr)
             && self.token != token::CloseDelim(token::Brace);
 
-        let hi = self.token.span;
+        let hi = self.prev_token.span;
 
         if require_comma {
             let sm = self.sess.source_map();

--- a/src/librustc_passes/check_attr.rs
+++ b/src/librustc_passes/check_attr.rs
@@ -292,6 +292,8 @@ impl CheckAttrVisitor<'tcx> {
                 | sym::u32
                 | sym::i64
                 | sym::u64
+                | sym::i128
+                | sym::u128
                 | sym::isize
                 | sym::usize => {
                     int_reprs += 1;

--- a/src/librustc_resolve/late.rs
+++ b/src/librustc_resolve/late.rs
@@ -842,14 +842,14 @@ impl<'a, 'b, 'ast> LateResolutionVisitor<'a, 'b, 'ast> {
                         report_error(self, ns);
                     }
                     Some(LexicalScopeBinding::Item(binding)) => {
-                        let orig_blacklisted_binding =
-                            replace(&mut self.r.blacklisted_binding, Some(binding));
+                        let orig_unusable_binding =
+                            replace(&mut self.r.unusable_binding, Some(binding));
                         if let Some(LexicalScopeBinding::Res(..)) = self
                             .resolve_ident_in_lexical_scope(ident, ns, None, use_tree.prefix.span)
                         {
                             report_error(self, ns);
                         }
-                        self.r.blacklisted_binding = orig_blacklisted_binding;
+                        self.r.unusable_binding = orig_unusable_binding;
                     }
                     None => {}
                 }

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -867,7 +867,7 @@ pub struct Resolver<'a> {
     last_import_segment: bool,
     /// This binding should be ignored during in-module resolution, so that we don't get
     /// "self-confirming" import resolutions during import validation.
-    blacklisted_binding: Option<&'a NameBinding<'a>>,
+    unusable_binding: Option<&'a NameBinding<'a>>,
 
     /// The idents for the primitive types.
     primitive_type_table: PrimitiveTypeTable,
@@ -1266,7 +1266,7 @@ impl<'a> Resolver<'a> {
             indeterminate_imports: Vec::new(),
 
             last_import_segment: false,
-            blacklisted_binding: None,
+            unusable_binding: None,
 
             primitive_type_table: PrimitiveTypeTable::new(),
 

--- a/src/librustc_session/lint/builtin.rs
+++ b/src/librustc_session/lint/builtin.rs
@@ -404,7 +404,7 @@ declare_lint! {
 }
 
 declare_lint! {
-    pub INVALID_CODEBLOCK_ATTRIBUTE,
+    pub INVALID_CODEBLOCK_ATTRIBUTES,
     Warn,
     "codeblock attribute looks a lot like a known one"
 }
@@ -602,7 +602,7 @@ declare_lint_pass! {
         UNSTABLE_NAME_COLLISIONS,
         IRREFUTABLE_LET_PATTERNS,
         INTRA_DOC_LINK_RESOLUTION_FAILURE,
-        INVALID_CODEBLOCK_ATTRIBUTE,
+        INVALID_CODEBLOCK_ATTRIBUTES,
         MISSING_CRATE_LEVEL_DOCS,
         MISSING_DOC_CODE_EXAMPLES,
         PRIVATE_DOC_TESTS,

--- a/src/librustc_target/spec/aarch64_apple_ios.rs
+++ b/src/librustc_target/spec/aarch64_apple_ios.rs
@@ -18,7 +18,7 @@ pub fn target() -> TargetResult {
             features: "+neon,+fp-armv8,+apple-a7".to_string(),
             eliminate_frame_pointer: false,
             max_atomic_width: Some(128),
-            abi_blacklist: super::arm_base::abi_blacklist(),
+            unsupported_abis: super::arm_base::unsupported_abis(),
             forces_embed_bitcode: true,
             // Taken from a clang build on Xcode 11.4.1.
             // These arguments are not actually invoked - they just have

--- a/src/librustc_target/spec/aarch64_apple_tvos.rs
+++ b/src/librustc_target/spec/aarch64_apple_tvos.rs
@@ -18,7 +18,7 @@ pub fn target() -> TargetResult {
             features: "+neon,+fp-armv8,+apple-a7".to_string(),
             eliminate_frame_pointer: false,
             max_atomic_width: Some(128),
-            abi_blacklist: super::arm_base::abi_blacklist(),
+            unsupported_abis: super::arm_base::unsupported_abis(),
             forces_embed_bitcode: true,
             ..base
         },

--- a/src/librustc_target/spec/aarch64_fuchsia.rs
+++ b/src/librustc_target/spec/aarch64_fuchsia.rs
@@ -15,6 +15,6 @@ pub fn target() -> TargetResult {
         target_env: String::new(),
         target_vendor: String::new(),
         linker_flavor: LinkerFlavor::Lld(LldFlavor::Ld),
-        options: TargetOptions { abi_blacklist: super::arm_base::abi_blacklist(), ..base },
+        options: TargetOptions { unsupported_abis: super::arm_base::unsupported_abis(), ..base },
     })
 }

--- a/src/librustc_target/spec/aarch64_linux_android.rs
+++ b/src/librustc_target/spec/aarch64_linux_android.rs
@@ -20,6 +20,6 @@ pub fn target() -> TargetResult {
         target_env: String::new(),
         target_vendor: "unknown".to_string(),
         linker_flavor: LinkerFlavor::Gcc,
-        options: TargetOptions { abi_blacklist: super::arm_base::abi_blacklist(), ..base },
+        options: TargetOptions { unsupported_abis: super::arm_base::unsupported_abis(), ..base },
     })
 }

--- a/src/librustc_target/spec/aarch64_unknown_cloudabi.rs
+++ b/src/librustc_target/spec/aarch64_unknown_cloudabi.rs
@@ -3,7 +3,7 @@ use crate::spec::{LinkerFlavor, Target, TargetResult};
 pub fn target() -> TargetResult {
     let mut base = super::cloudabi_base::opts();
     base.max_atomic_width = Some(128);
-    base.abi_blacklist = super::arm_base::abi_blacklist();
+    base.unsupported_abis = super::arm_base::unsupported_abis();
     base.linker = Some("aarch64-unknown-cloudabi-cc".to_string());
 
     Ok(Target {

--- a/src/librustc_target/spec/aarch64_unknown_freebsd.rs
+++ b/src/librustc_target/spec/aarch64_unknown_freebsd.rs
@@ -15,6 +15,6 @@ pub fn target() -> TargetResult {
         target_env: String::new(),
         target_vendor: "unknown".to_string(),
         linker_flavor: LinkerFlavor::Gcc,
-        options: TargetOptions { abi_blacklist: super::arm_base::abi_blacklist(), ..base },
+        options: TargetOptions { unsupported_abis: super::arm_base::unsupported_abis(), ..base },
     })
 }

--- a/src/librustc_target/spec/aarch64_unknown_hermit.rs
+++ b/src/librustc_target/spec/aarch64_unknown_hermit.rs
@@ -3,7 +3,7 @@ use crate::spec::{LinkerFlavor, Target, TargetResult};
 pub fn target() -> TargetResult {
     let mut base = super::hermit_base::opts();
     base.max_atomic_width = Some(128);
-    base.abi_blacklist = super::arm_base::abi_blacklist();
+    base.unsupported_abis = super::arm_base::unsupported_abis();
     base.linker = Some("aarch64-hermit-gcc".to_string());
 
     Ok(Target {

--- a/src/librustc_target/spec/aarch64_unknown_linux_gnu.rs
+++ b/src/librustc_target/spec/aarch64_unknown_linux_gnu.rs
@@ -16,7 +16,7 @@ pub fn target() -> TargetResult {
         target_vendor: "unknown".to_string(),
         linker_flavor: LinkerFlavor::Gcc,
         options: TargetOptions {
-            abi_blacklist: super::arm_base::abi_blacklist(),
+            unsupported_abis: super::arm_base::unsupported_abis(),
             target_mcount: "\u{1}_mcount".to_string(),
             ..base
         },

--- a/src/librustc_target/spec/aarch64_unknown_linux_musl.rs
+++ b/src/librustc_target/spec/aarch64_unknown_linux_musl.rs
@@ -16,7 +16,7 @@ pub fn target() -> TargetResult {
         target_vendor: "unknown".to_string(),
         linker_flavor: LinkerFlavor::Gcc,
         options: TargetOptions {
-            abi_blacklist: super::arm_base::abi_blacklist(),
+            unsupported_abis: super::arm_base::unsupported_abis(),
             target_mcount: "\u{1}_mcount".to_string(),
             ..base
         },

--- a/src/librustc_target/spec/aarch64_unknown_netbsd.rs
+++ b/src/librustc_target/spec/aarch64_unknown_netbsd.rs
@@ -3,7 +3,7 @@ use crate::spec::{LinkerFlavor, Target, TargetOptions, TargetResult};
 pub fn target() -> TargetResult {
     let mut base = super::netbsd_base::opts();
     base.max_atomic_width = Some(128);
-    base.abi_blacklist = super::arm_base::abi_blacklist();
+    base.unsupported_abis = super::arm_base::unsupported_abis();
 
     Ok(Target {
         llvm_target: "aarch64-unknown-netbsd".to_string(),

--- a/src/librustc_target/spec/aarch64_unknown_none.rs
+++ b/src/librustc_target/spec/aarch64_unknown_none.rs
@@ -18,7 +18,7 @@ pub fn target() -> Result<Target, String> {
         linker_is_gnu: true,
         max_atomic_width: Some(128),
         panic_strategy: PanicStrategy::Abort,
-        abi_blacklist: super::arm_base::abi_blacklist(),
+        unsupported_abis: super::arm_base::unsupported_abis(),
         ..Default::default()
     };
     Ok(Target {

--- a/src/librustc_target/spec/aarch64_unknown_none_softfloat.rs
+++ b/src/librustc_target/spec/aarch64_unknown_none_softfloat.rs
@@ -18,7 +18,7 @@ pub fn target() -> Result<Target, String> {
         linker_is_gnu: true,
         max_atomic_width: Some(128),
         panic_strategy: PanicStrategy::Abort,
-        abi_blacklist: super::arm_base::abi_blacklist(),
+        unsupported_abis: super::arm_base::unsupported_abis(),
         ..Default::default()
     };
     Ok(Target {

--- a/src/librustc_target/spec/aarch64_unknown_openbsd.rs
+++ b/src/librustc_target/spec/aarch64_unknown_openbsd.rs
@@ -3,7 +3,7 @@ use crate::spec::{LinkerFlavor, Target, TargetResult};
 pub fn target() -> TargetResult {
     let mut base = super::openbsd_base::opts();
     base.max_atomic_width = Some(128);
-    base.abi_blacklist = super::arm_base::abi_blacklist();
+    base.unsupported_abis = super::arm_base::unsupported_abis();
 
     Ok(Target {
         llvm_target: "aarch64-unknown-openbsd".to_string(),

--- a/src/librustc_target/spec/aarch64_wrs_vxworks.rs
+++ b/src/librustc_target/spec/aarch64_wrs_vxworks.rs
@@ -15,6 +15,6 @@ pub fn target() -> TargetResult {
         target_env: "gnu".to_string(),
         target_vendor: "wrs".to_string(),
         linker_flavor: LinkerFlavor::Gcc,
-        options: TargetOptions { abi_blacklist: super::arm_base::abi_blacklist(), ..base },
+        options: TargetOptions { unsupported_abis: super::arm_base::unsupported_abis(), ..base },
     })
 }

--- a/src/librustc_target/spec/arm_base.rs
+++ b/src/librustc_target/spec/arm_base.rs
@@ -1,6 +1,6 @@
 use crate::spec::abi::Abi;
 
 // All the calling conventions trigger an assertion(Unsupported calling convention) in llvm on arm
-pub fn abi_blacklist() -> Vec<Abi> {
+pub fn unsupported_abis() -> Vec<Abi> {
     vec![Abi::Stdcall, Abi::Fastcall, Abi::Vectorcall, Abi::Thiscall, Abi::Win64, Abi::SysV64]
 }

--- a/src/librustc_target/spec/arm_linux_androideabi.rs
+++ b/src/librustc_target/spec/arm_linux_androideabi.rs
@@ -17,6 +17,6 @@ pub fn target() -> TargetResult {
         target_env: String::new(),
         target_vendor: "unknown".to_string(),
         linker_flavor: LinkerFlavor::Gcc,
-        options: TargetOptions { abi_blacklist: super::arm_base::abi_blacklist(), ..base },
+        options: TargetOptions { unsupported_abis: super::arm_base::unsupported_abis(), ..base },
     })
 }

--- a/src/librustc_target/spec/arm_unknown_linux_gnueabi.rs
+++ b/src/librustc_target/spec/arm_unknown_linux_gnueabi.rs
@@ -17,7 +17,7 @@ pub fn target() -> TargetResult {
 
         options: TargetOptions {
             features: "+strict-align,+v6".to_string(),
-            abi_blacklist: super::arm_base::abi_blacklist(),
+            unsupported_abis: super::arm_base::unsupported_abis(),
             target_mcount: "\u{1}__gnu_mcount_nc".to_string(),
             ..base
         },

--- a/src/librustc_target/spec/arm_unknown_linux_gnueabihf.rs
+++ b/src/librustc_target/spec/arm_unknown_linux_gnueabihf.rs
@@ -17,7 +17,7 @@ pub fn target() -> TargetResult {
 
         options: TargetOptions {
             features: "+strict-align,+v6,+vfp2,-d32".to_string(),
-            abi_blacklist: super::arm_base::abi_blacklist(),
+            unsupported_abis: super::arm_base::unsupported_abis(),
             target_mcount: "\u{1}__gnu_mcount_nc".to_string(),
             ..base
         },

--- a/src/librustc_target/spec/arm_unknown_linux_musleabi.rs
+++ b/src/librustc_target/spec/arm_unknown_linux_musleabi.rs
@@ -22,7 +22,7 @@ pub fn target() -> TargetResult {
         target_vendor: "unknown".to_string(),
         linker_flavor: LinkerFlavor::Gcc,
         options: TargetOptions {
-            abi_blacklist: super::arm_base::abi_blacklist(),
+            unsupported_abis: super::arm_base::unsupported_abis(),
             target_mcount: "\u{1}mcount".to_string(),
             ..base
         },

--- a/src/librustc_target/spec/arm_unknown_linux_musleabihf.rs
+++ b/src/librustc_target/spec/arm_unknown_linux_musleabihf.rs
@@ -22,7 +22,7 @@ pub fn target() -> TargetResult {
         target_vendor: "unknown".to_string(),
         linker_flavor: LinkerFlavor::Gcc,
         options: TargetOptions {
-            abi_blacklist: super::arm_base::abi_blacklist(),
+            unsupported_abis: super::arm_base::unsupported_abis(),
             target_mcount: "\u{1}mcount".to_string(),
             ..base
         },

--- a/src/librustc_target/spec/armebv7r_none_eabi.rs
+++ b/src/librustc_target/spec/armebv7r_none_eabi.rs
@@ -22,7 +22,7 @@ pub fn target() -> TargetResult {
             relocation_model: RelocModel::Static,
             panic_strategy: PanicStrategy::Abort,
             max_atomic_width: Some(32),
-            abi_blacklist: super::arm_base::abi_blacklist(),
+            unsupported_abis: super::arm_base::unsupported_abis(),
             emit_debug_gdb_scripts: false,
             ..Default::default()
         },

--- a/src/librustc_target/spec/armebv7r_none_eabihf.rs
+++ b/src/librustc_target/spec/armebv7r_none_eabihf.rs
@@ -23,7 +23,7 @@ pub fn target() -> TargetResult {
             panic_strategy: PanicStrategy::Abort,
             features: "+vfp3,-d32,-fp16".to_string(),
             max_atomic_width: Some(32),
-            abi_blacklist: super::arm_base::abi_blacklist(),
+            unsupported_abis: super::arm_base::unsupported_abis(),
             emit_debug_gdb_scripts: false,
             ..Default::default()
         },

--- a/src/librustc_target/spec/armv4t_unknown_linux_gnueabi.rs
+++ b/src/librustc_target/spec/armv4t_unknown_linux_gnueabi.rs
@@ -18,7 +18,7 @@ pub fn target() -> TargetResult {
             features: "+soft-float,+strict-align".to_string(),
             // Atomic operations provided by compiler-builtins
             max_atomic_width: Some(32),
-            abi_blacklist: super::arm_base::abi_blacklist(),
+            unsupported_abis: super::arm_base::unsupported_abis(),
             target_mcount: "\u{1}__gnu_mcount_nc".to_string(),
             ..base
         },

--- a/src/librustc_target/spec/armv5te_unknown_linux_gnueabi.rs
+++ b/src/librustc_target/spec/armv5te_unknown_linux_gnueabi.rs
@@ -18,7 +18,7 @@ pub fn target() -> TargetResult {
             features: "+soft-float,+strict-align".to_string(),
             // Atomic operations provided by compiler-builtins
             max_atomic_width: Some(32),
-            abi_blacklist: super::arm_base::abi_blacklist(),
+            unsupported_abis: super::arm_base::unsupported_abis(),
             target_mcount: "\u{1}__gnu_mcount_nc".to_string(),
             ..base
         },

--- a/src/librustc_target/spec/armv5te_unknown_linux_musleabi.rs
+++ b/src/librustc_target/spec/armv5te_unknown_linux_musleabi.rs
@@ -21,7 +21,7 @@ pub fn target() -> TargetResult {
             features: "+soft-float,+strict-align".to_string(),
             // Atomic operations provided by compiler-builtins
             max_atomic_width: Some(32),
-            abi_blacklist: super::arm_base::abi_blacklist(),
+            unsupported_abis: super::arm_base::unsupported_abis(),
             target_mcount: "\u{1}mcount".to_string(),
             ..base
         },

--- a/src/librustc_target/spec/armv6_unknown_freebsd.rs
+++ b/src/librustc_target/spec/armv6_unknown_freebsd.rs
@@ -17,7 +17,7 @@ pub fn target() -> TargetResult {
         options: TargetOptions {
             features: "+v6,+vfp2,-d32".to_string(),
             max_atomic_width: Some(64),
-            abi_blacklist: super::arm_base::abi_blacklist(),
+            unsupported_abis: super::arm_base::unsupported_abis(),
             target_mcount: "\u{1}__gnu_mcount_nc".to_string(),
             ..base
         },

--- a/src/librustc_target/spec/armv6_unknown_netbsd_eabihf.rs
+++ b/src/librustc_target/spec/armv6_unknown_netbsd_eabihf.rs
@@ -17,7 +17,7 @@ pub fn target() -> TargetResult {
 
         options: TargetOptions {
             features: "+v6,+vfp2,-d32".to_string(),
-            abi_blacklist: super::arm_base::abi_blacklist(),
+            unsupported_abis: super::arm_base::unsupported_abis(),
             target_mcount: "__mcount".to_string(),
             ..base
         },

--- a/src/librustc_target/spec/armv7_apple_ios.rs
+++ b/src/librustc_target/spec/armv7_apple_ios.rs
@@ -17,7 +17,7 @@ pub fn target() -> TargetResult {
         options: TargetOptions {
             features: "+v7,+vfp3,+neon".to_string(),
             max_atomic_width: Some(64),
-            abi_blacklist: super::arm_base::abi_blacklist(),
+            unsupported_abis: super::arm_base::unsupported_abis(),
             ..base
         },
     })

--- a/src/librustc_target/spec/armv7_linux_androideabi.rs
+++ b/src/librustc_target/spec/armv7_linux_androideabi.rs
@@ -25,6 +25,6 @@ pub fn target() -> TargetResult {
         target_env: String::new(),
         target_vendor: "unknown".to_string(),
         linker_flavor: LinkerFlavor::Gcc,
-        options: TargetOptions { abi_blacklist: super::arm_base::abi_blacklist(), ..base },
+        options: TargetOptions { unsupported_abis: super::arm_base::unsupported_abis(), ..base },
     })
 }

--- a/src/librustc_target/spec/armv7_unknown_cloudabi_eabihf.rs
+++ b/src/librustc_target/spec/armv7_unknown_cloudabi_eabihf.rs
@@ -5,7 +5,7 @@ pub fn target() -> TargetResult {
     base.cpu = "cortex-a8".to_string();
     base.max_atomic_width = Some(64);
     base.features = "+v7,+vfp3,+neon".to_string();
-    base.abi_blacklist = super::arm_base::abi_blacklist();
+    base.unsupported_abis = super::arm_base::unsupported_abis();
     base.linker = Some("armv7-unknown-cloudabi-eabihf-cc".to_string());
 
     Ok(Target {

--- a/src/librustc_target/spec/armv7_unknown_freebsd.rs
+++ b/src/librustc_target/spec/armv7_unknown_freebsd.rs
@@ -17,7 +17,7 @@ pub fn target() -> TargetResult {
         options: TargetOptions {
             features: "+v7,+vfp3,-d32,+thumb2,-neon".to_string(),
             max_atomic_width: Some(64),
-            abi_blacklist: super::arm_base::abi_blacklist(),
+            unsupported_abis: super::arm_base::unsupported_abis(),
             target_mcount: "\u{1}__gnu_mcount_nc".to_string(),
             ..base
         },

--- a/src/librustc_target/spec/armv7_unknown_linux_gnueabi.rs
+++ b/src/librustc_target/spec/armv7_unknown_linux_gnueabi.rs
@@ -21,7 +21,7 @@ pub fn target() -> TargetResult {
             features: "+v7,+thumb2,+soft-float,-neon".to_string(),
             cpu: "generic".to_string(),
             max_atomic_width: Some(64),
-            abi_blacklist: super::arm_base::abi_blacklist(),
+            unsupported_abis: super::arm_base::unsupported_abis(),
             target_mcount: "\u{1}__gnu_mcount_nc".to_string(),
             ..base
         },

--- a/src/librustc_target/spec/armv7_unknown_linux_gnueabihf.rs
+++ b/src/librustc_target/spec/armv7_unknown_linux_gnueabihf.rs
@@ -22,7 +22,7 @@ pub fn target() -> TargetResult {
             features: "+v7,+vfp3,-d32,+thumb2,-neon".to_string(),
             cpu: "generic".to_string(),
             max_atomic_width: Some(64),
-            abi_blacklist: super::arm_base::abi_blacklist(),
+            unsupported_abis: super::arm_base::unsupported_abis(),
             target_mcount: "\u{1}__gnu_mcount_nc".to_string(),
             ..base
         },

--- a/src/librustc_target/spec/armv7_unknown_linux_musleabi.rs
+++ b/src/librustc_target/spec/armv7_unknown_linux_musleabi.rs
@@ -26,7 +26,7 @@ pub fn target() -> TargetResult {
             features: "+v7,+thumb2,+soft-float,-neon".to_string(),
             cpu: "generic".to_string(),
             max_atomic_width: Some(64),
-            abi_blacklist: super::arm_base::abi_blacklist(),
+            unsupported_abis: super::arm_base::unsupported_abis(),
             target_mcount: "\u{1}mcount".to_string(),
             ..base
         },

--- a/src/librustc_target/spec/armv7_unknown_linux_musleabihf.rs
+++ b/src/librustc_target/spec/armv7_unknown_linux_musleabihf.rs
@@ -25,7 +25,7 @@ pub fn target() -> TargetResult {
             features: "+v7,+vfp3,-d32,+thumb2,-neon".to_string(),
             cpu: "generic".to_string(),
             max_atomic_width: Some(64),
-            abi_blacklist: super::arm_base::abi_blacklist(),
+            unsupported_abis: super::arm_base::unsupported_abis(),
             target_mcount: "\u{1}mcount".to_string(),
             ..base
         },

--- a/src/librustc_target/spec/armv7_unknown_netbsd_eabihf.rs
+++ b/src/librustc_target/spec/armv7_unknown_netbsd_eabihf.rs
@@ -18,7 +18,7 @@ pub fn target() -> TargetResult {
             features: "+v7,+vfp3,-d32,+thumb2,-neon".to_string(),
             cpu: "generic".to_string(),
             max_atomic_width: Some(64),
-            abi_blacklist: super::arm_base::abi_blacklist(),
+            unsupported_abis: super::arm_base::unsupported_abis(),
             target_mcount: "__mcount".to_string(),
             ..base
         },

--- a/src/librustc_target/spec/armv7_wrs_vxworks_eabihf.rs
+++ b/src/librustc_target/spec/armv7_wrs_vxworks_eabihf.rs
@@ -18,7 +18,7 @@ pub fn target() -> TargetResult {
             features: "+v7,+vfp3,-d32,+thumb2,-neon".to_string(),
             cpu: "generic".to_string(),
             max_atomic_width: Some(64),
-            abi_blacklist: super::arm_base::abi_blacklist(),
+            unsupported_abis: super::arm_base::unsupported_abis(),
             ..base
         },
     })

--- a/src/librustc_target/spec/armv7a_none_eabi.rs
+++ b/src/librustc_target/spec/armv7a_none_eabi.rs
@@ -28,7 +28,7 @@ pub fn target() -> Result<Target, String> {
         disable_redzone: true,
         max_atomic_width: Some(64),
         panic_strategy: PanicStrategy::Abort,
-        abi_blacklist: super::arm_base::abi_blacklist(),
+        unsupported_abis: super::arm_base::unsupported_abis(),
         emit_debug_gdb_scripts: false,
         ..Default::default()
     };

--- a/src/librustc_target/spec/armv7a_none_eabihf.rs
+++ b/src/librustc_target/spec/armv7a_none_eabihf.rs
@@ -16,7 +16,7 @@ pub fn target() -> Result<Target, String> {
         disable_redzone: true,
         max_atomic_width: Some(64),
         panic_strategy: PanicStrategy::Abort,
-        abi_blacklist: super::arm_base::abi_blacklist(),
+        unsupported_abis: super::arm_base::unsupported_abis(),
         emit_debug_gdb_scripts: false,
         ..Default::default()
     };

--- a/src/librustc_target/spec/armv7r_none_eabi.rs
+++ b/src/librustc_target/spec/armv7r_none_eabi.rs
@@ -22,7 +22,7 @@ pub fn target() -> TargetResult {
             relocation_model: RelocModel::Static,
             panic_strategy: PanicStrategy::Abort,
             max_atomic_width: Some(32),
-            abi_blacklist: super::arm_base::abi_blacklist(),
+            unsupported_abis: super::arm_base::unsupported_abis(),
             emit_debug_gdb_scripts: false,
             ..Default::default()
         },

--- a/src/librustc_target/spec/armv7r_none_eabihf.rs
+++ b/src/librustc_target/spec/armv7r_none_eabihf.rs
@@ -23,7 +23,7 @@ pub fn target() -> TargetResult {
             panic_strategy: PanicStrategy::Abort,
             features: "+vfp3,-d32,-fp16".to_string(),
             max_atomic_width: Some(32),
-            abi_blacklist: super::arm_base::abi_blacklist(),
+            unsupported_abis: super::arm_base::unsupported_abis(),
             emit_debug_gdb_scripts: false,
             ..Default::default()
         },

--- a/src/librustc_target/spec/armv7s_apple_ios.rs
+++ b/src/librustc_target/spec/armv7s_apple_ios.rs
@@ -17,7 +17,7 @@ pub fn target() -> TargetResult {
         options: TargetOptions {
             features: "+v7,+vfp4,+neon".to_string(),
             max_atomic_width: Some(64),
-            abi_blacklist: super::arm_base::abi_blacklist(),
+            unsupported_abis: super::arm_base::unsupported_abis(),
             ..base
         },
     })

--- a/src/librustc_target/spec/nvptx64_nvidia_cuda.rs
+++ b/src/librustc_target/spec/nvptx64_nvidia_cuda.rs
@@ -55,7 +55,7 @@ pub fn target() -> TargetResult {
 
             // FIXME: enable compilation tests for the target and
             // create the tests for this.
-            abi_blacklist: vec![
+            unsupported_abis: vec![
                 Abi::Cdecl,
                 Abi::Stdcall,
                 Abi::Fastcall,

--- a/src/librustc_target/spec/riscv32i_unknown_none_elf.rs
+++ b/src/librustc_target/spec/riscv32i_unknown_none_elf.rs
@@ -24,7 +24,7 @@ pub fn target() -> TargetResult {
             panic_strategy: PanicStrategy::Abort,
             relocation_model: RelocModel::Static,
             emit_debug_gdb_scripts: false,
-            abi_blacklist: super::riscv_base::abi_blacklist(),
+            unsupported_abis: super::riscv_base::unsupported_abis(),
             ..Default::default()
         },
     })

--- a/src/librustc_target/spec/riscv32imac_unknown_none_elf.rs
+++ b/src/librustc_target/spec/riscv32imac_unknown_none_elf.rs
@@ -24,7 +24,7 @@ pub fn target() -> TargetResult {
             panic_strategy: PanicStrategy::Abort,
             relocation_model: RelocModel::Static,
             emit_debug_gdb_scripts: false,
-            abi_blacklist: super::riscv_base::abi_blacklist(),
+            unsupported_abis: super::riscv_base::unsupported_abis(),
             ..Default::default()
         },
     })

--- a/src/librustc_target/spec/riscv32imc_unknown_none_elf.rs
+++ b/src/librustc_target/spec/riscv32imc_unknown_none_elf.rs
@@ -24,7 +24,7 @@ pub fn target() -> TargetResult {
             panic_strategy: PanicStrategy::Abort,
             relocation_model: RelocModel::Static,
             emit_debug_gdb_scripts: false,
-            abi_blacklist: super::riscv_base::abi_blacklist(),
+            unsupported_abis: super::riscv_base::unsupported_abis(),
             ..Default::default()
         },
     })

--- a/src/librustc_target/spec/riscv64gc_unknown_linux_gnu.rs
+++ b/src/librustc_target/spec/riscv64gc_unknown_linux_gnu.rs
@@ -13,7 +13,7 @@ pub fn target() -> TargetResult {
         target_vendor: "unknown".to_string(),
         linker_flavor: LinkerFlavor::Gcc,
         options: TargetOptions {
-            abi_blacklist: super::riscv_base::abi_blacklist(),
+            unsupported_abis: super::riscv_base::unsupported_abis(),
             code_model: Some(CodeModel::Medium),
             cpu: "generic-rv64".to_string(),
             features: "+m,+a,+f,+d,+c".to_string(),

--- a/src/librustc_target/spec/riscv64gc_unknown_none_elf.rs
+++ b/src/librustc_target/spec/riscv64gc_unknown_none_elf.rs
@@ -25,7 +25,7 @@ pub fn target() -> TargetResult {
             relocation_model: RelocModel::Static,
             code_model: Some(CodeModel::Medium),
             emit_debug_gdb_scripts: false,
-            abi_blacklist: super::riscv_base::abi_blacklist(),
+            unsupported_abis: super::riscv_base::unsupported_abis(),
             ..Default::default()
         },
     })

--- a/src/librustc_target/spec/riscv64imac_unknown_none_elf.rs
+++ b/src/librustc_target/spec/riscv64imac_unknown_none_elf.rs
@@ -25,7 +25,7 @@ pub fn target() -> TargetResult {
             relocation_model: RelocModel::Static,
             code_model: Some(CodeModel::Medium),
             emit_debug_gdb_scripts: false,
-            abi_blacklist: super::riscv_base::abi_blacklist(),
+            unsupported_abis: super::riscv_base::unsupported_abis(),
             ..Default::default()
         },
     })

--- a/src/librustc_target/spec/riscv_base.rs
+++ b/src/librustc_target/spec/riscv_base.rs
@@ -2,7 +2,7 @@ use crate::spec::abi::Abi;
 
 // All the calling conventions trigger an assertion(Unsupported calling
 // convention) in llvm on RISCV
-pub fn abi_blacklist() -> Vec<Abi> {
+pub fn unsupported_abis() -> Vec<Abi> {
     vec![
         Abi::Cdecl,
         Abi::Stdcall,

--- a/src/librustc_target/spec/thumb_base.rs
+++ b/src/librustc_target/spec/thumb_base.rs
@@ -41,7 +41,7 @@ pub fn opts() -> TargetOptions {
         // Similarly, one almost always never wants to use relocatable code because of the extra
         // costs it involves.
         relocation_model: RelocModel::Static,
-        abi_blacklist: super::arm_base::abi_blacklist(),
+        unsupported_abis: super::arm_base::unsupported_abis(),
         // When this section is added a volatile load to its start address is also generated. This
         // volatile load is a footgun as it can end up loading an invalid memory address, depending
         // on how the user set up their linker scripts. This section adds pretty printer for stuff

--- a/src/librustc_target/spec/thumbv7a_pc_windows_msvc.rs
+++ b/src/librustc_target/spec/thumbv7a_pc_windows_msvc.rs
@@ -37,7 +37,7 @@ pub fn target() -> TargetResult {
             features: "+vfp3,+neon".to_string(),
             cpu: "generic".to_string(),
             max_atomic_width: Some(64),
-            abi_blacklist: super::arm_base::abi_blacklist(),
+            unsupported_abis: super::arm_base::unsupported_abis(),
             ..base
         },
     })

--- a/src/librustc_target/spec/thumbv7a_uwp_windows_msvc.rs
+++ b/src/librustc_target/spec/thumbv7a_uwp_windows_msvc.rs
@@ -23,7 +23,7 @@ pub fn target() -> TargetResult {
         options: TargetOptions {
             features: "+vfp3,+neon".to_string(),
             cpu: "generic".to_string(),
-            abi_blacklist: super::arm_base::abi_blacklist(),
+            unsupported_abis: super::arm_base::unsupported_abis(),
             ..base
         },
     })

--- a/src/librustc_target/spec/thumbv7neon_linux_androideabi.rs
+++ b/src/librustc_target/spec/thumbv7neon_linux_androideabi.rs
@@ -25,6 +25,6 @@ pub fn target() -> TargetResult {
         target_env: "".to_string(),
         target_vendor: "unknown".to_string(),
         linker_flavor: LinkerFlavor::Gcc,
-        options: TargetOptions { abi_blacklist: super::arm_base::abi_blacklist(), ..base },
+        options: TargetOptions { unsupported_abis: super::arm_base::unsupported_abis(), ..base },
     })
 }

--- a/src/librustc_target/spec/thumbv7neon_unknown_linux_gnueabihf.rs
+++ b/src/librustc_target/spec/thumbv7neon_unknown_linux_gnueabihf.rs
@@ -25,7 +25,7 @@ pub fn target() -> TargetResult {
             features: "+v7,+thumb-mode,+thumb2,+vfp3,+neon".to_string(),
             cpu: "generic".to_string(),
             max_atomic_width: Some(64),
-            abi_blacklist: super::arm_base::abi_blacklist(),
+            unsupported_abis: super::arm_base::unsupported_abis(),
             ..base
         },
     })

--- a/src/librustc_target/spec/thumbv7neon_unknown_linux_musleabihf.rs
+++ b/src/librustc_target/spec/thumbv7neon_unknown_linux_musleabihf.rs
@@ -29,7 +29,7 @@ pub fn target() -> TargetResult {
             features: "+v7,+thumb-mode,+thumb2,+vfp3,+neon".to_string(),
             cpu: "generic".to_string(),
             max_atomic_width: Some(64),
-            abi_blacklist: super::arm_base::abi_blacklist(),
+            unsupported_abis: super::arm_base::unsupported_abis(),
             target_mcount: "\u{1}mcount".to_string(),
             ..base
         },

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -214,7 +214,7 @@ pub fn new_handler(
 
 /// This function is used to setup the lint initialization. By default, in rustdoc, everything
 /// is "allowed". Depending if we run in test mode or not, we want some of them to be at their
-/// default level. For example, the "INVALID_CODEBLOCK_ATTRIBUTE" lint is activated in both
+/// default level. For example, the "INVALID_CODEBLOCK_ATTRIBUTES" lint is activated in both
 /// modes.
 ///
 /// A little detail easy to forget is that there is a way to set the lint level for all lints
@@ -315,7 +315,7 @@ pub fn run_core(options: RustdocOptions) -> (clean::Crate, RenderInfo, RenderOpt
     let missing_doc_example = rustc_lint::builtin::MISSING_DOC_CODE_EXAMPLES.name;
     let private_doc_tests = rustc_lint::builtin::PRIVATE_DOC_TESTS.name;
     let no_crate_level_docs = rustc_lint::builtin::MISSING_CRATE_LEVEL_DOCS.name;
-    let invalid_codeblock_attribute_name = rustc_lint::builtin::INVALID_CODEBLOCK_ATTRIBUTE.name;
+    let invalid_codeblock_attribute_name = rustc_lint::builtin::INVALID_CODEBLOCK_ATTRIBUTES.name;
 
     // In addition to those specific lints, we also need to whitelist those given through
     // command line, otherwise they'll get ignored and we don't want that.

--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -665,7 +665,7 @@ impl<'a, 'b> ExtraInfo<'a, 'b> {
             (None, None) => return,
         };
         self.tcx.struct_span_lint_hir(
-            lint::builtin::INVALID_CODEBLOCK_ATTRIBUTE,
+            lint::builtin::INVALID_CODEBLOCK_ATTRIBUTES,
             hir_id,
             self.sp,
             |lint| {

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -46,7 +46,7 @@ pub struct TestOptions {
 pub fn run(options: Options) -> Result<(), String> {
     let input = config::Input::File(options.input.clone());
 
-    let invalid_codeblock_attribute_name = rustc_lint::builtin::INVALID_CODEBLOCK_ATTRIBUTE.name;
+    let invalid_codeblock_attribute_name = rustc_lint::builtin::INVALID_CODEBLOCK_ATTRIBUTES.name;
 
     // In addition to those specific lints, we also need to whitelist those given through
     // command line, otherwise they'll get ignored and we don't want that.

--- a/src/test/codegen/naked-functions.rs
+++ b/src/test/codegen/naked-functions.rs
@@ -18,7 +18,7 @@ pub fn naked_empty() {
 // CHECK-NEXT: define void @naked_with_args(i{{[0-9]+( %0)?}})
 pub fn naked_with_args(a: isize) {
     // CHECK-NEXT: {{.+}}:
-    // CHECK-NEXT: %a = alloca i{{[0-9]+}}
+    // CHECK-NEXT: %_1 = alloca i{{[0-9]+}}
     &a; // keep variable in an alloca
     // CHECK: ret void
 }
@@ -39,7 +39,7 @@ pub fn naked_with_return() -> isize {
 #[naked]
 pub fn naked_with_args_and_return(a: isize) -> isize {
     // CHECK-NEXT: {{.+}}:
-    // CHECK-NEXT: %a = alloca i{{[0-9]+}}
+    // CHECK-NEXT: %_1 = alloca i{{[0-9]+}}
     &a; // keep variable in an alloca
     // CHECK: ret i{{[0-9]+}} %{{[0-9]+}}
     a

--- a/src/test/debuginfo/function-arguments.rs
+++ b/src/test/debuginfo/function-arguments.rs
@@ -18,6 +18,10 @@
 // gdb-check:$4 = 3000
 // gdb-command:continue
 
+// gdb-command:info args
+// gdb-check:No arguments.
+// gdb-command:continue
+
 // === LLDB TESTS ==================================================================================
 
 // lldb-command:run
@@ -38,7 +42,12 @@
 // lldbr-check:(i64) b = 3000
 // lldb-command:continue
 
+// lldb-command:frame variable
+// lldbg-check:(unsigned long) = 111 (unsigned long) = 222
+// lldbr-check:(unsigned long) = 111 (unsigned long) = 222
+// lldb-command:continue
 
+#![feature(naked_functions)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
 
@@ -46,6 +55,7 @@ fn main() {
 
     fun(111102, true);
     nested(2000, 3000);
+    naked(111, 222);
 
     fn nested(a: i32, b: i64) -> (i32, i64) {
         zzz(); // #break
@@ -57,6 +67,13 @@ fn fun(x: isize, y: bool) -> (isize, bool) {
     zzz(); // #break
 
     (x, y)
+}
+
+#[naked]
+fn naked(x: usize, y: usize) -> usize {
+    zzz(); // #break
+
+    x + y
 }
 
 fn zzz() { () }

--- a/src/test/mir-opt/exponential-or/rustc.match_tuple.SimplifyCfg-initial.after.mir
+++ b/src/test/mir-opt/exponential-or/rustc.match_tuple.SimplifyCfg-initial.after.mir
@@ -102,8 +102,8 @@ fn match_tuple(_1: (u32, bool, std::option::Option<i32>, u32)) -> u32 {
         _0 = BitXor(move _9, move _10);  // scope 1 at $DIR/exponential-or.rs:8:83: 8:88
         StorageDead(_10);                // scope 1 at $DIR/exponential-or.rs:8:87: 8:88
         StorageDead(_9);                 // scope 1 at $DIR/exponential-or.rs:8:87: 8:88
-        StorageDead(_8);                 // scope 0 at $DIR/exponential-or.rs:8:88: 8:89
-        StorageDead(_7);                 // scope 0 at $DIR/exponential-or.rs:8:88: 8:89
+        StorageDead(_8);                 // scope 0 at $DIR/exponential-or.rs:8:87: 8:88
+        StorageDead(_7);                 // scope 0 at $DIR/exponential-or.rs:8:87: 8:88
         goto -> bb10;                    // scope 0 at $DIR/exponential-or.rs:7:5: 10:6
     }
 

--- a/src/test/mir-opt/issue-73223/32bit/rustc.main.SimplifyArmIdentity.diff
+++ b/src/test/mir-opt/issue-73223/32bit/rustc.main.SimplifyArmIdentity.diff
@@ -137,7 +137,7 @@
           StorageLive(_4);                 // scope 0 at $DIR/issue-73223.rs:3:14: 3:15
           _4 = ((_2 as Some).0: i32);      // scope 0 at $DIR/issue-73223.rs:3:14: 3:15
           _1 = _4;                         // scope 2 at $DIR/issue-73223.rs:3:20: 3:21
-          StorageDead(_4);                 // scope 0 at $DIR/issue-73223.rs:3:21: 3:22
+          StorageDead(_4);                 // scope 0 at $DIR/issue-73223.rs:3:20: 3:21
           StorageDead(_2);                 // scope 0 at $DIR/issue-73223.rs:5:6: 5:7
           StorageLive(_6);                 // scope 1 at $DIR/issue-73223.rs:7:9: 7:14
           StorageLive(_7);                 // scope 1 at $DIR/issue-73223.rs:7:22: 7:27

--- a/src/test/mir-opt/issue-73223/64bit/rustc.main.SimplifyArmIdentity.diff
+++ b/src/test/mir-opt/issue-73223/64bit/rustc.main.SimplifyArmIdentity.diff
@@ -137,7 +137,7 @@
           StorageLive(_4);                 // scope 0 at $DIR/issue-73223.rs:3:14: 3:15
           _4 = ((_2 as Some).0: i32);      // scope 0 at $DIR/issue-73223.rs:3:14: 3:15
           _1 = _4;                         // scope 2 at $DIR/issue-73223.rs:3:20: 3:21
-          StorageDead(_4);                 // scope 0 at $DIR/issue-73223.rs:3:21: 3:22
+          StorageDead(_4);                 // scope 0 at $DIR/issue-73223.rs:3:20: 3:21
           StorageDead(_2);                 // scope 0 at $DIR/issue-73223.rs:5:6: 5:7
           StorageLive(_6);                 // scope 1 at $DIR/issue-73223.rs:7:9: 7:14
           StorageLive(_7);                 // scope 1 at $DIR/issue-73223.rs:7:22: 7:27

--- a/src/test/mir-opt/match-arm-scopes/rustc.complicated_match.ElaborateDrops.after.mir
+++ b/src/test/mir-opt/match-arm-scopes/rustc.complicated_match.ElaborateDrops.after.mir
@@ -61,7 +61,7 @@ fn complicated_match(_1: bool, _2: (bool, bool, std::string::String)) -> i32 {
                                          // mir::Constant
                                          // + span: $DIR/match-arm-scopes.rs:16:77: 16:78
                                          // + literal: Const { ty: i32, val: Value(Scalar(0x00000001)) }
-        drop(_7) -> [return: bb19, unwind: bb10]; // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
+        drop(_7) -> [return: bb19, unwind: bb10]; // scope 0 at $DIR/match-arm-scopes.rs:16:77: 16:78
     }
 
     bb6: {
@@ -90,9 +90,9 @@ fn complicated_match(_1: bool, _2: (bool, bool, std::string::String)) -> i32 {
                                          // + span: $DIR/match-arm-scopes.rs:16:59: 16:60
                                          // + literal: Const { ty: i32, val: Value(Scalar(0x00000003)) }
         StorageDead(_10);                // scope 0 at $DIR/match-arm-scopes.rs:16:72: 16:73
-        StorageDead(_9);                 // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
-        StorageDead(_8);                 // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
-        StorageDead(_6);                 // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
+        StorageDead(_9);                 // scope 0 at $DIR/match-arm-scopes.rs:16:77: 16:78
+        StorageDead(_8);                 // scope 0 at $DIR/match-arm-scopes.rs:16:77: 16:78
+        StorageDead(_6);                 // scope 0 at $DIR/match-arm-scopes.rs:16:77: 16:78
         goto -> bb11;                    // scope 0 at $DIR/match-arm-scopes.rs:16:52: 16:60
     }
 
@@ -109,7 +109,7 @@ fn complicated_match(_1: bool, _2: (bool, bool, std::string::String)) -> i32 {
     }
 
     bb12: {
-        StorageDead(_9);                 // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
+        StorageDead(_9);                 // scope 0 at $DIR/match-arm-scopes.rs:16:77: 16:78
         StorageLive(_5);                 // scope 0 at $DIR/match-arm-scopes.rs:16:17: 16:18
         _5 = (_2.1: bool);               // scope 0 at $DIR/match-arm-scopes.rs:16:17: 16:18
         StorageLive(_7);                 // scope 0 at $DIR/match-arm-scopes.rs:16:20: 16:21
@@ -118,9 +118,9 @@ fn complicated_match(_1: bool, _2: (bool, bool, std::string::String)) -> i32 {
     }
 
     bb13: {
-        StorageDead(_9);                 // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
-        StorageDead(_8);                 // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
-        StorageDead(_6);                 // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
+        StorageDead(_9);                 // scope 0 at $DIR/match-arm-scopes.rs:16:77: 16:78
+        StorageDead(_8);                 // scope 0 at $DIR/match-arm-scopes.rs:16:77: 16:78
+        StorageDead(_6);                 // scope 0 at $DIR/match-arm-scopes.rs:16:77: 16:78
         goto -> bb2;                     // scope 0 at $DIR/match-arm-scopes.rs:16:42: 16:73
     }
 
@@ -150,14 +150,14 @@ fn complicated_match(_1: bool, _2: (bool, bool, std::string::String)) -> i32 {
                                          // + span: $DIR/match-arm-scopes.rs:16:59: 16:60
                                          // + literal: Const { ty: i32, val: Value(Scalar(0x00000003)) }
         StorageDead(_13);                // scope 0 at $DIR/match-arm-scopes.rs:16:72: 16:73
-        StorageDead(_12);                // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
-        StorageDead(_8);                 // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
-        StorageDead(_6);                 // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
+        StorageDead(_12);                // scope 0 at $DIR/match-arm-scopes.rs:16:77: 16:78
+        StorageDead(_8);                 // scope 0 at $DIR/match-arm-scopes.rs:16:77: 16:78
+        StorageDead(_6);                 // scope 0 at $DIR/match-arm-scopes.rs:16:77: 16:78
         goto -> bb11;                    // scope 0 at $DIR/match-arm-scopes.rs:16:52: 16:60
     }
 
     bb17: {
-        StorageDead(_12);                // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
+        StorageDead(_12);                // scope 0 at $DIR/match-arm-scopes.rs:16:77: 16:78
         StorageLive(_5);                 // scope 0 at $DIR/match-arm-scopes.rs:16:26: 16:27
         _5 = (_2.0: bool);               // scope 0 at $DIR/match-arm-scopes.rs:16:26: 16:27
         StorageLive(_7);                 // scope 0 at $DIR/match-arm-scopes.rs:16:36: 16:37
@@ -166,17 +166,17 @@ fn complicated_match(_1: bool, _2: (bool, bool, std::string::String)) -> i32 {
     }
 
     bb18: {
-        StorageDead(_12);                // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
-        StorageDead(_8);                 // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
-        StorageDead(_6);                 // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
+        StorageDead(_12);                // scope 0 at $DIR/match-arm-scopes.rs:16:77: 16:78
+        StorageDead(_8);                 // scope 0 at $DIR/match-arm-scopes.rs:16:77: 16:78
+        StorageDead(_6);                 // scope 0 at $DIR/match-arm-scopes.rs:16:77: 16:78
         goto -> bb3;                     // scope 0 at $DIR/match-arm-scopes.rs:16:42: 16:73
     }
 
     bb19: {
-        StorageDead(_7);                 // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
-        StorageDead(_5);                 // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
-        StorageDead(_8);                 // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
-        StorageDead(_6);                 // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
+        StorageDead(_7);                 // scope 0 at $DIR/match-arm-scopes.rs:16:77: 16:78
+        StorageDead(_5);                 // scope 0 at $DIR/match-arm-scopes.rs:16:77: 16:78
+        StorageDead(_8);                 // scope 0 at $DIR/match-arm-scopes.rs:16:77: 16:78
+        StorageDead(_6);                 // scope 0 at $DIR/match-arm-scopes.rs:16:77: 16:78
         goto -> bb23;                    // scope 0 at $DIR/match-arm-scopes.rs:15:5: 18:6
     }
 
@@ -188,7 +188,7 @@ fn complicated_match(_1: bool, _2: (bool, bool, std::string::String)) -> i32 {
                                          // mir::Constant
                                          // + span: $DIR/match-arm-scopes.rs:17:41: 17:42
                                          // + literal: Const { ty: i32, val: Value(Scalar(0x00000002)) }
-        drop(_16) -> [return: bb22, unwind: bb10]; // scope 0 at $DIR/match-arm-scopes.rs:17:42: 17:43
+        drop(_16) -> [return: bb22, unwind: bb10]; // scope 0 at $DIR/match-arm-scopes.rs:17:41: 17:42
     }
 
     bb21: {
@@ -200,8 +200,8 @@ fn complicated_match(_1: bool, _2: (bool, bool, std::string::String)) -> i32 {
     }
 
     bb22: {
-        StorageDead(_16);                // scope 0 at $DIR/match-arm-scopes.rs:17:42: 17:43
-        StorageDead(_15);                // scope 0 at $DIR/match-arm-scopes.rs:17:42: 17:43
+        StorageDead(_16);                // scope 0 at $DIR/match-arm-scopes.rs:17:41: 17:42
+        StorageDead(_15);                // scope 0 at $DIR/match-arm-scopes.rs:17:41: 17:42
         goto -> bb23;                    // scope 0 at $DIR/match-arm-scopes.rs:15:5: 18:6
     }
 

--- a/src/test/mir-opt/match-arm-scopes/rustc.complicated_match.SimplifyCfg-initial.after.mir
+++ b/src/test/mir-opt/match-arm-scopes/rustc.complicated_match.SimplifyCfg-initial.after.mir
@@ -74,7 +74,7 @@ fn complicated_match(_1: bool, _2: (bool, bool, std::string::String)) -> i32 {
                                          // mir::Constant
                                          // + span: $DIR/match-arm-scopes.rs:16:77: 16:78
                                          // + literal: Const { ty: i32, val: Value(Scalar(0x00000001)) }
-        drop(_7) -> [return: bb24, unwind: bb14]; // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
+        drop(_7) -> [return: bb24, unwind: bb14]; // scope 0 at $DIR/match-arm-scopes.rs:16:77: 16:78
     }
 
     bb9: {
@@ -110,9 +110,9 @@ fn complicated_match(_1: bool, _2: (bool, bool, std::string::String)) -> i32 {
                                          // + span: $DIR/match-arm-scopes.rs:16:59: 16:60
                                          // + literal: Const { ty: i32, val: Value(Scalar(0x00000003)) }
         StorageDead(_10);                // scope 0 at $DIR/match-arm-scopes.rs:16:72: 16:73
-        StorageDead(_9);                 // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
-        StorageDead(_8);                 // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
-        StorageDead(_6);                 // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
+        StorageDead(_9);                 // scope 0 at $DIR/match-arm-scopes.rs:16:77: 16:78
+        StorageDead(_8);                 // scope 0 at $DIR/match-arm-scopes.rs:16:77: 16:78
+        StorageDead(_6);                 // scope 0 at $DIR/match-arm-scopes.rs:16:77: 16:78
         goto -> bb15;                    // scope 0 at $DIR/match-arm-scopes.rs:16:52: 16:60
     }
 
@@ -129,7 +129,7 @@ fn complicated_match(_1: bool, _2: (bool, bool, std::string::String)) -> i32 {
     }
 
     bb16: {
-        StorageDead(_9);                 // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
+        StorageDead(_9);                 // scope 0 at $DIR/match-arm-scopes.rs:16:77: 16:78
         FakeRead(ForMatchGuard, _3);     // scope 0 at $DIR/match-arm-scopes.rs:16:72: 16:73
         FakeRead(ForMatchGuard, _4);     // scope 0 at $DIR/match-arm-scopes.rs:16:72: 16:73
         FakeRead(ForGuardBinding, _6);   // scope 0 at $DIR/match-arm-scopes.rs:16:72: 16:73
@@ -142,9 +142,9 @@ fn complicated_match(_1: bool, _2: (bool, bool, std::string::String)) -> i32 {
     }
 
     bb17: {
-        StorageDead(_9);                 // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
-        StorageDead(_8);                 // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
-        StorageDead(_6);                 // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
+        StorageDead(_9);                 // scope 0 at $DIR/match-arm-scopes.rs:16:77: 16:78
+        StorageDead(_8);                 // scope 0 at $DIR/match-arm-scopes.rs:16:77: 16:78
+        StorageDead(_6);                 // scope 0 at $DIR/match-arm-scopes.rs:16:77: 16:78
         falseEdge -> [real: bb3, imaginary: bb4]; // scope 0 at $DIR/match-arm-scopes.rs:16:42: 16:73
     }
 
@@ -181,14 +181,14 @@ fn complicated_match(_1: bool, _2: (bool, bool, std::string::String)) -> i32 {
                                          // + span: $DIR/match-arm-scopes.rs:16:59: 16:60
                                          // + literal: Const { ty: i32, val: Value(Scalar(0x00000003)) }
         StorageDead(_13);                // scope 0 at $DIR/match-arm-scopes.rs:16:72: 16:73
-        StorageDead(_12);                // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
-        StorageDead(_8);                 // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
-        StorageDead(_6);                 // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
+        StorageDead(_12);                // scope 0 at $DIR/match-arm-scopes.rs:16:77: 16:78
+        StorageDead(_8);                 // scope 0 at $DIR/match-arm-scopes.rs:16:77: 16:78
+        StorageDead(_6);                 // scope 0 at $DIR/match-arm-scopes.rs:16:77: 16:78
         goto -> bb15;                    // scope 0 at $DIR/match-arm-scopes.rs:16:52: 16:60
     }
 
     bb22: {
-        StorageDead(_12);                // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
+        StorageDead(_12);                // scope 0 at $DIR/match-arm-scopes.rs:16:77: 16:78
         FakeRead(ForMatchGuard, _3);     // scope 0 at $DIR/match-arm-scopes.rs:16:72: 16:73
         FakeRead(ForMatchGuard, _4);     // scope 0 at $DIR/match-arm-scopes.rs:16:72: 16:73
         FakeRead(ForGuardBinding, _6);   // scope 0 at $DIR/match-arm-scopes.rs:16:72: 16:73
@@ -201,17 +201,17 @@ fn complicated_match(_1: bool, _2: (bool, bool, std::string::String)) -> i32 {
     }
 
     bb23: {
-        StorageDead(_12);                // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
-        StorageDead(_8);                 // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
-        StorageDead(_6);                 // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
+        StorageDead(_12);                // scope 0 at $DIR/match-arm-scopes.rs:16:77: 16:78
+        StorageDead(_8);                 // scope 0 at $DIR/match-arm-scopes.rs:16:77: 16:78
+        StorageDead(_6);                 // scope 0 at $DIR/match-arm-scopes.rs:16:77: 16:78
         falseEdge -> [real: bb5, imaginary: bb6]; // scope 0 at $DIR/match-arm-scopes.rs:16:42: 16:73
     }
 
     bb24: {
-        StorageDead(_7);                 // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
-        StorageDead(_5);                 // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
-        StorageDead(_8);                 // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
-        StorageDead(_6);                 // scope 0 at $DIR/match-arm-scopes.rs:16:78: 16:79
+        StorageDead(_7);                 // scope 0 at $DIR/match-arm-scopes.rs:16:77: 16:78
+        StorageDead(_5);                 // scope 0 at $DIR/match-arm-scopes.rs:16:77: 16:78
+        StorageDead(_8);                 // scope 0 at $DIR/match-arm-scopes.rs:16:77: 16:78
+        StorageDead(_6);                 // scope 0 at $DIR/match-arm-scopes.rs:16:77: 16:78
         goto -> bb28;                    // scope 0 at $DIR/match-arm-scopes.rs:15:5: 18:6
     }
 
@@ -223,7 +223,7 @@ fn complicated_match(_1: bool, _2: (bool, bool, std::string::String)) -> i32 {
                                          // mir::Constant
                                          // + span: $DIR/match-arm-scopes.rs:17:41: 17:42
                                          // + literal: Const { ty: i32, val: Value(Scalar(0x00000002)) }
-        drop(_16) -> [return: bb27, unwind: bb14]; // scope 0 at $DIR/match-arm-scopes.rs:17:42: 17:43
+        drop(_16) -> [return: bb27, unwind: bb14]; // scope 0 at $DIR/match-arm-scopes.rs:17:41: 17:42
     }
 
     bb26: {
@@ -235,8 +235,8 @@ fn complicated_match(_1: bool, _2: (bool, bool, std::string::String)) -> i32 {
     }
 
     bb27: {
-        StorageDead(_16);                // scope 0 at $DIR/match-arm-scopes.rs:17:42: 17:43
-        StorageDead(_15);                // scope 0 at $DIR/match-arm-scopes.rs:17:42: 17:43
+        StorageDead(_16);                // scope 0 at $DIR/match-arm-scopes.rs:17:41: 17:42
+        StorageDead(_15);                // scope 0 at $DIR/match-arm-scopes.rs:17:41: 17:42
         goto -> bb28;                    // scope 0 at $DIR/match-arm-scopes.rs:15:5: 18:6
     }
 

--- a/src/test/mir-opt/match_false_edges/rustc.full_tested_match.PromoteTemps.after.mir
+++ b/src/test/mir-opt/match_false_edges/rustc.full_tested_match.PromoteTemps.after.mir
@@ -97,7 +97,7 @@ fn full_tested_match() -> () {
     }
 
     bb8: {
-        StorageDead(_7);                 // scope 0 at $DIR/match_false_edges.rs:16:37: 16:38
+        StorageDead(_7);                 // scope 0 at $DIR/match_false_edges.rs:16:36: 16:37
         FakeRead(ForMatchGuard, _4);     // scope 0 at $DIR/match_false_edges.rs:16:26: 16:27
         FakeRead(ForGuardBinding, _6);   // scope 0 at $DIR/match_false_edges.rs:16:26: 16:27
         StorageLive(_5);                 // scope 0 at $DIR/match_false_edges.rs:16:14: 16:15
@@ -112,14 +112,14 @@ fn full_tested_match() -> () {
                                          // + span: $DIR/match_false_edges.rs:16:32: 16:33
                                          // + literal: Const { ty: i32, val: Value(Scalar(0x00000001)) }
         StorageDead(_8);                 // scope 2 at $DIR/match_false_edges.rs:16:36: 16:37
-        StorageDead(_5);                 // scope 0 at $DIR/match_false_edges.rs:16:37: 16:38
-        StorageDead(_6);                 // scope 0 at $DIR/match_false_edges.rs:16:37: 16:38
+        StorageDead(_5);                 // scope 0 at $DIR/match_false_edges.rs:16:36: 16:37
+        StorageDead(_6);                 // scope 0 at $DIR/match_false_edges.rs:16:36: 16:37
         goto -> bb11;                    // scope 0 at $DIR/match_false_edges.rs:15:13: 19:6
     }
 
     bb9: {
-        StorageDead(_7);                 // scope 0 at $DIR/match_false_edges.rs:16:37: 16:38
-        StorageDead(_6);                 // scope 0 at $DIR/match_false_edges.rs:16:37: 16:38
+        StorageDead(_7);                 // scope 0 at $DIR/match_false_edges.rs:16:36: 16:37
+        StorageDead(_6);                 // scope 0 at $DIR/match_false_edges.rs:16:36: 16:37
         goto -> bb4;                     // scope 0 at $DIR/match_false_edges.rs:16:20: 16:27
     }
 
@@ -136,7 +136,7 @@ fn full_tested_match() -> () {
                                          // + span: $DIR/match_false_edges.rs:17:21: 17:22
                                          // + literal: Const { ty: i32, val: Value(Scalar(0x00000002)) }
         StorageDead(_10);                // scope 3 at $DIR/match_false_edges.rs:17:25: 17:26
-        StorageDead(_9);                 // scope 0 at $DIR/match_false_edges.rs:17:26: 17:27
+        StorageDead(_9);                 // scope 0 at $DIR/match_false_edges.rs:17:25: 17:26
         goto -> bb11;                    // scope 0 at $DIR/match_false_edges.rs:15:13: 19:6
     }
 

--- a/src/test/mir-opt/match_false_edges/rustc.full_tested_match2.PromoteTemps.before.mir
+++ b/src/test/mir-opt/match_false_edges/rustc.full_tested_match2.PromoteTemps.before.mir
@@ -62,7 +62,7 @@ fn full_tested_match2() -> () {
                                          // + span: $DIR/match_false_edges.rs:29:21: 29:22
                                          // + literal: Const { ty: i32, val: Value(Scalar(0x00000002)) }
         StorageDead(_10);                // scope 3 at $DIR/match_false_edges.rs:29:25: 29:26
-        StorageDead(_9);                 // scope 0 at $DIR/match_false_edges.rs:29:26: 29:27
+        StorageDead(_9);                 // scope 0 at $DIR/match_false_edges.rs:29:25: 29:26
         goto -> bb11;                    // scope 0 at $DIR/match_false_edges.rs:26:13: 30:6
     }
 
@@ -89,7 +89,7 @@ fn full_tested_match2() -> () {
     }
 
     bb8: {
-        StorageDead(_7);                 // scope 0 at $DIR/match_false_edges.rs:27:37: 27:38
+        StorageDead(_7);                 // scope 0 at $DIR/match_false_edges.rs:27:36: 27:37
         FakeRead(ForMatchGuard, _4);     // scope 0 at $DIR/match_false_edges.rs:27:26: 27:27
         FakeRead(ForGuardBinding, _6);   // scope 0 at $DIR/match_false_edges.rs:27:26: 27:27
         StorageLive(_5);                 // scope 0 at $DIR/match_false_edges.rs:27:14: 27:15
@@ -104,14 +104,14 @@ fn full_tested_match2() -> () {
                                          // + span: $DIR/match_false_edges.rs:27:32: 27:33
                                          // + literal: Const { ty: i32, val: Value(Scalar(0x00000001)) }
         StorageDead(_8);                 // scope 2 at $DIR/match_false_edges.rs:27:36: 27:37
-        StorageDead(_5);                 // scope 0 at $DIR/match_false_edges.rs:27:37: 27:38
-        StorageDead(_6);                 // scope 0 at $DIR/match_false_edges.rs:27:37: 27:38
+        StorageDead(_5);                 // scope 0 at $DIR/match_false_edges.rs:27:36: 27:37
+        StorageDead(_6);                 // scope 0 at $DIR/match_false_edges.rs:27:36: 27:37
         goto -> bb11;                    // scope 0 at $DIR/match_false_edges.rs:26:13: 30:6
     }
 
     bb9: {
-        StorageDead(_7);                 // scope 0 at $DIR/match_false_edges.rs:27:37: 27:38
-        StorageDead(_6);                 // scope 0 at $DIR/match_false_edges.rs:27:37: 27:38
+        StorageDead(_7);                 // scope 0 at $DIR/match_false_edges.rs:27:36: 27:37
+        StorageDead(_6);                 // scope 0 at $DIR/match_false_edges.rs:27:36: 27:37
         falseEdge -> [real: bb4, imaginary: bb2]; // scope 0 at $DIR/match_false_edges.rs:27:20: 27:27
     }
 

--- a/src/test/mir-opt/match_false_edges/rustc.main.PromoteTemps.before.mir
+++ b/src/test/mir-opt/match_false_edges/rustc.main.PromoteTemps.before.mir
@@ -70,7 +70,7 @@ fn main() -> () {
                                          // mir::Constant
                                          // + span: $DIR/match_false_edges.rs:39:15: 39:16
                                          // + literal: Const { ty: i32, val: Value(Scalar(0x00000004)) }
-        StorageDead(_14);                // scope 0 at $DIR/match_false_edges.rs:39:16: 39:17
+        StorageDead(_14);                // scope 0 at $DIR/match_false_edges.rs:39:15: 39:16
         goto -> bb15;                    // scope 0 at $DIR/match_false_edges.rs:35:13: 40:6
     }
 
@@ -97,7 +97,7 @@ fn main() -> () {
     }
 
     bb8: {
-        StorageDead(_8);                 // scope 0 at $DIR/match_false_edges.rs:36:33: 36:34
+        StorageDead(_8);                 // scope 0 at $DIR/match_false_edges.rs:36:32: 36:33
         FakeRead(ForMatchGuard, _5);     // scope 0 at $DIR/match_false_edges.rs:36:27: 36:28
         FakeRead(ForGuardBinding, _7);   // scope 0 at $DIR/match_false_edges.rs:36:27: 36:28
         StorageLive(_6);                 // scope 0 at $DIR/match_false_edges.rs:36:14: 36:16
@@ -109,14 +109,14 @@ fn main() -> () {
                                          // mir::Constant
                                          // + span: $DIR/match_false_edges.rs:36:32: 36:33
                                          // + literal: Const { ty: i32, val: Value(Scalar(0x00000001)) }
-        StorageDead(_6);                 // scope 0 at $DIR/match_false_edges.rs:36:33: 36:34
-        StorageDead(_7);                 // scope 0 at $DIR/match_false_edges.rs:36:33: 36:34
+        StorageDead(_6);                 // scope 0 at $DIR/match_false_edges.rs:36:32: 36:33
+        StorageDead(_7);                 // scope 0 at $DIR/match_false_edges.rs:36:32: 36:33
         goto -> bb15;                    // scope 0 at $DIR/match_false_edges.rs:35:13: 40:6
     }
 
     bb9: {
-        StorageDead(_8);                 // scope 0 at $DIR/match_false_edges.rs:36:33: 36:34
-        StorageDead(_7);                 // scope 0 at $DIR/match_false_edges.rs:36:33: 36:34
+        StorageDead(_8);                 // scope 0 at $DIR/match_false_edges.rs:36:32: 36:33
+        StorageDead(_7);                 // scope 0 at $DIR/match_false_edges.rs:36:32: 36:33
         falseEdge -> [real: bb2, imaginary: bb2]; // scope 0 at $DIR/match_false_edges.rs:36:21: 36:28
     }
 
@@ -130,7 +130,7 @@ fn main() -> () {
                                          // mir::Constant
                                          // + span: $DIR/match_false_edges.rs:37:15: 37:16
                                          // + literal: Const { ty: i32, val: Value(Scalar(0x00000002)) }
-        StorageDead(_9);                 // scope 0 at $DIR/match_false_edges.rs:37:16: 37:17
+        StorageDead(_9);                 // scope 0 at $DIR/match_false_edges.rs:37:15: 37:16
         goto -> bb15;                    // scope 0 at $DIR/match_false_edges.rs:35:13: 40:6
     }
 
@@ -156,7 +156,7 @@ fn main() -> () {
     }
 
     bb13: {
-        StorageDead(_12);                // scope 0 at $DIR/match_false_edges.rs:38:34: 38:35
+        StorageDead(_12);                // scope 0 at $DIR/match_false_edges.rs:38:33: 38:34
         FakeRead(ForMatchGuard, _5);     // scope 0 at $DIR/match_false_edges.rs:38:28: 38:29
         FakeRead(ForGuardBinding, _11);  // scope 0 at $DIR/match_false_edges.rs:38:28: 38:29
         StorageLive(_10);                // scope 0 at $DIR/match_false_edges.rs:38:14: 38:15
@@ -168,14 +168,14 @@ fn main() -> () {
                                          // mir::Constant
                                          // + span: $DIR/match_false_edges.rs:38:33: 38:34
                                          // + literal: Const { ty: i32, val: Value(Scalar(0x00000003)) }
-        StorageDead(_10);                // scope 0 at $DIR/match_false_edges.rs:38:34: 38:35
-        StorageDead(_11);                // scope 0 at $DIR/match_false_edges.rs:38:34: 38:35
+        StorageDead(_10);                // scope 0 at $DIR/match_false_edges.rs:38:33: 38:34
+        StorageDead(_11);                // scope 0 at $DIR/match_false_edges.rs:38:33: 38:34
         goto -> bb15;                    // scope 0 at $DIR/match_false_edges.rs:35:13: 40:6
     }
 
     bb14: {
-        StorageDead(_12);                // scope 0 at $DIR/match_false_edges.rs:38:34: 38:35
-        StorageDead(_11);                // scope 0 at $DIR/match_false_edges.rs:38:34: 38:35
+        StorageDead(_12);                // scope 0 at $DIR/match_false_edges.rs:38:33: 38:34
+        StorageDead(_11);                // scope 0 at $DIR/match_false_edges.rs:38:33: 38:34
         falseEdge -> [real: bb4, imaginary: bb4]; // scope 0 at $DIR/match_false_edges.rs:38:20: 38:29
     }
 

--- a/src/test/mir-opt/match_test/rustc.main.SimplifyCfg-initial.after.mir
+++ b/src/test/mir-opt/match_test/rustc.main.SimplifyCfg-initial.after.mir
@@ -117,7 +117,7 @@ fn main() -> () {
     }
 
     bb10: {
-        StorageDead(_9);                 // scope 2 at $DIR/match_test.rs:13:24: 13:25
+        StorageDead(_9);                 // scope 2 at $DIR/match_test.rs:13:23: 13:24
         FakeRead(ForMatchGuard, _8);     // scope 2 at $DIR/match_test.rs:13:18: 13:19
         _3 = const 0_i32;                // scope 2 at $DIR/match_test.rs:13:23: 13:24
                                          // ty::Const
@@ -130,7 +130,7 @@ fn main() -> () {
     }
 
     bb11: {
-        StorageDead(_9);                 // scope 2 at $DIR/match_test.rs:13:24: 13:25
+        StorageDead(_9);                 // scope 2 at $DIR/match_test.rs:13:23: 13:24
         falseEdge -> [real: bb3, imaginary: bb6]; // scope 2 at $DIR/match_test.rs:13:18: 13:19
     }
 

--- a/src/test/mir-opt/no-drop-for-inactive-variant/rustc.unwrap.SimplifyCfg-elaborate-drops.after.mir
+++ b/src/test/mir-opt/no-drop-for-inactive-variant/rustc.unwrap.SimplifyCfg-elaborate-drops.after.mir
@@ -43,7 +43,7 @@ fn unwrap(_1: std::option::Option<T>) -> T {
         StorageLive(_3);                 // scope 0 at $DIR/no-drop-for-inactive-variant.rs:9:14: 9:15
         _3 = move ((_1 as Some).0: T);   // scope 0 at $DIR/no-drop-for-inactive-variant.rs:9:14: 9:15
         _0 = move _3;                    // scope 1 at $DIR/no-drop-for-inactive-variant.rs:9:20: 9:21
-        StorageDead(_3);                 // scope 0 at $DIR/no-drop-for-inactive-variant.rs:9:21: 9:22
+        StorageDead(_3);                 // scope 0 at $DIR/no-drop-for-inactive-variant.rs:9:20: 9:21
         _6 = discriminant(_1);           // scope 0 at $DIR/no-drop-for-inactive-variant.rs:12:1: 12:2
         return;                          // scope 0 at $DIR/no-drop-for-inactive-variant.rs:12:2: 12:2
     }

--- a/src/test/mir-opt/remove_fake_borrows/rustc.match_guard.CleanupNonCodegenStatements.diff
+++ b/src/test/mir-opt/remove_fake_borrows/rustc.match_guard.CleanupNonCodegenStatements.diff
@@ -53,7 +53,7 @@
       }
   
       bb5: {
-          StorageDead(_8);                 // scope 0 at $DIR/remove_fake_borrows.rs:8:26: 8:27
+          StorageDead(_8);                 // scope 0 at $DIR/remove_fake_borrows.rs:8:25: 8:26
 -         FakeRead(ForMatchGuard, _4);     // scope 0 at $DIR/remove_fake_borrows.rs:8:20: 8:21
 -         FakeRead(ForMatchGuard, _5);     // scope 0 at $DIR/remove_fake_borrows.rs:8:20: 8:21
 -         FakeRead(ForMatchGuard, _6);     // scope 0 at $DIR/remove_fake_borrows.rs:8:20: 8:21
@@ -73,7 +73,7 @@
       }
   
       bb6: {
-          StorageDead(_8);                 // scope 0 at $DIR/remove_fake_borrows.rs:8:26: 8:27
+          StorageDead(_8);                 // scope 0 at $DIR/remove_fake_borrows.rs:8:25: 8:26
           goto -> bb1;                     // scope 0 at $DIR/remove_fake_borrows.rs:8:20: 8:21
       }
   

--- a/src/test/mir-opt/simplify-arm-identity/32bit/rustc.main.SimplifyArmIdentity.diff
+++ b/src/test/mir-opt/simplify-arm-identity/32bit/rustc.main.SimplifyArmIdentity.diff
@@ -61,7 +61,7 @@
           ((_2 as Foo).0: u8) = move _5;   // scope 3 at $DIR/simplify-arm-identity.rs:20:24: 20:35
           discriminant(_2) = 0;            // scope 3 at $DIR/simplify-arm-identity.rs:20:24: 20:35
           StorageDead(_5);                 // scope 3 at $DIR/simplify-arm-identity.rs:20:34: 20:35
-          StorageDead(_4);                 // scope 1 at $DIR/simplify-arm-identity.rs:20:35: 20:36
+          StorageDead(_4);                 // scope 1 at $DIR/simplify-arm-identity.rs:20:34: 20:35
           goto -> bb4;                     // scope 1 at $DIR/simplify-arm-identity.rs:19:18: 22:6
       }
   

--- a/src/test/mir-opt/simplify-arm-identity/64bit/rustc.main.SimplifyArmIdentity.diff
+++ b/src/test/mir-opt/simplify-arm-identity/64bit/rustc.main.SimplifyArmIdentity.diff
@@ -61,7 +61,7 @@
           ((_2 as Foo).0: u8) = move _5;   // scope 3 at $DIR/simplify-arm-identity.rs:20:24: 20:35
           discriminant(_2) = 0;            // scope 3 at $DIR/simplify-arm-identity.rs:20:24: 20:35
           StorageDead(_5);                 // scope 3 at $DIR/simplify-arm-identity.rs:20:34: 20:35
-          StorageDead(_4);                 // scope 1 at $DIR/simplify-arm-identity.rs:20:35: 20:36
+          StorageDead(_4);                 // scope 1 at $DIR/simplify-arm-identity.rs:20:34: 20:35
           goto -> bb4;                     // scope 1 at $DIR/simplify-arm-identity.rs:19:18: 22:6
       }
   

--- a/src/test/mir-opt/simplify-arm/rustc.id.SimplifyArmIdentity.diff
+++ b/src/test/mir-opt/simplify-arm/rustc.id.SimplifyArmIdentity.diff
@@ -33,7 +33,7 @@
           ((_0 as Some).0: u8) = move _4;  // scope 1 at $DIR/simplify-arm.rs:11:20: 11:27
           discriminant(_0) = 1;            // scope 1 at $DIR/simplify-arm.rs:11:20: 11:27
           StorageDead(_4);                 // scope 1 at $DIR/simplify-arm.rs:11:26: 11:27
-          StorageDead(_3);                 // scope 0 at $DIR/simplify-arm.rs:11:27: 11:28
+          StorageDead(_3);                 // scope 0 at $DIR/simplify-arm.rs:11:26: 11:27
           goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:10:5: 13:6
       }
   

--- a/src/test/mir-opt/simplify-arm/rustc.id.SimplifyBranchSame.diff
+++ b/src/test/mir-opt/simplify-arm/rustc.id.SimplifyBranchSame.diff
@@ -33,7 +33,7 @@
           ((_0 as Some).0: u8) = move _4;  // scope 1 at $DIR/simplify-arm.rs:11:20: 11:27
           discriminant(_0) = 1;            // scope 1 at $DIR/simplify-arm.rs:11:20: 11:27
           StorageDead(_4);                 // scope 1 at $DIR/simplify-arm.rs:11:26: 11:27
-          StorageDead(_3);                 // scope 0 at $DIR/simplify-arm.rs:11:27: 11:28
+          StorageDead(_3);                 // scope 0 at $DIR/simplify-arm.rs:11:26: 11:27
           goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:10:5: 13:6
       }
   

--- a/src/test/mir-opt/simplify-arm/rustc.id_result.SimplifyArmIdentity.diff
+++ b/src/test/mir-opt/simplify-arm/rustc.id_result.SimplifyArmIdentity.diff
@@ -29,7 +29,7 @@
           ((_0 as Err).0: i32) = move _6;  // scope 2 at $DIR/simplify-arm.rs:19:19: 19:25
           discriminant(_0) = 1;            // scope 2 at $DIR/simplify-arm.rs:19:19: 19:25
           StorageDead(_6);                 // scope 2 at $DIR/simplify-arm.rs:19:24: 19:25
-          StorageDead(_5);                 // scope 0 at $DIR/simplify-arm.rs:19:25: 19:26
+          StorageDead(_5);                 // scope 0 at $DIR/simplify-arm.rs:19:24: 19:25
           goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:17:5: 20:6
       }
   
@@ -45,7 +45,7 @@
           ((_0 as Ok).0: u8) = move _4;    // scope 1 at $DIR/simplify-arm.rs:18:18: 18:23
           discriminant(_0) = 0;            // scope 1 at $DIR/simplify-arm.rs:18:18: 18:23
           StorageDead(_4);                 // scope 1 at $DIR/simplify-arm.rs:18:22: 18:23
-          StorageDead(_3);                 // scope 0 at $DIR/simplify-arm.rs:18:23: 18:24
+          StorageDead(_3);                 // scope 0 at $DIR/simplify-arm.rs:18:22: 18:23
           goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:17:5: 20:6
       }
   

--- a/src/test/mir-opt/simplify-arm/rustc.id_result.SimplifyBranchSame.diff
+++ b/src/test/mir-opt/simplify-arm/rustc.id_result.SimplifyBranchSame.diff
@@ -29,7 +29,7 @@
           ((_0 as Err).0: i32) = move _6;  // scope 2 at $DIR/simplify-arm.rs:19:19: 19:25
           discriminant(_0) = 1;            // scope 2 at $DIR/simplify-arm.rs:19:19: 19:25
           StorageDead(_6);                 // scope 2 at $DIR/simplify-arm.rs:19:24: 19:25
-          StorageDead(_5);                 // scope 0 at $DIR/simplify-arm.rs:19:25: 19:26
+          StorageDead(_5);                 // scope 0 at $DIR/simplify-arm.rs:19:24: 19:25
           goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:17:5: 20:6
       }
   
@@ -45,7 +45,7 @@
           ((_0 as Ok).0: u8) = move _4;    // scope 1 at $DIR/simplify-arm.rs:18:18: 18:23
           discriminant(_0) = 0;            // scope 1 at $DIR/simplify-arm.rs:18:18: 18:23
           StorageDead(_4);                 // scope 1 at $DIR/simplify-arm.rs:18:22: 18:23
-          StorageDead(_3);                 // scope 0 at $DIR/simplify-arm.rs:18:23: 18:24
+          StorageDead(_3);                 // scope 0 at $DIR/simplify-arm.rs:18:22: 18:23
           goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:17:5: 20:6
       }
   

--- a/src/test/mir-opt/simplify_try_if_let/rustc.{{impl}}-append.SimplifyArmIdentity.diff
+++ b/src/test/mir-opt/simplify_try_if_let/rustc.{{impl}}-append.SimplifyArmIdentity.diff
@@ -115,7 +115,7 @@
   
       bb8: {
           StorageDead(_5);                 // scope 1 at $DIR/simplify_try_if_let.rs:31:13: 31:14
-          StorageDead(_4);                 // scope 0 at $DIR/simplify_try_if_let.rs:32:9: 32:10
+          StorageDead(_4);                 // scope 0 at $DIR/simplify_try_if_let.rs:31:13: 31:14
           goto -> bb9;                     // scope 0 at $DIR/simplify_try_if_let.rs:21:9: 32:10
       }
   

--- a/src/test/rustdoc-ui/check-attr-test.rs
+++ b/src/test/rustdoc-ui/check-attr-test.rs
@@ -1,6 +1,6 @@
 // compile-flags:--test
 
-#![deny(invalid_codeblock_attribute)]
+#![deny(invalid_codeblock_attributes)]
 
 /// foo
 ///

--- a/src/test/rustdoc-ui/check-attr-test.stderr
+++ b/src/test/rustdoc-ui/check-attr-test.stderr
@@ -11,8 +11,8 @@ error: unknown attribute `compile-fail`. Did you mean `compile_fail`?
 note: the lint level is defined here
  --> $DIR/check-attr-test.rs:3:9
   |
-3 | #![deny(invalid_codeblock_attribute)]
-  |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+3 | #![deny(invalid_codeblock_attributes)]
+  |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   = help: the code block will either not be tested if not marked as a rust one or won't fail if it compiles successfully
 
 error: unknown attribute `compilefail`. Did you mean `compile_fail`?

--- a/src/test/rustdoc-ui/check-attr.rs
+++ b/src/test/rustdoc-ui/check-attr.rs
@@ -1,4 +1,4 @@
-#![deny(invalid_codeblock_attribute)]
+#![deny(invalid_codeblock_attributes)]
 
 /// foo
 //~^ ERROR

--- a/src/test/rustdoc-ui/check-attr.stderr
+++ b/src/test/rustdoc-ui/check-attr.stderr
@@ -13,8 +13,8 @@ LL | | /// ```
 note: the lint level is defined here
   --> $DIR/check-attr.rs:1:9
    |
-LL | #![deny(invalid_codeblock_attribute)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | #![deny(invalid_codeblock_attributes)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: the code block will either not be tested if not marked as a rust one or won't fail if it compiles successfully
 
 error: unknown attribute `compilefail`. Did you mean `compile_fail`?

--- a/src/test/ui/consts/const-eval/ub-enum.rs
+++ b/src/test/ui/consts/const-eval/ub-enum.rs
@@ -88,9 +88,10 @@ const BAD_OPTION_CHAR: Option<(char, char)> = Some(('x', unsafe { mem::transmute
 //~^ ERROR is undefined behavior
 
 // All variants are uninhabited but also have data.
-const BAD_UNINHABITED_WITH_DATA1: Result<(i32, Never), (i32, !)> = unsafe { mem::transmute(1u64) };
+// Use `0` as constant to make behavior endianess-independent.
+const BAD_UNINHABITED_WITH_DATA1: Result<(i32, Never), (i32, !)> = unsafe { mem::transmute(0u64) };
 //~^ ERROR is undefined behavior
-const BAD_UNINHABITED_WITH_DATA2: Result<(i32, !), (i32, Never)> = unsafe { mem::transmute(1u64) };
+const BAD_UNINHABITED_WITH_DATA2: Result<(i32, !), (i32, Never)> = unsafe { mem::transmute(0u64) };
 //~^ ERROR is undefined behavior
 
 fn main() {

--- a/src/test/ui/consts/const-eval/ub-enum.stderr
+++ b/src/test/ui/consts/const-eval/ub-enum.stderr
@@ -87,18 +87,18 @@ LL | const BAD_OPTION_CHAR: Option<(char, char)> = Some(('x', unsafe { mem::tran
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-enum.rs:91:1
+  --> $DIR/ub-enum.rs:92:1
    |
-LL | const BAD_UNINHABITED_WITH_DATA1: Result<(i32, Never), (i32, !)> = unsafe { mem::transmute(1u64) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a value of the never type `!` at .<enum-variant(Err)>.0.1
+LL | const BAD_UNINHABITED_WITH_DATA1: Result<(i32, Never), (i32, !)> = unsafe { mem::transmute(0u64) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a value of uninhabited type Never at .<enum-variant(Ok)>.0.1
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-enum.rs:93:1
+  --> $DIR/ub-enum.rs:94:1
    |
-LL | const BAD_UNINHABITED_WITH_DATA2: Result<(i32, !), (i32, Never)> = unsafe { mem::transmute(1u64) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a value of uninhabited type Never at .<enum-variant(Err)>.0.1
+LL | const BAD_UNINHABITED_WITH_DATA2: Result<(i32, !), (i32, Never)> = unsafe { mem::transmute(0u64) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a value of the never type `!` at .<enum-variant(Ok)>.0.1
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 

--- a/src/test/ui/issues/issue-29540.rs
+++ b/src/test/ui/issues/issue-29540.rs
@@ -283,7 +283,7 @@ pub struct Config {
     pub mds_beacon_interval: String,
     pub mds_beacon_grace: String,
     pub mds_enforce_unique_name: String,
-    pub mds_blacklist_interval: String,
+    pub mds_interval: String,
     pub mds_session_timeout: String,
     pub mds_freeze_tree_timeout: String,
     pub mds_session_autoclose: String,

--- a/src/test/ui/issues/issue-74082.rs
+++ b/src/test/ui/issues/issue-74082.rs
@@ -1,0 +1,9 @@
+#![allow(dead_code)]
+
+#[repr(i128)] //~ ERROR: attribute should be applied to enum
+struct Foo;
+
+#[repr(u128)] //~ ERROR: attribute should be applied to enum
+struct Bar;
+
+fn main() {}

--- a/src/test/ui/issues/issue-74082.stderr
+++ b/src/test/ui/issues/issue-74082.stderr
@@ -1,0 +1,19 @@
+error[E0517]: attribute should be applied to enum
+  --> $DIR/issue-74082.rs:3:8
+   |
+LL | #[repr(i128)]
+   |        ^^^^
+LL | struct Foo;
+   | ----------- not an enum
+
+error[E0517]: attribute should be applied to enum
+  --> $DIR/issue-74082.rs:6:8
+   |
+LL | #[repr(u128)]
+   |        ^^^^
+LL | struct Bar;
+   | ----------- not an enum
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0517`.

--- a/src/test/ui/match/issue-74050-end-span.rs
+++ b/src/test/ui/match/issue-74050-end-span.rs
@@ -1,0 +1,13 @@
+fn main() {
+    let mut args = std::env::args_os();
+    let _arg = match args.next() {
+        Some(arg) => {
+            match arg.to_str() {
+                //~^ ERROR `arg` does not live long enough
+                Some(s) => s,
+                None => return,
+            }
+        }
+        None => return,
+    };
+}

--- a/src/test/ui/match/issue-74050-end-span.stderr
+++ b/src/test/ui/match/issue-74050-end-span.stderr
@@ -1,0 +1,15 @@
+error[E0597]: `arg` does not live long enough
+  --> $DIR/issue-74050-end-span.rs:5:19
+   |
+LL |     let _arg = match args.next() {
+   |         ---- borrow later stored here
+LL |         Some(arg) => {
+LL |             match arg.to_str() {
+   |                   ^^^ borrowed value does not live long enough
+...
+LL |         }
+   |         - `arg` dropped here while still borrowed
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0597`.

--- a/src/tools/compiletest/src/main.rs
+++ b/src/tools/compiletest/src/main.rs
@@ -401,7 +401,7 @@ fn configure_lldb(config: &Config) -> Option<Config> {
     }
 
     if let Some(lldb_version) = config.lldb_version.as_ref() {
-        if is_blacklisted_lldb_version(&lldb_version) {
+        if lldb_version == "350" {
             println!(
                 "WARNING: The used version of LLDB ({}) has a \
                  known issue that breaks debuginfo tests. See \
@@ -978,8 +978,4 @@ fn extract_lldb_version(full_version_line: Option<String>) -> (Option<String>, b
         }
     }
     (None, false)
-}
-
-fn is_blacklisted_lldb_version(version: &str) -> bool {
-    version == "350"
 }


### PR DESCRIPTION
Successful merges:

 - #73989 (adjust ub-enum test to be endianess-independent)
 - #74105 (Suppress debuginfo on naked function arguments)
 - #74109 (Only allow `repr(i128/u128)` on enum)
 - #74116 (Fix cross compilation of LLVM to aarch64 Windows targets)
 - #74125 (Correctly mark the ending span of a match arm)
 - #74131 (rustdoc: Rename invalid_codeblock_attribute lint to be plural)
 - #74135 (Update books)
 - #74136 (Fix broken link in rustdocdoc)
 - #74142 (Liballoc use vec instead of vector)
 - #74143 (Try remove unneeded ToString import in liballoc slice)
 - #74145 (Update rust-installer to latest version)
 - #74150 (Avoid "blacklist")
 - #74153 (Fix x.py test for librustc crates.)

Failed merges:


r? @ghost