### PR TITLE
Minor refactor for rustc_resolve diagnostics match

### DIFF
--- a/src/librustc_resolve/late/diagnostics.rs
+++ b/src/librustc_resolve/late/diagnostics.rs
@@ -100,9 +100,7 @@ impl<'a> LateResolutionVisitor<'a, '_, '_> {
         let ident_span = path.last().map_or(span, |ident| ident.ident.span);
         let ns = source.namespace();
         let is_expected = &|res| source.is_expected(res);
-        let is_enum_variant = &|res| {
-            if let Res::Def(DefKind::Variant, _) = res { true } else { false }
-        };
+        let is_enum_variant = &|res| matches!(res, Res::Def(DefKind::Variant, _));
 
         // Make the base error.
         let expected = source.descr_expected();


### PR DESCRIPTION
Use `matches!` instead of old `if let`