### PR TITLE
improve DiscriminantKind handling

### DIFF
--- a/src/libcore/marker.rs
+++ b/src/libcore/marker.rs
@@ -693,6 +693,7 @@ mod impls {
 pub trait DiscriminantKind {
     /// The type of the discriminant, which must satisfy the trait
     /// bounds required by `mem::Discriminant`.
+    #[cfg_attr(not(bootstrap), lang = "discriminant_type")]
     type Discriminant: Clone + Copy + Debug + Eq + PartialEq + Hash + Send + Sync + Unpin;
 }
 

--- a/src/librustc_hir/lang_items.rs
+++ b/src/librustc_hir/lang_items.rs
@@ -193,6 +193,9 @@ language_item_table! {
     CloneTraitLangItem,            sym::clone,              clone_trait,             Target::Trait;
     SyncTraitLangItem,             sym::sync,               sync_trait,              Target::Trait;
     DiscriminantKindTraitLangItem, sym::discriminant_kind,  discriminant_kind_trait, Target::Trait;
+    // The associated item of `trait DiscriminantKind`.
+    DiscriminantTypeLangItem,      sym::discriminant_type,  discriminant_type,       Target::AssocTy;
+
     FreezeTraitLangItem,           sym::freeze,             freeze_trait,            Target::Trait;
 
     DropTraitLangItem,             sym::drop,               drop_trait,              Target::Trait;

--- a/src/librustc_span/symbol.rs
+++ b/src/librustc_span/symbol.rs
@@ -327,6 +327,7 @@ symbols! {
         diagnostic,
         direct,
         discriminant_kind,
+        discriminant_type,
         discriminant_value,
         dispatch_from_dyn,
         div,

--- a/src/test/ui/generator/discriminant.rs
+++ b/src/test/ui/generator/discriminant.rs
@@ -66,8 +66,8 @@ macro_rules! yield250 {
 }
 
 fn cycle(
-    gen: impl Generator<()> + Unpin + DiscriminantKind<Discriminant = i32>,
-    expected_max_discr: i32
+    gen: impl Generator<()> + Unpin + DiscriminantKind<Discriminant = u32>,
+    expected_max_discr: u32
 ) {
     let mut gen = Box::pin(gen);
     let mut max_discr = 0;


### PR DESCRIPTION
Adds a lang item `discriminant_type` for the associated type `DiscriminantKind::Discriminant`.

Changes the discriminant of generators from `i32` to `u32`, which should not be observable to fix an
oversight where MIR was using `u32` and codegen and typeck used `i32`.
