### PR TITLE
Improve unresolved use error message

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes/E0433.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0433.md
@@ -1,17 +1,27 @@
-An undeclared type or module was used.
+An undeclared crate, module, or type was used.
 
 Erroneous code example:
 
 ```compile_fail,E0433
 let map = HashMap::new();
-// error: failed to resolve: use of undeclared type or module `HashMap`
+// error: failed to resolve: use of undeclared type `HashMap`
 ```
 
 Please verify you didn't misspell the type/module's name or that you didn't
 forget to import it:
 
-
 ```
 use std::collections::HashMap; // HashMap has been imported.
 let map: HashMap<u32, u32> = HashMap::new(); // So it can be used!
 ```
+
+If you've expected to use a crate name:
+
+```compile_fail
+use ferris_wheel::BigO;
+// error: failed to resolve: use of undeclared crate or module `ferris_wheel`
+```
+
+Make sure the crate has been added as a dependency in `Cargo.toml`.
+
+To use a module from your current crate, add the `crate::` prefix to the path.

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -2407,7 +2407,14 @@ impl<'a> Resolver<'a> {
                             (format!("maybe a missing crate `{}`?", ident), None)
                         }
                     } else if i == 0 {
-                        (format!("use of undeclared type or module `{}`", ident), None)
+                        if ident
+                            .name
+                            .with(|n| n.chars().next().map_or(false, |c| c.is_ascii_uppercase()))
+                        {
+                            (format!("use of undeclared type `{}`", ident), None)
+                        } else {
+                            (format!("use of undeclared crate or module `{}`", ident), None)
+                        }
                     } else {
                         let mut msg =
                             format!("could not find `{}` in `{}`", ident, path[i - 1].ident);

--- a/src/test/ui/attributes/register-attr-tool-prelude.rs
+++ b/src/test/ui/attributes/register-attr-tool-prelude.rs
@@ -7,7 +7,7 @@
 #[no_implicit_prelude]
 mod m {
     #[attr] //~ ERROR cannot find attribute `attr` in this scope
-    #[tool::attr] //~ ERROR failed to resolve: use of undeclared type or module `tool`
+    #[tool::attr] //~ ERROR failed to resolve: use of undeclared crate or module `tool`
     fn check() {}
 }
 

--- a/src/test/ui/attributes/register-attr-tool-prelude.stderr
+++ b/src/test/ui/attributes/register-attr-tool-prelude.stderr
@@ -1,8 +1,8 @@
-error[E0433]: failed to resolve: use of undeclared type or module `tool`
+error[E0433]: failed to resolve: use of undeclared crate or module `tool`
   --> $DIR/register-attr-tool-prelude.rs:10:7
    |
 LL |     #[tool::attr]
-   |       ^^^^ use of undeclared type or module `tool`
+   |       ^^^^ use of undeclared crate or module `tool`
 
 error: cannot find attribute `attr` in this scope
   --> $DIR/register-attr-tool-prelude.rs:9:7

--- a/src/test/ui/bad/bad-module.rs
+++ b/src/test/ui/bad/bad-module.rs
@@ -1,7 +1,7 @@
 fn main() {
     let foo = thing::len(Vec::new());
-    //~^ ERROR failed to resolve: use of undeclared type or module `thing`
+    //~^ ERROR failed to resolve: use of undeclared crate or module `thing`
 
     let foo = foo::bar::baz();
-    //~^ ERROR failed to resolve: use of undeclared type or module `foo`
+    //~^ ERROR failed to resolve: use of undeclared crate or module `foo`
 }

--- a/src/test/ui/bad/bad-module.stderr
+++ b/src/test/ui/bad/bad-module.stderr
@@ -1,14 +1,14 @@
-error[E0433]: failed to resolve: use of undeclared type or module `thing`
+error[E0433]: failed to resolve: use of undeclared crate or module `thing`
   --> $DIR/bad-module.rs:2:15
    |
 LL |     let foo = thing::len(Vec::new());
-   |               ^^^^^ use of undeclared type or module `thing`
+   |               ^^^^^ use of undeclared crate or module `thing`
 
-error[E0433]: failed to resolve: use of undeclared type or module `foo`
+error[E0433]: failed to resolve: use of undeclared crate or module `foo`
   --> $DIR/bad-module.rs:5:15
    |
 LL |     let foo = foo::bar::baz();
-   |               ^^^ use of undeclared type or module `foo`
+   |               ^^^ use of undeclared crate or module `foo`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/coherence/conflicting-impl-with-err.stderr
+++ b/src/test/ui/coherence/conflicting-impl-with-err.stderr
@@ -1,14 +1,14 @@
-error[E0433]: failed to resolve: use of undeclared type or module `nope`
+error[E0433]: failed to resolve: use of undeclared crate or module `nope`
   --> $DIR/conflicting-impl-with-err.rs:4:11
    |
 LL | impl From<nope::Thing> for Error {
-   |           ^^^^ use of undeclared type or module `nope`
+   |           ^^^^ use of undeclared crate or module `nope`
 
-error[E0433]: failed to resolve: use of undeclared type or module `nope`
+error[E0433]: failed to resolve: use of undeclared crate or module `nope`
   --> $DIR/conflicting-impl-with-err.rs:5:16
    |
 LL |     fn from(_: nope::Thing) -> Self {
-   |                ^^^^ use of undeclared type or module `nope`
+   |                ^^^^ use of undeclared crate or module `nope`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/derived-errors/issue-31997-1.stderr
+++ b/src/test/ui/derived-errors/issue-31997-1.stderr
@@ -1,4 +1,4 @@
-error[E0433]: failed to resolve: use of undeclared type or module `HashMap`
+error[E0433]: failed to resolve: use of undeclared type `HashMap`
   --> $DIR/issue-31997-1.rs:20:19
    |
 LL |     let mut map = HashMap::new();

--- a/src/test/ui/dyn-trait-compatibility.rs
+++ b/src/test/ui/dyn-trait-compatibility.rs
@@ -1,7 +1,7 @@
 type A0 = dyn;
 //~^ ERROR cannot find type `dyn` in this scope
 type A1 = dyn::dyn;
-//~^ ERROR use of undeclared type or module `dyn`
+//~^ ERROR use of undeclared crate or module `dyn`
 type A2 = dyn<dyn, dyn>;
 //~^ ERROR cannot find type `dyn` in this scope
 //~| ERROR cannot find type `dyn` in this scope
@@ -9,6 +9,6 @@ type A2 = dyn<dyn, dyn>;
 type A3 = dyn<<dyn as dyn>::dyn>;
 //~^ ERROR cannot find type `dyn` in this scope
 //~| ERROR cannot find type `dyn` in this scope
-//~| ERROR use of undeclared type or module `dyn`
+//~| ERROR use of undeclared crate or module `dyn`
 
 fn main() {}

--- a/src/test/ui/dyn-trait-compatibility.stderr
+++ b/src/test/ui/dyn-trait-compatibility.stderr
@@ -1,14 +1,14 @@
-error[E0433]: failed to resolve: use of undeclared type or module `dyn`
+error[E0433]: failed to resolve: use of undeclared crate or module `dyn`
   --> $DIR/dyn-trait-compatibility.rs:3:11
    |
 LL | type A1 = dyn::dyn;
-   |           ^^^ use of undeclared type or module `dyn`
+   |           ^^^ use of undeclared crate or module `dyn`
 
-error[E0433]: failed to resolve: use of undeclared type or module `dyn`
+error[E0433]: failed to resolve: use of undeclared crate or module `dyn`
   --> $DIR/dyn-trait-compatibility.rs:9:23
    |
 LL | type A3 = dyn<<dyn as dyn>::dyn>;
-   |                       ^^^ use of undeclared type or module `dyn`
+   |                       ^^^ use of undeclared crate or module `dyn`
 
 error[E0412]: cannot find type `dyn` in this scope
   --> $DIR/dyn-trait-compatibility.rs:1:11

--- a/src/test/ui/error-codes/E0433.stderr
+++ b/src/test/ui/error-codes/E0433.stderr
@@ -1,8 +1,8 @@
-error[E0433]: failed to resolve: use of undeclared type or module `NonExistingMap`
+error[E0433]: failed to resolve: use of undeclared type `NonExistingMap`
   --> $DIR/E0433.rs:2:15
    |
 LL |     let map = NonExistingMap::new();
-   |               ^^^^^^^^^^^^^^ use of undeclared type or module `NonExistingMap`
+   |               ^^^^^^^^^^^^^^ use of undeclared type `NonExistingMap`
 
 error: aborting due to previous error
 

--- a/src/test/ui/export-fully-qualified.rs
+++ b/src/test/ui/export-fully-qualified.rs
@@ -1,9 +1,11 @@
+// ignore-tidy-linelength
+
 // In this test baz isn't resolved when called as foo.baz even though
 // it's called from inside foo. This is somewhat surprising and may
 // want to change eventually.
 
 mod foo {
-    pub fn bar() { foo::baz(); } //~ ERROR failed to resolve: use of undeclared type or module `foo`
+    pub fn bar() { foo::baz(); } //~ ERROR failed to resolve: use of undeclared crate or module `foo`
 
     fn baz() { }
 }

--- a/src/test/ui/export-fully-qualified.stderr
+++ b/src/test/ui/export-fully-qualified.stderr
@@ -1,8 +1,8 @@
-error[E0433]: failed to resolve: use of undeclared type or module `foo`
-  --> $DIR/export-fully-qualified.rs:6:20
+error[E0433]: failed to resolve: use of undeclared crate or module `foo`
+  --> $DIR/export-fully-qualified.rs:8:20
    |
 LL |     pub fn bar() { foo::baz(); }
-   |                    ^^^ use of undeclared type or module `foo`
+   |                    ^^^ use of undeclared crate or module `foo`
 
 error: aborting due to previous error
 

--- a/src/test/ui/export2.rs
+++ b/src/test/ui/export2.rs
@@ -1,5 +1,5 @@
 mod foo {
-    pub fn x() { bar::x(); } //~ ERROR failed to resolve: use of undeclared type or module `bar`
+    pub fn x() { bar::x(); } //~ ERROR failed to resolve: use of undeclared crate or module `bar`
 }
 
 mod bar {

--- a/src/test/ui/export2.stderr
+++ b/src/test/ui/export2.stderr
@@ -1,8 +1,8 @@
-error[E0433]: failed to resolve: use of undeclared type or module `bar`
+error[E0433]: failed to resolve: use of undeclared crate or module `bar`
   --> $DIR/export2.rs:2:18
    |
 LL |     pub fn x() { bar::x(); }
-   |                  ^^^ use of undeclared type or module `bar`
+   |                  ^^^ use of undeclared crate or module `bar`
 
 error: aborting due to previous error
 

--- a/src/test/ui/extern-flag/multiple-opts.stderr
+++ b/src/test/ui/extern-flag/multiple-opts.stderr
@@ -1,8 +1,8 @@
-error[E0433]: failed to resolve: use of undeclared type or module `somedep`
+error[E0433]: failed to resolve: use of undeclared crate or module `somedep`
   --> $DIR/multiple-opts.rs:19:5
    |
 LL |     somedep::somefun();
-   |     ^^^^^^^ use of undeclared type or module `somedep`
+   |     ^^^^^^^ use of undeclared crate or module `somedep`
 
 error: aborting due to previous error
 

--- a/src/test/ui/extern-flag/noprelude.stderr
+++ b/src/test/ui/extern-flag/noprelude.stderr
@@ -1,8 +1,8 @@
-error[E0433]: failed to resolve: use of undeclared type or module `somedep`
+error[E0433]: failed to resolve: use of undeclared crate or module `somedep`
   --> $DIR/noprelude.rs:6:5
    |
 LL |     somedep::somefun();
-   |     ^^^^^^^ use of undeclared type or module `somedep`
+   |     ^^^^^^^ use of undeclared crate or module `somedep`
 
 error: aborting due to previous error
 

--- a/src/test/ui/hygiene/extern-prelude-from-opaque-fail.rs
+++ b/src/test/ui/hygiene/extern-prelude-from-opaque-fail.rs
@@ -9,7 +9,7 @@ macro a() {
     mod u {
         // Late resolution.
         fn f() { my_core::mem::drop(0); }
-        //~^ ERROR failed to resolve: use of undeclared type or module `my_core`
+        //~^ ERROR failed to resolve: use of undeclared crate or module `my_core`
     }
 }
 
@@ -22,7 +22,7 @@ mod v {
 mod u {
     // Late resolution.
     fn f() { my_core::mem::drop(0); }
-    //~^ ERROR failed to resolve: use of undeclared type or module `my_core`
+    //~^ ERROR failed to resolve: use of undeclared crate or module `my_core`
 }
 
 fn main() {}

--- a/src/test/ui/hygiene/extern-prelude-from-opaque-fail.stderr
+++ b/src/test/ui/hygiene/extern-prelude-from-opaque-fail.stderr
@@ -18,22 +18,22 @@ LL | a!();
    |
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0433]: failed to resolve: use of undeclared type or module `my_core`
+error[E0433]: failed to resolve: use of undeclared crate or module `my_core`
   --> $DIR/extern-prelude-from-opaque-fail.rs:11:18
    |
 LL |         fn f() { my_core::mem::drop(0); }
-   |                  ^^^^^^^ use of undeclared type or module `my_core`
+   |                  ^^^^^^^ use of undeclared crate or module `my_core`
 ...
 LL | a!();
    | ----- in this macro invocation
    |
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0433]: failed to resolve: use of undeclared type or module `my_core`
+error[E0433]: failed to resolve: use of undeclared crate or module `my_core`
   --> $DIR/extern-prelude-from-opaque-fail.rs:24:14
    |
 LL |     fn f() { my_core::mem::drop(0); }
-   |              ^^^^^^^ use of undeclared type or module `my_core`
+   |              ^^^^^^^ use of undeclared crate or module `my_core`
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/hygiene/no_implicit_prelude.stderr
+++ b/src/test/ui/hygiene/no_implicit_prelude.stderr
@@ -6,7 +6,7 @@ LL |         assert_eq!(0, 0);
    |
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0433]: failed to resolve: use of undeclared type or module `Vec`
+error[E0433]: failed to resolve: use of undeclared type `Vec`
   --> $DIR/no_implicit_prelude.rs:11:9
    |
 LL |     fn f() { ::bar::m!(); }

--- a/src/test/ui/impl-trait/issue-72911.stderr
+++ b/src/test/ui/impl-trait/issue-72911.stderr
@@ -1,14 +1,14 @@
-error[E0433]: failed to resolve: use of undeclared type or module `foo`
+error[E0433]: failed to resolve: use of undeclared crate or module `foo`
   --> $DIR/issue-72911.rs:12:33
    |
 LL | fn gather_from_file(dir_entry: &foo::MissingItem) -> impl Iterator<Item = Lint> {
-   |                                 ^^^ use of undeclared type or module `foo`
+   |                                 ^^^ use of undeclared crate or module `foo`
 
-error[E0433]: failed to resolve: use of undeclared type or module `foo`
+error[E0433]: failed to resolve: use of undeclared crate or module `foo`
   --> $DIR/issue-72911.rs:17:41
    |
 LL | fn lint_files() -> impl Iterator<Item = foo::MissingItem> {
-   |                                         ^^^ use of undeclared type or module `foo`
+   |                                         ^^^ use of undeclared crate or module `foo`
 
 error[E0720]: cannot resolve opaque type
   --> $DIR/issue-72911.rs:7:24

--- a/src/test/ui/imports/extern-prelude-extern-crate-fail.rs
+++ b/src/test/ui/imports/extern-prelude-extern-crate-fail.rs
@@ -1,3 +1,5 @@
+// ignore-tidy-linelength
+
 // aux-build:two_macros.rs
 // compile-flags:--extern non_existent
 
@@ -7,7 +9,7 @@ mod n {
 
 mod m {
     fn check() {
-        two_macros::m!(); //~ ERROR failed to resolve: use of undeclared type or module `two_macros`
+        two_macros::m!(); //~ ERROR failed to resolve: use of undeclared crate or module `two_macros`
     }
 }
 

--- a/src/test/ui/imports/extern-prelude-extern-crate-fail.stderr
+++ b/src/test/ui/imports/extern-prelude-extern-crate-fail.stderr
@@ -1,5 +1,5 @@
 error: macro-expanded `extern crate` items cannot shadow names passed with `--extern`
-  --> $DIR/extern-prelude-extern-crate-fail.rs:16:9
+  --> $DIR/extern-prelude-extern-crate-fail.rs:18:9
    |
 LL |         extern crate std as non_existent;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -9,11 +9,11 @@ LL | define_std_as_non_existent!();
    |
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0433]: failed to resolve: use of undeclared type or module `two_macros`
-  --> $DIR/extern-prelude-extern-crate-fail.rs:10:9
+error[E0433]: failed to resolve: use of undeclared crate or module `two_macros`
+  --> $DIR/extern-prelude-extern-crate-fail.rs:12:9
    |
 LL |         two_macros::m!();
-   |         ^^^^^^^^^^ use of undeclared type or module `two_macros`
+   |         ^^^^^^^^^^ use of undeclared crate or module `two_macros`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-33293.rs
+++ b/src/test/ui/issues/issue-33293.rs
@@ -1,6 +1,6 @@
 fn main() {
     match 0 {
         aaa::bbb(_) => ()
-        //~^ ERROR failed to resolve: use of undeclared type or module `aaa`
+        //~^ ERROR failed to resolve: use of undeclared crate or module `aaa`
     };
 }

--- a/src/test/ui/issues/issue-33293.stderr
+++ b/src/test/ui/issues/issue-33293.stderr
@@ -1,8 +1,8 @@
-error[E0433]: failed to resolve: use of undeclared type or module `aaa`
+error[E0433]: failed to resolve: use of undeclared crate or module `aaa`
   --> $DIR/issue-33293.rs:3:9
    |
 LL |         aaa::bbb(_) => ()
-   |         ^^^ use of undeclared type or module `aaa`
+   |         ^^^ use of undeclared crate or module `aaa`
 
 error: aborting due to previous error
 

--- a/src/test/ui/macros/builtin-prelude-no-accidents.rs
+++ b/src/test/ui/macros/builtin-prelude-no-accidents.rs
@@ -2,7 +2,7 @@
 // because macros with the same names are in prelude.
 
 fn main() {
-    env::current_dir; //~ ERROR use of undeclared type or module `env`
-    type A = panic::PanicInfo; //~ ERROR use of undeclared type or module `panic`
-    type B = vec::Vec<u8>; //~ ERROR use of undeclared type or module `vec`
+    env::current_dir; //~ ERROR use of undeclared crate or module `env`
+    type A = panic::PanicInfo; //~ ERROR use of undeclared crate or module `panic`
+    type B = vec::Vec<u8>; //~ ERROR use of undeclared crate or module `vec`
 }

--- a/src/test/ui/macros/builtin-prelude-no-accidents.stderr
+++ b/src/test/ui/macros/builtin-prelude-no-accidents.stderr
@@ -1,20 +1,20 @@
-error[E0433]: failed to resolve: use of undeclared type or module `env`
+error[E0433]: failed to resolve: use of undeclared crate or module `env`
   --> $DIR/builtin-prelude-no-accidents.rs:5:5
    |
 LL |     env::current_dir;
-   |     ^^^ use of undeclared type or module `env`
+   |     ^^^ use of undeclared crate or module `env`
 
-error[E0433]: failed to resolve: use of undeclared type or module `panic`
+error[E0433]: failed to resolve: use of undeclared crate or module `panic`
   --> $DIR/builtin-prelude-no-accidents.rs:6:14
    |
 LL |     type A = panic::PanicInfo;
-   |              ^^^^^ use of undeclared type or module `panic`
+   |              ^^^^^ use of undeclared crate or module `panic`
 
-error[E0433]: failed to resolve: use of undeclared type or module `vec`
+error[E0433]: failed to resolve: use of undeclared crate or module `vec`
   --> $DIR/builtin-prelude-no-accidents.rs:7:14
    |
 LL |     type B = vec::Vec<u8>;
-   |              ^^^ use of undeclared type or module `vec`
+   |              ^^^ use of undeclared crate or module `vec`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/macros/macro-inner-attributes.rs
+++ b/src/test/ui/macros/macro-inner-attributes.rs
@@ -15,6 +15,6 @@ test!(b,
 #[rustc_dummy]
 fn main() {
     a::bar();
-    //~^ ERROR failed to resolve: use of undeclared type or module `a`
+    //~^ ERROR failed to resolve: use of undeclared crate or module `a`
     b::bar();
 }

--- a/src/test/ui/macros/macro-inner-attributes.stderr
+++ b/src/test/ui/macros/macro-inner-attributes.stderr
@@ -1,8 +1,8 @@
-error[E0433]: failed to resolve: use of undeclared type or module `a`
+error[E0433]: failed to resolve: use of undeclared crate or module `a`
   --> $DIR/macro-inner-attributes.rs:17:5
    |
 LL |     a::bar();
-   |     ^ use of undeclared type or module `a`
+   |     ^ use of undeclared crate or module `a`
 
 error: aborting due to previous error
 

--- a/src/test/ui/macros/macro_path_as_generic_bound.stderr
+++ b/src/test/ui/macros/macro_path_as_generic_bound.stderr
@@ -1,8 +1,8 @@
-error[E0433]: failed to resolve: use of undeclared type or module `m`
+error[E0433]: failed to resolve: use of undeclared crate or module `m`
   --> $DIR/macro_path_as_generic_bound.rs:7:6
    |
 LL | foo!(m::m2::A);
-   |      ^ use of undeclared type or module `m`
+   |      ^ use of undeclared crate or module `m`
 
 error: aborting due to previous error
 

--- a/src/test/ui/mod/mod_file_disambig.rs
+++ b/src/test/ui/mod/mod_file_disambig.rs
@@ -2,5 +2,5 @@ mod mod_file_disambig_aux; //~ ERROR file for module `mod_file_disambig_aux` fou
 
 fn main() {
     assert_eq!(mod_file_aux::bar(), 10);
-    //~^ ERROR failed to resolve: use of undeclared type or module `mod_file_aux`
+    //~^ ERROR failed to resolve: use of undeclared crate or module `mod_file_aux`
 }

--- a/src/test/ui/mod/mod_file_disambig.stderr
+++ b/src/test/ui/mod/mod_file_disambig.stderr
@@ -6,11 +6,11 @@ LL | mod mod_file_disambig_aux;
    |
    = help: delete or rename one of them to remove the ambiguity
 
-error[E0433]: failed to resolve: use of undeclared type or module `mod_file_aux`
+error[E0433]: failed to resolve: use of undeclared crate or module `mod_file_aux`
   --> $DIR/mod_file_disambig.rs:4:16
    |
 LL |     assert_eq!(mod_file_aux::bar(), 10);
-   |                ^^^^^^^^^^^^ use of undeclared type or module `mod_file_aux`
+   |                ^^^^^^^^^^^^ use of undeclared crate or module `mod_file_aux`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/parser/mod_file_not_exist.rs
+++ b/src/test/ui/parser/mod_file_not_exist.rs
@@ -5,5 +5,5 @@ mod not_a_real_file; //~ ERROR file not found for module `not_a_real_file`
 
 fn main() {
     assert_eq!(mod_file_aux::bar(), 10);
-    //~^ ERROR failed to resolve: use of undeclared type or module `mod_file_aux`
+    //~^ ERROR failed to resolve: use of undeclared crate or module `mod_file_aux`
 }

--- a/src/test/ui/parser/mod_file_not_exist.stderr
+++ b/src/test/ui/parser/mod_file_not_exist.stderr
@@ -6,11 +6,11 @@ LL | mod not_a_real_file;
    |
    = help: to create the module `not_a_real_file`, create file "$DIR/not_a_real_file.rs"
 
-error[E0433]: failed to resolve: use of undeclared type or module `mod_file_aux`
+error[E0433]: failed to resolve: use of undeclared crate or module `mod_file_aux`
   --> $DIR/mod_file_not_exist.rs:7:16
    |
 LL |     assert_eq!(mod_file_aux::bar(), 10);
-   |                ^^^^^^^^^^^^ use of undeclared type or module `mod_file_aux`
+   |                ^^^^^^^^^^^^ use of undeclared crate or module `mod_file_aux`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/parser/mod_file_not_exist_windows.rs
+++ b/src/test/ui/parser/mod_file_not_exist_windows.rs
@@ -5,5 +5,5 @@ mod not_a_real_file; //~ ERROR file not found for module `not_a_real_file`
 
 fn main() {
     assert_eq!(mod_file_aux::bar(), 10);
-    //~^ ERROR failed to resolve: use of undeclared type or module `mod_file_aux`
+    //~^ ERROR failed to resolve: use of undeclared crate or module `mod_file_aux`
 }

--- a/src/test/ui/parser/mod_file_not_exist_windows.stderr
+++ b/src/test/ui/parser/mod_file_not_exist_windows.stderr
@@ -6,11 +6,11 @@ LL | mod not_a_real_file;
    |
    = help: to create the module `not_a_real_file`, create file "$DIR/not_a_real_file.rs"
 
-error[E0433]: failed to resolve: use of undeclared type or module `mod_file_aux`
+error[E0433]: failed to resolve: use of undeclared crate or module `mod_file_aux`
   --> $DIR/mod_file_not_exist_windows.rs:7:16
    |
 LL |     assert_eq!(mod_file_aux::bar(), 10);
-   |                ^^^^^^^^^^^^ use of undeclared type or module `mod_file_aux`
+   |                ^^^^^^^^^^^^ use of undeclared crate or module `mod_file_aux`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/pattern/pattern-error-continue.rs
+++ b/src/test/ui/pattern/pattern-error-continue.rs
@@ -30,6 +30,6 @@ fn main() {
     //~| expected `char`, found `bool`
 
     match () {
-        E::V => {} //~ ERROR failed to resolve: use of undeclared type or module `E`
+        E::V => {} //~ ERROR failed to resolve: use of undeclared type `E`
     }
 }

--- a/src/test/ui/pattern/pattern-error-continue.stderr
+++ b/src/test/ui/pattern/pattern-error-continue.stderr
@@ -1,8 +1,8 @@
-error[E0433]: failed to resolve: use of undeclared type or module `E`
+error[E0433]: failed to resolve: use of undeclared type `E`
   --> $DIR/pattern-error-continue.rs:33:9
    |
 LL |         E::V => {}
-   |         ^ use of undeclared type or module `E`
+   |         ^ use of undeclared type `E`
 
 error[E0532]: expected tuple struct or tuple variant, found unit variant `A::D`
   --> $DIR/pattern-error-continue.rs:18:9

--- a/src/test/ui/resolve/use_suggestion.stderr
+++ b/src/test/ui/resolve/use_suggestion.stderr
@@ -1,10 +1,10 @@
-error[E0433]: failed to resolve: use of undeclared type or module `GooMap`
+error[E0433]: failed to resolve: use of undeclared type `GooMap`
   --> $DIR/use_suggestion.rs:3:14
    |
 LL |     let x2 = GooMap::new();
-   |              ^^^^^^ use of undeclared type or module `GooMap`
+   |              ^^^^^^ use of undeclared type `GooMap`
 
-error[E0433]: failed to resolve: use of undeclared type or module `HashMap`
+error[E0433]: failed to resolve: use of undeclared type `HashMap`
   --> $DIR/use_suggestion.rs:2:14
    |
 LL |     let x1 = HashMap::new();

--- a/src/test/ui/rfc-2126-extern-absolute-paths/non-existent-1.stderr
+++ b/src/test/ui/rfc-2126-extern-absolute-paths/non-existent-1.stderr
@@ -2,7 +2,7 @@ error[E0432]: unresolved import `xcrate`
   --> $DIR/non-existent-1.rs:3:5
    |
 LL | use xcrate::S;
-   |     ^^^^^^ use of undeclared type or module `xcrate`
+   |     ^^^^^^ use of undeclared crate or module `xcrate`
 
 error: aborting due to previous error
 

--- a/src/test/ui/suggestions/type-ascription-instead-of-path.rs
+++ b/src/test/ui/suggestions/type-ascription-instead-of-path.rs
@@ -1,5 +1,5 @@
 fn main() {
     std:io::stdin();
-    //~^ ERROR failed to resolve: use of undeclared type or module `io`
+    //~^ ERROR failed to resolve: use of undeclared crate or module `io`
     //~| ERROR expected value, found crate
 }

--- a/src/test/ui/suggestions/type-ascription-instead-of-path.stderr
+++ b/src/test/ui/suggestions/type-ascription-instead-of-path.stderr
@@ -1,8 +1,8 @@
-error[E0433]: failed to resolve: use of undeclared type or module `io`
+error[E0433]: failed to resolve: use of undeclared crate or module `io`
   --> $DIR/type-ascription-instead-of-path.rs:2:9
    |
 LL |     std:io::stdin();
-   |         ^^ use of undeclared type or module `io`
+   |         ^^ use of undeclared crate or module `io`
 
 error[E0423]: expected value, found crate `std`
   --> $DIR/type-ascription-instead-of-path.rs:2:5

--- a/src/test/ui/type-alias/issue-62263-self-in-atb.rs
+++ b/src/test/ui/type-alias/issue-62263-self-in-atb.rs
@@ -3,6 +3,6 @@ pub trait Trait {
 }
 
 pub type Alias = dyn Trait<A = Self::A>;
-//~^ ERROR failed to resolve: use of undeclared type or module `Self` [E0433]
+//~^ ERROR failed to resolve: use of undeclared type `Self` [E0433]
 
 fn main() {}

--- a/src/test/ui/type-alias/issue-62263-self-in-atb.stderr
+++ b/src/test/ui/type-alias/issue-62263-self-in-atb.stderr
@@ -1,8 +1,8 @@
-error[E0433]: failed to resolve: use of undeclared type or module `Self`
+error[E0433]: failed to resolve: use of undeclared type `Self`
   --> $DIR/issue-62263-self-in-atb.rs:5:32
    |
 LL | pub type Alias = dyn Trait<A = Self::A>;
-   |                                ^^^^ use of undeclared type or module `Self`
+   |                                ^^^^ use of undeclared type `Self`
 
 error: aborting due to previous error
 

--- a/src/test/ui/type-alias/issue-62305-self-assoc-ty.rs
+++ b/src/test/ui/type-alias/issue-62305-self-assoc-ty.rs
@@ -1,4 +1,4 @@
 type Alias = Self::Target;
-//~^ ERROR failed to resolve: use of undeclared type or module `Self` [E0433]
+//~^ ERROR failed to resolve: use of undeclared type `Self` [E0433]
 
 fn main() {}

--- a/src/test/ui/type-alias/issue-62305-self-assoc-ty.stderr
+++ b/src/test/ui/type-alias/issue-62305-self-assoc-ty.stderr
@@ -1,8 +1,8 @@
-error[E0433]: failed to resolve: use of undeclared type or module `Self`
+error[E0433]: failed to resolve: use of undeclared type `Self`
   --> $DIR/issue-62305-self-assoc-ty.rs:1:14
    |
 LL | type Alias = Self::Target;
-   |              ^^^^ use of undeclared type or module `Self`
+   |              ^^^^ use of undeclared type `Self`
 
 error: aborting due to previous error
 

--- a/src/test/ui/type/type-path-err-node-types.rs
+++ b/src/test/ui/type/type-path-err-node-types.rs
@@ -12,7 +12,7 @@ fn ufcs_trait() {
 }
 
 fn ufcs_item() {
-    NonExistent::Assoc::<u8>; //~ ERROR undeclared type or module `NonExistent`
+    NonExistent::Assoc::<u8>; //~ ERROR undeclared type `NonExistent`
 }
 
 fn method() {

--- a/src/test/ui/type/type-path-err-node-types.stderr
+++ b/src/test/ui/type/type-path-err-node-types.stderr
@@ -1,8 +1,8 @@
-error[E0433]: failed to resolve: use of undeclared type or module `NonExistent`
+error[E0433]: failed to resolve: use of undeclared type `NonExistent`
   --> $DIR/type-path-err-node-types.rs:15:5
    |
 LL |     NonExistent::Assoc::<u8>;
-   |     ^^^^^^^^^^^ use of undeclared type or module `NonExistent`
+   |     ^^^^^^^^^^^ use of undeclared type `NonExistent`
 
 error[E0412]: cannot find type `Nonexistent` in this scope
   --> $DIR/type-path-err-node-types.rs:7:12

--- a/src/test/ui/unknown-tool-name.rs
+++ b/src/test/ui/unknown-tool-name.rs
@@ -1,2 +1,2 @@
-#[foo::bar] //~ ERROR failed to resolve: use of undeclared type or module `foo`
+#[foo::bar] //~ ERROR failed to resolve: use of undeclared crate or module `foo`
 fn main() {}

--- a/src/test/ui/unknown-tool-name.stderr
+++ b/src/test/ui/unknown-tool-name.stderr
@@ -1,8 +1,8 @@
-error[E0433]: failed to resolve: use of undeclared type or module `foo`
+error[E0433]: failed to resolve: use of undeclared crate or module `foo`
   --> $DIR/unknown-tool-name.rs:1:3
    |
 LL | #[foo::bar]
-   |   ^^^ use of undeclared type or module `foo`
+   |   ^^^ use of undeclared crate or module `foo`
 
 error: aborting due to previous error
 

--- a/src/test/ui/use/use-self-type.rs
+++ b/src/test/ui/use/use-self-type.rs
@@ -4,7 +4,7 @@ impl S {
     fn f() {}
     fn g() {
         use Self::f; //~ ERROR unresolved import
-        pub(in Self::f) struct Z; //~ ERROR use of undeclared type or module `Self`
+        pub(in Self::f) struct Z; //~ ERROR use of undeclared type `Self`
     }
 }
 

--- a/src/test/ui/use/use-self-type.stderr
+++ b/src/test/ui/use/use-self-type.stderr
@@ -1,14 +1,14 @@
-error[E0433]: failed to resolve: use of undeclared type or module `Self`
+error[E0433]: failed to resolve: use of undeclared type `Self`
   --> $DIR/use-self-type.rs:7:16
    |
 LL |         pub(in Self::f) struct Z;
-   |                ^^^^ use of undeclared type or module `Self`
+   |                ^^^^ use of undeclared type `Self`
 
 error[E0432]: unresolved import `Self`
   --> $DIR/use-self-type.rs:6:13
    |
 LL |         use Self::f;
-   |             ^^^^ use of undeclared type or module `Self`
+   |             ^^^^ use of undeclared type `Self`
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
"use of undeclared type or module `foo`" doesn't mention that it could be a crate. 

This error can happen when users forget to add a dependency to `Cargo.toml`, so I think it's important to mention that it could be a missing crate.

I've used a heuristic based on Rust's naming conventions. It complains about an unknown type if the ident starts with an upper-case letter, and crate or module otherwise. It seems to work very well. The expanded error help covers both an unknown type and a missing crate case.
