### PR TITLE
[Don't merge] Learn the performance impact of running lints

### DIFF
--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -179,6 +179,10 @@ pub fn run_compiler(
             registry: diagnostics_registry(),
         };
         callbacks.config(&mut config);
+        // lol no lints at all
+        config.override_queries = Some(|_, providers, _| {
+            providers.lint_mod = |_, _| {};
+        });
         config
     };
 
@@ -256,6 +260,10 @@ pub fn run_compiler(
     };
 
     callbacks.config(&mut config);
+    // lol no lints at all
+    config.override_queries = Some(|_, providers, _| {
+        providers.lint_mod = |_, _| {};
+    });
 
     interface::run_compiler(config, |compiler| {
         let sess = compiler.session();


### PR DESCRIPTION
Related: https://github.com/rust-lang/rust/issues/74704

This is still running some things, not sure why. I think the lints are being run directly by the passes, not through `lint_mod`.

```
warning: hidden lifetime parameters in types are deprecated
  --> ui/lint/reasons.rs:21:29
   |
21 |     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
   |                             ^^^^^^^^^^^^^^- help: indicate the anonymous lifetime: `<'_>`
   |
   = note: explicit anonymous lifetimes aid reasoning about ownership
note: the lint level is defined here
  --> ui/lint/reasons.rs:5:9
   |
5  | #![warn(elided_lifetimes_in_paths,
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^
```

However most of the lints have gone away.

r? @ghost