### PR TITLE
 Miri: use extern fn to expose interpreter operations to program; fix leak checker on Windows

### DIFF
--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -1947,14 +1947,6 @@ extern "rust-intrinsic" {
     #[rustc_const_unstable(feature = "const_ptr_offset_from", issue = "41079")]
     pub fn ptr_offset_from<T>(ptr: *const T, base: *const T) -> isize;
 
-    /// Internal hook used by Miri to implement unwinding.
-    /// ICEs when encountered during non-Miri codegen.
-    ///
-    /// The `payload` ptr here will be exactly the one `do_catch` gets passed by `try`.
-    ///
-    /// Perma-unstable: do not use.
-    pub fn miri_start_panic(payload: *mut u8) -> !;
-
     /// Internal placeholder for injecting code coverage counters when the "instrument-coverage"
     /// option is enabled. The placeholder is replaced with `llvm.instrprof.increment` during code
     /// generation.

--- a/src/libpanic_unwind/miri.rs
+++ b/src/libpanic_unwind/miri.rs
@@ -6,11 +6,16 @@ use core::any::Any;
 // Must be pointer-sized.
 type Payload = Box<Box<dyn Any + Send>>;
 
+extern "Rust" {
+    /// Miri-provided extern function to begin unwinding.
+    fn miri_start_panic(payload: *mut u8) -> !;
+}
+
 pub unsafe fn panic(payload: Box<dyn Any + Send>) -> u32 {
     // The payload we pass to `miri_start_panic` will be exactly the argument we get
     // in `cleanup` below. So we just box it up once, to get something pointer-sized.
     let payload_box: Payload = Box::new(payload);
-    core::intrinsics::miri_start_panic(Box::into_raw(payload_box) as *mut u8)
+    miri_start_panic(Box::into_raw(payload_box) as *mut u8)
 }
 
 pub unsafe fn cleanup(payload_box: *mut u8) -> Box<dyn Any + Send> {

--- a/src/librustc_codegen_ssa/mir/block.rs
+++ b/src/librustc_codegen_ssa/mir/block.rs
@@ -606,11 +606,6 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
             return;
         }
 
-        // For normal codegen, this Miri-specific intrinsic should never occur.
-        if intrinsic == Some(sym::miri_start_panic) {
-            bug!("`miri_start_panic` should never end up in compiled code");
-        }
-
         if self.codegen_panic_intrinsic(
             &helper,
             &mut bx,

--- a/src/librustc_span/symbol.rs
+++ b/src/librustc_span/symbol.rs
@@ -677,7 +677,6 @@ symbols! {
         minnumf32,
         minnumf64,
         mips_target_feature,
-        miri_start_panic,
         mmx_target_feature,
         module,
         module_path,

--- a/src/librustc_typeck/check/intrinsic.rs
+++ b/src/librustc_typeck/check/intrinsic.rs
@@ -379,12 +379,6 @@ pub fn check_intrinsic_type(tcx: TyCtxt<'_>, it: &hir::ForeignItem<'_>) {
 
             sym::nontemporal_store => (1, vec![tcx.mk_mut_ptr(param(0)), param(0)], tcx.mk_unit()),
 
-            sym::miri_start_panic => {
-                // FIXME - the relevant types aren't lang items,
-                // so it's not trivial to check this
-                return;
-            }
-
             sym::count_code_region => {
                 (0, vec![tcx.types.u64, tcx.types.u32, tcx.types.u32, tcx.types.u32], tcx.mk_unit())
             }

--- a/src/libstd/sys/windows/thread_local_key.rs
+++ b/src/libstd/sys/windows/thread_local_key.rs
@@ -131,7 +131,8 @@ unsafe fn register_dtor(key: Key, dtor: Dtor) {
                 #[cfg(miri)]
                 miri_static_root(&*node as *const _ as *const u8);
 
-                return mem::forget(node);
+                mem::forget(node);
+                return;
             }
             Err(cur) => head = cur,
         }

--- a/src/libstd/sys/windows/thread_local_key.rs
+++ b/src/libstd/sys/windows/thread_local_key.rs
@@ -110,6 +110,16 @@ struct Node {
     next: *mut Node,
 }
 
+#[cfg(miri)]
+extern "Rust" {
+    /// Miri-provided extern function to mark the block `ptr` points to as a "root"
+    /// for some static memory. This memory and everything reachable by it is not
+    /// considered leaking even if it still exists when the program terminates.
+    ///
+    /// `ptr` has to point to the beginning of an allocated block.
+    fn miri_static_root(ptr: *const u8);
+}
+
 unsafe fn register_dtor(key: Key, dtor: Dtor) {
     let mut node = Box::new(Node { key, dtor, next: ptr::null_mut() });
 
@@ -117,7 +127,12 @@ unsafe fn register_dtor(key: Key, dtor: Dtor) {
     loop {
         node.next = head;
         match DTORS.compare_exchange(head, &mut *node, SeqCst, SeqCst) {
-            Ok(_) => return mem::forget(node),
+            Ok(_) => {
+                #[cfg(miri)]
+                miri_static_root(&*node as *const _ as *const u8);
+
+                return mem::forget(node);
+            }
             Err(cur) => head = cur,
         }
     }


### PR DESCRIPTION
This PR realizes an idea that @oli-obk has been suggesting for a while: to use Miri-specific `extern` functions to provide some extra capabilities to the program. Initially, we have two of these methods, which libstd itself needs:
* `miri_start_panic`, which replaces the intrinsic of the same name (mostly for consistency, to avoid having multiple mechanisms for Miri-specific functionality).
* `miri_static_root`, which adds an allocation to a list of static "roots" that Miri considers as not having leaked (including all memory reachable through them). This is needed for https://github.com/rust-lang/miri/issues/1302.

We use `extern` functions instead of intrinsics for this so that user code can more easily call these Miri hoolks -- e.g. `miri_static_root` should be useful for https://github.com/rust-lang/miri/issues/1318.

The Miri side of this is at https://github.com/rust-lang/miri/pull/1485.

r? @oli-obk 