### PR TITLE
Add fallible AArch64 CI builder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -576,6 +576,11 @@ jobs:
     strategy:
       matrix:
         include:
+          - name: aarch64-gnu
+            os:
+              - self-hosted
+              - ARM64
+              - linux
           - name: dist-x86_64-apple
             env:
               SCRIPT: "./x.py dist"

--- a/src/ci/github-actions/ci.yml
+++ b/src/ci/github-actions/ci.yml
@@ -84,6 +84,9 @@ x--expand-yaml-anchors--remove:
     os: windows-latest-xl
     <<: *base-job
 
+  - &job-aarch64-linux
+    os: [self-hosted, ARM64, linux]
+
   - &step
     if: success() && !env.SKIP_JOB
 
@@ -585,6 +588,13 @@ jobs:
     strategy:
       matrix:
         include:
+          #############################
+          #   Linux/Docker builders   #
+          #############################
+
+          - name: aarch64-gnu
+            <<: *job-aarch64-linux
+
           ####################
           #  macOS Builders  #
           ####################

--- a/src/ci/scripts/symlink-build-dir.sh
+++ b/src/ci/scripts/symlink-build-dir.sh
@@ -12,7 +12,7 @@ source "$(cd "$(dirname "$0")" && pwd)/../shared.sh"
 if isWindows && isAzurePipelines; then
     cmd //c "mkdir c:\\MORE_SPACE"
     cmd //c "mklink /J build c:\\MORE_SPACE"
-elif isLinux && isGitHubActions; then
+elif isLinux && isGitHubActions && ! isSelfHostedGitHubActions; then
     sudo mkdir -p /mnt/more-space
     sudo chown -R "$(whoami):" /mnt/more-space
 

--- a/src/ci/shared.sh
+++ b/src/ci/shared.sh
@@ -38,6 +38,11 @@ function isGitHubActions {
     [[ "${GITHUB_ACTIONS-false}" = "true" ]]
 }
 
+
+function isSelfHostedGitHubActions {
+    [[ "${RUST_GHA_SELF_HOSTED-false}" = "true" ]]
+}
+
 function isMacOS {
     [[ "${OSTYPE}" = "darwin"* ]]
 }


### PR DESCRIPTION
This adds the `aarch64-gnu` CI builder to the `auto-fallible` job, as a first step in the process of actually gating on it.

r? @Mark-Simulacrum 