### PR TITLE
Fix Const-Generic Cycle ICE #74199

### DIFF
--- a/src/librustc_typeck/variance/constraints.rs
+++ b/src/librustc_typeck/variance/constraints.rs
@@ -161,7 +161,13 @@ impl<'a, 'tcx> ConstraintContext<'a, 'tcx> {
                 self.add_constraints_from_sig(current_item, tcx.fn_sig(def_id), self.covariant);
             }
 
-            _ => {}
+            ty::Error(_) => {}
+            _ => {
+                span_bug!(
+                    tcx.def_span(def_id),
+                    "`build_constraints_for_item` unsupported for this item"
+                );
+            }
         }
     }
 

--- a/src/librustc_typeck/variance/constraints.rs
+++ b/src/librustc_typeck/variance/constraints.rs
@@ -161,12 +161,7 @@ impl<'a, 'tcx> ConstraintContext<'a, 'tcx> {
                 self.add_constraints_from_sig(current_item, tcx.fn_sig(def_id), self.covariant);
             }
 
-            _ => {
-                span_bug!(
-                    tcx.def_span(def_id),
-                    "`build_constraints_for_item` unsupported for this item"
-                );
-            }
+            _ => {}
         }
     }
 

--- a/src/test/ui/const-generics/nested-type.rs
+++ b/src/test/ui/const-generics/nested-type.rs
@@ -1,0 +1,18 @@
+#![feature(const_generics)]
+#![allow(incomplete_features)]
+
+struct Foo<const N: [u8; {
+//~^ ERROR cycle detected
+//~| ERROR cycle detected
+    struct Foo<const N: usize>;
+
+    impl<const N: usize> Foo<N> {
+        fn value() -> usize {
+            N
+        }
+    }
+
+    Foo::<17>::value()
+}]>;
+
+fn main() {}

--- a/src/test/ui/const-generics/nested-type.stderr
+++ b/src/test/ui/const-generics/nested-type.stderr
@@ -1,0 +1,159 @@
+error[E0391]: cycle detected when computing type of `Foo`
+  --> $DIR/nested-type.rs:4:1
+   |
+LL | struct Foo<const N: [u8; {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: ...which requires computing type of `Foo::N`...
+  --> $DIR/nested-type.rs:4:18
+   |
+LL | struct Foo<const N: [u8; {
+   |                  ^
+note: ...which requires const-evaluating + checking `Foo::{{constant}}#0`...
+  --> $DIR/nested-type.rs:4:26
+   |
+LL |   struct Foo<const N: [u8; {
+   |  __________________________^
+LL | |
+LL | |
+LL | |     struct Foo<const N: usize>;
+...  |
+LL | |     Foo::<17>::value()
+LL | | }]>;
+   | |_^
+note: ...which requires const-evaluating + checking `Foo::{{constant}}#0`...
+  --> $DIR/nested-type.rs:4:26
+   |
+LL |   struct Foo<const N: [u8; {
+   |  __________________________^
+LL | |
+LL | |
+LL | |     struct Foo<const N: usize>;
+...  |
+LL | |     Foo::<17>::value()
+LL | | }]>;
+   | |_^
+note: ...which requires const-evaluating `Foo::{{constant}}#0`...
+  --> $DIR/nested-type.rs:4:26
+   |
+LL |   struct Foo<const N: [u8; {
+   |  __________________________^
+LL | |
+LL | |
+LL | |     struct Foo<const N: usize>;
+...  |
+LL | |     Foo::<17>::value()
+LL | | }]>;
+   | |_^
+note: ...which requires type-checking `Foo::{{constant}}#0`...
+  --> $DIR/nested-type.rs:4:26
+   |
+LL |   struct Foo<const N: [u8; {
+   |  __________________________^
+LL | |
+LL | |
+LL | |     struct Foo<const N: usize>;
+...  |
+LL | |     Foo::<17>::value()
+LL | | }]>;
+   | |_^
+note: ...which requires computing the variances of `Foo::{{constant}}#0::Foo`...
+  --> $DIR/nested-type.rs:7:5
+   |
+LL |     struct Foo<const N: usize>;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: ...which requires computing the variances for items in this crate...
+   = note: ...which again requires computing type of `Foo`, completing the cycle
+note: cycle used when collecting item types in top-level module
+  --> $DIR/nested-type.rs:1:1
+   |
+LL | / #![feature(const_generics)]
+LL | | #![allow(incomplete_features)]
+LL | |
+LL | | struct Foo<const N: [u8; {
+...  |
+LL | |
+LL | | fn main() {}
+   | |____________^
+
+error[E0391]: cycle detected when computing type of `Foo`
+  --> $DIR/nested-type.rs:4:1
+   |
+LL | struct Foo<const N: [u8; {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: ...which requires computing type of `Foo::N`...
+  --> $DIR/nested-type.rs:4:18
+   |
+LL | struct Foo<const N: [u8; {
+   |                  ^
+note: ...which requires const-evaluating + checking `Foo::{{constant}}#0`...
+  --> $DIR/nested-type.rs:4:26
+   |
+LL |   struct Foo<const N: [u8; {
+   |  __________________________^
+LL | |
+LL | |
+LL | |     struct Foo<const N: usize>;
+...  |
+LL | |     Foo::<17>::value()
+LL | | }]>;
+   | |_^
+note: ...which requires const-evaluating + checking `Foo::{{constant}}#0`...
+  --> $DIR/nested-type.rs:4:26
+   |
+LL |   struct Foo<const N: [u8; {
+   |  __________________________^
+LL | |
+LL | |
+LL | |     struct Foo<const N: usize>;
+...  |
+LL | |     Foo::<17>::value()
+LL | | }]>;
+   | |_^
+note: ...which requires const-evaluating `Foo::{{constant}}#0`...
+  --> $DIR/nested-type.rs:4:26
+   |
+LL |   struct Foo<const N: [u8; {
+   |  __________________________^
+LL | |
+LL | |
+LL | |     struct Foo<const N: usize>;
+...  |
+LL | |     Foo::<17>::value()
+LL | | }]>;
+   | |_^
+note: ...which requires type-checking `Foo::{{constant}}#0`...
+  --> $DIR/nested-type.rs:4:26
+   |
+LL |   struct Foo<const N: [u8; {
+   |  __________________________^
+LL | |
+LL | |
+LL | |     struct Foo<const N: usize>;
+...  |
+LL | |     Foo::<17>::value()
+LL | | }]>;
+   | |_^
+note: ...which requires computing the variances of `Foo::{{constant}}#0::Foo`...
+  --> $DIR/nested-type.rs:7:5
+   |
+LL |     struct Foo<const N: usize>;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: ...which requires computing the variances for items in this crate...
+   = note: ...which again requires computing type of `Foo`, completing the cycle
+note: cycle used when collecting item types in top-level module
+  --> $DIR/nested-type.rs:1:1
+   |
+LL | / #![feature(const_generics)]
+LL | | #![allow(incomplete_features)]
+LL | |
+LL | | struct Foo<const N: [u8; {
+...  |
+LL | |
+LL | | fn main() {}
+   | |____________^
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0391`.


### PR DESCRIPTION
This PR intends to fix the bug in Issue #74199 by following the suggestion provided of ignoring the error that causes the ICE.

This does not fix the underlying cycle detection issue, but fixes the ICE.
Also adds a test to check that it doesn't causes an ICE but returns a valid error for now.

r? @lcnr 

Edit: Also it's funny how this PR number is an anagram of the issue number