### PR TITLE
Add rustc-docs as a component

### DIFF
--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -501,6 +501,7 @@ impl Builder {
         // for users to install the additional component manually, if needed.
         if self.rust_release == "nightly" {
             self.extend_profile("complete", &mut manifest.profiles, &["rustc-dev"]);
+            self.extend_profile("complete", &mut manifest.profiles, &["rustc-docs"]);
         }
     }
 
@@ -576,6 +577,7 @@ impl Builder {
                 .map(|target| Component::from_str("rust-std", target)),
         );
         extensions.extend(HOSTS.iter().map(|target| Component::from_str("rustc-dev", target)));
+        extensions.extend(HOSTS.iter().map(|target| Component::from_str("rustc-docs", target)));
         extensions.push(Component::from_str("rust-src", "*"));
 
         // If the components/extensions don't actually exist for this


### PR DESCRIPTION
Previously it was listed as a package but wasn't available in the component
lists in rustup, so wasn't actually installable.

rustc-docs is also only present for x86_64-unknown-linux-gnu. Eventually it'll
also be shipped for aarch64-gnu with current CI configuration, but that builder
isn't quite up and running yet.

We probably want to ship compiler docs for other platforms as well, though, but
this commit doesn't enable that quite yet. A future PR may do so by adding
--enable-compiler-docs to the relevant builders (but it would also need to
decide the set of builders which we'd ship on).

r? @matthiaskrgr 