### PR TITLE
Remove trait_selection error message in specific case

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -1906,6 +1906,11 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
             ObligationCauseCode::BuiltinDerivedObligation(ref data) => {
                 let parent_trait_ref = self.resolve_vars_if_possible(&data.parent_trait_ref);
                 let ty = parent_trait_ref.skip_binder().self_ty();
+                if parent_trait_ref.references_error() {
+                    err.cancel();
+                    return;
+                }
+
                 err.note(&format!("required because it appears within the type `{}`", ty));
                 obligated_types.push(ty);
 

--- a/src/test/ui/traits/issue-75627.rs
+++ b/src/test/ui/traits/issue-75627.rs
@@ -1,0 +1,6 @@
+struct Foo<T>(T, *const ());
+
+unsafe impl Send for Foo<T> {}
+//~^ ERROR cannot find type
+
+fn main() {}

--- a/src/test/ui/traits/issue-75627.stderr
+++ b/src/test/ui/traits/issue-75627.stderr
@@ -1,0 +1,9 @@
+error[E0412]: cannot find type `T` in this scope
+  --> $DIR/issue-75627.rs:3:26
+   |
+LL | unsafe impl Send for Foo<T> {}
+   |                          ^ not found in this scope
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0412`.


### PR DESCRIPTION
In the case that a trait is not implemented for an ADT with type errors, cancel the error.

Fixes #75627 