### PR TITLE
Improve E0118

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes/E0118.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0118.md
@@ -1,5 +1,5 @@
-An inherent implementation was defined for something which isn't a struct, an
-enum, a union or a trait object.
+An inherent implementation was defined for something which isn't a struct,
+enum, union, or trait object.
 
 Erroneous code example:
 

--- a/compiler/rustc_error_codes/src/error_codes/E0118.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0118.md
@@ -1,10 +1,10 @@
-An inherent implementation was defined for something which isn't a struct nor
-an enum.
+An inherent implementation was defined for something which isn't a struct, an
+enum, a union or a trait object.
 
 Erroneous code example:
 
 ```compile_fail,E0118
-impl (u8, u8) { // error: no base type found for inherent implementation
+impl (u8, u8) { // error: no nominal type found for inherent implementation
     fn get_state(&self) -> String {
         // ...
     }
@@ -39,5 +39,26 @@ impl TypeWrapper {
     fn get_state(&self) -> String {
         "Fascinating!".to_owned()
     }
+}
+```
+
+Instead of defining an inherent implementation on a reference, you could also
+move the reference inside the implementation:
+
+```compile_fail,E0118
+struct Foo;
+
+impl &Foo { // error: no nominal type found for inherent implementation
+    fn bar(self, other: Self) {}
+}
+```
+
+becomes
+
+```
+struct Foo;
+
+impl Foo {
+    fn bar(&self, other: &Self) {}
 }
 ```

--- a/src/test/ui/error-codes/E0118-2.rs
+++ b/src/test/ui/error-codes/E0118-2.rs
@@ -1,0 +1,8 @@
+struct Foo;
+
+impl &mut Foo {
+    //~^ ERROR E0118
+    fn bar(self) {}
+}
+
+fn main() {}

--- a/src/test/ui/error-codes/E0118-2.stderr
+++ b/src/test/ui/error-codes/E0118-2.stderr
@@ -1,10 +1,11 @@
 error[E0118]: no nominal type found for inherent implementation
-  --> $DIR/E0118.rs:1:6
+  --> $DIR/E0118-2.rs:3:6
    |
-LL | impl (u8, u8) {
+LL | impl &mut Foo {
    |      ^^^^^^^^ impl requires a nominal type
    |
    = note: either implement a trait on it or create a newtype to wrap it instead
+   = note: you could also try moving the reference to uses of `Foo` (such as `self`) within the implementation
 
 error: aborting due to previous error
 

--- a/src/test/ui/privacy/private-in-public-ill-formed.rs
+++ b/src/test/ui/privacy/private-in-public-ill-formed.rs
@@ -11,7 +11,8 @@ mod aliases_pub {
         type AssocAlias = m::Pub3;
     }
 
-    impl <Priv as PrivTr>::AssocAlias { //~ ERROR no base type found for inherent implementation
+    impl <Priv as PrivTr>::AssocAlias {
+        //~^ ERROR no nominal type found for inherent implementation
         pub fn f(arg: Priv) {} // private type `aliases_pub::Priv` in public interface
     }
 }
@@ -27,7 +28,8 @@ mod aliases_priv {
         type AssocAlias = Priv3;
     }
 
-    impl <Priv as PrivTr>::AssocAlias { //~ ERROR no base type found for inherent implementation
+    impl <Priv as PrivTr>::AssocAlias {
+        //~^ ERROR no nominal type found for inherent implementation
         pub fn f(arg: Priv) {} // OK
     }
 }

--- a/src/test/ui/privacy/private-in-public-ill-formed.stderr
+++ b/src/test/ui/privacy/private-in-public-ill-formed.stderr
@@ -1,16 +1,16 @@
-error[E0118]: no base type found for inherent implementation
+error[E0118]: no nominal type found for inherent implementation
   --> $DIR/private-in-public-ill-formed.rs:14:10
    |
 LL |     impl <Priv as PrivTr>::AssocAlias {
-   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl requires a base type
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl requires a nominal type
    |
    = note: either implement a trait on it or create a newtype to wrap it instead
 
-error[E0118]: no base type found for inherent implementation
-  --> $DIR/private-in-public-ill-formed.rs:30:10
+error[E0118]: no nominal type found for inherent implementation
+  --> $DIR/private-in-public-ill-formed.rs:31:10
    |
 LL |     impl <Priv as PrivTr>::AssocAlias {
-   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl requires a base type
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl requires a nominal type
    |
    = note: either implement a trait on it or create a newtype to wrap it instead
 


### PR DESCRIPTION
- Changes the "base type" terminology to "nominal type" (according to the [reference](https://doc.rust-lang.org/stable/reference/items/implementations.html#inherent-implementations)).
- Suggests removing a reference, if one is present on the type.
- Clarify what is meant by a "nominal type".

closes #69392

This is my first not-entirely-trivial PR, so please let me know if I missed anything or if something could be improved. Though I probably won't be able to fix anything in the upcoming week.