### PR TITLE
Change registered "program name" for -Cllvm-args usage messages

### DIFF
--- a/src/librustc_codegen_llvm/llvm_util.rs
+++ b/src/librustc_codegen_llvm/llvm_util.rs
@@ -73,7 +73,8 @@ unsafe fn configure_llvm(sess: &Session) {
                 llvm_c_strs.push(s);
             }
         };
-        add("rustc", true); // fake program name
+        // Set the llvm "program name" to make usage and invalid argument messages more clear.
+        add("rustc -Cllvm-args=\"...\" with", true);
         if sess.time_llvm_passes() {
             add("-time-passes", false);
         }

--- a/src/test/ui/unknown-llvm-arg.rs
+++ b/src/test/ui/unknown-llvm-arg.rs
@@ -1,0 +1,22 @@
+// compile-flags: -Cllvm-args=-not-a-real-llvm-arg
+// normalize-stderr-test "--help" -> "-help"
+// normalize-stderr-test "\n(\n|.)*" -> ""
+
+// I'm seeing "--help" locally, but "-help" in CI, so I'm normalizing it to just "-help".
+
+// Note that the rustc-supplied "program name", given when invoking LLVM, is used by LLVM to
+// generate user-facing error messages and a usage (--help) messages. If the program name is
+// `rustc`, the usage message in response to `--llvm-args="--help"` starts with:
+// ```
+//   USAGE: rustc [options]
+// ```
+// followed by the list of options not to `rustc` but to `llvm`.
+//
+// On the other hand, if the program name is set to `rustc -Cllvm-args="..." with`, the usage
+// message is more clear:
+// ```
+//   USAGE: rustc -Cllvm-args="..." with [options]
+// ```
+// This test captures the effect of the current program name setting on LLVM command line
+// error messages.
+fn main() {}

--- a/src/test/ui/unknown-llvm-arg.stderr
+++ b/src/test/ui/unknown-llvm-arg.stderr
@@ -1,0 +1,1 @@
+rustc -Cllvm-args="..." with: Unknown command line argument '-not-a-real-llvm-arg'.  Try: 'rustc -Cllvm-args="..." with -help'


### PR DESCRIPTION
While debugging a codegen issue, I tried adding LLVM options with
the rustc -Cllvm-args option, and was confused by the error and usage
messaging.

The LLVM "program name" argument is set to "rustc", and command line
error messages make it look like invalid arguments are "rustc"
arguments, not LLVM.

I changed this argument so error messages and the "-help" usage feedback
is easier to understand and react to. (Clang does something similar.)

r? @wesleywiser 