### PR TITLE
Add sample fix for E0749

### DIFF
--- a/src/librustc_error_codes/error_codes/E0749.md
+++ b/src/librustc_error_codes/error_codes/E0749.md
@@ -18,7 +18,7 @@ Negative impls are not allowed to have any items. Negative impls declare that a
 trait is **not** implemented (and never will be) and hence there is no need to
 specify the values for trait methods or other items.
 
-One way to fix this is to remove the items in negative impls.
+One way to fix this is to remove the items in negative impls:
 
 ```
 # #![feature(negative_impls)]

--- a/src/librustc_error_codes/error_codes/E0749.md
+++ b/src/librustc_error_codes/error_codes/E0749.md
@@ -11,10 +11,20 @@ trait MyTrait {
 impl !MyTrait for u32 {
     type Foo = i32; // error!
 }
-// impl !MyTrait for u32 {} // fix
 # fn main() {}
 ```
 
 Negative impls are not allowed to have any items. Negative impls declare that a
 trait is **not** implemented (and never will be) and hence there is no need to
 specify the values for trait methods or other items.
+
+One way to fix this is to remove the items in negative impls.
+
+```
+# #![feature(negative_impls)]
+trait MyTrait {
+    type Foo;
+}
+
+impl !MyTrait for u32 {}
+```

--- a/src/librustc_error_codes/error_codes/E0749.md
+++ b/src/librustc_error_codes/error_codes/E0749.md
@@ -11,6 +11,7 @@ trait MyTrait {
 impl !MyTrait for u32 {
     type Foo = i32; // error!
 }
+// impl !MyTrait for u32 {} // fix
 # fn main() {}
 ```
 

--- a/src/librustc_error_codes/error_codes/E0749.md
+++ b/src/librustc_error_codes/error_codes/E0749.md
@@ -11,7 +11,6 @@ trait MyTrait {
 impl !MyTrait for u32 {
     type Foo = i32; // error!
 }
-# fn main() {}
 ```
 
 Negative impls are not allowed to have any items. Negative impls declare that a


### PR DESCRIPTION
Even though the description is clear but the solution may not be as straightforward.
Adding a suggested fix from documentation side.

r? @GuillaumeGomez 

However, this suggestion should be shown in rustc itself for easy fix, the documentation should also reflect on the changes in rustc. Currently,
```
error[E0749]: negative impls cannot have any items
 --> test.rs:6:5
  |
6 |     type Foo = i32; // error!
  |     ^^^^^^^^^^^^^^^

error: aborting due to previous error

For more information about this error, try `rustc --explain E0749`.
```
rustc should tell the user to remove it.