### PR TITLE
datastructures: replace `once_cell` crate with an impl from std

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3420,7 +3420,6 @@ dependencies = [
  "lazy_static",
  "libc",
  "measureme",
- "once_cell",
  "parking_lot 0.10.2",
  "rustc-hash",
  "rustc-rayon",

--- a/compiler/rustc_data_structures/Cargo.toml
+++ b/compiler/rustc_data_structures/Cargo.toml
@@ -13,7 +13,6 @@ indexmap = "1.5.1"
 tracing = "0.1"
 jobserver_crate = { version = "0.1.13", package = "jobserver" }
 lazy_static = "1"
-once_cell = { version = "1", features = ["parking_lot"] }
 rustc_serialize = { path = "../rustc_serialize" }
 rustc_macros = { path = "../rustc_macros" }
 rustc_graphviz = { path = "../rustc_graphviz" }

--- a/compiler/rustc_data_structures/src/lib.rs
+++ b/compiler/rustc_data_structures/src/lib.rs
@@ -26,6 +26,7 @@
 #![feature(extend_one)]
 #![feature(const_panic)]
 #![feature(const_generics)]
+#![feature(once_cell)]
 #![allow(rustc::default_hash_types)]
 
 #[macro_use]

--- a/compiler/rustc_data_structures/src/sync.rs
+++ b/compiler/rustc_data_structures/src/sync.rs
@@ -229,7 +229,7 @@ cfg_if! {
         pub use std::cell::RefMut as LockGuard;
         pub use std::cell::RefMut as MappedLockGuard;
 
-        pub use once_cell::unsync::OnceCell;
+        pub use std::lazy::OnceCell;
 
         use std::cell::RefCell as InnerRwLock;
         use std::cell::RefCell as InnerLock;
@@ -314,7 +314,7 @@ cfg_if! {
         pub use parking_lot::MutexGuard as LockGuard;
         pub use parking_lot::MappedMutexGuard as MappedLockGuard;
 
-        pub use once_cell::sync::OnceCell;
+        pub use std::lazy::SyncOnceCell as OnceCell;
 
         pub use std::sync::atomic::{AtomicBool, AtomicUsize, AtomicU32, AtomicU64};
 

--- a/compiler/rustc_driver/src/lib.rs
+++ b/compiler/rustc_driver/src/lib.rs
@@ -6,6 +6,7 @@
 
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/")]
 #![feature(nll)]
+#![feature(once_cell)]
 #![recursion_limit = "256"]
 
 #[macro_use]

--- a/compiler/rustc_interface/src/lib.rs
+++ b/compiler/rustc_interface/src/lib.rs
@@ -4,6 +4,7 @@
 #![feature(nll)]
 #![feature(generator_trait)]
 #![feature(generators)]
+#![feature(once_cell)]
 #![recursion_limit = "256"]
 
 mod callbacks;

--- a/compiler/rustc_middle/src/lib.rs
+++ b/compiler/rustc_middle/src/lib.rs
@@ -38,6 +38,7 @@
 #![feature(exhaustive_patterns)]
 #![feature(extern_types)]
 #![feature(nll)]
+#![feature(once_cell)]
 #![feature(option_expect_none)]
 #![feature(or_patterns)]
 #![feature(min_specialization)]

--- a/compiler/rustc_session/src/lib.rs
+++ b/compiler/rustc_session/src/lib.rs
@@ -1,4 +1,5 @@
 #![feature(crate_visibility_modifier)]
+#![feature(once_cell)]
 #![feature(or_patterns)]
 
 #[macro_use]


### PR DESCRIPTION
Fixes #75700

r? @matklad 

We might need a perf run for this change.