### PR TITLE
Don't run allowed lints

### DIFF
--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -179,6 +179,10 @@ pub fn run_compiler(
             registry: diagnostics_registry(),
         };
         callbacks.config(&mut config);
+        // lol no lints at all
+        config.override_queries = Some(|_, providers, _| {
+            providers.lint_mod = |_, _| {};
+        });
         config
     };
 
@@ -256,6 +260,10 @@ pub fn run_compiler(
     };
 
     callbacks.config(&mut config);
+    // lol no lints at all
+    config.override_queries = Some(|_, providers, _| {
+        providers.lint_mod = |_, _| {};
+    });
 
     interface::run_compiler(config, |compiler| {
         let sess = compiler.session();

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -35,7 +35,7 @@ use rustc_serialize::json::{self, ToJson};
 use rustc_session::config::nightly_options;
 use rustc_session::config::{ErrorOutputType, Input, OutputType, PrintRequest};
 use rustc_session::getopts;
-use rustc_session::lint::{Level, Lint, LintId};
+use rustc_session::lint::{Lint, LintId};
 use rustc_session::{config, DiagnosticOutput, Session};
 use rustc_session::{early_error, early_warn};
 use rustc_span::source_map::{FileLoader, FileName};
@@ -256,12 +256,6 @@ pub fn run_compiler(
     };
 
     callbacks.config(&mut config);
-    // Since the warnings from these lints will never be shown, there is no need to run them at all!
-    if let Some(Level::Allow) = config.opts.lint_cap {
-        config.override_queries = Some(|_, providers, _| {
-            providers.lint_mod = |_, _| {};
-        });
-    }
 
     interface::run_compiler(config, |compiler| {
         let sess = compiler.session();

--- a/src/librustc_interface/interface.rs
+++ b/src/librustc_interface/interface.rs
@@ -158,7 +158,14 @@ pub struct Config {
     pub registry: Registry,
 }
 
-pub fn create_compiler_and_run<R>(config: Config, f: impl FnOnce(&Compiler) -> R) -> R {
+pub fn create_compiler_and_run<R>(mut config: Config, f: impl FnOnce(&Compiler) -> R) -> R {
+    // Since the warnings from these lints will never be shown, there is no need to run them at all!
+    if let Some(lint::Level::Allow) = config.opts.lint_cap {
+        config.override_queries = Some(|_, providers, _| {
+            providers.lint_mod = |_, _| {};
+        });
+    }
+
     let registry = &config.registry;
     let (sess, codegen_backend) = util::create_session(
         config.opts,


### PR DESCRIPTION
Partial implementation of https://github.com/rust-lang/rust/issues/74704.

Not sure exactly why some lints are still run - I think they're being added later with `register_lint_pass`? I don't understand the machinery in `rustc_lint` very well. However this still cuts off a solid percent of the runtime: https://github.com/rust-lang/rust/pull/74718#issuecomment-663781456 and further improvements can be done in follow-up PRs.