### PR TITLE
Impl task::Wake for Fn

### DIFF
--- a/library/alloc/src/task.rs
+++ b/library/alloc/src/task.rs
@@ -87,3 +87,13 @@ fn raw_waker<W: Wake + Send + Sync + 'static>(waker: Arc<W>) -> RawWaker {
         &RawWakerVTable::new(clone_waker::<W>, wake::<W>, wake_by_ref::<W>, drop_waker::<W>),
     )
 }
+
+impl<F: Fn() + Send + Sync + 'static> Wake for F {
+    fn wake(self: Arc<Self>) {
+        (self)();
+    }
+
+    fn wake_by_ref(self: &Arc<Self>) {
+        (self)();
+    }
+}


### PR DESCRIPTION
Add a blanket `alloc::task::Wake` impl for `F: Fn() + Send + Sync + 'static`.

## Motivation

The goal of the `Wake` trait is to ease the creation of `Waker`s (especially by removing the need of `unsafe`). This proposal goes further by offering to create them from closures :

```rust
use std::sync::Arc;
use std::task::Waker;

let waker = Waker::from(Arc::new(|| {
    println!("Woken !");
}));
```

## Prior art

- Crate [`waker_fn`](https://crates.io/crates/waker-fn/)
- [`async_task::waker_fn`](https://docs.rs/async-task/3.0.0/async_task/fn.waker_fn.html)

## Alternatives

- Do nothing
- Create a `Waker::from_fn` function to provide equivalent functionnality without using trait `Wake`.
