### PR TITLE
std: Fix compilation without backtrace feature

### DIFF
--- a/src/libstd/Cargo.toml
+++ b/src/libstd/Cargo.toml
@@ -27,7 +27,7 @@ hashbrown = { version = "0.6.2", default-features = false, features = ['rustc-de
 
 # Dependencies of the `backtrace` crate
 addr2line = { version = "0.13.0", optional = true, default-features = false }
-rustc-demangle = { version = "0.1.4", optional = true }
+rustc-demangle = { version = "0.1.4", features = ['rustc-dep-of-std'] }
 miniz_oxide = { version = "0.4.0", optional = true, default-features = false }
 [dependencies.object]
 version = "0.20"
@@ -55,7 +55,6 @@ backtrace = [
   "gimli-symbolize",
   'addr2line/rustc-dep-of-std',
   'object/rustc-dep-of-std',
-  'rustc-demangle/rustc-dep-of-std',
   'miniz_oxide/rustc-dep-of-std',
 ]
 gimli-symbolize = []


### PR DESCRIPTION
This should hopefully handle #74484 but in any case fixes compilation of
the standard library without the `backtrace` feature. The need for this
feature is somewhat unclear now because the `backtrace` crate should
always compile (no more C code!) but we can handle that later if
necessary.