### PR TITLE
rustbuild: fix bad usage of UNIX exec() in rustc wrapper

### DIFF
--- a/src/bootstrap/bin/rustc.rs
+++ b/src/bootstrap/bin/rustc.rs
@@ -186,13 +186,6 @@ fn main() {
     std::process::exit(code);
 }
 
-#[cfg(unix)]
-fn exec_cmd(cmd: &mut Command) -> io::Result<i32> {
-    use std::os::unix::process::CommandExt;
-    Err(cmd.exec())
-}
-
-#[cfg(not(unix))]
 fn exec_cmd(cmd: &mut Command) -> io::Result<i32> {
     cmd.status().map(|status| status.code().unwrap())
 }

--- a/src/bootstrap/bin/rustc.rs
+++ b/src/bootstrap/bin/rustc.rs
@@ -153,7 +153,7 @@ fn main() {
             e => e,
         };
         println!("\nDid not run successfully: {:?}\n{:?}\n-------------", e, cmd);
-        exec_cmd(&mut on_fail).expect("could not run the backup command");
+        status_code(&mut on_fail).expect("could not run the backup command");
         std::process::exit(1);
     }
 
@@ -182,10 +182,10 @@ fn main() {
         }
     }
 
-    let code = exec_cmd(&mut cmd).unwrap_or_else(|_| panic!("\n\n failed to run {:?}", cmd));
+    let code = status_code(&mut cmd).unwrap_or_else(|_| panic!("\n\n failed to run {:?}", cmd));
     std::process::exit(code);
 }
 
-fn exec_cmd(cmd: &mut Command) -> io::Result<i32> {
+fn status_code(cmd: &mut Command) -> io::Result<i32> {
     cmd.status().map(|status| status.code().unwrap())
 }


### PR DESCRIPTION
exec never returns, it replaces the current process. so anything after it is unreachable. that's not how exec_cmd() is used in the surrounding code

We use `--on-fail env` on Debian. `env` always returns exit code 0. This means that the `rustc` bootstrap wrapper always returns exit code 0 even when it fails. However, the crossbeam-utils build process (due to autocfg) relies on `rustc` returning error exit codes when detecting CPU features, and ends up writing `cargo:rustc-cfg=has_atomic_u128` even when it's not detected, because the `rustc` wrapper is always giving exit code 0.

(This separately is causing our builds to try to compile rustc 40+ times, due to #74801.)