### PR TITLE
Fix potential UB in align_offset doc examples

### DIFF
--- a/library/core/src/ptr/const_ptr.rs
+++ b/library/core/src/ptr/const_ptr.rs
@@ -836,7 +836,7 @@ impl<T: ?Sized> *const T {
     /// # use std::mem::align_of;
     /// # unsafe {
     /// let x = [5u8, 6u8, 7u8, 8u8, 9u8];
-    /// let ptr = &x[n] as *const u8;
+    /// let ptr = x.as_ptr().add(n) as *const u8;
     /// let offset = ptr.align_offset(align_of::<u16>());
     /// if offset < x.len() - n - 1 {
     ///     let u16_ptr = ptr.add(offset) as *const u16;

--- a/library/core/src/ptr/mut_ptr.rs
+++ b/library/core/src/ptr/mut_ptr.rs
@@ -1094,7 +1094,7 @@ impl<T: ?Sized> *mut T {
     /// # use std::mem::align_of;
     /// # unsafe {
     /// let x = [5u8, 6u8, 7u8, 8u8, 9u8];
-    /// let ptr = &x[n] as *const u8;
+    /// let ptr = x.as_ptr().add(n) as *const u8;
     /// let offset = ptr.align_offset(align_of::<u16>());
     /// if offset < x.len() - n - 1 {
     ///     let u16_ptr = ptr.add(offset) as *const u16;


### PR DESCRIPTION
Currently it takes a pointer only to the first element in the array, this changes the code to take a pointer to the whole array.
miri can't catch this right now because it later calls `x.len()` which re-tags the pointer for the whole array.

https://github.com/rust-lang/miri/issues/1526#issuecomment-680897144