### PR TITLE
Marking remapping with an enum, instead of a bool

### DIFF
--- a/src/librustc_errors/emitter.rs
+++ b/src/librustc_errors/emitter.rs
@@ -1299,7 +1299,7 @@ impl EmitterWriter {
                         &format!(
                             "{}:{}:{}",
                             loc.file.name,
-                            sm.doctest_offset_line(&loc.file.name, loc.line),
+                            sm.doctest_offset_line(&loc.file.name.name(), loc.line),
                             loc.col.0 + 1,
                         ),
                         Style::LineAndColumn,
@@ -1313,7 +1313,7 @@ impl EmitterWriter {
                         &format!(
                             "{}:{}:{}: ",
                             loc.file.name,
-                            sm.doctest_offset_line(&loc.file.name, loc.line),
+                            sm.doctest_offset_line(&loc.file.name.name(), loc.line),
                             loc.col.0 + 1,
                         ),
                         Style::LineAndColumn,
@@ -1337,7 +1337,10 @@ impl EmitterWriter {
                     format!(
                         "{}:{}{}",
                         annotated_file.file.name,
-                        sm.doctest_offset_line(&annotated_file.file.name, first_line.line_index),
+                        sm.doctest_offset_line(
+                            &annotated_file.file.name.name(),
+                            first_line.line_index
+                        ),
                         col
                     )
                 } else {

--- a/src/librustc_expand/proc_macro_server.rs
+++ b/src/librustc_expand/proc_macro_server.rs
@@ -610,7 +610,7 @@ impl server::SourceFile for Rustc<'_> {
         Lrc::ptr_eq(file1, file2)
     }
     fn path(&mut self, file: &Self::SourceFile) -> String {
-        match file.name {
+        match file.name.name() {
             FileName::Real(ref name) => name
                 .local_path()
                 .to_str()

--- a/src/librustc_interface/passes.rs
+++ b/src/librustc_interface/passes.rs
@@ -547,7 +547,7 @@ fn write_out_deps(
             .iter()
             .filter(|fmap| fmap.is_real_file())
             .filter(|fmap| !fmap.is_imported())
-            .map(|fmap| escape_dep_filename(&fmap.unmapped_path.as_ref().unwrap_or(&fmap.name)))
+            .map(|fmap| escape_dep_filename(&fmap.name.unmapped_path()))
             .collect();
 
         if sess.binary_dep_depinfo() {

--- a/src/librustc_metadata/rmeta/decoder.rs
+++ b/src/librustc_metadata/rmeta/decoder.rs
@@ -1635,7 +1635,6 @@ impl<'a, 'tcx> CrateMetadataRef<'a> {
                     // containing the information we need.
                     let rustc_span::SourceFile {
                         mut name,
-                        name_was_remapped,
                         src_hash,
                         start_pos,
                         end_pos,
@@ -1652,7 +1651,7 @@ impl<'a, 'tcx> CrateMetadataRef<'a> {
                     // on `try_to_translate_virtual_to_real`).
                     // FIXME(eddyb) we could check `name_was_remapped` here,
                     // but in practice it seems to be always `false`.
-                    try_to_translate_virtual_to_real(&mut name);
+                    try_to_translate_virtual_to_real(name.name_mut());
 
                     let source_length = (end_pos - start_pos).to_usize();
 
@@ -1675,8 +1674,8 @@ impl<'a, 'tcx> CrateMetadataRef<'a> {
                     }
 
                     let local_version = sess.source_map().new_imported_source_file(
-                        name,
-                        name_was_remapped,
+                        name.name().clone(),
+                        name.was_remapped(),
                         src_hash,
                         name_hash,
                         source_length,

--- a/src/librustc_metadata/rmeta/encoder.rs
+++ b/src/librustc_metadata/rmeta/encoder.rs
@@ -445,11 +445,11 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
                 (!source_file.is_imported() || self.is_proc_macro)
             })
             .map(|(_, source_file)| {
-                let mut adapted = match source_file.name {
+                let mut adapted = match source_file.name.name() {
                     // This path of this SourceFile has been modified by
                     // path-remapping, so we use it verbatim (and avoid
                     // cloning the whole map in the process).
-                    _ if source_file.name_was_remapped => source_file.clone(),
+                    _ if source_file.name.was_remapped() => source_file.clone(),
 
                     // Otherwise expand all paths to absolute paths because
                     // any relative paths are potentially relative to a
@@ -460,7 +460,7 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
                         adapted.name = Path::new(&working_dir).join(name).into();
                         adapted.name_hash = {
                             let mut hasher: StableHasher = StableHasher::new();
-                            adapted.name.hash(&mut hasher);
+                            adapted.name.name().hash(&mut hasher);
                             hasher.finish::<u128>()
                         };
                         Lrc::new(adapted)

--- a/src/librustc_middle/ich/impls_syntax.rs
+++ b/src/librustc_middle/ich/impls_syntax.rs
@@ -56,8 +56,6 @@ impl<'a> HashStable<StableHashingContext<'a>> for SourceFile {
         let SourceFile {
             name: _, // We hash the smaller name_hash instead of this
             name_hash,
-            name_was_remapped,
-            unmapped_path: _,
             cnum,
             // Do not hash the source as it is not encoded
             src: _,
@@ -72,7 +70,6 @@ impl<'a> HashStable<StableHashingContext<'a>> for SourceFile {
         } = *self;
 
         (name_hash as u64).hash_stable(hcx, hasher);
-        name_was_remapped.hash_stable(hcx, hasher);
 
         src_hash.hash_stable(hcx, hasher);
 

--- a/src/librustc_mir/transform/instrument_coverage.rs
+++ b/src/librustc_mir/transform/instrument_coverage.rs
@@ -214,7 +214,7 @@ fn make_code_region<'tcx>(tcx: TyCtxt<'tcx>, span: &Span) -> CodeRegion {
         );
         end
     };
-    match &start.file.name {
+    match &start.file.name.name() {
         FileName::Real(RealFileName::Named(path)) => CodeRegion {
             file_name: Symbol::intern(&path.to_string_lossy()),
             start_line: start.line as u32,

--- a/src/librustc_save_analysis/span_utils.rs
+++ b/src/librustc_save_analysis/span_utils.rs
@@ -15,8 +15,8 @@ impl<'a> SpanUtils<'a> {
     }
 
     pub fn make_filename_string(&self, file: &SourceFile) -> String {
-        match &file.name {
-            FileName::Real(name) if !file.name_was_remapped => {
+        match file.name.name() {
+            FileName::Real(name) if !file.name.was_remapped() => {
                 let path = name.local_path();
                 if path.is_absolute() {
                     self.sess

--- a/src/librustc_span/lib.rs
+++ b/src/librustc_span/lib.rs
@@ -1096,6 +1096,10 @@ impl SourceFileName {
         &self.name
     }
 
+    pub fn name_mut(&mut self) -> &mut FileName {
+        &mut self.name
+    }
+
     pub fn unmapped_path(&self) -> &FileName {
         self.unmapped_name.as_ref().unwrap_or(self.name())
     }
@@ -1106,6 +1110,14 @@ impl SourceFileName {
 
     pub fn was_remapped(&self) -> bool {
         self.was_remapped
+    }
+}
+
+/// This conversion assumes that the path was not remapped (ie name == unmapped_name)
+impl From<PathBuf> for SourceFileName {
+    fn from(path: PathBuf) -> Self {
+        let name: FileName = path.into();
+        Self::new(name.clone(), false, Some(name))
     }
 }
 

--- a/src/librustc_span/lib.rs
+++ b/src/librustc_span/lib.rs
@@ -1074,7 +1074,7 @@ impl SourceFileHash {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct SourceFileName {
     /// The name of the file that the source came from. Source that doesn't
     /// originate from files has names between angle brackets by convention

--- a/src/librustc_span/lib.rs
+++ b/src/librustc_span/lib.rs
@@ -1103,6 +1103,10 @@ impl SourceFileName {
     fn is_real(&self) -> bool {
         self.name.is_real()
     }
+
+    pub fn was_remapped(&self) -> bool {
+        self.was_remapped
+    }
 }
 
 impl Encodable for SourceFileName {

--- a/src/librustc_span/lib.rs
+++ b/src/librustc_span/lib.rs
@@ -1146,8 +1146,12 @@ impl<D: Decoder> Decodable<D> for SourceFileName {
 }
 
 impl std::fmt::Display for SourceFileName {
-    fn fmt(&self, _fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        todo!()
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.was_remapped() {
+            write!(fmt, "SourceFileName({}, remapped from {})", self.name, self.unmapped_path())
+        } else {
+            write!(fmt, "SourceFileName({})", self.name)
+        }
     }
 }
 

--- a/src/librustc_span/lib.rs
+++ b/src/librustc_span/lib.rs
@@ -1121,8 +1121,8 @@ impl From<PathBuf> for SourceFileName {
     }
 }
 
-impl Encodable for SourceFileName {
-    fn encode<S: Encoder>(&self, s: &mut S) -> Result<(), S::Error> {
+impl<S: Encoder> Encodable<S> for SourceFileName {
+    fn encode(&self, s: &mut S) -> Result<(), S::Error> {
         s.emit_struct("SourceFileName", 3, |s| {
             s.emit_struct_field("name", 0, |s| self.name.encode(s))?;
             s.emit_struct_field("was_remapped", 1, |s| self.was_remapped.encode(s))?;
@@ -1132,8 +1132,8 @@ impl Encodable for SourceFileName {
     }
 }
 
-impl Decodable for SourceFileName {
-    fn decode<D: Decoder>(d: &mut D) -> Result<Self, D::Error> {
+impl<D: Decoder> Decodable<D> for SourceFileName {
+    fn decode(d: &mut D) -> Result<Self, D::Error> {
         d.read_struct("SourceFileName", 3, |d| {
             let name: FileName = d.read_struct_field("name", 0, |d| Decodable::decode(d))?;
             let was_remapped: bool =

--- a/src/librustc_span/lib.rs
+++ b/src/librustc_span/lib.rs
@@ -1356,7 +1356,7 @@ impl SourceFile {
             analyze_source_file::analyze_source_file(&src[..], start_pos);
 
         SourceFile {
-            name: if name_was_remapped { Name::Remapped(name) } else { Name::Normal(name) },
+            name: Name::new(name, name_was_remapped),
             unmapped_path: Some(unmapped_path),
             src: Some(Lrc::new(src)),
             src_hash,

--- a/src/librustc_span/lib.rs
+++ b/src/librustc_span/lib.rs
@@ -1074,97 +1074,71 @@ impl SourceFileHash {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
-enum Name {
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd)]
+pub struct SourceFileName {
     /// The name of the file that the source came from. Source that doesn't
     /// originate from files has names between angle brackets by convention
     /// (e.g., `<anon>`).
-    Normal(FileName),
-    /// FileName modified by `--remap-path-prefix`.
-    Remapped(FileName),
+    name: FileName,
+    /// `true` if the name field was modified by `--remap-path-prefix`.
+    was_remapped: bool,
+    /// The unmapped path of the file that the source came from.
+    /// Set to `None` if the `SourceFile` was imported from an external crate.
+    unmapped_name: Option<FileName>,
 }
 
-impl Name {
-    pub fn new(filename: FileName, was_remapped: bool) -> Self {
-        if was_remapped { Name::Remapped(filename) } else { Name::Normal(filename) }
+impl SourceFileName {
+    pub fn new(name: FileName, was_remapped: bool, unmapped_name: Option<FileName>) -> Self {
+        Self { name, was_remapped, unmapped_name }
+    }
+
+    pub fn name(&self) -> &FileName {
+        &self.name
+    }
+
+    pub fn unmapped_path(&self) -> &FileName {
+        self.unmapped_name.as_ref().unwrap_or(self.name())
     }
 
     fn is_real(&self) -> bool {
-        use Name::*;
-        match *self {
-            Normal(ref name) => name.is_real(),
-            Remapped(ref name) => name.is_real(),
-        }
-    }
-
-    fn is_remapped(&self) -> bool {
-        use Name::*;
-        match *self {
-            Normal(_) => false,
-            Remapped(_) => true,
-        }
-    }
-
-    fn name_and_remapped(&self) -> (FileName, bool) {
-        use Name::*;
-        let name = match *self {
-            Normal(ref name) => name,
-            Remapped(ref name) => name,
-        };
-        (name.clone(), self.is_remapped())
+        self.name.is_real()
     }
 }
 
-/// Does a comparison with the filename, ignoring any remapping.
-impl PartialEq<FileName> for Name {
-    fn eq(&self, other: &FileName) -> bool {
-        use Name::*;
-        match *self {
-            Normal(ref name) => name == other,
-            Remapped(ref name) => name == other,
-        }
-    }
-}
-
-impl std::fmt::Display for Name {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        use Name::*;
-        match *self {
-            Normal(ref name) => write!(fmt, "{}", name),
-            Remapped(ref name) => write!(fmt, "remapped {}", name),
-        }
-    }
-}
-
-impl Encodable for Name {
+impl Encodable for SourceFileName {
     fn encode<S: Encoder>(&self, s: &mut S) -> Result<(), S::Error> {
-        s.emit_enum("Name", |s| match self {
-            Name::Normal(name) => s.emit_enum_variant("Normal", 0, 1, |s| name.encode(s)),
-            Name::Remapped(name) => s.emit_enum_variant("Remapped", 1, 1, |s| name.encode(s)),
+        s.emit_struct("SourceFileName", 3, |s| {
+            s.emit_struct_field("name", 0, |s| self.name.encode(s))?;
+            s.emit_struct_field("was_remapped", 1, |s| self.was_remapped.encode(s))?;
+            s.emit_struct_field("unmapped_name", 2, |s| self.unmapped_name.encode(s))?;
+            Ok(())
         })
     }
 }
 
-impl Decodable for Name {
+impl Decodable for SourceFileName {
     fn decode<D: Decoder>(d: &mut D) -> Result<Self, D::Error> {
-        let names = ["Normal", "Remapped"];
-        d.read_enum("Name", |d| {
-            d.read_enum_variant(&names, |d, id| match id {
-                0 => Ok(Name::Normal(FileName::decode(d)?)),
-                1 => Ok(Name::Remapped(FileName::decode(d)?)),
-                _ => Err(d.error("Name enum variant could not be found")),
-            })
+        d.read_struct("SourceFileName", 3, |d| {
+            let name: FileName = d.read_struct_field("name", 0, |d| Decodable::decode(d))?;
+            let was_remapped: bool =
+                d.read_struct_field("was_remapped", 1, |d| Decodable::decode(d))?;
+            let unmapped_name: Option<FileName> =
+                d.read_struct_field("unmapped_name", 2, |d| Decodable::decode(d))?;
+            Ok(Self::new(name, was_remapped, unmapped_name))
         })
+    }
+}
+
+impl std::fmt::Display for SourceFileName {
+    fn fmt(&self, _fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        todo!()
     }
 }
 
 /// A single source in the `SourceMap`.
 #[derive(Clone)]
 pub struct SourceFile {
-    pub name: Name,
-    /// The unmapped path of the file that the source came from.
-    /// Set to `None` if the `SourceFile` was imported from an external crate.
-    pub unmapped_path: Option<FileName>,
+    pub name: SourceFileName,
     /// The complete source code.
     pub src: Option<Lrc<String>>,
     /// The source code's hash.
@@ -1262,7 +1236,7 @@ impl<S: Encoder> Encodable<S> for SourceFile {
 impl<D: Decoder> Decodable<D> for SourceFile {
     fn decode(d: &mut D) -> Result<SourceFile, D::Error> {
         d.read_struct("SourceFile", 8, |d| {
-            let name: Name = d.read_struct_field("name", 0, |d| Decodable::decode(d))?;
+            let name: SourceFileName = d.read_struct_field("name", 0, |d| Decodable::decode(d))?;
             let src_hash: SourceFileHash =
                 d.read_struct_field("src_hash", 2, |d| Decodable::decode(d))?;
             let start_pos: BytePos =
@@ -1306,7 +1280,6 @@ impl<D: Decoder> Decodable<D> for SourceFile {
             let cnum: CrateNum = d.read_struct_field("cnum", 10, |d| Decodable::decode(d))?;
             Ok(SourceFile {
                 name,
-                unmapped_path: None,
                 start_pos,
                 end_pos,
                 src: None,
@@ -1356,8 +1329,7 @@ impl SourceFile {
             analyze_source_file::analyze_source_file(&src[..], start_pos);
 
         SourceFile {
-            name: Name::new(name, name_was_remapped),
-            unmapped_path: Some(unmapped_path),
+            name: SourceFileName::new(name, name_was_remapped, Some(unmapped_path)),
             src: Some(Lrc::new(src)),
             src_hash,
             external_src: Lock::new(ExternalSource::Unneeded),
@@ -1774,18 +1746,18 @@ pub enum SpanSnippetError {
     IllFormedSpan(Span),
     DistinctSources(DistinctSources),
     MalformedForSourcemap(MalformedSourceMapPositions),
-    SourceNotAvailable { filename: Name },
+    SourceNotAvailable { filename: SourceFileName },
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct DistinctSources {
-    pub begin: (Name, BytePos),
-    pub end: (Name, BytePos),
+    pub begin: (SourceFileName, BytePos),
+    pub end: (SourceFileName, BytePos),
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct MalformedSourceMapPositions {
-    pub name: Name,
+    pub name: SourceFileName,
     pub source_len: usize,
     pub begin_pos: BytePos,
     pub end_pos: BytePos,

--- a/src/librustc_span/source_map.rs
+++ b/src/librustc_span/source_map.rs
@@ -125,9 +125,10 @@ pub struct StableSourceFileId(u128);
 // StableSourceFileId, perhaps built atop source_file.name_hash.
 impl StableSourceFileId {
     pub fn new(source_file: &SourceFile) -> StableSourceFileId {
+        let (source_file_name, source_file_was_remapped) = source_file.name.name_and_remapped();
         StableSourceFileId::new_from_pieces(
-            &source_file.name,
-            source_file.name_was_remapped,
+            &source_file_name,
+            source_file_was_remapped,
             source_file.unmapped_path.as_ref(),
         )
     }
@@ -379,8 +380,7 @@ impl SourceMap {
         }
 
         let source_file = Lrc::new(SourceFile {
-            name: filename,
-            name_was_remapped,
+            name: Name::new(filename, name_was_remapped),
             unmapped_path: None,
             src: None,
             src_hash,
@@ -540,7 +540,7 @@ impl SourceMap {
     }
 
     pub fn span_to_filename(&self, sp: Span) -> FileName {
-        self.lookup_char_pos(sp.lo()).file.name.clone()
+        self.lookup_char_pos(sp.lo()).file.name.name_and_remapped().0
     }
 
     pub fn span_to_unmapped_path(&self, sp: Span) -> FileName {
@@ -906,12 +906,7 @@ impl SourceMap {
     }
 
     pub fn get_source_file(&self, filename: &FileName) -> Option<Lrc<SourceFile>> {
-        for sf in self.files.borrow().source_files.iter() {
-            if *filename == sf.name {
-                return Some(sf.clone());
-            }
-        }
-        None
+        self.files.borrow().source_files.iter().find(|sf| sf.name == *filename).cloned()
     }
 
     /// For a global `BytePos`, computes the local offset within the containing `SourceFile`.
@@ -1052,8 +1047,8 @@ impl SourceMap {
         None
     }
     pub fn ensure_source_file_source_present(&self, source_file: Lrc<SourceFile>) -> bool {
-        source_file.add_external_src(|| match source_file.name {
-            FileName::Real(ref name) => self.file_loader.read_file(name.local_path()).ok(),
+        source_file.add_external_src(|| match source_file.name.name_and_remapped() {
+            (FileName::Real(ref name), _) => self.file_loader.read_file(name.local_path()).ok(),
             _ => None,
         })
     }


### PR DESCRIPTION
Solves #75550 

This branch moves three fields relating to the name of a file of the `SourceFile` struct from `rustc_span` and moves them to a separate struct. The intent is to encapulate the state of the fields.