### PR TITLE
Move to intra doc links for std::thread documentation

### DIFF
--- a/library/std/src/thread/local.rs
+++ b/library/std/src/thread/local.rs
@@ -71,9 +71,7 @@ use crate::fmt;
 ///    not guard typically have a synthetic limit after which point no more
 ///    destructors are run.
 ///
-/// [`with`]: ../../std/thread/struct.LocalKey.html#method.with
-/// [`thread_local!`]: ../../std/macro.thread_local.html
-/// [`Drop`]: ../../std/ops/trait.Drop.html
+/// [`with`]: LocalKey::with
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct LocalKey<T: 'static> {
     // This outer `LocalKey<T>` type is what's going to be stored in statics,
@@ -118,10 +116,10 @@ impl<T: 'static> fmt::Debug for LocalKey<T> {
 /// # fn main() {}
 /// ```
 ///
-/// See [LocalKey documentation][`std::thread::LocalKey`] for more
+/// See [`LocalKey` documentation][`std::thread::LocalKey`] for more
 /// information.
 ///
-/// [`std::thread::LocalKey`]: ../std/thread/struct.LocalKey.html
+/// [`std::thread::LocalKey`]: crate::thread::LocalKey
 #[macro_export]
 #[stable(feature = "rust1", since = "1.0.0")]
 #[allow_internal_unstable(thread_local_internals)]

--- a/library/std/src/thread/mod.rs
+++ b/library/std/src/thread/mod.rs
@@ -129,30 +129,19 @@
 //!
 //! Note that the stack size of the main thread is *not* determined by Rust.
 //!
-//! [channels]: ../../std/sync/mpsc/index.html
-//! [`Arc`]: ../../std/sync/struct.Arc.html
-//! [`spawn`]: ../../std/thread/fn.spawn.html
-//! [`JoinHandle`]: ../../std/thread/struct.JoinHandle.html
-//! [`JoinHandle::thread`]: ../../std/thread/struct.JoinHandle.html#method.thread
-//! [`join`]: ../../std/thread/struct.JoinHandle.html#method.join
-//! [`Result`]: ../../std/result/enum.Result.html
-//! [`Ok`]: ../../std/result/enum.Result.html#variant.Ok
-//! [`Err`]: ../../std/result/enum.Result.html#variant.Err
-//! [`panic!`]: ../../std/macro.panic.html
-//! [`Builder`]: ../../std/thread/struct.Builder.html
-//! [`Builder::stack_size`]: ../../std/thread/struct.Builder.html#method.stack_size
-//! [`Builder::name`]: ../../std/thread/struct.Builder.html#method.name
-//! [`thread::current`]: ../../std/thread/fn.current.html
-//! [`thread::Result`]: ../../std/thread/type.Result.html
-//! [`Thread`]: ../../std/thread/struct.Thread.html
-//! [`park`]: ../../std/thread/fn.park.html
-//! [`unpark`]: ../../std/thread/struct.Thread.html#method.unpark
-//! [`Thread::name`]: ../../std/thread/struct.Thread.html#method.name
-//! [`thread::park_timeout`]: ../../std/thread/fn.park_timeout.html
-//! [`Cell`]: ../cell/struct.Cell.html
-//! [`RefCell`]: ../cell/struct.RefCell.html
-//! [`thread_local!`]: ../macro.thread_local.html
-//! [`with`]: struct.LocalKey.html#method.with
+//! [channels]: crate::sync::mpsc
+//! [`join`]: JoinHandle::join
+//! [`Result`]: crate::result::Result
+//! [`Ok`]: crate::result::Result::Ok
+//! [`Err`]: crate::result::Result::Err
+//! [`thread::current`]: current
+//! [`thread::Result`]: Result
+//! [`unpark`]: Thread::unpark
+//! [`Thread::name`]: Thread::name
+//! [`thread::park_timeout`]: park_timeout
+//! [`Cell`]: crate::cell::Cell
+//! [`RefCell`]: crate::cell::RefCell
+//! [`with`]: LocalKey::with
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
@@ -245,12 +234,12 @@ pub use self::local::statik::Key as __StaticLocalKeyInner;
 /// handler.join().unwrap();
 /// ```
 ///
