### PR TITLE
Add help note when using type in place of const

### DIFF
--- a/src/test/ui/const-generics/invalid-enum.rs
+++ b/src/test/ui/const-generics/invalid-enum.rs
@@ -7,11 +7,33 @@ enum CompileFlag {
   B,
 }
 
-pub fn test<const CF: CompileFlag>() {}
+pub fn test_1<const CF: CompileFlag>() {}
+pub fn test_2<T, const CF: CompileFlag>(x: T) {}
+pub struct Example<const CF: CompileFlag, T=u32>{
+  x: T,
+}
+
+impl<const CF: CompileFlag, T> Example<CF, T> {
+  const ASSOC_FLAG: CompileFlag = CompileFlag::A;
+}
 
 pub fn main() {
-  test::<CompileFlag::A>();
+  test_1::<CompileFlag::A>();
   //~^ ERROR: expected type, found variant
   //~| ERROR: wrong number of const arguments
+  //~| ERROR: wrong number of type arguments
+
+  test_2::<_, CompileFlag::A>(0);
+  //~^ ERROR: expected type, found variant
+  //~| ERROR: wrong number of const arguments
+  //~| ERROR: wrong number of type arguments
+
+  let _: Example<CompileFlag::A, _> = Example { x: 0 };
+  //~^ ERROR: expected type, found variant
+  //~| ERROR: wrong number of const arguments
+  //~| ERROR: wrong number of type arguments
+
+  let _: Example<Example::ASSOC_FLAG, _> = Example { x: 0 };
+  //~^ ERROR: wrong number of const arguments
   //~| ERROR: wrong number of type arguments
 }

--- a/src/test/ui/const-generics/invalid-enum.rs
+++ b/src/test/ui/const-generics/invalid-enum.rs
@@ -1,0 +1,17 @@
+#![feature(const_generics)]
+#![allow(incomplete_features)]
+
+#[derive(PartialEq, Eq)]
+enum CompileFlag {
+  A,
+  B,
+}
+
+pub fn test<const CF: CompileFlag>() {}
+
+pub fn main() {
+  test::<CompileFlag::A>();
+  //~^ ERROR: expected type, found variant
+  //~| ERROR: wrong number of const arguments
+  //~| ERROR: wrong number of type arguments
+}

--- a/src/test/ui/const-generics/invalid-enum.stderr
+++ b/src/test/ui/const-generics/invalid-enum.stderr
@@ -19,7 +19,10 @@ error[E0107]: wrong number of type arguments: expected 0, found 1
 LL |   test::<CompileFlag::A>();
    |          ^^^^^^^^^^^^^^ unexpected type argument
    |
-   = help: For more complex types, surround with braces: `{ HirId { owner: DefId(0:5 ~ invalid_enum[317d]::main[0]), local_id: 1 } }`
+help: If this generic argument was intended as a const parameter, try surrounding it with braces:
+   |
+LL |   test::<{ CompileFlag::A }>();
+   |          ^                ^
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/const-generics/invalid-enum.stderr
+++ b/src/test/ui/const-generics/invalid-enum.stderr
@@ -1,0 +1,27 @@
+error[E0573]: expected type, found variant `CompileFlag::A`
+  --> $DIR/invalid-enum.rs:13:10
+   |
+LL |   test::<CompileFlag::A>();
+   |          ^^^^^^^^^^^^^^
+   |          |
+   |          not a type
+   |          help: try using the variant's enum: `CompileFlag`
+
+error[E0107]: wrong number of const arguments: expected 1, found 0
+  --> $DIR/invalid-enum.rs:13:3
+   |
+LL |   test::<CompileFlag::A>();
+   |   ^^^^^^^^^^^^^^^^^^^^^^ expected 1 const argument
+
+error[E0107]: wrong number of type arguments: expected 0, found 1
+  --> $DIR/invalid-enum.rs:13:10
+   |
+LL |   test::<CompileFlag::A>();
+   |          ^^^^^^^^^^^^^^ unexpected type argument
+   |
+   = help: For more complex types, surround with braces: `{ HirId { owner: DefId(0:5 ~ invalid_enum[317d]::main[0]), local_id: 1 } }`
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0107, E0573.
+For more information about an error, try `rustc --explain E0107`.

--- a/src/test/ui/const-generics/invalid-enum.stderr
+++ b/src/test/ui/const-generics/invalid-enum.stderr
@@ -1,30 +1,99 @@
 error[E0573]: expected type, found variant `CompileFlag::A`
-  --> $DIR/invalid-enum.rs:13:10
+  --> $DIR/invalid-enum.rs:21:12
    |
-LL |   test::<CompileFlag::A>();
-   |          ^^^^^^^^^^^^^^
-   |          |
-   |          not a type
-   |          help: try using the variant's enum: `CompileFlag`
+LL |   test_1::<CompileFlag::A>();
+   |            ^^^^^^^^^^^^^^
+   |            |
+   |            not a type
+   |            help: try using the variant's enum: `CompileFlag`
+
+error[E0573]: expected type, found variant `CompileFlag::A`
+  --> $DIR/invalid-enum.rs:26:15
+   |
+LL |   test_2::<_, CompileFlag::A>(0);
+   |               ^^^^^^^^^^^^^^
+   |               |
+   |               not a type
+   |               help: try using the variant's enum: `CompileFlag`
+
+error[E0573]: expected type, found variant `CompileFlag::A`
+  --> $DIR/invalid-enum.rs:31:18
+   |
+LL |   let _: Example<CompileFlag::A, _> = Example { x: 0 };
+   |                  ^^^^^^^^^^^^^^
+   |                  |
+   |                  not a type
+   |                  help: try using the variant's enum: `CompileFlag`
 
 error[E0107]: wrong number of const arguments: expected 1, found 0
