### PR TITLE
HermitCore switchs to relocatable binaries

### DIFF
--- a/src/librustc_target/spec/aarch64_unknown_hermit.rs
+++ b/src/librustc_target/spec/aarch64_unknown_hermit.rs
@@ -1,10 +1,8 @@
-use crate::spec::{LinkerFlavor, Target, TargetResult};
+use crate::spec::{LinkerFlavor, LldFlavor, Target, TargetResult};
 
 pub fn target() -> TargetResult {
     let mut base = super::hermit_base::opts();
     base.max_atomic_width = Some(128);
-    base.unsupported_abis = super::arm_base::unsupported_abis();
-    base.linker = Some("aarch64-hermit-gcc".to_string());
 
     Ok(Target {
         llvm_target: "aarch64-unknown-hermit".to_string(),
@@ -16,7 +14,7 @@ pub fn target() -> TargetResult {
         target_os: "hermit".to_string(),
         target_env: String::new(),
         target_vendor: "unknown".to_string(),
-        linker_flavor: LinkerFlavor::Gcc,
+        linker_flavor: LinkerFlavor::Lld(LldFlavor::Ld),
         options: base,
     })
 }

--- a/src/librustc_target/spec/hermit_base.rs
+++ b/src/librustc_target/spec/hermit_base.rs
@@ -16,7 +16,8 @@ pub fn opts() -> TargetOptions {
         pre_link_args,
         panic_strategy: PanicStrategy::Abort,
         position_independent_executables: true,
-        relocation_model: RelocModel::Static,
+        static_position_independent_executables: true,
+        relocation_model: RelocModel::Pic,
         target_family: None,
         tls_model: TlsModel::InitialExec,
         ..Default::default()

--- a/src/librustc_target/spec/hermit_kernel_base.rs
+++ b/src/librustc_target/spec/hermit_kernel_base.rs
@@ -17,7 +17,8 @@ pub fn opts() -> TargetOptions {
         pre_link_args,
         panic_strategy: PanicStrategy::Abort,
         position_independent_executables: true,
-        relocation_model: RelocModel::Static,
+        static_position_independent_executables: true,
+        relocation_model: RelocModel::Pic,
         target_family: None,
         tls_model: TlsModel::InitialExec,
         ..Default::default()


### PR DESCRIPTION
- switch to relocatbale binaries to realize ASLR
- remove all dependencies to gcc