### PR TITLE
Permit uninhabited enums to cast into ints

### DIFF
--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -2481,8 +2481,10 @@ impl<'tcx> AdtDef {
         self.variants.iter().flat_map(|v| v.fields.iter())
     }
 
+    /// Whether the ADT lacks fields. Note that this includes uninhabited enums,
+    /// e.g., `enum Void {}` is considered payload free as well.
     pub fn is_payloadfree(&self) -> bool {
-        !self.variants.is_empty() && self.variants.iter().all(|v| v.fields.is_empty())
+        self.variants.iter().all(|v| v.fields.is_empty())
     }
 
     /// Return a `VariantDef` given a variant id.

--- a/src/test/ui/uninhabited/uninhabited-enum-cast.rs
+++ b/src/test/ui/uninhabited/uninhabited-enum-cast.rs
@@ -1,7 +1,9 @@
+// check-pass
+
 enum E {}
 
 fn f(e: E) {
-    println!("{}", (e as isize).to_string());   //~ ERROR non-primitive cast
+    println!("{}", (e as isize).to_string());
 }
 
 fn main() {}

--- a/src/test/ui/uninhabited/uninhabited-enum-cast.stderr
+++ b/src/test/ui/uninhabited/uninhabited-enum-cast.stderr
@@ -1,9 +1,0 @@
-error[E0605]: non-primitive cast: `E` as `isize`
-  --> $DIR/uninhabited-enum-cast.rs:4:20
-   |
-LL |     println!("{}", (e as isize).to_string());
-   |                    ^^^^^^^^^^^^ an `as` expression can only be used to convert between primitive types or to coerce to a specific trait object
-
-error: aborting due to previous error
-
-For more information about this error, try `rustc --explain E0605`.


### PR DESCRIPTION
This essentially reverts part of #6204; it is unclear why that [commit](https://github.com/rust-lang/rust/pull/6204/commits/c0f587de34f30b060df8a88c4068740e587b9340) was introduced, and I suspect no one remembers.

The changed code was only called from casting checks and appears to not affect any callers of that code (other than permitting this one case).

Fixes #75647.