### PR TITLE
Allowing raw ptr dereference in const fn

### DIFF
--- a/src/librustc_mir/transform/check_unsafety.rs
+++ b/src/librustc_mir/transform/check_unsafety.rs
@@ -228,7 +228,7 @@ impl<'a, 'tcx> Visitor<'tcx> for UnsafetyChecker<'a, 'tcx> {
             let base_ty = Place::ty_from(place.local, proj_base, self.body, self.tcx).ty;
             match base_ty.kind {
                 ty::RawPtr(..) => self.require_unsafe(
-                    UnsafetyViolationKind::General,
+                    UnsafetyViolationKind::GeneralAndConstFn,
                     UnsafetyViolationDetails::DerefOfRawPointer,
                 ),
                 ty::Adt(adt, _) => {

--- a/src/test/ui/consts/min_const_fn/allow_raw_ptr_dereference_const_fn.rs
+++ b/src/test/ui/consts/min_const_fn/allow_raw_ptr_dereference_const_fn.rs
@@ -1,0 +1,11 @@
+// check-pass
+#![feature(const_raw_ptr_deref)]
+#![feature(raw_ref_macros)]
+
+use std::ptr;
+
+const fn test_fn(x: *const i32) {
+    let x2 = unsafe { ptr::raw_const!(*x) };
+}
+
+fn main() {}

--- a/src/test/ui/consts/min_const_fn/min_const_fn_unsafe_bad.rs
+++ b/src/test/ui/consts/min_const_fn/min_const_fn_unsafe_bad.rs
@@ -1,4 +1,4 @@
-const fn bad_const_fn_deref_raw(x: *mut usize) -> &'static usize { unsafe { &*x } } //~ is unsafe
+const fn bad_const_fn_deref_raw(x: *mut usize) -> &'static usize { unsafe { &*x } }
 //~^ dereferencing raw pointers in constant functions
 
 const unsafe fn bad_const_unsafe_deref_raw(x: *mut usize) -> usize { *x }

--- a/src/test/ui/consts/min_const_fn/min_const_fn_unsafe_bad.stderr
+++ b/src/test/ui/consts/min_const_fn/min_const_fn_unsafe_bad.stderr
@@ -34,15 +34,7 @@ LL |     Foo { x: () }.y
    = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
-error[E0133]: dereference of raw pointer is unsafe and requires unsafe function or block
-  --> $DIR/min_const_fn_unsafe_bad.rs:1:77
-   |
-LL | const fn bad_const_fn_deref_raw(x: *mut usize) -> &'static usize { unsafe { &*x } }
-   |                                                                             ^^^ dereference of raw pointer
-   |
-   = note: raw pointers may be NULL, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
+error: aborting due to 4 previous errors
 
-error: aborting due to 5 previous errors
-
-Some errors have detailed explanations: E0133, E0658, E0723.
-For more information about an error, try `rustc --explain E0133`.
+Some errors have detailed explanations: E0658, E0723.
+For more information about an error, try `rustc --explain E0658`.


### PR DESCRIPTION
Reflect on issue #75340
Discussion in previous PR  #75425

## Updates
Change `UnsafetyViolationKind::General` to `UnsafetyViolationKind::GeneralAndConstFn` in check_unsafety.rs

Remove `unsafe` in min_const_fn_unsafe_bad.rs

Bless min_const_fn

Add the test case from issue 75340
***
Sorry for the chaos. I messed up and ended up deleting the repo in the last PR. I have to create a new PR for the new repo. I will make a feature branch next time. I will edit the old PR once I receive the commends. 

@RalfJung Thank you all for your replies. They are helpful!

r? @oli-obk 