### PR TITLE
Don't immediately error for cycles during normalization

### DIFF
--- a/src/librustc_trait_selection/traits/mod.rs
+++ b/src/librustc_trait_selection/traits/mod.rs
@@ -51,9 +51,7 @@ pub use self::object_safety::is_vtable_safe_method;
 pub use self::object_safety::MethodViolationCode;
 pub use self::object_safety::ObjectSafetyViolation;
 pub use self::on_unimplemented::{OnUnimplementedDirective, OnUnimplementedNote};
-pub use self::project::{
-    normalize, normalize_projection_type, normalize_to, poly_project_and_unify_type,
-};
+pub use self::project::{normalize, normalize_projection_type, normalize_to};
 pub use self::select::{EvaluationCache, SelectionCache, SelectionContext};
 pub use self::select::{EvaluationResult, IntercrateAmbiguityCause, OverflowError};
 pub use self::specialize::specialization_graph::FutureCompatOverlapError;

--- a/src/test/ui/associated-types/defaults-cyclic-fail-1.rs
+++ b/src/test/ui/associated-types/defaults-cyclic-fail-1.rs
@@ -26,16 +26,16 @@ impl Tr for u32 {
 
 // ...but only if this actually breaks the cycle
 impl Tr for bool {
-//~^ ERROR overflow evaluating the requirement
+    //~^ ERROR type mismatch resolving `<bool as Tr>::B == _`
     type A = Box<Self::B>;
-    //~^ ERROR overflow evaluating the requirement
+    //~^ ERROR type mismatch resolving `<bool as Tr>::B == _`
 }
 // (the error is shown twice for some reason)
 
 impl Tr for usize {
-//~^ ERROR overflow evaluating the requirement
+    //~^ ERROR type mismatch resolving `<usize as Tr>::B == _`
     type B = &'static Self::A;
-    //~^ ERROR overflow evaluating the requirement
+    //~^ ERROR type mismatch resolving `<usize as Tr>::A == _`
 }
 
 fn main() {

--- a/src/test/ui/associated-types/defaults-cyclic-fail-1.stderr
+++ b/src/test/ui/associated-types/defaults-cyclic-fail-1.stderr
@@ -1,33 +1,34 @@
-error[E0275]: overflow evaluating the requirement `<() as Tr>::B`
+error[E0275]: overflow evaluating the requirement `<() as Tr>::B == _`
   --> $DIR/defaults-cyclic-fail-1.rs:10:6
    |
 LL | impl Tr for () {}
    |      ^^
 
-error[E0275]: overflow evaluating the requirement `<bool as Tr>::B`
+error[E0271]: type mismatch resolving `<bool as Tr>::B == _`
   --> $DIR/defaults-cyclic-fail-1.rs:28:6
    |
 LL | impl Tr for bool {
-   |      ^^
+   |      ^^ cyclic type of infinite size
 
-error[E0275]: overflow evaluating the requirement `<usize as Tr>::B`
+error[E0271]: type mismatch resolving `<usize as Tr>::B == _`
   --> $DIR/defaults-cyclic-fail-1.rs:35:6
    |
 LL | impl Tr for usize {
-   |      ^^
+   |      ^^ cyclic type of infinite size
 
-error[E0275]: overflow evaluating the requirement `<bool as Tr>::B`
+error[E0271]: type mismatch resolving `<bool as Tr>::B == _`
   --> $DIR/defaults-cyclic-fail-1.rs:30:5
    |
 LL |     type A = Box<Self::B>;
-   |     ^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^ cyclic type of infinite size
 
-error[E0275]: overflow evaluating the requirement `<usize as Tr>::A`
+error[E0271]: type mismatch resolving `<usize as Tr>::A == _`
   --> $DIR/defaults-cyclic-fail-1.rs:37:5
    |
 LL |     type B = &'static Self::A;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ cyclic type of infinite size
 
 error: aborting due to 5 previous errors
 
-For more information about this error, try `rustc --explain E0275`.
+Some errors have detailed explanations: E0271, E0275.
+For more information about an error, try `rustc --explain E0271`.

--- a/src/test/ui/associated-types/defaults-cyclic-fail-2.rs
+++ b/src/test/ui/associated-types/defaults-cyclic-fail-2.rs
@@ -10,7 +10,7 @@ trait Tr {
 
 // ...but is an error in any impl that doesn't override at least one of the defaults
 impl Tr for () {}
-//~^ ERROR overflow evaluating the requirement
+//~^ ERROR type mismatch resolving `<() as Tr>::B == _`
 
 // As soon as at least one is redefined, it works:
 impl Tr for u8 {
@@ -28,16 +28,16 @@ impl Tr for u32 {
 
 // ...but only if this actually breaks the cycle
 impl Tr for bool {
-//~^ ERROR overflow evaluating the requirement
+    //~^ ERROR type mismatch resolving `<bool as Tr>::B == _`
     type A = Box<Self::B>;
-    //~^ ERROR overflow evaluating the requirement
+    //~^ ERROR type mismatch resolving `<bool as Tr>::B == _`
 }
 // (the error is shown twice for some reason)
 
 impl Tr for usize {
-//~^ ERROR overflow evaluating the requirement
+    //~^ ERROR type mismatch resolving `<usize as Tr>::B == _`
     type B = &'static Self::A;
-    //~^ ERROR overflow evaluating the requirement
+    //~^ ERROR type mismatch resolving `<usize as Tr>::A == _`
 }
 
 fn main() {

--- a/src/test/ui/associated-types/defaults-cyclic-fail-2.stderr
+++ b/src/test/ui/associated-types/defaults-cyclic-fail-2.stderr
@@ -1,33 +1,33 @@
-error[E0275]: overflow evaluating the requirement `<() as Tr>::B`
+error[E0271]: type mismatch resolving `<() as Tr>::B == _`
   --> $DIR/defaults-cyclic-fail-2.rs:12:6
    |
 LL | impl Tr for () {}
-   |      ^^
+   |      ^^ cyclic type of infinite size
 
-error[E0275]: overflow evaluating the requirement `<bool as Tr>::B`
+error[E0271]: type mismatch resolving `<bool as Tr>::B == _`
   --> $DIR/defaults-cyclic-fail-2.rs:30:6
    |
 LL | impl Tr for bool {
-   |      ^^
+   |      ^^ cyclic type of infinite size
 
-error[E0275]: overflow evaluating the requirement `<usize as Tr>::B`
+error[E0271]: type mismatch resolving `<usize as Tr>::B == _`
   --> $DIR/defaults-cyclic-fail-2.rs:37:6
    |
 LL | impl Tr for usize {
-   |      ^^
+   |      ^^ cyclic type of infinite size
 
-error[E0275]: overflow evaluating the requirement `<bool as Tr>::B`
+error[E0271]: type mismatch resolving `<bool as Tr>::B == _`
   --> $DIR/defaults-cyclic-fail-2.rs:32:5
    |
 LL |     type A = Box<Self::B>;
-   |     ^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^ cyclic type of infinite size
 
-error[E0275]: overflow evaluating the requirement `<usize as Tr>::A`
+error[E0271]: type mismatch resolving `<usize as Tr>::A == _`
   --> $DIR/defaults-cyclic-fail-2.rs:39:5
    |
 LL |     type B = &'static Self::A;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ cyclic type of infinite size
 
 error: aborting due to 5 previous errors
 
-For more information about this error, try `rustc --explain E0275`.
+For more information about this error, try `rustc --explain E0271`.

--- a/src/test/ui/associated-types/normalize-cycle-in-eval-no-region.rs
+++ b/src/test/ui/associated-types/normalize-cycle-in-eval-no-region.rs
@@ -1,0 +1,20 @@
+// Case that the fix for #74868 also allowed to compile
+
+// check-pass
+
+trait BoxedDsl {
+    type Output;
+}
+
+impl<T> BoxedDsl for T
+where
+    T: BoxedDsl,
+{
+    type Output = <T as BoxedDsl>::Output;
+}
+
+trait HandleUpdate {}
+
+impl<T> HandleUpdate for T where T: BoxedDsl<Output = ()> {}
+
+fn main() {}

--- a/src/test/ui/associated-types/normalize-cycle-in-eval.rs
+++ b/src/test/ui/associated-types/normalize-cycle-in-eval.rs
@@ -1,0 +1,43 @@
+// regression test for #74868
+
+// check-pass
+
+trait BoxedDsl<'a> {
+    type Output;
+}
+
+impl<'a, T> BoxedDsl<'a> for T
+where
+    T: BoxedDsl<'a>,
+{
+    type Output = <T as BoxedDsl<'a>>::Output;
+}
+
+// Showing this trait is wf requires proving
+// Self: HandleUpdate
+//
+// The impl below is a candidate for this projection, as well as the `Self:
+// HandleUpdate` bound in the environment.
+// We evaluate both candidates to see if we need to consider both applicable.
+// Evaluating the impl candidate requires evaluating
+// <T as BoxedDsl<'static>>::Output == ()
+// The above impl cause normalizing the above type normalize to itself.
+//
+// This previously compiled because we would generate a new region
+// variable each time around the cycle, and evaluation would eventually return
+// `EvaluatedToErr` from the `Self: Sized` in the impl, which would in turn
+// leave the bound as the only candidate.
+//
+// #73452 changed this so that region variables are canonicalized when we
+// normalize, which means that the projection cycle is detected before
+// evaluation returns EvaluatedToErr. The cycle resulted in an error being
+// emitted immediately, causing this to fail to compile.
+//
+// To fix this, normalization doesn't directly emit errors when it finds a
+// cycle, instead letting the caller handle it. This restores the original
+// behavior.
+trait HandleUpdate {}
+
+impl<T> HandleUpdate for T where T: BoxedDsl<'static, Output = ()> {}
+
+fn main() {}

--- a/src/test/ui/auto-traits/issue-23080-2.rs
+++ b/src/test/ui/auto-traits/issue-23080-2.rs
@@ -1,5 +1,3 @@
-//~ ERROR
-
 #![feature(optin_builtin_traits)]
 #![feature(negative_impls)]
 

--- a/src/test/ui/auto-traits/issue-23080-2.stderr
+++ b/src/test/ui/auto-traits/issue-23080-2.stderr
@@ -1,17 +1,11 @@
 error[E0380]: auto traits cannot have methods or associated items
-  --> $DIR/issue-23080-2.rs:7:10
+  --> $DIR/issue-23080-2.rs:5:10
    |
 LL | unsafe auto trait Trait {
    |                   ----- auto trait cannot have items
 LL |     type Output;
    |          ^^^^^^
 
-error[E0275]: overflow evaluating the requirement `<() as Trait>::Output`
-   |
-   = note: required because of the requirements on the impl of `Trait` for `()`
-   = note: required because of the requirements on the impl of `Trait` for `()`
+error: aborting due to previous error
 
-error: aborting due to 2 previous errors
-
-Some errors have detailed explanations: E0275, E0380.
-For more information about an error, try `rustc --explain E0275`.
+For more information about this error, try `rustc --explain E0380`.

--- a/src/test/ui/issues/issue-21946.rs
+++ b/src/test/ui/issues/issue-21946.rs
@@ -5,9 +5,9 @@ trait Foo {
 struct FooStruct;
 
 impl Foo for FooStruct {
-//~^ ERROR overflow evaluating the requirement `<FooStruct as Foo>::A`
+    //~^ ERROR overflow evaluating the requirement `<FooStruct as Foo>::A == _`
     type A = <FooStruct as Foo>::A;
-    //~^ ERROR overflow evaluating the requirement `<FooStruct as Foo>::A`
+    //~^ ERROR overflow evaluating the requirement `<FooStruct as Foo>::A == _`
 }
 
 fn main() {}

--- a/src/test/ui/issues/issue-21946.stderr
+++ b/src/test/ui/issues/issue-21946.stderr
@@ -1,10 +1,10 @@
-error[E0275]: overflow evaluating the requirement `<FooStruct as Foo>::A`
+error[E0275]: overflow evaluating the requirement `<FooStruct as Foo>::A == _`
   --> $DIR/issue-21946.rs:7:6
    |
 LL | impl Foo for FooStruct {
    |      ^^^
 
-error[E0275]: overflow evaluating the requirement `<FooStruct as Foo>::A`
+error[E0275]: overflow evaluating the requirement `<FooStruct as Foo>::A == _`
   --> $DIR/issue-21946.rs:9:5
    |
 LL |     type A = <FooStruct as Foo>::A;

--- a/src/test/ui/issues/issue-23122-1.stderr
+++ b/src/test/ui/issues/issue-23122-1.stderr
@@ -1,10 +1,10 @@
-error[E0275]: overflow evaluating the requirement `<GetNext<T> as Next>::Next`
+error[E0275]: overflow evaluating the requirement `<GetNext<T> as Next>::Next == _`
   --> $DIR/issue-23122-1.rs:7:15
    |
 LL | impl<T: Next> Next for GetNext<T> {
    |               ^^^^
 
-error[E0275]: overflow evaluating the requirement `<GetNext<T> as Next>::Next`
+error[E0275]: overflow evaluating the requirement `<GetNext<T> as Next>::Next == _`
   --> $DIR/issue-23122-1.rs:9:5
    |
 LL |     type Next = <GetNext<T> as Next>::Next;


### PR DESCRIPTION
#73452 meant some normalization cycles could be detected earlier, breaking some code.
This PR makes defers errors for normalization cycles to fulfillment, fixing said code.

Fixes #74868 

r? @nikomatsakis 