### PR TITLE
Remove `#[cfg(miri)]` from OnceCell tests

### DIFF
--- a/library/std/src/lazy.rs
+++ b/library/std/src/lazy.rs
@@ -516,6 +516,7 @@ mod tests {
             mpsc::channel,
             Mutex,
         },
+        thread,
     };
 
     #[test]
@@ -552,26 +553,8 @@ mod tests {
         }
     }
 
-    // miri doesn't support threads
-    #[cfg(not(miri))]
     fn spawn_and_wait<R: Send + 'static>(f: impl FnOnce() -> R + Send + 'static) -> R {
-        crate::thread::spawn(f).join().unwrap()
-    }
-
-    #[cfg(not(miri))]
-    fn spawn(f: impl FnOnce() + Send + 'static) {
-        let _ = crate::thread::spawn(f);
-    }
-
-    // "stub threads" for Miri
-    #[cfg(miri)]
-    fn spawn_and_wait<R: Send + 'static>(f: impl FnOnce() -> R + Send + 'static) -> R {
-        f(())
-    }
-
-    #[cfg(miri)]
-    fn spawn(f: impl FnOnce() + Send + 'static) {
-        f(())
+        thread::spawn(f).join().unwrap()
     }
 
     #[test]
@@ -734,7 +717,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)] // leaks memory
     fn static_sync_lazy() {
         static XS: SyncLazy<Vec<i32>> = SyncLazy::new(|| {
             let mut xs = Vec::new();
@@ -752,7 +734,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)] // leaks memory
     fn static_sync_lazy_via_fn() {
         fn xs() -> &'static Vec<i32> {
             static XS: SyncOnceCell<Vec<i32>> = SyncOnceCell::new();
@@ -811,7 +792,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)] // deadlocks without real threads
     fn sync_once_cell_does_not_leak_partially_constructed_boxes() {
         static ONCE_CELL: SyncOnceCell<String> = SyncOnceCell::new();
 
@@ -823,7 +803,7 @@ mod tests {
 
         for _ in 0..n_readers {
             let tx = tx.clone();
-            spawn(move || {
+            thread::spawn(move || {
                 loop {
                     if let Some(msg) = ONCE_CELL.get() {
                         tx.send(msg).unwrap();
@@ -835,7 +815,7 @@ mod tests {
             });
         }
         for _ in 0..n_writers {
-            spawn(move || {
+            thread::spawn(move || {
                 let _ = ONCE_CELL.set(MSG.to_owned());
             });
         }


### PR DESCRIPTION
They were carried over from once_cell crate, but they are not entirely
correct (as miri now supports more things), and we don't run miri
tests for std, so let's just remove them.

Maybe one day we'll run miri in std, but then we can just re-install
these attributes.