### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/library/alloc/src/collections/btree/map.rs
+++ b/library/alloc/src/collections/btree/map.rs
@@ -1294,7 +1294,7 @@ impl<K: Ord, V> BTreeMap<K, V> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a, K: 'a, V: 'a> IntoIterator for &'a BTreeMap<K, V> {
+impl<'a, K, V> IntoIterator for &'a BTreeMap<K, V> {
     type Item = (&'a K, &'a V);
     type IntoIter = Iter<'a, K, V>;
 
@@ -1363,7 +1363,7 @@ impl<K, V> Clone for Iter<'_, K, V> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a, K: 'a, V: 'a> IntoIterator for &'a mut BTreeMap<K, V> {
+impl<'a, K, V> IntoIterator for &'a mut BTreeMap<K, V> {
     type Item = (&'a K, &'a mut V);
     type IntoIter = IterMut<'a, K, V>;
 

--- a/library/core/src/ptr/const_ptr.rs
+++ b/library/core/src/ptr/const_ptr.rs
@@ -656,6 +656,38 @@ impl<T: ?Sized> *const T {
         self.wrapping_offset((count as isize).wrapping_neg())
     }
 
+    /// Sets the pointer value to `ptr`.
+    ///
+    /// In case `self` is a (fat) pointer to an unsized type, this operation
+    /// will only affect the pointer part, whereas for (thin) pointers to
+    /// sized types, this has the same effect as a simple assignment.
+    ///
+    /// # Examples
+    ///
+    /// This function is primarily useful for allowing byte-wise pointer
+    /// arithmetic on potentially fat pointers:
+    ///
+    /// ```
+    /// #![feature(set_ptr_value)]
+    /// # use core::fmt::Debug;
+    /// let arr: [i32; 3] = [1, 2, 3];
+    /// let mut ptr = &arr[0] as *const dyn Debug;
+    /// let thin = ptr as *const u8;
+    /// ptr = ptr.set_ptr_value(unsafe { thin.add(8).cast() });
+    /// assert_eq!(unsafe { *(ptr as *const i32) }, 3);
+    /// ```
+    #[unstable(feature = "set_ptr_value", issue = "75091")]
+    #[inline]
+    pub fn set_ptr_value(mut self, val: *const ()) -> Self {
+        let thin = &mut self as *mut *const T as *mut *const ();
+        // SAFETY: In case of a thin pointer, this operations is identical
+        // to a simple assignment. In case of a fat pointer, with the current
+        // fat pointer layout implementation, the first field of such a
+        // pointer is always the data pointer, which is likewise assigned.
+        unsafe { *thin = val };
+        self
+    }
+
     /// Reads the value from `self` without moving it. This leaves the
     /// memory in `self` unchanged.
     ///

--- a/src/librustc_ast_lowering/expr.rs
+++ b/src/librustc_ast_lowering/expr.rs
@@ -1067,7 +1067,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
             .collect();
 
         // Stop if there were any errors when lowering the register classes
-        if operands.len() != asm.operands.len() {
+        if operands.len() != asm.operands.len() || sess.asm_arch.is_none() {
             return hir::ExprKind::Err;
         }
 

--- a/src/librustc_hir/def.rs
+++ b/src/librustc_hir/def.rs
@@ -150,7 +150,7 @@ impl DefKind {
         }
     }
 
-    pub fn matches_ns(&self, ns: Namespace) -> bool {
+    pub fn ns(&self) -> Option<Namespace> {
         match self {
             DefKind::Mod
             | DefKind::Struct
@@ -163,7 +163,7 @@ impl DefKind {
             | DefKind::ForeignTy
             | DefKind::TraitAlias
             | DefKind::AssocTy
-            | DefKind::TyParam => ns == Namespace::TypeNS,
+            | DefKind::TyParam => Some(Namespace::TypeNS),
 
             DefKind::Fn
             | DefKind::Const
@@ -171,9 +171,9 @@ impl DefKind {
             | DefKind::Static
             | DefKind::Ctor(..)
             | DefKind::AssocFn
-            | DefKind::AssocConst => ns == Namespace::ValueNS,
+            | DefKind::AssocConst => Some(Namespace::ValueNS),
 
-            DefKind::Macro(..) => ns == Namespace::MacroNS,
+            DefKind::Macro(..) => Some(Namespace::MacroNS),
 
             // Not namespaced.
             DefKind::AnonConst
@@ -185,7 +185,7 @@ impl DefKind {
             | DefKind::Use
             | DefKind::ForeignMod
             | DefKind::GlobalAsm
-            | DefKind::Impl => false,
+            | DefKind::Impl => None,
         }
     }
 }
@@ -453,7 +453,7 @@ impl<Id> Res<Id> {
 
     pub fn matches_ns(&self, ns: Namespace) -> bool {
         match self {
-            Res::Def(kind, ..) => kind.matches_ns(ns),
+            Res::Def(kind, ..) => kind.ns() == Some(ns),
             Res::PrimTy(..) | Res::SelfTy(..) | Res::ToolMod => ns == Namespace::TypeNS,
             Res::SelfCtor(..) | Res::Local(..) => ns == Namespace::ValueNS,
             Res::NonMacroAttr(..) => ns == Namespace::MacroNS,

--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -607,6 +607,9 @@ pub fn register_res(cx: &DocContext<'_>, res: Res) -> DefId {
         Res::Def(DefKind::TyAlias, i) => (i, TypeKind::Typedef),
         Res::Def(DefKind::Enum, i) => (i, TypeKind::Enum),
         Res::Def(DefKind::Trait, i) => (i, TypeKind::Trait),
+        Res::Def(DefKind::AssocTy | DefKind::AssocFn | DefKind::AssocConst, i) => {
+            (cx.tcx.parent(i).unwrap(), TypeKind::Trait)
+        }
         Res::Def(DefKind::Struct, i) => (i, TypeKind::Struct),
         Res::Def(DefKind::Union, i) => (i, TypeKind::Union),
         Res::Def(DefKind::Mod, i) => (i, TypeKind::Module),

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -893,6 +893,8 @@ impl Disambiguator {
     fn display_for(kind: DefKind, path_str: &str) -> String {
         if kind == DefKind::Macro(MacroKind::Bang) {
             return format!("{}!", path_str);
+        } else if kind == DefKind::Fn || kind == DefKind::AssocFn {
+            return format!("{}()", path_str);
         }
         let prefix = match kind {
             DefKind::Struct => "struct",
@@ -904,7 +906,6 @@ impl Disambiguator {
                 "const"
             }
             DefKind::Static => "static",
-            DefKind::Fn | DefKind::AssocFn => "fn",
             DefKind::Macro(MacroKind::Derive) => "derive",
             // Now handle things that don't have a specific disambiguator
             _ => match kind

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -767,8 +767,6 @@ impl<'a, 'tcx> DocFolder for LinkCollector<'a, 'tcx> {
                 // Disallow e.g. linking to enums with `struct@`
                 if let Res::Def(kind, id) = res {
                     debug!("saw kind {:?} with disambiguator {:?}", kind, disambiguator);
-                    // NOTE: this relies on the fact that `''` is never parsed as a disambiguator
-                    // NOTE: this needs to be kept in sync with the disambiguator parsing
                     match (self.kind_side_channel.take().unwrap_or(kind), disambiguator) {
                         | (DefKind::Const | DefKind::ConstParam | DefKind::AssocConst | DefKind::AnonConst, Some(Disambiguator::Kind(DefKind::Const)))
                         // NOTE: this allows 'method' to mean both normal functions and associated functions
@@ -780,7 +778,7 @@ impl<'a, 'tcx> DocFolder for LinkCollector<'a, 'tcx> {
                         | (_, None)
                         // All of these are valid, so do nothing
                         => {}
-                        (_, Some(Disambiguator::Kind(expected))) if kind == expected => {}
+                        (actual, Some(Disambiguator::Kind(expected))) if actual == expected => {}
                         (_, Some(expected)) => {
                             // The resolved item did not match the disambiguator; give a better error than 'not found'
                             let msg = format!("incompatible link kind for `{}`", path_str);

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -779,7 +779,7 @@ impl<'a, 'tcx> DocFolder for LinkCollector<'a, 'tcx> {
                         // All of these are valid, so do nothing
                         => {}
                         (actual, Some(Disambiguator::Kind(expected))) if actual == expected => {}
-                        (_, Some(expected)) => {
+                        (_, Some(Disambiguator::Kind(expected))) => {
                             // The resolved item did not match the disambiguator; give a better error than 'not found'
                             let msg = format!("incompatible link kind for `{}`", path_str);
                             report_diagnostic(cx, &msg, &item, &dox, link_range, |diag, sp| {
@@ -932,22 +932,6 @@ impl Disambiguator {
             Self::Kind(k) => {
                 k.ns().expect("only DefKinds with a valid namespace can be disambiguators")
             }
-        }
-    }
-
-    fn article(&self) -> &'static str {
-        match self {
-            Self::Namespace(_) => "a",
-            Self::Kind(kind) => kind.article(),
-        }
-    }
-
-    fn descr(&self, def_id: DefId) -> &'static str {
-        match self {
-            Self::Namespace(Namespace::TypeNS) => "type",
-            Self::Namespace(Namespace::ValueNS) => "value",
-            Self::Namespace(Namespace::MacroNS) => "macro",
-            Self::Kind(kind) => kind.descr(def_id),
         }
     }
 }

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -415,7 +415,8 @@ impl<'a, 'tcx> LinkCollector<'a, 'tcx> {
                                 AnchorFailure::Method
                             }))
                         } else {
-                            Ok((ty_res, Some(format!("{}.{}", kind, item_name))))
+                            let res = Res::Def(item.kind.as_def_kind(), item.def_id);
+                            Ok((res, Some(format!("{}.{}", kind, item_name))))
                         }
                     } else {
                         self.variant_field(path_str, current_item, module_id)

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -819,7 +819,7 @@ impl<'a, 'tcx> DocFolder for LinkCollector<'a, 'tcx> {
                             // The resolved item did not match the disambiguator; give a better error than 'not found'
                             let msg = format!("unresolved link to `{}`", path_str);
                             report_diagnostic(cx, &msg, &item, &dox, link_range, |diag, sp| {
-                                let msg = format!("this item resolved to {} {}, which did not match the disambiguator '{}'", kind.article(), kind.descr(id), disambiguator);
+                                let msg = format!("this link resolved to {} {}, which did not match the disambiguator '{}'", kind.article(), kind.descr(id), disambiguator);
                                 if let Some(sp) = sp {
                                     diag.span_note(sp, &msg);
                                 } else {

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -787,6 +787,8 @@ impl<'a, 'tcx> DocFolder for LinkCollector<'a, 'tcx> {
                                 diag.note(&note);
                                 if let Some(sp) = sp {
                                     diag.span_suggestion(sp, &help_msg, suggestion, Applicability::MaybeIncorrect);
+                                } else {
+                                    diag.help(&format!("{}: {}", help_msg, suggestion));
                                 }
                             });
                             continue;

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -777,7 +777,7 @@ impl<'a, 'tcx> DocFolder for LinkCollector<'a, 'tcx> {
                         (_, Some(Disambiguator::Kind(expected))) if kind == expected => {}
                         (_, Some(expected)) => {
                             // The resolved item did not match the disambiguator; give a better error than 'not found'
-                            let msg = format!("unresolved link to `{}`", path_str);
+                            let msg = format!("incompatible link kind for `{}`", path_str);
                             report_diagnostic(cx, &msg, &item, &dox, link_range, |diag, sp| {
                                 // HACK(jynelson): by looking at the source I saw the DefId we pass
                                 // for `expected.descr()` doesn't matter, since it's not a crate
@@ -787,7 +787,6 @@ impl<'a, 'tcx> DocFolder for LinkCollector<'a, 'tcx> {
                                 diag.note(&note);
                                 if let Some(sp) = sp {
                                     diag.span_suggestion(sp, &help_msg, suggestion, Applicability::MaybeIncorrect);
-                                    diag.set_sort_span(sp);
                                 }
                             });
                             continue;

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -63,6 +63,9 @@ struct LinkCollector<'a, 'tcx> {
     cx: &'a DocContext<'tcx>,
     // NOTE: this may not necessarily be a module in the current crate
     mod_ids: Vec<DefId>,
+    /// This is used to store the kind of associated items,
+    /// because `clean` and the disambiguator code expect them to be different.
+    /// See the code for associated items on inherent impls for details.
     kind_side_channel: Cell<Option<DefKind>>,
 }
 

--- a/src/test/rustdoc-ui/intra-links-disambiguator-mismatch.rs
+++ b/src/test/rustdoc-ui/intra-links-disambiguator-mismatch.rs
@@ -2,6 +2,10 @@
 //~^ NOTE lint level is defined
 pub enum S {}
 
+impl S {
+    fn assoc_fn() {}
+}
+
 macro_rules! m {
     () => {};
 }
@@ -65,4 +69,6 @@ trait T {}
 //~^ ERROR incompatible link kind for `f`
 //~| NOTE this link resolved
 //~| HELP use its disambiguator
+
+/// Link to [S::assoc_fn()]
 pub fn f() {}

--- a/src/test/rustdoc-ui/intra-links-disambiguator-mismatch.rs
+++ b/src/test/rustdoc-ui/intra-links-disambiguator-mismatch.rs
@@ -60,4 +60,9 @@ trait T {}
 //~^ ERROR incompatible link kind for `c`
 //~| NOTE this link resolved
 //~| HELP use its disambiguator
+
+/// Link to [const@f]
+//~^ ERROR incompatible link kind for `f`
+//~| NOTE this link resolved
+//~| HELP use its disambiguator
 pub fn f() {}

--- a/src/test/rustdoc-ui/intra-links-disambiguator-mismatch.rs
+++ b/src/test/rustdoc-ui/intra-links-disambiguator-mismatch.rs
@@ -2,10 +2,6 @@
 //~^ NOTE lint level is defined
 pub enum S {}
 
-impl S {
-    fn assoc_fn() {}
-}
-
 macro_rules! m {
     () => {};
 }
@@ -69,6 +65,4 @@ trait T {}
 //~^ ERROR incompatible link kind for `f`
 //~| NOTE this link resolved
 //~| HELP use its disambiguator
-
-/// Link to [S::assoc_fn()]
 pub fn f() {}

--- a/src/test/rustdoc-ui/intra-links-disambiguator-mismatch.rs
+++ b/src/test/rustdoc-ui/intra-links-disambiguator-mismatch.rs
@@ -13,41 +13,51 @@ trait T {}
 
 /// Link to [struct@S]
 //~^ ERROR unresolved link to `S`
-//~| NOTE did not match
+//~| NOTE this link resolved
+//~| HELP use its disambiguator
 
 /// Link to [mod@S]
 //~^ ERROR unresolved link to `S`
-//~| NOTE did not match
+//~| NOTE this link resolved
+//~| HELP use its disambiguator
 
 /// Link to [union@S]
 //~^ ERROR unresolved link to `S`
-//~| NOTE did not match
+//~| NOTE this link resolved
+//~| HELP use its disambiguator
 
 /// Link to [trait@S]
 //~^ ERROR unresolved link to `S`
-//~| NOTE did not match
+//~| NOTE this link resolved
+//~| HELP use its disambiguator
 
 /// Link to [struct@T]
 //~^ ERROR unresolved link to `T`
-//~| NOTE did not match
+//~| NOTE this link resolved
+//~| HELP use its disambiguator
 
 /// Link to [derive@m]
 //~^ ERROR unresolved link to `m`
-//~| NOTE did not match
+//~| NOTE this link resolved
+//~| HELP use its disambiguator
 
 /// Link to [const@s]
 //~^ ERROR unresolved link to `s`
-//~| NOTE did not match
+//~| NOTE this link resolved
+//~| HELP use its disambiguator
 
 /// Link to [static@c]
 //~^ ERROR unresolved link to `c`
-//~| NOTE did not match
+//~| NOTE this link resolved
+//~| HELP use its disambiguator
 
 /// Link to [fn@c]
 //~^ ERROR unresolved link to `c`
-//~| NOTE did not match
+//~| NOTE this link resolved
+//~| HELP use its disambiguator
 
 /// Link to [c()]
 //~^ ERROR unresolved link to `c`
-//~| NOTE did not match
+//~| NOTE this link resolved
+//~| HELP use its disambiguator
 pub fn f() {}

--- a/src/test/rustdoc-ui/intra-links-disambiguator-mismatch.rs
+++ b/src/test/rustdoc-ui/intra-links-disambiguator-mismatch.rs
@@ -12,52 +12,52 @@ const c: usize = 0;
 trait T {}
 
 /// Link to [struct@S]
-//~^ ERROR unresolved link to `S`
+//~^ ERROR incompatible link kind for `S`
 //~| NOTE this link resolved
 //~| HELP use its disambiguator
 
 /// Link to [mod@S]
-//~^ ERROR unresolved link to `S`
+//~^ ERROR incompatible link kind for `S`
 //~| NOTE this link resolved
 //~| HELP use its disambiguator
 
 /// Link to [union@S]
-//~^ ERROR unresolved link to `S`
+//~^ ERROR incompatible link kind for `S`
 //~| NOTE this link resolved
 //~| HELP use its disambiguator
 
 /// Link to [trait@S]
-//~^ ERROR unresolved link to `S`
+//~^ ERROR incompatible link kind for `S`
 //~| NOTE this link resolved
 //~| HELP use its disambiguator
 
 /// Link to [struct@T]
-//~^ ERROR unresolved link to `T`
+//~^ ERROR incompatible link kind for `T`
 //~| NOTE this link resolved
 //~| HELP use its disambiguator
 
 /// Link to [derive@m]
-//~^ ERROR unresolved link to `m`
+//~^ ERROR incompatible link kind for `m`
 //~| NOTE this link resolved
 //~| HELP use its disambiguator
 
 /// Link to [const@s]
-//~^ ERROR unresolved link to `s`
+//~^ ERROR incompatible link kind for `s`
 //~| NOTE this link resolved
 //~| HELP use its disambiguator
 
 /// Link to [static@c]
-//~^ ERROR unresolved link to `c`
+//~^ ERROR incompatible link kind for `c`
 //~| NOTE this link resolved
 //~| HELP use its disambiguator
 
 /// Link to [fn@c]
-//~^ ERROR unresolved link to `c`
+//~^ ERROR incompatible link kind for `c`
 //~| NOTE this link resolved
 //~| HELP use its disambiguator
 
 /// Link to [c()]
-//~^ ERROR unresolved link to `c`
+//~^ ERROR incompatible link kind for `c`
 //~| NOTE this link resolved
 //~| HELP use its disambiguator
 pub fn f() {}

--- a/src/test/rustdoc-ui/intra-links-disambiguator-mismatch.rs
+++ b/src/test/rustdoc-ui/intra-links-disambiguator-mismatch.rs
@@ -1,0 +1,53 @@
+#![deny(broken_intra_doc_links)]
+//~^ NOTE lint level is defined
+pub enum S {}
+
+macro_rules! m {
+    () => {};
+}
+
+static s: usize = 0;
+const c: usize = 0;
+
+trait T {}
+
+/// Link to [struct@S]
+//~^ ERROR unresolved link to `S`
+//~| NOTE did not match
+
+/// Link to [mod@S]
+//~^ ERROR unresolved link to `S`
+//~| NOTE did not match
+
+/// Link to [union@S]
+//~^ ERROR unresolved link to `S`
+//~| NOTE did not match
+
+/// Link to [trait@S]
+//~^ ERROR unresolved link to `S`
+//~| NOTE did not match
+
+/// Link to [struct@T]
+//~^ ERROR unresolved link to `T`
+//~| NOTE did not match
+
+/// Link to [derive@m]
+//~^ ERROR unresolved link to `m`
+//~| NOTE did not match
+
+/// Link to [const@s]
+//~^ ERROR unresolved link to `s`
+//~| NOTE did not match
+
+/// Link to [static@c]
+//~^ ERROR unresolved link to `c`
+//~| NOTE did not match
+
+/// Link to [fn@c]
+//~^ ERROR unresolved link to `c`
+//~| NOTE did not match
+
+/// Link to [c()]
+//~^ ERROR unresolved link to `c`
+//~| NOTE did not match
+pub fn f() {}

--- a/src/test/rustdoc-ui/intra-links-disambiguator-mismatch.stderr
+++ b/src/test/rustdoc-ui/intra-links-disambiguator-mismatch.stderr
@@ -1,5 +1,5 @@
 error: incompatible link kind for `S`
-  --> $DIR/intra-links-disambiguator-mismatch.rs:18:14
+  --> $DIR/intra-links-disambiguator-mismatch.rs:14:14
    |
 LL | /// Link to [struct@S]
    |              ^^^^^^^^ help: to link to the enum, use its disambiguator: `enum@S`
@@ -12,7 +12,7 @@ LL | #![deny(broken_intra_doc_links)]
    = note: this link resolved to an enum, which is not a struct
 
 error: incompatible link kind for `S`
-  --> $DIR/intra-links-disambiguator-mismatch.rs:23:14
+  --> $DIR/intra-links-disambiguator-mismatch.rs:19:14
    |
 LL | /// Link to [mod@S]
    |              ^^^^^ help: to link to the enum, use its disambiguator: `enum@S`
@@ -20,7 +20,7 @@ LL | /// Link to [mod@S]
    = note: this link resolved to an enum, which is not a module
 
 error: incompatible link kind for `S`
-  --> $DIR/intra-links-disambiguator-mismatch.rs:28:14
+  --> $DIR/intra-links-disambiguator-mismatch.rs:24:14
    |
 LL | /// Link to [union@S]
    |              ^^^^^^^ help: to link to the enum, use its disambiguator: `enum@S`
@@ -28,7 +28,7 @@ LL | /// Link to [union@S]
    = note: this link resolved to an enum, which is not a union
 
 error: incompatible link kind for `S`
-  --> $DIR/intra-links-disambiguator-mismatch.rs:33:14
+  --> $DIR/intra-links-disambiguator-mismatch.rs:29:14
    |
 LL | /// Link to [trait@S]
    |              ^^^^^^^ help: to link to the enum, use its disambiguator: `enum@S`
@@ -36,7 +36,7 @@ LL | /// Link to [trait@S]
    = note: this link resolved to an enum, which is not a trait
 
 error: incompatible link kind for `T`
-  --> $DIR/intra-links-disambiguator-mismatch.rs:38:14
+  --> $DIR/intra-links-disambiguator-mismatch.rs:34:14
    |
 LL | /// Link to [struct@T]
    |              ^^^^^^^^ help: to link to the trait, use its disambiguator: `trait@T`
@@ -44,7 +44,7 @@ LL | /// Link to [struct@T]
    = note: this link resolved to a trait, which is not a struct
 
 error: incompatible link kind for `m`
-  --> $DIR/intra-links-disambiguator-mismatch.rs:43:14
+  --> $DIR/intra-links-disambiguator-mismatch.rs:39:14
    |
 LL | /// Link to [derive@m]
    |              ^^^^^^^^ help: to link to the macro, use its disambiguator: `m!`
@@ -52,7 +52,7 @@ LL | /// Link to [derive@m]
    = note: this link resolved to a macro, which is not a derive macro
 
 error: incompatible link kind for `s`
-  --> $DIR/intra-links-disambiguator-mismatch.rs:48:14
+  --> $DIR/intra-links-disambiguator-mismatch.rs:44:14
    |
 LL | /// Link to [const@s]
    |              ^^^^^^^ help: to link to the static, use its disambiguator: `static@s`
@@ -60,7 +60,7 @@ LL | /// Link to [const@s]
    = note: this link resolved to a static, which is not a constant
 
 error: incompatible link kind for `c`
-  --> $DIR/intra-links-disambiguator-mismatch.rs:53:14
+  --> $DIR/intra-links-disambiguator-mismatch.rs:49:14
    |
 LL | /// Link to [static@c]
    |              ^^^^^^^^ help: to link to the constant, use its disambiguator: `const@c`
@@ -68,7 +68,7 @@ LL | /// Link to [static@c]
    = note: this link resolved to a constant, which is not a static
 
 error: incompatible link kind for `c`
-  --> $DIR/intra-links-disambiguator-mismatch.rs:58:14
+  --> $DIR/intra-links-disambiguator-mismatch.rs:54:14
    |
 LL | /// Link to [fn@c]
    |              ^^^^ help: to link to the constant, use its disambiguator: `const@c`
@@ -76,7 +76,7 @@ LL | /// Link to [fn@c]
    = note: this link resolved to a constant, which is not a function
 
 error: incompatible link kind for `c`
-  --> $DIR/intra-links-disambiguator-mismatch.rs:63:14
+  --> $DIR/intra-links-disambiguator-mismatch.rs:59:14
    |
 LL | /// Link to [c()]
    |              ^^^ help: to link to the constant, use its disambiguator: `const@c`
@@ -84,7 +84,7 @@ LL | /// Link to [c()]
    = note: this link resolved to a constant, which is not a function
 
 error: incompatible link kind for `f`
-  --> $DIR/intra-links-disambiguator-mismatch.rs:68:14
+  --> $DIR/intra-links-disambiguator-mismatch.rs:64:14
    |
 LL | /// Link to [const@f]
    |              ^^^^^^^ help: to link to the function, use its disambiguator: `f()`

--- a/src/test/rustdoc-ui/intra-links-disambiguator-mismatch.stderr
+++ b/src/test/rustdoc-ui/intra-links-disambiguator-mismatch.stderr
@@ -1,5 +1,5 @@
 error: unresolved link to `S`
-  --> $DIR/intra-links-disambiguator-mismatch.rs:16:14
+  --> $DIR/intra-links-disambiguator-mismatch.rs:14:14
    |
 LL | /// Link to [struct@S]
    |              ^^^^^^^^
@@ -9,116 +9,116 @@ note: the lint level is defined here
    |
 LL | #![deny(broken_intra_doc_links)]
    |         ^^^^^^^^^^^^^^^^^^^^^^
-note: this item resolved to an enum, which did not match the disambiguator 'struct'
-  --> $DIR/intra-links-disambiguator-mismatch.rs:16:14
+note: this link resolved to an enum, which did not match the disambiguator 'struct'
+  --> $DIR/intra-links-disambiguator-mismatch.rs:14:14
    |
 LL | /// Link to [struct@S]
    |              ^^^^^^^^
 
 error: unresolved link to `S`
-  --> $DIR/intra-links-disambiguator-mismatch.rs:20:14
+  --> $DIR/intra-links-disambiguator-mismatch.rs:18:14
    |
 LL | /// Link to [mod@S]
    |              ^^^^^
    |
-note: this item resolved to an enum, which did not match the disambiguator 'mod'
-  --> $DIR/intra-links-disambiguator-mismatch.rs:20:14
+note: this link resolved to an enum, which did not match the disambiguator 'mod'
+  --> $DIR/intra-links-disambiguator-mismatch.rs:18:14
    |
 LL | /// Link to [mod@S]
    |              ^^^^^
 
 error: unresolved link to `S`
-  --> $DIR/intra-links-disambiguator-mismatch.rs:24:14
+  --> $DIR/intra-links-disambiguator-mismatch.rs:22:14
    |
 LL | /// Link to [union@S]
    |              ^^^^^^^
    |
-note: this item resolved to an enum, which did not match the disambiguator 'union'
-  --> $DIR/intra-links-disambiguator-mismatch.rs:24:14
+note: this link resolved to an enum, which did not match the disambiguator 'union'
+  --> $DIR/intra-links-disambiguator-mismatch.rs:22:14
    |
 LL | /// Link to [union@S]
    |              ^^^^^^^
 
 error: unresolved link to `S`
-  --> $DIR/intra-links-disambiguator-mismatch.rs:28:14
+  --> $DIR/intra-links-disambiguator-mismatch.rs:26:14
    |
 LL | /// Link to [trait@S]
    |              ^^^^^^^
    |
-note: this item resolved to an enum, which did not match the disambiguator 'trait'
-  --> $DIR/intra-links-disambiguator-mismatch.rs:28:14
+note: this link resolved to an enum, which did not match the disambiguator 'trait'
+  --> $DIR/intra-links-disambiguator-mismatch.rs:26:14
    |
 LL | /// Link to [trait@S]
    |              ^^^^^^^
 
 error: unresolved link to `T`
-  --> $DIR/intra-links-disambiguator-mismatch.rs:32:14
+  --> $DIR/intra-links-disambiguator-mismatch.rs:30:14
    |
 LL | /// Link to [struct@T]
    |              ^^^^^^^^
    |
-note: this item resolved to a trait, which did not match the disambiguator 'struct'
-  --> $DIR/intra-links-disambiguator-mismatch.rs:32:14
+note: this link resolved to a trait, which did not match the disambiguator 'struct'
+  --> $DIR/intra-links-disambiguator-mismatch.rs:30:14
    |
 LL | /// Link to [struct@T]
    |              ^^^^^^^^
 
 error: unresolved link to `m`
-  --> $DIR/intra-links-disambiguator-mismatch.rs:36:14
+  --> $DIR/intra-links-disambiguator-mismatch.rs:34:14
    |
 LL | /// Link to [derive@m]
    |              ^^^^^^^^
    |
-note: this item resolved to a macro, which did not match the disambiguator 'derive'
-  --> $DIR/intra-links-disambiguator-mismatch.rs:36:14
+note: this link resolved to a macro, which did not match the disambiguator 'derive'
+  --> $DIR/intra-links-disambiguator-mismatch.rs:34:14
    |
 LL | /// Link to [derive@m]
    |              ^^^^^^^^
 
 error: unresolved link to `s`
-  --> $DIR/intra-links-disambiguator-mismatch.rs:40:14
+  --> $DIR/intra-links-disambiguator-mismatch.rs:38:14
    |
 LL | /// Link to [const@s]
    |              ^^^^^^^
    |
-note: this item resolved to a static, which did not match the disambiguator 'const'
-  --> $DIR/intra-links-disambiguator-mismatch.rs:40:14
+note: this link resolved to a static, which did not match the disambiguator 'const'
+  --> $DIR/intra-links-disambiguator-mismatch.rs:38:14
    |
 LL | /// Link to [const@s]
    |              ^^^^^^^
 
 error: unresolved link to `c`
-  --> $DIR/intra-links-disambiguator-mismatch.rs:44:14
+  --> $DIR/intra-links-disambiguator-mismatch.rs:42:14
    |
 LL | /// Link to [static@c]
    |              ^^^^^^^^
    |
-note: this item resolved to a constant, which did not match the disambiguator 'static'
-  --> $DIR/intra-links-disambiguator-mismatch.rs:44:14
+note: this link resolved to a constant, which did not match the disambiguator 'static'
+  --> $DIR/intra-links-disambiguator-mismatch.rs:42:14
    |
 LL | /// Link to [static@c]
    |              ^^^^^^^^
 
 error: unresolved link to `c`
-  --> $DIR/intra-links-disambiguator-mismatch.rs:48:14
+  --> $DIR/intra-links-disambiguator-mismatch.rs:46:14
    |
 LL | /// Link to [fn@c]
    |              ^^^^
    |
-note: this item resolved to a constant, which did not match the disambiguator 'fn'
-  --> $DIR/intra-links-disambiguator-mismatch.rs:48:14
+note: this link resolved to a constant, which did not match the disambiguator 'fn'
+  --> $DIR/intra-links-disambiguator-mismatch.rs:46:14
    |
 LL | /// Link to [fn@c]
    |              ^^^^
 
 error: unresolved link to `c`
-  --> $DIR/intra-links-disambiguator-mismatch.rs:52:14
+  --> $DIR/intra-links-disambiguator-mismatch.rs:50:14
    |
 LL | /// Link to [c()]
    |              ^^^
    |
-note: this item resolved to a constant, which did not match the disambiguator 'fn'
-  --> $DIR/intra-links-disambiguator-mismatch.rs:52:14
+note: this link resolved to a constant, which did not match the disambiguator 'fn'
+  --> $DIR/intra-links-disambiguator-mismatch.rs:50:14
    |
 LL | /// Link to [c()]
    |              ^^^

--- a/src/test/rustdoc-ui/intra-links-disambiguator-mismatch.stderr
+++ b/src/test/rustdoc-ui/intra-links-disambiguator-mismatch.stderr
@@ -2,126 +2,86 @@ error: unresolved link to `S`
   --> $DIR/intra-links-disambiguator-mismatch.rs:14:14
    |
 LL | /// Link to [struct@S]
-   |              ^^^^^^^^
+   |              ^^^^^^^^ help: to link to the enum, use its disambiguator: `enum@S`
    |
 note: the lint level is defined here
   --> $DIR/intra-links-disambiguator-mismatch.rs:1:9
    |
 LL | #![deny(broken_intra_doc_links)]
    |         ^^^^^^^^^^^^^^^^^^^^^^
-note: this link resolved to an enum, which did not match the disambiguator 'struct'
-  --> $DIR/intra-links-disambiguator-mismatch.rs:14:14
-   |
-LL | /// Link to [struct@S]
-   |              ^^^^^^^^
+   = note: this link resolved to an enum, which is not a struct
 
 error: unresolved link to `S`
-  --> $DIR/intra-links-disambiguator-mismatch.rs:18:14
+  --> $DIR/intra-links-disambiguator-mismatch.rs:19:14
    |
 LL | /// Link to [mod@S]
-   |              ^^^^^
+   |              ^^^^^ help: to link to the enum, use its disambiguator: `enum@S`
    |
-note: this link resolved to an enum, which did not match the disambiguator 'mod'
-  --> $DIR/intra-links-disambiguator-mismatch.rs:18:14
-   |
-LL | /// Link to [mod@S]
-   |              ^^^^^
+   = note: this link resolved to an enum, which is not a module
 
 error: unresolved link to `S`
-  --> $DIR/intra-links-disambiguator-mismatch.rs:22:14
+  --> $DIR/intra-links-disambiguator-mismatch.rs:24:14
    |
 LL | /// Link to [union@S]
-   |              ^^^^^^^
+   |              ^^^^^^^ help: to link to the enum, use its disambiguator: `enum@S`
    |
-note: this link resolved to an enum, which did not match the disambiguator 'union'
-  --> $DIR/intra-links-disambiguator-mismatch.rs:22:14
-   |
-LL | /// Link to [union@S]
-   |              ^^^^^^^
+   = note: this link resolved to an enum, which is not a union
 
 error: unresolved link to `S`
-  --> $DIR/intra-links-disambiguator-mismatch.rs:26:14
+  --> $DIR/intra-links-disambiguator-mismatch.rs:29:14
    |
 LL | /// Link to [trait@S]
-   |              ^^^^^^^
+   |              ^^^^^^^ help: to link to the enum, use its disambiguator: `enum@S`
    |
-note: this link resolved to an enum, which did not match the disambiguator 'trait'
-  --> $DIR/intra-links-disambiguator-mismatch.rs:26:14
-   |
-LL | /// Link to [trait@S]
-   |              ^^^^^^^
+   = note: this link resolved to an enum, which is not a trait
 
 error: unresolved link to `T`
-  --> $DIR/intra-links-disambiguator-mismatch.rs:30:14
+  --> $DIR/intra-links-disambiguator-mismatch.rs:34:14
    |
 LL | /// Link to [struct@T]
-   |              ^^^^^^^^
+   |              ^^^^^^^^ help: to link to the trait, use its disambiguator: `trait@T`
    |
-note: this link resolved to a trait, which did not match the disambiguator 'struct'
-  --> $DIR/intra-links-disambiguator-mismatch.rs:30:14
-   |
-LL | /// Link to [struct@T]
-   |              ^^^^^^^^
+   = note: this link resolved to a trait, which is not a struct
 
 error: unresolved link to `m`
-  --> $DIR/intra-links-disambiguator-mismatch.rs:34:14
+  --> $DIR/intra-links-disambiguator-mismatch.rs:39:14
    |
 LL | /// Link to [derive@m]
-   |              ^^^^^^^^
+   |              ^^^^^^^^ help: to link to the macro, use its disambiguator: `m!`
    |
-note: this link resolved to a macro, which did not match the disambiguator 'derive'
-  --> $DIR/intra-links-disambiguator-mismatch.rs:34:14
-   |
-LL | /// Link to [derive@m]
-   |              ^^^^^^^^
+   = note: this link resolved to a macro, which is not a derive macro
 
 error: unresolved link to `s`
-  --> $DIR/intra-links-disambiguator-mismatch.rs:38:14
+  --> $DIR/intra-links-disambiguator-mismatch.rs:44:14
    |
 LL | /// Link to [const@s]
-   |              ^^^^^^^
+   |              ^^^^^^^ help: to link to the static, use its disambiguator: `static@s`
    |
-note: this link resolved to a static, which did not match the disambiguator 'const'
-  --> $DIR/intra-links-disambiguator-mismatch.rs:38:14
-   |
-LL | /// Link to [const@s]
-   |              ^^^^^^^
+   = note: this link resolved to a static, which is not a constant
 
 error: unresolved link to `c`
-  --> $DIR/intra-links-disambiguator-mismatch.rs:42:14
+  --> $DIR/intra-links-disambiguator-mismatch.rs:49:14
    |
 LL | /// Link to [static@c]
-   |              ^^^^^^^^
+   |              ^^^^^^^^ help: to link to the constant, use its disambiguator: `const@c`
    |
-note: this link resolved to a constant, which did not match the disambiguator 'static'
-  --> $DIR/intra-links-disambiguator-mismatch.rs:42:14
-   |
-LL | /// Link to [static@c]
-   |              ^^^^^^^^
+   = note: this link resolved to a constant, which is not a static
 
 error: unresolved link to `c`
-  --> $DIR/intra-links-disambiguator-mismatch.rs:46:14
+  --> $DIR/intra-links-disambiguator-mismatch.rs:54:14
    |
 LL | /// Link to [fn@c]
-   |              ^^^^
+   |              ^^^^ help: to link to the constant, use its disambiguator: `const@c`
    |
-note: this link resolved to a constant, which did not match the disambiguator 'fn'
-  --> $DIR/intra-links-disambiguator-mismatch.rs:46:14
-   |
-LL | /// Link to [fn@c]
-   |              ^^^^
+   = note: this link resolved to a constant, which is not a function
 
 error: unresolved link to `c`
-  --> $DIR/intra-links-disambiguator-mismatch.rs:50:14
+  --> $DIR/intra-links-disambiguator-mismatch.rs:59:14
    |
 LL | /// Link to [c()]
-   |              ^^^
+   |              ^^^ help: to link to the constant, use its disambiguator: `const@c`
    |
-note: this link resolved to a constant, which did not match the disambiguator 'fn'
-  --> $DIR/intra-links-disambiguator-mismatch.rs:50:14
-   |
-LL | /// Link to [c()]
-   |              ^^^
+   = note: this link resolved to a constant, which is not a function
 
 error: aborting due to 10 previous errors
 

--- a/src/test/rustdoc-ui/intra-links-disambiguator-mismatch.stderr
+++ b/src/test/rustdoc-ui/intra-links-disambiguator-mismatch.stderr
@@ -1,5 +1,5 @@
 error: incompatible link kind for `S`
-  --> $DIR/intra-links-disambiguator-mismatch.rs:14:14
+  --> $DIR/intra-links-disambiguator-mismatch.rs:18:14
    |
 LL | /// Link to [struct@S]
    |              ^^^^^^^^ help: to link to the enum, use its disambiguator: `enum@S`
@@ -12,7 +12,7 @@ LL | #![deny(broken_intra_doc_links)]
    = note: this link resolved to an enum, which is not a struct
 
 error: incompatible link kind for `S`
-  --> $DIR/intra-links-disambiguator-mismatch.rs:19:14
+  --> $DIR/intra-links-disambiguator-mismatch.rs:23:14
    |
 LL | /// Link to [mod@S]
    |              ^^^^^ help: to link to the enum, use its disambiguator: `enum@S`
@@ -20,7 +20,7 @@ LL | /// Link to [mod@S]
    = note: this link resolved to an enum, which is not a module
 
 error: incompatible link kind for `S`
-  --> $DIR/intra-links-disambiguator-mismatch.rs:24:14
+  --> $DIR/intra-links-disambiguator-mismatch.rs:28:14
    |
 LL | /// Link to [union@S]
    |              ^^^^^^^ help: to link to the enum, use its disambiguator: `enum@S`
@@ -28,7 +28,7 @@ LL | /// Link to [union@S]
    = note: this link resolved to an enum, which is not a union
 
 error: incompatible link kind for `S`
-  --> $DIR/intra-links-disambiguator-mismatch.rs:29:14
+  --> $DIR/intra-links-disambiguator-mismatch.rs:33:14
    |
 LL | /// Link to [trait@S]
    |              ^^^^^^^ help: to link to the enum, use its disambiguator: `enum@S`
@@ -36,7 +36,7 @@ LL | /// Link to [trait@S]
    = note: this link resolved to an enum, which is not a trait
 
 error: incompatible link kind for `T`
-  --> $DIR/intra-links-disambiguator-mismatch.rs:34:14
+  --> $DIR/intra-links-disambiguator-mismatch.rs:38:14
    |
 LL | /// Link to [struct@T]
    |              ^^^^^^^^ help: to link to the trait, use its disambiguator: `trait@T`
@@ -44,7 +44,7 @@ LL | /// Link to [struct@T]
    = note: this link resolved to a trait, which is not a struct
 
 error: incompatible link kind for `m`
-  --> $DIR/intra-links-disambiguator-mismatch.rs:39:14
+  --> $DIR/intra-links-disambiguator-mismatch.rs:43:14
    |
 LL | /// Link to [derive@m]
    |              ^^^^^^^^ help: to link to the macro, use its disambiguator: `m!`
@@ -52,7 +52,7 @@ LL | /// Link to [derive@m]
    = note: this link resolved to a macro, which is not a derive macro
 
 error: incompatible link kind for `s`
-  --> $DIR/intra-links-disambiguator-mismatch.rs:44:14
+  --> $DIR/intra-links-disambiguator-mismatch.rs:48:14
    |
 LL | /// Link to [const@s]
    |              ^^^^^^^ help: to link to the static, use its disambiguator: `static@s`
@@ -60,7 +60,7 @@ LL | /// Link to [const@s]
    = note: this link resolved to a static, which is not a constant
 
 error: incompatible link kind for `c`
-  --> $DIR/intra-links-disambiguator-mismatch.rs:49:14
+  --> $DIR/intra-links-disambiguator-mismatch.rs:53:14
    |
 LL | /// Link to [static@c]
    |              ^^^^^^^^ help: to link to the constant, use its disambiguator: `const@c`
@@ -68,7 +68,7 @@ LL | /// Link to [static@c]
    = note: this link resolved to a constant, which is not a static
 
 error: incompatible link kind for `c`
-  --> $DIR/intra-links-disambiguator-mismatch.rs:54:14
+  --> $DIR/intra-links-disambiguator-mismatch.rs:58:14
    |
 LL | /// Link to [fn@c]
    |              ^^^^ help: to link to the constant, use its disambiguator: `const@c`
@@ -76,7 +76,7 @@ LL | /// Link to [fn@c]
    = note: this link resolved to a constant, which is not a function
 
 error: incompatible link kind for `c`
-  --> $DIR/intra-links-disambiguator-mismatch.rs:59:14
+  --> $DIR/intra-links-disambiguator-mismatch.rs:63:14
    |
 LL | /// Link to [c()]
    |              ^^^ help: to link to the constant, use its disambiguator: `const@c`
@@ -84,7 +84,7 @@ LL | /// Link to [c()]
    = note: this link resolved to a constant, which is not a function
 
 error: incompatible link kind for `f`
-  --> $DIR/intra-links-disambiguator-mismatch.rs:64:14
+  --> $DIR/intra-links-disambiguator-mismatch.rs:68:14
    |
 LL | /// Link to [const@f]
    |              ^^^^^^^ help: to link to the function, use its disambiguator: `f()`

--- a/src/test/rustdoc-ui/intra-links-disambiguator-mismatch.stderr
+++ b/src/test/rustdoc-ui/intra-links-disambiguator-mismatch.stderr
@@ -1,4 +1,4 @@
-error: unresolved link to `S`
+error: incompatible link kind for `S`
   --> $DIR/intra-links-disambiguator-mismatch.rs:14:14
    |
 LL | /// Link to [struct@S]
@@ -11,7 +11,7 @@ LL | #![deny(broken_intra_doc_links)]
    |         ^^^^^^^^^^^^^^^^^^^^^^
    = note: this link resolved to an enum, which is not a struct
 
-error: unresolved link to `S`
+error: incompatible link kind for `S`
   --> $DIR/intra-links-disambiguator-mismatch.rs:19:14
    |
 LL | /// Link to [mod@S]
@@ -19,7 +19,7 @@ LL | /// Link to [mod@S]
    |
    = note: this link resolved to an enum, which is not a module
 
-error: unresolved link to `S`
+error: incompatible link kind for `S`
   --> $DIR/intra-links-disambiguator-mismatch.rs:24:14
    |
 LL | /// Link to [union@S]
@@ -27,7 +27,7 @@ LL | /// Link to [union@S]
    |
    = note: this link resolved to an enum, which is not a union
 
-error: unresolved link to `S`
+error: incompatible link kind for `S`
   --> $DIR/intra-links-disambiguator-mismatch.rs:29:14
    |
 LL | /// Link to [trait@S]
@@ -35,7 +35,7 @@ LL | /// Link to [trait@S]
    |
    = note: this link resolved to an enum, which is not a trait
 
-error: unresolved link to `T`
+error: incompatible link kind for `T`
   --> $DIR/intra-links-disambiguator-mismatch.rs:34:14
    |
 LL | /// Link to [struct@T]
@@ -43,7 +43,7 @@ LL | /// Link to [struct@T]
    |
    = note: this link resolved to a trait, which is not a struct
 
-error: unresolved link to `m`
+error: incompatible link kind for `m`
   --> $DIR/intra-links-disambiguator-mismatch.rs:39:14
    |
 LL | /// Link to [derive@m]
@@ -51,7 +51,7 @@ LL | /// Link to [derive@m]
    |
    = note: this link resolved to a macro, which is not a derive macro
 
-error: unresolved link to `s`
+error: incompatible link kind for `s`
   --> $DIR/intra-links-disambiguator-mismatch.rs:44:14
    |
 LL | /// Link to [const@s]
@@ -59,7 +59,7 @@ LL | /// Link to [const@s]
    |
    = note: this link resolved to a static, which is not a constant
 
-error: unresolved link to `c`
+error: incompatible link kind for `c`
   --> $DIR/intra-links-disambiguator-mismatch.rs:49:14
    |
 LL | /// Link to [static@c]
@@ -67,7 +67,7 @@ LL | /// Link to [static@c]
    |
    = note: this link resolved to a constant, which is not a static
 
-error: unresolved link to `c`
+error: incompatible link kind for `c`
   --> $DIR/intra-links-disambiguator-mismatch.rs:54:14
    |
 LL | /// Link to [fn@c]
@@ -75,7 +75,7 @@ LL | /// Link to [fn@c]
    |
    = note: this link resolved to a constant, which is not a function
 
-error: unresolved link to `c`
+error: incompatible link kind for `c`
   --> $DIR/intra-links-disambiguator-mismatch.rs:59:14
    |
 LL | /// Link to [c()]

--- a/src/test/rustdoc-ui/intra-links-disambiguator-mismatch.stderr
+++ b/src/test/rustdoc-ui/intra-links-disambiguator-mismatch.stderr
@@ -1,0 +1,127 @@
+error: unresolved link to `S`
+  --> $DIR/intra-links-disambiguator-mismatch.rs:16:14
+   |
+LL | /// Link to [struct@S]
+   |              ^^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/intra-links-disambiguator-mismatch.rs:1:9
+   |
+LL | #![deny(broken_intra_doc_links)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^
+note: this item resolved to an enum, which did not match the disambiguator 'struct'
+  --> $DIR/intra-links-disambiguator-mismatch.rs:16:14
+   |
+LL | /// Link to [struct@S]
+   |              ^^^^^^^^
+
+error: unresolved link to `S`
+  --> $DIR/intra-links-disambiguator-mismatch.rs:20:14
+   |
+LL | /// Link to [mod@S]
+   |              ^^^^^
+   |
+note: this item resolved to an enum, which did not match the disambiguator 'mod'
+  --> $DIR/intra-links-disambiguator-mismatch.rs:20:14
+   |
+LL | /// Link to [mod@S]
+   |              ^^^^^
+
+error: unresolved link to `S`
+  --> $DIR/intra-links-disambiguator-mismatch.rs:24:14
+   |
+LL | /// Link to [union@S]
+   |              ^^^^^^^
+   |
+note: this item resolved to an enum, which did not match the disambiguator 'union'
+  --> $DIR/intra-links-disambiguator-mismatch.rs:24:14
+   |
+LL | /// Link to [union@S]
+   |              ^^^^^^^
+
+error: unresolved link to `S`
+  --> $DIR/intra-links-disambiguator-mismatch.rs:28:14
+   |
+LL | /// Link to [trait@S]
+   |              ^^^^^^^
+   |
+note: this item resolved to an enum, which did not match the disambiguator 'trait'
+  --> $DIR/intra-links-disambiguator-mismatch.rs:28:14
+   |
+LL | /// Link to [trait@S]
+   |              ^^^^^^^
+
+error: unresolved link to `T`
+  --> $DIR/intra-links-disambiguator-mismatch.rs:32:14
+   |
+LL | /// Link to [struct@T]
+   |              ^^^^^^^^
+   |
+note: this item resolved to a trait, which did not match the disambiguator 'struct'
+  --> $DIR/intra-links-disambiguator-mismatch.rs:32:14
+   |
+LL | /// Link to [struct@T]
+   |              ^^^^^^^^
+
+error: unresolved link to `m`
+  --> $DIR/intra-links-disambiguator-mismatch.rs:36:14
+   |
+LL | /// Link to [derive@m]
+   |              ^^^^^^^^
+   |
+note: this item resolved to a macro, which did not match the disambiguator 'derive'
+  --> $DIR/intra-links-disambiguator-mismatch.rs:36:14
+   |
+LL | /// Link to [derive@m]
+   |              ^^^^^^^^
+
+error: unresolved link to `s`
+  --> $DIR/intra-links-disambiguator-mismatch.rs:40:14
+   |
+LL | /// Link to [const@s]
+   |              ^^^^^^^
+   |
+note: this item resolved to a static, which did not match the disambiguator 'const'
+  --> $DIR/intra-links-disambiguator-mismatch.rs:40:14
+   |
+LL | /// Link to [const@s]
+   |              ^^^^^^^
+
+error: unresolved link to `c`
+  --> $DIR/intra-links-disambiguator-mismatch.rs:44:14
+   |
+LL | /// Link to [static@c]
+   |              ^^^^^^^^
+   |
+note: this item resolved to a constant, which did not match the disambiguator 'static'
+  --> $DIR/intra-links-disambiguator-mismatch.rs:44:14
+   |
+LL | /// Link to [static@c]
+   |              ^^^^^^^^
+
+error: unresolved link to `c`
+  --> $DIR/intra-links-disambiguator-mismatch.rs:48:14
+   |
+LL | /// Link to [fn@c]
+   |              ^^^^
+   |
+note: this item resolved to a constant, which did not match the disambiguator 'fn'
+  --> $DIR/intra-links-disambiguator-mismatch.rs:48:14
+   |
+LL | /// Link to [fn@c]
+   |              ^^^^
+
+error: unresolved link to `c`
+  --> $DIR/intra-links-disambiguator-mismatch.rs:52:14
+   |
+LL | /// Link to [c()]
+   |              ^^^
+   |
+note: this item resolved to a constant, which did not match the disambiguator 'fn'
+  --> $DIR/intra-links-disambiguator-mismatch.rs:52:14
+   |
+LL | /// Link to [c()]
+   |              ^^^
+
+error: aborting due to 10 previous errors
+

--- a/src/test/rustdoc-ui/intra-links-disambiguator-mismatch.stderr
+++ b/src/test/rustdoc-ui/intra-links-disambiguator-mismatch.stderr
@@ -83,5 +83,13 @@ LL | /// Link to [c()]
    |
    = note: this link resolved to a constant, which is not a function
 
-error: aborting due to 10 previous errors
+error: incompatible link kind for `f`
+  --> $DIR/intra-links-disambiguator-mismatch.rs:64:14
+   |
+LL | /// Link to [const@f]
+   |              ^^^^^^^ help: to link to the function, use its disambiguator: `f()`
+   |
+   = note: this link resolved to a function, which is not a constant
+
+error: aborting due to 11 previous errors
 

--- a/src/test/rustdoc/intra-link-trait-item.rs
+++ b/src/test/rustdoc/intra-link-trait-item.rs
@@ -1,10 +1,10 @@
-// allow-tidy-line-length
+// ignore-tidy-linelength
 #![deny(broken_intra_doc_links)]
 
 /// Link to [S::assoc_fn()]
 /// Link to [Default::default()]
-// @has intra_link_trait_item/struct.S.html '//*[@href="https://doc.rust-lang.org/nightly/core/default/trait.Default.html#tymethod.default"]' 'Default::default()'
-// @has - '//*[@href="../intra_link_trait_item/struct.S.html#method.assoc_fn"]' 'S::assoc_fn()'
+// @has intra_link_trait_item/struct.S.html '//*[@href="../intra_link_trait_item/struct.S.html#method.assoc_fn"]' 'S::assoc_fn()'
+// @has - '//*[@href="https://doc.rust-lang.org/nightly/core/default/trait.Default.html#tymethod.default"]' 'Default::default()'
 pub struct S;
 
 impl S {

--- a/src/test/rustdoc/intra-link-trait-item.rs
+++ b/src/test/rustdoc/intra-link-trait-item.rs
@@ -1,0 +1,3 @@
+#![deny(broken_intra_doc_links_)]
+/// Link to [Default::default()]
+pub fn f() {}

--- a/src/test/rustdoc/intra-link-trait-item.rs
+++ b/src/test/rustdoc/intra-link-trait-item.rs
@@ -1,3 +1,12 @@
-#![deny(broken_intra_doc_links_)]
+// allow-tidy-line-length
+#![deny(broken_intra_doc_links)]
+
+/// Link to [S::assoc_fn()]
 /// Link to [Default::default()]
-pub fn f() {}
+// @has intra_link_trait_item/struct.S.html '//*[@href="https://doc.rust-lang.org/nightly/core/default/trait.Default.html#tymethod.default"]' 'Default::default()'
+// @has - '//*[@href="../intra_link_trait_item/struct.S.html#method.assoc_fn"]' 'S::assoc_fn()'
+pub struct S;
+
+impl S {
+    pub fn assoc_fn() {}
+}

--- a/src/test/ui/asm/bad-arch.rs
+++ b/src/test/ui/asm/bad-arch.rs
@@ -1,0 +1,18 @@
+// compile-flags: --target wasm32-unknown-unknown
+
+#![feature(no_core, lang_items, rustc_attrs)]
+#![no_core]
+
+#[rustc_builtin_macro]
+macro_rules! asm {
+    () => {};
+}
+#[lang = "sized"]
+trait Sized {}
+
+fn main() {
+    unsafe {
+        asm!("");
+        //~^ ERROR asm! is unsupported on this target
+    }
+}

--- a/src/test/ui/asm/bad-arch.stderr
+++ b/src/test/ui/asm/bad-arch.stderr
@@ -1,0 +1,8 @@
+error[E0472]: asm! is unsupported on this target
+  --> $DIR/bad-arch.rs:15:9
+   |
+LL |         asm!("");
+   |         ^^^^^^^^^
+
+error: aborting due to previous error
+

--- a/src/test/ui/btreemap/btreemap_into_iterator_lifetime.rs
+++ b/src/test/ui/btreemap/btreemap_into_iterator_lifetime.rs
@@ -1,0 +1,23 @@
+// check-pass
+
+use std::collections::{BTreeMap, HashMap};
+
+trait Map
+where
+    for<'a> &'a Self: IntoIterator<Item = (&'a Self::Key, &'a Self::Value)>,
+{
+    type Key;
+    type Value;
+}
+
+impl<K, V> Map for HashMap<K, V> {
+    type Key = K;
+    type Value = V;
+}
+
+impl<K, V> Map for BTreeMap<K, V> {
+  type Key = K;
+  type Value = V;
+}
+
+fn main() {}

--- a/src/test/ui/feature-gates/feature-gate-asm.rs
+++ b/src/test/ui/feature-gates/feature-gate-asm.rs
@@ -1,4 +1,4 @@
-// ignore-emscripten
+// only-x86_64
 
 fn main() {
     unsafe {

--- a/src/test/ui/feature-gates/feature-gate-asm2.rs
+++ b/src/test/ui/feature-gates/feature-gate-asm2.rs
@@ -1,4 +1,4 @@
-// ignore-emscripten
+// only-x86_64
 
 fn main() {
     unsafe {


### PR DESCRIPTION
Successful merges:

 - #74774 (adds [*mut|*const] ptr::set_ptr_value)
 - #75079 (Disallow linking to items with a mismatched disambiguator)
 - #75203 (Make `IntoIterator` lifetime bounds of `&BTreeMap` match with `&HashMap` )
 - #75227 (Fix ICE when using asm! on an unsupported architecture)

Failed merges:


r? @ghost