### PR TITLE
Make OnceCell<T> transparent to dropck

### DIFF
--- a/library/core/tests/lazy.rs
+++ b/library/core/tests/lazy.rs
@@ -122,3 +122,12 @@ fn reentrant_init() {
     });
     eprintln!("use after free: {:?}", dangling_ref.get().unwrap());
 }
+
+#[test]
+fn dropck() {
+    let cell = OnceCell::new();
+    {
+        let s = String::new();
+        cell.set(&s).unwrap();
+    }
+}


### PR DESCRIPTION
See the failed build in

https://github.com/rust-lang/rust/pull/75555#issuecomment-675016718

for an example where we need this in real life

r? @ghost