### PR TITLE
Stabilize Range[Inclusive]::is_empty

### DIFF
--- a/library/core/src/ops/range.rs
+++ b/library/core/src/ops/range.rs
@@ -125,8 +125,6 @@ impl<Idx: PartialOrd<Idx>> Range<Idx> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(range_is_empty)]
-    ///
     /// assert!(!(3..5).is_empty());
     /// assert!( (3..3).is_empty());
     /// assert!( (3..2).is_empty());
@@ -135,13 +133,11 @@ impl<Idx: PartialOrd<Idx>> Range<Idx> {
     /// The range is empty if either side is incomparable:
     ///
     /// ```
-    /// #![feature(range_is_empty)]
-    ///
     /// assert!(!(3.0..5.0).is_empty());
     /// assert!( (3.0..f32::NAN).is_empty());
     /// assert!( (f32::NAN..5.0).is_empty());
     /// ```
-    #[unstable(feature = "range_is_empty", reason = "recently added", issue = "48111")]
+    #[stable(feature = "range_is_empty", since = "1.47.0")]
     pub fn is_empty(&self) -> bool {
         !(self.start < self.end)
     }
@@ -481,8 +477,6 @@ impl<Idx: PartialOrd<Idx>> RangeInclusive<Idx> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(range_is_empty)]
-    ///
     /// assert!(!(3..=5).is_empty());
     /// assert!(!(3..=3).is_empty());
     /// assert!( (3..=2).is_empty());
@@ -491,8 +485,6 @@ impl<Idx: PartialOrd<Idx>> RangeInclusive<Idx> {
     /// The range is empty if either side is incomparable:
     ///
     /// ```
-    /// #![feature(range_is_empty)]
-    ///
     /// assert!(!(3.0..=5.0).is_empty());
     /// assert!( (3.0..=f32::NAN).is_empty());
     /// assert!( (f32::NAN..=5.0).is_empty());
@@ -501,14 +493,12 @@ impl<Idx: PartialOrd<Idx>> RangeInclusive<Idx> {
     /// This method returns `true` after iteration has finished:
     ///
     /// ```
-    /// #![feature(range_is_empty)]
-    ///
     /// let mut r = 3..=5;
     /// for _ in r.by_ref() {}
     /// // Precise field values are unspecified here
     /// assert!(r.is_empty());
     /// ```
-    #[unstable(feature = "range_is_empty", reason = "recently added", issue = "48111")]
+    #[stable(feature = "range_is_empty", since = "1.47.0")]
     #[inline]
     pub fn is_empty(&self) -> bool {
         self.exhausted || !(self.start <= self.end)

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -17,7 +17,6 @@
 #![feature(try_find)]
 #![feature(is_sorted)]
 #![feature(pattern)]
-#![feature(range_is_empty)]
 #![feature(raw)]
 #![feature(sort_internals)]
 #![feature(slice_partition_at_index)]

--- a/src/librustc_infer/lib.rs
+++ b/src/librustc_infer/lib.rs
@@ -22,7 +22,6 @@
 #![feature(extend_one)]
 #![feature(never_type)]
 #![feature(or_patterns)]
-#![feature(range_is_empty)]
 #![feature(in_band_lifetimes)]
 #![feature(crate_visibility_modifier)]
 #![recursion_limit = "512"] // For rustdoc

--- a/src/librustc_middle/lib.rs
+++ b/src/librustc_middle/lib.rs
@@ -40,7 +40,6 @@
 #![feature(nll)]
 #![feature(option_expect_none)]
 #![feature(or_patterns)]
-#![feature(range_is_empty)]
 #![feature(min_specialization)]
 #![feature(trusted_len)]
 #![feature(stmt_expr_attributes)]

--- a/src/librustc_mir/lib.rs
+++ b/src/librustc_mir/lib.rs
@@ -22,7 +22,6 @@ Rust MIR: a lowered representation of Rust.
 #![feature(try_blocks)]
 #![feature(associated_type_bounds)]
 #![feature(associated_type_defaults)]
-#![feature(range_is_empty)]
 #![feature(stmt_expr_attributes)]
 #![feature(trait_alias)]
 #![feature(option_expect_none)]

--- a/src/test/ui/range_inclusive.rs
+++ b/src/test/ui/range_inclusive.rs
@@ -1,6 +1,5 @@
 // run-pass
 // Test inclusive range syntax.
-#![feature(range_is_empty)]
 #![allow(unused_braces)]
 #![allow(unused_comparisons)]
 

--- a/src/tools/clippy/tests/ui/len_zero_ranges.fixed
+++ b/src/tools/clippy/tests/ui/len_zero_ranges.fixed
@@ -3,6 +3,7 @@
 #![feature(range_is_empty)]
 #![warn(clippy::len_zero)]
 #![allow(unused)]
+#![allow(stable_features)] // TODO: https://github.com/rust-lang/rust-clippy/issues/5956
 
 mod issue_3807 {
     // With the feature enabled, `is_empty` should be suggested

--- a/src/tools/clippy/tests/ui/len_zero_ranges.rs
+++ b/src/tools/clippy/tests/ui/len_zero_ranges.rs
@@ -3,6 +3,7 @@
 #![feature(range_is_empty)]
 #![warn(clippy::len_zero)]
 #![allow(unused)]
+#![allow(stable_features)] // TODO: https://github.com/rust-lang/rust-clippy/issues/5956
 
 mod issue_3807 {
     // With the feature enabled, `is_empty` should be suggested

--- a/src/tools/clippy/tests/ui/len_zero_ranges.stderr
+++ b/src/tools/clippy/tests/ui/len_zero_ranges.stderr
@@ -1,5 +1,5 @@
 error: length comparison to zero
-  --> $DIR/len_zero_ranges.rs:10:17
+  --> $DIR/len_zero_ranges.rs:11:17
    |
 LL |         let _ = (0..42).len() == 0;
    |                 ^^^^^^^^^^^^^^^^^^ help: using `is_empty` is clearer and more explicit: `(0..42).is_empty()`


### PR DESCRIPTION
I would like to propose these two simple methods for stabilization:
- Knowing that a range is exhausted isn't otherwise trivial
- Clippy would like to suggest them, but had to do extra work to disable that path <https://github.com/rust-lang/rust-clippy/issues/3807> because they're unstable
- These work on `PartialOrd`, consistently with the stable `contains` method, and are thus more general than iterator-based approaches that need `Step`
- They've been unchanged for some time, and have picked up uses in the compiler
- Stabilizing them doesn't block any future iterator-based `is_empty` plans, as these inherent ones are preferred in name resolution

https://doc.rust-lang.org/nightly/std/ops/struct.Range.html#method.is_empty
https://doc.rust-lang.org/nightly/std/ops/struct.RangeInclusive.html#method.is_empty

Closes #48111