### PR TITLE
WIP: move the 'record all toolstates' list into rustbuild

### DIFF
--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -383,6 +383,7 @@ impl<'a> Builder<'a> {
                 describe!(check::Std, check::Rustc, check::Rustdoc, check::Clippy)
             }
             Kind::Test => describe!(
+                crate::toolstate::ToolStateRecord,
                 crate::toolstate::ToolStateCheck,
                 test::ExpandYamlAnchors,
                 test::Tidy,
@@ -561,6 +562,10 @@ impl<'a> Builder<'a> {
 
     pub fn execute_cli(&self) {
         self.run_step_descriptions(&Builder::get_step_descriptions(self.kind), &self.paths);
+    }
+
+    pub fn execute_cli_for_paths(&self, paths: &[PathBuf]) {
+        self.run_step_descriptions(&Builder::get_step_descriptions(self.kind), paths);
     }
 
     pub fn default_doc(&self, paths: Option<&[PathBuf]>) {

--- a/src/ci/docker/host-x86_64/x86_64-gnu-tools/checktools.sh
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-tools/checktools.sh
@@ -5,22 +5,14 @@ set -eu
 X_PY="$1"
 
 # Try to test all the tools and store the build/test success in the TOOLSTATE_FILE
-
 set +e
-python3 "$X_PY" test --no-fail-fast \
-    src/doc/book \
-    src/doc/nomicon \
-    src/doc/reference \
-    src/doc/rust-by-example \
-    src/doc/embedded-book \
-    src/doc/edition-guide \
-    src/tools/rls \
-    src/tools/rustfmt \
-    src/tools/miri \
-
+python3 "$X_PY" test --no-fail-fast record-toolstate
 set -e
-
 # debugging: print out the saved toolstates
 cat /tmp/toolstate/toolstates.json
+# Check the JSON to ensure that there are no unexpected tool failures.
 python3 "$X_PY" test check-tools
+
+# Clippy is not part of the toolstate system;
+# just test it the regular way.
 python3 "$X_PY" test src/tools/clippy


### PR DESCRIPTION
Currently, we still build Miri on beta/stable branches to record its toolstate. That seems rather unnecessary. This is a beginning of an attempt to fix that.

However, I think I have to give up here... I have no idea if this `execute_cli_for_paths` makes any sense; the control flow in rustbuild is entirely impossible to follow.^^ For some reason `--dry-run` does not work for my new target (it does nothing). Maybe that is because of this `execute_cli`; I tried to understand the [existing `dry_run` logic](https://github.com/rust-lang/rust/blob/c724b67e1b474262917a5154d74e7072267593fe/src/bootstrap/lib.rs#L484) but it is very strange (if this is not a dry run then the first thing we do is set `dry_run` to true?!??) and there are no comments explaining what happens.

I am pretty sure what I have so far is wrong; the code in `toolstate.rs` all assumes that *all* tools have a state recorded in the JSON:

https://github.com/rust-lang/rust/blob/c724b67e1b474262917a5154d74e7072267593fe/src/bootstrap/toolstate.rs#L182

and this loop looks like it makes similar assumptions:

https://github.com/rust-lang/rust/blob/c724b67e1b474262917a5154d74e7072267593fe/src/bootstrap/toolstate.rs#L125

@Mark-Simulacrum I think someone who actually understands the maze that is rustbuild needs to complete this. It would take me forever to figure this all out, I have no idea how to test any of this with reasonable effort, and it's just not enough of a problem I think to warrant that amount of effort.