### PR TITLE
Overload `Iterator::last()` for `IntoIter`.

### DIFF
--- a/library/alloc/src/vec.rs
+++ b/library/alloc/src/vec.rs
@@ -2955,24 +2955,11 @@ impl<T> Iterator for IntoIter<T> {
         unsafe {
             if mem::size_of::<T>() == 0 { mem::zeroed() } else { ptr::read(self.ptr.add(i)) }
         }
+    }
+
     #[inline]
     fn last(mut self) -> Option<T> {
-        unsafe {
-            if self.ptr as *const _ == self.end {
-                None
-            } else {
-                if mem::size_of::<T>() == 0 {
-                    // Immediately marches to end of the iterator.
-                    self.ptr = self.end;
-                    // Make up a value of this ZST.
-                    Some(mem::zeroed())
-                } else {
-                    // Immediately marches to end of the iterator.
-                    self.ptr = self.end;
-                    Some(ptr::read(self.ptr.offset(-1)))
-                }
-            }
-        }
+        self.next_back()
     }
 }
 

--- a/library/alloc/src/vec.rs
+++ b/library/alloc/src/vec.rs
@@ -2955,6 +2955,12 @@ impl<T> Iterator for IntoIter<T> {
         unsafe {
             if mem::size_of::<T>() == 0 { mem::zeroed() } else { ptr::read(self.ptr.add(i)) }
         }
+    #[inline]
+    fn last(self) -> Option<Self::Item>
+    where
+        Self: Sized,
+    {
+        if self.ptr == self.end { None } else { unsafe { Some(ptr::read(self.end.offset(-1))) } }
     }
 }
 

--- a/library/alloc/src/vec.rs
+++ b/library/alloc/src/vec.rs
@@ -2956,11 +2956,23 @@ impl<T> Iterator for IntoIter<T> {
             if mem::size_of::<T>() == 0 { mem::zeroed() } else { ptr::read(self.ptr.add(i)) }
         }
     #[inline]
-    fn last(self) -> Option<Self::Item>
-    where
-        Self: Sized,
-    {
-        if self.ptr == self.end { None } else { unsafe { Some(ptr::read(self.end.offset(-1))) } }
+    fn last(mut self) -> Option<T> {
+        unsafe {
+            if self.ptr as *const _ == self.end {
+                None
+            } else {
+                if mem::size_of::<T>() == 0 {
+                    // Immediately marches to end of the iterator.
+                    self.ptr = self.end;
+                    // Make up a value of this ZST.
+                    Some(mem::zeroed())
+                } else {
+                    // Immediately marches to end of the iterator.
+                    self.ptr = self.end;
+                    Some(ptr::read(self.ptr.offset(-1)))
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Simply use the fact that `IntoIter` stores the end pointer and we
can perform pointer arithmetic.

NOTE: Where is the test for this?