### PR TITLE
Fix #73948

### DIFF
--- a/src/librustc_metadata/locator.rs
+++ b/src/librustc_metadata/locator.rs
@@ -219,7 +219,7 @@ use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_data_structures::owning_ref::OwningRef;
 use rustc_data_structures::svh::Svh;
 use rustc_data_structures::sync::MetadataRef;
-use rustc_errors::struct_span_err;
+use rustc_errors::{struct_span_err, Applicability};
 use rustc_middle::middle::cstore::{CrateSource, MetadataLoader};
 use rustc_session::config::{self, CrateType};
 use rustc_session::filesearch::{FileDoesntMatch, FileMatches, FileSearch};
@@ -1068,6 +1068,14 @@ impl CrateError {
                         err.note(&format!("the `{}` target may not be installed", locator.triple));
                     } else if crate_name == sym::profiler_builtins {
                         err.note(&"the compiler may have been built without the profiler runtime");
+                    } else if crate_name == sym::meta {
+                        err.note(&"meta is a reserved crate name");
+                        err.span_suggestion(
+                                span,
+                                "you can use `crate::` or `self::` if you intended to refer to a local module and not a crate",
+                                "crate::meta".to_string(),
+                                Applicability::MaybeIncorrect,
+                            );
                     }
                     err.span_label(span, "can't find crate");
                     err

--- a/src/test/ui/suggestions/issue-73948-meta-as-module-name.fixed
+++ b/src/test/ui/suggestions/issue-73948-meta-as-module-name.fixed
@@ -1,0 +1,17 @@
+// check-only
+// run-rustfix
+// edition:2018
+
+// https://github.com/rust-lang/rust/issues/73948
+// Tests that when `meta` is used as a module name and imported uniformly a
+// suggestion is made to make the import unambiguous with `crate::meta`
+
+mod meta {
+    pub const FOO: bool = true;
+}
+
+use crate::meta::FOO; //~ ERROR can't find crate for `meta`
+
+fn main() {
+    assert!(FOO);
+}

--- a/src/test/ui/suggestions/issue-73948-meta-as-module-name.rs
+++ b/src/test/ui/suggestions/issue-73948-meta-as-module-name.rs
@@ -1,0 +1,17 @@
+// check-only
+// run-rustfix
+// edition:2018
+
+// https://github.com/rust-lang/rust/issues/73948
+// Tests that when `meta` is used as a module name and imported uniformly a
+// suggestion is made to make the import unambiguous with `crate::meta`
+
+mod meta {
+    pub const FOO: bool = true;
+}
+
+use meta::FOO; //~ ERROR can't find crate for `meta`
+
+fn main() {
+    assert!(FOO);
+}

--- a/src/test/ui/suggestions/issue-73948-meta-as-module-name.stderr
+++ b/src/test/ui/suggestions/issue-73948-meta-as-module-name.stderr
@@ -1,13 +1,13 @@
 error[E0463]: can't find crate for `meta`
-  --> $DIR/meta.rs:5:5
+  --> $DIR/issue-73948-meta-as-module-name.rs:13:5
    |
-LL | use meta;
+LL | use meta::FOO;
    |     ^^^^ can't find crate
    |
    = note: meta is a reserved crate name
 help: you can use `crate::` or `self::` if you intended to refer to a local module and not a crate
    |
-LL | use crate::meta;
+LL | use crate::meta::FOO;
    |     ^^^^^^^^^^^
 
 error: aborting due to previous error


### PR DESCRIPTION
Closes #73948 by adding a note that `meta` is a reserved name and suggesting the use of the `crate::` prefix to reduce ambiguity.