### PR TITLE
don't mark linux kernel module targets as a unix environment

### DIFF
--- a/src/librustc_target/spec/linux_kernel_base.rs
+++ b/src/librustc_target/spec/linux_kernel_base.rs
@@ -17,7 +17,6 @@ pub fn opts() -> TargetOptions {
         needs_plt: true,
         relro_level: RelroLevel::Full,
         relocation_model: RelocModel::Static,
-        target_family: Some("unix".to_string()),
         pre_link_args,
 
         ..Default::default()


### PR DESCRIPTION
refs #74247 

r?@joshtriplett

cc: @ehuss 