### PR TITLE
std: Don't emit debuginfo for backtrace deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,18 @@ overflow-checks = false
 # per-crate configuration isn't specifiable in the environment.
 codegen-units = 10000
 
+# These dependencies of the standard library implement symbolication for
+# backtraces on most platforms. Their debuginfo causes both linking to be slower
+# (more data to chew through) and binaries to be larger without really all that
+# much benefit. This section turns them all to down to have no debuginfo which
+# helps to improve link times a little bit.
+[profile.release.package]
+addr2line.debug = 0
+adler.debug = 0
+gimli.debug = 0
+miniz_oxide.debug = 0
+object.debug = 0
+
 # We want the RLS to use the version of Cargo that we've got vendored in this
 # repository to ensure that the same exact version of Cargo is used by both the
 # RLS and the Cargo binary itself. The RLS depends on Cargo as a git repository


### PR DESCRIPTION
This was evaluated in #74560 and shown to have a positive effect on some
of the regressions originally reported from #73441. While it doesn't
recover all of the lost ground this is hopefully an easy enough knob to
tweak that we don't have worry too much about it later.