### PR TITLE
Use intra-doc links in /library/core/src/cmp.rs

### DIFF
--- a/library/core/src/cmp.rs
+++ b/library/core/src/cmp.rs
@@ -17,12 +17,6 @@
 //!
 //! For more details, see the respective documentation of each item in the list.
 //!
-//! [`Eq`]: trait.Eq.html
-//! [`PartialEq`]: trait.PartialEq.html
-//! [`Ord`]: trait.Ord.html
-//! [`PartialOrd`]: trait.PartialOrd.html
-//! [`Ordering`]: enum.Ordering.html
-//! [`Reverse`]: struct.Reverse.html
 //! [`max`]: fn.max.html
 //! [`min`]: fn.min.html
 

--- a/library/core/src/cmp.rs
+++ b/library/core/src/cmp.rs
@@ -17,8 +17,8 @@
 //!
 //! For more details, see the respective documentation of each item in the list.
 //!
-//! [`max`]: fn.max.html
-//! [`min`]: fn.min.html
+//! [`max`]: Ord::max
+//! [`min`]: Ord::min
 
 #![stable(feature = "rust1", since = "1.0.0")]
 


### PR DESCRIPTION
Helps with #75080.

@rustbot modify labels: T-doc, A-intra-doc-links, T-rustdoc

Known issues:

* Links from `core` to `std` (#74481):
    * [`Vec::sort_by_key`]