### PR TITLE
tests: Mark `ui/asm/bad-arch.rs` as requiring wasm llvm backend

### DIFF
--- a/src/test/ui/asm/bad-arch.rs
+++ b/src/test/ui/asm/bad-arch.rs
@@ -1,4 +1,5 @@
 // compile-flags: --target wasm32-unknown-unknown
+// needs-llvm-components: webassembly
 
 #![feature(no_core, lang_items, rustc_attrs)]
 #![no_core]

--- a/src/test/ui/asm/bad-arch.stderr
+++ b/src/test/ui/asm/bad-arch.stderr
@@ -1,5 +1,5 @@
 error[E0472]: asm! is unsupported on this target
-  --> $DIR/bad-arch.rs:15:9
+  --> $DIR/bad-arch.rs:16:9
    |
 LL |         asm!("");
    |         ^^^^^^^^^


### PR DESCRIPTION
So it doesn't fail when not all LLVM backends are built.