### PR TITLE
Add margin after doc search results

### DIFF
--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -361,6 +361,7 @@ nav.sub {
 #results > table {
 	width: 100%;
 	table-layout: fixed;
+	margin-bottom: 40px;
 }
 
 .content pre.line-numbers {


### PR DESCRIPTION
I found it not really on computer that the last result is right at the bottom of the page. I find it better with margin below (especially when you hover the last element!). A screenshot to show the result:

![Screenshot from 2020-07-10 16-32-23](https://user-images.githubusercontent.com/3050060/87166097-6103a580-c2cb-11ea-81a8-12772cf20f64.png)

r? @kinnison 
cc @rust-lang/rustdoc @Manishearth @jyn514 