### PR TITLE
Add fn on types for layout of variants

### DIFF
--- a/src/librustc_middle/query/mod.rs
+++ b/src/librustc_middle/query/mod.rs
@@ -884,6 +884,7 @@ rustc_queries! {
         query is_sized_raw(env: ty::ParamEnvAnd<'tcx, Ty<'tcx>>) -> bool {
             desc { "computing whether `{}` is `Sized`", env.value }
         }
+
         /// Query backing `TyS::is_freeze`.
         query is_freeze_raw(env: ty::ParamEnvAnd<'tcx, Ty<'tcx>>) -> bool {
             desc { "computing whether `{}` is freeze", env.value }


### PR DESCRIPTION
~~This creates a query(I believe?) for the variants of types, which can later be used in #54360.
Edit: Looking at this again, I'm not particularly sure how to connect the query system & the actual function call.
2nd Edit: I realize that I'm missing a call to modify the `Providers` struct, but I'm not quite sure where to put it. As well, I'm not sure if this is even necessary because I can return an iterator to the layouts of each of the variants, which also contains a size field which is good enough for my use case.~~

This just creates a function on type which returns an iterator of reference to the layouts of the types.

I have no idea who to request for review here, and/or what about this PR should watch out for.