### PR TITLE
VxWorks: fix building errors

### DIFF
--- a/library/std/src/sys/vxworks/fd.rs
+++ b/library/std/src/sys/vxworks/fd.rs
@@ -53,7 +53,7 @@ impl FileDesc {
     }
 
     #[inline]
-    fn is_read_vectored(&self) -> bool {
+    pub fn is_read_vectored(&self) -> bool {
         true
     }
 

--- a/library/std/src/sys/vxworks/process/process_common.rs
+++ b/library/std/src/sys/vxworks/process/process_common.rs
@@ -352,7 +352,7 @@ impl ExitStatus {
 
     fn exited(&self) -> bool {
         /*unsafe*/
-        { libc::WIFEXITED(self.0) }
+        libc::WIFEXITED(self.0)
     }
 
     pub fn success(&self) -> bool {
@@ -361,7 +361,7 @@ impl ExitStatus {
 
     pub fn code(&self) -> Option<i32> {
         if self.exited() {
-            Some(/*unsafe*/ { libc::WEXITSTATUS(self.0) })
+            Some(/*unsafe*/ libc::WEXITSTATUS(self.0))
         } else {
             None
         }
@@ -369,7 +369,7 @@ impl ExitStatus {
 
     pub fn signal(&self) -> Option<i32> {
         if !self.exited() {
-            Some(/*unsafe*/ { libc::WTERMSIG(self.0) })
+            Some(/*unsafe*/ libc::WTERMSIG(self.0))
         } else {
             None
         }

--- a/library/std/src/sys/vxworks/thread_local_dtor.rs
+++ b/library/std/src/sys/vxworks/thread_local_dtor.rs
@@ -2,6 +2,6 @@
 #![unstable(feature = "thread_local_internals", issue = "none")]
 
 pub unsafe fn register_dtor(t: *mut u8, dtor: unsafe extern "C" fn(*mut u8)) {
-    use crate::sys_common::thread_local::register_dtor_fallback;
+    use crate::sys_common::thread_local_dtor::register_dtor_fallback;
     register_dtor_fallback(t, dtor);
 }

--- a/src/bootstrap/cc_detect.rs
+++ b/src/bootstrap/cc_detect.rs
@@ -132,7 +132,7 @@ pub fn find(build: &mut Build) {
             false
         };
 
-        if cxx_configured {
+        if cxx_configured || target.contains("vxworks") {
             let compiler = cfg.get_compiler();
             build.cxx.insert(target, compiler);
         }

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -857,6 +857,8 @@ impl Build {
         if let Some(linker) = self.config.target_config.get(&target).and_then(|c| c.linker.as_ref())
         {
             Some(linker)
+        } else if target.contains("vxworks"){
+            Some(self.cxx[&target].path())
         } else if target != self.config.build
             && util::use_host_linker(target)
             && !target.contains("msvc")


### PR DESCRIPTION
1. fix building errors in building library/std for VxWorks
2. use CXX compiler driver as the linker for VxWorks