### PR TITLE
Remove `GCX_PTR`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3677,7 +3677,6 @@ dependencies = [
  "rustc_session",
  "rustc_span",
  "rustc_target",
- "scoped-tls",
  "smallvec 1.4.0",
  "tracing",
 ]

--- a/src/librustc_infer/infer/canonical/canonicalizer.rs
+++ b/src/librustc_infer/infer/canonical/canonicalizer.rs
@@ -199,8 +199,8 @@ impl CanonicalizeRegionMode for CanonicalizeQueryResponse {
                 // rust-lang/rust#57464: `impl Trait` can leak local
                 // scopes (in manner violating typeck). Therefore, use
                 // `delay_span_bug` to allow type error over an ICE.
-                ty::tls::with_context(|c| {
-                    c.tcx.sess.delay_span_bug(
+                ty::tls::with(|tcx| {
+                    tcx.sess.delay_span_bug(
                         rustc_span::DUMMY_SP,
                         &format!("unexpected region in query response: `{:?}`", r),
                     );

--- a/src/librustc_middle/Cargo.toml
+++ b/src/librustc_middle/Cargo.toml
@@ -12,7 +12,6 @@ doctest = false
 [dependencies]
 rustc_arena = { path = "../librustc_arena" }
 bitflags = "1.2.1"
-scoped-tls = "1.0"
 log = { package = "tracing", version = "0.1" }
 rustc-rayon-core = "0.3.0"
 polonius-engine = "0.12.0"

--- a/src/librustc_middle/lib.rs
+++ b/src/librustc_middle/lib.rs
@@ -55,8 +55,6 @@
 #[macro_use]
 extern crate bitflags;
 #[macro_use]
-extern crate scoped_tls;
-#[macro_use]
 extern crate rustc_macros;
 #[macro_use]
 extern crate rustc_data_structures;

--- a/src/librustc_middle/mir/interpret/error.rs
+++ b/src/librustc_middle/mir/interpret/error.rs
@@ -242,9 +242,9 @@ impl From<ErrorHandled> for InterpErrorInfo<'_> {
 
 impl<'tcx> From<InterpError<'tcx>> for InterpErrorInfo<'tcx> {
     fn from(kind: InterpError<'tcx>) -> Self {
-        let capture_backtrace = tls::with_context_opt(|ctxt| {
-            if let Some(ctxt) = ctxt {
-                *Lock::borrow(&ctxt.tcx.sess.ctfe_backtrace)
+        let capture_backtrace = tls::with_opt(|tcx| {
+            if let Some(tcx) = tcx {
+                *Lock::borrow(&tcx.sess.ctfe_backtrace)
             } else {
                 CtfeBacktrace::Disabled
             }

--- a/src/librustc_middle/ty/query/job.rs
+++ b/src/librustc_middle/ty/query/job.rs
@@ -10,18 +10,21 @@ use std::thread;
 pub unsafe fn handle_deadlock() {
     let registry = rayon_core::Registry::current();
 
-    let gcx_ptr = tls::GCX_PTR.with(|gcx_ptr| gcx_ptr as *const _);
-    let gcx_ptr = &*gcx_ptr;
+    let context = tls::get_tlv();
+    assert!(context != 0);
+    rustc_data_structures::sync::assert_sync::<tls::ImplicitCtxt<'_, '_>>();
+    let icx: &tls::ImplicitCtxt<'_, '_> = &*(context as *const tls::ImplicitCtxt<'_, '_>);
 
     let span_session_globals = rustc_span::SESSION_GLOBALS.with(|ssg| ssg as *const _);
     let span_session_globals = &*span_session_globals;
     let ast_session_globals = rustc_ast::attr::SESSION_GLOBALS.with(|asg| asg as *const _);
     let ast_session_globals = &*ast_session_globals;
     thread::spawn(move || {
-        tls::GCX_PTR.set(gcx_ptr, || {
+        tls::enter_context(icx, |_| {
             rustc_ast::attr::SESSION_GLOBALS.set(ast_session_globals, || {
-                rustc_span::SESSION_GLOBALS
-                    .set(span_session_globals, || tls::with_global(|tcx| deadlock(tcx, &registry)))
+                rustc_span::SESSION_GLOBALS.set(span_session_globals, || {
+                    tls::with_context(|icx| deadlock(icx.tcx, &registry))
+                })
             });
         })
     });

--- a/src/librustc_middle/ty/query/job.rs
+++ b/src/librustc_middle/ty/query/job.rs
@@ -22,9 +22,8 @@ pub unsafe fn handle_deadlock() {
     thread::spawn(move || {
         tls::enter_context(icx, |_| {
             rustc_ast::attr::SESSION_GLOBALS.set(ast_session_globals, || {
-                rustc_span::SESSION_GLOBALS.set(span_session_globals, || {
-                    tls::with_context(|icx| deadlock(icx.tcx, &registry))
-                })
+                rustc_span::SESSION_GLOBALS
+                    .set(span_session_globals, || tls::with(|tcx| deadlock(tcx, &registry)))
             });
         })
     });


### PR DESCRIPTION
We store an `ImplicitCtxt` pointer in a thread-local value (TLV). This allows
implicit access to a `GlobalCtxt` and some other things.

We also store a `GlobalCtxt` pointer in `GCX_PTR`. This is always the same
`GlobalCtxt` as the one within the `ImplicitCtxt` pointer in TLV. `GCX_PTR`
is only used in the parallel compiler's `handle_deadlock()` function.

This commit does the following.
- It removes `GCX_PTR`.
- It also adds `ImplicitCtxt::new()`, which constructs an `ImplicitCtxt` from a
  `GlobalCtxt`. `ImplicitCtxt::new()` + `tls::enter_context()` is now
  equivalent to the old `tls::enter_global()`.
- Makes `tls::get_tlv()` public for the parallel compiler, because it's
  now used in `handle_deadlock()`.

r? @petrochenkov 