### PR TITLE
Add the convenience method `Option::is_some_and`

### DIFF
--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -207,6 +207,35 @@ impl<T> Option<T> {
         !self.is_some()
     }
 
+    /// Returns `true` if the option is a [`Some`] and the given predicate
+    /// returns `true` for the contained value.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(option_is_some_and)]
+    ///
+    /// let x: Option<u32> = Some(2);
+    /// assert_eq!(x.is_some_and(|&n| n == 9), false);
+    /// assert_eq!(x.is_some_and(|&n| n < 5), true);
+    ///
+    /// let x: Option<u32> = None;
+    /// assert_eq!(x.is_some_and(|&n| n == 9), false);
+    /// assert_eq!(x.is_some_and(|&n| n < 5), false);
+    /// ```
+    #[must_use]
+    #[inline]
+    #[unstable(feature = "option_is_some_and", issue = "none")]
+    pub fn is_some_and<P>(&self, predicate: P) -> bool
+    where
+        P: FnOnce(&T) -> bool,
+    {
+        match self {
+            Some(x) => predicate(x),
+            None => false,
+        }
+    }
+
     /// Returns `true` if the option is a [`Some`] value containing the given value.
     ///
     /// # Examples


### PR DESCRIPTION
Adds:

```rust
impl Option<T> {
    fn is_some_and<P>(&self, predicate: P) -> bool
    where
        P: FnOnce(&T) -> bool;
}
```

I recently got the idea for this method. It solves a "pain point" (albeit a small one) I encountered many times over the years: checking if an `Option` is `Some(x)` and if a condition holds for `x`. Currently possible solutions:

- Verbose:
  ```rust
  if let Some(s) = opt {
      if s.is_ascii() {
          // body
      }
  }
  ```
  
  ```rust
  match opt {
      Some(s) if s.is_ascii() => {
          // body
      }
      _ => {}
  }
  ```
- Concise, but the `unwrap` is not nice :/
  ```rust
  if opt.is_some() && opt.unwrap().is_ascii() {
      // body
  }
  ```

- Somewhat concise, but not easy to read. At least I have to actively think about it for a few seconds before I know what exactly it does.
  ```rust
  if opt.map(|s| s.is_ascii()).unwrap_or(false) {
      // body
  }
  ```

- Concise and probably the best solution currently. However, uses a macro and the "reading flow" is not optimal (due to the two `if`s).
  ```rust
  if matches!(opt, Some(s) if s.is_ascii()) {
      // body
  }
  ```

With the new method, it would look like this:

```rust
if opt.is_some_and(|s| s.is_ascii()) {
    // body
}
```

I think this is a bit better than the `matches!` version. *However*, I understand there are a bunch of reasons not to add this method:

- `Option` already has lots of helper methods and expanding the API surface has some disadvantages. If the advantage over the `matches!` solution is too small, adding `is_some_and` might not be worth it.
- Sometimes, people might want the opposite: `true` in the `None` case. If that use case is equally as common (it is not in *my* experience), there should be a method for that, too. Something like `is_none_or`. But adding two methods is even worse than one, so it might not be worth it.
- `and` in the name might be confusing because of its use in `Option::and` and `Option::and_then`.

So I can totally understand if we decide against this addition. Just wanted to hear people's opinion on this :)

<sub>I tried searching for previous attempts to add such a method, but didn't find anything. If I missed something, please let me know.</sub>