### PR TITLE
cargotest: fix clippy warnings

### DIFF
--- a/src/tools/cargotest/main.rs
+++ b/src/tools/cargotest/main.rs
@@ -11,7 +11,7 @@ struct Test {
     packages: &'static [&'static str],
 }
 
-const TEST_REPOS: &'static [Test] = &[
+const TEST_REPOS: &[Test] = &[
     Test {
         name: "iron",
         repo: "https://github.com/iron/iron",
@@ -53,9 +53,9 @@ const TEST_REPOS: &'static [Test] = &[
 
 fn main() {
     let args = env::args().collect::<Vec<_>>();
-    let ref cargo = args[1];
+    let cargo = &args[1];
     let out_dir = Path::new(&args[2]);
-    let ref cargo = Path::new(cargo);
+    let cargo = &Path::new(cargo);
 
     for test in TEST_REPOS.iter().rev() {
         test_repo(cargo, out_dir, test);
@@ -77,7 +77,7 @@ fn clone_repo(test: &Test, out_dir: &Path) -> PathBuf {
     let out_dir = out_dir.join(test.name);
 
     if !out_dir.join(".git").is_dir() {
-        let status = Command::new("git").arg("init").arg(&out_dir).status().expect("");
+        let status = Command::new("git").arg("init").arg(&out_dir).status().unwrap();
         assert!(status.success());
     }
 
@@ -92,7 +92,7 @@ fn clone_repo(test: &Test, out_dir: &Path) -> PathBuf {
                 .arg(&format!("--depth={}", depth))
                 .current_dir(&out_dir)
                 .status()
-                .expect("");
+                .unwrap();
             assert!(status.success());
         }
 
@@ -102,7 +102,7 @@ fn clone_repo(test: &Test, out_dir: &Path) -> PathBuf {
             .arg("--hard")
             .current_dir(&out_dir)
             .status()
-            .expect("");
+            .unwrap();
 
         if status.success() {
             found = true;
@@ -133,7 +133,7 @@ fn run_cargo_test(cargo_path: &Path, crate_path: &Path, packages: &[&str]) -> bo
         .env("RUSTFLAGS", "--cap-lints warn")
         .current_dir(crate_path)
         .status()
-        .expect("");
+        .unwrap();
 
     status.success()
 }


### PR DESCRIPTION
Fixes clippy::redundant_static_lifetimes and clippy::toplevel_ref_arg
I also replaced some .expect("") calls with .unwrap()s since there was no message passed by the .expect() anyway.