### PR TITLE
Implementation of peer credentials for Unix sockets

### DIFF
--- a/library/std/src/sys/unix/ext/mod.rs
+++ b/library/std/src/sys/unix/ext/mod.rs
@@ -37,6 +37,18 @@ pub mod process;
 pub mod raw;
 pub mod thread;
 
+#[unstable(feature = "peer_credentials_unix_socket", issue = "42839", reason = "unstable")]
+#[cfg(any(
+    target_os = "android",
+    target_os = "linux",
+    target_os = "dragonfly",
+    target_os = "freebsd",
+    target_os = "ios",
+    target_os = "macos",
+    target_os = "openbsd"
+))]
+pub mod ucred;
+
 /// A prelude for conveniently writing platform-specific code.
 ///
 /// Includes all extension traits, and some important type definitions.

--- a/library/std/src/sys/unix/ext/net.rs
+++ b/library/std/src/sys/unix/ext/net.rs
@@ -31,6 +31,29 @@ use crate::sys_common::{self, AsInner, FromInner, IntoInner};
 use crate::time::Duration;
 
 #[cfg(any(
+    target_os = "android",
+    target_os = "linux",
+    target_os = "dragonfly",
+    target_os = "freebsd",
+    target_os = "ios",
+    target_os = "macos",
+    target_os = "openbsd"
+))]
+use crate::os::unix::ucred;
+
+#[unstable(feature = "peer_credentials_unix_socket", issue = "42839", reason = "unstable")]
+#[cfg(any(
+    target_os = "android",
+    target_os = "linux",
+    target_os = "dragonfly",
+    target_os = "freebsd",
+    target_os = "ios",
+    target_os = "macos",
+    target_os = "openbsd"
+))]
+pub use ucred::UCred;
+
+#[cfg(any(
     target_os = "linux",
     target_os = "android",
     target_os = "dragonfly",
@@ -403,6 +426,24 @@ impl UnixStream {
     #[stable(feature = "unix_socket", since = "1.10.0")]
     pub fn peer_addr(&self) -> io::Result<SocketAddr> {
         SocketAddr::new(|addr, len| unsafe { libc::getpeername(*self.0.as_inner(), addr, len) })
+    }
+
+    /// Gets the peer credentials for this Unix domain socket.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use std::os::unix::net::UnixStream;
+    ///
+    /// fn main() -> std::io::Result<()> {
+    ///     let socket = UnixStream::connect("/tmp/sock")?;
+    ///     let peer_cred = socket.peer_cred().expect("Couldn't get peer credentials");
+    ///     Ok(())
+    /// }
+    /// ```
+    #[unstable(feature = "peer_credentials_unix_socket", issue = "42839", reason = "unstable")]
+    pub fn peer_cred(&self) -> io::Result<UCred> {
+        ucred::peer_cred(self)
     }
 
     /// Sets the read timeout for the socket.

--- a/library/std/src/sys/unix/ext/net.rs
+++ b/library/std/src/sys/unix/ext/net.rs
@@ -433,6 +433,7 @@ impl UnixStream {
     /// # Examples
     ///
     /// ```no_run
+    /// #![feature(peer_credentials_unix_socket)]
     /// use std::os::unix::net::UnixStream;
     ///
     /// fn main() -> std::io::Result<()> {

--- a/library/std/src/sys/unix/ext/net.rs
+++ b/library/std/src/sys/unix/ext/net.rs
@@ -443,6 +443,15 @@ impl UnixStream {
     /// }
     /// ```
     #[unstable(feature = "peer_credentials_unix_socket", issue = "42839", reason = "unstable")]
+    #[cfg(any(
+        target_os = "android",
+        target_os = "linux",
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "openbsd"
+    ))]
     pub fn peer_cred(&self) -> io::Result<UCred> {
         ucred::peer_cred(self)
     }

--- a/library/std/src/sys/unix/ext/ucred.rs
+++ b/library/std/src/sys/unix/ext/ucred.rs
@@ -42,7 +42,7 @@ pub mod impl_linux {
 
         // Trivial sanity checks.
         assert!(mem::size_of::<u32>() <= mem::size_of::<usize>());
-        assert!(ucred_size <= u32::max_value() as usize);
+        assert!(ucred_size <= u32::MAX as usize);
 
         let mut ucred_size = ucred_size as u32;
         let mut ucred: ucred = ucred { pid: 1, uid: 1, gid: 1 };

--- a/library/std/src/sys/unix/ext/ucred.rs
+++ b/library/std/src/sys/unix/ext/ucred.rs
@@ -87,3 +87,23 @@ pub mod impl_bsd {
         }
     }
 }
