### PR TITLE
Use allow(unused_imports) instead of cfg(doc) for imports used only for intra-doc links

### DIFF
--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -58,7 +58,7 @@ use crate::marker::DiscriminantKind;
 use crate::mem;
 
 // These imports are used for simplifying intra-doc links
-#[cfg(doc)]
+#[allow(unused_imports)]
 use crate::sync::atomic::{self, AtomicBool, AtomicI32, AtomicIsize, AtomicU32, Ordering};
 
 #[stable(feature = "drop_in_place", since = "1.8.0")]

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -59,6 +59,7 @@ use crate::mem;
 
 // These imports are used for simplifying intra-doc links
 #[allow(unused_imports)]
+#[cfg(all(target_has_atomic = "8", target_has_atomic = "32", target_has_atomic = "ptr"))]
 use crate::sync::atomic::{self, AtomicBool, AtomicI32, AtomicIsize, AtomicU32, Ordering};
 
 #[stable(feature = "drop_in_place", since = "1.8.0")]


### PR DESCRIPTION
This prevents links from breaking when items are re-exported in a
different crate and the original isn't being documented.

Spotted in https://github.com/rust-lang/rust/pull/75832#discussion_r475275837 (thanks ollie!)

r? @ollie27 