### PR TITLE
Use intra-doc-links in `core::{char, macros, fmt}`

### DIFF
--- a/library/core/src/char/mod.rs
+++ b/library/core/src/char/mod.rs
@@ -94,7 +94,6 @@ const MAX_THREE_B: u32 = 0x10000;
 /// Point], but only ones within a certain range. `MAX` is the highest valid
 /// code point that's a valid [Unicode Scalar Value].
 ///
-/// [`char`]: ../../std/primitive.char.html
 /// [Unicode Scalar Value]: http://www.unicode.org/glossary/#unicode_scalar_value
 /// [Code Point]: http://www.unicode.org/glossary/#code_point
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -114,8 +113,7 @@ pub const REPLACEMENT_CHARACTER: char = char::REPLACEMENT_CHARACTER;
 /// This `struct` is created by the [`escape_unicode`] method on [`char`]. See
 /// its documentation for more.
 ///
-/// [`escape_unicode`]: ../../std/primitive.char.html#method.escape_unicode
-/// [`char`]: ../../std/primitive.char.html
+/// [`escape_unicode`]: char::escape_unicode
 #[derive(Clone, Debug)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct EscapeUnicode {
@@ -236,8 +234,7 @@ impl fmt::Display for EscapeUnicode {
 /// This `struct` is created by the [`escape_default`] method on [`char`]. See
 /// its documentation for more.
 ///
-/// [`escape_default`]: ../../std/primitive.char.html#method.escape_default
-/// [`char`]: ../../std/primitive.char.html
+/// [`escape_default`]: char::escape_default
 #[derive(Clone, Debug)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct EscapeDefault {
@@ -345,8 +342,7 @@ impl fmt::Display for EscapeDefault {
 /// This `struct` is created by the [`escape_debug`] method on [`char`]. See its
 /// documentation for more.
 ///
-/// [`escape_debug`]: ../../std/primitive.char.html#method.escape_debug
-/// [`char`]: ../../std/primitive.char.html
+/// [`escape_debug`]: char::escape_debug
 #[stable(feature = "char_escape_debug", since = "1.20.0")]
 #[derive(Clone, Debug)]
 pub struct EscapeDebug(EscapeDefault);
@@ -380,8 +376,7 @@ impl fmt::Display for EscapeDebug {
 /// This `struct` is created by the [`to_lowercase`] method on [`char`]. See
 /// its documentation for more.
 ///
-/// [`to_lowercase`]: ../../std/primitive.char.html#method.to_lowercase
-/// [`char`]: ../../std/primitive.char.html
+/// [`to_lowercase`]: char::to_lowercase
 #[stable(feature = "rust1", since = "1.0.0")]
 #[derive(Debug, Clone)]
 pub struct ToLowercase(CaseMappingIter);
@@ -408,8 +403,7 @@ impl ExactSizeIterator for ToLowercase {}
 /// This `struct` is created by the [`to_uppercase`] method on [`char`]. See
 /// its documentation for more.
 ///
-/// [`to_uppercase`]: ../../std/primitive.char.html#method.to_uppercase
-/// [`char`]: ../../std/primitive.char.html
+/// [`to_uppercase`]: char::to_uppercase
 #[stable(feature = "rust1", since = "1.0.0")]
 #[derive(Debug, Clone)]
 pub struct ToUppercase(CaseMappingIter);

--- a/library/core/src/fmt/mod.rs
+++ b/library/core/src/fmt/mod.rs
@@ -117,8 +117,6 @@ pub trait Write {
     ///
     /// This function will return an instance of [`Error`] on error.
     ///
-    /// [`Error`]: struct.Error.html
-    ///
     /// # Examples
     ///
     /// ```
@@ -145,9 +143,6 @@ pub trait Write {
     /// # Errors
     ///
     /// This function will return an instance of [`Error`] on error.
-    ///
-    /// [`char`]: ../../std/primitive.char.html
-    /// [`Error`]: struct.Error.html
     ///
     /// # Examples
     ///
@@ -218,9 +213,6 @@ impl<W: Write + ?Sized> Write for &mut W {
 /// To interact with a `Formatter`, you'll call various methods to change the
 /// various options related to formatting. For examples, please see the
 /// documentation of the methods defined on `Formatter` below.
-///
-/// [`Debug`]: trait.Debug.html
-/// [`Display`]: trait.Display.html
 #[allow(missing_debug_implementations)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct Formatter<'a> {
@@ -378,7 +370,7 @@ impl<'a> Arguments<'a> {
 ///
 /// The [`format_args!`] macro will safely create an instance of this structure.
 /// The macro validates the format string at compile-time so usage of the
-/// [`write`] and [`format`] functions can be safely performed.
+/// [`write()`] and [`format()`] functions can be safely performed.
 ///
 /// You can use the `Arguments<'a>` that [`format_args!`] returns in `Debug`
 /// and `Display` contexts as seen below. The example also shows that `Debug`
@@ -392,9 +384,7 @@ impl<'a> Arguments<'a> {
 /// assert_eq!(display, debug);
 /// ```
 ///
-/// [`format_args!`]: ../../std/macro.format_args.html
-/// [`format`]: ../../std/fmt/fn.format.html
-/// [`write`]: ../../std/fmt/fn.write.html
+/// [`format()`]: ../../std/fmt/fn.format.html
 #[stable(feature = "rust1", since = "1.0.0")]
 #[derive(Copy, Clone)]
 pub struct Arguments<'a> {
@@ -472,9 +462,7 @@ impl Display for Arguments<'_> {
 ///
 /// When used with the alternate format specifier `#?`, the output is pretty-printed.
 ///
-/// For more information on formatters, see [the module-level documentation][module].
-///
-/// [module]: ../../std/fmt/index.html
+/// For more information on formatters, see [the module-level documentation][self].
 ///
 /// This trait can be used with `#[derive]` if all fields implement `Debug`. When
 /// `derive`d for structs, it will use the name of the `struct`, then `{`, then a
@@ -535,8 +523,7 @@ impl Display for Arguments<'_> {
 /// `Debug` implementations using either `derive` or the debug builder API
 /// on [`Formatter`] support pretty-printing using the alternate flag: `{:#?}`.
 ///
-/// [`debug_struct`]: ../../std/fmt/struct.Formatter.html#method.debug_struct
-/// [`Formatter`]: ../../std/fmt/struct.Formatter.html
+/// [`debug_struct`]: Formatter::debug_struct
 ///
 /// Pretty-printing with `#?`:
 ///
@@ -618,14 +605,10 @@ pub use macros::Debug;
 
 /// Format trait for an empty format, `{}`.
 ///
-/// `Display` is similar to [`Debug`][debug], but `Display` is for user-facing
+/// `Display` is similar to [`Debug`], but `Display` is for user-facing
 /// output, and so cannot be derived.
 ///
-/// [debug]: trait.Debug.html
-///
-/// For more information on formatters, see [the module-level documentation][module].
-///
-/// [module]: ../../std/fmt/index.html
+/// For more information on formatters, see [the module-level documentation][self].
 ///
 /// # Examples
 ///
@@ -697,9 +680,7 @@ pub trait Display {
 ///
 /// The alternate flag, `#`, adds a `0o` in front of the output.
 ///
-/// For more information on formatters, see [the module-level documentation][module].
-///
-/// [module]: ../../std/fmt/index.html
+/// For more information on formatters, see [the module-level documentation][self].
 ///
 /// # Examples
 ///
@@ -751,7 +732,7 @@ pub trait Octal {
 ///
 /// The alternate flag, `#`, adds a `0b` in front of the output.
 ///
-/// For more information on formatters, see [the module-level documentation][module].
+/// For more information on formatters, see [the module-level documentation][self].
 ///
 /// # Examples
 ///
@@ -790,12 +771,6 @@ pub trait Octal {
 ///     "l as binary is: 0b000000000000000000000001101011"
 /// );
 /// ```
-///
-/// [module]: ../../std/fmt/index.html
-/// [`i8`]: ../../std/primitive.i8.html
-/// [`i128`]: ../../std/primitive.i128.html
-/// [`isize`]: ../../std/primitive.isize.html
-/// [`i32`]: ../../std/primitive.i32.html
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait Binary {
     /// Formats the value using the given formatter.
@@ -813,9 +788,7 @@ pub trait Binary {
 ///
 /// The alternate flag, `#`, adds a `0x` in front of the output.
 ///
-/// For more information on formatters, see [the module-level documentation][module].
-///
-/// [module]: ../../std/fmt/index.html
+/// For more information on formatters, see [the module-level documentation][self].
 ///
 /// # Examples
 ///
@@ -868,9 +841,7 @@ pub trait LowerHex {
 ///
 /// The alternate flag, `#`, adds a `0x` in front of the output.
 ///
-/// For more information on formatters, see [the module-level documentation][module].
-///
-/// [module]: ../../std/fmt/index.html
+/// For more information on formatters, see [the module-level documentation][self].
 ///
 /// # Examples
 ///
@@ -918,9 +889,7 @@ pub trait UpperHex {
 /// The `Pointer` trait should format its output as a memory location. This is commonly presented
 /// as hexadecimal.
 ///
-/// For more information on formatters, see [the module-level documentation][module].
-///
-/// [module]: ../../std/fmt/index.html
+/// For more information on formatters, see [the module-level documentation][self].
 ///
 /// # Examples
 ///
@@ -967,9 +936,7 @@ pub trait Pointer {
 ///
 /// The `LowerExp` trait should format its output in scientific notation with a lower-case `e`.
 ///
-/// For more information on formatters, see [the module-level documentation][module].
-///
-/// [module]: ../../std/fmt/index.html
+/// For more information on formatters, see [the module-level documentation][self].
 ///
 /// # Examples
 ///
@@ -1018,9 +985,7 @@ pub trait LowerExp {
 ///
 /// The `UpperExp` trait should format its output in scientific notation with an upper-case `E`.
 ///
-/// For more information on formatters, see [the module-level documentation][module].
-///
-/// [module]: ../../std/fmt/index.html
+/// For more information on formatters, see [the module-level documentation][self].
 ///
 /// # Examples
 ///
@@ -1812,8 +1777,7 @@ impl<'a> Formatter<'a> {
     /// Creates a [`DebugStruct`] builder designed to assist with creation of
     /// [`fmt::Debug`] implementations for structs.
     ///
-    /// [`DebugStruct`]: ../../std/fmt/struct.DebugStruct.html
-    /// [`fmt::Debug`]: ../../std/fmt/trait.Debug.html
+    /// [`fmt::Debug`]: self::Debug
     ///
     /// # Examples
     ///

--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -28,9 +28,6 @@ macro_rules! panic {
 /// Like [`assert!`], this macro has a second form, where a custom
 /// panic message can be provided.
 ///
-/// [`PartialEq`]: cmp/trait.PartialEq.html
-/// [`assert!`]: macro.assert.html
-///
 /// # Examples
 ///
 /// ```
@@ -84,9 +81,6 @@ macro_rules! assert_eq {
 ///
 /// Like [`assert!`], this macro has a second form, where a custom
 /// panic message can be provided.
-///
-/// [`PartialEq`]: cmp/trait.PartialEq.html
-/// [`assert!`]: macro.assert.html
 ///
 /// # Examples
 ///
@@ -158,9 +152,6 @@ macro_rules! assert_ne {
 /// with `debug_assert!` is thus only encouraged after thorough profiling, and
 /// more importantly, only in safe code!
 ///
-/// [`panic!`]: macro.panic.html
-/// [`assert!`]: macro.assert.html
-///
 /// # Examples
 ///
 /// ```
@@ -196,8 +187,6 @@ macro_rules! debug_assert {
 /// expensive to be present in a release build but may be helpful during
 /// development. The result of expanding `debug_assert_eq!` is always type checked.
 ///
-/// [`assert_eq!`]: ../std/macro.assert_eq.html
-///
 /// # Examples
 ///
 /// ```
@@ -222,8 +211,6 @@ macro_rules! debug_assert_eq {
 /// compiler. This makes `debug_assert_ne!` useful for checks that are too
 /// expensive to be present in a release build but may be helpful during
 /// development. The result of expanding `debug_assert_ne!` is always type checked.
-///
-/// [`assert_ne!`]: ../std/macro.assert_ne.html
 ///
 /// # Examples
 ///
@@ -281,8 +268,6 @@ macro_rules! matches {
 ///
 /// Because of the early return, `try!` can only be used in functions that
 /// return [`Result`].
-///
-/// [`Result`]: ../std/result/enum.Result.html
 ///
 /// # Examples
 ///
@@ -354,10 +339,10 @@ macro_rules! r#try {
 ///
 /// See [`std::fmt`] for more information on the format string syntax.
 ///
-/// [`std::fmt`]: ../std/fmt/index.html
-/// [`std::fmt::Write`]: ../std/fmt/trait.Write.html
+/// [`std::fmt`]: crate::fmt
+/// [`std::fmt::Write`]: crate::fmt::Write
 /// [`std::io::Write`]: ../std/io/trait.Write.html
-/// [`std::fmt::Result`]: ../std/fmt/type.Result.html
+/// [`std::fmt::Result`]: crate::fmt::Result
 /// [`io::Result`]: ../std/io/type.Result.html
 ///
 /// # Examples
@@ -426,9 +411,7 @@ macro_rules! write {
 /// For more information, see [`write!`]. For information on the format string syntax, see
 /// [`std::fmt`].
 ///
-/// [`write!`]: macro.write.html
-/// [`std::fmt`]: ../std/fmt/index.html
-///
+/// [`std::fmt`]: crate::fmt
 ///
 /// # Examples
 ///
@@ -494,15 +477,11 @@ macro_rules! writeln {
 /// The unsafe counterpart of this macro is the [`unreachable_unchecked`] function, which
 /// will cause undefined behavior if the code is reached.
 ///
-/// [`panic!`]: ../std/macro.panic.html
-/// [`unreachable_unchecked`]: ../std/hint/fn.unreachable_unchecked.html
-/// [`std::hint`]: ../std/hint/index.html
+/// [`unreachable_unchecked`]: crate::hint::unreachable_unchecked
 ///
 /// # Panics
 ///
 /// This will always [`panic!`]
-///
-/// [`panic!`]: ../std/macro.panic.html
 ///
 /// # Examples
 ///
@@ -637,8 +616,6 @@ macro_rules! unimplemented {
 /// implemented", `unimplemented!` makes no such claims. Its message is "not implemented".
 /// Also some IDEs will mark `todo!`s.
 ///
-/// [`unimplemented!`]: macro.unimplemented.html
-///
 /// # Panics
 ///
 /// This will always [panic!](macro.panic.html)
@@ -730,8 +707,6 @@ pub(crate) mod builtin {
     /// #[cfg(not(any(feature = "foo", feature = "bar")))]
     /// compile_error!("Either feature \"foo\" or \"bar\" must be enabled for this crate.");
     /// ```
-    ///
-    /// [`panic!`]: ../std/macro.panic.html
     #[stable(feature = "compile_error_macro", since = "1.20.0")]
     #[rustc_builtin_macro]
     #[macro_export]
@@ -769,12 +744,11 @@ pub(crate) mod builtin {
     ///
     /// For more information, see the documentation in [`std::fmt`].
     ///
-    /// [`Display`]: ../std/fmt/trait.Display.html
-    /// [`Debug`]: ../std/fmt/trait.Debug.html
-    /// [`fmt::Arguments`]: ../std/fmt/struct.Arguments.html
-    /// [`std::fmt`]: ../std/fmt/index.html
+    /// [`Display`]: crate::fmt::Display
+    /// [`Debug`]: crate::fmt::Debug
+    /// [`fmt::Arguments`]: crate::fmt::Arguments
+    /// [`std::fmt`]: crate::fmt
     /// [`format!`]: ../std/macro.format.html
-    /// [`write!`]: ../std/macro.write.html
     /// [`println!`]: ../std/macro.println.html
     ///
     /// # Examples
@@ -818,8 +792,6 @@ pub(crate) mod builtin {
     /// will be emitted. To not emit a compile error, use the [`option_env!`]
     /// macro instead.
     ///
-    /// [`option_env!`]: ../std/macro.option_env.html
-    ///
     /// # Examples
     ///
     /// ```
@@ -854,12 +826,10 @@ pub(crate) mod builtin {
     /// expand into an expression of type `Option<&'static str>` whose value is
     /// `Some` of the value of the environment variable. If the environment
     /// variable is not present, then this will expand to `None`. See
-    /// [`Option<T>`][option] for more information on this type.
+    /// [`Option<T>`][Option] for more information on this type.
     ///
     /// A compile time error is never emitted when using this macro regardless
     /// of whether the environment variable is present or not.
-    ///
-    /// [option]: ../std/option/enum.Option.html
     ///
     /// # Examples
     ///
@@ -946,9 +916,6 @@ pub(crate) mod builtin {
     /// but rather the first macro invocation leading up to the invocation
     /// of the `line!` macro.
     ///
-    /// [`column!`]: macro.column.html
-    /// [`file!`]: macro.file.html
-    ///
     /// # Examples
     ///
     /// ```
@@ -976,9 +943,6 @@ pub(crate) mod builtin {
     /// but rather the first macro invocation leading up to the invocation
     /// of the `column!` macro.
     ///
-    /// [`line!`]: macro.line.html
-    /// [`file!`]: macro.file.html
-    ///
     /// # Examples
     ///
     /// ```
@@ -999,14 +963,10 @@ pub(crate) mod builtin {
     /// With [`line!`] and [`column!`], these macros provide debugging information for
     /// developers about the location within the source.
     ///
-    ///
     /// The expanded expression has type `&'static str`, and the returned file
     /// is not the invocation of the `file!` macro itself, but rather the
     /// first macro invocation leading up to the invocation of the `file!`
     /// macro.
-    ///
-    /// [`line!`]: macro.line.html
-    /// [`column!`]: macro.column.html
     ///
     /// # Examples
     ///
@@ -1258,9 +1218,7 @@ pub(crate) mod builtin {
     /// be provided with or without arguments for formatting. See [`std::fmt`]
     /// for syntax for this form.
     ///
-    /// [`panic!`]: macro.panic.html
-    /// [`debug_assert!`]: macro.debug_assert.html
-    /// [`std::fmt`]: ../std/fmt/index.html
+    /// [`std::fmt`]: crate::fmt
     ///
     /// # Examples
     ///


### PR DESCRIPTION
Helps with #75080.
r? @jyn514