### PR TITLE
Remove unused `Maybe` wrapper around raw standard streams

### DIFF
--- a/library/std/src/io/stdio.rs
+++ b/library/std/src/io/stdio.rs
@@ -83,11 +83,11 @@ const fn stderr_raw() -> StderrRaw {
 
 impl Read for StdinRaw {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        self.0.read(buf)
+        handle_ebadf(self.0.read(buf), 0)
     }
 
     fn read_vectored(&mut self, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
-        self.0.read_vectored(bufs)
+        handle_ebadf(self.0.read_vectored(bufs), 0)
     }
 
     #[inline]
@@ -101,25 +101,22 @@ impl Read for StdinRaw {
     }
 
     fn read_to_end(&mut self, buf: &mut Vec<u8>) -> io::Result<usize> {
-        self.0.read_to_end(buf)
+        handle_ebadf(self.0.read_to_end(buf), 0)
     }
 
     fn read_to_string(&mut self, buf: &mut String) -> io::Result<usize> {
-        self.0.read_to_string(buf)
-    }
-
-    fn read_exact(&mut self, buf: &mut [u8]) -> io::Result<()> {
-        self.0.read_exact(buf)
+        handle_ebadf(self.0.read_to_string(buf), 0)
     }
 }
 
 impl Write for StdoutRaw {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.0.write(buf)
+        handle_ebadf(self.0.write(buf), buf.len())
     }
 
     fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
-        self.0.write_vectored(bufs)
+        let total = bufs.iter().map(|b| b.len()).sum();
+        handle_ebadf(self.0.write_vectored(bufs), total)
     }
 
     #[inline]
@@ -128,29 +125,30 @@ impl Write for StdoutRaw {
     }
 
     fn flush(&mut self) -> io::Result<()> {
-        self.0.flush()
+        handle_ebadf(self.0.flush(), ())
     }
 
     fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
-        self.0.write_all(buf)
+        handle_ebadf(self.0.write_all(buf), ())
     }
 
     fn write_all_vectored(&mut self, bufs: &mut [IoSlice<'_>]) -> io::Result<()> {
-        self.0.write_all_vectored(bufs)
+        handle_ebadf(self.0.write_all_vectored(bufs), ())
     }
 
     fn write_fmt(&mut self, fmt: fmt::Arguments<'_>) -> io::Result<()> {
-        self.0.write_fmt(fmt)
+        handle_ebadf(self.0.write_fmt(fmt), ())
     }
 }
 
 impl Write for StderrRaw {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.0.write(buf)
+        handle_ebadf(self.0.write(buf), buf.len())
     }
 
     fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
-        self.0.write_vectored(bufs)
+        let total = bufs.iter().map(|b| b.len()).sum();
+        handle_ebadf(self.0.write_vectored(bufs), total)
     }
 
     #[inline]
@@ -159,80 +157,19 @@ impl Write for StderrRaw {
     }
 
     fn flush(&mut self) -> io::Result<()> {
-        self.0.flush()
+        handle_ebadf(self.0.flush(), ())
     }
 
     fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
