### PR TITLE
Enable PGO tests on Windows-gnu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -434,7 +434,7 @@ jobs:
           - name: x86_64-mingw-1
             env:
               SCRIPT: make ci-mingw-subset-1
-              RUST_CONFIGURE_ARGS: "--build=x86_64-pc-windows-gnu"
+              RUST_CONFIGURE_ARGS: "--build=x86_64-pc-windows-gnu --enable-profiler"
               CUSTOM_MINGW: 1
               NO_DEBUG_ASSERTIONS: 1
               NO_LLVM_ASSERTIONS: 1
@@ -442,7 +442,7 @@ jobs:
           - name: x86_64-mingw-2
             env:
               SCRIPT: make ci-mingw-subset-2
-              RUST_CONFIGURE_ARGS: "--build=x86_64-pc-windows-gnu"
+              RUST_CONFIGURE_ARGS: "--build=x86_64-pc-windows-gnu --enable-profiler"
               CUSTOM_MINGW: 1
             os: windows-latest-xl
           - name: dist-x86_64-msvc

--- a/src/ci/github-actions/ci.yml
+++ b/src/ci/github-actions/ci.yml
@@ -522,7 +522,7 @@ jobs:
           - name: x86_64-mingw-1
             env:
               SCRIPT: make ci-mingw-subset-1
-              RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-gnu
+              RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-gnu --enable-profiler
               CUSTOM_MINGW: 1
               # FIXME(#59637)
               NO_DEBUG_ASSERTIONS: 1
@@ -532,7 +532,7 @@ jobs:
           - name: x86_64-mingw-2
             env:
               SCRIPT: make ci-mingw-subset-2
-              RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-gnu
+              RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-gnu --enable-profiler
               CUSTOM_MINGW: 1
             <<: *job-windows-xl
 


### PR DESCRIPTION
Closes https://github.com/rust-lang/rust/issues/61266

This will enable 10 tests (those with `needs-profiler-support`), the time they take should be marginal but I can add it to `try` first if you want.