### PR TITLE
Update expect-test to 1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -998,9 +998,9 @@ dependencies = [
 
 [[package]]
 name = "expect-test"
-version = "0.1.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e383741ea1982866572109d1a8c807bd36aad91fca701489fdca56ef92b3b8"
+checksum = "ceb96f3eaa0d4e8769c52dacfd4eb60183b817ed2f176171b3c691d5022b0f2e"
 dependencies = [
  "difference",
  "once_cell",

--- a/compiler/rustc_lexer/Cargo.toml
+++ b/compiler/rustc_lexer/Cargo.toml
@@ -20,4 +20,4 @@ doctest = false
 unicode-xid = "0.2.0"
 
 [dev-dependencies]
-expect-test = "0.1"
+expect-test = "1.0"

--- a/src/librustdoc/Cargo.toml
+++ b/src/librustdoc/Cargo.toml
@@ -18,4 +18,4 @@ tempfile = "3"
 itertools = "0.8"
 
 [dev-dependencies]
-expect-test = "0.1"
+expect-test = "1.0"

--- a/src/librustdoc/html/highlight/tests.rs
+++ b/src/librustdoc/html/highlight/tests.rs
@@ -9,7 +9,7 @@ fn test_html_highlighting() {
         write_code(&mut out, src);
         format!("{}<pre><code>{}</code></pre>\n", STYLE, out)
     };
-    expect_file!["src/librustdoc/html/highlight/fixtures/sample.html"].assert_eq(&html);
+    expect_file!["fixtures/sample.html"].assert_eq(&html);
 }
 
 const STYLE: &str = r#"


### PR DESCRIPTION
The only change is that `expect_file` now uses path relative to the
current file (same as `include!`). Before, it used paths relative to
the workspace root, which makes no sense.