### PR TITLE
polymorphize: `I` used if `T` used in `I: Foo<T>`

### DIFF
--- a/src/test/ui/polymorphization/predicates.rs
+++ b/src/test/ui/polymorphization/predicates.rs
@@ -18,7 +18,55 @@ where
     bar::<I>()
 }
 
+#[rustc_polymorphize_error]
+fn baz<I, T>(_: I)
+where
+    std::iter::Repeat<I>: Iterator<Item = T>,
+{
+    bar::<I>()
+}
+
+// In addition, check that `I` is considered used in `next::{{closure}}`, because `T` is used and
+// `T` is really just `I::Item`. `E` is used due to the fixed-point marking of predicates.
+
+pub(crate) struct Foo<'a, I, E>(I, &'a E);
+
+impl<'a, I, T: 'a, E> Iterator for Foo<'a, I, E>
+where
+    I: Iterator<Item = &'a (T, E)>,
+{
+    type Item = T;
+
+    #[rustc_polymorphize_error]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.find(|_| true)
+    }
+}
+
+// Furthermore, check that `B` is considered used because `C` is used, and that `A` is considered
+// used because `B` is now used.
+
+trait Baz<Z> {}
+
+impl Baz<u16> for u8 {}
+impl Baz<u32> for u16 {}
+
+#[rustc_polymorphize_error]
+fn quux<A, B, C: Default>() -> usize
+where
+    A: Baz<B>,
+    B: Baz<C>,
+{
+    std::mem::size_of::<C>()
+}
+
 fn main() {
     let x = &[2u32];
     foo(x.iter());
+    baz(x.iter());
+
+    let mut a = Foo([(1u32, 1u16)].iter(), &1u16);
+    let _ = a.next();
+
+    let _ = quux::<u8, u16, u32>();
 }

--- a/src/test/ui/polymorphization/symbol-ambiguity.rs
+++ b/src/test/ui/polymorphization/symbol-ambiguity.rs
@@ -1,0 +1,22 @@
+// build-pass
+// compile-flags: -Zpolymorphize=on -Zsymbol-mangling-version=v0
+
+pub(crate) struct Foo<'a, I, E>(I, &'a E);
+
+impl<'a, I, T: 'a, E> Iterator for Foo<'a, I, E>
+where
+    I: Iterator<Item = &'a (T, E)>,
+{
+    type Item = T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.find(|_| true)
+    }
+}
+
+fn main() {
+    let mut a = Foo([(1u32, 1u16)].iter(), &1u16);
+    let mut b = Foo([(1u16, 1u32)].iter(), &1u32);
+    let _ = a.next();
+    let _ = b.next();
+}


### PR DESCRIPTION
Fixes #75326.

This PR adjusts polymorphization's handling of predicates so that after ensuring that `T` is used in `I: Foo<T>` if `I` is used, it now ensures that `I` is used if `T` is used in `I: Foo<T>`. This is necessary to mark generic parameters that only exist in impl parameters as used - thereby avoiding symbol clashes when using the new mangling scheme.

With this PR, rustc will now fully bootstrap with polymorphization and the new symbol mangling scheme enabled - not all tests pass, but I'm not sure how much of that is the interaction of the two features, I'll be looking into that soon. All tests pass with only polymorphization enabled.

r? @lcnr (this isn't sufficiently complex that I need to add to eddy's review queue)
cc @eddyb 