### PR TITLE
Move CloudABI to tier 3.

### DIFF
--- a/src/ci/docker/host-x86_64/dist-various-2/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-various-2/Dockerfile
@@ -61,8 +61,6 @@ RUN env \
 
 WORKDIR /tmp
 COPY host-x86_64/dist-various-2/shared.sh /tmp/
-COPY host-x86_64/dist-various-2/build-cloudabi-toolchain.sh /tmp/
-RUN /tmp/build-cloudabi-toolchain.sh x86_64-unknown-cloudabi
 COPY host-x86_64/dist-various-2/build-fuchsia-toolchain.sh /tmp/
 RUN /tmp/build-fuchsia-toolchain.sh
 COPY host-x86_64/dist-various-2/build-solaris-toolchain.sh /tmp/
@@ -97,7 +95,6 @@ ENV TARGETS=$TARGETS,wasm32-wasi
 ENV TARGETS=$TARGETS,sparcv9-sun-solaris
 ENV TARGETS=$TARGETS,x86_64-sun-solaris
 ENV TARGETS=$TARGETS,x86_64-unknown-linux-gnux32
-ENV TARGETS=$TARGETS,x86_64-unknown-cloudabi
 ENV TARGETS=$TARGETS,x86_64-fortanix-unknown-sgx
 ENV TARGETS=$TARGETS,nvptx64-nvidia-cuda
 ENV TARGETS=$TARGETS,armv7-unknown-linux-gnueabi

--- a/src/ci/docker/host-x86_64/dist-various-2/build-x86_64-fortanix-unknown-sgx-toolchain.sh
+++ b/src/ci/docker/host-x86_64/dist-various-2/build-x86_64-fortanix-unknown-sgx-toolchain.sh
@@ -7,7 +7,7 @@ target="x86_64-fortanix-unknown-sgx"
 
 install_prereq() {
     curl https://apt.llvm.org/llvm-snapshot.gpg.key|apt-key add -
-    add-apt-repository -y 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic main'
+    add-apt-repository -y 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-11 main'
     apt-get update
     apt-get install -y --no-install-recommends \
             build-essential \

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -128,7 +128,6 @@ target | std | host | notes
 `x86_64-linux-android` | ✓ |  | 64-bit x86 Android
 `x86_64-rumprun-netbsd` | ✓ |  | 64-bit NetBSD Rump Kernel
 `x86_64-sun-solaris` | ✓ |  | 64-bit Solaris 10/11, illumos
-`x86_64-unknown-cloudabi` | ✓ |  | 64-bit CloudABI
 `x86_64-unknown-freebsd` | ✓ | ✓ | 64-bit FreeBSD
 `x86_64-unknown-illumos` | ✓ | ✓ | illumos
 `x86_64-unknown-linux-gnux32` | ✓ |  | 64-bit Linux (x32 ABI) (kernel 4.15, glibc 2.27)
@@ -208,6 +207,7 @@ target | std | host | notes
 `x86_64-linux-kernel` | ? |  | Linux kernel modules
 `x86_64-pc-solaris` | ? |  |
 `x86_64-pc-windows-msvc` | ✓ |  | 64-bit Windows XP support
+`x86_64-unknown-cloudabi` | ✓ |  | 64-bit CloudABI
 `x86_64-unknown-dragonfly` | ✓ | ✓ | 64-bit DragonFlyBSD
 `x86_64-unknown-haiku` | ✓ | ✓ | 64-bit Haiku
 `x86_64-unknown-hermit` | ? |  |


### PR DESCRIPTION
The CloudABI target hasn't had much work done on it in a while, and it doesn't appear to be in active use. It has a fairly substantial amount of code, particularly in the [sys module](https://github.com/rust-lang/rust/tree/5addb135edc2653b07670482a430aac9b655a86b/library/std/src/sys/cloudabi) that requires actively supporting. I contacted @EdSchouten who indicated that many of the CloudABI concepts are now in WASI, and that they are OK with the target being moved to tier 3.
