### PR TITLE
libtest: Print the total time taken to execute a test suite

### DIFF
--- a/library/test/src/formatters/pretty.rs
+++ b/library/test/src/formatters/pretty.rs
@@ -259,7 +259,7 @@ impl<T: Write> OutputFormatter for PrettyFormatter<T> {
 
         let s = if state.allowed_fail > 0 {
             format!(
-                ". {} passed; {} failed ({} allowed); {} ignored; {} measured; {} filtered out\n\n",
+                ". {} passed; {} failed ({} allowed); {} ignored; {} measured; {} filtered out",
                 state.passed,
                 state.failed + state.allowed_fail,
                 state.allowed_fail,
@@ -269,12 +269,19 @@ impl<T: Write> OutputFormatter for PrettyFormatter<T> {
             )
         } else {
             format!(
-                ". {} passed; {} failed; {} ignored; {} measured; {} filtered out\n\n",
+                ". {} passed; {} failed; {} ignored; {} measured; {} filtered out",
                 state.passed, state.failed, state.ignored, state.measured, state.filtered_out
             )
         };
 
         self.write_plain(&s)?;
+
+        if let Some(ref exec_time) = state.exec_time {
+            let time_str = format!("; finished in {}", exec_time);
+            self.write_plain(&time_str)?;
+        }
+
+        self.write_plain("\n\n")?;
 
         Ok(success)
     }

--- a/library/test/src/formatters/terse.rs
+++ b/library/test/src/formatters/terse.rs
@@ -236,7 +236,7 @@ impl<T: Write> OutputFormatter for TerseFormatter<T> {
 
         let s = if state.allowed_fail > 0 {
             format!(
-                ". {} passed; {} failed ({} allowed); {} ignored; {} measured; {} filtered out\n\n",
+                ". {} passed; {} failed ({} allowed); {} ignored; {} measured; {} filtered out",
                 state.passed,
                 state.failed + state.allowed_fail,
                 state.allowed_fail,
@@ -246,12 +246,19 @@ impl<T: Write> OutputFormatter for TerseFormatter<T> {
             )
         } else {
             format!(
-                ". {} passed; {} failed; {} ignored; {} measured; {} filtered out\n\n",
+                ". {} passed; {} failed; {} ignored; {} measured; {} filtered out",
                 state.passed, state.failed, state.ignored, state.measured, state.filtered_out
             )
         };
 
         self.write_plain(&s)?;
+
+        if let Some(ref exec_time) = state.exec_time {
+            let time_str = format!("; finished in {}", exec_time);
+            self.write_plain(&time_str)?;
+        }
+
+        self.write_plain("\n\n")?;
 
         Ok(success)
     }

--- a/library/test/src/tests.rs
+++ b/library/test/src/tests.rs
@@ -669,6 +669,7 @@ fn should_sort_failures_before_printing_them() {
         allowed_fail: 0,
         filtered_out: 0,
         measured: 0,
+        exec_time: None,
         metrics: MetricMap::new(),
         failures: vec![(test_b, Vec::new()), (test_a, Vec::new())],
         options: Options::new(),

--- a/library/test/src/time.rs
+++ b/library/test/src/time.rs
@@ -1,8 +1,9 @@
 //! Module `time` contains everything related to the time measurement of unit tests
 //! execution.
-//! Two main purposes of this module:
+//! The purposes of this module:
 //! - Check whether test is timed out.
 //! - Provide helpers for `report-time` and `measure-time` options.
+//! - Provide newtypes for executions times.
 
 use std::env;
 use std::fmt;
@@ -60,13 +61,23 @@ pub fn get_default_test_timeout() -> Instant {
     Instant::now() + Duration::from_secs(TEST_WARN_TIMEOUT_S)
 }
 
-/// The meassured execution time of a unit test.
+/// The measured execution time of a unit test.
 #[derive(Debug, Clone, PartialEq)]
 pub struct TestExecTime(pub Duration);
 
 impl fmt::Display for TestExecTime {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{:.3}s", self.0.as_secs_f64())
+    }
+}
+
+/// The measured execution time of the whole test suite.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct TestSuiteExecTime(pub Duration);
+
+impl fmt::Display for TestSuiteExecTime {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:.2}s", self.0.as_secs_f64())
     }
 }
 

