### PR TITLE
Update cargo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,7 +278,7 @@ checksum = "716960a18f978640f25101b5cbf1c6f6b0d3192fab36a2d98ca96f0ecbe41010"
 
 [[package]]
 name = "cargo"
-version = "0.47.0"
+version = "0.48.0"
 dependencies = [
  "anyhow",
  "atty",


### PR DESCRIPTION
21 commits in 43cf77395cad5b79887b20b7cf19d418bbd703a9..aa6872140ab0fa10f641ab0b981d5330d419e927
2020-07-13 17:35:42 +0000 to 2020-07-23 13:46:27 +0000
- Update features set in CI. (rust-lang/cargo#8530)
- Stabilize -Z crate-versions (rust-lang/cargo#8509)
- Fix typo in docs (rust-lang/cargo#8529)
- Remove unused CompileMode::all_modes (rust-lang/cargo#8526)
- Mask out system core.autocrlf settings before resetting git repos (rust-lang/cargo#8523)
- Flag git zlib errors as spurious errors (rust-lang/cargo#8520)
- Fix the help display for the target-triple option (rust-lang/cargo#8515)
- Check workspace member existence as dir. (rust-lang/cargo#8511)
- Bump to 0.48.0, update changelog (rust-lang/cargo#8508)
- Apply workspace.exclude to workspace.default-members. (rust-lang/cargo#8485)
- Fix nightly tests for intra-doc links. (rust-lang/cargo#8528)
- doc: Replace "regenerate" with "revoke" for API tokens (rust-lang/cargo#8510)
- Add back Manifest::targets_mut (rust-lang/cargo#8494)
- Build host dependencies with opt-level 0 by default (rust-lang/cargo#8500)
- Fix freshness checks for build scripts on renamed dirs (rust-lang/cargo#8497)
- Add a `-Zbuild-std-features` flag (rust-lang/cargo#8490)
- clippy cleanups (rust-lang/cargo#8495)
- Fix self-publish script. (rust-lang/cargo#8492)
- Ensure `unstable.build-std` works like `-Zbuild-std` (rust-lang/cargo#8491)
- Make `cargo metadata` output deterministic (rust-lang/cargo#8489)
- Switch to github actions (rust-lang/cargo#8467)