### PR TITLE
Fix intra-doc links on pub re-exports

### DIFF
--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -578,6 +578,9 @@ impl<'a, 'tcx> DocFolder for LinkCollector<'a, 'tcx> {
         let parent_node = if item.is_fake() {
             // FIXME: is this correct?
             None
+        // If we're documenting the crate root itself, it has no parent. Use the root instead.
+        } else if item.def_id.is_top_level_module() {
+            Some(item.def_id)
         } else {
             let mut current = item.def_id;
             // The immediate parent might not always be a module.
@@ -589,6 +592,7 @@ impl<'a, 'tcx> DocFolder for LinkCollector<'a, 'tcx> {
                     }
                     current = parent;
                 } else {
+                    debug!("{:?} has no parent (kind={:?}, original was {:?})", current, self.cx.tcx.def_kind(current), item.def_id);
                     break None;
                 }
             }

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -592,7 +592,12 @@ impl<'a, 'tcx> DocFolder for LinkCollector<'a, 'tcx> {
                     }
                     current = parent;
                 } else {
-                    debug!("{:?} has no parent (kind={:?}, original was {:?})", current, self.cx.tcx.def_kind(current), item.def_id);
+                    debug!(
+                        "{:?} has no parent (kind={:?}, original was {:?})",
+                        current,
+                        self.cx.tcx.def_kind(current),
+                        item.def_id
+                    );
                     break None;
                 }
             }

--- a/src/test/rustdoc/auxiliary/intra-link-pub-use.rs
+++ b/src/test/rustdoc/auxiliary/intra-link-pub-use.rs
@@ -1,0 +1,4 @@
+#![crate_name = "inner"]
+
+/// Documentation, including a link to [std::ptr]
+pub fn f() {}

--- a/src/test/rustdoc/intra-link-pub-use.rs
+++ b/src/test/rustdoc/intra-link-pub-use.rs
@@ -1,8 +1,17 @@
-#![deny(intra_doc_link_resolution_failure)]
+#![deny(broken_intra_doc_links)]
 
 /// [std::env] [g]
-// @has intra_link_pub_use/index.html '//a[@href="https://doc.rust-lang.org/nightly/std/env/fn.var.html"]' "std::env"
-// @has - '//a[@href="../intra_link_pub_use/fn.f.html"]' "g"
+// FIXME: This can't be tested because rustdoc doesn't show documentation on pub re-exports.
+// Until then, comment out the `htmldocck` test.
+// This test still does something; namely check that no incorrect errors are emitted when
+// documenting the re-export.
+
+// @has intra_link_pub_use/index.html
+// @ has - '//a[@href="https://doc.rust-lang.org/nightly/std/env/fn.var.html"]' "std::env"
+// @ has - '//a[@href="../intra_link_pub_use/fn.f.html"]' "g"
 pub use f as g;
+
+/// [std::env]
+extern crate self as _;
 
 pub fn f() {}

--- a/src/test/rustdoc/intra-link-pub-use.rs
+++ b/src/test/rustdoc/intra-link-pub-use.rs
@@ -1,0 +1,8 @@
+#![deny(intra_doc_link_resolution_failure)]
+
+/// [std::env] [g]
+// @has intra_link_pub_use/index.html '//a[@href="https://doc.rust-lang.org/nightly/std/env/fn.var.html"]' "std::env"
+// @has - '//a[@href="../intra_link_pub_use/fn.f.html"]' "g"
+pub use f as g;
+
+pub fn f() {}

--- a/src/test/rustdoc/intra-link-pub-use.rs
+++ b/src/test/rustdoc/intra-link-pub-use.rs
@@ -1,17 +1,27 @@
+// aux-build: intra-link-pub-use.rs
 #![deny(broken_intra_doc_links)]
+#![crate_name = "outer"]
 
-/// [std::env] [g]
+extern crate inner;
+
+/// [mod@std::env] [g]
+
 // FIXME: This can't be tested because rustdoc doesn't show documentation on pub re-exports.
 // Until then, comment out the `htmldocck` test.
 // This test still does something; namely check that no incorrect errors are emitted when
 // documenting the re-export.
 
-// @has intra_link_pub_use/index.html
+// @has outer/index.html
 // @ has - '//a[@href="https://doc.rust-lang.org/nightly/std/env/fn.var.html"]' "std::env"
-// @ has - '//a[@href="../intra_link_pub_use/fn.f.html"]' "g"
+// @ has - '//a[@href="../outer/fn.f.html"]' "g"
 pub use f as g;
 
+// FIXME: same as above
 /// [std::env]
 extern crate self as _;
 
-pub fn f() {}
+// Make sure the documentation is actually correct by documenting an inlined re-export
+/// [mod@std::env]
+// @has outer/fn.f.html
+// @has - '//a[@href="https://doc.rust-lang.org/nightly/std/env/index.html"]' "std::env"
+pub use inner::f;


### PR DESCRIPTION
Partial fix for https://github.com/rust-lang/rust/issues/76073 - This removes the incorrect error, but doesn't show the documentation anywhere.
r? @GuillaumeGomez 