### PR TITLE
Fix sync_once_cell_does_not_leak_partially_constructed_boxes

### DIFF
--- a/src/libstd/lazy.rs
+++ b/src/libstd/lazy.rs
@@ -827,6 +827,8 @@ mod tests {
                         tx.send(msg).unwrap();
                         break;
                     }
+                    #[cfg(target_env = "sgx")]
+                    crate::thread::yield_now();
                 }
             });
         }


### PR DESCRIPTION
Spinning multiple threads in this test causes a deadlock in
SGX where thread scheduling is not preemptive.

cc @jethrogb @AdrianCX 