### PR TITLE
Enable to ping RISC-V group via triagebot

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -58,6 +58,17 @@ Thanks! <3
 """
 label = "O-ARM"
 
+[ping.risc-v]
+message = """\
+Hey RISC-V Group! This bug has been identified as a good "RISC-V candidate".
+In case it's useful, here are some [instructions] for tackling these sorts of
+bugs. Maybe take a look?
+Thanks! <3
+
+[instructions]: https://rustc-dev-guide.rust-lang.org/notification-groups/risc-v.html
+"""
+label = "O-riscv"
+
 [prioritize]
 label = "I-prioritize"
 


### PR DESCRIPTION
We have the RISC-V group (https://github.com/rust-lang/team/blob/master/teams/risc-v.toml) but don't enable to ping on this repository (https://github.com/rust-lang/rust/pull/74813#issuecomment-664841177).
We don't have the instructions on the rustc-dev-guide yet but I'll create it soonish.