### PR TITLE
[AVR] Disable passing of he '--eh-frame-hdr' argument to the linker

### DIFF
--- a/src/librustc_codegen_ssa/back/linker.rs
+++ b/src/librustc_codegen_ssa/back/linker.rs
@@ -623,6 +623,7 @@ impl<'a> Linker for GccLinker<'a> {
             && !self.sess.target.target.options.is_like_windows
             && !self.sess.target.target.options.is_like_solaris
             && self.sess.target.target.target_os != "uefi"
+            && self.sess.target.target.arch != "avr"
         {
             self.linker_arg("--eh-frame-hdr");
         }


### PR DESCRIPTION
In general, the GNU AVR linker that is distributed does not support this flag.
On Arch Linux, the most recently distributed version of avr-ld
corresponds to binutils 2.34, which is the most recent version of
binutils as of today (2020-07-22), however - it still does not list
this argument in its --help list compared to the host LD, which does.

As AVR has no exception handling support, the exception handling frame header
argument is redundant. This patch disables passing of the '--eh-frame-hdr' argument
to avr-ld, similar to the existing exclusions (i.e. Windows, Solaris,
UEFI).