### PR TITLE
Fix font color for help button in ayu and dark themes

### DIFF
--- a/src/librustdoc/html/static/themes/ayu.css
+++ b/src/librustdoc/html/static/themes/ayu.css
@@ -495,6 +495,7 @@ kbd {
 #theme-picker, #settings-menu, .help-button {
 	border-color: #5c6773;
 	background-color: #0f1419;
+	color: #fff;
 }
 
 #theme-picker > img, #settings-menu > img {

--- a/src/librustdoc/html/static/themes/dark.css
+++ b/src/librustdoc/html/static/themes/dark.css
@@ -389,6 +389,7 @@ kbd {
 #theme-picker, #settings-menu, .help-button {
 	border-color: #e0e0e0;
 	background: #f0f0f0;
+	color: #000;
 }
 
 #theme-picker:hover, #theme-picker:focus,


### PR DESCRIPTION
A nice before/after:

![Screenshot from 2020-08-23 14-47-07](https://user-images.githubusercontent.com/3050060/90979230-0dd07400-e554-11ea-85f7-046dfca65e8e.png)

![Screenshot from 2020-08-23 14-47-03](https://user-images.githubusercontent.com/3050060/90979233-145eeb80-e554-11ea-8e63-1864c3f2699b.png)

For the ayu theme, the change is very "light", the font color was already close to white, so I unified the color with the pictures of the other buttons:

![Screenshot from 2020-08-23 15-20-45](https://user-images.githubusercontent.com/3050060/90979281-5e47d180-e554-11ea-9993-8595057481ab.png)
![Screenshot from 2020-08-23 15-20-50](https://user-images.githubusercontent.com/3050060/90979279-5daf3b00-e554-11ea-8d39-beb57091aba7.png)
