### PR TITLE
[WIP] Remove some `FatalError.raise()`s in StringReader

### DIFF
--- a/compiler/rustc_parse/src/lexer/mod.rs
+++ b/compiler/rustc_parse/src/lexer/mod.rs
@@ -169,7 +169,6 @@ impl<'a> StringReader<'a> {
                             error_code!(E0758),
                         )
                         .emit();
-                    FatalError.raise();
                 }
                 match doc_style {
                     Some(doc_style) => {
@@ -336,9 +335,8 @@ impl<'a> StringReader<'a> {
                             error_code!(E0762),
                         )
                         .emit();
-                    FatalError.raise();
                 }
-                (token::Char, Mode::Char, 1, 1) // ' '
+                (token::Char, Mode::Char, 1, if terminated { 1 } else { 0 }) // ' '
             }
             rustc_lexer::LiteralKind::Byte { terminated } => {
                 if !terminated {
@@ -350,9 +348,8 @@ impl<'a> StringReader<'a> {
                             error_code!(E0763),
                         )
                         .emit();
-                    FatalError.raise();
                 }
-                (token::Byte, Mode::Byte, 2, 1) // b' '
+                (token::Byte, Mode::Byte, 2, if terminated { 1 } else { 0 }) // b' '
             }
             rustc_lexer::LiteralKind::Str { terminated } => {
                 if !terminated {
@@ -364,9 +361,8 @@ impl<'a> StringReader<'a> {
                             error_code!(E0765),
                         )
                         .emit();
-                    FatalError.raise();
                 }
-                (token::Str, Mode::Str, 1, 1) // " "
+                (token::Str, Mode::Str, 1, if terminated { 1 } else { 0 }) // " "
             }
             rustc_lexer::LiteralKind::ByteStr { terminated } => {
                 if !terminated {
@@ -378,9 +374,8 @@ impl<'a> StringReader<'a> {
                             error_code!(E0766),
                         )
                         .emit();
-                    FatalError.raise();
                 }
-                (token::ByteStr, Mode::ByteStr, 2, 1) // b" "
+                (token::ByteStr, Mode::ByteStr, 2, if terminated { 1 } else { 0 }) // b" "
             }
             rustc_lexer::LiteralKind::RawStr { n_hashes, err } => {
                 self.report_raw_str_error(start, err);

--- a/src/test/ui/codemap_tests/tab_2.stderr
+++ b/src/test/ui/codemap_tests/tab_2.stderr
@@ -1,11 +1,35 @@
 error[E0765]: unterminated double quote string
   --> $DIR/tab_2.rs:4:7
    |
-LL |                   """;
+LL |                   """; //~ ERROR unterminated double quote
    |  ___________________^
 LL | | }
    | |__^
 
