### PR TITLE
do not apply DerefMut on union field

### DIFF
--- a/compiler/rustc_typeck/src/check/place_op.rs
+++ b/compiler/rustc_typeck/src/check/place_op.rs
@@ -211,13 +211,21 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         debug!("convert_place_derefs_to_mutable: exprs={:?}", exprs);
 
         // Fix up autoderefs and derefs.
+        let mut inside_union = false;
         for (i, &expr) in exprs.iter().rev().enumerate() {
             debug!("convert_place_derefs_to_mutable: i={} expr={:?}", i, expr);
 
+            let mut source = self.node_ty(expr.hir_id);
+            if matches!(expr.kind, hir::ExprKind::Unary(hir::UnOp::UnDeref, _)) {
+                // Clear previous flag; after a pointer indirection it does not apply any more.
+                inside_union = false;
+            }
+            if source.ty_adt_def().map_or(false, |adt| adt.is_union()) {
+                inside_union = true;
+            }
             // Fix up the autoderefs. Autorefs can only occur immediately preceding
             // overloaded place ops, and will be fixed by them in order to get
             // the correct region.
-            let mut source = self.node_ty(expr.hir_id);
             // Do not mutate adjustments in place, but rather take them,
             // and replace them after mutating them, to avoid having the
             // typeck results borrowed during (`deref_mut`) method resolution.
@@ -238,17 +246,14 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             }
                             // If this is a union field, also throw an error.
                             // Union fields should not get mutable auto-deref'd (see RFC 2514).
-                            if let hir::ExprKind::Field(ref outer_expr, _) = expr.kind {
-                                let ty = self.node_ty(outer_expr.hir_id);
-                                if ty.ty_adt_def().map_or(false, |adt| adt.is_union()) {
-                                    let mut err = self.tcx.sess.struct_span_err(
-                                        expr.span,
-                                        "not automatically applying `DerefMut` on union field",
-                                    );
-                                    err.help("writing to this field calls the destructor for the old value");
-                                    err.help("add an explicit `*` if that is desired, or call `ptr::write` to not run the destructor");
-                                    err.emit();
-                                }
+                            if inside_union {
+                                let mut err = self.tcx.sess.struct_span_err(
+                                    expr.span,
+                                    "not automatically applying `DerefMut` on union field",
+                                );
+                                err.help("writing to this field calls the destructor for the old value");
+                                err.help("add an explicit `*` if that is desired, or call `ptr::write` to not run the destructor");
+                                err.emit();
                             }
                         }
                     }

--- a/src/test/ui/union/union-deref.rs
+++ b/src/test/ui/union/union-deref.rs
@@ -1,0 +1,13 @@
+//! Test the part of RFC 2514 that is about not applying `DerefMut` coercions
+//! of union fields.
+#![feature(untagged_unions)]
+
+use std::mem::ManuallyDrop;
+
+union U<T> { x:(), f: ManuallyDrop<(T,)> }
+
+fn main() {
+    let mut u : U<Vec<i32>> = U { x: () };
+    unsafe { (*u.f).0 = Vec::new() }; // explicit deref, this compiles
+    unsafe { u.f.0 = Vec::new() }; //~ERROR not automatically applying `DerefMut` on union field
+}

--- a/src/test/ui/union/union-deref.rs
+++ b/src/test/ui/union/union-deref.rs
@@ -1,3 +1,4 @@
+// ignore-tidy-linelength
 //! Test the part of RFC 2514 that is about not applying `DerefMut` coercions
 //! of union fields.
 #![feature(untagged_unions)]
@@ -11,9 +12,9 @@ union U2<T> { x:(), f: (ManuallyDrop<(T,)>,) }
 fn main() {
     let mut u : U1<Vec<i32>> = U1 { x: () };
     unsafe { (*u.f).0 = Vec::new() }; // explicit deref, this compiles
-    unsafe { u.f.0 = Vec::new() }; //~ERROR not automatically applying `DerefMut` on union field
+    unsafe { u.f.0 = Vec::new() }; //~ERROR not automatically applying `DerefMut` on `ManuallyDrop` union field
 
     let mut u : U2<Vec<i32>> = U2 { x: () };
     unsafe { (*u.f.0).0 = Vec::new() }; // explicit deref, this compiles
-    unsafe { u.f.0.0 = Vec::new() }; //~ERROR not automatically applying `DerefMut` on union field
+    unsafe { u.f.0.0 = Vec::new() }; //~ERROR not automatically applying `DerefMut` on `ManuallyDrop` union field
 }

