### PR TITLE
Make `cow_is_borrowed` methods const

### DIFF
--- a/library/alloc/src/borrow.rs
+++ b/library/alloc/src/borrow.rs
@@ -217,7 +217,7 @@ impl<B: ?Sized + ToOwned> Cow<'_, B> {
     /// assert!(!bull.is_borrowed());
     /// ```
     #[unstable(feature = "cow_is_borrowed", issue = "65143")]
-    pub fn is_borrowed(&self) -> bool {
+    pub const fn is_borrowed(&self) -> bool {
         match *self {
             Borrowed(_) => true,
             Owned(_) => false,
@@ -239,7 +239,7 @@ impl<B: ?Sized + ToOwned> Cow<'_, B> {
     /// assert!(!bull.is_owned());
     /// ```
     #[unstable(feature = "cow_is_borrowed", issue = "65143")]
-    pub fn is_owned(&self) -> bool {
+    pub const fn is_owned(&self) -> bool {
         !self.is_borrowed()
     }
 

--- a/src/test/ui/consts/cow-is-borrowed.rs
+++ b/src/test/ui/consts/cow-is-borrowed.rs
@@ -1,0 +1,15 @@
+// run-pass
+
+#![feature(cow_is_borrowed)]
+
+use std::borrow::Cow;
+
+fn main() {
+    const COW: Cow<str> = Cow::Borrowed("moo");
+
+    const IS_BORROWED: bool = COW.is_borrowed();
+    assert!(IS_BORROWED);
+
+    const IS_OWNED: bool = COW.is_owned();
+    assert!(!IS_OWNED);
+}


### PR DESCRIPTION
Constify the following methods of `alloc::borrow::Cow`:
 - `is_borrowed`
 - `is_owned`

Analogous to the const methods `is_some` and `is_none` for Option, and `is_ok` and `is_err` for Result.

These methods are still unstable under `cow_is_borrowed`.
Possible because of #49146 (Allow if and match in constants).

Tracking issue: #65143