### PR TITLE
Use existing `infcx` when emitting trait impl diagnostic

### DIFF
--- a/src/librustc_infer/infer/error_reporting/nice_region_error/trait_impl_difference.rs
+++ b/src/librustc_infer/infer/error_reporting/nice_region_error/trait_impl_difference.rs
@@ -2,7 +2,7 @@
 
 use crate::infer::error_reporting::nice_region_error::NiceRegionError;
 use crate::infer::lexical_region_resolve::RegionResolutionError;
-use crate::infer::{Subtype, TyCtxtInferExt, ValuePairs};
+use crate::infer::{Subtype, ValuePairs};
 use crate::traits::ObligationCauseCode::CompareImplMethodObligation;
 use rustc_errors::ErrorReported;
 use rustc_hir as hir;
@@ -53,7 +53,6 @@ impl<'a, 'tcx> NiceRegionError<'a, 'tcx> {
     }
 
     fn emit_err(&self, sp: Span, expected: Ty<'tcx>, found: Ty<'tcx>, trait_def_id: DefId) {
-        let tcx = self.tcx();
         let trait_sp = self.tcx().def_span(trait_def_id);
         let mut err = self
             .tcx()
@@ -85,9 +84,8 @@ impl<'a, 'tcx> NiceRegionError<'a, 'tcx> {
             );
         }
 
-        if let Some((expected, found)) = tcx
-            .infer_ctxt()
-            .enter(|infcx| infcx.expected_found_str_ty(&ExpectedFound { expected, found }))
+        if let Some((expected, found)) =
+            self.infcx.expected_found_str_ty(&ExpectedFound { expected, found })
         {
             // Highlighted the differences when showing the "expected/found" note.
             err.note_expected_found(&"", expected, &"", found);

--- a/src/test/ui/mismatched_types/issue-74918-missing-lifetime.rs
+++ b/src/test/ui/mismatched_types/issue-74918-missing-lifetime.rs
@@ -1,0 +1,28 @@
+// Regression test for issue #74918
+// Tests that we don't ICE after emitting an error
+
+struct ChunkingIterator<T, S: 'static + Iterator<Item = T>> {
+    source: S,
+}
+
+impl<T, S: Iterator<Item = T>> Iterator for ChunkingIterator<T, S> {
+    type Item = IteratorChunk<T, S>; //~ ERROR missing lifetime
+
+    fn next(&mut self) -> Option<IteratorChunk<T, S>> { //~ ERROR `impl`
+        todo!()
+    }
+}
+
+struct IteratorChunk<'a, T, S: Iterator<Item = T>> {
+    source: &'a mut S,
+}
+
+impl<T, S: Iterator<Item = T>> Iterator for IteratorChunk<'_, T, S> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<T> {
+        todo!()
+    }
+}
+
+fn main() {}

--- a/src/test/ui/mismatched_types/issue-74918-missing-lifetime.stderr
+++ b/src/test/ui/mismatched_types/issue-74918-missing-lifetime.stderr
@@ -1,0 +1,30 @@
+error[E0106]: missing lifetime specifier
+  --> $DIR/issue-74918-missing-lifetime.rs:9:31
+   |
+LL |     type Item = IteratorChunk<T, S>;
+   |                               ^ expected named lifetime parameter
+   |
+help: consider introducing a named lifetime parameter
+   |
+LL |     type Item<'a> = IteratorChunk<<'a>T, S>;
+   |              ^^^^                 ^^^^
+
+error: `impl` item signature doesn't match `trait` item signature
+  --> $DIR/issue-74918-missing-lifetime.rs:11:5
+   |
+LL |     fn next(&mut self) -> Option<IteratorChunk<T, S>> {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ found `fn(&mut ChunkingIterator<T, S>) -> std::option::Option<IteratorChunk<'_, T, S>>`
+   | 
+  ::: $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
+   |
+LL |     fn next(&mut self) -> Option<Self::Item>;
+   |     ----------------------------------------- expected `fn(&mut ChunkingIterator<T, S>) -> std::option::Option<IteratorChunk<'static, _, _>>`
+   |
+   = note: expected `fn(&mut ChunkingIterator<T, S>) -> std::option::Option<IteratorChunk<'static, _, _>>`
+              found `fn(&mut ChunkingIterator<T, S>) -> std::option::Option<IteratorChunk<'_, _, _>>`
+   = help: the lifetime requirements from the `impl` do not correspond to the requirements in the `trait`
+   = help: verify the lifetime relationships in the `trait` and `impl` between the `self` argument, the other inputs and its output
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0106`.

--- a/src/test/ui/mismatched_types/issue-75361-mismatched-impl.rs
+++ b/src/test/ui/mismatched_types/issue-75361-mismatched-impl.rs
@@ -1,0 +1,24 @@
+// Regresison test for issue #75361
+// Tests that we don't ICE on mismatched types with inference variables
+
+
+trait MyTrait {
+    type Item;
+}
+
+pub trait Graph {
+  type EdgeType;
+
+  fn adjacent_edges(&self) -> Box<dyn MyTrait<Item = &Self::EdgeType>>;
+}
+
+impl<T> Graph for T {
+  type EdgeType = T;
+
+  fn adjacent_edges(&self) -> Box<dyn MyTrait<Item = &Self::EdgeType> + '_> { //~ ERROR `impl`
+      panic!()
+  }
+
+}
+
+fn main() {}

--- a/src/test/ui/mismatched_types/issue-75361-mismatched-impl.stderr
+++ b/src/test/ui/mismatched_types/issue-75361-mismatched-impl.stderr
@@ -1,0 +1,19 @@
+error: `impl` item signature doesn't match `trait` item signature
+  --> $DIR/issue-75361-mismatched-impl.rs:18:3
+   |
+LL |   fn adjacent_edges(&self) -> Box<dyn MyTrait<Item = &Self::EdgeType>>;
+   |   --------------------------------------------------------------------- expected `fn(&T) -> std::boxed::Box<(dyn MyTrait<Item = &_> + 'static)>`
+...
+LL |   fn adjacent_edges(&self) -> Box<dyn MyTrait<Item = &Self::EdgeType> + '_> {
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ found `fn(&T) -> std::boxed::Box<dyn MyTrait<Item = &_>>`
+   |
+   = note: expected `fn(&T) -> std::boxed::Box<(dyn MyTrait<Item = &T> + 'static)>`
+              found `fn(&T) -> std::boxed::Box<dyn MyTrait<Item = &T>>`
+help: the lifetime requirements from the `impl` do not correspond to the requirements in the `trait`
+  --> $DIR/issue-75361-mismatched-impl.rs:12:55
+   |
+LL |   fn adjacent_edges(&self) -> Box<dyn MyTrait<Item = &Self::EdgeType>>;
+   |                                                       ^^^^^^^^^^^^^^ consider borrowing this type parameter in the trait
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Fixes #75361
Fixes #74918

Previously, we were creating a new `InferCtxt`, which caused an ICE when
used with type variables from the existing `InferCtxt`