### PR TITLE
build aarch64-musl host compiler in CI

### DIFF
--- a/src/ci/docker/host-x86_64/dist-aarch64-linux/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-aarch64-linux/Dockerfile
@@ -1,5 +1,8 @@
 FROM ubuntu:16.04
 
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  g++-aarch64-linux-gnu
+
 COPY scripts/cross-apt-packages.sh /scripts/
 RUN sh /scripts/cross-apt-packages.sh
 
@@ -24,17 +27,25 @@ USER root
 COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
+COPY scripts/musl.sh /scripts/
+RUN env \
+    CC=aarch64-linux-gnu-gcc \
+    CXX=aarch64-linux-gnu-g++ \
+    bash /scripts/musl.sh aarch64
+
 ENV PATH=$PATH:/x-tools/aarch64-unknown-linux-gnueabi/bin
 
 ENV CC_aarch64_unknown_linux_gnu=aarch64-unknown-linux-gnueabi-gcc \
     AR_aarch64_unknown_linux_gnu=aarch64-unknown-linux-gnueabi-ar \
     CXX_aarch64_unknown_linux_gnu=aarch64-unknown-linux-gnueabi-g++
 
-ENV HOSTS=aarch64-unknown-linux-gnu
+ENV HOSTS=aarch64-unknown-linux-gnu,aarch64-unknown-linux-musl
 
 ENV RUST_CONFIGURE_ARGS \
       --enable-full-tools \
       --enable-profiler \
       --enable-sanitizers \
+      --musl-root-aarch64=/musl-aarch64 \
       --disable-docs
+
 ENV SCRIPT python3 ../x.py dist --host $HOSTS --target $HOSTS

--- a/src/ci/docker/host-x86_64/dist-various-1/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-various-1/Dockerfile
@@ -83,10 +83,6 @@ RUN env \
     CXX=arm-linux-gnueabihf-g++ CXXFLAGS="-march=armv7-a" \
     bash musl.sh armv7hf && \
     env \
-    CC=aarch64-linux-gnu-gcc \
-    CXX=aarch64-linux-gnu-g++ \
-    bash musl.sh aarch64 && \
-    env \
     CC=mips-openwrt-linux-gcc \
     CXX=mips-openwrt-linux-g++ \
     bash musl.sh mips && \
@@ -129,7 +125,6 @@ ENV TARGETS=$TARGETS,arm-unknown-linux-musleabihf
 ENV TARGETS=$TARGETS,armv5te-unknown-linux-gnueabi
 ENV TARGETS=$TARGETS,armv5te-unknown-linux-musleabi
 ENV TARGETS=$TARGETS,armv7-unknown-linux-musleabihf
-ENV TARGETS=$TARGETS,aarch64-unknown-linux-musl
 ENV TARGETS=$TARGETS,aarch64-unknown-none
 ENV TARGETS=$TARGETS,aarch64-unknown-none-softfloat
 ENV TARGETS=$TARGETS,sparc64-unknown-linux-gnu
@@ -184,7 +179,6 @@ ENV RUST_CONFIGURE_ARGS \
       --musl-root-arm=/musl-arm \
       --musl-root-armhf=/musl-armhf \
       --musl-root-armv7hf=/musl-armv7hf \
-      --musl-root-aarch64=/musl-aarch64 \
       --musl-root-mips=/musl-mips \
       --musl-root-mipsel=/musl-mipsel \
       --musl-root-mips64=/musl-mips64 \

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -62,7 +62,7 @@ target | std | host | notes
 `aarch64-linux-android` | ✓ |  | ARM64 Android
 `aarch64-pc-windows-msvc` | ✓ |  | ARM64 Windows MSVC
 `aarch64-unknown-linux-gnu` | ✓ | ✓ | ARM64 Linux (kernel 4.2, glibc 2.17)
-`aarch64-unknown-linux-musl` | ✓ |  | ARM64 Linux with MUSL
+`aarch64-unknown-linux-musl` | ✓ | ✓ | ARM64 Linux with MUSL
 `aarch64-unknown-none` | * |  | Bare ARM64, hardfloat
 `aarch64-unknown-none-softfloat` | * |  | Bare ARM64, softfloat
 `arm-linux-androideabi` | ✓ |  | ARMv7 Android


### PR DESCRIPTION
fixes #75721

I've put this together by cargo culting pieces from different Docker files. It's a bit emberassing, because I frankly have no idea if I did this correctly 😬 The docker image builds, but attempting to run it produces various permission errors that I believe are related to my local docker setup by rootless. In short, I'm very sorry for this mess and please review with a critical eye.