### PR TITLE
Allow --bess ing expect-tests in tools

### DIFF
--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -1079,6 +1079,11 @@ impl<'a> Builder<'a> {
             },
         );
 
+        if self.config.cmd.bless() {
+            // Bless `expect!` tests.
+            cargo.env("UPDATE_EXPECT", "1");
+        }
+
         if !mode.is_tool() {
             cargo.env("RUSTC_FORCE_UNSTABLE", "1");
         }

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -1754,11 +1754,6 @@ impl Step for Crate {
             cargo.arg("--quiet");
         }
 
-        if builder.config.cmd.bless() {
-            // Bless `expect!` tests.
-            cargo.env("UPDATE_EXPECT", "1");
-        }
-
         if target.contains("emscripten") {
             cargo.env(
                 format!("CARGO_TARGET_{}_RUNNER", envify(&target.triple)),


### PR DESCRIPTION
I haven't tried this, but I think this should do the trick, as `RustdocCrate` is a special step in bootstrap, which uses `tool_caro`

r? @ghost 