### PR TITLE
Check against `local_cdata.cnum` instead of `LOCAL_CRATE` for hygiene decoding

### DIFF
--- a/src/librustc_metadata/rmeta/decoder.rs
+++ b/src/librustc_metadata/rmeta/decoder.rs
@@ -406,7 +406,7 @@ impl<'a, 'tcx> Decodable<DecodeContext<'a, 'tcx>> for ExpnId {
         let expn_cnum = Cell::new(None);
         let get_ctxt = |cnum| {
             expn_cnum.set(Some(cnum));
-            if cnum == LOCAL_CRATE {
+            if cnum == local_cdata.cnum {
                 &local_cdata.hygiene_context
             } else {
                 &local_cdata.cstore.get_crate_data(cnum).cdata.hygiene_context
@@ -420,7 +420,7 @@ impl<'a, 'tcx> Decodable<DecodeContext<'a, 'tcx>> for ExpnId {
                 let cnum = expn_cnum.get().unwrap();
                 // Lookup local `ExpnData`s in our own crate data. Foreign `ExpnData`s
                 // are stored in the owning crate, to avoid duplication.
-                let crate_data = if cnum == LOCAL_CRATE {
+                let crate_data = if cnum == local_cdata.cnum {
                     local_cdata
                 } else {
                     local_cdata.cstore.get_crate_data(cnum)


### PR DESCRIPTION
`LOCAL_CRATE` is the `CrateNum` of the current crate being compiled,
which will never be a crate that we are decoding metadata for.

This has no effect on the behavior of hygiene decoding, but allow us to
skip looking up a crate from the `CrateStore`