### PR TITLE
Format Duration microseconds with "us" suffix, without Unicode

### DIFF
--- a/library/core/src/time.rs
+++ b/library/core/src/time.rs
@@ -997,7 +997,7 @@ impl fmt::Debug for Duration {
             f.write_str("ms")
         } else if self.nanos >= 1_000 {
             fmt_decimal(f, self.nanos as u64 / 1_000, self.nanos % 1_000, 100)?;
-            f.write_str("µs")
+            f.write_str("us")
         } else {
             fmt_decimal(f, self.nanos as u64, 0, 1)?;
             f.write_str("ns")

--- a/library/core/tests/time.rs
+++ b/library/core/tests/time.rs
@@ -213,20 +213,20 @@ fn debug_formatting_millis() {
 
 #[test]
 fn debug_formatting_micros() {
-    assert_eq!(format!("{:?}", Duration::new(0, 7_000)), "7µs");
-    assert_eq!(format!("{:?}", Duration::new(0, 7_100)), "7.1µs");
-    assert_eq!(format!("{:?}", Duration::new(0, 7_001)), "7.001µs");
-    assert_eq!(format!("{:?}", Duration::new(0, 7_123)), "7.123µs");
+    assert_eq!(format!("{:?}", Duration::new(0, 7_000)), "7us");
+    assert_eq!(format!("{:?}", Duration::new(0, 7_100)), "7.1us");
+    assert_eq!(format!("{:?}", Duration::new(0, 7_001)), "7.001us");
+    assert_eq!(format!("{:?}", Duration::new(0, 7_123)), "7.123us");
 
-    assert_eq!(format!("{:?}", Duration::new(0, 88_000)), "88µs");
-    assert_eq!(format!("{:?}", Duration::new(0, 88_100)), "88.1µs");
-    assert_eq!(format!("{:?}", Duration::new(0, 88_001)), "88.001µs");
-    assert_eq!(format!("{:?}", Duration::new(0, 88_123)), "88.123µs");
+    assert_eq!(format!("{:?}", Duration::new(0, 88_000)), "88us");
+    assert_eq!(format!("{:?}", Duration::new(0, 88_100)), "88.1us");
+    assert_eq!(format!("{:?}", Duration::new(0, 88_001)), "88.001us");
+    assert_eq!(format!("{:?}", Duration::new(0, 88_123)), "88.123us");
 
-    assert_eq!(format!("{:?}", Duration::new(0, 999_000)), "999µs");
-    assert_eq!(format!("{:?}", Duration::new(0, 999_100)), "999.1µs");
-    assert_eq!(format!("{:?}", Duration::new(0, 999_001)), "999.001µs");
-    assert_eq!(format!("{:?}", Duration::new(0, 999_123)), "999.123µs");
+    assert_eq!(format!("{:?}", Duration::new(0, 999_000)), "999us");
+    assert_eq!(format!("{:?}", Duration::new(0, 999_100)), "999.1us");
+    assert_eq!(format!("{:?}", Duration::new(0, 999_001)), "999.001us");
+    assert_eq!(format!("{:?}", Duration::new(0, 999_123)), "999.123us");
 }
 
 #[test]
@@ -242,10 +242,10 @@ fn debug_formatting_precision_zero() {
     assert_eq!(format!("{:.0?}", Duration::new(0, 0)), "0ns");
     assert_eq!(format!("{:.0?}", Duration::new(0, 123)), "123ns");
 
-    assert_eq!(format!("{:.0?}", Duration::new(0, 1_001)), "1µs");
-    assert_eq!(format!("{:.0?}", Duration::new(0, 1_499)), "1µs");
-    assert_eq!(format!("{:.0?}", Duration::new(0, 1_500)), "2µs");
-    assert_eq!(format!("{:.0?}", Duration::new(0, 1_999)), "2µs");
+    assert_eq!(format!("{:.0?}", Duration::new(0, 1_001)), "1us");
+    assert_eq!(format!("{:.0?}", Duration::new(0, 1_499)), "1us");
+    assert_eq!(format!("{:.0?}", Duration::new(0, 1_500)), "2us");
+    assert_eq!(format!("{:.0?}", Duration::new(0, 1_999)), "2us");
 
     assert_eq!(format!("{:.0?}", Duration::new(0, 1_000_001)), "1ms");
     assert_eq!(format!("{:.0?}", Duration::new(0, 1_499_999)), "1ms");
@@ -263,12 +263,12 @@ fn debug_formatting_precision_two() {
     assert_eq!(format!("{:.2?}", Duration::new(0, 0)), "0.00ns");
     assert_eq!(format!("{:.2?}", Duration::new(0, 123)), "123.00ns");
 
-    assert_eq!(format!("{:.2?}", Duration::new(0, 1_000)), "1.00µs");
-    assert_eq!(format!("{:.2?}", Duration::new(0, 7_001)), "7.00µs");
-    assert_eq!(format!("{:.2?}", Duration::new(0, 7_100)), "7.10µs");
-    assert_eq!(format!("{:.2?}", Duration::new(0, 7_109)), "7.11µs");
-    assert_eq!(format!("{:.2?}", Duration::new(0, 7_199)), "7.20µs");
-    assert_eq!(format!("{:.2?}", Duration::new(0, 1_999)), "2.00µs");
+    assert_eq!(format!("{:.2?}", Duration::new(0, 1_000)), "1.00us");
+    assert_eq!(format!("{:.2?}", Duration::new(0, 7_001)), "7.00us");
+    assert_eq!(format!("{:.2?}", Duration::new(0, 7_100)), "7.10us");
+    assert_eq!(format!("{:.2?}", Duration::new(0, 7_109)), "7.11us");
+    assert_eq!(format!("{:.2?}", Duration::new(0, 7_199)), "7.20us");
+    assert_eq!(format!("{:.2?}", Duration::new(0, 1_999)), "2.00us");
 
     assert_eq!(format!("{:.2?}", Duration::new(0, 1_000_000)), "1.00ms");
     assert_eq!(format!("{:.2?}", Duration::new(0, 3_001_000)), "3.00ms");
@@ -285,7 +285,7 @@ fn debug_formatting_precision_two() {
 
 #[test]
 fn debug_formatting_precision_high() {
-    assert_eq!(format!("{:.5?}", Duration::new(0, 23_678)), "23.67800µs");
+    assert_eq!(format!("{:.5?}", Duration::new(0, 23_678)), "23.67800us");
 
     assert_eq!(format!("{:.9?}", Duration::new(1, 000_000_000)), "1.000000000s");
     assert_eq!(format!("{:.10?}", Duration::new(4, 001_000_000)), "4.0010000000s");


### PR DESCRIPTION
Formatting a Duration currently uses the suffix "µs" for microseconds.
However, this does not take into account whether the terminal or other
output device can handle Unicode. Make it more robust on legacy
terminals by using "us" instead.