### PR TITLE
Fix primitive retrieval in search index generation

### DIFF
--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -1173,7 +1173,7 @@ impl GetDefId for Type {
     fn def_id(&self) -> Option<DefId> {
         match *self {
             ResolvedPath { did, .. } => Some(did),
-            Primitive(p) => super::primitives().get(&p).cloned(),
+            Primitive(p) => crate::core::primitives().get(&p).cloned(),
             BorrowedRef { type_: box Generic(..), .. } => {
                 Primitive(PrimitiveType::Reference).def_id()
             }

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -1173,7 +1173,7 @@ impl GetDefId for Type {
     fn def_id(&self) -> Option<DefId> {
         match *self {
             ResolvedPath { did, .. } => Some(did),
-            Primitive(p) => cache().primitive_locations.get(&p).cloned(),
+            Primitive(p) => super::primitives().get(&p).cloned(),
             BorrowedRef { type_: box Generic(..), .. } => {
                 Primitive(PrimitiveType::Reference).def_id()
             }

--- a/src/librustdoc/formats/cache.rs
+++ b/src/librustdoc/formats/cache.rs
@@ -9,8 +9,9 @@ use rustc_hir::def_id::{CrateNum, DefId, CRATE_DEF_INDEX};
 use rustc_middle::middle::privacy::AccessLevels;
 use rustc_span::source_map::FileName;
 
-use crate::clean::{self, primitives, GetDefId};
+use crate::clean::{self, GetDefId};
 use crate::config::RenderInfo;
+use crate::core::primitives;
 use crate::fold::DocFolder;
 use crate::formats::item_type::ItemType;
 use crate::formats::Impl;

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -14,7 +14,7 @@ use rustc_hir as hir;
 use rustc_span::def_id::DefId;
 use rustc_target::spec::abi::Abi;
 
-use crate::clean::{self, PrimitiveType};
+use crate::clean::{self, primitives, PrimitiveType};
 use crate::formats::cache::cache;
 use crate::formats::item_type::ItemType;
 use crate::html::escape::Escape;
@@ -559,10 +559,13 @@ fn primitive_link(
     prim: clean::PrimitiveType,
     name: &str,
 ) -> fmt::Result {
-    let m = cache();
     let mut needs_termination = false;
+
     if !f.alternate() {
-        match m.primitive_locations.get(&prim) {
+        let m = cache();
+        let primitives = primitives();
+
+        match primitives.get(&prim) {
             Some(&def_id) if def_id.is_local() => {
                 let len = CURRENT_DEPTH.with(|s| s.get());
                 let len = if len == 0 { 0 } else { len - 1 };

--- a/src/librustdoc/html/render/cache.rs
+++ b/src/librustdoc/html/render/cache.rs
@@ -13,6 +13,7 @@ use crate::html::render::{plain_summary_line, shorten};
 use crate::html::render::{Generic, IndexItem, IndexItemFunctionType, RenderType, TypeWithKind};
 
 /// Indicates where an external crate can be found.
+#[derive(Debug)]
 pub enum ExternalLocation {
     /// Remote URL root of the external crate
     Remote(String),

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -63,9 +63,10 @@ use rustc_span::symbol::{sym, Symbol};
 use serde::ser::SerializeSeq;
 use serde::{Serialize, Serializer};
 
-use crate::clean::{self, primitives, AttributesExt, Deprecation, GetDefId, SelfTy, TypeKind};
+use crate::clean::{self, AttributesExt, Deprecation, GetDefId, SelfTy, TypeKind};
 use crate::config::RenderInfo;
 use crate::config::RenderOptions;
+use crate::core::primitives;
 use crate::docfs::{DocFS, PathError};
 use crate::doctree;
 use crate::error::Error;

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -63,7 +63,7 @@ use rustc_span::symbol::{sym, Symbol};
 use serde::ser::SerializeSeq;
 use serde::{Serialize, Serializer};
 
-use crate::clean::{self, AttributesExt, Deprecation, GetDefId, SelfTy, TypeKind};
+use crate::clean::{self, primitives, AttributesExt, Deprecation, GetDefId, SelfTy, TypeKind};
 use crate::config::RenderInfo;
 use crate::config::RenderOptions;
 use crate::docfs::{DocFS, PathError};
@@ -3405,7 +3405,7 @@ fn render_deref_methods(
         render_assoc_items(w, cx, container_item, did, what, cache);
     } else {
         if let Some(prim) = target.primitive_type() {
-            if let Some(&did) = cache.primitive_locations.get(&prim) {
+            if let Some(&did) = primitives().get(&prim) {
                 render_assoc_items(w, cx, container_item, did, what, cache);
             }
         }
@@ -4058,7 +4058,7 @@ fn sidebar_assoc_items(it: &clean::Item) -> String {
                         .def_id()
                         .or(target
                             .primitive_type()
-                            .and_then(|prim| c.primitive_locations.get(&prim).cloned()))
+                            .and_then(|prim| primitives().get(&prim).cloned()))
                         .and_then(|did| c.impls.get(&did));
                     if let Some(impls) = inner_impl {
                         out.push_str("<a class=\"sidebar-title\" href=\"#deref-methods\">");

--- a/src/test/rustdoc-js/primitive-fn-like-search.js
+++ b/src/test/rustdoc-js/primitive-fn-like-search.js
@@ -1,0 +1,13 @@
+// exact-check
+const QUERY = 'u32 -> u32';
+
+const EXPECTED = {
+    'others': [
+    ],
+    'returned': [
+        { 'path': 'primitive_fn_like_search', 'name': 'foo' },
+    ],
+    'in_args': [
+        { 'path': 'primitive_fn_like_search', 'name': 'foo' },
+    ],
+};

--- a/src/test/rustdoc-js/primitive-fn-like-search.rs
+++ b/src/test/rustdoc-js/primitive-fn-like-search.rs
@@ -1,0 +1,5 @@
+pub struct Foo;
+
+pub trait Bar {}
+
+pub fn foo<T: Bar, D: ::std::fmt::Debug>(a: Foo, b: u32, c: T, d: D) -> u32 {0}


### PR DESCRIPTION
Part of #60485. Fixes https://github.com/rust-lang/rust/issues/74780.

Before merging, I have a few questions remaining:

 Should we remove the `primitive_locations` field from the `Cache` type? If so, we'll have to replace in the few places where we use this field (not really a problem). However, this field includes the primitive types of the current crates, whereas my new implementation only includes the ones coming from external crates. I'm not sure if it'll be an issue for libcore or not (maybe not since they can be retrieved directly inside the crate, no?).

EDIT: I removed the `primitive_locations` field from the `Cache` type, so now we're only referring/using the new "primitives cache" added by this PR.

cc @rust-lang/rustdoc 

r? @Manishearth 