### PR TITLE
rustc_target: Add a target spec option for disabling `--eh-frame-hdr`

### DIFF
--- a/src/librustc_codegen_ssa/back/link.rs
+++ b/src/librustc_codegen_ssa/back/link.rs
@@ -1598,7 +1598,9 @@ fn linker_with_args<'a, B: ArchiveBuilder<'a>>(
     }
 
     // NO-OPT-OUT, OBJECT-FILES-NO, AUDIT-ORDER
-    cmd.add_eh_frame_header();
+    if sess.target.target.options.eh_frame_header {
+        cmd.add_eh_frame_header();
+    }
 
     // NO-OPT-OUT, OBJECT-FILES-NO
     if crt_objects_fallback {

--- a/src/librustc_codegen_ssa/back/linker.rs
+++ b/src/librustc_codegen_ssa/back/linker.rs
@@ -619,13 +619,7 @@ impl<'a> Linker for GccLinker<'a> {
     // Some versions of `gcc` add it implicitly, some (e.g. `musl-gcc`) don't,
     // so we just always add it.
     fn add_eh_frame_header(&mut self) {
-        if !self.sess.target.target.options.is_like_osx
-            && !self.sess.target.target.options.is_like_windows
-            && !self.sess.target.target.options.is_like_solaris
-            && self.sess.target.target.target_os != "uefi"
-        {
-            self.linker_arg("--eh-frame-hdr");
-        }
+        self.linker_arg("--eh-frame-hdr");
     }
 }
 

--- a/src/librustc_target/spec/apple_base.rs
+++ b/src/librustc_target/spec/apple_base.rs
@@ -31,6 +31,7 @@ pub fn opts() -> TargetOptions {
         has_elf_tls: version >= (10, 7),
         abi_return_struct_as_int: true,
         emit_debug_gdb_scripts: false,
+        eh_frame_header: false,
 
         // This environment variable is pretty magical but is intended for
         // producing deterministic builds. This was first discovered to be used

--- a/src/librustc_target/spec/freestanding_base.rs
+++ b/src/librustc_target/spec/freestanding_base.rs
@@ -25,6 +25,7 @@ pub fn opts() -> TargetOptions {
         has_rpath: false,
         pre_link_args: args,
         position_independent_executables: false,
+        eh_frame_header: false,
         ..Default::default()
     }
 }

--- a/src/librustc_target/spec/illumos_base.rs
+++ b/src/librustc_target/spec/illumos_base.rs
@@ -23,6 +23,7 @@ pub fn opts() -> TargetOptions {
         is_like_solaris: true,
         limit_rdylib_exports: false, // Linker doesn't support this
         eliminate_frame_pointer: false,
+        eh_frame_header: false,
         late_link_args,
 
         // While we support ELF TLS, rust requires a way to register

--- a/src/librustc_target/spec/mod.rs
+++ b/src/librustc_target/spec/mod.rs
@@ -987,6 +987,11 @@ pub struct TargetOptions {
     /// Whether to use legacy .ctors initialization hooks rather than .init_array. Defaults
     /// to false (uses .init_array).
     pub use_ctors_section: bool,
+
+    /// Whether the linker is instructed to add a `GNU_EH_FRAME` ELF header
+    /// used to locate unwinding information is passed
+    /// (only has effect if the linker is `ld`-like).
+    pub eh_frame_header: bool,
 }
 
 impl Default for TargetOptions {
@@ -1078,6 +1083,7 @@ impl Default for TargetOptions {
             relax_elf_relocations: false,
             llvm_args: vec![],
             use_ctors_section: false,
+            eh_frame_header: true,
         }
     }
 }
@@ -1470,6 +1476,7 @@ impl Target {
         key!(relax_elf_relocations, bool);
         key!(llvm_args, list);
         key!(use_ctors_section, bool);
+        key!(eh_frame_header, bool);
 
         // NB: The old name is deprecated, but support for it is retained for
         // compatibility.
@@ -1707,6 +1714,7 @@ impl ToJson for Target {
         target_option_val!(relax_elf_relocations);
         target_option_val!(llvm_args);
         target_option_val!(use_ctors_section);
+        target_option_val!(eh_frame_header);
 
         if default.unsupported_abis != self.options.unsupported_abis {
             d.insert(

--- a/src/librustc_target/spec/msp430_none_elf.rs
+++ b/src/librustc_target/spec/msp430_none_elf.rs
@@ -56,6 +56,8 @@ pub fn target() -> TargetResult {
             // See the thumb_base.rs file for an explanation of this value
             emit_debug_gdb_scripts: false,
 
+            eh_frame_header: false,
+
             ..Default::default()
         },
     })

--- a/src/librustc_target/spec/riscv32i_unknown_none_elf.rs
+++ b/src/librustc_target/spec/riscv32i_unknown_none_elf.rs
@@ -25,6 +25,7 @@ pub fn target() -> TargetResult {
             relocation_model: RelocModel::Static,
             emit_debug_gdb_scripts: false,
             unsupported_abis: super::riscv_base::unsupported_abis(),
+            eh_frame_header: false,
             ..Default::default()
         },
     })

--- a/src/librustc_target/spec/riscv32imac_unknown_none_elf.rs
+++ b/src/librustc_target/spec/riscv32imac_unknown_none_elf.rs
@@ -25,6 +25,7 @@ pub fn target() -> TargetResult {
             relocation_model: RelocModel::Static,
             emit_debug_gdb_scripts: false,
             unsupported_abis: super::riscv_base::unsupported_abis(),
+            eh_frame_header: false,
             ..Default::default()
         },
     })

