### PR TITLE
Don't assign `()` to `!` MIR locals

### DIFF
--- a/src/test/mir-opt/issue-49232/rustc.main.mir_map.0.mir
+++ b/src/test/mir-opt/issue-49232/rustc.main.mir_map.0.mir
@@ -79,13 +79,6 @@ fn main() -> () {
     }
 
     bb10: {
-        _4 = const ();                   // scope 0 at $DIR/issue-49232.rs:10:25: 10:30
-                                         // ty::Const
-                                         // + ty: ()
-                                         // + val: Value(Scalar(<ZST>))
-                                         // mir::Constant
-                                         // + span: $DIR/issue-49232.rs:10:25: 10:30
-                                         // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
         unreachable;                     // scope 0 at $DIR/issue-49232.rs:10:25: 10:30
     }
 


### PR DESCRIPTION
Implements the fix described in https://github.com/rust-lang/rust/issues/73860#issuecomment-651731893.

Fixes https://github.com/rust-lang/rust/issues/73860

r? @matthewjasper 