### PR TITLE
Rename intra_doc_link_resolution_failure

### DIFF
--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -69,7 +69,6 @@
 #![warn(deprecated_in_future)]
 #![warn(missing_docs)]
 #![warn(missing_debug_implementations)]
-#![deny(intra_doc_resolution_failures)] // rustdoc is run without -D warnings
 #![allow(explicit_outlives_requirements)]
 #![allow(incomplete_features)]
 #![deny(unsafe_op_in_unsafe_fn)]

--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -69,7 +69,7 @@
 #![warn(deprecated_in_future)]
 #![warn(missing_docs)]
 #![warn(missing_debug_implementations)]
-#![deny(intra_doc_link_resolution_failure)] // rustdoc is run without -D warnings
+#![deny(intra_doc_resolution_failures)] // rustdoc is run without -D warnings
 #![allow(explicit_outlives_requirements)]
 #![allow(incomplete_features)]
 #![deny(unsafe_op_in_unsafe_fn)]

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -61,7 +61,7 @@
 #![warn(deprecated_in_future)]
 #![warn(missing_docs)]
 #![warn(missing_debug_implementations)]
-#![deny(intra_doc_link_resolution_failure)] // rustdoc is run without -D warnings
+#![deny(intra_doc_resolution_failures)] // rustdoc is run without -D warnings
 #![allow(explicit_outlives_requirements)]
 #![allow(incomplete_features)]
 #![feature(allow_internal_unstable)]
@@ -149,7 +149,7 @@
 #![feature(slice_ptr_get)]
 #![feature(no_niche)] // rust-lang/rust#68303
 #![feature(unsafe_block_in_unsafe_fn)]
-#![deny(intra_doc_link_resolution_failure)]
+#![deny(intra_doc_resolution_failures)]
 #![deny(unsafe_op_in_unsafe_fn)]
 
 #[prelude_import]

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -61,7 +61,6 @@
 #![warn(deprecated_in_future)]
 #![warn(missing_docs)]
 #![warn(missing_debug_implementations)]
-#![deny(intra_doc_resolution_failures)] // rustdoc is run without -D warnings
 #![allow(explicit_outlives_requirements)]
 #![allow(incomplete_features)]
 #![feature(allow_internal_unstable)]
@@ -149,7 +148,6 @@
 #![feature(slice_ptr_get)]
 #![feature(no_niche)] // rust-lang/rust#68303
 #![feature(unsafe_block_in_unsafe_fn)]
-#![deny(intra_doc_resolution_failures)]
 #![deny(unsafe_op_in_unsafe_fn)]
 
 #[prelude_import]

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -212,7 +212,7 @@
 #![warn(deprecated_in_future)]
 #![warn(missing_docs)]
 #![warn(missing_debug_implementations)]
-#![deny(intra_doc_link_resolution_failure)] // rustdoc is run without -D warnings
+#![deny(intra_doc_resolution_failures)] // rustdoc is run without -D warnings
 #![allow(explicit_outlives_requirements)]
 #![allow(unused_lifetimes)]
 // Tell the compiler to link to either panic_abort or panic_unwind

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -212,7 +212,6 @@
 #![warn(deprecated_in_future)]
 #![warn(missing_docs)]
 #![warn(missing_debug_implementations)]
-#![deny(intra_doc_resolution_failures)] // rustdoc is run without -D warnings
 #![allow(explicit_outlives_requirements)]
 #![allow(unused_lifetimes)]
 // Tell the compiler to link to either panic_abort or panic_unwind

--- a/src/doc/rustdoc/src/lints.md
+++ b/src/doc/rustdoc/src/lints.md
@@ -11,7 +11,7 @@ can use them like any other lints by doing this:
 
 Here is the list of the lints provided by `rustdoc`:
 
-## intra_doc_link_resolution_failures
+## intra_doc_resolution_failures
 
 This lint **warns by default** and is **nightly-only**. This lint detects when
 an intra-doc link fails to get resolved. For example:

--- a/src/doc/rustdoc/src/lints.md
+++ b/src/doc/rustdoc/src/lints.md
@@ -11,7 +11,7 @@ can use them like any other lints by doing this:
 
 Here is the list of the lints provided by `rustdoc`:
 
-## intra_doc_link_resolution_failure
+## intra_doc_link_resolution_failures
 
 This lint **warns by default** and is **nightly-only**. This lint detects when
 an intra-doc link fails to get resolved. For example:

--- a/src/doc/rustdoc/src/lints.md
+++ b/src/doc/rustdoc/src/lints.md
@@ -11,7 +11,7 @@ can use them like any other lints by doing this:
 
 Here is the list of the lints provided by `rustdoc`:
 
-## intra_doc_resolution_failures
+## broken_intra_doc_links
 
 This lint **warns by default** and is **nightly-only**. This lint detects when
 an intra-doc link fails to get resolved. For example:

--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -62,7 +62,7 @@ use rustc_middle::ty::query::Providers;
 use rustc_middle::ty::TyCtxt;
 use rustc_session::lint::builtin::{
     BARE_TRAIT_OBJECTS, ELIDED_LIFETIMES_IN_PATHS, EXPLICIT_OUTLIVES_REQUIREMENTS,
-    INTRA_DOC_LINK_RESOLUTION_FAILURE, INVALID_CODEBLOCK_ATTRIBUTES, MISSING_DOC_CODE_EXAMPLES,
+    INTRA_DOC_LINK_RESOLUTION_FAILURES, INVALID_CODEBLOCK_ATTRIBUTES, MISSING_DOC_CODE_EXAMPLES,
     PRIVATE_DOC_TESTS,
 };
 use rustc_span::symbol::{Ident, Symbol};
