### PR TITLE
bootstrap: Improve wording on docs for `verbose-tests`

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -391,8 +391,7 @@
 # desired in distributions, for example.
 #rpath = true
 
-# Emits extraneous output from tests to ensure that failures of the test
-# harness are debuggable just from logfiles.
+# Emits extra output from tests so test failures are debuggable just from logfiles.
 #verbose-tests = false
 
 # Flag indicating whether tests are compiled with optimizations (the -O flag).


### PR DESCRIPTION
From https://github.com/rust-lang/rustc-dev-guide/pull/795#discussion_r454392291

r? @spastorino 