### PR TITLE
Fix tooltip position if the documentation starts with a code block

### DIFF
--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -1291,6 +1291,16 @@ h4 > .important-traits {
 
 /* Media Queries */
 
+@media (min-width: 701px) {
+	/* In case there is no documentation before a code block, we need to add some margin at the top
+	to prevent an overlay between the "collapse toggle" and the information tooltip.
+	However, it's needed needed with smaller screen width because the doc/code block is always put
+	"one line" below. */
+	.information:first-child > .tooltip {
+		margin-top: 16px;
+	}
+}
+
 @media (max-width: 700px) {
 	body {
 		padding-top: 0px;


### PR DESCRIPTION
Fixes #74321.

Before:

![before](https://user-images.githubusercontent.com/3050060/88188970-cf842400-cc38-11ea-839b-37e41656837d.png)

After:

![after](https://user-images.githubusercontent.com/3050060/88188981-d3b04180-cc38-11ea-8194-713ffe640d3a.png)

And in case there is text, it is not being applied:

![after-witness](https://user-images.githubusercontent.com/3050060/88189009-ddd24000-cc38-11ea-9f0a-61dfd0a0cbd0.png)

And on mobile it isn't needed so it's not "activated":

![Screenshot from 2020-07-22 17-17-43](https://user-images.githubusercontent.com/3050060/88194698-65bb4880-cc3f-11ea-8513-0043ccca8cfc.png)

r? @rust-lang/rustdoc 