### PR TITLE
Rollup of 9 pull requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ build.
    # Install build tools needed for Rust. If you're building a 32-bit compiler,
    # then replace "x86_64" below with "i686". If you've already got git, python,
    # or CMake installed and in PATH you can remove them from this list. Note
-   # that it is important that you do **not** use the 'python2' and 'cmake'
+   # that it is important that you do **not** use the 'python2', 'cmake' and 'ninja'
    # packages from the 'msys2' subsystem. The build has historically been known
    # to fail with these packages.
    $ pacman -S git \
@@ -121,7 +121,8 @@ build.
                tar \
                mingw-w64-x86_64-python \
                mingw-w64-x86_64-cmake \
-               mingw-w64-x86_64-gcc
+               mingw-w64-x86_64-gcc \
+               mingw-w64-x86_64-ninja
    ```
 
 4. Navigate to Rust's source code (or clone it), then build it:

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -111,7 +111,7 @@ macro_rules! acquire {
 ///
 /// # Cloning references
 ///
-/// Creating a new reference from an existing reference counted pointer is done using the
+/// Creating a new reference from an existing reference-counted pointer is done using the
 /// `Clone` trait implemented for [`Arc<T>`][Arc] and [`Weak<T>`][Weak].
 ///
 /// ```

--- a/library/alloc/src/vec.rs
+++ b/library/alloc/src/vec.rs
@@ -116,8 +116,10 @@ use crate::raw_vec::RawVec;
 /// assert_eq!(vec, [0, 0, 0, 0, 0]);
 ///
 /// // The following is equivalent, but potentially slower:
-/// let mut vec1 = Vec::with_capacity(5);
-/// vec1.resize(5, 0);
+/// let mut vec = Vec::with_capacity(5);
+/// assert_eq!(vec, []);
+/// vec.resize(5, 0);
+/// assert_eq!(vec, [0, 0, 0, 0, 0]);
 /// ```
 ///
 /// Use a `Vec<T>` as an efficient stack:

--- a/library/alloc/src/vec.rs
+++ b/library/alloc/src/vec.rs
@@ -3026,7 +3026,10 @@ impl<T> Drain<'_, T> {
     }
 }
 
-/// An iterator produced by calling `drain_filter` on Vec.
+/// A draining iterator with filter predicate for `Vec`.
+///
+/// This struct is created by [`Vec::drain_filter()`].
+/// See its documentation for more.
 #[unstable(feature = "drain_filter", reason = "recently added", issue = "43244")]
 #[derive(Debug)]
 pub struct DrainFilter<'a, T, F>