--- a/src/test/ui/union/union-deref.rs
+++ b/src/test/ui/union/union-deref.rs
@@ -13,8 +13,16 @@ fn main() {
     let mut u : U1<Vec<i32>> = U1 { x: () };
     unsafe { (*u.f).0 = Vec::new() }; // explicit deref, this compiles
     unsafe { u.f.0 = Vec::new() }; //~ERROR not automatically applying `DerefMut` on `ManuallyDrop` union field
+    unsafe { &mut (*u.f).0 }; // explicit deref, this compiles
+    unsafe { &mut u.f.0 }; //~ERROR not automatically applying `DerefMut` on `ManuallyDrop` union field
+    unsafe { (*u.f).0.push(0) }; // explicit deref, this compiles
+    unsafe { u.f.0.push(0) }; //~ERROR not automatically applying `DerefMut` on `ManuallyDrop` union field
 
     let mut u : U2<Vec<i32>> = U2 { x: () };
     unsafe { (*u.f.0).0 = Vec::new() }; // explicit deref, this compiles
     unsafe { u.f.0.0 = Vec::new() }; //~ERROR not automatically applying `DerefMut` on `ManuallyDrop` union field
+    unsafe { &mut (*u.f.0).0 }; // explicit deref, this compiles
+    unsafe { &mut u.f.0.0 }; //~ERROR not automatically applying `DerefMut` on `ManuallyDrop` union field
+    unsafe { (*u.f.0).0.push(0) }; // explicit deref, this compiles
+    unsafe { u.f.0.0.push(0) }; //~ERROR not automatically applying `DerefMut` on `ManuallyDrop` union field
 }

--- a/src/test/ui/union/union-deref.rs
+++ b/src/test/ui/union/union-deref.rs
@@ -4,10 +4,16 @@
 
 use std::mem::ManuallyDrop;
 
-union U<T> { x:(), f: ManuallyDrop<(T,)> }
+union U1<T> { x:(), f: ManuallyDrop<(T,)> }
+
+union U2<T> { x:(), f: (ManuallyDrop<(T,)>,) }
 
 fn main() {
-    let mut u : U<Vec<i32>> = U { x: () };
+    let mut u : U1<Vec<i32>> = U1 { x: () };
     unsafe { (*u.f).0 = Vec::new() }; // explicit deref, this compiles
     unsafe { u.f.0 = Vec::new() }; //~ERROR not automatically applying `DerefMut` on union field
+
+    let mut u : U2<Vec<i32>> = U2 { x: () };
+    unsafe { (*u.f.0).0 = Vec::new() }; // explicit deref, this compiles
+    unsafe { u.f.0.0 = Vec::new() }; //~ERROR not automatically applying `DerefMut` on union field
 }

--- a/src/test/ui/union/union-deref.stderr
+++ b/src/test/ui/union/union-deref.stderr
@@ -8,7 +8,25 @@ LL |     unsafe { u.f.0 = Vec::new() };
    = help: add an explicit `*` if that is desired, or call `ptr::write` to not run the destructor
 
 error: not automatically applying `DerefMut` on `ManuallyDrop` union field
+  --> $DIR/union-deref.rs:17:19
+   |
+LL |     unsafe { &mut u.f.0 };
+   |                   ^^^
+   |
+   = help: writing to this reference calls the destructor for the old value
+   = help: add an explicit `*` if that is desired, or call `ptr::write` to not run the destructor
+
+error: not automatically applying `DerefMut` on `ManuallyDrop` union field
   --> $DIR/union-deref.rs:19:14
+   |
+LL |     unsafe { u.f.0.push(0) };
+   |              ^^^
+   |
+   = help: writing to this reference calls the destructor for the old value
+   = help: add an explicit `*` if that is desired, or call `ptr::write` to not run the destructor
+
+error: not automatically applying `DerefMut` on `ManuallyDrop` union field
+  --> $DIR/union-deref.rs:23:14
    |
 LL |     unsafe { u.f.0.0 = Vec::new() };
    |              ^^^^^^^
@@ -16,5 +34,23 @@ LL |     unsafe { u.f.0.0 = Vec::new() };
    = help: writing to this reference calls the destructor for the old value
    = help: add an explicit `*` if that is desired, or call `ptr::write` to not run the destructor
 
