### PR TITLE
Rename rustc_lexer::TokenKind::Not to Bang

### DIFF
--- a/src/librustc_lexer/src/lib.rs
+++ b/src/librustc_lexer/src/lib.rs
@@ -103,7 +103,7 @@ pub enum TokenKind {
     /// "="
     Eq,
     /// "!"
-    Not,
+    Bang,
     /// "<"
     Lt,
     /// ">"
@@ -378,7 +378,7 @@ impl Cursor<'_> {
             ':' => Colon,
             '$' => Dollar,
             '=' => Eq,
-            '!' => Not,
+            '!' => Bang,
             '<' => Lt,
             '>' => Gt,
             '-' => Minus,

--- a/src/librustc_parse/lexer/mod.rs
+++ b/src/librustc_parse/lexer/mod.rs
@@ -290,7 +290,7 @@ impl<'a> StringReader<'a> {
             rustc_lexer::TokenKind::Colon => token::Colon,
             rustc_lexer::TokenKind::Dollar => token::Dollar,
             rustc_lexer::TokenKind::Eq => token::Eq,
-            rustc_lexer::TokenKind::Not => token::Not,
+            rustc_lexer::TokenKind::Bang => token::Not,
             rustc_lexer::TokenKind::Lt => token::Lt,
             rustc_lexer::TokenKind::Gt => token::Gt,
             rustc_lexer::TokenKind::Minus => token::BinOp(token::Minus),


### PR DESCRIPTION
All other tokens are named by the punctuation they use, rather than
by semantics operation they stand for. `!` is the only exception to
the rule, let's fix it.