### PR TITLE
Rollup of 11 pull requests

### DIFF
--- a/library/alloc/src/collections/binary_heap.rs
+++ b/library/alloc/src/collections/binary_heap.rs
@@ -12,9 +12,9 @@
 //! to solve the [shortest path problem][sssp] on a [directed graph][dir_graph].
 //! It shows how to use [`BinaryHeap`] with custom types.
 //!
-//! [dijkstra]: http://en.wikipedia.org/wiki/Dijkstra%27s_algorithm
-//! [sssp]: http://en.wikipedia.org/wiki/Shortest_path_problem
-//! [dir_graph]: http://en.wikipedia.org/wiki/Directed_graph
+//! [dijkstra]: https://en.wikipedia.org/wiki/Dijkstra%27s_algorithm
+//! [sssp]: https://en.wikipedia.org/wiki/Shortest_path_problem
+//! [dir_graph]: https://en.wikipedia.org/wiki/Directed_graph
 //! [`BinaryHeap`]: struct.BinaryHeap.html
 //!
 //! ```

--- a/library/core/src/char/mod.rs
+++ b/library/core/src/char/mod.rs
@@ -94,7 +94,6 @@ const MAX_THREE_B: u32 = 0x10000;
 /// Point], but only ones within a certain range. `MAX` is the highest valid
 /// code point that's a valid [Unicode Scalar Value].
 ///
-/// [`char`]: ../../std/primitive.char.html
 /// [Unicode Scalar Value]: http://www.unicode.org/glossary/#unicode_scalar_value
 /// [Code Point]: http://www.unicode.org/glossary/#code_point
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -114,8 +113,7 @@ pub const REPLACEMENT_CHARACTER: char = char::REPLACEMENT_CHARACTER;
 /// This `struct` is created by the [`escape_unicode`] method on [`char`]. See
 /// its documentation for more.
 ///
-/// [`escape_unicode`]: ../../std/primitive.char.html#method.escape_unicode
-/// [`char`]: ../../std/primitive.char.html
+/// [`escape_unicode`]: char::escape_unicode
 #[derive(Clone, Debug)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct EscapeUnicode {
