### PR TITLE
Constified str::from_utf8_unchecked

### DIFF
--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -381,12 +381,6 @@ pub fn from_utf8_mut(v: &mut [u8]) -> Result<&mut str, Utf8Error> {
     Ok(unsafe { from_utf8_unchecked_mut(v) })
 }
 
-#[repr(C)]
-union StrOrSlice<'a> {
-    str: &'a str,
-    slice: &'a [u8],
-}
-
 /// Converts a slice of bytes to a string slice without checking
 /// that the string contains valid UTF-8.
 ///
@@ -422,11 +416,11 @@ union StrOrSlice<'a> {
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_const_unstable(feature = "const_str_from_utf8_unchecked", issue = "75196")]
 #[allow(unused_attributes)]
-#[allow_internal_unstable(const_fn_union)]
+#[allow_internal_unstable(const_fn_transmute)]
 pub const unsafe fn from_utf8_unchecked(v: &[u8]) -> &str {
     // SAFETY: the caller must guarantee that the bytes `v` are valid UTF-8.
     // Also relies on `&str` and `&[u8]` having the same layout.
-    unsafe { StrOrSlice { slice: v }.str }
+    unsafe { mem::transmute(self) }
 }
 
 /// Converts a slice of bytes to a string slice without checking
@@ -2355,10 +2349,10 @@ impl str {
     #[rustc_const_stable(feature = "str_as_bytes", since = "1.32.0")]
     #[inline(always)]
     #[allow(unused_attributes)]
-    #[allow_internal_unstable(const_fn_union)]
+    #[allow_internal_unstable(const_fn_transmute)]
     pub const fn as_bytes(&self) -> &[u8] {
         // SAFETY: const sound because we transmute two types with the same layout
-        unsafe { StrOrSlice { str: self }.slice }
+        unsafe { mem::transmute(self) }
     }
 
     /// Converts a mutable string slice to a mutable byte slice.

--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -381,14 +381,11 @@ pub fn from_utf8_mut(v: &mut [u8]) -> Result<&mut str, Utf8Error> {
     Ok(unsafe { from_utf8_unchecked_mut(v) })
 }
 
-
 #[repr(C)]
 union StrOrSlice<'a> {
     str: &'a str,
     slice: &'a [u8],
 }
-
-
 
 /// Converts a slice of bytes to a string slice without checking
 /// that the string contains valid UTF-8.
@@ -429,9 +426,8 @@ union StrOrSlice<'a> {
 pub const unsafe fn from_utf8_unchecked(v: &[u8]) -> &str {
     // SAFETY: the caller must guarantee that the bytes `v` are valid UTF-8.
     // Also relies on `&str` and `&[u8]` having the same layout.
-    unsafe{ StrOrSlice{ slice: v }.str }
+    unsafe { StrOrSlice { slice: v }.str }
 }
-
 
 /// Converts a slice of bytes to a string slice without checking
 /// that the string contains valid UTF-8; mutable version.

--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -22,7 +22,7 @@ use crate::slice::{self, SliceIndex, Split as SliceSplit};
 
 pub mod pattern;
 
-#[unstable(feature = "str_internals", issue = "75196")]
+#[unstable(feature = "str_internals", issue = "none")]
 #[allow(missing_docs)]
 pub mod lossy;
 
@@ -423,7 +423,7 @@ union StrOrSlice<'a> {
 /// ```
 #[inline]
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_const_unstable(feature = "const_str_from_utf8_unchecked", issue = "none")]
+#[rustc_const_unstable(feature = "const_str_from_utf8_unchecked", issue = "75196")]
 #[allow(unused_attributes)]
 #[allow_internal_unstable(const_fn_union)]
 pub const unsafe fn from_utf8_unchecked(v: &[u8]) -> &str {

--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -22,7 +22,7 @@ use crate::slice::{self, SliceIndex, Split as SliceSplit};
 
 pub mod pattern;
 
-#[unstable(feature = "str_internals", issue = "none")]
+#[unstable(feature = "str_internals", issue = "75196")]
 #[allow(missing_docs)]
 pub mod lossy;
 
@@ -2361,7 +2361,7 @@ impl str {
     #[allow(unused_attributes)]
     #[allow_internal_unstable(const_fn_union)]
     pub const fn as_bytes(&self) -> &[u8] {
-        
+
         // SAFETY: const sound because we transmute two types with the same layout
         unsafe { StrOrSlice { str: self }.slice }
     }

--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -420,7 +420,7 @@ pub fn from_utf8_mut(v: &mut [u8]) -> Result<&mut str, Utf8Error> {
 pub const unsafe fn from_utf8_unchecked(v: &[u8]) -> &str {
     // SAFETY: the caller must guarantee that the bytes `v` are valid UTF-8.
     // Also relies on `&str` and `&[u8]` having the same layout.
-    unsafe { mem::transmute(self) }
+    unsafe { mem::transmute(v) }
 }
 
 /// Converts a slice of bytes to a string slice without checking

--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -2357,7 +2357,6 @@ impl str {
     #[allow(unused_attributes)]
     #[allow_internal_unstable(const_fn_union)]
     pub const fn as_bytes(&self) -> &[u8] {
-
         // SAFETY: const sound because we transmute two types with the same layout
         unsafe { StrOrSlice { str: self }.slice }
     }


### PR DESCRIPTION
This would be useful for const code to use an array to construct a string using guaranteed utf8 inputs, and then create a `&str` from it.