### PR TITLE
Add Iterator::intersperse

### DIFF
--- a/library/core/src/iter/adapters/intersperse.rs
+++ b/library/core/src/iter/adapters/intersperse.rs
@@ -1,0 +1,62 @@
+use crate::iter::Fuse;
+
+/// An iterator adapter that places a separator between all elements.
+#[unstable(feature = "iter_intersperse", reason = "recently added", issue = "none")]
+#[derive(Debug, Clone)]
+pub struct Intersperse<I: Iterator>
+where
+    I::Item: Clone,
+{
+    element: I::Item,
+    iter: Fuse<I>,
+    peek: Option<I::Item>,
+}
+
+impl<I: Iterator> Intersperse<I>
+where
+    I::Item: Clone,
+{
+    pub(in super::super) fn new(iter: I, separator: I::Item) -> Self {
+        let mut iter = iter.fuse();
+        Self { peek: iter.next(), iter, element: separator }
+    }
+}
+
+#[unstable(feature = "iter_intersperse", reason = "recently added", issue = "none")]
+impl<I> Iterator for Intersperse<I>
+where
+    I: Iterator,
+    I::Item: Clone,
+{
+    type Item = I::Item;
+
+    #[inline]
+    fn next(&mut self) -> Option<I::Item> {
+        if self.peek.is_some() {
+            self.peek.take()
+        } else {
+            self.peek = self.iter.next();
+            if self.peek.is_some() { Some(self.element.clone()) } else { None }
+        }
+    }
+
+    fn fold<B, F>(mut self, init: B, mut f: F) -> B
+    where
+        Self: Sized,
+        F: FnMut(B, Self::Item) -> B,
+    {
+        let mut accum = init;
+
+        if let Some(x) = self.peek.take() {
+            accum = f(accum, x);
+        }
+
+        let element = &self.element;
+
+        self.iter.fold(accum, |accum, x| {
+            let accum = f(accum, element.clone());
+            let accum = f(accum, x);
+            accum
+        })
+    }
+}

--- a/library/core/src/iter/adapters/intersperse.rs
+++ b/library/core/src/iter/adapters/intersperse.rs
@@ -66,7 +66,7 @@ where
         let (lo, hi) = self.iter.size_hint();
         let has_peek = self.peek.is_some() as usize;
         let lo = lo.saturating_add(lo).saturating_add(has_peek);
-        let hi = hi.map(|hi| hi.saturating_add(hi).saturating_add(has_peek));
+        let hi = hi.and_then(|hi| hi.checked_add(hi)).and_then(|hi| hi.checked_add(has_peek));
         (lo, hi)
     }
 }

--- a/library/core/src/iter/adapters/intersperse.rs
+++ b/library/core/src/iter/adapters/intersperse.rs
@@ -32,11 +32,11 @@ where
 
     #[inline]
     fn next(&mut self) -> Option<I::Item> {
-        if self.peek.is_some() {
-            self.peek.take()
+        if let Some(item) = self.peek.take() {
+            Some(item)
         } else {
-            self.peek = self.iter.next();
-            if self.peek.is_some() { Some(self.element.clone()) } else { None }
+            self.peek = Some(self.iter.next()?);
+            Some(self.element.clone())
         }
     }
 

--- a/library/core/src/iter/adapters/intersperse.rs
+++ b/library/core/src/iter/adapters/intersperse.rs
@@ -59,4 +59,14 @@ where
             accum
         })
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        // We'll yield the whole `self.iter`, and just as many separators, as well as (if present)
+        // `self.peek`.
+        let (lo, hi) = self.iter.size_hint();
+        let has_peek = self.peek.is_some() as usize;
+        let lo = lo.saturating_add(lo).saturating_add(has_peek);
+        let hi = hi.map(|hi| hi.saturating_add(hi).saturating_add(has_peek));
+        (lo, hi)
+    }
 }

--- a/library/core/src/iter/adapters/intersperse.rs
+++ b/library/core/src/iter/adapters/intersperse.rs
@@ -1,5 +1,3 @@
-use crate::ops::Try;
-
 use super::Peekable;
 
 /// An iterator adapter that places a separator between all elements.
@@ -62,30 +60,6 @@ where
             accum = f(accum, element.clone());
             accum = f(accum, x);
             accum
-        })
-    }
-
-    fn try_fold<B, F, R>(&mut self, init: B, mut f: F) -> R
-    where
-        Self: Sized,
-        F: FnMut(B, Self::Item) -> R,
-        R: Try<Ok = B>,
-    {
-        let mut accum = init;
-
-        // Use `peek()` first to avoid calling `next()` on an empty iterator.
-        if !self.needs_sep || self.iter.peek().is_some() {
-            if let Some(x) = self.iter.next() {
-                accum = f(accum, x)?;
-            }
-        }
-
-        let element = &self.separator;
-
-        self.iter.try_fold(accum, |mut accum, x| {
-            accum = f(accum, element.clone())?;
-            accum = f(accum, x)?;
-            Try::from_ok(accum)
         })
     }
 

