### PR TITLE
Fix change detection in CfgSimplifier::collapse_goto_chain

### DIFF
--- a/src/librustc_mir/transform/simplify.rs
+++ b/src/librustc_mir/transform/simplify.rs
@@ -212,6 +212,7 @@ impl<'a, 'tcx> CfgSimplifier<'a, 'tcx> {
                 Terminator { kind: TerminatorKind::Goto { ref mut target }, .. } => target,
                 _ => unreachable!(),
             };
+            *changed |= *target != last;
             *target = last;
             debug!("collapsing goto chain from {:?} to {:?}", current, target);
 
@@ -223,7 +224,6 @@ impl<'a, 'tcx> CfgSimplifier<'a, 'tcx> {
                 self.pred_count[*target] += 1;
                 self.pred_count[current] -= 1;
             }
-            *changed = true;
             self.basic_blocks[current].terminator = Some(terminator);
         }
     }

--- a/src/librustc_mir/transform/simplify.rs
+++ b/src/librustc_mir/transform/simplify.rs
@@ -142,8 +142,6 @@ impl<'a, 'tcx> CfgSimplifier<'a, 'tcx> {
                 }
 
                 self.basic_blocks[bb].terminator = Some(terminator);
-
-                changed |= inner_changed;
             }
 
             if !changed {

--- a/src/test/ui/issues/issue-75704.rs
+++ b/src/test/ui/issues/issue-75704.rs
@@ -1,0 +1,7 @@
+// Caused an infinite loop during SimlifyCfg MIR transform previously.
+//
+// build-pass
+
+fn main() {
+    loop { continue; }
+}


### PR DESCRIPTION
Check that the old target is different from the new collapsed one, before concluding that anything changed.

Fixes #75074
Fixes #75051
