### PR TITLE
Add test for issue #27130

### DIFF
--- a/src/test/codegen/issue-27130.rs
+++ b/src/test/codegen/issue-27130.rs
@@ -1,0 +1,22 @@
+// compile-flags: -O
+// min-llvm-version: 11.0
+
+#![crate_type = "lib"]
+
+// CHECK-LABEL: @trim_in_place
+#[no_mangle]
+pub fn trim_in_place(a: &mut &[u8]) {
+    while a.first() == Some(&42) {
+        // CHECK-NOT: slice_index_order_fail
+        *a = &a[1..];
+    }
+}
+
+// CHECK-LABEL: @trim_in_place2
+#[no_mangle]
+pub fn trim_in_place2(a: &mut &[u8]) {
+    while let Some(&42) = a.first() {
+        // CHECK-NOT: slice_index_order_fail
+        *a = &a[1..];
+    }
+}

--- a/src/test/codegen/issue-27130.rs
+++ b/src/test/codegen/issue-27130.rs
@@ -17,6 +17,6 @@ pub fn trim_in_place(a: &mut &[u8]) {
 pub fn trim_in_place2(a: &mut &[u8]) {
     while let Some(&42) = a.first() {
         // CHECK-NOT: slice_index_order_fail
-        *a = &a[1..];
+        *a = &a[2..];
     }
 }


### PR DESCRIPTION
#27130 seems to be fixed by the llvm 11 update. The issue is marked with needs-test, so here it is. As some historical context, the generated code was fine until 1.38, and remained unoptimized from 1.38 up until the current nightly.

I've also added a pattern matching version that was fine on 1.45.2.