### PR TITLE
rustc_span: Generate keyword classification functions automatically

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3625,6 +3625,7 @@ dependencies = [
 name = "rustc_macros"
 version = "0.1.0"
 dependencies = [
+ "indexmap",
  "proc-macro2",
  "quote",
  "syn",

--- a/src/librustc_macros/Cargo.toml
+++ b/src/librustc_macros/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 proc-macro = true
 
 [dependencies]
+indexmap = "1"
 synstructure = "0.12.1"
 syn = { version = "1", features = ["full"] }
 proc-macro2 = "1"

--- a/src/librustc_span/symbol.rs
+++ b/src/librustc_span/symbol.rs
@@ -25,12 +25,14 @@ symbols! {
     Keywords {
         // Special reserved identifiers used internally for elided lifetimes,
         // unnamed method parameters, crate root module, error recovery etc.
+        fn is_special:
         Invalid:            "",
         PathRoot:           "{{root}}",
         DollarCrate:        "$crate",
         Underscore:         "_",
 
-        // Keywords that are used in stable Rust.
+        // Keywords that are used in stable Rust on all editions.
+        fn is_used_keyword_20xx:
         As:                 "as",
         Break:              "break",
         Const:              "const",
@@ -67,7 +69,8 @@ symbols! {
         Where:              "where",
         While:              "while",
 
-        // Keywords that are used in unstable Rust or reserved for future use.
+        // Keywords that are used in unstable Rust or reserved for future use on all editions.
+        fn is_unused_keyword_20xx:
         Abstract:           "abstract",
         Become:             "become",
         Box:                "box",
@@ -82,18 +85,22 @@ symbols! {
         Yield:              "yield",
 
         // Edition-specific keywords that are used in stable Rust.
+        fn is_used_keyword_2018:
         Async:              "async", // >= 2018 Edition only
         Await:              "await", // >= 2018 Edition only
         Dyn:                "dyn", // >= 2018 Edition only
 
         // Edition-specific keywords that are used in unstable Rust or reserved for future use.
+        fn is_unused_keyword_2018:
         Try:                "try", // >= 2018 Edition only
 
         // Special lifetime names
+        fn is_special_lifetime:
         UnderscoreLifetime: "'_",
         StaticLifetime:     "'static",
 
         // Weak keywords, have special meaning only in specific contexts.
+        fn is_weak_keyword:
         Auto:               "auto",
         Catch:              "catch",
         Default:            "default",
@@ -1546,14 +1553,6 @@ pub mod sym {
 }
 
 impl Symbol {
-    fn is_used_keyword_2018(self) -> bool {
-        self >= kw::Async && self <= kw::Dyn
-    }
-
-    fn is_unused_keyword_2018(self) -> bool {
-        self == kw::Try
-    }
-
     /// A keyword or reserved identifier that can be used as a path segment.
     pub fn is_path_segment_keyword(self) -> bool {
         self == kw::Super
@@ -1579,20 +1578,20 @@ impl Ident {
     // Returns `true` for reserved identifiers used internally for elided lifetimes,
     // unnamed method parameters, crate root module, error recovery etc.
     pub fn is_special(self) -> bool {
-        self.name <= kw::Underscore
+        self.name.is_special()
     }
 
     /// Returns `true` if the token is a keyword used in the language.
     pub fn is_used_keyword(self) -> bool {
         // Note: `span.edition()` is relatively expensive, don't call it unless necessary.
-        self.name >= kw::As && self.name <= kw::While
+        self.name.is_used_keyword_20xx()
             || self.name.is_used_keyword_2018() && self.span.rust_2018()
     }
 
     /// Returns `true` if the token is a keyword reserved for possible future use.
     pub fn is_unused_keyword(self) -> bool {
         // Note: `span.edition()` is relatively expensive, don't call it unless necessary.
-        self.name >= kw::Abstract && self.name <= kw::Yield
+        self.name.is_unused_keyword_20xx()
             || self.name.is_unused_keyword_2018() && self.span.rust_2018()
     }
 

--- a/src/librustc_span/symbol.rs
+++ b/src/librustc_span/symbol.rs
@@ -1554,11 +1554,6 @@ impl Symbol {
         self == kw::Try
     }
 
-    /// Used for sanity checking rustdoc keyword sections.
-    pub fn is_doc_keyword(self) -> bool {
-        self <= kw::Union
-    }
-
     /// A keyword or reserved identifier that can be used as a path segment.
     pub fn is_path_segment_keyword(self) -> bool {
         self == kw::Super

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -169,11 +169,8 @@ impl Clean<ExternalCrate> for CrateNum {
                 for attr in attrs.lists(sym::doc) {
                     if let Some(v) = attr.value_str() {
                         if attr.has_name(sym::keyword) {
-                            if v.is_doc_keyword() {
-                                keyword = Some(v.to_string());
-                                break;
-                            }
-                            // FIXME: should warn on unknown keywords?
+                            keyword = Some(v.to_string());
+                            break;
                         }
                     }
                 }


### PR DESCRIPTION
The generated functions are compatible with symbols not forming continuous ranges.
This is a nicer alternative to https://github.com/rust-lang/rust/pull/74554/commits/48966144d4ad7d409152a405633acfc5924ec8cc from https://github.com/rust-lang/rust/pull/74554.
r? @nnethercote 