### PR TITLE
Fix loading pretty-printers in rust-lldb script

### DIFF
--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -647,6 +647,7 @@ impl Step for DebuggerScripts {
 
             cp_debugger_script("lldb_lookup.py");
             cp_debugger_script("lldb_providers.py");
+            cp_debugger_script("lldb_commands")
         }
     }
 }

--- a/src/etc/lldb_commands
+++ b/src/etc/lldb_commands
@@ -1,4 +1,3 @@
-command script import \"$RUSTC_SYSROOT/lib/rustlib/etc/lldb_lookup.py\"
 type synthetic add -l lldb_lookup.synthetic_lookup -x \".*\" --category Rust
 type summary add -F lldb_lookup.summary_lookup  -e -x -h \"^(alloc::([a-z_]+::)+)String$\" --category Rust
 type summary add -F lldb_lookup.summary_lookup  -e -x -h \"^&str$\" --category Rust

--- a/src/etc/rust-lldb
+++ b/src/etc/rust-lldb
@@ -30,5 +30,8 @@ EOF
     fi
 fi
 
+script_import="command script import \"$RUSTC_SYSROOT/lib/rustlib/etc/lldb_lookup.py\""
+commands_file="$RUSTC_SYSROOT/lib/rustlib/etc/lldb_commands"
+
 # Call LLDB with the commands added to the argument list
-exec "$lldb" --source-before-file ./lldb_commands "$@"
+exec "$lldb" --one-line-before-file "$script_import" --source-before-file "$commands_file" "$@"


### PR DESCRIPTION
Pretty-printers loading in `rust-lldb` script was broken in https://github.com/rust-lang/rust/pull/72357

This fixes https://github.com/rust-lang/rust/issues/76006