### PR TITLE
Suggest `if let x = y` when encountering `if x = y`

### DIFF
--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -213,6 +213,9 @@ pub struct Session {
 
     known_attrs: Lock<MarkedAttrs>,
     used_attrs: Lock<MarkedAttrs>,
+
+    /// `Span`s for `if` conditions that we have suggested turning into `if let`.
+    pub if_let_suggestions: Lock<FxHashSet<Span>>,
 }
 
 pub struct PerfStats {
@@ -1354,6 +1357,7 @@ pub fn build_session(
         target_features: FxHashSet::default(),
         known_attrs: Lock::new(MarkedAttrs::new()),
         used_attrs: Lock::new(MarkedAttrs::new()),
+        if_let_suggestions: Default::default(),
     };
 
     validate_commandline_args_with_session_available(&sess);

--- a/src/test/ui/error-codes/E0070.stderr
+++ b/src/test/ui/error-codes/E0070.stderr
@@ -14,12 +14,6 @@ LL |     1 = 3;
    |     |
    |     cannot assign to this expression
 
-error[E0308]: mismatched types
-  --> $DIR/E0070.rs:8:25
-   |
-LL |     some_other_func() = 4;
-   |                         ^ expected `()`, found integer
-
 error[E0070]: invalid left-hand side of assignment
   --> $DIR/E0070.rs:8:23
    |
@@ -27,6 +21,12 @@ LL |     some_other_func() = 4;
    |     ----------------- ^
    |     |
    |     cannot assign to this expression
+
+error[E0308]: mismatched types
+  --> $DIR/E0070.rs:8:25
+   |
+LL |     some_other_func() = 4;
+   |                         ^ expected `()`, found integer
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/issues/issue-13407.stderr
+++ b/src/test/ui/issues/issue-13407.stderr
@@ -10,12 +10,6 @@ note: the unit struct `C` is defined here
 LL |     struct C;
    |     ^^^^^^^^^
 
-error[E0308]: mismatched types
-  --> $DIR/issue-13407.rs:6:12
-   |
-LL |     A::C = 1;
-   |            ^ expected struct `A::C`, found integer
-
 error[E0070]: invalid left-hand side of assignment
   --> $DIR/issue-13407.rs:6:10
    |
@@ -23,6 +17,12 @@ LL |     A::C = 1;
    |     ---- ^
    |     |
    |     cannot assign to this expression
+
+error[E0308]: mismatched types
+  --> $DIR/issue-13407.rs:6:12
+   |
+LL |     A::C = 1;
+   |            ^ expected struct `A::C`, found integer
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/rfc-2497-if-let-chains/disallowed-positions.stderr
+++ b/src/test/ui/rfc-2497-if-let-chains/disallowed-positions.stderr
@@ -568,10 +568,12 @@ error[E0308]: mismatched types
   --> $DIR/disallowed-positions.rs:56:8
    |
 LL |     if x = let 0 = 0 {}
-   |        ^^^^^^^^^^^^^
-   |        |
-   |        expected `bool`, found `()`
-   |        help: try comparing for equality: `x == let 0 = 0`
+   |        ^^^^^^^^^^^^^ expected `bool`, found `()`
+   |
+help: you might have meant to compare for equality
+   |
+LL |     if x == let 0 = 0 {}
+   |          ^^
 
 error[E0308]: mismatched types
   --> $DIR/disallowed-positions.rs:59:8
@@ -754,10 +756,12 @@ error[E0308]: mismatched types
   --> $DIR/disallowed-positions.rs:120:11
    |
 LL |     while x = let 0 = 0 {}
-   |           ^^^^^^^^^^^^^
-   |           |
-   |           expected `bool`, found `()`
-   |           help: try comparing for equality: `x == let 0 = 0`
+   |           ^^^^^^^^^^^^^ expected `bool`, found `()`
+   |
+help: you might have meant to compare for equality
+   |
+LL |     while x == let 0 = 0 {}
+   |             ^^
 
 error[E0308]: mismatched types
   --> $DIR/disallowed-positions.rs:123:11

--- a/src/test/ui/suggestions/if-let-typo.rs
+++ b/src/test/ui/suggestions/if-let-typo.rs
@@ -1,0 +1,9 @@
+fn main() {
+    let foo = Some(0);
+    let bar = None;
+    if Some(x) = foo {} //~ ERROR cannot find value `x` in this scope
+    if Some(foo) = bar {} //~ ERROR mismatched types
+    if 3 = foo {} //~ ERROR mismatched types
+    //~^ ERROR mismatched types
+    if Some(3) = foo {} //~ ERROR mismatched types
+}

--- a/src/test/ui/suggestions/if-let-typo.stderr
+++ b/src/test/ui/suggestions/if-let-typo.stderr
@@ -1,0 +1,60 @@
+error[E0425]: cannot find value `x` in this scope
+  --> $DIR/if-let-typo.rs:4:13
+   |
+LL |     if Some(x) = foo {}
+   |             ^ not found in this scope
+   |
+help: you might have meant to use pattern matching
+   |
+LL |     if let Some(x) = foo {}
+   |        ^^^
+
+error[E0308]: mismatched types
+  --> $DIR/if-let-typo.rs:5:8
+   |
+LL |     if Some(foo) = bar {}
+   |        ^^^^^^^^^^^^^^^ expected `bool`, found `()`
+   |
+help: you might have meant to use pattern matching
+   |
+LL |     if let Some(foo) = bar {}
+   |        ^^^
+help: you might have meant to compare for equality
+   |
+LL |     if Some(foo) == bar {}
+   |                  ^^
+
+error[E0308]: mismatched types
+  --> $DIR/if-let-typo.rs:6:12
+   |
+LL |     if 3 = foo {}
+   |            ^^^ expected integer, found enum `std::option::Option`
+   |
+   = note: expected type `{integer}`
+              found enum `std::option::Option<{integer}>`
+
+error[E0308]: mismatched types
+  --> $DIR/if-let-typo.rs:6:8
+   |
+LL |     if 3 = foo {}
+   |        ^^^^^^^ expected `bool`, found `()`
+
+error[E0308]: mismatched types
+  --> $DIR/if-let-typo.rs:8:8
+   |
+LL |     if Some(3) = foo {}
+   |        ^^^^^^^^^^^^^ expected `bool`, found `()`
+   |
+help: you might have meant to use pattern matching
+   |
+LL |     if let Some(3) = foo {}
+   |        ^^^
+help: you might have meant to compare for equality
+   |
+LL |     if Some(3) == foo {}
+   |                ^^
+
+error: aborting due to 5 previous errors
+
+Some errors have detailed explanations: E0308, E0425.
+For more information about an error, try `rustc --explain E0308`.

--- a/src/test/ui/type/type-check/assignment-expected-bool.stderr
+++ b/src/test/ui/type/type-check/assignment-expected-bool.stderr
@@ -2,100 +2,126 @@ error[E0308]: mismatched types
   --> $DIR/assignment-expected-bool.rs:6:19
    |
 LL |     let _: bool = 0 = 0;
-   |                   ^^^^^
-   |                   |
-   |                   expected `bool`, found `()`
-   |                   help: try comparing for equality: `0 == 0`
+   |                   ^^^^^ expected `bool`, found `()`
+   |
+help: you might have meant to compare for equality
+   |
+LL |     let _: bool = 0 == 0;
+   |                     ^^
 
 error[E0308]: mismatched types
   --> $DIR/assignment-expected-bool.rs:9:14
    |
 LL |         0 => 0 = 0,
-   |              ^^^^^
-   |              |
-   |              expected `bool`, found `()`
-   |              help: try comparing for equality: `0 == 0`
+   |              ^^^^^ expected `bool`, found `()`
+   |
+help: you might have meant to compare for equality
+   |
+LL |         0 => 0 == 0,
+   |                ^^
 
 error[E0308]: mismatched types
   --> $DIR/assignment-expected-bool.rs:10:14
    |
 LL |         _ => 0 = 0,
-   |              ^^^^^
-   |              |
-   |              expected `bool`, found `()`
-   |              help: try comparing for equality: `0 == 0`
+   |              ^^^^^ expected `bool`, found `()`
+   |
+help: you might have meant to compare for equality
+   |
+LL |         _ => 0 == 0,
+   |                ^^
 
 error[E0308]: mismatched types
   --> $DIR/assignment-expected-bool.rs:14:17
    |
 LL |         true => 0 = 0,
-   |                 ^^^^^
-   |                 |
-   |                 expected `bool`, found `()`
-   |                 help: try comparing for equality: `0 == 0`
+   |                 ^^^^^ expected `bool`, found `()`
+   |
+help: you might have meant to compare for equality
+   |
+LL |         true => 0 == 0,
+   |                   ^^
 
 error[E0308]: mismatched types
   --> $DIR/assignment-expected-bool.rs:18:8
    |
 LL |     if 0 = 0 {}
-   |        ^^^^^
-   |        |
-   |        expected `bool`, found `()`
-   |        help: try comparing for equality: `0 == 0`
+   |        ^^^^^ expected `bool`, found `()`
+   |
+help: you might have meant to use pattern matching
+   |
+LL |     if let 0 = 0 {}
+   |        ^^^
+help: you might have meant to compare for equality
+   |
+LL |     if 0 == 0 {}
+   |          ^^
 
 error[E0308]: mismatched types
   --> $DIR/assignment-expected-bool.rs:20:24
    |
 LL |     let _: bool = if { 0 = 0 } {
-   |                        ^^^^^
-   |                        |
-   |                        expected `bool`, found `()`
-   |                        help: try comparing for equality: `0 == 0`
+   |                        ^^^^^ expected `bool`, found `()`
+   |
+help: you might have meant to compare for equality
+   |
+LL |     let _: bool = if { 0 == 0 } {
+   |                          ^^
 
 error[E0308]: mismatched types
   --> $DIR/assignment-expected-bool.rs:21:9
    |
 LL |         0 = 0
-   |         ^^^^^
-   |         |
-   |         expected `bool`, found `()`
-   |         help: try comparing for equality: `0 == 0`
+   |         ^^^^^ expected `bool`, found `()`
+   |
+help: you might have meant to compare for equality
+   |
+LL |         0 == 0
+   |           ^^
 
 error[E0308]: mismatched types
   --> $DIR/assignment-expected-bool.rs:23:9
    |
 LL |         0 = 0
-   |         ^^^^^
-   |         |
-   |         expected `bool`, found `()`
-   |         help: try comparing for equality: `0 == 0`
+   |         ^^^^^ expected `bool`, found `()`
+   |
+help: you might have meant to compare for equality
+   |
+LL |         0 == 0
+   |           ^^
 
 error[E0308]: mismatched types
   --> $DIR/assignment-expected-bool.rs:26:13
    |
 LL |     let _ = (0 = 0)
-   |             ^^^^^^^
-   |             |
-   |             expected `bool`, found `()`
-   |             help: try comparing for equality: `0 == 0`
+   |             ^^^^^^^ expected `bool`, found `()`
+   |
+help: you might have meant to compare for equality
+   |
+LL |     let _ = (0 == 0)
+   |                ^^
 
 error[E0308]: mismatched types
   --> $DIR/assignment-expected-bool.rs:27:14
    |
 LL |         && { 0 = 0 }
-   |              ^^^^^
-   |              |
-   |              expected `bool`, found `()`
-   |              help: try comparing for equality: `0 == 0`
+   |              ^^^^^ expected `bool`, found `()`
+   |
+help: you might have meant to compare for equality
+   |
+LL |         && { 0 == 0 }
+   |                ^^
 
 error[E0308]: mismatched types
   --> $DIR/assignment-expected-bool.rs:28:12
    |
 LL |         || (0 = 0);
-   |            ^^^^^^^
-   |            |
-   |            expected `bool`, found `()`
-   |            help: try comparing for equality: `0 == 0`
+   |            ^^^^^^^ expected `bool`, found `()`
+   |
+help: you might have meant to compare for equality
+   |
+LL |         || (0 == 0);
+   |               ^^
 
 error[E0070]: invalid left-hand side of assignment
   --> $DIR/assignment-expected-bool.rs:31:22

--- a/src/test/ui/type/type-check/assignment-in-if.stderr
+++ b/src/test/ui/type/type-check/assignment-in-if.stderr
@@ -2,55 +2,71 @@ error[E0308]: mismatched types
   --> $DIR/assignment-in-if.rs:15:8
    |
 LL |     if x = x {
-   |        ^^^^^
-   |        |
-   |        expected `bool`, found `()`
-   |        help: try comparing for equality: `x == x`
+   |        ^^^^^ expected `bool`, found `()`
+   |
+help: you might have meant to compare for equality
+   |
+LL |     if x == x {
+   |          ^^
 
 error[E0308]: mismatched types
   --> $DIR/assignment-in-if.rs:20:8
    |
 LL |     if (x = x) {
-   |        ^^^^^^^
-   |        |
-   |        expected `bool`, found `()`
-   |        help: try comparing for equality: `x == x`
+   |        ^^^^^^^ expected `bool`, found `()`
+   |
+help: you might have meant to compare for equality
+   |
+LL |     if (x == x) {
+   |           ^^
 
 error[E0308]: mismatched types
   --> $DIR/assignment-in-if.rs:25:8
    |
 LL |     if y = (Foo { foo: x }) {
-   |        ^^^^^^^^^^^^^^^^^^^^
-   |        |
-   |        expected `bool`, found `()`
-   |        help: try comparing for equality: `y == (Foo { foo: x })`
+   |        ^^^^^^^^^^^^^^^^^^^^ expected `bool`, found `()`
+   |
+help: you might have meant to compare for equality
+   |
+LL |     if y == (Foo { foo: x }) {
+   |          ^^
 
 error[E0308]: mismatched types
   --> $DIR/assignment-in-if.rs:30:8
    |
 LL |     if 3 = x {
-   |        ^^^^^
-   |        |
-   |        expected `bool`, found `()`
-   |        help: try comparing for equality: `3 == x`
+   |        ^^^^^ expected `bool`, found `()`
+   |
+help: you might have meant to use pattern matching
+   |
+LL |     if let 3 = x {
+   |        ^^^
+help: you might have meant to compare for equality
+   |
+LL |     if 3 == x {
+   |          ^^
 
 error[E0308]: mismatched types
   --> $DIR/assignment-in-if.rs:36:13
    |
 LL |             x = 4
-   |             ^^^^^
-   |             |
-   |             expected `bool`, found `()`
-   |             help: try comparing for equality: `x == 4`
+   |             ^^^^^ expected `bool`, found `()`
+   |
+help: you might have meant to compare for equality
+   |
+LL |             x == 4
+   |               ^^
 
 error[E0308]: mismatched types
   --> $DIR/assignment-in-if.rs:38:13
    |
 LL |             x = 5
-   |             ^^^^^
-   |             |
-   |             expected `bool`, found `()`
-   |             help: try comparing for equality: `x == 5`
+   |             ^^^^^ expected `bool`, found `()`
+   |
+help: you might have meant to compare for equality
+   |
+LL |             x == 5
+   |               ^^
 
 error: aborting due to 6 previous errors
 


### PR DESCRIPTION
Detect potential cases where `if let` was meant but `let` was left out.

Fix #44990.