### PR TITLE
Add #[track_caller] to `Session::delay_span_bug`

### DIFF
--- a/src/librustc_session/session.rs
+++ b/src/librustc_session/session.rs
@@ -432,6 +432,7 @@ impl Session {
         }
     }
     /// Delay a span_bug() call until abort_if_errors()
+    #[track_caller]
     pub fn delay_span_bug<S: Into<MultiSpan>>(&self, sp: S, msg: &str) {
         self.diagnostic().delay_span_bug(sp, msg)
     }


### PR DESCRIPTION
This forwards the caller span to `Handler::delay_span_bug`