### PR TITLE
Fix -Clinker-plugin-lto with opt-levels s and z

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/linker.rs
+++ b/compiler/rustc_codegen_ssa/src/back/linker.rs
@@ -221,10 +221,8 @@ impl<'a> GccLinker<'a> {
         let opt_level = match self.sess.opts.optimize {
             config::OptLevel::No => "O0",
             config::OptLevel::Less => "O1",
-            config::OptLevel::Default => "O2",
+            config::OptLevel::Default | config::OptLevel::Size | config::OptLevel::SizeMin => "O2",
             config::OptLevel::Aggressive => "O3",
-            config::OptLevel::Size => "Os",
-            config::OptLevel::SizeMin => "Oz",
         };
 
         self.linker_arg(&format!("-plugin-opt={}", opt_level));

--- a/src/test/ui/lto-opt-level-s.rs
+++ b/src/test/ui/lto-opt-level-s.rs
@@ -1,5 +1,6 @@
 // compile-flags: -Clinker-plugin-lto -Copt-level=s
 // build-pass
+// no-prefer-dynamic
 
 #![crate_type = "rlib"]
 

--- a/src/test/ui/lto-opt-level-s.rs
+++ b/src/test/ui/lto-opt-level-s.rs
@@ -1,0 +1,6 @@
+// compile-flags: -Clinker-plugin-lto -Copt-level=s
+// build-pass
+
+#![crate_type = "rlib"]
+
+pub fn foo() {}

--- a/src/test/ui/lto-opt-level-z.rs
+++ b/src/test/ui/lto-opt-level-z.rs
@@ -1,0 +1,6 @@
+// compile-flags: -Clinker-plugin-lto -Copt-level=z
+// build-pass
+
+#![crate_type = "rlib"]
+
+pub fn foo() {}

--- a/src/test/ui/lto-opt-level-z.rs
+++ b/src/test/ui/lto-opt-level-z.rs
@@ -1,5 +1,6 @@
 // compile-flags: -Clinker-plugin-lto -Copt-level=z
 // build-pass
+// no-prefer-dynamic
 
 #![crate_type = "rlib"]
 


### PR DESCRIPTION
Pass s and z as `-plugin-opt=O2` to the linker. This is what `-Os` and `-Oz` correspond to, apparently.

Fixes https://github.com/rust-lang/rust/issues/75940