### PR TITLE
Only skip impls of foreign unstable traits

### DIFF
--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -346,9 +346,11 @@ pub fn build_impl(
         // such. This helps prevent dependencies of the standard library, for
         // example, from getting documented as "traits `u32` implements" which
         // isn't really too helpful.
-        if let Some(stab) = cx.tcx.lookup_stability(did) {
-            if stab.level.is_unstable() {
-                return;
+        if let Some(trait_did) = associated_trait {
+            if let Some(stab) = cx.tcx.lookup_stability(trait_did.def_id) {
+                if stab.level.is_unstable() {
+                    return;
+                }
             }
         }
     }

--- a/src/test/rustdoc/auxiliary/unstable-trait.rs
+++ b/src/test/rustdoc/auxiliary/unstable-trait.rs
@@ -1,0 +1,26 @@
+#![feature(staged_api)]
+#![stable(feature = "private_general", since = "1.0.0")]
+
+#[unstable(feature = "private_trait", issue = "none")]
+pub trait Bar {}
+
+#[stable(feature = "private_general", since = "1.0.0")]
+pub struct Foo {
+    // nothing
+}
+
+impl Foo {
+    #[stable(feature = "private_general", since = "1.0.0")]
+    pub fn stable_impl() {}
+}
+
+impl Foo {
+    #[unstable(feature = "private_trait", issue = "none")]
+    pub fn bar() {}
+
+    #[stable(feature = "private_general", since = "1.0.0")]
+    pub fn bar2() {}
+}
+
+#[stable(feature = "private_general", since = "1.0.0")]
+impl Bar for Foo {}

--- a/src/test/rustdoc/hide-unstable-trait.rs
+++ b/src/test/rustdoc/hide-unstable-trait.rs
@@ -1,0 +1,11 @@
+// aux-build:unstable-trait.rs
+
+#![crate_name = "foo"]
+#![feature(private_trait)]
+
+extern crate unstable_trait;
+
+// @has foo/struct.Foo.html 'bar'
+// @has foo/struct.Foo.html 'bar2'
+#[doc(inline)]
+pub use unstable_trait::Foo;


### PR DESCRIPTION
Previously unstable impls were skipped, which meant that any impl with an unstable method would get skipped.

Fixes #74531.