### PR TITLE
Function to convert OpenOptions to c_int

### DIFF
--- a/library/std/src/sys/unix/ext/fs.rs
+++ b/library/std/src/sys/unix/ext/fs.rs
@@ -346,9 +346,13 @@ pub trait OpenOptionsExt {
     #[stable(feature = "open_options_ext", since = "1.10.0")]
     fn custom_flags(&mut self, flags: i32) -> &mut Self;
 
-    /// Get the flags of this OpenOptions as libc::c_int.
+    /// Get the flags of this OpenOptions as [`libc::c_int`].
+    /// With: [`libc::open`]
     ///
-    /// This method allows the reuse of the OpenOptions as flags argument for `libc::open()`.
+    /// This method allows the reuse of the OpenOptions as flags argument for [`fs::OpenOptions`].
+    ///
+    /// [`libc::c_int`]: https://docs.rs/libc/*/libc/type.c_int.html
+    /// [`libc::open`]: https://docs.rs/libc/*/libc/fn.open.html
     ///
     /// # Examples
     ///
@@ -359,16 +363,10 @@ pub trait OpenOptionsExt {
     /// use std::fs::OpenOptions;
     /// use std::os::unix::fs::OpenOptionsExt;
     ///
-    /// # fn main() {
     /// let mut options = OpenOptions::new();
     /// options.write(true).read(true);
-    /// if cfg!(unix) {
-    ///     options.custom_flags(libc::O_NOFOLLOW);
-    /// }
     /// let file_name = CString::new("foo.txt").unwrap();
-    /// let file = unsafe{ libc::open(file_name.as_c_str().as_ptr(), options.as_flags().unwrap()) };
-    ///
-    /// # }
+    /// let file = unsafe { libc::open(file_name.as_c_str().as_ptr(), options.as_flags().unwrap()) };
     /// ```
     #[stable(feature = "open_options_ext_as_flags", since = "1.47.0")]
     fn as_flags(&self) -> io::Result<libc::c_int>;
@@ -385,6 +383,7 @@ impl OpenOptionsExt for OpenOptions {
         self.as_inner_mut().custom_flags(flags);
         self
     }
+
     fn as_flags(&self) -> io::Result<libc::c_int> {
         self.as_inner().as_flags()
     }

--- a/library/std/src/sys/unix/ext/fs.rs
+++ b/library/std/src/sys/unix/ext/fs.rs
@@ -346,10 +346,9 @@ pub trait OpenOptionsExt {
     #[stable(feature = "open_options_ext", since = "1.10.0")]
     fn custom_flags(&mut self, flags: i32) -> &mut Self;
 
-    /// Get the flags of this OpenOptions as [`libc::c_int`].
-    /// With: [`libc::open`]
+    /// Get the flags as [`libc::c_int`].
     ///
-    /// This method allows the reuse of the OpenOptions as flags argument for [`fs::OpenOptions`].
+    /// This method allows the reuse of the OpenOptions as flags argument for [`libc::open`].
     ///
     /// [`libc::c_int`]: https://docs.rs/libc/*/libc/type.c_int.html
     /// [`libc::open`]: https://docs.rs/libc/*/libc/fn.open.html

--- a/library/std/src/sys/unix/ext/fs.rs
+++ b/library/std/src/sys/unix/ext/fs.rs
@@ -367,7 +367,7 @@ pub trait OpenOptionsExt {
     /// let file_name = CString::new("foo.txt").unwrap();
     /// let file = unsafe { libc::open(file_name.as_c_str().as_ptr(), options.as_flags().unwrap()) };
     /// ```
-    #[stable(feature = "open_options_ext_as_flags", since = "1.47.0")]
+    #[unstable(feature = "open_options_ext_as_flags", issue = "76801")]
     fn as_flags(&self) -> io::Result<libc::c_int>;
 }
 

--- a/library/std/src/sys/unix/ext/fs.rs
+++ b/library/std/src/sys/unix/ext/fs.rs
@@ -357,6 +357,7 @@ pub trait OpenOptionsExt {
     ///
     /// ```no_run
     /// # #![feature(rustc_private)]
+    /// #![feature(open_options_ext_as_flags)]
     /// extern crate libc;
     /// use std::ffi::CString;
     /// use std::fs::OpenOptions;

--- a/library/std/src/sys/unix/ext/fs.rs
+++ b/library/std/src/sys/unix/ext/fs.rs
@@ -345,6 +345,33 @@ pub trait OpenOptionsExt {
     /// ```
     #[stable(feature = "open_options_ext", since = "1.10.0")]
     fn custom_flags(&mut self, flags: i32) -> &mut Self;
+
+    /// Get the flags of this OpenOptions as libc::c_int.
+    ///
+    /// This method allows the reuse of the OpenOptions as flags argument for `libc::open()`.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # #![feature(rustc_private)]
+    /// extern crate libc;
+    /// use std::ffi::CString;
+    /// use std::fs::OpenOptions;
+    /// use std::os::unix::fs::OpenOptionsExt;
+    ///
+    /// # fn main() {
+    /// let mut options = OpenOptions::new();
+    /// options.write(true).read(true);
+    /// if cfg!(unix) {
+    ///     options.custom_flags(libc::O_NOFOLLOW);
+    /// }
+    /// let file_name = CString::new("foo.txt").unwrap();
+    /// let file = unsafe{ libc::open(file_name.as_c_str().as_ptr(), options.as_flags().unwrap()) };
+    ///
+    /// # }
+    /// ```
+    #[stable(feature = "open_options_ext_as_flags", since = "1.47.0")]
+    fn as_flags(&self) -> io::Result<libc::c_int>;
 }
 
 #[stable(feature = "fs_ext", since = "1.1.0")]
@@ -357,6 +384,9 @@ impl OpenOptionsExt for OpenOptions {
     fn custom_flags(&mut self, flags: i32) -> &mut OpenOptions {
         self.as_inner_mut().custom_flags(flags);
         self
+    }
+    fn as_flags(&self) -> io::Result<libc::c_int> {
+        self.as_inner().as_flags()
     }
 }
 

--- a/library/std/src/sys/unix/fs.rs
+++ b/library/std/src/sys/unix/fs.rs
@@ -963,7 +963,7 @@ pub fn rename(old: &Path, new: &Path) -> io::Result<()> {
     Ok(())
 }
 
-pub fn get_openopetions_as_cint(from: OpenOptions) -> io::Result<libc::c_int> {
+pub fn get_openoptions_as_cint(from: OpenOptions) -> io::Result<libc::c_int> {
     let access_mode = from.get_access_mode()?;
     let creation_mode = from.get_creation_mode()?;
     Ok(creation_mode | access_mode)

--- a/library/std/src/sys/unix/fs.rs
+++ b/library/std/src/sys/unix/fs.rs
@@ -660,6 +660,7 @@ impl OpenOptions {
         let creation_mode = self.get_creation_mode()?;
         Ok(creation_mode | access_mode | self.custom_flags)
     }
+
     fn get_access_mode(&self) -> io::Result<c_int> {
         match (self.read, self.write, self.append) {
             (true, false, false) => Ok(libc::O_RDONLY),

--- a/library/std/src/sys/unix/fs.rs
+++ b/library/std/src/sys/unix/fs.rs
@@ -655,6 +655,7 @@ impl OpenOptions {
     pub fn mode(&mut self, mode: u32) {
         self.mode = mode as mode_t;
     }
+
     pub fn as_flags(&self) -> io::Result<c_int> {
         let access_mode = self.get_access_mode()?;
         let creation_mode = self.get_creation_mode()?;

--- a/library/std/src/sys/unix/fs.rs
+++ b/library/std/src/sys/unix/fs.rs
@@ -692,6 +692,7 @@ impl OpenOptions {
     }
 }
 
+
 impl File {
     pub fn open(path: &Path, opts: &OpenOptions) -> io::Result<File> {
         let path = cstr(path)?;
@@ -960,6 +961,12 @@ pub fn rename(old: &Path, new: &Path) -> io::Result<()> {
     let new = cstr(new)?;
     cvt(unsafe { libc::rename(old.as_ptr(), new.as_ptr()) })?;
     Ok(())
+}
+
+pub fn get_openopetions_as_cint(from: OpenOptions) -> io::Result<libc::c_int> {
+    let access_mode = from.get_access_mode()?;
+    let creation_mode = from.get_creation_mode()?;
+    Ok(creation_mode | access_mode)
 }
 
 pub fn set_perm(p: &Path, perm: FilePermissions) -> io::Result<()> {

--- a/library/std/src/sys/unix/fs.rs
+++ b/library/std/src/sys/unix/fs.rs
@@ -655,7 +655,11 @@ impl OpenOptions {
     pub fn mode(&mut self, mode: u32) {
         self.mode = mode as mode_t;
     }
-
+    pub fn as_flags(&self) -> io::Result<c_int> {
+        let access_mode = self.get_access_mode()?;
+        let creation_mode = self.get_creation_mode()?;
+        Ok(creation_mode | access_mode | self.custom_flags)
+    }
     fn get_access_mode(&self) -> io::Result<c_int> {
         match (self.read, self.write, self.append) {
             (true, false, false) => Ok(libc::O_RDONLY),
@@ -691,7 +695,6 @@ impl OpenOptions {
         })
     }
 }
-
 
 impl File {
     pub fn open(path: &Path, opts: &OpenOptions) -> io::Result<File> {
@@ -963,11 +966,6 @@ pub fn rename(old: &Path, new: &Path) -> io::Result<()> {
     Ok(())
 }
 
-pub fn get_openopetions_as_cint(from: OpenOptions) -> io::Result<libc::c_int> {
-    let access_mode = from.get_access_mode()?;
-    let creation_mode = from.get_creation_mode()?;
-    Ok(creation_mode | access_mode)
-}
 
 pub fn set_perm(p: &Path, perm: FilePermissions) -> io::Result<()> {
     let p = cstr(p)?;


### PR DESCRIPTION
Fixes: #74943
The creation_mode and access_mode function were already available in the OpenOptions struct, but currently private. I've added a new free functions to unix/fs.rs which takes the OpenOptions, and returns the c_int to be used as parameter for the `open` call.
