### PR TITLE
Add `str::{Split,RSplit,SplitN,RSplitN,SplitTerminator,RSplitTerminator,SplitInclusive}::as_str` methods

### DIFF
--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -125,6 +125,7 @@
 #![feature(staged_api)]
 #![feature(std_internals)]
 #![feature(stmt_expr_attributes)]
+#![feature(str_split_as_str)]
 #![feature(transparent_unions)]
 #![feature(unboxed_closures)]
 #![feature(unsized_locals)]

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -126,6 +126,7 @@
 #![feature(std_internals)]
 #![feature(stmt_expr_attributes)]
 #![feature(str_split_as_str)]
+#![feature(str_split_inclusive_as_str)]
 #![feature(transparent_unions)]
 #![feature(unboxed_closures)]
 #![feature(unsized_locals)]

--- a/library/core/src/str/iter.rs
+++ b/library/core/src/str/iter.rs
@@ -690,6 +690,19 @@ impl<'a, P: Pattern<'a>> SplitInternal<'a, P> {
             },
         }
     }
+
+    #[inline]
+    fn as_str(&self) -> &'a str {
+        // `Self::get_end` doesn't change `self.start`
+        if self.finished {
+            return "";
+        }
+
+        // SAFETY: `self.start` and `self.end` always lie on unicode boundaries.
+        unsafe {
+            self.matcher.haystack().get_unchecked(self.start..self.end)
+        }
+    }
 }
 
 generate_pattern_iterators! {
@@ -708,6 +721,48 @@ generate_pattern_iterators! {
     internal:
         SplitInternal yielding (&'a str);
     delegate double ended;
+}
+
+impl<'a, P: Pattern<'a>> Split<'a, P> {
+    /// Returns remainder of the splitted string
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(str_split_as_str)]
+    /// let mut split = "Mary had a little lamb".split(' ');
+    /// assert_eq!(split.as_str(), "Mary had a little lamb");
+    /// split.next();
+    /// assert_eq!(split.as_str(), "had a little lamb");
+    /// split.by_ref().for_each(drop);
+    /// assert_eq!(split.as_str(), "");
+    /// ```
+    #[inline]
+    #[unstable(feature = "str_split_as_str", issue = "none")]
+    pub fn as_str(&self) -> &'a str {
+        self.0.as_str()
+    }
+}
+
+impl<'a, P: Pattern<'a>> RSplit<'a, P> {
+    /// Returns remainder of the splitted string
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(str_split_as_str)]
+    /// let mut split = "Mary had a little lamb".rsplit(' ');
+    /// assert_eq!(split.as_str(), "Mary had a little lamb");
+    /// split.next();
+    /// assert_eq!(split.as_str(), "Mary had a little");
+    /// split.by_ref().for_each(drop);
+    /// assert_eq!(split.as_str(), "");
+    /// ```
+    #[inline]
+    #[unstable(feature = "str_split_as_str", issue = "none")]
+    pub fn as_str(&self) -> &'a str {
+        self.0.as_str()
+    }
 }
 
 generate_pattern_iterators! {

--- a/library/core/src/str/iter.rs
+++ b/library/core/src/str/iter.rs
@@ -736,7 +736,7 @@ impl<'a, P: Pattern<'a>> Split<'a, P> {
     /// assert_eq!(split.as_str(), "");
     /// ```
     #[inline]
-    #[unstable(feature = "str_split_as_str", issue = "none")]
+    #[unstable(feature = "str_split_as_str", issue = "77998")]
     pub fn as_str(&self) -> &'a str {
         self.0.as_str()
     }
@@ -757,7 +757,7 @@ impl<'a, P: Pattern<'a>> RSplit<'a, P> {
     /// assert_eq!(split.as_str(), "");
     /// ```
     #[inline]
-    #[unstable(feature = "str_split_as_str", issue = "none")]
+    #[unstable(feature = "str_split_as_str", issue = "77998")]
     pub fn as_str(&self) -> &'a str {
         self.0.as_str()
     }
@@ -796,7 +796,7 @@ impl<'a, P: Pattern<'a>> SplitTerminator<'a, P> {
     /// assert_eq!(split.as_str(), "");
     /// ```
     #[inline]