+
+#[cfg(test)]
+mod test {
+    use crate::os::unix::net::UnixStream;
+    use libc::{getegid, geteuid};
+
+    #[test]
+    fn test_socket_pair() {
+        // Create two connected sockets and get their peer credentials. They should be equal.
+        let (sock_a, sock_b) = UnixStream::pair().unwrap();
+        let (cred_a, cred_b) = (sock_a.peer_cred().unwrap(), sock_b.peer_cred().unwrap());
+        assert_eq!(cred_a, cred_b);
+
+        // Check that the UID and GIDs match up.
+        let uid = unsafe { geteuid() };
+        let gid = unsafe { getegid() };
+        assert_eq!(cred_a.uid, uid);
+        assert_eq!(cred_a.gid, gid);
+    }
+}

--- a/library/std/src/sys/unix/ext/ucred.rs
+++ b/library/std/src/sys/unix/ext/ucred.rs
@@ -12,9 +12,16 @@ use libc::{gid_t, pid_t, uid_t};
 #[unstable(feature = "peer_credentials_unix_socket", issue = "42839", reason = "unstable")]
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct UCred {
+    /// The UID part of the peer credential. This is the effective UID of the process at the domain
+    /// socket's endpoint.
     pub uid: uid_t,
+    /// The GID part of the peer credential. This is the effective GID of the process at the domain
+    /// socket's endpoint.
     pub gid: gid_t,
-    // pid field is an option because it is not supported on some platforms.
+    /// The PID part of the peer credential. This field is optional because the PID part of the
+    /// peer credentials is not supported on every platform. On platforms where the mechanism to
+    /// discover the PID exists, this field will be populated to the PID of the process at the
+    /// domain socket's endpoint. Otherwise, it will be set to None.
     pub pid: Option<pid_t>,
 }
 

--- a/library/std/src/sys/unix/ext/ucred.rs
+++ b/library/std/src/sys/unix/ext/ucred.rs
@@ -89,23 +89,3 @@ pub mod impl_bsd {
         }
     }
 }
-
-#[cfg(test)]
-mod test {
-    use crate::os::unix::net::UnixStream;
-    use libc::{getegid, geteuid};
-
-    #[test]
-    fn test_socket_pair() {
-        // Create two connected sockets and get their peer credentials. They should be equal.
-        let (sock_a, sock_b) = UnixStream::pair().unwrap();
-        let (cred_a, cred_b) = (sock_a.peer_cred().unwrap(), sock_b.peer_cred().unwrap());
-        assert_eq!(cred_a, cred_b);
-
-        // Check that the UID and GIDs match up.
-        let uid = unsafe { geteuid() };
-        let gid = unsafe { getegid() };
-        assert_eq!(cred_a.uid, uid);
-        assert_eq!(cred_a.gid, gid);
-    }
-}

--- a/library/std/src/sys/unix/ext/ucred.rs
+++ b/library/std/src/sys/unix/ext/ucred.rs
@@ -1,0 +1,92 @@
+//! Unix peer credentials.
+
+// NOTE: Code in this file is heavily based on work done in PR 13 from the tokio-uds repository on
+//       GitHub.
+//
+//       For reference, the link is here: https://github.com/tokio-rs/tokio-uds/pull/13
+//       Credit to Martin Habovštiak (GitHub username Kixunil) and contributors for this work.
+
+use libc::{gid_t, uid_t};
+
+/// Credentials for a UNIX process for credentials passing.
+#[unstable(feature = "peer_credentials_unix_socket", issue = "42839", reason = "unstable")]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct UCred {
+    pub uid: uid_t,
+    pub gid: gid_t,
+}
+
+#[cfg(any(target_os = "android", target_os = "linux"))]
+pub use self::impl_linux::peer_cred;
+
+#[cfg(any(
+    target_os = "dragonfly",
+    target_os = "freebsd",
+    target_os = "ios",
+    target_os = "macos",
+    target_os = "openbsd"
+))]
+pub use self::impl_bsd::peer_cred;
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+pub mod impl_linux {
+    use super::UCred;
+    use crate::mem::MaybeUninit;
+    use crate::os::unix::io::AsRawFd;
+    use crate::os::unix::net::UnixStream;
+    use crate::{io, mem};
+
+    pub fn peer_cred(socket: &UnixStream) -> io::Result<UCred> {
+        use libc::{c_void, ucred};
+
+        let ucred_size = mem::size_of::<ucred>();
+
+        // Trivial sanity checks.
+        assert!(mem::size_of::<u32>() <= mem::size_of::<usize>());
+        assert!(ucred_size <= u32::max_value() as usize);
+
+        let mut ucred_size = ucred_size as u32;
+
+        unsafe {
+            let mut ucred: ucred = MaybeUninit::uninit().assume_init();
+            let ret = libc::getsockopt(
+                socket.as_raw_fd(),
+                libc::SOL_SOCKET,
+                libc::SO_PEERCRED,
+                &mut ucred as *mut ucred as *mut c_void,
+                &mut ucred_size,
+            );
+
+            if ret == 0 && ucred_size as usize == mem::size_of::<ucred>() {
+                Ok(UCred { uid: ucred.uid, gid: ucred.gid })
+            } else {
+                Err(io::Error::last_os_error())
+            }
+        }
+    }
+}
+
+#[cfg(any(
+    target_os = "dragonfly",
+    target_os = "macos",
+    target_os = "ios",
+    target_os = "freebsd",
+    target_os = "openbsd"
+))]
+pub mod impl_bsd {
+    use super::UCred;
+    use crate::io;
+    use crate::mem::MaybeUninit;
+    use crate::os::unix::io::AsRawFd;
+    use crate::os::unix::net::UnixStream;
+
+    pub fn peer_cred(socket: &UnixStream) -> io::Result<UCred> {
+        unsafe {
+            // Create `cred` and attempt to populate it.
+            let mut cred: UCred = MaybeUninit::uninit().assume_init();
+            let ret = libc::getpeereid(socket.as_raw_fd(), &mut cred.uid, &mut cred.gid);
+
+            if ret == 0 { Ok(cred) } else { Err(io::Error::last_os_error()) }
+        }
+    }
+}

