### PR TITLE
Update MinGW instructions to include ninja

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ build.
    # Install build tools needed for Rust. If you're building a 32-bit compiler,
    # then replace "x86_64" below with "i686". If you've already got git, python,
    # or CMake installed and in PATH you can remove them from this list. Note
-   # that it is important that you do **not** use the 'python2' and 'cmake'
+   # that it is important that you do **not** use the 'python2', 'cmake' and 'ninja'
    # packages from the 'msys2' subsystem. The build has historically been known
    # to fail with these packages.
    $ pacman -S git \
@@ -121,7 +121,8 @@ build.
                tar \
                mingw-w64-x86_64-python \
                mingw-w64-x86_64-cmake \
-               mingw-w64-x86_64-gcc
+               mingw-w64-x86_64-gcc \
+               mingw-w64-x86_64-ninja
    ```
 
 4. Navigate to Rust's source code (or clone it), then build it:


### PR DESCRIPTION
Rust now requires `ninja` to build, so the MinGW build instructions are updated to reflect this.

Like for `python` and `cmake`, the `mingw-w64-x86_64-ninja` package should be used. The default package from the `msys2` subsystem doesn't handle paths correctly on windows.