### PR TITLE
Add fix to error msg which relied on order

### DIFF
--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -826,6 +826,8 @@ pub struct GenericParamCount {
     pub lifetimes: usize,
     pub types: usize,
     pub consts: usize,
+
+    pub type_defaults: usize,
 }
 
 /// Information about the formal type/lifetime parameters associated
@@ -861,7 +863,10 @@ impl<'tcx> Generics {
         for param in &self.params {
             match param.kind {
                 GenericParamDefKind::Lifetime => own_counts.lifetimes += 1,
-                GenericParamDefKind::Type { .. } => own_counts.types += 1,
+                GenericParamDefKind::Type { has_default, .. } => {
+                    own_counts.types += 1;
+                    own_counts.type_defaults += has_default as usize;
+                }
                 GenericParamDefKind::Const => own_counts.consts += 1,
             };
         }

--- a/src/test/ui/const-generics/defaults/intermixed-correct-error.rs
+++ b/src/test/ui/const-generics/defaults/intermixed-correct-error.rs
@@ -1,0 +1,88 @@
+// Check that ordering of errors is correctly reported even with consts preceding types.
+
+#![feature(const_generics)]
+#![allow(incomplete_features)]
+
+struct Example<'a, const N: usize, T=f32> {
+  s: &'a T,
+}
+
+type Consts = Example<3, 3, 3>;
+//~^ ERROR missing lifetime specifier
+//~| ERROR wrong number of const arguments
+type Types = Example<f32, f32, f32>;
+//~^ ERROR missing lifetime specifier
+//~| ERROR wrong number of const arguments
+//~| ERROR wrong number of type arguments
+type Lifetimes = Example<'static, 'static, 'static>;
+//~^ ERROR wrong number of const arguments
+//~| ERROR misplaced type arguments
+//~| wrong number of lifetime
+
+type LtConst1 = Example<'static, 3, 3>;
+//~^ ERROR wrong number of const arguments
+type LtConst2 = Example<3, 'static, 3>;
+//~^ ERROR wrong number of const arguments
+type LtConst3 = Example<3, 3, 'static>;
+//~^ ERROR misplaced type arguments
+
+type LtTy1 = Example<'static, f32, f32>;
+//~^ ERROR wrong number of const arguments
+//~| ERROR wrong number of type arguments
+type LtTy2 = Example<f32, 'static, f32>;
+//~^ ERROR wrong number of const arguments
+//~| ERROR wrong number of type arguments
+type LtTy3 = Example<f32, f32, 'static>;
+//~^ ERROR wrong number of const arguments
+//~| ERROR wrong number of type arguments
+
+type ConstTy1 = Example<3, f32, f32>;
+//~^ ERROR missing lifetime specifier
+//~| ERROR wrong number of type arguments
+type ConstTy2 = Example<f32, 3, f32>;
+//~^ ERROR missing lifetime specifier
+//~| ERROR wrong number of type arguments
+type ConstTy3 = Example<f32, f32, 3>;
+//~^ ERROR missing lifetime specifier
+//~| ERROR wrong number of type arguments
+
+type ConstLt1 = Example<3, 'static, 'static>;
+//~^ ERROR wrong number of lifetime
+type ConstLt2 = Example<'static, 3, 'static>;
+//~^ ERROR wrong number of lifetime
+type ConstLt3 = Example<'static, 'static, 3>;
+//~^ ERROR wrong number of lifetime
+
+type TyLt1 = Example<f32, 'static, 'static>;
+//~^ ERROR wrong number of lifetime
+//~| ERROR wrong number of const
+//~| ERROR misplaced type arguments
+type TyLt2 = Example<'static, f32, 'static>;
+//~^ ERROR wrong number of lifetime
+//~| ERROR wrong number of const
+//~| ERROR misplaced type arguments
+type TyLt3 = Example<'static, 'static, f32>;
+//~^ ERROR wrong number of const
+//~| ERROR wrong number of lifetime
+
+type TyConst1 = Example<f32, 3, 3>;
+//~^ ERROR missing lifetime specifier
+//~| ERROR wrong number of const
+//~| ERROR misplaced type arguments
+type TyConst2 = Example<3, f32, 3>;
+//~^ ERROR missing lifetime specifier
+//~| ERROR wrong number of const
+type TyConst3 = Example<3, 3, f32>;
+//~^ ERROR missing lifetime specifier
+//~| ERROR wrong number of const
+//~| ERROR misplaced type arguments
+
+type Intermixed1 = Example<'static, 3, f32>; // ok
+
+
+type Intermixed2 = Example<f32, 'static, 3>;
+//~^ ERROR type provided when a constant was expected
+type Intermixed3 = Example<3, f32, 'static>;
+//~^ ERROR constant provided when a lifetime
+
+fn main() {}

