### PR TITLE
Be consistent when describing a move as a 'partial' in diagnostics

### DIFF
--- a/src/librustc_mir/borrow_check/diagnostics/mod.rs
+++ b/src/librustc_mir/borrow_check/diagnostics/mod.rs
@@ -412,10 +412,11 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
         place_desc: &str,
         ty: Ty<'tcx>,
         span: Option<Span>,
+        move_prefix: &str,
     ) {
         let message = format!(
-            "move occurs because {} has type `{}`, which does not implement the `Copy` trait",
-            place_desc, ty,
+            "{}move occurs because {} has type `{}`, which does not implement the `Copy` trait",
+            move_prefix, place_desc, ty,
         );
         if let Some(span) = span {
             err.span_label(span, message);

--- a/src/librustc_mir/borrow_check/diagnostics/move_errors.rs
+++ b/src/librustc_mir/borrow_check/diagnostics/move_errors.rs
@@ -445,7 +445,13 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
                         None => "value".to_string(),
                     };
 
-                    self.note_type_does_not_implement_copy(err, &place_desc, place_ty, Some(span));
+                    self.note_type_does_not_implement_copy(
+                        err,
+                        &place_desc,
+                        place_ty,
+                        Some(span),
+                        "",
+                    );
                 } else {
                     binds_to.sort();
                     binds_to.dedup();
@@ -467,7 +473,7 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
                     Some(desc) => format!("`{}`", desc),
                     None => "value".to_string(),
                 };
-                self.note_type_does_not_implement_copy(err, &place_desc, place_ty, Some(span));
+                self.note_type_does_not_implement_copy(err, &place_desc, place_ty, Some(span), "");
 
                 use_spans.args_span_label(err, format!("move out of {} occurs here", place_desc));
                 use_spans
@@ -529,6 +535,7 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
                     &format!("`{}`", self.local_names[*local].unwrap()),
                     bind_to.ty,
                     Some(binding_span),
+                    "",
                 );
             }
         }

--- a/src/test/ui/async-await/issues/issue-66958-non-copy-infered-type-arg.rs
+++ b/src/test/ui/async-await/issues/issue-66958-non-copy-infered-type-arg.rs
@@ -8,7 +8,7 @@ impl<S> Ia<S> {
 
     async fn crash(self) {
         Self::partial(self.0);
-        Self::full(self); //~ ERROR use of moved value: `self`
+        Self::full(self); //~ ERROR use of partially moved value: `self`
     }
 }
 

--- a/src/test/ui/async-await/issues/issue-66958-non-copy-infered-type-arg.stderr
+++ b/src/test/ui/async-await/issues/issue-66958-non-copy-infered-type-arg.stderr
@@ -1,12 +1,12 @@
-error[E0382]: use of moved value: `self`
+error[E0382]: use of partially moved value: `self`
   --> $DIR/issue-66958-non-copy-infered-type-arg.rs:11:20
    |
 LL |         Self::partial(self.0);
-   |                       ------ value moved here
+   |                       ------ value partially moved here
 LL |         Self::full(self);
    |                    ^^^^ value used here after partial move
    |
-   = note: move occurs because `self.0` has type `S`, which does not implement the `Copy` trait
+   = note: partial move occurs because `self.0` has type `S`, which does not implement the `Copy` trait
 
 error: aborting due to previous error
 

--- a/src/test/ui/binding/issue-53114-borrow-checks.stderr
+++ b/src/test/ui/binding/issue-53114-borrow-checks.stderr
@@ -8,26 +8,26 @@ LL |     drop(m);
 LL |     match m { _ => { } } // #53114: should eventually be accepted too
    |           ^ value used here after move
 
-error[E0382]: use of moved value: `mm`
+error[E0382]: use of partially moved value: `mm`
   --> $DIR/issue-53114-borrow-checks.rs:27:11
    |
 LL |     match mm { (_x, _) => { } }
-   |                 -- value moved here
+   |                 -- value partially moved here
 LL |     match mm { (_, _y) => { } }
    |           ^^ value used here after partial move
    |
-   = note: move occurs because `mm.0` has type `M`, which does not implement the `Copy` trait
+   = note: partial move occurs because `mm.0` has type `M`, which does not implement the `Copy` trait
 
-error[E0382]: use of moved value: `mm`
+error[E0382]: use of partially moved value: `mm`
   --> $DIR/issue-53114-borrow-checks.rs:29:11
    |
 LL |     match mm { (_, _y) => { } }
-   |                    -- value moved here
+   |                    -- value partially moved here
 LL |
 LL |     match mm { (_, _) => { } }
    |           ^^ value used here after partial move
    |
-   = note: move occurs because `mm.1` has type `M`, which does not implement the `Copy` trait
+   = note: partial move occurs because `mm.1` has type `M`, which does not implement the `Copy` trait
 
 error[E0382]: use of moved value: `m`
   --> $DIR/issue-53114-borrow-checks.rs:36:16
@@ -39,26 +39,26 @@ LL |     drop(m);
 LL |     if let _ = m { } // #53114: should eventually be accepted too
    |                ^ value used here after move
 
-error[E0382]: use of moved value: `mm`
+error[E0382]: use of partially moved value: `mm`
   --> $DIR/issue-53114-borrow-checks.rs:41:22
    |
 LL |     if let (_x, _) = mm { }
-   |             -- value moved here
+   |             -- value partially moved here
 LL |     if let (_, _y) = mm { }
    |                      ^^ value used here after partial move
    |
-   = note: move occurs because `mm.0` has type `M`, which does not implement the `Copy` trait
+   = note: partial move occurs because `mm.0` has type `M`, which does not implement the `Copy` trait
 
-error[E0382]: use of moved value: `mm`
+error[E0382]: use of partially moved value: `mm`
   --> $DIR/issue-53114-borrow-checks.rs:43:21
    |
 LL |     if let (_, _y) = mm { }
-   |                -- value moved here
+   |                -- value partially moved here
 LL |
 LL |     if let (_, _) = mm { }
    |                     ^^ value used here after partial move
    |
-   = note: move occurs because `mm.1` has type `M`, which does not implement the `Copy` trait
+   = note: partial move occurs because `mm.1` has type `M`, which does not implement the `Copy` trait
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/borrowck/borrowck-move-out-from-array-match.rs
+++ b/src/test/ui/borrowck/borrowck-move-out-from-array-match.rs
@@ -20,7 +20,7 @@ fn move_out_from_begin_field_and_end() {
         [_, _, (_x, _)] => {}
     }
     match a {
-        [.., _y] => {} //~ ERROR use of moved value
+        [.., _y] => {} //~ ERROR use of partially moved value
     }
 }
 
@@ -42,7 +42,7 @@ fn move_out_by_const_index_and_subslice() {
         [_x, _, _] => {}
     }
     match a {
-        //~^ ERROR use of moved value
+        //~^ ERROR use of partially moved value
         [_y @ .., _, _] => {}
     }
 }
