### PR TITLE
Add a function to `TyCtxt` for computing an `Allocation` for a `static` item's initializer

### DIFF
--- a/src/librustc_mir/interpret/mod.rs
+++ b/src/librustc_mir/interpret/mod.rs
@@ -21,7 +21,7 @@ pub use rustc_middle::mir::interpret::*; // have all the `interpret` symbols in 
 pub use self::eval_context::{Frame, FrameInfo, InterpCx, LocalState, LocalValue, StackPopCleanup};
 pub use self::intern::{intern_const_alloc_recursive, InternKind};
 pub use self::machine::{compile_time_machine, AllocMap, Machine, MayLeak, StackPopJump};
-pub use self::memory::{get_static, AllocCheck, FnVal, Memory, MemoryKind};
+pub use self::memory::{AllocCheck, FnVal, Memory, MemoryKind};
 pub use self::operand::{ImmTy, Immediate, OpTy, Operand};
 pub use self::place::{MPlaceTy, MemPlace, MemPlaceMeta, Place, PlaceTy};
 pub use self::validity::RefTracking;


### PR DESCRIPTION
r? @RalfJung 

miri-side: https://github.com/rust-lang/miri/issues/1507

split out of https://github.com/rust-lang/rust/pull/74949#discussion_r468100991 to make that PR leaner