--- a/src/test/ui/const-generics/defaults/intermixed-correct-error.stderr
+++ b/src/test/ui/const-generics/defaults/intermixed-correct-error.stderr
@@ -1,0 +1,407 @@
+error[E0106]: missing lifetime specifier
+  --> $DIR/intermixed-correct-error.rs:10:23
+   |
+LL | type Consts = Example<3, 3, 3>;
+   |                       ^ expected named lifetime parameter
+   |
+help: consider introducing a named lifetime parameter
+   |
+LL | type Consts<'a> = Example<'a, 3, 3, 3>;
+   |            ^^^^           ^^^
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/intermixed-correct-error.rs:13:22
+   |
+LL | type Types = Example<f32, f32, f32>;
+   |                      ^ expected named lifetime parameter
+   |
+help: consider introducing a named lifetime parameter
+   |
+LL | type Types<'a> = Example<'a, f32, f32, f32>;
+   |           ^^^^           ^^^
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/intermixed-correct-error.rs:39:25
+   |
+LL | type ConstTy1 = Example<3, f32, f32>;
+   |                         ^ expected named lifetime parameter
+   |
+help: consider introducing a named lifetime parameter
+   |
+LL | type ConstTy1<'a> = Example<'a, 3, f32, f32>;
+   |              ^^^^           ^^^
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/intermixed-correct-error.rs:42:25
+   |
+LL | type ConstTy2 = Example<f32, 3, f32>;
+   |                         ^ expected named lifetime parameter
+   |
+help: consider introducing a named lifetime parameter
+   |
+LL | type ConstTy2<'a> = Example<'a, f32, 3, f32>;
+   |              ^^^^           ^^^
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/intermixed-correct-error.rs:45:25
+   |
+LL | type ConstTy3 = Example<f32, f32, 3>;
+   |                         ^ expected named lifetime parameter
+   |
+help: consider introducing a named lifetime parameter
+   |
+LL | type ConstTy3<'a> = Example<'a, f32, f32, 3>;
+   |              ^^^^           ^^^
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/intermixed-correct-error.rs:68:25
+   |
+LL | type TyConst1 = Example<f32, 3, 3>;
+   |                         ^ expected named lifetime parameter
+   |
+help: consider introducing a named lifetime parameter
+   |
+LL | type TyConst1<'a> = Example<'a, f32, 3, 3>;
+   |              ^^^^           ^^^
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/intermixed-correct-error.rs:72:25
+   |
+LL | type TyConst2 = Example<3, f32, 3>;
+   |                         ^ expected named lifetime parameter
+   |
+help: consider introducing a named lifetime parameter
+   |
+LL | type TyConst2<'a> = Example<'a, 3, f32, 3>;
+   |              ^^^^           ^^^
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/intermixed-correct-error.rs:75:25
+   |
+LL | type TyConst3 = Example<3, 3, f32>;
+   |                         ^ expected named lifetime parameter
+   |
+help: consider introducing a named lifetime parameter
+   |
+LL | type TyConst3<'a> = Example<'a, 3, 3, f32>;
+   |              ^^^^           ^^^
+
+error[E0107]: wrong number of const arguments: expected 1, found 3
+  --> $DIR/intermixed-correct-error.rs:10:26
+   |
+LL | type Consts = Example<3, 3, 3>;
+   |                          ^  ^ unexpected const argument
+   |                          |
+   |                          expected type, found const
+
+error[E0107]: wrong number of const arguments: expected 1, found 0
+  --> $DIR/intermixed-correct-error.rs:13:14
+   |
+LL | type Types = Example<f32, f32, f32>;
+   |              ^^^^^^^^^^^^^^^^^^^^^^ expected 1 const argument
+
+error[E0107]: wrong number of type arguments: expected at most 1, found 3
+  --> $DIR/intermixed-correct-error.rs:13:14
+   |
+LL | type Types = Example<f32, f32, f32>;
+   |              ^^^^^^^^^^^^^^^^^^^^^^
+   |              |       |         |
+   |              |       |         unexpected type argument
+   |              |       expected const, found type
+   |              expected at most 1 type argument
+   |
+help: If this generic argument was intended as a const parameter, try surrounding it with braces:
+   |
+LL | type Types = Example<{ f32 }, f32, f32>;
+   |                      ^     ^
+
+error[E0107]: wrong number of lifetime arguments: expected 1, found 3
+  --> $DIR/intermixed-correct-error.rs:17:35
+   |
+LL | type Lifetimes = Example<'static, 'static, 'static>;
+   |                                   ^^^^^^^  ^^^^^^^ unexpected lifetime argument
+   |                                   |
+   |                                   unexpected lifetime argument
+
+error[E0107]: wrong number of const arguments: expected 1, found 0
+  --> $DIR/intermixed-correct-error.rs:17:18
+   |
+LL | type Lifetimes = Example<'static, 'static, 'static>;
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                  |                |
+   |                  |                expected const, found lifetime
+   |                  expected 1 const argument
+
+error[E0107]: misplaced type arguments
+  --> $DIR/intermixed-correct-error.rs:17:18
+   |
+LL | type Lifetimes = Example<'static, 'static, 'static>;
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                  |                         |
+   |                  |                         expected type, found lifetime
+   |                  expected at most 1 type argument
+
+error[E0107]: wrong number of const arguments: expected 1, found 2
+  --> $DIR/intermixed-correct-error.rs:22:37
+   |
+LL | type LtConst1 = Example<'static, 3, 3>;
+   |                                     ^ expected type, found const
+
+error[E0107]: wrong number of const arguments: expected 1, found 2
+  --> $DIR/intermixed-correct-error.rs:24:28
+   |
+LL | type LtConst2 = Example<3, 'static, 3>;
+   |                            ^^^^^^^  ^ expected type, found const
+   |                            |
+   |                            expected const, found lifetime
+
+error[E0107]: wrong number of const arguments: expected 1, found 2
+
+error[E0107]: misplaced type arguments
+  --> $DIR/intermixed-correct-error.rs:26:17
+   |
+LL | type LtConst3 = Example<3, 3, 'static>;
+   |                 ^^^^^^^^^^^^^^^^^^^^^^
+   |                 |             |
+   |                 |             expected type, found lifetime
+   |                 expected at most 1 type argument
+
+error[E0107]: wrong number of const arguments: expected 1, found 0
+  --> $DIR/intermixed-correct-error.rs:29:14
+   |
+LL | type LtTy1 = Example<'static, f32, f32>;
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ expected 1 const argument
+
+error[E0107]: wrong number of type arguments: expected at most 1, found 2
+  --> $DIR/intermixed-correct-error.rs:29:14
+   |
+LL | type LtTy1 = Example<'static, f32, f32>;
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |              |                |
+   |              |                expected const, found type
+   |              expected at most 1 type argument
+   |
+help: If this generic argument was intended as a const parameter, try surrounding it with braces:
+   |
+LL | type LtTy1 = Example<'static, { f32 }, f32>;
+   |                               ^     ^
+
+error[E0107]: wrong number of const arguments: expected 1, found 0
+  --> $DIR/intermixed-correct-error.rs:32:14
+   |
+LL | type LtTy2 = Example<f32, 'static, f32>;
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |              |            |
+   |              |            expected const, found lifetime
+   |              expected 1 const argument
+
+error[E0107]: wrong number of type arguments: expected at most 1, found 2
+  --> $DIR/intermixed-correct-error.rs:32:14
+   |
+LL | type LtTy2 = Example<f32, 'static, f32>;
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ expected at most 1 type argument
+
+error[E0107]: wrong number of const arguments: expected 1, found 0
+  --> $DIR/intermixed-correct-error.rs:35:14
+   |
+LL | type LtTy3 = Example<f32, f32, 'static>;
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ expected 1 const argument
+
+error[E0107]: wrong number of type arguments: expected at most 1, found 2
+  --> $DIR/intermixed-correct-error.rs:35:14
+   |
+LL | type LtTy3 = Example<f32, f32, 'static>;
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |              |            |    |
+   |              |            |    expected type, found lifetime
+   |              |            expected const, found type
+   |              expected at most 1 type argument
+   |
+help: If this generic argument was intended as a const parameter, try surrounding it with braces:
+   |
+LL | type LtTy3 = Example<f32, { f32 }, 'static>;
+   |                           ^     ^
+
+error[E0107]: wrong number of type arguments: expected at most 1, found 2
+  --> $DIR/intermixed-correct-error.rs:39:17
+   |
+LL | type ConstTy1 = Example<3, f32, f32>;
+   |                 ^^^^^^^^^^^^^^^^^^^^
+   |                 |               |
+   |                 |               unexpected type argument
+   |                 expected at most 1 type argument
+
+error[E0107]: wrong number of type arguments: expected at most 1, found 2
+  --> $DIR/intermixed-correct-error.rs:42:17
+   |
+LL | type ConstTy2 = Example<f32, 3, f32>;
+   |                 ^^^^^^^^^^^^^^^^^^^^
+   |                 |       |       |
+   |                 |       |       unexpected type argument
+   |                 |       expected const, found type
+   |                 expected at most 1 type argument
+   |
+help: If this generic argument was intended as a const parameter, try surrounding it with braces:
+   |
+LL | type ConstTy2 = Example<{ f32 }, 3, f32>;
+   |                         ^     ^
+
+error[E0107]: wrong number of type arguments: expected at most 1, found 2
+  --> $DIR/intermixed-correct-error.rs:45:17
+   |
+LL | type ConstTy3 = Example<f32, f32, 3>;
+   |                 ^^^^^^^^^^^^^^^^^^^^
+   |                 |       |
+   |                 |       expected const, found type
+   |                 expected at most 1 type argument
+   |
+help: If this generic argument was intended as a const parameter, try surrounding it with braces:
+   |
+LL | type ConstTy3 = Example<{ f32 }, f32, 3>;
+   |                         ^     ^
+
+error[E0107]: wrong number of lifetime arguments: expected 1, found 2
+  --> $DIR/intermixed-correct-error.rs:49:28
+   |
+LL | type ConstLt1 = Example<3, 'static, 'static>;
+   |                            ^^^^^^^ unexpected lifetime argument
+
+error[E0107]: wrong number of lifetime arguments: expected 1, found 2
+  --> $DIR/intermixed-correct-error.rs:51:37
+   |
+LL | type ConstLt2 = Example<'static, 3, 'static>;
+   |                                     ^^^^^^^ unexpected lifetime argument
+
+error[E0107]: wrong number of lifetime arguments: expected 1, found 2
+  --> $DIR/intermixed-correct-error.rs:53:34
+   |
+LL | type ConstLt3 = Example<'static, 'static, 3>;
+   |                                  ^^^^^^^ unexpected lifetime argument
+
+error[E0107]: wrong number of lifetime arguments: expected 1, found 2
+  --> $DIR/intermixed-correct-error.rs:56:27
+   |
+LL | type TyLt1 = Example<f32, 'static, 'static>;
+   |                           ^^^^^^^ unexpected lifetime argument
+
+error[E0107]: wrong number of const arguments: expected 1, found 0
+  --> $DIR/intermixed-correct-error.rs:56:14
+   |
+LL | type TyLt1 = Example<f32, 'static, 'static>;
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |              |            |
+   |              |            expected const, found lifetime
+   |              expected 1 const argument
+
+error[E0107]: misplaced type arguments
+  --> $DIR/intermixed-correct-error.rs:56:14
+   |
+LL | type TyLt1 = Example<f32, 'static, 'static>;
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |              |                     |
+   |              |                     expected type, found lifetime
+   |              expected at most 1 type argument
+
+error[E0107]: wrong number of lifetime arguments: expected 1, found 2
+  --> $DIR/intermixed-correct-error.rs:60:36
+   |
+LL | type TyLt2 = Example<'static, f32, 'static>;
+   |                                    ^^^^^^^ unexpected lifetime argument
+
+error[E0107]: wrong number of const arguments: expected 1, found 0
+  --> $DIR/intermixed-correct-error.rs:60:14
+   |
+LL | type TyLt2 = Example<'static, f32, 'static>;
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected 1 const argument
+
+error[E0107]: misplaced type arguments
+  --> $DIR/intermixed-correct-error.rs:60:14
+   |
+LL | type TyLt2 = Example<'static, f32, 'static>;
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |              |                |    |
+   |              |                |    expected type, found lifetime
+   |              |                expected const, found type
+   |              expected at most 1 type argument
+   |
+help: If this generic argument was intended as a const parameter, try surrounding it with braces:
+   |
+LL | type TyLt2 = Example<'static, { f32 }, 'static>;
+   |                               ^     ^
+
+error[E0107]: wrong number of lifetime arguments: expected 1, found 2
+  --> $DIR/intermixed-correct-error.rs:64:31
+   |
+LL | type TyLt3 = Example<'static, 'static, f32>;
+   |                               ^^^^^^^ unexpected lifetime argument
+
+error[E0107]: wrong number of const arguments: expected 1, found 0
+  --> $DIR/intermixed-correct-error.rs:64:14
+   |
+LL | type TyLt3 = Example<'static, 'static, f32>;
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |              |                |
+   |              |                expected const, found lifetime
+   |              expected 1 const argument
+
+error[E0107]: wrong number of const arguments: expected 1, found 2
+  --> $DIR/intermixed-correct-error.rs:68:30
+   |
+LL | type TyConst1 = Example<f32, 3, 3>;
+   |                              ^  ^ unexpected const argument
+   |                              |
+   |                              expected type, found const
+
+error[E0107]: misplaced type arguments
+  --> $DIR/intermixed-correct-error.rs:68:17
+   |
+LL | type TyConst1 = Example<f32, 3, 3>;
+   |                 ^^^^^^^^^^^^^^^^^^
+   |                 |       |
+   |                 |       expected const, found type
+   |                 expected at most 1 type argument
+   |
+help: If this generic argument was intended as a const parameter, try surrounding it with braces:
+   |
+LL | type TyConst1 = Example<{ f32 }, 3, 3>;
+   |                         ^     ^
+
+error[E0107]: wrong number of const arguments: expected 1, found 2
+  --> $DIR/intermixed-correct-error.rs:72:33
+   |
+LL | type TyConst2 = Example<3, f32, 3>;
+   |                                 ^ unexpected const argument
+
+error[E0107]: wrong number of const arguments: expected 1, found 2
+  --> $DIR/intermixed-correct-error.rs:75:28
+   |
+LL | type TyConst3 = Example<3, 3, f32>;
+   |                            ^ expected type, found const
+
+error[E0107]: misplaced type arguments
+  --> $DIR/intermixed-correct-error.rs:75:17
+   |
+LL | type TyConst3 = Example<3, 3, f32>;
+   |                 ^^^^^^^^^^^^^^^^^^
+   |                 |             |
+   |                 |             unexpected type argument
+   |                 expected at most 1 type argument
+
+error[E0747]: type provided when a constant was expected
+  --> $DIR/intermixed-correct-error.rs:83:28
+   |
+LL | type Intermixed2 = Example<f32, 'static, 3>;
+   |                            ^^^
+
+error[E0747]: constant provided when a lifetime was expected
+  --> $DIR/intermixed-correct-error.rs:85:28
+   |
+LL | type Intermixed3 = Example<3, f32, 'static>;
+   |                            ^
+   |
+   = note: lifetime arguments must be provided before constant arguments
+
+error: aborting due to 45 previous errors
+
+Some errors have detailed explanations: E0106, E0107, E0747.
+For more information about an error, try `rustc --explain E0106`.