--- a/library/core/src/iter/adapters/intersperse.rs
+++ b/library/core/src/iter/adapters/intersperse.rs
@@ -16,7 +16,7 @@ impl<I: Iterator> Intersperse<I>
 where
     I::Item: Clone,
 {
-    pub(in super::super) fn new(iter: I, separator: I::Item) -> Self {
+    pub(in crate::iter) fn new(iter: I, separator: I::Item) -> Self {
         let mut iter = iter.fuse();
         Self { peek: iter.next(), iter, element: separator }
     }

--- a/library/core/src/iter/adapters/intersperse.rs
+++ b/library/core/src/iter/adapters/intersperse.rs
@@ -66,10 +66,11 @@ where
     fn size_hint(&self) -> (usize, Option<usize>) {
         let (lo, hi) = self.iter.size_hint();
         let next_is_elem = !self.needs_sep;
-        let lo = lo.saturating_add(lo).saturating_sub(next_is_elem as usize);
-        let hi = hi
-            .and_then(|hi| hi.checked_add(hi))
-            .and_then(|hi| hi.checked_sub(next_is_elem as usize));
+        let lo = lo.saturating_sub(next_is_elem as usize).saturating_add(lo);
+        let hi = match hi {
+            Some(hi) => hi.saturating_sub(next_is_elem as usize).checked_add(hi),
+            None => None,
+        };
         (lo, hi)
     }
 }

--- a/library/core/src/iter/adapters/mod.rs
+++ b/library/core/src/iter/adapters/mod.rs
@@ -11,12 +11,15 @@ use super::{
 mod chain;
 mod flatten;
 mod fuse;
+mod intersperse;
 mod zip;
 
 pub use self::chain::Chain;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::flatten::{FlatMap, Flatten};
 pub use self::fuse::Fuse;
+#[unstable(feature = "iter_intersperse", reason = "recently added", issue = "none")]
+pub use self::intersperse::Intersperse;
 use self::zip::try_get_unchecked;
 #[unstable(feature = "trusted_random_access", issue = "none")]
 pub use self::zip::TrustedRandomAccess;

--- a/library/core/src/iter/mod.rs
+++ b/library/core/src/iter/mod.rs
@@ -351,7 +351,8 @@ pub use self::adapters::Cloned;
 pub use self::adapters::Copied;
 #[stable(feature = "iterator_flatten", since = "1.29.0")]
 pub use self::adapters::Flatten;
-
+#[unstable(feature = "iter_intersperse", reason = "recently added", issue = "none")]
+pub use self::adapters::Intersperse;
 #[unstable(feature = "iter_map_while", reason = "recently added", issue = "68537")]
 pub use self::adapters::MapWhile;
 #[unstable(issue = "none", feature = "inplace_iteration")]

--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -545,7 +545,7 @@ pub trait Iterator {
     /// ```
     /// #![feature(iter_intersperse)]
     ///
-    /// let hello = ["Hello", "World"].iter().map(|s| *s).intersperse(" ").collect::<String>();
+    /// let hello = ["Hello", "World"].iter().copied().intersperse(" ").collect::<String>();
     /// assert_eq!(hello, "Hello World");
     /// ```
     #[inline]

--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -8,7 +8,7 @@ use crate::ops::{Add, ControlFlow, Try};
 use super::super::TrustedRandomAccess;
 use super::super::{Chain, Cloned, Copied, Cycle, Enumerate, Filter, FilterMap, Fuse};
 use super::super::{FlatMap, Flatten};
-use super::super::{FromIterator, Product, Sum, Zip};
+use super::super::{FromIterator, Intersperse, Product, Sum, Zip};
 use super::super::{
     Inspect, Map, MapWhile, Peekable, Rev, Scan, Skip, SkipWhile, StepBy, Take, TakeWhile,
 };
@@ -534,6 +534,28 @@ pub trait Iterator {
         U: IntoIterator,
     {
         Zip::new(self, other.into_iter())
+    }
+
+    /// Places a copy of `separator` between all elements.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// #![feature(iter_intersperse)]
+    ///
+    /// let hello = ["Hello", "World"].iter().map(|s| *s).intersperse(" ").collect::<String>();
+    /// assert_eq!(hello, "Hello World");
+    /// ```
+    #[inline]
+    #[unstable(feature = "iter_intersperse", reason = "recently added", issue = "none")]
+    fn intersperse(self, separator: Self::Item) -> Intersperse<Self>
+    where
+        Self: Sized,
+        Self::Item: Clone,
+    {
+        Intersperse::new(self, separator)
     }
 
     /// Takes a closure and creates an iterator which calls that closure on each

--- a/library/core/tests/iter.rs
+++ b/library/core/tests/iter.rs
@@ -3222,3 +3222,39 @@ fn test_flatten_non_fused_inner() {
     assert_eq!(iter.next(), Some(1));
     assert_eq!(iter.next(), None);
 }
+
+#[test]
+fn test_intersperse() {
+    let xs = ["a", "", "b", "c"];
+    let v: Vec<&str> = xs.iter().map(|x| x.clone()).intersperse(", ").collect();
+    let text: String = v.concat();
+    assert_eq!(text, "a, , b, c".to_string());
+
+    let ys = [0, 1, 2, 3];
+    let mut it = ys[..0].iter().map(|x| *x).intersperse(1);
+    assert!(it.next() == None);
+}
+
+#[test]
+fn test_intersperse_size_hint() {
+    let xs = ["a", "", "b", "c"];
+    let mut iter = xs.iter().map(|x| x.clone()).intersperse(", ");
+    assert_eq!(iter.size_hint(), (7, Some(7)));
+
+    assert_eq!(iter.next(), Some("a"));
+    assert_eq!(iter.size_hint(), (6, Some(6)));
+    assert_eq!(iter.next(), Some(", "));
+    assert_eq!(iter.size_hint(), (5, Some(5)));
+}
+
+#[test]
+fn test_fold_specialization_intersperse() {
+    let mut iter = (1..2).intersperse(0);
+    iter.clone().for_each(|x| assert_eq!(Some(x), iter.next()));
+
+    let mut iter = (1..3).intersperse(0);
+    iter.clone().for_each(|x| assert_eq!(Some(x), iter.next()));
+
+    let mut iter = (1..4).intersperse(0);
+    iter.clone().for_each(|x| assert_eq!(Some(x), iter.next()));
+}

--- a/library/core/tests/iter.rs
+++ b/library/core/tests/iter.rs
@@ -3258,3 +3258,47 @@ fn test_fold_specialization_intersperse() {
     let mut iter = (1..4).intersperse(0);
     iter.clone().for_each(|x| assert_eq!(Some(x), iter.next()));
 }
+
+#[test]
+fn test_try_fold_specialization_intersperse_ok() {
+    let mut iter = (1..2).intersperse(0);
+    iter.clone().try_for_each(|x| {
+        assert_eq!(Some(x), iter.next());
+        Some(())
+    });
+
+    let mut iter = (1..3).intersperse(0);
+    iter.clone().try_for_each(|x| {
+        assert_eq!(Some(x), iter.next());
+        Some(())
+    });
+
+    let mut iter = (1..4).intersperse(0);
+    iter.clone().try_for_each(|x| {
+        assert_eq!(Some(x), iter.next());
+        Some(())
+    });
+}
+
+#[test]
+fn test_try_fold_specialization_intersperse_err() {
+    let orig_iter = ["a", "b"].iter().copied().intersperse("-");
+
+    // Abort after the first item.
+    let mut iter = orig_iter.clone();
+    iter.try_for_each(|_| None::<()>);
+    assert_eq!(iter.next(), Some("-"));
+    assert_eq!(iter.next(), Some("b"));
+    assert_eq!(iter.next(), None);
+
+    // Abort after the second item.
+    let mut iter = orig_iter.clone();
+    iter.try_for_each(|item| if item == "-" { None } else { Some(()) });
+    assert_eq!(iter.next(), Some("b"));
+    assert_eq!(iter.next(), None);
+
+    // Abort after the third item.
+    let mut iter = orig_iter.clone();
+    iter.try_for_each(|item| if item == "b" { None } else { Some(()) });
+    assert_eq!(iter.next(), None);
+}

--- a/library/core/tests/iter.rs
+++ b/library/core/tests/iter.rs
@@ -3245,6 +3245,8 @@ fn test_intersperse_size_hint() {
     assert_eq!(iter.size_hint(), (6, Some(6)));
     assert_eq!(iter.next(), Some(", "));
     assert_eq!(iter.size_hint(), (5, Some(5)));
+
+    assert_eq!([].iter().intersperse(&()).size_hint(), (0, Some(0)));
 }
 
 #[test]

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -33,6 +33,7 @@
 #![feature(int_error_matching)]
 #![feature(array_value_iter)]
 #![feature(iter_partition_in_place)]
+#![feature(iter_intersperse)]
 #![feature(iter_is_partitioned)]
 #![feature(iter_order_by)]
 #![feature(cmp_min_max_by)]

--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -8,7 +8,6 @@ use crate::clean::{
 };
 use crate::core::DocContext;
 
-use itertools::Itertools;
 use rustc_data_structures::fx::FxHashSet;
 use rustc_hir as hir;
 use rustc_hir::def::{DefKind, Res};

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -12,6 +12,7 @@
 #![feature(crate_visibility_modifier)]
 #![feature(never_type)]
 #![feature(once_cell)]
+#![feature(iter_intersperse)]
 #![recursion_limit = "256"]
 
 #[macro_use]


### PR DESCRIPTION
This is occasionally useful when wanting to separate an iterator's items.

Implementation adapted from [itertools](https://github.com/rust-itertools/itertools).

Drawback: Breaks all code currently using itertools' `intersperse` method since the method name collides.