### PR TITLE
Use local links in the alloc docs.

### DIFF
--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -773,7 +773,8 @@ impl<'a> Builder<'a> {
             let my_out = match mode {
                 // This is the intended out directory for compiler documentation.
                 Mode::Rustc | Mode::ToolRustc | Mode::Codegen => self.compiler_doc_out(target),
-                _ => self.crate_doc_out(target),
+                Mode::Std => out_dir.join(target).join("doc"),
+                _ => panic!("doc mode {:?} not expected", mode),
             };
             let rustdoc = self.rustdoc(compiler);
             self.clear_if_dirty(&my_out, &rustdoc);

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -612,13 +612,6 @@ impl Build {
         INTERNER.intern_path(self.out.join(&*target).join("md-doc"))
     }
 
-    /// Output directory for all crate documentation for a target (temporary)
-    ///
-    /// The artifacts here are then copied into `doc_out` above.
-    fn crate_doc_out(&self, target: Interned<String>) -> PathBuf {
-        self.out.join(&*target).join("crate-docs")
-    }
-
     /// Returns `true` if no custom `llvm-config` is set for the specified target.
     ///
     /// If no custom `llvm-config` was specified then Rust's llvm will be used.


### PR DESCRIPTION
Links to other crates (like core) from the alloc crate were incorrectly using the `https://doc.rust-lang.org/nightly/` absolute (remote) links, instead of relative (local) links.  For example, the link to `Result` at https://doc.rust-lang.org/1.44.1/alloc/vec/struct.Vec.html#method.try_reserve goes to /nightly/.

This is because alloc was being documented before core, and rustdoc relies on the existence of the local directory to know if it should use a local or remote link.

There was code that tried to compensate for this (`create_dir_all`), but in #54543 it was broken because instead of running `cargo doc` once for all the crates, it was changed to run `cargo rustdoc` for each crate individually. This means that `create_dir_all` was no longer doing what it was supposed to be doing (creating all the directories before starting).

The solution here is to just build in the correct order (from the dependency leaves towards the root).  An alternate solution would be to switch back to running `cargo doc` once (and use RUSTDOCFLAGS for passing in flags).  Another alternate solution would be to iterate over the list twice, creating the directories during the first pass.

I also did a little cleanup to remove the "crate-docs" directory. This was added in the past because different crates were built in different directories. Over time, things have been unified (and rustc docs no longer include std), so it is no longer necessary.