--- a/src/test/ui/const-generics/invalid-enum.stderr
+++ b/src/test/ui/const-generics/invalid-enum.stderr
@@ -35,7 +35,10 @@ error[E0107]: wrong number of type arguments: expected at most 1, found 2
   --> $DIR/invalid-enum.rs:31:10
    |
 LL |   let _: Example<CompileFlag::A, _> = Example { x: 0 };
-   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^ expected at most 1 type argument
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |          |       |
+   |          |       expected const, found type
+   |          expected at most 1 type argument
    |
 help: If this generic argument was intended as a const parameter, try surrounding it with braces:
    |
@@ -52,7 +55,10 @@ error[E0107]: wrong number of type arguments: expected at most 1, found 2
   --> $DIR/invalid-enum.rs:36:10
    |
 LL |   let _: Example<Example::ASSOC_FLAG, _> = Example { x: 0 };
-   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected at most 1 type argument
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |          |       |
+   |          |       expected const, found type
+   |          expected at most 1 type argument
    |
 help: If this generic argument was intended as a const parameter, try surrounding it with braces:
    |
@@ -69,7 +75,7 @@ error[E0107]: wrong number of type arguments: expected 0, found 1
   --> $DIR/invalid-enum.rs:21:12
    |
 LL |   test_1::<CompileFlag::A>();
