### PR TITLE
mir: add `used_generic_parameters_needs_subst`

### DIFF
--- a/src/librustc_mir/interpret/mod.rs
+++ b/src/librustc_mir/interpret/mod.rs
@@ -12,6 +12,7 @@ mod place;
 mod step;
 mod terminator;
 mod traits;
+mod util;
 mod validity;
 mod visitor;
 

--- a/src/librustc_mir/interpret/util.rs
+++ b/src/librustc_mir/interpret/util.rs
@@ -1,0 +1,73 @@
+use rustc_middle::mir::interpret::InterpResult;
+use rustc_middle::ty::{self, Ty, TyCtxt, TypeFoldable, TypeVisitor};
+use std::convert::TryInto;
+
+/// Returns `true` if a used generic parameter requires substitution.
+crate fn ensure_monomorphic_enough<'tcx, T>(tcx: TyCtxt<'tcx>, ty: T) -> InterpResult<'tcx>
+where
+    T: TypeFoldable<'tcx>,
+{
+    debug!("ensure_monomorphic_enough: ty={:?}", ty);
+    if !ty.needs_subst() {
+        return Ok(());
+    }
+
+    struct UsedParamsNeedSubstVisitor<'tcx> {
+        tcx: TyCtxt<'tcx>,
+    };
+
+    impl<'tcx> TypeVisitor<'tcx> for UsedParamsNeedSubstVisitor<'tcx> {
+        fn visit_const(&mut self, c: &'tcx ty::Const<'tcx>) -> bool {
+            if !c.needs_subst() {
+                return false;
+            }
+
+            match c.val {
+                ty::ConstKind::Param(..) => true,
+                _ => c.super_visit_with(self),
+            }
+        }
+
+        fn visit_ty(&mut self, ty: Ty<'tcx>) -> bool {
+            if !ty.needs_subst() {
+                return false;
+            }
+
+            match ty.kind {
+                ty::Param(_) => true,
+                ty::Closure(def_id, substs)
+                | ty::Generator(def_id, substs, ..)
+                | ty::FnDef(def_id, substs) => {
+                    let unused_params = self.tcx.unused_generic_params(def_id);
+                    for (index, subst) in substs.into_iter().enumerate() {
+                        let index = index
+                            .try_into()
+                            .expect("more generic parameters than can fit into a `u32`");
+                        let is_used =
+                            unused_params.contains(index).map(|unused| !unused).unwrap_or(true);
+                        // Only recurse when generic parameters in fns, closures and generators
+                        // are used and require substitution.
+                        if is_used && subst.needs_subst() {
+                            // Just in case there are closures or generators within this subst,
+                            // recurse.
+                            if subst.super_visit_with(self) {
+                                // Only return when we find a parameter so the remaining substs
+                                // are not skipped.
+                                return true;
+                            }
+                        }
+                    }
+                    false
+                }
+                _ => ty.super_visit_with(self),
+            }
+        }
+    }
+
+    let mut vis = UsedParamsNeedSubstVisitor { tcx };
+    if ty.visit_with(&mut vis) {
+        throw_inval!(TooGeneric);
+    } else {
+        Ok(())
+    }
+}

--- a/src/test/ui/issues/issue-74614.rs
+++ b/src/test/ui/issues/issue-74614.rs
@@ -1,3 +1,4 @@
+// compile-flags:-Zpolymorphize=on
 // build-pass
 
 fn test<T>() {

--- a/src/test/ui/polymorphization/issue-74636.rs
+++ b/src/test/ui/polymorphization/issue-74636.rs
@@ -1,0 +1,16 @@
+// compile-flags:-Zpolymorphize=on
+// build-pass
+
+use std::any::TypeId;
+
+pub fn foo<T: 'static>(_: T) -> TypeId {
+    TypeId::of::<T>()
+}
+
+fn outer<T: 'static>() {
+    foo(|| ());
+}
+
+fn main() {
+    outer::<u8>();
+}


### PR DESCRIPTION
Fixes #74636.

This PR adds a `used_generic_parameters_needs_subst` helper function which checks whether a type needs substitution, but only for parameters that the `unused_generic_params` query considers used. This is used in the MIR interpreter to make the check for some pointer casts and for reflection intrinsics more precise.

I've opened this as a draft PR because this might not be the approach we want to fix this issue and we have to decide what to do about the reflection case.

r? @eddyb 
cc @lcnr @wesleywiser 