-        self.0.write_all(buf)
+        handle_ebadf(self.0.write_all(buf), ())
     }
 
     fn write_all_vectored(&mut self, bufs: &mut [IoSlice<'_>]) -> io::Result<()> {
-        self.0.write_all_vectored(bufs)
+        handle_ebadf(self.0.write_all_vectored(bufs), ())
     }
 
     fn write_fmt(&mut self, fmt: fmt::Arguments<'_>) -> io::Result<()> {
-        self.0.write_fmt(fmt)
-    }
-}
-
-enum Maybe<T> {
-    Real(T),
-    Fake,
-}
-
-impl<W: io::Write> io::Write for Maybe<W> {
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        match *self {
-            Maybe::Real(ref mut w) => handle_ebadf(w.write(buf), buf.len()),
-            Maybe::Fake => Ok(buf.len()),
-        }
-    }
-
-    fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
-        let total = bufs.iter().map(|b| b.len()).sum();
-        match self {
-            Maybe::Real(w) => handle_ebadf(w.write_vectored(bufs), total),
-            Maybe::Fake => Ok(total),
-        }
-    }
-
-    #[inline]
-    fn is_write_vectored(&self) -> bool {
-        match self {
-            Maybe::Real(w) => w.is_write_vectored(),
-            Maybe::Fake => true,
-        }
-    }
-
-    fn flush(&mut self) -> io::Result<()> {
-        match *self {
-            Maybe::Real(ref mut w) => handle_ebadf(w.flush(), ()),
-            Maybe::Fake => Ok(()),
-        }
-    }
-}
-
-impl<R: io::Read> io::Read for Maybe<R> {
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        match *self {
-            Maybe::Real(ref mut r) => handle_ebadf(r.read(buf), 0),
-            Maybe::Fake => Ok(0),
-        }
-    }
-
-    fn read_vectored(&mut self, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
-        match self {
-            Maybe::Real(r) => handle_ebadf(r.read_vectored(bufs), 0),
-            Maybe::Fake => Ok(0),
-        }
-    }
-
-    #[inline]
-    fn is_read_vectored(&self) -> bool {
-        match self {
-            Maybe::Real(w) => w.is_read_vectored(),
-            Maybe::Fake => true,
-        }
+        handle_ebadf(self.0.write_fmt(fmt), ())
     }
 }
 
