### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -2101,7 +2101,7 @@ impl<T: ?Sized> Unpin for Rc<T> {}
 ///
 /// - This function is safe for any argument if `T` is sized, and
 /// - if `T` is unsized, the pointer must have appropriate pointer metadata
-///   aquired from the real instance that you are getting this offset for.
+///   acquired from the real instance that you are getting this offset for.
 unsafe fn data_offset<T: ?Sized>(ptr: *const T) -> isize {
     // Align the unsized value to the end of the `RcBox`.
     // Because it is ?Sized, it will always be the last field in memory.

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -2255,7 +2255,7 @@ impl<T: ?Sized> Unpin for Arc<T> {}
 ///
 /// - This function is safe for any argument if `T` is sized, and
 /// - if `T` is unsized, the pointer must have appropriate pointer metadata
-///   aquired from the real instance that you are getting this offset for.
+///   acquired from the real instance that you are getting this offset for.
 unsafe fn data_offset<T: ?Sized>(ptr: *const T) -> isize {
     // Align the unsized value to the end of the `ArcInner`.
     // Because it is `?Sized`, it will always be the last field in memory.

--- a/library/alloc/tests/boxed.rs
+++ b/library/alloc/tests/boxed.rs
@@ -37,7 +37,7 @@ fn box_clone_and_clone_from_equivalence() {
 /// This test might give a false positive in case the box realocates, but the alocator keeps the
 /// original pointer.
 ///
-/// On the other hand it won't give a false negative, if it fails than the memory was definitly not
+/// On the other hand it won't give a false negative, if it fails than the memory was definitely not
 /// reused
 #[test]
 fn box_clone_from_ptr_stability() {

--- a/library/std/src/alloc.rs
+++ b/library/std/src/alloc.rs
@@ -189,7 +189,7 @@ unsafe impl AllocRef for System {
             ReallocPlacement::MayMove if layout.size() == 0 => {
                 let new_layout =
                     // SAFETY: The new size and layout alignement guarantees
-                    // are transfered to the caller (they come from parameters).
+                    // are transferred to the caller (they come from parameters).
                     //
                     // See the preconditions for `Layout::from_size_align` to
                     // see what must be checked.
@@ -254,7 +254,7 @@ unsafe impl AllocRef for System {
                 //
                 // See `GlobalAlloc::realloc` for more informations about the
                 // guarantees expected by this method. `ptr`, `layout` and
-                // `new_size` are parameters and the responsability for their
+                // `new_size` are parameters and the responsibility for their
                 // correctness is left to the caller.
                 //
                 // `realloc` probably checks for `new_size < size` or something

--- a/library/std/src/keyword_docs.rs
+++ b/library/std/src/keyword_docs.rs
@@ -1363,7 +1363,7 @@ mod self_upper_keyword {}
 ///
 /// let r1 = &FOO as *const _;
 /// let r2 = &FOO as *const _;
-/// // With a strictly read-only static, references will have the same adress
+/// // With a strictly read-only static, references will have the same address
 /// assert_eq!(r1, r2);
 /// // A static item can be used just like a variable in many cases
 /// println!("{:?}", FOO);

--- a/library/std/src/sync/once.rs
+++ b/library/std/src/sync/once.rs
@@ -81,7 +81,7 @@
 //   see the changes to drop the `Waiter` struct correctly.
 // * There is one place where the two atomics `Once.state_and_queue` and
 //   `Waiter.signaled` come together, and might be reordered by the compiler or
-//   processor. Because both use Aquire ordering such a reordering is not
+//   processor. Because both use Acquire ordering such a reordering is not
 //   allowed, so no need for SeqCst.
 
 use crate::cell::Cell;

--- a/src/librustc_ast_pretty/pprust.rs
+++ b/src/librustc_ast_pretty/pprust.rs
@@ -450,7 +450,9 @@ pub trait PrintState<'a>: std::ops::Deref<Target = pp::Printer> + std::ops::Dere
     fn print_comment(&mut self, cmnt: &comments::Comment) {
         match cmnt.style {
             comments::Mixed => {
-                self.zerobreak();
+                if !self.is_beginning_of_line() {
+                    self.zerobreak();
+                }
                 if let Some((last, lines)) = cmnt.lines.split_last() {
                     self.ibox(0);
 

--- a/src/librustc_infer/infer/combine.rs
+++ b/src/librustc_infer/infer/combine.rs
@@ -166,7 +166,7 @@ impl<'infcx, 'tcx> InferCtxt<'infcx, 'tcx> {
                 return self.unify_const_variable(!a_is_expected, vid, a);
             }
             (ty::ConstKind::Unevaluated(..), _) if self.tcx.lazy_normalization() => {
-                // FIXME(#59490): Need to remove the leak check to accomodate
+                // FIXME(#59490): Need to remove the leak check to accommodate
                 // escaping bound variables here.
                 if !a.has_escaping_bound_vars() && !b.has_escaping_bound_vars() {
                     relation.const_equate_obligation(a, b);
@@ -174,7 +174,7 @@ impl<'infcx, 'tcx> InferCtxt<'infcx, 'tcx> {
                 return Ok(b);
             }
             (_, ty::ConstKind::Unevaluated(..)) if self.tcx.lazy_normalization() => {
-                // FIXME(#59490): Need to remove the leak check to accomodate
+                // FIXME(#59490): Need to remove the leak check to accommodate
                 // escaping bound variables here.
                 if !a.has_escaping_bound_vars() && !b.has_escaping_bound_vars() {
                     relation.const_equate_obligation(a, b);

--- a/src/librustc_infer/infer/error_reporting/nice_region_error/static_impl_trait.rs
+++ b/src/librustc_infer/infer/error_reporting/nice_region_error/static_impl_trait.rs
@@ -195,7 +195,7 @@ impl<'a, 'tcx> NiceRegionError<'a, 'tcx> {
             }
         }
         if let (Some(ident), true) = (override_error_code, fn_returns.is_empty()) {
-            // Provide a more targetted error code and description.
+            // Provide a more targeted error code and description.
             err.code(rustc_errors::error_code!(E0772));
             err.set_primary_message(&format!(
                 "{} has {} but calling `{}` introduces an implicit `'static` lifetime \

--- a/src/librustc_lint/unused.rs
+++ b/src/librustc_lint/unused.rs
@@ -422,10 +422,9 @@ trait UnusedDelimLint {
         lhs_needs_parens
             || (followed_by_block
                 && match inner.kind {
-                    ExprKind::Ret(_) | ExprKind::Break(..) => true,
+                    ExprKind::Ret(_) | ExprKind::Break(..) | ExprKind::Yield(..) => true,
                     _ => parser::contains_exterior_struct_lit(&inner),
                 })
-            || if let ExprKind::Yield(..) = inner.kind { true } else { false }
     }
 
     fn emit_unused_delims_expr(

--- a/src/librustc_lint/unused.rs
+++ b/src/librustc_lint/unused.rs
@@ -425,6 +425,7 @@ trait UnusedDelimLint {
                     ExprKind::Ret(_) | ExprKind::Break(..) => true,
                     _ => parser::contains_exterior_struct_lit(&inner),
                 })
+            || if let ExprKind::Yield(..) = inner.kind { true } else { false }
     }
 
     fn emit_unused_delims_expr(

--- a/src/librustc_metadata/rmeta/encoder.rs
+++ b/src/librustc_metadata/rmeta/encoder.rs
@@ -267,7 +267,7 @@ impl<'a, 'tcx> SpecializedEncoder<Span> for EncodeContext<'a, 'tcx> {
         // real code should never need to care about this.
         //
         // 2. Using `Span::def_site` or `Span::mixed_site` will not
-        // include any hygiene information associated with the defintion
+        // include any hygiene information associated with the definition
         // site. This means that a proc-macro cannot emit a `$crate`
         // identifier which resolves to one of its dependencies,
         // which also should never come up in practice.

--- a/src/librustc_middle/ty/util.rs
+++ b/src/librustc_middle/ty/util.rs
@@ -585,7 +585,7 @@ struct OpaqueTypeExpander<'tcx> {
     found_recursion: bool,
     /// Whether or not to check for recursive opaque types.
     /// This is `true` when we're explicitly checking for opaque type
-    /// recursion, and 'false' otherwise to avoid unecessary work.
+    /// recursion, and 'false' otherwise to avoid unnecessary work.
     check_recursion: bool,
     tcx: TyCtxt<'tcx>,
 }

--- a/src/librustc_mir/transform/promote_consts.rs
+++ b/src/librustc_mir/transform/promote_consts.rs
@@ -524,7 +524,7 @@ impl<'tcx> Validator<'_, 'tcx> {
                                         // The `is_empty` predicate is introduced to exclude the case
                                         // where the projection operations are [ .field, * ].
                                         // The reason is because promotion will be illegal if field
-                                        // accesses preceed the dereferencing.
+                                        // accesses precede the dereferencing.
                                         // Discussion can be found at
                                         // https://github.com/rust-lang/rust/pull/74945#discussion_r463063247
                                         // There may be opportunity for generalization, but this needs to be

--- a/src/librustc_mir_build/thir/pattern/mod.rs
+++ b/src/librustc_mir_build/thir/pattern/mod.rs
@@ -133,7 +133,7 @@ crate enum PatKind<'tcx> {
         var: hir::HirId,
         ty: Ty<'tcx>,
         subpattern: Option<Pat<'tcx>>,
-        /// Is this the leftmost occurance of the binding, i.e., is `var` the
+        /// Is this the leftmost occurrence of the binding, i.e., is `var` the
         /// `HirId` of this pattern?
         is_primary: bool,
     },

--- a/src/librustc_session/config.rs
+++ b/src/librustc_session/config.rs
@@ -1717,7 +1717,7 @@ pub fn build_session_options(matches: &getopts::Matches) -> Options {
         }
 
         // `-Z instrument-coverage` implies:
-        //   * `-Z symbol-mangling-version=v0` - to ensure consistent and reversable name mangling.
+        //   * `-Z symbol-mangling-version=v0` - to ensure consistent and reversible name mangling.
         //     Note, LLVM coverage tools can analyze coverage over multiple runs, including some
         //     changes to source code; so mangled names must be consistent across compilations.
         //   * `-C link-dead-code` - so unexecuted code is still counted as zero, rather than be

--- a/src/librustc_session/parse.rs
+++ b/src/librustc_session/parse.rs
@@ -63,7 +63,7 @@ impl GatedSpans {
 
 #[derive(Default)]
 pub struct SymbolGallery {
-    /// All symbols occurred and their first occurrance span.
+    /// All symbols occurred and their first occurrence span.
     pub symbols: Lock<BTreeMap<Symbol, Span>>,
 }
 

--- a/src/librustc_span/hygiene.rs
+++ b/src/librustc_span/hygiene.rs
@@ -891,7 +891,7 @@ impl UseSpecializedDecodable for ExpnId {}
 
 #[derive(Default)]
 pub struct HygieneEncodeContext {
-    /// All `SyntaxContexts` for which we have writen `SyntaxContextData` into crate metadata.
+    /// All `SyntaxContexts` for which we have written `SyntaxContextData` into crate metadata.
     /// This is `None` after we finish encoding `SyntaxContexts`, to ensure
     /// that we don't accidentally try to encode any more `SyntaxContexts`
     serialized_ctxts: Lock<FxHashSet<SyntaxContext>>,
@@ -961,7 +961,7 @@ pub struct HygieneDecodeContext {
     // Maps serialized `SyntaxContext` ids to a `SyntaxContext` in the current
     // global `HygieneData`. When we deserialize a `SyntaxContext`, we need to create
     // a new id in the global `HygieneData`. This map tracks the ID we end up picking,
-    // so that multiple occurences of the same serialized id are decoded to the same
+    // so that multiple occurrences of the same serialized id are decoded to the same
     // `SyntaxContext`
     remapped_ctxts: Lock<Vec<Option<SyntaxContext>>>,
     // The same as `remapepd_ctxts`, but for `ExpnId`s

--- a/src/librustc_typeck/check/coercion.rs
+++ b/src/librustc_typeck/check/coercion.rs
@@ -456,7 +456,7 @@ impl<'f, 'tcx> Coerce<'f, 'tcx> {
         //
         // Both of these trigger a special `CoerceUnsized`-related error (E0376)
         //
-        // We can take advantage of this fact to avoid performing unecessary work.
+        // We can take advantage of this fact to avoid performing unnecessary work.
         // If either `source` or `target` is a type variable, then any applicable impl
         // would need to be generic over the self-type (`impl<T> CoerceUnsized<SomeType> for T`)
         // or generic over the `CoerceUnsized` type parameter (`impl<T> CoerceUnsized<T> for

--- a/src/test/assembly/asm/aarch64-modifiers.rs
+++ b/src/test/assembly/asm/aarch64-modifiers.rs
@@ -2,6 +2,7 @@
 // assembly-output: emit-asm
 // compile-flags: -O
 // compile-flags: --target aarch64-unknown-linux-gnu
+// needs-llvm-components: aarch64
 
 #![feature(no_core, lang_items, rustc_attrs)]
 #![crate_type = "rlib"]

--- a/src/test/assembly/asm/aarch64-types.rs
+++ b/src/test/assembly/asm/aarch64-types.rs
@@ -1,6 +1,7 @@
 // no-system-llvm
 // assembly-output: emit-asm
 // compile-flags: --target aarch64-unknown-linux-gnu
+// needs-llvm-components: aarch64
 
 #![feature(no_core, lang_items, rustc_attrs, repr_simd)]
 #![crate_type = "rlib"]

--- a/src/test/assembly/asm/arm-modifiers.rs
+++ b/src/test/assembly/asm/arm-modifiers.rs
@@ -3,6 +3,7 @@
 // compile-flags: -O
 // compile-flags: --target armv7-unknown-linux-gnueabihf
 // compile-flags: -C target-feature=+neon
+// needs-llvm-components: arm
 
 #![feature(no_core, lang_items, rustc_attrs, repr_simd)]
 #![crate_type = "rlib"]

--- a/src/test/assembly/asm/arm-types.rs
+++ b/src/test/assembly/asm/arm-types.rs
@@ -2,6 +2,7 @@
 // assembly-output: emit-asm
 // compile-flags: --target armv7-unknown-linux-gnueabihf
 // compile-flags: -C target-feature=+neon
+// needs-llvm-components: arm
 
 #![feature(no_core, lang_items, rustc_attrs, repr_simd)]
 #![crate_type = "rlib"]

--- a/src/test/assembly/asm/hexagon-types.rs
+++ b/src/test/assembly/asm/hexagon-types.rs
@@ -1,6 +1,7 @@
 // no-system-llvm
 // assembly-output: emit-asm
 // compile-flags: --target hexagon-unknown-linux-musl
+// needs-llvm-components: hexagon
 
 #![feature(no_core, lang_items, rustc_attrs, repr_simd)]
 #![crate_type = "rlib"]

--- a/src/test/assembly/asm/nvptx-types.rs
+++ b/src/test/assembly/asm/nvptx-types.rs
@@ -2,6 +2,7 @@
 // assembly-output: emit-asm
 // compile-flags: --target nvptx64-nvidia-cuda
 // compile-flags: --crate-type cdylib
+// needs-llvm-components: nvptx
 
 #![feature(no_core, lang_items, rustc_attrs)]
 #![no_core]

--- a/src/test/assembly/asm/riscv-modifiers.rs
+++ b/src/test/assembly/asm/riscv-modifiers.rs
@@ -3,6 +3,7 @@
 // compile-flags: -O
 // compile-flags: --target riscv64gc-unknown-linux-gnu
 // compile-flags: -C target-feature=+f
+// needs-llvm-components: riscv
 
 #![feature(no_core, lang_items, rustc_attrs)]
 #![crate_type = "rlib"]

--- a/src/test/assembly/asm/riscv-types.rs
+++ b/src/test/assembly/asm/riscv-types.rs
@@ -4,6 +4,7 @@
 //[riscv64] compile-flags: --target riscv64imac-unknown-none-elf
 //[riscv32] compile-flags: --target riscv32imac-unknown-none-elf
 // compile-flags: -C target-feature=+d
+// needs-llvm-components: riscv
 
 #![feature(no_core, lang_items, rustc_attrs)]
 #![crate_type = "rlib"]

--- a/src/test/codegen/abi-efiapi.rs
+++ b/src/test/codegen/abi-efiapi.rs
@@ -1,12 +1,14 @@
 // Checks if the correct annotation for the efiapi ABI is passed to llvm.
 
-// revisions:x86_64 i686 arm
-
+// revisions:x86_64 i686 aarch64 arm riscv
 // min-llvm-version: 9.0
+// needs-llvm-components: aarch64 arm riscv
 
 //[x86_64] compile-flags: --target x86_64-unknown-uefi
 //[i686] compile-flags: --target i686-unknown-linux-musl
+//[aarch64] compile-flags: --target aarch64-unknown-none
 //[arm] compile-flags: --target armv7r-none-eabi
+//[riscv] compile-flags: --target riscv64gc-unknown-none-elf
 // compile-flags: -C no-prepopulate-passes
 
 #![crate_type = "lib"]
@@ -22,6 +24,8 @@ trait Copy { }
 
 //x86_64: define win64cc void @has_efiapi
 //i686: define void @has_efiapi
+//aarch64: define void @has_efiapi
 //arm: define void @has_efiapi
+//riscv: define void @has_efiapi
 #[no_mangle]
 pub extern "efiapi" fn has_efiapi() {}

--- a/src/test/codegen/avr/avr-func-addrspace.rs
+++ b/src/test/codegen/avr/avr-func-addrspace.rs
@@ -1,4 +1,5 @@
 // compile-flags: -O --target=avr-unknown-unknown --crate-type=rlib
+// needs-llvm-components: avr
 
 // This test validates that function pointers can be stored in global variables
 // and called upon. It ensures that Rust emits function pointers in the correct

--- a/src/test/pretty/block-comment-wchar.pp
+++ b/src/test/pretty/block-comment-wchar.pp
@@ -73,7 +73,6 @@ fn f() {
     */
 
 
-
     /* */
 
     /*
@@ -81,7 +80,6 @@ fn f() {
       Space 6+2:                     compare A
       Ogham Space Mark 6+2: compare B
     */
-
     /* */
 
     /*

--- a/src/test/pretty/issue-74745.rs
+++ b/src/test/pretty/issue-74745.rs
@@ -1,0 +1,5 @@
+// ignore-tidy-trailing-newlines
+// pretty-compare-only
+
+/*
+*/

--- a/src/test/ui/consts/const_in_pattern/warn_corner_cases.rs
+++ b/src/test/ui/consts/const_in_pattern/warn_corner_cases.rs
@@ -10,7 +10,7 @@
 // const-evaluator computes a value that *does* meet the conditions for
 // structural-match, but the const expression itself has abstractions (like
 // calls to const functions) that may fit better with a type-based analysis
-// rather than a committment to a specific value.
+// rather than a commitment to a specific value.
 
 #![warn(indirect_structural_match)]
 

--- a/src/test/ui/consts/issue-73976-polymorphic.rs
+++ b/src/test/ui/consts/issue-73976-polymorphic.rs
@@ -1,5 +1,5 @@
 // This test is from #73976. We previously did not check if a type is monomorphized
-// before calculating its type id, which leads to the bizzare behaviour below that
+// before calculating its type id, which leads to the bizarre behaviour below that
 // TypeId of a generic type does not match itself.
 //
 // This test case should either run-pass or be rejected at compile time.

--- a/src/test/ui/issues/issue-37131.rs
+++ b/src/test/ui/issues/issue-37131.rs
@@ -3,6 +3,7 @@
 
 // compile-flags: --target=thumbv6m-none-eabi
 // ignore-arm
+// needs-llvm-components: arm
 
 // error-pattern:target may not be installed
 fn main() { }

--- a/src/test/ui/issues/issue-49851/compiler-builtins-error.rs
+++ b/src/test/ui/issues/issue-49851/compiler-builtins-error.rs
@@ -1,6 +1,7 @@
 //~ ERROR 1:1: 1:1: can't find crate for `core` [E0463]
 
 // compile-flags: --target thumbv7em-none-eabihf
+// needs-llvm-components: arm
 #![deny(unsafe_code)]
 #![deny(warnings)]
 #![no_std]

--- a/src/test/ui/issues/issue-50993.rs
+++ b/src/test/ui/issues/issue-50993.rs
@@ -1,4 +1,5 @@
 // compile-flags: --crate-type dylib --target thumbv7em-none-eabihf
+// needs-llvm-components: arm
 // build-pass
 // error-pattern: dropping unsupported crate type `dylib` for target `thumbv7em-none-eabihf`
 

--- a/src/test/ui/lint/issue-74883-unused-paren-baren-yield.rs
+++ b/src/test/ui/lint/issue-74883-unused-paren-baren-yield.rs
@@ -1,0 +1,17 @@
+#![feature(generator_trait)]
+#![feature(generators)]
+#![deny(unused_braces, unused_parens)]
+
+use std::ops::Generator;
+use std::pin::Pin;
+
+fn main() {
+    let mut x = |_| {
+        while let Some(_) = (yield) {}
+        while let Some(_) = {yield} {}
+        // Only warn these cases
+        while let Some(_) = ({yield}) {} //~ ERROR: unnecessary parentheses
+        while let Some(_) = {(yield)} {} //~ ERROR: unnecessary braces
+    };
+    let _ = Pin::new(&mut x).resume(Some(5));
+}

--- a/src/test/ui/lint/issue-74883-unused-paren-baren-yield.rs
+++ b/src/test/ui/lint/issue-74883-unused-paren-baren-yield.rs
@@ -9,9 +9,25 @@ fn main() {
     let mut x = |_| {
         while let Some(_) = (yield) {}
         while let Some(_) = {yield} {}
+
         // Only warn these cases
         while let Some(_) = ({yield}) {} //~ ERROR: unnecessary parentheses
-        while let Some(_) = {(yield)} {} //~ ERROR: unnecessary braces
+        while let Some(_) = ((yield)) {} //~ ERROR: unnecessary parentheses
+        {{yield}}; //~ ERROR: unnecessary braces
+        {( yield )}; //~ ERROR: unnecessary parentheses
+
+        // FIXME: Reduce duplicate warnings.
+        // Perhaps we should tweak checks in `BlockRetValue`?
+        while let Some(_) = {(yield)} {}
+        //~^ ERROR: unnecessary braces
+        //~| ERROR: unnecessary parentheses
+        while let Some(_) = {{yield}} {}
+        //~^ ERROR: unnecessary braces
+        //~| ERROR: unnecessary braces
+
+        // FIXME: It'd be great if we could also warn them.
+        ((yield));
+        ({ yield });
     };
     let _ = Pin::new(&mut x).resume(Some(5));
 }

--- a/src/test/ui/lint/issue-74883-unused-paren-baren-yield.stderr
+++ b/src/test/ui/lint/issue-74883-unused-paren-baren-yield.stderr
@@ -1,5 +1,5 @@
 error: unnecessary parentheses around `let` scrutinee expression
-  --> $DIR/issue-74883-unused-paren-baren-yield.rs:13:29
+  --> $DIR/issue-74883-unused-paren-baren-yield.rs:14:29
    |
 LL |         while let Some(_) = ({yield}) {}
    |                             ^^^^^^^^^ help: remove these parentheses
@@ -10,11 +10,17 @@ note: the lint level is defined here
 LL | #![deny(unused_braces, unused_parens)]
    |                        ^^^^^^^^^^^^^
 
-error: unnecessary braces around `let` scrutinee expression
-  --> $DIR/issue-74883-unused-paren-baren-yield.rs:14:29
+error: unnecessary parentheses around `let` scrutinee expression
+  --> $DIR/issue-74883-unused-paren-baren-yield.rs:15:29
    |
-LL |         while let Some(_) = {(yield)} {}
-   |                             ^^^^^^^^^ help: remove these braces
+LL |         while let Some(_) = ((yield)) {}
+   |                             ^^^^^^^^^ help: remove these parentheses
+
+error: unnecessary braces around block return value
+  --> $DIR/issue-74883-unused-paren-baren-yield.rs:16:10
+   |
+LL |         {{yield}};
+   |          ^^^^^^^ help: remove these braces
    |
 note: the lint level is defined here
   --> $DIR/issue-74883-unused-paren-baren-yield.rs:3:9
@@ -22,5 +28,35 @@ note: the lint level is defined here
 LL | #![deny(unused_braces, unused_parens)]
    |         ^^^^^^^^^^^^^
 
-error: aborting due to 2 previous errors
+error: unnecessary parentheses around block return value
+  --> $DIR/issue-74883-unused-paren-baren-yield.rs:17:10
+   |
+LL |         {( yield )};
+   |          ^^^^^^^^^ help: remove these parentheses
+
+error: unnecessary braces around `let` scrutinee expression
+  --> $DIR/issue-74883-unused-paren-baren-yield.rs:21:29
+   |
+LL |         while let Some(_) = {(yield)} {}
+   |                             ^^^^^^^^^ help: remove these braces
+
+error: unnecessary parentheses around block return value
+  --> $DIR/issue-74883-unused-paren-baren-yield.rs:21:30
+   |
+LL |         while let Some(_) = {(yield)} {}
+   |                              ^^^^^^^ help: remove these parentheses
+
+error: unnecessary braces around `let` scrutinee expression
+  --> $DIR/issue-74883-unused-paren-baren-yield.rs:24:29
+   |
+LL |         while let Some(_) = {{yield}} {}
+   |                             ^^^^^^^^^ help: remove these braces
+
+error: unnecessary braces around block return value
+  --> $DIR/issue-74883-unused-paren-baren-yield.rs:24:30
+   |
+LL |         while let Some(_) = {{yield}} {}
+   |                              ^^^^^^^ help: remove these braces
+
+error: aborting due to 8 previous errors
 

--- a/src/test/ui/lint/issue-74883-unused-paren-baren-yield.stderr
+++ b/src/test/ui/lint/issue-74883-unused-paren-baren-yield.stderr
@@ -1,0 +1,26 @@
+error: unnecessary parentheses around `let` scrutinee expression
+  --> $DIR/issue-74883-unused-paren-baren-yield.rs:13:29
+   |
+LL |         while let Some(_) = ({yield}) {}
+   |                             ^^^^^^^^^ help: remove these parentheses
+   |
+note: the lint level is defined here
+  --> $DIR/issue-74883-unused-paren-baren-yield.rs:3:24
+   |
+LL | #![deny(unused_braces, unused_parens)]
+   |                        ^^^^^^^^^^^^^
+
+error: unnecessary braces around `let` scrutinee expression
+  --> $DIR/issue-74883-unused-paren-baren-yield.rs:14:29
+   |
+LL |         while let Some(_) = {(yield)} {}
+   |                             ^^^^^^^^^ help: remove these braces
+   |
+note: the lint level is defined here
+  --> $DIR/issue-74883-unused-paren-baren-yield.rs:3:9
+   |
+LL | #![deny(unused_braces, unused_parens)]
+   |         ^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/lint/lint-nonstandard-style-unicode-1.rs
+++ b/src/test/ui/lint/lint-nonstandard-style-unicode-1.rs
@@ -23,7 +23,7 @@ struct _ヒb;
 struct __χa;
 //~^ ERROR type `__χa` should have an upper camel case name
 
-// Besides this, we cannot have two continous underscores in the middle.
+// Besides this, we cannot have two continuous underscores in the middle.
 
 struct 对__否;
 //~^ ERROR type `对__否` should have an upper camel case name

--- a/src/test/ui/lint/lint-nonstandard-style-unicode-2.rs
+++ b/src/test/ui/lint/lint-nonstandard-style-unicode-2.rs
@@ -18,7 +18,7 @@ fn 编程() {}
 fn Ц() {}
 //~^ ERROR function `Ц` should have a snake case name
 
-// besides this, you cannot use continous underscores in the middle
+// besides this, you cannot use continuous underscores in the middle
 
 fn 分__隔() {}
 //~^ ERROR function `分__隔` should have a snake case name

--- a/src/test/ui/proc-macro/crt-static.rs
+++ b/src/test/ui/proc-macro/crt-static.rs
@@ -1,4 +1,4 @@
-// Test proc-macro crate can be built without addtional RUSTFLAGS
+// Test proc-macro crate can be built without additional RUSTFLAGS
 // on musl target
 // override -Ctarget-feature=-crt-static from compiletest
 // compile-flags: -Ctarget-feature=

--- a/src/tools/clippy/tests/ui/formatting.rs
+++ b/src/tools/clippy/tests/ui/formatting.rs
@@ -149,7 +149,7 @@ fn main() {
         1 + 2, 3 
                 - 4, 5
     ];
-    // lint if it doesnt
+    // lint if it doesn't
     let _ = &[
         -1
         -4,

--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::env;
 use std::fs::File;
 use std::io::prelude::*;
@@ -185,6 +186,17 @@ impl EarlyProps {
         fn ignore_llvm(config: &Config, line: &str) -> bool {
             if config.system_llvm && line.starts_with("no-system-llvm") {
                 return true;
+            }
+            if let Some(needed_components) =
+                config.parse_name_value_directive(line, "needs-llvm-components")
+            {
+                let components: HashSet<_> = config.llvm_components.split_whitespace().collect();
+                if !needed_components
+                    .split_whitespace()
+                    .all(|needed_component| components.contains(needed_component))
+                {
+                    return true;
+                }
             }
             if let Some(actual_version) = config.llvm_version {
                 if let Some(rest) = line.strip_prefix("min-llvm-version:").map(str::trim) {

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -178,27 +178,30 @@ pub fn make_diff(expected: &str, actual: &str, context_size: usize) -> Vec<Misma
     results
 }
 
-fn print_diff(expected: &str, actual: &str, context_size: usize) {
+fn write_diff(expected: &str, actual: &str, context_size: usize) -> String {
+    use std::fmt::Write;
+    let mut output = String::new();
     let diff_results = make_diff(expected, actual, context_size);
     for result in diff_results {
         let mut line_number = result.line_number;
         for line in result.lines {
             match line {
                 DiffLine::Expected(e) => {
-                    println!("-\t{}", e);
+                    writeln!(output, "-\t{}", e).unwrap();
                     line_number += 1;
                 }
                 DiffLine::Context(c) => {
-                    println!("{}\t{}", line_number, c);
+                    writeln!(output, "{}\t{}", line_number, c).unwrap();
                     line_number += 1;
                 }
                 DiffLine::Resulting(r) => {
-                    println!("+\t{}", r);
+                    writeln!(output, "+\t{}", r).unwrap();
                 }
             }
         }
-        println!();
+        writeln!(output, "").unwrap();
     }
+    output
 }
 
 pub fn run(config: Config, testpaths: &TestPaths, revision: Option<&str>) {
@@ -655,8 +658,12 @@ impl<'test> TestCx<'test> {
                  ------------------------------------------\n\
                  {}\n\
                  ------------------------------------------\n\
-                 \n",
-                expected, actual
+                 diff:\n\
+                 ------------------------------------------\n\
+                 {}\n",
+                expected,
+                actual,
+                write_diff(expected, actual, 3),
             ));
         }
     }
@@ -3227,7 +3234,7 @@ impl<'test> TestCx<'test> {
                     }
                     let expected_string = fs::read_to_string(&expected_file).unwrap();
                     if dumped_string != expected_string {
-                        print_diff(&expected_string, &dumped_string, 3);
+                        print!("{}", write_diff(&expected_string, &dumped_string, 3));
                         panic!(
                             "Actual MIR output differs from expected MIR output {}",
                             expected_file.display()
@@ -3452,7 +3459,7 @@ impl<'test> TestCx<'test> {
                 println!("normalized {}:\n{}\n", kind, actual);
             } else {
                 println!("diff of {}:\n", kind);
-                print_diff(expected, actual, 3);
+                print!("{}", write_diff(expected, actual, 3));
             }
         }
 


### PR DESCRIPTION
Successful merges:

 - #74980 (pprust: adjust mixed comment printing and add regression test for #74745)
 - #75009 (Document the discrepancy in the mask type for _mm_shuffle_ps)
 - #75031 (Do not trigger `unused_{braces,parens}` lints with `yield`)
 - #75059 (fix typos)
 - #75064 (compiletest: Support ignoring tests requiring missing LLVM components)

Failed merges:


r? @ghost