### PR TITLE
Make `mem::size_of_val` and `mem::align_of_val` unstably const

### DIFF
--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -1004,11 +1004,13 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is
     /// [`std::mem::size_of_val`](../../std/mem/fn.size_of_val.html).
+    #[rustc_const_unstable(feature = "const_size_of_val", issue = "46571")]
     pub fn size_of_val<T: ?Sized>(_: *const T) -> usize;
     /// The required alignment of the referenced value.
     ///
     /// The stabilized version of this intrinsic is
     /// [`std::mem::align_of_val`](../../std/mem/fn.align_of_val.html).
+    #[rustc_const_unstable(feature = "const_align_of_val", issue = "46571")]
     pub fn min_align_of_val<T: ?Sized>(_: *const T) -> usize;
 
     /// Gets a static string slice containing the name of a type.

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -88,6 +88,8 @@
 #![feature(const_result)]
 #![feature(const_slice_from_raw_parts)]
 #![feature(const_slice_ptr_len)]
+#![feature(const_size_of_val)]
+#![feature(const_align_of_val)]
 #![feature(const_type_name)]
 #![feature(const_likely)]
 #![feature(const_unreachable_unchecked)]

--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -332,7 +332,8 @@ pub const fn size_of<T>() -> usize {
 /// ```
 #[inline]
 #[stable(feature = "rust1", since = "1.0.0")]
-pub fn size_of_val<T: ?Sized>(val: &T) -> usize {
+#[rustc_const_unstable(feature = "const_size_of_val", issue = "46571")]
+pub const fn size_of_val<T: ?Sized>(val: &T) -> usize {
     intrinsics::size_of_val(val)
 }
 
@@ -466,9 +467,10 @@ pub const fn align_of<T>() -> usize {
 /// ```
 #[inline]
 #[stable(feature = "rust1", since = "1.0.0")]
+#[rustc_const_unstable(feature = "const_align_of_val", issue = "46571")]
 #[allow(deprecated)]
-pub fn align_of_val<T: ?Sized>(val: &T) -> usize {
-    min_align_of_val(val)
+pub const fn align_of_val<T: ?Sized>(val: &T) -> usize {
+    intrinsics::min_align_of_val(val)
 }
 
 /// Returns the [ABI]-required minimum alignment of the type of the value that `val` points to.

--- a/src/test/ui/consts/const-size_of_val-align_of_val-extern-type.rs
+++ b/src/test/ui/consts/const-size_of_val-align_of_val-extern-type.rs
@@ -1,0 +1,14 @@
+#![feature(extern_types)]
+#![feature(core_intrinsics)]
+#![feature(const_size_of_val, const_align_of_val)]
+
+use std::intrinsics::{size_of_val, min_align_of_val};
+
+extern {
+    type Opaque;
+}
+
+const _SIZE: usize = unsafe { size_of_val(&4 as *const i32 as *const Opaque) }; //~ ERROR
+const _ALIGN: usize = unsafe { min_align_of_val(&4 as *const i32 as *const Opaque) }; //~ ERROR
+
+fn main() {}

--- a/src/test/ui/consts/const-size_of_val-align_of_val-extern-type.stderr
+++ b/src/test/ui/consts/const-size_of_val-align_of_val-extern-type.stderr
@@ -1,0 +1,20 @@
+error: any use of this value will cause an error
+  --> $DIR/const-size_of_val-align_of_val-extern-type.rs:11:31
+   |
+LL | const _SIZE: usize = unsafe { size_of_val(&4 as *const i32 as *const Opaque) };
+   | ------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
+   |                               |
+   |                               `extern type` does not have known layout
+   |
+   = note: `#[deny(const_err)]` on by default
+
+error: any use of this value will cause an error
+  --> $DIR/const-size_of_val-align_of_val-extern-type.rs:12:32
+   |
+LL | const _ALIGN: usize = unsafe { min_align_of_val(&4 as *const i32 as *const Opaque) };
+   | -------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
+   |                                |
+   |                                `extern type` does not have known layout
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/consts/const-size_of_val-align_of_val.rs
+++ b/src/test/ui/consts/const-size_of_val-align_of_val.rs
@@ -1,0 +1,45 @@
+// run-pass
+
+#![feature(const_size_of_val, const_align_of_val)]
+
+use std::mem;
+
+struct Foo(u32);
+
+#[derive(Clone, Copy)]
+struct Bar {
+    _x: u8,
+    _y: u16,
+    _z: u8,
+}
+
+union Ugh {
+    _a: [u8; 3],
+    _b: Bar,
+}
+
+const FOO: Foo = Foo(4);
+const BAR: Bar = Bar { _x: 4, _y: 1, _z: 2 };
+const UGH: Ugh = Ugh { _a: [0; 3] };
+
+const SIZE_OF_FOO: usize = mem::size_of_val(&FOO);
+const SIZE_OF_BAR: usize = mem::size_of_val(&BAR);
+const SIZE_OF_UGH: usize = mem::size_of_val(&UGH);
+
+const ALIGN_OF_FOO: usize = mem::align_of_val(&FOO);
+const ALIGN_OF_BAR: usize = mem::align_of_val(&BAR);
+const ALIGN_OF_UGH: usize = mem::align_of_val(&UGH);
+
+const SIZE_OF_SLICE: usize = mem::size_of_val("foobar".as_bytes());
+
+fn main() {
+    assert_eq!(SIZE_OF_FOO, mem::size_of::<Foo>());
+    assert_eq!(SIZE_OF_BAR, mem::size_of::<Bar>());
+    assert_eq!(SIZE_OF_UGH, mem::size_of::<Ugh>());
+
+    assert_eq!(ALIGN_OF_FOO, mem::align_of::<Foo>());
+    assert_eq!(ALIGN_OF_BAR, mem::align_of::<Bar>());
+    assert_eq!(ALIGN_OF_UGH, mem::align_of::<Ugh>());
+
+    assert_eq!(SIZE_OF_SLICE, "foobar".len());
+}


### PR DESCRIPTION
Implements #46571 but does not stabilize it. I wanted this while working on something today.

The only reason not to immediately stabilize are concerns around [custom DSTs](https://github.com/rust-lang/rust/issues/46571#issuecomment-387669352). That proposal has made zero progress in the last two years and const eval is rich enough to support pretty much any user-defined `len` function as long as nightly features are allowed (`raw_ptr_deref`).

Currently, this raises a `const_err` lint when passed an `extern type`.

r? @oli-obk 

cc @rust-lang/wg-const-eval 