### PR TITLE
config.toml.example: Update remap-debuginfo doc to be more general & accurate

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -453,8 +453,7 @@
 # instead of LLVM's default of 100.
 #thin-lto-import-instr-limit = 100
 
-# Map all debuginfo paths for libstd and crates to `/rust/$sha/$crate/...`,
-# generally only set for releases
+# Map debuginfo paths to `/rust/$sha/...`, generally only set for releases
 #remap-debuginfo = false
 
 # Link the compiler against `jemalloc`, where on Linux and OSX it should


### PR DESCRIPTION
This makes it more obvious that the work-around to #74786 is actually correct, and a custom `--remap-path-prefix` isn't needed.

In fact the previous comment `/rustc/$hash/$crate` was wrong, it is not `$crate` but whatever path exists in the rustc source tree, so either `src/$crate` or `vendor/$crate`. I've fixed that as well to avoid future confusion.
