### PR TITLE
Improve diagnostics when constant pattern is too generic

### DIFF
--- a/src/test/ui/consts/issue-73976-polymorphic.rs
+++ b/src/test/ui/consts/issue-73976-polymorphic.rs
@@ -17,8 +17,8 @@ impl<T: 'static> GetTypeId<T> {
 
 const fn check_type_id<T: 'static>() -> bool {
     matches!(GetTypeId::<T>::VALUE, GetTypeId::<T>::VALUE)
-    //~^ ERROR could not evaluate constant pattern
-    //~| ERROR could not evaluate constant pattern
+    //~^ ERROR constant pattern depends on a generic parameter
+    //~| ERROR constant pattern depends on a generic parameter
 }
 
 pub struct GetTypeNameLen<T>(T);
@@ -29,8 +29,8 @@ impl<T: 'static> GetTypeNameLen<T> {
 
 const fn check_type_name_len<T: 'static>() -> bool {
     matches!(GetTypeNameLen::<T>::VALUE, GetTypeNameLen::<T>::VALUE)
-    //~^ ERROR could not evaluate constant pattern
-    //~| ERROR could not evaluate constant pattern
+    //~^ ERROR constant pattern depends on a generic parameter
+    //~| ERROR constant pattern depends on a generic parameter
 }
 
 fn main() {

--- a/src/test/ui/consts/issue-73976-polymorphic.stderr
+++ b/src/test/ui/consts/issue-73976-polymorphic.stderr
@@ -1,22 +1,22 @@
-error: could not evaluate constant pattern
+error: constant pattern depends on a generic parameter
   --> $DIR/issue-73976-polymorphic.rs:19:37
    |
 LL |     matches!(GetTypeId::<T>::VALUE, GetTypeId::<T>::VALUE)
    |                                     ^^^^^^^^^^^^^^^^^^^^^
 
-error: could not evaluate constant pattern
+error: constant pattern depends on a generic parameter
   --> $DIR/issue-73976-polymorphic.rs:31:42
    |
 LL |     matches!(GetTypeNameLen::<T>::VALUE, GetTypeNameLen::<T>::VALUE)
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: could not evaluate constant pattern
+error: constant pattern depends on a generic parameter
   --> $DIR/issue-73976-polymorphic.rs:19:37
    |
 LL |     matches!(GetTypeId::<T>::VALUE, GetTypeId::<T>::VALUE)
    |                                     ^^^^^^^^^^^^^^^^^^^^^
 
-error: could not evaluate constant pattern
+error: constant pattern depends on a generic parameter
   --> $DIR/issue-73976-polymorphic.rs:31:42
    |
 LL |     matches!(GetTypeNameLen::<T>::VALUE, GetTypeNameLen::<T>::VALUE)


### PR DESCRIPTION
This PR is a follow-up to PR #74538 and issue #73976 

When constants queries Layout, TypeId or type_name of a generic parameter, instead of emitting `could not evaluate constant pattern`, we will instead emit a more detailed message `constant pattern depends on a generic parameter`.