### PR TITLE
include backtrace folder in rust-src component

### DIFF
--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -1005,6 +1005,7 @@ impl Step for Src {
         // (essentially libstd and all of its path dependencies)
         let std_src_dirs = [
             "src/build_helper",
+            "src/backtrace",
             "src/liballoc",
             "src/libcore",
             "src/libpanic_abort",


### PR DESCRIPTION
libstd has a [mandatory dependency on this code](https://github.com/rust-lang/rust/pull/73441/files#diff-242481015141f373dcb178e93cffa850), ergo we need to include it in rust-src.

r? @oli-obk 
Fixes https://github.com/rust-lang/rust/issues/74506