### PR TITLE
Recover gracefully from `struct` parse errors

### DIFF
--- a/src/librustc_parse/parser/item.rs
+++ b/src/librustc_parse/parser/item.rs
@@ -1313,7 +1313,7 @@ impl<'a> Parser<'a> {
         vis: Visibility,
         attrs: Vec<Attribute>,
     ) -> PResult<'a, StructField> {
-        let name = self.parse_ident()?;
+        let name = self.parse_ident_common(false)?;
         self.expect(&token::Colon)?;
         let ty = self.parse_ty()?;
         Ok(StructField {

--- a/src/test/ui/parser/mismatched-braces/missing-close-brace-in-struct.rs
+++ b/src/test/ui/parser/mismatched-braces/missing-close-brace-in-struct.rs
@@ -2,7 +2,6 @@ pub(crate) struct Bar<T> {
   foo: T,
 
 trait T { //~ ERROR expected identifier, found keyword `trait`
-//~^ ERROR expected `:`, found `T`
     fn foo(&self);
 }
 

--- a/src/test/ui/parser/mismatched-braces/missing-close-brace-in-struct.stderr
+++ b/src/test/ui/parser/mismatched-braces/missing-close-brace-in-struct.stderr
@@ -1,5 +1,5 @@
 error: this file contains an unclosed delimiter
-  --> $DIR/missing-close-brace-in-struct.rs:14:65
+  --> $DIR/missing-close-brace-in-struct.rs:13:65
    |
 LL | pub(crate) struct Bar<T> {
    |                          - unclosed delimiter
@@ -13,11 +13,5 @@ error: expected identifier, found keyword `trait`
 LL | trait T {
    | ^^^^^ expected identifier, found keyword
 
-error: expected `:`, found `T`
-  --> $DIR/missing-close-brace-in-struct.rs:4:7
-   |
-LL | trait T {
-   |       ^ expected `:`
-
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/parser/removed-syntax-field-let.rs
+++ b/src/test/ui/parser/removed-syntax-field-let.rs
@@ -1,7 +1,6 @@
 struct S {
     let foo: (),
     //~^  ERROR expected identifier, found keyword `let`
-    //~^^ ERROR expected `:`, found `foo`
 }
 
 fn main() {}

--- a/src/test/ui/parser/removed-syntax-field-let.stderr
+++ b/src/test/ui/parser/removed-syntax-field-let.stderr
@@ -4,11 +4,5 @@ error: expected identifier, found keyword `let`
 LL |     let foo: (),
    |     ^^^ expected identifier, found keyword
 
-error: expected `:`, found `foo`
-  --> $DIR/removed-syntax-field-let.rs:2:9
-   |
-LL |     let foo: (),
-   |         ^^^ expected `:`
-
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 


### PR DESCRIPTION
Currently the parser tries to recover from finding a keyword where a field name was expected, but this causes extra knock down parse errors that are completely irrelevant. Instead, bail out early in the parsing of the field and consume the remaining tokens in the block. This can reduce output significantly.

_Improvements based on the narrative in https://fasterthanli.me/articles/i-am-a-java-csharp-c-or-cplusplus-dev-time-to-do-some-rust_