-error: aborting due to previous error
+error: this file contains an unclosed delimiter
+  --> $DIR/tab_2.rs:5:3
+   |
+LL | fn main() {
+   |           - unclosed delimiter
+LL |                 """; //~ ERROR unterminated double quote
+LL | }
+   |   ^
+error: expected one of `.`, `;`, `?`, `}`, or an operator, found `"; //~ ERROR unterminated double quote
+}
+"`
+  --> $DIR/tab_2.rs:4:7
+   |
+LL |   fn main() {
+   |             - unclosed delimiter
+LL |                   """; //~ ERROR unterminated double quote
+   |                     ^
+   |                     |
+   |                     expected one of `.`, `;`, `?`, `}`, or an operator
+   |  ___________________help: `}` may belong here
+   | |
+LL | | }
+   | |__^ unexpected token
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0765`.

--- a/src/test/ui/issues/issue-44078.stderr
+++ b/src/test/ui/issues/issue-44078.stderr
@@ -6,6 +6,31 @@ LL |       "😊"";
 LL | | }
    | |__^
 
-error: aborting due to previous error
+error: this file contains an unclosed delimiter
+  --> $DIR/issue-44078.rs:3:3
+   |
+LL | fn main() {
+   |           - unclosed delimiter
+LL |     "😊"";
+LL | }
+   |   ^
+
+error: expected one of `.`, `;`, `?`, `}`, or an operator, found `";
+}
+"`
+  --> $DIR/issue-44078.rs:2:8
+   |
+LL |   fn main() {
+   |             - unclosed delimiter
+LL |       "😊"";
+   |           ^
+   |           |
+   |           expected one of `.`, `;`, `?`, `}`, or an operator
+   |  _________help: `}` may belong here
+   | |
+LL | | }
+   | |__^ unexpected token
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0765`.

--- a/src/test/ui/parser/byte-literals.stderr
+++ b/src/test/ui/parser/byte-literals.stderr
@@ -40,6 +40,17 @@ error[E0763]: unterminated byte constant
 LL |     b'a
    |      ^^^^
 
-error: aborting due to 7 previous errors
+error: character literal may only contain one codepoint
+  --> $DIR/byte-literals.rs:11:6
+   |
+LL |     b'a
+   |      ^^^^^
+   |
+help: if you meant to write a byte string literal, use double quotes
+   |
+LL |     b"a  "/~ ERROR unterminated byte constant [E0763]
+   |      ^^^^^
+
+error: aborting due to 8 previous errors
 
 For more information about this error, try `rustc --explain E0763`.

--- a/src/test/ui/parser/byte-string-literals.stderr
+++ b/src/test/ui/parser/byte-string-literals.stderr
@@ -30,6 +30,26 @@ LL |       b"a
 LL | | }
    | |__^
 
-error: aborting due to 5 previous errors
+error: this file contains an unclosed delimiter
+  --> $DIR/byte-string-literals.rs:8:3
+   |
+LL | pub fn main() {
+   |               - unclosed delimiter
+...
+LL | }
+   |   ^
 
-For more information about this error, try `rustc --explain E0766`.
+error[E0308]: mismatched types
+  --> $DIR/byte-string-literals.rs:7:5
+   |
+LL |   pub fn main() {
+   |                 - expected `()` because of default return type
+...
+LL | /     b"a
+LL | | }
+   | |__^ expected `()`, found `&[u8; 53]`
+
+error: aborting due to 7 previous errors
+
+Some errors have detailed explanations: E0308, E0766.
+For more information about an error, try `rustc --explain E0308`.

--- a/src/test/ui/parser/lex-bad-char-literals-4.stderr
+++ b/src/test/ui/parser/lex-bad-char-literals-4.stderr
@@ -4,6 +4,26 @@ error[E0762]: unterminated character literal
 LL |     '●
    |     ^^^^
 
-error: aborting due to previous error
+error: character literal may only contain one codepoint
+  --> $DIR/lex-bad-char-literals-4.rs:4:5
+   |
+LL |     '●
+   |     ^^^^^
+   |
+help: if you meant to write a `str` literal, use double quotes
+   |
+LL |     "●  "/~ ERROR: unterminated character literal
+   |     ^^^^^
 
-For more information about this error, try `rustc --explain E0762`.
+error[E0601]: `main` function not found in crate `lex_bad_char_literals_4`
+  --> $DIR/lex-bad-char-literals-4.rs:3:1
+   |
+LL | / static c: char =
+LL | |     '●
+LL | | ;
+   | |_^ consider adding a `main` function to `$DIR/lex-bad-char-literals-4.rs`
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0601, E0762.
+For more information about an error, try `rustc --explain E0601`.

--- a/src/test/ui/parser/lex-bad-char-literals-7.stderr
+++ b/src/test/ui/parser/lex-bad-char-literals-7.stderr
@@ -16,6 +16,26 @@ error[E0762]: unterminated character literal
 LL |     let _ = ' hello // here's a comment
    |             ^^^^^^^^
 
-error: aborting due to 3 previous errors
+error: character literal may only contain one codepoint
+  --> $DIR/lex-bad-char-literals-7.rs:11:13
+   |
+LL |     let _ = ' hello // here's a comment
+   |             ^^^^^^^^^
+   |
+help: if you meant to write a `str` literal, use double quotes
+   |
+LL |     let _ = " hello "/ here's a comment
+   |             ^^^^^^^^^
+
+error: expected `;`, found `}`
+  --> $DIR/lex-bad-char-literals-7.rs:11:21
+   |
+LL |     let _ = ' hello // here's a comment
+   |                     ^ help: add `;` here
+LL |
+LL | }
+   | - unexpected token
+
+error: aborting due to 5 previous errors
 
 For more information about this error, try `rustc --explain E0762`.

--- a/src/test/ui/parser/unbalanced-doublequote.stderr
+++ b/src/test/ui/parser/unbalanced-doublequote.stderr
@@ -5,6 +5,25 @@ LL | /     "
 LL | | }
    | |__^
 
-error: aborting due to previous error
+error: this file contains an unclosed delimiter
+  --> $DIR/unbalanced-doublequote.rs:6:3
+   |
+LL | fn main() {
+   |           - unclosed delimiter
+LL |     "
+LL | }
+   |   ^
 
-For more information about this error, try `rustc --explain E0765`.
+error[E0308]: mismatched types
+  --> $DIR/unbalanced-doublequote.rs:5:5
+   |
+LL |   fn main() {
+   |             - expected `()` because of default return type
+LL | /     "
+LL | | }
+   | |__^ expected `()`, found `&str`
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0308, E0765.
+For more information about an error, try `rustc --explain E0308`.

--- a/src/test/ui/unterminated-comment.stderr
+++ b/src/test/ui/unterminated-comment.stderr
@@ -4,6 +4,13 @@ error[E0758]: unterminated block comment
 LL | /*
    | ^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to previous error
+error[E0601]: `main` function not found in crate `unterminated_comment`
+  --> $DIR/unterminated-comment.rs:1:20
+   |
+LL | /*
+   |                    ^ consider adding a `main` function to `$DIR/unterminated-comment.rs`
 
-For more information about this error, try `rustc --explain E0758`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0601, E0758.
+For more information about an error, try `rustc --explain E0601`.

--- a/src/test/ui/unterminated-doc-comment.stderr
+++ b/src/test/ui/unterminated-doc-comment.stderr
@@ -4,6 +4,13 @@ error[E0758]: unterminated block doc-comment
 LL | /*!
    | ^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to previous error
+error[E0601]: `main` function not found in crate `unterminated_doc_comment`
+  --> $DIR/unterminated-doc-comment.rs:1:1
+   |
+LL | /*!
+   | ^^^^^^^^^^^^^^^^^^^^ consider adding a `main` function to `$DIR/unterminated-doc-comment.rs`
 
-For more information about this error, try `rustc --explain E0758`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0601, E0758.
+For more information about an error, try `rustc --explain E0601`.


### PR DESCRIPTION
I currently have some issues with compiling `rustc` locally, so I'm opening this to exploit the CI.

Helps with #76065.
r? @ghost for now