### PR TITLE
report kind of deprecated item in message

### DIFF
--- a/src/librustc_lint/context.rs
+++ b/src/librustc_lint/context.rs
@@ -573,7 +573,7 @@ pub trait LintContext: Sized {
                     }
                 }
                 BuiltinLintDiagnostics::DeprecatedMacro(suggestion, span) => {
-                    stability::deprecation_suggestion(&mut db, suggestion, span)
+                    stability::deprecation_suggestion(&mut db, "macro", suggestion, span)
                 }
                 BuiltinLintDiagnostics::UnusedDocComment(span) => {
                     db.span_label(span, "rustdoc does not generate documentation for macro invocations");

--- a/src/librustc_resolve/macros.rs
+++ b/src/librustc_resolve/macros.rs
@@ -1020,7 +1020,7 @@ impl<'a> Resolver<'a> {
         }
         if let Some(depr) = &ext.deprecation {
             let path = pprust::path_to_string(&path);
-            let (message, lint) = stability::deprecation_message(depr, &path);
+            let (message, lint) = stability::deprecation_message(depr, "macro", &path);
             stability::early_report_deprecation(
                 &mut self.lint_buffer,
                 &message,

--- a/src/test/ui/conditional-compilation/cfg-attr-multi-true.rs
+++ b/src/test/ui/conditional-compilation/cfg-attr-multi-true.rs
@@ -9,13 +9,13 @@
 #[cfg_attr(all(), deprecated, must_use)]
 struct MustUseDeprecated {}
 
-impl MustUseDeprecated { //~ warning: use of deprecated item
-    fn new() -> MustUseDeprecated { //~ warning: use of deprecated item
-        MustUseDeprecated {} //~ warning: use of deprecated item
+impl MustUseDeprecated { //~ warning: use of deprecated
+    fn new() -> MustUseDeprecated { //~ warning: use of deprecated
+        MustUseDeprecated {} //~ warning: use of deprecated
     }
 }
 
 fn main() {
-    MustUseDeprecated::new(); //~ warning: use of deprecated item
+    MustUseDeprecated::new(); //~ warning: use of deprecated
     //~| warning: unused `MustUseDeprecated` that must be used
 }

--- a/src/test/ui/conditional-compilation/cfg-attr-multi-true.stderr
+++ b/src/test/ui/conditional-compilation/cfg-attr-multi-true.stderr
@@ -1,4 +1,4 @@
-warning: use of deprecated item 'MustUseDeprecated'
+warning: use of deprecated struct `MustUseDeprecated`
   --> $DIR/cfg-attr-multi-true.rs:12:6
    |
 LL | impl MustUseDeprecated {
@@ -6,19 +6,19 @@ LL | impl MustUseDeprecated {
    |
    = note: `#[warn(deprecated)]` on by default
 
-warning: use of deprecated item 'MustUseDeprecated'
+warning: use of deprecated struct `MustUseDeprecated`
   --> $DIR/cfg-attr-multi-true.rs:19:5
    |
 LL |     MustUseDeprecated::new();
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'MustUseDeprecated'
+warning: use of deprecated struct `MustUseDeprecated`
   --> $DIR/cfg-attr-multi-true.rs:13:17
    |
 LL |     fn new() -> MustUseDeprecated {
    |                 ^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'MustUseDeprecated'
+warning: use of deprecated struct `MustUseDeprecated`
   --> $DIR/cfg-attr-multi-true.rs:14:9
    |
 LL |         MustUseDeprecated {}

--- a/src/test/ui/deprecation/atomic_initializers.fixed
+++ b/src/test/ui/deprecation/atomic_initializers.fixed
@@ -6,6 +6,6 @@ use std::sync::atomic::{AtomicIsize, ATOMIC_ISIZE_INIT};
 
 #[allow(dead_code)]
 static FOO: AtomicIsize = AtomicIsize::new(0);
-//~^ WARN use of deprecated item
+//~^ WARN use of deprecated constant
 
 fn main() {}

--- a/src/test/ui/deprecation/atomic_initializers.rs
+++ b/src/test/ui/deprecation/atomic_initializers.rs
@@ -6,6 +6,6 @@ use std::sync::atomic::{AtomicIsize, ATOMIC_ISIZE_INIT};
 
 #[allow(dead_code)]
 static FOO: AtomicIsize = ATOMIC_ISIZE_INIT;
-//~^ WARN use of deprecated item
+//~^ WARN use of deprecated constant
 
 fn main() {}

--- a/src/test/ui/deprecation/atomic_initializers.stderr
+++ b/src/test/ui/deprecation/atomic_initializers.stderr
@@ -1,8 +1,8 @@
-warning: use of deprecated item 'std::sync::atomic::ATOMIC_ISIZE_INIT': the `new` function is now preferred
+warning: use of deprecated constant `std::sync::atomic::ATOMIC_ISIZE_INIT`: the `new` function is now preferred
   --> $DIR/atomic_initializers.rs:8:27
    |
 LL | static FOO: AtomicIsize = ATOMIC_ISIZE_INIT;
-   |                           ^^^^^^^^^^^^^^^^^ help: replace the use of the deprecated item: `AtomicIsize::new(0)`
+   |                           ^^^^^^^^^^^^^^^^^ help: replace the use of the deprecated constant: `AtomicIsize::new(0)`
    |
    = note: `#[warn(deprecated)]` on by default
 

--- a/src/test/ui/deprecation/deprecation-in-future.rs
+++ b/src/test/ui/deprecation/deprecation-in-future.rs
@@ -7,7 +7,7 @@ pub fn deprecated_future() {}
 
 fn test() {
     deprecated_future(); // ok; deprecated_in_future only applies to rustc_deprecated
-    //~^ WARNING use of deprecated item 'deprecated_future': text [deprecated]
+    //~^ WARNING use of deprecated function `deprecated_future`: text [deprecated]
 }
 
 fn main() {}

--- a/src/test/ui/deprecation/deprecation-in-future.stderr
+++ b/src/test/ui/deprecation/deprecation-in-future.stderr
@@ -1,4 +1,4 @@
-warning: use of deprecated item 'deprecated_future': text
+warning: use of deprecated function `deprecated_future`: text
   --> $DIR/deprecation-in-future.rs:9:5
    |
 LL |     deprecated_future(); // ok; deprecated_in_future only applies to rustc_deprecated

--- a/src/test/ui/deprecation/deprecation-lint-2.rs
+++ b/src/test/ui/deprecation/deprecation-lint-2.rs
@@ -1,5 +1,5 @@
 // aux-build:deprecation-lint.rs
-// error-pattern: use of deprecated item
+// error-pattern: use of deprecated function
 
 #![deny(deprecated)]
 

--- a/src/test/ui/deprecation/deprecation-lint-2.stderr
+++ b/src/test/ui/deprecation/deprecation-lint-2.stderr
@@ -1,4 +1,4 @@
-error: use of deprecated item 'deprecation_lint::deprecated': text
+error: use of deprecated function `deprecation_lint::deprecated`: text
   --> $DIR/deprecation-lint-2.rs:12:5
    |
 LL |     macro_test!();

--- a/src/test/ui/deprecation/deprecation-lint-3.rs
+++ b/src/test/ui/deprecation/deprecation-lint-3.rs
@@ -1,5 +1,5 @@
 // aux-build:deprecation-lint.rs
-// error-pattern: use of deprecated item
+// error-pattern: use of deprecated function
 
 #![deny(deprecated)]
 #![allow(warnings)]

--- a/src/test/ui/deprecation/deprecation-lint-3.stderr
+++ b/src/test/ui/deprecation/deprecation-lint-3.stderr
@@ -1,4 +1,4 @@
-error: use of deprecated item 'deprecation_lint::deprecated_text': text
+error: use of deprecated function `deprecation_lint::deprecated_text`: text
   --> $DIR/deprecation-lint-3.rs:13:5
    |
 LL |     macro_test_arg_nested!(deprecated_text);

--- a/src/test/ui/deprecation/deprecation-lint-nested.rs
+++ b/src/test/ui/deprecation/deprecation-lint-nested.rs
@@ -52,19 +52,19 @@ mod loud {
     #[deprecated]
     const DEPRECATED_CONST: u8 = 1;
 
-    struct Foo(DeprecatedType); //~ ERROR use of deprecated item
+    struct Foo(DeprecatedType); //~ ERROR use of deprecated type alias
 
-    impl DeprecatedTrait for Foo {} //~ ERROR use of deprecated item
+    impl DeprecatedTrait for Foo {} //~ ERROR use of deprecated trait
 
     impl Foo {
-        fn bar<T: DeprecatedTrait>() { //~ ERROR use of deprecated item
-            deprecated_fn(); //~ ERROR use of deprecated item
+        fn bar<T: DeprecatedTrait>() { //~ ERROR use of deprecated trait
+            deprecated_fn(); //~ ERROR use of deprecated function
         }
     }
 
     fn foo() -> u8 {
-        DEPRECATED_STATIC + //~ ERROR use of deprecated item
-        DEPRECATED_CONST //~ ERROR use of deprecated item
+        DEPRECATED_STATIC + //~ ERROR use of deprecated static
+        DEPRECATED_CONST //~ ERROR use of deprecated const
     }
 }
 

--- a/src/test/ui/deprecation/deprecation-lint-nested.stderr
+++ b/src/test/ui/deprecation/deprecation-lint-nested.stderr
@@ -1,4 +1,4 @@
-error: use of deprecated item 'loud::DeprecatedType'
+error: use of deprecated type alias `loud::DeprecatedType`
   --> $DIR/deprecation-lint-nested.rs:55:16
    |
 LL |     struct Foo(DeprecatedType);
@@ -10,31 +10,31 @@ note: the lint level is defined here
 LL | #![deny(deprecated)]
    |         ^^^^^^^^^^
 
-error: use of deprecated item 'loud::DeprecatedTrait'
+error: use of deprecated trait `loud::DeprecatedTrait`
   --> $DIR/deprecation-lint-nested.rs:57:10
    |
 LL |     impl DeprecatedTrait for Foo {}
    |          ^^^^^^^^^^^^^^^
 
-error: use of deprecated item 'loud::DEPRECATED_STATIC'
+error: use of deprecated static `loud::DEPRECATED_STATIC`
   --> $DIR/deprecation-lint-nested.rs:66:9
    |
 LL |         DEPRECATED_STATIC +
    |         ^^^^^^^^^^^^^^^^^
 
-error: use of deprecated item 'loud::DEPRECATED_CONST'
+error: use of deprecated constant `loud::DEPRECATED_CONST`
   --> $DIR/deprecation-lint-nested.rs:67:9
    |
 LL |         DEPRECATED_CONST
    |         ^^^^^^^^^^^^^^^^
 
-error: use of deprecated item 'loud::DeprecatedTrait'
+error: use of deprecated trait `loud::DeprecatedTrait`
   --> $DIR/deprecation-lint-nested.rs:60:19
    |
 LL |         fn bar<T: DeprecatedTrait>() {
    |                   ^^^^^^^^^^^^^^^
 
-error: use of deprecated item 'loud::deprecated_fn'
+error: use of deprecated function `loud::deprecated_fn`
   --> $DIR/deprecation-lint-nested.rs:61:13
    |
 LL |             deprecated_fn();

--- a/src/test/ui/deprecation/deprecation-lint.rs
+++ b/src/test/ui/deprecation/deprecation-lint.rs
@@ -14,86 +14,86 @@ mod cross_crate {
         type Foo = MethodTester;
         let foo = MethodTester;
 
-        deprecated(); //~ ERROR use of deprecated item 'deprecation_lint::deprecated'
-        foo.method_deprecated(); //~ ERROR use of deprecated item 'deprecation_lint::MethodTester::method_deprecated'
-        Foo::method_deprecated(&foo); //~ ERROR use of deprecated item 'deprecation_lint::MethodTester::method_deprecated'
-        <Foo>::method_deprecated(&foo); //~ ERROR use of deprecated item 'deprecation_lint::MethodTester::method_deprecated'
-        foo.trait_deprecated(); //~ ERROR use of deprecated item 'deprecation_lint::Trait::trait_deprecated'
-        Trait::trait_deprecated(&foo); //~ ERROR use of deprecated item 'deprecation_lint::Trait::trait_deprecated'
-        <Foo>::trait_deprecated(&foo); //~ ERROR use of deprecated item 'deprecation_lint::Trait::trait_deprecated'
-        <Foo as Trait>::trait_deprecated(&foo); //~ ERROR use of deprecated item 'deprecation_lint::Trait::trait_deprecated'
+        deprecated(); //~ ERROR use of deprecated function `deprecation_lint::deprecated`
+        foo.method_deprecated(); //~ ERROR use of deprecated associated function `deprecation_lint::MethodTester::method_deprecated`
+        Foo::method_deprecated(&foo); //~ ERROR use of deprecated associated function `deprecation_lint::MethodTester::method_deprecated`
+        <Foo>::method_deprecated(&foo); //~ ERROR use of deprecated associated function `deprecation_lint::MethodTester::method_deprecated`
+        foo.trait_deprecated(); //~ ERROR use of deprecated associated function `deprecation_lint::Trait::trait_deprecated`
+        Trait::trait_deprecated(&foo); //~ ERROR use of deprecated associated function `deprecation_lint::Trait::trait_deprecated`
+        <Foo>::trait_deprecated(&foo); //~ ERROR use of deprecated associated function `deprecation_lint::Trait::trait_deprecated`
+        <Foo as Trait>::trait_deprecated(&foo); //~ ERROR use of deprecated associated function `deprecation_lint::Trait::trait_deprecated`
 
-        deprecated_text(); //~ ERROR use of deprecated item 'deprecation_lint::deprecated_text': text
-        foo.method_deprecated_text(); //~ ERROR use of deprecated item 'deprecation_lint::MethodTester::method_deprecated_text': text
-        Foo::method_deprecated_text(&foo); //~ ERROR use of deprecated item 'deprecation_lint::MethodTester::method_deprecated_text': text
-        <Foo>::method_deprecated_text(&foo); //~ ERROR use of deprecated item 'deprecation_lint::MethodTester::method_deprecated_text': text
-        foo.trait_deprecated_text(); //~ ERROR use of deprecated item 'deprecation_lint::Trait::trait_deprecated_text': text
-        Trait::trait_deprecated_text(&foo); //~ ERROR use of deprecated item 'deprecation_lint::Trait::trait_deprecated_text': text
-        <Foo>::trait_deprecated_text(&foo); //~ ERROR use of deprecated item 'deprecation_lint::Trait::trait_deprecated_text': text
-        <Foo as Trait>::trait_deprecated_text(&foo); //~ ERROR use of deprecated item 'deprecation_lint::Trait::trait_deprecated_text': text
+        deprecated_text(); //~ ERROR use of deprecated function `deprecation_lint::deprecated_text`: text
+        foo.method_deprecated_text(); //~ ERROR use of deprecated associated function `deprecation_lint::MethodTester::method_deprecated_text`: text
+        Foo::method_deprecated_text(&foo); //~ ERROR use of deprecated associated function `deprecation_lint::MethodTester::method_deprecated_text`: text
+        <Foo>::method_deprecated_text(&foo); //~ ERROR use of deprecated associated function `deprecation_lint::MethodTester::method_deprecated_text`: text
+        foo.trait_deprecated_text(); //~ ERROR use of deprecated associated function `deprecation_lint::Trait::trait_deprecated_text`: text
+        Trait::trait_deprecated_text(&foo); //~ ERROR use of deprecated associated function `deprecation_lint::Trait::trait_deprecated_text`: text
+        <Foo>::trait_deprecated_text(&foo); //~ ERROR use of deprecated associated function `deprecation_lint::Trait::trait_deprecated_text`: text
+        <Foo as Trait>::trait_deprecated_text(&foo); //~ ERROR use of deprecated associated function `deprecation_lint::Trait::trait_deprecated_text`: text
 
-        let _ = DeprecatedStruct { //~ ERROR use of deprecated item 'deprecation_lint::DeprecatedStruct': text
-            i: 0 //~ ERROR use of deprecated item 'deprecation_lint::DeprecatedStruct::i': text
+        let _ = DeprecatedStruct { //~ ERROR use of deprecated struct `deprecation_lint::DeprecatedStruct`: text
+            i: 0 //~ ERROR use of deprecated field `deprecation_lint::DeprecatedStruct::i`: text
         };
 
-        let _ = DeprecatedUnitStruct; //~ ERROR use of deprecated item 'deprecation_lint::DeprecatedUnitStruct': text
+        let _ = DeprecatedUnitStruct; //~ ERROR use of deprecated struct `deprecation_lint::DeprecatedUnitStruct`: text
 
-        let _ = Enum::DeprecatedVariant; //~ ERROR use of deprecated item 'deprecation_lint::Enum::DeprecatedVariant': text
+        let _ = Enum::DeprecatedVariant; //~ ERROR use of deprecated variant `deprecation_lint::Enum::DeprecatedVariant`: text
 
-        let _ = DeprecatedTupleStruct (1); //~ ERROR use of deprecated item 'deprecation_lint::DeprecatedTupleStruct': text
+        let _ = DeprecatedTupleStruct (1); //~ ERROR use of deprecated struct `deprecation_lint::DeprecatedTupleStruct`: text
 
-        let _ = nested::DeprecatedStruct { //~ ERROR use of deprecated item 'deprecation_lint::nested::DeprecatedStruct': text
-            i: 0 //~ ERROR use of deprecated item 'deprecation_lint::nested::DeprecatedStruct::i': text
+        let _ = nested::DeprecatedStruct { //~ ERROR use of deprecated struct `deprecation_lint::nested::DeprecatedStruct`: text
+            i: 0 //~ ERROR use of deprecated field `deprecation_lint::nested::DeprecatedStruct::i`: text
         };
 
-        let _ = nested::DeprecatedUnitStruct; //~ ERROR use of deprecated item 'deprecation_lint::nested::DeprecatedUnitStruct': text
+        let _ = nested::DeprecatedUnitStruct; //~ ERROR use of deprecated struct `deprecation_lint::nested::DeprecatedUnitStruct`: text
 
-        let _ = nested::Enum::DeprecatedVariant; //~ ERROR use of deprecated item 'deprecation_lint::nested::Enum::DeprecatedVariant': text
+        let _ = nested::Enum::DeprecatedVariant; //~ ERROR use of deprecated variant `deprecation_lint::nested::Enum::DeprecatedVariant`: text
 
-        let _ = nested::DeprecatedTupleStruct (1); //~ ERROR use of deprecated item 'deprecation_lint::nested::DeprecatedTupleStruct': text
+        let _ = nested::DeprecatedTupleStruct (1); //~ ERROR use of deprecated struct `deprecation_lint::nested::DeprecatedTupleStruct`: text
 
         // At the moment, the lint checker only checks stability in
         // in the arguments of macros.
         // Eventually, we will want to lint the contents of the
         // macro in the module *defining* it. Also, stability levels
         // on macros themselves are not yet linted.
-        macro_test_arg!(deprecated_text()); //~ ERROR use of deprecated item 'deprecation_lint::deprecated_text': text
-        macro_test_arg!(macro_test_arg!(deprecated_text())); //~ ERROR use of deprecated item 'deprecation_lint::deprecated_text': text
+        macro_test_arg!(deprecated_text()); //~ ERROR use of deprecated function `deprecation_lint::deprecated_text`: text
+        macro_test_arg!(macro_test_arg!(deprecated_text())); //~ ERROR use of deprecated function `deprecation_lint::deprecated_text`: text
     }
 
     fn test_method_param<Foo: Trait>(foo: Foo) {
-        foo.trait_deprecated(); //~ ERROR use of deprecated item 'deprecation_lint::Trait::trait_deprecated'
-        Trait::trait_deprecated(&foo); //~ ERROR use of deprecated item 'deprecation_lint::Trait::trait_deprecated'
-        <Foo>::trait_deprecated(&foo); //~ ERROR use of deprecated item 'deprecation_lint::Trait::trait_deprecated'
-        <Foo as Trait>::trait_deprecated(&foo); //~ ERROR use of deprecated item 'deprecation_lint::Trait::trait_deprecated'
-        foo.trait_deprecated_text(); //~ ERROR use of deprecated item 'deprecation_lint::Trait::trait_deprecated_text': text
-        Trait::trait_deprecated_text(&foo); //~ ERROR use of deprecated item 'deprecation_lint::Trait::trait_deprecated_text': text
-        <Foo>::trait_deprecated_text(&foo); //~ ERROR use of deprecated item 'deprecation_lint::Trait::trait_deprecated_text': text
-        <Foo as Trait>::trait_deprecated_text(&foo); //~ ERROR use of deprecated item 'deprecation_lint::Trait::trait_deprecated_text': text
+        foo.trait_deprecated(); //~ ERROR use of deprecated associated function `deprecation_lint::Trait::trait_deprecated`
+        Trait::trait_deprecated(&foo); //~ ERROR use of deprecated associated function `deprecation_lint::Trait::trait_deprecated`
+        <Foo>::trait_deprecated(&foo); //~ ERROR use of deprecated associated function `deprecation_lint::Trait::trait_deprecated`
+        <Foo as Trait>::trait_deprecated(&foo); //~ ERROR use of deprecated associated function `deprecation_lint::Trait::trait_deprecated`
+        foo.trait_deprecated_text(); //~ ERROR use of deprecated associated function `deprecation_lint::Trait::trait_deprecated_text`: text
+        Trait::trait_deprecated_text(&foo); //~ ERROR use of deprecated associated function `deprecation_lint::Trait::trait_deprecated_text`: text
+        <Foo>::trait_deprecated_text(&foo); //~ ERROR use of deprecated associated function `deprecation_lint::Trait::trait_deprecated_text`: text
+        <Foo as Trait>::trait_deprecated_text(&foo); //~ ERROR use of deprecated associated function `deprecation_lint::Trait::trait_deprecated_text`: text
     }
 
     fn test_method_object(foo: &Trait) {
-        foo.trait_deprecated(); //~ ERROR use of deprecated item 'deprecation_lint::Trait::trait_deprecated'
-        foo.trait_deprecated_text(); //~ ERROR use of deprecated item 'deprecation_lint::Trait::trait_deprecated_text': text
+        foo.trait_deprecated(); //~ ERROR use of deprecated associated function `deprecation_lint::Trait::trait_deprecated`
+        foo.trait_deprecated_text(); //~ ERROR use of deprecated associated function `deprecation_lint::Trait::trait_deprecated_text`: text
     }
 
     struct S;
 
-    impl DeprecatedTrait for S {} //~ ERROR use of deprecated item 'deprecation_lint::DeprecatedTrait': text
-    trait LocalTrait : DeprecatedTrait { } //~ ERROR use of deprecated item 'deprecation_lint::DeprecatedTrait': text
+    impl DeprecatedTrait for S {} //~ ERROR use of deprecated trait `deprecation_lint::DeprecatedTrait`: text
+    trait LocalTrait : DeprecatedTrait { } //~ ERROR use of deprecated trait `deprecation_lint::DeprecatedTrait`: text
 
     pub fn foo() {
         let x = Stable {
             override2: 3,
-            //~^ ERROR use of deprecated item 'deprecation_lint::Stable::override2': text
+            //~^ ERROR use of deprecated field `deprecation_lint::Stable::override2`: text
         };
 
         let _ = x.override2;
-        //~^ ERROR use of deprecated item 'deprecation_lint::Stable::override2': text
+        //~^ ERROR use of deprecated field `deprecation_lint::Stable::override2`: text
 
         let Stable {
             override2: _
-            //~^ ERROR use of deprecated item 'deprecation_lint::Stable::override2': text
+            //~^ ERROR use of deprecated field `deprecation_lint::Stable::override2`: text
         } = x;
         // all fine
         let Stable { .. } = x;
@@ -101,56 +101,56 @@ mod cross_crate {
         let x = Stable2(1, 2, 3);
 
         let _ = x.2;
-        //~^ ERROR use of deprecated item 'deprecation_lint::Stable2::2': text
+        //~^ ERROR use of deprecated field `deprecation_lint::Stable2::2`: text
 
         let Stable2(_,
                    _,
                    _)
-            //~^ ERROR use of deprecated item 'deprecation_lint::Stable2::2': text
+            //~^ ERROR use of deprecated field `deprecation_lint::Stable2::2`: text
             = x;
         // all fine
         let Stable2(..) = x;
 
         let x = Deprecated {
-            //~^ ERROR use of deprecated item 'deprecation_lint::Deprecated': text
+            //~^ ERROR use of deprecated struct `deprecation_lint::Deprecated`: text
             inherit: 1,
-            //~^ ERROR use of deprecated item 'deprecation_lint::Deprecated::inherit': text
+            //~^ ERROR use of deprecated field `deprecation_lint::Deprecated::inherit`: text
         };
 
         let _ = x.inherit;
-        //~^ ERROR use of deprecated item 'deprecation_lint::Deprecated::inherit': text
+        //~^ ERROR use of deprecated field `deprecation_lint::Deprecated::inherit`: text
 
         let Deprecated {
-            //~^ ERROR use of deprecated item 'deprecation_lint::Deprecated': text
+            //~^ ERROR use of deprecated struct `deprecation_lint::Deprecated`: text
             inherit: _,
-            //~^ ERROR use of deprecated item 'deprecation_lint::Deprecated::inherit': text
+            //~^ ERROR use of deprecated field `deprecation_lint::Deprecated::inherit`: text
         } = x;
 
         let Deprecated
-            //~^ ERROR use of deprecated item 'deprecation_lint::Deprecated': text
+            //~^ ERROR use of deprecated struct `deprecation_lint::Deprecated`: text
             { .. } = x;
 
         let x = Deprecated2(1, 2, 3);
-        //~^ ERROR use of deprecated item 'deprecation_lint::Deprecated2': text
+        //~^ ERROR use of deprecated struct `deprecation_lint::Deprecated2`: text
 
         let _ = x.0;
-        //~^ ERROR use of deprecated item 'deprecation_lint::Deprecated2::0': text
+        //~^ ERROR use of deprecated field `deprecation_lint::Deprecated2::0`: text
         let _ = x.1;
-        //~^ ERROR use of deprecated item 'deprecation_lint::Deprecated2::1': text
+        //~^ ERROR use of deprecated field `deprecation_lint::Deprecated2::1`: text
         let _ = x.2;
-        //~^ ERROR use of deprecated item 'deprecation_lint::Deprecated2::2': text
+        //~^ ERROR use of deprecated field `deprecation_lint::Deprecated2::2`: text
 
         let Deprecated2
-        //~^ ERROR use of deprecated item 'deprecation_lint::Deprecated2': text
+        //~^ ERROR use of deprecated struct `deprecation_lint::Deprecated2`: text
             (_,
-             //~^ ERROR use of deprecated item 'deprecation_lint::Deprecated2::0': text
+             //~^ ERROR use of deprecated field `deprecation_lint::Deprecated2::0`: text
              _,
-             //~^ ERROR use of deprecated item 'deprecation_lint::Deprecated2::1': text
+             //~^ ERROR use of deprecated field `deprecation_lint::Deprecated2::1`: text
              _)
-             //~^ ERROR use of deprecated item 'deprecation_lint::Deprecated2::2': text
+             //~^ ERROR use of deprecated field `deprecation_lint::Deprecated2::2`: text
             = x;
         let Deprecated2
-        //~^ ERROR use of deprecated item 'deprecation_lint::Deprecated2': text
+        //~^ ERROR use of deprecated struct `deprecation_lint::Deprecated2`: text
             // the patterns are all fine:
             (..) = x;
     }
@@ -160,7 +160,7 @@ mod inheritance {
     use deprecation_lint::*;
 
     fn test_inheritance() {
-        deprecated_mod::deprecated(); //~ ERROR use of deprecated item 'deprecation_lint::deprecated_mod::deprecated': text
+        deprecated_mod::deprecated(); //~ ERROR use of deprecated function `deprecation_lint::deprecated_mod::deprecated`: text
     }
 }
 
@@ -243,65 +243,65 @@ mod this_crate {
         type Foo = MethodTester;
         let foo = MethodTester;
 
-        deprecated(); //~ ERROR use of deprecated item 'this_crate::deprecated'
-        foo.method_deprecated(); //~ ERROR use of deprecated item 'this_crate::MethodTester::method_deprecated'
-        Foo::method_deprecated(&foo); //~ ERROR use of deprecated item 'this_crate::MethodTester::method_deprecated'
-        <Foo>::method_deprecated(&foo); //~ ERROR use of deprecated item 'this_crate::MethodTester::method_deprecated'
-        foo.trait_deprecated(); //~ ERROR use of deprecated item 'this_crate::Trait::trait_deprecated'
-        Trait::trait_deprecated(&foo); //~ ERROR use of deprecated item 'this_crate::Trait::trait_deprecated'
-        <Foo>::trait_deprecated(&foo); //~ ERROR use of deprecated item 'this_crate::Trait::trait_deprecated'
-        <Foo as Trait>::trait_deprecated(&foo); //~ ERROR use of deprecated item 'this_crate::Trait::trait_deprecated'
+        deprecated(); //~ ERROR use of deprecated function `this_crate::deprecated`
+        foo.method_deprecated(); //~ ERROR use of deprecated associated function `this_crate::MethodTester::method_deprecated`
+        Foo::method_deprecated(&foo); //~ ERROR use of deprecated associated function `this_crate::MethodTester::method_deprecated`
+        <Foo>::method_deprecated(&foo); //~ ERROR use of deprecated associated function `this_crate::MethodTester::method_deprecated`
+        foo.trait_deprecated(); //~ ERROR use of deprecated associated function `this_crate::Trait::trait_deprecated`
+        Trait::trait_deprecated(&foo); //~ ERROR use of deprecated associated function `this_crate::Trait::trait_deprecated`
+        <Foo>::trait_deprecated(&foo); //~ ERROR use of deprecated associated function `this_crate::Trait::trait_deprecated`
+        <Foo as Trait>::trait_deprecated(&foo); //~ ERROR use of deprecated associated function `this_crate::Trait::trait_deprecated`
 
-        deprecated_text(); //~ ERROR use of deprecated item 'this_crate::deprecated_text': text
-        foo.method_deprecated_text(); //~ ERROR use of deprecated item 'this_crate::MethodTester::method_deprecated_text': text
-        Foo::method_deprecated_text(&foo); //~ ERROR use of deprecated item 'this_crate::MethodTester::method_deprecated_text': text
-        <Foo>::method_deprecated_text(&foo); //~ ERROR use of deprecated item 'this_crate::MethodTester::method_deprecated_text': text
-        foo.trait_deprecated_text(); //~ ERROR use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
-        Trait::trait_deprecated_text(&foo); //~ ERROR use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
-        <Foo>::trait_deprecated_text(&foo); //~ ERROR use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
-        <Foo as Trait>::trait_deprecated_text(&foo); //~ ERROR use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
+        deprecated_text(); //~ ERROR use of deprecated function `this_crate::deprecated_text`: text
+        foo.method_deprecated_text(); //~ ERROR use of deprecated associated function `this_crate::MethodTester::method_deprecated_text`: text
+        Foo::method_deprecated_text(&foo); //~ ERROR use of deprecated associated function `this_crate::MethodTester::method_deprecated_text`: text
+        <Foo>::method_deprecated_text(&foo); //~ ERROR use of deprecated associated function `this_crate::MethodTester::method_deprecated_text`: text
+        foo.trait_deprecated_text(); //~ ERROR use of deprecated associated function `this_crate::Trait::trait_deprecated_text`: text
+        Trait::trait_deprecated_text(&foo); //~ ERROR use of deprecated associated function `this_crate::Trait::trait_deprecated_text`: text
+        <Foo>::trait_deprecated_text(&foo); //~ ERROR use of deprecated associated function `this_crate::Trait::trait_deprecated_text`: text
+        <Foo as Trait>::trait_deprecated_text(&foo); //~ ERROR use of deprecated associated function `this_crate::Trait::trait_deprecated_text`: text
 
         // Future deprecations are only permitted for rustc_deprecated.
-        deprecated_future(); //~ ERROR use of deprecated item
-        deprecated_future_text(); //~ ERROR use of deprecated item
+        deprecated_future(); //~ ERROR use of deprecated function
+        deprecated_future_text(); //~ ERROR use of deprecated function
 
         let _ = DeprecatedStruct {
-            //~^ ERROR use of deprecated item 'this_crate::DeprecatedStruct': text
-            i: 0 //~ ERROR use of deprecated item 'this_crate::DeprecatedStruct::i': text
+            //~^ ERROR use of deprecated struct `this_crate::DeprecatedStruct`: text
+            i: 0 //~ ERROR use of deprecated field `this_crate::DeprecatedStruct::i`: text
         };
 
-        let _ = DeprecatedUnitStruct; //~ ERROR use of deprecated item 'this_crate::DeprecatedUnitStruct': text
+        let _ = DeprecatedUnitStruct; //~ ERROR use of deprecated unit struct `this_crate::DeprecatedUnitStruct`: text
 
-        let _ = Enum::DeprecatedVariant; //~ ERROR use of deprecated item 'this_crate::Enum::DeprecatedVariant': text
+        let _ = Enum::DeprecatedVariant; //~ ERROR use of deprecated unit variant `this_crate::Enum::DeprecatedVariant`: text
 
-        let _ = DeprecatedTupleStruct (1); //~ ERROR use of deprecated item 'this_crate::DeprecatedTupleStruct': text
+        let _ = DeprecatedTupleStruct (1); //~ ERROR use of deprecated tuple struct `this_crate::DeprecatedTupleStruct`: text
 
         let _ = nested::DeprecatedStruct {
-            //~^ ERROR use of deprecated item 'this_crate::nested::DeprecatedStruct': text
-            i: 0 //~ ERROR use of deprecated item 'this_crate::nested::DeprecatedStruct::i': text
+            //~^ ERROR use of deprecated struct `this_crate::nested::DeprecatedStruct`: text
+            i: 0 //~ ERROR use of deprecated field `this_crate::nested::DeprecatedStruct::i`: text
         };
 
-        let _ = nested::DeprecatedUnitStruct; //~ ERROR use of deprecated item 'this_crate::nested::DeprecatedUnitStruct': text
+        let _ = nested::DeprecatedUnitStruct; //~ ERROR use of deprecated unit struct `this_crate::nested::DeprecatedUnitStruct`: text
 
-        let _ = nested::Enum::DeprecatedVariant; //~ ERROR use of deprecated item 'this_crate::nested::Enum::DeprecatedVariant': text
+        let _ = nested::Enum::DeprecatedVariant; //~ ERROR use of deprecated unit variant `this_crate::nested::Enum::DeprecatedVariant`: text
 
-        let _ = nested::DeprecatedTupleStruct (1); //~ ERROR use of deprecated item 'this_crate::nested::DeprecatedTupleStruct': text
+        let _ = nested::DeprecatedTupleStruct (1); //~ ERROR use of deprecated tuple struct `this_crate::nested::DeprecatedTupleStruct`: text
     }
 
     fn test_method_param<Foo: Trait>(foo: Foo) {
-        foo.trait_deprecated(); //~ ERROR use of deprecated item 'this_crate::Trait::trait_deprecated'
-        Trait::trait_deprecated(&foo); //~ ERROR use of deprecated item 'this_crate::Trait::trait_deprecated'
-        <Foo>::trait_deprecated(&foo); //~ ERROR use of deprecated item 'this_crate::Trait::trait_deprecated'
-        <Foo as Trait>::trait_deprecated(&foo); //~ ERROR use of deprecated item 'this_crate::Trait::trait_deprecated'
-        foo.trait_deprecated_text(); //~ ERROR use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
-        Trait::trait_deprecated_text(&foo); //~ ERROR use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
-        <Foo>::trait_deprecated_text(&foo); //~ ERROR use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
-        <Foo as Trait>::trait_deprecated_text(&foo); //~ ERROR use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
+        foo.trait_deprecated(); //~ ERROR use of deprecated associated function `this_crate::Trait::trait_deprecated`
+        Trait::trait_deprecated(&foo); //~ ERROR use of deprecated associated function `this_crate::Trait::trait_deprecated`
+        <Foo>::trait_deprecated(&foo); //~ ERROR use of deprecated associated function `this_crate::Trait::trait_deprecated`
+        <Foo as Trait>::trait_deprecated(&foo); //~ ERROR use of deprecated associated function `this_crate::Trait::trait_deprecated`
+        foo.trait_deprecated_text(); //~ ERROR use of deprecated associated function `this_crate::Trait::trait_deprecated_text`: text
+        Trait::trait_deprecated_text(&foo); //~ ERROR use of deprecated associated function `this_crate::Trait::trait_deprecated_text`: text
+        <Foo>::trait_deprecated_text(&foo); //~ ERROR use of deprecated associated function `this_crate::Trait::trait_deprecated_text`: text
+        <Foo as Trait>::trait_deprecated_text(&foo); //~ ERROR use of deprecated associated function `this_crate::Trait::trait_deprecated_text`: text
     }
 
     fn test_method_object(foo: &Trait) {
-        foo.trait_deprecated(); //~ ERROR use of deprecated item 'this_crate::Trait::trait_deprecated'
-        foo.trait_deprecated_text(); //~ ERROR use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
+        foo.trait_deprecated(); //~ ERROR use of deprecated associated function `this_crate::Trait::trait_deprecated`
+        foo.trait_deprecated_text(); //~ ERROR use of deprecated associated function `this_crate::Trait::trait_deprecated_text`: text
     }
 
     #[deprecated(since = "1.0.0", note = "text")]
@@ -314,7 +314,7 @@ mod this_crate {
         let _ = || {
             #[deprecated]
             fn bar() { }
-            bar(); //~ ERROR use of deprecated item 'this_crate::test_fn_closure_body::{{closure}}#0::bar'
+            bar(); //~ ERROR use of deprecated function `this_crate::test_fn_closure_body::{{closure}}#0::bar`
         };
     }
 
@@ -333,9 +333,9 @@ mod this_crate {
 
     struct S;
 
-    impl DeprecatedTrait for S { } //~ ERROR use of deprecated item 'this_crate::DeprecatedTrait': text
+    impl DeprecatedTrait for S { } //~ ERROR use of deprecated trait `this_crate::DeprecatedTrait`: text
 
-    trait LocalTrait : DeprecatedTrait { } //~ ERROR use of deprecated item 'this_crate::DeprecatedTrait': text
+    trait LocalTrait : DeprecatedTrait { } //~ ERROR use of deprecated trait `this_crate::DeprecatedTrait`: text
 }
 
 mod this_crate2 {
@@ -361,15 +361,15 @@ mod this_crate2 {
     pub fn foo() {
         let x = Stable {
             override2: 3,
-            //~^ ERROR use of deprecated item 'this_crate2::Stable::override2': text
+            //~^ ERROR use of deprecated field `this_crate2::Stable::override2`: text
         };
 
         let _ = x.override2;
-        //~^ ERROR use of deprecated item 'this_crate2::Stable::override2': text
+        //~^ ERROR use of deprecated field `this_crate2::Stable::override2`: text
 
         let Stable {
             override2: _
-            //~^ ERROR use of deprecated item 'this_crate2::Stable::override2': text
+            //~^ ERROR use of deprecated field `this_crate2::Stable::override2`: text
         } = x;
         // all fine
         let Stable { .. } = x;
@@ -377,57 +377,57 @@ mod this_crate2 {
         let x = Stable2(1, 2, 3);
 
         let _ = x.2;
-        //~^ ERROR use of deprecated item 'this_crate2::Stable2::2': text
+        //~^ ERROR use of deprecated field `this_crate2::Stable2::2`: text
 
         let Stable2(_,
                    _,
                    _)
-            //~^ ERROR use of deprecated item 'this_crate2::Stable2::2': text
+            //~^ ERROR use of deprecated field `this_crate2::Stable2::2`: text
             = x;
         // all fine
         let Stable2(..) = x;
 
         let x = Deprecated {
-            //~^ ERROR use of deprecated item 'this_crate2::Deprecated': text
+            //~^ ERROR use of deprecated struct `this_crate2::Deprecated`: text
             inherit: 1,
-            //~^ ERROR use of deprecated item 'this_crate2::Deprecated::inherit': text
+            //~^ ERROR use of deprecated field `this_crate2::Deprecated::inherit`: text
         };
 
         let _ = x.inherit;
-        //~^ ERROR use of deprecated item 'this_crate2::Deprecated::inherit': text
+        //~^ ERROR use of deprecated field `this_crate2::Deprecated::inherit`: text
 
         let Deprecated {
-            //~^ ERROR use of deprecated item 'this_crate2::Deprecated': text
+            //~^ ERROR use of deprecated struct `this_crate2::Deprecated`: text
             inherit: _,
-            //~^ ERROR use of deprecated item 'this_crate2::Deprecated::inherit': text
+            //~^ ERROR use of deprecated field `this_crate2::Deprecated::inherit`: text
         } = x;
 
         let Deprecated
-            //~^ ERROR use of deprecated item 'this_crate2::Deprecated': text
+            //~^ ERROR use of deprecated struct `this_crate2::Deprecated`: text
             // the patterns are all fine:
             { .. } = x;
 
         let x = Deprecated2(1, 2, 3);
-        //~^ ERROR use of deprecated item 'this_crate2::Deprecated2': text
+        //~^ ERROR use of deprecated tuple struct `this_crate2::Deprecated2`: text
 
         let _ = x.0;
-        //~^ ERROR use of deprecated item 'this_crate2::Deprecated2::0': text
+        //~^ ERROR use of deprecated field `this_crate2::Deprecated2::0`: text
         let _ = x.1;
-        //~^ ERROR use of deprecated item 'this_crate2::Deprecated2::1': text
+        //~^ ERROR use of deprecated field `this_crate2::Deprecated2::1`: text
         let _ = x.2;
-        //~^ ERROR use of deprecated item 'this_crate2::Deprecated2::2': text
+        //~^ ERROR use of deprecated field `this_crate2::Deprecated2::2`: text
 
         let Deprecated2
-        //~^ ERROR use of deprecated item 'this_crate2::Deprecated2': text
+        //~^ ERROR use of deprecated tuple struct `this_crate2::Deprecated2`: text
             (_,
-             //~^ ERROR use of deprecated item 'this_crate2::Deprecated2::0': text
+             //~^ ERROR use of deprecated field `this_crate2::Deprecated2::0`: text
              _,
-             //~^ ERROR use of deprecated item 'this_crate2::Deprecated2::1': text
+             //~^ ERROR use of deprecated field `this_crate2::Deprecated2::1`: text
              _)
-            //~^ ERROR use of deprecated item 'this_crate2::Deprecated2::2': text
+            //~^ ERROR use of deprecated field `this_crate2::Deprecated2::2`: text
             = x;
         let Deprecated2
-        //~^ ERROR use of deprecated item 'this_crate2::Deprecated2': text
+        //~^ ERROR use of deprecated tuple struct `this_crate2::Deprecated2`: text
             // the patterns are all fine:
             (..) = x;
     }

--- a/src/test/ui/deprecation/deprecation-lint.stderr
+++ b/src/test/ui/deprecation/deprecation-lint.stderr
@@ -1,4 +1,4 @@
-error: use of deprecated item 'deprecation_lint::deprecated': text
+error: use of deprecated function `deprecation_lint::deprecated`: text
   --> $DIR/deprecation-lint.rs:17:9
    |
 LL |         deprecated();
@@ -10,727 +10,727 @@ note: the lint level is defined here
 LL | #![deny(deprecated)]
    |         ^^^^^^^^^^
 
-error: use of deprecated item 'deprecation_lint::Trait::trait_deprecated': text
+error: use of deprecated associated function `deprecation_lint::Trait::trait_deprecated`: text
   --> $DIR/deprecation-lint.rs:22:9
    |
 LL |         Trait::trait_deprecated(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^
 
-error: use of deprecated item 'deprecation_lint::Trait::trait_deprecated': text
+error: use of deprecated associated function `deprecation_lint::Trait::trait_deprecated`: text
   --> $DIR/deprecation-lint.rs:24:9
    |
 LL |         <Foo as Trait>::trait_deprecated(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: use of deprecated item 'deprecation_lint::deprecated_text': text
+error: use of deprecated function `deprecation_lint::deprecated_text`: text
   --> $DIR/deprecation-lint.rs:26:9
    |
 LL |         deprecated_text();
    |         ^^^^^^^^^^^^^^^
 
-error: use of deprecated item 'deprecation_lint::Trait::trait_deprecated_text': text
+error: use of deprecated associated function `deprecation_lint::Trait::trait_deprecated_text`: text
   --> $DIR/deprecation-lint.rs:31:9
    |
-LL |         Trait::trait_deprecated_text(&foo);
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | ...   Trait::trait_deprecated_text(&foo);
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: use of deprecated item 'deprecation_lint::Trait::trait_deprecated_text': text
+error: use of deprecated associated function `deprecation_lint::Trait::trait_deprecated_text`: text
   --> $DIR/deprecation-lint.rs:33:9
    |
-LL |         <Foo as Trait>::trait_deprecated_text(&foo);
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | ...   <Foo as Trait>::trait_deprecated_text(&foo);
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: use of deprecated item 'deprecation_lint::DeprecatedStruct': text
+error: use of deprecated struct `deprecation_lint::DeprecatedStruct`: text
   --> $DIR/deprecation-lint.rs:35:17
    |
 LL |         let _ = DeprecatedStruct {
    |                 ^^^^^^^^^^^^^^^^
 
-error: use of deprecated item 'deprecation_lint::DeprecatedUnitStruct': text
+error: use of deprecated struct `deprecation_lint::DeprecatedUnitStruct`: text
   --> $DIR/deprecation-lint.rs:39:17
    |
 LL |         let _ = DeprecatedUnitStruct;
    |                 ^^^^^^^^^^^^^^^^^^^^
 
-error: use of deprecated item 'deprecation_lint::Enum::DeprecatedVariant': text
+error: use of deprecated variant `deprecation_lint::Enum::DeprecatedVariant`: text
   --> $DIR/deprecation-lint.rs:41:17
    |
 LL |         let _ = Enum::DeprecatedVariant;
    |                 ^^^^^^^^^^^^^^^^^^^^^^^
 
-error: use of deprecated item 'deprecation_lint::DeprecatedTupleStruct': text
+error: use of deprecated struct `deprecation_lint::DeprecatedTupleStruct`: text
   --> $DIR/deprecation-lint.rs:43:17
    |
 LL |         let _ = DeprecatedTupleStruct (1);
    |                 ^^^^^^^^^^^^^^^^^^^^^
 
-error: use of deprecated item 'deprecation_lint::nested::DeprecatedStruct': text
+error: use of deprecated struct `deprecation_lint::nested::DeprecatedStruct`: text
   --> $DIR/deprecation-lint.rs:45:17
    |
 LL |         let _ = nested::DeprecatedStruct {
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: use of deprecated item 'deprecation_lint::nested::DeprecatedUnitStruct': text
+error: use of deprecated struct `deprecation_lint::nested::DeprecatedUnitStruct`: text
   --> $DIR/deprecation-lint.rs:49:17
    |
 LL |         let _ = nested::DeprecatedUnitStruct;
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: use of deprecated item 'deprecation_lint::nested::Enum::DeprecatedVariant': text
+error: use of deprecated variant `deprecation_lint::nested::Enum::DeprecatedVariant`: text
   --> $DIR/deprecation-lint.rs:51:17
    |
-LL |         let _ = nested::Enum::DeprecatedVariant;
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | ...   let _ = nested::Enum::DeprecatedVariant;
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: use of deprecated item 'deprecation_lint::nested::DeprecatedTupleStruct': text
+error: use of deprecated struct `deprecation_lint::nested::DeprecatedTupleStruct`: text
   --> $DIR/deprecation-lint.rs:53:17
    |
-LL |         let _ = nested::DeprecatedTupleStruct (1);
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | ...   let _ = nested::DeprecatedTupleStruct (1);
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: use of deprecated item 'deprecation_lint::deprecated_text': text
+error: use of deprecated function `deprecation_lint::deprecated_text`: text
   --> $DIR/deprecation-lint.rs:60:25
    |
 LL |         macro_test_arg!(deprecated_text());
    |                         ^^^^^^^^^^^^^^^
 
-error: use of deprecated item 'deprecation_lint::deprecated_text': text
+error: use of deprecated function `deprecation_lint::deprecated_text`: text
   --> $DIR/deprecation-lint.rs:61:41
    |
 LL |         macro_test_arg!(macro_test_arg!(deprecated_text()));
    |                                         ^^^^^^^^^^^^^^^
 
-error: use of deprecated item 'deprecation_lint::Trait::trait_deprecated': text
+error: use of deprecated associated function `deprecation_lint::Trait::trait_deprecated`: text
   --> $DIR/deprecation-lint.rs:66:9
    |
 LL |         Trait::trait_deprecated(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^
 
-error: use of deprecated item 'deprecation_lint::Trait::trait_deprecated': text
+error: use of deprecated associated function `deprecation_lint::Trait::trait_deprecated`: text
   --> $DIR/deprecation-lint.rs:68:9
    |
 LL |         <Foo as Trait>::trait_deprecated(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: use of deprecated item 'deprecation_lint::Trait::trait_deprecated_text': text
+error: use of deprecated associated function `deprecation_lint::Trait::trait_deprecated_text`: text
   --> $DIR/deprecation-lint.rs:70:9
    |
-LL |         Trait::trait_deprecated_text(&foo);
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | ...   Trait::trait_deprecated_text(&foo);
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: use of deprecated item 'deprecation_lint::Trait::trait_deprecated_text': text
+error: use of deprecated associated function `deprecation_lint::Trait::trait_deprecated_text`: text
   --> $DIR/deprecation-lint.rs:72:9
    |
-LL |         <Foo as Trait>::trait_deprecated_text(&foo);
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | ...   <Foo as Trait>::trait_deprecated_text(&foo);
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: use of deprecated item 'deprecation_lint::DeprecatedTrait': text
+error: use of deprecated trait `deprecation_lint::DeprecatedTrait`: text
   --> $DIR/deprecation-lint.rs:82:10
    |
 LL |     impl DeprecatedTrait for S {}
    |          ^^^^^^^^^^^^^^^
 
-error: use of deprecated item 'deprecation_lint::DeprecatedTrait': text
+error: use of deprecated trait `deprecation_lint::DeprecatedTrait`: text
   --> $DIR/deprecation-lint.rs:83:24
    |
 LL |     trait LocalTrait : DeprecatedTrait { }
    |                        ^^^^^^^^^^^^^^^
 
-error: use of deprecated item 'deprecation_lint::Deprecated': text
+error: use of deprecated struct `deprecation_lint::Deprecated`: text
   --> $DIR/deprecation-lint.rs:114:17
    |
 LL |         let x = Deprecated {
    |                 ^^^^^^^^^^
 
-error: use of deprecated item 'deprecation_lint::Deprecated': text
+error: use of deprecated struct `deprecation_lint::Deprecated`: text
   --> $DIR/deprecation-lint.rs:123:13
    |
 LL |         let Deprecated {
    |             ^^^^^^^^^^
 
-error: use of deprecated item 'deprecation_lint::Deprecated': text
+error: use of deprecated struct `deprecation_lint::Deprecated`: text
   --> $DIR/deprecation-lint.rs:129:13
    |
 LL |         let Deprecated
    |             ^^^^^^^^^^
 
-error: use of deprecated item 'deprecation_lint::Deprecated2': text
+error: use of deprecated struct `deprecation_lint::Deprecated2`: text
   --> $DIR/deprecation-lint.rs:133:17
    |
 LL |         let x = Deprecated2(1, 2, 3);
    |                 ^^^^^^^^^^^
 
-error: use of deprecated item 'deprecation_lint::Deprecated2': text
+error: use of deprecated struct `deprecation_lint::Deprecated2`: text
   --> $DIR/deprecation-lint.rs:143:13
    |
 LL |         let Deprecated2
    |             ^^^^^^^^^^^
 
-error: use of deprecated item 'deprecation_lint::Deprecated2': text
+error: use of deprecated struct `deprecation_lint::Deprecated2`: text
   --> $DIR/deprecation-lint.rs:152:13
    |
 LL |         let Deprecated2
    |             ^^^^^^^^^^^
 
-error: use of deprecated item 'deprecation_lint::deprecated_mod::deprecated': text
+error: use of deprecated function `deprecation_lint::deprecated_mod::deprecated`: text
   --> $DIR/deprecation-lint.rs:163:9
    |
 LL |         deprecated_mod::deprecated();
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: use of deprecated item 'this_crate::deprecated': text
+error: use of deprecated function `this_crate::deprecated`: text
   --> $DIR/deprecation-lint.rs:246:9
    |
 LL |         deprecated();
    |         ^^^^^^^^^^
 
-error: use of deprecated item 'this_crate::Trait::trait_deprecated': text
+error: use of deprecated associated function `this_crate::Trait::trait_deprecated`: text
   --> $DIR/deprecation-lint.rs:251:9
    |
 LL |         Trait::trait_deprecated(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^
 
-error: use of deprecated item 'this_crate::Trait::trait_deprecated': text
+error: use of deprecated associated function `this_crate::Trait::trait_deprecated`: text
   --> $DIR/deprecation-lint.rs:253:9
    |
 LL |         <Foo as Trait>::trait_deprecated(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: use of deprecated item 'this_crate::deprecated_text': text
+error: use of deprecated function `this_crate::deprecated_text`: text
   --> $DIR/deprecation-lint.rs:255:9
    |
 LL |         deprecated_text();
    |         ^^^^^^^^^^^^^^^
 
-error: use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
+error: use of deprecated associated function `this_crate::Trait::trait_deprecated_text`: text
   --> $DIR/deprecation-lint.rs:260:9
    |
 LL |         Trait::trait_deprecated_text(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
+error: use of deprecated associated function `this_crate::Trait::trait_deprecated_text`: text
   --> $DIR/deprecation-lint.rs:262:9
    |
-LL |         <Foo as Trait>::trait_deprecated_text(&foo);
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | ...   <Foo as Trait>::trait_deprecated_text(&foo);
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: use of deprecated item 'this_crate::deprecated_future': text
+error: use of deprecated function `this_crate::deprecated_future`: text
   --> $DIR/deprecation-lint.rs:265:9
    |
 LL |         deprecated_future();
    |         ^^^^^^^^^^^^^^^^^
 
-error: use of deprecated item 'this_crate::deprecated_future_text': text
+error: use of deprecated function `this_crate::deprecated_future_text`: text
   --> $DIR/deprecation-lint.rs:266:9
    |
 LL |         deprecated_future_text();
    |         ^^^^^^^^^^^^^^^^^^^^^^
 
-error: use of deprecated item 'this_crate::DeprecatedStruct': text
+error: use of deprecated struct `this_crate::DeprecatedStruct`: text
   --> $DIR/deprecation-lint.rs:268:17
    |
 LL |         let _ = DeprecatedStruct {
    |                 ^^^^^^^^^^^^^^^^
 
-error: use of deprecated item 'this_crate::DeprecatedUnitStruct': text
+error: use of deprecated unit struct `this_crate::DeprecatedUnitStruct`: text
   --> $DIR/deprecation-lint.rs:273:17
    |
 LL |         let _ = DeprecatedUnitStruct;
    |                 ^^^^^^^^^^^^^^^^^^^^
 
-error: use of deprecated item 'this_crate::Enum::DeprecatedVariant': text
+error: use of deprecated unit variant `this_crate::Enum::DeprecatedVariant`: text
   --> $DIR/deprecation-lint.rs:275:17
    |
 LL |         let _ = Enum::DeprecatedVariant;
    |                 ^^^^^^^^^^^^^^^^^^^^^^^
 
-error: use of deprecated item 'this_crate::DeprecatedTupleStruct': text
+error: use of deprecated tuple struct `this_crate::DeprecatedTupleStruct`: text
   --> $DIR/deprecation-lint.rs:277:17
    |
 LL |         let _ = DeprecatedTupleStruct (1);
    |                 ^^^^^^^^^^^^^^^^^^^^^
 
-error: use of deprecated item 'this_crate::nested::DeprecatedStruct': text
+error: use of deprecated struct `this_crate::nested::DeprecatedStruct`: text
   --> $DIR/deprecation-lint.rs:279:17
    |
 LL |         let _ = nested::DeprecatedStruct {
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: use of deprecated item 'this_crate::nested::DeprecatedUnitStruct': text
+error: use of deprecated unit struct `this_crate::nested::DeprecatedUnitStruct`: text
   --> $DIR/deprecation-lint.rs:284:17
    |
 LL |         let _ = nested::DeprecatedUnitStruct;
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: use of deprecated item 'this_crate::nested::Enum::DeprecatedVariant': text
+error: use of deprecated unit variant `this_crate::nested::Enum::DeprecatedVariant`: text
   --> $DIR/deprecation-lint.rs:286:17
    |
-LL |         let _ = nested::Enum::DeprecatedVariant;
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | ...   let _ = nested::Enum::DeprecatedVariant;
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: use of deprecated item 'this_crate::nested::DeprecatedTupleStruct': text
+error: use of deprecated tuple struct `this_crate::nested::DeprecatedTupleStruct`: text
   --> $DIR/deprecation-lint.rs:288:17
    |
-LL |         let _ = nested::DeprecatedTupleStruct (1);
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | ...   let _ = nested::DeprecatedTupleStruct (1);
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: use of deprecated item 'this_crate::Trait::trait_deprecated': text
+error: use of deprecated associated function `this_crate::Trait::trait_deprecated`: text
   --> $DIR/deprecation-lint.rs:293:9
    |
 LL |         Trait::trait_deprecated(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^
 
-error: use of deprecated item 'this_crate::Trait::trait_deprecated': text
+error: use of deprecated associated function `this_crate::Trait::trait_deprecated`: text
   --> $DIR/deprecation-lint.rs:295:9
    |
 LL |         <Foo as Trait>::trait_deprecated(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
+error: use of deprecated associated function `this_crate::Trait::trait_deprecated_text`: text
   --> $DIR/deprecation-lint.rs:297:9
    |
 LL |         Trait::trait_deprecated_text(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
+error: use of deprecated associated function `this_crate::Trait::trait_deprecated_text`: text
   --> $DIR/deprecation-lint.rs:299:9
    |
-LL |         <Foo as Trait>::trait_deprecated_text(&foo);
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | ...   <Foo as Trait>::trait_deprecated_text(&foo);
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: use of deprecated item 'this_crate::test_fn_closure_body::{{closure}}#0::bar'
+error: use of deprecated function `this_crate::test_fn_closure_body::{{closure}}#0::bar`
   --> $DIR/deprecation-lint.rs:317:13
    |
 LL |             bar();
    |             ^^^
 
-error: use of deprecated item 'this_crate::DeprecatedTrait': text
+error: use of deprecated trait `this_crate::DeprecatedTrait`: text
   --> $DIR/deprecation-lint.rs:336:10
    |
 LL |     impl DeprecatedTrait for S { }
    |          ^^^^^^^^^^^^^^^
 
-error: use of deprecated item 'this_crate::DeprecatedTrait': text
+error: use of deprecated trait `this_crate::DeprecatedTrait`: text
   --> $DIR/deprecation-lint.rs:338:24
    |
 LL |     trait LocalTrait : DeprecatedTrait { }
    |                        ^^^^^^^^^^^^^^^
 
-error: use of deprecated item 'this_crate2::Deprecated': text
+error: use of deprecated struct `this_crate2::Deprecated`: text
   --> $DIR/deprecation-lint.rs:390:17
    |
 LL |         let x = Deprecated {
    |                 ^^^^^^^^^^
 
-error: use of deprecated item 'this_crate2::Deprecated': text
+error: use of deprecated struct `this_crate2::Deprecated`: text
   --> $DIR/deprecation-lint.rs:399:13
    |
 LL |         let Deprecated {
    |             ^^^^^^^^^^
 
-error: use of deprecated item 'this_crate2::Deprecated': text
+error: use of deprecated struct `this_crate2::Deprecated`: text
   --> $DIR/deprecation-lint.rs:405:13
    |
 LL |         let Deprecated
    |             ^^^^^^^^^^
 
-error: use of deprecated item 'this_crate2::Deprecated2': text
+error: use of deprecated tuple struct `this_crate2::Deprecated2`: text
   --> $DIR/deprecation-lint.rs:410:17
    |
 LL |         let x = Deprecated2(1, 2, 3);
    |                 ^^^^^^^^^^^
 
-error: use of deprecated item 'this_crate2::Deprecated2': text
+error: use of deprecated tuple struct `this_crate2::Deprecated2`: text
   --> $DIR/deprecation-lint.rs:420:13
    |
 LL |         let Deprecated2
    |             ^^^^^^^^^^^
 
-error: use of deprecated item 'this_crate2::Deprecated2': text
+error: use of deprecated tuple struct `this_crate2::Deprecated2`: text
   --> $DIR/deprecation-lint.rs:429:13
    |
 LL |         let Deprecated2
    |             ^^^^^^^^^^^
 
-error: use of deprecated item 'deprecation_lint::MethodTester::method_deprecated': text
+error: use of deprecated associated function `deprecation_lint::MethodTester::method_deprecated`: text
   --> $DIR/deprecation-lint.rs:18:13
    |
 LL |         foo.method_deprecated();
    |             ^^^^^^^^^^^^^^^^^
 
-error: use of deprecated item 'deprecation_lint::MethodTester::method_deprecated': text
+error: use of deprecated associated function `deprecation_lint::MethodTester::method_deprecated`: text
   --> $DIR/deprecation-lint.rs:19:9
    |
 LL |         Foo::method_deprecated(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^
 
-error: use of deprecated item 'deprecation_lint::MethodTester::method_deprecated': text
+error: use of deprecated associated function `deprecation_lint::MethodTester::method_deprecated`: text
   --> $DIR/deprecation-lint.rs:20:9
    |
 LL |         <Foo>::method_deprecated(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: use of deprecated item 'deprecation_lint::Trait::trait_deprecated': text
+error: use of deprecated associated function `deprecation_lint::Trait::trait_deprecated`: text
   --> $DIR/deprecation-lint.rs:21:13
    |
 LL |         foo.trait_deprecated();
    |             ^^^^^^^^^^^^^^^^
 
-error: use of deprecated item 'deprecation_lint::Trait::trait_deprecated': text
+error: use of deprecated associated function `deprecation_lint::Trait::trait_deprecated`: text
   --> $DIR/deprecation-lint.rs:23:9
    |
 LL |         <Foo>::trait_deprecated(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^
 
-error: use of deprecated item 'deprecation_lint::MethodTester::method_deprecated_text': text
+error: use of deprecated associated function `deprecation_lint::MethodTester::method_deprecated_text`: text
   --> $DIR/deprecation-lint.rs:27:13
    |
-LL |         foo.method_deprecated_text();
-   |             ^^^^^^^^^^^^^^^^^^^^^^
+LL | ...   foo.method_deprecated_text();
+   |           ^^^^^^^^^^^^^^^^^^^^^^
 
-error: use of deprecated item 'deprecation_lint::MethodTester::method_deprecated_text': text
+error: use of deprecated associated function `deprecation_lint::MethodTester::method_deprecated_text`: text
   --> $DIR/deprecation-lint.rs:28:9
    |
-LL |         Foo::method_deprecated_text(&foo);
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | ...   Foo::method_deprecated_text(&foo);
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: use of deprecated item 'deprecation_lint::MethodTester::method_deprecated_text': text
+error: use of deprecated associated function `deprecation_lint::MethodTester::method_deprecated_text`: text
   --> $DIR/deprecation-lint.rs:29:9
    |
-LL |         <Foo>::method_deprecated_text(&foo);
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | ...   <Foo>::method_deprecated_text(&foo);
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: use of deprecated item 'deprecation_lint::Trait::trait_deprecated_text': text
+error: use of deprecated associated function `deprecation_lint::Trait::trait_deprecated_text`: text
   --> $DIR/deprecation-lint.rs:30:13
    |
 LL |         foo.trait_deprecated_text();
    |             ^^^^^^^^^^^^^^^^^^^^^
 
-error: use of deprecated item 'deprecation_lint::Trait::trait_deprecated_text': text
+error: use of deprecated associated function `deprecation_lint::Trait::trait_deprecated_text`: text
   --> $DIR/deprecation-lint.rs:32:9
    |
-LL |         <Foo>::trait_deprecated_text(&foo);
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | ...   <Foo>::trait_deprecated_text(&foo);
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: use of deprecated item 'deprecation_lint::DeprecatedStruct::i': text
+error: use of deprecated field `deprecation_lint::DeprecatedStruct::i`: text
   --> $DIR/deprecation-lint.rs:36:13
    |
 LL |             i: 0
    |             ^^^^
 
-error: use of deprecated item 'deprecation_lint::nested::DeprecatedStruct::i': text
+error: use of deprecated field `deprecation_lint::nested::DeprecatedStruct::i`: text
   --> $DIR/deprecation-lint.rs:46:13
    |
 LL |             i: 0
    |             ^^^^
 
-error: use of deprecated item 'deprecation_lint::Trait::trait_deprecated': text
+error: use of deprecated associated function `deprecation_lint::Trait::trait_deprecated`: text
   --> $DIR/deprecation-lint.rs:65:13
    |
 LL |         foo.trait_deprecated();
    |             ^^^^^^^^^^^^^^^^
 
-error: use of deprecated item 'deprecation_lint::Trait::trait_deprecated': text
+error: use of deprecated associated function `deprecation_lint::Trait::trait_deprecated`: text
   --> $DIR/deprecation-lint.rs:67:9
    |
 LL |         <Foo>::trait_deprecated(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^
 
-error: use of deprecated item 'deprecation_lint::Trait::trait_deprecated_text': text
+error: use of deprecated associated function `deprecation_lint::Trait::trait_deprecated_text`: text
   --> $DIR/deprecation-lint.rs:69:13
    |
 LL |         foo.trait_deprecated_text();
    |             ^^^^^^^^^^^^^^^^^^^^^
 
-error: use of deprecated item 'deprecation_lint::Trait::trait_deprecated_text': text
+error: use of deprecated associated function `deprecation_lint::Trait::trait_deprecated_text`: text
   --> $DIR/deprecation-lint.rs:71:9
    |
-LL |         <Foo>::trait_deprecated_text(&foo);
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | ...   <Foo>::trait_deprecated_text(&foo);
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: use of deprecated item 'deprecation_lint::Trait::trait_deprecated': text
+error: use of deprecated associated function `deprecation_lint::Trait::trait_deprecated`: text
   --> $DIR/deprecation-lint.rs:76:13
    |
 LL |         foo.trait_deprecated();
    |             ^^^^^^^^^^^^^^^^
 
-error: use of deprecated item 'deprecation_lint::Trait::trait_deprecated_text': text
+error: use of deprecated associated function `deprecation_lint::Trait::trait_deprecated_text`: text
   --> $DIR/deprecation-lint.rs:77:13
    |
 LL |         foo.trait_deprecated_text();
    |             ^^^^^^^^^^^^^^^^^^^^^
 
-error: use of deprecated item 'deprecation_lint::Stable::override2': text
+error: use of deprecated field `deprecation_lint::Stable::override2`: text
   --> $DIR/deprecation-lint.rs:87:13
    |
 LL |             override2: 3,
    |             ^^^^^^^^^^^^
 
-error: use of deprecated item 'deprecation_lint::Stable::override2': text
+error: use of deprecated field `deprecation_lint::Stable::override2`: text
   --> $DIR/deprecation-lint.rs:91:17
    |
 LL |         let _ = x.override2;
    |                 ^^^^^^^^^^^
 
-error: use of deprecated item 'deprecation_lint::Stable::override2': text
+error: use of deprecated field `deprecation_lint::Stable::override2`: text
   --> $DIR/deprecation-lint.rs:95:13
    |
 LL |             override2: _
    |             ^^^^^^^^^^^^
 
-error: use of deprecated item 'deprecation_lint::Stable2::2': text
+error: use of deprecated field `deprecation_lint::Stable2::2`: text
   --> $DIR/deprecation-lint.rs:103:17
    |
 LL |         let _ = x.2;
    |                 ^^^
 
-error: use of deprecated item 'deprecation_lint::Stable2::2': text
+error: use of deprecated field `deprecation_lint::Stable2::2`: text
   --> $DIR/deprecation-lint.rs:108:20
    |
 LL |                    _)
    |                    ^
 
-error: use of deprecated item 'deprecation_lint::Deprecated::inherit': text
+error: use of deprecated field `deprecation_lint::Deprecated::inherit`: text
   --> $DIR/deprecation-lint.rs:116:13
    |
 LL |             inherit: 1,
    |             ^^^^^^^^^^
 
-error: use of deprecated item 'deprecation_lint::Deprecated::inherit': text
+error: use of deprecated field `deprecation_lint::Deprecated::inherit`: text
   --> $DIR/deprecation-lint.rs:120:17
    |
 LL |         let _ = x.inherit;
    |                 ^^^^^^^^^
 
-error: use of deprecated item 'deprecation_lint::Deprecated::inherit': text
+error: use of deprecated field `deprecation_lint::Deprecated::inherit`: text
   --> $DIR/deprecation-lint.rs:125:13
    |
 LL |             inherit: _,
    |             ^^^^^^^^^^
 
-error: use of deprecated item 'deprecation_lint::Deprecated2::0': text
+error: use of deprecated field `deprecation_lint::Deprecated2::0`: text
   --> $DIR/deprecation-lint.rs:136:17
    |
 LL |         let _ = x.0;
    |                 ^^^
 
-error: use of deprecated item 'deprecation_lint::Deprecated2::1': text
+error: use of deprecated field `deprecation_lint::Deprecated2::1`: text
   --> $DIR/deprecation-lint.rs:138:17
    |
 LL |         let _ = x.1;
    |                 ^^^
 
-error: use of deprecated item 'deprecation_lint::Deprecated2::2': text
+error: use of deprecated field `deprecation_lint::Deprecated2::2`: text
   --> $DIR/deprecation-lint.rs:140:17
    |
 LL |         let _ = x.2;
    |                 ^^^
 
-error: use of deprecated item 'deprecation_lint::Deprecated2::0': text
+error: use of deprecated field `deprecation_lint::Deprecated2::0`: text
   --> $DIR/deprecation-lint.rs:145:14
    |
 LL |             (_,
    |              ^
 
-error: use of deprecated item 'deprecation_lint::Deprecated2::1': text
+error: use of deprecated field `deprecation_lint::Deprecated2::1`: text
   --> $DIR/deprecation-lint.rs:147:14
    |
 LL |              _,
    |              ^
 
-error: use of deprecated item 'deprecation_lint::Deprecated2::2': text
+error: use of deprecated field `deprecation_lint::Deprecated2::2`: text
   --> $DIR/deprecation-lint.rs:149:14
    |
 LL |              _)
    |              ^
 
-error: use of deprecated item 'this_crate::MethodTester::method_deprecated': text
+error: use of deprecated associated function `this_crate::MethodTester::method_deprecated`: text
   --> $DIR/deprecation-lint.rs:247:13
    |
 LL |         foo.method_deprecated();
    |             ^^^^^^^^^^^^^^^^^
 
-error: use of deprecated item 'this_crate::MethodTester::method_deprecated': text
+error: use of deprecated associated function `this_crate::MethodTester::method_deprecated`: text
   --> $DIR/deprecation-lint.rs:248:9
    |
 LL |         Foo::method_deprecated(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^
 
-error: use of deprecated item 'this_crate::MethodTester::method_deprecated': text
+error: use of deprecated associated function `this_crate::MethodTester::method_deprecated`: text
   --> $DIR/deprecation-lint.rs:249:9
    |
 LL |         <Foo>::method_deprecated(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: use of deprecated item 'this_crate::Trait::trait_deprecated': text
+error: use of deprecated associated function `this_crate::Trait::trait_deprecated`: text
   --> $DIR/deprecation-lint.rs:250:13
    |
 LL |         foo.trait_deprecated();
    |             ^^^^^^^^^^^^^^^^
 
-error: use of deprecated item 'this_crate::Trait::trait_deprecated': text
+error: use of deprecated associated function `this_crate::Trait::trait_deprecated`: text
   --> $DIR/deprecation-lint.rs:252:9
    |
 LL |         <Foo>::trait_deprecated(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^
 
-error: use of deprecated item 'this_crate::MethodTester::method_deprecated_text': text
+error: use of deprecated associated function `this_crate::MethodTester::method_deprecated_text`: text
   --> $DIR/deprecation-lint.rs:256:13
    |
-LL |         foo.method_deprecated_text();
-   |             ^^^^^^^^^^^^^^^^^^^^^^
+LL | ...   foo.method_deprecated_text();
+   |           ^^^^^^^^^^^^^^^^^^^^^^
 
-error: use of deprecated item 'this_crate::MethodTester::method_deprecated_text': text
+error: use of deprecated associated function `this_crate::MethodTester::method_deprecated_text`: text
   --> $DIR/deprecation-lint.rs:257:9
    |
-LL |         Foo::method_deprecated_text(&foo);
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | ...   Foo::method_deprecated_text(&foo);
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: use of deprecated item 'this_crate::MethodTester::method_deprecated_text': text
+error: use of deprecated associated function `this_crate::MethodTester::method_deprecated_text`: text
   --> $DIR/deprecation-lint.rs:258:9
    |
-LL |         <Foo>::method_deprecated_text(&foo);
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | ...   <Foo>::method_deprecated_text(&foo);
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
+error: use of deprecated associated function `this_crate::Trait::trait_deprecated_text`: text
   --> $DIR/deprecation-lint.rs:259:13
    |
 LL |         foo.trait_deprecated_text();
    |             ^^^^^^^^^^^^^^^^^^^^^
 
-error: use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
+error: use of deprecated associated function `this_crate::Trait::trait_deprecated_text`: text
   --> $DIR/deprecation-lint.rs:261:9
    |
 LL |         <Foo>::trait_deprecated_text(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: use of deprecated item 'this_crate::DeprecatedStruct::i': text
+error: use of deprecated field `this_crate::DeprecatedStruct::i`: text
   --> $DIR/deprecation-lint.rs:270:13
    |
 LL |             i: 0
    |             ^^^^
 
-error: use of deprecated item 'this_crate::nested::DeprecatedStruct::i': text
+error: use of deprecated field `this_crate::nested::DeprecatedStruct::i`: text
   --> $DIR/deprecation-lint.rs:281:13
    |
 LL |             i: 0
    |             ^^^^
 
-error: use of deprecated item 'this_crate::Trait::trait_deprecated': text
+error: use of deprecated associated function `this_crate::Trait::trait_deprecated`: text
   --> $DIR/deprecation-lint.rs:292:13
    |
 LL |         foo.trait_deprecated();
    |             ^^^^^^^^^^^^^^^^
 
-error: use of deprecated item 'this_crate::Trait::trait_deprecated': text
+error: use of deprecated associated function `this_crate::Trait::trait_deprecated`: text
   --> $DIR/deprecation-lint.rs:294:9
    |
 LL |         <Foo>::trait_deprecated(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^
 
-error: use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
+error: use of deprecated associated function `this_crate::Trait::trait_deprecated_text`: text
   --> $DIR/deprecation-lint.rs:296:13
    |
 LL |         foo.trait_deprecated_text();
    |             ^^^^^^^^^^^^^^^^^^^^^
 
-error: use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
+error: use of deprecated associated function `this_crate::Trait::trait_deprecated_text`: text
   --> $DIR/deprecation-lint.rs:298:9
    |
 LL |         <Foo>::trait_deprecated_text(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: use of deprecated item 'this_crate::Trait::trait_deprecated': text
+error: use of deprecated associated function `this_crate::Trait::trait_deprecated`: text
   --> $DIR/deprecation-lint.rs:303:13
    |
 LL |         foo.trait_deprecated();
    |             ^^^^^^^^^^^^^^^^
 
-error: use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
+error: use of deprecated associated function `this_crate::Trait::trait_deprecated_text`: text
   --> $DIR/deprecation-lint.rs:304:13
    |
 LL |         foo.trait_deprecated_text();
    |             ^^^^^^^^^^^^^^^^^^^^^
 
-error: use of deprecated item 'this_crate2::Stable::override2': text
+error: use of deprecated field `this_crate2::Stable::override2`: text
   --> $DIR/deprecation-lint.rs:363:13
    |
 LL |             override2: 3,
    |             ^^^^^^^^^^^^
 
-error: use of deprecated item 'this_crate2::Stable::override2': text
+error: use of deprecated field `this_crate2::Stable::override2`: text
   --> $DIR/deprecation-lint.rs:367:17
    |
 LL |         let _ = x.override2;
    |                 ^^^^^^^^^^^
 
-error: use of deprecated item 'this_crate2::Stable::override2': text
+error: use of deprecated field `this_crate2::Stable::override2`: text
   --> $DIR/deprecation-lint.rs:371:13
    |
 LL |             override2: _
    |             ^^^^^^^^^^^^
 
-error: use of deprecated item 'this_crate2::Stable2::2': text
+error: use of deprecated field `this_crate2::Stable2::2`: text
   --> $DIR/deprecation-lint.rs:379:17
    |
 LL |         let _ = x.2;
    |                 ^^^
 
-error: use of deprecated item 'this_crate2::Stable2::2': text
+error: use of deprecated field `this_crate2::Stable2::2`: text
   --> $DIR/deprecation-lint.rs:384:20
    |
 LL |                    _)
    |                    ^
 
-error: use of deprecated item 'this_crate2::Deprecated::inherit': text
+error: use of deprecated field `this_crate2::Deprecated::inherit`: text
   --> $DIR/deprecation-lint.rs:392:13
    |
 LL |             inherit: 1,
    |             ^^^^^^^^^^
 
-error: use of deprecated item 'this_crate2::Deprecated::inherit': text
+error: use of deprecated field `this_crate2::Deprecated::inherit`: text
   --> $DIR/deprecation-lint.rs:396:17
    |
 LL |         let _ = x.inherit;
    |                 ^^^^^^^^^
 
-error: use of deprecated item 'this_crate2::Deprecated::inherit': text
+error: use of deprecated field `this_crate2::Deprecated::inherit`: text
   --> $DIR/deprecation-lint.rs:401:13
    |
 LL |             inherit: _,
    |             ^^^^^^^^^^
 
-error: use of deprecated item 'this_crate2::Deprecated2::0': text
+error: use of deprecated field `this_crate2::Deprecated2::0`: text
   --> $DIR/deprecation-lint.rs:413:17
    |
 LL |         let _ = x.0;
    |                 ^^^
 
-error: use of deprecated item 'this_crate2::Deprecated2::1': text
+error: use of deprecated field `this_crate2::Deprecated2::1`: text
   --> $DIR/deprecation-lint.rs:415:17
    |
 LL |         let _ = x.1;
    |                 ^^^
 
-error: use of deprecated item 'this_crate2::Deprecated2::2': text
+error: use of deprecated field `this_crate2::Deprecated2::2`: text
   --> $DIR/deprecation-lint.rs:417:17
    |
 LL |         let _ = x.2;
    |                 ^^^
 
-error: use of deprecated item 'this_crate2::Deprecated2::0': text
+error: use of deprecated field `this_crate2::Deprecated2::0`: text
   --> $DIR/deprecation-lint.rs:422:14
    |
 LL |             (_,
    |              ^
 
-error: use of deprecated item 'this_crate2::Deprecated2::1': text
+error: use of deprecated field `this_crate2::Deprecated2::1`: text
   --> $DIR/deprecation-lint.rs:424:14
    |
 LL |              _,
    |              ^
 
-error: use of deprecated item 'this_crate2::Deprecated2::2': text
+error: use of deprecated field `this_crate2::Deprecated2::2`: text
   --> $DIR/deprecation-lint.rs:426:14
    |
 LL |              _)

--- a/src/test/ui/deprecation/rustc_deprecation-in-future.rs
+++ b/src/test/ui/deprecation/rustc_deprecation-in-future.rs
@@ -11,5 +11,5 @@
 pub struct S;
 
 fn main() {
-    let _ = S; //~ ERROR use of item 'S' that will be deprecated in future version 99.99.99: effectively never
+    let _ = S; //~ ERROR use of unit struct `S` that will be deprecated in future version 99.99.99: effectively never
 }

--- a/src/test/ui/deprecation/rustc_deprecation-in-future.stderr
+++ b/src/test/ui/deprecation/rustc_deprecation-in-future.stderr
@@ -1,4 +1,4 @@
-error: use of item 'S' that will be deprecated in future version 99.99.99: effectively never
+error: use of unit struct `S` that will be deprecated in future version 99.99.99: effectively never
   --> $DIR/rustc_deprecation-in-future.rs:14:13
    |
 LL |     let _ = S;

--- a/src/test/ui/deprecation/suggestion.stderr
+++ b/src/test/ui/deprecation/suggestion.stderr
@@ -1,8 +1,8 @@
-error: use of deprecated item 'Foo::deprecated': replaced by `replacement`
+error: use of deprecated associated function `Foo::deprecated`: replaced by `replacement`
   --> $DIR/suggestion.rs:27:9
    |
 LL |     foo.deprecated();
-   |         ^^^^^^^^^^ help: replace the use of the deprecated item: `replacement`
+   |         ^^^^^^^^^^ help: replace the use of the deprecated associated function: `replacement`
    |
 note: the lint level is defined here
   --> $DIR/suggestion.rs:7:9

--- a/src/test/ui/issues/issue-17337.rs
+++ b/src/test/ui/issues/issue-17337.rs
@@ -13,5 +13,5 @@ impl Foo {
 
 fn main() {
     Foo
-    .foo(); //~ ERROR use of deprecated item
+    .foo(); //~ ERROR use of deprecated
 }

--- a/src/test/ui/issues/issue-17337.stderr
+++ b/src/test/ui/issues/issue-17337.stderr
@@ -1,4 +1,4 @@
-error: use of deprecated item 'Foo::foo': text
+error: use of deprecated associated function `Foo::foo`: text
   --> $DIR/issue-17337.rs:16:6
    |
 LL |     .foo();

--- a/src/test/ui/lint/lint-output-format-2.rs
+++ b/src/test/ui/lint/lint-output-format-2.rs
@@ -5,11 +5,11 @@
 
 extern crate lint_output_format;
 use lint_output_format::{foo, bar};
-//~^ WARNING use of deprecated item 'lint_output_format::foo': text
+//~^ WARNING use of deprecated function `lint_output_format::foo`: text
 
 
 fn main() {
     let _x = foo();
-    //~^ WARNING use of deprecated item 'lint_output_format::foo': text
+    //~^ WARNING use of deprecated function `lint_output_format::foo`: text
     let _y = bar();
 }

--- a/src/test/ui/lint/lint-output-format-2.stderr
+++ b/src/test/ui/lint/lint-output-format-2.stderr
@@ -1,4 +1,4 @@
-warning: use of deprecated item 'lint_output_format::foo': text
+warning: use of deprecated function `lint_output_format::foo`: text
   --> $DIR/lint-output-format-2.rs:7:26
    |
 LL | use lint_output_format::{foo, bar};
@@ -6,7 +6,7 @@ LL | use lint_output_format::{foo, bar};
    |
    = note: `#[warn(deprecated)]` on by default
 
-warning: use of deprecated item 'lint_output_format::foo': text
+warning: use of deprecated function `lint_output_format::foo`: text
   --> $DIR/lint-output-format-2.rs:12:14
    |
 LL |     let _x = foo();

--- a/src/test/ui/lint/lint-stability-deprecated.rs
+++ b/src/test/ui/lint/lint-stability-deprecated.rs
@@ -22,41 +22,41 @@ mod cross_crate {
         type Foo = MethodTester;
         let foo = MethodTester;
 
-        deprecated(); //~ WARN use of deprecated item 'lint_stability::deprecated'
-        foo.method_deprecated(); //~ WARN use of deprecated item 'lint_stability::MethodTester::method_deprecated'
-        Foo::method_deprecated(&foo); //~ WARN use of deprecated item 'lint_stability::MethodTester::method_deprecated'
-        <Foo>::method_deprecated(&foo); //~ WARN use of deprecated item 'lint_stability::MethodTester::method_deprecated'
-        foo.trait_deprecated(); //~ WARN use of deprecated item 'lint_stability::Trait::trait_deprecated'
-        Trait::trait_deprecated(&foo); //~ WARN use of deprecated item 'lint_stability::Trait::trait_deprecated'
-        <Foo>::trait_deprecated(&foo); //~ WARN use of deprecated item 'lint_stability::Trait::trait_deprecated'
-        <Foo as Trait>::trait_deprecated(&foo); //~ WARN use of deprecated item 'lint_stability::Trait::trait_deprecated'
+        deprecated(); //~ WARN use of deprecated function `lint_stability::deprecated`
+        foo.method_deprecated(); //~ WARN use of deprecated associated function `lint_stability::MethodTester::method_deprecated`
+        Foo::method_deprecated(&foo); //~ WARN use of deprecated associated function `lint_stability::MethodTester::method_deprecated`
+        <Foo>::method_deprecated(&foo); //~ WARN use of deprecated associated function `lint_stability::MethodTester::method_deprecated`
+        foo.trait_deprecated(); //~ WARN use of deprecated associated function `lint_stability::Trait::trait_deprecated`
+        Trait::trait_deprecated(&foo); //~ WARN use of deprecated associated function `lint_stability::Trait::trait_deprecated`
+        <Foo>::trait_deprecated(&foo); //~ WARN use of deprecated associated function `lint_stability::Trait::trait_deprecated`
+        <Foo as Trait>::trait_deprecated(&foo); //~ WARN use of deprecated associated function `lint_stability::Trait::trait_deprecated`
 
-        deprecated_text(); //~ WARN use of deprecated item 'lint_stability::deprecated_text': text
-        foo.method_deprecated_text(); //~ WARN use of deprecated item 'lint_stability::MethodTester::method_deprecated_text': text
-        Foo::method_deprecated_text(&foo); //~ WARN use of deprecated item 'lint_stability::MethodTester::method_deprecated_text': text
-        <Foo>::method_deprecated_text(&foo); //~ WARN use of deprecated item 'lint_stability::MethodTester::method_deprecated_text': text
-        foo.trait_deprecated_text(); //~ WARN use of deprecated item 'lint_stability::Trait::trait_deprecated_text': text
-        Trait::trait_deprecated_text(&foo); //~ WARN use of deprecated item 'lint_stability::Trait::trait_deprecated_text': text
-        <Foo>::trait_deprecated_text(&foo); //~ WARN use of deprecated item 'lint_stability::Trait::trait_deprecated_text': text
-        <Foo as Trait>::trait_deprecated_text(&foo); //~ WARN use of deprecated item 'lint_stability::Trait::trait_deprecated_text': text
+        deprecated_text(); //~ WARN use of deprecated function `lint_stability::deprecated_text`: text
+        foo.method_deprecated_text(); //~ WARN use of deprecated associated function `lint_stability::MethodTester::method_deprecated_text`: text
+        Foo::method_deprecated_text(&foo); //~ WARN use of deprecated associated function `lint_stability::MethodTester::method_deprecated_text`: text
+        <Foo>::method_deprecated_text(&foo); //~ WARN use of deprecated associated function `lint_stability::MethodTester::method_deprecated_text`: text
+        foo.trait_deprecated_text(); //~ WARN use of deprecated associated function `lint_stability::Trait::trait_deprecated_text`: text
+        Trait::trait_deprecated_text(&foo); //~ WARN use of deprecated associated function `lint_stability::Trait::trait_deprecated_text`: text
+        <Foo>::trait_deprecated_text(&foo); //~ WARN use of deprecated associated function `lint_stability::Trait::trait_deprecated_text`: text
+        <Foo as Trait>::trait_deprecated_text(&foo); //~ WARN use of deprecated associated function `lint_stability::Trait::trait_deprecated_text`: text
 
-        deprecated_unstable(); //~ WARN use of deprecated item 'lint_stability::deprecated_unstable'
-        foo.method_deprecated_unstable(); //~ WARN use of deprecated item 'lint_stability::MethodTester::method_deprecated_unstable'
-        Foo::method_deprecated_unstable(&foo); //~ WARN use of deprecated item 'lint_stability::MethodTester::method_deprecated_unstable'
-        <Foo>::method_deprecated_unstable(&foo); //~ WARN use of deprecated item 'lint_stability::MethodTester::method_deprecated_unstable'
-        foo.trait_deprecated_unstable(); //~ WARN use of deprecated item 'lint_stability::Trait::trait_deprecated_unstable'
-        Trait::trait_deprecated_unstable(&foo); //~ WARN use of deprecated item 'lint_stability::Trait::trait_deprecated_unstable'
-        <Foo>::trait_deprecated_unstable(&foo); //~ WARN use of deprecated item 'lint_stability::Trait::trait_deprecated_unstable'
-        <Foo as Trait>::trait_deprecated_unstable(&foo); //~ WARN use of deprecated item 'lint_stability::Trait::trait_deprecated_unstable'
+        deprecated_unstable(); //~ WARN use of deprecated function `lint_stability::deprecated_unstable`
+        foo.method_deprecated_unstable(); //~ WARN use of deprecated associated function `lint_stability::MethodTester::method_deprecated_unstable`
+        Foo::method_deprecated_unstable(&foo); //~ WARN use of deprecated associated function `lint_stability::MethodTester::method_deprecated_unstable`
+        <Foo>::method_deprecated_unstable(&foo); //~ WARN use of deprecated associated function `lint_stability::MethodTester::method_deprecated_unstable`
+        foo.trait_deprecated_unstable(); //~ WARN use of deprecated associated function `lint_stability::Trait::trait_deprecated_unstable`
+        Trait::trait_deprecated_unstable(&foo); //~ WARN use of deprecated associated function `lint_stability::Trait::trait_deprecated_unstable`
+        <Foo>::trait_deprecated_unstable(&foo); //~ WARN use of deprecated associated function `lint_stability::Trait::trait_deprecated_unstable`
+        <Foo as Trait>::trait_deprecated_unstable(&foo); //~ WARN use of deprecated associated function `lint_stability::Trait::trait_deprecated_unstable`
 
-        deprecated_unstable_text(); //~ WARN use of deprecated item 'lint_stability::deprecated_unstable_text': text
-        foo.method_deprecated_unstable_text(); //~ WARN use of deprecated item 'lint_stability::MethodTester::method_deprecated_unstable_text': text
-        Foo::method_deprecated_unstable_text(&foo); //~ WARN use of deprecated item 'lint_stability::MethodTester::method_deprecated_unstable_text': text
-        <Foo>::method_deprecated_unstable_text(&foo); //~ WARN use of deprecated item 'lint_stability::MethodTester::method_deprecated_unstable_text': text
-        foo.trait_deprecated_unstable_text(); //~ WARN use of deprecated item 'lint_stability::Trait::trait_deprecated_unstable_text': text
-        Trait::trait_deprecated_unstable_text(&foo); //~ WARN use of deprecated item 'lint_stability::Trait::trait_deprecated_unstable_text': text
-        <Foo>::trait_deprecated_unstable_text(&foo); //~ WARN use of deprecated item 'lint_stability::Trait::trait_deprecated_unstable_text': text
-        <Foo as Trait>::trait_deprecated_unstable_text(&foo); //~ WARN use of deprecated item 'lint_stability::Trait::trait_deprecated_unstable_text': text
+        deprecated_unstable_text(); //~ WARN use of deprecated function `lint_stability::deprecated_unstable_text`: text
+        foo.method_deprecated_unstable_text(); //~ WARN use of deprecated associated function `lint_stability::MethodTester::method_deprecated_unstable_text`: text
+        Foo::method_deprecated_unstable_text(&foo); //~ WARN use of deprecated associated function `lint_stability::MethodTester::method_deprecated_unstable_text`: text
+        <Foo>::method_deprecated_unstable_text(&foo); //~ WARN use of deprecated associated function `lint_stability::MethodTester::method_deprecated_unstable_text`: text
+        foo.trait_deprecated_unstable_text(); //~ WARN use of deprecated associated function `lint_stability::Trait::trait_deprecated_unstable_text`: text
+        Trait::trait_deprecated_unstable_text(&foo); //~ WARN use of deprecated associated function `lint_stability::Trait::trait_deprecated_unstable_text`: text
+        <Foo>::trait_deprecated_unstable_text(&foo); //~ WARN use of deprecated associated function `lint_stability::Trait::trait_deprecated_unstable_text`: text
+        <Foo as Trait>::trait_deprecated_unstable_text(&foo); //~ WARN use of deprecated associated function `lint_stability::Trait::trait_deprecated_unstable_text`: text
 
         unstable();
         foo.method_unstable();
@@ -96,38 +96,38 @@ mod cross_crate {
 
         struct S1<T: TraitWithAssociatedTypes>(T::TypeUnstable);
         struct S2<T: TraitWithAssociatedTypes>(T::TypeDeprecated);
-        //~^ WARN use of deprecated item 'lint_stability::TraitWithAssociatedTypes::TypeDeprecated': text
-        //~| WARN use of deprecated item 'lint_stability::TraitWithAssociatedTypes::TypeDeprecated': text
+        //~^ WARN use of deprecated associated type `lint_stability::TraitWithAssociatedTypes::TypeDeprecated`: text
+        //~| WARN use of deprecated associated type `lint_stability::TraitWithAssociatedTypes::TypeDeprecated`: text
         type A = dyn TraitWithAssociatedTypes<
             TypeUnstable = u8,
             TypeDeprecated = u16,
-            //~^ WARN use of deprecated item 'lint_stability::TraitWithAssociatedTypes::TypeDeprecated'
-            //~| WARN use of deprecated item 'lint_stability::TraitWithAssociatedTypes::TypeDeprecated'
-            //~| WARN use of deprecated item 'lint_stability::TraitWithAssociatedTypes::TypeDeprecated'
+            //~^ WARN use of deprecated associated type `lint_stability::TraitWithAssociatedTypes::TypeDeprecated`
+            //~| WARN use of deprecated associated type `lint_stability::TraitWithAssociatedTypes::TypeDeprecated`
+            //~| WARN use of deprecated associated type `lint_stability::TraitWithAssociatedTypes::TypeDeprecated`
         >;
 
-        let _ = DeprecatedStruct { //~ WARN use of deprecated item 'lint_stability::DeprecatedStruct'
-            i: 0 //~ WARN use of deprecated item 'lint_stability::DeprecatedStruct::i'
+        let _ = DeprecatedStruct { //~ WARN use of deprecated struct `lint_stability::DeprecatedStruct`
+            i: 0 //~ WARN use of deprecated field `lint_stability::DeprecatedStruct::i`
         };
         let _ = DeprecatedUnstableStruct {
-            //~^ WARN use of deprecated item 'lint_stability::DeprecatedUnstableStruct'
-            i: 0 //~ WARN use of deprecated item 'lint_stability::DeprecatedUnstableStruct::i'
+            //~^ WARN use of deprecated struct `lint_stability::DeprecatedUnstableStruct`
+            i: 0 //~ WARN use of deprecated field `lint_stability::DeprecatedUnstableStruct::i`
         };
         let _ = UnstableStruct { i: 0 };
         let _ = StableStruct { i: 0 };
 
-        let _ = DeprecatedUnitStruct; //~ WARN use of deprecated item 'lint_stability::DeprecatedUnitStruct'
-        let _ = DeprecatedUnstableUnitStruct; //~ WARN use of deprecated item 'lint_stability::DeprecatedUnstableUnitStruct'
+        let _ = DeprecatedUnitStruct; //~ WARN use of deprecated struct `lint_stability::DeprecatedUnitStruct`
+        let _ = DeprecatedUnstableUnitStruct; //~ WARN use of deprecated struct `lint_stability::DeprecatedUnstableUnitStruct`
         let _ = UnstableUnitStruct;
         let _ = StableUnitStruct;
 
-        let _ = Enum::DeprecatedVariant; //~ WARN use of deprecated item 'lint_stability::Enum::DeprecatedVariant'
-        let _ = Enum::DeprecatedUnstableVariant; //~ WARN use of deprecated item 'lint_stability::Enum::DeprecatedUnstableVariant'
+        let _ = Enum::DeprecatedVariant; //~ WARN use of deprecated variant `lint_stability::Enum::DeprecatedVariant`
+        let _ = Enum::DeprecatedUnstableVariant; //~ WARN use of deprecated variant `lint_stability::Enum::DeprecatedUnstableVariant`
         let _ = Enum::UnstableVariant;
         let _ = Enum::StableVariant;
 
-        let _ = DeprecatedTupleStruct (1); //~ WARN use of deprecated item 'lint_stability::DeprecatedTupleStruct'
-        let _ = DeprecatedUnstableTupleStruct (1); //~ WARN use of deprecated item 'lint_stability::DeprecatedUnstableTupleStruct'
+        let _ = DeprecatedTupleStruct (1); //~ WARN use of deprecated struct `lint_stability::DeprecatedTupleStruct`
+        let _ = DeprecatedUnstableTupleStruct (1); //~ WARN use of deprecated struct `lint_stability::DeprecatedUnstableTupleStruct`
         let _ = UnstableTupleStruct (1);
         let _ = StableTupleStruct (1);
 
@@ -136,28 +136,28 @@ mod cross_crate {
         // Eventually, we will want to lint the contents of the
         // macro in the module *defining* it. Also, stability levels
         // on macros themselves are not yet linted.
-        macro_test_arg!(deprecated_text()); //~ WARN use of deprecated item 'lint_stability::deprecated_text': text
-        macro_test_arg!(deprecated_unstable_text()); //~ WARN use of deprecated item 'lint_stability::deprecated_unstable_text': text
-        macro_test_arg!(macro_test_arg!(deprecated_text())); //~ WARN use of deprecated item 'lint_stability::deprecated_text': text
+        macro_test_arg!(deprecated_text()); //~ WARN use of deprecated function `lint_stability::deprecated_text`: text
+        macro_test_arg!(deprecated_unstable_text()); //~ WARN use of deprecated function `lint_stability::deprecated_unstable_text`: text
+        macro_test_arg!(macro_test_arg!(deprecated_text())); //~ WARN use of deprecated function `lint_stability::deprecated_text`: text
     }
 
     fn test_method_param<Foo: Trait>(foo: Foo) {
-        foo.trait_deprecated(); //~ WARN use of deprecated item 'lint_stability::Trait::trait_deprecated'
-        Trait::trait_deprecated(&foo); //~ WARN use of deprecated item 'lint_stability::Trait::trait_deprecated'
-        <Foo>::trait_deprecated(&foo); //~ WARN use of deprecated item 'lint_stability::Trait::trait_deprecated'
-        <Foo as Trait>::trait_deprecated(&foo); //~ WARN use of deprecated item 'lint_stability::Trait::trait_deprecated'
-        foo.trait_deprecated_text(); //~ WARN use of deprecated item 'lint_stability::Trait::trait_deprecated_text': text
-        Trait::trait_deprecated_text(&foo); //~ WARN use of deprecated item 'lint_stability::Trait::trait_deprecated_text': text
-        <Foo>::trait_deprecated_text(&foo); //~ WARN use of deprecated item 'lint_stability::Trait::trait_deprecated_text': text
-        <Foo as Trait>::trait_deprecated_text(&foo); //~ WARN use of deprecated item 'lint_stability::Trait::trait_deprecated_text': text
-        foo.trait_deprecated_unstable(); //~ WARN use of deprecated item 'lint_stability::Trait::trait_deprecated_unstable'
-        Trait::trait_deprecated_unstable(&foo); //~ WARN use of deprecated item 'lint_stability::Trait::trait_deprecated_unstable'
-        <Foo>::trait_deprecated_unstable(&foo); //~ WARN use of deprecated item 'lint_stability::Trait::trait_deprecated_unstable'
-        <Foo as Trait>::trait_deprecated_unstable(&foo); //~ WARN use of deprecated item 'lint_stability::Trait::trait_deprecated_unstable'
-        foo.trait_deprecated_unstable_text(); //~ WARN use of deprecated item 'lint_stability::Trait::trait_deprecated_unstable_text': text
-        Trait::trait_deprecated_unstable_text(&foo); //~ WARN use of deprecated item 'lint_stability::Trait::trait_deprecated_unstable_text': text
-        <Foo>::trait_deprecated_unstable_text(&foo); //~ WARN use of deprecated item 'lint_stability::Trait::trait_deprecated_unstable_text': text
-        <Foo as Trait>::trait_deprecated_unstable_text(&foo); //~ WARN use of deprecated item 'lint_stability::Trait::trait_deprecated_unstable_text': text
+        foo.trait_deprecated(); //~ WARN use of deprecated associated function `lint_stability::Trait::trait_deprecated`
+        Trait::trait_deprecated(&foo); //~ WARN use of deprecated associated function `lint_stability::Trait::trait_deprecated`
+        <Foo>::trait_deprecated(&foo); //~ WARN use of deprecated associated function `lint_stability::Trait::trait_deprecated`
+        <Foo as Trait>::trait_deprecated(&foo); //~ WARN use of deprecated associated function `lint_stability::Trait::trait_deprecated`
+        foo.trait_deprecated_text(); //~ WARN use of deprecated associated function `lint_stability::Trait::trait_deprecated_text`: text
+        Trait::trait_deprecated_text(&foo); //~ WARN use of deprecated associated function `lint_stability::Trait::trait_deprecated_text`: text
+        <Foo>::trait_deprecated_text(&foo); //~ WARN use of deprecated associated function `lint_stability::Trait::trait_deprecated_text`: text
+        <Foo as Trait>::trait_deprecated_text(&foo); //~ WARN use of deprecated associated function `lint_stability::Trait::trait_deprecated_text`: text
+        foo.trait_deprecated_unstable(); //~ WARN use of deprecated associated function `lint_stability::Trait::trait_deprecated_unstable`
+        Trait::trait_deprecated_unstable(&foo); //~ WARN use of deprecated associated function `lint_stability::Trait::trait_deprecated_unstable`
+        <Foo>::trait_deprecated_unstable(&foo); //~ WARN use of deprecated associated function `lint_stability::Trait::trait_deprecated_unstable`
+        <Foo as Trait>::trait_deprecated_unstable(&foo); //~ WARN use of deprecated associated function `lint_stability::Trait::trait_deprecated_unstable`
+        foo.trait_deprecated_unstable_text(); //~ WARN use of deprecated associated function `lint_stability::Trait::trait_deprecated_unstable_text`: text
+        Trait::trait_deprecated_unstable_text(&foo); //~ WARN use of deprecated associated function `lint_stability::Trait::trait_deprecated_unstable_text`: text
+        <Foo>::trait_deprecated_unstable_text(&foo); //~ WARN use of deprecated associated function `lint_stability::Trait::trait_deprecated_unstable_text`: text
+        <Foo as Trait>::trait_deprecated_unstable_text(&foo); //~ WARN use of deprecated associated function `lint_stability::Trait::trait_deprecated_unstable_text`: text
         foo.trait_unstable();
         Trait::trait_unstable(&foo);
         <Foo>::trait_unstable(&foo);
@@ -173,10 +173,10 @@ mod cross_crate {
     }
 
     fn test_method_object(foo: &dyn Trait) {
-        foo.trait_deprecated(); //~ WARN use of deprecated item 'lint_stability::Trait::trait_deprecated'
-        foo.trait_deprecated_text(); //~ WARN use of deprecated item 'lint_stability::Trait::trait_deprecated_text': text
-        foo.trait_deprecated_unstable(); //~ WARN use of deprecated item 'lint_stability::Trait::trait_deprecated_unstable'
-        foo.trait_deprecated_unstable_text(); //~ WARN use of deprecated item 'lint_stability::Trait::trait_deprecated_unstable_text': text
+        foo.trait_deprecated(); //~ WARN use of deprecated associated function `lint_stability::Trait::trait_deprecated`
+        foo.trait_deprecated_text(); //~ WARN use of deprecated associated function `lint_stability::Trait::trait_deprecated_text`: text
+        foo.trait_deprecated_unstable(); //~ WARN use of deprecated associated function `lint_stability::Trait::trait_deprecated_unstable`
+        foo.trait_deprecated_unstable_text(); //~ WARN use of deprecated associated function `lint_stability::Trait::trait_deprecated_unstable_text`: text
         foo.trait_unstable();
         foo.trait_unstable_text();
         foo.trait_stable();
@@ -185,9 +185,9 @@ mod cross_crate {
     struct S;
 
     impl UnstableTrait for S { }
-    impl DeprecatedTrait for S {} //~ WARN use of deprecated item 'lint_stability::DeprecatedTrait': text
+    impl DeprecatedTrait for S {} //~ WARN use of deprecated trait `lint_stability::DeprecatedTrait`: text
     trait LocalTrait : UnstableTrait { }
-    trait LocalTrait2 : DeprecatedTrait { } //~ WARN use of deprecated item 'lint_stability::DeprecatedTrait': text
+    trait LocalTrait2 : DeprecatedTrait { } //~ WARN use of deprecated trait `lint_stability::DeprecatedTrait`: text
 
     impl Trait for S {
         fn trait_stable(&self) {}
@@ -206,7 +206,7 @@ mod inheritance {
         stable_mod::unstable();
         stable_mod::stable();
 
-        unstable_mod::deprecated(); //~ WARN use of deprecated item 'inheritance::inherited_stability::unstable_mod::deprecated': text
+        unstable_mod::deprecated(); //~ WARN use of deprecated function `inheritance::inherited_stability::unstable_mod::deprecated`: text
         unstable_mod::unstable();
 
         let _ = Unstable::UnstableVariant;
@@ -328,23 +328,23 @@ mod this_crate {
         type Foo = MethodTester;
         let foo = MethodTester;
 
-        deprecated(); //~ WARN use of deprecated item 'this_crate::deprecated'
-        foo.method_deprecated(); //~ WARN use of deprecated item 'this_crate::MethodTester::method_deprecated'
-        Foo::method_deprecated(&foo); //~ WARN use of deprecated item 'this_crate::MethodTester::method_deprecated'
-        <Foo>::method_deprecated(&foo); //~ WARN use of deprecated item 'this_crate::MethodTester::method_deprecated'
-        foo.trait_deprecated(); //~ WARN use of deprecated item 'this_crate::Trait::trait_deprecated'
-        Trait::trait_deprecated(&foo); //~ WARN use of deprecated item 'this_crate::Trait::trait_deprecated'
-        <Foo>::trait_deprecated(&foo); //~ WARN use of deprecated item 'this_crate::Trait::trait_deprecated'
-        <Foo as Trait>::trait_deprecated(&foo); //~ WARN use of deprecated item 'this_crate::Trait::trait_deprecated'
+        deprecated(); //~ WARN use of deprecated function `this_crate::deprecated`
+        foo.method_deprecated(); //~ WARN use of deprecated associated function `this_crate::MethodTester::method_deprecated`
+        Foo::method_deprecated(&foo); //~ WARN use of deprecated associated function `this_crate::MethodTester::method_deprecated`
+        <Foo>::method_deprecated(&foo); //~ WARN use of deprecated associated function `this_crate::MethodTester::method_deprecated`
+        foo.trait_deprecated(); //~ WARN use of deprecated associated function `this_crate::Trait::trait_deprecated`
+        Trait::trait_deprecated(&foo); //~ WARN use of deprecated associated function `this_crate::Trait::trait_deprecated`
+        <Foo>::trait_deprecated(&foo); //~ WARN use of deprecated associated function `this_crate::Trait::trait_deprecated`
+        <Foo as Trait>::trait_deprecated(&foo); //~ WARN use of deprecated associated function `this_crate::Trait::trait_deprecated`
 
-        deprecated_text(); //~ WARN use of deprecated item 'this_crate::deprecated_text': text
-        foo.method_deprecated_text(); //~ WARN use of deprecated item 'this_crate::MethodTester::method_deprecated_text': text
-        Foo::method_deprecated_text(&foo); //~ WARN use of deprecated item 'this_crate::MethodTester::method_deprecated_text': text
-        <Foo>::method_deprecated_text(&foo); //~ WARN use of deprecated item 'this_crate::MethodTester::method_deprecated_text': text
-        foo.trait_deprecated_text(); //~ WARN use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
-        Trait::trait_deprecated_text(&foo); //~ WARN use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
-        <Foo>::trait_deprecated_text(&foo); //~ WARN use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
-        <Foo as Trait>::trait_deprecated_text(&foo); //~ WARN use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
+        deprecated_text(); //~ WARN use of deprecated function `this_crate::deprecated_text`: text
+        foo.method_deprecated_text(); //~ WARN use of deprecated associated function `this_crate::MethodTester::method_deprecated_text`: text
+        Foo::method_deprecated_text(&foo); //~ WARN use of deprecated associated function `this_crate::MethodTester::method_deprecated_text`: text
+        <Foo>::method_deprecated_text(&foo); //~ WARN use of deprecated associated function `this_crate::MethodTester::method_deprecated_text`: text
+        foo.trait_deprecated_text(); //~ WARN use of deprecated associated function `this_crate::Trait::trait_deprecated_text`: text
+        Trait::trait_deprecated_text(&foo); //~ WARN use of deprecated associated function `this_crate::Trait::trait_deprecated_text`: text
+        <Foo>::trait_deprecated_text(&foo); //~ WARN use of deprecated associated function `this_crate::Trait::trait_deprecated_text`: text
+        <Foo as Trait>::trait_deprecated_text(&foo); //~ WARN use of deprecated associated function `this_crate::Trait::trait_deprecated_text`: text
 
         unstable();
         foo.method_unstable();
@@ -383,34 +383,34 @@ mod this_crate {
         <Foo as Trait>::trait_stable_text(&foo);
 
         let _ = DeprecatedStruct {
-            //~^ WARN use of deprecated item 'this_crate::DeprecatedStruct'
-            i: 0 //~ WARN use of deprecated item 'this_crate::DeprecatedStruct::i'
+            //~^ WARN use of deprecated struct `this_crate::DeprecatedStruct`
+            i: 0 //~ WARN use of deprecated field `this_crate::DeprecatedStruct::i`
         };
         let _ = UnstableStruct { i: 0 };
         let _ = StableStruct { i: 0 };
 
-        let _ = DeprecatedUnitStruct; //~ WARN use of deprecated item 'this_crate::DeprecatedUnitStruct'
+        let _ = DeprecatedUnitStruct; //~ WARN use of deprecated unit struct `this_crate::DeprecatedUnitStruct`
         let _ = UnstableUnitStruct;
         let _ = StableUnitStruct;
 
-        let _ = Enum::DeprecatedVariant; //~ WARN use of deprecated item 'this_crate::Enum::DeprecatedVariant'
+        let _ = Enum::DeprecatedVariant; //~ WARN use of deprecated unit variant `this_crate::Enum::DeprecatedVariant`
         let _ = Enum::UnstableVariant;
         let _ = Enum::StableVariant;
 
-        let _ = DeprecatedTupleStruct (1); //~ WARN use of deprecated item 'this_crate::DeprecatedTupleStruct'
+        let _ = DeprecatedTupleStruct (1); //~ WARN use of deprecated tuple struct `this_crate::DeprecatedTupleStruct`
         let _ = UnstableTupleStruct (1);
         let _ = StableTupleStruct (1);
     }
 
     fn test_method_param<Foo: Trait>(foo: Foo) {
-        foo.trait_deprecated(); //~ WARN use of deprecated item 'this_crate::Trait::trait_deprecated'
-        Trait::trait_deprecated(&foo); //~ WARN use of deprecated item 'this_crate::Trait::trait_deprecated'
-        <Foo>::trait_deprecated(&foo); //~ WARN use of deprecated item 'this_crate::Trait::trait_deprecated'
-        <Foo as Trait>::trait_deprecated(&foo); //~ WARN use of deprecated item 'this_crate::Trait::trait_deprecated'
-        foo.trait_deprecated_text(); //~ WARN use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
-        Trait::trait_deprecated_text(&foo); //~ WARN use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
-        <Foo>::trait_deprecated_text(&foo); //~ WARN use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
-        <Foo as Trait>::trait_deprecated_text(&foo); //~ WARN use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
+        foo.trait_deprecated(); //~ WARN use of deprecated associated function `this_crate::Trait::trait_deprecated`
+        Trait::trait_deprecated(&foo); //~ WARN use of deprecated associated function `this_crate::Trait::trait_deprecated`
+        <Foo>::trait_deprecated(&foo); //~ WARN use of deprecated associated function `this_crate::Trait::trait_deprecated`
+        <Foo as Trait>::trait_deprecated(&foo); //~ WARN use of deprecated associated function `this_crate::Trait::trait_deprecated`
+        foo.trait_deprecated_text(); //~ WARN use of deprecated associated function `this_crate::Trait::trait_deprecated_text`: text
+        Trait::trait_deprecated_text(&foo); //~ WARN use of deprecated associated function `this_crate::Trait::trait_deprecated_text`: text
+        <Foo>::trait_deprecated_text(&foo); //~ WARN use of deprecated associated function `this_crate::Trait::trait_deprecated_text`: text
+        <Foo as Trait>::trait_deprecated_text(&foo); //~ WARN use of deprecated associated function `this_crate::Trait::trait_deprecated_text`: text
         foo.trait_unstable();
         Trait::trait_unstable(&foo);
         <Foo>::trait_unstable(&foo);
@@ -426,8 +426,8 @@ mod this_crate {
     }
 
     fn test_method_object(foo: &dyn Trait) {
-        foo.trait_deprecated(); //~ WARN use of deprecated item 'this_crate::Trait::trait_deprecated'
-        foo.trait_deprecated_text(); //~ WARN use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
+        foo.trait_deprecated(); //~ WARN use of deprecated associated function `this_crate::Trait::trait_deprecated`
+        foo.trait_deprecated_text(); //~ WARN use of deprecated associated function `this_crate::Trait::trait_deprecated_text`: text
         foo.trait_unstable();
         foo.trait_unstable_text();
         foo.trait_stable();
@@ -437,7 +437,7 @@ mod this_crate {
     #[rustc_deprecated(since = "1.0.0", reason = "text")]
     fn test_fn_body() {
         fn fn_in_body() {}
-        fn_in_body(); //~ WARN use of deprecated item 'this_crate::test_fn_body::fn_in_body': text
+        fn_in_body(); //~ WARN use of deprecated function `this_crate::test_fn_body::fn_in_body`: text
     }
 
     impl MethodTester {
@@ -445,7 +445,7 @@ mod this_crate {
         #[rustc_deprecated(since = "1.0.0", reason = "text")]
         fn test_method_body(&self) {
             fn fn_in_body() {}
-            fn_in_body(); //~ WARN use of deprecated item 'this_crate::MethodTester::test_method_body::fn_in_body': text
+            fn_in_body(); //~ WARN use of deprecated function `this_crate::MethodTester::test_method_body::fn_in_body`: text
         }
     }
 
@@ -457,9 +457,9 @@ mod this_crate {
 
     struct S;
 
-    impl DeprecatedTrait for S { } //~ WARN use of deprecated item 'this_crate::DeprecatedTrait'
+    impl DeprecatedTrait for S { } //~ WARN use of deprecated trait `this_crate::DeprecatedTrait`
 
-    trait LocalTrait : DeprecatedTrait { } //~ WARN use of deprecated item 'this_crate::DeprecatedTrait'
+    trait LocalTrait : DeprecatedTrait { } //~ WARN use of deprecated trait `this_crate::DeprecatedTrait`
 }
 
 fn main() {}

--- a/src/test/ui/lint/lint-stability-deprecated.stderr
+++ b/src/test/ui/lint/lint-stability-deprecated.stderr
@@ -1,4 +1,4 @@
-warning: use of deprecated item 'lint_stability::deprecated': text
+warning: use of deprecated function `lint_stability::deprecated`: text
   --> $DIR/lint-stability-deprecated.rs:25:9
    |
 LL |         deprecated();
@@ -10,643 +10,643 @@ note: the lint level is defined here
 LL | #![warn(deprecated)]
    |         ^^^^^^^^^^
 
-warning: use of deprecated item 'lint_stability::Trait::trait_deprecated': text
+warning: use of deprecated associated function `lint_stability::Trait::trait_deprecated`: text
   --> $DIR/lint-stability-deprecated.rs:30:9
    |
 LL |         Trait::trait_deprecated(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'lint_stability::Trait::trait_deprecated': text
+warning: use of deprecated associated function `lint_stability::Trait::trait_deprecated`: text
   --> $DIR/lint-stability-deprecated.rs:32:9
    |
 LL |         <Foo as Trait>::trait_deprecated(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'lint_stability::deprecated_text': text
+warning: use of deprecated function `lint_stability::deprecated_text`: text
   --> $DIR/lint-stability-deprecated.rs:34:9
    |
 LL |         deprecated_text();
    |         ^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'lint_stability::Trait::trait_deprecated_text': text
+warning: use of deprecated associated function `lint_stability::Trait::trait_deprecated_text`: text
   --> $DIR/lint-stability-deprecated.rs:39:9
    |
-LL |         Trait::trait_deprecated_text(&foo);
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | ...   Trait::trait_deprecated_text(&foo);
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'lint_stability::Trait::trait_deprecated_text': text
+warning: use of deprecated associated function `lint_stability::Trait::trait_deprecated_text`: text
   --> $DIR/lint-stability-deprecated.rs:41:9
    |
-LL |         <Foo as Trait>::trait_deprecated_text(&foo);
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | ...   <Foo as Trait>::trait_deprecated_text(&foo);
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'lint_stability::deprecated_unstable': text
+warning: use of deprecated function `lint_stability::deprecated_unstable`: text
   --> $DIR/lint-stability-deprecated.rs:43:9
    |
 LL |         deprecated_unstable();
    |         ^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'lint_stability::Trait::trait_deprecated_unstable': text
+warning: use of deprecated associated function `lint_stability::Trait::trait_deprecated_unstable`: text
   --> $DIR/lint-stability-deprecated.rs:48:9
    |
-LL |         Trait::trait_deprecated_unstable(&foo);
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | ...   Trait::trait_deprecated_unstable(&foo);
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'lint_stability::Trait::trait_deprecated_unstable': text
+warning: use of deprecated associated function `lint_stability::Trait::trait_deprecated_unstable`: text
   --> $DIR/lint-stability-deprecated.rs:50:9
    |
-LL |         <Foo as Trait>::trait_deprecated_unstable(&foo);
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | ...   <Foo as Trait>::trait_deprecated_unstable(&foo);
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'lint_stability::deprecated_unstable_text': text
+warning: use of deprecated function `lint_stability::deprecated_unstable_text`: text
   --> $DIR/lint-stability-deprecated.rs:52:9
    |
 LL |         deprecated_unstable_text();
    |         ^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'lint_stability::Trait::trait_deprecated_unstable_text': text
+warning: use of deprecated associated function `lint_stability::Trait::trait_deprecated_unstable_text`: text
   --> $DIR/lint-stability-deprecated.rs:57:9
    |
 LL | ...   Trait::trait_deprecated_unstable_text(&foo);
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'lint_stability::Trait::trait_deprecated_unstable_text': text
+warning: use of deprecated associated function `lint_stability::Trait::trait_deprecated_unstable_text`: text
   --> $DIR/lint-stability-deprecated.rs:59:9
    |
 LL | ...   <Foo as Trait>::trait_deprecated_unstable_text(&foo);
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'lint_stability::DeprecatedStruct': text
+warning: use of deprecated struct `lint_stability::DeprecatedStruct`: text
   --> $DIR/lint-stability-deprecated.rs:109:17
    |
 LL |         let _ = DeprecatedStruct {
    |                 ^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'lint_stability::DeprecatedUnstableStruct': text
+warning: use of deprecated struct `lint_stability::DeprecatedUnstableStruct`: text
   --> $DIR/lint-stability-deprecated.rs:112:17
    |
 LL |         let _ = DeprecatedUnstableStruct {
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'lint_stability::DeprecatedUnitStruct': text
+warning: use of deprecated struct `lint_stability::DeprecatedUnitStruct`: text
   --> $DIR/lint-stability-deprecated.rs:119:17
    |
 LL |         let _ = DeprecatedUnitStruct;
    |                 ^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'lint_stability::DeprecatedUnstableUnitStruct': text
+warning: use of deprecated struct `lint_stability::DeprecatedUnstableUnitStruct`: text
   --> $DIR/lint-stability-deprecated.rs:120:17
    |
 LL |         let _ = DeprecatedUnstableUnitStruct;
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'lint_stability::Enum::DeprecatedVariant': text
+warning: use of deprecated variant `lint_stability::Enum::DeprecatedVariant`: text
   --> $DIR/lint-stability-deprecated.rs:124:17
    |
 LL |         let _ = Enum::DeprecatedVariant;
    |                 ^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'lint_stability::Enum::DeprecatedUnstableVariant': text
+warning: use of deprecated variant `lint_stability::Enum::DeprecatedUnstableVariant`: text
   --> $DIR/lint-stability-deprecated.rs:125:17
    |
 LL |         let _ = Enum::DeprecatedUnstableVariant;
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'lint_stability::DeprecatedTupleStruct': text
+warning: use of deprecated struct `lint_stability::DeprecatedTupleStruct`: text
   --> $DIR/lint-stability-deprecated.rs:129:17
    |
 LL |         let _ = DeprecatedTupleStruct (1);
    |                 ^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'lint_stability::DeprecatedUnstableTupleStruct': text
+warning: use of deprecated struct `lint_stability::DeprecatedUnstableTupleStruct`: text
   --> $DIR/lint-stability-deprecated.rs:130:17
    |
 LL |         let _ = DeprecatedUnstableTupleStruct (1);
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'lint_stability::deprecated_text': text
+warning: use of deprecated function `lint_stability::deprecated_text`: text
   --> $DIR/lint-stability-deprecated.rs:139:25
    |
 LL |         macro_test_arg!(deprecated_text());
    |                         ^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'lint_stability::deprecated_unstable_text': text
+warning: use of deprecated function `lint_stability::deprecated_unstable_text`: text
   --> $DIR/lint-stability-deprecated.rs:140:25
    |
 LL |         macro_test_arg!(deprecated_unstable_text());
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'lint_stability::deprecated_text': text
+warning: use of deprecated function `lint_stability::deprecated_text`: text
   --> $DIR/lint-stability-deprecated.rs:141:41
    |
 LL |         macro_test_arg!(macro_test_arg!(deprecated_text()));
    |                                         ^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'lint_stability::Trait::trait_deprecated': text
+warning: use of deprecated associated function `lint_stability::Trait::trait_deprecated`: text
   --> $DIR/lint-stability-deprecated.rs:146:9
    |
 LL |         Trait::trait_deprecated(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'lint_stability::Trait::trait_deprecated': text
+warning: use of deprecated associated function `lint_stability::Trait::trait_deprecated`: text
   --> $DIR/lint-stability-deprecated.rs:148:9
    |
 LL |         <Foo as Trait>::trait_deprecated(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'lint_stability::Trait::trait_deprecated_text': text
+warning: use of deprecated associated function `lint_stability::Trait::trait_deprecated_text`: text
   --> $DIR/lint-stability-deprecated.rs:150:9
    |
-LL |         Trait::trait_deprecated_text(&foo);
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | ...   Trait::trait_deprecated_text(&foo);
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'lint_stability::Trait::trait_deprecated_text': text
+warning: use of deprecated associated function `lint_stability::Trait::trait_deprecated_text`: text
   --> $DIR/lint-stability-deprecated.rs:152:9
    |
-LL |         <Foo as Trait>::trait_deprecated_text(&foo);
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | ...   <Foo as Trait>::trait_deprecated_text(&foo);
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'lint_stability::Trait::trait_deprecated_unstable': text
+warning: use of deprecated associated function `lint_stability::Trait::trait_deprecated_unstable`: text
   --> $DIR/lint-stability-deprecated.rs:154:9
    |
-LL |         Trait::trait_deprecated_unstable(&foo);
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | ...   Trait::trait_deprecated_unstable(&foo);
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'lint_stability::Trait::trait_deprecated_unstable': text
+warning: use of deprecated associated function `lint_stability::Trait::trait_deprecated_unstable`: text
   --> $DIR/lint-stability-deprecated.rs:156:9
    |
-LL |         <Foo as Trait>::trait_deprecated_unstable(&foo);
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | ...   <Foo as Trait>::trait_deprecated_unstable(&foo);
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'lint_stability::Trait::trait_deprecated_unstable_text': text
+warning: use of deprecated associated function `lint_stability::Trait::trait_deprecated_unstable_text`: text
   --> $DIR/lint-stability-deprecated.rs:158:9
    |
 LL | ...   Trait::trait_deprecated_unstable_text(&foo);
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'lint_stability::Trait::trait_deprecated_unstable_text': text
+warning: use of deprecated associated function `lint_stability::Trait::trait_deprecated_unstable_text`: text
   --> $DIR/lint-stability-deprecated.rs:160:9
    |
 LL | ...   <Foo as Trait>::trait_deprecated_unstable_text(&foo);
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'lint_stability::DeprecatedTrait': text
+warning: use of deprecated trait `lint_stability::DeprecatedTrait`: text
   --> $DIR/lint-stability-deprecated.rs:188:10
    |
 LL |     impl DeprecatedTrait for S {}
    |          ^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'lint_stability::DeprecatedTrait': text
+warning: use of deprecated trait `lint_stability::DeprecatedTrait`: text
   --> $DIR/lint-stability-deprecated.rs:190:25
    |
 LL |     trait LocalTrait2 : DeprecatedTrait { }
    |                         ^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'inheritance::inherited_stability::unstable_mod::deprecated': text
+warning: use of deprecated function `inheritance::inherited_stability::unstable_mod::deprecated`: text
   --> $DIR/lint-stability-deprecated.rs:209:9
    |
 LL |         unstable_mod::deprecated();
    |         ^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'this_crate::deprecated': text
+warning: use of deprecated function `this_crate::deprecated`: text
   --> $DIR/lint-stability-deprecated.rs:331:9
    |
 LL |         deprecated();
    |         ^^^^^^^^^^
 
-warning: use of deprecated item 'this_crate::Trait::trait_deprecated': text
+warning: use of deprecated associated function `this_crate::Trait::trait_deprecated`: text
   --> $DIR/lint-stability-deprecated.rs:336:9
    |
 LL |         Trait::trait_deprecated(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'this_crate::Trait::trait_deprecated': text
+warning: use of deprecated associated function `this_crate::Trait::trait_deprecated`: text
   --> $DIR/lint-stability-deprecated.rs:338:9
    |
 LL |         <Foo as Trait>::trait_deprecated(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'this_crate::deprecated_text': text
+warning: use of deprecated function `this_crate::deprecated_text`: text
   --> $DIR/lint-stability-deprecated.rs:340:9
    |
 LL |         deprecated_text();
    |         ^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
+warning: use of deprecated associated function `this_crate::Trait::trait_deprecated_text`: text
   --> $DIR/lint-stability-deprecated.rs:345:9
    |
 LL |         Trait::trait_deprecated_text(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
+warning: use of deprecated associated function `this_crate::Trait::trait_deprecated_text`: text
   --> $DIR/lint-stability-deprecated.rs:347:9
    |
-LL |         <Foo as Trait>::trait_deprecated_text(&foo);
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | ...   <Foo as Trait>::trait_deprecated_text(&foo);
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'this_crate::DeprecatedStruct': text
+warning: use of deprecated struct `this_crate::DeprecatedStruct`: text
   --> $DIR/lint-stability-deprecated.rs:385:17
    |
 LL |         let _ = DeprecatedStruct {
    |                 ^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'this_crate::DeprecatedUnitStruct': text
+warning: use of deprecated unit struct `this_crate::DeprecatedUnitStruct`: text
   --> $DIR/lint-stability-deprecated.rs:392:17
    |
 LL |         let _ = DeprecatedUnitStruct;
    |                 ^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'this_crate::Enum::DeprecatedVariant': text
+warning: use of deprecated unit variant `this_crate::Enum::DeprecatedVariant`: text
   --> $DIR/lint-stability-deprecated.rs:396:17
    |
 LL |         let _ = Enum::DeprecatedVariant;
    |                 ^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'this_crate::DeprecatedTupleStruct': text
+warning: use of deprecated tuple struct `this_crate::DeprecatedTupleStruct`: text
   --> $DIR/lint-stability-deprecated.rs:400:17
    |
 LL |         let _ = DeprecatedTupleStruct (1);
    |                 ^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'this_crate::Trait::trait_deprecated': text
+warning: use of deprecated associated function `this_crate::Trait::trait_deprecated`: text
   --> $DIR/lint-stability-deprecated.rs:407:9
    |
 LL |         Trait::trait_deprecated(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'this_crate::Trait::trait_deprecated': text
+warning: use of deprecated associated function `this_crate::Trait::trait_deprecated`: text
   --> $DIR/lint-stability-deprecated.rs:409:9
    |
 LL |         <Foo as Trait>::trait_deprecated(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
+warning: use of deprecated associated function `this_crate::Trait::trait_deprecated_text`: text
   --> $DIR/lint-stability-deprecated.rs:411:9
    |
 LL |         Trait::trait_deprecated_text(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
+warning: use of deprecated associated function `this_crate::Trait::trait_deprecated_text`: text
   --> $DIR/lint-stability-deprecated.rs:413:9
    |
-LL |         <Foo as Trait>::trait_deprecated_text(&foo);
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | ...   <Foo as Trait>::trait_deprecated_text(&foo);
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'this_crate::test_fn_body::fn_in_body': text
+warning: use of deprecated function `this_crate::test_fn_body::fn_in_body`: text
   --> $DIR/lint-stability-deprecated.rs:440:9
    |
 LL |         fn_in_body();
    |         ^^^^^^^^^^
 
-warning: use of deprecated item 'this_crate::DeprecatedTrait': text
+warning: use of deprecated trait `this_crate::DeprecatedTrait`: text
   --> $DIR/lint-stability-deprecated.rs:460:10
    |
 LL |     impl DeprecatedTrait for S { }
    |          ^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'this_crate::DeprecatedTrait': text
+warning: use of deprecated trait `this_crate::DeprecatedTrait`: text
   --> $DIR/lint-stability-deprecated.rs:462:24
    |
 LL |     trait LocalTrait : DeprecatedTrait { }
    |                        ^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'this_crate::MethodTester::test_method_body::fn_in_body': text
+warning: use of deprecated function `this_crate::MethodTester::test_method_body::fn_in_body`: text
   --> $DIR/lint-stability-deprecated.rs:448:13
    |
 LL |             fn_in_body();
    |             ^^^^^^^^^^
 
-warning: use of deprecated item 'lint_stability::TraitWithAssociatedTypes::TypeDeprecated': text
+warning: use of deprecated associated type `lint_stability::TraitWithAssociatedTypes::TypeDeprecated`: text
   --> $DIR/lint-stability-deprecated.rs:98:48
    |
 LL |         struct S2<T: TraitWithAssociatedTypes>(T::TypeDeprecated);
    |                                                ^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'lint_stability::TraitWithAssociatedTypes::TypeDeprecated': text
+warning: use of deprecated associated type `lint_stability::TraitWithAssociatedTypes::TypeDeprecated`: text
   --> $DIR/lint-stability-deprecated.rs:103:13
    |
 LL |             TypeDeprecated = u16,
    |             ^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'lint_stability::MethodTester::method_deprecated': text
+warning: use of deprecated associated function `lint_stability::MethodTester::method_deprecated`: text
   --> $DIR/lint-stability-deprecated.rs:26:13
    |
 LL |         foo.method_deprecated();
    |             ^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'lint_stability::MethodTester::method_deprecated': text
+warning: use of deprecated associated function `lint_stability::MethodTester::method_deprecated`: text
   --> $DIR/lint-stability-deprecated.rs:27:9
    |
 LL |         Foo::method_deprecated(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'lint_stability::MethodTester::method_deprecated': text
+warning: use of deprecated associated function `lint_stability::MethodTester::method_deprecated`: text
   --> $DIR/lint-stability-deprecated.rs:28:9
    |
 LL |         <Foo>::method_deprecated(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'lint_stability::Trait::trait_deprecated': text
+warning: use of deprecated associated function `lint_stability::Trait::trait_deprecated`: text
   --> $DIR/lint-stability-deprecated.rs:29:13
    |
 LL |         foo.trait_deprecated();
    |             ^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'lint_stability::Trait::trait_deprecated': text
+warning: use of deprecated associated function `lint_stability::Trait::trait_deprecated`: text
   --> $DIR/lint-stability-deprecated.rs:31:9
    |
 LL |         <Foo>::trait_deprecated(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'lint_stability::MethodTester::method_deprecated_text': text
+warning: use of deprecated associated function `lint_stability::MethodTester::method_deprecated_text`: text
   --> $DIR/lint-stability-deprecated.rs:35:13
    |
-LL |         foo.method_deprecated_text();
-   |             ^^^^^^^^^^^^^^^^^^^^^^
+LL | ...   foo.method_deprecated_text();
+   |           ^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'lint_stability::MethodTester::method_deprecated_text': text
+warning: use of deprecated associated function `lint_stability::MethodTester::method_deprecated_text`: text
   --> $DIR/lint-stability-deprecated.rs:36:9
    |
-LL |         Foo::method_deprecated_text(&foo);
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | ...   Foo::method_deprecated_text(&foo);
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'lint_stability::MethodTester::method_deprecated_text': text
+warning: use of deprecated associated function `lint_stability::MethodTester::method_deprecated_text`: text
   --> $DIR/lint-stability-deprecated.rs:37:9
    |
-LL |         <Foo>::method_deprecated_text(&foo);
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | ...   <Foo>::method_deprecated_text(&foo);
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'lint_stability::Trait::trait_deprecated_text': text
+warning: use of deprecated associated function `lint_stability::Trait::trait_deprecated_text`: text
   --> $DIR/lint-stability-deprecated.rs:38:13
    |
 LL |         foo.trait_deprecated_text();
    |             ^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'lint_stability::Trait::trait_deprecated_text': text
+warning: use of deprecated associated function `lint_stability::Trait::trait_deprecated_text`: text
   --> $DIR/lint-stability-deprecated.rs:40:9
    |
-LL |         <Foo>::trait_deprecated_text(&foo);
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | ...   <Foo>::trait_deprecated_text(&foo);
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'lint_stability::MethodTester::method_deprecated_unstable': text
+warning: use of deprecated associated function `lint_stability::MethodTester::method_deprecated_unstable`: text
   --> $DIR/lint-stability-deprecated.rs:44:13
    |
-LL |         foo.method_deprecated_unstable();
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | ...   foo.method_deprecated_unstable();
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'lint_stability::MethodTester::method_deprecated_unstable': text
+warning: use of deprecated associated function `lint_stability::MethodTester::method_deprecated_unstable`: text
   --> $DIR/lint-stability-deprecated.rs:45:9
    |
-LL |         Foo::method_deprecated_unstable(&foo);
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | ...   Foo::method_deprecated_unstable(&foo);
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'lint_stability::MethodTester::method_deprecated_unstable': text
+warning: use of deprecated associated function `lint_stability::MethodTester::method_deprecated_unstable`: text
   --> $DIR/lint-stability-deprecated.rs:46:9
    |
-LL |         <Foo>::method_deprecated_unstable(&foo);
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | ...   <Foo>::method_deprecated_unstable(&foo);
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'lint_stability::Trait::trait_deprecated_unstable': text
+warning: use of deprecated associated function `lint_stability::Trait::trait_deprecated_unstable`: text
   --> $DIR/lint-stability-deprecated.rs:47:13
    |
 LL |         foo.trait_deprecated_unstable();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'lint_stability::Trait::trait_deprecated_unstable': text
+warning: use of deprecated associated function `lint_stability::Trait::trait_deprecated_unstable`: text
   --> $DIR/lint-stability-deprecated.rs:49:9
    |
-LL |         <Foo>::trait_deprecated_unstable(&foo);
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | ...   <Foo>::trait_deprecated_unstable(&foo);
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'lint_stability::MethodTester::method_deprecated_unstable_text': text
+warning: use of deprecated associated function `lint_stability::MethodTester::method_deprecated_unstable_text`: text
   --> $DIR/lint-stability-deprecated.rs:53:13
    |
 LL | ...   foo.method_deprecated_unstable_text();
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'lint_stability::MethodTester::method_deprecated_unstable_text': text
+warning: use of deprecated associated function `lint_stability::MethodTester::method_deprecated_unstable_text`: text
   --> $DIR/lint-stability-deprecated.rs:54:9
    |
 LL | ...   Foo::method_deprecated_unstable_text(&foo);
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'lint_stability::MethodTester::method_deprecated_unstable_text': text
+warning: use of deprecated associated function `lint_stability::MethodTester::method_deprecated_unstable_text`: text
   --> $DIR/lint-stability-deprecated.rs:55:9
    |
 LL | ...   <Foo>::method_deprecated_unstable_text(&foo);
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'lint_stability::Trait::trait_deprecated_unstable_text': text
+warning: use of deprecated associated function `lint_stability::Trait::trait_deprecated_unstable_text`: text
   --> $DIR/lint-stability-deprecated.rs:56:13
    |
-LL |         foo.trait_deprecated_unstable_text();
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | ...   foo.trait_deprecated_unstable_text();
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'lint_stability::Trait::trait_deprecated_unstable_text': text
+warning: use of deprecated associated function `lint_stability::Trait::trait_deprecated_unstable_text`: text
   --> $DIR/lint-stability-deprecated.rs:58:9
    |
 LL | ...   <Foo>::trait_deprecated_unstable_text(&foo);
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'lint_stability::DeprecatedStruct::i': text
+warning: use of deprecated field `lint_stability::DeprecatedStruct::i`: text
   --> $DIR/lint-stability-deprecated.rs:110:13
    |
 LL |             i: 0
    |             ^^^^
 
-warning: use of deprecated item 'lint_stability::DeprecatedUnstableStruct::i': text
+warning: use of deprecated field `lint_stability::DeprecatedUnstableStruct::i`: text
   --> $DIR/lint-stability-deprecated.rs:114:13
    |
 LL |             i: 0
    |             ^^^^
 
-warning: use of deprecated item 'lint_stability::Trait::trait_deprecated': text
+warning: use of deprecated associated function `lint_stability::Trait::trait_deprecated`: text
   --> $DIR/lint-stability-deprecated.rs:145:13
    |
 LL |         foo.trait_deprecated();
    |             ^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'lint_stability::Trait::trait_deprecated': text
+warning: use of deprecated associated function `lint_stability::Trait::trait_deprecated`: text
   --> $DIR/lint-stability-deprecated.rs:147:9
    |
 LL |         <Foo>::trait_deprecated(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'lint_stability::Trait::trait_deprecated_text': text
+warning: use of deprecated associated function `lint_stability::Trait::trait_deprecated_text`: text
   --> $DIR/lint-stability-deprecated.rs:149:13
    |
 LL |         foo.trait_deprecated_text();
    |             ^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'lint_stability::Trait::trait_deprecated_text': text
+warning: use of deprecated associated function `lint_stability::Trait::trait_deprecated_text`: text
   --> $DIR/lint-stability-deprecated.rs:151:9
    |
-LL |         <Foo>::trait_deprecated_text(&foo);
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | ...   <Foo>::trait_deprecated_text(&foo);
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'lint_stability::Trait::trait_deprecated_unstable': text
+warning: use of deprecated associated function `lint_stability::Trait::trait_deprecated_unstable`: text
   --> $DIR/lint-stability-deprecated.rs:153:13
    |
 LL |         foo.trait_deprecated_unstable();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'lint_stability::Trait::trait_deprecated_unstable': text
+warning: use of deprecated associated function `lint_stability::Trait::trait_deprecated_unstable`: text
   --> $DIR/lint-stability-deprecated.rs:155:9
    |
-LL |         <Foo>::trait_deprecated_unstable(&foo);
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | ...   <Foo>::trait_deprecated_unstable(&foo);
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'lint_stability::Trait::trait_deprecated_unstable_text': text
+warning: use of deprecated associated function `lint_stability::Trait::trait_deprecated_unstable_text`: text
   --> $DIR/lint-stability-deprecated.rs:157:13
    |
-LL |         foo.trait_deprecated_unstable_text();
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | ...   foo.trait_deprecated_unstable_text();
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'lint_stability::Trait::trait_deprecated_unstable_text': text
+warning: use of deprecated associated function `lint_stability::Trait::trait_deprecated_unstable_text`: text
   --> $DIR/lint-stability-deprecated.rs:159:9
    |
 LL | ...   <Foo>::trait_deprecated_unstable_text(&foo);
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'lint_stability::Trait::trait_deprecated': text
+warning: use of deprecated associated function `lint_stability::Trait::trait_deprecated`: text
   --> $DIR/lint-stability-deprecated.rs:176:13
    |
 LL |         foo.trait_deprecated();
    |             ^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'lint_stability::Trait::trait_deprecated_text': text
+warning: use of deprecated associated function `lint_stability::Trait::trait_deprecated_text`: text
   --> $DIR/lint-stability-deprecated.rs:177:13
    |
 LL |         foo.trait_deprecated_text();
    |             ^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'lint_stability::Trait::trait_deprecated_unstable': text
+warning: use of deprecated associated function `lint_stability::Trait::trait_deprecated_unstable`: text
   --> $DIR/lint-stability-deprecated.rs:178:13
    |
 LL |         foo.trait_deprecated_unstable();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'lint_stability::Trait::trait_deprecated_unstable_text': text
+warning: use of deprecated associated function `lint_stability::Trait::trait_deprecated_unstable_text`: text
   --> $DIR/lint-stability-deprecated.rs:179:13
    |
-LL |         foo.trait_deprecated_unstable_text();
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | ...   foo.trait_deprecated_unstable_text();
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'this_crate::MethodTester::method_deprecated': text
+warning: use of deprecated associated function `this_crate::MethodTester::method_deprecated`: text
   --> $DIR/lint-stability-deprecated.rs:332:13
    |
 LL |         foo.method_deprecated();
    |             ^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'this_crate::MethodTester::method_deprecated': text
+warning: use of deprecated associated function `this_crate::MethodTester::method_deprecated`: text
   --> $DIR/lint-stability-deprecated.rs:333:9
    |
 LL |         Foo::method_deprecated(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'this_crate::MethodTester::method_deprecated': text
+warning: use of deprecated associated function `this_crate::MethodTester::method_deprecated`: text
   --> $DIR/lint-stability-deprecated.rs:334:9
    |
 LL |         <Foo>::method_deprecated(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'this_crate::Trait::trait_deprecated': text
+warning: use of deprecated associated function `this_crate::Trait::trait_deprecated`: text
   --> $DIR/lint-stability-deprecated.rs:335:13
    |
 LL |         foo.trait_deprecated();
    |             ^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'this_crate::Trait::trait_deprecated': text
+warning: use of deprecated associated function `this_crate::Trait::trait_deprecated`: text
   --> $DIR/lint-stability-deprecated.rs:337:9
    |
 LL |         <Foo>::trait_deprecated(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'this_crate::MethodTester::method_deprecated_text': text
+warning: use of deprecated associated function `this_crate::MethodTester::method_deprecated_text`: text
   --> $DIR/lint-stability-deprecated.rs:341:13
    |
-LL |         foo.method_deprecated_text();
-   |             ^^^^^^^^^^^^^^^^^^^^^^
+LL | ...   foo.method_deprecated_text();
+   |           ^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'this_crate::MethodTester::method_deprecated_text': text
+warning: use of deprecated associated function `this_crate::MethodTester::method_deprecated_text`: text
   --> $DIR/lint-stability-deprecated.rs:342:9
    |
-LL |         Foo::method_deprecated_text(&foo);
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | ...   Foo::method_deprecated_text(&foo);
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'this_crate::MethodTester::method_deprecated_text': text
+warning: use of deprecated associated function `this_crate::MethodTester::method_deprecated_text`: text
   --> $DIR/lint-stability-deprecated.rs:343:9
    |
-LL |         <Foo>::method_deprecated_text(&foo);
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | ...   <Foo>::method_deprecated_text(&foo);
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
+warning: use of deprecated associated function `this_crate::Trait::trait_deprecated_text`: text
   --> $DIR/lint-stability-deprecated.rs:344:13
    |
 LL |         foo.trait_deprecated_text();
    |             ^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
+warning: use of deprecated associated function `this_crate::Trait::trait_deprecated_text`: text
   --> $DIR/lint-stability-deprecated.rs:346:9
    |
 LL |         <Foo>::trait_deprecated_text(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'this_crate::DeprecatedStruct::i': text
+warning: use of deprecated field `this_crate::DeprecatedStruct::i`: text
   --> $DIR/lint-stability-deprecated.rs:387:13
    |
 LL |             i: 0
    |             ^^^^
 
-warning: use of deprecated item 'this_crate::Trait::trait_deprecated': text
+warning: use of deprecated associated function `this_crate::Trait::trait_deprecated`: text
   --> $DIR/lint-stability-deprecated.rs:406:13
    |
 LL |         foo.trait_deprecated();
    |             ^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'this_crate::Trait::trait_deprecated': text
+warning: use of deprecated associated function `this_crate::Trait::trait_deprecated`: text
   --> $DIR/lint-stability-deprecated.rs:408:9
    |
 LL |         <Foo>::trait_deprecated(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
+warning: use of deprecated associated function `this_crate::Trait::trait_deprecated_text`: text
   --> $DIR/lint-stability-deprecated.rs:410:13
    |
 LL |         foo.trait_deprecated_text();
    |             ^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
+warning: use of deprecated associated function `this_crate::Trait::trait_deprecated_text`: text
   --> $DIR/lint-stability-deprecated.rs:412:9
    |
 LL |         <Foo>::trait_deprecated_text(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'this_crate::Trait::trait_deprecated': text
+warning: use of deprecated associated function `this_crate::Trait::trait_deprecated`: text
   --> $DIR/lint-stability-deprecated.rs:429:13
    |
 LL |         foo.trait_deprecated();
    |             ^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'this_crate::Trait::trait_deprecated_text': text
+warning: use of deprecated associated function `this_crate::Trait::trait_deprecated_text`: text
   --> $DIR/lint-stability-deprecated.rs:430:13
    |
 LL |         foo.trait_deprecated_text();
    |             ^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'lint_stability::TraitWithAssociatedTypes::TypeDeprecated': text
+warning: use of deprecated associated type `lint_stability::TraitWithAssociatedTypes::TypeDeprecated`: text
   --> $DIR/lint-stability-deprecated.rs:98:48
    |
 LL |         struct S2<T: TraitWithAssociatedTypes>(T::TypeDeprecated);
    |                                                ^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'lint_stability::TraitWithAssociatedTypes::TypeDeprecated': text
+warning: use of deprecated associated type `lint_stability::TraitWithAssociatedTypes::TypeDeprecated`: text
   --> $DIR/lint-stability-deprecated.rs:103:13
    |
 LL |             TypeDeprecated = u16,
    |             ^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated item 'lint_stability::TraitWithAssociatedTypes::TypeDeprecated': text
+warning: use of deprecated associated type `lint_stability::TraitWithAssociatedTypes::TypeDeprecated`: text
   --> $DIR/lint-stability-deprecated.rs:103:13
    |
 LL |             TypeDeprecated = u16,

--- a/src/test/ui/lint/lint-stability-fields-deprecated.rs
+++ b/src/test/ui/lint/lint-stability-fields-deprecated.rs
@@ -16,19 +16,19 @@ mod cross_crate {
             inherit: 1,
             override1: 2,
             override2: 3,
-            //~^ ERROR use of deprecated item
+            //~^ ERROR use of deprecated field
         };
 
         let _ = x.inherit;
         let _ = x.override1;
         let _ = x.override2;
-        //~^ ERROR use of deprecated item
+        //~^ ERROR use of deprecated field
 
         let Stable {
             inherit: _,
             override1: _,
             override2: _
-            //~^ ERROR use of deprecated item
+            //~^ ERROR use of deprecated field
         } = x;
         // all fine
         let Stable { .. } = x;
@@ -38,12 +38,12 @@ mod cross_crate {
         let _ = x.0;
         let _ = x.1;
         let _ = x.2;
-        //~^ ERROR use of deprecated item
+        //~^ ERROR use of deprecated field
 
         let Stable2(_,
                    _,
                    _)
-            //~^ ERROR use of deprecated item
+            //~^ ERROR use of deprecated field
             = x;
         // all fine
         let Stable2(..) = x;
@@ -53,19 +53,19 @@ mod cross_crate {
             inherit: 1,
             override1: 2,
             override2: 3,
-            //~^ ERROR use of deprecated item
+            //~^ ERROR use of deprecated field
         };
 
         let _ = x.inherit;
         let _ = x.override1;
         let _ = x.override2;
-        //~^ ERROR use of deprecated item
+        //~^ ERROR use of deprecated field
 
         let Unstable {
             inherit: _,
             override1: _,
             override2: _
-            //~^ ERROR use of deprecated item
+            //~^ ERROR use of deprecated field
         } = x;
 
         let Unstable
@@ -78,13 +78,13 @@ mod cross_crate {
         let _ = x.0;
         let _ = x.1;
         let _ = x.2;
-        //~^ ERROR use of deprecated item
+        //~^ ERROR use of deprecated field
 
         let Unstable2
             (_,
              _,
              _)
-            //~^ ERROR use of deprecated item
+            //~^ ERROR use of deprecated field
             = x;
         let Unstable2
             // the patterns are all fine:
@@ -92,58 +92,58 @@ mod cross_crate {
 
 
         let x = Deprecated {
-            //~^ ERROR use of deprecated item
+            //~^ ERROR use of deprecated struct
             inherit: 1,
-            //~^ ERROR use of deprecated item
+            //~^ ERROR use of deprecated field
             override1: 2,
-            //~^ ERROR use of deprecated item
+            //~^ ERROR use of deprecated field
             override2: 3,
-            //~^ ERROR use of deprecated item
+            //~^ ERROR use of deprecated field
         };
 
         let _ = x.inherit;
-        //~^ ERROR use of deprecated item
+        //~^ ERROR use of deprecated field
         let _ = x.override1;
-        //~^ ERROR use of deprecated item
+        //~^ ERROR use of deprecated field
         let _ = x.override2;
-        //~^ ERROR use of deprecated item
+        //~^ ERROR use of deprecated field
 
         let Deprecated {
-            //~^ ERROR use of deprecated item
+            //~^ ERROR use of deprecated struct
             inherit: _,
-            //~^ ERROR use of deprecated item
+            //~^ ERROR use of deprecated field
             override1: _,
-            //~^ ERROR use of deprecated item
+            //~^ ERROR use of deprecated field
             override2: _
-            //~^ ERROR use of deprecated item
+            //~^ ERROR use of deprecated field
         } = x;
 
         let Deprecated
-            //~^ ERROR use of deprecated item
+            //~^ ERROR use of deprecated struct
             // the patterns are all fine:
             { .. } = x;
 
         let x = Deprecated2(1, 2, 3);
-        //~^ ERROR use of deprecated item
+        //~^ ERROR use of deprecated struct
 
         let _ = x.0;
-        //~^ ERROR use of deprecated item
+        //~^ ERROR use of deprecated field
         let _ = x.1;
-        //~^ ERROR use of deprecated item
+        //~^ ERROR use of deprecated field
         let _ = x.2;
-        //~^ ERROR use of deprecated item
+        //~^ ERROR use of deprecated field
 
         let Deprecated2
-        //~^ ERROR use of deprecated item
+        //~^ ERROR use of deprecated struct
             (_,
-             //~^ ERROR use of deprecated item
+             //~^ ERROR use of deprecated field
              _,
-             //~^ ERROR use of deprecated item
+             //~^ ERROR use of deprecated field
              _)
-             //~^ ERROR use of deprecated item
+             //~^ ERROR use of deprecated field
             = x;
         let Deprecated2
-        //~^ ERROR use of deprecated item
+        //~^ ERROR use of deprecated struct
             // the patterns are all fine:
             (..) = x;
     }
@@ -203,19 +203,19 @@ mod this_crate {
             inherit: 1,
             override1: 2,
             override2: 3,
-            //~^ ERROR use of deprecated item
+            //~^ ERROR use of deprecated field
         };
 
         let _ = x.inherit;
         let _ = x.override1;
         let _ = x.override2;
-        //~^ ERROR use of deprecated item
+        //~^ ERROR use of deprecated field
 
         let Stable {
             inherit: _,
             override1: _,
             override2: _
-            //~^ ERROR use of deprecated item
+            //~^ ERROR use of deprecated field
         } = x;
         // all fine
         let Stable { .. } = x;
@@ -225,12 +225,12 @@ mod this_crate {
         let _ = x.0;
         let _ = x.1;
         let _ = x.2;
-        //~^ ERROR use of deprecated item
+        //~^ ERROR use of deprecated field
 
         let Stable2(_,
                    _,
                    _)
-            //~^ ERROR use of deprecated item
+            //~^ ERROR use of deprecated field
             = x;
         // all fine
         let Stable2(..) = x;
@@ -240,19 +240,19 @@ mod this_crate {
             inherit: 1,
             override1: 2,
             override2: 3,
-            //~^ ERROR use of deprecated item
+            //~^ ERROR use of deprecated field
         };
 
         let _ = x.inherit;
         let _ = x.override1;
         let _ = x.override2;
-        //~^ ERROR use of deprecated item
+        //~^ ERROR use of deprecated field
 
         let Unstable {
             inherit: _,
             override1: _,
             override2: _
-            //~^ ERROR use of deprecated item
+            //~^ ERROR use of deprecated field
         } = x;
 
         let Unstable
@@ -265,13 +265,13 @@ mod this_crate {
         let _ = x.0;
         let _ = x.1;
         let _ = x.2;
-        //~^ ERROR use of deprecated item
+        //~^ ERROR use of deprecated field
 
         let Unstable2
             (_,
              _,
              _)
-            //~^ ERROR use of deprecated item
+            //~^ ERROR use of deprecated field
             = x;
         let Unstable2
             // the patterns are all fine:
@@ -279,58 +279,58 @@ mod this_crate {
 
 
         let x = Deprecated {
-            //~^ ERROR use of deprecated item
+            //~^ ERROR use of deprecated struct
             inherit: 1,
-            //~^ ERROR use of deprecated item
+            //~^ ERROR use of deprecated field
             override1: 2,
-            //~^ ERROR use of deprecated item
+            //~^ ERROR use of deprecated field
             override2: 3,
-            //~^ ERROR use of deprecated item
+            //~^ ERROR use of deprecated field
         };
 
         let _ = x.inherit;
-        //~^ ERROR use of deprecated item
+        //~^ ERROR use of deprecated field
         let _ = x.override1;
-        //~^ ERROR use of deprecated item
+        //~^ ERROR use of deprecated field
         let _ = x.override2;
-        //~^ ERROR use of deprecated item
+        //~^ ERROR use of deprecated field
 
         let Deprecated {
-            //~^ ERROR use of deprecated item
+            //~^ ERROR use of deprecated struct
             inherit: _,
-            //~^ ERROR use of deprecated item
+            //~^ ERROR use of deprecated field
             override1: _,
-            //~^ ERROR use of deprecated item
+            //~^ ERROR use of deprecated field
             override2: _
-            //~^ ERROR use of deprecated item
+            //~^ ERROR use of deprecated field
         } = x;
 
         let Deprecated
-            //~^ ERROR use of deprecated item
+            //~^ ERROR use of deprecated struct
             // the patterns are all fine:
             { .. } = x;
 
         let x = Deprecated2(1, 2, 3);
-        //~^ ERROR use of deprecated item
+        //~^ ERROR use of deprecated tuple struct
 
         let _ = x.0;
-        //~^ ERROR use of deprecated item
+        //~^ ERROR use of deprecated field
         let _ = x.1;
-        //~^ ERROR use of deprecated item
+        //~^ ERROR use of deprecated field
         let _ = x.2;
-        //~^ ERROR use of deprecated item
+        //~^ ERROR use of deprecated field
 
         let Deprecated2
-        //~^ ERROR use of deprecated item
+        //~^ ERROR use of deprecated tuple struct
             (_,
-             //~^ ERROR use of deprecated item
+             //~^ ERROR use of deprecated field
              _,
-             //~^ ERROR use of deprecated item
+             //~^ ERROR use of deprecated field
              _)
-            //~^ ERROR use of deprecated item
+            //~^ ERROR use of deprecated field
             = x;
         let Deprecated2
-        //~^ ERROR use of deprecated item
+        //~^ ERROR use of deprecated tuple struct
             // the patterns are all fine:
             (..) = x;
     }

--- a/src/test/ui/lint/lint-stability-fields-deprecated.stderr
+++ b/src/test/ui/lint/lint-stability-fields-deprecated.stderr
@@ -1,4 +1,4 @@
-error: use of deprecated item 'cross_crate::lint_stability_fields::Deprecated': text
+error: use of deprecated struct `cross_crate::lint_stability_fields::Deprecated`: text
   --> $DIR/lint-stability-fields-deprecated.rs:94:17
    |
 LL |         let x = Deprecated {
@@ -10,367 +10,367 @@ note: the lint level is defined here
 LL | #![deny(deprecated)]
    |         ^^^^^^^^^^
 
-error: use of deprecated item 'cross_crate::lint_stability_fields::Deprecated': text
+error: use of deprecated struct `cross_crate::lint_stability_fields::Deprecated`: text
   --> $DIR/lint-stability-fields-deprecated.rs:111:13
    |
 LL |         let Deprecated {
    |             ^^^^^^^^^^
 
-error: use of deprecated item 'cross_crate::lint_stability_fields::Deprecated': text
+error: use of deprecated struct `cross_crate::lint_stability_fields::Deprecated`: text
   --> $DIR/lint-stability-fields-deprecated.rs:121:13
    |
 LL |         let Deprecated
    |             ^^^^^^^^^^
 
-error: use of deprecated item 'cross_crate::lint_stability_fields::Deprecated2': text
+error: use of deprecated struct `cross_crate::lint_stability_fields::Deprecated2`: text
   --> $DIR/lint-stability-fields-deprecated.rs:126:17
    |
 LL |         let x = Deprecated2(1, 2, 3);
    |                 ^^^^^^^^^^^
 
-error: use of deprecated item 'cross_crate::lint_stability_fields::Deprecated2': text
+error: use of deprecated struct `cross_crate::lint_stability_fields::Deprecated2`: text
   --> $DIR/lint-stability-fields-deprecated.rs:136:13
    |
 LL |         let Deprecated2
    |             ^^^^^^^^^^^
 
-error: use of deprecated item 'cross_crate::lint_stability_fields::Deprecated2': text
+error: use of deprecated struct `cross_crate::lint_stability_fields::Deprecated2`: text
   --> $DIR/lint-stability-fields-deprecated.rs:145:13
    |
 LL |         let Deprecated2
    |             ^^^^^^^^^^^
 
-error: use of deprecated item 'this_crate::Deprecated': text
+error: use of deprecated struct `this_crate::Deprecated`: text
   --> $DIR/lint-stability-fields-deprecated.rs:281:17
    |
 LL |         let x = Deprecated {
    |                 ^^^^^^^^^^
 
-error: use of deprecated item 'this_crate::Deprecated': text
+error: use of deprecated struct `this_crate::Deprecated`: text
   --> $DIR/lint-stability-fields-deprecated.rs:298:13
    |
 LL |         let Deprecated {
    |             ^^^^^^^^^^
 
-error: use of deprecated item 'this_crate::Deprecated': text
+error: use of deprecated struct `this_crate::Deprecated`: text
   --> $DIR/lint-stability-fields-deprecated.rs:308:13
    |
 LL |         let Deprecated
    |             ^^^^^^^^^^
 
-error: use of deprecated item 'this_crate::Deprecated2': text
+error: use of deprecated tuple struct `this_crate::Deprecated2`: text
   --> $DIR/lint-stability-fields-deprecated.rs:313:17
    |
 LL |         let x = Deprecated2(1, 2, 3);
    |                 ^^^^^^^^^^^
 
-error: use of deprecated item 'this_crate::Deprecated2': text
+error: use of deprecated tuple struct `this_crate::Deprecated2`: text
   --> $DIR/lint-stability-fields-deprecated.rs:323:13
    |
 LL |         let Deprecated2
    |             ^^^^^^^^^^^
 
-error: use of deprecated item 'this_crate::Deprecated2': text
+error: use of deprecated tuple struct `this_crate::Deprecated2`: text
   --> $DIR/lint-stability-fields-deprecated.rs:332:13
    |
 LL |         let Deprecated2
    |             ^^^^^^^^^^^
 
-error: use of deprecated item 'cross_crate::lint_stability_fields::Stable::override2': text
+error: use of deprecated field `cross_crate::lint_stability_fields::Stable::override2`: text
   --> $DIR/lint-stability-fields-deprecated.rs:18:13
    |
 LL |             override2: 3,
    |             ^^^^^^^^^^^^
 
-error: use of deprecated item 'cross_crate::lint_stability_fields::Stable::override2': text
+error: use of deprecated field `cross_crate::lint_stability_fields::Stable::override2`: text
   --> $DIR/lint-stability-fields-deprecated.rs:24:17
    |
 LL |         let _ = x.override2;
    |                 ^^^^^^^^^^^
 
-error: use of deprecated item 'cross_crate::lint_stability_fields::Stable::override2': text
+error: use of deprecated field `cross_crate::lint_stability_fields::Stable::override2`: text
   --> $DIR/lint-stability-fields-deprecated.rs:30:13
    |
 LL |             override2: _
    |             ^^^^^^^^^^^^
 
-error: use of deprecated item 'cross_crate::lint_stability_fields::Stable2::2': text
+error: use of deprecated field `cross_crate::lint_stability_fields::Stable2::2`: text
   --> $DIR/lint-stability-fields-deprecated.rs:40:17
    |
 LL |         let _ = x.2;
    |                 ^^^
 
-error: use of deprecated item 'cross_crate::lint_stability_fields::Stable2::2': text
+error: use of deprecated field `cross_crate::lint_stability_fields::Stable2::2`: text
   --> $DIR/lint-stability-fields-deprecated.rs:45:20
    |
 LL |                    _)
    |                    ^
 
-error: use of deprecated item 'cross_crate::lint_stability_fields::Unstable::override2': text
+error: use of deprecated field `cross_crate::lint_stability_fields::Unstable::override2`: text
   --> $DIR/lint-stability-fields-deprecated.rs:55:13
    |
 LL |             override2: 3,
    |             ^^^^^^^^^^^^
 
-error: use of deprecated item 'cross_crate::lint_stability_fields::Unstable::override2': text
+error: use of deprecated field `cross_crate::lint_stability_fields::Unstable::override2`: text
   --> $DIR/lint-stability-fields-deprecated.rs:61:17
    |
 LL |         let _ = x.override2;
    |                 ^^^^^^^^^^^
 
-error: use of deprecated item 'cross_crate::lint_stability_fields::Unstable::override2': text
+error: use of deprecated field `cross_crate::lint_stability_fields::Unstable::override2`: text
   --> $DIR/lint-stability-fields-deprecated.rs:67:13
    |
 LL |             override2: _
    |             ^^^^^^^^^^^^
 
-error: use of deprecated item 'cross_crate::lint_stability_fields::Unstable2::2': text
+error: use of deprecated field `cross_crate::lint_stability_fields::Unstable2::2`: text
   --> $DIR/lint-stability-fields-deprecated.rs:80:17
    |
 LL |         let _ = x.2;
    |                 ^^^
 
-error: use of deprecated item 'cross_crate::lint_stability_fields::Unstable2::2': text
+error: use of deprecated field `cross_crate::lint_stability_fields::Unstable2::2`: text
   --> $DIR/lint-stability-fields-deprecated.rs:86:14
    |
 LL |              _)
    |              ^
 
-error: use of deprecated item 'cross_crate::lint_stability_fields::Deprecated::inherit': text
+error: use of deprecated field `cross_crate::lint_stability_fields::Deprecated::inherit`: text
   --> $DIR/lint-stability-fields-deprecated.rs:96:13
    |
 LL |             inherit: 1,
    |             ^^^^^^^^^^
 
-error: use of deprecated item 'cross_crate::lint_stability_fields::Deprecated::override1': text
+error: use of deprecated field `cross_crate::lint_stability_fields::Deprecated::override1`: text
   --> $DIR/lint-stability-fields-deprecated.rs:98:13
    |
 LL |             override1: 2,
    |             ^^^^^^^^^^^^
 
-error: use of deprecated item 'cross_crate::lint_stability_fields::Deprecated::override2': text
+error: use of deprecated field `cross_crate::lint_stability_fields::Deprecated::override2`: text
   --> $DIR/lint-stability-fields-deprecated.rs:100:13
    |
 LL |             override2: 3,
    |             ^^^^^^^^^^^^
 
-error: use of deprecated item 'cross_crate::lint_stability_fields::Deprecated::inherit': text
+error: use of deprecated field `cross_crate::lint_stability_fields::Deprecated::inherit`: text
   --> $DIR/lint-stability-fields-deprecated.rs:104:17
    |
 LL |         let _ = x.inherit;
    |                 ^^^^^^^^^
 
-error: use of deprecated item 'cross_crate::lint_stability_fields::Deprecated::override1': text
+error: use of deprecated field `cross_crate::lint_stability_fields::Deprecated::override1`: text
   --> $DIR/lint-stability-fields-deprecated.rs:106:17
    |
 LL |         let _ = x.override1;
    |                 ^^^^^^^^^^^
 
-error: use of deprecated item 'cross_crate::lint_stability_fields::Deprecated::override2': text
+error: use of deprecated field `cross_crate::lint_stability_fields::Deprecated::override2`: text
   --> $DIR/lint-stability-fields-deprecated.rs:108:17
    |
 LL |         let _ = x.override2;
    |                 ^^^^^^^^^^^
 
-error: use of deprecated item 'cross_crate::lint_stability_fields::Deprecated::inherit': text
+error: use of deprecated field `cross_crate::lint_stability_fields::Deprecated::inherit`: text
   --> $DIR/lint-stability-fields-deprecated.rs:113:13
    |
 LL |             inherit: _,
    |             ^^^^^^^^^^
 
-error: use of deprecated item 'cross_crate::lint_stability_fields::Deprecated::override1': text
+error: use of deprecated field `cross_crate::lint_stability_fields::Deprecated::override1`: text
   --> $DIR/lint-stability-fields-deprecated.rs:115:13
    |
 LL |             override1: _,
    |             ^^^^^^^^^^^^
 
-error: use of deprecated item 'cross_crate::lint_stability_fields::Deprecated::override2': text
+error: use of deprecated field `cross_crate::lint_stability_fields::Deprecated::override2`: text
   --> $DIR/lint-stability-fields-deprecated.rs:117:13
    |
 LL |             override2: _
    |             ^^^^^^^^^^^^
 
-error: use of deprecated item 'cross_crate::lint_stability_fields::Deprecated2::0': text
+error: use of deprecated field `cross_crate::lint_stability_fields::Deprecated2::0`: text
   --> $DIR/lint-stability-fields-deprecated.rs:129:17
    |
 LL |         let _ = x.0;
    |                 ^^^
 
-error: use of deprecated item 'cross_crate::lint_stability_fields::Deprecated2::1': text
+error: use of deprecated field `cross_crate::lint_stability_fields::Deprecated2::1`: text
   --> $DIR/lint-stability-fields-deprecated.rs:131:17
    |
 LL |         let _ = x.1;
    |                 ^^^
 
-error: use of deprecated item 'cross_crate::lint_stability_fields::Deprecated2::2': text
+error: use of deprecated field `cross_crate::lint_stability_fields::Deprecated2::2`: text
   --> $DIR/lint-stability-fields-deprecated.rs:133:17
    |
 LL |         let _ = x.2;
    |                 ^^^
 
-error: use of deprecated item 'cross_crate::lint_stability_fields::Deprecated2::0': text
+error: use of deprecated field `cross_crate::lint_stability_fields::Deprecated2::0`: text
   --> $DIR/lint-stability-fields-deprecated.rs:138:14
    |
 LL |             (_,
    |              ^
 
-error: use of deprecated item 'cross_crate::lint_stability_fields::Deprecated2::1': text
+error: use of deprecated field `cross_crate::lint_stability_fields::Deprecated2::1`: text
   --> $DIR/lint-stability-fields-deprecated.rs:140:14
    |
 LL |              _,
    |              ^
 
-error: use of deprecated item 'cross_crate::lint_stability_fields::Deprecated2::2': text
+error: use of deprecated field `cross_crate::lint_stability_fields::Deprecated2::2`: text
   --> $DIR/lint-stability-fields-deprecated.rs:142:14
    |
 LL |              _)
    |              ^
 
-error: use of deprecated item 'this_crate::Stable::override2': text
+error: use of deprecated field `this_crate::Stable::override2`: text
   --> $DIR/lint-stability-fields-deprecated.rs:205:13
    |
 LL |             override2: 3,
    |             ^^^^^^^^^^^^
 
-error: use of deprecated item 'this_crate::Stable::override2': text
+error: use of deprecated field `this_crate::Stable::override2`: text
   --> $DIR/lint-stability-fields-deprecated.rs:211:17
    |
 LL |         let _ = x.override2;
    |                 ^^^^^^^^^^^
 
-error: use of deprecated item 'this_crate::Stable::override2': text
+error: use of deprecated field `this_crate::Stable::override2`: text
   --> $DIR/lint-stability-fields-deprecated.rs:217:13
    |
 LL |             override2: _
    |             ^^^^^^^^^^^^
 
-error: use of deprecated item 'this_crate::Stable2::2': text
+error: use of deprecated field `this_crate::Stable2::2`: text
   --> $DIR/lint-stability-fields-deprecated.rs:227:17
    |
 LL |         let _ = x.2;
    |                 ^^^
 
-error: use of deprecated item 'this_crate::Stable2::2': text
+error: use of deprecated field `this_crate::Stable2::2`: text
   --> $DIR/lint-stability-fields-deprecated.rs:232:20
    |
 LL |                    _)
    |                    ^
 
-error: use of deprecated item 'this_crate::Unstable::override2': text
+error: use of deprecated field `this_crate::Unstable::override2`: text
   --> $DIR/lint-stability-fields-deprecated.rs:242:13
    |
 LL |             override2: 3,
    |             ^^^^^^^^^^^^
 
-error: use of deprecated item 'this_crate::Unstable::override2': text
+error: use of deprecated field `this_crate::Unstable::override2`: text
   --> $DIR/lint-stability-fields-deprecated.rs:248:17
    |
 LL |         let _ = x.override2;
    |                 ^^^^^^^^^^^
 
-error: use of deprecated item 'this_crate::Unstable::override2': text
+error: use of deprecated field `this_crate::Unstable::override2`: text
   --> $DIR/lint-stability-fields-deprecated.rs:254:13
    |
 LL |             override2: _
    |             ^^^^^^^^^^^^
 
-error: use of deprecated item 'this_crate::Unstable2::2': text
+error: use of deprecated field `this_crate::Unstable2::2`: text
   --> $DIR/lint-stability-fields-deprecated.rs:267:17
    |
 LL |         let _ = x.2;
    |                 ^^^
 
-error: use of deprecated item 'this_crate::Unstable2::2': text
+error: use of deprecated field `this_crate::Unstable2::2`: text
   --> $DIR/lint-stability-fields-deprecated.rs:273:14
    |
 LL |              _)
    |              ^
 
-error: use of deprecated item 'this_crate::Deprecated::inherit': text
+error: use of deprecated field `this_crate::Deprecated::inherit`: text
   --> $DIR/lint-stability-fields-deprecated.rs:283:13
    |
 LL |             inherit: 1,
    |             ^^^^^^^^^^
 
-error: use of deprecated item 'this_crate::Deprecated::override1': text
+error: use of deprecated field `this_crate::Deprecated::override1`: text
   --> $DIR/lint-stability-fields-deprecated.rs:285:13
    |
 LL |             override1: 2,
    |             ^^^^^^^^^^^^
 
-error: use of deprecated item 'this_crate::Deprecated::override2': text
+error: use of deprecated field `this_crate::Deprecated::override2`: text
   --> $DIR/lint-stability-fields-deprecated.rs:287:13
    |
 LL |             override2: 3,
    |             ^^^^^^^^^^^^
 
-error: use of deprecated item 'this_crate::Deprecated::inherit': text
+error: use of deprecated field `this_crate::Deprecated::inherit`: text
   --> $DIR/lint-stability-fields-deprecated.rs:291:17
    |
 LL |         let _ = x.inherit;
    |                 ^^^^^^^^^
 
-error: use of deprecated item 'this_crate::Deprecated::override1': text
+error: use of deprecated field `this_crate::Deprecated::override1`: text
   --> $DIR/lint-stability-fields-deprecated.rs:293:17
    |
 LL |         let _ = x.override1;
    |                 ^^^^^^^^^^^
 
-error: use of deprecated item 'this_crate::Deprecated::override2': text
+error: use of deprecated field `this_crate::Deprecated::override2`: text
   --> $DIR/lint-stability-fields-deprecated.rs:295:17
    |
 LL |         let _ = x.override2;
    |                 ^^^^^^^^^^^
 
-error: use of deprecated item 'this_crate::Deprecated::inherit': text
+error: use of deprecated field `this_crate::Deprecated::inherit`: text
   --> $DIR/lint-stability-fields-deprecated.rs:300:13
    |
 LL |             inherit: _,
    |             ^^^^^^^^^^
 
-error: use of deprecated item 'this_crate::Deprecated::override1': text
+error: use of deprecated field `this_crate::Deprecated::override1`: text
   --> $DIR/lint-stability-fields-deprecated.rs:302:13
    |
 LL |             override1: _,
    |             ^^^^^^^^^^^^
 
-error: use of deprecated item 'this_crate::Deprecated::override2': text
+error: use of deprecated field `this_crate::Deprecated::override2`: text
   --> $DIR/lint-stability-fields-deprecated.rs:304:13
    |
 LL |             override2: _
    |             ^^^^^^^^^^^^
 
-error: use of deprecated item 'this_crate::Deprecated2::0': text
+error: use of deprecated field `this_crate::Deprecated2::0`: text
   --> $DIR/lint-stability-fields-deprecated.rs:316:17
    |
 LL |         let _ = x.0;
    |                 ^^^
 
-error: use of deprecated item 'this_crate::Deprecated2::1': text
+error: use of deprecated field `this_crate::Deprecated2::1`: text
   --> $DIR/lint-stability-fields-deprecated.rs:318:17
    |
 LL |         let _ = x.1;
    |                 ^^^
 
-error: use of deprecated item 'this_crate::Deprecated2::2': text
+error: use of deprecated field `this_crate::Deprecated2::2`: text
   --> $DIR/lint-stability-fields-deprecated.rs:320:17
    |
 LL |         let _ = x.2;
    |                 ^^^
 
-error: use of deprecated item 'this_crate::Deprecated2::0': text
+error: use of deprecated field `this_crate::Deprecated2::0`: text
   --> $DIR/lint-stability-fields-deprecated.rs:325:14
    |
 LL |             (_,
    |              ^
 
-error: use of deprecated item 'this_crate::Deprecated2::1': text
+error: use of deprecated field `this_crate::Deprecated2::1`: text
   --> $DIR/lint-stability-fields-deprecated.rs:327:14
    |
 LL |              _,
    |              ^
 
-error: use of deprecated item 'this_crate::Deprecated2::2': text
+error: use of deprecated field `this_crate::Deprecated2::2`: text
   --> $DIR/lint-stability-fields-deprecated.rs:329:14
    |
 LL |              _)

--- a/src/test/ui/lint/lint-stability2.rs
+++ b/src/test/ui/lint/lint-stability2.rs
@@ -1,5 +1,5 @@
 // aux-build:lint_stability.rs
-// error-pattern: use of deprecated item
+// error-pattern: use of deprecated function
 
 #![deny(deprecated)]
 

--- a/src/test/ui/lint/lint-stability2.stderr
+++ b/src/test/ui/lint/lint-stability2.stderr
@@ -1,4 +1,4 @@
-error: use of deprecated item 'lint_stability::deprecated': text
+error: use of deprecated function `lint_stability::deprecated`: text
   --> $DIR/lint-stability2.rs:12:5
    |
 LL |     macro_test!();

--- a/src/test/ui/lint/lint-stability3.rs
+++ b/src/test/ui/lint/lint-stability3.rs
@@ -1,5 +1,5 @@
 // aux-build:lint_stability.rs
-// error-pattern: use of deprecated item
+// error-pattern: use of deprecated function
 
 #![deny(deprecated)]
 #![allow(warnings)]

--- a/src/test/ui/lint/lint-stability3.stderr
+++ b/src/test/ui/lint/lint-stability3.stderr
@@ -1,4 +1,4 @@
-error: use of deprecated item 'lint_stability::deprecated_text': text
+error: use of deprecated function `lint_stability::deprecated_text`: text
   --> $DIR/lint-stability3.rs:13:5
    |
 LL |     macro_test_arg_nested!(deprecated_text);

--- a/src/test/ui/macros/macro-deprecation.rs
+++ b/src/test/ui/macros/macro-deprecation.rs
@@ -8,6 +8,6 @@
 macro_rules! local_deprecated{ () => () }
 
 fn main() {
-    local_deprecated!(); //~ WARN use of deprecated item 'local_deprecated': local deprecation note
-    deprecated_macro!(); //~ WARN use of deprecated item 'deprecated_macro': deprecation note
+    local_deprecated!(); //~ WARN use of deprecated macro `local_deprecated`: local deprecation note
+    deprecated_macro!(); //~ WARN use of deprecated macro `deprecated_macro`: deprecation note
 }

--- a/src/test/ui/macros/macro-deprecation.stderr
+++ b/src/test/ui/macros/macro-deprecation.stderr
@@ -1,4 +1,4 @@
-warning: use of deprecated item 'local_deprecated': local deprecation note
+warning: use of deprecated macro `local_deprecated`: local deprecation note
   --> $DIR/macro-deprecation.rs:11:5
    |
 LL |     local_deprecated!();
@@ -6,7 +6,7 @@ LL |     local_deprecated!();
    |
    = note: `#[warn(deprecated)]` on by default
 
-warning: use of deprecated item 'deprecated_macro': deprecation note
+warning: use of deprecated macro `deprecated_macro`: deprecation note
   --> $DIR/macro-deprecation.rs:12:5
    |
 LL |     deprecated_macro!();

--- a/src/test/ui/macros/macro-stability.rs
+++ b/src/test/ui/macros/macro-stability.rs
@@ -22,7 +22,7 @@ fn main() {
     // unstable_macro_modern!(); // ERROR use of unstable library feature 'unstable_macros'
 
     deprecated_macro!();
-    //~^ WARN use of deprecated item 'deprecated_macro': deprecation reason
+    //~^ WARN use of deprecated macro `deprecated_macro`: deprecation reason
     local_deprecated!();
-    //~^ WARN use of deprecated item 'local_deprecated': local deprecation reason
+    //~^ WARN use of deprecated macro `local_deprecated`: local deprecation reason
 }

--- a/src/test/ui/macros/macro-stability.stderr
+++ b/src/test/ui/macros/macro-stability.stderr
@@ -22,7 +22,7 @@ LL |     unstable_macro!();
    |
    = help: add `#![feature(unstable_macros)]` to the crate attributes to enable
 
-warning: use of deprecated item 'deprecated_macro': deprecation reason
+warning: use of deprecated macro `deprecated_macro`: deprecation reason
   --> $DIR/macro-stability.rs:24:5
    |
 LL |     deprecated_macro!();
@@ -30,7 +30,7 @@ LL |     deprecated_macro!();
    |
    = note: `#[warn(deprecated)]` on by default
 
-warning: use of deprecated item 'local_deprecated': local deprecation reason
+warning: use of deprecated macro `local_deprecated`: local deprecation reason
   --> $DIR/macro-stability.rs:26:5
    |
 LL |     local_deprecated!();

--- a/src/test/ui/proc-macro/attributes-on-definitions.rs
+++ b/src/test/ui/proc-macro/attributes-on-definitions.rs
@@ -6,7 +6,7 @@
 extern crate attributes_on_definitions;
 
 attributes_on_definitions::with_attrs!();
-//~^ WARN use of deprecated item
+//~^ WARN use of deprecated
 // No errors about the use of unstable and unsafe code inside the macro.
 
 fn main() {}

--- a/src/test/ui/proc-macro/attributes-on-definitions.stderr
+++ b/src/test/ui/proc-macro/attributes-on-definitions.stderr
@@ -1,4 +1,4 @@
-warning: use of deprecated item 'attributes_on_definitions::with_attrs': test
+warning: use of deprecated macro `attributes_on_definitions::with_attrs`: test
   --> $DIR/attributes-on-definitions.rs:8:1
    |
 LL | attributes_on_definitions::with_attrs!();


### PR DESCRIPTION
This is important for fields, which are incorrectly referred to as
"items".