### PR TITLE
[beta] Backport fix for swapped stability attributes

### DIFF
--- a/src/librustdoc/passes/doc_test_lints.rs
+++ b/src/librustdoc/passes/doc_test_lints.rs
@@ -1,7 +1,7 @@
 //! This pass is overloaded and runs two different lints.
 //!
-//! - MISSING_DOC_CODE_EXAMPLES: this looks for public items missing doc-tests
-//! - PRIVATE_DOC_TESTS: this looks for private items with doc-tests.
+//! - MISSING_DOC_CODE_EXAMPLES: this lint is **UNSTABLE** and looks for public items missing doc-tests
+//! - PRIVATE_DOC_TESTS: this lint is **STABLE** and looks for private items with doc-tests.
 
 use super::{span_of_attrs, Pass};
 use crate::clean;
@@ -89,7 +89,9 @@ pub fn look_for_tests<'tcx>(cx: &DocContext<'tcx>, dox: &str, item: &Item) {
 
     find_testable_code(&dox, &mut tests, ErrorCodes::No, false, None);
 
-    if tests.found_tests == 0 {
+    if tests.found_tests == 0
+        && rustc_feature::UnstableFeatures::from_environment().is_nightly_build()
+    {
         if should_have_doc_example(&item.inner) {
             debug!("reporting error for {:?} (hir_id={:?})", item, hir_id);
             let sp = span_of_attrs(&item.attrs).unwrap_or(item.source.span());
@@ -100,9 +102,7 @@ pub fn look_for_tests<'tcx>(cx: &DocContext<'tcx>, dox: &str, item: &Item) {
                 |lint| lint.build("missing code example in this documentation").emit(),
             );
         }
-    } else if rustc_feature::UnstableFeatures::from_environment().is_nightly_build()
-        && tests.found_tests > 0
-        && !cx.renderinfo.borrow().access_levels.is_public(item.def_id)
+    } else if tests.found_tests > 0 && !cx.renderinfo.borrow().access_levels.is_public(item.def_id)
     {
         cx.tcx.struct_span_lint_hir(
             lint::builtin::PRIVATE_DOC_TESTS,


### PR DESCRIPTION
This backports the only commit in https://github.com/rust-lang/rust/pull/75953/, fixing one unstable lint which ran on stable and one stable lint which only ran on nightly. This change can be replicated with
```
git fetch origin
git checkout origin/beta
git cherry-pick 29399fad5f961f0e235d28ed2f4c68e7a1ae5062
```