### PR TITLE
Don't use `dep_graph.with_ignore` when encoding fn param names

### DIFF
--- a/src/librustc_metadata/rmeta/decoder/cstore_impl.rs
+++ b/src/librustc_metadata/rmeta/decoder/cstore_impl.rs
@@ -136,10 +136,6 @@ provide! { <'tcx> tcx, def_id, other, cdata,
     item_attrs => { tcx.arena.alloc_from_iter(
         cdata.get_item_attrs(def_id.index, tcx.sess).into_iter()
     ) }
-    // FIXME(#38501) We've skipped a `read` on the `hir_owner_nodes` of
-    // a `fn` when encoding, so the dep-tracking wouldn't work.
-    // This is only used by rustdoc anyway, which shouldn't have
-    // incremental recompilation ever enabled.
     fn_arg_names => { cdata.get_fn_param_names(tcx, def_id.index) }
     rendered_const => { cdata.get_rendered_const(def_id.index) }
     impl_parent => { cdata.get_parent_impl(def_id.index) }

--- a/src/librustc_metadata/rmeta/encoder.rs
+++ b/src/librustc_metadata/rmeta/encoder.rs
@@ -1089,7 +1089,7 @@ impl EncodeContext<'a, 'tcx> {
     }
 
     fn encode_fn_param_names_for_body(&mut self, body_id: hir::BodyId) -> Lazy<[Ident]> {
-        self.tcx.dep_graph.with_ignore(|| self.lazy(self.tcx.hir().body_param_names(body_id)))
+        self.lazy(self.tcx.hir().body_param_names(body_id))
     }
 
     fn encode_fn_param_names(&mut self, param_names: &[Ident]) -> Lazy<[Ident]> {


### PR DESCRIPTION
The call to `with_ignore` was added years ago, and should no longer be
necessary with the modern incremental query infrastructure.

I also removed a related FIXME comment for issue #38501, which was
closed months ago.