-  --> $DIR/invalid-enum.rs:13:3
+  --> $DIR/invalid-enum.rs:31:10
    |
-LL |   test::<CompileFlag::A>();
-   |   ^^^^^^^^^^^^^^^^^^^^^^ expected 1 const argument
+LL |   let _: Example<CompileFlag::A, _> = Example { x: 0 };
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^ expected 1 const argument
 
-error[E0107]: wrong number of type arguments: expected 0, found 1
-  --> $DIR/invalid-enum.rs:13:10
+error[E0107]: wrong number of type arguments: expected at most 1, found 2
+  --> $DIR/invalid-enum.rs:31:10
    |
-LL |   test::<CompileFlag::A>();
-   |          ^^^^^^^^^^^^^^ unexpected type argument
+LL |   let _: Example<CompileFlag::A, _> = Example { x: 0 };
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^ expected at most 1 type argument
    |
 help: If this generic argument was intended as a const parameter, try surrounding it with braces:
    |
-LL |   test::<{ CompileFlag::A }>();
-   |          ^                ^
+LL |   let _: Example<{ CompileFlag::A }, _> = Example { x: 0 };
+   |                  ^                ^
 
-error: aborting due to 3 previous errors
+error[E0107]: wrong number of const arguments: expected 1, found 0
+  --> $DIR/invalid-enum.rs:36:10
+   |
+LL |   let _: Example<Example::ASSOC_FLAG, _> = Example { x: 0 };
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected 1 const argument
+
+error[E0107]: wrong number of type arguments: expected at most 1, found 2
+  --> $DIR/invalid-enum.rs:36:10
+   |
+LL |   let _: Example<Example::ASSOC_FLAG, _> = Example { x: 0 };
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected at most 1 type argument
+   |
+help: If this generic argument was intended as a const parameter, try surrounding it with braces:
+   |
+LL |   let _: Example<{ Example::ASSOC_FLAG }, _> = Example { x: 0 };
+   |                  ^                     ^
+
+error[E0107]: wrong number of const arguments: expected 1, found 0
+  --> $DIR/invalid-enum.rs:21:3
+   |
+LL |   test_1::<CompileFlag::A>();
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^ expected 1 const argument
+
+error[E0107]: wrong number of type arguments: expected 0, found 1
+  --> $DIR/invalid-enum.rs:21:12
+   |
+LL |   test_1::<CompileFlag::A>();
+   |            ^^^^^^^^^^^^^^ unexpected type argument
+   |
+help: If this generic argument was intended as a const parameter, try surrounding it with braces:
+   |
+LL |   test_1::<{ CompileFlag::A }>();
+   |            ^                ^
+
+error[E0107]: wrong number of const arguments: expected 1, found 0
+  --> $DIR/invalid-enum.rs:26:3
+   |
+LL |   test_2::<_, CompileFlag::A>(0);
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected 1 const argument
+
+error[E0107]: wrong number of type arguments: expected 1, found 2
+  --> $DIR/invalid-enum.rs:26:15
+   |
+LL |   test_2::<_, CompileFlag::A>(0);
+   |               ^^^^^^^^^^^^^^ unexpected type argument
+   |
+help: If this generic argument was intended as a const parameter, try surrounding it with braces:
+   |
+LL |   test_2::<_, { CompileFlag::A }>(0);
+   |               ^                ^
+
+error: aborting due to 11 previous errors
 
 Some errors have detailed explanations: E0107, E0573.
 For more information about an error, try `rustc --explain E0107`.

--- a/src/test/ui/const-generics/issues/issue-62878.stderr
+++ b/src/test/ui/const-generics/issues/issue-62878.stderr
@@ -24,6 +24,8 @@ error[E0107]: wrong number of type arguments: expected 0, found 1
    |
 LL |     foo::<_, {[1]}>();
    |           ^ unexpected type argument
+   |
+   = help: For more complex types, surround with braces: `{ HirId { owner: DefId(0:7 ~ issue_62878[317d]::main[0]), local_id: 1 } }`
 
 error[E0308]: mismatched types
   --> $DIR/issue-62878.rs:7:15

--- a/src/test/ui/const-generics/issues/issue-62878.stderr
+++ b/src/test/ui/const-generics/issues/issue-62878.stderr
@@ -24,8 +24,6 @@ error[E0107]: wrong number of type arguments: expected 0, found 1
    |
 LL |     foo::<_, {[1]}>();
    |           ^ unexpected type argument
-   |
-   = help: For more complex types, surround with braces: `{ HirId { owner: DefId(0:7 ~ issue_62878[317d]::main[0]), local_id: 1 } }`
 
 error[E0308]: mismatched types
   --> $DIR/issue-62878.rs:7:15


### PR DESCRIPTION
This adds a small help note when it might be possible that wrapping a parameter in braces might resolve the issue of having a type where a const was expected.

Currently, I am displaying the `HirId`, and I'm not particularly sure where to get the currently displayed path(?).

r? @lcnr 