### PR TITLE
BTreeMap: better way to postpone root access in DrainFilter

### DIFF
--- a/library/alloc/src/collections/btree/node.rs
+++ b/library/alloc/src/collections/btree/node.rs
@@ -1083,12 +1083,12 @@ impl<'a, K, V> Handle<NodeRef<marker::Mut<'a>, K, V, marker::Leaf>, marker::KV> 
     /// between the now adjacent key/value pairs (if any) to the left and right of this handle.
     pub fn remove(
         mut self,
-    ) -> (Handle<NodeRef<marker::Mut<'a>, K, V, marker::Leaf>, marker::Edge>, K, V) {
+    ) -> ((K, V), Handle<NodeRef<marker::Mut<'a>, K, V, marker::Leaf>, marker::Edge>) {
         unsafe {
             let k = slice_remove(self.node.keys_mut(), self.idx);
             let v = slice_remove(self.node.vals_mut(), self.idx);
             (*self.node.as_leaf_mut()).len -= 1;
-            (self.left_edge(), k, v)
+            ((k, v), self.left_edge())
         }
     }
 }


### PR DESCRIPTION
A slightly more elegant (in my opinion) adaptation of #74762. Benchmarks seem irrationally pleased to:
```
benchcmp old new --threshold 5
 name                                           old ns/iter  new ns/iter  diff ns/iter   diff %  speedup
 btree::map::clone_fat_100_and_remove_all       215,182      185,052           -30,130  -14.00%   x 1.16
 btree::map::clone_fat_100_and_remove_half      139,667      127,945           -11,722   -8.39%   x 1.09
 btree::map::clone_fat_val_100_and_remove_all   96,755       81,279            -15,476  -16.00%   x 1.19
 btree::map::clone_fat_val_100_and_remove_half  64,678       56,911             -7,767  -12.01%   x 1.14
 btree::map::find_rand_100                      18           17                     -1   -5.56%   x 1.06
 btree::map::first_and_last_0                   33           35                      2    6.06%   x 0.94
 btree::map::first_and_last_100                 40           54                     14   35.00%   x 0.74
 btree::map::insert_rand_100                    45           42                     -3   -6.67%   x 1.07
 btree::map::insert_rand_10_000                 45           41                     -4   -8.89%   x 1.10
 btree::map::iter_0                             2,010        1,759                -251  -12.49%   x 1.14
 btree::map::iter_100                           3,514        2,764                -750  -21.34%   x 1.27
 btree::map::iter_10k                           4,018        3,768                -250   -6.22%   x 1.07
 btree::map::range_unbounded_unbounded          37,269       28,929             -8,340  -22.38%   x 1.29
 btree::map::range_unbounded_vs_iter            31,518       28,814             -2,704   -8.58%   x 1.09
```

r? @Mark-Simulacrum 