### PR TITLE
CI: Enable cargo's net.git-fetch-with-cli

### DIFF
--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -43,6 +43,9 @@ else
     PYTHON="python2"
 fi
 
+# This is a temporary workaround for a cargo issue.
+export CARGO_NET_GIT_FETCH_WITH_CLI=true
+
 if ! isCI || isCiBranch auto || isCiBranch beta; then
     RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --set build.print-step-timings --enable-verbose-tests"
 fi


### PR DESCRIPTION
The i686 builders are frequently failing with a zlib error.  This issue is tracked at https://github.com/rust-lang/cargo/issues/8517.  For now, to get CI working again, this switches cargo to use the git CLI to fetch instead of its internal libgit2 implementation.

I am not 100% certain this will work.  I *think* all of the builders and docker images have git installed, but I haven't checked all of them.
