### PR TITLE
Unify theme choices border color in ayu theme

### DIFF
--- a/src/librustdoc/html/static/themes/ayu.css
+++ b/src/librustdoc/html/static/themes/ayu.css
@@ -513,7 +513,7 @@ kbd {
 }
 
 #theme-choices > button:not(:first-child) {
-	border-top-color: #c5c5c5;
+	border-top-color: #5c6773;
 }
 
 #theme-choices > button:hover, #theme-choices > button:focus {


### PR DESCRIPTION
There was a slight color difference in the theme choice menu borders:

![Screenshot from 2020-08-24 10-37-05](https://user-images.githubusercontent.com/3050060/91022913-22654880-e5f6-11ea-8165-302b2d4e701e.png)
![Screenshot from 2020-08-24 10-37-58](https://user-images.githubusercontent.com/3050060/91022918-242f0c00-e5f6-11ea-989a-e26a28196d09.png)

r? @Cldfire 