### PR TITLE
Move to intra-doc links for library/core/src/sync/atomic.rs

### DIFF
--- a/library/core/src/sync/atomic.rs
+++ b/library/core/src/sync/atomic.rs
@@ -144,8 +144,6 @@ pub fn spin_loop_hint() {
 ///
 /// **Note**: This type is only available on platforms that support atomic
 /// loads and stores of `u8`.
-///
-/// [`bool`]: ../../../std/primitive.bool.html
 #[cfg(target_has_atomic_load_store = "8")]
 #[stable(feature = "rust1", since = "1.0.0")]
 #[repr(C, align(1))]
@@ -311,8 +309,6 @@ impl AtomicBool {
     ///
     /// This is safe because the mutable reference guarantees that no other threads are
     /// concurrently accessing the atomic data.
-    ///
-    /// [`bool`]: ../../../std/primitive.bool.html
     ///
     /// # Examples
     ///
@@ -486,8 +482,6 @@ impl AtomicBool {
     /// **Note:** This method is only available on platforms that support atomic
     /// operations on `u8`.
     ///
-    /// [`bool`]: ../../../std/primitive.bool.html
-    ///
     /// # Examples
     ///
     /// ```
@@ -544,8 +538,6 @@ impl AtomicBool {
     ///
     /// **Note:** This method is only available on platforms that support atomic
     /// operations on `u8`.
-    ///
-    /// [`bool`]: ../../../std/primitive.bool.html
     ///
     /// # Examples
     ///
@@ -765,8 +757,6 @@ impl AtomicBool {
     /// through a shared reference, and can do so safely as long as they use atomic operations. Any
     /// use of the returned raw pointer requires an `unsafe` block and still has to uphold the same
     /// restriction: operations on it must be atomic.
-    ///
-    /// [`bool`]: ../../../std/primitive.bool.html
     ///
     /// # Examples
     ///
@@ -1709,8 +1699,6 @@ and must be equivalent to or weaker than the success ordering.
 
 **Note**: This method is only available on platforms that support atomic
 operations on [`", $s_int_type, "`](", $int_ref, ").
-
-[`bool`]: ../../../std/primitive.bool.html
 
 # Examples
 

--- a/library/core/src/sync/atomic.rs
+++ b/library/core/src/sync/atomic.rs
@@ -10,17 +10,9 @@
 //! Atomic types present operations that, when used correctly, synchronize
 //! updates between threads.
 //!
-//! [`AtomicBool`]: struct.AtomicBool.html
-//! [`AtomicIsize`]: struct.AtomicIsize.html
-//! [`AtomicUsize`]: struct.AtomicUsize.html
-//! [`AtomicI8`]: struct.AtomicI8.html
-//! [`AtomicU16`]: struct.AtomicU16.html
-//!
 //! Each method takes an [`Ordering`] which represents the strength of
 //! the memory barrier for that operation. These orderings are the
 //! same as the [C++20 atomic orderings][1]. For more information see the [nomicon][2].
-//!
-//! [`Ordering`]: enum.Ordering.html
 //!
 //! [1]: https://en.cppreference.com/w/cpp/atomic/memory_order
 //! [2]: ../../../nomicon/atomics.html
@@ -31,14 +23,11 @@
 //! The most common way to share an atomic variable is to put it into an [`Arc`][arc] (an
 //! atomically-reference-counted shared pointer).
 //!
-//! [`Sync`]: ../../marker/trait.Sync.html
 //! [arc]: ../../../std/sync/struct.Arc.html
 //!
 //! Atomic types may be stored in static variables, initialized using
 //! the constant initializers like [`AtomicBool::new`]. Atomic statics
 //! are often used for lazy global initialization.
-//!
-//! [`AtomicBool::new`]: struct.AtomicBool.html#method.new
 //!
 //! # Portability
 //!
@@ -212,8 +201,8 @@ unsafe impl<T> Sync for AtomicPtr<T> {}
 /// Atomic memory orderings
 ///
 /// Memory orderings specify the way atomic operations synchronize memory.
-/// In its weakest [`Relaxed`][Ordering::Relaxed], only the memory directly touched by the
-/// operation is synchronized. On the other hand, a store-load pair of [`SeqCst`][Ordering::SeqCst]
+/// In its weakest [`Ordering::Relaxed`], only the memory directly touched by the
+/// operation is synchronized. On the other hand, a store-load pair of [`Ordering::SeqCst`]
 /// operations synchronize other memory while additionally preserving a total order of such
 /// operations across all threads.
 ///
@@ -223,8 +212,6 @@ unsafe impl<T> Sync for AtomicPtr<T> {}
 /// For more information see the [nomicon].
 ///
 /// [nomicon]: ../../../nomicon/atomics.html
-/// [Ordering::Relaxed]: #variant.Relaxed
-/// [Ordering::SeqCst]: #variant.SeqCst
 #[stable(feature = "rust1", since = "1.0.0")]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 #[non_exhaustive]
@@ -248,9 +235,6 @@ pub enum Ordering {
     ///
     /// Corresponds to [`memory_order_release`] in C++20.
     ///
-    /// [`Release`]: #variant.Release
-    /// [`Acquire`]: #variant.Acquire
-    /// [`Relaxed`]: #variant.Relaxed
     /// [`memory_order_release`]: https://en.cppreference.com/w/cpp/atomic/memory_order#Release-Acquire_ordering
     #[stable(feature = "rust1", since = "1.0.0")]
     Release,
@@ -266,9 +250,6 @@ pub enum Ordering {
     ///
     /// Corresponds to [`memory_order_acquire`] in C++20.
     ///
-    /// [`Acquire`]: #variant.Acquire
-    /// [`Release`]: #variant.Release
-    /// [`Relaxed`]: #variant.Relaxed
     /// [`memory_order_acquire`]: https://en.cppreference.com/w/cpp/atomic/memory_order#Release-Acquire_ordering
     #[stable(feature = "rust1", since = "1.0.0")]
     Acquire,
@@ -284,9 +265,6 @@ pub enum Ordering {
     /// Corresponds to [`memory_order_acq_rel`] in C++20.
     ///
     /// [`memory_order_acq_rel`]: https://en.cppreference.com/w/cpp/atomic/memory_order#Release-Acquire_ordering
-    /// [`Acquire`]: #variant.Acquire
-    /// [`Release`]: #variant.Release
-    /// [`Relaxed`]: #variant.Relaxed
     #[stable(feature = "rust1", since = "1.0.0")]
     AcqRel,
     /// Like [`Acquire`]/[`Release`]/[`AcqRel`] (for load, store, and load-with-store
@@ -296,16 +274,11 @@ pub enum Ordering {
     /// Corresponds to [`memory_order_seq_cst`] in C++20.
     ///
     /// [`memory_order_seq_cst`]: https://en.cppreference.com/w/cpp/atomic/memory_order#Sequentially-consistent_ordering
-    /// [`Acquire`]: #variant.Acquire
-    /// [`Release`]: #variant.Release
-    /// [`AcqRel`]: #variant.AcqRel
     #[stable(feature = "rust1", since = "1.0.0")]
     SeqCst,
 }
 
 /// An [`AtomicBool`] initialized to `false`.
-///
-/// [`AtomicBool`]: struct.AtomicBool.html
 #[cfg(target_has_atomic_load_store = "8")]
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_deprecated(
@@ -386,13 +359,6 @@ impl AtomicBool {
     ///
     /// Panics if `order` is [`Release`] or [`AcqRel`].
     ///
-    /// [`Ordering`]: enum.Ordering.html
-    /// [`Relaxed`]: enum.Ordering.html#variant.Relaxed
-    /// [`Release`]: enum.Ordering.html#variant.Release
-    /// [`Acquire`]: enum.Ordering.html#variant.Acquire
-    /// [`AcqRel`]: enum.Ordering.html#variant.AcqRel
-    /// [`SeqCst`]: enum.Ordering.html#variant.SeqCst
-    ///
     /// # Examples
     ///
     /// ```
@@ -418,13 +384,6 @@ impl AtomicBool {
     /// # Panics
     ///
     /// Panics if `order` is [`Acquire`] or [`AcqRel`].
-    ///
-    /// [`Ordering`]: enum.Ordering.html
-    /// [`Relaxed`]: enum.Ordering.html#variant.Relaxed
-    /// [`Release`]: enum.Ordering.html#variant.Release
-    /// [`Acquire`]: enum.Ordering.html#variant.Acquire
-    /// [`AcqRel`]: enum.Ordering.html#variant.AcqRel
-    /// [`SeqCst`]: enum.Ordering.html#variant.SeqCst
     ///
     /// # Examples
     ///
@@ -455,11 +414,6 @@ impl AtomicBool {
     ///
     /// **Note:** This method is only available on platforms that support atomic
     /// operations on `u8`.
-    ///
-    /// [`Ordering`]: enum.Ordering.html
-    /// [`Relaxed`]: enum.Ordering.html#variant.Relaxed
-    /// [`Release`]: enum.Ordering.html#variant.Release
-    /// [`Acquire`]: enum.Ordering.html#variant.Acquire
     ///
     /// # Examples
     ///
@@ -492,13 +446,6 @@ impl AtomicBool {
     ///
     /// **Note:** This method is only available on platforms that support atomic
     /// operations on `u8`.
-    ///
-    /// [`Ordering`]: enum.Ordering.html
-    /// [`Relaxed`]: enum.Ordering.html#variant.Relaxed
-    /// [`Release`]: enum.Ordering.html#variant.Release
-    /// [`Acquire`]: enum.Ordering.html#variant.Acquire
-    /// [`AcqRel`]: enum.Ordering.html#variant.AcqRel
-    /// [`bool`]: ../../../std/primitive.bool.html
     ///
     /// # Examples
     ///
@@ -540,11 +487,6 @@ impl AtomicBool {
     /// operations on `u8`.
     ///
     /// [`bool`]: ../../../std/primitive.bool.html
-    /// [`Ordering`]: enum.Ordering.html
-    /// [`Relaxed`]: enum.Ordering.html#variant.Relaxed
-    /// [`Release`]: enum.Ordering.html#variant.Release
-    /// [`Acquire`]: enum.Ordering.html#variant.Acquire
-    /// [`SeqCst`]: enum.Ordering.html#variant.SeqCst
     ///
     /// # Examples
     ///
@@ -587,7 +529,7 @@ impl AtomicBool {
 
     /// Stores a value into the [`bool`] if the current value is the same as the `current` value.
     ///
-    /// Unlike [`compare_exchange`], this function is allowed to spuriously fail even when the
+    /// Unlike [`AtomicBool::compare_exchange`], this function is allowed to spuriously fail even when the
     /// comparison succeeds, which can result in more efficient code on some platforms. The
     /// return value is a result indicating whether the new value was written and containing the
     /// previous value.
@@ -604,12 +546,6 @@ impl AtomicBool {
     /// operations on `u8`.
     ///
     /// [`bool`]: ../../../std/primitive.bool.html
-    /// [`compare_exchange`]: #method.compare_exchange
-    /// [`Ordering`]: enum.Ordering.html
-    /// [`Relaxed`]: enum.Ordering.html#variant.Relaxed
-    /// [`Release`]: enum.Ordering.html#variant.Release
-    /// [`Acquire`]: enum.Ordering.html#variant.Acquire
-    /// [`SeqCst`]: enum.Ordering.html#variant.SeqCst
     ///
     /// # Examples
     ///
@@ -658,11 +594,6 @@ impl AtomicBool {
     /// [`Acquire`] makes the store part of this operation [`Relaxed`], and
     /// using [`Release`] makes the load part [`Relaxed`].
     ///
-    /// [`Ordering`]: enum.Ordering.html
-    /// [`Relaxed`]: enum.Ordering.html#variant.Relaxed
-    /// [`Release`]: enum.Ordering.html#variant.Release
-    /// [`Acquire`]: enum.Ordering.html#variant.Acquire
-    ///
     /// **Note:** This method is only available on platforms that support atomic
     /// operations on `u8`.
     ///
@@ -705,11 +636,6 @@ impl AtomicBool {
     ///
     /// **Note:** This method is only available on platforms that support atomic
     /// operations on `u8`.
-    ///
-    /// [`Ordering`]: enum.Ordering.html
-    /// [`Relaxed`]: enum.Ordering.html#variant.Relaxed
-    /// [`Release`]: enum.Ordering.html#variant.Release
-    /// [`Acquire`]: enum.Ordering.html#variant.Acquire
     ///
     /// # Examples
     ///
@@ -763,11 +689,6 @@ impl AtomicBool {
     /// **Note:** This method is only available on platforms that support atomic
     /// operations on `u8`.
     ///
-    /// [`Ordering`]: enum.Ordering.html
-    /// [`Relaxed`]: enum.Ordering.html#variant.Relaxed
-    /// [`Release`]: enum.Ordering.html#variant.Release
-    /// [`Acquire`]: enum.Ordering.html#variant.Acquire
-    ///
     /// # Examples
     ///
     /// ```
@@ -807,11 +728,6 @@ impl AtomicBool {
     ///
     /// **Note:** This method is only available on platforms that support atomic
     /// operations on `u8`.
-    ///
-    /// [`Ordering`]: enum.Ordering.html
-    /// [`Relaxed`]: enum.Ordering.html#variant.Relaxed
-    /// [`Release`]: enum.Ordering.html#variant.Release
-    /// [`Acquire`]: enum.Ordering.html#variant.Acquire
     ///
     /// # Examples
     ///
@@ -942,13 +858,6 @@ impl<T> AtomicPtr<T> {
     ///
     /// Panics if `order` is [`Release`] or [`AcqRel`].
     ///
-    /// [`Ordering`]: enum.Ordering.html
-    /// [`Relaxed`]: enum.Ordering.html#variant.Relaxed
-    /// [`Release`]: enum.Ordering.html#variant.Release
-    /// [`Acquire`]: enum.Ordering.html#variant.Acquire
-    /// [`AcqRel`]: enum.Ordering.html#variant.AcqRel
-    /// [`SeqCst`]: enum.Ordering.html#variant.SeqCst
-    ///
     /// # Examples
     ///
     /// ```
@@ -974,13 +883,6 @@ impl<T> AtomicPtr<T> {
     /// # Panics
     ///
     /// Panics if `order` is [`Acquire`] or [`AcqRel`].
-    ///
-    /// [`Ordering`]: enum.Ordering.html
-    /// [`Relaxed`]: enum.Ordering.html#variant.Relaxed
-    /// [`Release`]: enum.Ordering.html#variant.Release
-    /// [`Acquire`]: enum.Ordering.html#variant.Acquire
-    /// [`AcqRel`]: enum.Ordering.html#variant.AcqRel
-    /// [`SeqCst`]: enum.Ordering.html#variant.SeqCst
     ///
     /// # Examples
     ///
@@ -1012,11 +914,6 @@ impl<T> AtomicPtr<T> {
     ///
     /// **Note:** This method is only available on platforms that support atomic
     /// operations on pointers.
-    ///
-    /// [`Ordering`]: enum.Ordering.html
-    /// [`Relaxed`]: enum.Ordering.html#variant.Relaxed
-    /// [`Release`]: enum.Ordering.html#variant.Release
-    /// [`Acquire`]: enum.Ordering.html#variant.Acquire
     ///
     /// # Examples
     ///
@@ -1051,12 +948,6 @@ impl<T> AtomicPtr<T> {
     ///
     /// **Note:** This method is only available on platforms that support atomic
     /// operations on pointers.
-    ///
-    /// [`Ordering`]: enum.Ordering.html
-    /// [`Relaxed`]: enum.Ordering.html#variant.Relaxed
-    /// [`Release`]: enum.Ordering.html#variant.Release
-    /// [`Acquire`]: enum.Ordering.html#variant.Acquire
-    /// [`AcqRel`]: enum.Ordering.html#variant.AcqRel
     ///
     /// # Examples
     ///
@@ -1095,12 +986,6 @@ impl<T> AtomicPtr<T> {
     ///
     /// **Note:** This method is only available on platforms that support atomic
     /// operations on pointers.
-    ///
-    /// [`Ordering`]: enum.Ordering.html
-    /// [`Relaxed`]: enum.Ordering.html#variant.Relaxed
-    /// [`Release`]: enum.Ordering.html#variant.Release
-    /// [`Acquire`]: enum.Ordering.html#variant.Acquire
-    /// [`SeqCst`]: enum.Ordering.html#variant.SeqCst
     ///
     /// # Examples
     ///
@@ -1143,7 +1028,7 @@ impl<T> AtomicPtr<T> {
 
     /// Stores a value into the pointer if the current value is the same as the `current` value.
     ///
-    /// Unlike [`compare_exchange`], this function is allowed to spuriously fail even when the
+    /// Unlike [`AtomicPtr::compare_exchange`], this function is allowed to spuriously fail even when the
     /// comparison succeeds, which can result in more efficient code on some platforms. The
     /// return value is a result indicating whether the new value was written and containing the
     /// previous value.
@@ -1158,13 +1043,6 @@ impl<T> AtomicPtr<T> {
     ///
     /// **Note:** This method is only available on platforms that support atomic
     /// operations on pointers.
-    ///
-    /// [`compare_exchange`]: #method.compare_exchange
-    /// [`Ordering`]: enum.Ordering.html
-    /// [`Relaxed`]: enum.Ordering.html#variant.Relaxed
-    /// [`Release`]: enum.Ordering.html#variant.Release
-    /// [`Acquire`]: enum.Ordering.html#variant.Acquire
-    /// [`SeqCst`]: enum.Ordering.html#variant.SeqCst
     ///
     /// # Examples
     ///
@@ -1271,7 +1149,7 @@ macro_rules! atomic_int {
         #[doc = $int_ref]
         /// ).
         ///
-        /// [module-level documentation]: index.html
+        /// [module-level documentation]: crate::sync::atomic
         #[$stable]
         #[repr(C, align($align))]
         pub struct $atomic_type {
@@ -1389,13 +1267,6 @@ Possible values are [`SeqCst`], [`Acquire`] and [`Relaxed`].
 
 Panics if `order` is [`Release`] or [`AcqRel`].
 
-[`Ordering`]: enum.Ordering.html
-[`Relaxed`]: enum.Ordering.html#variant.Relaxed
-[`Release`]: enum.Ordering.html#variant.Release
-[`Acquire`]: enum.Ordering.html#variant.Acquire
-[`AcqRel`]: enum.Ordering.html#variant.AcqRel
-[`SeqCst`]: enum.Ordering.html#variant.SeqCst
-
 # Examples
 
 ```
@@ -1422,13 +1293,6 @@ assert_eq!(some_var.load(Ordering::Relaxed), 5);
 # Panics
 
 Panics if `order` is [`Acquire`] or [`AcqRel`].
-
-[`Ordering`]: enum.Ordering.html
-[`Relaxed`]: enum.Ordering.html#variant.Relaxed
-[`Release`]: enum.Ordering.html#variant.Release
-[`Acquire`]: enum.Ordering.html#variant.Acquire
-[`AcqRel`]: enum.Ordering.html#variant.AcqRel
-[`SeqCst`]: enum.Ordering.html#variant.SeqCst
 
 # Examples
 
@@ -1458,11 +1322,6 @@ using [`Release`] makes the load part [`Relaxed`].
 
 **Note**: This method is only available on platforms that support atomic
 operations on [`", $s_int_type, "`](", $int_ref, ").
-
-[`Ordering`]: enum.Ordering.html
-[`Relaxed`]: enum.Ordering.html#variant.Relaxed
-[`Release`]: enum.Ordering.html#variant.Release
-[`Acquire`]: enum.Ordering.html#variant.Acquire
 
 # Examples
 
@@ -1497,12 +1356,6 @@ happens, and using [`Release`] makes the load part [`Relaxed`].
 
 **Note**: This method is only available on platforms that support atomic
 operations on [`", $s_int_type, "`](", $int_ref, ").
-
-[`Ordering`]: enum.Ordering.html
-[`Relaxed`]: enum.Ordering.html#variant.Relaxed
-[`Release`]: enum.Ordering.html#variant.Release
-[`Acquire`]: enum.Ordering.html#variant.Acquire
-[`AcqRel`]: enum.Ordering.html#variant.AcqRel
 
 # Examples
 
@@ -1553,12 +1406,6 @@ and must be equivalent to or weaker than the success ordering.
 **Note**: This method is only available on platforms that support atomic
 operations on [`", $s_int_type, "`](", $int_ref, ").
 
-[`Ordering`]: enum.Ordering.html
-[`Relaxed`]: enum.Ordering.html#variant.Relaxed
-[`Release`]: enum.Ordering.html#variant.Release
-[`Acquire`]: enum.Ordering.html#variant.Acquire
-[`SeqCst`]: enum.Ordering.html#variant.SeqCst
-
 # Examples
 
 ```
@@ -1595,7 +1442,7 @@ assert_eq!(some_var.load(Ordering::Relaxed), 10);
                 concat!("Stores a value into the atomic integer if the current value is the same as
 the `current` value.
 
-Unlike [`compare_exchange`], this function is allowed to spuriously fail even
+Unlike [`", stringify!($atomic_type), "::compare_exchange`], this function is allowed to spuriously fail even
 when the comparison succeeds, which can result in more efficient code on some
 platforms. The return value is a result indicating whether the new value was
 written and containing the previous value.
@@ -1607,13 +1454,6 @@ operation fails. Using [`Acquire`] as success ordering makes the store part
 of this operation [`Relaxed`], and using [`Release`] makes the successful load
 [`Relaxed`]. The failure ordering can only be [`SeqCst`], [`Acquire`] or [`Relaxed`]
 and must be equivalent to or weaker than the success ordering.
-
-[`compare_exchange`]: #method.compare_exchange
-[`Ordering`]: enum.Ordering.html
-[`Relaxed`]: enum.Ordering.html#variant.Relaxed
-[`Release`]: enum.Ordering.html#variant.Release
-[`Acquire`]: enum.Ordering.html#variant.Acquire
-[`SeqCst`]: enum.Ordering.html#variant.SeqCst
 
 **Note**: This method is only available on platforms that support atomic
 operations on [`", $s_int_type, "`](", $int_ref, ").
@@ -1662,11 +1502,6 @@ using [`Release`] makes the load part [`Relaxed`].
 **Note**: This method is only available on platforms that support atomic
 operations on [`", $s_int_type, "`](", $int_ref, ").
 
-[`Ordering`]: enum.Ordering.html
-[`Relaxed`]: enum.Ordering.html#variant.Relaxed
-[`Release`]: enum.Ordering.html#variant.Release
-[`Acquire`]: enum.Ordering.html#variant.Acquire
-
 # Examples
 
 ```
@@ -1697,11 +1532,6 @@ using [`Release`] makes the load part [`Relaxed`].
 
 **Note**: This method is only available on platforms that support atomic
 operations on [`", $s_int_type, "`](", $int_ref, ").
-
-[`Ordering`]: enum.Ordering.html
-[`Relaxed`]: enum.Ordering.html#variant.Relaxed
-[`Release`]: enum.Ordering.html#variant.Release
-[`Acquire`]: enum.Ordering.html#variant.Acquire
 
 # Examples
 
@@ -1737,11 +1567,6 @@ using [`Release`] makes the load part [`Relaxed`].
 **Note**: This method is only available on platforms that support atomic
 operations on [`", $s_int_type, "`](", $int_ref, ").
 
-[`Ordering`]: enum.Ordering.html
-[`Relaxed`]: enum.Ordering.html#variant.Relaxed
-[`Release`]: enum.Ordering.html#variant.Release
-[`Acquire`]: enum.Ordering.html#variant.Acquire
-
 # Examples
 
 ```
@@ -1775,11 +1600,6 @@ using [`Release`] makes the load part [`Relaxed`].
 
 **Note**: This method is only available on platforms that support atomic
 operations on [`", $s_int_type, "`](", $int_ref, ").
-
-[`Ordering`]: enum.Ordering.html
-[`Relaxed`]: enum.Ordering.html#variant.Relaxed
-[`Release`]: enum.Ordering.html#variant.Release
-[`Acquire`]: enum.Ordering.html#variant.Acquire
 
 # Examples
 
@@ -1816,11 +1636,6 @@ using [`Release`] makes the load part [`Relaxed`].
 **Note**: This method is only available on platforms that support atomic
 operations on [`", $s_int_type, "`](", $int_ref, ").
 
-[`Ordering`]: enum.Ordering.html
-[`Relaxed`]: enum.Ordering.html#variant.Relaxed
-[`Release`]: enum.Ordering.html#variant.Release
-[`Acquire`]: enum.Ordering.html#variant.Acquire
-
 # Examples
 
 ```
@@ -1855,11 +1670,6 @@ using [`Release`] makes the load part [`Relaxed`].
 **Note**: This method is only available on platforms that support atomic
 operations on [`", $s_int_type, "`](", $int_ref, ").
 
-[`Ordering`]: enum.Ordering.html
-[`Relaxed`]: enum.Ordering.html#variant.Relaxed
-[`Release`]: enum.Ordering.html#variant.Release
-[`Acquire`]: enum.Ordering.html#variant.Acquire
-
 # Examples
 
 ```
@@ -1890,7 +1700,7 @@ only once to the stored value.
 `fetch_update` takes two [`Ordering`] arguments to describe the memory ordering of this operation.
 The first describes the required ordering for when the operation finally succeeds while the second
 describes the required ordering for loads. These correspond to the success and failure orderings of
-[`compare_exchange`] respectively.
+[`", stringify!($atomic_type), "::compare_exchange`] respectively.
 
 Using [`Acquire`] as success ordering makes the store part
 of this operation [`Relaxed`], and using [`Release`] makes the final successful load
@@ -1901,12 +1711,6 @@ and must be equivalent to or weaker than the success ordering.
 operations on [`", $s_int_type, "`](", $int_ref, ").
 
 [`bool`]: ../../../std/primitive.bool.html
-[`compare_exchange`]: #method.compare_exchange
-[`Ordering`]: enum.Ordering.html
-[`Relaxed`]: enum.Ordering.html#variant.Relaxed
-[`Release`]: enum.Ordering.html#variant.Release
-[`Acquire`]: enum.Ordering.html#variant.Acquire
-[`SeqCst`]: enum.Ordering.html#variant.SeqCst
 
 # Examples
 
@@ -1954,11 +1758,6 @@ using [`Release`] makes the load part [`Relaxed`].
 **Note**: This method is only available on platforms that support atomic
 operations on [`", $s_int_type, "`](", $int_ref, ").
 
-[`Ordering`]: enum.Ordering.html
-[`Relaxed`]: enum.Ordering.html#variant.Relaxed
-[`Release`]: enum.Ordering.html#variant.Release
-[`Acquire`]: enum.Ordering.html#variant.Acquire
-
 # Examples
 
 ```
@@ -2003,11 +1802,6 @@ using [`Release`] makes the load part [`Relaxed`].
 
 **Note**: This method is only available on platforms that support atomic
 operations on [`", $s_int_type, "`](", $int_ref, ").
-
-[`Ordering`]: enum.Ordering.html
-[`Relaxed`]: enum.Ordering.html#variant.Relaxed
-[`Release`]: enum.Ordering.html#variant.Release
-[`Acquire`]: enum.Ordering.html#variant.Acquire
 
 # Examples
 
@@ -2660,13 +2454,6 @@ unsafe fn atomic_umin<T: Copy>(dst: *mut T, val: T, order: Ordering) -> T {
 ///     }
 /// }
 /// ```
-///
-/// [`Ordering`]: enum.Ordering.html
-/// [`Acquire`]: enum.Ordering.html#variant.Acquire
-/// [`SeqCst`]: enum.Ordering.html#variant.SeqCst
-/// [`Release`]: enum.Ordering.html#variant.Release
-/// [`AcqRel`]: enum.Ordering.html#variant.AcqRel
-/// [`Relaxed`]: enum.Ordering.html#variant.Relaxed
 #[inline]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub fn fence(order: Ordering) {
@@ -2747,13 +2534,6 @@ pub fn fence(order: Ordering) {
 /// }
 /// ```
 ///
-/// [`fence`]: fn.fence.html
-/// [`Ordering`]: enum.Ordering.html
-/// [`Acquire`]: enum.Ordering.html#variant.Acquire
-/// [`SeqCst`]: enum.Ordering.html#variant.SeqCst
-/// [`Release`]: enum.Ordering.html#variant.Release
-/// [`AcqRel`]: enum.Ordering.html#variant.AcqRel
-/// [`Relaxed`]: enum.Ordering.html#variant.Relaxed
 /// [memory barriers]: https://www.kernel.org/doc/Documentation/memory-barriers.txt
 #[inline]
 #[stable(feature = "compiler_fences", since = "1.21.0")]


### PR DESCRIPTION
Helps with #75080. 

@rustbot modify labels: T-doc, A-intra-doc-links, T-rustdoc

Known issues:

* Link from core to std:

    [`Arc`]
	[`std::thread::yield_now`]
	[`std::thread::sleep`]
	[`std::sync::Mutex`]
