### PR TITLE
Fix intra-doc links for associated constants on primitives

### DIFF
--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -261,9 +261,10 @@ impl<'a, 'tcx> LinkCollector<'a, 'tcx> {
                             ns,
                             impl_,
                         )
-                        .and_then(|item| match item.kind {
-                            ty::AssocKind::Fn => Some("method"),
-                            _ => None,
+                        .map(|item| match item.kind {
+                            ty::AssocKind::Fn => "method",
+                            ty::AssocKind::Const => "associatedconstant",
+                            ty::AssocKind::Type => "associatedtype",
                         })
                         .map(|out| (prim, Some(format!("{}#{}.{}", path, out, item_name))));
                     if let Some(link) = link {

--- a/src/test/rustdoc/intra-link-prim-assoc.rs
+++ b/src/test/rustdoc/intra-link-prim-assoc.rs
@@ -1,0 +1,5 @@
+// ignore-tidy-linelength
+#![deny(broken_intra_doc_links)]
+
+//! [i32::MAX]
+// @has intra_link_prim_assoc/index.html '//a[@href="https://doc.rust-lang.org/nightly/std/primitive.i32.html#associatedconstant.MAX"]' "i32::MAX"


### PR DESCRIPTION
Previously, only associated functions would be resolved. Fixes the issues in https://github.com/rust-lang/rust/pull/75969#discussion_r477898003.

I'm a little uncomfortable hard-coding the string constants, but it looks like that's how it's done elsewhere. I might make a follow-up PR at some point putting it in one place.

Not sure how to test associated types, since AFAIK there aren't any on primitives.

r? @Manishearth