### PR TITLE
Link sanitizers when creating dynamic libraries on macOS

### DIFF
--- a/src/test/run-make-fulldeps/sanitizer-cdylib-link/Makefile
+++ b/src/test/run-make-fulldeps/sanitizer-cdylib-link/Makefile
@@ -1,6 +1,5 @@
 # needs-sanitizer-support
 # needs-sanitizer-address
-# only-linux
 
 -include ../tools.mk
 

--- a/src/test/run-make-fulldeps/sanitizer-dylib-link/Makefile
+++ b/src/test/run-make-fulldeps/sanitizer-dylib-link/Makefile
@@ -1,6 +1,5 @@
 # needs-sanitizer-support
 # needs-sanitizer-address
-# only-linux
 
 -include ../tools.mk
 

--- a/src/test/run-make-fulldeps/sanitizer-staticlib-link/Makefile
+++ b/src/test/run-make-fulldeps/sanitizer-staticlib-link/Makefile
@@ -1,6 +1,5 @@
 # needs-sanitizer-support
 # needs-sanitizer-address
-# only-linux
 
 -include ../tools.mk
 


### PR DESCRIPTION
Link sanitizer runtime when creating dynamic libraries on macOS
to resolve sanitizer runtime symbols and avoid failure at link time.

Closes #74571.