### PR TITLE
Switch to intra-doc links in `core::result`

### DIFF
--- a/library/core/src/result.rs
+++ b/library/core/src/result.rs
@@ -216,17 +216,14 @@
 //! [`?`] can only be used in functions that return [`Result`] because of the
 //! early return of [`Err`] that it provides.
 //!
-//! [`expect`]: enum.Result.html#method.expect
+//! [`expect`]: Result::expect
 //! [`Write`]: ../../std/io/trait.Write.html
 //! [`write_all`]: ../../std/io/trait.Write.html#method.write_all
 //! [`io::Result`]: ../../std/io/type.Result.html
 //! [`?`]: ../../std/macro.try.html
-//! [`Result`]: enum.Result.html
-//! [`Ok(T)`]: enum.Result.html#variant.Ok
-//! [`Err(E)`]: enum.Result.html#variant.Err
+//! [`Ok(T)`]: Ok
+//! [`Err(E)`]: Err
 //! [`io::Error`]: ../../std/io/struct.Error.html
-//! [`Ok`]: enum.Result.html#variant.Ok
-//! [`Err`]: enum.Result.html#variant.Err
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
@@ -237,9 +234,6 @@ use crate::{convert, fmt};
 /// `Result` is a type that represents either success ([`Ok`]) or failure ([`Err`]).
 ///
 /// See the [`std::result`](index.html) module documentation for details.
-///
-/// [`Ok`]: enum.Result.html#variant.Ok
-/// [`Err`]: enum.Result.html#variant.Err
 #[derive(Copy, PartialEq, PartialOrd, Eq, Ord, Debug, Hash)]
 #[must_use = "this `Result` may be an `Err` variant, which should be handled"]
 #[rustc_diagnostic_item = "result_type"]
