### PR TITLE
polymorphize: remove predicate logic

### DIFF
--- a/src/test/ui/polymorphization/predicates.rs
+++ b/src/test/ui/polymorphization/predicates.rs
@@ -12,6 +12,7 @@ fn bar<I>() {
 
 #[rustc_polymorphize_error]
 fn foo<I, T>(_: I)
+//~^ ERROR item has unused generic parameters
 where
     I: Iterator<Item = T>,
 {
@@ -20,6 +21,7 @@ where
 
 #[rustc_polymorphize_error]
 fn baz<I, T>(_: I)
+//~^ ERROR item has unused generic parameters
 where
     std::iter::Repeat<I>: Iterator<Item = T>,
 {
@@ -40,6 +42,7 @@ where
     #[rustc_polymorphize_error]
     fn next(&mut self) -> Option<Self::Item> {
         self.find(|_| true)
+        //~^ ERROR item has unused generic parameters
     }
 }
 
@@ -53,6 +56,7 @@ impl Baz<u32> for u16 {}
 
 #[rustc_polymorphize_error]
 fn quux<A, B, C: Default>() -> usize
+//~^ ERROR item has unused generic parameters
 where
     A: Baz<B>,
     B: Baz<C>,
@@ -69,6 +73,7 @@ impl Foobar<u32, u32> for () {}
 
 #[rustc_polymorphize_error]
 fn foobar<F, G>() -> usize
+//~^ ERROR item has unused generic parameters
 where
     (): Foobar<F, G>,
 {

--- a/src/test/ui/polymorphization/predicates.stderr
+++ b/src/test/ui/polymorphization/predicates.stderr
@@ -1,8 +1,45 @@
 error: item has unused generic parameters
+  --> $DIR/predicates.rs:14:4
+   |
+LL | fn foo<I, T>(_: I)
+   |    ^^^    - generic parameter `T` is unused
+
+error: item has unused generic parameters
+  --> $DIR/predicates.rs:23:4
+   |
+LL | fn baz<I, T>(_: I)
+   |    ^^^    - generic parameter `T` is unused
+
+error: item has unused generic parameters
+  --> $DIR/predicates.rs:44:19
+   |
+LL | impl<'a, I, T: 'a, E> Iterator for Foo<'a, I, E>
+   |          -         - generic parameter `E` is unused
+   |          |
+   |          generic parameter `I` is unused
+...
+LL |         self.find(|_| true)
+   |                   ^^^^^^^^
+
+error: item has unused generic parameters
+  --> $DIR/predicates.rs:58:4
+   |
+LL | fn quux<A, B, C: Default>() -> usize
+   |    ^^^^ -  - generic parameter `B` is unused
+   |         |
+   |         generic parameter `A` is unused
+
+error: item has unused generic parameters
+  --> $DIR/predicates.rs:75:4
+   |
+LL | fn foobar<F, G>() -> usize
+   |    ^^^^^^ - generic parameter `F` is unused
+
+error: item has unused generic parameters
   --> $DIR/predicates.rs:9:4
    |
 LL | fn bar<I>() {
    |    ^^^ - generic parameter `I` is unused
 
-error: aborting due to previous error
+error: aborting due to 6 previous errors
 


### PR DESCRIPTION
This PR removes all logic which marks parameters as used based on their presence in predicates - given rust-lang/rust#75675, this will enable more polymorphization and avoid the symbol clashes that predicate logic previously sidestepped.

~~Opened as a draft as it depends on #75675 (will need rebased to re-enable a test).~~

r? @eddyb