@@ -277,7 +214,7 @@ fn handle_ebadf<T>(r: io::Result<T>, default: T) -> io::Result<T> {
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct Stdin {
-    inner: Arc<Mutex<BufReader<Maybe<StdinRaw>>>>,
+    inner: Arc<Mutex<BufReader<StdinRaw>>>,
 }
 
 /// A locked reference to the `Stdin` handle.
@@ -308,7 +245,7 @@ pub struct Stdin {
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct StdinLock<'a> {
-    inner: MutexGuard<'a, BufReader<Maybe<StdinRaw>>>,
+    inner: MutexGuard<'a, BufReader<StdinRaw>>,
 }
 
 /// Constructs a new handle to the standard input of the current process.
@@ -352,14 +289,14 @@ pub struct StdinLock<'a> {
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 pub fn stdin() -> Stdin {
-    static INSTANCE: Lazy<Mutex<BufReader<Maybe<StdinRaw>>>> = Lazy::new();
+    static INSTANCE: Lazy<Mutex<BufReader<StdinRaw>>> = Lazy::new();
     return Stdin {
         inner: unsafe { INSTANCE.get(stdin_init).expect("cannot access stdin during shutdown") },
     };
 
-    fn stdin_init() -> Arc<Mutex<BufReader<Maybe<StdinRaw>>>> {
+    fn stdin_init() -> Arc<Mutex<BufReader<StdinRaw>>> {
         // This must not reentrantly access `INSTANCE`
-        let stdin = Maybe::Real(stdin_raw());
+        let stdin = stdin_raw();
         Arc::new(Mutex::new(BufReader::with_capacity(stdio::STDIN_BUF_SIZE, stdin)))
     }
 }
@@ -536,7 +473,7 @@ pub struct Stdout {
     // FIXME: this should be LineWriter or BufWriter depending on the state of
     //        stdout (tty or not). Note that if this is not line buffered it
     //        should also flush-on-panic or some form of flush-on-abort.
-    inner: Arc<ReentrantMutex<RefCell<LineWriter<Maybe<StdoutRaw>>>>>,
+    inner: Arc<ReentrantMutex<RefCell<LineWriter<StdoutRaw>>>>,
 }
 
 /// A locked reference to the `Stdout` handle.
@@ -550,7 +487,7 @@ pub struct Stdout {
 /// an error.
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct StdoutLock<'a> {
-    inner: ReentrantMutexGuard<'a, RefCell<LineWriter<Maybe<StdoutRaw>>>>,
+    inner: ReentrantMutexGuard<'a, RefCell<LineWriter<StdoutRaw>>>,
 }
 
 /// Constructs a new handle to the standard output of the current process.
@@ -594,14 +531,14 @@ pub struct StdoutLock<'a> {
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 pub fn stdout() -> Stdout {
-    static INSTANCE: Lazy<ReentrantMutex<RefCell<LineWriter<Maybe<StdoutRaw>>>>> = Lazy::new();
+    static INSTANCE: Lazy<ReentrantMutex<RefCell<LineWriter<StdoutRaw>>>> = Lazy::new();
     return Stdout {
         inner: unsafe { INSTANCE.get(stdout_init).expect("cannot access stdout during shutdown") },
     };
 
-    fn stdout_init() -> Arc<ReentrantMutex<RefCell<LineWriter<Maybe<StdoutRaw>>>>> {
+    fn stdout_init() -> Arc<ReentrantMutex<RefCell<LineWriter<StdoutRaw>>>> {
         // This must not reentrantly access `INSTANCE`
-        let stdout = Maybe::Real(stdout_raw());
+        let stdout = stdout_raw();
         unsafe {
             let ret = Arc::new(ReentrantMutex::new(RefCell::new(LineWriter::new(stdout))));
             ret.init();
@@ -711,7 +648,7 @@ impl fmt::Debug for StdoutLock<'_> {
 /// an error.
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct Stderr {
-    inner: &'static ReentrantMutex<RefCell<Maybe<StderrRaw>>>,
+    inner: &'static ReentrantMutex<RefCell<StderrRaw>>,
 }
 
 /// A locked reference to the `Stderr` handle.
@@ -725,7 +662,7 @@ pub struct Stderr {
 /// an error.
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct StderrLock<'a> {
-    inner: ReentrantMutexGuard<'a, RefCell<Maybe<StderrRaw>>>,
+    inner: ReentrantMutexGuard<'a, RefCell<StderrRaw>>,
 }
 
 /// Constructs a new handle to the standard error of the current process.
@@ -774,18 +711,14 @@ pub fn stderr() -> Stderr {
     //
     // This has the added benefit of allowing `stderr` to be usable during
     // process shutdown as well!
-    static INSTANCE: ReentrantMutex<RefCell<Maybe<StderrRaw>>> =
-        unsafe { ReentrantMutex::new(RefCell::new(Maybe::Fake)) };
+    static INSTANCE: ReentrantMutex<RefCell<StderrRaw>> =
+        unsafe { ReentrantMutex::new(RefCell::new(stderr_raw())) };
 
     // When accessing stderr we need one-time initialization of the reentrant
-    // mutex, followed by one-time detection of whether we actually have a
-    // stderr handle or not. Afterwards we can just always use the now-filled-in
-    // `INSTANCE` value.
+    // mutex. Afterwards we can just always use the now-filled-in `INSTANCE` value.
     static INIT: Once = Once::new();
     INIT.call_once(|| unsafe {
         INSTANCE.init();
-        let stderr = stderr_raw();
-        *INSTANCE.lock().borrow_mut() = Maybe::Real(stderr);
     });
     Stderr { inner: &INSTANCE }
 }

--- a/library/std/src/io/stdio.rs
+++ b/library/std/src/io/stdio.rs
@@ -50,7 +50,8 @@ struct StderrRaw(stdio::Stderr);
 /// handles is **not** available to raw handles returned from this function.
 ///
 /// The returned handle has no external synchronization or buffering.
-fn stdin_raw() -> StdinRaw {
+#[unstable(feature = "libstd_sys_internals", issue = "none")]
+const fn stdin_raw() -> StdinRaw {
     StdinRaw(stdio::Stdin::new())
 }
 
@@ -63,7 +64,8 @@ fn stdin_raw() -> StdinRaw {
 ///
 /// The returned handle has no external synchronization or buffering layered on
 /// top.
-fn stdout_raw() -> StdoutRaw {
+#[unstable(feature = "libstd_sys_internals", issue = "none")]
+const fn stdout_raw() -> StdoutRaw {
     StdoutRaw(stdio::Stdout::new())
 }
 
@@ -74,7 +76,8 @@ fn stdout_raw() -> StdoutRaw {
 ///
 /// The returned handle has no external synchronization or buffering layered on
 /// top.
-fn stderr_raw() -> StderrRaw {
+#[unstable(feature = "libstd_sys_internals", issue = "none")]
+const fn stderr_raw() -> StderrRaw {
     StderrRaw(stdio::Stderr::new())
 }
 

--- a/library/std/src/sys/cloudabi/stdio.rs
+++ b/library/std/src/sys/cloudabi/stdio.rs
@@ -6,8 +6,8 @@ pub struct Stdout(());
 pub struct Stderr(());
 
 impl Stdin {
-    pub fn new() -> io::Result<Stdin> {
-        Ok(Stdin(()))
+    pub fn new() -> Stdin {
+        Stdin(())
     }
 }
 
@@ -18,8 +18,8 @@ impl io::Read for Stdin {
 }
 
 impl Stdout {
-    pub fn new() -> io::Result<Stdout> {
-        Ok(Stdout(()))
+    pub fn new() -> Stdout {
+        Stdout(())
     }
 }
 
@@ -37,8 +37,8 @@ impl io::Write for Stdout {
 }
 
 impl Stderr {
-    pub fn new() -> io::Result<Stderr> {
-        Ok(Stderr(()))
+    pub fn new() -> Stderr {
+        Stderr(())
     }
 }
 
@@ -62,5 +62,5 @@ pub fn is_ebadf(err: &io::Error) -> bool {
 pub const STDIN_BUF_SIZE: usize = crate::sys_common::io::DEFAULT_BUF_SIZE;
 
 pub fn panic_output() -> Option<impl io::Write> {
-    Stderr::new().ok()
+    Some(Stderr::new())
 }

--- a/library/std/src/sys/cloudabi/stdio.rs
+++ b/library/std/src/sys/cloudabi/stdio.rs
@@ -6,7 +6,7 @@ pub struct Stdout(());
 pub struct Stderr(());
 
 impl Stdin {
-    pub fn new() -> Stdin {
+    pub const fn new() -> Stdin {
         Stdin(())
     }
 }
@@ -18,7 +18,7 @@ impl io::Read for Stdin {
 }
 
 impl Stdout {
-    pub fn new() -> Stdout {
+    pub const fn new() -> Stdout {
         Stdout(())
     }
 }
@@ -37,7 +37,7 @@ impl io::Write for Stdout {
 }
 
 impl Stderr {
-    pub fn new() -> Stderr {
+    pub const fn new() -> Stderr {
         Stderr(())
     }
 }

--- a/library/std/src/sys/hermit/stdio.rs
+++ b/library/std/src/sys/hermit/stdio.rs
@@ -7,7 +7,7 @@ pub struct Stdout;
 pub struct Stderr;
 
 impl Stdin {
-    pub fn new() -> Stdin {
+    pub const fn new() -> Stdin {
         Stdin
     }
 }
@@ -28,7 +28,7 @@ impl io::Read for Stdin {
 }
 
 impl Stdout {
-    pub fn new() -> Stdout {
+    pub const fn new() -> Stdout {
         Stdout
     }
 }
@@ -69,7 +69,7 @@ impl io::Write for Stdout {
 }
 
 impl Stderr {
-    pub fn new() -> Stderr {
+    pub const fn new() -> Stderr {
         Stderr
     }
 }

--- a/library/std/src/sys/hermit/stdio.rs
+++ b/library/std/src/sys/hermit/stdio.rs
@@ -7,8 +7,8 @@ pub struct Stdout;
 pub struct Stderr;
 
 impl Stdin {
-    pub fn new() -> io::Result<Stdin> {
-        Ok(Stdin)
+    pub fn new() -> Stdin {
+        Stdin
     }
 }
 
@@ -28,8 +28,8 @@ impl io::Read for Stdin {
 }
 
 impl Stdout {
-    pub fn new() -> io::Result<Stdout> {
-        Ok(Stdout)
+    pub fn new() -> Stdout {
+        Stdout
     }
 }
 
@@ -69,8 +69,8 @@ impl io::Write for Stdout {
 }
 
 impl Stderr {
-    pub fn new() -> io::Result<Stderr> {
-        Ok(Stderr)
+    pub fn new() -> Stderr {
+        Stderr
     }
 }
 
@@ -116,5 +116,5 @@ pub fn is_ebadf(_err: &io::Error) -> bool {
 }
 
 pub fn panic_output() -> Option<impl io::Write> {
-    Stderr::new().ok()
+    Some(Stderr::new())
 }

--- a/library/std/src/sys/sgx/stdio.rs
+++ b/library/std/src/sys/sgx/stdio.rs
@@ -19,8 +19,8 @@ fn with_std_fd<F: FnOnce(&FileDesc) -> R, R>(fd: abi::Fd, f: F) -> R {
 }
 
 impl Stdin {
-    pub fn new() -> io::Result<Stdin> {
-        Ok(Stdin(()))
+    pub fn new() -> Stdin {
+        Stdin(())
     }
 }
 
@@ -31,8 +31,8 @@ impl io::Read for Stdin {
 }
 
 impl Stdout {
-    pub fn new() -> io::Result<Stdout> {
-        Ok(Stdout(()))
+    pub fn new() -> Stdout {
+        Stdout(())
     }
 }
 
@@ -47,8 +47,8 @@ impl io::Write for Stdout {
 }
 
 impl Stderr {
-    pub fn new() -> io::Result<Stderr> {
-        Ok(Stderr(()))
+    pub fn new() -> Stderr {
+        Stderr(())
     }
 }
 

--- a/library/std/src/sys/sgx/stdio.rs
+++ b/library/std/src/sys/sgx/stdio.rs
@@ -19,7 +19,7 @@ fn with_std_fd<F: FnOnce(&FileDesc) -> R, R>(fd: abi::Fd, f: F) -> R {
 }
 
 impl Stdin {
-    pub fn new() -> Stdin {
+    pub const fn new() -> Stdin {
         Stdin(())
     }
 }
@@ -31,7 +31,7 @@ impl io::Read for Stdin {
 }
 
 impl Stdout {
-    pub fn new() -> Stdout {
+    pub const fn new() -> Stdout {
         Stdout(())
     }
 }
@@ -47,7 +47,7 @@ impl io::Write for Stdout {
 }
 
 impl Stderr {
-    pub fn new() -> Stderr {
+    pub const fn new() -> Stderr {
         Stderr(())
     }
 }

--- a/library/std/src/sys/unix/stdio.rs
+++ b/library/std/src/sys/unix/stdio.rs
@@ -7,7 +7,7 @@ pub struct Stdout(());
 pub struct Stderr(());
 
 impl Stdin {
-    pub fn new() -> Stdin {
+    pub const fn new() -> Stdin {
         Stdin(())
     }
 }
@@ -28,7 +28,7 @@ impl io::Read for Stdin {
 }
 
 impl Stdout {
-    pub fn new() -> Stdout {
+    pub const fn new() -> Stdout {
         Stdout(())
     }
 }
@@ -53,7 +53,7 @@ impl io::Write for Stdout {
 }
 
 impl Stderr {
-    pub fn new() -> Stderr {
+    pub const fn new() -> Stderr {
         Stderr(())
     }
 }

--- a/library/std/src/sys/unix/stdio.rs
+++ b/library/std/src/sys/unix/stdio.rs
@@ -7,8 +7,8 @@ pub struct Stdout(());
 pub struct Stderr(());
 
 impl Stdin {
-    pub fn new() -> io::Result<Stdin> {
-        Ok(Stdin(()))
+    pub fn new() -> Stdin {
+        Stdin(())
     }
 }
 
@@ -28,8 +28,8 @@ impl io::Read for Stdin {
 }
 
 impl Stdout {
-    pub fn new() -> io::Result<Stdout> {
-        Ok(Stdout(()))
+    pub fn new() -> Stdout {
+        Stdout(())
     }
 }
 
@@ -53,8 +53,8 @@ impl io::Write for Stdout {
 }
 
 impl Stderr {
-    pub fn new() -> io::Result<Stderr> {
-        Ok(Stderr(()))
+    pub fn new() -> Stderr {
+        Stderr(())
     }
 }
 
@@ -84,5 +84,5 @@ pub fn is_ebadf(err: &io::Error) -> bool {
 pub const STDIN_BUF_SIZE: usize = crate::sys_common::io::DEFAULT_BUF_SIZE;
 
 pub fn panic_output() -> Option<impl io::Write> {
-    Stderr::new().ok()
+    Some(Stderr::new())
 }

--- a/library/std/src/sys/unsupported/stdio.rs
+++ b/library/std/src/sys/unsupported/stdio.rs
@@ -5,7 +5,7 @@ pub struct Stdout;
 pub struct Stderr;
 
 impl Stdin {
-    pub fn new() -> Stdin {
+    pub const fn new() -> Stdin {
         Stdin
     }
 }
@@ -17,7 +17,7 @@ impl io::Read for Stdin {
 }
 
 impl Stdout {
-    pub fn new() -> Stdout {
+    pub const fn new() -> Stdout {
         Stdout
     }
 }
@@ -33,7 +33,7 @@ impl io::Write for Stdout {
 }
 
 impl Stderr {
-    pub fn new() -> Stderr {
+    pub const fn new() -> Stderr {
         Stderr
     }
 }

--- a/library/std/src/sys/unsupported/stdio.rs
+++ b/library/std/src/sys/unsupported/stdio.rs
@@ -5,8 +5,8 @@ pub struct Stdout;
 pub struct Stderr;
 
 impl Stdin {
-    pub fn new() -> io::Result<Stdin> {
-        Ok(Stdin)
+    pub fn new() -> Stdin {
+        Stdin
     }
 }
 
@@ -17,8 +17,8 @@ impl io::Read for Stdin {
 }
 
 impl Stdout {
-    pub fn new() -> io::Result<Stdout> {
-        Ok(Stdout)
+    pub fn new() -> Stdout {
+        Stdout
     }
 }
 
@@ -33,8 +33,8 @@ impl io::Write for Stdout {
 }
 
 impl Stderr {
-    pub fn new() -> io::Result<Stderr> {
-        Ok(Stderr)
+    pub fn new() -> Stderr {
+        Stderr
     }
 }
 

--- a/library/std/src/sys/vxworks/stdio.rs
+++ b/library/std/src/sys/vxworks/stdio.rs
@@ -6,8 +6,8 @@ pub struct Stdout(());
 pub struct Stderr(());
 
 impl Stdin {
-    pub fn new() -> io::Result<Stdin> {
-        Ok(Stdin(()))
+    pub fn new() -> Stdin {
+        Stdin(())
     }
 }
 
@@ -21,8 +21,8 @@ impl io::Read for Stdin {
 }
 
 impl Stdout {
-    pub fn new() -> io::Result<Stdout> {
-        Ok(Stdout(()))
+    pub fn new() -> Stdout {
+        Stdout(())
     }
 }
 
@@ -40,8 +40,8 @@ impl io::Write for Stdout {
 }
 
 impl Stderr {
-    pub fn new() -> io::Result<Stderr> {
-        Ok(Stderr(()))
+    pub fn new() -> Stderr {
+        Stderr(())
     }
 }
 
@@ -65,5 +65,5 @@ pub fn is_ebadf(err: &io::Error) -> bool {
 pub const STDIN_BUF_SIZE: usize = crate::sys_common::io::DEFAULT_BUF_SIZE;
 
 pub fn panic_output() -> Option<impl io::Write> {
-    Stderr::new().ok()
+    Some(Stderr::new())
 }

--- a/library/std/src/sys/vxworks/stdio.rs
+++ b/library/std/src/sys/vxworks/stdio.rs
@@ -6,7 +6,7 @@ pub struct Stdout(());
 pub struct Stderr(());
 
 impl Stdin {
-    pub fn new() -> Stdin {
+    pub const fn new() -> Stdin {
         Stdin(())
     }
 }
@@ -21,7 +21,7 @@ impl io::Read for Stdin {
 }
 
 impl Stdout {
-    pub fn new() -> Stdout {
+    pub const fn new() -> Stdout {
         Stdout(())
     }
 }
@@ -40,7 +40,7 @@ impl io::Write for Stdout {
 }
 
 impl Stderr {
-    pub fn new() -> Stderr {
+    pub const fn new() -> Stderr {
         Stderr(())
     }
 }

--- a/library/std/src/sys/wasi/stdio.rs
+++ b/library/std/src/sys/wasi/stdio.rs
@@ -7,8 +7,8 @@ pub struct Stdout;
 pub struct Stderr;
 
 impl Stdin {
-    pub fn new() -> io::Result<Stdin> {
-        Ok(Stdin)
+    pub fn new() -> Stdin {
+        Stdin
     }
 
     #[inline]
@@ -33,8 +33,8 @@ impl io::Read for Stdin {
 }
 
 impl Stdout {
-    pub fn new() -> io::Result<Stdout> {
-        Ok(Stdout)
+    pub fn new() -> Stdout {
+        Stdout
     }
 
     #[inline]
@@ -62,8 +62,8 @@ impl io::Write for Stdout {
 }
 
 impl Stderr {
-    pub fn new() -> io::Result<Stderr> {
-        Ok(Stderr)
+    pub fn new() -> Stderr {
+        Stderr
     }
 
     #[inline]
@@ -98,5 +98,5 @@ pub fn is_ebadf(err: &io::Error) -> bool {
 }
 
 pub fn panic_output() -> Option<impl io::Write> {
-    Stderr::new().ok()
+    Some(Stderr::new())
 }

--- a/library/std/src/sys/wasi/stdio.rs
+++ b/library/std/src/sys/wasi/stdio.rs
@@ -7,7 +7,7 @@ pub struct Stdout;
 pub struct Stderr;
 
 impl Stdin {
-    pub fn new() -> Stdin {
+    pub const fn new() -> Stdin {
         Stdin
     }
 
@@ -33,7 +33,7 @@ impl io::Read for Stdin {
 }
 
 impl Stdout {
-    pub fn new() -> Stdout {
+    pub const fn new() -> Stdout {
         Stdout
     }
 
@@ -62,7 +62,7 @@ impl io::Write for Stdout {
 }
 
 impl Stderr {
-    pub fn new() -> Stderr {
+    pub const fn new() -> Stderr {
         Stderr
     }
 

--- a/library/std/src/sys/windows/stdio.rs
+++ b/library/std/src/sys/windows/stdio.rs
@@ -131,7 +131,7 @@ fn write_u16s(handle: c::HANDLE, data: &[u16]) -> io::Result<usize> {
 }
 
 impl Stdin {
-    pub fn new() -> Stdin {
+    pub const fn new() -> Stdin {
         Stdin { surrogate: 0 }
     }
 }
@@ -255,7 +255,7 @@ fn utf16_to_utf8(utf16: &[u16], utf8: &mut [u8]) -> io::Result<usize> {
 }
 
 impl Stdout {
-    pub fn new() -> Stdout {
+    pub const fn new() -> Stdout {
         Stdout
     }
 }
@@ -271,7 +271,7 @@ impl io::Write for Stdout {
 }
 
 impl Stderr {
-    pub fn new() -> Stderr {
+    pub const fn new() -> Stderr {
         Stderr
     }
 }

--- a/library/std/src/sys/windows/stdio.rs
+++ b/library/std/src/sys/windows/stdio.rs
@@ -131,8 +131,8 @@ fn write_u16s(handle: c::HANDLE, data: &[u16]) -> io::Result<usize> {
 }
 
 impl Stdin {
-    pub fn new() -> io::Result<Stdin> {
-        Ok(Stdin { surrogate: 0 })
+    pub fn new() -> Stdin {
+        Stdin { surrogate: 0 }
     }
 }
 
@@ -255,8 +255,8 @@ fn utf16_to_utf8(utf16: &[u16], utf8: &mut [u8]) -> io::Result<usize> {
 }
 
 impl Stdout {
-    pub fn new() -> io::Result<Stdout> {
-        Ok(Stdout)
+    pub fn new() -> Stdout {
+        Stdout
     }
 }
 
@@ -271,8 +271,8 @@ impl io::Write for Stdout {
 }
 
 impl Stderr {
-    pub fn new() -> io::Result<Stderr> {
-        Ok(Stderr)
+    pub fn new() -> Stderr {
+        Stderr
     }
 }
 
@@ -291,5 +291,5 @@ pub fn is_ebadf(err: &io::Error) -> bool {
 }
 
 pub fn panic_output() -> Option<impl io::Write> {
-    Stderr::new().ok()
+    Some(Stderr::new())
 }

--- a/library/std/src/sys/windows/stdio_uwp.rs
+++ b/library/std/src/sys/windows/stdio_uwp.rs
@@ -30,8 +30,8 @@ fn write(handle_id: c::DWORD, data: &[u8]) -> io::Result<usize> {
 }
 
 impl Stdin {
-    pub fn new() -> io::Result<Stdin> {
-        Ok(Stdin {})
+    pub fn new() -> Stdin {
+        Stdin {}
     }
 }
 
@@ -44,8 +44,8 @@ impl io::Read for Stdin {
 }
 
 impl Stdout {
-    pub fn new() -> io::Result<Stdout> {
-        Ok(Stdout)
+    pub fn new() -> Stdout {
+        Stdout
     }
 }
 
@@ -60,8 +60,8 @@ impl io::Write for Stdout {
 }
 
 impl Stderr {
-    pub fn new() -> io::Result<Stderr> {
-        Ok(Stderr)
+    pub fn new() -> Stderr {
+        Stderr
     }
 }
 
@@ -80,5 +80,5 @@ pub fn is_ebadf(err: &io::Error) -> bool {
 }
 
 pub fn panic_output() -> Option<impl io::Write> {
-    Stderr::new().ok()
+    Some(Stderr::new())
 }

--- a/library/std/src/sys/windows/stdio_uwp.rs
+++ b/library/std/src/sys/windows/stdio_uwp.rs
@@ -30,7 +30,7 @@ fn write(handle_id: c::DWORD, data: &[u8]) -> io::Result<usize> {
 }
 
 impl Stdin {
-    pub fn new() -> Stdin {
+    pub const fn new() -> Stdin {
         Stdin {}
     }
 }
@@ -44,7 +44,7 @@ impl io::Read for Stdin {
 }
 
 impl Stdout {
-    pub fn new() -> Stdout {
+    pub const fn new() -> Stdout {
         Stdout
     }
 }
@@ -60,7 +60,7 @@ impl io::Write for Stdout {
 }
 
 impl Stderr {
-    pub fn new() -> Stderr {
+    pub const fn new() -> Stderr {
         Stderr
     }
 }


### PR DESCRIPTION
* Remove result type from raw standard streams constructors
* Make raw standard stream constructors const
* Remove wrapper type handling absent raw standard streams

cargo checked with:

```shell
env CC=true ./x.py check library/std/ \
  --target i686-unknown-linux-gnu \
  --target wasm32-unknown-emscripten \
  --target wasm32-wasi \
  --target x86_64-fortanix-unknown-sgx \
  --target x86_64-pc-windows-gnu \
  --target x86_64-unknown-cloudabi \
  --target x86_64-unknown-hermit \
  --target x86_64-unknown-linux-gnu \
  --target x86_64-uwp-windows-gnu \
  --target x86_64-wrs-vxworks
```

Note: Last target doesn't compile currently.