### PR TITLE
Disable zlib in LLVM on aarch64-apple-darwin

### DIFF
--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -178,7 +178,7 @@ impl Step for Llvm {
             .define("LLVM_TARGET_ARCH", target_native.split('-').next().unwrap())
             .define("LLVM_DEFAULT_TARGET_TRIPLE", target_native);
 
-        if !target.contains("netbsd") {
+        if !target.contains("netbsd") && target != "aarch64-apple-darwin" {
             cfg.define("LLVM_ENABLE_ZLIB", "ON");
         } else {
             // FIXME: Enable zlib on NetBSD too


### PR DESCRIPTION
For some reason, building rustc on the Apple Silicon DTK fails with some undefined symbols from zlib, which I guess is similar to some issues that appeared on *-apple-ios and *-apple-tvos.