### PR TITLE
Suppress MIR comments of FnDef and unit types

### DIFF
--- a/src/librustc_middle/ty/sty.rs
+++ b/src/librustc_middle/ty/sty.rs
@@ -185,7 +185,7 @@ pub enum TyKind<'tcx> {
     /// After typeck, the concrete type can be found in the `types` map.
     Opaque(DefId, SubstsRef<'tcx>),
 
-    /// A type parameter; for example, `T` in `fn f<T>(x: T) {}
+    /// A type parameter; for example, `T` in `fn f<T>(x: T) {}`.
     Param(ParamTy),
 
     /// Bound type variable, used only when preparing a trait query.

--- a/src/librustc_mir/util/pretty.rs
+++ b/src/librustc_mir/util/pretty.rs
@@ -389,6 +389,8 @@ impl Visitor<'tcx> for ExtraComments<'tcx> {
         let Constant { span, user_ty, literal } = constant;
         match literal.ty.kind {
             ty::Int(_) | ty::Uint(_) | ty::Bool | ty::Char => {}
+            // Unit type
+            ty::Tuple(tys) if tys.is_empty() => {}
             _ => {
                 self.push("mir::Constant");
                 self.push(&format!("+ span: {}", self.tcx.sess.source_map().span_to_string(*span)));
@@ -405,6 +407,8 @@ impl Visitor<'tcx> for ExtraComments<'tcx> {
         let ty::Const { ty, val, .. } = constant;
         match ty.kind {
             ty::Int(_) | ty::Uint(_) | ty::Bool | ty::Char => {}
+            // Unit type
+            ty::Tuple(tys) if tys.is_empty() => {}
             ty::FnDef(..) => {}
             _ => {
                 self.push("ty::Const");

--- a/src/librustc_mir/util/pretty.rs
+++ b/src/librustc_mir/util/pretty.rs
@@ -405,6 +405,7 @@ impl Visitor<'tcx> for ExtraComments<'tcx> {
         let ty::Const { ty, val, .. } = constant;
         match ty.kind {
             ty::Int(_) | ty::Uint(_) | ty::Bool | ty::Char => {}
+            ty::FnDef(..) => {}
             _ => {
                 self.push("ty::Const");
                 self.push(&format!("+ ty: {:?}", ty));

--- a/src/test/mir-opt/address_of.address_of_reborrow.SimplifyCfg-initial.after.mir
+++ b/src/test/mir-opt/address_of.address_of_reborrow.SimplifyCfg-initial.after.mir
@@ -287,12 +287,6 @@ fn address_of_reborrow() -> () {
         FakeRead(ForLet, _47);           // scope 13 at $DIR/address-of.rs:36:9: 36:10
         AscribeUserType(_47, o, UserTypeProjection { base: UserType(29), projs: [] }); // scope 13 at $DIR/address-of.rs:36:12: 36:22
         _0 = const ();                   // scope 0 at $DIR/address-of.rs:3:26: 37:2
-                                         // ty::Const
-                                         // + ty: ()
-                                         // + val: Value(Scalar(<ZST>))
-                                         // mir::Constant
-                                         // + span: $DIR/address-of.rs:3:26: 37:2
-                                         // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
         StorageDead(_47);                // scope 13 at $DIR/address-of.rs:37:1: 37:2
         StorageDead(_45);                // scope 12 at $DIR/address-of.rs:37:1: 37:2
         StorageDead(_44);                // scope 11 at $DIR/address-of.rs:37:1: 37:2

--- a/src/test/mir-opt/address_of.borrow_and_cast.SimplifyCfg-initial.after.mir
+++ b/src/test/mir-opt/address_of.borrow_and_cast.SimplifyCfg-initial.after.mir
@@ -39,12 +39,6 @@ fn borrow_and_cast(_1: i32) -> () {
         FakeRead(ForLet, _6);            // scope 2 at $DIR/address-of.rs:44:9: 44:10
         StorageDead(_7);                 // scope 2 at $DIR/address-of.rs:44:31: 44:32
         _0 = const ();                   // scope 0 at $DIR/address-of.rs:41:32: 45:2
-                                         // ty::Const
-                                         // + ty: ()
-                                         // + val: Value(Scalar(<ZST>))
-                                         // mir::Constant
-                                         // + span: $DIR/address-of.rs:41:32: 45:2
-                                         // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
         StorageDead(_6);                 // scope 2 at $DIR/address-of.rs:45:1: 45:2
         StorageDead(_4);                 // scope 1 at $DIR/address-of.rs:45:1: 45:2
         StorageDead(_2);                 // scope 0 at $DIR/address-of.rs:45:1: 45:2

--- a/src/test/mir-opt/array_index_is_temporary.main.SimplifyCfg-elaborate-drops.after.mir.32bit
+++ b/src/test/mir-opt/array_index_is_temporary.main.SimplifyCfg-elaborate-drops.after.mir.32bit
@@ -56,12 +56,6 @@ fn main() -> () {
         StorageDead(_5);                 // scope 3 at $DIR/array-index-is-temporary.rs:16:28: 16:29
         StorageDead(_7);                 // scope 3 at $DIR/array-index-is-temporary.rs:16:29: 16:30
         _0 = const ();                   // scope 0 at $DIR/array-index-is-temporary.rs:12:11: 17:2
-                                         // ty::Const
-                                         // + ty: ()
-                                         // + val: Value(Scalar(<ZST>))
-                                         // mir::Constant
-                                         // + span: $DIR/array-index-is-temporary.rs:12:11: 17:2
-                                         // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
         StorageDead(_3);                 // scope 2 at $DIR/array-index-is-temporary.rs:17:1: 17:2
         StorageDead(_2);                 // scope 1 at $DIR/array-index-is-temporary.rs:17:1: 17:2
         StorageDead(_1);                 // scope 0 at $DIR/array-index-is-temporary.rs:17:1: 17:2

--- a/src/test/mir-opt/array_index_is_temporary.main.SimplifyCfg-elaborate-drops.after.mir.32bit
+++ b/src/test/mir-opt/array_index_is_temporary.main.SimplifyCfg-elaborate-drops.after.mir.32bit
@@ -37,9 +37,6 @@ fn main() -> () {
         StorageLive(_6);                 // scope 4 at $DIR/array-index-is-temporary.rs:16:25: 16:26
         _6 = _3;                         // scope 4 at $DIR/array-index-is-temporary.rs:16:25: 16:26
         _5 = const foo(move _6) -> bb1;  // scope 4 at $DIR/array-index-is-temporary.rs:16:21: 16:27
-                                         // ty::Const
-                                         // + ty: unsafe fn(*mut usize) -> u32 {foo}
-                                         // + val: Value(Scalar(<ZST>))
                                          // mir::Constant
                                          // + span: $DIR/array-index-is-temporary.rs:16:21: 16:24
                                          // + literal: Const { ty: unsafe fn(*mut usize) -> u32 {foo}, val: Value(Scalar(<ZST>)) }

--- a/src/test/mir-opt/array_index_is_temporary.main.SimplifyCfg-elaborate-drops.after.mir.64bit
+++ b/src/test/mir-opt/array_index_is_temporary.main.SimplifyCfg-elaborate-drops.after.mir.64bit
@@ -56,12 +56,6 @@ fn main() -> () {
         StorageDead(_5);                 // scope 3 at $DIR/array-index-is-temporary.rs:16:28: 16:29
         StorageDead(_7);                 // scope 3 at $DIR/array-index-is-temporary.rs:16:29: 16:30
         _0 = const ();                   // scope 0 at $DIR/array-index-is-temporary.rs:12:11: 17:2
-                                         // ty::Const
-                                         // + ty: ()
-                                         // + val: Value(Scalar(<ZST>))
-                                         // mir::Constant
-                                         // + span: $DIR/array-index-is-temporary.rs:12:11: 17:2
-                                         // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
         StorageDead(_3);                 // scope 2 at $DIR/array-index-is-temporary.rs:17:1: 17:2
         StorageDead(_2);                 // scope 1 at $DIR/array-index-is-temporary.rs:17:1: 17:2
         StorageDead(_1);                 // scope 0 at $DIR/array-index-is-temporary.rs:17:1: 17:2

--- a/src/test/mir-opt/array_index_is_temporary.main.SimplifyCfg-elaborate-drops.after.mir.64bit
+++ b/src/test/mir-opt/array_index_is_temporary.main.SimplifyCfg-elaborate-drops.after.mir.64bit
@@ -37,9 +37,6 @@ fn main() -> () {
         StorageLive(_6);                 // scope 4 at $DIR/array-index-is-temporary.rs:16:25: 16:26
         _6 = _3;                         // scope 4 at $DIR/array-index-is-temporary.rs:16:25: 16:26
         _5 = const foo(move _6) -> bb1;  // scope 4 at $DIR/array-index-is-temporary.rs:16:21: 16:27
-                                         // ty::Const
-                                         // + ty: unsafe fn(*mut usize) -> u32 {foo}
-                                         // + val: Value(Scalar(<ZST>))
                                          // mir::Constant
                                          // + span: $DIR/array-index-is-temporary.rs:16:21: 16:24
                                          // + literal: Const { ty: unsafe fn(*mut usize) -> u32 {foo}, val: Value(Scalar(<ZST>)) }

--- a/src/test/mir-opt/basic_assignment.main.SimplifyCfg-initial.after.mir
+++ b/src/test/mir-opt/basic_assignment.main.SimplifyCfg-initial.after.mir
@@ -67,12 +67,6 @@ fn main() -> () {
     bb6: {
         StorageDead(_6);                 // scope 4 at $DIR/basic_assignment.rs:23:19: 23:20
         _0 = const ();                   // scope 0 at $DIR/basic_assignment.rs:10:11: 24:2
-                                         // ty::Const
-                                         // + ty: ()
-                                         // + val: Value(Scalar(<ZST>))
-                                         // mir::Constant
-                                         // + span: $DIR/basic_assignment.rs:10:11: 24:2
-                                         // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
         drop(_5) -> [return: bb7, unwind: bb3]; // scope 3 at $DIR/basic_assignment.rs:24:1: 24:2
     }
 

--- a/src/test/mir-opt/box_expr.main.ElaborateDrops.before.mir
+++ b/src/test/mir-opt/box_expr.main.ElaborateDrops.before.mir
@@ -15,9 +15,6 @@ fn main() -> () {
         StorageLive(_2);                 // scope 0 at $DIR/box_expr.rs:7:13: 7:25
         _2 = Box(S);                     // scope 0 at $DIR/box_expr.rs:7:13: 7:25
         (*_2) = const S::new() -> [return: bb2, unwind: bb3]; // scope 0 at $DIR/box_expr.rs:7:17: 7:25
-                                         // ty::Const
-                                         // + ty: fn() -> S {S::new}
-                                         // + val: Value(Scalar(<ZST>))
                                          // mir::Constant
                                          // + span: $DIR/box_expr.rs:7:17: 7:23
                                          // + literal: Const { ty: fn() -> S {S::new}, val: Value(Scalar(<ZST>)) }
@@ -42,9 +39,6 @@ fn main() -> () {
         StorageLive(_4);                 // scope 1 at $DIR/box_expr.rs:8:10: 8:11
         _4 = move _1;                    // scope 1 at $DIR/box_expr.rs:8:10: 8:11
         _3 = const std::mem::drop::<std::boxed::Box<S>>(move _4) -> [return: bb5, unwind: bb7]; // scope 1 at $DIR/box_expr.rs:8:5: 8:12
-                                         // ty::Const
-                                         // + ty: fn(std::boxed::Box<S>) {std::mem::drop::<std::boxed::Box<S>>}
-                                         // + val: Value(Scalar(<ZST>))
                                          // mir::Constant
                                          // + span: $DIR/box_expr.rs:8:5: 8:9
                                          // + literal: Const { ty: fn(std::boxed::Box<S>) {std::mem::drop::<std::boxed::Box<S>>}, val: Value(Scalar(<ZST>)) }

--- a/src/test/mir-opt/box_expr.main.ElaborateDrops.before.mir
+++ b/src/test/mir-opt/box_expr.main.ElaborateDrops.before.mir
@@ -48,12 +48,6 @@ fn main() -> () {
         StorageDead(_4);                 // scope 1 at $DIR/box_expr.rs:8:11: 8:12
         StorageDead(_3);                 // scope 1 at $DIR/box_expr.rs:8:12: 8:13
         _0 = const ();                   // scope 0 at $DIR/box_expr.rs:6:11: 9:2
-                                         // ty::Const
-                                         // + ty: ()
-                                         // + val: Value(Scalar(<ZST>))
-                                         // mir::Constant
-                                         // + span: $DIR/box_expr.rs:6:11: 9:2
-                                         // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
         drop(_1) -> bb8;                 // scope 0 at $DIR/box_expr.rs:9:1: 9:2
     }
 

--- a/src/test/mir-opt/byte_slice.main.SimplifyCfg-elaborate-drops.after.mir
+++ b/src/test/mir-opt/byte_slice.main.SimplifyCfg-elaborate-drops.after.mir
@@ -23,12 +23,6 @@ fn main() -> () {
         StorageLive(_2);                 // scope 1 at $DIR/byte_slice.rs:6:9: 6:10
         _2 = [const 5_u8, const 120_u8]; // scope 1 at $DIR/byte_slice.rs:6:13: 6:24
         _0 = const ();                   // scope 0 at $DIR/byte_slice.rs:4:11: 7:2
-                                         // ty::Const
-                                         // + ty: ()
-                                         // + val: Value(Scalar(<ZST>))
-                                         // mir::Constant
-                                         // + span: $DIR/byte_slice.rs:4:11: 7:2
-                                         // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
         StorageDead(_2);                 // scope 1 at $DIR/byte_slice.rs:7:1: 7:2
         StorageDead(_1);                 // scope 0 at $DIR/byte_slice.rs:7:1: 7:2
         return;                          // scope 0 at $DIR/byte_slice.rs:7:2: 7:2

--- a/src/test/mir-opt/const_allocation.main.ConstProp.after.mir.32bit
+++ b/src/test/mir-opt/const_allocation.main.ConstProp.after.mir.32bit
@@ -19,12 +19,6 @@ fn main() -> () {
         StorageDead(_2);                 // scope 0 at $DIR/const_allocation.rs:8:8: 8:9
         StorageDead(_1);                 // scope 0 at $DIR/const_allocation.rs:8:8: 8:9
         _0 = const ();                   // scope 0 at $DIR/const_allocation.rs:7:11: 9:2
-                                         // ty::Const
-                                         // + ty: ()
-                                         // + val: Value(Scalar(<ZST>))
-                                         // mir::Constant
-                                         // + span: $DIR/const_allocation.rs:7:11: 9:2
-                                         // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
         return;                          // scope 0 at $DIR/const_allocation.rs:9:2: 9:2
     }
 }

--- a/src/test/mir-opt/const_allocation.main.ConstProp.after.mir.64bit
+++ b/src/test/mir-opt/const_allocation.main.ConstProp.after.mir.64bit
@@ -19,12 +19,6 @@ fn main() -> () {
         StorageDead(_2);                 // scope 0 at $DIR/const_allocation.rs:8:8: 8:9
         StorageDead(_1);                 // scope 0 at $DIR/const_allocation.rs:8:8: 8:9
         _0 = const ();                   // scope 0 at $DIR/const_allocation.rs:7:11: 9:2
-                                         // ty::Const
-                                         // + ty: ()
-                                         // + val: Value(Scalar(<ZST>))
-                                         // mir::Constant
-                                         // + span: $DIR/const_allocation.rs:7:11: 9:2
-                                         // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
         return;                          // scope 0 at $DIR/const_allocation.rs:9:2: 9:2
     }
 }

--- a/src/test/mir-opt/const_allocation2.main.ConstProp.after.mir.32bit
+++ b/src/test/mir-opt/const_allocation2.main.ConstProp.after.mir.32bit
@@ -19,12 +19,6 @@ fn main() -> () {
         StorageDead(_2);                 // scope 0 at $DIR/const_allocation2.rs:5:8: 5:9
         StorageDead(_1);                 // scope 0 at $DIR/const_allocation2.rs:5:8: 5:9
         _0 = const ();                   // scope 0 at $DIR/const_allocation2.rs:4:11: 6:2
-                                         // ty::Const
-                                         // + ty: ()
-                                         // + val: Value(Scalar(<ZST>))
-                                         // mir::Constant
-                                         // + span: $DIR/const_allocation2.rs:4:11: 6:2
-                                         // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
         return;                          // scope 0 at $DIR/const_allocation2.rs:6:2: 6:2
     }
 }

--- a/src/test/mir-opt/const_allocation2.main.ConstProp.after.mir.64bit
+++ b/src/test/mir-opt/const_allocation2.main.ConstProp.after.mir.64bit
@@ -19,12 +19,6 @@ fn main() -> () {
         StorageDead(_2);                 // scope 0 at $DIR/const_allocation2.rs:5:8: 5:9
         StorageDead(_1);                 // scope 0 at $DIR/const_allocation2.rs:5:8: 5:9
         _0 = const ();                   // scope 0 at $DIR/const_allocation2.rs:4:11: 6:2
-                                         // ty::Const
-                                         // + ty: ()
-                                         // + val: Value(Scalar(<ZST>))
-                                         // mir::Constant
-                                         // + span: $DIR/const_allocation2.rs:4:11: 6:2
-                                         // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
         return;                          // scope 0 at $DIR/const_allocation2.rs:6:2: 6:2
     }
 }

--- a/src/test/mir-opt/const_allocation3.main.ConstProp.after.mir.32bit
+++ b/src/test/mir-opt/const_allocation3.main.ConstProp.after.mir.32bit
@@ -19,12 +19,6 @@ fn main() -> () {
         StorageDead(_2);                 // scope 0 at $DIR/const_allocation3.rs:5:8: 5:9
         StorageDead(_1);                 // scope 0 at $DIR/const_allocation3.rs:5:8: 5:9
         _0 = const ();                   // scope 0 at $DIR/const_allocation3.rs:4:11: 6:2
-                                         // ty::Const
-                                         // + ty: ()
-                                         // + val: Value(Scalar(<ZST>))
-                                         // mir::Constant
-                                         // + span: $DIR/const_allocation3.rs:4:11: 6:2
-                                         // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
         return;                          // scope 0 at $DIR/const_allocation3.rs:6:2: 6:2
     }
 }

--- a/src/test/mir-opt/const_allocation3.main.ConstProp.after.mir.64bit
+++ b/src/test/mir-opt/const_allocation3.main.ConstProp.after.mir.64bit
@@ -19,12 +19,6 @@ fn main() -> () {
         StorageDead(_2);                 // scope 0 at $DIR/const_allocation3.rs:5:8: 5:9
         StorageDead(_1);                 // scope 0 at $DIR/const_allocation3.rs:5:8: 5:9
         _0 = const ();                   // scope 0 at $DIR/const_allocation3.rs:4:11: 6:2
-                                         // ty::Const
-                                         // + ty: ()
-                                         // + val: Value(Scalar(<ZST>))
-                                         // mir::Constant
-                                         // + span: $DIR/const_allocation3.rs:4:11: 6:2
-                                         // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
         return;                          // scope 0 at $DIR/const_allocation3.rs:6:2: 6:2
     }
 }

--- a/src/test/mir-opt/const_promotion_extern_static.BAR.PromoteTemps.diff
+++ b/src/test/mir-opt/const_promotion_extern_static.BAR.PromoteTemps.diff
@@ -34,9 +34,6 @@
 +         _2 = &(*_6);                     // scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:35
           _1 = move _2 as &[&i32] (Pointer(Unsize)); // scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:35
           _0 = const core::slice::<impl [&i32]>::as_ptr(move _1) -> [return: bb2, unwind: bb1]; // scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:44
-                                           // ty::Const
-                                           // + ty: for<'r> fn(&'r [&i32]) -> *const &i32 {core::slice::<impl [&i32]>::as_ptr}
-                                           // + val: Value(Scalar(<ZST>))
                                            // mir::Constant
                                            // + span: $DIR/const-promotion-extern-static.rs:9:36: 9:42
                                            // + literal: Const { ty: for<'r> fn(&'r [&i32]) -> *const &i32 {core::slice::<impl [&i32]>::as_ptr}, val: Value(Scalar(<ZST>)) }

--- a/src/test/mir-opt/const_promotion_extern_static.FOO.PromoteTemps.diff
+++ b/src/test/mir-opt/const_promotion_extern_static.FOO.PromoteTemps.diff
@@ -36,9 +36,6 @@
 +         _2 = &(*_6);                     // scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:46
           _1 = move _2 as &[&i32] (Pointer(Unsize)); // scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:46
           _0 = const core::slice::<impl [&i32]>::as_ptr(move _1) -> [return: bb2, unwind: bb1]; // scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:55
-                                           // ty::Const
-                                           // + ty: for<'r> fn(&'r [&i32]) -> *const &i32 {core::slice::<impl [&i32]>::as_ptr}
-                                           // + val: Value(Scalar(<ZST>))
                                            // mir::Constant
                                            // + span: $DIR/const-promotion-extern-static.rs:13:47: 13:53
                                            // + literal: Const { ty: for<'r> fn(&'r [&i32]) -> *const &i32 {core::slice::<impl [&i32]>::as_ptr}, val: Value(Scalar(<ZST>)) }

--- a/src/test/mir-opt/const_prop/aggregate.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/aggregate.main.ConstProp.diff
@@ -24,12 +24,6 @@
           StorageDead(_2);                 // scope 0 at $DIR/aggregate.rs:5:27: 5:28
           StorageDead(_3);                 // scope 0 at $DIR/aggregate.rs:5:28: 5:29
           _0 = const ();                   // scope 0 at $DIR/aggregate.rs:4:11: 6:2
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/aggregate.rs:4:11: 6:2
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           StorageDead(_1);                 // scope 0 at $DIR/aggregate.rs:6:1: 6:2
           return;                          // scope 0 at $DIR/aggregate.rs:6:2: 6:2
       }

--- a/src/test/mir-opt/const_prop/array_index.main.ConstProp.diff.32bit
+++ b/src/test/mir-opt/const_prop/array_index.main.ConstProp.diff.32bit
@@ -31,12 +31,6 @@
           StorageDead(_3);                 // scope 0 at $DIR/array_index.rs:5:33: 5:34
           StorageDead(_2);                 // scope 0 at $DIR/array_index.rs:5:33: 5:34
           _0 = const ();                   // scope 0 at $DIR/array_index.rs:4:11: 6:2
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/array_index.rs:4:11: 6:2
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           StorageDead(_1);                 // scope 0 at $DIR/array_index.rs:6:1: 6:2
           return;                          // scope 0 at $DIR/array_index.rs:6:2: 6:2
       }

--- a/src/test/mir-opt/const_prop/array_index.main.ConstProp.diff.64bit
+++ b/src/test/mir-opt/const_prop/array_index.main.ConstProp.diff.64bit
@@ -31,12 +31,6 @@
           StorageDead(_3);                 // scope 0 at $DIR/array_index.rs:5:33: 5:34
           StorageDead(_2);                 // scope 0 at $DIR/array_index.rs:5:33: 5:34
           _0 = const ();                   // scope 0 at $DIR/array_index.rs:4:11: 6:2
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/array_index.rs:4:11: 6:2
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           StorageDead(_1);                 // scope 0 at $DIR/array_index.rs:6:1: 6:2
           return;                          // scope 0 at $DIR/array_index.rs:6:2: 6:2
       }

--- a/src/test/mir-opt/const_prop/bad_op_div_by_zero.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/bad_op_div_by_zero.main.ConstProp.diff
@@ -46,12 +46,6 @@
 +         _2 = Div(const 1_i32, const 0_i32); // scope 1 at $DIR/bad_op_div_by_zero.rs:5:14: 5:19
           StorageDead(_3);                 // scope 1 at $DIR/bad_op_div_by_zero.rs:5:18: 5:19
           _0 = const ();                   // scope 0 at $DIR/bad_op_div_by_zero.rs:3:11: 6:2
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/bad_op_div_by_zero.rs:3:11: 6:2
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           StorageDead(_2);                 // scope 1 at $DIR/bad_op_div_by_zero.rs:6:1: 6:2
           StorageDead(_1);                 // scope 0 at $DIR/bad_op_div_by_zero.rs:6:1: 6:2
           return;                          // scope 0 at $DIR/bad_op_div_by_zero.rs:6:2: 6:2

--- a/src/test/mir-opt/const_prop/bad_op_mod_by_zero.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/bad_op_mod_by_zero.main.ConstProp.diff
@@ -46,12 +46,6 @@
 +         _2 = Rem(const 1_i32, const 0_i32); // scope 1 at $DIR/bad_op_mod_by_zero.rs:5:14: 5:19
           StorageDead(_3);                 // scope 1 at $DIR/bad_op_mod_by_zero.rs:5:18: 5:19
           _0 = const ();                   // scope 0 at $DIR/bad_op_mod_by_zero.rs:3:11: 6:2
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/bad_op_mod_by_zero.rs:3:11: 6:2
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           StorageDead(_2);                 // scope 1 at $DIR/bad_op_mod_by_zero.rs:6:1: 6:2
           StorageDead(_1);                 // scope 0 at $DIR/bad_op_mod_by_zero.rs:6:1: 6:2
           return;                          // scope 0 at $DIR/bad_op_mod_by_zero.rs:6:2: 6:2

--- a/src/test/mir-opt/const_prop/bad_op_unsafe_oob_for_slices.main.ConstProp.diff.32bit
+++ b/src/test/mir-opt/const_prop/bad_op_unsafe_oob_for_slices.main.ConstProp.diff.32bit
@@ -51,12 +51,6 @@
           _5 = (*_1)[_6];                  // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:7:18: 7:25
           StorageDead(_6);                 // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:7:25: 7:26
           _0 = const ();                   // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:6:5: 8:6
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/bad_op_unsafe_oob_for_slices.rs:6:5: 8:6
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           StorageDead(_5);                 // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:8:5: 8:6
           StorageDead(_1);                 // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:9:1: 9:2
           return;                          // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:9:2: 9:2

--- a/src/test/mir-opt/const_prop/bad_op_unsafe_oob_for_slices.main.ConstProp.diff.64bit
+++ b/src/test/mir-opt/const_prop/bad_op_unsafe_oob_for_slices.main.ConstProp.diff.64bit
@@ -51,12 +51,6 @@
           _5 = (*_1)[_6];                  // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:7:18: 7:25
           StorageDead(_6);                 // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:7:25: 7:26
           _0 = const ();                   // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:6:5: 8:6
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/bad_op_unsafe_oob_for_slices.rs:6:5: 8:6
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           StorageDead(_5);                 // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:8:5: 8:6
           StorageDead(_1);                 // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:9:1: 9:2
           return;                          // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:9:2: 9:2

--- a/src/test/mir-opt/const_prop/boxes.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/boxes.main.ConstProp.diff
@@ -33,12 +33,6 @@
       bb2: {
           StorageDead(_3);                 // scope 0 at $DIR/boxes.rs:12:26: 12:27
           _0 = const ();                   // scope 0 at $DIR/boxes.rs:11:11: 13:2
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/boxes.rs:11:11: 13:2
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           StorageDead(_1);                 // scope 0 at $DIR/boxes.rs:13:1: 13:2
           return;                          // scope 0 at $DIR/boxes.rs:13:2: 13:2
       }

--- a/src/test/mir-opt/const_prop/cast.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/cast.main.ConstProp.diff
@@ -20,12 +20,6 @@
 -         _2 = const 42_u32 as u8 (Misc);  // scope 1 at $DIR/cast.rs:6:13: 6:24
 +         _2 = const 42_u8;                // scope 1 at $DIR/cast.rs:6:13: 6:24
           _0 = const ();                   // scope 0 at $DIR/cast.rs:3:11: 7:2
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/cast.rs:3:11: 7:2
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           StorageDead(_2);                 // scope 1 at $DIR/cast.rs:7:1: 7:2
           StorageDead(_1);                 // scope 0 at $DIR/cast.rs:7:1: 7:2
           return;                          // scope 0 at $DIR/cast.rs:7:2: 7:2

--- a/src/test/mir-opt/const_prop/checked_add.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/checked_add.main.ConstProp.diff
@@ -21,12 +21,6 @@
 -         _1 = move (_2.0: u32);           // scope 0 at $DIR/checked_add.rs:5:18: 5:23
 +         _1 = const 2_u32;                // scope 0 at $DIR/checked_add.rs:5:18: 5:23
           _0 = const ();                   // scope 0 at $DIR/checked_add.rs:4:11: 6:2
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/checked_add.rs:4:11: 6:2
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           StorageDead(_1);                 // scope 0 at $DIR/checked_add.rs:6:1: 6:2
           return;                          // scope 0 at $DIR/checked_add.rs:6:2: 6:2
       }

--- a/src/test/mir-opt/const_prop/const_prop_fails_gracefully.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/const_prop_fails_gracefully.main.ConstProp.diff
@@ -31,9 +31,6 @@
           StorageLive(_5);                 // scope 1 at $DIR/const_prop_fails_gracefully.rs:8:10: 8:11
           _5 = _1;                         // scope 1 at $DIR/const_prop_fails_gracefully.rs:8:10: 8:11
           _4 = const read(move _5) -> bb1; // scope 1 at $DIR/const_prop_fails_gracefully.rs:8:5: 8:12
-                                           // ty::Const
-                                           // + ty: fn(usize) {read}
-                                           // + val: Value(Scalar(<ZST>))
                                            // mir::Constant
                                            // + span: $DIR/const_prop_fails_gracefully.rs:8:5: 8:9
                                            // + literal: Const { ty: fn(usize) {read}, val: Value(Scalar(<ZST>)) }

--- a/src/test/mir-opt/const_prop/const_prop_fails_gracefully.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/const_prop_fails_gracefully.main.ConstProp.diff
@@ -40,12 +40,6 @@
           StorageDead(_5);                 // scope 1 at $DIR/const_prop_fails_gracefully.rs:8:11: 8:12
           StorageDead(_4);                 // scope 1 at $DIR/const_prop_fails_gracefully.rs:8:12: 8:13
           _0 = const ();                   // scope 0 at $DIR/const_prop_fails_gracefully.rs:5:11: 9:2
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/const_prop_fails_gracefully.rs:5:11: 9:2
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           StorageDead(_1);                 // scope 0 at $DIR/const_prop_fails_gracefully.rs:9:1: 9:2
           return;                          // scope 0 at $DIR/const_prop_fails_gracefully.rs:9:2: 9:2
       }

--- a/src/test/mir-opt/const_prop/control_flow_simplification.hello.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/control_flow_simplification.hello.ConstProp.diff
@@ -16,12 +16,6 @@
   
       bb1: {
           _0 = const ();                   // scope 0 at $DIR/control-flow-simplification.rs:12:5: 14:6
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/control-flow-simplification.rs:12:5: 14:6
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           StorageDead(_1);                 // scope 0 at $DIR/control-flow-simplification.rs:15:1: 15:2
           return;                          // scope 0 at $DIR/control-flow-simplification.rs:15:2: 15:2
       }

--- a/src/test/mir-opt/const_prop/control_flow_simplification.hello.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/control_flow_simplification.hello.ConstProp.diff
@@ -29,9 +29,6 @@
       bb2: {
           StorageLive(_2);                 // scope 0 at $SRC_DIR/std/src/macros.rs:LL:COL
           const std::rt::begin_panic::<&str>(const "explicit panic"); // scope 0 at $SRC_DIR/std/src/macros.rs:LL:COL
-                                           // ty::Const
-                                           // + ty: fn(&str) -> ! {std::rt::begin_panic::<&str>}
-                                           // + val: Value(Scalar(<ZST>))
                                            // mir::Constant
                                            // + span: $SRC_DIR/std/src/macros.rs:LL:COL
                                            // + literal: Const { ty: fn(&str) -> ! {std::rt::begin_panic::<&str>}, val: Value(Scalar(<ZST>)) }

--- a/src/test/mir-opt/const_prop/control_flow_simplification.hello.PreCodegen.before.mir
+++ b/src/test/mir-opt/const_prop/control_flow_simplification.hello.PreCodegen.before.mir
@@ -5,12 +5,6 @@ fn hello() -> () {
 
     bb0: {
         _0 = const ();                   // scope 0 at $DIR/control-flow-simplification.rs:12:5: 14:6
-                                         // ty::Const
-                                         // + ty: ()
-                                         // + val: Value(Scalar(<ZST>))
-                                         // mir::Constant
-                                         // + span: $DIR/control-flow-simplification.rs:12:5: 14:6
-                                         // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
         return;                          // scope 0 at $DIR/control-flow-simplification.rs:15:2: 15:2
     }
 }

--- a/src/test/mir-opt/const_prop/discriminant.main.ConstProp.diff.32bit
+++ b/src/test/mir-opt/const_prop/discriminant.main.ConstProp.diff.32bit
@@ -42,12 +42,6 @@
           StorageDead(_2);                 // scope 0 at $DIR/discriminant.rs:11:67: 11:68
           StorageDead(_3);                 // scope 0 at $DIR/discriminant.rs:11:68: 11:69
           _0 = const ();                   // scope 0 at $DIR/discriminant.rs:10:11: 12:2
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/discriminant.rs:10:11: 12:2
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           StorageDead(_1);                 // scope 0 at $DIR/discriminant.rs:12:1: 12:2
           return;                          // scope 0 at $DIR/discriminant.rs:12:2: 12:2
       }

--- a/src/test/mir-opt/const_prop/discriminant.main.ConstProp.diff.64bit
+++ b/src/test/mir-opt/const_prop/discriminant.main.ConstProp.diff.64bit
@@ -42,12 +42,6 @@
           StorageDead(_2);                 // scope 0 at $DIR/discriminant.rs:11:67: 11:68
           StorageDead(_3);                 // scope 0 at $DIR/discriminant.rs:11:68: 11:69
           _0 = const ();                   // scope 0 at $DIR/discriminant.rs:10:11: 12:2
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/discriminant.rs:10:11: 12:2
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           StorageDead(_1);                 // scope 0 at $DIR/discriminant.rs:12:1: 12:2
           return;                          // scope 0 at $DIR/discriminant.rs:12:2: 12:2
       }

--- a/src/test/mir-opt/const_prop/indirect.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/indirect.main.ConstProp.diff
@@ -26,12 +26,6 @@
 +         _1 = const 3_u8;                 // scope 0 at $DIR/indirect.rs:5:13: 5:29
           StorageDead(_2);                 // scope 0 at $DIR/indirect.rs:5:28: 5:29
           _0 = const ();                   // scope 0 at $DIR/indirect.rs:4:11: 6:2
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/indirect.rs:4:11: 6:2
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           StorageDead(_1);                 // scope 0 at $DIR/indirect.rs:6:1: 6:2
           return;                          // scope 0 at $DIR/indirect.rs:6:2: 6:2
       }

--- a/src/test/mir-opt/const_prop/issue_66971.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/issue_66971.main.ConstProp.diff
@@ -23,9 +23,6 @@
           (_2.2: u8) = const 0_u8;         // scope 0 at $DIR/issue-66971.rs:16:12: 16:22
           StorageDead(_3);                 // scope 0 at $DIR/issue-66971.rs:16:21: 16:22
           _1 = const encode(move _2) -> bb1; // scope 0 at $DIR/issue-66971.rs:16:5: 16:23
-                                           // ty::Const
-                                           // + ty: fn(((), u8, u8)) {encode}
-                                           // + val: Value(Scalar(<ZST>))
                                            // mir::Constant
                                            // + span: $DIR/issue-66971.rs:16:5: 16:11
                                            // + literal: Const { ty: fn(((), u8, u8)) {encode}, val: Value(Scalar(<ZST>)) }

--- a/src/test/mir-opt/const_prop/issue_66971.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/issue_66971.main.ConstProp.diff
@@ -13,12 +13,6 @@
           StorageLive(_3);                 // scope 0 at $DIR/issue-66971.rs:16:13: 16:15
 -         (_2.0: ()) = move _3;            // scope 0 at $DIR/issue-66971.rs:16:12: 16:22
 +         (_2.0: ()) = const ();           // scope 0 at $DIR/issue-66971.rs:16:12: 16:22
-+                                          // ty::Const
-+                                          // + ty: ()
-+                                          // + val: Value(Scalar(<ZST>))
-+                                          // mir::Constant
-+                                          // + span: $DIR/issue-66971.rs:16:12: 16:22
-+                                          // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           (_2.1: u8) = const 0_u8;         // scope 0 at $DIR/issue-66971.rs:16:12: 16:22
           (_2.2: u8) = const 0_u8;         // scope 0 at $DIR/issue-66971.rs:16:12: 16:22
           StorageDead(_3);                 // scope 0 at $DIR/issue-66971.rs:16:21: 16:22
@@ -32,12 +26,6 @@
           StorageDead(_2);                 // scope 0 at $DIR/issue-66971.rs:16:22: 16:23
           StorageDead(_1);                 // scope 0 at $DIR/issue-66971.rs:16:23: 16:24
           _0 = const ();                   // scope 0 at $DIR/issue-66971.rs:15:11: 17:2
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/issue-66971.rs:15:11: 17:2
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           return;                          // scope 0 at $DIR/issue-66971.rs:17:2: 17:2
       }
   }

--- a/src/test/mir-opt/const_prop/issue_67019.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/issue_67019.main.ConstProp.diff
@@ -26,12 +26,6 @@
           StorageDead(_2);                 // scope 0 at $DIR/issue-67019.rs:11:19: 11:20
           StorageDead(_1);                 // scope 0 at $DIR/issue-67019.rs:11:20: 11:21
           _0 = const ();                   // scope 0 at $DIR/issue-67019.rs:10:11: 12:2
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/issue-67019.rs:10:11: 12:2
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           return;                          // scope 0 at $DIR/issue-67019.rs:12:2: 12:2
       }
   }

--- a/src/test/mir-opt/const_prop/issue_67019.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/issue_67019.main.ConstProp.diff
@@ -17,9 +17,6 @@
 +         (_2.0: (u8, u8)) = (const 1_u8, const 2_u8); // scope 0 at $DIR/issue-67019.rs:11:10: 11:19
           StorageDead(_3);                 // scope 0 at $DIR/issue-67019.rs:11:18: 11:19
           _1 = const test(move _2) -> bb1; // scope 0 at $DIR/issue-67019.rs:11:5: 11:20
-                                           // ty::Const
-                                           // + ty: fn(((u8, u8),)) {test}
-                                           // + val: Value(Scalar(<ZST>))
                                            // mir::Constant
                                            // + span: $DIR/issue-67019.rs:11:5: 11:9
                                            // + literal: Const { ty: fn(((u8, u8),)) {test}, val: Value(Scalar(<ZST>)) }

--- a/src/test/mir-opt/const_prop/large_array_index.main.ConstProp.diff.32bit
+++ b/src/test/mir-opt/const_prop/large_array_index.main.ConstProp.diff.32bit
@@ -30,12 +30,6 @@
           StorageDead(_3);                 // scope 0 at $DIR/large_array_index.rs:6:32: 6:33
           StorageDead(_2);                 // scope 0 at $DIR/large_array_index.rs:6:32: 6:33
           _0 = const ();                   // scope 0 at $DIR/large_array_index.rs:4:11: 7:2
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/large_array_index.rs:4:11: 7:2
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           StorageDead(_1);                 // scope 0 at $DIR/large_array_index.rs:7:1: 7:2
           return;                          // scope 0 at $DIR/large_array_index.rs:7:2: 7:2
       }

--- a/src/test/mir-opt/const_prop/large_array_index.main.ConstProp.diff.64bit
+++ b/src/test/mir-opt/const_prop/large_array_index.main.ConstProp.diff.64bit
@@ -30,12 +30,6 @@
           StorageDead(_3);                 // scope 0 at $DIR/large_array_index.rs:6:32: 6:33
           StorageDead(_2);                 // scope 0 at $DIR/large_array_index.rs:6:32: 6:33
           _0 = const ();                   // scope 0 at $DIR/large_array_index.rs:4:11: 7:2
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/large_array_index.rs:4:11: 7:2
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           StorageDead(_1);                 // scope 0 at $DIR/large_array_index.rs:7:1: 7:2
           return;                          // scope 0 at $DIR/large_array_index.rs:7:2: 7:2
       }

--- a/src/test/mir-opt/const_prop/mutable_variable.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/mutable_variable.main.ConstProp.diff
@@ -20,12 +20,6 @@
 -         _2 = _1;                         // scope 1 at $DIR/mutable_variable.rs:7:13: 7:14
 +         _2 = const 99_i32;               // scope 1 at $DIR/mutable_variable.rs:7:13: 7:14
           _0 = const ();                   // scope 0 at $DIR/mutable_variable.rs:4:11: 8:2
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/mutable_variable.rs:4:11: 8:2
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           StorageDead(_2);                 // scope 1 at $DIR/mutable_variable.rs:8:1: 8:2
           StorageDead(_1);                 // scope 0 at $DIR/mutable_variable.rs:8:1: 8:2
           return;                          // scope 0 at $DIR/mutable_variable.rs:8:2: 8:2

--- a/src/test/mir-opt/const_prop/mutable_variable_aggregate.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/mutable_variable_aggregate.main.ConstProp.diff
@@ -21,12 +21,6 @@
 -         _2 = _1;                         // scope 1 at $DIR/mutable_variable_aggregate.rs:7:13: 7:14
 +         _2 = (const 42_i32, const 99_i32); // scope 1 at $DIR/mutable_variable_aggregate.rs:7:13: 7:14
           _0 = const ();                   // scope 0 at $DIR/mutable_variable_aggregate.rs:4:11: 8:2
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/mutable_variable_aggregate.rs:4:11: 8:2
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           StorageDead(_2);                 // scope 1 at $DIR/mutable_variable_aggregate.rs:8:1: 8:2
           StorageDead(_1);                 // scope 0 at $DIR/mutable_variable_aggregate.rs:8:1: 8:2
           return;                          // scope 0 at $DIR/mutable_variable_aggregate.rs:8:2: 8:2

--- a/src/test/mir-opt/const_prop/mutable_variable_aggregate_mut_ref.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/mutable_variable_aggregate_mut_ref.main.ConstProp.diff
@@ -26,12 +26,6 @@
           StorageLive(_3);                 // scope 2 at $DIR/mutable_variable_aggregate_mut_ref.rs:8:9: 8:10
           _3 = _1;                         // scope 2 at $DIR/mutable_variable_aggregate_mut_ref.rs:8:13: 8:14
           _0 = const ();                   // scope 0 at $DIR/mutable_variable_aggregate_mut_ref.rs:4:11: 9:2
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/mutable_variable_aggregate_mut_ref.rs:4:11: 9:2
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           StorageDead(_3);                 // scope 2 at $DIR/mutable_variable_aggregate_mut_ref.rs:9:1: 9:2
           StorageDead(_2);                 // scope 1 at $DIR/mutable_variable_aggregate_mut_ref.rs:9:1: 9:2
           StorageDead(_1);                 // scope 0 at $DIR/mutable_variable_aggregate_mut_ref.rs:9:1: 9:2

--- a/src/test/mir-opt/const_prop/mutable_variable_aggregate_partial_read.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/mutable_variable_aggregate_partial_read.main.ConstProp.diff
@@ -27,12 +27,6 @@
 -         _2 = (_1.1: i32);                // scope 1 at $DIR/mutable_variable_aggregate_partial_read.rs:8:13: 8:16
 +         _2 = const 99_i32;               // scope 1 at $DIR/mutable_variable_aggregate_partial_read.rs:8:13: 8:16
           _0 = const ();                   // scope 0 at $DIR/mutable_variable_aggregate_partial_read.rs:4:11: 9:2
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/mutable_variable_aggregate_partial_read.rs:4:11: 9:2
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           StorageDead(_2);                 // scope 1 at $DIR/mutable_variable_aggregate_partial_read.rs:9:1: 9:2
           StorageDead(_1);                 // scope 0 at $DIR/mutable_variable_aggregate_partial_read.rs:9:1: 9:2
           return;                          // scope 0 at $DIR/mutable_variable_aggregate_partial_read.rs:9:2: 9:2

--- a/src/test/mir-opt/const_prop/mutable_variable_aggregate_partial_read.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/mutable_variable_aggregate_partial_read.main.ConstProp.diff
@@ -15,9 +15,6 @@
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/mutable_variable_aggregate_partial_read.rs:5:9: 5:14
           _1 = const foo() -> bb1;         // scope 0 at $DIR/mutable_variable_aggregate_partial_read.rs:5:29: 5:34
-                                           // ty::Const
-                                           // + ty: fn() -> (i32, i32) {foo}
-                                           // + val: Value(Scalar(<ZST>))
                                            // mir::Constant
                                            // + span: $DIR/mutable_variable_aggregate_partial_read.rs:5:29: 5:32
                                            // + literal: Const { ty: fn() -> (i32, i32) {foo}, val: Value(Scalar(<ZST>)) }

--- a/src/test/mir-opt/const_prop/mutable_variable_no_prop.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/mutable_variable_no_prop.main.ConstProp.diff
@@ -35,22 +35,10 @@
           StorageDead(_3);                 // scope 2 at $DIR/mutable_variable_no_prop.rs:9:18: 9:19
           StorageDead(_4);                 // scope 2 at $DIR/mutable_variable_no_prop.rs:9:19: 9:20
           _2 = const ();                   // scope 2 at $DIR/mutable_variable_no_prop.rs:8:5: 10:6
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/mutable_variable_no_prop.rs:8:5: 10:6
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           StorageDead(_2);                 // scope 1 at $DIR/mutable_variable_no_prop.rs:10:5: 10:6
           StorageLive(_5);                 // scope 1 at $DIR/mutable_variable_no_prop.rs:11:9: 11:10
           _5 = _1;                         // scope 1 at $DIR/mutable_variable_no_prop.rs:11:13: 11:14
           _0 = const ();                   // scope 0 at $DIR/mutable_variable_no_prop.rs:6:11: 12:2
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/mutable_variable_no_prop.rs:6:11: 12:2
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           StorageDead(_5);                 // scope 1 at $DIR/mutable_variable_no_prop.rs:12:1: 12:2
           StorageDead(_1);                 // scope 0 at $DIR/mutable_variable_no_prop.rs:12:1: 12:2
           return;                          // scope 0 at $DIR/mutable_variable_no_prop.rs:12:2: 12:2

--- a/src/test/mir-opt/const_prop/mutable_variable_unprop_assign.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/mutable_variable_unprop_assign.main.ConstProp.diff
@@ -42,12 +42,6 @@
           StorageLive(_5);                 // scope 3 at $DIR/mutable_variable_unprop_assign.rs:9:9: 9:10
           _5 = (_2.0: i32);                // scope 3 at $DIR/mutable_variable_unprop_assign.rs:9:13: 9:16
           _0 = const ();                   // scope 0 at $DIR/mutable_variable_unprop_assign.rs:4:11: 10:2
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/mutable_variable_unprop_assign.rs:4:11: 10:2
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           StorageDead(_5);                 // scope 3 at $DIR/mutable_variable_unprop_assign.rs:10:1: 10:2
           StorageDead(_4);                 // scope 2 at $DIR/mutable_variable_unprop_assign.rs:10:1: 10:2
           StorageDead(_2);                 // scope 1 at $DIR/mutable_variable_unprop_assign.rs:10:1: 10:2

--- a/src/test/mir-opt/const_prop/mutable_variable_unprop_assign.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/mutable_variable_unprop_assign.main.ConstProp.diff
@@ -24,9 +24,6 @@
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/mutable_variable_unprop_assign.rs:5:9: 5:10
           _1 = const foo() -> bb1;         // scope 0 at $DIR/mutable_variable_unprop_assign.rs:5:13: 5:18
-                                           // ty::Const
-                                           // + ty: fn() -> i32 {foo}
-                                           // + val: Value(Scalar(<ZST>))
                                            // mir::Constant
                                            // + span: $DIR/mutable_variable_unprop_assign.rs:5:13: 5:16
                                            // + literal: Const { ty: fn() -> i32 {foo}, val: Value(Scalar(<ZST>)) }

--- a/src/test/mir-opt/const_prop/optimizes_into_variable.main.ConstProp.diff.32bit
+++ b/src/test/mir-opt/const_prop/optimizes_into_variable.main.ConstProp.diff.32bit
@@ -58,12 +58,6 @@
 +         _8 = const 42_u32;               // scope 2 at $DIR/optimizes_into_variable.rs:14:13: 14:38
           StorageDead(_9);                 // scope 2 at $DIR/optimizes_into_variable.rs:14:38: 14:39
           _0 = const ();                   // scope 0 at $DIR/optimizes_into_variable.rs:11:11: 15:2
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/optimizes_into_variable.rs:11:11: 15:2
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           StorageDead(_8);                 // scope 2 at $DIR/optimizes_into_variable.rs:15:1: 15:2
           StorageDead(_3);                 // scope 1 at $DIR/optimizes_into_variable.rs:15:1: 15:2
           StorageDead(_1);                 // scope 0 at $DIR/optimizes_into_variable.rs:15:1: 15:2

--- a/src/test/mir-opt/const_prop/optimizes_into_variable.main.ConstProp.diff.64bit
+++ b/src/test/mir-opt/const_prop/optimizes_into_variable.main.ConstProp.diff.64bit
@@ -58,12 +58,6 @@
 +         _8 = const 42_u32;               // scope 2 at $DIR/optimizes_into_variable.rs:14:13: 14:38
           StorageDead(_9);                 // scope 2 at $DIR/optimizes_into_variable.rs:14:38: 14:39
           _0 = const ();                   // scope 0 at $DIR/optimizes_into_variable.rs:11:11: 15:2
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/optimizes_into_variable.rs:11:11: 15:2
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           StorageDead(_8);                 // scope 2 at $DIR/optimizes_into_variable.rs:15:1: 15:2
           StorageDead(_3);                 // scope 1 at $DIR/optimizes_into_variable.rs:15:1: 15:2
           StorageDead(_1);                 // scope 0 at $DIR/optimizes_into_variable.rs:15:1: 15:2

--- a/src/test/mir-opt/const_prop/optimizes_into_variable.main.SimplifyLocals.after.mir.32bit
+++ b/src/test/mir-opt/const_prop/optimizes_into_variable.main.SimplifyLocals.after.mir.32bit
@@ -23,12 +23,6 @@ fn main() -> () {
         StorageLive(_3);                 // scope 2 at $DIR/optimizes_into_variable.rs:14:9: 14:10
         _3 = const 42_u32;               // scope 2 at $DIR/optimizes_into_variable.rs:14:13: 14:38
         _0 = const ();                   // scope 0 at $DIR/optimizes_into_variable.rs:11:11: 15:2
-                                         // ty::Const
-                                         // + ty: ()
-                                         // + val: Value(Scalar(<ZST>))
-                                         // mir::Constant
-                                         // + span: $DIR/optimizes_into_variable.rs:11:11: 15:2
-                                         // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
         StorageDead(_3);                 // scope 2 at $DIR/optimizes_into_variable.rs:15:1: 15:2
         StorageDead(_2);                 // scope 1 at $DIR/optimizes_into_variable.rs:15:1: 15:2
         StorageDead(_1);                 // scope 0 at $DIR/optimizes_into_variable.rs:15:1: 15:2

--- a/src/test/mir-opt/const_prop/optimizes_into_variable.main.SimplifyLocals.after.mir.64bit
+++ b/src/test/mir-opt/const_prop/optimizes_into_variable.main.SimplifyLocals.after.mir.64bit
@@ -23,12 +23,6 @@ fn main() -> () {
         StorageLive(_3);                 // scope 2 at $DIR/optimizes_into_variable.rs:14:9: 14:10
         _3 = const 42_u32;               // scope 2 at $DIR/optimizes_into_variable.rs:14:13: 14:38
         _0 = const ();                   // scope 0 at $DIR/optimizes_into_variable.rs:11:11: 15:2
-                                         // ty::Const
-                                         // + ty: ()
-                                         // + val: Value(Scalar(<ZST>))
-                                         // mir::Constant
-                                         // + span: $DIR/optimizes_into_variable.rs:11:11: 15:2
-                                         // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
         StorageDead(_3);                 // scope 2 at $DIR/optimizes_into_variable.rs:15:1: 15:2
         StorageDead(_2);                 // scope 1 at $DIR/optimizes_into_variable.rs:15:1: 15:2
         StorageDead(_1);                 // scope 0 at $DIR/optimizes_into_variable.rs:15:1: 15:2

--- a/src/test/mir-opt/const_prop/read_immutable_static.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/read_immutable_static.main.ConstProp.diff
@@ -43,12 +43,6 @@
           StorageDead(_5);                 // scope 0 at $DIR/read_immutable_static.rs:7:22: 7:23
           StorageDead(_3);                 // scope 0 at $DIR/read_immutable_static.rs:7:22: 7:23
           _0 = const ();                   // scope 0 at $DIR/read_immutable_static.rs:6:11: 8:2
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/read_immutable_static.rs:6:11: 8:2
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           StorageDead(_1);                 // scope 0 at $DIR/read_immutable_static.rs:8:1: 8:2
           return;                          // scope 0 at $DIR/read_immutable_static.rs:8:2: 8:2
       }

--- a/src/test/mir-opt/const_prop/ref_deref.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/ref_deref.main.ConstProp.diff
@@ -24,12 +24,6 @@
           StorageDead(_2);                 // scope 0 at $DIR/ref_deref.rs:5:10: 5:11
           StorageDead(_1);                 // scope 0 at $DIR/ref_deref.rs:5:10: 5:11
           _0 = const ();                   // scope 0 at $DIR/ref_deref.rs:4:11: 6:2
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/ref_deref.rs:4:11: 6:2
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           return;                          // scope 0 at $DIR/ref_deref.rs:6:2: 6:2
       }
   }

