### PR TITLE
Add `--output-format json` for Rustdoc on nightly

### DIFF
--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -508,7 +508,7 @@ impl Options {
         let output_format = match matches.opt_str("output-format") {
             Some(s) => match OutputFormat::try_from(s.as_str()) {
                 Ok(o) => {
-                    if o.is_json() && !show_coverage {
+                    if o.is_json() && !(show_coverage || nightly_options::is_nightly_build()) {
                         diag.struct_err("json output format isn't supported for doc generation")
                             .emit();
                         return Err(1);
@@ -626,7 +626,9 @@ fn check_deprecated_options(matches: &getopts::Matches, diag: &rustc_errors::Han
 
     for flag in deprecated_flags.iter() {
         if matches.opt_present(flag) {
-            if *flag == "output-format" && matches.opt_present("show-coverage") {
+            if *flag == "output-format"
+                && (matches.opt_present("show-coverage") || nightly_options::is_nightly_build())
+            {
                 continue;
             }
             let mut err =

--- a/src/librustdoc/json/mod.rs
+++ b/src/librustdoc/json/mod.rs
@@ -1,0 +1,47 @@
+use crate::clean;
+use crate::config::{RenderInfo, RenderOptions};
+use crate::error::Error;
+use crate::formats::cache::Cache;
+use crate::formats::FormatRenderer;
+
+use rustc_span::edition::Edition;
+
+#[derive(Clone)]
+pub struct JsonRenderer {}
+
+impl FormatRenderer for JsonRenderer {
+    fn init(
+        _krate: clean::Crate,
+        _options: RenderOptions,
+        _render_info: RenderInfo,
+        _edition: Edition,
+        _cache: &mut Cache,
+    ) -> Result<(Self, clean::Crate), Error> {
+        unimplemented!()
+    }
+
+    fn item(&mut self, _item: clean::Item, _cache: &Cache) -> Result<(), Error> {
+        unimplemented!()
+    }
+
+    fn mod_item_in(
+        &mut self,
+        _item: &clean::Item,
+        _item_name: &str,
+        _cache: &Cache,
+    ) -> Result<(), Error> {
+        unimplemented!()
+    }
+
+    fn mod_item_out(&mut self, _item_name: &str) -> Result<(), Error> {
+        unimplemented!()
+    }
+
+    fn after_krate(&mut self, _krate: &clean::Crate, _cache: &Cache) -> Result<(), Error> {
+        unimplemented!()
+    }
+
+    fn after_run(&mut self, _diag: &rustc_errors::Handler) -> Result<(), Error> {
+        unimplemented!()
+    }
+}


### PR DESCRIPTION
This enables the previously deprecated `--output-format` flag so it can be used on nightly to host the experimental implementation of [rfc/2963](https://github.com/rust-lang/rfcs/pull/2963). The actual implementation will come in later PRs so for now there's just a stub that gives you an ICE.

I'm _pretty_ sure that the logic I added makes it inaccessible from stable, but someone should double check that. @tmandry @jyn514 