### PR TITLE
Fix wasi::fs::OpenOptions to imply write when append is on

### DIFF
--- a/library/std/src/sys/wasi/fs.rs
+++ b/library/std/src/sys/wasi/fs.rs
@@ -46,6 +46,7 @@ pub struct DirEntry {
 pub struct OpenOptions {
     read: bool,
     write: bool,
+    append: bool,
     dirflags: wasi::Lookupflags,
     fdflags: wasi::Fdflags,
     oflags: wasi::Oflags,
@@ -270,8 +271,9 @@ impl OpenOptions {
         }
     }
 
-    pub fn append(&mut self, set: bool) {
-        self.fdflag(wasi::FDFLAGS_APPEND, set);
+    pub fn append(&mut self, append: bool) {
+        self.append = append;
+        self.fdflag(wasi::FDFLAGS_APPEND, append);
     }
 
     pub fn dsync(&mut self, set: bool) {
@@ -321,7 +323,7 @@ impl OpenOptions {
             base |= wasi::RIGHTS_FD_READ;
             base |= wasi::RIGHTS_FD_READDIR;
         }
-        if self.write {
+        if self.write || self.append {
             base |= wasi::RIGHTS_FD_WRITE;
             base |= wasi::RIGHTS_FD_DATASYNC;
             base |= wasi::RIGHTS_FD_ALLOCATE;


### PR DESCRIPTION
This PR fixes a bug in `OpenOptions` of `wasi` platform that it currently doesn't imply write mode when only `append` is enabled.
As explained in the [doc of OpenOptions#append](https://doc.rust-lang.org/std/fs/struct.OpenOptions.html#method.append), calling `.append(true)` should imply `.write(true)` as well.

## Reproduce

Given below simple Rust program:

```rust
use std::fs::OpenOptions;
use std::io::Write;

fn main() {
    let mut file = OpenOptions::new()
        .write(true)
        .create(true)
        .open("foo.txt")
        .unwrap();
    writeln!(file, "abc").unwrap();
}
```

it can successfully compiled into wasm and execute by `wasmtime` runtime:

```sh
$ rustc --target wasm32-wasi write.rs
$ ~/wasmtime/target/debug/wasmtime run --dir=. write.wasm 
$ cat foo.txt 
abc
```

However when I change `.write(true)` to `.append(true)`, it fails to execute by the error "Capabilities insufficient":

```sh
$ ~/wasmtime/target/debug/wasmtime run --dir=. append.wasm
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Os { code: 76, kind: Other, message: "Capabilities insufficient" }', append.rs:10:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Error: failed to run main module `append.wasm`
...
```

This is because of lacking "rights" on the opened file:

```sh
$ RUST_LOG=trace ~/wasmtime/target/debug/wasmtime run --dir=. append.wasm 2>&1 | grep validate_rights
 TRACE wasi_common::entry                                  >      | validate_rights failed: required rights = HandleRights { base: fd_write (0x40), inheriting: empty (0x0) }; actual rights = HandleRights { base: fd_seek|fd_fdstat_set_flags|fd_sync|fd_tell|fd_advise|fd_filestat_set_times|poll_fd_readwrite (0x88000bc), inheriting: empty (0x0) }
```