--- a/src/test/run-make-fulldeps/libtest-json/Makefile
+++ b/src/test/run-make-fulldeps/libtest-json/Makefile
@@ -14,5 +14,5 @@ all:
 	cat $(OUTPUT_FILE_STDOUT_SUCCESS) | "$(PYTHON)" validate_json.py
 
 	# Normalize the actual output and compare to expected output file
-	cat $(OUTPUT_FILE_DEFAULT) | sed -r 's/\"exec_time\": [0-9]+(\.[0-9]+)?/\"exec_time\": \$$TIME/' | diff output-default.json -
-	cat $(OUTPUT_FILE_STDOUT_SUCCESS) | sed -r 's/\"exec_time\": [0-9]+(\.[0-9]+)?/\"exec_time\": \$$TIME/' | diff output-stdout-success.json -
+	cat $(OUTPUT_FILE_DEFAULT) | sed 's/"exec_time": [0-9.]*/"exec_time": $$TIME/' | diff output-default.json -
+	cat $(OUTPUT_FILE_STDOUT_SUCCESS) | sed 's/"exec_time": [0-9.]*/"exec_time": $$TIME/' | diff output-stdout-success.json -

--- a/src/test/run-make-fulldeps/libtest-json/Makefile
+++ b/src/test/run-make-fulldeps/libtest-json/Makefile
@@ -13,6 +13,6 @@ all:
 	cat $(OUTPUT_FILE_DEFAULT) | "$(PYTHON)" validate_json.py
 	cat $(OUTPUT_FILE_STDOUT_SUCCESS) | "$(PYTHON)" validate_json.py
 
-	# Compare to output file
-	diff output-default.json $(OUTPUT_FILE_DEFAULT)
-	diff output-stdout-success.json $(OUTPUT_FILE_STDOUT_SUCCESS)
+	# Normalize the actual output and compare to expected output file
+	cat $(OUTPUT_FILE_DEFAULT) | sed -r 's/\"exec_time\": [0-9]+(\.[0-9]+)?/\"exec_time\": \$$TIME/' | diff output-default.json -
+	cat $(OUTPUT_FILE_STDOUT_SUCCESS) | sed -r 's/\"exec_time\": [0-9]+(\.[0-9]+)?/\"exec_time\": \$$TIME/' | diff output-stdout-success.json -

--- a/src/test/run-make-fulldeps/libtest-json/output-default.json
+++ b/src/test/run-make-fulldeps/libtest-json/output-default.json
@@ -7,4 +7,4 @@
 { "type": "test", "name": "c", "event": "ok" }
 { "type": "test", "event": "started", "name": "d" }
 { "type": "test", "name": "d", "event": "ignored" }
-{ "type": "suite", "event": "failed", "passed": 2, "failed": 1, "allowed_fail": 0, "ignored": 1, "measured": 0, "filtered_out": 0 }
+{ "type": "suite", "event": "failed", "passed": 2, "failed": 1, "allowed_fail": 0, "ignored": 1, "measured": 0, "filtered_out": 0, "exec_time": $TIME }

--- a/src/test/run-make-fulldeps/libtest-json/output-stdout-success.json
+++ b/src/test/run-make-fulldeps/libtest-json/output-stdout-success.json
@@ -7,4 +7,4 @@
 { "type": "test", "name": "c", "event": "ok", "stdout": "thread 'main' panicked at 'assertion failed: false', f.rs:15:5\n" }
 { "type": "test", "event": "started", "name": "d" }
 { "type": "test", "name": "d", "event": "ignored" }
-{ "type": "suite", "event": "failed", "passed": 2, "failed": 1, "allowed_fail": 0, "ignored": 1, "measured": 0, "filtered_out": 0 }
+{ "type": "suite", "event": "failed", "passed": 2, "failed": 1, "allowed_fail": 0, "ignored": 1, "measured": 0, "filtered_out": 0, "exec_time": $TIME }

--- a/src/test/rustdoc-ui/cfg-test.rs
+++ b/src/test/rustdoc-ui/cfg-test.rs
@@ -1,6 +1,7 @@
 // check-pass
 // compile-flags:--test --test-args --test-threads=1
 // normalize-stdout-test: "src/test/rustdoc-ui" -> "$$DIR"
+// normalize-stdout-test "finished in \d+\.\d+s" -> "finished in $$TIME"
 
 // Crates like core have doctests gated on `cfg(not(test))` so we need to make
 // sure `cfg(test)` is not active when running `rustdoc --test`.

