### PR TITLE
Accept more safety comments

### DIFF
--- a/src/tools/tidy/src/style.rs
+++ b/src/tools/tidy/src/style.rs
@@ -263,7 +263,7 @@ pub fn check(path: &Path, bad: &mut bool) {
                     suppressible_tidy_err!(err, skip_undocumented_unsafe, "undocumented unsafe");
                 }
             }
-            if line.contains("// SAFETY: ") || line.contains("// Safety: ") {
+            if line.contains("// SAFETY:") || line.contains("// Safety:") {
                 last_safety_comment = true;
             } else if line.trim().starts_with("//") || line.trim().is_empty() {
                 // keep previous value


### PR DESCRIPTION
This accepts more `// SAFETY:` comments from `tidy`.

This is done after the current behaviour of requiring text one the same line (because spaces are stripped so the last space never pass if there is no text on the same line) bit me once more in #75066 

This could potentially accept empty `// SAFETY:` comments but `tidy` is an internal tool used only here so my reasoning is reviews will catch those.