### PR TITLE
Suggest `mem::forget` if `mem::ManuallyDrop::new` isn't used

### DIFF
--- a/library/core/src/mem/manually_drop.rs
+++ b/library/core/src/mem/manually_drop.rs
@@ -74,8 +74,12 @@ impl<T> ManuallyDrop<T> {
     ///
     /// ```rust
     /// use std::mem::ManuallyDrop;
-    /// ManuallyDrop::new(Box::new(()));
+    /// let mut x = ManuallyDrop::new(String::from("Hello World!"));
+    /// x.truncate(5); // You can still safely operate on the value
+    /// assert_eq!(*x, "Hello");
+    /// // But `Drop` will not be run here
     /// ```
+    #[must_use = "if you don't need the wrapper, you can use `mem::forget` instead"]
     #[stable(feature = "manually_drop", since = "1.20.0")]
     #[rustc_const_stable(feature = "const_manually_drop", since = "1.36.0")]
     #[inline(always)]

--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -145,7 +145,7 @@ pub use crate::intrinsics::transmute;
 #[rustc_const_stable(feature = "const_forget", since = "1.46.0")]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub const fn forget<T>(t: T) {
-    ManuallyDrop::new(t);
+    let _ = ManuallyDrop::new(t);
 }
 
 /// Like [`forget`], but also accepts unsized values.

--- a/library/std/src/lazy.rs
+++ b/library/std/src/lazy.rs
@@ -293,7 +293,7 @@ impl<T> SyncOnceCell<T> {
 
         // Don't drop this `SyncOnceCell`. We just moved out one of the fields, but didn't set
         // the state to uninitialized.
-        mem::ManuallyDrop::new(self);
+        mem::forget(self);
         inner
     }
 


### PR DESCRIPTION
I think this communicates the intent more idiomatically, and is shorter anyway.

Inspired because [it came up on URLO](https://users.rust-lang.org/t/validity-of-memory-area-after-std-forget/47730/7?u=scottmcm), and it turns out that std had done it too in one spot:
![image](https://user-images.githubusercontent.com/18526288/91203819-e19f2980-e6f2-11ea-9112-835f3b22ce05.png)
