### PR TITLE
Add iter_max to test::Bencher

### DIFF
--- a/library/test/src/bench.rs
+++ b/library/test/src/bench.rs
@@ -39,6 +39,22 @@ impl Bencher {
         self.summary = Some(iter(&mut inner));
     }
 
+    /// Like iter but limits the amount of execution cycles.
+    /// Useful for benchmarking functions that need unique pre-generated
+    /// data for each iteration.
+    /// For better results set max_iter as high as possible.
+    pub fn iter_max<T, F>(&mut self, mut inner: F, max_iter: u64)
+    where
+        F: FnMut() -> T,
+    {
+        if self.mode == BenchMode::Single {
+            ns_iter_inner(&mut inner, 1);
+            return;
+        }
+
+        self.summary = Some(iter_max(&mut inner, max_iter));
+    }
+
     pub fn bench<F>(&mut self, mut f: F) -> Option<stats::Summary>
     where
         F: FnMut(&mut Bencher),
@@ -179,6 +195,146 @@ where
                 return summ5;
             }
         };
+    }
+}
+
+pub fn iter_max<T, F>(inner: &mut F, max_iter: u64) -> stats::Summary
+where
+    F: FnMut() -> T,
+{
+    assert_ne!(max_iter, 0);
+
+    // max_iter is so small that it's doesn't make sense to calculate a
+    // ballpark figure.
+    if max_iter < 10 {
+        let mut samples = vec![0.0_f64; max_iter as usize];
+        let samples: &mut [f64] = samples.as_mut_slice();
+
+        for p in &mut *samples {
+            *p = ns_iter_inner(inner, 1) as f64;
+        }
+
+        stats::winsorize(samples, 5.0);
+        return stats::Summary::new(samples);
+    }
+
+    // Initial bench run to get ballpark figure.
+    let ns_single = ns_iter_inner(inner, 1);
+    let max_iter: u64 = max_iter - 1;
+
+    // Try to estimate iter count for 1ms falling back to 1m
+    // iterations if first run took < 1ns.
+    let ns_target_total = 1_000_000; // 1ms
+    let mut n = ns_target_total / cmp::max(1, ns_single);
+
+    // If the first run took more than 1ms we don't want to just
+    // be left doing 0 iterations on every loop. The unfortunate
+    // side effect of not being able to do as many runs is
+    // automatically handled by the statistical analysis below
+    // (i.e., larger error bars).
+    n = cmp::max(1, n);
+
+    // max_iter is too small to run statistically accurate tests
+    // with n iterations per sample. Instead we're measuring only
+    // one iteration per sample.
+    if max_iter < n * 5 {
+        let mut samples = vec![0.0_f64; max_iter as usize];
+        let samples: &mut [f64] = samples.as_mut_slice();
+
+        for p in &mut *samples {
+            *p = ns_iter_inner(inner, 1) as f64;
+        }
+
+        stats::winsorize(samples, 5.0);
+        return stats::Summary::new(samples);
+    }
+
+    // max_iter is now large enough for at least five samples
+    // with n iterations
+    if max_iter < 300 * n {
+        // If possible multiply the sample iterations so we can get more
+        // stable results but still end up with about 40 samples on average.
+        // Example: max_iter = 160 * n => k = n * 4; using 40 iterations
+        let k: u64 = match n.checked_mul(max_iter / (50 * n) + 1) {
+            Some(k) => k,
+            None => n,
+        };
+        let iterations: u64 = max_iter / k;
+
+        let mut samples = vec![0.0_f64; iterations as usize];
+        let samples: &mut [f64] = samples.as_mut_slice();
+
+        for p in &mut *samples {
+            *p = ns_iter_inner(inner, k) as f64 / k as f64;
+        }
+
+        stats::winsorize(samples, 5.0);
+        return stats::Summary::new(samples);
+    }
+
+    // max_iter is large enough to run the loop at least once.
+    // We will keep track of the consumed iterations and only continue looping
+    // if enough iterations are still available.
+    let mut consumed_iterations: u64 = 0;
+
+    let mut total_run = Duration::new(0, 0);
+    let samples: &mut [f64] = &mut [0.0_f64; 50];
+    loop {
+        let loop_start = Instant::now();
+
+        // measure the time of 50 samples running n times each
+        for p in &mut *samples {
+            *p = ns_iter_inner(inner, n) as f64 / n as f64;
+        }
+
+        stats::winsorize(samples, 5.0);
+        let summ = stats::Summary::new(samples);
+
+        // measure the time of 50 samples running n * 5 times each
+        for p in &mut *samples {
+            let ns = ns_iter_inner(inner, 5 * n);
+            *p = ns as f64 / (5 * n) as f64;
+        }
+
+        stats::winsorize(samples, 5.0);
+        let summ5 = stats::Summary::new(samples);
+
+        let loop_run = loop_start.elapsed();
+
+        // So far we've run (50 * n) + (50 * 5 * n) = 300 * n iterations
+        consumed_iterations += 300 * n;
+
+        // If we've run for 100ms and seem to have converged to a
+        // stable median.
+        if loop_run > Duration::from_millis(100)
+            && summ.median_abs_dev_pct < 1.0
+            && summ.median - summ5.median < summ5.median_abs_dev
+        {
+            return summ5;
+        }
+
+        total_run = total_run + loop_run;
+        // Longest we ever run for is 3s.
+        if total_run > Duration::from_secs(3) {
+            return summ5;
+        }
+
+        // If we overflow here just return the results so far. We check a
+        // multiplier of 10 because we're about to multiply by 2 and the
+        // next iteration of the loop will also multiply by 5 (to calculate
+        // the summ5 result)
+        n = match n.checked_mul(10) {
+            Some(_) => n * 2,
+            None => {
+                return summ5;
+            }
+        };
+
+        // Check whether the next iteration of the loop would exceed the limit
+        // specified by max_iter. If it does we just return the current results.
+        if consumed_iterations + n * 300 > max_iter {
+            return summ5;
+        }
     }
 }
 


### PR DESCRIPTION
**The problem**
The Bencher struct of the test library provides the iter method that benchmarks a function. However the amount of executions of the benchmarked function is not limited and only depends on the runtime performance of the function. This makes it hard to benchmark functions that need pre-generated data passed into them.

**Example**
The function bubble_sort should be benchmarked with randomly generated arrays. With each call the bubble_sort function sorts the array that was passed into by reference and therefore consumes the array. This means we need to generate an array for each call of the function yet we don't know how often it will be called because iter doesn't limit the amount of executions. The only workaround is to generate a lot of arrays and hope it will be enough.

**The solution**
I implemented a method for Bencher called iter_max that takes a limit for maximum iterations as second argument. This would make it a lot easier to benchmark bubble_sort and similar functions :)

**Code example**
```rust
#[bench]
fn rust_sort_bench(b: &mut Bencher) {

    // generate 1000 arrays with 10_000 random entries
    let mut arrays = generate_test_arrays(1000, 10_000);
    let mut index = 0;

    // benchmark the sort function but never call it more than 1000 times
    b.iter_max(|| {
        arrays[index].sort();
        // increment the index to select another array next time 
        index += 1;
    }, 1000);
}
```