--- a/src/test/rustdoc-ui/doc-test-doctest-feature.rs
+++ b/src/test/rustdoc-ui/doc-test-doctest-feature.rs
@@ -1,6 +1,7 @@
 // check-pass
 // compile-flags:--test
 // normalize-stdout-test: "src/test/rustdoc-ui" -> "$$DIR"
+// normalize-stdout-test "finished in \d+\.\d+s" -> "finished in $$TIME"
 
 // Make sure `cfg(doctest)` is set when finding doctests but not inside
 // the doctests.

--- a/src/test/rustdoc-ui/doc-test-doctest-feature.stdout
+++ b/src/test/rustdoc-ui/doc-test-doctest-feature.stdout
@@ -1,6 +1,6 @@
 
 running 1 test
-test $DIR/doc-test-doctest-feature.rs - Foo (line 8) ... ok
+test $DIR/doc-test-doctest-feature.rs - Foo (line 9) ... ok
 
-test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
 

--- a/src/test/rustdoc-ui/doc-test-rustdoc-feature.rs
+++ b/src/test/rustdoc-ui/doc-test-rustdoc-feature.rs
@@ -1,6 +1,7 @@
 // check-pass
 // compile-flags:--test
 // normalize-stdout-test: "src/test/rustdoc-ui" -> "$$DIR"
+// normalize-stdout-test "finished in \d+\.\d+s" -> "finished in $$TIME"
 
 #![feature(doc_cfg)]
 

--- a/src/test/rustdoc-ui/doc-test-rustdoc-feature.stdout
+++ b/src/test/rustdoc-ui/doc-test-rustdoc-feature.stdout
@@ -1,6 +1,6 @@
 
 running 1 test
-test $DIR/doc-test-rustdoc-feature.rs - Foo (line 9) ... ok
+test $DIR/doc-test-rustdoc-feature.rs - Foo (line 10) ... ok
 
-test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
 

--- a/src/test/rustdoc-ui/doctest-output.rs
+++ b/src/test/rustdoc-ui/doctest-output.rs
@@ -2,6 +2,7 @@
 // aux-build:extern_macros.rs
 // compile-flags:--test --test-args=--test-threads=1
 // normalize-stdout-test: "src/test/rustdoc-ui" -> "$$DIR"
+// normalize-stdout-test "finished in \d+\.\d+s" -> "finished in $$TIME"
 // check-pass
 
 //! ```

--- a/src/test/rustdoc-ui/doctest-output.stdout
+++ b/src/test/rustdoc-ui/doctest-output.stdout
@@ -1,8 +1,8 @@
 
 running 3 tests
-test $DIR/doctest-output.rs - (line 7) ... ok
-test $DIR/doctest-output.rs - ExpandedStruct (line 23) ... ok
-test $DIR/doctest-output.rs - foo::bar (line 17) ... ok
+test $DIR/doctest-output.rs - (line 8) ... ok
+test $DIR/doctest-output.rs - ExpandedStruct (line 24) ... ok
+test $DIR/doctest-output.rs - foo::bar (line 18) ... ok
 
-test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
+test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
 

--- a/src/test/rustdoc-ui/failed-doctest-compile-fail.rs
+++ b/src/test/rustdoc-ui/failed-doctest-compile-fail.rs
@@ -3,6 +3,7 @@
 
 // compile-flags:--test
 // normalize-stdout-test: "src/test/rustdoc-ui" -> "$$DIR"
+// normalize-stdout-test "finished in \d+\.\d+s" -> "finished in $$TIME"
 // failure-status: 101
 
 /// ```compile_fail

--- a/src/test/rustdoc-ui/failed-doctest-compile-fail.stdout
+++ b/src/test/rustdoc-ui/failed-doctest-compile-fail.stdout
@@ -1,14 +1,14 @@
 
 running 1 test
-test $DIR/failed-doctest-compile-fail.rs - Foo (line 8) ... FAILED
+test $DIR/failed-doctest-compile-fail.rs - Foo (line 9) ... FAILED
 
 failures:
 
----- $DIR/failed-doctest-compile-fail.rs - Foo (line 8) stdout ----
+---- $DIR/failed-doctest-compile-fail.rs - Foo (line 9) stdout ----
 Test compiled successfully, but it's marked `compile_fail`.
 
 failures:
