### PR TITLE
Don't allow `DESTDIR` to influence LLVM builds

### DIFF
--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -347,6 +347,11 @@ fn configure_cmake(
     // LLVM and LLD builds can produce a lot of those and hit CI limits on log size.
     cfg.define("CMAKE_INSTALL_MESSAGE", "LAZY");
 
+    // Do not allow the user's value of DESTDIR to influence where
+    // LLVM will install itself. LLVM must always be installed in our
+    // own build directories.
+    cfg.env("DESTDIR", "");
+
     if builder.config.ninja {
         cfg.generator("Ninja");
     }


### PR DESCRIPTION
When running a command like `DESTDIR=foo x.py install` in a completely
clean build directory, this will cause LLVM to be installed into
`DESTDIR`, which then causes the build to fail later when it attempts
to *use* those LLVM files.