### PR TITLE
Add std::panic::panic_any.

### DIFF
--- a/library/std/src/panic.rs
+++ b/library/std/src/panic.rs
@@ -31,7 +31,7 @@ pub use core::panic::{Location, PanicInfo};
 /// accessed later using [`PanicInfo::payload`].
 ///
 /// See the [`panic!`] macro for more information about panicking.
-#[unstable(feature = "panic_box", issue = "none")]
+#[unstable(feature = "panic_any", issue = "none")]
 #[inline]
 pub fn panic_any<M: Any + Send>(msg: M) -> ! {
     crate::panicking::begin_panic(msg);

--- a/library/std/src/panic.rs
+++ b/library/std/src/panic.rs
@@ -23,17 +23,17 @@ pub use crate::panicking::{set_hook, take_hook};
 #[stable(feature = "panic_hooks", since = "1.10.0")]
 pub use core::panic::{Location, PanicInfo};
 
-/// Panic the current thread, with the given payload as the panic message.
+/// Panic the current thread with the given message as the panic payload.
 ///
-/// This supports an arbitrary panic payload, instead of just (formatted) strings.
+/// The message can be of any (`Any + Send`) type, not just strings.
 ///
-/// The message is attached as a `Box<'static + Any + Send>`, which can be
-/// accessed using [`PanicInfo::payload`].
+/// The message is wrapped in a `Box<'static + Any + Send>`, which can be
+/// accessed later using [`PanicInfo::payload`].
 ///
 /// See the [`panic!`] macro for more information about panicking.
 #[unstable(feature = "panic_box", issue = "none")]
 #[inline]
-pub fn panic_box<M: Any + Send>(msg: M) -> ! {
+pub fn panic_any<M: Any + Send>(msg: M) -> ! {
     crate::panicking::begin_panic(msg);
 }
 

--- a/library/std/src/panic.rs
+++ b/library/std/src/panic.rs
@@ -23,6 +23,20 @@ pub use crate::panicking::{set_hook, take_hook};
 #[stable(feature = "panic_hooks", since = "1.10.0")]
 pub use core::panic::{Location, PanicInfo};
 
+/// Panic the current thread, with the given payload as the panic message.
+///
+/// This supports an arbitrary panic payload, instead of just (formatted) strings.
+///
+/// The message is attached as a `Box<'static + Any + Send>`, which can be
+/// accessed using [`PanicInfo::payload`].
+///
+/// See the [`panic!`] macro for more information about panicking.
+#[unstable(feature = "panic_box", issue = "none")]
+#[inline]
+pub fn panic_box<M: Any + Send>(msg: M) -> ! {
+    crate::panicking::begin_panic(msg);
+}
+
 /// A marker trait which represents "panic safe" types in Rust.
 ///
 /// This trait is implemented by default for many types and behaves similarly in

--- a/library/std/src/panic.rs
+++ b/library/std/src/panic.rs
@@ -31,7 +31,7 @@ pub use core::panic::{Location, PanicInfo};
 /// accessed later using [`PanicInfo::payload`].
 ///
 /// See the [`panic!`] macro for more information about panicking.
-#[unstable(feature = "panic_any", issue = "none")]
+#[unstable(feature = "panic_any", issue = "78500")]
 #[inline]
 pub fn panic_any<M: Any + Send>(msg: M) -> ! {
     crate::panicking::begin_panic(msg);


### PR DESCRIPTION
The discussion of #67984 lead to the conclusion that there should be a macro or function separate from `std::panic!()` for throwing arbitrary payloads, to make it possible to deprecate or disallow (in edition 2021) `std::panic!(arbitrary_payload)`.

Alternative names:

- `panic_with!(..)`
- ~~`start_unwind(..)`~~ (panicking doesn't always unwind)
- `throw!(..)`
- `panic_throwing!(..)`
- `panic_with_value(..)`
- `panic_value(..)`
- `panic_with(..)`
- `panic_box(..)`
- `panic(..)`

The equivalent (private, unstable) function in `libstd` is called `std::panicking::begin_panic`.

I suggest `panic_any`, because it allows for any (`Any + Send`) type.

_Tracking issue: #78500_