### PR TITLE
[WIP; Crater] Use `parse_cond_expr` instead `parse_expr` in `if` guards

### DIFF
--- a/src/librustc_parse/parser/expr.rs
+++ b/src/librustc_parse/parser/expr.rs
@@ -1820,7 +1820,7 @@ impl<'a> Parser<'a> {
         let attrs = self.parse_outer_attributes()?;
         let lo = self.token.span;
         let pat = self.parse_top_pat(GateOr::No)?;
-        let guard = if self.eat_keyword(kw::If) { Some(self.parse_expr()?) } else { None };
+        let guard = if self.eat_keyword(kw::If) { Some(self.parse_cond_expr()?) } else { None };
         let arrow_span = self.token.span;
         self.expect(&token::FatArrow)?;
         let arm_start_span = self.token.span;

--- a/src/test/ui/parser/issue-15980.rs
+++ b/src/test/ui/parser/issue-15980.rs
@@ -4,14 +4,9 @@ fn main(){
     let x: io::Result<()> = Ok(());
     match x {
         Err(ref e) if e.kind == io::EndOfFile {
-            //~^ NOTE while parsing this struct
+        //~^ ERROR expected one of `!`, `.`, `::`, `=>`, `?`, or an operator, found `{`
             return
-            //~^ ERROR expected identifier, found keyword `return`
-            //~| NOTE expected identifier, found keyword
         }
-        //~^ NOTE expected one of `.`, `=>`, `?`, or an operator
         _ => {}
-        //~^ ERROR expected one of `.`, `=>`, `?`, or an operator, found reserved identifier `_`
-        //~| NOTE unexpected token
     }
 }

--- a/src/test/ui/parser/issue-15980.stderr
+++ b/src/test/ui/parser/issue-15980.stderr
@@ -1,25 +1,8 @@
-error: expected identifier, found keyword `return`
-  --> $DIR/issue-15980.rs:8:13
+error: expected one of `!`, `.`, `::`, `=>`, `?`, or an operator, found `{`
+  --> $DIR/issue-15980.rs:6:47
    |
 LL |         Err(ref e) if e.kind == io::EndOfFile {
-   |                                 ------------- while parsing this struct
-LL |
-LL |             return
-   |             ^^^^^^ expected identifier, found keyword
-   |
-help: you can escape reserved keywords to use them as identifiers
-   |
-LL |             r#return
-   |
+   |                                               ^ expected one of `!`, `.`, `::`, `=>`, `?`, or an operator
 
-error: expected one of `.`, `=>`, `?`, or an operator, found reserved identifier `_`
-  --> $DIR/issue-15980.rs:13:9
-   |
-LL |         }
-   |          - expected one of `.`, `=>`, `?`, or an operator
-LL |
-LL |         _ => {}
-   |         ^ unexpected token
-
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 

--- a/src/test/ui/rfc-2294-if-let-guard/non-implemented.rs
+++ b/src/test/ui/rfc-2294-if-let-guard/non-implemented.rs
@@ -1,0 +1,13 @@
+// This function is to check whether `if-let` guard error points to
+// `let_chains` feature gate, which is wrong and confuse people.
+pub fn foo(a: &[u8], b: bool) -> bool {
+    match b {
+        true if let [1, 2, 3, ..] = a => true,
+        //~^    ERROR `let` expressions are not supported here
+        //~^^   NOTE only supported directly in conditions of `if`- and `while`-expressions
+        //~^^^  NOTE as well as when nested within `&&` and parenthesis in those conditions
+        _ => false,
+    }
+}
+
+fn main() {}

--- a/src/test/ui/rfc-2294-if-let-guard/non-implemented.stderr
+++ b/src/test/ui/rfc-2294-if-let-guard/non-implemented.stderr
@@ -1,0 +1,11 @@
+error: `let` expressions are not supported here
+  --> $DIR/non-implemented.rs:5:17
+   |
+LL |         true if let [1, 2, 3, ..] = a => true,
+   |                 ^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: only supported directly in conditions of `if`- and `while`-expressions
+   = note: as well as when nested within `&&` and parenthesis in those conditions
+
+error: aborting due to previous error
+


### PR DESCRIPTION
This PR improves diagnostic a bit for #15980.