### PR TITLE
Write manifest for MAJOR.MINOR channel to enable rustup convenience

### DIFF
--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -293,6 +293,8 @@ impl Builder {
         self.write_channel_files(self.versions.channel(), &manifest);
         if self.versions.channel() != rust_version {
             self.write_channel_files(&rust_version, &manifest);
+        }
+        if self.versions.channel() == "stable" {
             let major_minor = rust_version.split('.').take(2).collect::<Vec<_>>().join(".");
             self.write_channel_files(&major_minor, &manifest);
         }

--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -293,6 +293,8 @@ impl Builder {
         self.write_channel_files(self.versions.channel(), &manifest);
         if self.versions.channel() != rust_version {
             self.write_channel_files(&rust_version, &manifest);
+            let major_minor = rust_version.split('.').take(2).collect::<Vec<_>>().join(".");
+            self.write_channel_files(&major_minor, &manifest);
         }
     }
 


### PR DESCRIPTION
This connects to https://github.com/rust-lang/rustup/issues/794.

It's hard to remember if there have been patch releases for old versions
when you'd like to install the latest in a MAJOR.MINOR series.

When we're doing a stable release, we write duplicate manifests to
`stable`. With this change, only when we're doing a stable release, also
write duplicate manifests to `MAJOR.MINOR` to eventually enable rustup
(and any other tooling that builds Rust release URLs) to request, say,
`1.45` and get `1.45.2` (assuming `1.45.2` is the latest available
`1.45` and assuming that we never publish patch releases out of order).

I tested the best I could; it's a bit hard to get everything set up right
to be able to run the build-manifest tool. But I was able to run it with
a release of "1.45.2" and in addition to the files like `channel-rust-1.45.2.toml`
and `channel-rust-stable.toml` (and other manifests) that I got before this
change, I now get `channel-rust-1.45.toml`.

I believe this change to be safe to deploy as it does not change or remove
anything about manifests, just adds more. The actions in rust-central-station
that interact with manifests appear to use wildcards in such a way that it will
pick up these files without any problems.

There will need to be changes to `rustup` before `rustup install 1.45` will work,
but we can wait for a stable release and stable patch releases to happen with this
change before making the `rustup` changes, so that we're not committing to anything
before we know it works.