-    $DIR/failed-doctest-compile-fail.rs - Foo (line 8)
+    $DIR/failed-doctest-compile-fail.rs - Foo (line 9)
 
-test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out
+test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
 

--- a/src/test/rustdoc-ui/failed-doctest-missing-codes.rs
+++ b/src/test/rustdoc-ui/failed-doctest-missing-codes.rs
@@ -3,6 +3,7 @@
 
 // compile-flags:--test
 // normalize-stdout-test: "src/test/rustdoc-ui" -> "$$DIR"
+// normalize-stdout-test "finished in \d+\.\d+s" -> "finished in $$TIME"
 // failure-status: 101
 
 /// ```compile_fail,E0004

--- a/src/test/rustdoc-ui/failed-doctest-missing-codes.stdout
+++ b/src/test/rustdoc-ui/failed-doctest-missing-codes.stdout
@@ -1,12 +1,12 @@
 
 running 1 test
-test $DIR/failed-doctest-missing-codes.rs - Foo (line 8) ... FAILED
+test $DIR/failed-doctest-missing-codes.rs - Foo (line 9) ... FAILED
 
 failures:
 
----- $DIR/failed-doctest-missing-codes.rs - Foo (line 8) stdout ----
+---- $DIR/failed-doctest-missing-codes.rs - Foo (line 9) stdout ----
 error[E0308]: mismatched types
-  --> $DIR/failed-doctest-missing-codes.rs:9:13
+  --> $DIR/failed-doctest-missing-codes.rs:10:13
    |
 LL | let x: () = 5i32;
    |        --   ^^^^ expected `()`, found `i32`
@@ -19,7 +19,7 @@ For more information about this error, try `rustc --explain E0308`.
 Some expected error codes were not found: ["E0004"]
 
 failures:
-    $DIR/failed-doctest-missing-codes.rs - Foo (line 8)
+    $DIR/failed-doctest-missing-codes.rs - Foo (line 9)
 
-test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out
+test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
 

--- a/src/test/rustdoc-ui/failed-doctest-output.rs
+++ b/src/test/rustdoc-ui/failed-doctest-output.rs
@@ -5,6 +5,7 @@
 // compile-flags:--test --test-args --test-threads=1
 // rustc-env:RUST_BACKTRACE=0
 // normalize-stdout-test: "src/test/rustdoc-ui" -> "$$DIR"
+// normalize-stdout-test "finished in \d+\.\d+s" -> "finished in $$TIME"
 // failure-status: 101
 
 // doctest fails at runtime

--- a/src/test/rustdoc-ui/failed-doctest-output.stdout
+++ b/src/test/rustdoc-ui/failed-doctest-output.stdout
@@ -1,13 +1,13 @@
 
 running 2 tests
-test $DIR/failed-doctest-output.rs - OtherStruct (line 21) ... FAILED
-test $DIR/failed-doctest-output.rs - SomeStruct (line 11) ... FAILED
+test $DIR/failed-doctest-output.rs - OtherStruct (line 22) ... FAILED
+test $DIR/failed-doctest-output.rs - SomeStruct (line 12) ... FAILED
 
 failures:
 
----- $DIR/failed-doctest-output.rs - OtherStruct (line 21) stdout ----
+---- $DIR/failed-doctest-output.rs - OtherStruct (line 22) stdout ----
 error[E0425]: cannot find value `no` in this scope
-  --> $DIR/failed-doctest-output.rs:22:1
+  --> $DIR/failed-doctest-output.rs:23:1
    |
 LL | no
    | ^^ not found in this scope
@@ -16,7 +16,7 @@ error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0425`.
 Couldn't compile the test.
----- $DIR/failed-doctest-output.rs - SomeStruct (line 11) stdout ----
+---- $DIR/failed-doctest-output.rs - SomeStruct (line 12) stdout ----
 Test executable failed (exit code 101).
 
 stdout:
@@ -32,8 +32,8 @@ note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 
 
 failures:
-    $DIR/failed-doctest-output.rs - OtherStruct (line 21)
-    $DIR/failed-doctest-output.rs - SomeStruct (line 11)
+    $DIR/failed-doctest-output.rs - OtherStruct (line 22)
+    $DIR/failed-doctest-output.rs - SomeStruct (line 12)
 
-test result: FAILED. 0 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out
+test result: FAILED. 0 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
 

--- a/src/test/rustdoc-ui/failed-doctest-should-panic.rs
+++ b/src/test/rustdoc-ui/failed-doctest-should-panic.rs
@@ -3,6 +3,7 @@
 
 // compile-flags:--test
 // normalize-stdout-test: "src/test/rustdoc-ui" -> "$$DIR"
+// normalize-stdout-test "finished in \d+\.\d+s" -> "finished in $$TIME"
 // failure-status: 101
 
 /// ```should_panic

