### PR TITLE
Link vec doc to & reference

### DIFF
--- a/library/alloc/src/vec.rs
+++ b/library/alloc/src/vec.rs
@@ -159,7 +159,7 @@ use crate::raw_vec::RawVec;
 /// # Slicing
 ///
 /// A `Vec` can be mutable. Slices, on the other hand, are read-only objects.
-/// To get a slice, use `&`. Example:
+/// To get a slice, use [`&`][prim@reference]. Example:
 ///
 /// ```
 /// fn read_slice(slice: &[usize]) {

--- a/library/alloc/src/vec.rs
+++ b/library/alloc/src/vec.rs
@@ -159,7 +159,7 @@ use crate::raw_vec::RawVec;
 /// # Slicing
 ///
 /// A `Vec` can be mutable. Slices, on the other hand, are read-only objects.
-/// To get a slice, use [`&`][prim@reference]. Example:
+/// To get a slice, use [`&`]. Example:
 ///
 /// ```
 /// fn read_slice(slice: &[usize]) {

--- a/library/alloc/src/vec.rs
+++ b/library/alloc/src/vec.rs
@@ -159,7 +159,7 @@ use crate::raw_vec::RawVec;
 /// # Slicing
 ///
 /// A `Vec` can be mutable. Slices, on the other hand, are read-only objects.
-/// To get a slice, use [`&`]. Example:
+/// To get a [slice], use [`&`]. Example:
 ///
 /// ```
 /// fn read_slice(slice: &[usize]) {
@@ -287,6 +287,7 @@ use crate::raw_vec::RawVec;
 /// [`insert`]: Vec::insert
 /// [`reserve`]: Vec::reserve
 /// [owned slice]: Box
+/// [slice]: ../../std/primitive.slice.html
 /// [`&`]: ../../std/primitive.reference.html
 #[stable(feature = "rust1", since = "1.0.0")]
 #[cfg_attr(not(test), rustc_diagnostic_item = "vec_type")]

--- a/library/alloc/src/vec.rs
+++ b/library/alloc/src/vec.rs
@@ -287,6 +287,7 @@ use crate::raw_vec::RawVec;
 /// [`insert`]: Vec::insert
 /// [`reserve`]: Vec::reserve
 /// [owned slice]: Box
+/// [`&`]: ../../std/primitive.reference.html
 #[stable(feature = "rust1", since = "1.0.0")]
 #[cfg_attr(not(test), rustc_diagnostic_item = "vec_type")]
 pub struct Vec<T> {


### PR DESCRIPTION
It is not always obvious that people could see the docs for `&`
especially for beginners, it also helps learnability.