### PR TITLE
Allow sidebar links to be specified for Rustdoc

### DIFF
--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -157,6 +157,8 @@ crate struct SharedContext {
     pub edition: Edition,
     pub codes: ErrorCodes,
     playground: Option<markdown::Playground>,
+    /// Links displayed on the crate root page.
+    pub crate_root_links: BTreeMap<String, String>,
 }
 
 impl Context {
@@ -396,6 +398,7 @@ impl FormatRenderer for Context {
             resource_suffix,
             static_root_path,
             generate_search_filter,
+            crate_root_links,
             ..
         } = options;
 
@@ -466,6 +469,7 @@ impl FormatRenderer for Context {
             edition,
             codes: ErrorCodes::from(UnstableFeatures::from_environment().is_nightly_build()),
             playground,
+            crate_root_links,
         };
 
         // Add the default themes to the `Vec` of stylepaths
@@ -3893,6 +3897,26 @@ fn print_sidebar(cx: &Context, it: &clean::Item, buffer: &mut Buffer, cache: &Ca
             );
         }
     }
+
+    if it.is_crate() && !cx.shared.crate_root_links.is_empty() {
+        let mut links_html = String::new();
+        for (name, url) in &cx.shared.crate_root_links {
+            links_html.push_str(&format!(
+                "<li><a href='{}'>{}</a></li>",
+                Escape(url),
+                Escape(name),
+            ));
+        }
+        write!(
+            buffer,
+            "<div class='block items'>\
+            <ul>\
+            {}\
+            </ul>\
+            </div>",
+            links_html
+        );
+    };
 
     write!(buffer, "<div class=\"sidebar-elems\">");
     if it.is_crate() {

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -3898,6 +3898,8 @@ fn print_sidebar(cx: &Context, it: &clean::Item, buffer: &mut Buffer, cache: &Ca
         }
     }
 
+    write!(buffer, "<div class=\"sidebar-elems\">");
+
     if it.is_crate() && !cx.shared.crate_root_links.is_empty() {
         let mut links_html = String::new();
         for (name, url) in &cx.shared.crate_root_links {
@@ -3918,7 +3920,6 @@ fn print_sidebar(cx: &Context, it: &clean::Item, buffer: &mut Buffer, cache: &Ca
         );
     };
 
-    write!(buffer, "<div class=\"sidebar-elems\">");
     if it.is_crate() {
         write!(
             buffer,

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -406,6 +406,9 @@ fn opts() -> Vec<RustcOptGroup> {
                 "specified the rustc-like binary to use as the test builder",
             )
         }),
+        unstable("crate-root-link", |o| {
+            o.optmulti("", "crate-root-link", "", "Specifies links to display on the crate root")
+        }),
     ]
 }
 

--- a/x.py
+++ b/x.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # This file is only a "symlink" to bootstrap.py, all logic should go there.
 


### PR DESCRIPTION
This should implement everything needed in `rustc` to implement #72475 (although automatically adding links based on `Cargo.toml` would have to be implemented in `cargo-doc`). It allows an arbitrary links to be added to be added to the left sidebar. These are only displayed on the crate root.

Sidebar links can be specified in two ways:
- On the commandline, like `rustdoc src/lib.rs --sidebar-url Homepage=http://rust-lang.org --sidebar-url "Repository URL"="https://example.com/ a"`
- As a `#[doc]` attribute:
```rust
#![doc(
    sidebar_url(
        name = "Repository",
        url = "https://github.com/rust-lang/rust",
    )
)]
```

## Screenshot
![Cropped creenshot of a list of links. Three external links are visible on the left sidebar, directly underneath a header that says "Crate lib": "Homepage", "Refdspo", and "Repository".](https://user-images.githubusercontent.com/10530973/87206321-77176300-c2d7-11ea-91a9-5552a19746b1.png)


## Notes
- [Invalid `#[doc]` attributes are, and always have been silently ignored.](https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=0b8a3f5d579e9ff1f25899caccd59367)
- Links are sorted Unicode order.
- Later command-line flags override earlier command-line flags.
- `#[doc]` attributes override commnad-line flags in the case of a disagreement.
- Later `#[doc]` attributes override earlier `#[doc]` attributes.
- Currently it is stable. It could be added as unstable, but since it uses both the `#[doc]` attribute and command line config, it's unclear if it should be enabled by a seperate `rustdoc` flag, or by a rust `feature` (I can't find any info on this).