@@ -53,7 +53,7 @@ fn move_out_by_const_index_end_and_subslice() {
         [.., _x] => {}
     }
     match a {
-        //~^ ERROR use of moved value
+        //~^ ERROR use of partially moved value
         [_, _, _y @ ..] => {}
     }
 }
@@ -64,7 +64,7 @@ fn move_out_by_const_index_field_and_subslice() {
         [(_x, _), _, _] => {}
     }
     match a {
-        //~^ ERROR use of moved value
+        //~^ ERROR use of partially moved value
         [_y @ .., _, _] => {}
     }
 }
@@ -75,7 +75,7 @@ fn move_out_by_const_index_end_field_and_subslice() {
         [.., (_x, _)] => {}
     }
     match a {
-        //~^ ERROR use of moved value
+        //~^ ERROR use of partially moved value
         [_, _, _y @ ..] => {}
     }
 }
@@ -108,7 +108,7 @@ fn move_out_by_subslice_and_subslice() {
         [x @ .., _] => {}
     }
     match a {
-        //~^ ERROR use of moved value
+        //~^ ERROR use of partially moved value
         [_, _y @ ..] => {}
     }
 }

--- a/src/test/ui/borrowck/borrowck-move-out-from-array-match.stderr
+++ b/src/test/ui/borrowck/borrowck-move-out-from-array-match.stderr
@@ -9,16 +9,16 @@ LL |         [.., _y] => {}
    |
    = note: move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
 
-error[E0382]: use of moved value: `a[..]`
+error[E0382]: use of partially moved value: `a[..]`
   --> $DIR/borrowck-move-out-from-array-match.rs:23:14
    |
 LL |         [_, _, (_x, _)] => {}
-   |                 -- value moved here
+   |                 -- value partially moved here
 ...
 LL |         [.., _y] => {}
    |              ^^ value used here after partial move
    |
-   = note: move occurs because `a[..].0` has type `std::string::String`, which does not implement the `Copy` trait
+   = note: partial move occurs because `a[..].0` has type `std::string::String`, which does not implement the `Copy` trait
 
 error[E0382]: use of moved value: `a[..].0`
   --> $DIR/borrowck-move-out-from-array-match.rs:33:15
@@ -31,49 +31,49 @@ LL |         [.., (_y, _)] => {}
    |
    = note: move occurs because `a[..].0` has type `std::string::String`, which does not implement the `Copy` trait
 
-error[E0382]: use of moved value: `a`
+error[E0382]: use of partially moved value: `a`
   --> $DIR/borrowck-move-out-from-array-match.rs:44:11
    |
 LL |         [_x, _, _] => {}
-   |          -- value moved here
+   |          -- value partially moved here
 LL |     }
 LL |     match a {
    |           ^ value used here after partial move
    |
-   = note: move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
+   = note: partial move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
 
-error[E0382]: use of moved value: `a`
+error[E0382]: use of partially moved value: `a`
   --> $DIR/borrowck-move-out-from-array-match.rs:55:11
    |
 LL |         [.., _x] => {}
-   |              -- value moved here
+   |              -- value partially moved here
 LL |     }
 LL |     match a {
    |           ^ value used here after partial move
    |
-   = note: move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
+   = note: partial move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
 
-error[E0382]: use of moved value: `a`
+error[E0382]: use of partially moved value: `a`
   --> $DIR/borrowck-move-out-from-array-match.rs:66:11
    |
 LL |         [(_x, _), _, _] => {}
-   |           -- value moved here
+   |           -- value partially moved here
 LL |     }
 LL |     match a {
    |           ^ value used here after partial move
    |
-   = note: move occurs because `a[..].0` has type `std::string::String`, which does not implement the `Copy` trait
+   = note: partial move occurs because `a[..].0` has type `std::string::String`, which does not implement the `Copy` trait
 
-error[E0382]: use of moved value: `a`
+error[E0382]: use of partially moved value: `a`
   --> $DIR/borrowck-move-out-from-array-match.rs:77:11
    |
 LL |         [.., (_x, _)] => {}
-   |               -- value moved here
+   |               -- value partially moved here
 LL |     }
 LL |     match a {
    |           ^ value used here after partial move
    |
-   = note: move occurs because `a[..].0` has type `std::string::String`, which does not implement the `Copy` trait
+   = note: partial move occurs because `a[..].0` has type `std::string::String`, which does not implement the `Copy` trait
 
 error[E0382]: use of moved value: `a[..].0`
   --> $DIR/borrowck-move-out-from-array-match.rs:89:11
@@ -97,16 +97,16 @@ LL |         [.., (_x, _)] => {}
    |
    = note: move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
 
-error[E0382]: use of moved value: `a`
+error[E0382]: use of partially moved value: `a`
   --> $DIR/borrowck-move-out-from-array-match.rs:110:11
    |
 LL |         [x @ .., _] => {}
-   |          ------ value moved here
+   |          ------ value partially moved here
 LL |     }
 LL |     match a {
    |           ^ value used here after partial move
    |
-   = note: move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
+   = note: partial move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
 
 error: aborting due to 10 previous errors
 

--- a/src/test/ui/borrowck/borrowck-move-out-from-array-no-overlap-match.rs
+++ b/src/test/ui/borrowck/borrowck-move-out-from-array-no-overlap-match.rs
@@ -15,7 +15,7 @@ fn move_out_from_begin_and_one_from_end() {
         [_, _, _x] => {}
     }
     match a {
-        //~^ ERROR use of moved value
+        //~^ ERROR use of partially moved value
         [.., _y, _] => {}
     }
 }
@@ -26,7 +26,7 @@ fn move_out_from_begin_field_and_end_field() {
         [_, _, (_x, _)] => {}
     }
     match a {
-        //~^ ERROR use of moved value
+        //~^ ERROR use of partially moved value
         [.., (_, _y)] => {}
     }
 }
@@ -39,7 +39,7 @@ fn move_out_by_const_index_and_subslice() {
         [_x, _, _] => {}
     }
     match a {
-        //~^ ERROR use of moved value
+        //~^ ERROR use of partially moved value
         [_, _y @ ..] => {}
     }
 }
@@ -50,7 +50,7 @@ fn move_out_by_const_index_end_and_subslice() {
         [.., _x] => {}
     }
     match a {
-        //~^ ERROR use of moved value
+        //~^ ERROR use of partially moved value
         [_y @ .., _] => {}
     }
 }
@@ -61,7 +61,7 @@ fn move_out_by_const_index_field_and_subslice() {
         [(_x, _), _, _] => {}
     }
     match a {
-        //~^ ERROR use of moved value
+        //~^ ERROR use of partially moved value
         [_, _y @ ..] => {}
     }
 }
@@ -72,7 +72,7 @@ fn move_out_by_const_index_end_field_and_subslice() {
         [.., (_x, _)] => {}
     }
     match a {
-        //~^ ERROR use of moved value
+        //~^ ERROR use of partially moved value
         [_y @ .., _] => {}
     }
 }
@@ -83,7 +83,7 @@ fn move_out_by_const_subslice_and_index_field() {
         [_, _y @ ..] => {}
     }
     match a {
-        //~^ ERROR use of moved value
+        //~^ ERROR use of partially moved value
         [(_x, _), _, _] => {}
     }
 }
