### PR TITLE
polymorphize: constrain unevaluated const handling

### DIFF
--- a/src/test/ui/polymorphization/promoted-function-3.rs
+++ b/src/test/ui/polymorphization/promoted-function-3.rs
@@ -1,0 +1,14 @@
+// run-pass
+// compile-flags: -Zpolymorphize=on -Zmir-opt-level=3
+
+fn caller<T, U>() -> &'static usize {
+    callee::<U>()
+}
+
+fn callee<T>() -> &'static usize {
+    &std::mem::size_of::<T>()
+}
+
+fn main() {
+    assert_eq!(caller::<(), ()>(), &0);
+}


### PR DESCRIPTION
This PR constrains the support added for handling unevaluated consts in polymorphization (introduced in #75260) by:

- Skipping associated constants as this causes cycle errors.
- Skipping promoted constants when they contain `Self` as this ensures `T` is used in constants of the form `<Self as Foo<T>>`.

Due to an oversight on my part, when landing #75260 and #75255, some tests started failing when polymorphization was enabled that I didn't notice until after landing - this PR fixes the regressions from #75260.

r? @lcnr