### PR TITLE
Do not emit `{{root}}` in diagnostics

### DIFF
--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -2319,8 +2319,15 @@ impl<'a> Resolver<'a> {
                     } else if i == 0 {
                         (format!("use of undeclared type or module `{}`", ident), None)
                     } else {
-                        let mut msg =
-                            format!("could not find `{}` in `{}`", ident, path[i - 1].ident);
+                        // Do not emit `PathRoot`(`{{root}}`) as it's unclear.
+                        let ident_str;
+                        let ident_name = if path[i - 1].ident.name == kw::PathRoot {
+                            "the crate root"
+                        } else {
+                            ident_str = format!("`{}`", path[i - 1].ident);
+                            &ident_str
+                        };
+                        let mut msg = format!("could not find `{}` in {}", ident, ident_name);
                         if ns == TypeNS || ns == ValueNS {
                             let ns_to_try = if ns == TypeNS { ValueNS } else { TypeNS };
                             if let FindBindingResult::Binding(Ok(binding)) =
@@ -2328,11 +2335,11 @@ impl<'a> Resolver<'a> {
                             {
                                 let mut found = |what| {
                                     msg = format!(
-                                        "expected {}, found {} `{}` in `{}`",
+                                        "expected {}, found {} `{}` in {}",
                                         ns.descr(),
                                         what,
                                         ident,
-                                        path[i - 1].ident
+                                        ident_name
                                     )
                                 };
                                 if binding.module().is_some() {

--- a/src/test/ui/editions/edition-imports-virtual-2015-gated.stderr
+++ b/src/test/ui/editions/edition-imports-virtual-2015-gated.stderr
@@ -2,7 +2,7 @@ error[E0432]: unresolved import `E`
   --> $DIR/edition-imports-virtual-2015-gated.rs:8:5
    |
 LL |     gen_gated!();
-   |     ^^^^^^^^^^^^^ could not find `E` in `{{root}}`
+   |     ^^^^^^^^^^^^^ could not find `E` in the crate root
    |
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/rfc-2126-extern-absolute-paths/non-existent-2.rs
+++ b/src/test/ui/rfc-2126-extern-absolute-paths/non-existent-2.rs
@@ -2,5 +2,5 @@
 
 fn main() {
     let s = ::xcrate::S;
-    //~^ ERROR failed to resolve: could not find `xcrate` in `{{root}}`
+    //~^ ERROR failed to resolve: could not find `xcrate` in the crate root
 }

--- a/src/test/ui/rfc-2126-extern-absolute-paths/non-existent-2.stderr
+++ b/src/test/ui/rfc-2126-extern-absolute-paths/non-existent-2.stderr
@@ -1,8 +1,8 @@
-error[E0433]: failed to resolve: could not find `xcrate` in `{{root}}`
+error[E0433]: failed to resolve: could not find `xcrate` in the crate root
   --> $DIR/non-existent-2.rs:4:15
    |
 LL |     let s = ::xcrate::S;
-   |               ^^^^^^ could not find `xcrate` in `{{root}}`
+   |               ^^^^^^ could not find `xcrate` in the crate root
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Fixes #46577
