### PR TITLE
tests: Ignore src/test/debuginfo/rc_arc.rs on Windows

### DIFF
--- a/src/test/debuginfo/rc_arc.rs
+++ b/src/test/debuginfo/rc_arc.rs
@@ -1,3 +1,4 @@
+// ignore-windows pretty-printers are not loaded
 // compile-flags:-g
 
 // min-gdb-version: 8.1


### PR DESCRIPTION
It requires loading pretty-printers (`src\etc\gdb_load_rust_pretty_printers.py`), but GDB doesn't load them on Windows.

Not sure how this passes through CI, due to an old GDB version perhaps?