### PR TITLE
Update cargo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,7 +278,7 @@ checksum = "81a18687293a1546b67c246452202bbbf143d239cb43494cc163da14979082da"
 
 [[package]]
 name = "cargo"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
  "anyhow",
  "atty",


### PR DESCRIPTION
8 commits in 51b66125ba97d2906f461b3f4e0408f206299bb6..126907a7cfccbe93778530e6a6bbaa3adb6c515c
2020-08-19 20:22:52 +0000 to 2020-08-31 20:42:11 +0000
- Fix flakiness in close_output test (rust-lang/cargo#8668)
- Reload unstable table from config file in `reload_rooted_at` (rust-lang/cargo#8656)
- Bump to 0.49.0, update changelog (rust-lang/cargo#8659)
- Fix LTO with doctests. (rust-lang/cargo#8657)
- Add spaces after -C and -Z flags for consistency (rust-lang/cargo#8648)
- Fix cache_messages::rustdoc test broken on beta. (rust-lang/cargo#8653)
- fix: remove unnecessary allocations (rust-lang/cargo#8641)
- Fixed a spelling and some clippy warnings (rust-lang/cargo#8637)