### PR TITLE
Add `std::io::input()`, simple input function.

### DIFF
--- a/src/libstd/io/stdio.rs
+++ b/src/libstd/io/stdio.rs
@@ -872,6 +872,44 @@ impl fmt::Debug for StderrLock<'_> {
     }
 }
 
+/// Locks the current handle and reads a line of input, returning a `String` containing
+/// the input.
+/// 
+/// If you need more explicit control over
+/// locking, see the [`Stdin::lock`] and [`Stdout::lock`] methods.
+///
+/// [`Stdin::lock`]: struct.Stdin.html#method.lock
+/// [`Stdout::lock`]: struct.Stdout.html#method.lock
+/// 
+/// ### Note: Windows Portability Consideration
+/// When operating in a console, the Windows implementation of this stream does not support
+/// non-UTF-8 byte sequences. Attempting to read and write bytes that are not valid UTF-8 will 
+/// return an error.
+///
+/// # Examples
+///
+/// ```no_run
+/// use std::io::input;
+///
+/// fn main() {
+///     let user_input = input("Please enter some text: ");
+///         
+///     println!("You typed: {}", get);
+///         
+/// }
+/// ```
+pub fn input(message:&str) -> String {
+	use std::io::Write;
+	print!("{}", message);
+	let mut input = String::new();
+	let _ = std::io::stdout().flush();
+	std::io::stdin().read_line(&mut input).expect("RUST ERROR HELP");
+	if ['\n','\r'].contains(&input.chars().next_back().unwrap()) {
+		input.pop();
+	}
+	return input;
+}
+
 /// Resets the thread-local stderr handle to the specified writer
 ///
 /// This will replace the current thread's stderr handle, returning the old


### PR DESCRIPTION
Condenses the normal input process into one function. This is good for new rust users who don't understand the normal process and for users who don't require special functionality.

Especially with new rust users looking to make small programs, input can be a tricky thing for them to grasp, especially when other languages do this much simpler.

EX:
Python : ```user_input = input("Enter: ")```
Ruby: ```user_input = gets```
C#: ```user_input = Console.ReadLine();```

So this...

```
use std::io::{stdin,stdout,Write};
let mut s=String::new();
print!("Please enter some text: ");
let _=stdout().flush();
stdin().read_line(&mut s).expect("Did not enter a correct string");
if let Some('\n')=s.chars().next_back() {
    s.pop();
}
if let Some('\r')=s.chars().next_back() {
    s.pop();
}
println!("You typed: {}",s);
```

Would turn into this...

```
use std::io::input;
let user_input = input("Please enter some text: ");
println!("You typed: {}", user_input);
```