### PR TITLE
Fix the documentation for move about Fn traits implementations

### DIFF
--- a/library/std/src/keyword_docs.rs
+++ b/library/std/src/keyword_docs.rs
@@ -945,16 +945,28 @@ mod mod_keyword {}
 /// `move` converts any variables captured by reference or mutable reference
 /// to owned by value variables.
 ///
-/// Note: `move` closures may still implement [`Fn`] or [`FnMut`], even though
-/// they capture variables by `move`. This is because the traits implemented by
-/// a closure type are determined by *what* the closure does with captured
-/// values, not *how* it captures them.
-///
 /// ```rust
 /// let capture = "hello";
 /// let closure = move || {
 ///     println!("rust says {}", capture);
 /// };
+/// ```
+///
+/// Note: `move` closures may still implement [`Fn`] or [`FnMut`], even though
+/// they capture variables by `move`. This is because the traits implemented by
+/// a closure type are determined by *what* the closure does with captured
+/// values, not *how* it captures them:
+///
+/// ```rust
+/// fn create_fn() -> impl Fn() {
+///     let text = "Fn".to_owned();
+///
+///     move || println!("This is a: {}", text)
+/// }
+///
+///     let fn_plain = create_fn();
+///
+///     fn_plain();
 /// ```
 ///
 /// `move` is often used when [threads] are involved.

--- a/library/std/src/keyword_docs.rs
+++ b/library/std/src/keyword_docs.rs
@@ -943,8 +943,12 @@ mod mod_keyword {}
 /// Capture a [closure]'s environment by value.
 ///
 /// `move` converts any variables captured by reference or mutable reference
-/// to owned by value variables. The three [`Fn` trait]'s mirror the ways to capture
-/// variables, when `move` is used, the closures is represented by the `FnOnce` trait.
+/// to owned by value variables.
+///
+/// Note: `move` closures may still implement [`Fn`] or [`FnMut`], even though
+/// they capture variables by `move`. This is because the traits implemented by
+/// a closure type are determined by *what* the closure does with captured
+/// values, not *how* it captures them.
 ///
 /// ```rust
 /// let capture = "hello";


### PR DESCRIPTION
Fixes #74997.

This uses the note from the [reference](https://doc.rust-lang.org/reference/types/closure.html#call-traits-and-coercions) but I can also just put a link to it or do both.

@rusbot modify labels: C-bug T-doc T-libs