--- a/library/alloc/src/vec.rs
+++ b/library/alloc/src/vec.rs
@@ -1567,7 +1567,7 @@ impl<T: Clone> Vec<T> {
     /// This method requires `T` to implement [`Clone`],
     /// in order to be able to clone the passed value.
     /// If you need more flexibility (or want to rely on [`Default`] instead of
-    /// [`Clone`]), use [`resize_with`].
+    /// [`Clone`]), use [`Vec::resize_with`].
     ///
     /// # Examples
     ///
@@ -1580,8 +1580,6 @@ impl<T: Clone> Vec<T> {
     /// vec.resize(2, 0);
     /// assert_eq!(vec, [1, 2]);
     /// ```
-    ///
-    /// [`resize_with`]: Vec::resize_with
     #[stable(feature = "vec_resize", since = "1.5.0")]
     pub fn resize(&mut self, new_len: usize, value: T) {
         let len = self.len();

--- a/library/alloc/src/vec.rs
+++ b/library/alloc/src/vec.rs
@@ -1610,6 +1610,8 @@ impl<T: Clone> Vec<T> {
     /// vec.extend_from_slice(&[2, 3, 4]);
     /// assert_eq!(vec, [1, 2, 3, 4]);
     /// ```
+    ///
+    /// [`extend`]: Vec::extend
     #[stable(feature = "vec_extend_from_slice", since = "1.6.0")]
     pub fn extend_from_slice(&mut self, other: &[T]) {
         self.spec_extend(other.iter())

--- a/library/alloc/src/vec.rs
+++ b/library/alloc/src/vec.rs
@@ -3028,7 +3028,7 @@ impl<T> Drain<'_, T> {
 
 /// A draining iterator with filter predicate for `Vec`.
 ///
-/// This struct is created by [`Vec::drain_filter()`].
+/// This struct is created by [`Vec::drain_filter`].
 /// See its documentation for more.
 #[unstable(feature = "drain_filter", reason = "recently added", issue = "43244")]
 #[derive(Debug)]

--- a/library/alloc/src/vec.rs
+++ b/library/alloc/src/vec.rs
@@ -3026,7 +3026,7 @@ impl<T> Drain<'_, T> {
     }
 }
 
-/// A draining iterator with filter predicate for `Vec`.
+/// An iterator which uses a closure to determine if an element should be removed.
 ///
 /// This struct is created by [`Vec::drain_filter`].
 /// See its documentation for more.

--- a/library/alloc/src/vec.rs
+++ b/library/alloc/src/vec.rs
@@ -1610,8 +1610,6 @@ impl<T: Clone> Vec<T> {
     /// vec.extend_from_slice(&[2, 3, 4]);
     /// assert_eq!(vec, [1, 2, 3, 4]);
     /// ```
-    ///
-    /// [`extend`]: #method.extend
     #[stable(feature = "vec_extend_from_slice", since = "1.6.0")]
     pub fn extend_from_slice(&mut self, other: &[T]) {
         self.spec_extend(other.iter())

--- a/library/alloc/src/vec.rs
+++ b/library/alloc/src/vec.rs
@@ -117,7 +117,6 @@ use crate::raw_vec::RawVec;
 ///
 /// // The following is equivalent, but potentially slower:
 /// let mut vec = Vec::with_capacity(5);
-/// assert_eq!(vec, []);
 /// vec.resize(5, 0);
 /// assert_eq!(vec, [0, 0, 0, 0, 0]);
 /// ```

--- a/library/core/src/convert/mod.rs
+++ b/library/core/src/convert/mod.rs
@@ -134,8 +134,8 @@ pub const fn identity<T>(x: T) -> T {
 /// want to accept all references that can be converted to [`&str`] as an argument.
 /// Since both [`String`] and [`&str`] implement `AsRef<str>` we can accept both as input argument.
 ///
-/// [`Option<T>`]: crate::option::Option
-/// [`Result<T, E>`]: crate::result::Result
+/// [`Option<T>`]: Option
+/// [`Result<T, E>`]: Result
 /// [`Borrow`]: crate::borrow::Borrow
 /// [`Eq`]: crate::cmp::Eq
 /// [`Ord`]: crate::cmp::Ord
@@ -168,8 +168,8 @@ pub trait AsRef<T: ?Sized> {
 /// **Note: This trait must not fail**. If the conversion can fail, use a
 /// dedicated method which returns an [`Option<T>`] or a [`Result<T, E>`].
 ///
-/// [`Option<T>`]: crate::option::Option
-/// [`Result<T, E>`]: crate::result::Result
+/// [`Option<T>`]: Option
+/// [`Result<T, E>`]: Result
 ///
 /// # Generic Implementations
 ///
@@ -195,7 +195,7 @@ pub trait AsRef<T: ?Sized> {
 /// assert_eq!(*boxed_num, 1);
 /// ```
 ///
-/// [`Box<T>`]: crate::boxed::Box<T>
+/// [`Box<T>`]: ../../std/boxed/struct.Box.html
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait AsMut<T: ?Sized> {
     /// Performs the conversion.
@@ -269,10 +269,10 @@ pub trait AsMut<T: ?Sized> {
 /// is_hello(s);
 /// ```
 ///
-/// [`Option<T>`]: crate::option::Option
-/// [`Result<T, E>`]: crate::result::Result
+/// [`Option<T>`]: Option
+/// [`Result<T, E>`]: Result
 /// [`String`]: ../../std/string/struct.String.html
-/// [`Vec`]: crate::vec::Vec<T>
+/// [`Vec`]: ../../std/vec/struct.Vec.html
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait Into<T>: Sized {
     /// Performs the conversion.
@@ -358,9 +358,10 @@ pub trait Into<T>: Sized {
 /// }
 /// ```
 ///
-/// [`Option<T>`]: crate::option::Option
-/// [`Result<T, E>`]: crate::result::Result
+/// [`Option<T>`]: Option
+/// [`Result<T, E>`]: Result
 /// [`String`]: ../../std/string/struct.String.html
+/// [`from`]: From::from
 /// [book]: ../../book/ch09-00-error-handling.html
 #[rustc_diagnostic_item = "from_trait"]
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -418,7 +419,7 @@ pub trait TryInto<T>: Sized {
 /// # Generic Implementations
 ///
 /// - `TryFrom<T> for U` implies [`TryInto`]`<U> for T`
-/// - [`TryFrom::try_from`] is reflexive, which means that `TryFrom<T> for T`
+/// - [`try_from`] is reflexive, which means that `TryFrom<T> for T`
 /// is implemented and cannot fail -- the associated `Error` type for
 /// calling `T::try_from()` on a value of type `T` is [`Infallible`].
 /// When the [`!`] type is stabilized [`Infallible`] and [`!`] will be
@@ -467,7 +468,7 @@ pub trait TryInto<T>: Sized {
 /// assert!(try_successful_smaller_number.is_ok());
 /// ```
 ///
-/// [`i32::MAX`]: crate::i32::MAX
+/// [`try_from`]: TryFrom::try_from
 /// [`!`]: ../../std/primitive.never.html
 #[stable(feature = "try_from", since = "1.34.0")]
 pub trait TryFrom<T>: Sized {
@@ -670,8 +671,6 @@ impl AsRef<str> for str {
 /// the two `impl`s will start to overlap
 /// and therefore will be disallowed by the language’s trait coherence rules.
 ///
-/// [`Ok`]: super::result::Result::Ok
-/// [`Result`]: super::result::Result
 /// [never]: ../../std/primitive.never.html
 #[stable(feature = "convert_infallible", since = "1.34.0")]
 #[derive(Copy)]

--- a/library/core/src/convert/mod.rs
+++ b/library/core/src/convert/mod.rs
@@ -31,13 +31,6 @@
 //!   `into` themselves and `from` themselves
 //!
 //! See each trait for usage examples.
-//!
-//! [`Into`]: trait.Into.html
-//! [`From`]: trait.From.html
-//! [`TryFrom`]: trait.TryFrom.html
-//! [`TryInto`]: trait.TryInto.html
-//! [`AsRef`]: trait.AsRef.html
-//! [`AsMut`]: trait.AsMut.html
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
@@ -141,13 +134,11 @@ pub const fn identity<T>(x: T) -> T {
 /// want to accept all references that can be converted to [`&str`] as an argument.
 /// Since both [`String`] and [`&str`] implement `AsRef<str>` we can accept both as input argument.
 ///
-/// [`Option<T>`]: ../../std/option/enum.Option.html
-/// [`Result<T, E>`]: ../../std/result/enum.Result.html
-/// [`Borrow`]: ../../std/borrow/trait.Borrow.html
-/// [`Hash`]: ../../std/hash/trait.Hash.html
-/// [`Eq`]: ../../std/cmp/trait.Eq.html
-/// [`Ord`]: ../../std/cmp/trait.Ord.html
-/// [`&str`]: ../../std/primitive.str.html
+/// [`Option<T>`]: crate::option::Option
+/// [`Result<T, E>`]: crate::result::Result
+/// [`Borrow`]: crate::borrow::Borrow
+/// [`Eq`]: crate::cmp::Eq
+/// [`Ord`]: crate::cmp::Ord
 /// [`String`]: ../../std/string/struct.String.html
 ///
 /// ```
@@ -177,8 +168,8 @@ pub trait AsRef<T: ?Sized> {
 /// **Note: This trait must not fail**. If the conversion can fail, use a
 /// dedicated method which returns an [`Option<T>`] or a [`Result<T, E>`].
 ///
-/// [`Option<T>`]: ../../std/option/enum.Option.html
-/// [`Result<T, E>`]: ../../std/result/enum.Result.html
+/// [`Option<T>`]: crate::option::Option
+/// [`Result<T, E>`]: crate::result::Result
 ///
 /// # Generic Implementations
 ///
@@ -204,7 +195,7 @@ pub trait AsRef<T: ?Sized> {
 /// assert_eq!(*boxed_num, 1);
 /// ```
 ///
-/// [`Box<T>`]: ../../std/boxed/struct.Box.html
+/// [`Box<T>`]: crate::boxed::Box<T>
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait AsMut<T: ?Sized> {
     /// Performs the conversion.
@@ -278,13 +269,10 @@ pub trait AsMut<T: ?Sized> {
 /// is_hello(s);
 /// ```
 ///
-/// [`TryInto`]: trait.TryInto.html
-/// [`Option<T>`]: ../../std/option/enum.Option.html
-/// [`Result<T, E>`]: ../../std/result/enum.Result.html
+/// [`Option<T>`]: crate::option::Option
+/// [`Result<T, E>`]: crate::result::Result
 /// [`String`]: ../../std/string/struct.String.html
-/// [`From`]: trait.From.html
-/// [`Into`]: trait.Into.html
-/// [`Vec`]: ../../std/vec/struct.Vec.html
+/// [`Vec`]: crate::vec::Vec<T>
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait Into<T>: Sized {
     /// Performs the conversion.
@@ -370,12 +358,9 @@ pub trait Into<T>: Sized {
 /// }
 /// ```
 ///
-/// [`TryFrom`]: trait.TryFrom.html
-/// [`Option<T>`]: ../../std/option/enum.Option.html
-/// [`Result<T, E>`]: ../../std/result/enum.Result.html
+/// [`Option<T>`]: crate::option::Option
+/// [`Result<T, E>`]: crate::result::Result
 /// [`String`]: ../../std/string/struct.String.html
-/// [`Into`]: trait.Into.html
-/// [`from`]: trait.From.html#tymethod.from
 /// [book]: ../../book/ch09-00-error-handling.html
 #[rustc_diagnostic_item = "from_trait"]
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -404,9 +389,6 @@ pub trait From<T>: Sized {
 ///
 /// This suffers the same restrictions and reasoning as implementing
 /// [`Into`], see there for details.
-///
-/// [`TryFrom`]: trait.TryFrom.html
-/// [`Into`]: trait.Into.html
 #[stable(feature = "try_from", since = "1.34.0")]
 pub trait TryInto<T>: Sized {
     /// The type returned in the event of a conversion error.
@@ -436,7 +418,7 @@ pub trait TryInto<T>: Sized {
 /// # Generic Implementations
 ///
 /// - `TryFrom<T> for U` implies [`TryInto`]`<U> for T`
-/// - [`try_from`] is reflexive, which means that `TryFrom<T> for T`
+/// - [`TryFrom::try_from`] is reflexive, which means that `TryFrom<T> for T`
 /// is implemented and cannot fail -- the associated `Error` type for
 /// calling `T::try_from()` on a value of type `T` is [`Infallible`].
 /// When the [`!`] type is stabilized [`Infallible`] and [`!`] will be
@@ -485,11 +467,8 @@ pub trait TryInto<T>: Sized {
 /// assert!(try_successful_smaller_number.is_ok());
 /// ```
 ///
-/// [`try_from`]: trait.TryFrom.html#tymethod.try_from
-/// [`TryInto`]: trait.TryInto.html
-/// [`i32::MAX`]: ../../std/i32/constant.MAX.html
+/// [`i32::MAX`]: crate::i32::MAX
 /// [`!`]: ../../std/primitive.never.html
-/// [`Infallible`]: enum.Infallible.html
 #[stable(feature = "try_from", since = "1.34.0")]
 pub trait TryFrom<T>: Sized {
     /// The type returned in the event of a conversion error.
@@ -676,7 +655,6 @@ impl AsRef<str> for str {
 ///
 /// … and eventually deprecate `Infallible`.
 ///
-///
 /// However there is one case where `!` syntax can be used
 /// before `!` is stabilized as a full-fledged type: in the position of a function’s return type.
 /// Specifically, it is possible implementations for two different function pointer types:
@@ -692,10 +670,8 @@ impl AsRef<str> for str {
 /// the two `impl`s will start to overlap
 /// and therefore will be disallowed by the language’s trait coherence rules.
 ///
-/// [`Ok`]: ../result/enum.Result.html#variant.Ok
-/// [`Result`]: ../result/enum.Result.html
-/// [`TryFrom`]: trait.TryFrom.html
-/// [`Into`]: trait.Into.html
+/// [`Ok`]: super::result::Result::Ok
+/// [`Result`]: super::result::Result
 /// [never]: ../../std/primitive.never.html
 #[stable(feature = "convert_infallible", since = "1.34.0")]
 #[derive(Copy)]

--- a/library/core/src/convert/mod.rs
+++ b/library/core/src/convert/mod.rs
@@ -468,6 +468,7 @@ pub trait TryInto<T>: Sized {
 /// assert!(try_successful_smaller_number.is_ok());
 /// ```
 ///
+/// [`i32::MAX`]: crate::i32::MAX
 /// [`try_from`]: TryFrom::try_from
 /// [`!`]: ../../std/primitive.never.html
 #[stable(feature = "try_from", since = "1.34.0")]

--- a/library/core/src/iter/mod.rs
+++ b/library/core/src/iter/mod.rs
@@ -53,9 +53,7 @@
 //! more complex forms of processing. See the [Adapters](#adapters) section
 //! below for more details.
 //!
-//! [`Some(Item)`]: Some
-//! [`Iterator`]: trait.Iterator.html
-//! [`next`]: trait.Iterator.html#tymethod.next
+//! [`next`]: Iterator::next
 //! [`TryIter`]: ../../std/sync/mpsc/struct.TryIter.html
 //!
 //! # The three forms of iteration
@@ -154,13 +152,10 @@
 //! produce an iterator. What gives?
 //!
 //! There's a trait in the standard library for converting something into an
-//! iterator: [`IntoIterator`]. This trait has one method, [`into_iter`],
+//! iterator: [`IntoIterator`]. This trait has one method, [`IntoIterator::into_iter`],
 //! which converts the thing implementing [`IntoIterator`] into an iterator.
 //! Let's take a look at that `for` loop again, and what the compiler converts
 //! it into:
-//!
-//! [`IntoIterator`]: trait.IntoIterator.html
-//! [`into_iter`]: trait.IntoIterator.html#tymethod.into_iter
 //!
 //! ```
 //! let values = vec![1, 2, 3, 4, 5];
@@ -214,7 +209,7 @@
 //! often called 'iterator adapters', as they're a form of the 'adapter
 //! pattern'.
 //!
-//! Common iterator adapters include [`map`], [`take`], and [`filter`].
+//! Common iterator adapters include [`Iterator::map`], [`Iterator::take`], and [`Iterator::filter`].
 //! For more, see their documentation.
 //!
 //! If an iterator adapter panics, the iterator will be in an unspecified (but
@@ -222,16 +217,12 @@
 //! across versions of Rust, so you should avoid relying on the exact values
 //! returned by an iterator which panicked.
 //!
-//! [`map`]: trait.Iterator.html#method.map
-//! [`take`]: trait.Iterator.html#method.take
-//! [`filter`]: trait.Iterator.html#method.filter
-//!
 //! # Laziness
 //!
 //! Iterators (and iterator [adapters](#adapters)) are *lazy*. This means that
 //! just creating an iterator doesn't _do_ a whole lot. Nothing really happens
 //! until you call [`next`]. This is sometimes a source of confusion when
-//! creating an iterator solely for its side effects. For example, the [`map`]
+//! creating an iterator solely for its side effects. For example, the [`Iterator::map`]
 //! method calls a closure on each element it iterates over:
 //!
 //! ```
@@ -248,8 +239,8 @@
 //! do nothing unless consumed
 //! ```
 //!
-//! The idiomatic way to write a [`map`] for its side effects is to use a
-//! `for` loop or call the [`for_each`] method:
+//! The idiomatic way to write a [`Iterator::map`] for its side effects is to use a
+//! `for` loop or call the [`Iterator::for_each`] method:
 //!
 //! ```
 //! let v = vec![1, 2, 3, 4, 5];
@@ -261,13 +252,8 @@
 //! }
 //! ```
 //!
-//! [`map`]: trait.Iterator.html#method.map
-//! [`for_each`]: trait.Iterator.html#method.for_each
-//!
-//! Another common way to evaluate an iterator is to use the [`collect`]
+//! Another common way to evaluate an iterator is to use the [`Iterator::collect`]
 //! method to produce a new collection.
-//!
-//! [`collect`]: trait.Iterator.html#method.collect
 //!
 //! # Infinity
 //!
@@ -278,7 +264,7 @@
 //! let numbers = 0..;
 //! ```
 //!
-//! It is common to use the [`take`] iterator adapter to turn an infinite
+//! It is common to use the [`Iterator::take`] iterator adapter to turn an infinite
 //! iterator into a finite one:
 //!
 //! ```
@@ -294,7 +280,7 @@
 //!
 //! Bear in mind that methods on infinite iterators, even those for which a
 //! result can be determined mathematically in finite time, may not terminate.
-//! Specifically, methods such as [`min`], which in the general case require
+//! Specifically, methods such as [`Iterator::min`], which in the general case require
 //! traversing every element in the iterator, are likely not to return
 //! successfully for any infinite iterators.
 //!
@@ -304,9 +290,6 @@
 //! // `ones.min()` causes an infinite loop, so we won't reach this point!
 //! println!("The smallest number one is {}.", least);
 //! ```
-//!
-//! [`take`]: trait.Iterator.html#method.take
-//! [`min`]: trait.Iterator.html#method.min
 
 #![stable(feature = "rust1", since = "1.0.0")]
 

--- a/library/core/src/iter/mod.rs
+++ b/library/core/src/iter/mod.rs
@@ -152,10 +152,12 @@
 //! produce an iterator. What gives?
 //!
 //! There's a trait in the standard library for converting something into an
-//! iterator: [`IntoIterator`]. This trait has one method, [`IntoIterator::into_iter`],
+//! iterator: [`IntoIterator`]. This trait has one method, [`into_iter`],
 //! which converts the thing implementing [`IntoIterator`] into an iterator.
 //! Let's take a look at that `for` loop again, and what the compiler converts
 //! it into:
+//!
+//! [`into_iter`]: IntoIterator::into_iter
 //!
 //! ```
 //! let values = vec![1, 2, 3, 4, 5];
@@ -209,7 +211,7 @@
 //! often called 'iterator adapters', as they're a form of the 'adapter
 //! pattern'.
 //!
-//! Common iterator adapters include [`Iterator::map`], [`Iterator::take`], and [`Iterator::filter`].
+//! Common iterator adapters include [`map`], [`take`], and [`filter`].
 //! For more, see their documentation.
 //!
 //! If an iterator adapter panics, the iterator will be in an unspecified (but
@@ -217,12 +219,16 @@
 //! across versions of Rust, so you should avoid relying on the exact values
 //! returned by an iterator which panicked.
 //!
+//! [`map`]: Iterator::map
+//! [`take`]: Iterator::take
+//! [`filter`]: Iterator::filter
+//!
 //! # Laziness
 //!
 //! Iterators (and iterator [adapters](#adapters)) are *lazy*. This means that
 //! just creating an iterator doesn't _do_ a whole lot. Nothing really happens
 //! until you call [`next`]. This is sometimes a source of confusion when
-//! creating an iterator solely for its side effects. For example, the [`Iterator::map`]
+//! creating an iterator solely for its side effects. For example, the [`map`]
 //! method calls a closure on each element it iterates over:
 //!
 //! ```
@@ -239,8 +245,8 @@
 //! do nothing unless consumed
 //! ```
 //!
-//! The idiomatic way to write a [`Iterator::map`] for its side effects is to use a
-//! `for` loop or call the [`Iterator::for_each`] method:
+//! The idiomatic way to write a [`map`] for its side effects is to use a
+//! `for` loop or call the [`for_each`] method:
 //!
 //! ```
 //! let v = vec![1, 2, 3, 4, 5];
@@ -252,8 +258,13 @@
 //! }
 //! ```
 //!
-//! Another common way to evaluate an iterator is to use the [`Iterator::collect`]
+//! [`map`]: Iterator::map
+//! [`for_each`]: Iterator::for_each
+//!
+//! Another common way to evaluate an iterator is to use the [`collect`]
 //! method to produce a new collection.
+//!
+//! [`collect`]: Iterator::collect
 //!
 //! # Infinity
 //!
@@ -264,7 +275,7 @@
 //! let numbers = 0..;
 //! ```
 //!
-//! It is common to use the [`Iterator::take`] iterator adapter to turn an infinite
+//! It is common to use the [`take`] iterator adapter to turn an infinite
 //! iterator into a finite one:
 //!
 //! ```
@@ -280,7 +291,7 @@
 //!
 //! Bear in mind that methods on infinite iterators, even those for which a
 //! result can be determined mathematically in finite time, may not terminate.
-//! Specifically, methods such as [`Iterator::min`], which in the general case require
+//! Specifically, methods such as [`min`], which in the general case require
 //! traversing every element in the iterator, are likely not to return
 //! successfully for any infinite iterators.
 //!
@@ -290,6 +301,9 @@
 //! // `ones.min()` causes an infinite loop, so we won't reach this point!
 //! println!("The smallest number one is {}.", least);
 //! ```
+//!
+//! [`take`]: Iterator::take
+//! [`min`]: Iterator::min
 
 #![stable(feature = "rust1", since = "1.0.0")]
 

--- a/library/core/src/iter/mod.rs
+++ b/library/core/src/iter/mod.rs
@@ -53,6 +53,7 @@
 //! more complex forms of processing. See the [Adapters](#adapters) section
 //! below for more details.
 //!
+//! [`Some(Item)`]: Some
 //! [`next`]: Iterator::next
 //! [`TryIter`]: ../../std/sync/mpsc/struct.TryIter.html
 //!

--- a/src/README.md
+++ b/src/README.md
@@ -1,5 +1,5 @@
 This directory contains the source code of the rust project, including:
-- `rustc` and its tests
+- The test suite
 - The bootstrapping build system
 - Various submodules for tools, like rustdoc, rls, etc.
 

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -2740,6 +2740,10 @@ function defocusSearchBar() {
     }
 
     window.addSearchOptions = function(crates) {
+        if (search_input) {
+            search_input.removeAttribute('disabled');
+        }
+
         var elem = document.getElementById("crate-search");
 
         if (!elem) {
@@ -2781,9 +2785,6 @@ function defocusSearchBar() {
             }
         }
 
-        if (search_input) {
-            search_input.removeAttribute('disabled');
-        }
     };
 
     function buildHelperPopup() {

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -2739,14 +2739,17 @@ function defocusSearchBar() {
         });
     }
 
-    window.addSearchOptions = function(crates) {
+    function enableSearchInput() {
         if (search_input) {
             search_input.removeAttribute('disabled');
         }
+    }
 
+    window.addSearchOptions = function(crates) {
         var elem = document.getElementById("crate-search");
 
         if (!elem) {
+            enableSearchInput();
             return;
         }
         var crates_text = [];
@@ -2784,7 +2787,7 @@ function defocusSearchBar() {
                 elem.value = savedCrate;
             }
         }
-
+        enableSearchInput();
     };
 
     function buildHelperPopup() {


### PR DESCRIPTION
Successful merges:

 - #75969 (Switch to intra-doc links in core/src/{convert,iter}/mod.rs)
 - #76023 (Liballoc extend use intra doc link)
 - #76033 (Add missing hyphen)
 - #76052 (GH-66816:  Remove disable attr before return)
 - #76055 (Keep doc standard for Vec DrainFilter)
 - #76058 (Use assertions on Vec doc)
 - #76069 (Use explicit intra-doc link in path for Vec resize)
 - #76117 (Update README.md)
 - #76134 (Update MinGW instructions to include ninja)

Failed merges:


r? @ghost