### PR TITLE
Improve doc theme logo display

### DIFF
--- a/src/librustdoc/html/static/themes/ayu.css
+++ b/src/librustdoc/html/static/themes/ayu.css
@@ -61,6 +61,10 @@ pre {
 	background-color: #14191f;
 }
 
+.logo-container > img {
+	filter: drop-shadow(0 0 5px #fff);
+}
+
 /* Improve the scrollbar display on firefox */
 * {
 	scrollbar-color: #5c6773 transparent;

--- a/src/librustdoc/html/static/themes/dark.css
+++ b/src/librustdoc/html/static/themes/dark.css
@@ -32,6 +32,10 @@ pre {
 	background-color: #505050;
 }
 
+.logo-container > img {
+	filter: drop-shadow(0 0 5px #fff);
+}
+
 /* Improve the scrollbar display on firefox */
 * {
 	scrollbar-color: rgb(64, 65, 67) #717171;

--- a/src/librustdoc/html/static/themes/light.css
+++ b/src/librustdoc/html/static/themes/light.css
@@ -43,6 +43,10 @@ pre {
 	scrollbar-color: rgba(36, 37, 39, 0.6) #d9d9d9;
 }
 
+.logo-container > img {
+	filter: drop-shadow(0 0 5px #aaa);
+}
+
 /* Improve the scrollbar display on webkit-based browsers */
 ::-webkit-scrollbar-track {
 	background-color: #ecebeb;


### PR DESCRIPTION
Fixes #74350.

The first commit cleans up the whitespaces and converts them to tabs. We should definitely write a tidy check for this (will do it in another PR).

Screenshots:

![Screenshot from 2020-07-15 14-08-25](https://user-images.githubusercontent.com/3050060/87543748-8581c800-c6a5-11ea-8417-cbf98ebbfd10.png)
![Screenshot from 2020-07-15 14-11-59](https://user-images.githubusercontent.com/3050060/87543747-84e93180-c6a5-11ea-8cea-976b1470e809.png)
![Screenshot from 2020-07-15 14-12-12](https://user-images.githubusercontent.com/3050060/87543745-84509b00-c6a5-11ea-8324-c3c46ab2d9ef.png)

r? @lzutao 
cc @Cldfire