### PR TITLE
[beta] Make ClashingExternDeclarations Allow by default.

### DIFF
--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -2051,7 +2051,7 @@ impl<'tcx> LateLintPass<'tcx> for InvalidValue {
 
 declare_lint! {
     pub CLASHING_EXTERN_DECLARATIONS,
-    Warn,
+    Allow,
     "detects when an extern fn has been declared with the same name but different types"
 }
 


### PR DESCRIPTION
As per https://github.com/rust-lang/rust/pull/73990#issuecomment-666457338, this PR changes `clashing_extern_declarations` to allow-by-default to sidestep current false positives & negatives on the beta branch.

Note that the changes to fix the issue properly have been merged to master (see #73990), but those changes will have to arrive on the next release train.