### PR TITLE
Add some timing info to rustdoc

### DIFF
--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -484,9 +484,7 @@ pub fn run_core(options: RustdocOptions) -> (clean::Crate, RenderInfo, RenderOpt
                     tcx.ensure().check_mod_attrs(local_def_id);
                 }
 
-                let access_levels = tcx
-                    .sess
-                    .time("privacy_access_levels", || tcx.privacy_access_levels(LOCAL_CRATE));
+                let access_levels = tcx.privacy_access_levels(LOCAL_CRATE);
                 // Convert from a HirId set to a DefId set since we don't always have easy access
                 // to the map from defid -> hirid
                 let access_levels = AccessLevels {

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -457,7 +457,7 @@ pub fn run_core(options: RustdocOptions) -> (clean::Crate, RenderInfo, RenderOpt
 
             let mut global_ctxt = abort_on_err(queries.global_ctxt(), sess).take();
 
-            global_ctxt.enter(|tcx| run_global_ctxt(tcx, resolver, default_passes, manual_passes, render_options, output_format))
+            sess.time("run_global_ctxt", || global_ctxt.enter(|tcx| run_global_ctxt(tcx, resolver, default_passes, manual_passes, render_options, output_format)))
         })
     })
 }

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -409,7 +409,7 @@ pub fn run_core(
                 let hir = tcx.hir();
                 let body = hir.body(hir.body_owned_by(hir.local_def_id_to_hir_id(def_id)));
                 debug!("visiting body for {:?}", def_id);
-                tcx.sess.time("emit ignored resolution errors", || {
+                tcx.sess.time("emit_ignored_resolution_errors", || {
                 EmitIgnoredResolutionErrors::new(tcx).visit_body(body);
                 });
                 (rustc_interface::DEFAULT_QUERY_PROVIDERS.typeck)(tcx, def_id)
@@ -433,7 +433,7 @@ pub fn run_core(
                 // actually be loaded, just in case they're only referred to inside
                 // intra-doc-links
                 resolver.borrow_mut().access(|resolver| {
-                    sess.time("load extern crates", || {
+                    sess.time("load_extern_crates", || {
                     for extern_name in &extern_names {
                         resolver
                             .resolve_str_path_error(
@@ -551,7 +551,7 @@ fn run_global_ctxt(
                 };
                 debug!("crate: {:?}", tcx.hir().krate());
 
-                let mut krate = tcx.sess.time("clean crate", || clean::krate(&mut ctxt));
+    let mut krate = tcx.sess.time("clean_crate", || clean::krate(&mut ctxt));
 
                 if let Some(ref m) = krate.module {
                     if let None | Some("") = m.doc_value() {

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -431,8 +431,8 @@ pub fn run_core(options: RustdocOptions) -> (clean::Crate, RenderInfo, RenderOpt
                 // actually be loaded, just in case they're only referred to inside
                 // intra-doc-links
                 resolver.borrow_mut().access(|resolver| {
+                    sess.time("load extern crates", || {
                     for extern_name in &extern_names {
-                        sess.time("load extern crate", || {
                         resolver
                             .resolve_str_path_error(
                                 DUMMY_SP,
@@ -443,8 +443,8 @@ pub fn run_core(options: RustdocOptions) -> (clean::Crate, RenderInfo, RenderOpt
                             .unwrap_or_else(|()| {
                                 panic!("Unable to resolve external crate {}", extern_name)
                             });
-                        });
                     }
+                });
                 });
 
                 // Now we're good to clone the resolver because everything should be loaded

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -280,7 +280,9 @@ where
     (lint_opts, lint_caps)
 }
 
-pub fn run_core(options: RustdocOptions) -> (clean::Crate, RenderInfo, RenderOptions) {
+pub fn run_core(
+    options: RustdocOptions,
+) -> (clean::Crate, RenderInfo, RenderOptions, Lrc<Session>) {
     // Parse, resolve, and typecheck the given crate.
 
     let RustdocOptions {
@@ -457,7 +459,7 @@ pub fn run_core(options: RustdocOptions) -> (clean::Crate, RenderInfo, RenderOpt
 
             let mut global_ctxt = abort_on_err(queries.global_ctxt(), sess).take();
 
-            sess.time("run_global_ctxt", || {
+            let (krate, render_info, opts) = sess.time("run_global_ctxt", || {
                 global_ctxt.enter(|tcx| {
                     run_global_ctxt(
                         tcx,
@@ -468,7 +470,8 @@ pub fn run_core(options: RustdocOptions) -> (clean::Crate, RenderInfo, RenderOpt
                         output_format,
                     )
                 })
-            })
+            });
+            (krate, render_info, opts, Lrc::clone(sess))
         })
     })
 }

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -524,10 +524,10 @@ fn main_options(options: config::Options) -> MainResult {
     let (error_format, edition, debugging_options) = diag_opts;
     let diag = core::new_handler(error_format, None, &debugging_options);
     match output_format {
-        None | Some(config::OutputFormat::Html) => sess.time("render html", || {
+        None | Some(config::OutputFormat::Html) => sess.time("render_html", || {
             run_renderer::<html::render::Context>(krate, renderopts, renderinfo, &diag, edition)
         }),
-        Some(config::OutputFormat::Json) => sess.time("render json", || {
+        Some(config::OutputFormat::Json) => sess.time("render_json", || {
             run_renderer::<json::JsonRenderer>(krate, renderopts, renderinfo, &diag, edition)
         }),
     }

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -501,7 +501,7 @@ fn main_options(options: config::Options) -> MainResult {
     let crate_name = options.crate_name.clone();
     let crate_version = options.crate_version.clone();
     let output_format = options.output_format;
-    let (mut krate, renderinfo, renderopts) = core::run_core(options);
+    let (mut krate, renderinfo, renderopts, sess) = core::run_core(options);
 
     info!("finished with rustc");
 
@@ -524,11 +524,11 @@ fn main_options(options: config::Options) -> MainResult {
     let (error_format, edition, debugging_options) = diag_opts;
     let diag = core::new_handler(error_format, None, &debugging_options);
     match output_format {
-        None | Some(config::OutputFormat::Html) => {
+        None | Some(config::OutputFormat::Html) => sess.time("render html", || {
             run_renderer::<html::render::Context>(krate, renderopts, renderinfo, &diag, edition)
-        }
-        Some(config::OutputFormat::Json) => {
+        }),
+        Some(config::OutputFormat::Json) => sess.time("render json", || {
             run_renderer::<json::JsonRenderer>(krate, renderopts, renderinfo, &diag, edition)
-        }
+        }),
     }
 }

--- a/src/librustdoc/passes/collect_trait_impls.rs
+++ b/src/librustdoc/passes/collect_trait_impls.rs
@@ -29,7 +29,7 @@ pub fn collect_trait_impls(krate: Crate, cx: &DocContext<'_>) -> Crate {
 
     for &cnum in cx.tcx.crates().iter() {
         for &(did, _) in cx.tcx.all_trait_implementations(cnum).iter() {
-            cx.tcx.sess.time("build extern trait impl", || {
+            cx.tcx.sess.time("build_extern_trait_impl", || {
                 inline::build_impl(cx, did, None, &mut new_items);
             });
         }
@@ -89,7 +89,7 @@ pub fn collect_trait_impls(krate: Crate, cx: &DocContext<'_>) -> Crate {
     for &trait_did in cx.tcx.all_traits(LOCAL_CRATE).iter() {
         for &impl_node in cx.tcx.hir().trait_impls(trait_did) {
             let impl_did = cx.tcx.hir().local_def_id(impl_node);
-            cx.tcx.sess.time("build local trait impl", || {
+            cx.tcx.sess.time("build_local_trait_impl", || {
                 inline::build_impl(cx, impl_did.to_def_id(), None, &mut new_items);
             });
         }

--- a/src/librustdoc/passes/collect_trait_impls.rs
+++ b/src/librustdoc/passes/collect_trait_impls.rs
@@ -29,7 +29,9 @@ pub fn collect_trait_impls(krate: Crate, cx: &DocContext<'_>) -> Crate {
 
     for &cnum in cx.tcx.crates().iter() {
         for &(did, _) in cx.tcx.all_trait_implementations(cnum).iter() {
-            inline::build_impl(cx, did, None, &mut new_items);
+            cx.tcx.sess.time("build extern trait impl", || {
+                inline::build_impl(cx, did, None, &mut new_items);
+            });
         }
     }
 
@@ -87,7 +89,9 @@ pub fn collect_trait_impls(krate: Crate, cx: &DocContext<'_>) -> Crate {
     for &trait_did in cx.tcx.all_traits(LOCAL_CRATE).iter() {
         for &impl_node in cx.tcx.hir().trait_impls(trait_did) {
             let impl_did = cx.tcx.hir().local_def_id(impl_node);
-            inline::build_impl(cx, impl_did.to_def_id(), None, &mut new_items);
+            cx.tcx.sess.time("build local trait impl", || {
+                inline::build_impl(cx, impl_did.to_def_id(), None, &mut new_items);
+            });
         }
     }
 


### PR DESCRIPTION
There are various improvements, but the main one is to time each pass
that rustdoc performs (`rustdoc::passes`).

Before, these were the top five timings for `cargo doc` on the cargo
repository:

```
+---------------------------------+-----------+-----------------+----------+------------+
| Item                            | Self time | % of total time | Time     | Item count |
+---------------------------------+-----------+-----------------+----------+------------+
| <unknown>                       | 854.70ms  | 20.888          | 2.47s    | 744823     |
+---------------------------------+-----------+-----------------+----------+------------+
| expand_crate                    | 795.29ms  | 19.436          | 848.00ms | 1          |
+---------------------------------+-----------+-----------------+----------+------------+
| metadata_decode_entry           | 256.73ms  | 6.274           | 279.49ms | 518344     |
+---------------------------------+-----------+-----------------+----------+------------+
| resolve_crate                   | 240.56ms  | 5.879           | 242.86ms | 1          |
+---------------------------------+-----------+-----------------+----------+------------+
| hir_lowering                    | 146.79ms  | 3.587           | 146.79ms | 1          |
+---------------------------------+-----------+-----------------+----------+------------+
```

Now the timings are:

```
+---------------------------------+-----------+-----------------+----------+------------+
| Item                            | Self time | % of total time | Time     | Item count |
+---------------------------------+-----------+-----------------+----------+------------+
| <unknown>                       | 1.40s     | 22.662          | 3.73s    | 771430     |
+---------------------------------+-----------+-----------------+----------+------------+
| collect-trait-impls             | 1.34s     | 21.672          | 2.87s    | 1          |
+---------------------------------+-----------+-----------------+----------+------------+
| expand_crate                    | 1.21s     | 19.577          | 1.28s    | 1          |
+---------------------------------+-----------+-----------------+----------+------------+
| build extern trait impl         | 704.66ms  | 11.427          | 1.07s    | 21893      |
+---------------------------------+-----------+-----------------+----------+------------+
| metadata_decode_entry           | 354.84ms  | 5.754           | 391.81ms | 544919     |
+---------------------------------+-----------+-----------------+----------+------------+
```

The goal is to help me debug regressions like https://github.com/rust-lang/rust/pull/74518#issuecomment-661498214 (currently I have _no_ idea what could have gone wrong).

r? @eddyb or @Mark-Simulacrum 