--- a/src/test/mir-opt/const_prop/ref_deref.main.PromoteTemps.diff
+++ b/src/test/mir-opt/const_prop/ref_deref.main.PromoteTemps.diff
@@ -27,12 +27,6 @@
           StorageDead(_2);                 // scope 0 at $DIR/ref_deref.rs:5:10: 5:11
           StorageDead(_1);                 // scope 0 at $DIR/ref_deref.rs:5:10: 5:11
           _0 = const ();                   // scope 0 at $DIR/ref_deref.rs:4:11: 6:2
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/ref_deref.rs:4:11: 6:2
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           return;                          // scope 0 at $DIR/ref_deref.rs:6:2: 6:2
       }
   }

--- a/src/test/mir-opt/const_prop/ref_deref_project.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/ref_deref_project.main.ConstProp.diff
@@ -23,12 +23,6 @@
           StorageDead(_2);                 // scope 0 at $DIR/ref_deref_project.rs:5:17: 5:18
           StorageDead(_1);                 // scope 0 at $DIR/ref_deref_project.rs:5:17: 5:18
           _0 = const ();                   // scope 0 at $DIR/ref_deref_project.rs:4:11: 6:2
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/ref_deref_project.rs:4:11: 6:2
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           return;                          // scope 0 at $DIR/ref_deref_project.rs:6:2: 6:2
       }
   }

--- a/src/test/mir-opt/const_prop/ref_deref_project.main.PromoteTemps.diff
+++ b/src/test/mir-opt/const_prop/ref_deref_project.main.PromoteTemps.diff
@@ -27,12 +27,6 @@
           StorageDead(_2);                 // scope 0 at $DIR/ref_deref_project.rs:5:17: 5:18
           StorageDead(_1);                 // scope 0 at $DIR/ref_deref_project.rs:5:17: 5:18
           _0 = const ();                   // scope 0 at $DIR/ref_deref_project.rs:4:11: 6:2
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/ref_deref_project.rs:4:11: 6:2
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           return;                          // scope 0 at $DIR/ref_deref_project.rs:6:2: 6:2
       }
   }

--- a/src/test/mir-opt/const_prop/reify_fn_ptr.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/reify_fn_ptr.main.ConstProp.diff
@@ -23,12 +23,6 @@
           StorageDead(_2);                 // scope 0 at $DIR/reify_fn_ptr.rs:4:40: 4:41
           StorageDead(_1);                 // scope 0 at $DIR/reify_fn_ptr.rs:4:41: 4:42
           _0 = const ();                   // scope 0 at $DIR/reify_fn_ptr.rs:3:11: 5:2
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/reify_fn_ptr.rs:3:11: 5:2
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           return;                          // scope 0 at $DIR/reify_fn_ptr.rs:5:2: 5:2
       }
   }

