### PR TITLE
Move to intra-doc links for /library/core/src/intrinsics.rs

### DIFF
--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -823,7 +823,7 @@ extern "rust-intrinsic" {
     /// An atomic fence.
     ///
     /// The stabilized version of this intrinsic is available in
-    /// [`std::sync::atomic::fence`](../../std/sync/atomic/fn.fence.html)
+    /// [`std::sync::atomic::fence`](crate::sync::atomic::fence)
     /// by passing
     /// [`Ordering::SeqCst`](crate::sync::atomic::Ordering::SeqCst)
     /// as the `order`.
@@ -831,7 +831,7 @@ extern "rust-intrinsic" {
     /// An atomic fence.
     ///
     /// The stabilized version of this intrinsic is available in
-    /// [`std::sync::atomic::fence`](../../std/sync/atomic/fn.fence.html)
+    /// [`std::sync::atomic::fence`](crate::sync::atomic::fence)
     /// by passing
     /// [`Ordering::Acquire`](crate::sync::atomic::Ordering::Acquire)
     /// as the `order`.
@@ -839,7 +839,7 @@ extern "rust-intrinsic" {
     /// An atomic fence.
     ///
     /// The stabilized version of this intrinsic is available in
-    /// [`std::sync::atomic::fence`](../../std/sync/atomic/fn.fence.html)
+    /// [`std::sync::atomic::fence`](crate::sync::atomic::fence)
     /// by passing
     /// [`Ordering::Release`](crate::sync::atomic::Ordering::Release)
     /// as the `order`.
@@ -847,7 +847,7 @@ extern "rust-intrinsic" {
     /// An atomic fence.
     ///
     /// The stabilized version of this intrinsic is available in
-    /// [`std::sync::atomic::fence`](../../std/sync/atomic/fn.fence.html)
+    /// [`std::sync::atomic::fence`](crate::sync::atomic::fence)
     /// by passing
     /// [`Ordering::AcqRel`](crate::sync::atomic::Ordering::AcqRel)
     /// as the `order`.
@@ -861,7 +861,7 @@ extern "rust-intrinsic" {
     /// such as when interacting with signal handlers.
     ///
     /// The stabilized version of this intrinsic is available in
-    /// [`std::sync::atomic::compiler_fence`](../../std/sync/atomic/fn.compiler_fence.html)
+    /// [`std::sync::atomic::compiler_fence`](crate::sync::atomic::compiler_fence)
     /// by passing
     /// [`Ordering::SeqCst`](crate::sync::atomic::Ordering::SeqCst)
     /// as the `order`.
@@ -874,7 +874,7 @@ extern "rust-intrinsic" {
     /// such as when interacting with signal handlers.
     ///
     /// The stabilized version of this intrinsic is available in
-    /// [`std::sync::atomic::compiler_fence`](../../std/sync/atomic/fn.compiler_fence.html)
+    /// [`std::sync::atomic::compiler_fence`](crate::sync::atomic::compiler_fence)
     /// by passing
     /// [`Ordering::Acquire`](crate::sync::atomic::Ordering::Acquire)
     /// as the `order`.
@@ -887,7 +887,7 @@ extern "rust-intrinsic" {
     /// such as when interacting with signal handlers.
     ///
     /// The stabilized version of this intrinsic is available in
-    /// [`std::sync::atomic::compiler_fence`](../../std/sync/atomic/fn.compiler_fence.html)
+    /// [`std::sync::atomic::compiler_fence`](crate::sync::atomic::compiler_fence)
     /// by passing
     /// [`Ordering::Release`](crate::sync::atomic::Ordering::Release)
     /// as the `order`.
@@ -900,7 +900,7 @@ extern "rust-intrinsic" {
     /// such as when interacting with signal handlers.
     ///
     /// The stabilized version of this intrinsic is available in
-    /// [`std::sync::atomic::compiler_fence`](../../std/sync/atomic/fn.compiler_fence.html)
+    /// [`std::sync::atomic::compiler_fence`](crate::sync::atomic::compiler_fence)
     /// by passing
     /// [`Ordering::AcqRel`](crate::sync::atomic::Ordering::AcqRel)
     /// as the `order`.

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -976,7 +976,7 @@ extern "rust-intrinsic" {
     /// items of the same type, including alignment padding.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::mem::size_of`](../../std/mem/fn.size_of.html).
+    /// [`std::mem::size_of`](crate::mem::size_of).
     #[rustc_const_stable(feature = "const_size_of", since = "1.40.0")]
     pub fn size_of<T>() -> usize;
 
@@ -991,7 +991,7 @@ extern "rust-intrinsic" {
     /// The minimum alignment of a type.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::mem::align_of`](../../std/mem/fn.align_of.html).
+    /// [`std::mem::align_of`](crate::mem::align_of).
     #[rustc_const_stable(feature = "const_min_align_of", since = "1.40.0")]
     pub fn min_align_of<T>() -> usize;
     /// The preferred alignment of a type.
@@ -1003,13 +1003,13 @@ extern "rust-intrinsic" {
     /// The size of the referenced value in bytes.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::mem::size_of_val`](../../std/mem/fn.size_of_val.html).
+    /// [`std::mem::size_of_val`](crate::mem::size_of_val).
     #[rustc_const_unstable(feature = "const_size_of_val", issue = "46571")]
     pub fn size_of_val<T: ?Sized>(_: *const T) -> usize;
     /// The required alignment of the referenced value.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::mem::align_of_val`](../../std/mem/fn.align_of_val.html).
+    /// [`std::mem::align_of_val`](crate::mem::align_of_val).
     #[rustc_const_unstable(feature = "const_align_of_val", issue = "46571")]
     pub fn min_align_of_val<T: ?Sized>(_: *const T) -> usize;
 
@@ -1301,7 +1301,7 @@ extern "rust-intrinsic" {
     /// `Copy`, then the return value of this function is unspecified.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::mem::needs_drop`](../../std/mem/fn.needs_drop.html).
+    /// [`std::mem::needs_drop`](crate::mem::needs_drop).
     #[rustc_const_stable(feature = "const_needs_drop", since = "1.40.0")]
     pub fn needs_drop<T>() -> bool;
 
@@ -1920,7 +1920,7 @@ extern "rust-intrinsic" {
     /// cast to a `u64`; if `T` has no discriminant, returns 0.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::mem::discriminant`](../../std/mem/fn.discriminant.html)
+    /// [`std::mem::discriminant`](crate::mem::discriminant)
     #[rustc_const_unstable(feature = "const_discriminant", issue = "69821")]
     pub fn discriminant_value<T>(v: &T) -> <T as DiscriminantKind>::Discriminant;
 
@@ -1928,7 +1928,7 @@ extern "rust-intrinsic" {
     /// if `T` has no variants, returns 0. Uninhabited variants will be counted.
     ///
     /// The to-be-stabilized version of this intrinsic is
-    /// [`std::mem::variant_count`](../../std/mem/fn.variant_count.html)
+    /// [`std::mem::variant_count`](crate::mem::variant_count)
     #[rustc_const_unstable(feature = "variant_count", issue = "73662")]
     pub fn variant_count<T>() -> usize;
 

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -931,7 +931,7 @@ extern "rust-intrinsic" {
     /// reach code marked with this function.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::hint::unreachable_unchecked`](../../std/hint/fn.unreachable_unchecked.html).
+    /// [`std::hint::unreachable_unchecked`](crate::hint::unreachable_unchecked).
     #[rustc_const_unstable(feature = "const_unreachable_unchecked", issue = "53188")]
     pub fn unreachable() -> !;
 
@@ -1016,7 +1016,7 @@ extern "rust-intrinsic" {
     /// Gets a static string slice containing the name of a type.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::any::type_name`](../../std/any/fn.type_name.html)
+    /// [`std::any::type_name`](crate::any::type_name)
     #[rustc_const_unstable(feature = "const_type_name", issue = "63084")]
     pub fn type_name<T: ?Sized>() -> &'static str;
 
@@ -1025,7 +1025,7 @@ extern "rust-intrinsic" {
     /// crate it is invoked in.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::any::TypeId::of`](../../std/any/struct.TypeId.html#method.of)
+    /// [`std::any::TypeId::of`](crate::any::TypeId::of)
     #[rustc_const_stable(feature = "const_type_id", since = "1.46.0")]
     pub fn type_id<T: ?Sized + 'static>() -> u64;
 
@@ -1049,7 +1049,7 @@ extern "rust-intrinsic" {
 
     /// Gets a reference to a static `Location` indicating where it was called.
     ///
-    /// Consider using [`std::panic::Location::caller`](../../std/panic/struct.Location.html#method.caller)
+    /// Consider using [`std::panic::Location::caller`](crate::panic::Location::caller)
     /// instead.
     #[rustc_const_unstable(feature = "const_caller_location", issue = "47809")]
     pub fn caller_location() -> &'static crate::panic::Location<'static>;
@@ -2053,7 +2053,6 @@ pub(crate) fn is_nonoverlapping<T>(src: *const T, dst: *const T, count: usize) -
 /// `copy_nonoverlapping` is semantically equivalent to C's [`memcpy`], but
 /// with the argument order swapped.
 ///
-/// [`copy`]: ./fn.copy.html
 /// [`memcpy`]: https://en.cppreference.com/w/c/string/byte/memcpy
 ///
 /// # Safety
@@ -2078,8 +2077,8 @@ pub(crate) fn is_nonoverlapping<T>(src: *const T, dst: *const T, count: usize) -
 /// Note that even if the effectively copied size (`count * size_of::<T>()`) is
 /// `0`, the pointers must be non-NULL and properly aligned.
 ///
-/// [`Copy`]: ../marker/trait.Copy.html
-/// [`read`]: ../ptr/fn.read.html
+/// [`Copy`]: crate::marker::Copy
+/// [`read`]: crate::ptr::read
 /// [read-ownership]: ../ptr/fn.read.html#ownership-of-the-returned-value
 /// [valid]: ../ptr/index.html#safety
 ///
@@ -2160,7 +2159,6 @@ pub unsafe fn copy_nonoverlapping<T>(src: *const T, dst: *mut T, count: usize) {
 /// order swapped. Copying takes place as if the bytes were copied from `src`
 /// to a temporary array and then copied from the array to `dst`.
 ///
-/// [`copy_nonoverlapping`]: ./fn.copy_nonoverlapping.html
 /// [`memmove`]: https://en.cppreference.com/w/c/string/byte/memmove
 ///
 /// # Safety
@@ -2181,8 +2179,8 @@ pub unsafe fn copy_nonoverlapping<T>(src: *const T, dst: *mut T, count: usize) {
 /// Note that even if the effectively copied size (`count * size_of::<T>()`) is
 /// `0`, the pointers must be non-NULL and properly aligned.
 ///
-/// [`Copy`]: ../marker/trait.Copy.html
-/// [`read`]: ../ptr/fn.read.html
+/// [`Copy`]: crate::marker::Copy
+/// [`read`]: crate::ptr::read
 /// [read-ownership]: ../ptr/fn.read.html#ownership-of-the-returned-value
 /// [valid]: ../ptr/index.html#safety
 ///

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -701,7 +701,7 @@ extern "rust-intrinsic" {
     /// `std::sync::atomic` unsigned integer types via the `fetch_min` method by passing
     /// [`Ordering::SeqCst`](crate::sync::atomic::Ordering::SeqCst)
     /// as the `order`. For example,
-    /// [`AtomicU32::fetch_min`](../../std/sync/atomic/struct.AtomicU32.html#method.fetch_min).
+    /// [`AtomicU32::fetch_min`](crate::sync::atomic::AtomicU32::fetch_min).
     pub fn atomic_umin<T: Copy>(dst: *mut T, src: T) -> T;
     /// Minimum with the current value using an unsigned comparison.
     ///
@@ -709,7 +709,7 @@ extern "rust-intrinsic" {
     /// `std::sync::atomic` unsigned integer types via the `fetch_min` method by passing
     /// [`Ordering::Acquire`](crate::sync::atomic::Ordering::Acquire)
     /// as the `order`. For example,
-    /// [`AtomicU32::fetch_min`](../../std/sync/atomic/struct.AtomicU32.html#method.fetch_min).
+    /// [`AtomicU32::fetch_min`](crate::sync::atomic::AtomicU32::fetch_min).
     pub fn atomic_umin_acq<T: Copy>(dst: *mut T, src: T) -> T;
     /// Minimum with the current value using an unsigned comparison.
     ///
@@ -717,7 +717,7 @@ extern "rust-intrinsic" {
     /// `std::sync::atomic` unsigned integer types via the `fetch_min` method by passing
     /// [`Ordering::Release`](crate::sync::atomic::Ordering::Release)
     /// as the `order`. For example,
-    /// [`AtomicU32::fetch_min`](../../std/sync/atomic/struct.AtomicU32.html#method.fetch_min).
+    /// [`AtomicU32::fetch_min`](crate::sync::atomic::AtomicU32::fetch_min).
     pub fn atomic_umin_rel<T: Copy>(dst: *mut T, src: T) -> T;
     /// Minimum with the current value using an unsigned comparison.
     ///
@@ -725,7 +725,7 @@ extern "rust-intrinsic" {
     /// `std::sync::atomic` unsigned integer types via the `fetch_min` method by passing
     /// [`Ordering::AcqRel`](crate::sync::atomic::Ordering::AcqRel)
     /// as the `order`. For example,
-    /// [`AtomicU32::fetch_min`](../../std/sync/atomic/struct.AtomicU32.html#method.fetch_min).
+    /// [`AtomicU32::fetch_min`](crate::sync::atomic::AtomicU32::fetch_min).
     pub fn atomic_umin_acqrel<T: Copy>(dst: *mut T, src: T) -> T;
     /// Minimum with the current value using an unsigned comparison.
     ///
@@ -733,7 +733,7 @@ extern "rust-intrinsic" {
     /// `std::sync::atomic` unsigned integer types via the `fetch_min` method by passing
     /// [`Ordering::Relaxed`](crate::sync::atomic::Ordering::Relaxed)
     /// as the `order`. For example,
-    /// [`AtomicU32::fetch_min`](../../std/sync/atomic/struct.AtomicU32.html#method.fetch_min).
+    /// [`AtomicU32::fetch_min`](crate::sync::atomic::AtomicU32::fetch_min).
     pub fn atomic_umin_relaxed<T: Copy>(dst: *mut T, src: T) -> T;
 
     /// Maximum with the current value using an unsigned comparison.
@@ -742,7 +742,7 @@ extern "rust-intrinsic" {
     /// `std::sync::atomic` unsigned integer types via the `fetch_max` method by passing
     /// [`Ordering::SeqCst`](crate::sync::atomic::Ordering::SeqCst)
     /// as the `order`. For example,
-    /// [`AtomicU32::fetch_max`](../../std/sync/atomic/struct.AtomicU32.html#method.fetch_max).
+    /// [`AtomicU32::fetch_max`](crate::sync::atomic::AtomicU32::fetch_max).
     pub fn atomic_umax<T: Copy>(dst: *mut T, src: T) -> T;
     /// Maximum with the current value using an unsigned comparison.
     ///
@@ -750,7 +750,7 @@ extern "rust-intrinsic" {
     /// `std::sync::atomic` unsigned integer types via the `fetch_max` method by passing
     /// [`Ordering::Acquire`](crate::sync::atomic::Ordering::Acquire)
     /// as the `order`. For example,
-    /// [`AtomicU32::fetch_max`](../../std/sync/atomic/struct.AtomicU32.html#method.fetch_max).
+    /// [`AtomicU32::fetch_max`](crate::sync::atomic::AtomicU32::fetch_max).
     pub fn atomic_umax_acq<T: Copy>(dst: *mut T, src: T) -> T;
     /// Maximum with the current value using an unsigned comparison.
     ///
@@ -758,7 +758,7 @@ extern "rust-intrinsic" {
     /// `std::sync::atomic` unsigned integer types via the `fetch_max` method by passing
     /// [`Ordering::Release`](crate::sync::atomic::Ordering::Release)
     /// as the `order`. For example,
-    /// [`AtomicU32::fetch_max`](../../std/sync/atomic/struct.AtomicU32.html#method.fetch_max).
+    /// [`AtomicU32::fetch_max`](crate::sync::atomic::AtomicU32::fetch_max).
     pub fn atomic_umax_rel<T: Copy>(dst: *mut T, src: T) -> T;
     /// Maximum with the current value using an unsigned comparison.
     ///
@@ -766,7 +766,7 @@ extern "rust-intrinsic" {
     /// `std::sync::atomic` unsigned integer types via the `fetch_max` method by passing
     /// [`Ordering::AcqRel`](crate::sync::atomic::Ordering::AcqRel)
     /// as the `order`. For example,
-    /// [`AtomicU32::fetch_max`](../../std/sync/atomic/struct.AtomicU32.html#method.fetch_max).
+    /// [`AtomicU32::fetch_max`](crate::sync::atomic::AtomicU32::fetch_max).
     pub fn atomic_umax_acqrel<T: Copy>(dst: *mut T, src: T) -> T;
     /// Maximum with the current value using an unsigned comparison.
     ///
@@ -774,7 +774,7 @@ extern "rust-intrinsic" {
     /// `std::sync::atomic` unsigned integer types via the `fetch_max` method by passing
     /// [`Ordering::Relaxed`](crate::sync::atomic::Ordering::Relaxed)
     /// as the `order`. For example,
-    /// [`AtomicU32::fetch_max`](../../std/sync/atomic/struct.AtomicU32.html#method.fetch_max).
+    /// [`AtomicU32::fetch_max`](crate::sync::atomic::AtomicU32::fetch_max).
     pub fn atomic_umax_relaxed<T: Copy>(dst: *mut T, src: T) -> T;
 
     /// The `prefetch` intrinsic is a hint to the code generator to insert a prefetch instruction

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -53,9 +53,18 @@
     issue = "none"
 )]
 #![allow(missing_docs)]
+#![allow(unused_imports)]
 
 use crate::marker::DiscriminantKind;
 use crate::mem;
+
+// These imports are used for simplifying intra-doc links
+use crate::sync::atomic;
+use crate::sync::atomic::Ordering;
+use crate::sync::atomic::AtomicU32;
+use crate::sync::atomic::AtomicI32;
+use crate::sync::atomic::AtomicBool;
+use crate::sync::atomic::AtomicIsize;
 
 #[stable(feature = "drop_in_place", since = "1.8.0")]
 #[rustc_deprecated(
@@ -71,710 +80,510 @@ extern "rust-intrinsic" {
     /// Stores a value if the current value is the same as the `old` value.
     ///
     /// The stabilized version of this intrinsic is available on the
-    /// `std::sync::atomic` types via the `compare_exchange` method by passing
-    /// [`Ordering::SeqCst`](crate::sync::atomic::Ordering::SeqCst)
-    /// as both the `success` and `failure` parameters. For example,
-    /// [`AtomicBool::compare_exchange`][compare_exchange].
-    ///
-    /// [compare_exchange]: crate::sync::atomic::AtomicBool::compare_exchange
+    /// [`atomic`] types via the `compare_exchange` method by passing
+    /// [`Ordering::SeqCst`] as both the `success` and `failure` parameters.
+    /// For example, [`AtomicBool::compare_exchange`].
     pub fn atomic_cxchg<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
     /// Stores a value if the current value is the same as the `old` value.
     ///
     /// The stabilized version of this intrinsic is available on the
-    /// `std::sync::atomic` types via the `compare_exchange` method by passing
-    /// [`Ordering::Acquire`](crate::sync::atomic::Ordering::Acquire)
-    /// as both the `success` and `failure` parameters. For example,
-    /// [`AtomicBool::compare_exchange`][compare_exchange].
-    ///
-    /// [compare_exchange]: crate::sync::atomic::AtomicBool::compare_exchange
+    /// [`atomic`] types via the `compare_exchange` method by passing
+    /// [`Ordering::Acquire`] as both the `success` and `failure` parameters.
+    /// For example, [`AtomicBool::compare_exchange`].
     pub fn atomic_cxchg_acq<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
     /// Stores a value if the current value is the same as the `old` value.
     ///
     /// The stabilized version of this intrinsic is available on the
-    /// `std::sync::atomic` types via the `compare_exchange` method by passing
-    /// [`Ordering::Release`](crate::sync::atomic::Ordering::Release)
-    /// as the `success` and
-    /// [`Ordering::Relaxed`](crate::sync::atomic::Ordering::Relaxed)
-    /// as the `failure` parameters. For example,
-    /// [`AtomicBool::compare_exchange`][compare_exchange].
-    ///
-    /// [compare_exchange]: crate::sync::atomic::AtomicBool::compare_exchange
+    /// [`atomic`] types via the `compare_exchange` method by passing
+    /// [`Ordering::Release`] as the `success` and [`Ordering::Relaxed`] as the
+    /// `failure` parameters. For example, [`AtomicBool::compare_exchange`].
     pub fn atomic_cxchg_rel<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
     /// Stores a value if the current value is the same as the `old` value.
     ///
     /// The stabilized version of this intrinsic is available on the
-    /// `std::sync::atomic` types via the `compare_exchange` method by passing
-    /// [`Ordering::AcqRel`](crate::sync::atomic::Ordering::AcqRel)
-    /// as the `success` and
-    /// [`Ordering::Acquire`](crate::sync::atomic::Ordering::Acquire)
-    /// as the `failure` parameters. For example,
-    /// [`AtomicBool::compare_exchange`][compare_exchange].
-    ///
-    /// [compare_exchange]: crate::sync::atomic::AtomicBool::compare_exchange
+    /// [`atomic`] types via the `compare_exchange` method by passing
+    /// [`Ordering::AcqRel`] as the `success` and [`Ordering::Acquire`] as the
+    /// `failure` parameters. For example, [`AtomicBool::compare_exchange`].
     pub fn atomic_cxchg_acqrel<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
     /// Stores a value if the current value is the same as the `old` value.
     ///
     /// The stabilized version of this intrinsic is available on the
-    /// `std::sync::atomic` types via the `compare_exchange` method by passing
-    /// [`Ordering::Relaxed`](crate::sync::atomic::Ordering::Relaxed)
-    /// as both the `success` and `failure` parameters. For example,
-    /// [`AtomicBool::compare_exchange`][compare_exchange].
-    ///
-    /// [compare_exchange]: crate::sync::atomic::AtomicBool::compare_exchange
+    /// [`atomic`] types via the `compare_exchange` method by passing
+    /// [`Ordering::Relaxed`] as both the `success` and `failure` parameters.
+    /// For example, [`AtomicBool::compare_exchange`].
     pub fn atomic_cxchg_relaxed<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
     /// Stores a value if the current value is the same as the `old` value.
     ///
     /// The stabilized version of this intrinsic is available on the
-    /// `std::sync::atomic` types via the `compare_exchange` method by passing
-    /// [`Ordering::SeqCst`](crate::sync::atomic::Ordering::SeqCst)
-    /// as the `success` and
-    /// [`Ordering::Relaxed`](crate::sync::atomic::Ordering::Relaxed)
-    /// as the `failure` parameters. For example,
-    /// [`AtomicBool::compare_exchange`][compare_exchange].
-    ///
-    /// [compare_exchange]: crate::sync::atomic::AtomicBool::compare_exchange
+    /// [`atomic`] types via the `compare_exchange` method by passing
+    /// [`Ordering::SeqCst`] as the `success` and [`Ordering::Relaxed`] as the
+    /// `failure` parameters. For example, [`AtomicBool::compare_exchange`].
     pub fn atomic_cxchg_failrelaxed<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
     /// Stores a value if the current value is the same as the `old` value.
     ///
     /// The stabilized version of this intrinsic is available on the
-    /// `std::sync::atomic` types via the `compare_exchange` method by passing
-    /// [`Ordering::SeqCst`](crate::sync::atomic::Ordering::SeqCst)
-    /// as the `success` and
-    /// [`Ordering::Acquire`](crate::sync::atomic::Ordering::Acquire)
-    /// as the `failure` parameters. For example,
-    /// [`AtomicBool::compare_exchange`][compare_exchange].
-    ///
-    /// [compare_exchange]: crate::sync::atomic::AtomicBool::compare_exchange
+    /// [`atomic`] types via the `compare_exchange` method by passing
+    /// [`Ordering::SeqCst`] as the `success` and [`Ordering::Acquire`] as the
+    /// `failure` parameters. For example, [`AtomicBool::compare_exchange`].
     pub fn atomic_cxchg_failacq<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
     /// Stores a value if the current value is the same as the `old` value.
     ///
     /// The stabilized version of this intrinsic is available on the
-    /// `std::sync::atomic` types via the `compare_exchange` method by passing
-    /// [`Ordering::Acquire`](crate::sync::atomic::Ordering::Acquire)
-    /// as the `success` and
-    /// [`Ordering::Relaxed`](crate::sync::atomic::Ordering::Relaxed)
-    /// as the `failure` parameters. For example,
-    /// [`AtomicBool::compare_exchange`][compare_exchange].
-    ///
-    /// [compare_exchange]: crate::sync::atomic::AtomicBool::compare_exchange
+    /// [`atomic`] types via the `compare_exchange` method by passing
+    /// [`Ordering::Acquire`] as the `success` and [`Ordering::Relaxed`] as the
+    /// `failure` parameters. For example, [`AtomicBool::compare_exchange`].
     pub fn atomic_cxchg_acq_failrelaxed<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
     /// Stores a value if the current value is the same as the `old` value.
     ///
     /// The stabilized version of this intrinsic is available on the
-    /// `std::sync::atomic` types via the `compare_exchange` method by passing
-    /// [`Ordering::AcqRel`](crate::sync::atomic::Ordering::AcqRel)
-    /// as the `success` and
-    /// [`Ordering::Relaxed`](crate::sync::atomic::Ordering::Relaxed)
-    /// as the `failure` parameters. For example,
-    /// [`AtomicBool::compare_exchange`][compare_exchange].
-    ///
-    /// [compare_exchange]: crate::sync::atomic::AtomicBool::compare_exchange
+    /// [`atomic`] types via the `compare_exchange` method by passing
+    /// [`Ordering::AcqRel`] as the `success` and [`Ordering::Relaxed`] as the
+    /// `failure` parameters. For example, [`AtomicBool::compare_exchange`].
     pub fn atomic_cxchg_acqrel_failrelaxed<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
 
     /// Stores a value if the current value is the same as the `old` value.
     ///
     /// The stabilized version of this intrinsic is available on the
-    /// `std::sync::atomic` types via the `compare_exchange_weak` method by passing
-    /// [`Ordering::SeqCst`](crate::sync::atomic::Ordering::SeqCst)
-    /// as both the `success` and `failure` parameters. For example,
-    /// [`AtomicBool::compare_exchange_weak`][cew].
-    ///
-    /// [cew]: crate::sync::atomic::AtomicBool::compare_exchange_weak
+    /// [`atomic`] types via the `compare_exchange_weak` method by passing
+    /// [`Ordering::SeqCst`] as both the `success` and `failure` parameters.
+    /// For example, [`AtomicBool::compare_exchange_weak`].
     pub fn atomic_cxchgweak<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
     /// Stores a value if the current value is the same as the `old` value.
     ///
     /// The stabilized version of this intrinsic is available on the
-    /// `std::sync::atomic` types via the `compare_exchange_weak` method by passing
-    /// [`Ordering::Acquire`](crate::sync::atomic::Ordering::Acquire)
-    /// as both the `success` and `failure` parameters. For example,
-    /// [`AtomicBool::compare_exchange_weak`][cew].
-    ///
-    /// [cew]: crate::sync::atomic::AtomicBool::compare_exchange_weak
+    /// [`atomic`] types via the `compare_exchange_weak` method by passing
+    /// [`Ordering::Acquire`] as both the `success` and `failure` parameters.
+    /// For example, [`AtomicBool::compare_exchange_weak`].
     pub fn atomic_cxchgweak_acq<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
     /// Stores a value if the current value is the same as the `old` value.
     ///
     /// The stabilized version of this intrinsic is available on the
-    /// `std::sync::atomic` types via the `compare_exchange_weak` method by passing
-    /// [`Ordering::Release`](crate::sync::atomic::Ordering::Release)
-    /// as the `success` and
-    /// [`Ordering::Relaxed`](crate::sync::atomic::Ordering::Relaxed)
-    /// as the `failure` parameters. For example,
-    /// [`AtomicBool::compare_exchange_weak`][cew].
-    ///
-    /// [cew]: crate::sync::atomic::AtomicBool::compare_exchange_weak
+    /// [`atomic`] types via the `compare_exchange_weak` method by passing
+    /// [`Ordering::Release`] as the `success` and [`Ordering::Relaxed`] as the
+    /// `failure` parameters. For example, [`AtomicBool::compare_exchange_weak`].
     pub fn atomic_cxchgweak_rel<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
     /// Stores a value if the current value is the same as the `old` value.
     ///
     /// The stabilized version of this intrinsic is available on the
-    /// `std::sync::atomic` types via the `compare_exchange_weak` method by passing
-    /// [`Ordering::AcqRel`](crate::sync::atomic::Ordering::AcqRel)
-    /// as the `success` and
-    /// [`Ordering::Acquire`](crate::sync::atomic::Ordering::Acquire)
-    /// as the `failure` parameters. For example,
-    /// [`AtomicBool::compare_exchange_weak`][cew].
-    ///
-    /// [cew]: crate::sync::atomic::AtomicBool::compare_exchange_weak
+    /// [`atomic`] types via the `compare_exchange_weak` method by passing
+    /// [`Ordering::AcqRel`] as the `success` and [`Ordering::Acquire`] as the
+    /// `failure` parameters. For example, [`AtomicBool::compare_exchange_weak`].
     pub fn atomic_cxchgweak_acqrel<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
     /// Stores a value if the current value is the same as the `old` value.
     ///
     /// The stabilized version of this intrinsic is available on the
-    /// `std::sync::atomic` types via the `compare_exchange_weak` method by passing
-    /// [`Ordering::Relaxed`](crate::sync::atomic::Ordering::Relaxed)
-    /// as both the `success` and `failure` parameters. For example,
-    /// [`AtomicBool::compare_exchange_weak`][cew].
-    ///
-    /// [cew]: crate::sync::atomic::AtomicBool::compare_exchange_weak
+    /// [`atomic`] types via the `compare_exchange_weak` method by passing
+    /// [`Ordering::Relaxed`] as both the `success` and `failure` parameters.
+    /// For example, [`AtomicBool::compare_exchange_weak`].
     pub fn atomic_cxchgweak_relaxed<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
     /// Stores a value if the current value is the same as the `old` value.
     ///
     /// The stabilized version of this intrinsic is available on the
-    /// `std::sync::atomic` types via the `compare_exchange_weak` method by passing
-    /// [`Ordering::SeqCst`](crate::sync::atomic::Ordering::SeqCst)
-    /// as the `success` and
-    /// [`Ordering::Relaxed`](crate::sync::atomic::Ordering::Relaxed)
-    /// as the `failure` parameters. For example,
-    /// [`AtomicBool::compare_exchange_weak`][cew].
-    ///
-    /// [cew]: crate::sync::atomic::AtomicBool::compare_exchange_weak
+    /// [`atomic`] types via the `compare_exchange_weak` method by passing
+    /// [`Ordering::SeqCst`] as the `success` and [`Ordering::Relaxed`] as the
+    /// `failure` parameters. For example, [`AtomicBool::compare_exchange_weak`].
     pub fn atomic_cxchgweak_failrelaxed<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
     /// Stores a value if the current value is the same as the `old` value.
     ///
     /// The stabilized version of this intrinsic is available on the
-    /// `std::sync::atomic` types via the `compare_exchange_weak` method by passing
-    /// [`Ordering::SeqCst`](crate::sync::atomic::Ordering::SeqCst)
-    /// as the `success` and
-    /// [`Ordering::Acquire`](crate::sync::atomic::Ordering::Acquire)
-    /// as the `failure` parameters. For example,
-    /// [`AtomicBool::compare_exchange_weak`][cew].
-    ///
-    /// [cew]: crate::sync::atomic::AtomicBool::compare_exchange_weak
+    /// [`atomic`] types via the `compare_exchange_weak` method by passing
+    /// [`Ordering::SeqCst`] as the `success` and [`Ordering::Acquire`] as the
+    /// `failure` parameters. For example, [`AtomicBool::compare_exchange_weak`].
     pub fn atomic_cxchgweak_failacq<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
     /// Stores a value if the current value is the same as the `old` value.
     ///
     /// The stabilized version of this intrinsic is available on the
-    /// `std::sync::atomic` types via the `compare_exchange_weak` method by passing
-    /// [`Ordering::Acquire`](crate::sync::atomic::Ordering::Acquire)
-    /// as the `success` and
-    /// [`Ordering::Relaxed`](crate::sync::atomic::Ordering::Relaxed)
-    /// as the `failure` parameters. For example,
-    /// [`AtomicBool::compare_exchange_weak`][cew].
-    ///
-    /// [cew]: crate::sync::atomic::AtomicBool::compare_exchange_weak
+    /// [`atomic`] types via the `compare_exchange_weak` method by passing
+    /// [`Ordering::Acquire`] as the `success` and [`Ordering::Relaxed`] as the
+    /// `failure` parameters. For example, [`AtomicBool::compare_exchange_weak`].
     pub fn atomic_cxchgweak_acq_failrelaxed<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
     /// Stores a value if the current value is the same as the `old` value.
     ///
     /// The stabilized version of this intrinsic is available on the
-    /// `std::sync::atomic` types via the `compare_exchange_weak` method by passing
-    /// [`Ordering::AcqRel`](crate::sync::atomic::Ordering::AcqRel)
-    /// as the `success` and
-    /// [`Ordering::Relaxed`](crate::sync::atomic::Ordering::Relaxed)
-    /// as the `failure` parameters. For example,
-    /// [`AtomicBool::compare_exchange_weak`][cew].
-    ///
-    /// [cew]: crate::sync::atomic::AtomicBool::compare_exchange_weak
+    /// [`atomic`] types via the `compare_exchange_weak` method by passing
+    /// [`Ordering::AcqRel`] as the `success` and [`Ordering::Relaxed`] as the
+    /// `failure` parameters. For example, [`AtomicBool::compare_exchange_weak`].
     pub fn atomic_cxchgweak_acqrel_failrelaxed<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
 
     /// Loads the current value of the pointer.
     ///
     /// The stabilized version of this intrinsic is available on the
-    /// `std::sync::atomic` types via the `load` method by passing
-    /// [`Ordering::SeqCst`](crate::sync::atomic::Ordering::SeqCst)
-    /// as the `order`. For example,
-    /// [`AtomicBool::load`](crate::sync::atomic::AtomicBool::load).
+    /// [`atomic`] types via the `load` method by passing
+    /// [`Ordering::SeqCst`] as the `order`. For example, [`AtomicBool::load`].
     pub fn atomic_load<T: Copy>(src: *const T) -> T;
     /// Loads the current value of the pointer.
     ///
     /// The stabilized version of this intrinsic is available on the
-    /// `std::sync::atomic` types via the `load` method by passing
-    /// [`Ordering::Acquire`](crate::sync::atomic::Ordering::Acquire)
-    /// as the `order`. For example,
-    /// [`AtomicBool::load`](crate::sync::atomic::AtomicBool::load).
+    /// [`atomic`] types via the `load` method by passing
+    /// [`Ordering::Acquire`] as the `order`. For example, [`AtomicBool::load`].
     pub fn atomic_load_acq<T: Copy>(src: *const T) -> T;
     /// Loads the current value of the pointer.
     ///
     /// The stabilized version of this intrinsic is available on the
-    /// `std::sync::atomic` types via the `load` method by passing
-    /// [`Ordering::Relaxed`](crate::sync::atomic::Ordering::Relaxed)
-    /// as the `order`. For example,
-    /// [`AtomicBool::load`](crate::sync::atomic::AtomicBool::load).
+    /// [`atomic`] types via the `load` method by passing
+    /// [`Ordering::Relaxed`] as the `order`. For example, [`AtomicBool::load`].
     pub fn atomic_load_relaxed<T: Copy>(src: *const T) -> T;
     pub fn atomic_load_unordered<T: Copy>(src: *const T) -> T;
 
     /// Stores the value at the specified memory location.
     ///
     /// The stabilized version of this intrinsic is available on the
-    /// `std::sync::atomic` types via the `store` method by passing
-    /// [`Ordering::SeqCst`](crate::sync::atomic::Ordering::SeqCst)
-    /// as the `order`. For example,
-    /// [`AtomicBool::store`](crate::sync::atomic::AtomicBool::store).
+    /// [`atomic`] types via the `store` method by passing
+    /// [`Ordering::SeqCst`] as the `order`. For example, [`AtomicBool::store`].
     pub fn atomic_store<T: Copy>(dst: *mut T, val: T);
     /// Stores the value at the specified memory location.
     ///
     /// The stabilized version of this intrinsic is available on the
-    /// `std::sync::atomic` types via the `store` method by passing
-    /// [`Ordering::Release`](crate::sync::atomic::Ordering::Release)
-    /// as the `order`. For example,
-    /// [`AtomicBool::store`](crate::sync::atomic::AtomicBool::store).
+    /// [`atomic`] types via the `store` method by passing
+    /// [`Ordering::Release`] as the `order`. For example, [`AtomicBool::store`].
     pub fn atomic_store_rel<T: Copy>(dst: *mut T, val: T);
     /// Stores the value at the specified memory location.
     ///
     /// The stabilized version of this intrinsic is available on the
-    /// `std::sync::atomic` types via the `store` method by passing
-    /// [`Ordering::Relaxed`](crate::sync::atomic::Ordering::Relaxed)
-    /// as the `order`. For example,
-    /// [`AtomicBool::store`](crate::sync::atomic::AtomicBool::store).
+    /// [`atomic`] types via the `store` method by passing
+    /// [`Ordering::Relaxed`] as the `order`. For example, [`AtomicBool::store`].
     pub fn atomic_store_relaxed<T: Copy>(dst: *mut T, val: T);
     pub fn atomic_store_unordered<T: Copy>(dst: *mut T, val: T);
 
     /// Stores the value at the specified memory location, returning the old value.
     ///
     /// The stabilized version of this intrinsic is available on the
-    /// `std::sync::atomic` types via the `swap` method by passing
-    /// [`Ordering::SeqCst`](crate::sync::atomic::Ordering::SeqCst)
-    /// as the `order`. For example,
-    /// [`AtomicBool::swap`](crate::sync::atomic::AtomicBool::swap).
+    /// [`atomic`] types via the `swap` method by passing
+    /// [`Ordering::SeqCst`] as the `order`. For example, [`AtomicBool::swap`].
     pub fn atomic_xchg<T: Copy>(dst: *mut T, src: T) -> T;
     /// Stores the value at the specified memory location, returning the old value.
     ///
     /// The stabilized version of this intrinsic is available on the
-    /// `std::sync::atomic` types via the `swap` method by passing
-    /// [`Ordering::Acquire`](crate::sync::atomic::Ordering::Acquire)
-    /// as the `order`. For example,
-    /// [`AtomicBool::swap`](crate::sync::atomic::AtomicBool::swap).
+    /// [`atomic`] types via the `swap` method by passing
+    /// [`Ordering::Acquire`] as the `order`. For example, [`AtomicBool::swap`].
     pub fn atomic_xchg_acq<T: Copy>(dst: *mut T, src: T) -> T;
     /// Stores the value at the specified memory location, returning the old value.
     ///
     /// The stabilized version of this intrinsic is available on the
-    /// `std::sync::atomic` types via the `swap` method by passing
-    /// [`Ordering::Release`](crate::sync::atomic::Ordering::Release)
-    /// as the `order`. For example,
-    /// [`AtomicBool::swap`](crate::sync::atomic::AtomicBool::swap).
+    /// [`atomic`] types via the `swap` method by passing
+    /// [`Ordering::Release`] as the `order`. For example, [`AtomicBool::swap`].
     pub fn atomic_xchg_rel<T: Copy>(dst: *mut T, src: T) -> T;
     /// Stores the value at the specified memory location, returning the old value.
     ///
     /// The stabilized version of this intrinsic is available on the
-    /// `std::sync::atomic` types via the `swap` method by passing
-    /// [`Ordering::AcqRel`](crate::sync::atomic::Ordering::AcqRel)
-    /// as the `order`. For example,
-    /// [`AtomicBool::swap`](crate::sync::atomic::AtomicBool::swap).
+    /// [`atomic`] types via the `swap` method by passing
+    /// [`Ordering::AcqRel`] as the `order`. For example, [`AtomicBool::swap`].
     pub fn atomic_xchg_acqrel<T: Copy>(dst: *mut T, src: T) -> T;
     /// Stores the value at the specified memory location, returning the old value.
     ///
     /// The stabilized version of this intrinsic is available on the
-    /// `std::sync::atomic` types via the `swap` method by passing
-    /// [`Ordering::Relaxed`](crate::sync::atomic::Ordering::Relaxed)
-    /// as the `order`. For example,
-    /// [`AtomicBool::swap`](crate::sync::atomic::AtomicBool::swap).
+    /// [`atomic`] types via the `swap` method by passing
+    /// [`Ordering::Relaxed`] as the `order`. For example, [`AtomicBool::swap`].
     pub fn atomic_xchg_relaxed<T: Copy>(dst: *mut T, src: T) -> T;
 
     /// Adds to the current value, returning the previous value.
     ///
     /// The stabilized version of this intrinsic is available on the
-    /// `std::sync::atomic` types via the `fetch_add` method by passing
-    /// [`Ordering::SeqCst`](crate::sync::atomic::Ordering::SeqCst)
-    /// as the `order`. For example,
-    /// [`AtomicIsize::fetch_add`](crate::sync::atomic::AtomicIsize::fetch_add).
+    /// [`atomic`] types via the `fetch_add` method by passing
+    /// [`Ordering::SeqCst`] as the `order`. For example, [`AtomicIsize::fetch_add`].
     pub fn atomic_xadd<T: Copy>(dst: *mut T, src: T) -> T;
     /// Adds to the current value, returning the previous value.
     ///
     /// The stabilized version of this intrinsic is available on the
-    /// `std::sync::atomic` types via the `fetch_add` method by passing
-    /// [`Ordering::Acquire`](crate::sync::atomic::Ordering::Acquire)
-    /// as the `order`. For example,
-    /// [`AtomicIsize::fetch_add`](crate::sync::atomic::AtomicIsize::fetch_add).
+    /// [`atomic`] types via the `fetch_add` method by passing
+    /// [`Ordering::Acquire`] as the `order`. For example, [`AtomicIsize::fetch_add`].
     pub fn atomic_xadd_acq<T: Copy>(dst: *mut T, src: T) -> T;
     /// Adds to the current value, returning the previous value.
     ///
     /// The stabilized version of this intrinsic is available on the
-    /// `std::sync::atomic` types via the `fetch_add` method by passing
-    /// [`Ordering::Release`](crate::sync::atomic::Ordering::Release)
-    /// as the `order`. For example,
-    /// [`AtomicIsize::fetch_add`](crate::sync::atomic::AtomicIsize::fetch_add).
+    /// [`atomic`] types via the `fetch_add` method by passing
+    /// [`Ordering::Release`] as the `order`. For example, [`AtomicIsize::fetch_add`].
     pub fn atomic_xadd_rel<T: Copy>(dst: *mut T, src: T) -> T;
     /// Adds to the current value, returning the previous value.
     ///
     /// The stabilized version of this intrinsic is available on the
-    /// `std::sync::atomic` types via the `fetch_add` method by passing
-    /// [`Ordering::AcqRel`](crate::sync::atomic::Ordering::AcqRel)
-    /// as the `order`. For example,
-    /// [`AtomicIsize::fetch_add`](crate::sync::atomic::AtomicIsize::fetch_add).
+    /// [`atomic`] types via the `fetch_add` method by passing
+    /// [`Ordering::AcqRel`] as the `order`. For example, [`AtomicIsize::fetch_add`].
     pub fn atomic_xadd_acqrel<T: Copy>(dst: *mut T, src: T) -> T;
     /// Adds to the current value, returning the previous value.
     ///
     /// The stabilized version of this intrinsic is available on the
-    /// `std::sync::atomic` types via the `fetch_add` method by passing
-    /// [`Ordering::Relaxed`](crate::sync::atomic::Ordering::Relaxed)
-    /// as the `order`. For example,
-    /// [`AtomicIsize::fetch_add`](crate::sync::atomic::AtomicIsize::fetch_add).
+    /// [`atomic`] types via the `fetch_add` method by passing
+    /// [`Ordering::Relaxed`] as the `order`. For example, [`AtomicIsize::fetch_add`].
     pub fn atomic_xadd_relaxed<T: Copy>(dst: *mut T, src: T) -> T;
 
     /// Subtract from the current value, returning the previous value.
     ///
     /// The stabilized version of this intrinsic is available on the
-    /// `std::sync::atomic` types via the `fetch_sub` method by passing
-    /// [`Ordering::SeqCst`](crate::sync::atomic::Ordering::SeqCst)
-    /// as the `order`. For example,
-    /// [`AtomicIsize::fetch_sub`](crate::sync::atomic::AtomicIsize::fetch_sub).
+    /// [`atomic`] types via the `fetch_sub` method by passing
+    /// [`Ordering::SeqCst`] as the `order`. For example, [`AtomicIsize::fetch_sub`].
     pub fn atomic_xsub<T: Copy>(dst: *mut T, src: T) -> T;
     /// Subtract from the current value, returning the previous value.
     ///
     /// The stabilized version of this intrinsic is available on the
-    /// `std::sync::atomic` types via the `fetch_sub` method by passing
-    /// [`Ordering::Acquire`](crate::sync::atomic::Ordering::Acquire)
-    /// as the `order`. For example,
-    /// [`AtomicIsize::fetch_sub`](crate::sync::atomic::AtomicIsize::fetch_sub).
+    /// [`atomic`] types via the `fetch_sub` method by passing
+    /// [`Ordering::Acquire`] as the `order`. For example, [`AtomicIsize::fetch_sub`].
     pub fn atomic_xsub_acq<T: Copy>(dst: *mut T, src: T) -> T;
     /// Subtract from the current value, returning the previous value.
     ///
     /// The stabilized version of this intrinsic is available on the
-    /// `std::sync::atomic` types via the `fetch_sub` method by passing
-    /// [`Ordering::Release`](crate::sync::atomic::Ordering::Release)
-    /// as the `order`. For example,
-    /// [`AtomicIsize::fetch_sub`](crate::sync::atomic::AtomicIsize::fetch_sub).
+    /// [`atomic`] types via the `fetch_sub` method by passing
+    /// [`Ordering::Release`] as the `order`. For example, [`AtomicIsize::fetch_sub`].
     pub fn atomic_xsub_rel<T: Copy>(dst: *mut T, src: T) -> T;
     /// Subtract from the current value, returning the previous value.
     ///
     /// The stabilized version of this intrinsic is available on the
-    /// `std::sync::atomic` types via the `fetch_sub` method by passing
-    /// [`Ordering::AcqRel`](crate::sync::atomic::Ordering::AcqRel)
-    /// as the `order`. For example,
-    /// [`AtomicIsize::fetch_sub`](crate::sync::atomic::AtomicIsize::fetch_sub).
+    /// [`atomic`] types via the `fetch_sub` method by passing
+    /// [`Ordering::AcqRel`] as the `order`. For example, [`AtomicIsize::fetch_sub`].
     pub fn atomic_xsub_acqrel<T: Copy>(dst: *mut T, src: T) -> T;
     /// Subtract from the current value, returning the previous value.
     ///
     /// The stabilized version of this intrinsic is available on the
-    /// `std::sync::atomic` types via the `fetch_sub` method by passing
-    /// [`Ordering::Relaxed`](crate::sync::atomic::Ordering::Relaxed)
-    /// as the `order`. For example,
-    /// [`AtomicIsize::fetch_sub`](crate::sync::atomic::AtomicIsize::fetch_sub).
+    /// [`atomic`] types via the `fetch_sub` method by passing
+    /// [`Ordering::Relaxed`] as the `order`. For example, [`AtomicIsize::fetch_sub`].
     pub fn atomic_xsub_relaxed<T: Copy>(dst: *mut T, src: T) -> T;
 
     /// Bitwise and with the current value, returning the previous value.
     ///
     /// The stabilized version of this intrinsic is available on the
-    /// `std::sync::atomic` types via the `fetch_and` method by passing
-    /// [`Ordering::SeqCst`](crate::sync::atomic::Ordering::SeqCst)
-    /// as the `order`. For example,
-    /// [`AtomicBool::fetch_and`](crate::sync::atomic::AtomicBool::fetch_and).
+    /// [`atomic`] types via the `fetch_and` method by passing
+    /// [`Ordering::SeqCst`] as the `order`. For example, [`AtomicBool::fetch_and`].
     pub fn atomic_and<T: Copy>(dst: *mut T, src: T) -> T;
     /// Bitwise and with the current value, returning the previous value.
     ///
     /// The stabilized version of this intrinsic is available on the
-    /// `std::sync::atomic` types via the `fetch_and` method by passing
-    /// [`Ordering::Acquire`](crate::sync::atomic::Ordering::Acquire)
-    /// as the `order`. For example,
-    /// [`AtomicBool::fetch_and`](crate::sync::atomic::AtomicBool::fetch_and).
+    /// [`atomic`] types via the `fetch_and` method by passing
+    /// [`Ordering::Acquire`] as the `order`. For example, [`AtomicBool::fetch_and`].
     pub fn atomic_and_acq<T: Copy>(dst: *mut T, src: T) -> T;
     /// Bitwise and with the current value, returning the previous value.
     ///
     /// The stabilized version of this intrinsic is available on the
-    /// `std::sync::atomic` types via the `fetch_and` method by passing
-    /// [`Ordering::Release`](crate::sync::atomic::Ordering::Release)
-    /// as the `order`. For example,
-    /// [`AtomicBool::fetch_and`](crate::sync::atomic::AtomicBool::fetch_and).
+    /// [`atomic`] types via the `fetch_and` method by passing
+    /// [`Ordering::Release`] as the `order`. For example, [`AtomicBool::fetch_and`].
     pub fn atomic_and_rel<T: Copy>(dst: *mut T, src: T) -> T;
     /// Bitwise and with the current value, returning the previous value.
     ///
     /// The stabilized version of this intrinsic is available on the
-    /// `std::sync::atomic` types via the `fetch_and` method by passing
-    /// [`Ordering::AcqRel`](crate::sync::atomic::Ordering::AcqRel)
-    /// as the `order`. For example,
-    /// [`AtomicBool::fetch_and`](crate::sync::atomic::AtomicBool::fetch_and).
+    /// [`atomic`] types via the `fetch_and` method by passing
+    /// [`Ordering::AcqRel`] as the `order`. For example, [`AtomicBool::fetch_and`].
     pub fn atomic_and_acqrel<T: Copy>(dst: *mut T, src: T) -> T;
     /// Bitwise and with the current value, returning the previous value.
     ///
     /// The stabilized version of this intrinsic is available on the
-    /// `std::sync::atomic` types via the `fetch_and` method by passing
-    /// [`Ordering::Relaxed`](crate::sync::atomic::Ordering::Relaxed)
-    /// as the `order`. For example,
-    /// [`AtomicBool::fetch_and`](crate::sync::atomic::AtomicBool::fetch_and).
+    /// [`atomic`] types via the `fetch_and` method by passing
+    /// [`Ordering::Relaxed`] as the `order`. For example, [`AtomicBool::fetch_and`].
     pub fn atomic_and_relaxed<T: Copy>(dst: *mut T, src: T) -> T;
 
     /// Bitwise nand with the current value, returning the previous value.
     ///
     /// The stabilized version of this intrinsic is available on the
-    /// `std::sync::atomic::AtomicBool` type via the `fetch_nand` method by passing
-    /// [`Ordering::SeqCst`](crate::sync::atomic::Ordering::SeqCst)
-    /// as the `order`. For example,
-    /// [`AtomicBool::fetch_nand`](crate::sync::atomic::AtomicBool::fetch_nand).
+    /// [`AtomicBool`] type via the `fetch_nand` method by passing
+    /// [`Ordering::SeqCst`] as the `order`. For example, [`AtomicBool::fetch_nand`].
     pub fn atomic_nand<T: Copy>(dst: *mut T, src: T) -> T;
     /// Bitwise nand with the current value, returning the previous value.
     ///
     /// The stabilized version of this intrinsic is available on the
-    /// `std::sync::atomic::AtomicBool` type via the `fetch_nand` method by passing
-    /// [`Ordering::Acquire`](crate::sync::atomic::Ordering::Acquire)
-    /// as the `order`. For example,
-    /// [`AtomicBool::fetch_nand`](crate::sync::atomic::AtomicBool::fetch_nand).
+    /// [`AtomicBool`] type via the `fetch_nand` method by passing
+    /// [`Ordering::Acquire`] as the `order`. For example, [`AtomicBool::fetch_nand`].
     pub fn atomic_nand_acq<T: Copy>(dst: *mut T, src: T) -> T;
     /// Bitwise nand with the current value, returning the previous value.
     ///
     /// The stabilized version of this intrinsic is available on the
-    /// `std::sync::atomic::AtomicBool` type via the `fetch_nand` method by passing
-    /// [`Ordering::Release`](crate::sync::atomic::Ordering::Release)
-    /// as the `order`. For example,
-    /// [`AtomicBool::fetch_nand`](crate::sync::atomic::AtomicBool::fetch_nand).
+    /// [`AtomicBool`] type via the `fetch_nand` method by passing
+    /// [`Ordering::Release`] as the `order`. For example, [`AtomicBool::fetch_nand`].
     pub fn atomic_nand_rel<T: Copy>(dst: *mut T, src: T) -> T;
     /// Bitwise nand with the current value, returning the previous value.
     ///
     /// The stabilized version of this intrinsic is available on the
-    /// `std::sync::atomic::AtomicBool` type via the `fetch_nand` method by passing
-    /// [`Ordering::AcqRel`](crate::sync::atomic::Ordering::AcqRel)
-    /// as the `order`. For example,
-    /// [`AtomicBool::fetch_nand`](crate::sync::atomic::AtomicBool::fetch_nand).
+    /// [`AtomicBool`] type via the `fetch_nand` method by passing
+    /// [`Ordering::AcqRel`] as the `order`. For example, [`AtomicBool::fetch_nand`].
     pub fn atomic_nand_acqrel<T: Copy>(dst: *mut T, src: T) -> T;
     /// Bitwise nand with the current value, returning the previous value.
     ///
     /// The stabilized version of this intrinsic is available on the
-    /// `std::sync::atomic::AtomicBool` type via the `fetch_nand` method by passing
-    /// [`Ordering::Relaxed`](crate::sync::atomic::Ordering::Relaxed)
-    /// as the `order`. For example,
-    /// [`AtomicBool::fetch_nand`](crate::sync::atomic::AtomicBool::fetch_nand).
+    /// [`AtomicBool`] type via the `fetch_nand` method by passing
+    /// [`Ordering::Relaxed`] as the `order`. For example, [`AtomicBool::fetch_nand`].
     pub fn atomic_nand_relaxed<T: Copy>(dst: *mut T, src: T) -> T;
 
     /// Bitwise or with the current value, returning the previous value.
     ///
     /// The stabilized version of this intrinsic is available on the
-    /// `std::sync::atomic` types via the `fetch_or` method by passing
-    /// [`Ordering::SeqCst`](crate::sync::atomic::Ordering::SeqCst)
-    /// as the `order`. For example,
-    /// [`AtomicBool::fetch_or`](crate::sync::atomic::AtomicBool::fetch_or).
+    /// [`atomic`] types via the `fetch_or` method by passing
+    /// [`Ordering::SeqCst`] as the `order`. For example, [`AtomicBool::fetch_or`].
     pub fn atomic_or<T: Copy>(dst: *mut T, src: T) -> T;
     /// Bitwise or with the current value, returning the previous value.
     ///
     /// The stabilized version of this intrinsic is available on the
-    /// `std::sync::atomic` types via the `fetch_or` method by passing
-    /// [`Ordering::Acquire`](crate::sync::atomic::Ordering::Acquire)
-    /// as the `order`. For example,
-    /// [`AtomicBool::fetch_or`](crate::sync::atomic::AtomicBool::fetch_or).
+    /// [`atomic`] types via the `fetch_or` method by passing
+    /// [`Ordering::Acquire`] as the `order`. For example, [`AtomicBool::fetch_or`].
     pub fn atomic_or_acq<T: Copy>(dst: *mut T, src: T) -> T;
     /// Bitwise or with the current value, returning the previous value.
     ///
     /// The stabilized version of this intrinsic is available on the
-    /// `std::sync::atomic` types via the `fetch_or` method by passing
-    /// [`Ordering::Release`](crate::sync::atomic::Ordering::Release)
-    /// as the `order`. For example,
-    /// [`AtomicBool::fetch_or`](crate::sync::atomic::AtomicBool::fetch_or).
+    /// [`atomic`] types via the `fetch_or` method by passing
+    /// [`Ordering::Release`] as the `order`. For example, [`AtomicBool::fetch_or`].
     pub fn atomic_or_rel<T: Copy>(dst: *mut T, src: T) -> T;
     /// Bitwise or with the current value, returning the previous value.
     ///
     /// The stabilized version of this intrinsic is available on the
-    /// `std::sync::atomic` types via the `fetch_or` method by passing
-    /// [`Ordering::AcqRel`](crate::sync::atomic::Ordering::AcqRel)
-    /// as the `order`. For example,
-    /// [`AtomicBool::fetch_or`](crate::sync::atomic::AtomicBool::fetch_or).
+    /// [`atomic`] types via the `fetch_or` method by passing
+    /// [`Ordering::AcqRel`] as the `order`. For example, [`AtomicBool::fetch_or`].
     pub fn atomic_or_acqrel<T: Copy>(dst: *mut T, src: T) -> T;
     /// Bitwise or with the current value, returning the previous value.
     ///
     /// The stabilized version of this intrinsic is available on the
-    /// `std::sync::atomic` types via the `fetch_or` method by passing
-    /// [`Ordering::Relaxed`](crate::sync::atomic::Ordering::Relaxed)
-    /// as the `order`. For example,
-    /// [`AtomicBool::fetch_or`](crate::sync::atomic::AtomicBool::fetch_or).
+    /// [`atomic`] types via the `fetch_or` method by passing
+    /// [`Ordering::Relaxed`] as the `order`. For example, [`AtomicBool::fetch_or`].
     pub fn atomic_or_relaxed<T: Copy>(dst: *mut T, src: T) -> T;
 
     /// Bitwise xor with the current value, returning the previous value.
     ///
     /// The stabilized version of this intrinsic is available on the
-    /// `std::sync::atomic` types via the `fetch_xor` method by passing
-    /// [`Ordering::SeqCst`](crate::sync::atomic::Ordering::SeqCst)
-    /// as the `order`. For example,
-    /// [`AtomicBool::fetch_xor`](crate::sync::atomic::AtomicBool::fetch_xor).
+    /// [`atomic`] types via the `fetch_xor` method by passing
+    /// [`Ordering::SeqCst`] as the `order`. For example, [`AtomicBool::fetch_xor`].
     pub fn atomic_xor<T: Copy>(dst: *mut T, src: T) -> T;
     /// Bitwise xor with the current value, returning the previous value.
     ///
     /// The stabilized version of this intrinsic is available on the
-    /// `std::sync::atomic` types via the `fetch_xor` method by passing
-    /// [`Ordering::Acquire`](crate::sync::atomic::Ordering::Acquire)
-    /// as the `order`. For example,
-    /// [`AtomicBool::fetch_xor`](crate::sync::atomic::AtomicBool::fetch_xor).
+    /// [`atomic`] types via the `fetch_xor` method by passing
+    /// [`Ordering::Acquire`] as the `order`. For example, [`AtomicBool::fetch_xor`].
     pub fn atomic_xor_acq<T: Copy>(dst: *mut T, src: T) -> T;
     /// Bitwise xor with the current value, returning the previous value.
     ///
     /// The stabilized version of this intrinsic is available on the
-    /// `std::sync::atomic` types via the `fetch_xor` method by passing
-    /// [`Ordering::Release`](crate::sync::atomic::Ordering::Release)
-    /// as the `order`. For example,
-    /// [`AtomicBool::fetch_xor`](crate::sync::atomic::AtomicBool::fetch_xor).
+    /// [`atomic`] types via the `fetch_xor` method by passing
+    /// [`Ordering::Release`] as the `order`. For example, [`AtomicBool::fetch_xor`].
     pub fn atomic_xor_rel<T: Copy>(dst: *mut T, src: T) -> T;
     /// Bitwise xor with the current value, returning the previous value.
     ///
     /// The stabilized version of this intrinsic is available on the
-    /// `std::sync::atomic` types via the `fetch_xor` method by passing
-    /// [`Ordering::AcqRel`](crate::sync::atomic::Ordering::AcqRel)
-    /// as the `order`. For example,
-    /// [`AtomicBool::fetch_xor`](crate::sync::atomic::AtomicBool::fetch_xor).
+    /// [`atomic`] types via the `fetch_xor` method by passing
+    /// [`Ordering::AcqRel`] as the `order`. For example, [`AtomicBool::fetch_xor`].
     pub fn atomic_xor_acqrel<T: Copy>(dst: *mut T, src: T) -> T;
     /// Bitwise xor with the current value, returning the previous value.
     ///
     /// The stabilized version of this intrinsic is available on the
-    /// `std::sync::atomic` types via the `fetch_xor` method by passing
-    /// [`Ordering::Relaxed`](crate::sync::atomic::Ordering::Relaxed)
-    /// as the `order`. For example,
-    /// [`AtomicBool::fetch_xor`](crate::sync::atomic::AtomicBool::fetch_xor).
+    /// [`atomic`] types via the `fetch_xor` method by passing
+    /// [`Ordering::Relaxed`] as the `order`. For example, [`AtomicBool::fetch_xor`].
     pub fn atomic_xor_relaxed<T: Copy>(dst: *mut T, src: T) -> T;
 
     /// Maximum with the current value using a signed comparison.
     ///
     /// The stabilized version of this intrinsic is available on the
-    /// `std::sync::atomic` signed integer types via the `fetch_max` method by passing
-    /// [`Ordering::SeqCst`](crate::sync::atomic::Ordering::SeqCst)
-    /// as the `order`. For example,
-    /// [`AtomicI32::fetch_max`](crate::sync::atomic::AtomicI32::fetch_max).
+    /// [`atomic`] signed integer types via the `fetch_max` method by passing
+    /// [`Ordering::SeqCst`] as the `order`. For example, [`AtomicI32::fetch_max`].
     pub fn atomic_max<T: Copy>(dst: *mut T, src: T) -> T;
     /// Maximum with the current value using a signed comparison.
     ///
     /// The stabilized version of this intrinsic is available on the
-    /// `std::sync::atomic` signed integer types via the `fetch_max` method by passing
-    /// [`Ordering::Acquire`](crate::sync::atomic::Ordering::Acquire)
-    /// as the `order`. For example,
-    /// [`AtomicI32::fetch_max`](crate::sync::atomic::AtomicI32::fetch_max).
+    /// [`atomic`] signed integer types via the `fetch_max` method by passing
+    /// [`Ordering::Acquire`] as the `order`. For example, [`AtomicI32::fetch_max`].
     pub fn atomic_max_acq<T: Copy>(dst: *mut T, src: T) -> T;
     /// Maximum with the current value using a signed comparison.
     ///
     /// The stabilized version of this intrinsic is available on the
-    /// `std::sync::atomic` signed integer types via the `fetch_max` method by passing
-    /// [`Ordering::Release`](crate::sync::atomic::Ordering::Release)
-    /// as the `order`. For example,
-    /// [`AtomicI32::fetch_max`](crate::sync::atomic::AtomicI32::fetch_max).
+    /// [`atomic`] signed integer types via the `fetch_max` method by passing
+    /// [`Ordering::Release`] as the `order`. For example, [`AtomicI32::fetch_max`].
     pub fn atomic_max_rel<T: Copy>(dst: *mut T, src: T) -> T;
     /// Maximum with the current value using a signed comparison.
     ///
     /// The stabilized version of this intrinsic is available on the
-    /// `std::sync::atomic` signed integer types via the `fetch_max` method by passing
-    /// [`Ordering::AcqRel`](crate::sync::atomic::Ordering::AcqRel)
-    /// as the `order`. For example,
-    /// [`AtomicI32::fetch_max`](crate::sync::atomic::AtomicI32::fetch_max).
+    /// [`atomic`] signed integer types via the `fetch_max` method by passing
+    /// [`Ordering::AcqRel`] as the `order`. For example, [`AtomicI32::fetch_max`].
     pub fn atomic_max_acqrel<T: Copy>(dst: *mut T, src: T) -> T;
     /// Maximum with the current value.
     ///
     /// The stabilized version of this intrinsic is available on the
-    /// `std::sync::atomic` signed integer types via the `fetch_max` method by passing
-    /// [`Ordering::Relaxed`](crate::sync::atomic::Ordering::Relaxed)
-    /// as the `order`. For example,
-    /// [`AtomicI32::fetch_max`](crate::sync::atomic::AtomicI32::fetch_max).
+    /// [`atomic`] signed integer types via the `fetch_max` method by passing
+    /// [`Ordering::Relaxed`] as the `order`. For example, [`AtomicI32::fetch_max`].
     pub fn atomic_max_relaxed<T: Copy>(dst: *mut T, src: T) -> T;
 
     /// Minimum with the current value using a signed comparison.
     ///
     /// The stabilized version of this intrinsic is available on the
-    /// `std::sync::atomic` signed integer types via the `fetch_min` method by passing
-    /// [`Ordering::SeqCst`](crate::sync::atomic::Ordering::SeqCst)
-    /// as the `order`. For example,
-    /// [`AtomicI32::fetch_min`](crate::sync::atomic::AtomicI32::fetch_min).
+    /// [`atomic`] signed integer types via the `fetch_min` method by passing
+    /// [`Ordering::SeqCst`] as the `order`. For example, [`AtomicI32::fetch_min`].
     pub fn atomic_min<T: Copy>(dst: *mut T, src: T) -> T;
     /// Minimum with the current value using a signed comparison.
     ///
     /// The stabilized version of this intrinsic is available on the
-    /// `std::sync::atomic` signed integer types via the `fetch_min` method by passing
-    /// [`Ordering::Acquire`](crate::sync::atomic::Ordering::Acquire)
-    /// as the `order`. For example,
-    /// [`AtomicI32::fetch_min`](crate::sync::atomic::AtomicI32::fetch_min).
+    /// [`atomic`] signed integer types via the `fetch_min` method by passing
+    /// [`Ordering::Acquire`] as the `order`. For example, [`AtomicI32::fetch_min`].
     pub fn atomic_min_acq<T: Copy>(dst: *mut T, src: T) -> T;
     /// Minimum with the current value using a signed comparison.
     ///
     /// The stabilized version of this intrinsic is available on the
-    /// `std::sync::atomic` signed integer types via the `fetch_min` method by passing
-    /// [`Ordering::Release`](crate::sync::atomic::Ordering::Release)
-    /// as the `order`. For example,
-    /// [`AtomicI32::fetch_min`](crate::sync::atomic::AtomicI32::fetch_min).
+    /// [`atomic`] signed integer types via the `fetch_min` method by passing
+    /// [`Ordering::Release`] as the `order`. For example, [`AtomicI32::fetch_min`].
     pub fn atomic_min_rel<T: Copy>(dst: *mut T, src: T) -> T;
     /// Minimum with the current value using a signed comparison.
     ///
     /// The stabilized version of this intrinsic is available on the
-    /// `std::sync::atomic` signed integer types via the `fetch_min` method by passing
-    /// [`Ordering::AcqRel`](crate::sync::atomic::Ordering::AcqRel)
-    /// as the `order`. For example,
-    /// [`AtomicI32::fetch_min`](crate::sync::atomic::AtomicI32::fetch_min).
+    /// [`atomic`] signed integer types via the `fetch_min` method by passing
+    /// [`Ordering::AcqRel`] as the `order`. For example, [`AtomicI32::fetch_min`].
     pub fn atomic_min_acqrel<T: Copy>(dst: *mut T, src: T) -> T;
     /// Minimum with the current value using a signed comparison.
     ///
     /// The stabilized version of this intrinsic is available on the
-    /// `std::sync::atomic` signed integer types via the `fetch_min` method by passing
-    /// [`Ordering::Relaxed`](crate::sync::atomic::Ordering::Relaxed)
-    /// as the `order`. For example,
-    /// [`AtomicI32::fetch_min`](crate::sync::atomic::AtomicI32::fetch_min).
+    /// [`atomic`] signed integer types via the `fetch_min` method by passing
+    /// [`Ordering::Relaxed`] as the `order`. For example, [`AtomicI32::fetch_min`].
     pub fn atomic_min_relaxed<T: Copy>(dst: *mut T, src: T) -> T;
 
     /// Minimum with the current value using an unsigned comparison.
     ///
     /// The stabilized version of this intrinsic is available on the
-    /// `std::sync::atomic` unsigned integer types via the `fetch_min` method by passing
-    /// [`Ordering::SeqCst`](crate::sync::atomic::Ordering::SeqCst)
-    /// as the `order`. For example,
-    /// [`AtomicU32::fetch_min`](crate::sync::atomic::AtomicU32::fetch_min).
+    /// [`atomic`] unsigned integer types via the `fetch_min` method by passing
+    /// [`Ordering::SeqCst`] as the `order`. For example, [`AtomicU32::fetch_min`].
     pub fn atomic_umin<T: Copy>(dst: *mut T, src: T) -> T;
     /// Minimum with the current value using an unsigned comparison.
     ///
     /// The stabilized version of this intrinsic is available on the
-    /// `std::sync::atomic` unsigned integer types via the `fetch_min` method by passing
-    /// [`Ordering::Acquire`](crate::sync::atomic::Ordering::Acquire)
-    /// as the `order`. For example,
-    /// [`AtomicU32::fetch_min`](crate::sync::atomic::AtomicU32::fetch_min).
+    /// [`atomic`] unsigned integer types via the `fetch_min` method by passing
+    /// [`Ordering::Acquire`] as the `order`. For example, [`AtomicU32::fetch_min`].
     pub fn atomic_umin_acq<T: Copy>(dst: *mut T, src: T) -> T;
     /// Minimum with the current value using an unsigned comparison.
     ///
     /// The stabilized version of this intrinsic is available on the
-    /// `std::sync::atomic` unsigned integer types via the `fetch_min` method by passing
-    /// [`Ordering::Release`](crate::sync::atomic::Ordering::Release)
-    /// as the `order`. For example,
-    /// [`AtomicU32::fetch_min`](crate::sync::atomic::AtomicU32::fetch_min).
+    /// [`atomic`] unsigned integer types via the `fetch_min` method by passing
+    /// [`Ordering::Release`] as the `order`. For example, [`AtomicU32::fetch_min`].
     pub fn atomic_umin_rel<T: Copy>(dst: *mut T, src: T) -> T;
     /// Minimum with the current value using an unsigned comparison.
     ///
     /// The stabilized version of this intrinsic is available on the
-    /// `std::sync::atomic` unsigned integer types via the `fetch_min` method by passing
-    /// [`Ordering::AcqRel`](crate::sync::atomic::Ordering::AcqRel)
-    /// as the `order`. For example,
-    /// [`AtomicU32::fetch_min`](crate::sync::atomic::AtomicU32::fetch_min).
+    /// [`atomic`] unsigned integer types via the `fetch_min` method by passing
+    /// [`Ordering::AcqRel`] as the `order`. For example, [`AtomicU32::fetch_min`].
     pub fn atomic_umin_acqrel<T: Copy>(dst: *mut T, src: T) -> T;
     /// Minimum with the current value using an unsigned comparison.
     ///
     /// The stabilized version of this intrinsic is available on the
-    /// `std::sync::atomic` unsigned integer types via the `fetch_min` method by passing
-    /// [`Ordering::Relaxed`](crate::sync::atomic::Ordering::Relaxed)
-    /// as the `order`. For example,
-    /// [`AtomicU32::fetch_min`](crate::sync::atomic::AtomicU32::fetch_min).
+    /// [`atomic`] unsigned integer types via the `fetch_min` method by passing
+    /// [`Ordering::Relaxed`] as the `order`. For example, [`AtomicU32::fetch_min`].
     pub fn atomic_umin_relaxed<T: Copy>(dst: *mut T, src: T) -> T;
 
     /// Maximum with the current value using an unsigned comparison.
     ///
     /// The stabilized version of this intrinsic is available on the
-    /// `std::sync::atomic` unsigned integer types via the `fetch_max` method by passing
-    /// [`Ordering::SeqCst`](crate::sync::atomic::Ordering::SeqCst)
-    /// as the `order`. For example,
-    /// [`AtomicU32::fetch_max`](crate::sync::atomic::AtomicU32::fetch_max).
+    /// [`atomic`] unsigned integer types via the `fetch_max` method by passing
+    /// [`Ordering::SeqCst`] as the `order`. For example, [`AtomicU32::fetch_max`].
     pub fn atomic_umax<T: Copy>(dst: *mut T, src: T) -> T;
     /// Maximum with the current value using an unsigned comparison.
     ///
     /// The stabilized version of this intrinsic is available on the
-    /// `std::sync::atomic` unsigned integer types via the `fetch_max` method by passing
-    /// [`Ordering::Acquire`](crate::sync::atomic::Ordering::Acquire)
-    /// as the `order`. For example,
-    /// [`AtomicU32::fetch_max`](crate::sync::atomic::AtomicU32::fetch_max).
+    /// [`atomic`] unsigned integer types via the `fetch_max` method by passing
+    /// [`Ordering::Acquire`] as the `order`. For example, [`AtomicU32::fetch_max`].
     pub fn atomic_umax_acq<T: Copy>(dst: *mut T, src: T) -> T;
     /// Maximum with the current value using an unsigned comparison.
     ///
     /// The stabilized version of this intrinsic is available on the
-    /// `std::sync::atomic` unsigned integer types via the `fetch_max` method by passing
-    /// [`Ordering::Release`](crate::sync::atomic::Ordering::Release)
-    /// as the `order`. For example,
-    /// [`AtomicU32::fetch_max`](crate::sync::atomic::AtomicU32::fetch_max).
+    /// [`atomic`] unsigned integer types via the `fetch_max` method by passing
+    /// [`Ordering::Release`] as the `order`. For example, [`AtomicU32::fetch_max`].
     pub fn atomic_umax_rel<T: Copy>(dst: *mut T, src: T) -> T;
     /// Maximum with the current value using an unsigned comparison.
     ///
     /// The stabilized version of this intrinsic is available on the
-    /// `std::sync::atomic` unsigned integer types via the `fetch_max` method by passing
-    /// [`Ordering::AcqRel`](crate::sync::atomic::Ordering::AcqRel)
-    /// as the `order`. For example,
-    /// [`AtomicU32::fetch_max`](crate::sync::atomic::AtomicU32::fetch_max).
+    /// [`atomic`] unsigned integer types via the `fetch_max` method by passing
+    /// [`Ordering::AcqRel`] as the `order`. For example, [`AtomicU32::fetch_max`].
     pub fn atomic_umax_acqrel<T: Copy>(dst: *mut T, src: T) -> T;
     /// Maximum with the current value using an unsigned comparison.
     ///
     /// The stabilized version of this intrinsic is available on the
-    /// `std::sync::atomic` unsigned integer types via the `fetch_max` method by passing
-    /// [`Ordering::Relaxed`](crate::sync::atomic::Ordering::Relaxed)
-    /// as the `order`. For example,
-    /// [`AtomicU32::fetch_max`](crate::sync::atomic::AtomicU32::fetch_max).
+    /// [`atomic`] unsigned integer types via the `fetch_max` method by passing
+    /// [`Ordering::Relaxed`] as the `order`. For example, [`AtomicU32::fetch_max`].
     pub fn atomic_umax_relaxed<T: Copy>(dst: *mut T, src: T) -> T;
 
     /// The `prefetch` intrinsic is a hint to the code generator to insert a prefetch instruction
@@ -823,33 +632,25 @@ extern "rust-intrinsic" {
     /// An atomic fence.
     ///
     /// The stabilized version of this intrinsic is available in
-    /// [`std::sync::atomic::fence`](crate::sync::atomic::fence)
-    /// by passing
-    /// [`Ordering::SeqCst`](crate::sync::atomic::Ordering::SeqCst)
+    /// [`atomic::fence`] by passing [`Ordering::SeqCst`]
     /// as the `order`.
     pub fn atomic_fence();
     /// An atomic fence.
     ///
     /// The stabilized version of this intrinsic is available in
-    /// [`std::sync::atomic::fence`](crate::sync::atomic::fence)
-    /// by passing
-    /// [`Ordering::Acquire`](crate::sync::atomic::Ordering::Acquire)
+    /// [`atomic::fence`] by passing [`Ordering::Acquire`]
     /// as the `order`.
     pub fn atomic_fence_acq();
     /// An atomic fence.
     ///
     /// The stabilized version of this intrinsic is available in
-    /// [`std::sync::atomic::fence`](crate::sync::atomic::fence)
-    /// by passing
-    /// [`Ordering::Release`](crate::sync::atomic::Ordering::Release)
+    /// [`atomic::fence`] by passing [`Ordering::Release`]
     /// as the `order`.
     pub fn atomic_fence_rel();
     /// An atomic fence.
     ///
     /// The stabilized version of this intrinsic is available in
-    /// [`std::sync::atomic::fence`](crate::sync::atomic::fence)
-    /// by passing
-    /// [`Ordering::AcqRel`](crate::sync::atomic::Ordering::AcqRel)
+    /// [`atomic::fence`] by passing [`Ordering::AcqRel`]
     /// as the `order`.
     pub fn atomic_fence_acqrel();
 
@@ -861,9 +662,7 @@ extern "rust-intrinsic" {
     /// such as when interacting with signal handlers.
     ///
     /// The stabilized version of this intrinsic is available in
-    /// [`std::sync::atomic::compiler_fence`](crate::sync::atomic::compiler_fence)
-    /// by passing
-    /// [`Ordering::SeqCst`](crate::sync::atomic::Ordering::SeqCst)
+    /// [`atomic::compiler_fence`] by passing [`Ordering::SeqCst`]
     /// as the `order`.
     pub fn atomic_singlethreadfence();
     /// A compiler-only memory barrier.
@@ -874,9 +673,7 @@ extern "rust-intrinsic" {
     /// such as when interacting with signal handlers.
     ///
     /// The stabilized version of this intrinsic is available in
-    /// [`std::sync::atomic::compiler_fence`](crate::sync::atomic::compiler_fence)
-    /// by passing
-    /// [`Ordering::Acquire`](crate::sync::atomic::Ordering::Acquire)
+    /// [`atomic::compiler_fence`] by passing [`Ordering::Acquire`]
     /// as the `order`.
     pub fn atomic_singlethreadfence_acq();
     /// A compiler-only memory barrier.
@@ -887,9 +684,7 @@ extern "rust-intrinsic" {
     /// such as when interacting with signal handlers.
     ///
     /// The stabilized version of this intrinsic is available in
-    /// [`std::sync::atomic::compiler_fence`](crate::sync::atomic::compiler_fence)
-    /// by passing
-    /// [`Ordering::Release`](crate::sync::atomic::Ordering::Release)
+    /// [`atomic::compiler_fence`] by passing [`Ordering::Release`]
     /// as the `order`.
     pub fn atomic_singlethreadfence_rel();
     /// A compiler-only memory barrier.
@@ -900,9 +695,7 @@ extern "rust-intrinsic" {
     /// such as when interacting with signal handlers.
     ///
     /// The stabilized version of this intrinsic is available in
-    /// [`std::sync::atomic::compiler_fence`](crate::sync::atomic::compiler_fence)
-    /// by passing
-    /// [`Ordering::AcqRel`](crate::sync::atomic::Ordering::AcqRel)
+    /// [`atomic::compiler_fence`] by passing [`Ordering::AcqRel`]
     /// as the `order`.
     pub fn atomic_singlethreadfence_acqrel();
 
@@ -930,8 +723,7 @@ extern "rust-intrinsic" {
     /// macro, which panics when it is executed, it is *undefined behavior* to
     /// reach code marked with this function.
     ///
-    /// The stabilized version of this intrinsic is
-    /// [`std::hint::unreachable_unchecked`](crate::hint::unreachable_unchecked).
+    /// The stabilized version of this intrinsic is [`crate::hint::unreachable_unchecked`].
     #[rustc_const_unstable(feature = "const_unreachable_unchecked", issue = "53188")]
     pub fn unreachable() -> !;
 
@@ -975,8 +767,7 @@ extern "rust-intrinsic" {
     /// More specifically, this is the offset in bytes between successive
     /// items of the same type, including alignment padding.
     ///
-    /// The stabilized version of this intrinsic is
-    /// [`std::mem::size_of`](crate::mem::size_of).
+    /// The stabilized version of this intrinsic is [`size_of`].
     #[rustc_const_stable(feature = "const_size_of", since = "1.40.0")]
     pub fn size_of<T>() -> usize;
 
@@ -984,14 +775,12 @@ extern "rust-intrinsic" {
     ///
     /// Drop glue is not run on the destination.
     ///
-    /// The stabilized version of this intrinsic is
-    /// [`std::ptr::write`](crate::ptr::write).
+    /// The stabilized version of this intrinsic is [`crate::ptr::write`].
     pub fn move_val_init<T>(dst: *mut T, src: T);
 
     /// The minimum alignment of a type.
     ///
-    /// The stabilized version of this intrinsic is
-    /// [`std::mem::align_of`](crate::mem::align_of).
+    /// The stabilized version of this intrinsic is [`crate::mem::align_of`].
     #[rustc_const_stable(feature = "const_min_align_of", since = "1.40.0")]
     pub fn min_align_of<T>() -> usize;
     /// The preferred alignment of a type.
@@ -1002,21 +791,18 @@ extern "rust-intrinsic" {
 
     /// The size of the referenced value in bytes.
     ///
-    /// The stabilized version of this intrinsic is
-    /// [`std::mem::size_of_val`](crate::mem::size_of_val).
+    /// The stabilized version of this intrinsic is [`size_of_val`].
     #[rustc_const_unstable(feature = "const_size_of_val", issue = "46571")]
     pub fn size_of_val<T: ?Sized>(_: *const T) -> usize;
     /// The required alignment of the referenced value.
     ///
-    /// The stabilized version of this intrinsic is
-    /// [`std::mem::align_of_val`](crate::mem::align_of_val).
+    /// The stabilized version of this intrinsic is [`crate::mem::align_of_val`].
     #[rustc_const_unstable(feature = "const_align_of_val", issue = "46571")]
     pub fn min_align_of_val<T: ?Sized>(_: *const T) -> usize;
 
     /// Gets a static string slice containing the name of a type.
     ///
-    /// The stabilized version of this intrinsic is
-    /// [`std::any::type_name`](crate::any::type_name)
+    /// The stabilized version of this intrinsic is [`crate::any::type_name`].
     #[rustc_const_unstable(feature = "const_type_name", issue = "63084")]
     pub fn type_name<T: ?Sized>() -> &'static str;
 
@@ -1024,8 +810,7 @@ extern "rust-intrinsic" {
     /// function will return the same value for a type regardless of whichever
     /// crate it is invoked in.
     ///
-    /// The stabilized version of this intrinsic is
-    /// [`std::any::TypeId::of`](crate::any::TypeId::of)
+    /// The stabilized version of this intrinsic is [`crate::any::TypeId::of`].
     #[rustc_const_stable(feature = "const_type_id", since = "1.46.0")]
     pub fn type_id<T: ?Sized + 'static>() -> u64;
 
@@ -1049,15 +834,14 @@ extern "rust-intrinsic" {
 
     /// Gets a reference to a static `Location` indicating where it was called.
     ///
-    /// Consider using [`std::panic::Location::caller`](crate::panic::Location::caller)
-    /// instead.
+    /// Consider using [`crate::panic::Location::caller`] instead.
     #[rustc_const_unstable(feature = "const_caller_location", issue = "47809")]
     pub fn caller_location() -> &'static crate::panic::Location<'static>;
 
     /// Moves a value out of scope without running drop glue.
     ///
-    /// This exists solely for [`mem::forget_unsized`](../../std/mem/fn.forget_unsized.html);
-    /// normal `forget` uses `ManuallyDrop` instead.
+    /// This exists solely for [`mem::forget_unsized`]; normal `forget` uses
+    /// `ManuallyDrop` instead.
     pub fn forget<T: ?Sized>(_: T);
 
     /// Reinterprets the bits of a value of one type as another type.
@@ -1300,8 +1084,7 @@ extern "rust-intrinsic" {
     /// If the actual type neither requires drop glue nor implements
     /// `Copy`, then the return value of this function is unspecified.
     ///
-    /// The stabilized version of this intrinsic is
-    /// [`std::mem::needs_drop`](crate::mem::needs_drop).
+    /// The stabilized version of this intrinsic is [`needs_drop`].
     #[rustc_const_stable(feature = "const_needs_drop", since = "1.40.0")]
     pub fn needs_drop<T>() -> bool;
 
@@ -1371,13 +1154,11 @@ extern "rust-intrinsic" {
 
     /// Performs a volatile load from the `src` pointer.
     ///
-    /// The stabilized version of this intrinsic is
-    /// [`std::ptr::read_volatile`](crate::ptr::read_volatile).
+    /// The stabilized version of this intrinsic is [`crate::ptr::read_volatile`].
     pub fn volatile_load<T>(src: *const T) -> T;
     /// Performs a volatile store to the `dst` pointer.
     ///
-    /// The stabilized version of this intrinsic is
-    /// [`std::ptr::write_volatile`](crate::ptr::write_volatile).
+    /// The stabilized version of this intrinsic is [`crate::ptr::write_volatile`].
     pub fn volatile_store<T>(dst: *mut T, val: T);
 
     /// Performs a volatile load from the `src` pointer
@@ -1526,22 +1307,22 @@ extern "rust-intrinsic" {
     /// Returns the minimum of two `f32` values.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::f32::min`](f32::min)
+    /// [`f32::min`]
     pub fn minnumf32(x: f32, y: f32) -> f32;
     /// Returns the minimum of two `f64` values.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::f64::min`](f64::min)
+    /// [`f64::min`]
     pub fn minnumf64(x: f64, y: f64) -> f64;
     /// Returns the maximum of two `f32` values.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::f32::max`](f32::max)
+    /// [`f32::max`]
     pub fn maxnumf32(x: f32, y: f32) -> f32;
     /// Returns the maximum of two `f64` values.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::f64::max`](f64::max)
+    /// [`f64::max`]
     pub fn maxnumf64(x: f64, y: f64) -> f64;
 
     /// Copies the sign from `y` to `x` for `f32` values.
@@ -1648,15 +1429,14 @@ extern "rust-intrinsic" {
     /// Convert with LLVM’s fptoui/fptosi, which may return undef for values out of range
     /// (<https://github.com/rust-lang/rust/issues/10184>)
     ///
-    /// Stabilized as [`f32::to_int_unchecked`](../../std/primitive.f32.html#method.to_int_unchecked)
-    /// and [`f64::to_int_unchecked`](../../std/primitive.f64.html#method.to_int_unchecked).
+    /// Stabilized as [`f32::to_int_unchecked`] and [`f64::to_int_unchecked`].
     pub fn float_to_int_unchecked<Float: Copy, Int: Copy>(value: Float) -> Int;
 
     /// Returns the number of bits set in an integer type `T`
     ///
     /// The stabilized versions of this intrinsic are available on the integer
     /// primitives via the `count_ones` method. For example,
-    /// [`std::u32::count_ones`](u32::count_ones)
+    /// [`u32::count_ones`]
     #[rustc_const_stable(feature = "const_ctpop", since = "1.40.0")]
     pub fn ctpop<T: Copy>(x: T) -> T;
 
@@ -1664,7 +1444,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized versions of this intrinsic are available on the integer
     /// primitives via the `leading_zeros` method. For example,
-    /// [`std::u32::leading_zeros`](u32::leading_zeros)
+    /// [`u32::leading_zeros`]
     ///
     /// # Examples
     ///
@@ -1715,7 +1495,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized versions of this intrinsic are available on the integer
     /// primitives via the `trailing_zeros` method. For example,
-    /// [`std::u32::trailing_zeros`](u32::trailing_zeros)
+    /// [`u32::trailing_zeros`]
     ///
     /// # Examples
     ///
@@ -1766,7 +1546,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized versions of this intrinsic are available on the integer
     /// primitives via the `swap_bytes` method. For example,
-    /// [`std::u32::swap_bytes`](u32::swap_bytes)
+    /// [`u32::swap_bytes`]
     #[rustc_const_stable(feature = "const_bswap", since = "1.40.0")]
     pub fn bswap<T: Copy>(x: T) -> T;
 
@@ -1774,7 +1554,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized versions of this intrinsic are available on the integer
     /// primitives via the `reverse_bits` method. For example,
-    /// [`std::u32::reverse_bits`](u32::reverse_bits)
+    /// [`u32::reverse_bits`]
     #[rustc_const_stable(feature = "const_bitreverse", since = "1.40.0")]
     pub fn bitreverse<T: Copy>(x: T) -> T;
 
@@ -1782,7 +1562,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized versions of this intrinsic are available on the integer
     /// primitives via the `overflowing_add` method. For example,
-    /// [`std::u32::overflowing_add`](u32::overflowing_add)
+    /// [`u32::overflowing_add`]
     #[rustc_const_stable(feature = "const_int_overflow", since = "1.40.0")]
     pub fn add_with_overflow<T: Copy>(x: T, y: T) -> (T, bool);
 
@@ -1790,7 +1570,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized versions of this intrinsic are available on the integer
     /// primitives via the `overflowing_sub` method. For example,
-    /// [`std::u32::overflowing_sub`](u32::overflowing_sub)
+    /// [`u32::overflowing_sub`]
     #[rustc_const_stable(feature = "const_int_overflow", since = "1.40.0")]
     pub fn sub_with_overflow<T: Copy>(x: T, y: T) -> (T, bool);
 
@@ -1798,7 +1578,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized versions of this intrinsic are available on the integer
     /// primitives via the `overflowing_mul` method. For example,
-    /// [`std::u32::overflowing_mul`](u32::overflowing_mul)
+    /// [`u32::overflowing_mul`]
     #[rustc_const_stable(feature = "const_int_overflow", since = "1.40.0")]
     pub fn mul_with_overflow<T: Copy>(x: T, y: T) -> (T, bool);
 
@@ -1813,7 +1593,7 @@ extern "rust-intrinsic" {
     ///
     /// Safe wrappers for this intrinsic are available on the integer
     /// primitives via the `checked_div` method. For example,
-    /// [`std::u32::checked_div`](u32::checked_div)
+    /// [`u32::checked_div`]
     #[rustc_const_unstable(feature = "const_int_unchecked_arith", issue = "none")]
     pub fn unchecked_div<T: Copy>(x: T, y: T) -> T;
     /// Returns the remainder of an unchecked division, resulting in
@@ -1821,7 +1601,7 @@ extern "rust-intrinsic" {
     ///
     /// Safe wrappers for this intrinsic are available on the integer
     /// primitives via the `checked_rem` method. For example,
-    /// [`std::u32::checked_rem`](u32::checked_rem)
+    /// [`u32::checked_rem`]
     #[rustc_const_unstable(feature = "const_int_unchecked_arith", issue = "none")]
     pub fn unchecked_rem<T: Copy>(x: T, y: T) -> T;
 
@@ -1830,7 +1610,7 @@ extern "rust-intrinsic" {
     ///
     /// Safe wrappers for this intrinsic are available on the integer
     /// primitives via the `checked_shl` method. For example,
-    /// [`std::u32::checked_shl`](u32::checked_shl)
+    /// [`u32::checked_shl`]
     #[rustc_const_stable(feature = "const_int_unchecked", since = "1.40.0")]
     pub fn unchecked_shl<T: Copy>(x: T, y: T) -> T;
     /// Performs an unchecked right shift, resulting in undefined behavior when
@@ -1838,7 +1618,7 @@ extern "rust-intrinsic" {
     ///
     /// Safe wrappers for this intrinsic are available on the integer
     /// primitives via the `checked_shr` method. For example,
-    /// [`std::u32::checked_shr`](u32::checked_shr)
+    /// [`u32::checked_shr`]
     #[rustc_const_stable(feature = "const_int_unchecked", since = "1.40.0")]
     pub fn unchecked_shr<T: Copy>(x: T, y: T) -> T;
 
@@ -1867,7 +1647,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized versions of this intrinsic are available on the integer
     /// primitives via the `rotate_left` method. For example,
-    /// [`std::u32::rotate_left`](u32::rotate_left)
+    /// [`u32::rotate_left`]
     #[rustc_const_stable(feature = "const_int_rotate", since = "1.40.0")]
     pub fn rotate_left<T: Copy>(x: T, y: T) -> T;
 
@@ -1875,7 +1655,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized versions of this intrinsic are available on the integer
     /// primitives via the `rotate_right` method. For example,
-    /// [`std::u32::rotate_right`](u32::rotate_right)
+    /// [`u32::rotate_right`]
     #[rustc_const_stable(feature = "const_int_rotate", since = "1.40.0")]
     pub fn rotate_right<T: Copy>(x: T, y: T) -> T;
 
@@ -1883,21 +1663,21 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized versions of this intrinsic are available on the integer
     /// primitives via the `checked_add` method. For example,
-    /// [`std::u32::checked_add`](u32::checked_add)
+    /// [`u32::checked_add`]
     #[rustc_const_stable(feature = "const_int_wrapping", since = "1.40.0")]
     pub fn wrapping_add<T: Copy>(a: T, b: T) -> T;
     /// Returns (a - b) mod 2<sup>N</sup>, where N is the width of T in bits.
     ///
     /// The stabilized versions of this intrinsic are available on the integer
     /// primitives via the `checked_sub` method. For example,
-    /// [`std::u32::checked_sub`](u32::checked_sub)
+    /// [`u32::checked_sub`]
     #[rustc_const_stable(feature = "const_int_wrapping", since = "1.40.0")]
     pub fn wrapping_sub<T: Copy>(a: T, b: T) -> T;
     /// Returns (a * b) mod 2<sup>N</sup>, where N is the width of T in bits.
     ///
     /// The stabilized versions of this intrinsic are available on the integer
     /// primitives via the `checked_mul` method. For example,
-    /// [`std::u32::checked_mul`](u32::checked_mul)
+    /// [`u32::checked_mul`]
     #[rustc_const_stable(feature = "const_int_wrapping", since = "1.40.0")]
     pub fn wrapping_mul<T: Copy>(a: T, b: T) -> T;
 
@@ -1905,30 +1685,28 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized versions of this intrinsic are available on the integer
     /// primitives via the `saturating_add` method. For example,
-    /// [`std::u32::saturating_add`](u32::saturating_add)
+    /// [`u32::saturating_add`]
     #[rustc_const_stable(feature = "const_int_saturating", since = "1.40.0")]
     pub fn saturating_add<T: Copy>(a: T, b: T) -> T;
     /// Computes `a - b`, while saturating at numeric bounds.
     ///
     /// The stabilized versions of this intrinsic are available on the integer
     /// primitives via the `saturating_sub` method. For example,
-    /// [`std::u32::saturating_sub`](u32::saturating_sub)
+    /// [`u32::saturating_sub`]
     #[rustc_const_stable(feature = "const_int_saturating", since = "1.40.0")]
     pub fn saturating_sub<T: Copy>(a: T, b: T) -> T;
 
     /// Returns the value of the discriminant for the variant in 'v',
     /// cast to a `u64`; if `T` has no discriminant, returns 0.
     ///
-    /// The stabilized version of this intrinsic is
-    /// [`std::mem::discriminant`](crate::mem::discriminant)
+    /// The stabilized version of this intrinsic is [`crate::mem::discriminant`].
     #[rustc_const_unstable(feature = "const_discriminant", issue = "69821")]
     pub fn discriminant_value<T>(v: &T) -> <T as DiscriminantKind>::Discriminant;
 
     /// Returns the number of variants of the type `T` cast to a `usize`;
     /// if `T` has no variants, returns 0. Uninhabited variants will be counted.
     ///
-    /// The to-be-stabilized version of this intrinsic is
-    /// [`std::mem::variant_count`](crate::mem::variant_count)
+    /// The to-be-stabilized version of this intrinsic is [`variant_count`].
     #[rustc_const_unstable(feature = "variant_count", issue = "73662")]
     pub fn variant_count<T>() -> usize;
 
@@ -2077,7 +1855,6 @@ pub(crate) fn is_nonoverlapping<T>(src: *const T, dst: *const T, count: usize) -
 /// Note that even if the effectively copied size (`count * size_of::<T>()`) is
 /// `0`, the pointers must be non-NULL and properly aligned.
 ///
-/// [`Copy`]: crate::marker::Copy
 /// [`read`]: crate::ptr::read
 /// [read-ownership]: crate::ptr::read#ownership-of-the-returned-value
 /// [valid]: crate::ptr#safety
@@ -2179,7 +1956,6 @@ pub unsafe fn copy_nonoverlapping<T>(src: *const T, dst: *mut T, count: usize) {
 /// Note that even if the effectively copied size (`count * size_of::<T>()`) is
 /// `0`, the pointers must be non-NULL and properly aligned.
 ///
-/// [`Copy`]: crate::marker::Copy
 /// [`read`]: crate::ptr::read
 /// [read-ownership]: crate::ptr::read#ownership-of-the-returned-value
 /// [valid]: crate::ptr#safety

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -2079,8 +2079,8 @@ pub(crate) fn is_nonoverlapping<T>(src: *const T, dst: *const T, count: usize) -
 ///
 /// [`Copy`]: crate::marker::Copy
 /// [`read`]: crate::ptr::read
-/// [read-ownership]: crate::ptr::read
-/// [valid]: crate::ptr
+/// [read-ownership]: crate::ptr::read#ownership-of-the-returned-value
+/// [valid]: crate::ptr#safety
 ///
 /// # Examples
 ///
@@ -2181,8 +2181,8 @@ pub unsafe fn copy_nonoverlapping<T>(src: *const T, dst: *mut T, count: usize) {
 ///
 /// [`Copy`]: crate::marker::Copy
 /// [`read`]: crate::ptr::read
-/// [read-ownership]: crate::ptr::read
-/// [valid]: crate::ptr
+/// [read-ownership]: crate::ptr::read#ownership-of-the-returned-value
+/// [valid]: crate::ptr#safety
 ///
 /// # Examples
 ///
@@ -2240,7 +2240,7 @@ pub unsafe fn copy<T>(src: *const T, dst: *mut T, count: usize) {
 /// Note that even if the effectively copied size (`count * size_of::<T>()`) is
 /// `0`, the pointer must be non-NULL and properly aligned.
 ///
-/// [valid]: crate::ptr
+/// [valid]: crate::ptr#safety
 ///
 /// # Examples
 ///

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -985,7 +985,7 @@ extern "rust-intrinsic" {
     /// Drop glue is not run on the destination.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::ptr::write`](../../std/ptr/fn.write.html).
+    /// [`std::ptr::write`](crate::ptr::write).
     pub fn move_val_init<T>(dst: *mut T, src: T);
 
     /// The minimum alignment of a type.
@@ -1372,12 +1372,12 @@ extern "rust-intrinsic" {
     /// Performs a volatile load from the `src` pointer.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::ptr::read_volatile`](../../std/ptr/fn.read_volatile.html).
+    /// [`std::ptr::read_volatile`](crate::ptr::read_volatile).
     pub fn volatile_load<T>(src: *const T) -> T;
     /// Performs a volatile store to the `dst` pointer.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::ptr::write_volatile`](../../std/ptr/fn.write_volatile.html).
+    /// [`std::ptr::write_volatile`](crate::ptr::write_volatile).
     pub fn volatile_store<T>(dst: *mut T, val: T);
 
     /// Performs a volatile load from the `src` pointer

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -280,7 +280,7 @@ extern "rust-intrinsic" {
     /// `std::sync::atomic` types via the `load` method by passing
     /// [`Ordering::SeqCst`](crate::sync::atomic::Ordering::SeqCst)
     /// as the `order`. For example,
-    /// [`AtomicBool::load`](../../std/sync/atomic/struct.AtomicBool.html#method.load).
+    /// [`AtomicBool::load`](crate::sync::atomic::AtomicBool::load).
     pub fn atomic_load<T: Copy>(src: *const T) -> T;
     /// Loads the current value of the pointer.
     ///
@@ -288,7 +288,7 @@ extern "rust-intrinsic" {
     /// `std::sync::atomic` types via the `load` method by passing
     /// [`Ordering::Acquire`](crate::sync::atomic::Ordering::Acquire)
     /// as the `order`. For example,
-    /// [`AtomicBool::load`](../../std/sync/atomic/struct.AtomicBool.html#method.load).
+    /// [`AtomicBool::load`](crate::sync::atomic::AtomicBool::load).
     pub fn atomic_load_acq<T: Copy>(src: *const T) -> T;
     /// Loads the current value of the pointer.
     ///
@@ -296,7 +296,7 @@ extern "rust-intrinsic" {
     /// `std::sync::atomic` types via the `load` method by passing
     /// [`Ordering::Relaxed`](crate::sync::atomic::Ordering::Relaxed)
     /// as the `order`. For example,
-    /// [`AtomicBool::load`](../../std/sync/atomic/struct.AtomicBool.html#method.load).
+    /// [`AtomicBool::load`](crate::sync::atomic::AtomicBool::load).
     pub fn atomic_load_relaxed<T: Copy>(src: *const T) -> T;
     pub fn atomic_load_unordered<T: Copy>(src: *const T) -> T;
 
@@ -306,7 +306,7 @@ extern "rust-intrinsic" {
     /// `std::sync::atomic` types via the `store` method by passing
     /// [`Ordering::SeqCst`](crate::sync::atomic::Ordering::SeqCst)
     /// as the `order`. For example,
-    /// [`AtomicBool::store`](../../std/sync/atomic/struct.AtomicBool.html#method.store).
+    /// [`AtomicBool::store`](crate::sync::atomic::AtomicBool::store).
     pub fn atomic_store<T: Copy>(dst: *mut T, val: T);
     /// Stores the value at the specified memory location.
     ///
@@ -314,7 +314,7 @@ extern "rust-intrinsic" {
     /// `std::sync::atomic` types via the `store` method by passing
     /// [`Ordering::Release`](crate::sync::atomic::Ordering::Release)
     /// as the `order`. For example,
-    /// [`AtomicBool::store`](../../std/sync/atomic/struct.AtomicBool.html#method.store).
+    /// [`AtomicBool::store`](crate::sync::atomic::AtomicBool::store).
     pub fn atomic_store_rel<T: Copy>(dst: *mut T, val: T);
     /// Stores the value at the specified memory location.
     ///
@@ -322,7 +322,7 @@ extern "rust-intrinsic" {
     /// `std::sync::atomic` types via the `store` method by passing
     /// [`Ordering::Relaxed`](crate::sync::atomic::Ordering::Relaxed)
     /// as the `order`. For example,
-    /// [`AtomicBool::store`](../../std/sync/atomic/struct.AtomicBool.html#method.store).
+    /// [`AtomicBool::store`](crate::sync::atomic::AtomicBool::store).
     pub fn atomic_store_relaxed<T: Copy>(dst: *mut T, val: T);
     pub fn atomic_store_unordered<T: Copy>(dst: *mut T, val: T);
 
@@ -332,7 +332,7 @@ extern "rust-intrinsic" {
     /// `std::sync::atomic` types via the `swap` method by passing
     /// [`Ordering::SeqCst`](crate::sync::atomic::Ordering::SeqCst)
     /// as the `order`. For example,
-    /// [`AtomicBool::swap`](../../std/sync/atomic/struct.AtomicBool.html#method.swap).
+    /// [`AtomicBool::swap`](crate::sync::atomic::AtomicBool::swap).
     pub fn atomic_xchg<T: Copy>(dst: *mut T, src: T) -> T;
     /// Stores the value at the specified memory location, returning the old value.
     ///
@@ -340,7 +340,7 @@ extern "rust-intrinsic" {
     /// `std::sync::atomic` types via the `swap` method by passing
     /// [`Ordering::Acquire`](crate::sync::atomic::Ordering::Acquire)
     /// as the `order`. For example,
-    /// [`AtomicBool::swap`](../../std/sync/atomic/struct.AtomicBool.html#method.swap).
+    /// [`AtomicBool::swap`](crate::sync::atomic::AtomicBool::swap).
     pub fn atomic_xchg_acq<T: Copy>(dst: *mut T, src: T) -> T;
     /// Stores the value at the specified memory location, returning the old value.
     ///
@@ -348,7 +348,7 @@ extern "rust-intrinsic" {
     /// `std::sync::atomic` types via the `swap` method by passing
     /// [`Ordering::Release`](crate::sync::atomic::Ordering::Release)
     /// as the `order`. For example,
-    /// [`AtomicBool::swap`](../../std/sync/atomic/struct.AtomicBool.html#method.swap).
+    /// [`AtomicBool::swap`](crate::sync::atomic::AtomicBool::swap).
     pub fn atomic_xchg_rel<T: Copy>(dst: *mut T, src: T) -> T;
     /// Stores the value at the specified memory location, returning the old value.
     ///
@@ -356,7 +356,7 @@ extern "rust-intrinsic" {
     /// `std::sync::atomic` types via the `swap` method by passing
     /// [`Ordering::AcqRel`](crate::sync::atomic::Ordering::AcqRel)
     /// as the `order`. For example,
-    /// [`AtomicBool::swap`](../../std/sync/atomic/struct.AtomicBool.html#method.swap).
+    /// [`AtomicBool::swap`](crate::sync::atomic::AtomicBool::swap).
     pub fn atomic_xchg_acqrel<T: Copy>(dst: *mut T, src: T) -> T;
     /// Stores the value at the specified memory location, returning the old value.
     ///
@@ -364,7 +364,7 @@ extern "rust-intrinsic" {
     /// `std::sync::atomic` types via the `swap` method by passing
     /// [`Ordering::Relaxed`](crate::sync::atomic::Ordering::Relaxed)
     /// as the `order`. For example,
-    /// [`AtomicBool::swap`](../../std/sync/atomic/struct.AtomicBool.html#method.swap).
+    /// [`AtomicBool::swap`](crate::sync::atomic::AtomicBool::swap).
     pub fn atomic_xchg_relaxed<T: Copy>(dst: *mut T, src: T) -> T;
 
     /// Adds to the current value, returning the previous value.
@@ -455,7 +455,7 @@ extern "rust-intrinsic" {
     /// `std::sync::atomic` types via the `fetch_and` method by passing
     /// [`Ordering::SeqCst`](crate::sync::atomic::Ordering::SeqCst)
     /// as the `order`. For example,
-    /// [`AtomicBool::fetch_and`](../../std/sync/atomic/struct.AtomicBool.html#method.fetch_and).
+    /// [`AtomicBool::fetch_and`](crate::sync::atomic::AtomicBool::fetch_and).
     pub fn atomic_and<T: Copy>(dst: *mut T, src: T) -> T;
     /// Bitwise and with the current value, returning the previous value.
     ///
@@ -463,7 +463,7 @@ extern "rust-intrinsic" {
     /// `std::sync::atomic` types via the `fetch_and` method by passing
     /// [`Ordering::Acquire`](crate::sync::atomic::Ordering::Acquire)
     /// as the `order`. For example,
-    /// [`AtomicBool::fetch_and`](../../std/sync/atomic/struct.AtomicBool.html#method.fetch_and).
+    /// [`AtomicBool::fetch_and`](crate::sync::atomic::AtomicBool::fetch_and).
     pub fn atomic_and_acq<T: Copy>(dst: *mut T, src: T) -> T;
     /// Bitwise and with the current value, returning the previous value.
     ///
@@ -471,7 +471,7 @@ extern "rust-intrinsic" {
     /// `std::sync::atomic` types via the `fetch_and` method by passing
     /// [`Ordering::Release`](crate::sync::atomic::Ordering::Release)
     /// as the `order`. For example,
-    /// [`AtomicBool::fetch_and`](../../std/sync/atomic/struct.AtomicBool.html#method.fetch_and).
+    /// [`AtomicBool::fetch_and`](crate::sync::atomic::AtomicBool::fetch_and).
     pub fn atomic_and_rel<T: Copy>(dst: *mut T, src: T) -> T;
     /// Bitwise and with the current value, returning the previous value.
     ///
@@ -479,7 +479,7 @@ extern "rust-intrinsic" {
     /// `std::sync::atomic` types via the `fetch_and` method by passing
     /// [`Ordering::AcqRel`](crate::sync::atomic::Ordering::AcqRel)
     /// as the `order`. For example,
-    /// [`AtomicBool::fetch_and`](../../std/sync/atomic/struct.AtomicBool.html#method.fetch_and).
+    /// [`AtomicBool::fetch_and`](crate::sync::atomic::AtomicBool::fetch_and).
     pub fn atomic_and_acqrel<T: Copy>(dst: *mut T, src: T) -> T;
     /// Bitwise and with the current value, returning the previous value.
     ///
@@ -487,7 +487,7 @@ extern "rust-intrinsic" {
     /// `std::sync::atomic` types via the `fetch_and` method by passing
     /// [`Ordering::Relaxed`](crate::sync::atomic::Ordering::Relaxed)
     /// as the `order`. For example,
-    /// [`AtomicBool::fetch_and`](../../std/sync/atomic/struct.AtomicBool.html#method.fetch_and).
+    /// [`AtomicBool::fetch_and`](crate::sync::atomic::AtomicBool::fetch_and).
     pub fn atomic_and_relaxed<T: Copy>(dst: *mut T, src: T) -> T;
 
     /// Bitwise nand with the current value, returning the previous value.
@@ -496,7 +496,7 @@ extern "rust-intrinsic" {
     /// `std::sync::atomic::AtomicBool` type via the `fetch_nand` method by passing
     /// [`Ordering::SeqCst`](crate::sync::atomic::Ordering::SeqCst)
     /// as the `order`. For example,
-    /// [`AtomicBool::fetch_nand`](../../std/sync/atomic/struct.AtomicBool.html#method.fetch_nand).
+    /// [`AtomicBool::fetch_nand`](crate::sync::atomic::AtomicBool::fetch_nand).
     pub fn atomic_nand<T: Copy>(dst: *mut T, src: T) -> T;
     /// Bitwise nand with the current value, returning the previous value.
     ///
@@ -504,7 +504,7 @@ extern "rust-intrinsic" {
     /// `std::sync::atomic::AtomicBool` type via the `fetch_nand` method by passing
     /// [`Ordering::Acquire`](crate::sync::atomic::Ordering::Acquire)
     /// as the `order`. For example,
-    /// [`AtomicBool::fetch_nand`](../../std/sync/atomic/struct.AtomicBool.html#method.fetch_nand).
+    /// [`AtomicBool::fetch_nand`](crate::sync::atomic::AtomicBool::fetch_nand).
     pub fn atomic_nand_acq<T: Copy>(dst: *mut T, src: T) -> T;
     /// Bitwise nand with the current value, returning the previous value.
     ///
@@ -512,7 +512,7 @@ extern "rust-intrinsic" {
     /// `std::sync::atomic::AtomicBool` type via the `fetch_nand` method by passing
     /// [`Ordering::Release`](crate::sync::atomic::Ordering::Release)
     /// as the `order`. For example,
-    /// [`AtomicBool::fetch_nand`](../../std/sync/atomic/struct.AtomicBool.html#method.fetch_nand).
+    /// [`AtomicBool::fetch_nand`](crate::sync::atomic::AtomicBool::fetch_nand).
     pub fn atomic_nand_rel<T: Copy>(dst: *mut T, src: T) -> T;
     /// Bitwise nand with the current value, returning the previous value.
     ///
@@ -520,7 +520,7 @@ extern "rust-intrinsic" {
     /// `std::sync::atomic::AtomicBool` type via the `fetch_nand` method by passing
     /// [`Ordering::AcqRel`](crate::sync::atomic::Ordering::AcqRel)
     /// as the `order`. For example,
-    /// [`AtomicBool::fetch_nand`](../../std/sync/atomic/struct.AtomicBool.html#method.fetch_nand).
+    /// [`AtomicBool::fetch_nand`](crate::sync::atomic::AtomicBool::fetch_nand).
     pub fn atomic_nand_acqrel<T: Copy>(dst: *mut T, src: T) -> T;
     /// Bitwise nand with the current value, returning the previous value.
     ///
@@ -528,7 +528,7 @@ extern "rust-intrinsic" {
     /// `std::sync::atomic::AtomicBool` type via the `fetch_nand` method by passing
     /// [`Ordering::Relaxed`](crate::sync::atomic::Ordering::Relaxed)
     /// as the `order`. For example,
-    /// [`AtomicBool::fetch_nand`](../../std/sync/atomic/struct.AtomicBool.html#method.fetch_nand).
+    /// [`AtomicBool::fetch_nand`](crate::sync::atomic::AtomicBool::fetch_nand).
     pub fn atomic_nand_relaxed<T: Copy>(dst: *mut T, src: T) -> T;
 
     /// Bitwise or with the current value, returning the previous value.
@@ -537,7 +537,7 @@ extern "rust-intrinsic" {
     /// `std::sync::atomic` types via the `fetch_or` method by passing
     /// [`Ordering::SeqCst`](crate::sync::atomic::Ordering::SeqCst)
     /// as the `order`. For example,
-    /// [`AtomicBool::fetch_or`](../../std/sync/atomic/struct.AtomicBool.html#method.fetch_or).
+    /// [`AtomicBool::fetch_or`](crate::sync::atomic::AtomicBool::fetch_or).
     pub fn atomic_or<T: Copy>(dst: *mut T, src: T) -> T;
     /// Bitwise or with the current value, returning the previous value.
     ///
@@ -545,7 +545,7 @@ extern "rust-intrinsic" {
     /// `std::sync::atomic` types via the `fetch_or` method by passing
     /// [`Ordering::Acquire`](crate::sync::atomic::Ordering::Acquire)
     /// as the `order`. For example,
-    /// [`AtomicBool::fetch_or`](../../std/sync/atomic/struct.AtomicBool.html#method.fetch_or).
+    /// [`AtomicBool::fetch_or`](crate::sync::atomic::AtomicBool::fetch_or).
     pub fn atomic_or_acq<T: Copy>(dst: *mut T, src: T) -> T;
     /// Bitwise or with the current value, returning the previous value.
     ///
@@ -553,7 +553,7 @@ extern "rust-intrinsic" {
     /// `std::sync::atomic` types via the `fetch_or` method by passing
     /// [`Ordering::Release`](crate::sync::atomic::Ordering::Release)
     /// as the `order`. For example,
-    /// [`AtomicBool::fetch_or`](../../std/sync/atomic/struct.AtomicBool.html#method.fetch_or).
+    /// [`AtomicBool::fetch_or`](crate::sync::atomic::AtomicBool::fetch_or).
     pub fn atomic_or_rel<T: Copy>(dst: *mut T, src: T) -> T;
     /// Bitwise or with the current value, returning the previous value.
     ///
@@ -561,7 +561,7 @@ extern "rust-intrinsic" {
     /// `std::sync::atomic` types via the `fetch_or` method by passing
     /// [`Ordering::AcqRel`](crate::sync::atomic::Ordering::AcqRel)
     /// as the `order`. For example,
-    /// [`AtomicBool::fetch_or`](../../std/sync/atomic/struct.AtomicBool.html#method.fetch_or).
+    /// [`AtomicBool::fetch_or`](crate::sync::atomic::AtomicBool::fetch_or).
     pub fn atomic_or_acqrel<T: Copy>(dst: *mut T, src: T) -> T;
     /// Bitwise or with the current value, returning the previous value.
     ///
@@ -569,7 +569,7 @@ extern "rust-intrinsic" {
     /// `std::sync::atomic` types via the `fetch_or` method by passing
     /// [`Ordering::Relaxed`](crate::sync::atomic::Ordering::Relaxed)
     /// as the `order`. For example,
-    /// [`AtomicBool::fetch_or`](../../std/sync/atomic/struct.AtomicBool.html#method.fetch_or).
+    /// [`AtomicBool::fetch_or`](crate::sync::atomic::AtomicBool::fetch_or).
     pub fn atomic_or_relaxed<T: Copy>(dst: *mut T, src: T) -> T;
 
     /// Bitwise xor with the current value, returning the previous value.
@@ -578,7 +578,7 @@ extern "rust-intrinsic" {
     /// `std::sync::atomic` types via the `fetch_xor` method by passing
     /// [`Ordering::SeqCst`](crate::sync::atomic::Ordering::SeqCst)
     /// as the `order`. For example,
-    /// [`AtomicBool::fetch_xor`](../../std/sync/atomic/struct.AtomicBool.html#method.fetch_xor).
+    /// [`AtomicBool::fetch_xor`](crate::sync::atomic::AtomicBool::fetch_xor).
     pub fn atomic_xor<T: Copy>(dst: *mut T, src: T) -> T;
     /// Bitwise xor with the current value, returning the previous value.
     ///
@@ -586,7 +586,7 @@ extern "rust-intrinsic" {
     /// `std::sync::atomic` types via the `fetch_xor` method by passing
     /// [`Ordering::Acquire`](crate::sync::atomic::Ordering::Acquire)
     /// as the `order`. For example,
-    /// [`AtomicBool::fetch_xor`](../../std/sync/atomic/struct.AtomicBool.html#method.fetch_xor).
+    /// [`AtomicBool::fetch_xor`](crate::sync::atomic::AtomicBool::fetch_xor).
     pub fn atomic_xor_acq<T: Copy>(dst: *mut T, src: T) -> T;
     /// Bitwise xor with the current value, returning the previous value.
     ///
@@ -594,7 +594,7 @@ extern "rust-intrinsic" {
     /// `std::sync::atomic` types via the `fetch_xor` method by passing
     /// [`Ordering::Release`](crate::sync::atomic::Ordering::Release)
     /// as the `order`. For example,
-    /// [`AtomicBool::fetch_xor`](../../std/sync/atomic/struct.AtomicBool.html#method.fetch_xor).
+    /// [`AtomicBool::fetch_xor`](crate::sync::atomic::AtomicBool::fetch_xor).
     pub fn atomic_xor_rel<T: Copy>(dst: *mut T, src: T) -> T;
     /// Bitwise xor with the current value, returning the previous value.
     ///
@@ -602,7 +602,7 @@ extern "rust-intrinsic" {
     /// `std::sync::atomic` types via the `fetch_xor` method by passing
     /// [`Ordering::AcqRel`](crate::sync::atomic::Ordering::AcqRel)
     /// as the `order`. For example,
-    /// [`AtomicBool::fetch_xor`](../../std/sync/atomic/struct.AtomicBool.html#method.fetch_xor).
+    /// [`AtomicBool::fetch_xor`](crate::sync::atomic::AtomicBool::fetch_xor).
     pub fn atomic_xor_acqrel<T: Copy>(dst: *mut T, src: T) -> T;
     /// Bitwise xor with the current value, returning the previous value.
     ///
@@ -610,7 +610,7 @@ extern "rust-intrinsic" {
     /// `std::sync::atomic` types via the `fetch_xor` method by passing
     /// [`Ordering::Relaxed`](crate::sync::atomic::Ordering::Relaxed)
     /// as the `order`. For example,
-    /// [`AtomicBool::fetch_xor`](../../std/sync/atomic/struct.AtomicBool.html#method.fetch_xor).
+    /// [`AtomicBool::fetch_xor`](crate::sync::atomic::AtomicBool::fetch_xor).
     pub fn atomic_xor_relaxed<T: Copy>(dst: *mut T, src: T) -> T;
 
     /// Maximum with the current value using a signed comparison.

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -619,7 +619,7 @@ extern "rust-intrinsic" {
     /// `std::sync::atomic` signed integer types via the `fetch_max` method by passing
     /// [`Ordering::SeqCst`](crate::sync::atomic::Ordering::SeqCst)
     /// as the `order`. For example,
-    /// [`AtomicI32::fetch_max`](../../std/sync/atomic/struct.AtomicI32.html#method.fetch_max).
+    /// [`AtomicI32::fetch_max`](crate::sync::atomic::AtomicI32::fetch_max).
     pub fn atomic_max<T: Copy>(dst: *mut T, src: T) -> T;
     /// Maximum with the current value using a signed comparison.
     ///
@@ -627,7 +627,7 @@ extern "rust-intrinsic" {
     /// `std::sync::atomic` signed integer types via the `fetch_max` method by passing
     /// [`Ordering::Acquire`](crate::sync::atomic::Ordering::Acquire)
     /// as the `order`. For example,
-    /// [`AtomicI32::fetch_max`](../../std/sync/atomic/struct.AtomicI32.html#method.fetch_max).
+    /// [`AtomicI32::fetch_max`](crate::sync::atomic::AtomicI32::fetch_max).
     pub fn atomic_max_acq<T: Copy>(dst: *mut T, src: T) -> T;
     /// Maximum with the current value using a signed comparison.
     ///
@@ -635,7 +635,7 @@ extern "rust-intrinsic" {
     /// `std::sync::atomic` signed integer types via the `fetch_max` method by passing
     /// [`Ordering::Release`](crate::sync::atomic::Ordering::Release)
     /// as the `order`. For example,
-    /// [`AtomicI32::fetch_max`](../../std/sync/atomic/struct.AtomicI32.html#method.fetch_max).
+    /// [`AtomicI32::fetch_max`](crate::sync::atomic::AtomicI32::fetch_max).
     pub fn atomic_max_rel<T: Copy>(dst: *mut T, src: T) -> T;
     /// Maximum with the current value using a signed comparison.
     ///
@@ -643,7 +643,7 @@ extern "rust-intrinsic" {
     /// `std::sync::atomic` signed integer types via the `fetch_max` method by passing
     /// [`Ordering::AcqRel`](crate::sync::atomic::Ordering::AcqRel)
     /// as the `order`. For example,
-    /// [`AtomicI32::fetch_max`](../../std/sync/atomic/struct.AtomicI32.html#method.fetch_max).
+    /// [`AtomicI32::fetch_max`](crate::sync::atomic::AtomicI32::fetch_max).
     pub fn atomic_max_acqrel<T: Copy>(dst: *mut T, src: T) -> T;
     /// Maximum with the current value.
     ///
@@ -651,7 +651,7 @@ extern "rust-intrinsic" {
     /// `std::sync::atomic` signed integer types via the `fetch_max` method by passing
     /// [`Ordering::Relaxed`](crate::sync::atomic::Ordering::Relaxed)
     /// as the `order`. For example,
-    /// [`AtomicI32::fetch_max`](../../std/sync/atomic/struct.AtomicI32.html#method.fetch_max).
+    /// [`AtomicI32::fetch_max`](crate::sync::atomic::AtomicI32::fetch_max).
     pub fn atomic_max_relaxed<T: Copy>(dst: *mut T, src: T) -> T;
 
     /// Minimum with the current value using a signed comparison.
@@ -660,7 +660,7 @@ extern "rust-intrinsic" {
     /// `std::sync::atomic` signed integer types via the `fetch_min` method by passing
     /// [`Ordering::SeqCst`](crate::sync::atomic::Ordering::SeqCst)
     /// as the `order`. For example,
-    /// [`AtomicI32::fetch_min`](../../std/sync/atomic/struct.AtomicI32.html#method.fetch_min).
+    /// [`AtomicI32::fetch_min`](crate::sync::atomic::AtomicI32::fetch_min).
     pub fn atomic_min<T: Copy>(dst: *mut T, src: T) -> T;
     /// Minimum with the current value using a signed comparison.
     ///
@@ -668,7 +668,7 @@ extern "rust-intrinsic" {
     /// `std::sync::atomic` signed integer types via the `fetch_min` method by passing
     /// [`Ordering::Acquire`](crate::sync::atomic::Ordering::Acquire)
     /// as the `order`. For example,
-    /// [`AtomicI32::fetch_min`](../../std/sync/atomic/struct.AtomicI32.html#method.fetch_min).
+    /// [`AtomicI32::fetch_min`](crate::sync::atomic::AtomicI32::fetch_min).
     pub fn atomic_min_acq<T: Copy>(dst: *mut T, src: T) -> T;
     /// Minimum with the current value using a signed comparison.
     ///
@@ -676,7 +676,7 @@ extern "rust-intrinsic" {
     /// `std::sync::atomic` signed integer types via the `fetch_min` method by passing
     /// [`Ordering::Release`](crate::sync::atomic::Ordering::Release)
     /// as the `order`. For example,
-    /// [`AtomicI32::fetch_min`](../../std/sync/atomic/struct.AtomicI32.html#method.fetch_min).
+    /// [`AtomicI32::fetch_min`](crate::sync::atomic::AtomicI32::fetch_min).
     pub fn atomic_min_rel<T: Copy>(dst: *mut T, src: T) -> T;
     /// Minimum with the current value using a signed comparison.
     ///
@@ -684,7 +684,7 @@ extern "rust-intrinsic" {
     /// `std::sync::atomic` signed integer types via the `fetch_min` method by passing
     /// [`Ordering::AcqRel`](crate::sync::atomic::Ordering::AcqRel)
     /// as the `order`. For example,
-    /// [`AtomicI32::fetch_min`](../../std/sync/atomic/struct.AtomicI32.html#method.fetch_min).
+    /// [`AtomicI32::fetch_min`](crate::sync::atomic::AtomicI32::fetch_min).
     pub fn atomic_min_acqrel<T: Copy>(dst: *mut T, src: T) -> T;
     /// Minimum with the current value using a signed comparison.
     ///
@@ -692,7 +692,7 @@ extern "rust-intrinsic" {
     /// `std::sync::atomic` signed integer types via the `fetch_min` method by passing
     /// [`Ordering::Relaxed`](crate::sync::atomic::Ordering::Relaxed)
     /// as the `order`. For example,
-    /// [`AtomicI32::fetch_min`](../../std/sync/atomic/struct.AtomicI32.html#method.fetch_min).
+    /// [`AtomicI32::fetch_min`](crate::sync::atomic::AtomicI32::fetch_min).
     pub fn atomic_min_relaxed<T: Copy>(dst: *mut T, src: T) -> T;
 
     /// Minimum with the current value using an unsigned comparison.

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -2079,8 +2079,8 @@ pub(crate) fn is_nonoverlapping<T>(src: *const T, dst: *const T, count: usize) -
 ///
 /// [`Copy`]: crate::marker::Copy
 /// [`read`]: crate::ptr::read
-/// [read-ownership]: ../ptr/fn.read.html#ownership-of-the-returned-value
-/// [valid]: ../ptr/index.html#safety
+/// [read-ownership]: crate::ptr::read
+/// [valid]: crate::ptr
 ///
 /// # Examples
 ///
@@ -2181,8 +2181,8 @@ pub unsafe fn copy_nonoverlapping<T>(src: *const T, dst: *mut T, count: usize) {
 ///
 /// [`Copy`]: crate::marker::Copy
 /// [`read`]: crate::ptr::read
-/// [read-ownership]: ../ptr/fn.read.html#ownership-of-the-returned-value
-/// [valid]: ../ptr/index.html#safety
+/// [read-ownership]: crate::ptr::read
+/// [valid]: crate::ptr
 ///
 /// # Examples
 ///
@@ -2240,7 +2240,7 @@ pub unsafe fn copy<T>(src: *const T, dst: *mut T, count: usize) {
 /// Note that even if the effectively copied size (`count * size_of::<T>()`) is
 /// `0`, the pointer must be non-NULL and properly aligned.
 ///
-/// [valid]: ../ptr/index.html#safety
+/// [valid]: crate::ptr
 ///
 /// # Examples
 ///

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -53,18 +53,13 @@
     issue = "none"
 )]
 #![allow(missing_docs)]
-#![allow(unused_imports)]
 
 use crate::marker::DiscriminantKind;
 use crate::mem;
 
 // These imports are used for simplifying intra-doc links
-use crate::sync::atomic;
-use crate::sync::atomic::AtomicBool;
-use crate::sync::atomic::AtomicI32;
-use crate::sync::atomic::AtomicIsize;
-use crate::sync::atomic::AtomicU32;
-use crate::sync::atomic::Ordering;
+#[cfg(doc)]
+use crate::sync::atomic::{self, AtomicBool, AtomicI32, AtomicIsize, AtomicU32, Ordering};
 
 #[stable(feature = "drop_in_place", since = "1.8.0")]
 #[rustc_deprecated(

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -1656,7 +1656,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized versions of this intrinsic are available on the integer
     /// primitives via the `count_ones` method. For example,
-    /// [`std::u32::count_ones`](../../std/primitive.u32.html#method.count_ones)
+    /// [`std::u32::count_ones`](u32::count_ones)
     #[rustc_const_stable(feature = "const_ctpop", since = "1.40.0")]
     pub fn ctpop<T: Copy>(x: T) -> T;
 
@@ -1664,7 +1664,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized versions of this intrinsic are available on the integer
     /// primitives via the `leading_zeros` method. For example,
-    /// [`std::u32::leading_zeros`](../../std/primitive.u32.html#method.leading_zeros)
+    /// [`std::u32::leading_zeros`](u32::leading_zeros)
     ///
     /// # Examples
     ///
@@ -1715,7 +1715,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized versions of this intrinsic are available on the integer
     /// primitives via the `trailing_zeros` method. For example,
-    /// [`std::u32::trailing_zeros`](../../std/primitive.u32.html#method.trailing_zeros)
+    /// [`std::u32::trailing_zeros`](u32::trailing_zeros)
     ///
     /// # Examples
     ///
@@ -1766,7 +1766,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized versions of this intrinsic are available on the integer
     /// primitives via the `swap_bytes` method. For example,
-    /// [`std::u32::swap_bytes`](../../std/primitive.u32.html#method.swap_bytes)
+    /// [`std::u32::swap_bytes`](u32::swap_bytes)
     #[rustc_const_stable(feature = "const_bswap", since = "1.40.0")]
     pub fn bswap<T: Copy>(x: T) -> T;
 
@@ -1774,7 +1774,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized versions of this intrinsic are available on the integer
     /// primitives via the `reverse_bits` method. For example,
-    /// [`std::u32::reverse_bits`](../../std/primitive.u32.html#method.reverse_bits)
+    /// [`std::u32::reverse_bits`](u32::reverse_bits)
     #[rustc_const_stable(feature = "const_bitreverse", since = "1.40.0")]
     pub fn bitreverse<T: Copy>(x: T) -> T;
 
@@ -1782,7 +1782,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized versions of this intrinsic are available on the integer
     /// primitives via the `overflowing_add` method. For example,
-    /// [`std::u32::overflowing_add`](../../std/primitive.u32.html#method.overflowing_add)
+    /// [`std::u32::overflowing_add`](u32::overflowing_add)
     #[rustc_const_stable(feature = "const_int_overflow", since = "1.40.0")]
     pub fn add_with_overflow<T: Copy>(x: T, y: T) -> (T, bool);
 
@@ -1790,7 +1790,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized versions of this intrinsic are available on the integer
     /// primitives via the `overflowing_sub` method. For example,
-    /// [`std::u32::overflowing_sub`](../../std/primitive.u32.html#method.overflowing_sub)
+    /// [`std::u32::overflowing_sub`](u32::overflowing_sub)
     #[rustc_const_stable(feature = "const_int_overflow", since = "1.40.0")]
     pub fn sub_with_overflow<T: Copy>(x: T, y: T) -> (T, bool);
 
@@ -1798,7 +1798,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized versions of this intrinsic are available on the integer
     /// primitives via the `overflowing_mul` method. For example,
-    /// [`std::u32::overflowing_mul`](../../std/primitive.u32.html#method.overflowing_mul)
+    /// [`std::u32::overflowing_mul`](u32::overflowing_mul)
     #[rustc_const_stable(feature = "const_int_overflow", since = "1.40.0")]
     pub fn mul_with_overflow<T: Copy>(x: T, y: T) -> (T, bool);
 
@@ -1813,7 +1813,7 @@ extern "rust-intrinsic" {
     ///
     /// Safe wrappers for this intrinsic are available on the integer
     /// primitives via the `checked_div` method. For example,
-    /// [`std::u32::checked_div`](../../std/primitive.u32.html#method.checked_div)
+    /// [`std::u32::checked_div`](u32::checked_div)
     #[rustc_const_unstable(feature = "const_int_unchecked_arith", issue = "none")]
     pub fn unchecked_div<T: Copy>(x: T, y: T) -> T;
     /// Returns the remainder of an unchecked division, resulting in
@@ -1821,7 +1821,7 @@ extern "rust-intrinsic" {
     ///
     /// Safe wrappers for this intrinsic are available on the integer
     /// primitives via the `checked_rem` method. For example,
-    /// [`std::u32::checked_rem`](../../std/primitive.u32.html#method.checked_rem)
+    /// [`std::u32::checked_rem`](u32::checked_rem)
     #[rustc_const_unstable(feature = "const_int_unchecked_arith", issue = "none")]
     pub fn unchecked_rem<T: Copy>(x: T, y: T) -> T;
 
@@ -1830,7 +1830,7 @@ extern "rust-intrinsic" {
     ///
     /// Safe wrappers for this intrinsic are available on the integer
     /// primitives via the `checked_shl` method. For example,
-    /// [`std::u32::checked_shl`](../../std/primitive.u32.html#method.checked_shl)
+    /// [`std::u32::checked_shl`](u32::checked_shl)
     #[rustc_const_stable(feature = "const_int_unchecked", since = "1.40.0")]
     pub fn unchecked_shl<T: Copy>(x: T, y: T) -> T;
     /// Performs an unchecked right shift, resulting in undefined behavior when
@@ -1838,7 +1838,7 @@ extern "rust-intrinsic" {
     ///
     /// Safe wrappers for this intrinsic are available on the integer
     /// primitives via the `checked_shr` method. For example,
-    /// [`std::u32::checked_shr`](../../std/primitive.u32.html#method.checked_shr)
+    /// [`std::u32::checked_shr`](u32::checked_shr)
     #[rustc_const_stable(feature = "const_int_unchecked", since = "1.40.0")]
     pub fn unchecked_shr<T: Copy>(x: T, y: T) -> T;
 
@@ -1867,7 +1867,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized versions of this intrinsic are available on the integer
     /// primitives via the `rotate_left` method. For example,
-    /// [`std::u32::rotate_left`](../../std/primitive.u32.html#method.rotate_left)
+    /// [`std::u32::rotate_left`](u32::rotate_left)
     #[rustc_const_stable(feature = "const_int_rotate", since = "1.40.0")]
     pub fn rotate_left<T: Copy>(x: T, y: T) -> T;
 
@@ -1875,7 +1875,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized versions of this intrinsic are available on the integer
     /// primitives via the `rotate_right` method. For example,
-    /// [`std::u32::rotate_right`](../../std/primitive.u32.html#method.rotate_right)
+    /// [`std::u32::rotate_right`](u32::rotate_right)
     #[rustc_const_stable(feature = "const_int_rotate", since = "1.40.0")]
     pub fn rotate_right<T: Copy>(x: T, y: T) -> T;
 
@@ -1883,21 +1883,21 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized versions of this intrinsic are available on the integer
     /// primitives via the `checked_add` method. For example,
-    /// [`std::u32::checked_add`](../../std/primitive.u32.html#method.checked_add)
+    /// [`std::u32::checked_add`](u32::checked_add)
     #[rustc_const_stable(feature = "const_int_wrapping", since = "1.40.0")]
     pub fn wrapping_add<T: Copy>(a: T, b: T) -> T;
     /// Returns (a - b) mod 2<sup>N</sup>, where N is the width of T in bits.
     ///
     /// The stabilized versions of this intrinsic are available on the integer
     /// primitives via the `checked_sub` method. For example,
-    /// [`std::u32::checked_sub`](../../std/primitive.u32.html#method.checked_sub)
+    /// [`std::u32::checked_sub`](u32::checked_sub)
     #[rustc_const_stable(feature = "const_int_wrapping", since = "1.40.0")]
     pub fn wrapping_sub<T: Copy>(a: T, b: T) -> T;
     /// Returns (a * b) mod 2<sup>N</sup>, where N is the width of T in bits.
     ///
     /// The stabilized versions of this intrinsic are available on the integer
     /// primitives via the `checked_mul` method. For example,
-    /// [`std::u32::checked_mul`](../../std/primitive.u32.html#method.checked_mul)
+    /// [`std::u32::checked_mul`](u32::checked_mul)
     #[rustc_const_stable(feature = "const_int_wrapping", since = "1.40.0")]
     pub fn wrapping_mul<T: Copy>(a: T, b: T) -> T;
 
@@ -1905,14 +1905,14 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized versions of this intrinsic are available on the integer
     /// primitives via the `saturating_add` method. For example,
-    /// [`std::u32::saturating_add`](../../std/primitive.u32.html#method.saturating_add)
+    /// [`std::u32::saturating_add`](u32::saturating_add)
     #[rustc_const_stable(feature = "const_int_saturating", since = "1.40.0")]
     pub fn saturating_add<T: Copy>(a: T, b: T) -> T;
     /// Computes `a - b`, while saturating at numeric bounds.
     ///
     /// The stabilized versions of this intrinsic are available on the integer
     /// primitives via the `saturating_sub` method. For example,
-    /// [`std::u32::saturating_sub`](../../std/primitive.u32.html#method.saturating_sub)
+    /// [`std::u32::saturating_sub`](u32::saturating_sub)
     #[rustc_const_stable(feature = "const_int_saturating", since = "1.40.0")]
     pub fn saturating_sub<T: Copy>(a: T, b: T) -> T;
 

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -60,11 +60,11 @@ use crate::mem;
 
 // These imports are used for simplifying intra-doc links
 use crate::sync::atomic;
-use crate::sync::atomic::Ordering;
-use crate::sync::atomic::AtomicU32;
-use crate::sync::atomic::AtomicI32;
 use crate::sync::atomic::AtomicBool;
+use crate::sync::atomic::AtomicI32;
 use crate::sync::atomic::AtomicIsize;
+use crate::sync::atomic::AtomicU32;
+use crate::sync::atomic::Ordering;
 
 #[stable(feature = "drop_in_place", since = "1.8.0")]
 #[rustc_deprecated(

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -76,7 +76,7 @@ extern "rust-intrinsic" {
     /// as both the `success` and `failure` parameters. For example,
     /// [`AtomicBool::compare_exchange`][compare_exchange].
     ///
-    /// [compare_exchange]: ../../std/sync/atomic/struct.AtomicBool.html#method.compare_exchange
+    /// [compare_exchange]: crate::sync::atomic::AtomicBool::compare_exchange
     pub fn atomic_cxchg<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
     /// Stores a value if the current value is the same as the `old` value.
     ///
@@ -86,7 +86,7 @@ extern "rust-intrinsic" {
     /// as both the `success` and `failure` parameters. For example,
     /// [`AtomicBool::compare_exchange`][compare_exchange].
     ///
-    /// [compare_exchange]: ../../std/sync/atomic/struct.AtomicBool.html#method.compare_exchange
+    /// [compare_exchange]: crate::sync::atomic::AtomicBool::compare_exchange
     pub fn atomic_cxchg_acq<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
     /// Stores a value if the current value is the same as the `old` value.
     ///
@@ -98,7 +98,7 @@ extern "rust-intrinsic" {
     /// as the `failure` parameters. For example,
     /// [`AtomicBool::compare_exchange`][compare_exchange].
     ///
-    /// [compare_exchange]: ../../std/sync/atomic/struct.AtomicBool.html#method.compare_exchange
+    /// [compare_exchange]: crate::sync::atomic::AtomicBool::compare_exchange
     pub fn atomic_cxchg_rel<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
     /// Stores a value if the current value is the same as the `old` value.
     ///
@@ -110,7 +110,7 @@ extern "rust-intrinsic" {
     /// as the `failure` parameters. For example,
     /// [`AtomicBool::compare_exchange`][compare_exchange].
     ///
-    /// [compare_exchange]: ../../std/sync/atomic/struct.AtomicBool.html#method.compare_exchange
+    /// [compare_exchange]: crate::sync::atomic::AtomicBool::compare_exchange
     pub fn atomic_cxchg_acqrel<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
     /// Stores a value if the current value is the same as the `old` value.
     ///
@@ -120,7 +120,7 @@ extern "rust-intrinsic" {
     /// as both the `success` and `failure` parameters. For example,
     /// [`AtomicBool::compare_exchange`][compare_exchange].
     ///
-    /// [compare_exchange]: ../../std/sync/atomic/struct.AtomicBool.html#method.compare_exchange
+    /// [compare_exchange]: crate::sync::atomic::AtomicBool::compare_exchange
     pub fn atomic_cxchg_relaxed<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
     /// Stores a value if the current value is the same as the `old` value.
     ///
@@ -132,7 +132,7 @@ extern "rust-intrinsic" {
     /// as the `failure` parameters. For example,
     /// [`AtomicBool::compare_exchange`][compare_exchange].
     ///
-    /// [compare_exchange]: ../../std/sync/atomic/struct.AtomicBool.html#method.compare_exchange
+    /// [compare_exchange]: crate::sync::atomic::AtomicBool::compare_exchange
     pub fn atomic_cxchg_failrelaxed<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
     /// Stores a value if the current value is the same as the `old` value.
     ///
@@ -144,7 +144,7 @@ extern "rust-intrinsic" {
     /// as the `failure` parameters. For example,
     /// [`AtomicBool::compare_exchange`][compare_exchange].
     ///
-    /// [compare_exchange]: ../../std/sync/atomic/struct.AtomicBool.html#method.compare_exchange
+    /// [compare_exchange]: crate::sync::atomic::AtomicBool::compare_exchange
     pub fn atomic_cxchg_failacq<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
     /// Stores a value if the current value is the same as the `old` value.
     ///
@@ -156,7 +156,7 @@ extern "rust-intrinsic" {
     /// as the `failure` parameters. For example,
     /// [`AtomicBool::compare_exchange`][compare_exchange].
     ///
-    /// [compare_exchange]: ../../std/sync/atomic/struct.AtomicBool.html#method.compare_exchange
+    /// [compare_exchange]: crate::sync::atomic::AtomicBool::compare_exchange
     pub fn atomic_cxchg_acq_failrelaxed<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
     /// Stores a value if the current value is the same as the `old` value.
     ///
@@ -168,7 +168,7 @@ extern "rust-intrinsic" {
     /// as the `failure` parameters. For example,
     /// [`AtomicBool::compare_exchange`][compare_exchange].
     ///
-    /// [compare_exchange]: ../../std/sync/atomic/struct.AtomicBool.html#method.compare_exchange
+    /// [compare_exchange]: crate::sync::atomic::AtomicBool::compare_exchange
     pub fn atomic_cxchg_acqrel_failrelaxed<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
 
     /// Stores a value if the current value is the same as the `old` value.
@@ -179,7 +179,7 @@ extern "rust-intrinsic" {
     /// as both the `success` and `failure` parameters. For example,
     /// [`AtomicBool::compare_exchange_weak`][cew].
     ///
-    /// [cew]: ../../std/sync/atomic/struct.AtomicBool.html#method.compare_exchange_weak
+    /// [cew]: crate::sync::atomic::AtomicBool::compare_exchange_weak
     pub fn atomic_cxchgweak<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
     /// Stores a value if the current value is the same as the `old` value.
     ///
@@ -189,7 +189,7 @@ extern "rust-intrinsic" {
     /// as both the `success` and `failure` parameters. For example,
     /// [`AtomicBool::compare_exchange_weak`][cew].
     ///
-    /// [cew]: ../../std/sync/atomic/struct.AtomicBool.html#method.compare_exchange_weak
+    /// [cew]: crate::sync::atomic::AtomicBool::compare_exchange_weak
     pub fn atomic_cxchgweak_acq<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
     /// Stores a value if the current value is the same as the `old` value.
     ///
@@ -201,7 +201,7 @@ extern "rust-intrinsic" {
     /// as the `failure` parameters. For example,
     /// [`AtomicBool::compare_exchange_weak`][cew].
     ///
-    /// [cew]: ../../std/sync/atomic/struct.AtomicBool.html#method.compare_exchange_weak
+    /// [cew]: crate::sync::atomic::AtomicBool::compare_exchange_weak
     pub fn atomic_cxchgweak_rel<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
     /// Stores a value if the current value is the same as the `old` value.
     ///
@@ -213,7 +213,7 @@ extern "rust-intrinsic" {
     /// as the `failure` parameters. For example,
     /// [`AtomicBool::compare_exchange_weak`][cew].
     ///
-    /// [cew]: ../../std/sync/atomic/struct.AtomicBool.html#method.compare_exchange_weak
+    /// [cew]: crate::sync::atomic::AtomicBool::compare_exchange_weak
     pub fn atomic_cxchgweak_acqrel<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
     /// Stores a value if the current value is the same as the `old` value.
     ///
@@ -223,7 +223,7 @@ extern "rust-intrinsic" {
     /// as both the `success` and `failure` parameters. For example,
     /// [`AtomicBool::compare_exchange_weak`][cew].
     ///
-    /// [cew]: ../../std/sync/atomic/struct.AtomicBool.html#method.compare_exchange_weak
+    /// [cew]: crate::sync::atomic::AtomicBool::compare_exchange_weak
     pub fn atomic_cxchgweak_relaxed<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
     /// Stores a value if the current value is the same as the `old` value.
     ///
@@ -235,7 +235,7 @@ extern "rust-intrinsic" {
     /// as the `failure` parameters. For example,
     /// [`AtomicBool::compare_exchange_weak`][cew].
     ///
-    /// [cew]: ../../std/sync/atomic/struct.AtomicBool.html#method.compare_exchange_weak
+    /// [cew]: crate::sync::atomic::AtomicBool::compare_exchange_weak
     pub fn atomic_cxchgweak_failrelaxed<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
     /// Stores a value if the current value is the same as the `old` value.
     ///
@@ -247,7 +247,7 @@ extern "rust-intrinsic" {
     /// as the `failure` parameters. For example,
     /// [`AtomicBool::compare_exchange_weak`][cew].
     ///
-    /// [cew]: ../../std/sync/atomic/struct.AtomicBool.html#method.compare_exchange_weak
+    /// [cew]: crate::sync::atomic::AtomicBool::compare_exchange_weak
     pub fn atomic_cxchgweak_failacq<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
     /// Stores a value if the current value is the same as the `old` value.
     ///
@@ -259,7 +259,7 @@ extern "rust-intrinsic" {
     /// as the `failure` parameters. For example,
     /// [`AtomicBool::compare_exchange_weak`][cew].
     ///
-    /// [cew]: ../../std/sync/atomic/struct.AtomicBool.html#method.compare_exchange_weak
+    /// [cew]: crate::sync::atomic::AtomicBool::compare_exchange_weak
     pub fn atomic_cxchgweak_acq_failrelaxed<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
     /// Stores a value if the current value is the same as the `old` value.
     ///
@@ -271,7 +271,7 @@ extern "rust-intrinsic" {
     /// as the `failure` parameters. For example,
     /// [`AtomicBool::compare_exchange_weak`][cew].
     ///
-    /// [cew]: ../../std/sync/atomic/struct.AtomicBool.html#method.compare_exchange_weak
+    /// [cew]: crate::sync::atomic::AtomicBool::compare_exchange_weak
     pub fn atomic_cxchgweak_acqrel_failrelaxed<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
 
     /// Loads the current value of the pointer.

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -72,7 +72,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `compare_exchange` method by passing
-    /// [`Ordering::SeqCst`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::SeqCst`](crate::sync::atomic::Ordering::SeqCst)
     /// as both the `success` and `failure` parameters. For example,
     /// [`AtomicBool::compare_exchange`][compare_exchange].
     ///
@@ -82,7 +82,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `compare_exchange` method by passing
-    /// [`Ordering::Acquire`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Acquire`](crate::sync::atomic::Ordering::Acquire)
     /// as both the `success` and `failure` parameters. For example,
     /// [`AtomicBool::compare_exchange`][compare_exchange].
     ///
@@ -92,9 +92,9 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `compare_exchange` method by passing
-    /// [`Ordering::Release`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Release`](crate::sync::atomic::Ordering::Release)
     /// as the `success` and
-    /// [`Ordering::Relaxed`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Relaxed`](crate::sync::atomic::Ordering::Relaxed)
     /// as the `failure` parameters. For example,
     /// [`AtomicBool::compare_exchange`][compare_exchange].
     ///
@@ -104,9 +104,9 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `compare_exchange` method by passing
-    /// [`Ordering::AcqRel`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::AcqRel`](crate::sync::atomic::Ordering::AcqRel)
     /// as the `success` and
-    /// [`Ordering::Acquire`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Acquire`](crate::sync::atomic::Ordering::Acquire)
     /// as the `failure` parameters. For example,
     /// [`AtomicBool::compare_exchange`][compare_exchange].
     ///
@@ -116,7 +116,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `compare_exchange` method by passing
-    /// [`Ordering::Relaxed`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Relaxed`](crate::sync::atomic::Ordering::Relaxed)
     /// as both the `success` and `failure` parameters. For example,
     /// [`AtomicBool::compare_exchange`][compare_exchange].
     ///
@@ -126,9 +126,9 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `compare_exchange` method by passing
-    /// [`Ordering::SeqCst`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::SeqCst`](crate::sync::atomic::Ordering::SeqCst)
     /// as the `success` and
-    /// [`Ordering::Relaxed`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Relaxed`](crate::sync::atomic::Ordering::Relaxed)
     /// as the `failure` parameters. For example,
     /// [`AtomicBool::compare_exchange`][compare_exchange].
     ///
@@ -138,9 +138,9 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `compare_exchange` method by passing
-    /// [`Ordering::SeqCst`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::SeqCst`](crate::sync::atomic::Ordering::SeqCst)
     /// as the `success` and
-    /// [`Ordering::Acquire`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Acquire`](crate::sync::atomic::Ordering::Acquire)
     /// as the `failure` parameters. For example,
     /// [`AtomicBool::compare_exchange`][compare_exchange].
     ///
@@ -150,9 +150,9 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `compare_exchange` method by passing
-    /// [`Ordering::Acquire`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Acquire`](crate::sync::atomic::Ordering::Acquire)
     /// as the `success` and
-    /// [`Ordering::Relaxed`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Relaxed`](crate::sync::atomic::Ordering::Relaxed)
     /// as the `failure` parameters. For example,
     /// [`AtomicBool::compare_exchange`][compare_exchange].
     ///
@@ -162,9 +162,9 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `compare_exchange` method by passing
-    /// [`Ordering::AcqRel`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::AcqRel`](crate::sync::atomic::Ordering::AcqRel)
     /// as the `success` and
-    /// [`Ordering::Relaxed`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Relaxed`](crate::sync::atomic::Ordering::Relaxed)
     /// as the `failure` parameters. For example,
     /// [`AtomicBool::compare_exchange`][compare_exchange].
     ///
@@ -175,7 +175,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `compare_exchange_weak` method by passing
-    /// [`Ordering::SeqCst`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::SeqCst`](crate::sync::atomic::Ordering::SeqCst)
     /// as both the `success` and `failure` parameters. For example,
     /// [`AtomicBool::compare_exchange_weak`][cew].
     ///
@@ -185,7 +185,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `compare_exchange_weak` method by passing
-    /// [`Ordering::Acquire`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Acquire`](crate::sync::atomic::Ordering::Acquire)
     /// as both the `success` and `failure` parameters. For example,
     /// [`AtomicBool::compare_exchange_weak`][cew].
     ///
@@ -195,9 +195,9 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `compare_exchange_weak` method by passing
-    /// [`Ordering::Release`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Release`](crate::sync::atomic::Ordering::Release)
     /// as the `success` and
-    /// [`Ordering::Relaxed`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Relaxed`](crate::sync::atomic::Ordering::Relaxed)
     /// as the `failure` parameters. For example,
     /// [`AtomicBool::compare_exchange_weak`][cew].
     ///
@@ -207,9 +207,9 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `compare_exchange_weak` method by passing
-    /// [`Ordering::AcqRel`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::AcqRel`](crate::sync::atomic::Ordering::AcqRel)
     /// as the `success` and
-    /// [`Ordering::Acquire`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Acquire`](crate::sync::atomic::Ordering::Acquire)
     /// as the `failure` parameters. For example,
     /// [`AtomicBool::compare_exchange_weak`][cew].
     ///
@@ -219,7 +219,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `compare_exchange_weak` method by passing
-    /// [`Ordering::Relaxed`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Relaxed`](crate::sync::atomic::Ordering::Relaxed)
     /// as both the `success` and `failure` parameters. For example,
     /// [`AtomicBool::compare_exchange_weak`][cew].
     ///
@@ -229,9 +229,9 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `compare_exchange_weak` method by passing
-    /// [`Ordering::SeqCst`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::SeqCst`](crate::sync::atomic::Ordering::SeqCst)
     /// as the `success` and
-    /// [`Ordering::Relaxed`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Relaxed`](crate::sync::atomic::Ordering::Relaxed)
     /// as the `failure` parameters. For example,
     /// [`AtomicBool::compare_exchange_weak`][cew].
     ///
@@ -241,9 +241,9 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `compare_exchange_weak` method by passing
-    /// [`Ordering::SeqCst`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::SeqCst`](crate::sync::atomic::Ordering::SeqCst)
     /// as the `success` and
-    /// [`Ordering::Acquire`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Acquire`](crate::sync::atomic::Ordering::Acquire)
     /// as the `failure` parameters. For example,
     /// [`AtomicBool::compare_exchange_weak`][cew].
     ///
@@ -253,9 +253,9 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `compare_exchange_weak` method by passing
-    /// [`Ordering::Acquire`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Acquire`](crate::sync::atomic::Ordering::Acquire)
     /// as the `success` and
-    /// [`Ordering::Relaxed`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Relaxed`](crate::sync::atomic::Ordering::Relaxed)
     /// as the `failure` parameters. For example,
     /// [`AtomicBool::compare_exchange_weak`][cew].
     ///
@@ -265,9 +265,9 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `compare_exchange_weak` method by passing
-    /// [`Ordering::AcqRel`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::AcqRel`](crate::sync::atomic::Ordering::AcqRel)
     /// as the `success` and
-    /// [`Ordering::Relaxed`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Relaxed`](crate::sync::atomic::Ordering::Relaxed)
     /// as the `failure` parameters. For example,
     /// [`AtomicBool::compare_exchange_weak`][cew].
     ///
@@ -278,7 +278,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `load` method by passing
-    /// [`Ordering::SeqCst`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::SeqCst`](crate::sync::atomic::Ordering::SeqCst)
     /// as the `order`. For example,
     /// [`AtomicBool::load`](../../std/sync/atomic/struct.AtomicBool.html#method.load).
     pub fn atomic_load<T: Copy>(src: *const T) -> T;
@@ -286,7 +286,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `load` method by passing
-    /// [`Ordering::Acquire`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Acquire`](crate::sync::atomic::Ordering::Acquire)
     /// as the `order`. For example,
     /// [`AtomicBool::load`](../../std/sync/atomic/struct.AtomicBool.html#method.load).
     pub fn atomic_load_acq<T: Copy>(src: *const T) -> T;
@@ -294,7 +294,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `load` method by passing
-    /// [`Ordering::Relaxed`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Relaxed`](crate::sync::atomic::Ordering::Relaxed)
     /// as the `order`. For example,
     /// [`AtomicBool::load`](../../std/sync/atomic/struct.AtomicBool.html#method.load).
     pub fn atomic_load_relaxed<T: Copy>(src: *const T) -> T;
@@ -304,7 +304,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `store` method by passing
-    /// [`Ordering::SeqCst`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::SeqCst`](crate::sync::atomic::Ordering::SeqCst)
     /// as the `order`. For example,
     /// [`AtomicBool::store`](../../std/sync/atomic/struct.AtomicBool.html#method.store).
     pub fn atomic_store<T: Copy>(dst: *mut T, val: T);
@@ -312,7 +312,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `store` method by passing
-    /// [`Ordering::Release`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Release`](crate::sync::atomic::Ordering::Release)
     /// as the `order`. For example,
     /// [`AtomicBool::store`](../../std/sync/atomic/struct.AtomicBool.html#method.store).
     pub fn atomic_store_rel<T: Copy>(dst: *mut T, val: T);
@@ -320,7 +320,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `store` method by passing
-    /// [`Ordering::Relaxed`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Relaxed`](crate::sync::atomic::Ordering::Relaxed)
     /// as the `order`. For example,
     /// [`AtomicBool::store`](../../std/sync/atomic/struct.AtomicBool.html#method.store).
     pub fn atomic_store_relaxed<T: Copy>(dst: *mut T, val: T);
@@ -330,7 +330,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `swap` method by passing
-    /// [`Ordering::SeqCst`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::SeqCst`](crate::sync::atomic::Ordering::SeqCst)
     /// as the `order`. For example,
     /// [`AtomicBool::swap`](../../std/sync/atomic/struct.AtomicBool.html#method.swap).
     pub fn atomic_xchg<T: Copy>(dst: *mut T, src: T) -> T;
@@ -338,7 +338,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `swap` method by passing
-    /// [`Ordering::Acquire`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Acquire`](crate::sync::atomic::Ordering::Acquire)
     /// as the `order`. For example,
     /// [`AtomicBool::swap`](../../std/sync/atomic/struct.AtomicBool.html#method.swap).
     pub fn atomic_xchg_acq<T: Copy>(dst: *mut T, src: T) -> T;
@@ -346,7 +346,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `swap` method by passing
-    /// [`Ordering::Release`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Release`](crate::sync::atomic::Ordering::Release)
     /// as the `order`. For example,
     /// [`AtomicBool::swap`](../../std/sync/atomic/struct.AtomicBool.html#method.swap).
     pub fn atomic_xchg_rel<T: Copy>(dst: *mut T, src: T) -> T;
@@ -354,7 +354,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `swap` method by passing
-    /// [`Ordering::AcqRel`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::AcqRel`](crate::sync::atomic::Ordering::AcqRel)
     /// as the `order`. For example,
     /// [`AtomicBool::swap`](../../std/sync/atomic/struct.AtomicBool.html#method.swap).
     pub fn atomic_xchg_acqrel<T: Copy>(dst: *mut T, src: T) -> T;
@@ -362,7 +362,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `swap` method by passing
-    /// [`Ordering::Relaxed`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Relaxed`](crate::sync::atomic::Ordering::Relaxed)
     /// as the `order`. For example,
     /// [`AtomicBool::swap`](../../std/sync/atomic/struct.AtomicBool.html#method.swap).
     pub fn atomic_xchg_relaxed<T: Copy>(dst: *mut T, src: T) -> T;
@@ -371,7 +371,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `fetch_add` method by passing
-    /// [`Ordering::SeqCst`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::SeqCst`](crate::sync::atomic::Ordering::SeqCst)
     /// as the `order`. For example,
     /// [`AtomicIsize::fetch_add`](../../std/sync/atomic/struct.AtomicIsize.html#method.fetch_add).
     pub fn atomic_xadd<T: Copy>(dst: *mut T, src: T) -> T;
@@ -379,7 +379,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `fetch_add` method by passing
-    /// [`Ordering::Acquire`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Acquire`](crate::sync::atomic::Ordering::Acquire)
     /// as the `order`. For example,
     /// [`AtomicIsize::fetch_add`](../../std/sync/atomic/struct.AtomicIsize.html#method.fetch_add).
     pub fn atomic_xadd_acq<T: Copy>(dst: *mut T, src: T) -> T;
@@ -387,7 +387,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `fetch_add` method by passing
-    /// [`Ordering::Release`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Release`](crate::sync::atomic::Ordering::Release)
     /// as the `order`. For example,
     /// [`AtomicIsize::fetch_add`](../../std/sync/atomic/struct.AtomicIsize.html#method.fetch_add).
     pub fn atomic_xadd_rel<T: Copy>(dst: *mut T, src: T) -> T;
@@ -395,7 +395,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `fetch_add` method by passing
-    /// [`Ordering::AcqRel`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::AcqRel`](crate::sync::atomic::Ordering::AcqRel)
     /// as the `order`. For example,
     /// [`AtomicIsize::fetch_add`](../../std/sync/atomic/struct.AtomicIsize.html#method.fetch_add).
     pub fn atomic_xadd_acqrel<T: Copy>(dst: *mut T, src: T) -> T;
@@ -403,7 +403,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `fetch_add` method by passing
-    /// [`Ordering::Relaxed`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Relaxed`](crate::sync::atomic::Ordering::Relaxed)
     /// as the `order`. For example,
     /// [`AtomicIsize::fetch_add`](../../std/sync/atomic/struct.AtomicIsize.html#method.fetch_add).
     pub fn atomic_xadd_relaxed<T: Copy>(dst: *mut T, src: T) -> T;
@@ -412,7 +412,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `fetch_sub` method by passing
-    /// [`Ordering::SeqCst`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::SeqCst`](crate::sync::atomic::Ordering::SeqCst)
     /// as the `order`. For example,
     /// [`AtomicIsize::fetch_sub`](../../std/sync/atomic/struct.AtomicIsize.html#method.fetch_sub).
     pub fn atomic_xsub<T: Copy>(dst: *mut T, src: T) -> T;
@@ -420,7 +420,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `fetch_sub` method by passing
-    /// [`Ordering::Acquire`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Acquire`](crate::sync::atomic::Ordering::Acquire)
     /// as the `order`. For example,
     /// [`AtomicIsize::fetch_sub`](../../std/sync/atomic/struct.AtomicIsize.html#method.fetch_sub).
     pub fn atomic_xsub_acq<T: Copy>(dst: *mut T, src: T) -> T;
@@ -428,7 +428,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `fetch_sub` method by passing
-    /// [`Ordering::Release`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Release`](crate::sync::atomic::Ordering::Release)
     /// as the `order`. For example,
     /// [`AtomicIsize::fetch_sub`](../../std/sync/atomic/struct.AtomicIsize.html#method.fetch_sub).
     pub fn atomic_xsub_rel<T: Copy>(dst: *mut T, src: T) -> T;
@@ -436,7 +436,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `fetch_sub` method by passing
-    /// [`Ordering::AcqRel`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::AcqRel`](crate::sync::atomic::Ordering::AcqRel)
     /// as the `order`. For example,
     /// [`AtomicIsize::fetch_sub`](../../std/sync/atomic/struct.AtomicIsize.html#method.fetch_sub).
     pub fn atomic_xsub_acqrel<T: Copy>(dst: *mut T, src: T) -> T;
@@ -444,7 +444,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `fetch_sub` method by passing
-    /// [`Ordering::Relaxed`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Relaxed`](crate::sync::atomic::Ordering::Relaxed)
     /// as the `order`. For example,
     /// [`AtomicIsize::fetch_sub`](../../std/sync/atomic/struct.AtomicIsize.html#method.fetch_sub).
     pub fn atomic_xsub_relaxed<T: Copy>(dst: *mut T, src: T) -> T;
@@ -453,7 +453,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `fetch_and` method by passing
-    /// [`Ordering::SeqCst`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::SeqCst`](crate::sync::atomic::Ordering::SeqCst)
     /// as the `order`. For example,
     /// [`AtomicBool::fetch_and`](../../std/sync/atomic/struct.AtomicBool.html#method.fetch_and).
     pub fn atomic_and<T: Copy>(dst: *mut T, src: T) -> T;
@@ -461,7 +461,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `fetch_and` method by passing
-    /// [`Ordering::Acquire`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Acquire`](crate::sync::atomic::Ordering::Acquire)
     /// as the `order`. For example,
     /// [`AtomicBool::fetch_and`](../../std/sync/atomic/struct.AtomicBool.html#method.fetch_and).
     pub fn atomic_and_acq<T: Copy>(dst: *mut T, src: T) -> T;
@@ -469,7 +469,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `fetch_and` method by passing
-    /// [`Ordering::Release`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Release`](crate::sync::atomic::Ordering::Release)
     /// as the `order`. For example,
     /// [`AtomicBool::fetch_and`](../../std/sync/atomic/struct.AtomicBool.html#method.fetch_and).
     pub fn atomic_and_rel<T: Copy>(dst: *mut T, src: T) -> T;
@@ -477,7 +477,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `fetch_and` method by passing
-    /// [`Ordering::AcqRel`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::AcqRel`](crate::sync::atomic::Ordering::AcqRel)
     /// as the `order`. For example,
     /// [`AtomicBool::fetch_and`](../../std/sync/atomic/struct.AtomicBool.html#method.fetch_and).
     pub fn atomic_and_acqrel<T: Copy>(dst: *mut T, src: T) -> T;
@@ -485,7 +485,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `fetch_and` method by passing
-    /// [`Ordering::Relaxed`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Relaxed`](crate::sync::atomic::Ordering::Relaxed)
     /// as the `order`. For example,
     /// [`AtomicBool::fetch_and`](../../std/sync/atomic/struct.AtomicBool.html#method.fetch_and).
     pub fn atomic_and_relaxed<T: Copy>(dst: *mut T, src: T) -> T;
@@ -494,7 +494,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic::AtomicBool` type via the `fetch_nand` method by passing
-    /// [`Ordering::SeqCst`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::SeqCst`](crate::sync::atomic::Ordering::SeqCst)
     /// as the `order`. For example,
     /// [`AtomicBool::fetch_nand`](../../std/sync/atomic/struct.AtomicBool.html#method.fetch_nand).
     pub fn atomic_nand<T: Copy>(dst: *mut T, src: T) -> T;
@@ -502,7 +502,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic::AtomicBool` type via the `fetch_nand` method by passing
-    /// [`Ordering::Acquire`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Acquire`](crate::sync::atomic::Ordering::Acquire)
     /// as the `order`. For example,
     /// [`AtomicBool::fetch_nand`](../../std/sync/atomic/struct.AtomicBool.html#method.fetch_nand).
     pub fn atomic_nand_acq<T: Copy>(dst: *mut T, src: T) -> T;
@@ -510,7 +510,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic::AtomicBool` type via the `fetch_nand` method by passing
-    /// [`Ordering::Release`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Release`](crate::sync::atomic::Ordering::Release)
     /// as the `order`. For example,
     /// [`AtomicBool::fetch_nand`](../../std/sync/atomic/struct.AtomicBool.html#method.fetch_nand).
     pub fn atomic_nand_rel<T: Copy>(dst: *mut T, src: T) -> T;
@@ -518,7 +518,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic::AtomicBool` type via the `fetch_nand` method by passing
-    /// [`Ordering::AcqRel`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::AcqRel`](crate::sync::atomic::Ordering::AcqRel)
     /// as the `order`. For example,
     /// [`AtomicBool::fetch_nand`](../../std/sync/atomic/struct.AtomicBool.html#method.fetch_nand).
     pub fn atomic_nand_acqrel<T: Copy>(dst: *mut T, src: T) -> T;
@@ -526,7 +526,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic::AtomicBool` type via the `fetch_nand` method by passing
-    /// [`Ordering::Relaxed`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Relaxed`](crate::sync::atomic::Ordering::Relaxed)
     /// as the `order`. For example,
     /// [`AtomicBool::fetch_nand`](../../std/sync/atomic/struct.AtomicBool.html#method.fetch_nand).
     pub fn atomic_nand_relaxed<T: Copy>(dst: *mut T, src: T) -> T;
@@ -535,7 +535,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `fetch_or` method by passing
-    /// [`Ordering::SeqCst`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::SeqCst`](crate::sync::atomic::Ordering::SeqCst)
     /// as the `order`. For example,
     /// [`AtomicBool::fetch_or`](../../std/sync/atomic/struct.AtomicBool.html#method.fetch_or).
     pub fn atomic_or<T: Copy>(dst: *mut T, src: T) -> T;
@@ -543,7 +543,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `fetch_or` method by passing
-    /// [`Ordering::Acquire`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Acquire`](crate::sync::atomic::Ordering::Acquire)
     /// as the `order`. For example,
     /// [`AtomicBool::fetch_or`](../../std/sync/atomic/struct.AtomicBool.html#method.fetch_or).
     pub fn atomic_or_acq<T: Copy>(dst: *mut T, src: T) -> T;
@@ -551,7 +551,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `fetch_or` method by passing
-    /// [`Ordering::Release`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Release`](crate::sync::atomic::Ordering::Release)
     /// as the `order`. For example,
     /// [`AtomicBool::fetch_or`](../../std/sync/atomic/struct.AtomicBool.html#method.fetch_or).
     pub fn atomic_or_rel<T: Copy>(dst: *mut T, src: T) -> T;
@@ -559,7 +559,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `fetch_or` method by passing
-    /// [`Ordering::AcqRel`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::AcqRel`](crate::sync::atomic::Ordering::AcqRel)
     /// as the `order`. For example,
     /// [`AtomicBool::fetch_or`](../../std/sync/atomic/struct.AtomicBool.html#method.fetch_or).
     pub fn atomic_or_acqrel<T: Copy>(dst: *mut T, src: T) -> T;
@@ -567,7 +567,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `fetch_or` method by passing
-    /// [`Ordering::Relaxed`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Relaxed`](crate::sync::atomic::Ordering::Relaxed)
     /// as the `order`. For example,
     /// [`AtomicBool::fetch_or`](../../std/sync/atomic/struct.AtomicBool.html#method.fetch_or).
     pub fn atomic_or_relaxed<T: Copy>(dst: *mut T, src: T) -> T;
@@ -576,7 +576,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `fetch_xor` method by passing
-    /// [`Ordering::SeqCst`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::SeqCst`](crate::sync::atomic::Ordering::SeqCst)
     /// as the `order`. For example,
     /// [`AtomicBool::fetch_xor`](../../std/sync/atomic/struct.AtomicBool.html#method.fetch_xor).
     pub fn atomic_xor<T: Copy>(dst: *mut T, src: T) -> T;
@@ -584,7 +584,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `fetch_xor` method by passing
-    /// [`Ordering::Acquire`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Acquire`](crate::sync::atomic::Ordering::Acquire)
     /// as the `order`. For example,
     /// [`AtomicBool::fetch_xor`](../../std/sync/atomic/struct.AtomicBool.html#method.fetch_xor).
     pub fn atomic_xor_acq<T: Copy>(dst: *mut T, src: T) -> T;
@@ -592,7 +592,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `fetch_xor` method by passing
-    /// [`Ordering::Release`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Release`](crate::sync::atomic::Ordering::Release)
     /// as the `order`. For example,
     /// [`AtomicBool::fetch_xor`](../../std/sync/atomic/struct.AtomicBool.html#method.fetch_xor).
     pub fn atomic_xor_rel<T: Copy>(dst: *mut T, src: T) -> T;
@@ -600,7 +600,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `fetch_xor` method by passing
-    /// [`Ordering::AcqRel`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::AcqRel`](crate::sync::atomic::Ordering::AcqRel)
     /// as the `order`. For example,
     /// [`AtomicBool::fetch_xor`](../../std/sync/atomic/struct.AtomicBool.html#method.fetch_xor).
     pub fn atomic_xor_acqrel<T: Copy>(dst: *mut T, src: T) -> T;
@@ -608,7 +608,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `fetch_xor` method by passing
-    /// [`Ordering::Relaxed`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Relaxed`](crate::sync::atomic::Ordering::Relaxed)
     /// as the `order`. For example,
     /// [`AtomicBool::fetch_xor`](../../std/sync/atomic/struct.AtomicBool.html#method.fetch_xor).
     pub fn atomic_xor_relaxed<T: Copy>(dst: *mut T, src: T) -> T;
@@ -617,7 +617,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` signed integer types via the `fetch_max` method by passing
-    /// [`Ordering::SeqCst`](../../std/sync/atomic/enum.Ordering.html#variant.SeqCst)
+    /// [`Ordering::SeqCst`](crate::sync::atomic::Ordering::SeqCst)
     /// as the `order`. For example,
     /// [`AtomicI32::fetch_max`](../../std/sync/atomic/struct.AtomicI32.html#method.fetch_max).
     pub fn atomic_max<T: Copy>(dst: *mut T, src: T) -> T;
@@ -625,7 +625,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` signed integer types via the `fetch_max` method by passing
-    /// [`Ordering::Acquire`](../../std/sync/atomic/enum.Ordering.html#variant.Acquire)
+    /// [`Ordering::Acquire`](crate::sync::atomic::Ordering::Acquire)
     /// as the `order`. For example,
     /// [`AtomicI32::fetch_max`](../../std/sync/atomic/struct.AtomicI32.html#method.fetch_max).
     pub fn atomic_max_acq<T: Copy>(dst: *mut T, src: T) -> T;
@@ -633,7 +633,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` signed integer types via the `fetch_max` method by passing
-    /// [`Ordering::Release`](../../std/sync/atomic/enum.Ordering.html#variant.Release)
+    /// [`Ordering::Release`](crate::sync::atomic::Ordering::Release)
     /// as the `order`. For example,
     /// [`AtomicI32::fetch_max`](../../std/sync/atomic/struct.AtomicI32.html#method.fetch_max).
     pub fn atomic_max_rel<T: Copy>(dst: *mut T, src: T) -> T;
@@ -641,7 +641,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` signed integer types via the `fetch_max` method by passing
-    /// [`Ordering::AcqRel`](../../std/sync/atomic/enum.Ordering.html#variant.AcqRel)
+    /// [`Ordering::AcqRel`](crate::sync::atomic::Ordering::AcqRel)
     /// as the `order`. For example,
     /// [`AtomicI32::fetch_max`](../../std/sync/atomic/struct.AtomicI32.html#method.fetch_max).
     pub fn atomic_max_acqrel<T: Copy>(dst: *mut T, src: T) -> T;
@@ -649,7 +649,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` signed integer types via the `fetch_max` method by passing
-    /// [`Ordering::Relaxed`](../../std/sync/atomic/enum.Ordering.html#variant.Relaxed)
+    /// [`Ordering::Relaxed`](crate::sync::atomic::Ordering::Relaxed)
     /// as the `order`. For example,
     /// [`AtomicI32::fetch_max`](../../std/sync/atomic/struct.AtomicI32.html#method.fetch_max).
     pub fn atomic_max_relaxed<T: Copy>(dst: *mut T, src: T) -> T;
@@ -658,7 +658,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` signed integer types via the `fetch_min` method by passing
-    /// [`Ordering::SeqCst`](../../std/sync/atomic/enum.Ordering.html#variant.SeqCst)
+    /// [`Ordering::SeqCst`](crate::sync::atomic::Ordering::SeqCst)
     /// as the `order`. For example,
     /// [`AtomicI32::fetch_min`](../../std/sync/atomic/struct.AtomicI32.html#method.fetch_min).
     pub fn atomic_min<T: Copy>(dst: *mut T, src: T) -> T;
@@ -666,7 +666,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` signed integer types via the `fetch_min` method by passing
-    /// [`Ordering::Acquire`](../../std/sync/atomic/enum.Ordering.html#variant.Acquire)
+    /// [`Ordering::Acquire`](crate::sync::atomic::Ordering::Acquire)
     /// as the `order`. For example,
     /// [`AtomicI32::fetch_min`](../../std/sync/atomic/struct.AtomicI32.html#method.fetch_min).
     pub fn atomic_min_acq<T: Copy>(dst: *mut T, src: T) -> T;
@@ -674,7 +674,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` signed integer types via the `fetch_min` method by passing
-    /// [`Ordering::Release`](../../std/sync/atomic/enum.Ordering.html#variant.Release)
+    /// [`Ordering::Release`](crate::sync::atomic::Ordering::Release)
     /// as the `order`. For example,
     /// [`AtomicI32::fetch_min`](../../std/sync/atomic/struct.AtomicI32.html#method.fetch_min).
     pub fn atomic_min_rel<T: Copy>(dst: *mut T, src: T) -> T;
@@ -682,7 +682,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` signed integer types via the `fetch_min` method by passing
-    /// [`Ordering::AcqRel`](../../std/sync/atomic/enum.Ordering.html#variant.AcqRel)
+    /// [`Ordering::AcqRel`](crate::sync::atomic::Ordering::AcqRel)
     /// as the `order`. For example,
     /// [`AtomicI32::fetch_min`](../../std/sync/atomic/struct.AtomicI32.html#method.fetch_min).
     pub fn atomic_min_acqrel<T: Copy>(dst: *mut T, src: T) -> T;
@@ -690,7 +690,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` signed integer types via the `fetch_min` method by passing
-    /// [`Ordering::Relaxed`](../../std/sync/atomic/enum.Ordering.html#variant.Relaxed)
+    /// [`Ordering::Relaxed`](crate::sync::atomic::Ordering::Relaxed)
     /// as the `order`. For example,
     /// [`AtomicI32::fetch_min`](../../std/sync/atomic/struct.AtomicI32.html#method.fetch_min).
     pub fn atomic_min_relaxed<T: Copy>(dst: *mut T, src: T) -> T;
@@ -699,7 +699,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` unsigned integer types via the `fetch_min` method by passing
-    /// [`Ordering::SeqCst`](../../std/sync/atomic/enum.Ordering.html#variant.SeqCst)
+    /// [`Ordering::SeqCst`](crate::sync::atomic::Ordering::SeqCst)
     /// as the `order`. For example,
     /// [`AtomicU32::fetch_min`](../../std/sync/atomic/struct.AtomicU32.html#method.fetch_min).
     pub fn atomic_umin<T: Copy>(dst: *mut T, src: T) -> T;
@@ -707,7 +707,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` unsigned integer types via the `fetch_min` method by passing
-    /// [`Ordering::Acquire`](../../std/sync/atomic/enum.Ordering.html#variant.Acquire)
+    /// [`Ordering::Acquire`](crate::sync::atomic::Ordering::Acquire)
     /// as the `order`. For example,
     /// [`AtomicU32::fetch_min`](../../std/sync/atomic/struct.AtomicU32.html#method.fetch_min).
     pub fn atomic_umin_acq<T: Copy>(dst: *mut T, src: T) -> T;
@@ -715,7 +715,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` unsigned integer types via the `fetch_min` method by passing
-    /// [`Ordering::Release`](../../std/sync/atomic/enum.Ordering.html#variant.Release)
+    /// [`Ordering::Release`](crate::sync::atomic::Ordering::Release)
     /// as the `order`. For example,
     /// [`AtomicU32::fetch_min`](../../std/sync/atomic/struct.AtomicU32.html#method.fetch_min).
     pub fn atomic_umin_rel<T: Copy>(dst: *mut T, src: T) -> T;
@@ -723,7 +723,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` unsigned integer types via the `fetch_min` method by passing
-    /// [`Ordering::AcqRel`](../../std/sync/atomic/enum.Ordering.html#variant.AcqRel)
+    /// [`Ordering::AcqRel`](crate::sync::atomic::Ordering::AcqRel)
     /// as the `order`. For example,
     /// [`AtomicU32::fetch_min`](../../std/sync/atomic/struct.AtomicU32.html#method.fetch_min).
     pub fn atomic_umin_acqrel<T: Copy>(dst: *mut T, src: T) -> T;
@@ -731,7 +731,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` unsigned integer types via the `fetch_min` method by passing
-    /// [`Ordering::Relaxed`](../../std/sync/atomic/enum.Ordering.html#variant.Relaxed)
+    /// [`Ordering::Relaxed`](crate::sync::atomic::Ordering::Relaxed)
     /// as the `order`. For example,
     /// [`AtomicU32::fetch_min`](../../std/sync/atomic/struct.AtomicU32.html#method.fetch_min).
     pub fn atomic_umin_relaxed<T: Copy>(dst: *mut T, src: T) -> T;
@@ -740,7 +740,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` unsigned integer types via the `fetch_max` method by passing
-    /// [`Ordering::SeqCst`](../../std/sync/atomic/enum.Ordering.html#variant.SeqCst)
+    /// [`Ordering::SeqCst`](crate::sync::atomic::Ordering::SeqCst)
     /// as the `order`. For example,
     /// [`AtomicU32::fetch_max`](../../std/sync/atomic/struct.AtomicU32.html#method.fetch_max).
     pub fn atomic_umax<T: Copy>(dst: *mut T, src: T) -> T;
@@ -748,7 +748,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` unsigned integer types via the `fetch_max` method by passing
-    /// [`Ordering::Acquire`](../../std/sync/atomic/enum.Ordering.html#variant.Acquire)
+    /// [`Ordering::Acquire`](crate::sync::atomic::Ordering::Acquire)
     /// as the `order`. For example,
     /// [`AtomicU32::fetch_max`](../../std/sync/atomic/struct.AtomicU32.html#method.fetch_max).
     pub fn atomic_umax_acq<T: Copy>(dst: *mut T, src: T) -> T;
@@ -756,7 +756,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` unsigned integer types via the `fetch_max` method by passing
-    /// [`Ordering::Release`](../../std/sync/atomic/enum.Ordering.html#variant.Release)
+    /// [`Ordering::Release`](crate::sync::atomic::Ordering::Release)
     /// as the `order`. For example,
     /// [`AtomicU32::fetch_max`](../../std/sync/atomic/struct.AtomicU32.html#method.fetch_max).
     pub fn atomic_umax_rel<T: Copy>(dst: *mut T, src: T) -> T;
@@ -764,7 +764,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` unsigned integer types via the `fetch_max` method by passing
-    /// [`Ordering::AcqRel`](../../std/sync/atomic/enum.Ordering.html#variant.AcqRel)
+    /// [`Ordering::AcqRel`](crate::sync::atomic::Ordering::AcqRel)
     /// as the `order`. For example,
     /// [`AtomicU32::fetch_max`](../../std/sync/atomic/struct.AtomicU32.html#method.fetch_max).
     pub fn atomic_umax_acqrel<T: Copy>(dst: *mut T, src: T) -> T;
@@ -772,7 +772,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` unsigned integer types via the `fetch_max` method by passing
-    /// [`Ordering::Relaxed`](../../std/sync/atomic/enum.Ordering.html#variant.Relaxed)
+    /// [`Ordering::Relaxed`](crate::sync::atomic::Ordering::Relaxed)
     /// as the `order`. For example,
     /// [`AtomicU32::fetch_max`](../../std/sync/atomic/struct.AtomicU32.html#method.fetch_max).
     pub fn atomic_umax_relaxed<T: Copy>(dst: *mut T, src: T) -> T;
@@ -825,7 +825,7 @@ extern "rust-intrinsic" {
     /// The stabilized version of this intrinsic is available in
     /// [`std::sync::atomic::fence`](../../std/sync/atomic/fn.fence.html)
     /// by passing
-    /// [`Ordering::SeqCst`](../../std/sync/atomic/enum.Ordering.html#variant.SeqCst)
+    /// [`Ordering::SeqCst`](crate::sync::atomic::Ordering::SeqCst)
     /// as the `order`.
     pub fn atomic_fence();
     /// An atomic fence.
@@ -833,7 +833,7 @@ extern "rust-intrinsic" {
     /// The stabilized version of this intrinsic is available in
     /// [`std::sync::atomic::fence`](../../std/sync/atomic/fn.fence.html)
     /// by passing
-    /// [`Ordering::Acquire`](../../std/sync/atomic/enum.Ordering.html#variant.Acquire)
+    /// [`Ordering::Acquire`](crate::sync::atomic::Ordering::Acquire)
     /// as the `order`.
     pub fn atomic_fence_acq();
     /// An atomic fence.
@@ -841,7 +841,7 @@ extern "rust-intrinsic" {
     /// The stabilized version of this intrinsic is available in
     /// [`std::sync::atomic::fence`](../../std/sync/atomic/fn.fence.html)
     /// by passing
-    /// [`Ordering::Release`](../../std/sync/atomic/enum.Ordering.html#variant.Release)
+    /// [`Ordering::Release`](crate::sync::atomic::Ordering::Release)
     /// as the `order`.
     pub fn atomic_fence_rel();
     /// An atomic fence.
@@ -849,7 +849,7 @@ extern "rust-intrinsic" {
     /// The stabilized version of this intrinsic is available in
     /// [`std::sync::atomic::fence`](../../std/sync/atomic/fn.fence.html)
     /// by passing
-    /// [`Ordering::AcqRel`](../../std/sync/atomic/enum.Ordering.html#variant.AcqRel)
+    /// [`Ordering::AcqRel`](crate::sync::atomic::Ordering::AcqRel)
     /// as the `order`.
     pub fn atomic_fence_acqrel();
 
@@ -863,7 +863,7 @@ extern "rust-intrinsic" {
     /// The stabilized version of this intrinsic is available in
     /// [`std::sync::atomic::compiler_fence`](../../std/sync/atomic/fn.compiler_fence.html)
     /// by passing
-    /// [`Ordering::SeqCst`](../../std/sync/atomic/enum.Ordering.html#variant.SeqCst)
+    /// [`Ordering::SeqCst`](crate::sync::atomic::Ordering::SeqCst)
     /// as the `order`.
     pub fn atomic_singlethreadfence();
     /// A compiler-only memory barrier.
@@ -876,7 +876,7 @@ extern "rust-intrinsic" {
     /// The stabilized version of this intrinsic is available in
     /// [`std::sync::atomic::compiler_fence`](../../std/sync/atomic/fn.compiler_fence.html)
     /// by passing
-    /// [`Ordering::Acquire`](../../std/sync/atomic/enum.Ordering.html#variant.Acquire)
+    /// [`Ordering::Acquire`](crate::sync::atomic::Ordering::Acquire)
     /// as the `order`.
     pub fn atomic_singlethreadfence_acq();
     /// A compiler-only memory barrier.
@@ -889,7 +889,7 @@ extern "rust-intrinsic" {
     /// The stabilized version of this intrinsic is available in
     /// [`std::sync::atomic::compiler_fence`](../../std/sync/atomic/fn.compiler_fence.html)
     /// by passing
-    /// [`Ordering::Release`](../../std/sync/atomic/enum.Ordering.html#variant.Release)
+    /// [`Ordering::Release`](crate::sync::atomic::Ordering::Release)
     /// as the `order`.
     pub fn atomic_singlethreadfence_rel();
     /// A compiler-only memory barrier.
@@ -902,7 +902,7 @@ extern "rust-intrinsic" {
     /// The stabilized version of this intrinsic is available in
     /// [`std::sync::atomic::compiler_fence`](../../std/sync/atomic/fn.compiler_fence.html)
     /// by passing
-    /// [`Ordering::AcqRel`](../../std/sync/atomic/enum.Ordering.html#variant.AcqRel)
+    /// [`Ordering::AcqRel`](crate::sync::atomic::Ordering::AcqRel)
     /// as the `order`.
     pub fn atomic_singlethreadfence_acqrel();
 

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -373,7 +373,7 @@ extern "rust-intrinsic" {
     /// `std::sync::atomic` types via the `fetch_add` method by passing
     /// [`Ordering::SeqCst`](crate::sync::atomic::Ordering::SeqCst)
     /// as the `order`. For example,
-    /// [`AtomicIsize::fetch_add`](../../std/sync/atomic/struct.AtomicIsize.html#method.fetch_add).
+    /// [`AtomicIsize::fetch_add`](crate::sync::atomic::AtomicIsize::fetch_add).
     pub fn atomic_xadd<T: Copy>(dst: *mut T, src: T) -> T;
     /// Adds to the current value, returning the previous value.
     ///
@@ -381,7 +381,7 @@ extern "rust-intrinsic" {
     /// `std::sync::atomic` types via the `fetch_add` method by passing
     /// [`Ordering::Acquire`](crate::sync::atomic::Ordering::Acquire)
     /// as the `order`. For example,
-    /// [`AtomicIsize::fetch_add`](../../std/sync/atomic/struct.AtomicIsize.html#method.fetch_add).
+    /// [`AtomicIsize::fetch_add`](crate::sync::atomic::AtomicIsize::fetch_add).
     pub fn atomic_xadd_acq<T: Copy>(dst: *mut T, src: T) -> T;
     /// Adds to the current value, returning the previous value.
     ///
@@ -389,7 +389,7 @@ extern "rust-intrinsic" {
     /// `std::sync::atomic` types via the `fetch_add` method by passing
     /// [`Ordering::Release`](crate::sync::atomic::Ordering::Release)
     /// as the `order`. For example,
-    /// [`AtomicIsize::fetch_add`](../../std/sync/atomic/struct.AtomicIsize.html#method.fetch_add).
+    /// [`AtomicIsize::fetch_add`](crate::sync::atomic::AtomicIsize::fetch_add).
     pub fn atomic_xadd_rel<T: Copy>(dst: *mut T, src: T) -> T;
     /// Adds to the current value, returning the previous value.
     ///
@@ -397,7 +397,7 @@ extern "rust-intrinsic" {
     /// `std::sync::atomic` types via the `fetch_add` method by passing
     /// [`Ordering::AcqRel`](crate::sync::atomic::Ordering::AcqRel)
     /// as the `order`. For example,
-    /// [`AtomicIsize::fetch_add`](../../std/sync/atomic/struct.AtomicIsize.html#method.fetch_add).
+    /// [`AtomicIsize::fetch_add`](crate::sync::atomic::AtomicIsize::fetch_add).
     pub fn atomic_xadd_acqrel<T: Copy>(dst: *mut T, src: T) -> T;
     /// Adds to the current value, returning the previous value.
     ///
@@ -405,7 +405,7 @@ extern "rust-intrinsic" {
     /// `std::sync::atomic` types via the `fetch_add` method by passing
     /// [`Ordering::Relaxed`](crate::sync::atomic::Ordering::Relaxed)
     /// as the `order`. For example,
-    /// [`AtomicIsize::fetch_add`](../../std/sync/atomic/struct.AtomicIsize.html#method.fetch_add).
+    /// [`AtomicIsize::fetch_add`](crate::sync::atomic::AtomicIsize::fetch_add).
     pub fn atomic_xadd_relaxed<T: Copy>(dst: *mut T, src: T) -> T;
 
     /// Subtract from the current value, returning the previous value.
@@ -414,7 +414,7 @@ extern "rust-intrinsic" {
     /// `std::sync::atomic` types via the `fetch_sub` method by passing
     /// [`Ordering::SeqCst`](crate::sync::atomic::Ordering::SeqCst)
     /// as the `order`. For example,
-    /// [`AtomicIsize::fetch_sub`](../../std/sync/atomic/struct.AtomicIsize.html#method.fetch_sub).
+    /// [`AtomicIsize::fetch_sub`](crate::sync::atomic::AtomicIsize::fetch_sub).
     pub fn atomic_xsub<T: Copy>(dst: *mut T, src: T) -> T;
     /// Subtract from the current value, returning the previous value.
     ///
@@ -422,7 +422,7 @@ extern "rust-intrinsic" {
     /// `std::sync::atomic` types via the `fetch_sub` method by passing
     /// [`Ordering::Acquire`](crate::sync::atomic::Ordering::Acquire)
     /// as the `order`. For example,
-    /// [`AtomicIsize::fetch_sub`](../../std/sync/atomic/struct.AtomicIsize.html#method.fetch_sub).
+    /// [`AtomicIsize::fetch_sub`](crate::sync::atomic::AtomicIsize::fetch_sub).
     pub fn atomic_xsub_acq<T: Copy>(dst: *mut T, src: T) -> T;
     /// Subtract from the current value, returning the previous value.
     ///
@@ -430,7 +430,7 @@ extern "rust-intrinsic" {
     /// `std::sync::atomic` types via the `fetch_sub` method by passing
     /// [`Ordering::Release`](crate::sync::atomic::Ordering::Release)
     /// as the `order`. For example,
-    /// [`AtomicIsize::fetch_sub`](../../std/sync/atomic/struct.AtomicIsize.html#method.fetch_sub).
+    /// [`AtomicIsize::fetch_sub`](crate::sync::atomic::AtomicIsize::fetch_sub).
     pub fn atomic_xsub_rel<T: Copy>(dst: *mut T, src: T) -> T;
     /// Subtract from the current value, returning the previous value.
     ///
@@ -438,7 +438,7 @@ extern "rust-intrinsic" {
     /// `std::sync::atomic` types via the `fetch_sub` method by passing
     /// [`Ordering::AcqRel`](crate::sync::atomic::Ordering::AcqRel)
     /// as the `order`. For example,
-    /// [`AtomicIsize::fetch_sub`](../../std/sync/atomic/struct.AtomicIsize.html#method.fetch_sub).
+    /// [`AtomicIsize::fetch_sub`](crate::sync::atomic::AtomicIsize::fetch_sub).
     pub fn atomic_xsub_acqrel<T: Copy>(dst: *mut T, src: T) -> T;
     /// Subtract from the current value, returning the previous value.
     ///
@@ -446,7 +446,7 @@ extern "rust-intrinsic" {
     /// `std::sync::atomic` types via the `fetch_sub` method by passing
     /// [`Ordering::Relaxed`](crate::sync::atomic::Ordering::Relaxed)
     /// as the `order`. For example,
-    /// [`AtomicIsize::fetch_sub`](../../std/sync/atomic/struct.AtomicIsize.html#method.fetch_sub).
+    /// [`AtomicIsize::fetch_sub`](crate::sync::atomic::AtomicIsize::fetch_sub).
     pub fn atomic_xsub_relaxed<T: Copy>(dst: *mut T, src: T) -> T;
 
     /// Bitwise and with the current value, returning the previous value.

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -1526,22 +1526,22 @@ extern "rust-intrinsic" {
     /// Returns the minimum of two `f32` values.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::f32::min`](../../std/primitive.f32.html#method.min)
+    /// [`std::f32::min`](f32::min)
     pub fn minnumf32(x: f32, y: f32) -> f32;
     /// Returns the minimum of two `f64` values.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::f64::min`](../../std/primitive.f64.html#method.min)
+    /// [`std::f64::min`](f64::min)
     pub fn minnumf64(x: f64, y: f64) -> f64;
     /// Returns the maximum of two `f32` values.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::f32::max`](../../std/primitive.f32.html#method.max)
+    /// [`std::f32::max`](f32::max)
     pub fn maxnumf32(x: f32, y: f32) -> f32;
     /// Returns the maximum of two `f64` values.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::f64::max`](../../std/primitive.f64.html#method.max)
+    /// [`std::f64::max`](f64::max)
     pub fn maxnumf64(x: f64, y: f64) -> f64;
 
     /// Copies the sign from `y` to `x` for `f32` values.


### PR DESCRIPTION
Helps with #75080.

@rustbot modify labels: T-doc, A-intra-doc-links, T-rustdoc

Known issues:

* The following f32 and f64 primitive methods cannot be resolved:

    f32/f64::powi
    f32/f64::sqrt
    f32/f64::sin
    f32/f64::cos
    f32/f64::powf
    f32/f64::exp
    f32/f64::exp2
    f32/f64::ln
    f32/f64::log2
    f32/f64::log10
    f32/f64::mul_add
    f32/f64::abs
    f32/f64::copysign
    f32/f64::floor
    f32/f64::ceil
    f32/f64::trunc
    f32/f64::round

* Links from core to std:

    [`std::pointer::*`]
    [`std::process::abort`]
    [`from_raw_parts`]
    [`Vec::append`]

* Links with anchors?

	I provided a separate commit that replaced links with anchors by intra-doc links.
	Here the anchor location information gets lost, so its questionable whether to 
	actually replace those links.
