### PR TITLE
Don't keep {Closure,Generator}Substs synthetics in an Instance.

### DIFF
--- a/src/librustc_codegen_ssa/mir/rvalue.rs
+++ b/src/librustc_codegen_ssa/mir/rvalue.rs
@@ -211,7 +211,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                                 let instance = Instance::resolve_closure(
                                     bx.cx().tcx(),
                                     def_id,
-                                    substs,
+                                    substs.as_closure(),
                                     ty::ClosureKind::FnOnce,
                                 );
                                 OperandValue::Immediate(bx.cx().get_fn_addr(instance))

--- a/src/librustc_middle/ty/mod.rs
+++ b/src/librustc_middle/ty/mod.rs
@@ -65,6 +65,7 @@ pub use self::sty::{ConstVid, FloatVid, IntVid, RegionVid, TyVid};
 pub use self::sty::{ExistentialPredicate, InferConst, InferTy, ParamConst, ParamTy, ProjectionTy};
 pub use self::sty::{ExistentialTraitRef, PolyExistentialTraitRef};
 pub use self::sty::{PolyTraitRef, TraitRef, TyKind};
+pub use self::sty::{SplitClosureSubsts, SplitGeneratorSubsts};
 pub use crate::ty::diagnostics::*;
 
 pub use self::binding::BindingMode;

--- a/src/librustc_mir/interpret/cast.rs
+++ b/src/librustc_mir/interpret/cast.rs
@@ -96,7 +96,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                         let instance = ty::Instance::resolve_closure(
                             *self.tcx,
                             def_id,
-                            substs,
+                            substs.as_closure(),
                             ty::ClosureKind::FnOnce,
                         );
                         let fn_ptr = self.memory.create_fn_alloc(FnVal::Instance(instance));

--- a/src/librustc_mir/monomorphize/collector.rs
+++ b/src/librustc_mir/monomorphize/collector.rs
@@ -581,7 +581,7 @@ impl<'a, 'tcx> MirVisitor<'tcx> for MirNeighborCollector<'a, 'tcx> {
                         let instance = Instance::resolve_closure(
                             self.tcx,
                             def_id,
-                            substs,
+                            substs.as_closure(),
                             ty::ClosureKind::FnOnce,
                         );
                         if should_monomorphize_locally(self.tcx, &instance) {

--- a/src/librustc_ty/instance.rs
+++ b/src/librustc_ty/instance.rs
@@ -190,7 +190,7 @@ fn resolve_associated_item<'tcx>(
             Some(Instance::resolve_closure(
                 tcx,
                 closure_data.closure_def_id,
-                closure_data.substs,
+                closure_data.substs.as_closure(),
                 trait_closure_kind,
             ))
         }

--- a/src/librustc_typeck/check/closure.rs
+++ b/src/librustc_typeck/check/closure.rs
@@ -11,7 +11,7 @@ use rustc_infer::infer::LateBoundRegionConversionTime;
 use rustc_infer::infer::{InferOk, InferResult};
 use rustc_middle::ty::fold::TypeFoldable;
 use rustc_middle::ty::subst::InternalSubsts;
-use rustc_middle::ty::{self, GenericParamDefKind, Ty};
+use rustc_middle::ty::{self, Ty};
 use rustc_span::source_map::Span;
 use rustc_target::spec::abi::Abi;
 use rustc_trait_selection::traits::error_reporting::ArgKind;
@@ -80,56 +80,40 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             self.tcx,
             self.tcx.closure_base_def_id(expr_def_id.to_def_id()),
         );
-        // HACK(eddyb) this hardcodes indices into substs but it should rely on
-        // `ClosureSubsts` and `GeneratorSubsts` providing constructors, instead.
-        // That would also remove the need for most of the inference variables,
-        // as they immediately unified with the actual type below, including
-        // the `InferCtxt::closure_sig` and `ClosureSubsts::sig_ty` methods.
-        let tupled_upvars_idx = base_substs.len() + if generator_types.is_some() { 4 } else { 2 };
-        let substs =
-            base_substs.extend_to(self.tcx, expr_def_id.to_def_id(), |param, _| match param.kind {
-                GenericParamDefKind::Lifetime => span_bug!(expr.span, "closure has lifetime param"),
-                GenericParamDefKind::Type { .. } => if param.index as usize == tupled_upvars_idx {
-                    self.tcx.mk_tup(self.tcx.upvars_mentioned(expr_def_id).iter().flat_map(
-                        |upvars| {
-                            upvars.iter().map(|(&var_hir_id, _)| {
-                                // Create type variables (for now) to represent the transformed
-                                // types of upvars. These will be unified during the upvar
-                                // inference phase (`upvar.rs`).
-                                self.infcx.next_ty_var(TypeVariableOrigin {
-                                    // FIXME(eddyb) distinguish upvar inference variables from the rest.
-                                    kind: TypeVariableOriginKind::ClosureSynthetic,
-                                    span: self.tcx.hir().span(var_hir_id),
-                                })
-                            })
-                        },
-                    ))
-                } else {
-                    // Create type variables (for now) to represent the various
-                    // pieces of information kept in `{Closure,Generic}Substs`.
-                    // They will either be unified below, or later during the upvar
-                    // inference phase (`upvar.rs`)
+
+        let tupled_upvars_ty =
+            self.tcx.mk_tup(self.tcx.upvars_mentioned(expr_def_id).iter().flat_map(|upvars| {
+                upvars.iter().map(|(&var_hir_id, _)| {
+                    // Create type variables (for now) to represent the transformed
+                    // types of upvars. These will be unified during the upvar
+                    // inference phase (`upvar.rs`).
                     self.infcx.next_ty_var(TypeVariableOrigin {
+                        // FIXME(eddyb) distinguish upvar inference variables from the rest.
                         kind: TypeVariableOriginKind::ClosureSynthetic,
-                        span: expr.span,
+                        span: self.tcx.hir().span(var_hir_id),
                     })
-                }
-                .into(),
-                GenericParamDefKind::Const => span_bug!(expr.span, "closure has const param"),
-            });
+                })
+            }));
+
         if let Some(GeneratorTypes { resume_ty, yield_ty, interior, movability }) = generator_types
         {
-            let generator_substs = substs.as_generator();
-            self.demand_eqtype(expr.span, resume_ty, generator_substs.resume_ty());
-            self.demand_eqtype(expr.span, yield_ty, generator_substs.yield_ty());
-            self.demand_eqtype(expr.span, liberated_sig.output(), generator_substs.return_ty());
-            self.demand_eqtype(expr.span, interior, generator_substs.witness());
+            let generator_substs = ty::GeneratorSubsts::new(
+                self.tcx,
+                base_substs,
+                ty::SplitGeneratorSubsts {
+                    resume_ty,
+                    yield_ty,
+                    return_ty: liberated_sig.output(),
+                    witness: interior,
+                    tupled_upvars_ty,
+                },
+            );
 
-            // HACK(eddyb) this forces the types equated above into `substs` but
-            // it should rely on `GeneratorSubsts` providing a constructor, instead.
-            let substs = self.resolve_vars_if_possible(&substs);
-
-            return self.tcx.mk_generator(expr_def_id.to_def_id(), substs, movability);
+            return self.tcx.mk_generator(
+                expr_def_id.to_def_id(),
+                generator_substs.substs,
+                movability,
+            );
         }
 
         // Tuple up the arguments and insert the resulting function type into