@@ -94,7 +94,7 @@ fn move_out_by_const_subslice_and_end_index_field() {
         [_y @ .., _] => {}
     }
     match a {
-        //~^ ERROR use of moved value
+        //~^ ERROR use of partially moved value
         [.., (_x, _)] => {}
     }
 }
@@ -107,7 +107,7 @@ fn move_out_by_subslice_and_subslice() {
         [x @ .., _, _] => {}
     }
     match a {
-        //~^ ERROR use of moved value
+        //~^ ERROR use of partially moved value
         [_, _y @ ..] => {}
     }
 }

--- a/src/test/ui/borrowck/borrowck-move-out-from-array-no-overlap-match.stderr
+++ b/src/test/ui/borrowck/borrowck-move-out-from-array-no-overlap-match.stderr
@@ -1,101 +1,101 @@
-error[E0382]: use of moved value: `a`
+error[E0382]: use of partially moved value: `a`
   --> $DIR/borrowck-move-out-from-array-no-overlap-match.rs:17:11
    |
 LL |         [_, _, _x] => {}
-   |                -- value moved here
+   |                -- value partially moved here
 LL |     }
 LL |     match a {
    |           ^ value used here after partial move
    |
-   = note: move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
+   = note: partial move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
 
-error[E0382]: use of moved value: `a`
+error[E0382]: use of partially moved value: `a`
   --> $DIR/borrowck-move-out-from-array-no-overlap-match.rs:28:11
    |
 LL |         [_, _, (_x, _)] => {}
-   |                 -- value moved here
+   |                 -- value partially moved here
 LL |     }
 LL |     match a {
    |           ^ value used here after partial move
    |
-   = note: move occurs because `a[..].0` has type `std::string::String`, which does not implement the `Copy` trait
+   = note: partial move occurs because `a[..].0` has type `std::string::String`, which does not implement the `Copy` trait
 
-error[E0382]: use of moved value: `a`
+error[E0382]: use of partially moved value: `a`
   --> $DIR/borrowck-move-out-from-array-no-overlap-match.rs:41:11
    |
 LL |         [_x, _, _] => {}
-   |          -- value moved here
+   |          -- value partially moved here
 LL |     }
 LL |     match a {
    |           ^ value used here after partial move
    |
-   = note: move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
+   = note: partial move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
 
-error[E0382]: use of moved value: `a`
+error[E0382]: use of partially moved value: `a`
   --> $DIR/borrowck-move-out-from-array-no-overlap-match.rs:52:11
    |
 LL |         [.., _x] => {}
-   |              -- value moved here
+   |              -- value partially moved here
 LL |     }
 LL |     match a {
    |           ^ value used here after partial move
    |
-   = note: move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
+   = note: partial move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
 
-error[E0382]: use of moved value: `a`
+error[E0382]: use of partially moved value: `a`
   --> $DIR/borrowck-move-out-from-array-no-overlap-match.rs:63:11
    |
 LL |         [(_x, _), _, _] => {}
-   |           -- value moved here
+   |           -- value partially moved here
 LL |     }
 LL |     match a {
    |           ^ value used here after partial move
    |
-   = note: move occurs because `a[..].0` has type `std::string::String`, which does not implement the `Copy` trait
+   = note: partial move occurs because `a[..].0` has type `std::string::String`, which does not implement the `Copy` trait
 
-error[E0382]: use of moved value: `a`
+error[E0382]: use of partially moved value: `a`
   --> $DIR/borrowck-move-out-from-array-no-overlap-match.rs:74:11
    |
 LL |         [.., (_x, _)] => {}
-   |               -- value moved here
+   |               -- value partially moved here
 LL |     }
 LL |     match a {
    |           ^ value used here after partial move
    |
-   = note: move occurs because `a[..].0` has type `std::string::String`, which does not implement the `Copy` trait
+   = note: partial move occurs because `a[..].0` has type `std::string::String`, which does not implement the `Copy` trait
 
-error[E0382]: use of moved value: `a`
+error[E0382]: use of partially moved value: `a`
   --> $DIR/borrowck-move-out-from-array-no-overlap-match.rs:85:11
    |
 LL |         [_, _y @ ..] => {}
-   |             ------- value moved here
+   |             ------- value partially moved here
 LL |     }
 LL |     match a {
    |           ^ value used here after partial move
    |
-   = note: move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
+   = note: partial move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
 
-error[E0382]: use of moved value: `a`
+error[E0382]: use of partially moved value: `a`
   --> $DIR/borrowck-move-out-from-array-no-overlap-match.rs:96:11
    |
 LL |         [_y @ .., _] => {}
-   |          ------- value moved here
+   |          ------- value partially moved here
 LL |     }
 LL |     match a {
    |           ^ value used here after partial move
    |
-   = note: move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
+   = note: partial move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
 
-error[E0382]: use of moved value: `a`
+error[E0382]: use of partially moved value: `a`
   --> $DIR/borrowck-move-out-from-array-no-overlap-match.rs:109:11
    |
 LL |         [x @ .., _, _] => {}
-   |          ------ value moved here
+   |          ------ value partially moved here
 LL |     }
 LL |     match a {
    |           ^ value used here after partial move
    |
-   = note: move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
+   = note: partial move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
 
 error: aborting due to 9 previous errors
 

--- a/src/test/ui/borrowck/borrowck-move-out-from-array-use-match.stderr
+++ b/src/test/ui/borrowck/borrowck-move-out-from-array-use-match.stderr
@@ -9,16 +9,16 @@ LL |         [.., ref _y] => {}
    |
    = note: move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
 
-error[E0382]: borrow of moved value: `a[..]`
+error[E0382]: borrow of partially moved value: `a[..]`
   --> $DIR/borrowck-move-out-from-array-use-match.rs:23:14
    |
 LL |         [_, _, (_x, _)] => {}
-   |                 -- value moved here
+   |                 -- value partially moved here
 ...
 LL |         [.., ref _y] => {}
    |              ^^^^^^ value borrowed here after partial move
    |
-   = note: move occurs because `a[..].0` has type `std::string::String`, which does not implement the `Copy` trait
+   = note: partial move occurs because `a[..].0` has type `std::string::String`, which does not implement the `Copy` trait
 
 error[E0382]: borrow of moved value: `a[..].0`
   --> $DIR/borrowck-move-out-from-array-use-match.rs:33:15
@@ -31,49 +31,49 @@ LL |         [.., (ref _y, _)] => {}
    |
    = note: move occurs because `a[..].0` has type `std::string::String`, which does not implement the `Copy` trait
 
-error[E0382]: use of moved value: `a`
+error[E0382]: use of partially moved value: `a`
   --> $DIR/borrowck-move-out-from-array-use-match.rs:44:11
    |
 LL |         [_x, _, _] => {}
-   |          -- value moved here
+   |          -- value partially moved here
 LL |     }
 LL |     match a {
    |           ^ value used here after partial move
    |
-   = note: move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
+   = note: partial move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
 
-error[E0382]: use of moved value: `a`
+error[E0382]: use of partially moved value: `a`
   --> $DIR/borrowck-move-out-from-array-use-match.rs:55:11
    |
 LL |         [.., _x] => {}
-   |              -- value moved here
+   |              -- value partially moved here
 LL |     }
 LL |     match a {
    |           ^ value used here after partial move
    |
-   = note: move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
+   = note: partial move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
 
-error[E0382]: use of moved value: `a`
+error[E0382]: use of partially moved value: `a`
   --> $DIR/borrowck-move-out-from-array-use-match.rs:66:11
    |
 LL |         [(_x, _), _, _] => {}
-   |           -- value moved here
+   |           -- value partially moved here
 LL |     }
 LL |     match a {
    |           ^ value used here after partial move
    |
-   = note: move occurs because `a[..].0` has type `std::string::String`, which does not implement the `Copy` trait
+   = note: partial move occurs because `a[..].0` has type `std::string::String`, which does not implement the `Copy` trait
 
-error[E0382]: use of moved value: `a`
+error[E0382]: use of partially moved value: `a`
   --> $DIR/borrowck-move-out-from-array-use-match.rs:77:11
    |
 LL |         [.., (_x, _)] => {}
-   |               -- value moved here
+   |               -- value partially moved here
 LL |     }
 LL |     match a {
    |           ^ value used here after partial move
    |
-   = note: move occurs because `a[..].0` has type `std::string::String`, which does not implement the `Copy` trait
+   = note: partial move occurs because `a[..].0` has type `std::string::String`, which does not implement the `Copy` trait
 
 error[E0382]: borrow of moved value: `a[..]`
   --> $DIR/borrowck-move-out-from-array-use-match.rs:89:11
@@ -97,60 +97,60 @@ LL |         [.., (ref _x, _)] => {}
    |
    = note: move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
 
-error[E0382]: use of moved value: `a`
+error[E0382]: use of partially moved value: `a`
   --> $DIR/borrowck-move-out-from-array-use-match.rs:110:11
    |
 LL |         [x @ .., _] => {}
-   |          ------ value moved here
+   |          ------ value partially moved here
 LL |     }
 LL |     match a {
    |           ^ value used here after partial move
    |
-   = note: move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
+   = note: partial move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
 
-error[E0382]: use of moved value: `a`
+error[E0382]: use of partially moved value: `a`
   --> $DIR/borrowck-move-out-from-array-use-match.rs:123:5
    |
 LL |         [_, _, _x] => {}
-   |                -- value moved here
+   |                -- value partially moved here
 LL |     }
 LL |     a[2] = Default::default();
    |     ^^^^ value used here after partial move
    |
