### PR TITLE
doc: Fix typo in std::process::Child documentation

### DIFF
--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -126,7 +126,7 @@ use crate::sys_common::{AsInner, AsInnerMut, FromInner, IntoInner};
 ///
 /// # Warning
 ///
-/// On some system, calling [`wait`] or similar is necessary for the OS to
+/// On some systems, calling [`wait`] or similar is necessary for the OS to
 /// release resources. A process that terminated but has not been waited on is
 /// still around as a "zombie". Leaving too many zombies around may exhaust
 /// global resources (for example process IDs).


### PR DESCRIPTION
Nearly done reading stdlib docs, found another small typo, here's a PR!

r? @steveklabnik