### PR TITLE
lexer: Tiny improvement to shebang detection

### DIFF
--- a/compiler/rustc_lexer/src/lib.rs
+++ b/compiler/rustc_lexer/src/lib.rs
@@ -191,12 +191,16 @@ pub fn strip_shebang(input: &str) -> Option<usize> {
     // For simplicity we consider any line starting with `#!` a shebang,
     // regardless of restrictions put on shebangs by specific platforms.
     if let Some(input_tail) = input.strip_prefix("#!") {
-        // Ok, this is a shebang but if the next non-whitespace token is `[` or maybe
-        // a doc comment (due to `TokenKind::(Line,Block)Comment` ambiguity at lexer level),
+        // Ok, this is a shebang but if the next non-whitespace token is `[`,
         // then it may be valid Rust code, so consider it Rust code.
-        let next_non_whitespace_token = tokenize(input_tail).map(|tok| tok.kind).find(|tok|
-            !matches!(tok, TokenKind::Whitespace | TokenKind::LineComment { .. } | TokenKind::BlockComment { .. })
-        );
+        let next_non_whitespace_token = tokenize(input_tail).map(|tok| tok.kind).find(|tok| {
+            !matches!(
+                tok,
+                TokenKind::Whitespace
+                    | TokenKind::LineComment { doc_style: None }
+                    | TokenKind::BlockComment { doc_style: None, .. }
+            )
+        });
         if next_non_whitespace_token != Some(TokenKind::OpenBracket) {
             // No other choice than to consider this a shebang.
             return Some(2 + input_tail.lines().next().unwrap_or_default().len());

--- a/src/test/ui/parser/shebang/shebang-doc-comment.rs
+++ b/src/test/ui/parser/shebang/shebang-doc-comment.rs
@@ -1,6 +1,3 @@
 #!///bin/bash
 [allow(unused_variables)]
-//~^^ ERROR expected `[`, found doc comment
-
-// Doc comment is misinterpreted as a whitespace (regular comment) during shebang detection.
-// Even if it wasn't, it would still result in an error, just a different one.
+//~^ ERROR expected item, found `[`

--- a/src/test/ui/parser/shebang/shebang-doc-comment.stderr
+++ b/src/test/ui/parser/shebang/shebang-doc-comment.stderr
@@ -1,8 +1,8 @@
-error: expected `[`, found doc comment `///bin/bash`
-  --> $DIR/shebang-doc-comment.rs:1:3
+error: expected item, found `[`
+  --> $DIR/shebang-doc-comment.rs:2:1
    |
-LL | #!///bin/bash
-   |   ^^^^^^^^^^^ expected `[`
+LL | [allow(unused_variables)]
+   | ^ expected item
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Lexer now discerns between regular comments and doc comments, so use that.
The change only affects the choice of reported errors.