### PR TITLE
Fix windows-gnu host cross-compilation

### DIFF
--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -226,7 +226,7 @@ fn make_win_dist(
         let idx = line.find(':').unwrap();
         let key = &line[..idx];
         let trim_chars: &[_] = &[' ', '='];
-        let value = line[(idx + 1)..].trim_start_matches(trim_chars).split(';').map(PathBuf::from);
+        let value = env::split_paths(line[(idx + 1)..].trim_start_matches(trim_chars));
 
         if key == "programs" {
             bin_path.extend(value);

--- a/src/librustc_llvm/build.rs
+++ b/src/librustc_llvm/build.rs
@@ -151,6 +151,12 @@ fn main() {
             continue;
         }
 
+        // Include path contains host directory, replace it with target
+        if is_crossed && flag.starts_with("-I") {
+            cfg.flag(&flag.replace(&host, &target));
+            continue;
+        }
+
         cfg.flag(flag);
     }
 
@@ -189,6 +195,9 @@ fn main() {
 
     if !is_crossed {
         cmd.arg("--system-libs");
+    } else if target.contains("windows-gnu") {
+        println!("cargo:rustc-link-lib=shell32");
+        println!("cargo:rustc-link-lib=uuid");
     }
     cmd.args(&components);
 


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/64218

Also turns out it's faster to run Linux virtual machine on Windows and cross-compile `./x.py dist` than doing it on Windows directly...