### PR TITLE
Improve the documentation for Vec::drain

### DIFF
--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -1274,12 +1274,10 @@ impl<T> Vec<T> {
     /// Creates a draining iterator that removes the specified range in the vector
     /// and yields the removed items.
     ///
-    /// The element range is removed even if the iterator is only partially
-    /// consumed or not consumed at all.
-    ///
-    /// Note: Be aware that if the iterator is leaked (eg: [`mem::forget`]), it
-    /// cancels this property so it is unspecified how many elements are removed
-    /// from the vector in this case.
+    /// When the iterator **is** dropped, all elements in the range are removed
+    /// from the vector, even if the iterator was not fully consumed. If the
+    /// iterator **is not** dropped (with [`mem::forget`] for example), it is
+    /// unspecified how many elements are removed.
     ///
     /// # Panics
     ///

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -1298,8 +1298,6 @@ impl<T> Vec<T> {
     /// v.drain(..);
     /// assert_eq!(v, &[]);
     /// ```
-    ///
-    /// [`mem::forget`]: mem::forget
     #[stable(feature = "drain", since = "1.6.0")]
     pub fn drain<R>(&mut self, range: R) -> Drain<'_, T>
     where

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -1274,11 +1274,12 @@ impl<T> Vec<T> {
     /// Creates a draining iterator that removes the specified range in the vector
     /// and yields the removed items.
     ///
-    /// Note 1: The element range is removed even if the iterator is only
-    /// partially consumed or not consumed at all.
+    /// The element range is removed even if the iterator is only partially
+    /// consumed or not consumed at all.
     ///
-    /// Note 2: It is unspecified how many elements are removed from the vector
-    /// if the `Drain` value is leaked.
+    /// Note: Be aware that if the iterator is leaked (eg: [`mem::forget`]), it
+    /// cancels this property so it is unspecified how many elements are removed
+    /// from the vector in this case.
     ///
     /// # Panics
     ///
@@ -1297,6 +1298,8 @@ impl<T> Vec<T> {
     /// v.drain(..);
     /// assert_eq!(v, &[]);
     /// ```
+    ///
+    /// [`mem::forget`]: mem::forget
     #[stable(feature = "drain", since = "1.6.0")]
     pub fn drain<R>(&mut self, range: R) -> Drain<'_, T>
     where


### PR DESCRIPTION
Fixes #73844.

@rusbot modify labels: A-collections, C-enhancement, T-doc, T-libs