### PR TITLE
polymorphize: if any param in a predicate is used, then all are used

### DIFF
--- a/src/test/ui/polymorphization/predicates.rs
+++ b/src/test/ui/polymorphization/predicates.rs
@@ -60,6 +60,21 @@ where
     std::mem::size_of::<C>()
 }
 
+// Finally, check that `F` is considered used because `G` is used when neither are in the self-ty
+// of the predicate.
+
+trait Foobar<F, G> {}
+
+impl Foobar<u32, u32> for () {}
+
+#[rustc_polymorphize_error]
+fn foobar<F, G>() -> usize
+where
+    (): Foobar<F, G>,
+{
+    std::mem::size_of::<G>()
+}
+
 fn main() {
     let x = &[2u32];
     foo(x.iter());
@@ -69,4 +84,6 @@ fn main() {
     let _ = a.next();
 
     let _ = quux::<u8, u16, u32>();
+
+    let _ = foobar::<u32, u32>();
 }


### PR DESCRIPTION
Addresses [review](https://github.com/rust-lang/rust/pull/75518#discussion_r470907646) [comments](https://github.com/rust-lang/rust/pull/75518#discussion_r470907865) [from](https://github.com/rust-lang/rust/pull/75518#discussion_r470908188) @eddyb in #75518 that I didn't get to resolve before bors merged.

This PR modifies polymorphization's handling of predicates so that if any generic parameter is used in a predicate then all parameters in that predicate are used.

r? @eddyb