### PR TITLE
Don't run tidy exec check on WSL2

### DIFF
--- a/src/tools/tidy/src/bins.rs
+++ b/src/tools/tidy/src/bins.rs
@@ -20,7 +20,7 @@ pub fn check(path: &Path, bad: &mut bool) {
     if let Ok(contents) = fs::read_to_string("/proc/version") {
         // Probably on Windows Linux Subsystem or Docker via VirtualBox,
         // all files will be marked as executable, so skip checking.
-        if contents.contains("Microsoft") || contents.contains("boot2docker") {
+        if contents.contains("Microsoft") || contents.contains("microsoft") || contents.contains("boot2docker") {
             return;
         }
     }

--- a/src/tools/tidy/src/bins.rs
+++ b/src/tools/tidy/src/bins.rs
@@ -20,7 +20,10 @@ pub fn check(path: &Path, bad: &mut bool) {
     if let Ok(contents) = fs::read_to_string("/proc/version") {
         // Probably on Windows Linux Subsystem or Docker via VirtualBox,
         // all files will be marked as executable, so skip checking.
-        if contents.contains("Microsoft") || contents.contains("microsoft") || contents.contains("boot2docker") {
+        if contents.contains("Microsoft")
+            || contents.contains("microsoft")
+            || contents.contains("boot2docker")
+        {
             return;
         }
     }


### PR DESCRIPTION
WSL2 has a lowercase "microsoft' in `/proc/version`