### PR TITLE
WIP: check that required_consts really contains all required consts

### DIFF
--- a/src/librustc_codegen_ssa/mir/operand.rs
+++ b/src/librustc_codegen_ssa/mir/operand.rs
@@ -6,9 +6,8 @@ use crate::glue;
 use crate::traits::*;
 use crate::MemFlags;
 
-use rustc_errors::ErrorReported;
 use rustc_middle::mir;
-use rustc_middle::mir::interpret::{ConstValue, ErrorHandled, Pointer, Scalar};
+use rustc_middle::mir::interpret::{ConstValue, Pointer, Scalar};
 use rustc_middle::ty::layout::TyAndLayout;
 use rustc_middle::ty::Ty;
 use rustc_target::abi::{Abi, Align, LayoutOf, Size};
@@ -445,25 +444,9 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
             }
 
             mir::Operand::Constant(ref constant) => {
-                self.eval_mir_constant_to_operand(bx, constant).unwrap_or_else(|err| {
-                    match err {
-                        // errored or at least linted
-                        ErrorHandled::Reported(ErrorReported) | ErrorHandled::Linted => {}
-                        ErrorHandled::TooGeneric => {
-                            bug!("codegen encountered polymorphic constant")
-                        }
-                    }
-                    // Allow RalfJ to sleep soundly knowing that even refactorings that remove
-                    // the above error (or silence it under some conditions) will not cause UB.
-                    bx.abort();
-                    // We still have to return an operand but it doesn't matter,
-                    // this code is unreachable.
-                    let ty = self.monomorphize(&constant.literal.ty);
-                    let layout = bx.cx().layout_of(ty);
-                    bx.load_operand(PlaceRef::new_sized(
-                        bx.cx().const_undef(bx.cx().type_ptr_to(bx.cx().backend_type(layout))),
-                        layout,
-                    ))
+                // This cannot fail because we checked all required_consts in advance.
+                self.eval_mir_constant_to_operand(bx, constant).unwrap_or_else(|_| {
+                    span_bug!(constant.span, "erroneous constant not captured by required_consts")
                 })
             }
         }

--- a/src/librustc_mir/interpret/machine.rs
+++ b/src/librustc_mir/interpret/machine.rs
@@ -119,6 +119,11 @@ pub trait Machine<'mir, 'tcx>: Sized {
     /// that is added to the memory so that the work is not done twice.
     const GLOBAL_KIND: Option<Self::MemoryKind>;
 
+    /// Whether this machine allow const evaluation of `mir::Operand` to fail.
+    /// Usually machines do not, as frame pushing already makes sure that all consts evaluated.
+    /// However, ConstProp does not do regular frame pushing.
+    const PERMIT_LATE_CONST_EVAL_FAIL: bool = false;
+
     /// Whether memory accesses should be alignment-checked.
     fn enforce_alignment(memory_extra: &Self::MemoryExtra) -> bool;
 

--- a/src/librustc_mir/transform/const_prop.rs
+++ b/src/librustc_mir/transform/const_prop.rs
@@ -179,6 +179,8 @@ impl<'mir, 'tcx> interpret::Machine<'mir, 'tcx> for ConstPropMachine<'mir, 'tcx>
 
     type MemoryExtra = ();
 
+    const PERMIT_LATE_CONST_EVAL_FAIL: bool = true;
+
     fn find_mir_or_eval_fn(
         _ecx: &mut InterpCx<'mir, 'tcx, Self>,
         _instance: ty::Instance<'tcx>,


### PR DESCRIPTION
To this end, assert that evaluating const operands never fails (as they all should have been checked as part of `required_consts`).

I am going to try to find the right spot for codegen to add a similar check.

However, this also currently does not work -- const-eval triggers the new assertion. I am not sure how that is possible. (My previous theory made no sense.)

Cc @oli-obk 