### PR TITLE
typeck: use `item_name` in cross-crate packed diag

### DIFF
--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -103,7 +103,7 @@ use rustc_hir::itemlikevisit::ItemLikeVisitor;
 use rustc_hir::lang_items::{
     FutureTraitLangItem, PinTypeLangItem, SizedTraitLangItem, VaListTypeLangItem,
 };
-use rustc_hir::{ExprKind, GenericArg, HirIdMap, Item, ItemKind, Node, PatKind, QPath};
+use rustc_hir::{ExprKind, GenericArg, HirIdMap, ItemKind, Node, PatKind, QPath};
 use rustc_index::bit_set::BitSet;
 use rustc_index::vec::Idx;
 use rustc_infer::infer;
@@ -2624,34 +2624,31 @@ fn check_packed(tcx: TyCtxt<'_>, sp: Span, def: &ty::AdtDef) {
                     "packed type cannot transitively contain a `#[repr(align)]` type"
                 );
 
-                let hir = tcx.hir();
-                let hir_id = hir.as_local_hir_id(def_spans[0].0.expect_local());
-                if let Node::Item(Item { ident, .. }) = hir.get(hir_id) {
-                    err.span_note(
-                        tcx.def_span(def_spans[0].0),
-                        &format!("`{}` has a `#[repr(align)]` attribute", ident),
-                    );
-                }
+                err.span_note(
+                    tcx.def_span(def_spans[0].0),
+                    &format!(
+                        "`{}` has a `#[repr(align)]` attribute",
+                        tcx.item_name(def_spans[0].0)
+                    ),
+                );
 
                 if def_spans.len() > 2 {
                     let mut first = true;
                     for (adt_def, span) in def_spans.iter().skip(1).rev() {
-                        let hir_id = hir.as_local_hir_id(adt_def.expect_local());
-                        if let Node::Item(Item { ident, .. }) = hir.get(hir_id) {
-                            err.span_note(
-                                *span,
-                                &if first {
-                                    format!(
-                                        "`{}` contains a field of type `{}`",
-                                        tcx.type_of(def.did),
-                                        ident
-                                    )
-                                } else {
-                                    format!("...which contains a field of type `{}`", ident)
-                                },
-                            );
-                            first = false;
-                        }
+                        let ident = tcx.item_name(*adt_def);
+                        err.span_note(
+                            *span,
+                            &if first {
+                                format!(
+                                    "`{}` contains a field of type `{}`",
+                                    tcx.type_of(def.did),
+                                    ident
+                                )
+                            } else {
+                                format!("...which contains a field of type `{}`", ident)
+                            },
+                        );
+                        first = false;
                     }
                 }
 

--- a/src/test/ui/issues/auxiliary/issue-73112.rs
+++ b/src/test/ui/issues/auxiliary/issue-73112.rs
@@ -1,0 +1,10 @@
+#[repr(transparent)]
+pub struct PageTableEntry {
+    entry: u64,
+}
+
+#[repr(align(4096))]
+#[repr(C)]
+pub struct PageTable {
+    entries: [PageTableEntry; 512],
+}

--- a/src/test/ui/issues/issue-73112.rs
+++ b/src/test/ui/issues/issue-73112.rs
@@ -1,0 +1,13 @@
+// aux-build:issue-73112.rs
+
+extern crate issue_73112;
+
+fn main() {
+    use issue_73112::PageTable;
+
+    #[repr(C, packed)]
+    struct SomeStruct {
+    //~^ ERROR packed type cannot transitively contain a `#[repr(align)]` type [E0588]
+        page_table: PageTable,
+    }
+}

--- a/src/test/ui/issues/issue-73112.stderr
+++ b/src/test/ui/issues/issue-73112.stderr
@@ -1,0 +1,20 @@
+error[E0588]: packed type cannot transitively contain a `#[repr(align)]` type
+  --> $DIR/issue-73112.rs:9:5
+   |
+LL | /     struct SomeStruct {
+LL | |
+LL | |         page_table: PageTable,
+LL | |     }
+   | |_____^
+   |
+note: `PageTable` has a `#[repr(align)]` attribute
+  --> $DIR/auxiliary/issue-73112.rs:8:1
+   |
+LL | / pub struct PageTable {
+LL | |     entries: [PageTableEntry; 512],
+LL | | }
+   | |_^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0588`.


### PR DESCRIPTION
Fixes #73112.

This PR replaces the use of `expect_local` and `hir().get` to fetch the identifier for a ADT with `item_name` - which works across crates.