@@ -303,7 +303,7 @@ fn register_builtins(store: &mut LintStore, no_interleave_lints: bool) {
 
     add_lint_group!(
         "rustdoc",
-        INTRA_DOC_LINK_RESOLUTION_FAILURE,
+        INTRA_DOC_LINK_RESOLUTION_FAILURES,
         INVALID_CODEBLOCK_ATTRIBUTES,
         MISSING_DOC_CODE_EXAMPLES,
         PRIVATE_DOC_TESTS

--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -61,8 +61,8 @@ use rustc_hir::def_id::LocalDefId;
 use rustc_middle::ty::query::Providers;
 use rustc_middle::ty::TyCtxt;
 use rustc_session::lint::builtin::{
-    BARE_TRAIT_OBJECTS, ELIDED_LIFETIMES_IN_PATHS, EXPLICIT_OUTLIVES_REQUIREMENTS,
-    INTRA_DOC_RESOLUTION_FAILURES, INVALID_CODEBLOCK_ATTRIBUTES, MISSING_DOC_CODE_EXAMPLES,
+    BARE_TRAIT_OBJECTS, BROKEN_INTRA_DOC_LINKS, ELIDED_LIFETIMES_IN_PATHS,
+    EXPLICIT_OUTLIVES_REQUIREMENTS, INVALID_CODEBLOCK_ATTRIBUTES, MISSING_DOC_CODE_EXAMPLES,
     PRIVATE_DOC_TESTS,
 };
 use rustc_span::symbol::{Ident, Symbol};
@@ -303,7 +303,7 @@ fn register_builtins(store: &mut LintStore, no_interleave_lints: bool) {
 
     add_lint_group!(
         "rustdoc",
-        INTRA_DOC_RESOLUTION_FAILURES,
+        BROKEN_INTRA_DOC_LINKS,
         INVALID_CODEBLOCK_ATTRIBUTES,
         MISSING_DOC_CODE_EXAMPLES,
         PRIVATE_DOC_TESTS

--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -62,7 +62,7 @@ use rustc_middle::ty::query::Providers;
 use rustc_middle::ty::TyCtxt;
 use rustc_session::lint::builtin::{
     BARE_TRAIT_OBJECTS, ELIDED_LIFETIMES_IN_PATHS, EXPLICIT_OUTLIVES_REQUIREMENTS,
-    INTRA_DOC_LINK_RESOLUTION_FAILURES, INVALID_CODEBLOCK_ATTRIBUTES, MISSING_DOC_CODE_EXAMPLES,
+    INTRA_DOC_RESOLUTION_FAILURES, INVALID_CODEBLOCK_ATTRIBUTES, MISSING_DOC_CODE_EXAMPLES,
     PRIVATE_DOC_TESTS,
 };
 use rustc_span::symbol::{Ident, Symbol};
@@ -303,7 +303,7 @@ fn register_builtins(store: &mut LintStore, no_interleave_lints: bool) {
 
     add_lint_group!(
         "rustdoc",
-        INTRA_DOC_LINK_RESOLUTION_FAILURES,
+        INTRA_DOC_RESOLUTION_FAILURES,
         INVALID_CODEBLOCK_ATTRIBUTES,
         MISSING_DOC_CODE_EXAMPLES,
         PRIVATE_DOC_TESTS
@@ -318,7 +318,7 @@ fn register_builtins(store: &mut LintStore, no_interleave_lints: bool) {
     store.register_renamed("async_idents", "keyword_idents");
     store.register_renamed("exceeding_bitshifts", "arithmetic_overflow");
     store.register_renamed("redundant_semicolon", "redundant_semicolons");
-    store.register_renamed("intra_doc_link_resolution_failure", "intra_doc_link_resolution_failures");
+    store.register_renamed("intra_doc_link_resolution_failure", "intra_doc_resolution_failures");
     store.register_removed("unknown_features", "replaced by an error");
     store.register_removed("unsigned_negation", "replaced by negate_unsigned feature gate");
     store.register_removed("negate_unsigned", "cast a signed value instead");

--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -318,7 +318,7 @@ fn register_builtins(store: &mut LintStore, no_interleave_lints: bool) {
     store.register_renamed("async_idents", "keyword_idents");
     store.register_renamed("exceeding_bitshifts", "arithmetic_overflow");
     store.register_renamed("redundant_semicolon", "redundant_semicolons");
-    store.register_renamed("intra_doc_link_resolution_failure", "intra_doc_resolution_failures");
+    store.register_renamed("intra_doc_link_resolution_failure", "broken_intra_doc_links");
     store.register_removed("unknown_features", "replaced by an error");
     store.register_removed("unsigned_negation", "replaced by negate_unsigned feature gate");
     store.register_removed("negate_unsigned", "cast a signed value instead");

--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -318,6 +318,7 @@ fn register_builtins(store: &mut LintStore, no_interleave_lints: bool) {
     store.register_renamed("async_idents", "keyword_idents");
     store.register_renamed("exceeding_bitshifts", "arithmetic_overflow");
     store.register_renamed("redundant_semicolon", "redundant_semicolons");
+    store.register_renamed("intra_doc_link_resolution_failure", "intra_doc_link_resolution_failures");
     store.register_removed("unknown_features", "replaced by an error");
     store.register_removed("unsigned_negation", "replaced by negate_unsigned feature gate");
     store.register_removed("negate_unsigned", "cast a signed value instead");

--- a/src/librustc_session/lint/builtin.rs
+++ b/src/librustc_session/lint/builtin.rs
@@ -398,7 +398,7 @@ declare_lint! {
 }
 
 declare_lint! {
-    pub INTRA_DOC_RESOLUTION_FAILURES,
+    pub BROKEN_INTRA_DOC_LINKS,
     Warn,
     "failures in resolving intra-doc link targets"
 }
@@ -601,7 +601,7 @@ declare_lint_pass! {
         ABSOLUTE_PATHS_NOT_STARTING_WITH_CRATE,
         UNSTABLE_NAME_COLLISIONS,
         IRREFUTABLE_LET_PATTERNS,
-        INTRA_DOC_RESOLUTION_FAILURES,
+        BROKEN_INTRA_DOC_LINKS,
         INVALID_CODEBLOCK_ATTRIBUTES,
         MISSING_CRATE_LEVEL_DOCS,
         MISSING_DOC_CODE_EXAMPLES,

--- a/src/librustc_session/lint/builtin.rs
+++ b/src/librustc_session/lint/builtin.rs
@@ -398,7 +398,7 @@ declare_lint! {
 }
 
 declare_lint! {
-    pub INTRA_DOC_LINK_RESOLUTION_FAILURES,
+    pub INTRA_DOC_RESOLUTION_FAILURES,
     Warn,
     "failures in resolving intra-doc link targets"
 }
@@ -601,7 +601,7 @@ declare_lint_pass! {
         ABSOLUTE_PATHS_NOT_STARTING_WITH_CRATE,
         UNSTABLE_NAME_COLLISIONS,
         IRREFUTABLE_LET_PATTERNS,
-        INTRA_DOC_LINK_RESOLUTION_FAILURES,
+        INTRA_DOC_RESOLUTION_FAILURES,
         INVALID_CODEBLOCK_ATTRIBUTES,
         MISSING_CRATE_LEVEL_DOCS,
         MISSING_DOC_CODE_EXAMPLES,

--- a/src/librustc_session/lint/builtin.rs
+++ b/src/librustc_session/lint/builtin.rs
@@ -398,7 +398,7 @@ declare_lint! {
 }
 
 declare_lint! {
-    pub INTRA_DOC_LINK_RESOLUTION_FAILURE,
+    pub INTRA_DOC_LINK_RESOLUTION_FAILURES,
     Warn,
     "failures in resolving intra-doc link targets"
 }
@@ -601,7 +601,7 @@ declare_lint_pass! {
         ABSOLUTE_PATHS_NOT_STARTING_WITH_CRATE,
         UNSTABLE_NAME_COLLISIONS,
         IRREFUTABLE_LET_PATTERNS,
-        INTRA_DOC_LINK_RESOLUTION_FAILURE,
+        INTRA_DOC_LINK_RESOLUTION_FAILURES,
         INVALID_CODEBLOCK_ATTRIBUTES,
         MISSING_CRATE_LEVEL_DOCS,
         MISSING_DOC_CODE_EXAMPLES,

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -315,7 +315,7 @@ pub fn run_core(options: RustdocOptions) -> (clean::Crate, RenderInfo, RenderOpt
     let cpath = Some(input.clone());
     let input = Input::File(input);
 
-    let intra_link_resolution_failure_name = lint::builtin::INTRA_DOC_LINK_RESOLUTION_FAILURE.name;
+    let intra_link_resolution_failure_name = lint::builtin::INTRA_DOC_LINK_RESOLUTION_FAILURES.name;
     let missing_docs = rustc_lint::builtin::MISSING_DOCS.name;
     let missing_doc_example = rustc_lint::builtin::MISSING_DOC_CODE_EXAMPLES.name;
     let private_doc_tests = rustc_lint::builtin::PRIVATE_DOC_TESTS.name;

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -315,7 +315,7 @@ pub fn run_core(options: RustdocOptions) -> (clean::Crate, RenderInfo, RenderOpt
     let cpath = Some(input.clone());
     let input = Input::File(input);
 
-    let intra_link_resolution_failure_name = lint::builtin::INTRA_DOC_LINK_RESOLUTION_FAILURES.name;
+    let intra_link_resolution_failure_name = lint::builtin::INTRA_DOC_RESOLUTION_FAILURES.name;
     let missing_docs = rustc_lint::builtin::MISSING_DOCS.name;
     let missing_doc_example = rustc_lint::builtin::MISSING_DOC_CODE_EXAMPLES.name;
     let private_doc_tests = rustc_lint::builtin::PRIVATE_DOC_TESTS.name;

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -315,7 +315,7 @@ pub fn run_core(options: RustdocOptions) -> (clean::Crate, RenderInfo, RenderOpt
     let cpath = Some(input.clone());
     let input = Input::File(input);
 
-    let intra_link_resolution_failure_name = lint::builtin::INTRA_DOC_RESOLUTION_FAILURES.name;
+    let intra_link_resolution_failure_name = lint::builtin::BROKEN_INTRA_DOC_LINKS.name;
     let missing_docs = rustc_lint::builtin::MISSING_DOCS.name;
     let missing_doc_example = rustc_lint::builtin::MISSING_DOC_CODE_EXAMPLES.name;
     let private_doc_tests = rustc_lint::builtin::PRIVATE_DOC_TESTS.name;

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -867,46 +867,40 @@ fn report_diagnostic(
     let attrs = &item.attrs;
     let sp = span_of_attrs(attrs).unwrap_or(item.source.span());
 
-    cx.tcx.struct_span_lint_hir(
-        lint::builtin::INTRA_DOC_LINK_RESOLUTION_FAILURES,
-        hir_id,
-        sp,
-        |lint| {
-            let mut diag = lint.build(msg);
+    cx.tcx.struct_span_lint_hir(lint::builtin::INTRA_DOC_RESOLUTION_FAILURES, hir_id, sp, |lint| {
+        let mut diag = lint.build(msg);
 
-            let span = link_range
-                .as_ref()
-                .and_then(|range| super::source_span_for_markdown_range(cx, dox, range, attrs));
+        let span = link_range
+            .as_ref()
+            .and_then(|range| super::source_span_for_markdown_range(cx, dox, range, attrs));
 
-            if let Some(link_range) = link_range {
-                if let Some(sp) = span {
-                    diag.set_span(sp);
-                } else {
-                    // blah blah blah\nblah\nblah [blah] blah blah\nblah blah
-                    //                       ^     ~~~~
-                    //                       |     link_range
-                    //                       last_new_line_offset
-                    let last_new_line_offset =
-                        dox[..link_range.start].rfind('\n').map_or(0, |n| n + 1);
-                    let line = dox[last_new_line_offset..].lines().next().unwrap_or("");
+        if let Some(link_range) = link_range {
+            if let Some(sp) = span {
+                diag.set_span(sp);
+            } else {
+                // blah blah blah\nblah\nblah [blah] blah blah\nblah blah
+                //                       ^     ~~~~
+                //                       |     link_range
+                //                       last_new_line_offset
+                let last_new_line_offset = dox[..link_range.start].rfind('\n').map_or(0, |n| n + 1);
+                let line = dox[last_new_line_offset..].lines().next().unwrap_or("");
 
-                    // Print the line containing the `link_range` and manually mark it with '^'s.
-                    diag.note(&format!(
-                        "the link appears in this line:\n\n{line}\n\
+                // Print the line containing the `link_range` and manually mark it with '^'s.
+                diag.note(&format!(
+                    "the link appears in this line:\n\n{line}\n\
                          {indicator: <before$}{indicator:^<found$}",
-                        line = line,
-                        indicator = "",
-                        before = link_range.start - last_new_line_offset,
-                        found = link_range.len(),
-                    ));
-                }
+                    line = line,
+                    indicator = "",
+                    before = link_range.start - last_new_line_offset,
+                    found = link_range.len(),
+                ));
             }
+        }
 
-            decorate(&mut diag, span);
+        decorate(&mut diag, span);
 
-            diag.emit();
-        },
-    );
+        diag.emit();
+    });
 }
 
 fn resolution_failure(

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -868,7 +868,7 @@ fn report_diagnostic(
     let sp = span_of_attrs(attrs).unwrap_or(item.source.span());
 
     cx.tcx.struct_span_lint_hir(
-        lint::builtin::INTRA_DOC_LINK_RESOLUTION_FAILURE,
+        lint::builtin::INTRA_DOC_LINK_RESOLUTION_FAILURES,
         hir_id,
         sp,
         |lint| {

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -867,7 +867,7 @@ fn report_diagnostic(
     let attrs = &item.attrs;
     let sp = span_of_attrs(attrs).unwrap_or(item.source.span());
 
-    cx.tcx.struct_span_lint_hir(lint::builtin::INTRA_DOC_RESOLUTION_FAILURES, hir_id, sp, |lint| {
+    cx.tcx.struct_span_lint_hir(lint::builtin::BROKEN_INTRA_DOC_LINKS, hir_id, sp, |lint| {
         let mut diag = lint.build(msg);
 
         let span = link_range

--- a/src/test/run-make-fulldeps/exit-code/lint-failure.rs
+++ b/src/test/run-make-fulldeps/exit-code/lint-failure.rs
@@ -1,4 +1,4 @@
-#![deny(intra_doc_link_resolution_failure)]
+#![deny(intra_doc_link_resolution_failures)]
 
 /// [intradoc::failure]
 pub fn main() {

--- a/src/test/run-make-fulldeps/exit-code/lint-failure.rs
+++ b/src/test/run-make-fulldeps/exit-code/lint-failure.rs
@@ -1,4 +1,4 @@
-#![deny(intra_doc_resolution_failures)]
+#![deny(broken_intra_doc_links)]
 
 /// [intradoc::failure]
 pub fn main() {

--- a/src/test/run-make-fulldeps/exit-code/lint-failure.rs
+++ b/src/test/run-make-fulldeps/exit-code/lint-failure.rs
@@ -1,4 +1,4 @@
-#![deny(intra_doc_link_resolution_failures)]
+#![deny(intra_doc_resolution_failures)]
 
 /// [intradoc::failure]
 pub fn main() {

--- a/src/test/rustdoc-ui/deny-intra-link-resolution-failure.rs
+++ b/src/test/rustdoc-ui/deny-intra-link-resolution-failure.rs
@@ -1,4 +1,4 @@
-#![deny(intra_doc_link_resolution_failure)]
+#![deny(intra_doc_link_resolution_failures)]
 
 /// [v2] //~ ERROR
 pub fn foo() {}

--- a/src/test/rustdoc-ui/deny-intra-link-resolution-failure.rs
+++ b/src/test/rustdoc-ui/deny-intra-link-resolution-failure.rs
@@ -1,4 +1,4 @@
-#![deny(intra_doc_resolution_failures)]
+#![deny(broken_intra_doc_links)]
 
 /// [v2] //~ ERROR
 pub fn foo() {}

--- a/src/test/rustdoc-ui/deny-intra-link-resolution-failure.rs
+++ b/src/test/rustdoc-ui/deny-intra-link-resolution-failure.rs
@@ -1,4 +1,4 @@
-#![deny(intra_doc_link_resolution_failures)]
+#![deny(intra_doc_resolution_failures)]
 
 /// [v2] //~ ERROR
 pub fn foo() {}

--- a/src/test/rustdoc-ui/deny-intra-link-resolution-failure.stderr
+++ b/src/test/rustdoc-ui/deny-intra-link-resolution-failure.stderr
@@ -7,7 +7,7 @@ LL | /// [v2]
 note: the lint level is defined here
   --> $DIR/deny-intra-link-resolution-failure.rs:1:9
    |
-LL | #![deny(intra_doc_link_resolution_failure)]
+LL | #![deny(intra_doc_link_resolution_failures)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 

--- a/src/test/rustdoc-ui/deny-intra-link-resolution-failure.stderr
+++ b/src/test/rustdoc-ui/deny-intra-link-resolution-failure.stderr
@@ -7,7 +7,7 @@ LL | /// [v2]
 note: the lint level is defined here
   --> $DIR/deny-intra-link-resolution-failure.rs:1:9
    |
-LL | #![deny(intra_doc_link_resolution_failures)]
+LL | #![deny(intra_doc_resolution_failures)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 

--- a/src/test/rustdoc-ui/deny-intra-link-resolution-failure.stderr
+++ b/src/test/rustdoc-ui/deny-intra-link-resolution-failure.stderr
@@ -7,7 +7,7 @@ LL | /// [v2]
 note: the lint level is defined here
   --> $DIR/deny-intra-link-resolution-failure.rs:1:9
    |
-LL | #![deny(intra_doc_resolution_failures)]
+LL | #![deny(broken_intra_doc_links)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 

--- a/src/test/rustdoc-ui/deny-intra-link-resolution-failure.stderr
+++ b/src/test/rustdoc-ui/deny-intra-link-resolution-failure.stderr
@@ -8,7 +8,7 @@ note: the lint level is defined here
   --> $DIR/deny-intra-link-resolution-failure.rs:1:9
    |
 LL | #![deny(intra_doc_resolution_failures)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 error: aborting due to previous error

--- a/src/test/rustdoc-ui/deny-intra-link-resolution-failure.stderr
+++ b/src/test/rustdoc-ui/deny-intra-link-resolution-failure.stderr
@@ -8,7 +8,7 @@ note: the lint level is defined here
   --> $DIR/deny-intra-link-resolution-failure.rs:1:9
    |
 LL | #![deny(broken_intra_doc_links)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^^^^
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 error: aborting due to previous error

--- a/src/test/rustdoc-ui/intra-doc-alias-ice.rs
+++ b/src/test/rustdoc-ui/intra-doc-alias-ice.rs
@@ -1,4 +1,4 @@
-#![deny(intra_doc_link_resolution_failure)]
+#![deny(intra_doc_link_resolution_failures)]
 
 pub type TypeAlias = usize;
 

--- a/src/test/rustdoc-ui/intra-doc-alias-ice.rs
+++ b/src/test/rustdoc-ui/intra-doc-alias-ice.rs
@@ -1,4 +1,4 @@
-#![deny(intra_doc_resolution_failures)]
+#![deny(broken_intra_doc_links)]
 
 pub type TypeAlias = usize;
 

--- a/src/test/rustdoc-ui/intra-doc-alias-ice.rs
+++ b/src/test/rustdoc-ui/intra-doc-alias-ice.rs
@@ -1,4 +1,4 @@
-#![deny(intra_doc_link_resolution_failures)]
+#![deny(intra_doc_resolution_failures)]
 
 pub type TypeAlias = usize;
 

--- a/src/test/rustdoc-ui/intra-doc-alias-ice.stderr
+++ b/src/test/rustdoc-ui/intra-doc-alias-ice.stderr
@@ -7,7 +7,7 @@ LL | /// [broken cross-reference](TypeAlias::hoge)
 note: the lint level is defined here
   --> $DIR/intra-doc-alias-ice.rs:1:9
    |
-LL | #![deny(intra_doc_link_resolution_failures)]
+LL | #![deny(intra_doc_resolution_failures)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 

--- a/src/test/rustdoc-ui/intra-doc-alias-ice.stderr
+++ b/src/test/rustdoc-ui/intra-doc-alias-ice.stderr
@@ -7,7 +7,7 @@ LL | /// [broken cross-reference](TypeAlias::hoge)
 note: the lint level is defined here
   --> $DIR/intra-doc-alias-ice.rs:1:9
    |
-LL | #![deny(intra_doc_link_resolution_failure)]
+LL | #![deny(intra_doc_link_resolution_failures)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 

--- a/src/test/rustdoc-ui/intra-doc-alias-ice.stderr
+++ b/src/test/rustdoc-ui/intra-doc-alias-ice.stderr
@@ -8,7 +8,7 @@ note: the lint level is defined here
   --> $DIR/intra-doc-alias-ice.rs:1:9
    |
 LL | #![deny(broken_intra_doc_links)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^^^^
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 error: aborting due to previous error

--- a/src/test/rustdoc-ui/intra-doc-alias-ice.stderr
+++ b/src/test/rustdoc-ui/intra-doc-alias-ice.stderr
@@ -7,7 +7,7 @@ LL | /// [broken cross-reference](TypeAlias::hoge)
 note: the lint level is defined here
   --> $DIR/intra-doc-alias-ice.rs:1:9
    |
-LL | #![deny(intra_doc_resolution_failures)]
+LL | #![deny(broken_intra_doc_links)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 

--- a/src/test/rustdoc-ui/intra-doc-alias-ice.stderr
+++ b/src/test/rustdoc-ui/intra-doc-alias-ice.stderr
@@ -8,7 +8,7 @@ note: the lint level is defined here
   --> $DIR/intra-doc-alias-ice.rs:1:9
    |
 LL | #![deny(intra_doc_resolution_failures)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 error: aborting due to previous error

--- a/src/test/rustdoc-ui/intra-link-span-ice-55723.rs
+++ b/src/test/rustdoc-ui/intra-link-span-ice-55723.rs
@@ -1,4 +1,4 @@
-#![deny(intra_doc_link_resolution_failure)]
+#![deny(intra_doc_link_resolution_failures)]
 
 // An error in calculating spans while reporting intra-doc link resolution errors caused rustdoc to
 // attempt to slice in the middle of a multibyte character. See

--- a/src/test/rustdoc-ui/intra-link-span-ice-55723.rs
+++ b/src/test/rustdoc-ui/intra-link-span-ice-55723.rs
@@ -1,4 +1,4 @@
-#![deny(intra_doc_resolution_failures)]
+#![deny(broken_intra_doc_links)]
 
 // An error in calculating spans while reporting intra-doc link resolution errors caused rustdoc to
 // attempt to slice in the middle of a multibyte character. See

--- a/src/test/rustdoc-ui/intra-link-span-ice-55723.rs
+++ b/src/test/rustdoc-ui/intra-link-span-ice-55723.rs
@@ -1,4 +1,4 @@
-#![deny(intra_doc_link_resolution_failures)]
+#![deny(intra_doc_resolution_failures)]
 
 // An error in calculating spans while reporting intra-doc link resolution errors caused rustdoc to
 // attempt to slice in the middle of a multibyte character. See

--- a/src/test/rustdoc-ui/intra-link-span-ice-55723.stderr
+++ b/src/test/rustdoc-ui/intra-link-span-ice-55723.stderr
@@ -7,7 +7,7 @@ LL | /// （arr[i]）
 note: the lint level is defined here
   --> $DIR/intra-link-span-ice-55723.rs:1:9
    |
-LL | #![deny(intra_doc_link_resolution_failure)]
+LL | #![deny(intra_doc_link_resolution_failures)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 

--- a/src/test/rustdoc-ui/intra-link-span-ice-55723.stderr
+++ b/src/test/rustdoc-ui/intra-link-span-ice-55723.stderr
@@ -8,7 +8,7 @@ note: the lint level is defined here
   --> $DIR/intra-link-span-ice-55723.rs:1:9
    |
 LL | #![deny(intra_doc_resolution_failures)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 error: aborting due to previous error

--- a/src/test/rustdoc-ui/intra-link-span-ice-55723.stderr
+++ b/src/test/rustdoc-ui/intra-link-span-ice-55723.stderr
@@ -7,7 +7,7 @@ LL | /// （arr[i]）
 note: the lint level is defined here
   --> $DIR/intra-link-span-ice-55723.rs:1:9
    |
-LL | #![deny(intra_doc_resolution_failures)]
+LL | #![deny(broken_intra_doc_links)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 

--- a/src/test/rustdoc-ui/intra-link-span-ice-55723.stderr
+++ b/src/test/rustdoc-ui/intra-link-span-ice-55723.stderr
@@ -7,7 +7,7 @@ LL | /// （arr[i]）
 note: the lint level is defined here
   --> $DIR/intra-link-span-ice-55723.rs:1:9
    |
-LL | #![deny(intra_doc_link_resolution_failures)]
+LL | #![deny(intra_doc_resolution_failures)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 

--- a/src/test/rustdoc-ui/intra-link-span-ice-55723.stderr
+++ b/src/test/rustdoc-ui/intra-link-span-ice-55723.stderr
@@ -8,7 +8,7 @@ note: the lint level is defined here
   --> $DIR/intra-link-span-ice-55723.rs:1:9
    |
 LL | #![deny(broken_intra_doc_links)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^^^^
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 error: aborting due to previous error

--- a/src/test/rustdoc-ui/intra-links-ambiguity.rs
+++ b/src/test/rustdoc-ui/intra-links-ambiguity.rs
@@ -1,4 +1,4 @@
-#![deny(intra_doc_link_resolution_failure)]
+#![deny(intra_doc_link_resolution_failures)]
 #![allow(non_camel_case_types)]
 #![allow(non_upper_case_globals)]
 

--- a/src/test/rustdoc-ui/intra-links-ambiguity.rs
+++ b/src/test/rustdoc-ui/intra-links-ambiguity.rs
@@ -1,4 +1,4 @@
-#![deny(intra_doc_link_resolution_failures)]
+#![deny(intra_doc_resolution_failures)]
 #![allow(non_camel_case_types)]
 #![allow(non_upper_case_globals)]
 

--- a/src/test/rustdoc-ui/intra-links-ambiguity.rs
+++ b/src/test/rustdoc-ui/intra-links-ambiguity.rs
@@ -1,4 +1,4 @@
-#![deny(intra_doc_resolution_failures)]
+#![deny(broken_intra_doc_links)]
 #![allow(non_camel_case_types)]
 #![allow(non_upper_case_globals)]
 

--- a/src/test/rustdoc-ui/intra-links-ambiguity.stderr
+++ b/src/test/rustdoc-ui/intra-links-ambiguity.stderr
@@ -8,7 +8,7 @@ note: the lint level is defined here
   --> $DIR/intra-links-ambiguity.rs:1:9
    |
 LL | #![deny(broken_intra_doc_links)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^^^^
 help: to link to the struct, prefix with the item type
    |
 LL | /// [`struct@ambiguous`] is ambiguous.

--- a/src/test/rustdoc-ui/intra-links-ambiguity.stderr
+++ b/src/test/rustdoc-ui/intra-links-ambiguity.stderr
@@ -7,7 +7,7 @@ LL | /// [`ambiguous`] is ambiguous.
 note: the lint level is defined here
   --> $DIR/intra-links-ambiguity.rs:1:9
    |
-LL | #![deny(intra_doc_link_resolution_failure)]
+LL | #![deny(intra_doc_link_resolution_failures)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: to link to the struct, prefix with the item type
    |

--- a/src/test/rustdoc-ui/intra-links-ambiguity.stderr
+++ b/src/test/rustdoc-ui/intra-links-ambiguity.stderr
@@ -8,7 +8,7 @@ note: the lint level is defined here
   --> $DIR/intra-links-ambiguity.rs:1:9
    |
 LL | #![deny(intra_doc_resolution_failures)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: to link to the struct, prefix with the item type
    |
 LL | /// [`struct@ambiguous`] is ambiguous.

--- a/src/test/rustdoc-ui/intra-links-ambiguity.stderr
+++ b/src/test/rustdoc-ui/intra-links-ambiguity.stderr
@@ -7,7 +7,7 @@ LL | /// [`ambiguous`] is ambiguous.
 note: the lint level is defined here
   --> $DIR/intra-links-ambiguity.rs:1:9
    |
-LL | #![deny(intra_doc_resolution_failures)]
+LL | #![deny(broken_intra_doc_links)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: to link to the struct, prefix with the item type
    |

--- a/src/test/rustdoc-ui/intra-links-ambiguity.stderr
+++ b/src/test/rustdoc-ui/intra-links-ambiguity.stderr
@@ -7,7 +7,7 @@ LL | /// [`ambiguous`] is ambiguous.
 note: the lint level is defined here
   --> $DIR/intra-links-ambiguity.rs:1:9
    |
-LL | #![deny(intra_doc_link_resolution_failures)]
+LL | #![deny(intra_doc_resolution_failures)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: to link to the struct, prefix with the item type
    |

--- a/src/test/rustdoc-ui/intra-links-anchors.rs
+++ b/src/test/rustdoc-ui/intra-links-anchors.rs
@@ -1,4 +1,4 @@
-#![deny(intra_doc_link_resolution_failure)]
+#![deny(intra_doc_link_resolution_failures)]
 
 // A few tests on anchors.
 

--- a/src/test/rustdoc-ui/intra-links-anchors.rs
+++ b/src/test/rustdoc-ui/intra-links-anchors.rs
@@ -1,4 +1,4 @@
-#![deny(intra_doc_link_resolution_failures)]
+#![deny(intra_doc_resolution_failures)]
 
 // A few tests on anchors.
 

--- a/src/test/rustdoc-ui/intra-links-anchors.rs
+++ b/src/test/rustdoc-ui/intra-links-anchors.rs
@@ -1,4 +1,4 @@
-#![deny(intra_doc_resolution_failures)]
+#![deny(broken_intra_doc_links)]
 
 // A few tests on anchors.
 

--- a/src/test/rustdoc-ui/intra-links-anchors.stderr
+++ b/src/test/rustdoc-ui/intra-links-anchors.stderr
@@ -7,7 +7,7 @@ LL | /// Or maybe [Foo::f#hola].
 note: the lint level is defined here
   --> $DIR/intra-links-anchors.rs:1:9
    |
-LL | #![deny(intra_doc_resolution_failures)]
+LL | #![deny(broken_intra_doc_links)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `hello#people#!` contains multiple anchors

--- a/src/test/rustdoc-ui/intra-links-anchors.stderr
+++ b/src/test/rustdoc-ui/intra-links-anchors.stderr
@@ -8,7 +8,7 @@ note: the lint level is defined here
   --> $DIR/intra-links-anchors.rs:1:9
    |
 LL | #![deny(broken_intra_doc_links)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^^^^
 
 error: `hello#people#!` contains multiple anchors
   --> $DIR/intra-links-anchors.rs:31:28

--- a/src/test/rustdoc-ui/intra-links-anchors.stderr
+++ b/src/test/rustdoc-ui/intra-links-anchors.stderr
@@ -8,7 +8,7 @@ note: the lint level is defined here
   --> $DIR/intra-links-anchors.rs:1:9
    |
 LL | #![deny(intra_doc_resolution_failures)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `hello#people#!` contains multiple anchors
   --> $DIR/intra-links-anchors.rs:31:28

--- a/src/test/rustdoc-ui/intra-links-anchors.stderr
+++ b/src/test/rustdoc-ui/intra-links-anchors.stderr
@@ -7,7 +7,7 @@ LL | /// Or maybe [Foo::f#hola].
 note: the lint level is defined here
   --> $DIR/intra-links-anchors.rs:1:9
    |
-LL | #![deny(intra_doc_link_resolution_failures)]
+LL | #![deny(intra_doc_resolution_failures)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `hello#people#!` contains multiple anchors

--- a/src/test/rustdoc-ui/intra-links-anchors.stderr
+++ b/src/test/rustdoc-ui/intra-links-anchors.stderr
@@ -7,7 +7,7 @@ LL | /// Or maybe [Foo::f#hola].
 note: the lint level is defined here
   --> $DIR/intra-links-anchors.rs:1:9
    |
-LL | #![deny(intra_doc_link_resolution_failure)]
+LL | #![deny(intra_doc_link_resolution_failures)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `hello#people#!` contains multiple anchors

--- a/src/test/rustdoc-ui/intra-links-private.private.stderr
+++ b/src/test/rustdoc-ui/intra-links-private.private.stderr
@@ -4,7 +4,7 @@ warning: public documentation for `DocMe` links to private item `DontDocMe`
 LL | /// docs [DontDocMe]
    |           ^^^^^^^^^ this item is private
    |
-   = note: `#[warn(intra_doc_link_resolution_failures)]` on by default
+   = note: `#[warn(intra_doc_resolution_failures)]` on by default
    = note: this link resolves only because you passed `--document-private-items`, but will break without
 
 warning: 1 warning emitted

--- a/src/test/rustdoc-ui/intra-links-private.private.stderr
+++ b/src/test/rustdoc-ui/intra-links-private.private.stderr
@@ -4,7 +4,7 @@ warning: public documentation for `DocMe` links to private item `DontDocMe`
 LL | /// docs [DontDocMe]
    |           ^^^^^^^^^ this item is private
    |
-   = note: `#[warn(intra_doc_link_resolution_failure)]` on by default
+   = note: `#[warn(intra_doc_link_resolution_failures)]` on by default
    = note: this link resolves only because you passed `--document-private-items`, but will break without
 
 warning: 1 warning emitted

--- a/src/test/rustdoc-ui/intra-links-private.private.stderr
+++ b/src/test/rustdoc-ui/intra-links-private.private.stderr
@@ -4,7 +4,7 @@ warning: public documentation for `DocMe` links to private item `DontDocMe`
 LL | /// docs [DontDocMe]
    |           ^^^^^^^^^ this item is private
    |
-   = note: `#[warn(intra_doc_resolution_failures)]` on by default
+   = note: `#[warn(broken_intra_doc_links)]` on by default
    = note: this link resolves only because you passed `--document-private-items`, but will break without
 
 warning: 1 warning emitted

--- a/src/test/rustdoc-ui/intra-links-private.public.stderr
+++ b/src/test/rustdoc-ui/intra-links-private.public.stderr
@@ -4,7 +4,7 @@ warning: public documentation for `DocMe` links to private item `DontDocMe`
 LL | /// docs [DontDocMe]
    |           ^^^^^^^^^ this item is private
    |
-   = note: `#[warn(intra_doc_link_resolution_failures)]` on by default
+   = note: `#[warn(intra_doc_resolution_failures)]` on by default
    = note: this link will resolve properly if you pass `--document-private-items`
 
 warning: 1 warning emitted

--- a/src/test/rustdoc-ui/intra-links-private.public.stderr
+++ b/src/test/rustdoc-ui/intra-links-private.public.stderr
@@ -4,7 +4,7 @@ warning: public documentation for `DocMe` links to private item `DontDocMe`
 LL | /// docs [DontDocMe]
    |           ^^^^^^^^^ this item is private
    |
-   = note: `#[warn(intra_doc_link_resolution_failure)]` on by default
+   = note: `#[warn(intra_doc_link_resolution_failures)]` on by default
    = note: this link will resolve properly if you pass `--document-private-items`
 
 warning: 1 warning emitted

--- a/src/test/rustdoc-ui/intra-links-private.public.stderr
+++ b/src/test/rustdoc-ui/intra-links-private.public.stderr
@@ -4,7 +4,7 @@ warning: public documentation for `DocMe` links to private item `DontDocMe`
 LL | /// docs [DontDocMe]
    |           ^^^^^^^^^ this item is private
    |
-   = note: `#[warn(intra_doc_resolution_failures)]` on by default
+   = note: `#[warn(broken_intra_doc_links)]` on by default
    = note: this link will resolve properly if you pass `--document-private-items`
 
 warning: 1 warning emitted

--- a/src/test/rustdoc-ui/intra-links-warning-crlf.stderr
+++ b/src/test/rustdoc-ui/intra-links-warning-crlf.stderr
@@ -4,7 +4,7 @@ warning: unresolved link to `error`
 LL | /// [error]
    |      ^^^^^ unresolved link
    |
-   = note: `#[warn(intra_doc_link_resolution_failure)]` on by default
+   = note: `#[warn(intra_doc_link_resolution_failures)]` on by default
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 warning: unresolved link to `error1`

--- a/src/test/rustdoc-ui/intra-links-warning-crlf.stderr
+++ b/src/test/rustdoc-ui/intra-links-warning-crlf.stderr
@@ -4,7 +4,7 @@ warning: unresolved link to `error`
 LL | /// [error]
    |      ^^^^^ unresolved link
    |
-   = note: `#[warn(intra_doc_link_resolution_failures)]` on by default
+   = note: `#[warn(intra_doc_resolution_failures)]` on by default
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 warning: unresolved link to `error1`

--- a/src/test/rustdoc-ui/intra-links-warning-crlf.stderr
+++ b/src/test/rustdoc-ui/intra-links-warning-crlf.stderr
@@ -4,7 +4,7 @@ warning: unresolved link to `error`
 LL | /// [error]
    |      ^^^^^ unresolved link
    |
-   = note: `#[warn(intra_doc_resolution_failures)]` on by default
+   = note: `#[warn(broken_intra_doc_links)]` on by default
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 warning: unresolved link to `error1`

--- a/src/test/rustdoc-ui/intra-links-warning.stderr
+++ b/src/test/rustdoc-ui/intra-links-warning.stderr
@@ -4,7 +4,7 @@ warning: unresolved link to `Foo::baz`
 LL |        //! Test with [Foo::baz], [Bar::foo], ...
    |                       ^^^^^^^^ unresolved link
    |
-   = note: `#[warn(intra_doc_resolution_failures)]` on by default
+   = note: `#[warn(broken_intra_doc_links)]` on by default
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 warning: unresolved link to `Bar::foo`

--- a/src/test/rustdoc-ui/intra-links-warning.stderr
+++ b/src/test/rustdoc-ui/intra-links-warning.stderr
@@ -4,7 +4,7 @@ warning: unresolved link to `Foo::baz`
 LL |        //! Test with [Foo::baz], [Bar::foo], ...
    |                       ^^^^^^^^ unresolved link
    |
-   = note: `#[warn(intra_doc_link_resolution_failure)]` on by default
+   = note: `#[warn(intra_doc_link_resolution_failures)]` on by default
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 warning: unresolved link to `Bar::foo`

--- a/src/test/rustdoc-ui/intra-links-warning.stderr
+++ b/src/test/rustdoc-ui/intra-links-warning.stderr
@@ -4,7 +4,7 @@ warning: unresolved link to `Foo::baz`
 LL |        //! Test with [Foo::baz], [Bar::foo], ...
    |                       ^^^^^^^^ unresolved link
    |
-   = note: `#[warn(intra_doc_link_resolution_failures)]` on by default
+   = note: `#[warn(intra_doc_resolution_failures)]` on by default
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 warning: unresolved link to `Bar::foo`

--- a/src/test/rustdoc-ui/issue-74134.private.stderr
+++ b/src/test/rustdoc-ui/issue-74134.private.stderr
@@ -4,7 +4,7 @@ warning: public documentation for `public_item` links to private item `PrivateTy
 LL |     /// [`PrivateType`]
    |          ^^^^^^^^^^^^^ this item is private
    |
-   = note: `#[warn(intra_doc_resolution_failures)]` on by default
+   = note: `#[warn(broken_intra_doc_links)]` on by default
    = note: this link resolves only because you passed `--document-private-items`, but will break without
 
 warning: 1 warning emitted

--- a/src/test/rustdoc-ui/issue-74134.private.stderr
+++ b/src/test/rustdoc-ui/issue-74134.private.stderr
@@ -4,7 +4,7 @@ warning: public documentation for `public_item` links to private item `PrivateTy
 LL |     /// [`PrivateType`]
    |          ^^^^^^^^^^^^^ this item is private
    |
-   = note: `#[warn(intra_doc_link_resolution_failures)]` on by default
+   = note: `#[warn(intra_doc_resolution_failures)]` on by default
    = note: this link resolves only because you passed `--document-private-items`, but will break without
 
 warning: 1 warning emitted

--- a/src/test/rustdoc-ui/issue-74134.private.stderr
+++ b/src/test/rustdoc-ui/issue-74134.private.stderr
@@ -4,7 +4,7 @@ warning: public documentation for `public_item` links to private item `PrivateTy
 LL |     /// [`PrivateType`]
    |          ^^^^^^^^^^^^^ this item is private
    |
-   = note: `#[warn(intra_doc_link_resolution_failure)]` on by default
+   = note: `#[warn(intra_doc_link_resolution_failures)]` on by default
    = note: this link resolves only because you passed `--document-private-items`, but will break without
 
 warning: 1 warning emitted

--- a/src/test/rustdoc-ui/issue-74134.public.stderr
+++ b/src/test/rustdoc-ui/issue-74134.public.stderr
@@ -4,7 +4,7 @@ warning: public documentation for `public_item` links to private item `PrivateTy
 LL |     /// [`PrivateType`]
    |          ^^^^^^^^^^^^^ this item is private
    |
-   = note: `#[warn(intra_doc_resolution_failures)]` on by default
+   = note: `#[warn(broken_intra_doc_links)]` on by default
    = note: this link will resolve properly if you pass `--document-private-items`
 
 warning: 1 warning emitted

--- a/src/test/rustdoc-ui/issue-74134.public.stderr
+++ b/src/test/rustdoc-ui/issue-74134.public.stderr
@@ -4,7 +4,7 @@ warning: public documentation for `public_item` links to private item `PrivateTy
 LL |     /// [`PrivateType`]
    |          ^^^^^^^^^^^^^ this item is private
    |
-   = note: `#[warn(intra_doc_link_resolution_failures)]` on by default
+   = note: `#[warn(intra_doc_resolution_failures)]` on by default
    = note: this link will resolve properly if you pass `--document-private-items`
 
 warning: 1 warning emitted

--- a/src/test/rustdoc-ui/issue-74134.public.stderr
+++ b/src/test/rustdoc-ui/issue-74134.public.stderr
@@ -4,7 +4,7 @@ warning: public documentation for `public_item` links to private item `PrivateTy
 LL |     /// [`PrivateType`]
    |          ^^^^^^^^^^^^^ this item is private
    |
-   = note: `#[warn(intra_doc_link_resolution_failure)]` on by default
+   = note: `#[warn(intra_doc_link_resolution_failures)]` on by default
    = note: this link will resolve properly if you pass `--document-private-items`
 
 warning: 1 warning emitted

--- a/src/test/rustdoc-ui/lint-group.stderr
+++ b/src/test/rustdoc-ui/lint-group.stderr
@@ -39,7 +39,7 @@ note: the lint level is defined here
    |
 LL | #![deny(rustdoc)]
    |         ^^^^^^^
-   = note: `#[deny(intra_doc_resolution_failures)]` implied by `#[deny(rustdoc)]`
+   = note: `#[deny(broken_intra_doc_links)]` implied by `#[deny(rustdoc)]`
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 error: aborting due to 3 previous errors

--- a/src/test/rustdoc-ui/lint-group.stderr
+++ b/src/test/rustdoc-ui/lint-group.stderr
@@ -39,7 +39,7 @@ note: the lint level is defined here
    |
 LL | #![deny(rustdoc)]
    |         ^^^^^^^
-   = note: `#[deny(intra_doc_link_resolution_failures)]` implied by `#[deny(rustdoc)]`
+   = note: `#[deny(intra_doc_resolution_failures)]` implied by `#[deny(rustdoc)]`
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 error: aborting due to 3 previous errors

--- a/src/test/rustdoc-ui/lint-group.stderr
+++ b/src/test/rustdoc-ui/lint-group.stderr
@@ -39,7 +39,7 @@ note: the lint level is defined here
    |
 LL | #![deny(rustdoc)]
    |         ^^^^^^^
-   = note: `#[deny(intra_doc_link_resolution_failure)]` implied by `#[deny(rustdoc)]`
+   = note: `#[deny(intra_doc_link_resolution_failures)]` implied by `#[deny(rustdoc)]`
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 error: aborting due to 3 previous errors

--- a/src/test/rustdoc-ui/reference-link-has-one-warning.stderr
+++ b/src/test/rustdoc-ui/reference-link-has-one-warning.stderr
@@ -4,7 +4,7 @@ warning: `[with#anchor#error]` has an issue with the link anchor.
 LL | /// docs [label][with#anchor#error]
    |                  ^^^^^^^^^^^^^^^^^ only one `#` is allowed in a link
    |
-   = note: `#[warn(intra_doc_link_resolution_failure)]` on by default
+   = note: `#[warn(intra_doc_link_resolution_failures)]` on by default
 
 warning: 1 warning emitted
 

--- a/src/test/rustdoc-ui/reference-link-has-one-warning.stderr
+++ b/src/test/rustdoc-ui/reference-link-has-one-warning.stderr
@@ -4,7 +4,7 @@ warning: `[with#anchor#error]` has an issue with the link anchor.
 LL | /// docs [label][with#anchor#error]
    |                  ^^^^^^^^^^^^^^^^^ only one `#` is allowed in a link
    |
-   = note: `#[warn(intra_doc_resolution_failures)]` on by default
+   = note: `#[warn(broken_intra_doc_links)]` on by default
 
 warning: 1 warning emitted
 

--- a/src/test/rustdoc-ui/reference-link-has-one-warning.stderr
+++ b/src/test/rustdoc-ui/reference-link-has-one-warning.stderr
@@ -4,7 +4,7 @@ warning: `[with#anchor#error]` has an issue with the link anchor.
 LL | /// docs [label][with#anchor#error]
    |                  ^^^^^^^^^^^^^^^^^ only one `#` is allowed in a link
    |
-   = note: `#[warn(intra_doc_link_resolution_failures)]` on by default
+   = note: `#[warn(intra_doc_resolution_failures)]` on by default
 
 warning: 1 warning emitted
 

--- a/src/test/rustdoc/intra-doc-crate/additional_doc.rs
+++ b/src/test/rustdoc/intra-doc-crate/additional_doc.rs
@@ -1,6 +1,6 @@
 // aux-build:additional_doc.rs
 // build-aux-docs
-#![deny(intra_doc_link_resolution_failures)]
+#![deny(intra_doc_resolution_failures)]
 
 extern crate my_rand;
 

--- a/src/test/rustdoc/intra-doc-crate/additional_doc.rs
+++ b/src/test/rustdoc/intra-doc-crate/additional_doc.rs
@@ -1,6 +1,6 @@
 // aux-build:additional_doc.rs
 // build-aux-docs
-#![deny(intra_doc_resolution_failures)]
+#![deny(broken_intra_doc_links)]
 
 extern crate my_rand;
 

--- a/src/test/rustdoc/intra-doc-crate/additional_doc.rs
+++ b/src/test/rustdoc/intra-doc-crate/additional_doc.rs
@@ -1,6 +1,6 @@
 // aux-build:additional_doc.rs
 // build-aux-docs
-#![deny(intra_doc_link_resolution_failure)]
+#![deny(intra_doc_link_resolution_failures)]
 
 extern crate my_rand;
 

--- a/src/test/rustdoc/intra-doc-crate/auxiliary/additional_doc.rs
+++ b/src/test/rustdoc/intra-doc-crate/auxiliary/additional_doc.rs
@@ -1,5 +1,5 @@
 #![crate_name = "my_rand"]
-#![deny(intra_doc_link_resolution_failure)]
+#![deny(intra_doc_link_resolution_failures)]
 
 pub trait RngCore {}
 /// Rng extends [`RngCore`].

--- a/src/test/rustdoc/intra-doc-crate/auxiliary/additional_doc.rs
+++ b/src/test/rustdoc/intra-doc-crate/auxiliary/additional_doc.rs
@@ -1,5 +1,5 @@
 #![crate_name = "my_rand"]
-#![deny(intra_doc_resolution_failures)]
+#![deny(broken_intra_doc_links)]
 
 pub trait RngCore {}
 /// Rng extends [`RngCore`].

--- a/src/test/rustdoc/intra-doc-crate/auxiliary/additional_doc.rs
+++ b/src/test/rustdoc/intra-doc-crate/auxiliary/additional_doc.rs
@@ -1,5 +1,5 @@
 #![crate_name = "my_rand"]
-#![deny(intra_doc_link_resolution_failures)]
+#![deny(intra_doc_resolution_failures)]
 
 pub trait RngCore {}
 /// Rng extends [`RngCore`].

--- a/src/test/rustdoc/intra-doc-crate/auxiliary/hidden.rs
+++ b/src/test/rustdoc/intra-doc-crate/auxiliary/hidden.rs
@@ -1,5 +1,5 @@
 #![crate_name = "hidden_dep"]
-#![deny(intra_doc_resolution_failures)]
+#![deny(broken_intra_doc_links)]
 
 #[doc(hidden)]
 pub mod __reexport {

--- a/src/test/rustdoc/intra-doc-crate/auxiliary/hidden.rs
+++ b/src/test/rustdoc/intra-doc-crate/auxiliary/hidden.rs
@@ -1,5 +1,5 @@
 #![crate_name = "hidden_dep"]
-#![deny(intra_doc_link_resolution_failures)]
+#![deny(intra_doc_resolution_failures)]
 
 #[doc(hidden)]
 pub mod __reexport {

--- a/src/test/rustdoc/intra-doc-crate/auxiliary/hidden.rs
+++ b/src/test/rustdoc/intra-doc-crate/auxiliary/hidden.rs
@@ -1,5 +1,5 @@
 #![crate_name = "hidden_dep"]
-#![deny(intra_doc_link_resolution_failure)]
+#![deny(intra_doc_link_resolution_failures)]
 
 #[doc(hidden)]
 pub mod __reexport {

--- a/src/test/rustdoc/intra-doc-crate/auxiliary/intra-doc-basic.rs
+++ b/src/test/rustdoc/intra-doc-crate/auxiliary/intra-doc-basic.rs
@@ -1,5 +1,5 @@
 #![crate_name = "a"]
-#![deny(intra_doc_link_resolution_failures)]
+#![deny(intra_doc_resolution_failures)]
 
 pub struct Foo;
 

--- a/src/test/rustdoc/intra-doc-crate/auxiliary/intra-doc-basic.rs
+++ b/src/test/rustdoc/intra-doc-crate/auxiliary/intra-doc-basic.rs
@@ -1,5 +1,5 @@
 #![crate_name = "a"]
-#![deny(intra_doc_link_resolution_failure)]
+#![deny(intra_doc_link_resolution_failures)]
 
 pub struct Foo;
 

--- a/src/test/rustdoc/intra-doc-crate/auxiliary/intra-doc-basic.rs
+++ b/src/test/rustdoc/intra-doc-crate/auxiliary/intra-doc-basic.rs
@@ -1,5 +1,5 @@
 #![crate_name = "a"]
-#![deny(intra_doc_resolution_failures)]
+#![deny(broken_intra_doc_links)]
 
 pub struct Foo;
 

--- a/src/test/rustdoc/intra-doc-crate/auxiliary/macro_inner.rs
+++ b/src/test/rustdoc/intra-doc-crate/auxiliary/macro_inner.rs
@@ -1,5 +1,5 @@
 #![crate_name = "macro_inner"]
-#![deny(intra_doc_resolution_failures)]
+#![deny(broken_intra_doc_links)]
 
 pub struct Foo;
 

--- a/src/test/rustdoc/intra-doc-crate/auxiliary/macro_inner.rs
+++ b/src/test/rustdoc/intra-doc-crate/auxiliary/macro_inner.rs
@@ -1,5 +1,5 @@
 #![crate_name = "macro_inner"]
-#![deny(intra_doc_link_resolution_failures)]
+#![deny(intra_doc_resolution_failures)]
 
 pub struct Foo;
 

--- a/src/test/rustdoc/intra-doc-crate/auxiliary/macro_inner.rs
+++ b/src/test/rustdoc/intra-doc-crate/auxiliary/macro_inner.rs
@@ -1,5 +1,5 @@
 #![crate_name = "macro_inner"]
-#![deny(intra_doc_link_resolution_failure)]
+#![deny(intra_doc_link_resolution_failures)]
 
 pub struct Foo;
 

--- a/src/test/rustdoc/intra-doc-crate/auxiliary/module.rs
+++ b/src/test/rustdoc/intra-doc-crate/auxiliary/module.rs
@@ -1,5 +1,5 @@
 #![crate_name = "module_inner"]
-#![deny(intra_doc_link_resolution_failure)]
+#![deny(intra_doc_link_resolution_failures)]
 /// [SomeType] links to [bar]
 pub struct SomeType;
 pub trait SomeTrait {}

--- a/src/test/rustdoc/intra-doc-crate/auxiliary/module.rs
+++ b/src/test/rustdoc/intra-doc-crate/auxiliary/module.rs
@@ -1,5 +1,5 @@
 #![crate_name = "module_inner"]
-#![deny(intra_doc_resolution_failures)]
+#![deny(broken_intra_doc_links)]
 /// [SomeType] links to [bar]
 pub struct SomeType;
 pub trait SomeTrait {}

--- a/src/test/rustdoc/intra-doc-crate/auxiliary/module.rs
+++ b/src/test/rustdoc/intra-doc-crate/auxiliary/module.rs
@@ -1,5 +1,5 @@
 #![crate_name = "module_inner"]
-#![deny(intra_doc_link_resolution_failures)]
+#![deny(intra_doc_resolution_failures)]
 /// [SomeType] links to [bar]
 pub struct SomeType;
 pub trait SomeTrait {}

--- a/src/test/rustdoc/intra-doc-crate/auxiliary/submodule-inner.rs
+++ b/src/test/rustdoc/intra-doc-crate/auxiliary/submodule-inner.rs
@@ -1,5 +1,5 @@
 #![crate_name = "a"]
-#![deny(intra_doc_resolution_failures)]
+#![deny(broken_intra_doc_links)]
 
 pub mod bar {
    pub struct Bar;

--- a/src/test/rustdoc/intra-doc-crate/auxiliary/submodule-inner.rs
+++ b/src/test/rustdoc/intra-doc-crate/auxiliary/submodule-inner.rs
@@ -1,5 +1,5 @@
 #![crate_name = "a"]
-#![deny(intra_doc_link_resolution_failures)]
+#![deny(intra_doc_resolution_failures)]
 
 pub mod bar {
    pub struct Bar;

--- a/src/test/rustdoc/intra-doc-crate/auxiliary/submodule-inner.rs
+++ b/src/test/rustdoc/intra-doc-crate/auxiliary/submodule-inner.rs
@@ -1,5 +1,5 @@
 #![crate_name = "a"]
-#![deny(intra_doc_link_resolution_failure)]
+#![deny(intra_doc_link_resolution_failures)]
 
 pub mod bar {
    pub struct Bar;

--- a/src/test/rustdoc/intra-doc-crate/auxiliary/submodule-outer.rs
+++ b/src/test/rustdoc/intra-doc-crate/auxiliary/submodule-outer.rs
@@ -1,5 +1,5 @@
 #![crate_name = "bar"]
-#![deny(intra_doc_link_resolution_failure)]
+#![deny(intra_doc_link_resolution_failures)]
 
 pub trait Foo {
     /// [`Bar`] [`Baz`]

--- a/src/test/rustdoc/intra-doc-crate/auxiliary/submodule-outer.rs
+++ b/src/test/rustdoc/intra-doc-crate/auxiliary/submodule-outer.rs
@@ -1,5 +1,5 @@
 #![crate_name = "bar"]
-#![deny(intra_doc_link_resolution_failures)]
+#![deny(intra_doc_resolution_failures)]
 
 pub trait Foo {
     /// [`Bar`] [`Baz`]

--- a/src/test/rustdoc/intra-doc-crate/auxiliary/submodule-outer.rs
+++ b/src/test/rustdoc/intra-doc-crate/auxiliary/submodule-outer.rs
@@ -1,5 +1,5 @@
 #![crate_name = "bar"]
-#![deny(intra_doc_resolution_failures)]
+#![deny(broken_intra_doc_links)]
 
 pub trait Foo {
     /// [`Bar`] [`Baz`]

--- a/src/test/rustdoc/intra-doc-crate/basic.rs
+++ b/src/test/rustdoc/intra-doc-crate/basic.rs
@@ -1,6 +1,6 @@
 // aux-build:intra-doc-basic.rs
 // build-aux-docs
-#![deny(intra_doc_link_resolution_failure)]
+#![deny(intra_doc_link_resolution_failures)]
 
 // from https://github.com/rust-lang/rust/issues/65983
 extern crate a;

--- a/src/test/rustdoc/intra-doc-crate/basic.rs
+++ b/src/test/rustdoc/intra-doc-crate/basic.rs
@@ -1,6 +1,6 @@
 // aux-build:intra-doc-basic.rs
 // build-aux-docs
-#![deny(intra_doc_resolution_failures)]
+#![deny(broken_intra_doc_links)]
 
 // from https://github.com/rust-lang/rust/issues/65983
 extern crate a;

--- a/src/test/rustdoc/intra-doc-crate/basic.rs
+++ b/src/test/rustdoc/intra-doc-crate/basic.rs
@@ -1,6 +1,6 @@
 // aux-build:intra-doc-basic.rs
 // build-aux-docs
-#![deny(intra_doc_link_resolution_failures)]
+#![deny(intra_doc_resolution_failures)]
 
 // from https://github.com/rust-lang/rust/issues/65983
 extern crate a;

--- a/src/test/rustdoc/intra-doc-crate/hidden.rs
+++ b/src/test/rustdoc/intra-doc-crate/hidden.rs
@@ -1,6 +1,6 @@
 // aux-build:hidden.rs
 // build-aux-docs
-#![deny(intra_doc_link_resolution_failures)]
+#![deny(intra_doc_resolution_failures)]
 
 // tests https://github.com/rust-lang/rust/issues/73363
 

--- a/src/test/rustdoc/intra-doc-crate/hidden.rs
+++ b/src/test/rustdoc/intra-doc-crate/hidden.rs
@@ -1,6 +1,6 @@
 // aux-build:hidden.rs
 // build-aux-docs
-#![deny(intra_doc_link_resolution_failure)]
+#![deny(intra_doc_link_resolution_failures)]
 
 // tests https://github.com/rust-lang/rust/issues/73363
 

--- a/src/test/rustdoc/intra-doc-crate/hidden.rs
+++ b/src/test/rustdoc/intra-doc-crate/hidden.rs
@@ -1,6 +1,6 @@
 // aux-build:hidden.rs
 // build-aux-docs
-#![deny(intra_doc_resolution_failures)]
+#![deny(broken_intra_doc_links)]
 
 // tests https://github.com/rust-lang/rust/issues/73363
 

--- a/src/test/rustdoc/intra-doc-crate/macro.rs
+++ b/src/test/rustdoc/intra-doc-crate/macro.rs
@@ -2,7 +2,7 @@
 // aux-build:macro_inner.rs
 // aux-build:proc_macro.rs
 // build-aux-docs
-#![deny(intra_doc_link_resolution_failure)]
+#![deny(intra_doc_link_resolution_failures)]
 extern crate macro_inner;
 extern crate proc_macro_inner;
 

--- a/src/test/rustdoc/intra-doc-crate/macro.rs
+++ b/src/test/rustdoc/intra-doc-crate/macro.rs
@@ -2,7 +2,7 @@
 // aux-build:macro_inner.rs
 // aux-build:proc_macro.rs
 // build-aux-docs
-#![deny(intra_doc_resolution_failures)]
+#![deny(broken_intra_doc_links)]
 extern crate macro_inner;
 extern crate proc_macro_inner;
 

--- a/src/test/rustdoc/intra-doc-crate/macro.rs
+++ b/src/test/rustdoc/intra-doc-crate/macro.rs
@@ -2,7 +2,7 @@
 // aux-build:macro_inner.rs
 // aux-build:proc_macro.rs
 // build-aux-docs
-#![deny(intra_doc_link_resolution_failures)]
+#![deny(intra_doc_resolution_failures)]
 extern crate macro_inner;
 extern crate proc_macro_inner;
 

--- a/src/test/rustdoc/intra-doc-crate/module.rs
+++ b/src/test/rustdoc/intra-doc-crate/module.rs
@@ -1,7 +1,7 @@
 // outer.rs
 // aux-build: module.rs
 // build-aux-docs
-#![deny(intra_doc_link_resolution_failures)]
+#![deny(intra_doc_resolution_failures)]
 extern crate module_inner;
 // @has 'module/bar/index.html' '//a[@href="../../module_inner/trait.SomeTrait.html"]' 'SomeTrait'
 // @has 'module/bar/index.html' '//a[@href="../../module_inner/struct.SomeType.html"]' 'SomeType'

--- a/src/test/rustdoc/intra-doc-crate/module.rs
+++ b/src/test/rustdoc/intra-doc-crate/module.rs
@@ -1,7 +1,7 @@
 // outer.rs
 // aux-build: module.rs
 // build-aux-docs
-#![deny(intra_doc_resolution_failures)]
+#![deny(broken_intra_doc_links)]
 extern crate module_inner;
 // @has 'module/bar/index.html' '//a[@href="../../module_inner/trait.SomeTrait.html"]' 'SomeTrait'
 // @has 'module/bar/index.html' '//a[@href="../../module_inner/struct.SomeType.html"]' 'SomeType'

--- a/src/test/rustdoc/intra-doc-crate/module.rs
+++ b/src/test/rustdoc/intra-doc-crate/module.rs
@@ -1,7 +1,7 @@
 // outer.rs
 // aux-build: module.rs
 // build-aux-docs
-#![deny(intra_doc_link_resolution_failure)]
+#![deny(intra_doc_link_resolution_failures)]
 extern crate module_inner;
 // @has 'module/bar/index.html' '//a[@href="../../module_inner/trait.SomeTrait.html"]' 'SomeTrait'
 // @has 'module/bar/index.html' '//a[@href="../../module_inner/struct.SomeType.html"]' 'SomeType'

--- a/src/test/rustdoc/intra-doc-crate/submodule-inner.rs
+++ b/src/test/rustdoc/intra-doc-crate/submodule-inner.rs
@@ -1,6 +1,6 @@
 // aux-build:submodule-inner.rs
 // build-aux-docs
-#![deny(intra_doc_link_resolution_failures)]
+#![deny(intra_doc_resolution_failures)]
 
 extern crate a;
 

--- a/src/test/rustdoc/intra-doc-crate/submodule-inner.rs
+++ b/src/test/rustdoc/intra-doc-crate/submodule-inner.rs
@@ -1,6 +1,6 @@
 // aux-build:submodule-inner.rs
 // build-aux-docs
-#![deny(intra_doc_resolution_failures)]
+#![deny(broken_intra_doc_links)]
 
 extern crate a;
 

--- a/src/test/rustdoc/intra-doc-crate/submodule-inner.rs
+++ b/src/test/rustdoc/intra-doc-crate/submodule-inner.rs
@@ -1,6 +1,6 @@
 // aux-build:submodule-inner.rs
 // build-aux-docs
-#![deny(intra_doc_link_resolution_failure)]
+#![deny(intra_doc_link_resolution_failures)]
 
 extern crate a;
 

--- a/src/test/rustdoc/intra-doc-crate/submodule-outer.rs
+++ b/src/test/rustdoc/intra-doc-crate/submodule-outer.rs
@@ -1,6 +1,6 @@
 // aux-build:submodule-outer.rs
 // edition:2018
-#![deny(intra_doc_resolution_failures)]
+#![deny(broken_intra_doc_links)]
 
 extern crate bar as bar_;
 

--- a/src/test/rustdoc/intra-doc-crate/submodule-outer.rs
+++ b/src/test/rustdoc/intra-doc-crate/submodule-outer.rs
@@ -1,6 +1,6 @@
 // aux-build:submodule-outer.rs
 // edition:2018
-#![deny(intra_doc_link_resolution_failures)]
+#![deny(intra_doc_resolution_failures)]
 
 extern crate bar as bar_;
 

--- a/src/test/rustdoc/intra-doc-crate/submodule-outer.rs
+++ b/src/test/rustdoc/intra-doc-crate/submodule-outer.rs
@@ -1,6 +1,6 @@
 // aux-build:submodule-outer.rs
 // edition:2018
-#![deny(intra_doc_link_resolution_failure)]
+#![deny(intra_doc_link_resolution_failures)]
 
 extern crate bar as bar_;
 

--- a/src/test/rustdoc/intra-doc-crate/traits.rs
+++ b/src/test/rustdoc/intra-doc-crate/traits.rs
@@ -3,7 +3,7 @@
 // aux-build:traits.rs
 // build-aux-docs
 // ignore-tidy-line-length
-#![deny(intra_doc_link_resolution_failures)]
+#![deny(intra_doc_resolution_failures)]
 
 extern crate inner;
 use inner::SomeTrait;

--- a/src/test/rustdoc/intra-doc-crate/traits.rs
+++ b/src/test/rustdoc/intra-doc-crate/traits.rs
@@ -3,7 +3,7 @@
 // aux-build:traits.rs
 // build-aux-docs
 // ignore-tidy-line-length
-#![deny(intra_doc_resolution_failures)]
+#![deny(broken_intra_doc_links)]
 
 extern crate inner;
 use inner::SomeTrait;

--- a/src/test/rustdoc/intra-doc-crate/traits.rs
+++ b/src/test/rustdoc/intra-doc-crate/traits.rs
@@ -3,7 +3,7 @@
 // aux-build:traits.rs
 // build-aux-docs
 // ignore-tidy-line-length
-#![deny(intra_doc_link_resolution_failure)]
+#![deny(intra_doc_link_resolution_failures)]
 
 extern crate inner;
 use inner::SomeTrait;

--- a/src/test/rustdoc/intra-doc-link-mod-ambiguity.rs
+++ b/src/test/rustdoc/intra-doc-link-mod-ambiguity.rs
@@ -1,6 +1,6 @@
 // ignore-tidy-linelength
 
-#![deny(intra_doc_resolution_failures)]
+#![deny(broken_intra_doc_links)]
 
 
 pub fn foo() {

--- a/src/test/rustdoc/intra-doc-link-mod-ambiguity.rs
+++ b/src/test/rustdoc/intra-doc-link-mod-ambiguity.rs
@@ -1,6 +1,6 @@
 // ignore-tidy-linelength
 
-#![deny(intra_doc_link_resolution_failures)]
+#![deny(intra_doc_resolution_failures)]
 
 
 pub fn foo() {

--- a/src/test/rustdoc/intra-doc-link-mod-ambiguity.rs
+++ b/src/test/rustdoc/intra-doc-link-mod-ambiguity.rs
@@ -1,6 +1,6 @@
 // ignore-tidy-linelength
 
-#![deny(intra_doc_link_resolution_failure)]
+#![deny(intra_doc_link_resolution_failures)]
 
 
 pub fn foo() {

--- a/src/test/rustdoc/intra-link-extern-crate.rs
+++ b/src/test/rustdoc/intra-link-extern-crate.rs
@@ -4,6 +4,6 @@
 // though they would never actually get displayed. This tripped intra-doc-link resolution failures,
 // for items that aren't under our control, and not actually getting documented!
 
-#![deny(intra_doc_link_resolution_failures)]
+#![deny(intra_doc_resolution_failures)]
 
 extern crate inner;

--- a/src/test/rustdoc/intra-link-extern-crate.rs
+++ b/src/test/rustdoc/intra-link-extern-crate.rs
@@ -4,6 +4,6 @@
 // though they would never actually get displayed. This tripped intra-doc-link resolution failures,
 // for items that aren't under our control, and not actually getting documented!
 
-#![deny(intra_doc_link_resolution_failure)]
+#![deny(intra_doc_link_resolution_failures)]
 
 extern crate inner;

--- a/src/test/rustdoc/intra-link-extern-crate.rs
+++ b/src/test/rustdoc/intra-link-extern-crate.rs
@@ -4,6 +4,6 @@
 // though they would never actually get displayed. This tripped intra-doc-link resolution failures,
 // for items that aren't under our control, and not actually getting documented!
 
-#![deny(intra_doc_resolution_failures)]
+#![deny(broken_intra_doc_links)]
 
 extern crate inner;

--- a/src/test/rustdoc/intra-link-in-bodies.rs
+++ b/src/test/rustdoc/intra-link-in-bodies.rs
@@ -1,6 +1,6 @@
 // we need to make sure that intra-doc links on trait impls get resolved in the right scope
 
-#![deny(intra_doc_link_resolution_failures)]
+#![deny(intra_doc_resolution_failures)]
 
 pub mod inner {
     pub struct SomethingOutOfScope;

--- a/src/test/rustdoc/intra-link-in-bodies.rs
+++ b/src/test/rustdoc/intra-link-in-bodies.rs
@@ -1,6 +1,6 @@
 // we need to make sure that intra-doc links on trait impls get resolved in the right scope
 
-#![deny(intra_doc_link_resolution_failure)]
+#![deny(intra_doc_link_resolution_failures)]
 
 pub mod inner {
     pub struct SomethingOutOfScope;

--- a/src/test/rustdoc/intra-link-in-bodies.rs
+++ b/src/test/rustdoc/intra-link-in-bodies.rs
@@ -1,6 +1,6 @@
 // we need to make sure that intra-doc links on trait impls get resolved in the right scope
 
-#![deny(intra_doc_resolution_failures)]
+#![deny(broken_intra_doc_links)]
 
 pub mod inner {
     pub struct SomethingOutOfScope;

--- a/src/test/rustdoc/intra-link-libstd-re-export.rs
+++ b/src/test/rustdoc/intra-link-libstd-re-export.rs
@@ -1,3 +1,3 @@
-#![deny(intra_doc_link_resolution_failure)]
+#![deny(intra_doc_link_resolution_failures)]
 
 pub use std::*;

--- a/src/test/rustdoc/intra-link-libstd-re-export.rs
+++ b/src/test/rustdoc/intra-link-libstd-re-export.rs
@@ -1,3 +1,3 @@
-#![deny(intra_doc_link_resolution_failures)]
+#![deny(intra_doc_resolution_failures)]
 
 pub use std::*;

--- a/src/test/rustdoc/intra-link-libstd-re-export.rs
+++ b/src/test/rustdoc/intra-link-libstd-re-export.rs
@@ -1,3 +1,3 @@
-#![deny(intra_doc_resolution_failures)]
+#![deny(broken_intra_doc_links)]
 
 pub use std::*;

--- a/src/test/rustdoc/intra-link-prim-methods-external-core.rs
+++ b/src/test/rustdoc/intra-link-prim-methods-external-core.rs
@@ -4,7 +4,7 @@
 // ignore-windows
 // ignore-tidy-linelength
 
-#![deny(intra_doc_link_resolution_failures)]
+#![deny(intra_doc_resolution_failures)]
 #![feature(no_core, lang_items)]
 #![no_core]
 #![crate_type = "rlib"]

--- a/src/test/rustdoc/intra-link-prim-methods-external-core.rs
+++ b/src/test/rustdoc/intra-link-prim-methods-external-core.rs
@@ -4,7 +4,7 @@
 // ignore-windows
 // ignore-tidy-linelength
 
-#![deny(intra_doc_resolution_failures)]
+#![deny(broken_intra_doc_links)]
 #![feature(no_core, lang_items)]
 #![no_core]
 #![crate_type = "rlib"]

--- a/src/test/rustdoc/intra-link-prim-methods-external-core.rs
+++ b/src/test/rustdoc/intra-link-prim-methods-external-core.rs
@@ -4,7 +4,7 @@
 // ignore-windows
 // ignore-tidy-linelength
 
-#![deny(intra_doc_link_resolution_failure)]
+#![deny(intra_doc_link_resolution_failures)]
 #![feature(no_core, lang_items)]
 #![no_core]
 #![crate_type = "rlib"]

--- a/src/test/rustdoc/intra-link-prim-methods-local.rs
+++ b/src/test/rustdoc/intra-link-prim-methods-local.rs
@@ -1,4 +1,4 @@
-#![deny(intra_doc_link_resolution_failure)]
+#![deny(intra_doc_link_resolution_failures)]
 #![feature(no_core, lang_items)]
 #![no_core]
 #![crate_type = "rlib"]

--- a/src/test/rustdoc/intra-link-prim-methods-local.rs
+++ b/src/test/rustdoc/intra-link-prim-methods-local.rs
@@ -1,4 +1,4 @@
-#![deny(intra_doc_resolution_failures)]
+#![deny(broken_intra_doc_links)]
 #![feature(no_core, lang_items)]
 #![no_core]
 #![crate_type = "rlib"]

--- a/src/test/rustdoc/intra-link-prim-methods-local.rs
+++ b/src/test/rustdoc/intra-link-prim-methods-local.rs
@@ -1,4 +1,4 @@
-#![deny(intra_doc_link_resolution_failures)]
+#![deny(intra_doc_resolution_failures)]
 #![feature(no_core, lang_items)]
 #![no_core]
 #![crate_type = "rlib"]

--- a/src/test/rustdoc/intra-link-prim-methods.rs
+++ b/src/test/rustdoc/intra-link-prim-methods.rs
@@ -1,4 +1,4 @@
-#![deny(intra_doc_resolution_failures)]
+#![deny(broken_intra_doc_links)]
 
 // ignore-tidy-linelength
 

--- a/src/test/rustdoc/intra-link-prim-methods.rs
+++ b/src/test/rustdoc/intra-link-prim-methods.rs
@@ -1,4 +1,4 @@
-#![deny(intra_doc_link_resolution_failure)]
+#![deny(intra_doc_link_resolution_failures)]
 
 // ignore-tidy-linelength
 

--- a/src/test/rustdoc/intra-link-prim-methods.rs
+++ b/src/test/rustdoc/intra-link-prim-methods.rs
@@ -1,4 +1,4 @@
-#![deny(intra_doc_link_resolution_failures)]
+#![deny(intra_doc_resolution_failures)]
 
 // ignore-tidy-linelength
 

--- a/src/test/rustdoc/intra-link-prim-precedence.rs
+++ b/src/test/rustdoc/intra-link-prim-precedence.rs
@@ -1,5 +1,5 @@
 // ignore-tidy-linelength
-#![deny(intra_doc_link_resolution_failure)]
+#![deny(intra_doc_link_resolution_failures)]
 
 pub mod char {}
 

--- a/src/test/rustdoc/intra-link-prim-precedence.rs
+++ b/src/test/rustdoc/intra-link-prim-precedence.rs
@@ -1,5 +1,5 @@
 // ignore-tidy-linelength
-#![deny(intra_doc_resolution_failures)]
+#![deny(broken_intra_doc_links)]
 
 pub mod char {}
 

--- a/src/test/rustdoc/intra-link-prim-precedence.rs
+++ b/src/test/rustdoc/intra-link-prim-precedence.rs
@@ -1,5 +1,5 @@
 // ignore-tidy-linelength
-#![deny(intra_doc_link_resolution_failures)]
+#![deny(intra_doc_resolution_failures)]
 
 pub mod char {}
 

--- a/src/test/rustdoc/intra-link-private.rs
+++ b/src/test/rustdoc/intra-link-private.rs
@@ -2,7 +2,7 @@
 // These failures were legitimate, but not truly relevant - the docs in question couldn't be
 // checked for accuracy anyway.
 
-#![deny(intra_doc_link_resolution_failures)]
+#![deny(intra_doc_resolution_failures)]
 
 /// ooh, i'm a [rebel] just for kicks
 struct SomeStruct;

--- a/src/test/rustdoc/intra-link-private.rs
+++ b/src/test/rustdoc/intra-link-private.rs
@@ -2,7 +2,7 @@
 // These failures were legitimate, but not truly relevant - the docs in question couldn't be
 // checked for accuracy anyway.
 
-#![deny(intra_doc_resolution_failures)]
+#![deny(broken_intra_doc_links)]
 
 /// ooh, i'm a [rebel] just for kicks
 struct SomeStruct;

--- a/src/test/rustdoc/intra-link-private.rs
+++ b/src/test/rustdoc/intra-link-private.rs
@@ -2,7 +2,7 @@
 // These failures were legitimate, but not truly relevant - the docs in question couldn't be
 // checked for accuracy anyway.
 
-#![deny(intra_doc_link_resolution_failure)]
+#![deny(intra_doc_link_resolution_failures)]
 
 /// ooh, i'm a [rebel] just for kicks
 struct SomeStruct;

--- a/src/test/rustdoc/intra-link-proc-macro.rs
+++ b/src/test/rustdoc/intra-link-proc-macro.rs
@@ -1,6 +1,6 @@
 // aux-build:intra-link-proc-macro-macro.rs
 // build-aux-docs
-#![deny(intra_doc_resolution_failures)]
+#![deny(broken_intra_doc_links)]
 
 extern crate intra_link_proc_macro_macro;
 

--- a/src/test/rustdoc/intra-link-proc-macro.rs
+++ b/src/test/rustdoc/intra-link-proc-macro.rs
@@ -1,6 +1,6 @@
 // aux-build:intra-link-proc-macro-macro.rs
 // build-aux-docs
-#![deny(intra_doc_link_resolution_failure)]
+#![deny(intra_doc_link_resolution_failures)]
 
 extern crate intra_link_proc_macro_macro;
 

--- a/src/test/rustdoc/intra-link-proc-macro.rs
+++ b/src/test/rustdoc/intra-link-proc-macro.rs
@@ -1,6 +1,6 @@
 // aux-build:intra-link-proc-macro-macro.rs
 // build-aux-docs
-#![deny(intra_doc_link_resolution_failures)]
+#![deny(intra_doc_resolution_failures)]
 
 extern crate intra_link_proc_macro_macro;
 

--- a/src/test/rustdoc/intra-links-external-traits.rs
+++ b/src/test/rustdoc/intra-links-external-traits.rs
@@ -2,7 +2,7 @@
 // ignore-cross-compile
 
 #![crate_name = "outer"]
-#![deny(intra_doc_link_resolution_failure)]
+#![deny(intra_doc_link_resolution_failures)]
 
 // using a trait that has intra-doc links on it from another crate (whether re-exporting or just
 // implementing it) used to give spurious resolution failure warnings

--- a/src/test/rustdoc/intra-links-external-traits.rs
+++ b/src/test/rustdoc/intra-links-external-traits.rs
@@ -2,7 +2,7 @@
 // ignore-cross-compile
 
 #![crate_name = "outer"]
-#![deny(intra_doc_resolution_failures)]
+#![deny(broken_intra_doc_links)]
 
 // using a trait that has intra-doc links on it from another crate (whether re-exporting or just
 // implementing it) used to give spurious resolution failure warnings

--- a/src/test/rustdoc/intra-links-external-traits.rs
+++ b/src/test/rustdoc/intra-links-external-traits.rs
@@ -2,7 +2,7 @@
 // ignore-cross-compile
 
 #![crate_name = "outer"]
-#![deny(intra_doc_link_resolution_failures)]
+#![deny(intra_doc_resolution_failures)]
 
 // using a trait that has intra-doc links on it from another crate (whether re-exporting or just
 // implementing it) used to give spurious resolution failure warnings

--- a/src/test/rustdoc/through-proc-macro.rs
+++ b/src/test/rustdoc/through-proc-macro.rs
@@ -1,6 +1,6 @@
 // aux-build:through-proc-macro-aux.rs
 // build-aux-docs
-#![warn(intra_doc_link_resolution_failure)]
+#![warn(intra_doc_link_resolution_failures)]
 extern crate some_macros;
 
 #[some_macros::second]

--- a/src/test/rustdoc/through-proc-macro.rs
+++ b/src/test/rustdoc/through-proc-macro.rs
@@ -1,6 +1,6 @@
 // aux-build:through-proc-macro-aux.rs
 // build-aux-docs
-#![warn(intra_doc_resolution_failures)]
+#![warn(broken_intra_doc_links)]
 extern crate some_macros;
 
 #[some_macros::second]

--- a/src/test/rustdoc/through-proc-macro.rs
+++ b/src/test/rustdoc/through-proc-macro.rs
@@ -1,6 +1,6 @@
 // aux-build:through-proc-macro-aux.rs
 // build-aux-docs
-#![warn(intra_doc_link_resolution_failures)]
+#![warn(intra_doc_resolution_failures)]
 extern crate some_macros;
 
 #[some_macros::second]


### PR DESCRIPTION
It should be plural to follow the conventions in https://github.com/rust-lang/rfcs/blob/master/text/0344-conventions-galore.md#lints