### PR TITLE
rename get_{ref, mut} to assume_init_{ref,mut} in Maybeuninit

### DIFF
--- a/library/core/src/fmt/float.rs
+++ b/library/core/src/fmt/float.rs
@@ -28,8 +28,8 @@ where
             *num,
             sign,
             precision,
-            buf.get_mut(),
-            parts.get_mut(),
+            buf.assume_init_mut(),
+            parts.assume_init_mut(),
         );
         fmt.pad_formatted_parts(&formatted)
     }
@@ -58,8 +58,8 @@ where
             *num,
             sign,
             precision,
-            buf.get_mut(),
-            parts.get_mut(),
+            buf.assume_init_mut(),
+            parts.assume_init_mut(),
         );
         fmt.pad_formatted_parts(&formatted)
     }
@@ -114,8 +114,8 @@ where
             sign,
             precision,
             upper,
-            buf.get_mut(),
-            parts.get_mut(),
+            buf.assume_init_mut(),
+            parts.assume_init_mut(),
         );
         fmt.pad_formatted_parts(&formatted)
     }
@@ -145,8 +145,8 @@ where
             sign,
             (0, 0),
             upper,
-            buf.get_mut(),
-            parts.get_mut(),
+            buf.assume_init_mut(),
+            parts.assume_init_mut(),
         );
         fmt.pad_formatted_parts(&formatted)
     }

