### PR TITLE
Fix RFC-1014 test

### DIFF
--- a/src/test/ui/rfcs/rfc-1014-2.rs
+++ b/src/test/ui/rfcs/rfc-1014-2.rs
@@ -23,7 +23,8 @@ fn close_stdout() {
 #[cfg(windows)]
 fn main() {
     close_stdout();
-    println!("hello world");
+    println!("hello");
+    println!("world");
 }
 
 #[cfg(not(windows))]

--- a/src/test/ui/rfcs/rfc-1014.rs
+++ b/src/test/ui/rfcs/rfc-1014.rs
@@ -30,5 +30,6 @@ fn close_stdout() {
 
 fn main() {
     close_stdout();
-    println!("hello world");
+    println!("hello");
+    println!("world");
 }


### PR DESCRIPTION
Use two printlns when testing that writing to a closed stdout does not
panic. Otherwise the test is ineffective, since the current implementation
silently ignores the error during first println regardless.