### PR TITLE
Clean up E0502

### DIFF
--- a/src/librustc_error_codes/error_codes/E0502.md
+++ b/src/librustc_error_codes/error_codes/E0502.md
@@ -5,7 +5,7 @@ Erroneous code example:
 ```compile_fail,E0502
 fn bar(x: &mut i32) {}
 fn foo(a: &mut i32) {
-    let ref y = a; // a is borrowed as immutable.
+    let y = &a; // a is borrowed as immutable.
     bar(a); // error: cannot borrow `*a` as mutable because `a` is also borrowed
             //        as immutable
     println!("{}", y);
@@ -19,7 +19,7 @@ variable before trying to access it mutably:
 fn bar(x: &mut i32) {}
 fn foo(a: &mut i32) {
     bar(a);
-    let ref y = a; // ok!
+    let y = &a; // ok!
     println!("{}", y);
 }
 ```


### PR DESCRIPTION
`ref` on an entire `let` pattern is discouraged, take a reference with `&` instead.