### PR TITLE
Widen TypeId from 64 bits to 128.

### DIFF
--- a/library/core/src/any.rs
+++ b/library/core/src/any.rs
@@ -415,7 +415,10 @@ impl dyn Any + Send + Sync {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct TypeId {
+    #[cfg(bootstrap)]
     t: u64,
+    #[cfg(not(bootstrap))]
+    t: u128,
 }
 
 impl TypeId {

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -808,7 +808,17 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is [`crate::any::TypeId::of`].
     #[rustc_const_stable(feature = "const_type_id", since = "1.46.0")]
+    #[cfg(bootstrap)]
     pub fn type_id<T: ?Sized + 'static>() -> u64;
+
+    /// Gets an identifier which is globally unique to the specified type. This
+    /// function will return the same value for a type regardless of whichever
+    /// crate it is invoked in.
+    ///
+    /// The stabilized version of this intrinsic is [`crate::any::TypeId::of`].
+    #[rustc_const_stable(feature = "const_type_id", since = "1.46.0")]
+    #[cfg(not(bootstrap))]
+    pub fn type_id<T: ?Sized + 'static>() -> u128;
 
     /// A guard for unsafe functions that cannot ever be executed if `T` is uninhabited:
     /// This will statically either panic, or do nothing.

--- a/src/librustc_middle/mir/interpret/value.rs
+++ b/src/librustc_middle/mir/interpret/value.rs
@@ -95,8 +95,8 @@ impl<'tcx> ConstValue<'tcx> {
         ConstValue::Scalar(Scalar::from_bool(b))
     }
 
-    pub fn from_u64(i: u64) -> Self {
-        ConstValue::Scalar(Scalar::from_u64(i))
+    pub fn from_u128(i: u128) -> Self {
+        ConstValue::Scalar(Scalar::from_u128(i))
     }
 
     pub fn from_machine_usize(i: u64, cx: &impl HasDataLayout) -> Self {
@@ -322,6 +322,11 @@ impl<'tcx, Tag> Scalar<Tag> {
     pub fn from_u64(i: u64) -> Self {
         // Guaranteed to be truncated and does not need sign extension.
         Scalar::Raw { data: i.into(), size: 8 }
+    }
+
+    #[inline]
+    pub fn from_u128(i: u128) -> Self {
+        Scalar::Raw { data: i, size: 16 }
     }
 
     #[inline]

--- a/src/librustc_middle/ty/util.rs
+++ b/src/librustc_middle/ty/util.rs
@@ -154,7 +154,7 @@ pub enum Representability {
 impl<'tcx> TyCtxt<'tcx> {
     /// Creates a hash of the type `Ty` which will be the same no matter what crate
     /// context it's calculated within. This is used by the `type_id` intrinsic.
-    pub fn type_id_hash(self, ty: Ty<'tcx>) -> u64 {
+    pub fn type_id_hash(self, ty: Ty<'tcx>) -> u128 {
         let mut hasher = StableHasher::new();
         let mut hcx = self.create_stable_hashing_context();
 

--- a/src/librustc_mir/interpret/intrinsics.rs
+++ b/src/librustc_mir/interpret/intrinsics.rs
@@ -73,7 +73,7 @@ crate fn eval_nullary_intrinsic<'tcx>(
         }
         sym::type_id => {
             ensure_monomorphic_enough(tcx, tp_ty)?;
-            ConstValue::from_u64(tcx.type_id_hash(tp_ty))
+            ConstValue::from_u128(tcx.type_id_hash(tp_ty))
         }
         sym::variant_count => {
             if let ty::Adt(ref adt, _) = tp_ty.kind {
@@ -146,7 +146,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                         self.tcx.types.usize
                     }
                     sym::needs_drop => self.tcx.types.bool,
-                    sym::type_id => self.tcx.types.u64,
+                    sym::type_id => self.tcx.types.u128,
                     sym::type_name => self.tcx.mk_static_str(),
                     _ => bug!("already checked for nullary intrinsics"),
                 };

--- a/src/librustc_typeck/check/intrinsic.rs
+++ b/src/librustc_typeck/check/intrinsic.rs
@@ -194,7 +194,7 @@ pub fn check_intrinsic_type(tcx: TyCtxt<'_>, it: &hir::ForeignItem<'_>) {
             sym::needs_drop => (1, Vec::new(), tcx.types.bool),
 
             sym::type_name => (1, Vec::new(), tcx.mk_static_str()),
-            sym::type_id => (1, Vec::new(), tcx.types.u64),
+            sym::type_id => (1, Vec::new(), tcx.types.u128),
             sym::offset | sym::arith_offset => (
                 1,
                 vec![


### PR DESCRIPTION
Doubling the bit-width of the type hash inside `TypeId` would serve two purposes:
* with a crater run we could find out if anyone was `transmute`-ing `TypeId`s to `u64` (although not if they read an `u64` from a `&TypeId` in a less checked way)
* it should be more collision-resistant (similar to how we use 128-bit hashes in the incremental dep-graph)

Maybe we shouldn't use SipHash for `TypeId`, as unlike incremental dep-graph hashes, we don't need computing `TypeId`s to be incredibly fast, but also we can change that independently of the bit-width we keep in `TypeId`.