### PR TITLE
Don't ICE on unconstrained anonymous lifetimes inside associated types.

### DIFF
--- a/src/test/ui/associated-types/issue-62200.rs
+++ b/src/test/ui/associated-types/issue-62200.rs
@@ -1,0 +1,14 @@
+struct S {}
+
+trait T<'a> {
+    type A;
+}
+
+impl T<'_> for S {
+    type A = u32;
+}
+
+fn foo(x: impl Fn(<S as T<'_>>::A) -> <S as T<'_>>::A) {}
+//~^ ERROR binding for associated type `Output` references an anonymous lifetime
+
+fn main() {}

--- a/src/test/ui/associated-types/issue-62200.rs
+++ b/src/test/ui/associated-types/issue-62200.rs
@@ -10,5 +10,6 @@ impl T<'_> for S {
 
 fn foo(x: impl Fn(<S as T<'_>>::A) -> <S as T<'_>>::A) {}
 //~^ ERROR binding for associated type `Output` references an anonymous lifetime
+//~^^ NOTE lifetimes appearing in an associated type are not considered constrained
 
 fn main() {}

--- a/src/test/ui/associated-types/issue-62200.stderr
+++ b/src/test/ui/associated-types/issue-62200.stderr
@@ -1,0 +1,11 @@
+error[E0582]: binding for associated type `Output` references an anonymous lifetime, which does not appear in the trait input types
+  --> $DIR/issue-62200.rs:11:39
+   |
+LL | fn foo(x: impl Fn(<S as T<'_>>::A) -> <S as T<'_>>::A) {}
+   |                                       ^^^^^^^^^^^^^^^
+   |
+   = note: lifetimes appearing in an associated type are not considered constrained
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0582`.


### PR DESCRIPTION
Fixes #62200. The change here is inspired (copied) by how this case is handled on bare fns at https://github.com/rust-lang/rust/blob/e8b55a4ad230ebec762fdfc4f241ba98a98560af/src/librustc_typeck/astconv.rs#L3083-L3106.