### PR TITLE
Forbid non-derefable types explicitly in unsizing casts

### DIFF
--- a/src/librustc_mir/transform/qualify_min_const_fn.rs
+++ b/src/librustc_mir/transform/qualify_min_const_fn.rs
@@ -193,7 +193,15 @@ fn check_rvalue(
             _,
         ) => Err((span, "function pointer casts are not allowed in const fn".into())),
         Rvalue::Cast(CastKind::Pointer(PointerCast::Unsize), op, cast_ty) => {
-            let pointee_ty = cast_ty.builtin_deref(true).unwrap().ty;
+            let pointee_ty = if let Some(deref_ty) = cast_ty.builtin_deref(true) {
+                deref_ty.ty
+            } else {
+                // We cannot allow this for now.
+                return Err((
+                    span,
+                    "unsizing casts are only allowed for references right now".into(),
+                ));
+            };
             let unsized_ty = tcx.struct_tail_erasing_lifetimes(pointee_ty, tcx.param_env(def_id));
             if let ty::Slice(_) | ty::Str = unsized_ty.kind {
                 check_operand(tcx, op, span, def_id, body)?;

--- a/src/test/ui/consts/unsizing-cast-non-null.rs
+++ b/src/test/ui/consts/unsizing-cast-non-null.rs
@@ -1,0 +1,10 @@
+// Regression test for #75118.
+
+use std::ptr::NonNull;
+
+pub const fn dangling_slice<T>() -> NonNull<[T]> {
+    NonNull::<[T; 0]>::dangling()
+    //~^ ERROR: unsizing casts are only allowed for references right now
+}
+
+fn main() {}

--- a/src/test/ui/consts/unsizing-cast-non-null.stderr
+++ b/src/test/ui/consts/unsizing-cast-non-null.stderr
@@ -1,0 +1,12 @@
+error[E0723]: unsizing casts are only allowed for references right now
+  --> $DIR/unsizing-cast-non-null.rs:6:5
+   |
+LL |     NonNull::<[T; 0]>::dangling()
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0723`.


### PR DESCRIPTION
Fixes #75118
r? @oli-obk 