--- a/src/test/rustdoc-ui/failed-doctest-should-panic.stdout
+++ b/src/test/rustdoc-ui/failed-doctest-should-panic.stdout
@@ -1,14 +1,14 @@
 
 running 1 test
-test $DIR/failed-doctest-should-panic.rs - Foo (line 8) ... FAILED
+test $DIR/failed-doctest-should-panic.rs - Foo (line 9) ... FAILED
 
 failures:
 
----- $DIR/failed-doctest-should-panic.rs - Foo (line 8) stdout ----
+---- $DIR/failed-doctest-should-panic.rs - Foo (line 9) stdout ----
 Test executable succeeded, but it's marked `should_panic`.
 
 failures:
-    $DIR/failed-doctest-should-panic.rs - Foo (line 8)
+    $DIR/failed-doctest-should-panic.rs - Foo (line 9)
 
-test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out
+test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
 

--- a/src/test/rustdoc-ui/test-no_std.rs
+++ b/src/test/rustdoc-ui/test-no_std.rs
@@ -1,5 +1,6 @@
 // compile-flags:--test
 // normalize-stdout-test: "src/test/rustdoc-ui" -> "$$DIR"
+// normalize-stdout-test "finished in \d+\.\d+s" -> "finished in $$TIME"
 // check-pass
 
 #![no_std]

--- a/src/test/rustdoc-ui/test-no_std.stdout
+++ b/src/test/rustdoc-ui/test-no_std.stdout
@@ -1,6 +1,6 @@
 
 running 1 test
-test $DIR/test-no_std.rs - f (line 9) ... ok
+test $DIR/test-no_std.rs - f (line 10) ... ok
 
-test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
 

--- a/src/test/rustdoc-ui/unparseable-doc-test.rs
+++ b/src/test/rustdoc-ui/unparseable-doc-test.rs
@@ -1,5 +1,6 @@
 // compile-flags: --test
 // normalize-stdout-test: "src/test/rustdoc-ui" -> "$$DIR"
+// normalize-stdout-test "finished in \d+\.\d+s" -> "finished in $$TIME"
 // failure-status: 101
 // rustc-env: RUST_BACKTRACE=0
 

--- a/src/test/rustdoc-ui/unparseable-doc-test.stdout
+++ b/src/test/rustdoc-ui/unparseable-doc-test.stdout
@@ -1,12 +1,12 @@
 
 running 1 test
-test $DIR/unparseable-doc-test.rs - foo (line 6) ... FAILED
+test $DIR/unparseable-doc-test.rs - foo (line 7) ... FAILED
 
 failures:
 
----- $DIR/unparseable-doc-test.rs - foo (line 6) stdout ----
+---- $DIR/unparseable-doc-test.rs - foo (line 7) stdout ----
 error[E0765]: unterminated double quote string
-  --> $DIR/unparseable-doc-test.rs:8:1
+  --> $DIR/unparseable-doc-test.rs:9:1
    |
 LL | "unterminated
    | ^^^^^^^^^^^^^
@@ -17,7 +17,7 @@ For more information about this error, try `rustc --explain E0765`.
 Couldn't compile the test.
 
 failures:
-    $DIR/unparseable-doc-test.rs - foo (line 6)
+    $DIR/unparseable-doc-test.rs - foo (line 7)
 
-test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out
+test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
 

--- a/src/test/ui/test-panic-abort-nocapture.rs
+++ b/src/test/ui/test-panic-abort-nocapture.rs
@@ -4,6 +4,7 @@
 // run-fail
 // check-run-results
 // exec-env:RUST_BACKTRACE=0
+// normalize-stdout-test "finished in \d+\.\d+s" -> "finished in $$TIME"
 
 // ignore-wasm no panic or subprocess support
 // ignore-emscripten no panic or subprocess support

--- a/src/test/ui/test-panic-abort-nocapture.run.stderr
+++ b/src/test/ui/test-panic-abort-nocapture.run.stderr
@@ -1,9 +1,9 @@
 thread 'main' panicked at 'assertion failed: `(left == right)`
   left: `2`,
