### PR TITLE
Upgrade Emscripten on CI to 1.39.20 

### DIFF
--- a/src/ci/docker/scripts/emscripten.sh
+++ b/src/ci/docker/scripts/emscripten.sh
@@ -19,5 +19,5 @@ exit 1
 
 git clone https://github.com/emscripten-core/emsdk.git /emsdk-portable
 cd /emsdk-portable
-hide_output ./emsdk install 1.38.47-upstream
-./emsdk activate 1.38.47-upstream
+hide_output ./emsdk install 1.39.20
+./emsdk activate 1.39.20


### PR DESCRIPTION
This Emscripten version was the first to be cut after the LLVM 11
release branch was created, so it should be the most compatible with
LLVM 11. The old version we were using was incompatible with LLVM 11
because its wasm-ld did not understand all the relocations that LLVM
11 emits.