-   |            ^^^^^^^^^^^^^^ unexpected type argument
+   |            ^^^^^^^^^^^^^^ expected const, found type
    |
 help: If this generic argument was intended as a const parameter, try surrounding it with braces:
    |
@@ -86,7 +92,7 @@ error[E0107]: wrong number of type arguments: expected 1, found 2
   --> $DIR/invalid-enum.rs:26:15
    |
 LL |   test_2::<_, CompileFlag::A>(0);
-   |               ^^^^^^^^^^^^^^ unexpected type argument
+   |               ^^^^^^^^^^^^^^ expected const, found type
    |
 help: If this generic argument was intended as a const parameter, try surrounding it with braces:
    |

--- a/src/test/ui/const-generics/issues/issue-62878.full.stderr
+++ b/src/test/ui/const-generics/issues/issue-62878.full.stderr
@@ -14,7 +14,7 @@ error[E0107]: wrong number of type arguments: expected 0, found 1
   --> $DIR/issue-62878.rs:11:11
    |
 LL |     foo::<_, {[1]}>();
-   |           ^ unexpected type argument
+   |           ^ expected const, found type
 
 error[E0308]: mismatched types
   --> $DIR/issue-62878.rs:11:15

--- a/src/test/ui/const-generics/min_const_generics/const-expression-suggest-missing-braces.stderr
+++ b/src/test/ui/const-generics/min_const_generics/const-expression-suggest-missing-braces.stderr
@@ -149,7 +149,7 @@ error[E0107]: wrong number of type arguments: expected 0, found 1
   --> $DIR/const-expression-suggest-missing-braces.rs:13:11
    |
 LL |     foo::<BAR + BAR>();
