### PR TITLE
require type defaults to be after const generic parameters

### DIFF
--- a/src/librustc_ast_passes/ast_validation.rs
+++ b/src/librustc_ast_passes/ast_validation.rs
@@ -1132,7 +1132,7 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                         if matches!(param.kind, GenericParamKind::Const { .. }) {
                             err.note(
                                 "using type defaults and const parameters \
-                                 in the same parameter listing is currently not possible",
+                                 in the same parameter list is currently not permitted",
                             );
                         }
                         err.emit();

--- a/src/librustc_ast_passes/ast_validation.rs
+++ b/src/librustc_ast_passes/ast_validation.rs
@@ -1118,13 +1118,26 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
     fn visit_generics(&mut self, generics: &'a Generics) {
         let mut prev_ty_default = None;
         for param in &generics.params {
-            if let GenericParamKind::Type { ref default, .. } = param.kind {
-                if default.is_some() {
+            match param.kind {
+                GenericParamKind::Lifetime => (),
+                GenericParamKind::Type { default: Some(_), .. } => {
                     prev_ty_default = Some(param.ident.span);
-                } else if let Some(span) = prev_ty_default {
-                    self.err_handler()
-                        .span_err(span, "type parameters with a default must be trailing");
-                    break;
+                }
+                GenericParamKind::Type { .. } | GenericParamKind::Const { .. } => {
+                    if let Some(span) = prev_ty_default {
+                        let mut err = self.err_handler().struct_span_err(
+                            span,
+                            "type parameters with a default must be trailing",
+                        );
+                        if matches!(param.kind, GenericParamKind::Const { .. }) {
+                            err.note(
+                                "using type defaults and const parameters \
+                                 in the same parameter listing is currently not possible",
+                            );
+                        }
+                        err.emit();
+                        break;
+                    }
                 }
             }
         }

--- a/src/test/ui/const-generics/defaults/wrong-order.rs
+++ b/src/test/ui/const-generics/defaults/wrong-order.rs
@@ -1,0 +1,8 @@
+#![feature(const_generics)] //~ WARN the feature `const_generics` is incomplete
+
+struct A<T = u32, const N: usize> {
+    //~^ ERROR type parameters with a default must be trailing
+    arg: T,
+}
+
+fn main() {}

--- a/src/test/ui/const-generics/defaults/wrong-order.stderr
+++ b/src/test/ui/const-generics/defaults/wrong-order.stderr
@@ -4,7 +4,7 @@ error: type parameters with a default must be trailing
 LL | struct A<T = u32, const N: usize> {
    |          ^
    |
-   = note: using type defaults and const parameters in the same parameter listing is currently not possible
+   = note: using type defaults and const parameters in the same parameter list is currently not permitted
 
 warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/wrong-order.rs:1:12

--- a/src/test/ui/const-generics/defaults/wrong-order.stderr
+++ b/src/test/ui/const-generics/defaults/wrong-order.stderr
@@ -1,0 +1,19 @@
+error: type parameters with a default must be trailing
+  --> $DIR/wrong-order.rs:3:10
+   |
+LL | struct A<T = u32, const N: usize> {
+   |          ^
+   |
+   = note: using type defaults and const parameters in the same parameter listing is currently not possible
+
+warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/wrong-order.rs:1:12
+   |
+LL | #![feature(const_generics)]
+   |            ^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
+
+error: aborting due to previous error; 1 warning emitted
+


### PR DESCRIPTION
From current discussions it seems like the goal here is for type and const parameters to be unordered and allow things like `struct Foo<const N: usize, T = u32>(T)` and `struct Foo<T, const N: usize = 7>` this way.

Note: This means that using `min_const_generics` it will not be possible for an adt to have both type defaults and const parameters.

closes #70471

r? @varkor @eddyb