### PR TITLE
Use a slice pattern instead of rchunks_exact(_).next()

### DIFF
--- a/src/librustc_privacy/lib.rs
+++ b/src/librustc_privacy/lib.rs
@@ -637,7 +637,7 @@ impl EmbargoVisitor<'tcx> {
         &mut self,
         segments: &[hir::PathSegment<'_>],
     ) {
-        if let Some([module, segment]) = segments.rchunks_exact(2).next() {
+        if let [.., module, segment] = segments {
             if let Some(item) = module
                 .res
                 .and_then(|res| res.mod_def_id())


### PR DESCRIPTION
This is a minor cleanup, but trying a single-use `rchunks` iterator can
be more directly matched with a slice pattern, `[.., a, b]`.