### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/library/alloc/tests/lib.rs
+++ b/library/alloc/tests/lib.rs
@@ -6,6 +6,7 @@
 #![feature(map_first_last)]
 #![feature(new_uninit)]
 #![feature(pattern)]
+#![feature(str_split_once)]
 #![feature(trusted_len)]
 #![feature(try_reserve)]
 #![feature(unboxed_closures)]

--- a/library/alloc/tests/str.rs
+++ b/library/alloc/tests/str.rs
@@ -1319,6 +1319,30 @@ fn test_rsplitn() {
 }
 
 #[test]
+fn test_split_once() {
+    assert_eq!("".split_once("->"), None);
+    assert_eq!("-".split_once("->"), None);
+    assert_eq!("->".split_once("->"), Some(("", "")));
+    assert_eq!("a->".split_once("->"), Some(("a", "")));
+    assert_eq!("->b".split_once("->"), Some(("", "b")));
+    assert_eq!("a->b".split_once("->"), Some(("a", "b")));
+    assert_eq!("a->b->c".split_once("->"), Some(("a", "b->c")));
+    assert_eq!("---".split_once("--"), Some(("", "-")));
+}
+
+#[test]
+fn test_rsplit_once() {
+    assert_eq!("".rsplit_once("->"), None);
+    assert_eq!("-".rsplit_once("->"), None);
+    assert_eq!("->".rsplit_once("->"), Some(("", "")));
+    assert_eq!("a->".rsplit_once("->"), Some(("a", "")));
+    assert_eq!("->b".rsplit_once("->"), Some(("", "b")));
+    assert_eq!("a->b".rsplit_once("->"), Some(("a", "b")));
+    assert_eq!("a->b->c".rsplit_once("->"), Some(("a->b", "c")));
+    assert_eq!("---".rsplit_once("--"), Some(("-", "")));
+}
+
+#[test]
 fn test_split_whitespace() {
     let data = "\n \tMäry   häd\tä  little lämb\nLittle lämb\n";
     let words: Vec<&str> = data.split_whitespace().collect();

--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -3610,6 +3610,47 @@ impl str {
         RSplitN(self.splitn(n, pat).0)
     }
 
+    /// Splits the string on the first occurrence of the specified delimiter and
+    /// returns prefix before delimiter and suffix after delimiter.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(str_split_once)]
+    ///
+    /// assert_eq!("cfg".split_once('='), None);
+    /// assert_eq!("cfg=foo".split_once('='), Some(("cfg", "foo")));
+    /// assert_eq!("cfg=foo=bar".split_once('='), Some(("cfg", "foo=bar")));
+    /// ```
+    #[unstable(feature = "str_split_once", reason = "newly added", issue = "74773")]
+    #[inline]
+    pub fn split_once<'a, P: Pattern<'a>>(&'a self, delimiter: P) -> Option<(&'a str, &'a str)> {
+        let (start, end) = delimiter.into_searcher(self).next_match()?;
+        Some((&self[..start], &self[end..]))
+    }
+
+    /// Splits the string on the last occurrence of the specified delimiter and
+    /// returns prefix before delimiter and suffix after delimiter.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(str_split_once)]
+    ///
+    /// assert_eq!("cfg".rsplit_once('='), None);
+    /// assert_eq!("cfg=foo".rsplit_once('='), Some(("cfg", "foo")));
+    /// assert_eq!("cfg=foo=bar".rsplit_once('='), Some(("cfg=foo", "bar")));
+    /// ```
+    #[unstable(feature = "str_split_once", reason = "newly added", issue = "74773")]
+    #[inline]
+    pub fn rsplit_once<'a, P>(&'a self, delimiter: P) -> Option<(&'a str, &'a str)>
+    where
+        P: Pattern<'a, Searcher: ReverseSearcher<'a>>,
+    {
+        let (start, end) = delimiter.into_searcher(self).next_match_back()?;
+        Some((&self[..start], &self[end..]))
+    }
+
     /// An iterator over the disjoint matches of a pattern within the given string
     /// slice.
     ///

--- a/library/std/src/lazy.rs
+++ b/library/std/src/lazy.rs
@@ -451,7 +451,9 @@ unsafe impl<T, F: Send> Sync for SyncLazy<T, F> where SyncOnceCell<T>: Sync {}
 // auto-derived `Send` impl is OK.
 
 #[unstable(feature = "once_cell", issue = "74465")]
