### PR TITLE
do not try fetching the ancestors of errored trait impls

### DIFF
--- a/src/librustc_middle/traits/specialization_graph.rs
+++ b/src/librustc_middle/traits/specialization_graph.rs
@@ -1,5 +1,6 @@
 use crate::ich::{self, StableHashingContext};
 use crate::ty::fast_reject::SimplifiedType;
+use crate::ty::fold::TypeFoldable;
 use crate::ty::{self, TyCtxt};
 use rustc_data_structures::fx::FxHashMap;
 use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
@@ -226,7 +227,8 @@ pub fn ancestors(
     start_from_impl: DefId,
 ) -> Result<Ancestors<'tcx>, ErrorReported> {
     let specialization_graph = tcx.specialization_graph_of(trait_def_id);
-    if specialization_graph.has_errored {
+
+    if specialization_graph.has_errored || tcx.type_of(start_from_impl).references_error() {
         Err(ErrorReported)
     } else {
         Ok(Ancestors {

--- a/src/test/ui/specialization/min_specialization/impl-on-nonexisting.rs
+++ b/src/test/ui/specialization/min_specialization/impl-on-nonexisting.rs
@@ -1,0 +1,7 @@
+#![feature(min_specialization)]
+
+trait Trait {}
+impl Trait for NonExistent {}
+//~^ ERROR cannot find type `NonExistent` in this scope
+
+fn main() {}

--- a/src/test/ui/specialization/min_specialization/impl-on-nonexisting.stderr
+++ b/src/test/ui/specialization/min_specialization/impl-on-nonexisting.stderr
@@ -1,0 +1,9 @@
+error[E0412]: cannot find type `NonExistent` in this scope
+  --> $DIR/impl-on-nonexisting.rs:4:16
+   |
+LL | impl Trait for NonExistent {}
+   |                ^^^^^^^^^^^ not found in this scope
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0412`.


### PR DESCRIPTION
fixes #74483

While building the specialization graph, we use `tcx.all_impls` which discards impls with incorrect self types,
we do however call `trait_def.ancestors` with these impls which caused an ICE as they aren't part of the
specialization graph.