### PR TITLE
use type folder + normalization for MIR assignment type-checking

### DIFF
--- a/src/librustc_mir/transform/validate.rs
+++ b/src/librustc_mir/transform/validate.rs
@@ -7,11 +7,7 @@ use rustc_middle::{
         BasicBlock, Body, Location, Operand, Rvalue, Statement, StatementKind, Terminator,
         TerminatorKind,
     },
-    ty::{
-        self,
-        relate::{Relate, RelateResult, TypeRelation},
-        ParamEnv, Ty, TyCtxt,
-    },
+    ty::{self, fold::BottomUpFolder, ParamEnv, Ty, TyCtxt, TypeFoldable},
 };
 
 #[derive(Copy, Clone, Debug)]
@@ -49,79 +45,24 @@ pub fn equal_up_to_regions(
         return true;
     }
 
-    struct LifetimeIgnoreRelation<'tcx> {
-        tcx: TyCtxt<'tcx>,
-        param_env: ty::ParamEnv<'tcx>,
-    }
-
-    impl TypeRelation<'tcx> for LifetimeIgnoreRelation<'tcx> {
-        fn tcx(&self) -> TyCtxt<'tcx> {
-            self.tcx
-        }
-
-        fn param_env(&self) -> ty::ParamEnv<'tcx> {
-            self.param_env
-        }
-
-        fn tag(&self) -> &'static str {
-            "librustc_mir::transform::validate"
-        }
-
-        fn a_is_expected(&self) -> bool {
-            true
-        }
-
-        fn relate_with_variance<T: Relate<'tcx>>(
-            &mut self,
-            _: ty::Variance,
-            a: T,
-            b: T,
-        ) -> RelateResult<'tcx, T> {
-            // Ignore variance, require types to be exactly the same.
-            self.relate(a, b)
-        }
-
-        fn tys(&mut self, a: Ty<'tcx>, b: Ty<'tcx>) -> RelateResult<'tcx, Ty<'tcx>> {
-            if a == b {
-                // Short-circuit.
-                return Ok(a);
-            }
-            ty::relate::super_relate_tys(self, a, b)
-        }
-
-        fn regions(
-            &mut self,
-            a: ty::Region<'tcx>,
-            _b: ty::Region<'tcx>,
-        ) -> RelateResult<'tcx, ty::Region<'tcx>> {
-            // Ignore regions.
-            Ok(a)
-        }
-
-        fn consts(
-            &mut self,
-            a: &'tcx ty::Const<'tcx>,
-            b: &'tcx ty::Const<'tcx>,
-        ) -> RelateResult<'tcx, &'tcx ty::Const<'tcx>> {
-            ty::relate::super_relate_consts(self, a, b)
-        }
-
-        fn binders<T>(
-            &mut self,
-            a: ty::Binder<T>,
-            b: ty::Binder<T>,
-        ) -> RelateResult<'tcx, ty::Binder<T>>
-        where
-            T: Relate<'tcx>,
-        {
-            self.relate(a.skip_binder(), b.skip_binder())?;
-            Ok(a)
-        }
-    }
-
-    // Instantiate and run relation.
-    let mut relator: LifetimeIgnoreRelation<'tcx> = LifetimeIgnoreRelation { tcx: tcx, param_env };
-    relator.relate(src, dest).is_ok()
+    // Normalize lifetimes away on both sides, then compare.
+    let param_env = param_env.with_reveal_all_normalized(tcx);
+    let normalize = |ty: Ty<'tcx>| {
+        tcx.normalize_erasing_regions(
+            param_env,
+            ty.fold_with(&mut BottomUpFolder {
+                tcx,
+                // We just erase all late-bound lifetimes, but this is not fully correct (FIXME):
+                // lifetimes in invariant positions could matter (e.g. through associated types).
+                // We rely on the fact that layout was confirmed to be equal above.
+                lt_op: |_| tcx.lifetimes.re_erased,
+                // Leave consts and types unchanged.
+                ct_op: |ct| ct,
+                ty_op: |ty| ty,
+            }),
+        )
+    };
+    normalize(src) == normalize(dest)
 }
 
 struct TypeChecker<'a, 'tcx> {

--- a/src/test/ui/mir/validation_impl_trait_lifetime.rs
+++ b/src/test/ui/mir/validation_impl_trait_lifetime.rs
@@ -1,0 +1,10 @@
+// build-pass
+//! This used to fail MIR validation due to the types on both sides of an assignment not being equal.
+//! The failure doesn't occur with a check-only build.
+fn iter_slice<'a, T>(xs: &'a [T]) -> impl Iterator<Item = &'a T> {
+    xs.iter()
+}
+
+fn main() {
+    iter_slice::<()> as fn(_) -> _;
+}

--- a/src/test/ui/mir/validation_impl_trait_lifetime.rs
+++ b/src/test/ui/mir/validation_impl_trait_lifetime.rs
@@ -1,5 +1,6 @@
 // build-pass
-//! This used to fail MIR validation due to the types on both sides of an assignment not being equal.
+//! This used to fail MIR validation due to the types on both sides of
+//! an assignment not being equal.
 //! The failure doesn't occur with a check-only build.
 fn iter_slice<'a, T>(xs: &'a [T]) -> impl Iterator<Item = &'a T> {
     xs.iter()


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/75313
Thanks to @eddyb who did all the hard work, I just implemented his suggestions.^^

@lcnr  Unfortunately this loses the type relator, we normalize the entire thing instead. There might be a perf hit.