@@ -267,8 +261,6 @@ impl<T, E> Result<T, E> {
 
     /// Returns `true` if the result is [`Ok`].
     ///
-    /// [`Ok`]: enum.Result.html#variant.Ok
-    ///
     /// # Examples
     ///
     /// Basic usage:
@@ -289,8 +281,6 @@ impl<T, E> Result<T, E> {
     }
 
     /// Returns `true` if the result is [`Err`].
-    ///
-    /// [`Err`]: enum.Result.html#variant.Err
     ///
     /// # Examples
     ///
@@ -378,7 +368,7 @@ impl<T, E> Result<T, E> {
     /// Converts `self` into an [`Option<T>`], consuming `self`,
     /// and discarding the error, if any.
     ///
-    /// [`Option<T>`]: ../../std/option/enum.Option.html
+    /// [`Option<T>`]: Option
     ///
     /// # Examples
     ///
@@ -405,7 +395,7 @@ impl<T, E> Result<T, E> {
     /// Converts `self` into an [`Option<E>`], consuming `self`,
     /// and discarding the success value, if any.
     ///
-    /// [`Option<E>`]: ../../std/option/enum.Option.html
+    /// [`Option<E>`]: Option
     ///
     /// # Examples
     ///
@@ -497,9 +487,6 @@ impl<T, E> Result<T, E> {
     ///
     /// This function can be used to compose the results of two functions.
     ///
-    /// [`Ok`]: enum.Result.html#variant.Ok
-    /// [`Err`]: enum.Result.html#variant.Err
-    ///
     /// # Examples
     ///
     /// Print the numbers on each line of a string multiplied by two.
@@ -530,9 +517,7 @@ impl<T, E> Result<T, E> {
     /// the result of a function call, it is recommended to use [`map_or_else`],
     /// which is lazily evaluated.
     ///
-    /// [`map_or_else`]: #method.map_or_else
-    /// [`Ok`]: enum.Result.html#variant.Ok
-    /// [`Err`]: enum.Result.html#variant.Err
+    /// [`map_or_else`]: Result::map_or_else
     ///
     /// # Examples
     ///
@@ -559,8 +544,6 @@ impl<T, E> Result<T, E> {
     /// This function can be used to unpack a successful result
     /// while handling an error.
     ///
-    /// [`Ok`]: enum.Result.html#variant.Ok
-    /// [`Err`]: enum.Result.html#variant.Err
     ///
     /// # Examples
     ///
@@ -590,8 +573,6 @@ impl<T, E> Result<T, E> {
     /// This function can be used to pass through a successful result while handling
     /// an error.
     ///
-    /// [`Ok`]: enum.Result.html#variant.Ok
-    /// [`Err`]: enum.Result.html#variant.Err
     ///
     /// # Examples
     ///
@@ -671,8 +652,6 @@ impl<T, E> Result<T, E> {
 
     /// Returns `res` if the result is [`Ok`], otherwise returns the [`Err`] value of `self`.
     ///
-    /// [`Ok`]: enum.Result.html#variant.Ok
-    /// [`Err`]: enum.Result.html#variant.Err
     ///
     /// # Examples
     ///
@@ -706,8 +685,6 @@ impl<T, E> Result<T, E> {
 
     /// Calls `op` if the result is [`Ok`], otherwise returns the [`Err`] value of `self`.
     ///
-    /// [`Ok`]: enum.Result.html#variant.Ok
-    /// [`Err`]: enum.Result.html#variant.Err
     ///
     /// This function can be used for control flow based on `Result` values.
     ///
@@ -739,9 +716,7 @@ impl<T, E> Result<T, E> {
     /// result of a function call, it is recommended to use [`or_else`], which is
     /// lazily evaluated.
     ///
-    /// [`Ok`]: enum.Result.html#variant.Ok
-    /// [`Err`]: enum.Result.html#variant.Err
-    /// [`or_else`]: #method.or_else
+    /// [`or_else`]: Result::or_else
     ///
     /// # Examples
     ///
@@ -777,8 +752,6 @@ impl<T, E> Result<T, E> {
     ///
     /// This function can be used for control flow based on result values.
     ///
-    /// [`Ok`]: enum.Result.html#variant.Ok
-    /// [`Err`]: enum.Result.html#variant.Err
     ///
     /// # Examples
     ///
@@ -808,9 +781,7 @@ impl<T, E> Result<T, E> {
     /// the result of a function call, it is recommended to use [`unwrap_or_else`],
     /// which is lazily evaluated.
     ///
-    /// [`Ok`]: enum.Result.html#variant.Ok
-    /// [`Err`]: enum.Result.html#variant.Err
-    /// [`unwrap_or_else`]: #method.unwrap_or_else
+    /// [`unwrap_or_else`]: Result::unwrap_or_else
     ///
     /// # Examples
     ///
@@ -835,7 +806,6 @@ impl<T, E> Result<T, E> {
 
     /// Returns the contained [`Ok`] value or computes it from a closure.
     ///
-    /// [`Ok`]: enum.Result.html#variant.Ok
     ///
     /// # Examples
     ///
@@ -945,8 +915,6 @@ impl<T, E: fmt::Debug> Result<T, E> {
     /// Panics if the value is an [`Err`], with a panic message including the
     /// passed message, and the content of the [`Err`].
     ///
-    /// [`Ok`]: enum.Result.html#variant.Ok
-    /// [`Err`]: enum.Result.html#variant.Err
     ///
     /// # Examples
     ///
@@ -973,17 +941,15 @@ impl<T, E: fmt::Debug> Result<T, E> {
     /// case explicitly, or call [`unwrap_or`], [`unwrap_or_else`], or
     /// [`unwrap_or_default`].
     ///
-    /// [`unwrap_or`]: #method.unwrap_or
-    /// [`unwrap_or_else`]: #method.unwrap_or_else
-    /// [`unwrap_or_default`]: #method.unwrap_or_default
+    /// [`unwrap_or`]: Result::unwrap_or
+    /// [`unwrap_or_else`]: Result::unwrap_or_else
+    /// [`unwrap_or_default`]: Result::unwrap_or_default
     ///
     /// # Panics
     ///
     /// Panics if the value is an [`Err`], with a panic message provided by the
     /// [`Err`]'s value.
     ///
-    /// [`Ok`]: enum.Result.html#variant.Ok
-    /// [`Err`]: enum.Result.html#variant.Err
     ///
     /// # Examples
     ///
@@ -1017,8 +983,6 @@ impl<T: fmt::Debug, E> Result<T, E> {
     /// Panics if the value is an [`Ok`], with a panic message including the
     /// passed message, and the content of the [`Ok`].
     ///
-    /// [`Ok`]: enum.Result.html#variant.Ok
-    /// [`Err`]: enum.Result.html#variant.Err
     ///
     /// # Examples
     ///
@@ -1045,8 +1009,6 @@ impl<T: fmt::Debug, E> Result<T, E> {
     /// Panics if the value is an [`Ok`], with a custom panic message provided
     /// by the [`Ok`]'s value.
     ///
-    /// [`Ok`]: enum.Result.html#variant.Ok
-    /// [`Err`]: enum.Result.html#variant.Err
     ///
     ///
     /// # Examples
@@ -1095,10 +1057,8 @@ impl<T: Default, E> Result<T, E> {
     /// assert_eq!(0, bad_year);
     /// ```
     ///
-    /// [`parse`]: ../../std/primitive.str.html#method.parse
-    /// [`FromStr`]: ../../std/str/trait.FromStr.html
-    /// [`Ok`]: enum.Result.html#variant.Ok
-    /// [`Err`]: enum.Result.html#variant.Err
+    /// [`parse`]: str::parse
+    /// [`FromStr`]: FromStr
     #[inline]
     #[stable(feature = "result_unwrap_or_default", since = "1.16.0")]
     pub fn unwrap_or_default(self) -> T {
@@ -1119,9 +1079,7 @@ impl<T, E: Into<!>> Result<T, E> {
     /// to compile if the error type of the `Result` is later changed
     /// to an error that can actually occur.
     ///
-    /// [`Ok`]: enum.Result.html#variant.Ok
-    /// [`Err`]: enum.Result.html#variant.Err
-    /// [`unwrap`]: enum.Result.html#method.unwrap
+    /// [`unwrap`]: Result::unwrap
     ///
     /// # Examples
     ///
@@ -1343,10 +1301,6 @@ impl<'a, T, E> IntoIterator for &'a mut Result<T, E> {
 /// The iterator yields one value if the result is [`Ok`], otherwise none.
 ///
 /// Created by [`Result::iter`].
-///
-/// [`Ok`]: enum.Result.html#variant.Ok
-/// [`Result`]: enum.Result.html
-/// [`Result::iter`]: enum.Result.html#method.iter
 #[derive(Debug)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct Iter<'a, T: 'a> {
@@ -1396,10 +1350,6 @@ impl<T> Clone for Iter<'_, T> {
 /// An iterator over a mutable reference to the [`Ok`] variant of a [`Result`].
 ///
 /// Created by [`Result::iter_mut`].
-///
-/// [`Ok`]: enum.Result.html#variant.Ok
-/// [`Result`]: enum.Result.html
-/// [`Result::iter_mut`]: enum.Result.html#method.iter_mut
 #[derive(Debug)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct IterMut<'a, T: 'a> {
@@ -1445,10 +1395,7 @@ unsafe impl<A> TrustedLen for IterMut<'_, A> {}
 /// This struct is created by the [`into_iter`] method on
 /// [`Result`] (provided by the [`IntoIterator`] trait).
 ///
-/// [`Ok`]: enum.Result.html#variant.Ok
-/// [`Result`]: enum.Result.html
-/// [`into_iter`]: ../iter/trait.IntoIterator.html#tymethod.into_iter
-/// [`IntoIterator`]: ../iter/trait.IntoIterator.html
+/// [`into_iter`]: IntoIterator::into_iter
 #[derive(Clone, Debug)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct IntoIter<T> {

--- a/library/core/src/result.rs
+++ b/library/core/src/result.rs
@@ -1058,7 +1058,7 @@ impl<T: Default, E> Result<T, E> {
     /// ```
     ///
     /// [`parse`]: str::parse
-    /// [`FromStr`]: FromStr
+    /// [`FromStr`]: ../../std/str/trait.FromStr.html
     #[inline]
     #[stable(feature = "result_unwrap_or_default", since = "1.16.0")]
     pub fn unwrap_or_default(self) -> T {

--- a/library/core/src/result.rs
+++ b/library/core/src/result.rs
@@ -220,7 +220,7 @@
 //! [`Write`]: ../../std/io/trait.Write.html
 //! [`write_all`]: ../../std/io/trait.Write.html#method.write_all
 //! [`io::Result`]: ../../std/io/type.Result.html
-//! [`?`]: ../../std/macro.try.html
+//! [`?`]: crate::ops::Try
 //! [`Ok(T)`]: Ok
 //! [`Err(E)`]: Err
 //! [`io::Error`]: ../../std/io/struct.Error.html
@@ -1058,7 +1058,7 @@ impl<T: Default, E> Result<T, E> {
     /// ```
     ///
     /// [`parse`]: str::parse
-    /// [`FromStr`]: ../../std/str/trait.FromStr.html
+    /// [`FromStr`]: crate::str::FromStr
     #[inline]
     #[stable(feature = "result_unwrap_or_default", since = "1.16.0")]
     pub fn unwrap_or_default(self) -> T {


### PR DESCRIPTION
Part of #75080.

@rustbot modify labels: A-intra-doc-links T-doc T-rustdoc