### PR TITLE
Rollup of 10 pull requests

### DIFF
--- a/library/core/src/hint.rs
+++ b/library/core/src/hint.rs
@@ -24,7 +24,6 @@ use crate::intrinsics;
 /// Otherwise, consider using the [`unreachable!`] macro, which does not allow
 /// optimizations but will panic when executed.
 ///
-/// [`unreachable!`]: unreachable
 ///
 /// # Example
 ///

--- a/library/core/src/hint.rs
+++ b/library/core/src/hint.rs
@@ -24,7 +24,7 @@ use crate::intrinsics;
 /// Otherwise, consider using the [`unreachable!`] macro, which does not allow
 /// optimizations but will panic when executed.
 ///
-/// [`unreachable!`]: ../macro.unreachable.html
+/// [`unreachable!`]: unreachable
 ///
 /// # Example
 ///
@@ -61,7 +61,7 @@ pub const unsafe fn unreachable_unchecked() -> ! {
 /// **Note**: On platforms that do not support receiving spin-loop hints this function does not
 /// do anything at all.
 ///
-/// [`core::sync::atomic::spin_loop_hint`]: ../sync/atomic/fn.spin_loop_hint.html
+/// [`core::sync::atomic::spin_loop_hint`]: crate::sync::atomic::spin_loop_hint
 #[inline]
 #[unstable(feature = "renamed_spin_loop", issue = "55002")]
 pub fn spin_loop() {
@@ -99,7 +99,7 @@ pub fn spin_loop() {
 /// An identity function that *__hints__* to the compiler to be maximally pessimistic about what
 /// `black_box` could do.
 ///
-/// [`std::convert::identity`]: https://doc.rust-lang.org/core/convert/fn.identity.html
+/// [`std::convert::identity`]: crate::convert::identity
 ///
 /// Unlike [`std::convert::identity`], a Rust compiler is encouraged to assume that `black_box` can
 /// use `x` in any possible valid way that Rust code is allowed to without introducing undefined

--- a/library/core/src/hint.rs
+++ b/library/core/src/hint.rs
@@ -99,7 +99,7 @@ pub fn spin_loop() {
 /// An identity function that *__hints__* to the compiler to be maximally pessimistic about what
 /// `black_box` could do.
 ///
-/// [`std::convert::identity`]: crate::convert::identity
+/// [`std::convert::identity`]: https://doc.rust-lang.org/core/convert/fn.identity.html
 ///
 /// Unlike [`std::convert::identity`], a Rust compiler is encouraged to assume that `black_box` can
 /// use `x` in any possible valid way that Rust code is allowed to without introducing undefined

--- a/library/core/src/pin.rs
+++ b/library/core/src/pin.rs
@@ -6,9 +6,12 @@
 //! as moving an object with pointers to itself will invalidate them, which could cause undefined
 //! behavior.
 //!
-//! A [`Pin<P>`] ensures that the pointee of any pointer type `P` has a stable location in memory,
-//! meaning it cannot be moved elsewhere and its memory cannot be deallocated
-//! until it gets dropped. We say that the pointee is "pinned".
+//! At a high level, a [`Pin<P>`] ensures that the pointee of any pointer type
+//! `P` has a stable location in memory, meaning it cannot be moved elsewhere
+//! and its memory cannot be deallocated until it gets dropped. We say that the
+//! pointee is "pinned". Things get more subtle when discussing types that
+//! combine pinned with non-pinned data; [see below](#projections-and-structural-pinning)
+//! for more details.
 //!
 //! By default, all types in Rust are movable. Rust allows passing all types by-value,
 //! and common smart-pointer types such as [`Box<T>`] and `&mut T` allow replacing and
@@ -60,6 +63,10 @@
 //! pointed-to type).
 //!
 //! # Example: self-referential struct
+//!
+//! Before we go into more details to explain the guarantees and choices
+//! associated with `Pin<T>`, we discuss some examples for how it might be used.
+//! Feel free to [skip to where the theoretical discussion continues](#drop-guarantee).
 //!
 //! ```rust
 //! use std::pin::Pin;

--- a/library/std/src/sys/windows/ext/ffi.rs
+++ b/library/std/src/sys/windows/ext/ffi.rs
@@ -30,13 +30,13 @@
 //! [`OsString`] is the Rust wrapper for owned strings in the
 //! preferred representation of the operating system. On Windows,
 //! this struct gets augmented with an implementation of the
-//! [`OsStringExt`] trait, which has a [`from_wide`] method. This
+//! [`OsStringExt`] trait, which has a [`OsStringExt::from_wide`] method. This
 //! lets you create an [`OsString`] from a `&[u16]` slice; presumably
 //! you get such a slice out of a `WCHAR` Windows API.
 //!
 //! Similarly, [`OsStr`] is the Rust wrapper for borrowed strings from
 //! preferred representation of the operating system. On Windows, the
-//! [`OsStrExt`] trait provides the [`encode_wide`] method, which
+//! [`OsStrExt`] trait provides the [`OsStrExt::encode_wide`] method, which
 //! outputs an [`EncodeWide`] iterator. You can [`collect`] this
 //! iterator, for example, to obtain a `Vec<u16>`; you can later get a
 //! pointer to this vector's contents and feed it to Windows APIs.
@@ -47,15 +47,8 @@
 //! ill-formed UTF-16.
 //!
 //! [ill-formed-utf-16]: https://simonsapin.github.io/wtf-8/#ill-formed-utf-16
-//! [`OsString`]: ../../../ffi/struct.OsString.html
-//! [`OsStr`]: ../../../ffi/struct.OsStr.html
-//! [`OsStringExt`]: trait.OsStringExt.html
-//! [`OsStrExt`]: trait.OsStrExt.html
-//! [`EncodeWide`]: struct.EncodeWide.html
-//! [`from_wide`]: trait.OsStringExt.html#tymethod.from_wide
-//! [`encode_wide`]: trait.OsStrExt.html#tymethod.encode_wide
-//! [`collect`]: ../../../iter/trait.Iterator.html#method.collect
-//! [U+FFFD]: ../../../char/constant.REPLACEMENT_CHARACTER.html
+//! [`collect`]: crate::iter::Iterator::collect
+//! [U+FFFD]: crate::char::REPLACEMENT_CHARACTER
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
@@ -68,14 +61,12 @@ use crate::sys_common::{AsInner, FromInner};
 pub use crate::sys_common::wtf8::EncodeWide;
 
 /// Windows-specific extensions to [`OsString`].
-///
-/// [`OsString`]: ../../../../std/ffi/struct.OsString.html
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait OsStringExt {
     /// Creates an `OsString` from a potentially ill-formed UTF-16 slice of
     /// 16-bit code units.
     ///
-    /// This is lossless: calling [`encode_wide`] on the resulting string
+    /// This is lossless: calling [`OsStrExt::encode_wide`] on the resulting string
     /// will always return the original code units.
     ///
     /// # Examples
@@ -89,8 +80,6 @@ pub trait OsStringExt {
     ///
     /// let string = OsString::from_wide(&source[..]);
     /// ```
-    ///
-    /// [`encode_wide`]: ./trait.OsStrExt.html#tymethod.encode_wide
     #[stable(feature = "rust1", since = "1.0.0")]
     fn from_wide(wide: &[u16]) -> Self;
 }
@@ -103,14 +92,12 @@ impl OsStringExt for OsString {
 }
 
 /// Windows-specific extensions to [`OsStr`].
-///
-/// [`OsStr`]: ../../../../std/ffi/struct.OsStr.html
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait OsStrExt {
     /// Re-encodes an `OsStr` as a wide character sequence, i.e., potentially
     /// ill-formed UTF-16.
     ///
-    /// This is lossless: calling [`OsString::from_wide`] and then
+    /// This is lossless: calling [`OsStringExt::from_wide`] and then
     /// `encode_wide` on the result will yield the original code units.
     /// Note that the encoding does not add a final null terminator.
     ///
@@ -128,8 +115,6 @@ pub trait OsStrExt {
     /// let result: Vec<u16> = string.encode_wide().collect();
     /// assert_eq!(&source[..], &result[..]);
     /// ```
-    ///
-    /// [`OsString::from_wide`]: ./trait.OsStringExt.html#tymethod.from_wide
     #[stable(feature = "rust1", since = "1.0.0")]
     fn encode_wide(&self) -> EncodeWide<'_>;
 }

--- a/library/std/src/sys/windows/ext/fs.rs
+++ b/library/std/src/sys/windows/ext/fs.rs
@@ -8,9 +8,7 @@ use crate::path::Path;
 use crate::sys;
 use crate::sys_common::{AsInner, AsInnerMut};
 
-/// Windows-specific extensions to [`File`].
-///
-/// [`File`]: ../../../fs/struct.File.html
+/// Windows-specific extensions to [`fs::File`].
 #[stable(feature = "file_offset", since = "1.15.0")]
 pub trait FileExt {
     /// Seeks to a given position and reads a number of bytes.
@@ -94,8 +92,6 @@ impl FileExt for fs::File {
 }
 
 /// Windows-specific extensions to [`fs::OpenOptions`].
-///
-/// [`fs::OpenOptions`]: ../../../../std/fs/struct.OpenOptions.html
 #[stable(feature = "open_options_ext", since = "1.10.0")]
 pub trait OpenOptionsExt {
     /// Overrides the `dwDesiredAccess` argument to the call to [`CreateFile`]
@@ -295,7 +291,6 @@ impl OpenOptionsExt for OpenOptions {
 /// The data members that this trait exposes correspond to the members
 /// of the [`BY_HANDLE_FILE_INFORMATION`] structure.
 ///
-/// [`fs::Metadata`]: ../../../../std/fs/struct.Metadata.html
 /// [`BY_HANDLE_FILE_INFORMATION`]:
 ///     https://docs.microsoft.com/en-us/windows/win32/api/fileapi/ns-fileapi-by_handle_file_information
 #[stable(feature = "metadata_ext", since = "1.1.0")]
@@ -499,11 +494,9 @@ impl MetadataExt for Metadata {
     }
 }
 
-/// Windows-specific extensions to [`FileType`].
+/// Windows-specific extensions to [`fs::FileType`].
 ///
 /// On Windows, a symbolic link knows whether it is a file or directory.
-///
-/// [`FileType`]: ../../../../std/fs/struct.FileType.html
 #[unstable(feature = "windows_file_type_ext", issue = "none")]
 pub trait FileTypeExt {
     /// Returns `true` if this file type is a symbolic link that is also a directory.

--- a/library/std/src/sys/windows/ext/process.rs
+++ b/library/std/src/sys/windows/ext/process.rs
@@ -73,8 +73,6 @@ impl IntoRawHandle for process::ChildStderr {
 }
 
 /// Windows-specific extensions to [`process::ExitStatus`].
-///
-/// [`process::ExitStatus`]: ../../../../std/process/struct.ExitStatus.html
 #[stable(feature = "exit_status_from", since = "1.12.0")]
 pub trait ExitStatusExt {
     /// Creates a new `ExitStatus` from the raw underlying `u32` return value of
@@ -91,8 +89,6 @@ impl ExitStatusExt for process::ExitStatus {
 }
 
 /// Windows-specific extensions to the [`process::Command`] builder.
-///
-/// [`process::Command`]: ../../../../std/process/struct.Command.html
 #[stable(feature = "windows_process_extensions", since = "1.16.0")]
 pub trait CommandExt {
     /// Sets the [process creation flags][1] to be passed to `CreateProcess`.

--- a/src/ci/docker/scripts/emscripten.sh
+++ b/src/ci/docker/scripts/emscripten.sh
@@ -19,5 +19,5 @@ exit 1
 
 git clone https://github.com/emscripten-core/emsdk.git /emsdk-portable
 cd /emsdk-portable
-hide_output ./emsdk install 1.38.46-upstream
-./emsdk activate 1.38.46-upstream
+hide_output ./emsdk install 1.38.47-upstream
+./emsdk activate 1.38.47-upstream

--- a/src/librustc_ast_lowering/item.rs
+++ b/src/librustc_ast_lowering/item.rs
@@ -81,6 +81,8 @@ impl<'a> Visitor<'a> for ItemLowerer<'a, '_, '_> {
             FnKind::Fn(FnCtxt::Foreign, _, sig, _, _) => {
                 self.visit_fn_header(&sig.header);
                 visit::walk_fn_decl(self, &sig.decl);
+                // Don't visit the foreign function body even if it has one, since lowering the
+                // body would have no meaning and will have already been caught as a parse error.
             }
             _ => visit::walk_fn(self, fk, sp),
         }

--- a/src/librustc_ast_lowering/item.rs
+++ b/src/librustc_ast_lowering/item.rs
@@ -77,21 +77,13 @@ impl<'a> Visitor<'a> for ItemLowerer<'a, '_, '_> {
         }
     }
 
-    fn visit_fn(&mut self, fk: FnKind<'a>, _: Span, _: NodeId) {
+    fn visit_fn(&mut self, fk: FnKind<'a>, sp: Span, _: NodeId) {
         match fk {
             FnKind::Fn(FnCtxt::Foreign, _, sig, _, _) => {
                 self.visit_fn_header(&sig.header);
                 visit::walk_fn_decl(self, &sig.decl);
             }
-            FnKind::Fn(_, _, sig, _, body) => {
-                self.visit_fn_header(&sig.header);
-                visit::walk_fn_decl(self, &sig.decl);
-                walk_list!(self, visit_block, body);
-            }
-            FnKind::Closure(decl, body) => {
-                visit::walk_fn_decl(self, decl);
-                self.visit_expr(body);
-            }
+            _ => visit::walk_fn(self, fk, sp),
         }
     }
 

--- a/src/librustc_ast_lowering/item.rs
+++ b/src/librustc_ast_lowering/item.rs
@@ -7,7 +7,6 @@ use rustc_ast::attr;
 use rustc_ast::node_id::NodeMap;
 use rustc_ast::ptr::P;
 use rustc_ast::visit::{self, AssocCtxt, FnCtxt, FnKind, Visitor};
-use rustc_ast::walk_list;
 use rustc_data_structures::fx::FxHashSet;
 use rustc_errors::struct_span_err;
 use rustc_hir as hir;

--- a/src/librustc_codegen_ssa/back/symbol_export.rs
+++ b/src/librustc_codegen_ssa/back/symbol_export.rs
@@ -61,7 +61,7 @@ fn reachable_non_generics_provider(tcx: TyCtxt<'_>, cnum: CrateNum) -> DefIdMap<
     let mut reachable_non_generics: DefIdMap<_> = tcx
         .reachable_set(LOCAL_CRATE)
         .iter()
-        .filter_map(|&hir_id| {
+        .filter_map(|&def_id| {
             // We want to ignore some FFI functions that are not exposed from
             // this crate. Reachable FFI functions can be lumped into two
             // categories:
@@ -75,9 +75,8 @@ fn reachable_non_generics_provider(tcx: TyCtxt<'_>, cnum: CrateNum) -> DefIdMap<
             //
             // As a result, if this id is an FFI item (foreign item) then we only
             // let it through if it's included statically.
-            match tcx.hir().get(hir_id) {
+            match tcx.hir().get(tcx.hir().local_def_id_to_hir_id(def_id)) {
                 Node::ForeignItem(..) => {
-                    let def_id = tcx.hir().local_def_id(hir_id);
                     tcx.is_statically_included_foreign_item(def_id).then_some(def_id)
                 }
 
@@ -87,7 +86,6 @@ fn reachable_non_generics_provider(tcx: TyCtxt<'_>, cnum: CrateNum) -> DefIdMap<
                     ..
                 })
                 | Node::ImplItem(&hir::ImplItem { kind: hir::ImplItemKind::Fn(..), .. }) => {
-                    let def_id = tcx.hir().local_def_id(hir_id);
                     let generics = tcx.generics_of(def_id);
                     if !generics.requires_monomorphization(tcx)
                         // Functions marked with #[inline] are codegened with "internal"
@@ -361,7 +359,7 @@ fn upstream_drop_glue_for_provider<'tcx>(
 
 fn is_unreachable_local_definition_provider(tcx: TyCtxt<'_>, def_id: DefId) -> bool {
     if let Some(def_id) = def_id.as_local() {
-        !tcx.reachable_set(LOCAL_CRATE).contains(&tcx.hir().local_def_id_to_hir_id(def_id))
+        !tcx.reachable_set(LOCAL_CRATE).contains(&def_id)
     } else {
         bug!("is_unreachable_local_definition called with non-local DefId: {:?}", def_id)
     }

--- a/src/librustc_middle/query/mod.rs
+++ b/src/librustc_middle/query/mod.rs
@@ -740,7 +740,8 @@ rustc_queries! {
     }
 
     Other {
-        query reachable_set(_: CrateNum) -> &'tcx HirIdSet {
+        query reachable_set(_: CrateNum) -> FxHashSet<LocalDefId> {
+            storage(ArenaCacheSelector<'tcx>)
             desc { "reachability" }
         }
 

--- a/src/librustc_middle/ty/consts/kind.rs
+++ b/src/librustc_middle/ty/consts/kind.rs
@@ -34,7 +34,7 @@ pub enum ConstKind<'tcx> {
 
     /// A placeholder for a const which could not be computed; this is
     /// propagated to avoid useless error messages.
-    Error(ty::sty::DelaySpanBugEmitted),
+    Error(ty::DelaySpanBugEmitted),
 }
 
 #[cfg(target_arch = "x86_64")]

--- a/src/librustc_middle/ty/context.rs
+++ b/src/librustc_middle/ty/context.rs
@@ -64,6 +64,12 @@ use std::mem;
 use std::ops::{Bound, Deref};
 use std::sync::Arc;
 
+/// A type that is not publicly constructable. This prevents people from making `TyKind::Error`
+/// except through `tcx.err*()`, which are in this module.
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[derive(TyEncodable, TyDecodable, HashStable)]
+pub struct DelaySpanBugEmitted(());
+
 type InternedSet<'tcx, T> = ShardedHashMap<Interned<'tcx, T>, ()>;
 
 pub struct CtxtInterners<'tcx> {
@@ -1170,7 +1176,7 @@ impl<'tcx> TyCtxt<'tcx> {
     #[track_caller]
     pub fn ty_error_with_message<S: Into<MultiSpan>>(self, span: S, msg: &str) -> Ty<'tcx> {
         self.sess.delay_span_bug(span, msg);
-        self.mk_ty(Error(super::sty::DelaySpanBugEmitted(())))
+        self.mk_ty(Error(DelaySpanBugEmitted(())))
     }
 
     /// Like `err` but for constants.
@@ -1178,10 +1184,7 @@ impl<'tcx> TyCtxt<'tcx> {
     pub fn const_error(self, ty: Ty<'tcx>) -> &'tcx Const<'tcx> {
         self.sess
             .delay_span_bug(DUMMY_SP, "ty::ConstKind::Error constructed but no error reported.");
-        self.mk_const(ty::Const {
-            val: ty::ConstKind::Error(super::sty::DelaySpanBugEmitted(())),
-            ty,
-        })
+        self.mk_const(ty::Const { val: ty::ConstKind::Error(DelaySpanBugEmitted(())), ty })
     }
 
     pub fn consider_optimizing<T: Fn() -> String>(&self, msg: T) -> bool {

--- a/src/librustc_middle/ty/mod.rs
+++ b/src/librustc_middle/ty/mod.rs
@@ -60,6 +60,7 @@ pub use self::sty::{Binder, BoundTy, BoundTyKind, BoundVar, DebruijnIndex, INNER
 pub use self::sty::{BoundRegion, EarlyBoundRegion, FreeRegion, Region};
 pub use self::sty::{CanonicalPolyFnSig, FnSig, GenSig, PolyFnSig, PolyGenSig};
 pub use self::sty::{ClosureSubsts, GeneratorSubsts, TypeAndMut, UpvarSubsts};
+pub use self::sty::{ClosureSubstsParts, GeneratorSubstsParts};
 pub use self::sty::{ConstVid, FloatVid, IntVid, RegionVid, TyVid};
 pub use self::sty::{ExistentialPredicate, InferTy, ParamConst, ParamTy, ProjectionTy};
 pub use self::sty::{ExistentialProjection, PolyExistentialProjection};

--- a/src/librustc_middle/ty/mod.rs
+++ b/src/librustc_middle/ty/mod.rs
@@ -72,8 +72,8 @@ pub use self::binding::BindingMode::*;
 
 pub use self::context::{tls, FreeRegionInfo, TyCtxt};
 pub use self::context::{
-    CanonicalUserType, CanonicalUserTypeAnnotation, CanonicalUserTypeAnnotations, ResolvedOpaqueTy,
-    UserType, UserTypeAnnotationIndex,
+    CanonicalUserType, CanonicalUserTypeAnnotation, CanonicalUserTypeAnnotations,
+    DelaySpanBugEmitted, ResolvedOpaqueTy, UserType, UserTypeAnnotationIndex,
 };
 pub use self::context::{
     CtxtInterners, GeneratorInteriorTypeCause, GlobalCtxt, Lift, TypeckResults,

--- a/src/librustc_middle/ty/query/mod.rs
+++ b/src/librustc_middle/ty/query/mod.rs
@@ -43,7 +43,7 @@ use rustc_hir as hir;
 use rustc_hir::def::DefKind;
 use rustc_hir::def_id::{CrateNum, DefId, DefIdMap, DefIdSet, LocalDefId};
 use rustc_hir::lang_items::{LangItem, LanguageItems};
-use rustc_hir::{Crate, HirIdSet, ItemLocalId, TraitCandidate};
+use rustc_hir::{Crate, ItemLocalId, TraitCandidate};
 use rustc_index::{bit_set::FiniteBitSet, vec::IndexVec};
 use rustc_session::config::{EntryFnType, OptLevel, OutputFilenames, SymbolManglingVersion};
 use rustc_session::utils::NativeLibKind;

--- a/src/librustc_middle/ty/sty.rs
+++ b/src/librustc_middle/ty/sty.rs
@@ -325,24 +325,39 @@ pub struct ClosureSubsts<'tcx> {
     pub substs: SubstsRef<'tcx>,
 }
 
-/// Struct returned by `split()`. Note that these are subslices of the
-/// parent slice and not canonical substs themselves.
-struct SplitClosureSubsts<'tcx> {
-    parent: &'tcx [GenericArg<'tcx>],
-    closure_kind_ty: GenericArg<'tcx>,
-    closure_sig_as_fn_ptr_ty: GenericArg<'tcx>,
-    tupled_upvars_ty: GenericArg<'tcx>,
+/// Struct returned by `split()`.
+pub struct ClosureSubstsParts<'tcx, T> {
+    pub parent_substs: &'tcx [GenericArg<'tcx>],
+    pub closure_kind_ty: T,
+    pub closure_sig_as_fn_ptr_ty: T,
+    pub tupled_upvars_ty: T,
 }
 
 impl<'tcx> ClosureSubsts<'tcx> {
-    /// Divides the closure substs into their respective
-    /// components. Single source of truth with respect to the
-    /// ordering.
-    fn split(self) -> SplitClosureSubsts<'tcx> {
+    /// Construct `ClosureSubsts` from `ClosureSubstsParts`, containing `Substs`
+    /// for the closure parent, alongside additional closure-specific components.
+    pub fn new(
+        tcx: TyCtxt<'tcx>,
+        parts: ClosureSubstsParts<'tcx, Ty<'tcx>>,
+    ) -> ClosureSubsts<'tcx> {
+        ClosureSubsts {
+            substs: tcx.mk_substs(
+                parts.parent_substs.iter().copied().chain(
+                    [parts.closure_kind_ty, parts.closure_sig_as_fn_ptr_ty, parts.tupled_upvars_ty]
+                        .iter()
+                        .map(|&ty| ty.into()),
+                ),
+            ),
+        }
+    }
+
+    /// Divides the closure substs into their respective components.
+    /// The ordering assumed here must match that used by `ClosureSubsts::new` above.
+    fn split(self) -> ClosureSubstsParts<'tcx, GenericArg<'tcx>> {
         match self.substs[..] {
-            [ref parent @ .., closure_kind_ty, closure_sig_as_fn_ptr_ty, tupled_upvars_ty] => {
-                SplitClosureSubsts {
-                    parent,
+            [ref parent_substs @ .., closure_kind_ty, closure_sig_as_fn_ptr_ty, tupled_upvars_ty] => {
+                ClosureSubstsParts {
+                    parent_substs,
                     closure_kind_ty,
                     closure_sig_as_fn_ptr_ty,
                     tupled_upvars_ty,
@@ -363,7 +378,7 @@ impl<'tcx> ClosureSubsts<'tcx> {
 
     /// Returns the substitutions of the closure's parent.
     pub fn parent_substs(self) -> &'tcx [GenericArg<'tcx>] {
-        self.split().parent
+        self.split().parent_substs
     }
 
     #[inline]
@@ -418,21 +433,46 @@ pub struct GeneratorSubsts<'tcx> {
     pub substs: SubstsRef<'tcx>,
 }
 
-struct SplitGeneratorSubsts<'tcx> {
-    parent: &'tcx [GenericArg<'tcx>],
-    resume_ty: GenericArg<'tcx>,
-    yield_ty: GenericArg<'tcx>,
-    return_ty: GenericArg<'tcx>,
-    witness: GenericArg<'tcx>,
-    tupled_upvars_ty: GenericArg<'tcx>,
+pub struct GeneratorSubstsParts<'tcx, T> {
+    pub parent_substs: &'tcx [GenericArg<'tcx>],
+    pub resume_ty: T,
+    pub yield_ty: T,
+    pub return_ty: T,
+    pub witness: T,
+    pub tupled_upvars_ty: T,
 }
 
 impl<'tcx> GeneratorSubsts<'tcx> {
-    fn split(self) -> SplitGeneratorSubsts<'tcx> {
+    /// Construct `GeneratorSubsts` from `GeneratorSubstsParts`, containing `Substs`
+    /// for the generator parent, alongside additional generator-specific components.
+    pub fn new(
+        tcx: TyCtxt<'tcx>,
+        parts: GeneratorSubstsParts<'tcx, Ty<'tcx>>,
+    ) -> GeneratorSubsts<'tcx> {
+        GeneratorSubsts {
+            substs: tcx.mk_substs(
+                parts.parent_substs.iter().copied().chain(
+                    [
+                        parts.resume_ty,
+                        parts.yield_ty,
+                        parts.return_ty,
+                        parts.witness,
+                        parts.tupled_upvars_ty,
+                    ]
+                    .iter()
+                    .map(|&ty| ty.into()),
+                ),
+            ),
+        }
+    }
+
+    /// Divides the generator substs into their respective components.
+    /// The ordering assumed here must match that used by `GeneratorSubsts::new` above.
+    fn split(self) -> GeneratorSubstsParts<'tcx, GenericArg<'tcx>> {
         match self.substs[..] {
-            [ref parent @ .., resume_ty, yield_ty, return_ty, witness, tupled_upvars_ty] => {
-                SplitGeneratorSubsts {
-                    parent,
+            [ref parent_substs @ .., resume_ty, yield_ty, return_ty, witness, tupled_upvars_ty] => {
+                GeneratorSubstsParts {
+                    parent_substs,
                     resume_ty,
                     yield_ty,
                     return_ty,
@@ -455,7 +495,7 @@ impl<'tcx> GeneratorSubsts<'tcx> {
 
     /// Returns the substitutions of the generator's parent.
     pub fn parent_substs(self) -> &'tcx [GenericArg<'tcx>] {
-        self.split().parent
+        self.split().parent_substs
     }
 
     /// This describes the types that can be contained in a generator.

--- a/src/librustc_middle/ty/sty.rs
+++ b/src/librustc_middle/ty/sty.rs
@@ -10,7 +10,7 @@ use crate::ty::subst::{GenericArg, InternalSubsts, Subst, SubstsRef};
 use crate::ty::{
     self, AdtDef, DefIdTree, Discr, Ty, TyCtxt, TypeFlags, TypeFoldable, WithConstness,
 };
-use crate::ty::{List, ParamEnv, TyS};
+use crate::ty::{DelaySpanBugEmitted, List, ParamEnv, TyS};
 use polonius_engine::Atom;
 use rustc_ast::ast;
 use rustc_data_structures::captures::Captures;
@@ -211,12 +211,6 @@ impl TyKind<'tcx> {
         }
     }
 }
-
-/// A type that is not publicly constructable. This prevents people from making `TyKind::Error`
-/// except through `tcx.err*()`.
-#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
-#[derive(TyEncodable, TyDecodable, HashStable)]
-pub struct DelaySpanBugEmitted(pub(super) ());
 
 // `TyKind` is used a lot. Make sure it doesn't unintentionally get bigger.
 #[cfg(target_arch = "x86_64")]

--- a/src/librustc_session/session.rs
+++ b/src/librustc_session/session.rs
@@ -432,6 +432,7 @@ impl Session {
         }
     }
     /// Delay a span_bug() call until abort_if_errors()
+    #[track_caller]
     pub fn delay_span_bug<S: Into<MultiSpan>>(&self, sp: S, msg: &str) {
         self.diagnostic().delay_span_bug(sp, msg)
     }

--- a/src/librustc_typeck/check/closure.rs
+++ b/src/librustc_typeck/check/closure.rs
@@ -11,7 +11,7 @@ use rustc_infer::infer::LateBoundRegionConversionTime;
 use rustc_infer::infer::{InferOk, InferResult};
 use rustc_middle::ty::fold::TypeFoldable;
 use rustc_middle::ty::subst::InternalSubsts;
-use rustc_middle::ty::{self, GenericParamDefKind, Ty};
+use rustc_middle::ty::{self, Ty};
 use rustc_span::source_map::Span;
 use rustc_target::spec::abi::Abi;
 use rustc_trait_selection::traits::error_reporting::ArgKind;
@@ -76,60 +76,44 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let generator_types =
             check_fn(self, self.param_env, liberated_sig, decl, expr.hir_id, body, gen).1;
 
-        let base_substs = InternalSubsts::identity_for_item(
+        let parent_substs = InternalSubsts::identity_for_item(
             self.tcx,
             self.tcx.closure_base_def_id(expr_def_id.to_def_id()),
         );
-        // HACK(eddyb) this hardcodes indices into substs but it should rely on
-        // `ClosureSubsts` and `GeneratorSubsts` providing constructors, instead.
-        // That would also remove the need for most of the inference variables,
-        // as they immediately unified with the actual type below, including
-        // the `InferCtxt::closure_sig` and `ClosureSubsts::sig_ty` methods.
-        let tupled_upvars_idx = base_substs.len() + if generator_types.is_some() { 4 } else { 2 };
-        let substs =
-            base_substs.extend_to(self.tcx, expr_def_id.to_def_id(), |param, _| match param.kind {
-                GenericParamDefKind::Lifetime => span_bug!(expr.span, "closure has lifetime param"),
-                GenericParamDefKind::Type { .. } => if param.index as usize == tupled_upvars_idx {
-                    self.tcx.mk_tup(self.tcx.upvars_mentioned(expr_def_id).iter().flat_map(
-                        |upvars| {
-                            upvars.iter().map(|(&var_hir_id, _)| {
-                                // Create type variables (for now) to represent the transformed
-                                // types of upvars. These will be unified during the upvar
-                                // inference phase (`upvar.rs`).
-                                self.infcx.next_ty_var(TypeVariableOrigin {
-                                    // FIXME(eddyb) distinguish upvar inference variables from the rest.
-                                    kind: TypeVariableOriginKind::ClosureSynthetic,
-                                    span: self.tcx.hir().span(var_hir_id),
-                                })
-                            })
-                        },
-                    ))
-                } else {
-                    // Create type variables (for now) to represent the various
-                    // pieces of information kept in `{Closure,Generic}Substs`.
-                    // They will either be unified below, or later during the upvar
-                    // inference phase (`upvar.rs`)
+
+        let tupled_upvars_ty =
+            self.tcx.mk_tup(self.tcx.upvars_mentioned(expr_def_id).iter().flat_map(|upvars| {
+                upvars.iter().map(|(&var_hir_id, _)| {
+                    // Create type variables (for now) to represent the transformed
+                    // types of upvars. These will be unified during the upvar
+                    // inference phase (`upvar.rs`).
                     self.infcx.next_ty_var(TypeVariableOrigin {
+                        // FIXME(eddyb) distinguish upvar inference variables from the rest.
                         kind: TypeVariableOriginKind::ClosureSynthetic,
-                        span: expr.span,
+                        span: self.tcx.hir().span(var_hir_id),
                     })
-                }
-                .into(),
-                GenericParamDefKind::Const => span_bug!(expr.span, "closure has const param"),
-            });
+                })
+            }));
+
         if let Some(GeneratorTypes { resume_ty, yield_ty, interior, movability }) = generator_types
         {
-            let generator_substs = substs.as_generator();
-            self.demand_eqtype(expr.span, resume_ty, generator_substs.resume_ty());
-            self.demand_eqtype(expr.span, yield_ty, generator_substs.yield_ty());
-            self.demand_eqtype(expr.span, liberated_sig.output(), generator_substs.return_ty());
-            self.demand_eqtype(expr.span, interior, generator_substs.witness());
+            let generator_substs = ty::GeneratorSubsts::new(
+                self.tcx,
+                ty::GeneratorSubstsParts {
+                    parent_substs,
+                    resume_ty,
+                    yield_ty,
+                    return_ty: liberated_sig.output(),
+                    witness: interior,
+                    tupled_upvars_ty,
+                },
+            );
 
-            // HACK(eddyb) this forces the types equated above into `substs` but
-            // it should rely on `GeneratorSubsts` providing a constructor, instead.
-            let substs = self.resolve_vars_if_possible(&substs);
-
-            return self.tcx.mk_generator(expr_def_id.to_def_id(), substs, movability);
+            return self.tcx.mk_generator(
+                expr_def_id.to_def_id(),
+                generator_substs.substs,
+                movability,
+            );
         }
 
         // Tuple up the arguments and insert the resulting function type into
@@ -149,18 +133,29 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             expr_def_id, sig, opt_kind
         );
 
-        let sig_fn_ptr_ty = self.tcx.mk_fn_ptr(sig);
-        self.demand_eqtype(expr.span, sig_fn_ptr_ty, substs.as_closure().sig_as_fn_ptr_ty());
+        let closure_kind_ty = match opt_kind {
+            Some(kind) => kind.to_ty(self.tcx),
 
-        if let Some(kind) = opt_kind {
-            self.demand_eqtype(expr.span, kind.to_ty(self.tcx), substs.as_closure().kind_ty());
-        }
+            // Create a type variable (for now) to represent the closure kind.
+            // It will be unified during the upvar inference phase (`upvar.rs`)
+            None => self.infcx.next_ty_var(TypeVariableOrigin {
+                // FIXME(eddyb) distinguish closure kind inference variables from the rest.
+                kind: TypeVariableOriginKind::ClosureSynthetic,
+                span: expr.span,
+            }),
+        };
 
-        // HACK(eddyb) this forces the types equated above into `substs` but
-        // it should rely on `ClosureSubsts` providing a constructor, instead.
-        let substs = self.resolve_vars_if_possible(&substs);
+        let closure_substs = ty::ClosureSubsts::new(
+            self.tcx,
+            ty::ClosureSubstsParts {
+                parent_substs,
+                closure_kind_ty,
+                closure_sig_as_fn_ptr_ty: self.tcx.mk_fn_ptr(sig),
+                tupled_upvars_ty,
+            },
+        );
 
-        let closure_type = self.tcx.mk_closure(expr_def_id.to_def_id(), substs);
+        let closure_type = self.tcx.mk_closure(expr_def_id.to_def_id(), closure_substs.substs);
 
         debug!("check_closure: expr.hir_id={:?} closure_type={:?}", expr.hir_id, closure_type);
 

--- a/src/test/ui/foreign/issue-74120-lowering-of-ffi-block-bodies.rs
+++ b/src/test/ui/foreign/issue-74120-lowering-of-ffi-block-bodies.rs
@@ -1,0 +1,11 @@
+// Previously this ICE'd because `fn g()` would be lowered, but the block associated with `fn f()`
+// wasn't.
+
+// compile-flags: --crate-type=lib
+
+extern "C" {
+    fn f() {
+    //~^ incorrect function inside `extern` block
+        fn g() {}
+    }
+}

--- a/src/test/ui/foreign/issue-74120-lowering-of-ffi-block-bodies.stderr
+++ b/src/test/ui/foreign/issue-74120-lowering-of-ffi-block-bodies.stderr
@@ -1,0 +1,19 @@
+error: incorrect function inside `extern` block
+  --> $DIR/issue-74120-lowering-of-ffi-block-bodies.rs:7:8
+   |
+LL |   extern "C" {
+   |   ---------- `extern` blocks define existing foreign functions and functions inside of them cannot have a body
+LL |       fn f() {
+   |  ________^___-
+   | |        |
+   | |        cannot have a body
+LL | |
+LL | |         fn g() {}
+LL | |     }
+   | |_____- help: remove the invalid body: `;`
+   |
+   = help: you might have meant to write a function accessible through FFI, which can be done by writing `extern fn` outside of the `extern` block
+   = note: for more information, visit https://doc.rust-lang.org/std/keyword.extern.html
+
+error: aborting due to previous error
+

--- a/src/test/ui/issues/issue-66768.rs
+++ b/src/test/ui/issues/issue-66768.rs
@@ -1,0 +1,205 @@
+// Regression test for #66768.
+// check-pass
+#![allow(dead_code)]
+//-^ "dead code" is needed to reproduce the issue.
+
+use std::marker::PhantomData;
+use std::ops::{Add, Mul};
+
+fn problematic_function<Space>(material_surface_element: Edge2dElement)
+where
+    DefaultAllocator: FiniteElementAllocator<DimU1, Space>,
+{
+    let _: Point2<f64> = material_surface_element.map_reference_coords().into();
+}
+
+impl<T> ArrayLength<T> for UTerm {
+    type ArrayType = ();
+}
+impl<T, N: ArrayLength<T>> ArrayLength<T> for UInt<N, B0> {
+    type ArrayType = GenericArrayImplEven<T, N>;
+}
+impl<T, N: ArrayLength<T>> ArrayLength<T> for UInt<N, B1> {
+    type ArrayType = GenericArrayImplOdd<T, N>;
+}
+impl<U> Add<U> for UTerm {
+    type Output = U;
+    fn add(self, _: U) -> Self::Output {
+        unimplemented!()
+    }
+}
+impl<Ul, Ur> Add<UInt<Ur, B1>> for UInt<Ul, B0>
+where
+    Ul: Add<Ur>,
+{
+    type Output = UInt<Sum<Ul, Ur>, B1>;
+    fn add(self, _: UInt<Ur, B1>) -> Self::Output {
+        unimplemented!()
+    }
+}
+impl<U> Mul<U> for UTerm {
+    type Output = UTerm;
+    fn mul(self, _: U) -> Self {
+        unimplemented!()
+    }
+}
+impl<Ul, B, Ur> Mul<UInt<Ur, B>> for UInt<Ul, B0>
+where
+    Ul: Mul<UInt<Ur, B>>,
+{
+    type Output = UInt<Prod<Ul, UInt<Ur, B>>, B0>;
+    fn mul(self, _: UInt<Ur, B>) -> Self::Output {
+        unimplemented!()
+    }
+}
+impl<Ul, B, Ur> Mul<UInt<Ur, B>> for UInt<Ul, B1>
+where
+    Ul: Mul<UInt<Ur, B>>,
+    UInt<Prod<Ul, UInt<Ur, B>>, B0>: Add<UInt<Ur, B>>,
+{
+    type Output = Sum<UInt<Prod<Ul, UInt<Ur, B>>, B0>, UInt<Ur, B>>;
+    fn mul(self, _: UInt<Ur, B>) -> Self::Output {
+        unimplemented!()
+    }
+}
+impl<N, R, C> Allocator<N, R, C> for DefaultAllocator
+where
+    R: DimName,
+    C: DimName,
+    R::Value: Mul<C::Value>,
+    Prod<R::Value, C::Value>: ArrayLength<N>,
+{
+    type Buffer = ArrayStorage<N, R, C>;
+    fn allocate_uninitialized(_: R, _: C) -> Self::Buffer {
+        unimplemented!()
+    }
+    fn allocate_from_iterator<I>(_: R, _: C, _: I) -> Self::Buffer {
+        unimplemented!()
+    }
+}
+impl<N, C> Allocator<N, Dynamic, C> for DefaultAllocator {
+    type Buffer = VecStorage<N, Dynamic, C>;
+    fn allocate_uninitialized(_: Dynamic, _: C) -> Self::Buffer {
+        unimplemented!()
+    }
+    fn allocate_from_iterator<I>(_: Dynamic, _: C, _: I) -> Self::Buffer {
+        unimplemented!()
+    }
+}
+impl DimName for DimU1 {
+    type Value = U1;
+    fn name() -> Self {
+        unimplemented!()
+    }
+}
+impl DimName for DimU2 {
+    type Value = U2;
+    fn name() -> Self {
+        unimplemented!()
+    }
+}
+impl<N, D> From<VectorN<N, D>> for Point<N, D>
+where
+    DefaultAllocator: Allocator<N, D>,
+{
+    fn from(_: VectorN<N, D>) -> Self {
+        unimplemented!()
+    }
+}
+impl<GeometryDim, NodalDim> FiniteElementAllocator<GeometryDim, NodalDim> for DefaultAllocator where
+    DefaultAllocator: Allocator<f64, GeometryDim> + Allocator<f64, NodalDim>
+{
+}
+impl ReferenceFiniteElement for Edge2dElement {
+    type NodalDim = DimU1;
+}
+impl FiniteElement<DimU2> for Edge2dElement {
+    fn map_reference_coords(&self) -> Vector2<f64> {
+        unimplemented!()
+    }
+}
+
+type Owned<N, R, C> = <DefaultAllocator as Allocator<N, R, C>>::Buffer;
+type MatrixMN<N, R, C> = Matrix<N, R, C, Owned<N, R, C>>;
+type VectorN<N, D> = MatrixMN<N, D, DimU1>;
+type Vector2<N> = VectorN<N, DimU2>;
+type Point2<N> = Point<N, DimU2>;
+type U1 = UInt<UTerm, B1>;
+type U2 = UInt<UInt<UTerm, B1>, B0>;
+type Sum<A, B> = <A as Add<B>>::Output;
+type Prod<A, B> = <A as Mul<B>>::Output;
+
+struct GenericArray<T, U: ArrayLength<T>> {
+    _data: U::ArrayType,
+}
+struct GenericArrayImplEven<T, U> {
+    _parent2: U,
+    _marker: T,
+}
+struct GenericArrayImplOdd<T, U> {
+    _parent2: U,
+    _data: T,
+}
+struct B0;
+struct B1;
+struct UTerm;
+struct UInt<U, B> {
+    _marker: PhantomData<(U, B)>,
+}
+struct DefaultAllocator;
+struct Dynamic;
+struct DimU1;
+struct DimU2;
+struct Matrix<N, R, C, S> {
+    _data: S,
+    _phantoms: PhantomData<(N, R, C)>,
+}
+struct ArrayStorage<N, R, C>
+where
+    R: DimName,
+    C: DimName,
+    R::Value: Mul<C::Value>,
+    Prod<R::Value, C::Value>: ArrayLength<N>,
+{
+    _data: GenericArray<N, Prod<R::Value, C::Value>>,
+}
+struct VecStorage<N, R, C> {
+    _data: N,
+    _nrows: R,
+    _ncols: C,
+}
+struct Point<N, D>
+where
+    DefaultAllocator: Allocator<N, D>,
+{
+    _coords: VectorN<N, D>,
+}
+struct Edge2dElement;
+
+trait ArrayLength<T> {
+    type ArrayType;
+}
+trait Allocator<Scalar, R, C = DimU1> {
+    type Buffer;
+    fn allocate_uninitialized(nrows: R, ncols: C) -> Self::Buffer;
+    fn allocate_from_iterator<I>(nrows: R, ncols: C, iter: I) -> Self::Buffer;
+}
+trait DimName {
+    type Value;
+    fn name() -> Self;
+}
+trait FiniteElementAllocator<GeometryDim, NodalDim>:
+    Allocator<f64, GeometryDim> + Allocator<f64, NodalDim>
+{
+}
+trait ReferenceFiniteElement {
+    type NodalDim;
+}
+trait FiniteElement<GeometryDim>: ReferenceFiniteElement
+where
+    DefaultAllocator: FiniteElementAllocator<GeometryDim, Self::NodalDim>,
+{
+    fn map_reference_coords(&self) -> VectorN<f64, GeometryDim>;
+}
+
+fn main() {}


### PR DESCRIPTION
Successful merges:

 - #74204 (Don't visit foreign function bodies when lowering ast to hir)
 - #74314 (rustc_typeck: construct {Closure,Generator}Substs more directly.)
 - #74346 (Use LocalDefId instead of HirId for reachable_set elements.)
 - #74399 (Move DelaySpanBugEmitted to ty::context)
 - #75177 (Add regression test for issue-66768)
 - #75223 (Add #[track_caller] to `Session::delay_span_bug`)
 - #75423 (Move to intra-doc links for /library/core/src/hint.rs)
 - #75485 (pin docs: add some forward references)
 - #75569 (Bump minor version of emsdk to 1.38.47)
 - #75596 (Switch to intra-doc links in /sys/windows/ext/{ffi,fs,process}.rs)

Failed merges:


r? @ghost