### PR TITLE
Add Peekable::until

### DIFF
--- a/library/core/src/iter/adapters/mod.rs
+++ b/library/core/src/iter/adapters/mod.rs
@@ -1706,6 +1706,7 @@ impl<I: Iterator> Peekable<I> {
     /// #![feature(peekable_next_if)]
     /// let mut iter = (0..10).peekable();
     /// assert_eq!(iter.until(|&x| x == 5).collect::<String>(), "1234".to_string());
+    /// assert_eq!(iter.next(), Some(5));
     /// ```
     /// [`skip_while`]: trait.Iterator.html#method.skip_while
     #[unstable(feature = "peekable_next_if", issue = "72480")]

--- a/library/core/src/iter/adapters/mod.rs
+++ b/library/core/src/iter/adapters/mod.rs
@@ -1689,7 +1689,7 @@ impl<I: Iterator> Peekable<I> {
     }
 
     /// Creates an iterator that consumes elements until predicate is
-    /// true, without consuming that last element.
+    /// true, without consuming the last matching element.
     ///
     /// `until()` takes a closure as an argument. It will call this
     /// closure on each element of the iterator, and consume elements

--- a/library/core/src/iter/adapters/mod.rs
+++ b/library/core/src/iter/adapters/mod.rs
@@ -679,11 +679,7 @@ where
     fn next_back_index(&self) -> usize {
         let rem = self.iter.len() % (self.step + 1);
         if self.first_take {
-            if rem == 0 {
-                self.step
-            } else {
-                rem - 1
-            }
+            if rem == 0 { self.step } else { rem - 1 }
         } else {
             rem
         }
@@ -2213,11 +2209,7 @@ where
     I: DoubleEndedIterator + ExactSizeIterator,
 {
     fn next_back(&mut self) -> Option<Self::Item> {
-        if self.len() > 0 {
-            self.iter.next_back()
-        } else {
-            None
-        }
+        if self.len() > 0 { self.iter.next_back() } else { None }
     }
 
     #[inline]
@@ -2247,11 +2239,7 @@ where
             move |acc, x| {
                 n -= 1;
                 let r = fold(acc, x);
-                if n == 0 {
-                    LoopState::Break(r)
-                } else {
-                    LoopState::from_try(r)
-                }
+                if n == 0 { LoopState::Break(r) } else { LoopState::from_try(r) }
             }
         }
 
@@ -2362,11 +2350,7 @@ where
             move |acc, x| {
                 *n -= 1;
                 let r = fold(acc, x);
-                if *n == 0 {
-                    LoopState::Break(r)
-                } else {
-                    LoopState::from_try(r)
-                }
+                if *n == 0 { LoopState::Break(r) } else { LoopState::from_try(r) }
             }
         }
 

--- a/library/core/tests/iter.rs
+++ b/library/core/tests/iter.rs
@@ -226,7 +226,11 @@ impl Iterator for Toggle {
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        if self.is_empty { (0, Some(0)) } else { (1, Some(1)) }
+        if self.is_empty {
+            (0, Some(0))
+        } else {
+            (1, Some(1))
+        }
     }
 }
 
@@ -835,6 +839,17 @@ fn test_iterator_peekable_next_if_eq() {
     assert_eq!(it.next_if_eq("Ludicrous"), Some("Ludicrous".into()));
     assert_eq!(it.next_if_eq("speed"), Some("speed".into()));
     assert_eq!(it.next_if_eq(""), None);
+}
+
+#[test]
+fn test_until_iter() {
+    let xs = "Heart of Gold";
+    let mut it = xs.chars().peekable();
+    {
+        let until = it.until(|&c| c == ' ');
+        assert_eq!(until.collect::<String>(), "Heart".to_string());
+    }
+    assert_eq!(it.collect::<String>(), " of Gold".to_string());
 }
 
 /// This is an iterator that follows the Iterator contract,
@@ -1592,7 +1607,11 @@ fn test_find_map() {
     assert_eq!(iter.next(), Some(&7));
 
     fn half_if_even(x: &isize) -> Option<isize> {
-        if x % 2 == 0 { Some(x / 2) } else { None }
+        if x % 2 == 0 {
+            Some(x / 2)
+        } else {
+            None
+        }
     }
 }
 

--- a/library/core/tests/iter.rs
+++ b/library/core/tests/iter.rs
@@ -226,11 +226,7 @@ impl Iterator for Toggle {
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        if self.is_empty {
-            (0, Some(0))
-        } else {
-            (1, Some(1))
-        }
+        if self.is_empty { (0, Some(0)) } else { (1, Some(1)) }
     }
 }
 
@@ -1607,11 +1603,7 @@ fn test_find_map() {
     assert_eq!(iter.next(), Some(&7));
 
     fn half_if_even(x: &isize) -> Option<isize> {
-        if x % 2 == 0 {
-            Some(x / 2)
-        } else {
-            None
-        }
+        if x % 2 == 0 { Some(x / 2) } else { None }
     }
 }
 


### PR DESCRIPTION
Useful to parse since you can read from an iterator until a specific
predicate becomes true, without consuming the positive item.

Following up on https://github.com/rust-lang/rust/pull/72310#issuecomment-671709257. I've also reused the same "issue", I know nothing about the process.