### PR TITLE
Use smaller def span for functions

### DIFF
--- a/src/librustc_ast/ast.rs
+++ b/src/librustc_ast/ast.rs
@@ -1671,6 +1671,7 @@ pub struct MutTy {
 pub struct FnSig {
     pub header: FnHeader,
     pub decl: P<FnDecl>,
+    pub span: Span,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]

--- a/src/librustc_ast/mut_visit.rs
+++ b/src/librustc_ast/mut_visit.rs
@@ -363,9 +363,10 @@ pub fn visit_bounds<T: MutVisitor>(bounds: &mut GenericBounds, vis: &mut T) {
 }
 
 // No `noop_` prefix because there isn't a corresponding method in `MutVisitor`.
-pub fn visit_fn_sig<T: MutVisitor>(FnSig { header, decl }: &mut FnSig, vis: &mut T) {
+pub fn visit_fn_sig<T: MutVisitor>(FnSig { header, decl, span }: &mut FnSig, vis: &mut T) {
     vis.visit_fn_header(header);
     vis.visit_fn_decl(decl);
+    vis.visit_span(span);
 }
 
 // No `noop_` prefix because there isn't a corresponding method in `MutVisitor`.

--- a/src/librustc_ast_lowering/item.rs
+++ b/src/librustc_ast_lowering/item.rs
@@ -263,7 +263,12 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 let (ty, body_id) = self.lower_const_item(t, span, e.as_deref());
                 hir::ItemKind::Const(ty, body_id)
             }
-            ItemKind::Fn(_, FnSig { ref decl, header }, ref generics, ref body) => {
+            ItemKind::Fn(
+                _,
+                FnSig { ref decl, header, span: fn_sig_span },
+                ref generics,
+                ref body,
+            ) => {
                 let fn_def_id = self.resolver.local_def_id(id);
                 self.with_new_scopes(|this| {
                     this.current_item = Some(ident.span);
@@ -290,7 +295,11 @@ impl<'hir> LoweringContext<'_, 'hir> {
                             )
                         },
                     );
-                    let sig = hir::FnSig { decl, header: this.lower_fn_header(header) };
+                    let sig = hir::FnSig {
+                        decl,
+                        header: this.lower_fn_header(header),
+                        span: fn_sig_span,
+                    };
                     hir::ItemKind::Fn(sig, generics, body_id)
                 })
             }
@@ -1243,7 +1252,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 )
             },
         );
