### PR TITLE
MIR-OPT: Make SimplifyBranchSame able to remove identity match with fieldless variant

### DIFF
--- a/src/test/mir-opt/simplify-arm.rs
+++ b/src/test/mir-opt/simplify-arm.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Z mir-opt-level=1
+// compile-flags: -Z mir-opt-level=2
 // EMIT_MIR simplify_arm.id.SimplifyArmIdentity.diff
 // EMIT_MIR simplify_arm.id.SimplifyBranchSame.diff
 // EMIT_MIR simplify_arm.id_result.SimplifyArmIdentity.diff

--- a/src/test/mir-opt/simplify_arm.id.SimplifyArmIdentity.diff
+++ b/src/test/mir-opt/simplify_arm.id.SimplifyArmIdentity.diff
@@ -8,7 +8,8 @@
       let _3: u8;                          // in scope 0 at $DIR/simplify-arm.rs:11:14: 11:15
       let mut _4: u8;                      // in scope 0 at $DIR/simplify-arm.rs:11:25: 11:26
       scope 1 {
-          debug v => _3;                   // in scope 1 at $DIR/simplify-arm.rs:11:14: 11:15
+-         debug v => _3;                   // in scope 1 at $DIR/simplify-arm.rs:11:14: 11:15
++         debug v => ((_0 as Some).0: u8); // in scope 1 at $DIR/simplify-arm.rs:11:14: 11:15
       }
   
       bb0: {
@@ -26,14 +27,15 @@
       }
   
       bb3: {
-          StorageLive(_3);                 // scope 0 at $DIR/simplify-arm.rs:11:14: 11:15
-          _3 = ((_1 as Some).0: u8);       // scope 0 at $DIR/simplify-arm.rs:11:14: 11:15
-          StorageLive(_4);                 // scope 1 at $DIR/simplify-arm.rs:11:25: 11:26
-          _4 = _3;                         // scope 1 at $DIR/simplify-arm.rs:11:25: 11:26
-          ((_0 as Some).0: u8) = move _4;  // scope 1 at $DIR/simplify-arm.rs:11:20: 11:27
-          discriminant(_0) = 1;            // scope 1 at $DIR/simplify-arm.rs:11:20: 11:27
-          StorageDead(_4);                 // scope 1 at $DIR/simplify-arm.rs:11:26: 11:27
-          StorageDead(_3);                 // scope 0 at $DIR/simplify-arm.rs:11:26: 11:27
+-         StorageLive(_3);                 // scope 0 at $DIR/simplify-arm.rs:11:14: 11:15
+-         _3 = ((_1 as Some).0: u8);       // scope 0 at $DIR/simplify-arm.rs:11:14: 11:15
+-         StorageLive(_4);                 // scope 1 at $DIR/simplify-arm.rs:11:25: 11:26
+-         _4 = _3;                         // scope 1 at $DIR/simplify-arm.rs:11:25: 11:26
+-         ((_0 as Some).0: u8) = move _4;  // scope 1 at $DIR/simplify-arm.rs:11:20: 11:27
+-         discriminant(_0) = 1;            // scope 1 at $DIR/simplify-arm.rs:11:20: 11:27
+-         StorageDead(_4);                 // scope 1 at $DIR/simplify-arm.rs:11:26: 11:27
+-         StorageDead(_3);                 // scope 0 at $DIR/simplify-arm.rs:11:26: 11:27
++         _0 = move _1;                    // scope 1 at $DIR/simplify-arm.rs:11:20: 11:27
           goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:10:5: 13:6
       }
   

--- a/src/test/mir-opt/simplify_arm.id.SimplifyBranchSame.diff
+++ b/src/test/mir-opt/simplify_arm.id.SimplifyBranchSame.diff
@@ -8,36 +8,32 @@
       let _3: u8;                          // in scope 0 at $DIR/simplify-arm.rs:11:14: 11:15
       let mut _4: u8;                      // in scope 0 at $DIR/simplify-arm.rs:11:25: 11:26
       scope 1 {
-          debug v => _3;                   // in scope 1 at $DIR/simplify-arm.rs:11:14: 11:15
+          debug v => ((_0 as Some).0: u8); // in scope 1 at $DIR/simplify-arm.rs:11:14: 11:15
       }
   
       bb0: {
           _2 = discriminant(_1);           // scope 0 at $DIR/simplify-arm.rs:11:9: 11:16
-          switchInt(move _2) -> [0_isize: bb1, 1_isize: bb3, otherwise: bb2]; // scope 0 at $DIR/simplify-arm.rs:11:9: 11:16
+-         switchInt(move _2) -> [0_isize: bb1, 1_isize: bb3, otherwise: bb2]; // scope 0 at $DIR/simplify-arm.rs:11:9: 11:16
++         goto -> bb1;                     // scope 0 at $DIR/simplify-arm.rs:11:9: 11:16
       }
   
       bb1: {
-          discriminant(_0) = 0;            // scope 0 at $DIR/simplify-arm.rs:12:17: 12:21
-          goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:10:5: 13:6
+-         discriminant(_0) = 0;            // scope 0 at $DIR/simplify-arm.rs:12:17: 12:21
+-         goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:10:5: 13:6
+-     }
+- 
+-     bb2: {
+-         unreachable;                     // scope 0 at $DIR/simplify-arm.rs:10:11: 10:12
+-     }
+- 
+-     bb3: {
+          _0 = move _1;                    // scope 1 at $DIR/simplify-arm.rs:11:20: 11:27
+-         goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:10:5: 13:6
++         goto -> bb2;                     // scope 0 at $DIR/simplify-arm.rs:10:5: 13:6
       }
   
