### PR TITLE
Applied `#![deny(unsafe_op_in_unsafe_fn)]` in library/std/src/wasi

### DIFF
--- a/library/std/src/sys/wasi/alloc.rs
+++ b/library/std/src/sys/wasi/alloc.rs
@@ -1,26 +1,45 @@
+#![deny(unsafe_op_in_unsafe_fn)]
+
 use crate::alloc::{GlobalAlloc, Layout, System};
 use crate::ptr;
 use crate::sys_common::alloc::{realloc_fallback, MIN_ALIGN};
 
+// SAFETY: All methods implemented follow the contract rules defined
+// in `GlobalAlloc`.
 #[stable(feature = "alloc_system_type", since = "1.28.0")]
 unsafe impl GlobalAlloc for System {
     #[inline]
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
         if layout.align() <= MIN_ALIGN && layout.align() <= layout.size() {
-            libc::malloc(layout.size()) as *mut u8
+            // SAFETY: `libc::malloc` is guaranteed to be safe, it will allocate
+            // `layout.size()` bytes of memory and return a pointer to it
+            unsafe { libc::malloc(layout.size()) as *mut u8 }
         } else {
-            libc::aligned_alloc(layout.align(), layout.size()) as *mut u8
+            // SAFETY: `libc::aligned_alloc` is guaranteed to be safe if
+            // `layout.size()` is a multiple of `layout.align()`. This
+            // constraint can be satisfied if `pad_to_align` is called,
+            // which creates a layout by rounding the size of this layout up
+            // to a multiple of the layout's alignment
+            let aligned_layout = layout.pad_to_align();
+            unsafe { libc::aligned_alloc(aligned_layout.align(), aligned_layout.size()) as *mut u8 }
         }
     }
 
     #[inline]
     unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
         if layout.align() <= MIN_ALIGN && layout.align() <= layout.size() {
-            libc::calloc(layout.size(), 1) as *mut u8
+            // SAFETY: `libc::calloc` is safe as long that `layout.size() * 1`
+            // would not result in integer overflow which cannot happen,
+            // multiplying by one never overflows
+            unsafe { libc::calloc(layout.size(), 1) as *mut u8 }
         } else {
-            let ptr = self.alloc(layout.clone());
+            // SAFETY: The safety contract for `alloc` must be upheld by the caller
+            let ptr = unsafe { self.alloc(layout.clone()) };
             if !ptr.is_null() {
-                ptr::write_bytes(ptr, 0, layout.size());
+                // SAFETY: in the case of the `ptr` being not null
+                // it will be properly aligned and a valid ptr
+                // which satisfies `ptr::write_bytes` safety constrains
+                unsafe { ptr::write_bytes(ptr, 0, layout.size()) };
             }
             ptr
         }
@@ -28,15 +47,23 @@ unsafe impl GlobalAlloc for System {
 
     #[inline]
     unsafe fn dealloc(&self, ptr: *mut u8, _layout: Layout) {
-        libc::free(ptr as *mut libc::c_void)
+        // SAFETY: `libc::free` is guaranteed to be safe if `ptr` is allocated
+        // by this allocator or if `ptr` is NULL
+        unsafe { libc::free(ptr as *mut libc::c_void) }
     }
 
     #[inline]
     unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
         if layout.align() <= MIN_ALIGN && layout.align() <= new_size {
-            libc::realloc(ptr as *mut libc::c_void, new_size) as *mut u8
+            // SAFETY: `libc::realloc` is safe if `ptr` is allocated by this
+            // allocator or NULL
+            // - If `new_size` is 0 and `ptr` is not NULL, it will act as `libc::free`
+            // - If `new_size` is not 0 and `ptr` is NULL, it will act as `libc::malloc`
+            // - Else, it will resize the block accordingly
+            unsafe { libc::realloc(ptr as *mut libc::c_void, new_size) as *mut u8 }
         } else {
-            realloc_fallback(self, ptr, layout, new_size)
+            // SAFETY: The safety contract for `realloc_fallback` must be upheld by the caller
+            unsafe { realloc_fallback(self, ptr, layout, new_size) }
         }
     }
 }

--- a/library/std/src/sys/wasi/args.rs
+++ b/library/std/src/sys/wasi/args.rs
@@ -1,3 +1,5 @@
+#![deny(unsafe_op_in_unsafe_fn)]
+
 use crate::ffi::{CStr, OsStr, OsString};
 use crate::marker::PhantomData;
 use crate::os::wasi::ffi::OsStrExt;

--- a/library/std/src/sys/wasi/ext/fs.rs
+++ b/library/std/src/sys/wasi/ext/fs.rs
@@ -1,5 +1,6 @@
 //! WASI-specific extensions to primitives in the `std::fs` module.
 
