### PR TITLE
linker: illumos ld does not support --eh-frame-hdr

### DIFF
--- a/src/librustc_codegen_ssa/back/linker.rs
+++ b/src/librustc_codegen_ssa/back/linker.rs
@@ -621,9 +621,9 @@ impl<'a> Linker for GccLinker<'a> {
     // Some versions of `gcc` add it implicitly, some (e.g. `musl-gcc`) don't,
     // so we just always add it.
     fn add_eh_frame_header(&mut self) {
-        // The condition here is "uses ELF" basically.
         if !self.sess.target.target.options.is_like_osx
             && !self.sess.target.target.options.is_like_windows
+            && !self.sess.target.target.options.is_like_solaris
             && self.sess.target.target.target_os != "uefi"
         {
             self.linker_arg("--eh-frame-hdr");


### PR DESCRIPTION
As of rust-lang/rust#73564, the --eh-frame-hdr flag is unconditionally
passed to linkers on many platforms.  The illumos link editor does not
currently support this flag.

The linker machinery in the Rust toolchain currently seems to use the
(potentially cross-compiled) target to choose linker flags, rather than
looking at what might be running on the build system.  Disabling the
flag for all illumos/Solaris targets seems like the best we can do for
now without more serious surgery.