@@ -149,18 +133,29 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             expr_def_id, sig, opt_kind
         );
 
-        let sig_fn_ptr_ty = self.tcx.mk_fn_ptr(sig);
-        self.demand_eqtype(expr.span, sig_fn_ptr_ty, substs.as_closure().sig_as_fn_ptr_ty());
+        let closure_kind_ty = match opt_kind {
+            Some(kind) => kind.to_ty(self.tcx),
 
-        if let Some(kind) = opt_kind {
-            self.demand_eqtype(expr.span, kind.to_ty(self.tcx), substs.as_closure().kind_ty());
-        }
+            // Create a type variable (for now) to represent the closure kind.
+            // It will be unified during the upvar inference phase (`upvar.rs`)
+            None => self.infcx.next_ty_var(TypeVariableOrigin {
+                // FIXME(eddyb) distinguish closure kind inference variables from the rest.
+                kind: TypeVariableOriginKind::ClosureSynthetic,
+                span: expr.span,
+            }),
+        };
 
-        // HACK(eddyb) this forces the types equated above into `substs` but
-        // it should rely on `ClosureSubsts` providing a constructor, instead.
-        let substs = self.resolve_vars_if_possible(&substs);
+        let closure_substs = ty::ClosureSubsts::new(
+            self.tcx,
+            base_substs,
+            ty::SplitClosureSubsts {
+                closure_kind_ty,
+                closure_sig_as_fn_ptr_ty: self.tcx.mk_fn_ptr(sig),
+                tupled_upvars_ty,
+            },
+        );
 
-        let closure_type = self.tcx.mk_closure(expr_def_id.to_def_id(), substs);
+        let closure_type = self.tcx.mk_closure(expr_def_id.to_def_id(), closure_substs.substs);
 
         debug!("check_closure: expr.hir_id={:?} closure_type={:?}", expr.hir_id, closure_type);
 

--- a/src/librustc_typeck/collect/type_of.rs
+++ b/src/librustc_typeck/collect/type_of.rs
@@ -177,13 +177,8 @@ pub(super) fn type_of(tcx: TyCtxt<'_>, def_id: DefId) -> Ty<'_> {
 
         Node::Field(field) => icx.to_ty(&field.ty),
 
-        Node::Expr(&Expr { kind: ExprKind::Closure(.., gen), .. }) => {
-            let substs = InternalSubsts::identity_for_item(tcx, def_id);
-            if let Some(movability) = gen {
-                tcx.mk_generator(def_id, substs, movability)
-            } else {
-                tcx.mk_closure(def_id, substs)
-            }
+        Node::Expr(&Expr { kind: ExprKind::Closure(..), .. }) => {
+            tcx.typeck_tables_of(def_id.expect_local()).node_type(hir_id)
         }
 
         Node::AnonConst(_) => {


### PR DESCRIPTION
*Based on #74314, which removes the main use of synthetic type parameters in closure/generator `ty::Generics`*

This PR keeps the "synthetics" (closure kind/signature/upvar types, or similar information for generators) only in the `Ty` (`Closure`/`Generator`) substitutions (used during inference and for type layout), but not in `Instance`s which are used to refer to the MIR body of the closure during codegen (and the MIR body doesn't refer to the "synthetics" at all).

I originally started work on this to change the codegen behavior of closures with no type/const generics in scope (and have them not be deduplicated across crates), as per https://github.com/rust-lang/rust/pull/74283#issuecomment-657530357 - but have since given up on that line of experimentation.

It might still improve some performance or help with @davidtwco polymorphization work, but it's not clear that it will.

r? @nikomatsakis 