### PR TITLE
bump tidy to cargo_metadata 0.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -404,6 +404,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "cargo_metadata"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89fec17b16f1ac67908af82e47d0a90a7afd0e1827b181cd77504323d3263d35"
+dependencies = [
+ "semver 0.10.0",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "cargotest2"
 version = "0.1.0"
 
@@ -4680,7 +4691,7 @@ dependencies = [
 name = "tidy"
 version = "0.1.0"
 dependencies = [
- "cargo_metadata 0.9.1",
+ "cargo_metadata 0.11.1",
  "lazy_static",
  "regex",
  "walkdir",

--- a/src/tools/tidy/Cargo.toml
+++ b/src/tools/tidy/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Alex Crichton <alex@alexcrichton.com>"]
 edition = "2018"
 
 [dependencies]
-cargo_metadata = "0.9.1"
+cargo_metadata = "0.11"
 regex = "1"
 lazy_static = "1"
 walkdir = "2"


### PR DESCRIPTION
Updates cargo_metadata in tidy's Cargo.toml from 0.9.1 to 0.11
Real version change 0.9.11 -> 0.11.1
https://github.com/oli-obk/cargo_metadata/compare/v0.9.1...v0.11.1