-error: aborting due to 2 previous errors
+error: not automatically applying `DerefMut` on `ManuallyDrop` union field
+  --> $DIR/union-deref.rs:25:19
+   |
+LL |     unsafe { &mut u.f.0.0 };
+   |                   ^^^^^^^
+   |
+   = help: writing to this reference calls the destructor for the old value
+   = help: add an explicit `*` if that is desired, or call `ptr::write` to not run the destructor
+
+error: not automatically applying `DerefMut` on `ManuallyDrop` union field
+  --> $DIR/union-deref.rs:27:14
+   |
+LL |     unsafe { u.f.0.0.push(0) };
+   |              ^^^^^^^
+   |
+   = help: writing to this reference calls the destructor for the old value
+   = help: add an explicit `*` if that is desired, or call `ptr::write` to not run the destructor
+
+error: aborting due to 6 previous errors
 

--- a/src/test/ui/union/union-deref.stderr
+++ b/src/test/ui/union/union-deref.stderr
@@ -1,5 +1,5 @@
 error: not automatically applying `DerefMut` on union field
-  --> $DIR/union-deref.rs:12:14
+  --> $DIR/union-deref.rs:14:14
    |
 LL |     unsafe { u.f.0 = Vec::new() };
    |              ^^^
@@ -7,5 +7,14 @@ LL |     unsafe { u.f.0 = Vec::new() };
    = help: writing to this field calls the destructor for the old value
    = help: add an explicit `*` if that is desired, or call `ptr::write` to not run the destructor
 
-error: aborting due to previous error
+error: not automatically applying `DerefMut` on union field
+  --> $DIR/union-deref.rs:18:14
+   |
+LL |     unsafe { u.f.0.0 = Vec::new() };
+   |              ^^^^^^^
+   |
+   = help: writing to this field calls the destructor for the old value
+   = help: add an explicit `*` if that is desired, or call `ptr::write` to not run the destructor
+
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/union/union-deref.stderr
+++ b/src/test/ui/union/union-deref.stderr
@@ -1,19 +1,19 @@
-error: not automatically applying `DerefMut` on union field
-  --> $DIR/union-deref.rs:14:14
+error: not automatically applying `DerefMut` on `ManuallyDrop` union field
+  --> $DIR/union-deref.rs:15:14
    |
 LL |     unsafe { u.f.0 = Vec::new() };
    |              ^^^
    |
-   = help: writing to this field calls the destructor for the old value
+   = help: writing to this reference calls the destructor for the old value
    = help: add an explicit `*` if that is desired, or call `ptr::write` to not run the destructor
 
-error: not automatically applying `DerefMut` on union field
-  --> $DIR/union-deref.rs:18:14
+error: not automatically applying `DerefMut` on `ManuallyDrop` union field
+  --> $DIR/union-deref.rs:19:14
    |
 LL |     unsafe { u.f.0.0 = Vec::new() };
    |              ^^^^^^^
    |
-   = help: writing to this field calls the destructor for the old value
+   = help: writing to this reference calls the destructor for the old value
    = help: add an explicit `*` if that is desired, or call `ptr::write` to not run the destructor
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/union/union-deref.stderr
+++ b/src/test/ui/union/union-deref.stderr
@@ -1,0 +1,11 @@
+error: not automatically applying `DerefMut` on union field
+  --> $DIR/union-deref.rs:12:14
+   |
+LL |     unsafe { u.f.0 = Vec::new() };
+   |              ^^^
+   |
+   = help: writing to this field calls the destructor for the old value
+   = help: add an explicit `*` if that is desired, or call `ptr::write` to not run the destructor
+
+error: aborting due to previous error
+


### PR DESCRIPTION
This implements the part of [RFC 2514](https://github.com/rust-lang/rfcs/blob/master/text/2514-union-initialization-and-drop.md) about `DerefMut`. Unlike described in the RFC, we only apply this warning specifically when doing `DerefMut` of a `ManuallyDrop` field; that is really the case we are worried about here.

@matthewjasper suggested I patch `convert_place_derefs_to_mutable` and `convert_place_op_to_mutable` for this, but I could not find anything to do in `convert_place_op_to_mutable` and this is sufficient to make the test pass. However, maybe there are some other cases this misses? I have no familiarity with this code.

This is a breaking change *in theory*, if someone used `ManuallyDrop<T>` in a union field and relied on automatic `DerefMut`. But on stable this means `T: Copy`, so the `ManuallyDrop` is rather pointless.

Cc https://github.com/rust-lang/rust/issues/55149