### PR TITLE
Disable stylesheet objects rather than link elements

### DIFF
--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -428,7 +428,7 @@ impl Options {
                     ))
                     .emit();
                 }
-                themes.push(StylePath { path: theme_file, disabled: true });
+                themes.push(StylePath { path: theme_file });
             }
         }
 

--- a/src/librustdoc/html/layout.rs
+++ b/src/librustdoc/html/layout.rs
@@ -50,8 +50,7 @@ pub fn render<T: Print, S: Print>(
     <meta name=\"keywords\" content=\"{keywords}\">\
     <title>{title}</title>\
     <link rel=\"stylesheet\" type=\"text/css\" href=\"{static_root_path}normalize{suffix}.css\">\
-    <link rel=\"stylesheet\" type=\"text/css\" href=\"{static_root_path}rustdoc{suffix}.css\" \
-          id=\"mainThemeStyle\">\
+    <link rel=\"stylesheet\" type=\"text/css\" href=\"{static_root_path}rustdoc{suffix}.css\">\
     {style_files}\
     <script src=\"{static_root_path}storage{suffix}.js\"></script>\
     <noscript><link rel=\"stylesheet\" href=\"{static_root_path}noscript{suffix}.css\"></noscript>\
@@ -171,17 +170,11 @@ pub fn render<T: Print, S: Print>(
         krate = layout.krate,
         style_files = style_files
             .iter()
-            .filter_map(|t| {
-                if let Some(stem) = t.path.file_stem() { Some((stem, t.disabled)) } else { None }
-            })
-            .filter_map(|t| {
-                if let Some(path) = t.0.to_str() { Some((path, t.1)) } else { None }
-            })
+            .filter_map(|t| t.path.file_stem())
+            .filter_map(|t| t.to_str())
             .map(|t| format!(
-                r#"<link rel="stylesheet" type="text/css" href="{}.css" {} {}>"#,
-                Escape(&format!("{}{}{}", static_root_path, t.0, page.resource_suffix)),
-                if t.1 { "disabled" } else { "" },
-                if t.0 == "light" { "id=\"themeStyle\"" } else { "" }
+                r#"<link rel="stylesheet" type="text/css" href="{}.css">"#,
+                Escape(&format!("{}{}{}", static_root_path, t, page.resource_suffix)),
             ))
             .collect::<String>(),
         suffix = page.resource_suffix,

--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -1148,8 +1148,6 @@ pub struct IdMap {
 fn init_id_map() -> FxHashMap<String, usize> {
     let mut map = FxHashMap::default();
     // This is the list of IDs used by rustdoc templates.
-    map.insert("mainThemeStyle".to_owned(), 1);
-    map.insert("themeStyle".to_owned(), 1);
     map.insert("theme-picker".to_owned(), 1);
     map.insert("theme-choices".to_owned(), 1);
     map.insert("settings-menu".to_owned(), 1);

--- a/src/librustdoc/html/static/storage.js
+++ b/src/librustdoc/html/static/storage.js
@@ -106,7 +106,7 @@ function switchTheme(newTheme, saveTheme) {
             // The theme file for this theme name
             var themeFile = themeName + resourcesSuffix + ".css";
             var themeSheet = document.querySelector("[href$='" + themeFile + "']");
-    
+
             if (themeName === newTheme) {
                 themeSheet.disabled = false;
             } else {

--- a/src/librustdoc/html/static/storage.js
+++ b/src/librustdoc/html/static/storage.js
@@ -107,11 +107,7 @@ function switchTheme(newTheme, saveTheme) {
             var themeFile = themeName + resourcesSuffix + ".css";
             var themeSheet = document.querySelector("[href$='" + themeFile + "']");
 
-            if (themeName === newTheme) {
-                themeSheet.disabled = false;
-            } else {
-                themeSheet.disabled = true;
-            }
+            themeSheet.disabled = themeName !== newTheme;
         });
         // If this new value comes from a system setting or from the previously saved theme, no
         // need to save it.

--- a/src/librustdoc/html/static/storage.js
+++ b/src/librustdoc/html/static/storage.js
@@ -1,8 +1,6 @@
 // From rust:
 /* global resourcesSuffix */
-
-var currentTheme = document.getElementById("themeStyle");
-var mainTheme = document.getElementById("mainThemeStyle");
+/* global allThemeNames */
 
 var savedHref = [];
 
@@ -87,14 +85,9 @@ function getCurrentValue(name) {
     return null;
 }
 
-function switchTheme(styleElem, mainStyleElem, newTheme, saveTheme) {
-    var fullBasicCss = "rustdoc" + resourcesSuffix + ".css";
-    var fullNewTheme = newTheme + resourcesSuffix + ".css";
-    var newHref = mainStyleElem.href.replace(fullBasicCss, fullNewTheme);
-
-    if (styleElem.href === newHref) {
-        return;
-    }
+function switchTheme(newTheme, saveTheme) {
+    // The theme file we are switching to
+    var newThemeFile = newTheme + resourcesSuffix + ".css";
 
     var found = false;
     if (savedHref.length === 0) {
@@ -102,14 +95,24 @@ function switchTheme(styleElem, mainStyleElem, newTheme, saveTheme) {
             savedHref.push(el.href);
         });
     }
-    onEach(savedHref, function(el) {
-        if (el === newHref) {
+    onEach(savedHref, function(href) {
+        if (href.endsWith(newThemeFile)) {
             found = true;
             return true;
         }
     });
     if (found === true) {
-        styleElem.href = newHref;
+        onEach(allThemeNames, function(themeName) {
+            // The theme file for this theme name
+            var themeFile = themeName + resourcesSuffix + ".css";
+            var themeSheet = document.querySelector("[href$='" + themeFile + "']");
+    
+            if (themeName === newTheme) {
+                themeSheet.disabled = false;
+            } else {
+                themeSheet.disabled = true;
+            }
+        });
         // If this new value comes from a system setting or from the previously saved theme, no
         // need to save it.
         if (saveTheme === true) {
@@ -123,6 +126,4 @@ function getSystemValue() {
     return property.replace(/[\"\']/g, "");
 }
 
-switchTheme(currentTheme, mainTheme,
-            getCurrentValue("rustdoc-theme") || getSystemValue() || "light",
-            false);
+switchTheme(getCurrentValue("rustdoc-theme") || getSystemValue() || "light", false);


### PR DESCRIPTION
Resolves #75011.

I changed the way themes are switched in rustdoc to more closely resemble [that of mdbook](https://github.com/rust-lang/mdBook/blob/a884c2574e5729a8c0e25e3c5c4302edfba11485/src/theme/book.js#L307-L326). This method uses [StyleSheet.disabled](https://developer.mozilla.org/en-US/docs/Web/API/StyleSheet/disabled) which has much better browser support than the usage of `disabled` on `link` that I introduced in a previous PR.

As added bonuses, we no longer need to use the IDs `mainThemeStyle` or `themeStyle`, usage of `switchTheme` is simpler, and we no longer need the hack that changes the href on the `light.css` stylesheet.

I've tested this in Firefox, Chromium, and Waterfox Classic, and it works well across all those browsers. @Nemo157 would perhaps be able to test this in Safari as well?

r? @GuillaumeGomez 
