### PR TITLE
Add option to use the new symbol mangling in rustc/std

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -475,6 +475,10 @@
 # This only applies from stage 1 onwards, and only for Windows targets.
 #control-flow-guard = false
 
+# Enable symbol-mangling-version v0. This can be helpful when profiling rustc,
+# as generics will be preserved in symbols (rather than erased into opaque T).
+#new-symbol-mangling = false
+
 # =============================================================================
 # Options for specific targets
 #

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -859,6 +859,10 @@ impl<'a> Builder<'a> {
             rustflags.arg("--cfg=bootstrap");
         }
 
+        if self.config.rust_new_symbol_mangling {
+            rustflags.arg("-Zsymbol-mangling-version=v0");
+        }
+
         // FIXME: It might be better to use the same value for both `RUSTFLAGS` and `RUSTDOCFLAGS`,
         // but this breaks CI. At the very least, stage0 `rustdoc` needs `--cfg bootstrap`. See
         // #71458.

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -112,6 +112,7 @@ pub struct Config {
     pub rust_verify_llvm_ir: bool,
     pub rust_thin_lto_import_instr_limit: Option<u32>,
     pub rust_remap_debuginfo: bool,
+    pub rust_new_symbol_mangling: bool,
 
     pub build: TargetSelection,
     pub hosts: Vec<TargetSelection>,
@@ -410,6 +411,7 @@ struct Rust {
     test_compare_mode: Option<bool>,
     llvm_libunwind: Option<bool>,
     control_flow_guard: Option<bool>,
+    new_symbol_mangling: Option<bool>,
 }
 
 /// TOML representation of how each build target is configured.
@@ -637,6 +639,7 @@ impl Config {
             debuginfo_level_tests = rust.debuginfo_level_tests;
             optimize = rust.optimize;
             ignore_git = rust.ignore_git;
+            set(&mut config.rust_new_symbol_mangling, rust.new_symbol_mangling);
             set(&mut config.rust_optimize_tests, rust.optimize_tests);
             set(&mut config.codegen_tests, rust.codegen_tests);
             set(&mut config.rust_rpath, rust.rpath);


### PR DESCRIPTION
I don't know if this causes problems in some cases -- maybe it should be on by default for at least rustc. I've never encountered problems with it other than tools not supporting it, though.

cc @nnethercote 
r? @eddyb 