### PR TITLE
Implement PartialOrd and PartialEq for UTF-8 strings and FFI Strings

### DIFF
--- a/library/std/src/ffi/os_str.rs
+++ b/library/std/src/ffi/os_str.rs
@@ -1051,6 +1051,57 @@ impl_cmp!(Cow<'a, OsStr>, OsStr);
 impl_cmp!(Cow<'a, OsStr>, &'b OsStr);
 impl_cmp!(Cow<'a, OsStr>, OsString);
 
+macro_rules! impl_cmp_str {
+    ($lhs:ty, $rhs: ty) => {
+        #[stable(feature = "path_os_str_cmp_str", since = "1.48.0")]
+        impl<'a, 'b> PartialEq<$rhs> for $lhs {
+            #[inline]
+            fn eq(&self, other: &$rhs) -> bool {
+                let s: &str = other.as_ref();
+                *self == *OsStr::new(s)
+            }
+        }
+
+        #[stable(feature = "path_os_str_cmp_str", since = "1.48.0")]
+        impl<'a, 'b> PartialEq<$lhs> for $rhs {
+            #[inline]
+            fn eq(&self, other: &$lhs) -> bool {
+                let s: &str = self.as_ref();
+                *OsStr::new(s) == *other
+            }
+        }
+
+        #[stable(feature = "path_os_str_cmp_str", since = "1.48.0")]
+        impl<'a, 'b> PartialOrd<$rhs> for $lhs {
+            #[inline]
+            fn partial_cmp(&self, other: &$rhs) -> Option<cmp::Ordering> {
+                let s: &str = other.as_ref();
+                <OsStr as PartialOrd>::partial_cmp(self.as_ref(), OsStr::new(s))
+            }
+        }
+
+        #[stable(feature = "path_os_str_cmp_str", since = "1.48.0")]
+        impl<'a, 'b> PartialOrd<$lhs> for $rhs {
+            #[inline]
+            fn partial_cmp(&self, other: &$lhs) -> Option<cmp::Ordering> {
+                let s: &str = self.as_ref();
+                <OsStr as PartialOrd>::partial_cmp(OsStr::new(s), other.as_ref())
+            }
+        }
+    };
+}
+
+impl_cmp_str!(OsString, String);
+impl_cmp_str!(OsString, Cow<'a, str>);
+impl_cmp_str!(OsString, Box<str>);
+impl_cmp_str!(OsString, Rc<str>);
+impl_cmp_str!(OsString, Arc<str>);
+impl_cmp_str!(OsStr, String);
+impl_cmp_str!(OsStr, Cow<'a, str>);
+impl_cmp_str!(OsStr, Box<str>);
+impl_cmp_str!(OsStr, Rc<str>);
+impl_cmp_str!(OsStr, Arc<str>);
+
 #[stable(feature = "rust1", since = "1.0.0")]
 impl Hash for OsStr {
     #[inline]

--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -535,6 +535,135 @@ impl AsRef<Path> for Component<'_> {
     }
 }
 
+macro_rules! impl_component_cmp {
+    ($other:ty) => {
+        #[stable(feature = "path_os_str_cmp_str", since = "1.48.0")]
+        impl<'a, 'b> PartialEq<$other> for Component<'_> {
+            #[inline]
+            fn eq(&self, other: &$other) -> bool {
+                <OsStr as PartialEq>::eq(self.as_os_str(), other.as_ref())
+            }
+        }
+
+        #[stable(feature = "path_os_str_cmp_str", since = "1.48.0")]
+        impl<'a, 'b> PartialEq<Component<'_>> for $other {
+            #[inline]
+            fn eq(&self, other: &'_ Component<'_>) -> bool {
+                <OsStr as PartialEq>::eq(self.as_ref(), other.as_os_str())
+            }
+        }
+
+        #[stable(feature = "path_os_str_cmp_str", since = "1.48.0")]
+        impl<'a, 'b> PartialOrd<$other> for Component<'_> {
+            #[inline]
+            fn partial_cmp(&self, other: &$other) -> Option<cmp::Ordering> {
+                <OsStr as PartialOrd>::partial_cmp(self.as_os_str(), other.as_ref())
+            }
+        }
+
+        #[stable(feature = "path_os_str_cmp_str", since = "1.48.0")]
+        impl<'a, 'b> PartialOrd<Component<'_>> for $other {
+            #[inline]
+            fn partial_cmp(&self, other: &Component<'_>) -> Option<cmp::Ordering> {
+                <OsStr as PartialOrd>::partial_cmp(self.as_ref(), other.as_os_str())
+            }
+        }
+    };
+}
+
+impl_component_cmp!(OsStr);
+impl_component_cmp!(&'a OsStr);
+impl_component_cmp!(OsString);
+impl_component_cmp!(Cow<'a, OsStr>);
+impl_component_cmp!(Box<OsStr>);
+
+macro_rules! impl_component_cmp_path {
+    ($other:ty) => {
+        #[stable(feature = "path_os_str_cmp_str", since = "1.48.0")]
+        impl<'a, 'b> PartialEq<$other> for Component<'_> {
+            #[inline]
+            fn eq(&self, other: &$other) -> bool {
+                <OsStr as PartialEq>::eq(self.as_os_str(), other.as_os_str())
+            }
+        }
+
+        #[stable(feature = "path_os_str_cmp_str", since = "1.48.0")]
+        impl<'a, 'b> PartialEq<Component<'_>> for $other {
+            #[inline]
+            fn eq(&self, other: &'_ Component<'_>) -> bool {
+                <OsStr as PartialEq>::eq(self.as_os_str(), other.as_os_str())
+            }
+        }
+
+        #[stable(feature = "path_os_str_cmp_str", since = "1.48.0")]
+        impl<'a, 'b> PartialOrd<$other> for Component<'_> {
+            #[inline]
+            fn partial_cmp(&self, other: &$other) -> Option<cmp::Ordering> {
+                <OsStr as PartialOrd>::partial_cmp(self.as_os_str(), other.as_os_str())
+            }
+        }
+
+        #[stable(feature = "path_os_str_cmp_str", since = "1.48.0")]
+        impl<'a, 'b> PartialOrd<Component<'_>> for $other {
+            #[inline]
+            fn partial_cmp(&self, other: &Component<'_>) -> Option<cmp::Ordering> {
+                <OsStr as PartialOrd>::partial_cmp(self.as_os_str(), other.as_os_str())
+            }
+        }
+    };
+}
+
+impl_component_cmp_path!(Path);
+impl_component_cmp_path!(&'a Path);
+impl_component_cmp_path!(PathBuf);
+impl_component_cmp_path!(Cow<'a, Path>);
+impl_component_cmp_path!(Box<Path>);
+
+macro_rules! impl_component_cmp_str {
+    ($other:ty) => {
+        #[stable(feature = "path_os_str_cmp_str", since = "1.48.0")]
+        impl<'a, 'b> PartialEq<$other> for Component<'_> {
+            #[inline]
+            fn eq(&self, other: &$other) -> bool {
+                self.as_os_str() == other
+            }
+        }
+
+        #[stable(feature = "path_os_str_cmp_str", since = "1.48.0")]
+        impl<'a, 'b> PartialEq<Component<'_>> for $other {
+            #[inline]
+            fn eq(&self, other: &Component<'_>) -> bool {
+                self == other.as_os_str()
+            }
+        }
+
+        #[stable(feature = "path_os_str_cmp_str", since = "1.48.0")]
+        impl<'a, 'b> PartialOrd<$other> for Component<'_> {
+            #[inline]
+            fn partial_cmp(&self, other: &$other) -> Option<cmp::Ordering> {
+                let s: &str = other.as_ref();
+                <OsStr as PartialOrd>::partial_cmp(self.as_os_str(), OsStr::new(s))
+            }
+        }
+
+        #[stable(feature = "path_os_str_cmp_str", since = "1.48.0")]
+        impl<'a, 'b> PartialOrd<Component<'_>> for $other {
+            #[inline]
+            fn partial_cmp(&self, other: &Component<'_>) -> Option<cmp::Ordering> {
+                let s: &str = self.as_ref();
+                <OsStr as PartialOrd>::partial_cmp(OsStr::new(s), other.as_os_str())
+            }
+        }
+    };
+}
+
+impl_component_cmp_str!(str);
+impl_component_cmp_str!(String);
+impl_component_cmp_str!(Cow<'a, str>);
+impl_component_cmp_str!(Box<str>);
+impl_component_cmp_str!(Rc<str>);
+impl_component_cmp_str!(Arc<str>);
+
 /// An iterator over the [`Component`]s of a [`Path`].
 ///
 /// This `struct` is created by the [`components`] method on [`Path`].
@@ -2726,6 +2855,61 @@ impl_cmp_os_str!(&'a Path, OsString);
 impl_cmp_os_str!(Cow<'a, Path>, OsStr);
 impl_cmp_os_str!(Cow<'a, Path>, &'b OsStr);
 impl_cmp_os_str!(Cow<'a, Path>, OsString);
+
+macro_rules! impl_cmp_str {
+    ($lhs:ty, $rhs: ty) => {
+        #[stable(feature = "path_os_str_cmp_str", since = "1.48.0")]
+        impl<'a, 'b> PartialEq<$rhs> for $lhs {
+            #[inline]
+            fn eq(&self, other: &$rhs) -> bool {
+                let other: &str = other.as_ref();
+                *self == *OsStr::new(other)
+            }
+        }
+
+        #[stable(feature = "path_os_str_cmp_str", since = "1.48.0")]
+        impl<'a, 'b> PartialEq<$lhs> for $rhs {
+            #[inline]
+            fn eq(&self, other: &$lhs) -> bool {
+                let s: &str = self.as_ref();
+                *OsStr::new(s) == *other
+            }
+        }
+
+        #[stable(feature = "path_os_str_cmp_str", since = "1.48.0")]
+        impl<'a, 'b> PartialOrd<$rhs> for $lhs {
+            #[inline]
+            fn partial_cmp(&self, other: &$rhs) -> Option<cmp::Ordering> {
+                let s: &str = other.as_ref();
+                <OsStr as PartialOrd>::partial_cmp(self.as_os_str(), OsStr::new(s))
+            }
+        }
+
+        #[stable(feature = "path_os_str_cmp_str", since = "1.48.0")]
+        impl<'a, 'b> PartialOrd<$lhs> for $rhs {
+            #[inline]
+            fn partial_cmp(&self, other: &$lhs) -> Option<cmp::Ordering> {
+                let s: &str = self.as_ref();
+                <OsStr as PartialOrd>::partial_cmp(OsStr::new(s), other.as_os_str())
+            }
+        }
+    };
+}
+
+impl_cmp_str!(PathBuf, str);
+impl_cmp_str!(PathBuf, &'a str);
+impl_cmp_str!(PathBuf, String);
+impl_cmp_str!(PathBuf, Cow<'a, str>);
+impl_cmp_str!(PathBuf, Box<str>);
+impl_cmp_str!(PathBuf, Rc<str>);
+impl_cmp_str!(PathBuf, Arc<str>);
+impl_cmp_str!(Path, str);
+impl_cmp_str!(Path, &'a str);
+impl_cmp_str!(Path, String);
+impl_cmp_str!(Path, Cow<'a, str>);
+impl_cmp_str!(Path, Box<str>);
+impl_cmp_str!(Path, Rc<str>);
+impl_cmp_str!(Path, Arc<str>);
 
 #[stable(since = "1.7.0", feature = "strip_prefix")]
 impl fmt::Display for StripPrefixError {


### PR DESCRIPTION
Implement PartialOrd and PartialEq for UTF-8 strings and FFI Strings

This PR adds many more `PartialEq` and `PartialOrd` implementations for
`Path`, `PathBuf`, `OsStr`, `OsString`, and `Component`.

The Rust Standard Library guarantees that these types are freely and
cheaply constructable from UTF-8 `String` and `&str`, but comparing
these types with `&str` literals is not ergonomic. One use case I'd like
to enable is filtering out paths containing a "test" directory while
walking a tree and inspecting the path with the `components()` iterator.

Example:

```rust
let is_test_source = relative_source
    .components()
    .any(|component| component.as_os_str() == OsStr::new("test"));
```

New core trait impls:

`OsString`:

- `impl PartialEq<String> for OsString` and reflexive
- `impl PartialEq<Cow<'_, str>> for OsString` and reflexive
- `impl PartialEq<Box<str>> for OsString` and reflexive
- `impl PartialEq<Rc<str>> for OsString` and reflexive
- `impl PartialEq<Arc<str>> for OsString` and reflexive
- `impl PartialOrd<String> for OsString` and reflexive
- `impl PartialOrd<Cow<'_, str>> for OsString` and reflexive
- `impl PartialOrd<Box<str>> for OsString` and reflexive
- `impl PartialOrd<Rc<str>> for OsString` and reflexive
- `impl PartialOrd<Arc<str>> for OsString` and reflexive

`OsStr`:

- `impl PartialEq<String> for OsStr` and reflexive
- `impl PartialEq<Cow<'_, str>> for OsStr` and reflexive
- `impl PartialEq<Box<str>> for OsStr` and reflexive
- `impl PartialEq<Rc<str>> for OsStr` and reflexive
- `impl PartialEq<Arc<str>> for OsStr` and reflexive
- `impl PartialOrd<String> for OsStr` and reflexive
- `impl PartialOrd<Cow<'_, str>> for OsStr` and reflexive
- `impl PartialOrd<Box<str>> for OsStr` and reflexive
- `impl PartialOrd<Rc<str>> for OsStr` and reflexive
- `impl PartialOrd<Arc<str>> for OsStr` and reflexive

`Component`:

- `impl PartialEq<OsStr> for Component` and reflexive
- `impl PartialEq<&'_ OsStr> for Component` and reflexive
- `impl PartialEq<OsString> for Component` and reflexive
- `impl PartialEq<Cow<'_, OsStr>> for Component` and reflexive
- `impl PartialEq<Box<OsStr>> for Component` and reflexive
- `impl PartialEq<Path> for Component` and reflexive
- `impl PartialEq<&'_ Path> for Component` and reflexive
- `impl PartialEq<PathBuf> for Component` and reflexive
- `impl PartialEq<Cow<'_, Path>> for Component` and reflexive
- `impl PartialEq<Box<Path>> for Component` and reflexive
- `impl PartialEq<str> for Component` and reflexive
- `impl PartialEq<String> for Component` and reflexive
- `impl PartialEq<Cow<'_, str>> for Component` and reflexive
- `impl PartialEq<Box<str>> for Component` and reflexive
- `impl PartialEq<Rc<str>> for Component` and reflexive
- `impl PartialEq<Arc<str>> for Component` and reflexive
- `impl PartialEq<str> for Component` and reflexive
- `impl PartialEq<String> for Component` and reflexive
- `impl PartialEq<Cow<'_, str>> for Component` and reflexive
- `impl PartialEq<Box<str>> for Component` and reflexive
- `impl PartialEq<Rc<str>> for Component` and reflexive
- `impl PartialEq<Arc<str>> for Component` and reflexive
- `impl PartialOrd<OsStr> for Component` and reflexive
- `impl PartialOrd<&'_ OsStr> for Component` and reflexive
- `impl PartialOrd<OsString> for Component` and reflexive
- `impl PartialOrd<Cow<'_, OsStr>> for Component` and reflexive
- `impl PartialOrd<Box<OsStr>> for Component` and reflexive
- `impl PartialOrd<Path> for Component` and reflexive
- `impl PartialOrd<&'_ Path> for Component` and reflexive
- `impl PartialOrd<PathBuf> for Component` and reflexive
- `impl PartialOrd<Cow<'_, Path>> for Component` and reflexive
- `impl PartialOrd<Box<Path>> for Component` and reflexive
- `impl PartialOrd<str> for Component` and reflexive
- `impl PartialOrd<String> for Component` and reflexive
- `impl PartialOrd<Cow<'_, str>> for Component` and reflexive
- `impl PartialOrd<Box<str>> for Component` and reflexive
- `impl PartialOrd<Rc<str>> for Component` and reflexive
- `impl PartialOrd<Arc<str>> for Component` and reflexive

`PathBuf`:

- `impl PartialEq<str> for PathBuf` and reflexive
- `impl PartialEq<&'_ str> for PathBuf` and reflexive
- `impl PartialEq<String> for PathBuf` and reflexive
- `impl PartialEq<Cow<'_, str>> for PathBuf` and reflexive
- `impl PartialEq<Box<str>> for PathBuf` and reflexive
- `impl PartialEq<Rc<str>> for PathBuf` and reflexive
- `impl PartialEq<Arc<str>> for PathBuf` and reflexive
- `impl PartialOrd<str> for PathBuf` and reflexive
- `impl PartialOrd<&'_ str> for PathBuf` and reflexive
- `impl PartialOrd<String> for PathBuf` and reflexive
- `impl PartialOrd<Cow<'_, str>> for PathBuf` and reflexive
- `impl PartialOrd<Box<str>> for PathBuf` and reflexive
- `impl PartialOrd<Rc<str>> for PathBuf` and reflexive
- `impl PartialOrd<Arc<str>> for PathBuf` and reflexive

`Path`:

- `impl PartialEq<str> for Path` and reflexive
- `impl PartialEq<&'_ str> for Path` and reflexive
- `impl PartialEq<String> for Path` and reflexive
- `impl PartialEq<Cow<'_, str>> for Path` and reflexive
- `impl PartialEq<Box<str>> for Path` and reflexive
- `impl PartialEq<Rc<str>> for Path` and reflexive
- `impl PartialEq<Arc<str>> for Path` and reflexive
- `impl PartialOrd<str> for Path` and reflexive
- `impl PartialOrd<&'_ str> for Path` and reflexive
- `impl PartialOrd<String> for Path` and reflexive
- `impl PartialOrd<Cow<'_, str>> for Path` and reflexive
- `impl PartialOrd<Box<str>> for Path` and reflexive
- `impl PartialOrd<Rc<str>> for Path` and reflexive
- `impl PartialOrd<Arc<str>> for Path` and reflexive

Fixes #71700.