-   |           ^^^^^^^^^ unexpected type argument
+   |           ^^^^^^^^^ expected const, found type
 
 error: aborting due to 15 previous errors; 1 warning emitted
 

--- a/src/test/ui/generic-associated-types/parameter_number_and_kind.stderr
+++ b/src/test/ui/generic-associated-types/parameter_number_and_kind.stderr
@@ -8,7 +8,10 @@ error[E0107]: wrong number of type arguments: expected 1, found 0
   --> $DIR/parameter_number_and_kind.rs:13:18
    |
 LL |     type FErr1 = Self::E<'static, 'static>;
-   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^ expected 1 type argument
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                  |                |
+   |                  |                expected type, found lifetime
+   |                  expected 1 type argument
 
 error[E0107]: wrong number of type arguments: expected 1, found 2
   --> $DIR/parameter_number_and_kind.rs:16:41

--- a/src/test/ui/generics/generic-impl-more-params-with-defaults.stderr
+++ b/src/test/ui/generics/generic-impl-more-params-with-defaults.stderr
@@ -2,7 +2,10 @@ error[E0107]: wrong number of type arguments: expected at most 2, found 3
   --> $DIR/generic-impl-more-params-with-defaults.rs:13:5
    |
 LL |     Vec::<isize, Heap, bool>::new();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected at most 2 type arguments
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     |                  |
+   |     |                  unexpected type argument
+   |     expected at most 2 type arguments
 
 error: aborting due to previous error
 

