### PR TITLE
Add --no-source option flag to rustdoc

### DIFF
--- a/src/doc/rustdoc/src/command-line-arguments.md
+++ b/src/doc/rustdoc/src/command-line-arguments.md
@@ -417,3 +417,21 @@ This flag is **deprecated** and **has no effect**.
 Rustdoc only supports Rust source code and Markdown input formats. If the
 file ends in `.md` or `.markdown`, `rustdoc` treats it as a Markdown file.
 Otherwise, it assumes that the input file is Rust.
+
+## `--no-source`: prevent source code generation in HTML output format generation
+
+Using this flag looks like this:
+
+```bash
+$ rustdoc src/lib.rs --no-source
+```
+
+By default, `rustdoc` renders the source code as HTML and links to it from the documentation. When
+this flag is used, `rustdoc` won't render the source code. `--no-source` is equivalent to the
+`#![doc(html_no_source)]` attribute:
+
+```rust
+// lib.rs
+#![doc(html_no_source)]
+// your code
+```

--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -268,6 +268,8 @@ crate struct RenderOptions {
     crate generate_redirect_map: bool,
     crate unstable_features: rustc_feature::UnstableFeatures,
     crate emit: Vec<EmitType>,
+    /// Whether the source code should be rendered as HTML.
+    pub no_source: bool,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -622,6 +624,7 @@ impl Options {
         let document_hidden = matches.opt_present("document-hidden-items");
         let run_check = matches.opt_present("check");
         let generate_redirect_map = matches.opt_present("generate-redirect-map");
+        let no_source = matches.opt_present("no-source");
 
         let (lint_opts, describe_lints, lint_cap) = get_cmd_lint_options(matches, error_format);
 
@@ -684,6 +687,7 @@ impl Options {
                     crate_name.as_deref(),
                 ),
                 emit,
+                no_source,
             },
             crate_name,
             output_format,

--- a/src/librustdoc/html/render/context.rs
+++ b/src/librustdoc/html/render/context.rs
@@ -331,7 +331,7 @@ impl<'tcx> FormatRenderer<'tcx> for Context<'tcx> {
             generate_search_filter,
         };
         let mut issue_tracker_base_url = None;
-        let mut include_sources = true;
+        let mut include_sources = !options.no_source;
 
         // Crawl the crate attributes looking for attributes which control how we're
         // going to emit HTML

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -533,6 +533,12 @@ fn opts() -> Vec<RustcOptGroup> {
                 "emit",
                 "Comma separated list of types of output for rustdoc to emit",
                 "[unversioned-shared-resources,toolchain-shared-resources,invocation-specific]",
+        stable("no-source", |o| {
+            o.optflag(
+                "",
+                "no-source",
+                "Prevent source code generation in HTML output format generation. \
+                 This is the same as using the `#![doc(html_no_source)]` attribute.",
             )
         }),
     ]

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -533,6 +533,8 @@ fn opts() -> Vec<RustcOptGroup> {
                 "emit",
                 "Comma separated list of types of output for rustdoc to emit",
                 "[unversioned-shared-resources,toolchain-shared-resources,invocation-specific]",
+            )
+        }),
         stable("no-source", |o| {
             o.optflag(
                 "",

--- a/src/test/rustdoc/html_no_source_attr.rs
+++ b/src/test/rustdoc/html_no_source_attr.rs
@@ -1,0 +1,6 @@
+#![doc(html_no_source)]
+#![crate_name = "foo"]
+
+// @!has src/foo/html_no_source_attr.rs.html
+// @has foo/index.html
+// @!has - '//*[@class="srclink"]' '[src]'

--- a/src/test/rustdoc/html_no_source_flag.rs
+++ b/src/test/rustdoc/html_no_source_flag.rs
@@ -1,0 +1,7 @@
+// compile-flags: --no-source
+
+#![crate_name = "foo"]
+
+// @!has src/foo/html_no_source_attr.rs.html
+// @has foo/index.html
+// @!has - '//*[@class="srclink"]' '[src]'

--- a/src/test/rustdoc/html_source.rs
+++ b/src/test/rustdoc/html_source.rs
@@ -1,0 +1,5 @@
+#![crate_name = "foo"]
+
+// @has src/foo/html_source.rs.html
+// @has foo/index.html
+// @has - '//*[@class="srclink"]' '[src]'


### PR DESCRIPTION
Fixes #75497.

A question though: should we go through an unstable phase or not considering the attribute is already stable?