### PR TITLE
Add #[inline] to RawWaker::new

### DIFF
--- a/library/core/src/task/wake.rs
+++ b/library/core/src/task/wake.rs
@@ -37,6 +37,7 @@ impl RawWaker {
     /// The `vtable` customizes the behavior of a `Waker` which gets created
     /// from a `RawWaker`. For each operation on the `Waker`, the associated
     /// function in the `vtable` of the underlying `RawWaker` will be called.
+    #[inline]
     #[rustc_promotable]
     #[stable(feature = "futures_api", since = "1.36.0")]
     #[rustc_const_stable(feature = "futures_api", since = "1.36.0")]


### PR DESCRIPTION
`RawWaker::new` is used when creating a new waker or cloning an existing one,
for example as in code below. The `RawWakerVTable::new` can be const evaluated,
but `RawWaker::new` itself cannot since waker pointer is not known at compile
time. Add `#[inline]` to avoid overhead of a function call.

```rust
unsafe fn clone_waker<W: Wake + Send + Sync + 'static>(waker: *const ()) -> RawWaker {
    unsafe { Arc::incr_strong_count(waker as *const W) };
    RawWaker::new(
        waker as *const (),
        &RawWakerVTable::new(clone_waker::<W>, wake::<W>, wake_by_ref::<W>, drop_waker::<W>),
    )
}
```