### PR TITLE
[mir] Special treatment for dereferencing a borrow to a static definition

### DIFF
--- a/src/librustc_mir/transform/promote_consts.rs
+++ b/src/librustc_mir/transform/promote_consts.rs
@@ -529,7 +529,9 @@ impl<'tcx> Validator<'_, 'tcx> {
                                         // https://github.com/rust-lang/rust/pull/74945#discussion_r463063247
                                         // There may be opportunity for generalization, but this needs to be
                                         // accounted for.
-                                        if proj_base.is_empty() && !self.tcx.is_thread_local_static(did) {
+                                        if proj_base.is_empty()
+                                            && !self.tcx.is_thread_local_static(did)
+                                        {
                                             not_promotable = false;
                                         }
                                     }

--- a/src/librustc_mir/transform/promote_consts.rs
+++ b/src/librustc_mir/transform/promote_consts.rs
@@ -526,7 +526,7 @@ impl<'tcx> Validator<'_, 'tcx> {
                                         // The reason is because promotion will be illegal if field
                                         // accesses preceed the dereferencing.
                                         // Discussion can be found at
-                                        // https://github.com/rust-lang/rust/pull/74945#discussion_r463063247 
+                                        // https://github.com/rust-lang/rust/pull/74945#discussion_r463063247
                                         // There may be opportunity for generalization, but this needs to be
                                         // accounted for.
                                         if proj_base.is_empty() && !self.tcx.is_thread_local_static(did) {

--- a/src/test/ui/statics/static-promotion.rs
+++ b/src/test/ui/statics/static-promotion.rs
@@ -12,12 +12,23 @@ struct A<T: 'static>(&'static T);
 struct B<T: 'static + ?Sized> {
     x: &'static T,
 }
+static STR: &'static [u8] = b"hi";
 static C: A<B<B<[u8]>>> = {
     A(&B {
-        x: &B { x: b"hi" as &[u8] },
+        x: &B { x: STR },
     })
 };
 
+pub struct Slice(&'static [i32]);
+
+static CONTENT: i32 = 42;
+pub static CONTENT_MAP: Slice = Slice(&[CONTENT]);
+
+pub static FOO: (i32, i32) = (42, 43);
+pub static CONTENT_MAP2: Slice = Slice(&[FOO.0]);
+
 fn main() {
     assert_eq!(b"hi", C.0.x.x);
+    assert_eq!(&[42], CONTENT_MAP.0);
+    assert_eq!(&[42], CONTENT_MAP2.0);
 }

--- a/src/test/ui/statics/static-promotion.rs
+++ b/src/test/ui/statics/static-promotion.rs
@@ -1,4 +1,12 @@
-// run-pass
+// check-pass
+
+// Use of global static variables in literal values should be allowed for
+// promotion.
+// This test is to demonstrate the issue raised in
+// https://github.com/rust-lang/rust/issues/70584
+
+// Literal values were previously promoted into local static values when
+// other global static variables are used.
 
 struct A<T: 'static>(&'static T);
 struct B<T: 'static + ?Sized> {

--- a/src/test/ui/statics/static-promotion.rs
+++ b/src/test/ui/statics/static-promotion.rs
@@ -1,0 +1,15 @@
+// run-pass
+
+struct A<T: 'static>(&'static T);
+struct B<T: 'static + ?Sized> {
+    x: &'static T,
+}
+static C: A<B<B<[u8]>>> = {
+    A(&B {
+        x: &B { x: b"hi" as &[u8] },
+    })
+};
+
+fn main() {
+    assert_eq!(b"hi", C.0.x.x);
+}


### PR DESCRIPTION
Fix #70584.

As suggested by @oli-obk in this [comment](https://github.com/rust-lang/rust/issues/70584#issuecomment-626009260), one can chase the definition of the local variable being de-referenced and check if it is a true static variable. If that is the case, `validate_place` will admit the promotion.

This is my first time to contribute to `rustc`, and I have two questions.
1. A generalization to some extent is applied to decide if the promotion is possible in the static context. In case that there are more projection operations preceding the de-referencing, `validate_place` recursively decent into inner projection operations. I have put thoughts into its correctness but I am not totally sure about it.
2. I have a hard time to find a good place for the test case. This patch has to do with MIR, but this test case would look out of place compared to other tests in `src/test/ui/mir` or `src/test/ui/borrowck` because it does not generate errors while others do. It is tentatively placed in `src/test/ui/statics` for now.

Thank you for any comments and suggestions!