### PR TITLE
rename MaybeUninit slice methods

### DIFF
--- a/library/alloc/src/collections/btree/node.rs
+++ b/library/alloc/src/collections/btree/node.rs
@@ -474,11 +474,15 @@ impl<'a, K, V, Type> NodeRef<marker::Mut<'a>, K, V, Type> {
 
 impl<'a, K: 'a, V: 'a, Type> NodeRef<marker::Immut<'a>, K, V, Type> {
     fn into_key_slice(self) -> &'a [K] {
-        unsafe { slice::from_raw_parts(MaybeUninit::first_ptr(&self.as_leaf().keys), self.len()) }
+        unsafe {
+            slice::from_raw_parts(MaybeUninit::slice_as_ptr(&self.as_leaf().keys), self.len())
+        }
     }
 
     fn into_val_slice(self) -> &'a [V] {
-        unsafe { slice::from_raw_parts(MaybeUninit::first_ptr(&self.as_leaf().vals), self.len()) }
+        unsafe {
+            slice::from_raw_parts(MaybeUninit::slice_as_ptr(&self.as_leaf().vals), self.len())
+        }
     }
 }
 
@@ -493,7 +497,7 @@ impl<'a, K: 'a, V: 'a, Type> NodeRef<marker::Mut<'a>, K, V, Type> {
         // SAFETY: The keys of a node must always be initialized up to length.
         unsafe {
             slice::from_raw_parts_mut(
-                MaybeUninit::first_ptr_mut(&mut (*self.as_leaf_mut()).keys),
+                MaybeUninit::slice_as_mut_ptr(&mut (*self.as_leaf_mut()).keys),
                 self.len(),
             )
         }
@@ -503,7 +507,7 @@ impl<'a, K: 'a, V: 'a, Type> NodeRef<marker::Mut<'a>, K, V, Type> {
         // SAFETY: The values of a node must always be initialized up to length.
         unsafe {
             slice::from_raw_parts_mut(
-                MaybeUninit::first_ptr_mut(&mut (*self.as_leaf_mut()).vals),
+                MaybeUninit::slice_as_mut_ptr(&mut (*self.as_leaf_mut()).vals),
                 self.len(),
             )
         }
@@ -519,10 +523,10 @@ impl<'a, K: 'a, V: 'a, Type> NodeRef<marker::Mut<'a>, K, V, Type> {
         let leaf = self.as_leaf_mut();
         // SAFETY: The keys and values of a node must always be initialized up to length.
         let keys = unsafe {
-            slice::from_raw_parts_mut(MaybeUninit::first_ptr_mut(&mut (*leaf).keys), len)
+            slice::from_raw_parts_mut(MaybeUninit::slice_as_mut_ptr(&mut (*leaf).keys), len)
         };
         let vals = unsafe {
-            slice::from_raw_parts_mut(MaybeUninit::first_ptr_mut(&mut (*leaf).vals), len)
+            slice::from_raw_parts_mut(MaybeUninit::slice_as_mut_ptr(&mut (*leaf).vals), len)
         };
         (keys, vals)
     }
@@ -536,9 +540,9 @@ impl<'a, K: 'a, V: 'a, Type> NodeRef<marker::ValMut<'a>, K, V, Type> {
         let len = self.len();
         let leaf = self.node.as_ptr();
         // SAFETY: The keys and values of a node must always be initialized up to length.
-        let keys = unsafe { slice::from_raw_parts(MaybeUninit::first_ptr(&(*leaf).keys), len) };
+        let keys = unsafe { slice::from_raw_parts(MaybeUninit::slice_as_ptr(&(*leaf).keys), len) };
         let vals = unsafe {
-            slice::from_raw_parts_mut(MaybeUninit::first_ptr_mut(&mut (*leaf).vals), len)
+            slice::from_raw_parts_mut(MaybeUninit::slice_as_mut_ptr(&mut (*leaf).vals), len)
         };
         (keys, vals)
     }
@@ -617,7 +621,7 @@ impl<'a, K, V> NodeRef<marker::Mut<'a>, K, V, marker::Internal> {
             slice_insert(self.vals_mut(), 0, val);
             slice_insert(
                 slice::from_raw_parts_mut(
-                    MaybeUninit::first_ptr_mut(&mut self.as_internal_mut().edges),
+                    MaybeUninit::slice_as_mut_ptr(&mut self.as_internal_mut().edges),
                     self.len() + 1,
                 ),
                 0,
@@ -675,7 +679,7 @@ impl<'a, K, V> NodeRef<marker::Mut<'a>, K, V, marker::LeafOrInternal> {
                 ForceResult::Internal(mut internal) => {
                     let edge = slice_remove(
                         slice::from_raw_parts_mut(
-                            MaybeUninit::first_ptr_mut(&mut internal.as_internal_mut().edges),
+                            MaybeUninit::slice_as_mut_ptr(&mut internal.as_internal_mut().edges),
                             old_len + 1,
                         ),
                         0,
@@ -962,7 +966,7 @@ impl<'a, K, V> Handle<NodeRef<marker::Mut<'a>, K, V, marker::Internal>, marker::
 
             slice_insert(
                 slice::from_raw_parts_mut(
-                    MaybeUninit::first_ptr_mut(&mut self.node.as_internal_mut().edges),
+                    MaybeUninit::slice_as_mut_ptr(&mut self.node.as_internal_mut().edges),
                     self.node.len(),
                 ),
                 self.idx + 1,

--- a/library/core/src/array/iter.rs
+++ b/library/core/src/array/iter.rs
@@ -73,7 +73,7 @@ impl<T, const N: usize> IntoIter<T, N> {
         // SAFETY: We know that all elements within `alive` are properly initialized.
         unsafe {
             let slice = self.data.get_unchecked(self.alive.clone());
-            MaybeUninit::slice_get_ref(slice)
+            MaybeUninit::slice_assume_init_ref(slice)
         }
     }
 
@@ -82,7 +82,7 @@ impl<T, const N: usize> IntoIter<T, N> {
         // SAFETY: We know that all elements within `alive` are properly initialized.
         unsafe {
             let slice = self.data.get_unchecked_mut(self.alive.clone());
-            MaybeUninit::slice_get_mut(slice)
+            MaybeUninit::slice_assume_init_mut(slice)
         }
     }
 }

--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -410,7 +410,7 @@ impl<T, const N: usize> [T; N] {
         }
         let mut dst = MaybeUninit::uninit_array::<N>();
         let mut guard: Guard<U, N> =
-            Guard { dst: MaybeUninit::first_ptr_mut(&mut dst), initialized: 0 };
+            Guard { dst: MaybeUninit::slice_as_mut_ptr(&mut dst), initialized: 0 };
         for (src, dst) in IntoIter::new(self).zip(&mut dst) {
             dst.write(f(src));
             guard.initialized += 1;

--- a/library/core/src/fmt/num.rs
+++ b/library/core/src/fmt/num.rs
@@ -85,7 +85,10 @@ trait GenericRadix {
         // SAFETY: The only chars in `buf` are created by `Self::digit` which are assumed to be
         // valid UTF-8
         let buf = unsafe {
-            str::from_utf8_unchecked(slice::from_raw_parts(MaybeUninit::first_ptr(buf), buf.len()))
+            str::from_utf8_unchecked(slice::from_raw_parts(
+                MaybeUninit::slice_as_ptr(buf),
+                buf.len(),
+            ))
         };
         f.pad_integral(is_nonnegative, Self::PREFIX, buf)
     }
@@ -192,7 +195,7 @@ macro_rules! impl_Display {
             // 2^128 is about 3*10^38, so 39 gives an extra byte of space
             let mut buf = [MaybeUninit::<u8>::uninit(); 39];
             let mut curr = buf.len() as isize;
-            let buf_ptr = MaybeUninit::first_ptr_mut(&mut buf);
+            let buf_ptr = MaybeUninit::slice_as_mut_ptr(&mut buf);
             let lut_ptr = DEC_DIGITS_LUT.as_ptr();
 
             // SAFETY: Since `d1` and `d2` are always less than or equal to `198`, we
@@ -322,7 +325,7 @@ macro_rules! impl_Exp {
             // that `curr >= 0`.
             let mut buf = [MaybeUninit::<u8>::uninit(); 40];
             let mut curr = buf.len() as isize; //index for buf
-            let buf_ptr = MaybeUninit::first_ptr_mut(&mut buf);
+            let buf_ptr = MaybeUninit::slice_as_mut_ptr(&mut buf);
             let lut_ptr = DEC_DIGITS_LUT.as_ptr();
 
             // decode 2 chars at a time
@@ -370,7 +373,7 @@ macro_rules! impl_Exp {
 
             // stores 'e' (or 'E') and the up to 2-digit exponent
             let mut exp_buf = [MaybeUninit::<u8>::uninit(); 3];
-            let exp_ptr = MaybeUninit::first_ptr_mut(&mut exp_buf);
+            let exp_ptr = MaybeUninit::slice_as_mut_ptr(&mut exp_buf);
             // SAFETY: In either case, `exp_buf` is written within bounds and `exp_ptr[..len]`
             // is contained within `exp_buf` since `len <= 3`.
             let exp_slice = unsafe {

--- a/library/core/src/mem/maybe_uninit.rs
+++ b/library/core/src/mem/maybe_uninit.rs
@@ -281,7 +281,7 @@ impl<T> MaybeUninit<T> {
     /// # Examples
     ///
     /// ```no_run
-    /// #![feature(maybe_uninit_uninit_array, maybe_uninit_extra, maybe_uninit_slice_assume_init)]
+    /// #![feature(maybe_uninit_uninit_array, maybe_uninit_extra, maybe_uninit_slice)]
     ///
     /// use std::mem::MaybeUninit;
     ///
@@ -293,7 +293,7 @@ impl<T> MaybeUninit<T> {
     /// fn read(buf: &mut [MaybeUninit<u8>]) -> &[u8] {
     ///     unsafe {
     ///         let len = read_into_buffer(buf.as_mut_ptr() as *mut u8, buf.len());
-    ///         MaybeUninit::slice_get_ref(&buf[..len])
+    ///         MaybeUninit::slice_assume_init_ref(&buf[..len])
     ///     }
     /// }
     ///
@@ -303,6 +303,7 @@ impl<T> MaybeUninit<T> {
     #[unstable(feature = "maybe_uninit_uninit_array", issue = "none")]
     #[inline(always)]
     pub fn uninit_array<const LEN: usize>() -> [Self; LEN] {
+        // SAFETY: An uninitialized `[MaybeUninit<_>; LEN]` is valid.
         unsafe { MaybeUninit::<[MaybeUninit<T>; LEN]>::uninit().assume_init() }
     }
 
@@ -769,9 +770,13 @@ impl<T> MaybeUninit<T> {
     /// It is up to the caller to guarantee that the `MaybeUninit<T>` elements
     /// really are in an initialized state.
     /// Calling this when the content is not yet fully initialized causes undefined behavior.
-    #[unstable(feature = "maybe_uninit_slice_assume_init", issue = "none")]
+    ///
+    /// See [`assume_init_ref`] for more details and examples.
+    ///
+    /// [`assume_init_ref`]: MaybeUninit::assume_init_ref
+    #[unstable(feature = "maybe_uninit_slice", issue = "63569")]
     #[inline(always)]
-    pub unsafe fn slice_get_ref(slice: &[Self]) -> &[T] {
+    pub unsafe fn slice_assume_init_ref(slice: &[Self]) -> &[T] {
         // SAFETY: casting slice to a `*const [T]` is safe since the caller guarantees that
         // `slice` is initialized, and`MaybeUninit` is guaranteed to have the same layout as `T`.
         // The pointer obtained is valid since it refers to memory owned by `slice` which is a
@@ -786,9 +791,13 @@ impl<T> MaybeUninit<T> {
     /// It is up to the caller to guarantee that the `MaybeUninit<T>` elements
     /// really are in an initialized state.
     /// Calling this when the content is not yet fully initialized causes undefined behavior.
-    #[unstable(feature = "maybe_uninit_slice_assume_init", issue = "none")]
+    ///
+    /// See [`assume_init_mut`] for more details and examples.
+    ///
+    /// [`assume_init_mut`]: MaybeUninit::assume_init_mut
+    #[unstable(feature = "maybe_uninit_slice", issue = "63569")]
     #[inline(always)]
-    pub unsafe fn slice_get_mut(slice: &mut [Self]) -> &mut [T] {
+    pub unsafe fn slice_assume_init_mut(slice: &mut [Self]) -> &mut [T] {
         // SAFETY: similar to safety notes for `slice_get_ref`, but we have a
         // mutable reference which is also guaranteed to be valid for writes.
         unsafe { &mut *(slice as *mut [Self] as *mut [T]) }
@@ -797,14 +806,14 @@ impl<T> MaybeUninit<T> {
     /// Gets a pointer to the first element of the array.
     #[unstable(feature = "maybe_uninit_slice", issue = "63569")]
     #[inline(always)]
-    pub fn first_ptr(this: &[MaybeUninit<T>]) -> *const T {
+    pub fn slice_as_ptr(this: &[MaybeUninit<T>]) -> *const T {
         this as *const [MaybeUninit<T>] as *const T
     }
 
     /// Gets a mutable pointer to the first element of the array.
     #[unstable(feature = "maybe_uninit_slice", issue = "63569")]
     #[inline(always)]
-    pub fn first_ptr_mut(this: &mut [MaybeUninit<T>]) -> *mut T {
+    pub fn slice_as_mut_ptr(this: &mut [MaybeUninit<T>]) -> *mut T {
         this as *mut [MaybeUninit<T>] as *mut T
     }
 }

--- a/library/core/src/num/flt2dec/mod.rs
+++ b/library/core/src/num/flt2dec/mod.rs
@@ -311,10 +311,10 @@ fn digits_to_dec_str<'a>(
         if frac_digits > buf.len() && frac_digits - buf.len() > minus_exp {
             parts[3] = MaybeUninit::new(Part::Zero((frac_digits - buf.len()) - minus_exp));
             // SAFETY: we just initialized the elements `..4`.
-            unsafe { MaybeUninit::slice_get_ref(&parts[..4]) }
+            unsafe { MaybeUninit::slice_assume_init_ref(&parts[..4]) }
         } else {
             // SAFETY: we just initialized the elements `..3`.
-            unsafe { MaybeUninit::slice_get_ref(&parts[..3]) }
+            unsafe { MaybeUninit::slice_assume_init_ref(&parts[..3]) }
         }
     } else {
         let exp = exp as usize;
@@ -326,10 +326,10 @@ fn digits_to_dec_str<'a>(
             if frac_digits > buf.len() - exp {
                 parts[3] = MaybeUninit::new(Part::Zero(frac_digits - (buf.len() - exp)));
                 // SAFETY: we just initialized the elements `..4`.
-                unsafe { MaybeUninit::slice_get_ref(&parts[..4]) }
+                unsafe { MaybeUninit::slice_assume_init_ref(&parts[..4]) }
             } else {
                 // SAFETY: we just initialized the elements `..3`.
-                unsafe { MaybeUninit::slice_get_ref(&parts[..3]) }
+                unsafe { MaybeUninit::slice_assume_init_ref(&parts[..3]) }
             }
         } else {
             // the decimal point is after rendered digits: [1234][____0000] or [1234][__][.][__].
@@ -339,10 +339,10 @@ fn digits_to_dec_str<'a>(
                 parts[2] = MaybeUninit::new(Part::Copy(b"."));
                 parts[3] = MaybeUninit::new(Part::Zero(frac_digits));
                 // SAFETY: we just initialized the elements `..4`.
-                unsafe { MaybeUninit::slice_get_ref(&parts[..4]) }
+                unsafe { MaybeUninit::slice_assume_init_ref(&parts[..4]) }
             } else {
                 // SAFETY: we just initialized the elements `..2`.
-                unsafe { MaybeUninit::slice_get_ref(&parts[..2]) }
+                unsafe { MaybeUninit::slice_assume_init_ref(&parts[..2]) }
             }
         }
     }
@@ -393,7 +393,7 @@ fn digits_to_exp_str<'a>(
         parts[n + 1] = MaybeUninit::new(Part::Num(exp as u16));
     }
     // SAFETY: we just initialized the elements `..n + 2`.
-    unsafe { MaybeUninit::slice_get_ref(&parts[..n + 2]) }
+    unsafe { MaybeUninit::slice_assume_init_ref(&parts[..n + 2]) }
 }
 
 /// Sign formatting options.
@@ -487,24 +487,30 @@ where
         FullDecoded::Nan => {
             parts[0] = MaybeUninit::new(Part::Copy(b"NaN"));
             // SAFETY: we just initialized the elements `..1`.
-            Formatted { sign, parts: unsafe { MaybeUninit::slice_get_ref(&parts[..1]) } }
+            Formatted { sign, parts: unsafe { MaybeUninit::slice_assume_init_ref(&parts[..1]) } }
         }
         FullDecoded::Infinite => {
             parts[0] = MaybeUninit::new(Part::Copy(b"inf"));
             // SAFETY: we just initialized the elements `..1`.
-            Formatted { sign, parts: unsafe { MaybeUninit::slice_get_ref(&parts[..1]) } }
+            Formatted { sign, parts: unsafe { MaybeUninit::slice_assume_init_ref(&parts[..1]) } }
         }
         FullDecoded::Zero => {
             if frac_digits > 0 {
                 // [0.][0000]
                 parts[0] = MaybeUninit::new(Part::Copy(b"0."));
                 parts[1] = MaybeUninit::new(Part::Zero(frac_digits));
-                // SAFETY: we just initialized the elements `..2`.
-                Formatted { sign, parts: unsafe { MaybeUninit::slice_get_ref(&parts[..2]) } }
+                Formatted {
+                    sign,
+                    // SAFETY: we just initialized the elements `..2`.
+                    parts: unsafe { MaybeUninit::slice_assume_init_ref(&parts[..2]) },
+                }
             } else {
                 parts[0] = MaybeUninit::new(Part::Copy(b"0"));
-                // SAFETY: we just initialized the elements `..1`.
-                Formatted { sign, parts: unsafe { MaybeUninit::slice_get_ref(&parts[..1]) } }
+                Formatted {
+                    sign,
+                    // SAFETY: we just initialized the elements `..1`.
+                    parts: unsafe { MaybeUninit::slice_assume_init_ref(&parts[..1]) },
+                }
             }
         }
         FullDecoded::Finite(ref decoded) => {
@@ -557,12 +563,12 @@ where
         FullDecoded::Nan => {
             parts[0] = MaybeUninit::new(Part::Copy(b"NaN"));
             // SAFETY: we just initialized the elements `..1`.
-            Formatted { sign, parts: unsafe { MaybeUninit::slice_get_ref(&parts[..1]) } }
+            Formatted { sign, parts: unsafe { MaybeUninit::slice_assume_init_ref(&parts[..1]) } }
         }
         FullDecoded::Infinite => {
             parts[0] = MaybeUninit::new(Part::Copy(b"inf"));
             // SAFETY: we just initialized the elements `..1`.
-            Formatted { sign, parts: unsafe { MaybeUninit::slice_get_ref(&parts[..1]) } }
+            Formatted { sign, parts: unsafe { MaybeUninit::slice_assume_init_ref(&parts[..1]) } }
         }
         FullDecoded::Zero => {
             parts[0] = if dec_bounds.0 <= 0 && 0 < dec_bounds.1 {
@@ -571,7 +577,7 @@ where
                 MaybeUninit::new(Part::Copy(if upper { b"0E0" } else { b"0e0" }))
             };
             // SAFETY: we just initialized the elements `..1`.
-            Formatted { sign, parts: unsafe { MaybeUninit::slice_get_ref(&parts[..1]) } }
+            Formatted { sign, parts: unsafe { MaybeUninit::slice_assume_init_ref(&parts[..1]) } }
         }
         FullDecoded::Finite(ref decoded) => {
             let (buf, exp) = format_shortest(decoded, buf);
@@ -648,12 +654,12 @@ where
         FullDecoded::Nan => {
             parts[0] = MaybeUninit::new(Part::Copy(b"NaN"));
             // SAFETY: we just initialized the elements `..1`.
-            Formatted { sign, parts: unsafe { MaybeUninit::slice_get_ref(&parts[..1]) } }
+            Formatted { sign, parts: unsafe { MaybeUninit::slice_assume_init_ref(&parts[..1]) } }
         }
         FullDecoded::Infinite => {
             parts[0] = MaybeUninit::new(Part::Copy(b"inf"));
             // SAFETY: we just initialized the elements `..1`.
-            Formatted { sign, parts: unsafe { MaybeUninit::slice_get_ref(&parts[..1]) } }
+            Formatted { sign, parts: unsafe { MaybeUninit::slice_assume_init_ref(&parts[..1]) } }
         }
         FullDecoded::Zero => {
             if ndigits > 1 {
@@ -661,12 +667,18 @@ where
                 parts[0] = MaybeUninit::new(Part::Copy(b"0."));
                 parts[1] = MaybeUninit::new(Part::Zero(ndigits - 1));
                 parts[2] = MaybeUninit::new(Part::Copy(if upper { b"E0" } else { b"e0" }));
-                // SAFETY: we just initialized the elements `..3`.
-                Formatted { sign, parts: unsafe { MaybeUninit::slice_get_ref(&parts[..3]) } }
+                Formatted {
+                    sign,
+                    // SAFETY: we just initialized the elements `..3`.
+                    parts: unsafe { MaybeUninit::slice_assume_init_ref(&parts[..3]) },
+                }
             } else {
                 parts[0] = MaybeUninit::new(Part::Copy(if upper { b"0E0" } else { b"0e0" }));
-                // SAFETY: we just initialized the elements `..1`.
-                Formatted { sign, parts: unsafe { MaybeUninit::slice_get_ref(&parts[..1]) } }
+                Formatted {
+                    sign,
+                    // SAFETY: we just initialized the elements `..1`.
+                    parts: unsafe { MaybeUninit::slice_assume_init_ref(&parts[..1]) },
+                }
             }
         }
         FullDecoded::Finite(ref decoded) => {
@@ -716,24 +728,30 @@ where
         FullDecoded::Nan => {
             parts[0] = MaybeUninit::new(Part::Copy(b"NaN"));
             // SAFETY: we just initialized the elements `..1`.
-            Formatted { sign, parts: unsafe { MaybeUninit::slice_get_ref(&parts[..1]) } }
+            Formatted { sign, parts: unsafe { MaybeUninit::slice_assume_init_ref(&parts[..1]) } }
         }
         FullDecoded::Infinite => {
             parts[0] = MaybeUninit::new(Part::Copy(b"inf"));
             // SAFETY: we just initialized the elements `..1`.
-            Formatted { sign, parts: unsafe { MaybeUninit::slice_get_ref(&parts[..1]) } }
+            Formatted { sign, parts: unsafe { MaybeUninit::slice_assume_init_ref(&parts[..1]) } }
         }
         FullDecoded::Zero => {
             if frac_digits > 0 {
                 // [0.][0000]
                 parts[0] = MaybeUninit::new(Part::Copy(b"0."));
                 parts[1] = MaybeUninit::new(Part::Zero(frac_digits));
-                // SAFETY: we just initialized the elements `..2`.
-                Formatted { sign, parts: unsafe { MaybeUninit::slice_get_ref(&parts[..2]) } }
+                Formatted {
+                    sign,
+                    // SAFETY: we just initialized the elements `..2`.
+                    parts: unsafe { MaybeUninit::slice_assume_init_ref(&parts[..2]) },
+                }
             } else {
                 parts[0] = MaybeUninit::new(Part::Copy(b"0"));
-                // SAFETY: we just initialized the elements `..1`.
-                Formatted { sign, parts: unsafe { MaybeUninit::slice_get_ref(&parts[..1]) } }
+                Formatted {
+                    sign,
+                    // SAFETY: we just initialized the elements `..1`.
+                    parts: unsafe { MaybeUninit::slice_assume_init_ref(&parts[..1]) },
+                }
             }
         }
         FullDecoded::Finite(ref decoded) => {
@@ -754,12 +772,18 @@ where
                     // [0.][0000]
                     parts[0] = MaybeUninit::new(Part::Copy(b"0."));
                     parts[1] = MaybeUninit::new(Part::Zero(frac_digits));
-                    // SAFETY: we just initialized the elements `..2`.
-                    Formatted { sign, parts: unsafe { MaybeUninit::slice_get_ref(&parts[..2]) } }
+                    Formatted {
+                        sign,
+                        // SAFETY: we just initialized the elements `..2`.
+                        parts: unsafe { MaybeUninit::slice_assume_init_ref(&parts[..2]) },
+                    }
                 } else {
                     parts[0] = MaybeUninit::new(Part::Copy(b"0"));
-                    // SAFETY: we just initialized the elements `..1`.
-                    Formatted { sign, parts: unsafe { MaybeUninit::slice_get_ref(&parts[..1]) } }
+                    Formatted {
+                        sign,
+                        // SAFETY: we just initialized the elements `..1`.
+                        parts: unsafe { MaybeUninit::slice_assume_init_ref(&parts[..1]) },
+                    }
                 }
             } else {
                 Formatted { sign, parts: digits_to_dec_str(buf, exp, frac_digits, parts) }

--- a/library/core/src/num/flt2dec/strategy/dragon.rs
+++ b/library/core/src/num/flt2dec/strategy/dragon.rs
@@ -246,7 +246,7 @@ pub fn format_shortest<'a>(
         // it seems that this condition is very hard to satisfy (possibly impossible),
         // but we are just being safe and consistent here.
         // SAFETY: we initialized that memory above.
-        if let Some(c) = round_up(unsafe { MaybeUninit::slice_get_mut(&mut buf[..i]) }) {
+        if let Some(c) = round_up(unsafe { MaybeUninit::slice_assume_init_mut(&mut buf[..i]) }) {
             buf[i] = MaybeUninit::new(c);
             i += 1;
             k += 1;
@@ -254,7 +254,7 @@ pub fn format_shortest<'a>(
     }
 
     // SAFETY: we initialized that memory above.
-    (unsafe { MaybeUninit::slice_get_ref(&buf[..i]) }, k)
+    (unsafe { MaybeUninit::slice_assume_init_ref(&buf[..i]) }, k)
 }
 
 /// The exact and fixed mode implementation for Dragon.
@@ -332,7 +332,7 @@ pub fn format_exact<'a>(
                     *c = MaybeUninit::new(b'0');
                 }
                 // SAFETY: we initialized that memory above.
-                return (unsafe { MaybeUninit::slice_get_ref(&buf[..len]) }, k);
+                return (unsafe { MaybeUninit::slice_assume_init_ref(&buf[..len]) }, k);
             }
 
             let mut d = 0;
@@ -371,7 +371,7 @@ pub fn format_exact<'a>(
         // if rounding up changes the length, the exponent should also change.
         // but we've been requested a fixed number of digits, so do not alter the buffer...
         // SAFETY: we initialized that memory above.
-        if let Some(c) = round_up(unsafe { MaybeUninit::slice_get_mut(&mut buf[..len]) }) {
+        if let Some(c) = round_up(unsafe { MaybeUninit::slice_assume_init_mut(&mut buf[..len]) }) {
             // ...unless we've been requested the fixed precision instead.
             // we also need to check that, if the original buffer was empty,
             // the additional digit can only be added when `k == limit` (edge case).
@@ -384,5 +384,5 @@ pub fn format_exact<'a>(
     }
 
     // SAFETY: we initialized that memory above.
-    (unsafe { MaybeUninit::slice_get_ref(&buf[..len]) }, k)
+    (unsafe { MaybeUninit::slice_assume_init_ref(&buf[..len]) }, k)
 }

--- a/library/core/src/slice/sort.rs
+++ b/library/core/src/slice/sort.rs
@@ -299,8 +299,8 @@ where
 
         if start_l == end_l {
             // Trace `block_l` elements from the left side.
-            start_l = MaybeUninit::first_ptr_mut(&mut offsets_l);
-            end_l = MaybeUninit::first_ptr_mut(&mut offsets_l);
+            start_l = MaybeUninit::slice_as_mut_ptr(&mut offsets_l);
+            end_l = MaybeUninit::slice_as_mut_ptr(&mut offsets_l);
             let mut elem = l;
 
             for i in 0..block_l {
@@ -325,8 +325,8 @@ where
 
         if start_r == end_r {
             // Trace `block_r` elements from the right side.
-            start_r = MaybeUninit::first_ptr_mut(&mut offsets_r);
-            end_r = MaybeUninit::first_ptr_mut(&mut offsets_r);
+            start_r = MaybeUninit::slice_as_mut_ptr(&mut offsets_r);
+            end_r = MaybeUninit::slice_as_mut_ptr(&mut offsets_r);
             let mut elem = r;
 
             for i in 0..block_r {


### PR DESCRIPTION
The `first` methods conceptually point to the whole slice, not just its first element, so rename them to be consistent with the raw ptr methods on ref-slices.

Also, do the equivalent of https://github.com/rust-lang/rust/pull/76047 for the slice reference getters, and make them part of https://github.com/rust-lang/rust/issues/63569 (so far they somehow had no tracking issue).

* first_ptr -> slice_as_ptr
* first_ptr_mut -> slice_as_mut_ptr
* slice_get_ref -> slice_assume_init_ref
* slice_get_mut -> slice_assume_init_mut