### PR TITLE
Add core::task::yield_now

### DIFF
--- a/library/core/src/task/mod.rs
+++ b/library/core/src/task/mod.rs
@@ -13,3 +13,7 @@ pub use self::wake::{Context, RawWaker, RawWakerVTable, Waker};
 mod ready;
 #[unstable(feature = "ready_macro", issue = "70922")]
 pub use ready::ready;
+
+mod yield_now;
+#[unstable(feature = "task_yield_now", issue = "74331")]
+pub use self::yield_now::{yield_now, YieldNow};

--- a/library/core/src/task/yield_now.rs
+++ b/library/core/src/task/yield_now.rs
@@ -1,0 +1,58 @@
+use crate::future::Future;
+use crate::pin::Pin;
+use crate::task::{Context, Poll};
+
+/// Cooperatively gives up a timeslice to the executor.
+///
+/// Calling this function calls move the currently executing future to the back
+/// of the execution queue, making room for other futures to execute. This is
+/// especially useful after running CPU-intensive operations inside a future.
+///
+/// # Examples
+///
+/// Basic usage:
+///
+/// ```
+/// #![feature(task_yield_now)]
+/// # async fn run() {
+/// #
+/// use core::task;
+///
+/// task::yield_now().await;
+/// #
+/// # }
+/// ```
+#[unstable(feature = "task_yield_now", issue = "74331")]
+#[inline]
+pub fn yield_now() -> YieldNow {
+    YieldNow { is_polled: false }
+}
+
+/// Creates a future that yields back to the executor exactly once.
+///
+/// This `struct` is created by the [`yield_now`] function. See its
+/// documentation for more.
+#[unstable(feature = "task_yield_now", issue = "74331")]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
+#[derive(Debug)]
+pub struct YieldNow {
+    is_polled: bool,
+}
+
+#[unstable(feature = "task_yield_now", issue = "74331")]
+impl Future for YieldNow {
+    type Output = ();
+
+    // Most futures executors are implemented as a FIFO queue, so all this
+    // future does is re-schedule the future back to the end of the queue,
+    // giving room for other futures to progress.
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        if self.is_polled {
+            return Poll::Ready(());
+        }
+
+        self.is_polled = true;
+        cx.waker().wake_by_ref();
+        Poll::Pending
+    }
+}

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -307,6 +307,7 @@
 #![feature(stdsimd)]
 #![feature(stmt_expr_attributes)]
 #![feature(str_internals)]
+#![feature(task_yield_now)]
 #![feature(test)]
 #![feature(thread_local)]
 #![feature(toowned_clone_into)]
@@ -478,11 +479,15 @@ pub mod task {
 
     #[doc(inline)]
     #[stable(feature = "futures_api", since = "1.36.0")]
-    pub use core::task::*;
+    pub use core::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
 
     #[doc(inline)]
     #[unstable(feature = "wake_trait", issue = "69912")]
-    pub use alloc::task::*;
+    pub use alloc::task::Wake;
+
+    #[doc(inline)]
+    #[unstable(feature = "task_yield_now", issue = "74331")]
+    pub use core::task::{yield_now, YieldNow};
 }
 
 #[stable(feature = "futures_api", since = "1.36.0")]


### PR DESCRIPTION
Adds `core::task::yield_now` as a counterpart to `std::thread::yield_now`. Tracking issue is https://github.com/rust-lang/rust/issues/74331.


cc/ @rust-lang/wg-async-foundations 

## Motivation

Schedulers generally infer when tasks should be run to optimize performance. However some of the time the programmer has more information than the scheduler, and may want to manually yield back to the scheduler to enable other code to run. For threads this mechanism is [`std::thread::yield_now`](https://doc.rust-lang.org/std/thread/fn.yield_now.html).

This PR introduces a counterpart to `thread::yield_now` in the form of `task::yield_now`. The way this works is that the first time the future is polled it returns `Poll::Pending` and immediately calls `Waker::wake`. `Poll::Pending` signals to executors that the current task is not ready and will be suspended, while the call to `Waker::wake` then immediately puts it at the back of the execution queue.

This somewhat depends on behavior of executors; but in practice this is compatible with all executors in the ecosystem right now. Both [`async_std::task::yield_now`](https://docs.rs/async-std/1.6.2/async_std/task/fn.yield_now.html) and [`tokio::task::yield_now`](https://docs.rs/tokio/0.2.21/src/tokio/task/yield_now.rs.html#16-37) share similar implementations. With neither implementation being bound to any particular runtime, this is a good candidate to start trialing in nightly.

## Implementation notes

Much like [`core::future::ready`](https://doc.rust-lang.org/nightly/core/future/fn.ready.html) and [`core::future::pending`](https://doc.rust-lang.org/nightly/core/future/fn.pending.html) this function returns a concrete future rather than being implemented as an `async fn`. This enables it to be inspected and stored inside structs, which is a useful property for types found in the stdlib.

We also make note of the concept of an "executor", which has precedent in the [`Wake`](https://doc.rust-lang.org/nightly/alloc/task/trait.Wake.html) trait.

## References

- Initial feature request in `tokio` https://github.com/tokio-rs/tokio/issues/592
- Initial PR for `async_std` https://github.com/async-rs/async-std/pull/300
- Stabilization PR for `async_std` https://github.com/async-rs/async-std/pull/514