### PR TITLE
Upgrade Chalk to 0.21

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -427,9 +427,9 @@ dependencies = [
 
 [[package]]
 name = "chalk-derive"
-version = "0.14.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d463e01905d607e181de72e8608721d3269f29176c9a14ce037011316ae7131d"
+checksum = "c1df0dbb57d74b4acd20f20fa66ab2acd09776b79eaeb9d8f947b2f3e01c40bf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -439,21 +439,22 @@ dependencies = [
 
 [[package]]
 name = "chalk-engine"
-version = "0.14.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efaf428f5398d36284f79690cf988762b7c091249f50a6c11db613a46c057000"
+checksum = "fb7c65a13f32f02aba8f1d9a37f206af615f77ac564624b81a4c593c6c1735b9"
 dependencies = [
  "chalk-derive",
  "chalk-ir",
+ "chalk-solve",
  "rustc-hash",
  "tracing",
 ]
 
 [[package]]
 name = "chalk-ir"
-version = "0.14.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd3fdc1e9f68498ffe80f4a23b0b95f1ca6fb21d5a4c9b0c085fab3ca712bdbe"
+checksum = "44361a25dbdb1dc428f56ad7a3c21ba9ca12f3225c26a47919ff6fcb10a583d4"
 dependencies = [
  "chalk-derive",
  "lazy_static",
@@ -461,18 +462,19 @@ dependencies = [
 
 [[package]]
 name = "chalk-solve"
-version = "0.14.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b9fd4102807b7ebe8fb034fa0f488c5656e1966d3261b558b81a08d519cdb29"
+checksum = "a886da37a0dc457057d86f78f026f7a09c6d8088aa13f4f4127fdb8dc80119a3"
 dependencies = [
  "chalk-derive",
- "chalk-engine",
  "chalk-ir",
  "ena",
  "itertools 0.9.0",
  "petgraph",
  "rustc-hash",
  "tracing",
+ "tracing-subscriber",
+ "tracing-tree",
 ]
 
 [[package]]
@@ -4038,6 +4040,7 @@ dependencies = [
 name = "rustc_traits"
 version = "0.0.0"
 dependencies = [
+ "chalk-engine",
  "chalk-ir",
  "chalk-solve",
  "rustc_ast",
@@ -4997,20 +5000,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-log"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e0f8c7178e13481ff6765bd169b33e8d554c5d2bbede5e32c356194be02b9b9"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6ccba2f8f16e0ed268fc765d9b7ff22e965e7185d32f8f1ec8294fe17d86e79"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abd165311cc4d7a555ad11cc77a37756df836182db0d81aac908c8184c584f40"
 dependencies = [
  "ansi_term 0.12.1",
+ "chrono",
  "lazy_static",
  "matchers",
  "parking_lot 0.11.0",
  "regex",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec 1.4.2",
  "thread_local",
  "tracing-core",
+ "tracing-log",
+ "tracing-serde",
+]
+
+[[package]]
+name = "tracing-tree"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1a3dc4774db3a6b2d66a4f8d8de670e874ec3ed55615860c994927419b32c5f"
+dependencies = [
+ "ansi_term 0.12.1",
+ "atty",
+ "chrono",
+ "termcolor",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/compiler/rustc_middle/Cargo.toml
+++ b/compiler/rustc_middle/Cargo.toml
@@ -27,7 +27,7 @@ rustc_serialize = { path = "../rustc_serialize" }
 rustc_ast = { path = "../rustc_ast" }
 rustc_span = { path = "../rustc_span" }
 byteorder = { version = "1.3" }
-chalk-ir = "0.14.0"
+chalk-ir = "0.21.0"
 smallvec = { version = "1.0", features = ["union", "may_dangle"] }
 measureme = "0.7.1"
 rustc_session = { path = "../rustc_session" }

--- a/compiler/rustc_middle/src/traits/chalk.rs
+++ b/compiler/rustc_middle/src/traits/chalk.rs
@@ -75,6 +75,7 @@ impl<'tcx> chalk_ir::interner::Interner for RustInterner<'tcx> {
     type InternedQuantifiedWhereClauses = Vec<chalk_ir::QuantifiedWhereClause<Self>>;
     type InternedVariableKinds = Vec<chalk_ir::VariableKind<Self>>;
     type InternedCanonicalVarKinds = Vec<chalk_ir::CanonicalVarKind<Self>>;
+    type InternedConstraints = Vec<chalk_ir::InEnvironment<chalk_ir::Constraint<Self>>>;
     type DefId = DefId;
     type InternedAdtId = &'tcx AdtDef;
     type Identifier = ();
@@ -320,6 +321,20 @@ impl<'tcx> chalk_ir::interner::Interner for RustInterner<'tcx> {
         canonical_var_kinds: &'a Self::InternedCanonicalVarKinds,
     ) -> &'a [chalk_ir::CanonicalVarKind<Self>] {
         canonical_var_kinds
+    }
+
+    fn intern_constraints<E>(
+        &self,
+        data: impl IntoIterator<Item = Result<chalk_ir::InEnvironment<chalk_ir::Constraint<Self>>, E>>,
+    ) -> Result<Self::InternedConstraints, E> {
+        data.into_iter().collect::<Result<Vec<_>, _>>()
+    }
+
+    fn constraints_data<'a>(
+        &self,
+        constraints: &'a Self::InternedConstraints,
+    ) -> &'a [chalk_ir::InEnvironment<chalk_ir::Constraint<Self>>] {
+        constraints
     }
 }
 

--- a/compiler/rustc_traits/Cargo.toml
+++ b/compiler/rustc_traits/Cargo.toml
@@ -12,8 +12,9 @@ rustc_hir = { path = "../rustc_hir" }
 rustc_index = { path = "../rustc_index" }
 rustc_ast = { path = "../rustc_ast" }
 rustc_span = { path = "../rustc_span" }
-chalk-ir = "0.14.0"
-chalk-solve = "0.14.0"
+chalk-ir = "0.21.0"
+chalk-solve = "0.21.0"
+chalk-engine = "0.21.0"
 smallvec = { version = "1.0", features = ["union", "may_dangle"] }
 rustc_infer = { path = "../rustc_infer" }
 rustc_trait_selection = { path = "../rustc_trait_selection" }

--- a/compiler/rustc_traits/src/chalk/lowering.rs
+++ b/compiler/rustc_traits/src/chalk/lowering.rs
@@ -60,6 +60,12 @@ impl<'tcx> LowerInto<'tcx, chalk_ir::Substitution<RustInterner<'tcx>>> for Subst
     }
 }
 
+impl<'tcx> LowerInto<'tcx, SubstsRef<'tcx>> for &chalk_ir::Substitution<RustInterner<'tcx>> {
+    fn lower_into(self, interner: &RustInterner<'tcx>) -> SubstsRef<'tcx> {
+        interner.tcx.mk_substs(self.iter(interner).map(|subst| subst.lower_into(interner)))
+    }
+}
+
 impl<'tcx> LowerInto<'tcx, chalk_ir::AliasTy<RustInterner<'tcx>>> for ty::ProjectionTy<'tcx> {
     fn lower_into(self, interner: &RustInterner<'tcx>) -> chalk_ir::AliasTy<RustInterner<'tcx>> {
         chalk_ir::AliasTy::Projection(chalk_ir::ProjectionTy {
@@ -76,104 +82,29 @@ impl<'tcx> LowerInto<'tcx, chalk_ir::InEnvironment<chalk_ir::Goal<RustInterner<'
         self,
         interner: &RustInterner<'tcx>,
     ) -> chalk_ir::InEnvironment<chalk_ir::Goal<RustInterner<'tcx>>> {
-        let clauses = self.environment.into_iter().filter_map(|clause| match clause {
+        let clauses = self.environment.into_iter().map(|clause| match clause {
             ChalkEnvironmentClause::Predicate(predicate) => {
-                // FIXME(chalk): forall
-                match predicate.bound_atom(interner.tcx).skip_binder() {
-                    ty::PredicateAtom::Trait(predicate, _) => {
-                        let predicate = ty::Binder::bind(predicate);
-                        let (predicate, binders, _named_regions) =
-                            collect_bound_vars(interner, interner.tcx, &predicate);
-
-                        Some(
-                            chalk_ir::ProgramClauseData(chalk_ir::Binders::new(
-                                binders,
-                                chalk_ir::ProgramClauseImplication {
-                                    consequence: chalk_ir::DomainGoal::FromEnv(
-                                        chalk_ir::FromEnv::Trait(
-                                            predicate.trait_ref.lower_into(interner),
-                                        ),
-                                    ),
-                                    conditions: chalk_ir::Goals::empty(interner),
-                                    priority: chalk_ir::ClausePriority::High,
-                                    constraints: chalk_ir::Constraints::empty(interner),
-                                },
-                            ))
-                            .intern(interner),
-                        )
-                    }
-                    ty::PredicateAtom::RegionOutlives(predicate) => {
-                        let predicate = ty::Binder::bind(predicate);
-                        let (predicate, binders, _named_regions) =
-                            collect_bound_vars(interner, interner.tcx, &predicate);
-
-                        Some(
-                            chalk_ir::ProgramClauseData(chalk_ir::Binders::new(
-                                binders,
-                                chalk_ir::ProgramClauseImplication {
-                                    consequence: chalk_ir::DomainGoal::Holds(
-                                        chalk_ir::WhereClause::LifetimeOutlives(
-                                            chalk_ir::LifetimeOutlives {
-                                                a: predicate.0.lower_into(interner),
-                                                b: predicate.1.lower_into(interner),
-                                            },
-                                        ),
-                                    ),
-                                    conditions: chalk_ir::Goals::empty(interner),
-                                    priority: chalk_ir::ClausePriority::High,
-                                    constraints: chalk_ir::Constraints::empty(interner),
-                                },
-                            ))
-                            .intern(interner),
-                        )
-                    }
-                    ty::PredicateAtom::TypeOutlives(predicate) => {
-                        let predicate = ty::Binder::bind(predicate);
-                        let (predicate, binders, _named_regions) =
-                            collect_bound_vars(interner, interner.tcx, &predicate);
-
-                        Some(
-                            chalk_ir::ProgramClauseData(chalk_ir::Binders::new(
-                                binders,
-                                chalk_ir::ProgramClauseImplication {
-                                    consequence: chalk_ir::DomainGoal::Holds(
-                                        chalk_ir::WhereClause::TypeOutlives(
-                                            chalk_ir::TypeOutlives {
-                                                ty: predicate.0.lower_into(interner),
-                                                lifetime: predicate.1.lower_into(interner),
-                                            },
-                                        ),
-                                    ),
-                                    conditions: chalk_ir::Goals::empty(interner),
-                                    priority: chalk_ir::ClausePriority::High,
-                                    constraints: chalk_ir::Constraints::empty(interner),
-                                },
-                            ))
-                            .intern(interner),
-                        )
-                    }
-                    ty::PredicateAtom::Projection(predicate) => {
-                        let predicate = ty::Binder::bind(predicate);
-                        let (predicate, binders, _named_regions) =
-                            collect_bound_vars(interner, interner.tcx, &predicate);
-
-                        Some(
-                            chalk_ir::ProgramClauseData(chalk_ir::Binders::new(
-                                binders,
-                                chalk_ir::ProgramClauseImplication {
-                                    consequence: chalk_ir::DomainGoal::Holds(
-                                        chalk_ir::WhereClause::AliasEq(
-                                            predicate.lower_into(interner),
-                                        ),
-                                    ),
-                                    conditions: chalk_ir::Goals::empty(interner),
-                                    priority: chalk_ir::ClausePriority::High,
-                                    constraints: chalk_ir::Constraints::empty(interner),
-                                },
-                            ))
-                            .intern(interner),
-                        )
-                    }
+                let (predicate, binders, _named_regions) =
+                    collect_bound_vars(interner, interner.tcx, &predicate.bound_atom(interner.tcx));
+                let consequence = match predicate {
+                    ty::PredicateAtom::Trait(predicate, _) => chalk_ir::DomainGoal::FromEnv(
+                        chalk_ir::FromEnv::Trait(predicate.trait_ref.lower_into(interner)),
+                    ),
+                    ty::PredicateAtom::RegionOutlives(predicate) => chalk_ir::DomainGoal::Holds(
+                        chalk_ir::WhereClause::LifetimeOutlives(chalk_ir::LifetimeOutlives {
+                            a: predicate.0.lower_into(interner),
+                            b: predicate.1.lower_into(interner),
+                        }),
+                    ),
+                    ty::PredicateAtom::TypeOutlives(predicate) => chalk_ir::DomainGoal::Holds(
+                        chalk_ir::WhereClause::TypeOutlives(chalk_ir::TypeOutlives {
+                            ty: predicate.0.lower_into(interner),
+                            lifetime: predicate.1.lower_into(interner),
+                        }),
+                    ),
+                    ty::PredicateAtom::Projection(predicate) => chalk_ir::DomainGoal::Holds(
+                        chalk_ir::WhereClause::AliasEq(predicate.lower_into(interner)),
+                    ),
                     ty::PredicateAtom::WellFormed(..)
                     | ty::PredicateAtom::ObjectSafe(..)
                     | ty::PredicateAtom::ClosureKind(..)
@@ -182,9 +113,16 @@ impl<'tcx> LowerInto<'tcx, chalk_ir::InEnvironment<chalk_ir::Goal<RustInterner<'
                     | ty::PredicateAtom::ConstEquate(..) => {
                         bug!("unexpected predicate {}", predicate)
                     }
-                }
+                };
+                let value = chalk_ir::ProgramClauseImplication {
+                    consequence,
+                    conditions: chalk_ir::Goals::empty(interner),
+                    priority: chalk_ir::ClausePriority::High,
+                    constraints: chalk_ir::Constraints::empty(interner),
+                };
+                chalk_ir::ProgramClauseData(chalk_ir::Binders::new(binders, value)).intern(interner)
             }
-            ChalkEnvironmentClause::TypeFromEnv(ty) => Some(
+            ChalkEnvironmentClause::TypeFromEnv(ty) => {
                 chalk_ir::ProgramClauseData(chalk_ir::Binders::new(
                     chalk_ir::VariableKinds::empty(interner),
                     chalk_ir::ProgramClauseImplication {
@@ -196,8 +134,8 @@ impl<'tcx> LowerInto<'tcx, chalk_ir::InEnvironment<chalk_ir::Goal<RustInterner<'
                         constraints: chalk_ir::Constraints::empty(interner),
                     },
                 ))
-                .intern(interner),
-            ),
+                .intern(interner)
+            }
         });
 
         let goal: chalk_ir::GoalData<RustInterner<'tcx>> = self.goal.lower_into(&interner);
@@ -212,36 +150,35 @@ impl<'tcx> LowerInto<'tcx, chalk_ir::InEnvironment<chalk_ir::Goal<RustInterner<'
 
 impl<'tcx> LowerInto<'tcx, chalk_ir::GoalData<RustInterner<'tcx>>> for ty::Predicate<'tcx> {
     fn lower_into(self, interner: &RustInterner<'tcx>) -> chalk_ir::GoalData<RustInterner<'tcx>> {
-        // FIXME(chalk): forall
-        match self.bound_atom(interner.tcx).skip_binder() {
+        let (predicate, binders, _named_regions) =
+            collect_bound_vars(interner, interner.tcx, &self.bound_atom(interner.tcx));
+
+        let value = match predicate {
             ty::PredicateAtom::Trait(predicate, _) => {
-                ty::Binder::bind(predicate).lower_into(interner)
+                chalk_ir::GoalData::DomainGoal(chalk_ir::DomainGoal::Holds(
+                    chalk_ir::WhereClause::Implemented(predicate.trait_ref.lower_into(interner)),
+                ))
             }
             ty::PredicateAtom::RegionOutlives(predicate) => {
-                let predicate = ty::Binder::bind(predicate);
-                let (predicate, binders, _named_regions) =
-                    collect_bound_vars(interner, interner.tcx, &predicate);
-
-                chalk_ir::GoalData::Quantified(
-                    chalk_ir::QuantifierKind::ForAll,
-                    chalk_ir::Binders::new(
-                        binders,
-                        chalk_ir::GoalData::DomainGoal(chalk_ir::DomainGoal::Holds(
-                            chalk_ir::WhereClause::LifetimeOutlives(chalk_ir::LifetimeOutlives {
-                                a: predicate.0.lower_into(interner),
-                                b: predicate.1.lower_into(interner),
-                            }),
-                        ))
-                        .intern(interner),
-                    ),
-                )
+                chalk_ir::GoalData::DomainGoal(chalk_ir::DomainGoal::Holds(
+                    chalk_ir::WhereClause::LifetimeOutlives(chalk_ir::LifetimeOutlives {
+                        a: predicate.0.lower_into(interner),
+                        b: predicate.1.lower_into(interner),
+                    }),
+                ))
             }
-            // FIXME(chalk): TypeOutlives
-            ty::PredicateAtom::TypeOutlives(_predicate) => {
-                chalk_ir::GoalData::All(chalk_ir::Goals::empty(interner))
+            ty::PredicateAtom::TypeOutlives(predicate) => {
+                chalk_ir::GoalData::DomainGoal(chalk_ir::DomainGoal::Holds(
+                    chalk_ir::WhereClause::TypeOutlives(chalk_ir::TypeOutlives {
+                        ty: predicate.0.lower_into(interner),
+                        lifetime: predicate.1.lower_into(interner),
+                    }),
+                ))
             }
             ty::PredicateAtom::Projection(predicate) => {
-                ty::Binder::bind(predicate).lower_into(interner)
+                chalk_ir::GoalData::DomainGoal(chalk_ir::DomainGoal::Holds(
+                    chalk_ir::WhereClause::AliasEq(predicate.lower_into(interner)),
+                ))
             }
             ty::PredicateAtom::WellFormed(arg) => match arg.unpack() {
                 GenericArgKind::Type(ty) => match ty.kind() {
@@ -252,21 +189,9 @@ impl<'tcx> LowerInto<'tcx, chalk_ir::GoalData<RustInterner<'tcx>>> for ty::Predi
                         chalk_ir::GoalData::All(chalk_ir::Goals::empty(interner))
                     }
 
-                    _ => {
-                        let (ty, binders, _named_regions) =
-                            collect_bound_vars(interner, interner.tcx, &ty::Binder::bind(ty));
-
-                        chalk_ir::GoalData::Quantified(
-                            chalk_ir::QuantifierKind::ForAll,
-                            chalk_ir::Binders::new(
-                                binders,
-                                chalk_ir::GoalData::DomainGoal(chalk_ir::DomainGoal::WellFormed(
-                                    chalk_ir::WellFormed::Ty(ty.lower_into(interner)),
-                                ))
-                                .intern(interner),
-                            ),
-                        )
-                    }
+                    _ => chalk_ir::GoalData::DomainGoal(chalk_ir::DomainGoal::WellFormed(
+                        chalk_ir::WellFormed::Ty(ty.lower_into(interner)),
+                    )),
                 },
                 // FIXME(chalk): handle well formed consts
                 GenericArgKind::Const(..) => {
@@ -289,7 +214,12 @@ impl<'tcx> LowerInto<'tcx, chalk_ir::GoalData<RustInterner<'tcx>>> for ty::Predi
             | ty::PredicateAtom::ConstEquate(..) => {
                 chalk_ir::GoalData::All(chalk_ir::Goals::empty(interner))
             }
-        }
+        };
+
+        chalk_ir::GoalData::Quantified(
+            chalk_ir::QuantifierKind::ForAll,
+            chalk_ir::Binders::new(binders, value.intern(interner)),
+        )
     }
 }
 
@@ -304,25 +234,6 @@ impl<'tcx> LowerInto<'tcx, chalk_ir::TraitRef<RustInterner<'tcx>>>
     }
 }
 
-impl<'tcx> LowerInto<'tcx, chalk_ir::GoalData<RustInterner<'tcx>>>
-    for ty::PolyTraitPredicate<'tcx>
-{
-    fn lower_into(self, interner: &RustInterner<'tcx>) -> chalk_ir::GoalData<RustInterner<'tcx>> {
-        let (ty, binders, _named_regions) = collect_bound_vars(interner, interner.tcx, &self);
-
-        chalk_ir::GoalData::Quantified(
-            chalk_ir::QuantifierKind::ForAll,
-            chalk_ir::Binders::new(
-                binders,
-                chalk_ir::GoalData::DomainGoal(chalk_ir::DomainGoal::Holds(
-                    chalk_ir::WhereClause::Implemented(ty.trait_ref.lower_into(interner)),
-                ))
-                .intern(interner),
-            ),
-        )
-    }
-}
-
 impl<'tcx> LowerInto<'tcx, chalk_ir::AliasEq<RustInterner<'tcx>>>
     for rustc_middle::ty::ProjectionPredicate<'tcx>
 {
@@ -331,25 +242,6 @@ impl<'tcx> LowerInto<'tcx, chalk_ir::AliasEq<RustInterner<'tcx>>>
             ty: self.ty.lower_into(interner),
             alias: self.projection_ty.lower_into(interner),
         }
-    }
-}
-
-impl<'tcx> LowerInto<'tcx, chalk_ir::GoalData<RustInterner<'tcx>>>
-    for ty::PolyProjectionPredicate<'tcx>
-{
-    fn lower_into(self, interner: &RustInterner<'tcx>) -> chalk_ir::GoalData<RustInterner<'tcx>> {
-        let (ty, binders, _named_regions) = collect_bound_vars(interner, interner.tcx, &self);
-
-        chalk_ir::GoalData::Quantified(
-            chalk_ir::QuantifierKind::ForAll,
-            chalk_ir::Binders::new(
-                binders,
-                chalk_ir::GoalData::DomainGoal(chalk_ir::DomainGoal::Holds(
-                    chalk_ir::WhereClause::AliasEq(ty.lower_into(interner)),
-                ))
-                .intern(interner),
-            ),
-        )
     }
 }
 
@@ -393,7 +285,8 @@ impl<'tcx> LowerInto<'tcx, chalk_ir::Ty<RustInterner<'tcx>>> for Ty<'tcx> {
                 ast::FloatTy::F64 => float(chalk_ir::FloatTy::F64),
             },
             Adt(def, substs) => apply(struct_ty(def.did), substs.lower_into(interner)),
-            Foreign(_def_id) => unimplemented!(),
+            // FIXME(chalk): lower Foreign
+            Foreign(def_id) => apply(chalk_ir::TypeName::FnDef(chalk_ir::FnDefId(def_id)), empty()),
             Str => apply(chalk_ir::TypeName::Str, empty()),
             Array(ty, len) => {
                 let value = match len.val {
@@ -520,6 +413,111 @@ impl<'tcx> LowerInto<'tcx, chalk_ir::Ty<RustInterner<'tcx>>> for Ty<'tcx> {
     }
 }
 
+impl<'tcx> LowerInto<'tcx, Ty<'tcx>> for &chalk_ir::Ty<RustInterner<'tcx>> {
+    fn lower_into(self, interner: &RustInterner<'tcx>) -> Ty<'tcx> {
+        use chalk_ir::TyData;
+        use rustc_ast::ast;
+
+        let kind = match self.data(interner) {
+            TyData::Apply(application_ty) => match application_ty.name {
+                chalk_ir::TypeName::Adt(struct_id) => {
+                    ty::Adt(struct_id.0, application_ty.substitution.lower_into(interner))
+                }
+                chalk_ir::TypeName::Scalar(scalar) => match scalar {
+                    chalk_ir::Scalar::Bool => ty::Bool,
+                    chalk_ir::Scalar::Char => ty::Char,
+                    chalk_ir::Scalar::Int(int_ty) => match int_ty {
+                        chalk_ir::IntTy::Isize => ty::Int(ast::IntTy::Isize),
+                        chalk_ir::IntTy::I8 => ty::Int(ast::IntTy::I8),
+                        chalk_ir::IntTy::I16 => ty::Int(ast::IntTy::I16),
+                        chalk_ir::IntTy::I32 => ty::Int(ast::IntTy::I32),
+                        chalk_ir::IntTy::I64 => ty::Int(ast::IntTy::I64),
+                        chalk_ir::IntTy::I128 => ty::Int(ast::IntTy::I128),
+                    },
+                    chalk_ir::Scalar::Uint(int_ty) => match int_ty {
+                        chalk_ir::UintTy::Usize => ty::Uint(ast::UintTy::Usize),
+                        chalk_ir::UintTy::U8 => ty::Uint(ast::UintTy::U8),
+                        chalk_ir::UintTy::U16 => ty::Uint(ast::UintTy::U16),
+                        chalk_ir::UintTy::U32 => ty::Uint(ast::UintTy::U32),
+                        chalk_ir::UintTy::U64 => ty::Uint(ast::UintTy::U64),
+                        chalk_ir::UintTy::U128 => ty::Uint(ast::UintTy::U128),
+                    },
+                    chalk_ir::Scalar::Float(float_ty) => match float_ty {
+                        chalk_ir::FloatTy::F32 => ty::Float(ast::FloatTy::F32),
+                        chalk_ir::FloatTy::F64 => ty::Float(ast::FloatTy::F64),
+                    },
+                },
+                chalk_ir::TypeName::Array => unimplemented!(),
+                chalk_ir::TypeName::FnDef(id) => {
+                    ty::FnDef(id.0, application_ty.substitution.lower_into(interner))
+                }
+                chalk_ir::TypeName::Closure(closure) => {
+                    ty::Closure(closure.0, application_ty.substitution.lower_into(interner))
+                }
+                chalk_ir::TypeName::Never => ty::Never,
+                chalk_ir::TypeName::Tuple(_size) => {
+                    ty::Tuple(application_ty.substitution.lower_into(interner))
+                }
+                chalk_ir::TypeName::Slice => ty::Slice(
+                    application_ty.substitution.as_slice(interner)[0]
+                        .ty(interner)
+                        .unwrap()
+                        .lower_into(interner),
+                ),
+                chalk_ir::TypeName::Raw(mutbl) => ty::RawPtr(ty::TypeAndMut {
+                    ty: application_ty.substitution.as_slice(interner)[0]
+                        .ty(interner)
+                        .unwrap()
+                        .lower_into(interner),
+                    mutbl: match mutbl {
+                        chalk_ir::Mutability::Mut => ast::Mutability::Mut,
+                        chalk_ir::Mutability::Not => ast::Mutability::Not,
+                    },
+                }),
+                chalk_ir::TypeName::Ref(mutbl) => ty::Ref(
+                    application_ty.substitution.as_slice(interner)[0]
+                        .lifetime(interner)
+                        .unwrap()
+                        .lower_into(interner),
+                    application_ty.substitution.as_slice(interner)[1]
+                        .ty(interner)
+                        .unwrap()
+                        .lower_into(interner),
+                    match mutbl {
+                        chalk_ir::Mutability::Mut => ast::Mutability::Mut,
+                        chalk_ir::Mutability::Not => ast::Mutability::Not,
+                    },
+                ),
+                chalk_ir::TypeName::Str => ty::Str,
+                chalk_ir::TypeName::OpaqueType(opaque_ty) => {
+                    ty::Opaque(opaque_ty.0, application_ty.substitution.lower_into(interner))
+                }
+                chalk_ir::TypeName::AssociatedType(assoc_ty) => ty::Projection(ty::ProjectionTy {
+                    substs: application_ty.substitution.lower_into(interner),
+                    item_def_id: assoc_ty.0,
+                }),
+                chalk_ir::TypeName::Error => unimplemented!(),
+            },
+            TyData::Placeholder(placeholder) => ty::Placeholder(ty::Placeholder {
+                universe: ty::UniverseIndex::from_usize(placeholder.ui.counter),
+                name: ty::BoundVar::from_usize(placeholder.idx),
+            }),
+            TyData::Alias(_alias_ty) => unimplemented!(),
+            TyData::Function(_quantified_ty) => unimplemented!(),
+            TyData::BoundVar(_bound) => ty::Bound(
+                ty::DebruijnIndex::from_usize(_bound.debruijn.depth() as usize),
+                ty::BoundTy {
+                    var: ty::BoundVar::from_usize(_bound.index),
+                    kind: ty::BoundTyKind::Anon,
+                },
+            ),
+            TyData::InferenceVar(_, _) => unimplemented!(),
+            TyData::Dyn(_) => unimplemented!(),
+        };
+        interner.tcx.mk_ty(kind)
+    }
+}
+
 impl<'tcx> LowerInto<'tcx, chalk_ir::Lifetime<RustInterner<'tcx>>> for Region<'tcx> {
     fn lower_into(self, interner: &RustInterner<'tcx>) -> chalk_ir::Lifetime<RustInterner<'tcx>> {
         use rustc_middle::ty::RegionKind::*;
@@ -557,6 +555,59 @@ impl<'tcx> LowerInto<'tcx, chalk_ir::Lifetime<RustInterner<'tcx>>> for Region<'t
     }
 }
 
+impl<'tcx> LowerInto<'tcx, Region<'tcx>> for &chalk_ir::Lifetime<RustInterner<'tcx>> {
+    fn lower_into(self, interner: &RustInterner<'tcx>) -> Region<'tcx> {
+        let kind = match self.data(interner) {
+            chalk_ir::LifetimeData::BoundVar(var) => ty::RegionKind::ReLateBound(
+                ty::DebruijnIndex::from_u32(var.debruijn.depth()),
+                ty::BoundRegion::BrAnon(var.index as u32),
+            ),
+            chalk_ir::LifetimeData::InferenceVar(_var) => unimplemented!(),
+            chalk_ir::LifetimeData::Placeholder(p) => {
+                ty::RegionKind::RePlaceholder(ty::Placeholder {
+                    universe: ty::UniverseIndex::from_usize(p.ui.counter),
+                    name: ty::BoundRegion::BrAnon(p.idx as u32),
+                })
+            }
+            chalk_ir::LifetimeData::Phantom(_, _) => unimplemented!(),
+        };
+        interner.tcx.mk_region(kind)
+    }
+}
+
+impl<'tcx> LowerInto<'tcx, chalk_ir::Const<RustInterner<'tcx>>> for ty::Const<'tcx> {
+    fn lower_into(self, interner: &RustInterner<'tcx>) -> chalk_ir::Const<RustInterner<'tcx>> {
+        let ty = self.ty.lower_into(interner);
+        let value = match self.val {
+            ty::ConstKind::Value(val) => {
+                chalk_ir::ConstValue::Concrete(chalk_ir::ConcreteConst { interned: val })
+            }
+            ty::ConstKind::Bound(db, bound) => chalk_ir::ConstValue::BoundVar(
+                chalk_ir::BoundVar::new(chalk_ir::DebruijnIndex::new(db.as_u32()), bound.index()),
+            ),
+            _ => unimplemented!("Const not implemented. {:?}", self),
+        };
+        chalk_ir::ConstData { ty, value }.intern(interner)
+    }
+}
+
+impl<'tcx> LowerInto<'tcx, ty::Const<'tcx>> for &chalk_ir::Const<RustInterner<'tcx>> {
+    fn lower_into(self, interner: &RustInterner<'tcx>) -> ty::Const<'tcx> {
+        let data = self.data(interner);
+        let ty = data.ty.lower_into(interner);
+        let val = match data.value {
+            chalk_ir::ConstValue::BoundVar(var) => ty::ConstKind::Bound(
+                ty::DebruijnIndex::from_u32(var.debruijn.depth()),
+                ty::BoundVar::from_u32(var.index as u32),
+            ),
+            chalk_ir::ConstValue::InferenceVar(_var) => unimplemented!(),
+            chalk_ir::ConstValue::Placeholder(_p) => unimplemented!(),
+            chalk_ir::ConstValue::Concrete(c) => ty::ConstKind::Value(c.interned),
+        };
+        ty::Const { ty, val }
+    }
+}
+
 impl<'tcx> LowerInto<'tcx, chalk_ir::GenericArg<RustInterner<'tcx>>> for GenericArg<'tcx> {
     fn lower_into(self, interner: &RustInterner<'tcx>) -> chalk_ir::GenericArg<RustInterner<'tcx>> {
         match self.unpack() {
@@ -566,15 +617,32 @@ impl<'tcx> LowerInto<'tcx, chalk_ir::GenericArg<RustInterner<'tcx>>> for Generic
             ty::subst::GenericArgKind::Lifetime(lifetime) => {
                 chalk_ir::GenericArgData::Lifetime(lifetime.lower_into(interner))
             }
-            ty::subst::GenericArgKind::Const(_) => chalk_ir::GenericArgData::Ty(
-                chalk_ir::TyData::Apply(chalk_ir::ApplicationTy {
-                    name: chalk_ir::TypeName::Tuple(0),
-                    substitution: chalk_ir::Substitution::empty(interner),
-                })
-                .intern(interner),
-            ),
+            ty::subst::GenericArgKind::Const(c) => {
+                chalk_ir::GenericArgData::Const(c.lower_into(interner))
+            }
         }
         .intern(interner)
+    }
+}
+
+impl<'tcx> LowerInto<'tcx, ty::subst::GenericArg<'tcx>>
+    for &chalk_ir::GenericArg<RustInterner<'tcx>>
+{
+    fn lower_into(self, interner: &RustInterner<'tcx>) -> ty::subst::GenericArg<'tcx> {
+        match self.data(interner) {
+            chalk_ir::GenericArgData::Ty(ty) => {
+                let t: Ty<'tcx> = ty.lower_into(interner);
+                t.into()
+            }
+            chalk_ir::GenericArgData::Lifetime(lifetime) => {
+                let r: Region<'tcx> = lifetime.lower_into(interner);
+                r.into()
+            }
+            chalk_ir::GenericArgData::Const(c) => {
+                let c: ty::Const<'tcx> = c.lower_into(interner);
+                interner.tcx.mk_const(c).into()
+            }
+        }
     }
 }
 
@@ -589,33 +657,27 @@ impl<'tcx> LowerInto<'tcx, Option<chalk_ir::QuantifiedWhereClause<RustInterner<'
         self,
         interner: &RustInterner<'tcx>,
     ) -> Option<chalk_ir::QuantifiedWhereClause<RustInterner<'tcx>>> {
-        // FIXME(chalk): forall
-        match self.bound_atom(interner.tcx).skip_binder() {
+        let (predicate, binders, _named_regions) =
+            collect_bound_vars(interner, interner.tcx, &self.bound_atom(interner.tcx));
+        let value = match predicate {
             ty::PredicateAtom::Trait(predicate, _) => {
-                let predicate = ty::Binder::bind(predicate);
-                let (predicate, binders, _named_regions) =
-                    collect_bound_vars(interner, interner.tcx, &predicate);
-
-                Some(chalk_ir::Binders::new(
-                    binders,
-                    chalk_ir::WhereClause::Implemented(predicate.trait_ref.lower_into(interner)),
-                ))
+                Some(chalk_ir::WhereClause::Implemented(predicate.trait_ref.lower_into(interner)))
             }
             ty::PredicateAtom::RegionOutlives(predicate) => {
-                let predicate = ty::Binder::bind(predicate);
-                let (predicate, binders, _named_regions) =
-                    collect_bound_vars(interner, interner.tcx, &predicate);
-
-                Some(chalk_ir::Binders::new(
-                    binders,
-                    chalk_ir::WhereClause::LifetimeOutlives(chalk_ir::LifetimeOutlives {
-                        a: predicate.0.lower_into(interner),
-                        b: predicate.1.lower_into(interner),
-                    }),
-                ))
+                Some(chalk_ir::WhereClause::LifetimeOutlives(chalk_ir::LifetimeOutlives {
+                    a: predicate.0.lower_into(interner),
+                    b: predicate.1.lower_into(interner),
+                }))
             }
-            ty::PredicateAtom::TypeOutlives(_predicate) => None,
-            ty::PredicateAtom::Projection(_predicate) => None,
+            ty::PredicateAtom::TypeOutlives(predicate) => {
+                Some(chalk_ir::WhereClause::TypeOutlives(chalk_ir::TypeOutlives {
+                    ty: predicate.0.lower_into(interner),
+                    lifetime: predicate.1.lower_into(interner),
+                }))
+            }
+            ty::PredicateAtom::Projection(predicate) => {
+                Some(chalk_ir::WhereClause::AliasEq(predicate.lower_into(interner)))
+            }
             ty::PredicateAtom::WellFormed(_ty) => None,
 
             ty::PredicateAtom::ObjectSafe(..)
@@ -623,7 +685,8 @@ impl<'tcx> LowerInto<'tcx, Option<chalk_ir::QuantifiedWhereClause<RustInterner<'
             | ty::PredicateAtom::Subtype(..)
             | ty::PredicateAtom::ConstEvaluatable(..)
             | ty::PredicateAtom::ConstEquate(..) => bug!("unexpected predicate {}", &self),
-        }
+        };
+        value.map(|value| chalk_ir::Binders::new(binders, value))
     }
 }
 
@@ -636,13 +699,21 @@ impl<'tcx> LowerInto<'tcx, chalk_ir::Binders<chalk_ir::QuantifiedWhereClauses<Ru
     ) -> chalk_ir::Binders<chalk_ir::QuantifiedWhereClauses<RustInterner<'tcx>>> {
         let (predicates, binders, _named_regions) =
             collect_bound_vars(interner, interner.tcx, &self);
+        let self_ty = interner.tcx.mk_ty(ty::Bound(
+            // This is going to be wrapped in a binder
+            ty::DebruijnIndex::from_usize(1),
+            ty::BoundTy { var: ty::BoundVar::from_usize(0), kind: ty::BoundTyKind::Anon },
+        ));
         let where_clauses = predicates.into_iter().map(|predicate| match predicate {
             ty::ExistentialPredicate::Trait(ty::ExistentialTraitRef { def_id, substs }) => {
                 chalk_ir::Binders::new(
                     chalk_ir::VariableKinds::empty(interner),
                     chalk_ir::WhereClause::Implemented(chalk_ir::TraitRef {
                         trait_id: chalk_ir::TraitId(def_id),
-                        substitution: substs.lower_into(interner),
+                        substitution: interner
+                            .tcx
+                            .mk_substs_trait(self_ty, substs)
+                            .lower_into(interner),
                     }),
                 )
             }
@@ -651,7 +722,7 @@ impl<'tcx> LowerInto<'tcx, chalk_ir::Binders<chalk_ir::QuantifiedWhereClauses<Ru
                 chalk_ir::VariableKinds::empty(interner),
                 chalk_ir::WhereClause::Implemented(chalk_ir::TraitRef {
                     trait_id: chalk_ir::TraitId(def_id),
-                    substitution: chalk_ir::Substitution::empty(interner),
+                    substitution: interner.tcx.mk_substs_trait(self_ty, &[]).lower_into(interner),
                 }),
             ),
         });
@@ -843,16 +914,18 @@ crate struct ParamsSubstitutor<'tcx> {
     tcx: TyCtxt<'tcx>,
     binder_index: ty::DebruijnIndex,
     list: Vec<rustc_middle::ty::ParamTy>,
+    next_ty_placehoder: usize,
     crate params: rustc_data_structures::fx::FxHashMap<usize, rustc_middle::ty::ParamTy>,
     crate named_regions: BTreeMap<DefId, u32>,
 }
 
 impl<'tcx> ParamsSubstitutor<'tcx> {
-    crate fn new(tcx: TyCtxt<'tcx>) -> Self {
+    crate fn new(tcx: TyCtxt<'tcx>, next_ty_placehoder: usize) -> Self {
         ParamsSubstitutor {
             tcx,
             binder_index: ty::INNERMOST,
             list: vec![],
+            next_ty_placehoder,
             params: rustc_data_structures::fx::FxHashMap::default(),
             named_regions: BTreeMap::default(),
         }
@@ -878,13 +951,13 @@ impl<'tcx> TypeFolder<'tcx> for ParamsSubstitutor<'tcx> {
             // first pass to collect placeholders. Then we can insert params after.
             ty::Placeholder(_) => unimplemented!(),
             ty::Param(param) => match self.list.iter().position(|r| r == &param) {
-                Some(_idx) => self.tcx.mk_ty(ty::Placeholder(ty::PlaceholderType {
+                Some(idx) => self.tcx.mk_ty(ty::Placeholder(ty::PlaceholderType {
                     universe: ty::UniverseIndex::from_usize(0),
-                    name: ty::BoundVar::from_usize(_idx),
+                    name: ty::BoundVar::from_usize(idx),
                 })),
                 None => {
                     self.list.push(param);
-                    let idx = self.list.len() - 1;
+                    let idx = self.list.len() - 1 + self.next_ty_placehoder;
                     self.params.insert(idx, param);
                     self.tcx.mk_ty(ty::Placeholder(ty::PlaceholderType {
                         universe: ty::UniverseIndex::from_usize(0),
@@ -915,6 +988,98 @@ impl<'tcx> TypeFolder<'tcx> for ParamsSubstitutor<'tcx> {
                     ))
                 }
             },
+
+            _ => r.super_fold_with(self),
+        }
+    }
+}
+
+/// Used to collect `Placeholder`s.
+crate struct PlaceholdersCollector {
+    universe_index: ty::UniverseIndex,
+    crate next_ty_placehoder: usize,
+    crate next_anon_region_placeholder: u32,
+}
+
+impl PlaceholdersCollector {
+    crate fn new() -> Self {
+        PlaceholdersCollector {
+            universe_index: ty::UniverseIndex::ROOT,
+            next_ty_placehoder: 0,
+            next_anon_region_placeholder: 0,
+        }
+    }
+}
+
+impl<'tcx> TypeVisitor<'tcx> for PlaceholdersCollector {
+    fn visit_binder<T: TypeFoldable<'tcx>>(&mut self, t: &Binder<T>) -> bool {
+        t.super_visit_with(self)
+    }
+
+    fn visit_ty(&mut self, t: Ty<'tcx>) -> bool {
+        match t.kind {
+            ty::Placeholder(p) if p.universe == self.universe_index => {
+                self.next_ty_placehoder = self.next_ty_placehoder.max(p.name.as_usize() + 1);
+            }
+
+            _ => (),
+        };
+
+        t.super_visit_with(self)
+    }
+
+    fn visit_region(&mut self, r: Region<'tcx>) -> bool {
+        match r {
+            ty::RePlaceholder(p) if p.universe == self.universe_index => {
+                if let ty::BoundRegion::BrAnon(anon) = p.name {
+                    self.next_anon_region_placeholder = self.next_anon_region_placeholder.max(anon);
+                }
+            }
+
+            _ => (),
+        };
+
+        r.super_visit_with(self)
+    }
+}
+
+/// Used to substitute specific `Regions`s with placeholders.
+crate struct RegionsSubstitutor<'tcx> {
+    tcx: TyCtxt<'tcx>,
+    restatic_placeholder: ty::Region<'tcx>,
+    reempty_placeholder: ty::Region<'tcx>,
+}
+
+impl<'tcx> RegionsSubstitutor<'tcx> {
+    crate fn new(
+        tcx: TyCtxt<'tcx>,
+        restatic_placeholder: ty::Region<'tcx>,
+        reempty_placeholder: ty::Region<'tcx>,
+    ) -> Self {
+        RegionsSubstitutor { tcx, restatic_placeholder, reempty_placeholder }
+    }
+}
+
+impl<'tcx> TypeFolder<'tcx> for RegionsSubstitutor<'tcx> {
+    fn tcx<'b>(&'b self) -> TyCtxt<'tcx> {
+        self.tcx
+    }
+
+    fn fold_binder<T: TypeFoldable<'tcx>>(&mut self, t: &Binder<T>) -> Binder<T> {
+        t.super_fold_with(self)
+    }
+
+    fn fold_ty(&mut self, t: Ty<'tcx>) -> Ty<'tcx> {
+        t.super_fold_with(self)
+    }
+
+    fn fold_region(&mut self, r: Region<'tcx>) -> Region<'tcx> {
+        match r {
+            ty::ReStatic => self.restatic_placeholder,
+            ty::ReEmpty(ui) => {
+                assert_eq!(ui.as_usize(), 0);
+                self.reempty_placeholder
+            }
 
             _ => r.super_fold_with(self),
         }

--- a/compiler/rustc_traits/src/chalk/lowering.rs
+++ b/compiler/rustc_traits/src/chalk/lowering.rs
@@ -1009,7 +1009,7 @@ impl PlaceholdersCollector {
 
 impl<'tcx> TypeVisitor<'tcx> for PlaceholdersCollector {
     fn visit_ty(&mut self, t: Ty<'tcx>) -> bool {
-        match t.kind {
+        match t.kind() {
             ty::Placeholder(p) if p.universe == self.universe_index => {
                 self.next_ty_placeholder = self.next_ty_placeholder.max(p.name.as_usize() + 1);
             }

--- a/compiler/rustc_traits/src/chalk/mod.rs
+++ b/compiler/rustc_traits/src/chalk/mod.rs
@@ -15,9 +15,7 @@ use rustc_middle::infer::canonical::{CanonicalTyVarKind, CanonicalVarKind};
 use rustc_middle::traits::ChalkRustInterner;
 use rustc_middle::ty::query::Providers;
 use rustc_middle::ty::subst::GenericArg;
-use rustc_middle::ty::{
-    self, Bound, BoundVar, ParamTy, Region, RegionKind, Ty, TyCtxt, TypeFoldable,
-};
+use rustc_middle::ty::{self, BoundVar, ParamTy, TyCtxt, TypeFoldable};
 
 use rustc_infer::infer::canonical::{
     Canonical, CanonicalVarValues, Certainty, QueryRegionConstraints, QueryResponse,
@@ -25,7 +23,9 @@ use rustc_infer::infer::canonical::{
 use rustc_infer::traits::{self, ChalkCanonicalGoal};
 
 use crate::chalk::db::RustIrDatabase as ChalkRustIrDatabase;
-use crate::chalk::lowering::{LowerInto, ParamsSubstitutor};
+use crate::chalk::lowering::{
+    LowerInto, ParamsSubstitutor, PlaceholdersCollector, RegionsSubstitutor,
+};
 
 use chalk_solve::Solution;
 
@@ -40,9 +40,27 @@ crate fn evaluate_goal<'tcx>(
     let interner = ChalkRustInterner { tcx };
 
     // Chalk doesn't have a notion of `Params`, so instead we use placeholders.
-    let mut params_substitutor = ParamsSubstitutor::new(tcx);
+    let mut placeholders_collector = PlaceholdersCollector::new();
+    obligation.visit_with(&mut placeholders_collector);
+
+    let restatic_placeholder = tcx.mk_region(ty::RegionKind::RePlaceholder(ty::Placeholder {
+        universe: ty::UniverseIndex::ROOT,
+        name: ty::BoundRegion::BrAnon(placeholders_collector.next_anon_region_placeholder),
+    }));
+    let reempty_placeholder = tcx.mk_region(ty::RegionKind::RePlaceholder(ty::Placeholder {
+        universe: ty::UniverseIndex::ROOT,
+        name: ty::BoundRegion::BrAnon(placeholders_collector.next_anon_region_placeholder + 1),
+    }));
+
+    let mut params_substitutor =
+        ParamsSubstitutor::new(tcx, placeholders_collector.next_ty_placehoder);
     let obligation = obligation.fold_with(&mut params_substitutor);
     let _params: FxHashMap<usize, ParamTy> = params_substitutor.params;
+
+    let mut regions_substitutor =
+        RegionsSubstitutor::new(tcx, restatic_placeholder, reempty_placeholder);
+    let obligation = obligation.fold_with(&mut regions_substitutor);
+
     let max_universe = obligation.max_universe.index();
 
     let _lowered_goal: chalk_ir::UCanonical<
@@ -83,7 +101,7 @@ crate fn evaluate_goal<'tcx>(
 
     use chalk_solve::Solver;
     let mut solver = chalk_engine::solve::SLGSolver::new(32, None);
-    let db = ChalkRustIrDatabase { tcx, interner };
+    let db = ChalkRustIrDatabase { tcx, interner, restatic_placeholder, reempty_placeholder };
     let solution = chalk_solve::logging::with_tracing_logs(|| solver.solve(&db, &_lowered_goal));
 
     // Ideally, the code to convert *back* to rustc types would live close to
@@ -94,94 +112,7 @@ crate fn evaluate_goal<'tcx>(
     let make_solution = |_subst: chalk_ir::Substitution<_>| {
         let mut var_values: IndexVec<BoundVar, GenericArg<'tcx>> = IndexVec::new();
         _subst.as_slice(&interner).iter().for_each(|p| {
-            // FIXME(chalk): we should move this elsewhere, since this is
-            // essentially inverse of lowering a `GenericArg`.
-            let _data = p.data(&interner);
-            match _data {
-                chalk_ir::GenericArgData::Ty(_t) => {
-                    use chalk_ir::TyData;
-                    use rustc_ast as ast;
-
-                    let _data = _t.data(&interner);
-                    let kind = match _data {
-                        TyData::Apply(_application_ty) => match _application_ty.name {
-                            chalk_ir::TypeName::Adt(_struct_id) => unimplemented!(),
-                            chalk_ir::TypeName::Scalar(scalar) => match scalar {
-                                chalk_ir::Scalar::Bool => ty::Bool,
-                                chalk_ir::Scalar::Char => ty::Char,
-                                chalk_ir::Scalar::Int(int_ty) => match int_ty {
-                                    chalk_ir::IntTy::Isize => ty::Int(ast::IntTy::Isize),
-                                    chalk_ir::IntTy::I8 => ty::Int(ast::IntTy::I8),
-                                    chalk_ir::IntTy::I16 => ty::Int(ast::IntTy::I16),
-                                    chalk_ir::IntTy::I32 => ty::Int(ast::IntTy::I32),
-                                    chalk_ir::IntTy::I64 => ty::Int(ast::IntTy::I64),
-                                    chalk_ir::IntTy::I128 => ty::Int(ast::IntTy::I128),
-                                },
-                                chalk_ir::Scalar::Uint(int_ty) => match int_ty {
-                                    chalk_ir::UintTy::Usize => ty::Uint(ast::UintTy::Usize),
-                                    chalk_ir::UintTy::U8 => ty::Uint(ast::UintTy::U8),
-                                    chalk_ir::UintTy::U16 => ty::Uint(ast::UintTy::U16),
-                                    chalk_ir::UintTy::U32 => ty::Uint(ast::UintTy::U32),
-                                    chalk_ir::UintTy::U64 => ty::Uint(ast::UintTy::U64),
-                                    chalk_ir::UintTy::U128 => ty::Uint(ast::UintTy::U128),
-                                },
-                                chalk_ir::Scalar::Float(float_ty) => match float_ty {
-                                    chalk_ir::FloatTy::F32 => ty::Float(ast::FloatTy::F32),
-                                    chalk_ir::FloatTy::F64 => ty::Float(ast::FloatTy::F64),
-                                },
-                            },
-                            chalk_ir::TypeName::Array => unimplemented!(),
-                            chalk_ir::TypeName::FnDef(_) => unimplemented!(),
-                            chalk_ir::TypeName::Closure(_) => unimplemented!(),
-                            chalk_ir::TypeName::Never => unimplemented!(),
-                            chalk_ir::TypeName::Tuple(_size) => unimplemented!(),
-                            chalk_ir::TypeName::Slice => unimplemented!(),
-                            chalk_ir::TypeName::Raw(_) => unimplemented!(),
-                            chalk_ir::TypeName::Ref(_) => unimplemented!(),
-                            chalk_ir::TypeName::Str => unimplemented!(),
-                            chalk_ir::TypeName::OpaqueType(_ty) => unimplemented!(),
-                            chalk_ir::TypeName::AssociatedType(_assoc_ty) => unimplemented!(),
-                            chalk_ir::TypeName::Error => unimplemented!(),
-                        },
-                        TyData::Placeholder(_placeholder) => {
-                            unimplemented!();
-                        }
-                        TyData::Alias(_alias_ty) => unimplemented!(),
-                        TyData::Function(_quantified_ty) => unimplemented!(),
-                        TyData::BoundVar(_bound) => Bound(
-                            ty::DebruijnIndex::from_usize(_bound.debruijn.depth() as usize),
-                            ty::BoundTy {
-                                var: ty::BoundVar::from_usize(_bound.index),
-                                kind: ty::BoundTyKind::Anon,
-                            },
-                        ),
-                        TyData::InferenceVar(_, _) => unimplemented!(),
-                        TyData::Dyn(_) => unimplemented!(),
-                    };
-                    let _ty: Ty<'_> = tcx.mk_ty(kind);
-                    let _arg: GenericArg<'_> = _ty.into();
-                    var_values.push(_arg);
-                }
-                chalk_ir::GenericArgData::Lifetime(_l) => {
-                    let _data = _l.data(&interner);
-                    let _lifetime: Region<'_> = match _data {
-                        chalk_ir::LifetimeData::BoundVar(_var) => {
-                            tcx.mk_region(RegionKind::ReLateBound(
-                                rustc_middle::ty::DebruijnIndex::from_usize(
-                                    _var.debruijn.depth() as usize
-                                ),
-                                rustc_middle::ty::BoundRegion::BrAnon(_var.index as u32),
-                            ))
-                        }
-                        chalk_ir::LifetimeData::InferenceVar(_var) => unimplemented!(),
-                        chalk_ir::LifetimeData::Placeholder(_index) => unimplemented!(),
-                        chalk_ir::LifetimeData::Phantom(_, _) => unimplemented!(),
-                    };
-                    let _arg: GenericArg<'_> = _lifetime.into();
-                    var_values.push(_arg);
-                }
-                chalk_ir::GenericArgData::Const(_) => unimplemented!(),
-            }
+            var_values.push(p.lower_into(&interner));
         });
         let sol = Canonical {
             max_universe: ty::UniverseIndex::from_usize(0),
@@ -193,7 +124,7 @@ crate fn evaluate_goal<'tcx>(
                 value: (),
             },
         };
-        &*tcx.arena.alloc(sol)
+        tcx.arena.alloc(sol)
     };
     solution
         .map(|s| match s {

--- a/src/test/ui/chalkify/type_inference.rs
+++ b/src/test/ui/chalkify/type_inference.rs
@@ -24,5 +24,5 @@ fn main() {
 
     // Here we have two solutions so we get back the behavior of the old-style
     // trait solver.
-    only_bar(x); //~ ERROR the trait bound `f64: Bar` is not satisfied
+    only_bar(x); //~ ERROR the trait bound `{float}: Bar` is not satisfied
 }

--- a/src/test/ui/chalkify/type_inference.stderr
+++ b/src/test/ui/chalkify/type_inference.stderr
@@ -1,11 +1,15 @@
-error[E0277]: the trait bound `f64: Bar` is not satisfied
+error[E0277]: the trait bound `{float}: Bar` is not satisfied
   --> $DIR/type_inference.rs:27:5
    |
 LL | fn only_bar<T: Bar>(_x: T) { }
    |                --- required by this bound in `only_bar`
 ...
 LL |     only_bar(x);
-   |     ^^^^^^^^ the trait `Bar` is not implemented for `f64`
+   |     ^^^^^^^^ the trait `Bar` is not implemented for `{float}`
+   |
+   = help: the following implementations were found:
+             <i32 as Bar>
+             <u32 as Bar>
 
 error: aborting due to previous error
 

--- a/src/test/ui/chalkify/type_wf.rs
+++ b/src/test/ui/chalkify/type_wf.rs
@@ -15,7 +15,7 @@ fn main() {
        x: 5,
     };
 
-    let s = S { //~ ERROR the trait bound `f64: Foo` is not satisfied
+    let s = S { //~ ERROR the trait bound `{float}: Foo` is not satisfied
         x: 5.0,
     };
 

--- a/src/test/ui/chalkify/type_wf.stderr
+++ b/src/test/ui/chalkify/type_wf.stderr
@@ -8,8 +8,8 @@ LL |     let s = S {
    |             ^ the trait `Foo` is not implemented for `{float}`
    |
    = help: the following implementations were found:
+             <Option<T> as Foo>
              <i32 as Foo>
-             <std::option::Option<T> as Foo>
 
 error: aborting due to previous error
 

--- a/src/test/ui/chalkify/type_wf.stderr
+++ b/src/test/ui/chalkify/type_wf.stderr
@@ -1,11 +1,15 @@
-error[E0277]: the trait bound `f64: Foo` is not satisfied
+error[E0277]: the trait bound `{float}: Foo` is not satisfied
   --> $DIR/type_wf.rs:18:13
    |
 LL | struct S<T: Foo> {
    | ---------------- required by `S`
 ...
 LL |     let s = S {
-   |             ^ the trait `Foo` is not implemented for `f64`
+   |             ^ the trait `Foo` is not implemented for `{float}`
+   |
+   = help: the following implementations were found:
+             <i32 as Foo>
+             <std::option::Option<T> as Foo>
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Two commits here. First commit actually does the upgrade. Second commit has some changes to make more tests in compare-mode=chalk pass.

The `PlaceholdersCollector` and `RegionsSubstitutor` bits are bit a hacky, but only insomuch as `ParamsSubstitutor` is. These won't be needed eventually.

r? @nikomatsakis 