-impl<T, F: RefUnwindSafe> RefUnwindSafe for SyncLazy<T, F> where SyncOnceCell<T>: RefUnwindSafe {}
+impl<T, F: UnwindSafe> RefUnwindSafe for SyncLazy<T, F> where SyncOnceCell<T>: RefUnwindSafe {}
+#[unstable(feature = "once_cell", issue = "74465")]
+impl<T, F: UnwindSafe> UnwindSafe for SyncLazy<T, F> where SyncOnceCell<T>: UnwindSafe {}
 
 impl<T, F> SyncLazy<T, F> {
     /// Creates a new lazy value with the given initializing

--- a/src/README.md
+++ b/src/README.md
@@ -1,6 +1,6 @@
 This directory contains the source code of the rust project, including:
 - `rustc` and its tests
-- `libstd`
+- The bootstrapping build system
 - Various submodules for tools, like rustdoc, rls, etc.
 
 For more information on how various parts of the compiler work, see the [rustc dev guide].

--- a/src/librustc_error_codes/error_codes/E0720.md
+++ b/src/librustc_error_codes/error_codes/E0720.md
@@ -1,11 +1,13 @@
 An `impl Trait` type expands to a recursive type.
 
-An `impl Trait` type must be expandable to a concrete type that contains no
-`impl Trait` types. For example the following example tries to create an
-`impl Trait` type `T` that is equal to `[T, T]`:
+Erroneous code example:
 
 ```compile_fail,E0720
 fn make_recursive_type() -> impl Sized {
     [make_recursive_type(), make_recursive_type()]
 }
 ```
+
+An `impl Trait` type must be expandable to a concrete type that contains no
+`impl Trait` types. For example the previous example tries to create an
+`impl Trait` type `T` that is equal to `[T, T]`.

--- a/src/librustdoc/html/static/themes/ayu.css
+++ b/src/librustdoc/html/static/themes/ayu.css
@@ -197,9 +197,8 @@ pre {
 	color: #a37acc;
 }
 
-pre.rust .comment, pre.rust .doccomment {
-	color: #788797;
-}
+pre.rust .comment { color: #788797; }
+pre.rust .doccomment { color: #a1ac88; }
 
 nav:not(.sidebar) {
 	border-bottom-color: #424c57;

--- a/src/test/rustdoc/lazy_normalization_consts/const-equate-pred.rs
+++ b/src/test/rustdoc/lazy_normalization_consts/const-equate-pred.rs
@@ -1,0 +1,18 @@
+#![crate_name = "foo"]
+#![feature(lazy_normalization_consts)]
+#![allow(incomplete_features)]
+
+// Checking if `Send` is implemented for `Hasher` requires us to evaluate a `ConstEquate` predicate,
+// which previously caused an ICE.
+
+pub struct Hasher<T> {
+    cv_stack: T,
+}
+
+unsafe impl<T: Default> Send for Hasher<T> {}
+
+// @has foo/struct.Foo.html
+// @has - '//code' 'impl Send for Foo'
+pub struct Foo {
+    hasher: Hasher<[u8; 3]>,
+}

--- a/src/test/ui/const-generics/coerce_unsized_array.rs
+++ b/src/test/ui/const-generics/coerce_unsized_array.rs
@@ -1,0 +1,11 @@
+// run-pass
+#![feature(const_generics)]
+#![allow(incomplete_features)]
+
+fn foo<const N: usize>(v: &[u8; N]) -> &[u8] {
+    v
+}
+
+fn main() {
+    assert_eq!(foo(&[1, 2]), &[1, 2]);
+}

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -58,6 +58,17 @@ Thanks! <3
 """
 label = "O-ARM"
 
+[ping.risc-v]
+message = """\
+Hey RISC-V Group! This bug has been identified as a good "RISC-V candidate".
+In case it's useful, here are some [instructions] for tackling these sorts of
+bugs. Maybe take a look?
+Thanks! <3
+
+[instructions]: https://rustc-dev-guide.rust-lang.org/notification-groups/risc-v.html
+"""
+label = "O-riscv"
+
 [prioritize]
 label = "I-prioritize"
 


### PR DESCRIPTION
Successful merges:

 - #74266 (Clean up E0720 explanation)
 - #74671 (add const generics array coercion test)
 - #74707 (Add str::[r]split_once)
 - #74814 (Fix RefUnwindSafe & UnwinsSafe impls for lazy::SyncLazy)
 - #74859 (Update outdated readme)
 - #74864 (ayu theme: Change doccomment color to `#a1ac88`)
 - #74872 (Enable to ping RISC-V group via triagebot)
 - #74891 (handle ConstEquate in rustdoc)

Failed merges:


r? @ghost