### PR TITLE
Ignore gated-plugin test on stage1

### DIFF
--- a/src/test/ui-fulldeps/gated-plugin.rs
+++ b/src/test/ui-fulldeps/gated-plugin.rs
@@ -1,4 +1,5 @@
 // aux-build:empty-plugin.rs
+// ignore-stage1
 
 #![plugin(empty_plugin)]
 //~^ ERROR compiler plugins are deprecated

--- a/src/test/ui-fulldeps/gated-plugin.stderr
+++ b/src/test/ui-fulldeps/gated-plugin.stderr
@@ -1,5 +1,5 @@
 error[E0658]: compiler plugins are deprecated
-  --> $DIR/gated-plugin.rs:3:1
+  --> $DIR/gated-plugin.rs:4:1
    |
 LL | #![plugin(empty_plugin)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -8,7 +8,7 @@ LL | #![plugin(empty_plugin)]
    = help: add `#![feature(plugin)]` to the crate attributes to enable
 
 warning: use of deprecated attribute `plugin`: compiler plugins are deprecated. See https://github.com/rust-lang/rust/pull/64675
-  --> $DIR/gated-plugin.rs:3:1
+  --> $DIR/gated-plugin.rs:4:1
    |
 LL | #![plugin(empty_plugin)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^ help: may be removed in a future compiler version


### PR DESCRIPTION
Just like other `#![plugin(...)]` tests it requires stage2 to work correctly.