--- a/src/librustc_target/spec/riscv32imc_unknown_none_elf.rs
+++ b/src/librustc_target/spec/riscv32imc_unknown_none_elf.rs
@@ -25,6 +25,7 @@ pub fn target() -> TargetResult {
             relocation_model: RelocModel::Static,
             emit_debug_gdb_scripts: false,
             unsupported_abis: super::riscv_base::unsupported_abis(),
+            eh_frame_header: false,
             ..Default::default()
         },
     })

--- a/src/librustc_target/spec/riscv64gc_unknown_none_elf.rs
+++ b/src/librustc_target/spec/riscv64gc_unknown_none_elf.rs
@@ -26,6 +26,7 @@ pub fn target() -> TargetResult {
             code_model: Some(CodeModel::Medium),
             emit_debug_gdb_scripts: false,
             unsupported_abis: super::riscv_base::unsupported_abis(),
+            eh_frame_header: false,
             ..Default::default()
         },
     })

--- a/src/librustc_target/spec/riscv64imac_unknown_none_elf.rs
+++ b/src/librustc_target/spec/riscv64imac_unknown_none_elf.rs
@@ -26,6 +26,7 @@ pub fn target() -> TargetResult {
             code_model: Some(CodeModel::Medium),
             emit_debug_gdb_scripts: false,
             unsupported_abis: super::riscv_base::unsupported_abis(),
+            eh_frame_header: false,
             ..Default::default()
         },
     })

--- a/src/librustc_target/spec/solaris_base.rs
+++ b/src/librustc_target/spec/solaris_base.rs
@@ -8,6 +8,7 @@ pub fn opts() -> TargetOptions {
         target_family: Some("unix".to_string()),
         is_like_solaris: true,
         limit_rdylib_exports: false, // Linker doesn't support this
+        eh_frame_header: false,
 
         ..Default::default()
     }

--- a/src/librustc_target/spec/windows_gnu_base.rs
+++ b/src/librustc_target/spec/windows_gnu_base.rs
@@ -91,6 +91,7 @@ pub fn opts() -> TargetOptions {
         abi_return_struct_as_int: true,
         emit_debug_gdb_scripts: false,
         requires_uwtable: true,
+        eh_frame_header: false,
 
         ..Default::default()
     }


### PR DESCRIPTION
Disable `--eh-frame-hdr` for targets that use an `ld`-like linker, but don't support that option.
Do it through a target spec option rather than through hard-coding in `linker.rs`.
The option is still enabled by default though.

cc https://github.com/rust-lang/rust/pull/73564
Fixes https://github.com/rust-lang/rust/pull/73564#issuecomment-657011004
Fixes https://github.com/rust-lang/rust/pull/74625
Fixes https://github.com/rust-embedded/msp430-rt/issues/12