### PR TITLE
Convert `Option<Box<dyn>>` into enum w/ 1 variant

### DIFF
--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -174,7 +174,7 @@ pub fn run_compiler(
             stderr: None,
             crate_name: None,
             lint_caps: Default::default(),
-            register_lints: None,
+            register_lints: Default::default(),
             override_queries: None,
             registry: diagnostics_registry(),
         };
@@ -250,7 +250,7 @@ pub fn run_compiler(
         stderr: None,
         crate_name: None,
         lint_caps: Default::default(),
-        register_lints: None,
+        register_lints: Default::default(),
         override_queries: None,
         registry: diagnostics_registry(),
     };

--- a/src/librustc_interface/interface.rs
+++ b/src/librustc_interface/interface.rs
@@ -49,7 +49,7 @@ impl RegisterLints {
             }
         }
     }
-    pub fn on(&self, sess: &Session, lint_store: &mut LintStore) {
+    pub fn call(&self, sess: &Session, lint_store: &mut LintStore) {
         match self {
             RegisterLints::Empty => (),
             RegisterLints::Register(reg) => (reg)(sess, lint_store),

--- a/src/librustc_interface/passes.rs
+++ b/src/librustc_interface/passes.rs
@@ -1,4 +1,4 @@
-use crate::interface::{Compiler, Result};
+use crate::interface::{Compiler, RegisterLints, Result};
 use crate::proc_macro_decls;
 use crate::util;
 
@@ -150,7 +150,7 @@ impl BoxedResolver {
 pub fn register_plugins<'a>(
     sess: &'a Session,
     metadata_loader: &'a dyn MetadataLoader,
-    register_lints: impl Fn(&Session, &mut LintStore),
+    register_lints: &RegisterLints,
     mut krate: ast::Crate,
     crate_name: &str,
 ) -> Result<(ast::Crate, Lrc<LintStore>)> {
@@ -193,7 +193,7 @@ pub fn register_plugins<'a>(
         sess.opts.debugging_opts.no_interleave_lints,
         sess.unstable_options(),
     );
-    register_lints(&sess, &mut lint_store);
+    register_lints.on(&sess, &mut lint_store);
 
     let registrars =
         sess.time("plugin_loading", || plugin::load::load_plugins(sess, metadata_loader, &krate));

--- a/src/librustc_interface/passes.rs
+++ b/src/librustc_interface/passes.rs
@@ -193,7 +193,7 @@ pub fn register_plugins<'a>(
         sess.opts.debugging_opts.no_interleave_lints,
         sess.unstable_options(),
     );
-    register_lints.on(&sess, &mut lint_store);
+    register_lints.call(&sess, &mut lint_store);
 
     let registrars =
         sess.time("plugin_loading", || plugin::load::load_plugins(sess, metadata_loader, &krate));

--- a/src/librustc_interface/queries.rs
+++ b/src/librustc_interface/queries.rs
@@ -132,11 +132,10 @@ impl<'tcx> Queries<'tcx> {
             let crate_name = self.crate_name()?.peek().clone();
             let krate = self.parse()?.take();
 
-            let empty: &(dyn Fn(&Session, &mut LintStore) + Sync + Send) = &|_, _| {};
             let result = passes::register_plugins(
                 self.session(),
                 &*self.codegen_backend().metadata_loader(),
-                self.compiler.register_lints.as_deref().unwrap_or_else(|| empty),
+                &self.compiler.register_lints,
                 krate,
                 &crate_name,
             );

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -376,7 +376,7 @@ pub fn run_core(options: RustdocOptions) -> (clean::Crate, RenderInfo, RenderOpt
         stderr: None,
         crate_name,
         lint_caps,
-        register_lints: None,
+        register_lints: Default::default(),
         override_queries: Some(|_sess, providers, _external_providers| {
             // Most lints will require typechecking, so just don't run them.
             providers.lint_mod = |_, _| {};

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -93,7 +93,7 @@ pub fn run(options: Options) -> Result<(), ErrorReported> {
         stderr: None,
         crate_name: options.crate_name.clone(),
         lint_caps,
-        register_lints: None,
+        register_lints: Default::default(),
         override_queries: None,
         registry: rustc_driver::diagnostics_registry(),
     };

--- a/src/test/run-make-fulldeps/issue-19371/foo.rs
+++ b/src/test/run-make-fulldeps/issue-19371/foo.rs
@@ -58,7 +58,7 @@ fn compile(code: String, output: PathBuf, sysroot: PathBuf) {
         stderr: None,
         crate_name: None,
         lint_caps: Default::default(),
-        register_lints: None,
+        register_lints: Default::default(),
         override_queries: None,
         registry: rustc_driver::diagnostics_registry(),
     };

--- a/src/tools/clippy/src/driver.rs
+++ b/src/tools/clippy/src/driver.rs
@@ -69,14 +69,7 @@ impl rustc_driver::Callbacks for DefaultCallbacks {}
 struct ClippyCallbacks;
 impl rustc_driver::Callbacks for ClippyCallbacks {
     fn config(&mut self, config: &mut interface::Config) {
-        let previous = config.register_lints.take();
-        config.register_lints = Some(Box::new(move |sess, mut lint_store| {
-            // technically we're ~guaranteed that this is none but might as well call anything that
-            // is there already. Certainly it can't hurt.
-            if let Some(previous) = &previous {
-                (previous)(sess, lint_store);
-            }
-
+        config.register_lints.set(Box::new(move |sess, mut lint_store| {
             let conf = clippy_lints::read_conf(&[], &sess);
             clippy_lints::register_plugins(&mut lint_store, &sess, &conf);
             clippy_lints::register_pre_expansion_lints(&mut lint_store);


### PR DESCRIPTION
This adds a more specific variant of `Option<Box<dyn Fn>>` so that if no plugins are registered it will do no extra work. This is a really minor change but hopefully should improve efficiency a very tiny bit.