### PR TITLE
Handle projection predicates in the param env for auto-trait docs

### DIFF
--- a/src/librustc_trait_selection/traits/auto_trait.rs
+++ b/src/librustc_trait_selection/traits/auto_trait.rs
@@ -270,6 +270,13 @@ impl AutoTraitFinder<'tcx> {
     ) -> Option<(ty::ParamEnv<'tcx>, ty::ParamEnv<'tcx>)> {
         let tcx = infcx.tcx;
 
+        // Don't try to proess any nested obligations involving predicates
+        // that are already in the `ParamEnv` (modulo regions): we already
+        // know that they must hold.
+        for predicate in param_env.caller_bounds() {
+            fresh_preds.insert(self.clean_pred(infcx, predicate));
+        }
+
         let mut select = SelectionContext::with_negative(&infcx, true);
 
         let mut already_visited = FxHashSet::default();

--- a/src/test/rustdoc/synthetic_auto/issue-72213-projection-lifetime.rs
+++ b/src/test/rustdoc/synthetic_auto/issue-72213-projection-lifetime.rs
@@ -1,0 +1,25 @@
+// Regression test for issue #72213
+// Tests that we don't ICE when we have projection predicates
+// in our initial ParamEnv
+
+pub struct Lines<'a, L>
+where
+    L: Iterator<Item = &'a ()>,
+{
+    words: std::iter::Peekable<Words<'a, L>>,
+}
+
+pub struct Words<'a, L> {
+    _m: std::marker::PhantomData<&'a L>,
+}
+
+impl<'a, L> Iterator for Words<'a, L>
+where
+    L: Iterator<Item = &'a ()>,
+{
+    type Item = ();
+
+    fn next(&mut self) -> Option<Self::Item> {
+        unimplemented!()
+    }
+}


### PR DESCRIPTION
Fixes #72213

Any predicates in the param env are guaranteed to hold, so we don't need
to do any additional processing of them if we come across them as
sub-obligations of a different predicate. This allows us to avoid adding
the same predicate to the computed ParamEnv multiple times (but with
different regions each time), which causes an ambiguity error during
fulfillment.