### PR TITLE
Improve ayu rustdoc theme

### DIFF
--- a/src/librustdoc/html/static/themes/ayu.css
+++ b/src/librustdoc/html/static/themes/ayu.css
@@ -70,6 +70,11 @@ pre {
 	scrollbar-color: #5c6773 transparent;
 }
 
+.logo-container > img {
+	/* Make dark logos better visible in supported browsers */
+	filter: drop-shadow(0 0 30px rgba(255,255,255,0.7));
+}
+
 /* Improve the scrollbar display on webkit-based browsers */
 ::-webkit-scrollbar-track {
 	background-color: transparent;
@@ -108,7 +113,7 @@ pre {
 }
 
 .sidebar .version {
-	border-bottom-color: #DDD;
+	border-bottom-color: #424c57;
 }
 
 .sidebar-title {
@@ -198,7 +203,7 @@ pre.rust .comment, pre.rust .doccomment {
 }
 
 nav:not(.sidebar) {
-	border-bottom-color: #e0e0e0;
+	border-bottom-color: #424c57;
 }
 nav.main .current {
 	border-top-color: #5c6773;
@@ -227,22 +232,19 @@ a {
 #crate-search {
 	color: #c5c5c5;
 	background-color: #141920;
-	border-radius: 4px;
-	box-shadow: none;
-	border-color: #5c6773;
+	box-shadow: 0 0 0 1px #424c57,0 0 0 2px transparent;
+	border-color: #424c57;
 }
 
 .search-input {
     color: #ffffff;
     background-color: #141920;
-    box-shadow: none;
+    box-shadow: 0 0 0 1px #424c57,0 0 0 2px transparent;
     transition: box-shadow 150ms ease-in-out;
-    border-radius: 4px;
-    margin-left: 8px;
 }
 
 #crate-search+.search-input:focus {
-    box-shadow: 0px 6px 20px 0px black;
+    box-shadow: 0 0 0 1px #148099,0 0 0 2px transparent;
 }
 
 .search-focus:disabled {

--- a/src/librustdoc/html/static/themes/ayu.css
+++ b/src/librustdoc/html/static/themes/ayu.css
@@ -70,11 +70,6 @@ pre {
 	scrollbar-color: #5c6773 transparent;
 }
 
-.logo-container > img {
-	/* Make dark logos better visible in supported browsers */
-	filter: drop-shadow(0 0 30px rgba(255,255,255,0.7));
-}
-
 /* Improve the scrollbar display on webkit-based browsers */
 ::-webkit-scrollbar-track {
 	background-color: transparent;


### PR DESCRIPTION
This PR changes the following:

* It makes some lines darker
* It gives the crate selector and search bar a border
  * The search bar's border turns blue when focused
* ~~Gives the logo a bright shadow.~~

For standard library crates, it would be better to invert the logo, but that would be bad for crates with a colored logo, e.g. [async-std](https://docs.rs/async-std/1.6.2/async_std/).

Before:

![old](https://user-images.githubusercontent.com/15658558/87576611-ed4e0800-c6d1-11ea-9667-3924702f79e2.png)

After (note that this PR no longer includes the white shadow of the logo):

![new](https://user-images.githubusercontent.com/15658558/87576621-ef17cb80-c6d1-11ea-8e15-5d7f8b180c07.png)
