### PR TITLE
Doc: String isn't a collection

### DIFF
--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -1543,11 +1543,10 @@ pub trait Iterator {
     /// collection into another. You take a collection, call [`iter`] on it,
     /// do a bunch of transformations, and then `collect()` at the end.
     ///
-    /// One of the keys to `collect()`'s power is that many things you might
-    /// not think of as 'collections' actually are. For example, a [`String`]
-    /// is a collection of [`char`]s. And a collection of
-    /// [`Result<T, E>`][`Result`] can be thought of as single
-    /// [`Result`]`<Collection<T>, E>`. See the examples below for more.
+    /// `collect()` can also create instances of types that are not typical
+    /// collections. For example, a [`String`] can be built from [`char`]s,
+    /// and an iterator of [`Result<T, E>`][`Result`] items can be collected
+    /// into `Result<Collection<T>, E>`. See the examples below for more.
     ///
     /// Because `collect()` is so general, it can cause problems with type
     /// inference. As such, `collect()` is one of the few times you'll see


### PR DESCRIPTION
On forums one user was confused by this text, interpreting it as saying that `String` is a `Vec<char>` literally, rather than figuratively for the purpose of collect. I've reworded that paragraph.