- right: `4`', $DIR/test-panic-abort-nocapture.rs:32:5
+ right: `4`', $DIR/test-panic-abort-nocapture.rs:33:5
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 thread 'main' panicked at 'assertion failed: `(left == right)`
   left: `2`,
- right: `4`', $DIR/test-panic-abort-nocapture.rs:26:5
+ right: `4`', $DIR/test-panic-abort-nocapture.rs:27:5
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 testing321

--- a/src/test/ui/test-panic-abort-nocapture.run.stdout
+++ b/src/test/ui/test-panic-abort-nocapture.run.stdout
@@ -19,5 +19,5 @@ failures:
 failures:
     it_fails
 
-test result: FAILED. 3 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out
+test result: FAILED. 3 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
 

--- a/src/test/ui/test-panic-abort.rs
+++ b/src/test/ui/test-panic-abort.rs
@@ -4,6 +4,7 @@
 // run-fail
 // check-run-results
 // exec-env:RUST_BACKTRACE=0
+// normalize-stdout-test "finished in \d+\.\d+s" -> "finished in $$TIME"
 
 // ignore-wasm no panic or subprocess support
 // ignore-emscripten no panic or subprocess support

--- a/src/test/ui/test-panic-abort.run.stdout
+++ b/src/test/ui/test-panic-abort.run.stdout
@@ -18,7 +18,7 @@ testing123
 testing321
 thread 'main' panicked at 'assertion failed: `(left == right)`
   left: `2`,
- right: `5`', $DIR/test-panic-abort.rs:33:5
+ right: `5`', $DIR/test-panic-abort.rs:34:5
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 
 
@@ -26,5 +26,5 @@ failures:
     it_exits
     it_fails
 
-test result: FAILED. 3 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out
+test result: FAILED. 3 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
 

--- a/src/test/ui/test-passed-wasm.rs
+++ b/src/test/ui/test-passed-wasm.rs
@@ -1,0 +1,20 @@
+// no-prefer-dynamic
+// compile-flags: --test
+// run-flags: --test-threads=1
+// run-pass
+// check-run-results
+// only-wasm32
+
+// Tests the output of the test harness with only passed tests.
+
+#![cfg(test)]
+
+#[test]
+fn it_works() {
+    assert_eq!(1 + 1, 2);
+}
+
+#[test]
+fn it_works_too() {
+    assert_eq!(1 * 0, 0);
+}

--- a/src/test/ui/test-passed-wasm.run.stdout
+++ b/src/test/ui/test-passed-wasm.run.stdout
@@ -1,0 +1,7 @@
+
+running 2 tests
+test it_works ... ok
+test it_works_too ... ok
+
+test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
+

--- a/src/test/ui/test-passed.rs
+++ b/src/test/ui/test-passed.rs
@@ -1,0 +1,21 @@
+// no-prefer-dynamic
+// compile-flags: --test
+// run-flags: --test-threads=1
+// run-pass
+// check-run-results
+// normalize-stdout-test "finished in \d+\.\d+s" -> "finished in $$TIME"
+// ignore-wasm32 no support for `Instant`
+
+// Tests the output of the test harness with only passed tests.
+
+#![cfg(test)]
+
+#[test]
+fn it_works() {
+    assert_eq!(1 + 1, 2);
+}
+
+#[test]
+fn it_works_too() {
+    assert_eq!(1 * 0, 0);
+}

--- a/src/test/ui/test-passed.run.stdout
+++ b/src/test/ui/test-passed.run.stdout
@@ -1,7 +1,7 @@
 
 running 2 tests
-test $DIR/cfg-test.rs - Bar (line 27) ... ok
-test $DIR/cfg-test.rs - Foo (line 19) ... ok
+test it_works ... ok
+test it_works_too ... ok
 
 test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
 

--- a/src/test/ui/test-thread-capture.rs
+++ b/src/test/ui/test-thread-capture.rs
@@ -3,6 +3,7 @@
 // run-flags: --test-threads=1
 // check-run-results
 // exec-env:RUST_BACKTRACE=0
+// normalize-stdout-test "finished in \d+\.\d+s" -> "finished in $$TIME"
 // ignore-emscripten no threads support
 
 #[test]

