### PR TITLE
Switch to intra-doc links in /src/sys/unix/ext/*.rs

### DIFF
--- a/library/std/src/sys/unix/ext/fs.rs
+++ b/library/std/src/sys/unix/ext/fs.rs
@@ -9,9 +9,7 @@ use crate::sys;
 use crate::sys::platform::fs::MetadataExt as UnixMetadataExt;
 use crate::sys_common::{AsInner, AsInnerMut, FromInner};
 
-/// Unix-specific extensions to [`File`].
-///
-/// [`File`]: ../../../../std/fs/struct.File.html
+/// Unix-specific extensions to [`fs::File`].
 #[stable(feature = "file_offset", since = "1.15.0")]
 pub trait FileExt {
     /// Reads a number of bytes starting from a given offset.
@@ -55,19 +53,18 @@ pub trait FileExt {
     ///
     /// The current file cursor is not affected by this function.
     ///
-    /// Similar to [`Read::read_exact`] but uses [`read_at`] instead of `read`.
+    /// Similar to [`io::Read::read_exact`] but uses [`read_at`] instead of `read`.
     ///
-    /// [`Read::read_exact`]: ../../../../std/io/trait.Read.html#method.read_exact
-    /// [`read_at`]: #tymethod.read_at
+    /// [`read_at`]: FileExt::read_at
     ///
     /// # Errors
     ///
     /// If this function encounters an error of the kind
-    /// [`ErrorKind::Interrupted`] then the error is ignored and the operation
+    /// [`io::ErrorKind::Interrupted`] then the error is ignored and the operation
     /// will continue.
     ///
     /// If this function encounters an "end of file" before completely filling
-    /// the buffer, it returns an error of the kind [`ErrorKind::UnexpectedEof`].
+    /// the buffer, it returns an error of the kind [`io::ErrorKind::UnexpectedEof`].
     /// The contents of `buf` are unspecified in this case.
     ///
     /// If any other read error is encountered then this function immediately
@@ -76,9 +73,6 @@ pub trait FileExt {
     /// If this function returns an error, it is unspecified how many bytes it
     /// has read, but it will never read more than would be necessary to
     /// completely fill the buffer.
-    ///
-    /// [`ErrorKind::Interrupted`]: ../../../../std/io/enum.ErrorKind.html#variant.Interrupted
-    /// [`ErrorKind::UnexpectedEof`]: ../../../../std/io/enum.ErrorKind.html#variant.UnexpectedEof
     ///
     /// # Examples
     ///
@@ -161,19 +155,18 @@ pub trait FileExt {
     /// The current file cursor is not affected by this function.
     ///
     /// This method will continuously call [`write_at`] until there is no more data
-    /// to be written or an error of non-[`ErrorKind::Interrupted`] kind is
+    /// to be written or an error of non-[`io::ErrorKind::Interrupted`] kind is
     /// returned. This method will not return until the entire buffer has been
     /// successfully written or such an error occurs. The first error that is
-    /// not of [`ErrorKind::Interrupted`] kind generated from this method will be
+    /// not of [`io::ErrorKind::Interrupted`] kind generated from this method will be
     /// returned.
     ///
     /// # Errors
     ///
     /// This function will return the first error of
-    /// non-[`ErrorKind::Interrupted`] kind that [`write_at`] returns.
+    /// non-[`io::ErrorKind::Interrupted`] kind that [`write_at`] returns.
     ///
-    /// [`ErrorKind::Interrupted`]: ../../../../std/io/enum.ErrorKind.html#variant.Interrupted
-    /// [`write_at`]: #tymethod.write_at
+    /// [`write_at`]: FileExt::write_at
     ///
     /// # Examples
     ///
@@ -223,8 +216,6 @@ impl FileExt for fs::File {
 }
 
 /// Unix-specific extensions to [`fs::Permissions`].
-///
-/// [`fs::Permissions`]: ../../../../std/fs/struct.Permissions.html
 #[stable(feature = "fs_ext", since = "1.1.0")]
 pub trait PermissionsExt {
     /// Returns the underlying raw `st_mode` bits that contain the standard
@@ -302,8 +293,6 @@ impl PermissionsExt for Permissions {
 }
 
 /// Unix-specific extensions to [`fs::OpenOptions`].
-///
-/// [`fs::OpenOptions`]: ../../../../std/fs/struct.OpenOptions.html
 #[stable(feature = "fs_ext", since = "1.1.0")]
 pub trait OpenOptionsExt {
     /// Sets the mode bits that a new file will be created with.
@@ -372,8 +361,6 @@ impl OpenOptionsExt for OpenOptions {
 }
 
 /// Unix-specific extensions to [`fs::Metadata`].
-///
-/// [`fs::Metadata`]: ../../../../std/fs/struct.Metadata.html
 #[stable(feature = "metadata_ext", since = "1.1.0")]
 pub trait MetadataExt {
     /// Returns the ID of the device containing the file.
@@ -535,7 +522,7 @@ pub trait MetadataExt {
     fn atime(&self) -> i64;
     /// Returns the last access time of the file, in nanoseconds since [`atime`].
     ///
-    /// [`atime`]: #tymethod.atime
+    /// [`atime`]: MetadataExt::atime
     ///
     /// # Examples
     ///
@@ -571,7 +558,7 @@ pub trait MetadataExt {
     fn mtime(&self) -> i64;
     /// Returns the last modification time of the file, in nanoseconds since [`mtime`].
     ///
-    /// [`mtime`]: #tymethod.mtime
+    /// [`mtime`]: MetadataExt::mtime
     ///
     /// # Examples
     ///
@@ -607,7 +594,7 @@ pub trait MetadataExt {
     fn ctime(&self) -> i64;
     /// Returns the last status change time of the file, in nanoseconds since [`ctime`].
     ///
-    /// [`ctime`]: #tymethod.ctime
+    /// [`ctime`]: MetadataExt::ctime
     ///
     /// # Examples
     ///
@@ -714,12 +701,10 @@ impl MetadataExt for fs::Metadata {
     }
 }
 
-/// Unix-specific extensions for [`FileType`].
+/// Unix-specific extensions for [`fs::FileType`].
 ///
 /// Adds support for special Unix file types such as block/character devices,
 /// pipes, and sockets.
-///
-/// [`FileType`]: ../../../../std/fs/struct.FileType.html
 #[stable(feature = "file_type_ext", since = "1.5.0")]
 pub trait FileTypeExt {
     /// Returns `true` if this file type is a block device.
@@ -813,8 +798,6 @@ impl FileTypeExt for fs::FileType {
 }
 
 /// Unix-specific extension methods for [`fs::DirEntry`].
-///
-/// [`fs::DirEntry`]: ../../../../std/fs/struct.DirEntry.html
 #[stable(feature = "dir_entry_ext", since = "1.1.0")]
 pub trait DirEntryExt {
     /// Returns the underlying `d_ino` field in the contained `dirent`
@@ -875,8 +858,6 @@ pub fn symlink<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q) -> io::Result<()>
 }
 
 /// Unix-specific extensions to [`fs::DirBuilder`].
-///
-/// [`fs::DirBuilder`]: ../../../../std/fs/struct.DirBuilder.html
 #[stable(feature = "dir_builder", since = "1.6.0")]
 pub trait DirBuilderExt {
     /// Sets the mode to create new directories with. This option defaults to

--- a/library/std/src/sys/unix/ext/net.rs
+++ b/library/std/src/sys/unix/ext/net.rs
@@ -408,8 +408,6 @@ impl UnixStream {
     /// indefinitely. An [`Err`] is returned if the zero [`Duration`] is passed to this
     /// method.
     ///
-    /// [`None`]: crate::option::Option::None
-    /// [`Err`]: crate::result::Result::Err
     /// [`read`]: io::Read::read
     ///
     /// # Examples
@@ -452,8 +450,6 @@ impl UnixStream {
     /// indefinitely. An [`Err`] is returned if the zero [`Duration`] is
     /// passed to this method.
     ///
-    /// [`None`]: crate::option::Option::None
-    /// [`Err`]: crate::result::Result::Err
     /// [`read`]: io::Read::read
     ///
     /// # Examples
@@ -967,8 +963,6 @@ impl UnixListener {
     /// The iterator will never return [`None`] and will also not yield the
     /// peer's [`SocketAddr`] structure.
     ///
-    /// [`None`]: crate::option::Option::None
-    ///
     /// # Examples
     ///
     /// ```no_run
@@ -1035,8 +1029,6 @@ impl<'a> IntoIterator for &'a UnixListener {
 /// An iterator over incoming connections to a [`UnixListener`].
 ///
 /// It will never return [`None`].
-///
-/// [`None`]: crate::option::Option::None
 ///
 /// # Examples
 ///
@@ -1424,8 +1416,6 @@ impl UnixDatagram {
     /// block indefinitely. An [`Err`] is returned if the zero [`Duration`]
     /// is passed to this method.
     ///
-    /// [`None`]: crate::option::Option::None
-    /// [`Err`]: crate::result::Result::Err
     /// [`recv`]: UnixDatagram::recv
     /// [`recv_from`]: UnixDatagram::recv_from
     ///
@@ -1470,7 +1460,6 @@ impl UnixDatagram {
     /// block indefinitely. An [`Err`] is returned if the zero [`Duration`] is passed to this
     /// method.
     ///
-    /// [`None`]: crate::option::Option::None
     /// [`send`]: UnixDatagram::send
     /// [`send_to`]: UnixDatagram::send_to
     ///

--- a/library/std/src/sys/unix/ext/net.rs
+++ b/library/std/src/sys/unix/ext/net.rs
@@ -408,10 +408,9 @@ impl UnixStream {
     /// indefinitely. An [`Err`] is returned if the zero [`Duration`] is passed to this
     /// method.
     ///
-    /// [`None`]: ../../../../std/option/enum.Option.html#variant.None
-    /// [`Err`]: ../../../../std/result/enum.Result.html#variant.Err
-    /// [`read`]: ../../../../std/io/trait.Read.html#tymethod.read
-    /// [`Duration`]: ../../../../std/time/struct.Duration.html
+    /// [`None`]: crate::option::Option::None
+    /// [`Err`]: crate::result::Result::Err
+    /// [`read`]: io::Read::read
     ///
     /// # Examples
     ///
@@ -453,10 +452,9 @@ impl UnixStream {
     /// indefinitely. An [`Err`] is returned if the zero [`Duration`] is
     /// passed to this method.
     ///
-    /// [`None`]: ../../../../std/option/enum.Option.html#variant.None
-    /// [`Err`]: ../../../../std/result/enum.Result.html#variant.Err
-    /// [`write`]: ../../../../std/io/trait.Write.html#tymethod.write
-    /// [`Duration`]: ../../../../std/time/struct.Duration.html
+    /// [`None`]: crate::option::Option::None
+    /// [`Err`]: crate::result::Result::Err
+    /// [`read`]: io::Read::read
     ///
     /// # Examples
     ///
@@ -580,8 +578,6 @@ impl UnixStream {
     /// This function will cause all pending and future I/O calls on the
     /// specified portions to immediately return with an appropriate value
     /// (see the documentation of [`Shutdown`]).
-    ///
-    /// [`Shutdown`]: ../../../../std/net/enum.Shutdown.html
     ///
     /// # Examples
     ///
@@ -852,7 +848,7 @@ impl UnixListener {
     /// is established. When established, the corresponding [`UnixStream`] and
     /// the remote peer's address will be returned.
     ///
-    /// [`UnixStream`]: ../../../../std/os/unix/net/struct.UnixStream.html
+    /// [`UnixStream`]: crate::os::unix::net::UnixStream
     ///
     /// # Examples
     ///
@@ -937,8 +933,6 @@ impl UnixListener {
     ///     Ok(())
     /// }
     /// ```
-    ///
-    /// [`io::ErrorKind::WouldBlock`]: ../../../io/enum.ErrorKind.html#variant.WouldBlock
     #[stable(feature = "unix_socket", since = "1.10.0")]
     pub fn set_nonblocking(&self, nonblocking: bool) -> io::Result<()> {
         self.0.set_nonblocking(nonblocking)
@@ -973,8 +967,7 @@ impl UnixListener {
     /// The iterator will never return [`None`] and will also not yield the
     /// peer's [`SocketAddr`] structure.
     ///
-    /// [`None`]: ../../../../std/option/enum.Option.html#variant.None
-    /// [`SocketAddr`]: struct.SocketAddr.html
+    /// [`None`]: crate::option::Option::None
     ///
     /// # Examples
     ///
@@ -1043,8 +1036,7 @@ impl<'a> IntoIterator for &'a UnixListener {
 ///
 /// It will never return [`None`].
 ///
-/// [`None`]: ../../../../std/option/enum.Option.html#variant.None
-/// [`UnixListener`]: struct.UnixListener.html
+/// [`None`]: crate::option::Option::None
 ///
 /// # Examples
 ///
@@ -1205,9 +1197,9 @@ impl UnixDatagram {
     /// The [`send`] method may be used to send data to the specified address.
     /// [`recv`] and [`recv_from`] will only receive data from that address.
     ///
-    /// [`send`]: #method.send
-    /// [`recv`]: #method.recv
-    /// [`recv_from`]: #method.recv_from
+    /// [`send`]: UnixDatagram::send
+    /// [`recv`]: UnixDatagram::recv
+    /// [`recv_from`]: UnixDatagram::recv_from
     ///
     /// # Examples
     ///
@@ -1284,7 +1276,7 @@ impl UnixDatagram {
     ///
     /// The [`connect`] method will connect the socket to a peer.
     ///
-    /// [`connect`]: #method.connect
+    /// [`connect`]: UnixDatagram::connect
     ///
     /// # Examples
     ///
@@ -1432,11 +1424,10 @@ impl UnixDatagram {
     /// block indefinitely. An [`Err`] is returned if the zero [`Duration`]
     /// is passed to this method.
     ///
-    /// [`None`]: ../../../../std/option/enum.Option.html#variant.None
-    /// [`Err`]: ../../../../std/result/enum.Result.html#variant.Err
-    /// [`recv`]: #method.recv
-    /// [`recv_from`]: #method.recv_from
-    /// [`Duration`]: ../../../../std/time/struct.Duration.html
+    /// [`None`]: crate::option::Option::None
+    /// [`Err`]: crate::result::Result::Err
+    /// [`recv`]: UnixDatagram::recv
+    /// [`recv_from`]: UnixDatagram::recv_from
     ///
     /// # Examples
     ///
@@ -1479,10 +1470,9 @@ impl UnixDatagram {
     /// block indefinitely. An [`Err`] is returned if the zero [`Duration`] is passed to this
     /// method.
     ///
-    /// [`None`]: ../../../../std/option/enum.Option.html#variant.None
-    /// [`send`]: #method.send
-    /// [`send_to`]: #method.send_to
-    /// [`Duration`]: ../../../../std/time/struct.Duration.html
+    /// [`None`]: crate::option::Option::None
+    /// [`send`]: UnixDatagram::send
+    /// [`send_to`]: UnixDatagram::send_to
     ///
     /// # Examples
     ///
@@ -1604,8 +1594,6 @@ impl UnixDatagram {
     /// This function will cause all pending and future I/O calls on the
     /// specified portions to immediately return with an appropriate value
     /// (see the documentation of [`Shutdown`]).
-    ///
-    /// [`Shutdown`]: ../../../../std/net/enum.Shutdown.html
     ///
     /// ```no_run
     /// use std::os::unix::net::UnixDatagram;

--- a/library/std/src/sys/unix/ext/process.rs
+++ b/library/std/src/sys/unix/ext/process.rs
@@ -10,8 +10,6 @@ use crate::sys;
 use crate::sys_common::{AsInner, AsInnerMut, FromInner, IntoInner};
 
 /// Unix-specific extensions to the [`process::Command`] builder.
-///
-/// [`process::Command`]: ../../../../std/process/struct.Command.html
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait CommandExt {
     /// Sets the child process's user ID. This translates to a
@@ -65,7 +63,7 @@ pub trait CommandExt {
     /// This method is stable and usable, but it should be unsafe. To fix
     /// that, it got deprecated in favor of the unsafe [`pre_exec`].
     ///
-    /// [`pre_exec`]: #tymethod.pre_exec
+    /// [`pre_exec`]: CommandExt::pre_exec
     #[stable(feature = "process_exec", since = "1.15.0")]
     #[rustc_deprecated(since = "1.37.0", reason = "should be unsafe, use `pre_exec` instead")]
     fn before_exec<F>(&mut self, f: F) -> &mut process::Command
@@ -93,8 +91,6 @@ pub trait CommandExt {
     /// This function, unlike `spawn`, will **not** `fork` the process to create
     /// a new child. Like spawn, however, the default behavior for the stdio
     /// descriptors will be to inherited from the current process.
-    ///
-    /// [`process::exit`]: ../../../process/fn.exit.html
     ///
     /// # Notes
     ///
@@ -151,8 +147,6 @@ impl CommandExt for process::Command {
 }
 
 /// Unix-specific extensions to [`process::ExitStatus`].
-///
-/// [`process::ExitStatus`]: ../../../../std/process/struct.ExitStatus.html
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait ExitStatusExt {
     /// Creates a new `ExitStatus` from the raw underlying `i32` return value of

--- a/library/std/src/sys/unix/ext/thread.rs
+++ b/library/std/src/sys/unix/ext/thread.rs
@@ -11,9 +11,7 @@ use crate::thread::JoinHandle;
 #[allow(deprecated)]
 pub type RawPthread = pthread_t;
 
-/// Unix-specific extensions to [`thread::JoinHandle`].
-///
-/// [`thread::JoinHandle`]: ../../../../std/thread/struct.JoinHandle.html
+/// Unix-specific extensions to [`JoinHandle`].
 #[stable(feature = "thread_extensions", since = "1.9.0")]
 pub trait JoinHandleExt {
     /// Extracts the raw pthread_t without taking ownership


### PR DESCRIPTION
Partial fix for #75080

@rustbot modify labels: T-doc, A-intra-doc-links, T-rustdoc

r? @jyn514

These two links are not resolving to either `crate::fs::File...` or `fs::File...`
```
# unix/ext/fs.rs
   27:    /// [`File::read`]: ../../../../std/fs/struct.File.html#method.read

  130:   /// [`File::write`]: ../../../../std/fs/struct.File.html#method.write
```