### PR TITLE
allow concrete self types in consts

### DIFF
--- a/compiler/rustc_hir/src/def.rs
+++ b/compiler/rustc_hir/src/def.rs
@@ -201,11 +201,13 @@ pub enum Res<Id = hir::HirId> {
     PrimTy(hir::PrimTy),
     /// `Self`, with both an optional trait and impl `DefId`.
     ///
-    /// HACK: impl self types also have an optional requirement to not mention
-    /// any generic parameters to allow the following with `min_const_generics`.
-    /// `impl Foo { fn test() -> [u8; std::mem::size_of::<Self>()]`.
+    /// HACK(min_const_generics): impl self types also have an optional requirement to not mention
+    /// any generic parameters to allow the following with `min_const_generics`:
+    /// ```rust
+    /// impl Foo { fn test() -> [u8; std::mem::size_of::<Self>()] {} }
+    /// ```
     ///
-    /// Once `lazy_normalization_consts` is stable, this bodge can be removed again.
+    /// FIXME(lazy_normalization_consts): Remove this bodge once this feature is stable.
     SelfTy(Option<DefId> /* trait */, Option<(DefId, bool)> /* impl */),
     ToolMod, // e.g., `rustfmt` in `#[rustfmt::skip]`
 

--- a/compiler/rustc_hir/src/def.rs
+++ b/compiler/rustc_hir/src/def.rs
@@ -199,7 +199,14 @@ pub enum Res<Id = hir::HirId> {
 
     // Type namespace
     PrimTy(hir::PrimTy),
-    SelfTy(Option<DefId> /* trait */, Option<DefId> /* impl */),
+    /// `Self`, with both an optional trait and impl `DefId`.
+    ///
+    /// HACK: impl self types also have an optional requirement to not mention
+    /// any generic parameters to allow the following with `min_const_generics`.
+    /// `impl Foo { fn test() -> [u8; std::mem::size_of::<Self>()]`.
+    ///
+    /// Once `lazy_normalization_consts` is stable, this bodge can be removed again.
+    SelfTy(Option<DefId> /* trait */, Option<(DefId, bool)> /* impl */),
     ToolMod, // e.g., `rustfmt` in `#[rustfmt::skip]`
 
     // Value namespace

--- a/compiler/rustc_passes/src/dead.rs
+++ b/compiler/rustc_passes/src/dead.rs
@@ -104,7 +104,7 @@ impl<'tcx> MarkSymbolVisitor<'tcx> {
                 if let Some(t) = t {
                     self.check_def_id(t);
                 }
-                if let Some(i) = i {
+                if let Some((i, _)) = i {
                     self.check_def_id(i);
                 }
             }

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -112,7 +112,7 @@ impl<'a> Resolver<'a> {
                 match outer_res {
                     Res::SelfTy(maybe_trait_defid, maybe_impl_defid) => {
                         if let Some(impl_span) =
-                            maybe_impl_defid.and_then(|def_id| self.opt_span(def_id))
+                            maybe_impl_defid.and_then(|(def_id, _)| self.opt_span(def_id))
                         {
                             err.span_label(
                                 reduce_impl_span_to_impl_keyword(sm, impl_span),

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -2627,25 +2627,23 @@ impl<'a> Resolver<'a> {
                             continue;
                         }
                         ConstantItemRibKind(trivial) => {
-                            if self.session.features_untracked().min_const_generics {
-                                // HACK(min_const_generics): We currently only allow `N` or `{ N }`.
-                                if !trivial {
-                                    // HACK(min_const_generics): If we encounter `Self` in an anonymous constant
-                                    // we can't easily tell if it's generic at this stage, so we instead remember
-                                    // this and then enforce the self type to be concrete later on.
-                                    if let Res::SelfTy(trait_def, Some((impl_def, _))) = res {
-                                        res = Res::SelfTy(trait_def, Some((impl_def, true)));
-                                    } else {
-                                        if record_used {
-                                            self.report_error(
-                                                span,
-                                                ResolutionError::ParamInNonTrivialAnonConst(
-                                                    rib_ident.name,
-                                                ),
-                                            );
-                                        }
-                                        return Res::Err;
+                            // HACK(min_const_generics): We currently only allow `N` or `{ N }`.
+                            if !trivial && self.session.features_untracked().min_const_generics {
+                                // HACK(min_const_generics): If we encounter `Self` in an anonymous constant
+                                // we can't easily tell if it's generic at this stage, so we instead remember
+                                // this and then enforce the self type to be concrete later on.
+                                if let Res::SelfTy(trait_def, Some((impl_def, _))) = res {
+                                    res = Res::SelfTy(trait_def, Some((impl_def, true)));
+                                } else {
+                                    if record_used {
+                                        self.report_error(
+                                            span,
+                                            ResolutionError::ParamInNonTrivialAnonConst(
+                                                rib_ident.name,
+                                            ),
+                                        );
                                     }
+                                    return Res::Err;
                                 }
                             }
 

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -2539,7 +2539,7 @@ impl<'a> Resolver<'a> {
         &mut self,
         rib_index: usize,
         rib_ident: Ident,
-        res: Res,
+        mut res: Res,
         record_used: bool,
         span: Span,
         all_ribs: &[Rib<'a>],
@@ -2627,15 +2627,26 @@ impl<'a> Resolver<'a> {
                             continue;
                         }
                         ConstantItemRibKind(trivial) => {
-                            // HACK(min_const_generics): We currently only allow `N` or `{ N }`.
-                            if !trivial && self.session.features_untracked().min_const_generics {
-                                if record_used {
-                                    self.report_error(
-                                        span,
-                                        ResolutionError::ParamInNonTrivialAnonConst(rib_ident.name),
-                                    );
+                            if self.session.features_untracked().min_const_generics {
+                                // HACK(min_const_generics): We currently only allow `N` or `{ N }`.
+                                if !trivial {
+                                    // HACK(min_const_generics): If we encounter `Self` in an anonymous constant
+                                    // we can't easily tell if it's generic at this stage, so we instead remember
+                                    // this and then enforce the self type to be concrete later on.
+                                    if let Res::SelfTy(trait_def, Some((impl_def, _))) = res {
+                                        res = Res::SelfTy(trait_def, Some((impl_def, true)));
+                                    } else {
+                                        if record_used {
+                                            self.report_error(
+                                                span,
+                                                ResolutionError::ParamInNonTrivialAnonConst(
+                                                    rib_ident.name,
+                                                ),
+                                            );
+                                        }
+                                        return Res::Err;
+                                    }
                                 }
-                                return Res::Err;
                             }
 
                             if in_ty_param_default {

--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -601,7 +601,7 @@ pub fn register_res(cx: &DocContext<'_>, res: Res) -> DefId {
         },
         Res::Def(DefKind::TraitAlias, i) => (i, TypeKind::TraitAlias),
         Res::SelfTy(Some(def_id), _) => (def_id, TypeKind::Trait),
-        Res::SelfTy(_, Some(impl_def_id)) => return impl_def_id,
+        Res::SelfTy(_, Some((impl_def_id, _))) => return impl_def_id,
         _ => return res.def_id(),
     };
     if did.is_local() {

--- a/src/test/ui/const-generics/issues/issue-62504.min.stderr
+++ b/src/test/ui/const-generics/issues/issue-62504.min.stderr
@@ -1,10 +1,14 @@
-error: generic parameters must not be used inside of non trivial constant values
+error: generic `Self` types are currently not permitted in anonymous constants
   --> $DIR/issue-62504.rs:19:25
    |
 LL |         ArrayHolder([0; Self::SIZE])
-   |                         ^^^^^^^^^^ non-trivial anonymous constants must not depend on the parameter `Self`
+   |                         ^^^^^^^^^^
    |
-   = help: it is currently only allowed to use either `Self` or `{ Self }` as generic constants
+note: not a concrete type
+  --> $DIR/issue-62504.rs:17:22
+   |
+LL | impl<const X: usize> ArrayHolder<X> {
+   |                      ^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/const-generics/issues/issue-62504.rs
+++ b/src/test/ui/const-generics/issues/issue-62504.rs
@@ -18,7 +18,7 @@ impl<const X: usize> ArrayHolder<X> {
     pub const fn new() -> Self {
         ArrayHolder([0; Self::SIZE])
         //[full]~^ ERROR constant expression depends on a generic parameter
-        //[min]~^^ ERROR generic parameters must not be used inside of non trivial constant values
+        //[min]~^^ ERROR generic `Self` types are currently
     }
 }
 

--- a/src/test/ui/const-generics/min_const_generics/self-ty-in-const-1.rs
+++ b/src/test/ui/const-generics/min_const_generics/self-ty-in-const-1.rs
@@ -1,0 +1,27 @@
+#![feature(min_const_generics)]
+
+trait Foo {
+    fn t1() -> [u8; std::mem::size_of::<Self>()]; //~ERROR generic parameters
+}
+
+struct Bar<T>(T);
+
+impl Bar<u8> {
+    fn t2() -> [u8; std::mem::size_of::<Self>()] { todo!() } // ok
+}
+
+impl<T> Bar<T> {
+    fn t3() -> [u8; std::mem::size_of::<Self>()] {} //~ERROR generic `Self`
+}
+
+trait Baz {
+    fn hey();
+}
+
+impl Baz for u16 {
+    fn hey() {
+        let _: [u8; std::mem::size_of::<Self>()]; // ok
+    }
+}
+
+fn main() {}

--- a/src/test/ui/const-generics/min_const_generics/self-ty-in-const-1.stderr
+++ b/src/test/ui/const-generics/min_const_generics/self-ty-in-const-1.stderr
@@ -1,0 +1,24 @@
+error: generic parameters must not be used inside of non trivial constant values
+  --> $DIR/self-ty-in-const-1.rs:4:41
+   |
+LL |     fn t1() -> [u8; std::mem::size_of::<Self>()];
+   |                                         ^^^^ non-trivial anonymous constants must not depend on the parameter `Self`
+   |
+   = help: it is currently only allowed to use either `Self` or `{ Self }` as generic constants
+
+error: generic `Self` types are currently not permitted in anonymous constants
+  --> $DIR/self-ty-in-const-1.rs:14:41
+   |
+LL |     fn t3() -> [u8; std::mem::size_of::<Self>()] {}
+   |                                         ^^^^
+   |
+note: not a concrete type
+  --> $DIR/self-ty-in-const-1.rs:13:1
+   |
+LL | / impl<T> Bar<T> {
+LL | |     fn t3() -> [u8; std::mem::size_of::<Self>()] {}
+LL | | }
+   | |_^
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/const-generics/min_const_generics/self-ty-in-const-1.stderr
+++ b/src/test/ui/const-generics/min_const_generics/self-ty-in-const-1.stderr
@@ -13,12 +13,10 @@ LL |     fn t3() -> [u8; std::mem::size_of::<Self>()] {}
    |                                         ^^^^
    |
 note: not a concrete type
-  --> $DIR/self-ty-in-const-1.rs:13:1
+  --> $DIR/self-ty-in-const-1.rs:13:9
    |
-LL | / impl<T> Bar<T> {
-LL | |     fn t3() -> [u8; std::mem::size_of::<Self>()] {}
-LL | | }
-   | |_^
+LL | impl<T> Bar<T> {
+   |         ^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/const-generics/min_const_generics/self-ty-in-const-2.rs
+++ b/src/test/ui/const-generics/min_const_generics/self-ty-in-const-2.rs
@@ -1,0 +1,21 @@
+#![feature(min_const_generics)]
+
+struct Bar<T>(T);
+
+trait Baz {
+    fn hey();
+}
+
+impl Baz for u16 {
+    fn hey() {
+        let _: [u8; std::mem::size_of::<Self>()]; // ok
+    }
+}
+
+impl<T> Baz for Bar<T> {
+    fn hey() {
+        let _: [u8; std::mem::size_of::<Self>()]; //~ERROR generic `Self`
+    }
+}
+
+fn main() {}

--- a/src/test/ui/const-generics/min_const_generics/self-ty-in-const-2.stderr
+++ b/src/test/ui/const-generics/min_const_generics/self-ty-in-const-2.stderr
@@ -1,0 +1,18 @@
+error: generic `Self` types are currently not permitted in anonymous constants
+  --> $DIR/self-ty-in-const-2.rs:17:41
+   |
+LL |         let _: [u8; std::mem::size_of::<Self>()];
+   |                                         ^^^^
+   |
+note: not a concrete type
+  --> $DIR/self-ty-in-const-2.rs:15:1
+   |
+LL | / impl<T> Baz for Bar<T> {
+LL | |     fn hey() {
+LL | |         let _: [u8; std::mem::size_of::<Self>()];
+LL | |     }
+LL | | }
+   | |_^
+
+error: aborting due to previous error
+

--- a/src/test/ui/const-generics/min_const_generics/self-ty-in-const-2.stderr
+++ b/src/test/ui/const-generics/min_const_generics/self-ty-in-const-2.stderr
@@ -5,14 +5,10 @@ LL |         let _: [u8; std::mem::size_of::<Self>()];
    |                                         ^^^^
    |
 note: not a concrete type
-  --> $DIR/self-ty-in-const-2.rs:15:1
+  --> $DIR/self-ty-in-const-2.rs:15:17
    |
-LL | / impl<T> Baz for Bar<T> {
-LL | |     fn hey() {
-LL | |         let _: [u8; std::mem::size_of::<Self>()];
-LL | |     }
-LL | | }
-   | |_^
+LL | impl<T> Baz for Bar<T> {
+   |                 ^^^^^^
 
 error: aborting due to previous error
 


### PR DESCRIPTION
This is quite a bad hack to fix #75486. There might be a better way to check if the self type depends on generic parameters, but I wasn't able to come up with one.

r? @varkor cc @petrochenkov 