### PR TITLE
fix documentation surrounding the `in` and `for` keywords

### DIFF
--- a/src/libstd/keyword_docs.rs
+++ b/src/libstd/keyword_docs.rs
@@ -473,8 +473,8 @@ mod fn_keyword {}
 /// * `for` is also used for [higher-ranked trait bounds] as in `for<'a> &'a T: PartialEq<i32>`.
 ///
 /// for-in-loops, or to be more precise, iterator loops, are a simple syntactic sugar over a common
-/// practice within Rust, which is to loop over an iterator until that iterator returns `None` (or
-/// `break` is called).
+/// practice within Rust, which is to loop over anything that implements `IntoIterator` until the
+/// temporary iterator returns `None` (or `break` is called).
 ///
 /// ```rust
 /// for i in 0..5 {

--- a/src/libstd/keyword_docs.rs
+++ b/src/libstd/keyword_docs.rs
@@ -473,7 +473,7 @@ mod fn_keyword {}
 /// * `for` is also used for [higher-ranked trait bounds] as in `for<'a> &'a T: PartialEq<i32>`.
 ///
 /// for-in-loops, or to be more precise, iterator loops, are a simple syntactic sugar over a common
-/// practice within Rust, which is to loop over anything that implements `IntoIterator` until the
+/// practice within Rust, which is to loop over anything that implements [`IntoIterator`] until the
 /// temporary iterator returns `None` (or `break` is called).
 ///
 /// ```rust

--- a/src/libstd/keyword_docs.rs
+++ b/src/libstd/keyword_docs.rs
@@ -680,7 +680,7 @@ mod impl_keyword {}
 //
 /// Iterate over a series of values with [`for`].
 ///
-/// The expression immediately following `in` must implement the [`Iterator`] trait.
+/// The expression immediately following `in` must implement the [`IntoIterator`] trait.
 ///
 /// ## Literal Examples:
 ///
@@ -689,7 +689,7 @@ mod impl_keyword {}
 ///
 /// (Read more about [range patterns])
 ///
-/// [`Iterator`]: ../book/ch13-04-performance.html
+/// [`IntoIterator`]: ../book/ch13-04-performance.html
 /// [range patterns]: ../reference/patterns.html?highlight=range#range-patterns
 /// [`for`]: keyword.for.html
 mod in_keyword {}

--- a/src/libstd/keyword_docs.rs
+++ b/src/libstd/keyword_docs.rs
@@ -474,7 +474,7 @@ mod fn_keyword {}
 ///
 /// for-in-loops, or to be more precise, iterator loops, are a simple syntactic sugar over a common
 /// practice within Rust, which is to loop over anything that implements [`IntoIterator`] until the
-/// temporary iterator returns `None` (or `break` is called).
+/// iterator returned by `.into_iter()` returns `None` (or the loop body uses `break`).
 ///
 /// ```rust
 /// for i in 0..5 {


### PR DESCRIPTION
Addresses #74529 

The `in` keyword incorrectly referenced the `Iterator` trait. This reference was changed to `IntoIterator` without changing the underlying link.

Additionally, the `IntoIterator` trait was referenced towards the end of the documentation for `for`. An additional reference was added earlier and broadened the existing documentation from any iterator to anything that can be turned into an iterator. 