### PR TITLE
add lazy normalization regression tests

### DIFF
--- a/src/test/ui/lazy_normalization_consts/trait-resolution-breakage.rs
+++ b/src/test/ui/lazy_normalization_consts/trait-resolution-breakage.rs
@@ -1,0 +1,18 @@
+// check-pass
+
+trait Trait<T> {
+    const ASSOC_CONST: usize = 0;
+}
+
+impl Trait<()> for u8 {}
+
+// `u8::ASSOC_CONST` is resolved today, but will be ambiguous
+// under lazy normalization.
+fn foo<T, U>() -> [(T, U); u8::ASSOC_CONST]
+where
+    u8: Trait<T> + Trait<U>,
+{
+    todo!()
+}
+
+fn main() {}

--- a/src/test/ui/lazy_normalization_consts/unevaluated-consts.rs
+++ b/src/test/ui/lazy_normalization_consts/unevaluated-consts.rs
@@ -1,0 +1,18 @@
+// check-pass
+
+// If we allow the parent generics here without using lazy normalization
+// this results in a cycle error.
+struct Foo<T, U>(T, U);
+
+impl<T> From<[u8; 1 + 1]> for Foo<T, [u8; 1 + 1]> {
+    fn from(value: [u8; 1 + 1]) -> Foo<T, [u8; 1 + 1]> {
+        todo!();
+    }
+}
+
+fn break_me<T>()
+where
+    [u8; 1 + 1]: From<[u8; 1 + 1]>
+{}
+
+fn main() {}


### PR DESCRIPTION
We previously didn't have simple tests which fail if we aren't careful around lazy normalization.

We now do.