### PR TITLE
Inlined symbols

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3688,6 +3688,7 @@ dependencies = [
 name = "rustc_macros"
 version = "0.1.0"
 dependencies = [
+ "indexmap",
  "proc-macro2",
  "quote",
  "syn",

--- a/compiler/rustc_macros/Cargo.toml
+++ b/compiler/rustc_macros/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 proc-macro = true
 
 [dependencies]
+indexmap = "1"
 synstructure = "0.12.1"
 syn = { version = "1", features = ["full"] }
 proc-macro2 = "1"

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1556,11 +1556,6 @@ impl Symbol {
         self == kw::Try
     }
 
-    /// Used for sanity checking rustdoc keyword sections.
-    pub fn is_doc_keyword(self) -> bool {
-        self <= kw::Union
-    }
-
     /// A keyword or reserved identifier that can be used as a path segment.
     pub fn is_path_segment_keyword(self) -> bool {
         self == kw::Super

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -25,12 +25,14 @@ symbols! {
     Keywords {
         // Special reserved identifiers used internally for elided lifetimes,
         // unnamed method parameters, crate root module, error recovery etc.
+        fn is_special:
         Invalid:            "",
         PathRoot:           "{{root}}",
         DollarCrate:        "$crate",
         Underscore:         "_",
 
-        // Keywords that are used in stable Rust.
+        // Keywords that are used in stable Rust on all editions.
+        fn is_used_keyword_20xx:
         As:                 "as",
         Break:              "break",
         Const:              "const",
@@ -67,7 +69,8 @@ symbols! {
         Where:              "where",
         While:              "while",
 
-        // Keywords that are used in unstable Rust or reserved for future use.
+        // Keywords that are used in unstable Rust or reserved for future use on all editions.
+        fn is_unused_keyword_20xx:
         Abstract:           "abstract",
         Become:             "become",
         Box:                "box",
@@ -82,18 +85,22 @@ symbols! {
         Yield:              "yield",
 
         // Edition-specific keywords that are used in stable Rust.
+        fn is_used_keyword_2018:
         Async:              "async", // >= 2018 Edition only
         Await:              "await", // >= 2018 Edition only
         Dyn:                "dyn", // >= 2018 Edition only
 
         // Edition-specific keywords that are used in unstable Rust or reserved for future use.
+        fn is_unused_keyword_2018:
         Try:                "try", // >= 2018 Edition only
 
         // Special lifetime names
+        fn is_special_lifetime:
         UnderscoreLifetime: "'_",
         StaticLifetime:     "'static",
 
         // Weak keywords, have special meaning only in specific contexts.
+        fn is_weak_keyword:
         Auto:               "auto",
         Catch:              "catch",
         Default:            "default",
@@ -1548,14 +1555,6 @@ pub mod sym {
 }
 
 impl Symbol {
-    fn is_used_keyword_2018(self) -> bool {
-        self >= kw::Async && self <= kw::Dyn
-    }
-
-    fn is_unused_keyword_2018(self) -> bool {
-        self == kw::Try
-    }
-
     /// A keyword or reserved identifier that can be used as a path segment.
     pub fn is_path_segment_keyword(self) -> bool {
         self == kw::Super
@@ -1581,20 +1580,20 @@ impl Ident {
     // Returns `true` for reserved identifiers used internally for elided lifetimes,
     // unnamed method parameters, crate root module, error recovery etc.
     pub fn is_special(self) -> bool {
-        self.name <= kw::Underscore
+        self.name.is_special()
     }
 
     /// Returns `true` if the token is a keyword used in the language.
     pub fn is_used_keyword(self) -> bool {
         // Note: `span.edition()` is relatively expensive, don't call it unless necessary.
-        self.name >= kw::As && self.name <= kw::While
+        self.name.is_used_keyword_20xx()
             || self.name.is_used_keyword_2018() && self.span.rust_2018()
     }
 
     /// Returns `true` if the token is a keyword reserved for possible future use.
     pub fn is_unused_keyword(self) -> bool {
         // Note: `span.edition()` is relatively expensive, don't call it unless necessary.
-        self.name >= kw::Abstract && self.name <= kw::Yield
+        self.name.is_unused_keyword_20xx()
             || self.name.is_unused_keyword_2018() && self.span.rust_2018()
     }
 

--- a/compiler/rustc_span/src/symbol/tests.rs
+++ b/compiler/rustc_span/src/symbol/tests.rs
@@ -3,23 +3,99 @@ use super::*;
 use crate::{edition, SessionGlobals};
 
 #[test]
-fn interner_tests() {
-    let mut i: Interner = Interner::default();
-    // first one is zero:
-    assert_eq!(i.intern("dog"), Symbol::new(0));
-    // re-use gets the same entry:
-    assert_eq!(i.intern("dog"), Symbol::new(0));
-    // different string gets a different #:
-    assert_eq!(i.intern("cat"), Symbol::new(1));
-    assert_eq!(i.intern("cat"), Symbol::new(1));
-    // dog is still at zero
-    assert_eq!(i.intern("dog"), Symbol::new(0));
+fn symbol_tests() {
+    let sym = |n| Some(Symbol(SymbolIndex::from_u32(n)));
+
+    // Simple ASCII symbols.
+    assert_eq!(Symbol::try_new_inlined(""), sym(0x00_00_00_00));
+    assert_eq!(Symbol::try_new_inlined("a"), sym(0x00_00_00_61));
+    assert_eq!(Symbol::try_new_inlined("ab"), sym(0x00_00_62_61));
+    assert_eq!(Symbol::try_new_inlined("abc"), sym(0x00_63_62_61));
+    assert_eq!(Symbol::try_new_inlined("abcd"), sym(0x64_63_62_61));
+    assert_eq!(Symbol::try_new_inlined("abcde"), None); // too long
+    assert_eq!(Symbol::try_new_inlined("abcdefghijklmnopqrstuvwxyz"), None); // too long
+
+    // Symbols involving non-ASCII chars.
+    // Note that the UTF-8 sequence for 'é' is `[0xc3, 0xa9]`.
+    assert_eq!(Symbol::try_new_inlined("é"), sym(0x00_00_a9_c3));
+    assert_eq!(Symbol::try_new_inlined("dé"), sym(0x00_a9_c3_64));
+    assert_eq!(Symbol::try_new_inlined("édc"), sym(0x63_64_a9_c3));
+    assert_eq!(Symbol::try_new_inlined("cdé"), None); // byte 3 (0xa9) is > 0x7f
+
+    // Symbols involving NUL chars.
+    assert_eq!(Symbol::try_new_inlined("\0"), None); // last byte is NUL
+    assert_eq!(Symbol::try_new_inlined("a\0"), None); // last byte is NUL
+    assert_eq!(Symbol::try_new_inlined("\0a"), sym(0x00_00_61_00));
+    assert_eq!(Symbol::try_new_inlined("aa\0"), None); // last byte is NUL
+    assert_eq!(Symbol::try_new_inlined("\0\0a"), sym(0x00_61_00_00));
+    assert_eq!(Symbol::try_new_inlined("aaa\0"), None); // last byte is NUL
+    assert_eq!(Symbol::try_new_inlined("\0\0\0a"), sym(0x61_00_00_00));
+
+    // Tabled symbols.
+    assert_eq!(Symbol::new_tabled(0).as_u32(), 0x80000000);
+    assert_eq!(Symbol::new_tabled(5).as_u32(), 0x80000005);
+    assert_eq!(Symbol::new_tabled(0x123456).as_u32(), 0x80123456);
+
+    // Tabled symbol indices.
+    assert_eq!(Symbol::new_tabled(0).as_tabled_index(), 0);
+    assert_eq!(Symbol::new_tabled(5).as_tabled_index(), 5);
+    assert_eq!(Symbol::new_tabled(0x123456).as_tabled_index(), 0x123456);
 }
 
 #[test]
-fn without_first_quote_test() {
+fn symbol_interner_tests() {
     SESSION_GLOBALS.set(&SessionGlobals::new(edition::DEFAULT_EDITION), || {
+        let inlined = |s, n, len| {
+            // Check the symbol and the deinterned string look right.
+            let sym = Symbol::intern(s);
+            assert_eq!(sym.as_u32(), n);
+            sym.with(|w| w == s);
+            assert_eq!(sym.as_str(), s);
+            assert_eq!(sym.as_str().len(), len);
+        };
+
+        let tabled = |s, len| {
+            // Check the symbol and the deinterned string look right.
+            let sym = Symbol::intern(s);
+            assert!(sym.as_u32() & 0x80000000 != 0);
+            sym.with(|w| w == s);
+            assert_eq!(sym.as_str(), s);
+            assert_eq!(sym.as_str().len(), len);
+        };
+
+        // Inlined symbols, lengths 1..=4.
+        // Note that the UTF-8 sequence for 'é' is `[0xc3, 0xa9]`.
+        inlined("", 0x00_00_00_00, 0);
+        inlined("a", 0x00_00_00_61, 1);
+        inlined("é", 0x00_00_a9_c3, 2);
+        inlined("dé", 0x00_a9_c3_64, 3);
+        inlined("édc", 0x63_64_a9_c3, 4);
+
+        // Tabled symbols.
+        tabled("abcde", 5); // tabled due to length
+        tabled("cdé", 4); // tabled due to the fourth byte being > 0x7f
+        tabled("a\0", 2); // tabled due to the last byte being NUL
+
+        // Test `without_first_quote()`.
         let i = Ident::from_str("'break");
         assert_eq!(i.without_first_quote().name, kw::Break);
     });
+}
+
+#[test]
+fn interner_tests() {
+    let mut i: Interner = Interner::default();
+
+    // Note that going directly through `Interner` means that no inlined
+    // symbols are made.
+
+    // First long one is zero.
+    assert_eq!(i.intern("dog"), Symbol::new_tabled(0));
+    // Re-use gets the same entry.
+    assert_eq!(i.intern("dog"), Symbol::new_tabled(0));
+    // Different string gets a different index.
+    assert_eq!(i.intern("salamander"), Symbol::new_tabled(1));
+    assert_eq!(i.intern("salamander"), Symbol::new_tabled(1));
+    // Dog is still at zero.
+    assert_eq!(i.intern("dog"), Symbol::new_tabled(0));
 }

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -170,11 +170,8 @@ impl Clean<ExternalCrate> for CrateNum {
                 for attr in attrs.lists(sym::doc) {
                     if let Some(v) = attr.value_str() {
                         if attr.has_name(sym::keyword) {
-                            if v.is_doc_keyword() {
-                                keyword = Some(v.to_string());
-                                break;
-                            }
-                            // FIXME: should warn on unknown keywords?
+                            keyword = Some(v.to_string());
+                            break;
                         }
                     }
                 }


### PR DESCRIPTION
The idea here is to encode symbols that are 4 bytes or shorter directly in the `u32`, and only use the hash table for longer symbols. Avoiding the hash table accesses should speed things up.

r? @ghost