### PR TITLE
Move to intra-doc links for /library/core/src/char/convert.rs

### DIFF
--- a/library/core/src/char/convert.rs
+++ b/library/core/src/char/convert.rs
@@ -23,9 +23,6 @@ use super::MAX;
 /// [`char`]s. `from_u32()` will return `None` if the input is not a valid value
 /// for a [`char`].
 ///
-/// [`char`]: crate::char
-/// [`u32`]: crate::u32
-///
 /// For an unsafe version of this function which ignores these checks, see
 /// [`from_u32_unchecked`].
 ///
@@ -71,9 +68,6 @@ pub fn from_u32(i: u32) -> Option<char> {
 /// However, the reverse is not true: not all valid [`u32`]s are valid
 /// [`char`]s. `from_u32_unchecked()` will ignore this, and blindly cast to
 /// [`char`], possibly creating an invalid one.
-///
-/// [`char`]: crate::char
-/// [`u32`]: crate::u32
 ///
 /// # Safety
 ///

--- a/library/core/src/char/convert.rs
+++ b/library/core/src/char/convert.rs
@@ -23,13 +23,11 @@ use super::MAX;
 /// [`char`]s. `from_u32()` will return `None` if the input is not a valid value
 /// for a [`char`].
 ///
-/// [`char`]: ../../std/primitive.char.html
-/// [`u32`]: ../../std/primitive.u32.html
+/// [`char`]: crate::char
+/// [`u32`]: crate::u32
 ///
 /// For an unsafe version of this function which ignores these checks, see
 /// [`from_u32_unchecked`].
-///
-/// [`from_u32_unchecked`]: fn.from_u32_unchecked.html
 ///
 /// # Examples
 ///
@@ -74,16 +72,14 @@ pub fn from_u32(i: u32) -> Option<char> {
 /// [`char`]s. `from_u32_unchecked()` will ignore this, and blindly cast to
 /// [`char`], possibly creating an invalid one.
 ///
-/// [`char`]: ../../std/primitive.char.html
-/// [`u32`]: ../../std/primitive.u32.html
+/// [`char`]: crate::char
+/// [`u32`]: crate::u32
 ///
 /// # Safety
 ///
 /// This function is unsafe, as it may construct invalid `char` values.
 ///
 /// For a safe version of this function, see the [`from_u32`] function.
-///
-/// [`from_u32`]: fn.from_u32.html
 ///
 /// # Examples
 ///


### PR DESCRIPTION
Helps with #75080.

@rustbot modify labels: T-doc, A-intra-doc-links, T-rustdoc

