### PR TITLE
Add a thumbv4t-none-eabi target

### DIFF
--- a/src/librustc_target/spec/mod.rs
+++ b/src/librustc_target/spec/mod.rs
@@ -676,7 +676,7 @@ supported_targets! {
     ("powerpc64-wrs-vxworks", powerpc64_wrs_vxworks),
 
     ("mipsel-sony-psp", mipsel_sony_psp),
-    ("thumbv4t-nintendo-gba", thumbv4t_nintendo_gba),
+    ("thumbv4t-none-eabi", thumbv4t_none_eabi),
 }
 
 /// Everything `rustc` knows about how to compile for a specific target.

--- a/src/librustc_target/spec/mod.rs
+++ b/src/librustc_target/spec/mod.rs
@@ -676,6 +676,7 @@ supported_targets! {
     ("powerpc64-wrs-vxworks", powerpc64_wrs_vxworks),
 
     ("mipsel-sony-psp", mipsel_sony_psp),
+    ("thumbv4t-nintendo-gba", thumbv4t_nintendo_gba),
 }
 
 /// Everything `rustc` knows about how to compile for a specific target.

--- a/src/librustc_target/spec/thumbv4t_nintendo_gba.rs
+++ b/src/librustc_target/spec/thumbv4t_nintendo_gba.rs
@@ -62,9 +62,6 @@ pub fn target() -> TargetResult {
             // ABIs to not use
             unsupported_abis: super::arm_base::unsupported_abis(),
 
-            // The minimum alignment for global symbols.
-            min_global_align: Some(4),
-
             // this is off just like in the `thumb_base`
             emit_debug_gdb_scripts: false,
 

--- a/src/librustc_target/spec/thumbv4t_nintendo_gba.rs
+++ b/src/librustc_target/spec/thumbv4t_nintendo_gba.rs
@@ -65,9 +65,6 @@ pub fn target() -> TargetResult {
             // The minimum alignment for global symbols.
             min_global_align: Some(4),
 
-            // GBA has no builtins
-            no_builtins: true,
-
             // this is off just like in the `thumb_base`
             emit_debug_gdb_scripts: false,
 

--- a/src/librustc_target/spec/thumbv4t_nintendo_gba.rs
+++ b/src/librustc_target/spec/thumbv4t_nintendo_gba.rs
@@ -1,0 +1,30 @@
+//! Targets the Nintendo Game Boy Advance (GBA).
+//!
+//! The GBA is a handheld game device from 2001. Inside, the CPU is an ARM7TDMI.
+//! That's in the ARMv4T architecture family.
+//!
+//! Technically the device has no OS, however we're going to copy the
+//! `mipsel_sony_psp` target setup and set the OS string to be "GBA". Other than
+//! the setting of the `target_os` and `target_vendor` values, this target is a
+//! fairly standard configuration for `thumbv4t`
+
+use crate::spec::{LinkerFlavor, LldFlavor, Target, TargetOptions, TargetResult};
+
+pub fn target() -> TargetResult {
+    Ok(Target {
+        llvm_target: "thumbv4t-none-eabi".to_string(),
+        target_endian: "little".to_string(),
+        target_pointer_width: "32".to_string(),
+        target_c_int_width: "32".to_string(),
+        target_os: "gba".to_string(),
+        target_env: String::new(),
+        target_vendor: "nintendo".to_string(),
+        arch: "arm".to_string(),
+        data_layout: "TODO".to_string(),
+        linker_flavor: LinkerFlavor::Ld,
+        options: TargetOptions {
+            // TODO
+            ..TargetOptions::default()
+        },
+    })
+}

--- a/src/librustc_target/spec/thumbv4t_nintendo_gba.rs
+++ b/src/librustc_target/spec/thumbv4t_nintendo_gba.rs
@@ -1,11 +1,11 @@
-//! Targets the Nintendo Game Boy Advance (GBA), a handheld game device from 2001.
+//! Targets the Nintendo Game Boy Advance (GBA),
+//! a handheld game device from 2001.
 //!
 //! Please ping @Lokathor if changes are needed.
 //!
-//! Important: This target **does not** specify a linker script or the ROM
-//! header. You'll still need to provide these yourself to construct a final
-//! binary. Generally you'd do this with something like
-//! `-Clink-arg=-Tmy_script.ld` and `-Clink-arg=my_crt.o`.
+//! The target profile assumes that you have the ARM binutils in your path (specifically the linker, `arm-none-eabi-ld`). They can be obtained for free for all major OSes from the ARM developer's website, and they may also be available in your system's package manager
+//!
+//! **Important:** This target profile **does not** specify a linker script or the ROM header. You'll still need to provide these yourself to construct a final  binary. Generally you'd do this with something like `-Clink-arg=-Tmy_script.ld` and `-Clink-arg=my_crt.o`.
 
 use crate::spec::{LinkerFlavor, LldFlavor, Target, TargetOptions, TargetResult};
 

--- a/src/librustc_target/spec/thumbv4t_nintendo_gba.rs
+++ b/src/librustc_target/spec/thumbv4t_nintendo_gba.rs
@@ -1,12 +1,11 @@
-//! Targets the Nintendo Game Boy Advance (GBA).
+//! Targets the Nintendo Game Boy Advance (GBA), a handheld game device from 2001.
 //!
-//! The GBA is a handheld game device from 2001. Inside, the CPU is an ARM7TDMI.
-//! That's in the ARMv4T architecture family.
+//! Please ping @Lokathor if changes are needed.
 //!
-//! Technically the device has no OS, however we're going to copy the
-//! `mipsel_sony_psp` target setup and set the OS string to be "GBA". Other than
-//! the setting of the `target_os` and `target_vendor` values, this target is a
-//! fairly standard configuration for `thumbv4t`
+//! Important: This target **does not** specify a linker script or the ROM
+//! header. You'll still need to provide these yourself to construct a final
+//! binary. Generally you'd do this with something like
+//! `-Clink-arg=-Tmy_script.ld` and `-Clink-arg=my_crt.o`.
 
 use crate::spec::{LinkerFlavor, LldFlavor, Target, TargetOptions, TargetResult};
 
@@ -16,14 +15,65 @@ pub fn target() -> TargetResult {
         target_endian: "little".to_string(),
         target_pointer_width: "32".to_string(),
         target_c_int_width: "32".to_string(),
-        target_os: "gba".to_string(),
-        target_env: String::new(),
+        target_os: "none".to_string(),
+        target_env: "gba".to_string(),
         target_vendor: "nintendo".to_string(),
         arch: "arm".to_string(),
-        data_layout: "TODO".to_string(),
+        /* Data layout args are '-' separated:
+         * little endian
+         * stack is 64-bit aligned (EABI)
+         * pointers are 32-bit
+         * i64 must be 64-bit aligned (EABI)
+         * mangle names with ELF style
+         * native integers are 32-bit
+         * All other elements are default
+         */
+        data_layout: "e-S64-p:32:32-i64:64-m:e-n32".to_string(),
         linker_flavor: LinkerFlavor::Ld,
         options: TargetOptions {
-            // TODO
+            linker: Some("arm-none-eabi-ld".to_string()),
+            linker_is_gnu: true,
+
+            // extra args passed to the external assembler
+            asm_args: vec!["-mcpu=arm7tdmi".to_string(), "-mthumb-interwork".to_string()],
+
+            cpu: "arm7tdmi".to_string(),
+
+            // minimum extra features, these cannot be disabled via -C
+            features: "+soft-float,+strict-align".to_string(),
+
+            executables: true,
+
+            relocation_model: RelocModel::Static,
+
+            //function_sections: bool,
+            //exe_suffix: String,
+            main_needs_argc_argv: false,
+
+            // if we have thread-local storage
+            has_elf_tls: false,
+
+            // don't have atomic compare-and-swap
+            atomic_cas: false,
+
+            // always just abort
+            panic_strategy: PanicStrategy::Abort,
+
+            // ABIs to not use
+            unsupported_abis: super::arm_base::unsupported_abis(),
+
+            // The minimum alignment for global symbols.
+            min_global_align: Some(4),
+
+            // no threads here
+            singlethread: true,
+
+            // GBA has no builtins
+            no_builtins: true,
+
+            // this is off just like in the `thumb_base`
+            emit_debug_gdb_scripts: false,
+
             ..TargetOptions::default()
         },
     })

--- a/src/librustc_target/spec/thumbv4t_nintendo_gba.rs
+++ b/src/librustc_target/spec/thumbv4t_nintendo_gba.rs
@@ -65,9 +65,6 @@ pub fn target() -> TargetResult {
             // The minimum alignment for global symbols.
             min_global_align: Some(4),
 
-            // no threads here
-            singlethread: true,
-
             // GBA has no builtins
             no_builtins: true,
 

--- a/src/librustc_target/spec/thumbv4t_nintendo_gba.rs
+++ b/src/librustc_target/spec/thumbv4t_nintendo_gba.rs
@@ -46,8 +46,6 @@ pub fn target() -> TargetResult {
 
             relocation_model: RelocModel::Static,
 
-            //function_sections: bool,
-            //exe_suffix: String,
             main_needs_argc_argv: false,
 
             // if we have thread-local storage

--- a/src/librustc_target/spec/thumbv4t_nintendo_gba.rs
+++ b/src/librustc_target/spec/thumbv4t_nintendo_gba.rs
@@ -7,7 +7,7 @@
 //!
 //! **Important:** This target profile **does not** specify a linker script or the ROM header. You'll still need to provide these yourself to construct a final  binary. Generally you'd do this with something like `-Clink-arg=-Tmy_script.ld` and `-Clink-arg=my_crt.o`.
 
-use crate::spec::{LinkerFlavor, LldFlavor, Target, TargetOptions, TargetResult};
+use crate::spec::{LinkerFlavor, PanicStrategy, RelocModel, Target, TargetOptions, TargetResult};
 
 pub fn target() -> TargetResult {
     Ok(Target {

--- a/src/librustc_target/spec/thumbv4t_none_eabi.rs
+++ b/src/librustc_target/spec/thumbv4t_none_eabi.rs
@@ -48,10 +48,6 @@ pub fn target() -> TargetResult {
             // minimum extra features, these cannot be disabled via -C
             features: "+soft-float,+strict-align".to_string(),
 
-            executables: true,
-
-            relocation_model: RelocModel::Static,
-
             main_needs_argc_argv: false,
 
             // No thread-local storage (just use a static Cell)
@@ -60,16 +56,7 @@ pub fn target() -> TargetResult {
             // don't have atomic compare-and-swap
             atomic_cas: false,
 
-            // always just abort
-            panic_strategy: PanicStrategy::Abort,
-
-            // ABIs to not use
-            unsupported_abis: super::arm_base::unsupported_abis(),
-
-            // this is turned off just like in the `thumb_base` module
-            emit_debug_gdb_scripts: false,
-
-            ..TargetOptions::default()
+            ..super::thumb_base::opts()
         },
     })
 }

--- a/src/librustc_target/spec/thumbv4t_none_eabi.rs
+++ b/src/librustc_target/spec/thumbv4t_none_eabi.rs
@@ -8,7 +8,7 @@
 //!
 //! **Important:** This target profile **does not** specify a linker script. You just get the default link script when you build a binary for this target. The default link script is very likely wrong, so you should use `-Clink-arg=-Tmy_script.ld` to override that with a correct linker script.
 
-use crate::spec::{LinkerFlavor, PanicStrategy, RelocModel, Target, TargetOptions, TargetResult};
+use crate::spec::{LinkerFlavor, Target, TargetOptions, TargetResult};
 
 pub fn target() -> TargetResult {
     Ok(Target {


### PR DESCRIPTION
(cc @ketsuban, one of the few other Rust users who programs for GBA.)

---

**EDIT:** This is now a more general `thumbv4t-none-eabi` PR! See [this comment](https://github.com/rust-lang/rust/pull/74419#issuecomment-660391579)

---

Now that the PSP officially has an official target within Rust, well as the lead of the `gba` crate I can't _not_ add a GBA target as well.

I know that the [target tier policy](https://github.com/rust-lang/rfcs/pull/2803) isn't ratified and official, but I'll use it as an outline (cc @joshtriplett):
* Designated Developer: Lokathor
* Naming consistent with any existing targets
* Doesn't create Rust project legal issues.
* No license issues
* Uses the standard Apache/mit license.
* Rust tooling users don't have to accept any new licensing requirements
* Does not support hosting rust tooling.
* Doesn't require linking in proprietary code to obtain a functional binary. However, you will need to do some post-build steps to turn the ELF file into a usable GBA ROM (either for an emulator or for the actual hardware).
* This is a `no_std` environment, without even a standard global allocator, so this adds no new code to `alloc` or `std`.
* The process of building for this target is documented in the `gba` crate ([link](https://rust-console.github.io/gba/development-setup.html)). Well, the docs there are currently a little out of date, they're back on using `cargo-xbuild`, but the crate docs there will get updated once this target is available.
* This places no new burden on any other targets
* Does not break any existing targets.

I'm not fully confident in specifying the same linker script for all possible projects, so I'm currently just not giving a linker script at all, and users can continue to select their own linker script by using `-C` to provide a linker arg.

I added the file, and added it to the `supported_targets!` macro usage, and I think that's all there is to do.