### PR TITLE
Add InstrProfilingPlatformFuchsia.c to profiler_builtins

### DIFF
--- a/library/profiler_builtins/build.rs
+++ b/library/profiler_builtins/build.rs
@@ -20,6 +20,7 @@ fn main() {
         "InstrProfilingMergeFile.c",
         "InstrProfilingNameVar.c",
         "InstrProfilingPlatformDarwin.c",
+        "InstrProfilingPlatformFuchsia.c",
         "InstrProfilingPlatformLinux.c",
         "InstrProfilingPlatformOther.c",
         "InstrProfilingPlatformWindows.c",


### PR DESCRIPTION
All other Platform files included in `llvm-project/compiler-rt` were
present, except Fuchsia.

Now that there is a functional end-to-end version of
`-Zinstrument-coverage`, I need to start building and testing
coverage-enabled Rust programs on Fuchsia, and this file is required.

r? @tmandry 
FYI, @wesleywiser 