### PR TITLE
Rollup of 9 pull requests

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,10 +1,12 @@
 Version 1.45.1 (2020-07-30)
 ==========================
 
+* [Fix const propagation with references.][73613]
 * [rustfmt accepts rustfmt_skip in cfg_attr again.][73078]
 * [Avoid spurious implicit region bound.][74509]
 * [Install clippy on x.py install][74457]
 
+[73613]: https://github.com/rust-lang/rust/pull/73613
 [73078]: https://github.com/rust-lang/rust/issues/73078
 [74509]: https://github.com/rust-lang/rust/pull/74509
 [74457]: https://github.com/rust-lang/rust/pull/74457

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,14 @@
+Version 1.45.1 (2020-07-30)
+==========================
+
+* [rustfmt accepts rustfmt_skip in cfg_attr again.][73078]
+* [Avoid spurious implicit region bound.][74509]
+* [Install clippy on x.py install][74457]
+
+[73078]: https://github.com/rust-lang/rust/issues/73078
+[74509]: https://github.com/rust-lang/rust/pull/74509
+[74457]: https://github.com/rust-lang/rust/pull/74457
+
 Version 1.45.0 (2020-07-16)
 ==========================
 

--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -1715,8 +1715,9 @@ impl<T> Weak<T> {
 
     /// Consumes the `Weak<T>` and turns it into a raw pointer.
     ///
-    /// This converts the weak pointer into a raw pointer, preserving the original weak count. It
-    /// can be turned back into the `Weak<T>` with [`from_raw`].
+    /// This converts the weak pointer into a raw pointer, while still preserving the ownership of
+    /// one weak reference (the weak count is not modified by this operation). It can be turned
+    /// back into the `Weak<T>` with [`from_raw`].
     ///
     /// The same restrictions of accessing the target of the pointer as with
     /// [`as_ptr`] apply.
@@ -1751,17 +1752,18 @@ impl<T> Weak<T> {
     /// This can be used to safely get a strong reference (by calling [`upgrade`]
     /// later) or to deallocate the weak count by dropping the `Weak<T>`.
     ///
-    /// It takes ownership of one weak count (with the exception of pointers created by [`new`],
-    /// as these don't have any corresponding weak count).
+    /// It takes ownership of one weak reference (with the exception of pointers created by [`new`],
+    /// as these don't own anything; the method still works on them).
     ///
     /// # Safety
     ///
-    /// The pointer must have originated from the [`into_raw`]  and must still own its potential
-    /// weak reference count.
+    /// The pointer must have originated from the [`into_raw`] and must still own its potential
+    /// weak reference.
     ///
-    /// It is allowed for the strong count to be 0 at the time of calling this, but the weak count
-    /// must be non-zero or the pointer must have originated from a dangling `Weak<T>` (one created
-    /// by [`new`]).
+    /// It is allowed for the strong count to be 0 at the time of calling this. Nevertheless, this
+    /// takes ownership of one weak reference currently represented as a raw pointer (the weak
+    /// count is not modified by this operation) and therefore it must be paired with a previous
+    /// call to [`into_raw`].
     ///
     /// # Examples
     ///

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -1485,8 +1485,9 @@ impl<T> Weak<T> {
 
     /// Consumes the `Weak<T>` and turns it into a raw pointer.
     ///
-    /// This converts the weak pointer into a raw pointer, preserving the original weak count. It
-    /// can be turned back into the `Weak<T>` with [`from_raw`].
+    /// This converts the weak pointer into a raw pointer, while still preserving the ownership of
+    /// one weak reference (the weak count is not modified by this operation). It can be turned
+    /// back into the `Weak<T>` with [`from_raw`].
     ///
     /// The same restrictions of accessing the target of the pointer as with
     /// [`as_ptr`] apply.
@@ -1516,24 +1517,23 @@ impl<T> Weak<T> {
         result
     }
 
-    /// Converts a raw pointer previously created by [`into_raw`] back into
-    /// `Weak<T>`.
+    /// Converts a raw pointer previously created by [`into_raw`] back into `Weak<T>`.
     ///
     /// This can be used to safely get a strong reference (by calling [`upgrade`]
     /// later) or to deallocate the weak count by dropping the `Weak<T>`.
     ///
-    /// It takes ownership of one weak count (with the exception of pointers created by [`new`],
-    /// as these don't have any corresponding weak count).
+    /// It takes ownership of one weak reference (with the exception of pointers created by [`new`],
+    /// as these don't own anything; the method still works on them).
     ///
     /// # Safety
     ///
     /// The pointer must have originated from the [`into_raw`] and must still own its potential
-    /// weak reference count.
+    /// weak reference.
     ///
-    /// It is allowed for the strong count to be 0 at the time of calling this, but the weak count
-    /// must be non-zero or the pointer must have originated from a dangling `Weak<T>` (one created
-    /// by [`new`]).
-    ///
+    /// It is allowed for the strong count to be 0 at the time of calling this. Nevertheless, this
+    /// takes ownership of one weak reference currently represented as a raw pointer (the weak
+    /// count is not modified by this operation) and therefore it must be paired with a previous
+    /// call to [`into_raw`].
     /// # Examples
     ///
     /// ```

--- a/src/ci/docker/host-x86_64/dist-x86_64-musl/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-x86_64-musl/Dockerfile
@@ -33,7 +33,6 @@ ENV HOSTS=x86_64-unknown-linux-musl
 ENV RUST_CONFIGURE_ARGS \
       --musl-root-x86_64=/usr/local/x86_64-linux-musl \
       --enable-extended \
-      --disable-docs \
       --enable-lld \
       --set target.x86_64-unknown-linux-musl.crt-static=false \
       --build $HOSTS

--- a/src/etc/test-float-parse/runtests.py
+++ b/src/etc/test-float-parse/runtests.py
@@ -195,9 +195,8 @@ def main():
     global MAILBOX
     tests = [os.path.splitext(f)[0] for f in glob('*.rs')
                                     if not f.startswith('_')]
-    listed = sys.argv[1:]
-    if listed:
-        tests = [test for test in tests if test in listed]
+    args = sys.argv[1:]
+    tests = [test for test in tests if test in args]
     if not tests:
         print("Error: No tests to run")
         sys.exit(1)

--- a/src/librustc_error_codes/error_codes/E0730.md
+++ b/src/librustc_error_codes/error_codes/E0730.md
@@ -14,14 +14,28 @@ fn is_123<const N: usize>(x: [u32; N]) -> bool {
 }
 ```
 
-Ensure that the pattern is consistent with the size of the matched array.
-Additional elements can be matched with `..`:
+To fix this error, you have two solutions:
+ 1. Use an array with a fixed length.
+ 2. Use a slice.
+
+Example with an array with a fixed length:
 
 ```
-let r = &[1, 2, 3, 4];
-match r {
-    &[a, b, ..] => { // ok!
-        println!("a={}, b={}", a, b);
+fn is_123(x: [u32; 3]) -> bool { // We use an array with a fixed size
+    match x {
+        [1, 2, ..] => true, // ok!
+        _ => false
+    }
+}
+```
+
+Example with a slice:
+
+```
+fn is_123(x: &[u32]) -> bool { // We use a slice
+    match x {
+        [1, 2, ..] => true, // ok!
+        _ => false
     }
 }
 ```

--- a/src/librustc_error_codes/error_codes/E0730.md
+++ b/src/librustc_error_codes/error_codes/E0730.md
@@ -1,6 +1,6 @@
 An array without a fixed length was pattern-matched.
 
-Example of erroneous code:
+Erroneous code example:
 
 ```compile_fail,E0730
 #![feature(const_generics)]
@@ -14,8 +14,8 @@ fn is_123<const N: usize>(x: [u32; N]) -> bool {
 }
 ```
 
-Ensure that the pattern is consistent with the size of the matched
-array. Additional elements can be matched with `..`:
+Ensure that the pattern is consistent with the size of the matched array.
+Additional elements can be matched with `..`:
 
 ```
 let r = &[1, 2, 3, 4];

--- a/src/librustc_error_codes/error_codes/E0734.md
+++ b/src/librustc_error_codes/error_codes/E0734.md
@@ -1,6 +1,6 @@
 A stability attribute has been used outside of the standard library.
 
-Erroneous code examples:
+Erroneous code example:
 
 ```compile_fail,E0734
 #[rustc_deprecated(since = "b", reason = "text")] // invalid

--- a/src/librustc_error_codes/error_codes/E0740.md
+++ b/src/librustc_error_codes/error_codes/E0740.md
@@ -1,4 +1,4 @@
-A `union` cannot have fields with destructors.
+A `union` was declared with fields with destructors.
 
 Erroneous code example:
 
@@ -14,3 +14,5 @@ impl Drop for A {
     fn drop(&mut self) { println!("A"); }
 }
 ```
+
+A `union` cannot have fields with destructors.

--- a/src/librustc_metadata/creader.rs
+++ b/src/librustc_metadata/creader.rs
@@ -236,9 +236,9 @@ impl<'a> CrateLoader<'a> {
                 // Only use `--extern crate_name=path` here, not `--extern crate_name`.
                 if let Some(mut files) = entry.files() {
                     if files.any(|l| {
-                        let l = fs::canonicalize(l).ok();
-                        source.dylib.as_ref().map(|p| &p.0) == l.as_ref()
-                            || source.rlib.as_ref().map(|p| &p.0) == l.as_ref()
+                        let l = fs::canonicalize(l).unwrap_or(l.clone().into());
+                        source.dylib.as_ref().map(|p| &p.0) == Some(&l)
+                            || source.rlib.as_ref().map(|p| &p.0) == Some(&l)
                     }) {
                         ret = Some(cnum);
                     }

--- a/src/librustc_session/filesearch.rs
+++ b/src/librustc_session/filesearch.rs
@@ -117,28 +117,22 @@ pub fn make_target_lib_path(sysroot: &Path, target_triple: &str) -> PathBuf {
 
 pub fn get_or_default_sysroot() -> PathBuf {
     // Follow symlinks.  If the resolved path is relative, make it absolute.
-    fn canonicalize(path: Option<PathBuf>) -> Option<PathBuf> {
-        path.and_then(|path| {
-            match fs::canonicalize(&path) {
-                // See comments on this target function, but the gist is that
-                // gcc chokes on verbatim paths which fs::canonicalize generates
-                // so we try to avoid those kinds of paths.
-                Ok(canon) => Some(fix_windows_verbatim_for_gcc(&canon)),
-                Err(e) => panic!("failed to get realpath: {}", e),
-            }
-        })
+    fn canonicalize(path: PathBuf) -> PathBuf {
+        let path = fs::canonicalize(&path).unwrap_or(path);
+        // See comments on this target function, but the gist is that
+        // gcc chokes on verbatim paths which fs::canonicalize generates
+        // so we try to avoid those kinds of paths.
+        fix_windows_verbatim_for_gcc(&path)
     }
 
     match env::current_exe() {
-        Ok(exe) => match canonicalize(Some(exe)) {
-            Some(mut p) => {
-                p.pop();
-                p.pop();
-                p
-            }
-            None => panic!("can't determine value for sysroot"),
-        },
-        Err(ref e) => panic!(format!("failed to get current_exe: {}", e)),
+        Ok(exe) => {
+            let mut p = canonicalize(exe);
+            p.pop();
+            p.pop();
+            p
+        }
+        Err(e) => panic!("failed to get current_exe: {}", e),
     }
 }
 

--- a/src/test/ui/consts/issue-73976-polymorphic.rs
+++ b/src/test/ui/consts/issue-73976-polymorphic.rs
@@ -17,8 +17,8 @@ impl<T: 'static> GetTypeId<T> {
 
 const fn check_type_id<T: 'static>() -> bool {
     matches!(GetTypeId::<T>::VALUE, GetTypeId::<T>::VALUE)
-    //~^ ERROR could not evaluate constant pattern
-    //~| ERROR could not evaluate constant pattern
+    //~^ ERROR constant pattern depends on a generic parameter
+    //~| ERROR constant pattern depends on a generic parameter
 }
 
 pub struct GetTypeNameLen<T>(T);
@@ -29,8 +29,8 @@ impl<T: 'static> GetTypeNameLen<T> {
 
 const fn check_type_name_len<T: 'static>() -> bool {
     matches!(GetTypeNameLen::<T>::VALUE, GetTypeNameLen::<T>::VALUE)
-    //~^ ERROR could not evaluate constant pattern
-    //~| ERROR could not evaluate constant pattern
+    //~^ ERROR constant pattern depends on a generic parameter
+    //~| ERROR constant pattern depends on a generic parameter
 }
 
 fn main() {

--- a/src/test/ui/consts/issue-73976-polymorphic.stderr
+++ b/src/test/ui/consts/issue-73976-polymorphic.stderr
@@ -1,22 +1,22 @@
-error: could not evaluate constant pattern
+error: constant pattern depends on a generic parameter
   --> $DIR/issue-73976-polymorphic.rs:19:37
    |
 LL |     matches!(GetTypeId::<T>::VALUE, GetTypeId::<T>::VALUE)
    |                                     ^^^^^^^^^^^^^^^^^^^^^
 
-error: could not evaluate constant pattern
+error: constant pattern depends on a generic parameter
   --> $DIR/issue-73976-polymorphic.rs:31:42
    |
 LL |     matches!(GetTypeNameLen::<T>::VALUE, GetTypeNameLen::<T>::VALUE)
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: could not evaluate constant pattern
+error: constant pattern depends on a generic parameter
   --> $DIR/issue-73976-polymorphic.rs:19:37
    |
 LL |     matches!(GetTypeId::<T>::VALUE, GetTypeId::<T>::VALUE)
    |                                     ^^^^^^^^^^^^^^^^^^^^^
 
-error: could not evaluate constant pattern
+error: constant pattern depends on a generic parameter
   --> $DIR/issue-73976-polymorphic.rs:31:42
    |
 LL |     matches!(GetTypeNameLen::<T>::VALUE, GetTypeNameLen::<T>::VALUE)


### PR DESCRIPTION
Successful merges:

 - #74751 (Clean up E0730 explanation)
 - #74782 (Don't use "weak count" around Weak::from_raw_ptr)
 - #74835 (Clean up E0734 explanation)
 - #74871 (Enable docs on dist-x86_64-musl)
 - #74905 (Avoid bool-like naming)
 - #74907 (Clean up E0740 explanation)
 - #74915 (rustc: Ignore fs::canonicalize errors in metadata)
 - #74934 (Improve diagnostics when constant pattern is too generic)
 - #74951 (Cherry-pick the release notes for 1.45.1)

Failed merges:


r? @ghost