### PR TITLE
Fix  disabled dockerfiles

### DIFF
--- a/src/ci/docker/host-x86_64/disabled/riscv64gc-linux/Dockerfile
+++ b/src/ci/docker/host-x86_64/disabled/riscv64gc-linux/Dockerfile
@@ -40,9 +40,9 @@ RUN curl https://cdn.kernel.org/pub/linux/kernel/v5.x/linux-5.6.16.tar.xz | tar 
     cp linux.config linux-5.6.16/.config && \
     cd /build/linux-5.6.16 && \
     make olddefconfig && \
-    make -j$(nproc) vmlinux
-RUN cp linux-5.6.16/vmlinux /tmp
-RUN rm -rf linux-5.6.16
+    make -j$(nproc) vmlinux && \
+    cp vmlinux /tmp && \
+    rm -rf linux-5.6.16
 
 # Compile an instance of busybox as this provides a lightweight system and init
 # binary which we will boot into. Only trick here is configuring busybox to

--- a/src/ci/docker/run.sh
+++ b/src/ci/docker/run.sh
@@ -119,11 +119,11 @@ elif [ -f "$docker_dir/disabled/$image/Dockerfile" ]; then
         exit 1
     fi
     # Transform changes the context of disabled Dockerfiles to match the enabled ones
-    tar --transform 's#^./disabled/#./#' -C $docker_dir -c . | docker \
+    tar --transform 's#disabled/#./#' -C $script_dir -c . | docker \
       build \
       --rm \
       -t rust-ci \
-      -f "$image/Dockerfile" \
+      -f "host-$(uname -m)/$image/Dockerfile" \
       -
 else
     echo Invalid image: $image


### PR DESCRIPTION
When the dockerfiles were moved into the host-x86_64 directory, paths
for COPY commands were updated with the new host-x86_64/ prefix. This
suggested that the intended context was src/ci/docker. However, the context
for disabled docker images was src/ci/docker/host-x86_64. This broke the new
paths and prevented src/ci/docker/scripts from being included in the
context at all.

This commit corrects this context allowing docker to find the files it
needs for COPY commands.

Also includes a quick fix to riscv recommended by @bjorn3 