### PR TITLE
Move to intra-doc links in /library/core/src/borrow.rs

### DIFF
--- a/library/core/src/borrow.rs
+++ b/library/core/src/borrow.rs
@@ -40,7 +40,6 @@
 /// provide a reference to related type `T`, it is often better to use
 /// [`AsRef<T>`] as more types can safely implement it.
 ///
-/// [`AsRef<T>`]: crate::convert::AsRef
 /// [`BorrowMut<T>`]: BorrowMut
 /// [`Box<T>`]: ../../std/boxed/struct.Box.html
 /// [`Mutex<T>`]: ../../std/sync/struct.Mutex.html

--- a/library/core/src/borrow.rs
+++ b/library/core/src/borrow.rs
@@ -40,14 +40,13 @@
 /// provide a reference to related type `T`, it is often better to use
 /// [`AsRef<T>`] as more types can safely implement it.
 ///
-/// [`AsRef<T>`]: ../../std/convert/trait.AsRef.html
-/// [`BorrowMut<T>`]: trait.BorrowMut.html
+/// [`AsRef<T>`]: crate::convert::AsRef
+/// [`BorrowMut<T>`]: BorrowMut
 /// [`Box<T>`]: ../../std/boxed/struct.Box.html
 /// [`Mutex<T>`]: ../../std/sync/struct.Mutex.html
 /// [`Rc<T>`]: ../../std/rc/struct.Rc.html
-/// [`str`]: ../../std/primitive.str.html
 /// [`String`]: ../../std/string/struct.String.html
-/// [`borrow`]: #tymethod.borrow
+/// [`borrow`]: Borrow::borrow
 ///
 /// # Examples
 ///
@@ -152,10 +151,9 @@
 /// If it wants to allow others access to the underlying `str`, it can do
 /// that via `AsRef<str>` which doesn’t carry any extra requirements.
 ///
-/// [`Hash`]: ../../std/hash/trait.Hash.html
+/// [`Hash`]: crate::hash::Hash
 /// [`HashMap<K, V>`]: ../../std/collections/struct.HashMap.html
 /// [`String`]: ../../std/string/struct.String.html
-/// [`str`]: ../../std/primitive.str.html
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait Borrow<Borrowed: ?Sized> {
     /// Immutably borrows from an owned value.
@@ -187,7 +185,7 @@ pub trait Borrow<Borrowed: ?Sized> {
 /// an underlying type by providing a mutable reference. See [`Borrow<T>`]
 /// for more information on borrowing as another type.
 ///
-/// [`Borrow<T>`]: trait.Borrow.html
+/// [`Borrow<T>`]: Borrow
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait BorrowMut<Borrowed: ?Sized>: Borrow<Borrowed> {
     /// Mutably borrows from an owned value.


### PR DESCRIPTION
Helps with #75080.

@rustbot modify labels: T-doc, A-intra-doc-links, T-rustdoc

Known issues:

* Links from `core` to `std` (#74481):
    * [`Box<T>`]
    * [`Mutex<T>`]
    * [`Rc<T>`]
    * [`String`]
    * [`HashMap<K, V>`]
