### PR TITLE
Give a better error message for duplicate built-in macros

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes.rs
+++ b/compiler/rustc_error_codes/src/error_codes.rs
@@ -454,6 +454,7 @@ E0768: include_str!("./error_codes/E0768.md"),
 E0769: include_str!("./error_codes/E0769.md"),
 E0770: include_str!("./error_codes/E0770.md"),
 E0771: include_str!("./error_codes/E0771.md"),
+E0773: include_str!("./error_codes/E0773.md"),
 ;
 //  E0006, // merged with E0005
 //  E0008, // cannot bind by-move into a pattern guard

--- a/compiler/rustc_error_codes/src/error_codes/E0773.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0773.md
@@ -1,0 +1,38 @@
+A builtin-macro was defined more than once.
+
+Erroneous code example:
+
+```compile_fail,E0773
+#![feature(decl_macro)]
+#![feature(rustc_attrs)]
+
+#[rustc_builtin_macro]
+pub macro test($item:item) {
+    /* compiler built-in */
+}
+
+mod inner {
+    #[rustc_builtin_macro]
+    pub macro test($item:item) {
+        /* compiler built-in */
+    }
+}
+```
+
+To fix the issue, remove the duplicate declaration:
+
+```
+#![feature(decl_macro)]
+#![feature(rustc_attrs)]
+
+#[rustc_builtin_macro]
+pub macro test($item:item) {
+    /* compiler built-in */
+}
+```
+
+In very rare edge cases, this may happen when loading `core` or `std` twice,
+once with `check` metadata and once with `build` metadata.
+For more information, see [#75176].
+
+[#75176]: https://github.com/rust-lang/rust/pull/75176#issuecomment-683234468

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -867,6 +867,12 @@ pub struct ExternPreludeEntry<'a> {
     pub introduced_by_item: bool,
 }
 
+/// Used for better errors for E0773
+enum BuiltinMacroState {
+    NotYetSeen(SyntaxExtension),
+    AlreadySeen(Span),
+}
+
 /// The main resolver class.
 ///
 /// This is the visitor that walks the whole crate.
@@ -960,7 +966,7 @@ pub struct Resolver<'a> {
 
     crate_loader: CrateLoader<'a>,
     macro_names: FxHashSet<Ident>,
-    builtin_macros: FxHashMap<Symbol, SyntaxExtension>,
+    builtin_macros: FxHashMap<Symbol, BuiltinMacroState>,
     registered_attrs: FxHashSet<Ident>,
     registered_tools: FxHashSet<Ident>,
     macro_use_prelude: FxHashMap<Symbol, &'a NameBinding<'a>>,

--- a/src/test/ui/macros/duplicate-builtin.rs
+++ b/src/test/ui/macros/duplicate-builtin.rs
@@ -1,0 +1,17 @@
+// compile-flags:--crate-type lib
+#![feature(decl_macro)]
+#![feature(rustc_attrs)]
+
+#[rustc_builtin_macro]
+pub macro test($item:item) {
+//~^ NOTE previously defined
+    /* compiler built-in */
+}
+
+mod inner {
+    #[rustc_builtin_macro]
+    pub macro test($item:item) {
+    //~^ ERROR attempted to define built-in macro more than once [E0773]
+        /* compiler built-in */
+    }
+}

--- a/src/test/ui/macros/duplicate-builtin.stderr
+++ b/src/test/ui/macros/duplicate-builtin.stderr
@@ -1,0 +1,21 @@
+error[E0773]: attempted to define built-in macro more than once
+  --> $DIR/duplicate-builtin.rs:13:5
+   |
+LL | /     pub macro test($item:item) {
+LL | |
+LL | |         /* compiler built-in */
+LL | |     }
+   | |_____^
+   |
+note: previously defined here
+  --> $DIR/duplicate-builtin.rs:6:1
+   |
+LL | / pub macro test($item:item) {
+LL | |
+LL | |     /* compiler built-in */
+LL | | }
+   | |_^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0773`.

--- a/src/test/ui/macros/unknown-builtin.rs
+++ b/src/test/ui/macros/unknown-builtin.rs
@@ -1,4 +1,4 @@
-// error-pattern: cannot find a built-in macro with name `line`
+// error-pattern: attempted to define built-in macro more than once
 
 #![feature(rustc_attrs)]
 
@@ -6,7 +6,7 @@
 macro_rules! unknown { () => () } //~ ERROR cannot find a built-in macro with name `unknown`
 
 #[rustc_builtin_macro]
-macro_rules! line { () => () }
+macro_rules! line { () => () } //~ NOTE previously defined here
 
 fn main() {
     line!();

--- a/src/test/ui/macros/unknown-builtin.stderr
+++ b/src/test/ui/macros/unknown-builtin.stderr
@@ -4,7 +4,7 @@ error: cannot find a built-in macro with name `unknown`
 LL | macro_rules! unknown { () => () }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: cannot find a built-in macro with name `line`
+error[E0773]: attempted to define built-in macro more than once
   --> $SRC_DIR/core/src/macros/mod.rs:LL:COL
    |
 LL | /     macro_rules! line {
@@ -13,6 +13,13 @@ LL | |             /* compiler built-in */
 LL | |         };
 LL | |     }
    | |_____^
+   |
+note: previously defined here
+  --> $DIR/unknown-builtin.rs:9:1
+   |
+LL | macro_rules! line { () => () }
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 
+For more information about this error, try `rustc --explain E0773`.


### PR DESCRIPTION
Minor follow-up to https://github.com/rust-lang/rust/pull/75176 giving a better error message for duplicate builtin macros. This would have made it a little easier to debug.

r? @petrochenkov