### PR TITLE
Explicitly document the size guarantees that Option makes.

### DIFF
--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -83,10 +83,10 @@
 //! * [`ptr::NonNull<U>`]
 //! * `#[repr(transparent)]` struct around one of the types in this list.
 //!
-//! For the above cases, it is guaranteed that one can [`mem::transmute`]
-//! from all valid values of `T` to `Option<T>` and from
-//! `Some::<T>(_)` to `T` (but transmuting `None::<T>` to `T` is undefined
-//! behaviour).
+//! It is further guaranteed that, for the cases above, one can
+//! [`mem::transmute`] from all valid values of `T` to `Option<T>` and
+//! from `Some::<T>(_)` to `T` (but transmuting `None::<T>` to `T`
+//! is undefined behaviour).
 //!
 //! # Examples
 //!

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -72,15 +72,15 @@
 //!
 //! # Representation
 //!
-//! Rust guarantees to optimize the following types `<T>` such that an
+//! Rust guarantees to optimize the following types `T` such that
 //! [`Option<T>`] has the same size as `T`:
 //!
-//! * [`Box<T>`]
-//! * `&T`
-//! * `&mut T`
+//! * [`Box<U>`]
+//! * `&U`
+//! * `&mut U`
 //! * `fn`, `extern "C" fn`
 //! * [`num::NonZero*`]
-//! * [`ptr::NonNull<T>`]
+//! * [`ptr::NonNull<U>`]
 //! * `#[repr(transparent)]` struct around one of the types in this list.
 //!
 //! For the above cases, it is guaranteed that one can [`mem::transmute`]

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -72,16 +72,19 @@
 //!
 //! # Representation
 //!
-//! Rust guarantees to optimise the following inner types such that an [`Option`] which contains
-//! them has the same size as a pointer:
+//! Rust guarantees to optimize the following types `<T>` such that an
+//! [`Option<T>`] has the same size as `T`:
 //!
+//! * [`Box<T>`]
 //! * `&T`
 //! * `&mut T`
 //! * `extern "C" fn`
 //! * [`num::NonZero*`]
 //! * [`ptr::NonNull<T>`]
 //! * `#[repr(transparent)]` struct around one of the types in this list.
-//! * [`Box<T>`]
+//!
+//! For the above cases, it is guaranteed that one can use [`mem::transmute`]
+//! between `T` and `Option<T>` and vice versa.
 //!
 //! # Examples
 //!

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -70,10 +70,18 @@
 //! }
 //! ```
 //!
-//! This usage of [`Option`] to create safe nullable pointers is so
-//! common that Rust does special optimizations to make the
-//! representation of [`Option`]`<`[`Box<T>`]`>` a single pointer. Optional pointers
-//! in Rust are stored as efficiently as any other pointer type.
+//! # Representation
+//!
+//! Rust guarantees to optimise the following inner types such that an [`Option`] which contains
+//! them has the same size as a pointer:
+//!
+//! * `&T`
+//! * `&mut T`
+//! * `extern "C" fn`
+//! * [`num::NonZero*`]
+//! * [`ptr::NonNull<T>`]
+//! * `#[repr(transparent)]` struct around one of the types in this list.
+//! * [`Box<T>`]
 //!
 //! # Examples
 //!

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -78,7 +78,7 @@
 //! * [`Box<T>`]
 //! * `&T`
 //! * `&mut T`
-//! * `extern "C" fn`
+//! * `fn`, `extern "C" fn`
 //! * [`num::NonZero*`]
 //! * [`ptr::NonNull<T>`]
 //! * `#[repr(transparent)]` struct around one of the types in this list.

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -84,8 +84,8 @@
 //! * `#[repr(transparent)]` struct around one of the types in this list.
 //!
 //! For the above cases, it is guaranteed that one can [`mem::transmute`]
-//! from all valid values of `T` to `Option<T>` but only from
-//! `Option::Some(T)` to `T` (i.e. transmuting `None` to `<T>` is undefined
+//! from all valid values of `T` to `Option<T>` and from
+//! `Some::<T>(_)` to `T` (but transmuting `None::<T>` to `T` is undefined
 //! behaviour).
 //!
 //! # Examples

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -83,8 +83,9 @@
 //! * [`ptr::NonNull<T>`]
 //! * `#[repr(transparent)]` struct around one of the types in this list.
 //!
-//! For the above cases, it is guaranteed that one can use [`mem::transmute`]
-//! between `T` and `Option<T>` and vice versa.
+//! For the above cases, it is guaranteed that one can [`mem::transmute`]
+//! from all valid values of `T` to `Option<T>` but only from non-`None`
+//! Option<T>` to `T`.
 //!
 //! # Examples
 //!

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -84,8 +84,9 @@
 //! * `#[repr(transparent)]` struct around one of the types in this list.
 //!
 //! For the above cases, it is guaranteed that one can [`mem::transmute`]
-//! from all valid values of `T` to `Option<T>` but only from non-`None`
-//! Option<T>` to `T`.
+//! from all valid values of `T` to `Option<T>` but only from
+//! `Option::Some(T)` to `T` (i.e. transmuting `None` to `<T>` is undefined
+//! behaviour).
 //!
 //! # Examples
 //!


### PR DESCRIPTION
Triggered by a discussion on wg-unsafe-code-guidelines about which layouts of `Option<T>` one can guarantee are optimised to a single pointer.

CC @RalfJung 