### PR TITLE
Call into fastfail on abort in libpanic_abort on Windows x86(_64)

### DIFF
--- a/library/panic_abort/src/lib.rs
+++ b/library/panic_abort/src/lib.rs
@@ -27,16 +27,7 @@ pub unsafe extern "C" fn __rust_panic_cleanup(_: *mut u8) -> *mut (dyn Any + Sen
     unreachable!()
 }
 
-// "Leak" the payload and shim to the relevant abort on the platform in
-// question.
-//
-// For Unix we just use `abort` from libc as it'll trigger debuggers, core
-// dumps, etc, as one might expect. On Windows, however, the best option we have
-// is the `__fastfail` intrinsics, but that's unfortunately not defined in LLVM,
-// and the `RaiseFailFastException` function isn't available until Windows 7
-// which would break compat with XP. For now just use `intrinsics::abort` which
-// will kill us with an illegal instruction, which will do a good enough job for
-// now hopefully.
+// "Leak" the payload and shim to the relevant abort on the platform in question.
 #[rustc_std_internal_symbol]
 pub unsafe extern "C" fn __rust_start_panic(_payload: usize) -> u32 {
     abort();
@@ -57,14 +48,16 @@ pub unsafe extern "C" fn __rust_start_panic(_payload: usize) -> u32 {
                 __rust_abort();
             }
         } else if #[cfg(all(windows, any(target_arch = "x86", target_arch = "x86_64")))] {
-            // On Windows, use the processor-specific __fastfail mechanism.  In Windows 8
+            // On Windows, use the processor-specific __fastfail mechanism. In Windows 8
             // and later, this will terminate the process immediately without running any
-            // in-process exception handlers.  In earlier versions of Windows, this
+            // in-process exception handlers. In earlier versions of Windows, this
             // sequence of instructions will be treated as an access violation,
             // terminating the process but without necessarily bypassing all exception
             // handlers.
             //
             // https://docs.microsoft.com/en-us/cpp/intrinsics/fastfail
+            //
+            // Note: this is the same implementation as in libstd's `abort_internal`
             unsafe fn abort() -> ! {
                 llvm_asm!("int $$0x29" :: "{ecx}"(7) ::: volatile); // 7 is FAST_FAIL_FATAL_APP_EXIT
                 core::intrinsics::unreachable();

--- a/library/std/src/sys/windows/mod.rs
+++ b/library/std/src/sys/windows/mod.rs
@@ -281,7 +281,11 @@ macro_rules! impl_is_zero {
 impl_is_zero! { i8 i16 i32 i64 isize u8 u16 u32 u64 usize }
 
 pub fn cvt<I: IsZero>(i: I) -> crate::io::Result<I> {
-    if i.is_zero() { Err(crate::io::Error::last_os_error()) } else { Ok(i) }
+    if i.is_zero() {
+        Err(crate::io::Error::last_os_error())
+    } else {
+        Ok(i)
+    }
 }
 
 pub fn dur2timeout(dur: Duration) -> c::DWORD {
@@ -300,14 +304,10 @@ pub fn dur2timeout(dur: Duration) -> c::DWORD {
         .unwrap_or(c::INFINITE)
 }
 
-// On Windows, use the processor-specific __fastfail mechanism.  In Windows 8
-// and later, this will terminate the process immediately without running any
-// in-process exception handlers.  In earlier versions of Windows, this
-// sequence of instructions will be treated as an access violation,
-// terminating the process but without necessarily bypassing all exception
-// handlers.
-//
-// https://docs.microsoft.com/en-us/cpp/intrinsics/fastfail
+/// Use `__fastfail` to abort the process
+///
+/// This is the same implementation as in libpanic_abort's `__rust_start_panic`. See
+/// that function for more information on `__fastfail`
 #[allow(unreachable_code)]
 pub fn abort_internal() -> ! {
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]

--- a/library/std/src/sys/windows/mod.rs
+++ b/library/std/src/sys/windows/mod.rs
@@ -281,11 +281,7 @@ macro_rules! impl_is_zero {
 impl_is_zero! { i8 i16 i32 i64 isize u8 u16 u32 u64 usize }
 
 pub fn cvt<I: IsZero>(i: I) -> crate::io::Result<I> {
-    if i.is_zero() {
-        Err(crate::io::Error::last_os_error())
-    } else {
-        Ok(i)
-    }
+    if i.is_zero() { Err(crate::io::Error::last_os_error()) } else { Ok(i) }
 }
 
 pub fn dur2timeout(dur: Duration) -> c::DWORD {


### PR DESCRIPTION
This partially resolves #73215 though this is only for x86 targets. This code is directly lifted from [libstd](https://github.com/rust-lang/rust/blob/13290e83a6e20f3b408d177a9d64d8cf98fe4615/library/std/src/sys/windows/mod.rs#L315). `__fastfail` is the preferred way to abort a process on Windows as it will hook into debugger toolchains.  

Other platforms expose a `_rust_abort` symbol which wraps `std::sys::abort_internal`. This would also work on Windows, but is a slightly largely change as we'd need to make sure that the symbol is properly exposed to the linker. I'm inlining the call to the `__fastfail`, but the indirection through `rust_abort` might be a cleaner approach. 

 A different instruction must be used on ARM architectures. I'd like to verify this works first before tackling ARM. 