### PR TITLE
correctly deal with unsorted generic parameters

### DIFF
--- a/src/librustc_ast_lowering/lib.rs
+++ b/src/librustc_ast_lowering/lib.rs
@@ -936,7 +936,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                 })
             });
 
-        lowered_generics.params = lowered_generics.params.into_iter().chain(in_band_defs).collect();
+        lowered_generics.params.extend(in_band_defs);
 
         let lowered_generics = lowered_generics.into_generics(self.arena);
         (lowered_generics, res)

--- a/src/librustc_ast_lowering/lib.rs
+++ b/src/librustc_ast_lowering/lib.rs
@@ -936,20 +936,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                 })
             });
 
-        let mut lowered_params: Vec<_> =
-            lowered_generics.params.into_iter().chain(in_band_defs).collect();
-
-        // FIXME(const_generics): the compiler doesn't always cope with
-        // unsorted generic parameters at the moment, so we make sure
-        // that they're ordered correctly here for now. (When we chain
-        // the `in_band_defs`, we might make the order unsorted.)
-        lowered_params.sort_by_key(|param| match param.kind {
-            hir::GenericParamKind::Lifetime { .. } => ParamKindOrd::Lifetime,
-            hir::GenericParamKind::Type { .. } => ParamKindOrd::Type,
-            hir::GenericParamKind::Const { .. } => ParamKindOrd::Const,
-        });
-
-        lowered_generics.params = lowered_params.into();
+        lowered_generics.params = lowered_generics.params.into_iter().chain(in_band_defs).collect();
 
         let lowered_generics = lowered_generics.into_generics(self.arena);
         (lowered_generics, res)

--- a/src/librustc_resolve/late/lifetimes.rs
+++ b/src/librustc_resolve/late/lifetimes.rs
@@ -1298,7 +1298,10 @@ fn object_lifetime_defaults_for_item(
             }
             GenericParamKind::Const { .. } => {
                 // Generic consts don't impose any constraints.
-                None
+                //
+                // We still store a dummy value here to allow generic paramters
+                // in arbitrary order.
+                Some(Set1::Empty)
             }
         })
         .collect()

--- a/src/librustc_resolve/late/lifetimes.rs
+++ b/src/librustc_resolve/late/lifetimes.rs
@@ -1299,8 +1299,8 @@ fn object_lifetime_defaults_for_item(
             GenericParamKind::Const { .. } => {
                 // Generic consts don't impose any constraints.
                 //
-                // We still store a dummy value here to allow generic paramters
-                // in arbitrary order.
+                // We still store a dummy value here to allow generic parameters
+                // in an arbitrary order.
                 Some(Set1::Empty)
             }
         })

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -1374,7 +1374,7 @@ fn generics_of(tcx: TyCtxt<'_>, def_id: DefId) -> ty::Generics {
                         |lint| {
                             lint.build(
                                 "defaults for type parameters are only allowed in \
-                                            `struct`, `enum`, `type`, or `trait` definitions.",
+                                 `struct`, `enum`, `type`, or `trait` definitions.",
                             )
                             .emit();
                         },

--- a/src/test/ui/const-generics/argument_order.rs
+++ b/src/test/ui/const-generics/argument_order.rs
@@ -6,4 +6,11 @@ struct Bad<const N: usize, T> { //~ ERROR type parameters must be declared prior
     another: T,
 }
 
+struct AlsoBad<const N: usize, 'a, T, 'b, const M: usize, U> {
+    //~^ ERROR type parameters must be declared prior
+    //~| ERROR lifetime parameters must be declared prior
+    a: &'a T,
+    b: &'b U,
+}
+
 fn main() { }

--- a/src/test/ui/const-generics/argument_order.rs
+++ b/src/test/ui/const-generics/argument_order.rs
@@ -13,4 +13,7 @@ struct AlsoBad<const N: usize, 'a, T, 'b, const M: usize, U> {
     b: &'b U,
 }
 
-fn main() { }
+fn main() {
+    let _: AlsoBad<7, 'static, u32, 'static, 17, u16>;
+    //~^ ERROR lifetime provided when a type was expected
+ }

--- a/src/test/ui/const-generics/argument_order.stderr
+++ b/src/test/ui/const-generics/argument_order.stderr
@@ -4,6 +4,18 @@ error: type parameters must be declared prior to const parameters
 LL | struct Bad<const N: usize, T> {
    |           -----------------^- help: reorder the parameters: lifetimes, then types, then consts: `<T, const N: usize>`
 
+error: lifetime parameters must be declared prior to const parameters
+  --> $DIR/argument_order.rs:9:32
+   |
+LL | struct AlsoBad<const N: usize, 'a, T, 'b, const M: usize, U> {
+   |               -----------------^^-----^^-------------------- help: reorder the parameters: lifetimes, then types, then consts: `<'a, 'b, T, U, const N: usize, const M: usize>`
+
+error: type parameters must be declared prior to const parameters
+  --> $DIR/argument_order.rs:9:36
+   |
+LL | struct AlsoBad<const N: usize, 'a, T, 'b, const M: usize, U> {
+   |               ---------------------^----------------------^- help: reorder the parameters: lifetimes, then types, then consts: `<'a, 'b, T, U, const N: usize, const M: usize>`
+
 warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/argument_order.rs:1:12
    |
@@ -13,5 +25,5 @@ LL | #![feature(const_generics)]
    = note: `#[warn(incomplete_features)]` on by default
    = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
 
-error: aborting due to previous error; 1 warning emitted
+error: aborting due to 3 previous errors; 1 warning emitted
 

--- a/src/test/ui/const-generics/argument_order.stderr
+++ b/src/test/ui/const-generics/argument_order.stderr
@@ -25,5 +25,15 @@ LL | #![feature(const_generics)]
    = note: `#[warn(incomplete_features)]` on by default
    = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
 
-error: aborting due to 3 previous errors; 1 warning emitted
+error[E0747]: lifetime provided when a type was expected
+  --> $DIR/argument_order.rs:17:23
+   |
+LL |     let _: AlsoBad<7, 'static, u32, 'static, 17, u16>;
+   |                       ^^^^^^^
+   |
+   = note: lifetime arguments must be provided before type arguments
+   = help: reorder the arguments: lifetimes, then types, then consts: `<'a, 'b, T, U, N, M>`
 
+error: aborting due to 4 previous errors; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0747`.


### PR DESCRIPTION
We now stop sorting generic params and instead correctly handle unsorted params in the rest of the compiler.

We still restrict const params to come after type params though, so this PR does not change anything which
is visible to users.

This might slightly influence perf, so let's prevent any unintentional rollups. @bors rollup=never

r? @varkor 