### PR TITLE
Forbid generic parameters in anon consts inside of type defaults

### DIFF
--- a/src/librustc_resolve/diagnostics.rs
+++ b/src/librustc_resolve/diagnostics.rs
@@ -455,6 +455,17 @@ impl<'a> Resolver<'a> {
                 );
                 err
             }
+            ResolutionError::ParamInAnonConstInTyDefault(name) => {
+                let mut err = self.session.struct_span_err(
+                    span,
+                    "constant values inside of type parameter defaults must not depend on generic parameters",
+                );
+                err.span_label(
+                    span,
+                    format!("the anonymous constant must not depend on the parameter `{}`", name),
+                );
+                err
+            }
             ResolutionError::SelfInTyParamDefault => {
                 let mut err = struct_span_err!(
                     self.session,

--- a/src/librustc_resolve/diagnostics.rs
+++ b/src/librustc_resolve/diagnostics.rs
@@ -442,7 +442,7 @@ impl<'a> Resolver<'a> {
                 );
                 err
             }
-            ResolutionError::ParamInTyOfConstArg(name) => {
+            ResolutionError::ParamInTyOfConstParam(name) => {
                 let mut err = struct_span_err!(
                     self.session,
                     span,

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -216,6 +216,8 @@ enum ResolutionError<'a> {
     ForwardDeclaredTyParam, // FIXME(const_generics:defaults)
     /// ERROR E0770: the type of const parameters must not depend on other generic parameters.
     ParamInTyOfConstParam(Symbol),
+    /// constant values inside of type parameter defaults must not depend on generic parameters.
+    ParamInAnonConstInTyDefault(Symbol),
     /// Error E0735: type parameters with a default cannot use `Self`
     SelfInTyParamDefault,
     /// Error E0767: use of unreachable label
@@ -2526,18 +2528,40 @@ impl<'a> Resolver<'a> {
                 }
             }
             Res::Def(DefKind::TyParam, _) | Res::SelfTy(..) => {
+                let mut in_ty_param_default = false;
                 for rib in ribs {
                     let has_generic_params = match rib.kind {
                         NormalRibKind
                         | ClosureOrAsyncRibKind
                         | AssocItemRibKind
                         | ModuleRibKind(..)
-                        | MacroDefinition(..)
-                        | ForwardTyParamBanRibKind
-                        | ConstantItemRibKind => {
+                        | MacroDefinition(..) => {
                             // Nothing to do. Continue.
                             continue;
                         }
+
+                        // We only forbid constant items if we are inside of type defaults,
+                        // for example `struct Foo<T, U = [u8; std::mem::size_of::<T>()]>`
+                        ForwardTyParamBanRibKind => {
+                            in_ty_param_default = true;
+                            continue;
+                        }
+                        ConstantItemRibKind => {
+                            if in_ty_param_default {
+                                if record_used {
+                                    self.report_error(
+                                        span,
+                                        ResolutionError::ParamInAnonConstInTyDefault(
+                                            rib_ident.name,
+                                        ),
+                                    );
+                                }
+                                return Res::Err;
+                            } else {
+                                continue;
+                            }
+                        }
+
                         // This was an attempt to use a type parameter outside its scope.
                         ItemRibKind(has_generic_params) => has_generic_params,
                         FnItemRibKind => HasGenericParams::Yes,
@@ -2572,15 +2596,38 @@ impl<'a> Resolver<'a> {
                     // (spuriously) conflicting with the const param.
                     ribs.next();
                 }
+
+                let mut in_ty_param_default = false;
                 for rib in ribs {
                     let has_generic_params = match rib.kind {
                         NormalRibKind
                         | ClosureOrAsyncRibKind
                         | AssocItemRibKind
                         | ModuleRibKind(..)
-                        | MacroDefinition(..)
-                        | ForwardTyParamBanRibKind
-                        | ConstantItemRibKind => continue,
+                        | MacroDefinition(..) => continue,
+
+                        // We only forbid constant items if we are inside of type defaults,
+                        // for example `struct Foo<T, U = [u8; std::mem::size_of::<T>()]>`
+                        ForwardTyParamBanRibKind => {
+                            in_ty_param_default = true;
+                            continue;
+                        }
+                        ConstantItemRibKind => {
+                            if in_ty_param_default {
+                                if record_used {
+                                    self.report_error(
+                                        span,
+                                        ResolutionError::ParamInAnonConstInTyDefault(
+                                            rib_ident.name,
+                                        ),
+                                    );
+                                }
+                                return Res::Err;
+                            } else {
+                                continue;
+                            }
+                        }
+
                         ItemRibKind(has_generic_params) => has_generic_params,
                         FnItemRibKind => HasGenericParams::Yes,
                         ConstParamTyRibKind => {

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -215,7 +215,7 @@ enum ResolutionError<'a> {
     /// Error E0128: type parameters with a default cannot use forward-declared identifiers.
     ForwardDeclaredTyParam, // FIXME(const_generics:defaults)
     /// ERROR E0770: the type of const parameters must not depend on other generic parameters.
-    ParamInTyOfConstArg(Symbol),
+    ParamInTyOfConstParam(Symbol),
     /// Error E0735: type parameters with a default cannot use `Self`
     SelfInTyParamDefault,
     /// Error E0767: use of unreachable label
@@ -2514,7 +2514,7 @@ impl<'a> Resolver<'a> {
                         }
                         ConstParamTyRibKind => {
                             if record_used {
-                                self.report_error(span, ParamInTyOfConstArg(rib_ident.name));
+                                self.report_error(span, ParamInTyOfConstParam(rib_ident.name));
                             }
                             return Res::Err;
                         }
@@ -2545,7 +2545,7 @@ impl<'a> Resolver<'a> {
                             if record_used {
                                 self.report_error(
                                     span,
-                                    ResolutionError::ParamInTyOfConstArg(rib_ident.name),
+                                    ResolutionError::ParamInTyOfConstParam(rib_ident.name),
                                 );
                             }
                             return Res::Err;
@@ -2587,7 +2587,7 @@ impl<'a> Resolver<'a> {
                             if record_used {
                                 self.report_error(
                                     span,
-                                    ResolutionError::ParamInTyOfConstArg(rib_ident.name),
+                                    ResolutionError::ParamInTyOfConstParam(rib_ident.name),
                                 );
                             }
                             return Res::Err;

--- a/src/test/ui/const-generics/params-in-ct-in-ty-param-lazy-norm.rs
+++ b/src/test/ui/const-generics/params-in-ct-in-ty-param-lazy-norm.rs
@@ -1,0 +1,10 @@
+#![feature(const_generics)] //~ WARN the feature `const_generics` is incomplete
+
+struct Foo<T, U = [u8; std::mem::size_of::<T>()]>(T, U);
+//~^ ERROR constant values inside of type parameter defaults
+
+// FIXME(const_generics:defaults): We still don't know how to we deal with type defaults.
+struct Bar<T = [u8; N], const N: usize>(T);
+//~^ ERROR constant values inside of type parameter defaults
+
+fn main() {}

--- a/src/test/ui/const-generics/params-in-ct-in-ty-param-lazy-norm.rs
+++ b/src/test/ui/const-generics/params-in-ct-in-ty-param-lazy-norm.rs
@@ -6,5 +6,6 @@ struct Foo<T, U = [u8; std::mem::size_of::<T>()]>(T, U);
 // FIXME(const_generics:defaults): We still don't know how to we deal with type defaults.
 struct Bar<T = [u8; N], const N: usize>(T);
 //~^ ERROR constant values inside of type parameter defaults
+//~| ERROR type parameters with a default
 
 fn main() {}

--- a/src/test/ui/const-generics/params-in-ct-in-ty-param-lazy-norm.stderr
+++ b/src/test/ui/const-generics/params-in-ct-in-ty-param-lazy-norm.stderr
@@ -1,0 +1,23 @@
+error: constant values inside of type parameter defaults must not depend on generic parameters
+  --> $DIR/params-in-ct-in-ty-param-lazy-norm.rs:3:44
+   |
+LL | struct Foo<T, U = [u8; std::mem::size_of::<T>()]>(T, U);
+   |                                            ^ the anonymous constant must not depend on the parameter `T`
+
+error: constant values inside of type parameter defaults must not depend on generic parameters
+  --> $DIR/params-in-ct-in-ty-param-lazy-norm.rs:7:21
+   |
+LL | struct Bar<T = [u8; N], const N: usize>(T);
+   |                     ^ the anonymous constant must not depend on the parameter `N`
+
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/params-in-ct-in-ty-param-lazy-norm.rs:1:12
+   |
+LL | #![feature(const_generics)]
+   |            ^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
+
+error: aborting due to 2 previous errors; 1 warning emitted
+

--- a/src/test/ui/const-generics/params-in-ct-in-ty-param-lazy-norm.stderr
+++ b/src/test/ui/const-generics/params-in-ct-in-ty-param-lazy-norm.stderr
@@ -1,3 +1,11 @@
+error: type parameters with a default must be trailing
+  --> $DIR/params-in-ct-in-ty-param-lazy-norm.rs:7:12
+   |
+LL | struct Bar<T = [u8; N], const N: usize>(T);
+   |            ^
+   |
+   = note: using type defaults and const parameters in the same parameter list is currently not permitted
+
 error: constant values inside of type parameter defaults must not depend on generic parameters
   --> $DIR/params-in-ct-in-ty-param-lazy-norm.rs:3:44
    |
@@ -19,5 +27,5 @@ LL | #![feature(const_generics)]
    = note: `#[warn(incomplete_features)]` on by default
    = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
 
-error: aborting due to 2 previous errors; 1 warning emitted
+error: aborting due to 3 previous errors; 1 warning emitted
 

--- a/src/test/ui/generic/param-in-ct-in-ty-param-default.rs
+++ b/src/test/ui/generic/param-in-ct-in-ty-param-default.rs
@@ -1,0 +1,4 @@
+struct Foo<T, U = [u8; std::mem::size_of::<T>()]>(T, U);
+//~^ ERROR constant values inside of type parameter defaults
+
+fn main() {}

--- a/src/test/ui/generic/param-in-ct-in-ty-param-default.stderr
+++ b/src/test/ui/generic/param-in-ct-in-ty-param-default.stderr
@@ -1,0 +1,8 @@
+error: constant values inside of type parameter defaults must not depend on generic parameters
+  --> $DIR/param-in-ct-in-ty-param-default.rs:1:44
+   |
+LL | struct Foo<T, U = [u8; std::mem::size_of::<T>()]>(T, U);
+   |                                            ^ the anonymous constant must not depend on the parameter `T`
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Emit a resolution error for `struct Foo<T, U = [u8; std::mem::size_of::<T>()]>`.
We are unable to support this with the way `ty::Generics` is currently used,
so let's just forbid it entirely for now.

Fixes some ICE on stable, e.g.
```rust
struct Foo<T, U = [u8; std::mem::size_of::<*mut T>()]>(T, U);
```

r? @varkor @eddyb