### PR TITLE
Refactor byteorder to std in rustc_middle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3722,7 +3722,6 @@ name = "rustc_middle"
 version = "0.0.0"
 dependencies = [
  "bitflags",
- "byteorder",
  "chalk-ir",
  "measureme",
  "polonius-engine",

--- a/compiler/rustc_middle/Cargo.toml
+++ b/compiler/rustc_middle/Cargo.toml
@@ -26,7 +26,6 @@ rustc_index = { path = "../rustc_index" }
 rustc_serialize = { path = "../rustc_serialize" }
 rustc_ast = { path = "../rustc_ast" }
 rustc_span = { path = "../rustc_span" }
-byteorder = { version = "1.3" }
 chalk-ir = "0.21.0"
 smallvec = { version = "1.0", features = ["union", "may_dangle"] }
 measureme = "0.7.1"

--- a/compiler/rustc_middle/src/mir/interpret/allocation.rs
+++ b/compiler/rustc_middle/src/mir/interpret/allocation.rs
@@ -345,10 +345,8 @@ impl<'tcx, Tag: Copy, Extra: AllocationExtra<Tag>> Allocation<Tag, Extra> {
 
     /// Reads a *non-ZST* scalar.
     ///
-    /// ZSTs can't be read for two reasons:
-    /// * byte-order cannot work with zero-element buffers;
-    /// * in order to obtain a `Pointer`, we need to check for ZSTness anyway due to integer
-    ///   pointers being valid for ZSTs.
+    /// ZSTs can't be read because in order to obtain a `Pointer`, we need to check
+    /// for ZSTness anyway due to integer pointers being valid for ZSTs.
     ///
     /// It is the caller's responsibility to check bounds and alignment beforehand.
     /// Most likely, you want to call `InterpCx::read_scalar` instead of this method.
@@ -397,10 +395,8 @@ impl<'tcx, Tag: Copy, Extra: AllocationExtra<Tag>> Allocation<Tag, Extra> {
 
     /// Writes a *non-ZST* scalar.
     ///
-    /// ZSTs can't be read for two reasons:
-    /// * byte-order cannot work with zero-element buffers;
-    /// * in order to obtain a `Pointer`, we need to check for ZSTness anyway due to integer
-    ///   pointers being valid for ZSTs.
+    /// ZSTs can't be read because in order to obtain a `Pointer`, we need to check
+    /// for ZSTness anyway due to integer pointers being valid for ZSTs.
     ///
     /// It is the caller's responsibility to check bounds and alignment beforehand.
     /// Most likely, you want to call `InterpCx::write_scalar` instead of this method.

--- a/compiler/rustc_middle/src/mir/interpret/mod.rs
+++ b/compiler/rustc_middle/src/mir/interpret/mod.rs
@@ -561,17 +561,23 @@ pub fn write_target_uint(
     mut target: &mut [u8],
     data: u128,
 ) -> Result<(), io::Error> {
+    // This u128 holds an "any-size uint" (since smaller uints can fits in it)
+    // So we do not write all bytes of the u128, just the "payload".
     match endianness {
         Endian::Little => target.write(&data.to_le_bytes())?,
         Endian::Big => target.write(&data.to_be_bytes())?,
     };
+    debug_assert!(target.len() == 0); // We should have filled the target buffer.
     Ok(())
 }
 
 #[inline]
 pub fn read_target_uint(endianness: Endian, mut source: &[u8]) -> Result<u128, io::Error> {
+    // This u128 holds an "any-size uint" (since smaller uints can fits in it)
     let mut buf = [0u8; std::mem::size_of::<u128>()];
+    // So we do not read exactly 16 bytes into the u128, just the "payload".
     source.read(&mut buf)?;
+    debug_assert!(source.len() == 0); // We should have consumed the source buffer.
     match endianness {
         Endian::Little => Ok(u128::from_le_bytes(buf)),
         Endian::Big => Ok(u128::from_be_bytes(buf)),

--- a/compiler/rustc_middle/src/mir/interpret/mod.rs
+++ b/compiler/rustc_middle/src/mir/interpret/mod.rs
@@ -565,7 +565,7 @@ pub fn write_target_uint(
     // So we do not write all bytes of the u128, just the "payload".
     match endianness {
         Endian::Little => target.write(&data.to_le_bytes())?,
-        Endian::Big => target.write(&data.to_be_bytes())?,
+        Endian::Big => target.write(&data.to_be_bytes()[16 - target.len()..])?,
     };
     debug_assert!(target.len() == 0); // We should have filled the target buffer.
     Ok(())
@@ -576,12 +576,18 @@ pub fn read_target_uint(endianness: Endian, mut source: &[u8]) -> Result<u128, i
     // This u128 holds an "any-size uint" (since smaller uints can fits in it)
     let mut buf = [0u8; std::mem::size_of::<u128>()];
     // So we do not read exactly 16 bytes into the u128, just the "payload".
-    source.read(&mut buf)?;
+    let uint = match endianness {
+        Endian::Little => {
+            source.read(&mut buf)?;
+            Ok(u128::from_le_bytes(buf))
+        }
+        Endian::Big => {
+            source.read(&mut buf[16 - source.len()..])?;
+            Ok(u128::from_be_bytes(buf))
+        }
+    };
     debug_assert!(source.len() == 0); // We should have consumed the source buffer.
-    match endianness {
-        Endian::Little => Ok(u128::from_le_bytes(buf)),
-        Endian::Big => Ok(u128::from_be_bytes(buf)),
-    }
+    uint
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/compiler/rustc_middle/src/mir/interpret/mod.rs
+++ b/compiler/rustc_middle/src/mir/interpret/mod.rs
@@ -570,7 +570,7 @@ pub fn write_target_uint(
 
 #[inline]
 pub fn read_target_uint(endianness: Endian, mut source: &[u8]) -> Result<u128, io::Error> {
-    let mut buf = [0; 16];
+    let mut buf = [0u8; std::mem::size_of::<u128>()];
     source.read(&mut buf)?;
     match endianness {
         Endian::Little => Ok(u128::from_le_bytes(buf)),


### PR DESCRIPTION
Use std::io::{Read, Write} and {to, from}_{le, be}_bytes methods in
order to remove byteorder from librustc_middle's dependency graph.