### PR TITLE
Do not render unstable items for rustc doc

### DIFF
--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -2229,12 +2229,15 @@ fn stability_tags(item: &clean::Item) -> String {
         tags += &tag_html("deprecated", message);
     }
 
-    if let Some(stab) = item.stability.as_ref().filter(|s| s.level == stability::Unstable) {
-        if stab.feature.as_deref() == Some("rustc_private") {
-            tags += &tag_html("internal", "Internal");
-        } else {
-            tags += &tag_html("unstable", "Experimental");
-        }
+    // The "rustc_private" crates are permanently unstable so it makes no sense
+    // to render "unstable" everywhere.
+    if item
+        .stability
+        .as_ref()
+        .map(|s| s.level == stability::Unstable && s.feature.as_deref() != Some("rustc_private"))
+        == Some(true)
+    {
+        tags += &tag_html("unstable", "Experimental");
     }
 
     if let Some(ref cfg) = item.attrs.cfg {
@@ -2285,15 +2288,13 @@ fn short_stability(item: &clean::Item, cx: &Context) -> Vec<String> {
         ));
     }
 
-    if let Some(stab) = item.stability.as_ref().filter(|stab| stab.level == stability::Unstable) {
-        let is_rustc_private = stab.feature.as_deref() == Some("rustc_private");
-
-        let mut message = if is_rustc_private {
-            "<span class='emoji'>⚙️</span> This is an internal compiler API."
-        } else {
-            "<span class='emoji'>🔬</span> This is a nightly-only experimental API."
-        }
-        .to_owned();
+    // Render unstable items. But don't render "rustc_private" crates (internal compiler crates).
+    // Those crates are permanently unstable so it makes no sense to render "unstable" everywhere.
+    if let Some(stab) = item.stability.as_ref().filter(|stab| {
+        stab.level == stability::Unstable && stab.feature.as_deref() != Some("rustc_private")
+    }) {
+        let mut message =
+            "<span class='emoji'>🔬</span> This is a nightly-only experimental API.".to_owned();
 
         if let Some(feature) = stab.feature.as_deref() {
             let mut feature = format!("<code>{}</code>", Escape(&feature));
@@ -2309,17 +2310,6 @@ fn short_stability(item: &clean::Item, cx: &Context) -> Vec<String> {
         }
 
         if let Some(unstable_reason) = &stab.unstable_reason {
-            // Provide a more informative message than the compiler help.
-            let unstable_reason = if is_rustc_private {
-                "This crate is being loaded from the sysroot, a permanently unstable location \
-                for private compiler dependencies. It is not intended for general use. Prefer \
-                using a public version of this crate from \
-                [crates.io](https://crates.io) via [`Cargo.toml`]\
-                (https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html)."
-            } else {
-                unstable_reason
-            };
-
             let mut ids = cx.id_map.borrow_mut();
             message = format!(
                 "<details><summary>{}</summary>{}</details>",
@@ -2335,8 +2325,7 @@ fn short_stability(item: &clean::Item, cx: &Context) -> Vec<String> {
             );
         }
 
-        let class = if is_rustc_private { "internal" } else { "unstable" };
-        stability.push(format!("<div class='stab {}'>{}</div>", class, message));
+        stability.push(format!("<div class='stab unstable'>{}</div>", message));
     }
 
     if let Some(ref cfg) = item.attrs.cfg {

--- a/src/librustdoc/html/static/themes/ayu.css
+++ b/src/librustdoc/html/static/themes/ayu.css
@@ -216,10 +216,6 @@ a {
 	color: #39AFD7;
 }
 
-.stab.internal a {
-	color: #304FFE;
-}
-
 .collapse-toggle {
 	color: #999;
 }
@@ -254,7 +250,6 @@ a {
 }
 
 .stab.unstable,
-.stab.internal,
 .stab.deprecated,
 .stab.portability {
     color: #c5c5c5;
@@ -457,7 +452,6 @@ pre.rust .doccomment {}
 .content .highlighted.type {}
 pre.rust .kw-2,pre.rust .prelude-ty {}
 .content span.trait,.content a.trait,.block a.current.trait {}
-.stab.internal {}
 
 @media (max-width: 700px) {
 	.sidebar-menu {

--- a/src/librustdoc/html/static/themes/dark.css
+++ b/src/librustdoc/html/static/themes/dark.css
@@ -172,10 +172,6 @@ a {
 	color: #D2991D;
 }
 
-.stab.internal a {
-	color: #304FFE;
-}
-
 a.test-arrow {
 	color: #dedede;
 }
@@ -214,7 +210,6 @@ a.test-arrow {
 }
 
 .stab.unstable { background: #FFF5D6; border-color: #FFC600; color: #2f2f2f; }
-.stab.internal { background: #FFB9B3; border-color: #B71C1C; color: #2f2f2f; }
 .stab.deprecated { background: #F3DFFF; border-color: #7F0087; color: #2f2f2f; }
 .stab.portability { background: #C4ECFF; border-color: #7BA5DB; color: #2f2f2f; }
 

--- a/src/librustdoc/html/static/themes/light.css
+++ b/src/librustdoc/html/static/themes/light.css
@@ -173,10 +173,6 @@ a {
 	color: #3873AD;
 }
 
-.stab.internal a {
-	color: #304FFE;
-}
-
 a.test-arrow {
 	color: #f5f5f5;
 }
@@ -215,7 +211,6 @@ a.test-arrow {
 }
 
 .stab.unstable { background: #FFF5D6; border-color: #FFC600; }
-.stab.internal { background: #FFB9B3; border-color: #B71C1C; }
 .stab.deprecated { background: #F3DFFF; border-color: #7F0087; }
 .stab.portability { background: #C4ECFF; border-color: #7BA5DB; }
 

--- a/src/test/rustdoc/internal.rs
+++ b/src/test/rustdoc/internal.rs
@@ -1,11 +1,13 @@
 // compile-flags: -Z force-unstable-if-unmarked
 
-// @matches internal/index.html '//*[@class="docblock-short"]/span[@class="stab internal"]' \
-//      'Internal'
+// Check that the unstable marker is not added for "rustc_private".
+
+// @!matches internal/index.html '//*[@class="docblock-short"]/span[@class="stab unstable"]'
+// @!matches internal/index.html '//*[@class="docblock-short"]/span[@class="stab internal"]'
 // @matches - '//*[@class="docblock-short"]' 'Docs'
 
-// @has internal/struct.S.html '//*[@class="stab internal"]' \
-//      'This is an internal compiler API. (rustc_private)'
+// @!has internal/struct.S.html '//*[@class="stab unstable"]'
+// @!has internal/struct.S.html '//*[@class="stab internal"]'
 /// Docs
 pub struct S;
 


### PR DESCRIPTION
See the zulip conversation at https://rust-lang.zulipchat.com/#narrow/stream/131828-t-compiler/topic/rustc.20doc.3A.20.22internal.20compiler.20API.22.20warns.20are.20everywhere!/near/203850782

Before: 
![image](https://user-images.githubusercontent.com/15225902/87501971-9cff8780-c68a-11ea-93b4-ea53ce18a77b.png)
After:  
![image](https://user-images.githubusercontent.com/15225902/87501985-a7218600-c68a-11ea-81c0-a6b5b120832c.png)

Nothing changes in unstable items of std:
Before: 
![image](https://user-images.githubusercontent.com/15225902/87502004-b7d1fc00-c68a-11ea-9224-a27a1d2a81d6.png)
After: 
![image](https://user-images.githubusercontent.com/15225902/87502018-c0c2cd80-c68a-11ea-9773-4c63158025cb.png)

Closes  #54682