### PR TITLE
Fix ICE while building MIR with type errors

### DIFF
--- a/src/librustc_mir_build/hair/pattern/mod.rs
+++ b/src/librustc_mir_build/hair/pattern/mod.rs
@@ -509,11 +509,6 @@ impl<'a, 'tcx> PatCtxt<'a, 'tcx> {
     fn lower_pattern_unadjusted(&mut self, pat: &'tcx hir::Pat<'tcx>) -> Pat<'tcx> {
         let mut ty = self.typeck_results.node_type(pat.hir_id);
 
-        if let ty::Error(_) = ty.kind {
-            // Avoid ICEs (e.g., #50577 and #50585).
-            return Pat { span: pat.span, ty, kind: Box::new(PatKind::Wild) };
-        }
-
         let kind = match pat.kind {
             hir::PatKind::Wild => PatKind::Wild,
 

--- a/src/test/ui/issue-74047.rs
+++ b/src/test/ui/issue-74047.rs
@@ -1,0 +1,17 @@
+// edition:2018
+
+use std::convert::{TryFrom, TryInto};
+use std::io;
+
+pub struct MyStream;
+pub struct OtherStream;
+
+pub async fn connect() -> io::Result<MyStream> {
+    let stream: MyStream = OtherStream.try_into()?;
+    Ok(stream)
+}
+
+impl TryFrom<OtherStream> for MyStream {}
+//~^ ERROR: missing
+
+fn main() {}

--- a/src/test/ui/issue-74047.stderr
+++ b/src/test/ui/issue-74047.stderr
@@ -1,0 +1,12 @@
+error[E0046]: not all trait items implemented, missing: `Error`, `try_from`
+  --> $DIR/issue-74047.rs:14:1
+   |
+LL | impl TryFrom<OtherStream> for MyStream {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `Error`, `try_from` in implementation
+   |
+   = help: implement the missing item: `type Error = Type;`
+   = help: implement the missing item: `fn try_from(_: T) -> std::result::Result<Self, <Self as std::convert::TryFrom<T>>::Error> { todo!() }`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0046`.


### PR DESCRIPTION
See https://github.com/rust-lang/rust/issues/74047#issuecomment-663290913 for background. Replacing a binding with `PatKind::Wild` (introduced in #51789 and later refactored in #67439) caused an ICE downstream while building MIR.

I noticed that taking this code out no longer triggers the ICEs it was added to prevent. I'm not sure what else changed, or if this change is _correct_, but it does seem to be passing ui tests at least.

r? @oli-obk 
cc @estebank 

Fixes #74047.