### PR TITLE
Stabilize core::future::{pending,ready}

### DIFF
--- a/library/core/src/future/mod.rs
+++ b/library/core/src/future/mod.rs
@@ -21,9 +21,9 @@ pub use self::future::Future;
 #[unstable(feature = "into_future", issue = "67644")]
 pub use into_future::IntoFuture;
 
-#[unstable(feature = "future_readiness_fns", issue = "70921")]
+#[stable(feature = "future_readiness_fns", since = "1.47.0")]
 pub use pending::{pending, Pending};
-#[unstable(feature = "future_readiness_fns", issue = "70921")]
+#[stable(feature = "future_readiness_fns", since = "1.47.0")]
 pub use ready::{ready, Ready};
 
 #[unstable(feature = "future_poll_fn", issue = "72302")]

--- a/library/core/src/future/pending.rs
+++ b/library/core/src/future/pending.rs
@@ -1,3 +1,4 @@
+use crate::fmt::{self, Debug};
 use crate::future::Future;
 use crate::marker;
 use crate::pin::Pin;
@@ -10,8 +11,7 @@ use crate::task::{Context, Poll};
 /// documentation for more.
 ///
 /// [`pending`]: fn.pending.html
-#[unstable(feature = "future_readiness_fns", issue = "70921")]
-#[derive(Debug)]
+#[stable(feature = "future_readiness_fns", since = "1.47.0")]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Pending<T> {
     _data: marker::PhantomData<T>,
@@ -23,7 +23,6 @@ pub struct Pending<T> {
 /// # Examples
 ///
 /// ```no_run
-/// #![feature(future_readiness_fns)]
 /// use core::future;
 ///
 /// # async fn run() {
@@ -32,12 +31,12 @@ pub struct Pending<T> {
 /// unreachable!();
 /// # }
 /// ```
-#[unstable(feature = "future_readiness_fns", issue = "70921")]
+#[stable(feature = "future_readiness_fns", since = "1.47.0")]
 pub fn pending<T>() -> Pending<T> {
     Pending { _data: marker::PhantomData }
 }
 
-#[unstable(feature = "future_readiness_fns", issue = "70921")]
+#[stable(feature = "future_readiness_fns", since = "1.47.0")]
 impl<T> Future for Pending<T> {
     type Output = T;
 
@@ -46,10 +45,17 @@ impl<T> Future for Pending<T> {
     }
 }
 
-#[unstable(feature = "future_readiness_fns", issue = "70921")]
+#[stable(feature = "future_readiness_fns", since = "1.47.0")]
 impl<T> Unpin for Pending<T> {}
 
-#[unstable(feature = "future_readiness_fns", issue = "70921")]
+#[stable(feature = "future_readiness_fns", since = "1.47.0")]
+impl<T> Debug for Pending<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Pending").finish()
+    }
+}
+
+#[stable(feature = "future_readiness_fns", since = "1.47.0")]
 impl<T> Clone for Pending<T> {
     fn clone(&self) -> Self {
         pending()

--- a/library/core/src/future/ready.rs
+++ b/library/core/src/future/ready.rs
@@ -8,15 +8,15 @@ use crate::task::{Context, Poll};
 /// documentation for more.
 ///
 /// [`ready`]: fn.ready.html
-#[unstable(feature = "future_readiness_fns", issue = "70921")]
+#[stable(feature = "future_readiness_fns", since = "1.47.0")]
 #[derive(Debug, Clone)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Ready<T>(Option<T>);
 
-#[unstable(feature = "future_readiness_fns", issue = "70921")]
+#[stable(feature = "future_readiness_fns", since = "1.47.0")]
 impl<T> Unpin for Ready<T> {}
 
-#[unstable(feature = "future_readiness_fns", issue = "70921")]
+#[stable(feature = "future_readiness_fns", since = "1.47.0")]
 impl<T> Future for Ready<T> {
     type Output = T;
 
@@ -28,10 +28,13 @@ impl<T> Future for Ready<T> {
 
 /// Creates a future that is immediately ready with a value.
 ///
+/// Futures created through this function are functionally similar to those
+/// created through `async {}`. The main difference is that futures created
+/// through this function are named and implement `Unpin`.
+///
 /// # Examples
 ///
 /// ```
-/// #![feature(future_readiness_fns)]
 /// use core::future;
 ///
 /// # async fn run() {
@@ -39,7 +42,7 @@ impl<T> Future for Ready<T> {
 /// assert_eq!(a.await, 1);
 /// # }
 /// ```
-#[unstable(feature = "future_readiness_fns", issue = "70921")]
+#[stable(feature = "future_readiness_fns", since = "1.47.0")]
 pub fn ready<T>(t: T) -> Ready<T> {
     Ready(Some(t))
 }

--- a/library/core/src/task/ready.rs
+++ b/library/core/src/task/ready.rs
@@ -5,7 +5,6 @@
 /// # Examples
 ///
 /// ```
-/// #![feature(future_readiness_fns)]
 /// #![feature(ready_macro)]
 ///
 /// use core::task::{ready, Context, Poll};
@@ -27,7 +26,6 @@
 /// The `ready!` call expands to:
 ///
 /// ```
-/// # #![feature(future_readiness_fns)]
 /// # #![feature(ready_macro)]
 /// #
 /// # use core::task::{Context, Poll};

--- a/library/std/src/future.rs
+++ b/library/std/src/future.rs
@@ -9,7 +9,7 @@ pub use core::future::Future;
 pub use core::future::{from_generator, get_context, ResumeTy};
 
 #[doc(inline)]
-#[unstable(feature = "future_readiness_fns", issue = "70921")]
+#[stable(feature = "future_readiness_fns", since = "1.47.0")]
 pub use core::future::{pending, ready, Pending, Ready};
 
 #[doc(inline)]

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -268,7 +268,6 @@
 #![feature(external_doc)]
 #![feature(fn_traits)]
 #![feature(format_args_nl)]
-#![feature(future_readiness_fns)]
 #![feature(gen_future)]
 #![feature(generator_trait)]
 #![feature(global_asm)]


### PR DESCRIPTION
This PR stabilizes `core::future::{pending,ready}`, tracking issue https://github.com/rust-lang/rust/issues/70921.

## Motivation

These functions have been on nightly for three months now, and have lived as part of the futures ecosystem for several years. In that time these functions have undergone several iterations, with [the `async-std` impls](https://docs.rs/async-std/1.6.2/async_std/future/index.html) probably diverging the most (using `async fn`, which in hindsight was a mistake).

It seems the space around these functions has been _thoroughly_ explored over the last couple of years, and the ecosystem has settled on the current shape of the functions. It seems highly unlikely we'd want to make any further changes to these functions, so I propose we stabilize.

## Implementation notes

This stabilization PR was fairly straightforward; this feature has already thoroughly been reviewed by the libs team already in https://github.com/rust-lang/rust/pull/70834. So all this PR does is remove the feature gate.