### PR TITLE
Fix documentation error

### DIFF
--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -2030,7 +2030,7 @@ mod traits {
     /// # Panics
     ///
     /// Panics if `begin` does not point to the starting byte offset of
-    /// a character (as defined by `is_char_boundary`), or if `begin >= len`.
+    /// a character (as defined by `is_char_boundary`), or if `begin > len`.
     #[stable(feature = "str_checked_slicing", since = "1.20.0")]
     unsafe impl SliceIndex<str> for ops::RangeFrom<usize> {
         type Output = str;


### PR DESCRIPTION
This should fix #75412. Just a quick >= to > sign replacement.