### PR TITLE
Use intra-doc links in `core::future::future` and `core::num::dec2flt`

### DIFF
--- a/library/core/src/future/future.rs
+++ b/library/core/src/future/future.rs
@@ -91,7 +91,6 @@ pub trait Future {
     /// (memory corruption, incorrect use of `unsafe` functions, or the like),
     /// regardless of the future's state.
     ///
-    /// [`Poll::Pending`]: Poll::Pending
     /// [`Poll::Ready(val)`]: Poll::Ready
     /// [`Waker`]: crate::task::Waker
     /// [`Waker::wake`]: crate::task::Waker::wake

--- a/library/core/src/future/future.rs
+++ b/library/core/src/future/future.rs
@@ -23,7 +23,7 @@ use crate::task::{Context, Poll};
 /// When using a future, you generally won't call `poll` directly, but instead
 /// `.await` the value.
 ///
-/// [`Waker`]: ../task/struct.Waker.html
+/// [`Waker`]: crate::task::Waker
 #[doc(spotlight)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 #[stable(feature = "futures_api", since = "1.36.0")]
@@ -91,11 +91,10 @@ pub trait Future {
     /// (memory corruption, incorrect use of `unsafe` functions, or the like),
     /// regardless of the future's state.
     ///
-    /// [`Poll::Pending`]: ../task/enum.Poll.html#variant.Pending
-    /// [`Poll::Ready(val)`]: ../task/enum.Poll.html#variant.Ready
-    /// [`Context`]: ../task/struct.Context.html
-    /// [`Waker`]: ../task/struct.Waker.html
-    /// [`Waker::wake`]: ../task/struct.Waker.html#method.wake
+    /// [`Poll::Pending`]: Poll::Pending
+    /// [`Poll::Ready(val)`]: Poll::Ready
+    /// [`Waker`]: crate::task::Waker
+    /// [`Waker::wake`]: crate::task::Waker::wake
     #[lang = "poll"]
     #[stable(feature = "futures_api", since = "1.36.0")]
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output>;

--- a/library/core/src/num/dec2flt/mod.rs
+++ b/library/core/src/num/dec2flt/mod.rs
@@ -166,10 +166,6 @@ from_str_float_impl!(f64);
 ///
 /// This error is used as the error type for the [`FromStr`] implementation
 /// for [`f32`] and [`f64`].
-///
-/// [`FromStr`]: ../str/trait.FromStr.html
-/// [`f32`]: ../../std/primitive.f32.html
-/// [`f64`]: ../../std/primitive.f64.html
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct ParseFloatError {


### PR DESCRIPTION
Part of #75080.

@rustbot modify labels: A-intra-doc-links T-doc