--- a/src/test/ui/test-thread-capture.run.stdout
+++ b/src/test/ui/test-thread-capture.run.stdout
@@ -10,12 +10,12 @@ fee
 fie
 foe
 fum
-thread 'main' panicked at 'explicit panic', $DIR/test-thread-capture.rs:30:5
+thread 'main' panicked at 'explicit panic', $DIR/test-thread-capture.rs:31:5
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 
 
 failures:
     thready_fail
 
-test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out
+test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
 

--- a/src/test/ui/test-thread-nocapture.rs
+++ b/src/test/ui/test-thread-nocapture.rs
@@ -3,6 +3,7 @@
 // run-flags: --test-threads=1 --nocapture
 // check-run-results
 // exec-env:RUST_BACKTRACE=0
+// normalize-stdout-test "finished in \d+\.\d+s" -> "finished in $$TIME"
 // ignore-emscripten no threads support
 
 #[test]

--- a/src/test/ui/test-thread-nocapture.run.stderr
+++ b/src/test/ui/test-thread-nocapture.run.stderr
@@ -1,2 +1,2 @@
-thread 'main' panicked at 'explicit panic', $DIR/test-thread-nocapture.rs:30:5
+thread 'main' panicked at 'explicit panic', $DIR/test-thread-nocapture.rs:31:5
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

--- a/src/test/ui/test-thread-nocapture.run.stdout
+++ b/src/test/ui/test-thread-nocapture.run.stdout
@@ -16,5 +16,5 @@ failures:
 failures:
     thready_fail
 
-test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out
+test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
 


### PR DESCRIPTION
Print the total time taken to execute a test suite by default, without any kind of flag.

Closes #75660

# Example
```
anon@anon:~/code/rust/example$ cargo test
   Compiling example v0.1.0 (/home/anon/code/rust/example)
    Finished test [unoptimized + debuginfo] target(s) in 0.18s
     Running target/debug/deps/example-745b64d3885c3565

running 3 tests
test tests::foo ... ok
test tests::bar ... ok
test tests::baz ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; 1.2s

   Doc-tests example

running 3 tests
test src/lib.rs - foo (line 3) ... ok
test src/lib.rs - bar (line 11) ... ok
test src/lib.rs - baz (line 19) ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; 1.3s
```

```
anon@anon:~/code/rust/example$ cargo test -- --format terse
    Finished test [unoptimized + debuginfo] target(s) in 0.08s
     Running target/debug/deps/example-745b64d3885c3565

running 3 tests
...
test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; 1.2s

   Doc-tests example

running 3 tests
...
test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; 1.3s
```

```
anon@anon:~/code/rust/example$ cargo test -- --format json -Z unstable-options
   Compiling example v0.1.0 (/home/anon/code/rust/example)
    Finished test [unoptimized + debuginfo] target(s) in 0.25s
     Running target/debug/deps/example-745b64d3885c3565
{ "type": "suite", "event": "started", "test_count": 3 }
{ "type": "test", "event": "started", "name": "tests::bar" }
{ "type": "test", "event": "started", "name": "tests::baz" }
{ "type": "test", "event": "started", "name": "tests::foo" }
{ "type": "test", "name": "tests::foo", "event": "ok" }
{ "type": "test", "name": "tests::bar", "event": "ok" }
{ "type": "test", "name": "tests::baz", "event": "ok" }
{ "type": "suite", "event": "ok", "passed": 3, "failed": 0, "allowed_fail": 0, "ignored": 0, "measured": 0, "filtered_out": 0, "exec_time": "1.2s" }
   Doc-tests example
{ "type": "suite", "event": "started", "test_count": 3 }
{ "type": "test", "event": "started", "name": "src/lib.rs - bar (line 11)" }
{ "type": "test", "event": "started", "name": "src/lib.rs - baz (line 19)" }
{ "type": "test", "event": "started", "name": "src/lib.rs - foo (line 3)" }
{ "type": "test", "name": "src/lib.rs - foo (line 3)", "event": "ok" }
{ "type": "test", "name": "src/lib.rs - bar (line 11)", "event": "ok" }
{ "type": "test", "name": "src/lib.rs - baz (line 19)", "event": "ok" }
{ "type": "suite", "event": "ok", "passed": 3, "failed": 0, "allowed_fail": 0, "ignored": 0, "measured": 0, "filtered_out": 0, "exec_time": "1.3s" }
```