### PR TITLE
Implement Error for &(impl Error)

### DIFF
--- a/library/std/src/error.rs
+++ b/library/std/src/error.rs
@@ -506,6 +506,27 @@ impl<T: Error> Error for Box<T> {
     }
 }
 
+#[stable(feature = "error_by_ref", since = "1.47.0")]
+impl<'a, T: Error + ?Sized> Error for &'a T {
+    #[allow(deprecated, deprecated_in_future)]
+    fn description(&self) -> &str {
+        Error::description(&**self)
+    }
+
+    #[allow(deprecated)]
+    fn cause(&self) -> Option<&dyn Error> {
+        Error::cause(&**self)
+    }
+
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        Error::source(&**self)
+    }
+
+    fn backtrace(&self) -> Option<&Backtrace> {
+        Error::backtrace(&**self)
+    }
+}
+
 #[stable(feature = "fmt_error", since = "1.11.0")]
 impl Error for fmt::Error {
     #[allow(deprecated)]

--- a/library/std/src/error.rs
+++ b/library/std/src/error.rs
@@ -506,7 +506,7 @@ impl<T: Error> Error for Box<T> {
     }
 }
 
-#[stable(feature = "error_by_ref", since = "1.49.0")]
+#[stable(feature = "error_by_ref", since = "1.51.0")]
 impl<'a, T: Error + ?Sized> Error for &'a T {
     #[allow(deprecated, deprecated_in_future)]
     fn description(&self) -> &str {

--- a/library/std/src/error.rs
+++ b/library/std/src/error.rs
@@ -506,7 +506,7 @@ impl<T: Error> Error for Box<T> {
     }
 }
 
-#[stable(feature = "error_by_ref", since = "1.47.0")]
+#[stable(feature = "error_by_ref", since = "1.49.0")]
 impl<'a, T: Error + ?Sized> Error for &'a T {
     #[allow(deprecated, deprecated_in_future)]
     fn description(&self) -> &str {


### PR DESCRIPTION
Opening this up just to see what it breaks. It's unfortunate that `&(impl Error)` doesn't actually implement `Error`. If this direct approach doesn't work out then I'll try something different, like an `Error::by_ref` method.

**EDIT:** This is a super low-priority experiment so feel free to cancel it for more important crater runs! 🙂

-----

# Stabilization Report

## Why?

We've been working for the last few years to try "fix" the `Error` trait, which is probably one of the most fundamental in the whole standard library. One of its issues is that we commonly expect you to work with abstract errors through `dyn Trait`, but references and smart pointers over `dyn Trait` don't actually implement the `Error` trait. If you have a `&dyn Error` or a `Box<dyn Error>` you simply can't pass it to a method that wants a `impl Error`.

## What does this do?

This stabilizes the following trait impl:

```rust
impl<'a, T: Error + ?Sized + 'static> Error for &'a T;
```

This means that `&dyn Error` will now satisfy a `impl Error` bound.

It doesn't do anything with `Box<dyn Error>` directly. We discussed how we could do `Box<dyn Error>` in the thread here (and elsewhere in the past), but it seems like we need something like lattice-based specialization or a sprinkling of snowflake compiler magic to make that work. Having said that, with this new impl you _can_ now get a `impl Error` from a `Box<dyn Error>`  by dereferencing it.

## What breaks?

A crater run revealed a few crates broke with something like the following:

```rust
// where e: &'short &'long dyn Error
err.source()
```

previously we'd auto-deref that `&'short &'long dyn Error` to return a `Option<&'long dyn Error>` from `source`, but now will call directly on `&'short impl Error`, so will return a `Option<&'short dyn Error>`. The fix is to manually deref:

```rust
// where e: &'short &'long dyn Error
(*err).source()
```

In the recent Libs meeting we considered this acceptable breakage.