--- a/library/std/src/sys/unix/ext/ucred/tests.rs
+++ b/library/std/src/sys/unix/ext/ucred/tests.rs
@@ -2,6 +2,15 @@ use crate::os::unix::net::UnixStream;
 use libc::{getegid, geteuid};
 
 #[test]
+#[cfg(any(
+    target_os = "android",
+    target_os = "linux",
+    target_os = "dragonfly",
+    target_os = "freebsd",
+    target_os = "ios",
+    target_os = "macos",
+    target_os = "openbsd"
+))]
 fn test_socket_pair() {
     // Create two connected sockets and get their peer credentials. They should be equal.
     let (sock_a, sock_b) = UnixStream::pair().unwrap();

--- a/library/std/src/sys/unix/ext/ucred/tests.rs
+++ b/library/std/src/sys/unix/ext/ucred/tests.rs
@@ -1,0 +1,16 @@
+use crate::os::unix::net::UnixStream;
+use libc::{getegid, geteuid};
+
+#[test]
+fn test_socket_pair() {
+    // Create two connected sockets and get their peer credentials. They should be equal.
+    let (sock_a, sock_b) = UnixStream::pair().unwrap();
+    let (cred_a, cred_b) = (sock_a.peer_cred().unwrap(), sock_b.peer_cred().unwrap());
+    assert_eq!(cred_a, cred_b);
+
+    // Check that the UID and GIDs match up.
+    let uid = unsafe { geteuid() };
+    let gid = unsafe { getegid() };
+    assert_eq!(cred_a.uid, uid);
+    assert_eq!(cred_a.gid, gid);
+}

--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -714,7 +714,6 @@ class RustBuild(object):
         # See also: <https://github.com/rust-lang/rust/issues/70208>.
         if "CARGO_BUILD_TARGET" in env:
             del env["CARGO_BUILD_TARGET"]
-        env["RUSTC_BOOTSTRAP"] = '1'
         env["CARGO_TARGET_DIR"] = build_dir
         env["RUSTC"] = self.rustc()
         env["LD_LIBRARY_PATH"] = os.path.join(self.bin_root(), "lib") + \

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -103,8 +103,6 @@
 //! More documentation can be found in each respective module below, and you can
 //! also check out the `src/bootstrap/README.md` file for more information.
 
-#![feature(drain_filter)]
-
 use std::cell::{Cell, RefCell};
 use std::collections::{HashMap, HashSet};
 use std::env;

--- a/src/bootstrap/tool.rs
+++ b/src/bootstrap/tool.rs
@@ -162,13 +162,15 @@ impl Step for ToolBuild {
                 "the following dependencies are duplicated although they \
                       have the same features enabled:"
             );
-            for (id, cur, prev) in duplicates.drain_filter(|(_, cur, prev)| cur.2 == prev.2) {
+            let (same, different): (Vec<_>, Vec<_>) =
+                duplicates.into_iter().partition(|(_, cur, prev)| cur.2 == prev.2);
+            for (id, cur, prev) in same {
                 println!("  {}", id);
                 // same features
                 println!("    `{}` ({:?})\n    `{}` ({:?})", cur.0, cur.1, prev.0, prev.1);
             }
             println!("the following dependencies have different features:");
-            for (id, cur, prev) in duplicates {
+            for (id, cur, prev) in different {
                 println!("  {}", id);
                 let cur_features: HashSet<_> = cur.2.into_iter().collect();
                 let prev_features: HashSet<_> = prev.2.into_iter().collect();


### PR DESCRIPTION
The code in `ucred.rs` is based on the work done in [PR 13](https://github.com/tokio-rs/tokio-uds/pull/13) in the tokio-uds repository on GitHub.

This commit is effectively a port to the stdlib, so credit to Martin Habovštiak (@Kixunil) and contributors for the meat of this work. 🥇 

Happy to make changes as needed. 🙂 