### PR TITLE
update stacker to 0.1.11 to unbreak build for wasm32-unknown-unknown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4345,9 +4345,9 @@ checksum = "ffbc596e092fe5f598b12ef46cc03754085ac2f4d8c739ad61c4ae266cc3b3fa"
 
 [[package]]
 name = "stacker"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72dd941b456e1c006d6b9f27c526d5b69281288aeea8cba82c19d3843d8ccdd2"
+checksum = "a92bc346006ae78c539d6ab2cf1a1532bc657b8339c464877a990ec82073c66f"
 dependencies = [
  "cc",
  "cfg-if",

--- a/src/librustc_data_structures/Cargo.toml
+++ b/src/librustc_data_structures/Cargo.toml
@@ -30,7 +30,7 @@ rustc_index = { path = "../librustc_index", package = "rustc_index" }
 bitflags = "1.2.1"
 measureme = "0.7.1"
 libc = "0.2"
-stacker = "0.1.9"
+stacker = "0.1.11"
 tempfile = "3.0.5"
 
 [dependencies.parking_lot]


### PR DESCRIPTION
Like #72079, this updates stacker. The related problem is stacker is here https://github.com/rust-lang/stacker/issues/42. It was fixed by switching from `libc::c_void` to `std::ffi::c_void` https://github.com/rust-lang/stacker/pull/43/files.