### PR TITLE
Fix opening docs for std crates with ./x.py doc --open library/*

### DIFF
--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -460,7 +460,7 @@ impl Step for Std {
         // open the corresponding rendered docs.
         for path in builder.paths.iter().map(components_simplified) {
             if path.get(0) == Some(&"library") {
-                let requested_crate = &path[1][3..];
+                let requested_crate = &path[1];
                 if krates.contains(&requested_crate) {
                     let index = out.join(requested_crate).join("index.html");
                     open(builder, &index);


### PR DESCRIPTION
The directories for core, alloc, std, proc_macro, and test crates now
correspond directly to the crate name, and stripping the "lib" prefix is
no longer necessary.