### PR TITLE
publish-toolstate: show more context on HTTP error

### DIFF
--- a/src/tools/publish_toolstate.py
+++ b/src/tools/publish_toolstate.py
@@ -275,7 +275,7 @@ def update_latest(
         return message
 
 
-if __name__ == '__main__':
+def main():
     repo = os.environ.get('TOOLSTATE_VALIDATE_MAINTAINERS_REPO')
     if repo:
         github_token = os.environ.get('TOOLSTATE_REPO_ACCESS_TOKEN')
@@ -342,3 +342,11 @@ if __name__ == '__main__':
         }
     ))
     response.read()
+
+
+if __name__ == '__main__':
+    try:
+        main()
+    except urllib2.HTTPError as e:
+        print("HTTPError: %s\n%s" % (e, e.read()))
+        raise


### PR DESCRIPTION
The default display for HTTPError in Python does not include the request body. For GitHub API, the body includes more details about the error (like rate limiting). This could help diagnosing errors like this: https://github.com/rust-lang/rust/pull/75815#issuecomment-678798158
