### PR TITLE
rustc: Ignore fs::canonicalize errors in metadata

### DIFF
--- a/src/librustc_metadata/creader.rs
+++ b/src/librustc_metadata/creader.rs
@@ -236,9 +236,9 @@ impl<'a> CrateLoader<'a> {
                 // Only use `--extern crate_name=path` here, not `--extern crate_name`.
                 if let Some(mut files) = entry.files() {
                     if files.any(|l| {
-                        let l = fs::canonicalize(l).ok();
-                        source.dylib.as_ref().map(|p| &p.0) == l.as_ref()
-                            || source.rlib.as_ref().map(|p| &p.0) == l.as_ref()
+                        let l = fs::canonicalize(l).unwrap_or(l.clone().into());
+                        source.dylib.as_ref().map(|p| &p.0) == Some(&l)
+                            || source.rlib.as_ref().map(|p| &p.0) == Some(&l)
                     }) {
                         ret = Some(cnum);
                     }

--- a/src/librustc_session/filesearch.rs
+++ b/src/librustc_session/filesearch.rs
@@ -117,28 +117,22 @@ pub fn make_target_lib_path(sysroot: &Path, target_triple: &str) -> PathBuf {
 
 pub fn get_or_default_sysroot() -> PathBuf {
     // Follow symlinks.  If the resolved path is relative, make it absolute.
-    fn canonicalize(path: Option<PathBuf>) -> Option<PathBuf> {
-        path.and_then(|path| {
-            match fs::canonicalize(&path) {
-                // See comments on this target function, but the gist is that
-                // gcc chokes on verbatim paths which fs::canonicalize generates
-                // so we try to avoid those kinds of paths.
-                Ok(canon) => Some(fix_windows_verbatim_for_gcc(&canon)),
-                Err(e) => panic!("failed to get realpath: {}", e),
-            }
-        })
+    fn canonicalize(path: PathBuf) -> PathBuf {
+        let path = fs::canonicalize(&path).unwrap_or(path);
+        // See comments on this target function, but the gist is that
+        // gcc chokes on verbatim paths which fs::canonicalize generates
+        // so we try to avoid those kinds of paths.
+        fix_windows_verbatim_for_gcc(&path)
     }
 
     match env::current_exe() {
-        Ok(exe) => match canonicalize(Some(exe)) {
-            Some(mut p) => {
-                p.pop();
-                p.pop();
-                p
-            }
-            None => panic!("can't determine value for sysroot"),
-        },
-        Err(ref e) => panic!(format!("failed to get current_exe: {}", e)),
+        Ok(exe) => {
+            let mut p = canonicalize(exe);
+            p.pop();
+            p.pop();
+            p
+        }
+        Err(e) => panic!("failed to get current_exe: {}", e),
     }
 }
 


### PR DESCRIPTION
This commit updates the metadata location logic to ignore errors when
calling `fs::canonicalize`. Canonicalization was added historically so
multiple `-L` paths to the same directory don't print errors about
multiple candidates (since rustc can deduplicate same-named paths), but
canonicalization doesn't work on all filesystems. Cargo, for example,
always uses this sort of fallback where it will opportunitistically try
to canonicalize but fall back to using the input path if it otherwise
doesn't work.

If rustc is run on a filesystem that doesn't support canonicalization
then the effect of this change will be that `-L` paths which logically
point to the same directory will cause errors, but that's a rare enough
occurrence it shouldn't cause much issue in practice. Otherwise rustc
doesn't work at all today on those sorts of filesystem where
canonicalization isn't supported!