### PR TITLE
Improve documentation for slice strip_* functions

### DIFF
--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -1703,8 +1703,7 @@ impl<T> [T] {
 
     /// Returns a subslice with the prefix removed.
     ///
-    /// If the slice starts with `prefix`, returns
-    /// the subslice after the prefix, wrapped in `Some`.
+    /// If the slice starts with `prefix`, returns the subslice after the prefix, wrapped in `Some`.
     ///
     /// If the slice does not start with `prefix`, returns `None`.
     ///
@@ -1738,8 +1737,7 @@ impl<T> [T] {
 
     /// Returns a subslice with the suffix removed.
     ///
-    /// If the slice ends with `suffix`, returns
-    /// the subslice before the suffix, wrapped in `Some`.
+    /// If the slice ends with `suffix`, returns the subslice before the suffix, wrapped in `Some`.
     ///
     /// If the slice does not end with `suffix`, returns `None`.
     ///

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -1704,10 +1704,9 @@ impl<T> [T] {
     /// Returns a subslice with the prefix removed.
     ///
     /// If the slice starts with `prefix`, returns the subslice after the prefix, wrapped in `Some`.
+    /// If `prefix` is empty, simply returns the original slice.
     ///
     /// If the slice does not start with `prefix`, returns `None`.
-    ///
-    /// (If `prefix` is empty, simply returns the original slice.)
     ///
     /// # Examples
     ///
@@ -1738,10 +1737,9 @@ impl<T> [T] {
     /// Returns a subslice with the suffix removed.
     ///
     /// If the slice ends with `suffix`, returns the subslice before the suffix, wrapped in `Some`.
+    /// If `suffix` is empty, simply returns the original slice.
     ///
     /// If the slice does not end with `suffix`, returns `None`.
-    ///
-    /// (If `suffix` is empty, simply returns the original slice.)
     ///
     /// # Examples
     ///

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -1703,8 +1703,12 @@ impl<T> [T] {
 
     /// Returns a subslice with the prefix removed.
     ///
-    /// This method returns [`None`] if slice does not start with `prefix`.
-    /// Also it returns the original slice if `prefix` is an empty slice.
+    /// If the slice starts with `prefix`, returns
+    /// the subslice after the prefix, wrapped in `Some`.
+    ///
+    /// If the slice does not start with `prefix`, returns `None`.
+    ///
+    /// (If `prefix` is empty, simply returns the original slice.)
     ///
     /// # Examples
     ///
@@ -1734,8 +1738,12 @@ impl<T> [T] {
 
     /// Returns a subslice with the suffix removed.
     ///
-    /// This method returns [`None`] if slice does not end with `suffix`.
-    /// Also it returns the original slice if `suffix` is an empty slice
+    /// If the slice ends with `suffix`, returns
+    /// the subslice before the suffix, wrapped in `Some`.
+    ///
+    /// If the slice does not end with `suffix`, returns `None`.
+    ///
+    /// (If `suffix` is empty, simply returns the original slice.)
     ///
     /// # Examples
     ///

--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -1964,10 +1964,8 @@ impl str {
 
     /// Returns a string slice with the prefix removed.
     ///
-    /// If the string starts with the pattern `prefix`, returns
-    /// substring after the prefix, wrapped in `Some`.
-    /// Unlike `trim_start_matches`, this method removes the
-    /// prefix exactly once.
+    /// If the string starts with the pattern `prefix`, returns substring after the prefix, wrapped
+    /// in `Some`.  Unlike `trim_start_matches`, this method removes the prefix exactly once.
     ///
     /// If the string does not start with `prefix`, returns `None`.
     ///
@@ -1993,10 +1991,8 @@ impl str {
 
     /// Returns a string slice with the suffix removed.
     ///
-    /// If the string ends with the pattern `suffix`, returns the
-    /// substring before the suffix, wrapped in `Some`.
-    /// Unlike `trim_end_matches`, this method removes the
-    /// suffix exactly once.
+    /// If the string ends with the pattern `suffix`, returns the substring before the suffix,
+    /// wrapped in `Some`.  Unlike `trim_end_matches`, this method removes the suffix exactly once.
     ///
     /// If the string does not end with `suffix`, returns `None`.
     ///

--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -1964,11 +1964,12 @@ impl str {
 
     /// Returns a string slice with the prefix removed.
     ///
-    /// If the string starts with the pattern `prefix`, `Some` is returned with the substring where
-    /// the prefix is removed. Unlike `trim_start_matches`, this method removes the prefix exactly
-    /// once.
+    /// If the string starts with the pattern `prefix`, returns
+    /// substring after the prefix, wrapped in `Some`.
+    /// Unlike `trim_start_matches`, this method removes the
+    /// prefix exactly once.
     ///
-    /// If the string does not start with `prefix`, `None` is returned.
+    /// If the string does not start with `prefix`, returns `None`.
     ///
     /// The [pattern] can be a `&str`, [`char`], a slice of [`char`]s, or a
     /// function or closure that determines if a character matches.
@@ -1992,11 +1993,12 @@ impl str {
 
     /// Returns a string slice with the suffix removed.
     ///
-    /// If the string ends with the pattern `suffix`, `Some` is returned with the substring where
-    /// the suffix is removed. Unlike `trim_end_matches`, this method removes the suffix exactly
-    /// once.
+    /// If the string ends with the pattern `suffix`, returns the
+    /// substring before the suffix, wrapped in `Some`.
+    /// Unlike `trim_end_matches`, this method removes the
+    /// suffix exactly once.
     ///
-    /// If the string does not end with `suffix`, `None` is returned.
+    /// If the string does not end with `suffix`, returns `None`.
     ///
     /// The [pattern] can be a `&str`, [`char`], a slice of [`char`]s, or a
     /// function or closure that determines if a character matches.


### PR DESCRIPTION
Prompted by the stabilisation tracking issue #73413 I looked at the docs for `strip_prefix` and `strip_suffix` for both `str` and `slice`, and I felt they could be slightly improved.

Thanks for your attention.