--- a/src/test/ui/generics/generic-type-more-params-with-defaults.stderr
+++ b/src/test/ui/generics/generic-type-more-params-with-defaults.stderr
@@ -2,7 +2,10 @@ error[E0107]: wrong number of type arguments: expected at most 2, found 3
   --> $DIR/generic-type-more-params-with-defaults.rs:9:12
    |
 LL |     let _: Vec<isize, Heap, bool>;
-   |            ^^^^^^^^^^^^^^^^^^^^^^ expected at most 2 type arguments
+   |            ^^^^^^^^^^^^^^^^^^^^^^
+   |            |                |
+   |            |                unexpected type argument
+   |            expected at most 2 type arguments
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-23024.stderr
+++ b/src/test/ui/issues/issue-23024.stderr
@@ -17,7 +17,7 @@ error[E0191]: the value of the associated type `Output` (from trait `FnOnce`) mu
   --> $DIR/issue-23024.rs:9:39
    |
 LL |     println!("{:?}",(vfnfer[0] as dyn Fn)(3));
-   |                                       ^^ help: specify the associated type: `Fn<Output = Type>`
+   |                                       ^^ help: specify the associated type: `Output = Fn`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/privacy/privacy-ns1.stderr
+++ b/src/test/ui/privacy/privacy-ns1.stderr
@@ -56,7 +56,7 @@ error[E0107]: wrong number of const arguments: expected 0, found 1
   --> $DIR/privacy-ns1.rs:35:17
    |
 LL |     let _x: Box<Bar>;
