### PR TITLE
Fix ICE #75307 in `format`

### DIFF
--- a/src/test/ui/issues/issue-75307.rs
+++ b/src/test/ui/issues/issue-75307.rs
@@ -1,0 +1,3 @@
+fn main() {
+    format!(r"{}{}{}", named_arg=1); //~ ERROR invalid reference to positional arguments 1 and 2
+}

--- a/src/test/ui/issues/issue-75307.stderr
+++ b/src/test/ui/issues/issue-75307.stderr
@@ -1,0 +1,10 @@
+error: invalid reference to positional arguments 1 and 2 (there is 1 argument)
+  --> $DIR/issue-75307.rs:2:13
+   |
+LL |     format!(r"{}{}{}", named_arg=1);
+   |             ^^^^^^^^^
+   |
+   = note: positional arguments are zero-based
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Remove usages of `unwrap` (even when some are safe today).

Fix #75307.