-   = note: move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
+   = note: partial move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
 
-error[E0382]: use of moved value: `a`
+error[E0382]: use of partially moved value: `a`
   --> $DIR/borrowck-move-out-from-array-use-match.rs:131:5
    |
 LL |         [_, _, (_x, _)] => {}
-   |                 -- value moved here
+   |                 -- value partially moved here
 LL |     }
 LL |     a[2].1 = Default::default();
    |     ^^^^ value used here after partial move
    |
-   = note: move occurs because `a[..].0` has type `std::string::String`, which does not implement the `Copy` trait
+   = note: partial move occurs because `a[..].0` has type `std::string::String`, which does not implement the `Copy` trait
 
-error[E0382]: use of moved value: `a`
+error[E0382]: use of partially moved value: `a`
   --> $DIR/borrowck-move-out-from-array-use-match.rs:139:5
    |
 LL |         [_, _, _x @ ..] => {}
-   |                ------- value moved here
+   |                ------- value partially moved here
 LL |     }
 LL |     a[0] = Default::default();
    |     ^^^^ value used here after partial move
    |
-   = note: move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
+   = note: partial move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
 
-error[E0382]: use of moved value: `a`
+error[E0382]: use of partially moved value: `a`
   --> $DIR/borrowck-move-out-from-array-use-match.rs:147:5
    |
 LL |         [_, _, _x @ ..] => {}
-   |                ------- value moved here
+   |                ------- value partially moved here
 LL |     }
 LL |     a[0].1 = Default::default();
    |     ^^^^ value used here after partial move
    |
-   = note: move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
+   = note: partial move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
 
 error: aborting due to 14 previous errors
 

--- a/src/test/ui/borrowck/borrowck-move-out-from-array-use-no-overlap-match.rs
+++ b/src/test/ui/borrowck/borrowck-move-out-from-array-use-no-overlap-match.rs
@@ -15,7 +15,7 @@ fn move_out_from_begin_and_one_from_end() {
         [_, _, _x] => {}
     }
     match a {
-        //~^ ERROR use of moved value
+        //~^ ERROR use of partially moved value
         [.., ref _y, _] => {}
     }
 }
@@ -26,7 +26,7 @@ fn move_out_from_begin_field_and_end_field() {
         [_, _, (_x, _)] => {}
     }
     match a {
-        //~^ ERROR use of moved value
+        //~^ ERROR use of partially moved value
         [.., (_, ref _y)] => {}
     }
 }
@@ -39,7 +39,7 @@ fn move_out_by_const_index_and_subslice() {
         [_x, _, _] => {}
     }
     match a {
-        //~^ ERROR use of moved value
+        //~^ ERROR use of partially moved value
         [_, ref _y @ ..] => {}
     }
 }
@@ -50,7 +50,7 @@ fn move_out_by_const_index_end_and_subslice() {
         [.., _x] => {}
     }
     match a {
-        //~^ ERROR use of moved value
+        //~^ ERROR use of partially moved value
         [ref _y @ .., _] => {}
     }
 }
@@ -61,7 +61,7 @@ fn move_out_by_const_index_field_and_subslice() {
         [(_x, _), _, _] => {}
     }
     match a {
-        //~^ ERROR use of moved value
+        //~^ ERROR use of partially moved value
         [_, ref _y @ ..] => {}
     }
 }
@@ -72,7 +72,7 @@ fn move_out_by_const_index_end_field_and_subslice() {
         [.., (_x, _)] => {}
     }
     match a {
-        //~^ ERROR use of moved value
+        //~^ ERROR use of partially moved value
         [ref _y @ .., _] => {}
     }
 }
@@ -83,7 +83,7 @@ fn move_out_by_const_subslice_and_index_field() {
         [_, _y @ ..] => {}
     }
     match a {
-        //~^ ERROR use of moved value
+        //~^ ERROR use of partially moved value
         [(ref _x, _), _, _] => {}
     }
 }
@@ -94,7 +94,7 @@ fn move_out_by_const_subslice_and_end_index_field() {
         [_y @ .., _] => {}
     }
     match a {
-        //~^ ERROR use of moved value
+        //~^ ERROR use of partially moved value
         [.., (ref _x, _)] => {}
     }
 }
@@ -107,7 +107,7 @@ fn move_out_by_subslice_and_subslice() {
         [x @ .., _, _] => {}
     }
     match a {
-        //~^ ERROR use of moved value
+        //~^ ERROR use of partially moved value
         [_, ref _y @ ..] => {}
     }
 }

