### PR TITLE
Move to intra-doc links for /library/core/src/hint.rs

### DIFF
--- a/library/core/src/hint.rs
+++ b/library/core/src/hint.rs
@@ -24,7 +24,6 @@ use crate::intrinsics;
 /// Otherwise, consider using the [`unreachable!`] macro, which does not allow
 /// optimizations but will panic when executed.
 ///
-/// [`unreachable!`]: unreachable
 ///
 /// # Example
 ///

--- a/library/core/src/hint.rs
+++ b/library/core/src/hint.rs
@@ -24,7 +24,7 @@ use crate::intrinsics;
 /// Otherwise, consider using the [`unreachable!`] macro, which does not allow
 /// optimizations but will panic when executed.
 ///
-/// [`unreachable!`]: ../macro.unreachable.html
+/// [`unreachable!`]: unreachable
 ///
 /// # Example
 ///
@@ -61,7 +61,7 @@ pub const unsafe fn unreachable_unchecked() -> ! {
 /// **Note**: On platforms that do not support receiving spin-loop hints this function does not
 /// do anything at all.
 ///
-/// [`core::sync::atomic::spin_loop_hint`]: ../sync/atomic/fn.spin_loop_hint.html
+/// [`core::sync::atomic::spin_loop_hint`]: crate::sync::atomic::spin_loop_hint
 #[inline]
 #[unstable(feature = "renamed_spin_loop", issue = "55002")]
 pub fn spin_loop() {
@@ -99,7 +99,7 @@ pub fn spin_loop() {
 /// An identity function that *__hints__* to the compiler to be maximally pessimistic about what
 /// `black_box` could do.
 ///
-/// [`std::convert::identity`]: https://doc.rust-lang.org/core/convert/fn.identity.html
+/// [`std::convert::identity`]: crate::convert::identity
 ///
 /// Unlike [`std::convert::identity`], a Rust compiler is encouraged to assume that `black_box` can
 /// use `x` in any possible valid way that Rust code is allowed to without introducing undefined

--- a/library/core/src/hint.rs
+++ b/library/core/src/hint.rs
@@ -99,7 +99,7 @@ pub fn spin_loop() {
 /// An identity function that *__hints__* to the compiler to be maximally pessimistic about what
 /// `black_box` could do.
 ///
-/// [`std::convert::identity`]: crate::convert::identity
+/// [`std::convert::identity`]: https://doc.rust-lang.org/core/convert/fn.identity.html
 ///
 /// Unlike [`std::convert::identity`], a Rust compiler is encouraged to assume that `black_box` can
 /// use `x` in any possible valid way that Rust code is allowed to without introducing undefined


### PR DESCRIPTION
Helps with #75080.

@rustbot modify labels: T-doc, A-intra-doc-links, T-rustdoc