### PR TITLE
impl ops::Try for Ordering

### DIFF
--- a/library/core/src/cmp.rs
+++ b/library/core/src/cmp.rs
@@ -23,6 +23,7 @@
 #![stable(feature = "rust1", since = "1.0.0")]
 
 use self::Ordering::*;
+use crate::ops;
 
 /// Trait for equality comparisons which are [partial equivalence
 /// relations](https://en.wikipedia.org/wiki/Partial_equivalence_relation).
@@ -676,6 +677,30 @@ impl PartialOrd for Ordering {
     #[inline]
     fn partial_cmp(&self, other: &Ordering) -> Option<Ordering> {
         (*self as i32).partial_cmp(&(*other as i32))
+    }
+}
+
+#[unstable(feature = "try_trait", issue = "42327")]
+impl ops::Try for Ordering {
+    type Ok = ();
+    type Error = Self;
+
+    #[inline]
+    fn into_result(self) -> Result<(), Self> {
+        match self {
+            Equal => Ok(()),
+            _ => Err(self),
+        }
+    }
+
+    #[inline]
+    fn from_ok(_: ()) -> Self {
+        Equal
+    }
+
+    #[inline]
+    fn from_error(v: Self) -> Self {
+        v
     }
 }
 

--- a/src/test/ui/ordering-try.rs
+++ b/src/test/ui/ordering-try.rs
@@ -1,0 +1,89 @@
+// run-pass
+
+use std::cmp::Ordering;
+use std::iter;
+
+#[derive(Eq, PartialEq)]
+struct Test(bool, u8, &'static str);
+
+const BOOL_VALUES: [bool; 2] = [true, false];
+const U8_VALUES: [u8; 3] = [1, 2, 3];
+const STR_VALUES: [&str; 3] = ["a", "ab", "c"];
+
+fn test_values() -> impl Iterator<Item = Test> {
+    BOOL_VALUES.iter().flat_map(|&a| {
+        U8_VALUES.iter().flat_map(move |&b| {
+            STR_VALUES.iter().map(move |&c| Test(a, b, c))
+        })
+    })
+}
+
+// This Ord implementation should behave the same as #[derive(Ord)],
+// but uses the Try operator on Ordering values
+impl Ord for Test {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.0.cmp(&other.0)?;
+        self.1.cmp(&other.1)?;
+        self.2.cmp(&other.2)
+    }
+}
+
+impl PartialOrd for Test {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+fn test_struct_cmp() {
+    for test1 in test_values() {
+        let test1_alt = (test1.0, test1.1, test1.2);
+        for test2 in test_values() {
+            let test2_alt = (test2.0, test2.1, test2.2);
+            assert_eq!(test1.cmp(&test2), test1_alt.cmp(&test2_alt));
+        }
+    }
+}
+
+// Implement Iterator::cmp() using the Try operator
+fn cmp<A, I1, I2>(mut iter1: I1, mut iter2: I2) -> Ordering
+where
+    A: Ord,
+    I1: Iterator<Item = A>,
+    I2: Iterator<Item = A>,
+{
+    loop {
+        match (iter1.next(), iter2.next()) {
+            (Some(x), Some(y)) => x.cmp(&y)?,
+            (x, y) => return x.cmp(&y),
+        }
+    }
+}
+
+fn u8_sequences() -> impl Iterator<Item = Vec<u8>> {
+    iter::once(vec![])
+        .chain(U8_VALUES.iter().map(|&a| vec![a]))
+        .chain(U8_VALUES.iter().flat_map(|&a| {
+            U8_VALUES.iter().map(move |&b| vec![a, b])
+        }))
+        .chain(U8_VALUES.iter().flat_map(|&a| {
+            U8_VALUES.iter().flat_map(move |&b| {
+                U8_VALUES.iter().map(move |&c| vec![a, b, c])
+            })
+        }))
+}
+
+fn test_slice_cmp() {
+    for sequence1 in u8_sequences() {
+        for sequence2 in u8_sequences() {
+            assert_eq!(
+                cmp(sequence1.iter().copied(), sequence2.iter().copied()),
+                sequence1.iter().copied().cmp(sequence2.iter().copied()),
+            );
+        }
+    }
+}
+
+fn main() {
+    test_struct_cmp();
+    test_slice_cmp();
+}


### PR DESCRIPTION
Implements `Try` for `Ordering`, mirroring the behavior of `Ordering::then()`. (Applying `?` to `Less` or `Greater` causes it to be `return`ed immediately, while `Equal?` results in `()`.) This is useful for implementing lexicographic orderings, where comparisons are chained until the first one that returns non-`Equal`. See the examples below.

I've currently gated this behind the `try_trait` feature, but maybe a separate feature should be used instead? I was surprised that the test passed without `#![feature(try_trait)]`; is this expected behavior?

Example 1: comparing structs as `#[derive(Ord)]` would do
```rust
struct Test(bool, u8, &'static str);

impl Ord for Test {
    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
        self.0.cmp(&other.0)?;
        self.1.cmp(&other.1)?;
        self.2.cmp(&other.2)
    }
}
```

Example 2: comparing iterators as `Iterator::cmp()` would do
```rust
fn cmp<A, I1, I2>(mut iter1: I1, mut iter2: I2) -> std::cmp::Ordering
where
    A: Ord,
    I1: Iterator<Item = A>,
    I2: Iterator<Item = A>,
{
    loop {
        match (iter1.next(), iter2.next()) {
            // If both iterators have an item available, compare them
            // and return the result if it is not `Equal`
            (Some(x), Some(y)) => x.cmp(&y)?,
            // If some iterator has finished, compare their `Option<A>` values
            // (`None < Some(_)`, so this matches the behavior of `Iterator::cmp()`)
            (x, y) => return x.cmp(&y),
        }
    }
}
```