### PR TITLE
Display elided lifetime for non-reference type in doc

### DIFF
--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -749,6 +749,10 @@ impl Lifetime {
     pub fn statik() -> Lifetime {
         Lifetime("'static".to_string())
     }
+
+    pub fn elided() -> Lifetime {
+        Lifetime("'_".to_string())
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/src/test/rustdoc/auxiliary/elided-lifetime.rs
+++ b/src/test/rustdoc/auxiliary/elided-lifetime.rs
@@ -1,0 +1,11 @@
+#![crate_name = "bar"]
+
+pub struct Ref<'a>(&'a u32);
+
+pub fn test5(a: &u32) -> Ref {
+    Ref(a)
+}
+
+pub fn test6(a: &u32) -> Ref<'_> {
+    Ref(a)
+}

--- a/src/test/rustdoc/elided-lifetime.rs
+++ b/src/test/rustdoc/elided-lifetime.rs
@@ -1,9 +1,11 @@
-#![crate_name = "foo"]
-
+// aux-build:elided-lifetime.rs
+//
 // rust-lang/rust#75225
 //
 // Since Rust 2018 we encourage writing out <'_> explicitly to make it clear
 // that borrowing is occuring. Make sure rustdoc is following the same idiom.
+
+#![crate_name = "foo"]
 
 pub struct Ref<'a>(&'a u32);
 type ARef<'a> = Ref<'a>;
@@ -32,15 +34,10 @@ pub fn test4(a: &u32) -> ARef<'_> {
     Ref(a)
 }
 
-// Ensure external paths also display elided lifetime
-// @has foo/fn.test5.html
-// @matches - "Iter</a>&lt;'_"
-pub fn test5(a: &Option<u32>) -> std::option::Iter<u32> {
-    a.iter()
-}
-
-// @has foo/fn.test6.html
-// @matches - "Iter</a>&lt;'_"
-pub fn test6(a: &Option<u32>) -> std::option::Iter<'_, u32> {
-    a.iter()
-}
+// Ensure external paths in inlined docs also display elided lifetime
+// @has foo/bar/fn.test5.html
+// @matches - "Ref</a>&lt;'_&gt;"
+// @has foo/bar/fn.test6.html
+// @matches - "Ref</a>&lt;'_&gt;"
+#[doc(inline)]
+pub extern crate bar;

--- a/src/test/rustdoc/elided-lifetime.rs
+++ b/src/test/rustdoc/elided-lifetime.rs
@@ -1,0 +1,33 @@
+#![crate_name = "foo"]
+
+// rust-lang/rust#75225
+//
+// Since Rust 2018 we encourage writing out <'_> explicitly to make it clear
+// that borrowing is occuring. Make sure rustdoc is following the same idiom.
+
+pub struct Ref<'a>(&'a u32);
+type ARef<'a> = Ref<'a>;
+
+// @has foo/fn.test1.html
+// @matches - "Ref</a>&lt;'_&gt;"
+pub fn test1(a: &u32) -> Ref {
+    Ref(a)
+}
+
+// @has foo/fn.test2.html
+// @matches - "Ref</a>&lt;'_&gt;"
+pub fn test2(a: &u32) -> Ref<'_> {
+    Ref(a)
+}
+
+// @has foo/fn.test3.html
+// @matches - "Ref</a>&lt;'_&gt;"
+pub fn test3(a: &u32) -> ARef {
+    Ref(a)
+}
+
+// @has foo/fn.test4.html
+// @matches - "Ref</a>&lt;'_&gt;"
+pub fn test4(a: &u32) -> ARef<'_> {
+    Ref(a)
+}

--- a/src/test/rustdoc/elided-lifetime.rs
+++ b/src/test/rustdoc/elided-lifetime.rs
@@ -31,3 +31,16 @@ pub fn test3(a: &u32) -> ARef {
 pub fn test4(a: &u32) -> ARef<'_> {
     Ref(a)
 }
+
+// Ensure external paths also display elided lifetime
+// @has foo/fn.test5.html
+// @matches - "Iter</a>&lt;'_"
+pub fn test5(a: &Option<u32>) -> std::option::Iter<u32> {
+    a.iter()
+}
+
+// @has foo/fn.test6.html
+// @matches - "Iter</a>&lt;'_"
+pub fn test6(a: &Option<u32>) -> std::option::Iter<'_, u32> {
+    a.iter()
+}


### PR DESCRIPTION
In edition 2018 we encourage writing `<'_>` explicitly, so rustdoc should display like such as well.

Fixes #75225

~~Somehow when I run the compiled rustdoc using `cargo +stage2 doc` on other crates, it correctly produces `<'_>`, but I couldn't get the std doc to do the same with `./x.py doc --stage 2`. Might this be related to the recent change to x.py about how the doc is built?~~