### PR TITLE
Remove unnecessary type hints from Wake internals

### DIFF
--- a/src/liballoc/task.rs
+++ b/src/liballoc/task.rs
@@ -69,14 +69,13 @@ fn raw_waker<W: Wake + Send + Sync + 'static>(waker: Arc<W>) -> RawWaker {
 
     // Wake by value, moving the Arc into the Wake::wake function
     unsafe fn wake<W: Wake + Send + Sync + 'static>(waker: *const ()) {
-        let waker: Arc<W> = unsafe { Arc::from_raw(waker as *const W) };
+        let waker = unsafe { Arc::from_raw(waker as *const W) };
         <W as Wake>::wake(waker);
     }
 
     // Wake by reference, wrap the waker in ManuallyDrop to avoid dropping it
     unsafe fn wake_by_ref<W: Wake + Send + Sync + 'static>(waker: *const ()) {
-        let waker: ManuallyDrop<Arc<W>> =
-            unsafe { ManuallyDrop::new(Arc::from_raw(waker as *const W)) };
+        let waker = unsafe { ManuallyDrop::new(Arc::from_raw(waker as *const W)) };
         <W as Wake>::wake_by_ref(&waker);
     }
 


### PR DESCRIPTION
While working on https://github.com/rust-lang/rust/pull/74304 I noticed we were writing out the type signature twice in some internal `Wake` impl methods; this streamlines that. Thanks!