### PR TITLE
Remove links to rejected errata 4406 for RFC 4291

### DIFF
--- a/library/std/src/net/ip.rs
+++ b/library/std/src/net/ip.rs
@@ -1265,15 +1265,12 @@ impl Ipv6Addr {
     /// # See also
     ///
     /// - [IETF RFC 4291 section 2.5.6]
-    /// - [RFC 4291 errata 4406]
     /// - [`is_unicast_link_local()`]
     ///
     /// [IETF RFC 4291]: https://tools.ietf.org/html/rfc4291
     /// [IETF RFC 4291 section 2.5.6]: https://tools.ietf.org/html/rfc4291#section-2.5.6
     /// [`true`]: ../../std/primitive.bool.html
-    /// [RFC 4291 errata 4406]: https://www.rfc-editor.org/errata/eid4406
     /// [`is_unicast_link_local()`]: ../../std/net/struct.Ipv6Addr.html#method.is_unicast_link_local
-    ///
     pub fn is_unicast_link_local_strict(&self) -> bool {
         (self.segments()[0] & 0xffff) == 0xfe80
             && (self.segments()[1] & 0xffff) == 0
@@ -1324,13 +1321,10 @@ impl Ipv6Addr {
     /// # See also
     ///
     /// - [IETF RFC 4291 section 2.4]
-    /// - [RFC 4291 errata 4406]
     ///
     /// [IETF RFC 4291 section 2.4]: https://tools.ietf.org/html/rfc4291#section-2.4
     /// [`true`]: ../../std/primitive.bool.html
-    /// [RFC 4291 errata 4406]: https://www.rfc-editor.org/errata/eid4406
     /// [`is_unicast_link_local_strict()`]: ../../std/net/struct.Ipv6Addr.html#method.is_unicast_link_local_strict
-    ///
     pub fn is_unicast_link_local(&self) -> bool {
         (self.segments()[0] & 0xffc0) == 0xfe80
     }

--- a/library/std/src/net/ip.rs
+++ b/library/std/src/net/ip.rs
@@ -1265,11 +1265,14 @@ impl Ipv6Addr {
     /// # See also
     ///
     /// - [IETF RFC 4291 section 2.5.6]
+    /// - [RFC 4291 errata 4406] (which has been rejected but provides useful
+    ///   insight)
     /// - [`is_unicast_link_local()`]
     ///
     /// [IETF RFC 4291]: https://tools.ietf.org/html/rfc4291
     /// [IETF RFC 4291 section 2.5.6]: https://tools.ietf.org/html/rfc4291#section-2.5.6
     /// [`true`]: ../../std/primitive.bool.html
+    /// [RFC 4291 errata 4406]: https://www.rfc-editor.org/errata/eid4406
     /// [`is_unicast_link_local()`]: ../../std/net/struct.Ipv6Addr.html#method.is_unicast_link_local
     pub fn is_unicast_link_local_strict(&self) -> bool {
         (self.segments()[0] & 0xffff) == 0xfe80
@@ -1321,9 +1324,12 @@ impl Ipv6Addr {
     /// # See also
     ///
     /// - [IETF RFC 4291 section 2.4]
+    /// - [RFC 4291 errata 4406] (which has been rejected but provides useful
+    ///   insight)
     ///
     /// [IETF RFC 4291 section 2.4]: https://tools.ietf.org/html/rfc4291#section-2.4
     /// [`true`]: ../../std/primitive.bool.html
+    /// [RFC 4291 errata 4406]: https://www.rfc-editor.org/errata/eid4406
     /// [`is_unicast_link_local_strict()`]: ../../std/net/struct.Ipv6Addr.html#method.is_unicast_link_local_strict
     pub fn is_unicast_link_local(&self) -> bool {
         (self.segments()[0] & 0xffc0) == 0xfe80


### PR DESCRIPTION
Fixes #74198.

For now I simply removed the links, the docs seems clear enough to me but I'm no expert in the domain so don't hesitate to correct me if more is needed.

cc @ghanan94.

@rustbot modify labels: T-doc, T-libs