### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/library/alloc/benches/vec.rs
+++ b/library/alloc/benches/vec.rs
@@ -213,7 +213,7 @@ fn bench_extend_1000_1000(b: &mut Bencher) {
     do_bench_extend(b, 1000, 1000)
 }
 
-fn do_bench_push_all(b: &mut Bencher, dst_len: usize, src_len: usize) {
+fn do_bench_extend_from_slice(b: &mut Bencher, dst_len: usize, src_len: usize) {
     let dst: Vec<_> = FromIterator::from_iter(0..dst_len);
     let src: Vec<_> = FromIterator::from_iter(dst_len..dst_len + src_len);
 
@@ -228,38 +228,38 @@ fn do_bench_push_all(b: &mut Bencher, dst_len: usize, src_len: usize) {
 }
 
 #[bench]
-fn bench_push_all_0000_0000(b: &mut Bencher) {
-    do_bench_push_all(b, 0, 0)
+fn bench_extend_from_slice_0000_0000(b: &mut Bencher) {
+    do_bench_extend_from_slice(b, 0, 0)
 }
 
 #[bench]
-fn bench_push_all_0000_0010(b: &mut Bencher) {
-    do_bench_push_all(b, 0, 10)
+fn bench_extend_from_slice_0000_0010(b: &mut Bencher) {
+    do_bench_extend_from_slice(b, 0, 10)
 }
 
 #[bench]
-fn bench_push_all_0000_0100(b: &mut Bencher) {
-    do_bench_push_all(b, 0, 100)
+fn bench_extend_from_slice_0000_0100(b: &mut Bencher) {
+    do_bench_extend_from_slice(b, 0, 100)
 }
 
 #[bench]
-fn bench_push_all_0000_1000(b: &mut Bencher) {
-    do_bench_push_all(b, 0, 1000)
+fn bench_extend_from_slice_0000_1000(b: &mut Bencher) {
+    do_bench_extend_from_slice(b, 0, 1000)
 }
 
 #[bench]
-fn bench_push_all_0010_0010(b: &mut Bencher) {
-    do_bench_push_all(b, 10, 10)
+fn bench_extend_from_slice_0010_0010(b: &mut Bencher) {
+    do_bench_extend_from_slice(b, 10, 10)
 }
 
 #[bench]
-fn bench_push_all_0100_0100(b: &mut Bencher) {
-    do_bench_push_all(b, 100, 100)
+fn bench_extend_from_slice_0100_0100(b: &mut Bencher) {
+    do_bench_extend_from_slice(b, 100, 100)
 }
 
 #[bench]
-fn bench_push_all_1000_1000(b: &mut Bencher) {
-    do_bench_push_all(b, 1000, 1000)
+fn bench_extend_from_slice_1000_1000(b: &mut Bencher) {
+    do_bench_extend_from_slice(b, 1000, 1000)
 }
 
 fn do_bench_clone(b: &mut Bencher, src_len: usize) {

--- a/library/alloc/benches/vec.rs
+++ b/library/alloc/benches/vec.rs
@@ -262,55 +262,6 @@ fn bench_push_all_1000_1000(b: &mut Bencher) {
     do_bench_push_all(b, 1000, 1000)
 }
 
-fn do_bench_push_all_move(b: &mut Bencher, dst_len: usize, src_len: usize) {
-    let dst: Vec<_> = FromIterator::from_iter(0..dst_len);
-    let src: Vec<_> = FromIterator::from_iter(dst_len..dst_len + src_len);
-
-    b.bytes = src_len as u64;
-
-    b.iter(|| {
-        let mut dst = dst.clone();
-        dst.extend(src.clone());
-        assert_eq!(dst.len(), dst_len + src_len);
-        assert!(dst.iter().enumerate().all(|(i, x)| i == *x));
-    });
-}
-
-#[bench]
-fn bench_push_all_move_0000_0000(b: &mut Bencher) {
-    do_bench_push_all_move(b, 0, 0)
-}
-
-#[bench]
-fn bench_push_all_move_0000_0010(b: &mut Bencher) {
-    do_bench_push_all_move(b, 0, 10)
-}
-
-#[bench]
-fn bench_push_all_move_0000_0100(b: &mut Bencher) {
-    do_bench_push_all_move(b, 0, 100)
-}
-
-#[bench]
-fn bench_push_all_move_0000_1000(b: &mut Bencher) {
-    do_bench_push_all_move(b, 0, 1000)
-}
-
-#[bench]
-fn bench_push_all_move_0010_0010(b: &mut Bencher) {
-    do_bench_push_all_move(b, 10, 10)
-}
-
-#[bench]
-fn bench_push_all_move_0100_0100(b: &mut Bencher) {
-    do_bench_push_all_move(b, 100, 100)
-}
-
-#[bench]
-fn bench_push_all_move_1000_1000(b: &mut Bencher) {
-    do_bench_push_all_move(b, 1000, 1000)
-}
-
 fn do_bench_clone(b: &mut Bencher, src_len: usize) {
     let src: Vec<usize> = FromIterator::from_iter(0..src_len);
 

--- a/library/alloc/src/task.rs
+++ b/library/alloc/src/task.rs
@@ -13,11 +13,9 @@ use crate::sync::Arc;
 ///
 /// This trait is a memory-safe and ergonomic alternative to constructing a
 /// [`RawWaker`]. It supports the common executor design in which the data used
-/// to wake up a task is stored in an [`Arc`][arc]. Some executors (especially
+/// to wake up a task is stored in an [`Arc`]. Some executors (especially
 /// those for embedded systems) cannot use this API, which is why [`RawWaker`]
 /// exists as an alternative for those systems.
-///
-/// [arc]: ../../std/sync/struct.Arc.html
 #[unstable(feature = "wake_trait", issue = "69912")]
 pub trait Wake {
     /// Wake this task.

--- a/library/alloc/src/vec.rs
+++ b/library/alloc/src/vec.rs
@@ -368,7 +368,7 @@ impl<T> Vec<T> {
     /// into a `Vec` with the [`from_raw_parts`] function, allowing
     /// the destructor to perform the cleanup.
     ///
-    /// [`from_raw_parts`]: #method.from_raw_parts
+    /// [`from_raw_parts`]: Vec::from_raw_parts
     ///
     /// # Examples
     ///
@@ -722,8 +722,8 @@ impl<T> Vec<T> {
     /// assert_eq!(vec, []);
     /// ```
     ///
-    /// [`clear`]: #method.clear
-    /// [`drain`]: #method.drain
+    /// [`clear`]: Vec::clear
+    /// [`drain`]: Vec::drain
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn truncate(&mut self, len: usize) {
         // This is safe because:
@@ -802,7 +802,7 @@ impl<T> Vec<T> {
     /// }
     /// ```
     ///
-    /// [`as_mut_ptr`]: #method.as_mut_ptr
+    /// [`as_mut_ptr`]: Vec::as_mut_ptr
     #[stable(feature = "vec_as_ptr", since = "1.37.0")]
     #[inline]
     pub fn as_ptr(&self) -> *const T {
@@ -858,17 +858,17 @@ impl<T> Vec<T> {
     /// is done using one of the safe operations instead, such as
     /// [`truncate`], [`resize`], [`extend`], or [`clear`].
     ///
-    /// [`truncate`]: #method.truncate
-    /// [`resize`]: #method.resize
+    /// [`truncate`]: Vec::truncate
+    /// [`resize`]: Vec::resize
     /// [`extend`]: Extend::extend
-    /// [`clear`]: #method.clear
+    /// [`clear`]: Vec::clear
     ///
     /// # Safety
     ///
     /// - `new_len` must be less than or equal to [`capacity()`].
     /// - The elements at `old_len..new_len` must be initialized.
     ///
-    /// [`capacity()`]: #method.capacity
+    /// [`capacity()`]: Vec::capacity
     ///
     /// # Examples
     ///
@@ -1470,7 +1470,7 @@ impl<T> Vec<T> {
     /// assert_eq!(vec, [2, 4, 8, 16]);
     /// ```
     ///
-    /// [`resize`]: #method.resize
+    /// [`resize`]: Vec::resize
     #[stable(feature = "vec_resize_with", since = "1.33.0")]
     pub fn resize_with<F>(&mut self, new_len: usize, f: F)
     where
@@ -1521,7 +1521,7 @@ impl<T> Vec<T> {
     /// reading from a file) before marking the data as initialized using the
     /// [`set_len`] method.
     ///
-    /// [`set_len`]: #method.set_len
+    /// [`set_len`]: Vec::set_len
     ///
     /// # Examples
     ///
@@ -1580,7 +1580,7 @@ impl<T: Clone> Vec<T> {
     /// assert_eq!(vec, [1, 2]);
     /// ```
     ///
-    /// [`resize_with`]: #method.resize_with
+    /// [`resize_with`]: Vec::resize_with
     #[stable(feature = "vec_resize", since = "1.5.0")]
     pub fn resize(&mut self, new_len: usize, value: T) {
         let len = self.len();
@@ -1642,8 +1642,7 @@ impl<T: Default> Vec<T> {
     /// assert_eq!(vec, [1, 2]);
     /// ```
     ///
-    /// [`resize`]: #method.resize
-    /// [`Default::default()`]: Default::default
+    /// [`resize`]: Vec::resize
     #[unstable(feature = "vec_resize_default", issue = "41758")]
     #[rustc_deprecated(
         reason = "This is moving towards being removed in favor \

--- a/library/alloc/src/vec.rs
+++ b/library/alloc/src/vec.rs
@@ -50,12 +50,9 @@
 //! v[1] = v[1] + 5;
 //! ```
 //!
-//! [`Vec<T>`]: ../../std/vec/struct.Vec.html
-//! [`new`]: ../../std/vec/struct.Vec.html#method.new
-//! [`push`]: ../../std/vec/struct.Vec.html#method.push
-//! [`Index`]: ../../std/ops/trait.Index.html
-//! [`IndexMut`]: ../../std/ops/trait.IndexMut.html
-//! [`vec!`]: ../../std/macro.vec.html
+//! [`Vec<T>`]: Vec
+//! [`new`]: Vec::new
+//! [`push`]: Vec::push
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
@@ -278,22 +275,18 @@ use crate::raw_vec::RawVec;
 /// `Vec` does not currently guarantee the order in which elements are dropped.
 /// The order has changed in the past and may change again.
 ///
-/// [`vec!`]: ../../std/macro.vec.html
 /// [`get`]: ../../std/vec/struct.Vec.html#method.get
 /// [`get_mut`]: ../../std/vec/struct.Vec.html#method.get_mut
-/// [`Index`]: ../../std/ops/trait.Index.html
-/// [`String`]: ../../std/string/struct.String.html
-/// [`&str`]: ../../std/primitive.str.html
-/// [`Vec::with_capacity`]: ../../std/vec/struct.Vec.html#method.with_capacity
-/// [`Vec::new`]: ../../std/vec/struct.Vec.html#method.new
-/// [`shrink_to_fit`]: ../../std/vec/struct.Vec.html#method.shrink_to_fit
-/// [`capacity`]: ../../std/vec/struct.Vec.html#method.capacity
-/// [`mem::size_of::<T>`]: ../../std/mem/fn.size_of.html
-/// [`len`]: ../../std/vec/struct.Vec.html#method.len
-/// [`push`]: ../../std/vec/struct.Vec.html#method.push
-/// [`insert`]: ../../std/vec/struct.Vec.html#method.insert
-/// [`reserve`]: ../../std/vec/struct.Vec.html#method.reserve
-/// [owned slice]: ../../std/boxed/struct.Box.html
+/// [`String`]: crate::string::String
+/// [`&str`]: type@str
+/// [`shrink_to_fit`]: Vec::shrink_to_fit
+/// [`capacity`]: Vec::capacity
+/// [`mem::size_of::<T>`]: core::mem::size_of
+/// [`len`]: Vec::len
+/// [`push`]: Vec::push
+/// [`insert`]: Vec::insert
+/// [`reserve`]: Vec::reserve
+/// [owned slice]: Box
 #[stable(feature = "rust1", since = "1.0.0")]
 #[cfg_attr(not(test), rustc_diagnostic_item = "vec_type")]
 pub struct Vec<T> {
@@ -430,8 +423,8 @@ impl<T> Vec<T> {
     /// that nothing else uses the pointer after calling this
     /// function.
     ///
-    /// [`String`]: ../../std/string/struct.String.html
-    /// [`dealloc`]: ../../alloc/alloc/trait.GlobalAlloc.html#tymethod.dealloc
+    /// [`String`]: crate::string::String
+    /// [`dealloc`]: crate::alloc::GlobalAlloc::dealloc
     ///
     /// # Examples
     ///
@@ -658,7 +651,7 @@ impl<T> Vec<T> {
     ///
     /// Note that this will drop any excess capacity.
     ///
-    /// [owned slice]: ../../std/boxed/struct.Box.html
+    /// [owned slice]: Box
     ///
     /// # Examples
     ///
@@ -867,7 +860,7 @@ impl<T> Vec<T> {
     ///
     /// [`truncate`]: #method.truncate
     /// [`resize`]: #method.resize
-    /// [`extend`]: ../../std/iter/trait.Extend.html#tymethod.extend
+    /// [`extend`]: Extend::extend
     /// [`clear`]: #method.clear
     ///
     /// # Safety
@@ -1214,8 +1207,6 @@ impl<T> Vec<T> {
     /// Removes the last element from a vector and returns it, or [`None`] if it
     /// is empty.
     ///
-    /// [`None`]: ../../std/option/enum.Option.html#variant.None
-    ///
     /// # Examples
     ///
     /// ```
@@ -1480,7 +1471,6 @@ impl<T> Vec<T> {
     /// ```
     ///
     /// [`resize`]: #method.resize
-    /// [`Clone`]: ../../std/clone/trait.Clone.html
     #[stable(feature = "vec_resize_with", since = "1.33.0")]
     pub fn resize_with<F>(&mut self, new_len: usize, f: F)
     where
@@ -1590,8 +1580,6 @@ impl<T: Clone> Vec<T> {
     /// assert_eq!(vec, [1, 2]);
     /// ```
     ///
-    /// [`Clone`]: ../../std/clone/trait.Clone.html
-    /// [`Default`]: ../../std/default/trait.Default.html
     /// [`resize_with`]: #method.resize_with
     #[stable(feature = "vec_resize", since = "1.5.0")]
     pub fn resize(&mut self, new_len: usize, value: T) {
@@ -1655,9 +1643,7 @@ impl<T: Default> Vec<T> {
     /// ```
     ///
     /// [`resize`]: #method.resize
-    /// [`Default::default()`]: ../../std/default/trait.Default.html#tymethod.default
-    /// [`Default`]: ../../std/default/trait.Default.html
-    /// [`Clone`]: ../../std/clone/trait.Clone.html
+    /// [`Default::default()`]: Default::default
     #[unstable(feature = "vec_resize_default", issue = "41758")]
     #[rustc_deprecated(
         reason = "This is moving towards being removed in favor \
@@ -2337,7 +2323,6 @@ impl<T> Vec<T> {
     ///
     /// Note that `drain_filter` also lets you mutate every element in the filter closure,
     /// regardless of whether you choose to keep or remove it.
-    ///
     ///
     /// # Examples
     ///

--- a/library/std/src/sys/unix/thread.rs
+++ b/library/std/src/sys/unix/thread.rs
@@ -213,7 +213,7 @@ impl Drop for Thread {
 }
 
 #[cfg(all(
-    not(all(target_os = "linux", not(target_env = "musl"))),
+    not(target_os = "linux"),
     not(target_os = "freebsd"),
     not(target_os = "macos"),
     not(all(target_os = "netbsd", not(target_vendor = "rumprun"))),
@@ -233,7 +233,7 @@ pub mod guard {
 }
 
 #[cfg(any(
-    all(target_os = "linux", not(target_env = "musl")),
+    target_os = "linux",
     target_os = "freebsd",
     target_os = "macos",
     all(target_os = "netbsd", not(target_vendor = "rumprun")),
@@ -333,9 +333,7 @@ pub mod guard {
         let page_size = os::page_size();
         PAGE_SIZE.store(page_size, Ordering::Relaxed);
 
-        let stackaddr = get_stack_start_aligned()?;
-
-        if cfg!(target_os = "linux") {
+        if cfg!(all(target_os = "linux", not(target_env = "musl"))) {
             // Linux doesn't allocate the whole stack right away, and
             // the kernel has its own stack-guard mechanism to fault
             // when growing too close to an existing mapping.  If we map
@@ -346,8 +344,15 @@ pub mod guard {
             // Instead, we'll just note where we expect rlimit to start
             // faulting, so our handler can report "stack overflow", and
             // trust that the kernel's own stack guard will work.
+            let stackaddr = get_stack_start_aligned()?;
             let stackaddr = stackaddr as usize;
             Some(stackaddr - page_size..stackaddr)
+        } else if cfg!(all(target_os = "linux", target_env = "musl")) {
+            // For the main thread, the musl's pthread_attr_getstack
+            // returns the current stack size, rather than maximum size
+            // it can eventually grow to. It cannot be used to determine
+            // the position of kernel's stack guard.
+            None
         } else {
             // Reallocate the last page of the stack.
             // This ensures SIGBUS will be raised on
@@ -357,6 +362,7 @@ pub mod guard {
             // than the initial mmap() used, so we mmap() here with
             // read/write permissions and only then mprotect() it to
             // no permissions at all. See issue #50313.
+            let stackaddr = get_stack_start_aligned()?;
             let result = mmap(
                 stackaddr,
                 page_size,
@@ -406,7 +412,14 @@ pub mod guard {
             let mut guardsize = 0;
             assert_eq!(libc::pthread_attr_getguardsize(&attr, &mut guardsize), 0);
             if guardsize == 0 {
-                panic!("there is no guard page");
+                if cfg!(all(target_os = "linux", target_env = "musl")) {
+                    // musl versions before 1.1.19 always reported guard
+                    // size obtained from pthread_attr_get_np as zero.
+                    // Use page size as a fallback.
+                    guardsize = PAGE_SIZE.load(Ordering::Relaxed);
+                } else {
+                    panic!("there is no guard page");
+                }
             }
             let mut stackaddr = crate::ptr::null_mut();
             let mut size = 0;
@@ -418,6 +431,8 @@ pub mod guard {
                 let guardaddr = stackaddr - guardsize;
                 Some(guardaddr - PAGE_SIZE.load(Ordering::Relaxed)..guardaddr)
             } else if cfg!(target_os = "netbsd") {
+                Some(stackaddr - guardsize..stackaddr)
+            } else if cfg!(all(target_os = "linux", target_env = "musl")) {
                 Some(stackaddr - guardsize..stackaddr)
             } else if cfg!(all(target_os = "linux", target_env = "gnu")) {
                 // glibc used to include the guard area within the stack, as noted in the BUGS

--- a/src/ci/docker/scripts/emscripten.sh
+++ b/src/ci/docker/scripts/emscripten.sh
@@ -19,5 +19,5 @@ exit 1
 
 git clone https://github.com/emscripten-core/emsdk.git /emsdk-portable
 cd /emsdk-portable
-hide_output ./emsdk install 1.38.47-upstream
-./emsdk activate 1.38.47-upstream
+hide_output ./emsdk install 1.39.20
+./emsdk activate 1.39.20

--- a/src/librustc_error_codes/error_codes/E0759.md
+++ b/src/librustc_error_codes/error_codes/E0759.md
@@ -5,14 +5,11 @@ Erroneous code examples:
 ```compile_fail,E0759
 use std::fmt::Debug;
 
-fn foo(x: &i32) -> impl Debug {
+fn foo(x: &i32) -> impl Debug { // error!
     x
 }
-```
 
-```compile_fail,E0759
-# use std::fmt::Debug;
-fn bar(x: &i32) -> Box<dyn Debug> {
+fn bar(x: &i32) -> Box<dyn Debug> { // error!
     Box::new(x)
 }
 ```
@@ -21,14 +18,11 @@ These examples have the same semantics as the following:
 
 ```compile_fail,E0759
 # use std::fmt::Debug;
-fn foo(x: &i32) -> impl Debug + 'static {
+fn foo(x: &i32) -> impl Debug + 'static { // ok!
     x
 }
-```
 
-```compile_fail,E0759
-# use std::fmt::Debug;
-fn bar(x: &i32) -> Box<dyn Debug + 'static> {
+fn bar(x: &i32) -> Box<dyn Debug + 'static> { // ok!
     Box::new(x)
 }
 ```

--- a/src/librustc_error_codes/error_codes/E0759.md
+++ b/src/librustc_error_codes/error_codes/E0759.md
@@ -1,4 +1,4 @@
-A `'static` requirement in a return type involving a trait is not fulfilled.
+Return type involving a trait did not require `'static` lifetime.
 
 Erroneous code examples:
 
@@ -14,7 +14,7 @@ fn bar(x: &i32) -> Box<dyn Debug> { // error!
 }
 ```
 
-These examples have the same semantics as the following:
+Add `'static` requirement to fix them:
 
 ```compile_fail,E0759
 # use std::fmt::Debug;

--- a/src/librustc_lexer/src/lib.rs
+++ b/src/librustc_lexer/src/lib.rs
@@ -103,7 +103,7 @@ pub enum TokenKind {
     /// "="
     Eq,
     /// "!"
-    Not,
+    Bang,
     /// "<"
     Lt,
     /// ">"
@@ -378,7 +378,7 @@ impl Cursor<'_> {
             ':' => Colon,
             '$' => Dollar,
             '=' => Eq,
-            '!' => Not,
+            '!' => Bang,
             '<' => Lt,
             '>' => Gt,
             '-' => Minus,

--- a/src/librustc_middle/mir/interpret/mod.rs
+++ b/src/librustc_middle/mir/interpret/mod.rs
@@ -143,6 +143,17 @@ pub struct GlobalId<'tcx> {
     pub promoted: Option<mir::Promoted>,
 }
 
+impl GlobalId<'tcx> {
+    pub fn display(self, tcx: TyCtxt<'tcx>) -> String {
+        let instance_name = tcx.def_path_str(self.instance.def.def_id());
+        if let Some(promoted) = self.promoted {
+            format!("{}::{:?}", instance_name, promoted)
+        } else {
+            instance_name
+        }
+    }
+}
+
 /// Input argument for `tcx.lit_to_const`.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, HashStable)]
 pub struct LitToConstInput<'tcx> {

--- a/src/librustc_middle/query/mod.rs
+++ b/src/librustc_middle/query/mod.rs
@@ -679,7 +679,7 @@ rustc_queries! {
             -> ConstEvalRawResult<'tcx> {
             desc { |tcx|
                 "const-evaluating `{}`",
-                tcx.def_path_str(key.value.instance.def.def_id())
+                key.value.display(tcx)
             }
         }
 
@@ -695,7 +695,7 @@ rustc_queries! {
             -> ConstEvalResult<'tcx> {
             desc { |tcx|
                 "const-evaluating + checking `{}`",
-                tcx.def_path_str(key.value.instance.def.def_id())
+                key.value.display(tcx)
             }
             cache_on_disk_if(_, opt_result) {
                 // Only store results without errors

--- a/src/librustc_mir/util/pretty.rs
+++ b/src/librustc_mir/util/pretty.rs
@@ -406,7 +406,7 @@ impl Visitor<'tcx> for ExtraComments<'tcx> {
         self.super_const(constant);
         let ty::Const { ty, val, .. } = constant;
         match ty.kind {
-            ty::Int(_) | ty::Uint(_) | ty::Bool | ty::Char => {}
+            ty::Int(_) | ty::Uint(_) | ty::Bool | ty::Char | ty::Float(_) => {}
             // Unit type
             ty::Tuple(tys) if tys.is_empty() => {}
             ty::FnDef(..) => {}

--- a/src/librustc_parse/lexer/mod.rs
+++ b/src/librustc_parse/lexer/mod.rs
@@ -290,7 +290,7 @@ impl<'a> StringReader<'a> {
             rustc_lexer::TokenKind::Colon => token::Colon,
             rustc_lexer::TokenKind::Dollar => token::Dollar,
             rustc_lexer::TokenKind::Eq => token::Eq,
-            rustc_lexer::TokenKind::Not => token::Not,
+            rustc_lexer::TokenKind::Bang => token::Not,
             rustc_lexer::TokenKind::Lt => token::Lt,
             rustc_lexer::TokenKind::Gt => token::Gt,
             rustc_lexer::TokenKind::Minus => token::BinOp(token::Minus),

--- a/src/test/mir-opt/deaggregator_test.bar.Deaggregator.diff
+++ b/src/test/mir-opt/deaggregator_test.bar.Deaggregator.diff
@@ -12,9 +12,6 @@
 -         _0 = Baz { x: move _2, y: const 0f32, z: const false }; // scope 0 at $DIR/deaggregator_test.rs:9:5: 9:35
 +         (_0.0: usize) = move _2;         // scope 0 at $DIR/deaggregator_test.rs:9:5: 9:35
 +         (_0.1: f32) = const 0f32;        // scope 0 at $DIR/deaggregator_test.rs:9:5: 9:35
-                                           // ty::Const
-                                           // + ty: f32
-                                           // + val: Value(Scalar(0x00000000))
                                            // mir::Constant
                                            // + span: $DIR/deaggregator_test.rs:9:20: 9:23
                                            // + literal: Const { ty: f32, val: Value(Scalar(0x00000000)) }

--- a/src/test/ui/abi/stack-probes.rs
+++ b/src/test/ui/abi/stack-probes.rs
@@ -11,7 +11,6 @@
 // ignore-cloudabi no processes
 // ignore-emscripten no processes
 // ignore-sgx no processes
-// ignore-musl FIXME #31506
 
 use std::mem::MaybeUninit;
 use std::process::Command;

--- a/src/test/ui/associated-const/defaults-cyclic-fail.stderr
+++ b/src/test/ui/associated-const/defaults-cyclic-fail.stderr
@@ -32,7 +32,7 @@ note: ...which requires const-evaluating `Tr::B`...
 LL |     const B: u8 = Self::A;
    |     ^^^^^^^^^^^^^^^^^^^^^^
    = note: ...which again requires normalizing `<() as Tr>::A`, completing the cycle
-note: cycle used when const-evaluating `main`
+note: cycle used when const-evaluating `main::promoted[2]`
   --> $DIR/defaults-cyclic-fail.rs:14:1
    |
 LL | fn main() {

--- a/src/test/ui/consts/const-eval/const-eval-query-stack.rs
+++ b/src/test/ui/consts/const-eval/const-eval-query-stack.rs
@@ -1,6 +1,7 @@
 // compile-flags: -Ztreat-err-as-bug
 // build-fail
 // failure-status: 101
+// rustc-env:RUST_BACKTRACE=1
 // normalize-stderr-test "\nerror: internal compiler error.*\n\n" -> ""
 // normalize-stderr-test "note:.*unexpectedly panicked.*\n\n" -> ""
 // normalize-stderr-test "note: we would appreciate a bug report.*\n\n" -> ""

--- a/src/test/ui/consts/const-eval/const-eval-query-stack.rs
+++ b/src/test/ui/consts/const-eval/const-eval-query-stack.rs
@@ -1,0 +1,20 @@
+// compile-flags: -Ztreat-err-as-bug
+// build-fail
+// failure-status: 101
+// normalize-stderr-test "\nerror: internal compiler error.*\n\n" -> ""
+// normalize-stderr-test "note:.*unexpectedly panicked.*\n\n" -> ""
+// normalize-stderr-test "note: we would appreciate a bug report.*\n\n" -> ""
+// normalize-stderr-test "note: compiler flags.*\n\n" -> ""
+// normalize-stderr-test "note: rustc.*running on.*\n\n" -> ""
+// normalize-stderr-test "thread.*panicked.*\n" -> ""
+// normalize-stderr-test "stack backtrace:\n" -> ""
+// normalize-stderr-test "  \d{1,}: .*\n" -> ""
+// normalize-stderr-test ".*note: Some details.*\n" -> ""
+
+#![allow(unconditional_panic)]
+
+fn main() {
+    let x: &'static i32 = &(1 / 0);
+    //~^ ERROR reaching this expression at runtime will panic or abort [const_err]
+    println!("x={}", x);
+}

--- a/src/test/ui/consts/const-eval/const-eval-query-stack.stderr
+++ b/src/test/ui/consts/const-eval/const-eval-query-stack.stderr
@@ -1,0 +1,18 @@
+error: reaching this expression at runtime will panic or abort
+  --> $DIR/const-eval-query-stack.rs:17:28
+   |
+LL |     let x: &'static i32 = &(1 / 0);
+   |                           -^^^^^^^
+   |                            |
+   |                            dividing by zero
+   |
+   = note: `#[deny(const_err)]` on by default
+
+query stack during panic:
+#0 [const_eval_raw] const-evaluating `main::promoted[1]`
+#1 [const_eval_validated] const-evaluating + checking `main::promoted[1]`
+#2 [const_eval_validated] const-evaluating + checking `main::promoted[1]`
+#3 [normalize_generic_arg_after_erasing_regions] normalizing `main::promoted[1]`
+#4 [optimized_mir] optimizing MIR for `main`
+#5 [collect_and_partition_mono_items] collect_and_partition_mono_items
+end of query stack

--- a/src/test/ui/consts/const-eval/const-eval-query-stack.stderr
+++ b/src/test/ui/consts/const-eval/const-eval-query-stack.stderr
@@ -1,5 +1,5 @@
 error: reaching this expression at runtime will panic or abort
-  --> $DIR/const-eval-query-stack.rs:17:28
+  --> $DIR/const-eval-query-stack.rs:18:28
    |
 LL |     let x: &'static i32 = &(1 / 0);
    |                           -^^^^^^^

--- a/src/test/ui/out-of-stack.rs
+++ b/src/test/ui/out-of-stack.rs
@@ -3,7 +3,6 @@
 #![allow(unused_must_use)]
 #![allow(unconditional_recursion)]
 // ignore-android: FIXME (#20004)
-// ignore-musl
 // ignore-cloudabi no processes
 // ignore-emscripten no processes
 // ignore-sgx no processes


### PR DESCRIPTION
Successful merges:

 - #75672 (Move to intra-doc links for task.rs and vec.rs)
 - #75702 (Clean up E0759 explanation)
 - #75703 (Enable stack-overflow detection on musl for non-main threads)
 - #75710 (Fix bad printing of const-eval queries)
 - #75716 (Upgrade Emscripten on CI to 1.39.20 )
 - #75731 (Suppress ty::Float in MIR comments of ty::Const)
 - #75733 (Remove duplicated alloc vec bench push_all_move)
 - #75743 (Rename rustc_lexer::TokenKind::Not to Bang)

Failed merges:


r? @ghost