### PR TITLE
rustbuild: drop tool::should_install

### DIFF
--- a/src/bootstrap/install.rs
+++ b/src/bootstrap/install.rs
@@ -159,11 +159,6 @@ macro_rules! install {
                 config.extended && config.tools.as_ref()
                     .map_or(true, |t| t.contains($path))
             }
-
-            #[allow(dead_code)]
-            fn should_install(builder: &Builder<'_>) -> bool {
-                builder.config.tools.as_ref().map_or(false, |t| t.contains($path))
-            }
         }
 
         impl Step for $name {
@@ -210,8 +205,7 @@ install!((self, builder, _config),
         install_cargo(builder, self.compiler.stage, self.target);
     };
     Rls, "rls", Self::should_build(_config), only_hosts: true, {
-        if builder.ensure(dist::Rls { compiler: self.compiler, target: self.target }).is_some() ||
-            Self::should_install(builder) {
+        if builder.ensure(dist::Rls { compiler: self.compiler, target: self.target }).is_some() {
             install_rls(builder, self.compiler.stage, self.target);
         } else {
             builder.info(
@@ -221,27 +215,14 @@ install!((self, builder, _config),
     };
     RustAnalyzer, "rust-analyzer", Self::should_build(_config), only_hosts: true, {
         builder.ensure(dist::RustAnalyzer { compiler: self.compiler, target: self.target });
-        if Self::should_install(builder) {
-            install_rust_analyzer(builder, self.compiler.stage, self.target);
-        } else {
-            builder.info(
-                &format!("skipping Install rust-analyzer stage{} ({})", self.compiler.stage, self.target),
-            );
-        }
+        install_rust_analyzer(builder, self.compiler.stage, self.target);
     };
     Clippy, "clippy", Self::should_build(_config), only_hosts: true, {
         builder.ensure(dist::Clippy { compiler: self.compiler, target: self.target });
-        if Self::should_install(builder) {
-            install_clippy(builder, self.compiler.stage, self.target);
-        } else {
-            builder.info(
-                &format!("skipping Install clippy stage{} ({})", self.compiler.stage, self.target),
-            );
-        }
+        install_clippy(builder, self.compiler.stage, self.target);
     };
     Miri, "miri", Self::should_build(_config), only_hosts: true, {
-        if builder.ensure(dist::Miri { compiler: self.compiler, target: self.target }).is_some() ||
-            Self::should_install(builder) {
+        if builder.ensure(dist::Miri { compiler: self.compiler, target: self.target }).is_some() {
             install_miri(builder, self.compiler.stage, self.target);
         } else {
             builder.info(
@@ -253,7 +234,7 @@ install!((self, builder, _config),
         if builder.ensure(dist::Rustfmt {
             compiler: self.compiler,
             target: self.target
-        }).is_some() || Self::should_install(builder) {
+        }).is_some() {
             install_rustfmt(builder, self.compiler.stage, self.target);
         } else {
             builder.info(


### PR DESCRIPTION
Always install when the build succeeds

Fixes #74431