### PR TITLE
Don't italicize comments in ayu theme

### DIFF
--- a/src/librustdoc/html/static/themes/ayu.css
+++ b/src/librustdoc/html/static/themes/ayu.css
@@ -199,7 +199,6 @@ pre {
 
 pre.rust .comment, pre.rust .doccomment {
 	color: #788797;
-	font-style: italic;
 }
 
 nav:not(.sidebar) {


### PR DESCRIPTION
Closes #74770.

Before:

![image](https://user-images.githubusercontent.com/13814214/88486217-2bf18700-cf4a-11ea-896d-e7787b94e7a7.png)

After:

![image](https://user-images.githubusercontent.com/13814214/88486225-3a3fa300-cf4a-11ea-929f-90461799dc01.png)
