### PR TITLE
Transmute big endian `s6_addr` and `[u16; 8]`

### DIFF
--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -249,6 +249,7 @@
 #![feature(clamp)]
 #![feature(concat_idents)]
 #![feature(const_cstr_unchecked)]
+#![feature(const_fn_transmute)]
 #![feature(const_raw_ptr_deref)]
 #![feature(container_error_extra)]
 #![feature(core_intrinsics)]


### PR DESCRIPTION
The old code already made the assumption to reinterpret
`Ipv6Addr` as `[u16; 8]`.

Glibc, Linux, FreeBSD, Win32 all makes this assumption.
The main motivation of using union it to better optimize code.
Godbolt: https://rust.godbolt.org/z/sdP4Pc
Const is introducing unsafe when transmuting.

ref:
* https://docs.microsoft.com/en-us/windows/win32/api/in6addr/ns-in6addr-in6_addr
* https://github.com/freebsd/freebsd/blob/1d6e4247415d264485ee94b59fdbc12e0c566fd0/contrib/ntp/lib/isc/include/isc/ipv6.h#L63
* https://github.com/zephyrproject-rtos/zephyr/blob/8b531aa996bba254c03129658490af59597acd78/include/net/net_ip.h#L137
* https://sourceware.org/git/?p=glibc.git;a=blob;f=inet/netinet/in.h;h=f6355c7efe5192b88337b136ef687fe9a5ed648c;hb=HEAD#l216
