### PR TITLE
intra-doc links: resolve modules in the type namespace

### DIFF
--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -584,25 +584,18 @@ impl<'a, 'tcx> DocFolder for LinkCollector<'a, 'tcx> {
             let (res, fragment) = {
                 let mut kind = None;
                 let mut disambiguator = None;
-                path_str = if let Some(prefix) = ["struct@", "enum@", "type@", "trait@", "union@"]
-                    .iter()
-                    .find(|p| link.starts_with(**p))
+                path_str = if let Some(prefix) =
+                    ["struct@", "enum@", "type@", "trait@", "union@", "module@", "mod@"]
+                        .iter()
+                        .find(|p| link.starts_with(**p))
                 {
                     kind = Some(TypeNS);
                     disambiguator = Some(&prefix[..prefix.len() - 1]);
                     link.trim_start_matches(prefix)
-                } else if let Some(prefix) = [
-                    "const@",
-                    "static@",
-                    "value@",
-                    "function@",
-                    "mod@",
-                    "fn@",
-                    "module@",
-                    "method@",
-                ]
-                .iter()
-                .find(|p| link.starts_with(**p))
+                } else if let Some(prefix) =
+                    ["const@", "static@", "value@", "function@", "fn@", "method@"]
+                        .iter()
+                        .find(|p| link.starts_with(**p))
                 {
                     kind = Some(ValueNS);
                     disambiguator = Some(&prefix[..prefix.len() - 1]);

--- a/src/test/rustdoc/intra-doc-link-mod-ambiguity.rs
+++ b/src/test/rustdoc/intra-doc-link-mod-ambiguity.rs
@@ -1,0 +1,18 @@
+// ignore-tidy-linelength
+
+#![deny(intra_doc_link_resolution_failure)]
+
+
+pub fn foo() {
+
+}
+
+pub mod foo {}
+// @has intra_doc_link_mod_ambiguity/struct.A.html '//a/@href' '../intra_doc_link_mod_ambiguity/foo/index.html'
+/// Module is [`module@foo`]
+pub struct A;
+
+
+// @has intra_doc_link_mod_ambiguity/struct.B.html '//a/@href' '../intra_doc_link_mod_ambiguity/fn.foo.html'
+/// Function is [`fn@foo`]
+pub struct B;


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/62830

Modules actually live in the type namespace, not all three, and it's not possible to clash a type with a module.