### PR TITLE
Fix RefUnwindSafe & UnwinsSafe impls for lazy::SyncLazy

### DIFF
--- a/library/std/src/lazy.rs
+++ b/library/std/src/lazy.rs
@@ -451,7 +451,9 @@ unsafe impl<T, F: Send> Sync for SyncLazy<T, F> where SyncOnceCell<T>: Sync {}
 // auto-derived `Send` impl is OK.
 
 #[unstable(feature = "once_cell", issue = "74465")]
-impl<T, F: RefUnwindSafe> RefUnwindSafe for SyncLazy<T, F> where SyncOnceCell<T>: RefUnwindSafe {}
+impl<T, F: UnwindSafe> RefUnwindSafe for SyncLazy<T, F> where SyncOnceCell<T>: RefUnwindSafe {}
+#[unstable(feature = "once_cell", issue = "74465")]
+impl<T, F: UnwindSafe> UnwindSafe for SyncLazy<T, F> where SyncOnceCell<T>: UnwindSafe {}
 
 impl<T, F> SyncLazy<T, F> {
     /// Creates a new lazy value with the given initializing


### PR DESCRIPTION
I *think* we should implement those unconditionally with respect to `F`.

The user code can't observe the closure in any way, and we poison lazy if the closure itself panics.

But I've never fully wrapped my head around `UnwindSafe` traits, so :man_shrugging: 