### PR TITLE
Use "Fira Sans" for crate list font

### DIFF
--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -1062,12 +1062,13 @@ themePicker.onblur = handleThemeButtonsBlur;
             let content = format!(
                 "<h1 class='fqn'>\
                      <span class='in-band'>List of all crates</span>\
-                </h1><ul class='mod'>{}</ul>",
+                </h1>\
+                <ul class='crate mod'>{}</ul>",
                 krates
                     .iter()
                     .map(|s| {
                         format!(
-                            "<li><a class=\"mod\" href=\"{}index.html\">{}</a></li>",
+                            "<li><a class=\"crate mod\" href=\"{}index.html\">{}</a></li>",
                             ensure_trailing_slash(s),
                             s
                         )

--- a/src/librustdoc/html/static/themes/ayu.css
+++ b/src/librustdoc/html/static/themes/ayu.css
@@ -178,6 +178,9 @@ pre {
 .content span.externcrate, .content span.mod, .content a.mod {
 	color: #acccf9;
 }
+.content ul.crate a.crate {
+	font: 16px/1.6 "Fira Sans";
+}
 .content span.struct, .content a.struct {
 	color: #ffa0a5;
 }

--- a/src/test/rustdoc/index-page.rs
+++ b/src/test/rustdoc/index-page.rs
@@ -6,6 +6,6 @@
 
 // @has foo/../index.html
 // @has - '//span[@class="in-band"]' 'List of all crates'
-// @has - '//ul[@class="mod"]//a[@href="foo/index.html"]' 'foo'
-// @has - '//ul[@class="mod"]//a[@href="all_item_types/index.html"]' 'all_item_types'
+// @has - '//ul[@class="crate mod"]//a[@href="foo/index.html"]' 'foo'
+// @has - '//ul[@class="crate mod"]//a[@href="all_item_types/index.html"]' 'all_item_types'
 pub struct Foo;


### PR DESCRIPTION
Fira Sans is what's used for module lists and other item lists.
Previously, the default body font, "Source Serif Pro", was used for
crate lists, which didn't visually match other item lists.

@rustbot modify labels: T-rustdoc