### PR TITLE
Add `Arc::unwrap_or_drop` for safely discarding `Arc`s without calling the destructor on the inner type.

### DIFF
--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -469,6 +469,17 @@ impl<T> Arc<T> {
     ///
     /// This will succeed even if there are outstanding weak references.
     ///
+    /// It is strongly recommended to use [`Arc::unwrap_or_drop`] instead if you don't
+    /// want to keep the `Arc` in the [`Err`] case.
+    /// Immediately dropping the [`Err`] payload, like in the expression
+    /// `Arc::try_unwrap(this).ok()`, can still cause the strong count to
+    /// drop to zero and the inner value of the `Arc` to be dropped:
+    /// For instance if two threads execute this expression in parallel, then
+    /// there is a race condition. The threads could first both check whether they
+    /// have the last clone of their `Arc` via `try_unwrap`, and then
+    /// both drop their `Arc` in the call to [`ok`][`Result::ok`],
+    /// taking the strong count from two down to zero.
+    ///
     /// # Examples
     ///
     /// ```
@@ -509,8 +520,11 @@ impl<T> Arc<T> {
     ///
     /// If `unwrap_or_drop` is called on every clone of this `Arc`,
     /// it is guaranteed that exactly one of the calls returns the inner value.
+    /// This means in particular that the inner value is not dropped.
+    ///
     /// The similar expression `Arc::try_unwrap(this).ok()` does not
-    /// offer this guarantee.
+    /// offer such a guarantee. See the last example below and the documentation
+    /// of `try_unwrap`[`Arc::try_unwrap`].
     ///
     /// # Examples
     ///
@@ -522,16 +536,67 @@ impl<T> Arc<T> {
     /// let x = Arc::new(3);
     /// let y = Arc::clone(&x);
     ///
+    /// // Two threads calling `unwrap_or_drop` on both clones of an `Arc`:
     /// let x_unwrap_thread = std::thread::spawn(|| Arc::unwrap_or_drop(x));
     /// let y_unwrap_thread = std::thread::spawn(|| Arc::unwrap_or_drop(y));
     ///
     /// let x_unwrapped_value = x_unwrap_thread.join().unwrap();
     /// let y_unwrapped_value = y_unwrap_thread.join().unwrap();
     ///
+    /// // One of the threads is guaranteed to receive the inner value:
     /// assert!(matches!(
     ///     (x_unwrapped_value, y_unwrapped_value),
     ///     (None, Some(3)) | (Some(3), None)
     /// ));
+    ///
+    ///
+    ///
+    /// // For a somewhat more practical example,
+    /// // we define a singly linked list using `Arc`:
+    /// #[derive(Clone)]
+    /// struct LinkedList<T>(Option<Arc<Node<T>>>);
+    /// struct Node<T>(T, Option<Arc<Node<T>>>);
+    ///
+    /// // Dropping a long `LinkedList<T>` relying on the destructor of `Arc`
+    /// // can cause a stack overflow. To prevent this, we can provide a
+    /// // manual `Drop` implementation that does the destruction in a loop:
+    /// impl<T> Drop for LinkedList<T> {
+    ///     fn drop(&mut self) {
+    ///         let mut x = self.0.take();
+    ///         while let Some(arc) = x.take() {
+    ///             Arc::unwrap_or_drop(arc).map(|node| x = node.1);
+    ///         }
+    ///     }
+    /// }
+    ///
+    /// // implementation of `new` and `push` omitted
+    /// impl<T> LinkedList<T> {
+    ///     /* ... */
+    /// #   fn new() -> Self {
+    /// #       LinkedList(None)
+    /// #   }
+    /// #   fn push(&mut self, x: T) {
+    /// #       self.0 = Some(Arc::new(Node(x, self.0.take())));
+    /// #   }
+    /// }
+    ///
+    /// // The following code could still cause a stack overflow
+    /// // despite the manual `Drop` impl if that `Drop` impl used
+    /// // `Arc::try_unwrap(arc).ok()` instead of `Arc::unwrap_or_drop(arc)`.
+    /// {
+    ///     // create a long list and clone it
+    ///     let mut x = LinkedList::new();
+    ///     for i in 0..100000 {
+    ///         x.push(i); // adds i to the front of x
+    ///     }
+    ///     let y = x.clone();
+    ///
+    ///     // drop the clones in parallel
+    ///     let t1 = std::thread::spawn(|| drop(x));
+    ///     let t2 = std::thread::spawn(|| drop(y));
+    ///     t1.join().unwrap();
+    ///     t2.join().unwrap();
+    /// }
     /// ```
     #[inline]
     #[unstable(feature = "unwrap_or_drop", issue = "none")] // FIXME: add issue

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -528,6 +528,7 @@ impl<T> Arc<T> {
     ///
     /// # Examples
     ///
+    /// Minimal example demonstrating the guarantee that `unwrap_or_drop` gives.
     /// ```
     /// #![feature(unwrap_or_drop)]
     ///
@@ -548,11 +549,17 @@ impl<T> Arc<T> {
     ///     (x_unwrapped_value, y_unwrapped_value),
     ///     (None, Some(3)) | (Some(3), None)
     /// ));
+    /// // The result could also be `(None, None)` if the threads called
+    /// // `Arc::try_unwrap(x).ok()` and `Arc::try_unwrap(y).ok()` instead.
+    /// ```
     ///
+    /// A more practical example demonstrating the need for `unwrap_or_drop`:
+    /// ```
+    /// #![feature(unwrap_or_drop)]
     ///
+    /// use std::sync::Arc;
     ///
-    /// // For a somewhat more practical example,
-    /// // we define a singly linked list using `Arc`:
+    /// // Definition of a simple singly linked list using `Arc`:
     /// #[derive(Clone)]
     /// struct LinkedList<T>(Option<Arc<Node<T>>>);
     /// struct Node<T>(T, Option<Arc<Node<T>>>);

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -500,6 +500,62 @@ impl<T> Arc<T> {
             Ok(elem)
         }
     }
+
+    /// Returns the inner value, if the `Arc` has exactly one strong reference.
+    ///
+    /// Otherwise, [`None`] is returned and the `Arc` is dropped.
+    ///
+    /// This will succeed even if there are outstanding weak references.
+    ///
+    /// If `unwrap_or_drop` is called on every clone of this `Arc`,
+    /// it is guaranteed that exactly one of the calls returns the inner value.
+    /// The similar expression `Arc::try_unwrap(this).ok()` does not
+    /// offer this guarantee.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(unwrap_or_drop)]
+    ///
+    /// use std::sync::Arc;
+    ///
+    /// let x = Arc::new(3);
+    /// let y = Arc::clone(&x);
+    ///
+    /// let x_unwrap_thread = std::thread::spawn(|| Arc::unwrap_or_drop(x));
+    /// let y_unwrap_thread = std::thread::spawn(|| Arc::unwrap_or_drop(y));
+    ///
+    /// let x_unwrapped_value = x_unwrap_thread.join().unwrap();
+    /// let y_unwrapped_value = y_unwrap_thread.join().unwrap();
+    ///
+    /// assert!(matches!(
+    ///     (x_unwrapped_value, y_unwrapped_value),
+    ///     (None, Some(3)) | (Some(3), None)
+    /// ));
+    /// ```
+    #[inline]
+    #[unstable(feature = "unwrap_or_drop", issue = "none")] // FIXME: add issue
+    // FIXME: should this copy all/some of the comments from drop and drop_slow?
+    pub fn unwrap_or_drop(this: Self) -> Option<T> {
+        // following the implementation of `drop` (and `drop_slow`)
+        let mut this = core::mem::ManuallyDrop::new(this);
+
+        if this.inner().strong.fetch_sub(1, Release) != 1 {
+            return None;
+        }
+
+        acquire!(this.inner().strong);
+
+        // FIXME: should the part below this be moved into a seperate #[inline(never)]
+        // function, like it's done with drop_slow in drop?
+
+        // using `ptr::read` where `drop_slow` was using `ptr::drop_in_place`
+        let inner = unsafe { ptr::read(Self::get_mut_unchecked(&mut this)) };
+
+        drop(Weak { ptr: this.ptr });
+
+        Some(inner)
+    }
 }
 
 impl<T> Arc<[T]> {

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -524,7 +524,7 @@ impl<T> Arc<T> {
     ///
     /// The similar expression `Arc::try_unwrap(this).ok()` does not
     /// offer such a guarantee. See the last example below and the documentation
-    /// of `try_unwrap`[`Arc::try_unwrap`].
+    /// of [`try_unwrap`][`Arc::try_unwrap`].
     ///
     /// # Examples
     ///

--- a/library/alloc/src/sync/tests.rs
+++ b/library/alloc/src/sync/tests.rs
@@ -112,11 +112,10 @@ fn unwrap_or_drop() {
     for _ in 0..100
     // ^ increase chances of hitting uncommon race conditions
     {
-        use std::sync::Arc;
         let x = Arc::new(3);
         let y = Arc::clone(&x);
-        let r_thread = std::thread::spawn(|| Arc::try_unwrap(x).ok());
-        let s_thread = std::thread::spawn(|| Arc::try_unwrap(y).ok());
+        let r_thread = std::thread::spawn(|| Arc::unwrap_or_drop(x));
+        let s_thread = std::thread::spawn(|| Arc::unwrap_or_drop(y));
         let r = r_thread.join().expect("r_thread panicked");
         let s = s_thread.join().expect("s_thread panicked");
         assert!(

--- a/library/alloc/src/sync/tests.rs
+++ b/library/alloc/src/sync/tests.rs
@@ -141,41 +141,6 @@ fn unwrap_or_drop() {
 }
 
 #[test]
-fn unwrap_or_drop_linked_list() {
-    #[derive(Clone)]
-    struct LinkedList<T>(Option<Arc<Node<T>>>);
-    struct Node<T>(T, Option<Arc<Node<T>>>);
-
-    impl<T> Drop for LinkedList<T> {
-        fn drop(&mut self) {
-            let mut x = self.0.take();
-            while let Some(arc) = x.take() {
-                Arc::unwrap_or_drop(arc).map(|node| x = node.1);
-            }
-        }
-    }
-
-    impl<T> LinkedList<T> {
-        fn push(&mut self, x: T) {
-            self.0 = Some(Arc::new(Node(x, self.0.take())));
-        }
-    }
-
-    use std::thread;
-    for _ in 0..25 {
-        let mut x = LinkedList(None);
-        for i in 0..100000 {
-            x.push(i);
-        }
-        let y = x.clone();
-        let t1 = thread::spawn(|| drop(x));
-        let t2 = thread::spawn(|| drop(y));
-        t1.join().unwrap();
-        t2.join().unwrap();
-    }
-}
-
-#[test]
 fn into_from_raw() {
     let x = Arc::new(box "hello");
     let y = x.clone();

--- a/library/alloc/src/sync/tests.rs
+++ b/library/alloc/src/sync/tests.rs
@@ -141,6 +141,41 @@ fn unwrap_or_drop() {
 }
 
 #[test]
+fn unwrap_or_drop_linked_list() {
+    #[derive(Clone)]
+    struct LinkedList<T>(Option<Arc<Node<T>>>);
+    struct Node<T>(T, Option<Arc<Node<T>>>);
+
+    impl<T> Drop for LinkedList<T> {
+        fn drop(&mut self) {
+            let mut x = self.0.take();
+            while let Some(arc) = x.take() {
+                Arc::unwrap_or_drop(arc).map(|node| x = node.1);
+            }
+        }
+    }
+
+    impl<T> LinkedList<T> {
+        fn push(&mut self, x: T) {
+            self.0 = Some(Arc::new(Node(x, self.0.take())));
+        }
+    }
+
+    use std::thread;
+    for _ in 0..25 {
+        let mut x = LinkedList(None);
+        for i in 0..100000 {
+            x.push(i);
+        }
+        let y = x.clone();
+        let t1 = thread::spawn(|| drop(x));
+        let t2 = thread::spawn(|| drop(y));
+        t1.join().unwrap();
+        t2.join().unwrap();
+    }
+}
+
+#[test]
 fn into_from_raw() {
     let x = Arc::new(box "hello");
     let y = x.clone();


### PR DESCRIPTION
This is my first contribution. The commit includes tests and documentation. I have marked a few stylistic or technical questions with `FIXME`. In particular, I don’t know how the tracking issues for new unstable standard library functions work.

There was previously some [discussion on IRLO](https://internals.rust-lang.org/t/de-facto-linear-types-and-arc-need-for-an-unwrap-or-drop-api/12939).

### Motivation
The functionality provided by this new “method” on `Arc` was previously not archievable with the `Arc` API. The function `unwrap_or_drop` is related to (and hence similarly named similar to) `try_unwrap`. The expression `Arc::unwrap_or_drop(x)` is almost the same as `Arc::try_unwrap(x).ok()`, however the latter includes two steps, the `try_unwrap` call and dropping the `Arc`, whereas `unwrap_or_drop` accesses the `Arc` atomically. Since this is an issue in multi-threaded settings only, a similar function on `Rc` is not strictly necessary but could be wanted nontheless for ergonomic and API-similarity reasons. (This PR currently only offers the function on `Arc`, but I could add one for `Rc` if wanted.) In the IRLO discussion, I also mentioned two more functions that could possibly extend this API.

The function `Arc::unwrap_or_drop(this: Arc<T>) -> Option<T>` offers a way to “drop” an `Arc` without calling the destructor on the contained type. When the `Arc` provided was the last strong pointer to its target, the target value is returned. Being able to do this is valueable around linear(-ish) types that should not or cannot just be dropped ordinarity, but require extra arguments, or operations that can fail or are `async` to properly get rid of.

### Further Remarks
The current documentation is adapted from and compares this function to `try_unwrap` so there’s no mention of the motivation (dropping `Arc` without calling a destructor). I don’t know if this should be added.

The names `try_unwrap` and `unwrap_or_drop` are a bit unfortunate since these operations seem quite different from the `unwrap` methods on `Option` or `Result`. This functionality could be renamed around `into_inner`, for example as `try_into_inner` (instead of `try_unwrap`, which would be deprecated) and `into_inner` (instead of `unwrap_or_drop`). Some people favored this kind of naming scheme in the IRLO discussion. On the other hand, `into_inner` is usually more straightforward and deterministic than what `unwrap_or_drop` offers.

### Rendered Documentation
![Screenshot_20200825_214643](https://user-images.githubusercontent.com/3986214/91220786-f7294900-e71c-11ea-87e9-0d0dd9277066.png)