--- a/src/test/mir-opt/const_prop/reify_fn_ptr.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/reify_fn_ptr.main.ConstProp.diff
@@ -14,9 +14,6 @@
           StorageLive(_2);                 // scope 0 at $DIR/reify_fn_ptr.rs:4:13: 4:26
           StorageLive(_3);                 // scope 0 at $DIR/reify_fn_ptr.rs:4:13: 4:17
           _3 = const main as fn() (Pointer(ReifyFnPointer)); // scope 0 at $DIR/reify_fn_ptr.rs:4:13: 4:17
-                                           // ty::Const
-                                           // + ty: fn() {main}
-                                           // + val: Value(Scalar(<ZST>))
                                            // mir::Constant
                                            // + span: $DIR/reify_fn_ptr.rs:4:13: 4:17
                                            // + literal: Const { ty: fn() {main}, val: Value(Scalar(<ZST>)) }

--- a/src/test/mir-opt/const_prop/repeat.main.ConstProp.diff.32bit
+++ b/src/test/mir-opt/const_prop/repeat.main.ConstProp.diff.32bit
@@ -36,12 +36,6 @@
           StorageDead(_4);                 // scope 0 at $DIR/repeat.rs:6:32: 6:33
           StorageDead(_3);                 // scope 0 at $DIR/repeat.rs:6:32: 6:33
           _0 = const ();                   // scope 0 at $DIR/repeat.rs:5:11: 7:2
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/repeat.rs:5:11: 7:2
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           StorageDead(_1);                 // scope 0 at $DIR/repeat.rs:7:1: 7:2
           return;                          // scope 0 at $DIR/repeat.rs:7:2: 7:2
       }

--- a/src/test/mir-opt/const_prop/repeat.main.ConstProp.diff.64bit
+++ b/src/test/mir-opt/const_prop/repeat.main.ConstProp.diff.64bit
@@ -36,12 +36,6 @@
           StorageDead(_4);                 // scope 0 at $DIR/repeat.rs:6:32: 6:33
           StorageDead(_3);                 // scope 0 at $DIR/repeat.rs:6:32: 6:33
           _0 = const ();                   // scope 0 at $DIR/repeat.rs:5:11: 7:2
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/repeat.rs:5:11: 7:2
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           StorageDead(_1);                 // scope 0 at $DIR/repeat.rs:7:1: 7:2
           return;                          // scope 0 at $DIR/repeat.rs:7:2: 7:2
       }

--- a/src/test/mir-opt/const_prop/scalar_literal_propagation.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/scalar_literal_propagation.main.ConstProp.diff
@@ -28,12 +28,6 @@
           StorageDead(_3);                 // scope 1 at $DIR/scalar_literal_propagation.rs:4:14: 4:15
           StorageDead(_2);                 // scope 1 at $DIR/scalar_literal_propagation.rs:4:15: 4:16
           _0 = const ();                   // scope 0 at $DIR/scalar_literal_propagation.rs:2:11: 5:2
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/scalar_literal_propagation.rs:2:11: 5:2
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           StorageDead(_1);                 // scope 0 at $DIR/scalar_literal_propagation.rs:5:1: 5:2
           return;                          // scope 0 at $DIR/scalar_literal_propagation.rs:5:2: 5:2
       }

--- a/src/test/mir-opt/const_prop/scalar_literal_propagation.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/scalar_literal_propagation.main.ConstProp.diff
@@ -19,9 +19,6 @@
 -         _2 = const consume(move _3) -> bb1; // scope 1 at $DIR/scalar_literal_propagation.rs:4:5: 4:15
 +         _3 = const 1_u32;                // scope 1 at $DIR/scalar_literal_propagation.rs:4:13: 4:14
 +         _2 = const consume(const 1_u32) -> bb1; // scope 1 at $DIR/scalar_literal_propagation.rs:4:5: 4:15
-                                           // ty::Const
-                                           // + ty: fn(u32) {consume}
-                                           // + val: Value(Scalar(<ZST>))
                                            // mir::Constant
                                            // + span: $DIR/scalar_literal_propagation.rs:4:5: 4:12
                                            // + literal: Const { ty: fn(u32) {consume}, val: Value(Scalar(<ZST>)) }

--- a/src/test/mir-opt/const_prop/slice_len.main.ConstProp.diff.32bit
+++ b/src/test/mir-opt/const_prop/slice_len.main.ConstProp.diff.32bit
@@ -47,12 +47,6 @@
           StorageDead(_2);                 // scope 0 at $DIR/slice_len.rs:5:33: 5:34
           StorageDead(_1);                 // scope 0 at $DIR/slice_len.rs:5:33: 5:34
           _0 = const ();                   // scope 0 at $DIR/slice_len.rs:4:11: 6:2
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/slice_len.rs:4:11: 6:2
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           return;                          // scope 0 at $DIR/slice_len.rs:6:2: 6:2
       }
   }

--- a/src/test/mir-opt/const_prop/slice_len.main.ConstProp.diff.64bit
+++ b/src/test/mir-opt/const_prop/slice_len.main.ConstProp.diff.64bit
@@ -47,12 +47,6 @@
           StorageDead(_2);                 // scope 0 at $DIR/slice_len.rs:5:33: 5:34
           StorageDead(_1);                 // scope 0 at $DIR/slice_len.rs:5:33: 5:34
           _0 = const ();                   // scope 0 at $DIR/slice_len.rs:4:11: 6:2
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/slice_len.rs:4:11: 6:2
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           return;                          // scope 0 at $DIR/slice_len.rs:6:2: 6:2
       }
   }

--- a/src/test/mir-opt/const_prop/switch_int.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/switch_int.main.ConstProp.diff
@@ -14,9 +14,6 @@
   
       bb1: {
           _0 = const foo(const -1_i32) -> bb3; // scope 0 at $DIR/switch_int.rs:9:14: 9:21
-                                           // ty::Const
-                                           // + ty: fn(i32) {foo}
-                                           // + val: Value(Scalar(<ZST>))
                                            // mir::Constant
                                            // + span: $DIR/switch_int.rs:9:14: 9:17
                                            // + literal: Const { ty: fn(i32) {foo}, val: Value(Scalar(<ZST>)) }
@@ -24,9 +21,6 @@
   
       bb2: {
           _0 = const foo(const 0_i32) -> bb3; // scope 0 at $DIR/switch_int.rs:8:14: 8:20
-                                           // ty::Const
-                                           // + ty: fn(i32) {foo}
-                                           // + val: Value(Scalar(<ZST>))
                                            // mir::Constant
                                            // + span: $DIR/switch_int.rs:8:14: 8:17
                                            // + literal: Const { ty: fn(i32) {foo}, val: Value(Scalar(<ZST>)) }

--- a/src/test/mir-opt/const_prop/switch_int.main.SimplifyBranches-after-const-prop.diff
+++ b/src/test/mir-opt/const_prop/switch_int.main.SimplifyBranches-after-const-prop.diff
@@ -14,9 +14,6 @@
   
       bb1: {
           _0 = const foo(const -1_i32) -> bb3; // scope 0 at $DIR/switch_int.rs:9:14: 9:21
-                                           // ty::Const
-                                           // + ty: fn(i32) {foo}
-                                           // + val: Value(Scalar(<ZST>))
                                            // mir::Constant
                                            // + span: $DIR/switch_int.rs:9:14: 9:17
                                            // + literal: Const { ty: fn(i32) {foo}, val: Value(Scalar(<ZST>)) }
@@ -24,9 +21,6 @@
   
       bb2: {
           _0 = const foo(const 0_i32) -> bb3; // scope 0 at $DIR/switch_int.rs:8:14: 8:20
-                                           // ty::Const
-                                           // + ty: fn(i32) {foo}
-                                           // + val: Value(Scalar(<ZST>))
                                            // mir::Constant
                                            // + span: $DIR/switch_int.rs:8:14: 8:17
                                            // + literal: Const { ty: fn(i32) {foo}, val: Value(Scalar(<ZST>)) }

--- a/src/test/mir-opt/const_prop/tuple_literal_propagation.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/tuple_literal_propagation.main.ConstProp.diff
@@ -19,9 +19,6 @@
 -         _3 = _1;                         // scope 1 at $DIR/tuple_literal_propagation.rs:5:13: 5:14
 +         _3 = (const 1_u32, const 2_u32); // scope 1 at $DIR/tuple_literal_propagation.rs:5:13: 5:14
           _2 = const consume(move _3) -> bb1; // scope 1 at $DIR/tuple_literal_propagation.rs:5:5: 5:15
-                                           // ty::Const
-                                           // + ty: fn((u32, u32)) {consume}
-                                           // + val: Value(Scalar(<ZST>))
                                            // mir::Constant
                                            // + span: $DIR/tuple_literal_propagation.rs:5:5: 5:12
                                            // + literal: Const { ty: fn((u32, u32)) {consume}, val: Value(Scalar(<ZST>)) }

--- a/src/test/mir-opt/const_prop/tuple_literal_propagation.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/tuple_literal_propagation.main.ConstProp.diff
@@ -28,12 +28,6 @@
           StorageDead(_3);                 // scope 1 at $DIR/tuple_literal_propagation.rs:5:14: 5:15
           StorageDead(_2);                 // scope 1 at $DIR/tuple_literal_propagation.rs:5:15: 5:16
           _0 = const ();                   // scope 0 at $DIR/tuple_literal_propagation.rs:2:11: 6:2
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/tuple_literal_propagation.rs:2:11: 6:2
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           StorageDead(_1);                 // scope 0 at $DIR/tuple_literal_propagation.rs:6:1: 6:2
           return;                          // scope 0 at $DIR/tuple_literal_propagation.rs:6:2: 6:2
       }

--- a/src/test/mir-opt/const_prop_miscompile.bar.ConstProp.diff
+++ b/src/test/mir-opt/const_prop_miscompile.bar.ConstProp.diff
@@ -26,12 +26,6 @@
           (*_3) = const 5_i32;             // scope 2 at $DIR/const_prop_miscompile.rs:14:9: 14:26
           StorageDead(_3);                 // scope 2 at $DIR/const_prop_miscompile.rs:14:26: 14:27
           _2 = const ();                   // scope 2 at $DIR/const_prop_miscompile.rs:13:5: 15:6
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/const_prop_miscompile.rs:13:5: 15:6
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           StorageDead(_2);                 // scope 1 at $DIR/const_prop_miscompile.rs:15:5: 15:6
           StorageLive(_4);                 // scope 1 at $DIR/const_prop_miscompile.rs:16:9: 16:10
           StorageLive(_5);                 // scope 1 at $DIR/const_prop_miscompile.rs:16:13: 16:20
@@ -39,12 +33,6 @@
           _4 = Eq(move _5, const 5_i32);   // scope 1 at $DIR/const_prop_miscompile.rs:16:13: 16:25
           StorageDead(_5);                 // scope 1 at $DIR/const_prop_miscompile.rs:16:24: 16:25
           _0 = const ();                   // scope 0 at $DIR/const_prop_miscompile.rs:11:10: 17:2
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/const_prop_miscompile.rs:11:10: 17:2
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           StorageDead(_4);                 // scope 1 at $DIR/const_prop_miscompile.rs:17:1: 17:2
           StorageDead(_1);                 // scope 0 at $DIR/const_prop_miscompile.rs:17:1: 17:2
           return;                          // scope 0 at $DIR/const_prop_miscompile.rs:17:2: 17:2

--- a/src/test/mir-opt/const_prop_miscompile.foo.ConstProp.diff
+++ b/src/test/mir-opt/const_prop_miscompile.foo.ConstProp.diff
@@ -27,12 +27,6 @@
           _3 = Eq(move _4, const 5_i32);   // scope 1 at $DIR/const_prop_miscompile.rs:7:13: 7:25
           StorageDead(_4);                 // scope 1 at $DIR/const_prop_miscompile.rs:7:24: 7:25
           _0 = const ();                   // scope 0 at $DIR/const_prop_miscompile.rs:4:10: 8:2
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/const_prop_miscompile.rs:4:10: 8:2
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           StorageDead(_3);                 // scope 1 at $DIR/const_prop_miscompile.rs:8:1: 8:2
           StorageDead(_1);                 // scope 0 at $DIR/const_prop_miscompile.rs:8:1: 8:2
           return;                          // scope 0 at $DIR/const_prop_miscompile.rs:8:2: 8:2

--- a/src/test/mir-opt/copy_propagation_arg.bar.CopyPropagation.diff
+++ b/src/test/mir-opt/copy_propagation_arg.bar.CopyPropagation.diff
@@ -12,9 +12,6 @@
           StorageLive(_3);                 // scope 0 at $DIR/copy_propagation_arg.rs:16:11: 16:12
           _3 = _1;                         // scope 0 at $DIR/copy_propagation_arg.rs:16:11: 16:12
           _2 = const dummy(move _3) -> bb1; // scope 0 at $DIR/copy_propagation_arg.rs:16:5: 16:13
-                                           // ty::Const
-                                           // + ty: fn(u8) -> u8 {dummy}
-                                           // + val: Value(Scalar(<ZST>))
                                            // mir::Constant
                                            // + span: $DIR/copy_propagation_arg.rs:16:5: 16:10
                                            // + literal: Const { ty: fn(u8) -> u8 {dummy}, val: Value(Scalar(<ZST>)) }

--- a/src/test/mir-opt/copy_propagation_arg.bar.CopyPropagation.diff
+++ b/src/test/mir-opt/copy_propagation_arg.bar.CopyPropagation.diff
@@ -22,12 +22,6 @@
           StorageDead(_2);                 // scope 0 at $DIR/copy_propagation_arg.rs:16:13: 16:14
           _1 = const 5_u8;                 // scope 0 at $DIR/copy_propagation_arg.rs:17:5: 17:10
           _0 = const ();                   // scope 0 at $DIR/copy_propagation_arg.rs:15:19: 18:2
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/copy_propagation_arg.rs:15:19: 18:2
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           return;                          // scope 0 at $DIR/copy_propagation_arg.rs:18:2: 18:2
       }
   }

--- a/src/test/mir-opt/copy_propagation_arg.baz.CopyPropagation.diff
+++ b/src/test/mir-opt/copy_propagation_arg.baz.CopyPropagation.diff
@@ -12,12 +12,6 @@
           _1 = move _2;                    // scope 0 at $DIR/copy_propagation_arg.rs:23:5: 23:10
           StorageDead(_2);                 // scope 0 at $DIR/copy_propagation_arg.rs:23:9: 23:10
           _0 = const ();                   // scope 0 at $DIR/copy_propagation_arg.rs:21:20: 24:2
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/copy_propagation_arg.rs:21:20: 24:2
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           return;                          // scope 0 at $DIR/copy_propagation_arg.rs:24:2: 24:2
       }
   }

--- a/src/test/mir-opt/copy_propagation_arg.foo.CopyPropagation.diff
+++ b/src/test/mir-opt/copy_propagation_arg.foo.CopyPropagation.diff
@@ -22,12 +22,6 @@
           _1 = move _2;                    // scope 0 at $DIR/copy_propagation_arg.rs:11:5: 11:17
           StorageDead(_2);                 // scope 0 at $DIR/copy_propagation_arg.rs:11:16: 11:17
           _0 = const ();                   // scope 0 at $DIR/copy_propagation_arg.rs:9:19: 12:2
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/copy_propagation_arg.rs:9:19: 12:2
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           return;                          // scope 0 at $DIR/copy_propagation_arg.rs:12:2: 12:2
       }
   }

--- a/src/test/mir-opt/copy_propagation_arg.foo.CopyPropagation.diff
+++ b/src/test/mir-opt/copy_propagation_arg.foo.CopyPropagation.diff
@@ -12,9 +12,6 @@
           StorageLive(_3);                 // scope 0 at $DIR/copy_propagation_arg.rs:11:15: 11:16
           _3 = _1;                         // scope 0 at $DIR/copy_propagation_arg.rs:11:15: 11:16
           _2 = const dummy(move _3) -> bb1; // scope 0 at $DIR/copy_propagation_arg.rs:11:9: 11:17
-                                           // ty::Const
-                                           // + ty: fn(u8) -> u8 {dummy}
-                                           // + val: Value(Scalar(<ZST>))
                                            // mir::Constant
                                            // + span: $DIR/copy_propagation_arg.rs:11:9: 11:14
                                            // + literal: Const { ty: fn(u8) -> u8 {dummy}, val: Value(Scalar(<ZST>)) }

--- a/src/test/mir-opt/funky_arms.float_to_exponential_common.ConstProp.diff
+++ b/src/test/mir-opt/funky_arms.float_to_exponential_common.ConstProp.diff
@@ -39,9 +39,6 @@
           StorageLive(_5);                 // scope 0 at $DIR/funky_arms.rs:15:22: 15:25
           _5 = &(*_1);                     // scope 0 at $DIR/funky_arms.rs:15:22: 15:25
           _4 = const std::fmt::Formatter::sign_plus(move _5) -> bb1; // scope 0 at $DIR/funky_arms.rs:15:22: 15:37
-                                           // ty::Const
-                                           // + ty: for<'r> fn(&'r std::fmt::Formatter) -> bool {std::fmt::Formatter::sign_plus}
-                                           // + val: Value(Scalar(<ZST>))
                                            // mir::Constant
                                            // + span: $DIR/funky_arms.rs:15:26: 15:35
                                            // + literal: Const { ty: for<'r> fn(&'r std::fmt::Formatter) -> bool {std::fmt::Formatter::sign_plus}, val: Value(Scalar(<ZST>)) }
@@ -68,9 +65,6 @@
           StorageLive(_8);                 // scope 2 at $DIR/funky_arms.rs:24:30: 24:33
           _8 = &(*_1);                     // scope 2 at $DIR/funky_arms.rs:24:30: 24:33
           _7 = const std::fmt::Formatter::precision(move _8) -> bb5; // scope 2 at $DIR/funky_arms.rs:24:30: 24:45
-                                           // ty::Const
-                                           // + ty: for<'r> fn(&'r std::fmt::Formatter) -> std::option::Option<usize> {std::fmt::Formatter::precision}
-                                           // + val: Value(Scalar(<ZST>))
                                            // mir::Constant
                                            // + span: $DIR/funky_arms.rs:24:34: 24:43
                                            // + literal: Const { ty: for<'r> fn(&'r std::fmt::Formatter) -> std::option::Option<usize> {std::fmt::Formatter::precision}, val: Value(Scalar(<ZST>)) }
@@ -92,9 +86,6 @@
           StorageLive(_21);                // scope 2 at $DIR/funky_arms.rs:28:62: 28:67
           _21 = _3;                        // scope 2 at $DIR/funky_arms.rs:28:62: 28:67
           _0 = const float_to_exponential_common_shortest::<T>(move _18, move _19, move _20, move _21) -> bb9; // scope 2 at $DIR/funky_arms.rs:28:9: 28:68
-                                           // ty::Const
-                                           // + ty: for<'r, 's, 't0> fn(&'r mut std::fmt::Formatter<'s>, &'t0 T, core::num::flt2dec::Sign, bool) -> std::result::Result<(), std::fmt::Error> {float_to_exponential_common_shortest::<T>}
-                                           // + val: Value(Scalar(<ZST>))
                                            // mir::Constant
                                            // + span: $DIR/funky_arms.rs:28:9: 28:45
                                            // + literal: Const { ty: for<'r, 's, 't0> fn(&'r mut std::fmt::Formatter<'s>, &'t0 T, core::num::flt2dec::Sign, bool) -> std::result::Result<(), std::fmt::Error> {float_to_exponential_common_shortest::<T>}, val: Value(Scalar(<ZST>)) }
@@ -120,9 +111,6 @@
           StorageLive(_17);                // scope 3 at $DIR/funky_arms.rs:26:81: 26:86
           _17 = _3;                        // scope 3 at $DIR/funky_arms.rs:26:81: 26:86
           _0 = const float_to_exponential_common_exact::<T>(move _11, move _12, move _13, move _14, move _17) -> bb8; // scope 3 at $DIR/funky_arms.rs:26:9: 26:87
-                                           // ty::Const
-                                           // + ty: for<'r, 's, 't0> fn(&'r mut std::fmt::Formatter<'s>, &'t0 T, core::num::flt2dec::Sign, u32, bool) -> std::result::Result<(), std::fmt::Error> {float_to_exponential_common_exact::<T>}
-                                           // + val: Value(Scalar(<ZST>))
                                            // mir::Constant
                                            // + span: $DIR/funky_arms.rs:26:9: 26:42
                                            // + literal: Const { ty: for<'r, 's, 't0> fn(&'r mut std::fmt::Formatter<'s>, &'t0 T, core::num::flt2dec::Sign, u32, bool) -> std::result::Result<(), std::fmt::Error> {float_to_exponential_common_exact::<T>}, val: Value(Scalar(<ZST>)) }

--- a/src/test/mir-opt/generator_storage_dead_unwind.main-{{closure}}.StateTransform.before.mir
+++ b/src/test/mir-opt/generator_storage_dead_unwind.main-{{closure}}.StateTransform.before.mir
@@ -94,12 +94,6 @@ yields ()
         StorageDead(_10);                // scope 2 at $DIR/generator-storage-dead-unwind.rs:27:15: 27:16
         StorageDead(_9);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:27:16: 27:17
         _0 = const ();                   // scope 0 at $DIR/generator-storage-dead-unwind.rs:22:19: 28:6
-                                         // ty::Const
-                                         // + ty: ()
-                                         // + val: Value(Scalar(<ZST>))
-                                         // mir::Constant
-                                         // + span: $DIR/generator-storage-dead-unwind.rs:22:19: 28:6
-                                         // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
         StorageDead(_4);                 // scope 1 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
         StorageDead(_3);                 // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
         drop(_1) -> [return: bb12, unwind: bb1]; // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6

--- a/src/test/mir-opt/generator_storage_dead_unwind.main-{{closure}}.StateTransform.before.mir
+++ b/src/test/mir-opt/generator_storage_dead_unwind.main-{{closure}}.StateTransform.before.mir
@@ -40,9 +40,6 @@ yields ()
         StorageLive(_8);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:26:14: 26:15
         _8 = move _3;                    // scope 2 at $DIR/generator-storage-dead-unwind.rs:26:14: 26:15
         _7 = const take::<Foo>(move _8) -> [return: bb7, unwind: bb9]; // scope 2 at $DIR/generator-storage-dead-unwind.rs:26:9: 26:16
-                                         // ty::Const
-                                         // + ty: fn(Foo) {take::<Foo>}
-                                         // + val: Value(Scalar(<ZST>))
                                          // mir::Constant
                                          // + span: $DIR/generator-storage-dead-unwind.rs:26:9: 26:13
                                          // + literal: Const { ty: fn(Foo) {take::<Foo>}, val: Value(Scalar(<ZST>)) }
@@ -76,9 +73,6 @@ yields ()
         StorageLive(_10);                // scope 2 at $DIR/generator-storage-dead-unwind.rs:27:14: 27:15
         _10 = move _4;                   // scope 2 at $DIR/generator-storage-dead-unwind.rs:27:14: 27:15
         _9 = const take::<Bar>(move _10) -> [return: bb10, unwind: bb11]; // scope 2 at $DIR/generator-storage-dead-unwind.rs:27:9: 27:16
-                                         // ty::Const
-                                         // + ty: fn(Bar) {take::<Bar>}
-                                         // + val: Value(Scalar(<ZST>))
                                          // mir::Constant
                                          // + span: $DIR/generator-storage-dead-unwind.rs:27:9: 27:13
                                          // + literal: Const { ty: fn(Bar) {take::<Bar>}, val: Value(Scalar(<ZST>)) }

--- a/src/test/mir-opt/generator_tiny.main-{{closure}}.generator_resume.0.mir
+++ b/src/test/mir-opt/generator_tiny.main-{{closure}}.generator_resume.0.mir
@@ -59,12 +59,6 @@ fn main::{{closure}}#0(_1: std::pin::Pin<&mut [generator@$DIR/generator-tiny.rs:
     bb4: {
         StorageDead(_8);                 // scope 1 at $DIR/generator-tiny.rs:23:21: 23:22
         _5 = const ();                   // scope 1 at $DIR/generator-tiny.rs:21:14: 24:10
-                                         // ty::Const
-                                         // + ty: ()
-                                         // + val: Value(Scalar(<ZST>))
-                                         // mir::Constant
-                                         // + span: $DIR/generator-tiny.rs:21:14: 24:10
-                                         // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
         goto -> bb2;                     // scope 1 at $DIR/generator-tiny.rs:21:9: 24:10
     }
 

--- a/src/test/mir-opt/generator_tiny.main-{{closure}}.generator_resume.0.mir
+++ b/src/test/mir-opt/generator_tiny.main-{{closure}}.generator_resume.0.mir
@@ -51,9 +51,6 @@ fn main::{{closure}}#0(_1: std::pin::Pin<&mut [generator@$DIR/generator-tiny.rs:
         StorageDead(_6);                 // scope 1 at $DIR/generator-tiny.rs:22:18: 22:19
         StorageLive(_8);                 // scope 1 at $DIR/generator-tiny.rs:23:13: 23:21
         _8 = const callee() -> bb4;      // scope 1 at $DIR/generator-tiny.rs:23:13: 23:21
-                                         // ty::Const
-                                         // + ty: fn() {callee}
-                                         // + val: Value(Scalar(<ZST>))
                                          // mir::Constant
                                          // + span: $DIR/generator-tiny.rs:23:13: 23:19
                                          // + literal: Const { ty: fn() {callee}, val: Value(Scalar(<ZST>)) }

