### PR TITLE
lint: use `transparent_newtype_field` to avoid ICE

### DIFF
--- a/src/test/ui/lint/lint-ctypes-73747.rs
+++ b/src/test/ui/lint/lint-ctypes-73747.rs
@@ -1,0 +1,14 @@
+// check-pass
+
+#[repr(transparent)]
+struct NonNullRawComPtr<T: ComInterface> {
+    inner: std::ptr::NonNull<<T as ComInterface>::VTable>,
+}
+
+trait ComInterface {
+    type VTable;
+}
+
+extern "C" fn invoke<T: ComInterface>(_: Option<NonNullRawComPtr<T>>) {}
+
+fn main() {}


### PR DESCRIPTION
Fixes #73747.

This PR re-uses the `transparent_newtype_field` function instead of manually calling `is_zst` on normalized fields to determine which field in a transparent type is the non-zero-sized field, thus avoiding an ICE.
