### PR TITLE
Add support for "true"/"false" intra doc link

### DIFF
--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -629,9 +629,11 @@ impl Attributes {
                             Some((
                                 s.clone(),
                                 format!(
-                                    "{}{}std/primitive.{}.html{}",
+                                    "{}{}std/{}{}.html{}",
                                     url,
                                     if !url.ends_with('/') { "/" } else { "" },
+                                    // This is needed in case we are generating for keywords.
+                                    if fragment[..tail].contains(".") { "" } else { "primitive." },
                                     &fragment[..tail],
                                     &fragment[tail..]
                                 ),

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -747,30 +747,39 @@ impl<'a, 'tcx> DocFolder for LinkCollector<'a, 'tcx> {
                         };
 
                         if candidates.is_empty() {
-                            resolution_failure(cx, &item, path_str, &dox, link_range);
-                            // this could just be a normal link
-                            continue;
-                        }
-
-                        let len = candidates.clone().present_items().count();
-
-                        if len == 1 {
-                            candidates.present_items().next().unwrap()
-                        } else if len == 2 && is_derive_trait_collision(&candidates) {
-                            candidates.type_ns.unwrap()
-                        } else {
-                            if is_derive_trait_collision(&candidates) {
-                                candidates.macro_ns = None;
+                            if path_str == "true" || path_str == "false" {
+                                item.attrs.links.push((
+                                    ori_link,
+                                    None,
+                                    Some(format!("keyword.{}", path_str,)),
+                                ));
+                                continue;
+                            } else {
+                                resolution_failure(cx, &item, path_str, &dox, link_range);
+                                // this could just be a normal link
+                                continue;
                             }
-                            ambiguity_error(
-                                cx,
-                                &item,
-                                path_str,
-                                &dox,
-                                link_range,
-                                candidates.map(|candidate| candidate.map(|(res, _)| res)),
-                            );
-                            continue;
+                        } else {
+                            let len = candidates.clone().present_items().count();
+
+                            if len == 1 {
+                                candidates.present_items().next().unwrap()
+                            } else if len == 2 && is_derive_trait_collision(&candidates) {
+                                candidates.type_ns.unwrap()
+                            } else {
+                                if is_derive_trait_collision(&candidates) {
+                                    candidates.macro_ns = None;
+                                }
+                                ambiguity_error(
+                                    cx,
+                                    &item,
+                                    path_str,
+                                    &dox,
+                                    link_range,
+                                    candidates.map(|candidate| candidate.map(|(res, _)| res)),
+                                );
+                                continue;
+                            }
                         }
                     }
                     Some(MacroNS) => {

--- a/src/test/rustdoc/intra-doc-link-true-false.rs
+++ b/src/test/rustdoc/intra-doc-link-true-false.rs
@@ -1,0 +1,10 @@
+#![deny(broken_intra_doc_links)]
+#![crate_name = "foo"]
+
+// ignore-tidy-linelength
+
+// @has foo/index.html
+// @has - '//*[@id="main"]//a[@href="https://doc.rust-lang.org/nightly/std/keyword.true.html"]' 'true'
+// @has - '//*[@id="main"]//a[@href="https://doc.rust-lang.org/nightly/std/keyword.false.html"]' 'false'
+
+//! A `bool` is either [`true`] or [`false`].


### PR DESCRIPTION
Part of https://github.com/rust-lang/rust/issues/74515.

Explanations of what I did here: instead of checking more globally in primitive types, I think that only `true` and `false` values should be transformed into a link to `bool`. Others are either numbers or strings and I don't think we want to link all of them "generally". So in here, in case `true` and `false` didn't match anything (maybe a module was here, we don't know?), we then link them to the `bool` type.

r? @jyn514 

cc @rust-lang/rustdoc 