### PR TITLE
docs(marker/copy): provide example for `&T` being `Copy`

### DIFF
--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -315,6 +315,18 @@ pub trait StructuralEq {
 /// the trait `Copy` may not be implemented for this type; field `points` does not implement `Copy`
 /// ```
 ///
+/// Shared references (`&T`) are also `Copy`, so a struct can be `Copy`, even when it holds
+/// shared references of types `T` that are *not* `Copy`. Consider the following struct,
+/// which can implement `Copy`, because it only holds a *shared reference* to our non-`Copy`
+/// type `PointList` from above:
+/// ```
+/// # #![allow(dead_code)]
+/// # struct PointList;
+/// struct PointListWrapper<'a> {
+///     point_list_ref: &'a PointList,
+/// }
+/// ```
+///
 /// ## When *can't* my type be `Copy`?
 ///
 /// Some types can't be copied safely. For example, copying `&mut T` would create an aliased
@@ -347,8 +359,9 @@ pub trait StructuralEq {
 /// * Tuple types, if each component also implements `Copy` (e.g., `()`, `(i32, bool)`)
 /// * Closure types, if they capture no value from the environment
 ///   or if all such captured values implement `Copy` themselves.
-/// * Variables captured by shared reference (e.g. `&T`) implement `Copy`, even if the referent (`T`) doesn't,
-///   while variables captured by mutable reference (e.g. `&mut T`) never implement `Copy`.
+///   Note that variables captured by shared reference always implement `Copy`
+///   (even if the referent doesn't),
+///   while variables captured by mutable reference never implement `Copy`.
 ///
 /// [`Vec<T>`]: ../../std/vec/struct.Vec.html
 /// [`String`]: ../../std/string/struct.String.html
@@ -539,7 +552,7 @@ macro_rules! impls {
 /// For a more in-depth explanation of how to use `PhantomData<T>`, please see
 /// [the Nomicon](../../nomicon/phantom-data.html).
 ///
-/// # A ghastly note 👻👻👻
+/// # A ghastly note 
 ///
 /// Though they both have scary names, `PhantomData` and 'phantom types' are
 /// related, but not identical. A phantom type parameter is simply a type

--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -319,6 +319,7 @@ pub trait StructuralEq {
 /// shared references of types `T` that are *not* `Copy`. Consider the following struct,
 /// which can implement `Copy`, because it only holds a *shared reference* to our non-`Copy`
 /// type `PointList` from above:
+///
 /// ```
 /// # #![allow(dead_code)]
 /// # struct PointList;

--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -315,7 +315,7 @@ pub trait StructuralEq {
 /// the trait `Copy` may not be implemented for this type; field `points` does not implement `Copy`
 /// ```
 ///
-/// Shared references (`&T`) are also `Copy`, so a struct can be `Copy`, even when it holds
+/// Shared references (`&T`) are also `Copy`, so a type can be `Copy`, even when it holds
 /// shared references of types `T` that are *not* `Copy`. Consider the following struct,
 /// which can implement `Copy`, because it only holds a *shared reference* to our non-`Copy`
 /// type `PointList` from above:

--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -552,7 +552,7 @@ macro_rules! impls {
 /// For a more in-depth explanation of how to use `PhantomData<T>`, please see
 /// [the Nomicon](../../nomicon/phantom-data.html).
 ///
-/// # A ghastly note 
+/// # A ghastly note 👻👻👻
 ///
 /// Though they both have scary names, `PhantomData` and 'phantom types' are
 /// related, but not identical. A phantom type parameter is simply a type

--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -347,9 +347,8 @@ pub trait StructuralEq {
 /// * Tuple types, if each component also implements `Copy` (e.g., `()`, `(i32, bool)`)
 /// * Closure types, if they capture no value from the environment
 ///   or if all such captured values implement `Copy` themselves.
-///   Note that variables captured by shared reference always implement `Copy`
-///   (even if the referent doesn't),
-///   while variables captured by mutable reference never implement `Copy`.
+/// * Variables captured by shared reference (e.g. `&T`) implement `Copy`, even if the referent (`T`) doesn't,
+///   while variables captured by mutable reference (e.g. `&mut T`) never implement `Copy`.
 ///
 /// [`Vec<T>`]: ../../std/vec/struct.Vec.html
 /// [`String`]: ../../std/string/struct.String.html

--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -291,6 +291,7 @@ pub trait StructuralEq {
 ///
 /// ```
 /// # #[allow(dead_code)]
+/// #[derive(Copy, Clone)]
 /// struct Point {
 ///    x: i32,
 ///    y: i32,

--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -323,6 +323,7 @@ pub trait StructuralEq {
 /// ```
 /// # #![allow(dead_code)]
 /// # struct PointList;
+/// #[derive(Copy, Clone)]
 /// struct PointListWrapper<'a> {
 ///     point_list_ref: &'a PointList,
 /// }


### PR DESCRIPTION
### Edited 2020-08-16 (most recent)
In the current documentation about the `Copy` marker trait, there is a section
with examples of structs that can implement `Copy`. Currently there is no example for
showing that shared references (`&T`) are also `Copy`.
It is worth to have a dedicated example for `&T` being `Copy`, because shared
references are an integral part of the language and it being `Copy` is not as
intuitive as other types that share this behaviour like `i32` or `bool`.

The example picks up on the previous non-`Copy` struct and shows that
structs can be `Copy`, even when they hold a shared reference to a non-`Copy` type.

-----------------------------------------
### Edited 2020-08-02, 3:28 p.m.
I've just realized that it says "in addition to the **implementors listed below**", which makes this PR kind of "wrong", because `&T` is indeed in the "implementors listed below".
Maybe we can instead show an example with `&T` in the [When can my type be Copy](https://doc.rust-lang.org/std/marker/trait.Copy.html#when-can-my-type-be-copy) section.

What I really want to achieve is that it becomes more obvious that `&T` is also `Copy`, because, I think, it is very valuable to know and it wasn't obvious for me, until I read something about it in a forum post.

What do you think? I would create another PR for that.
**Please feel free to close this PR.**

-----------------------------------
### Original post
In the current documentation about the `Copy` marker trait, there is a section
about "additional implementors", which list additional implementors of the `Copy` trait.
The fact that shared references are also `Copy` is mixed with another point,
which makes it hard to recognize and make it seem not as important.

This clarifies the fact that shared references are also `Copy`, by mentioning it as a
separate item in the list of "additional implementors".