@@ -236,8 +234,7 @@ impl fmt::Display for EscapeUnicode {
 /// This `struct` is created by the [`escape_default`] method on [`char`]. See
 /// its documentation for more.
 ///
-/// [`escape_default`]: ../../std/primitive.char.html#method.escape_default
-/// [`char`]: ../../std/primitive.char.html
+/// [`escape_default`]: char::escape_default
 #[derive(Clone, Debug)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct EscapeDefault {
@@ -345,8 +342,7 @@ impl fmt::Display for EscapeDefault {
 /// This `struct` is created by the [`escape_debug`] method on [`char`]. See its
 /// documentation for more.
 ///
-/// [`escape_debug`]: ../../std/primitive.char.html#method.escape_debug
-/// [`char`]: ../../std/primitive.char.html
+/// [`escape_debug`]: char::escape_debug
 #[stable(feature = "char_escape_debug", since = "1.20.0")]
 #[derive(Clone, Debug)]
 pub struct EscapeDebug(EscapeDefault);
@@ -380,8 +376,7 @@ impl fmt::Display for EscapeDebug {
 /// This `struct` is created by the [`to_lowercase`] method on [`char`]. See
 /// its documentation for more.
 ///
-/// [`to_lowercase`]: ../../std/primitive.char.html#method.to_lowercase
-/// [`char`]: ../../std/primitive.char.html
+/// [`to_lowercase`]: char::to_lowercase
 #[stable(feature = "rust1", since = "1.0.0")]
 #[derive(Debug, Clone)]
 pub struct ToLowercase(CaseMappingIter);
@@ -408,8 +403,7 @@ impl ExactSizeIterator for ToLowercase {}
 /// This `struct` is created by the [`to_uppercase`] method on [`char`]. See
 /// its documentation for more.
 ///
-/// [`to_uppercase`]: ../../std/primitive.char.html#method.to_uppercase
-/// [`char`]: ../../std/primitive.char.html
+/// [`to_uppercase`]: char::to_uppercase
 #[stable(feature = "rust1", since = "1.0.0")]
 #[derive(Debug, Clone)]
 pub struct ToUppercase(CaseMappingIter);

--- a/library/core/src/cmp.rs
+++ b/library/core/src/cmp.rs
@@ -25,7 +25,7 @@
 use self::Ordering::*;
 
 /// Trait for equality comparisons which are [partial equivalence
-/// relations](http://en.wikipedia.org/wiki/Partial_equivalence_relation).
+/// relations](https://en.wikipedia.org/wiki/Partial_equivalence_relation).
 ///
 /// This trait allows for partial equality, for types that do not have a full
 /// equivalence relation. For example, in floating point numbers `NaN != NaN`,

--- a/library/core/src/cmp.rs
+++ b/library/core/src/cmp.rs
@@ -505,7 +505,7 @@ impl<T: Ord> Ord for Reverse<T> {
 ///
 /// This trait can be used with `#[derive]`. When `derive`d on structs, it will produce a
 /// lexicographic ordering based on the top-to-bottom declaration order of the struct's members.
-/// When `derive`d on enums, variants are ordered by their top-to-bottom declaration order.
+/// When `derive`d on enums, variants are ordered by their top-to-bottom discriminant order.
 ///
 /// ## How can I implement `Ord`?
 ///
@@ -694,7 +694,7 @@ impl PartialOrd for Ordering {
 ///
 /// This trait can be used with `#[derive]`. When `derive`d on structs, it will produce a
 /// lexicographic ordering based on the top-to-bottom declaration order of the struct's members.
-/// When `derive`d on enums, variants are ordered by their top-to-bottom declaration order.
+/// When `derive`d on enums, variants are ordered by their top-to-bottom discriminant order.
 ///
 /// ## How can I implement `PartialOrd`?
 ///

--- a/library/core/src/fmt/mod.rs
+++ b/library/core/src/fmt/mod.rs
@@ -117,8 +117,6 @@ pub trait Write {
     ///
     /// This function will return an instance of [`Error`] on error.
     ///
-    /// [`Error`]: struct.Error.html
-    ///
     /// # Examples
     ///
     /// ```
@@ -145,9 +143,6 @@ pub trait Write {
     /// # Errors
     ///
     /// This function will return an instance of [`Error`] on error.
-    ///
-    /// [`char`]: ../../std/primitive.char.html
-    /// [`Error`]: struct.Error.html
     ///
     /// # Examples
     ///
@@ -218,9 +213,6 @@ impl<W: Write + ?Sized> Write for &mut W {
 /// To interact with a `Formatter`, you'll call various methods to change the
 /// various options related to formatting. For examples, please see the
 /// documentation of the methods defined on `Formatter` below.
-///
-/// [`Debug`]: trait.Debug.html
-/// [`Display`]: trait.Display.html
 #[allow(missing_debug_implementations)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct Formatter<'a> {
@@ -378,7 +370,7 @@ impl<'a> Arguments<'a> {
 ///
 /// The [`format_args!`] macro will safely create an instance of this structure.
 /// The macro validates the format string at compile-time so usage of the
-/// [`write`] and [`format`] functions can be safely performed.
+/// [`write()`] and [`format()`] functions can be safely performed.
 ///
 /// You can use the `Arguments<'a>` that [`format_args!`] returns in `Debug`
 /// and `Display` contexts as seen below. The example also shows that `Debug`
@@ -392,9 +384,7 @@ impl<'a> Arguments<'a> {
 /// assert_eq!(display, debug);
 /// ```
 ///
-/// [`format_args!`]: ../../std/macro.format_args.html
-/// [`format`]: ../../std/fmt/fn.format.html
-/// [`write`]: ../../std/fmt/fn.write.html
+/// [`format()`]: ../../std/fmt/fn.format.html
 #[stable(feature = "rust1", since = "1.0.0")]
 #[derive(Copy, Clone)]
 pub struct Arguments<'a> {
@@ -472,9 +462,7 @@ impl Display for Arguments<'_> {
 ///
 /// When used with the alternate format specifier `#?`, the output is pretty-printed.
 ///
-/// For more information on formatters, see [the module-level documentation][module].
-///
-/// [module]: ../../std/fmt/index.html
+/// For more information on formatters, see [the module-level documentation][self].
 ///
 /// This trait can be used with `#[derive]` if all fields implement `Debug`. When
 /// `derive`d for structs, it will use the name of the `struct`, then `{`, then a
@@ -535,8 +523,7 @@ impl Display for Arguments<'_> {
 /// `Debug` implementations using either `derive` or the debug builder API
 /// on [`Formatter`] support pretty-printing using the alternate flag: `{:#?}`.
 ///
-/// [`debug_struct`]: ../../std/fmt/struct.Formatter.html#method.debug_struct
-/// [`Formatter`]: ../../std/fmt/struct.Formatter.html
+/// [`debug_struct`]: Formatter::debug_struct
 ///
 /// Pretty-printing with `#?`:
 ///
@@ -618,14 +605,10 @@ pub use macros::Debug;
 
 /// Format trait for an empty format, `{}`.
 ///
-/// `Display` is similar to [`Debug`][debug], but `Display` is for user-facing
+/// `Display` is similar to [`Debug`], but `Display` is for user-facing
 /// output, and so cannot be derived.
 ///
-/// [debug]: trait.Debug.html
-///
-/// For more information on formatters, see [the module-level documentation][module].
-///
-/// [module]: ../../std/fmt/index.html
+/// For more information on formatters, see [the module-level documentation][self].
 ///
 /// # Examples
 ///
@@ -697,9 +680,7 @@ pub trait Display {
 ///
 /// The alternate flag, `#`, adds a `0o` in front of the output.
 ///
-/// For more information on formatters, see [the module-level documentation][module].
-///
-/// [module]: ../../std/fmt/index.html
+/// For more information on formatters, see [the module-level documentation][self].
 ///
 /// # Examples
 ///
@@ -751,7 +732,7 @@ pub trait Octal {
 ///
 /// The alternate flag, `#`, adds a `0b` in front of the output.
 ///
-/// For more information on formatters, see [the module-level documentation][module].
+/// For more information on formatters, see [the module-level documentation][self].
 ///
 /// # Examples
 ///
@@ -790,12 +771,6 @@ pub trait Octal {
 ///     "l as binary is: 0b000000000000000000000001101011"
 /// );
 /// ```
-///
-/// [module]: ../../std/fmt/index.html
-/// [`i8`]: ../../std/primitive.i8.html
-/// [`i128`]: ../../std/primitive.i128.html
-/// [`isize`]: ../../std/primitive.isize.html
-/// [`i32`]: ../../std/primitive.i32.html
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait Binary {
     /// Formats the value using the given formatter.
@@ -813,9 +788,7 @@ pub trait Binary {
 ///
 /// The alternate flag, `#`, adds a `0x` in front of the output.
 ///
-/// For more information on formatters, see [the module-level documentation][module].
-///
-/// [module]: ../../std/fmt/index.html
+/// For more information on formatters, see [the module-level documentation][self].
 ///
 /// # Examples
 ///
@@ -868,9 +841,7 @@ pub trait LowerHex {
 ///
 /// The alternate flag, `#`, adds a `0x` in front of the output.
 ///
-/// For more information on formatters, see [the module-level documentation][module].
-///
-/// [module]: ../../std/fmt/index.html
+/// For more information on formatters, see [the module-level documentation][self].
 ///
 /// # Examples
 ///
@@ -918,9 +889,7 @@ pub trait UpperHex {
 /// The `Pointer` trait should format its output as a memory location. This is commonly presented
 /// as hexadecimal.
 ///
-/// For more information on formatters, see [the module-level documentation][module].
-///
-/// [module]: ../../std/fmt/index.html
+/// For more information on formatters, see [the module-level documentation][self].
 ///
 /// # Examples
 ///
@@ -967,9 +936,7 @@ pub trait Pointer {
 ///
 /// The `LowerExp` trait should format its output in scientific notation with a lower-case `e`.
 ///
-/// For more information on formatters, see [the module-level documentation][module].
-///
-/// [module]: ../../std/fmt/index.html
+/// For more information on formatters, see [the module-level documentation][self].
 ///
 /// # Examples
 ///
@@ -1018,9 +985,7 @@ pub trait LowerExp {
 ///
 /// The `UpperExp` trait should format its output in scientific notation with an upper-case `E`.
 ///
-/// For more information on formatters, see [the module-level documentation][module].
-///
-/// [module]: ../../std/fmt/index.html
+/// For more information on formatters, see [the module-level documentation][self].
 ///
 /// # Examples
 ///
@@ -1812,8 +1777,7 @@ impl<'a> Formatter<'a> {
     /// Creates a [`DebugStruct`] builder designed to assist with creation of
     /// [`fmt::Debug`] implementations for structs.
     ///
-    /// [`DebugStruct`]: ../../std/fmt/struct.DebugStruct.html
-    /// [`fmt::Debug`]: ../../std/fmt/trait.Debug.html
+    /// [`fmt::Debug`]: self::Debug
     ///
     /// # Examples
     ///

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -58,7 +58,7 @@ use crate::marker::DiscriminantKind;
 use crate::mem;
 
 // These imports are used for simplifying intra-doc links
-#[cfg(doc)]
+#[allow(unused_imports)]
 use crate::sync::atomic::{self, AtomicBool, AtomicI32, AtomicIsize, AtomicU32, Ordering};
 
 #[stable(feature = "drop_in_place", since = "1.8.0")]

--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -28,9 +28,6 @@ macro_rules! panic {
 /// Like [`assert!`], this macro has a second form, where a custom
 /// panic message can be provided.
 ///
-/// [`PartialEq`]: cmp/trait.PartialEq.html
-/// [`assert!`]: macro.assert.html
-///
 /// # Examples
 ///
 /// ```
@@ -84,9 +81,6 @@ macro_rules! assert_eq {
 ///
 /// Like [`assert!`], this macro has a second form, where a custom
 /// panic message can be provided.
-///
-/// [`PartialEq`]: cmp/trait.PartialEq.html
-/// [`assert!`]: macro.assert.html
 ///
 /// # Examples
 ///
@@ -158,9 +152,6 @@ macro_rules! assert_ne {
 /// with `debug_assert!` is thus only encouraged after thorough profiling, and
 /// more importantly, only in safe code!
 ///
-/// [`panic!`]: macro.panic.html
-/// [`assert!`]: macro.assert.html
-///
 /// # Examples
 ///
 /// ```
@@ -196,8 +187,6 @@ macro_rules! debug_assert {
 /// expensive to be present in a release build but may be helpful during
 /// development. The result of expanding `debug_assert_eq!` is always type checked.
 ///
-/// [`assert_eq!`]: ../std/macro.assert_eq.html
-///
 /// # Examples
 ///
 /// ```
@@ -222,8 +211,6 @@ macro_rules! debug_assert_eq {
 /// compiler. This makes `debug_assert_ne!` useful for checks that are too
 /// expensive to be present in a release build but may be helpful during
 /// development. The result of expanding `debug_assert_ne!` is always type checked.
-///
-/// [`assert_ne!`]: ../std/macro.assert_ne.html
 ///
 /// # Examples
 ///
@@ -281,8 +268,6 @@ macro_rules! matches {
 ///
 /// Because of the early return, `try!` can only be used in functions that
 /// return [`Result`].
-///
-/// [`Result`]: ../std/result/enum.Result.html
 ///
 /// # Examples
 ///
@@ -354,10 +339,10 @@ macro_rules! r#try {
 ///
 /// See [`std::fmt`] for more information on the format string syntax.
 ///
-/// [`std::fmt`]: ../std/fmt/index.html
-/// [`std::fmt::Write`]: ../std/fmt/trait.Write.html
+/// [`std::fmt`]: crate::fmt
+/// [`std::fmt::Write`]: crate::fmt::Write
 /// [`std::io::Write`]: ../std/io/trait.Write.html
-/// [`std::fmt::Result`]: ../std/fmt/type.Result.html
+/// [`std::fmt::Result`]: crate::fmt::Result
 /// [`io::Result`]: ../std/io/type.Result.html
 ///
 /// # Examples
@@ -426,9 +411,7 @@ macro_rules! write {
 /// For more information, see [`write!`]. For information on the format string syntax, see
 /// [`std::fmt`].
 ///
-/// [`write!`]: macro.write.html
-/// [`std::fmt`]: ../std/fmt/index.html
-///
+/// [`std::fmt`]: crate::fmt
 ///
 /// # Examples
 ///
@@ -494,15 +477,11 @@ macro_rules! writeln {
 /// The unsafe counterpart of this macro is the [`unreachable_unchecked`] function, which
 /// will cause undefined behavior if the code is reached.
 ///
-/// [`panic!`]: ../std/macro.panic.html
-/// [`unreachable_unchecked`]: ../std/hint/fn.unreachable_unchecked.html
-/// [`std::hint`]: ../std/hint/index.html
+/// [`unreachable_unchecked`]: crate::hint::unreachable_unchecked
 ///
 /// # Panics
 ///
 /// This will always [`panic!`]
-///
-/// [`panic!`]: ../std/macro.panic.html
 ///
 /// # Examples
 ///
@@ -637,8 +616,6 @@ macro_rules! unimplemented {
 /// implemented", `unimplemented!` makes no such claims. Its message is "not implemented".
 /// Also some IDEs will mark `todo!`s.
 ///
-/// [`unimplemented!`]: macro.unimplemented.html
-///
 /// # Panics
 ///
 /// This will always [panic!](macro.panic.html)
@@ -730,8 +707,6 @@ pub(crate) mod builtin {
     /// #[cfg(not(any(feature = "foo", feature = "bar")))]
     /// compile_error!("Either feature \"foo\" or \"bar\" must be enabled for this crate.");
     /// ```
-    ///
-    /// [`panic!`]: ../std/macro.panic.html
     #[stable(feature = "compile_error_macro", since = "1.20.0")]
     #[rustc_builtin_macro]
     #[macro_export]
@@ -769,12 +744,11 @@ pub(crate) mod builtin {
     ///
     /// For more information, see the documentation in [`std::fmt`].
     ///
-    /// [`Display`]: ../std/fmt/trait.Display.html
-    /// [`Debug`]: ../std/fmt/trait.Debug.html
-    /// [`fmt::Arguments`]: ../std/fmt/struct.Arguments.html
-    /// [`std::fmt`]: ../std/fmt/index.html
+    /// [`Display`]: crate::fmt::Display
+    /// [`Debug`]: crate::fmt::Debug
+    /// [`fmt::Arguments`]: crate::fmt::Arguments
+    /// [`std::fmt`]: crate::fmt
     /// [`format!`]: ../std/macro.format.html
-    /// [`write!`]: ../std/macro.write.html
     /// [`println!`]: ../std/macro.println.html
     ///
     /// # Examples
@@ -818,8 +792,6 @@ pub(crate) mod builtin {
     /// will be emitted. To not emit a compile error, use the [`option_env!`]
     /// macro instead.
     ///
-    /// [`option_env!`]: ../std/macro.option_env.html
-    ///
     /// # Examples
     ///
     /// ```
@@ -854,12 +826,10 @@ pub(crate) mod builtin {
     /// expand into an expression of type `Option<&'static str>` whose value is
     /// `Some` of the value of the environment variable. If the environment
     /// variable is not present, then this will expand to `None`. See
-    /// [`Option<T>`][option] for more information on this type.
+    /// [`Option<T>`][Option] for more information on this type.
     ///
     /// A compile time error is never emitted when using this macro regardless
     /// of whether the environment variable is present or not.
-    ///
-    /// [option]: ../std/option/enum.Option.html
     ///
     /// # Examples
     ///
@@ -946,9 +916,6 @@ pub(crate) mod builtin {
     /// but rather the first macro invocation leading up to the invocation
     /// of the `line!` macro.
     ///
-    /// [`column!`]: macro.column.html
-    /// [`file!`]: macro.file.html
-    ///
     /// # Examples
     ///
     /// ```
@@ -976,9 +943,6 @@ pub(crate) mod builtin {
     /// but rather the first macro invocation leading up to the invocation
     /// of the `column!` macro.
     ///
-    /// [`line!`]: macro.line.html
-    /// [`file!`]: macro.file.html
-    ///
     /// # Examples
     ///
     /// ```
@@ -999,14 +963,10 @@ pub(crate) mod builtin {
     /// With [`line!`] and [`column!`], these macros provide debugging information for
     /// developers about the location within the source.
     ///
-    ///
     /// The expanded expression has type `&'static str`, and the returned file
     /// is not the invocation of the `file!` macro itself, but rather the
     /// first macro invocation leading up to the invocation of the `file!`
     /// macro.
-    ///
-    /// [`line!`]: macro.line.html
-    /// [`column!`]: macro.column.html
     ///
     /// # Examples
     ///
@@ -1258,9 +1218,7 @@ pub(crate) mod builtin {
     /// be provided with or without arguments for formatting. See [`std::fmt`]
     /// for syntax for this form.
     ///
-    /// [`panic!`]: macro.panic.html
-    /// [`debug_assert!`]: macro.debug_assert.html
-    /// [`std::fmt`]: ../std/fmt/index.html
+    /// [`std::fmt`]: crate::fmt
     ///
     /// # Examples
     ///

--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -1573,7 +1573,7 @@ $EndFeature, "
 the boundary of the type.
 
 The only case where such wrapping can occur is when one takes the absolute value of the negative
-minimal value for the type this is a positive value that is too large to represent in the type. In
+minimal value for the type; this is a positive value that is too large to represent in the type. In
 such a case, this function returns `MIN` itself.
 
 # Examples

--- a/library/proc_macro/src/lib.rs
+++ b/library/proc_macro/src/lib.rs
@@ -451,7 +451,7 @@ impl SourceFile {
     /// Also note that even if `is_real` returns `true`, if `--remap-path-prefix` was passed on
     /// the command line, the path as given may not actually be valid.
     ///
-    /// [`is_real`]: #method.is_real
+    /// [`is_real`]: Self::is_real
     #[unstable(feature = "proc_macro_span", issue = "54725")]
     pub fn path(&self) -> PathBuf {
         PathBuf::from(self.0.path())

--- a/library/std/src/collections/mod.rs
+++ b/library/std/src/collections/mod.rs
@@ -396,15 +396,7 @@
 //! assert_eq!(map.keys().next().unwrap().b, "baz");
 //! ```
 //!
-//! [`Vec`]: ../../std/vec/struct.Vec.html
-//! [`HashMap`]: ../../std/collections/struct.HashMap.html
-//! [`VecDeque`]: ../../std/collections/struct.VecDeque.html
-//! [`LinkedList`]: ../../std/collections/struct.LinkedList.html
-//! [`BTreeMap`]: ../../std/collections/struct.BTreeMap.html
-//! [`HashSet`]: ../../std/collections/struct.HashSet.html
-//! [`BTreeSet`]: ../../std/collections/struct.BTreeSet.html
-//! [`BinaryHeap`]: ../../std/collections/struct.BinaryHeap.html
-//! [`IntoIterator`]: ../../std/iter/trait.IntoIterator.html
+//! [`IntoIterator`]: crate::iter::IntoIterator
 
 #![stable(feature = "rust1", since = "1.0.0")]
 

--- a/library/std/src/macros.rs
+++ b/library/std/src/macros.rs
@@ -72,6 +72,8 @@ macro_rules! print {
 /// Use `println!` only for the primary output of your program. Use
 /// [`eprintln!`] instead to print error and progress messages.
 ///
+/// [`std::fmt`]: crate::fmt
+///
 /// # Panics
 ///
 /// Panics if writing to `io::stdout` fails.

--- a/library/std/src/macros.rs
+++ b/library/std/src/macros.rs
@@ -76,7 +76,7 @@ macro_rules! print {
 ///
 /// # Panics
 ///
-/// Panics if writing to `io::stdout` fails.
+/// Panics if writing to [`io::stdout`] fails.
 ///
 /// [`io::stdout`]: crate::io::stdout
 ///
@@ -100,7 +100,7 @@ macro_rules! println {
 /// Prints to the standard error.
 ///
 /// Equivalent to the [`print!`] macro, except that output goes to
-/// [`io::stderr`] instead of `io::stdout`. See [`print!`] for
+/// [`io::stderr`] instead of [`io::stdout`]. See [`print!`] for
 /// example usage.
 ///
 /// Use `eprint!` only for error and progress messages. Use `print!`
@@ -128,7 +128,7 @@ macro_rules! eprint {
 /// Prints to the standard error, with a newline.
 ///
 /// Equivalent to the [`println!`] macro, except that output goes to
-/// [`io::stderr`] instead of `io::stdout`. See [`println!`] for
+/// [`io::stderr`] instead of [`io::stdout`]. See [`println!`] for
 /// example usage.
 ///
 /// Use `eprintln!` only for error and progress messages. Use `println!`

--- a/library/std/src/macros.rs
+++ b/library/std/src/macros.rs
@@ -1,6 +1,6 @@
 //! Standard library macros
 //!
-//! This modules contains a set of macros which are exported from the standard
+//! This module contains a set of macros which are exported from the standard
 //! library. Each macro is available for use when linking against the standard
 //! library.
 
@@ -29,9 +29,7 @@ macro_rules! panic {
 /// Use `print!` only for the primary output of your program. Use
 /// [`eprint!`] instead to print error and progress messages.
 ///
-/// [`println!`]: ../std/macro.println.html
-/// [flush]: ../std/io/trait.Write.html#tymethod.flush
-/// [`eprint!`]: ../std/macro.eprint.html
+/// [flush]: crate::io::Write::flush
 ///
 /// # Panics
 ///
@@ -74,12 +72,11 @@ macro_rules! print {
 /// Use `println!` only for the primary output of your program. Use
 /// [`eprintln!`] instead to print error and progress messages.
 ///
-/// [`format!`]: ../std/macro.format.html
-/// [`std::fmt`]: ../std/fmt/index.html
-/// [`eprintln!`]: ../std/macro.eprintln.html
 /// # Panics
 ///
 /// Panics if writing to `io::stdout` fails.
+///
+/// [`io::stdout`]: crate::io::stdout
 ///
 /// # Examples
 ///
@@ -107,8 +104,8 @@ macro_rules! println {
 /// Use `eprint!` only for error and progress messages. Use `print!`
 /// instead for the primary output of your program.
 ///
-/// [`io::stderr`]: ../std/io/struct.Stderr.html
-/// [`print!`]: ../std/macro.print.html
+/// [`io::stderr`]: crate::io::stderr
+/// [`io::stdout`]: crate::io::stdout
 ///
 /// # Panics
 ///
@@ -135,8 +132,8 @@ macro_rules! eprint {
 /// Use `eprintln!` only for error and progress messages. Use `println!`
 /// instead for the primary output of your program.
 ///
-/// [`io::stderr`]: ../std/io/struct.Stderr.html
-/// [`println!`]: ../std/macro.println.html
+/// [`io::stderr`]: crate::io::stderr
+/// [`io::stdout`]: crate::io::stdout
 ///
 /// # Panics
 ///

--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -126,7 +126,7 @@ use crate::sys_common::{AsInner, AsInnerMut, FromInner, IntoInner};
 ///
 /// # Warning
 ///
-/// On some system, calling [`wait`] or similar is necessary for the OS to
+/// On some systems, calling [`wait`] or similar is necessary for the OS to
 /// release resources. A process that terminated but has not been waited on is
 /// still around as a "zombie". Leaving too many zombies around may exhaust
 /// global resources (for example process IDs).

--- a/library/std/src/sync/barrier.rs
+++ b/library/std/src/sync/barrier.rs
@@ -131,7 +131,7 @@ impl Barrier {
         lock.count += 1;
         if lock.count < self.num_threads {
             // We need a while loop to guard against spurious wakeups.
-            // http://en.wikipedia.org/wiki/Spurious_wakeup
+            // https://en.wikipedia.org/wiki/Spurious_wakeup
             while local_gen == lock.generation_id && lock.count < self.num_threads {
                 lock = self.cvar.wait(lock).unwrap();
             }

--- a/library/test/src/stats.rs
+++ b/library/test/src/stats.rs
@@ -84,7 +84,7 @@ pub trait Stats {
     /// by the constant `1.4826` to allow its use as a consistent estimator for the standard
     /// deviation.
     ///
-    /// See: <http://en.wikipedia.org/wiki/Median_absolute_deviation>
+    /// See: <https://en.wikipedia.org/wiki/Median_absolute_deviation>
     fn median_abs_dev(&self) -> f64;
 
     /// Median absolute deviation as a percent of the median. See `median_abs_dev` and `median`.
@@ -96,7 +96,7 @@ pub trait Stats {
     ///
     /// Calculated by linear interpolation between closest ranks.
     ///
-    /// See: <http://en.wikipedia.org/wiki/Percentile>
+    /// See: <https://en.wikipedia.org/wiki/Percentile>
     fn percentile(&self, pct: f64) -> f64;
 
     /// Quartiles of the sample: three values that divide the sample into four equal groups, each
@@ -302,7 +302,7 @@ fn percentile_of_sorted(sorted_samples: &[f64], pct: f64) -> f64 {
 /// It differs from trimming in that it does not change the number of samples,
 /// just changes the values of those that are outliers.
 ///
-/// See: <http://en.wikipedia.org/wiki/Winsorising>
+/// See: <https://en.wikipedia.org/wiki/Winsorising>
 pub fn winsorize(samples: &mut [f64], pct: f64) {
     let mut tmp = samples.to_vec();
     local_sort(&mut tmp);

--- a/src/librustc_expand/mbe.rs
+++ b/src/librustc_expand/mbe.rs
@@ -61,7 +61,7 @@ impl KleeneToken {
     }
 }
 
-/// A Kleene-style [repetition operator](http://en.wikipedia.org/wiki/Kleene_star)
+/// A Kleene-style [repetition operator](https://en.wikipedia.org/wiki/Kleene_star)
 /// for token sequences.
 #[derive(Clone, PartialEq, Encodable, Decodable, Debug, Copy)]
 enum KleeneOp {

--- a/src/librustc_middle/ty/sty.rs
+++ b/src/librustc_middle/ty/sty.rs
@@ -1264,7 +1264,7 @@ rustc_index::newtype_index! {
     /// De Bruijn index of 0, because the innermost binder in that location
     /// is the outer fn.
     ///
-    /// [dbi]: http://en.wikipedia.org/wiki/De_Bruijn_index
+    /// [dbi]: https://en.wikipedia.org/wiki/De_Bruijn_index
     #[derive(HashStable)]
     pub struct DebruijnIndex {
         DEBUG_FORMAT = "DebruijnIndex({})",

--- a/src/librustc_symbol_mangling/legacy.rs
+++ b/src/librustc_symbol_mangling/legacy.rs
@@ -136,7 +136,7 @@ fn get_symbol_hash<'tcx>(
 }
 
 // Follow C++ namespace-mangling style, see
-// http://en.wikipedia.org/wiki/Name_mangling for more info.
+// https://en.wikipedia.org/wiki/Name_mangling for more info.
 //
 // It turns out that on macOS you can actually have arbitrary symbols in
 // function names (at least when given to LLVM), but this is not possible

--- a/src/test/ui/unboxed-closures/unboxed-closures-infer-recursive-fn.rs
+++ b/src/test/ui/unboxed-closures/unboxed-closures-infer-recursive-fn.rs
@@ -7,7 +7,7 @@ use std::marker::PhantomData;
 // closure.  As far as I can tell, coding up a recursive closure
 // requires the good ol' [Y Combinator].
 //
-// [Y Combinator]: http://en.wikipedia.org/wiki/Fixed-point_combinator#Y_combinator
+// [Y Combinator]: https://en.wikipedia.org/wiki/Fixed-point_combinator#Y_combinator
 
 struct YCombinator<F,A,R> {
     func: F,

--- a/src/tools/expand-yaml-anchors/src/main.rs
+++ b/src/tools/expand-yaml-anchors/src/main.rs
@@ -48,8 +48,8 @@ impl App {
         // Parse CLI arguments
         let args = std::env::args().skip(1).collect::<Vec<_>>();
         let (mode, base) = match args.iter().map(|s| s.as_str()).collect::<Vec<_>>().as_slice() {
-            &["generate", ref base] => (Mode::Generate, PathBuf::from(base)),
-            &["check", ref base] => (Mode::Check, PathBuf::from(base)),
+            ["generate", ref base] => (Mode::Generate, PathBuf::from(base)),
+            ["check", ref base] => (Mode::Check, PathBuf::from(base)),
             _ => {
                 eprintln!("usage: expand-yaml-anchors <source-dir> <dest-dir>");
                 std::process::exit(1);
@@ -138,9 +138,7 @@ fn filter_document(document: Yaml) -> Yaml {
                 .map(|(key, value)| (filter_document(key), filter_document(value)))
                 .collect(),
         ),
-        Yaml::Array(vec) => {
-            Yaml::Array(vec.into_iter().map(|item| filter_document(item)).collect())
-        }
+        Yaml::Array(vec) => Yaml::Array(vec.into_iter().map(filter_document).collect()),
         other => other,
     }
 }

--- a/src/tools/linkchecker/main.rs
+++ b/src/tools/linkchecker/main.rs
@@ -172,10 +172,10 @@ fn check(cache: &mut Cache, root: &Path, file: &Path, errors: &mut bool) -> Opti
         {
             return;
         }
-        let mut parts = url.splitn(2, "#");
+        let mut parts = url.splitn(2, '#');
         let url = parts.next().unwrap();
         let fragment = parts.next();
-        let mut parts = url.splitn(2, "?");
+        let mut parts = url.splitn(2, '?');
         let url = parts.next().unwrap();
 
         // Once we've plucked out the URL, parse it using our base url and
@@ -258,7 +258,7 @@ fn check(cache: &mut Cache, root: &Path, file: &Path, errors: &mut bool) -> Opti
                 }
 
                 // These appear to be broken in mdbook right now?
-                if fragment.starts_with("-") {
+                if fragment.starts_with('-') {
                     return;
                 }
 
@@ -324,7 +324,7 @@ fn load_file(
 }
 
 fn maybe_redirect(source: &str) -> Option<String> {
-    const REDIRECT: &'static str = "<p>Redirecting to <a href=";
+    const REDIRECT: &str = "<p>Redirecting to <a href=";
 
     let mut lines = source.lines();
     let redirect_line = lines.nth(6)?;
@@ -345,11 +345,11 @@ fn with_attrs_in_source<F: FnMut(&str, usize, &str)>(contents: &str, attr: &str,
             // we can get away with using one pass.
             let is_base = line[..j].ends_with("<base");
             line = rest;
-            let pos_equals = match rest.find("=") {
+            let pos_equals = match rest.find('=') {
                 Some(i) => i,
                 None => continue,
             };
-            if rest[..pos_equals].trim_start_matches(" ") != "" {
+            if rest[..pos_equals].trim_start_matches(' ') != "" {
                 continue;
             }
 
@@ -361,7 +361,7 @@ fn with_attrs_in_source<F: FnMut(&str, usize, &str)>(contents: &str, attr: &str,
             };
             let quote_delim = rest.as_bytes()[pos_quote] as char;
 
-            if rest[..pos_quote].trim_start_matches(" ") != "" {
+            if rest[..pos_quote].trim_start_matches(' ') != "" {
                 continue;
             }
             let rest = &rest[pos_quote + 1..];

--- a/src/tools/publish_toolstate.py
+++ b/src/tools/publish_toolstate.py
@@ -275,7 +275,7 @@ def update_latest(
         return message
 
 
-if __name__ == '__main__':
+def main():
     repo = os.environ.get('TOOLSTATE_VALIDATE_MAINTAINERS_REPO')
     if repo:
         github_token = os.environ.get('TOOLSTATE_REPO_ACCESS_TOKEN')
@@ -342,3 +342,11 @@ if __name__ == '__main__':
         }
     ))
     response.read()
+
+
+if __name__ == '__main__':
+    try:
+        main()
+    except urllib2.HTTPError as e:
+        print("HTTPError: %s\n%s" % (e, e.read()))
+        raise

--- a/src/tools/tidy/src/error_codes_check.rs
+++ b/src/tools/tidy/src/error_codes_check.rs
@@ -56,7 +56,7 @@ fn check_if_error_code_is_test_in_explanation(f: &str, err_code: &str) -> bool {
         if s.starts_with("```") {
             if s.contains("compile_fail") && s.contains(err_code) {
                 return true;
-            } else if s.contains("(") {
+            } else if s.contains('(') {
                 // It's very likely that we can't actually make it fail compilation...
                 return true;
             }

--- a/src/tools/tidy/src/error_codes_check.rs
+++ b/src/tools/tidy/src/error_codes_check.rs
@@ -47,9 +47,7 @@ fn check_error_code_explanation(
     invalid_compile_fail_format
 }
 
-fn check_if_error_code_is_test_in_explanation(f: &str, err_code: &String) -> bool {
-    let mut can_be_ignored = false;
-
+fn check_if_error_code_is_test_in_explanation(f: &str, err_code: &str) -> bool {
     for line in f.lines() {
         let s = line.trim();
         if s.starts_with("#### Note: this error code is no longer emitted by the compiler") {
@@ -60,11 +58,11 @@ fn check_if_error_code_is_test_in_explanation(f: &str, err_code: &String) -> boo
                 return true;
             } else if s.contains("(") {
                 // It's very likely that we can't actually make it fail compilation...
-                can_be_ignored = true;
+                return true;
             }
         }
     }
-    can_be_ignored
+    false
 }
 
 macro_rules! some_or_continue {

--- a/src/tools/unicode-table-generator/src/main.rs
+++ b/src/tools/unicode-table-generator/src/main.rs
@@ -315,7 +315,7 @@ fn version() -> String {
 fn fmt_list<V: std::fmt::Debug>(values: impl IntoIterator<Item = V>) -> String {
     let pieces = values.into_iter().map(|b| format!("{:?}, ", b)).collect::<Vec<_>>();
     let mut out = String::new();
-    let mut line = format!("\n    ");
+    let mut line = String::from("\n    ");
     for piece in pieces {
         if line.len() + piece.len() < 98 {
             line.push_str(&piece);

--- a/src/tools/unicode-table-generator/src/raw_emitter.rs
+++ b/src/tools/unicode-table-generator/src/raw_emitter.rs
@@ -20,7 +20,7 @@ impl RawEmitter {
         if self.file.is_empty() || self.file.ends_with("\n\n") {
             return;
         }
-        writeln!(&mut self.file, "").unwrap();
+        writeln!(&mut self.file).unwrap();
     }
 
     fn emit_bitset(&mut self, ranges: &[Range<u32>]) {
@@ -161,10 +161,10 @@ pub fn emit_codepoints(emitter: &mut RawEmitter, ranges: &[Range<u32>]) {
 
     if bitset.bytes_used <= skiplist.bytes_used {
         *emitter = bitset;
-        emitter.desc = format!("bitset");
+        emitter.desc = String::from("bitset");
     } else {
         *emitter = skiplist;
-        emitter.desc = format!("skiplist");
+        emitter.desc = String::from("skiplist");
     }
 }
 
@@ -289,7 +289,7 @@ impl Canonicalized {
                 // Remove the now-canonicalized word from other mappings,
                 // to ensure that we deprioritize them in the next iteration of
                 // the while loop.
-                for (_, mapped) in &mut mappings {
+                for mapped in mappings.values_mut() {
                     let mut i = 0;
                     while i != mapped.len() {
                         if mapped[i].0 == *from {
@@ -309,7 +309,7 @@ impl Canonicalized {
 
             // Remove the now-canonical word from other mappings, to ensure that
             // we deprioritize them in the next iteration of the while loop.
-            for (_, mapped) in &mut mappings {
+            for mapped in mappings.values_mut() {
                 let mut i = 0;
                 while i != mapped.len() {
                     if mapped[i].0 == to {

--- a/src/tools/unstable-book-gen/src/main.rs
+++ b/src/tools/unstable-book-gen/src/main.rs
@@ -94,9 +94,9 @@ fn copy_recursive(from: &Path, to: &Path) {
 }
 
 fn main() {
-    let library_path_str = env::args_os().skip(1).next().expect("library path required");
-    let src_path_str = env::args_os().skip(2).next().expect("source path required");
-    let dest_path_str = env::args_os().skip(3).next().expect("destination path required");
+    let library_path_str = env::args_os().nth(1).expect("library path required");
+    let src_path_str = env::args_os().nth(2).expect("source path required");
+    let dest_path_str = env::args_os().nth(3).expect("destination path required");
     let library_path = Path::new(&library_path_str);
     let src_path = Path::new(&src_path_str);
     let dest_path = Path::new(&dest_path_str);


### PR DESCRIPTION
Successful merges:

 - #75817 (Use intra-doc link in `proc_macro`)
 - #75819 (Use intra-doc-links in `core::{char, macros, fmt}`)
 - #75821 (Switch to intra-doc links in `std::macros`)
 - #75825 (Fix typo in documentation of i32 wrapping_abs())
 - #75826 (Corrected Misleading documentation for derived Ord/PartialOrd implementation )
 - #75831 (doc: Prefer https link for wikipedia URLs)
 - #75844 (publish-toolstate: show more context on HTTP error)
 - #75847 (Switch to intra-doc links in `std::collections`)
 - #75855 (Use allow(unused_imports) instead of cfg(doc) for imports used only for intra-doc links)
 - #75856 (more tool clippy fixes)
 - #75859 (doc: Fix typo in std::process::Child documentation)

Failed merges:


r? @ghost