### PR TITLE
Corrected Misleading documentation for derived Ord/PartialOrd implementation 

### DIFF
--- a/library/core/src/cmp.rs
+++ b/library/core/src/cmp.rs
@@ -505,7 +505,7 @@ impl<T: Ord> Ord for Reverse<T> {
 ///
 /// This trait can be used with `#[derive]`. When `derive`d on structs, it will produce a
 /// lexicographic ordering based on the top-to-bottom declaration order of the struct's members.
-/// When `derive`d on enums, variants are ordered by their top-to-bottom declaration order.
+/// When `derive`d on enums, variants are ordered by their top-to-bottom discriminant order.
 ///
 /// ## How can I implement `Ord`?
 ///
@@ -694,7 +694,7 @@ impl PartialOrd for Ordering {
 ///
 /// This trait can be used with `#[derive]`. When `derive`d on structs, it will produce a
 /// lexicographic ordering based on the top-to-bottom declaration order of the struct's members.
-/// When `derive`d on enums, variants are ordered by their top-to-bottom declaration order.
+/// When `derive`d on enums, variants are ordered by their top-to-bottom discriminant order.
 ///
 /// ## How can I implement `PartialOrd`?
 ///


### PR DESCRIPTION
Corrected Misleading documentation for derived Ord/PartialOrd implementation 

Fixes #75620 