-/// [`thread::spawn`]: ../../std/thread/fn.spawn.html
-/// [`stack_size`]: ../../std/thread/struct.Builder.html#method.stack_size
-/// [`name`]: ../../std/thread/struct.Builder.html#method.name
-/// [`spawn`]: ../../std/thread/struct.Builder.html#method.spawn
-/// [`io::Result`]: ../../std/io/type.Result.html
-/// [`unwrap`]: ../../std/result/enum.Result.html#method.unwrap
+/// [`stack_size`]: Builder::stack_size
+/// [`name`]: Builder::name
+/// [`spawn`]: Builder::spawn
+/// [`thread::spawn`]: spawn
+/// [`io::Result`]: crate::io::Result
+/// [`unwrap`]: crate::result::Result::unwrap
 /// [naming-threads]: ./index.html#naming-threads
 /// [stack-size]: ./index.html#stack-size
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -355,9 +344,7 @@ impl Builder {
     /// [`io::Result`] to capture any failure to create the thread at
     /// the OS level.
     ///
-    /// [`spawn`]: ../../std/thread/fn.spawn.html
-    /// [`io::Result`]: ../../std/io/type.Result.html
-    /// [`JoinHandle`]: ../../std/thread/struct.JoinHandle.html
+    /// [`io::Result`]: crate::io::Result
     ///
     /// # Panics
     ///
@@ -443,11 +430,7 @@ impl Builder {
     /// handler.join().unwrap();
     /// ```
     ///
-    /// [`spawn`]: ../../std/thread/fn.spawn.html
-    /// [`Builder::spawn`]: ../../std/thread/struct.Builder.html#method.spawn
-    /// [`io::Result`]: ../../std/io/type.Result.html
-    /// [`JoinHandle`]: ../../std/thread/struct.JoinHandle.html
-    /// [`JoinHandle::join`]: ../../std/thread/struct.JoinHandle.html#method.join
+    /// [`io::Result`]: crate::io::Result
     #[unstable(feature = "thread_spawn_unchecked", issue = "55132")]
     pub unsafe fn spawn_unchecked<'a, F, T>(self, f: F) -> io::Result<JoinHandle<T>>
     where
@@ -513,7 +496,7 @@ impl Builder {
 /// the main thread finishes). Additionally, the join handle provides a [`join`]
 /// method that can be used to join the child thread. If the child thread
 /// panics, [`join`] will return an [`Err`] containing the argument given to
-/// [`panic`].
+/// [`panic!`].
 ///
 /// This will create a thread using default parameters of [`Builder`], if you
 /// want to specify the stack size or the name of the thread, use this API
@@ -600,15 +583,9 @@ impl Builder {
 /// println!("{}", result);
 /// ```
 ///
-/// [`channels`]: ../../std/sync/mpsc/index.html
-/// [`JoinHandle`]: ../../std/thread/struct.JoinHandle.html
-/// [`join`]: ../../std/thread/struct.JoinHandle.html#method.join
-/// [`Err`]: ../../std/result/enum.Result.html#variant.Err
-/// [`panic`]: ../../std/macro.panic.html
-/// [`Builder::spawn`]: ../../std/thread/struct.Builder.html#method.spawn
-/// [`Builder`]: ../../std/thread/struct.Builder.html
-/// [`Send`]: ../../std/marker/trait.Send.html
-/// [`Sync`]: ../../std/marker/trait.Sync.html
+/// [`channels`]: crate::sync::mpsc
+/// [`join`]: JoinHandle::join
+/// [`Err`]: crate::result::Result::Err
 #[stable(feature = "rust1", since = "1.0.0")]
 pub fn spawn<F, T>(f: F) -> JoinHandle<T>
 where
@@ -673,11 +650,8 @@ pub fn current() -> Thread {
 /// thread::yield_now();
 /// ```
 ///
-/// [`channel`]: ../../std/sync/mpsc/index.html
-/// [`spawn`]: ../../std/thread/fn.spawn.html
-/// [`join`]: ../../std/thread/struct.JoinHandle.html#method.join
-/// [`Mutex`]: ../../std/sync/struct.Mutex.html
-/// [`Condvar`]: ../../std/sync/struct.Condvar.html
+/// [`channel`]: crate::sync::mpsc
+/// [`join`]: JoinHandle::join
 #[stable(feature = "rust1", since = "1.0.0")]
 pub fn yield_now() {
     imp::Thread::yield_now()
@@ -723,8 +697,6 @@ pub fn yield_now() {
 ///     panic!()
 /// }
 /// ```
-///
-/// [Mutex]: ../../std/sync/struct.Mutex.html
 #[inline]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub fn panicking() -> bool {
@@ -881,10 +853,8 @@ const NOTIFIED: usize = 2;
 /// parked_thread.join().unwrap();
 /// ```
 ///
-/// [`Thread`]: ../../std/thread/struct.Thread.html
-/// [`park`]: ../../std/thread/fn.park.html
-/// [`unpark`]: ../../std/thread/struct.Thread.html#method.unpark
-/// [`thread::park_timeout`]: ../../std/thread/fn.park_timeout.html
+/// [`unpark`]: Thread::unpark
+/// [`thread::park_timeout`]: park_timeout
 //
 // The implementation currently uses the trivial strategy of a Mutex+Condvar
 // with wakeup flag, which does not actually allow spurious wakeups. In the
@@ -939,9 +909,6 @@ pub fn park() {
 /// amount of time waited to be precisely `ms` long.
 ///
 /// See the [park documentation][`park`] for more detail.
-///
-/// [`park_timeout`]: fn.park_timeout.html
-/// [`park`]: ../../std/thread/fn.park.html
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_deprecated(since = "1.6.0", reason = "replaced by `std::thread::park_timeout`")]
 pub fn park_timeout_ms(ms: u32) {
@@ -986,8 +953,6 @@ pub fn park_timeout_ms(ms: u32) {
 ///     timeout_remaining = timeout - elapsed;
 /// }
 /// ```
-///
-/// [park]: fn.park.html
 #[stable(feature = "park_timeout", since = "1.4.0")]
 pub fn park_timeout(dur: Duration) {
     let thread = current();
@@ -1046,8 +1011,7 @@ pub fn park_timeout(dur: Duration) {
 /// assert!(thread::current().id() != other_thread_id);
 /// ```
 ///
-/// [`id`]: ../../std/thread/struct.Thread.html#method.id
-/// [`Thread`]: ../../std/thread/struct.Thread.html
+/// [`id`]: Thread::id
 #[stable(feature = "thread_id", since = "1.19.0")]
 #[derive(Eq, PartialEq, Clone, Copy, Hash, Debug)]
 pub struct ThreadId(NonZeroU64);
@@ -1124,12 +1088,7 @@ struct Inner {
 /// should instead use a function like `spawn` to create new threads, see the
 /// docs of [`Builder`] and [`spawn`] for more details.
 ///
-/// [`Builder`]: ../../std/thread/struct.Builder.html
-/// [`JoinHandle::thread`]: ../../std/thread/struct.JoinHandle.html#method.thread
-/// [`JoinHandle`]: ../../std/thread/struct.JoinHandle.html
-/// [`thread::current`]: ../../std/thread/fn.current.html
-/// [`spawn`]: ../../std/thread/fn.spawn.html
-
+/// [`thread::current`]: current
 pub struct Thread {
     inner: Arc<Inner>,
 }
@@ -1181,8 +1140,6 @@ impl Thread {
     ///
     /// parked_thread.join().unwrap();
     /// ```
-    ///
-    /// [park]: fn.park.html
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn unpark(&self) {
         // To ensure the unparked thread will observe any writes we made
@@ -1326,7 +1283,7 @@ impl fmt::Debug for Thread {
 /// }
 /// ```
 ///
-/// [`Result`]: ../../std/result/enum.Result.html
+/// [`Result`]: crate::result::Result
 #[stable(feature = "rust1", since = "1.0.0")]
 pub type Result<T> = crate::result::Result<T, Box<dyn Any + Send + 'static>>;
 
@@ -1421,9 +1378,8 @@ impl<T> JoinInner<T> {
 /// thread::sleep(Duration::from_millis(1000));
 /// ```
 ///
-/// [`Clone`]: ../../std/clone/trait.Clone.html
-/// [`thread::spawn`]: fn.spawn.html
-/// [`thread::Builder::spawn`]: struct.Builder.html#method.spawn
+/// [`thread::Builder::spawn`]: Builder::spawn
+/// [`thread::spawn`]: spawn
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct JoinHandle<T>(JoinInner<T>);
 
@@ -1462,11 +1418,10 @@ impl<T> JoinHandle<T> {
     /// operations that happen after `join` returns.
     ///
     /// If the child thread panics, [`Err`] is returned with the parameter given
-    /// to [`panic`].
+    /// to [`panic!`].
     ///
-    /// [`Err`]: ../../std/result/enum.Result.html#variant.Err
-    /// [`panic`]: ../../std/macro.panic.html
-    /// [atomic memory orderings]: ../../std/sync/atomic/index.html
+    /// [`Err`]: crate::result::Result::Err
+    /// [atomic memory orderings]: crate::sync::atomic
     ///
     /// # Panics
     ///


### PR DESCRIPTION
Helps with #75080.

@rustbot modify labels: T-doc, A-intra-doc-links, T-rustdoc

r? @jyn514 