### PR TITLE
Deny unsafe operations in unsafe fns in libstd/sync/

### DIFF
--- a/src/libstd/sync/mod.rs
+++ b/src/libstd/sync/mod.rs
@@ -149,6 +149,7 @@
 //! [`Once`]: crate::sync::Once
 //! [`RwLock`]: crate::sync::RwLock
 
+#![deny(unsafe_op_in_unsafe_fn)]
 #![stable(feature = "rust1", since = "1.0.0")]
 
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/libstd/sync/mpsc/blocking.rs
+++ b/src/libstd/sync/mpsc/blocking.rs
@@ -47,14 +47,18 @@ impl SignalToken {
     /// flag.
     #[inline]
     pub unsafe fn cast_to_usize(self) -> usize {
-        mem::transmute(self.inner)
+        // SAFETY: this ok because of the internal represention of Arc, which
+        // is a pointer and phantom data (so the size of a pointer -> a usize).
+        unsafe { mem::transmute(self.inner) }
     }
 
     /// Converts from an unsafe usize value. Useful for retrieving a pipe's state
     /// flag.
     #[inline]
     pub unsafe fn cast_from_usize(signal_ptr: usize) -> SignalToken {
-        SignalToken { inner: mem::transmute(signal_ptr) }
+        // SAFETY: this ok because of the internal represention of Arc, which
+        // is a pointer and phantom data (so the size of a pointer -> a usize).
+        SignalToken { inner: unsafe { mem::transmute(signal_ptr) } }
     }
 }
 

--- a/src/libstd/sync/mpsc/mod.rs
+++ b/src/libstd/sync/mpsc/mod.rs
@@ -651,7 +651,7 @@ trait UnsafeFlavor<T> {
         // SAFETY: We are sure the inner value will never be NUL when this is
         // called, the invariants of the module make it so.
         //
-        // It is also ensured that no other (mutable) reference will be handed
+        // The caller ensures that no other (mutable) reference will be handed
         // out while the one returned here is in action.
         unsafe { &mut *self.inner_unsafe().get() }
     }

--- a/src/libstd/sync/mpsc/mod.rs
+++ b/src/libstd/sync/mpsc/mod.rs
@@ -648,10 +648,18 @@ enum Flavor<T> {
 trait UnsafeFlavor<T> {
     fn inner_unsafe(&self) -> &UnsafeCell<Flavor<T>>;
     unsafe fn inner_mut(&self) -> &mut Flavor<T> {
-        &mut *self.inner_unsafe().get()
+        // SAFETY: We are sure the inner value will never be NUL when this is
+        // called, the invariants of the module make it so.
+        //
+        // It is also ensured that no other (mutable) reference will be handed
+        // out while the one returned here is in action.
+        unsafe { &mut *self.inner_unsafe().get() }
     }
     unsafe fn inner(&self) -> &Flavor<T> {
-        &*self.inner_unsafe().get()
+        // SAFETY: We are sure the inner value will never be NUL when this is
+        // called, the invariants of the module make it so nor will any mutable
+        // reference be active while this one is.
+        unsafe { &*self.inner_unsafe().get() }
     }
 }
 impl<T> UnsafeFlavor<T> for Sender<T> {


### PR DESCRIPTION
Partial fix of #73904.

This encloses `unsafe` operations in `unsafe fn` in `libstd/sync/`.

@rustbot modify labels: F-unsafe-block-in-unsafe-fn