### PR TITLE
pprust: support multiline comments within lines

### DIFF
--- a/src/librustc_ast_pretty/pprust.rs
+++ b/src/librustc_ast_pretty/pprust.rs
@@ -450,9 +450,20 @@ pub trait PrintState<'a>: std::ops::Deref<Target = pp::Printer> + std::ops::Dere
     fn print_comment(&mut self, cmnt: &comments::Comment) {
         match cmnt.style {
             comments::Mixed => {
-                assert_eq!(cmnt.lines.len(), 1);
                 self.zerobreak();
-                self.word(cmnt.lines[0].clone());
+                if let Some((last, lines)) = cmnt.lines.split_last() {
+                    self.ibox(0);
+
+                    for line in lines {
+                        self.word(line.clone());
+                        self.hardbreak()
+                    }
+
+                    self.word(last.clone());
+                    self.space();
+
+                    self.end();
+                }
                 self.zerobreak()
             }
             comments::Isolated => {

--- a/src/test/pretty/issue-73626.rs
+++ b/src/test/pretty/issue-73626.rs
@@ -1,0 +1,34 @@
+fn main(/*
+    ---
+*/) {
+    let x /* this is one line */ = 3;
+
+    let x /*
+           * this
+           * is
+           * multiple
+           * lines
+           */ = 3;
+
+    let x = /*
+           * this
+           * is
+           * multiple
+           * lines
+           * after
+           * the
+           * =
+           */ 3;
+
+    let x /*
+           * this
+           * is
+           * multiple
+           * lines
+           * including
+           * a
+
+           * blank
+           * line
+           */ = 3;
+}


### PR DESCRIPTION
Fixes #73626.

This PR adds support to `rustc_ast_pretty` for multiline comments that start and end within a line of source code.


Fun fact: [the commit which added this assert](https://github.com/rust-lang/rust/commit/d12ea3989649616437a7c1434f5c5a6438235eb7) was from 2011! 
https://github.com/rust-lang/rust/blob/d12ea3989649616437a7c1434f5c5a6438235eb7/src/comp/pretty/pprust.rs#L1146-L1150