### PR TITLE
Improve suggestions for broken intra-doc links

### DIFF
--- a/compiler/rustc_hir/src/def.rs
+++ b/compiler/rustc_hir/src/def.rs
@@ -6,6 +6,7 @@ use rustc_ast::NodeId;
 use rustc_macros::HashStable_Generic;
 use rustc_span::hygiene::MacroKind;
 
+use std::array::IntoIter;
 use std::fmt::Debug;
 
 /// Encodes if a `DefKind::Ctor` is the constructor of an enum variant or a struct.
@@ -290,6 +291,14 @@ pub struct PerNS<T> {
 impl<T> PerNS<T> {
     pub fn map<U, F: FnMut(T) -> U>(self, mut f: F) -> PerNS<U> {
         PerNS { value_ns: f(self.value_ns), type_ns: f(self.type_ns), macro_ns: f(self.macro_ns) }
+    }
+
+    pub fn into_iter(self) -> IntoIter<T, 3> {
+        IntoIter::new([self.value_ns, self.type_ns, self.macro_ns])
+    }
+
+    pub fn iter(&self) -> IntoIter<&T, 3> {
+        IntoIter::new([&self.value_ns, &self.type_ns, &self.macro_ns])
     }
 }
 

--- a/compiler/rustc_hir/src/lib.rs
+++ b/compiler/rustc_hir/src/lib.rs
@@ -2,6 +2,7 @@
 //!
 //! [rustc dev guide]: https://rustc-dev-guide.rust-lang.org/hir.html
 
+#![feature(array_value_iter)]
 #![feature(crate_visibility_modifier)]
 #![feature(const_fn)] // For the unsizing cast on `&[]`
 #![feature(const_panic)]

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -150,7 +150,6 @@ impl<'a, 'tcx> LinkCollector<'a, 'tcx> {
         let variant_name =
             // we're not sure this is a variant at all, so use the full string
             split.next().map(|f| Symbol::intern(f)).ok_or(ErrorKind::Resolve(ResolutionFailure::NotInScope(path_str.into())))?;
-        // TODO: this looks very wrong, why are we requiring 3 fields?
         let path = split
             .next()
             .map(|f| {
@@ -161,7 +160,6 @@ impl<'a, 'tcx> LinkCollector<'a, 'tcx> {
                 }
                 f.to_owned()
             })
-            // TODO: is this right?
             .ok_or(ErrorKind::Resolve(ResolutionFailure::NotInScope(
                 variant_name.to_string().into(),
             )))?;

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -541,7 +541,6 @@ impl<'a, 'tcx> LinkCollector<'a, 'tcx> {
             })
         } else {
             debug!("attempting to resolve item without parent module: {}", path_str);
-            // TODO: maybe this should just be an ICE?
             Err(ErrorKind::Resolve(ResolutionFailure::NoParentItem))
         }
     }
