### PR TITLE
ayu theme: Change doccomment color to `#a1ac88`

### DIFF
--- a/src/librustdoc/html/static/themes/ayu.css
+++ b/src/librustdoc/html/static/themes/ayu.css
@@ -197,9 +197,8 @@ pre {
 	color: #a37acc;
 }
 
-pre.rust .comment, pre.rust .doccomment {
-	color: #788797;
-}
+pre.rust .comment { color: #788797; }
+pre.rust .doccomment { color: #a1ac88; }
 
 nav:not(.sidebar) {
 	border-bottom-color: #424c57;


### PR DESCRIPTION
Before: 
![image](https://user-images.githubusercontent.com/15225902/88621499-d1cbff80-d0ca-11ea-99c3-5e2632709274.png)

After: 
![image](https://user-images.githubusercontent.com/15225902/88621471-bf51c600-d0ca-11ea-9455-9c297f50f15f.png)

Close #74788