### PR TITLE
Use Arc::clone and Rc::clone in documentation

### DIFF
--- a/library/core/src/pin.rs
+++ b/library/core/src/pin.rs
@@ -541,7 +541,7 @@ impl<P: Deref> Pin<P> {
     /// use std::pin::Pin;
     ///
     /// fn move_pinned_rc<T>(mut x: Rc<T>) {
-    ///     let pinned = unsafe { Pin::new_unchecked(x.clone()) };
+    ///     let pinned = unsafe { Pin::new_unchecked(Rc::clone(&x)) };
     ///     {
     ///         let p: Pin<&T> = pinned.as_ref();
     ///         // This should mean the pointee can never move again.

--- a/library/core/src/sync/atomic.rs
+++ b/library/core/src/sync/atomic.rs
@@ -76,7 +76,7 @@
 //! fn main() {
 //!     let spinlock = Arc::new(AtomicUsize::new(1));
 //!
-//!     let spinlock_clone = spinlock.clone();
+//!     let spinlock_clone = Arc::clone(&spinlock);
 //!     let thread = thread::spawn(move|| {
 //!         spinlock_clone.store(0, Ordering::SeqCst);
 //!     });

--- a/library/std/src/collections/hash/map.rs
+++ b/library/std/src/collections/hash/map.rs
@@ -2381,7 +2381,7 @@ impl<'a, K, V> OccupiedEntry<'a, K, V> {
     /// use std::rc::Rc;
     ///
     /// let mut map: HashMap<Rc<String>, u32> = HashMap::new();
-    /// let mut known_strings: Vec<Rc<String>> = Vec::new();
+    /// let known_strings: Vec<Rc<String>> = Vec::new();
     ///
     /// // Initialise known strings, run program, etc.
     ///
@@ -2389,7 +2389,7 @@ impl<'a, K, V> OccupiedEntry<'a, K, V> {
     ///
     /// fn reclaim_memory(map: &mut HashMap<Rc<String>, u32>, known_strings: &[Rc<String>] ) {
     ///     for s in known_strings {
-    ///         if let Entry::Occupied(entry) = map.entry(s.clone()) {
+    ///         if let Entry::Occupied(entry) = map.entry(Rc::clone(s)) {
     ///             // Replaces the entry's key with our version of it in `known_strings`.
     ///             entry.replace_key();
     ///         }

--- a/library/std/src/sync/barrier.rs
+++ b/library/std/src/sync/barrier.rs
@@ -13,7 +13,7 @@ use crate::sync::{Condvar, Mutex};
 /// let mut handles = Vec::with_capacity(10);
 /// let barrier = Arc::new(Barrier::new(10));
 /// for _ in 0..10 {
-///     let c = barrier.clone();
+///     let c = Arc::clone(&barrier);
 ///     // The same messages will be printed together.
 ///     // You will NOT see any interleaving.
 ///     handles.push(thread::spawn(move|| {
@@ -110,7 +110,7 @@ impl Barrier {
     /// let mut handles = Vec::with_capacity(10);
     /// let barrier = Arc::new(Barrier::new(10));
     /// for _ in 0..10 {
-    ///     let c = barrier.clone();
+    ///     let c = Arc::clone(&barrier);
     ///     // The same messages will be printed together.
     ///     // You will NOT see any interleaving.
     ///     handles.push(thread::spawn(move|| {

--- a/library/std/src/sync/condvar.rs
+++ b/library/std/src/sync/condvar.rs
@@ -33,7 +33,7 @@ impl WaitTimeoutResult {
     /// use std::time::Duration;
     ///
     /// let pair = Arc::new((Mutex::new(false), Condvar::new()));
-    /// let pair2 = pair.clone();
+    /// let pair2 = Arc::clone(&pair);
     ///
     /// thread::spawn(move || {
     ///     let (lock, cvar) = &*pair2;
@@ -90,7 +90,7 @@ impl WaitTimeoutResult {
 /// use std::thread;
 ///
 /// let pair = Arc::new((Mutex::new(false), Condvar::new()));
-/// let pair2 = pair.clone();
+/// let pair2 = Arc::clone(&pair);
 ///
 /// // Inside of our lock, spawn a new thread, and then wait for it to start.
 /// thread::spawn(move|| {
@@ -173,7 +173,7 @@ impl Condvar {
     /// use std::thread;
     ///
     /// let pair = Arc::new((Mutex::new(false), Condvar::new()));
-    /// let pair2 = pair.clone();
+    /// let pair2 = Arc::clone(&pair);
     ///
     /// thread::spawn(move|| {
     ///     let (lock, cvar) = &*pair2;
@@ -229,7 +229,7 @@ impl Condvar {
     /// use std::thread;
     ///
     /// let pair = Arc::new((Mutex::new(true), Condvar::new()));
-    /// let pair2 = pair.clone();
+    /// let pair2 = Arc::clone(&pair);
     ///
     /// thread::spawn(move|| {
     ///     let (lock, cvar) = &*pair2;
@@ -288,7 +288,7 @@ impl Condvar {
     /// use std::thread;
     ///
     /// let pair = Arc::new((Mutex::new(false), Condvar::new()));
-    /// let pair2 = pair.clone();
+    /// let pair2 = Arc::clone(&pair);
     ///
     /// thread::spawn(move|| {
     ///     let (lock, cvar) = &*pair2;
@@ -360,7 +360,7 @@ impl Condvar {
     /// use std::time::Duration;
     ///
     /// let pair = Arc::new((Mutex::new(false), Condvar::new()));
-    /// let pair2 = pair.clone();
+    /// let pair2 = Arc::clone(&pair);
     ///
     /// thread::spawn(move|| {
     ///     let (lock, cvar) = &*pair2;
@@ -429,7 +429,7 @@ impl Condvar {
     /// use std::time::Duration;
     ///
     /// let pair = Arc::new((Mutex::new(true), Condvar::new()));
-    /// let pair2 = pair.clone();
+    /// let pair2 = Arc::clone(&pair);
     ///
     /// thread::spawn(move|| {
     ///     let (lock, cvar) = &*pair2;
@@ -493,7 +493,7 @@ impl Condvar {
     /// use std::thread;
     ///
     /// let pair = Arc::new((Mutex::new(false), Condvar::new()));
-    /// let pair2 = pair.clone();
+    /// let pair2 = Arc::clone(&pair);
     ///
     /// thread::spawn(move|| {
     ///     let (lock, cvar) = &*pair2;
@@ -533,7 +533,7 @@ impl Condvar {
     /// use std::thread;
     ///
     /// let pair = Arc::new((Mutex::new(false), Condvar::new()));
-    /// let pair2 = pair.clone();
+    /// let pair2 = Arc::clone(&pair);
     ///
     /// thread::spawn(move|| {
     ///     let (lock, cvar) = &*pair2;

--- a/library/std/src/sync/mutex.rs
+++ b/library/std/src/sync/mutex.rs
@@ -85,7 +85,7 @@ use crate::sys_common::poison::{self, LockResult, TryLockError, TryLockResult};
 /// use std::thread;
 ///
 /// let lock = Arc::new(Mutex::new(0_u32));
-/// let lock2 = lock.clone();
+/// let lock2 = Arc::clone(&lock);
 ///
 /// let _ = thread::spawn(move || -> () {
 ///     // This thread will acquire the mutex first, unwrapping the result of
@@ -256,7 +256,7 @@ impl<T: ?Sized> Mutex<T> {
     /// use std::thread;
     ///
     /// let mutex = Arc::new(Mutex::new(0));
-    /// let c_mutex = mutex.clone();
+    /// let c_mutex = Arc::clone(&mutex);
     ///
     /// thread::spawn(move || {
     ///     *c_mutex.lock().unwrap() = 10;
@@ -292,7 +292,7 @@ impl<T: ?Sized> Mutex<T> {
     /// use std::thread;
     ///
     /// let mutex = Arc::new(Mutex::new(0));
-    /// let c_mutex = mutex.clone();
+    /// let c_mutex = Arc::clone(&mutex);
     ///
     /// thread::spawn(move || {
     ///     let mut lock = c_mutex.try_lock();
@@ -328,7 +328,7 @@ impl<T: ?Sized> Mutex<T> {
     /// use std::thread;
     ///
     /// let mutex = Arc::new(Mutex::new(0));
-    /// let c_mutex = mutex.clone();
+    /// let c_mutex = Arc::clone(&mutex);
     ///
     /// let _ = thread::spawn(move || {
     ///     let _lock = c_mutex.lock().unwrap();

--- a/library/std/src/sync/rwlock.rs
+++ b/library/std/src/sync/rwlock.rs
@@ -162,7 +162,7 @@ impl<T: ?Sized> RwLock<T> {
     /// use std::thread;
     ///
     /// let lock = Arc::new(RwLock::new(1));
-    /// let c_lock = lock.clone();
+    /// let c_lock = Arc::clone(&lock);
     ///
     /// let n = lock.read().unwrap();
     /// assert_eq!(*n, 1);
@@ -318,7 +318,7 @@ impl<T: ?Sized> RwLock<T> {
     /// use std::thread;
     ///
     /// let lock = Arc::new(RwLock::new(0));
-    /// let c_lock = lock.clone();
+    /// let c_lock = Arc::clone(&lock);
     ///
     /// let _ = thread::spawn(move || {
     ///     let _lock = c_lock.write().unwrap();

--- a/library/std/src/sys_common/poison.rs
+++ b/library/std/src/sys_common/poison.rs
@@ -65,7 +65,7 @@ pub struct Guard {
 /// let mutex = Arc::new(Mutex::new(1));
 ///
 /// // poison the mutex
-/// let c_mutex = mutex.clone();
+/// let c_mutex = Arc::clone(&mutex);
 /// let _ = thread::spawn(move || {
 ///     let mut data = c_mutex.lock().unwrap();
 ///     *data = 2;
@@ -168,7 +168,7 @@ impl<T> PoisonError<T> {
     /// let mutex = Arc::new(Mutex::new(HashSet::new()));
     ///
     /// // poison the mutex
-    /// let c_mutex = mutex.clone();
+    /// let c_mutex = Arc::clone(&mutex);
     /// let _ = thread::spawn(move || {
     ///     let mut data = c_mutex.lock().unwrap();
     ///     data.insert(10);


### PR DESCRIPTION
This PR replaces uses of `x.clone()` by `Rc::clone(&x)` (or `Arc::clone(&x)`) to better match the documentation for those types.

@rustbot modify labels: T-doc