### PR TITLE
Convert core/num/mod.rs to intra-doc links

### DIFF
--- a/library/core/src/num/error.rs
+++ b/library/core/src/num/error.rs
@@ -54,7 +54,7 @@ impl From<!> for TryFromIntError {
 ///
 /// Among other causes, `ParseIntError` can be thrown because of leading or trailing whitespace
 /// in the string e.g., when it is obtained from the standard input.
-/// Using the [`str.trim()`] method ensures that no whitespace remains before parsing.
+/// Using the [`str::trim()`] method ensures that no whitespace remains before parsing.
 ///
 /// # Example
 ///

--- a/library/core/src/num/error.rs
+++ b/library/core/src/num/error.rs
@@ -56,9 +56,6 @@ impl From<!> for TryFromIntError {
 /// in the string e.g., when it is obtained from the standard input.
 /// Using the [`str.trim()`] method ensures that no whitespace remains before parsing.
 ///
-/// [`str.trim()`]: ../../std/primitive.str.html#method.trim
-/// [`i8::from_str_radix`]: ../../std/primitive.i8.html#method.from_str_radix
-///
 /// # Example
 ///
 /// ```

--- a/library/core/src/num/f32.rs
+++ b/library/core/src/num/f32.rs
@@ -18,7 +18,7 @@ use crate::mem;
 use crate::num::FpCategory;
 
 /// The radix or base of the internal representation of `f32`.
-/// Use [`f32::RADIX`](../../std/primitive.f32.html#associatedconstant.RADIX) instead.
+/// Use [`f32::RADIX`] instead.
 ///
 /// # Examples
 ///
@@ -832,8 +832,8 @@ impl f32 {
     /// As the target platform's native endianness is used, portable code
     /// should use [`to_be_bytes`] or [`to_le_bytes`], as appropriate, instead.
     ///
-    /// [`to_be_bytes`]: #method.to_be_bytes
-    /// [`to_le_bytes`]: #method.to_le_bytes
+    /// [`to_be_bytes`]: f32::to_be_bytes
+    /// [`to_le_bytes`]: f32::to_le_bytes
     ///
     /// # Examples
     ///
@@ -860,7 +860,7 @@ impl f32 {
     ///
     /// [`to_ne_bytes`] should be preferred over this whenever possible.
     ///
-    /// [`to_ne_bytes`]: #method.to_ne_bytes
+    /// [`to_ne_bytes`]: f32::to_ne_bytes
     ///
     /// # Examples
     ///
@@ -920,8 +920,8 @@ impl f32 {
     /// likely wants to use [`from_be_bytes`] or [`from_le_bytes`], as
     /// appropriate instead.
     ///
-    /// [`from_be_bytes`]: #method.from_be_bytes
-    /// [`from_le_bytes`]: #method.from_le_bytes
+    /// [`from_be_bytes`]: f32::from_be_bytes
+    /// [`from_le_bytes`]: f32::from_le_bytes
     ///
     /// # Examples
     ///

--- a/library/core/src/num/f64.rs
+++ b/library/core/src/num/f64.rs
@@ -846,8 +846,8 @@ impl f64 {
     /// As the target platform's native endianness is used, portable code
     /// should use [`to_be_bytes`] or [`to_le_bytes`], as appropriate, instead.
     ///
-    /// [`to_be_bytes`]: #method.to_be_bytes
-    /// [`to_le_bytes`]: #method.to_le_bytes
+    /// [`to_be_bytes`]: f64::to_be_bytes
+    /// [`to_le_bytes`]: f64::to_le_bytes
     ///
     /// # Examples
     ///
@@ -874,7 +874,7 @@ impl f64 {
     ///
     /// [`to_ne_bytes`] should be preferred over this whenever possible.
     ///
-    /// [`to_ne_bytes`]: #method.to_ne_bytes
+    /// [`to_ne_bytes`]: f64::to_ne_bytes
     ///
     /// # Examples
     ///
@@ -934,8 +934,8 @@ impl f64 {
     /// likely wants to use [`from_be_bytes`] or [`from_le_bytes`], as
     /// appropriate instead.
     ///
-    /// [`from_be_bytes`]: #method.from_be_bytes
-    /// [`from_le_bytes`]: #method.from_le_bytes
+    /// [`from_be_bytes`]: f64::from_be_bytes
+    /// [`from_le_bytes`]: f64::from_le_bytes
     ///
     /// # Examples
     ///

--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -1067,7 +1067,7 @@ macro_rules! int_impl {
         ///
         /// Note that this is *not* the same as a rotate-left; the RHS of a wrapping shift-left is restricted to
         /// the range of the type, rather than the bits shifted out of the LHS being returned to the other end.
-        /// The primitive integer types all implement a [`rotate_left`](#method.rotate_left) function,
+        /// The primitive integer types all implement a [`rotate_left`](Self::rotate_left) function,
         /// which may be what you want instead.
         ///
         /// # Examples
@@ -1096,7 +1096,7 @@ macro_rules! int_impl {
         ///
         /// Note that this is *not* the same as a rotate-right; the RHS of a wrapping shift-right is restricted
         /// to the range of the type, rather than the bits shifted out of the LHS being returned to the other
-        /// end. The primitive integer types all implement a [`rotate_right`](#method.rotate_right) function,
+        /// end. The primitive integer types all implement a [`rotate_right`](Self::rotate_right) function,
         /// which may be what you want instead.
         ///
         /// # Examples
@@ -1812,8 +1812,8 @@ macro_rules! int_impl {
         ///
         #[doc = $to_xe_bytes_doc]
         ///
-        /// [`to_be_bytes`]: #method.to_be_bytes
-        /// [`to_le_bytes`]: #method.to_le_bytes
+        /// [`to_be_bytes`]: Self::to_be_bytes
+        /// [`to_le_bytes`]: Self::to_le_bytes
         ///
         /// # Examples
         ///
@@ -1845,7 +1845,7 @@ macro_rules! int_impl {
         ///
         /// [`to_ne_bytes`] should be preferred over this whenever possible.
         ///
-        /// [`to_ne_bytes`]: #method.to_ne_bytes
+        /// [`to_ne_bytes`]: Self::to_ne_bytes
         ///
         /// # Examples
         ///
@@ -1937,8 +1937,8 @@ macro_rules! int_impl {
         /// likely wants to use [`from_be_bytes`] or [`from_le_bytes`], as
         /// appropriate instead.
         ///
-        /// [`from_be_bytes`]: #method.from_be_bytes
-        /// [`from_le_bytes`]: #method.from_le_bytes
+        /// [`from_be_bytes`]: Self::from_be_bytes
+        /// [`from_le_bytes`]: Self::from_le_bytes
         ///
         #[doc = $to_xe_bytes_doc]
         ///
@@ -1976,7 +1976,7 @@ macro_rules! int_impl {
         }
 
         /// New code should prefer to use
-        #[doc = concat!("[`", stringify!($SelfT), "::MIN", "`](#associatedconstant.MIN).")]
+        #[doc = concat!("[`", stringify!($SelfT), "::MIN", "`] instead.")]
         ///
         /// Returns the smallest value that can be represented by this integer type.
         #[stable(feature = "rust1", since = "1.0.0")]
@@ -1989,7 +1989,7 @@ macro_rules! int_impl {
         }
 
         /// New code should prefer to use
-        #[doc = concat!("[`", stringify!($SelfT), "::MAX", "`](#associatedconstant.MAX).")]
+        #[doc = concat!("[`", stringify!($SelfT), "::MAX", "`] instead.")]
         ///
         /// Returns the largest value that can be represented by this integer type.
         #[stable(feature = "rust1", since = "1.0.0")]

--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -193,7 +193,7 @@ impl u8 {
     /// assert_eq!(65, lowercase_a.to_ascii_uppercase());
     /// ```
     ///
-    /// [`make_ascii_uppercase`]: #method.make_ascii_uppercase
+    /// [`make_ascii_uppercase`]: Self::make_ascii_uppercase
     #[stable(feature = "ascii_methods_on_intrinsics", since = "1.23.0")]
     #[inline]
     pub fn to_ascii_uppercase(&self) -> u8 {
@@ -216,7 +216,7 @@ impl u8 {
     /// assert_eq!(97, uppercase_a.to_ascii_lowercase());
     /// ```
     ///
-    /// [`make_ascii_lowercase`]: #method.make_ascii_lowercase
+    /// [`make_ascii_lowercase`]: Self::make_ascii_lowercase
     #[stable(feature = "ascii_methods_on_intrinsics", since = "1.23.0")]
     #[inline]
     pub fn to_ascii_lowercase(&self) -> u8 {
@@ -266,7 +266,7 @@ impl u8 {
     /// assert_eq!(b'A', byte);
     /// ```
     ///
-    /// [`to_ascii_uppercase`]: #method.to_ascii_uppercase
+    /// [`to_ascii_uppercase`]: Self::to_ascii_uppercase
     #[stable(feature = "ascii_methods_on_intrinsics", since = "1.23.0")]
     #[inline]
     pub fn make_ascii_uppercase(&mut self) {
@@ -291,7 +291,7 @@ impl u8 {
     /// assert_eq!(b'a', byte);
     /// ```
     ///
-    /// [`to_ascii_lowercase`]: #method.to_ascii_lowercase
+    /// [`to_ascii_lowercase`]: Self::to_ascii_lowercase
     #[stable(feature = "ascii_methods_on_intrinsics", since = "1.23.0")]
     #[inline]
     pub fn make_ascii_lowercase(&mut self) {
@@ -722,9 +722,6 @@ impl usize {
 ///
 /// This `enum` is used as the return type for [`f32::classify`] and [`f64::classify`]. See
 /// their documentation for more.
-///
-/// [`f32::classify`]: ../../std/primitive.f32.html#method.classify
-/// [`f64::classify`]: ../../std/primitive.f64.html#method.classify
 ///
 /// # Examples
 ///

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -994,7 +994,7 @@ macro_rules! uint_impl {
         /// RHS of a wrapping shift-left is restricted to the range
         /// of the type, rather than the bits shifted out of the LHS
         /// being returned to the other end. The primitive integer
-        /// types all implement a [`rotate_left`](#method.rotate_left) function,
+        /// types all implement a [`rotate_left`](Self::rotate_left) function,
         /// which may be what you want instead.
         ///
         /// # Examples
@@ -1026,7 +1026,7 @@ macro_rules! uint_impl {
         /// RHS of a wrapping shift-right is restricted to the range
         /// of the type, rather than the bits shifted out of the LHS
         /// being returned to the other end. The primitive integer
-        /// types all implement a [`rotate_right`](#method.rotate_right) function,
+        /// types all implement a [`rotate_right`](Self::rotate_right) function,
         /// which may be what you want instead.
         ///
         /// # Examples
@@ -1642,8 +1642,8 @@ macro_rules! uint_impl {
         ///
         #[doc = $to_xe_bytes_doc]
         ///
-        /// [`to_be_bytes`]: #method.to_be_bytes
-        /// [`to_le_bytes`]: #method.to_le_bytes
+        /// [`to_be_bytes`]: Self::to_be_bytes
+        /// [`to_le_bytes`]: Self::to_le_bytes
         ///
         /// # Examples
         ///
@@ -1675,7 +1675,7 @@ macro_rules! uint_impl {
         ///
         /// [`to_ne_bytes`] should be preferred over this whenever possible.
         ///
-        /// [`to_ne_bytes`]: #method.to_ne_bytes
+        /// [`to_ne_bytes`]: Self::to_ne_bytes
         ///
         /// # Examples
         ///
@@ -1767,8 +1767,8 @@ macro_rules! uint_impl {
         /// likely wants to use [`from_be_bytes`] or [`from_le_bytes`], as
         /// appropriate instead.
         ///
-        /// [`from_be_bytes`]: #method.from_be_bytes
-        /// [`from_le_bytes`]: #method.from_le_bytes
+        /// [`from_be_bytes`]: Self::from_be_bytes
+        /// [`from_le_bytes`]: Self::from_le_bytes
         ///
         #[doc = $from_xe_bytes_doc]
         ///
@@ -1806,8 +1806,7 @@ macro_rules! uint_impl {
         }
 
         /// New code should prefer to use
-        #[doc = concat!("[`", stringify!($SelfT), "::MIN", "`](#associatedconstant.MIN).")]
-        /// instead.
+        #[doc = concat!("[`", stringify!($SelfT), "::MIN", "`] instead.")]
         ///
         /// Returns the smallest value that can be represented by this integer type.
         #[stable(feature = "rust1", since = "1.0.0")]
@@ -1818,8 +1817,7 @@ macro_rules! uint_impl {
         pub const fn min_value() -> Self { Self::MIN }
 
         /// New code should prefer to use
-        #[doc = concat!("[`", stringify!($SelfT), "::MAX", "`](#associatedconstant.MAX).")]
-        /// instead.
+        #[doc = concat!("[`", stringify!($SelfT), "::MAX", "`] instead.")]
         ///
         /// Returns the largest value that can be represented by this integer type.
         #[stable(feature = "rust1", since = "1.0.0")]


### PR DESCRIPTION
Helps with #75080.
This can't convert the associated constants `MAX` and `MIN` until #74489 is merged.

r? @poliorcetics