### PR TITLE
Rollup of 10 pull requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4624,6 +4624,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "tier-check"
+version = "0.1.0"
+
+[[package]]
 name = "time"
 version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
   "src/tools/rustbook",
   "src/tools/unstable-book-gen",
   "src/tools/tidy",
+  "src/tools/tier-check",
   "src/tools/build-manifest",
   "src/tools/remote-test-client",
   "src/tools/remote-test-server",

--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -377,7 +377,7 @@ impl<T, const N: usize> [T; N] {
     /// assert_eq!(y, [2,3,4]);
     /// ```
     #[unstable(feature = "array_map", issue = "77777")]
-    fn map<F, S>(self, mut f: F) -> [S; N]
+    pub fn map<F, S>(self, mut f: F) -> [S; N]
     where
         F: FnMut(T) -> S,
     {
@@ -385,12 +385,6 @@ impl<T, const N: usize> [T; N] {
         struct Guard<T, const N: usize> {
             dst: *mut T,
             curr_init: usize,
-        }
-
-        impl<T, const N: usize> Guard<T, N> {
-            fn new(dst: &mut [MaybeUninit<T>; N]) -> Self {
-                Guard { dst: dst as *mut _ as *mut T, curr_init: 0 }
-            }
         }
 
         impl<T, const N: usize> Drop for Guard<T, N> {
@@ -407,15 +401,16 @@ impl<T, const N: usize> [T; N] {
             }
         }
         let mut dst = MaybeUninit::uninit_array::<N>();
-        let mut guard = Guard::new(&mut dst);
+        let mut guard: Guard<S, N> = Guard { dst: &mut dst as *mut _ as *mut S, curr_init: 0 };
         for (i, e) in IntoIter::new(self).enumerate() {
             dst[i] = MaybeUninit::new(f(e));
             guard.curr_init += 1;
         }
         // FIXME convert to crate::mem::transmute when works with generics
         // unsafe { crate::mem::transmute::<[MaybeUninit<S>; N], [S; N]>(dst) }
-        let mapped = unsafe { (&mut dst as *mut _ as *mut [S; N]).read() };
         crate::mem::forget(guard);
-        mapped
+        // SAFETY: At this point we've properly initialized the whole array
+        // and we just need to cast it to the correct type
+        unsafe { (&mut dst as *mut _ as *mut [S; N]).read() }
     }
 }

--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -368,10 +368,11 @@ array_impl_default! {32, T T T T T T T T T T T T T T T T T T T T T T T T T T T T
 #[cfg(not(bootstrap))]
 #[lang = "array"]
 impl<T, const N: usize> [T; N] {
-    /// Returns an array of the same size as self, with `f` applied to each element.
+    /// Returns an array of the same size as `self`, with `f` applied to each element.
     /// The closure will be called on elements 0 up to N.
     ///
     /// # Examples
+    ///
     /// ```
     /// # #![feature(array_map)]
     /// let x = [1, 2, 3];

--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -377,7 +377,7 @@ impl<T, const N: usize> [T; N] {
     /// let y = x.map(|v| v + 1);
     /// assert_eq!(y, [2, 3, 4]);
     /// ```
-    #[unstable(feature = "array_map", issue = "77777")]
+    #[unstable(feature = "array_map", issue = "75027")]
     pub fn map<F, U>(self, mut f: F) -> [U; N]
     where
         F: FnMut(T) -> U,

--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -368,8 +368,8 @@ array_impl_default! {32, T T T T T T T T T T T T T T T T T T T T T T T T T T T T
 #[cfg(not(bootstrap))]
 #[lang = "array"]
 impl<T, const N: usize> [T; N] {
-    /// Returns an array of the same size as `self`, with function `f` applied to each element.
-    /// The closure will be called on elements 0 up to but excluding N.
+    /// Returns an array of the same size as `self`, with function `f` applied to each element
+    /// in order.
     ///
     /// # Examples
     ///

--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -407,11 +407,11 @@ impl<T, const N: usize> [T; N] {
             dst.write(f(src));
             guard.initialized += 1;
         }
-        // FIXME convert to crate::mem::transmute when works with generics
+        // FIXME: Convert to crate::mem::transmute once it works with generics.
         // unsafe { crate::mem::transmute::<[MaybeUninit<U>; N], [U; N]>(dst) }
         crate::mem::forget(guard);
         // SAFETY: At this point we've properly initialized the whole array
-        // and we just need to cast it to the correct type
+        // and we just need to cast it to the correct type.
         unsafe { (&mut dst as *mut _ as *mut [U; N]).read() }
     }
 }

--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -374,7 +374,7 @@ impl<T, const N: usize> [T; N] {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(array_map)]
+    /// #![feature(array_map)]
     /// let x = [1, 2, 3];
     /// let y = x.map(|v| v + 1);
     /// assert_eq!(y, [2, 3, 4]);
@@ -383,6 +383,10 @@ impl<T, const N: usize> [T; N] {
     /// let mut temp = 0;
     /// let y = x.map(|v| { temp += 1; v * temp });
     /// assert_eq!(y, [1, 4, 9]);
+    ///
+    /// let x = ["Ferris", "Bueller's", "Day", "Off"];
+    /// let y = x.map(|v| v.len());
+    /// assert_eq!(y, [6, 9, 3, 3]);
     /// ```
     #[unstable(feature = "array_map", issue = "75243")]
     pub fn map<F, U>(self, mut f: F) -> [U; N]

--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -372,6 +372,7 @@ impl<T, const N: usize> [T; N] {
     ///
     /// # Examples
     /// ```
+    /// #![feature(array_map)]
     /// let x = [1,2,3];
     /// let y = x.map(|v| v + 1);
     /// assert_eq!(y, [2,3,4]);
@@ -402,8 +403,8 @@ impl<T, const N: usize> [T; N] {
         }
         let mut dst = MaybeUninit::uninit_array::<N>();
         let mut guard: Guard<S, N> = Guard { dst: &mut dst as *mut _ as *mut S, curr_init: 0 };
-        for (i, e) in IntoIter::new(self).enumerate() {
-            dst[i] = MaybeUninit::new(f(e));
+        for (src, dst) in IntoIter::new(self).zip(&mut dst) {
+            dst.write(f(src));
             guard.curr_init += 1;
         }
         // FIXME convert to crate::mem::transmute when works with generics

--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -369,6 +369,7 @@ array_impl_default! {32, T T T T T T T T T T T T T T T T T T T T T T T T T T T T
 #[lang = "array"]
 impl<T, const N: usize> [T; N] {
     /// Returns an array of the same size as self, with `f` applied to each element.
+    /// The closure will be called on elements 0 up to N.
     ///
     /// # Examples
     /// ```
@@ -376,8 +377,13 @@ impl<T, const N: usize> [T; N] {
     /// let x = [1, 2, 3];
     /// let y = x.map(|v| v + 1);
     /// assert_eq!(y, [2, 3, 4]);
+    ///
+    /// let x = [1, 2, 3];
+    /// let mut temp = 0;
+    /// let y = x.map(|v| { temp += 1; v * temp });
+    /// assert_eq!(y, [1, 4, 9]);
     /// ```
-    #[unstable(feature = "array_map", issue = "75027")]
+    #[unstable(feature = "array_map", issue = "75243")]
     pub fn map<F, U>(self, mut f: F) -> [U; N]
     where
         F: FnMut(T) -> U,

--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -365,8 +365,8 @@ macro_rules! array_impl_default {
 
 array_impl_default! {32, T T T T T T T T T T T T T T T T T T T T T T T T T T T T T T T T}
 
-#[lang = "array"]
 #[cfg(not(bootstrap))]
+#[lang = "array"]
 impl<T, const N: usize> [T; N] {
     /// Returns an array of the same size as self, with `f` applied to each element.
     ///
@@ -382,9 +382,35 @@ impl<T, const N: usize> [T; N] {
         F: FnMut(T) -> S,
     {
         use crate::mem::MaybeUninit;
+        struct Guard<T, const N: usize> {
+            dst: *mut T,
+            curr_init: usize,
+        }
+
+        impl<T, const N: usize> Guard<T, N> {
+            fn new(dst: &mut [MaybeUninit<T>; N]) -> Self {
+                Guard { dst: dst as *mut _ as *mut T, curr_init: 0 }
+            }
+        }
+
+        impl<T, const N: usize> Drop for Guard<T, N> {
+            fn drop(&mut self) {
+                debug_assert!(self.curr_init <= N);
+
+                let initialized_part =
+                    crate::ptr::slice_from_raw_parts_mut(self.dst, self.curr_init);
+                // SAFETY: this raw slice will contain only initialized objects
+                // that's why, it is allowed to drop it.
+                unsafe {
+                    crate::ptr::drop_in_place(initialized_part);
+                }
+            }
+        }
         let dst = MaybeUninit::uninit_array::<N>();
+        let mut guard = Guard::new(&mut dst);
         for (i, e) in self.into_iter().enumerate() {
             dst[i] = MaybeUninit::new(f(e));
+            guard.curr_init += 1;
         }
         // FIXME convert to crate::mem::transmute when works with generics
         // unsafe { crate::mem::transmute::<[MaybeUninit<S>; N], [S; N]>(dst) }

--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -368,8 +368,8 @@ array_impl_default! {32, T T T T T T T T T T T T T T T T T T T T T T T T T T T T
 #[cfg(not(bootstrap))]
 #[lang = "array"]
 impl<T, const N: usize> [T; N] {
-    /// Returns an array of the same size as `self`, with `f` applied to each element.
-    /// The closure will be called on elements 0 up to N.
+    /// Returns an array of the same size as `self`, with function `f` applied to each element.
+    /// The closure will be called on elements 0 up to but excluding N.
     ///
     /// # Examples
     ///

--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -372,28 +372,28 @@ impl<T, const N: usize> [T; N] {
     ///
     /// # Examples
     /// ```
-    /// #![feature(array_map)]
-    /// let x = [1,2,3];
+    /// # #![feature(array_map)]
+    /// let x = [1, 2, 3];
     /// let y = x.map(|v| v + 1);
-    /// assert_eq!(y, [2,3,4]);
+    /// assert_eq!(y, [2, 3, 4]);
     /// ```
     #[unstable(feature = "array_map", issue = "77777")]
-    pub fn map<F, S>(self, mut f: F) -> [S; N]
+    pub fn map<F, U>(self, mut f: F) -> [U; N]
     where
-        F: FnMut(T) -> S,
+        F: FnMut(T) -> U,
     {
         use crate::mem::MaybeUninit;
         struct Guard<T, const N: usize> {
             dst: *mut T,
-            curr_init: usize,
+            initialized: usize,
         }
 
         impl<T, const N: usize> Drop for Guard<T, N> {
             fn drop(&mut self) {
-                debug_assert!(self.curr_init <= N);
+                debug_assert!(self.initialized <= N);
 
                 let initialized_part =
-                    crate::ptr::slice_from_raw_parts_mut(self.dst, self.curr_init);
+                    crate::ptr::slice_from_raw_parts_mut(self.dst, self.initialized);
                 // SAFETY: this raw slice will contain only initialized objects
                 // that's why, it is allowed to drop it.
                 unsafe {
@@ -402,16 +402,16 @@ impl<T, const N: usize> [T; N] {
             }
         }
         let mut dst = MaybeUninit::uninit_array::<N>();
-        let mut guard: Guard<S, N> = Guard { dst: &mut dst as *mut _ as *mut S, curr_init: 0 };
+        let mut guard: Guard<U, N> = Guard { dst: &mut dst as *mut _ as *mut U, initialized: 0 };
         for (src, dst) in IntoIter::new(self).zip(&mut dst) {
             dst.write(f(src));
-            guard.curr_init += 1;
+            guard.initialized += 1;
         }
         // FIXME convert to crate::mem::transmute when works with generics
-        // unsafe { crate::mem::transmute::<[MaybeUninit<S>; N], [S; N]>(dst) }
+        // unsafe { crate::mem::transmute::<[MaybeUninit<U>; N], [U; N]>(dst) }
         crate::mem::forget(guard);
         // SAFETY: At this point we've properly initialized the whole array
         // and we just need to cast it to the correct type
-        unsafe { (&mut dst as *mut _ as *mut [S; N]).read() }
+        unsafe { (&mut dst as *mut _ as *mut [U; N]).read() }
     }
 }

--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -413,7 +413,8 @@ impl<T, const N: usize> [T; N] {
             }
         }
         let mut dst = MaybeUninit::uninit_array::<N>();
-        let mut guard: Guard<U, N> = Guard { dst: &mut dst as *mut _ as *mut U, initialized: 0 };
+        let mut guard: Guard<U, N> =
+            Guard { dst: MaybeUninit::first_ptr_mut(&mut dst), initialized: 0 };
         for (src, dst) in IntoIter::new(self).zip(&mut dst) {
             dst.write(f(src));
             guard.initialized += 1;

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -145,6 +145,7 @@
 #![feature(abi_unadjusted)]
 #![feature(adx_target_feature)]
 #![feature(maybe_uninit_slice)]
+#![feature(maybe_uninit_extra)]
 #![feature(external_doc)]
 #![feature(associated_type_bounds)]
 #![feature(const_caller_location)]

--- a/library/core/tests/array.rs
+++ b/library/core/tests/array.rs
@@ -290,3 +290,10 @@ fn empty_array_is_always_default() {
 
     let _arr = <[DoesNotImplDefault; 0]>::default();
 }
+
+#[test]
+fn array_map() {
+    let a = [1, 2, 3];
+    let b = a.map(|v| v + 1);
+    assert_eq!(b, [2, 3, 4]);
+}

--- a/library/core/tests/array.rs
+++ b/library/core/tests/array.rs
@@ -296,4 +296,8 @@ fn array_map() {
     let a = [1, 2, 3];
     let b = a.map(|v| v + 1);
     assert_eq!(b, [2, 3, 4]);
+
+    let a = [1u8, 2, 3];
+    let b = a.map(|v| v as u64);
+    assert_eq!(b, [1, 2, 3]);
 }

--- a/library/core/tests/array.rs
+++ b/library/core/tests/array.rs
@@ -301,3 +301,31 @@ fn array_map() {
     let b = a.map(|v| v as u64);
     assert_eq!(b, [1, 2, 3]);
 }
+
+#[test]
+fn array_map_drop_safety() {
+    use core::sync::atomic::AtomicUsize;
+    use core::sync::atomic::Ordering;
+    static DROPPED: AtomicUsize = AtomicUsize::new(0);
+    struct DropCounter;
+    impl Drop for DropCounter {
+        fn drop(&mut self) {
+            DROPPED.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    let num_to_create = 5;
+    let success = std::panic::catch_unwind(|| {
+        let items = [0; 10];
+        let mut nth = 0;
+        items.map(|_| {
+            if nth == num_to_create {
+                panic!("Oh no!");
+            }
+            nth += 1;
+            DropCounter
+        });
+    });
+    assert!(success.is_err());
+    assert_eq!(DROPPED.load(Ordering::SeqCst), num_to_create);
+}

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -1,5 +1,6 @@
 #![feature(alloc_layout_extra)]
 #![feature(array_chunks)]
+#![feature(array_map)]
 #![feature(bool_to_option)]
 #![feature(bound_cloned)]
 #![feature(box_syntax)]

--- a/library/std/src/primitive_docs.rs
+++ b/library/std/src/primitive_docs.rs
@@ -768,7 +768,8 @@ mod prim_tuple {}
 ///
 /// This type can represent a wide range of decimal numbers, like `3.5`, `27`,
 /// `-113.75`, `0.0078125`, `34359738368`, `0`, `-1`. So unlike integer types
-/// (like `i32`), floating point types can represent non-integer numbers, too.
+/// (such as `i32`), floating point types can represent non-integer numbers,
+/// too.
 ///
 /// However, being able to represent this wide range of numbers comes at the
 /// cost of precision: floats can only represent some of the real numbers and
@@ -779,15 +780,12 @@ mod prim_tuple {}
 /// often discard insignificant digits: `println!("{}", 1.0f32 / 5.0f32)` will
 /// print `0.2`.
 ///
-/// The precision is better for numbers near 0 and worse for large numbers. For
-/// example, above 2<sup>24</sup>, not even all integers are representable.
-///
 /// Additionally, `f32` can represent a couple of special values:
 ///
 /// - `-0`: this is just due to how floats are encoded. It is semantically
 ///   equivalent to `0` and `-0.0 == 0.0` results in `true`.
 /// - [∞](#associatedconstant.INFINITY) and
-///   [-∞](#associatedconstant.NEG_INFINITY): these result from calculations
+///   [−∞](#associatedconstant.NEG_INFINITY): these result from calculations
 ///   like `1.0 / 0.0`.
 /// - [NaN (not a number)](#associatedconstant.NAN): this value results from
 ///   calculations like `(-1.0).sqrt()`. NaN has some potentially unexpected

--- a/library/std/src/sys/cloudabi/abi/cloudabi.rs
+++ b/library/std/src/sys/cloudabi/abi/cloudabi.rs
@@ -1910,7 +1910,7 @@ extern "C" {
 /// The resolution of the clock.
 #[inline]
 pub unsafe fn clock_res_get(clock_id_: clockid, resolution_: &mut timestamp) -> errno {
-    cloudabi_sys_clock_res_get(clock_id_, resolution_)
+    unsafe { cloudabi_sys_clock_res_get(clock_id_, resolution_) }
 }
 
 /// Obtains the time value of a clock.
@@ -1934,7 +1934,7 @@ pub unsafe fn clock_time_get(
     precision_: timestamp,
     time_: *mut timestamp,
 ) -> errno {
-    cloudabi_sys_clock_time_get(clock_id_, precision_, time_)
+    unsafe { cloudabi_sys_clock_time_get(clock_id_, precision_, time_) }
 }
 
 /// Wakes up threads waiting on a userspace condition variable.
@@ -1961,7 +1961,7 @@ pub unsafe fn clock_time_get(
 /// threads, all threads are woken up.
 #[inline]
 pub unsafe fn condvar_signal(condvar_: *mut condvar, scope_: scope, nwaiters_: nthreads) -> errno {
-    cloudabi_sys_condvar_signal(condvar_, scope_, nwaiters_)
+    unsafe { cloudabi_sys_condvar_signal(condvar_, scope_, nwaiters_) }
 }
 
 /// Closes a file descriptor.
@@ -1972,7 +1972,7 @@ pub unsafe fn condvar_signal(condvar_: *mut condvar, scope_: scope, nwaiters_: n
 /// The file descriptor that needs to be closed.
 #[inline]
 pub unsafe fn fd_close(fd_: fd) -> errno {
-    cloudabi_sys_fd_close(fd_)
+    unsafe { cloudabi_sys_fd_close(fd_) }
 }
 
 /// Creates a file descriptor.
@@ -1990,7 +1990,7 @@ pub unsafe fn fd_close(fd_: fd) -> errno {
 /// The file descriptor that has been created.
 #[inline]
 pub unsafe fn fd_create1(type_: filetype, fd_: &mut fd) -> errno {
-    cloudabi_sys_fd_create1(type_, fd_)
+    unsafe { cloudabi_sys_fd_create1(type_, fd_) }
 }
 
 /// Creates a pair of file descriptors.
@@ -2013,7 +2013,8 @@ pub unsafe fn fd_create1(type_: filetype, fd_: &mut fd) -> errno {
 /// The second file descriptor of the pair.
 #[inline]
 pub unsafe fn fd_create2(type_: filetype, fd1_: &mut fd, fd2_: &mut fd) -> errno {
-    cloudabi_sys_fd_create2(type_, fd1_, fd2_)
+    // SAFETY: the caller must uphold the safety contract for `cloudabi_sys_fd_create2`.
+    unsafe { cloudabi_sys_fd_create2(type_, fd1_, fd2_) }
 }
 
 /// Synchronizes the data of a file to disk.
@@ -2025,7 +2026,9 @@ pub unsafe fn fd_create2(type_: filetype, fd1_: &mut fd, fd2_: &mut fd) -> errno
 /// needs to be synchronized to disk.
 #[inline]
 pub unsafe fn fd_datasync(fd_: fd) -> errno {
-    cloudabi_sys_fd_datasync(fd_)
+    // SAFETY: the caller must guarantee that `fd` is valid
+    // for synchronization.
+    unsafe { cloudabi_sys_fd_datasync(fd_) }
 }
 
 /// Duplicates a file descriptor.
@@ -2040,7 +2043,7 @@ pub unsafe fn fd_datasync(fd_: fd) -> errno {
 /// The new file descriptor.
 #[inline]
 pub unsafe fn fd_dup(from_: fd, fd_: &mut fd) -> errno {
-    cloudabi_sys_fd_dup(from_, fd_)
+    unsafe { cloudabi_sys_fd_dup(from_, fd_) }
 }
 
 /// Reads from a file descriptor, without using and updating the
@@ -2064,7 +2067,7 @@ pub unsafe fn fd_dup(from_: fd, fd_: &mut fd) -> errno {
 /// The number of bytes read.
 #[inline]
 pub unsafe fn fd_pread(fd_: fd, iovs_: &[iovec], offset_: filesize, nread_: &mut usize) -> errno {
-    cloudabi_sys_fd_pread(fd_, iovs_.as_ptr(), iovs_.len(), offset_, nread_)
+    unsafe { cloudabi_sys_fd_pread(fd_, iovs_.as_ptr(), iovs_.len(), offset_, nread_) }
 }
 
 /// Writes to a file descriptor, without using and updating the
@@ -2093,7 +2096,7 @@ pub unsafe fn fd_pwrite(
     offset_: filesize,
     nwritten_: &mut usize,
 ) -> errno {
-    cloudabi_sys_fd_pwrite(fd_, iovs_.as_ptr(), iovs_.len(), offset_, nwritten_)
+    unsafe { cloudabi_sys_fd_pwrite(fd_, iovs_.as_ptr(), iovs_.len(), offset_, nwritten_) }
 }
 
 /// Reads from a file descriptor.
@@ -2112,7 +2115,7 @@ pub unsafe fn fd_pwrite(
 /// The number of bytes read.
 #[inline]
 pub unsafe fn fd_read(fd_: fd, iovs_: &[iovec], nread_: &mut usize) -> errno {
-    cloudabi_sys_fd_read(fd_, iovs_.as_ptr(), iovs_.len(), nread_)
+    unsafe { cloudabi_sys_fd_read(fd_, iovs_.as_ptr(), iovs_.len(), nread_) }
 }
 
 /// Atomically replaces a file descriptor by a copy of another
@@ -2138,7 +2141,7 @@ pub unsafe fn fd_read(fd_: fd, iovs_: &[iovec], nread_: &mut usize) -> errno {
 /// overwritten.
 #[inline]
 pub unsafe fn fd_replace(from_: fd, to_: fd) -> errno {
-    cloudabi_sys_fd_replace(from_, to_)
+    unsafe { cloudabi_sys_fd_replace(from_, to_) }
 }
 
 /// Moves the offset of the file descriptor.
@@ -2166,7 +2169,7 @@ pub unsafe fn fd_seek(
     whence_: whence,
     newoffset_: &mut filesize,
 ) -> errno {
-    cloudabi_sys_fd_seek(fd_, offset_, whence_, newoffset_)
+    unsafe { cloudabi_sys_fd_seek(fd_, offset_, whence_, newoffset_) }
 }
 
 /// Gets attributes of a file descriptor.
@@ -2182,7 +2185,7 @@ pub unsafe fn fd_seek(
 /// attributes are stored.
 #[inline]
 pub unsafe fn fd_stat_get(fd_: fd, buf_: *mut fdstat) -> errno {
-    cloudabi_sys_fd_stat_get(fd_, buf_)
+    unsafe { cloudabi_sys_fd_stat_get(fd_, buf_) }
 }
 
 /// Adjusts attributes of a file descriptor.
@@ -2202,7 +2205,7 @@ pub unsafe fn fd_stat_get(fd_: fd, buf_: *mut fdstat) -> errno {
 /// be adjusted.
 #[inline]
 pub unsafe fn fd_stat_put(fd_: fd, buf_: *const fdstat, flags_: fdsflags) -> errno {
-    cloudabi_sys_fd_stat_put(fd_, buf_, flags_)
+    unsafe { cloudabi_sys_fd_stat_put(fd_, buf_, flags_) }
 }
 
 /// Synchronizes the data and metadata of a file to disk.
@@ -2214,7 +2217,7 @@ pub unsafe fn fd_stat_put(fd_: fd, buf_: *const fdstat, flags_: fdsflags) -> err
 /// and metadata needs to be synchronized to disk.
 #[inline]
 pub unsafe fn fd_sync(fd_: fd) -> errno {
-    cloudabi_sys_fd_sync(fd_)
+    unsafe { cloudabi_sys_fd_sync(fd_) }
 }
 
 /// Writes to a file descriptor.
@@ -2233,7 +2236,7 @@ pub unsafe fn fd_sync(fd_: fd) -> errno {
 /// The number of bytes written.
 #[inline]
 pub unsafe fn fd_write(fd_: fd, iovs_: &[ciovec], nwritten_: &mut usize) -> errno {
-    cloudabi_sys_fd_write(fd_, iovs_.as_ptr(), iovs_.len(), nwritten_)
+    unsafe { cloudabi_sys_fd_write(fd_, iovs_.as_ptr(), iovs_.len(), nwritten_) }
 }
 
 /// Provides file advisory information on a file descriptor.
@@ -2256,7 +2259,7 @@ pub unsafe fn fd_write(fd_: fd, iovs_: &[ciovec], nwritten_: &mut usize) -> errn
 /// The advice.
 #[inline]
 pub unsafe fn file_advise(fd_: fd, offset_: filesize, len_: filesize, advice_: advice) -> errno {
-    cloudabi_sys_file_advise(fd_, offset_, len_, advice_)
+    unsafe { cloudabi_sys_file_advise(fd_, offset_, len_, advice_) }
 }
 
 /// Forces the allocation of space in a file.
@@ -2275,7 +2278,7 @@ pub unsafe fn file_advise(fd_: fd, offset_: filesize, len_: filesize, advice_: a
 /// The length of the area that is allocated.
 #[inline]
 pub unsafe fn file_allocate(fd_: fd, offset_: filesize, len_: filesize) -> errno {
-    cloudabi_sys_file_allocate(fd_, offset_, len_)
+    unsafe { cloudabi_sys_file_allocate(fd_, offset_, len_) }
 }
 
 /// Creates a file of a specified type.
@@ -2296,7 +2299,7 @@ pub unsafe fn file_allocate(fd_: fd, offset_: filesize, len_: filesize) -> errno
 ///     Creates a directory.
 #[inline]
 pub unsafe fn file_create(fd_: fd, path_: &[u8], type_: filetype) -> errno {
-    cloudabi_sys_file_create(fd_, path_.as_ptr(), path_.len(), type_)
+    unsafe { cloudabi_sys_file_create(fd_, path_.as_ptr(), path_.len(), type_)}
 }
 
 /// Creates a hard link.
@@ -2320,7 +2323,7 @@ pub unsafe fn file_create(fd_: fd, path_: &[u8], type_: filetype) -> errno {
 /// should be created.
 #[inline]
 pub unsafe fn file_link(fd1_: lookup, path1_: &[u8], fd2_: fd, path2_: &[u8]) -> errno {
-    cloudabi_sys_file_link(fd1_, path1_.as_ptr(), path1_.len(), fd2_, path2_.as_ptr(), path2_.len())
+    unsafe { cloudabi_sys_file_link(fd1_, path1_.as_ptr(), path1_.len(), fd2_, path2_.as_ptr(), path2_.len()) }
 }
 
 /// Opens a file.
@@ -2362,7 +2365,7 @@ pub unsafe fn file_open(
     fds_: *const fdstat,
     fd_: &mut fd,
 ) -> errno {
-    cloudabi_sys_file_open(dirfd_, path_.as_ptr(), path_.len(), oflags_, fds_, fd_)
+    unsafe { cloudabi_sys_file_open(dirfd_, path_.as_ptr(), path_.len(), oflags_, fds_, fd_) }
 }
 
 /// Reads directory entries from a directory.
@@ -2402,7 +2405,7 @@ pub unsafe fn file_readdir(
     cookie_: dircookie,
     bufused_: &mut usize,
 ) -> errno {
-    cloudabi_sys_file_readdir(fd_, buf_.as_mut_ptr() as *mut (), buf_.len(), cookie_, bufused_)
+    unsafe { cloudabi_sys_file_readdir(fd_, buf_.as_mut_ptr() as *mut (), buf_.len(), cookie_, bufused_) }
 }
 
 /// Reads the contents of a symbolic link.
@@ -2425,14 +2428,16 @@ pub unsafe fn file_readdir(
 /// The number of bytes placed in the buffer.
 #[inline]
 pub unsafe fn file_readlink(fd_: fd, path_: &[u8], buf_: &mut [u8], bufused_: &mut usize) -> errno {
-    cloudabi_sys_file_readlink(
-        fd_,
-        path_.as_ptr(),
-        path_.len(),
-        buf_.as_mut_ptr(),
-        buf_.len(),
-        bufused_,
-    )
+    unsafe {
+        cloudabi_sys_file_readlink(
+            fd_,
+            path_.as_ptr(),
+            path_.len(),
+            buf_.as_mut_ptr(),
+            buf_.len(),
+            bufused_,
+        )
+    }
 }
 
 /// Renames a file.
@@ -2456,14 +2461,16 @@ pub unsafe fn file_readlink(fd_: fd, path_: &[u8], buf_: &mut [u8], bufused_: &m
 /// be renamed.
 #[inline]
 pub unsafe fn file_rename(fd1_: fd, path1_: &[u8], fd2_: fd, path2_: &[u8]) -> errno {
-    cloudabi_sys_file_rename(
-        fd1_,
-        path1_.as_ptr(),
-        path1_.len(),
-        fd2_,
-        path2_.as_ptr(),
-        path2_.len(),
-    )
+    unsafe {
+        cloudabi_sys_file_rename(
+            fd1_,
+            path1_.as_ptr(),
+            path1_.len(),
+            fd2_,
+            path2_.as_ptr(),
+            path2_.len(),
+        )
+    }
 }
 
 /// Gets attributes of a file by file descriptor.
@@ -2479,7 +2486,7 @@ pub unsafe fn file_rename(fd1_: fd, path1_: &[u8], fd2_: fd, path2_: &[u8]) -> e
 /// stored.
 #[inline]
 pub unsafe fn file_stat_fget(fd_: fd, buf_: *mut filestat) -> errno {
-    cloudabi_sys_file_stat_fget(fd_, buf_)
+    unsafe { cloudabi_sys_file_stat_fget(fd_, buf_) }
 }
 
 /// Adjusts attributes of a file by file descriptor.
@@ -2499,7 +2506,7 @@ pub unsafe fn file_stat_fget(fd_: fd, buf_: *mut filestat) -> errno {
 /// be adjusted.
 #[inline]
 pub unsafe fn file_stat_fput(fd_: fd, buf_: *const filestat, flags_: fsflags) -> errno {
-    cloudabi_sys_file_stat_fput(fd_, buf_, flags_)
+    unsafe { cloudabi_sys_file_stat_fput(fd_, buf_, flags_) }
 }
 
 /// Gets attributes of a file by path.
@@ -2520,7 +2527,7 @@ pub unsafe fn file_stat_fput(fd_: fd, buf_: *const filestat, flags_: fsflags) ->
 /// stored.
 #[inline]
 pub unsafe fn file_stat_get(fd_: lookup, path_: &[u8], buf_: *mut filestat) -> errno {
-    cloudabi_sys_file_stat_get(fd_, path_.as_ptr(), path_.len(), buf_)
+    unsafe { cloudabi_sys_file_stat_get(fd_, path_.as_ptr(), path_.len(), buf_) }
 }
 
 /// Adjusts attributes of a file by path.
@@ -2550,7 +2557,7 @@ pub unsafe fn file_stat_put(
     buf_: *const filestat,
     flags_: fsflags,
 ) -> errno {
-    cloudabi_sys_file_stat_put(fd_, path_.as_ptr(), path_.len(), buf_, flags_)
+    unsafe { cloudabi_sys_file_stat_put(fd_, path_.as_ptr(), path_.len(), buf_, flags_) }
 }
 
 /// Creates a symbolic link.
@@ -2569,7 +2576,7 @@ pub unsafe fn file_stat_put(
 /// link should be created.
 #[inline]
 pub unsafe fn file_symlink(path1_: &[u8], fd_: fd, path2_: &[u8]) -> errno {
-    cloudabi_sys_file_symlink(path1_.as_ptr(), path1_.len(), fd_, path2_.as_ptr(), path2_.len())
+    unsafe { cloudabi_sys_file_symlink(path1_.as_ptr(), path1_.len(), fd_, path2_.as_ptr(), path2_.len()) }
 }
 
 /// Unlinks a file, or removes a directory.
@@ -2591,7 +2598,7 @@ pub unsafe fn file_symlink(path1_: &[u8], fd_: fd, path2_: &[u8]) -> errno {
 ///     Otherwise, unlink a file.
 #[inline]
 pub unsafe fn file_unlink(fd_: fd, path_: &[u8], flags_: ulflags) -> errno {
-    cloudabi_sys_file_unlink(fd_, path_.as_ptr(), path_.len(), flags_)
+    unsafe { cloudabi_sys_file_unlink(fd_, path_.as_ptr(), path_.len(), flags_) }
 }
 
 /// Unlocks a write-locked userspace lock.
@@ -2618,7 +2625,7 @@ pub unsafe fn file_unlink(fd_: fd, path_: &[u8], flags_: ulflags) -> errno {
 /// shared memory.
 #[inline]
 pub unsafe fn lock_unlock(lock_: *mut lock, scope_: scope) -> errno {
-    cloudabi_sys_lock_unlock(lock_, scope_)
+    unsafe { cloudabi_sys_lock_unlock(lock_, scope_) }
 }
 
 /// Provides memory advisory information on a region of memory.
@@ -2633,7 +2640,7 @@ pub unsafe fn lock_unlock(lock_: *mut lock, scope_: scope) -> errno {
 /// The advice.
 #[inline]
 pub unsafe fn mem_advise(mapping_: &mut [u8], advice_: advice) -> errno {
-    cloudabi_sys_mem_advise(mapping_.as_mut_ptr() as *mut (), mapping_.len(), advice_)
+    unsafe { cloudabi_sys_mem_advise(mapping_.as_mut_ptr() as *mut (), mapping_.len(), advice_) }
 }
 
 /// Creates a memory mapping, making the contents of a file
@@ -2682,7 +2689,7 @@ pub unsafe fn mem_map(
     off_: filesize,
     mem_: &mut *mut (),
 ) -> errno {
-    cloudabi_sys_mem_map(addr_, len_, prot_, flags_, fd_, off_, mem_)
+    unsafe { cloudabi_sys_mem_map(addr_, len_, prot_, flags_, fd_, off_, mem_) }
 }
 
 /// Changes the protection of a memory mapping.
@@ -2696,7 +2703,7 @@ pub unsafe fn mem_map(
 /// New protection options.
 #[inline]
 pub unsafe fn mem_protect(mapping_: &mut [u8], prot_: mprot) -> errno {
-    cloudabi_sys_mem_protect(mapping_.as_mut_ptr() as *mut (), mapping_.len(), prot_)
+    unsafe { cloudabi_sys_mem_protect(mapping_.as_mut_ptr() as *mut (), mapping_.len(), prot_) }
 }
 
 /// Synchronizes a region of memory with its physical storage.
@@ -2710,7 +2717,7 @@ pub unsafe fn mem_protect(mapping_: &mut [u8], prot_: mprot) -> errno {
 /// The method of synchronization.
 #[inline]
 pub unsafe fn mem_sync(mapping_: &mut [u8], flags_: msflags) -> errno {
-    cloudabi_sys_mem_sync(mapping_.as_mut_ptr() as *mut (), mapping_.len(), flags_)
+    unsafe { cloudabi_sys_mem_sync(mapping_.as_mut_ptr() as *mut (), mapping_.len(), flags_) }
 }
 
 /// Unmaps a region of memory.
@@ -2721,7 +2728,7 @@ pub unsafe fn mem_sync(mapping_: &mut [u8], flags_: msflags) -> errno {
 /// The pages that needs to be unmapped.
 #[inline]
 pub unsafe fn mem_unmap(mapping_: &mut [u8]) -> errno {
-    cloudabi_sys_mem_unmap(mapping_.as_mut_ptr() as *mut (), mapping_.len())
+    unsafe { cloudabi_sys_mem_unmap(mapping_.as_mut_ptr() as *mut (), mapping_.len()) }
 }
 
 /// Concurrently polls for the occurrence of a set of events.
@@ -2746,7 +2753,7 @@ pub unsafe fn poll(
     nsubscriptions_: usize,
     nevents_: *mut usize,
 ) -> errno {
-    cloudabi_sys_poll(in_, out_, nsubscriptions_, nevents_)
+    unsafe { cloudabi_sys_poll(in_, out_, nsubscriptions_, nevents_) }
 }
 
 /// Replaces the process by a new executable.
@@ -2784,7 +2791,7 @@ pub unsafe fn poll(
 /// execution.
 #[inline]
 pub unsafe fn proc_exec(fd_: fd, data_: &[u8], fds_: &[fd]) -> errno {
-    cloudabi_sys_proc_exec(fd_, data_.as_ptr() as *const (), data_.len(), fds_.as_ptr(), fds_.len())
+    unsafe { cloudabi_sys_proc_exec(fd_, data_.as_ptr() as *const (), data_.len(), fds_.as_ptr(), fds_.len()) }
 }
 
 /// Terminates the process normally.
@@ -2797,7 +2804,7 @@ pub unsafe fn proc_exec(fd_: fd, data_: &[u8], fds_: &[fd]) -> errno {
 /// through [`event.union.proc_terminate.exitcode`](struct.event_proc_terminate.html#structfield.exitcode).
 #[inline]
 pub unsafe fn proc_exit(rval_: exitcode) -> ! {
-    cloudabi_sys_proc_exit(rval_)
+    unsafe { cloudabi_sys_proc_exit(rval_) }
 }
 
 /// Forks the process of the calling thread.
@@ -2822,7 +2829,7 @@ pub unsafe fn proc_exit(rval_: exitcode) -> ! {
 /// initial thread of the child process.
 #[inline]
 pub unsafe fn proc_fork(fd_: &mut fd, tid_: &mut tid) -> errno {
-    cloudabi_sys_proc_fork(fd_, tid_)
+    unsafe { cloudabi_sys_proc_fork(fd_, tid_) }
 }
 
 /// Sends a signal to the process of the calling thread.
@@ -2837,7 +2844,7 @@ pub unsafe fn proc_fork(fd_: &mut fd, tid_: &mut tid) -> errno {
 /// [`event.union.proc_terminate.signal`](struct.event_proc_terminate.html#structfield.signal).
 #[inline]
 pub unsafe fn proc_raise(sig_: signal) -> errno {
-    cloudabi_sys_proc_raise(sig_)
+    unsafe { cloudabi_sys_proc_raise(sig_) }
 }
 
 /// Obtains random data from the kernel random number generator.
@@ -2853,7 +2860,7 @@ pub unsafe fn proc_raise(sig_: signal) -> errno {
 /// data.
 #[inline]
 pub unsafe fn random_get(buf_: &mut [u8]) -> errno {
-    cloudabi_sys_random_get(buf_.as_mut_ptr() as *mut (), buf_.len())
+    unsafe { cloudabi_sys_random_get(buf_.as_mut_ptr() as *mut (), buf_.len()) }
 }
 
 /// Receives a message on a socket.
@@ -2871,7 +2878,7 @@ pub unsafe fn random_get(buf_: &mut [u8]) -> errno {
 /// Output parameters.
 #[inline]
 pub unsafe fn sock_recv(sock_: fd, in_: *const recv_in, out_: *mut recv_out) -> errno {
-    cloudabi_sys_sock_recv(sock_, in_, out_)
+    unsafe { cloudabi_sys_sock_recv(sock_, in_, out_) }
 }
 
 /// Sends a message on a socket.
@@ -2888,7 +2895,7 @@ pub unsafe fn sock_recv(sock_: fd, in_: *const recv_in, out_: *mut recv_out) -> 
 /// Output parameters.
 #[inline]
 pub unsafe fn sock_send(sock_: fd, in_: *const send_in, out_: *mut send_out) -> errno {
-    cloudabi_sys_sock_send(sock_, in_, out_)
+    unsafe { cloudabi_sys_sock_send(sock_, in_, out_) }
 }
 
 /// Shuts down socket send and receive channels.
@@ -2903,7 +2910,7 @@ pub unsafe fn sock_send(sock_: fd, in_: *const send_in, out_: *mut send_out) -> 
 /// down.
 #[inline]
 pub unsafe fn sock_shutdown(sock_: fd, how_: sdflags) -> errno {
-    cloudabi_sys_sock_shutdown(sock_, how_)
+    unsafe { cloudabi_sys_sock_shutdown(sock_, how_) }
 }
 
 /// Creates a new thread within the current process.
@@ -2917,7 +2924,7 @@ pub unsafe fn sock_shutdown(sock_: fd, how_: sdflags) -> errno {
 /// The thread ID of the new thread.
 #[inline]
 pub unsafe fn thread_create(attr_: *mut threadattr, tid_: &mut tid) -> errno {
-    cloudabi_sys_thread_create(attr_, tid_)
+    unsafe { cloudabi_sys_thread_create(attr_, tid_) }
 }
 
 /// Terminates the calling thread.
@@ -2937,11 +2944,11 @@ pub unsafe fn thread_create(attr_: *mut threadattr, tid_: &mut tid) -> errno {
 /// shared memory.
 #[inline]
 pub unsafe fn thread_exit(lock_: *mut lock, scope_: scope) -> ! {
-    cloudabi_sys_thread_exit(lock_, scope_)
+    unsafe { cloudabi_sys_thread_exit(lock_, scope_) }
 }
 
 /// Temporarily yields execution of the calling thread.
 #[inline]
 pub unsafe fn thread_yield() -> errno {
-    cloudabi_sys_thread_yield()
+    unsafe { cloudabi_sys_thread_yield() }
 }

--- a/library/std/src/sys/cloudabi/mod.rs
+++ b/library/std/src/sys/cloudabi/mod.rs
@@ -1,3 +1,5 @@
+#![deny(unsafe_op_in_unsafe_fn)]
+
 use crate::io::ErrorKind;
 use crate::mem;
 

--- a/library/std/src/sys/cloudabi/mutex.rs
+++ b/library/std/src/sys/cloudabi/mutex.rs
@@ -106,7 +106,9 @@ impl ReentrantMutex {
             };
             let mut event = MaybeUninit::<abi::event>::uninit();
             let mut nevents = MaybeUninit::<usize>::uninit();
-            let ret = abi::poll(&subscription, event.as_mut_ptr(), 1, nevents.as_mut_ptr());
+            // SAFE: The caller must to ensure that `event` and `nevents` are initialized.
+            let ret =
+                unsafe { abi::poll(&subscription, event.as_mut_ptr(), 1, nevents.as_mut_ptr()) };
             assert_eq!(ret, abi::errno::SUCCESS, "Failed to acquire mutex");
             let event = event.assume_init();
             assert_eq!(event.error, abi::errno::SUCCESS, "Failed to acquire mutex");

--- a/library/std/src/sys/wasi/fs.rs
+++ b/library/std/src/sys/wasi/fs.rs
@@ -46,6 +46,7 @@ pub struct DirEntry {
 pub struct OpenOptions {
     read: bool,
     write: bool,
+    append: bool,
     dirflags: wasi::Lookupflags,
     fdflags: wasi::Fdflags,
     oflags: wasi::Oflags,
@@ -270,8 +271,9 @@ impl OpenOptions {
         }
     }
 
-    pub fn append(&mut self, set: bool) {
-        self.fdflag(wasi::FDFLAGS_APPEND, set);
+    pub fn append(&mut self, append: bool) {
+        self.append = append;
+        self.fdflag(wasi::FDFLAGS_APPEND, append);
     }
 
     pub fn dsync(&mut self, set: bool) {
@@ -321,7 +323,7 @@ impl OpenOptions {
             base |= wasi::RIGHTS_FD_READ;
             base |= wasi::RIGHTS_FD_READDIR;
         }
-        if self.write {
+        if self.write || self.append {
             base |= wasi::RIGHTS_FD_WRITE;
             base |= wasi::RIGHTS_FD_DATASYNC;
             base |= wasi::RIGHTS_FD_ALLOCATE;

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -404,6 +404,7 @@ impl<'a> Builder<'a> {
                 test::CrateLibrustc,
                 test::CrateRustdoc,
                 test::Linkcheck,
+                test::TierCheck,
                 test::Cargotest,
                 test::Cargo,
                 test::Rls,

--- a/src/doc/rustc/src/SUMMARY.md
+++ b/src/doc/rustc/src/SUMMARY.md
@@ -11,6 +11,7 @@
         - [Deny-by-default lints](lints/listing/deny-by-default.md)
 - [Codegen options](codegen-options/index.md)
 - [JSON Output](json.md)
+- [Platform Support](platform-support.md)
 - [Targets](targets/index.md)
     - [Built-in Targets](targets/built-in.md)
     - [Custom Targets](targets/custom.md)

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -57,7 +57,7 @@ Specifically, these platforms are required to have each of the following:
 
 target | std | host | notes
 -------|-----|------|-------
-`aarch64-apple-ios` | ✓ |  | ARM64 iOS
+`aarch64-apple-ios` | ✓[^apple] |  | ARM64 iOS
 `aarch64-fuchsia` | ✓ |  | ARM64 Fuchsia
 `aarch64-linux-android` | ✓ |  | ARM64 Android
 `aarch64-pc-windows-msvc` | ✓ |  | ARM64 Windows MSVC
@@ -122,7 +122,7 @@ target | std | host | notes
 `wasm32-unknown-emscripten` | ✓ |  | WebAssembly via Emscripten
 `wasm32-unknown-unknown` | ✓ |  | WebAssembly
 `wasm32-wasi` | ✓ |  | WebAssembly with WASI
-`x86_64-apple-ios` | ✓ |  | 64-bit x86 iOS
+`x86_64-apple-ios` | ✓[^apple] |  | 64-bit x86 iOS
 `x86_64-fortanix-unknown-sgx` | ✓ |  | [Fortanix ABI] for 64-bit Intel SGX
 `x86_64-fuchsia` | ✓ |  | 64-bit Fuchsia
 `x86_64-linux-android` | ✓ |  | 64-bit x86 Android
@@ -147,7 +147,7 @@ not available.
 target | std | host | notes
 -------|-----|------|-------
 `aarch64-apple-darwin` | ? |  | ARM64 macOS
-`aarch64-apple-tvos` | * |  | ARM64 tvOS
+`aarch64-apple-tvos` | *[^apple] |  | ARM64 tvOS
 `aarch64-unknown-cloudabi` | ✓ |  | ARM64 CloudABI
 `aarch64-unknown-freebsd` | ✓ | ✓ | ARM64 FreeBSD
 `aarch64-unknown-hermit` | ? |  |
@@ -159,16 +159,16 @@ target | std | host | notes
 `armv4t-unknown-linux-gnueabi` | ? |  |
 `armv6-unknown-freebsd` | ✓ | ✓ | ARMv6 FreeBSD
 `armv6-unknown-netbsd-eabihf` | ? |  |
-`armv7-apple-ios` | ✓ |  | RMv7 iOS, Cortex-
+`armv7-apple-ios` | ✓[^apple] |  | ARMv7 iOS, Cortex-a8
 `armv7-unknown-cloudabi-eabihf` | ✓ |  | ARMv7 CloudABI, hardfloat
 `armv7-unknown-freebsd` | ✓ | ✓ | ARMv7 FreeBSD
 `armv7-unknown-netbsd-eabihf` | ? |  |
 `armv7-wrs-vxworks-eabihf` | ? |  |
 `armv7a-none-eabihf` | * | | ARM Cortex-A, hardfloat
-`armv7s-apple-ios` | ✓ |  |
+`armv7s-apple-ios` | ✓[^apple] |  |
 `avr-unknown-unknown` | ? |  | AVR
 `hexagon-unknown-linux-musl` | ? |  |
-`i386-apple-ios` | ✓ |  | 32-bit x86 iOS
+`i386-apple-ios` | ✓[^apple] |  | 32-bit x86 iOS
 `i686-apple-darwin` | ✓ | ✓ | 32-bit OSX (10.7+, Lion+)
 `i686-pc-windows-msvc` | ✓ |  | 32-bit Windows XP support
 `i686-unknown-cloudabi` | ✓ |  | 32-bit CloudABI
@@ -203,8 +203,8 @@ target | std | host | notes
 `thumbv7a-uwp-windows-msvc` | ✓ |  |
 `thumbv7neon-unknown-linux-musleabihf` | ? |  | Thumb2-mode ARMv7a Linux with NEON, MUSL
 `thumbv4t-none-eabi` | * |  | ARMv4T T32
-`x86_64-apple-ios-macabi` | ✓ |  | Apple Catalyst
-`x86_64-apple-tvos` | * | | x86 64-bit tvOS
+`x86_64-apple-ios-macabi` | ✓[^apple] |  | Apple Catalyst
+`x86_64-apple-tvos` | *[^apple] | | x86 64-bit tvOS
 `x86_64-linux-kernel` | ? |  | Linux kernel modules
 `x86_64-pc-solaris` | ? |  |
 `x86_64-pc-windows-msvc` | ✓ |  | 64-bit Windows XP support
@@ -220,3 +220,4 @@ target | std | host | notes
 `x86_64-wrs-vxworks` | ? |  |
 
 [runs on NVIDIA GPUs]: https://github.com/japaric-archived/nvptx#targets
+[^apple]: These targets are only available on macOS.

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -1,34 +1,49 @@
-# Rust Platform Support
+# Platform Support
 
-The Rust compiler runs on, and compiles to, a great number of platforms, though
-not all platforms are equally supported. Rust's support levels are organized
-into three tiers, each with a different set of guarantees.
+<style type="text/css">
+    td code {
+        white-space: nowrap;
+    }
+</style>
 
-Platforms are identified by their "target triple" which is the string to inform
-the compiler what kind of output should be produced. The columns below indicate
-whether the corresponding component works on the specified platform.
+Support for different platforms are organized into three tiers, each with a
+different set of guarantees.
+
+Platforms are identified by their "target triple" which is the string to
+inform the compiler what kind of output should be produced. The columns in the
+tables below have the following meanings:
+
+* std:
+    * ✓ indicates the full standard library is available.
+    * \* indicates the target only supports [`no_std`] development.
+    * ? indicates the standard library support is unknown or a work-in-progress.
+* host: A ✓ indicates that `rustc` and `cargo` can run on the host platform.
+
+[`no_std`]: https://rust-embedded.github.io/book/intro/no-std.html
 
 ## Tier 1
+
 Tier 1 platforms can be thought of as "guaranteed to work".
 Specifically they will each satisfy the following requirements:
 
 * Official binary releases are provided for the platform.
 * Automated testing is set up to run tests for the platform.
-* Landing changes to the `rust-lang/rust` repository's master branch is gated on
-    tests passing.
+* Landing changes to the `rust-lang/rust` repository's master branch is gated
+  on tests passing.
 * Documentation for how to use and how to build the platform is available.
 
-target | std | rustc | cargo | notes
--------|-----|-------|-------|-------
-`i686-pc-windows-gnu` | ✓ | ✓ | ✓ | 32-bit MinGW (Windows 7+)
-`i686-pc-windows-msvc` | ✓ | ✓ | ✓ | 32-bit MSVC (Windows 7+)
-`i686-unknown-linux-gnu` | ✓ | ✓ | ✓ | 32-bit Linux (kernel 2.6.32+, glibc 2.11+)
-`x86_64-apple-darwin` | ✓ | ✓ | ✓ | 64-bit OSX (10.7+, Lion+)
-`x86_64-pc-windows-gnu` | ✓ | ✓ | ✓ | 64-bit MinGW (Windows 7+)
-`x86_64-pc-windows-msvc` | ✓ | ✓ | ✓ | 64-bit MSVC (Windows 7+)
-`x86_64-unknown-linux-gnu` | ✓ | ✓ | ✓ | 64-bit Linux (kernel 2.6.32+, glibc 2.11+)
+target | std | host | notes
+-------|-----|------|-------
+`i686-pc-windows-gnu` | ✓ | ✓ | 32-bit MinGW (Windows 7+)
+`i686-pc-windows-msvc` | ✓ | ✓ | 32-bit MSVC (Windows 7+)
+`i686-unknown-linux-gnu` | ✓ | ✓ | 32-bit Linux (kernel 2.6.32+, glibc 2.11+)
+`x86_64-apple-darwin` | ✓ | ✓ | 64-bit OSX (10.7+, Lion+)
+`x86_64-pc-windows-gnu` | ✓ | ✓ | 64-bit MinGW (Windows 7+)
+`x86_64-pc-windows-msvc` | ✓ | ✓ | 64-bit MSVC (Windows 7+)
+`x86_64-unknown-linux-gnu` | ✓ | ✓ | 64-bit Linux (kernel 2.6.32+, glibc 2.11+)
 
 ## Tier 2
+
 Tier 2 platforms can be thought of as "guaranteed to build". Automated tests
 are not run so it's not guaranteed to produce a working build, but platforms
 often work to quite a good degree and patches are always welcome!
@@ -40,183 +55,168 @@ Specifically, these platforms are required to have each of the following:
     platforms **building**. For some platforms only the standard library is
     compiled, but for others `rustc` and `cargo` are too.
 
-target | std | rustc | cargo | notes
--------|-----|-------|-------|-------
-`aarch64-apple-ios` | ✓ |  |  | ARM64 iOS
-`aarch64-fuchsia` | ✓ |  |  | ARM64 Fuchsia
-`aarch64-linux-android` | ✓ |  |  | ARM64 Android
-`aarch64-pc-windows-msvc` | ✓ |  |  | ARM64 Windows MSVC
-`aarch64-unknown-linux-gnu` | ✓ | ✓ | ✓ | ARM64 Linux (kernel 4.2, glibc 2.17)
-`aarch64-unknown-linux-musl` | ✓ |  |  | ARM64 Linux with MUSL
-`aarch64-unknown-none` | * |  |  | Bare ARM64, hardfloat
-`aarch64-unknown-none-softfloat` | * |  |  | Bare ARM64, softfloat
-`arm-linux-androideabi` | ✓ |  |  | ARMv7 Android
-`arm-unknown-linux-gnueabi` | ✓ | ✓ | ✓ | ARMv6 Linux (kernel 3.2, glibc 2.17)
-`arm-unknown-linux-gnueabihf` | ✓ | ✓ | ✓ | ARMv6 Linux, hardfloat (kernel 3.2, glibc 2.17)
-`arm-unknown-linux-musleabi` | ✓ |  |  | ARMv6 Linux with MUSL
-`arm-unknown-linux-musleabihf` | ✓ |  |  | ARMv6 Linux with MUSL, hardfloat
-`armebv7r-none-eabi` | * |  |  | Bare ARMv7-R, Big Endian
-`armebv7r-none-eabihf` | * |  |  | Bare ARMv7-R, Big Endian, hardfloat
-`armv5te-unknown-linux-gnueabi` | ✓ |  |  | ARMv5TE Linux (kernel 4.4, glibc 2.23)
-`armv5te-unknown-linux-musleabi` | ✓ |  |  | ARMv5TE Linux with MUSL
-`armv7-linux-androideabi` | ✓ |  |  | ARMv7a Android
-`armv7a-none-eabi` | * |  |  | Bare ARMv7-A
-`armv7r-none-eabi` | * |  |  | Bare ARMv7-R
-`armv7r-none-eabihf` | * |  |  | Bare ARMv7-R, hardfloat
-`armv7-unknown-linux-gnueabi` | ✓ |   |   | ARMv7 Linux (kernel 4.15, glibc 2.27)
-`armv7-unknown-linux-gnueabihf` | ✓ | ✓ | ✓ | ARMv7 Linux, hardfloat (kernel 3.2, glibc 2.17)
-`armv7-unknown-linux-musleabi` | ✓ |   |   | ARMv7 Linux, MUSL
-`armv7-unknown-linux-musleabihf` | ✓ |  |  | ARMv7 Linux with MUSL
-`asmjs-unknown-emscripten` | ✓ |  |  | asm.js via Emscripten
-`i586-pc-windows-msvc` | ✓ |  |  | 32-bit Windows w/o SSE
-`i586-unknown-linux-gnu` | ✓ |  |  | 32-bit Linux w/o SSE (kernel 4.4, glibc 2.23)
-`i586-unknown-linux-musl` | ✓ |  |  | 32-bit Linux w/o SSE, MUSL
-`i686-linux-android` | ✓ |  |  | 32-bit x86 Android
-`i686-unknown-freebsd` | ✓ | ✓ | ✓ | 32-bit FreeBSD
-`i686-unknown-linux-musl` | ✓ |  |  | 32-bit Linux with MUSL
-`mips-unknown-linux-gnu` | ✓ | ✓ | ✓ | MIPS Linux (kernel 4.4, glibc 2.23)
-`mips-unknown-linux-musl` | ✓ |  |  | MIPS Linux with MUSL
-`mips64-unknown-linux-gnuabi64` | ✓ | ✓ | ✓ | MIPS64 Linux, n64 ABI (kernel 4.4, glibc 2.23)
-`mips64-unknown-linux-muslabi64` | ✓ |  |  | MIPS64 Linux, n64 ABI, MUSL
-`mips64el-unknown-linux-gnuabi64` | ✓ | ✓ | ✓ | MIPS64 (LE) Linux, n64 ABI (kernel 4.4, glibc 2.23)
-`mips64el-unknown-linux-muslabi64` | ✓ |  |  | MIPS64 (LE) Linux, n64 ABI, MUSL
-`mipsel-unknown-linux-gnu` | ✓ | ✓ | ✓ | MIPS (LE) Linux (kernel 4.4, glibc 2.23)
-`mipsel-unknown-linux-musl` | ✓ |  |  | MIPS (LE) Linux with MUSL
-`nvptx64-nvidia-cuda` | ✓ |  |  | --emit=asm generates PTX code that [runs on NVIDIA GPUs]
-`powerpc-unknown-linux-gnu` | ✓ | ✓ | ✓ | PowerPC Linux (kernel 2.6.32, glibc 2.11)
-`powerpc64-unknown-linux-gnu` | ✓ | ✓ | ✓ | PPC64 Linux (kernel 2.6.32, glibc 2.11)
-`powerpc64le-unknown-linux-gnu` | ✓ | ✓ | ✓ | PPC64LE Linux (kernel 3.10, glibc 2.17)
-`riscv32i-unknown-none-elf` | * |  |  | Bare RISC-V (RV32I ISA)
-`riscv32imac-unknown-none-elf` | * |  |  | Bare RISC-V (RV32IMAC ISA)
-`riscv32imc-unknown-none-elf` | * |  |  | Bare RISC-V (RV32IMC ISA)
-`riscv64gc-unknown-linux-gnu` | ✓ | ✓ | ✓ | RISC-V Linux (kernel 4.20, glibc 2.29)
-`riscv64gc-unknown-none-elf` | * |  |  | Bare RISC-V (RV64IMAFDC ISA)
-`riscv64imac-unknown-none-elf` | * |  |  | Bare RISC-V (RV64IMAC ISA)
-`s390x-unknown-linux-gnu` | ✓ | ✓ | ✓ | S390x Linux (kernel 2.6.32, glibc 2.11)
-`sparc64-unknown-linux-gnu` | ✓ |  |  | SPARC Linux (kernel 4.4, glibc 2.23)
-`sparcv9-sun-solaris` | ✓ |  |  | SPARC Solaris 10/11, illumos
-`thumbv6m-none-eabi` | * |  |  | Bare Cortex-M0, M0+, M1
-`thumbv7em-none-eabi` | * |  |  | Bare Cortex-M4, M7
-`thumbv7em-none-eabihf` | * |  |  | Bare Cortex-M4F, M7F, FPU, hardfloat
-`thumbv7m-none-eabi` | * |  |  | Bare Cortex-M3
-`thumbv7neon-linux-androideabi` | ✓ |  |  | Thumb2-mode ARMv7a Android with NEON
-`thumbv7neon-unknown-linux-gnueabihf` | ✓ |  |  | Thumb2-mode ARMv7a Linux with NEON (kernel 4.4, glibc 2.23)
-`thumbv8m.base-none-eabi` | * |  |  | ARMv8-M Baseline
-`thumbv8m.main-none-eabi` | * |  |  | ARMv8-M Mainline
-`thumbv8m.main-none-eabihf` | * |  |  | ARMv8-M Baseline, hardfloat
-`wasm32-unknown-emscripten` | ✓ |  |  | WebAssembly via Emscripten
-`wasm32-unknown-unknown` | ✓ |  |  | WebAssembly
-`wasm32-wasi` | ✓ |  |  | WebAssembly with WASI
-`x86_64-apple-ios` | ✓ |  |  | 64-bit x86 iOS
-`x86_64-fortanix-unknown-sgx` | ✓ |  |  | [Fortanix ABI] for 64-bit Intel SGX
-`x86_64-fuchsia` | ✓ |  |  | 64-bit Fuchsia
-`x86_64-linux-android` | ✓ |  |  | 64-bit x86 Android
-`x86_64-rumprun-netbsd` | ✓ |  |  | 64-bit NetBSD Rump Kernel
-`x86_64-sun-solaris` | ✓ |  |  | 64-bit Solaris 10/11, illumos
-`x86_64-unknown-cloudabi` | ✓ |  |  | 64-bit CloudABI
-`x86_64-unknown-freebsd` | ✓ | ✓ | ✓ | 64-bit FreeBSD
-`x86_64-unknown-illumos` | ✓ | ✓ | ✓ | illumos
-`x86_64-unknown-linux-gnux32` | ✓ |  |  | 64-bit Linux (x32 ABI) (kernel 4.15, glibc 2.27)
-`x86_64-unknown-linux-musl` | ✓ | ✓ | ✓ | 64-bit Linux with MUSL
-`x86_64-unknown-netbsd` | ✓ | ✓ | ✓ | NetBSD/amd64
-`x86_64-unknown-redox` | ✓ |  |  | Redox OS
+target | std | host | notes
+-------|-----|------|-------
+`aarch64-apple-ios` | ✓ |  | ARM64 iOS
+`aarch64-fuchsia` | ✓ |  | ARM64 Fuchsia
+`aarch64-linux-android` | ✓ |  | ARM64 Android
+`aarch64-pc-windows-msvc` | ✓ |  | ARM64 Windows MSVC
+`aarch64-unknown-linux-gnu` | ✓ | ✓ | ARM64 Linux (kernel 4.2, glibc 2.17)
+`aarch64-unknown-linux-musl` | ✓ |  | ARM64 Linux with MUSL
+`aarch64-unknown-none` | * |  | Bare ARM64, hardfloat
+`aarch64-unknown-none-softfloat` | * |  | Bare ARM64, softfloat
+`arm-linux-androideabi` | ✓ |  | ARMv7 Android
+`arm-unknown-linux-gnueabi` | ✓ | ✓ | ARMv6 Linux (kernel 3.2, glibc 2.17)
+`arm-unknown-linux-gnueabihf` | ✓ | ✓ | ARMv6 Linux, hardfloat (kernel 3.2, glibc 2.17)
+`arm-unknown-linux-musleabi` | ✓ |  | ARMv6 Linux with MUSL
+`arm-unknown-linux-musleabihf` | ✓ |  | ARMv6 Linux with MUSL, hardfloat
+`armebv7r-none-eabi` | * |  | Bare ARMv7-R, Big Endian
+`armebv7r-none-eabihf` | * |  | Bare ARMv7-R, Big Endian, hardfloat
+`armv5te-unknown-linux-gnueabi` | ✓ |  | ARMv5TE Linux (kernel 4.4, glibc 2.23)
+`armv5te-unknown-linux-musleabi` | ✓ |  | ARMv5TE Linux with MUSL
+`armv7-linux-androideabi` | ✓ |  | ARMv7a Android
+`armv7a-none-eabi` | * |  | Bare ARMv7-A
+`armv7r-none-eabi` | * |  | Bare ARMv7-R
+`armv7r-none-eabihf` | * |  | Bare ARMv7-R, hardfloat
+`armv7-unknown-linux-gnueabi` | ✓ |   | ARMv7 Linux (kernel 4.15, glibc 2.27)
+`armv7-unknown-linux-gnueabihf` | ✓ | ✓ | ARMv7 Linux, hardfloat (kernel 3.2, glibc 2.17)
+`armv7-unknown-linux-musleabi` | ✓ |   | ARMv7 Linux, MUSL
+`armv7-unknown-linux-musleabihf` | ✓ |  | ARMv7 Linux with MUSL
+`asmjs-unknown-emscripten` | ✓ |  | asm.js via Emscripten
+`i586-pc-windows-msvc` | ✓ |  | 32-bit Windows w/o SSE
+`i586-unknown-linux-gnu` | ✓ |  | 32-bit Linux w/o SSE (kernel 4.4, glibc 2.23)
+`i586-unknown-linux-musl` | ✓ |  | 32-bit Linux w/o SSE, MUSL
+`i686-linux-android` | ✓ |  | 32-bit x86 Android
+`i686-unknown-freebsd` | ✓ | ✓ | 32-bit FreeBSD
+`i686-unknown-linux-musl` | ✓ |  | 32-bit Linux with MUSL
+`mips-unknown-linux-gnu` | ✓ | ✓ | MIPS Linux (kernel 4.4, glibc 2.23)
+`mips-unknown-linux-musl` | ✓ |  | MIPS Linux with MUSL
+`mips64-unknown-linux-gnuabi64` | ✓ | ✓ | MIPS64 Linux, n64 ABI (kernel 4.4, glibc 2.23)
+`mips64-unknown-linux-muslabi64` | ✓ |  | MIPS64 Linux, n64 ABI, MUSL
+`mips64el-unknown-linux-gnuabi64` | ✓ | ✓ | MIPS64 (LE) Linux, n64 ABI (kernel 4.4, glibc 2.23)
+`mips64el-unknown-linux-muslabi64` | ✓ |  | MIPS64 (LE) Linux, n64 ABI, MUSL
+`mipsel-unknown-linux-gnu` | ✓ | ✓ | MIPS (LE) Linux (kernel 4.4, glibc 2.23)
+`mipsel-unknown-linux-musl` | ✓ |  | MIPS (LE) Linux with MUSL
+`nvptx64-nvidia-cuda` | ✓ |  | --emit=asm generates PTX code that [runs on NVIDIA GPUs]
+`powerpc-unknown-linux-gnu` | ✓ | ✓ | PowerPC Linux (kernel 2.6.32, glibc 2.11)
+`powerpc64-unknown-linux-gnu` | ✓ | ✓ | PPC64 Linux (kernel 2.6.32, glibc 2.11)
+`powerpc64le-unknown-linux-gnu` | ✓ | ✓ | PPC64LE Linux (kernel 3.10, glibc 2.17)
+`riscv32i-unknown-none-elf` | * |  | Bare RISC-V (RV32I ISA)
+`riscv32imac-unknown-none-elf` | * |  | Bare RISC-V (RV32IMAC ISA)
+`riscv32imc-unknown-none-elf` | * |  | Bare RISC-V (RV32IMC ISA)
+`riscv64gc-unknown-linux-gnu` | ✓ | ✓ | RISC-V Linux (kernel 4.20, glibc 2.29)
+`riscv64gc-unknown-none-elf` | * |  | Bare RISC-V (RV64IMAFDC ISA)
+`riscv64imac-unknown-none-elf` | * |  | Bare RISC-V (RV64IMAC ISA)
+`s390x-unknown-linux-gnu` | ✓ | ✓ | S390x Linux (kernel 2.6.32, glibc 2.11)
+`sparc64-unknown-linux-gnu` | ✓ |  | SPARC Linux (kernel 4.4, glibc 2.23)
+`sparcv9-sun-solaris` | ✓ |  | SPARC Solaris 10/11, illumos
+`thumbv6m-none-eabi` | * |  | Bare Cortex-M0, M0+, M1
+`thumbv7em-none-eabi` | * |  | Bare Cortex-M4, M7
+`thumbv7em-none-eabihf` | * |  | Bare Cortex-M4F, M7F, FPU, hardfloat
+`thumbv7m-none-eabi` | * |  | Bare Cortex-M3
+`thumbv7neon-linux-androideabi` | ✓ |  | Thumb2-mode ARMv7a Android with NEON
+`thumbv7neon-unknown-linux-gnueabihf` | ✓ |  | Thumb2-mode ARMv7a Linux with NEON (kernel 4.4, glibc 2.23)
+`thumbv8m.base-none-eabi` | * |  | ARMv8-M Baseline
+`thumbv8m.main-none-eabi` | * |  | ARMv8-M Mainline
+`thumbv8m.main-none-eabihf` | * |  | ARMv8-M Baseline, hardfloat
+`wasm32-unknown-emscripten` | ✓ |  | WebAssembly via Emscripten
+`wasm32-unknown-unknown` | ✓ |  | WebAssembly
+`wasm32-wasi` | ✓ |  | WebAssembly with WASI
+`x86_64-apple-ios` | ✓ |  | 64-bit x86 iOS
+`x86_64-fortanix-unknown-sgx` | ✓ |  | [Fortanix ABI] for 64-bit Intel SGX
+`x86_64-fuchsia` | ✓ |  | 64-bit Fuchsia
+`x86_64-linux-android` | ✓ |  | 64-bit x86 Android
+`x86_64-rumprun-netbsd` | ✓ |  | 64-bit NetBSD Rump Kernel
+`x86_64-sun-solaris` | ✓ |  | 64-bit Solaris 10/11, illumos
+`x86_64-unknown-cloudabi` | ✓ |  | 64-bit CloudABI
+`x86_64-unknown-freebsd` | ✓ | ✓ | 64-bit FreeBSD
+`x86_64-unknown-illumos` | ✓ | ✓ | illumos
+`x86_64-unknown-linux-gnux32` | ✓ |  | 64-bit Linux (x32 ABI) (kernel 4.15, glibc 2.27)
+`x86_64-unknown-linux-musl` | ✓ | ✓ | 64-bit Linux with MUSL
+`x86_64-unknown-netbsd` | ✓ | ✓ | NetBSD/amd64
+`x86_64-unknown-redox` | ✓ |  | Redox OS
 
 [Fortanix ABI]: https://edp.fortanix.com/
 
 ## Tier 3
+
 Tier 3 platforms are those which the Rust codebase has support for, but which
 are not built or tested automatically, and may not work. Official builds are
 not available.
 
-target | std | rustc | cargo | notes
--------|-----|-------|-------|-------
-`aarch64-apple-darwin` | ? |  |  | ARM64 macOS
-`aarch64-apple-tvos` | ** |  |  | ARM64 tvOS
-`aarch64-unknown-cloudabi` | ✓ |  |  | ARM64 CloudABI
-`aarch64-unknown-freebsd` | ✓ | ✓ | ✓ | ARM64 FreeBSD
-`aarch64-unknown-hermit` | ? |  |  |
-`aarch64-unknown-netbsd` | ? |  |  |
-`aarch64-unknown-openbsd` | ✓ | ✓ | ✓ | ARM64 OpenBSD
-`aarch64-unknown-redox` | ? |  |  | ARM64 Redox OS
-`aarch64-uwp-windows-msvc` | ? |  |  |
-`aarch64-wrs-vxworks` | ? |  |  |
-`armv4t-unknown-linux-gnueabi` | ? |  |  |
-`armv6-unknown-freebsd` | ✓ | ✓ | ✓ | ARMv6 FreeBSD
-`armv6-unknown-netbsd-eabihf` | ? |  |  |
-`armv7-apple-ios` | ✓ |  |  | RMv7 iOS, Cortex-
-`armv7-unknown-cloudabi-eabihf` | ✓ |  |  | ARMv7 CloudABI, hardfloat
-`armv7-unknown-freebsd` | ✓ | ✓ | ✓ | ARMv7 FreeBSD
-`armv7-unknown-netbsd-eabihf` | ? |  |  |
-`armv7-wrs-vxworks-eabihf` | ? |  |  |
-`armv7a-none-eabihf` | * | | | ARM Cortex-A, hardfloat
-`armv7s-apple-ios` | ✓ |  |  |
-`avr-unknown-unknown` | ? |  |  | AVR
-`hexagon-unknown-linux-musl` | ? |  |  |
-`i386-apple-ios` | ✓ |  |  | 32-bit x86 iOS
-`i686-apple-darwin` | ✓ | ✓ | ✓ | 32-bit OSX (10.7+, Lion+)
-`i686-pc-windows-msvc` | ✓ |  |  | 32-bit Windows XP support
-`i686-unknown-cloudabi` | ✓ |  |  | 32-bit CloudABI
-`i686-unknown-uefi` | ? |  |  | 32-bit UEFI
-`i686-unknown-haiku` | ✓ | ✓ | ✓ | 32-bit Haiku
-`i686-unknown-netbsd` | ✓ |  |  | NetBSD/i386 with SSE2
-`i686-unknown-openbsd` | ✓ | ✓ | ✓ | 32-bit OpenBSD
-`i686-uwp-windows-gnu` | ? |  |  |
-`i686-uwp-windows-msvc` | ? |  |  |
-`i686-wrs-vxworks` | ? |  |  |
-`mips-unknown-linux-uclibc` | ✓ |  |  | MIPS Linux with uClibc
-`mipsel-unknown-linux-uclibc` | ✓ |  |  | MIPS (LE) Linux with uClibc
-`mipsel-sony-psp` | ** |  |  | MIPS (LE) Sony PlayStation Portable (PSP)
-`mipsisa32r6-unknown-linux-gnu` | ? |  |  |
-`mipsisa32r6el-unknown-linux-gnu` | ? |  |  |
-`mipsisa64r6-unknown-linux-gnuabi64` | ? |  |  |
-`mipsisa64r6el-unknown-linux-gnuabi64` | ? |  |  |
-`msp430-none-elf` | * |  |  | 16-bit MSP430 microcontrollers
-`powerpc-unknown-linux-gnuspe` | ✓ |  |  | PowerPC SPE Linux
-`powerpc-unknown-linux-musl` | ? |  |  |
-`powerpc-unknown-netbsd` | ? |  |  |
-`powerpc-wrs-vxworks` | ? |  |  |
-`powerpc-wrs-vxworks-spe` | ? |  |  |
-`powerpc64-unknown-freebsd` | ✓ | ✓ | ✓ | PPC64 FreeBSD (ELFv1 and ELFv2)
-`powerpc64-unknown-linux-musl` | ? |  |  |
-`powerpc64-wrs-vxworks` | ? |  |  |
-`powerpc64le-unknown-linux-musl` | ? |  |  |
-`sparc-unknown-linux-gnu` | ✓ |  |  | 32-bit SPARC Linux
-`sparc64-unknown-netbsd` | ✓ | ✓ |  | NetBSD/sparc64
-`sparc64-unknown-openbsd` | ? |  |  |
-`thumbv7a-pc-windows-msvc` | ? |  |  |
-`thumbv7a-uwp-windows-msvc` | ✓ |  |  |
-`thumbv7neon-unknown-linux-musleabihf` | ? |  |  | Thumb2-mode ARMv7a Linux with NEON, MUSL
-`thumbv4t-none-eabi` | * |  |  | ARMv4T T32
-`x86_64-apple-ios-macabi` | ✓ |  |  | Apple Catalyst
-`x86_64-apple-tvos` | ** | | | x86 64-bit tvOS
-`x86_64-linux-kernel` | ? |  |  | Linux kernel modules
-`x86_64-pc-solaris` | ? |  |  |
-`x86_64-pc-windows-msvc` | ✓ |  |  | 64-bit Windows XP support
-`x86_64-unknown-dragonfly` | ✓ | ✓ | ✓ | 64-bit DragonFlyBSD
-`x86_64-unknown-haiku` | ✓ | ✓ | ✓ | 64-bit Haiku
-`x86_64-unknown-hermit` | ? |  |  |
-`x86_64-unknown-hermit-kernel` | ? |  |  | HermitCore kernel
-`x86_64-unknown-l4re-uclibc` | ? |  |  |
-`x86_64-unknown-openbsd` | ✓ | ✓ | ✓ | 64-bit OpenBSD
-`x86_64-unknown-uefi` | ? |  |  |
-`x86_64-uwp-windows-gnu` | ✓ |  |  |
-`x86_64-uwp-windows-msvc` | ✓ |  |  |
-`x86_64-wrs-vxworks` | ? |  |  |
-
-
-\* These targets only support `core`, not `alloc` or `std`.
-
-\*\* These targets only support `core` or `alloc`, not `std`.
-
-? These are targets that haven't yet been documented here. If you can shed some
-  light on these platforms support, please create an issue or PR on the [Rust
-  Forge repo].
-
-But those aren't the only platforms Rust can compile to! Those are the ones with
-built-in target definitions and/or standard library support. When linking only
-to the core library, Rust can also target additional "bare metal" platforms in
-the x86, ARM, MIPS, and PowerPC families, though it may require defining custom
-target specifications to do so.
+target | std | host | notes
+-------|-----|------|-------
+`aarch64-apple-darwin` | ? |  | ARM64 macOS
+`aarch64-apple-tvos` | * |  | ARM64 tvOS
+`aarch64-unknown-cloudabi` | ✓ |  | ARM64 CloudABI
+`aarch64-unknown-freebsd` | ✓ | ✓ | ARM64 FreeBSD
+`aarch64-unknown-hermit` | ? |  |
+`aarch64-unknown-netbsd` | ? |  |
+`aarch64-unknown-openbsd` | ✓ | ✓ | ARM64 OpenBSD
+`aarch64-unknown-redox` | ? |  | ARM64 Redox OS
+`aarch64-uwp-windows-msvc` | ? |  |
+`aarch64-wrs-vxworks` | ? |  |
+`armv4t-unknown-linux-gnueabi` | ? |  |
+`armv6-unknown-freebsd` | ✓ | ✓ | ARMv6 FreeBSD
+`armv6-unknown-netbsd-eabihf` | ? |  |
+`armv7-apple-ios` | ✓ |  | RMv7 iOS, Cortex-
+`armv7-unknown-cloudabi-eabihf` | ✓ |  | ARMv7 CloudABI, hardfloat
+`armv7-unknown-freebsd` | ✓ | ✓ | ARMv7 FreeBSD
+`armv7-unknown-netbsd-eabihf` | ? |  |
+`armv7-wrs-vxworks-eabihf` | ? |  |
+`armv7a-none-eabihf` | * | | ARM Cortex-A, hardfloat
+`armv7s-apple-ios` | ✓ |  |
+`avr-unknown-unknown` | ? |  | AVR
+`hexagon-unknown-linux-musl` | ? |  |
+`i386-apple-ios` | ✓ |  | 32-bit x86 iOS
+`i686-apple-darwin` | ✓ | ✓ | 32-bit OSX (10.7+, Lion+)
+`i686-pc-windows-msvc` | ✓ |  | 32-bit Windows XP support
+`i686-unknown-cloudabi` | ✓ |  | 32-bit CloudABI
+`i686-unknown-uefi` | ? |  | 32-bit UEFI
+`i686-unknown-haiku` | ✓ | ✓ | 32-bit Haiku
+`i686-unknown-netbsd` | ✓ |  | NetBSD/i386 with SSE2
+`i686-unknown-openbsd` | ✓ | ✓ | 32-bit OpenBSD
+`i686-uwp-windows-gnu` | ? |  |
+`i686-uwp-windows-msvc` | ? |  |
+`i686-wrs-vxworks` | ? |  |
+`mips-unknown-linux-uclibc` | ✓ |  | MIPS Linux with uClibc
+`mipsel-unknown-linux-uclibc` | ✓ |  | MIPS (LE) Linux with uClibc
+`mipsel-sony-psp` | * |  | MIPS (LE) Sony PlayStation Portable (PSP)
+`mipsisa32r6-unknown-linux-gnu` | ? |  |
+`mipsisa32r6el-unknown-linux-gnu` | ? |  |
+`mipsisa64r6-unknown-linux-gnuabi64` | ? |  |
+`mipsisa64r6el-unknown-linux-gnuabi64` | ? |  |
+`msp430-none-elf` | * |  | 16-bit MSP430 microcontrollers
+`powerpc-unknown-linux-gnuspe` | ✓ |  | PowerPC SPE Linux
+`powerpc-unknown-linux-musl` | ? |  |
+`powerpc-unknown-netbsd` | ? |  |
+`powerpc-wrs-vxworks` | ? |  |
+`powerpc-wrs-vxworks-spe` | ? |  |
+`powerpc64-unknown-freebsd` | ✓ | ✓ | PPC64 FreeBSD (ELFv1 and ELFv2)
+`powerpc64-unknown-linux-musl` | ? |  |
+`powerpc64-wrs-vxworks` | ? |  |
+`powerpc64le-unknown-linux-musl` | ? |  |
+`sparc-unknown-linux-gnu` | ✓ |  | 32-bit SPARC Linux
+`sparc64-unknown-netbsd` | ✓ | ✓ | NetBSD/sparc64
+`sparc64-unknown-openbsd` | ? |  |
+`thumbv7a-pc-windows-msvc` | ? |  |
+`thumbv7a-uwp-windows-msvc` | ✓ |  |
+`thumbv7neon-unknown-linux-musleabihf` | ? |  | Thumb2-mode ARMv7a Linux with NEON, MUSL
+`thumbv4t-none-eabi` | * |  | ARMv4T T32
+`x86_64-apple-ios-macabi` | ✓ |  | Apple Catalyst
+`x86_64-apple-tvos` | * | | x86 64-bit tvOS
+`x86_64-linux-kernel` | ? |  | Linux kernel modules
+`x86_64-pc-solaris` | ? |  |
+`x86_64-pc-windows-msvc` | ✓ |  | 64-bit Windows XP support
+`x86_64-unknown-dragonfly` | ✓ | ✓ | 64-bit DragonFlyBSD
+`x86_64-unknown-haiku` | ✓ | ✓ | 64-bit Haiku
+`x86_64-unknown-hermit` | ? |  |
+`x86_64-unknown-hermit-kernel` | ? |  | HermitCore kernel
+`x86_64-unknown-l4re-uclibc` | ? |  |
+`x86_64-unknown-openbsd` | ✓ | ✓ | 64-bit OpenBSD
+`x86_64-unknown-uefi` | ? |  |
+`x86_64-uwp-windows-gnu` | ✓ |  |
+`x86_64-uwp-windows-msvc` | ✓ |  |
+`x86_64-wrs-vxworks` | ? |  |
 
 [runs on NVIDIA GPUs]: https://github.com/japaric-archived/nvptx#targets
-[Rust Forge repo]: https://github.com/rust-lang/rust-forge

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -1,0 +1,222 @@
+# Rust Platform Support
+
+The Rust compiler runs on, and compiles to, a great number of platforms, though
+not all platforms are equally supported. Rust's support levels are organized
+into three tiers, each with a different set of guarantees.
+
+Platforms are identified by their "target triple" which is the string to inform
+the compiler what kind of output should be produced. The columns below indicate
+whether the corresponding component works on the specified platform.
+
+## Tier 1
+Tier 1 platforms can be thought of as "guaranteed to work".
+Specifically they will each satisfy the following requirements:
+
+* Official binary releases are provided for the platform.
+* Automated testing is set up to run tests for the platform.
+* Landing changes to the `rust-lang/rust` repository's master branch is gated on
+    tests passing.
+* Documentation for how to use and how to build the platform is available.
+
+target | std | rustc | cargo | notes
+-------|-----|-------|-------|-------
+`i686-pc-windows-gnu` | ✓ | ✓ | ✓ | 32-bit MinGW (Windows 7+)
+`i686-pc-windows-msvc` | ✓ | ✓ | ✓ | 32-bit MSVC (Windows 7+)
+`i686-unknown-linux-gnu` | ✓ | ✓ | ✓ | 32-bit Linux (kernel 2.6.32+, glibc 2.11+)
+`x86_64-apple-darwin` | ✓ | ✓ | ✓ | 64-bit OSX (10.7+, Lion+)
+`x86_64-pc-windows-gnu` | ✓ | ✓ | ✓ | 64-bit MinGW (Windows 7+)
+`x86_64-pc-windows-msvc` | ✓ | ✓ | ✓ | 64-bit MSVC (Windows 7+)
+`x86_64-unknown-linux-gnu` | ✓ | ✓ | ✓ | 64-bit Linux (kernel 2.6.32+, glibc 2.11+)
+
+## Tier 2
+Tier 2 platforms can be thought of as "guaranteed to build". Automated tests
+are not run so it's not guaranteed to produce a working build, but platforms
+often work to quite a good degree and patches are always welcome!
+Specifically, these platforms are required to have each of the following:
+
+* Official binary releases are provided for the platform.
+* Automated building is set up, but may not be running tests.
+* Landing changes to the `rust-lang/rust` repository's master branch is gated on
+    platforms **building**. For some platforms only the standard library is
+    compiled, but for others `rustc` and `cargo` are too.
+
+target | std | rustc | cargo | notes
+-------|-----|-------|-------|-------
+`aarch64-apple-ios` | ✓ |  |  | ARM64 iOS
+`aarch64-fuchsia` | ✓ |  |  | ARM64 Fuchsia
+`aarch64-linux-android` | ✓ |  |  | ARM64 Android
+`aarch64-pc-windows-msvc` | ✓ |  |  | ARM64 Windows MSVC
+`aarch64-unknown-linux-gnu` | ✓ | ✓ | ✓ | ARM64 Linux (kernel 4.2, glibc 2.17)
+`aarch64-unknown-linux-musl` | ✓ |  |  | ARM64 Linux with MUSL
+`aarch64-unknown-none` | * |  |  | Bare ARM64, hardfloat
+`aarch64-unknown-none-softfloat` | * |  |  | Bare ARM64, softfloat
+`arm-linux-androideabi` | ✓ |  |  | ARMv7 Android
+`arm-unknown-linux-gnueabi` | ✓ | ✓ | ✓ | ARMv6 Linux (kernel 3.2, glibc 2.17)
+`arm-unknown-linux-gnueabihf` | ✓ | ✓ | ✓ | ARMv6 Linux, hardfloat (kernel 3.2, glibc 2.17)
+`arm-unknown-linux-musleabi` | ✓ |  |  | ARMv6 Linux with MUSL
+`arm-unknown-linux-musleabihf` | ✓ |  |  | ARMv6 Linux with MUSL, hardfloat
+`armebv7r-none-eabi` | * |  |  | Bare ARMv7-R, Big Endian
+`armebv7r-none-eabihf` | * |  |  | Bare ARMv7-R, Big Endian, hardfloat
+`armv5te-unknown-linux-gnueabi` | ✓ |  |  | ARMv5TE Linux (kernel 4.4, glibc 2.23)
+`armv5te-unknown-linux-musleabi` | ✓ |  |  | ARMv5TE Linux with MUSL
+`armv7-linux-androideabi` | ✓ |  |  | ARMv7a Android
+`armv7a-none-eabi` | * |  |  | Bare ARMv7-A
+`armv7r-none-eabi` | * |  |  | Bare ARMv7-R
+`armv7r-none-eabihf` | * |  |  | Bare ARMv7-R, hardfloat
+`armv7-unknown-linux-gnueabi` | ✓ |   |   | ARMv7 Linux (kernel 4.15, glibc 2.27)
+`armv7-unknown-linux-gnueabihf` | ✓ | ✓ | ✓ | ARMv7 Linux, hardfloat (kernel 3.2, glibc 2.17)
+`armv7-unknown-linux-musleabi` | ✓ |   |   | ARMv7 Linux, MUSL
+`armv7-unknown-linux-musleabihf` | ✓ |  |  | ARMv7 Linux with MUSL
+`asmjs-unknown-emscripten` | ✓ |  |  | asm.js via Emscripten
+`i586-pc-windows-msvc` | ✓ |  |  | 32-bit Windows w/o SSE
+`i586-unknown-linux-gnu` | ✓ |  |  | 32-bit Linux w/o SSE (kernel 4.4, glibc 2.23)
+`i586-unknown-linux-musl` | ✓ |  |  | 32-bit Linux w/o SSE, MUSL
+`i686-linux-android` | ✓ |  |  | 32-bit x86 Android
+`i686-unknown-freebsd` | ✓ | ✓ | ✓ | 32-bit FreeBSD
+`i686-unknown-linux-musl` | ✓ |  |  | 32-bit Linux with MUSL
+`mips-unknown-linux-gnu` | ✓ | ✓ | ✓ | MIPS Linux (kernel 4.4, glibc 2.23)
+`mips-unknown-linux-musl` | ✓ |  |  | MIPS Linux with MUSL
+`mips64-unknown-linux-gnuabi64` | ✓ | ✓ | ✓ | MIPS64 Linux, n64 ABI (kernel 4.4, glibc 2.23)
+`mips64-unknown-linux-muslabi64` | ✓ |  |  | MIPS64 Linux, n64 ABI, MUSL
+`mips64el-unknown-linux-gnuabi64` | ✓ | ✓ | ✓ | MIPS64 (LE) Linux, n64 ABI (kernel 4.4, glibc 2.23)
+`mips64el-unknown-linux-muslabi64` | ✓ |  |  | MIPS64 (LE) Linux, n64 ABI, MUSL
+`mipsel-unknown-linux-gnu` | ✓ | ✓ | ✓ | MIPS (LE) Linux (kernel 4.4, glibc 2.23)
+`mipsel-unknown-linux-musl` | ✓ |  |  | MIPS (LE) Linux with MUSL
+`nvptx64-nvidia-cuda` | ✓ |  |  | --emit=asm generates PTX code that [runs on NVIDIA GPUs]
+`powerpc-unknown-linux-gnu` | ✓ | ✓ | ✓ | PowerPC Linux (kernel 2.6.32, glibc 2.11)
+`powerpc64-unknown-linux-gnu` | ✓ | ✓ | ✓ | PPC64 Linux (kernel 2.6.32, glibc 2.11)
+`powerpc64le-unknown-linux-gnu` | ✓ | ✓ | ✓ | PPC64LE Linux (kernel 3.10, glibc 2.17)
+`riscv32i-unknown-none-elf` | * |  |  | Bare RISC-V (RV32I ISA)
+`riscv32imac-unknown-none-elf` | * |  |  | Bare RISC-V (RV32IMAC ISA)
+`riscv32imc-unknown-none-elf` | * |  |  | Bare RISC-V (RV32IMC ISA)
+`riscv64gc-unknown-linux-gnu` | ✓ | ✓ | ✓ | RISC-V Linux (kernel 4.20, glibc 2.29)
+`riscv64gc-unknown-none-elf` | * |  |  | Bare RISC-V (RV64IMAFDC ISA)
+`riscv64imac-unknown-none-elf` | * |  |  | Bare RISC-V (RV64IMAC ISA)
+`s390x-unknown-linux-gnu` | ✓ | ✓ | ✓ | S390x Linux (kernel 2.6.32, glibc 2.11)
+`sparc64-unknown-linux-gnu` | ✓ |  |  | SPARC Linux (kernel 4.4, glibc 2.23)
+`sparcv9-sun-solaris` | ✓ |  |  | SPARC Solaris 10/11, illumos
+`thumbv6m-none-eabi` | * |  |  | Bare Cortex-M0, M0+, M1
+`thumbv7em-none-eabi` | * |  |  | Bare Cortex-M4, M7
+`thumbv7em-none-eabihf` | * |  |  | Bare Cortex-M4F, M7F, FPU, hardfloat
+`thumbv7m-none-eabi` | * |  |  | Bare Cortex-M3
+`thumbv7neon-linux-androideabi` | ✓ |  |  | Thumb2-mode ARMv7a Android with NEON
+`thumbv7neon-unknown-linux-gnueabihf` | ✓ |  |  | Thumb2-mode ARMv7a Linux with NEON (kernel 4.4, glibc 2.23)
+`thumbv8m.base-none-eabi` | * |  |  | ARMv8-M Baseline
+`thumbv8m.main-none-eabi` | * |  |  | ARMv8-M Mainline
+`thumbv8m.main-none-eabihf` | * |  |  | ARMv8-M Baseline, hardfloat
+`wasm32-unknown-emscripten` | ✓ |  |  | WebAssembly via Emscripten
+`wasm32-unknown-unknown` | ✓ |  |  | WebAssembly
+`wasm32-wasi` | ✓ |  |  | WebAssembly with WASI
+`x86_64-apple-ios` | ✓ |  |  | 64-bit x86 iOS
+`x86_64-fortanix-unknown-sgx` | ✓ |  |  | [Fortanix ABI] for 64-bit Intel SGX
+`x86_64-fuchsia` | ✓ |  |  | 64-bit Fuchsia
+`x86_64-linux-android` | ✓ |  |  | 64-bit x86 Android
+`x86_64-rumprun-netbsd` | ✓ |  |  | 64-bit NetBSD Rump Kernel
+`x86_64-sun-solaris` | ✓ |  |  | 64-bit Solaris 10/11, illumos
+`x86_64-unknown-cloudabi` | ✓ |  |  | 64-bit CloudABI
+`x86_64-unknown-freebsd` | ✓ | ✓ | ✓ | 64-bit FreeBSD
+`x86_64-unknown-illumos` | ✓ | ✓ | ✓ | illumos
+`x86_64-unknown-linux-gnux32` | ✓ |  |  | 64-bit Linux (x32 ABI) (kernel 4.15, glibc 2.27)
+`x86_64-unknown-linux-musl` | ✓ | ✓ | ✓ | 64-bit Linux with MUSL
+`x86_64-unknown-netbsd` | ✓ | ✓ | ✓ | NetBSD/amd64
+`x86_64-unknown-redox` | ✓ |  |  | Redox OS
+
+[Fortanix ABI]: https://edp.fortanix.com/
+
+## Tier 3
+Tier 3 platforms are those which the Rust codebase has support for, but which
+are not built or tested automatically, and may not work. Official builds are
+not available.
+
+target | std | rustc | cargo | notes
+-------|-----|-------|-------|-------
+`aarch64-apple-darwin` | ? |  |  | ARM64 macOS
+`aarch64-apple-tvos` | ** |  |  | ARM64 tvOS
+`aarch64-unknown-cloudabi` | ✓ |  |  | ARM64 CloudABI
+`aarch64-unknown-freebsd` | ✓ | ✓ | ✓ | ARM64 FreeBSD
+`aarch64-unknown-hermit` | ? |  |  |
+`aarch64-unknown-netbsd` | ? |  |  |
+`aarch64-unknown-openbsd` | ✓ | ✓ | ✓ | ARM64 OpenBSD
+`aarch64-unknown-redox` | ? |  |  | ARM64 Redox OS
+`aarch64-uwp-windows-msvc` | ? |  |  |
+`aarch64-wrs-vxworks` | ? |  |  |
+`armv4t-unknown-linux-gnueabi` | ? |  |  |
+`armv6-unknown-freebsd` | ✓ | ✓ | ✓ | ARMv6 FreeBSD
+`armv6-unknown-netbsd-eabihf` | ? |  |  |
+`armv7-apple-ios` | ✓ |  |  | RMv7 iOS, Cortex-
+`armv7-unknown-cloudabi-eabihf` | ✓ |  |  | ARMv7 CloudABI, hardfloat
+`armv7-unknown-freebsd` | ✓ | ✓ | ✓ | ARMv7 FreeBSD
+`armv7-unknown-netbsd-eabihf` | ? |  |  |
+`armv7-wrs-vxworks-eabihf` | ? |  |  |
+`armv7a-none-eabihf` | * | | | ARM Cortex-A, hardfloat
+`armv7s-apple-ios` | ✓ |  |  |
+`avr-unknown-unknown` | ? |  |  | AVR
+`hexagon-unknown-linux-musl` | ? |  |  |
+`i386-apple-ios` | ✓ |  |  | 32-bit x86 iOS
+`i686-apple-darwin` | ✓ | ✓ | ✓ | 32-bit OSX (10.7+, Lion+)
+`i686-pc-windows-msvc` | ✓ |  |  | 32-bit Windows XP support
+`i686-unknown-cloudabi` | ✓ |  |  | 32-bit CloudABI
+`i686-unknown-uefi` | ? |  |  | 32-bit UEFI
+`i686-unknown-haiku` | ✓ | ✓ | ✓ | 32-bit Haiku
+`i686-unknown-netbsd` | ✓ |  |  | NetBSD/i386 with SSE2
+`i686-unknown-openbsd` | ✓ | ✓ | ✓ | 32-bit OpenBSD
+`i686-uwp-windows-gnu` | ? |  |  |
+`i686-uwp-windows-msvc` | ? |  |  |
+`i686-wrs-vxworks` | ? |  |  |
+`mips-unknown-linux-uclibc` | ✓ |  |  | MIPS Linux with uClibc
+`mipsel-unknown-linux-uclibc` | ✓ |  |  | MIPS (LE) Linux with uClibc
+`mipsel-sony-psp` | ** |  |  | MIPS (LE) Sony PlayStation Portable (PSP)
+`mipsisa32r6-unknown-linux-gnu` | ? |  |  |
+`mipsisa32r6el-unknown-linux-gnu` | ? |  |  |
+`mipsisa64r6-unknown-linux-gnuabi64` | ? |  |  |
+`mipsisa64r6el-unknown-linux-gnuabi64` | ? |  |  |
+`msp430-none-elf` | * |  |  | 16-bit MSP430 microcontrollers
+`powerpc-unknown-linux-gnuspe` | ✓ |  |  | PowerPC SPE Linux
+`powerpc-unknown-linux-musl` | ? |  |  |
+`powerpc-unknown-netbsd` | ? |  |  |
+`powerpc-wrs-vxworks` | ? |  |  |
+`powerpc-wrs-vxworks-spe` | ? |  |  |
+`powerpc64-unknown-freebsd` | ✓ | ✓ | ✓ | PPC64 FreeBSD (ELFv1 and ELFv2)
+`powerpc64-unknown-linux-musl` | ? |  |  |
+`powerpc64-wrs-vxworks` | ? |  |  |
+`powerpc64le-unknown-linux-musl` | ? |  |  |
+`sparc-unknown-linux-gnu` | ✓ |  |  | 32-bit SPARC Linux
+`sparc64-unknown-netbsd` | ✓ | ✓ |  | NetBSD/sparc64
+`sparc64-unknown-openbsd` | ? |  |  |
+`thumbv7a-pc-windows-msvc` | ? |  |  |
+`thumbv7a-uwp-windows-msvc` | ✓ |  |  |
+`thumbv7neon-unknown-linux-musleabihf` | ? |  |  | Thumb2-mode ARMv7a Linux with NEON, MUSL
+`thumbv4t-none-eabi` | * |  |  | ARMv4T T32
+`x86_64-apple-ios-macabi` | ✓ |  |  | Apple Catalyst
+`x86_64-apple-tvos` | ** | | | x86 64-bit tvOS
+`x86_64-linux-kernel` | ? |  |  | Linux kernel modules
+`x86_64-pc-solaris` | ? |  |  |
+`x86_64-pc-windows-msvc` | ✓ |  |  | 64-bit Windows XP support
+`x86_64-unknown-dragonfly` | ✓ | ✓ | ✓ | 64-bit DragonFlyBSD
+`x86_64-unknown-haiku` | ✓ | ✓ | ✓ | 64-bit Haiku
+`x86_64-unknown-hermit` | ? |  |  |
+`x86_64-unknown-hermit-kernel` | ? |  |  | HermitCore kernel
+`x86_64-unknown-l4re-uclibc` | ? |  |  |
+`x86_64-unknown-openbsd` | ✓ | ✓ | ✓ | 64-bit OpenBSD
+`x86_64-unknown-uefi` | ? |  |  |
+`x86_64-uwp-windows-gnu` | ✓ |  |  |
+`x86_64-uwp-windows-msvc` | ✓ |  |  |
+`x86_64-wrs-vxworks` | ? |  |  |
+
+
+\* These targets only support `core`, not `alloc` or `std`.
+
+\*\* These targets only support `core` or `alloc`, not `std`.
+
+? These are targets that haven't yet been documented here. If you can shed some
+  light on these platforms support, please create an issue or PR on the [Rust
+  Forge repo].
+
+But those aren't the only platforms Rust can compile to! Those are the ones with
+built-in target definitions and/or standard library support. When linking only
+to the core library, Rust can also target additional "bare metal" platforms in
+the x86, ARM, MIPS, and PowerPC families, though it may require defining custom
+target specifications to do so.
+
+[runs on NVIDIA GPUs]: https://github.com/japaric-archived/nvptx#targets
+[Rust Forge repo]: https://github.com/rust-lang/rust-forge

--- a/src/doc/rustc/src/targets/built-in.md
+++ b/src/doc/rustc/src/targets/built-in.md
@@ -2,9 +2,14 @@
 
 `rustc` ships with the ability to compile to many targets automatically, we
 call these "built-in" targets, and they generally correspond to targets that
-the team is supporting directly.
+the team is supporting directly. To see the list of built-in targets, you can
+run `rustc --print target-list`.
 
-To see the list of built-in targets, you can run `rustc --print target-list`,
-or look at [the API
-docs](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_target/spec/index.html#modules).
-Each module there defines a builder for a particular target.
+Typically, a target needs a compiled copy of the Rust standard library to
+work. If using [rustup], then check out the documentation on
+[Cross-compilation][rustup-cross] on how to download a pre-built standard
+library built by the official Rust distributions. Most targets will need a
+system linker, and possibly other things.
+
+[rustup]: https://github.com/rust-lang/rustup
+[rustup-cross]: https://github.com/rust-lang/rustup#cross-compilation

--- a/src/librustc_codegen_llvm/consts.rs
+++ b/src/librustc_codegen_llvm/consts.rs
@@ -215,7 +215,7 @@ impl CodegenCx<'ll, 'tcx> {
         debug!("get_static: sym={} instance={:?}", sym, instance);
 
         let g = if let Some(def_id) = def_id.as_local() {
-            let id = self.tcx.hir().as_local_hir_id(def_id);
+            let id = self.tcx.hir().local_def_id_to_hir_id(def_id);
             let llty = self.layout_of(ty).llvm_type(self);
             // FIXME: refactor this to work without accessing the HIR
             let (g, attrs) = match self.tcx.hir().get(id) {

--- a/src/librustc_codegen_ssa/back/symbol_export.rs
+++ b/src/librustc_codegen_ssa/back/symbol_export.rs
@@ -370,7 +370,7 @@ fn upstream_drop_glue_for_provider<'tcx>(
 
 fn is_unreachable_local_definition_provider(tcx: TyCtxt<'_>, def_id: DefId) -> bool {
     if let Some(def_id) = def_id.as_local() {
-        !tcx.reachable_set(LOCAL_CRATE).contains(&tcx.hir().as_local_hir_id(def_id))
+        !tcx.reachable_set(LOCAL_CRATE).contains(&tcx.hir().local_def_id_to_hir_id(def_id))
     } else {
         bug!("is_unreachable_local_definition called with non-local DefId: {:?}", def_id)
     }

--- a/src/librustc_hir/definitions.rs
+++ b/src/librustc_hir/definitions.rs
@@ -307,11 +307,6 @@ impl Definitions {
     }
 
     #[inline]
-    pub fn as_local_hir_id(&self, def_id: LocalDefId) -> hir::HirId {
-        self.local_def_id_to_hir_id(def_id)
-    }
-
-    #[inline]
     pub fn local_def_id_to_hir_id(&self, id: LocalDefId) -> hir::HirId {
         self.def_id_to_hir_id[id].unwrap()
     }

--- a/src/librustc_hir/lang_items.rs
+++ b/src/librustc_hir/lang_items.rs
@@ -157,6 +157,7 @@ language_item_table! {
     BoolImplItem,                  sym::bool,               bool_impl,               Target::Impl;
     CharImplItem,                  sym::char,               char_impl,               Target::Impl;
     StrImplItem,                   sym::str,                str_impl,                Target::Impl;
+    ArrayImplItem,                 sym::array,              array_impl,              Target::Impl;
     SliceImplItem,                 sym::slice,              slice_impl,              Target::Impl;
     SliceU8ImplItem,               sym::slice_u8,           slice_u8_impl,           Target::Impl;
     StrAllocImplItem,              sym::str_alloc,          str_alloc_impl,          Target::Impl;

--- a/src/librustc_infer/infer/error_reporting/nice_region_error/find_anon_type.rs
+++ b/src/librustc_infer/infer/error_reporting/nice_region_error/find_anon_type.rs
@@ -28,7 +28,7 @@ impl<'a, 'tcx> NiceRegionError<'a, 'tcx> {
         br: &ty::BoundRegion,
     ) -> Option<(&hir::Ty<'tcx>, &hir::FnDecl<'tcx>)> {
         if let Some(anon_reg) = self.tcx().is_suitable_region(region) {
-            let hir_id = self.tcx().hir().as_local_hir_id(anon_reg.def_id);
+            let hir_id = self.tcx().hir().local_def_id_to_hir_id(anon_reg.def_id);
             let fndecl = match self.tcx().hir().get(hir_id) {
                 Node::Item(&hir::Item { kind: hir::ItemKind::Fn(ref m, ..), .. })
                 | Node::TraitItem(&hir::TraitItem {

--- a/src/librustc_infer/infer/error_reporting/nice_region_error/trait_impl_difference.rs
+++ b/src/librustc_infer/infer/error_reporting/nice_region_error/trait_impl_difference.rs
@@ -67,7 +67,8 @@ impl<'a, 'tcx> NiceRegionError<'a, 'tcx> {
         match assoc_item.kind {
             ty::AssocKind::Fn => {
                 let hir = self.tcx().hir();
-                if let Some(hir_id) = assoc_item.def_id.as_local().map(|id| hir.as_local_hir_id(id))
+                if let Some(hir_id) =
+                    assoc_item.def_id.as_local().map(|id| hir.local_def_id_to_hir_id(id))
                 {
                     if let Some(decl) = hir.fn_decl_by_hir_id(hir_id) {
                         visitor.visit_fn_decl(decl);

--- a/src/librustc_infer/infer/error_reporting/nice_region_error/util.rs
+++ b/src/librustc_infer/infer/error_reporting/nice_region_error/util.rs
@@ -49,7 +49,7 @@ impl<'a, 'tcx> NiceRegionError<'a, 'tcx> {
         };
 
         let hir = &self.tcx().hir();
-        let hir_id = hir.as_local_hir_id(id.as_local()?);
+        let hir_id = hir.local_def_id_to_hir_id(id.as_local()?);
         let body_id = hir.maybe_body_owned_by(hir_id)?;
         let body = hir.body(body_id);
         let owner_id = hir.body_owner(body_id);

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -440,7 +440,7 @@ impl<'tcx> LateLintPass<'tcx> for MissingDoc {
                 // reported for missing docs.
                 let real_trait = trait_ref.path.res.def_id();
                 if let Some(def_id) = real_trait.as_local() {
-                    let hir_id = cx.tcx.hir().as_local_hir_id(def_id);
+                    let hir_id = cx.tcx.hir().local_def_id_to_hir_id(def_id);
                     if let Some(Node::Item(item)) = cx.tcx.hir().find(hir_id) {
                         if let hir::VisibilityKind::Inherited = item.vis.node {
                             for impl_item_ref in items {
@@ -614,7 +614,7 @@ impl<'tcx> LateLintPass<'tcx> for MissingDebugImplementations {
             cx.tcx.for_each_impl(debug, |d| {
                 if let Some(ty_def) = cx.tcx.type_of(d).ty_adt_def() {
                     if let Some(def_id) = ty_def.did.as_local() {
-                        impls.insert(cx.tcx.hir().as_local_hir_id(def_id));
+                        impls.insert(cx.tcx.hir().local_def_id_to_hir_id(def_id));
                     }
                 }
             });

--- a/src/librustc_lint/late.rs
+++ b/src/librustc_lint/late.rs
@@ -379,7 +379,7 @@ fn late_lint_mod_pass<'tcx, T: LateLintPass<'tcx>>(
         param_env: ty::ParamEnv::empty(),
         access_levels,
         lint_store: unerased_lint_store(tcx),
-        last_node_with_lint_attrs: tcx.hir().as_local_hir_id(module_def_id),
+        last_node_with_lint_attrs: tcx.hir().local_def_id_to_hir_id(module_def_id),
         generics: None,
         only_module: true,
     };

--- a/src/librustc_metadata/rmeta/encoder.rs
+++ b/src/librustc_metadata/rmeta/encoder.rs
@@ -733,7 +733,7 @@ impl EncodeContext<'a, 'tcx> {
             is_non_exhaustive: variant.is_field_list_non_exhaustive(),
         };
 
-        let enum_id = tcx.hir().as_local_hir_id(def.did.expect_local());
+        let enum_id = tcx.hir().local_def_id_to_hir_id(def.did.expect_local());
         let enum_vis = &tcx.hir().expect_item(enum_id).vis;
 
         record!(self.tables.kind[def_id] <- EntryKind::Variant(self.lazy(data)));
@@ -780,7 +780,7 @@ impl EncodeContext<'a, 'tcx> {
 
         // Variant constructors have the same visibility as the parent enums, unless marked as
         // non-exhaustive, in which case they are lowered to `pub(crate)`.
-        let enum_id = tcx.hir().as_local_hir_id(def.did.expect_local());
+        let enum_id = tcx.hir().local_def_id_to_hir_id(def.did.expect_local());
         let enum_vis = &tcx.hir().expect_item(enum_id).vis;
         let mut ctor_vis = ty::Visibility::from_hir(enum_vis, enum_id, tcx);
         if variant.is_field_list_non_exhaustive() && ctor_vis == ty::Visibility::Public {
@@ -819,11 +819,11 @@ impl EncodeContext<'a, 'tcx> {
         let data = ModData {
             reexports: match tcx.module_exports(local_def_id) {
                 Some(exports) => {
-                    let hir_map = self.tcx.hir();
+                    let hir = self.tcx.hir();
                     self.lazy(
                         exports
                             .iter()
-                            .map(|export| export.map_id(|id| hir_map.as_local_hir_id(id))),
+                            .map(|export| export.map_id(|id| hir.local_def_id_to_hir_id(id))),
                     )
                 }
                 _ => Lazy::empty(),
@@ -855,7 +855,7 @@ impl EncodeContext<'a, 'tcx> {
         let def_id = field.did;
         debug!("EncodeContext::encode_field({:?})", def_id);
 
-        let variant_id = tcx.hir().as_local_hir_id(variant.def_id.expect_local());
+        let variant_id = tcx.hir().local_def_id_to_hir_id(variant.def_id.expect_local());
         let variant_data = tcx.hir().expect_variant_data(variant_id);
 
         record!(self.tables.kind[def_id] <- EntryKind::Field);
@@ -883,7 +883,7 @@ impl EncodeContext<'a, 'tcx> {
             is_non_exhaustive: variant.is_field_list_non_exhaustive(),
         };
 
-        let struct_id = tcx.hir().as_local_hir_id(adt_def.did.expect_local());
+        let struct_id = tcx.hir().local_def_id_to_hir_id(adt_def.did.expect_local());
         let struct_vis = &tcx.hir().expect_item(struct_id).vis;
         let mut ctor_vis = ty::Visibility::from_hir(struct_vis, struct_id, tcx);
         for field in &variant.fields {
@@ -945,7 +945,7 @@ impl EncodeContext<'a, 'tcx> {
         debug!("EncodeContext::encode_info_for_trait_item({:?})", def_id);
         let tcx = self.tcx;
 
-        let hir_id = tcx.hir().as_local_hir_id(def_id.expect_local());
+        let hir_id = tcx.hir().local_def_id_to_hir_id(def_id.expect_local());
         let ast_item = tcx.hir().expect_trait_item(hir_id);
         let trait_item = tcx.associated_item(def_id);
 
@@ -1034,7 +1034,7 @@ impl EncodeContext<'a, 'tcx> {
         debug!("EncodeContext::encode_info_for_impl_item({:?})", def_id);
         let tcx = self.tcx;
 
-        let hir_id = self.tcx.hir().as_local_hir_id(def_id.expect_local());
+        let hir_id = self.tcx.hir().local_def_id_to_hir_id(def_id.expect_local());
         let ast_item = self.tcx.hir().expect_impl_item(hir_id);
         let impl_item = self.tcx.associated_item(def_id);
 
@@ -1438,7 +1438,7 @@ impl EncodeContext<'a, 'tcx> {
 
         // NOTE(eddyb) `tcx.type_of(def_id)` isn't used because it's fully generic,
         // including on the signature, which is inferred in `typeck.
-        let hir_id = self.tcx.hir().as_local_hir_id(def_id);
+        let hir_id = self.tcx.hir().local_def_id_to_hir_id(def_id);
         let ty = self.tcx.typeck(def_id).node_type(hir_id);
 
         record!(self.tables.kind[def_id.to_def_id()] <- match ty.kind {
@@ -1465,7 +1465,7 @@ impl EncodeContext<'a, 'tcx> {
 
     fn encode_info_for_anon_const(&mut self, def_id: LocalDefId) {
         debug!("EncodeContext::encode_info_for_anon_const({:?})", def_id);
-        let id = self.tcx.hir().as_local_hir_id(def_id);
+        let id = self.tcx.hir().local_def_id_to_hir_id(def_id);
         let body_id = self.tcx.hir().body_owned_by(id);
         let const_data = self.encode_rendered_const_for_body(body_id);
         let qualifs = self.tcx.mir_const_qualif(def_id);

--- a/src/librustc_middle/dep_graph/mod.rs
+++ b/src/librustc_middle/dep_graph/mod.rs
@@ -185,6 +185,6 @@ impl<'tcx> DepContext for TyCtxt<'tcx> {
 }
 
 fn def_id_corresponds_to_hir_dep_node(tcx: TyCtxt<'_>, def_id: LocalDefId) -> bool {
-    let hir_id = tcx.hir().as_local_hir_id(def_id);
+    let hir_id = tcx.hir().local_def_id_to_hir_id(def_id);
     def_id == hir_id.owner
 }

--- a/src/librustc_middle/hir/map/mod.rs
+++ b/src/librustc_middle/hir/map/mod.rs
@@ -174,11 +174,6 @@ impl<'hir> Map<'hir> {
     }
 
     #[inline]
-    pub fn as_local_hir_id(&self, def_id: LocalDefId) -> HirId {
-        self.tcx.definitions.as_local_hir_id(def_id)
-    }
-
-    #[inline]
     pub fn local_def_id_to_hir_id(&self, def_id: LocalDefId) -> HirId {
         self.tcx.definitions.local_def_id_to_hir_id(def_id)
     }
@@ -450,7 +445,7 @@ impl<'hir> Map<'hir> {
     }
 
     pub fn get_module(&self, module: LocalDefId) -> (&'hir Mod<'hir>, Span, HirId) {
-        let hir_id = self.as_local_hir_id(module);
+        let hir_id = self.local_def_id_to_hir_id(module);
         match self.get_entry(hir_id).node {
             Node::Item(&Item { span, kind: ItemKind::Mod(ref m), .. }) => (m, span, hir_id),
             Node::Crate(item) => (&item.module, item.span, hir_id),
@@ -483,7 +478,7 @@ impl<'hir> Map<'hir> {
     }
 
     pub fn get_if_local(&self, id: DefId) -> Option<Node<'hir>> {
-        id.as_local().map(|id| self.get(self.as_local_hir_id(id)))
+        id.as_local().map(|id| self.get(self.local_def_id_to_hir_id(id)))
     }
 
     pub fn get_generics(&self, id: DefId) -> Option<&'hir Generics<'hir>> {
@@ -872,7 +867,7 @@ impl<'hir> Map<'hir> {
     }
 
     pub fn span_if_local(&self, id: DefId) -> Option<Span> {
-        id.as_local().map(|id| self.span(self.as_local_hir_id(id)))
+        id.as_local().map(|id| self.span(self.local_def_id_to_hir_id(id)))
     }
 
     pub fn res_span(&self, res: Res) -> Option<Span> {

--- a/src/librustc_middle/hir/mod.rs
+++ b/src/librustc_middle/hir/mod.rs
@@ -66,20 +66,20 @@ impl<'tcx> TyCtxt<'tcx> {
 pub fn provide(providers: &mut Providers) {
     providers.parent_module_from_def_id = |tcx, id| {
         let hir = tcx.hir();
-        hir.local_def_id(hir.get_module_parent_node(hir.as_local_hir_id(id)))
+        hir.local_def_id(hir.get_module_parent_node(hir.local_def_id_to_hir_id(id)))
     };
     providers.hir_crate = |tcx, _| tcx.untracked_crate;
     providers.index_hir = map::index_hir;
     providers.hir_module_items = |tcx, id| {
         let hir = tcx.hir();
-        let module = hir.as_local_hir_id(id);
+        let module = hir.local_def_id_to_hir_id(id);
         &tcx.untracked_crate.modules[&module]
     };
     providers.hir_owner = |tcx, id| tcx.index_hir(LOCAL_CRATE).map[id].signature;
     providers.hir_owner_nodes = |tcx, id| tcx.index_hir(LOCAL_CRATE).map[id].with_bodies.as_deref();
     providers.fn_arg_names = |tcx, id| {
         let hir = tcx.hir();
-        let hir_id = hir.as_local_hir_id(id.expect_local());
+        let hir_id = hir.local_def_id_to_hir_id(id.expect_local());
         if let Some(body_id) = hir.maybe_body_owned_by(hir_id) {
             tcx.arena.alloc_from_iter(hir.body_param_names(body_id))
         } else if let Node::TraitItem(&TraitItem {

--- a/src/librustc_middle/mir/mod.rs
+++ b/src/librustc_middle/mir/mod.rs
@@ -2127,7 +2127,7 @@ impl<'tcx> Debug for Rvalue<'tcx> {
 
                     AggregateKind::Closure(def_id, substs) => ty::tls::with(|tcx| {
                         if let Some(def_id) = def_id.as_local() {
-                            let hir_id = tcx.hir().as_local_hir_id(def_id);
+                            let hir_id = tcx.hir().local_def_id_to_hir_id(def_id);
                             let name = if tcx.sess.opts.debugging_opts.span_free_formats {
                                 let substs = tcx.lift(&substs).unwrap();
                                 format!(
@@ -2155,7 +2155,7 @@ impl<'tcx> Debug for Rvalue<'tcx> {
 
                     AggregateKind::Generator(def_id, _, _) => ty::tls::with(|tcx| {
                         if let Some(def_id) = def_id.as_local() {
-                            let hir_id = tcx.hir().as_local_hir_id(def_id);
+                            let hir_id = tcx.hir().local_def_id_to_hir_id(def_id);
                             let name = format!("[generator@{:?}]", tcx.hir().span(hir_id));
                             let mut struct_fmt = fmt.debug_struct(&name);
 

--- a/src/librustc_middle/mir/mono.rs
+++ b/src/librustc_middle/mir/mono.rs
@@ -198,10 +198,10 @@ impl<'tcx> MonoItem<'tcx> {
     pub fn local_span(&self, tcx: TyCtxt<'tcx>) -> Option<Span> {
         match *self {
             MonoItem::Fn(Instance { def, .. }) => {
-                def.def_id().as_local().map(|def_id| tcx.hir().as_local_hir_id(def_id))
+                def.def_id().as_local().map(|def_id| tcx.hir().local_def_id_to_hir_id(def_id))
             }
             MonoItem::Static(def_id) => {
-                def_id.as_local().map(|def_id| tcx.hir().as_local_hir_id(def_id))
+                def_id.as_local().map(|def_id| tcx.hir().local_def_id_to_hir_id(def_id))
             }
             MonoItem::GlobalAsm(hir_id) => Some(hir_id),
         }
@@ -346,9 +346,10 @@ impl<'tcx> CodegenUnit<'tcx> {
                             // instances into account. The others don't matter for
                             // the codegen tests and can even make item order
                             // unstable.
-                            InstanceDef::Item(def) => {
-                                def.did.as_local().map(|def_id| tcx.hir().as_local_hir_id(def_id))
-                            }
+                            InstanceDef::Item(def) => def
+                                .did
+                                .as_local()
+                                .map(|def_id| tcx.hir().local_def_id_to_hir_id(def_id)),
                             InstanceDef::VtableShim(..)
                             | InstanceDef::ReifyShim(..)
                             | InstanceDef::Intrinsic(..)
@@ -360,7 +361,7 @@ impl<'tcx> CodegenUnit<'tcx> {
                         }
                     }
                     MonoItem::Static(def_id) => {
-                        def_id.as_local().map(|def_id| tcx.hir().as_local_hir_id(def_id))
+                        def_id.as_local().map(|def_id| tcx.hir().local_def_id_to_hir_id(def_id))
                     }
                     MonoItem::GlobalAsm(hir_id) => Some(hir_id),
                 },

--- a/src/librustc_middle/query/mod.rs
+++ b/src/librustc_middle/query/mod.rs
@@ -352,7 +352,7 @@ rustc_queries! {
         /// per-type-parameter predicates for resolving `T::AssocTy`.
         query type_param_predicates(key: (DefId, LocalDefId)) -> ty::GenericPredicates<'tcx> {
             desc { |tcx| "computing the bounds for type parameter `{}`", {
-                let id = tcx.hir().as_local_hir_id(key.1);
+                let id = tcx.hir().local_def_id_to_hir_id(key.1);
                 tcx.hir().ty_param_name(id)
             }}
         }

--- a/src/librustc_middle/ty/consts.rs
+++ b/src/librustc_middle/ty/consts.rs
@@ -88,7 +88,7 @@ impl<'tcx> Const<'tcx> {
             ExprKind::Path(QPath::Resolved(_, &Path { res: Res::Def(ConstParam, def_id), .. })) => {
                 // Find the name and index of the const parameter by indexing the generics of
                 // the parent item and construct a `ParamConst`.
-                let hir_id = tcx.hir().as_local_hir_id(def_id.expect_local());
+                let hir_id = tcx.hir().local_def_id_to_hir_id(def_id.expect_local());
                 let item_id = tcx.hir().get_parent_node(hir_id);
                 let item_def_id = tcx.hir().local_def_id(item_id);
                 let generics = tcx.generics_of(item_def_id.to_def_id());

--- a/src/librustc_middle/ty/context.rs
+++ b/src/librustc_middle/ty/context.rs
@@ -1420,7 +1420,7 @@ impl<'tcx> TyCtxt<'tcx> {
             _ => return None, // not a free region
         };
 
-        let hir_id = self.hir().as_local_hir_id(suitable_region_binding_scope);
+        let hir_id = self.hir().local_def_id_to_hir_id(suitable_region_binding_scope);
         let is_impl_item = match self.hir().find(hir_id) {
             Some(Node::Item(..) | Node::TraitItem(..)) => false,
             Some(Node::ImplItem(..)) => {
@@ -1441,7 +1441,7 @@ impl<'tcx> TyCtxt<'tcx> {
         &self,
         scope_def_id: LocalDefId,
     ) -> Vec<&'tcx hir::Ty<'tcx>> {
-        let hir_id = self.hir().as_local_hir_id(scope_def_id);
+        let hir_id = self.hir().local_def_id_to_hir_id(scope_def_id);
         let hir_output = match self.hir().get(hir_id) {
             Node::Item(hir::Item {
                 kind:
@@ -1486,7 +1486,7 @@ impl<'tcx> TyCtxt<'tcx> {
 
     pub fn return_type_impl_trait(&self, scope_def_id: LocalDefId) -> Option<(Ty<'tcx>, Span)> {
         // HACK: `type_of_def_id()` will fail on these (#55796), so return `None`.
-        let hir_id = self.hir().as_local_hir_id(scope_def_id);
+        let hir_id = self.hir().local_def_id_to_hir_id(scope_def_id);
         match self.hir().get(hir_id) {
             Node::Item(item) => {
                 match item.kind {

--- a/src/librustc_middle/ty/error.rs
+++ b/src/librustc_middle/ty/error.rs
@@ -403,7 +403,7 @@ impl<'tcx> TyCtxt<'tcx> {
                             .type_param(p, self)
                             .def_id
                             .as_local()
-                            .map(|id| hir.as_local_hir_id(id))
+                            .map(|id| hir.local_def_id_to_hir_id(id))
                             .and_then(|id| self.hir().find(self.hir().get_parent_node(id)))
                             .as_ref()
                             .and_then(|node| node.generics())
@@ -791,10 +791,11 @@ fn foo(&self) -> Self::T { String::new() }
         body_owner_def_id: DefId,
         found: Ty<'tcx>,
     ) -> bool {
-        let hir_id = match body_owner_def_id.as_local().map(|id| self.hir().as_local_hir_id(id)) {
-            Some(hir_id) => hir_id,
-            None => return false,
-        };
+        let hir_id =
+            match body_owner_def_id.as_local().map(|id| self.hir().local_def_id_to_hir_id(id)) {
+                Some(hir_id) => hir_id,
+                None => return false,
+            };
         // When `body_owner` is an `impl` or `trait` item, look in its associated types for
         // `expected` and point at it.
         let parent_id = self.hir().get_parent_item(hir_id);

--- a/src/librustc_middle/ty/mod.rs
+++ b/src/librustc_middle/ty/mod.rs
@@ -2845,12 +2845,12 @@ impl<'tcx> TyCtxt<'tcx> {
     pub fn opt_item_name(self, def_id: DefId) -> Option<Ident> {
         def_id
             .as_local()
-            .and_then(|def_id| self.hir().get(self.hir().as_local_hir_id(def_id)).ident())
+            .and_then(|def_id| self.hir().get(self.hir().local_def_id_to_hir_id(def_id)).ident())
     }
 
     pub fn opt_associated_item(self, def_id: DefId) -> Option<&'tcx AssocItem> {
         let is_associated_item = if let Some(def_id) = def_id.as_local() {
-            match self.hir().get(self.hir().as_local_hir_id(def_id)) {
+            match self.hir().get(self.hir().local_def_id_to_hir_id(def_id)) {
                 Node::TraitItem(_) | Node::ImplItem(_) => true,
                 _ => false,
             }
@@ -3009,7 +3009,7 @@ impl<'tcx> TyCtxt<'tcx> {
     /// Gets the attributes of a definition.
     pub fn get_attrs(self, did: DefId) -> Attributes<'tcx> {
         if let Some(did) = did.as_local() {
-            self.hir().attrs(self.hir().as_local_hir_id(did))
+            self.hir().attrs(self.hir().local_def_id_to_hir_id(did))
         } else {
             self.item_attrs(did)
         }
@@ -3048,7 +3048,7 @@ impl<'tcx> TyCtxt<'tcx> {
     /// with the name of the crate containing the impl.
     pub fn span_of_impl(self, impl_did: DefId) -> Result<Span, Symbol> {
         if let Some(impl_did) = impl_did.as_local() {
-            let hir_id = self.hir().as_local_hir_id(impl_did);
+            let hir_id = self.hir().local_def_id_to_hir_id(impl_did);
             Ok(self.hir().span(hir_id))
         } else {
             Err(self.crate_name(impl_did.krate))
@@ -3109,7 +3109,7 @@ pub struct AdtSizedConstraint<'tcx>(pub &'tcx [Ty<'tcx>]);
 /// Yields the parent function's `DefId` if `def_id` is an `impl Trait` definition.
 pub fn is_impl_trait_defn(tcx: TyCtxt<'_>, def_id: DefId) -> Option<DefId> {
     if let Some(def_id) = def_id.as_local() {
-        if let Node::Item(item) = tcx.hir().get(tcx.hir().as_local_hir_id(def_id)) {
+        if let Node::Item(item) = tcx.hir().get(tcx.hir().local_def_id_to_hir_id(def_id)) {
             if let hir::ItemKind::OpaqueTy(ref opaque_ty) = item.kind {
                 return opaque_ty.impl_trait_fn;
             }

--- a/src/librustc_middle/ty/print/pretty.rs
+++ b/src/librustc_middle/ty/print/pretty.rs
@@ -610,7 +610,7 @@ pub trait PrettyPrinter<'tcx>:
 
                 // FIXME(eddyb) should use `def_span`.
                 if let Some(did) = did.as_local() {
-                    let hir_id = self.tcx().hir().as_local_hir_id(did);
+                    let hir_id = self.tcx().hir().local_def_id_to_hir_id(did);
                     let span = self.tcx().hir().span(hir_id);
                     p!(write("@{}", self.tcx().sess.source_map().span_to_string(span)));
 
@@ -656,7 +656,7 @@ pub trait PrettyPrinter<'tcx>:
 
                 // FIXME(eddyb) should use `def_span`.
                 if let Some(did) = did.as_local() {
-                    let hir_id = self.tcx().hir().as_local_hir_id(did);
+                    let hir_id = self.tcx().hir().local_def_id_to_hir_id(did);
                     if self.tcx().sess.opts.debugging_opts.span_free_formats {
                         p!(write("@"), print_def_path(did.to_def_id(), substs));
                     } else {

--- a/src/librustc_middle/ty/util.rs
+++ b/src/librustc_middle/ty/util.rs
@@ -879,7 +879,7 @@ impl<'tcx> ty::TyS<'tcx> {
                         let span = match field
                             .did
                             .as_local()
-                            .map(|id| tcx.hir().as_local_hir_id(id))
+                            .map(|id| tcx.hir().local_def_id_to_hir_id(id))
                             .and_then(|id| tcx.hir().find(id))
                         {
                             Some(hir::Node::Field(field)) => field.ty.span,

--- a/src/librustc_mir/borrow_check/diagnostics/conflict_errors.rs
+++ b/src/librustc_mir/borrow_check/diagnostics/conflict_errors.rs
@@ -263,7 +263,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
             let needs_note = match ty.kind {
                 ty::Closure(id, _) => {
                     let tables = self.infcx.tcx.typeck(id.expect_local());
-                    let hir_id = self.infcx.tcx.hir().as_local_hir_id(id.expect_local());
+                    let hir_id = self.infcx.tcx.hir().local_def_id_to_hir_id(id.expect_local());
 
                     tables.closure_kind_origins().get(hir_id).is_none()
                 }
@@ -954,7 +954,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                 format!("`{}` would have to be valid for `{}`...", name, region_name),
             );
 
-            let fn_hir_id = self.infcx.tcx.hir().as_local_hir_id(self.mir_def_id);
+            let fn_hir_id = self.infcx.tcx.hir().local_def_id_to_hir_id(self.mir_def_id);
             err.span_label(
                 drop_span,
                 format!(
@@ -1863,7 +1863,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
     ) -> Option<AnnotatedBorrowFnSignature<'tcx>> {
         debug!("annotate_fn_sig: did={:?} sig={:?}", did, sig);
         let is_closure = self.infcx.tcx.is_closure(did);
-        let fn_hir_id = self.infcx.tcx.hir().as_local_hir_id(did.as_local()?);
+        let fn_hir_id = self.infcx.tcx.hir().local_def_id_to_hir_id(did.as_local()?);
         let fn_decl = self.infcx.tcx.hir().fn_decl_by_hir_id(fn_hir_id)?;
 
         // We need to work out which arguments to highlight. We do this by looking

--- a/src/librustc_mir/borrow_check/diagnostics/mod.rs
+++ b/src/librustc_mir/borrow_check/diagnostics/mod.rs
@@ -104,7 +104,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                 debug!("add_moved_or_invoked_closure_note: closure={:?}", closure);
                 if let ty::Closure(did, _) = self.body.local_decls[closure].ty.kind {
                     let did = did.expect_local();
-                    let hir_id = self.infcx.tcx.hir().as_local_hir_id(did);
+                    let hir_id = self.infcx.tcx.hir().local_def_id_to_hir_id(did);
 
                     if let Some((span, name)) =
                         self.infcx.tcx.typeck(did).closure_kind_origins().get(hir_id)
@@ -127,7 +127,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
         if let Some(target) = target {
             if let ty::Closure(did, _) = self.body.local_decls[target].ty.kind {
                 let did = did.expect_local();
-                let hir_id = self.infcx.tcx.hir().as_local_hir_id(did);
+                let hir_id = self.infcx.tcx.hir().local_def_id_to_hir_id(did);
 
                 if let Some((span, name)) =
                     self.infcx.tcx.typeck(did).closure_kind_origins().get(hir_id)
@@ -937,7 +937,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
             "closure_span: def_id={:?} target_place={:?} places={:?}",
             def_id, target_place, places
         );
-        let hir_id = self.infcx.tcx.hir().as_local_hir_id(def_id.as_local()?);
+        let hir_id = self.infcx.tcx.hir().local_def_id_to_hir_id(def_id.as_local()?);
         let expr = &self.infcx.tcx.hir().expect_expr(hir_id).kind;
         debug!("closure_span: hir_id={:?} expr={:?}", hir_id, expr);
         if let hir::ExprKind::Closure(.., body_id, args_span, _) = expr {

--- a/src/librustc_mir/borrow_check/diagnostics/mutability_errors.rs
+++ b/src/librustc_mir/borrow_check/diagnostics/mutability_errors.rs
@@ -492,7 +492,7 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
         err.span_label(sp, format!("cannot {}", act));
 
         let hir = self.infcx.tcx.hir();
-        let closure_id = hir.as_local_hir_id(self.mir_def_id);
+        let closure_id = hir.local_def_id_to_hir_id(self.mir_def_id);
         let fn_call_id = hir.get_parent_node(closure_id);
         let node = hir.get(fn_call_id);
         let item_id = hir.enclosing_body_owner(fn_call_id);
@@ -691,7 +691,7 @@ fn annotate_struct_field(
         if let ty::Adt(def, _) = ty.kind {
             let field = def.all_fields().nth(field.index())?;
             // Use the HIR types to construct the diagnostic message.
-            let hir_id = tcx.hir().as_local_hir_id(field.did.as_local()?);
+            let hir_id = tcx.hir().local_def_id_to_hir_id(field.did.as_local()?);
             let node = tcx.hir().find(hir_id)?;
             // Now we're dealing with the actual struct that we're going to suggest a change to,
             // we can expect a field that is an immutable reference to a type.

--- a/src/librustc_mir/borrow_check/diagnostics/region_name.rs
+++ b/src/librustc_mir/borrow_check/diagnostics/region_name.rs
@@ -266,7 +266,7 @@ impl<'tcx> MirBorrowckCtxt<'_, 'tcx> {
                 }
 
                 ty::BoundRegion::BrEnv => {
-                    let mir_hir_id = self.infcx.tcx.hir().as_local_hir_id(self.mir_def_id);
+                    let mir_hir_id = self.infcx.tcx.hir().local_def_id_to_hir_id(self.mir_def_id);
                     let def_ty = self.regioncx.universal_regions().defining_ty;
 
                     if let DefiningTy::Closure(_, substs) = def_ty {
@@ -361,7 +361,7 @@ impl<'tcx> MirBorrowckCtxt<'_, 'tcx> {
         &self,
         argument_index: usize,
     ) -> Option<&hir::Ty<'tcx>> {
-        let mir_hir_id = self.infcx.tcx.hir().as_local_hir_id(self.mir_def_id);
+        let mir_hir_id = self.infcx.tcx.hir().local_def_id_to_hir_id(self.mir_def_id);
         let fn_decl = self.infcx.tcx.hir().fn_decl_by_hir_id(mir_hir_id)?;
         let argument_hir_ty: &hir::Ty<'_> = fn_decl.inputs.get(argument_index)?;
         match argument_hir_ty.kind {
@@ -648,7 +648,7 @@ impl<'tcx> MirBorrowckCtxt<'_, 'tcx> {
         highlight.highlighting_region_vid(fr, *self.next_region_name.try_borrow().unwrap());
         let type_name = self.infcx.extract_type_name(&return_ty, Some(highlight)).0;
 
-        let mir_hir_id = tcx.hir().as_local_hir_id(self.mir_def_id);
+        let mir_hir_id = tcx.hir().local_def_id_to_hir_id(self.mir_def_id);
 
         let (return_span, mir_description) = match tcx.hir().get(mir_hir_id) {
             hir::Node::Expr(hir::Expr {
@@ -700,7 +700,7 @@ impl<'tcx> MirBorrowckCtxt<'_, 'tcx> {
         highlight.highlighting_region_vid(fr, *self.next_region_name.try_borrow().unwrap());
         let type_name = self.infcx.extract_type_name(&yield_ty, Some(highlight)).0;
 
-        let mir_hir_id = tcx.hir().as_local_hir_id(self.mir_def_id);
+        let mir_hir_id = tcx.hir().local_def_id_to_hir_id(self.mir_def_id);
 
         let yield_span = match tcx.hir().get(mir_hir_id) {
             hir::Node::Expr(hir::Expr {

--- a/src/librustc_mir/borrow_check/mod.rs
+++ b/src/librustc_mir/borrow_check/mod.rs
@@ -129,7 +129,7 @@ fn do_mir_borrowck<'a, 'tcx>(
 
     let tcx = infcx.tcx;
     let param_env = tcx.param_env(def.did);
-    let id = tcx.hir().as_local_hir_id(def.did);
+    let id = tcx.hir().local_def_id_to_hir_id(def.did);
 
     let mut local_names = IndexVec::from_elem(None, &input_body.local_decls);
     for var_debug_info in &input_body.var_debug_info {

--- a/src/librustc_mir/borrow_check/universal_regions.rs
+++ b/src/librustc_mir/borrow_check/universal_regions.rs
@@ -231,7 +231,7 @@ impl<'tcx> UniversalRegions<'tcx> {
         param_env: ty::ParamEnv<'tcx>,
     ) -> Self {
         let tcx = infcx.tcx;
-        let mir_hir_id = tcx.hir().as_local_hir_id(mir_def.did);
+        let mir_hir_id = tcx.hir().local_def_id_to_hir_id(mir_def.did);
         UniversalRegionsBuilder { infcx, mir_def, mir_hir_id, param_env }.build()
     }
 

--- a/src/librustc_mir/const_eval/eval_queries.rs
+++ b/src/librustc_mir/const_eval/eval_queries.rs
@@ -347,7 +347,7 @@ pub fn const_eval_raw_provider<'tcx>(
                     // validation thus preventing such a hard error from being a backwards
                     // compatibility hazard
                     DefKind::Const | DefKind::AssocConst => {
-                        let hir_id = tcx.hir().as_local_hir_id(def.did);
+                        let hir_id = tcx.hir().local_def_id_to_hir_id(def.did);
                         err.report_as_lint(
                             tcx.at(tcx.def_span(def.did)),
                             "any use of this value will cause an error",
@@ -370,7 +370,7 @@ pub fn const_eval_raw_provider<'tcx>(
                                 err.report_as_lint(
                                     tcx.at(span),
                                     "reaching this expression at runtime will panic or abort",
-                                    tcx.hir().as_local_hir_id(def.did),
+                                    tcx.hir().local_def_id_to_hir_id(def.did),
                                     Some(err.span),
                                 )
                             }

--- a/src/librustc_mir/const_eval/fn_queries.rs
+++ b/src/librustc_mir/const_eval/fn_queries.rs
@@ -90,7 +90,7 @@ pub fn is_parent_const_impl_raw(tcx: TyCtxt<'_>, hir_id: hir::HirId) -> bool {
 /// Checks whether the function has a `const` modifier or, in case it is an intrinsic, whether
 /// said intrinsic has a `rustc_const_{un,}stable` attribute.
 fn is_const_fn_raw(tcx: TyCtxt<'_>, def_id: DefId) -> bool {
-    let hir_id = tcx.hir().as_local_hir_id(def_id.expect_local());
+    let hir_id = tcx.hir().local_def_id_to_hir_id(def_id.expect_local());
 
     let node = tcx.hir().get(hir_id);
 

--- a/src/librustc_mir/transform/check_consts/validation.rs
+++ b/src/librustc_mir/transform/check_consts/validation.rs
@@ -215,7 +215,7 @@ impl Validator<'mir, 'tcx> {
             && !tcx.is_thread_local_static(def_id.to_def_id());
 
         if should_check_for_sync {
-            let hir_id = tcx.hir().as_local_hir_id(def_id);
+            let hir_id = tcx.hir().local_def_id_to_hir_id(def_id);
             check_return_ty_is_sync(tcx, &body, hir_id);
         }
     }

--- a/src/librustc_mir/transform/check_unsafety.rs
+++ b/src/librustc_mir/transform/check_unsafety.rs
@@ -483,7 +483,7 @@ fn check_unused_unsafe(
     used_unsafe: &FxHashSet<hir::HirId>,
     unsafe_blocks: &mut Vec<(hir::HirId, bool)>,
 ) {
-    let body_id = tcx.hir().maybe_body_owned_by(tcx.hir().as_local_hir_id(def_id));
+    let body_id = tcx.hir().maybe_body_owned_by(tcx.hir().local_def_id_to_hir_id(def_id));
 
     let body_id = match body_id {
         Some(body) => body,
@@ -511,7 +511,7 @@ fn unsafety_check_result<'tcx>(
 
     let param_env = tcx.param_env(def.did);
 
-    let id = tcx.hir().as_local_hir_id(def.did);
+    let id = tcx.hir().local_def_id_to_hir_id(def.did);
     let (const_context, min_const_fn) = match tcx.hir().body_owner_kind(id) {
         hir::BodyOwnerKind::Closure => (false, false),
         hir::BodyOwnerKind::Fn => {
@@ -532,7 +532,7 @@ fn unsafety_check_result<'tcx>(
 }
 
 fn unsafe_derive_on_repr_packed(tcx: TyCtxt<'_>, def_id: LocalDefId) {
-    let lint_hir_id = tcx.hir().as_local_hir_id(def_id);
+    let lint_hir_id = tcx.hir().local_def_id_to_hir_id(def_id);
 
     tcx.struct_span_lint_hir(SAFE_PACKED_BORROWS, lint_hir_id, tcx.def_span(def_id), |lint| {
         // FIXME: when we make this a hard error, this should have its

--- a/src/librustc_mir/transform/const_prop.rs
+++ b/src/librustc_mir/transform/const_prop.rs
@@ -67,7 +67,7 @@ impl<'tcx> MirPass<'tcx> for ConstProp {
         }
 
         use rustc_middle::hir::map::blocks::FnLikeNode;
-        let hir_id = tcx.hir().as_local_hir_id(source.def_id().expect_local());
+        let hir_id = tcx.hir().local_def_id_to_hir_id(source.def_id().expect_local());
 
         let is_fn_like = FnLikeNode::from_node(tcx.hir().get(hir_id)).is_some();
         let is_assoc_const = tcx.def_kind(source.def_id()) == DefKind::AssocConst;

--- a/src/librustc_mir/transform/inline.rs
+++ b/src/librustc_mir/transform/inline.rs
@@ -75,7 +75,7 @@ impl Inliner<'tcx> {
         let param_env = self.tcx.param_env_reveal_all_normalized(self.source.def_id());
 
         // Only do inlining into fn bodies.
-        let id = self.tcx.hir().as_local_hir_id(self.source.def_id().expect_local());
+        let id = self.tcx.hir().local_def_id_to_hir_id(self.source.def_id().expect_local());
         if self.tcx.hir().body_owner_kind(id).is_fn_or_closure() && self.source.promoted.is_none() {
             for (bb, bb_data) in caller_body.basic_blocks().iter_enumerated() {
                 if let Some(callsite) =
@@ -101,9 +101,9 @@ impl Inliner<'tcx> {
                 }
 
                 let callee_body = if let Some(callee_def_id) = callsite.callee.as_local() {
-                    let callee_hir_id = self.tcx.hir().as_local_hir_id(callee_def_id);
+                    let callee_hir_id = self.tcx.hir().local_def_id_to_hir_id(callee_def_id);
                     let self_hir_id =
-                        self.tcx.hir().as_local_hir_id(self.source.def_id().expect_local());
+                        self.tcx.hir().local_def_id_to_hir_id(self.source.def_id().expect_local());
                     // Avoid a cycle here by only using `optimized_mir` only if we have
                     // a lower `HirId` than the callee. This ensures that the callee will
                     // not inline us. This trick only works without incremental compilation.

--- a/src/librustc_mir/transform/qualify_min_const_fn.rs
+++ b/src/librustc_mir/transform/qualify_min_const_fn.rs
@@ -14,7 +14,7 @@ type McfResult = Result<(), (Span, Cow<'static, str>)>;
 pub fn is_min_const_fn(tcx: TyCtxt<'tcx>, def_id: DefId, body: &'a Body<'tcx>) -> McfResult {
     // Prevent const trait methods from being annotated as `stable`.
     if tcx.features().staged_api {
-        let hir_id = tcx.hir().as_local_hir_id(def_id.expect_local());
+        let hir_id = tcx.hir().local_def_id_to_hir_id(def_id.expect_local());
         if crate::const_eval::is_parent_const_impl_raw(tcx, hir_id) {
             return Err((body.span, "trait methods cannot be stable const fn".into()));
         }

--- a/src/librustc_mir_build/build/mod.rs
+++ b/src/librustc_mir_build/build/mod.rs
@@ -35,7 +35,7 @@ crate fn mir_built<'tcx>(
 
 /// Construct the MIR for a given `DefId`.
 fn mir_build(tcx: TyCtxt<'_>, def: ty::WithOptConstParam<LocalDefId>) -> Body<'_> {
-    let id = tcx.hir().as_local_hir_id(def.did);
+    let id = tcx.hir().local_def_id_to_hir_id(def.did);
 
     // Figure out what primary body this item has.
     let (body_id, return_ty_span) = match tcx.hir().get(id) {

--- a/src/librustc_mir_build/lints.rs
+++ b/src/librustc_mir_build/lints.rs
@@ -11,7 +11,7 @@ use rustc_session::lint::builtin::UNCONDITIONAL_RECURSION;
 use rustc_span::Span;
 
 crate fn check<'tcx>(tcx: TyCtxt<'tcx>, body: &Body<'tcx>, def_id: LocalDefId) {
-    let hir_id = tcx.hir().as_local_hir_id(def_id);
+    let hir_id = tcx.hir().local_def_id_to_hir_id(def_id);
 
     if let Some(fn_like_node) = FnLikeNode::from_node(tcx.hir().get(hir_id)) {
         if let FnKind::Closure(_) = fn_like_node.kind() {
@@ -37,7 +37,7 @@ crate fn check<'tcx>(tcx: TyCtxt<'tcx>, body: &Body<'tcx>, def_id: LocalDefId) {
 
         vis.reachable_recursive_calls.sort();
 
-        let hir_id = tcx.hir().as_local_hir_id(def_id);
+        let hir_id = tcx.hir().local_def_id_to_hir_id(def_id);
         let sp = tcx.sess.source_map().guess_head_span(tcx.hir().span(hir_id));
         tcx.struct_span_lint_hir(UNCONDITIONAL_RECURSION, hir_id, sp, |lint| {
             let mut db = lint.build("function cannot return without recursing");

--- a/src/librustc_mir_build/thir/cx/expr.rs
+++ b/src/librustc_mir_build/thir/cx/expr.rs
@@ -781,7 +781,7 @@ fn convert_path_expr<'a, 'tcx>(
         }
 
         Res::Def(DefKind::ConstParam, def_id) => {
-            let hir_id = cx.tcx.hir().as_local_hir_id(def_id.expect_local());
+            let hir_id = cx.tcx.hir().local_def_id_to_hir_id(def_id.expect_local());
             let item_id = cx.tcx.hir().get_parent_node(hir_id);
             let item_def_id = cx.tcx.hir().local_def_id(item_id);
             let generics = cx.tcx.generics_of(item_def_id);

--- a/src/librustc_mir_build/thir/pattern/check_match.rs
+++ b/src/librustc_mir_build/thir/pattern/check_match.rs
@@ -23,7 +23,7 @@ use std::slice;
 crate fn check_match(tcx: TyCtxt<'_>, def_id: DefId) {
     let body_id = match def_id.as_local() {
         None => return,
-        Some(id) => tcx.hir().body_owned_by(tcx.hir().as_local_hir_id(id)),
+        Some(id) => tcx.hir().body_owned_by(tcx.hir().local_def_id_to_hir_id(id)),
     };
 
     let mut visitor = MatchVisitor {

--- a/src/librustc_passes/dead.rs
+++ b/src/librustc_passes/dead.rs
@@ -62,7 +62,7 @@ impl<'tcx> MarkSymbolVisitor<'tcx> {
 
     fn check_def_id(&mut self, def_id: DefId) {
         if let Some(def_id) = def_id.as_local() {
-            let hir_id = self.tcx.hir().as_local_hir_id(def_id);
+            let hir_id = self.tcx.hir().local_def_id_to_hir_id(def_id);
             if should_explore(self.tcx, hir_id) || self.struct_constructors.contains_key(&hir_id) {
                 self.worklist.push(hir_id);
             }
@@ -72,7 +72,7 @@ impl<'tcx> MarkSymbolVisitor<'tcx> {
 
     fn insert_def_id(&mut self, def_id: DefId) {
         if let Some(def_id) = def_id.as_local() {
-            let hir_id = self.tcx.hir().as_local_hir_id(def_id);
+            let hir_id = self.tcx.hir().local_def_id_to_hir_id(def_id);
             debug_assert!(!should_explore(self.tcx, hir_id));
             self.live_symbols.insert(hir_id);
         }
@@ -461,7 +461,7 @@ fn create_and_seed_worklist<'tcx>(
         )
         .chain(
             // Seed entry point
-            tcx.entry_fn(LOCAL_CRATE).map(|(def_id, _)| tcx.hir().as_local_hir_id(def_id)),
+            tcx.entry_fn(LOCAL_CRATE).map(|(def_id, _)| tcx.hir().local_def_id_to_hir_id(def_id)),
         )
         .collect::<Vec<_>>();
 
@@ -546,7 +546,7 @@ impl DeadVisitor<'tcx> {
         for &impl_did in inherent_impls.iter() {
             for &item_did in &self.tcx.associated_item_def_ids(impl_did)[..] {
                 if let Some(did) = item_did.as_local() {
-                    let item_hir_id = self.tcx.hir().as_local_hir_id(did);
+                    let item_hir_id = self.tcx.hir().local_def_id_to_hir_id(did);
                     if self.live_symbols.contains(&item_hir_id) {
                         return true;
                     }

--- a/src/librustc_passes/region.rs
+++ b/src/librustc_passes/region.rs
@@ -807,7 +807,7 @@ fn region_scope_tree(tcx: TyCtxt<'_>, def_id: DefId) -> &ScopeTree {
         return tcx.region_scope_tree(closure_base_def_id);
     }
 
-    let id = tcx.hir().as_local_hir_id(def_id.expect_local());
+    let id = tcx.hir().local_def_id_to_hir_id(def_id.expect_local());
     let scope_tree = if let Some(body_id) = tcx.hir().maybe_body_owned_by(id) {
         let mut visitor = RegionResolutionVisitor {
             tcx,

--- a/src/librustc_passes/upvars.rs
+++ b/src/librustc_passes/upvars.rs
@@ -15,7 +15,7 @@ pub fn provide(providers: &mut Providers) {
             return None;
         }
 
-        let hir_id = tcx.hir().as_local_hir_id(def_id.expect_local());
+        let hir_id = tcx.hir().local_def_id_to_hir_id(def_id.expect_local());
         let body = tcx.hir().body(tcx.hir().maybe_body_owned_by(hir_id)?);
 
         let mut local_collector = LocalCollector::default();

--- a/src/librustc_resolve/late/diagnostics.rs
+++ b/src/librustc_resolve/late/diagnostics.rs
@@ -1349,7 +1349,13 @@ impl<'tcx> LifetimeContext<'_, 'tcx> {
                 suggest_new(err, "'a");
             }
             (0, _, Some(snippet)) if !snippet.ends_with('>') && count == 1 => {
-                suggest_new(err, &format!("{}<'a>", snippet));
+                if snippet == "" {
+                    // This happens when we have `type Bar<'a> = Foo<T>` where we point at the space
+                    // before `T`. We will suggest `type Bar<'a> = Foo<'a, T>`.
+                    suggest_new(err, "'a, ");
+                } else {
+                    suggest_new(err, &format!("{}<'a>", snippet));
+                }
             }
             (n, ..) if n > 1 => {
                 let spans: Vec<Span> = lifetime_names.iter().map(|lt| lt.span).collect();

--- a/src/librustc_resolve/late/diagnostics.rs
+++ b/src/librustc_resolve/late/diagnostics.rs
@@ -16,7 +16,7 @@ use rustc_hir::def_id::{DefId, CRATE_DEF_INDEX, LOCAL_CRATE};
 use rustc_hir::PrimTy;
 use rustc_session::config::nightly_options;
 use rustc_span::hygiene::MacroKind;
-use rustc_span::symbol::{kw, sym, Ident};
+use rustc_span::symbol::{kw, sym, Ident, Symbol};
 use rustc_span::{BytePos, Span, DUMMY_SP};
 
 use log::debug;
@@ -1244,7 +1244,8 @@ impl<'tcx> LifetimeContext<'_, 'tcx> {
         err: &mut DiagnosticBuilder<'_>,
         span: Span,
         count: usize,
-        lifetime_names: &FxHashSet<Ident>,
+        lifetime_names: &FxHashSet<Symbol>,
+        lifetime_spans: Vec<Span>,
         params: &[ElisionFailureInfo],
     ) {
         let snippet = self.tcx.sess.source_map().span_to_snippet(span).ok();
@@ -1258,11 +1259,60 @@ impl<'tcx> LifetimeContext<'_, 'tcx> {
             ),
         );
 
-        let suggest_existing = |err: &mut DiagnosticBuilder<'_>, sugg| {
+        let suggest_existing = |err: &mut DiagnosticBuilder<'_>,
+                                name: &str,
+                                formatter: &dyn Fn(&str) -> String| {
+            if let Some(MissingLifetimeSpot::HigherRanked { span: for_span, span_type }) =
+                self.missing_named_lifetime_spots.iter().rev().next()
+            {
+                // When we have `struct S<'a>(&'a dyn Fn(&X) -> &X);` we want to not only suggest
+                // using `'a`, but also introduce the concept of HRLTs by suggesting
+                // `struct S<'a>(&'a dyn for<'b> Fn(&X) -> &'b X);`. (#72404)
+                let mut introduce_suggestion = vec![];
+
+                let a_to_z_repeat_n = |n| {
+                    (b'a'..=b'z').map(move |c| {
+                        let mut s = '\''.to_string();
+                        s.extend(std::iter::repeat(char::from(c)).take(n));
+                        s
+                    })
+                };
+
+                // If all single char lifetime names are present, we wrap around and double the chars.
+                let lt_name = (1..)
+                    .flat_map(a_to_z_repeat_n)
+                    .find(|lt| !lifetime_names.contains(&Symbol::intern(&lt)))
+                    .unwrap();
+                let msg = format!(
+                    "consider making the {} lifetime-generic with a new `{}` lifetime",
+                    span_type.descr(),
+                    lt_name,
+                );
+                err.note(
+                    "for more information on higher-ranked polymorphism, visit \
+                    https://doc.rust-lang.org/nomicon/hrtb.html",
+                );
+                let for_sugg = span_type.suggestion(&lt_name);
+                for param in params {
+                    if let Ok(snippet) = self.tcx.sess.source_map().span_to_snippet(param.span) {
+                        if snippet.starts_with('&') && !snippet.starts_with("&'") {
+                            introduce_suggestion
+                                .push((param.span, format!("&{} {}", lt_name, &snippet[1..])));
+                        } else if snippet.starts_with("&'_ ") {
+                            introduce_suggestion
+                                .push((param.span, format!("&{} {}", lt_name, &snippet[4..])));
+                        }
+                    }
+                }
+                introduce_suggestion.push((*for_span, for_sugg.to_string()));
+                introduce_suggestion.push((span, formatter(&lt_name)));
+                err.multipart_suggestion(&msg, introduce_suggestion, Applicability::MaybeIncorrect);
+            }
+
             err.span_suggestion_verbose(
                 span,
                 &format!("consider using the `{}` lifetime", lifetime_names.iter().next().unwrap()),
-                sugg,
+                formatter(name),
                 Applicability::MaybeIncorrect,
             );
         };
@@ -1330,17 +1380,16 @@ impl<'tcx> LifetimeContext<'_, 'tcx> {
 
         match (lifetime_names.len(), lifetime_names.iter().next(), snippet.as_deref()) {
             (1, Some(name), Some("&")) => {
-                suggest_existing(err, format!("&{} ", name));
+                suggest_existing(err, &name.as_str()[..], &|name| format!("&{} ", name));
             }
             (1, Some(name), Some("'_")) => {
-                suggest_existing(err, name.to_string());
+                suggest_existing(err, &name.as_str()[..], &|n| n.to_string());
             }
             (1, Some(name), Some("")) => {
-                suggest_existing(err, format!("{}, ", name).repeat(count));
+                suggest_existing(err, &name.as_str()[..], &|n| format!("{}, ", n).repeat(count));
             }
             (1, Some(name), Some(snippet)) if !snippet.ends_with('>') => {
-                suggest_existing(
-                    err,
+                let f = |name: &str| {
                     format!(
                         "{}<{}>",
                         snippet,
@@ -1348,8 +1397,9 @@ impl<'tcx> LifetimeContext<'_, 'tcx> {
                             .take(count)
                             .collect::<Vec<_>>()
                             .join(", ")
-                    ),
-                );
+                    )
+                };
+                suggest_existing(err, &name.as_str()[..], &f);
             }
             (0, _, Some("&")) if count == 1 => {
                 suggest_new(err, "&'a ");
@@ -1367,8 +1417,7 @@ impl<'tcx> LifetimeContext<'_, 'tcx> {
                 }
             }
             (n, ..) if n > 1 => {
-                let spans: Vec<Span> = lifetime_names.iter().map(|lt| lt.span).collect();
-                err.span_note(spans, "these named lifetimes are available to use");
+                err.span_note(lifetime_spans, "these named lifetimes are available to use");
                 if Some("") == snippet.as_deref() {
                     // This happens when we have `Foo<T>` where we point at the space before `T`,
                     // but this can be confusing so we give a suggestion with placeholders.

--- a/src/librustc_resolve/late/lifetimes.rs
+++ b/src/librustc_resolve/late/lifetimes.rs
@@ -607,7 +607,7 @@ impl<'a, 'tcx> Visitor<'tcx> for LifetimeContext<'a, 'tcx> {
                         let def = self.map.defs.get(&lifetime.hir_id).cloned();
                         if let Some(Region::LateBound(_, def_id, _)) = def {
                             if let Some(def_id) = def_id.as_local() {
-                                let hir_id = self.tcx.hir().as_local_hir_id(def_id);
+                                let hir_id = self.tcx.hir().local_def_id_to_hir_id(def_id);
                                 // Ensure that the parent of the def is an item, not HRTB
                                 let parent_id = self.tcx.hir().get_parent_node(hir_id);
                                 let parent_impl_id = hir::ImplItemId { hir_id: parent_id };
@@ -1146,7 +1146,8 @@ fn extract_labels(ctxt: &mut LifetimeContext<'_, '_>, body: &hir::Body<'_>) {
                     if let Some(def) =
                         lifetimes.get(&hir::ParamName::Plain(label.normalize_to_macros_2_0()))
                     {
-                        let hir_id = tcx.hir().as_local_hir_id(def.id().unwrap().expect_local());
+                        let hir_id =
+                            tcx.hir().local_def_id_to_hir_id(def.id().unwrap().expect_local());
 
                         signal_shadowing_problem(
                             tcx,
@@ -1517,7 +1518,7 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
 
             match lifetimeuseset {
                 Some(LifetimeUseSet::One(lifetime)) => {
-                    let hir_id = self.tcx.hir().as_local_hir_id(def_id.expect_local());
+                    let hir_id = self.tcx.hir().local_def_id_to_hir_id(def_id.expect_local());
                     debug!("hir id first={:?}", hir_id);
                     if let Some((id, span, name)) = match self.tcx.hir().get(hir_id) {
                         Node::Lifetime(hir_lifetime) => Some((
@@ -1537,7 +1538,7 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
 
                         if let Some(parent_def_id) = self.tcx.parent(def_id) {
                             if let Some(def_id) = parent_def_id.as_local() {
-                                let parent_hir_id = self.tcx.hir().as_local_hir_id(def_id);
+                                let parent_hir_id = self.tcx.hir().local_def_id_to_hir_id(def_id);
                                 // lifetimes in `derive` expansions don't count (Issue #53738)
                                 if self.tcx.hir().attrs(parent_hir_id).iter().any(|attr| {
                                     self.tcx.sess.check_name(attr, sym::automatically_derived)
@@ -1575,7 +1576,7 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
                     debug!("not one use lifetime");
                 }
                 None => {
-                    let hir_id = self.tcx.hir().as_local_hir_id(def_id.expect_local());
+                    let hir_id = self.tcx.hir().local_def_id_to_hir_id(def_id.expect_local());
                     if let Some((id, span, name)) = match self.tcx.hir().get(hir_id) {
                         Node::Lifetime(hir_lifetime) => Some((
                             hir_lifetime.hir_id,
@@ -1931,7 +1932,7 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
 
             let map = &self.map;
             let unsubst = if let Some(def_id) = def_id.as_local() {
-                let id = self.tcx.hir().as_local_hir_id(def_id);
+                let id = self.tcx.hir().local_def_id_to_hir_id(def_id);
                 &map.object_lifetime_defaults[&id]
             } else {
                 let tcx = self.tcx;
@@ -2614,7 +2615,7 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
                 Scope::Binder { ref lifetimes, s, .. } => {
                     if let Some(&def) = lifetimes.get(&param.name.normalize_to_macros_2_0()) {
                         let hir_id =
-                            self.tcx.hir().as_local_hir_id(def.id().unwrap().expect_local());
+                            self.tcx.hir().local_def_id_to_hir_id(def.id().unwrap().expect_local());
 
                         signal_shadowing_problem(
                             self.tcx,

--- a/src/librustc_serialize/collection_impls.rs
+++ b/src/librustc_serialize/collection_impls.rs
@@ -86,11 +86,9 @@ where
 {
     fn encode<S: Encoder>(&self, e: &mut S) -> Result<(), S::Error> {
         e.emit_map(self.len(), |e| {
-            let mut i = 0;
-            for (key, val) in self {
+            for (i, (key, val)) in self.iter().enumerate() {
                 e.emit_map_elt_key(i, |e| key.encode(e))?;
                 e.emit_map_elt_val(i, |e| val.encode(e))?;
-                i += 1;
             }
             Ok(())
         })
@@ -121,10 +119,8 @@ where
 {
     fn encode<S: Encoder>(&self, s: &mut S) -> Result<(), S::Error> {
         s.emit_seq(self.len(), |s| {
-            let mut i = 0;
-            for e in self {
+            for (i, e) in self.iter().enumerate() {
                 s.emit_seq_elt(i, |s| e.encode(s))?;
-                i += 1;
             }
             Ok(())
         })
@@ -154,11 +150,9 @@ where
 {
     fn encode<E: Encoder>(&self, e: &mut E) -> Result<(), E::Error> {
         e.emit_map(self.len(), |e| {
-            let mut i = 0;
-            for (key, val) in self {
+            for (i, (key, val)) in self.iter().enumerate() {
                 e.emit_map_elt_key(i, |e| key.encode(e))?;
                 e.emit_map_elt_val(i, |e| val.encode(e))?;
-                i += 1;
             }
             Ok(())
         })
@@ -192,10 +186,8 @@ where
 {
     fn encode<E: Encoder>(&self, s: &mut E) -> Result<(), E::Error> {
         s.emit_seq(self.len(), |s| {
-            let mut i = 0;
-            for e in self {
+            for (i, e) in self.iter().enumerate() {
                 s.emit_seq_elt(i, |s| e.encode(s))?;
-                i += 1;
             }
             Ok(())
         })
@@ -227,11 +219,9 @@ where
 {
     fn encode<E: Encoder>(&self, e: &mut E) -> Result<(), E::Error> {
         e.emit_map(self.len(), |e| {
-            let mut i = 0;
-            for (key, val) in self {
+            for (i, (key, val)) in self.iter().enumerate() {
                 e.emit_map_elt_key(i, |e| key.encode(e))?;
                 e.emit_map_elt_val(i, |e| val.encode(e))?;
-                i += 1;
             }
             Ok(())
         })
@@ -265,10 +255,8 @@ where
 {
     fn encode<E: Encoder>(&self, s: &mut E) -> Result<(), E::Error> {
         s.emit_seq(self.len(), |s| {
-            let mut i = 0;
-            for e in self {
+            for (i, e) in self.iter().enumerate() {
                 s.emit_seq_elt(i, |s| e.encode(s))?;
-                i += 1;
             }
             Ok(())
         })

--- a/src/librustc_serialize/json.rs
+++ b/src/librustc_serialize/json.rs
@@ -78,19 +78,17 @@
 //!     data_vector: Vec<u8>,
 //! }
 //!
-//! fn main() {
-//!     let object = TestStruct {
-//!         data_int: 1,
-//!         data_str: "homura".to_string(),
-//!         data_vector: vec![2,3,4,5],
-//!     };
+//! let object = TestStruct {
+//!     data_int: 1,
+//!     data_str: "homura".to_string(),
+//!     data_vector: vec![2,3,4,5],
+//! };
 //!
-//!     // Serialize using `json::encode`
-//!     let encoded = json::encode(&object).unwrap();
+//! // Serialize using `json::encode`
+//! let encoded = json::encode(&object).unwrap();
 //!
-//!     // Deserialize using `json::decode`
-//!     let decoded: TestStruct = json::decode(&encoded[..]).unwrap();
-//! }
+//! // Deserialize using `json::decode`
+//! let decoded: TestStruct = json::decode(&encoded[..]).unwrap();
 //! ```
 //!
 //! ## Using the `ToJson` trait
@@ -125,16 +123,14 @@
 //!     val: Json,
 //! }
 //!
-//! fn main() {
-//!     let num = ComplexNum { a: 0.0001, b: 12.539 };
-//!     let data: String = json::encode(&ComplexNumRecord{
-//!         uid: 1,
-//!         dsc: "test".to_string(),
-//!         val: num.to_json(),
-//!     }).unwrap();
-//!     println!("data: {}", data);
-//!     // data: {"uid":1,"dsc":"test","val":"0.0001+12.539i"};
-//! }
+//! let num = ComplexNum { a: 0.0001, b: 12.539 };
+//! let data: String = json::encode(&ComplexNumRecord{
+//!     uid: 1,
+//!     dsc: "test".to_string(),
+//!     val: num.to_json(),
+//! }).unwrap();
+//! println!("data: {}", data);
+//! // data: {"uid":1,"dsc":"test","val":"0.0001+12.539i"};
 //! ```
 //!
 //! ### Verbose example of `ToJson` usage
@@ -164,19 +160,17 @@
 //!     }
 //! }
 //!
-//! fn main() {
-//!     // Serialize using `ToJson`
-//!     let input_data = TestStruct {
-//!         data_int: 1,
-//!         data_str: "madoka".to_string(),
-//!         data_vector: vec![2,3,4,5],
-//!     };
-//!     let json_obj: Json = input_data.to_json();
-//!     let json_str: String = json_obj.to_string();
+//! // Serialize using `ToJson`
+//! let input_data = TestStruct {
+//!     data_int: 1,
+//!     data_str: "madoka".to_string(),
+//!     data_vector: vec![2,3,4,5],
+//! };
+//! let json_obj: Json = input_data.to_json();
+//! let json_str: String = json_obj.to_string();
 //!
-//!     // Deserialize like before
-//!     let decoded: TestStruct = json::decode(&json_str).unwrap();
-//! }
+//! // Deserialize like before
+//! let decoded: TestStruct = json::decode(&json_str).unwrap();
 //! ```
 
 use self::DecoderError::*;
@@ -1269,34 +1263,22 @@ impl Json {
 
     /// Returns `true` if the Json value is a `Number`.
     pub fn is_number(&self) -> bool {
-        match *self {
-            Json::I64(_) | Json::U64(_) | Json::F64(_) => true,
-            _ => false,
-        }
+        matches!(*self, Json::I64(_) | Json::U64(_) | Json::F64(_))
     }
 
     /// Returns `true` if the Json value is a `i64`.
     pub fn is_i64(&self) -> bool {
-        match *self {
-            Json::I64(_) => true,
-            _ => false,
-        }
+        matches!(*self, Json::I64(_))
     }
 
     /// Returns `true` if the Json value is a `u64`.
     pub fn is_u64(&self) -> bool {
-        match *self {
-            Json::U64(_) => true,
-            _ => false,
-        }
+        matches!(*self, Json::U64(_))
     }
 
     /// Returns `true` if the Json value is a `f64`.
     pub fn is_f64(&self) -> bool {
-        match *self {
-            Json::F64(_) => true,
-            _ => false,
-        }
+        matches!(*self, Json::F64(_))
     }
 
     /// If the Json value is a number, returns or cast it to a `i64`;
@@ -1416,6 +1398,7 @@ enum ParserState {
 /// structure of the JSON stream.
 ///
 /// An example is `foo.bar[3].x`.
+#[derive(Default)]
 pub struct Stack {
     stack: Vec<InternalStackElement>,
     str_buffer: Vec<u8>,
@@ -1442,7 +1425,7 @@ enum InternalStackElement {
 
 impl Stack {
     pub fn new() -> Stack {
-        Stack { stack: Vec::new(), str_buffer: Vec::new() }
+        Self::default()
     }
 
     /// Returns The number of elements in the Stack.
@@ -1547,10 +1530,7 @@ impl Stack {
 
     // Used by Parser to test whether the top-most element is an index.
     fn last_is_index(&self) -> bool {
-        match self.stack.last() {
-            Some(InternalIndex(_)) => true,
-            _ => false,
-        }
+        matches!(self.stack.last(), Some(InternalIndex(_)))
     }
 
     // Used by Parser to increment the index of the top-most element.

--- a/src/librustc_serialize/opaque.rs
+++ b/src/librustc_serialize/opaque.rs
@@ -118,13 +118,13 @@ impl serialize::Encoder for Encoder {
 
     #[inline]
     fn emit_f64(&mut self, v: f64) -> EncodeResult {
-        let as_u64: u64 = unsafe { ::std::mem::transmute(v) };
+        let as_u64: u64 = v.to_bits();
         self.emit_u64(as_u64)
     }
 
     #[inline]
     fn emit_f32(&mut self, v: f32) -> EncodeResult {
-        let as_u32: u32 = unsafe { ::std::mem::transmute(v) };
+        let as_u32: u32 = v.to_bits();
         self.emit_u32(as_u32)
     }
 

--- a/src/librustc_symbol_mangling/lib.rs
+++ b/src/librustc_symbol_mangling/lib.rs
@@ -173,7 +173,7 @@ fn compute_symbol_name(
             let disambiguator = tcx.sess.local_crate_disambiguator();
             return tcx.sess.generate_proc_macro_decls_symbol(disambiguator);
         }
-        let hir_id = tcx.hir().as_local_hir_id(def_id);
+        let hir_id = tcx.hir().local_def_id_to_hir_id(def_id);
         match tcx.hir().get(hir_id) {
             Node::ForeignItem(_) => true,
             _ => false,

--- a/src/librustc_trait_selection/opaque_types.rs
+++ b/src/librustc_trait_selection/opaque_types.rs
@@ -1039,7 +1039,7 @@ impl<'a, 'tcx> Instantiator<'a, 'tcx> {
                     // }
                     // ```
                     if let Some(def_id) = def_id.as_local() {
-                        let opaque_hir_id = tcx.hir().as_local_hir_id(def_id);
+                        let opaque_hir_id = tcx.hir().local_def_id_to_hir_id(def_id);
                         let parent_def_id = self.parent_def_id;
                         let def_scope_default = || {
                             let opaque_parent_hir_id = tcx.hir().get_parent_item(opaque_hir_id);
@@ -1205,7 +1205,7 @@ pub fn may_define_opaque_type(
     def_id: LocalDefId,
     opaque_hir_id: hir::HirId,
 ) -> bool {
-    let mut hir_id = tcx.hir().as_local_hir_id(def_id);
+    let mut hir_id = tcx.hir().local_def_id_to_hir_id(def_id);
 
     // Named opaque types can be defined by any siblings or children of siblings.
     let scope = tcx.hir().get_defining_scope(opaque_hir_id);

--- a/src/librustc_trait_selection/traits/chalk_fulfill.rs
+++ b/src/librustc_trait_selection/traits/chalk_fulfill.rs
@@ -41,7 +41,7 @@ fn environment<'tcx>(
 
     let clauses = predicates.into_iter().map(ChalkEnvironmentClause::Predicate);
 
-    let hir_id = tcx.hir().as_local_hir_id(def_id.expect_local());
+    let hir_id = tcx.hir().local_def_id_to_hir_id(def_id.expect_local());
     let node = tcx.hir().get(hir_id);
 
     enum NodeKind {

--- a/src/librustc_trait_selection/traits/error_reporting/mod.rs
+++ b/src/librustc_trait_selection/traits/error_reporting/mod.rs
@@ -568,7 +568,8 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                             self.tcx.sess.source_map().guess_head_span(
                                 self.tcx.hir().span_if_local(closure_def_id).unwrap(),
                             );
-                        let hir_id = self.tcx.hir().as_local_hir_id(closure_def_id.expect_local());
+                        let hir_id =
+                            self.tcx.hir().local_def_id_to_hir_id(closure_def_id.expect_local());
                         let mut err = struct_span_err!(
                             self.tcx.sess,
                             closure_span,

--- a/src/librustc_trait_selection/traits/error_reporting/suggestions.rs
+++ b/src/librustc_trait_selection/traits/error_reporting/suggestions.rs
@@ -535,7 +535,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
             };
 
         let hir = self.tcx.hir();
-        let hir_id = hir.as_local_hir_id(def_id.as_local()?);
+        let hir_id = hir.local_def_id_to_hir_id(def_id.as_local()?);
         let parent_node = hir.get_parent_node(hir_id);
         match hir.find(parent_node) {
             Some(hir::Node::Stmt(hir::Stmt { kind: hir::StmtKind::Local(local), .. })) => {
@@ -1383,7 +1383,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
 
         let generator_body = generator_did
             .as_local()
-            .map(|def_id| hir.as_local_hir_id(def_id))
+            .map(|def_id| hir.local_def_id_to_hir_id(def_id))
             .and_then(|hir_id| hir.maybe_body_owned_by(hir_id))
             .map(|body_id| hir.body(body_id));
         let mut visitor = AwaitsVisitor::default();
@@ -1535,7 +1535,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                             .tcx
                             .parent(generator_did)
                             .and_then(|parent_did| parent_did.as_local())
-                            .map(|parent_did| hir.as_local_hir_id(parent_did))
+                            .map(|parent_did| hir.local_def_id_to_hir_id(parent_did))
                             .and_then(|parent_hir_id| hir.opt_name(parent_hir_id))
                             .map(|name| {
                                 format!("future returned by `{}` is not {}", name, trait_name)

--- a/src/librustc_trait_selection/traits/specialize/mod.rs
+++ b/src/librustc_trait_selection/traits/specialize/mod.rs
@@ -451,7 +451,7 @@ fn report_conflicting_impls(
             };
             tcx.struct_span_lint_hir(
                 lint,
-                tcx.hir().as_local_hir_id(impl_def_id),
+                tcx.hir().local_def_id_to_hir_id(impl_def_id),
                 impl_span,
                 decorate,
             )

--- a/src/librustc_ty/ty.rs
+++ b/src/librustc_ty/ty.rs
@@ -126,7 +126,7 @@ fn associated_item_from_impl_item_ref(
 }
 
 fn associated_item(tcx: TyCtxt<'_>, def_id: DefId) -> ty::AssocItem {
-    let id = tcx.hir().as_local_hir_id(def_id.expect_local());
+    let id = tcx.hir().local_def_id_to_hir_id(def_id.expect_local());
     let parent_id = tcx.hir().get_parent_item(id);
     let parent_def_id = tcx.hir().local_def_id(parent_id);
     let parent_item = tcx.hir().expect_item(parent_id);
@@ -164,7 +164,7 @@ fn associated_item(tcx: TyCtxt<'_>, def_id: DefId) -> ty::AssocItem {
 }
 
 fn impl_defaultness(tcx: TyCtxt<'_>, def_id: DefId) -> hir::Defaultness {
-    let hir_id = tcx.hir().as_local_hir_id(def_id.expect_local());
+    let hir_id = tcx.hir().local_def_id_to_hir_id(def_id.expect_local());
     let item = tcx.hir().expect_item(hir_id);
     if let hir::ItemKind::Impl { defaultness, .. } = item.kind {
         defaultness
@@ -198,7 +198,7 @@ fn adt_sized_constraint(tcx: TyCtxt<'_>, def_id: DefId) -> ty::AdtSizedConstrain
 }
 
 fn associated_item_def_ids(tcx: TyCtxt<'_>, def_id: DefId) -> &[DefId] {
-    let id = tcx.hir().as_local_hir_id(def_id.expect_local());
+    let id = tcx.hir().local_def_id_to_hir_id(def_id.expect_local());
     let item = tcx.hir().expect_item(id);
     match item.kind {
         hir::ItemKind::Trait(.., ref trait_item_refs) => tcx.arena.alloc_from_iter(
@@ -268,7 +268,7 @@ fn param_env(tcx: TyCtxt<'_>, def_id: DefId) -> ty::ParamEnv<'_> {
 
     let body_id = def_id
         .as_local()
-        .map(|def_id| tcx.hir().as_local_hir_id(def_id))
+        .map(|def_id| tcx.hir().local_def_id_to_hir_id(def_id))
         .map_or(hir::CRATE_HIR_ID, |id| {
             tcx.hir().maybe_body_owned_by(id).map_or(id, |body| body.hir_id)
         });
@@ -360,7 +360,7 @@ fn issue33140_self_ty(tcx: TyCtxt<'_>, def_id: DefId) -> Option<Ty<'_>> {
 
 /// Check if a function is async.
 fn asyncness(tcx: TyCtxt<'_>, def_id: DefId) -> hir::IsAsync {
-    let hir_id = tcx.hir().as_local_hir_id(def_id.expect_local());
+    let hir_id = tcx.hir().local_def_id_to_hir_id(def_id.expect_local());
 
     let node = tcx.hir().get(hir_id);
 

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -170,7 +170,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
         def: Option<&ty::GenericParamDef>,
     ) -> ty::Region<'tcx> {
         let tcx = self.tcx();
-        let lifetime_name = |def_id| tcx.hir().name(tcx.hir().as_local_hir_id(def_id));
+        let lifetime_name = |def_id| tcx.hir().name(tcx.hir().local_def_id_to_hir_id(def_id));
 
         let r = match tcx.named_region(lifetime.hir_id) {
             Some(rl::Region::Static) => tcx.lifetimes.re_static,
@@ -2099,7 +2099,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
 
         debug!("find_bound_for_assoc_item: predicates={:#?}", predicates);
 
-        let param_hir_id = tcx.hir().as_local_hir_id(ty_param_def_id);
+        let param_hir_id = tcx.hir().local_def_id_to_hir_id(ty_param_def_id);
         let param_name = tcx.hir().ty_param_name(param_hir_id);
         self.one_bound_for_assoc_type(
             || {
@@ -2483,7 +2483,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
 
             let parent_def_id = def_id
                 .and_then(|def_id| {
-                    def_id.as_local().map(|def_id| tcx.hir().as_local_hir_id(def_id))
+                    def_id.as_local().map(|def_id| tcx.hir().local_def_id_to_hir_id(def_id))
                 })
                 .map(|hir_id| tcx.hir().get_parent_did(hir_id).to_def_id());
 
@@ -2819,7 +2819,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                 assert_eq!(opt_self_ty, None);
                 self.prohibit_generics(path.segments);
 
-                let hir_id = tcx.hir().as_local_hir_id(def_id.expect_local());
+                let hir_id = tcx.hir().local_def_id_to_hir_id(def_id.expect_local());
                 let item_id = tcx.hir().get_parent_node(hir_id);
                 let item_def_id = tcx.hir().local_def_id(item_id);
                 let generics = tcx.generics_of(item_def_id);

--- a/src/librustc_typeck/check/coercion.rs
+++ b/src/librustc_typeck/check/coercion.rs
@@ -1502,7 +1502,7 @@ impl<'tcx, 'exprs, E: AsCoercionSite> CoerceMany<'tcx, 'exprs, E> {
                 let ty = AstConv::ast_ty_to_ty(fcx, ty);
                 // Get the `impl Trait`'s `DefId`.
                 if let ty::Opaque(def_id, _) = ty.kind {
-                    let hir_id = fcx.tcx.hir().as_local_hir_id(def_id.expect_local());
+                    let hir_id = fcx.tcx.hir().local_def_id_to_hir_id(def_id.expect_local());
                     // Get the `impl Trait`'s `Item` so that we can get its trait bounds and
                     // get the `Trait`'s `DefId`.
                     if let hir::ItemKind::OpaqueTy(hir::OpaqueTy { bounds, .. }) =

--- a/src/librustc_typeck/check/dropck.rs
+++ b/src/librustc_typeck/check/dropck.rs
@@ -70,7 +70,7 @@ fn ensure_drop_params_and_item_params_correspond<'tcx>(
     drop_impl_ty: Ty<'tcx>,
     self_type_did: DefId,
 ) -> Result<(), ErrorReported> {
-    let drop_impl_hir_id = tcx.hir().as_local_hir_id(drop_impl_did);
+    let drop_impl_hir_id = tcx.hir().local_def_id_to_hir_id(drop_impl_did);
 
     // check that the impl type can be made to match the trait type.
 
@@ -183,7 +183,7 @@ fn ensure_drop_predicates_are_implied_by_item_defn<'tcx>(
     // absent. So we report an error that the Drop impl injected a
     // predicate that is not present on the struct definition.
 
-    let self_type_hir_id = tcx.hir().as_local_hir_id(self_type_did);
+    let self_type_hir_id = tcx.hir().local_def_id_to_hir_id(self_type_did);
 
     // We can assume the predicates attached to struct/enum definition
     // hold.

--- a/src/librustc_typeck/check/expr.rs
+++ b/src/librustc_typeck/check/expr.rs
@@ -1606,7 +1606,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         }
         let param_def_id = generic_param.def_id;
         let param_hir_id = match param_def_id.as_local() {
-            Some(x) => self.tcx.hir().as_local_hir_id(x),
+            Some(x) => self.tcx.hir().local_def_id_to_hir_id(x),
             None => return,
         };
         let param_span = self.tcx.hir().span(param_hir_id);

--- a/src/librustc_typeck/check/method/probe.rs
+++ b/src/librustc_typeck/check/method/probe.rs
@@ -649,6 +649,10 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
                     self.assemble_inherent_impl_for_primitive(lang_def_id);
                 }
             }
+            ty::Array(_, _) => {
+                let lang_def_id = lang_items.array_impl();
+                self.assemble_inherent_impl_for_primitive(lang_def_id);
+            }
             ty::RawPtr(ty::TypeAndMut { ty: _, mutbl }) => {
                 let (lang_def_id1, lang_def_id2) = match mutbl {
                     hir::Mutability::Not => {

--- a/src/librustc_typeck/check/method/suggest.rs
+++ b/src/librustc_typeck/check/method/suggest.rs
@@ -579,7 +579,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             {
                                 if let ty::Adt(def, _) = p.trait_ref.self_ty().kind {
                                     let node = def.did.as_local().map(|def_id| {
-                                        self.tcx.hir().get(self.tcx.hir().as_local_hir_id(def_id))
+                                        self.tcx
+                                            .hir()
+                                            .get(self.tcx.hir().local_def_id_to_hir_id(def_id))
                                     });
                                     if let Some(hir::Node::Item(hir::Item { kind, .. })) = node {
                                         if let Some(g) = kind.generics() {
@@ -859,7 +861,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         candidates: Vec<DefId>,
     ) {
         let module_did = self.tcx.parent_module(self.body_id);
-        let module_id = self.tcx.hir().as_local_hir_id(module_did);
+        let module_id = self.tcx.hir().local_def_id_to_hir_id(module_did);
         let krate = self.tcx.hir().krate();
         let (span, found_use) = UsePlacementFinder::check(self.tcx, krate, module_id);
         if let Some(span) = span {
@@ -975,7 +977,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                 let id = item
                                     .def_id
                                     .as_local()
-                                    .map(|def_id| self.tcx.hir().as_local_hir_id(def_id));
+                                    .map(|def_id| self.tcx.hir().local_def_id_to_hir_id(def_id));
                                 if let Some(hir::Node::TraitItem(hir::TraitItem {
                                     kind: hir::TraitItemKind::Fn(fn_sig, method),
                                     ..
@@ -1062,7 +1064,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 let type_param = generics.type_param(param, self.tcx);
                 let hir = &self.tcx.hir();
                 if let Some(def_id) = type_param.def_id.as_local() {
-                    let id = hir.as_local_hir_id(def_id);
+                    let id = hir.local_def_id_to_hir_id(def_id);
                     // Get the `hir::Param` to verify whether it already has any bounds.
                     // We do this to avoid suggesting code that ends up as `T: FooBar`,
                     // instead we suggest `T: Foo + Bar` in that case.

--- a/src/librustc_typeck/check/op.rs
+++ b/src/librustc_typeck/check/op.rs
@@ -933,7 +933,7 @@ fn suggest_constraining_param(
     let param_def_id = generics.type_param(&p, tcx).def_id;
     if let Some(generics) = param_def_id
         .as_local()
-        .map(|id| hir.as_local_hir_id(id))
+        .map(|id| hir.local_def_id_to_hir_id(id))
         .and_then(|id| hir.find(hir.get_parent_item(id)))
         .as_ref()
         .and_then(|node| node.generics())

--- a/src/librustc_typeck/check/wfcheck.rs
+++ b/src/librustc_typeck/check/wfcheck.rs
@@ -71,7 +71,7 @@ impl<'tcx> CheckWfFcxBuilder<'tcx> {
 /// not included it frequently leads to confusing errors in fn bodies. So it's better to check
 /// the types first.
 pub fn check_item_well_formed(tcx: TyCtxt<'_>, def_id: LocalDefId) {
-    let hir_id = tcx.hir().as_local_hir_id(def_id);
+    let hir_id = tcx.hir().local_def_id_to_hir_id(def_id);
     let item = tcx.hir().expect_item(hir_id);
 
     debug!(
@@ -190,7 +190,7 @@ pub fn check_item_well_formed(tcx: TyCtxt<'_>, def_id: LocalDefId) {
 }
 
 pub fn check_trait_item(tcx: TyCtxt<'_>, def_id: LocalDefId) {
-    let hir_id = tcx.hir().as_local_hir_id(def_id);
+    let hir_id = tcx.hir().local_def_id_to_hir_id(def_id);
     let trait_item = tcx.hir().expect_trait_item(hir_id);
 
     let method_sig = match trait_item.kind {
@@ -264,7 +264,7 @@ fn check_object_unsafe_self_trait_by_name(tcx: TyCtxt<'_>, item: &hir::TraitItem
 }
 
 pub fn check_impl_item(tcx: TyCtxt<'_>, def_id: LocalDefId) {
-    let hir_id = tcx.hir().as_local_hir_id(def_id);
+    let hir_id = tcx.hir().local_def_id_to_hir_id(def_id);
     let impl_item = tcx.hir().expect_impl_item(hir_id);
 
     let method_sig = match impl_item.kind {
@@ -902,7 +902,7 @@ fn check_opaque_types<'fcx, 'tcx>(
                 let generics = tcx.generics_of(def_id);
 
                 let opaque_hir_id = if let Some(local_id) = def_id.as_local() {
-                    tcx.hir().as_local_hir_id(local_id)
+                    tcx.hir().local_def_id_to_hir_id(local_id)
                 } else {
                     // Opaque types from other crates won't have defining uses in this crate.
                     return ty;

--- a/src/librustc_typeck/check/writeback.rs
+++ b/src/librustc_typeck/check/writeback.rs
@@ -433,7 +433,7 @@ impl<'cx, 'tcx> WritebackCx<'cx, 'tcx> {
 
     fn visit_opaque_types(&mut self, span: Span) {
         for (&def_id, opaque_defn) in self.fcx.opaque_types.borrow().iter() {
-            let hir_id = self.tcx().hir().as_local_hir_id(def_id.expect_local());
+            let hir_id = self.tcx().hir().local_def_id_to_hir_id(def_id.expect_local());
             let instantiated_ty = self.resolve(&opaque_defn.concrete_ty, &hir_id);
 
             debug_assert!(!instantiated_ty.has_escaping_bound_vars());

--- a/src/librustc_typeck/check_unused.rs
+++ b/src/librustc_typeck/check_unused.rs
@@ -88,7 +88,7 @@ fn unused_crates_lint(tcx: TyCtxt<'_>) {
             // Note that if we carry through to the `extern_mod_stmt_cnum` query
             // below it'll cause a panic because `def_id` is actually bogus at this
             // point in time otherwise.
-            if tcx.hir().find(tcx.hir().as_local_hir_id(def_id)).is_none() {
+            if tcx.hir().find(tcx.hir().local_def_id_to_hir_id(def_id)).is_none() {
                 return false;
             }
             true
@@ -113,7 +113,7 @@ fn unused_crates_lint(tcx: TyCtxt<'_>) {
 
     for extern_crate in &crates_to_lint {
         let def_id = extern_crate.def_id.expect_local();
-        let id = tcx.hir().as_local_hir_id(def_id);
+        let id = tcx.hir().local_def_id_to_hir_id(def_id);
         let item = tcx.hir().expect_item(id);
 
         // If the crate is fully unused, we suggest removing it altogether.

--- a/src/librustc_typeck/coherence/builtin.rs
+++ b/src/librustc_typeck/coherence/builtin.rs
@@ -54,7 +54,7 @@ fn visit_implementation_of_drop(tcx: TyCtxt<'_>, impl_did: LocalDefId) {
         return;
     }
 
-    let impl_hir_id = tcx.hir().as_local_hir_id(impl_did);
+    let impl_hir_id = tcx.hir().local_def_id_to_hir_id(impl_did);
     let sp = match tcx.hir().expect_item(impl_hir_id).kind {
         ItemKind::Impl { self_ty, .. } => self_ty.span,
         _ => bug!("expected Drop impl item"),
@@ -73,7 +73,7 @@ fn visit_implementation_of_drop(tcx: TyCtxt<'_>, impl_did: LocalDefId) {
 fn visit_implementation_of_copy(tcx: TyCtxt<'_>, impl_did: LocalDefId) {
     debug!("visit_implementation_of_copy: impl_did={:?}", impl_did);
 
-    let impl_hir_id = tcx.hir().as_local_hir_id(impl_did);
+    let impl_hir_id = tcx.hir().local_def_id_to_hir_id(impl_did);
 
     let self_type = tcx.type_of(impl_did);
     debug!("visit_implementation_of_copy: self_type={:?} (bound)", self_type);
@@ -146,7 +146,7 @@ fn visit_implementation_of_coerce_unsized(tcx: TyCtxt<'tcx>, impl_did: LocalDefI
 fn visit_implementation_of_dispatch_from_dyn(tcx: TyCtxt<'_>, impl_did: LocalDefId) {
     debug!("visit_implementation_of_dispatch_from_dyn: impl_did={:?}", impl_did);
 
-    let impl_hir_id = tcx.hir().as_local_hir_id(impl_did);
+    let impl_hir_id = tcx.hir().local_def_id_to_hir_id(impl_did);
     let span = tcx.hir().span(impl_hir_id);
 
     let dispatch_from_dyn_trait = tcx.require_lang_item(DispatchFromDynTraitLangItem, Some(span));
@@ -315,7 +315,7 @@ pub fn coerce_unsized_info(tcx: TyCtxt<'tcx>, impl_did: DefId) -> CoerceUnsizedI
     debug!("compute_coerce_unsized_info(impl_did={:?})", impl_did);
 
     // this provider should only get invoked for local def-ids
-    let impl_hir_id = tcx.hir().as_local_hir_id(impl_did.expect_local());
+    let impl_hir_id = tcx.hir().local_def_id_to_hir_id(impl_did.expect_local());
     let span = tcx.hir().span(impl_hir_id);
 
     let coerce_unsized_trait = tcx.require_lang_item(CoerceUnsizedTraitLangItem, Some(span));

--- a/src/librustc_typeck/coherence/inherent_impls.rs
+++ b/src/librustc_typeck/coherence/inherent_impls.rs
@@ -112,6 +112,16 @@ impl ItemLikeVisitor<'v> for InherentCollect<'tcx> {
                     item.span,
                 );
             }
+            ty::Array(_, _) => {
+                self.check_primitive_impl(
+                    def_id,
+                    lang_items.array_impl(),
+                    None,
+                    "array",
+                    "[T; N]",
+                    item.span,
+                );
+            }
             ty::RawPtr(ty::TypeAndMut { ty: inner, mutbl: hir::Mutability::Not })
                 if matches!(inner.kind, ty::Slice(_)) =>
             {

--- a/src/librustc_typeck/collect/type_of.rs
+++ b/src/librustc_typeck/collect/type_of.rs
@@ -23,7 +23,7 @@ use super::{bad_placeholder_type, is_suggestable_infer_ty};
 pub(super) fn opt_const_param_of(tcx: TyCtxt<'_>, def_id: LocalDefId) -> Option<DefId> {
     use hir::*;
 
-    let hir_id = tcx.hir().as_local_hir_id(def_id);
+    let hir_id = tcx.hir().local_def_id_to_hir_id(def_id);
 
     if let Node::AnonConst(_) = tcx.hir().get(hir_id) {
         let parent_node_id = tcx.hir().get_parent_node(hir_id);
@@ -138,7 +138,7 @@ pub(super) fn type_of(tcx: TyCtxt<'_>, def_id: DefId) -> Ty<'_> {
     let def_id = def_id.expect_local();
     use rustc_hir::*;
 
-    let hir_id = tcx.hir().as_local_hir_id(def_id);
+    let hir_id = tcx.hir().local_def_id_to_hir_id(def_id);
 
     let icx = ItemCtxt::new(tcx, def_id.to_def_id());
 
@@ -564,7 +564,7 @@ fn find_opaque_ty_constraints(tcx: TyCtxt<'_>, def_id: LocalDefId) -> Ty<'_> {
         }
     }
 
-    let hir_id = tcx.hir().as_local_hir_id(def_id);
+    let hir_id = tcx.hir().local_def_id_to_hir_id(def_id);
     let scope = tcx.hir().get_defining_scope(hir_id);
     let mut locator = ConstraintLocator { def_id: def_id.to_def_id(), tcx, found: None };
 
@@ -617,7 +617,7 @@ fn find_opaque_ty_constraints(tcx: TyCtxt<'_>, def_id: LocalDefId) -> Ty<'_> {
 ///    by the time we borrow check, and it's not clear how we should handle
 ///    those.
 fn let_position_impl_trait_type(tcx: TyCtxt<'_>, opaque_ty_id: LocalDefId) -> Ty<'_> {
-    let scope = tcx.hir().get_defining_scope(tcx.hir().as_local_hir_id(opaque_ty_id));
+    let scope = tcx.hir().get_defining_scope(tcx.hir().local_def_id_to_hir_id(opaque_ty_id));
     let scope_def_id = tcx.hir().local_def_id(scope);
 
     let opaque_ty_def_id = opaque_ty_id.to_def_id();
@@ -653,7 +653,7 @@ fn let_position_impl_trait_type(tcx: TyCtxt<'_>, opaque_ty_id: LocalDefId) -> Ty
     if concrete_ty.has_erased_regions() {
         // FIXME(impl_trait_in_bindings) Handle this case.
         tcx.sess.span_fatal(
-            tcx.hir().span(tcx.hir().as_local_hir_id(opaque_ty_id)),
+            tcx.hir().span(tcx.hir().local_def_id_to_hir_id(opaque_ty_id)),
             "lifetimes in impl Trait types in bindings are not currently supported",
         );
     }

--- a/src/librustc_typeck/impl_wf_check/min_specialization.rs
+++ b/src/librustc_typeck/impl_wf_check/min_specialization.rs
@@ -336,7 +336,7 @@ fn check_predicates<'tcx>(
         if let Some(obligations) = wf::obligations(
             infcx,
             tcx.param_env(impl1_def_id),
-            tcx.hir().as_local_hir_id(impl1_def_id),
+            tcx.hir().local_def_id_to_hir_id(impl1_def_id),
             arg,
             span,
         ) {

--- a/src/librustc_typeck/lib.rs
+++ b/src/librustc_typeck/lib.rs
@@ -153,7 +153,7 @@ fn require_same_types<'tcx>(
 }
 
 fn check_main_fn_ty(tcx: TyCtxt<'_>, main_def_id: LocalDefId) {
-    let main_id = tcx.hir().as_local_hir_id(main_def_id);
+    let main_id = tcx.hir().local_def_id_to_hir_id(main_def_id);
     let main_span = tcx.def_span(main_def_id);
     let main_t = tcx.type_of(main_def_id);
     match main_t.kind {
@@ -249,7 +249,7 @@ fn check_main_fn_ty(tcx: TyCtxt<'_>, main_def_id: LocalDefId) {
 }
 
 fn check_start_fn_ty(tcx: TyCtxt<'_>, start_def_id: LocalDefId) {
-    let start_id = tcx.hir().as_local_hir_id(start_def_id);
+    let start_id = tcx.hir().local_def_id_to_hir_id(start_def_id);
     let start_span = tcx.def_span(start_def_id);
     let start_t = tcx.type_of(start_def_id);
     match start_t.kind {

--- a/src/librustc_typeck/outlives/implicit_infer.rs
+++ b/src/librustc_typeck/outlives/implicit_infer.rs
@@ -57,7 +57,7 @@ impl<'cx, 'tcx> ItemLikeVisitor<'tcx> for InferVisitor<'cx, 'tcx> {
 
         debug!("InferVisitor::visit_item(item={:?})", item_did);
 
-        let hir_id = self.tcx.hir().as_local_hir_id(item_did);
+        let hir_id = self.tcx.hir().local_def_id_to_hir_id(item_did);
         let item = match self.tcx.hir().get(hir_id) {
             Node::Item(item) => item,
             _ => bug!(),

--- a/src/librustc_typeck/outlives/mod.rs
+++ b/src/librustc_typeck/outlives/mod.rs
@@ -18,7 +18,7 @@ pub fn provide(providers: &mut Providers) {
 }
 
 fn inferred_outlives_of(tcx: TyCtxt<'_>, item_def_id: DefId) -> &[(ty::Predicate<'_>, Span)] {
-    let id = tcx.hir().as_local_hir_id(item_def_id.expect_local());
+    let id = tcx.hir().local_def_id_to_hir_id(item_def_id.expect_local());
 
     match tcx.hir().get(id) {
         Node::Item(item) => match item.kind {

--- a/src/librustc_typeck/variance/constraints.rs
+++ b/src/librustc_typeck/variance/constraints.rs
@@ -137,7 +137,7 @@ impl<'a, 'tcx> ConstraintContext<'a, 'tcx> {
             return;
         }
 
-        let id = tcx.hir().as_local_hir_id(def_id);
+        let id = tcx.hir().local_def_id_to_hir_id(def_id);
         let inferred_start = self.terms_cx.inferred_starts[&id];
         let current_item = &CurrentItem { inferred_start };
         match tcx.type_of(def_id).kind {
@@ -375,7 +375,7 @@ impl<'a, 'tcx> ConstraintContext<'a, 'tcx> {
         }
 
         let (local, remote) = if let Some(def_id) = def_id.as_local() {
-            let id = self.tcx().hir().as_local_hir_id(def_id);
+            let id = self.tcx().hir().local_def_id_to_hir_id(def_id);
             (Some(self.terms_cx.inferred_starts[&id]), None)
         } else {
             (None, Some(self.tcx().variances_of(def_id)))

--- a/src/librustc_typeck/variance/mod.rs
+++ b/src/librustc_typeck/variance/mod.rs
@@ -39,7 +39,7 @@ fn crate_variances(tcx: TyCtxt<'_>, crate_num: CrateNum) -> CrateVariancesMap<'_
 }
 
 fn variances_of(tcx: TyCtxt<'_>, item_def_id: DefId) -> &[ty::Variance] {
-    let id = tcx.hir().as_local_hir_id(item_def_id.expect_local());
+    let id = tcx.hir().local_def_id_to_hir_id(item_def_id.expect_local());
     let unsupported = || {
         // Variance not relevant.
         span_bug!(tcx.hir().span(id), "asked to compute variance for wrong kind of item")

--- a/src/librustc_typeck/variance/terms.rs
+++ b/src/librustc_typeck/variance/terms.rs
@@ -94,7 +94,9 @@ fn lang_items(tcx: TyCtxt<'_>) -> Vec<(hir::HirId, Vec<ty::Variance>)> {
     all.into_iter() // iterating over (Option<DefId>, Variance)
         .filter(|&(ref d, _)| d.is_some())
         .map(|(d, v)| (d.unwrap(), v)) // (DefId, Variance)
-        .filter_map(|(d, v)| d.as_local().map(|d| tcx.hir().as_local_hir_id(d)).map(|n| (n, v))) // (HirId, Variance)
+        .filter_map(|(d, v)| {
+            d.as_local().map(|d| tcx.hir().local_def_id_to_hir_id(d)).map(|n| (n, v))
+        }) // (HirId, Variance)
         .collect()
 }
 

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -356,7 +356,7 @@ pub fn build_impl(
     }
 
     let for_ = if let Some(did) = did.as_local() {
-        let hir_id = tcx.hir().as_local_hir_id(did);
+        let hir_id = tcx.hir().local_def_id_to_hir_id(did);
         match tcx.hir().expect_item(hir_id).kind {
             hir::ItemKind::Impl { self_ty, .. } => self_ty.clean(cx),
             _ => panic!("did given to build_impl was not an impl"),
@@ -377,7 +377,7 @@ pub fn build_impl(
 
     let predicates = tcx.explicit_predicates_of(did);
     let (trait_items, generics) = if let Some(did) = did.as_local() {
-        let hir_id = tcx.hir().as_local_hir_id(did);
+        let hir_id = tcx.hir().local_def_id_to_hir_id(did);
         match tcx.hir().expect_item(hir_id).kind {
             hir::ItemKind::Impl { ref generics, ref items, .. } => (
                 items.iter().map(|item| tcx.hir().impl_item(item.id).clean(cx)).collect::<Vec<_>>(),
@@ -500,7 +500,7 @@ fn build_module(cx: &DocContext<'_>, did: DefId, visited: &mut FxHashSet<DefId>)
 
 pub fn print_inlined_const(cx: &DocContext<'_>, did: DefId) -> String {
     if let Some(did) = did.as_local() {
-        let hir_id = cx.tcx.hir().as_local_hir_id(did);
+        let hir_id = cx.tcx.hir().local_def_id_to_hir_id(did);
         rustc_hir_pretty::id_to_string(&cx.tcx.hir(), hir_id)
     } else {
         cx.tcx.rendered_const(did)
@@ -513,7 +513,7 @@ fn build_const(cx: &DocContext<'_>, did: DefId) -> clean::Constant {
         expr: print_inlined_const(cx, did),
         value: clean::utils::print_evaluated_const(cx, did),
         is_literal: did.as_local().map_or(false, |did| {
-            clean::utils::is_literal_expr(cx, cx.tcx.hir().as_local_hir_id(did))
+            clean::utils::is_literal_expr(cx, cx.tcx.hir().local_def_id_to_hir_id(did))
         }),
     }
 }

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1382,7 +1382,7 @@ impl Clean<Type> for hir::Ty<'_> {
                 if let Res::Def(DefKind::TyAlias, def_id) = path.res {
                     // Substitute private type aliases
                     if let Some(def_id) = def_id.as_local() {
-                        let hir_id = cx.tcx.hir().as_local_hir_id(def_id);
+                        let hir_id = cx.tcx.hir().local_def_id_to_hir_id(def_id);
                         if !cx.renderinfo.borrow().access_levels.is_exported(def_id.to_def_id()) {
                             alias = Some(&cx.tcx.hir().expect_item(hir_id).kind);
                         }

--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -471,7 +471,7 @@ pub fn print_const(cx: &DocContext<'_>, n: &'tcx ty::Const<'_>) -> String {
     match n.val {
         ty::ConstKind::Unevaluated(def, _, promoted) => {
             let mut s = if let Some(def) = def.as_local() {
-                let hir_id = cx.tcx.hir().as_local_hir_id(def.did);
+                let hir_id = cx.tcx.hir().local_def_id_to_hir_id(def.did);
                 print_const_expr(cx, cx.tcx.hir().body_owned_by(hir_id))
             } else {
                 inline::print_inlined_const(cx, def.did)

--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -385,7 +385,7 @@ pub fn build_deref_target_impls(cx: &DocContext<'_>, items: &[Item], ret: &mut V
             Bool => tcx.lang_items().bool_impl(),
             Str => tcx.lang_items().str_impl(),
             Slice => tcx.lang_items().slice_impl(),
-            Array => tcx.lang_items().slice_impl(),
+            Array => tcx.lang_items().array_impl(),
             Tuple => None,
             Unit => None,
             RawPointer => tcx.lang_items().const_ptr_impl(),

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -143,13 +143,13 @@ impl<'tcx> DocContext<'tcx> {
         def_id
     }
 
-    /// Like the function of the same name on the HIR map, but skips calling it on fake DefIds.
+    /// Like `hir().local_def_id_to_hir_id()`, but skips calling it on fake DefIds.
     /// (This avoids a slice-index-out-of-bounds panic.)
     pub fn as_local_hir_id(&self, def_id: DefId) -> Option<HirId> {
         if self.all_fake_def_ids.borrow().contains(&def_id) {
             None
         } else {
-            def_id.as_local().map(|def_id| self.tcx.hir().as_local_hir_id(def_id))
+            def_id.as_local().map(|def_id| self.tcx.hir().local_def_id_to_hir_id(def_id))
         }
     }
 
@@ -400,7 +400,7 @@ pub fn run_core(options: RustdocOptions) -> (clean::Crate, RenderInfo, RenderOpt
                 }
 
                 let hir = tcx.hir();
-                let body = hir.body(hir.body_owned_by(hir.as_local_hir_id(def_id)));
+                let body = hir.body(hir.body_owned_by(hir.local_def_id_to_hir_id(def_id)));
                 debug!("visiting body for {:?}", def_id);
                 EmitIgnoredResolutionErrors::new(tcx).visit_body(body);
                 (rustc_interface::DEFAULT_QUERY_PROVIDERS.typeck)(tcx, def_id)

--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -655,7 +655,7 @@ impl<'a, 'b> ExtraInfo<'a, 'b> {
             (Some(h), _) => h,
             (None, Some(item_did)) => {
                 match item_did.as_local() {
-                    Some(item_did) => self.tcx.hir().as_local_hir_id(item_did),
+                    Some(item_did) => self.tcx.hir().local_def_id_to_hir_id(item_did),
                     None => {
                         // If non-local, no need to check anything.
                         return;

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -813,8 +813,8 @@ impl<'a, 'tcx> DocFolder for LinkCollector<'a, 'tcx> {
                 {
                     use rustc_hir::def_id::LOCAL_CRATE;
 
-                    let hir_src = self.cx.tcx.hir().as_local_hir_id(src_id);
-                    let hir_dst = self.cx.tcx.hir().as_local_hir_id(dst_id);
+                    let hir_src = self.cx.tcx.hir().local_def_id_to_hir_id(src_id);
+                    let hir_dst = self.cx.tcx.hir().local_def_id_to_hir_id(dst_id);
 
                     if self.cx.tcx.privacy_access_levels(LOCAL_CRATE).is_exported(hir_src)
                         && !self.cx.tcx.privacy_access_levels(LOCAL_CRATE).is_exported(hir_dst)

--- a/src/librustdoc/passes/collect_trait_impls.rs
+++ b/src/librustdoc/passes/collect_trait_impls.rs
@@ -55,6 +55,7 @@ pub fn collect_trait_impls(krate: Crate, cx: &DocContext<'_>) -> Crate {
         lang_items.bool_impl(),
         lang_items.char_impl(),
         lang_items.str_impl(),
+        lang_items.array_impl(),
         lang_items.slice_impl(),
         lang_items.slice_u8_impl(),
         lang_items.str_alloc_impl(),

--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -323,7 +323,7 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
         }
 
         let res_hir_id = match res_did.as_local() {
-            Some(n) => tcx.hir().as_local_hir_id(n),
+            Some(n) => tcx.hir().local_def_id_to_hir_id(n),
             None => return false,
         };
 

--- a/src/test/ui/__check/what.fixed
+++ b/src/test/ui/__check/what.fixed
@@ -1,0 +1,9 @@
+// check-pass
+// run-rustfix
+#![warn(unused_parens)]
+fn test(_: u32) {}
+
+fn main() {
+    test(7);
+    //~^^^ WARN unnecessary parentheses around function argument
+}

--- a/src/test/ui/__check/what.rs
+++ b/src/test/ui/__check/what.rs
@@ -1,0 +1,11 @@
+// check-pass
+// run-rustfix
+#![warn(unused_parens)]
+fn test(_: u32) {}
+
+fn main() {
+    test((
+        7
+    ));
+    //~^^^ WARN unnecessary parentheses around function argument
+}

--- a/src/test/ui/__check/what.stderr
+++ b/src/test/ui/__check/what.stderr
@@ -1,0 +1,17 @@
+warning: unnecessary parentheses around function argument
+  --> $DIR/what.rs:7:10
+   |
+LL |       test((
+   |  __________^
+LL | |         7
+LL | |     ));
+   | |_____^ help: remove these parentheses
+   |
+note: the lint level is defined here
+  --> $DIR/what.rs:3:9
+   |
+LL | #![warn(unused_parens)]
+   |         ^^^^^^^^^^^^^
+
+warning: 1 warning emitted
+

--- a/src/test/ui/associated-types/bound-lifetime-in-binding-only.elision.stderr
+++ b/src/test/ui/associated-types/bound-lifetime-in-binding-only.elision.stderr
@@ -5,6 +5,11 @@ LL | fn elision<T: Fn() -> &i32>() {
    |                       ^ expected named lifetime parameter
    |
    = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
+   = note: for more information on higher-ranked polymorphism, visit https://doc.rust-lang.org/nomicon/hrtb.html
+help: consider making the bound lifetime-generic with a new `'a` lifetime
+   |
+LL | fn elision<T: for<'a> Fn() -> &'a i32>() {
+   |               ^^^^^^^         ^^^
 help: consider using the `'static` lifetime
    |
 LL | fn elision<T: Fn() -> &'static i32>() {

--- a/src/test/ui/associated-types/bound-lifetime-in-return-only.elision.stderr
+++ b/src/test/ui/associated-types/bound-lifetime-in-return-only.elision.stderr
@@ -5,6 +5,11 @@ LL | fn elision(_: fn() -> &i32) {
    |                       ^ expected named lifetime parameter
    |
    = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
+   = note: for more information on higher-ranked polymorphism, visit https://doc.rust-lang.org/nomicon/hrtb.html
+help: consider making the type lifetime-generic with a new `'a` lifetime
+   |
+LL | fn elision(_: for<'a> fn() -> &'a i32) {
+   |               ^^^^^^^         ^^^
 help: consider using the `'static` lifetime
    |
 LL | fn elision(_: fn() -> &'static i32) {

--- a/src/test/ui/error-codes/E0106.stderr
+++ b/src/test/ui/error-codes/E0106.stderr
@@ -51,6 +51,15 @@ error[E0106]: missing lifetime specifiers
    |
 LL |     buzz: Buzz,
    |           ^^^^ expected 2 lifetime parameters
+   |
+help: consider introducing a named lifetime parameter
+   |
+LL | struct Quux<'a> {
+LL |     baz: Baz,
+LL |
+LL |
+LL |     buzz: Buzz<'a, 'a>,
+   |
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/issues/issue-74739.rs
+++ b/src/test/ui/issues/issue-74739.rs
@@ -1,0 +1,14 @@
+// compile-flags: -O
+// run-pass
+
+struct Foo {
+    x: i32,
+}
+
+pub fn main() {
+    let mut foo = Foo { x: 42 };
+    let x = &mut foo.x;
+    *x = 13;
+    let y = foo;
+    assert_eq!(y.x, 13); // used to print 42 due to mir-opt bug
+}

--- a/src/test/ui/mismatched_types/issue-74918-missing-lifetime.stderr
+++ b/src/test/ui/mismatched_types/issue-74918-missing-lifetime.stderr
@@ -6,8 +6,8 @@ LL |     type Item = IteratorChunk<T, S>;
    |
 help: consider introducing a named lifetime parameter
    |
-LL |     type Item<'a> = IteratorChunk<<'a>T, S>;
-   |              ^^^^                 ^^^^
+LL |     type Item<'a> = IteratorChunk<'a, T, S>;
+   |              ^^^^                 ^^^
 
 error: `impl` item signature doesn't match `trait` item signature
   --> $DIR/issue-74918-missing-lifetime.rs:11:5

--- a/src/test/ui/suggestions/missing-lifetime-in-assoc-const-type.rs
+++ b/src/test/ui/suggestions/missing-lifetime-in-assoc-const-type.rs
@@ -1,5 +1,16 @@
 trait ZstAssert: Sized {
-    const TYPE_NAME: &str = ""; //~ ERROR missing lifetime specifier
+    const A: &str = ""; //~ ERROR missing lifetime specifier
+    const B: S = S { s: &() }; //~ ERROR missing lifetime specifier
+    const C: &'_ str = ""; //~ ERROR missing lifetime specifier
+    const D: T = T { a: &(), b: &() }; //~ ERROR missing lifetime specifier
+}
+
+struct S<'a> {
+    s: &'a (),
+}
+struct T<'a, 'b> {
+    a: &'a (),
+    b: &'b (),
 }
 
 fn main() {}

--- a/src/test/ui/suggestions/missing-lifetime-in-assoc-const-type.rs
+++ b/src/test/ui/suggestions/missing-lifetime-in-assoc-const-type.rs
@@ -1,0 +1,5 @@
+trait ZstAssert: Sized {
+    const TYPE_NAME: &str = ""; //~ ERROR missing lifetime specifier
+}
+
+fn main() {}

--- a/src/test/ui/suggestions/missing-lifetime-in-assoc-const-type.stderr
+++ b/src/test/ui/suggestions/missing-lifetime-in-assoc-const-type.stderr
@@ -1,0 +1,15 @@
+error[E0106]: missing lifetime specifier
+  --> $DIR/missing-lifetime-in-assoc-const-type.rs:2:22
+   |
+LL |     const TYPE_NAME: &str = "";
+   |                      ^ expected named lifetime parameter
+   |
+help: consider introducing a named lifetime parameter
+   |
+LL | trait ZstAssert<'a>: Sized {
+LL |     const TYPE_NAME: &'a str = "";
+   |
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0106`.

--- a/src/test/ui/suggestions/missing-lifetime-in-assoc-const-type.stderr
+++ b/src/test/ui/suggestions/missing-lifetime-in-assoc-const-type.stderr
@@ -1,15 +1,73 @@
 error[E0106]: missing lifetime specifier
-  --> $DIR/missing-lifetime-in-assoc-const-type.rs:2:22
+  --> $DIR/missing-lifetime-in-assoc-const-type.rs:2:14
    |
-LL |     const TYPE_NAME: &str = "";
-   |                      ^ expected named lifetime parameter
+LL |     const A: &str = "";
+   |              ^ expected named lifetime parameter
    |
+help: consider using the `'static` lifetime
+   |
+LL |     const A: &'static str = "";
+   |               ^^^^^^^
 help: consider introducing a named lifetime parameter
    |
 LL | trait ZstAssert<'a>: Sized {
-LL |     const TYPE_NAME: &'a str = "";
+LL |     const A: &'a str = "";
    |
 
-error: aborting due to previous error
+error[E0106]: missing lifetime specifier
+  --> $DIR/missing-lifetime-in-assoc-const-type.rs:3:14
+   |
+LL |     const B: S = S { s: &() };
+   |              ^ expected named lifetime parameter
+   |
+help: consider using the `'static` lifetime
+   |
+LL |     const B: S<'static> = S { s: &() };
+   |               ^^^^^^^^^
+help: consider introducing a named lifetime parameter
+   |
+LL | trait ZstAssert<'a>: Sized {
+LL |     const A: &str = "";
+LL |     const B: S<'a> = S { s: &() };
+   |
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/missing-lifetime-in-assoc-const-type.rs:4:15
+   |
+LL |     const C: &'_ str = "";
+   |               ^^ expected named lifetime parameter
+   |
+help: consider using the `'static` lifetime
+   |
+LL |     const C: &'static str = "";
+   |               ^^^^^^^
+help: consider introducing a named lifetime parameter
+   |
+LL | trait ZstAssert<'a>: Sized {
+LL |     const A: &str = "";
+LL |     const B: S = S { s: &() };
+LL |     const C: &'a str = "";
+   |
+
+error[E0106]: missing lifetime specifiers
+  --> $DIR/missing-lifetime-in-assoc-const-type.rs:5:14
+   |
+LL |     const D: T = T { a: &(), b: &() };
+   |              ^ expected 2 lifetime parameters
+   |
+help: consider using the `'static` lifetime
+   |
+LL |     const D: T<'static, 'static> = T { a: &(), b: &() };
+   |               ^^^^^^^^^^^^^^^^^^
+help: consider introducing a named lifetime parameter
+   |
+LL | trait ZstAssert<'a>: Sized {
+LL |     const A: &str = "";
+LL |     const B: S = S { s: &() };
+LL |     const C: &'_ str = "";
+LL |     const D: T<'a, 'a> = T { a: &(), b: &() };
+   |
+
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0106`.

--- a/src/test/ui/suggestions/missing-lt-for-hrtb.rs
+++ b/src/test/ui/suggestions/missing-lt-for-hrtb.rs
@@ -1,0 +1,15 @@
+struct X<'a>(&'a ());
+struct S<'a>(&'a dyn Fn(&X) -> &X);
+//~^ ERROR missing lifetime specifier
+//~| ERROR missing lifetime specifier
+struct V<'a>(&'a dyn for<'b> Fn(&X) -> &X);
+//~^ ERROR missing lifetime specifier
+//~| ERROR missing lifetime specifier
+
+fn main() {
+    let x = S(&|x| {
+        println!("hi");
+        x
+    });
+    x.0(&X(&()));
+}

--- a/src/test/ui/suggestions/missing-lt-for-hrtb.stderr
+++ b/src/test/ui/suggestions/missing-lt-for-hrtb.stderr
@@ -1,0 +1,63 @@
+error[E0106]: missing lifetime specifier
+  --> $DIR/missing-lt-for-hrtb.rs:2:32
+   |
+LL | struct S<'a>(&'a dyn Fn(&X) -> &X);
+   |                         --     ^ expected named lifetime parameter
+   |
+   = help: this function's return type contains a borrowed value, but the signature does not say which one of argument 1's 2 lifetimes it is borrowed from
+   = note: for more information on higher-ranked polymorphism, visit https://doc.rust-lang.org/nomicon/hrtb.html
+help: consider making the bound lifetime-generic with a new `'b` lifetime
+   |
+LL | struct S<'a>(&'a dyn for<'b> Fn(&'b X) -> &'b X);
+   |                      ^^^^^^^    ^^^^^     ^^^
+help: consider using the `'a` lifetime
+   |
+LL | struct S<'a>(&'a dyn Fn(&X) -> &'a X);
+   |                                ^^^
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/missing-lt-for-hrtb.rs:2:33
+   |
+LL | struct S<'a>(&'a dyn Fn(&X) -> &X);
+   |                         --      ^ expected named lifetime parameter
+   |
+   = help: this function's return type contains a borrowed value, but the signature does not say which one of argument 1's 2 lifetimes it is borrowed from
+   = note: for more information on higher-ranked polymorphism, visit https://doc.rust-lang.org/nomicon/hrtb.html
+help: consider making the bound lifetime-generic with a new `'b` lifetime
+   |
+LL | struct S<'a>(&'a dyn for<'b> Fn(&'b X) -> &X<'b>);
+   |                      ^^^^^^^    ^^^^^      ^^^^^
+help: consider using the `'a` lifetime
+   |
+LL | struct S<'a>(&'a dyn Fn(&X) -> &X<'a>);
+   |                                 ^^^^^
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/missing-lt-for-hrtb.rs:5:40
+   |
+LL | struct V<'a>(&'a dyn for<'b> Fn(&X) -> &X);
+   |                                 --     ^ expected named lifetime parameter
+   |
+   = help: this function's return type contains a borrowed value, but the signature does not say which one of argument 1's 2 lifetimes it is borrowed from
+note: these named lifetimes are available to use
+  --> $DIR/missing-lt-for-hrtb.rs:5:10
+   |
+LL | struct V<'a>(&'a dyn for<'b> Fn(&X) -> &X);
+   |          ^^              ^^
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/missing-lt-for-hrtb.rs:5:41
+   |
+LL | struct V<'a>(&'a dyn for<'b> Fn(&X) -> &X);
+   |                                 --      ^ expected named lifetime parameter
+   |
+   = help: this function's return type contains a borrowed value, but the signature does not say which one of argument 1's 2 lifetimes it is borrowed from
+note: these named lifetimes are available to use
+  --> $DIR/missing-lt-for-hrtb.rs:5:10
+   |
+LL | struct V<'a>(&'a dyn for<'b> Fn(&X) -> &X);
+   |          ^^              ^^
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0106`.

--- a/src/tools/clippy/clippy_lints/src/derive.rs
+++ b/src/tools/clippy/clippy_lints/src/derive.rs
@@ -224,7 +224,7 @@ fn check_hash_peq<'tcx>(
                         mess,
                         |diag| {
                             if let Some(local_def_id) = impl_id.as_local() {
-                                let hir_id = cx.tcx.hir().as_local_hir_id(local_def_id);
+                                let hir_id = cx.tcx.hir().local_def_id_to_hir_id(local_def_id);
                                 diag.span_note(
                                     cx.tcx.hir().span(hir_id),
                                     "`PartialEq` implemented here"
@@ -278,7 +278,7 @@ fn check_ord_partial_ord<'tcx>(
                         mess,
                         |diag| {
                             if let Some(local_def_id) = impl_id.as_local() {
-                                let hir_id = cx.tcx.hir().as_local_hir_id(local_def_id);
+                                let hir_id = cx.tcx.hir().local_def_id_to_hir_id(local_def_id);
                                 diag.span_note(
                                     cx.tcx.hir().span(hir_id),
                                     "`PartialOrd` implemented here"
@@ -341,7 +341,7 @@ fn check_unsafe_derive_deserialize<'tcx>(
     ty: Ty<'tcx>,
 ) {
     fn item_from_def_id<'tcx>(cx: &LateContext<'tcx>, def_id: DefId) -> &'tcx Item<'tcx> {
-        let hir_id = cx.tcx.hir().as_local_hir_id(def_id.expect_local());
+        let hir_id = cx.tcx.hir().local_def_id_to_hir_id(def_id.expect_local());
         cx.tcx.hir().expect_item(hir_id)
     }
 
@@ -355,7 +355,7 @@ fn check_unsafe_derive_deserialize<'tcx>(
         if match_path(&trait_ref.path, &paths::SERDE_DESERIALIZE);
         if let ty::Adt(def, _) = ty.kind;
         if let Some(local_def_id) = def.did.as_local();
-        let adt_hir_id = cx.tcx.hir().as_local_hir_id(local_def_id);
+        let adt_hir_id = cx.tcx.hir().local_def_id_to_hir_id(local_def_id);
         if !is_allowed(cx, UNSAFE_DERIVE_DESERIALIZE, adt_hir_id);
         if cx.tcx.inherent_impls(def.did)
             .iter()

--- a/src/tools/clippy/clippy_lints/src/new_without_default.rs
+++ b/src/tools/clippy/clippy_lints/src/new_without_default.rs
@@ -103,7 +103,7 @@ impl<'tcx> LateLintPass<'tcx> for NewWithoutDefault {
                                         cx.tcx.for_each_impl(default_trait_id, |d| {
                                             if let Some(ty_def) = cx.tcx.type_of(d).ty_adt_def() {
                                                 if let Some(local_def_id) = ty_def.did.as_local() {
-                                                    impls.insert(cx.tcx.hir().as_local_hir_id(local_def_id));
+                                                    impls.insert(cx.tcx.hir().local_def_id_to_hir_id(local_def_id));
                                                 }
                                             }
                                         });

--- a/src/tools/tier-check/Cargo.toml
+++ b/src/tools/tier-check/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "tier-check"
+version = "0.1.0"
+authors = ["Eric Huss"]
+edition = "2018"
+license = "MIT OR Apache-2.0"
+
+[dependencies]

--- a/src/tools/tier-check/src/main.rs
+++ b/src/tools/tier-check/src/main.rs
@@ -1,0 +1,52 @@
+//! This is a script for validating the platform support page in the rustc book.
+//!
+//! The script takes two arguments, the path to the Platform Support source
+//! page, and the second argument is the path to `rustc`.
+
+use std::collections::HashSet;
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let src = args.next().expect("expected source file as first argument");
+    let filename = std::path::Path::new(&src).file_name().unwrap().to_str().unwrap();
+    let rustc = args.next().expect("expected rustc as second argument");
+    let output = std::process::Command::new(rustc)
+        .arg("--print=target-list")
+        .output()
+        .expect("rustc should run");
+    if !output.status.success() {
+        eprintln!("rustc failed to run");
+        std::process::exit(0);
+    }
+    let stdout = std::str::from_utf8(&output.stdout).expect("utf8");
+    let target_list: HashSet<_> = stdout.lines().collect();
+
+    let doc_targets_md = std::fs::read_to_string(&src).expect("failed to read input source");
+    let doc_targets: HashSet<_> = doc_targets_md
+        .lines()
+        .filter(|line| line.starts_with('`') && line.contains('|'))
+        // These platforms only exist on macos.
+        .filter(|line| !line.contains("[^apple]") || cfg!(target_os = "macos"))
+        .map(|line| line.split('`').skip(1).next().expect("expected target code span"))
+        .collect();
+
+    let missing: Vec<_> = target_list.difference(&doc_targets).collect();
+    let extra: Vec<_> = doc_targets.difference(&target_list).collect();
+    for target in &missing {
+        eprintln!(
+            "error: target `{}` is missing from {}\n\
+            If this is a new target, please add it to {}.",
+            target, filename, src
+        );
+    }
+    for target in &extra {
+        eprintln!(
+            "error: target `{}` is in {}, but does not appear in the rustc target list\n\
+            If the target has been removed, please edit {} and remove the target.",
+            target, filename, src
+        );
+    }
+    if !missing.is_empty() || !extra.is_empty() {
+        std::process::exit(1);
+    }
+}


### PR DESCRIPTION
Successful merges:

 - #75115 (`#[deny(unsafe_op_in_unsafe_fn)]` in sys/cloudabi)
 - #75189 (Fix wasi::fs::OpenOptions to imply write when append is on)
 - #75201 (Fix some Clippy warnings in librustc_serialize)
 - #75212 (Add `array` lang item and `[T; N]::map(f: FnMut(T) -> S)`)
 - #75372 (Fix suggestion to use lifetime in type and in assoc const)
 - #75400 (Fix minor things in the `f32` primitive docs)
 - #75426 (Update cargo)
 - #75431 (Move platform support to the rustc book.)
 - #75448 (merge `as_local_hir_id` with `local_def_id_to_hir_id`)
 - #75449 (add regression test for #74739 (mir const-prop bug))

Failed merges:


r? @ghost