### PR TITLE
resolve: Do not put nonexistent crate `meta` into prelude

### DIFF
--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -1240,9 +1240,6 @@ impl<'a> Resolver<'a> {
             extern_prelude.insert(Ident::with_dummy_span(sym::core), Default::default());
             if !session.contains_name(&krate.attrs, sym::no_std) {
                 extern_prelude.insert(Ident::with_dummy_span(sym::std), Default::default());
-                if session.rust_2018() {
-                    extern_prelude.insert(Ident::with_dummy_span(sym::meta), Default::default());
-                }
             }
         }
 

--- a/src/test/ui/rfc-2126-extern-absolute-paths/meta.rs
+++ b/src/test/ui/rfc-2126-extern-absolute-paths/meta.rs
@@ -1,7 +1,0 @@
-// edition:2018
-
-// Tests that `meta` is allowed, even if the crate doesn't exist
-// yet (i.e., it causes a different error than `not-allowed.rs`).
-use meta; //~ ERROR can't find crate for `meta`
-
-fn main() {}

--- a/src/test/ui/rfc-2126-extern-absolute-paths/meta.stderr
+++ b/src/test/ui/rfc-2126-extern-absolute-paths/meta.stderr
@@ -1,9 +1,0 @@
-error[E0463]: can't find crate for `meta`
-  --> $DIR/meta.rs:5:5
-   |
-LL | use meta;
-   |     ^^^^ can't find crate
-
-error: aborting due to previous error
-
-For more information about this error, try `rustc --explain E0463`.


### PR DESCRIPTION
Before the 2018 edition release there was some vague suggestion about adding a crate named `meta` to the standard distribution.
On this basis the name `meta` was "partially reserved" by putting `meta` into extern prelude (this means importing something named `meta` will result in an ambiguity error, for example).
This only caused confusion so far, and two years later there are no specific plans to add such crate.

If some standard crate (named `meta` or not) is added in the future, then cargo will hopefully already have ability to put it into extern prelude explicitly through `Cargo.toml`.
Otherwise, it could be added to extern prelude by the compiler at edition boundary.

Closes https://github.com/rust-lang/rust/issues/73948