### PR TITLE
fix LocalInfo doc comment

### DIFF
--- a/src/librustc_middle/mir/mod.rs
+++ b/src/librustc_middle/mir/mod.rs
@@ -857,9 +857,12 @@ pub struct LocalDecl<'tcx> {
 #[cfg(target_arch = "x86_64")]
 static_assert_size!(LocalDecl<'_>, 56);
 
-/// Extra information about a some locals that's used for diagnostics. (Not
-/// used for non-StaticRef temporaries, the return place, or anonymous function
-/// parameters.)
+/// Extra information about a some locals that's used for diagnostics and for
+/// classifying variables into local variables, statics, etc, which is needed e.g.
+/// for unsafety checking.
+///
+/// Not used for non-StaticRef temporaries, the return place, or anonymous
+/// function parameters.
 #[derive(Clone, Debug, RustcEncodable, RustcDecodable, HashStable, TypeFoldable)]
 pub enum LocalInfo<'tcx> {
     /// A user-defined local variable or function parameter


### PR DESCRIPTION
The doc comment makes it sound like this is diagnostics-only, but that is not true -- even [unsafety checking uses this information](https://github.com/rust-lang/rust/blob/ded20c98be8585b2a9fe4eeadd1be5524f6ffb17/src/librustc_mir/transform/check_unsafety.rs#L206), so it is crucial for soundness, not just "nice to have".

Cc @oli-obk 