### PR TITLE
Use intra-doc links in `std::env`, `std::alloc` and `std::error`

### DIFF
--- a/library/std/src/alloc.rs
+++ b/library/std/src/alloc.rs
@@ -7,8 +7,6 @@
 //! like `cdylib`s and `staticlib`s are guaranteed to use the [`System`] by
 //! default.
 //!
-//! [`System`]: struct.System.html
-//!
 //! # The `#[global_allocator]` attribute
 //!
 //! This attribute allows configuring the choice of global allocator.
@@ -42,8 +40,6 @@
 //!
 //! The attribute is used on a `static` item whose type implements the
 //! [`GlobalAlloc`] trait. This type can be provided by an external library:
-//!
-//! [`GlobalAlloc`]: ../../core/alloc/trait.GlobalAlloc.html
 //!
 //! ```rust,ignore (demonstrates crates.io usage)
 //! extern crate jemallocator;
@@ -284,9 +280,6 @@ static HOOK: AtomicPtr<()> = AtomicPtr::new(ptr::null_mut());
 /// about the allocation that failed.
 ///
 /// The allocation error hook is a global resource.
-///
-/// [`set_alloc_error_hook`]: fn.set_alloc_error_hook.html
-/// [`take_alloc_error_hook`]: fn.take_alloc_error_hook.html
 #[unstable(feature = "alloc_error_hook", issue = "51245")]
 pub fn set_alloc_error_hook(hook: fn(Layout)) {
     HOOK.store(hook as *mut (), Ordering::SeqCst);
@@ -297,8 +290,6 @@ pub fn set_alloc_error_hook(hook: fn(Layout)) {
 /// *See also the function [`set_alloc_error_hook`].*
 ///
 /// If no custom hook is registered, the default hook will be returned.
-///
-/// [`set_alloc_error_hook`]: fn.set_alloc_error_hook.html
 #[unstable(feature = "alloc_error_hook", issue = "51245")]
 pub fn take_alloc_error_hook() -> fn(Layout) {
     let hook = HOOK.swap(ptr::null_mut(), Ordering::SeqCst);

--- a/library/std/src/env.rs
+++ b/library/std/src/env.rs
@@ -7,9 +7,6 @@
 //! There are several functions and structs in this module that have a
 //! counterpart ending in `os`. Those ending in `os` will return an [`OsString`]
 //! and those without will return a [`String`].
-//!
-//! [`OsString`]: ../../std/ffi/struct.OsString.html
-//! [`String`]: ../string/struct.String.html
 
 #![stable(feature = "env", since = "1.0.0")]
 
@@ -31,8 +28,7 @@ use crate::sys::os as os_imp;
 /// * Current directory does not exist.
 /// * There are insufficient permissions to access the current directory.
 ///
-/// [`PathBuf`]: ../../std/path/struct.PathBuf.html
-/// [`Err`]: ../../std/result/enum.Result.html#method.err
+/// [`Err`]: Result::Err
 ///
 /// # Examples
 ///
@@ -54,7 +50,7 @@ pub fn current_dir() -> io::Result<PathBuf> {
 ///
 /// Returns an [`Err`] if the operation fails.
 ///
-/// [`Err`]: ../../std/result/enum.Result.html#method.err
+/// [`Err`]: Result::Err
 ///
 /// # Examples
 ///
@@ -76,7 +72,7 @@ pub fn set_current_dir<P: AsRef<Path>>(path: P) -> io::Result<()> {
 /// This structure is created by the [`std::env::vars`] function. See its
 /// documentation for more.
 ///
-/// [`std::env::vars`]: fn.vars.html
+/// [`std::env::vars`]: vars
 #[stable(feature = "env", since = "1.0.0")]
 pub struct Vars {
     inner: VarsOs,
@@ -87,7 +83,7 @@ pub struct Vars {
 /// This structure is created by the [`std::env::vars_os`] function. See
 /// its documentation for more.
 ///
-/// [`std::env::vars_os`]: fn.vars_os.html
+/// [`std::env::vars_os`]: vars_os
 #[stable(feature = "env", since = "1.0.0")]
 pub struct VarsOs {
     inner: os_imp::Env,
@@ -106,7 +102,7 @@ pub struct VarsOs {
 /// environment is not valid unicode. If this is not desired, consider using the
 /// [`env::vars_os`] function.
 ///
-/// [`env::vars_os`]: fn.vars_os.html
+/// [`env::vars_os`]: vars_os
 ///
 /// # Examples
 ///
@@ -222,7 +218,7 @@ fn _var(key: &OsStr) -> Result<String, VarError> {
 /// Fetches the environment variable `key` from the current process, returning
 /// [`None`] if the variable isn't set.
 ///
-/// [`None`]: ../option/enum.Option.html#variant.None
+/// [`None`]: Option::None
 ///
 /// # Panics
 ///
@@ -254,7 +250,7 @@ fn _var_os(key: &OsStr) -> Option<OsString> {
 /// The error type for operations interacting with environment variables.
 /// Possibly returned from the [`env::var`] function.
 ///
-/// [`env::var`]: fn.var.html
+/// [`env::var`]: var
 #[derive(Debug, PartialEq, Eq, Clone)]
 #[stable(feature = "env", since = "1.0.0")]
 pub enum VarError {
@@ -382,8 +378,7 @@ fn _remove_var(k: &OsStr) {
 /// This structure is created by the [`std::env::split_paths`] function. See its
 /// documentation for more.
 ///
-/// [`PathBuf`]: ../../std/path/struct.PathBuf.html
-/// [`std::env::split_paths`]: fn.split_paths.html
+/// [`std::env::split_paths`]: split_paths
 #[stable(feature = "env", since = "1.0.0")]
 pub struct SplitPaths<'a> {
     inner: os_imp::SplitPaths<'a>,
@@ -410,8 +405,6 @@ pub struct SplitPaths<'a> {
 ///     None => println!("{} is not defined in the environment.", key)
 /// }
 /// ```
-///
-/// [`PathBuf`]: ../../std/path/struct.PathBuf.html
 #[stable(feature = "env", since = "1.0.0")]
 pub fn split_paths<T: AsRef<OsStr> + ?Sized>(unparsed: &T) -> SplitPaths<'_> {
     SplitPaths { inner: os_imp::split_paths(unparsed.as_ref()) }
@@ -438,7 +431,7 @@ impl fmt::Debug for SplitPaths<'_> {
 /// The error type for operations on the `PATH` variable. Possibly returned from
 /// the [`env::join_paths`] function.
 ///
-/// [`env::join_paths`]: fn.join_paths.html
+/// [`env::join_paths`]: join_paths
 #[derive(Debug)]
 #[stable(feature = "env", since = "1.0.0")]
 pub struct JoinPathsError {
@@ -450,13 +443,11 @@ pub struct JoinPathsError {
 ///
 /// # Errors
 ///
-/// Returns an [`Err`][err] (containing an error message) if one of the input
+/// Returns an [`Err`] (containing an error message) if one of the input
 /// [`Path`]s contains an invalid character for constructing the `PATH`
 /// variable (a double quote on Windows or a colon on Unix).
 ///
-/// [`Path`]: ../../std/path/struct.Path.html
-/// [`OsString`]: ../../std/ffi/struct.OsString.html
-/// [err]: ../../std/result/enum.Result.html#variant.Err
+/// [Err]: Result::Err
 ///
 /// # Examples
 ///
@@ -508,7 +499,7 @@ pub struct JoinPathsError {
 /// }
 /// ```
 ///
-/// [`env::split_paths`]: fn.split_paths.html
+/// [`env::split_paths`]: split_paths
 #[stable(feature = "env", since = "1.0.0")]
 pub fn join_paths<I, T>(paths: I) -> Result<OsString, JoinPathsError>
 where
@@ -688,8 +679,7 @@ pub fn current_exe() -> io::Result<PathBuf> {
 /// set to arbitrary text, and may not even exist. This means this property
 /// should not be relied upon for security purposes.
 ///
-/// [`String`]: ../string/struct.String.html
-/// [`std::env::args`]: ./fn.args.html
+/// [`std::env::args`]: args
 #[stable(feature = "env", since = "1.0.0")]
 pub struct Args {
     inner: ArgsOs,
@@ -705,8 +695,7 @@ pub struct Args {
 /// set to arbitrary text, and may not even exist. This means this property
 /// should not be relied upon for security purposes.
 ///
-/// [`OsString`]: ../ffi/struct.OsString.html
-/// [`std::env::args_os`]: ./fn.args_os.html
+/// [`std::env::args_os`]: args_os
 #[stable(feature = "env", since = "1.0.0")]
 pub struct ArgsOs {
     inner: sys::args::Args,
@@ -744,8 +733,6 @@ pub struct ArgsOs {
 ///     println!("{}", argument);
 /// }
 /// ```
-///
-/// [`args_os`]: ./fn.args_os.html
 #[stable(feature = "env", since = "1.0.0")]
 pub fn args() -> Args {
     Args { inner: args_os() }

--- a/library/std/src/env.rs
+++ b/library/std/src/env.rs
@@ -28,8 +28,6 @@ use crate::sys::os as os_imp;
 /// * Current directory does not exist.
 /// * There are insufficient permissions to access the current directory.
 ///
-/// [`Err`]: Result::Err
-///
 /// # Examples
 ///
 /// ```
@@ -49,8 +47,6 @@ pub fn current_dir() -> io::Result<PathBuf> {
 /// Changes the current working directory to the specified path.
 ///
 /// Returns an [`Err`] if the operation fails.
-///
-/// [`Err`]: Result::Err
 ///
 /// # Examples
 ///
@@ -217,8 +213,6 @@ fn _var(key: &OsStr) -> Result<String, VarError> {
 
 /// Fetches the environment variable `key` from the current process, returning
 /// [`None`] if the variable isn't set.
-///
-/// [`None`]: Option::None
 ///
 /// # Panics
 ///
@@ -446,8 +440,6 @@ pub struct JoinPathsError {
 /// Returns an [`Err`] (containing an error message) if one of the input
 /// [`Path`]s contains an invalid character for constructing the `PATH`
 /// variable (a double quote on Windows or a colon on Unix).
-///
-/// [Err]: Result::Err
 ///
 /// # Examples
 ///

--- a/library/std/src/error.rs
+++ b/library/std/src/error.rs
@@ -40,10 +40,8 @@ use crate::string;
 /// provide its own errors while also revealing some of the implementation for
 /// debugging via [`source`] chains.
 ///
-/// [`Result<T, E>`]: ../result/enum.Result.html
-/// [`Display`]: ../fmt/trait.Display.html
-/// [`Debug`]: ../fmt/trait.Debug.html
-/// [`source`]: trait.Error.html#method.source
+/// [`Result<T, E>`]: Result
+/// [`source`]: Error::source
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait Error: Debug + Display {
     /// The lower-level source of this error, if any.
@@ -164,8 +162,6 @@ mod private {
 impl<'a, E: Error + 'a> From<E> for Box<dyn Error + 'a> {
     /// Converts a type of [`Error`] into a box of dyn [`Error`].
     ///
-    /// [`Error`]: ../error/trait.Error.html
-    ///
     /// # Examples
     ///
     /// ```
@@ -198,8 +194,6 @@ impl<'a, E: Error + 'a> From<E> for Box<dyn Error + 'a> {
 impl<'a, E: Error + Send + Sync + 'a> From<E> for Box<dyn Error + Send + Sync + 'a> {
     /// Converts a type of [`Error`] + [`Send`] + [`Sync`] into a box of
     /// dyn [`Error`] + [`Send`] + [`Sync`].
-    ///
-    /// [`Error`]: ../error/trait.Error.html
     ///
     /// # Examples
     ///
@@ -237,8 +231,6 @@ impl<'a, E: Error + Send + Sync + 'a> From<E> for Box<dyn Error + Send + Sync + 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl From<String> for Box<dyn Error + Send + Sync> {
     /// Converts a [`String`] into a box of dyn [`Error`] + [`Send`] + [`Sync`].
-    ///
-    /// [`Error`]: ../error/trait.Error.html
     ///
     /// # Examples
     ///
@@ -283,8 +275,6 @@ impl From<String> for Box<dyn Error + Send + Sync> {
 impl From<String> for Box<dyn Error> {
     /// Converts a [`String`] into a box of dyn [`Error`].
     ///
-    /// [`Error`]: ../error/trait.Error.html
-    ///
     /// # Examples
     ///
     /// ```
@@ -305,8 +295,6 @@ impl From<String> for Box<dyn Error> {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<'a> From<&str> for Box<dyn Error + Send + Sync + 'a> {
     /// Converts a [`str`] into a box of dyn [`Error`] + [`Send`] + [`Sync`].
-    ///
-    /// [`Error`]: ../error/trait.Error.html
     ///
     /// # Examples
     ///
@@ -329,8 +317,6 @@ impl<'a> From<&str> for Box<dyn Error + Send + Sync + 'a> {
 impl From<&str> for Box<dyn Error> {
     /// Converts a [`str`] into a box of dyn [`Error`].
     ///
-    /// [`Error`]: ../error/trait.Error.html
-    ///
     /// # Examples
     ///
     /// ```
@@ -349,9 +335,6 @@ impl From<&str> for Box<dyn Error> {
 #[stable(feature = "cow_box_error", since = "1.22.0")]
 impl<'a, 'b> From<Cow<'b, str>> for Box<dyn Error + Send + Sync + 'a> {
     /// Converts a [`Cow`] into a box of dyn [`Error`] + [`Send`] + [`Sync`].
-    ///
-    /// [`Cow`]: ../borrow/enum.Cow.html
-    /// [`Error`]: ../error/trait.Error.html
     ///
     /// # Examples
     ///
@@ -373,9 +356,6 @@ impl<'a, 'b> From<Cow<'b, str>> for Box<dyn Error + Send + Sync + 'a> {
 #[stable(feature = "cow_box_error", since = "1.22.0")]
 impl<'a> From<Cow<'a, str>> for Box<dyn Error> {
     /// Converts a [`Cow`] into a box of dyn [`Error`].
-    ///
-    /// [`Cow`]: ../borrow/enum.Cow.html
-    /// [`Error`]: ../error/trait.Error.html
     ///
     /// # Examples
     ///
@@ -703,7 +683,7 @@ impl dyn Error {
     /// assert!(iter.next().is_none());
     /// ```
     ///
-    /// [`source`]: trait.Error.html#method.source
+    /// [`source`]: Error::source
     #[unstable(feature = "error_iter", issue = "58520")]
     #[inline]
     pub fn chain(&self) -> Chain<'_> {
@@ -715,8 +695,6 @@ impl dyn Error {
 ///
 /// If you want to omit the initial error and only process
 /// its sources, use `skip(1)`.
-///
-/// [`Error`]: trait.Error.html
 #[unstable(feature = "error_iter", issue = "58520")]
 #[derive(Clone, Debug)]
 pub struct Chain<'a> {


### PR DESCRIPTION
This is partial fixes for #75080.  