### PR TITLE
Fix #[track_caller] shims for trait objects.

### DIFF
--- a/src/librustc_middle/ty/instance.rs
+++ b/src/librustc_middle/ty/instance.rs
@@ -411,7 +411,7 @@ impl<'tcx> Instance<'tcx> {
             debug!(" => associated item with unsizeable self: Self");
             Some(Instance { def: InstanceDef::VtableShim(def_id), substs })
         } else {
-            Instance::resolve(tcx, param_env, def_id, substs).ok().flatten()
+            Instance::resolve_for_fn_ptr(tcx, param_env, def_id, substs)
         }
     }
 

--- a/src/test/ui/rfc-2091-track-caller/tracked-trait-obj.rs
+++ b/src/test/ui/rfc-2091-track-caller/tracked-trait-obj.rs
@@ -1,0 +1,23 @@
+// run-pass
+
+trait Tracked {
+    #[track_caller]
+    fn handle(&self) {
+        let location = std::panic::Location::caller();
+        assert_eq!(location.file(), file!());
+        // we only call this via trait object, so the def site should *always* be returned
+        assert_eq!(location.line(), line!() - 4);
+        assert_eq!(location.column(), 5);
+    }
+}
+
+impl Tracked for () {}
+impl Tracked for u8 {}
+
+fn main() {
+    let tracked: &dyn Tracked = &5u8;
+    tracked.handle();
+
+    const TRACKED: &dyn Tracked = &();
+    TRACKED.handle();
+}


### PR DESCRIPTION
We were missing an Instance::resolve_for_fn_ptr in resolve_for_vtable.

Closes #74764.