### PR TITLE
impl Add for Option<T>

### DIFF
--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -135,7 +135,7 @@ use crate::iter::{FromIterator, FusedIterator, TrustedLen};
 use crate::pin::Pin;
 use crate::{
     convert, fmt, hint, mem,
-    ops::{self, Deref, DerefMut},
+    ops::{self, Add, Deref, DerefMut},
 };
 
 /// The `Option` type. See [the module level documentation](self) for more.
@@ -1257,6 +1257,19 @@ impl<T> Default for Option<T> {
     #[inline]
     fn default() -> Option<T> {
         None
+    }
+}
+
+#[stable(feature = "option_add", since = "1.46.0")]
+impl<T: Add<Output = T>> Add for Option<T> {
+    type Output = Self;
+
+    fn add(self, other: Self) -> Self::Output {
+        match (self, other) {
+            (a, None) => a,
+            (None, b) => b,
+            (Some(a), Some(b)) => Some(a.add(b)),
+        }
     }
 }
 


### PR DESCRIPTION
Implement `Add` for `Option<T>` for all `T` that also impl `Add`. The resulting `Option` type forms a semigroup as well as a monoid given that it also implements `Default`.

## Motivation

Fold iterators containing optional values, concatenating the values along the way.

## Example

```rust
fn fizzbuzz(n: u32) -> String {
    [(3, "Fizz"), (5, "Buzz"), (7, "Bazz")]
        .iter()
        .map(|(m, s)| Some(n).filter(|i| i % m == 0).map(|_| s.to_string()))
        .fold(None, Option::add)
        .unwrap_or(n.to_string())
}

assert_eq!("1", fizzbuzz(1));
assert_eq!("Fizz", fizzbuzz(3));
assert_eq!("FizzBuzzBazz", fizzbuzz(105));
```

To make the above possible, I've also added an implementation of `Add` for `String` along the lines of the below since the existing string impl didn't work. I've just started learning Rust so I don't understand why that is the case. I'd love to learn more if anyone has an explanation!
```rust
impl Add for String {
    type Output = String;

    fn add(self, other: String) -> String {
        format!("{}{}", self, other)
    }
}
```