### PR TITLE
[stable] Prepare Rust 1.46.0

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -68,7 +68,19 @@ Compatibility Notes
 - [Rustc now correctly relates the lifetime of an existential associated
   type.][71896] This fixes some edge cases where `rustc` would erroneously allow
   you to pass a shorter lifetime than expected.
+- [Rustc now dynamically links to `libz` (also called `zlib`) on Linux.][74420]
+  The library will need to be installed for `rustc` to work, even though we
+  expect it to be already available on most systems.
+- [Tests annotated with `#[should_panic]` are broken on ARMv7 while running
+  under QEMU.][74820]
+- [Pretty printing of some tokens in procedural macros changed.][75453] The
+  exact output returned by rustc's pretty printing is an unstable
+  implementation detail: we recommend any macro relying on it to switch to a
+  more robust parsing system.
 
+[75453]: https://github.com/rust-lang/rust/issues/75453/
+[74820]: https://github.com/rust-lang/rust/issues/74820/
+[74420]: https://github.com/rust-lang/rust/issues/74420/
 [74109]: https://github.com/rust-lang/rust/pull/74109/
 [74150]: https://github.com/rust-lang/rust/pull/74150/
 [73862]: https://github.com/rust-lang/rust/pull/73862/

--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -51,7 +51,7 @@ fi
 #
 # FIXME: need a scheme for changing this `nightly` value to `beta` and `stable`
 #        either automatically or manually.
-export RUST_RELEASE_CHANNEL=beta
+export RUST_RELEASE_CHANNEL=stable
 
 # Always set the release channel for bootstrap; this is normally not important (i.e., only dist
 # builds would seem to matter) but in practice bootstrap wants to know whether we're targeting

--- a/src/stage0.txt
+++ b/src/stage0.txt
@@ -12,9 +12,9 @@
 # source tarball for a stable release you'll likely see `1.x.0` for rustc and
 # `0.(x+1).0` for Cargo where they were released on `date`.
 
-date: 2020-07-13
-rustc: 1.45.0
-cargo: 0.46.0
+date: 2020-08-03
+rustc: 1.45.2
+cargo: 0.46.1
 
 # We use a nightly rustfmt to format the source because it solves some
 # bootstrapping issues with use of new syntax in this repo. If you're looking at
@@ -40,4 +40,4 @@ cargo: 0.46.0
 # looking at a beta source tarball and it's uncommented we'll shortly comment it
 # out.
 
-dev: 1
+#dev: 1


### PR DESCRIPTION
Also updated the compatibility notes to account for the regressions we didn't fix for this release. The release team evaluated them, and we agreed they're not enough to block the release.

r? @Mark-Simulacrum 
cc @rust-lang/release 