### PR TITLE
Add more space below the Rust badge in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 <img width = "90%" height = "auto" src = "https://img.shields.io/badge/Rust-Programming%20Language-black?style=flat&logo=rust" alt = "The Rust Programming Language">
 </a>
 
+---
+
 This is the main source code repository for [Rust]. It contains the compiler,
 standard library, and documentation.
 


### PR DESCRIPTION
The extra space makes it easier to read the README.