### PR TITLE
Clarify the doc for MaybeUninit::zeroed on incorrect use

### DIFF
--- a/library/core/src/mem/maybe_uninit.rs
+++ b/library/core/src/mem/maybe_uninit.rs
@@ -336,9 +336,8 @@ impl<T> MaybeUninit<T> {
     /// assert_eq!(x, (0, false));
     /// ```
     ///
-    /// *Incorrect* usage of this function: assuming zero filled memory is initialized,
-    /// where some fields cannot hold 0 as a valid value, without overwriting with a
-    /// valid bit-pattern.
+    /// *Incorrect* usage of this function: calling `x.zeroed().assume_init()`
+    /// when `0` is not a valid bit-pattern for the type:
     ///
     /// ```rust,no_run
     /// use std::mem::MaybeUninit;

--- a/library/core/src/mem/maybe_uninit.rs
+++ b/library/core/src/mem/maybe_uninit.rs
@@ -336,8 +336,9 @@ impl<T> MaybeUninit<T> {
     /// assert_eq!(x, (0, false));
     /// ```
     ///
-    /// *Incorrect* usage of this function: initializing a struct with zero, where some fields
-    /// cannot hold 0 as a valid value.
+    /// *Incorrect* usage of this function: assuming zero filled memory is initialized,
+    /// where some fields cannot hold 0 as a valid value, without overwriting with a
+    /// valid bit-pattern.
     ///
     /// ```rust,no_run
     /// use std::mem::MaybeUninit;


### PR DESCRIPTION
Fixes #74343.

@rustbot modify labels: C-enhancement, T-doc