### PR TITLE
hir: consistent use and naming of lang items

### DIFF
--- a/src/librustc_ast_lowering/lib.rs
+++ b/src/librustc_ast_lowering/lib.rs
@@ -2058,7 +2058,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
 
         hir::GenericBound::LangItemTrait(
             // ::std::future::Future<future_params>
-            hir::LangItem::FutureTraitLangItem,
+            hir::LangItem::Future,
             span,
             self.next_id(),
             future_args,

--- a/src/librustc_codegen_ssa/base.rs
+++ b/src/librustc_codegen_ssa/base.rs
@@ -31,7 +31,7 @@ use rustc_data_structures::profiling::print_time_passes_entry;
 use rustc_data_structures::sync::{par_iter, Lock, ParallelIterator};
 use rustc_hir as hir;
 use rustc_hir::def_id::{LocalDefId, LOCAL_CRATE};
-use rustc_hir::lang_items::StartFnLangItem;
+use rustc_hir::lang_items::LangItem;
 use rustc_index::vec::Idx;
 use rustc_middle::middle::codegen_fn_attrs::CodegenFnAttrs;
 use rustc_middle::middle::cstore::EncodedMetadata;
@@ -458,7 +458,7 @@ pub fn maybe_create_entry_wrapper<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
         let (arg_argc, arg_argv) = get_argc_argv(cx, &mut bx);
 
         let (start_fn, args) = if use_start_lang_item {
-            let start_def_id = cx.tcx().require_lang_item(StartFnLangItem, None);
+            let start_def_id = cx.tcx().require_lang_item(LangItem::Start, None);
             let start_fn = cx.get_fn_addr(
                 ty::Instance::resolve(
                     cx.tcx(),

--- a/src/librustc_codegen_ssa/mir/rvalue.rs
+++ b/src/librustc_codegen_ssa/mir/rvalue.rs
@@ -8,7 +8,7 @@ use crate::traits::*;
 use crate::MemFlags;
 
 use rustc_apfloat::{ieee, Float, Round, Status};
-use rustc_hir::lang_items::ExchangeMallocFnLangItem;
+use rustc_hir::lang_items::LangItem;
 use rustc_middle::mir;
 use rustc_middle::ty::cast::{CastTy, IntTy};
 use rustc_middle::ty::layout::{HasTyCtxt, TyAndLayout};
@@ -507,7 +507,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                 let llty_ptr = bx.cx().backend_type(box_layout);
 
                 // Allocate space:
-                let def_id = match bx.tcx().lang_items().require(ExchangeMallocFnLangItem) {
+                let def_id = match bx.tcx().lang_items().require(LangItem::ExchangeMalloc) {
                     Ok(id) => id,
                     Err(s) => {
                         bx.cx().sess().fatal(&format!("allocation of `{}` {}", box_layout.ty, s));

--- a/src/librustc_hir/lang_items.rs
+++ b/src/librustc_hir/lang_items.rs
@@ -7,8 +7,6 @@
 //! * Traits that represent operators; e.g., `Add`, `Sub`, `Index`.
 //! * Functions called by the compiler itself.
 
-pub use self::LangItem::*;
-
 use crate::def_id::DefId;
 use crate::{MethodKind, Target};
 
@@ -57,14 +55,14 @@ macro_rules! language_item_table {
             /// that is `#[lang = "eq"]` would result in `sym::eq`.
             pub fn name(self) -> Symbol {
                 match self {
-                    $( $variant => $name, )*
+                    $( LangItem::$variant => $name, )*
                 }
             }
 
             pub fn group(self) -> Option<LangItemGroup> {
                 use LangItemGroup::*;
                 match self {
-                    $( $variant => expand_group!($($group)*), )*
+                    $( LangItem::$variant => expand_group!($($group)*), )*
                 }
             }
         }
@@ -87,7 +85,7 @@ macro_rules! language_item_table {
                 fn init_none(_: LangItem) -> Option<DefId> { None }
 
                 Self {
-                    items: vec![$(init_none($variant)),*],
+                    items: vec![$(init_none(LangItem::$variant)),*],
                     missing: Vec::new(),
                     groups: [vec![]; NUM_GROUPS],
                 }
@@ -114,7 +112,7 @@ macro_rules! language_item_table {
                 /// exists.
                 #[allow(dead_code)]
                 pub fn $method(&self) -> Option<DefId> {
-                    self.items[$variant as usize]
+                    self.items[LangItem::$variant as usize]
                 }
             )*
         }
@@ -123,7 +121,7 @@ macro_rules! language_item_table {
             /// A mapping from the name of the lang item to its order and the form it must be of.
             pub static ref ITEM_REFS: FxHashMap<Symbol, (usize, Target)> = {
                 let mut item_refs = FxHashMap::default();
-                $( item_refs.insert($name, ($variant as usize, $target)); )*
+                $( item_refs.insert($name, (LangItem::$variant as usize, $target)); )*
                 item_refs
             };
         }
@@ -161,179 +159,176 @@ where
 }
 
 language_item_table! {
-//  Variant name,                  Name,                    Method name,             Target;
-    BoolImplItem,                  sym::bool,               bool_impl,               Target::Impl;
-    CharImplItem,                  sym::char,               char_impl,               Target::Impl;
-    StrImplItem,                   sym::str,                str_impl,                Target::Impl;
-    ArrayImplItem,                 sym::array,              array_impl,              Target::Impl;
-    SliceImplItem,                 sym::slice,              slice_impl,              Target::Impl;
-    SliceU8ImplItem,               sym::slice_u8,           slice_u8_impl,           Target::Impl;
-    StrAllocImplItem,              sym::str_alloc,          str_alloc_impl,          Target::Impl;
-    SliceAllocImplItem,            sym::slice_alloc,        slice_alloc_impl,        Target::Impl;
-    SliceU8AllocImplItem,          sym::slice_u8_alloc,     slice_u8_alloc_impl,     Target::Impl;
-    ConstPtrImplItem,              sym::const_ptr,          const_ptr_impl,          Target::Impl;
-    MutPtrImplItem,                sym::mut_ptr,            mut_ptr_impl,            Target::Impl;
-    ConstSlicePtrImplItem,         sym::const_slice_ptr,    const_slice_ptr_impl,    Target::Impl;
-    MutSlicePtrImplItem,           sym::mut_slice_ptr,      mut_slice_ptr_impl,      Target::Impl;
-    I8ImplItem,                    sym::i8,                 i8_impl,                 Target::Impl;
-    I16ImplItem,                   sym::i16,                i16_impl,                Target::Impl;
-    I32ImplItem,                   sym::i32,                i32_impl,                Target::Impl;
-    I64ImplItem,                   sym::i64,                i64_impl,                Target::Impl;
-    I128ImplItem,                  sym::i128,               i128_impl,               Target::Impl;
-    IsizeImplItem,                 sym::isize,              isize_impl,              Target::Impl;
-    U8ImplItem,                    sym::u8,                 u8_impl,                 Target::Impl;
-    U16ImplItem,                   sym::u16,                u16_impl,                Target::Impl;
-    U32ImplItem,                   sym::u32,                u32_impl,                Target::Impl;
-    U64ImplItem,                   sym::u64,                u64_impl,                Target::Impl;
-    U128ImplItem,                  sym::u128,               u128_impl,               Target::Impl;
-    UsizeImplItem,                 sym::usize,              usize_impl,              Target::Impl;
-    F32ImplItem,                   sym::f32,                f32_impl,                Target::Impl;
-    F64ImplItem,                   sym::f64,                f64_impl,                Target::Impl;
-    F32RuntimeImplItem,            sym::f32_runtime,        f32_runtime_impl,        Target::Impl;
-    F64RuntimeImplItem,            sym::f64_runtime,        f64_runtime_impl,        Target::Impl;
+//  Variant name,            Name,                    Method name,             Target;
+    Bool,                    sym::bool,                bool_impl,                  Target::Impl;
+    Char,                    sym::char,                char_impl,                  Target::Impl;
+    Str,                     sym::str,                 str_impl,                   Target::Impl;
+    Array,                   sym::array,               array_impl,                 Target::Impl;
+    Slice,                   sym::slice,               slice_impl,                 Target::Impl;
+    SliceU8,                 sym::slice_u8,            slice_u8_impl,              Target::Impl;
+    StrAlloc,                sym::str_alloc,           str_alloc_impl,             Target::Impl;
+    SliceAlloc,              sym::slice_alloc,         slice_alloc_impl,           Target::Impl;
+    SliceU8Alloc,            sym::slice_u8_alloc,      slice_u8_alloc_impl,        Target::Impl;
+    ConstPtr,                sym::const_ptr,           const_ptr_impl,             Target::Impl;
+    MutPtr,                  sym::mut_ptr,             mut_ptr_impl,               Target::Impl;
+    ConstSlicePtr,           sym::const_slice_ptr,     const_slice_ptr_impl,       Target::Impl;
+    MutSlicePtr,             sym::mut_slice_ptr,       mut_slice_ptr_impl,         Target::Impl;
+    I8,                      sym::i8,                  i8_impl,                    Target::Impl;
+    I16,                     sym::i16,                 i16_impl,                   Target::Impl;
+    I32,                     sym::i32,                 i32_impl,                   Target::Impl;
+    I64,                     sym::i64,                 i64_impl,                   Target::Impl;
+    I128,                    sym::i128,                i128_impl,                  Target::Impl;
+    Isize,                   sym::isize,               isize_impl,                 Target::Impl;
+    U8,                      sym::u8,                  u8_impl,                    Target::Impl;
+    U16,                     sym::u16,                 u16_impl,                   Target::Impl;
+    U32,                     sym::u32,                 u32_impl,                   Target::Impl;
+    U64,                     sym::u64,                 u64_impl,                   Target::Impl;
+    U128,                    sym::u128,                u128_impl,                  Target::Impl;
+    Usize,                   sym::usize,               usize_impl,                 Target::Impl;
+    F32,                     sym::f32,                 f32_impl,                   Target::Impl;
+    F64,                     sym::f64,                 f64_impl,                   Target::Impl;
+    F32Runtime,              sym::f32_runtime,         f32_runtime_impl,           Target::Impl;
+    F64Runtime,              sym::f64_runtime,         f64_runtime_impl,           Target::Impl;
 
-    SizedTraitLangItem,            sym::sized,              sized_trait,             Target::Trait;
-    UnsizeTraitLangItem,           sym::unsize,             unsize_trait,            Target::Trait;
-    // trait injected by #[derive(PartialEq)], (i.e. "Partial EQ").
-    StructuralPeqTraitLangItem,    sym::structural_peq,     structural_peq_trait,    Target::Trait;
-    // trait injected by #[derive(Eq)], (i.e. "Total EQ"; no, I will not apologize).
-    StructuralTeqTraitLangItem,    sym::structural_teq,     structural_teq_trait,    Target::Trait;
-    CopyTraitLangItem,             sym::copy,               copy_trait,              Target::Trait;
-    CloneTraitLangItem,            sym::clone,              clone_trait,             Target::Trait;
-    SyncTraitLangItem,             sym::sync,               sync_trait,              Target::Trait;
-    DiscriminantKindTraitLangItem, sym::discriminant_kind,  discriminant_kind_trait, Target::Trait;
+    Sized,                   sym::sized,               sized_trait,                Target::Trait;
+    Unsize,                  sym::unsize,              unsize_trait,               Target::Trait;
+    // Trait injected by #[derive(PartialEq)], (i.e. "Partial EQ").
+    StructuralPeq,           sym::structural_peq,      structural_peq_trait,       Target::Trait;
+    // Trait injected by #[derive(Eq)], (i.e. "Total EQ"; no, I will not apologize).
+    StructuralTeq,           sym::structural_teq,      structural_teq_trait,       Target::Trait;
+    Copy,                    sym::copy,                copy_trait,                 Target::Trait;
+    Clone,                   sym::clone,               clone_trait,                Target::Trait;
+    Sync,                    sym::sync,                sync_trait,                 Target::Trait;
+    DiscriminantKind,        sym::discriminant_kind,   discriminant_kind_trait,    Target::Trait;
     // The associated item of `trait DiscriminantKind`.
-    DiscriminantTypeLangItem,      sym::discriminant_type,  discriminant_type,       Target::AssocTy;
+    Discriminant,            sym::discriminant_type,   discriminant_type,          Target::AssocTy;
 
-    FreezeTraitLangItem,           sym::freeze,             freeze_trait,            Target::Trait;
+    Freeze,                  sym::freeze,              freeze_trait,               Target::Trait;
 
-    DropTraitLangItem,             sym::drop,               drop_trait,              Target::Trait;
+    Drop,                    sym::drop,                drop_trait,                 Target::Trait;
 
-    CoerceUnsizedTraitLangItem,    sym::coerce_unsized,     coerce_unsized_trait,    Target::Trait;
-    DispatchFromDynTraitLangItem,  sym::dispatch_from_dyn,  dispatch_from_dyn_trait, Target::Trait;
+    CoerceUnsized,           sym::coerce_unsized,      coerce_unsized_trait,       Target::Trait;
+    DispatchFromDyn,         sym::dispatch_from_dyn,   dispatch_from_dyn_trait,    Target::Trait;
 
-    AddTraitLangItem(Op),          sym::add,                add_trait,               Target::Trait;
-    SubTraitLangItem(Op),          sym::sub,                sub_trait,               Target::Trait;
-    MulTraitLangItem(Op),          sym::mul,                mul_trait,               Target::Trait;
-    DivTraitLangItem(Op),          sym::div,                div_trait,               Target::Trait;
-    RemTraitLangItem(Op),          sym::rem,                rem_trait,               Target::Trait;
-    NegTraitLangItem(Op),          sym::neg,                neg_trait,               Target::Trait;
-    NotTraitLangItem(Op),          sym::not,                not_trait,               Target::Trait;
-    BitXorTraitLangItem(Op),       sym::bitxor,             bitxor_trait,            Target::Trait;
-    BitAndTraitLangItem(Op),       sym::bitand,             bitand_trait,            Target::Trait;
-    BitOrTraitLangItem(Op),        sym::bitor,              bitor_trait,             Target::Trait;
-    ShlTraitLangItem(Op),          sym::shl,                shl_trait,               Target::Trait;
-    ShrTraitLangItem(Op),          sym::shr,                shr_trait,               Target::Trait;
-    AddAssignTraitLangItem(Op),    sym::add_assign,         add_assign_trait,        Target::Trait;
-    SubAssignTraitLangItem(Op),    sym::sub_assign,         sub_assign_trait,        Target::Trait;
-    MulAssignTraitLangItem(Op),    sym::mul_assign,         mul_assign_trait,        Target::Trait;
-    DivAssignTraitLangItem(Op),    sym::div_assign,         div_assign_trait,        Target::Trait;
-    RemAssignTraitLangItem(Op),    sym::rem_assign,         rem_assign_trait,        Target::Trait;
-    BitXorAssignTraitLangItem(Op), sym::bitxor_assign,      bitxor_assign_trait,     Target::Trait;
-    BitAndAssignTraitLangItem(Op), sym::bitand_assign,      bitand_assign_trait,     Target::Trait;
-    BitOrAssignTraitLangItem(Op),  sym::bitor_assign,       bitor_assign_trait,      Target::Trait;
-    ShlAssignTraitLangItem(Op),    sym::shl_assign,         shl_assign_trait,        Target::Trait;
-    ShrAssignTraitLangItem(Op),    sym::shr_assign,         shr_assign_trait,        Target::Trait;
-    IndexTraitLangItem(Op),        sym::index,              index_trait,             Target::Trait;
-    IndexMutTraitLangItem(Op),     sym::index_mut,          index_mut_trait,         Target::Trait;
+    Add(Op),                 sym::add,                 add_trait,                  Target::Trait;
+    Sub(Op),                 sym::sub,                 sub_trait,                  Target::Trait;
+    Mul(Op),                 sym::mul,                 mul_trait,                  Target::Trait;
+    Div(Op),                 sym::div,                 div_trait,                  Target::Trait;
+    Rem(Op),                 sym::rem,                 rem_trait,                  Target::Trait;
+    Neg(Op),                 sym::neg,                 neg_trait,                  Target::Trait;
+    Not(Op),                 sym::not,                 not_trait,                  Target::Trait;
+    BitXor(Op),              sym::bitxor,              bitxor_trait,               Target::Trait;
+    BitAnd(Op),              sym::bitand,              bitand_trait,               Target::Trait;
+    BitOr(Op),               sym::bitor,               bitor_trait,                Target::Trait;
+    Shl(Op),                 sym::shl,                 shl_trait,                  Target::Trait;
+    Shr(Op),                 sym::shr,                 shr_trait,                  Target::Trait;
+    AddAssign(Op),           sym::add_assign,          add_assign_trait,           Target::Trait;
+    SubAssign(Op),           sym::sub_assign,          sub_assign_trait,           Target::Trait;
+    MulAssign(Op),           sym::mul_assign,          mul_assign_trait,           Target::Trait;
+    DivAssign(Op),           sym::div_assign,          div_assign_trait,           Target::Trait;
+    RemAssign(Op),           sym::rem_assign,          rem_assign_trait,           Target::Trait;
+    BitXorAssign(Op),        sym::bitxor_assign,       bitxor_assign_trait,        Target::Trait;
+    BitAndAssign(Op),        sym::bitand_assign,       bitand_assign_trait,        Target::Trait;
+    BitOrAssign(Op),         sym::bitor_assign,        bitor_assign_trait,         Target::Trait;
+    ShlAssign(Op),           sym::shl_assign,          shl_assign_trait,           Target::Trait;
+    ShrAssign(Op),           sym::shr_assign,          shr_assign_trait,           Target::Trait;
+    Index(Op),               sym::index,               index_trait,                Target::Trait;
+    IndexMut(Op),            sym::index_mut,           index_mut_trait,            Target::Trait;
 
-    UnsafeCellTypeLangItem,        sym::unsafe_cell,        unsafe_cell_type,        Target::Struct;
-    VaListTypeLangItem,            sym::va_list,            va_list,                 Target::Struct;
+    UnsafeCell,              sym::unsafe_cell,         unsafe_cell_type,           Target::Struct;
+    VaList,                  sym::va_list,             va_list,                    Target::Struct;
 
-    DerefTraitLangItem,            sym::deref,              deref_trait,             Target::Trait;
-    DerefMutTraitLangItem,         sym::deref_mut,          deref_mut_trait,         Target::Trait;
-    ReceiverTraitLangItem,         sym::receiver,           receiver_trait,          Target::Trait;
+    Deref,                   sym::deref,               deref_trait,                Target::Trait;
+    DerefMut,                sym::deref_mut,           deref_mut_trait,            Target::Trait;
+    Receiver,                sym::receiver,            receiver_trait,             Target::Trait;
 
-    FnTraitLangItem,               kw::Fn,                  fn_trait,                Target::Trait;
-    FnMutTraitLangItem,            sym::fn_mut,             fn_mut_trait,            Target::Trait;
-    FnOnceTraitLangItem,           sym::fn_once,            fn_once_trait,           Target::Trait;
+    Fn,                      kw::Fn,                   fn_trait,                   Target::Trait;
+    FnMut,                   sym::fn_mut,              fn_mut_trait,               Target::Trait;
+    FnOnce,                  sym::fn_once,             fn_once_trait,              Target::Trait;
 
-    FnOnceOutputLangItem,          sym::fn_once_output,     fn_once_output,          Target::AssocTy;
+    FnOnceOutput,            sym::fn_once_output,      fn_once_output,             Target::AssocTy;
 
-    FutureTraitLangItem,           sym::future_trait,       future_trait,            Target::Trait;
-    GeneratorStateLangItem,        sym::generator_state,    gen_state,               Target::Enum;
-    GeneratorTraitLangItem,        sym::generator,          gen_trait,               Target::Trait;
-    UnpinTraitLangItem,            sym::unpin,              unpin_trait,             Target::Trait;
-    PinTypeLangItem,               sym::pin,                pin_type,                Target::Struct;
+    Future,                  sym::future_trait,        future_trait,               Target::Trait;
+    GeneratorState,          sym::generator_state,     gen_state,                  Target::Enum;
+    Generator,               sym::generator,           gen_trait,                  Target::Trait;
+    Unpin,                   sym::unpin,               unpin_trait,                Target::Trait;
+    Pin,                     sym::pin,                 pin_type,                   Target::Struct;
 
-    // Don't be fooled by the naming here: this lang item denotes `PartialEq`, not `Eq`.
-    EqTraitLangItem,               sym::eq,                 eq_trait,                Target::Trait;
-    PartialOrdTraitLangItem,       sym::partial_ord,        partial_ord_trait,       Target::Trait;
+    PartialEq,               sym::eq,                  eq_trait,                   Target::Trait;
+    PartialOrd,              sym::partial_ord,         partial_ord_trait,          Target::Trait;
 
-    // A number of panic-related lang items. The `panic` item corresponds to
-    // divide-by-zero and various panic cases with `match`. The
-    // `panic_bounds_check` item is for indexing arrays.
+    // A number of panic-related lang items. The `panic` item corresponds to divide-by-zero and
+    // various panic cases with `match`. The `panic_bounds_check` item is for indexing arrays.
     //
-    // The `begin_unwind` lang item has a predefined symbol name and is sort of
-    // a "weak lang item" in the sense that a crate is not required to have it
-    // defined to use it, but a final product is required to define it
-    // somewhere. Additionally, there are restrictions on crates that use a weak
-    // lang item, but do not have it defined.
-    PanicFnLangItem,               sym::panic,              panic_fn,                Target::Fn;
-    PanicBoundsCheckFnLangItem,    sym::panic_bounds_check, panic_bounds_check_fn,   Target::Fn;
-    PanicInfoLangItem,             sym::panic_info,         panic_info,              Target::Struct;
-    PanicLocationLangItem,         sym::panic_location,     panic_location,          Target::Struct;
-    PanicImplLangItem,             sym::panic_impl,         panic_impl,              Target::Fn;
-    // Libstd panic entry point. Necessary for const eval to be able to catch it
-    BeginPanicFnLangItem,          sym::begin_panic,        begin_panic_fn,          Target::Fn;
+    // The `begin_unwind` lang item has a predefined symbol name and is sort of a "weak lang item"
+    // in the sense that a crate is not required to have it defined to use it, but a final product
+    // is required to define it somewhere. Additionally, there are restrictions on crates that use
+    // a weak lang item, but do not have it defined.
+    Panic,                   sym::panic,               panic_fn,                   Target::Fn;
+    PanicBoundsCheck,        sym::panic_bounds_check,  panic_bounds_check_fn,      Target::Fn;
+    PanicInfo,               sym::panic_info,          panic_info,                 Target::Struct;
+    PanicLocation,           sym::panic_location,      panic_location,             Target::Struct;
+    PanicImpl,               sym::panic_impl,          panic_impl,                 Target::Fn;
+    // libstd panic entry point. Necessary for const eval to be able to catch it
+    BeginPanic,              sym::begin_panic,         begin_panic_fn,             Target::Fn;
 
-    ExchangeMallocFnLangItem,      sym::exchange_malloc,    exchange_malloc_fn,      Target::Fn;
-    BoxFreeFnLangItem,             sym::box_free,           box_free_fn,             Target::Fn;
-    DropInPlaceFnLangItem,         sym::drop_in_place,      drop_in_place_fn,        Target::Fn;
-    OomLangItem,                   sym::oom,                oom,                     Target::Fn;
-    AllocLayoutLangItem,           sym::alloc_layout,       alloc_layout,            Target::Struct;
+    ExchangeMalloc,          sym::exchange_malloc,     exchange_malloc_fn,         Target::Fn;
+    BoxFree,                 sym::box_free,            box_free_fn,                Target::Fn;
+    DropInPlace,             sym::drop_in_place,       drop_in_place_fn,           Target::Fn;
+    Oom,                     sym::oom,                 oom,                        Target::Fn;
+    AllocLayout,             sym::alloc_layout,        alloc_layout,               Target::Struct;
 
-    StartFnLangItem,               sym::start,              start_fn,                Target::Fn;
+    Start,                   sym::start,               start_fn,                   Target::Fn;
 
-    EhPersonalityLangItem,         sym::eh_personality,     eh_personality,          Target::Fn;
-    EhCatchTypeinfoLangItem,       sym::eh_catch_typeinfo,  eh_catch_typeinfo,       Target::Static;
+    EhPersonality,           sym::eh_personality,      eh_personality,             Target::Fn;
+    EhCatchTypeinfo,         sym::eh_catch_typeinfo,   eh_catch_typeinfo,          Target::Static;
 
-    OwnedBoxLangItem,              sym::owned_box,          owned_box,               Target::Struct;
+    OwnedBox,                sym::owned_box,           owned_box,                  Target::Struct;
 
-    PhantomDataItem,               sym::phantom_data,       phantom_data,            Target::Struct;
+    PhantomData,             sym::phantom_data,        phantom_data,               Target::Struct;
 
-    ManuallyDropItem,              sym::manually_drop,      manually_drop,           Target::Struct;
+    ManuallyDrop,            sym::manually_drop,       manually_drop,              Target::Struct;
 
-    MaybeUninitLangItem,           sym::maybe_uninit,       maybe_uninit,            Target::Union;
+    MaybeUninit,             sym::maybe_uninit,        maybe_uninit,               Target::Union;
 
     // Align offset for stride != 1; must not panic.
-    AlignOffsetLangItem,           sym::align_offset,       align_offset_fn,         Target::Fn;
+    AlignOffset,             sym::align_offset,        align_offset_fn,            Target::Fn;
 
-    TerminationTraitLangItem,      sym::termination,        termination,             Target::Trait;
+    Termination,             sym::termination,         termination,                Target::Trait;
 
-    TryTraitLangItem,              kw::Try,                 try_trait,               Target::Trait;
+    Try,                     kw::Try,                  try_trait,                  Target::Trait;
 
     // Language items from AST lowering
-    TryFromError,                  sym::from_error,         from_error_fn,           Target::Method(MethodKind::Trait { body: false });
-    TryFromOk,                     sym::from_ok,            from_ok_fn,              Target::Method(MethodKind::Trait { body: false });
-    TryIntoResult,                 sym::into_result,        into_result_fn,          Target::Method(MethodKind::Trait { body: false });
+    TryFromError,            sym::from_error,          from_error_fn,              Target::Method(MethodKind::Trait { body: false });
+    TryFromOk,               sym::from_ok,             from_ok_fn,                 Target::Method(MethodKind::Trait { body: false });
+    TryIntoResult,           sym::into_result,         into_result_fn,             Target::Method(MethodKind::Trait { body: false });
 
-    PollReady,                     sym::Ready,              poll_ready_variant,      Target::Variant;
-    PollPending,                   sym::Pending,            poll_pending_variant,    Target::Variant;
+    PollReady,               sym::Ready,               poll_ready_variant,         Target::Variant;
+    PollPending,             sym::Pending,             poll_pending_variant,       Target::Variant;
 
-    FromGenerator,                 sym::from_generator,     from_generator_fn,       Target::Fn;
-    GetContext,                    sym::get_context,        get_context_fn,          Target::Fn;
+    FromGenerator,           sym::from_generator,      from_generator_fn,          Target::Fn;
+    GetContext,              sym::get_context,         get_context_fn,             Target::Fn;
 
-    FuturePoll,                    sym::poll,               future_poll_fn,          Target::Method(MethodKind::Trait { body: false });
+    FuturePoll,              sym::poll,                future_poll_fn,             Target::Method(MethodKind::Trait { body: false });
 
-    FromFrom,                      sym::from,               from_fn,                 Target::Method(MethodKind::Trait { body: false });
+    FromFrom,                sym::from,                from_fn,                    Target::Method(MethodKind::Trait { body: false });
 
-    OptionSome,                    sym::Some,               option_some_variant,     Target::Variant;
-    OptionNone,                    sym::None,               option_none_variant,     Target::Variant;
+    OptionSome,              sym::Some,                option_some_variant,        Target::Variant;
+    OptionNone,              sym::None,                option_none_variant,        Target::Variant;
 
-    ResultOk,                      sym::Ok,                 result_ok_variant,       Target::Variant;
-    ResultErr,                     sym::Err,                result_err_variant,      Target::Variant;
+    ResultOk,                sym::Ok,                  result_ok_variant,          Target::Variant;
+    ResultErr,               sym::Err,                 result_err_variant,         Target::Variant;
 
-    IntoIterIntoIter,              sym::into_iter,          into_iter_fn,            Target::Method(MethodKind::Trait { body: false });
-    IteratorNext,                  sym::next,               next_fn,                 Target::Method(MethodKind::Trait { body: false});
+    IntoIterIntoIter,        sym::into_iter,           into_iter_fn,               Target::Method(MethodKind::Trait { body: false });
+    IteratorNext,            sym::next,                next_fn,                    Target::Method(MethodKind::Trait { body: false});
 
-    PinNewUnchecked,               sym::new_unchecked,      new_unchecked_fn,        Target::Method(MethodKind::Inherent);
+    PinNewUnchecked,         sym::new_unchecked,       new_unchecked_fn,           Target::Method(MethodKind::Inherent);
 
-    RangeFrom,                     sym::RangeFrom,           range_from_struct,          Target::Struct;
-    RangeFull,                     sym::RangeFull,           range_full_struct,          Target::Struct;
-    RangeInclusiveStruct,          sym::RangeInclusive,      range_inclusive_struct,     Target::Struct;
-    RangeInclusiveNew,             sym::range_inclusive_new, range_inclusive_new_method, Target::Method(MethodKind::Inherent);
-    Range,                         sym::Range,               range_struct,               Target::Struct;
-    RangeToInclusive,              sym::RangeToInclusive,    range_to_inclusive_struct,  Target::Struct;
-    RangeTo,                       sym::RangeTo,             range_to_struct,            Target::Struct;
+    RangeFrom,               sym::RangeFrom,           range_from_struct,          Target::Struct;
+    RangeFull,               sym::RangeFull,           range_full_struct,          Target::Struct;
+    RangeInclusiveStruct,    sym::RangeInclusive,      range_inclusive_struct,     Target::Struct;
+    RangeInclusiveNew,       sym::range_inclusive_new, range_inclusive_new_method, Target::Method(MethodKind::Inherent);
+    Range,                   sym::Range,               range_struct,               Target::Struct;
+    RangeToInclusive,        sym::RangeToInclusive,    range_to_inclusive_struct,  Target::Struct;
+    RangeTo,                 sym::RangeTo,             range_to_struct,            Target::Struct;
 }

--- a/src/librustc_hir/weak_lang_items.rs
+++ b/src/librustc_hir/weak_lang_items.rs
@@ -15,7 +15,7 @@ macro_rules! weak_lang_items {
 lazy_static! {
     pub static ref WEAK_ITEMS_REFS: FxHashMap<Symbol, LangItem> = {
         let mut map = FxHashMap::default();
-        $(map.insert(sym::$name, lang_items::$item);)*
+        $(map.insert(sym::$name, LangItem::$item);)*
         map
     };
 }
@@ -46,7 +46,7 @@ impl LanguageItems {
 ) }
 
 weak_lang_items! {
-    panic_impl,         PanicImplLangItem,          rust_begin_unwind;
-    eh_personality,     EhPersonalityLangItem,      rust_eh_personality;
-    oom,                OomLangItem,                rust_oom;
+    panic_impl,         PanicImpl,          rust_begin_unwind;
+    eh_personality,     EhPersonality,      rust_eh_personality;
+    oom,                Oom,                rust_oom;
 }

--- a/src/librustc_middle/middle/lang_items.rs
+++ b/src/librustc_middle/middle/lang_items.rs
@@ -53,7 +53,7 @@ pub fn required(tcx: TyCtxt<'_>, lang_item: LangItem) -> bool {
     // symbols. Other panic runtimes ensure that the relevant symbols are
     // available to link things together, but they're never exercised.
     match tcx.sess.panic_strategy() {
-        PanicStrategy::Abort => lang_item != LangItem::EhPersonalityLangItem,
+        PanicStrategy::Abort => lang_item != LangItem::EhPersonality,
         PanicStrategy::Unwind => true,
     }
 }

--- a/src/librustc_middle/ty/adjustment.rs
+++ b/src/librustc_middle/ty/adjustment.rs
@@ -2,7 +2,7 @@ use crate::ty::subst::SubstsRef;
 use crate::ty::{self, Ty, TyCtxt};
 use rustc_hir as hir;
 use rustc_hir::def_id::DefId;
-use rustc_hir::lang_items::{DerefMutTraitLangItem, DerefTraitLangItem};
+use rustc_hir::lang_items::LangItem;
 use rustc_macros::HashStable;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, TyEncodable, TyDecodable, HashStable)]
@@ -118,8 +118,8 @@ pub struct OverloadedDeref<'tcx> {
 impl<'tcx> OverloadedDeref<'tcx> {
     pub fn method_call(&self, tcx: TyCtxt<'tcx>, source: Ty<'tcx>) -> (DefId, SubstsRef<'tcx>) {
         let trait_def_id = match self.mutbl {
-            hir::Mutability::Not => tcx.require_lang_item(DerefTraitLangItem, None),
-            hir::Mutability::Mut => tcx.require_lang_item(DerefMutTraitLangItem, None),
+            hir::Mutability::Not => tcx.require_lang_item(LangItem::Deref, None),
+            hir::Mutability::Mut => tcx.require_lang_item(LangItem::DerefMut, None),
         };
         let method_def_id = tcx
             .associated_items(trait_def_id)

--- a/src/librustc_middle/ty/context.rs
+++ b/src/librustc_middle/ty/context.rs
@@ -40,7 +40,7 @@ use rustc_hir::def::{DefKind, Res};
 use rustc_hir::def_id::{CrateNum, DefId, DefIdMap, LocalDefId, LOCAL_CRATE};
 use rustc_hir::definitions::{DefPathHash, Definitions};
 use rustc_hir::intravisit::Visitor;
-use rustc_hir::lang_items::{self, PanicLocationLangItem};
+use rustc_hir::lang_items::LangItem;
 use rustc_hir::{HirId, ItemKind, ItemLocalId, ItemLocalMap, ItemLocalSet, Node, TraitCandidate};
 use rustc_index::vec::{Idx, IndexVec};
 use rustc_macros::HashStable;
@@ -1538,7 +1538,7 @@ impl<'tcx> TyCtxt<'tcx> {
     pub fn caller_location_ty(&self) -> Ty<'tcx> {
         self.mk_imm_ref(
             self.lifetimes.re_static,
-            self.type_of(self.require_lang_item(PanicLocationLangItem, None))
+            self.type_of(self.require_lang_item(LangItem::PanicLocation, None))
                 .subst(*self, self.mk_substs([self.lifetimes.re_static.into()].iter())),
         )
     }
@@ -2185,12 +2185,12 @@ impl<'tcx> TyCtxt<'tcx> {
 
     #[inline]
     pub fn mk_box(self, ty: Ty<'tcx>) -> Ty<'tcx> {
-        let def_id = self.require_lang_item(lang_items::OwnedBoxLangItem, None);
+        let def_id = self.require_lang_item(LangItem::OwnedBox, None);
         self.mk_generic_adt(def_id, ty)
     }
 
     #[inline]
-    pub fn mk_lang_item(self, ty: Ty<'tcx>, item: lang_items::LangItem) -> Option<Ty<'tcx>> {
+    pub fn mk_lang_item(self, ty: Ty<'tcx>, item: LangItem) -> Option<Ty<'tcx>> {
         let def_id = self.lang_items().require(item).ok()?;
         Some(self.mk_generic_adt(def_id, ty))
     }
@@ -2203,7 +2203,7 @@ impl<'tcx> TyCtxt<'tcx> {
 
     #[inline]
     pub fn mk_maybe_uninit(self, ty: Ty<'tcx>) -> Ty<'tcx> {
-        let def_id = self.require_lang_item(lang_items::MaybeUninitLangItem, None);
+        let def_id = self.require_lang_item(LangItem::MaybeUninit, None);
         self.mk_generic_adt(def_id, ty)
     }
 

--- a/src/librustc_middle/ty/instance.rs
+++ b/src/librustc_middle/ty/instance.rs
@@ -5,7 +5,7 @@ use crate::ty::{self, SubstsRef, Ty, TyCtxt, TypeFoldable};
 use rustc_errors::ErrorReported;
 use rustc_hir::def::Namespace;
 use rustc_hir::def_id::{CrateNum, DefId};
-use rustc_hir::lang_items::{DropInPlaceFnLangItem, FnOnceTraitLangItem};
+use rustc_hir::lang_items::LangItem;
 use rustc_macros::HashStable;
 
 use std::fmt;
@@ -408,7 +408,7 @@ impl<'tcx> Instance<'tcx> {
     }
 
     pub fn resolve_drop_in_place(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> ty::Instance<'tcx> {
-        let def_id = tcx.require_lang_item(DropInPlaceFnLangItem, None);
+        let def_id = tcx.require_lang_item(LangItem::DropInPlace, None);
         let substs = tcx.intern_substs(&[ty.into()]);
         Instance::resolve(tcx, ty::ParamEnv::reveal_all(), def_id, substs).unwrap().unwrap()
     }
@@ -419,7 +419,7 @@ impl<'tcx> Instance<'tcx> {
         substs: ty::SubstsRef<'tcx>,
     ) -> Instance<'tcx> {
         debug!("fn_once_adapter_shim({:?}, {:?})", closure_did, substs);
-        let fn_once = tcx.require_lang_item(FnOnceTraitLangItem, None);
+        let fn_once = tcx.require_lang_item(LangItem::FnOnce, None);
         let call_once = tcx
             .associated_items(fn_once)
             .in_definition_order()

--- a/src/librustc_middle/ty/layout.rs
+++ b/src/librustc_middle/ty/layout.rs
@@ -8,7 +8,7 @@ use rustc_ast::{self as ast, IntTy, UintTy};
 use rustc_attr as attr;
 use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
 use rustc_hir as hir;
-use rustc_hir::lang_items::{GeneratorStateLangItem, PinTypeLangItem};
+use rustc_hir::lang_items::LangItem;
 use rustc_index::bit_set::BitSet;
 use rustc_index::vec::{Idx, IndexVec};
 use rustc_session::{DataTypeKind, FieldInfo, SizeKind, VariantInfo};
@@ -2371,13 +2371,13 @@ impl<'tcx> ty::Instance<'tcx> {
                 let env_region = ty::ReLateBound(ty::INNERMOST, ty::BrEnv);
                 let env_ty = tcx.mk_mut_ref(tcx.mk_region(env_region), ty);
 
-                let pin_did = tcx.require_lang_item(PinTypeLangItem, None);
+                let pin_did = tcx.require_lang_item(LangItem::Pin, None);
                 let pin_adt_ref = tcx.adt_def(pin_did);
                 let pin_substs = tcx.intern_substs(&[env_ty.into()]);
                 let env_ty = tcx.mk_adt(pin_adt_ref, pin_substs);
 
                 sig.map_bound(|sig| {
-                    let state_did = tcx.require_lang_item(GeneratorStateLangItem, None);
+                    let state_did = tcx.require_lang_item(LangItem::GeneratorState, None);
                     let state_adt_ref = tcx.adt_def(state_did);
                     let state_substs =
                         tcx.intern_substs(&[sig.yield_ty.into(), sig.return_ty.into()]);

--- a/src/librustc_middle/ty/mod.rs
+++ b/src/librustc_middle/ty/mod.rs
@@ -32,7 +32,7 @@ use rustc_errors::ErrorReported;
 use rustc_hir as hir;
 use rustc_hir::def::{CtorKind, CtorOf, DefKind, Namespace, Res};
 use rustc_hir::def_id::{CrateNum, DefId, DefIdMap, LocalDefId, CRATE_DEF_INDEX};
-use rustc_hir::lang_items::{FnMutTraitLangItem, FnOnceTraitLangItem, FnTraitLangItem};
+use rustc_hir::lang_items::LangItem;
 use rustc_hir::{Constness, Node};
 use rustc_index::vec::{Idx, IndexVec};
 use rustc_macros::HashStable;
@@ -2670,9 +2670,9 @@ impl<'tcx> ClosureKind {
 
     pub fn trait_did(&self, tcx: TyCtxt<'tcx>) -> DefId {
         match *self {
-            ClosureKind::Fn => tcx.require_lang_item(FnTraitLangItem, None),
-            ClosureKind::FnMut => tcx.require_lang_item(FnMutTraitLangItem, None),
-            ClosureKind::FnOnce => tcx.require_lang_item(FnOnceTraitLangItem, None),
+            ClosureKind::Fn => tcx.require_lang_item(LangItem::Fn, None),
+            ClosureKind::FnMut => tcx.require_lang_item(LangItem::FnMut, None),
+            ClosureKind::FnOnce => tcx.require_lang_item(LangItem::FnOnce, None),
         }
     }
 

--- a/src/librustc_mir/borrow_check/type_check/mod.rs
+++ b/src/librustc_mir/borrow_check/type_check/mod.rs
@@ -10,7 +10,7 @@ use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_errors::struct_span_err;
 use rustc_hir as hir;
 use rustc_hir::def_id::{DefId, LocalDefId};
-use rustc_hir::lang_items::{CoerceUnsizedTraitLangItem, CopyTraitLangItem, SizedTraitLangItem};
+use rustc_hir::lang_items::LangItem;
 use rustc_index::vec::{Idx, IndexVec};
 use rustc_infer::infer::canonical::QueryRegionConstraints;
 use rustc_infer::infer::outlives::env::RegionBoundPairs;
@@ -507,7 +507,7 @@ impl<'a, 'b, 'tcx> TypeVerifier<'a, 'b, 'tcx> {
         if let PlaceContext::NonMutatingUse(NonMutatingUseContext::Copy) = context {
             let tcx = self.tcx();
             let trait_ref = ty::TraitRef {
-                def_id: tcx.require_lang_item(CopyTraitLangItem, Some(self.last_span)),
+                def_id: tcx.require_lang_item(LangItem::Copy, Some(self.last_span)),
                 substs: tcx.mk_substs_trait(place_ty.ty, &[]),
             };
 
@@ -1474,7 +1474,7 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
                 self.check_rvalue(body, rv, location);
                 if !self.tcx().features().unsized_locals {
                     let trait_ref = ty::TraitRef {
-                        def_id: tcx.require_lang_item(SizedTraitLangItem, Some(self.last_span)),
+                        def_id: tcx.require_lang_item(LangItem::Sized, Some(self.last_span)),
                         substs: tcx.mk_substs_trait(place_ty, &[]),
                     };
                     self.prove_trait_ref(
@@ -2025,7 +2025,7 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
                                     self.param_env,
                                     ty::Binder::bind(ty::TraitRef::new(
                                         self.tcx().require_lang_item(
-                                            CopyTraitLangItem,
+                                            LangItem::Copy,
                                             Some(self.last_span),
                                         ),
                                         tcx.mk_substs_trait(ty, &[]),
@@ -2050,7 +2050,7 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
                 }
 
                 let trait_ref = ty::TraitRef {
-                    def_id: tcx.require_lang_item(SizedTraitLangItem, Some(self.last_span)),
+                    def_id: tcx.require_lang_item(LangItem::Sized, Some(self.last_span)),
                     substs: tcx.mk_substs_trait(ty, &[]),
                 };
 
@@ -2148,10 +2148,8 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
                     CastKind::Pointer(PointerCast::Unsize) => {
                         let &ty = ty;
                         let trait_ref = ty::TraitRef {
-                            def_id: tcx.require_lang_item(
-                                CoerceUnsizedTraitLangItem,
-                                Some(self.last_span),
-                            ),
+                            def_id: tcx
+                                .require_lang_item(LangItem::CoerceUnsized, Some(self.last_span)),
                             substs: tcx.mk_substs_trait(op.ty(body, tcx), &[ty.into()]),
                         };
 

--- a/src/librustc_mir/borrow_check/universal_regions.rs
+++ b/src/librustc_mir/borrow_check/universal_regions.rs
@@ -17,7 +17,7 @@ use rustc_data_structures::fx::FxHashMap;
 use rustc_errors::DiagnosticBuilder;
 use rustc_hir as hir;
 use rustc_hir::def_id::{DefId, LocalDefId};
-use rustc_hir::lang_items;
+use rustc_hir::lang_items::LangItem;
 use rustc_hir::{BodyOwnerKind, HirId};
 use rustc_index::vec::{Idx, IndexVec};
 use rustc_infer::infer::{InferCtxt, NLLRegionVariableOrigin};
@@ -456,7 +456,7 @@ impl<'cx, 'tcx> UniversalRegionsBuilder<'cx, 'tcx> {
         if let DefiningTy::FnDef(def_id, _) = defining_ty {
             if self.infcx.tcx.fn_sig(def_id).c_variadic() {
                 let va_list_did = self.infcx.tcx.require_lang_item(
-                    lang_items::VaListTypeLangItem,
+                    LangItem::VaList,
                     Some(self.infcx.tcx.def_span(self.mir_def.did)),
                 );
                 let region = self

--- a/src/librustc_mir/interpret/intrinsics/caller_location.rs
+++ b/src/librustc_mir/interpret/intrinsics/caller_location.rs
@@ -1,6 +1,6 @@
 use std::convert::TryFrom;
 
-use rustc_hir::lang_items::PanicLocationLangItem;
+use rustc_hir::lang_items::LangItem;
 use rustc_middle::mir::TerminatorKind;
 use rustc_middle::ty::subst::Subst;
 use rustc_span::{Span, Symbol};
@@ -63,7 +63,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
         // Allocate memory for `CallerLocation` struct.
         let loc_ty = self
             .tcx
-            .type_of(self.tcx.require_lang_item(PanicLocationLangItem, None))
+            .type_of(self.tcx.require_lang_item(LangItem::PanicLocation, None))
             .subst(*self.tcx, self.tcx.mk_substs([self.tcx.lifetimes.re_erased.into()].iter()));
         let loc_layout = self.layout_of(loc_ty).unwrap();
         let location = self.allocate(loc_layout, MemoryKind::CallerLocation);

--- a/src/librustc_mir/monomorphize/collector.rs
+++ b/src/librustc_mir/monomorphize/collector.rs
@@ -182,7 +182,7 @@ use rustc_errors::{ErrorReported, FatalError};
 use rustc_hir as hir;
 use rustc_hir::def_id::{DefId, DefIdMap, LocalDefId, LOCAL_CRATE};
 use rustc_hir::itemlikevisit::ItemLikeVisitor;
-use rustc_hir::lang_items::{ExchangeMallocFnLangItem, StartFnLangItem};
+use rustc_hir::lang_items::LangItem;
 use rustc_index::bit_set::GrowableBitSet;
 use rustc_middle::middle::codegen_fn_attrs::CodegenFnAttrFlags;
 use rustc_middle::mir::interpret::{AllocId, ConstValue};
@@ -594,7 +594,7 @@ impl<'a, 'tcx> MirVisitor<'tcx> for MirNeighborCollector<'a, 'tcx> {
             mir::Rvalue::NullaryOp(mir::NullOp::Box, _) => {
                 let tcx = self.tcx;
                 let exchange_malloc_fn_def_id =
-                    tcx.require_lang_item(ExchangeMallocFnLangItem, None);
+                    tcx.require_lang_item(LangItem::ExchangeMalloc, None);
                 let instance = Instance::mono(tcx, exchange_malloc_fn_def_id);
                 if should_codegen_locally(tcx, &instance) {
                     self.output.push(create_fn_mono_item(self.tcx, instance, span));
@@ -1083,7 +1083,7 @@ impl RootCollector<'_, 'v> {
             _ => return,
         };
 
-        let start_def_id = match self.tcx.lang_items().require(StartFnLangItem) {
+        let start_def_id = match self.tcx.lang_items().require(LangItem::Start) {
             Ok(s) => s,
             Err(err) => self.tcx.sess.fatal(&err),
         };

--- a/src/librustc_mir/monomorphize/mod.rs
+++ b/src/librustc_mir/monomorphize/mod.rs
@@ -2,7 +2,7 @@ use rustc_middle::traits;
 use rustc_middle::ty::adjustment::CustomCoerceUnsized;
 use rustc_middle::ty::{self, Ty, TyCtxt};
 
-use rustc_hir::lang_items::CoerceUnsizedTraitLangItem;
+use rustc_hir::lang_items::LangItem;
 
 pub mod collector;
 pub mod partitioning;
@@ -13,7 +13,7 @@ pub fn custom_coerce_unsize_info<'tcx>(
     source_ty: Ty<'tcx>,
     target_ty: Ty<'tcx>,
 ) -> CustomCoerceUnsized {
-    let def_id = tcx.require_lang_item(CoerceUnsizedTraitLangItem, None);
+    let def_id = tcx.require_lang_item(LangItem::CoerceUnsized, None);
 
     let trait_ref = ty::Binder::bind(ty::TraitRef {
         def_id,

--- a/src/librustc_mir/shim.rs
+++ b/src/librustc_mir/shim.rs
@@ -1,6 +1,6 @@
 use rustc_hir as hir;
 use rustc_hir::def_id::DefId;
-use rustc_hir::lang_items::FnMutTraitLangItem;
+use rustc_hir::lang_items::LangItem;
 use rustc_middle::mir::*;
 use rustc_middle::ty::query::Providers;
 use rustc_middle::ty::subst::{InternalSubsts, Subst};
@@ -62,7 +62,7 @@ fn make_shim<'tcx>(tcx: TyCtxt<'tcx>, instance: ty::InstanceDef<'tcx>) -> Body<'
             build_call_shim(tcx, instance, None, CallKind::Direct(def_id), None)
         }
         ty::InstanceDef::ClosureOnceShim { call_once: _ } => {
-            let fn_mut = tcx.require_lang_item(FnMutTraitLangItem, None);
+            let fn_mut = tcx.require_lang_item(LangItem::FnMut, None);
             let call_mut = tcx
                 .associated_items(fn_mut)
                 .in_definition_order()

--- a/src/librustc_mir/transform/check_consts/validation.rs
+++ b/src/librustc_mir/transform/check_consts/validation.rs
@@ -1,7 +1,7 @@
 //! The `Visitor` responsible for actually checking a `mir::Body` for invalid operations.
 
 use rustc_errors::struct_span_err;
-use rustc_hir::{self as hir, lang_items};
+use rustc_hir::{self as hir, LangItem};
 use rustc_hir::{def_id::DefId, HirId};
 use rustc_infer::infer::TyCtxtInferExt;
 use rustc_middle::mir::visit::{MutatingUseContext, NonMutatingUseContext, PlaceContext, Visitor};
@@ -618,7 +618,7 @@ fn check_return_ty_is_sync(tcx: TyCtxt<'tcx>, body: &Body<'tcx>, hir_id: HirId) 
     tcx.infer_ctxt().enter(|infcx| {
         let cause = traits::ObligationCause::new(body.span, hir_id, traits::SharedStatic);
         let mut fulfillment_cx = traits::FulfillmentContext::new();
-        let sync_def_id = tcx.require_lang_item(lang_items::SyncTraitLangItem, Some(body.span));
+        let sync_def_id = tcx.require_lang_item(LangItem::Sync, Some(body.span));
         fulfillment_cx.register_bound(&infcx, ty::ParamEnv::empty(), ty, sync_def_id, cause);
         if let Err(err) = fulfillment_cx.select_all_or_error(&infcx) {
             infcx.report_fulfillment_errors(&err, None, false);

--- a/src/librustc_mir/transform/generator.rs
+++ b/src/librustc_mir/transform/generator.rs
@@ -62,7 +62,7 @@ use crate::util::storage;
 use rustc_data_structures::fx::FxHashMap;
 use rustc_hir as hir;
 use rustc_hir::def_id::DefId;
-use rustc_hir::lang_items::{GeneratorStateLangItem, PinTypeLangItem};
+use rustc_hir::lang_items::LangItem;
 use rustc_index::bit_set::{BitMatrix, BitSet};
 use rustc_index::vec::{Idx, IndexVec};
 use rustc_middle::mir::visit::{MutVisitor, PlaceContext, Visitor};
@@ -395,7 +395,7 @@ fn make_generator_state_argument_indirect<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Bo
 fn make_generator_state_argument_pinned<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
     let ref_gen_ty = body.local_decls.raw[1].ty;
 
-    let pin_did = tcx.require_lang_item(PinTypeLangItem, Some(body.span));
+    let pin_did = tcx.require_lang_item(LangItem::Pin, Some(body.span));
     let pin_adt_ref = tcx.adt_def(pin_did);
     let substs = tcx.intern_substs(&[ref_gen_ty.into()]);
     let pin_ref_gen_ty = tcx.mk_adt(pin_adt_ref, substs);
@@ -1270,7 +1270,7 @@ impl<'tcx> MirPass<'tcx> for StateTransform {
         };
 
         // Compute GeneratorState<yield_ty, return_ty>
-        let state_did = tcx.require_lang_item(GeneratorStateLangItem, None);
+        let state_did = tcx.require_lang_item(LangItem::GeneratorState, None);
         let state_adt_ref = tcx.adt_def(state_did);
         let state_substs = tcx.intern_substs(&[yield_ty.into(), body.return_ty().into()]);
         let ret_ty = tcx.mk_adt(state_adt_ref, state_substs);

--- a/src/librustc_mir/util/elaborate_drops.rs
+++ b/src/librustc_mir/util/elaborate_drops.rs
@@ -1,6 +1,6 @@
 use crate::util::patch::MirPatch;
 use rustc_hir as hir;
-use rustc_hir::lang_items::{BoxFreeFnLangItem, DropTraitLangItem};
+use rustc_hir::lang_items::LangItem;
 use rustc_index::vec::Idx;
 use rustc_middle::mir::*;
 use rustc_middle::traits::Reveal;
@@ -613,7 +613,7 @@ where
     fn destructor_call_block(&mut self, (succ, unwind): (BasicBlock, Unwind)) -> BasicBlock {
         debug!("destructor_call_block({:?}, {:?})", self, succ);
         let tcx = self.tcx();
-        let drop_trait = tcx.require_lang_item(DropTraitLangItem, None);
+        let drop_trait = tcx.require_lang_item(LangItem::Drop, None);
         let drop_fn = tcx.associated_items(drop_trait).in_definition_order().next().unwrap();
         let ty = self.place_ty(self.place);
         let substs = tcx.mk_substs_trait(ty, &[]);
@@ -971,7 +971,7 @@ where
     ) -> BasicBlock {
         let tcx = self.tcx();
         let unit_temp = Place::from(self.new_temp(tcx.mk_unit()));
-        let free_func = tcx.require_lang_item(BoxFreeFnLangItem, Some(self.source_info.span));
+        let free_func = tcx.require_lang_item(LangItem::BoxFree, Some(self.source_info.span));
         let args = adt.variants[VariantIdx::new(0)]
             .fields
             .iter()

--- a/src/librustc_mir_build/build/mod.rs
+++ b/src/librustc_mir_build/build/mod.rs
@@ -6,7 +6,7 @@ use rustc_attr::{self as attr, UnwindAttr};
 use rustc_errors::ErrorReported;
 use rustc_hir as hir;
 use rustc_hir::def_id::{DefId, LocalDefId};
-use rustc_hir::lang_items;
+use rustc_hir::lang_items::LangItem;
 use rustc_hir::{GeneratorKind, HirIdMap, Node};
 use rustc_index::vec::{Idx, IndexVec};
 use rustc_infer::infer::TyCtxtInferExt;
@@ -145,8 +145,7 @@ fn mir_build(tcx: TyCtxt<'_>, def: ty::WithOptConstParam<LocalDefId>) -> Body<'_
                 // C-variadic fns also have a `VaList` input that's not listed in `fn_sig`
                 // (as it's created inside the body itself, not passed in from outside).
                 let ty = if fn_sig.c_variadic && index == fn_sig.inputs().len() {
-                    let va_list_did =
-                        tcx.require_lang_item(lang_items::VaListTypeLangItem, Some(arg.span));
+                    let va_list_did = tcx.require_lang_item(LangItem::VaList, Some(arg.span));
 
                     tcx.type_of(va_list_did).subst(tcx, &[tcx.lifetimes.re_erased.into()])
                 } else {

--- a/src/librustc_mir_build/thir/pattern/const_to_pat.rs
+++ b/src/librustc_mir_build/thir/pattern/const_to_pat.rs
@@ -1,5 +1,4 @@
 use rustc_hir as hir;
-use rustc_hir::lang_items::EqTraitLangItem;
 use rustc_index::vec::Idx;
 use rustc_infer::infer::{InferCtxt, TyCtxtInferExt};
 use rustc_middle::mir::Field;
@@ -164,7 +163,7 @@ impl<'a, 'tcx> ConstToPat<'a, 'tcx> {
                 // not *yet* implement `PartialEq`. So for now we leave this here.
                 let ty_is_partial_eq: bool = {
                     let partial_eq_trait_id =
-                        self.tcx().require_lang_item(EqTraitLangItem, Some(self.span));
+                        self.tcx().require_lang_item(hir::LangItem::PartialEq, Some(self.span));
                     let obligation: PredicateObligation<'_> = predicate_for_trait_def(
                         self.tcx(),
                         self.param_env,

--- a/src/librustc_trait_selection/infer.rs
+++ b/src/librustc_trait_selection/infer.rs
@@ -2,7 +2,7 @@ use crate::traits::query::outlives_bounds::InferCtxtExt as _;
 use crate::traits::{self, TraitEngine, TraitEngineExt};
 
 use rustc_hir as hir;
-use rustc_hir::lang_items;
+use rustc_hir::lang_items::LangItem;
 use rustc_infer::infer::outlives::env::OutlivesEnvironment;
 use rustc_infer::traits::ObligationCause;
 use rustc_middle::arena::ArenaAllocatable;
@@ -47,7 +47,7 @@ impl<'cx, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'cx, 'tcx> {
             return ty.is_copy_modulo_regions(self.tcx.at(span), param_env);
         }
 
-        let copy_def_id = self.tcx.require_lang_item(lang_items::CopyTraitLangItem, None);
+        let copy_def_id = self.tcx.require_lang_item(LangItem::Copy, None);
 
         // This can get called from typeck (by euv), and `moves_by_default`
         // rightly refuses to work with inference variables, but

--- a/src/librustc_trait_selection/traits/error_reporting/suggestions.rs
+++ b/src/librustc_trait_selection/traits/error_reporting/suggestions.rs
@@ -13,7 +13,7 @@ use rustc_hir as hir;
 use rustc_hir::def::DefKind;
 use rustc_hir::def_id::DefId;
 use rustc_hir::intravisit::Visitor;
-use rustc_hir::lang_items;
+use rustc_hir::lang_items::LangItem;
 use rustc_hir::{AsyncGeneratorKind, GeneratorKind, Node};
 use rustc_middle::ty::{
     self, suggest_constraining_type_param, AdtKind, DefIdTree, Infer, InferTy, ToPredicate, Ty,
@@ -2015,8 +2015,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
         if let Some(body_id) = self.tcx.hir().maybe_body_owned_by(item_id) {
             let body = self.tcx.hir().body(body_id);
             if let Some(hir::GeneratorKind::Async(_)) = body.generator_kind {
-                let future_trait =
-                    self.tcx.require_lang_item(lang_items::FutureTraitLangItem, None);
+                let future_trait = self.tcx.require_lang_item(LangItem::Future, None);
 
                 let self_ty = self.resolve_vars_if_possible(&trait_ref.self_ty());
 

--- a/src/librustc_trait_selection/traits/project.rs
+++ b/src/librustc_trait_selection/traits/project.rs
@@ -23,9 +23,7 @@ use crate::traits::error_reporting::InferCtxtExt;
 use rustc_data_structures::stack::ensure_sufficient_stack;
 use rustc_errors::ErrorReported;
 use rustc_hir::def_id::DefId;
-use rustc_hir::lang_items::{
-    DiscriminantTypeLangItem, FnOnceOutputLangItem, FnOnceTraitLangItem, GeneratorTraitLangItem,
-};
+use rustc_hir::lang_items::LangItem;
 use rustc_infer::infer::resolve::OpportunisticRegionResolver;
 use rustc_middle::ty::fold::{TypeFoldable, TypeFolder};
 use rustc_middle::ty::subst::Subst;
@@ -1300,7 +1298,7 @@ fn confirm_generator_candidate<'cx, 'tcx>(
 
     let tcx = selcx.tcx();
 
-    let gen_def_id = tcx.require_lang_item(GeneratorTraitLangItem, None);
+    let gen_def_id = tcx.require_lang_item(LangItem::Generator, None);
 
     let predicate = super::util::generator_trait_ref_and_outputs(
         tcx,
@@ -1342,7 +1340,7 @@ fn confirm_discriminant_kind_candidate<'cx, 'tcx>(
     let self_ty = selcx.infcx().shallow_resolve(obligation.predicate.self_ty());
     let substs = tcx.mk_substs([self_ty.into()].iter());
 
-    let discriminant_def_id = tcx.require_lang_item(DiscriminantTypeLangItem, None);
+    let discriminant_def_id = tcx.require_lang_item(LangItem::Discriminant, None);
 
     let predicate = ty::ProjectionPredicate {
         projection_ty: ty::ProjectionTy { substs, item_def_id: discriminant_def_id },
@@ -1406,8 +1404,8 @@ fn confirm_callable_candidate<'cx, 'tcx>(
 
     debug!("confirm_callable_candidate({:?},{:?})", obligation, fn_sig);
 
-    let fn_once_def_id = tcx.require_lang_item(FnOnceTraitLangItem, None);
-    let fn_once_output_def_id = tcx.require_lang_item(FnOnceOutputLangItem, None);
+    let fn_once_def_id = tcx.require_lang_item(LangItem::FnOnce, None);
+    let fn_once_output_def_id = tcx.require_lang_item(LangItem::FnOnceOutput, None);
 
     let predicate = super::util::closure_trait_ref_and_return_type(
         tcx,

--- a/src/librustc_trait_selection/traits/select/confirmation.rs
+++ b/src/librustc_trait_selection/traits/select/confirmation.rs
@@ -7,7 +7,7 @@
 //! [rustc dev guide]:
 //! https://rustc-dev-guide.rust-lang.org/traits/resolution.html#confirmation
 use rustc_data_structures::stack::ensure_sufficient_stack;
-use rustc_hir::lang_items;
+use rustc_hir::lang_items::LangItem;
 use rustc_index::bit_set::GrowableBitSet;
 use rustc_infer::infer::InferOk;
 use rustc_middle::ty::subst::{GenericArg, GenericArgKind, Subst, SubstsRef};
@@ -669,7 +669,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
 
                 // We can only make objects from sized types.
                 let tr = ty::TraitRef::new(
-                    tcx.require_lang_item(lang_items::SizedTraitLangItem, None),
+                    tcx.require_lang_item(LangItem::Sized, None),
                     tcx.mk_substs_trait(source, &[]),
                 );
                 nested.push(predicate_to_obligation(tr.without_const().to_predicate(tcx)));

--- a/src/librustc_trait_selection/traits/structural_match.rs
+++ b/src/librustc_trait_selection/traits/structural_match.rs
@@ -4,7 +4,7 @@ use crate::traits::{self, TraitEngine};
 
 use rustc_data_structures::fx::FxHashSet;
 use rustc_hir as hir;
-use rustc_hir::lang_items::{StructuralPeqTraitLangItem, StructuralTeqTraitLangItem};
+use rustc_hir::lang_items::LangItem;
 use rustc_middle::ty::query::Providers;
 use rustc_middle::ty::{self, AdtDef, Ty, TyCtxt, TypeFoldable, TypeVisitor};
 use rustc_span::Span;
@@ -75,7 +75,7 @@ fn type_marked_structural(
     let mut fulfillment_cx = traits::FulfillmentContext::new();
     // require `#[derive(PartialEq)]`
     let structural_peq_def_id =
-        infcx.tcx.require_lang_item(StructuralPeqTraitLangItem, Some(cause.span));
+        infcx.tcx.require_lang_item(LangItem::StructuralPeq, Some(cause.span));
     fulfillment_cx.register_bound(
         infcx,
         ty::ParamEnv::empty(),
@@ -86,7 +86,7 @@ fn type_marked_structural(
     // for now, require `#[derive(Eq)]`. (Doing so is a hack to work around
     // the type `for<'a> fn(&'a ())` failing to implement `Eq` itself.)
     let structural_teq_def_id =
-        infcx.tcx.require_lang_item(StructuralTeqTraitLangItem, Some(cause.span));
+        infcx.tcx.require_lang_item(LangItem::StructuralTeq, Some(cause.span));
     fulfillment_cx.register_bound(
         infcx,
         ty::ParamEnv::empty(),

--- a/src/librustc_trait_selection/traits/wf.rs
+++ b/src/librustc_trait_selection/traits/wf.rs
@@ -3,7 +3,7 @@ use crate::opaque_types::required_region_bounds;
 use crate::traits;
 use rustc_hir as hir;
 use rustc_hir::def_id::DefId;
-use rustc_hir::lang_items;
+use rustc_hir::lang_items::LangItem;
 use rustc_middle::ty::subst::{GenericArg, GenericArgKind, SubstsRef};
 use rustc_middle::ty::{self, ToPredicate, Ty, TyCtxt, TypeFoldable, WithConstness};
 use rustc_span::Span;
@@ -340,7 +340,7 @@ impl<'a, 'tcx> WfPredicates<'a, 'tcx> {
         if !subty.has_escaping_bound_vars() {
             let cause = self.cause(cause);
             let trait_ref = ty::TraitRef {
-                def_id: self.infcx.tcx.require_lang_item(lang_items::SizedTraitLangItem, None),
+                def_id: self.infcx.tcx.require_lang_item(LangItem::Sized, None),
                 substs: self.infcx.tcx.mk_substs_trait(subty, &[]),
             };
             self.out.push(traits::Obligation::new(

--- a/src/librustc_ty/common_traits.rs
+++ b/src/librustc_ty/common_traits.rs
@@ -1,27 +1,27 @@
 //! Queries for checking whether a type implements one of a few common traits.
 
-use rustc_hir::lang_items;
+use rustc_hir::lang_items::LangItem;
 use rustc_infer::infer::TyCtxtInferExt;
 use rustc_middle::ty::{self, Ty, TyCtxt};
 use rustc_span::DUMMY_SP;
 use rustc_trait_selection::traits;
 
 fn is_copy_raw<'tcx>(tcx: TyCtxt<'tcx>, query: ty::ParamEnvAnd<'tcx, Ty<'tcx>>) -> bool {
-    is_item_raw(tcx, query, lang_items::CopyTraitLangItem)
+    is_item_raw(tcx, query, LangItem::Copy)
 }
 
 fn is_sized_raw<'tcx>(tcx: TyCtxt<'tcx>, query: ty::ParamEnvAnd<'tcx, Ty<'tcx>>) -> bool {
-    is_item_raw(tcx, query, lang_items::SizedTraitLangItem)
+    is_item_raw(tcx, query, LangItem::Sized)
 }
 
 fn is_freeze_raw<'tcx>(tcx: TyCtxt<'tcx>, query: ty::ParamEnvAnd<'tcx, Ty<'tcx>>) -> bool {
-    is_item_raw(tcx, query, lang_items::FreezeTraitLangItem)
+    is_item_raw(tcx, query, LangItem::Freeze)
 }
 
 fn is_item_raw<'tcx>(
     tcx: TyCtxt<'tcx>,
     query: ty::ParamEnvAnd<'tcx, Ty<'tcx>>,
-    item: lang_items::LangItem,
+    item: LangItem,
 ) -> bool {
     let (param_env, ty) = query.into_parts();
     let trait_def_id = tcx.require_lang_item(item, None);

--- a/src/librustc_typeck/astconv/mod.rs
+++ b/src/librustc_typeck/astconv/mod.rs
@@ -16,7 +16,7 @@ use rustc_hir as hir;
 use rustc_hir::def::{CtorOf, DefKind, Namespace, Res};
 use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_hir::intravisit::{walk_generics, Visitor as _};
-use rustc_hir::lang_items::SizedTraitLangItem;
+use rustc_hir::lang_items::LangItem;
 use rustc_hir::{Constness, GenericArg, GenericArgs};
 use rustc_middle::ty::subst::{self, InternalSubsts, Subst, SubstsRef};
 use rustc_middle::ty::GenericParamDefKind;
@@ -696,7 +696,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
             }
         }
 
-        let kind_id = tcx.lang_items().require(SizedTraitLangItem);
+        let kind_id = tcx.lang_items().require(LangItem::Sized);
         match unbound {
             Some(tpb) => {
                 // FIXME(#8559) currently requires the unbound to be built-in.

--- a/src/librustc_typeck/check/cast.rs
+++ b/src/librustc_typeck/check/cast.rs
@@ -35,7 +35,7 @@ use crate::type_error_struct;
 use rustc_ast as ast;
 use rustc_errors::{struct_span_err, Applicability, DiagnosticBuilder, ErrorReported};
 use rustc_hir as hir;
-use rustc_hir::lang_items;
+use rustc_hir::lang_items::LangItem;
 use rustc_middle::ty::adjustment::AllowTwoPhase;
 use rustc_middle::ty::cast::{CastKind, CastTy};
 use rustc_middle::ty::error::TypeError;
@@ -838,7 +838,7 @@ impl<'a, 'tcx> CastCheck<'tcx> {
 
 impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     fn type_is_known_to_be_sized_modulo_regions(&self, ty: Ty<'tcx>, span: Span) -> bool {
-        let lang_item = self.tcx.require_lang_item(lang_items::SizedTraitLangItem, None);
+        let lang_item = self.tcx.require_lang_item(LangItem::Sized, None);
         traits::type_known_to_meet_bound_modulo_regions(self, self.param_env, ty, lang_item, span)
     }
 }

--- a/src/librustc_typeck/check/closure.rs
+++ b/src/librustc_typeck/check/closure.rs
@@ -5,7 +5,7 @@ use super::{check_fn, Expectation, FnCtxt, GeneratorTypes};
 use crate::astconv::AstConv;
 use rustc_hir as hir;
 use rustc_hir::def_id::DefId;
-use rustc_hir::lang_items::{FutureTraitLangItem, GeneratorTraitLangItem};
+use rustc_hir::lang_items::LangItem;
 use rustc_infer::infer::type_variable::{TypeVariableOrigin, TypeVariableOriginKind};
 use rustc_infer::infer::LateBoundRegionConversionTime;
 use rustc_infer::infer::{InferOk, InferResult};
@@ -245,7 +245,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let trait_ref = projection.to_poly_trait_ref(tcx);
 
         let is_fn = tcx.fn_trait_kind_from_lang_item(trait_ref.def_id()).is_some();
-        let gen_trait = tcx.require_lang_item(GeneratorTraitLangItem, cause_span);
+        let gen_trait = tcx.require_lang_item(LangItem::Generator, cause_span);
         let is_gen = gen_trait == trait_ref.def_id();
         if !is_fn && !is_gen {
             debug!("deduce_sig_from_projection: not fn or generator");
@@ -668,7 +668,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         // Check that this is a projection from the `Future` trait.
         let trait_ref = predicate.projection_ty.trait_ref(self.tcx);
-        let future_trait = self.tcx.require_lang_item(FutureTraitLangItem, Some(cause_span));
+        let future_trait = self.tcx.require_lang_item(LangItem::Future, Some(cause_span));
         if trait_ref.def_id != future_trait {
             debug!("deduce_future_output_from_projection: not a future");
             return None;

--- a/src/librustc_typeck/check/demand.rs
+++ b/src/librustc_typeck/check/demand.rs
@@ -6,7 +6,7 @@ use rustc_trait_selection::traits::ObligationCause;
 use rustc_ast::util::parser::PREC_POSTFIX;
 use rustc_errors::{Applicability, DiagnosticBuilder};
 use rustc_hir as hir;
-use rustc_hir::lang_items::CloneTraitLangItem;
+use rustc_hir::lang_items::LangItem;
 use rustc_hir::{is_range_literal, Node};
 use rustc_middle::ty::adjustment::AllowTwoPhase;
 use rustc_middle::ty::{self, AssocItem, Ty, TypeAndMut};
@@ -465,7 +465,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 if self.can_coerce(ref_ty, expected) {
                     let mut sugg_sp = sp;
                     if let hir::ExprKind::MethodCall(ref segment, sp, ref args, _) = expr.kind {
-                        let clone_trait = self.tcx.require_lang_item(CloneTraitLangItem, Some(sp));
+                        let clone_trait = self.tcx.require_lang_item(LangItem::Clone, Some(sp));
                         if let ([arg], Some(true), sym::clone) = (
                             &args[..],
                             self.typeck_results.borrow().type_dependent_def_id(expr.hir_id).map(

--- a/src/librustc_typeck/check/expr.rs
+++ b/src/librustc_typeck/check/expr.rs
@@ -25,7 +25,7 @@ use rustc_errors::{pluralize, struct_span_err, Applicability, DiagnosticBuilder,
 use rustc_hir as hir;
 use rustc_hir::def::{CtorKind, DefKind, Res};
 use rustc_hir::def_id::DefId;
-use rustc_hir::lang_items;
+use rustc_hir::lang_items::LangItem;
 use rustc_hir::{ExprKind, QPath};
 use rustc_infer::infer;
 use rustc_infer::infer::type_variable::{TypeVariableOrigin, TypeVariableOriginKind};
@@ -926,8 +926,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 // Try alternative arbitrary self types that could fulfill this call.
                 // FIXME: probe for all types that *could* be arbitrary self-types, not
                 // just this list.
-                try_alt_rcvr(&mut err, self.tcx.mk_lang_item(rcvr_t, lang_items::OwnedBoxLangItem));
-                try_alt_rcvr(&mut err, self.tcx.mk_lang_item(rcvr_t, lang_items::PinTypeLangItem));
+                try_alt_rcvr(&mut err, self.tcx.mk_lang_item(rcvr_t, LangItem::OwnedBox));
+                try_alt_rcvr(&mut err, self.tcx.mk_lang_item(rcvr_t, LangItem::Pin));
                 try_alt_rcvr(&mut err, self.tcx.mk_diagnostic_item(rcvr_t, sym::Arc));
                 try_alt_rcvr(&mut err, self.tcx.mk_diagnostic_item(rcvr_t, sym::Rc));
             }

--- a/src/librustc_typeck/check/method/suggest.rs
+++ b/src/librustc_typeck/check/method/suggest.rs
@@ -9,7 +9,7 @@ use rustc_hir as hir;
 use rustc_hir::def::{DefKind, Namespace, Res};
 use rustc_hir::def_id::{DefId, CRATE_DEF_INDEX, LOCAL_CRATE};
 use rustc_hir::intravisit;
-use rustc_hir::lang_items::FnOnceTraitLangItem;
+use rustc_hir::lang_items::LangItem;
 use rustc_hir::{ExprKind, Node, QPath};
 use rustc_infer::infer::type_variable::{TypeVariableOrigin, TypeVariableOriginKind};
 use rustc_middle::hir::map as hir_map;
@@ -36,7 +36,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             ty::Closure(..) | ty::FnDef(..) | ty::FnPtr(_) => true,
             // If it's not a simple function, look for things which implement `FnOnce`.
             _ => {
-                let fn_once = match tcx.lang_items().require(FnOnceTraitLangItem) {
+                let fn_once = match tcx.lang_items().require(LangItem::FnOnce) {
                     Ok(fn_once) => fn_once,
                     Err(..) => return false,
                 };

--- a/src/librustc_typeck/check/wfcheck.rs
+++ b/src/librustc_typeck/check/wfcheck.rs
@@ -9,7 +9,7 @@ use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_hir::intravisit as hir_visit;
 use rustc_hir::intravisit::Visitor;
 use rustc_hir::itemlikevisit::ParItemLikeVisitor;
-use rustc_hir::lang_items;
+use rustc_hir::lang_items::LangItem;
 use rustc_hir::ItemKind;
 use rustc_middle::hir::map as hir_map;
 use rustc_middle::ty::subst::{GenericArgKind, InternalSubsts, Subst};
@@ -495,7 +495,7 @@ fn check_type_defn<'tcx, F>(
                 let last = idx == variant.fields.len() - 1;
                 fcx.register_bound(
                     field.ty,
-                    fcx.tcx.require_lang_item(lang_items::SizedTraitLangItem, None),
+                    fcx.tcx.require_lang_item(LangItem::Sized, None),
                     traits::ObligationCause::new(
                         field.span,
                         fcx.body_id,
@@ -718,7 +718,7 @@ fn check_item_type(tcx: TyCtxt<'_>, item_id: hir::HirId, ty_span: Span, allow_fo
         if forbid_unsized {
             fcx.register_bound(
                 item_ty,
-                fcx.tcx.require_lang_item(lang_items::SizedTraitLangItem, None),
+                fcx.tcx.require_lang_item(LangItem::Sized, None),
                 traits::ObligationCause::new(ty_span, fcx.body_id, traits::MiscObligation),
             );
         }
@@ -1223,7 +1223,7 @@ fn receiver_is_valid<'fcx, 'tcx>(
     // The first type is `receiver_ty`, which we know its not equal to `self_ty`; skip it.
     autoderef.next();
 
-    let receiver_trait_def_id = fcx.tcx.require_lang_item(lang_items::ReceiverTraitLangItem, None);
+    let receiver_trait_def_id = fcx.tcx.require_lang_item(LangItem::Receiver, None);
 
     // Keep dereferencing `receiver_ty` until we get to `self_ty`.
     loop {

--- a/src/librustc_typeck/coherence/builtin.rs
+++ b/src/librustc_typeck/coherence/builtin.rs
@@ -4,9 +4,7 @@
 use rustc_errors::struct_span_err;
 use rustc_hir as hir;
 use rustc_hir::def_id::{DefId, LocalDefId};
-use rustc_hir::lang_items::{
-    CoerceUnsizedTraitLangItem, DispatchFromDynTraitLangItem, UnsizeTraitLangItem,
-};
+use rustc_hir::lang_items::LangItem;
 use rustc_hir::ItemKind;
 use rustc_infer::infer;
 use rustc_infer::infer::outlives::env::OutlivesEnvironment;
@@ -149,7 +147,7 @@ fn visit_implementation_of_dispatch_from_dyn(tcx: TyCtxt<'_>, impl_did: LocalDef
     let impl_hir_id = tcx.hir().local_def_id_to_hir_id(impl_did);
     let span = tcx.hir().span(impl_hir_id);
 
-    let dispatch_from_dyn_trait = tcx.require_lang_item(DispatchFromDynTraitLangItem, Some(span));
+    let dispatch_from_dyn_trait = tcx.require_lang_item(LangItem::DispatchFromDyn, Some(span));
 
     let source = tcx.type_of(impl_did);
     assert!(!source.has_escaping_bound_vars());
@@ -318,9 +316,9 @@ pub fn coerce_unsized_info(tcx: TyCtxt<'tcx>, impl_did: DefId) -> CoerceUnsizedI
     let impl_hir_id = tcx.hir().local_def_id_to_hir_id(impl_did.expect_local());
     let span = tcx.hir().span(impl_hir_id);
 
-    let coerce_unsized_trait = tcx.require_lang_item(CoerceUnsizedTraitLangItem, Some(span));
+    let coerce_unsized_trait = tcx.require_lang_item(LangItem::CoerceUnsized, Some(span));
 
-    let unsize_trait = tcx.lang_items().require(UnsizeTraitLangItem).unwrap_or_else(|err| {
+    let unsize_trait = tcx.lang_items().require(LangItem::Unsize).unwrap_or_else(|err| {
         tcx.sess.fatal(&format!("`CoerceUnsized` implementation {}", err));
     });
 

--- a/src/librustdoc/clean/auto_trait.rs
+++ b/src/librustdoc/clean/auto_trait.rs
@@ -1,6 +1,6 @@
 use rustc_data_structures::fx::FxHashSet;
 use rustc_hir as hir;
-use rustc_hir::lang_items;
+use rustc_hir::lang_items::LangItem;
 use rustc_middle::ty::{self, Region, RegionVid, TypeFoldable};
 use rustc_trait_selection::traits::auto_trait::{self, AutoTraitResult};
 
@@ -454,7 +454,7 @@ impl<'a, 'tcx> AutoTraitFinder<'a, 'tcx> {
 
         // The `Sized` trait must be handled specially, since we only display it when
         // it is *not* required (i.e., '?Sized')
-        let sized_trait = self.cx.tcx.require_lang_item(lang_items::SizedTraitLangItem, None);
+        let sized_trait = self.cx.tcx.require_lang_item(LangItem::Sized, None);
 
         let mut replacer = RegionReplacer { vid_to_region: &vid_to_region, tcx };
 
@@ -742,9 +742,9 @@ impl<'a, 'tcx> AutoTraitFinder<'a, 'tcx> {
     fn is_fn_ty(&self, tcx: TyCtxt<'_>, ty: &Type) -> bool {
         match &ty {
             &&Type::ResolvedPath { ref did, .. } => {
-                *did == tcx.require_lang_item(lang_items::FnTraitLangItem, None)
-                    || *did == tcx.require_lang_item(lang_items::FnMutTraitLangItem, None)
-                    || *did == tcx.require_lang_item(lang_items::FnOnceTraitLangItem, None)
+                *did == tcx.require_lang_item(LangItem::Fn, None)
+                    || *did == tcx.require_lang_item(LangItem::FnMut, None)
+                    || *did == tcx.require_lang_item(LangItem::FnOnce, None)
             }
             _ => false,
         }

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -16,7 +16,7 @@ use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_hir as hir;
 use rustc_hir::def::Res;
 use rustc_hir::def_id::{CrateNum, DefId, LOCAL_CRATE};
-use rustc_hir::lang_items;
+use rustc_hir::lang_items::LangItem;
 use rustc_hir::Mutability;
 use rustc_index::vec::IndexVec;
 use rustc_middle::middle::stability;
@@ -710,7 +710,7 @@ pub enum GenericBound {
 
 impl GenericBound {
     pub fn maybe_sized(cx: &DocContext<'_>) -> GenericBound {
-        let did = cx.tcx.require_lang_item(lang_items::SizedTraitLangItem, None);
+        let did = cx.tcx.require_lang_item(LangItem::Sized, None);
         let empty = cx.tcx.intern_substs(&[]);
         let path = external_path(cx, cx.tcx.item_name(did), Some(did), false, vec![], empty);
         inline::record_extern_fqn(cx, did, TypeKind::Trait);


### PR DESCRIPTION
This PR adjusts the naming of various lang items so that they are consistent and don't include prefixes containing the target or "LangItem". In addition, lang item variants are no longer exported from the `lang_items` module.

This is certainly subjective and while I think this is an improvement, if many in the team don't then we can just close this.