-    #[unstable(feature = "str_split_as_str", issue = "none")]
+    #[unstable(feature = "str_split_as_str", issue = "77998")]
     pub fn as_str(&self) -> &'a str {
         self.0.as_str()
     }
@@ -817,7 +817,7 @@ impl<'a, P: Pattern<'a>> RSplitTerminator<'a, P> {
     /// assert_eq!(split.as_str(), "");
     /// ```
     #[inline]
-    #[unstable(feature = "str_split_as_str", issue = "none")]
+    #[unstable(feature = "str_split_as_str", issue = "77998")]
     pub fn as_str(&self) -> &'a str {
         self.0.as_str()
     }
@@ -919,7 +919,7 @@ impl<'a, P: Pattern<'a>> SplitN<'a, P> {
     /// assert_eq!(split.as_str(), "");
     /// ```
     #[inline]
-    #[unstable(feature = "str_split_as_str", issue = "none")]
+    #[unstable(feature = "str_split_as_str", issue = "77998")]
     pub fn as_str(&self) -> &'a str {
         self.0.as_str()
     }
@@ -940,7 +940,7 @@ impl<'a, P: Pattern<'a>> RSplitN<'a, P> {
     /// assert_eq!(split.as_str(), "");
     /// ```
     #[inline]
-    #[unstable(feature = "str_split_as_str", issue = "none")]
+    #[unstable(feature = "str_split_as_str", issue = "77998")]
     pub fn as_str(&self) -> &'a str {
         self.0.as_str()
     }
@@ -1292,7 +1292,7 @@ impl<'a, P: Pattern<'a>> SplitInclusive<'a, P> {
     /// assert_eq!(split.as_str(), "");
     /// ```
     #[inline]
-    #[unstable(feature = "str_split_inclusive_as_str", issue = "none")]
+    #[unstable(feature = "str_split_inclusive_as_str", issue = "77998")]
     pub fn as_str(&self) -> &'a str {
         self.0.as_str()
     }

--- a/library/core/src/str/iter.rs
+++ b/library/core/src/str/iter.rs
@@ -699,9 +699,7 @@ impl<'a, P: Pattern<'a>> SplitInternal<'a, P> {
         }
 
         // SAFETY: `self.start` and `self.end` always lie on unicode boundaries.
-        unsafe {
-            self.matcher.haystack().get_unchecked(self.start..self.end)
-        }
+        unsafe { self.matcher.haystack().get_unchecked(self.start..self.end) }
     }
 }
 
@@ -1277,6 +1275,28 @@ impl<'a, P: Pattern<'a, Searcher: ReverseSearcher<'a>>> DoubleEndedIterator
 
 #[unstable(feature = "split_inclusive", issue = "72360")]
 impl<'a, P: Pattern<'a>> FusedIterator for SplitInclusive<'a, P> {}
+
+impl<'a, P: Pattern<'a>> SplitInclusive<'a, P> {
+    /// Returns remainder of the splitted string
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(str_split_inclusive_as_str)]
+    /// #![feature(split_inclusive)]
+    /// let mut split = "Mary had a little lamb".split_inclusive(' ');
+    /// assert_eq!(split.as_str(), "Mary had a little lamb");
+    /// split.next();
+    /// assert_eq!(split.as_str(), "had a little lamb");
+    /// split.by_ref().for_each(drop);
+    /// assert_eq!(split.as_str(), "");
+    /// ```
+    #[inline]
+    #[unstable(feature = "str_split_inclusive_as_str", issue = "none")]
+    pub fn as_str(&self) -> &'a str {
+        self.0.as_str()
+    }
+}
 
 /// An iterator of [`u16`] over the string encoded as UTF-16.
 ///

--- a/library/core/src/str/iter.rs
+++ b/library/core/src/str/iter.rs
@@ -783,6 +783,48 @@ generate_pattern_iterators! {
     delegate double ended;
 }
 
