### PR TITLE
Avoid function-scoping global variables

### DIFF
--- a/src/tools/publish_toolstate.py
+++ b/src/tools/publish_toolstate.py
@@ -275,7 +275,12 @@ def update_latest(
         return message
 
 
-def main():
+# Warning: Do not try to add a function containing the body of this try block.
+# There are variables declared within that are implicitly global; it is unknown
+# which ones precisely but at least this is true for `github_token`.
+try:
+    if __name__ != '__main__':
+        exit(0)
     repo = os.environ.get('TOOLSTATE_VALIDATE_MAINTAINERS_REPO')
     if repo:
         github_token = os.environ.get('TOOLSTATE_REPO_ACCESS_TOKEN')
@@ -342,11 +347,6 @@ def main():
         }
     ))
     response.read()
-
-
-if __name__ == '__main__':
-    try:
-        main()
-    except urllib2.HTTPError as e:
-        print("HTTPError: %s\n%s" % (e, e.read()))
-        raise
+except urllib2.HTTPError as e:
+    print("HTTPError: %s\n%s" % (e, e.read()))
+    raise


### PR DESCRIPTION
In 2e6f2e885506ee4, we added a main function to the publish_toolstate.py script.
Unfortunately, we missed that the Python program implicitly declares global
variables in that code, which means that adding a function changes variable
scoping and breaks other code.

This commit avoids introducing that function and adds a warning to future
editors of the code.