### PR TITLE
Switch `mutable_borrow_reservation_conflict` lint to deny by default

### DIFF
--- a/compiler/rustc_session/src/lint/builtin.rs
+++ b/compiler/rustc_session/src/lint/builtin.rs
@@ -492,7 +492,7 @@ declare_lint! {
 
 declare_lint! {
     pub MUTABLE_BORROW_RESERVATION_CONFLICT,
-    Warn,
+    Deny,
     "reservation of a two-phased borrow conflicts with other shared borrows",
     @future_incompatible = FutureIncompatibleInfo {
         reference: "issue #59159 <https://github.com/rust-lang/rust/issues/59159>",

--- a/src/test/ui/borrowck/two-phase-reservation-sharing-interference-2.migrate2015.stderr
+++ b/src/test/ui/borrowck/two-phase-reservation-sharing-interference-2.migrate2015.stderr
@@ -20,7 +20,7 @@ LL |     v.extend(&v);
    |     | immutable borrow later used by call
    |     mutable borrow occurs here
 
-warning: cannot borrow `v` as mutable because it is also borrowed as immutable
+error: cannot borrow `v` as mutable because it is also borrowed as immutable
   --> $DIR/two-phase-reservation-sharing-interference-2.rs:40:5
    |
 LL |     let shared = &v;
@@ -31,10 +31,10 @@ LL |     v.push(shared.len());
    |     |
    |     mutable borrow occurs here
    |
-   = note: `#[warn(mutable_borrow_reservation_conflict)]` on by default
+   = note: `#[deny(mutable_borrow_reservation_conflict)]` on by default
    = warning: this borrowing pattern was not meant to be accepted, and may become a hard error in the future
    = note: for more information, see issue #59159 <https://github.com/rust-lang/rust/issues/59159>
 
-error: aborting due to 2 previous errors; 1 warning emitted
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0502`.

--- a/src/test/ui/borrowck/two-phase-reservation-sharing-interference-2.migrate2018.stderr
+++ b/src/test/ui/borrowck/two-phase-reservation-sharing-interference-2.migrate2018.stderr
@@ -20,7 +20,7 @@ LL |     v.extend(&v);
    |     | immutable borrow later used by call
    |     mutable borrow occurs here
 
-warning: cannot borrow `v` as mutable because it is also borrowed as immutable
+error: cannot borrow `v` as mutable because it is also borrowed as immutable
   --> $DIR/two-phase-reservation-sharing-interference-2.rs:40:5
    |
 LL |     let shared = &v;
@@ -31,10 +31,10 @@ LL |     v.push(shared.len());
    |     |
    |     mutable borrow occurs here
    |
-   = note: `#[warn(mutable_borrow_reservation_conflict)]` on by default
+   = note: `#[deny(mutable_borrow_reservation_conflict)]` on by default
    = warning: this borrowing pattern was not meant to be accepted, and may become a hard error in the future
    = note: for more information, see issue #59159 <https://github.com/rust-lang/rust/issues/59159>
 
-error: aborting due to 2 previous errors; 1 warning emitted
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0502`.

--- a/src/test/ui/borrowck/two-phase-reservation-sharing-interference-2.rs
+++ b/src/test/ui/borrowck/two-phase-reservation-sharing-interference-2.rs
@@ -40,10 +40,10 @@ fn reservation_conflict() {
     v.push(shared.len());
     //[nll2015]~^ ERROR cannot borrow `v` as mutable
     //[nll2018]~^^ ERROR cannot borrow `v` as mutable
-    //[migrate2015]~^^^ WARNING cannot borrow `v` as mutable
+    //[migrate2015]~^^^ ERROR cannot borrow `v` as mutable
     //[migrate2015]~| WARNING may become a hard error in the future
 
-    //[migrate2018]~^^^^^^ WARNING cannot borrow `v` as mutable
+    //[migrate2018]~^^^^^^ ERROR cannot borrow `v` as mutable
     //[migrate2018]~| WARNING may become a hard error in the future
 }
 


### PR DESCRIPTION
Lint `mutable_borrow_reservation_conflict` was added about a year and a half ago in warning mode by default. Issue #59159 states that at some point, it should be set to deny by default which this PR implements.

I am mainly creating this PR to start the discussion and try to help stabilizing full `nll`.
I also don't know if we need a crater run for this kind of change?

Assigning to @pnkfelix because of the tracking issue but feel free to re-assign to whoever might be better suited to review this change.

r? @pnkfelix 