### PR TITLE
Revert "Use an UTF-8 locale for the linker."

### DIFF
--- a/src/librustc_codegen_ssa/back/linker.rs
+++ b/src/librustc_codegen_ssa/back/linker.rs
@@ -28,9 +28,7 @@ use rustc_target::spec::{LinkOutputKind, LinkerFlavor, LldFlavor};
 pub fn disable_localization(linker: &mut Command) {
     // No harm in setting both env vars simultaneously.
     // Unix-style linkers.
-    // We use an UTF-8 locale, as the generic C locale disables support for non-ASCII
-    // bytes in filenames on some platforms.
-    linker.env("LC_ALL", "en_US.UTF-8");
+    linker.env("LC_ALL", "C");
     // MSVC's `link.exe`.
     linker.env("VSLANG", "1033");
 }


### PR DESCRIPTION
Reverts rust-lang/rust#74416

This is suspected to have caused significant compile time regressions: https://perf.rust-lang.org/compare.html?start=39d5a61f2e4e237123837f5162cc275c2fd7e625&end=d3df8512d2c2afc6d2e7d8b5b951dd7f2ad77b02&stat=instructions:u