### PR TITLE
Add ability for use push str with any type wich impl AsRef<str>.

### DIFF
--- a/src/liballoc/string.rs
+++ b/src/liballoc/string.rs
@@ -833,8 +833,10 @@ impl String {
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn push_str(&mut self, string: &str) {
-        self.vec.extend_from_slice(string.as_bytes())
+    pub fn push_str<T>(&mut self, string: T) 
+        where T: AsRef<str>
+    {
+        self.vec.extend_from_slice(string.as_ref().as_bytes())
     }
 
     /// Returns this `String`'s capacity, in bytes.


### PR DESCRIPTION
Example
```
let s = String::new()

s.push_str(format("{}", 1);
```