--- a/library/core/src/fmt/float.rs
+++ b/library/core/src/fmt/float.rs
@@ -14,11 +14,11 @@ fn float_to_decimal_common_exact<T>(
 where
     T: flt2dec::DecodableFloat,
 {
-    // SAFETY: Possible undefined behavior, see FIXME(#53491)
+    // SAFETY: Possible undefined behavior, see FIXME(#76092)
     unsafe {
         let mut buf = MaybeUninit::<[u8; 1024]>::uninit(); // enough for f32 and f64
         let mut parts = MaybeUninit::<[flt2dec::Part<'_>; 4]>::uninit();
-        // FIXME(#53491): This is calling `get_mut` on an uninitialized
+        // FIXME(#76092): This is calling `assume_init_mut` on an uninitialized
         // `MaybeUninit` (here and elsewhere in this file). Revisit this once
         // we decided whether that is valid or not.
         // We can do this only because we are libstd and coupled to the compiler.
@@ -47,12 +47,12 @@ fn float_to_decimal_common_shortest<T>(
 where
     T: flt2dec::DecodableFloat,
 {
-    // SAFETY: Possible undefined behavior, see FIXME(#53491)
+    // SAFETY: Possible undefined behavior, see FIXME(#76092)
     unsafe {
         // enough for f32 and f64
         let mut buf = MaybeUninit::<[u8; flt2dec::MAX_SIG_DIGITS]>::uninit();
         let mut parts = MaybeUninit::<[flt2dec::Part<'_>; 4]>::uninit();
-        // FIXME(#53491)
+        // FIXME(#76092)
         let formatted = flt2dec::to_shortest_str(
             flt2dec::strategy::grisu::format_shortest,
             *num,
@@ -103,11 +103,11 @@ fn float_to_exponential_common_exact<T>(
 where
     T: flt2dec::DecodableFloat,
 {
-    // SAFETY: Possible undefined behavior, see FIXME(#53491)
+    // SAFETY: Possible undefined behavior, see FIXME(#76092)
     unsafe {
         let mut buf = MaybeUninit::<[u8; 1024]>::uninit(); // enough for f32 and f64
         let mut parts = MaybeUninit::<[flt2dec::Part<'_>; 6]>::uninit();
-        // FIXME(#53491)
+        // FIXME(#76092)
         let formatted = flt2dec::to_exact_exp_str(
             flt2dec::strategy::grisu::format_exact,
             *num,
@@ -133,12 +133,12 @@ fn float_to_exponential_common_shortest<T>(
 where
     T: flt2dec::DecodableFloat,
 {
-    // SAFETY: Possible undefined behavior, see FIXME(#53491)
+    // SAFETY: Possible undefined behavior, see FIXME(#76092)
     unsafe {
         // enough for f32 and f64
         let mut buf = MaybeUninit::<[u8; flt2dec::MAX_SIG_DIGITS]>::uninit();
         let mut parts = MaybeUninit::<[flt2dec::Part<'_>; 6]>::uninit();
-        // FIXME(#53491)
+        // FIXME(#76092)
         let formatted = flt2dec::to_shortest_exp_str(
             flt2dec::strategy::grisu::format_shortest,
             *num,

--- a/library/core/src/mem/maybe_uninit.rs
+++ b/library/core/src/mem/maybe_uninit.rs
@@ -167,8 +167,7 @@ use crate::mem::ManuallyDrop;
 ///
 /// // For each item in the array, drop if we allocated it.
 /// for elem in &mut data[0..data_len] {
-///     unsafe { ptr::drop_in_place(elem.
-/// ptr()); }
+///     unsafe { ptr::drop_in_place(elem.ptr()); }
 /// }
 /// ```
 ///
@@ -718,7 +717,7 @@ impl<T> MaybeUninit<T> {
     /// {
     ///     let mut buffer = MaybeUninit::<[u8; 64]>::uninit();
     ///     reader.read_exact(unsafe { buffer.assume_init_mut() })?;
-    ///                             // ^^^^^^^^^^^^^^^^
+    ///                             // ^^^^^^^^^^^^^^^^^^^^^^^^
     ///                             // (mutable) reference to uninitialized memory!
     ///                             // This is undefined behavior.
     ///     Ok(unsafe { buffer.assume_init() })
@@ -739,11 +738,11 @@ impl<T> MaybeUninit<T> {
     /// let foo: Foo = unsafe {
     ///     let mut foo = MaybeUninit::<Foo>::uninit();
     ///     ptr::write(&mut foo.assume_init_mut().a as *mut u32, 1337);
-    ///                  // ^^^^^^^^^^^^^
+    ///                  // ^^^^^^^^^^^^^^^^^^^^^
     ///                  // (mutable) reference to uninitialized memory!
     ///                  // This is undefined behavior.
     ///     ptr::write(&mut foo.assume_init_mut().b as *mut u8, 42);
-    ///                  // ^^^^^^^^^^^^^
+    ///                  // ^^^^^^^^^^^^^^^^^^^^^
     ///                  // (mutable) reference to uninitialized memory!
     ///                  // This is undefined behavior.
     ///     foo.assume_init()

--- a/library/core/src/mem/maybe_uninit.rs
+++ b/library/core/src/mem/maybe_uninit.rs
@@ -679,7 +679,7 @@ impl<T> MaybeUninit<T> {
     /// // the `&mut MaybeUninit<[u8; 2048]>` to a `&mut [u8; 2048]`:
     /// let buf: &mut [u8; 2048] = unsafe {
     ///     // Safety: `buf` has been initialized.
-    ///     buf.assume_init_ref()
+    ///     buf.assume_init_mut()
     /// };
     ///
     /// // Now we can use `buf` as a normal slice:
@@ -746,7 +746,7 @@ impl<T> MaybeUninit<T> {
     ///                  // ^^^^^^^^^^^^^
     ///                  // (mutable) reference to uninitialized memory!
     ///                  // This is undefined behavior.
-    ///     foo.assume_init_mut()
+    ///     foo.assume_init()
     /// };
     /// ```
     // FIXME(#53491): We currently rely on the above being incorrect, i.e., we have references

--- a/library/core/src/mem/maybe_uninit.rs
+++ b/library/core/src/mem/maybe_uninit.rs
@@ -167,7 +167,8 @@ use crate::mem::ManuallyDrop;
 ///
 /// // For each item in the array, drop if we allocated it.
 /// for elem in &mut data[0..data_len] {
-///     unsafe { ptr::drop_in_place(elem.as_mut_ptr()); }
+///     unsafe { ptr::drop_in_place(elem.
+/// ptr()); }
 /// }
 /// ```
 ///
@@ -369,7 +370,7 @@ impl<T> MaybeUninit<T> {
     pub fn write(&mut self, val: T) -> &mut T {
         unsafe {
             self.value = ManuallyDrop::new(val);
-            self.get_mut()
+            self.assume_init_mut()
         }
     }
 
@@ -601,7 +602,7 @@ impl<T> MaybeUninit<T> {
     /// // create a shared reference to it:
     /// let x: &Vec<u32> = unsafe {
     ///     // Safety: `x` has been initialized.
-    ///     x.get_ref()
+    ///     x.assume_init_ref()
     /// };
     /// assert_eq!(x, &vec![1, 2, 3]);
     /// ```
@@ -613,7 +614,7 @@ impl<T> MaybeUninit<T> {
     /// use std::mem::MaybeUninit;
     ///
     /// let x = MaybeUninit::<Vec<u32>>::uninit();
-    /// let x_vec: &Vec<u32> = unsafe { x.get_ref() };
+    /// let x_vec: &Vec<u32> = unsafe { x.assume_init_ref() };
     /// // We have created a reference to an uninitialized vector! This is undefined behavior. ⚠️
     /// ```
     ///
@@ -624,14 +625,14 @@ impl<T> MaybeUninit<T> {
     /// let b = MaybeUninit::<Cell<bool>>::uninit();
     /// // Initialize the `MaybeUninit` using `Cell::set`:
     /// unsafe {
-    ///     b.get_ref().set(true);
+    ///     b.assume_init_ref().set(true);
     ///  // ^^^^^^^^^^^
     ///  // Reference to an uninitialized `Cell<bool>`: UB!
     /// }
     /// ```
     #[unstable(feature = "maybe_uninit_ref", issue = "63568")]
     #[inline(always)]
-    pub unsafe fn get_ref(&self) -> &T {
+    pub unsafe fn assume_init_ref(&self) -> &T {
         // SAFETY: the caller must guarantee that `self` is initialized.
         // This also means that `self` must be a `value` variant.
         unsafe {
@@ -650,7 +651,7 @@ impl<T> MaybeUninit<T> {
     ///
     /// Calling this when the content is not yet fully initialized causes undefined
     /// behavior: it is up to the caller to guarantee that the `MaybeUninit<T>` really
-    /// is in an initialized state. For instance, `.get_mut()` cannot be used to
+    /// is in an initialized state. For instance, `.assume_init_mut()` cannot be used to
     /// initialize a `MaybeUninit`.
     ///
     /// # Examples
@@ -678,7 +679,7 @@ impl<T> MaybeUninit<T> {
     /// // the `&mut MaybeUninit<[u8; 2048]>` to a `&mut [u8; 2048]`:
     /// let buf: &mut [u8; 2048] = unsafe {
     ///     // Safety: `buf` has been initialized.
-    ///     buf.get_mut()
+    ///     buf.assume_init_ref()
     /// };
     ///
     /// // Now we can use `buf` as a normal slice:
@@ -691,7 +692,7 @@ impl<T> MaybeUninit<T> {
     ///
     /// ### *Incorrect* usages of this method:
     ///
-    /// You cannot use `.get_mut()` to initialize a value:
+    /// You cannot use `.assume_init_mut()` to initialize a value:
     ///
     /// ```rust,no_run
     /// #![feature(maybe_uninit_ref)]
@@ -699,7 +700,7 @@ impl<T> MaybeUninit<T> {
     ///
     /// let mut b = MaybeUninit::<bool>::uninit();
     /// unsafe {
-    ///     *b.get_mut() = true;
+    ///     *b.assume_init_mut() = true;
     ///     // We have created a (mutable) reference to an uninitialized `bool`!
     ///     // This is undefined behavior. ⚠️
     /// }
@@ -716,7 +717,7 @@ impl<T> MaybeUninit<T> {
     /// fn read_chunk (reader: &'_ mut dyn io::Read) -> io::Result<[u8; 64]>
     /// {
     ///     let mut buffer = MaybeUninit::<[u8; 64]>::uninit();
-    ///     reader.read_exact(unsafe { buffer.get_mut() })?;
+    ///     reader.read_exact(unsafe { buffer.assume_init_mut() })?;
     ///                             // ^^^^^^^^^^^^^^^^
     ///                             // (mutable) reference to uninitialized memory!
     ///                             // This is undefined behavior.
@@ -737,15 +738,15 @@ impl<T> MaybeUninit<T> {
     ///
     /// let foo: Foo = unsafe {
     ///     let mut foo = MaybeUninit::<Foo>::uninit();
-    ///     ptr::write(&mut foo.get_mut().a as *mut u32, 1337);
+    ///     ptr::write(&mut foo.assume_init_mut().a as *mut u32, 1337);
     ///                  // ^^^^^^^^^^^^^
     ///                  // (mutable) reference to uninitialized memory!
     ///                  // This is undefined behavior.
-    ///     ptr::write(&mut foo.get_mut().b as *mut u8, 42);
+    ///     ptr::write(&mut foo.assume_init_mut().b as *mut u8, 42);
     ///                  // ^^^^^^^^^^^^^
     ///                  // (mutable) reference to uninitialized memory!
     ///                  // This is undefined behavior.
-    ///     foo.assume_init()
+    ///     foo.assume_init_mut()
     /// };
     /// ```
     // FIXME(#53491): We currently rely on the above being incorrect, i.e., we have references
@@ -753,7 +754,7 @@ impl<T> MaybeUninit<T> {
     // a final decision about the rules before stabilization.
     #[unstable(feature = "maybe_uninit_ref", issue = "63568")]
     #[inline(always)]
-    pub unsafe fn get_mut(&mut self) -> &mut T {
+    pub unsafe fn assume_init_mut(&mut self) -> &mut T {
         // SAFETY: the caller must guarantee that `self` is initialized.
         // This also means that `self` must be a `value` variant.
         unsafe {

--- a/library/core/src/mem/maybe_uninit.rs
+++ b/library/core/src/mem/maybe_uninit.rs
@@ -625,8 +625,8 @@ impl<T> MaybeUninit<T> {
     /// // Initialize the `MaybeUninit` using `Cell::set`:
     /// unsafe {
     ///     b.assume_init_ref().set(true);
-    ///  // ^^^^^^^^^^^
-    ///  // Reference to an uninitialized `Cell<bool>`: UB!
+    ///    // ^^^^^^^^^^^^^^^
+    ///    // Reference to an uninitialized `Cell<bool>`: UB!
     /// }
     /// ```
     #[unstable(feature = "maybe_uninit_ref", issue = "63568")]
@@ -748,7 +748,7 @@ impl<T> MaybeUninit<T> {
     ///     foo.assume_init()
     /// };
     /// ```
-    // FIXME(#53491): We currently rely on the above being incorrect, i.e., we have references
+    // FIXME(#76092): We currently rely on the above being incorrect, i.e., we have references
     // to uninitialized data (e.g., in `libcore/fmt/float.rs`).  We should make
     // a final decision about the rules before stabilization.
     #[unstable(feature = "maybe_uninit_ref", issue = "63568")]

--- a/library/core/src/mem/maybe_uninit.rs
+++ b/library/core/src/mem/maybe_uninit.rs
@@ -167,7 +167,7 @@ use crate::mem::ManuallyDrop;
 ///
 /// // For each item in the array, drop if we allocated it.
 /// for elem in &mut data[0..data_len] {
-///     unsafe { ptr::drop_in_place(elem.ptr()); }
+///     unsafe { ptr::drop_in_place(elem.as_mut_ptr()); }
 /// }
 /// ```
 ///

--- a/library/std/src/io/util.rs
+++ b/library/std/src/io/util.rs
@@ -55,18 +55,18 @@ where
     // to uninitialized data, but within libstd we can rely on more guarantees
     // than if this code were in an external lib.
     unsafe {
-        reader.initializer().initialize(buf.get_mut());
+        reader.initializer().initialize(buf.assume_init_mut());
     }
 
     let mut written = 0;
     loop {
-        let len = match reader.read(unsafe { buf.get_mut() }) {
+        let len = match reader.read(unsafe { buf.assume_init_mut() }) {
             Ok(0) => return Ok(written),
             Ok(len) => len,
             Err(ref e) if e.kind() == ErrorKind::Interrupted => continue,
             Err(e) => return Err(e),
         };
-        writer.write_all(unsafe { &buf.get_ref()[..len] })?;
+        writer.write_all(unsafe { &buf.assume_init_ref()[..len] })?;
         written += len as u64;
     }
 }

--- a/library/std/src/io/util.rs
+++ b/library/std/src/io/util.rs
@@ -49,7 +49,7 @@ where
     W: Write,
 {
     let mut buf = MaybeUninit::<[u8; super::DEFAULT_BUF_SIZE]>::uninit();
-    // FIXME(#53491): This is calling `get_mut` and `get_ref` on an uninitialized
+    // FIXME(#76092): This is calling `get_mut` and `get_ref` on an uninitialized
     // `MaybeUninit`. Revisit this once we decided whether that is valid or not.
     // This is still technically undefined behavior due to creating a reference
     // to uninitialized data, but within libstd we can rely on more guarantees

--- a/library/std/src/lazy.rs
+++ b/library/std/src/lazy.rs
@@ -376,13 +376,13 @@ impl<T> SyncOnceCell<T> {
     /// Safety: The value must be initialized
     unsafe fn get_unchecked(&self) -> &T {
         debug_assert!(self.is_initialized());
-        (&*self.value.get()).get_ref()
+        (&*self.value.get()).assume_init_ref()
     }
 
     /// Safety: The value must be initialized
     unsafe fn get_unchecked_mut(&mut self) -> &mut T {
         debug_assert!(self.is_initialized());
-        (&mut *self.value.get()).get_mut()
+        (&mut *self.value.get()).assume_init_mut()
     }
 }
 


### PR DESCRIPTION
References #63568 

Rework with comments addressed from #66174 

Have replaced most of the occurrences I've found, hopefully didn't miss out anything 

r? @RalfJung 

(thanks @danielhenrymantilla for the initial work on this)