### PR TITLE
Don't call a function in function-arguments-naked.rs

### DIFF
--- a/src/test/debuginfo/function-arguments-naked.rs
+++ b/src/test/debuginfo/function-arguments-naked.rs
@@ -3,6 +3,9 @@
 // We have to ignore android because of this issue:
 // https://github.com/rust-lang/rust/issues/74847
 // ignore-android
+//
+// We need to use inline assembly, so just use one platform
+// only-x86_64
 
 // compile-flags:-g
 
@@ -24,6 +27,7 @@
 // lldb-command:continue
 
 
+#![feature(asm)]
 #![feature(naked_functions)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
@@ -34,5 +38,5 @@ fn main() {
 
 #[naked]
 fn naked(x: usize, y: usize) {
-    // #break
+    unsafe { asm!("ret"); } // #break
 }

--- a/src/test/debuginfo/function-arguments-naked.rs
+++ b/src/test/debuginfo/function-arguments-naked.rs
@@ -34,7 +34,5 @@ fn main() {
 
 #[naked]
 fn naked(x: usize, y: usize) {
-    zzz(); // #break
+    // #break
 }
-
-fn zzz() { () }

--- a/src/test/debuginfo/function-arguments-naked.rs
+++ b/src/test/debuginfo/function-arguments-naked.rs
@@ -37,6 +37,6 @@ fn main() {
 }
 
 #[naked]
-fn naked(x: usize, y: usize) {
+extern "C" fn naked(x: usize, y: usize) {
     unsafe { asm!("ret"); } // #break
 }


### PR DESCRIPTION
Fixes #75096

It's U.B. to use anything other than inline assmebling in a naked
function. Fortunately, the `#break` directive works fine without
anything in the function body.