### PR TITLE
Permit (Release, Acquire) ordering for compare_exchange[_weak] and add appropriate compiler intrinsic

### DIFF
--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -104,6 +104,18 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `compare_exchange` method by passing
+    /// [`Ordering::Release`](../../std/sync/atomic/enum.Ordering.html)
+    /// as the `success` and
+    /// [`Ordering::Acquire`](../../std/sync/atomic/enum.Ordering.html)
+    /// as the `failure` parameters. For example,
+    /// [`AtomicBool::compare_exchange`][compare_exchange].
+    ///
+    /// [compare_exchange]: ../../std/sync/atomic/struct.AtomicBool.html#method.compare_exchange
+    pub fn atomic_cxchg_rel_acq<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
+    /// Stores a value if the current value is the same as the `old` value.
+    ///
+    /// The stabilized version of this intrinsic is available on the
+    /// `std::sync::atomic` types via the `compare_exchange` method by passing
     /// [`Ordering::AcqRel`](../../std/sync/atomic/enum.Ordering.html)
     /// as the `success` and
     /// [`Ordering::Acquire`](../../std/sync/atomic/enum.Ordering.html)
@@ -203,6 +215,18 @@ extern "rust-intrinsic" {
     ///
     /// [cew]: ../../std/sync/atomic/struct.AtomicBool.html#method.compare_exchange_weak
     pub fn atomic_cxchgweak_rel<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
+    /// Stores a value if the current value is the same as the `old` value.
+    ///
+    /// The stabilized version of this intrinsic is available on the
+    /// `std::sync::atomic` types via the `compare_exchange_weak` method by passing
+    /// [`Ordering::Release`](../../std/sync/atomic/enum.Ordering.html)
+    /// as the `success` and
+    /// [`Ordering::Acquire`](../../std/sync/atomic/enum.Ordering.html)
+    /// as the `failure` parameters. For example,
+    /// [`AtomicBool::compare_exchange_weak`][cew].
+    ///
+    /// [cew]: ../../std/sync/atomic/struct.AtomicBool.html#method.compare_exchange_weak
+    pub fn atomic_cxchgweak_rel_acq<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
     /// Stores a value if the current value is the same as the `old` value.
     ///
     /// The stabilized version of this intrinsic is available on the

--- a/library/core/src/sync/atomic.rs
+++ b/library/core/src/sync/atomic.rs
@@ -2421,6 +2421,8 @@ unsafe fn atomic_compare_exchange<T: Copy>(
     let (val, ok) = unsafe {
         match (success, failure) {
             (Acquire, Acquire) => intrinsics::atomic_cxchg_acq(dst, old, new),
+            #[cfg(not(bootstrap))]
+            (Release, Acquire) => intrinsics::atomic_cxchg_rel_acq(dst, old, new),
             (Release, Relaxed) => intrinsics::atomic_cxchg_rel(dst, old, new),
             (AcqRel, Acquire) => intrinsics::atomic_cxchg_acqrel(dst, old, new),
             (Relaxed, Relaxed) => intrinsics::atomic_cxchg_relaxed(dst, old, new),
@@ -2450,6 +2452,8 @@ unsafe fn atomic_compare_exchange_weak<T: Copy>(
     let (val, ok) = unsafe {
         match (success, failure) {
             (Acquire, Acquire) => intrinsics::atomic_cxchgweak_acq(dst, old, new),
+            #[cfg(not(bootstrap))]
+            (Release, Acquire) => intrinsics::atomic_cxchgweak_rel_acq(dst, old, new),
             (Release, Relaxed) => intrinsics::atomic_cxchgweak_rel(dst, old, new),
             (AcqRel, Acquire) => intrinsics::atomic_cxchgweak_acqrel(dst, old, new),
             (Relaxed, Relaxed) => intrinsics::atomic_cxchgweak_relaxed(dst, old, new),

--- a/src/librustc_codegen_llvm/intrinsic.rs
+++ b/src/librustc_codegen_llvm/intrinsic.rs
@@ -702,6 +702,7 @@ impl IntrinsicCallMethods<'tcx> for Builder<'a, 'll, 'tcx> {
                         _ => self.sess().fatal("unknown ordering in atomic intrinsic"),
                     },
                     4 => match (split[2], split[3]) {
+                        ("rel", "acq") if is_cxchg => (Release, Acquire),
                         ("acq", "failrelaxed") if is_cxchg => (Acquire, Monotonic),
                         ("acqrel", "failrelaxed") if is_cxchg => (AcquireRelease, Monotonic),
                         _ => self.sess().fatal("unknown ordering in atomic intrinsic"),


### PR DESCRIPTION
This will probably require further discussion, but according to my research the current rule of disallowing (`Release`, `Acquire`) as memory ordering for the atomic `compare_exchange[_weak]` primitives is unnecessarily strict and not actually required by the memory model.
[Here](https://users.rust-lang.org/t/why-does-rust-not-permit-cas-operations-with-release-acquire-ordering/40394/14) is a link to a previous discussion on that topic and here a link to a [question](http://lists.llvm.org/pipermail/llvm-dev/2020-April/140623.html) and [answer](http://lists.llvm.org/pipermail/llvm-dev/2020-April/140675.html) I've posted to the llvm-dev mailing list (my follow-up was unfortunately not answered). According to that answer, LLVM currently does **not** consider `Acquire` to be a *stronger* ordering than `Release` ([source code](https://github.com/llvm/llvm-project/blob/a5d375e0cbc4abf6e318270a1bc9c1c0961ae565/llvm/include/llvm/Support/AtomicOrdering.h#L89)) and apparently there are plans to drop the "relative strength" requirement altogether, since it is basically not really well-defined. 

[Here](https://godbolt.org/z/xEhKcf) is an example using `clang` on ARM that shows different assembly is generated when (`Release`, `Acquire`) is used instead of the next best approximation (`AcqRel`, `Acquire`).