### PR TITLE
Add `[T; N]::as_[mut_]slice`

### DIFF
--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -422,4 +422,17 @@ impl<T, const N: usize> [T; N] {
         // and we just need to cast it to the correct type.
         unsafe { crate::mem::transmute_copy::<_, [U; N]>(&dst) }
     }
+
+    /// Returns a slice containing the entire array. Equivalent to `&s[..]`.
+    #[unstable(feature = "array_methods", issue = "76118")]
+    pub fn as_slice(&self) -> &[T] {
+        self
+    }
+
+    /// Returns a mutable slice containing the entire array. Equivalent to
+    /// `&mut s[..]`.
+    #[unstable(feature = "array_methods", issue = "76118")]
+    pub fn as_mut_slice(&mut self) -> &mut [T] {
+        self
+    }
 }

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -1,5 +1,6 @@
 #![feature(alloc_layout_extra)]
 #![feature(array_chunks)]
+#![feature(array_methods)]
 #![feature(array_map)]
 #![feature(bool_to_option)]
 #![feature(bound_cloned)]

--- a/library/core/tests/option.rs
+++ b/library/core/tests/option.rs
@@ -1,4 +1,3 @@
-use core::array::FixedSizeArray;
 use core::clone::Clone;
 use core::mem;
 use core::ops::DerefMut;

--- a/library/core/tests/result.rs
+++ b/library/core/tests/result.rs
@@ -1,4 +1,3 @@
-use core::array::FixedSizeArray;
 use core::ops::DerefMut;
 use core::option::*;
 


### PR DESCRIPTION
Part of me trying to populate arrays with a couple of basic useful methods, like slices already have. The ability to add methods to arrays were added in #75212.  Tracking issue: #76118

This adds:

```rust
impl<T, const N: usize> [T; N] {
    pub fn as_slice(&self) -> &[T];
    pub fn as_mut_slice(&mut self) -> &mut [T];
}
```

These methods are like the ones on `std::array::FixedSizeArray` and in the crate `arraytools`.
