### PR TITLE
Fix rust-src component.

### DIFF
--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -1005,7 +1005,7 @@ impl Step for Src {
         // (essentially libstd and all of its path dependencies)
         let std_src_dirs = [
             "src/build_helper",
-            "src/backtrace",
+            "src/backtrace/src",
             "src/liballoc",
             "src/libcore",
             "src/libpanic_abort",


### PR DESCRIPTION
The rust-src component could not be installed by rustup because it included some symbolic links. #74520 added the backtrace directory which included some symlinks. Since the rust-src component doesn't need most of the files in the `backtrace` submodule, this changes it to only include the minimum necessary.

Tested with cargo's build-std that it can build from the resulting tarball.

Fixes #74577