### PR TITLE
Link to corresponding sections for enum variants in rustdoc

### DIFF
--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -2971,10 +2971,18 @@ fn item_enum(w: &mut Buffer, cx: &Context, it: &clean::Item, e: &clean::Enum, ca
                 match v.inner {
                     clean::VariantItem(ref var) => match var.kind {
                         clean::VariantKind::CLike => {
-                            write!(w, "<a href=\"#variant.{}\" class=\"variant\">{}</a>", name, name);
+                            write!(
+                                w,
+                                "<a href=\"#variant.{}\" class=\"variant\">{}</a>",
+                                name, name
+                            );
                         }
                         clean::VariantKind::Tuple(ref tys) => {
-                            write!(w, "<a href=\"#variant.{}\" class=\"variant\">{}</a>(", name, name);
+                            write!(
+                                w,
+                                "<a href=\"#variant.{}\" class=\"variant\">{}</a>(",
+                                name, name
+                            );
                             for (i, ty) in tys.iter().enumerate() {
                                 if i > 0 {
                                     write!(w, ",&nbsp;")
@@ -3134,7 +3142,12 @@ fn render_struct(
     // If this is an enum variant we should not write `struct` and the
     // name should be a link to the description of the variant.
     if enum_variant {
-        write!(w, "<a href=\"#variant.{}\" class=\"variant\">{}</a>", it.name.as_ref().unwrap(), it.name.as_ref().unwrap());
+        write!(
+            w,
+            "<a href=\"#variant.{}\" class=\"variant\">{}</a>",
+            it.name.as_ref().unwrap(),
+            it.name.as_ref().unwrap()
+        );
     } else {
         write!(w, "struct {} ", it.name.as_ref().unwrap());
     }

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -2857,7 +2857,7 @@ fn item_struct(w: &mut Buffer, cx: &Context, it: &clean::Item, s: &clean::Struct
     wrap_into_docblock(w, |w| {
         write!(w, "<pre class='rust struct'>");
         render_attributes(w, it, true);
-        render_struct(w, it, Some(&s.generics), s.struct_type, &s.fields, "", true);
+        render_struct(w, it, Some(&s.generics), s.struct_type, &s.fields, "", false);
         write!(w, "</pre>")
     });
 
@@ -2970,9 +2970,11 @@ fn item_enum(w: &mut Buffer, cx: &Context, it: &clean::Item, e: &clean::Enum, ca
                 let name = v.name.as_ref().unwrap();
                 match v.inner {
                     clean::VariantItem(ref var) => match var.kind {
-                        clean::VariantKind::CLike => write!(w, "{}", name),
+                        clean::VariantKind::CLike => {
+                            write!(w, "<a href=\"#variant.{}\" class=\"variant\">{}</a>", name, name);
+                        }
                         clean::VariantKind::Tuple(ref tys) => {
-                            write!(w, "{}(", name);
+                            write!(w, "<a href=\"#variant.{}\" class=\"variant\">{}</a>(", name, name);
                             for (i, ty) in tys.iter().enumerate() {
                                 if i > 0 {
                                     write!(w, ",&nbsp;")
@@ -2982,7 +2984,7 @@ fn item_enum(w: &mut Buffer, cx: &Context, it: &clean::Item, e: &clean::Enum, ca
                             write!(w, ")");
                         }
                         clean::VariantKind::Struct(ref s) => {
-                            render_struct(w, v, None, s.struct_type, &s.fields, "    ", false);
+                            render_struct(w, v, None, s.struct_type, &s.fields, "    ", true);
                         }
                     },
                     _ => unreachable!(),
@@ -3126,15 +3128,16 @@ fn render_struct(
     ty: doctree::StructType,
     fields: &[clean::Item],
     tab: &str,
-    structhead: bool,
+    enum_variant: bool,
 ) {
-    write!(
-        w,
-        "{}{}{}",
-        it.visibility.print_with_space(),
-        if structhead { "struct " } else { "" },
-        it.name.as_ref().unwrap()
-    );
+    write!(w, "{}", it.visibility.print_with_space());
+    // If this is an enum variant we should not write `struct` and the
+    // name should be a link to the description of the variant.
+    if enum_variant {
+        write!(w, "<a href=\"#variant.{}\" class=\"variant\">{}</a>", it.name.as_ref().unwrap(), it.name.as_ref().unwrap());
+    } else {
+        write!(w, "struct {} ", it.name.as_ref().unwrap());
+    }
     if let Some(g) = g {
         write!(w, "{}", g.print())
     }

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -3149,7 +3149,7 @@ fn render_struct(
             it.name.as_ref().unwrap()
         );
     } else {
-        write!(w, "struct {} ", it.name.as_ref().unwrap());
+        write!(w, "struct {}", it.name.as_ref().unwrap());
     }
     if let Some(g) = g {
         write!(w, "{}", g.print())

--- a/src/librustdoc/html/static/themes/ayu.css
+++ b/src/librustdoc/html/static/themes/ayu.css
@@ -181,6 +181,9 @@ pre {
 .content span.enum, .content a.enum {
 	color: #99e0c9;
 }
+.content span.variant, .content a.variant {
+	color: #6380a0;
+}
 .content span.trait, .content a.trait {
 	color: #39AFD7;
 }

--- a/src/librustdoc/html/static/themes/dark.css
+++ b/src/librustdoc/html/static/themes/dark.css
@@ -136,6 +136,7 @@ pre {
 .content .stability::before { color: #ccc; }
 
 .content span.enum, .content a.enum, .block a.current.enum { color: #82b089; }
+.content span.variant, .content a.variant, .block a.current.variant { color: #82a5c9; }
 .content span.struct, .content a.struct, .block a.current.struct { color: #2dbfb8; }
 .content span.type, .content a.type, .block a.current.type { color: #ff7f00; }
 .content span.foreigntype, .content a.foreigntype, .block a.current.foreigntype { color: #dd7de8; }

--- a/src/librustdoc/html/static/themes/light.css
+++ b/src/librustdoc/html/static/themes/light.css
@@ -137,6 +137,7 @@ pre {
 .content .stability::before { color: #ccc; }
 
 .content span.enum, .content a.enum, .block a.current.enum { color: #508157; }
+.content span.variant, .content a.variant, .block a.current.variant { color: #546e8a; }
 .content span.struct, .content a.struct, .block a.current.struct { color: #ad448e; }
 .content span.type, .content a.type, .block a.current.type { color: #ba5d00; }
 .content span.foreigntype, .content a.foreigntype, .block a.current.foreigntype { color: #cd00e2; }


### PR DESCRIPTION
resolves #74849 (for structs rustdoc shows fields omitted, so i am not sure if that should be removed and replaced for this)

This makes the text for each variant in an enum declaration a link to their corresponding section. As for the color that must be decided, i am by no means a design expert, i chose the color used for statics since it looked nice and not overbearing. But if you have an idea for a better color feel free to comment!

@Aaron1011 For structs do you mean rustdoc should render fields as well with clickable links for the fields?

Example of the output on dark theme
 ![Example](https://imgur.com/ZkVa9m3.png)