### PR TITLE
manually implement traits for Span

### DIFF
--- a/src/librustc_span/lib.rs
+++ b/src/librustc_span/lib.rs
@@ -14,6 +14,7 @@
 #![feature(min_specialization)]
 #![feature(option_expect_none)]
 #![feature(refcell_take)]
+#![feature(structural_match)]
 
 // FIXME(#56935): Work around ICEs during cross-compilation.
 #[allow(unused)]

--- a/src/librustc_span/span_encoding.rs
+++ b/src/librustc_span/span_encoding.rs
@@ -65,7 +65,7 @@ use std::mem;
 #[derive(Clone, Copy)]
 #[repr(C)] // So we can transmute to a `u64`.
 pub struct Span {
-    // We can transmute `SpanBaseOrIndex` to an `u32` as it is internally
+    // We can transmute `SpanBaseOrIndex` to `u32` as it is internally
     // represented as a scalar value.
     base_or_index: SpanBaseOrIndex,
     len_or_tag: u16,

--- a/src/librustc_span/span_encoding.rs
+++ b/src/librustc_span/span_encoding.rs
@@ -73,6 +73,7 @@ pub struct Span {
 }
 
 rustc_index::newtype_index! {
+    #[repr(transparent)]
     pub struct SpanBaseOrIndex {
         const DUMMY_SPAN_INDEX = 0,
     }

--- a/src/librustc_span/span_encoding.rs
+++ b/src/librustc_span/span_encoding.rs
@@ -13,6 +13,7 @@ use rustc_data_structures::fx::FxHashMap;
 use std::cmp::{Eq, PartialEq};
 use std::hash::{Hash, Hasher};
 use std::mem;
+use std::marker::{StructuralEq, StructuralPartialEq};
 
 /// A compressed span.
 ///
@@ -84,7 +85,11 @@ impl PartialEq for Span {
     }
 }
 
+impl StructuralPartialEq for Span {}
+
 impl Eq for Span {}
+
+impl StructuralEq for Span {}
 
 impl Hash for Span {
     #[inline]


### PR DESCRIPTION
`PartialEq::eq` is used a few billion times, so it might be worth it to go the extra mile here.

This also changes `base_or_index` to a `newtype_index`, meaning that the 256 highest values are used as a niche, thereby allowing `Option<Span>` to have the same size as `Span`.

r? @nnethercote 