### PR TITLE
Update compiler-builtins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -604,9 +604,9 @@ dependencies = [
 
 [[package]]
 name = "compiler_builtins"
-version = "0.1.32"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bc4ac2c824d2bfc612cba57708198547e9a26943af0632aff033e0693074d5c"
+checksum = "e3fcd8aba10d17504c87ef12d4f62ef404c6a4703d16682a9eb5543e6cf24455"
 dependencies = [
  "cc",
  "rustc-std-workspace-core",

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -17,7 +17,7 @@ panic_unwind = { path = "../panic_unwind", optional = true }
 panic_abort = { path = "../panic_abort" }
 core = { path = "../core" }
 libc = { version = "0.2.74", default-features = false, features = ['rustc-dep-of-std'] }
-compiler_builtins = { version = "0.1.32" }
+compiler_builtins = { version = "0.1.35" }
 profiler_builtins = { path = "../profiler_builtins", optional = true }
 unwind = { path = "../unwind" }
 hashbrown = { version = "0.8.1", default-features = false, features = ['rustc-dep-of-std'] }


### PR DESCRIPTION
Update the compiler-builtins dependency to include latest changes.

This allows for `aarch64-unknown-linux-musl` to pass all tests.

Fixes #57820 and fixes #46651