--- a/src/test/ui/borrowck/borrowck-move-out-from-array-use-no-overlap-match.stderr
+++ b/src/test/ui/borrowck/borrowck-move-out-from-array-use-no-overlap-match.stderr
@@ -1,101 +1,101 @@
-error[E0382]: use of moved value: `a`
+error[E0382]: use of partially moved value: `a`
   --> $DIR/borrowck-move-out-from-array-use-no-overlap-match.rs:17:11
    |
 LL |         [_, _, _x] => {}
-   |                -- value moved here
+   |                -- value partially moved here
 LL |     }
 LL |     match a {
    |           ^ value used here after partial move
    |
-   = note: move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
+   = note: partial move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
 
-error[E0382]: use of moved value: `a`
+error[E0382]: use of partially moved value: `a`
   --> $DIR/borrowck-move-out-from-array-use-no-overlap-match.rs:28:11
    |
 LL |         [_, _, (_x, _)] => {}
-   |                 -- value moved here
+   |                 -- value partially moved here
 LL |     }
 LL |     match a {
    |           ^ value used here after partial move
    |
-   = note: move occurs because `a[..].0` has type `std::string::String`, which does not implement the `Copy` trait
+   = note: partial move occurs because `a[..].0` has type `std::string::String`, which does not implement the `Copy` trait
 
-error[E0382]: use of moved value: `a`
+error[E0382]: use of partially moved value: `a`
   --> $DIR/borrowck-move-out-from-array-use-no-overlap-match.rs:41:11
    |
 LL |         [_x, _, _] => {}
-   |          -- value moved here
+   |          -- value partially moved here
 LL |     }
 LL |     match a {
    |           ^ value used here after partial move
    |
-   = note: move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
+   = note: partial move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
 
-error[E0382]: use of moved value: `a`
+error[E0382]: use of partially moved value: `a`
   --> $DIR/borrowck-move-out-from-array-use-no-overlap-match.rs:52:11
    |
 LL |         [.., _x] => {}
-   |              -- value moved here
+   |              -- value partially moved here
 LL |     }
 LL |     match a {
    |           ^ value used here after partial move
    |
-   = note: move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
+   = note: partial move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
 
-error[E0382]: use of moved value: `a`
+error[E0382]: use of partially moved value: `a`
   --> $DIR/borrowck-move-out-from-array-use-no-overlap-match.rs:63:11
    |
 LL |         [(_x, _), _, _] => {}
-   |           -- value moved here
+   |           -- value partially moved here
 LL |     }
 LL |     match a {
    |           ^ value used here after partial move
    |
-   = note: move occurs because `a[..].0` has type `std::string::String`, which does not implement the `Copy` trait
+   = note: partial move occurs because `a[..].0` has type `std::string::String`, which does not implement the `Copy` trait
 
-error[E0382]: use of moved value: `a`
+error[E0382]: use of partially moved value: `a`
   --> $DIR/borrowck-move-out-from-array-use-no-overlap-match.rs:74:11
    |
 LL |         [.., (_x, _)] => {}
-   |               -- value moved here
+   |               -- value partially moved here
 LL |     }
 LL |     match a {
    |           ^ value used here after partial move
    |
-   = note: move occurs because `a[..].0` has type `std::string::String`, which does not implement the `Copy` trait
+   = note: partial move occurs because `a[..].0` has type `std::string::String`, which does not implement the `Copy` trait
 
-error[E0382]: use of moved value: `a`
+error[E0382]: use of partially moved value: `a`
   --> $DIR/borrowck-move-out-from-array-use-no-overlap-match.rs:85:11
    |
 LL |         [_, _y @ ..] => {}
-   |             ------- value moved here
+   |             ------- value partially moved here
 LL |     }
 LL |     match a {
    |           ^ value used here after partial move
    |
-   = note: move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
+   = note: partial move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
 
-error[E0382]: use of moved value: `a`
+error[E0382]: use of partially moved value: `a`
   --> $DIR/borrowck-move-out-from-array-use-no-overlap-match.rs:96:11
    |
 LL |         [_y @ .., _] => {}
-   |          ------- value moved here
+   |          ------- value partially moved here
 LL |     }
 LL |     match a {
    |           ^ value used here after partial move
    |
-   = note: move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
+   = note: partial move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
 
-error[E0382]: use of moved value: `a`
+error[E0382]: use of partially moved value: `a`
   --> $DIR/borrowck-move-out-from-array-use-no-overlap-match.rs:109:11
    |
 LL |         [x @ .., _, _] => {}
-   |          ------ value moved here
+   |          ------ value partially moved here
 LL |     }
 LL |     match a {
    |           ^ value used here after partial move
    |
-   = note: move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
+   = note: partial move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
 
 error: aborting due to 9 previous errors
 

--- a/src/test/ui/borrowck/borrowck-move-out-from-array-use.stderr
+++ b/src/test/ui/borrowck/borrowck-move-out-from-array-use.stderr
@@ -8,15 +8,15 @@ LL |     let [.., ref _y] = a;
    |
    = note: move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
 
-error[E0382]: borrow of moved value: `a[..]`
+error[E0382]: borrow of partially moved value: `a[..]`
   --> $DIR/borrowck-move-out-from-array-use.rs:16:14
    |
 LL |     let [_, _, (_x, _)] = a;
-   |                 -- value moved here
+   |                 -- value partially moved here
 LL |     let [.., ref _y] = a;
    |              ^^^^^^ value borrowed here after partial move
    |
-   = note: move occurs because `a[..].0` has type `std::string::String`, which does not implement the `Copy` trait
+   = note: partial move occurs because `a[..].0` has type `std::string::String`, which does not implement the `Copy` trait
 
 error[E0382]: borrow of moved value: `a[..].0`
   --> $DIR/borrowck-move-out-from-array-use.rs:22:15
@@ -28,45 +28,45 @@ LL |     let [.., (ref _y, _)] = a;
    |
    = note: move occurs because `a[..].0` has type `std::string::String`, which does not implement the `Copy` trait
 
-error[E0382]: borrow of moved value: `a`
+error[E0382]: borrow of partially moved value: `a`
   --> $DIR/borrowck-move-out-from-array-use.rs:30:10
    |
 LL |     let [_x, _, _] = a;
-   |          -- value moved here
+   |          -- value partially moved here
 LL |     let [ref _y @ .., _, _] = a;
    |          ^^^^^^^^^^^ value borrowed here after partial move
    |
-   = note: move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
+   = note: partial move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
 
-error[E0382]: borrow of moved value: `a`
+error[E0382]: borrow of partially moved value: `a`
   --> $DIR/borrowck-move-out-from-array-use.rs:36:16
    |
 LL |     let [.., _x] = a;
-   |              -- value moved here
+   |              -- value partially moved here
 LL |     let [_, _, ref _y @ ..] = a;
    |                ^^^^^^^^^^^ value borrowed here after partial move
    |
-   = note: move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
+   = note: partial move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
 
-error[E0382]: borrow of moved value: `a`
+error[E0382]: borrow of partially moved value: `a`
   --> $DIR/borrowck-move-out-from-array-use.rs:42:10
    |
 LL |     let [(_x, _), _, _] = a;
-   |           -- value moved here
+   |           -- value partially moved here
 LL |     let [ref _y @ .., _, _] = a;
    |          ^^^^^^^^^^^ value borrowed here after partial move
    |
-   = note: move occurs because `a[..].0` has type `std::string::String`, which does not implement the `Copy` trait
+   = note: partial move occurs because `a[..].0` has type `std::string::String`, which does not implement the `Copy` trait
 
-error[E0382]: borrow of moved value: `a`
+error[E0382]: borrow of partially moved value: `a`
   --> $DIR/borrowck-move-out-from-array-use.rs:48:16
    |
 LL |     let [.., (_x, _)] = a;
-   |               -- value moved here
+   |               -- value partially moved here
 LL |     let [_, _, ref _y @ ..] = a;
    |                ^^^^^^^^^^^ value borrowed here after partial move
    |
-   = note: move occurs because `a[..].0` has type `std::string::String`, which does not implement the `Copy` trait
+   = note: partial move occurs because `a[..].0` has type `std::string::String`, which does not implement the `Copy` trait
 
 error[E0382]: borrow of moved value: `a[..]`
   --> $DIR/borrowck-move-out-from-array-use.rs:54:11
@@ -88,55 +88,55 @@ LL |     let [.., (ref _x, _)] = a;
    |
    = note: move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
 
-error[E0382]: borrow of moved value: `a`
+error[E0382]: borrow of partially moved value: `a`
   --> $DIR/borrowck-move-out-from-array-use.rs:68:13
    |
 LL |     let [x @ .., _] = a;
-   |          ------ value moved here
+   |          ------ value partially moved here
 LL |     let [_, ref _y @ ..] = a;
    |             ^^^^^^^^^^^ value borrowed here after partial move
    |
-   = note: move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
+   = note: partial move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
 
-error[E0382]: use of moved value: `a`
+error[E0382]: use of partially moved value: `a`
   --> $DIR/borrowck-move-out-from-array-use.rs:76:5
    |
 LL |     let [_, _, _x] = a;
-   |                -- value moved here
+   |                -- value partially moved here
 LL |     a[2] = Default::default();
    |     ^^^^ value used here after partial move
    |
-   = note: move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
+   = note: partial move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
 
-error[E0382]: use of moved value: `a`
+error[E0382]: use of partially moved value: `a`
   --> $DIR/borrowck-move-out-from-array-use.rs:82:5
    |
 LL |     let [_, _, (_x, _)] = a;
-   |                 -- value moved here
+   |                 -- value partially moved here
 LL |     a[2].1 = Default::default();
    |     ^^^^ value used here after partial move
    |
-   = note: move occurs because `a[..].0` has type `std::string::String`, which does not implement the `Copy` trait
+   = note: partial move occurs because `a[..].0` has type `std::string::String`, which does not implement the `Copy` trait
 
-error[E0382]: use of moved value: `a`
+error[E0382]: use of partially moved value: `a`
   --> $DIR/borrowck-move-out-from-array-use.rs:88:5
    |
 LL |     let [_, _, _x @ ..] = a;
-   |                ------- value moved here
+   |                ------- value partially moved here
 LL |     a[0] = Default::default();
    |     ^^^^ value used here after partial move
    |
-   = note: move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
+   = note: partial move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
 
-error[E0382]: use of moved value: `a`
+error[E0382]: use of partially moved value: `a`
   --> $DIR/borrowck-move-out-from-array-use.rs:94:5
    |
 LL |     let [_, _, _x @ ..] = a;
-   |                ------- value moved here
+   |                ------- value partially moved here
 LL |     a[0].1 = Default::default();
    |     ^^^^ value used here after partial move
    |
-   = note: move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
+   = note: partial move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
 
 error: aborting due to 14 previous errors
 

--- a/src/test/ui/borrowck/borrowck-move-out-from-array.stderr
+++ b/src/test/ui/borrowck/borrowck-move-out-from-array.stderr
@@ -8,15 +8,15 @@ LL |     let [.., _y] = a;
    |
    = note: move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
 
-error[E0382]: use of moved value: `a[..]`
+error[E0382]: use of partially moved value: `a[..]`
   --> $DIR/borrowck-move-out-from-array.rs:16:14
    |
 LL |     let [_, _, (_x, _)] = a;
-   |                 -- value moved here
+   |                 -- value partially moved here
 LL |     let [.., _y] = a;
    |              ^^ value used here after partial move
    |
-   = note: move occurs because `a[..].0` has type `std::string::String`, which does not implement the `Copy` trait
+   = note: partial move occurs because `a[..].0` has type `std::string::String`, which does not implement the `Copy` trait
 
 error[E0382]: use of moved value: `a[..].0`
   --> $DIR/borrowck-move-out-from-array.rs:22:15
@@ -28,45 +28,45 @@ LL |     let [.., (_y, _)] = a;
    |
    = note: move occurs because `a[..].0` has type `std::string::String`, which does not implement the `Copy` trait
 
-error[E0382]: use of moved value: `a`
+error[E0382]: use of partially moved value: `a`
   --> $DIR/borrowck-move-out-from-array.rs:30:10
    |
 LL |     let [_x, _, _] = a;
-   |          -- value moved here
+   |          -- value partially moved here
 LL |     let [_y @ .., _, _] = a;
    |          ^^^^^^^ value used here after partial move
    |
-   = note: move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
+   = note: partial move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
 
-error[E0382]: use of moved value: `a`
+error[E0382]: use of partially moved value: `a`
   --> $DIR/borrowck-move-out-from-array.rs:36:16
    |
 LL |     let [.., _x] = a;
-   |              -- value moved here
+   |              -- value partially moved here
 LL |     let [_, _, _y @ ..] = a;
    |                ^^^^^^^ value used here after partial move
    |
-   = note: move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
+   = note: partial move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
 
-error[E0382]: use of moved value: `a`
+error[E0382]: use of partially moved value: `a`
   --> $DIR/borrowck-move-out-from-array.rs:42:10
    |
 LL |     let [(_x, _), _, _] = a;
-   |           -- value moved here
+   |           -- value partially moved here
 LL |     let [_y @ .., _, _] = a;
    |          ^^^^^^^ value used here after partial move
    |
-   = note: move occurs because `a[..].0` has type `std::string::String`, which does not implement the `Copy` trait
+   = note: partial move occurs because `a[..].0` has type `std::string::String`, which does not implement the `Copy` trait
 
-error[E0382]: use of moved value: `a`
+error[E0382]: use of partially moved value: `a`
   --> $DIR/borrowck-move-out-from-array.rs:48:16
    |
 LL |     let [.., (_x, _)] = a;
-   |               -- value moved here
+   |               -- value partially moved here
 LL |     let [_, _, _y @ ..] = a;
    |                ^^^^^^^ value used here after partial move
    |
-   = note: move occurs because `a[..].0` has type `std::string::String`, which does not implement the `Copy` trait
+   = note: partial move occurs because `a[..].0` has type `std::string::String`, which does not implement the `Copy` trait
 
 error[E0382]: use of moved value: `a[..].0`
   --> $DIR/borrowck-move-out-from-array.rs:54:11
@@ -88,15 +88,15 @@ LL |     let [.., (_x, _)] = a;
    |
    = note: move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
 
-error[E0382]: use of moved value: `a`
+error[E0382]: use of partially moved value: `a`
   --> $DIR/borrowck-move-out-from-array.rs:68:13
    |
 LL |     let [x @ .., _] = a;
-   |          ------ value moved here
+   |          ------ value partially moved here
 LL |     let [_, _y @ ..] = a;
    |             ^^^^^^^ value used here after partial move
    |
-   = note: move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
+   = note: partial move occurs because `a[..]` has type `(std::string::String, std::string::String)`, which does not implement the `Copy` trait
 
 error: aborting due to 10 previous errors
 

--- a/src/test/ui/borrowck/borrowck-uninit-field-access.stderr
+++ b/src/test/ui/borrowck/borrowck-uninit-field-access.stderr
@@ -14,15 +14,15 @@ LL |     let _ = line1.origin.x + 1;
    |
    = note: move occurs because `line1.origin` has type `Point`, which does not implement the `Copy` trait
 
-error[E0382]: use of moved value: `line2`
+error[E0382]: use of partially moved value: `line2`
   --> $DIR/borrowck-uninit-field-access.rs:29:5
    |
 LL |     let _moved = (line2.origin, line2.middle);
-   |                                 ------------ value moved here
+   |                                 ------------ value partially moved here
 LL |     line2.consume();
    |     ^^^^^ value used here after partial move
    |
-   = note: move occurs because `line2.middle` has type `Point`, which does not implement the `Copy` trait
+   = note: partial move occurs because `line2.middle` has type `Point`, which does not implement the `Copy` trait
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/borrowck/move-in-pattern-mut.rs
+++ b/src/test/ui/borrowck/move-in-pattern-mut.rs
@@ -15,9 +15,9 @@ fn main() {
     if let Some(mut x) = s {
         x = S;
     }
-    foo(s); //~ ERROR use of moved value: `s`
+    foo(s); //~ ERROR use of partially moved value: `s`
     let mut e = E::V { s: S };
     let E::V { s: mut x } = e;
     x = S;
-    bar(e); //~ ERROR use of moved value: `e`
+    bar(e); //~ ERROR use of partially moved value: `e`
 }

--- a/src/test/ui/borrowck/move-in-pattern-mut.stderr
+++ b/src/test/ui/borrowck/move-in-pattern-mut.stderr
@@ -1,28 +1,28 @@
-error[E0382]: use of moved value: `s`
+error[E0382]: use of partially moved value: `s`
   --> $DIR/move-in-pattern-mut.rs:18:9
    |
 LL |     if let Some(mut x) = s {
-   |                 ----- value moved here
+   |                 ----- value partially moved here
 ...
 LL |     foo(s);
    |         ^ value used here after partial move
    |
-   = note: move occurs because value has type `S`, which does not implement the `Copy` trait
+   = note: partial move occurs because value has type `S`, which does not implement the `Copy` trait
 help: borrow this field in the pattern to avoid moving `s.0`
    |
 LL |     if let Some(ref mut x) = s {
    |                 ^^^
 
-error[E0382]: use of moved value: `e`
+error[E0382]: use of partially moved value: `e`
   --> $DIR/move-in-pattern-mut.rs:22:9
    |
 LL |     let E::V { s: mut x } = e;
-   |                   ----- value moved here
+   |                   ----- value partially moved here
 LL |     x = S;
 LL |     bar(e);
    |         ^ value used here after partial move
    |
-   = note: move occurs because value has type `S`, which does not implement the `Copy` trait
+   = note: partial move occurs because value has type `S`, which does not implement the `Copy` trait
 help: borrow this field in the pattern to avoid moving `e.s`
    |
 LL |     let E::V { s: ref mut x } = e;

--- a/src/test/ui/borrowck/move-in-pattern.fixed
+++ b/src/test/ui/borrowck/move-in-pattern.fixed
@@ -16,9 +16,9 @@ fn main() {
     if let Some(ref x) = s {
         let _ = x;
     }
-    foo(s); //~ ERROR use of moved value: `s`
+    foo(s); //~ ERROR use of partially moved value: `s`
     let e = E::V { s: S };
     let E::V { s: ref x } = e;
     let _ = x;
-    bar(e); //~ ERROR use of moved value: `e`
+    bar(e); //~ ERROR use of partially moved value: `e`
 }

--- a/src/test/ui/borrowck/move-in-pattern.rs
+++ b/src/test/ui/borrowck/move-in-pattern.rs
@@ -16,9 +16,9 @@ fn main() {
     if let Some(x) = s {
         let _ = x;
     }
-    foo(s); //~ ERROR use of moved value: `s`
+    foo(s); //~ ERROR use of partially moved value: `s`
     let e = E::V { s: S };
     let E::V { s: x } = e;
     let _ = x;
-    bar(e); //~ ERROR use of moved value: `e`
+    bar(e); //~ ERROR use of partially moved value: `e`
 }

--- a/src/test/ui/borrowck/move-in-pattern.stderr
+++ b/src/test/ui/borrowck/move-in-pattern.stderr
@@ -1,28 +1,28 @@
-error[E0382]: use of moved value: `s`
+error[E0382]: use of partially moved value: `s`
   --> $DIR/move-in-pattern.rs:19:9
    |
 LL |     if let Some(x) = s {
-   |                 - value moved here
+   |                 - value partially moved here
 ...
 LL |     foo(s);
    |         ^ value used here after partial move
    |
-   = note: move occurs because value has type `S`, which does not implement the `Copy` trait
+   = note: partial move occurs because value has type `S`, which does not implement the `Copy` trait
 help: borrow this field in the pattern to avoid moving `s.0`
    |
 LL |     if let Some(ref x) = s {
    |                 ^^^
 
-error[E0382]: use of moved value: `e`
+error[E0382]: use of partially moved value: `e`
   --> $DIR/move-in-pattern.rs:23:9
    |
 LL |     let E::V { s: x } = e;
-   |                   - value moved here
+   |                   - value partially moved here
 LL |     let _ = x;
 LL |     bar(e);
    |         ^ value used here after partial move
    |
-   = note: move occurs because value has type `S`, which does not implement the `Copy` trait
+   = note: partial move occurs because value has type `S`, which does not implement the `Copy` trait
 help: borrow this field in the pattern to avoid moving `e.s`
    |
 LL |     let E::V { s: ref x } = e;

--- a/src/test/ui/moves/moves-based-on-type-cyclic-types-issue-4821.rs
+++ b/src/test/ui/moves/moves-based-on-type-cyclic-types-issue-4821.rs
@@ -10,7 +10,7 @@ fn foo(node: Box<List>) -> isize {
         Some(right) => consume(right),
         None => 0
     };
-    consume(node) + r //~ ERROR use of moved value: `node`
+    consume(node) + r //~ ERROR use of partially moved value: `node`
 }
 
 fn consume(v: Box<List>) -> isize {

--- a/src/test/ui/moves/moves-based-on-type-cyclic-types-issue-4821.stderr
+++ b/src/test/ui/moves/moves-based-on-type-cyclic-types-issue-4821.stderr
@@ -1,13 +1,13 @@
-error[E0382]: use of moved value: `node`
+error[E0382]: use of partially moved value: `node`
   --> $DIR/moves-based-on-type-cyclic-types-issue-4821.rs:13:13
    |
 LL |         Some(right) => consume(right),
-   |              ----- value moved here
+   |              ----- value partially moved here
 ...
 LL |     consume(node) + r
    |             ^^^^ value used here after partial move
    |
-   = note: move occurs because value has type `std::boxed::Box<List>`, which does not implement the `Copy` trait
+   = note: partial move occurs because value has type `std::boxed::Box<List>`, which does not implement the `Copy` trait
 help: borrow this field in the pattern to avoid moving `node.next.0`
    |
 LL |         Some(ref right) => consume(right),

--- a/src/test/ui/moves/moves-based-on-type-match-bindings.rs
+++ b/src/test/ui/moves/moves-based-on-type-match-bindings.rs
@@ -13,9 +13,9 @@ fn f10() {
         Foo {f} => {}
     };
 
-    touch(&x); //~ ERROR borrow of moved value: `x`
+    touch(&x); //~ ERROR borrow of partially moved value: `x`
     //~^ value borrowed here after partial move
-    //~| move occurs because `x.f` has type `std::string::String`
+    //~| partial move occurs because `x.f` has type `std::string::String`
 }
 
 fn main() {}

--- a/src/test/ui/moves/moves-based-on-type-match-bindings.stderr
+++ b/src/test/ui/moves/moves-based-on-type-match-bindings.stderr
@@ -1,13 +1,13 @@
-error[E0382]: borrow of moved value: `x`
+error[E0382]: borrow of partially moved value: `x`
   --> $DIR/moves-based-on-type-match-bindings.rs:16:11
    |
 LL |         Foo {f} => {}
-   |              - value moved here
+   |              - value partially moved here
 ...
 LL |     touch(&x);
    |           ^^ value borrowed here after partial move
    |
-   = note: move occurs because `x.f` has type `std::string::String`, which does not implement the `Copy` trait
+   = note: partial move occurs because `x.f` has type `std::string::String`, which does not implement the `Copy` trait
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/move-subpaths-moves-root.rs
+++ b/src/test/ui/nll/move-subpaths-moves-root.rs
@@ -1,5 +1,5 @@
 fn main() {
     let x = (vec![1, 2, 3], );
     drop(x.0);
-    drop(x); //~ ERROR use of moved value
+    drop(x); //~ ERROR use of partially moved value
 }

--- a/src/test/ui/nll/move-subpaths-moves-root.stderr
+++ b/src/test/ui/nll/move-subpaths-moves-root.stderr
@@ -1,12 +1,12 @@
-error[E0382]: use of moved value: `x`
+error[E0382]: use of partially moved value: `x`
   --> $DIR/move-subpaths-moves-root.rs:4:10
    |
 LL |     drop(x.0);
-   |          --- value moved here
+   |          --- value partially moved here
 LL |     drop(x);
    |          ^ value used here after partial move
    |
-   = note: move occurs because `x.0` has type `std::vec::Vec<i32>`, which does not implement the `Copy` trait
+   = note: partial move occurs because `x.0` has type `std::vec::Vec<i32>`, which does not implement the `Copy` trait
 
 error: aborting due to previous error
 

--- a/src/test/ui/ref-suggestion.rs
+++ b/src/test/ui/ref-suggestion.rs
@@ -13,5 +13,5 @@ fn main() {
         (Some(y), ()) => {},
         _ => {},
     }
-    x; //~ ERROR use of moved value
+    x; //~ ERROR use of partially moved value
 }

--- a/src/test/ui/ref-suggestion.stderr
+++ b/src/test/ui/ref-suggestion.stderr
@@ -18,16 +18,16 @@ LL |     let mut y = x;
 LL |     x;
    |     ^ value used here after move
 
-error[E0382]: use of moved value: `x`
+error[E0382]: use of partially moved value: `x`
   --> $DIR/ref-suggestion.rs:16:5
    |
 LL |         (Some(y), ()) => {},
-   |               - value moved here
+   |               - value partially moved here
 ...
 LL |     x;
    |     ^ value used here after partial move
    |
-   = note: move occurs because value has type `std::vec::Vec<i32>`, which does not implement the `Copy` trait
+   = note: partial move occurs because value has type `std::vec::Vec<i32>`, which does not implement the `Copy` trait
 help: borrow this field in the pattern to avoid moving `x.0.0`
    |
 LL |         (Some(ref y), ()) => {},

--- a/src/test/ui/unsized-locals/borrow-after-move.stderr
+++ b/src/test/ui/unsized-locals/borrow-after-move.stderr
@@ -5,7 +5,7 @@ LL |         let y = *x;
    |                 -- value moved here
 LL |         drop_unsized(y);
 LL |         println!("{}", &x);
-   |                        ^^ value borrowed here after partial move
+   |                        ^^ value borrowed here after move
    |
    = note: move occurs because `*x` has type `str`, which does not implement the `Copy` trait
 
@@ -27,7 +27,7 @@ LL |         let y = *x;
    |                 -- value moved here
 LL |         y.foo();
 LL |         println!("{}", &x);
-   |                        ^^ value borrowed here after partial move
+   |                        ^^ value borrowed here after move
    |
    = note: move occurs because `*x` has type `str`, which does not implement the `Copy` trait
 

--- a/src/test/ui/unsized-locals/double-move.stderr
+++ b/src/test/ui/unsized-locals/double-move.stderr
@@ -14,7 +14,7 @@ error[E0382]: use of moved value: `x`
 LL |         let _y = *x;
    |                  -- value moved here
 LL |         drop_unsized(x);
-   |                      ^ value used here after partial move
+   |                      ^ value used here after move
    |
    = note: move occurs because `*x` has type `str`, which does not implement the `Copy` trait
 
@@ -50,7 +50,7 @@ error[E0382]: use of moved value: `x`
 LL |         let _y = *x;
    |                  -- value moved here
 LL |         x.foo();
-   |         ^ value used here after partial move
+   |         ^ value used here after move
    |
    = note: move occurs because `*x` has type `str`, which does not implement the `Copy` trait
 


### PR DESCRIPTION
When an error occurs due to a partial move, we would use the world
"partial" in some parts of the error message, but not in others. This
commit ensures that we use the word 'partial' in either all or none of
the diagnostic messages.

Additionally, we no longer describe a move out of a `Box` via `*` as
a 'partial move'. This was a pre-existing issue, but became more
noticable when the word 'partial' is used in more places.