### PR TITLE
Make `<*const T>::is_null` const fn

### DIFF
--- a/library/core/src/ptr/const_ptr.rs
+++ b/library/core/src/ptr/const_ptr.rs
@@ -13,6 +13,15 @@ impl<T: ?Sized> *const T {
     /// Therefore, two pointers that are null may still not compare equal to
     /// each other.
     ///
+    /// ## Behavior during const evaluation
+    ///
+    /// When this function is used during const evaluation, it may return `false` for pointers
+    /// that turn out to be null at runtime. Specifically, when a pointer to some memory
+    /// is offset beyond its bounds in such a way that the resulting pointer is null,
+    /// the function will still return `false`. There is no way for CTFE to know
+    /// the absolute position of that memory, so we cannot tell if the pointer is
+    /// null or not.
+    ///
     /// # Examples
     ///
     /// Basic usage:
@@ -23,11 +32,12 @@ impl<T: ?Sized> *const T {
     /// assert!(!ptr.is_null());
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[rustc_const_unstable(feature = "const_ptr_is_null", issue = "74939")]
     #[inline]
-    pub fn is_null(self) -> bool {
+    pub const fn is_null(self) -> bool {
         // Compare via a cast to a thin pointer, so fat pointers are only
         // considering their "data" part for null-ness.
-        (self as *const u8) == null()
+        (self as *const u8).guaranteed_eq(null())
     }
 
     /// Casts to a pointer of another type.

--- a/library/core/src/ptr/mut_ptr.rs
+++ b/library/core/src/ptr/mut_ptr.rs
@@ -12,6 +12,15 @@ impl<T: ?Sized> *mut T {
     /// Therefore, two pointers that are null may still not compare equal to
     /// each other.
     ///
+    /// ## Behavior during const evaluation
+    ///
+    /// When this function is used during const evaluation, it may return `false` for pointers
+    /// that turn out to be null at runtime. Specifically, when a pointer to some memory
+    /// is offset beyond its bounds in such a way that the resulting pointer is null,
+    /// the function will still return `false`. There is no way for CTFE to know
+    /// the absolute position of that memory, so we cannot tell if the pointer is
+    /// null or not.
+    ///
     /// # Examples
     ///
     /// Basic usage:
@@ -22,11 +31,12 @@ impl<T: ?Sized> *mut T {
     /// assert!(!ptr.is_null());
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[rustc_const_unstable(feature = "const_ptr_is_null", issue = "74939")]
     #[inline]
-    pub fn is_null(self) -> bool {
+    pub const fn is_null(self) -> bool {
         // Compare via a cast to a thin pointer, so fat pointers are only
         // considering their "data" part for null-ness.
-        (self as *mut u8) == null_mut()
+        (self as *mut u8).guaranteed_eq(null_mut())
     }
 
     /// Casts to a pointer of another type.

--- a/src/test/ui/consts/ptr_comparisons.rs
+++ b/src/test/ui/consts/ptr_comparisons.rs
@@ -1,0 +1,74 @@
+// compile-flags: --crate-type=lib
+
+#![feature(
+    const_panic,
+    core_intrinsics,
+    const_raw_ptr_comparison,
+    const_ptr_offset,
+    const_raw_ptr_deref,
+    raw_ref_macros
+)]
+
+const FOO: &usize = &42;
+
+macro_rules! check {
+    (eq, $a:expr, $b:expr) => {
+        pub const _: () =
+            assert!(std::intrinsics::ptr_guaranteed_eq($a as *const u8, $b as *const u8));
+    };
+    (ne, $a:expr, $b:expr) => {
+        pub const _: () =
+            assert!(std::intrinsics::ptr_guaranteed_ne($a as *const u8, $b as *const u8));
+    };
+    (!eq, $a:expr, $b:expr) => {
+        pub const _: () =
+            assert!(!std::intrinsics::ptr_guaranteed_eq($a as *const u8, $b as *const u8));
+    };
+    (!ne, $a:expr, $b:expr) => {
+        pub const _: () =
+            assert!(!std::intrinsics::ptr_guaranteed_ne($a as *const u8, $b as *const u8));
+    };
+}
+
+check!(eq, 0, 0);
+check!(ne, 0, 1);
+check!(!eq, 0, 1);
+check!(!ne, 0, 0);
+check!(ne, FOO as *const _, 0);
+check!(!eq, FOO as *const _, 0);
+// We want pointers to be equal to themselves, but aren't checking this yet because
+// there are some open questions (e.g. whether function pointers to the same function
+// compare equal, they don't necessarily at runtime).
+// The case tested here should work eventually, but does not work yet.
+check!(!eq, FOO as *const _, FOO as *const _);
+check!(ne, unsafe { (FOO as *const usize).offset(1) }, 0);
+check!(!eq, unsafe { (FOO as *const usize).offset(1) }, 0);
+
+check!(ne, unsafe { (FOO as *const usize as *const u8).offset(3) }, 0);
+check!(!eq, unsafe { (FOO as *const usize as *const u8).offset(3) }, 0);
+
+///////////////////////////////////////////////////////////////////////////////
+// If any of the below start compiling, make sure to add a `check` test for it.
+// These invocations exist as canaries so we don't forget to check that the
+// behaviour of `guaranteed_eq` and `guaranteed_ne` is still correct.
+// All of these try to obtain an out of bounds pointer in some manner. If we
+// can create out of bounds pointers, we can offset a pointer far enough that
+// at runtime it would be zero and at compile-time it would not be zero.
+
+const _: *const usize = unsafe { (FOO as *const usize).offset(2) };
+//~^ NOTE
+
+const _: *const u8 =
+//~^ NOTE
+    unsafe { std::ptr::raw_const!((*(FOO as *const usize as *const [u8; 1000]))[999]) };
+//~^ ERROR any use of this value will cause an error
+
+const _: usize = unsafe { std::mem::transmute::<*const usize, usize>(FOO) + 4 };
+//~^ ERROR any use of this value will cause an error
+//~| NOTE "pointer-to-integer cast" needs an rfc
+//~| NOTE
+
+const _: usize = unsafe { *std::mem::transmute::<&&usize, &usize>(&FOO) + 4 };
+//~^ ERROR any use of this value will cause an error
+//~| NOTE "pointer-to-integer cast" needs an rfc
+//~| NOTE

--- a/src/test/ui/consts/ptr_comparisons.rs
+++ b/src/test/ui/consts/ptr_comparisons.rs
@@ -1,4 +1,8 @@
 // compile-flags: --crate-type=lib
+// normalize-stderr-32bit: "offset 8" -> "offset $$TWO_WORDS"
+// normalize-stderr-64bit: "offset 16" -> "offset $$TWO_WORDS"
+// normalize-stderr-32bit: "size 4" -> "size $$WORD"
+// normalize-stderr-64bit: "size 8" -> "size $$WORD"
 
 #![feature(
     const_panic,

--- a/src/test/ui/consts/ptr_comparisons.stderr
+++ b/src/test/ui/consts/ptr_comparisons.stderr
@@ -4,11 +4,11 @@ error: any use of this value will cause an error
 LL |         unsafe { intrinsics::offset(self, count) }
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |                  |
-   |                  inbounds test failed: pointer must be in-bounds at offset 16, but is outside bounds of alloc2 which has size 8
+   |                  inbounds test failed: pointer must be in-bounds at offset $TWO_WORDS, but is outside bounds of alloc2 which has size $WORD
    |                  inside `std::ptr::const_ptr::<impl *const usize>::offset` at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   |                  inside `_` at $DIR/ptr_comparisons.rs:58:34
+   |                  inside `_` at $DIR/ptr_comparisons.rs:62:34
    | 
-  ::: $DIR/ptr_comparisons.rs:58:1
+  ::: $DIR/ptr_comparisons.rs:62:1
    |
 LL | const _: *const usize = unsafe { (FOO as *const usize).offset(2) };
    | -------------------------------------------------------------------
@@ -16,19 +16,19 @@ LL | const _: *const usize = unsafe { (FOO as *const usize).offset(2) };
    = note: `#[deny(const_err)]` on by default
 
 error: any use of this value will cause an error
-  --> $DIR/ptr_comparisons.rs:63:14
+  --> $DIR/ptr_comparisons.rs:67:14
    |
 LL | / const _: *const u8 =
 LL | |
 LL | |     unsafe { std::ptr::raw_const!((*(FOO as *const usize as *const [u8; 1000]))[999]) };
    | |______________^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^__-
    |                |
-   |                memory access failed: pointer must be in-bounds at offset 1000, but is outside bounds of alloc2 which has size 8
+   |                memory access failed: pointer must be in-bounds at offset 1000, but is outside bounds of alloc2 which has size $WORD
    |
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: any use of this value will cause an error
-  --> $DIR/ptr_comparisons.rs:66:27
+  --> $DIR/ptr_comparisons.rs:70:27
    |
 LL | const _: usize = unsafe { std::mem::transmute::<*const usize, usize>(FOO) + 4 };
    | --------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
@@ -36,7 +36,7 @@ LL | const _: usize = unsafe { std::mem::transmute::<*const usize, usize>(FOO) +
    |                           "pointer-to-integer cast" needs an rfc before being allowed inside constants
 
 error: any use of this value will cause an error
-  --> $DIR/ptr_comparisons.rs:71:27
+  --> $DIR/ptr_comparisons.rs:75:27
    |
 LL | const _: usize = unsafe { *std::mem::transmute::<&&usize, &usize>(&FOO) + 4 };
    | --------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---

--- a/src/test/ui/consts/ptr_comparisons.stderr
+++ b/src/test/ui/consts/ptr_comparisons.stderr
@@ -1,0 +1,47 @@
+error: any use of this value will cause an error
+  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+   |
+LL |         unsafe { intrinsics::offset(self, count) }
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                  |
+   |                  inbounds test failed: pointer must be in-bounds at offset 16, but is outside bounds of alloc2 which has size 8
+   |                  inside `std::ptr::const_ptr::<impl *const usize>::offset` at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+   |                  inside `_` at $DIR/ptr_comparisons.rs:58:34
+   | 
+  ::: $DIR/ptr_comparisons.rs:58:1
+   |
+LL | const _: *const usize = unsafe { (FOO as *const usize).offset(2) };
+   | -------------------------------------------------------------------
+   |
+   = note: `#[deny(const_err)]` on by default
+
+error: any use of this value will cause an error
+  --> $DIR/ptr_comparisons.rs:63:14
+   |
+LL | / const _: *const u8 =
+LL | |
+LL | |     unsafe { std::ptr::raw_const!((*(FOO as *const usize as *const [u8; 1000]))[999]) };
+   | |______________^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^__-
+   |                |
+   |                memory access failed: pointer must be in-bounds at offset 1000, but is outside bounds of alloc2 which has size 8
+   |
+   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: any use of this value will cause an error
+  --> $DIR/ptr_comparisons.rs:66:27
+   |
+LL | const _: usize = unsafe { std::mem::transmute::<*const usize, usize>(FOO) + 4 };
+   | --------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
+   |                           |
+   |                           "pointer-to-integer cast" needs an rfc before being allowed inside constants
+
+error: any use of this value will cause an error
+  --> $DIR/ptr_comparisons.rs:71:27
+   |
+LL | const _: usize = unsafe { *std::mem::transmute::<&&usize, &usize>(&FOO) + 4 };
+   | --------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
+   |                           |
+   |                           "pointer-to-integer cast" needs an rfc before being allowed inside constants
+
+error: aborting due to 4 previous errors
+

--- a/src/test/ui/consts/ptr_is_null.rs
+++ b/src/test/ui/consts/ptr_is_null.rs
@@ -1,0 +1,16 @@
+// compile-flags: --crate-type=lib
+// check-pass
+
+#![feature(const_ptr_is_null, const_panic)]
+
+const FOO: &usize = &42;
+
+pub const _: () = assert!(!(FOO as *const usize).is_null());
+
+pub const _: () = assert!(!(42 as *const usize).is_null());
+
+pub const _: () = assert!((0 as *const usize).is_null());
+
+pub const _: () = assert!(std::ptr::null::<usize>().is_null());
+
+pub const _: () = assert!(!("foo" as *const str).is_null());


### PR DESCRIPTION
r? @RalfJung 

cc @rust-lang/wg-const-eval 

tracking issue: #74939 