### PR TITLE
enable align_to tests in Miri

### DIFF
--- a/library/core/tests/ascii.rs
+++ b/library/core/tests/ascii.rs
@@ -361,10 +361,8 @@ fn test_is_ascii_align_size_thoroughly() {
         repeat(b0).take(l).chain(repeat(b1).take(l)).collect()
     }
 
-    // Miri is too slow for much of this, and in miri `align_offset` always
-    // returns `usize::max_value()` anyway (at the moment), so we just test
-    // lightly.
-    let iter = if cfg!(miri) { 0..5 } else { 0..100 };
+    // Miri is too slow
+    let iter = if cfg!(miri) { 0..20 } else { 0..100 };
 
     for i in iter {
         #[cfg(not(miri))]
@@ -379,7 +377,7 @@ fn test_is_ascii_align_size_thoroughly() {
         ];
 
         #[cfg(miri)]
-        let cases = &[repeat_concat(b'a', 0x80u8, i)];
+        let cases = &[b"a".repeat(i), b"\x80".repeat(i), repeat_concat(b'a', 0x80u8, i)];
 
         for case in cases {
             for pos in 0..=case.len() {

--- a/library/core/tests/ptr.rs
+++ b/library/core/tests/ptr.rs
@@ -300,7 +300,6 @@ fn write_unaligned_drop() {
 }
 
 #[test]
-#[cfg_attr(miri, ignore)] // Miri does not compute a maximal `mid` for `align_offset`
 fn align_offset_zst() {
     // For pointers of stride = 0, the pointer is already aligned or it cannot be aligned at
     // all, because no amount of elements will align the pointer.
@@ -315,7 +314,6 @@ fn align_offset_zst() {
 }
 
 #[test]
-#[cfg_attr(miri, ignore)] // Miri does not compute a maximal `mid` for `align_offset`
 fn align_offset_stride1() {
     // For pointers of stride = 1, the pointer can always be aligned. The offset is equal to
     // number of bytes.
@@ -337,7 +335,6 @@ fn align_offset_stride1() {
 }
 
 #[test]
-#[cfg_attr(miri, ignore)] // Miri is too slow
 fn align_offset_weird_strides() {
     #[repr(packed)]
     struct A3(u16, u8);
@@ -384,7 +381,9 @@ fn align_offset_weird_strides() {
     // implementation
     let mut align = 1;
     let mut x = false;
-    while align < 1024 {
+    // Miri is too slow
+    let limit = if cfg!(miri) { 32 } else { 1024 };
+    while align < limit {
         for ptr in 1usize..4 * align {
             unsafe {
                 x |= test_weird_stride::<A3>(ptr as *const A3, align);

--- a/library/core/tests/slice.rs
+++ b/library/core/tests/slice.rs
@@ -1630,7 +1630,6 @@ pub mod memchr {
 }
 
 #[test]
-#[cfg_attr(miri, ignore)] // Miri does not compute a maximal `mid` for `align_offset`
 fn test_align_to_simple() {
     let bytes = [1u8, 2, 3, 4, 5, 6, 7];
     let (prefix, aligned, suffix) = unsafe { bytes.align_to::<u16>() };
@@ -1660,7 +1659,6 @@ fn test_align_to_zst() {
 }
 
 #[test]
-#[cfg_attr(miri, ignore)] // Miri does not compute a maximal `mid` for `align_offset`
 fn test_align_to_non_trivial() {
     #[repr(align(8))]
     struct U64(u64, u64);


### PR DESCRIPTION
With https://github.com/rust-lang/miri/issues/1074 resolved, we can enable these tests in Miri.

I also tweaked the test sized to get reasonable execution times with decent test coverage.