### PR TITLE
Put panic code path from `copy_from_slice` into cold function

### DIFF
--- a/library/alloc/tests/slice.rs
+++ b/library/alloc/tests/slice.rs
@@ -1522,7 +1522,7 @@ fn test_copy_from_slice() {
 }
 
 #[test]
-#[should_panic(expected = "destination and source slices have different lengths")]
+#[should_panic(expected = "source slice length (4) does not match destination slice length (5)")]
 fn test_copy_from_slice_dst_longer() {
     let src = [0, 1, 2, 3];
     let mut dst = [0; 5];
@@ -1530,7 +1530,7 @@ fn test_copy_from_slice_dst_longer() {
 }
 
 #[test]
-#[should_panic(expected = "destination and source slices have different lengths")]
+#[should_panic(expected = "source slice length (4) does not match destination slice length (3)")]
 fn test_copy_from_slice_dst_shorter() {
     let src = [0, 1, 2, 3];
     let mut dst = [0; 3];


### PR DESCRIPTION
The previous `assert_eq` generated quite some code, which is especially problematic when this call is inlined. This commit also slightly improves the panic message from:

    assertion failed: `(left == right)`
      left: `3`,
     right: `2`: destination and source slices have different lengths

...to:

    source slice length (2) does not match destination slice length (3)

You can see the code bloat in assembly [here](https://rust.godbolt.org/z/74a3qo).