### PR TITLE
Enable some of profiler tests on Windows-gnu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -431,7 +431,7 @@ jobs:
           - name: x86_64-mingw-1
             env:
               SCRIPT: make ci-mingw-subset-1
-              RUST_CONFIGURE_ARGS: "--build=x86_64-pc-windows-gnu"
+              RUST_CONFIGURE_ARGS: "--build=x86_64-pc-windows-gnu --enable-profiler"
               CUSTOM_MINGW: 1
               NO_DEBUG_ASSERTIONS: 1
               NO_LLVM_ASSERTIONS: 1
@@ -439,7 +439,7 @@ jobs:
           - name: x86_64-mingw-2
             env:
               SCRIPT: make ci-mingw-subset-2
-              RUST_CONFIGURE_ARGS: "--build=x86_64-pc-windows-gnu"
+              RUST_CONFIGURE_ARGS: "--build=x86_64-pc-windows-gnu --enable-profiler"
               CUSTOM_MINGW: 1
             os: windows-latest-xl
           - name: dist-x86_64-msvc

--- a/library/profiler_builtins/build.rs
+++ b/library/profiler_builtins/build.rs
@@ -48,10 +48,10 @@ fn main() {
         // Turn off various features of gcc and such, mostly copying
         // compiler-rt's build system already
         cfg.flag("-fno-builtin");
-        cfg.flag("-fvisibility=hidden");
         cfg.flag("-fomit-frame-pointer");
         cfg.define("VISIBILITY_HIDDEN", None);
         if !target.contains("windows") {
+            cfg.flag("-fvisibility=hidden");
             cfg.define("COMPILER_RT_HAS_UNAME", Some("1"));
         } else {
             profile_sources.push("WindowsMMap.c");

--- a/src/ci/github-actions/ci.yml
+++ b/src/ci/github-actions/ci.yml
@@ -523,7 +523,7 @@ jobs:
           - name: x86_64-mingw-1
             env:
               SCRIPT: make ci-mingw-subset-1
-              RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-gnu
+              RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-gnu --enable-profiler
               CUSTOM_MINGW: 1
               # FIXME(#59637)
               NO_DEBUG_ASSERTIONS: 1
@@ -533,7 +533,7 @@ jobs:
           - name: x86_64-mingw-2
             env:
               SCRIPT: make ci-mingw-subset-2
-              RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-gnu
+              RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-gnu --enable-profiler
               CUSTOM_MINGW: 1
             <<: *job-windows-xl
 

--- a/src/test/run-make-fulldeps/instrument-coverage-cov-reports-base/Makefile
+++ b/src/test/run-make-fulldeps/instrument-coverage-cov-reports-base/Makefile
@@ -1,4 +1,8 @@
 # needs-profiler-support
+# ignore-windows-gnu
+
+# FIXME(mati865): MinGW GCC miscompiles compiler-rt profiling library but with Clang it works
+# properly. Since we only have GCC on the CI ignore the test for now.
 
 # ISSUE(76038): When targeting MSVC, Rust binaries built with both `-Z instrument-coverage` and
 # `-C link-dead-code` typically crash (with a seg-fault) or at best generate an empty `*.profraw`.

--- a/src/test/run-make-fulldeps/instrument-coverage-cov-reports-link-dead-code/Makefile
+++ b/src/test/run-make-fulldeps/instrument-coverage-cov-reports-link-dead-code/Makefile
@@ -1,5 +1,9 @@
 # needs-profiler-support
 # ignore-msvc
+# ignore-windows-gnu
+
+# FIXME(mati865): MinGW GCC miscompiles compiler-rt profiling library but with Clang it works
+# properly. Since we only have GCC on the CI ignore the test for now.
 
 # LINK_DEAD_CODE requires ignore-msvc due to Issue #76038
 LINK_DEAD_CODE=yes

--- a/src/test/run-make-fulldeps/pgo-branch-weights/Makefile
+++ b/src/test/run-make-fulldeps/pgo-branch-weights/Makefile
@@ -1,4 +1,8 @@
 # needs-profiler-support
+# ignore-windows-gnu
+
+# FIXME(mati865): MinGW GCC miscompiles compiler-rt profiling library but with Clang it works
+# properly. Since we only have GCC on the CI ignore the test for now.
 
 -include ../tools.mk
 

--- a/src/test/run-make-fulldeps/pgo-gen-lto/Makefile
+++ b/src/test/run-make-fulldeps/pgo-gen-lto/Makefile
@@ -1,4 +1,8 @@
 # needs-profiler-support
+# ignore-windows-gnu
+
+# FIXME(mati865): MinGW GCC miscompiles compiler-rt profiling library but with Clang it works
+# properly. Since we only have GCC on the CI ignore the test for now.
 
 -include ../tools.mk
 

--- a/src/test/run-make-fulldeps/pgo-gen/Makefile
+++ b/src/test/run-make-fulldeps/pgo-gen/Makefile
@@ -1,4 +1,8 @@
 # needs-profiler-support
+# ignore-windows-gnu
+
+# FIXME(mati865): MinGW GCC miscompiles compiler-rt profiling library but with Clang it works
+# properly. Since we only have GCC on the CI ignore the test for now.
 
 -include ../tools.mk
 

--- a/src/test/run-make-fulldeps/pgo-indirect-call-promotion/Makefile
+++ b/src/test/run-make-fulldeps/pgo-indirect-call-promotion/Makefile
@@ -1,4 +1,8 @@
 # needs-profiler-support
+# ignore-windows-gnu
+
+# FIXME(mati865): MinGW GCC miscompiles compiler-rt profiling library but with Clang it works
+# properly. Since we only have GCC on the CI ignore the test for now.
 
 -include ../tools.mk
 

--- a/src/test/run-make-fulldeps/pgo-use/Makefile
+++ b/src/test/run-make-fulldeps/pgo-use/Makefile
@@ -1,4 +1,8 @@
 # needs-profiler-support
+# ignore-windows-gnu
+
+# FIXME(mati865): MinGW GCC miscompiles compiler-rt profiling library but with Clang it works
+# properly. Since we only have GCC on the CI ignore the test for now.
 
 -include ../tools.mk
 


### PR DESCRIPTION
CC https://github.com/rust-lang/rust/issues/61266

Because of force-push GitHub didn't let me reopen https://github.com/rust-lang/rust/pull/75184

Because of the GCC miscompilation, generated binaries either segfault or `.profraw` is malformed. Clang works fine but we can't use it on the CI.
However we can still test the IR for the proper instrumentation so let's do it.