### PR TITLE
Refactor dynamic library error checking on *nix

### DIFF
--- a/src/librustc_metadata/dynamic_lib.rs
+++ b/src/librustc_metadata/dynamic_lib.rs
@@ -99,10 +99,10 @@ mod dl {
         let s = CString::new(filename.as_bytes()).unwrap();
 
         let mut dlerror = error::lock();
-        let ret = unsafe { libc::dlopen(s.as_ptr(), libc::RTLD_LAZY) } as *mut u8;
+        let ret = unsafe { libc::dlopen(s.as_ptr(), libc::RTLD_LAZY | libc::RTLD_LOCAL) };
 
         if !ret.is_null() {
-            return Ok(ret);
+            return Ok(ret.cast());
         }
 
         // A NULL return from `dlopen` indicates that an error has definitely occurred, so if
@@ -122,10 +122,10 @@ mod dl {
         // error message by accident.
         dlerror.clear();
 
-        let ret = libc::dlsym(handle as *mut libc::c_void, symbol) as *mut u8;
+        let ret = libc::dlsym(handle as *mut libc::c_void, symbol);
 
         if !ret.is_null() {
-            return Ok(ret);
+            return Ok(ret.cast());
         }
 
         // If `dlsym` returns NULL but there is nothing in `dlerror` it means one of two things:

--- a/src/librustc_metadata/lib.rs
+++ b/src/librustc_metadata/lib.rs
@@ -5,6 +5,7 @@
 #![feature(drain_filter)]
 #![feature(in_band_lifetimes)]
 #![feature(nll)]
+#![feature(once_cell)]
 #![feature(or_patterns)]
 #![feature(proc_macro_internals)]
 #![feature(min_specialization)]


### PR DESCRIPTION
The old code was checking `dlerror` more often than necessary, since (unlike `dlsym`) checking the return value of [`dlopen`](https://www.man7.org/linux/man-pages/man3/dlopen.3.html) is enough to indicate whether an error occurred. In the first commit, I've refactored the code to minimize the number of system calls needed. It should be strictly better than the old version.

The second commit is an optional addendum which fixes the issue observed on illumos in #74469, a PR I reviewed that was ultimately closed due to inactivity. I'm not sure how hard we try to work around platform-specific bugs like this, and I believe that, due to the way that `dlerror` is specified in the POSIX standard, libc implementations that want to run on conforming systems cannot call `dlsym` in multi-threaded programs.