### PR TITLE
add `array::FillError` similar to `array::IntoIter`

### DIFF
--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -227,13 +227,13 @@ impl<T, const N: usize> FillError<T, N> {
     /// Returns an immutable slice of all initialized elements.
     pub fn as_slice(&self) -> &[T] {
         // SAFETY: We know that all elements from 0 to len are properly initialized.
-        unsafe { MaybeUninit::slice_get_ref(&self.array[0..self.len]) }
+        unsafe { MaybeUninit::slice_assume_init_ref(&self.array[0..self.len]) }
     }
 
     /// Returns a mutable slice of all initialized elements.
     pub fn as_mut_slice(&mut self) -> &mut [T] {
         // SAFETY: We know that all elements from 0 to len are properly initialized.
-        unsafe { MaybeUninit::slice_get_mut(&mut self.array[0..self.len]) }
+        unsafe { MaybeUninit::slice_assume_init_mut(&mut self.array[0..self.len]) }
     }
 
     /// Tries to initialize the left-over elements using `iter`.

--- a/library/core/src/mem/maybe_uninit.rs
+++ b/library/core/src/mem/maybe_uninit.rs
@@ -819,7 +819,7 @@ impl<T> MaybeUninit<T> {
     #[unstable(feature = "maybe_uninit_slice", issue = "63569")]
     #[inline(always)]
     pub unsafe fn slice_assume_init_mut(slice: &mut [Self]) -> &mut [T] {
-        // SAFETY: similar to safety notes for `slice_get_ref`, but we have a
+        // SAFETY: similar to safety notes for `slice_assume_init_ref`, but we have a
         // mutable reference which is also guaranteed to be valid for writes.
         unsafe { &mut *(slice as *mut [Self] as *mut [T]) }
     }

--- a/library/core/tests/array.rs
+++ b/library/core/tests/array.rs
@@ -330,3 +330,41 @@ fn array_map_drop_safety() {
     assert_eq!(DROPPED.load(Ordering::SeqCst), num_to_create);
     panic!("test succeeded")
 }
+
+#[test]
+fn array_collects() {
+    let v = vec![1, 2, 3, 4, 5];
+    let a: [i32; 5] = v
+        .clone()
+        .into_iter()
+        .collect::<Result<[i32; 5], core::array::FillError<i32, 5>>>()
+        .unwrap();
+
+    assert_eq!(v[..], a[..]);
+}
+
+#[test]
+fn array_collect_drop_on_panic() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    #[derive(Clone)]
+    struct Foo(Arc<AtomicUsize>);
+
+    // count the number of eleemts that got dropped
+    impl Drop for Foo {
+        fn drop(&mut self) {
+            self.0.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    let i = Arc::new(AtomicUsize::new(0));
+    let foo = Foo(i.clone());
+
+    std::panic::catch_unwind(move || {
+        let _a: [Foo; 5] = from_iter(vec![foo.clone(), foo.clone(), foo.clone(), foo]);
+    })
+    .unwrap_err();
+
+    assert_eq!(i.load(Ordering::SeqCst), 4);
+}

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -56,6 +56,7 @@
 #![feature(unsafe_block_in_unsafe_fn)]
 #![feature(int_bits_const)]
 #![deny(unsafe_op_in_unsafe_fn)]
+#![feature(array_from_iter_impl)]
 
 extern crate test;
 


### PR DESCRIPTION
Taken from #69985 without actually implementing `FromIterator` so we can merge this without having to worry about
stabilizing anything.

While implementing new methods for arrays, this is very often needed and we otherwise need to reimplement this in each new method.

A huge thanks to @lperlaki, who has done most of the work necessary for this PR as part of #69985.

To summarize, this PR adds `struct array::FillError<T, const N: usize>`, which is intended as part of the return type of `FromIterator` for arrays, once we implement this (requires at least stable `min_const_generics`). The current concept is to implement `FromIterator` for `Result<[T; N], FillError<T, N>>`, returning a `FillError` if the iterator had less than `N` elements.

Similar to `IntoIter`, we don't yet actually implement `FromIterator` but instead add a probably permanently unstable `new` method to `FillError`, meaning that one can now write `FillError::new().fill(iter).unwrap()` to collect into an array, which was previously not cleanly possible.

