### PR TITLE
Disable zlib in LLVM on Haiku

### DIFF
--- a/src/librustc_llvm/build.rs
+++ b/src/librustc_llvm/build.rs
@@ -198,7 +198,7 @@ fn main() {
     } else if target.contains("windows-gnu") {
         println!("cargo:rustc-link-lib=shell32");
         println!("cargo:rustc-link-lib=uuid");
-    } else if target.contains("netbsd") {
+    } else if target.contains("netbsd") || target.contains("haiku") {
         println!("cargo:rustc-link-lib=z");
     }
     cmd.args(&components);


### PR DESCRIPTION
PR #72696 enabled the option LLVM_ENABLE_ZLIB for the LLVM builds. Like NetBSD and aarch64-apple-darwin (see PR #75500), the LLVM build system not explicitly linking to libz on these platforms cause issues. For Haiku, this meant the runtime loader complaining about undefined symbols..