### PR TITLE
Bump yanked crates in Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2381,9 +2381,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.3"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e98a83a9f9b331f54b924e68a66acb1bb35cb01fb0a23645139967abefb697e8"
+checksum = "04f5f085b5d71e2188cb8271e5da0161ad52c3f227a661a3c135fdf28e258b12"
 dependencies = [
  "unicode-xid",
 ]
@@ -2445,9 +2445,9 @@ checksum = "07589615d719a60c8dd8a4622e7946465dfef20d1a428f969e3443e7386d5f45"
 
 [[package]]
 name = "quote"
-version = "1.0.2"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
+checksum = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
 dependencies = [
  "proc-macro2",
 ]
@@ -5036,9 +5036,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
+checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
 name = "unicode_categories"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -546,7 +546,7 @@ dependencies = [
  "regex-syntax",
  "semver 0.9.0",
  "serde",
- "smallvec 1.4.0",
+ "smallvec 1.4.2",
  "syn",
  "toml",
  "unicode-normalization",
@@ -2195,7 +2195,7 @@ dependencies = [
  "cloudabi",
  "libc",
  "redox_syscall",
- "smallvec 1.4.0",
+ "smallvec 1.4.2",
  "winapi 0.3.8",
 ]
 
@@ -2809,7 +2809,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a3941333c39ffa778611a34692244052fc9ba0f6b02dcf019c8d24925707dd6"
 dependencies = [
  "rustc-ap-rustc_data_structures",
- "smallvec 1.4.0",
+ "smallvec 1.4.2",
 ]
 
 [[package]]
@@ -2827,7 +2827,7 @@ dependencies = [
  "rustc-ap-rustc_serialize",
  "rustc-ap-rustc_span",
  "scoped-tls",
- "smallvec 1.4.0",
+ "smallvec 1.4.2",
 ]
 
 [[package]]
@@ -2903,7 +2903,7 @@ dependencies = [
  "rustc-hash",
  "rustc-rayon",
  "rustc-rayon-core",
- "smallvec 1.4.0",
+ "smallvec 1.4.2",
  "stable_deref_trait",
  "stacker",
  "winapi 0.3.8",
@@ -2946,7 +2946,7 @@ dependencies = [
  "rustc-ap-rustc_serialize",
  "rustc-ap-rustc_session",
  "rustc-ap-rustc_span",
- "smallvec 1.4.0",
+ "smallvec 1.4.2",
 ]
 
 [[package]]
@@ -3029,7 +3029,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e8c0b704e3dedb97cbb1ac566bbc0ab397ec4a4743098326a8f2230463fd9f9"
 dependencies = [
  "indexmap",
- "smallvec 1.4.0",
+ "smallvec 1.4.2",
 ]
 
 [[package]]
@@ -3166,7 +3166,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec 0.6.10",
- "smallvec 1.4.0",
+ "smallvec 1.4.2",
  "syn",
  "url 2.1.0",
  "winapi 0.3.8",
@@ -3177,7 +3177,7 @@ name = "rustc_apfloat"
 version = "0.0.0"
 dependencies = [
  "bitflags",
- "smallvec 1.4.0",
+ "smallvec 1.4.2",
 ]
 
 [[package]]
@@ -3185,7 +3185,7 @@ name = "rustc_arena"
 version = "0.0.0"
 dependencies = [
  "rustc_data_structures",
- "smallvec 1.4.0",
+ "smallvec 1.4.2",
 ]
 
 [[package]]
@@ -3199,7 +3199,7 @@ dependencies = [
  "rustc_macros",
  "rustc_serialize",
  "rustc_span",
- "smallvec 1.4.0",
+ "smallvec 1.4.2",
  "tracing",
 ]
 
@@ -3217,7 +3217,7 @@ dependencies = [
  "rustc_session",
  "rustc_span",
  "rustc_target",
- "smallvec 1.4.0",
+ "smallvec 1.4.2",
  "tracing",
 ]
 
@@ -3281,7 +3281,7 @@ dependencies = [
  "rustc_session",
  "rustc_span",
  "rustc_target",
- "smallvec 1.4.0",
+ "smallvec 1.4.2",
  "tracing",
 ]
 
@@ -3310,7 +3310,7 @@ dependencies = [
  "rustc_session",
  "rustc_span",
  "rustc_target",
- "smallvec 1.4.0",
+ "smallvec 1.4.2",
  "tracing",
 ]
 
@@ -3367,7 +3367,7 @@ dependencies = [
  "rustc_index",
  "rustc_macros",
  "rustc_serialize",
- "smallvec 1.4.0",
+ "smallvec 1.4.2",
  "stable_deref_trait",
  "stacker",
  "tempfile",
@@ -3445,7 +3445,7 @@ dependencies = [
  "rustc_serialize",
  "rustc_session",
  "rustc_span",
- "smallvec 1.4.0",
+ "smallvec 1.4.2",
  "tracing",
 ]
 
@@ -3478,7 +3478,7 @@ dependencies = [
  "rustc_serialize",
  "rustc_span",
  "rustc_target",
- "smallvec 1.4.0",
+ "smallvec 1.4.2",
  "tracing",
 ]
 
@@ -3536,7 +3536,7 @@ dependencies = [
  "rustc_session",
  "rustc_span",
  "rustc_target",
- "smallvec 1.4.0",
+ "smallvec 1.4.2",
  "tracing",
 ]
 
@@ -3578,7 +3578,7 @@ dependencies = [
  "rustc_traits",
  "rustc_ty",
  "rustc_typeck",
- "smallvec 1.4.0",
+ "smallvec 1.4.2",
  "tempfile",
  "tracing",
  "winapi 0.3.8",
@@ -3652,7 +3652,7 @@ dependencies = [
  "rustc_session",
  "rustc_span",
  "rustc_target",
- "smallvec 1.4.0",
+ "smallvec 1.4.2",
  "stable_deref_trait",
  "tracing",
  "winapi 0.3.8",
@@ -3683,7 +3683,7 @@ dependencies = [
  "rustc_session",
  "rustc_span",
  "rustc_target",
- "smallvec 1.4.0",
+ "smallvec 1.4.2",
  "tracing",
 ]
 
@@ -3712,7 +3712,7 @@ dependencies = [
  "rustc_span",
  "rustc_target",
  "rustc_trait_selection",
- "smallvec 1.4.0",
+ "smallvec 1.4.2",
  "tracing",
 ]
 
@@ -3735,7 +3735,7 @@ dependencies = [
  "rustc_span",
  "rustc_target",
  "rustc_trait_selection",
- "smallvec 1.4.0",
+ "smallvec 1.4.2",
  "tracing",
 ]
 
@@ -3752,7 +3752,7 @@ dependencies = [
  "rustc_lexer",
  "rustc_session",
  "rustc_span",
- "smallvec 1.4.0",
+ "smallvec 1.4.2",
  "tracing",
  "unicode-normalization",
 ]
@@ -3825,7 +3825,7 @@ dependencies = [
  "rustc_macros",
  "rustc_serialize",
  "rustc_span",
- "smallvec 1.4.0",
+ "smallvec 1.4.2",
  "tracing",
 ]
 
@@ -3849,7 +3849,7 @@ dependencies = [
  "rustc_middle",
  "rustc_session",
  "rustc_span",
- "smallvec 1.4.0",
+ "smallvec 1.4.2",
  "tracing",
 ]
 
@@ -3878,7 +3878,7 @@ version = "0.0.0"
 dependencies = [
  "indexmap",
  "rustc_macros",
- "smallvec 1.4.0",
+ "smallvec 1.4.2",
 ]
 
 [[package]]
@@ -3973,7 +3973,7 @@ dependencies = [
  "rustc_session",
  "rustc_span",
  "rustc_target",
- "smallvec 1.4.0",
+ "smallvec 1.4.2",
  "tracing",
 ]
 
@@ -3991,7 +3991,7 @@ dependencies = [
  "rustc_middle",
  "rustc_span",
  "rustc_trait_selection",
- "smallvec 1.4.0",
+ "smallvec 1.4.2",
  "tracing",
 ]
 
@@ -4029,7 +4029,7 @@ dependencies = [
  "rustc_span",
  "rustc_target",
  "rustc_trait_selection",
- "smallvec 1.4.0",
+ "smallvec 1.4.2",
  "tracing",
 ]
 
@@ -4321,9 +4321,9 @@ checksum = "ab606a9c5e214920bb66c458cd7be8ef094f813f20fe77a54cc7dbfff220d4b7"
 
 [[package]]
 name = "smallvec"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7cb5678e1615754284ec264d9bb5b4c27d2018577fd90ac0ceb578591ed5ee4"
+checksum = "fbee7696b84bbf3d89a1c2eccff0850e3047ed46bfcd2e92c29a2d074d57e252"
 
 [[package]]
 name = "socket2"
@@ -4941,7 +4941,7 @@ dependencies = [
  "parking_lot 0.10.2",
  "regex",
  "sharded-slab",
- "smallvec 1.4.0",
+ "smallvec 1.4.2",
  "tracing-core",
 ]
 
@@ -4998,7 +4998,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5479532badd04e128284890390c1e876ef7a993d0570b3597ae43dfa1d59afa4"
 dependencies = [
- "smallvec 1.4.0",
+ "smallvec 1.4.2",
 ]
 
 [[package]]


### PR DESCRIPTION
While browsing the Cargo.lock, I noticed 1.4.0 was yanked. Apparently there was a (fixed) UB issue. So, bump.