### PR TITLE
Disable cancel-outdated-builds for auto-fallible

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
         uses: rust-lang/simpleinfra/github-actions/cancel-outdated-builds@master
         with:
           github_token: "${{ secrets.github_token }}"
-        if: "success() && !env.SKIP_JOB && github.ref != 'refs/heads/try'"
+        if: "success() && !env.SKIP_JOB && github.ref != 'refs/heads/try' && !env.RUST_CI_TEMP_SKIP_CANCEL_OUTDATED"
       - name: configure the PR in which the error message will be posted
         run: "echo \"[CI_PR_NUMBER=$num]\""
         env:
@@ -167,7 +167,7 @@ jobs:
         uses: rust-lang/simpleinfra/github-actions/cancel-outdated-builds@master
         with:
           github_token: "${{ secrets.github_token }}"
-        if: "success() && !env.SKIP_JOB && github.ref != 'refs/heads/try'"
+        if: "success() && !env.SKIP_JOB && github.ref != 'refs/heads/try' && !env.RUST_CI_TEMP_SKIP_CANCEL_OUTDATED"
       - name: configure the PR in which the error message will be posted
         run: "echo \"[CI_PR_NUMBER=$num]\""
         env:
@@ -486,7 +486,7 @@ jobs:
         uses: rust-lang/simpleinfra/github-actions/cancel-outdated-builds@master
         with:
           github_token: "${{ secrets.github_token }}"
-        if: "success() && !env.SKIP_JOB && github.ref != 'refs/heads/try'"
+        if: "success() && !env.SKIP_JOB && github.ref != 'refs/heads/try' && !env.RUST_CI_TEMP_SKIP_CANCEL_OUTDATED"
       - name: configure the PR in which the error message will be posted
         run: "echo \"[CI_PR_NUMBER=$num]\""
         env:
@@ -589,6 +589,7 @@ jobs:
               NO_LLVM_ASSERTIONS: 1
               NO_DEBUG_ASSERTIONS: 1
               DIST_REQUIRE_ALL_TOOLS: 1
+              RUST_CI_TEMP_SKIP_CANCEL_OUTDATED: 1
             os: macos-latest
           - name: dist-x86_64-apple-alt
             env:
@@ -598,6 +599,7 @@ jobs:
               MACOSX_DEPLOYMENT_TARGET: 10.7
               NO_LLVM_ASSERTIONS: 1
               NO_DEBUG_ASSERTIONS: 1
+              RUST_CI_TEMP_SKIP_CANCEL_OUTDATED: 1
             os: macos-latest
           - name: x86_64-apple
             env:
@@ -608,6 +610,7 @@ jobs:
               MACOSX_STD_DEPLOYMENT_TARGET: 10.7
               NO_LLVM_ASSERTIONS: 1
               NO_DEBUG_ASSERTIONS: 1
+              RUST_CI_TEMP_SKIP_CANCEL_OUTDATED: 1
             os: macos-latest
     timeout-minutes: 600
     runs-on: "${{ matrix.os }}"
@@ -622,7 +625,7 @@ jobs:
         uses: rust-lang/simpleinfra/github-actions/cancel-outdated-builds@master
         with:
           github_token: "${{ secrets.github_token }}"
-        if: "success() && !env.SKIP_JOB && github.ref != 'refs/heads/try'"
+        if: "success() && !env.SKIP_JOB && github.ref != 'refs/heads/try' && !env.RUST_CI_TEMP_SKIP_CANCEL_OUTDATED"
       - name: configure the PR in which the error message will be posted
         run: "echo \"[CI_PR_NUMBER=$num]\""
         env:

--- a/src/ci/github-actions/ci.yml
+++ b/src/ci/github-actions/ci.yml
@@ -107,7 +107,9 @@ x--expand-yaml-anchors--remove:
         uses: rust-lang/simpleinfra/github-actions/cancel-outdated-builds@master
         with:
           github_token: "${{ secrets.github_token }}"
-        if: success() && !env.SKIP_JOB && github.ref != 'refs/heads/try'
+        # TODO: remove the condition on RUST_CI_TEMP_SKIP_CANCEL_OUTDATED once
+        # we remove the `auto-fallible` job.
+        if: success() && !env.SKIP_JOB && github.ref != 'refs/heads/try' && !env.RUST_CI_TEMP_SKIP_CANCEL_OUTDATED
         <<: *step
 
       # Rust Log Analyzer can't currently detect the PR number of a GitHub
@@ -609,6 +611,10 @@ jobs:
               NO_LLVM_ASSERTIONS: 1
               NO_DEBUG_ASSERTIONS: 1
               DIST_REQUIRE_ALL_TOOLS: 1
+
+              # TODO: remove once we move this job away from auto-fallible.
+              # Also, remove the variable from the cancel-outdated-builds step
+              RUST_CI_TEMP_SKIP_CANCEL_OUTDATED: 1
             <<: *job-macos-xl
 
           - name: dist-x86_64-apple-alt
@@ -619,6 +625,10 @@ jobs:
               MACOSX_DEPLOYMENT_TARGET: 10.7
               NO_LLVM_ASSERTIONS: 1
               NO_DEBUG_ASSERTIONS: 1
+
+              # TODO: remove once we move this job away from auto-fallible.
+              # Also, remove the variable from the cancel-outdated-builds step
+              RUST_CI_TEMP_SKIP_CANCEL_OUTDATED: 1
             <<: *job-macos-xl
 
           - name: x86_64-apple
@@ -630,6 +640,10 @@ jobs:
               MACOSX_STD_DEPLOYMENT_TARGET: 10.7
               NO_LLVM_ASSERTIONS: 1
               NO_DEBUG_ASSERTIONS: 1
+
+              # TODO: remove once we move this job away from auto-fallible.
+              # Also, remove the variable from the cancel-outdated-builds step
+              RUST_CI_TEMP_SKIP_CANCEL_OUTDATED: 1
             <<: *job-macos-xl
 
   master:


### PR DESCRIPTION
`cancel-outdated-builds` doesn't need to be enabled on fallible jobs, and it's actually making it harder for us to see if https://github.com/rust-lang/rust/issues/71988 is fixed. This adds some temporary code to avoid `auto-fallible` jobs from being cancelled by our tooling.

r? @Mark-Simulacrum 