### PR TITLE
Add a note for Ipv4Addr::to_ipv6_compatible

### DIFF
--- a/library/std/src/net/ip.rs
+++ b/library/std/src/net/ip.rs
@@ -745,6 +745,9 @@ impl Ipv4Addr {
     ///
     /// a.b.c.d becomes ::a.b.c.d
     ///
+    /// This isn't typically the method you want; these addresses don't typically
+    /// function on modern systems. Use `to_ipv6_mapped` instead.
+    ///
     /// [`IPv6` address]: Ipv6Addr
     ///
     /// # Examples


### PR DESCRIPTION
Previous discussion: #75019 

> I think adding a comment saying "This isn't typically the method you want; these addresses don't typically function on modern systems. Use `to_ipv6_mapped` instead." would be a good first step, whether this method gets marked as deprecated or not.

_Originally posted by @joshtriplett in https://github.com/rust-lang/rust/pull/75150#issuecomment-680267745_