### PR TITLE
Clean up some mir transform passes

### DIFF
--- a/src/librustc_mir/transform/deaggregator.rs
+++ b/src/librustc_mir/transform/deaggregator.rs
@@ -12,26 +12,24 @@ impl<'tcx> MirPass<'tcx> for Deaggregator {
         for bb in basic_blocks {
             bb.expand_statements(|stmt| {
                 // FIXME(eddyb) don't match twice on `stmt.kind` (post-NLL).
-                if let StatementKind::Assign(box (_, ref rhs)) = stmt.kind {
-                    if let Rvalue::Aggregate(ref kind, _) = *rhs {
-                        // FIXME(#48193) Deaggregate arrays when it's cheaper to do so.
-                        if let AggregateKind::Array(_) = **kind {
-                            return None;
-                        }
-                    } else {
+                match stmt.kind {
+                    // FIXME(#48193) Deaggregate arrays when it's cheaper to do so.
+                    StatementKind::Assign(box (
+                        _,
+                        Rvalue::Aggregate(box AggregateKind::Array(_), _),
+                    )) => {
                         return None;
                     }
-                } else {
-                    return None;
+                    StatementKind::Assign(box (_, Rvalue::Aggregate(_, _))) => {}
+                    _ => return None,
                 }
 
                 let stmt = stmt.replace_nop();
                 let source_info = stmt.source_info;
                 let (lhs, kind, operands) = match stmt.kind {
-                    StatementKind::Assign(box (lhs, rvalue)) => match rvalue {
-                        Rvalue::Aggregate(kind, operands) => (lhs, kind, operands),
-                        _ => bug!(),
-                    },
+                    StatementKind::Assign(box (lhs, Rvalue::Aggregate(kind, operands))) => {
+                        (lhs, kind, operands)
+                    }
                     _ => bug!(),
                 };
 

--- a/src/librustc_mir/transform/unreachable_prop.rs
+++ b/src/librustc_mir/transform/unreachable_prop.rs
@@ -68,17 +68,6 @@ where
     F: Fn(BasicBlock) -> bool,
 {
     let terminator = match *terminator_kind {
-        TerminatorKind::FalseEdge { real_target, imaginary_target }
-            if predicate(real_target) && predicate(imaginary_target) =>
-        {
-            TerminatorKind::Unreachable
-        }
-        TerminatorKind::FalseUnwind { real_target, unwind }
-            if predicate(real_target) && unwind.map_or(true, &predicate) =>
-        {
-            TerminatorKind::Unreachable
-        }
-
         TerminatorKind::Goto { target } if predicate(target) => TerminatorKind::Unreachable,
         TerminatorKind::SwitchInt { ref discr, switch_ty, ref values, ref targets } => {
             let original_targets_len = targets.len();


### PR DESCRIPTION
I noticed a few places where there were intermediates being created
in MIR optimization passes, so I removed them.

I also changed some `Some(..)` into just `..` and wrap `Some(..)` at the function end, doing early returns for `None`.

I was generally looking for some easy optimizations in theses passes, and hopefully these should improve the runtime of these passes by a tinnnyyyyy bit.

r? @oli-obk 