### PR TITLE
Make some Ordering methods const

### DIFF
--- a/library/core/src/cmp.rs
+++ b/library/core/src/cmp.rs
@@ -356,7 +356,7 @@ impl Ordering {
     /// ```
     #[inline]
     #[must_use]
-    #[rustc_const_stable(feature = "const_ordering", since = "1.47.0")]
+    #[rustc_const_stable(feature = "const_ordering", since = "1.48.0")]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub const fn reverse(self) -> Ordering {
         match self {
@@ -395,7 +395,7 @@ impl Ordering {
     /// ```
     #[inline]
     #[must_use]
-    #[rustc_const_stable(feature = "const_ordering", since = "1.47.0")]
+    #[rustc_const_stable(feature = "const_ordering", since = "1.48.0")]
     #[stable(feature = "ordering_chaining", since = "1.17.0")]
     pub const fn then(self, other: Ordering) -> Ordering {
         match self {

--- a/library/core/src/cmp.rs
+++ b/library/core/src/cmp.rs
@@ -356,6 +356,7 @@ impl Ordering {
     /// ```
     #[inline]
     #[must_use]
+    #[rustc_const_unstable(feature = "const_ordering", issue = "76113")]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub const fn reverse(self) -> Ordering {
         match self {
@@ -394,6 +395,7 @@ impl Ordering {
     /// ```
     #[inline]
     #[must_use]
+    #[rustc_const_unstable(feature = "const_ordering", issue = "76113")]
     #[stable(feature = "ordering_chaining", since = "1.17.0")]
     pub const fn then(self, other: Ordering) -> Ordering {
         match self {

--- a/library/core/src/cmp.rs
+++ b/library/core/src/cmp.rs
@@ -357,7 +357,7 @@ impl Ordering {
     #[inline]
     #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn reverse(self) -> Ordering {
+    pub const fn reverse(self) -> Ordering {
         match self {
             Less => Greater,
             Equal => Equal,
@@ -395,7 +395,7 @@ impl Ordering {
     #[inline]
     #[must_use]
     #[stable(feature = "ordering_chaining", since = "1.17.0")]
-    pub fn then(self, other: Ordering) -> Ordering {
+    pub const fn then(self, other: Ordering) -> Ordering {
         match self {
             Equal => other,
             _ => self,

--- a/library/core/src/cmp.rs
+++ b/library/core/src/cmp.rs
@@ -356,7 +356,7 @@ impl Ordering {
     /// ```
     #[inline]
     #[must_use]
-    #[rustc_const_unstable(feature = "const_ordering", issue = "76113")]
+    #[rustc_const_stable(feature = "const_ordering", since = "1.47.0")]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub const fn reverse(self) -> Ordering {
         match self {
@@ -395,7 +395,7 @@ impl Ordering {
     /// ```
     #[inline]
     #[must_use]
-    #[rustc_const_unstable(feature = "const_ordering", issue = "76113")]
+    #[rustc_const_stable(feature = "const_ordering", since = "1.47.0")]
     #[stable(feature = "ordering_chaining", since = "1.17.0")]
     pub const fn then(self, other: Ordering) -> Ordering {
         match self {

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -86,7 +86,6 @@
 #![feature(const_ptr_offset_from)]
 #![feature(const_raw_ptr_comparison)]
 #![feature(const_result)]
-#![feature(const_ordering)]
 #![feature(const_slice_from_raw_parts)]
 #![feature(const_slice_ptr_len)]
 #![feature(const_size_of_val)]

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -86,6 +86,7 @@
 #![feature(const_ptr_offset_from)]
 #![feature(const_raw_ptr_comparison)]
 #![feature(const_result)]
+#![feature(const_ordering)]
 #![feature(const_slice_from_raw_parts)]
 #![feature(const_slice_ptr_len)]
 #![feature(const_size_of_val)]

--- a/src/test/ui/consts/const-ordering.rs
+++ b/src/test/ui/consts/const-ordering.rs
@@ -1,0 +1,17 @@
+// run-pass
+
+#![feature(const_ordering)]
+
+use std::cmp::Ordering;
+
+// the following methods of core::cmp::Ordering are const:
+//  - reverse
+//  - then
+
+fn main() {
+    const REVERSE : Ordering = Ordering::Greater.reverse();
+    assert_eq!(REVERSE, Ordering::Less);
+
+    const THEN : Ordering = Ordering::Equal.then(REVERSE);
+    assert_eq!(THEN, Ordering::Less);
+}

--- a/src/test/ui/consts/const-ordering.rs
+++ b/src/test/ui/consts/const-ordering.rs
@@ -1,7 +1,5 @@
 // run-pass
 
-#![feature(const_ordering)]
-
 use std::cmp::Ordering;
 
 // the following methods of core::cmp::Ordering are const:


### PR DESCRIPTION
Constify the following methods of `core::cmp::Ordering`:
 - `reverse`
 - `then`

Possible because of #49146 (Allow `if` and `match` in constants).

Tracking issue:  #76113