### PR TITLE
GH-66816:  Remove disable attr before return

### DIFF
--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -2740,6 +2740,10 @@ function defocusSearchBar() {
     }
 
     window.addSearchOptions = function(crates) {
+        if (search_input) {
+            search_input.removeAttribute('disabled');
+        }
+
         var elem = document.getElementById("crate-search");
 
         if (!elem) {
@@ -2781,9 +2785,6 @@ function defocusSearchBar() {
             }
         }
 
-        if (search_input) {
-            search_input.removeAttribute('disabled');
-        }
     };
 
     function buildHelperPopup() {

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -2739,14 +2739,17 @@ function defocusSearchBar() {
         });
     }
 
-    window.addSearchOptions = function(crates) {
+    function enableSearchInput() {
         if (search_input) {
             search_input.removeAttribute('disabled');
         }
+    }
 
+    window.addSearchOptions = function(crates) {
         var elem = document.getElementById("crate-search");
 
         if (!elem) {
+            enableSearchInput();
             return;
         }
         var crates_text = [];
@@ -2784,7 +2787,7 @@ function defocusSearchBar() {
                 elem.value = savedCrate;
             }
         }
-
+        enableSearchInput();
     };
 
     function buildHelperPopup() {


### PR DESCRIPTION
Passing --disable-per-crate-search removes the create search inputs so moved code around so that the search input is enabled
first before the function returns.

Fixes #66816 