### PR TITLE
Do not promote &mut of a non-ZST ever

### DIFF
--- a/compiler/rustc_mir/src/transform/promote_consts.rs
+++ b/compiler/rustc_mir/src/transform/promote_consts.rs
@@ -364,15 +364,7 @@ impl<'tcx> Validator<'_, 'tcx> {
                             // In theory, any zero-sized value could be borrowed
                             // mutably without consequences. However, only &mut []
                             // is allowed right now, and only in functions.
-                            if self.const_kind
-                                == Some(hir::ConstContext::Static(hir::Mutability::Mut))
-                            {
-                                // Inside a `static mut`, &mut [...] is also allowed.
-                                match ty.kind() {
-                                    ty::Array(..) | ty::Slice(_) => {}
-                                    _ => return Err(Unpromotable),
-                                }
-                            } else if let ty::Array(_, len) = ty.kind() {
+                            if let ty::Array(_, len) = ty.kind() {
                                 // FIXME(eddyb) the `self.is_non_const_fn` condition
                                 // seems unnecessary, given that this is merely a ZST.
                                 match len.try_eval_usize(self.tcx, self.param_env) {
@@ -673,13 +665,7 @@ impl<'tcx> Validator<'_, 'tcx> {
                     // In theory, any zero-sized value could be borrowed
                     // mutably without consequences. However, only &mut []
                     // is allowed right now, and only in functions.
-                    if self.const_kind == Some(hir::ConstContext::Static(hir::Mutability::Mut)) {
-                        // Inside a `static mut`, &mut [...] is also allowed.
-                        match ty.kind() {
-                            ty::Array(..) | ty::Slice(_) => {}
-                            _ => return Err(Unpromotable),
-                        }
-                    } else if let ty::Array(_, len) = ty.kind() {
+                    if let ty::Array(_, len) = ty.kind() {
                         // FIXME(eddyb): We only return `Unpromotable` for `&mut []` inside a
                         // const context which seems unnecessary given that this is merely a ZST.
                         match len.try_eval_usize(self.tcx, self.param_env) {

--- a/src/test/ui/consts/promote-no-mut.rs
+++ b/src/test/ui/consts/promote-no-mut.rs
@@ -1,0 +1,10 @@
+// ignore-tidy-linelength
+// We do not promote mutable references.
+static mut TEST1: Option<&mut [i32]> = Some(&mut [1, 2, 3]); //~ ERROR temporary value dropped while borrowed
+
+static mut TEST2: &'static mut [i32] = {
+    let x = &mut [1,2,3]; //~ ERROR temporary value dropped while borrowed
+    x
+};
+
+fn main() {}

--- a/src/test/ui/consts/promote-no-mut.stderr
+++ b/src/test/ui/consts/promote-no-mut.stderr
@@ -1,0 +1,23 @@
+error[E0716]: temporary value dropped while borrowed
+  --> $DIR/promote-no-mut.rs:3:50
+   |
+LL | static mut TEST1: Option<&mut [i32]> = Some(&mut [1, 2, 3]);
+   |                                        ----------^^^^^^^^^-
+   |                                        |         |        |
+   |                                        |         |        temporary value is freed at the end of this statement
+   |                                        |         creates a temporary which is freed while still in use
+   |                                        using this value as a static requires that borrow lasts for `'static`
+
+error[E0716]: temporary value dropped while borrowed
+  --> $DIR/promote-no-mut.rs:6:18
+   |
+LL |     let x = &mut [1,2,3];
+   |                  ^^^^^^^ creates a temporary which is freed while still in use
+LL |     x
+   |     - using this value as a static requires that borrow lasts for `'static`
+LL | };
+   | - temporary value is freed at the end of this statement
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0716`.

--- a/src/test/ui/consts/promotion-mutable-ref.rs
+++ b/src/test/ui/consts/promotion-mutable-ref.rs
@@ -1,0 +1,17 @@
+// run-pass
+#![feature(const_mut_refs)]
+
+static mut TEST: i32 = {
+    // We cannot promote this, as CTFE needs to be able to mutate it later.
+    let x = &mut [1,2,3];
+    x[0] += 1;
+    x[0]
+};
+
+// This still works -- it's not done via promotion.
+#[allow(unused)]
+static mut TEST2: &'static mut [i32] = &mut [0,1,2];
+
+fn main() {
+    assert_eq!(unsafe { TEST }, 2);
+}

--- a/src/test/ui/consts/promotion-mutable-ref.rs
+++ b/src/test/ui/consts/promotion-mutable-ref.rs
@@ -2,7 +2,7 @@
 #![feature(const_mut_refs)]
 
 static mut TEST: i32 = {
-    // We cannot promote this, as CTFE needs to be able to mutate it later.
+    // We must not promote this, as CTFE needs to be able to mutate it later.
     let x = &mut [1,2,3];
     x[0] += 1;
     x[0]


### PR DESCRIPTION
Since ~pre-1.0~ 1.36, we have accepted code like this:
```rust
static mut TEST: &'static mut [i32] = {
    let x = &mut [1,2,3];
    x
};
```
I tracked it back to https://github.com/rust-lang/rust/pull/21744, but unfortunately could not find any discussion or RFC that would explain why we thought this was a good idea. And it's not, it breaks all sorts of things -- see https://github.com/rust-lang/rust/issues/75556.

To fix https://github.com/rust-lang/rust/issues/75556, we have to stop promoting non-ZST mutable references no matter the context, which is what this PR does. It's a breaking change.

Notice that this still works, since it does not rely on promotion:
```rust
static mut TEST: &'static mut [i32] = &mut [0,1,2];
```

Cc @rust-lang/wg-const-eval 