### PR TITLE
Add a way to limit inheritable handles when spawning child process on Windows

### DIFF
--- a/library/std/src/sys/windows/c.rs
+++ b/library/std/src/sys/windows/c.rs
@@ -13,6 +13,7 @@ pub use self::EXCEPTION_DISPOSITION::*;
 pub use self::FILE_INFO_BY_HANDLE_CLASS::*;
 
 pub type DWORD = c_ulong;
+pub type DWORD_PTR = ULONG_PTR;
 pub type HANDLE = LPVOID;
 pub type HINSTANCE = HANDLE;
 pub type HMODULE = HINSTANCE;
@@ -39,6 +40,7 @@ pub type LPCWSTR = *const WCHAR;
 pub type LPDWORD = *mut DWORD;
 pub type LPHANDLE = *mut HANDLE;
 pub type LPOVERLAPPED = *mut OVERLAPPED;
+pub type LPPROC_THREAD_ATTRIBUTE_LIST = *mut PROC_THREAD_ATTRIBUTE_LIST;
 pub type LPPROCESS_INFORMATION = *mut PROCESS_INFORMATION;
 pub type LPSECURITY_ATTRIBUTES = *mut SECURITY_ATTRIBUTES;
 pub type LPSTARTUPINFO = *mut STARTUPINFO;
@@ -56,7 +58,9 @@ pub type LPWSAOVERLAPPED_COMPLETION_ROUTINE = *mut c_void;
 
 pub type PCONDITION_VARIABLE = *mut CONDITION_VARIABLE;
 pub type PLARGE_INTEGER = *mut c_longlong;
+pub type PSIZE_T = *mut ULONG_PTR;
 pub type PSRWLOCK = *mut SRWLOCK;
+pub type PVOID = *mut c_void;
 
 pub type SOCKET = crate::os::windows::raw::SOCKET;
 pub type socklen_t = c_int;
@@ -100,6 +104,8 @@ pub const FILE_FLAG_BACKUP_SEMANTICS: DWORD = 0x02000000;
 pub const SECURITY_SQOS_PRESENT: DWORD = 0x00100000;
 
 pub const FIONBIO: c_ulong = 0x8004667e;
+
+pub const PROC_THREAD_ATTRIBUTE_HANDLE_LIST: DWORD_PTR = 0x00020002;
 
 #[repr(C)]
 #[derive(Copy)]
@@ -217,6 +223,7 @@ pub const CONDITION_VARIABLE_INIT: CONDITION_VARIABLE = CONDITION_VARIABLE { ptr
 pub const SRWLOCK_INIT: SRWLOCK = SRWLOCK { ptr: ptr::null_mut() };
 
 pub const DETACHED_PROCESS: DWORD = 0x00000008;
+pub const EXTENDED_STARTUPINFO_PRESENT: DWORD = 0x00080000;
 pub const CREATE_NEW_PROCESS_GROUP: DWORD = 0x00000200;
 pub const CREATE_UNICODE_ENVIRONMENT: DWORD = 0x00000400;
 pub const STARTF_USESTDHANDLES: DWORD = 0x00000100;
@@ -484,6 +491,11 @@ pub struct SECURITY_ATTRIBUTES {
 }
 
 #[repr(C)]
+pub struct PROC_THREAD_ATTRIBUTE_LIST {
+    pub dummy: *mut c_void,
+}
+
+#[repr(C)]
 pub struct PROCESS_INFORMATION {
     pub hProcess: HANDLE,
     pub hThread: HANDLE,
@@ -511,6 +523,12 @@ pub struct STARTUPINFO {
     pub hStdInput: HANDLE,
     pub hStdOutput: HANDLE,
     pub hStdError: HANDLE,
+}
+
+#[repr(C)]
+pub struct STARTUPINFOEX {
+    pub StartupInfo: STARTUPINFO,
+    pub lpAttributeList: LPPROC_THREAD_ATTRIBUTE_LIST,
 }
 
 #[repr(C)]
@@ -886,6 +904,23 @@ extern "system" {
         lpDefaultChar: LPCSTR,
         lpUsedDefaultChar: LPBOOL,
     ) -> c_int;
+
+    pub fn InitializeProcThreadAttributeList(
+        lpAttributeList: LPPROC_THREAD_ATTRIBUTE_LIST,
+        dwAttributeCount: DWORD,
+        dwFlags: DWORD,
+        lpSize: PSIZE_T,
+    ) -> BOOL;
+    pub fn UpdateProcThreadAttribute(
+        lpAttributeList: LPPROC_THREAD_ATTRIBUTE_LIST,
+        dwFlags: DWORD,
+        Attribute: DWORD_PTR,
+        lpValue: PVOID,
+        cbSize: SIZE_T,
+        lpPreviousValue: PVOID,
+        lpReturnSize: PSIZE_T,
+    ) -> BOOL;
+    pub fn DeleteProcThreadAttributeList(lpAttributeList: LPPROC_THREAD_ATTRIBUTE_LIST);
 
     pub fn closesocket(socket: SOCKET) -> c_int;
     pub fn recv(socket: SOCKET, buf: *mut c_void, len: c_int, flags: c_int) -> c_int;

--- a/library/std/src/sys/windows/ext/process.rs
+++ b/library/std/src/sys/windows/ext/process.rs
@@ -102,12 +102,42 @@ pub trait CommandExt {
     /// [1]: https://docs.microsoft.com/en-us/windows/win32/procthread/process-creation-flags
     #[stable(feature = "windows_process_extensions", since = "1.16.0")]
     fn creation_flags(&mut self, flags: u32) -> &mut process::Command;
+
+    /// Specifies additional [inheritable handles][1] for `CreateProcess`.
+    ///
+    /// Handles must be created as inheritable and must not be pseudo
+    /// such as those returned by the `GetCurrentProcess`.
+    ///
+    /// Handles for stdio redirection are always inherited. Handles are
+    /// passed via `STARTUPINFOEX`. Process creation flags will be ORed
+    /// by `EXTENDED_STARTUPINFO_PRESENT` automatically.
+    ///
+    /// Calling this function multiple times is equivalent to calling
+    /// one time with a chained iterator.
+    ///
+    /// If this function is not called, all inheritable handles will be
+    /// inherited. Note this may change in the future.
+    ///
+    /// [1]: https://docs.microsoft.com/en-us/windows/win32/procthread/inheritance#inheriting-handles
+    #[unstable(feature = "windows_process_inherit_handles", issue = "none")]
+    fn inherit_handles(
+        &mut self,
+        handles: impl IntoIterator<Item = RawHandle>,
+    ) -> &mut process::Command;
 }
 
 #[stable(feature = "windows_process_extensions", since = "1.16.0")]
 impl CommandExt for process::Command {
     fn creation_flags(&mut self, flags: u32) -> &mut process::Command {
         self.as_inner_mut().creation_flags(flags);
+        self
+    }
+
+    fn inherit_handles(
+        &mut self,
+        handles: impl IntoIterator<Item = RawHandle>,
+    ) -> &mut process::Command {
+        self.as_inner_mut().inherit_handles(handles.into_iter().collect());
         self
     }
 }


### PR DESCRIPTION
This is basically an implementation requested by #73281. The API is opt-in. The default behavior remains unchanged.

I read some contributing guidelines about RFC or not, tracking issues, etc. I'm relatively new and open to suggestions about best practice. I think the implementation is relatively straightforward with little room for design discussion. An RFC feels too heavyweight in this case. I plan to add a tracking issue (and update the code to point to it) after some consensus on the feature / API names and parameters.