### PR TITLE
Remove Linux workarounds for missing CLOEXEC support

### DIFF
--- a/src/libstd/sys/unix/os.rs
+++ b/src/libstd/sys/unix/os.rs
@@ -71,6 +71,7 @@ pub fn errno() -> i32 {
 
 /// Sets the platform-specific value of errno
 #[cfg(all(not(target_os = "linux"), not(target_os = "dragonfly")))] // needed for readdir and syscall!
+#[allow(dead_code)] // but not all target cfgs actually end up using it
 pub fn set_errno(e: i32) {
     unsafe { *errno_location() = e as c_int }
 }

--- a/src/libstd/sys/unix/pipe.rs
+++ b/src/libstd/sys/unix/pipe.rs
@@ -1,10 +1,7 @@
 use crate::io::{self, IoSlice, IoSliceMut};
 use crate::mem;
-use crate::sync::atomic::{AtomicBool, Ordering};
 use crate::sys::fd::FileDesc;
 use crate::sys::{cvt, cvt_r};
-
-use libc::c_int;
 
 ////////////////////////////////////////////////////////////////////////////////
 // Anonymous pipes
@@ -13,15 +10,11 @@ use libc::c_int;
 pub struct AnonPipe(FileDesc);
 
 pub fn anon_pipe() -> io::Result<(AnonPipe, AnonPipe)> {
-    syscall! { fn pipe2(fds: *mut c_int, flags: c_int) -> c_int }
-    static INVALID: AtomicBool = AtomicBool::new(false);
-
     let mut fds = [0; 2];
 
     // Unfortunately the only known way right now to create atomically set the
     // CLOEXEC flag is to use the `pipe2` syscall on Linux. This was added in
-    // 2.6.27, however, and because we support 2.6.18 we must detect this
-    // support dynamically.
+    // 2.6.27, glibc 2.9 and musl 0.9.3.
     if cfg!(any(
         target_os = "dragonfly",
         target_os = "freebsd",
@@ -29,30 +22,18 @@ pub fn anon_pipe() -> io::Result<(AnonPipe, AnonPipe)> {
         target_os = "netbsd",
         target_os = "openbsd",
         target_os = "redox"
-    )) && !INVALID.load(Ordering::SeqCst)
-    {
-        // Note that despite calling a glibc function here we may still
-        // get ENOSYS. Glibc has `pipe2` since 2.9 and doesn't try to
-        // emulate on older kernels, so if you happen to be running on
-        // an older kernel you may see `pipe2` as a symbol but still not
-        // see the syscall.
-        match cvt(unsafe { pipe2(fds.as_mut_ptr(), libc::O_CLOEXEC) }) {
-            Ok(_) => {
-                return Ok((AnonPipe(FileDesc::new(fds[0])), AnonPipe(FileDesc::new(fds[1]))));
-            }
-            Err(ref e) if e.raw_os_error() == Some(libc::ENOSYS) => {
-                INVALID.store(true, Ordering::SeqCst);
-            }
-            Err(e) => return Err(e),
-        }
-    }
-    cvt(unsafe { libc::pipe(fds.as_mut_ptr()) })?;
+    )) {
+        cvt(unsafe { libc::pipe2(fds.as_mut_ptr(), libc::O_CLOEXEC) })?;
+        Ok((AnonPipe(FileDesc::new(fds[0])), AnonPipe(FileDesc::new(fds[1]))))
+    } else {
+        cvt(unsafe { libc::pipe(fds.as_mut_ptr()) })?;
 
-    let fd0 = FileDesc::new(fds[0]);
-    let fd1 = FileDesc::new(fds[1]);
-    fd0.set_cloexec()?;
-    fd1.set_cloexec()?;
-    Ok((AnonPipe(fd0), AnonPipe(fd1)))
+        let fd0 = FileDesc::new(fds[0]);
+        let fd1 = FileDesc::new(fds[1]);
+        fd0.set_cloexec()?;
+        fd1.set_cloexec()?;
+        Ok((AnonPipe(fd0), AnonPipe(fd1)))
+    }
 }
 
 impl AnonPipe {

--- a/src/libstd/sys/unix/weak.rs
+++ b/src/libstd/sys/unix/weak.rs
@@ -16,6 +16,11 @@
 //! symbol, but that caused Debian to detect an unnecessarily strict versioned
 //! dependency on libc6 (#23628).
 
+// There are a variety of `#[cfg]`s controlling which targets are involved in
+// each instance of `weak!` and `syscall!`. Rather than trying to unify all of
+// that, we'll just allow that some unix targets don't use this module at all.
+#![allow(dead_code, unused_macros)]
+
 use crate::ffi::CStr;
 use crate::marker;
 use crate::mem;


### PR DESCRIPTION
Now that #74163 updated the minimum Linux kernel to 2.6.32, we can
assume the availability of APIs that open file descriptors that are
already set to close on exec, including the flags `O_CLOEXEC`,
`SOCK_CLOEXEC`, and `F_DUPFD_CLOEXEC`.

Closes #74519.