### PR TITLE
Use pathdiff crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2143,6 +2143,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pathdiff"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877630b3de15c0b64cc52f659345724fbf6bdad9bd9566699fc53688f3c34a34"
+
+[[package]]
 name = "percent-encoding"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3318,6 +3324,7 @@ dependencies = [
  "log",
  "memmap",
  "num_cpus",
+ "pathdiff",
  "rustc_apfloat",
  "rustc_ast",
  "rustc_attr",

--- a/src/librustc_codegen_ssa/Cargo.toml
+++ b/src/librustc_codegen_ssa/Cargo.toml
@@ -18,6 +18,7 @@ log = "0.4.5"
 libc = "0.2.50"
 jobserver = "0.1.11"
 tempfile = "3.1"
+pathdiff = "0.2.0"
 
 rustc_serialize = { path = "../librustc_serialize" }
 rustc_ast = { path = "../librustc_ast" }

--- a/src/librustc_codegen_ssa/back/rpath.rs
+++ b/src/librustc_codegen_ssa/back/rpath.rs
@@ -1,8 +1,8 @@
+use pathdiff::diff_paths;
 use rustc_data_structures::fx::FxHashSet;
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
-use pathdiff::diff_paths;
 
 use rustc_hir::def_id::CrateNum;
 use rustc_middle::middle::cstore::LibSource;

--- a/src/librustc_codegen_ssa/back/rpath.rs
+++ b/src/librustc_codegen_ssa/back/rpath.rs
@@ -2,6 +2,7 @@ use rustc_data_structures::fx::FxHashSet;
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
+use pathdiff::diff_paths;
 
 use rustc_hir::def_id::CrateNum;
 use rustc_middle::middle::cstore::LibSource;
@@ -109,37 +110,7 @@ fn get_rpath_relative_to_output(config: &mut RPathConfig<'_>, lib: &Path) -> Str
 // In particular, this handles the case on unix where both paths are
 // absolute but with only the root as the common directory.
 fn path_relative_from(path: &Path, base: &Path) -> Option<PathBuf> {
-    use std::path::Component;
-
-    if path.is_absolute() != base.is_absolute() {
-        path.is_absolute().then(|| PathBuf::from(path))
-    } else {
-        let mut ita = path.components();
-        let mut itb = base.components();
-        let mut comps: Vec<Component<'_>> = vec![];
-        loop {
-            match (ita.next(), itb.next()) {
-                (None, None) => break,
-                (Some(a), None) => {
-                    comps.push(a);
-                    comps.extend(ita.by_ref());
-                    break;
-                }
-                (None, _) => comps.push(Component::ParentDir),
-                (Some(a), Some(b)) if comps.is_empty() && a == b => (),
-                (Some(a), Some(b)) if b == Component::CurDir => comps.push(a),
-                (Some(_), Some(b)) if b == Component::ParentDir => return None,
-                (Some(a), Some(_)) => {
-                    comps.push(Component::ParentDir);
-                    comps.extend(itb.map(|_| Component::ParentDir));
-                    comps.push(a);
-                    comps.extend(ita.by_ref());
-                    break;
-                }
-            }
-        }
-        Some(comps.iter().map(|c| c.as_os_str()).collect())
-    }
+    diff_paths(path, base)
 }
 
 fn get_install_prefix_rpath(config: &mut RPathConfig<'_>) -> String {

--- a/src/tools/tidy/src/deps.rs
+++ b/src/tools/tidy/src/deps.rs
@@ -123,6 +123,7 @@ const PERMITTED_DEPENDENCIES: &[&str] = &[
     "opaque-debug",
     "parking_lot",
     "parking_lot_core",
+    "pathdiff",
     "pkg-config",
     "polonius-engine",
     "ppv-lite86",


### PR DESCRIPTION
I wanted to tackle a simple issue, and stumbled upon #67108: this pr removes the function which was exported to the external crate as required in the todo/issue.
I've tested it with:
```
./x.py build --stage 1 --keep-stage 1 src/librustc_codegen_ssa 
```
And it looks like it's compiling