### PR TITLE
MIR peephole optimize {Ne, Eq}(_1, false) into _1

### DIFF
--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -1954,6 +1954,15 @@ impl<'tcx> Operand<'tcx> {
             Operand::Constant(_) => None,
         }
     }
+
+    /// Returns the `Constant` that is the target of this `Operand`, or `None` if this `Operand` is a
+    /// place.
+    pub fn constant(&self) -> Option<&Constant<'tcx>> {
+        match self {
+            Operand::Constant(x) => Some(&**x),
+            Operand::Copy(_) | Operand::Move(_) => None,
+        }
+    }
 }
 
 ///////////////////////////////////////////////////////////////////////////

--- a/compiler/rustc_mir/src/transform/mod.rs
+++ b/compiler/rustc_mir/src/transform/mod.rs
@@ -453,8 +453,9 @@ fn run_optimization_passes<'tcx>(
 
     // The main optimizations that we do on MIR.
     let optimizations: &[&dyn MirPass<'tcx>] = &[
-        &instcombine::InstCombine,
         &match_branches::MatchBranchSimplification,
+        // inst combine is after MatchBranchSimplification to clean up Ne(_1, false)
+        &instcombine::InstCombine,
         &const_prop::ConstProp,
         &simplify_branches::SimplifyBranches::new("after-const-prop"),
         &simplify_comparison_integral::SimplifyComparisonIntegral,

--- a/src/test/mir-opt/equal_true.opt.InstCombine.diff
+++ b/src/test/mir-opt/equal_true.opt.InstCombine.diff
@@ -1,0 +1,35 @@
+- // MIR for `opt` before InstCombine
++ // MIR for `opt` after InstCombine
+  
+  fn opt(_1: bool) -> i32 {
+      debug x => _1;                       // in scope 0 at $DIR/equal_true.rs:3:8: 3:9
+      let mut _0: i32;                     // return place in scope 0 at $DIR/equal_true.rs:3:20: 3:23
+      let mut _2: bool;                    // in scope 0 at $DIR/equal_true.rs:4:8: 4:17
+      let mut _3: bool;                    // in scope 0 at $DIR/equal_true.rs:4:8: 4:9
+  
+      bb0: {
+          StorageLive(_2);                 // scope 0 at $DIR/equal_true.rs:4:8: 4:17
+          StorageLive(_3);                 // scope 0 at $DIR/equal_true.rs:4:8: 4:9
+          _3 = _1;                         // scope 0 at $DIR/equal_true.rs:4:8: 4:9
+-         _2 = Eq(move _3, const true);    // scope 0 at $DIR/equal_true.rs:4:8: 4:17
++         _2 = move _3;                    // scope 0 at $DIR/equal_true.rs:4:8: 4:17
+          StorageDead(_3);                 // scope 0 at $DIR/equal_true.rs:4:16: 4:17
+          switchInt(_2) -> [false: bb1, otherwise: bb2]; // scope 0 at $DIR/equal_true.rs:4:5: 4:34
+      }
+  
+      bb1: {
+          _0 = const 1_i32;                // scope 0 at $DIR/equal_true.rs:4:31: 4:32
+          goto -> bb3;                     // scope 0 at $DIR/equal_true.rs:4:5: 4:34
+      }
+  
+      bb2: {
+          _0 = const 0_i32;                // scope 0 at $DIR/equal_true.rs:4:20: 4:21
+          goto -> bb3;                     // scope 0 at $DIR/equal_true.rs:4:5: 4:34
+      }
+  
+      bb3: {
+          StorageDead(_2);                 // scope 0 at $DIR/equal_true.rs:5:1: 5:2
+          return;                          // scope 0 at $DIR/equal_true.rs:5:2: 5:2
+      }
+  }
+  

--- a/src/test/mir-opt/equal_true.rs
+++ b/src/test/mir-opt/equal_true.rs
@@ -1,0 +1,9 @@
+// EMIT_MIR equal_true.opt.InstCombine.diff
+
+fn opt(x: bool) -> i32 {
+    if x == true { 0 } else { 1 }
+}
+
+fn main() {
+    opt(true);
+}

--- a/src/test/mir-opt/not_equal_false.opt.InstCombine.diff
+++ b/src/test/mir-opt/not_equal_false.opt.InstCombine.diff
@@ -1,0 +1,72 @@
+- // MIR for `opt` before InstCombine
++ // MIR for `opt` after InstCombine
+  
+  fn opt(_1: Option<()>) -> bool {
+      debug x => _1;                       // in scope 0 at $DIR/not_equal_false.rs:3:8: 3:9
+      let mut _0: bool;                    // return place in scope 0 at $DIR/not_equal_false.rs:3:26: 3:30
+      let mut _2: bool;                    // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _3: isize;                   // in scope 0 at $DIR/not_equal_false.rs:4:17: 4:21
+      let mut _4: bool;                    // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _5: isize;                   // in scope 0 at $DIR/not_equal_false.rs:4:38: 4:45
+  
+      bb0: {
+          StorageLive(_2);                 // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _3 = discriminant(_1);           // scope 0 at $DIR/not_equal_false.rs:4:17: 4:21
+          _2 = Eq(_3, const 0_isize);      // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          goto -> bb7;                     // scope 0 at $DIR/not_equal_false.rs:4:17: 4:21
+      }
+  
+      bb1: {
+          _0 = const true;                 // scope 0 at $DIR/not_equal_false.rs:4:5: 4:46
+          goto -> bb4;                     // scope 0 at $DIR/not_equal_false.rs:4:5: 4:46
+      }
+  
+      bb2: {
+          _0 = const false;                // scope 0 at $DIR/not_equal_false.rs:4:5: 4:46
+          goto -> bb4;                     // scope 0 at $DIR/not_equal_false.rs:4:5: 4:46
+      }
+  
+      bb3: {
+          StorageLive(_4);                 // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _5 = discriminant(_1);           // scope 0 at $DIR/not_equal_false.rs:4:38: 4:45
+          _4 = Eq(_5, const 1_isize);      // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          goto -> bb10;                    // scope 0 at $DIR/not_equal_false.rs:4:38: 4:45
+      }
+  
+      bb4: {
+          StorageDead(_4);                 // scope 0 at $DIR/not_equal_false.rs:4:45: 4:46
+          StorageDead(_2);                 // scope 0 at $DIR/not_equal_false.rs:4:45: 4:46
+          return;                          // scope 0 at $DIR/not_equal_false.rs:5:2: 5:2
+      }
+  
+      bb5: {
+          _2 = const false;                // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          goto -> bb7;                     // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      }
+  
+      bb6: {
+          _2 = const true;                 // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          goto -> bb7;                     // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      }
+  
+      bb7: {
+          switchInt(move _2) -> [false: bb3, otherwise: bb1]; // scope 0 at $DIR/not_equal_false.rs:4:5: 4:46
+      }
+  
+      bb8: {
+          _4 = const false;                // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          goto -> bb10;                    // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      }
+  
+      bb9: {
+          _4 = const true;                 // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          goto -> bb10;                    // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      }
+  
+      bb10: {
+-         _0 = Ne(_4, const false);        // scope 0 at $DIR/not_equal_false.rs:4:5: 4:46
++         _0 = _4;                         // scope 0 at $DIR/not_equal_false.rs:4:5: 4:46
+          goto -> bb4;                     // scope 0 at $DIR/not_equal_false.rs:4:5: 4:46
+      }
+  }
+  

--- a/src/test/mir-opt/not_equal_false.rs
+++ b/src/test/mir-opt/not_equal_false.rs
@@ -1,0 +1,9 @@
+// EMIT_MIR not_equal_false.opt.InstCombine.diff
+
+fn opt(x: Option<()>) -> bool {
+    matches!(x, None) || matches!(x, Some(_))
+}
+
+fn main() {
+    opt(None);
+}


### PR DESCRIPTION
Add peephole optimization that simplifies Ne(_1, false) and Ne(false, _1) into _1. Similarly handles Eq(_1, true) and Eq(true, _1).

This was observed emitted from the MatchBranchSimplification pass.