### PR TITLE
Make rust.use-lld config option work with non MSVC targets

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -433,7 +433,7 @@
 #
 # LLD will not be used if we're cross linking or running tests.
 #
-# Explicitly setting the linker for a target will override this option.
+# Explicitly setting the linker for a target will override this option when targeting MSVC.
 #use-lld = false
 
 # Indicates whether some LLVM tools, like llvm-objdump, will be made available in the
@@ -503,7 +503,7 @@
 # Linker to be used to link Rust code. Note that the
 # default value is platform specific, and if not specified it may also depend on
 # what platform is crossing to what platform.
-# Setting this will override the `use-lld` option for Rust code.
+# Setting this will override the `use-lld` option for Rust code when targeting MSVC.
 #linker = "cc"
 
 # Path to the `llvm-config` binary of the installation of a custom LLVM to link

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -1037,7 +1037,7 @@ impl<'a> Builder<'a> {
             }
         }
 
-        // FIXME: Don't use LLD if we're compiling libtest, since it fails to link it.
+        // FIXME: Don't use LLD with MSVC if we're compiling libtest, since it fails to link it.
         // See https://github.com/rust-lang/rust/issues/68647.
         let can_use_lld = mode != Mode::Std;
 
@@ -1049,6 +1049,11 @@ impl<'a> Builder<'a> {
             let target = crate::envify(&target.triple);
             cargo.env(&format!("CARGO_TARGET_{}_LINKER", target), target_linker);
         }
+
+        if self.config.use_lld && !target.contains("msvc") {
+            rustflags.arg("-Clink-args=-fuse-ld=lld");
+        }
+
         if !(["build", "check", "clippy", "fix", "rustc"].contains(&cmd)) && want_rustdoc {
             cargo.env("RUSTDOC_LIBDIR", self.rustc_libdir(compiler));
         }


### PR DESCRIPTION
Builds fine and passes tests on Linux.
Not overriding `use-lld` by `linker` makes sense on those platforms since very old GCC versions don't understand `-fuse-ld=lld`. This allows pointing to newer GCC or Clang that will know how to call LLD.