--- a/src/test/mir-opt/inline/inline_any_operand.bar.Inline.after.mir
+++ b/src/test/mir-opt/inline/inline_any_operand.bar.Inline.after.mir
@@ -17,9 +17,6 @@ fn bar() -> bool {
     bb0: {
         StorageLive(_1);                 // scope 0 at $DIR/inline-any-operand.rs:11:9: 11:10
         _1 = const foo;                  // scope 0 at $DIR/inline-any-operand.rs:11:13: 11:16
-                                         // ty::Const
-                                         // + ty: fn(i32, i32) -> bool {foo}
-                                         // + val: Value(Scalar(<ZST>))
                                          // mir::Constant
                                          // + span: $DIR/inline-any-operand.rs:11:13: 11:16
                                          // + literal: Const { ty: fn(i32, i32) -> bool {foo}, val: Value(Scalar(<ZST>)) }

--- a/src/test/mir-opt/inline/inline_into_box_place.main.Inline.diff.32bit
+++ b/src/test/mir-opt/inline/inline_into_box_place.main.Inline.diff.32bit
@@ -27,45 +27,37 @@
 -                                          // + span: $DIR/inline-into-box-place.rs:8:33: 8:41
 -                                          // + user_ty: UserType(1)
 -                                          // + literal: Const { ty: fn() -> std::vec::Vec<u32> {std::vec::Vec::<u32>::new}, val: Value(Scalar(<ZST>)) }
--     }
-- 
--     bb1 (cleanup): {
--         resume;                          // scope 0 at $DIR/inline-into-box-place.rs:7:1: 9:2
--     }
-- 
--     bb2: {
 +                                          // + span: $SRC_DIR/alloc/src/vec.rs:LL:COL
 +                                          // + user_ty: UserType(0)
 +                                          // + literal: Const { ty: alloc::raw_vec::RawVec<u32>, val: Value(ByRef { alloc: Allocation { bytes: [4, 0, 0, 0, 0, 0, 0, 0], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [255], len: Size { raw: 8 } }, size: Size { raw: 8 }, align: Align { pow2: 2 }, mutability: Not, extra: () }, offset: Size { raw: 0 } }) }
 +         ((*_4).1: usize) = const 0_usize; // scope 2 at $SRC_DIR/alloc/src/vec.rs:LL:COL
-          _1 = move _2;                    // scope 0 at $DIR/inline-into-box-place.rs:8:29: 8:43
-          StorageDead(_2);                 // scope 0 at $DIR/inline-into-box-place.rs:8:42: 8:43
-          _0 = const ();                   // scope 0 at $DIR/inline-into-box-place.rs:7:11: 9:2
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/inline-into-box-place.rs:7:11: 9:2
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
--         drop(_1) -> [return: bb3, unwind: bb1]; // scope 0 at $DIR/inline-into-box-place.rs:9:1: 9:2
++         _1 = move _2;                    // scope 0 at $DIR/inline-into-box-place.rs:8:29: 8:43
++         StorageDead(_2);                 // scope 0 at $DIR/inline-into-box-place.rs:8:42: 8:43
++         _0 = const ();                   // scope 0 at $DIR/inline-into-box-place.rs:7:11: 9:2
 +         drop(_1) -> [return: bb2, unwind: bb1]; // scope 0 at $DIR/inline-into-box-place.rs:9:1: 9:2
       }
   
--     bb3: {
--         StorageDead(_1);                 // scope 0 at $DIR/inline-into-box-place.rs:9:1: 9:2
--         return;                          // scope 0 at $DIR/inline-into-box-place.rs:9:2: 9:2
-+     bb1 (cleanup): {
-+         resume;                          // scope 0 at $DIR/inline-into-box-place.rs:7:1: 9:2
+      bb1 (cleanup): {
+          resume;                          // scope 0 at $DIR/inline-into-box-place.rs:7:1: 9:2
       }
   
+      bb2: {
+-         _1 = move _2;                    // scope 0 at $DIR/inline-into-box-place.rs:8:29: 8:43
+-         StorageDead(_2);                 // scope 0 at $DIR/inline-into-box-place.rs:8:42: 8:43
+-         _0 = const ();                   // scope 0 at $DIR/inline-into-box-place.rs:7:11: 9:2
+-         drop(_1) -> [return: bb3, unwind: bb1]; // scope 0 at $DIR/inline-into-box-place.rs:9:1: 9:2
+-     }
+- 
+-     bb3: {
+          StorageDead(_1);                 // scope 0 at $DIR/inline-into-box-place.rs:9:1: 9:2
+          return;                          // scope 0 at $DIR/inline-into-box-place.rs:9:2: 9:2
+-     }
+- 
 -     bb4 (cleanup): {
 -         _3 = const alloc::alloc::box_free::<std::vec::Vec<u32>>(move (_2.0: std::ptr::Unique<std::vec::Vec<u32>>)) -> bb1; // scope 0 at $DIR/inline-into-box-place.rs:8:42: 8:43
 -                                          // mir::Constant
 -                                          // + span: $DIR/inline-into-box-place.rs:8:42: 8:43
 -                                          // + literal: Const { ty: unsafe fn(std::ptr::Unique<std::vec::Vec<u32>>) {alloc::alloc::box_free::<std::vec::Vec<u32>>}, val: Value(Scalar(<ZST>)) }
-+     bb2: {
-+         StorageDead(_1);                 // scope 0 at $DIR/inline-into-box-place.rs:9:1: 9:2
-+         return;                          // scope 0 at $DIR/inline-into-box-place.rs:9:2: 9:2
       }
   }
   

--- a/src/test/mir-opt/inline/inline_into_box_place.main.Inline.diff.32bit
+++ b/src/test/mir-opt/inline/inline_into_box_place.main.Inline.diff.32bit
@@ -20,9 +20,7 @@
 -         (*_2) = const std::vec::Vec::<u32>::new() -> [return: bb2, unwind: bb4]; // scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
 +         _4 = &mut (*_2);                 // scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
 +         ((*_4).0: alloc::raw_vec::RawVec<u32>) = const alloc::raw_vec::RawVec::<u32> { ptr: std::ptr::Unique::<u32> { pointer: {0x4 as *const u32}, _marker: std::marker::PhantomData::<u32> }, cap: 0_usize, alloc: std::alloc::Global }; // scope 2 at $SRC_DIR/alloc/src/vec.rs:LL:COL
-                                           // ty::Const
--                                          // + ty: fn() -> std::vec::Vec<u32> {std::vec::Vec::<u32>::new}
--                                          // + val: Value(Scalar(<ZST>))
++                                          // ty::Const
 +                                          // + ty: alloc::raw_vec::RawVec<u32>
 +                                          // + val: Value(ByRef { alloc: Allocation { bytes: [4, 0, 0, 0, 0, 0, 0, 0], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [255], len: Size { raw: 8 } }, size: Size { raw: 8 }, align: Align { pow2: 2 }, mutability: Not, extra: () }, offset: Size { raw: 0 } })
                                            // mir::Constant
@@ -62,9 +60,6 @@
   
 -     bb4 (cleanup): {
 -         _3 = const alloc::alloc::box_free::<std::vec::Vec<u32>>(move (_2.0: std::ptr::Unique<std::vec::Vec<u32>>)) -> bb1; // scope 0 at $DIR/inline-into-box-place.rs:8:42: 8:43
--                                          // ty::Const
--                                          // + ty: unsafe fn(std::ptr::Unique<std::vec::Vec<u32>>) {alloc::alloc::box_free::<std::vec::Vec<u32>>}
--                                          // + val: Value(Scalar(<ZST>))
 -                                          // mir::Constant
 -                                          // + span: $DIR/inline-into-box-place.rs:8:42: 8:43
 -                                          // + literal: Const { ty: unsafe fn(std::ptr::Unique<std::vec::Vec<u32>>) {alloc::alloc::box_free::<std::vec::Vec<u32>>}, val: Value(Scalar(<ZST>)) }

--- a/src/test/mir-opt/inline/inline_into_box_place.main.Inline.diff.64bit
+++ b/src/test/mir-opt/inline/inline_into_box_place.main.Inline.diff.64bit
@@ -27,45 +27,37 @@
 -                                          // + span: $DIR/inline-into-box-place.rs:8:33: 8:41
 -                                          // + user_ty: UserType(1)
 -                                          // + literal: Const { ty: fn() -> std::vec::Vec<u32> {std::vec::Vec::<u32>::new}, val: Value(Scalar(<ZST>)) }
--     }
-- 
--     bb1 (cleanup): {
--         resume;                          // scope 0 at $DIR/inline-into-box-place.rs:7:1: 9:2
--     }
-- 
--     bb2: {
 +                                          // + span: $SRC_DIR/alloc/src/vec.rs:LL:COL
 +                                          // + user_ty: UserType(0)
 +                                          // + literal: Const { ty: alloc::raw_vec::RawVec<u32>, val: Value(ByRef { alloc: Allocation { bytes: [4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [65535], len: Size { raw: 16 } }, size: Size { raw: 16 }, align: Align { pow2: 3 }, mutability: Not, extra: () }, offset: Size { raw: 0 } }) }
 +         ((*_4).1: usize) = const 0_usize; // scope 2 at $SRC_DIR/alloc/src/vec.rs:LL:COL
-          _1 = move _2;                    // scope 0 at $DIR/inline-into-box-place.rs:8:29: 8:43
-          StorageDead(_2);                 // scope 0 at $DIR/inline-into-box-place.rs:8:42: 8:43
-          _0 = const ();                   // scope 0 at $DIR/inline-into-box-place.rs:7:11: 9:2
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/inline-into-box-place.rs:7:11: 9:2
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
--         drop(_1) -> [return: bb3, unwind: bb1]; // scope 0 at $DIR/inline-into-box-place.rs:9:1: 9:2
++         _1 = move _2;                    // scope 0 at $DIR/inline-into-box-place.rs:8:29: 8:43
++         StorageDead(_2);                 // scope 0 at $DIR/inline-into-box-place.rs:8:42: 8:43
++         _0 = const ();                   // scope 0 at $DIR/inline-into-box-place.rs:7:11: 9:2
 +         drop(_1) -> [return: bb2, unwind: bb1]; // scope 0 at $DIR/inline-into-box-place.rs:9:1: 9:2
       }
   
--     bb3: {
--         StorageDead(_1);                 // scope 0 at $DIR/inline-into-box-place.rs:9:1: 9:2
--         return;                          // scope 0 at $DIR/inline-into-box-place.rs:9:2: 9:2
-+     bb1 (cleanup): {
-+         resume;                          // scope 0 at $DIR/inline-into-box-place.rs:7:1: 9:2
+      bb1 (cleanup): {
+          resume;                          // scope 0 at $DIR/inline-into-box-place.rs:7:1: 9:2
       }
   
+      bb2: {
+-         _1 = move _2;                    // scope 0 at $DIR/inline-into-box-place.rs:8:29: 8:43
+-         StorageDead(_2);                 // scope 0 at $DIR/inline-into-box-place.rs:8:42: 8:43
+-         _0 = const ();                   // scope 0 at $DIR/inline-into-box-place.rs:7:11: 9:2
+-         drop(_1) -> [return: bb3, unwind: bb1]; // scope 0 at $DIR/inline-into-box-place.rs:9:1: 9:2
+-     }
+- 
+-     bb3: {
+          StorageDead(_1);                 // scope 0 at $DIR/inline-into-box-place.rs:9:1: 9:2
+          return;                          // scope 0 at $DIR/inline-into-box-place.rs:9:2: 9:2
+-     }
+- 
 -     bb4 (cleanup): {
 -         _3 = const alloc::alloc::box_free::<std::vec::Vec<u32>>(move (_2.0: std::ptr::Unique<std::vec::Vec<u32>>)) -> bb1; // scope 0 at $DIR/inline-into-box-place.rs:8:42: 8:43
 -                                          // mir::Constant
 -                                          // + span: $DIR/inline-into-box-place.rs:8:42: 8:43
 -                                          // + literal: Const { ty: unsafe fn(std::ptr::Unique<std::vec::Vec<u32>>) {alloc::alloc::box_free::<std::vec::Vec<u32>>}, val: Value(Scalar(<ZST>)) }
-+     bb2: {
-+         StorageDead(_1);                 // scope 0 at $DIR/inline-into-box-place.rs:9:1: 9:2
-+         return;                          // scope 0 at $DIR/inline-into-box-place.rs:9:2: 9:2
       }
   }
   

--- a/src/test/mir-opt/inline/inline_into_box_place.main.Inline.diff.64bit
+++ b/src/test/mir-opt/inline/inline_into_box_place.main.Inline.diff.64bit
@@ -20,9 +20,7 @@
 -         (*_2) = const std::vec::Vec::<u32>::new() -> [return: bb2, unwind: bb4]; // scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
 +         _4 = &mut (*_2);                 // scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
 +         ((*_4).0: alloc::raw_vec::RawVec<u32>) = const alloc::raw_vec::RawVec::<u32> { ptr: std::ptr::Unique::<u32> { pointer: {0x4 as *const u32}, _marker: std::marker::PhantomData::<u32> }, cap: 0_usize, alloc: std::alloc::Global }; // scope 2 at $SRC_DIR/alloc/src/vec.rs:LL:COL
-                                           // ty::Const
--                                          // + ty: fn() -> std::vec::Vec<u32> {std::vec::Vec::<u32>::new}
--                                          // + val: Value(Scalar(<ZST>))
++                                          // ty::Const
 +                                          // + ty: alloc::raw_vec::RawVec<u32>
 +                                          // + val: Value(ByRef { alloc: Allocation { bytes: [4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [65535], len: Size { raw: 16 } }, size: Size { raw: 16 }, align: Align { pow2: 3 }, mutability: Not, extra: () }, offset: Size { raw: 0 } })
                                            // mir::Constant
@@ -62,9 +60,6 @@
   
 -     bb4 (cleanup): {
 -         _3 = const alloc::alloc::box_free::<std::vec::Vec<u32>>(move (_2.0: std::ptr::Unique<std::vec::Vec<u32>>)) -> bb1; // scope 0 at $DIR/inline-into-box-place.rs:8:42: 8:43
--                                          // ty::Const
--                                          // + ty: unsafe fn(std::ptr::Unique<std::vec::Vec<u32>>) {alloc::alloc::box_free::<std::vec::Vec<u32>>}
--                                          // + val: Value(Scalar(<ZST>))
 -                                          // mir::Constant
 -                                          // + span: $DIR/inline-into-box-place.rs:8:42: 8:43
 -                                          // + literal: Const { ty: unsafe fn(std::ptr::Unique<std::vec::Vec<u32>>) {alloc::alloc::box_free::<std::vec::Vec<u32>>}, val: Value(Scalar(<ZST>)) }

--- a/src/test/mir-opt/inline/inline_retag.bar.Inline.after.mir
+++ b/src/test/mir-opt/inline/inline_retag.bar.Inline.after.mir
@@ -25,9 +25,6 @@ fn bar() -> bool {
     bb0: {
         StorageLive(_1);                 // scope 0 at $DIR/inline-retag.rs:11:9: 11:10
         _1 = const foo;                  // scope 0 at $DIR/inline-retag.rs:11:13: 11:16
-                                         // ty::Const
-                                         // + ty: for<'r, 's> fn(&'r i32, &'s i32) -> bool {foo}
-                                         // + val: Value(Scalar(<ZST>))
                                          // mir::Constant
                                          // + span: $DIR/inline-retag.rs:11:13: 11:16
                                          // + literal: Const { ty: for<'r, 's> fn(&'r i32, &'s i32) -> bool {foo}, val: Value(Scalar(<ZST>)) }

--- a/src/test/mir-opt/inline/inline_specialization.main.Inline.diff
+++ b/src/test/mir-opt/inline/inline_specialization.main.Inline.diff
@@ -13,9 +13,6 @@
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/inline-specialization.rs:5:9: 5:10
 -         _1 = const <std::vec::Vec<()> as Foo>::bar() -> bb1; // scope 0 at $DIR/inline-specialization.rs:5:13: 5:38
--                                          // ty::Const
--                                          // + ty: fn() -> u32 {<std::vec::Vec<()> as Foo>::bar}
--                                          // + val: Value(Scalar(<ZST>))
 -                                          // mir::Constant
 -                                          // + span: $DIR/inline-specialization.rs:5:13: 5:36
 -                                          // + literal: Const { ty: fn() -> u32 {<std::vec::Vec<()> as Foo>::bar}, val: Value(Scalar(<ZST>)) }

--- a/src/test/mir-opt/inline/inline_specialization.main.Inline.diff
+++ b/src/test/mir-opt/inline/inline_specialization.main.Inline.diff
@@ -21,12 +21,6 @@
 -     bb1: {
 +         _1 = const 123_u32;              // scope 2 at $DIR/inline-specialization.rs:14:31: 14:34
           _0 = const ();                   // scope 0 at $DIR/inline-specialization.rs:4:11: 6:2
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/inline-specialization.rs:4:11: 6:2
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           StorageDead(_1);                 // scope 0 at $DIR/inline-specialization.rs:6:1: 6:2
           return;                          // scope 0 at $DIR/inline-specialization.rs:6:2: 6:2
       }

--- a/src/test/mir-opt/inline/inline_trait_method.test.Inline.after.mir
+++ b/src/test/mir-opt/inline/inline_trait_method.test.Inline.after.mir
@@ -9,9 +9,6 @@ fn test(_1: &dyn X) -> u32 {
         StorageLive(_2);                 // scope 0 at $DIR/inline-trait-method.rs:9:5: 9:6
         _2 = &(*_1);                     // scope 0 at $DIR/inline-trait-method.rs:9:5: 9:6
         _0 = const <dyn X as X>::y(move _2) -> bb1; // scope 0 at $DIR/inline-trait-method.rs:9:5: 9:10
-                                         // ty::Const
-                                         // + ty: for<'r> fn(&'r dyn X) -> u32 {<dyn X as X>::y}
-                                         // + val: Value(Scalar(<ZST>))
                                          // mir::Constant
                                          // + span: $DIR/inline-trait-method.rs:9:7: 9:8
                                          // + literal: Const { ty: for<'r> fn(&'r dyn X) -> u32 {<dyn X as X>::y}, val: Value(Scalar(<ZST>)) }

--- a/src/test/mir-opt/inline/inline_trait_method_2.test2.Inline.after.mir
+++ b/src/test/mir-opt/inline/inline_trait_method_2.test2.Inline.after.mir
@@ -16,9 +16,6 @@ fn test2(_1: &dyn X) -> bool {
         _2 = move _3 as &dyn X (Pointer(Unsize)); // scope 0 at $DIR/inline-trait-method_2.rs:5:10: 5:11
         StorageDead(_3);                 // scope 0 at $DIR/inline-trait-method_2.rs:5:10: 5:11
         _0 = const <dyn X as X>::y(move _2) -> bb1; // scope 1 at $DIR/inline-trait-method_2.rs:10:5: 10:10
-                                         // ty::Const
-                                         // + ty: for<'r> fn(&'r dyn X) -> bool {<dyn X as X>::y}
-                                         // + val: Value(Scalar(<ZST>))
                                          // mir::Constant
                                          // + span: $DIR/inline-trait-method_2.rs:10:7: 10:8
                                          // + literal: Const { ty: for<'r> fn(&'r dyn X) -> bool {<dyn X as X>::y}, val: Value(Scalar(<ZST>)) }

--- a/src/test/mir-opt/instrument_coverage.main.InstrumentCoverage.diff
+++ b/src/test/mir-opt/instrument_coverage.main.InstrumentCoverage.diff
@@ -15,9 +15,6 @@
       bb1: {
           StorageLive(_2);                 // scope 0 at /the/src/instrument_coverage.rs:12:12: 12:17
           _2 = const bar() -> [return: bb3, unwind: bb2]; // scope 0 at /the/src/instrument_coverage.rs:12:12: 12:17
-                                           // ty::Const
-                                           // + ty: fn() -> bool {bar}
-                                           // + val: Value(Scalar(<ZST>))
                                            // mir::Constant
                                            // + span: /the/src/instrument_coverage.rs:12:12: 12:15
                                            // + literal: Const { ty: fn() -> bool {bar}, val: Value(Scalar(<ZST>)) }

--- a/src/test/mir-opt/instrument_coverage.main.InstrumentCoverage.diff
+++ b/src/test/mir-opt/instrument_coverage.main.InstrumentCoverage.diff
@@ -35,24 +35,12 @@
   
       bb5: {
           _1 = const ();                   // scope 0 at /the/src/instrument_coverage.rs:12:9: 14:10
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: /the/src/instrument_coverage.rs:12:9: 14:10
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           StorageDead(_2);                 // scope 0 at /the/src/instrument_coverage.rs:15:5: 15:6
           goto -> bb0;                     // scope 0 at /the/src/instrument_coverage.rs:11:5: 15:6
       }
   
       bb6: {
           _0 = const ();                   // scope 0 at /the/src/instrument_coverage.rs:13:13: 13:18
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: /the/src/instrument_coverage.rs:13:13: 13:18
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           StorageDead(_2);                 // scope 0 at /the/src/instrument_coverage.rs:15:5: 15:6
           return;                          // scope 0 at /the/src/instrument_coverage.rs:16:2: 16:2
       }

--- a/src/test/mir-opt/issue_38669.main.SimplifyCfg-initial.after.mir
+++ b/src/test/mir-opt/issue_38669.main.SimplifyCfg-initial.after.mir
@@ -40,33 +40,15 @@ fn main() -> () {
 
     bb5: {
         _3 = const ();                   // scope 1 at $DIR/issue-38669.rs:7:9: 9:10
-                                         // ty::Const
-                                         // + ty: ()
-                                         // + val: Value(Scalar(<ZST>))
-                                         // mir::Constant
-                                         // + span: $DIR/issue-38669.rs:7:9: 9:10
-                                         // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
         StorageDead(_4);                 // scope 1 at $DIR/issue-38669.rs:9:9: 9:10
         StorageDead(_3);                 // scope 1 at $DIR/issue-38669.rs:9:9: 9:10
         _1 = const true;                 // scope 1 at $DIR/issue-38669.rs:10:9: 10:28
         _2 = const ();                   // scope 1 at $DIR/issue-38669.rs:6:10: 11:6
-                                         // ty::Const
-                                         // + ty: ()
-                                         // + val: Value(Scalar(<ZST>))
-                                         // mir::Constant
-                                         // + span: $DIR/issue-38669.rs:6:10: 11:6
-                                         // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
         goto -> bb2;                     // scope 1 at $DIR/issue-38669.rs:6:5: 11:6
     }
 
     bb6: {
         _0 = const ();                   // scope 1 at $DIR/issue-38669.rs:8:13: 8:18
-                                         // ty::Const
-                                         // + ty: ()
-                                         // + val: Value(Scalar(<ZST>))
-                                         // mir::Constant
-                                         // + span: $DIR/issue-38669.rs:8:13: 8:18
-                                         // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
         StorageDead(_4);                 // scope 1 at $DIR/issue-38669.rs:9:9: 9:10
         StorageDead(_3);                 // scope 1 at $DIR/issue-38669.rs:9:9: 9:10
         StorageDead(_1);                 // scope 0 at $DIR/issue-38669.rs:12:1: 12:2

--- a/src/test/mir-opt/issue_41110.main.ElaborateDrops.after.mir
+++ b/src/test/mir-opt/issue_41110.main.ElaborateDrops.after.mir
@@ -21,9 +21,6 @@ fn main() -> () {
         StorageLive(_4);                 // scope 0 at $DIR/issue-41110.rs:8:21: 8:22
         _4 = S;                          // scope 0 at $DIR/issue-41110.rs:8:21: 8:22
         _3 = const S::id(move _4) -> [return: bb2, unwind: bb4]; // scope 0 at $DIR/issue-41110.rs:8:21: 8:27
-                                         // ty::Const
-                                         // + ty: fn(S) -> S {S::id}
-                                         // + val: Value(Scalar(<ZST>))
                                          // mir::Constant
                                          // + span: $DIR/issue-41110.rs:8:23: 8:25
                                          // + literal: Const { ty: fn(S) -> S {S::id}, val: Value(Scalar(<ZST>)) }
@@ -37,9 +34,6 @@ fn main() -> () {
         StorageDead(_4);                 // scope 0 at $DIR/issue-41110.rs:8:26: 8:27
         _5 = const false;                // scope 0 at $DIR/issue-41110.rs:8:13: 8:28
         _1 = const S::other(move _2, move _3) -> [return: bb6, unwind: bb5]; // scope 0 at $DIR/issue-41110.rs:8:13: 8:28
-                                         // ty::Const
-                                         // + ty: fn(S, S) {S::other}
-                                         // + val: Value(Scalar(<ZST>))
                                          // mir::Constant
                                          // + span: $DIR/issue-41110.rs:8:15: 8:20
                                          // + literal: Const { ty: fn(S, S) {S::other}, val: Value(Scalar(<ZST>)) }

--- a/src/test/mir-opt/issue_41110.main.ElaborateDrops.after.mir
+++ b/src/test/mir-opt/issue_41110.main.ElaborateDrops.after.mir
@@ -56,12 +56,6 @@ fn main() -> () {
         _5 = const false;                // scope 0 at $DIR/issue-41110.rs:8:27: 8:28
         StorageDead(_2);                 // scope 0 at $DIR/issue-41110.rs:8:27: 8:28
         _0 = const ();                   // scope 0 at $DIR/issue-41110.rs:7:11: 9:2
-                                         // ty::Const
-                                         // + ty: ()
-                                         // + val: Value(Scalar(<ZST>))
-                                         // mir::Constant
-                                         // + span: $DIR/issue-41110.rs:7:11: 9:2
-                                         // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
         StorageDead(_1);                 // scope 0 at $DIR/issue-41110.rs:9:1: 9:2
         return;                          // scope 0 at $DIR/issue-41110.rs:9:2: 9:2
     }

--- a/src/test/mir-opt/issue_41110.test.ElaborateDrops.after.mir
+++ b/src/test/mir-opt/issue_41110.test.ElaborateDrops.after.mir
@@ -67,12 +67,6 @@ fn test() -> () {
     bb8: {
         StorageDead(_5);                 // scope 2 at $DIR/issue-41110.rs:18:9: 18:10
         _0 = const ();                   // scope 0 at $DIR/issue-41110.rs:14:15: 19:2
-                                         // ty::Const
-                                         // + ty: ()
-                                         // + val: Value(Scalar(<ZST>))
-                                         // mir::Constant
-                                         // + span: $DIR/issue-41110.rs:14:15: 19:2
-                                         // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
         drop(_2) -> [return: bb9, unwind: bb3]; // scope 1 at $DIR/issue-41110.rs:19:1: 19:2
     }
 

--- a/src/test/mir-opt/issue_41110.test.ElaborateDrops.after.mir
+++ b/src/test/mir-opt/issue_41110.test.ElaborateDrops.after.mir
@@ -26,9 +26,6 @@ fn test() -> () {
         StorageLive(_4);                 // scope 2 at $DIR/issue-41110.rs:17:10: 17:11
         _4 = move _2;                    // scope 2 at $DIR/issue-41110.rs:17:10: 17:11
         _3 = const std::mem::drop::<S>(move _4) -> [return: bb2, unwind: bb5]; // scope 2 at $DIR/issue-41110.rs:17:5: 17:12
-                                         // ty::Const
-                                         // + ty: fn(S) {std::mem::drop::<S>}
-                                         // + val: Value(Scalar(<ZST>))
                                          // mir::Constant
                                          // + span: $DIR/issue-41110.rs:17:5: 17:9
                                          // + literal: Const { ty: fn(S) {std::mem::drop::<S>}, val: Value(Scalar(<ZST>)) }

--- a/src/test/mir-opt/issue_41888.main.ElaborateDrops.after.mir
+++ b/src/test/mir-opt/issue_41888.main.ElaborateDrops.after.mir
@@ -27,9 +27,6 @@ fn main() -> () {
         StorageLive(_1);                 // scope 0 at $DIR/issue-41888.rs:7:9: 7:10
         StorageLive(_2);                 // scope 1 at $DIR/issue-41888.rs:8:8: 8:14
         _2 = const cond() -> [return: bb2, unwind: bb3]; // scope 1 at $DIR/issue-41888.rs:8:8: 8:14
-                                         // ty::Const
-                                         // + ty: fn() -> bool {cond}
-                                         // + val: Value(Scalar(<ZST>))
                                          // mir::Constant
                                          // + span: $DIR/issue-41888.rs:8:8: 8:12
                                          // + literal: Const { ty: fn() -> bool {cond}, val: Value(Scalar(<ZST>)) }

--- a/src/test/mir-opt/issue_41888.main.ElaborateDrops.after.mir
+++ b/src/test/mir-opt/issue_41888.main.ElaborateDrops.after.mir
@@ -46,12 +46,6 @@ fn main() -> () {
 
     bb4: {
         _0 = const ();                   // scope 1 at $DIR/issue-41888.rs:8:5: 14:6
-                                         // ty::Const
-                                         // + ty: ()
-                                         // + val: Value(Scalar(<ZST>))
-                                         // mir::Constant
-                                         // + span: $DIR/issue-41888.rs:8:5: 14:6
-                                         // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
         goto -> bb11;                    // scope 1 at $DIR/issue-41888.rs:8:5: 14:6
     }
 
@@ -80,12 +74,6 @@ fn main() -> () {
 
     bb9: {
         _0 = const ();                   // scope 1 at $DIR/issue-41888.rs:10:9: 13:10
-                                         // ty::Const
-                                         // + ty: ()
-                                         // + val: Value(Scalar(<ZST>))
-                                         // mir::Constant
-                                         // + span: $DIR/issue-41888.rs:10:9: 13:10
-                                         // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
         goto -> bb11;                    // scope 1 at $DIR/issue-41888.rs:10:9: 13:10
     }
 
@@ -94,12 +82,6 @@ fn main() -> () {
         _9 = const false;                // scope 1 at $DIR/issue-41888.rs:10:21: 10:23
         _6 = move ((_1 as F).0: K);      // scope 1 at $DIR/issue-41888.rs:10:21: 10:23
         _0 = const ();                   // scope 2 at $DIR/issue-41888.rs:10:29: 13:10
-                                         // ty::Const
-                                         // + ty: ()
-                                         // + val: Value(Scalar(<ZST>))
-                                         // mir::Constant
-                                         // + span: $DIR/issue-41888.rs:10:29: 13:10
-                                         // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
         StorageDead(_6);                 // scope 1 at $DIR/issue-41888.rs:13:9: 13:10
         goto -> bb11;                    // scope 1 at $DIR/issue-41888.rs:10:9: 13:10
     }

--- a/src/test/mir-opt/issue_49232.main.mir_map.0.mir
+++ b/src/test/mir-opt/issue_49232.main.mir_map.0.mir
@@ -81,9 +81,6 @@ fn main() -> () {
         StorageLive(_6);                 // scope 1 at $DIR/issue-49232.rs:13:14: 13:21
         _6 = &_2;                        // scope 1 at $DIR/issue-49232.rs:13:14: 13:21
         _5 = const std::mem::drop::<&i32>(move _6) -> [return: bb13, unwind: bb4]; // scope 1 at $DIR/issue-49232.rs:13:9: 13:22
-                                         // ty::Const
-                                         // + ty: fn(&i32) {std::mem::drop::<&i32>}
-                                         // + val: Value(Scalar(<ZST>))
                                          // mir::Constant
                                          // + span: $DIR/issue-49232.rs:13:9: 13:13
                                          // + literal: Const { ty: fn(&i32) {std::mem::drop::<&i32>}, val: Value(Scalar(<ZST>)) }

--- a/src/test/mir-opt/issue_49232.main.mir_map.0.mir
+++ b/src/test/mir-opt/issue_49232.main.mir_map.0.mir
@@ -42,12 +42,6 @@ fn main() -> () {
 
     bb6: {
         _0 = const ();                   // scope 0 at $DIR/issue-49232.rs:10:25: 10:30
-                                         // ty::Const
-                                         // + ty: ()
-                                         // + val: Value(Scalar(<ZST>))
-                                         // mir::Constant
-                                         // + span: $DIR/issue-49232.rs:10:25: 10:30
-                                         // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
         goto -> bb8;                     // scope 0 at $DIR/issue-49232.rs:10:25: 10:30
     }
 
@@ -90,12 +84,6 @@ fn main() -> () {
         StorageDead(_6);                 // scope 1 at $DIR/issue-49232.rs:13:21: 13:22
         StorageDead(_5);                 // scope 1 at $DIR/issue-49232.rs:13:22: 13:23
         _1 = const ();                   // scope 0 at $DIR/issue-49232.rs:6:10: 14:6
-                                         // ty::Const
-                                         // + ty: ()
-                                         // + val: Value(Scalar(<ZST>))
-                                         // mir::Constant
-                                         // + span: $DIR/issue-49232.rs:6:10: 14:6
-                                         // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
         StorageDead(_2);                 // scope 0 at $DIR/issue-49232.rs:14:5: 14:6
         goto -> bb1;                     // scope 0 at $DIR/issue-49232.rs:6:5: 14:6
     }

--- a/src/test/mir-opt/issue_62289.test.ElaborateDrops.before.mir
+++ b/src/test/mir-opt/issue_62289.test.ElaborateDrops.before.mir
@@ -31,9 +31,6 @@ fn test() -> std::option::Option<std::boxed::Box<u32>> {
         StorageLive(_4);                 // scope 0 at $DIR/issue-62289.rs:9:15: 9:19
         _4 = std::option::Option::<u32>::None; // scope 0 at $DIR/issue-62289.rs:9:15: 9:19
         _3 = const <std::option::Option<u32> as std::ops::Try>::into_result(move _4) -> [return: bb2, unwind: bb3]; // scope 0 at $DIR/issue-62289.rs:9:15: 9:20
-                                         // ty::Const
-                                         // + ty: fn(std::option::Option<u32>) -> std::result::Result<<std::option::Option<u32> as std::ops::Try>::Ok, <std::option::Option<u32> as std::ops::Try>::Error> {<std::option::Option<u32> as std::ops::Try>::into_result}
-                                         // + val: Value(Scalar(<ZST>))
                                          // mir::Constant
                                          // + span: $DIR/issue-62289.rs:9:15: 9:20
                                          // + literal: Const { ty: fn(std::option::Option<u32>) -> std::result::Result<<std::option::Option<u32> as std::ops::Try>::Ok, <std::option::Option<u32> as std::ops::Try>::Error> {<std::option::Option<u32> as std::ops::Try>::into_result}, val: Value(Scalar(<ZST>)) }
@@ -73,9 +70,6 @@ fn test() -> std::option::Option<std::boxed::Box<u32>> {
         StorageLive(_9);                 // scope 2 at $DIR/issue-62289.rs:9:19: 9:20
         _9 = _6;                         // scope 2 at $DIR/issue-62289.rs:9:19: 9:20
         _8 = const <std::option::NoneError as std::convert::From<std::option::NoneError>>::from(move _9) -> [return: bb8, unwind: bb3]; // scope 2 at $DIR/issue-62289.rs:9:19: 9:20
-                                         // ty::Const
-                                         // + ty: fn(std::option::NoneError) -> std::option::NoneError {<std::option::NoneError as std::convert::From<std::option::NoneError>>::from}
-                                         // + val: Value(Scalar(<ZST>))
                                          // mir::Constant
                                          // + span: $DIR/issue-62289.rs:9:19: 9:20
                                          // + literal: Const { ty: fn(std::option::NoneError) -> std::option::NoneError {<std::option::NoneError as std::convert::From<std::option::NoneError>>::from}, val: Value(Scalar(<ZST>)) }
@@ -88,9 +82,6 @@ fn test() -> std::option::Option<std::boxed::Box<u32>> {
     bb8: {
         StorageDead(_9);                 // scope 2 at $DIR/issue-62289.rs:9:19: 9:20
         _0 = const <std::option::Option<std::boxed::Box<u32>> as std::ops::Try>::from_error(move _8) -> [return: bb9, unwind: bb3]; // scope 2 at $DIR/issue-62289.rs:9:19: 9:20
-                                         // ty::Const
-                                         // + ty: fn(<std::option::Option<std::boxed::Box<u32>> as std::ops::Try>::Error) -> std::option::Option<std::boxed::Box<u32>> {<std::option::Option<std::boxed::Box<u32>> as std::ops::Try>::from_error}
-                                         // + val: Value(Scalar(<ZST>))
                                          // mir::Constant
                                          // + span: $DIR/issue-62289.rs:9:15: 9:20
                                          // + literal: Const { ty: fn(<std::option::Option<std::boxed::Box<u32>> as std::ops::Try>::Error) -> std::option::Option<std::boxed::Box<u32>> {<std::option::Option<std::boxed::Box<u32>> as std::ops::Try>::from_error}, val: Value(Scalar(<ZST>)) }

--- a/src/test/mir-opt/issue_72181.main.mir_map.0.mir.32bit
+++ b/src/test/mir-opt/issue_72181.main.mir_map.0.mir.32bit
@@ -23,9 +23,6 @@ fn main() -> () {
     bb0: {
         StorageLive(_1);                 // scope 0 at $DIR/issue-72181.rs:24:13: 24:34
         _1 = const std::mem::size_of::<Foo>() -> [return: bb2, unwind: bb1]; // scope 0 at $DIR/issue-72181.rs:24:13: 24:34
-                                         // ty::Const
-                                         // + ty: fn() -> usize {std::mem::size_of::<Foo>}
-                                         // + val: Value(Scalar(<ZST>))
                                          // mir::Constant
                                          // + span: $DIR/issue-72181.rs:24:13: 24:32
                                          // + literal: Const { ty: fn() -> usize {std::mem::size_of::<Foo>}, val: Value(Scalar(<ZST>)) }

--- a/src/test/mir-opt/issue_72181.main.mir_map.0.mir.32bit
+++ b/src/test/mir-opt/issue_72181.main.mir_map.0.mir.32bit
@@ -56,12 +56,6 @@ fn main() -> () {
         StorageDead(_6);                 // scope 2 at $DIR/issue-72181.rs:27:30: 27:31
         StorageDead(_5);                 // scope 2 at $DIR/issue-72181.rs:27:30: 27:31
         _0 = const ();                   // scope 0 at $DIR/issue-72181.rs:23:11: 28:2
-                                         // ty::Const
-                                         // + ty: ()
-                                         // + val: Value(Scalar(<ZST>))
-                                         // mir::Constant
-                                         // + span: $DIR/issue-72181.rs:23:11: 28:2
-                                         // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
         StorageDead(_2);                 // scope 1 at $DIR/issue-72181.rs:28:1: 28:2
         goto -> bb4;                     // scope 0 at $DIR/issue-72181.rs:28:2: 28:2
     }

--- a/src/test/mir-opt/issue_72181.main.mir_map.0.mir.64bit
+++ b/src/test/mir-opt/issue_72181.main.mir_map.0.mir.64bit
@@ -23,9 +23,6 @@ fn main() -> () {
     bb0: {
         StorageLive(_1);                 // scope 0 at $DIR/issue-72181.rs:24:13: 24:34
         _1 = const std::mem::size_of::<Foo>() -> [return: bb2, unwind: bb1]; // scope 0 at $DIR/issue-72181.rs:24:13: 24:34
-                                         // ty::Const
-                                         // + ty: fn() -> usize {std::mem::size_of::<Foo>}
-                                         // + val: Value(Scalar(<ZST>))
                                          // mir::Constant
                                          // + span: $DIR/issue-72181.rs:24:13: 24:32
                                          // + literal: Const { ty: fn() -> usize {std::mem::size_of::<Foo>}, val: Value(Scalar(<ZST>)) }

--- a/src/test/mir-opt/issue_72181.main.mir_map.0.mir.64bit
+++ b/src/test/mir-opt/issue_72181.main.mir_map.0.mir.64bit
@@ -56,12 +56,6 @@ fn main() -> () {
         StorageDead(_6);                 // scope 2 at $DIR/issue-72181.rs:27:30: 27:31
         StorageDead(_5);                 // scope 2 at $DIR/issue-72181.rs:27:30: 27:31
         _0 = const ();                   // scope 0 at $DIR/issue-72181.rs:23:11: 28:2
-                                         // ty::Const
-                                         // + ty: ()
-                                         // + val: Value(Scalar(<ZST>))
-                                         // mir::Constant
-                                         // + span: $DIR/issue-72181.rs:23:11: 28:2
-                                         // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
         StorageDead(_2);                 // scope 1 at $DIR/issue-72181.rs:28:1: 28:2
         goto -> bb4;                     // scope 0 at $DIR/issue-72181.rs:28:2: 28:2
     }

--- a/src/test/mir-opt/issue_72181_1.main.mir_map.0.mir
+++ b/src/test/mir-opt/issue_72181_1.main.mir_map.0.mir
@@ -22,9 +22,6 @@ fn main() -> () {
         StorageLive(_3);                 // scope 2 at $DIR/issue-72181-1.rs:17:41: 17:43
         _3 = ();                         // scope 2 at $DIR/issue-72181-1.rs:17:41: 17:43
         _2 = const std::intrinsics::transmute::<(), Void>(move _3) -> [return: bb2, unwind: bb1]; // scope 2 at $DIR/issue-72181-1.rs:17:9: 17:44
-                                         // ty::Const
-                                         // + ty: unsafe extern "rust-intrinsic" fn(()) -> Void {std::intrinsics::transmute::<(), Void>}
-                                         // + val: Value(Scalar(<ZST>))
                                          // mir::Constant
                                          // + span: $DIR/issue-72181-1.rs:17:9: 17:40
                                          // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(()) -> Void {std::intrinsics::transmute::<(), Void>}, val: Value(Scalar(<ZST>)) }
@@ -42,9 +39,6 @@ fn main() -> () {
         StorageLive(_5);                 // scope 1 at $DIR/issue-72181-1.rs:20:7: 20:8
         _5 = move _2;                    // scope 1 at $DIR/issue-72181-1.rs:20:7: 20:8
         const f(move _5) -> bb1;         // scope 1 at $DIR/issue-72181-1.rs:20:5: 20:9
-                                         // ty::Const
-                                         // + ty: fn(Void) -> ! {f}
-                                         // + val: Value(Scalar(<ZST>))
                                          // mir::Constant
                                          // + span: $DIR/issue-72181-1.rs:20:5: 20:6
                                          // + literal: Const { ty: fn(Void) -> ! {f}, val: Value(Scalar(<ZST>)) }

--- a/src/test/mir-opt/issue_73223.main.PreCodegen.diff.32bit
+++ b/src/test/mir-opt/issue_73223.main.PreCodegen.diff.32bit
@@ -147,17 +147,11 @@
           _23 = (_18.1: &&i32);            // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_24);                // scope 5 at $SRC_DIR/std/src/macros.rs:LL:COL
           _25 = const <&i32 as std::fmt::Debug>::fmt as for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> (Pointer(ReifyFnPointer)); // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                                           // ty::Const
-                                           // + ty: for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> {<&i32 as std::fmt::Debug>::fmt}
-                                           // + val: Value(Scalar(<ZST>))
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // + literal: Const { ty: for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> {<&i32 as std::fmt::Debug>::fmt}, val: Value(Scalar(<ZST>)) }
           StorageLive(_28);                // scope 7 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
           _28 = const std::intrinsics::transmute::<for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>, for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>>(move _25) -> bb3; // scope 7 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-                                           // ty::Const
-                                           // + ty: unsafe extern "rust-intrinsic" fn(for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>) -> for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> {std::intrinsics::transmute::<for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>, for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>>}
-                                           // + val: Value(Scalar(<ZST>))
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/fmt/mod.rs:LL:COL
                                            // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>) -> for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> {std::intrinsics::transmute::<for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>, for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>>}, val: Value(Scalar(<ZST>)) }
@@ -166,9 +160,6 @@
       bb3: {
           StorageLive(_29);                // scope 7 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
           _29 = const std::intrinsics::transmute::<&&i32, &core::fmt::Opaque>(move _22) -> bb4; // scope 7 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-                                           // ty::Const
-                                           // + ty: unsafe extern "rust-intrinsic" fn(&&i32) -> &core::fmt::Opaque {std::intrinsics::transmute::<&&i32, &core::fmt::Opaque>}
-                                           // + val: Value(Scalar(<ZST>))
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/fmt/mod.rs:LL:COL
                                            // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(&&i32) -> &core::fmt::Opaque {std::intrinsics::transmute::<&&i32, &core::fmt::Opaque>}, val: Value(Scalar(<ZST>)) }
@@ -181,17 +172,11 @@
           StorageDead(_28);                // scope 7 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
           StorageLive(_26);                // scope 5 at $SRC_DIR/std/src/macros.rs:LL:COL
           _27 = const <&i32 as std::fmt::Debug>::fmt as for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> (Pointer(ReifyFnPointer)); // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                                           // ty::Const
-                                           // + ty: for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> {<&i32 as std::fmt::Debug>::fmt}
-                                           // + val: Value(Scalar(<ZST>))
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // + literal: Const { ty: for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> {<&i32 as std::fmt::Debug>::fmt}, val: Value(Scalar(<ZST>)) }
           StorageLive(_30);                // scope 9 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
           _30 = const std::intrinsics::transmute::<for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>, for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>>(move _27) -> bb5; // scope 9 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-                                           // ty::Const
-                                           // + ty: unsafe extern "rust-intrinsic" fn(for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>) -> for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> {std::intrinsics::transmute::<for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>, for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>>}
-                                           // + val: Value(Scalar(<ZST>))
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/fmt/mod.rs:LL:COL
                                            // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>) -> for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> {std::intrinsics::transmute::<for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>, for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>>}, val: Value(Scalar(<ZST>)) }
@@ -200,9 +185,6 @@
       bb5: {
           StorageLive(_31);                // scope 9 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
           _31 = const std::intrinsics::transmute::<&&i32, &core::fmt::Opaque>(move _23) -> bb6; // scope 9 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-                                           // ty::Const
-                                           // + ty: unsafe extern "rust-intrinsic" fn(&&i32) -> &core::fmt::Opaque {std::intrinsics::transmute::<&&i32, &core::fmt::Opaque>}
-                                           // + val: Value(Scalar(<ZST>))
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/fmt/mod.rs:LL:COL
                                            // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(&&i32) -> &core::fmt::Opaque {std::intrinsics::transmute::<&&i32, &core::fmt::Opaque>}, val: Value(Scalar(<ZST>)) }
@@ -226,9 +208,6 @@
           StorageDead(_32);                // scope 10 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
           _12 = &_13;                      // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
           const std::rt::begin_panic_fmt(move _12); // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
-                                           // ty::Const
-                                           // + ty: for<'r, 's> fn(&'r std::fmt::Arguments<'s>) -> ! {std::rt::begin_panic_fmt}
-                                           // + val: Value(Scalar(<ZST>))
                                            // mir::Constant
                                            // + span: $SRC_DIR/std/src/macros.rs:LL:COL
                                            // + literal: Const { ty: for<'r, 's> fn(&'r std::fmt::Arguments<'s>) -> ! {std::rt::begin_panic_fmt}, val: Value(Scalar(<ZST>)) }

--- a/src/test/mir-opt/issue_73223.main.PreCodegen.diff.32bit
+++ b/src/test/mir-opt/issue_73223.main.PreCodegen.diff.32bit
@@ -112,12 +112,6 @@
           StorageDead(_7);                 // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageDead(_5);                 // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           _0 = const ();                   // scope 0 at $DIR/issue-73223.rs:1:11: 9:2
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/issue-73223.rs:1:11: 9:2
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           StorageDead(_3);                 // scope 1 at $DIR/issue-73223.rs:9:1: 9:2
           return;                          // scope 0 at $DIR/issue-73223.rs:9:2: 9:2
       }

--- a/src/test/mir-opt/issue_73223.main.PreCodegen.diff.64bit
+++ b/src/test/mir-opt/issue_73223.main.PreCodegen.diff.64bit
@@ -147,17 +147,11 @@
           _23 = (_18.1: &&i32);            // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_24);                // scope 5 at $SRC_DIR/std/src/macros.rs:LL:COL
           _25 = const <&i32 as std::fmt::Debug>::fmt as for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> (Pointer(ReifyFnPointer)); // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                                           // ty::Const
-                                           // + ty: for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> {<&i32 as std::fmt::Debug>::fmt}
-                                           // + val: Value(Scalar(<ZST>))
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // + literal: Const { ty: for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> {<&i32 as std::fmt::Debug>::fmt}, val: Value(Scalar(<ZST>)) }
           StorageLive(_28);                // scope 7 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
           _28 = const std::intrinsics::transmute::<for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>, for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>>(move _25) -> bb3; // scope 7 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-                                           // ty::Const
-                                           // + ty: unsafe extern "rust-intrinsic" fn(for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>) -> for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> {std::intrinsics::transmute::<for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>, for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>>}
-                                           // + val: Value(Scalar(<ZST>))
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/fmt/mod.rs:LL:COL
                                            // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>) -> for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> {std::intrinsics::transmute::<for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>, for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>>}, val: Value(Scalar(<ZST>)) }
@@ -166,9 +160,6 @@
       bb3: {
           StorageLive(_29);                // scope 7 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
           _29 = const std::intrinsics::transmute::<&&i32, &core::fmt::Opaque>(move _22) -> bb4; // scope 7 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-                                           // ty::Const
-                                           // + ty: unsafe extern "rust-intrinsic" fn(&&i32) -> &core::fmt::Opaque {std::intrinsics::transmute::<&&i32, &core::fmt::Opaque>}
-                                           // + val: Value(Scalar(<ZST>))
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/fmt/mod.rs:LL:COL
                                            // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(&&i32) -> &core::fmt::Opaque {std::intrinsics::transmute::<&&i32, &core::fmt::Opaque>}, val: Value(Scalar(<ZST>)) }
@@ -181,17 +172,11 @@
           StorageDead(_28);                // scope 7 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
           StorageLive(_26);                // scope 5 at $SRC_DIR/std/src/macros.rs:LL:COL
           _27 = const <&i32 as std::fmt::Debug>::fmt as for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> (Pointer(ReifyFnPointer)); // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                                           // ty::Const
-                                           // + ty: for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> {<&i32 as std::fmt::Debug>::fmt}
-                                           // + val: Value(Scalar(<ZST>))
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // + literal: Const { ty: for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> {<&i32 as std::fmt::Debug>::fmt}, val: Value(Scalar(<ZST>)) }
           StorageLive(_30);                // scope 9 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
           _30 = const std::intrinsics::transmute::<for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>, for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>>(move _27) -> bb5; // scope 9 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-                                           // ty::Const
-                                           // + ty: unsafe extern "rust-intrinsic" fn(for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>) -> for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> {std::intrinsics::transmute::<for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>, for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>>}
-                                           // + val: Value(Scalar(<ZST>))
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/fmt/mod.rs:LL:COL
                                            // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>) -> for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> {std::intrinsics::transmute::<for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>, for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>>}, val: Value(Scalar(<ZST>)) }
@@ -200,9 +185,6 @@
       bb5: {
           StorageLive(_31);                // scope 9 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
           _31 = const std::intrinsics::transmute::<&&i32, &core::fmt::Opaque>(move _23) -> bb6; // scope 9 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-                                           // ty::Const
-                                           // + ty: unsafe extern "rust-intrinsic" fn(&&i32) -> &core::fmt::Opaque {std::intrinsics::transmute::<&&i32, &core::fmt::Opaque>}
-                                           // + val: Value(Scalar(<ZST>))
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/fmt/mod.rs:LL:COL
                                            // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(&&i32) -> &core::fmt::Opaque {std::intrinsics::transmute::<&&i32, &core::fmt::Opaque>}, val: Value(Scalar(<ZST>)) }
@@ -226,9 +208,6 @@
           StorageDead(_32);                // scope 10 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
           _12 = &_13;                      // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
           const std::rt::begin_panic_fmt(move _12); // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
-                                           // ty::Const
-                                           // + ty: for<'r, 's> fn(&'r std::fmt::Arguments<'s>) -> ! {std::rt::begin_panic_fmt}
-                                           // + val: Value(Scalar(<ZST>))
                                            // mir::Constant
                                            // + span: $SRC_DIR/std/src/macros.rs:LL:COL
                                            // + literal: Const { ty: for<'r, 's> fn(&'r std::fmt::Arguments<'s>) -> ! {std::rt::begin_panic_fmt}, val: Value(Scalar(<ZST>)) }

--- a/src/test/mir-opt/issue_73223.main.PreCodegen.diff.64bit
+++ b/src/test/mir-opt/issue_73223.main.PreCodegen.diff.64bit
@@ -112,12 +112,6 @@
           StorageDead(_7);                 // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageDead(_5);                 // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           _0 = const ();                   // scope 0 at $DIR/issue-73223.rs:1:11: 9:2
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/issue-73223.rs:1:11: 9:2
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           StorageDead(_3);                 // scope 1 at $DIR/issue-73223.rs:9:1: 9:2
           return;                          // scope 0 at $DIR/issue-73223.rs:9:2: 9:2
       }

--- a/src/test/mir-opt/issue_73223.main.SimplifyArmIdentity.diff.32bit
+++ b/src/test/mir-opt/issue_73223.main.SimplifyArmIdentity.diff.32bit
@@ -236,9 +236,6 @@
           _39 = _36;                       // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_40);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           _40 = const <&i32 as std::fmt::Debug>::fmt as for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> (Pointer(ReifyFnPointer)); // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                                           // ty::Const
-                                           // + ty: for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> {<&i32 as std::fmt::Debug>::fmt}
-                                           // + val: Value(Scalar(<ZST>))
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // + literal: Const { ty: for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> {<&i32 as std::fmt::Debug>::fmt}, val: Value(Scalar(<ZST>)) }
@@ -246,9 +243,6 @@
           StorageLive(_47);                // scope 7 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
           _47 = _40;                       // scope 7 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
           _46 = const std::intrinsics::transmute::<for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>, for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>>(move _47) -> bb6; // scope 7 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-                                           // ty::Const
-                                           // + ty: unsafe extern "rust-intrinsic" fn(for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>) -> for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> {std::intrinsics::transmute::<for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>, for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>>}
-                                           // + val: Value(Scalar(<ZST>))
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/fmt/mod.rs:LL:COL
                                            // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>) -> for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> {std::intrinsics::transmute::<for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>, for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>>}, val: Value(Scalar(<ZST>)) }
@@ -260,9 +254,6 @@
           StorageLive(_49);                // scope 7 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
           _49 = _39;                       // scope 7 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
           _48 = const std::intrinsics::transmute::<&&i32, &core::fmt::Opaque>(move _49) -> bb7; // scope 7 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-                                           // ty::Const
-                                           // + ty: unsafe extern "rust-intrinsic" fn(&&i32) -> &core::fmt::Opaque {std::intrinsics::transmute::<&&i32, &core::fmt::Opaque>}
-                                           // + val: Value(Scalar(<ZST>))
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/fmt/mod.rs:LL:COL
                                            // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(&&i32) -> &core::fmt::Opaque {std::intrinsics::transmute::<&&i32, &core::fmt::Opaque>}, val: Value(Scalar(<ZST>)) }
@@ -281,9 +272,6 @@
           _42 = _37;                       // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_43);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           _43 = const <&i32 as std::fmt::Debug>::fmt as for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> (Pointer(ReifyFnPointer)); // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                                           // ty::Const
-                                           // + ty: for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> {<&i32 as std::fmt::Debug>::fmt}
-                                           // + val: Value(Scalar(<ZST>))
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // + literal: Const { ty: for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> {<&i32 as std::fmt::Debug>::fmt}, val: Value(Scalar(<ZST>)) }
@@ -291,9 +279,6 @@
           StorageLive(_51);                // scope 9 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
           _51 = _43;                       // scope 9 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
           _50 = const std::intrinsics::transmute::<for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>, for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>>(move _51) -> bb8; // scope 9 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-                                           // ty::Const
-                                           // + ty: unsafe extern "rust-intrinsic" fn(for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>) -> for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> {std::intrinsics::transmute::<for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>, for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>>}
-                                           // + val: Value(Scalar(<ZST>))
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/fmt/mod.rs:LL:COL
                                            // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>) -> for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> {std::intrinsics::transmute::<for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>, for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>>}, val: Value(Scalar(<ZST>)) }
@@ -305,9 +290,6 @@
           StorageLive(_53);                // scope 9 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
           _53 = _42;                       // scope 9 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
           _52 = const std::intrinsics::transmute::<&&i32, &core::fmt::Opaque>(move _53) -> bb9; // scope 9 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-                                           // ty::Const
-                                           // + ty: unsafe extern "rust-intrinsic" fn(&&i32) -> &core::fmt::Opaque {std::intrinsics::transmute::<&&i32, &core::fmt::Opaque>}
-                                           // + val: Value(Scalar(<ZST>))
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/fmt/mod.rs:LL:COL
                                            // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(&&i32) -> &core::fmt::Opaque {std::intrinsics::transmute::<&&i32, &core::fmt::Opaque>}, val: Value(Scalar(<ZST>)) }
@@ -347,9 +329,6 @@
           _21 = &_22;                      // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
           _20 = _21;                       // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
           const std::rt::begin_panic_fmt(move _20); // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
-                                           // ty::Const
-                                           // + ty: for<'r, 's> fn(&'r std::fmt::Arguments<'s>) -> ! {std::rt::begin_panic_fmt}
-                                           // + val: Value(Scalar(<ZST>))
                                            // mir::Constant
                                            // + span: $SRC_DIR/std/src/macros.rs:LL:COL
                                            // + literal: Const { ty: for<'r, 's> fn(&'r std::fmt::Arguments<'s>) -> ! {std::rt::begin_panic_fmt}, val: Value(Scalar(<ZST>)) }

--- a/src/test/mir-opt/issue_73223.main.SimplifyArmIdentity.diff.32bit
+++ b/src/test/mir-opt/issue_73223.main.SimplifyArmIdentity.diff.32bit
@@ -104,12 +104,6 @@
   
       bb1: {
           _0 = const ();                   // scope 0 at $DIR/issue-73223.rs:4:17: 4:23
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/issue-73223.rs:4:17: 4:23
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           StorageDead(_2);                 // scope 0 at $DIR/issue-73223.rs:5:6: 5:7
           StorageDead(_1);                 // scope 0 at $DIR/issue-73223.rs:9:1: 9:2
           goto -> bb3;                     // scope 0 at $DIR/issue-73223.rs:4:17: 4:23
@@ -168,24 +162,12 @@
   
       bb4: {
           _8 = const ();                   // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           StorageDead(_15);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageDead(_14);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageDead(_13);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageDead(_9);                 // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageDead(_8);                 // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           _0 = const ();                   // scope 0 at $DIR/issue-73223.rs:1:11: 9:2
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/issue-73223.rs:1:11: 9:2
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           StorageDead(_6);                 // scope 1 at $DIR/issue-73223.rs:9:1: 9:2
           StorageDead(_1);                 // scope 0 at $DIR/issue-73223.rs:9:1: 9:2
           goto -> bb3;                     // scope 0 at $DIR/issue-73223.rs:9:2: 9:2

--- a/src/test/mir-opt/issue_73223.main.SimplifyArmIdentity.diff.64bit
+++ b/src/test/mir-opt/issue_73223.main.SimplifyArmIdentity.diff.64bit
@@ -236,9 +236,6 @@
           _39 = _36;                       // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_40);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           _40 = const <&i32 as std::fmt::Debug>::fmt as for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> (Pointer(ReifyFnPointer)); // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                                           // ty::Const
-                                           // + ty: for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> {<&i32 as std::fmt::Debug>::fmt}
-                                           // + val: Value(Scalar(<ZST>))
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // + literal: Const { ty: for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> {<&i32 as std::fmt::Debug>::fmt}, val: Value(Scalar(<ZST>)) }
@@ -246,9 +243,6 @@
           StorageLive(_47);                // scope 7 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
           _47 = _40;                       // scope 7 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
           _46 = const std::intrinsics::transmute::<for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>, for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>>(move _47) -> bb6; // scope 7 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-                                           // ty::Const
-                                           // + ty: unsafe extern "rust-intrinsic" fn(for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>) -> for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> {std::intrinsics::transmute::<for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>, for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>>}
-                                           // + val: Value(Scalar(<ZST>))
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/fmt/mod.rs:LL:COL
                                            // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>) -> for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> {std::intrinsics::transmute::<for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>, for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>>}, val: Value(Scalar(<ZST>)) }
@@ -260,9 +254,6 @@
           StorageLive(_49);                // scope 7 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
           _49 = _39;                       // scope 7 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
           _48 = const std::intrinsics::transmute::<&&i32, &core::fmt::Opaque>(move _49) -> bb7; // scope 7 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-                                           // ty::Const
-                                           // + ty: unsafe extern "rust-intrinsic" fn(&&i32) -> &core::fmt::Opaque {std::intrinsics::transmute::<&&i32, &core::fmt::Opaque>}
-                                           // + val: Value(Scalar(<ZST>))
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/fmt/mod.rs:LL:COL
                                            // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(&&i32) -> &core::fmt::Opaque {std::intrinsics::transmute::<&&i32, &core::fmt::Opaque>}, val: Value(Scalar(<ZST>)) }
@@ -281,9 +272,6 @@
           _42 = _37;                       // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_43);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           _43 = const <&i32 as std::fmt::Debug>::fmt as for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> (Pointer(ReifyFnPointer)); // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                                           // ty::Const
-                                           // + ty: for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> {<&i32 as std::fmt::Debug>::fmt}
-                                           // + val: Value(Scalar(<ZST>))
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // + literal: Const { ty: for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> {<&i32 as std::fmt::Debug>::fmt}, val: Value(Scalar(<ZST>)) }
@@ -291,9 +279,6 @@
           StorageLive(_51);                // scope 9 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
           _51 = _43;                       // scope 9 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
           _50 = const std::intrinsics::transmute::<for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>, for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>>(move _51) -> bb8; // scope 9 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-                                           // ty::Const
-                                           // + ty: unsafe extern "rust-intrinsic" fn(for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>) -> for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> {std::intrinsics::transmute::<for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>, for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>>}
-                                           // + val: Value(Scalar(<ZST>))
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/fmt/mod.rs:LL:COL
                                            // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>) -> for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> {std::intrinsics::transmute::<for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>, for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>>}, val: Value(Scalar(<ZST>)) }
@@ -305,9 +290,6 @@
           StorageLive(_53);                // scope 9 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
           _53 = _42;                       // scope 9 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
           _52 = const std::intrinsics::transmute::<&&i32, &core::fmt::Opaque>(move _53) -> bb9; // scope 9 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-                                           // ty::Const
-                                           // + ty: unsafe extern "rust-intrinsic" fn(&&i32) -> &core::fmt::Opaque {std::intrinsics::transmute::<&&i32, &core::fmt::Opaque>}
-                                           // + val: Value(Scalar(<ZST>))
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/fmt/mod.rs:LL:COL
                                            // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(&&i32) -> &core::fmt::Opaque {std::intrinsics::transmute::<&&i32, &core::fmt::Opaque>}, val: Value(Scalar(<ZST>)) }
@@ -347,9 +329,6 @@
           _21 = &_22;                      // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
           _20 = _21;                       // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
           const std::rt::begin_panic_fmt(move _20); // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
-                                           // ty::Const
-                                           // + ty: for<'r, 's> fn(&'r std::fmt::Arguments<'s>) -> ! {std::rt::begin_panic_fmt}
-                                           // + val: Value(Scalar(<ZST>))
                                            // mir::Constant
                                            // + span: $SRC_DIR/std/src/macros.rs:LL:COL
                                            // + literal: Const { ty: for<'r, 's> fn(&'r std::fmt::Arguments<'s>) -> ! {std::rt::begin_panic_fmt}, val: Value(Scalar(<ZST>)) }

--- a/src/test/mir-opt/issue_73223.main.SimplifyArmIdentity.diff.64bit
+++ b/src/test/mir-opt/issue_73223.main.SimplifyArmIdentity.diff.64bit
@@ -104,12 +104,6 @@
   
       bb1: {
           _0 = const ();                   // scope 0 at $DIR/issue-73223.rs:4:17: 4:23
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/issue-73223.rs:4:17: 4:23
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           StorageDead(_2);                 // scope 0 at $DIR/issue-73223.rs:5:6: 5:7
           StorageDead(_1);                 // scope 0 at $DIR/issue-73223.rs:9:1: 9:2
           goto -> bb3;                     // scope 0 at $DIR/issue-73223.rs:4:17: 4:23
@@ -168,24 +162,12 @@
   
       bb4: {
           _8 = const ();                   // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           StorageDead(_15);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageDead(_14);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageDead(_13);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageDead(_9);                 // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageDead(_8);                 // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           _0 = const ();                   // scope 0 at $DIR/issue-73223.rs:1:11: 9:2
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/issue-73223.rs:1:11: 9:2
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           StorageDead(_6);                 // scope 1 at $DIR/issue-73223.rs:9:1: 9:2
           StorageDead(_1);                 // scope 0 at $DIR/issue-73223.rs:9:1: 9:2
           goto -> bb3;                     // scope 0 at $DIR/issue-73223.rs:9:2: 9:2

--- a/src/test/mir-opt/loop_test.main.SimplifyCfg-promote-consts.after.mir
+++ b/src/test/mir-opt/loop_test.main.SimplifyCfg-promote-consts.after.mir
@@ -30,12 +30,6 @@ fn main() -> () {
 
     bb3: {
         _1 = const ();                   // scope 0 at $DIR/loop_test.rs:10:5: 12:6
-                                         // ty::Const
-                                         // + ty: ()
-                                         // + val: Value(Scalar(<ZST>))
-                                         // mir::Constant
-                                         // + span: $DIR/loop_test.rs:10:5: 12:6
-                                         // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
         StorageDead(_2);                 // scope 0 at $DIR/loop_test.rs:12:5: 12:6
         StorageDead(_1);                 // scope 0 at $DIR/loop_test.rs:12:5: 12:6
         StorageLive(_4);                 // scope 0 at $DIR/loop_test.rs:13:5: 16:6
@@ -44,12 +38,6 @@ fn main() -> () {
 
     bb4: {
         _0 = const ();                   // scope 0 at $DIR/loop_test.rs:11:9: 11:15
-                                         // ty::Const
-                                         // + ty: ()
-                                         // + val: Value(Scalar(<ZST>))
-                                         // mir::Constant
-                                         // + span: $DIR/loop_test.rs:11:9: 11:15
-                                         // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
         StorageDead(_2);                 // scope 0 at $DIR/loop_test.rs:12:5: 12:6
         StorageDead(_1);                 // scope 0 at $DIR/loop_test.rs:12:5: 12:6
         return;                          // scope 0 at $DIR/loop_test.rs:17:2: 17:2

--- a/src/test/mir-opt/match_false_edges.full_tested_match.PromoteTemps.after.mir
+++ b/src/test/mir-opt/match_false_edges.full_tested_match.PromoteTemps.after.mir
@@ -111,12 +111,6 @@ fn full_tested_match() -> () {
         StorageDead(_2);                 // scope 0 at $DIR/match_false_edges.rs:19:6: 19:7
         StorageDead(_1);                 // scope 0 at $DIR/match_false_edges.rs:19:6: 19:7
         _0 = const ();                   // scope 0 at $DIR/match_false_edges.rs:14:28: 20:2
-                                         // ty::Const
-                                         // + ty: ()
-                                         // + val: Value(Scalar(<ZST>))
-                                         // mir::Constant
-                                         // + span: $DIR/match_false_edges.rs:14:28: 20:2
-                                         // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
         return;                          // scope 0 at $DIR/match_false_edges.rs:20:2: 20:2
     }
 }

--- a/src/test/mir-opt/match_false_edges.full_tested_match.PromoteTemps.after.mir
+++ b/src/test/mir-opt/match_false_edges.full_tested_match.PromoteTemps.after.mir
@@ -66,9 +66,6 @@ fn full_tested_match() -> () {
         _4 = &shallow _2;                // scope 0 at $DIR/match_false_edges.rs:15:19: 15:27
         StorageLive(_7);                 // scope 0 at $DIR/match_false_edges.rs:16:20: 16:27
         _7 = const guard() -> [return: bb7, unwind: bb1]; // scope 0 at $DIR/match_false_edges.rs:16:20: 16:27
-                                         // ty::Const
-                                         // + ty: fn() -> bool {guard}
-                                         // + val: Value(Scalar(<ZST>))
                                          // mir::Constant
                                          // + span: $DIR/match_false_edges.rs:16:20: 16:25
                                          // + literal: Const { ty: fn() -> bool {guard}, val: Value(Scalar(<ZST>)) }

--- a/src/test/mir-opt/match_false_edges.full_tested_match2.PromoteTemps.before.mir
+++ b/src/test/mir-opt/match_false_edges.full_tested_match2.PromoteTemps.before.mir
@@ -103,12 +103,6 @@ fn full_tested_match2() -> () {
         StorageDead(_2);                 // scope 0 at $DIR/match_false_edges.rs:30:6: 30:7
         StorageDead(_1);                 // scope 0 at $DIR/match_false_edges.rs:30:6: 30:7
         _0 = const ();                   // scope 0 at $DIR/match_false_edges.rs:25:29: 31:2
-                                         // ty::Const
-                                         // + ty: ()
-                                         // + val: Value(Scalar(<ZST>))
-                                         // mir::Constant
-                                         // + span: $DIR/match_false_edges.rs:25:29: 31:2
-                                         // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
         return;                          // scope 0 at $DIR/match_false_edges.rs:31:2: 31:2
     }
 }

--- a/src/test/mir-opt/match_false_edges.full_tested_match2.PromoteTemps.before.mir
+++ b/src/test/mir-opt/match_false_edges.full_tested_match2.PromoteTemps.before.mir
@@ -64,9 +64,6 @@ fn full_tested_match2() -> () {
         _4 = &shallow _2;                // scope 0 at $DIR/match_false_edges.rs:26:19: 26:27
         StorageLive(_7);                 // scope 0 at $DIR/match_false_edges.rs:27:20: 27:27
         _7 = const guard() -> [return: bb7, unwind: bb1]; // scope 0 at $DIR/match_false_edges.rs:27:20: 27:27
-                                         // ty::Const
-                                         // + ty: fn() -> bool {guard}
-                                         // + val: Value(Scalar(<ZST>))
                                          // mir::Constant
                                          // + span: $DIR/match_false_edges.rs:27:20: 27:25
                                          // + literal: Const { ty: fn() -> bool {guard}, val: Value(Scalar(<ZST>)) }

--- a/src/test/mir-opt/match_false_edges.main.PromoteTemps.before.mir
+++ b/src/test/mir-opt/match_false_edges.main.PromoteTemps.before.mir
@@ -72,9 +72,6 @@ fn main() -> () {
         _5 = &shallow _2;                // scope 0 at $DIR/match_false_edges.rs:35:19: 35:26
         StorageLive(_8);                 // scope 0 at $DIR/match_false_edges.rs:36:21: 36:28
         _8 = const guard() -> [return: bb7, unwind: bb1]; // scope 0 at $DIR/match_false_edges.rs:36:21: 36:28
-                                         // ty::Const
-                                         // + ty: fn() -> bool {guard}
-                                         // + val: Value(Scalar(<ZST>))
                                          // mir::Constant
                                          // + span: $DIR/match_false_edges.rs:36:21: 36:26
                                          // + literal: Const { ty: fn() -> bool {guard}, val: Value(Scalar(<ZST>)) }
@@ -118,9 +115,6 @@ fn main() -> () {
         StorageLive(_13);                // scope 0 at $DIR/match_false_edges.rs:38:27: 38:28
         _13 = (*_11);                    // scope 0 at $DIR/match_false_edges.rs:38:27: 38:28
         _12 = const guard2(move _13) -> [return: bb12, unwind: bb1]; // scope 0 at $DIR/match_false_edges.rs:38:20: 38:29
-                                         // ty::Const
-                                         // + ty: fn(i32) -> bool {guard2}
-                                         // + val: Value(Scalar(<ZST>))
                                          // mir::Constant
                                          // + span: $DIR/match_false_edges.rs:38:20: 38:26
                                          // + literal: Const { ty: fn(i32) -> bool {guard2}, val: Value(Scalar(<ZST>)) }

--- a/src/test/mir-opt/match_false_edges.main.PromoteTemps.before.mir
+++ b/src/test/mir-opt/match_false_edges.main.PromoteTemps.before.mir
@@ -147,12 +147,6 @@ fn main() -> () {
         StorageDead(_2);                 // scope 0 at $DIR/match_false_edges.rs:40:6: 40:7
         StorageDead(_1);                 // scope 0 at $DIR/match_false_edges.rs:40:6: 40:7
         _0 = const ();                   // scope 0 at $DIR/match_false_edges.rs:34:11: 41:2
-                                         // ty::Const
-                                         // + ty: ()
-                                         // + val: Value(Scalar(<ZST>))
-                                         // mir::Constant
-                                         // + span: $DIR/match_false_edges.rs:34:11: 41:2
-                                         // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
         return;                          // scope 0 at $DIR/match_false_edges.rs:41:2: 41:2
     }
 }

--- a/src/test/mir-opt/match_test.main.SimplifyCfg-initial.after.mir
+++ b/src/test/mir-opt/match_test.main.SimplifyCfg-initial.after.mir
@@ -99,12 +99,6 @@ fn main() -> () {
     bb14: {
         StorageDead(_3);                 // scope 2 at $DIR/match_test.rs:17:6: 17:7
         _0 = const ();                   // scope 0 at $DIR/match_test.rs:6:11: 18:2
-                                         // ty::Const
-                                         // + ty: ()
-                                         // + val: Value(Scalar(<ZST>))
-                                         // mir::Constant
-                                         // + span: $DIR/match_test.rs:6:11: 18:2
-                                         // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
         StorageDead(_2);                 // scope 1 at $DIR/match_test.rs:18:1: 18:2
         StorageDead(_1);                 // scope 0 at $DIR/match_test.rs:18:1: 18:2
         return;                          // scope 0 at $DIR/match_test.rs:18:2: 18:2

--- a/src/test/mir-opt/matches_reduce_branches.foo.MatchBranchSimplification.diff.32bit
+++ b/src/test/mir-opt/matches_reduce_branches.foo.MatchBranchSimplification.diff.32bit
@@ -31,12 +31,6 @@
   
       bb4: {
           _0 = const ();                   // scope 0 at $DIR/matches_reduce_branches.rs:6:5: 8:6
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/matches_reduce_branches.rs:6:5: 8:6
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           goto -> bb5;                     // scope 0 at $DIR/matches_reduce_branches.rs:6:5: 8:6
       }
   

--- a/src/test/mir-opt/matches_reduce_branches.foo.MatchBranchSimplification.diff.64bit
+++ b/src/test/mir-opt/matches_reduce_branches.foo.MatchBranchSimplification.diff.64bit
@@ -31,12 +31,6 @@
   
       bb4: {
           _0 = const ();                   // scope 0 at $DIR/matches_reduce_branches.rs:6:5: 8:6
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/matches_reduce_branches.rs:6:5: 8:6
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           goto -> bb5;                     // scope 0 at $DIR/matches_reduce_branches.rs:6:5: 8:6
       }
   

--- a/src/test/mir-opt/nll/region_subtyping_basic.main.nll.0.mir.32bit
+++ b/src/test/mir-opt/nll/region_subtyping_basic.main.nll.0.mir.32bit
@@ -97,24 +97,12 @@ fn main() -> () {
         StorageDead(_9);                 // bb6[0]: scope 3 at $DIR/region-subtyping-basic.rs:21:17: 21:18
         StorageDead(_8);                 // bb6[1]: scope 3 at $DIR/region-subtyping-basic.rs:21:18: 21:19
         _0 = const Const(Value(Scalar(<ZST>)): ()); // bb6[2]: scope 3 at $DIR/region-subtyping-basic.rs:20:13: 22:6
-                                         // ty::Const
-                                         // + ty: ()
-                                         // + val: Value(Scalar(<ZST>))
-                                         // mir::Constant
-                                         // + span: $DIR/region-subtyping-basic.rs:20:13: 22:6
-                                         // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
         goto -> bb8;                     // bb6[3]: scope 3 at $DIR/region-subtyping-basic.rs:20:5: 24:6
     }
 
     bb7: {
         StorageDead(_10);                // bb7[0]: scope 3 at $DIR/region-subtyping-basic.rs:23:18: 23:19
         _0 = const Const(Value(Scalar(<ZST>)): ()); // bb7[1]: scope 3 at $DIR/region-subtyping-basic.rs:22:12: 24:6
-                                         // ty::Const
-                                         // + ty: ()
-                                         // + val: Value(Scalar(<ZST>))
-                                         // mir::Constant
-                                         // + span: $DIR/region-subtyping-basic.rs:22:12: 24:6
-                                         // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
         goto -> bb8;                     // bb7[2]: scope 3 at $DIR/region-subtyping-basic.rs:20:5: 24:6
     }
 

--- a/src/test/mir-opt/nll/region_subtyping_basic.main.nll.0.mir.32bit
+++ b/src/test/mir-opt/nll/region_subtyping_basic.main.nll.0.mir.32bit
@@ -78,9 +78,6 @@ fn main() -> () {
     bb4: {
         StorageLive(_10);                // bb4[0]: scope 3 at $DIR/region-subtyping-basic.rs:23:9: 23:18
         _10 = const Const(Value(Scalar(<ZST>)): fn(usize) -> bool {use_x})(const Const(Value(Scalar(0x00000016)): usize)) -> [return: bb7, unwind: bb1]; // bb4[1]: scope 3 at $DIR/region-subtyping-basic.rs:23:9: 23:18
-                                         // ty::Const
-                                         // + ty: fn(usize) -> bool {use_x}
-                                         // + val: Value(Scalar(<ZST>))
                                          // mir::Constant
                                          // + span: $DIR/region-subtyping-basic.rs:23:9: 23:14
                                          // + literal: Const { ty: fn(usize) -> bool {use_x}, val: Value(Scalar(<ZST>)) }
@@ -91,9 +88,6 @@ fn main() -> () {
         StorageLive(_9);                 // bb5[1]: scope 3 at $DIR/region-subtyping-basic.rs:21:15: 21:17
         _9 = (*_6);                      // bb5[2]: scope 3 at $DIR/region-subtyping-basic.rs:21:15: 21:17
         _8 = const Const(Value(Scalar(<ZST>)): fn(usize) -> bool {use_x})(move _9) -> [return: bb6, unwind: bb1]; // bb5[3]: scope 3 at $DIR/region-subtyping-basic.rs:21:9: 21:18
-                                         // ty::Const
-                                         // + ty: fn(usize) -> bool {use_x}
-                                         // + val: Value(Scalar(<ZST>))
                                          // mir::Constant
                                          // + span: $DIR/region-subtyping-basic.rs:21:9: 21:14
                                          // + literal: Const { ty: fn(usize) -> bool {use_x}, val: Value(Scalar(<ZST>)) }

--- a/src/test/mir-opt/nll/region_subtyping_basic.main.nll.0.mir.64bit
+++ b/src/test/mir-opt/nll/region_subtyping_basic.main.nll.0.mir.64bit
@@ -97,24 +97,12 @@ fn main() -> () {
         StorageDead(_9);                 // bb6[0]: scope 3 at $DIR/region-subtyping-basic.rs:21:17: 21:18
         StorageDead(_8);                 // bb6[1]: scope 3 at $DIR/region-subtyping-basic.rs:21:18: 21:19
         _0 = const Const(Value(Scalar(<ZST>)): ()); // bb6[2]: scope 3 at $DIR/region-subtyping-basic.rs:20:13: 22:6
-                                         // ty::Const
-                                         // + ty: ()
-                                         // + val: Value(Scalar(<ZST>))
-                                         // mir::Constant
-                                         // + span: $DIR/region-subtyping-basic.rs:20:13: 22:6
-                                         // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
         goto -> bb8;                     // bb6[3]: scope 3 at $DIR/region-subtyping-basic.rs:20:5: 24:6
     }
 
     bb7: {
         StorageDead(_10);                // bb7[0]: scope 3 at $DIR/region-subtyping-basic.rs:23:18: 23:19
         _0 = const Const(Value(Scalar(<ZST>)): ()); // bb7[1]: scope 3 at $DIR/region-subtyping-basic.rs:22:12: 24:6
-                                         // ty::Const
-                                         // + ty: ()
-                                         // + val: Value(Scalar(<ZST>))
-                                         // mir::Constant
-                                         // + span: $DIR/region-subtyping-basic.rs:22:12: 24:6
-                                         // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
         goto -> bb8;                     // bb7[2]: scope 3 at $DIR/region-subtyping-basic.rs:20:5: 24:6
     }
 

--- a/src/test/mir-opt/nll/region_subtyping_basic.main.nll.0.mir.64bit
+++ b/src/test/mir-opt/nll/region_subtyping_basic.main.nll.0.mir.64bit
@@ -78,9 +78,6 @@ fn main() -> () {
     bb4: {
         StorageLive(_10);                // bb4[0]: scope 3 at $DIR/region-subtyping-basic.rs:23:9: 23:18
         _10 = const Const(Value(Scalar(<ZST>)): fn(usize) -> bool {use_x})(const Const(Value(Scalar(0x0000000000000016)): usize)) -> [return: bb7, unwind: bb1]; // bb4[1]: scope 3 at $DIR/region-subtyping-basic.rs:23:9: 23:18
-                                         // ty::Const
-                                         // + ty: fn(usize) -> bool {use_x}
-                                         // + val: Value(Scalar(<ZST>))
                                          // mir::Constant
                                          // + span: $DIR/region-subtyping-basic.rs:23:9: 23:14
                                          // + literal: Const { ty: fn(usize) -> bool {use_x}, val: Value(Scalar(<ZST>)) }
@@ -91,9 +88,6 @@ fn main() -> () {
         StorageLive(_9);                 // bb5[1]: scope 3 at $DIR/region-subtyping-basic.rs:21:15: 21:17
         _9 = (*_6);                      // bb5[2]: scope 3 at $DIR/region-subtyping-basic.rs:21:15: 21:17
         _8 = const Const(Value(Scalar(<ZST>)): fn(usize) -> bool {use_x})(move _9) -> [return: bb6, unwind: bb1]; // bb5[3]: scope 3 at $DIR/region-subtyping-basic.rs:21:9: 21:18
-                                         // ty::Const
-                                         // + ty: fn(usize) -> bool {use_x}
-                                         // + val: Value(Scalar(<ZST>))
                                          // mir::Constant
                                          // + span: $DIR/region-subtyping-basic.rs:21:9: 21:14
                                          // + literal: Const { ty: fn(usize) -> bool {use_x}, val: Value(Scalar(<ZST>)) }

--- a/src/test/mir-opt/no_drop_for_inactive_variant.unwrap.SimplifyCfg-elaborate-drops.after.mir
+++ b/src/test/mir-opt/no_drop_for_inactive_variant.unwrap.SimplifyCfg-elaborate-drops.after.mir
@@ -21,9 +21,6 @@ fn unwrap(_1: std::option::Option<T>) -> T {
     bb1: {
         StorageLive(_4);                 // scope 0 at $SRC_DIR/std/src/macros.rs:LL:COL
         const std::rt::begin_panic::<&str>(const "explicit panic") -> bb4; // scope 0 at $SRC_DIR/std/src/macros.rs:LL:COL
-                                         // ty::Const
-                                         // + ty: fn(&str) -> ! {std::rt::begin_panic::<&str>}
-                                         // + val: Value(Scalar(<ZST>))
                                          // mir::Constant
                                          // + span: $SRC_DIR/std/src/macros.rs:LL:COL
                                          // + literal: Const { ty: fn(&str) -> ! {std::rt::begin_panic::<&str>}, val: Value(Scalar(<ZST>)) }

--- a/src/test/mir-opt/no_spurious_drop_after_call.main.ElaborateDrops.before.mir
+++ b/src/test/mir-opt/no_spurious_drop_after_call.main.ElaborateDrops.before.mir
@@ -21,9 +21,6 @@ fn main() -> () {
                                          // + literal: Const { ty: &str, val: Value(Slice { data: Allocation { bytes: [], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [], len: Size { raw: 0 } }, size: Size { raw: 0 }, align: Align { pow2: 0 }, mutability: Not, extra: () }, start: 0, end: 0 }) }
         _3 = &(*_4);                     // scope 0 at $DIR/no-spurious-drop-after-call.rs:9:20: 9:22
         _2 = const <str as std::string::ToString>::to_string(move _3) -> bb2; // scope 0 at $DIR/no-spurious-drop-after-call.rs:9:20: 9:34
-                                         // ty::Const
-                                         // + ty: for<'r> fn(&'r str) -> std::string::String {<str as std::string::ToString>::to_string}
-                                         // + val: Value(Scalar(<ZST>))
                                          // mir::Constant
                                          // + span: $DIR/no-spurious-drop-after-call.rs:9:23: 9:32
                                          // + literal: Const { ty: for<'r> fn(&'r str) -> std::string::String {<str as std::string::ToString>::to_string}, val: Value(Scalar(<ZST>)) }
@@ -36,9 +33,6 @@ fn main() -> () {
     bb2: {
         StorageDead(_3);                 // scope 0 at $DIR/no-spurious-drop-after-call.rs:9:33: 9:34
         _1 = const std::mem::drop::<std::string::String>(move _2) -> [return: bb3, unwind: bb4]; // scope 0 at $DIR/no-spurious-drop-after-call.rs:9:5: 9:35
-                                         // ty::Const
-                                         // + ty: fn(std::string::String) {std::mem::drop::<std::string::String>}
-                                         // + val: Value(Scalar(<ZST>))
                                          // mir::Constant
                                          // + span: $DIR/no-spurious-drop-after-call.rs:9:5: 9:19
                                          // + literal: Const { ty: fn(std::string::String) {std::mem::drop::<std::string::String>}, val: Value(Scalar(<ZST>)) }

--- a/src/test/mir-opt/no_spurious_drop_after_call.main.ElaborateDrops.before.mir
+++ b/src/test/mir-opt/no_spurious_drop_after_call.main.ElaborateDrops.before.mir
@@ -43,12 +43,6 @@ fn main() -> () {
         StorageDead(_4);                 // scope 0 at $DIR/no-spurious-drop-after-call.rs:9:35: 9:36
         StorageDead(_1);                 // scope 0 at $DIR/no-spurious-drop-after-call.rs:9:35: 9:36
         _0 = const ();                   // scope 0 at $DIR/no-spurious-drop-after-call.rs:8:11: 10:2
-                                         // ty::Const
-                                         // + ty: ()
-                                         // + val: Value(Scalar(<ZST>))
-                                         // mir::Constant
-                                         // + span: $DIR/no-spurious-drop-after-call.rs:8:11: 10:2
-                                         // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
         return;                          // scope 0 at $DIR/no-spurious-drop-after-call.rs:10:2: 10:2
     }
 

--- a/src/test/mir-opt/packed_struct_drop_aligned.main.SimplifyCfg-elaborate-drops.after.mir.32bit
+++ b/src/test/mir-opt/packed_struct_drop_aligned.main.SimplifyCfg-elaborate-drops.after.mir.32bit
@@ -50,12 +50,6 @@ fn main() -> () {
         (_1.0: Aligned) = move _4;       // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:5: 7:8
         StorageDead(_4);                 // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:28: 7:29
         _0 = const ();                   // scope 0 at $DIR/packed-struct-drop-aligned.rs:5:11: 8:2
-                                         // ty::Const
-                                         // + ty: ()
-                                         // + val: Value(Scalar(<ZST>))
-                                         // mir::Constant
-                                         // + span: $DIR/packed-struct-drop-aligned.rs:5:11: 8:2
-                                         // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
         drop(_1) -> [return: bb2, unwind: bb1]; // scope 0 at $DIR/packed-struct-drop-aligned.rs:8:1: 8:2
     }
 }

--- a/src/test/mir-opt/packed_struct_drop_aligned.main.SimplifyCfg-elaborate-drops.after.mir.64bit
+++ b/src/test/mir-opt/packed_struct_drop_aligned.main.SimplifyCfg-elaborate-drops.after.mir.64bit
@@ -50,12 +50,6 @@ fn main() -> () {
         (_1.0: Aligned) = move _4;       // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:5: 7:8
         StorageDead(_4);                 // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:28: 7:29
         _0 = const ();                   // scope 0 at $DIR/packed-struct-drop-aligned.rs:5:11: 8:2
-                                         // ty::Const
-                                         // + ty: ()
-                                         // + val: Value(Scalar(<ZST>))
-                                         // mir::Constant
-                                         // + span: $DIR/packed-struct-drop-aligned.rs:5:11: 8:2
-                                         // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
         drop(_1) -> [return: bb2, unwind: bb1]; // scope 0 at $DIR/packed-struct-drop-aligned.rs:8:1: 8:2
     }
 }

--- a/src/test/mir-opt/retag.core.ptr-drop_in_place.Test.SimplifyCfg-make_shim.after.mir
+++ b/src/test/mir-opt/retag.core.ptr-drop_in_place.Test.SimplifyCfg-make_shim.after.mir
@@ -9,9 +9,6 @@ fn std::intrinsics::drop_in_place(_1: *mut Test) -> () {
         Retag([raw] _1);                 // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
         _2 = &mut (*_1);                 // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
         _3 = const <Test as std::ops::Drop>::drop(move _2) -> bb1; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-                                         // ty::Const
-                                         // + ty: for<'r> fn(&'r mut Test) {<Test as std::ops::Drop>::drop}
-                                         // + val: Value(Scalar(<ZST>))
                                          // mir::Constant
                                          // + span: $SRC_DIR/core/src/ptr/mod.rs:LL:COL
                                          // + literal: Const { ty: for<'r> fn(&'r mut Test) {<Test as std::ops::Drop>::drop}, val: Value(Scalar(<ZST>)) }

--- a/src/test/mir-opt/retag.main.SimplifyCfg-elaborate-drops.after.mir
+++ b/src/test/mir-opt/retag.main.SimplifyCfg-elaborate-drops.after.mir
@@ -71,9 +71,6 @@ fn main() -> () {
         _6 = &mut (*_7);                 // scope 1 at $DIR/retag.rs:32:29: 32:35
         Retag([2phase] _6);              // scope 1 at $DIR/retag.rs:32:29: 32:35
         _3 = const Test::foo(move _4, move _6) -> [return: bb2, unwind: bb3]; // scope 1 at $DIR/retag.rs:32:17: 32:36
-                                         // ty::Const
-                                         // + ty: for<'r, 'x> fn(&'r Test, &'x mut i32) -> &'x mut i32 {Test::foo}
-                                         // + val: Value(Scalar(<ZST>))
                                          // mir::Constant
                                          // + span: $DIR/retag.rs:32:25: 32:28
                                          // + literal: Const { ty: for<'r, 'x> fn(&'r Test, &'x mut i32) -> &'x mut i32 {Test::foo}, val: Value(Scalar(<ZST>)) }
@@ -176,9 +173,6 @@ fn main() -> () {
         _22 = &(*_23);                   // scope 7 at $DIR/retag.rs:47:21: 47:23
         Retag(_22);                      // scope 7 at $DIR/retag.rs:47:21: 47:23
         _19 = const Test::foo_shr(move _20, move _22) -> [return: bb6, unwind: bb7]; // scope 7 at $DIR/retag.rs:47:5: 47:24
-                                         // ty::Const
-                                         // + ty: for<'r, 'x> fn(&'r Test, &'x i32) -> &'x i32 {Test::foo_shr}
-                                         // + val: Value(Scalar(<ZST>))
                                          // mir::Constant
                                          // + span: $DIR/retag.rs:47:13: 47:20
                                          // + literal: Const { ty: for<'r, 'x> fn(&'r Test, &'x i32) -> &'x i32 {Test::foo_shr}, val: Value(Scalar(<ZST>)) }

--- a/src/test/mir-opt/retag.main.SimplifyCfg-elaborate-drops.after.mir
+++ b/src/test/mir-opt/retag.main.SimplifyCfg-elaborate-drops.after.mir
@@ -111,12 +111,6 @@ fn main() -> () {
         _11 = _12;                       // scope 4 at $DIR/retag.rs:36:18: 36:29
         StorageDead(_12);                // scope 4 at $DIR/retag.rs:36:29: 36:30
         _2 = const ();                   // scope 1 at $DIR/retag.rs:31:5: 37:6
-                                         // ty::Const
-                                         // + ty: ()
-                                         // + val: Value(Scalar(<ZST>))
-                                         // mir::Constant
-                                         // + span: $DIR/retag.rs:31:5: 37:6
-                                         // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
         StorageDead(_11);                // scope 4 at $DIR/retag.rs:37:5: 37:6
         StorageDead(_10);                // scope 3 at $DIR/retag.rs:37:5: 37:6
         StorageDead(_8);                 // scope 2 at $DIR/retag.rs:37:5: 37:6
@@ -200,12 +194,6 @@ fn main() -> () {
         _25 = _26;                       // scope 7 at $DIR/retag.rs:50:14: 50:28
         StorageDead(_26);                // scope 7 at $DIR/retag.rs:50:28: 50:29
         _0 = const ();                   // scope 0 at $DIR/retag.rs:29:11: 51:2
-                                         // ty::Const
-                                         // + ty: ()
-                                         // + val: Value(Scalar(<ZST>))
-                                         // mir::Constant
-                                         // + span: $DIR/retag.rs:29:11: 51:2
-                                         // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
         StorageDead(_25);                // scope 7 at $DIR/retag.rs:51:1: 51:2
         StorageDead(_15);                // scope 6 at $DIR/retag.rs:51:1: 51:2
         StorageDead(_13);                // scope 1 at $DIR/retag.rs:51:1: 51:2

--- a/src/test/mir-opt/simplify_arm_identity.main.SimplifyArmIdentity.diff.32bit
+++ b/src/test/mir-opt/simplify_arm_identity.main.SimplifyArmIdentity.diff.32bit
@@ -51,12 +51,6 @@
       bb4: {
           StorageDead(_2);                 // scope 1 at $DIR/simplify-arm-identity.rs:22:6: 22:7
           _0 = const ();                   // scope 0 at $DIR/simplify-arm-identity.rs:17:11: 23:2
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/simplify-arm-identity.rs:17:11: 23:2
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           StorageDead(_1);                 // scope 0 at $DIR/simplify-arm-identity.rs:23:1: 23:2
           return;                          // scope 0 at $DIR/simplify-arm-identity.rs:23:2: 23:2
       }

--- a/src/test/mir-opt/simplify_arm_identity.main.SimplifyArmIdentity.diff.64bit
+++ b/src/test/mir-opt/simplify_arm_identity.main.SimplifyArmIdentity.diff.64bit
@@ -51,12 +51,6 @@
       bb4: {
           StorageDead(_2);                 // scope 1 at $DIR/simplify-arm-identity.rs:22:6: 22:7
           _0 = const ();                   // scope 0 at $DIR/simplify-arm-identity.rs:17:11: 23:2
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/simplify-arm-identity.rs:17:11: 23:2
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           StorageDead(_1);                 // scope 0 at $DIR/simplify-arm-identity.rs:23:1: 23:2
           return;                          // scope 0 at $DIR/simplify-arm-identity.rs:23:2: 23:2
       }

--- a/src/test/mir-opt/simplify_cfg.main.SimplifyCfg-early-opt.diff
+++ b/src/test/mir-opt/simplify_cfg.main.SimplifyCfg-early-opt.diff
@@ -38,12 +38,6 @@
 -     bb5: {
 +     bb2: {
           _1 = const ();                   // scope 0 at $DIR/simplify_cfg.rs:7:9: 9:10
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/simplify_cfg.rs:7:9: 9:10
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           StorageDead(_2);                 // scope 0 at $DIR/simplify_cfg.rs:10:5: 10:6
           goto -> bb0;                     // scope 0 at $DIR/simplify_cfg.rs:6:5: 10:6
       }
@@ -51,12 +45,6 @@
 -     bb6: {
 +     bb3: {
           _0 = const ();                   // scope 0 at $DIR/simplify_cfg.rs:8:13: 8:18
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/simplify_cfg.rs:8:13: 8:18
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           StorageDead(_2);                 // scope 0 at $DIR/simplify_cfg.rs:10:5: 10:6
           return;                          // scope 0 at $DIR/simplify_cfg.rs:11:2: 11:2
       }

--- a/src/test/mir-opt/simplify_cfg.main.SimplifyCfg-early-opt.diff
+++ b/src/test/mir-opt/simplify_cfg.main.SimplifyCfg-early-opt.diff
@@ -15,9 +15,6 @@
           StorageLive(_2);                 // scope 0 at $DIR/simplify_cfg.rs:7:12: 7:17
 -         _2 = const bar() -> bb3;         // scope 0 at $DIR/simplify_cfg.rs:7:12: 7:17
 +         _2 = const bar() -> bb1;         // scope 0 at $DIR/simplify_cfg.rs:7:12: 7:17
-                                           // ty::Const
-                                           // + ty: fn() -> bool {bar}
-                                           // + val: Value(Scalar(<ZST>))
                                            // mir::Constant
                                            // + span: $DIR/simplify_cfg.rs:7:12: 7:15
                                            // + literal: Const { ty: fn() -> bool {bar}, val: Value(Scalar(<ZST>)) }

--- a/src/test/mir-opt/simplify_cfg.main.SimplifyCfg-initial.diff
+++ b/src/test/mir-opt/simplify_cfg.main.SimplifyCfg-initial.diff
@@ -24,9 +24,6 @@
           StorageLive(_2);                 // scope 0 at $DIR/simplify_cfg.rs:7:12: 7:17
 -         _2 = const bar() -> [return: bb5, unwind: bb4]; // scope 0 at $DIR/simplify_cfg.rs:7:12: 7:17
 +         _2 = const bar() -> [return: bb3, unwind: bb2]; // scope 0 at $DIR/simplify_cfg.rs:7:12: 7:17
-                                           // ty::Const
-                                           // + ty: fn() -> bool {bar}
-                                           // + val: Value(Scalar(<ZST>))
                                            // mir::Constant
                                            // + span: $DIR/simplify_cfg.rs:7:12: 7:15
                                            // + literal: Const { ty: fn() -> bool {bar}, val: Value(Scalar(<ZST>)) }

--- a/src/test/mir-opt/simplify_cfg.main.SimplifyCfg-initial.diff
+++ b/src/test/mir-opt/simplify_cfg.main.SimplifyCfg-initial.diff
@@ -50,12 +50,6 @@
 -     bb7: {
 +     bb5: {
           _1 = const ();                   // scope 0 at $DIR/simplify_cfg.rs:7:9: 9:10
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/simplify_cfg.rs:7:9: 9:10
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
 -         goto -> bb12;                    // scope 0 at $DIR/simplify_cfg.rs:7:9: 9:10
 +         StorageDead(_2);                 // scope 0 at $DIR/simplify_cfg.rs:10:5: 10:6
 +         goto -> bb0;                     // scope 0 at $DIR/simplify_cfg.rs:6:5: 10:6
@@ -64,12 +58,6 @@
 -     bb8: {
 +     bb6: {
           _0 = const ();                   // scope 0 at $DIR/simplify_cfg.rs:8:13: 8:18
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/simplify_cfg.rs:8:13: 8:18
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
 -         goto -> bb9;                     // scope 0 at $DIR/simplify_cfg.rs:8:13: 8:18
 -     }
 - 

--- a/src/test/mir-opt/simplify_if.main.SimplifyBranches-after-const-prop.diff
+++ b/src/test/mir-opt/simplify_if.main.SimplifyBranches-after-const-prop.diff
@@ -15,12 +15,6 @@
   
       bb1: {
           _0 = const ();                   // scope 0 at $DIR/simplify_if.rs:6:5: 8:6
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/simplify_if.rs:6:5: 8:6
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           goto -> bb4;                     // scope 0 at $DIR/simplify_if.rs:6:5: 8:6
       }
   
@@ -35,12 +29,6 @@
       bb3: {
           StorageDead(_2);                 // scope 0 at $DIR/simplify_if.rs:7:15: 7:16
           _0 = const ();                   // scope 0 at $DIR/simplify_if.rs:6:14: 8:6
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/simplify_if.rs:6:14: 8:6
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           goto -> bb4;                     // scope 0 at $DIR/simplify_if.rs:6:5: 8:6
       }
   

--- a/src/test/mir-opt/simplify_if.main.SimplifyBranches-after-const-prop.diff
+++ b/src/test/mir-opt/simplify_if.main.SimplifyBranches-after-const-prop.diff
@@ -27,9 +27,6 @@
       bb2: {
           StorageLive(_2);                 // scope 0 at $DIR/simplify_if.rs:7:9: 7:15
           _2 = const noop() -> bb3;        // scope 0 at $DIR/simplify_if.rs:7:9: 7:15
-                                           // ty::Const
-                                           // + ty: fn() {noop}
-                                           // + val: Value(Scalar(<ZST>))
                                            // mir::Constant
                                            // + span: $DIR/simplify_if.rs:7:9: 7:13
                                            // + literal: Const { ty: fn() {noop}, val: Value(Scalar(<ZST>)) }

--- a/src/test/mir-opt/simplify_locals_fixedpoint.foo.SimplifyLocals.diff
+++ b/src/test/mir-opt/simplify_locals_fixedpoint.foo.SimplifyLocals.diff
@@ -31,12 +31,6 @@
   
       bb1: {
           _0 = const ();                   // scope 0 at $DIR/simplify-locals-fixedpoint.rs:4:5: 8:6
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/simplify-locals-fixedpoint.rs:4:5: 8:6
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           goto -> bb7;                     // scope 0 at $DIR/simplify-locals-fixedpoint.rs:4:5: 8:6
       }
   
@@ -58,23 +52,11 @@
   
       bb4: {
           _0 = const ();                   // scope 1 at $DIR/simplify-locals-fixedpoint.rs:5:9: 7:10
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/simplify-locals-fixedpoint.rs:5:9: 7:10
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           goto -> bb6;                     // scope 1 at $DIR/simplify-locals-fixedpoint.rs:5:9: 7:10
       }
   
       bb5: {
           _0 = const ();                   // scope 1 at $DIR/simplify-locals-fixedpoint.rs:5:21: 7:10
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/simplify-locals-fixedpoint.rs:5:21: 7:10
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           goto -> bb6;                     // scope 1 at $DIR/simplify-locals-fixedpoint.rs:5:9: 7:10
       }
   

--- a/src/test/mir-opt/simplify_locals_removes_unused_consts.main.SimplifyLocals.diff
+++ b/src/test/mir-opt/simplify_locals_removes_unused_consts.main.SimplifyLocals.diff
@@ -24,12 +24,12 @@
 -         StorageLive(_2);                 // scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:13:21: 13:23
 -         StorageLive(_3);                 // scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:13:25: 13:27
 -         (_1.0: ()) = const ();           // scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:13:20: 13:28
-+         StorageLive(_1);                 // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:14:5: 14:22
-+         _1 = const use_zst(const ((), ())) -> bb1; // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:14:5: 14:22
-                                           // ty::Const
+-                                          // ty::Const
 -                                          // + ty: ()
 -                                          // + val: Value(Scalar(<ZST>))
--                                          // mir::Constant
++         StorageLive(_1);                 // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:14:5: 14:22
++         _1 = const use_zst(const ((), ())) -> bb1; // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:14:5: 14:22
+                                           // mir::Constant
 -                                          // + span: $DIR/simplify-locals-removes-unused-consts.rs:13:20: 13:28
 -                                          // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
 -         (_1.1: ()) = const ();           // scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:13:20: 13:28
@@ -63,10 +63,7 @@
 -         StorageDead(_7);                 // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:14:20: 14:21
 -         StorageDead(_6);                 // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:14:20: 14:21
 -         _4 = const use_zst(const ((), ())) -> bb1; // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:14:5: 14:22
--                                          // ty::Const
-                                           // + ty: fn(((), ())) {use_zst}
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
+-                                          // mir::Constant
                                            // + span: $DIR/simplify-locals-removes-unused-consts.rs:14:5: 14:12
                                            // + literal: Const { ty: fn(((), ())) {use_zst}, val: Value(Scalar(<ZST>)) }
                                            // ty::Const
@@ -92,9 +89,6 @@
 +         StorageDead(_1);                 // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:14:22: 14:23
 +         StorageLive(_2);                 // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:16:5: 16:35
 +         _2 = const use_u8(const 42_u8) -> bb2; // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:16:5: 16:35
-                                           // ty::Const
-                                           // + ty: fn(u8) {use_u8}
-                                           // + val: Value(Scalar(<ZST>))
                                            // mir::Constant
                                            // + span: $DIR/simplify-locals-removes-unused-consts.rs:16:5: 16:11
                                            // + literal: Const { ty: fn(u8) {use_u8}, val: Value(Scalar(<ZST>)) }

--- a/src/test/mir-opt/simplify_locals_removes_unused_consts.main.SimplifyLocals.diff
+++ b/src/test/mir-opt/simplify_locals_removes_unused_consts.main.SimplifyLocals.diff
@@ -24,21 +24,7 @@
 -         StorageLive(_2);                 // scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:13:21: 13:23
 -         StorageLive(_3);                 // scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:13:25: 13:27
 -         (_1.0: ()) = const ();           // scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:13:20: 13:28
--                                          // ty::Const
--                                          // + ty: ()
--                                          // + val: Value(Scalar(<ZST>))
-+         StorageLive(_1);                 // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:14:5: 14:22
-+         _1 = const use_zst(const ((), ())) -> bb1; // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:14:5: 14:22
-                                           // mir::Constant
--                                          // + span: $DIR/simplify-locals-removes-unused-consts.rs:13:20: 13:28
--                                          // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
 -         (_1.1: ()) = const ();           // scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:13:20: 13:28
--                                          // ty::Const
--                                          // + ty: ()
--                                          // + val: Value(Scalar(<ZST>))
--                                          // mir::Constant
--                                          // + span: $DIR/simplify-locals-removes-unused-consts.rs:13:20: 13:28
--                                          // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
 -         StorageDead(_3);                 // scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:13:27: 13:28
 -         StorageDead(_2);                 // scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:13:27: 13:28
 -         StorageDead(_1);                 // scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:13:28: 13:29
@@ -47,23 +33,13 @@
 -         StorageLive(_6);                 // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:14:14: 14:16
 -         StorageLive(_7);                 // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:14:18: 14:20
 -         (_5.0: ()) = const ();           // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:14:13: 14:21
--                                          // ty::Const
--                                          // + ty: ()
--                                          // + val: Value(Scalar(<ZST>))
--                                          // mir::Constant
--                                          // + span: $DIR/simplify-locals-removes-unused-consts.rs:14:13: 14:21
--                                          // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
 -         (_5.1: ()) = const ();           // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:14:13: 14:21
--                                          // ty::Const
--                                          // + ty: ()
--                                          // + val: Value(Scalar(<ZST>))
--                                          // mir::Constant
--                                          // + span: $DIR/simplify-locals-removes-unused-consts.rs:14:13: 14:21
--                                          // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
 -         StorageDead(_7);                 // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:14:20: 14:21
 -         StorageDead(_6);                 // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:14:20: 14:21
 -         _4 = const use_zst(const ((), ())) -> bb1; // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:14:5: 14:22
--                                          // mir::Constant
++         StorageLive(_1);                 // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:14:5: 14:22
++         _1 = const use_zst(const ((), ())) -> bb1; // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:14:5: 14:22
+                                           // mir::Constant
                                            // + span: $DIR/simplify-locals-removes-unused-consts.rs:14:5: 14:12
                                            // + literal: Const { ty: fn(((), ())) {use_zst}, val: Value(Scalar(<ZST>)) }
                                            // ty::Const
@@ -100,12 +76,6 @@
 -         StorageDead(_8);                 // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:16:35: 16:36
 +         StorageDead(_2);                 // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:16:35: 16:36
           _0 = const ();                   // scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:12:11: 17:2
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/simplify-locals-removes-unused-consts.rs:12:11: 17:2
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           return;                          // scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:17:2: 17:2
       }
   }

--- a/src/test/mir-opt/simplify_match.main.ConstProp.diff
+++ b/src/test/mir-opt/simplify_match.main.ConstProp.diff
@@ -22,12 +22,6 @@
   
       bb1: {
           _0 = const ();                   // scope 0 at $DIR/simplify_match.rs:8:18: 8:20
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/simplify_match.rs:8:18: 8:20
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           goto -> bb3;                     // scope 0 at $DIR/simplify_match.rs:6:5: 9:6
       }
   

--- a/src/test/mir-opt/simplify_match.main.ConstProp.diff
+++ b/src/test/mir-opt/simplify_match.main.ConstProp.diff
@@ -33,9 +33,6 @@
   
       bb2: {
           _0 = const noop() -> bb3;        // scope 0 at $DIR/simplify_match.rs:7:17: 7:23
-                                           // ty::Const
-                                           // + ty: fn() {noop}
-                                           // + val: Value(Scalar(<ZST>))
                                            // mir::Constant
                                            // + span: $DIR/simplify_match.rs:7:17: 7:21
                                            // + literal: Const { ty: fn() {noop}, val: Value(Scalar(<ZST>)) }

--- a/src/test/mir-opt/simplify_try_if_let.{{impl}}-append.SimplifyArmIdentity.diff
+++ b/src/test/mir-opt/simplify_try_if_let.{{impl}}-append.SimplifyArmIdentity.diff
@@ -47,12 +47,6 @@
   
       bb3: {
           _0 = const ();                   // scope 0 at $DIR/simplify_try_if_let.rs:22:21: 22:24
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/simplify_try_if_let.rs:22:21: 22:24
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           goto -> bb9;                     // scope 0 at $DIR/simplify_try_if_let.rs:21:9: 32:10
       }
   
@@ -64,12 +58,6 @@
   
       bb5: {
           _0 = const ();                   // scope 1 at $DIR/simplify_try_if_let.rs:26:17: 30:18
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/simplify_try_if_let.rs:26:17: 30:18
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           goto -> bb8;                     // scope 1 at $DIR/simplify_try_if_let.rs:26:17: 30:18
       }
   
@@ -97,12 +85,6 @@
           StorageDead(_9);                 // scope 3 at $DIR/simplify_try_if_let.rs:28:61: 28:62
           StorageDead(_11);                // scope 3 at $DIR/simplify_try_if_let.rs:28:62: 28:63
           _0 = const ();                   // scope 3 at $DIR/simplify_try_if_let.rs:27:21: 29:22
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/simplify_try_if_let.rs:27:21: 29:22
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           StorageDead(_8);                 // scope 1 at $DIR/simplify_try_if_let.rs:30:17: 30:18
           goto -> bb8;                     // scope 1 at $DIR/simplify_try_if_let.rs:26:17: 30:18
       }

--- a/src/test/mir-opt/simplify_try_if_let.{{impl}}-append.SimplifyArmIdentity.diff
+++ b/src/test/mir-opt/simplify_try_if_let.{{impl}}-append.SimplifyArmIdentity.diff
@@ -36,9 +36,6 @@
           StorageLive(_6);                 // scope 1 at $DIR/simplify_try_if_let.rs:26:43: 26:53
           _6 = &mut ((*_2).0: std::option::Option<std::ptr::NonNull<Node>>); // scope 1 at $DIR/simplify_try_if_let.rs:26:43: 26:53
           _5 = const std::option::Option::<std::ptr::NonNull<Node>>::take(move _6) -> bb4; // scope 1 at $DIR/simplify_try_if_let.rs:26:43: 26:60
-                                           // ty::Const
-                                           // + ty: for<'r> fn(&'r mut std::option::Option<std::ptr::NonNull<Node>>) -> std::option::Option<std::ptr::NonNull<Node>> {std::option::Option::<std::ptr::NonNull<Node>>::take}
-                                           // + val: Value(Scalar(<ZST>))
                                            // mir::Constant
                                            // + span: $DIR/simplify_try_if_let.rs:26:54: 26:58
                                            // + literal: Const { ty: for<'r> fn(&'r mut std::option::Option<std::ptr::NonNull<Node>>) -> std::option::Option<std::ptr::NonNull<Node>> {std::option::Option::<std::ptr::NonNull<Node>>::take}, val: Value(Scalar(<ZST>)) }
@@ -89,9 +86,6 @@
           StorageLive(_12);                // scope 3 at $DIR/simplify_try_if_let.rs:28:25: 28:29
           _12 = &mut _4;                   // scope 3 at $DIR/simplify_try_if_let.rs:28:25: 28:29
           _11 = const std::ptr::NonNull::<Node>::as_mut(move _12) -> bb7; // scope 3 at $DIR/simplify_try_if_let.rs:28:25: 28:38
-                                           // ty::Const
-                                           // + ty: for<'r> unsafe fn(&'r mut std::ptr::NonNull<Node>) -> &'r mut Node {std::ptr::NonNull::<Node>::as_mut}
-                                           // + val: Value(Scalar(<ZST>))
                                            // mir::Constant
                                            // + span: $DIR/simplify_try_if_let.rs:28:30: 28:36
                                            // + literal: Const { ty: for<'r> unsafe fn(&'r mut std::ptr::NonNull<Node>) -> &'r mut Node {std::ptr::NonNull::<Node>::as_mut}, val: Value(Scalar(<ZST>)) }

--- a/src/test/mir-opt/storage_ranges.main.nll.0.mir
+++ b/src/test/mir-opt/storage_ranges.main.nll.0.mir
@@ -50,12 +50,6 @@ fn main() -> () {
         _3 = &_4;                        // scope 1 at $DIR/storage_ranges.rs:6:17: 6:25
         FakeRead(ForLet, _3);            // scope 1 at $DIR/storage_ranges.rs:6:13: 6:14
         _2 = const ();                   // scope 1 at $DIR/storage_ranges.rs:5:5: 7:6
-                                         // ty::Const
-                                         // + ty: ()
-                                         // + val: Value(Scalar(<ZST>))
-                                         // mir::Constant
-                                         // + span: $DIR/storage_ranges.rs:5:5: 7:6
-                                         // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
         StorageDead(_4);                 // scope 1 at $DIR/storage_ranges.rs:7:5: 7:6
         StorageDead(_3);                 // scope 1 at $DIR/storage_ranges.rs:7:5: 7:6
         StorageDead(_2);                 // scope 1 at $DIR/storage_ranges.rs:7:5: 7:6
@@ -63,12 +57,6 @@ fn main() -> () {
         _6 = const 1_i32;                // scope 1 at $DIR/storage_ranges.rs:8:13: 8:14
         FakeRead(ForLet, _6);            // scope 1 at $DIR/storage_ranges.rs:8:9: 8:10
         _0 = const ();                   // scope 0 at $DIR/storage_ranges.rs:3:11: 9:2
-                                         // ty::Const
-                                         // + ty: ()
-                                         // + val: Value(Scalar(<ZST>))
-                                         // mir::Constant
-                                         // + span: $DIR/storage_ranges.rs:3:11: 9:2
-                                         // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
         StorageDead(_6);                 // scope 1 at $DIR/storage_ranges.rs:9:1: 9:2
         StorageDead(_1);                 // scope 0 at $DIR/storage_ranges.rs:9:1: 9:2
         return;                          // scope 0 at $DIR/storage_ranges.rs:9:2: 9:2

--- a/src/test/mir-opt/tls_access.main.SimplifyCfg-final.after.mir
+++ b/src/test/mir-opt/tls_access.main.SimplifyCfg-final.after.mir
@@ -21,12 +21,6 @@ fn main() -> () {
         (*_3) = const 42_u8;             // scope 2 at $DIR/tls-access.rs:9:9: 9:17
         StorageDead(_3);                 // scope 2 at $DIR/tls-access.rs:9:17: 9:18
         _0 = const ();                   // scope 1 at $DIR/tls-access.rs:7:5: 10:6
-                                         // ty::Const
-                                         // + ty: ()
-                                         // + val: Value(Scalar(<ZST>))
-                                         // mir::Constant
-                                         // + span: $DIR/tls-access.rs:7:5: 10:6
-                                         // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
         StorageDead(_2);                 // scope 1 at $DIR/tls-access.rs:10:5: 10:6
         StorageDead(_1);                 // scope 1 at $DIR/tls-access.rs:10:5: 10:6
         return;                          // scope 0 at $DIR/tls-access.rs:11:2: 11:2

--- a/src/test/mir-opt/uniform_array_move_out.move_out_by_subslice.mir_map.0.mir
+++ b/src/test/mir-opt/uniform_array_move_out.move_out_by_subslice.mir_map.0.mir
@@ -72,12 +72,6 @@ fn move_out_by_subslice() -> () {
         StorageLive(_6);                 // scope 1 at $DIR/uniform_array_move_out.rs:12:10: 12:17
         _6 = move _1[0..2];              // scope 1 at $DIR/uniform_array_move_out.rs:12:10: 12:17
         _0 = const ();                   // scope 0 at $DIR/uniform_array_move_out.rs:10:27: 13:2
-                                         // ty::Const
-                                         // + ty: ()
-                                         // + val: Value(Scalar(<ZST>))
-                                         // mir::Constant
-                                         // + span: $DIR/uniform_array_move_out.rs:10:27: 13:2
-                                         // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
         drop(_6) -> [return: bb12, unwind: bb10]; // scope 1 at $DIR/uniform_array_move_out.rs:13:1: 13:2
     }
 

--- a/src/test/mir-opt/uniform_array_move_out.move_out_from_end.mir_map.0.mir
+++ b/src/test/mir-opt/uniform_array_move_out.move_out_from_end.mir_map.0.mir
@@ -72,12 +72,6 @@ fn move_out_from_end() -> () {
         StorageLive(_6);                 // scope 1 at $DIR/uniform_array_move_out.rs:6:14: 6:16
         _6 = move _1[1 of 2];            // scope 1 at $DIR/uniform_array_move_out.rs:6:14: 6:16
         _0 = const ();                   // scope 0 at $DIR/uniform_array_move_out.rs:4:24: 7:2
-                                         // ty::Const
-                                         // + ty: ()
-                                         // + val: Value(Scalar(<ZST>))
-                                         // mir::Constant
-                                         // + span: $DIR/uniform_array_move_out.rs:4:24: 7:2
-                                         // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
         drop(_6) -> [return: bb12, unwind: bb10]; // scope 1 at $DIR/uniform_array_move_out.rs:7:1: 7:2
     }
 

--- a/src/test/mir-opt/uninhabited_enum.process_void.SimplifyLocals.after.mir
+++ b/src/test/mir-opt/uninhabited_enum.process_void.SimplifyLocals.after.mir
@@ -14,12 +14,6 @@ fn process_void(_1: *const Void) -> () {
         StorageLive(_2);                 // scope 0 at $DIR/uninhabited-enum.rs:14:8: 14:14
         _2 = &(*_1);                     // scope 2 at $DIR/uninhabited-enum.rs:14:26: 14:33
         _0 = const ();                   // scope 0 at $DIR/uninhabited-enum.rs:13:41: 17:2
-                                         // ty::Const
-                                         // + ty: ()
-                                         // + val: Value(Scalar(<ZST>))
-                                         // mir::Constant
-                                         // + span: $DIR/uninhabited-enum.rs:13:41: 17:2
-                                         // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
         StorageDead(_2);                 // scope 0 at $DIR/uninhabited-enum.rs:17:1: 17:2
         return;                          // scope 0 at $DIR/uninhabited-enum.rs:17:2: 17:2
     }

--- a/src/test/mir-opt/uninhabited_enum_branching.main.SimplifyCfg-after-uninhabited-enum-branching.after.mir
+++ b/src/test/mir-opt/uninhabited_enum_branching.main.SimplifyCfg-after-uninhabited-enum-branching.after.mir
@@ -65,12 +65,6 @@ fn main() -> () {
         StorageDead(_7);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:29:6: 29:7
         StorageDead(_6);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:29:6: 29:7
         _0 = const ();                   // scope 0 at $DIR/uninhabited_enum_branching.rs:19:11: 30:2
-                                         // ty::Const
-                                         // + ty: ()
-                                         // + val: Value(Scalar(<ZST>))
-                                         // mir::Constant
-                                         // + span: $DIR/uninhabited_enum_branching.rs:19:11: 30:2
-                                         // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
         return;                          // scope 0 at $DIR/uninhabited_enum_branching.rs:30:2: 30:2
     }
 }

--- a/src/test/mir-opt/uninhabited_enum_branching.main.UninhabitedEnumBranching.diff
+++ b/src/test/mir-opt/uninhabited_enum_branching.main.UninhabitedEnumBranching.diff
@@ -100,12 +100,6 @@
           StorageDead(_7);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:29:6: 29:7
           StorageDead(_6);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:29:6: 29:7
           _0 = const ();                   // scope 0 at $DIR/uninhabited_enum_branching.rs:19:11: 30:2
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/uninhabited_enum_branching.rs:19:11: 30:2
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           return;                          // scope 0 at $DIR/uninhabited_enum_branching.rs:30:2: 30:2
       }
   }

--- a/src/test/mir-opt/unreachable.main.UnreachablePropagation.diff
+++ b/src/test/mir-opt/unreachable.main.UnreachablePropagation.diff
@@ -20,9 +20,6 @@
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/unreachable.rs:9:23: 9:30
           _1 = const empty() -> bb1;       // scope 0 at $DIR/unreachable.rs:9:23: 9:30
-                                           // ty::Const
-                                           // + ty: fn() -> std::option::Option<Empty> {empty}
-                                           // + val: Value(Scalar(<ZST>))
                                            // mir::Constant
                                            // + span: $DIR/unreachable.rs:9:23: 9:28
                                            // + literal: Const { ty: fn() -> std::option::Option<Empty> {empty}, val: Value(Scalar(<ZST>)) }

--- a/src/test/mir-opt/unreachable.main.UnreachablePropagation.diff
+++ b/src/test/mir-opt/unreachable.main.UnreachablePropagation.diff
@@ -33,12 +33,6 @@
   
       bb2: {
           _0 = const ();                   // scope 0 at $DIR/unreachable.rs:9:5: 19:6
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/unreachable.rs:9:5: 19:6
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           StorageDead(_1);                 // scope 0 at $DIR/unreachable.rs:20:1: 20:2
           return;                          // scope 0 at $DIR/unreachable.rs:20:2: 20:2
 -     }
@@ -56,24 +50,12 @@
 -     bb4: {
 -         _4 = const 42_i32;               // scope 2 at $DIR/unreachable.rs:15:13: 15:20
 -         _5 = const ();                   // scope 2 at $DIR/unreachable.rs:14:16: 16:10
--                                          // ty::Const
--                                          // + ty: ()
--                                          // + val: Value(Scalar(<ZST>))
--                                          // mir::Constant
--                                          // + span: $DIR/unreachable.rs:14:16: 16:10
--                                          // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
 -         goto -> bb6;                     // scope 2 at $DIR/unreachable.rs:12:9: 16:10
 -     }
 - 
 -     bb5: {
 -         _4 = const 21_i32;               // scope 2 at $DIR/unreachable.rs:13:13: 13:20
 -         _5 = const ();                   // scope 2 at $DIR/unreachable.rs:12:17: 14:10
--                                          // ty::Const
--                                          // + ty: ()
--                                          // + val: Value(Scalar(<ZST>))
--                                          // mir::Constant
--                                          // + span: $DIR/unreachable.rs:12:17: 14:10
--                                          // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
 -         goto -> bb6;                     // scope 2 at $DIR/unreachable.rs:12:9: 16:10
 -     }
 - 

--- a/src/test/mir-opt/unreachable_asm.main.UnreachablePropagation.diff
+++ b/src/test/mir-opt/unreachable_asm.main.UnreachablePropagation.diff
@@ -35,12 +35,6 @@
   
       bb2: {
           _0 = const ();                   // scope 0 at $DIR/unreachable_asm.rs:11:5: 23:6
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/unreachable_asm.rs:11:5: 23:6
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           StorageDead(_1);                 // scope 0 at $DIR/unreachable_asm.rs:24:1: 24:2
           return;                          // scope 0 at $DIR/unreachable_asm.rs:24:2: 24:2
       }
@@ -58,24 +52,12 @@
       bb4: {
           _4 = const 42_i32;               // scope 2 at $DIR/unreachable_asm.rs:17:13: 17:20
           _5 = const ();                   // scope 2 at $DIR/unreachable_asm.rs:16:16: 18:10
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/unreachable_asm.rs:16:16: 18:10
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           goto -> bb6;                     // scope 2 at $DIR/unreachable_asm.rs:14:9: 18:10
       }
   
       bb5: {
           _4 = const 21_i32;               // scope 2 at $DIR/unreachable_asm.rs:15:13: 15:20
           _5 = const ();                   // scope 2 at $DIR/unreachable_asm.rs:14:17: 16:10
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/unreachable_asm.rs:14:17: 16:10
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           goto -> bb6;                     // scope 2 at $DIR/unreachable_asm.rs:14:9: 18:10
       }
   
@@ -85,12 +67,6 @@
           StorageLive(_7);                 // scope 2 at $DIR/unreachable_asm.rs:21:9: 21:37
           llvm_asm!(LlvmInlineAsmInner { asm: "NOP", asm_str_style: Cooked, outputs: [], inputs: [], clobbers: [], volatile: true, alignstack: false, dialect: Att } : [] : []); // scope 3 at $DIR/unreachable_asm.rs:21:18: 21:35
           _7 = const ();                   // scope 3 at $DIR/unreachable_asm.rs:21:9: 21:37
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/unreachable_asm.rs:21:9: 21:37
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           StorageDead(_7);                 // scope 2 at $DIR/unreachable_asm.rs:21:36: 21:37
           StorageLive(_8);                 // scope 2 at $DIR/unreachable_asm.rs:22:9: 22:21
           unreachable;                     // scope 2 at $DIR/unreachable_asm.rs:22:15: 22:17

--- a/src/test/mir-opt/unreachable_asm.main.UnreachablePropagation.diff
+++ b/src/test/mir-opt/unreachable_asm.main.UnreachablePropagation.diff
@@ -23,9 +23,6 @@
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/unreachable_asm.rs:11:23: 11:30
           _1 = const empty() -> bb1;       // scope 0 at $DIR/unreachable_asm.rs:11:23: 11:30
-                                           // ty::Const
-                                           // + ty: fn() -> std::option::Option<Empty> {empty}
-                                           // + val: Value(Scalar(<ZST>))
                                            // mir::Constant
                                            // + span: $DIR/unreachable_asm.rs:11:23: 11:28
                                            // + literal: Const { ty: fn() -> std::option::Option<Empty> {empty}, val: Value(Scalar(<ZST>)) }

--- a/src/test/mir-opt/unreachable_asm_2.main.UnreachablePropagation.diff
+++ b/src/test/mir-opt/unreachable_asm_2.main.UnreachablePropagation.diff
@@ -26,9 +26,6 @@
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/unreachable_asm_2.rs:11:23: 11:30
           _1 = const empty() -> bb1;       // scope 0 at $DIR/unreachable_asm_2.rs:11:23: 11:30
-                                           // ty::Const
-                                           // + ty: fn() -> std::option::Option<Empty> {empty}
-                                           // + val: Value(Scalar(<ZST>))
                                            // mir::Constant
                                            // + span: $DIR/unreachable_asm_2.rs:11:23: 11:28
                                            // + literal: Const { ty: fn() -> std::option::Option<Empty> {empty}, val: Value(Scalar(<ZST>)) }

--- a/src/test/mir-opt/unreachable_asm_2.main.UnreachablePropagation.diff
+++ b/src/test/mir-opt/unreachable_asm_2.main.UnreachablePropagation.diff
@@ -38,12 +38,6 @@
   
       bb2: {
           _0 = const ();                   // scope 0 at $DIR/unreachable_asm_2.rs:11:5: 25:6
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/unreachable_asm_2.rs:11:5: 25:6
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           StorageDead(_1);                 // scope 0 at $DIR/unreachable_asm_2.rs:26:1: 26:2
           return;                          // scope 0 at $DIR/unreachable_asm_2.rs:26:2: 26:2
       }
@@ -62,21 +56,9 @@
           StorageLive(_8);                 // scope 2 at $DIR/unreachable_asm_2.rs:20:13: 20:41
           llvm_asm!(LlvmInlineAsmInner { asm: "NOP", asm_str_style: Cooked, outputs: [], inputs: [], clobbers: [], volatile: true, alignstack: false, dialect: Att } : [] : []); // scope 4 at $DIR/unreachable_asm_2.rs:20:22: 20:39
           _8 = const ();                   // scope 4 at $DIR/unreachable_asm_2.rs:20:13: 20:41
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/unreachable_asm_2.rs:20:13: 20:41
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           StorageDead(_8);                 // scope 2 at $DIR/unreachable_asm_2.rs:20:40: 20:41
           _4 = const 42_i32;               // scope 2 at $DIR/unreachable_asm_2.rs:21:13: 21:20
           _5 = const ();                   // scope 2 at $DIR/unreachable_asm_2.rs:18:16: 22:10
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/unreachable_asm_2.rs:18:16: 22:10
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
 -         goto -> bb6;                     // scope 2 at $DIR/unreachable_asm_2.rs:14:9: 22:10
 +         unreachable;                     // scope 2 at $DIR/unreachable_asm_2.rs:14:9: 22:10
       }
@@ -85,21 +67,9 @@
           StorageLive(_7);                 // scope 2 at $DIR/unreachable_asm_2.rs:16:13: 16:41
           llvm_asm!(LlvmInlineAsmInner { asm: "NOP", asm_str_style: Cooked, outputs: [], inputs: [], clobbers: [], volatile: true, alignstack: false, dialect: Att } : [] : []); // scope 3 at $DIR/unreachable_asm_2.rs:16:22: 16:39
           _7 = const ();                   // scope 3 at $DIR/unreachable_asm_2.rs:16:13: 16:41
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/unreachable_asm_2.rs:16:13: 16:41
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           StorageDead(_7);                 // scope 2 at $DIR/unreachable_asm_2.rs:16:40: 16:41
           _4 = const 21_i32;               // scope 2 at $DIR/unreachable_asm_2.rs:17:13: 17:20
           _5 = const ();                   // scope 2 at $DIR/unreachable_asm_2.rs:14:17: 18:10
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/unreachable_asm_2.rs:14:17: 18:10
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
 -         goto -> bb6;                     // scope 2 at $DIR/unreachable_asm_2.rs:14:9: 22:10
 -     }
 - 

--- a/src/test/mir-opt/unreachable_diverging.main.UnreachablePropagation.diff
+++ b/src/test/mir-opt/unreachable_diverging.main.UnreachablePropagation.diff
@@ -34,12 +34,6 @@
   
       bb2: {
           _0 = const ();                   // scope 1 at $DIR/unreachable_diverging.rs:14:5: 19:6
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/unreachable_diverging.rs:14:5: 19:6
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           StorageDead(_1);                 // scope 0 at $DIR/unreachable_diverging.rs:20:1: 20:2
           StorageDead(_2);                 // scope 0 at $DIR/unreachable_diverging.rs:20:1: 20:2
           return;                          // scope 0 at $DIR/unreachable_diverging.rs:20:2: 20:2
@@ -57,19 +51,13 @@
   
       bb4: {
 -         _5 = const ();                   // scope 2 at $DIR/unreachable_diverging.rs:15:9: 17:10
--                                          // ty::Const
--                                          // + ty: ()
--                                          // + val: Value(Scalar(<ZST>))
-+         _5 = const loop_forever() -> bb5; // scope 2 at $DIR/unreachable_diverging.rs:16:13: 16:27
-                                           // mir::Constant
--                                          // + span: $DIR/unreachable_diverging.rs:15:9: 17:10
--                                          // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
 -         goto -> bb6;                     // scope 2 at $DIR/unreachable_diverging.rs:15:9: 17:10
 -     }
 - 
 -     bb5: {
 -         _5 = const loop_forever() -> bb6; // scope 2 at $DIR/unreachable_diverging.rs:16:13: 16:27
--                                          // mir::Constant
++         _5 = const loop_forever() -> bb5; // scope 2 at $DIR/unreachable_diverging.rs:16:13: 16:27
+                                           // mir::Constant
                                            // + span: $DIR/unreachable_diverging.rs:16:13: 16:25
                                            // + literal: Const { ty: fn() {loop_forever}, val: Value(Scalar(<ZST>)) }
       }

--- a/src/test/mir-opt/unreachable_diverging.main.UnreachablePropagation.diff
+++ b/src/test/mir-opt/unreachable_diverging.main.UnreachablePropagation.diff
@@ -22,9 +22,6 @@
           _1 = const true;                 // scope 0 at $DIR/unreachable_diverging.rs:13:13: 13:17
           StorageLive(_2);                 // scope 1 at $DIR/unreachable_diverging.rs:14:25: 14:32
           _2 = const empty() -> bb1;       // scope 1 at $DIR/unreachable_diverging.rs:14:25: 14:32
-                                           // ty::Const
-                                           // + ty: fn() -> std::option::Option<Empty> {empty}
-                                           // + val: Value(Scalar(<ZST>))
                                            // mir::Constant
                                            // + span: $DIR/unreachable_diverging.rs:14:25: 14:30
                                            // + literal: Const { ty: fn() -> std::option::Option<Empty> {empty}, val: Value(Scalar(<ZST>)) }
@@ -60,11 +57,11 @@
   
       bb4: {
 -         _5 = const ();                   // scope 2 at $DIR/unreachable_diverging.rs:15:9: 17:10
-+         _5 = const loop_forever() -> bb5; // scope 2 at $DIR/unreachable_diverging.rs:16:13: 16:27
-                                           // ty::Const
+-                                          // ty::Const
 -                                          // + ty: ()
 -                                          // + val: Value(Scalar(<ZST>))
--                                          // mir::Constant
++         _5 = const loop_forever() -> bb5; // scope 2 at $DIR/unreachable_diverging.rs:16:13: 16:27
+                                           // mir::Constant
 -                                          // + span: $DIR/unreachable_diverging.rs:15:9: 17:10
 -                                          // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
 -         goto -> bb6;                     // scope 2 at $DIR/unreachable_diverging.rs:15:9: 17:10
@@ -72,10 +69,7 @@
 - 
 -     bb5: {
 -         _5 = const loop_forever() -> bb6; // scope 2 at $DIR/unreachable_diverging.rs:16:13: 16:27
--                                          // ty::Const
-                                           // + ty: fn() {loop_forever}
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
+-                                          // mir::Constant
                                            // + span: $DIR/unreachable_diverging.rs:16:13: 16:25
                                            // + literal: Const { ty: fn() {loop_forever}, val: Value(Scalar(<ZST>)) }
       }

--- a/src/test/mir-opt/unusual_item_types.core.ptr-drop_in_place.std__vec__Vec_i32_.AddMovesForPackedDrops.before.mir.32bit
+++ b/src/test/mir-opt/unusual_item_types.core.ptr-drop_in_place.std__vec__Vec_i32_.AddMovesForPackedDrops.before.mir.32bit
@@ -36,9 +36,6 @@ fn std::intrinsics::drop_in_place(_1: *mut std::vec::Vec<i32>) -> () {
     bb7: {
         _2 = &mut (*_1);                 // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
         _3 = const <std::vec::Vec<i32> as std::ops::Drop>::drop(move _2) -> [return: bb6, unwind: bb5]; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-                                         // ty::Const
-                                         // + ty: for<'r> fn(&'r mut std::vec::Vec<i32>) {<std::vec::Vec<i32> as std::ops::Drop>::drop}
-                                         // + val: Value(Scalar(<ZST>))
                                          // mir::Constant
                                          // + span: $SRC_DIR/core/src/ptr/mod.rs:LL:COL
                                          // + literal: Const { ty: for<'r> fn(&'r mut std::vec::Vec<i32>) {<std::vec::Vec<i32> as std::ops::Drop>::drop}, val: Value(Scalar(<ZST>)) }

--- a/src/test/mir-opt/unusual_item_types.core.ptr-drop_in_place.std__vec__Vec_i32_.AddMovesForPackedDrops.before.mir.64bit
+++ b/src/test/mir-opt/unusual_item_types.core.ptr-drop_in_place.std__vec__Vec_i32_.AddMovesForPackedDrops.before.mir.64bit
@@ -36,9 +36,6 @@ fn std::intrinsics::drop_in_place(_1: *mut std::vec::Vec<i32>) -> () {
     bb7: {
         _2 = &mut (*_1);                 // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
         _3 = const <std::vec::Vec<i32> as std::ops::Drop>::drop(move _2) -> [return: bb6, unwind: bb5]; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-                                         // ty::Const
-                                         // + ty: for<'r> fn(&'r mut std::vec::Vec<i32>) {<std::vec::Vec<i32> as std::ops::Drop>::drop}
-                                         // + val: Value(Scalar(<ZST>))
                                          // mir::Constant
                                          // + span: $SRC_DIR/core/src/ptr/mod.rs:LL:COL
                                          // + literal: Const { ty: for<'r> fn(&'r mut std::vec::Vec<i32>) {<std::vec::Vec<i32> as std::ops::Drop>::drop}, val: Value(Scalar(<ZST>)) }

--- a/src/test/mir-opt/while_let_loops.change_loop_body.ConstProp.diff.32bit
+++ b/src/test/mir-opt/while_let_loops.change_loop_body.ConstProp.diff.32bit
@@ -26,12 +26,6 @@
   
       bb1: {
           _0 = const ();                   // scope 1 at $DIR/while_let_loops.rs:7:5: 10:6
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/while_let_loops.rs:7:5: 10:6
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           goto -> bb4;                     // scope 1 at $DIR/while_let_loops.rs:7:5: 10:6
       }
   
@@ -42,12 +36,6 @@
       bb3: {
           _1 = const 1_i32;                // scope 1 at $DIR/while_let_loops.rs:8:9: 8:15
           _0 = const ();                   // scope 1 at $DIR/while_let_loops.rs:9:9: 9:14
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/while_let_loops.rs:9:9: 9:14
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           goto -> bb4;                     // scope 1 at $DIR/while_let_loops.rs:9:9: 9:14
       }
   

--- a/src/test/mir-opt/while_let_loops.change_loop_body.ConstProp.diff.64bit
+++ b/src/test/mir-opt/while_let_loops.change_loop_body.ConstProp.diff.64bit
@@ -26,12 +26,6 @@
   
       bb1: {
           _0 = const ();                   // scope 1 at $DIR/while_let_loops.rs:7:5: 10:6
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/while_let_loops.rs:7:5: 10:6
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           goto -> bb4;                     // scope 1 at $DIR/while_let_loops.rs:7:5: 10:6
       }
   
@@ -42,12 +36,6 @@
       bb3: {
           _1 = const 1_i32;                // scope 1 at $DIR/while_let_loops.rs:8:9: 8:15
           _0 = const ();                   // scope 1 at $DIR/while_let_loops.rs:9:9: 9:14
-                                           // ty::Const
-                                           // + ty: ()
-                                           // + val: Value(Scalar(<ZST>))
-                                           // mir::Constant
-                                           // + span: $DIR/while_let_loops.rs:9:9: 9:14
-                                           // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
           goto -> bb4;                     // scope 1 at $DIR/while_let_loops.rs:9:9: 9:14
       }
   

--- a/src/test/mir-opt/while_let_loops.change_loop_body.PreCodegen.after.mir.32bit
+++ b/src/test/mir-opt/while_let_loops.change_loop_body.PreCodegen.after.mir.32bit
@@ -14,12 +14,6 @@ fn change_loop_body() -> () {
         StorageLive(_2);                 // scope 1 at $DIR/while_let_loops.rs:7:28: 7:32
         discriminant(_2) = 0;            // scope 1 at $DIR/while_let_loops.rs:7:28: 7:32
         _0 = const ();                   // scope 1 at $DIR/while_let_loops.rs:7:5: 10:6
-                                         // ty::Const
-                                         // + ty: ()
-                                         // + val: Value(Scalar(<ZST>))
-                                         // mir::Constant
-                                         // + span: $DIR/while_let_loops.rs:7:5: 10:6
-                                         // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
         StorageDead(_2);                 // scope 1 at $DIR/while_let_loops.rs:10:5: 10:6
         StorageDead(_1);                 // scope 0 at $DIR/while_let_loops.rs:11:1: 11:2
         return;                          // scope 0 at $DIR/while_let_loops.rs:11:2: 11:2

--- a/src/test/mir-opt/while_let_loops.change_loop_body.PreCodegen.after.mir.64bit
+++ b/src/test/mir-opt/while_let_loops.change_loop_body.PreCodegen.after.mir.64bit
@@ -14,12 +14,6 @@ fn change_loop_body() -> () {
         StorageLive(_2);                 // scope 1 at $DIR/while_let_loops.rs:7:28: 7:32
         discriminant(_2) = 0;            // scope 1 at $DIR/while_let_loops.rs:7:28: 7:32
         _0 = const ();                   // scope 1 at $DIR/while_let_loops.rs:7:5: 10:6
-                                         // ty::Const
-                                         // + ty: ()
-                                         // + val: Value(Scalar(<ZST>))
-                                         // mir::Constant
-                                         // + span: $DIR/while_let_loops.rs:7:5: 10:6
-                                         // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
         StorageDead(_2);                 // scope 1 at $DIR/while_let_loops.rs:10:5: 10:6
         StorageDead(_1);                 // scope 0 at $DIR/while_let_loops.rs:11:1: 11:2
         return;                          // scope 0 at $DIR/while_let_loops.rs:11:2: 11:2

--- a/src/test/mir-opt/while_storage.while_loop.PreCodegen.after.mir
+++ b/src/test/mir-opt/while_storage.while_loop.PreCodegen.after.mir
@@ -25,12 +25,6 @@ fn while_loop(_1: bool) -> () {
 
     bb2: {
         _0 = const ();                   // scope 0 at $DIR/while-storage.rs:10:5: 14:6
-                                         // ty::Const
-                                         // + ty: ()
-                                         // + val: Value(Scalar(<ZST>))
-                                         // mir::Constant
-                                         // + span: $DIR/while-storage.rs:10:5: 14:6
-                                         // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
         goto -> bb7;                     // scope 0 at $DIR/while-storage.rs:10:5: 14:6
     }
 
@@ -57,12 +51,6 @@ fn while_loop(_1: bool) -> () {
 
     bb6: {
         _0 = const ();                   // scope 0 at $DIR/while-storage.rs:12:13: 12:18
-                                         // ty::Const
-                                         // + ty: ()
-                                         // + val: Value(Scalar(<ZST>))
-                                         // mir::Constant
-                                         // + span: $DIR/while-storage.rs:12:13: 12:18
-                                         // + literal: Const { ty: (), val: Value(Scalar(<ZST>)) }
         StorageDead(_4);                 // scope 0 at $DIR/while-storage.rs:14:5: 14:6
         goto -> bb7;                     // scope 0 at $DIR/while-storage.rs:12:13: 12:18
     }

--- a/src/test/mir-opt/while_storage.while_loop.PreCodegen.after.mir
+++ b/src/test/mir-opt/while_storage.while_loop.PreCodegen.after.mir
@@ -13,9 +13,6 @@ fn while_loop(_1: bool) -> () {
         StorageLive(_3);                 // scope 0 at $DIR/while-storage.rs:10:20: 10:21
         _3 = _1;                         // scope 0 at $DIR/while-storage.rs:10:20: 10:21
         _2 = const get_bool(move _3) -> bb1; // scope 0 at $DIR/while-storage.rs:10:11: 10:22
-                                         // ty::Const
-                                         // + ty: fn(bool) -> bool {get_bool}
-                                         // + val: Value(Scalar(<ZST>))
                                          // mir::Constant
                                          // + span: $DIR/while-storage.rs:10:11: 10:19
                                          // + literal: Const { ty: fn(bool) -> bool {get_bool}, val: Value(Scalar(<ZST>)) }
@@ -42,9 +39,6 @@ fn while_loop(_1: bool) -> () {
         StorageLive(_5);                 // scope 0 at $DIR/while-storage.rs:11:21: 11:22
         _5 = _1;                         // scope 0 at $DIR/while-storage.rs:11:21: 11:22
         _4 = const get_bool(move _5) -> bb4; // scope 0 at $DIR/while-storage.rs:11:12: 11:23
-                                         // ty::Const
-                                         // + ty: fn(bool) -> bool {get_bool}
-                                         // + val: Value(Scalar(<ZST>))
                                          // mir::Constant
                                          // + span: $DIR/while-storage.rs:11:12: 11:20
                                          // + literal: Const { ty: fn(bool) -> bool {get_bool}, val: Value(Scalar(<ZST>)) }


### PR DESCRIPTION
An expansion of #75566.
Comments of FnDef MIR constant already contain `ty::Contains` comments.