### PR TITLE
Deprecate `linked_list_extras` methods.

### DIFF
--- a/library/alloc/src/collections/linked_list.rs
+++ b/library/alloc/src/collections/linked_list.rs
@@ -1110,31 +1110,16 @@ impl<T> IterMut<'_, T> {
     /// Inserts the given element just after the element most recently returned by `.next()`.
     /// The inserted element does not appear in the iteration.
     ///
-    /// # Examples
-    ///
-    /// ```
-    /// #![feature(linked_list_extras)]
-    ///
-    /// use std::collections::LinkedList;
-    ///
-    /// let mut list: LinkedList<_> = vec![1, 3, 4].into_iter().collect();
-    ///
-    /// {
-    ///     let mut it = list.iter_mut();
-    ///     assert_eq!(it.next().unwrap(), &1);
-    ///     // insert `2` after `1`
-    ///     it.insert_next(2);
-    /// }
-    /// {
-    ///     let vec: Vec<_> = list.into_iter().collect();
-    ///     assert_eq!(vec, [1, 2, 3, 4]);
-    /// }
-    /// ```
+    /// This method will be removed soon.
     #[inline]
     #[unstable(
         feature = "linked_list_extras",
         reason = "this is probably better handled by a cursor type -- we'll see",
         issue = "27794"
+    )]
+    #[rustc_deprecated(
+        reason = "Deprecated in favor of CursorMut methods. This method will be removed soon.",
+        since = "1.47.0"
     )]
     pub fn insert_next(&mut self, element: T) {
         match self.head {
@@ -1163,26 +1148,16 @@ impl<T> IterMut<'_, T> {
 
     /// Provides a reference to the next element, without changing the iterator.
     ///
-    /// # Examples
-    ///
-    /// ```
-    /// #![feature(linked_list_extras)]
-    ///
-    /// use std::collections::LinkedList;
-    ///
-    /// let mut list: LinkedList<_> = vec![1, 2, 3].into_iter().collect();
-    ///
-    /// let mut it = list.iter_mut();
-    /// assert_eq!(it.next().unwrap(), &1);
-    /// assert_eq!(it.peek_next().unwrap(), &2);
-    /// // We just peeked at 2, so it was not consumed from the iterator.
-    /// assert_eq!(it.next().unwrap(), &2);
-    /// ```
+    /// This method will be removed soon.
     #[inline]
     #[unstable(
         feature = "linked_list_extras",
         reason = "this is probably better handled by a cursor type -- we'll see",
         issue = "27794"
+    )]
+    #[rustc_deprecated(
+        reason = "Deprecated in favor of CursorMut methods. This method will be removed soon.",
+        since = "1.47.0"
     )]
     pub fn peek_next(&mut self) -> Option<&mut T> {
         if self.len == 0 {

--- a/library/alloc/src/collections/linked_list/tests.rs
+++ b/library/alloc/src/collections/linked_list/tests.rs
@@ -154,33 +154,6 @@ fn test_clone_from() {
 }
 
 #[test]
-fn test_insert_prev() {
-    let mut m = list_from(&[0, 2, 4, 6, 8]);
-    let len = m.len();
-    {
-        let mut it = m.iter_mut();
-        it.insert_next(-2);
-        loop {
-            match it.next() {
-                None => break,
-                Some(elt) => {
-                    it.insert_next(*elt + 1);
-                    match it.peek_next() {
-                        Some(x) => assert_eq!(*x, *elt + 2),
-                        None => assert_eq!(8, *elt),
-                    }
-                }
-            }
-        }
-        it.insert_next(0);
-        it.insert_next(1);
-    }
-    check_links(&m);
-    assert_eq!(m.len(), 3 + len * 2);
-    assert_eq!(m.into_iter().collect::<Vec<_>>(), [-2, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1]);
-}
-
-#[test]
 #[cfg_attr(target_os = "emscripten", ignore)]
 fn test_send() {
     let n = list_from(&[1, 2, 3]);


### PR DESCRIPTION
Removing these in favor of the `Cursor` API in https://github.com/rust-lang/rust/issues/58533 .
Closes #27794.

r? @Amanieu 