+impl<'a, P: Pattern<'a>> SplitTerminator<'a, P> {
+    /// Returns remainder of the splitted string
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(str_split_as_str)]
+    /// let mut split = "A..B..".split_terminator('.');
+    /// assert_eq!(split.as_str(), "A..B..");
+    /// split.next();
+    /// assert_eq!(split.as_str(), ".B..");
+    /// split.by_ref().for_each(drop);
+    /// assert_eq!(split.as_str(), "");
+    /// ```
+    #[inline]
+    #[unstable(feature = "str_split_as_str", issue = "none")]
+    pub fn as_str(&self) -> &'a str {
+        self.0.as_str()
+    }
+}
+
+impl<'a, P: Pattern<'a>> RSplitTerminator<'a, P> {
+    /// Returns remainder of the splitted string
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(str_split_as_str)]
+    /// let mut split = "A..B..".rsplit_terminator('.');
+    /// assert_eq!(split.as_str(), "A..B..");
+    /// split.next();
+    /// assert_eq!(split.as_str(), "A..B");
+    /// split.by_ref().for_each(drop);
+    /// assert_eq!(split.as_str(), "");
+    /// ```
+    #[inline]
+    #[unstable(feature = "str_split_as_str", issue = "none")]
+    pub fn as_str(&self) -> &'a str {
+        self.0.as_str()
+    }
+}
+
 derive_pattern_clone! {
     clone SplitNInternal
     with |s| SplitNInternal { iter: s.iter.clone(), ..*s }
@@ -839,6 +881,11 @@ impl<'a, P: Pattern<'a>> SplitNInternal<'a, P> {
             }
         }
     }
+
+    #[inline]
+    fn as_str(&self) -> &'a str {
+        self.iter.as_str()
+    }
 }
 
 generate_pattern_iterators! {
@@ -857,6 +904,48 @@ generate_pattern_iterators! {
     internal:
         SplitNInternal yielding (&'a str);
     delegate single ended;
+}
+
+impl<'a, P: Pattern<'a>> SplitN<'a, P> {
+    /// Returns remainder of the splitted string
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(str_split_as_str)]
+    /// let mut split = "Mary had a little lamb".splitn(3, ' ');
+    /// assert_eq!(split.as_str(), "Mary had a little lamb");
+    /// split.next();
+    /// assert_eq!(split.as_str(), "had a little lamb");
+    /// split.by_ref().for_each(drop);
+    /// assert_eq!(split.as_str(), "");
+    /// ```
+    #[inline]
+    #[unstable(feature = "str_split_as_str", issue = "none")]
+    pub fn as_str(&self) -> &'a str {
+        self.0.as_str()
+    }
+}
+
+impl<'a, P: Pattern<'a>> RSplitN<'a, P> {
+    /// Returns remainder of the splitted string
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(str_split_as_str)]
+    /// let mut split = "Mary had a little lamb".rsplitn(3, ' ');
+    /// assert_eq!(split.as_str(), "Mary had a little lamb");
+    /// split.next();
+    /// assert_eq!(split.as_str(), "Mary had a little");
+    /// split.by_ref().for_each(drop);
+    /// assert_eq!(split.as_str(), "");
+    /// ```
+    #[inline]
+    #[unstable(feature = "str_split_as_str", issue = "none")]
+    pub fn as_str(&self) -> &'a str {
+        self.0.as_str()
+    }
 }
 
 derive_pattern_clone! {


### PR DESCRIPTION
tl;dr this allows viewing unyelded part of str-split-iterators, like so:
```rust
let mut split = "Mary had a little lamb".split(' '); 
assert_eq!(split.as_str(), "Mary had a little lamb");
split.next();
assert_eq!(split.as_str(), "had a little lamb");
split.by_ref().for_each(drop);
assert_eq!(split.as_str(), "");
```

--------------

This PR adds semi-identical `as_str` methods to most str-split-iterators with signatures like `&'_ Split<'a, P: Pattern<'a>> -> &'a str` (Note: output `&str` lifetime is bound to the `'a`, not the `'_`). The methods are similar to [`Chars::as_str`]

`SplitInclusive::as_str` is under `"str_split_inclusive_as_str"` feature gate, all other methods are under `"str_split_as_str"` feature gate.

Before this PR you had to sum `len`s of all yielded parts or collect into `String` to emulate `as_str`.

[`Chars::as_str`]: https://doc.rust-lang.org/core/str/struct.Chars.html#method.as_str