### PR TITLE
Add back unwinding support for Sony PSP

### DIFF
--- a/library/panic_unwind/src/lib.rs
+++ b/library/panic_unwind/src/lib.rs
@@ -50,6 +50,7 @@ cfg_if::cfg_if! {
     } else if #[cfg(any(
         all(target_family = "windows", target_env = "gnu"),
         target_os = "cloudabi",
+        target_os = "psp",
         target_family = "unix",
         all(target_vendor = "fortanix", target_env = "sgx"),
     ))] {
@@ -65,7 +66,6 @@ cfg_if::cfg_if! {
         // - os=uefi
         // - nvptx64-nvidia-cuda
         // - avr-unknown-unknown
-        // - mipsel-sony-psp
         #[path = "dummy.rs"]
         mod real_imp;
     }

--- a/library/unwind/src/lib.rs
+++ b/library/unwind/src/lib.rs
@@ -19,6 +19,7 @@ cfg_if::cfg_if! {
     } else if #[cfg(any(
         unix,
         windows,
+        target_os = "psp",
         target_os = "cloudabi",
         all(target_vendor = "fortanix", target_env = "sgx"),
     ))] {
@@ -32,7 +33,6 @@ cfg_if::cfg_if! {
         // - os=uefi
         // - os=cuda
         // - nvptx64-nvidia-cuda
-        // - mipsel-sony-psp
         // - Any new targets not listed above.
     }
 }


### PR DESCRIPTION
This PR adds back unwinding support for the Sony PSP. The `mipsel-sony-psp` target works well with unwinding. In [rust-psp], we use the `panic_unwind` crate along with LLVM's libunwind to catch panics, run destructors, and print them to the debug screen without aborting all threads.

[rust-psp]: https://github.com/overdrivenpotato/rust-psp