-      bb2: {
-          unreachable;                     // scope 0 at $DIR/simplify-arm.rs:10:11: 10:12
-      }
-  
-      bb3: {
-          StorageLive(_3);                 // scope 0 at $DIR/simplify-arm.rs:11:14: 11:15
-          _3 = ((_1 as Some).0: u8);       // scope 0 at $DIR/simplify-arm.rs:11:14: 11:15
-          StorageLive(_4);                 // scope 1 at $DIR/simplify-arm.rs:11:25: 11:26
-          _4 = _3;                         // scope 1 at $DIR/simplify-arm.rs:11:25: 11:26
-          ((_0 as Some).0: u8) = move _4;  // scope 1 at $DIR/simplify-arm.rs:11:20: 11:27
-          discriminant(_0) = 1;            // scope 1 at $DIR/simplify-arm.rs:11:20: 11:27
-          StorageDead(_4);                 // scope 1 at $DIR/simplify-arm.rs:11:26: 11:27
-          StorageDead(_3);                 // scope 0 at $DIR/simplify-arm.rs:11:26: 11:27
-          goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:10:5: 13:6
-      }
-  
-      bb4: {
+-     bb4: {
++     bb2: {
           return;                          // scope 0 at $DIR/simplify-arm.rs:14:2: 14:2
       }
   }

--- a/src/test/mir-opt/simplify_arm.id_result.SimplifyArmIdentity.diff
+++ b/src/test/mir-opt/simplify_arm.id_result.SimplifyArmIdentity.diff
@@ -10,10 +10,12 @@
       let _5: i32;                         // in scope 0 at $DIR/simplify-arm.rs:19:13: 19:14
       let mut _6: i32;                     // in scope 0 at $DIR/simplify-arm.rs:19:23: 19:24
       scope 1 {
-          debug x => _3;                   // in scope 1 at $DIR/simplify-arm.rs:18:12: 18:13
+-         debug x => _3;                   // in scope 1 at $DIR/simplify-arm.rs:18:12: 18:13
++         debug x => ((_0 as Ok).0: u8);   // in scope 1 at $DIR/simplify-arm.rs:18:12: 18:13
       }
       scope 2 {
-          debug y => _5;                   // in scope 2 at $DIR/simplify-arm.rs:19:13: 19:14
+-         debug y => _5;                   // in scope 2 at $DIR/simplify-arm.rs:19:13: 19:14
++         debug y => ((_0 as Err).0: i32); // in scope 2 at $DIR/simplify-arm.rs:19:13: 19:14
       }
   
       bb0: {
@@ -22,14 +24,15 @@
       }
   
       bb1: {
-          StorageLive(_5);                 // scope 0 at $DIR/simplify-arm.rs:19:13: 19:14
-          _5 = ((_1 as Err).0: i32);       // scope 0 at $DIR/simplify-arm.rs:19:13: 19:14
-          StorageLive(_6);                 // scope 2 at $DIR/simplify-arm.rs:19:23: 19:24
-          _6 = _5;                         // scope 2 at $DIR/simplify-arm.rs:19:23: 19:24
-          ((_0 as Err).0: i32) = move _6;  // scope 2 at $DIR/simplify-arm.rs:19:19: 19:25
-          discriminant(_0) = 1;            // scope 2 at $DIR/simplify-arm.rs:19:19: 19:25
-          StorageDead(_6);                 // scope 2 at $DIR/simplify-arm.rs:19:24: 19:25
-          StorageDead(_5);                 // scope 0 at $DIR/simplify-arm.rs:19:24: 19:25
+-         StorageLive(_5);                 // scope 0 at $DIR/simplify-arm.rs:19:13: 19:14
+-         _5 = ((_1 as Err).0: i32);       // scope 0 at $DIR/simplify-arm.rs:19:13: 19:14
+-         StorageLive(_6);                 // scope 2 at $DIR/simplify-arm.rs:19:23: 19:24
+-         _6 = _5;                         // scope 2 at $DIR/simplify-arm.rs:19:23: 19:24
+-         ((_0 as Err).0: i32) = move _6;  // scope 2 at $DIR/simplify-arm.rs:19:19: 19:25
+-         discriminant(_0) = 1;            // scope 2 at $DIR/simplify-arm.rs:19:19: 19:25
+-         StorageDead(_6);                 // scope 2 at $DIR/simplify-arm.rs:19:24: 19:25
+-         StorageDead(_5);                 // scope 0 at $DIR/simplify-arm.rs:19:24: 19:25
++         _0 = move _1;                    // scope 2 at $DIR/simplify-arm.rs:19:19: 19:25
           goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:17:5: 20:6
       }
   
@@ -38,14 +41,15 @@
       }
   
       bb3: {
-          StorageLive(_3);                 // scope 0 at $DIR/simplify-arm.rs:18:12: 18:13
-          _3 = ((_1 as Ok).0: u8);         // scope 0 at $DIR/simplify-arm.rs:18:12: 18:13
-          StorageLive(_4);                 // scope 1 at $DIR/simplify-arm.rs:18:21: 18:22
-          _4 = _3;                         // scope 1 at $DIR/simplify-arm.rs:18:21: 18:22
-          ((_0 as Ok).0: u8) = move _4;    // scope 1 at $DIR/simplify-arm.rs:18:18: 18:23
-          discriminant(_0) = 0;            // scope 1 at $DIR/simplify-arm.rs:18:18: 18:23
-          StorageDead(_4);                 // scope 1 at $DIR/simplify-arm.rs:18:22: 18:23
-          StorageDead(_3);                 // scope 0 at $DIR/simplify-arm.rs:18:22: 18:23
+-         StorageLive(_3);                 // scope 0 at $DIR/simplify-arm.rs:18:12: 18:13
+-         _3 = ((_1 as Ok).0: u8);         // scope 0 at $DIR/simplify-arm.rs:18:12: 18:13
+-         StorageLive(_4);                 // scope 1 at $DIR/simplify-arm.rs:18:21: 18:22
+-         _4 = _3;                         // scope 1 at $DIR/simplify-arm.rs:18:21: 18:22
+-         ((_0 as Ok).0: u8) = move _4;    // scope 1 at $DIR/simplify-arm.rs:18:18: 18:23
+-         discriminant(_0) = 0;            // scope 1 at $DIR/simplify-arm.rs:18:18: 18:23
+-         StorageDead(_4);                 // scope 1 at $DIR/simplify-arm.rs:18:22: 18:23
+-         StorageDead(_3);                 // scope 0 at $DIR/simplify-arm.rs:18:22: 18:23
++         _0 = move _1;                    // scope 1 at $DIR/simplify-arm.rs:18:18: 18:23
           goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:17:5: 20:6
       }
   

