### PR TITLE
Bump once_cell 1.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1663,9 +1663,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.8"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
+checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
 dependencies = [
  "cfg-if",
 ]
@@ -2014,11 +2014,11 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.1.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6a04cb71e910d0034815600180f62a95bf6e67942d7ab52a166a68c7d7e9cd0"
+checksum = "0b631f7e854af39a1739f401cf34a8a013dfe09eac4fa4dba91e9768bd28168d"
 dependencies = [
- "parking_lot 0.9.0",
+ "parking_lot 0.10.2",
 ]
 
 [[package]]


### PR DESCRIPTION
log had recent yanks, so bumping it.
once_cell 1.1 depended on an old version of parking_lot which depended on a (very) old version of smallvec which had recent UB fixes as noted in #75523, so bumping it. The pre-1.0 of smallvec might not have had the UB, but better to be after and certain the fix is in than before it.

And it :musical_score: works on my machine~ :musical_note: