### PR TITLE
Move ninja requirements to a dynamic check, when actually building

### DIFF
--- a/src/bootstrap/builder/tests.rs
+++ b/src/bootstrap/builder/tests.rs
@@ -8,7 +8,7 @@ fn configure(host: &[&str], target: &[&str]) -> Config {
     config.save_toolstates = None;
     config.skip_only_host_steps = false;
     config.dry_run = true;
-    config.ninja = false;
+    config.ninja_in_file = false;
     // try to avoid spurious failures in dist where we create/delete each others file
     let dir = config
         .out

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -32,7 +32,8 @@ use serde::Deserialize;
 #[derive(Default)]
 pub struct Config {
     pub ccache: Option<String>,
-    pub ninja: bool,
+    /// Call Build::ninja() instead of this.
+    pub ninja_in_file: bool,
     pub verbose: usize,
     pub submodules: bool,
     pub fast_submodules: bool,
@@ -450,7 +451,7 @@ impl Config {
     pub fn default_opts() -> Config {
         let mut config = Config::default();
         config.llvm_optimize = true;
-        config.ninja = true;
+        config.ninja_in_file = true;
         config.llvm_version_check = true;
         config.backtrace = true;
         config.rust_optimize = true;
@@ -606,7 +607,7 @@ impl Config {
                 }
                 Some(StringOrBool::Bool(false)) | None => {}
             }
-            set(&mut config.ninja, llvm.ninja);
+            set(&mut config.ninja_in_file, llvm.ninja);
             llvm_assertions = llvm.assertions;
             llvm_skip_rebuild = llvm_skip_rebuild.or(llvm.skip_rebuild);
             set(&mut config.llvm_optimize, llvm.optimize);

--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -56,7 +56,7 @@ pub fn prebuilt_llvm_config(
     let out_dir = builder.llvm_out(target);
 
     let mut llvm_config_ret_dir = builder.llvm_out(builder.config.build);
-    if !builder.config.build.contains("msvc") || builder.config.ninja {
+    if !builder.config.build.contains("msvc") || builder.ninja() {
         llvm_config_ret_dir.push("build");
     }
     llvm_config_ret_dir.push("bin");
@@ -363,7 +363,7 @@ fn configure_cmake(
     // own build directories.
     cfg.env("DESTDIR", "");
 
-    if builder.config.ninja {
+    if builder.ninja() {
         cfg.generator("Ninja");
     }
     cfg.target(&target.triple).host(&builder.config.build.triple);
@@ -395,7 +395,7 @@ fn configure_cmake(
     // MSVC with CMake uses msbuild by default which doesn't respect these
     // vars that we'd otherwise configure. In that case we just skip this
     // entirely.
-    if target.contains("msvc") && !builder.config.ninja {
+    if target.contains("msvc") && !builder.ninja() {
         return;
     }
 
@@ -405,7 +405,7 @@ fn configure_cmake(
     };
 
     // Handle msvc + ninja + ccache specially (this is what the bots use)
-    if target.contains("msvc") && builder.config.ninja && builder.config.ccache.is_some() {
+    if target.contains("msvc") && builder.ninja() && builder.config.ccache.is_some() {
         let mut wrap_cc = env::current_exe().expect("failed to get cwd");
         wrap_cc.set_file_name("sccache-plus-cl.exe");
 


### PR DESCRIPTION
It isn't practical to determine whether we'll build LLVM very early in the
pipeline, so move the ninja checking to a dynamic check.

r? @pietroalbini -- this should fix nightlies