### PR TITLE
Minimize the cost of write_fmt without arguments

### DIFF
--- a/library/core/src/fmt/mod.rs
+++ b/library/core/src/fmt/mod.rs
@@ -190,7 +190,10 @@ pub trait Write {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     fn write_fmt(mut self: &mut Self, args: Arguments<'_>) -> Result {
-        write(&mut self, args)
+        match args.as_str() {
+            Some(s) => self.write_str(s),
+            None => write(&mut self, args),
+        }
     }
 }
 

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -1506,15 +1506,19 @@ pub trait Write {
             }
         }
 
-        let mut output = Adaptor { inner: self, error: Ok(()) };
-        match fmt::write(&mut output, fmt) {
-            Ok(()) => Ok(()),
-            Err(..) => {
-                // check if the error came from the underlying `Write` or not
-                if output.error.is_err() {
-                    output.error
-                } else {
-                    Err(Error::new(ErrorKind::Other, "formatter error"))
+        if let Some(s) = fmt.as_str() {
+            self.write_all(s.as_bytes())
+        } else {
+            let mut output = Adaptor { inner: self, error: Ok(()) };
+            match fmt::write(&mut output, fmt) {
+                Ok(()) => Ok(()),
+                Err(..) => {
+                    // check if the error came from the underlying `Write` or not
+                    if output.error.is_err() {
+                        output.error
+                    } else {
+                        Err(Error::new(ErrorKind::Other, "formatter error"))
+                    }
                 }
             }
         }

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -265,6 +265,7 @@
 #![feature(exhaustive_patterns)]
 #![feature(extend_one)]
 #![feature(external_doc)]
+#![feature(fmt_as_str)]
 #![feature(fn_traits)]
 #![feature(format_args_nl)]
 #![feature(future_readiness_fns)]


### PR DESCRIPTION
Thanks to [`Arguments::as_str`](https://doc.rust-lang.org/nightly/std/fmt/struct.Arguments.html#method.as_str), we should know
when we don't have any arguments at all.

Before: https://rust.godbolt.org/z/zKGEMP
After: 

```asm
check_stage1::foo:
 push    rbx
 mov     rax, rsi
 mov     rbx, rdi
 lea     rsi, [rip, +, .L__unnamed_1]
 mov     edx, 1
 mov     rdi, rax
 call    alloc::vec::Vec<T>::extend_from_slice
 mov     byte, ptr, [rbx], 3
 mov     rax, rbx
 pop     rbx
 ret
```

```asm
check_stage1::bar:
 push    rax
 lea     rsi, [rip, +, .L__unnamed_1]
 mov     edx, 1
 call    alloc::vec::Vec<T>::extend_from_slice
 xor     eax, eax
 pop     rcx
 ret
```

Closes #75301

Zulip discussion: https://rust-lang.zulipchat.com/#narrow/stream/131828-t-compiler/topic/Discuss.20changes.20in.20.20.2375358