--- a/src/test/mir-opt/simplify_arm.id_result.SimplifyBranchSame.diff
+++ b/src/test/mir-opt/simplify_arm.id_result.SimplifyBranchSame.diff
@@ -10,46 +10,35 @@
       let _5: i32;                         // in scope 0 at $DIR/simplify-arm.rs:19:13: 19:14
       let mut _6: i32;                     // in scope 0 at $DIR/simplify-arm.rs:19:23: 19:24
       scope 1 {
-          debug x => _3;                   // in scope 1 at $DIR/simplify-arm.rs:18:12: 18:13
+          debug x => ((_0 as Ok).0: u8);   // in scope 1 at $DIR/simplify-arm.rs:18:12: 18:13
       }
       scope 2 {
-          debug y => _5;                   // in scope 2 at $DIR/simplify-arm.rs:19:13: 19:14
+          debug y => ((_0 as Err).0: i32); // in scope 2 at $DIR/simplify-arm.rs:19:13: 19:14
       }
   
       bb0: {
           _2 = discriminant(_1);           // scope 0 at $DIR/simplify-arm.rs:18:9: 18:14
-          switchInt(move _2) -> [0_isize: bb3, 1_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/simplify-arm.rs:18:9: 18:14
+-         switchInt(move _2) -> [0_isize: bb3, 1_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/simplify-arm.rs:18:9: 18:14
++         goto -> bb1;                     // scope 0 at $DIR/simplify-arm.rs:18:9: 18:14
       }
   
       bb1: {
-          StorageLive(_5);                 // scope 0 at $DIR/simplify-arm.rs:19:13: 19:14
-          _5 = ((_1 as Err).0: i32);       // scope 0 at $DIR/simplify-arm.rs:19:13: 19:14
-          StorageLive(_6);                 // scope 2 at $DIR/simplify-arm.rs:19:23: 19:24
-          _6 = _5;                         // scope 2 at $DIR/simplify-arm.rs:19:23: 19:24
-          ((_0 as Err).0: i32) = move _6;  // scope 2 at $DIR/simplify-arm.rs:19:19: 19:25
-          discriminant(_0) = 1;            // scope 2 at $DIR/simplify-arm.rs:19:19: 19:25
-          StorageDead(_6);                 // scope 2 at $DIR/simplify-arm.rs:19:24: 19:25
-          StorageDead(_5);                 // scope 0 at $DIR/simplify-arm.rs:19:24: 19:25
-          goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:17:5: 20:6
+-         _0 = move _1;                    // scope 2 at $DIR/simplify-arm.rs:19:19: 19:25
+-         goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:17:5: 20:6
+-     }
+- 
+-     bb2: {
+-         unreachable;                     // scope 0 at $DIR/simplify-arm.rs:17:11: 17:12
+-     }
+- 
+-     bb3: {
+          _0 = move _1;                    // scope 1 at $DIR/simplify-arm.rs:18:18: 18:23
+-         goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:17:5: 20:6
++         goto -> bb2;                     // scope 0 at $DIR/simplify-arm.rs:17:5: 20:6
       }
   
-      bb2: {
-          unreachable;                     // scope 0 at $DIR/simplify-arm.rs:17:11: 17:12
-      }
-  
-      bb3: {
-          StorageLive(_3);                 // scope 0 at $DIR/simplify-arm.rs:18:12: 18:13
-          _3 = ((_1 as Ok).0: u8);         // scope 0 at $DIR/simplify-arm.rs:18:12: 18:13
-          StorageLive(_4);                 // scope 1 at $DIR/simplify-arm.rs:18:21: 18:22
-          _4 = _3;                         // scope 1 at $DIR/simplify-arm.rs:18:21: 18:22
-          ((_0 as Ok).0: u8) = move _4;    // scope 1 at $DIR/simplify-arm.rs:18:18: 18:23
-          discriminant(_0) = 0;            // scope 1 at $DIR/simplify-arm.rs:18:18: 18:23
-          StorageDead(_4);                 // scope 1 at $DIR/simplify-arm.rs:18:22: 18:23
-          StorageDead(_3);                 // scope 0 at $DIR/simplify-arm.rs:18:22: 18:23
-          goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:17:5: 20:6
-      }
-  
-      bb4: {
+-     bb4: {
++     bb2: {
           return;                          // scope 0 at $DIR/simplify-arm.rs:21:2: 21:2
       }
   }

--- a/src/test/mir-opt/simplify_arm.id_try.SimplifyArmIdentity.diff
+++ b/src/test/mir-opt/simplify_arm.id_try.SimplifyArmIdentity.diff
@@ -15,17 +15,32 @@
       let _10: u8;                         // in scope 0 at $DIR/simplify-arm.rs:24:13: 24:15
       let mut _11: u8;                     // in scope 0 at $DIR/simplify-arm.rs:25:8: 25:9
       scope 1 {
-          debug x => _2;                   // in scope 1 at $DIR/simplify-arm.rs:24:9: 24:10
+-         debug x => _2;                   // in scope 1 at $DIR/simplify-arm.rs:24:9: 24:10
++         debug x => ((_0 as Ok).0: u8);   // in scope 1 at $DIR/simplify-arm.rs:24:9: 24:10
       }
       scope 2 {
-          debug err => _6;                 // in scope 2 at $DIR/simplify-arm.rs:24:14: 24:15
+-         debug err => _6;                 // in scope 2 at $DIR/simplify-arm.rs:24:14: 24:15
++         debug err => ((_0 as Err).0: i32); // in scope 2 at $DIR/simplify-arm.rs:24:14: 24:15
           scope 3 {
+              scope 7 {
+-                 debug t => _9;           // in scope 7 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
++                 debug t => ((_0 as Err).0: i32); // in scope 7 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
+              }
+              scope 8 {
+-                 debug v => _8;           // in scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
++                 debug v => ((_0 as Err).0: i32); // in scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
+                  let mut _12: i32;        // in scope 8 at $DIR/simplify-arm.rs:24:14: 24:15
+              }
           }
       }
       scope 4 {
-          debug val => _10;                // in scope 4 at $DIR/simplify-arm.rs:24:13: 24:15
+-         debug val => _10;                // in scope 4 at $DIR/simplify-arm.rs:24:13: 24:15
++         debug val => ((_0 as Ok).0: u8); // in scope 4 at $DIR/simplify-arm.rs:24:13: 24:15
           scope 5 {
           }
+      }
+      scope 6 {
+          debug self => _4;                // in scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
       }
   
       bb0: {
@@ -33,76 +48,55 @@
           StorageLive(_3);                 // scope 0 at $DIR/simplify-arm.rs:24:13: 24:15
           StorageLive(_4);                 // scope 0 at $DIR/simplify-arm.rs:24:13: 24:14
           _4 = _1;                         // scope 0 at $DIR/simplify-arm.rs:24:13: 24:14
-          _3 = const <std::result::Result<u8, i32> as std::ops::Try>::into_result(move _4) -> bb1; // scope 0 at $DIR/simplify-arm.rs:24:13: 24:15
-                                           // ty::Const
-                                           // + ty: fn(std::result::Result<u8, i32>) -> std::result::Result<<std::result::Result<u8, i32> as std::ops::Try>::Ok, <std::result::Result<u8, i32> as std::ops::Try>::Error> {<std::result::Result<u8, i32> as std::ops::Try>::into_result}
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/simplify-arm.rs:24:13: 24:15
-                                           // + literal: Const { ty: fn(std::result::Result<u8, i32>) -> std::result::Result<<std::result::Result<u8, i32> as std::ops::Try>::Ok, <std::result::Result<u8, i32> as std::ops::Try>::Error> {<std::result::Result<u8, i32> as std::ops::Try>::into_result}, val: Value(Scalar(<ZST>)) }
+          _3 = move _4;                    // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+          StorageDead(_4);                 // scope 0 at $DIR/simplify-arm.rs:24:14: 24:15
+          _5 = discriminant(_3);           // scope 0 at $DIR/simplify-arm.rs:24:14: 24:15
+          switchInt(move _5) -> [0_isize: bb1, 1_isize: bb3, otherwise: bb2]; // scope 0 at $DIR/simplify-arm.rs:24:14: 24:15
       }
   
       bb1: {
-          StorageDead(_4);                 // scope 0 at $DIR/simplify-arm.rs:24:14: 24:15
-          _5 = discriminant(_3);           // scope 0 at $DIR/simplify-arm.rs:24:14: 24:15
-          switchInt(move _5) -> [0_isize: bb2, 1_isize: bb4, otherwise: bb3]; // scope 0 at $DIR/simplify-arm.rs:24:14: 24:15
+-         StorageLive(_10);                // scope 0 at $DIR/simplify-arm.rs:24:13: 24:15
+-         _10 = ((_3 as Ok).0: u8);        // scope 0 at $DIR/simplify-arm.rs:24:13: 24:15
+-         _2 = _10;                        // scope 5 at $DIR/simplify-arm.rs:24:13: 24:15
+-         StorageDead(_10);                // scope 0 at $DIR/simplify-arm.rs:24:14: 24:15
++         _0 = move _3;                    // scope 1 at $DIR/simplify-arm.rs:25:5: 25:10
+          StorageDead(_3);                 // scope 0 at $DIR/simplify-arm.rs:24:15: 24:16
+-         StorageLive(_11);                // scope 1 at $DIR/simplify-arm.rs:25:8: 25:9
+-         _11 = _2;                        // scope 1 at $DIR/simplify-arm.rs:25:8: 25:9
+-         ((_0 as Ok).0: u8) = move _11;   // scope 1 at $DIR/simplify-arm.rs:25:5: 25:10
+-         discriminant(_0) = 0;            // scope 1 at $DIR/simplify-arm.rs:25:5: 25:10
+-         StorageDead(_11);                // scope 1 at $DIR/simplify-arm.rs:25:9: 25:10
+          StorageDead(_2);                 // scope 0 at $DIR/simplify-arm.rs:26:1: 26:2
+          goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:26:2: 26:2
       }
   
       bb2: {
-          StorageLive(_10);                // scope 0 at $DIR/simplify-arm.rs:24:13: 24:15
-          _10 = ((_3 as Ok).0: u8);        // scope 0 at $DIR/simplify-arm.rs:24:13: 24:15
-          _2 = _10;                        // scope 5 at $DIR/simplify-arm.rs:24:13: 24:15
-          StorageDead(_10);                // scope 0 at $DIR/simplify-arm.rs:24:14: 24:15
-          StorageDead(_3);                 // scope 0 at $DIR/simplify-arm.rs:24:15: 24:16
-          StorageLive(_11);                // scope 1 at $DIR/simplify-arm.rs:25:8: 25:9
-          _11 = _2;                        // scope 1 at $DIR/simplify-arm.rs:25:8: 25:9
-          ((_0 as Ok).0: u8) = move _11;   // scope 1 at $DIR/simplify-arm.rs:25:5: 25:10
-          discriminant(_0) = 0;            // scope 1 at $DIR/simplify-arm.rs:25:5: 25:10
-          StorageDead(_11);                // scope 1 at $DIR/simplify-arm.rs:25:9: 25:10
-          StorageDead(_2);                 // scope 0 at $DIR/simplify-arm.rs:26:1: 26:2
-          goto -> bb5;                     // scope 0 at $DIR/simplify-arm.rs:26:2: 26:2
-      }
-  
-      bb3: {
           unreachable;                     // scope 0 at $DIR/simplify-arm.rs:24:13: 24:15
       }
   
-      bb4: {
-          StorageLive(_6);                 // scope 0 at $DIR/simplify-arm.rs:24:14: 24:15
-          _6 = ((_3 as Err).0: i32);       // scope 0 at $DIR/simplify-arm.rs:24:14: 24:15
-          StorageLive(_8);                 // scope 3 at $DIR/simplify-arm.rs:24:14: 24:15
-          StorageLive(_9);                 // scope 3 at $DIR/simplify-arm.rs:24:14: 24:15
-          _9 = _6;                         // scope 3 at $DIR/simplify-arm.rs:24:14: 24:15
-          _8 = const <i32 as std::convert::From<i32>>::from(move _9) -> bb6; // scope 3 at $DIR/simplify-arm.rs:24:14: 24:15
-                                           // ty::Const
-                                           // + ty: fn(i32) -> i32 {<i32 as std::convert::From<i32>>::from}
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/simplify-arm.rs:24:14: 24:15
-                                           // + literal: Const { ty: fn(i32) -> i32 {<i32 as std::convert::From<i32>>::from}, val: Value(Scalar(<ZST>)) }
-      }
-  
-      bb5: {
-          return;                          // scope 0 at $DIR/simplify-arm.rs:26:2: 26:2
-      }
-  
-      bb6: {
-          StorageDead(_9);                 // scope 3 at $DIR/simplify-arm.rs:24:14: 24:15
-          _0 = const <std::result::Result<u8, i32> as std::ops::Try>::from_error(move _8) -> bb7; // scope 3 at $DIR/simplify-arm.rs:24:14: 24:15
-                                           // ty::Const
-                                           // + ty: fn(<std::result::Result<u8, i32> as std::ops::Try>::Error) -> std::result::Result<u8, i32> {<std::result::Result<u8, i32> as std::ops::Try>::from_error}
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/simplify-arm.rs:24:13: 24:15
-                                           // + literal: Const { ty: fn(<std::result::Result<u8, i32> as std::ops::Try>::Error) -> std::result::Result<u8, i32> {<std::result::Result<u8, i32> as std::ops::Try>::from_error}, val: Value(Scalar(<ZST>)) }
-      }
-  
-      bb7: {
-          StorageDead(_8);                 // scope 3 at $DIR/simplify-arm.rs:24:14: 24:15
-          StorageDead(_6);                 // scope 0 at $DIR/simplify-arm.rs:24:14: 24:15
+      bb3: {
+-         StorageLive(_6);                 // scope 0 at $DIR/simplify-arm.rs:24:14: 24:15
+-         _6 = ((_3 as Err).0: i32);       // scope 0 at $DIR/simplify-arm.rs:24:14: 24:15
+-         StorageLive(_8);                 // scope 3 at $DIR/simplify-arm.rs:24:14: 24:15
+-         StorageLive(_9);                 // scope 3 at $DIR/simplify-arm.rs:24:14: 24:15
+-         _9 = _6;                         // scope 3 at $DIR/simplify-arm.rs:24:14: 24:15
+-         _8 = move _9;                    // scope 7 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
+-         StorageDead(_9);                 // scope 3 at $DIR/simplify-arm.rs:24:14: 24:15
+-         StorageLive(_12);                // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
+-         _12 = move _8;                   // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
+-         ((_0 as Err).0: i32) = move _12; // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
+-         discriminant(_0) = 1;            // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
+-         StorageDead(_12);                // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
+-         StorageDead(_8);                 // scope 3 at $DIR/simplify-arm.rs:24:14: 24:15
+-         StorageDead(_6);                 // scope 0 at $DIR/simplify-arm.rs:24:14: 24:15
++         _0 = move _3;                    // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
           StorageDead(_3);                 // scope 0 at $DIR/simplify-arm.rs:24:15: 24:16
           StorageDead(_2);                 // scope 0 at $DIR/simplify-arm.rs:26:1: 26:2
-          goto -> bb5;                     // scope 0 at $DIR/simplify-arm.rs:24:14: 24:15
+          goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:24:14: 24:15
+      }
+  
+      bb4: {
+          return;                          // scope 0 at $DIR/simplify-arm.rs:26:2: 26:2
       }
   }
   

--- a/src/test/mir-opt/simplify_arm.id_try.SimplifyBranchSame.diff
+++ b/src/test/mir-opt/simplify_arm.id_try.SimplifyBranchSame.diff
@@ -15,17 +15,27 @@
       let _10: u8;                         // in scope 0 at $DIR/simplify-arm.rs:24:13: 24:15
       let mut _11: u8;                     // in scope 0 at $DIR/simplify-arm.rs:25:8: 25:9
       scope 1 {
-          debug x => _2;                   // in scope 1 at $DIR/simplify-arm.rs:24:9: 24:10
+          debug x => ((_0 as Ok).0: u8);   // in scope 1 at $DIR/simplify-arm.rs:24:9: 24:10
       }
       scope 2 {
-          debug err => _6;                 // in scope 2 at $DIR/simplify-arm.rs:24:14: 24:15
+          debug err => ((_0 as Err).0: i32); // in scope 2 at $DIR/simplify-arm.rs:24:14: 24:15
           scope 3 {
+              scope 7 {
+                  debug t => ((_0 as Err).0: i32); // in scope 7 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
+              }
+              scope 8 {
+                  debug v => ((_0 as Err).0: i32); // in scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
+                  let mut _12: i32;        // in scope 8 at $DIR/simplify-arm.rs:24:14: 24:15
+              }
           }
       }
       scope 4 {
-          debug val => _10;                // in scope 4 at $DIR/simplify-arm.rs:24:13: 24:15
+          debug val => ((_0 as Ok).0: u8); // in scope 4 at $DIR/simplify-arm.rs:24:13: 24:15
           scope 5 {
           }
+      }
+      scope 6 {
+          debug self => _4;                // in scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
       }
   
       bb0: {
@@ -33,76 +43,34 @@
           StorageLive(_3);                 // scope 0 at $DIR/simplify-arm.rs:24:13: 24:15
           StorageLive(_4);                 // scope 0 at $DIR/simplify-arm.rs:24:13: 24:14
           _4 = _1;                         // scope 0 at $DIR/simplify-arm.rs:24:13: 24:14
-          _3 = const <std::result::Result<u8, i32> as std::ops::Try>::into_result(move _4) -> bb1; // scope 0 at $DIR/simplify-arm.rs:24:13: 24:15
-                                           // ty::Const
-                                           // + ty: fn(std::result::Result<u8, i32>) -> std::result::Result<<std::result::Result<u8, i32> as std::ops::Try>::Ok, <std::result::Result<u8, i32> as std::ops::Try>::Error> {<std::result::Result<u8, i32> as std::ops::Try>::into_result}
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/simplify-arm.rs:24:13: 24:15
-                                           // + literal: Const { ty: fn(std::result::Result<u8, i32>) -> std::result::Result<<std::result::Result<u8, i32> as std::ops::Try>::Ok, <std::result::Result<u8, i32> as std::ops::Try>::Error> {<std::result::Result<u8, i32> as std::ops::Try>::into_result}, val: Value(Scalar(<ZST>)) }
+          _3 = move _4;                    // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+          StorageDead(_4);                 // scope 0 at $DIR/simplify-arm.rs:24:14: 24:15
+          _5 = discriminant(_3);           // scope 0 at $DIR/simplify-arm.rs:24:14: 24:15
+-         switchInt(move _5) -> [0_isize: bb1, 1_isize: bb3, otherwise: bb2]; // scope 0 at $DIR/simplify-arm.rs:24:14: 24:15
++         goto -> bb1;                     // scope 0 at $DIR/simplify-arm.rs:24:14: 24:15
       }
   
       bb1: {
-          StorageDead(_4);                 // scope 0 at $DIR/simplify-arm.rs:24:14: 24:15
-          _5 = discriminant(_3);           // scope 0 at $DIR/simplify-arm.rs:24:14: 24:15
-          switchInt(move _5) -> [0_isize: bb2, 1_isize: bb4, otherwise: bb3]; // scope 0 at $DIR/simplify-arm.rs:24:14: 24:15
+          _0 = move _3;                    // scope 1 at $DIR/simplify-arm.rs:25:5: 25:10
+          StorageDead(_3);                 // scope 0 at $DIR/simplify-arm.rs:24:15: 24:16
+          StorageDead(_2);                 // scope 0 at $DIR/simplify-arm.rs:26:1: 26:2
+-         goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:26:2: 26:2
++         goto -> bb2;                     // scope 0 at $DIR/simplify-arm.rs:26:2: 26:2
       }
   
       bb2: {
-          StorageLive(_10);                // scope 0 at $DIR/simplify-arm.rs:24:13: 24:15
-          _10 = ((_3 as Ok).0: u8);        // scope 0 at $DIR/simplify-arm.rs:24:13: 24:15
-          _2 = _10;                        // scope 5 at $DIR/simplify-arm.rs:24:13: 24:15
-          StorageDead(_10);                // scope 0 at $DIR/simplify-arm.rs:24:14: 24:15
-          StorageDead(_3);                 // scope 0 at $DIR/simplify-arm.rs:24:15: 24:16
-          StorageLive(_11);                // scope 1 at $DIR/simplify-arm.rs:25:8: 25:9
-          _11 = _2;                        // scope 1 at $DIR/simplify-arm.rs:25:8: 25:9
-          ((_0 as Ok).0: u8) = move _11;   // scope 1 at $DIR/simplify-arm.rs:25:5: 25:10
-          discriminant(_0) = 0;            // scope 1 at $DIR/simplify-arm.rs:25:5: 25:10
-          StorageDead(_11);                // scope 1 at $DIR/simplify-arm.rs:25:9: 25:10
-          StorageDead(_2);                 // scope 0 at $DIR/simplify-arm.rs:26:1: 26:2
-          goto -> bb5;                     // scope 0 at $DIR/simplify-arm.rs:26:2: 26:2
-      }
-  
-      bb3: {
-          unreachable;                     // scope 0 at $DIR/simplify-arm.rs:24:13: 24:15
-      }
-  
-      bb4: {
-          StorageLive(_6);                 // scope 0 at $DIR/simplify-arm.rs:24:14: 24:15
-          _6 = ((_3 as Err).0: i32);       // scope 0 at $DIR/simplify-arm.rs:24:14: 24:15
-          StorageLive(_8);                 // scope 3 at $DIR/simplify-arm.rs:24:14: 24:15
-          StorageLive(_9);                 // scope 3 at $DIR/simplify-arm.rs:24:14: 24:15
-          _9 = _6;                         // scope 3 at $DIR/simplify-arm.rs:24:14: 24:15
-          _8 = const <i32 as std::convert::From<i32>>::from(move _9) -> bb6; // scope 3 at $DIR/simplify-arm.rs:24:14: 24:15
-                                           // ty::Const
-                                           // + ty: fn(i32) -> i32 {<i32 as std::convert::From<i32>>::from}
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/simplify-arm.rs:24:14: 24:15
-                                           // + literal: Const { ty: fn(i32) -> i32 {<i32 as std::convert::From<i32>>::from}, val: Value(Scalar(<ZST>)) }
-      }
-  
-      bb5: {
+-         unreachable;                     // scope 0 at $DIR/simplify-arm.rs:24:13: 24:15
+-     }
+- 
+-     bb3: {
+-         _0 = move _3;                    // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
+-         StorageDead(_3);                 // scope 0 at $DIR/simplify-arm.rs:24:15: 24:16
+-         StorageDead(_2);                 // scope 0 at $DIR/simplify-arm.rs:26:1: 26:2
+-         goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:24:14: 24:15
+-     }
+- 
+-     bb4: {
           return;                          // scope 0 at $DIR/simplify-arm.rs:26:2: 26:2
-      }
-  
-      bb6: {
-          StorageDead(_9);                 // scope 3 at $DIR/simplify-arm.rs:24:14: 24:15
-          _0 = const <std::result::Result<u8, i32> as std::ops::Try>::from_error(move _8) -> bb7; // scope 3 at $DIR/simplify-arm.rs:24:14: 24:15
-                                           // ty::Const
-                                           // + ty: fn(<std::result::Result<u8, i32> as std::ops::Try>::Error) -> std::result::Result<u8, i32> {<std::result::Result<u8, i32> as std::ops::Try>::from_error}
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/simplify-arm.rs:24:13: 24:15
-                                           // + literal: Const { ty: fn(<std::result::Result<u8, i32> as std::ops::Try>::Error) -> std::result::Result<u8, i32> {<std::result::Result<u8, i32> as std::ops::Try>::from_error}, val: Value(Scalar(<ZST>)) }
-      }
-  
-      bb7: {
-          StorageDead(_8);                 // scope 3 at $DIR/simplify-arm.rs:24:14: 24:15
-          StorageDead(_6);                 // scope 0 at $DIR/simplify-arm.rs:24:14: 24:15
-          StorageDead(_3);                 // scope 0 at $DIR/simplify-arm.rs:24:15: 24:16
-          StorageDead(_2);                 // scope 0 at $DIR/simplify-arm.rs:26:1: 26:2
-          goto -> bb5;                     // scope 0 at $DIR/simplify-arm.rs:24:14: 24:15
       }
   }
   

--- a/src/test/mir-opt/simplify_locals_removes_unused_discriminant_reads.map.SimplifyLocals.diff.32bit
+++ b/src/test/mir-opt/simplify_locals_removes_unused_discriminant_reads.map.SimplifyLocals.diff.32bit
@@ -4,7 +4,7 @@
   fn map(_1: std::option::Option<std::boxed::Box<()>>) -> std::option::Option<std::boxed::Box<()>> {
       debug x => _1;                       // in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:1:8: 1:9
       let mut _0: std::option::Option<std::boxed::Box<()>>; // return place in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:1:31: 1:46
-      let mut _2: isize;                   // in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:3:9: 3:13
+-     let mut _2: isize;                   // in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:3:9: 3:13
 -     let _3: std::boxed::Box<()>;         // in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:4:14: 4:15
 -     let mut _4: std::boxed::Box<()>;     // in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:4:25: 4:26
 -     let mut _5: bool;                    // in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:6:1: 6:2
@@ -29,21 +29,8 @@
 -                                          // mir::Constant
 -                                          // + span: $DIR/simplify-locals-removes-unused-discriminant-reads.rs:3:9: 3:13
 -                                          // + literal: Const { ty: bool, val: Value(Scalar(0x01)) }
-          _2 = discriminant(_1);           // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:3:9: 3:13
-          switchInt(move _2) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:3:9: 3:13
-      }
-  
-      bb1: {
+-         _2 = discriminant(_1);           // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:3:9: 3:13
           _0 = move _1;                    // scope 1 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:4:20: 4:27
-          goto -> bb3;                     // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:2:5: 5:6
-      }
-  
-      bb2: {
-          discriminant(_0) = 0;            // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:3:17: 3:21
-          goto -> bb3;                     // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:2:5: 5:6
-      }
-  
-      bb3: {
 -         _6 = discriminant(_1);           // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:6:1: 6:2
           return;                          // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:6:2: 6:2
       }

--- a/src/test/mir-opt/simplify_locals_removes_unused_discriminant_reads.map.SimplifyLocals.diff.64bit
+++ b/src/test/mir-opt/simplify_locals_removes_unused_discriminant_reads.map.SimplifyLocals.diff.64bit
@@ -4,7 +4,7 @@
   fn map(_1: std::option::Option<std::boxed::Box<()>>) -> std::option::Option<std::boxed::Box<()>> {
       debug x => _1;                       // in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:1:8: 1:9
       let mut _0: std::option::Option<std::boxed::Box<()>>; // return place in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:1:31: 1:46
-      let mut _2: isize;                   // in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:3:9: 3:13
+-     let mut _2: isize;                   // in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:3:9: 3:13
 -     let _3: std::boxed::Box<()>;         // in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:4:14: 4:15
 -     let mut _4: std::boxed::Box<()>;     // in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:4:25: 4:26
 -     let mut _5: bool;                    // in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:6:1: 6:2
@@ -29,21 +29,8 @@
 -                                          // mir::Constant
 -                                          // + span: $DIR/simplify-locals-removes-unused-discriminant-reads.rs:3:9: 3:13
 -                                          // + literal: Const { ty: bool, val: Value(Scalar(0x01)) }
-          _2 = discriminant(_1);           // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:3:9: 3:13
-          switchInt(move _2) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:3:9: 3:13
-      }
-  
-      bb1: {
+-         _2 = discriminant(_1);           // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:3:9: 3:13
           _0 = move _1;                    // scope 1 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:4:20: 4:27
-          goto -> bb3;                     // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:2:5: 5:6
-      }
-  
-      bb2: {
-          discriminant(_0) = 0;            // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:3:17: 3:21
-          goto -> bb3;                     // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:2:5: 5:6
-      }
-  
-      bb3: {
 -         _6 = discriminant(_1);           // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:6:1: 6:2
           return;                          // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:6:2: 6:2
       }


### PR DESCRIPTION
Modifies SimplifyBranchSame so that it can see that the statements can be considered equal in the following example 
`_0 = _1` and `discriminant(_0) = discriminant(0)` are considered equal if 0 is a fieldless variant of an enum.