### PR TITLE
MIR call terminator represents diverging calls too

### DIFF
--- a/src/librustc_middle/mir/terminator/mod.rs
+++ b/src/librustc_middle/mir/terminator/mod.rs
@@ -103,7 +103,7 @@ pub enum TerminatorKind<'tcx> {
         unwind: Option<BasicBlock>,
     },
 
-    /// Block ends with a call of a converging function.
+    /// Block ends with a call of a function.
     Call {
         /// The function that’s being called.
         func: Operand<'tcx>,


### PR DESCRIPTION
@bors rollup=always