### PR TITLE
Add a regression test for issue-72793

### DIFF
--- a/src/test/ui/type-alias-impl-trait/issue-72793.rs
+++ b/src/test/ui/type-alias-impl-trait/issue-72793.rs
@@ -1,0 +1,27 @@
+// build-pass
+
+// Regression test for #72793.
+// FIXME: This still shows ICE with `-Zmir-opt-level=2`.
+
+#![feature(type_alias_impl_trait)]
+
+trait T { type Item; }
+
+type Alias<'a> = impl T<Item = &'a ()>;
+
+struct S;
+impl<'a> T for &'a S {
+    type Item = &'a ();
+}
+
+fn filter_positive<'a>() -> Alias<'a> {
+    &S
+}
+
+fn with_positive(fun: impl Fn(Alias<'_>)) {
+    fun(filter_positive());
+}
+
+fn main() {
+    with_positive(|_| ());
+}


### PR DESCRIPTION
Adds a regression test for #72793, which is fixed by #75443. Note that this won't close the issue as the snippet still shows ICE with `-Zmir-opt-level=2`. But it makes sense to add a test anyway.