### PR TITLE
Switch to intra-doc links in `core::array`

### DIFF
--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -32,9 +32,6 @@ pub use iter::IntoIter;
 /// Note that the traits [`AsRef`] and [`AsMut`] provide similar methods for types that
 /// may not be fixed-size arrays. Implementors should prefer those traits
 /// instead.
-///
-/// [`AsRef`]: ../convert/trait.AsRef.html
-/// [`AsMut`]: ../convert/trait.AsMut.html
 #[unstable(feature = "fixed_size_array", issue = "27778")]
 pub unsafe trait FixedSizeArray<T> {
     /// Converts the array to immutable slice


### PR DESCRIPTION
Part of #75080.

@rustbot modify labels: A-intra-doc-links T-doc T-rustdoc