### PR TITLE
test caching opt_const_param_of on disc

### DIFF
--- a/src/librustc_middle/query/mod.rs
+++ b/src/librustc_middle/query/mod.rs
@@ -103,9 +103,13 @@ rustc_queries! {
         /// // ^ While calling `opt_const_param_of` for other bodies returns `None`.
         /// }
         /// ```
+        // It looks like caching this query on disk actually slightly
+        // worsened performance in #74376.
+        //
+        // Once const generics are more prevalently used, we might want to
+        // consider only caching calls returning `Some`.
         query opt_const_param_of(key: LocalDefId) -> Option<DefId> {
             desc { |tcx| "computing the optional const parameter of `{}`", tcx.def_path_str(key.to_def_id()) }
-            // FIXME(#74113): consider storing this query on disk.
         }
 
         /// Records the type of every item.


### PR DESCRIPTION
Followup to #74113, implements parts of #74360 

Tried caching `opt_const_param_of` on disk and adding an early exit if `tcx.dep_kind(def_id) != DefKind::AnonConst`.

Ended up causing a perf regression instead, so we just remove the FIXME and a short note to `opt_const_param_of`.

r? @eddyb