### PR TITLE
Switch to intra-doc links in std/src/sys/vxworks/ext/{fs,process}.rs

### DIFF
--- a/library/std/src/sys/vxworks/ext/fs.rs
+++ b/library/std/src/sys/vxworks/ext/fs.rs
@@ -223,7 +223,6 @@ impl FileExt for fs::File {
 }
 
 /// Unix-specific extensions to [`fs::Permissions`].
-///
 #[stable(feature = "fs_ext", since = "1.1.0")]
 pub trait PermissionsExt {
     /// Returns the underlying raw `st_mode` bits that contain the standard
@@ -299,7 +298,6 @@ impl PermissionsExt for Permissions {
 }
 
 /// Unix-specific extensions to [`fs::OpenOptions`].
-///
 #[stable(feature = "fs_ext", since = "1.1.0")]
 pub trait OpenOptionsExt {
     /// Sets the mode bits that a new file will be created with.
@@ -367,7 +365,6 @@ impl OpenOptionsExt for OpenOptions {
 */
 
 /// Unix-specific extensions to [`fs::Metadata`].
-///
 #[stable(feature = "metadata_ext", since = "1.1.0")]
 pub trait MetadataExt {
     /// Returns the ID of the device containing the file.
@@ -746,7 +743,6 @@ impl FileTypeExt for fs::FileType {
 }
 
 /// Unix-specific extension methods for [`fs::DirEntry`].
-///
 #[stable(feature = "dir_entry_ext", since = "1.1.0")]
 pub trait DirEntryExt {
     /// Returns the underlying `d_ino` field in the contained `dirent`
@@ -807,7 +803,6 @@ pub fn symlink<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q) -> io::Result<()>
 }
 
 /// Unix-specific extensions to [`fs::DirBuilder`].
-///
 #[stable(feature = "dir_builder", since = "1.6.0")]
 pub trait DirBuilderExt {
     /// Sets the mode to create new directories with. This option defaults to

--- a/library/std/src/sys/vxworks/ext/fs.rs
+++ b/library/std/src/sys/vxworks/ext/fs.rs
@@ -9,7 +9,7 @@ use crate::sys_common::{AsInner, AsInnerMut, FromInner};
 
 /// Unix-specific extensions to [`File`].
 ///
-/// [`File`]: crate::fs::File
+/// [`File`]: fs::File
 #[stable(feature = "file_offset", since = "1.15.0")]
 pub trait FileExt {
     /// Reads a number of bytes starting from a given offset.
@@ -24,7 +24,7 @@ pub trait FileExt {
     /// Note that similar to [`File::read`], it is not an error to return with a
     /// short read.
     ///
-    /// [`File::read`]: crate::fs::File::read
+    /// [`File::read`]: fs::File::read
     ///
     /// # Examples
     ///
@@ -55,7 +55,7 @@ pub trait FileExt {
     ///
     /// Similar to [`Read::read_exact`] but uses [`read_at`] instead of `read`.
     ///
-    /// [`Read::read_exact`]: crate::io::Read::read_exact
+    /// [`Read::read_exact`]: io::Read::read_exact
     /// [`read_at`]: FileExt::read_at
     ///
     /// # Errors
@@ -75,8 +75,8 @@ pub trait FileExt {
     /// has read, but it will never read more than would be necessary to
     /// completely fill the buffer.
     ///
-    /// [`ErrorKind::Interrupted`]: crate::io::ErrorKind::Interrupted
-    /// [`ErrorKind::UnexpectedEof`]: crate::io::ErrorKind::UnexpectedEof
+    /// [`ErrorKind::Interrupted`]: io::ErrorKind::Interrupted
+    /// [`ErrorKind::UnexpectedEof`]: io::ErrorKind::UnexpectedEof
     ///
     /// # Examples
     ///
@@ -132,7 +132,7 @@ pub trait FileExt {
     /// Note that similar to [`File::write`], it is not an error to return a
     /// short write.
     ///
-    /// [`File::write`]: crate::fs::File::write
+    /// [`File::write`]: fs::File::write
     ///
     /// # Examples
     ///
@@ -171,7 +171,7 @@ pub trait FileExt {
     /// This function will return the first error of
     /// non-[`ErrorKind::Interrupted`] kind that [`write_at`] returns.
     ///
-    /// [`ErrorKind::Interrupted`]: crate::io::ErrorKind::Interrupted
+    /// [`ErrorKind::Interrupted`]: io::ErrorKind::Interrupted
     /// [`write_at`]: FileExt::write_at
     ///
     /// # Examples
@@ -224,7 +224,6 @@ impl FileExt for fs::File {
 
 /// Unix-specific extensions to [`fs::Permissions`].
 ///
-/// [`fs::Permissions`]: crate::fs::Permissions
 #[stable(feature = "fs_ext", since = "1.1.0")]
 pub trait PermissionsExt {
     /// Returns the underlying raw `st_mode` bits that contain the standard
@@ -301,7 +300,6 @@ impl PermissionsExt for Permissions {
 
 /// Unix-specific extensions to [`fs::OpenOptions`].
 ///
-/// [`fs::OpenOptions`]: crate::fs::OpenOptions
 #[stable(feature = "fs_ext", since = "1.1.0")]
 pub trait OpenOptionsExt {
     /// Sets the mode bits that a new file will be created with.
@@ -370,7 +368,6 @@ impl OpenOptionsExt for OpenOptions {
 
 /// Unix-specific extensions to [`fs::Metadata`].
 ///
-/// [`fs::Metadata`]: crate::fs::Metadata
 #[stable(feature = "metadata_ext", since = "1.1.0")]
 pub trait MetadataExt {
     /// Returns the ID of the device containing the file.
@@ -655,7 +652,7 @@ impl MetadataExt for fs::Metadata {
 /// Adds support for special Unix file types such as block/character devices,
 /// pipes, and sockets.
 ///
-/// [`FileType`]: crate::fs::FileType
+/// [`FileType`]: fs::FileType
 #[stable(feature = "file_type_ext", since = "1.5.0")]
 pub trait FileTypeExt {
     /// Returns whether this file type is a block device.
@@ -750,7 +747,6 @@ impl FileTypeExt for fs::FileType {
 
 /// Unix-specific extension methods for [`fs::DirEntry`].
 ///
-/// [`fs::DirEntry`]: crate::fs::DirEntry
 #[stable(feature = "dir_entry_ext", since = "1.1.0")]
 pub trait DirEntryExt {
     /// Returns the underlying `d_ino` field in the contained `dirent`
@@ -812,7 +808,6 @@ pub fn symlink<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q) -> io::Result<()>
 
 /// Unix-specific extensions to [`fs::DirBuilder`].
 ///
-/// [`fs::DirBuilder`]: crate::fs::DirBuilder
 #[stable(feature = "dir_builder", since = "1.6.0")]
 pub trait DirBuilderExt {
     /// Sets the mode to create new directories with. This option defaults to

--- a/library/std/src/sys/vxworks/ext/fs.rs
+++ b/library/std/src/sys/vxworks/ext/fs.rs
@@ -7,9 +7,7 @@ use crate::sys;
 use crate::sys::platform::fs::MetadataExt as UnixMetadataExt;
 use crate::sys_common::{AsInner, AsInnerMut, FromInner};
 
-/// Unix-specific extensions to [`File`].
-///
-/// [`File`]: fs::File
+/// Unix-specific extensions to [`fs::File`].
 #[stable(feature = "file_offset", since = "1.15.0")]
 pub trait FileExt {
     /// Reads a number of bytes starting from a given offset.
@@ -644,12 +642,10 @@ impl MetadataExt for fs::Metadata {
     }
 }
 
-/// Unix-specific extensions for [`FileType`].
+/// Unix-specific extensions for [`fs::FileType`].
 ///
 /// Adds support for special Unix file types such as block/character devices,
 /// pipes, and sockets.
-///
-/// [`FileType`]: fs::FileType
 #[stable(feature = "file_type_ext", since = "1.5.0")]
 pub trait FileTypeExt {
     /// Returns whether this file type is a block device.

--- a/library/std/src/sys/vxworks/ext/fs.rs
+++ b/library/std/src/sys/vxworks/ext/fs.rs
@@ -9,7 +9,7 @@ use crate::sys_common::{AsInner, AsInnerMut, FromInner};
 
 /// Unix-specific extensions to [`File`].
 ///
-/// [`File`]: ../../../../std/fs/struct.File.html
+/// [`File`]: crate::fs::File
 #[stable(feature = "file_offset", since = "1.15.0")]
 pub trait FileExt {
     /// Reads a number of bytes starting from a given offset.
@@ -24,7 +24,7 @@ pub trait FileExt {
     /// Note that similar to [`File::read`], it is not an error to return with a
     /// short read.
     ///
-    /// [`File::read`]: ../../../../std/fs/struct.File.html#method.read
+    /// [`File::read`]: crate::fs::File::read
     ///
     /// # Examples
     ///
@@ -55,8 +55,8 @@ pub trait FileExt {
     ///
     /// Similar to [`Read::read_exact`] but uses [`read_at`] instead of `read`.
     ///
-    /// [`Read::read_exact`]: ../../../../std/io/trait.Read.html#method.read_exact
-    /// [`read_at`]: #tymethod.read_at
+    /// [`Read::read_exact`]: crate::io::Read::read_exact
+    /// [`read_at`]: FileExt::read_at
     ///
     /// # Errors
     ///
@@ -75,8 +75,8 @@ pub trait FileExt {
     /// has read, but it will never read more than would be necessary to
     /// completely fill the buffer.
     ///
-    /// [`ErrorKind::Interrupted`]: ../../../../std/io/enum.ErrorKind.html#variant.Interrupted
-    /// [`ErrorKind::UnexpectedEof`]: ../../../../std/io/enum.ErrorKind.html#variant.UnexpectedEof
+    /// [`ErrorKind::Interrupted`]: crate::io::ErrorKind::Interrupted
+    /// [`ErrorKind::UnexpectedEof`]: crate::io::ErrorKind::UnexpectedEof
     ///
     /// # Examples
     ///
@@ -132,7 +132,7 @@ pub trait FileExt {
     /// Note that similar to [`File::write`], it is not an error to return a
     /// short write.
     ///
-    /// [`File::write`]: ../../../../std/fs/struct.File.html#method.write
+    /// [`File::write`]: crate::fs::File::write
     ///
     /// # Examples
     ///
@@ -171,8 +171,8 @@ pub trait FileExt {
     /// This function will return the first error of
     /// non-[`ErrorKind::Interrupted`] kind that [`write_at`] returns.
     ///
-    /// [`ErrorKind::Interrupted`]: ../../../../std/io/enum.ErrorKind.html#variant.Interrupted
-    /// [`write_at`]: #tymethod.write_at
+    /// [`ErrorKind::Interrupted`]: crate::io::ErrorKind::Interrupted
+    /// [`write_at`]: FileExt::write_at
     ///
     /// # Examples
     ///
@@ -224,7 +224,7 @@ impl FileExt for fs::File {
 
 /// Unix-specific extensions to [`fs::Permissions`].
 ///
-/// [`fs::Permissions`]: ../../../../std/fs/struct.Permissions.html
+/// [`fs::Permissions`]: crate::fs::Permissions
 #[stable(feature = "fs_ext", since = "1.1.0")]
 pub trait PermissionsExt {
     /// Returns the underlying raw `st_mode` bits that contain the standard
@@ -301,7 +301,7 @@ impl PermissionsExt for Permissions {
 
 /// Unix-specific extensions to [`fs::OpenOptions`].
 ///
-/// [`fs::OpenOptions`]: ../../../../std/fs/struct.OpenOptions.html
+/// [`fs::OpenOptions`]: crate::fs::OpenOptions
 #[stable(feature = "fs_ext", since = "1.1.0")]
 pub trait OpenOptionsExt {
     /// Sets the mode bits that a new file will be created with.
@@ -370,7 +370,7 @@ impl OpenOptionsExt for OpenOptions {
 
 /// Unix-specific extensions to [`fs::Metadata`].
 ///
-/// [`fs::Metadata`]: ../../../../std/fs/struct.Metadata.html
+/// [`fs::Metadata`]: crate::fs::Metadata
 #[stable(feature = "metadata_ext", since = "1.1.0")]
 pub trait MetadataExt {
     /// Returns the ID of the device containing the file.
@@ -655,7 +655,7 @@ impl MetadataExt for fs::Metadata {
 /// Adds support for special Unix file types such as block/character devices,
 /// pipes, and sockets.
 ///
-/// [`FileType`]: ../../../../std/fs/struct.FileType.html
+/// [`FileType`]: crate::fs::FileType
 #[stable(feature = "file_type_ext", since = "1.5.0")]
 pub trait FileTypeExt {
     /// Returns whether this file type is a block device.
@@ -750,7 +750,7 @@ impl FileTypeExt for fs::FileType {
 
 /// Unix-specific extension methods for [`fs::DirEntry`].
 ///
-/// [`fs::DirEntry`]: ../../../../std/fs/struct.DirEntry.html
+/// [`fs::DirEntry`]: crate::fs::DirEntry
 #[stable(feature = "dir_entry_ext", since = "1.1.0")]
 pub trait DirEntryExt {
     /// Returns the underlying `d_ino` field in the contained `dirent`
@@ -812,7 +812,7 @@ pub fn symlink<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q) -> io::Result<()>
 
 /// Unix-specific extensions to [`fs::DirBuilder`].
 ///
-/// [`fs::DirBuilder`]: ../../../../std/fs/struct.DirBuilder.html
+/// [`fs::DirBuilder`]: crate::fs::DirBuilder
 #[stable(feature = "dir_builder", since = "1.6.0")]
 pub trait DirBuilderExt {
     /// Sets the mode to create new directories with. This option defaults to

--- a/library/std/src/sys/vxworks/ext/process.rs
+++ b/library/std/src/sys/vxworks/ext/process.rs
@@ -11,7 +11,6 @@ use crate::sys_common::{AsInner, AsInnerMut, FromInner, IntoInner};
 
 /// Unix-specific extensions to the [`process::Command`] builder.
 ///
-/// [`process::Command`]: crate::process::Command
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait CommandExt {
     /// Sets the child process's user ID. This translates to a
@@ -94,7 +93,6 @@ pub trait CommandExt {
     /// a new child. Like spawn, however, the default behavior for the stdio
     /// descriptors will be to inherited from the current process.
     ///
-    /// [`process::exit`]: crate::process::exit
     ///
     /// # Notes
     ///
@@ -152,7 +150,6 @@ impl CommandExt for process::Command {
 
 /// Unix-specific extensions to [`process::ExitStatus`].
 ///
-/// [`process::ExitStatus`]: crate::process::ExitStatus
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait ExitStatusExt {
     /// Creates a new `ExitStatus` from the raw underlying `i32` return value of

--- a/library/std/src/sys/vxworks/ext/process.rs
+++ b/library/std/src/sys/vxworks/ext/process.rs
@@ -10,7 +10,6 @@ use crate::sys::vxworks::ext::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 use crate::sys_common::{AsInner, AsInnerMut, FromInner, IntoInner};
 
 /// Unix-specific extensions to the [`process::Command`] builder.
-///
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait CommandExt {
     /// Sets the child process's user ID. This translates to a
@@ -149,7 +148,6 @@ impl CommandExt for process::Command {
 }
 
 /// Unix-specific extensions to [`process::ExitStatus`].
-///
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait ExitStatusExt {
     /// Creates a new `ExitStatus` from the raw underlying `i32` return value of

--- a/library/std/src/sys/vxworks/ext/process.rs
+++ b/library/std/src/sys/vxworks/ext/process.rs
@@ -11,7 +11,7 @@ use crate::sys_common::{AsInner, AsInnerMut, FromInner, IntoInner};
 
 /// Unix-specific extensions to the [`process::Command`] builder.
 ///
-/// [`process::Command`]: ../../../../std/process/struct.Command.html
+/// [`process::Command`]: crate::process::Command
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait CommandExt {
     /// Sets the child process's user ID. This translates to a
@@ -65,7 +65,7 @@ pub trait CommandExt {
     /// This method is stable and usable, but it should be unsafe. To fix
     /// that, it got deprecated in favor of the unsafe [`pre_exec`].
     ///
-    /// [`pre_exec`]: #tymethod.pre_exec
+    /// [`pre_exec`]: CommandExt::pre_exec
     #[stable(feature = "process_exec", since = "1.15.0")]
     #[rustc_deprecated(since = "1.37.0", reason = "should be unsafe, use `pre_exec` instead")]
     fn before_exec<F>(&mut self, f: F) -> &mut process::Command
@@ -94,7 +94,7 @@ pub trait CommandExt {
     /// a new child. Like spawn, however, the default behavior for the stdio
     /// descriptors will be to inherited from the current process.
     ///
-    /// [`process::exit`]: ../../../process/fn.exit.html
+    /// [`process::exit`]: crate::process::exit
     ///
     /// # Notes
     ///
@@ -152,7 +152,7 @@ impl CommandExt for process::Command {
 
 /// Unix-specific extensions to [`process::ExitStatus`].
 ///
-/// [`process::ExitStatus`]: ../../../../std/process/struct.ExitStatus.html
+/// [`process::ExitStatus`]: crate::process::ExitStatus
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait ExitStatusExt {
     /// Creates a new `ExitStatus` from the raw underlying `i32` return value of


### PR DESCRIPTION
Partial fix for #75080

@rustbot modify labels: T-doc, A-intra-doc-links, T-rustdoc

r? @jyn514

