### PR TITLE
Add HRTB-related regression test

### DIFF
--- a/src/test/ui/higher-rank-trait-bounds/issue-59311.rs
+++ b/src/test/ui/higher-rank-trait-bounds/issue-59311.rs
@@ -1,0 +1,16 @@
+// Regression test for #59311. The test is taken from
+// rust-lang/rust/issues/71546#issuecomment-620638437
+// as they seem to have the same cause.
+
+pub trait T {
+    fn t<F: Fn()>(&self, _: F) {}
+}
+
+pub fn crash<V>(v: &V)
+where
+    for<'a> &'a V: T + 'static,
+{
+    v.t(|| {}); //~ ERROR: higher-ranked subtype error
+}
+
+fn main() {}

--- a/src/test/ui/higher-rank-trait-bounds/issue-59311.rs
+++ b/src/test/ui/higher-rank-trait-bounds/issue-59311.rs
@@ -2,6 +2,10 @@
 // rust-lang/rust/issues/71546#issuecomment-620638437
 // as they seem to have the same cause.
 
+// FIXME: It's not clear that this code ought to report
+// an error, but the regression test is here to ensure
+// that it does not ICE. See discussion on #74889 for details.
+
 pub trait T {
     fn t<F: Fn()>(&self, _: F) {}
 }

--- a/src/test/ui/higher-rank-trait-bounds/issue-59311.stderr
+++ b/src/test/ui/higher-rank-trait-bounds/issue-59311.stderr
@@ -1,0 +1,8 @@
+error: higher-ranked subtype error
+  --> $DIR/issue-59311.rs:13:9
+   |
+LL |     v.t(|| {});
+   |         ^^^^^
+
+error: aborting due to previous error
+

--- a/src/test/ui/higher-rank-trait-bounds/issue-59311.stderr
+++ b/src/test/ui/higher-rank-trait-bounds/issue-59311.stderr
@@ -1,5 +1,5 @@
 error: higher-ranked subtype error
-  --> $DIR/issue-59311.rs:13:9
+  --> $DIR/issue-59311.rs:17:9
    |
 LL |     v.t(|| {});
    |         ^^^^^


### PR DESCRIPTION
Closes #59311 and cc #71546
This closes the former but the test is taken from https://github.com/rust-lang/rust/issues/71546#issuecomment-620638437 since it seems they have the same cause and it's simplified.
