### PR TITLE
Easy way to respect BTreeMap's minimum node length

### DIFF
--- a/library/alloc/src/collections/btree/node.rs
+++ b/library/alloc/src/collections/btree/node.rs
@@ -861,17 +861,14 @@ impl<'a, K, V> Handle<NodeRef<marker::Mut<'a>, K, V, marker::Leaf>, marker::Edge
             let kv = unsafe { Handle::new_kv(self.node, self.idx) };
             (InsertResult::Fit(kv), ptr)
         } else {
-            let middle = unsafe { Handle::new_kv(self.node, B) };
+            let middle = unsafe { Handle::new_kv(self.node, B - 1) };
             let (mut left, k, v, mut right) = middle.split();
-            let ptr = if self.idx <= B {
+            let ptr = if self.idx < B {
                 unsafe { Handle::new_edge(left.reborrow_mut(), self.idx).insert_fit(key, val) }
             } else {
                 unsafe {
-                    Handle::new_edge(
-                        right.as_mut().cast_unchecked::<marker::Leaf>(),
-                        self.idx - (B + 1),
-                    )
-                    .insert_fit(key, val)
+                    Handle::new_edge(right.as_mut().cast_unchecked::<marker::Leaf>(), self.idx - B)
+                        .insert_fit(key, val)
                 }
             };
             (InsertResult::Split(SplitResult { left: left.forget_type(), k, v, right }), ptr)
@@ -934,9 +931,9 @@ impl<'a, K, V> Handle<NodeRef<marker::Mut<'a>, K, V, marker::Internal>, marker::
             let kv = unsafe { Handle::new_kv(self.node, self.idx) };
             InsertResult::Fit(kv)
         } else {
-            let middle = unsafe { Handle::new_kv(self.node, B) };
+            let middle = unsafe { Handle::new_kv(self.node, B - 1) };
             let (mut left, k, v, mut right) = middle.split();
-            if self.idx <= B {
+            if self.idx < B {
                 unsafe {
                     Handle::new_edge(left.reborrow_mut(), self.idx).insert_fit(key, val, edge);
                 }
@@ -944,7 +941,7 @@ impl<'a, K, V> Handle<NodeRef<marker::Mut<'a>, K, V, marker::Internal>, marker::
                 unsafe {
                     Handle::new_edge(
                         right.as_mut().cast_unchecked::<marker::Internal>(),
-                        self.idx - (B + 1),
+                        self.idx - B,
                     )
                     .insert_fit(key, val, edge);
                 }


### PR DESCRIPTION
Resolves #74834 the easy way.

Benchmarks (which are all biased/realistic, inserting keys in ascending order) say:
```
benchcmp r0 r3 --threshold 10
 name                                           r0 ns/iter  r3 ns/iter  diff ns/iter   diff %  speedup
 btree::map::clone_fat_100_and_drain_all        156,137     178,180           22,043   14.12%   x 0.88
 btree::map::clone_fat_100_and_drain_half       121,160     142,412           21,252   17.54%   x 0.85
 btree::map::clone_fat_100_and_pop_all          176,110     196,380           20,270   11.51%   x 0.90
 btree::map::clone_fat_100_and_remove_all       215,075     237,690           22,615   10.51%   x 0.90
 btree::map::clone_fat_100_and_remove_half      142,377     164,035           21,658   15.21%   x 0.87
 btree::map::clone_fat_val_100_and_drain_half   60,372      70,638            10,266   17.00%   x 0.85
 btree::map::clone_fat_val_100_and_remove_half  64,124      75,858            11,734   18.30%   x 0.85
 btree::map::clone_slim_100_and_clear           2,183       2,838                655   30.00%   x 0.77
 btree::map::clone_slim_100_and_drain_all       3,652       4,350                698   19.11%   x 0.84
 btree::map::clone_slim_100_and_drain_half      3,320       4,443              1,123   33.83%   x 0.75
 btree::map::clone_slim_100_and_into_iter       2,154       2,836                682   31.66%   x 0.76
 btree::map::clone_slim_100_and_pop_all         3,372       4,051                679   20.14%   x 0.83
 btree::map::clone_slim_100_and_remove_all      5,111       5,820                709   13.87%   x 0.88
 btree::map::clone_slim_100_and_remove_half     3,259       4,198                939   28.81%   x 0.78
 btree::map::clone_slim_10k                     244,160     276,820           32,660   13.38%   x 0.88
 btree::map::clone_slim_10k_and_clear           244,032     277,426           33,394   13.68%   x 0.88
 btree::map::clone_slim_10k_and_drain_all       384,035     425,290           41,255   10.74%   x 0.90
 btree::map::clone_slim_10k_and_drain_half      383,575     439,660           56,085   14.62%   x 0.87
 btree::map::clone_slim_10k_and_into_iter       241,980     274,260           32,280   13.34%   x 0.88
 btree::map::iter_0                             1,733       1,487               -246  -14.20%   x 1.17
 btree::map::iter_100                           2,714       3,707                993   36.59%   x 0.73
 btree::map::iter_10k                           3,728       4,194                466   12.50%   x 0.89
 btree::map::iter_1m                            5,570       6,581              1,011   18.15%   x 0.85
 btree::map::range_unbounded_unbounded          28,426      36,604             8,178   28.77%   x 0.78
 btree::map::range_unbounded_vs_iter            28,808      37,503             8,695   30.18%   x 0.77
 btree::set::clone_100_and_drain_half           2,935       3,458                523   17.82%   x 0.85
 btree::set::clone_100_and_remove_half          2,869       3,252                383   13.35%   x 0.88
 btree::set::clone_10k                          205,255     232,898           27,643   13.47%   x 0.88
 btree::set::clone_10k_and_clear                204,650     231,412           26,762   13.08%   x 0.88
 btree::set::clone_10k_and_drain_all            319,003     354,305           35,302   11.07%   x 0.90
 btree::set::clone_10k_and_drain_half           332,200     374,400           42,200   12.70%   x 0.89
 btree::set::clone_10k_and_into_iter            204,652     229,792           25,140   12.28%   x 0.89
 btree::set::clone_10k_and_pop_all              318,360     351,400           33,040   10.38%   x 0.91
```
r? @Mark-Simulacrum 