### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/library/alloc/src/vec.rs
+++ b/library/alloc/src/vec.rs
@@ -65,7 +65,7 @@ use core::hash::{Hash, Hasher};
 use core::intrinsics::{arith_offset, assume};
 use core::iter::{FromIterator, FusedIterator, TrustedLen};
 use core::marker::PhantomData;
-use core::mem::{self, ManuallyDrop};
+use core::mem::{self, ManuallyDrop, MaybeUninit};
 use core::ops::Bound::{Excluded, Included, Unbounded};
 use core::ops::{self, Index, IndexMut, RangeBounds};
 use core::ptr::{self, NonNull};
@@ -1524,6 +1524,47 @@ impl<T> Vec<T> {
         T: 'a, // Technically not needed, but kept to be explicit.
     {
         Box::leak(vec.into_boxed_slice())
+    }
+
+    /// Returns the remaining spare capacity of the vector as a slice of
+    /// `MaybeUninit<T>`.
+    ///
+    /// The returned slice can be used to fill the vector with data (e.g. by
+    /// reading from a file) before marking the data as initialized using the
+    /// [`set_len`] method.
+    ///
+    /// [`set_len`]: #method.set_len
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(vec_spare_capacity, maybe_uninit_extra)]
+    ///
+    /// // Allocate vector big enough for 10 elements.
+    /// let mut v = Vec::with_capacity(10);
+    ///
+    /// // Fill in the first 3 elements.
+    /// let uninit = v.spare_capacity_mut();
+    /// uninit[0].write(0);
+    /// uninit[1].write(1);
+    /// uninit[2].write(2);
+    ///
+    /// // Mark the first 3 elements of the vector as being initialized.
+    /// unsafe {
+    ///     v.set_len(3);
+    /// }
+    ///
+    /// assert_eq!(&v, &[0, 1, 2]);
+    /// ```
+    #[unstable(feature = "vec_spare_capacity", issue = "75017")]
+    #[inline]
+    pub fn spare_capacity_mut(&mut self) -> &mut [MaybeUninit<T>] {
+        unsafe {
+            slice::from_raw_parts_mut(
+                self.as_mut_ptr().add(self.len) as *mut MaybeUninit<T>,
+                self.buf.capacity() - self.len,
+            )
+        }
     }
 }
 

