### PR TITLE
Fix swapped stability attributes for rustdoc lints

### DIFF
--- a/src/librustdoc/passes/doc_test_lints.rs
+++ b/src/librustdoc/passes/doc_test_lints.rs
@@ -1,7 +1,7 @@
 //! This pass is overloaded and runs two different lints.
 //!
-//! - MISSING_DOC_CODE_EXAMPLES: this looks for public items missing doc-tests
-//! - PRIVATE_DOC_TESTS: this looks for private items with doc-tests.
+//! - MISSING_DOC_CODE_EXAMPLES: this lint is **UNSTABLE** and looks for public items missing doc-tests
+//! - PRIVATE_DOC_TESTS: this lint is **STABLE** and looks for private items with doc-tests.
 
 use super::{span_of_attrs, Pass};
 use crate::clean;
@@ -89,7 +89,9 @@ pub fn look_for_tests<'tcx>(cx: &DocContext<'tcx>, dox: &str, item: &Item) {
 
     find_testable_code(&dox, &mut tests, ErrorCodes::No, false, None);
 
-    if tests.found_tests == 0 {
+    if tests.found_tests == 0
+        && rustc_feature::UnstableFeatures::from_environment().is_nightly_build()
+    {
         if should_have_doc_example(&item.inner) {
             debug!("reporting error for {:?} (hir_id={:?})", item, hir_id);
             let sp = span_of_attrs(&item.attrs).unwrap_or(item.source.span());
@@ -100,9 +102,7 @@ pub fn look_for_tests<'tcx>(cx: &DocContext<'tcx>, dox: &str, item: &Item) {
                 |lint| lint.build("missing code example in this documentation").emit(),
             );
         }
-    } else if rustc_feature::UnstableFeatures::from_environment().is_nightly_build()
-        && tests.found_tests > 0
-        && !cx.renderinfo.borrow().access_levels.is_public(item.def_id)
+    } else if tests.found_tests > 0 && !cx.renderinfo.borrow().access_levels.is_public(item.def_id)
     {
         cx.tcx.struct_span_lint_hir(
             lint::builtin::PRIVATE_DOC_TESTS,


### PR DESCRIPTION
This fixes a regression introduced in https://github.com/rust-lang/rust/pull/74855. Previously, `missing_doc_code_examples` would be run on stable and `private_doc_tests` would only be run on nightly. Now, it correctly does the reverse.
Closes https://github.com/rust-lang/rust/issues/75951.
r? @ehuss