### PR TITLE
Remove notrust in rustc_middle

### DIFF
--- a/compiler/rustc_middle/src/ty/walk.rs
+++ b/compiler/rustc_middle/src/ty/walk.rs
@@ -55,7 +55,7 @@ impl GenericArg<'tcx> {
     /// that appear in `self`, it does not descend into the fields of
     /// structs or variants. For example:
     ///
-    /// ```notrust
+    /// ```text
     /// isize => { isize }
     /// Foo<Bar<isize>> => { Foo<Bar<isize>>, Bar<isize>, isize }
     /// [isize] => { [isize], isize }
@@ -80,7 +80,7 @@ impl<'tcx> super::TyS<'tcx> {
     /// that appear in `self`, it does not descend into the fields of
     /// structs or variants. For example:
     ///
-    /// ```notrust
+    /// ```text
     /// isize => { isize }
     /// Foo<Bar<isize>> => { Foo<Bar<isize>>, Bar<isize>, isize }
     /// [isize] => { [isize], isize }


### PR DESCRIPTION
Fix #19599

This confuse people, no trust or not rust?
Or not rust no trust? Only trust rust ^^

Superseeds https://github.com/rust-lang/rust/pull/76063
r? @matklad 