### PR TITLE
Only add a border for the rust logo

### DIFF
--- a/src/librustdoc/html/layout.rs
+++ b/src/librustdoc/html/layout.rs
@@ -138,7 +138,7 @@ pub fn render<T: Print, S: Print>(
             if layout.logo.is_empty() {
                 format!(
                     "<a href='{path}index.html'>\
-                     <div class='logo-container'>\
+                     <div class='logo-container rust-logo'>\
                      <img src='{static_root_path}rust-logo{suffix}.png' alt='logo'></div></a>",
                     path = p,
                     static_root_path = static_root_path,

--- a/src/librustdoc/html/static/themes/ayu.css
+++ b/src/librustdoc/html/static/themes/ayu.css
@@ -62,8 +62,11 @@ pre {
 	background-color: #14191f;
 }
 
-.logo-container > img {
-	filter: drop-shadow(0 0 5px #fff);
+.logo-container.rust-logo > img {
+	filter: drop-shadow(1px 0 0px #fff)
+		drop-shadow(0 1px 0 #fff)
+		drop-shadow(-1px 0 0 #fff)
+		drop-shadow(0 -1px 0 #fff);
 }
 
 /* Improve the scrollbar display on firefox */

--- a/src/librustdoc/html/static/themes/dark.css
+++ b/src/librustdoc/html/static/themes/dark.css
@@ -34,8 +34,11 @@ pre {
 	background-color: #505050;
 }
 
-.logo-container > img {
-	filter: drop-shadow(0 0 5px #fff);
+.logo-container.rust-logo > img {
+	filter: drop-shadow(1px 0 0px #fff)
+		drop-shadow(0 1px 0 #fff)
+		drop-shadow(-1px 0 0 #fff)
+		drop-shadow(0 -1px 0 #fff)
 }
 
 /* Improve the scrollbar display on firefox */

--- a/src/librustdoc/html/static/themes/light.css
+++ b/src/librustdoc/html/static/themes/light.css
@@ -45,8 +45,8 @@ pre {
 	scrollbar-color: rgba(36, 37, 39, 0.6) #d9d9d9;
 }
 
-.logo-container > img {
-	filter: drop-shadow(0 0 5px #aaa);
+.logo-container.rust-logo > img {
+	/* No need for a border in here! */
 }
 
 /* Improve the scrollbar display on webkit-based browsers */


### PR DESCRIPTION
![Screenshot from 2020-08-07 11-22-51](https://user-images.githubusercontent.com/3050060/89631113-9dadc700-d8a0-11ea-8063-ad40207decaa.png)
![Screenshot from 2020-08-07 11-19-47](https://user-images.githubusercontent.com/3050060/89631114-9e465d80-d8a0-11ea-96ba-1d6926c8e7a9.png)
![Screenshot from 2020-08-07 11-19-41](https://user-images.githubusercontent.com/3050060/89631117-9edef400-d8a0-11ea-9c66-0df3d8c1ac2d.png)

I didn't add a border for the light theme though, as I felt it as unnecessary.

r? @Manishearth 