### PR TITLE
Improve "important traits" popup display on mobile

### DIFF
--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -1511,6 +1511,11 @@ h4 > .important-traits {
 	#main > .line-numbers {
 		margin-top: 0;
 	}
+
+	.important-traits .important-traits-tooltiptext {
+		left: 0;
+		top: 100%;
+	}
 }
 
 @media print {


### PR DESCRIPTION
I implemented what @XAMPPRocky suggested in the [internals thread topic](https://internals.rust-lang.org/t/feedback-on-important-traits-rustdoc-feature/12752/18). I can confirm it works nicely.

r? @Manishearth 

@Manishearth: By the way: I realized that when you click on the "i", you have to click again to make the popup disappear. Do you want me to extend the popup removal to any click outside the popup?