### PR TITLE
Allow eliminating the frame pointer on x86_64-apple-darwin

### DIFF
--- a/src/librustc_target/spec/x86_64_apple_darwin.rs
+++ b/src/librustc_target/spec/x86_64_apple_darwin.rs
@@ -4,7 +4,6 @@ pub fn target() -> TargetResult {
     let mut base = super::apple_base::opts();
     base.cpu = "core2".to_string();
     base.max_atomic_width = Some(128); // core2 support cmpxchg16b
-    base.eliminate_frame_pointer = false;
     base.pre_link_args.insert(LinkerFlavor::Gcc, vec!["-m64".to_string()]);
     base.link_env_remove.extend(super::apple_base::macos_link_env_remove());
     base.stack_probes = true;


### PR DESCRIPTION
Quoting @alexcrichton:

> the fp elim here comes from the code contents of the patch:
>
> ```rust
>     // FIXME: #11906: Omitting frame pointers breaks retrieving the value of a parameter.
>     // FIXME: #11954: mac64 unwinding may not work with fp elim
>     let no_fp_elim = (sess.opts.debuginfo != NoDebugInfo) ||
>                      (sess.targ_cfg.os == abi::OsMacos &&
>                       sess.targ_cfg.arch == abi::X86_64);
> ```
>
>
> which points to https://github.com/rust-lang/rust/issues/11954 which
> I believe was [incorrectly closed][] (only references i686, not
> x86_64).
>
> This sounds vaguely familiar about how it's related to
> unwinding. This also is the definition of something lost to time
> which we unfortunately lost track of :(.
>
> [incorrectly closed]: https://github.com/rust-lang/rust/issues/11954#issuecomment-283374851

r? @alexcrichton 