@@ -1462,7 +1461,8 @@ fn resolution_failure(
                         }
                     }
                     ResolutionFailure::NoParentItem => {
-                        panic!("all intra doc links should have a parent item")
+                        diag.level = rustc_errors::Level::Bug;
+                        diag.note("all intra doc links should have a parent item");
                     }
                     ResolutionFailure::NoPrimitiveImpl(res, _) => {
                         let note = format!(
@@ -1694,7 +1694,6 @@ fn handle_variant(
     let parent = if let Some(parent) = cx.tcx.parent(res.def_id()) {
         parent
     } else {
-        // TODO: this should just be an unwrap, there should never be `Variant`s without a parent
         return Err(ErrorKind::Resolve(ResolutionFailure::NoParentItem));
     };
     let parent_def = Res::Def(DefKind::Enum, parent);

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -1056,12 +1056,9 @@ impl<'a, 'tcx> DocFolder for LinkCollector<'a, 'tcx> {
                             }),
                         };
 
-                        let mut candidates_iter =
-                            candidates.iter().filter_map(|res| res.as_ref().ok());
-                        let len = candidates_iter.clone().count();
+                        let len = candidates.iter().filter(|res| res.is_ok()).count();
 
                         if len == 0 {
-                            drop(candidates_iter);
                             resolution_failure(
                                 self,
                                 &item,
@@ -1076,12 +1073,10 @@ impl<'a, 'tcx> DocFolder for LinkCollector<'a, 'tcx> {
                         }
 
                         if len == 1 {
-                            candidates_iter.next().unwrap().clone()
+                            candidates.into_iter().filter_map(|res| res.ok()).next().unwrap()
                         } else if len == 2 && is_derive_trait_collision(&candidates) {
-                            drop(candidates_iter);
                             candidates.type_ns.unwrap()
                         } else {
-                            drop(candidates_iter);
                             if is_derive_trait_collision(&candidates) {
                                 candidates.macro_ns = Err(ResolutionFailure::Dummy);
                             }

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -938,9 +938,9 @@ impl<'a, 'tcx> DocFolder for LinkCollector<'a, 'tcx> {
                                 // We only looked in one namespace. Try to give a better error if possible.
                                 if kind.full_res().is_none() {
                                     let other_ns = if ns == ValueNS { TypeNS } else { ValueNS };
-                                    for &ns in &[other_ns, MacroNS] {
+                                    for &new_ns in &[other_ns, MacroNS] {
                                         if let Some(res) = self.check_full_res(
-                                            ns,
+                                            new_ns,
                                             path_str,
                                             base_node,
                                             &current_item,

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -1554,12 +1554,13 @@ fn resolution_failure(
                 }
                 variants_seen.push(variant);
                 let note = match failure {
-                    ResolutionFailure::NotInScope { name, .. } => {
+                    ResolutionFailure::NotInScope { module_id, name, .. } => {
                         if in_scope {
                             continue;
                         }
                         // NOTE: uses an explicit `continue` so the `note:` will come before the `help:`
-                        let note = format!("no item named `{}` is in scope", name);
+                        let module_name = collector.cx.tcx.item_name(module_id);
+                        let note = format!("no item named `{}` in `{}`", name, module_name);
                         if let Some(span) = sp {
                             diag.span_label(span, &note);
                         } else {

--- a/src/test/rustdoc-ui/assoc-item-not-in-scope.stderr
+++ b/src/test/rustdoc-ui/assoc-item-not-in-scope.stderr
@@ -2,14 +2,14 @@ error: unresolved link to `S::fmt`
   --> $DIR/assoc-item-not-in-scope.rs:4:14
    |
 LL | /// Link to [`S::fmt`]
-   |              ^^^^^^^^ unresolved link
+   |              ^^^^^^^^
    |
 note: the lint level is defined here
   --> $DIR/assoc-item-not-in-scope.rs:1:9
    |
 LL | #![deny(broken_intra_doc_links)]
    |         ^^^^^^^^^^^^^^^^^^^^^^
-   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
+   = note: the struct `S` has no field or associated item named `fmt`
 
 error: aborting due to previous error
 

--- a/src/test/rustdoc-ui/assoc-item-not-in-scope.stderr
+++ b/src/test/rustdoc-ui/assoc-item-not-in-scope.stderr
@@ -2,14 +2,13 @@ error: unresolved link to `S::fmt`
   --> $DIR/assoc-item-not-in-scope.rs:4:14
    |
 LL | /// Link to [`S::fmt`]
-   |              ^^^^^^^^
+   |              ^^^^^^^^ the struct `S` has no field or associated item named `fmt`
    |
 note: the lint level is defined here
   --> $DIR/assoc-item-not-in-scope.rs:1:9
    |
 LL | #![deny(broken_intra_doc_links)]
    |         ^^^^^^^^^^^^^^^^^^^^^^
-   = note: the struct `S` has no field or associated item named `fmt`
 
 error: aborting due to previous error
 

--- a/src/test/rustdoc-ui/deny-intra-link-resolution-failure.stderr
+++ b/src/test/rustdoc-ui/deny-intra-link-resolution-failure.stderr
@@ -2,13 +2,14 @@ error: unresolved link to `v2`
   --> $DIR/deny-intra-link-resolution-failure.rs:3:6
    |
 LL | /// [v2]
-   |      ^^ unresolved link
+   |      ^^
    |
 note: the lint level is defined here
   --> $DIR/deny-intra-link-resolution-failure.rs:1:9
    |
 LL | #![deny(broken_intra_doc_links)]
    |         ^^^^^^^^^^^^^^^^^^^^^^
+   = note: no item named `v2` is in scope
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 error: aborting due to previous error

--- a/src/test/rustdoc-ui/deny-intra-link-resolution-failure.stderr
+++ b/src/test/rustdoc-ui/deny-intra-link-resolution-failure.stderr
@@ -2,14 +2,13 @@ error: unresolved link to `v2`
   --> $DIR/deny-intra-link-resolution-failure.rs:3:6
    |
 LL | /// [v2]
-   |      ^^
+   |      ^^ no item named `v2` in `deny_intra_link_resolution_failure`
    |
 note: the lint level is defined here
   --> $DIR/deny-intra-link-resolution-failure.rs:1:9
    |
 LL | #![deny(broken_intra_doc_links)]
    |         ^^^^^^^^^^^^^^^^^^^^^^
-   = note: no item named `v2` is in scope
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 error: aborting due to previous error

--- a/src/test/rustdoc-ui/intra-doc-alias-ice.stderr
+++ b/src/test/rustdoc-ui/intra-doc-alias-ice.stderr
@@ -2,14 +2,15 @@ error: unresolved link to `TypeAlias::hoge`
   --> $DIR/intra-doc-alias-ice.rs:5:30
    |
 LL | /// [broken cross-reference](TypeAlias::hoge)
-   |                              ^^^^^^^^^^^^^^^ unresolved link
+   |                              ^^^^^^^^^^^^^^^
    |
 note: the lint level is defined here
   --> $DIR/intra-doc-alias-ice.rs:1:9
    |
 LL | #![deny(broken_intra_doc_links)]
    |         ^^^^^^^^^^^^^^^^^^^^^^
-   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
+   = note: this link partially resolves to the type alias `TypeAlias`,
+   = note: `TypeAlias` has no field, variant, or associated item named `hoge`
 
 error: aborting due to previous error
 

--- a/src/test/rustdoc-ui/intra-doc-alias-ice.stderr
+++ b/src/test/rustdoc-ui/intra-doc-alias-ice.stderr
@@ -2,14 +2,13 @@ error: unresolved link to `TypeAlias::hoge`
   --> $DIR/intra-doc-alias-ice.rs:5:30
    |
 LL | /// [broken cross-reference](TypeAlias::hoge)
-   |                              ^^^^^^^^^^^^^^^
+   |                              ^^^^^^^^^^^^^^^ the type alias `TypeAlias` has no associated item named `hoge`
    |
 note: the lint level is defined here
   --> $DIR/intra-doc-alias-ice.rs:1:9
    |
 LL | #![deny(broken_intra_doc_links)]
    |         ^^^^^^^^^^^^^^^^^^^^^^
-   = note: the type alias `TypeAlias` has no associated item named `hoge`
 
 error: aborting due to previous error
 

--- a/src/test/rustdoc-ui/intra-doc-alias-ice.stderr
+++ b/src/test/rustdoc-ui/intra-doc-alias-ice.stderr
@@ -9,8 +9,7 @@ note: the lint level is defined here
    |
 LL | #![deny(broken_intra_doc_links)]
    |         ^^^^^^^^^^^^^^^^^^^^^^
-   = note: this link partially resolves to the type alias `TypeAlias`
-   = note: no `hoge` in `TypeAlias`
+   = note: the type alias `TypeAlias` has no associated item named `hoge`
 
 error: aborting due to previous error
 

--- a/src/test/rustdoc-ui/intra-doc-alias-ice.stderr
+++ b/src/test/rustdoc-ui/intra-doc-alias-ice.stderr
@@ -9,7 +9,7 @@ note: the lint level is defined here
    |
 LL | #![deny(broken_intra_doc_links)]
    |         ^^^^^^^^^^^^^^^^^^^^^^
-   = note: this link partially resolves to the type alias `TypeAlias`,
+   = note: this link partially resolves to the type alias `TypeAlias`
    = note: `TypeAlias` has no field, variant, or associated item named `hoge`
 
 error: aborting due to previous error

--- a/src/test/rustdoc-ui/intra-doc-alias-ice.stderr
+++ b/src/test/rustdoc-ui/intra-doc-alias-ice.stderr
@@ -10,7 +10,7 @@ note: the lint level is defined here
 LL | #![deny(broken_intra_doc_links)]
    |         ^^^^^^^^^^^^^^^^^^^^^^
    = note: this link partially resolves to the type alias `TypeAlias`
-   = note: `TypeAlias` has no field, variant, or associated item named `hoge`
+   = note: no `hoge` in `TypeAlias`
 
 error: aborting due to previous error
 

--- a/src/test/rustdoc-ui/intra-link-errors.rs
+++ b/src/test/rustdoc-ui/intra-link-errors.rs
@@ -10,7 +10,6 @@
 //~| NOTE no item named `path::to` is in scope
 //~| HELP to escape
 
-// TODO: why does this say `f` and not `f::A`??
 /// [f::A]
 //~^ ERROR unresolved link
 //~| NOTE this link partially resolves

--- a/src/test/rustdoc-ui/intra-link-errors.rs
+++ b/src/test/rustdoc-ui/intra-link-errors.rs
@@ -10,6 +10,18 @@
 //~| NOTE no item named `path::to` is in scope
 //~| HELP to escape
 
+/// [std::io::not::here]
+//~^ ERROR unresolved link
+//~| NOTE the module `io` has no inner item
+
+/// [std::io::Error::x]
+//~^ ERROR unresolved link
+//~| NOTE the struct `Error` has no field
+
+/// [std::io::ErrorKind::x]
+//~^ ERROR unresolved link
+//~| NOTE the enum `ErrorKind` has no variant
+
 /// [f::A]
 //~^ ERROR unresolved link
 //~| NOTE `f` is a function, not a module
@@ -59,4 +71,13 @@ impl S {
 //~| HELP to escape
 pub trait T {
     fn g() {}
+}
+
+/// [m()]
+//~^ ERROR unresolved link
+//~| HELP to link to the macro
+//~| NOTE not in the value namespace
+#[macro_export]
+macro_rules! m {
+    () => {};
 }

--- a/src/test/rustdoc-ui/intra-link-errors.rs
+++ b/src/test/rustdoc-ui/intra-link-errors.rs
@@ -1,9 +1,6 @@
 #![deny(broken_intra_doc_links)]
 //~^ NOTE lint level is defined
 
-//! [std::io::oops]
-//! [std::io::oops::not::here]
-
 // FIXME: this should say that it was skipped (maybe an allowed by default lint?)
 /// [<invalid syntax>]
 
@@ -22,17 +19,17 @@
 /// [S::A]
 //~^ ERROR unresolved link
 //~| NOTE this link partially resolves
-//~| NOTE `S` has no field
+//~| NOTE no `A` in `S`
 
 /// [S::fmt]
 //~^ ERROR unresolved link
 //~| NOTE this link partially resolves
-//~| NOTE `S` has no field
+//~| NOTE no `fmt` in `S`
 
 /// [E::D]
 //~^ ERROR unresolved link
 //~| NOTE this link partially resolves
-//~| NOTE `E` has no field
+//~| NOTE no `D` in `E`
 
 /// [u8::not_found]
 //~^ ERROR unresolved link
@@ -40,8 +37,8 @@
 
 /// [S!]
 //~^ ERROR unresolved link
-//~| HELP to link to the unit struct, use its disambiguator
-//~| NOTE this link resolves to the unit struct `S`
+//~| HELP to link to the struct, use its disambiguator
+//~| NOTE this link resolves to the struct `S`
 pub fn f() {}
 #[derive(Debug)]
 pub struct S;
@@ -62,6 +59,9 @@ impl S {
 //~| NOTE not in the type namespace
 
 /// [T::h!]
+//~^ ERROR unresolved link
+//~| NOTE no item named `T::h`
+//~| HELP to escape
 pub trait T {
     fn g() {}
 }

--- a/src/test/rustdoc-ui/intra-link-errors.rs
+++ b/src/test/rustdoc-ui/intra-link-errors.rs
@@ -7,7 +7,6 @@
 /// [path::to::nonexistent::module]
 //~^ ERROR unresolved link
 //~| NOTE no item named `path` is in scope
-//~| HELP to escape
 
 /// [std::io::not::here]
 //~^ ERROR unresolved link
@@ -67,7 +66,6 @@ impl S {
 /// [T::h!]
 //~^ ERROR unresolved link
 //~| NOTE no item named `T::h`
-//~| HELP to escape
 pub trait T {
     fn g() {}
 }

--- a/src/test/rustdoc-ui/intra-link-errors.rs
+++ b/src/test/rustdoc-ui/intra-link-errors.rs
@@ -6,15 +6,15 @@
 
 /// [path::to::nonexistent::module]
 //~^ ERROR unresolved link
-//~| NOTE no item named `path` is in scope
+//~| NOTE no item named `path` in `intra_link_errors`
 
 /// [path::to::nonexistent::macro!]
 //~^ ERROR unresolved link
-//~| NOTE no item named `path` is in scope
+//~| NOTE no item named `path` in `intra_link_errors`
 
 /// [type@path::to::nonexistent::type]
 //~^ ERROR unresolved link
-//~| NOTE no item named `path` is in scope
+//~| NOTE no item named `path` in `intra_link_errors`
 
 /// [std::io::not::here]
 //~^ ERROR unresolved link

--- a/src/test/rustdoc-ui/intra-link-errors.rs
+++ b/src/test/rustdoc-ui/intra-link-errors.rs
@@ -49,11 +49,18 @@ pub struct S;
 pub enum E { A, B, C }
 
 /// [type@S::h]
+//~^ ERROR unresolved link
+//~| HELP to link to the associated function
+//~| NOTE not in the type namespace
 impl S {
     pub fn h() {}
 }
 
 /// [type@T::g]
+//~^ ERROR unresolved link
+//~| HELP to link to the associated function
+//~| NOTE not in the type namespace
+
 /// [T::h!]
 pub trait T {
     fn g() {}

--- a/src/test/rustdoc-ui/intra-link-errors.rs
+++ b/src/test/rustdoc-ui/intra-link-errors.rs
@@ -54,6 +54,7 @@ impl S {
 }
 
 /// [type@T::g]
+/// [T::h!]
 pub trait T {
     fn g() {}
 }

--- a/src/test/rustdoc-ui/intra-link-errors.rs
+++ b/src/test/rustdoc-ui/intra-link-errors.rs
@@ -1,0 +1,59 @@
+#![deny(broken_intra_doc_links)]
+//~^ NOTE lint level is defined
+
+//! [std::io::oops]
+//! [std::io::oops::not::here]
+
+// FIXME: this should say that it was skipped (maybe an allowed by default lint?)
+/// [<invalid syntax>]
+
+// FIXME: this could say which path was the first to not be found (in this case, `path`)
+/// [path::to::nonexistent::module]
+//~^ ERROR unresolved link
+//~| NOTE no item named `path::to::nonexistent` is in scope
+//~| HELP to escape
+
+// TODO: why does this say `f` and not `f::A`??
+/// [f::A]
+//~^ ERROR unresolved link
+//~| NOTE no item named `f` is in scope
+//~| HELP to escape
+
+/// [S::A]
+//~^ ERROR unresolved link
+//~| NOTE this link partially resolves
+//~| NOTE `S` has no field
+
+/// [S::fmt]
+//~^ ERROR unresolved link
+//~| NOTE this link partially resolves
+//~| NOTE `S` has no field
+
+/// [E::D]
+//~^ ERROR unresolved link
+//~| NOTE this link partially resolves
+//~| NOTE `E` has no field
+
+/// [u8::not_found]
+//~^ ERROR unresolved link
+//~| NOTE the builtin type `u8` does not have an associated item named `not_found`
+
+/// [S!]
+//~^ ERROR unresolved link
+//~| HELP to link to the unit struct, use its disambiguator
+//~| NOTE this link resolves to the unit struct `S`
+pub fn f() {}
+#[derive(Debug)]
+pub struct S;
+
+pub enum E { A, B, C }
+
+/// [type@S::h]
+impl S {
+    pub fn h() {}
+}
+
+/// [type@T::g]
+pub trait T {
+    fn g() {}
+}

--- a/src/test/rustdoc-ui/intra-link-errors.rs
+++ b/src/test/rustdoc-ui/intra-link-errors.rs
@@ -4,10 +4,9 @@
 // FIXME: this should say that it was skipped (maybe an allowed by default lint?)
 /// [<invalid syntax>]
 
-// FIXME: this could say which path was the first to not be found (in this case, `path`)
 /// [path::to::nonexistent::module]
 //~^ ERROR unresolved link
-//~| NOTE no item named `path::to` is in scope
+//~| NOTE no item named `path` is in scope
 //~| HELP to escape
 
 /// [std::io::not::here]
@@ -44,7 +43,7 @@
 
 /// [S!]
 //~^ ERROR unresolved link
-//~| HELP to link to the struct, use its disambiguator
+//~| HELP to link to the struct, prefix with the item kind
 //~| NOTE this link resolves to the struct `S`
 pub fn f() {}
 #[derive(Debug)]

--- a/src/test/rustdoc-ui/intra-link-errors.rs
+++ b/src/test/rustdoc-ui/intra-link-errors.rs
@@ -65,7 +65,7 @@ impl S {
 
 /// [T::h!]
 //~^ ERROR unresolved link
-//~| NOTE no item named `T::h`
+//~| NOTE `T` has no macro named `h`
 pub trait T {
     fn g() {}
 }

--- a/src/test/rustdoc-ui/intra-link-errors.rs
+++ b/src/test/rustdoc-ui/intra-link-errors.rs
@@ -7,14 +7,14 @@
 // FIXME: this could say which path was the first to not be found (in this case, `path`)
 /// [path::to::nonexistent::module]
 //~^ ERROR unresolved link
-//~| NOTE no item named `path::to::nonexistent` is in scope
+//~| NOTE no item named `path::to` is in scope
 //~| HELP to escape
 
 // TODO: why does this say `f` and not `f::A`??
 /// [f::A]
 //~^ ERROR unresolved link
-//~| NOTE no item named `f` is in scope
-//~| HELP to escape
+//~| NOTE this link partially resolves
+//~| NOTE `f` is a function, not a module
 
 /// [S::A]
 //~^ ERROR unresolved link

--- a/src/test/rustdoc-ui/intra-link-errors.rs
+++ b/src/test/rustdoc-ui/intra-link-errors.rs
@@ -8,6 +8,14 @@
 //~^ ERROR unresolved link
 //~| NOTE no item named `path` is in scope
 
+/// [path::to::nonexistent::macro!]
+//~^ ERROR unresolved link
+//~| NOTE no item named `path` is in scope
+
+/// [type@path::to::nonexistent::type]
+//~^ ERROR unresolved link
+//~| NOTE no item named `path` is in scope
+
 /// [std::io::not::here]
 //~^ ERROR unresolved link
 //~| NOTE the module `io` has no inner item

--- a/src/test/rustdoc-ui/intra-link-errors.rs
+++ b/src/test/rustdoc-ui/intra-link-errors.rs
@@ -42,7 +42,7 @@
 
 /// [S!]
 //~^ ERROR unresolved link
-//~| HELP to link to the struct, prefix with the item kind
+//~| HELP to link to the struct, prefix with `struct@`
 //~| NOTE this link resolves to the struct `S`
 pub fn f() {}
 #[derive(Debug)]

--- a/src/test/rustdoc-ui/intra-link-errors.rs
+++ b/src/test/rustdoc-ui/intra-link-errors.rs
@@ -12,23 +12,19 @@
 
 /// [f::A]
 //~^ ERROR unresolved link
-//~| NOTE this link partially resolves
 //~| NOTE `f` is a function, not a module
 
 /// [S::A]
 //~^ ERROR unresolved link
-//~| NOTE this link partially resolves
-//~| NOTE no `A` in `S`
+//~| NOTE struct `S` has no field or associated item
 
 /// [S::fmt]
 //~^ ERROR unresolved link
-//~| NOTE this link partially resolves
-//~| NOTE no `fmt` in `S`
+//~| NOTE struct `S` has no field or associated item
 
 /// [E::D]
 //~^ ERROR unresolved link
-//~| NOTE this link partially resolves
-//~| NOTE no `D` in `E`
+//~| NOTE enum `E` has no variant or associated item
 
 /// [u8::not_found]
 //~^ ERROR unresolved link

--- a/src/test/rustdoc-ui/intra-link-errors.stderr
+++ b/src/test/rustdoc-ui/intra-link-errors.stderr
@@ -80,27 +80,34 @@ error: unresolved link to `S`
   --> $DIR/intra-link-errors.rs:41:6
    |
 LL | /// [S!]
-   |      ^^ help: to link to the unit struct, use its disambiguator: `value@S`
+   |      ^^ help: to link to the struct, use its disambiguator: `struct@S`
    |
-   = note: this link resolves to the unit struct `S`, which is not in the macro namespace
+   = note: this link resolves to the struct `S`, which is not in the macro namespace
 
 error: unresolved link to `T::g`
-  --> $DIR/intra-link-errors.rs:56:6
+  --> $DIR/intra-link-errors.rs:59:6
    |
 LL | /// [type@T::g]
-   |      ^^^^^^^^^
+   |      ^^^^^^^^^ help: to link to the associated function, use its disambiguator: `T::g()`
    |
-   = note: this link partially resolves to the trait `T`
-   = note: `T` has no field, variant, or associated item named `g`
+   = note: this link resolves to the associated function `g`, which is not in the type namespace
+
+error: unresolved link to `T::h`
+  --> $DIR/intra-link-errors.rs:64:6
+   |
+LL | /// [T::h!]
+   |      ^^^^^
+   |
+   = note: no item named `T::h` is in scope
+   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 error: unresolved link to `S::h`
   --> $DIR/intra-link-errors.rs:51:6
    |
 LL | /// [type@S::h]
-   |      ^^^^^^^^^
+   |      ^^^^^^^^^ help: to link to the associated function, use its disambiguator: `S::h()`
    |
-   = note: this link partially resolves to the struct `S`
-   = note: `S` has no field, variant, or associated item named `h`
+   = note: this link resolves to the associated function `h`, which is not in the type namespace
 
-error: aborting due to 11 previous errors
+error: aborting due to 12 previous errors
 

--- a/src/test/rustdoc-ui/intra-link-errors.stderr
+++ b/src/test/rustdoc-ui/intra-link-errors.stderr
@@ -13,43 +13,39 @@ LL | #![deny(broken_intra_doc_links)]
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 error: unresolved link to `f::A`
-  --> $DIR/intra-link-errors.rs:14:6
+  --> $DIR/intra-link-errors.rs:13:6
    |
 LL | /// [f::A]
    |      ^^^^
    |
-   = note: this link partially resolves to the function `f`
    = note: `f` is a function, not a module or type, and cannot have associated items
 
 error: unresolved link to `S::A`
-  --> $DIR/intra-link-errors.rs:19:6
+  --> $DIR/intra-link-errors.rs:17:6
    |
 LL | /// [S::A]
    |      ^^^^
    |
-   = note: this link partially resolves to the struct `S`
-   = note: no `A` in `S`
+   = note: the struct `S` has no field or associated item named `A`
 
 error: unresolved link to `S::fmt`
-  --> $DIR/intra-link-errors.rs:24:6
+  --> $DIR/intra-link-errors.rs:21:6
    |
 LL | /// [S::fmt]
    |      ^^^^^^
    |
-   = note: this link partially resolves to the struct `S`
-   = note: no `fmt` in `S`
+   = note: the struct `S` has no field or associated item named `fmt`
 
 error: unresolved link to `E::D`
-  --> $DIR/intra-link-errors.rs:29:6
+  --> $DIR/intra-link-errors.rs:25:6
    |
 LL | /// [E::D]
    |      ^^^^
    |
-   = note: this link partially resolves to the enum `E`
-   = note: no `D` in `E`
+   = note: the enum `E` has no variant or associated item named `D`
 
 error: unresolved link to `u8::not_found`
-  --> $DIR/intra-link-errors.rs:34:6
+  --> $DIR/intra-link-errors.rs:29:6
    |
 LL | /// [u8::not_found]
    |      ^^^^^^^^^^^^^
@@ -57,7 +53,7 @@ LL | /// [u8::not_found]
    = note: the builtin type `u8` does not have an associated item named `not_found`
 
 error: unresolved link to `S`
-  --> $DIR/intra-link-errors.rs:38:6
+  --> $DIR/intra-link-errors.rs:33:6
    |
 LL | /// [S!]
    |      ^^ help: to link to the struct, use its disambiguator: `struct@S`
@@ -65,7 +61,7 @@ LL | /// [S!]
    = note: this link resolves to the struct `S`, which is not in the macro namespace
 
 error: unresolved link to `T::g`
-  --> $DIR/intra-link-errors.rs:56:6
+  --> $DIR/intra-link-errors.rs:51:6
    |
 LL | /// [type@T::g]
    |      ^^^^^^^^^ help: to link to the associated function, use its disambiguator: `T::g()`
@@ -73,7 +69,7 @@ LL | /// [type@T::g]
    = note: this link resolves to the associated function `g`, which is not in the type namespace
 
 error: unresolved link to `T::h`
-  --> $DIR/intra-link-errors.rs:61:6
+  --> $DIR/intra-link-errors.rs:56:6
    |
 LL | /// [T::h!]
    |      ^^^^^
@@ -82,7 +78,7 @@ LL | /// [T::h!]
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 error: unresolved link to `S::h`
-  --> $DIR/intra-link-errors.rs:48:6
+  --> $DIR/intra-link-errors.rs:43:6
    |
 LL | /// [type@S::h]
    |      ^^^^^^^^^ help: to link to the associated function, use its disambiguator: `S::h()`

--- a/src/test/rustdoc-ui/intra-link-errors.stderr
+++ b/src/test/rustdoc-ui/intra-link-errors.stderr
@@ -1,39 +1,19 @@
-error: unresolved link to `std::io::oops`
-  --> $DIR/intra-link-errors.rs:4:6
+error: unresolved link to `path::to::nonexistent::module`
+  --> $DIR/intra-link-errors.rs:8:6
    |
-LL | //! [std::io::oops]
-   |      ^^^^^^^^^^^^^
+LL | /// [path::to::nonexistent::module]
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: the lint level is defined here
   --> $DIR/intra-link-errors.rs:1:9
    |
 LL | #![deny(broken_intra_doc_links)]
    |         ^^^^^^^^^^^^^^^^^^^^^^
-   = note: this link resolves to the crate `std`, which is not an enum
-   = note: if this were an enum, it might have a variant which resolved
-   = note: this link partially resolves to the module `io`
-   = note: `io` has no field, variant, or associated item named `oops`
-
-error: unresolved link to `std::io::oops::not::here`
-  --> $DIR/intra-link-errors.rs:5:6
-   |
-LL | //! [std::io::oops::not::here]
-   |      ^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: no item named `std::io::oops::not` is in scope
-   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
-
-error: unresolved link to `path::to::nonexistent::module`
-  --> $DIR/intra-link-errors.rs:11:6
-   |
-LL | /// [path::to::nonexistent::module]
-   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
    = note: no item named `path::to::nonexistent` is in scope
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 error: unresolved link to `f::A`
-  --> $DIR/intra-link-errors.rs:17:6
+  --> $DIR/intra-link-errors.rs:14:6
    |
 LL | /// [f::A]
    |      ^^^^
@@ -42,34 +22,34 @@ LL | /// [f::A]
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 error: unresolved link to `S::A`
-  --> $DIR/intra-link-errors.rs:22:6
+  --> $DIR/intra-link-errors.rs:19:6
    |
 LL | /// [S::A]
    |      ^^^^
    |
    = note: this link partially resolves to the struct `S`
-   = note: `S` has no field, variant, or associated item named `A`
+   = note: no `A` in `S`
 
 error: unresolved link to `S::fmt`
-  --> $DIR/intra-link-errors.rs:27:6
+  --> $DIR/intra-link-errors.rs:24:6
    |
 LL | /// [S::fmt]
    |      ^^^^^^
    |
    = note: this link partially resolves to the struct `S`
-   = note: `S` has no field, variant, or associated item named `fmt`
+   = note: no `fmt` in `S`
 
 error: unresolved link to `E::D`
-  --> $DIR/intra-link-errors.rs:32:6
+  --> $DIR/intra-link-errors.rs:29:6
    |
 LL | /// [E::D]
    |      ^^^^
    |
    = note: this link partially resolves to the enum `E`
-   = note: `E` has no field, variant, or associated item named `D`
+   = note: no `D` in `E`
 
 error: unresolved link to `u8::not_found`
-  --> $DIR/intra-link-errors.rs:37:6
+  --> $DIR/intra-link-errors.rs:34:6
    |
 LL | /// [u8::not_found]
    |      ^^^^^^^^^^^^^
@@ -77,7 +57,7 @@ LL | /// [u8::not_found]
    = note: the builtin type `u8` does not have an associated item named `not_found`
 
 error: unresolved link to `S`
-  --> $DIR/intra-link-errors.rs:41:6
+  --> $DIR/intra-link-errors.rs:38:6
    |
 LL | /// [S!]
    |      ^^ help: to link to the struct, use its disambiguator: `struct@S`
@@ -85,7 +65,7 @@ LL | /// [S!]
    = note: this link resolves to the struct `S`, which is not in the macro namespace
 
 error: unresolved link to `T::g`
-  --> $DIR/intra-link-errors.rs:59:6
+  --> $DIR/intra-link-errors.rs:56:6
    |
 LL | /// [type@T::g]
    |      ^^^^^^^^^ help: to link to the associated function, use its disambiguator: `T::g()`
@@ -93,7 +73,7 @@ LL | /// [type@T::g]
    = note: this link resolves to the associated function `g`, which is not in the type namespace
 
 error: unresolved link to `T::h`
-  --> $DIR/intra-link-errors.rs:64:6
+  --> $DIR/intra-link-errors.rs:61:6
    |
 LL | /// [T::h!]
    |      ^^^^^
@@ -102,12 +82,12 @@ LL | /// [T::h!]
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 error: unresolved link to `S::h`
-  --> $DIR/intra-link-errors.rs:51:6
+  --> $DIR/intra-link-errors.rs:48:6
    |
 LL | /// [type@S::h]
    |      ^^^^^^^^^ help: to link to the associated function, use its disambiguator: `S::h()`
    |
    = note: this link resolves to the associated function `h`, which is not in the type namespace
 
-error: aborting due to 12 previous errors
+error: aborting due to 10 previous errors
 

--- a/src/test/rustdoc-ui/intra-link-errors.stderr
+++ b/src/test/rustdoc-ui/intra-link-errors.stderr
@@ -9,7 +9,7 @@ note: the lint level is defined here
    |
 LL | #![deny(broken_intra_doc_links)]
    |         ^^^^^^^^^^^^^^^^^^^^^^
-   = note: no item named `path::to` is in scope
+   = note: no item named `path` is in scope
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 error: unresolved link to `std::io::not::here`
@@ -80,15 +80,19 @@ error: unresolved link to `S`
   --> $DIR/intra-link-errors.rs:45:6
    |
 LL | /// [S!]
-   |      ^^ help: to link to the struct, use its disambiguator: `struct@S`
+   |      ^^
    |
    = note: this link resolves to the struct `S`, which is not in the macro namespace
+help: to link to the struct, prefix with the item kind
+   |
+LL | /// [struct@S]
+   |      ^^^^^^^^
 
 error: unresolved link to `T::g`
   --> $DIR/intra-link-errors.rs:63:6
    |
 LL | /// [type@T::g]
-   |      ^^^^^^^^^ help: to link to the associated function, use its disambiguator: `T::g()`
+   |      ^^^^^^^^^ help: to link to the associated function, add parentheses: `T::g()`
    |
    = note: this link resolves to the associated function `g`, which is not in the type namespace
 
@@ -105,7 +109,7 @@ error: unresolved link to `S::h`
   --> $DIR/intra-link-errors.rs:55:6
    |
 LL | /// [type@S::h]
-   |      ^^^^^^^^^ help: to link to the associated function, use its disambiguator: `S::h()`
+   |      ^^^^^^^^^ help: to link to the associated function, add parentheses: `S::h()`
    |
    = note: this link resolves to the associated function `h`, which is not in the type namespace
 
@@ -113,7 +117,7 @@ error: unresolved link to `m`
   --> $DIR/intra-link-errors.rs:76:6
    |
 LL | /// [m()]
-   |      ^^^ help: to link to the macro, use its disambiguator: `m!`
+   |      ^^^ help: to link to the macro, add an exclamation mark: `m!`
    |
    = note: this link resolves to the macro `m`, which is not in the value namespace
 

--- a/src/test/rustdoc-ui/intra-link-errors.stderr
+++ b/src/test/rustdoc-ui/intra-link-errors.stderr
@@ -11,8 +11,24 @@ LL | #![deny(broken_intra_doc_links)]
    |         ^^^^^^^^^^^^^^^^^^^^^^
    = note: no item named `path` is in scope
 
-error: unresolved link to `std::io::not::here`
+error: unresolved link to `path::to::nonexistent::macro`
   --> $DIR/intra-link-errors.rs:11:6
+   |
+LL | /// [path::to::nonexistent::macro!]
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: no item named `path` is in scope
+
+error: unresolved link to `path::to::nonexistent::type`
+  --> $DIR/intra-link-errors.rs:15:6
+   |
+LL | /// [type@path::to::nonexistent::type]
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: no item named `path` is in scope
+
+error: unresolved link to `std::io::not::here`
+  --> $DIR/intra-link-errors.rs:19:6
    |
 LL | /// [std::io::not::here]
    |      ^^^^^^^^^^^^^^^^^^
@@ -20,7 +36,7 @@ LL | /// [std::io::not::here]
    = note: the module `io` has no inner item named `not`
 
 error: unresolved link to `std::io::Error::x`
-  --> $DIR/intra-link-errors.rs:15:6
+  --> $DIR/intra-link-errors.rs:23:6
    |
 LL | /// [std::io::Error::x]
    |      ^^^^^^^^^^^^^^^^^
@@ -28,7 +44,7 @@ LL | /// [std::io::Error::x]
    = note: the struct `Error` has no field or associated item named `x`
 
 error: unresolved link to `std::io::ErrorKind::x`
-  --> $DIR/intra-link-errors.rs:19:6
+  --> $DIR/intra-link-errors.rs:27:6
    |
 LL | /// [std::io::ErrorKind::x]
    |      ^^^^^^^^^^^^^^^^^^^^^
@@ -36,7 +52,7 @@ LL | /// [std::io::ErrorKind::x]
    = note: the enum `ErrorKind` has no variant or associated item named `x`
 
 error: unresolved link to `f::A`
-  --> $DIR/intra-link-errors.rs:23:6
+  --> $DIR/intra-link-errors.rs:31:6
    |
 LL | /// [f::A]
    |      ^^^^
@@ -44,7 +60,7 @@ LL | /// [f::A]
    = note: `f` is a function, not a module or type, and cannot have associated items
 
 error: unresolved link to `S::A`
-  --> $DIR/intra-link-errors.rs:27:6
+  --> $DIR/intra-link-errors.rs:35:6
    |
 LL | /// [S::A]
    |      ^^^^
@@ -52,7 +68,7 @@ LL | /// [S::A]
    = note: the struct `S` has no field or associated item named `A`
 
 error: unresolved link to `S::fmt`
-  --> $DIR/intra-link-errors.rs:31:6
+  --> $DIR/intra-link-errors.rs:39:6
    |
 LL | /// [S::fmt]
    |      ^^^^^^
@@ -60,7 +76,7 @@ LL | /// [S::fmt]
    = note: the struct `S` has no field or associated item named `fmt`
 
 error: unresolved link to `E::D`
-  --> $DIR/intra-link-errors.rs:35:6
+  --> $DIR/intra-link-errors.rs:43:6
    |
 LL | /// [E::D]
    |      ^^^^
@@ -68,7 +84,7 @@ LL | /// [E::D]
    = note: the enum `E` has no variant or associated item named `D`
 
 error: unresolved link to `u8::not_found`
-  --> $DIR/intra-link-errors.rs:39:6
+  --> $DIR/intra-link-errors.rs:47:6
    |
 LL | /// [u8::not_found]
    |      ^^^^^^^^^^^^^
@@ -76,7 +92,7 @@ LL | /// [u8::not_found]
    = note: the builtin type `u8` does not have an associated item named `not_found`
 
 error: unresolved link to `S`
-  --> $DIR/intra-link-errors.rs:43:6
+  --> $DIR/intra-link-errors.rs:51:6
    |
 LL | /// [S!]
    |      ^^ help: to link to the struct, prefix with `struct@`: `struct@S`
@@ -84,7 +100,7 @@ LL | /// [S!]
    = note: this link resolves to the struct `S`, which is not in the macro namespace
 
 error: unresolved link to `T::g`
-  --> $DIR/intra-link-errors.rs:61:6
+  --> $DIR/intra-link-errors.rs:69:6
    |
 LL | /// [type@T::g]
    |      ^^^^^^^^^ help: to link to the associated function, add parentheses: `T::g()`
@@ -92,7 +108,7 @@ LL | /// [type@T::g]
    = note: this link resolves to the associated function `g`, which is not in the type namespace
 
 error: unresolved link to `T::h`
-  --> $DIR/intra-link-errors.rs:66:6
+  --> $DIR/intra-link-errors.rs:74:6
    |
 LL | /// [T::h!]
    |      ^^^^^
@@ -100,7 +116,7 @@ LL | /// [T::h!]
    = note: the trait `T` has no macro named `h`
 
 error: unresolved link to `S::h`
-  --> $DIR/intra-link-errors.rs:53:6
+  --> $DIR/intra-link-errors.rs:61:6
    |
 LL | /// [type@S::h]
    |      ^^^^^^^^^ help: to link to the associated function, add parentheses: `S::h()`
@@ -108,12 +124,12 @@ LL | /// [type@S::h]
    = note: this link resolves to the associated function `h`, which is not in the type namespace
 
 error: unresolved link to `m`
-  --> $DIR/intra-link-errors.rs:73:6
+  --> $DIR/intra-link-errors.rs:81:6
    |
 LL | /// [m()]
    |      ^^^ help: to link to the macro, add an exclamation mark: `m!`
    |
    = note: this link resolves to the macro `m`, which is not in the value namespace
 
-error: aborting due to 14 previous errors
+error: aborting due to 16 previous errors
 

--- a/src/test/rustdoc-ui/intra-link-errors.stderr
+++ b/src/test/rustdoc-ui/intra-link-errors.stderr
@@ -97,7 +97,7 @@ error: unresolved link to `T::h`
 LL | /// [T::h!]
    |      ^^^^^
    |
-   = note: no item named `T::h` is in scope
+   = note: the trait `T` has no macro named `h`
 
 error: unresolved link to `S::h`
   --> $DIR/intra-link-errors.rs:54:6

--- a/src/test/rustdoc-ui/intra-link-errors.stderr
+++ b/src/test/rustdoc-ui/intra-link-errors.stderr
@@ -12,8 +12,32 @@ LL | #![deny(broken_intra_doc_links)]
    = note: no item named `path::to` is in scope
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
-error: unresolved link to `f::A`
+error: unresolved link to `std::io::not::here`
   --> $DIR/intra-link-errors.rs:13:6
+   |
+LL | /// [std::io::not::here]
+   |      ^^^^^^^^^^^^^^^^^^
+   |
+   = note: the module `io` has no inner item named `not`
+
+error: unresolved link to `std::io::Error::x`
+  --> $DIR/intra-link-errors.rs:17:6
+   |
+LL | /// [std::io::Error::x]
+   |      ^^^^^^^^^^^^^^^^^
+   |
+   = note: the struct `Error` has no field or associated item named `x`
+
+error: unresolved link to `std::io::ErrorKind::x`
+  --> $DIR/intra-link-errors.rs:21:6
+   |
+LL | /// [std::io::ErrorKind::x]
+   |      ^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: the enum `ErrorKind` has no variant or associated item named `x`
+
+error: unresolved link to `f::A`
+  --> $DIR/intra-link-errors.rs:25:6
    |
 LL | /// [f::A]
    |      ^^^^
@@ -21,7 +45,7 @@ LL | /// [f::A]
    = note: `f` is a function, not a module or type, and cannot have associated items
 
 error: unresolved link to `S::A`
-  --> $DIR/intra-link-errors.rs:17:6
+  --> $DIR/intra-link-errors.rs:29:6
    |
 LL | /// [S::A]
    |      ^^^^
@@ -29,7 +53,7 @@ LL | /// [S::A]
    = note: the struct `S` has no field or associated item named `A`
 
 error: unresolved link to `S::fmt`
-  --> $DIR/intra-link-errors.rs:21:6
+  --> $DIR/intra-link-errors.rs:33:6
    |
 LL | /// [S::fmt]
    |      ^^^^^^
@@ -37,7 +61,7 @@ LL | /// [S::fmt]
    = note: the struct `S` has no field or associated item named `fmt`
 
 error: unresolved link to `E::D`
-  --> $DIR/intra-link-errors.rs:25:6
+  --> $DIR/intra-link-errors.rs:37:6
    |
 LL | /// [E::D]
    |      ^^^^
@@ -45,7 +69,7 @@ LL | /// [E::D]
    = note: the enum `E` has no variant or associated item named `D`
 
 error: unresolved link to `u8::not_found`
-  --> $DIR/intra-link-errors.rs:29:6
+  --> $DIR/intra-link-errors.rs:41:6
    |
 LL | /// [u8::not_found]
    |      ^^^^^^^^^^^^^
@@ -53,7 +77,7 @@ LL | /// [u8::not_found]
    = note: the builtin type `u8` does not have an associated item named `not_found`
 
 error: unresolved link to `S`
-  --> $DIR/intra-link-errors.rs:33:6
+  --> $DIR/intra-link-errors.rs:45:6
    |
 LL | /// [S!]
    |      ^^ help: to link to the struct, use its disambiguator: `struct@S`
@@ -61,7 +85,7 @@ LL | /// [S!]
    = note: this link resolves to the struct `S`, which is not in the macro namespace
 
 error: unresolved link to `T::g`
-  --> $DIR/intra-link-errors.rs:51:6
+  --> $DIR/intra-link-errors.rs:63:6
    |
 LL | /// [type@T::g]
    |      ^^^^^^^^^ help: to link to the associated function, use its disambiguator: `T::g()`
@@ -69,7 +93,7 @@ LL | /// [type@T::g]
    = note: this link resolves to the associated function `g`, which is not in the type namespace
 
 error: unresolved link to `T::h`
-  --> $DIR/intra-link-errors.rs:56:6
+  --> $DIR/intra-link-errors.rs:68:6
    |
 LL | /// [T::h!]
    |      ^^^^^
@@ -78,12 +102,20 @@ LL | /// [T::h!]
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 error: unresolved link to `S::h`
-  --> $DIR/intra-link-errors.rs:43:6
+  --> $DIR/intra-link-errors.rs:55:6
    |
 LL | /// [type@S::h]
    |      ^^^^^^^^^ help: to link to the associated function, use its disambiguator: `S::h()`
    |
    = note: this link resolves to the associated function `h`, which is not in the type namespace
 
-error: aborting due to 10 previous errors
+error: unresolved link to `m`
+  --> $DIR/intra-link-errors.rs:76:6
+   |
+LL | /// [m()]
+   |      ^^^ help: to link to the macro, use its disambiguator: `m!`
+   |
+   = note: this link resolves to the macro `m`, which is not in the value namespace
+
+error: aborting due to 14 previous errors
 

--- a/src/test/rustdoc-ui/intra-link-errors.stderr
+++ b/src/test/rustdoc-ui/intra-link-errors.stderr
@@ -1,19 +1,39 @@
-error: unresolved link to `path::to::nonexistent::module`
-  --> $DIR/intra-link-errors.rs:8:6
+error: unresolved link to `std::io::oops`
+  --> $DIR/intra-link-errors.rs:4:6
    |
-LL | /// [path::to::nonexistent::module]
-   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | //! [std::io::oops]
+   |      ^^^^^^^^^^^^^
    |
 note: the lint level is defined here
   --> $DIR/intra-link-errors.rs:1:9
    |
 LL | #![deny(broken_intra_doc_links)]
    |         ^^^^^^^^^^^^^^^^^^^^^^
+   = note: this link resolves to the crate `std`, which is not an enum
+   = note: if this were an enum, it might have a variant which resolved
+   = note: this link partially resolves to the module `io`
+   = note: `io` has no field, variant, or associated item named `oops`
+
+error: unresolved link to `std::io::oops::not::here`
+  --> $DIR/intra-link-errors.rs:5:6
+   |
+LL | //! [std::io::oops::not::here]
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: no item named `std::io::oops::not` is in scope
+   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
+
+error: unresolved link to `path::to::nonexistent::module`
+  --> $DIR/intra-link-errors.rs:11:6
+   |
+LL | /// [path::to::nonexistent::module]
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
    = note: no item named `path::to::nonexistent` is in scope
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 error: unresolved link to `f::A`
-  --> $DIR/intra-link-errors.rs:14:6
+  --> $DIR/intra-link-errors.rs:17:6
    |
 LL | /// [f::A]
    |      ^^^^
@@ -22,34 +42,34 @@ LL | /// [f::A]
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 error: unresolved link to `S::A`
-  --> $DIR/intra-link-errors.rs:19:6
+  --> $DIR/intra-link-errors.rs:22:6
    |
 LL | /// [S::A]
    |      ^^^^
    |
-   = note: this link partially resolves to the struct `S`,
+   = note: this link partially resolves to the struct `S`
    = note: `S` has no field, variant, or associated item named `A`
 
 error: unresolved link to `S::fmt`
-  --> $DIR/intra-link-errors.rs:24:6
+  --> $DIR/intra-link-errors.rs:27:6
    |
 LL | /// [S::fmt]
    |      ^^^^^^
    |
-   = note: this link partially resolves to the struct `S`,
+   = note: this link partially resolves to the struct `S`
    = note: `S` has no field, variant, or associated item named `fmt`
 
 error: unresolved link to `E::D`
-  --> $DIR/intra-link-errors.rs:29:6
+  --> $DIR/intra-link-errors.rs:32:6
    |
 LL | /// [E::D]
    |      ^^^^
    |
-   = note: this link partially resolves to the enum `E`,
+   = note: this link partially resolves to the enum `E`
    = note: `E` has no field, variant, or associated item named `D`
 
 error: unresolved link to `u8::not_found`
-  --> $DIR/intra-link-errors.rs:34:6
+  --> $DIR/intra-link-errors.rs:37:6
    |
 LL | /// [u8::not_found]
    |      ^^^^^^^^^^^^^
@@ -57,12 +77,30 @@ LL | /// [u8::not_found]
    = note: the builtin type `u8` does not have an associated item named `not_found`
 
 error: unresolved link to `S`
-  --> $DIR/intra-link-errors.rs:38:6
+  --> $DIR/intra-link-errors.rs:41:6
    |
 LL | /// [S!]
    |      ^^ help: to link to the unit struct, use its disambiguator: `value@S`
    |
-   = note: this link resolves to the unit struct `S`, which is not in the value namespace
+   = note: this link resolves to the unit struct `S`, which is not in the macro namespace
 
-error: aborting due to 7 previous errors
+error: unresolved link to `T::g`
+  --> $DIR/intra-link-errors.rs:56:6
+   |
+LL | /// [type@T::g]
+   |      ^^^^^^^^^
+   |
+   = note: this link partially resolves to the trait `T`
+   = note: `T` has no field, variant, or associated item named `g`
+
+error: unresolved link to `S::h`
+  --> $DIR/intra-link-errors.rs:51:6
+   |
+LL | /// [type@S::h]
+   |      ^^^^^^^^^
+   |
+   = note: this link partially resolves to the struct `S`
+   = note: `S` has no field, variant, or associated item named `h`
+
+error: aborting due to 11 previous errors
 

--- a/src/test/rustdoc-ui/intra-link-errors.stderr
+++ b/src/test/rustdoc-ui/intra-link-errors.stderr
@@ -1,5 +1,5 @@
 error: unresolved link to `path::to::nonexistent::module`
-  --> $DIR/intra-link-errors.rs:8:6
+  --> $DIR/intra-link-errors.rs:7:6
    |
 LL | /// [path::to::nonexistent::module]
    |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -12,7 +12,7 @@ LL | #![deny(broken_intra_doc_links)]
    = note: no item named `path` is in scope
 
 error: unresolved link to `std::io::not::here`
-  --> $DIR/intra-link-errors.rs:12:6
+  --> $DIR/intra-link-errors.rs:11:6
    |
 LL | /// [std::io::not::here]
    |      ^^^^^^^^^^^^^^^^^^
@@ -20,7 +20,7 @@ LL | /// [std::io::not::here]
    = note: the module `io` has no inner item named `not`
 
 error: unresolved link to `std::io::Error::x`
-  --> $DIR/intra-link-errors.rs:16:6
+  --> $DIR/intra-link-errors.rs:15:6
    |
 LL | /// [std::io::Error::x]
    |      ^^^^^^^^^^^^^^^^^
@@ -28,7 +28,7 @@ LL | /// [std::io::Error::x]
    = note: the struct `Error` has no field or associated item named `x`
 
 error: unresolved link to `std::io::ErrorKind::x`
-  --> $DIR/intra-link-errors.rs:20:6
+  --> $DIR/intra-link-errors.rs:19:6
    |
 LL | /// [std::io::ErrorKind::x]
    |      ^^^^^^^^^^^^^^^^^^^^^
@@ -36,7 +36,7 @@ LL | /// [std::io::ErrorKind::x]
    = note: the enum `ErrorKind` has no variant or associated item named `x`
 
 error: unresolved link to `f::A`
-  --> $DIR/intra-link-errors.rs:24:6
+  --> $DIR/intra-link-errors.rs:23:6
    |
 LL | /// [f::A]
    |      ^^^^
@@ -44,7 +44,7 @@ LL | /// [f::A]
    = note: `f` is a function, not a module or type, and cannot have associated items
 
 error: unresolved link to `S::A`
-  --> $DIR/intra-link-errors.rs:28:6
+  --> $DIR/intra-link-errors.rs:27:6
    |
 LL | /// [S::A]
    |      ^^^^
@@ -52,7 +52,7 @@ LL | /// [S::A]
    = note: the struct `S` has no field or associated item named `A`
 
 error: unresolved link to `S::fmt`
-  --> $DIR/intra-link-errors.rs:32:6
+  --> $DIR/intra-link-errors.rs:31:6
    |
 LL | /// [S::fmt]
    |      ^^^^^^
@@ -60,7 +60,7 @@ LL | /// [S::fmt]
    = note: the struct `S` has no field or associated item named `fmt`
 
 error: unresolved link to `E::D`
-  --> $DIR/intra-link-errors.rs:36:6
+  --> $DIR/intra-link-errors.rs:35:6
    |
 LL | /// [E::D]
    |      ^^^^
@@ -68,7 +68,7 @@ LL | /// [E::D]
    = note: the enum `E` has no variant or associated item named `D`
 
 error: unresolved link to `u8::not_found`
-  --> $DIR/intra-link-errors.rs:40:6
+  --> $DIR/intra-link-errors.rs:39:6
    |
 LL | /// [u8::not_found]
    |      ^^^^^^^^^^^^^
@@ -76,7 +76,7 @@ LL | /// [u8::not_found]
    = note: the builtin type `u8` does not have an associated item named `not_found`
 
 error: unresolved link to `S`
-  --> $DIR/intra-link-errors.rs:44:6
+  --> $DIR/intra-link-errors.rs:43:6
    |
 LL | /// [S!]
    |      ^^ help: to link to the struct, prefix with `struct@`: `struct@S`
@@ -84,7 +84,7 @@ LL | /// [S!]
    = note: this link resolves to the struct `S`, which is not in the macro namespace
 
 error: unresolved link to `T::g`
-  --> $DIR/intra-link-errors.rs:62:6
+  --> $DIR/intra-link-errors.rs:61:6
    |
 LL | /// [type@T::g]
    |      ^^^^^^^^^ help: to link to the associated function, add parentheses: `T::g()`
@@ -92,7 +92,7 @@ LL | /// [type@T::g]
    = note: this link resolves to the associated function `g`, which is not in the type namespace
 
 error: unresolved link to `T::h`
-  --> $DIR/intra-link-errors.rs:67:6
+  --> $DIR/intra-link-errors.rs:66:6
    |
 LL | /// [T::h!]
    |      ^^^^^
@@ -100,7 +100,7 @@ LL | /// [T::h!]
    = note: the trait `T` has no macro named `h`
 
 error: unresolved link to `S::h`
-  --> $DIR/intra-link-errors.rs:54:6
+  --> $DIR/intra-link-errors.rs:53:6
    |
 LL | /// [type@S::h]
    |      ^^^^^^^^^ help: to link to the associated function, add parentheses: `S::h()`
@@ -108,7 +108,7 @@ LL | /// [type@S::h]
    = note: this link resolves to the associated function `h`, which is not in the type namespace
 
 error: unresolved link to `m`
-  --> $DIR/intra-link-errors.rs:74:6
+  --> $DIR/intra-link-errors.rs:73:6
    |
 LL | /// [m()]
    |      ^^^ help: to link to the macro, add an exclamation mark: `m!`

--- a/src/test/rustdoc-ui/intra-link-errors.stderr
+++ b/src/test/rustdoc-ui/intra-link-errors.stderr
@@ -10,10 +10,9 @@ note: the lint level is defined here
 LL | #![deny(broken_intra_doc_links)]
    |         ^^^^^^^^^^^^^^^^^^^^^^
    = note: no item named `path` is in scope
-   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 error: unresolved link to `std::io::not::here`
-  --> $DIR/intra-link-errors.rs:13:6
+  --> $DIR/intra-link-errors.rs:12:6
    |
 LL | /// [std::io::not::here]
    |      ^^^^^^^^^^^^^^^^^^
@@ -21,7 +20,7 @@ LL | /// [std::io::not::here]
    = note: the module `io` has no inner item named `not`
 
 error: unresolved link to `std::io::Error::x`
-  --> $DIR/intra-link-errors.rs:17:6
+  --> $DIR/intra-link-errors.rs:16:6
    |
 LL | /// [std::io::Error::x]
    |      ^^^^^^^^^^^^^^^^^
@@ -29,7 +28,7 @@ LL | /// [std::io::Error::x]
    = note: the struct `Error` has no field or associated item named `x`
 
 error: unresolved link to `std::io::ErrorKind::x`
-  --> $DIR/intra-link-errors.rs:21:6
+  --> $DIR/intra-link-errors.rs:20:6
    |
 LL | /// [std::io::ErrorKind::x]
    |      ^^^^^^^^^^^^^^^^^^^^^
@@ -37,7 +36,7 @@ LL | /// [std::io::ErrorKind::x]
    = note: the enum `ErrorKind` has no variant or associated item named `x`
 
 error: unresolved link to `f::A`
-  --> $DIR/intra-link-errors.rs:25:6
+  --> $DIR/intra-link-errors.rs:24:6
    |
 LL | /// [f::A]
    |      ^^^^
@@ -45,7 +44,7 @@ LL | /// [f::A]
    = note: `f` is a function, not a module or type, and cannot have associated items
 
 error: unresolved link to `S::A`
-  --> $DIR/intra-link-errors.rs:29:6
+  --> $DIR/intra-link-errors.rs:28:6
    |
 LL | /// [S::A]
    |      ^^^^
@@ -53,7 +52,7 @@ LL | /// [S::A]
    = note: the struct `S` has no field or associated item named `A`
 
 error: unresolved link to `S::fmt`
-  --> $DIR/intra-link-errors.rs:33:6
+  --> $DIR/intra-link-errors.rs:32:6
    |
 LL | /// [S::fmt]
    |      ^^^^^^
@@ -61,7 +60,7 @@ LL | /// [S::fmt]
    = note: the struct `S` has no field or associated item named `fmt`
 
 error: unresolved link to `E::D`
-  --> $DIR/intra-link-errors.rs:37:6
+  --> $DIR/intra-link-errors.rs:36:6
    |
 LL | /// [E::D]
    |      ^^^^
@@ -69,7 +68,7 @@ LL | /// [E::D]
    = note: the enum `E` has no variant or associated item named `D`
 
 error: unresolved link to `u8::not_found`
-  --> $DIR/intra-link-errors.rs:41:6
+  --> $DIR/intra-link-errors.rs:40:6
    |
 LL | /// [u8::not_found]
    |      ^^^^^^^^^^^^^
@@ -77,7 +76,7 @@ LL | /// [u8::not_found]
    = note: the builtin type `u8` does not have an associated item named `not_found`
 
 error: unresolved link to `S`
-  --> $DIR/intra-link-errors.rs:45:6
+  --> $DIR/intra-link-errors.rs:44:6
    |
 LL | /// [S!]
    |      ^^
@@ -89,7 +88,7 @@ LL | /// [struct@S]
    |      ^^^^^^^^
 
 error: unresolved link to `T::g`
-  --> $DIR/intra-link-errors.rs:63:6
+  --> $DIR/intra-link-errors.rs:62:6
    |
 LL | /// [type@T::g]
    |      ^^^^^^^^^ help: to link to the associated function, add parentheses: `T::g()`
@@ -97,16 +96,15 @@ LL | /// [type@T::g]
    = note: this link resolves to the associated function `g`, which is not in the type namespace
 
 error: unresolved link to `T::h`
-  --> $DIR/intra-link-errors.rs:68:6
+  --> $DIR/intra-link-errors.rs:67:6
    |
 LL | /// [T::h!]
    |      ^^^^^
    |
    = note: no item named `T::h` is in scope
-   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 error: unresolved link to `S::h`
-  --> $DIR/intra-link-errors.rs:55:6
+  --> $DIR/intra-link-errors.rs:54:6
    |
 LL | /// [type@S::h]
    |      ^^^^^^^^^ help: to link to the associated function, add parentheses: `S::h()`
@@ -114,7 +112,7 @@ LL | /// [type@S::h]
    = note: this link resolves to the associated function `h`, which is not in the type namespace
 
 error: unresolved link to `m`
-  --> $DIR/intra-link-errors.rs:76:6
+  --> $DIR/intra-link-errors.rs:74:6
    |
 LL | /// [m()]
    |      ^^^ help: to link to the macro, add an exclamation mark: `m!`

--- a/src/test/rustdoc-ui/intra-link-errors.stderr
+++ b/src/test/rustdoc-ui/intra-link-errors.stderr
@@ -1,0 +1,68 @@
+error: unresolved link to `path::to::nonexistent::module`
+  --> $DIR/intra-link-errors.rs:8:6
+   |
+LL | /// [path::to::nonexistent::module]
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/intra-link-errors.rs:1:9
+   |
+LL | #![deny(broken_intra_doc_links)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^
+   = note: no item named `path::to::nonexistent` is in scope
+   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
+
+error: unresolved link to `f::A`
+  --> $DIR/intra-link-errors.rs:14:6
+   |
+LL | /// [f::A]
+   |      ^^^^
+   |
+   = note: no item named `f` is in scope
+   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
+
+error: unresolved link to `S::A`
+  --> $DIR/intra-link-errors.rs:19:6
+   |
+LL | /// [S::A]
+   |      ^^^^
+   |
+   = note: this link partially resolves to the struct `S`,
+   = note: `S` has no field, variant, or associated item named `A`
+
+error: unresolved link to `S::fmt`
+  --> $DIR/intra-link-errors.rs:24:6
+   |
+LL | /// [S::fmt]
+   |      ^^^^^^
+   |
+   = note: this link partially resolves to the struct `S`,
+   = note: `S` has no field, variant, or associated item named `fmt`
+
+error: unresolved link to `E::D`
+  --> $DIR/intra-link-errors.rs:29:6
+   |
+LL | /// [E::D]
+   |      ^^^^
+   |
+   = note: this link partially resolves to the enum `E`,
+   = note: `E` has no field, variant, or associated item named `D`
+
+error: unresolved link to `u8::not_found`
+  --> $DIR/intra-link-errors.rs:34:6
+   |
+LL | /// [u8::not_found]
+   |      ^^^^^^^^^^^^^
+   |
+   = note: the builtin type `u8` does not have an associated item named `not_found`
+
+error: unresolved link to `S`
+  --> $DIR/intra-link-errors.rs:38:6
+   |
+LL | /// [S!]
+   |      ^^ help: to link to the unit struct, use its disambiguator: `value@S`
+   |
+   = note: this link resolves to the unit struct `S`, which is not in the value namespace
+
+error: aborting due to 7 previous errors
+

--- a/src/test/rustdoc-ui/intra-link-errors.stderr
+++ b/src/test/rustdoc-ui/intra-link-errors.stderr
@@ -9,7 +9,7 @@ note: the lint level is defined here
    |
 LL | #![deny(broken_intra_doc_links)]
    |         ^^^^^^^^^^^^^^^^^^^^^^
-   = note: no item named `path::to::nonexistent` is in scope
+   = note: no item named `path::to` is in scope
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 error: unresolved link to `f::A`
@@ -18,8 +18,8 @@ error: unresolved link to `f::A`
 LL | /// [f::A]
    |      ^^^^
    |
-   = note: no item named `f` is in scope
-   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
+   = note: this link partially resolves to the function `f`
+   = note: `f` is a function, not a module or type, and cannot have associated items
 
 error: unresolved link to `S::A`
   --> $DIR/intra-link-errors.rs:19:6

--- a/src/test/rustdoc-ui/intra-link-errors.stderr
+++ b/src/test/rustdoc-ui/intra-link-errors.stderr
@@ -2,134 +2,115 @@ error: unresolved link to `path::to::nonexistent::module`
   --> $DIR/intra-link-errors.rs:7:6
    |
 LL | /// [path::to::nonexistent::module]
-   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no item named `path` in `intra_link_errors`
    |
 note: the lint level is defined here
   --> $DIR/intra-link-errors.rs:1:9
    |
 LL | #![deny(broken_intra_doc_links)]
    |         ^^^^^^^^^^^^^^^^^^^^^^
-   = note: no item named `path` is in scope
 
 error: unresolved link to `path::to::nonexistent::macro`
   --> $DIR/intra-link-errors.rs:11:6
    |
 LL | /// [path::to::nonexistent::macro!]
-   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: no item named `path` is in scope
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no item named `path` in `intra_link_errors`
 
 error: unresolved link to `path::to::nonexistent::type`
   --> $DIR/intra-link-errors.rs:15:6
    |
 LL | /// [type@path::to::nonexistent::type]
-   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: no item named `path` is in scope
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no item named `path` in `intra_link_errors`
 
 error: unresolved link to `std::io::not::here`
   --> $DIR/intra-link-errors.rs:19:6
    |
 LL | /// [std::io::not::here]
-   |      ^^^^^^^^^^^^^^^^^^
-   |
-   = note: the module `io` has no inner item named `not`
+   |      ^^^^^^^^^^^^^^^^^^ the module `io` has no inner item named `not`
 
 error: unresolved link to `std::io::Error::x`
   --> $DIR/intra-link-errors.rs:23:6
    |
 LL | /// [std::io::Error::x]
-   |      ^^^^^^^^^^^^^^^^^
-   |
-   = note: the struct `Error` has no field or associated item named `x`
+   |      ^^^^^^^^^^^^^^^^^ the struct `Error` has no field or associated item named `x`
 
 error: unresolved link to `std::io::ErrorKind::x`
   --> $DIR/intra-link-errors.rs:27:6
    |
 LL | /// [std::io::ErrorKind::x]
-   |      ^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: the enum `ErrorKind` has no variant or associated item named `x`
+   |      ^^^^^^^^^^^^^^^^^^^^^ the enum `ErrorKind` has no variant or associated item named `x`
 
 error: unresolved link to `f::A`
   --> $DIR/intra-link-errors.rs:31:6
    |
 LL | /// [f::A]
-   |      ^^^^
-   |
-   = note: `f` is a function, not a module or type, and cannot have associated items
+   |      ^^^^ `f` is a function, not a module or type, and cannot have associated items
 
 error: unresolved link to `S::A`
   --> $DIR/intra-link-errors.rs:35:6
    |
 LL | /// [S::A]
-   |      ^^^^
-   |
-   = note: the struct `S` has no field or associated item named `A`
+   |      ^^^^ the struct `S` has no field or associated item named `A`
 
 error: unresolved link to `S::fmt`
   --> $DIR/intra-link-errors.rs:39:6
    |
 LL | /// [S::fmt]
-   |      ^^^^^^
-   |
-   = note: the struct `S` has no field or associated item named `fmt`
+   |      ^^^^^^ the struct `S` has no field or associated item named `fmt`
 
 error: unresolved link to `E::D`
   --> $DIR/intra-link-errors.rs:43:6
    |
 LL | /// [E::D]
-   |      ^^^^
-   |
-   = note: the enum `E` has no variant or associated item named `D`
+   |      ^^^^ the enum `E` has no variant or associated item named `D`
 
 error: unresolved link to `u8::not_found`
   --> $DIR/intra-link-errors.rs:47:6
    |
 LL | /// [u8::not_found]
-   |      ^^^^^^^^^^^^^
-   |
-   = note: the builtin type `u8` does not have an associated item named `not_found`
+   |      ^^^^^^^^^^^^^ the builtin type `u8` does not have an associated item named `not_found`
 
 error: unresolved link to `S`
   --> $DIR/intra-link-errors.rs:51:6
    |
 LL | /// [S!]
-   |      ^^ help: to link to the struct, prefix with `struct@`: `struct@S`
-   |
-   = note: this link resolves to the struct `S`, which is not in the macro namespace
+   |      ^^
+   |      |
+   |      this link resolves to the struct `S`, which is not in the macro namespace
+   |      help: to link to the struct, prefix with `struct@`: `struct@S`
 
 error: unresolved link to `T::g`
   --> $DIR/intra-link-errors.rs:69:6
    |
 LL | /// [type@T::g]
-   |      ^^^^^^^^^ help: to link to the associated function, add parentheses: `T::g()`
-   |
-   = note: this link resolves to the associated function `g`, which is not in the type namespace
+   |      ^^^^^^^^^
+   |      |
+   |      this link resolves to the associated function `g`, which is not in the type namespace
+   |      help: to link to the associated function, add parentheses: `T::g()`
 
 error: unresolved link to `T::h`
   --> $DIR/intra-link-errors.rs:74:6
    |
 LL | /// [T::h!]
-   |      ^^^^^
-   |
-   = note: the trait `T` has no macro named `h`
+   |      ^^^^^ the trait `T` has no macro named `h`
 
 error: unresolved link to `S::h`
   --> $DIR/intra-link-errors.rs:61:6
    |
 LL | /// [type@S::h]
-   |      ^^^^^^^^^ help: to link to the associated function, add parentheses: `S::h()`
-   |
-   = note: this link resolves to the associated function `h`, which is not in the type namespace
+   |      ^^^^^^^^^
+   |      |
+   |      this link resolves to the associated function `h`, which is not in the type namespace
+   |      help: to link to the associated function, add parentheses: `S::h()`
 
 error: unresolved link to `m`
   --> $DIR/intra-link-errors.rs:81:6
    |
 LL | /// [m()]
-   |      ^^^ help: to link to the macro, add an exclamation mark: `m!`
-   |
-   = note: this link resolves to the macro `m`, which is not in the value namespace
+   |      ^^^
+   |      |
+   |      this link resolves to the macro `m`, which is not in the value namespace
+   |      help: to link to the macro, add an exclamation mark: `m!`
 
 error: aborting due to 16 previous errors
 

--- a/src/test/rustdoc-ui/intra-link-errors.stderr
+++ b/src/test/rustdoc-ui/intra-link-errors.stderr
@@ -79,13 +79,9 @@ error: unresolved link to `S`
   --> $DIR/intra-link-errors.rs:44:6
    |
 LL | /// [S!]
-   |      ^^
+   |      ^^ help: to link to the struct, prefix with `struct@`: `struct@S`
    |
    = note: this link resolves to the struct `S`, which is not in the macro namespace
-help: to link to the struct, prefix with the item kind
-   |
-LL | /// [struct@S]
-   |      ^^^^^^^^
 
 error: unresolved link to `T::g`
   --> $DIR/intra-link-errors.rs:62:6

--- a/src/test/rustdoc-ui/intra-link-prim-conflict.rs
+++ b/src/test/rustdoc-ui/intra-link-prim-conflict.rs
@@ -18,13 +18,13 @@
 
 /// [struct@char]
 //~^ ERROR incompatible link
-//~| HELP prefix with the item kind
+//~| HELP prefix with `mod@`
 //~| NOTE resolved to a module
 pub mod char {}
 
 pub mod inner {
     //! [struct@char]
     //~^ ERROR incompatible link
-    //~| HELP prefix with the item kind
+    //~| HELP prefix with `prim@`
     //~| NOTE resolved to a builtin type
 }

--- a/src/test/rustdoc-ui/intra-link-prim-conflict.stderr
+++ b/src/test/rustdoc-ui/intra-link-prim-conflict.stderr
@@ -9,11 +9,11 @@ note: the lint level is defined here
    |
 LL | #![deny(broken_intra_doc_links)]
    |         ^^^^^^^^^^^^^^^^^^^^^^
-help: to link to the module, prefix with the item kind
+help: to link to the module, prefix with `mod@`
    |
 LL | /// [mod@char]
    |      ^^^^^^^^
-help: to link to the builtin type, prefix with the item kind
+help: to link to the builtin type, prefix with `prim@`
    |
 LL | /// [prim@char]
    |      ^^^^^^^^^
@@ -24,11 +24,11 @@ error: `char` is both a module and a builtin type
 LL | /// [type@char]
    |      ^^^^^^^^^ ambiguous link
    |
-help: to link to the module, prefix with the item kind
+help: to link to the module, prefix with `mod@`
    |
 LL | /// [mod@char]
    |      ^^^^^^^^
-help: to link to the builtin type, prefix with the item kind
+help: to link to the builtin type, prefix with `prim@`
    |
 LL | /// [prim@char]
    |      ^^^^^^^^^
@@ -37,25 +37,17 @@ error: incompatible link kind for `char`
   --> $DIR/intra-link-prim-conflict.rs:19:6
    |
 LL | /// [struct@char]
-   |      ^^^^^^^^^^^
+   |      ^^^^^^^^^^^ help: to link to the module, prefix with `mod@`: `mod@char`
    |
    = note: this link resolved to a module, which is not a struct
-help: to link to the module, prefix with the item kind
-   |
-LL | /// [mod@char]
-   |      ^^^^^^^^
 
 error: incompatible link kind for `char`
   --> $DIR/intra-link-prim-conflict.rs:26:10
    |
 LL |     //! [struct@char]
-   |          ^^^^^^^^^^^
+   |          ^^^^^^^^^^^ help: to link to the builtin type, prefix with `prim@`: `prim@char`
    |
    = note: this link resolved to a builtin type, which is not a struct
-help: to link to the builtin type, prefix with the item kind
-   |
-LL |     //! [prim@char]
-   |          ^^^^^^^^^
 
 error: aborting due to 4 previous errors
 

--- a/src/test/rustdoc-ui/intra-link-span-ice-55723.stderr
+++ b/src/test/rustdoc-ui/intra-link-span-ice-55723.stderr
@@ -2,14 +2,13 @@ error: unresolved link to `i`
   --> $DIR/intra-link-span-ice-55723.rs:9:10
    |
 LL | /// （arr[i]）
-   |           ^
+   |           ^ no item named `i` in `intra_link_span_ice_55723`
    |
 note: the lint level is defined here
   --> $DIR/intra-link-span-ice-55723.rs:1:9
    |
 LL | #![deny(broken_intra_doc_links)]
    |         ^^^^^^^^^^^^^^^^^^^^^^
-   = note: no item named `i` is in scope
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 error: aborting due to previous error

--- a/src/test/rustdoc-ui/intra-link-span-ice-55723.stderr
+++ b/src/test/rustdoc-ui/intra-link-span-ice-55723.stderr
@@ -2,13 +2,14 @@ error: unresolved link to `i`
   --> $DIR/intra-link-span-ice-55723.rs:9:10
    |
 LL | /// （arr[i]）
-   |           ^ unresolved link
+   |           ^
    |
 note: the lint level is defined here
   --> $DIR/intra-link-span-ice-55723.rs:1:9
    |
 LL | #![deny(broken_intra_doc_links)]
    |         ^^^^^^^^^^^^^^^^^^^^^^
+   = note: no item named `i` is in scope
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 error: aborting due to previous error

--- a/src/test/rustdoc-ui/intra-links-ambiguity.stderr
+++ b/src/test/rustdoc-ui/intra-links-ambiguity.stderr
@@ -9,7 +9,7 @@ note: the lint level is defined here
    |
 LL | #![deny(broken_intra_doc_links)]
    |         ^^^^^^^^^^^^^^^^^^^^^^
-help: to link to the struct, prefix with the item kind
+help: to link to the struct, prefix with `struct@`
    |
 LL | /// [`struct@ambiguous`] is ambiguous.
    |      ^^^^^^^^^^^^^^^^^^
@@ -24,7 +24,7 @@ error: `ambiguous` is both a struct and a function
 LL | /// [ambiguous] is ambiguous.
    |      ^^^^^^^^^ ambiguous link
    |
-help: to link to the struct, prefix with the item kind
+help: to link to the struct, prefix with `struct@`
    |
 LL | /// [struct@ambiguous] is ambiguous.
    |      ^^^^^^^^^^^^^^^^
@@ -39,7 +39,7 @@ error: `multi_conflict` is a struct, a function, and a macro
 LL | /// [`multi_conflict`] is a three-way conflict.
    |      ^^^^^^^^^^^^^^^^ ambiguous link
    |
-help: to link to the struct, prefix with the item kind
+help: to link to the struct, prefix with `struct@`
    |
 LL | /// [`struct@multi_conflict`] is a three-way conflict.
    |      ^^^^^^^^^^^^^^^^^^^^^^^
@@ -58,11 +58,11 @@ error: `type_and_value` is both a module and a constant
 LL | /// Ambiguous [type_and_value].
    |                ^^^^^^^^^^^^^^ ambiguous link
    |
-help: to link to the module, prefix with the item kind
+help: to link to the module, prefix with `mod@`
    |
 LL | /// Ambiguous [mod@type_and_value].
    |                ^^^^^^^^^^^^^^^^^^
-help: to link to the constant, prefix with the item kind
+help: to link to the constant, prefix with `const@`
    |
 LL | /// Ambiguous [const@type_and_value].
    |                ^^^^^^^^^^^^^^^^^^^^
@@ -73,7 +73,7 @@ error: `foo::bar` is both an enum and a function
 LL | /// Ambiguous non-implied shortcut link [`foo::bar`].
    |                                          ^^^^^^^^^^ ambiguous link
    |
-help: to link to the enum, prefix with the item kind
+help: to link to the enum, prefix with `enum@`
    |
 LL | /// Ambiguous non-implied shortcut link [`enum@foo::bar`].
    |                                          ^^^^^^^^^^^^^^^

--- a/src/test/rustdoc-ui/intra-links-anchors.stderr
+++ b/src/test/rustdoc-ui/intra-links-anchors.stderr
@@ -1,4 +1,4 @@
-error: `Foo::f#hola` contains an anchor, but links to struct fields are already anchored
+error: `Foo::f#hola` contains an anchor, but links to fields are already anchored
   --> $DIR/intra-links-anchors.rs:25:15
    |
 LL | /// Or maybe [Foo::f#hola].
@@ -16,13 +16,13 @@ error: `hello#people#!` contains multiple anchors
 LL | /// Another anchor error: [hello#people#!].
    |                            ^^^^^^^^^^^^^^ contains invalid anchor
 
-error: `Enum::A#whatever` contains an anchor, but links to enum variants are already anchored
+error: `Enum::A#whatever` contains an anchor, but links to variants are already anchored
   --> $DIR/intra-links-anchors.rs:37:28
    |
 LL | /// Damn enum's variants: [Enum::A#whatever].
    |                            ^^^^^^^^^^^^^^^^ contains invalid anchor
 
-error: `u32#hello` contains an anchor, but links to primitive types are already anchored
+error: `u32#hello` contains an anchor, but links to builtin types are already anchored
   --> $DIR/intra-links-anchors.rs:43:6
    |
 LL | /// [u32#hello]

--- a/src/test/rustdoc-ui/intra-links-disambiguator-mismatch.rs
+++ b/src/test/rustdoc-ui/intra-links-disambiguator-mismatch.rs
@@ -14,27 +14,27 @@ trait T {}
 /// Link to [struct@S]
 //~^ ERROR incompatible link kind for `S`
 //~| NOTE this link resolved
-//~| HELP prefix with the item kind
+//~| HELP prefix with `enum@`
 
 /// Link to [mod@S]
 //~^ ERROR incompatible link kind for `S`
 //~| NOTE this link resolved
-//~| HELP prefix with the item kind
+//~| HELP prefix with `enum@`
 
 /// Link to [union@S]
 //~^ ERROR incompatible link kind for `S`
 //~| NOTE this link resolved
-//~| HELP prefix with the item kind
+//~| HELP prefix with `enum@`
 
 /// Link to [trait@S]
 //~^ ERROR incompatible link kind for `S`
 //~| NOTE this link resolved
-//~| HELP prefix with the item kind
+//~| HELP prefix with `enum@`
 
 /// Link to [struct@T]
 //~^ ERROR incompatible link kind for `T`
 //~| NOTE this link resolved
-//~| HELP prefix with the item kind
+//~| HELP prefix with `trait@`
 
 /// Link to [derive@m]
 //~^ ERROR incompatible link kind for `m`
@@ -44,22 +44,22 @@ trait T {}
 /// Link to [const@s]
 //~^ ERROR incompatible link kind for `s`
 //~| NOTE this link resolved
-//~| HELP prefix with the item kind
+//~| HELP prefix with `static@`
 
 /// Link to [static@c]
 //~^ ERROR incompatible link kind for `c`
 //~| NOTE this link resolved
-//~| HELP prefix with the item kind
+//~| HELP prefix with `const@`
 
 /// Link to [fn@c]
 //~^ ERROR incompatible link kind for `c`
 //~| NOTE this link resolved
-//~| HELP prefix with the item kind
+//~| HELP prefix with `const@`
 
 /// Link to [c()]
 //~^ ERROR incompatible link kind for `c`
 //~| NOTE this link resolved
-//~| HELP prefix with the item kind
+//~| HELP prefix with `const@`
 
 /// Link to [const@f]
 //~^ ERROR incompatible link kind for `f`

--- a/src/test/rustdoc-ui/intra-links-disambiguator-mismatch.stderr
+++ b/src/test/rustdoc-ui/intra-links-disambiguator-mismatch.stderr
@@ -2,7 +2,7 @@ error: incompatible link kind for `S`
   --> $DIR/intra-links-disambiguator-mismatch.rs:14:14
    |
 LL | /// Link to [struct@S]
-   |              ^^^^^^^^
+   |              ^^^^^^^^ help: to link to the enum, prefix with `enum@`: `enum@S`
    |
 note: the lint level is defined here
   --> $DIR/intra-links-disambiguator-mismatch.rs:1:9
@@ -10,58 +10,38 @@ note: the lint level is defined here
 LL | #![deny(broken_intra_doc_links)]
    |         ^^^^^^^^^^^^^^^^^^^^^^
    = note: this link resolved to an enum, which is not a struct
-help: to link to the enum, prefix with the item kind
-   |
-LL | /// Link to [enum@S]
-   |              ^^^^^^
 
 error: incompatible link kind for `S`
   --> $DIR/intra-links-disambiguator-mismatch.rs:19:14
    |
 LL | /// Link to [mod@S]
-   |              ^^^^^
+   |              ^^^^^ help: to link to the enum, prefix with `enum@`: `enum@S`
    |
    = note: this link resolved to an enum, which is not a module
-help: to link to the enum, prefix with the item kind
-   |
-LL | /// Link to [enum@S]
-   |              ^^^^^^
 
 error: incompatible link kind for `S`
   --> $DIR/intra-links-disambiguator-mismatch.rs:24:14
    |
 LL | /// Link to [union@S]
-   |              ^^^^^^^
+   |              ^^^^^^^ help: to link to the enum, prefix with `enum@`: `enum@S`
    |
    = note: this link resolved to an enum, which is not a union
-help: to link to the enum, prefix with the item kind
-   |
-LL | /// Link to [enum@S]
-   |              ^^^^^^
 
 error: incompatible link kind for `S`
   --> $DIR/intra-links-disambiguator-mismatch.rs:29:14
    |
 LL | /// Link to [trait@S]
-   |              ^^^^^^^
+   |              ^^^^^^^ help: to link to the enum, prefix with `enum@`: `enum@S`
    |
    = note: this link resolved to an enum, which is not a trait
-help: to link to the enum, prefix with the item kind
-   |
-LL | /// Link to [enum@S]
-   |              ^^^^^^
 
 error: incompatible link kind for `T`
   --> $DIR/intra-links-disambiguator-mismatch.rs:34:14
    |
 LL | /// Link to [struct@T]
-   |              ^^^^^^^^
+   |              ^^^^^^^^ help: to link to the trait, prefix with `trait@`: `trait@T`
    |
    = note: this link resolved to a trait, which is not a struct
-help: to link to the trait, prefix with the item kind
-   |
-LL | /// Link to [trait@T]
-   |              ^^^^^^^
 
 error: incompatible link kind for `m`
   --> $DIR/intra-links-disambiguator-mismatch.rs:39:14
@@ -75,49 +55,33 @@ error: incompatible link kind for `s`
   --> $DIR/intra-links-disambiguator-mismatch.rs:44:14
    |
 LL | /// Link to [const@s]
-   |              ^^^^^^^
+   |              ^^^^^^^ help: to link to the static, prefix with `static@`: `static@s`
    |
    = note: this link resolved to a static, which is not a constant
-help: to link to the static, prefix with the item kind
-   |
-LL | /// Link to [static@s]
-   |              ^^^^^^^^
 
 error: incompatible link kind for `c`
   --> $DIR/intra-links-disambiguator-mismatch.rs:49:14
    |
 LL | /// Link to [static@c]
-   |              ^^^^^^^^
+   |              ^^^^^^^^ help: to link to the constant, prefix with `const@`: `const@c`
    |
    = note: this link resolved to a constant, which is not a static
-help: to link to the constant, prefix with the item kind
-   |
-LL | /// Link to [const@c]
-   |              ^^^^^^^
 
 error: incompatible link kind for `c`
   --> $DIR/intra-links-disambiguator-mismatch.rs:54:14
    |
 LL | /// Link to [fn@c]
-   |              ^^^^
+   |              ^^^^ help: to link to the constant, prefix with `const@`: `const@c`
    |
    = note: this link resolved to a constant, which is not a function
-help: to link to the constant, prefix with the item kind
-   |
-LL | /// Link to [const@c]
-   |              ^^^^^^^
 
 error: incompatible link kind for `c`
   --> $DIR/intra-links-disambiguator-mismatch.rs:59:14
    |
 LL | /// Link to [c()]
-   |              ^^^
+   |              ^^^ help: to link to the constant, prefix with `const@`: `const@c`
    |
    = note: this link resolved to a constant, which is not a function
-help: to link to the constant, prefix with the item kind
-   |
-LL | /// Link to [const@c]
-   |              ^^^^^^^
 
 error: incompatible link kind for `f`
   --> $DIR/intra-links-disambiguator-mismatch.rs:64:14

--- a/src/test/rustdoc-ui/intra-links-warning-crlf.stderr
+++ b/src/test/rustdoc-ui/intra-links-warning-crlf.stderr
@@ -2,33 +2,37 @@ warning: unresolved link to `error`
   --> $DIR/intra-links-warning-crlf.rs:7:6
    |
 LL | /// [error]
-   |      ^^^^^ unresolved link
+   |      ^^^^^
    |
    = note: `#[warn(broken_intra_doc_links)]` on by default
+   = note: no item named `error` is in scope
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 warning: unresolved link to `error1`
   --> $DIR/intra-links-warning-crlf.rs:12:11
    |
 LL | /// docs [error1]
-   |           ^^^^^^ unresolved link
+   |           ^^^^^^
    |
+   = note: no item named `error1` is in scope
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 warning: unresolved link to `error2`
   --> $DIR/intra-links-warning-crlf.rs:15:11
    |
 LL | /// docs [error2]
-   |           ^^^^^^ unresolved link
+   |           ^^^^^^
    |
+   = note: no item named `error2` is in scope
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 warning: unresolved link to `error`
   --> $DIR/intra-links-warning-crlf.rs:23:20
    |
 LL |  * It also has an [error].
-   |                    ^^^^^ unresolved link
+   |                    ^^^^^
    |
+   = note: no item named `error` is in scope
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 warning: 4 warnings emitted

--- a/src/test/rustdoc-ui/intra-links-warning-crlf.stderr
+++ b/src/test/rustdoc-ui/intra-links-warning-crlf.stderr
@@ -2,7 +2,7 @@ warning: unresolved link to `error`
   --> $DIR/intra-links-warning-crlf.rs:7:6
    |
 LL | /// [error]
-   |      ^^^^^ no item named `error` is in scope
+   |      ^^^^^ no item named `error` in `intra_links_warning_crlf`
    |
    = note: `#[warn(broken_intra_doc_links)]` on by default
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
@@ -11,7 +11,7 @@ warning: unresolved link to `error1`
   --> $DIR/intra-links-warning-crlf.rs:12:11
    |
 LL | /// docs [error1]
-   |           ^^^^^^ no item named `error1` is in scope
+   |           ^^^^^^ no item named `error1` in `intra_links_warning_crlf`
    |
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
@@ -19,7 +19,7 @@ warning: unresolved link to `error2`
   --> $DIR/intra-links-warning-crlf.rs:15:11
    |
 LL | /// docs [error2]
-   |           ^^^^^^ no item named `error2` is in scope
+   |           ^^^^^^ no item named `error2` in `intra_links_warning_crlf`
    |
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
@@ -27,7 +27,7 @@ warning: unresolved link to `error`
   --> $DIR/intra-links-warning-crlf.rs:23:20
    |
 LL |  * It also has an [error].
-   |                    ^^^^^ no item named `error` is in scope
+   |                    ^^^^^ no item named `error` in `intra_links_warning_crlf`
    |
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 

--- a/src/test/rustdoc-ui/intra-links-warning-crlf.stderr
+++ b/src/test/rustdoc-ui/intra-links-warning-crlf.stderr
@@ -2,37 +2,33 @@ warning: unresolved link to `error`
   --> $DIR/intra-links-warning-crlf.rs:7:6
    |
 LL | /// [error]
-   |      ^^^^^
+   |      ^^^^^ no item named `error` is in scope
    |
    = note: `#[warn(broken_intra_doc_links)]` on by default
-   = note: no item named `error` is in scope
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 warning: unresolved link to `error1`
   --> $DIR/intra-links-warning-crlf.rs:12:11
    |
 LL | /// docs [error1]
-   |           ^^^^^^
+   |           ^^^^^^ no item named `error1` is in scope
    |
-   = note: no item named `error1` is in scope
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 warning: unresolved link to `error2`
   --> $DIR/intra-links-warning-crlf.rs:15:11
    |
 LL | /// docs [error2]
-   |           ^^^^^^
+   |           ^^^^^^ no item named `error2` is in scope
    |
-   = note: no item named `error2` is in scope
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 warning: unresolved link to `error`
   --> $DIR/intra-links-warning-crlf.rs:23:20
    |
 LL |  * It also has an [error].
-   |                    ^^^^^
+   |                    ^^^^^ no item named `error` is in scope
    |
-   = note: no item named `error` is in scope
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 warning: 4 warnings emitted

--- a/src/test/rustdoc-ui/intra-links-warning.stderr
+++ b/src/test/rustdoc-ui/intra-links-warning.stderr
@@ -2,76 +2,62 @@ warning: unresolved link to `Foo::baz`
   --> $DIR/intra-links-warning.rs:3:23
    |
 LL |        //! Test with [Foo::baz], [Bar::foo], ...
-   |                       ^^^^^^^^
+   |                       ^^^^^^^^ the struct `Foo` has no field or associated item named `baz`
    |
    = note: `#[warn(broken_intra_doc_links)]` on by default
-   = note: the struct `Foo` has no field or associated item named `baz`
 
 warning: unresolved link to `Bar::foo`
   --> $DIR/intra-links-warning.rs:3:35
    |
 LL |        //! Test with [Foo::baz], [Bar::foo], ...
-   |                                   ^^^^^^^^
-   |
-   = note: no item named `Bar` is in scope
+   |                                   ^^^^^^^^ no item named `Bar` is in scope
 
 warning: unresolved link to `Uniooon::X`
   --> $DIR/intra-links-warning.rs:6:13
    |
 LL |      //! , [Uniooon::X] and [Qux::Z].
-   |             ^^^^^^^^^^
-   |
-   = note: no item named `Uniooon` is in scope
+   |             ^^^^^^^^^^ no item named `Uniooon` is in scope
 
 warning: unresolved link to `Qux::Z`
   --> $DIR/intra-links-warning.rs:6:30
    |
 LL |      //! , [Uniooon::X] and [Qux::Z].
-   |                              ^^^^^^
-   |
-   = note: no item named `Qux` is in scope
+   |                              ^^^^^^ no item named `Qux` is in scope
 
 warning: unresolved link to `Uniooon::X`
   --> $DIR/intra-links-warning.rs:10:14
    |
 LL |       //! , [Uniooon::X] and [Qux::Z].
-   |              ^^^^^^^^^^
-   |
-   = note: no item named `Uniooon` is in scope
+   |              ^^^^^^^^^^ no item named `Uniooon` is in scope
 
 warning: unresolved link to `Qux::Z`
   --> $DIR/intra-links-warning.rs:10:31
    |
 LL |       //! , [Uniooon::X] and [Qux::Z].
-   |                               ^^^^^^
-   |
-   = note: no item named `Qux` is in scope
+   |                               ^^^^^^ no item named `Qux` is in scope
 
 warning: unresolved link to `Qux:Y`
   --> $DIR/intra-links-warning.rs:14:13
    |
 LL |        /// [Qux:Y]
-   |             ^^^^^
+   |             ^^^^^ no item named `Qux:Y` is in scope
    |
-   = note: no item named `Qux:Y` is in scope
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 warning: unresolved link to `error`
   --> $DIR/intra-links-warning.rs:58:30
    |
 LL |  * time to introduce a link [error]*/
-   |                              ^^^^^
+   |                              ^^^^^ no item named `error` is in scope
    |
-   = note: no item named `error` is in scope
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 warning: unresolved link to `error`
   --> $DIR/intra-links-warning.rs:64:30
    |
 LL |  * time to introduce a link [error]
-   |                              ^^^^^
+   |                              ^^^^^ no item named `error` is in scope
    |
-   = note: no item named `error` is in scope
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 warning: unresolved link to `error`
@@ -119,45 +105,40 @@ warning: unresolved link to `error1`
   --> $DIR/intra-links-warning.rs:80:11
    |
 LL | /// docs [error1]
-   |           ^^^^^^
+   |           ^^^^^^ no item named `error1` is in scope
    |
-   = note: no item named `error1` is in scope
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 warning: unresolved link to `error2`
   --> $DIR/intra-links-warning.rs:82:11
    |
 LL | /// docs [error2]
-   |           ^^^^^^
+   |           ^^^^^^ no item named `error2` is in scope
    |
-   = note: no item named `error2` is in scope
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 warning: unresolved link to `BarA`
   --> $DIR/intra-links-warning.rs:21:10
    |
 LL | /// bar [BarA] bar
-   |          ^^^^
+   |          ^^^^ no item named `BarA` is in scope
    |
-   = note: no item named `BarA` is in scope
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 warning: unresolved link to `BarB`
   --> $DIR/intra-links-warning.rs:27:9
    |
 LL |  * bar [BarB] bar
-   |         ^^^^
+   |         ^^^^ no item named `BarB` is in scope
    |
-   = note: no item named `BarB` is in scope
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 warning: unresolved link to `BarC`
   --> $DIR/intra-links-warning.rs:34:6
    |
 LL | bar [BarC] bar
-   |      ^^^^
+   |      ^^^^ no item named `BarC` is in scope
    |
-   = note: no item named `BarC` is in scope
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 warning: unresolved link to `BarD`

--- a/src/test/rustdoc-ui/intra-links-warning.stderr
+++ b/src/test/rustdoc-ui/intra-links-warning.stderr
@@ -2,73 +2,82 @@ warning: unresolved link to `Foo::baz`
   --> $DIR/intra-links-warning.rs:3:23
    |
 LL |        //! Test with [Foo::baz], [Bar::foo], ...
-   |                       ^^^^^^^^ unresolved link
+   |                       ^^^^^^^^
    |
    = note: `#[warn(broken_intra_doc_links)]` on by default
-   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
+   = note: this link partially resolves to the struct `Foo`,
+   = note: `Foo` has no field, variant, or associated item named `baz`
 
 warning: unresolved link to `Bar::foo`
   --> $DIR/intra-links-warning.rs:3:35
    |
 LL |        //! Test with [Foo::baz], [Bar::foo], ...
-   |                                   ^^^^^^^^ unresolved link
+   |                                   ^^^^^^^^
    |
+   = note: no item named `Bar` is in scope
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 warning: unresolved link to `Uniooon::X`
   --> $DIR/intra-links-warning.rs:6:13
    |
 LL |      //! , [Uniooon::X] and [Qux::Z].
-   |             ^^^^^^^^^^ unresolved link
+   |             ^^^^^^^^^^
    |
+   = note: no item named `Uniooon` is in scope
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 warning: unresolved link to `Qux::Z`
   --> $DIR/intra-links-warning.rs:6:30
    |
 LL |      //! , [Uniooon::X] and [Qux::Z].
-   |                              ^^^^^^ unresolved link
+   |                              ^^^^^^
    |
+   = note: no item named `Qux` is in scope
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 warning: unresolved link to `Uniooon::X`
   --> $DIR/intra-links-warning.rs:10:14
    |
 LL |       //! , [Uniooon::X] and [Qux::Z].
-   |              ^^^^^^^^^^ unresolved link
+   |              ^^^^^^^^^^
    |
+   = note: no item named `Uniooon` is in scope
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 warning: unresolved link to `Qux::Z`
   --> $DIR/intra-links-warning.rs:10:31
    |
 LL |       //! , [Uniooon::X] and [Qux::Z].
-   |                               ^^^^^^ unresolved link
+   |                               ^^^^^^
    |
+   = note: no item named `Qux` is in scope
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 warning: unresolved link to `Qux:Y`
   --> $DIR/intra-links-warning.rs:14:13
    |
 LL |        /// [Qux:Y]
-   |             ^^^^^ unresolved link
+   |             ^^^^^
    |
+   = note: no item named `Qux:Y` is in scope
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 warning: unresolved link to `error`
   --> $DIR/intra-links-warning.rs:58:30
    |
 LL |  * time to introduce a link [error]*/
-   |                              ^^^^^ unresolved link
+   |                              ^^^^^
    |
+   = note: no item named `error` is in scope
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 warning: unresolved link to `error`
   --> $DIR/intra-links-warning.rs:64:30
    |
 LL |  * time to introduce a link [error]
-   |                              ^^^^^ unresolved link
+   |                              ^^^^^
    |
+   = note: no item named `error` is in scope
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 warning: unresolved link to `error`
@@ -81,6 +90,7 @@ LL | #[doc = "single line [error]"]
            
            single line [error]
                         ^^^^^
+   = note: no item named `error` is in scope
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 warning: unresolved link to `error`
@@ -93,6 +103,7 @@ LL | #[doc = "single line with \"escaping\" [error]"]
            
            single line with "escaping" [error]
                                         ^^^^^
+   = note: no item named `error` is in scope
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 warning: unresolved link to `error`
@@ -107,46 +118,52 @@ LL | | /// [error]
            
            [error]
             ^^^^^
+   = note: no item named `error` is in scope
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 warning: unresolved link to `error1`
   --> $DIR/intra-links-warning.rs:80:11
    |
 LL | /// docs [error1]
-   |           ^^^^^^ unresolved link
+   |           ^^^^^^
    |
+   = note: no item named `error1` is in scope
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 warning: unresolved link to `error2`
   --> $DIR/intra-links-warning.rs:82:11
    |
 LL | /// docs [error2]
-   |           ^^^^^^ unresolved link
+   |           ^^^^^^
    |
+   = note: no item named `error2` is in scope
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 warning: unresolved link to `BarA`
   --> $DIR/intra-links-warning.rs:21:10
    |
 LL | /// bar [BarA] bar
-   |          ^^^^ unresolved link
+   |          ^^^^
    |
+   = note: no item named `BarA` is in scope
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 warning: unresolved link to `BarB`
   --> $DIR/intra-links-warning.rs:27:9
    |
 LL |  * bar [BarB] bar
-   |         ^^^^ unresolved link
+   |         ^^^^
    |
+   = note: no item named `BarB` is in scope
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 warning: unresolved link to `BarC`
   --> $DIR/intra-links-warning.rs:34:6
    |
 LL | bar [BarC] bar
-   |      ^^^^ unresolved link
+   |      ^^^^
    |
+   = note: no item named `BarC` is in scope
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 warning: unresolved link to `BarD`
@@ -159,6 +176,7 @@ LL | #[doc = "Foo\nbar [BarD] bar\nbaz"]
            
            bar [BarD] bar
                 ^^^^
+   = note: no item named `BarD` is in scope
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 warning: unresolved link to `BarF`
@@ -174,6 +192,7 @@ LL | f!("Foo\nbar [BarF] bar\nbaz");
            
            bar [BarF] bar
                 ^^^^
+   = note: no item named `BarF` is in scope
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
    = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/rustdoc-ui/intra-links-warning.stderr
+++ b/src/test/rustdoc-ui/intra-links-warning.stderr
@@ -5,8 +5,7 @@ LL |        //! Test with [Foo::baz], [Bar::foo], ...
    |                       ^^^^^^^^
    |
    = note: `#[warn(broken_intra_doc_links)]` on by default
-   = note: this link partially resolves to the struct `Foo`
-   = note: no `baz` in `Foo`
+   = note: the struct `Foo` has no field or associated item named `baz`
 
 warning: unresolved link to `Bar::foo`
   --> $DIR/intra-links-warning.rs:3:35

--- a/src/test/rustdoc-ui/intra-links-warning.stderr
+++ b/src/test/rustdoc-ui/intra-links-warning.stderr
@@ -5,7 +5,7 @@ LL |        //! Test with [Foo::baz], [Bar::foo], ...
    |                       ^^^^^^^^
    |
    = note: `#[warn(broken_intra_doc_links)]` on by default
-   = note: this link partially resolves to the struct `Foo`,
+   = note: this link partially resolves to the struct `Foo`
    = note: `Foo` has no field, variant, or associated item named `baz`
 
 warning: unresolved link to `Bar::foo`

--- a/src/test/rustdoc-ui/intra-links-warning.stderr
+++ b/src/test/rustdoc-ui/intra-links-warning.stderr
@@ -10,37 +10,37 @@ warning: unresolved link to `Bar::foo`
   --> $DIR/intra-links-warning.rs:3:35
    |
 LL |        //! Test with [Foo::baz], [Bar::foo], ...
-   |                                   ^^^^^^^^ no item named `Bar` is in scope
+   |                                   ^^^^^^^^ no item named `Bar` in `intra_links_warning`
 
 warning: unresolved link to `Uniooon::X`
   --> $DIR/intra-links-warning.rs:6:13
    |
 LL |      //! , [Uniooon::X] and [Qux::Z].
-   |             ^^^^^^^^^^ no item named `Uniooon` is in scope
+   |             ^^^^^^^^^^ no item named `Uniooon` in `intra_links_warning`
 
 warning: unresolved link to `Qux::Z`
   --> $DIR/intra-links-warning.rs:6:30
    |
 LL |      //! , [Uniooon::X] and [Qux::Z].
-   |                              ^^^^^^ no item named `Qux` is in scope
+   |                              ^^^^^^ no item named `Qux` in `intra_links_warning`
 
 warning: unresolved link to `Uniooon::X`
   --> $DIR/intra-links-warning.rs:10:14
    |
 LL |       //! , [Uniooon::X] and [Qux::Z].
-   |              ^^^^^^^^^^ no item named `Uniooon` is in scope
+   |              ^^^^^^^^^^ no item named `Uniooon` in `intra_links_warning`
 
 warning: unresolved link to `Qux::Z`
   --> $DIR/intra-links-warning.rs:10:31
    |
 LL |       //! , [Uniooon::X] and [Qux::Z].
-   |                               ^^^^^^ no item named `Qux` is in scope
+   |                               ^^^^^^ no item named `Qux` in `intra_links_warning`
 
 warning: unresolved link to `Qux:Y`
   --> $DIR/intra-links-warning.rs:14:13
    |
 LL |        /// [Qux:Y]
-   |             ^^^^^ no item named `Qux:Y` is in scope
+   |             ^^^^^ no item named `Qux:Y` in `intra_links_warning`
    |
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
@@ -48,7 +48,7 @@ warning: unresolved link to `error`
   --> $DIR/intra-links-warning.rs:58:30
    |
 LL |  * time to introduce a link [error]*/
-   |                              ^^^^^ no item named `error` is in scope
+   |                              ^^^^^ no item named `error` in `intra_links_warning`
    |
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
@@ -56,7 +56,7 @@ warning: unresolved link to `error`
   --> $DIR/intra-links-warning.rs:64:30
    |
 LL |  * time to introduce a link [error]
-   |                              ^^^^^ no item named `error` is in scope
+   |                              ^^^^^ no item named `error` in `intra_links_warning`
    |
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
@@ -70,7 +70,7 @@ LL | #[doc = "single line [error]"]
            
            single line [error]
                         ^^^^^
-   = note: no item named `error` is in scope
+   = note: no item named `error` in `intra_links_warning`
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 warning: unresolved link to `error`
@@ -83,7 +83,7 @@ LL | #[doc = "single line with \"escaping\" [error]"]
            
            single line with "escaping" [error]
                                         ^^^^^
-   = note: no item named `error` is in scope
+   = note: no item named `error` in `intra_links_warning`
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 warning: unresolved link to `error`
@@ -98,14 +98,14 @@ LL | | /// [error]
            
            [error]
             ^^^^^
-   = note: no item named `error` is in scope
+   = note: no item named `error` in `intra_links_warning`
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 warning: unresolved link to `error1`
   --> $DIR/intra-links-warning.rs:80:11
    |
 LL | /// docs [error1]
-   |           ^^^^^^ no item named `error1` is in scope
+   |           ^^^^^^ no item named `error1` in `intra_links_warning`
    |
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
@@ -113,7 +113,7 @@ warning: unresolved link to `error2`
   --> $DIR/intra-links-warning.rs:82:11
    |
 LL | /// docs [error2]
-   |           ^^^^^^ no item named `error2` is in scope
+   |           ^^^^^^ no item named `error2` in `intra_links_warning`
    |
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
@@ -121,7 +121,7 @@ warning: unresolved link to `BarA`
   --> $DIR/intra-links-warning.rs:21:10
    |
 LL | /// bar [BarA] bar
-   |          ^^^^ no item named `BarA` is in scope
+   |          ^^^^ no item named `BarA` in `intra_links_warning`
    |
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
@@ -129,7 +129,7 @@ warning: unresolved link to `BarB`
   --> $DIR/intra-links-warning.rs:27:9
    |
 LL |  * bar [BarB] bar
-   |         ^^^^ no item named `BarB` is in scope
+   |         ^^^^ no item named `BarB` in `intra_links_warning`
    |
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
@@ -137,7 +137,7 @@ warning: unresolved link to `BarC`
   --> $DIR/intra-links-warning.rs:34:6
    |
 LL | bar [BarC] bar
-   |      ^^^^ no item named `BarC` is in scope
+   |      ^^^^ no item named `BarC` in `intra_links_warning`
    |
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
@@ -151,7 +151,7 @@ LL | #[doc = "Foo\nbar [BarD] bar\nbaz"]
            
            bar [BarD] bar
                 ^^^^
-   = note: no item named `BarD` is in scope
+   = note: no item named `BarD` in `intra_links_warning`
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 warning: unresolved link to `BarF`
@@ -167,7 +167,7 @@ LL | f!("Foo\nbar [BarF] bar\nbaz");
            
            bar [BarF] bar
                 ^^^^
-   = note: no item named `BarF` is in scope
+   = note: no item named `BarF` in `intra_links_warning`
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
    = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/rustdoc-ui/intra-links-warning.stderr
+++ b/src/test/rustdoc-ui/intra-links-warning.stderr
@@ -14,7 +14,6 @@ LL |        //! Test with [Foo::baz], [Bar::foo], ...
    |                                   ^^^^^^^^
    |
    = note: no item named `Bar` is in scope
-   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 warning: unresolved link to `Uniooon::X`
   --> $DIR/intra-links-warning.rs:6:13
@@ -23,7 +22,6 @@ LL |      //! , [Uniooon::X] and [Qux::Z].
    |             ^^^^^^^^^^
    |
    = note: no item named `Uniooon` is in scope
-   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 warning: unresolved link to `Qux::Z`
   --> $DIR/intra-links-warning.rs:6:30
@@ -32,7 +30,6 @@ LL |      //! , [Uniooon::X] and [Qux::Z].
    |                              ^^^^^^
    |
    = note: no item named `Qux` is in scope
-   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 warning: unresolved link to `Uniooon::X`
   --> $DIR/intra-links-warning.rs:10:14
@@ -41,7 +38,6 @@ LL |       //! , [Uniooon::X] and [Qux::Z].
    |              ^^^^^^^^^^
    |
    = note: no item named `Uniooon` is in scope
-   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 warning: unresolved link to `Qux::Z`
   --> $DIR/intra-links-warning.rs:10:31
@@ -50,7 +46,6 @@ LL |       //! , [Uniooon::X] and [Qux::Z].
    |                               ^^^^^^
    |
    = note: no item named `Qux` is in scope
-   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 warning: unresolved link to `Qux:Y`
   --> $DIR/intra-links-warning.rs:14:13

--- a/src/test/rustdoc-ui/intra-links-warning.stderr
+++ b/src/test/rustdoc-ui/intra-links-warning.stderr
@@ -6,7 +6,7 @@ LL |        //! Test with [Foo::baz], [Bar::foo], ...
    |
    = note: `#[warn(broken_intra_doc_links)]` on by default
    = note: this link partially resolves to the struct `Foo`
-   = note: `Foo` has no field, variant, or associated item named `baz`
+   = note: no `baz` in `Foo`
 
 warning: unresolved link to `Bar::foo`
   --> $DIR/intra-links-warning.rs:3:35

--- a/src/test/rustdoc-ui/lint-group.stderr
+++ b/src/test/rustdoc-ui/lint-group.stderr
@@ -32,7 +32,7 @@ error: unresolved link to `error`
   --> $DIR/lint-group.rs:9:29
    |
 LL | /// what up, let's make an [error]
-   |                             ^^^^^ unresolved link
+   |                             ^^^^^
    |
 note: the lint level is defined here
   --> $DIR/lint-group.rs:7:9
@@ -40,6 +40,7 @@ note: the lint level is defined here
 LL | #![deny(rustdoc)]
    |         ^^^^^^^
    = note: `#[deny(broken_intra_doc_links)]` implied by `#[deny(rustdoc)]`
+   = note: no item named `error` is in scope
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 error: aborting due to 3 previous errors

--- a/src/test/rustdoc-ui/lint-group.stderr
+++ b/src/test/rustdoc-ui/lint-group.stderr
@@ -32,7 +32,7 @@ error: unresolved link to `error`
   --> $DIR/lint-group.rs:9:29
    |
 LL | /// what up, let's make an [error]
-   |                             ^^^^^
+   |                             ^^^^^ no item named `error` in `lint_group`
    |
 note: the lint level is defined here
   --> $DIR/lint-group.rs:7:9
@@ -40,7 +40,6 @@ note: the lint level is defined here
 LL | #![deny(rustdoc)]
    |         ^^^^^^^
    = note: `#[deny(broken_intra_doc_links)]` implied by `#[deny(rustdoc)]`
-   = note: no item named `error` is in scope
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 error: aborting due to 3 previous errors


### PR DESCRIPTION
~~Depends on #74489 and should not be merged before that PR.~~ Merged 🎉
~~Depends on #75916 and should not be merged before.~~ Merged

Fixes https://github.com/rust-lang/rust/issues/75305.

This does a lot of different things 😆.

- Add `PerNS::into_iter()` so I didn't have to keep rewriting hacks around it. Also add `PerNS::iter()` for consistency. Let me know if this should be `impl IntoIterator` instead.
- Make `ResolutionFailure` an enum instead of a unit variant. This was most of the changes: everywhere that said `ErrorKind::ResolutionFailure` now has to say _why_ the link failed to resolve.
- Store the resolution in case of an anchor failure. Previously this was implemented as variants on `AnchorFailure` which was prone to typos and had inconsistent output compared to the rest of the diagnostics.
- Turn some `Err`ors into unwrap() or panic()s, because they're rustdoc bugs and not user error. These have comments as to why they're bugs (in particular this would have caught #76073 as a bug a while ago).
- If an item is not in scope at all, say the first segment in the path that failed to resolve
- If an item exists but not in the current namespaces, say that and suggests linking to that namespace.
- If there is a partial resolution for an item (part of the segments resolved, but not all of them), say the partial resolution and why the following segment didn't resolve.
- Add the `DefId` of associated items to `kind_side_channel` so it can be used for diagnostics (tl;dr of the hack: the rest of rustdoc expects the id of the item, but for diagnostics we need the associated item).
- No longer suggests escaping the brackets for every link that failed to resolve; this was pretty obnoxious. Now it only suggests `\[ \]` if no segment resolved and there is no `::` in the link.
- Add `Suggestion`, which says _what_ to prefix the link with, not just 'prefix with the item kind'.

Places where this is currently buggy:

<details><summary>All outdated</summary>

~~1. When the link has the wrong namespace:~~ Now fixed.

<details>

```rust
/// [type@S::h]
impl S {
	pub fn h() {}
}

/// [type@T::g]
pub trait T {
	fn g() {}
}
```
```
error: unresolved link to `T::g`
  --> /home/joshua/rustc/src/test/rustdoc-ui/intra-link-errors.rs:53:6
   |
53 | /// [type@T::g]
   |      ^^^^^^^^^
   |
   = note: this link partially resolves to the trait `T`,
   = note: `T` has no field, variant, or associated item named `g`

error: unresolved link to `S::h`
  --> /home/joshua/rustc/src/test/rustdoc-ui/intra-link-errors.rs:48:6
   |
48 | /// [type@S::h]
   |      ^^^^^^^^^
   |
   = note: this link partially resolves to the struct `S`,
   = note: `S` has no field, variant, or associated item named `h`
```
Instead it should suggest changing the disambiguator, the way it currently does for macros:
```
error: unresolved link to `S`
  --> /home/joshua/rustc/src/test/rustdoc-ui/intra-link-errors.rs:38:6
   |
38 | /// [S!]
   |      ^^ help: to link to the unit struct, use its disambiguator: `value@S`
   |
   = note: this link resolves to the unit struct `S`, which is not in the macro namespace
```

</details>

2. ~~Associated items for values. It says that the value isn't in scope; instead it should say that values can't have associated items.~~ Fixed.

<details>

```
error: unresolved link to `f::A`
  --> /home/joshua/rustc/src/test/rustdoc-ui/intra-link-errors.rs:14:6
   |
14 | /// [f::A]
   |      ^^^^
   |
   = note: no item named `f` is in scope
   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
```
This is _mostly_ fixed, it now says

```rust
warning: unresolved link to `f::A`
 --> /home/joshua/test-rustdoc/f.rs:1:6
  |
1 | /// [f::A]
  |      ^^^^
  |
  = note: this link partially resolves to the function `f`
  = note: `f` is a function, not a module
```

'function, not a module' seems awfully terse when what I actually mean is '`::` isn't allowed here', though.

</details>

It looks a lot nicer now, it says

```
error: unresolved link to `f::A`
  --> /home/joshua/rustc/src/test/rustdoc-ui/intra-link-errors.rs:13:6
   |
13 | /// [f::A]
   |      ^^^^
   |
   = note: `f` is a function, not a module or type, and cannot have associated items
```

3. ~~I'm also not very happy with the second note for this error:~~

<details>
```
error: unresolved link to `S::A`
  --> /home/joshua/rustc/src/test/rustdoc-ui/intra-link-errors.rs:19:6
   |
19 | /// [S::A]
   |      ^^^^
   |
   = note: this link partially resolves to the struct `S`,
   = note: `S` has no field, variant, or associated item named `A`
```

but I'm not sure how better to word it.

I ended up going with 'no `A` in `S`' to match `rustc_resolve` but that seems terse as well.

</details>

This now says

```
error: unresolved link to `S::A`
  --> /home/joshua/rustc/src/test/rustdoc-ui/intra-link-errors.rs:17:6
   |
17 | /// [S::A]
   |      ^^^^
   |
   = note: the struct `S` has no field or associated item named `A`
```

which I think looks pretty good :)

4. This is minor, but it would be nice to say that `path` wasn't found instead of the full thing:
```
error: unresolved link to `path::to::nonexistent::module`
 --> /home/joshua/rustc/src/test/rustdoc-ui/intra-link-errors.rs:8:6
  |
8 | /// [path::to::nonexistent::module]
  |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

It will now look at most 3 paths up (so it reports `path::to` as not in scope), but it doesn't work with arbitrarily many paths.

</details>

~~I recommend only reviewing the last few commits - the first 7 are all from #74489.~~ Rebased so that only the relevant commits are shown. Let me know if I should squash the history some more.

r? @estebank