### PR TITLE
Do not trigger `unused_{braces,parens}` lints with `yield`

### DIFF
--- a/src/librustc_lint/unused.rs
+++ b/src/librustc_lint/unused.rs
@@ -422,10 +422,9 @@ trait UnusedDelimLint {
         lhs_needs_parens
             || (followed_by_block
                 && match inner.kind {
-                    ExprKind::Ret(_) | ExprKind::Break(..) => true,
+                    ExprKind::Ret(_) | ExprKind::Break(..) | ExprKind::Yield(..) => true,
                     _ => parser::contains_exterior_struct_lit(&inner),
                 })
-            || if let ExprKind::Yield(..) = inner.kind { true } else { false }
     }
 
     fn emit_unused_delims_expr(

--- a/src/librustc_lint/unused.rs
+++ b/src/librustc_lint/unused.rs
@@ -425,6 +425,7 @@ trait UnusedDelimLint {
                     ExprKind::Ret(_) | ExprKind::Break(..) => true,
                     _ => parser::contains_exterior_struct_lit(&inner),
                 })
+            || if let ExprKind::Yield(..) = inner.kind { true } else { false }
     }
 
     fn emit_unused_delims_expr(

--- a/src/test/ui/lint/issue-74883-unused-paren-baren-yield.rs
+++ b/src/test/ui/lint/issue-74883-unused-paren-baren-yield.rs
@@ -1,0 +1,17 @@
+#![feature(generator_trait)]
+#![feature(generators)]
+#![deny(unused_braces, unused_parens)]
+
+use std::ops::Generator;
+use std::pin::Pin;
+
+fn main() {
+    let mut x = |_| {
+        while let Some(_) = (yield) {}
+        while let Some(_) = {yield} {}
+        // Only warn these cases
+        while let Some(_) = ({yield}) {} //~ ERROR: unnecessary parentheses
+        while let Some(_) = {(yield)} {} //~ ERROR: unnecessary braces
+    };
+    let _ = Pin::new(&mut x).resume(Some(5));
+}

--- a/src/test/ui/lint/issue-74883-unused-paren-baren-yield.rs
+++ b/src/test/ui/lint/issue-74883-unused-paren-baren-yield.rs
@@ -9,9 +9,25 @@ fn main() {
     let mut x = |_| {
         while let Some(_) = (yield) {}
         while let Some(_) = {yield} {}
+
         // Only warn these cases
         while let Some(_) = ({yield}) {} //~ ERROR: unnecessary parentheses
-        while let Some(_) = {(yield)} {} //~ ERROR: unnecessary braces
+        while let Some(_) = ((yield)) {} //~ ERROR: unnecessary parentheses
+        {{yield}}; //~ ERROR: unnecessary braces
+        {( yield )}; //~ ERROR: unnecessary parentheses
+
+        // FIXME: Reduce duplicate warnings.
+        // Perhaps we should tweak checks in `BlockRetValue`?
+        while let Some(_) = {(yield)} {}
+        //~^ ERROR: unnecessary braces
+        //~| ERROR: unnecessary parentheses
+        while let Some(_) = {{yield}} {}
+        //~^ ERROR: unnecessary braces
+        //~| ERROR: unnecessary braces
+
+        // FIXME: It'd be great if we could also warn them.
+        ((yield));
+        ({ yield });
     };
     let _ = Pin::new(&mut x).resume(Some(5));
 }

--- a/src/test/ui/lint/issue-74883-unused-paren-baren-yield.stderr
+++ b/src/test/ui/lint/issue-74883-unused-paren-baren-yield.stderr
@@ -1,5 +1,5 @@
 error: unnecessary parentheses around `let` scrutinee expression
-  --> $DIR/issue-74883-unused-paren-baren-yield.rs:13:29
+  --> $DIR/issue-74883-unused-paren-baren-yield.rs:14:29
    |
 LL |         while let Some(_) = ({yield}) {}
    |                             ^^^^^^^^^ help: remove these parentheses
@@ -10,11 +10,17 @@ note: the lint level is defined here
 LL | #![deny(unused_braces, unused_parens)]
    |                        ^^^^^^^^^^^^^
 
-error: unnecessary braces around `let` scrutinee expression
-  --> $DIR/issue-74883-unused-paren-baren-yield.rs:14:29
+error: unnecessary parentheses around `let` scrutinee expression
+  --> $DIR/issue-74883-unused-paren-baren-yield.rs:15:29
    |
-LL |         while let Some(_) = {(yield)} {}
-   |                             ^^^^^^^^^ help: remove these braces
+LL |         while let Some(_) = ((yield)) {}
+   |                             ^^^^^^^^^ help: remove these parentheses
+
+error: unnecessary braces around block return value
+  --> $DIR/issue-74883-unused-paren-baren-yield.rs:16:10
+   |
+LL |         {{yield}};
+   |          ^^^^^^^ help: remove these braces
    |
 note: the lint level is defined here
   --> $DIR/issue-74883-unused-paren-baren-yield.rs:3:9
@@ -22,5 +28,35 @@ note: the lint level is defined here
 LL | #![deny(unused_braces, unused_parens)]
    |         ^^^^^^^^^^^^^
 
-error: aborting due to 2 previous errors
+error: unnecessary parentheses around block return value
+  --> $DIR/issue-74883-unused-paren-baren-yield.rs:17:10
+   |
+LL |         {( yield )};
+   |          ^^^^^^^^^ help: remove these parentheses
+
+error: unnecessary braces around `let` scrutinee expression
+  --> $DIR/issue-74883-unused-paren-baren-yield.rs:21:29
+   |
+LL |         while let Some(_) = {(yield)} {}
+   |                             ^^^^^^^^^ help: remove these braces
+
+error: unnecessary parentheses around block return value
+  --> $DIR/issue-74883-unused-paren-baren-yield.rs:21:30
+   |
+LL |         while let Some(_) = {(yield)} {}
+   |                              ^^^^^^^ help: remove these parentheses
+
+error: unnecessary braces around `let` scrutinee expression
+  --> $DIR/issue-74883-unused-paren-baren-yield.rs:24:29
+   |
+LL |         while let Some(_) = {{yield}} {}
+   |                             ^^^^^^^^^ help: remove these braces
+
+error: unnecessary braces around block return value
+  --> $DIR/issue-74883-unused-paren-baren-yield.rs:24:30
+   |
+LL |         while let Some(_) = {{yield}} {}
+   |                              ^^^^^^^ help: remove these braces
+
+error: aborting due to 8 previous errors
 

--- a/src/test/ui/lint/issue-74883-unused-paren-baren-yield.stderr
+++ b/src/test/ui/lint/issue-74883-unused-paren-baren-yield.stderr
@@ -1,0 +1,26 @@
+error: unnecessary parentheses around `let` scrutinee expression
+  --> $DIR/issue-74883-unused-paren-baren-yield.rs:13:29
+   |
+LL |         while let Some(_) = ({yield}) {}
+   |                             ^^^^^^^^^ help: remove these parentheses
+   |
+note: the lint level is defined here
+  --> $DIR/issue-74883-unused-paren-baren-yield.rs:3:24
+   |
+LL | #![deny(unused_braces, unused_parens)]
+   |                        ^^^^^^^^^^^^^
+
+error: unnecessary braces around `let` scrutinee expression
+  --> $DIR/issue-74883-unused-paren-baren-yield.rs:14:29
+   |
+LL |         while let Some(_) = {(yield)} {}
+   |                             ^^^^^^^^^ help: remove these braces
+   |
+note: the lint level is defined here
+  --> $DIR/issue-74883-unused-paren-baren-yield.rs:3:9
+   |
+LL | #![deny(unused_braces, unused_parens)]
+   |         ^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Fixes #74883
r? @lcnr