### PR TITLE
Re-enable wasm32 tests in CI

### DIFF
--- a/src/ci/docker/host-x86_64/wasm32/Dockerfile
+++ b/src/ci/docker/host-x86_64/wasm32/Dockerfile
@@ -50,12 +50,4 @@ ENV EMCC_CFLAGS=-O1
 # Emscripten installation is user-specific
 ENV NO_CHANGE_USER=1
 
-# FIXME: Re-enable these tests once https://github.com/rust-lang/cargo/pull/7476
-# is picked up by CI
-ENV SCRIPT python3 ../x.py test --stage 2 --target $TARGETS \
-    --exclude library/core \
-    --exclude library/alloc \
-    --exclude library/proc_macro \
-    --exclude library/std \
-    --exclude library/term \
-    --exclude library/test
+ENV SCRIPT python3 ../x.py test --stage 2 --target $TARGETS

--- a/src/test/run-make/wasm-stringify-ints-small/Makefile
+++ b/src/test/run-make/wasm-stringify-ints-small/Makefile
@@ -1,10 +1,8 @@
+# only-wasm32-bare
+
 -include ../../run-make-fulldeps/tools.mk
 
-ifeq ($(TARGET),wasm32-unknown-unknown)
 all:
 	$(RUSTC) foo.rs -C lto -O --target wasm32-unknown-unknown
 	wc -c < $(TMPDIR)/foo.wasm
 	[ "`wc -c < $(TMPDIR)/foo.wasm`" -lt "25000" ]
-else
-all:
-endif


### PR DESCRIPTION
These were previously disabled but the [relevant fix] in Cargo has
long since landed. The wasm32 builder is hovering at around 35 
minutes right now, so we have capacity to do this.

[relevant fix]: https://github.com/rust-lang/cargo/pull/7476

r? @alexcrichton 