### PR TITLE
Move libstd's default feature to libtest

### DIFF
--- a/src/libstd/Cargo.toml
+++ b/src/libstd/Cargo.toml
@@ -47,8 +47,6 @@ hermit-abi = { version = "0.1.14", features = ['rustc-dep-of-std'] }
 wasi = { version = "0.9.0", features = ['rustc-dep-of-std'], default-features = false }
 
 [features]
-default = ["std_detect_file_io", "std_detect_dlsym_getauxval", "panic-unwind"]
-
 backtrace = [
   "backtrace_rs/dbghelp",          # backtrace/symbolize on MSVC
   "backtrace_rs/libbacktrace",     # symbolize on most platforms

--- a/src/libtest/Cargo.toml
+++ b/src/libtest/Cargo.toml
@@ -23,9 +23,12 @@ proc_macro = { path = "../libproc_macro" }
 
 # Forward features to the `std` crate as necessary
 [features]
+default = ["std_detect_file_io", "std_detect_dlsym_getauxval", "panic-unwind"]
 backtrace = ["std/backtrace"]
 compiler-builtins-c = ["std/compiler-builtins-c"]
 llvm-libunwind = ["std/llvm-libunwind"]
 panic-unwind = ["std/panic_unwind"]
 panic_immediate_abort = ["std/panic_immediate_abort"]
 profiler = ["std/profiler"]
+std_detect_file_io = ["std/std_detect_file_io"]
+std_detect_dlsym_getauxval = ["std/std_detect_dlsym_getauxval"]


### PR DESCRIPTION
This commit makes it so `std` no longer has a `default` feature, but
instead the `test` crate has a `default` feature doing the same thing.
The purpose of this commit is to allow Cargo's `-Zbuild-std` command,
which could customize the features of the standard library, to handle
the `default` feature for libstd. Currently Cargo's `-Zbuild-std`
support starts at libtests's manifest as the entry point to the std set
of crates.