-   |                 ^^^ unexpected const argument
+   |                 ^^^ expected type, found const
 
 error[E0107]: wrong number of type arguments: expected at least 1, found 0
   --> $DIR/privacy-ns1.rs:35:13

--- a/src/test/ui/privacy/privacy-ns2.stderr
+++ b/src/test/ui/privacy/privacy-ns2.stderr
@@ -82,7 +82,7 @@ error[E0107]: wrong number of const arguments: expected 0, found 1
   --> $DIR/privacy-ns2.rs:41:18
    |
 LL |     let _x : Box<Bar>;
-   |                  ^^^ unexpected const argument
+   |                  ^^^ expected type, found const
 
 error[E0107]: wrong number of type arguments: expected at least 1, found 0
   --> $DIR/privacy-ns2.rs:41:14
@@ -94,7 +94,7 @@ error[E0107]: wrong number of const arguments: expected 0, found 1
   --> $DIR/privacy-ns2.rs:49:17
    |
 LL |     let _x: Box<Bar>;
-   |                 ^^^ unexpected const argument
+   |                 ^^^ expected type, found const
 
 error[E0107]: wrong number of type arguments: expected at least 1, found 0
   --> $DIR/privacy-ns2.rs:49:13

--- a/src/test/ui/traits/trait-object-vs-lifetime.stderr
+++ b/src/test/ui/traits/trait-object-vs-lifetime.stderr
@@ -14,7 +14,10 @@ error[E0107]: wrong number of type arguments: expected 1, found 0
   --> $DIR/trait-object-vs-lifetime.rs:11:12
    |
 LL |     let _: S<'static, 'static>;
-   |            ^^^^^^^^^^^^^^^^^^^ expected 1 type argument
+   |            ^^^^^^^^^^^^^^^^^^^
+   |            |          |
+   |            |          expected type, found lifetime
+   |            expected 1 type argument
 
 error[E0224]: at least one trait is required for an object type
   --> $DIR/trait-object-vs-lifetime.rs:14:14


### PR DESCRIPTION
Previously types needed to be ordered before consts. Since relaxing that restriction, this
created a bug wherever relying on that. This produces a strange error message, so it's not awful
but should still be fixed.

I rushed a bit to make this PR, but I'll look more closely if there's better ways to write tmrw morning.

r? @lcnr
