### PR TITLE
Add more examples to Path ends_with

### DIFF
--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -2109,14 +2109,14 @@ impl Path {
     /// ```
     /// use std::path::Path;
     ///
-    /// let path = Path::new("/etc/passwd");
+    /// let path = Path::new("/etc/resolv.conf");
     ///
-    /// assert!(path.ends_with("passwd"));
-    /// assert!(path.ends_with("etc/passwd"));
-    /// assert!(path.ends_with("/etc/passwd"));
+    /// assert!(path.ends_with("resolv.conf"));
+    /// assert!(path.ends_with("etc/resolv.conf"));
+    /// assert!(path.ends_with("/etc/resolv.conf"));
     ///
-    /// assert!(!path.ends_with("/passwd"));
-    /// assert!(!path.ends_with("wd")); // use .extension() instead
+    /// assert!(!path.ends_with("/resolv.conf"));
+    /// assert!(!path.ends_with("conf")); // use .extension() instead
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn ends_with<P: AsRef<Path>>(&self, child: P) -> bool {

--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -2112,6 +2112,11 @@ impl Path {
     /// let path = Path::new("/etc/passwd");
     ///
     /// assert!(path.ends_with("passwd"));
+    /// assert!(path.ends_with("etc/passwd"));
+    /// assert!(path.ends_with("/etc/passwd"));
+    ///
+    /// assert!(!path.ends_with("/passwd"));
+    /// assert!(!path.ends_with("wd")); // use .extension() instead
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn ends_with<P: AsRef<Path>>(&self, child: P) -> bool {


### PR DESCRIPTION
We faced a footgun when using ends_with to check extension,
showing an example could prevent that.

https://github.com/rust-dc/fish-manpage-completions/pull/106/commits/2c155e50b2d9e607174908b3f80f1dcf92693eee