### PR TITLE
Update improper_ctypes warning to add info about `extern "Rust"`

### DIFF
--- a/src/librustc_lint/types.rs
+++ b/src/librustc_lint/types.rs
@@ -989,6 +989,9 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
                 diag.help(help);
             }
             diag.note(note);
+            diag.note(
+                r#"if intentionally using the unstable Rust ABI, specify it with `extern "Rust"`"#,
+            );
             if let ty::Adt(def, _) = ty.kind {
                 if let Some(sp) = self.cx.tcx.hir().span_if_local(def.did) {
                     diag.span_note(sp, "the type is defined here");

--- a/src/test/ui/issues/issue-14309.stderr
+++ b/src/test/ui/issues/issue-14309.stderr
@@ -11,6 +11,7 @@ LL | #![deny(improper_ctypes)]
    |         ^^^^^^^^^^^^^^^
    = help: consider adding a `#[repr(C)]` or `#[repr(transparent)]` attribute to this struct
    = note: this struct has unspecified layout
+   = note: if intentionally using the unstable Rust ABI, specify it with `extern "Rust"`
 note: the type is defined here
   --> $DIR/issue-14309.rs:4:1
    |
@@ -27,6 +28,7 @@ LL |     fn bar(x: B);
    |
    = help: consider adding a `#[repr(C)]` or `#[repr(transparent)]` attribute to this struct
    = note: this struct has unspecified layout
+   = note: if intentionally using the unstable Rust ABI, specify it with `extern "Rust"`
 note: the type is defined here
   --> $DIR/issue-14309.rs:4:1
    |
@@ -43,6 +45,7 @@ LL |     fn qux(x: A2);
    |
    = help: consider adding a `#[repr(C)]` or `#[repr(transparent)]` attribute to this struct
    = note: this struct has unspecified layout
+   = note: if intentionally using the unstable Rust ABI, specify it with `extern "Rust"`
 note: the type is defined here
   --> $DIR/issue-14309.rs:4:1
    |
@@ -59,6 +62,7 @@ LL |     fn quux(x: B2);
    |
    = help: consider adding a `#[repr(C)]` or `#[repr(transparent)]` attribute to this struct
    = note: this struct has unspecified layout
+   = note: if intentionally using the unstable Rust ABI, specify it with `extern "Rust"`
 note: the type is defined here
   --> $DIR/issue-14309.rs:4:1
    |
@@ -75,6 +79,7 @@ LL |     fn fred(x: D);
    |
    = help: consider adding a `#[repr(C)]` or `#[repr(transparent)]` attribute to this struct
    = note: this struct has unspecified layout
+   = note: if intentionally using the unstable Rust ABI, specify it with `extern "Rust"`
 note: the type is defined here
   --> $DIR/issue-14309.rs:4:1
    |

--- a/src/test/ui/issues/issue-16250.stderr
+++ b/src/test/ui/issues/issue-16250.stderr
@@ -12,6 +12,7 @@ LL | #![deny(warnings)]
    = note: `#[deny(improper_ctypes)]` implied by `#[deny(warnings)]`
    = help: consider adding a `#[repr(C)]` or `#[repr(transparent)]` attribute to this struct
    = note: this struct has unspecified layout
+   = note: if intentionally using the unstable Rust ABI, specify it with `extern "Rust"`
 note: the type is defined here
   --> $DIR/issue-16250.rs:3:1
    |

--- a/src/test/ui/lint/lint-ctypes-73249-2.stderr
+++ b/src/test/ui/lint/lint-ctypes-73249-2.stderr
@@ -10,6 +10,7 @@ note: the lint level is defined here
 LL | #![deny(improper_ctypes)]
    |         ^^^^^^^^^^^^^^^
    = note: opaque types have no C equivalent
+   = note: if intentionally using the unstable Rust ABI, specify it with `extern "Rust"`
 
 error: aborting due to previous error
 

--- a/src/test/ui/lint/lint-ctypes-73249-3.stderr
+++ b/src/test/ui/lint/lint-ctypes-73249-3.stderr
@@ -10,6 +10,7 @@ note: the lint level is defined here
 LL | #![deny(improper_ctypes)]
    |         ^^^^^^^^^^^^^^^
    = note: opaque types have no C equivalent
+   = note: if intentionally using the unstable Rust ABI, specify it with `extern "Rust"`
 
 error: aborting due to previous error
 

--- a/src/test/ui/lint/lint-ctypes-73249-5.stderr
+++ b/src/test/ui/lint/lint-ctypes-73249-5.stderr
@@ -10,6 +10,7 @@ note: the lint level is defined here
 LL | #![deny(improper_ctypes)]
    |         ^^^^^^^^^^^^^^^
    = note: opaque types have no C equivalent
+   = note: if intentionally using the unstable Rust ABI, specify it with `extern "Rust"`
 
 error: aborting due to previous error
 

--- a/src/test/ui/lint/lint-ctypes-73251-1.stderr
+++ b/src/test/ui/lint/lint-ctypes-73251-1.stderr
@@ -10,6 +10,7 @@ note: the lint level is defined here
 LL | #![deny(improper_ctypes)]
    |         ^^^^^^^^^^^^^^^
    = note: opaque types have no C equivalent
+   = note: if intentionally using the unstable Rust ABI, specify it with `extern "Rust"`
 
 error: aborting due to previous error
 

--- a/src/test/ui/lint/lint-ctypes-73251-2.stderr
+++ b/src/test/ui/lint/lint-ctypes-73251-2.stderr
@@ -10,6 +10,7 @@ note: the lint level is defined here
 LL | #![deny(improper_ctypes)]
    |         ^^^^^^^^^^^^^^^
    = note: opaque types have no C equivalent
+   = note: if intentionally using the unstable Rust ABI, specify it with `extern "Rust"`
 
 error: aborting due to previous error
 

--- a/src/test/ui/lint/lint-ctypes-enum.stderr
+++ b/src/test/ui/lint/lint-ctypes-enum.stderr
@@ -11,6 +11,7 @@ LL | #![deny(improper_ctypes)]
    |         ^^^^^^^^^^^^^^^
    = help: consider adding a `#[repr(C)]`, `#[repr(transparent)]`, or integer `#[repr(...)]` attribute to this enum
    = note: enum has no representation hint
+   = note: if intentionally using the unstable Rust ABI, specify it with `extern "Rust"`
 note: the type is defined here
   --> $DIR/lint-ctypes-enum.rs:9:1
    |
@@ -25,6 +26,7 @@ LL |    fn bf(x: B);
    |
    = help: consider adding a `#[repr(C)]`, `#[repr(transparent)]`, or integer `#[repr(...)]` attribute to this enum
    = note: enum has no representation hint
+   = note: if intentionally using the unstable Rust ABI, specify it with `extern "Rust"`
 note: the type is defined here
   --> $DIR/lint-ctypes-enum.rs:10:1
    |
@@ -39,6 +41,7 @@ LL |    fn tf(x: T);
    |
    = help: consider adding a `#[repr(C)]`, `#[repr(transparent)]`, or integer `#[repr(...)]` attribute to this enum
    = note: enum has no representation hint
+   = note: if intentionally using the unstable Rust ABI, specify it with `extern "Rust"`
 note: the type is defined here
   --> $DIR/lint-ctypes-enum.rs:11:1
    |
@@ -53,6 +56,7 @@ LL |    fn unique(x: Option<std::ptr::Unique<u8>>);
    |
    = help: consider adding a `#[repr(C)]`, `#[repr(transparent)]`, or integer `#[repr(...)]` attribute to this enum
    = note: enum has no representation hint
+   = note: if intentionally using the unstable Rust ABI, specify it with `extern "Rust"`
 
 error: `extern` block uses type `u128`, which is not FFI-safe
   --> $DIR/lint-ctypes-enum.rs:54:23
@@ -61,6 +65,7 @@ LL |    fn nonzero_u128(x: Option<num::NonZeroU128>);
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
    |
    = note: 128-bit integers don't currently have a known stable ABI
+   = note: if intentionally using the unstable Rust ABI, specify it with `extern "Rust"`
 
 error: `extern` block uses type `i128`, which is not FFI-safe
   --> $DIR/lint-ctypes-enum.rs:61:23
@@ -69,6 +74,7 @@ LL |    fn nonzero_i128(x: Option<num::NonZeroI128>);
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
    |
    = note: 128-bit integers don't currently have a known stable ABI
+   = note: if intentionally using the unstable Rust ABI, specify it with `extern "Rust"`
 
 error: `extern` block uses type `std::option::Option<TransparentUnion<std::num::NonZeroU8>>`, which is not FFI-safe
   --> $DIR/lint-ctypes-enum.rs:66:28
@@ -78,6 +84,7 @@ LL |    fn transparent_union(x: Option<TransparentUnion<num::NonZeroU8>>);
    |
    = help: consider adding a `#[repr(C)]`, `#[repr(transparent)]`, or integer `#[repr(...)]` attribute to this enum
    = note: enum has no representation hint
+   = note: if intentionally using the unstable Rust ABI, specify it with `extern "Rust"`
 
 error: `extern` block uses type `std::option::Option<Rust<std::num::NonZeroU8>>`, which is not FFI-safe
   --> $DIR/lint-ctypes-enum.rs:68:20
@@ -87,6 +94,7 @@ LL |    fn repr_rust(x: Option<Rust<num::NonZeroU8>>);
    |
    = help: consider adding a `#[repr(C)]`, `#[repr(transparent)]`, or integer `#[repr(...)]` attribute to this enum
    = note: enum has no representation hint
+   = note: if intentionally using the unstable Rust ABI, specify it with `extern "Rust"`
 
 error: `extern` block uses type `std::result::Result<(), std::num::NonZeroI32>`, which is not FFI-safe
   --> $DIR/lint-ctypes-enum.rs:69:20
@@ -96,6 +104,7 @@ LL |    fn no_result(x: Result<(), num::NonZeroI32>);
    |
    = help: consider adding a `#[repr(C)]`, `#[repr(transparent)]`, or integer `#[repr(...)]` attribute to this enum
    = note: enum has no representation hint
+   = note: if intentionally using the unstable Rust ABI, specify it with `extern "Rust"`
 
 error: aborting due to 9 previous errors
 

--- a/src/test/ui/lint/lint-ctypes-fn.stderr
+++ b/src/test/ui/lint/lint-ctypes-fn.stderr
@@ -11,6 +11,7 @@ LL | #![deny(improper_ctypes_definitions)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: consider using a raw pointer instead
    = note: slices have no C equivalent
+   = note: if intentionally using the unstable Rust ABI, specify it with `extern "Rust"`
 
 error: `extern` fn uses type `str`, which is not FFI-safe
   --> $DIR/lint-ctypes-fn.rs:70:31
@@ -20,6 +21,7 @@ LL | pub extern "C" fn str_type(p: &str) { }
    |
    = help: consider using `*const u8` and a length instead
    = note: string slices have no C equivalent
+   = note: if intentionally using the unstable Rust ABI, specify it with `extern "Rust"`
 
 error: `extern` fn uses type `char`, which is not FFI-safe
   --> $DIR/lint-ctypes-fn.rs:77:32
@@ -29,6 +31,7 @@ LL | pub extern "C" fn char_type(p: char) { }
    |
    = help: consider using `u32` or `libc::wchar_t` instead
    = note: the `char` type has no C equivalent
+   = note: if intentionally using the unstable Rust ABI, specify it with `extern "Rust"`
 
 error: `extern` fn uses type `i128`, which is not FFI-safe
   --> $DIR/lint-ctypes-fn.rs:80:32
@@ -37,6 +40,7 @@ LL | pub extern "C" fn i128_type(p: i128) { }
    |                                ^^^^ not FFI-safe
    |
    = note: 128-bit integers don't currently have a known stable ABI
+   = note: if intentionally using the unstable Rust ABI, specify it with `extern "Rust"`
 
 error: `extern` fn uses type `u128`, which is not FFI-safe
   --> $DIR/lint-ctypes-fn.rs:83:32
@@ -45,6 +49,7 @@ LL | pub extern "C" fn u128_type(p: u128) { }
    |                                ^^^^ not FFI-safe
    |
    = note: 128-bit integers don't currently have a known stable ABI
+   = note: if intentionally using the unstable Rust ABI, specify it with `extern "Rust"`
 
 error: `extern` fn uses type `(i32, i32)`, which is not FFI-safe
   --> $DIR/lint-ctypes-fn.rs:86:33
@@ -54,6 +59,7 @@ LL | pub extern "C" fn tuple_type(p: (i32, i32)) { }
    |
    = help: consider using a struct instead
    = note: tuples have unspecified layout
+   = note: if intentionally using the unstable Rust ABI, specify it with `extern "Rust"`
 
 error: `extern` fn uses type `(i32, i32)`, which is not FFI-safe
   --> $DIR/lint-ctypes-fn.rs:89:34
@@ -63,6 +69,7 @@ LL | pub extern "C" fn tuple_type2(p: I32Pair) { }
    |
    = help: consider using a struct instead
    = note: tuples have unspecified layout
+   = note: if intentionally using the unstable Rust ABI, specify it with `extern "Rust"`
 
 error: `extern` fn uses type `ZeroSize`, which is not FFI-safe
   --> $DIR/lint-ctypes-fn.rs:92:32
@@ -72,6 +79,7 @@ LL | pub extern "C" fn zero_size(p: ZeroSize) { }
    |
    = help: consider adding a member to this struct
    = note: this struct has no fields
+   = note: if intentionally using the unstable Rust ABI, specify it with `extern "Rust"`
 note: the type is defined here
   --> $DIR/lint-ctypes-fn.rs:26:1
    |
@@ -85,6 +93,7 @@ LL | pub extern "C" fn zero_size_phantom(p: ZeroSizeWithPhantomData) { }
    |                                        ^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
    |
    = note: composed only of `PhantomData`
+   = note: if intentionally using the unstable Rust ABI, specify it with `extern "Rust"`
 note: the type is defined here
   --> $DIR/lint-ctypes-fn.rs:61:1
    |
@@ -98,6 +107,7 @@ LL | pub extern "C" fn zero_size_phantom_toplevel() -> PhantomData<bool> {
    |                                                   ^^^^^^^^^^^^^^^^^ not FFI-safe
    |
    = note: composed only of `PhantomData`
+   = note: if intentionally using the unstable Rust ABI, specify it with `extern "Rust"`
 
 error: `extern` fn uses type `fn()`, which is not FFI-safe
   --> $DIR/lint-ctypes-fn.rs:103:30
@@ -107,6 +117,7 @@ LL | pub extern "C" fn fn_type(p: RustFn) { }
    |
    = help: consider using an `extern fn(...) -> ...` function pointer instead
    = note: this function pointer has Rust-specific calling convention
+   = note: if intentionally using the unstable Rust ABI, specify it with `extern "Rust"`
 
 error: `extern` fn uses type `fn()`, which is not FFI-safe
   --> $DIR/lint-ctypes-fn.rs:106:31
@@ -116,6 +127,7 @@ LL | pub extern "C" fn fn_type2(p: fn()) { }
    |
    = help: consider using an `extern fn(...) -> ...` function pointer instead
    = note: this function pointer has Rust-specific calling convention
+   = note: if intentionally using the unstable Rust ABI, specify it with `extern "Rust"`
 
 error: `extern` fn uses type `i128`, which is not FFI-safe
   --> $DIR/lint-ctypes-fn.rs:111:39
@@ -124,6 +136,7 @@ LL | pub extern "C" fn transparent_i128(p: TransparentI128) { }
    |                                       ^^^^^^^^^^^^^^^ not FFI-safe
    |
    = note: 128-bit integers don't currently have a known stable ABI
+   = note: if intentionally using the unstable Rust ABI, specify it with `extern "Rust"`
 
 error: `extern` fn uses type `str`, which is not FFI-safe
   --> $DIR/lint-ctypes-fn.rs:114:38
@@ -133,6 +146,7 @@ LL | pub extern "C" fn transparent_str(p: TransparentStr) { }
    |
    = help: consider using `*const u8` and a length instead
    = note: string slices have no C equivalent
+   = note: if intentionally using the unstable Rust ABI, specify it with `extern "Rust"`
 
 error: `extern` fn uses type `std::marker::PhantomData<bool>`, which is not FFI-safe
   --> $DIR/lint-ctypes-fn.rs:160:43
@@ -141,6 +155,7 @@ LL | pub extern "C" fn unused_generic2<T>() -> PhantomData<bool> {
    |                                           ^^^^^^^^^^^^^^^^^ not FFI-safe
    |
    = note: composed only of `PhantomData`
+   = note: if intentionally using the unstable Rust ABI, specify it with `extern "Rust"`
 
 error: `extern` fn uses type `std::vec::Vec<T>`, which is not FFI-safe
   --> $DIR/lint-ctypes-fn.rs:173:39
@@ -150,6 +165,7 @@ LL | pub extern "C" fn used_generic4<T>(x: Vec<T>) { }
    |
    = help: consider adding a `#[repr(C)]` or `#[repr(transparent)]` attribute to this struct
    = note: this struct has unspecified layout
+   = note: if intentionally using the unstable Rust ABI, specify it with `extern "Rust"`
 
 error: `extern` fn uses type `std::vec::Vec<T>`, which is not FFI-safe
   --> $DIR/lint-ctypes-fn.rs:176:41
@@ -159,6 +175,7 @@ LL | pub extern "C" fn used_generic5<T>() -> Vec<T> {
    |
    = help: consider adding a `#[repr(C)]` or `#[repr(transparent)]` attribute to this struct
    = note: this struct has unspecified layout
+   = note: if intentionally using the unstable Rust ABI, specify it with `extern "Rust"`
 
 error: aborting due to 17 previous errors
 

--- a/src/test/ui/lint/lint-ctypes.stderr
+++ b/src/test/ui/lint/lint-ctypes.stderr
@@ -11,6 +11,7 @@ LL | #![deny(improper_ctypes)]
    |         ^^^^^^^^^^^^^^^
    = help: consider adding a `#[repr(C)]` or `#[repr(transparent)]` attribute to this struct
    = note: this struct has unspecified layout
+   = note: if intentionally using the unstable Rust ABI, specify it with `extern "Rust"`
 note: the type is defined here
   --> $DIR/lint-ctypes.rs:25:1
    |
@@ -25,6 +26,7 @@ LL |     pub fn ptr_type2(size: *const Foo);
    |
    = help: consider adding a `#[repr(C)]` or `#[repr(transparent)]` attribute to this struct
    = note: this struct has unspecified layout
+   = note: if intentionally using the unstable Rust ABI, specify it with `extern "Rust"`
 note: the type is defined here
   --> $DIR/lint-ctypes.rs:25:1
    |
@@ -39,6 +41,7 @@ LL |     pub fn slice_type(p: &[u32]);
    |
    = help: consider using a raw pointer instead
    = note: slices have no C equivalent
+   = note: if intentionally using the unstable Rust ABI, specify it with `extern "Rust"`
 
 error: `extern` block uses type `str`, which is not FFI-safe
   --> $DIR/lint-ctypes.rs:50:24
@@ -48,6 +51,7 @@ LL |     pub fn str_type(p: &str);
    |
    = help: consider using `*const u8` and a length instead
    = note: string slices have no C equivalent
+   = note: if intentionally using the unstable Rust ABI, specify it with `extern "Rust"`
 
 error: `extern` block uses type `std::boxed::Box<u32>`, which is not FFI-safe
   --> $DIR/lint-ctypes.rs:51:24
@@ -57,6 +61,7 @@ LL |     pub fn box_type(p: Box<u32>);
    |
    = help: consider adding a `#[repr(C)]` or `#[repr(transparent)]` attribute to this struct
    = note: this struct has unspecified layout
+   = note: if intentionally using the unstable Rust ABI, specify it with `extern "Rust"`
 
 error: `extern` block uses type `std::option::Option<std::boxed::Box<u32>>`, which is not FFI-safe
   --> $DIR/lint-ctypes.rs:52:28
@@ -66,6 +71,7 @@ LL |     pub fn opt_box_type(p: Option<Box<u32>>);
    |
    = help: consider adding a `#[repr(C)]`, `#[repr(transparent)]`, or integer `#[repr(...)]` attribute to this enum
    = note: enum has no representation hint
+   = note: if intentionally using the unstable Rust ABI, specify it with `extern "Rust"`
 
 error: `extern` block uses type `char`, which is not FFI-safe
   --> $DIR/lint-ctypes.rs:54:25
@@ -75,6 +81,7 @@ LL |     pub fn char_type(p: char);
    |
    = help: consider using `u32` or `libc::wchar_t` instead
    = note: the `char` type has no C equivalent
+   = note: if intentionally using the unstable Rust ABI, specify it with `extern "Rust"`
 
 error: `extern` block uses type `i128`, which is not FFI-safe
   --> $DIR/lint-ctypes.rs:55:25
@@ -83,6 +90,7 @@ LL |     pub fn i128_type(p: i128);
    |                         ^^^^ not FFI-safe
    |
    = note: 128-bit integers don't currently have a known stable ABI
+   = note: if intentionally using the unstable Rust ABI, specify it with `extern "Rust"`
 
 error: `extern` block uses type `u128`, which is not FFI-safe
   --> $DIR/lint-ctypes.rs:56:25
@@ -91,6 +99,7 @@ LL |     pub fn u128_type(p: u128);
    |                         ^^^^ not FFI-safe
    |
    = note: 128-bit integers don't currently have a known stable ABI
+   = note: if intentionally using the unstable Rust ABI, specify it with `extern "Rust"`
 
 error: `extern` block uses type `dyn Bar`, which is not FFI-safe
   --> $DIR/lint-ctypes.rs:57:26
@@ -99,6 +108,7 @@ LL |     pub fn trait_type(p: &dyn Bar);
    |                          ^^^^^^^^ not FFI-safe
    |
    = note: trait objects have no C equivalent
+   = note: if intentionally using the unstable Rust ABI, specify it with `extern "Rust"`
 
 error: `extern` block uses type `(i32, i32)`, which is not FFI-safe
   --> $DIR/lint-ctypes.rs:58:26
@@ -108,6 +118,7 @@ LL |     pub fn tuple_type(p: (i32, i32));
    |
    = help: consider using a struct instead
    = note: tuples have unspecified layout
+   = note: if intentionally using the unstable Rust ABI, specify it with `extern "Rust"`
 
 error: `extern` block uses type `(i32, i32)`, which is not FFI-safe
   --> $DIR/lint-ctypes.rs:59:27
@@ -117,6 +128,7 @@ LL |     pub fn tuple_type2(p: I32Pair);
    |
    = help: consider using a struct instead
    = note: tuples have unspecified layout
+   = note: if intentionally using the unstable Rust ABI, specify it with `extern "Rust"`
 
 error: `extern` block uses type `ZeroSize`, which is not FFI-safe
   --> $DIR/lint-ctypes.rs:60:25
@@ -126,6 +138,7 @@ LL |     pub fn zero_size(p: ZeroSize);
    |
    = help: consider adding a member to this struct
    = note: this struct has no fields
+   = note: if intentionally using the unstable Rust ABI, specify it with `extern "Rust"`
 note: the type is defined here
   --> $DIR/lint-ctypes.rs:21:1
    |
@@ -139,6 +152,7 @@ LL |     pub fn zero_size_phantom(p: ZeroSizeWithPhantomData);
    |                                 ^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
    |
    = note: composed only of `PhantomData`
+   = note: if intentionally using the unstable Rust ABI, specify it with `extern "Rust"`
 note: the type is defined here
   --> $DIR/lint-ctypes.rs:44:1
    |
@@ -152,6 +166,7 @@ LL |         -> ::std::marker::PhantomData<bool>;
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
    |
    = note: composed only of `PhantomData`
+   = note: if intentionally using the unstable Rust ABI, specify it with `extern "Rust"`
 
 error: `extern` block uses type `fn()`, which is not FFI-safe
   --> $DIR/lint-ctypes.rs:65:23
@@ -161,6 +176,7 @@ LL |     pub fn fn_type(p: RustFn);
    |
    = help: consider using an `extern fn(...) -> ...` function pointer instead
    = note: this function pointer has Rust-specific calling convention
+   = note: if intentionally using the unstable Rust ABI, specify it with `extern "Rust"`
 
 error: `extern` block uses type `fn()`, which is not FFI-safe
   --> $DIR/lint-ctypes.rs:66:24
@@ -170,6 +186,7 @@ LL |     pub fn fn_type2(p: fn());
    |
    = help: consider using an `extern fn(...) -> ...` function pointer instead
    = note: this function pointer has Rust-specific calling convention
+   = note: if intentionally using the unstable Rust ABI, specify it with `extern "Rust"`
 
 error: `extern` block uses type `std::boxed::Box<u32>`, which is not FFI-safe
   --> $DIR/lint-ctypes.rs:67:28
@@ -179,6 +196,7 @@ LL |     pub fn fn_contained(p: RustBadRet);
    |
    = help: consider adding a `#[repr(C)]` or `#[repr(transparent)]` attribute to this struct
    = note: this struct has unspecified layout
+   = note: if intentionally using the unstable Rust ABI, specify it with `extern "Rust"`
 
 error: `extern` block uses type `i128`, which is not FFI-safe
   --> $DIR/lint-ctypes.rs:68:32
@@ -187,6 +205,7 @@ LL |     pub fn transparent_i128(p: TransparentI128);
    |                                ^^^^^^^^^^^^^^^ not FFI-safe
    |
    = note: 128-bit integers don't currently have a known stable ABI
+   = note: if intentionally using the unstable Rust ABI, specify it with `extern "Rust"`
 
 error: `extern` block uses type `str`, which is not FFI-safe
   --> $DIR/lint-ctypes.rs:69:31
@@ -196,6 +215,7 @@ LL |     pub fn transparent_str(p: TransparentStr);
    |
    = help: consider using `*const u8` and a length instead
    = note: string slices have no C equivalent
+   = note: if intentionally using the unstable Rust ABI, specify it with `extern "Rust"`
 
 error: `extern` block uses type `std::boxed::Box<u32>`, which is not FFI-safe
   --> $DIR/lint-ctypes.rs:70:30
@@ -205,6 +225,7 @@ LL |     pub fn transparent_fn(p: TransparentBadFn);
    |
    = help: consider adding a `#[repr(C)]` or `#[repr(transparent)]` attribute to this struct
    = note: this struct has unspecified layout
+   = note: if intentionally using the unstable Rust ABI, specify it with `extern "Rust"`
 
 error: `extern` block uses type `[u8; 8]`, which is not FFI-safe
   --> $DIR/lint-ctypes.rs:71:27
@@ -214,6 +235,7 @@ LL |     pub fn raw_array(arr: [u8; 8]);
    |
    = help: consider passing a pointer to the array
    = note: passing raw arrays by value is not FFI-safe
+   = note: if intentionally using the unstable Rust ABI, specify it with `extern "Rust"`
 
 error: `extern` block uses type `u128`, which is not FFI-safe
   --> $DIR/lint-ctypes.rs:73:34
@@ -222,6 +244,7 @@ LL |     pub static static_u128_type: u128;
    |                                  ^^^^ not FFI-safe
    |
    = note: 128-bit integers don't currently have a known stable ABI
+   = note: if intentionally using the unstable Rust ABI, specify it with `extern "Rust"`
 
 error: `extern` block uses type `u128`, which is not FFI-safe
   --> $DIR/lint-ctypes.rs:74:40
@@ -230,6 +253,7 @@ LL |     pub static static_u128_array_type: [u128; 16];
    |                                        ^^^^^^^^^^ not FFI-safe
    |
    = note: 128-bit integers don't currently have a known stable ABI
+   = note: if intentionally using the unstable Rust ABI, specify it with `extern "Rust"`
 
 error: aborting due to 24 previous errors
 

--- a/src/test/ui/lint/opaque-ty-ffi-unsafe.stderr
+++ b/src/test/ui/lint/opaque-ty-ffi-unsafe.stderr
@@ -10,6 +10,7 @@ note: the lint level is defined here
 LL | #![deny(improper_ctypes)]
    |         ^^^^^^^^^^^^^^^
    = note: opaque types have no C equivalent
+   = note: if intentionally using the unstable Rust ABI, specify it with `extern "Rust"`
 
 error: aborting due to previous error
 

--- a/src/test/ui/rfc-2008-non-exhaustive/improper_ctypes/extern_crate_improper.stderr
+++ b/src/test/ui/rfc-2008-non-exhaustive/improper_ctypes/extern_crate_improper.stderr
@@ -10,6 +10,7 @@ note: the lint level is defined here
 LL | #![deny(improper_ctypes)]
    |         ^^^^^^^^^^^^^^^
    = note: this enum is non-exhaustive
+   = note: if intentionally using the unstable Rust ABI, specify it with `extern "Rust"`
 
 error: `extern` block uses type `types::NormalStruct`, which is not FFI-safe
   --> $DIR/extern_crate_improper.rs:14:44
@@ -18,6 +19,7 @@ LL |     pub fn non_exhaustive_normal_struct(_: NormalStruct);
    |                                            ^^^^^^^^^^^^ not FFI-safe
    |
    = note: this struct is non-exhaustive
+   = note: if intentionally using the unstable Rust ABI, specify it with `extern "Rust"`
 
 error: `extern` block uses type `types::UnitStruct`, which is not FFI-safe
   --> $DIR/extern_crate_improper.rs:16:42
@@ -26,6 +28,7 @@ LL |     pub fn non_exhaustive_unit_struct(_: UnitStruct);
    |                                          ^^^^^^^^^^ not FFI-safe
    |
    = note: this struct is non-exhaustive
+   = note: if intentionally using the unstable Rust ABI, specify it with `extern "Rust"`
 
 error: `extern` block uses type `types::TupleStruct`, which is not FFI-safe
   --> $DIR/extern_crate_improper.rs:18:43
@@ -34,6 +37,7 @@ LL |     pub fn non_exhaustive_tuple_struct(_: TupleStruct);
    |                                           ^^^^^^^^^^^ not FFI-safe
    |
    = note: this struct is non-exhaustive
+   = note: if intentionally using the unstable Rust ABI, specify it with `extern "Rust"`
 
 error: `extern` block uses type `types::NonExhaustiveVariants`, which is not FFI-safe
   --> $DIR/extern_crate_improper.rs:20:38
@@ -42,6 +46,7 @@ LL |     pub fn non_exhaustive_variant(_: NonExhaustiveVariants);
    |                                      ^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
    |
    = note: this enum has non-exhaustive variants
+   = note: if intentionally using the unstable Rust ABI, specify it with `extern "Rust"`
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/union/union-repr-c.stderr
+++ b/src/test/ui/union/union-repr-c.stderr
@@ -11,6 +11,7 @@ LL | #![deny(improper_ctypes)]
    |         ^^^^^^^^^^^^^^^
    = help: consider adding a `#[repr(C)]` or `#[repr(transparent)]` attribute to this union
    = note: this union has unspecified layout
+   = note: if intentionally using the unstable Rust ABI, specify it with `extern "Rust"`
 note: the type is defined here
   --> $DIR/union-repr-c.rs:9:1
    |


### PR DESCRIPTION
The Rust ABI, while rarely the right tool for the job due to its unstable nature, has a discoverability problem when it *is* worth using. For example, in some embedded and/or unconventional platforms, it tends to be helpful for linkage trickery even if it is unstable. 

Minimal example:

```rust
fn main() {
    unsafe {
        dbg!(test1().unwrap());
    }
}

extern {
    #[link_name = "test"]
    fn test1() -> Result<u32, u32>;
}

#[no_mangle]
fn test() -> Result<u32, u32> {
    Ok(3)
}
```

In this situation, it may be unclear to some users that not specifying an ABI for the `extern` block and not specifying an ABI for the exposed `#[no_mangle]` function will actually lead to a mismatch of ABI due to the fact the default ABIs for these two contexts are different.

The resulting warning:

```
warning: `extern` block uses type `std::result::Result<u32, u32>`, which is not FFI-safe
 --> src/main.rs:9:19
  |
9 |     fn test1() -> Result<u32, u32>;
  |                   ^^^^^^^^^^^^^^^^ not FFI-safe
  |
  = note: `#[warn(improper_ctypes)]` on by default
  = help: consider adding a `#[repr(C)]`, `#[repr(transparent)]`, or integer `#[repr(...)]` attribute to this enum
  = note: enum has no representation hint
```

This error doesn't at all allude to the actual problem causing their issue, and has (multiple times, in my experience) lead to a rather dead-in debugging experience. (Maybe it should explicitly say `extern` defaults to `extern "C"`?)

While I believe this style of:

1. Not specifying an ABI
2. Abusing `#[no_mangle]`

is not good practice, it *is* something I have seen happen multiple times (from myself and from others asking questions) and while `extern "Rust"` is not *recommended*, giving the user things (to google, for example) which will lead to the discovery of information about the instability of the Rust ABI and the nature, it will direct users towards the information they need to solve their problem.

While I would argue `#[no_mangle]` without `extern` should raise a warning or error (as this would lead to exposing a Rust ABI function being opt-in, which better matches the unstable nature of the Rust ABI), I believe that is a significantly more controversial way to go about improving the user experience around this, hence this PR only being an update to existing warning, however I'm totally open to others' ideas on the subject.