+#![deny(unsafe_op_in_unsafe_fn)]
 #![unstable(feature = "wasi_ext", issue = "none")]
 
 use crate::fs::{self, File, Metadata, OpenOptions};

--- a/library/std/src/sys/wasi/ext/io.rs
+++ b/library/std/src/sys/wasi/ext/io.rs
@@ -1,5 +1,6 @@
 //! WASI-specific extensions to general I/O primitives
 
+#![deny(unsafe_op_in_unsafe_fn)]
 #![unstable(feature = "wasi_ext", issue = "none")]
 
 use crate::fs;

--- a/library/std/src/sys/wasi/ext/mod.rs
+++ b/library/std/src/sys/wasi/ext/mod.rs
@@ -1,3 +1,5 @@
+#![deny(unsafe_op_in_unsafe_fn)]
+
 pub mod ffi;
 pub mod fs;
 pub mod io;

--- a/library/std/src/sys/wasi/fd.rs
+++ b/library/std/src/sys/wasi/fd.rs
@@ -1,3 +1,4 @@
+#![deny(unsafe_op_in_unsafe_fn)]
 #![allow(dead_code)]
 
 use super::err2io;

--- a/library/std/src/sys/wasi/fs.rs
+++ b/library/std/src/sys/wasi/fs.rs
@@ -1,3 +1,5 @@
+#![deny(unsafe_op_in_unsafe_fn)]
+
 use crate::ffi::{CStr, CString, OsStr, OsString};
 use crate::fmt;
 use crate::io::{self, IoSlice, IoSliceMut, SeekFrom};

--- a/library/std/src/sys/wasi/io.rs
+++ b/library/std/src/sys/wasi/io.rs
@@ -1,3 +1,5 @@
+#![deny(unsafe_op_in_unsafe_fn)]
+
 use crate::marker::PhantomData;
 use crate::slice;
 

--- a/library/std/src/sys/wasi/net.rs
+++ b/library/std/src/sys/wasi/net.rs
@@ -1,3 +1,5 @@
+#![deny(unsafe_op_in_unsafe_fn)]
+
 use crate::convert::TryFrom;
 use crate::fmt;
 use crate::io::{self, IoSlice, IoSliceMut};

--- a/library/std/src/sys/wasi/os.rs
+++ b/library/std/src/sys/wasi/os.rs
@@ -1,3 +1,5 @@
+#![deny(unsafe_op_in_unsafe_fn)]
+
 use crate::any::Any;
 use crate::error::Error as StdError;
 use crate::ffi::{CStr, CString, OsStr, OsString};

--- a/library/std/src/sys/wasi/pipe.rs
+++ b/library/std/src/sys/wasi/pipe.rs
@@ -1,3 +1,5 @@
+#![deny(unsafe_op_in_unsafe_fn)]
+
 use crate::io::{self, IoSlice, IoSliceMut};
 use crate::sys::Void;
 

--- a/library/std/src/sys/wasi/process.rs
+++ b/library/std/src/sys/wasi/process.rs
@@ -1,3 +1,5 @@
+#![deny(unsafe_op_in_unsafe_fn)]
+
 use crate::ffi::OsStr;
 use crate::fmt;
 use crate::io;

--- a/library/std/src/sys/wasi/stdio.rs
+++ b/library/std/src/sys/wasi/stdio.rs
@@ -1,3 +1,5 @@
+#![deny(unsafe_op_in_unsafe_fn)]
+
 use crate::io::{self, IoSlice, IoSliceMut};
 use crate::mem::ManuallyDrop;
 use crate::sys::fd::WasiFd;

--- a/library/std/src/sys/wasi/thread.rs
+++ b/library/std/src/sys/wasi/thread.rs
@@ -1,3 +1,5 @@
+#![deny(unsafe_op_in_unsafe_fn)]
+
 use crate::ffi::CStr;
 use crate::io;
 use crate::mem;

--- a/library/std/src/sys/wasi/time.rs
+++ b/library/std/src/sys/wasi/time.rs
@@ -1,3 +1,5 @@
+#![deny(unsafe_op_in_unsafe_fn)]
+
 use crate::time::Duration;
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]


### PR DESCRIPTION
partial fix for #73904

There are still more that was not applied in [mod.rs]( https://github.com/rust-lang/rust/blob/38fab2ea92a48980219989817201bf2094ae826a/library/std/src/sys/wasi/mod.rs) and that is due to its using files from `../unsupported`

like: 
```
#[path = "../unsupported/cmath.rs"]
pub mod cmath;
```