### PR TITLE
Rustdoc: Fix natural ordering to look at all numbers.

### DIFF
--- a/src/librustdoc/html/render/tests.rs
+++ b/src/librustdoc/html/render/tests.rs
@@ -1,24 +1,40 @@
 use super::*;
 
 #[test]
-fn test_name_key() {
-    assert_eq!(name_key("0"), ("", 0, 1));
-    assert_eq!(name_key("123"), ("", 123, 0));
-    assert_eq!(name_key("Fruit"), ("Fruit", 0, 0));
-    assert_eq!(name_key("Fruit0"), ("Fruit", 0, 1));
-    assert_eq!(name_key("Fruit0000"), ("Fruit", 0, 4));
-    assert_eq!(name_key("Fruit01"), ("Fruit", 1, 1));
-    assert_eq!(name_key("Fruit10"), ("Fruit", 10, 0));
-    assert_eq!(name_key("Fruit123"), ("Fruit", 123, 0));
+fn test_compare_names() {
+    for &(a, b) in &[
+        ("hello", "world"),
+        ("", "world"),
+        ("123", "hello"),
+        ("123", ""),
+        ("123test", "123"),
+        ("hello", ""),
+        ("hello", "hello"),
+        ("hello123", "hello123"),
+        ("hello123", "hello12"),
+        ("hello12", "hello123"),
+        ("hello01abc", "hello01xyz"),
+        ("hello0abc", "hello0"),
+        ("hello0", "hello0abc"),
+        ("01", "1"),
+    ] {
+        assert_eq!(compare_names(a, b), a.cmp(b), "{:?} - {:?}", a, b);
+    }
+    assert_eq!(compare_names("u8", "u16"), Ordering::Less);
+    assert_eq!(compare_names("u32", "u16"), Ordering::Greater);
+    assert_eq!(compare_names("u8_to_f64", "u16_to_f64"), Ordering::Less);
+    assert_eq!(compare_names("u32_to_f64", "u16_to_f64"), Ordering::Greater);
+    assert_eq!(compare_names("u16_to_f64", "u16_to_f64"), Ordering::Equal);
+    assert_eq!(compare_names("u16_to_f32", "u16_to_f64"), Ordering::Less);
 }
 
 #[test]
 fn test_name_sorting() {
     let names = [
-        "Apple", "Banana", "Fruit", "Fruit0", "Fruit00", "Fruit1", "Fruit01", "Fruit2", "Fruit02",
+        "Apple", "Banana", "Fruit", "Fruit0", "Fruit00", "Fruit01", "Fruit1", "Fruit02", "Fruit2",
         "Fruit20", "Fruit30x", "Fruit100", "Pear",
     ];
     let mut sorted = names.to_owned();
-    sorted.sort_by_key(|&s| name_key(s));
+    sorted.sort_by(|&l, r| compare_names(l, r));
     assert_eq!(names, sorted);
 }


### PR DESCRIPTION
The old implementation only looks at numbers at the end, but not in other places in a name: `u8` and `u16` got sorted properly, but `u8_bla` and `u16_bla` did not.

![image](https://user-images.githubusercontent.com/783247/89740226-28e8b180-da87-11ea-885d-77a7c8a6ba00.png)

Edit: Also fixes bugs in the old sorting code:

![image](https://user-images.githubusercontent.com/783247/89944734-98de6f80-dc20-11ea-8c32-54ba8ffa8371.png)