--- a/library/core/src/mem/maybe_uninit.rs
+++ b/library/core/src/mem/maybe_uninit.rs
@@ -336,9 +336,8 @@ impl<T> MaybeUninit<T> {
     /// assert_eq!(x, (0, false));
     /// ```
     ///
-    /// *Incorrect* usage of this function: assuming zero filled memory is initialized,
-    /// where some fields cannot hold 0 as a valid value, without overwriting with a
-    /// valid bit-pattern.
+    /// *Incorrect* usage of this function: calling `x.zeroed().assume_init()`
+    /// when `0` is not a valid bit-pattern for the type:
     ///
     /// ```rust,no_run
     /// use std::mem::MaybeUninit;

--- a/library/core/src/mem/maybe_uninit.rs
+++ b/library/core/src/mem/maybe_uninit.rs
@@ -336,8 +336,9 @@ impl<T> MaybeUninit<T> {
     /// assert_eq!(x, (0, false));
     /// ```
     ///
-    /// *Incorrect* usage of this function: initializing a struct with zero, where some fields
-    /// cannot hold 0 as a valid value.
+    /// *Incorrect* usage of this function: assuming zero filled memory is initialized,
+    /// where some fields cannot hold 0 as a valid value, without overwriting with a
+    /// valid bit-pattern.
     ///
     /// ```rust,no_run
     /// use std::mem::MaybeUninit;

--- a/src/librustc_error_codes/error_codes/E0728.md
+++ b/src/librustc_error_codes/error_codes/E0728.md
@@ -1,6 +1,6 @@
-[`await`] has been used outside [`async`] function or block.
+[`await`] has been used outside [`async`] function or [`async`] block.
 
-Erroneous code examples:
+Erroneous code example:
 
 ```edition2018,compile_fail,E0728
 # use std::pin::Pin;
@@ -33,7 +33,7 @@ fn foo() {
 
 [`await`] is used to suspend the current computation until the given
 future is ready to produce a value. So it is legal only within
-an [`async`] context, like an `async fn` or an `async` block.
+an [`async`] context, like an `async` function or an `async` block.
 
 ```edition2018
 # use std::pin::Pin;

--- a/src/librustc_privacy/lib.rs
+++ b/src/librustc_privacy/lib.rs
@@ -637,7 +637,7 @@ impl EmbargoVisitor<'tcx> {
         &mut self,
         segments: &[hir::PathSegment<'_>],
     ) {
-        if let Some([module, segment]) = segments.rchunks_exact(2).next() {
+        if let [.., module, segment] = segments {
             if let Some(item) = module
                 .res
                 .and_then(|res| res.mod_def_id())

--- a/src/librustdoc/clean/auto_trait.rs
+++ b/src/librustdoc/clean/auto_trait.rs
@@ -480,6 +480,11 @@ impl<'a, 'tcx> AutoTraitFinder<'a, 'tcx> {
                 .clean(self.cx)
                 .params;
 
+        debug!(
+            "param_env_to_generics({:?}): generic_params={:?}",
+            param_env_def_id, generic_params
+        );
+
         let mut has_sized = FxHashSet::default();
         let mut ty_to_bounds: FxHashMap<_, FxHashSet<_>> = Default::default();
         let mut lifetime_to_bounds: FxHashMap<_, FxHashSet<_>> = Default::default();

--- a/src/librustdoc/clean/simplify.rs
+++ b/src/librustdoc/clean/simplify.rs
@@ -12,7 +12,6 @@
 //! bounds by special casing scenarios such as these. Fun!
 
 use std::collections::BTreeMap;
-use std::mem;
 
 use rustc_hir::def_id::DefId;
 use rustc_middle::ty;
@@ -116,18 +115,6 @@ pub fn merge_bounds(
         };
         true
     })
-}
-
-pub fn ty_params(mut params: Vec<clean::GenericParamDef>) -> Vec<clean::GenericParamDef> {
-    for param in &mut params {
-        match param.kind {
-            clean::GenericParamDefKind::Type { ref mut bounds, .. } => {
-                *bounds = mem::take(bounds);
-            }
-            _ => panic!("expected only type parameters"),
-        }
-    }
-    params
 }
 
 fn trait_is_same_or_supertrait(cx: &DocContext<'_>, child: DefId, trait_: DefId) -> bool {

--- a/src/test/rustdoc/const-generics/const-impl.rs
+++ b/src/test/rustdoc/const-generics/const-impl.rs
@@ -11,8 +11,8 @@ pub enum Order {
 }
 
 // @has foo/struct.VSet.html '//pre[@class="rust struct"]' 'pub struct VSet<T, const ORDER: Order>'
-// @has foo/struct.VSet.html '//h3[@id="impl-Send"]/code' 'impl<const ORDER: Order, T> Send for VSet<T, ORDER>'
-// @has foo/struct.VSet.html '//h3[@id="impl-Sync"]/code' 'impl<const ORDER: Order, T> Sync for VSet<T, ORDER>'
+// @has foo/struct.VSet.html '//h3[@id="impl-Send"]/code' 'impl<T, const ORDER: Order> Send for VSet<T, ORDER>'
+// @has foo/struct.VSet.html '//h3[@id="impl-Sync"]/code' 'impl<T, const ORDER: Order> Sync for VSet<T, ORDER>'
 pub struct VSet<T, const ORDER: Order> {
     inner: Vec<T>,
 }


### PR DESCRIPTION
Successful merges:

 - #74602 (Clarify the doc for MaybeUninit::zeroed on incorrect use)
 - #74720 (Clean up E0728 explanation)
 - #74992 (fix rustdoc generic param order)
 - #75015 (Add Vec::spare_capacity_mut)
 - #75022 (Use a slice pattern instead of rchunks_exact(_).next())

Failed merges:


r? @ghost