### PR TITLE
Document that slice refers to any pointer type to a sequence

### DIFF
--- a/library/std/src/primitive_docs.rs
+++ b/library/std/src/primitive_docs.rs
@@ -565,8 +565,8 @@ mod prim_array {}
 ///
 /// *[See also the `std::slice` module](slice/index.html).*
 ///
-/// Slices are a view into a block of memory represented as a pointer and a
-/// length.
+/// A slice is any pointer/reference to a block of memory. They are represented
+/// as a regular pointer and a length.
 ///
 /// ```
 /// // slicing a Vec
@@ -586,6 +586,19 @@ mod prim_array {}
 /// let x = &mut x[..]; // Take a full slice of `x`.
 /// x[1] = 7;
 /// assert_eq!(x, &[1, 7, 3]);
+/// ```
+///
+/// As slices store the length of the sequence they refer to, they have twice
+/// the size of pointers to [`Sized`](marker/trait.Sized.html) types.
+/// Also see the reference on
+/// [dynamically sized types](../reference/dynamically-sized-types.html)
+///
+/// ```
+/// let pointer_size = std::mem::size_of::<&u8>();
+/// assert_eq!(2 * pointer_size, std::mem::size_of::<&[u8]>());
+/// assert_eq!(2 * pointer_size, std::mem::size_of::<*const [u8]>());
+/// assert_eq!(2 * pointer_size, std::mem::size_of::<Box<[u8]>>());
+/// assert_eq!(2 * pointer_size, std::mem::size_of::<Rc<[u8]>>());
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 mod prim_slice {}

--- a/library/std/src/primitive_docs.rs
+++ b/library/std/src/primitive_docs.rs
@@ -594,6 +594,7 @@ mod prim_array {}
 /// [dynamically sized types](../reference/dynamically-sized-types.html).
 ///
 /// ```
+/// # use std::rc::Rc;
 /// let pointer_size = std::mem::size_of::<&u8>();
 /// assert_eq!(2 * pointer_size, std::mem::size_of::<&[u8]>());
 /// assert_eq!(2 * pointer_size, std::mem::size_of::<*const [u8]>());

--- a/library/std/src/primitive_docs.rs
+++ b/library/std/src/primitive_docs.rs
@@ -565,8 +565,8 @@ mod prim_array {}
 ///
 /// *[See also the `std::slice` module](slice/index.html).*
 ///
-/// A slice is any pointer/reference to a block of memory. They are represented
-/// as a regular pointer and a length.
+/// Slices are a view into a block of memory represented as a pointer and a
+/// length.
 ///
 /// ```
 /// // slicing a Vec

--- a/library/std/src/primitive_docs.rs
+++ b/library/std/src/primitive_docs.rs
@@ -591,7 +591,7 @@ mod prim_array {}
 /// As slices store the length of the sequence they refer to, they have twice
 /// the size of pointers to [`Sized`](marker/trait.Sized.html) types.
 /// Also see the reference on
-/// [dynamically sized types](../reference/dynamically-sized-types.html)
+/// [dynamically sized types](../reference/dynamically-sized-types.html).
 ///
 /// ```
 /// let pointer_size = std::mem::size_of::<&u8>();


### PR DESCRIPTION
I was recently confused about the way slices are represented in memory. The necessary information was not available in the std-docs directly, but was a mix of different material from the reference and book.

This PR should clear up the definition of slices a bit more in the documentation. Especially the fact that the term slice refers to the pointer/reference type, e.g. `&[T]`, and not `[T]`.
It also documents that slice pointers are twice the size of pointers to `Sized` types, as this concept may be unfamiliar to users coming from other languages that do not have the concept of "fat pointers" (especially C/C++).

I've documented why this was important to me and my findings in [this blog post](https://codecrash.me/understanding-rust-slices).

r? @lcnr 