### PR TITLE
Build dist-x86_64-musl with --enable-profiler.

### DIFF
--- a/src/ci/docker/host-x86_64/dist-x86_64-musl/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-x86_64-musl/Dockerfile
@@ -33,6 +33,7 @@ ENV HOSTS=x86_64-unknown-linux-musl
 ENV RUST_CONFIGURE_ARGS \
       --musl-root-x86_64=/usr/local/x86_64-linux-musl \
       --enable-extended \
+      --enable-profiler \
       --enable-lld \
       --set target.x86_64-unknown-linux-musl.crt-static=false \
       --build $HOSTS


### PR DESCRIPTION
Trying to build a Rust project with `-Zprofile` for target
x86_64-unknown-linux-musl using rustc 1.46.0-nightly (346aec9b0
2020-07-11), installed with rustup, results in the following error.
```
        export RUSTFLAGS="-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort"export CARGO_INCREMENTAL=0$ cargo build --target=x86_64-unknown-linux-muslCompiling hello_world v0.1.0 (…)error[E0463]: can't find crate for `profiler_builtins`
        |
         = note: the compiler may have been built without the profiler runtime

        error: aborting due to previous error

        For more information about this error, try `rustc --explain E0463`.error: could not compile `hello_world`.

        To learn more, run the command again with --verbose.
```

`-Zprofile` is required here to enable grcov profiling.

This is similar in nature to issue
https://github.com/rust-lang/rust/issues/57257, which has been fixed in
asimilar way at https://github.com/rust-lang/rust/pull/60476 .

A fix for Android has also landed not long ago:
https://github.com/rust-lang/rust/pull/70054 .

Signed-off-by: Tiago Lam <tiagol@hadean.com>