### PR TITLE
make rustc-docs component available to rustup

### DIFF
--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -447,6 +447,7 @@ impl Builder {
         let mut package = |name, targets| self.package(name, &mut manifest.pkg, targets);
         package("rustc", HOSTS);
         package("rustc-dev", HOSTS);
+        package("rustc-docs", HOSTS);
         package("cargo", HOSTS);
         package("rust-mingw", MINGW);
         package("rust-std", TARGETS);


### PR DESCRIPTION
The `rustc-docs` component was generated but not selectable via rustup.

Zulip thread: https://rust-lang.zulipchat.com/#narrow/stream/122651-general/topic/rustc.20nightly.20docs.20as.20component.3F

r? @Mark-Simulacrum 