### PR TITLE
Show backtrace numbers in backtrace whenever more than one is involved

### DIFF
--- a/src/librustc_errors/emitter.rs
+++ b/src/librustc_errors/emitter.rs
@@ -362,7 +362,7 @@ pub trait Emitter {
                         format!(
                             "in this expansion of `{}`{}",
                             trace.kind.descr(),
-                            if macro_backtrace.len() > 2 {
+                            if macro_backtrace.len() > 1 {
                                 // if macro_backtrace.len() == 1 it'll be
                                 // pointed at by "in this macro invocation"
                                 format!(" (#{})", i + 1)
@@ -393,7 +393,7 @@ pub trait Emitter {
                         trace.call_site,
                         format!(
                             "in this macro invocation{}",
-                            if macro_backtrace.len() > 2 && always_backtrace {
+                            if macro_backtrace.len() > 1 && always_backtrace {
                                 // only specify order when the macro
                                 // backtrace is multiple levels deep
                                 format!(" (#{})", i + 1)

--- a/src/test/ui/macro_backtrace/main.-Zmacro-backtrace.stderr
+++ b/src/test/ui/macro_backtrace/main.-Zmacro-backtrace.stderr
@@ -17,20 +17,20 @@ LL | /  macro_rules! pong {
 LL | |      () => { syntax error };
    | |                     ^^^^^ expected one of 8 possible tokens
 LL | |  }
-   | |__- in this expansion of `pong!`
+   | |__- in this expansion of `pong!` (#2)
 ...
 LL |        ping!();
-   |        -------- in this macro invocation
+   |        -------- in this macro invocation (#1)
    | 
   ::: $DIR/auxiliary/ping.rs:5:1
    |
 LL |  / macro_rules! ping {
 LL |  |     () => {
 LL |  |         pong!();
-   |  |         -------- in this macro invocation
+   |  |         -------- in this macro invocation (#2)
 LL |  |     }
 LL |  | }
-   |  |_- in this expansion of `ping!`
+   |  |_- in this expansion of `ping!` (#1)
 
 error: expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found `error`
   --> $DIR/main.rs:10:20


### PR DESCRIPTION
Previously, we only displayed 'frame' numbers in a macro backtrace when more
than two frames were involved. This commit should help make backtrace
more readable, since these kinds of messages can quickly get confusing.