### PR TITLE
Initialize default providers only once

### DIFF
--- a/src/librustc_interface/lib.rs
+++ b/src/librustc_interface/lib.rs
@@ -14,6 +14,7 @@ mod queries;
 pub mod util;
 
 pub use interface::{run_compiler, Config};
+pub use passes::{DEFAULT_EXTERN_QUERY_PROVIDERS, DEFAULT_QUERY_PROVIDERS};
 pub use queries::Queries;
 
 #[cfg(test)]


### PR DESCRIPTION
This avoids copying a new `Providers` struct for each downstream crate
that wants to use it.

Follow-up to https://github.com/rust-lang/rust/pull/74283 without the perf hit.

r? @eddyb