### PR TITLE
compiler: use `OnceCell` from std

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3530,7 +3530,6 @@ version = "0.0.0"
 name = "rustc_hir"
 version = "0.0.0"
 dependencies = [
- "lazy_static",
  "rustc_ast",
  "rustc_data_structures",
  "rustc_index",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3513,7 +3513,6 @@ dependencies = [
 name = "rustc_feature"
 version = "0.0.0"
 dependencies = [
- "lazy_static",
  "rustc_data_structures",
  "rustc_span",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3417,7 +3417,6 @@ dependencies = [
  "ena",
  "indexmap",
  "jobserver",
- "lazy_static",
  "libc",
  "measureme",
  "parking_lot 0.10.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3439,7 +3439,6 @@ dependencies = [
 name = "rustc_driver"
 version = "0.0.0"
 dependencies = [
- "lazy_static",
  "libc",
  "rustc_ast",
  "rustc_ast_pretty",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3606,7 +3606,6 @@ name = "rustc_interface"
 version = "0.0.0"
 dependencies = [
  "libc",
- "once_cell",
  "rustc-rayon",
  "rustc_ast",
  "rustc_ast_lowering",

--- a/compiler/rustc_data_structures/Cargo.toml
+++ b/compiler/rustc_data_structures/Cargo.toml
@@ -12,7 +12,6 @@ ena = "0.14"
 indexmap = "1.5.1"
 tracing = "0.1"
 jobserver_crate = { version = "0.1.13", package = "jobserver" }
-lazy_static = "1"
 rustc_serialize = { path = "../rustc_serialize" }
 rustc_macros = { path = "../rustc_macros" }
 rustc_graphviz = { path = "../rustc_graphviz" }

--- a/compiler/rustc_data_structures/src/jobserver.rs
+++ b/compiler/rustc_data_structures/src/jobserver.rs
@@ -1,33 +1,31 @@
 pub use jobserver_crate::Client;
-use lazy_static::lazy_static;
+use std::lazy::SyncLazy;
 
-lazy_static! {
-    // We can only call `from_env` once per process
+// We can only call `from_env` once per process
 
-    // Note that this is unsafe because it may misinterpret file descriptors
-    // on Unix as jobserver file descriptors. We hopefully execute this near
-    // the beginning of the process though to ensure we don't get false
-    // positives, or in other words we try to execute this before we open
-    // any file descriptors ourselves.
-    //
-    // Pick a "reasonable maximum" if we don't otherwise have
-    // a jobserver in our environment, capping out at 32 so we
-    // don't take everything down by hogging the process run queue.
-    // The fixed number is used to have deterministic compilation
-    // across machines.
-    //
-    // Also note that we stick this in a global because there could be
-    // multiple rustc instances in this process, and the jobserver is
-    // per-process.
-    static ref GLOBAL_CLIENT: Client = unsafe {
-        Client::from_env().unwrap_or_else(|| {
-            let client = Client::new(32).expect("failed to create jobserver");
-            // Acquire a token for the main thread which we can release later
-            client.acquire_raw().ok();
-            client
-        })
-    };
-}
+// Note that this is unsafe because it may misinterpret file descriptors
+// on Unix as jobserver file descriptors. We hopefully execute this near
+// the beginning of the process though to ensure we don't get false
+// positives, or in other words we try to execute this before we open
+// any file descriptors ourselves.
+//
+// Pick a "reasonable maximum" if we don't otherwise have
+// a jobserver in our environment, capping out at 32 so we
+// don't take everything down by hogging the process run queue.
+// The fixed number is used to have deterministic compilation
+// across machines.
+//
+// Also note that we stick this in a global because there could be
+// multiple rustc instances in this process, and the jobserver is
+// per-process.
+static GLOBAL_CLIENT: SyncLazy<Client> = SyncLazy::new(|| unsafe {
+    Client::from_env().unwrap_or_else(|| {
+        let client = Client::new(32).expect("failed to create jobserver");
+        // Acquire a token for the main thread which we can release later
+        client.acquire_raw().ok();
+        client
+    })
+});
 
 pub fn client() -> Client {
     GLOBAL_CLIENT.clone()

--- a/compiler/rustc_driver/Cargo.toml
+++ b/compiler/rustc_driver/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2018"
 crate-type = ["dylib"]
 
 [dependencies]
-lazy_static = "1.0"
 libc = "0.2"
 tracing = { version = "0.1.18", features = ["release_max_level_info"]  }
 tracing-subscriber = { version = "0.2.10", default-features = false, features = ["fmt", "env-filter", "smallvec", "parking_lot", "ansi"] }

--- a/compiler/rustc_driver/src/lib.rs
+++ b/compiler/rustc_driver/src/lib.rs
@@ -11,8 +11,6 @@
 
 #[macro_use]
 extern crate tracing;
-#[macro_use]
-extern crate lazy_static;
 
 pub extern crate rustc_plugin_impl as plugin;
 
@@ -49,6 +47,7 @@ use std::env;
 use std::ffi::OsString;
 use std::fs;
 use std::io::{self, Read, Write};
+use std::lazy::SyncLazy;
 use std::mem;
 use std::panic::{self, catch_unwind};
 use std::path::PathBuf;
@@ -1142,13 +1141,12 @@ pub fn catch_with_exit_code(f: impl FnOnce() -> interface::Result<()>) -> i32 {
     }
 }
 
-lazy_static! {
-    static ref DEFAULT_HOOK: Box<dyn Fn(&panic::PanicInfo<'_>) + Sync + Send + 'static> = {
+static DEFAULT_HOOK: SyncLazy<Box<dyn Fn(&panic::PanicInfo<'_>) + Sync + Send + 'static>> =
+    SyncLazy::new(|| {
         let hook = panic::take_hook();
         panic::set_hook(Box::new(|info| report_ice(info, BUG_REPORT_URL)));
         hook
-    };
-}
+    });
 
 /// Prints the ICE message, including backtrace and query stack.
 ///
@@ -1223,7 +1221,7 @@ pub fn report_ice(info: &panic::PanicInfo<'_>, bug_report_url: &str) {
 ///
 /// A custom rustc driver can skip calling this to set up a custom ICE hook.
 pub fn install_ice_hook() {
-    lazy_static::initialize(&DEFAULT_HOOK);
+    SyncLazy::force(&DEFAULT_HOOK);
 }
 
 /// This allows tools to enable rust logging without having to magically match rustc's

--- a/compiler/rustc_feature/Cargo.toml
+++ b/compiler/rustc_feature/Cargo.toml
@@ -9,5 +9,4 @@ doctest = false
 
 [dependencies]
 rustc_data_structures = { path = "../rustc_data_structures" }
-lazy_static = "1.0.0"
 rustc_span = { path = "../rustc_span" }

--- a/compiler/rustc_feature/src/builtin_attrs.rs
+++ b/compiler/rustc_feature/src/builtin_attrs.rs
@@ -5,9 +5,10 @@ use AttributeType::*;
 
 use crate::{Features, Stability};
 
-use lazy_static::lazy_static;
 use rustc_data_structures::fx::FxHashMap;
 use rustc_span::symbol::{sym, Symbol};
+
+use std::lazy::SyncLazy;
 
 type GateFn = fn(&Features) -> bool;
 
@@ -589,14 +590,12 @@ pub fn is_builtin_attr_name(name: Symbol) -> bool {
     BUILTIN_ATTRIBUTE_MAP.get(&name).is_some()
 }
 
-lazy_static! {
-    pub static ref BUILTIN_ATTRIBUTE_MAP: FxHashMap<Symbol, &'static BuiltinAttribute> = {
-        let mut map = FxHashMap::default();
-        for attr in BUILTIN_ATTRIBUTES.iter() {
-            if map.insert(attr.0, attr).is_some() {
-                panic!("duplicate builtin attribute `{}`", attr.0);
-            }
+pub static BUILTIN_ATTRIBUTE_MAP: SyncLazy<FxHashMap<Symbol, &'static BuiltinAttribute>> = SyncLazy::new(|| {
+    let mut map = FxHashMap::default();
+    for attr in BUILTIN_ATTRIBUTES.iter() {
+        if map.insert(attr.0, attr).is_some() {
+            panic!("duplicate builtin attribute `{}`", attr.0);
         }
-        map
-    };
-}
+    }
+    map
+});

--- a/compiler/rustc_feature/src/builtin_attrs.rs
+++ b/compiler/rustc_feature/src/builtin_attrs.rs
@@ -590,12 +590,13 @@ pub fn is_builtin_attr_name(name: Symbol) -> bool {
     BUILTIN_ATTRIBUTE_MAP.get(&name).is_some()
 }
 
-pub static BUILTIN_ATTRIBUTE_MAP: SyncLazy<FxHashMap<Symbol, &'static BuiltinAttribute>> = SyncLazy::new(|| {
-    let mut map = FxHashMap::default();
-    for attr in BUILTIN_ATTRIBUTES.iter() {
-        if map.insert(attr.0, attr).is_some() {
-            panic!("duplicate builtin attribute `{}`", attr.0);
+pub static BUILTIN_ATTRIBUTE_MAP: SyncLazy<FxHashMap<Symbol, &'static BuiltinAttribute>> =
+    SyncLazy::new(|| {
+        let mut map = FxHashMap::default();
+        for attr in BUILTIN_ATTRIBUTES.iter() {
+            if map.insert(attr.0, attr).is_some() {
+                panic!("duplicate builtin attribute `{}`", attr.0);
+            }
         }
-    }
-    map
-});
+        map
+    });

--- a/compiler/rustc_feature/src/lib.rs
+++ b/compiler/rustc_feature/src/lib.rs
@@ -11,6 +11,8 @@
 //! even if it is stabilized or removed, *do not remove it*. Instead, move the
 //! symbol to the `accepted` or `removed` modules respectively.
 
+#![feature(once_cell)]
+
 mod accepted;
 mod active;
 mod builtin_attrs;

--- a/compiler/rustc_hir/Cargo.toml
+++ b/compiler/rustc_hir/Cargo.toml
@@ -15,6 +15,5 @@ rustc_index = { path = "../rustc_index" }
 rustc_span = { path = "../rustc_span" }
 rustc_serialize = { path = "../rustc_serialize" }
 rustc_ast = { path = "../rustc_ast" }
-lazy_static = "1"
 tracing = "0.1"
 smallvec = { version = "1.0", features = ["union", "may_dangle"] }

--- a/compiler/rustc_hir/src/lang_items.rs
+++ b/compiler/rustc_hir/src/lang_items.rs
@@ -17,7 +17,7 @@ use rustc_macros::HashStable_Generic;
 use rustc_span::symbol::{kw, sym, Symbol};
 use rustc_span::Span;
 
-use lazy_static::lazy_static;
+use std::lazy::SyncLazy;
 
 pub enum LangItemGroup {
     Op,
@@ -117,14 +117,12 @@ macro_rules! language_item_table {
             )*
         }
 
-        lazy_static! {
-            /// A mapping from the name of the lang item to its order and the form it must be of.
-            pub static ref ITEM_REFS: FxHashMap<Symbol, (usize, Target)> = {
-                let mut item_refs = FxHashMap::default();
-                $( item_refs.insert($name, (LangItem::$variant as usize, $target)); )*
-                item_refs
-            };
-        }
+        /// A mapping from the name of the lang item to its order and the form it must be of.
+        pub static ITEM_REFS: SyncLazy<FxHashMap<Symbol, (usize, Target)>> = SyncLazy::new(|| {
+            let mut item_refs = FxHashMap::default();
+            $( item_refs.insert($name, (LangItem::$variant as usize, $target)); )*
+            item_refs
+        });
 
 // End of the macro
     }

--- a/compiler/rustc_hir/src/lib.rs
+++ b/compiler/rustc_hir/src/lib.rs
@@ -6,6 +6,7 @@
 #![feature(const_fn)] // For the unsizing cast on `&[]`
 #![feature(const_panic)]
 #![feature(in_band_lifetimes)]
+#![feature(once_cell)]
 #![feature(or_patterns)]
 #![recursion_limit = "256"]
 

--- a/compiler/rustc_hir/src/weak_lang_items.rs
+++ b/compiler/rustc_hir/src/weak_lang_items.rs
@@ -7,18 +7,16 @@ use rustc_ast as ast;
 use rustc_data_structures::fx::FxHashMap;
 use rustc_span::symbol::{sym, Symbol};
 
-use lazy_static::lazy_static;
+use std::lazy::SyncLazy;
 
 macro_rules! weak_lang_items {
     ($($name:ident, $item:ident, $sym:ident;)*) => (
 
-lazy_static! {
-    pub static ref WEAK_ITEMS_REFS: FxHashMap<Symbol, LangItem> = {
-        let mut map = FxHashMap::default();
-        $(map.insert(sym::$name, LangItem::$item);)*
-        map
-    };
-}
+pub static WEAK_ITEMS_REFS: SyncLazy<FxHashMap<Symbol, LangItem>> = SyncLazy::new(|| {
+    let mut map = FxHashMap::default();
+    $(map.insert(sym::$name, LangItem::$item);)*
+    map
+});
 
 /// The `check_name` argument avoids the need for `librustc_hir` to depend on
 /// `librustc_session`.

--- a/compiler/rustc_interface/Cargo.toml
+++ b/compiler/rustc_interface/Cargo.toml
@@ -43,7 +43,6 @@ rustc_resolve = { path = "../rustc_resolve" }
 rustc_trait_selection = { path = "../rustc_trait_selection" }
 rustc_ty = { path = "../rustc_ty" }
 tempfile = "3.0.5"
-once_cell = "1"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["libloaderapi"] }

--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -2,7 +2,6 @@ use crate::interface::{Compiler, Result};
 use crate::proc_macro_decls;
 use crate::util;
 
-use once_cell::sync::Lazy;
 use rustc_ast::mut_visit::MutVisitor;
 use rustc_ast::{self as ast, visit};
 use rustc_codegen_ssa::back::link::emit_metadata;
@@ -46,6 +45,7 @@ use std::any::Any;
 use std::cell::RefCell;
 use std::ffi::OsString;
 use std::io::{self, BufWriter, Write};
+use std::lazy::SyncLazy;
 use std::path::PathBuf;
 use std::rc::Rc;
 use std::{env, fs, iter, mem};
@@ -681,7 +681,7 @@ pub fn prepare_outputs(
     Ok(outputs)
 }
 
-pub static DEFAULT_QUERY_PROVIDERS: Lazy<Providers> = Lazy::new(|| {
+pub static DEFAULT_QUERY_PROVIDERS: SyncLazy<Providers> = SyncLazy::new(|| {
     let providers = &mut Providers::default();
     providers.analysis = analysis;
     proc_macro_decls::provide(providers);
@@ -704,7 +704,7 @@ pub static DEFAULT_QUERY_PROVIDERS: Lazy<Providers> = Lazy::new(|| {
     *providers
 });
 
-pub static DEFAULT_EXTERN_QUERY_PROVIDERS: Lazy<Providers> = Lazy::new(|| {
+pub static DEFAULT_EXTERN_QUERY_PROVIDERS: SyncLazy<Providers> = SyncLazy::new(|| {
     let mut extern_providers = *DEFAULT_QUERY_PROVIDERS;
     rustc_metadata::provide_extern(&mut extern_providers);
     rustc_codegen_ssa::provide_extern(&mut extern_providers);

--- a/compiler/rustc_interface/src/util.rs
+++ b/compiler/rustc_interface/src/util.rs
@@ -25,6 +25,7 @@ use rustc_span::symbol::{sym, Symbol};
 use smallvec::SmallVec;
 use std::env;
 use std::io::{self, Write};
+use std::lazy::SyncOnceCell;
 use std::mem;
 use std::ops::DerefMut;
 use std::path::{Path, PathBuf};
@@ -243,8 +244,7 @@ pub fn get_codegen_backend(sess: &Session) -> Box<dyn CodegenBackend> {
 // loading, so we leave the code here. It is potentially useful for other tools
 // that want to invoke the rustc binary while linking to rustc as well.
 pub fn rustc_path<'a>() -> Option<&'a Path> {
-    static RUSTC_PATH: once_cell::sync::OnceCell<Option<PathBuf>> =
-        once_cell::sync::OnceCell::new();
+    static RUSTC_PATH: SyncOnceCell<Option<PathBuf>> = SyncOnceCell::new();
 
     const BIN_PATH: &str = env!("RUSTC_INSTALL_BINDIR");
 


### PR DESCRIPTION
Fixes #76192 

The only remaining direct use of `lazy_static` crate is in `src/bootstrap`  but I am not sure how I can remove that dependency for now.

r? @matklad 