### PR TITLE
ci: disable fast-fail on auto-fallible

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -575,6 +575,7 @@ jobs:
       CACHE_DOMAIN: ci-caches-gha.rust-lang.org
     if: "github.event_name == 'push' && github.ref == 'refs/heads/auto' && github.repository == 'rust-lang-ci/rust'"
     strategy:
+      fail-fast: false
       matrix:
         include:
           - name: aarch64-gnu

--- a/src/ci/github-actions/ci.yml
+++ b/src/ci/github-actions/ci.yml
@@ -587,6 +587,7 @@ jobs:
       <<: [*shared-ci-variables, *dummy-variables]
     if: github.event_name == 'push' && github.ref == 'refs/heads/auto' && github.repository == 'rust-lang-ci/rust'
     strategy:
+      fail-fast: false
       matrix:
         include:
           #############################


### PR DESCRIPTION
The purpose of the auto-fallible job is to run builders that are likely to fail on CI without gating on them. Having fast-fail enabled there kinda defeats the purpose, as if one of them fails we can't monitor the outcome of the other ones.

This was prompted by the aarch64-gnu builder consistently failing due to a broken test, preventing us from seeing if the macOS spurious failure is fixed.

r? @Mark-Simulacrum 