### PR TITLE
move stack size check to const_eval machine

### DIFF
--- a/src/librustc_mir/const_eval/machine.rs
+++ b/src/librustc_mir/const_eval/machine.rs
@@ -301,6 +301,15 @@ impl<'mir, 'tcx> interpret::Machine<'mir, 'tcx> for CompileTimeInterpreter<'mir,
         Ok(())
     }
 
+    fn after_stack_push(ecx: &mut InterpCx<'mir, 'tcx, Self>) -> InterpResult<'tcx> {
+        // Enforce stack size limit.
+        if !ecx.tcx.sess.recursion_limit().value_within_limit(ecx.stack().len()) {
+            throw_exhaust!(StackFrameLimitReached)
+        } else {
+            Ok(())
+        }
+    }
+
     #[inline(always)]
     fn stack(
         ecx: &'a InterpCx<'mir, 'tcx, Self>,

--- a/src/librustc_mir/interpret/eval_context.rs
+++ b/src/librustc_mir/interpret/eval_context.rs
@@ -653,11 +653,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
         M::after_stack_push(self)?;
         info!("ENTERING({}) {}", self.frame_idx(), self.frame().instance);
 
-        if !self.tcx.sess.recursion_limit().value_within_limit(self.stack().len()) {
-            throw_exhaust!(StackFrameLimitReached)
-        } else {
-            Ok(())
-        }
+        Ok(())
     }
 
     /// Jump to the given block.


### PR DESCRIPTION
This is consistent with how we enforce the step limit. In particular, we do not want this limit checked for Miri-the-tool.