### PR TITLE
Mutex and RwLock arc method

### DIFF
--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -320,6 +320,7 @@
 #![feature(unwind_attributes)]
 #![feature(vec_into_raw_parts)]
 #![feature(wake_trait)]
+#![feature(mutex_arc)]
 // NB: the above list is sorted to minimize merge conflicts.
 #![default_lib_allocator]
 

--- a/library/std/src/sync/mutex.rs
+++ b/library/std/src/sync/mutex.rs
@@ -6,6 +6,7 @@ use crate::fmt;
 use crate::mem;
 use crate::ops::{Deref, DerefMut};
 use crate::ptr;
+use crate::sync::Arc;
 use crate::sys_common::mutex as sys;
 use crate::sys_common::poison::{self, LockResult, TryLockError, TryLockResult};
 
@@ -227,6 +228,22 @@ impl<T> Mutex<T> {
             m.inner.init();
         }
         m
+    }
+
+    /// Creates a new mutex in an unlocked state ready for use, and wraps it in an [`Arc`].
+    ///
+    /// [`Arc`]: ../../std/sync/struct.Arc.html
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::sync::Mutex;
+    ///
+    /// let mutex = Mutex::arc(0);
+    /// ```
+    #[unstable(feature = "mutex_arc", issue = "74866")]
+    pub fn arc(t: T) -> Arc<Mutex<T>> {
+        Arc::new(Mutex::new(t))
     }
 }
 

--- a/library/std/src/sync/mutex/tests.rs
+++ b/library/std/src/sync/mutex/tests.rs
@@ -83,7 +83,7 @@ fn test_into_inner_drop() {
 
 #[test]
 fn test_into_inner_poison() {
-    let m = Arc::new(Mutex::new(NonCopy(10)));
+    let m = Mutex::arc(NonCopy(10));
     let m2 = m.clone();
     let _ = thread::spawn(move || {
         let _lock = m2.lock().unwrap();
@@ -107,7 +107,7 @@ fn test_get_mut() {
 
 #[test]
 fn test_get_mut_poison() {
-    let m = Arc::new(Mutex::new(NonCopy(10)));
+    let m = Mutex::arc(NonCopy(10));
     let m2 = m.clone();
     let _ = thread::spawn(move || {
         let _lock = m2.lock().unwrap();

--- a/library/std/src/sync/rwlock.rs
+++ b/library/std/src/sync/rwlock.rs
@@ -6,6 +6,7 @@ use crate::fmt;
 use crate::mem;
 use crate::ops::{Deref, DerefMut};
 use crate::ptr;
+use crate::sync::Arc;
 use crate::sys_common::poison::{self, LockResult, TryLockError, TryLockResult};
 use crate::sys_common::rwlock as sys;
 
@@ -133,6 +134,22 @@ impl<T> RwLock<T> {
             data: UnsafeCell::new(t),
         }
     }
+
+    /// Creates a new instance of an `RwLock<T>` which is unlocked, and wraps it in an [`Arc`].
+    ///
+    /// [`Arc`]: ../../std/sync/struct.Arc.html
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::sync::RwLock;
+    ///
+    /// let lock = RwLock::arc(5);
+    /// ```
+    #[unstable(feature = "mutex_arc", issue = "74866")]
+    pub fn arc(t: T) -> Arc<RwLock<T>> {
+        Arc::new(RwLock::new(t))
+    }
 }
 
 impl<T: ?Sized> RwLock<T> {
@@ -164,7 +181,7 @@ impl<T: ?Sized> RwLock<T> {
     /// use std::sync::{Arc, RwLock};
     /// use std::thread;
     ///
-    /// let lock = Arc::new(RwLock::new(1));
+    /// let lock = RwLock::arc(1);
     /// let c_lock = Arc::clone(&lock);
     ///
     /// let n = lock.read().unwrap();
@@ -320,7 +337,7 @@ impl<T: ?Sized> RwLock<T> {
     /// use std::sync::{Arc, RwLock};
     /// use std::thread;
     ///
-    /// let lock = Arc::new(RwLock::new(0));
+    /// let lock = RwLock::arc(0);
     /// let c_lock = Arc::clone(&lock);
     ///
     /// let _ = thread::spawn(move || {

--- a/library/std/src/sync/rwlock/tests.rs
+++ b/library/std/src/sync/rwlock/tests.rs
@@ -21,7 +21,7 @@ fn frob() {
     const N: u32 = 10;
     const M: usize = 1000;
 
-    let r = Arc::new(RwLock::new(()));
+    let r = RwLock::arc(());
 
     let (tx, rx) = channel::<()>();
     for _ in 0..N {


### PR DESCRIPTION
This PR adds convenient methods `Mutex::arc` and `RwLock::arc` according to https://github.com/rust-lang/rust/issues/74866

Updates all the test to use the new methods instead of the old `Arc::new(..)`