### PR TITLE
do not call black_box on Miri

### DIFF
--- a/library/core/src/hint.rs
+++ b/library/core/src/hint.rs
@@ -119,9 +119,11 @@ pub fn black_box<T>(dummy: T) -> T {
     // box. This isn't the greatest implementation since it probably deoptimizes
     // more than we want, but it's so far good enough.
 
+    #[cfg(not(miri))] // This is just a hint, so it is fine to skip in Miri.
     // SAFETY: the inline assembly is a no-op.
     unsafe {
         llvm_asm!("" : : "r"(&dummy));
-        dummy
     }
+
+    dummy
 }


### PR DESCRIPTION
Helps with https://github.com/rust-lang/rust/issues/75274 (but https://github.com/rust-lang/rust/pull/74932 introduced unrelated breakage that will need a separate fix)
Cc @eggyal r? @Mark-Simulacrum 