### PR TITLE
clarify documentation of remove_dir errors

### DIFF
--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -1991,7 +1991,7 @@ pub fn create_dir_all<P: AsRef<Path>>(path: P) -> io::Result<()> {
     DirBuilder::new().recursive(true).create(path.as_ref())
 }
 
-/// Removes an existing, empty directory.
+/// Removes an empty directory.
 ///
 /// # Platform-specific behavior
 ///
@@ -2006,6 +2006,8 @@ pub fn create_dir_all<P: AsRef<Path>>(path: P) -> io::Result<()> {
 /// This function will return an error in the following situations, but is not
 /// limited to just these cases:
 ///
+/// * `path` doesn't exist.
+/// * `path` isn't a directory.
 /// * The user lacks permissions to remove the directory at the provided `path`.
 /// * The directory isn't empty.
 ///


### PR DESCRIPTION
remove_dir will error if the path doesn't exist or isn't a directory.

It's useful to clarify that this is "remove dir or fail" not "remove dir
if it exists".

I don't think this belongs in the title. "Removes an existing, empty
directory" is strangely worded-- there's no such thing as a non-existing
directory.  Better to just say explicitly it will return an error.