### PR TITLE
Revert "Make libunwind build hermetic"

### DIFF
--- a/library/unwind/build.rs
+++ b/library/unwind/build.rs
@@ -116,8 +116,6 @@ mod llvm_libunwind {
             cfg.flag("-fstrict-aliasing");
             cfg.flag("-funwind-tables");
             cfg.flag("-fvisibility=hidden");
-            cfg.flag_if_supported("-fvisibility-global-new-delete-hidden");
-            cfg.define("_LIBUNWIND_DISABLE_VISIBILITY_ANNOTATIONS", None);
         }
 
         let mut unwind_sources = vec![


### PR DESCRIPTION
This reverts commit 21abc8879cddd0002ca1da2eaa0f8e27ef09fa99.

Fixes #76020

I'm not sure what exact problem #72746 is supposed to fix, but it's probably incomplete as it breaks the build of 1.46.0 with llvm-libunwind enabled