-        (generics, hir::FnSig { header, decl })
+        (generics, hir::FnSig { header, decl, span: sig.span })
     }
 
     fn lower_fn_header(&mut self, h: FnHeader) -> hir::FnHeader {

--- a/src/librustc_builtin_macros/deriving/generic/mod.rs
+++ b/src/librustc_builtin_macros/deriving/generic/mod.rs
@@ -924,6 +924,7 @@ impl<'a> MethodDef<'a> {
         let sig = ast::FnSig {
             header: ast::FnHeader { unsafety, ext: ast::Extern::None, ..ast::FnHeader::default() },
             decl: fn_decl,
+            span: trait_.span,
         };
         let def = ast::Defaultness::Final;
 

--- a/src/librustc_builtin_macros/global_allocator.rs
+++ b/src/librustc_builtin_macros/global_allocator.rs
@@ -67,7 +67,7 @@ impl AllocFnFactory<'_, '_> {
         let (output_ty, output_expr) = self.ret_ty(&method.output, result);
         let decl = self.cx.fn_decl(abi_args, ast::FnRetTy::Ty(output_ty));
         let header = FnHeader { unsafety: Unsafe::Yes(self.span), ..FnHeader::default() };
-        let sig = FnSig { decl, header };
+        let sig = FnSig { decl, header, span: self.span };
         let block = Some(self.cx.block_expr(output_expr));
         let kind = ItemKind::Fn(ast::Defaultness::Final, sig, Generics::default(), block);
         let item = self.cx.item(

--- a/src/librustc_builtin_macros/test_harness.rs
+++ b/src/librustc_builtin_macros/test_harness.rs
@@ -318,7 +318,7 @@ fn mk_main(cx: &mut TestCtxt<'_>) -> P<ast::Item> {
     };
 
     let decl = ecx.fn_decl(vec![], ast::FnRetTy::Ty(main_ret_ty));
-    let sig = ast::FnSig { decl, header: ast::FnHeader::default() };
+    let sig = ast::FnSig { decl, header: ast::FnHeader::default(), span: sp };
     let def = ast::Defaultness::Final;
     let main = ast::ItemKind::Fn(def, sig, ast::Generics::default(), Some(main_body));
 

--- a/src/librustc_hir/hir.rs
+++ b/src/librustc_hir/hir.rs
@@ -1851,6 +1851,7 @@ pub struct MutTy<'hir> {
 pub struct FnSig<'hir> {
     pub header: FnHeader,
     pub decl: &'hir FnDecl<'hir>,
+    pub span: Span,
 }
 
 // The bodies for items are stored "out of line", in a separate

--- a/src/librustc_mir/borrow_check/diagnostics/outlives_suggestion.rs
+++ b/src/librustc_mir/borrow_check/diagnostics/outlives_suggestion.rs
@@ -257,7 +257,7 @@ impl OutlivesSuggestionBuilder {
         };
 
         // We want this message to appear after other messages on the mir def.
-        let mir_span = mbcx.infcx.tcx.def_span(mbcx.mir_def_id);
+        let mir_span = mbcx.body.span;
         diag.sort_span = mir_span.shrink_to_hi();
 
         // Buffer the diagnostic

--- a/src/librustc_mir_build/lints.rs
+++ b/src/librustc_mir_build/lints.rs
@@ -38,7 +38,7 @@ crate fn check<'tcx>(tcx: TyCtxt<'tcx>, body: &Body<'tcx>, def_id: LocalDefId) {
         vis.reachable_recursive_calls.sort();
 
         let hir_id = tcx.hir().local_def_id_to_hir_id(def_id);
-        let sp = tcx.sess.source_map().guess_head_span(tcx.hir().span(hir_id));
+        let sp = tcx.sess.source_map().guess_head_span(tcx.hir().span_with_body(hir_id));
         tcx.struct_span_lint_hir(UNCONDITIONAL_RECURSION, hir_id, sp, |lint| {
             let mut db = lint.build("function cannot return without recursing");
             db.span_label(sp, "cannot return without recursing");

--- a/src/librustc_save_analysis/sig.rs
+++ b/src/librustc_save_analysis/sig.rs
@@ -377,7 +377,7 @@ impl<'hir> Sig for hir::Item<'hir> {
 
                 Ok(extend_sig(ty, text, defs, vec![]))
             }
-            hir::ItemKind::Fn(hir::FnSig { ref decl, header }, ref generics, _) => {
+            hir::ItemKind::Fn(hir::FnSig { ref decl, header, span: _ }, ref generics, _) => {
                 let mut text = String::new();
                 if let hir::Constness::Const = header.constness {
                     text.push_str("const ");

--- a/src/librustc_trait_selection/traits/error_reporting/mod.rs
+++ b/src/librustc_trait_selection/traits/error_reporting/mod.rs
@@ -399,16 +399,17 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                             err.note(s.as_str());
                         }
                         if let Some(ref s) = enclosing_scope {
-                            let enclosing_scope_span = tcx.def_span(
-                                tcx.hir()
-                                    .opt_local_def_id(obligation.cause.body_id)
-                                    .unwrap_or_else(|| {
-                                        tcx.hir().body_owner_def_id(hir::BodyId {
-                                            hir_id: obligation.cause.body_id,
-                                        })
+                            let body = tcx
+                                .hir()
+                                .opt_local_def_id(obligation.cause.body_id)
+                                .unwrap_or_else(|| {
+                                    tcx.hir().body_owner_def_id(hir::BodyId {
+                                        hir_id: obligation.cause.body_id,
                                     })
-                                    .to_def_id(),
-                            );
+                                });
+
+                            let enclosing_scope_span =
+                                tcx.hir().span_with_body(tcx.hir().local_def_id_to_hir_id(body));
 
                             err.span_label(enclosing_scope_span, s.as_str());
                         }

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -1543,7 +1543,7 @@ fn fn_sig(tcx: TyCtxt<'_>, def_id: DefId) -> ty::PolyFnSig<'_> {
         }
 
         TraitItem(hir::TraitItem {
-            kind: TraitItemKind::Fn(FnSig { header, decl }, _),
+            kind: TraitItemKind::Fn(FnSig { header, decl, span: _ }, _),
             ident,
             generics,
             ..

--- a/src/test/ui/associated-types/bound-lifetime-in-binding-only.ok.stderr
+++ b/src/test/ui/associated-types/bound-lifetime-in-binding-only.ok.stderr
@@ -2,7 +2,7 @@ error: fatal error triggered by #[rustc_error]
   --> $DIR/bound-lifetime-in-binding-only.rs:71:1
    |
 LL | fn main() { }
-   | ^^^^^^^^^^^^^
+   | ^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/associated-types/bound-lifetime-in-return-only.ok.stderr
+++ b/src/test/ui/associated-types/bound-lifetime-in-return-only.ok.stderr
@@ -2,7 +2,7 @@ error: fatal error triggered by #[rustc_error]
   --> $DIR/bound-lifetime-in-return-only.rs:49:1
    |
 LL | fn main() { }
-   | ^^^^^^^^^^^^^
+   | ^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/associated-types/cache/project-fn-ret-contravariant.ok.stderr
+++ b/src/test/ui/associated-types/cache/project-fn-ret-contravariant.ok.stderr
@@ -2,7 +2,7 @@ error: fatal error triggered by #[rustc_error]
   --> $DIR/project-fn-ret-contravariant.rs:50:1
    |
 LL | fn main() { }
-   | ^^^^^^^^^^^^^
+   | ^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/associated-types/cache/project-fn-ret-contravariant.oneuse.stderr
+++ b/src/test/ui/associated-types/cache/project-fn-ret-contravariant.oneuse.stderr
@@ -2,7 +2,7 @@ error: fatal error triggered by #[rustc_error]
   --> $DIR/project-fn-ret-contravariant.rs:50:1
    |
 LL | fn main() { }
-   | ^^^^^^^^^^^^^
+   | ^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/associated-types/cache/project-fn-ret-invariant.ok.stderr
+++ b/src/test/ui/associated-types/cache/project-fn-ret-invariant.ok.stderr
@@ -2,7 +2,7 @@ error: fatal error triggered by #[rustc_error]
   --> $DIR/project-fn-ret-invariant.rs:60:1
    |
 LL | fn main() {}
-   | ^^^^^^^^^^^^
+   | ^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/associated-types/higher-ranked-projection.good.stderr
+++ b/src/test/ui/associated-types/higher-ranked-projection.good.stderr
@@ -1,11 +1,8 @@
 error: fatal error triggered by #[rustc_error]
   --> $DIR/higher-ranked-projection.rs:24:1
    |
-LL | / fn main() {
-LL | |     foo(());
-LL | |
-LL | | }
-   | |_^
+LL | fn main() {
+   | ^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/async-await/multiple-lifetimes/ret-impl-trait-no-fg.stderr
+++ b/src/test/ui/async-await/multiple-lifetimes/ret-impl-trait-no-fg.stderr
@@ -25,28 +25,16 @@ LL | async fn async_ret_impl_trait<'a, 'b>(a: &'a u8, b: &'b u8) -> impl Trait<'
 error[E0700]: hidden type for `impl Trait` captures lifetime that does not appear in bounds
   --> $DIR/ret-impl-trait-no-fg.rs:9:1
    |
-LL | / async fn async_ret_impl_trait<'a, 'b>(a: &'a u8, b: &'b u8) -> impl Trait<'a, 'b> {
-LL | |
-LL | |
-LL | |
-...  |
-LL | |     (a, b)
-LL | | }
-   | |_^
+LL | async fn async_ret_impl_trait<'a, 'b>(a: &'a u8, b: &'b u8) -> impl Trait<'a, 'b> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: hidden type `(&u8, &u8)` captures lifetime '_#5r
 
 error[E0700]: hidden type for `impl Trait` captures lifetime that does not appear in bounds
   --> $DIR/ret-impl-trait-no-fg.rs:9:1
    |
-LL | / async fn async_ret_impl_trait<'a, 'b>(a: &'a u8, b: &'b u8) -> impl Trait<'a, 'b> {
-LL | |
-LL | |
-LL | |
-...  |
-LL | |     (a, b)
-LL | | }
-   | |_^
+LL | async fn async_ret_impl_trait<'a, 'b>(a: &'a u8, b: &'b u8) -> impl Trait<'a, 'b> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: hidden type `(&u8, &u8)` captures lifetime '_#6r
 

--- a/src/test/ui/block-result/issue-20862.stderr
+++ b/src/test/ui/block-result/issue-20862.stderr
@@ -12,16 +12,13 @@ LL |     |y| x + y
 error[E0618]: expected function, found `()`
   --> $DIR/issue-20862.rs:7:13
    |
-LL | / fn foo(x: i32) {
-LL | |     |y| x + y
-LL | |
-LL | | }
-   | |_- `foo` defined here returns `()`
+LL | fn foo(x: i32) {
+   | -------------- `foo` defined here returns `()`
 ...
-LL |       let x = foo(5)(2);
-   |               ^^^^^^---
-   |               |
-   |               call expression requires function
+LL |     let x = foo(5)(2);
+   |             ^^^^^^---
+   |             |
+   |             call expression requires function
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/codemap_tests/coherence-overlapping-inherent-impl-trait.stderr
+++ b/src/test/ui/codemap_tests/coherence-overlapping-inherent-impl-trait.stderr
@@ -2,9 +2,9 @@ error[E0592]: duplicate definitions with name `f`
   --> $DIR/coherence-overlapping-inherent-impl-trait.rs:4:14
    |
 LL | impl dyn C { fn f() {} }
-   |              ^^^^^^^^^ duplicate definitions for `f`
+   |              ^^^^^^ duplicate definitions for `f`
 LL | impl dyn C { fn f() {} }
-   |              --------- other definition for `f`
+   |              ------ other definition for `f`
 
 error: aborting due to previous error
 

--- a/src/test/ui/codemap_tests/overlapping_inherent_impls.stderr
+++ b/src/test/ui/codemap_tests/overlapping_inherent_impls.stderr
@@ -2,28 +2,28 @@ error[E0592]: duplicate definitions with name `id`
   --> $DIR/overlapping_inherent_impls.rs:9:5
    |
 LL |     fn id() {}
-   |     ^^^^^^^^^^ duplicate definitions for `id`
+   |     ^^^^^^^ duplicate definitions for `id`
 ...
 LL |     fn id() {}
-   |     ---------- other definition for `id`
+   |     ------- other definition for `id`
 
 error[E0592]: duplicate definitions with name `bar`
   --> $DIR/overlapping_inherent_impls.rs:19:5
    |
 LL |     fn bar(&self) {}
-   |     ^^^^^^^^^^^^^^^^ duplicate definitions for `bar`
+   |     ^^^^^^^^^^^^^ duplicate definitions for `bar`
 ...
 LL |     fn bar(&self) {}
-   |     ---------------- other definition for `bar`
+   |     ------------- other definition for `bar`
 
 error[E0592]: duplicate definitions with name `baz`
   --> $DIR/overlapping_inherent_impls.rs:29:5
    |
 LL |     fn baz(&self) {}
-   |     ^^^^^^^^^^^^^^^^ duplicate definitions for `baz`
+   |     ^^^^^^^^^^^^^ duplicate definitions for `baz`
 ...
 LL |     fn baz(&self) {}
-   |     ---------------- other definition for `baz`
+   |     ------------- other definition for `baz`
    |
    = note: upstream crates may add a new impl of trait `std::marker::Copy` for type `std::vec::Vec<_>` in future versions
 

--- a/src/test/ui/coherence/coherence-inherited-subtyping.old.stderr
+++ b/src/test/ui/coherence/coherence-inherited-subtyping.old.stderr
@@ -2,10 +2,10 @@ error[E0592]: duplicate definitions with name `method1`
   --> $DIR/coherence-inherited-subtyping.rs:14:5
    |
 LL |     fn method1(&self) {}
-   |     ^^^^^^^^^^^^^^^^^^^^ duplicate definitions for `method1`
+   |     ^^^^^^^^^^^^^^^^^ duplicate definitions for `method1`
 ...
 LL |     fn method1(&self) {}
-   |     -------------------- other definition for `method1`
+   |     ----------------- other definition for `method1`
    |
    = note: this behavior recently changed as a result of a bug fix; see rust-lang/rust#56105 for details
 

--- a/src/test/ui/coherence/coherence-inherited-subtyping.re.stderr
+++ b/src/test/ui/coherence/coherence-inherited-subtyping.re.stderr
@@ -2,10 +2,10 @@ error[E0592]: duplicate definitions with name `method1`
   --> $DIR/coherence-inherited-subtyping.rs:14:5
    |
 LL |     fn method1(&self) {}
-   |     ^^^^^^^^^^^^^^^^^^^^ duplicate definitions for `method1`
+   |     ^^^^^^^^^^^^^^^^^ duplicate definitions for `method1`
 ...
 LL |     fn method1(&self) {}
-   |     -------------------- other definition for `method1`
+   |     ----------------- other definition for `method1`
    |
    = note: this behavior recently changed as a result of a bug fix; see rust-lang/rust#56105 for details
 

--- a/src/test/ui/coherence/coherence-overlap-downstream-inherent.stderr
+++ b/src/test/ui/coherence/coherence-overlap-downstream-inherent.stderr
@@ -2,19 +2,19 @@ error[E0592]: duplicate definitions with name `dummy`
   --> $DIR/coherence-overlap-downstream-inherent.rs:7:26
    |
 LL | impl<T:Sugar> Sweet<T> { fn dummy(&self) { } }
-   |                          ^^^^^^^^^^^^^^^^^^^ duplicate definitions for `dummy`
+   |                          ^^^^^^^^^^^^^^^ duplicate definitions for `dummy`
 LL |
 LL | impl<T:Fruit> Sweet<T> { fn dummy(&self) { } }
-   |                          ------------------- other definition for `dummy`
+   |                          --------------- other definition for `dummy`
 
 error[E0592]: duplicate definitions with name `f`
   --> $DIR/coherence-overlap-downstream-inherent.rs:13:38
    |
 LL | impl<X, T> A<T, X> where T: Bar<X> { fn f(&self) {} }
-   |                                      ^^^^^^^^^^^^^^ duplicate definitions for `f`
+   |                                      ^^^^^^^^^^^ duplicate definitions for `f`
 LL |
 LL | impl<X> A<i32, X> { fn f(&self) {} }
-   |                     -------------- other definition for `f`
+   |                     ----------- other definition for `f`
    |
    = note: downstream crates may implement trait `Bar<_>` for type `i32`
 

--- a/src/test/ui/coherence/coherence-overlap-issue-23516-inherent.stderr
+++ b/src/test/ui/coherence/coherence-overlap-issue-23516-inherent.stderr
@@ -2,10 +2,10 @@ error[E0592]: duplicate definitions with name `dummy`
   --> $DIR/coherence-overlap-issue-23516-inherent.rs:9:25
    |
 LL | impl<T:Sugar> Cake<T> { fn dummy(&self) { } }
-   |                         ^^^^^^^^^^^^^^^^^^^ duplicate definitions for `dummy`
+   |                         ^^^^^^^^^^^^^^^ duplicate definitions for `dummy`
 LL |
 LL | impl<U:Sugar> Cake<Box<U>> { fn dummy(&self) { } }
-   |                              ------------------- other definition for `dummy`
+   |                              --------------- other definition for `dummy`
    |
    = note: downstream crates may implement trait `Sugar` for type `std::boxed::Box<_>`
 

--- a/src/test/ui/coherence/coherence-overlap-upstream-inherent.stderr
+++ b/src/test/ui/coherence/coherence-overlap-upstream-inherent.stderr
@@ -2,10 +2,10 @@ error[E0592]: duplicate definitions with name `dummy`
   --> $DIR/coherence-overlap-upstream-inherent.rs:12:32
    |
 LL | impl<T> A<T> where T: Remote { fn dummy(&self) { } }
-   |                                ^^^^^^^^^^^^^^^^^^^ duplicate definitions for `dummy`
+   |                                ^^^^^^^^^^^^^^^ duplicate definitions for `dummy`
 LL |
 LL | impl A<i16> { fn dummy(&self) { } }
-   |               ------------------- other definition for `dummy`
+   |               --------------- other definition for `dummy`
    |
    = note: upstream crates may add a new impl of trait `coherence_lib::Remote` for type `i16` in future versions
 

--- a/src/test/ui/duplicate/dupe-symbols-1.stderr
+++ b/src/test/ui/duplicate/dupe-symbols-1.stderr
@@ -1,10 +1,8 @@
 error: symbol `fail` is already defined
   --> $DIR/dupe-symbols-1.rs:12:1
    |
-LL | / pub fn b() {
-LL | |
-LL | | }
-   | |_^
+LL | pub fn b() {
+   | ^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/duplicate/dupe-symbols-2.stderr
+++ b/src/test/ui/duplicate/dupe-symbols-2.stderr
@@ -1,10 +1,8 @@
 error: symbol `fail` is already defined
   --> $DIR/dupe-symbols-2.rs:15:5
    |
-LL | /     pub extern fn fail() {
-LL | |
-LL | |     }
-   | |_____^
+LL |     pub extern fn fail() {
+   |     ^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/duplicate/dupe-symbols-3.stderr
+++ b/src/test/ui/duplicate/dupe-symbols-3.stderr
@@ -1,10 +1,8 @@
 error: symbol `fail` is already defined
   --> $DIR/dupe-symbols-3.rs:12:1
    |
-LL | / pub fn fail() {
-LL | |
-LL | | }
-   | |_^
+LL | pub fn fail() {
+   | ^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/duplicate/dupe-symbols-4.stderr
+++ b/src/test/ui/duplicate/dupe-symbols-4.stderr
@@ -2,7 +2,7 @@ error: symbol `fail` is already defined
   --> $DIR/dupe-symbols-4.rs:23:5
    |
 LL |     fn fail(self) {}
-   |     ^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/duplicate/dupe-symbols-5.stderr
+++ b/src/test/ui/duplicate/dupe-symbols-5.stderr
@@ -1,10 +1,8 @@
 error: symbol `fail` is already defined
   --> $DIR/dupe-symbols-5.rs:11:1
    |
-LL | / pub fn b() {
-LL | |
-LL | | }
-   | |_^
+LL | pub fn b() {
+   | ^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/duplicate/dupe-symbols-7.stderr
+++ b/src/test/ui/duplicate/dupe-symbols-7.stderr
@@ -2,7 +2,7 @@ error: entry symbol `main` declared multiple times
   --> $DIR/dupe-symbols-7.rs:12:1
    |
 LL | fn main(){}
-   | ^^^^^^^^^^^
+   | ^^^^^^^^^
    |
    = help: did you use `#[no_mangle]` on `fn main`? Use `#[start]` instead
 

--- a/src/test/ui/duplicate/dupe-symbols-8.stderr
+++ b/src/test/ui/duplicate/dupe-symbols-8.stderr
@@ -1,13 +1,8 @@
 error: entry symbol `main` declared multiple times
   --> $DIR/dupe-symbols-8.rs:7:1
    |
-LL | / fn main() {
-LL | |     extern "Rust" {
-LL | |      fn main();
-LL | |     }
-LL | |     unsafe { main(); }
-LL | | }
-   | |_^
+LL | fn main() {
+   | ^^^^^^^^^
    |
    = help: did you use `#[no_mangle]` on `fn main`? Use `#[start]` instead
 

--- a/src/test/ui/duplicate_entry_error.stderr
+++ b/src/test/ui/duplicate_entry_error.stderr
@@ -1,11 +1,8 @@
 error[E0152]: found duplicate lang item `panic_impl`
   --> $DIR/duplicate_entry_error.rs:11:1
    |
-LL | / fn panic_impl(info: &PanicInfo) -> ! {
-LL | |
-LL | |     loop {}
-LL | | }
-   | |_^
+LL | fn panic_impl(info: &PanicInfo) -> ! {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: the lang item is first defined in crate `std` (which `duplicate_entry_error` depends on)
    = note: first definition in `std` loaded from SYSROOT/libstd-*.rlib

--- a/src/test/ui/error-codes/E0445.stderr
+++ b/src/test/ui/error-codes/E0445.stderr
@@ -14,7 +14,7 @@ error[E0445]: private trait `Foo` in public interface
   --> $DIR/E0445.rs:9:1
    |
 LL | pub fn foo<T: Foo> (t: T) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak private trait
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak private trait
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/error-codes/E0446.stderr
+++ b/src/test/ui/error-codes/E0446.stderr
@@ -1,13 +1,11 @@
 error[E0446]: private type `foo::Bar` in public interface
   --> $DIR/E0446.rs:4:5
    |
-LL |       struct Bar(u32);
-   |       - `foo::Bar` declared as private
+LL |     struct Bar(u32);
+   |     - `foo::Bar` declared as private
 LL | 
-LL | /     pub fn bar() -> Bar {
-LL | |         Bar(0)
-LL | |     }
-   | |_____^ can't leak private type
+LL |     pub fn bar() -> Bar {
+   |     ^^^^^^^^^^^^^^^^^^^ can't leak private type
 
 error: aborting due to previous error
 

--- a/src/test/ui/hr-subtype/hr-subtype.bound_a_b_vs_bound_a.stderr
+++ b/src/test/ui/hr-subtype/hr-subtype.bound_a_b_vs_bound_a.stderr
@@ -1,14 +1,8 @@
 error: fatal error triggered by #[rustc_error]
   --> $DIR/hr-subtype.rs:102:1
    |
-LL | / fn main() {
-LL | |
-LL | |
-LL | |
-...  |
-LL | |
-LL | | }
-   | |_^
+LL | fn main() {
+   | ^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/hr-subtype/hr-subtype.bound_a_vs_bound_a.stderr
+++ b/src/test/ui/hr-subtype/hr-subtype.bound_a_vs_bound_a.stderr
@@ -1,14 +1,8 @@
 error: fatal error triggered by #[rustc_error]
   --> $DIR/hr-subtype.rs:102:1
    |
-LL | / fn main() {
-LL | |
-LL | |
-LL | |
-...  |
-LL | |
-LL | | }
-   | |_^
+LL | fn main() {
+   | ^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/hr-subtype/hr-subtype.bound_a_vs_bound_b.stderr
+++ b/src/test/ui/hr-subtype/hr-subtype.bound_a_vs_bound_b.stderr
@@ -1,14 +1,8 @@
 error: fatal error triggered by #[rustc_error]
   --> $DIR/hr-subtype.rs:102:1
    |
-LL | / fn main() {
-LL | |
-LL | |
-LL | |
-...  |
-LL | |
-LL | | }
-   | |_^
+LL | fn main() {
+   | ^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/hr-subtype/hr-subtype.bound_co_a_b_vs_bound_co_a.stderr
+++ b/src/test/ui/hr-subtype/hr-subtype.bound_co_a_b_vs_bound_co_a.stderr
@@ -1,14 +1,8 @@
 error: fatal error triggered by #[rustc_error]
   --> $DIR/hr-subtype.rs:102:1
    |
-LL | / fn main() {
-LL | |
-LL | |
-LL | |
-...  |
-LL | |
-LL | | }
-   | |_^
+LL | fn main() {
+   | ^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/hr-subtype/hr-subtype.bound_co_a_co_b_ret_contra_a.stderr
+++ b/src/test/ui/hr-subtype/hr-subtype.bound_co_a_co_b_ret_contra_a.stderr
@@ -1,14 +1,8 @@
 error: fatal error triggered by #[rustc_error]
   --> $DIR/hr-subtype.rs:102:1
    |
-LL | / fn main() {
-LL | |
-LL | |
-LL | |
-...  |
-LL | |
-LL | | }
-   | |_^
+LL | fn main() {
+   | ^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/hr-subtype/hr-subtype.bound_co_a_vs_bound_co_b.stderr
+++ b/src/test/ui/hr-subtype/hr-subtype.bound_co_a_vs_bound_co_b.stderr
@@ -1,14 +1,8 @@
 error: fatal error triggered by #[rustc_error]
   --> $DIR/hr-subtype.rs:102:1
    |
-LL | / fn main() {
-LL | |
-LL | |
-LL | |
-...  |
-LL | |
-LL | | }
-   | |_^
+LL | fn main() {
+   | ^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/hr-subtype/hr-subtype.bound_contra_a_contra_b_ret_co_a.stderr
+++ b/src/test/ui/hr-subtype/hr-subtype.bound_contra_a_contra_b_ret_co_a.stderr
@@ -1,14 +1,8 @@
 error: fatal error triggered by #[rustc_error]
   --> $DIR/hr-subtype.rs:102:1
    |
-LL | / fn main() {
-LL | |
-LL | |
-LL | |
-...  |
-LL | |
-LL | | }
-   | |_^
+LL | fn main() {
+   | ^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/hr-subtype/hr-subtype.bound_inv_a_vs_bound_inv_b.stderr
+++ b/src/test/ui/hr-subtype/hr-subtype.bound_inv_a_vs_bound_inv_b.stderr
@@ -1,14 +1,8 @@
 error: fatal error triggered by #[rustc_error]
   --> $DIR/hr-subtype.rs:102:1
    |
-LL | / fn main() {
-LL | |
-LL | |
-LL | |
-...  |
-LL | |
-LL | | }
-   | |_^
+LL | fn main() {
+   | ^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/hr-subtype/hr-subtype.free_x_vs_free_x.stderr
+++ b/src/test/ui/hr-subtype/hr-subtype.free_x_vs_free_x.stderr
@@ -1,14 +1,8 @@
 error: fatal error triggered by #[rustc_error]
   --> $DIR/hr-subtype.rs:102:1
    |
-LL | / fn main() {
-LL | |
-LL | |
-LL | |
-...  |
-LL | |
-LL | | }
-   | |_^
+LL | fn main() {
+   | ^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/hrtb/issue-58451.stderr
+++ b/src/test/ui/hrtb/issue-58451.stderr
@@ -5,8 +5,7 @@ LL | / fn f<I>(i: I)
 LL | | where
 LL | |     I: IntoIterator,
 LL | |     I::Item: for<'a> Into<&'a ()>,
-LL | | {}
-   | |__- defined here
+   | |__________________________________- defined here
 ...
 LL |       f(&[f()]);
    |           ^-- supplied 0 arguments

--- a/src/test/ui/infinite/infinite-instantiation.stderr
+++ b/src/test/ui/infinite/infinite-instantiation.stderr
@@ -7,13 +7,8 @@ LL |         function(counter - 1, t.to_option());
 note: `function` defined here
   --> $DIR/infinite-instantiation.rs:19:1
    |
-LL | / fn function<T:ToOpt + Clone>(counter: usize, t: T) {
-LL | |     if counter > 0 {
-LL | |         function(counter - 1, t.to_option());
-LL | |
-LL | |     }
-LL | | }
-   | |_^
+LL | fn function<T:ToOpt + Clone>(counter: usize, t: T) {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-16683.stderr
+++ b/src/test/ui/issues/issue-16683.stderr
@@ -7,10 +7,8 @@ LL |         self.a();
 note: first, the lifetime cannot outlive the anonymous lifetime #1 defined on the method body at 3:5...
   --> $DIR/issue-16683.rs:3:5
    |
-LL | /     fn b(&self) {
-LL | |         self.a();
-LL | |     }
-   | |_____^
+LL |     fn b(&self) {
+   |     ^^^^^^^^^^^
 note: ...so that reference does not outlive borrowed content
   --> $DIR/issue-16683.rs:4:9
    |

--- a/src/test/ui/issues/issue-17740.stderr
+++ b/src/test/ui/issues/issue-17740.stderr
@@ -9,14 +9,8 @@ LL |     fn bar(self: &mut Foo) {
 note: the anonymous lifetime #2 defined on the method body at 6:5...
   --> $DIR/issue-17740.rs:6:5
    |
-LL | /     fn bar(self: &mut Foo) {
-LL | |
-LL | |
-LL | |
-...  |
-LL | |
-LL | |     }
-   | |_____^
+LL |     fn bar(self: &mut Foo) {
+   |     ^^^^^^^^^^^^^^^^^^^^^^
 note: ...does not necessarily outlive the lifetime `'a` as defined on the impl at 5:7
   --> $DIR/issue-17740.rs:5:7
    |
@@ -39,14 +33,8 @@ LL | impl <'a> Foo<'a>{
 note: ...does not necessarily outlive the anonymous lifetime #2 defined on the method body at 6:5
   --> $DIR/issue-17740.rs:6:5
    |
-LL | /     fn bar(self: &mut Foo) {
-LL | |
-LL | |
-LL | |
-...  |
-LL | |
-LL | |     }
-   | |_____^
+LL |     fn bar(self: &mut Foo) {
+   |     ^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-17758.stderr
+++ b/src/test/ui/issues/issue-17758.stderr
@@ -7,11 +7,8 @@ LL |         self.foo();
 note: first, the lifetime cannot outlive the anonymous lifetime #1 defined on the method body at 6:5...
   --> $DIR/issue-17758.rs:6:5
    |
-LL | /     fn bar(&self) {
-LL | |         self.foo();
-LL | |
-LL | |     }
-   | |_____^
+LL |     fn bar(&self) {
+   |     ^^^^^^^^^^^^^
 note: ...so that reference does not outlive borrowed content
   --> $DIR/issue-17758.rs:7:9
    |

--- a/src/test/ui/issues/issue-17905-2.stderr
+++ b/src/test/ui/issues/issue-17905-2.stderr
@@ -9,12 +9,8 @@ LL |     fn say(self: &Pair<&str, isize>) {
 note: the anonymous lifetime #2 defined on the method body at 8:5...
   --> $DIR/issue-17905-2.rs:8:5
    |
-LL | /     fn say(self: &Pair<&str, isize>) {
-LL | |
-LL | |
-LL | |         println!("{:?}", self);
-LL | |     }
-   | |_____^
+LL |     fn say(self: &Pair<&str, isize>) {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: ...does not necessarily outlive the lifetime `'_` as defined on the impl at 5:5
   --> $DIR/issue-17905-2.rs:5:5
    |
@@ -37,12 +33,8 @@ LL |     &str,
 note: ...does not necessarily outlive the anonymous lifetime #2 defined on the method body at 8:5
   --> $DIR/issue-17905-2.rs:8:5
    |
-LL | /     fn say(self: &Pair<&str, isize>) {
-LL | |
-LL | |
-LL | |         println!("{:?}", self);
-LL | |     }
-   | |_____^
+LL |     fn say(self: &Pair<&str, isize>) {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-20831-debruijn.stderr
+++ b/src/test/ui/issues/issue-20831-debruijn.stderr
@@ -15,14 +15,8 @@ LL | |     }
 note: the anonymous lifetime #2 defined on the method body at 28:5...
   --> $DIR/issue-20831-debruijn.rs:28:5
    |
-LL | /     fn subscribe(&mut self, t : Box<dyn Subscriber<Input=<Self as Publisher>::Output> + 'a>) {
-LL | |         // Not obvious, but there is an implicit lifetime here -------^
-LL | |
-LL | |
-...  |
-LL | |         self.sub = t;
-LL | |     }
-   | |_____^
+LL |     fn subscribe(&mut self, t : Box<dyn Subscriber<Input=<Self as Publisher>::Output> + 'a>) {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: ...does not necessarily outlive the lifetime `'a` as defined on the impl at 26:6
   --> $DIR/issue-20831-debruijn.rs:26:6
    |
@@ -51,14 +45,8 @@ LL | impl<'a> Publisher<'a> for MyStruct<'a> {
 note: ...does not necessarily outlive the anonymous lifetime #2 defined on the method body at 28:5
   --> $DIR/issue-20831-debruijn.rs:28:5
    |
-LL | /     fn subscribe(&mut self, t : Box<dyn Subscriber<Input=<Self as Publisher>::Output> + 'a>) {
-LL | |         // Not obvious, but there is an implicit lifetime here -------^
-LL | |
-LL | |
-...  |
-LL | |         self.sub = t;
-LL | |     }
-   | |_____^
+LL |     fn subscribe(&mut self, t : Box<dyn Subscriber<Input=<Self as Publisher>::Output> + 'a>) {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0495]: cannot infer an appropriate lifetime for lifetime parameter `'a` due to conflicting requirements
   --> $DIR/issue-20831-debruijn.rs:28:33
@@ -69,14 +57,8 @@ LL |     fn subscribe(&mut self, t : Box<dyn Subscriber<Input=<Self as Publisher
 note: first, the lifetime cannot outlive the anonymous lifetime #2 defined on the method body at 28:5...
   --> $DIR/issue-20831-debruijn.rs:28:5
    |
-LL | /     fn subscribe(&mut self, t : Box<dyn Subscriber<Input=<Self as Publisher>::Output> + 'a>) {
-LL | |         // Not obvious, but there is an implicit lifetime here -------^
-LL | |
-LL | |
-...  |
-LL | |         self.sub = t;
-LL | |     }
-   | |_____^
+LL |     fn subscribe(&mut self, t : Box<dyn Subscriber<Input=<Self as Publisher>::Output> + 'a>) {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: ...but the lifetime must also be valid for the lifetime `'a` as defined on the impl at 26:6...
   --> $DIR/issue-20831-debruijn.rs:26:6
    |
@@ -99,14 +81,8 @@ LL |     fn subscribe(&mut self, t : Box<dyn Subscriber<Input=<Self as Publisher
 note: first, the lifetime cannot outlive the anonymous lifetime #2 defined on the method body at 28:5...
   --> $DIR/issue-20831-debruijn.rs:28:5
    |
-LL | /     fn subscribe(&mut self, t : Box<dyn Subscriber<Input=<Self as Publisher>::Output> + 'a>) {
-LL | |         // Not obvious, but there is an implicit lifetime here -------^
-LL | |
-LL | |
-...  |
-LL | |         self.sub = t;
-LL | |     }
-   | |_____^
+LL |     fn subscribe(&mut self, t : Box<dyn Subscriber<Input=<Self as Publisher>::Output> + 'a>) {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: ...but the lifetime must also be valid for the lifetime `'a` as defined on the impl at 26:6...
   --> $DIR/issue-20831-debruijn.rs:26:6
    |

--- a/src/test/ui/issues/issue-22638.stderr
+++ b/src/test/ui/issues/issue-22638.stderr
@@ -1,12 +1,8 @@
 error: reached the type-length limit while instantiating `D::matches::$CLOSURE`
   --> $DIR/issue-22638.rs:53:5
    |
-LL | /     pub fn matches<F: Fn()>(&self, f: &F) {
-LL | |
-LL | |         let &D(ref a) = self;
-LL | |         a.matches(f)
-LL | |     }
-   | |_____^
+LL |     pub fn matches<F: Fn()>(&self, f: &F) {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: consider adding a `#![type_length_limit="30408681"]` attribute to your crate
 

--- a/src/test/ui/issues/issue-30079.stderr
+++ b/src/test/ui/issues/issue-30079.stderr
@@ -2,7 +2,7 @@ warning: private type `m1::Priv` in public interface (error E0446)
   --> $DIR/issue-30079.rs:6:9
    |
 LL |         pub fn f(_: Priv) {}
-   |         ^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(private_in_public)]` on by default
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!

--- a/src/test/ui/issues/issue-33140.stderr
+++ b/src/test/ui/issues/issue-33140.stderr
@@ -19,15 +19,11 @@ LL | impl Trait2 for dyn Sync + Send + Sync {
 error[E0592]: duplicate definitions with name `abc`
   --> $DIR/issue-33140.rs:29:5
    |
-LL | /     fn abc() -> bool {
-LL | |         false
-LL | |     }
-   | |_____^ duplicate definitions for `abc`
+LL |     fn abc() -> bool {
+   |     ^^^^^^^^^^^^^^^^ duplicate definitions for `abc`
 ...
-LL | /     fn abc() -> bool {
-LL | |         true
-LL | |     }
-   | |_____- other definition for `abc`
+LL |     fn abc() -> bool {
+   |     ---------------- other definition for `abc`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/issues/issue-37311-type-length-limit/issue-37311.stderr
+++ b/src/test/ui/issues/issue-37311-type-length-limit/issue-37311.stderr
@@ -1,10 +1,8 @@
 error: reached the type-length limit while instantiating `<(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(...))))))))))))))) as Foo>::recurse`
   --> $DIR/issue-37311.rs:15:5
    |
-LL | /     fn recurse(&self) {
-LL | |         (self, self).recurse();
-LL | |     }
-   | |_____^
+LL |     fn recurse(&self) {
+   |     ^^^^^^^^^^^^^^^^^
    |
    = note: consider adding a `#![type_length_limit="2097149"]` attribute to your crate
 

--- a/src/test/ui/issues/issue-37884.stderr
+++ b/src/test/ui/issues/issue-37884.stderr
@@ -14,13 +14,8 @@ LL | |     }
 note: the anonymous lifetime #1 defined on the method body at 6:5...
   --> $DIR/issue-37884.rs:6:5
    |
-LL | /     fn next(&'a mut self) -> Option<Self::Item>
-LL | |
-LL | |
-LL | |     {
-LL | |         Some(&mut self.0)
-LL | |     }
-   | |_____^
+LL |     fn next(&'a mut self) -> Option<Self::Item>
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: ...does not necessarily outlive the lifetime `'a` as defined on the impl at 3:6
   --> $DIR/issue-37884.rs:3:6
    |

--- a/src/test/ui/issues/issue-67552.stderr
+++ b/src/test/ui/issues/issue-67552.stderr
@@ -10,11 +10,7 @@ note: `rec` defined here
 LL | / fn rec<T>(mut it: T)
 LL | | where
 LL | |     T: Iterator,
-LL | | {
-...  |
-LL | |     }
-LL | | }
-   | |_^
+   | |________________^
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-8727.stderr
+++ b/src/test/ui/issues/issue-8727.stderr
@@ -18,10 +18,8 @@ LL |     generic::<Option<T>>();
 note: `generic` defined here
   --> $DIR/issue-8727.rs:6:1
    |
-LL | / fn generic<T>() {
-LL | |     generic::<Option<T>>();
-LL | | }
-   | |_^
+LL | fn generic<T>() {
+   | ^^^^^^^^^^^^^^^
 
 error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui/marker_trait_attr/marker-trait-with-associated-items.stderr
+++ b/src/test/ui/marker_trait_attr/marker-trait-with-associated-items.stderr
@@ -32,7 +32,7 @@ error[E0714]: marker traits cannot have associated items
   --> $DIR/marker-trait-with-associated-items.rs:36:5
    |
 LL |     fn foo() {}
-   |     ^^^^^^^^^^^
+   |     ^^^^^^^^
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/nll/issue-52742.stderr
+++ b/src/test/ui/nll/issue-52742.stderr
@@ -12,11 +12,8 @@ LL | impl Foo<'_, '_> {
 note: ...but the borrowed content is only valid for the anonymous lifetime #2 defined on the method body at 13:5
   --> $DIR/issue-52742.rs:13:5
    |
-LL | /     fn take_bar(&mut self, b: Bar<'_>) {
-LL | |         self.y = b.z
-LL | |
-LL | |     }
-   | |_____^
+LL |     fn take_bar(&mut self, b: Bar<'_>) {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/issue-55394.stderr
+++ b/src/test/ui/nll/issue-55394.stderr
@@ -7,10 +7,8 @@ LL |         Foo { bar }
 note: first, the lifetime cannot outlive the anonymous lifetime #1 defined on the method body at 8:5...
   --> $DIR/issue-55394.rs:8:5
    |
-LL | /     fn new(bar: &mut Bar) -> Self {
-LL | |         Foo { bar }
-LL | |     }
-   | |_____^
+LL |     fn new(bar: &mut Bar) -> Self {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: ...so that reference does not outlive borrowed content
   --> $DIR/issue-55394.rs:9:15
    |

--- a/src/test/ui/nll/type-alias-free-regions.stderr
+++ b/src/test/ui/nll/type-alias-free-regions.stderr
@@ -7,10 +7,8 @@ LL |         C { f: b }
 note: first, the lifetime cannot outlive the anonymous lifetime #1 defined on the method body at 16:5...
   --> $DIR/type-alias-free-regions.rs:16:5
    |
-LL | /     fn from_box(b: Box<B>) -> Self {
-LL | |         C { f: b }
-LL | |     }
-   | |_____^
+LL |     fn from_box(b: Box<B>) -> Self {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: ...so that the expression is assignable
   --> $DIR/type-alias-free-regions.rs:17:16
    |
@@ -40,10 +38,8 @@ LL |         C { f: Box::new(b.0) }
 note: first, the lifetime cannot outlive the anonymous lifetime #1 defined on the method body at 26:5...
   --> $DIR/type-alias-free-regions.rs:26:5
    |
-LL | /     fn from_tuple(b: (B,)) -> Self {
-LL | |         C { f: Box::new(b.0) }
-LL | |     }
-   | |_____^
+LL |     fn from_tuple(b: (B,)) -> Self {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: ...so that the expression is assignable
   --> $DIR/type-alias-free-regions.rs:27:25
    |

--- a/src/test/ui/panic-handler/panic-handler-bad-signature-4.stderr
+++ b/src/test/ui/panic-handler/panic-handler-bad-signature-4.stderr
@@ -1,11 +1,8 @@
 error: should have no type parameters
   --> $DIR/panic-handler-bad-signature-4.rs:9:1
    |
-LL | / fn panic<T>(pi: &PanicInfo) -> ! {
-LL | |
-LL | |     loop {}
-LL | | }
-   | |_^
+LL | fn panic<T>(pi: &PanicInfo) -> ! {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/panic-handler/panic-handler-duplicate.stderr
+++ b/src/test/ui/panic-handler/panic-handler-duplicate.stderr
@@ -1,18 +1,14 @@
 error[E0152]: found duplicate lang item `panic_impl`
   --> $DIR/panic-handler-duplicate.rs:15:1
    |
-LL | / fn panic2(info: &PanicInfo) -> ! {
-LL | |     loop {}
-LL | | }
-   | |_^
+LL | fn panic2(info: &PanicInfo) -> ! {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: the lang item is first defined here
   --> $DIR/panic-handler-duplicate.rs:10:1
    |
-LL | / fn panic(info: &PanicInfo) -> ! {
-LL | |     loop {}
-LL | | }
-   | |_^
+LL | fn panic(info: &PanicInfo) -> ! {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/panic-handler/panic-handler-std.stderr
+++ b/src/test/ui/panic-handler/panic-handler-std.stderr
@@ -1,10 +1,8 @@
 error[E0152]: found duplicate lang item `panic_impl`
   --> $DIR/panic-handler-std.rs:8:1
    |
-LL | / fn panic(info: PanicInfo) -> ! {
-LL | |     loop {}
-LL | | }
-   | |_^
+LL | fn panic(info: PanicInfo) -> ! {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: the lang item is first defined in crate `std` (which `panic_handler_std` depends on)
    = note: first definition in `std` loaded from SYSROOT/libstd-*.rlib

--- a/src/test/ui/privacy/private-in-public-lint.stderr
+++ b/src/test/ui/privacy/private-in-public-lint.stderr
@@ -5,7 +5,7 @@ LL |     struct Priv;
    |     - `m1::Priv` declared as private
 ...
 LL |         pub fn f() -> Priv {Priv}
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak private type
+   |         ^^^^^^^^^^^^^^^^^^ can't leak private type
 
 error[E0446]: private type `m2::Priv` in public interface
   --> $DIR/private-in-public-lint.rs:15:9
@@ -14,7 +14,7 @@ LL |     struct Priv;
    |     - `m2::Priv` declared as private
 ...
 LL |         pub fn f() -> Priv {Priv}
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak private type
+   |         ^^^^^^^^^^^^^^^^^^ can't leak private type
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/privacy/private-in-public-non-principal.stderr
+++ b/src/test/ui/privacy/private-in-public-non-principal.stderr
@@ -2,7 +2,7 @@ warning: private trait `PrivNonPrincipal` in public interface (error E0445)
   --> $DIR/private-in-public-non-principal.rs:7:1
    |
 LL | pub fn leak_dyn_nonprincipal() -> Box<dyn PubPrincipal + PrivNonPrincipal> { loop {} }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(private_in_public)]` on by default
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!

--- a/src/test/ui/privacy/private-in-public-warn.stderr
+++ b/src/test/ui/privacy/private-in-public-warn.stderr
@@ -52,7 +52,7 @@ error: private type `types::Priv` in public interface (error E0446)
   --> $DIR/private-in-public-warn.rs:27:9
    |
 LL |         fn f1(arg: Priv) {}
-   |         ^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
@@ -61,7 +61,7 @@ error: private type `types::Priv` in public interface (error E0446)
   --> $DIR/private-in-public-warn.rs:29:9
    |
 LL |         fn f2() -> Priv { panic!() }
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
@@ -148,7 +148,7 @@ error: private trait `traits::PrivTr` in public interface (error E0445)
   --> $DIR/private-in-public-warn.rs:61:9
    |
 LL |         fn f<T: PrivTr>(arg: T) {}
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
@@ -193,7 +193,7 @@ error: private trait `traits_where::PrivTr` in public interface (error E0445)
   --> $DIR/private-in-public-warn.rs:83:9
    |
 LL |         fn f<T>(arg: T) where T: PrivTr {}
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
@@ -265,7 +265,7 @@ error: private type `aliases_pub::Priv` in public interface (error E0446)
   --> $DIR/private-in-public-warn.rs:206:9
    |
 LL |         pub fn f(arg: Priv) {}
-   |         ^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>

--- a/src/test/ui/privacy/private-in-public.stderr
+++ b/src/test/ui/privacy/private-in-public.stderr
@@ -23,7 +23,7 @@ LL |     struct Priv;
    |     - `types::Priv` declared as private
 ...
 LL |     pub fn f1(arg: Priv) {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^ can't leak private type
+   |     ^^^^^^^^^^^^^^^^^^^^ can't leak private type
 
 error[E0446]: private type `types::Priv` in public interface
   --> $DIR/private-in-public.rs:16:5
@@ -32,7 +32,7 @@ LL |     struct Priv;
    |     - `types::Priv` declared as private
 ...
 LL |     pub fn f2() -> Priv { panic!() }
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak private type
+   |     ^^^^^^^^^^^^^^^^^^^ can't leak private type
 
 error[E0446]: private type `types::Priv` in public interface
   --> $DIR/private-in-public.rs:17:19
@@ -68,7 +68,7 @@ LL |     struct Priv;
    |     - `types::Priv` declared as private
 ...
 LL |         pub fn f1(arg: Priv) {}
-   |         ^^^^^^^^^^^^^^^^^^^^^^^ can't leak private type
+   |         ^^^^^^^^^^^^^^^^^^^^ can't leak private type
 
 error[E0446]: private type `types::Priv` in public interface
   --> $DIR/private-in-public.rs:22:9
@@ -77,7 +77,7 @@ LL |     struct Priv;
    |     - `types::Priv` declared as private
 ...
 LL |         pub fn f2() -> Priv { panic!() }
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak private type
+   |         ^^^^^^^^^^^^^^^^^^^ can't leak private type
 
 error[E0445]: private trait `traits::PrivTr` in public interface
   --> $DIR/private-in-public.rs:31:5
@@ -95,7 +95,7 @@ LL |     trait PrivTr {}
    |     - `traits::PrivTr` declared as private
 ...
 LL |     pub fn f<T: PrivTr>(arg: T) {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak private trait
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak private trait
 
 error[E0445]: private trait `traits::PrivTr` in public interface
   --> $DIR/private-in-public.rs:33:5
@@ -124,7 +124,7 @@ LL |     trait PrivTr {}
    |     - `traits::PrivTr` declared as private
 ...
 LL |         pub fn f<U: PrivTr>(arg: U) {}
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak private trait
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak private trait
 
 error[E0445]: private trait `traits_where::PrivTr` in public interface
   --> $DIR/private-in-public.rs:44:5
@@ -142,7 +142,7 @@ LL |     trait PrivTr {}
    |     - `traits_where::PrivTr` declared as private
 ...
 LL |     pub fn f<T>(arg: T) where T: PrivTr {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak private trait
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak private trait
 
 error[E0445]: private trait `traits_where::PrivTr` in public interface
   --> $DIR/private-in-public.rs:48:5
@@ -173,7 +173,7 @@ LL |     trait PrivTr {}
    |     - `traits_where::PrivTr` declared as private
 ...
 LL |         pub fn f<U>(arg: U) where U: PrivTr {}
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak private trait
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak private trait
 
 error[E0446]: private type `generics::Priv` in public interface
   --> $DIR/private-in-public.rs:63:5
@@ -182,7 +182,7 @@ LL |     struct Priv<T = u8>(T);
    |     - `generics::Priv` declared as private
 ...
 LL |     pub fn f1(arg: [Priv; 1]) {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak private type
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak private type
 
 error[E0446]: private type `generics::Priv` in public interface
   --> $DIR/private-in-public.rs:64:5
@@ -191,7 +191,7 @@ LL |     struct Priv<T = u8>(T);
    |     - `generics::Priv` declared as private
 ...
 LL |     pub fn f2(arg: Pub<Priv>) {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak private type
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak private type
 
 error[E0446]: private type `generics::Priv<generics::Pub>` in public interface
   --> $DIR/private-in-public.rs:65:5
@@ -200,7 +200,7 @@ LL |     struct Priv<T = u8>(T);
    |     - `generics::Priv<generics::Pub>` declared as private
 ...
 LL |     pub fn f3(arg: Priv<Pub>) {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak private type
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak private type
 
 error[E0446]: private type `impls::Priv` in public interface
   --> $DIR/private-in-public.rs:80:9
@@ -209,7 +209,7 @@ LL |     struct Priv;
    |     - `impls::Priv` declared as private
 ...
 LL |         pub fn f(arg: Priv) {}
-   |         ^^^^^^^^^^^^^^^^^^^^^^ can't leak private type
+   |         ^^^^^^^^^^^^^^^^^^^ can't leak private type
 
 error[E0445]: private trait `aliases_pub::PrivTr` in public interface
   --> $DIR/private-in-public.rs:104:5
@@ -218,7 +218,7 @@ LL |     trait PrivTr {
    |     - `aliases_pub::PrivTr` declared as private
 ...
 LL |     pub fn f3(arg: <Priv as PrivTr>::Assoc) {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak private trait
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak private trait
 
 error[E0446]: private type `aliases_pub::Priv` in public interface
   --> $DIR/private-in-public.rs:104:5
@@ -227,7 +227,7 @@ LL |     struct Priv;
    |     - `aliases_pub::Priv` declared as private
 ...
 LL |     pub fn f3(arg: <Priv as PrivTr>::Assoc) {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak private type
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak private type
 
 error[E0446]: private type `aliases_pub::Priv` in public interface
   --> $DIR/private-in-public.rs:109:9
@@ -236,7 +236,7 @@ LL |     struct Priv;
    |     - `aliases_pub::Priv` declared as private
 ...
 LL |         pub fn f(arg: Priv) {}
-   |         ^^^^^^^^^^^^^^^^^^^^^^ can't leak private type
+   |         ^^^^^^^^^^^^^^^^^^^ can't leak private type
 
 error[E0446]: private type `aliases_priv::Priv1` in public interface
   --> $DIR/private-in-public.rs:131:5
@@ -245,7 +245,7 @@ LL |     struct Priv1;
    |     - `aliases_priv::Priv1` declared as private
 ...
 LL |     pub fn f1(arg: PrivUseAlias) {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak private type
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak private type
 
 error[E0446]: private type `aliases_priv::Priv2` in public interface
   --> $DIR/private-in-public.rs:132:5
@@ -254,7 +254,7 @@ LL |     struct Priv2;
    |     - `aliases_priv::Priv2` declared as private
 ...
 LL |     pub fn f2(arg: PrivAlias) {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak private type
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak private type
 
 error[E0445]: private trait `aliases_priv::PrivTr` in public interface
   --> $DIR/private-in-public.rs:133:5
@@ -263,7 +263,7 @@ LL |     trait PrivTr {
    |     - `aliases_priv::PrivTr` declared as private
 ...
 LL |     pub fn f3(arg: <Priv as PrivTr>::Assoc) {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak private trait
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak private trait
 
 error[E0446]: private type `aliases_priv::Priv` in public interface
   --> $DIR/private-in-public.rs:133:5
@@ -272,7 +272,7 @@ LL |     struct Priv;
    |     - `aliases_priv::Priv` declared as private
 ...
 LL |     pub fn f3(arg: <Priv as PrivTr>::Assoc) {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak private type
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak private type
 
 error[E0446]: private type `aliases_params::Priv` in public interface
   --> $DIR/private-in-public.rs:143:5
@@ -281,7 +281,7 @@ LL |     struct Priv;
    |     - `aliases_params::Priv` declared as private
 ...
 LL |     pub fn f2(arg: PrivAliasGeneric) {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak private type
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak private type
 
 error[E0446]: private type `aliases_params::Priv` in public interface
   --> $DIR/private-in-public.rs:145:5
@@ -290,7 +290,7 @@ LL |     struct Priv;
    |     - `aliases_params::Priv` declared as private
 ...
 LL |     pub fn f3(arg: Result<u8>) {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak private type
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak private type
 
 error: aborting due to 32 previous errors
 

--- a/src/test/ui/privacy/pub-priv-dep/pub-priv1.stderr
+++ b/src/test/ui/privacy/pub-priv-dep/pub-priv1.stderr
@@ -14,7 +14,7 @@ error: type `priv_dep::OtherType` from private dependency 'priv_dep' in public i
   --> $DIR/pub-priv1.rs:27:5
    |
 LL |     pub fn pub_fn(param: OtherType) {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: trait `priv_dep::OtherTrait` from private dependency 'priv_dep' in public interface
   --> $DIR/pub-priv1.rs:33:1

--- a/src/test/ui/privacy/restricted/private-in-public.stderr
+++ b/src/test/ui/privacy/restricted/private-in-public.stderr
@@ -5,7 +5,7 @@ LL |     struct Priv;
    |     - `foo::Priv` declared as private
 ...
 LL |         pub(crate) fn g(_: Priv) {}
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak private type
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^ can't leak private type
 
 error[E0446]: private type `foo::Priv` in public interface
   --> $DIR/private-in-public.rs:9:9
@@ -14,7 +14,7 @@ LL |     struct Priv;
    |     - `foo::Priv` declared as private
 ...
 LL |         crate fn h(_: Priv) {}
-   |         ^^^^^^^^^^^^^^^^^^^^^^ can't leak private type
+   |         ^^^^^^^^^^^^^^^^^^^ can't leak private type
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/proc-macro/no-macro-use-attr.stderr
+++ b/src/test/ui/proc-macro/no-macro-use-attr.stderr
@@ -14,7 +14,7 @@ error: fatal error triggered by #[rustc_error]
   --> $DIR/no-macro-use-attr.rs:10:1
    |
 LL | fn main() {}
-   | ^^^^^^^^^^^^
+   | ^^^^^^^^^
 
 error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui/recursion/recursion.stderr
+++ b/src/test/ui/recursion/recursion.stderr
@@ -7,13 +7,8 @@ LL |     _ => {test (n-1, i+1, Cons {head:2*i+1, tail:first}, Cons{head:i*i, tai
 note: `test` defined here
   --> $DIR/recursion.rs:15:1
    |
-LL | / fn test<T:Dot> (n:isize, i:isize, first:T, second:T) ->isize {
-LL | |   match n {    0 => {first.dot(second)}
-LL | |     _ => {test (n-1, i+1, Cons {head:2*i+1, tail:first}, Cons{head:i*i, tail:second})}
-LL | |
-LL | |   }
-LL | | }
-   | |_^
+LL | fn test<T:Dot> (n:isize, i:isize, first:T, second:T) ->isize {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/regions/regions-infer-paramd-indirect.stderr
+++ b/src/test/ui/regions/regions-infer-paramd-indirect.stderr
@@ -9,14 +9,8 @@ LL |         self.f = b;
 note: the anonymous lifetime #2 defined on the method body at 21:5...
   --> $DIR/regions-infer-paramd-indirect.rs:21:5
    |
-LL | /     fn set_f_bad(&mut self, b: Box<B>) {
-LL | |         self.f = b;
-LL | |
-LL | |
-LL | |
-LL | |
-LL | |     }
-   | |_____^
+LL |     fn set_f_bad(&mut self, b: Box<B>) {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: ...does not necessarily outlive the lifetime `'a` as defined on the impl at 16:6
   --> $DIR/regions-infer-paramd-indirect.rs:16:6
    |

--- a/src/test/ui/regions/regions-normalize-in-where-clause-list.stderr
+++ b/src/test/ui/regions/regions-normalize-in-where-clause-list.stderr
@@ -5,9 +5,7 @@ LL | / fn bar<'a, 'b>()
 LL | |
 LL | |
 LL | |     where <() as Project<'a, 'b>>::Item : Eq
-LL | | {
-LL | | }
-   | |_^
+   | |____________________________________________^
    |
 note: first, the lifetime cannot outlive the lifetime `'a` as defined on the function body at 22:8...
   --> $DIR/regions-normalize-in-where-clause-list.rs:22:8
@@ -26,9 +24,7 @@ LL | / fn bar<'a, 'b>()
 LL | |
 LL | |
 LL | |     where <() as Project<'a, 'b>>::Item : Eq
-LL | | {
-LL | | }
-   | |_^
+   | |____________________________________________^
    = note: expected `Project<'a, 'b>`
               found `Project<'_, '_>`
 
@@ -39,9 +35,7 @@ LL | / fn bar<'a, 'b>()
 LL | |
 LL | |
 LL | |     where <() as Project<'a, 'b>>::Item : Eq
-LL | | {
-LL | | }
-   | |_^
+   | |____________________________________________^
    |
 note: first, the lifetime cannot outlive the lifetime `'a` as defined on the function body at 22:8...
   --> $DIR/regions-normalize-in-where-clause-list.rs:22:8
@@ -60,9 +54,7 @@ LL | / fn bar<'a, 'b>()
 LL | |
 LL | |
 LL | |     where <() as Project<'a, 'b>>::Item : Eq
-LL | | {
-LL | | }
-   | |_^
+   | |____________________________________________^
    = note: expected `Project<'a, 'b>`
               found `Project<'_, '_>`
 

--- a/src/test/ui/regions/regions-trait-1.stderr
+++ b/src/test/ui/regions/regions-trait-1.stderr
@@ -14,10 +14,8 @@ LL | impl<'a> GetCtxt for HasCtxt<'a> {
 note: ...does not necessarily outlive the anonymous lifetime #1 defined on the method body at 16:5
   --> $DIR/regions-trait-1.rs:16:5
    |
-LL | /     fn get_ctxt(&self) -> &'a Ctxt {
-LL | |         self.c
-LL | |     }
-   | |_____^
+LL |     fn get_ctxt(&self) -> &'a Ctxt {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/rfc-2091-track-caller/error-with-main.stderr
+++ b/src/test/ui/rfc-2091-track-caller/error-with-main.stderr
@@ -1,12 +1,10 @@
 error: `main` function is not allowed to be `#[track_caller]`
   --> $DIR/error-with-main.rs:1:1
    |
-LL |   #[track_caller]
-   |   ^^^^^^^^^^^^^^^
-LL | / fn main() {
-LL | |     panic!("{}: oh no", std::panic::Location::caller());
-LL | | }
-   | |_- `main` function is not allowed to be `#[track_caller]`
+LL | #[track_caller]
+   | ^^^^^^^^^^^^^^^
+LL | fn main() {
+   | --------- `main` function is not allowed to be `#[track_caller]`
 
 error: aborting due to previous error
 

--- a/src/test/ui/rfc-2091-track-caller/error-with-start.stderr
+++ b/src/test/ui/rfc-2091-track-caller/error-with-start.stderr
@@ -1,12 +1,10 @@
 error: `start` is not allowed to be `#[track_caller]`
   --> $DIR/error-with-start.rs:4:1
    |
-LL |   #[track_caller]
-   |   ^^^^^^^^^^^^^^^
-LL | / fn start(_argc: isize, _argv: *const *const u8) -> isize {
-LL | |     panic!("{}: oh no", std::panic::Location::caller());
-LL | | }
-   | |_- `start` is not allowed to be `#[track_caller]`
+LL | #[track_caller]
+   | ^^^^^^^^^^^^^^^
+LL | fn start(_argc: isize, _argv: *const *const u8) -> isize {
+   | -------------------------------------------------------- `start` is not allowed to be `#[track_caller]`
 
 error: aborting due to previous error
 

--- a/src/test/ui/rfc-2632-const-trait-impl/const-trait-bound-opt-out/feature-gate.gated.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/const-trait-bound-opt-out/feature-gate.gated.stderr
@@ -2,7 +2,7 @@ error: fatal error triggered by #[rustc_error]
   --> $DIR/feature-gate.rs:16:1
    |
 LL | fn main() {}
-   | ^^^^^^^^^^^^
+   | ^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/rfc-2632-const-trait-impl/feature-gate.gated.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/feature-gate.gated.stderr
@@ -2,7 +2,7 @@ error: fatal error triggered by #[rustc_error]
   --> $DIR/feature-gate.rs:14:1
    |
 LL | fn main() {}
-   | ^^^^^^^^^^^^
+   | ^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/rfc1445/feature-gate.with_gate.stderr
+++ b/src/test/ui/rfc1445/feature-gate.with_gate.stderr
@@ -1,14 +1,8 @@
 error: fatal error triggered by #[rustc_error]
   --> $DIR/feature-gate.rs:21:1
    |
-LL | / fn main() {
-LL | |     let y = Foo { x: 1 };
-LL | |     match y {
-LL | |         FOO => { }
-LL | |         _ => { }
-LL | |     }
-LL | | }
-   | |_^
+LL | fn main() {
+   | ^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/rfcs/rfc-2396-target_feature-11/feature-gate-target_feature_11.stderr
+++ b/src/test/ui/rfcs/rfc-2396-target_feature-11/feature-gate-target_feature_11.stderr
@@ -4,7 +4,7 @@ error[E0658]: `#[target_feature(..)]` can only be applied to `unsafe` functions
 LL | #[target_feature(enable = "sse2")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 LL | fn foo() {}
-   | ----------- not an `unsafe` function
+   | -------- not an `unsafe` function
    |
    = note: see issue #69098 <https://github.com/rust-lang/rust/issues/69098> for more information
    = help: add `#![feature(target_feature_11)]` to the crate attributes to enable

--- a/src/test/ui/rfcs/rfc-2396-target_feature-11/trait-impl.stderr
+++ b/src/test/ui/rfcs/rfc-2396-target_feature-11/trait-impl.stderr
@@ -5,7 +5,7 @@ LL |     #[target_feature(enable = "sse2")]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot be applied to safe trait method
 LL |
 LL |     fn foo(&self) {}
-   |     ---------------- not an `unsafe` function
+   |     ------------- not an `unsafe` function
 
 error: aborting due to previous error
 

--- a/src/test/ui/rustc-error.stderr
+++ b/src/test/ui/rustc-error.stderr
@@ -1,10 +1,8 @@
 error: fatal error triggered by #[rustc_error]
   --> $DIR/rustc-error.rs:4:1
    |
-LL | / fn main() {
-LL | |
-LL | | }
-   | |_^
+LL | fn main() {
+   | ^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/specialization/specialization-overlap-hygiene.stderr
+++ b/src/test/ui/specialization/specialization-overlap-hygiene.stderr
@@ -2,10 +2,10 @@ error[E0592]: duplicate definitions with name `f`
   --> $DIR/specialization-overlap-hygiene.rs:13:4
    |
 LL |     fn f() {}
-   |     --------- other definition for `f`
+   |     ------ other definition for `f`
 ...
 LL |    fn f() {}
-   |    ^^^^^^^^^ duplicate definitions for `f`
+   |    ^^^^^^ duplicate definitions for `f`
 
 error: aborting due to previous error
 

--- a/src/test/ui/suggestions/issue-51055-missing-semicolon-between-call-and-tuple.stderr
+++ b/src/test/ui/suggestions/issue-51055-missing-semicolon-between-call-and-tuple.stderr
@@ -2,7 +2,7 @@ error[E0618]: expected function, found `bool`
   --> $DIR/issue-51055-missing-semicolon-between-call-and-tuple.rs:4:5
    |
 LL |   fn vindictive() -> bool { true }
-   |   -------------------------------- `vindictive` defined here returns `bool`
+   |   ----------------------- `vindictive` defined here returns `bool`
 ...
 LL |       vindictive()
    |       -^^^^^^^^^^^- help: try adding a semicolon: `;`

--- a/src/test/ui/suggestions/lifetimes/missing-lifetimes-in-signature.nll.stderr
+++ b/src/test/ui/suggestions/lifetimes/missing-lifetimes-in-signature.nll.stderr
@@ -32,10 +32,7 @@ LL | / fn bar<G, T>(g: G, dest: &mut T) -> impl FnOnce() + '_
 LL | |
 LL | | where
 LL | |     G: Get<T>
-...  |
-LL | |     }
-LL | | }
-   | |_^
+   | |_____________^
 
 error[E0311]: the parameter type `G` may not live long enough
   --> $DIR/missing-lifetimes-in-signature.rs:47:45
@@ -50,10 +47,7 @@ LL | / fn qux<'a, G: 'a, T>(g: G, dest: &mut T) -> impl FnOnce() + '_
 LL | |
 LL | | where
 LL | |     G: Get<T>
-...  |
-LL | |     }
-LL | | }
-   | |_^
+   | |_____________^
 
 error[E0311]: the parameter type `G` may not live long enough
   --> $DIR/missing-lifetimes-in-signature.rs:59:58
@@ -64,13 +58,8 @@ LL |     fn qux<'b, G: Get<T> + 'b, T>(g: G, dest: &mut T) -> impl FnOnce() + '_
 note: the parameter type `G` must be valid for the anonymous lifetime #1 defined on the method body at 59:5...
   --> $DIR/missing-lifetimes-in-signature.rs:59:5
    |
-LL | /     fn qux<'b, G: Get<T> + 'b, T>(g: G, dest: &mut T) -> impl FnOnce() + '_ {
-LL | |
-LL | |         move || {
-LL | |             *dest = g.get();
-LL | |         }
-LL | |     }
-   | |_____^
+LL |     fn qux<'b, G: Get<T> + 'b, T>(g: G, dest: &mut T) -> impl FnOnce() + '_ {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0311]: the parameter type `G` may not live long enough
   --> $DIR/missing-lifetimes-in-signature.rs:68:45
@@ -85,10 +74,7 @@ LL | / fn bat<'a, G: 'a, T>(g: G, dest: &mut T) -> impl FnOnce() + '_ + 'a
 LL | |
 LL | | where
 LL | |     G: Get<T>
-...  |
-LL | |     }
-LL | | }
-   | |_^
+   | |_____________^
 
 error[E0621]: explicit lifetime required in the type of `dest`
   --> $DIR/missing-lifetimes-in-signature.rs:73:5

--- a/src/test/ui/suggestions/lifetimes/missing-lifetimes-in-signature.stderr
+++ b/src/test/ui/suggestions/lifetimes/missing-lifetimes-in-signature.stderr
@@ -40,10 +40,7 @@ LL | / fn bar<G, T>(g: G, dest: &mut T) -> impl FnOnce() + '_
 LL | |
 LL | | where
 LL | |     G: Get<T>
-...  |
-LL | |     }
-LL | | }
-   | |_^
+   | |_____________^
 note: ...so that the type `[closure@$DIR/missing-lifetimes-in-signature.rs:30:5: 32:6 g:G, dest:&mut T]` will meet its required lifetime bounds
   --> $DIR/missing-lifetimes-in-signature.rs:25:37
    |
@@ -67,10 +64,7 @@ LL | / fn qux<'a, G: 'a, T>(g: G, dest: &mut T) -> impl FnOnce() + '_
 LL | |
 LL | | where
 LL | |     G: Get<T>
-...  |
-LL | |     }
-LL | | }
-   | |_^
+   | |_____________^
 note: ...so that the type `[closure@$DIR/missing-lifetimes-in-signature.rs:52:5: 54:6 g:G, dest:&mut T]` will meet its required lifetime bounds
   --> $DIR/missing-lifetimes-in-signature.rs:47:45
    |
@@ -90,13 +84,8 @@ LL |     fn qux<'b, G: Get<T> + 'b, T>(g: G, dest: &mut T) -> impl FnOnce() + '_
 note: the parameter type `G` must be valid for the anonymous lifetime #1 defined on the method body at 59:5...
   --> $DIR/missing-lifetimes-in-signature.rs:59:5
    |
-LL | /     fn qux<'b, G: Get<T> + 'b, T>(g: G, dest: &mut T) -> impl FnOnce() + '_ {
-LL | |
-LL | |         move || {
-LL | |             *dest = g.get();
-LL | |         }
-LL | |     }
-   | |_____^
+LL |     fn qux<'b, G: Get<T> + 'b, T>(g: G, dest: &mut T) -> impl FnOnce() + '_ {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: ...so that the type `[closure@$DIR/missing-lifetimes-in-signature.rs:61:9: 63:10 g:G, dest:&mut T]` will meet its required lifetime bounds
   --> $DIR/missing-lifetimes-in-signature.rs:59:58
    |

--- a/src/test/ui/target-feature/invalid-attribute.stderr
+++ b/src/test/ui/target-feature/invalid-attribute.stderr
@@ -29,7 +29,7 @@ LL | #[target_feature(enable = "sse2")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
 LL | fn bar() {}
-   | ----------- not an `unsafe` function
+   | -------- not an `unsafe` function
    |
    = note: see issue #69098 <https://github.com/rust-lang/rust/issues/69098> for more information
    = help: add `#![feature(target_feature_11)]` to the crate attributes to enable
@@ -113,7 +113,7 @@ LL |     #[target_feature(enable = "sse2")]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
 LL |     fn foo() {}
-   |     ----------- not an `unsafe` function
+   |     -------- not an `unsafe` function
    |
    = note: see issue #69098 <https://github.com/rust-lang/rust/issues/69098> for more information
    = help: add `#![feature(target_feature_11)]` to the crate attributes to enable

--- a/src/test/ui/traits/trait-object-auto-dedup-in-impl.stderr
+++ b/src/test/ui/traits/trait-object-auto-dedup-in-impl.stderr
@@ -2,10 +2,10 @@ error[E0592]: duplicate definitions with name `test`
   --> $DIR/trait-object-auto-dedup-in-impl.rs:14:5
    |
 LL |     fn test(&self) { println!("one"); }
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ duplicate definitions for `test`
+   |     ^^^^^^^^^^^^^^ duplicate definitions for `test`
 ...
 LL |     fn test(&self) { println!("two"); }
-   |     ----------------------------------- other definition for `test`
+   |     -------------- other definition for `test`
 
 error: aborting due to previous error
 

--- a/src/test/ui/type-alias-impl-trait/different_defining_uses.stderr
+++ b/src/test/ui/type-alias-impl-trait/different_defining_uses.stderr
@@ -1,18 +1,14 @@
 error: concrete type differs from previous defining opaque type use
   --> $DIR/different_defining_uses.rs:12:1
    |
-LL | / fn bar() -> Foo {
-LL | |     42i32
-LL | | }
-   | |_^ expected `&'static str`, got `i32`
+LL | fn bar() -> Foo {
+   | ^^^^^^^^^^^^^^^ expected `&'static str`, got `i32`
    |
 note: previous use here
   --> $DIR/different_defining_uses.rs:8:1
    |
-LL | / fn foo() -> Foo {
-LL | |     ""
-LL | | }
-   | |_^
+LL | fn foo() -> Foo {
+   | ^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/type-alias-impl-trait/different_defining_uses_never_type.stderr
+++ b/src/test/ui/type-alias-impl-trait/different_defining_uses_never_type.stderr
@@ -1,34 +1,26 @@
 error: concrete type differs from previous defining opaque type use
   --> $DIR/different_defining_uses_never_type.rs:12:1
    |
-LL | / fn bar() -> Foo {
-LL | |     panic!()
-LL | | }
-   | |_^ expected `&'static str`, got `()`
+LL | fn bar() -> Foo {
+   | ^^^^^^^^^^^^^^^ expected `&'static str`, got `()`
    |
 note: previous use here
   --> $DIR/different_defining_uses_never_type.rs:8:1
    |
-LL | / fn foo() -> Foo {
-LL | |     ""
-LL | | }
-   | |_^
+LL | fn foo() -> Foo {
+   | ^^^^^^^^^^^^^^^
 
 error: concrete type differs from previous defining opaque type use
   --> $DIR/different_defining_uses_never_type.rs:16:1
    |
-LL | / fn boo() -> Foo {
-LL | |     loop {}
-LL | | }
-   | |_^ expected `&'static str`, got `()`
+LL | fn boo() -> Foo {
+   | ^^^^^^^^^^^^^^^ expected `&'static str`, got `()`
    |
 note: previous use here
   --> $DIR/different_defining_uses_never_type.rs:8:1
    |
-LL | / fn foo() -> Foo {
-LL | |     ""
-LL | | }
-   | |_^
+LL | fn foo() -> Foo {
+   | ^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/type-alias-impl-trait/generic_different_defining_uses.stderr
+++ b/src/test/ui/type-alias-impl-trait/generic_different_defining_uses.stderr
@@ -1,18 +1,14 @@
 error: concrete type differs from previous defining opaque type use
   --> $DIR/generic_different_defining_uses.rs:11:1
    |
-LL | / fn my_iter2<T>(t: T) -> MyIter<T> {
-LL | |     Some(t).into_iter()
-LL | | }
-   | |_^ expected `std::iter::Once<T>`, got `std::option::IntoIter<T>`
+LL | fn my_iter2<T>(t: T) -> MyIter<T> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `std::iter::Once<T>`, got `std::option::IntoIter<T>`
    |
 note: previous use here
   --> $DIR/generic_different_defining_uses.rs:7:1
    |
-LL | / fn my_iter<T>(t: T) -> MyIter<T> {
-LL | |     std::iter::once(t)
-LL | | }
-   | |_^
+LL | fn my_iter<T>(t: T) -> MyIter<T> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use2.stderr
+++ b/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use2.stderr
@@ -1,19 +1,14 @@
 error: concrete type differs from previous defining opaque type use
   --> $DIR/generic_duplicate_param_use2.rs:14:1
    |
-LL | / fn two<T: Debug, U>(t: T, _: U) -> Two<T, U> {
-LL | |
-LL | |     t
-LL | | }
-   | |_^ expected `U`, got `T`
+LL | fn two<T: Debug, U>(t: T, _: U) -> Two<T, U> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `U`, got `T`
    |
 note: previous use here
   --> $DIR/generic_duplicate_param_use2.rs:10:1
    |
-LL | / fn one<T: Debug>(t: T) -> Two<T, T> {
-LL | |     t
-LL | | }
-   | |_^
+LL | fn one<T: Debug>(t: T) -> Two<T, T> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use3.stderr
+++ b/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use3.stderr
@@ -1,19 +1,14 @@
 error: concrete type differs from previous defining opaque type use
   --> $DIR/generic_duplicate_param_use3.rs:14:1
    |
-LL | / fn two<T: Debug, U>(t: T, _: U) -> Two<T, U> {
-LL | |
-LL | |     t
-LL | | }
-   | |_^ expected `U`, got `T`
+LL | fn two<T: Debug, U>(t: T, _: U) -> Two<T, U> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `U`, got `T`
    |
 note: previous use here
   --> $DIR/generic_duplicate_param_use3.rs:10:1
    |
-LL | / fn one<T: Debug>(t: T) -> Two<T, T> {
-LL | |     t
-LL | | }
-   | |_^
+LL | fn one<T: Debug>(t: T) -> Two<T, T> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use5.stderr
+++ b/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use5.stderr
@@ -1,19 +1,14 @@
 error: concrete type differs from previous defining opaque type use
   --> $DIR/generic_duplicate_param_use5.rs:14:1
    |
-LL | / fn three<T: Debug, U: Debug>(t: T, u: U) -> Two<T, U> {
-LL | |
-LL | |     (u, t)
-LL | | }
-   | |_^ expected `(T, U)`, got `(U, T)`
+LL | fn three<T: Debug, U: Debug>(t: T, u: U) -> Two<T, U> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `(T, U)`, got `(U, T)`
    |
 note: previous use here
   --> $DIR/generic_duplicate_param_use5.rs:10:1
    |
-LL | / fn two<T: Debug, U: Debug>(t: T, u: U) -> Two<T, U> {
-LL | |     (t, u)
-LL | | }
-   | |_^
+LL | fn two<T: Debug, U: Debug>(t: T, u: U) -> Two<T, U> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use6.stderr
+++ b/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use6.stderr
@@ -1,19 +1,14 @@
 error: concrete type differs from previous defining opaque type use
   --> $DIR/generic_duplicate_param_use6.rs:14:1
    |
-LL | / fn three<T: Copy + Debug, U: Debug>(t: T, u: U) -> Two<T, U> {
-LL | |
-LL | |     (u, t)
-LL | | }
-   | |_^ expected `(T, T)`, got `(U, T)`
+LL | fn three<T: Copy + Debug, U: Debug>(t: T, u: U) -> Two<T, U> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `(T, T)`, got `(U, T)`
    |
 note: previous use here
   --> $DIR/generic_duplicate_param_use6.rs:10:1
    |
-LL | / fn two<T: Copy + Debug, U: Debug>(t: T, u: U) -> Two<T, U> {
-LL | |     (t, t)
-LL | | }
-   | |_^
+LL | fn two<T: Copy + Debug, U: Debug>(t: T, u: U) -> Two<T, U> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use8.stderr
+++ b/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use8.stderr
@@ -1,19 +1,14 @@
 error: concrete type differs from previous defining opaque type use
   --> $DIR/generic_duplicate_param_use8.rs:13:1
    |
-LL | / fn three<T: Debug, U: Debug>(_: T, u: U) -> Two<T, U> {
-LL | |
-LL | |     (u, 4u32)
-LL | | }
-   | |_^ expected `(T, u32)`, got `(U, u32)`
+LL | fn three<T: Debug, U: Debug>(_: T, u: U) -> Two<T, U> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `(T, u32)`, got `(U, u32)`
    |
 note: previous use here
   --> $DIR/generic_duplicate_param_use8.rs:9:1
    |
-LL | / fn two<T: Debug, U: Debug>(t: T, _: U) -> Two<T, U> {
-LL | |     (t, 4u32)
-LL | | }
-   | |_^
+LL | fn two<T: Debug, U: Debug>(t: T, _: U) -> Two<T, U> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use9.stderr
+++ b/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use9.stderr
@@ -1,18 +1,14 @@
 error: concrete type differs from previous defining opaque type use
   --> $DIR/generic_duplicate_param_use9.rs:18:1
    |
-LL | / fn three<T: Debug, U: Debug>(t: T, u: U) -> Two<T, U> {
-LL | |     (t, u, 42)
-LL | | }
-   | |_^ expected `(A, B, <A as Foo>::Bar)`, got `(A, B, i32)`
+LL | fn three<T: Debug, U: Debug>(t: T, u: U) -> Two<T, U> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `(A, B, <A as Foo>::Bar)`, got `(A, B, i32)`
    |
 note: previous use here
   --> $DIR/generic_duplicate_param_use9.rs:14:1
    |
-LL | / fn two<T: Debug + Foo, U: Debug>(t: T, u: U) -> Two<T, U> {
-LL | |     (t, u, T::BAR)
-LL | | }
-   | |_^
+LL | fn two<T: Debug + Foo, U: Debug>(t: T, u: U) -> Two<T, U> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/type-alias-impl-trait/issue-52843-closure-constrain.stderr
+++ b/src/test/ui/type-alias-impl-trait/issue-52843-closure-constrain.stderr
@@ -8,7 +8,7 @@ note: previous use here
   --> $DIR/issue-52843-closure-constrain.rs:9:5
    |
 LL |     fn _unused() -> Opaque { String::new() }
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/type-alias-impl-trait/not_a_defining_use.stderr
+++ b/src/test/ui/type-alias-impl-trait/not_a_defining_use.stderr
@@ -1,18 +1,14 @@
 error: concrete type differs from previous defining opaque type use
   --> $DIR/not_a_defining_use.rs:29:1
    |
-LL | / fn four<T: Debug, U: Bar>(t: T) -> Two<T, U> {
-LL | |     (t, <U as Bar>::FOO)
-LL | | }
-   | |_^ expected `(T, i8)`, got `(T, <U as Bar>::Blub)`
+LL | fn four<T: Debug, U: Bar>(t: T) -> Two<T, U> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `(T, i8)`, got `(T, <U as Bar>::Blub)`
    |
 note: previous use here
   --> $DIR/not_a_defining_use.rs:9:1
    |
-LL | / fn two<T: Debug>(t: T) -> Two<T, u32> {
-LL | |     (t, 4i8)
-LL | | }
-   | |_^
+LL | fn two<T: Debug>(t: T) -> Two<T, u32> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/ufcs/ufcs-explicit-self-bad.stderr
+++ b/src/test/ui/ufcs/ufcs-explicit-self-bad.stderr
@@ -37,7 +37,7 @@ note: the anonymous lifetime #1 defined on the method body at 37:5...
   --> $DIR/ufcs-explicit-self-bad.rs:37:5
    |
 LL |     fn dummy2(self: &Bar<T>) {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^
 note: ...does not necessarily outlive the lifetime `'a` as defined on the impl at 35:6
   --> $DIR/ufcs-explicit-self-bad.rs:35:6
    |
@@ -61,7 +61,7 @@ note: ...does not necessarily outlive the anonymous lifetime #1 defined on the m
   --> $DIR/ufcs-explicit-self-bad.rs:37:5
    |
 LL |     fn dummy2(self: &Bar<T>) {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched `self` parameter type
   --> $DIR/ufcs-explicit-self-bad.rs:39:21
@@ -75,7 +75,7 @@ note: the anonymous lifetime #2 defined on the method body at 39:5...
   --> $DIR/ufcs-explicit-self-bad.rs:39:5
    |
 LL |     fn dummy3(self: &&Bar<T>) {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 note: ...does not necessarily outlive the lifetime `'a` as defined on the impl at 35:6
   --> $DIR/ufcs-explicit-self-bad.rs:35:6
    |
@@ -99,7 +99,7 @@ note: ...does not necessarily outlive the anonymous lifetime #2 defined on the m
   --> $DIR/ufcs-explicit-self-bad.rs:39:5
    |
 LL |     fn dummy3(self: &&Bar<T>) {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 7 previous errors
 


### PR DESCRIPTION
Currently, the def span of a function encompasses the entire function
signature and body. However, this is usually unnecessarily verbose - when we are
pointing at an entire function in a diagnostic, we almost always want to
point at the signature. The actual contents of the body tends to be
irrelevant to the diagnostic we are emitting, and just takes up
additional screen space.

This commit changes the `def_span` of all function items (freestanding
functions, `impl`-block methods, and `trait`-block methods) to be the
span of the signature. For example, the function

```rust
pub fn foo<T>(val: T) -> T { val }
```

now has a `def_span` corresponding to `pub fn foo<T>(val: T) -> T`
(everything before the opening curly brace).

Trait methods without a body have a `def_span` which includes the
trailing semicolon. For example:

```rust
trait Foo {
    fn bar();
}
```

the function definition `Foo::bar` has a `def_span` of `fn bar();`

This makes our diagnostic output much shorter, and emphasizes
information that is relevant to whatever diagnostic we are reporting.

We continue to use the full span (including the body) in a few of
places:

* MIR building uses the full span when building source scopes.
* 'Outlives suggestions' use the full span to sort the diagnostics being
  emitted.
* The `#[rustc_on_unimplemented(enclosing_scope="in this scope")]`
attribute points the entire scope body.

All of these cases work only with local items, so we don't need to
add anything extra to crate metadata.

