### PR TITLE
Extend normalization in const-eval-query-stack test

### DIFF
--- a/src/test/ui/consts/const-eval/const-eval-query-stack.rs
+++ b/src/test/ui/consts/const-eval/const-eval-query-stack.rs
@@ -9,7 +9,8 @@
 // normalize-stderr-test "note: rustc.*running on.*\n\n" -> ""
 // normalize-stderr-test "thread.*panicked.*\n" -> ""
 // normalize-stderr-test "stack backtrace:\n" -> ""
-// normalize-stderr-test "  \d{1,}: .*\n" -> ""
+// normalize-stderr-test "\s\d{1,}: .*\n" -> ""
+// normalize-stderr-test "\s at .*\n" -> ""
 // normalize-stderr-test ".*note: Some details.*\n" -> ""
 
 #![allow(unconditional_panic)]

--- a/src/test/ui/consts/const-eval/const-eval-query-stack.stderr
+++ b/src/test/ui/consts/const-eval/const-eval-query-stack.stderr
@@ -1,5 +1,5 @@
 error: reaching this expression at runtime will panic or abort
-  --> $DIR/const-eval-query-stack.rs:18:28
+  --> $DIR/const-eval-query-stack.rs:19:28
    |
 LL |     let x: &'static i32 = &(1 / 0);
    |                           -^^^^^^^


### PR DESCRIPTION
Builds with debuginfo have additional information in backtrace.