### PR TITLE
Update the WASI libc build to LLVM 10.

### DIFF
--- a/src/ci/docker/host-x86_64/dist-various-2/build-wasi-toolchain.sh
+++ b/src/ci/docker/host-x86_64/dist-various-2/build-wasi-toolchain.sh
@@ -4,10 +4,10 @@
 
 set -ex
 
-# Originally from https://releases.llvm.org/9.0.0/clang+llvm-9.0.0-x86_64-linux-gnu-ubuntu-14.04.tar.xz
-curl https://ci-mirrors.rust-lang.org/rustc/clang%2Bllvm-9.0.0-x86_64-linux-gnu-ubuntu-14.04.tar.xz | \
+# Originally from https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.0/clang+llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz
+curl https://ci-mirrors.rust-lang.org/rustc/clang%2Bllvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz | \
   tar xJf -
-export PATH=`pwd`/clang+llvm-9.0.0-x86_64-linux-gnu-ubuntu-14.04/bin:$PATH
+export PATH=`pwd`/clang+llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04/bin:$PATH
 
 git clone https://github.com/CraneStation/wasi-libc
 


### PR DESCRIPTION
Among other things, this brings in [the `__main_argc_argv`] patch,
which simplifies the interaction between the compiler and WASI libc's
startup code, which will help work on reactor support.

[the `__main_argc_argv` patch]: https://github.com/llvm/llvm-project/commit/00072c08c75050ae2c835b7bb0e505475dbcd7b9

r? @alexcrichton 