### PR TITLE
Upgrade the FreeBSD toolchain to version 11.4

### DIFF
--- a/src/ci/docker/host-x86_64/dist-i686-freebsd/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-i686-freebsd/Dockerfile
@@ -23,9 +23,9 @@ COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
 ENV \
-    AR_i686_unknown_freebsd=i686-unknown-freebsd10-ar \
-    CC_i686_unknown_freebsd=i686-unknown-freebsd10-clang \
-    CXX_i686_unknown_freebsd=i686-unknown-freebsd10-clang++
+    AR_i686_unknown_freebsd=i686-unknown-freebsd11-ar \
+    CC_i686_unknown_freebsd=i686-unknown-freebsd11-clang \
+    CXX_i686_unknown_freebsd=i686-unknown-freebsd11-clang++
 
 ENV HOSTS=i686-unknown-freebsd
 

--- a/src/ci/docker/host-x86_64/dist-x86_64-freebsd/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-x86_64-freebsd/Dockerfile
@@ -23,9 +23,9 @@ COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
 ENV \
-    AR_x86_64_unknown_freebsd=x86_64-unknown-freebsd10-ar \
-    CC_x86_64_unknown_freebsd=x86_64-unknown-freebsd10-clang \
-    CXX_x86_64_unknown_freebsd=x86_64-unknown-freebsd10-clang++
+    AR_x86_64_unknown_freebsd=x86_64-unknown-freebsd11-ar \
+    CC_x86_64_unknown_freebsd=x86_64-unknown-freebsd11-clang \
+    CXX_x86_64_unknown_freebsd=x86_64-unknown-freebsd11-clang++
 
 ENV HOSTS=x86_64-unknown-freebsd
 

--- a/src/ci/docker/scripts/freebsd-toolchain.sh
+++ b/src/ci/docker/scripts/freebsd-toolchain.sh
@@ -5,8 +5,8 @@ set -eux
 
 arch=$1
 binutils_version=2.25.1
-freebsd_version=10.3
-triple=$arch-unknown-freebsd10
+freebsd_version=11.4
+triple=$arch-unknown-freebsd11
 sysroot=/usr/local/$triple
 
 hide_output() {
@@ -58,23 +58,9 @@ for lib in c++ c_nonshared compiler_rt execinfo gcc pthread rt ssp_nonshared; do
 done
 
 # Originally downloaded from:
-# https://download.freebsd.org/ftp/releases/${freebsd_arch}/${freebsd_version}-RELEASE/base.txz
-URL=https://ci-mirrors.rust-lang.org/rustc/2019-04-04-freebsd-${freebsd_arch}-${freebsd_version}-RELEASE-base.txz
+# URL=https://download.freebsd.org/ftp/releases/${freebsd_arch}/${freebsd_version}-RELEASE/base.txz
+URL=https://ci-mirrors.rust-lang.org/rustc/2020-08-09-freebsd-${freebsd_arch}-${freebsd_version}-RELEASE-base.txz
 curl "$URL" | tar xJf - -C "$sysroot" --wildcards "${files_to_extract[@]}"
-
-# Fix up absolute symlinks from the system image.  This can be removed
-# for FreeBSD 11.  (If there's an easy way to make them relative
-# symlinks instead, feel free to change this.)
-set +x
-find "$sysroot" -type l | while read symlink_path; do
-  symlink_target=$(readlink "$symlink_path")
-  case $symlink_target in
-    (/*)
-      echo "Fixing symlink ${symlink_path} -> ${sysroot}${symlink_target}" >&2
-      ln -nfs "${sysroot}${symlink_target}" "${symlink_path}" ;;
-  esac
-done
-set -x
 
 # Clang can do cross-builds out of the box, if we give it the right
 # flags.  (The local binutils seem to work, but they set the ELF
@@ -82,7 +68,7 @@ set -x
 # there might be other problems.)
 #
 # The --target option is last because the cross-build of LLVM uses
-# --target without an OS version ("-freebsd" vs. "-freebsd10").  This
+# --target without an OS version ("-freebsd" vs. "-freebsd11").  This
 # makes Clang default to libstdc++ (which no longer exists), and also
 # controls other features, like GNU-style symbol table hashing and
 # anything predicated on the version number in the __FreeBSD__


### PR DESCRIPTION
FreeBSD 10 reached its end-of-life in October 2018, and that toolchain
caused issues in the LLVM 11 upgrade (#73526) that are resolved with the
toolchain from FreeBSD 11.

Closes #72390.