### PR TITLE
Provide better spans for the match arm without tail expression

### DIFF
--- a/src/librustc_infer/infer/error_reporting/mod.rs
+++ b/src/librustc_infer/infer/error_reporting/mod.rs
@@ -609,6 +609,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 err.span_label(span, "expected due to this");
             }
             ObligationCauseCode::MatchExpressionArm(box MatchExpressionArmCause {
+                semi_span,
                 source,
                 ref prior_arms,
                 last_ty,
@@ -661,6 +662,14 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                         err.span_label(
                             *sp,
                             format!("this and all prior arms are found to be of type `{}`", t),
+                        );
+                    }
+                    if let Some(sp) = semi_span {
+                        err.span_suggestion_short(
+                            sp,
+                            "consider removing this semicolon",
+                            String::new(),
+                            Applicability::MachineApplicable,
                         );
                     }
                 }

--- a/src/librustc_middle/traits/mod.rs
+++ b/src/librustc_middle/traits/mod.rs
@@ -345,6 +345,7 @@ static_assert_size!(ObligationCauseCode<'_>, 32);
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Lift)]
 pub struct MatchExpressionArmCause<'tcx> {
     pub arm_span: Span,
+    pub semi_span: Option<Span>,
     pub source: hir::MatchSource,
     pub prior_arms: Vec<Span>,
     pub last_ty: Ty<'tcx>,

--- a/src/test/ui/match/match-incompat-type-semi.rs
+++ b/src/test/ui/match/match-incompat-type-semi.rs
@@ -1,0 +1,42 @@
+// Diagnostic enhancement explained in issue #75418.
+// Point at the last statement in the block if there's no tail expression,
+// and suggest removing the semicolon if appropriate.
+
+fn main() {
+    let _ = match Some(42) {
+        Some(x) => {
+            x
+        },
+        None => {
+            0;
+            //~^ ERROR incompatible types
+            //~| HELP consider removing this semicolon
+        },
+    };
+
+    let _ = if let Some(x) = Some(42) {
+        x
+    } else {
+        0;
+        //~^ ERROR incompatible types
+        //~| HELP consider removing this semicolon
+    };
+
+    let _ = match Some(42) {
+        Some(x) => {
+            x
+        },
+        None => {
+            ();
+            //~^ ERROR incompatible types
+        },
+    };
+
+    let _ = match Some(42) {
+        Some(x) => {
+            x
+        },
+        None => { //~ ERROR incompatible types
+        },
+    };
+}

--- a/src/test/ui/match/match-incompat-type-semi.stderr
+++ b/src/test/ui/match/match-incompat-type-semi.stderr
@@ -1,0 +1,74 @@
+error[E0308]: `match` arms have incompatible types
+  --> $DIR/match-incompat-type-semi.rs:11:13
+   |
+LL |       let _ = match Some(42) {
+   |  _____________-
+LL | |         Some(x) => {
+LL | |             x
+   | |             - this is found to be of type `{integer}`
+LL | |         },
+LL | |         None => {
+LL | |             0;
+   | |             ^-
+   | |             ||
+   | |             |help: consider removing this semicolon
+   | |             expected integer, found `()`
+...  |
+LL | |         },
+LL | |     };
+   | |_____- `match` arms have incompatible types
+
+error[E0308]: `if` and `else` have incompatible types
+  --> $DIR/match-incompat-type-semi.rs:20:9
+   |
+LL |       let _ = if let Some(x) = Some(42) {
+   |  _____________-
+LL | |         x
+   | |         - expected because of this
+LL | |     } else {
+LL | |         0;
+   | |         ^-
+   | |         ||
+   | |         |help: consider removing this semicolon
+   | |         expected integer, found `()`
+LL | |
+LL | |
+LL | |     };
+   | |_____- `if` and `else` have incompatible types
+
+error[E0308]: `match` arms have incompatible types
+  --> $DIR/match-incompat-type-semi.rs:30:13
+   |
+LL |       let _ = match Some(42) {
+   |  _____________-
+LL | |         Some(x) => {
+LL | |             x
+   | |             - this is found to be of type `{integer}`
+LL | |         },
+LL | |         None => {
+LL | |             ();
+   | |             ^^^ expected integer, found `()`
+LL | |
+LL | |         },
+LL | |     };
+   | |_____- `match` arms have incompatible types
+
+error[E0308]: `match` arms have incompatible types
+  --> $DIR/match-incompat-type-semi.rs:39:17
+   |
+LL |        let _ = match Some(42) {
+   |   _____________-
+LL |  |         Some(x) => {
+LL |  |             x
+   |  |             - this is found to be of type `{integer}`
+LL |  |         },
+LL |  |         None => {
+   |  |_________________^
+LL | ||         },
+   | ||_________^ expected integer, found `()`
+LL |  |     };
+   |  |_____- `match` arms have incompatible types
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Resolves #75418.

Applied the same logic in the `if`-`else` type mismatch case.

r? @estebank
