### PR TITLE
Add allow-by-default lint on implicit ABI in extern function pointers and items

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3896,6 +3896,7 @@ dependencies = [
  "rustc_macros",
  "rustc_serialize",
  "rustc_span",
+ "rustc_target",
  "tracing",
 ]
 

--- a/compiler/rustc_ast_lowering/src/item.rs
+++ b/compiler/rustc_ast_lowering/src/item.rs
@@ -317,12 +317,17 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 })
             }
             ItemKind::Mod(ref m) => hir::ItemKind::Mod(self.lower_mod(m)),
-            ItemKind::ForeignMod(ref fm) => hir::ItemKind::ForeignMod {
-                abi: fm.abi.map_or(abi::Abi::C, |abi| self.lower_abi(abi)),
-                items: self
-                    .arena
-                    .alloc_from_iter(fm.items.iter().map(|x| self.lower_foreign_item_ref(x))),
-            },
+            ItemKind::ForeignMod(ref fm) => {
+                if fm.abi.is_none() {
+                    self.maybe_lint_missing_abi(span, id, abi::Abi::C);
+                }
+                hir::ItemKind::ForeignMod {
+                    abi: fm.abi.map_or(abi::Abi::C, |abi| self.lower_abi(abi)),
+                    items: self
+                        .arena
+                        .alloc_from_iter(fm.items.iter().map(|x| self.lower_foreign_item_ref(x))),
+                }
+            }
             ItemKind::GlobalAsm(ref ga) => hir::ItemKind::GlobalAsm(self.lower_global_asm(ga)),
             ItemKind::TyAlias(_, ref gen, _, Some(ref ty)) => {
                 // We lower

--- a/compiler/rustc_ast_lowering/src/item.rs
+++ b/compiler/rustc_ast_lowering/src/item.rs
@@ -310,7 +310,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                     );
                     let sig = hir::FnSig {
                         decl,
-                        header: this.lower_fn_header(header),
+                        header: this.lower_fn_header(header, fn_sig_span, id),
                         span: fn_sig_span,
                     };
                     hir::ItemKind::Fn(sig, generics, body_id)
@@ -806,13 +806,13 @@ impl<'hir> LoweringContext<'_, 'hir> {
             AssocItemKind::Fn(_, ref sig, ref generics, None) => {
                 let names = self.lower_fn_params_to_names(&sig.decl);
                 let (generics, sig) =
-                    self.lower_method_sig(generics, sig, trait_item_def_id, false, None);
+                    self.lower_method_sig(generics, sig, trait_item_def_id, false, None, i.id);
                 (generics, hir::TraitItemKind::Fn(sig, hir::TraitFn::Required(names)))
             }
             AssocItemKind::Fn(_, ref sig, ref generics, Some(ref body)) => {
                 let body_id = self.lower_fn_body_block(i.span, &sig.decl, Some(body));
                 let (generics, sig) =
-                    self.lower_method_sig(generics, sig, trait_item_def_id, false, None);
+                    self.lower_method_sig(generics, sig, trait_item_def_id, false, None, i.id);
                 (generics, hir::TraitItemKind::Fn(sig, hir::TraitFn::Provided(body_id)))
             }
             AssocItemKind::TyAlias(_, ref generics, ref bounds, ref default) => {
@@ -882,6 +882,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                     impl_item_def_id,
                     impl_trait_return_allow,
                     asyncness.opt_return_id(),
+                    i.id,
                 );
 
                 (generics, hir::ImplItemKind::Fn(sig, body_id))
@@ -1275,8 +1276,9 @@ impl<'hir> LoweringContext<'_, 'hir> {
         fn_def_id: LocalDefId,
         impl_trait_return_allow: bool,
         is_async: Option<NodeId>,
+        id: NodeId,
     ) -> (hir::Generics<'hir>, hir::FnSig<'hir>) {
-        let header = self.lower_fn_header(sig.header);
+        let header = self.lower_fn_header(sig.header, sig.span, id);
         let (generics, decl) = self.add_in_band_defs(
             generics,
             fn_def_id,
@@ -1293,12 +1295,12 @@ impl<'hir> LoweringContext<'_, 'hir> {
         (generics, hir::FnSig { header, decl, span: sig.span })
     }
 
-    fn lower_fn_header(&mut self, h: FnHeader) -> hir::FnHeader {
+    fn lower_fn_header(&mut self, h: FnHeader, span: Span, id: NodeId) -> hir::FnHeader {
         hir::FnHeader {
             unsafety: self.lower_unsafety(h.unsafety),
             asyncness: self.lower_asyncness(h.asyncness),
             constness: self.lower_constness(h.constness),
-            abi: self.lower_extern(h.ext),
+            abi: self.lower_extern(h.ext, span, id),
         }
     }
 
@@ -1309,10 +1311,13 @@ impl<'hir> LoweringContext<'_, 'hir> {
         })
     }
 
-    pub(super) fn lower_extern(&mut self, ext: Extern) -> abi::Abi {
+    pub(super) fn lower_extern(&mut self, ext: Extern, span: Span, id: NodeId) -> abi::Abi {
         match ext {
             Extern::None => abi::Abi::Rust,
-            Extern::Implicit => abi::Abi::C,
+            Extern::Implicit => {
+                self.maybe_lint_missing_abi(span, id, abi::Abi::C);
+                abi::Abi::C
+            }
             Extern::Explicit(abi) => self.lower_abi(abi),
         }
     }

--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -1290,6 +1290,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
             }
             TyKind::BareFn(ref f) => self.with_in_scope_lifetime_defs(&f.generic_params, |this| {
                 this.with_anonymous_lifetime_mode(AnonymousLifetimeMode::PassThrough, |this| {
+                    let span = this.sess.source_map().next_point(t.span.shrink_to_lo());
                     hir::TyKind::BareFn(this.arena.alloc(hir::BareFnTy {
                         generic_params: this.lower_generic_params(
                             &f.generic_params,
@@ -1297,7 +1298,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                             ImplTraitContext::disallowed(),
                         ),
                         unsafety: this.lower_unsafety(f.unsafety),
-                        abi: this.lower_extern(f.ext),
+                        abi: this.lower_extern(f.ext, span, t.id),
                         decl: this.lower_fn_decl(&f.decl, None, false, None),
                         param_names: this.lower_fn_params_to_names(&f.decl),
                     }))

--- a/compiler/rustc_error_codes/src/error_codes/E0044.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0044.md
@@ -3,13 +3,13 @@ You cannot use type or const parameters on foreign items.
 Example of erroneous code:
 
 ```compile_fail,E0044
-extern { fn some_func<T>(x: T); }
+extern "C" { fn some_func<T>(x: T); }
 ```
 
 To fix this, replace the generic parameter with the specializations that you
 need:
 
 ```
-extern { fn some_func_i32(x: i32); }
-extern { fn some_func_i64(x: i64); }
+extern "C" { fn some_func_i32(x: i32); }
+extern "C" { fn some_func_i64(x: i64); }
 ```

--- a/compiler/rustc_error_codes/src/error_codes/E0130.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0130.md
@@ -3,7 +3,7 @@ A pattern was declared as an argument in a foreign function declaration.
 Erroneous code example:
 
 ```compile_fail,E0130
-extern {
+extern "C" {
     fn foo((a, b): (u32, u32)); // error: patterns aren't allowed in foreign
                                 //        function declarations
 }
@@ -17,7 +17,7 @@ struct SomeStruct {
     b: u32,
 }
 
-extern {
+extern "C" {
     fn foo(s: SomeStruct); // ok!
 }
 ```
@@ -25,7 +25,7 @@ extern {
 Or:
 
 ```
-extern {
+extern "C" {
     fn foo(a: (u32, u32)); // ok!
 }
 ```

--- a/compiler/rustc_error_codes/src/error_codes/E0454.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0454.md
@@ -3,7 +3,7 @@ A link name was given with an empty name.
 Erroneous code example:
 
 ```compile_fail,E0454
-#[link(name = "")] extern {}
+#[link(name = "")] extern "C" {}
 // error: `#[link(name = "")]` given with empty name
 ```
 
@@ -11,5 +11,5 @@ The rust compiler cannot link to an external library if you don't give it its
 name. Example:
 
 ```no_run
-#[link(name = "some_lib")] extern {} // ok!
+#[link(name = "some_lib")] extern "C" {} // ok!
 ```

--- a/compiler/rustc_error_codes/src/error_codes/E0455.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0455.md
@@ -4,7 +4,7 @@ as frameworks are specific to that operating system.
 Erroneous code example:
 
 ```ignore (should-compile_fail-but-cannot-doctest-conditionally-without-macos)
-#[link(name = "FooCoreServices", kind = "framework")] extern {}
+#[link(name = "FooCoreServices", kind = "framework")] extern "C" {}
 // OS used to compile is Linux for example
 ```
 
@@ -12,7 +12,7 @@ To solve this error you can use conditional compilation:
 
 ```
 #[cfg_attr(target="macos", link(name = "FooCoreServices", kind = "framework"))]
-extern {}
+extern "C" {}
 ```
 
 Learn more in the [Conditional Compilation][conditional-compilation] section

--- a/compiler/rustc_error_codes/src/error_codes/E0458.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0458.md
@@ -3,7 +3,7 @@ An unknown "kind" was specified for a link attribute.
 Erroneous code example:
 
 ```compile_fail,E0458
-#[link(kind = "wonderful_unicorn")] extern {}
+#[link(kind = "wonderful_unicorn")] extern "C" {}
 // error: unknown kind: `wonderful_unicorn`
 ```
 

--- a/compiler/rustc_error_codes/src/error_codes/E0459.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0459.md
@@ -3,7 +3,7 @@ A link was used without a name parameter.
 Erroneous code example:
 
 ```compile_fail,E0459
-#[link(kind = "dylib")] extern {}
+#[link(kind = "dylib")] extern "C" {}
 // error: `#[link(...)]` specified without `name = "foo"`
 ```
 
@@ -11,5 +11,5 @@ Please add the name parameter to allow the rust compiler to find the library
 you want. Example:
 
 ```no_run
-#[link(kind = "dylib", name = "some_lib")] extern {} // ok!
+#[link(kind = "dylib", name = "some_lib")] extern "C" {} // ok!
 ```

--- a/compiler/rustc_error_codes/src/error_codes/E0617.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0617.md
@@ -3,7 +3,7 @@ Attempted to pass an invalid type of variable into a variadic function.
 Erroneous code example:
 
 ```compile_fail,E0617
-extern {
+extern "C" {
     fn printf(c: *const i8, ...);
 }
 
@@ -21,7 +21,7 @@ to import from `std::os::raw`).
 In this case, `c_double` has the same size as `f64` so we can use it directly:
 
 ```no_run
-# extern {
+# extern "C" {
 #     fn printf(c: *const i8, ...);
 # }
 unsafe {

--- a/compiler/rustc_error_codes/src/error_codes/E0633.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0633.md
@@ -6,7 +6,7 @@ Erroneous code example:
 #![feature(unwind_attributes)]
 
 #[unwind()] // error: expected one argument
-pub extern fn something() {}
+pub extern "C" fn something() {}
 
 fn main() {}
 ```

--- a/compiler/rustc_error_codes/src/error_codes/E0724.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0724.md
@@ -18,7 +18,7 @@ the function inside of an `extern` block.
 ```
 #![feature(ffi_returns_twice)]
 
-extern {
+extern "C" {
    #[ffi_returns_twice] // ok!
    pub fn foo();
 }

--- a/compiler/rustc_lint/src/context.rs
+++ b/compiler/rustc_lint/src/context.rs
@@ -600,6 +600,10 @@ pub trait LintContext: Sized {
                 BuiltinLintDiagnostics::PatternsInFnsWithoutBody(span, ident) => {
                     db.span_suggestion(span, "remove `mut` from the parameter", ident.to_string(), Applicability::MachineApplicable);
                 }
+                BuiltinLintDiagnostics::MissingAbi(span, default_abi) => {
+                    db.span_label(span, "ABI should be specified here");
+                    db.help(&format!("the default ABI is {}", default_abi.name()));
+                }
             }
             // Rewrap `db`, and pass control to the user.
             decorate(LintDiagnosticBuilder::new(db));

--- a/compiler/rustc_lint_defs/Cargo.toml
+++ b/compiler/rustc_lint_defs/Cargo.toml
@@ -11,3 +11,4 @@ rustc_data_structures = { path = "../rustc_data_structures" }
 rustc_span = { path = "../rustc_span" }
 rustc_serialize = { path = "../rustc_serialize" }
 rustc_macros = { path = "../rustc_macros" }
+rustc_target = { path = "../rustc_target" }

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -2917,6 +2917,7 @@ declare_lint_pass! {
         FUNCTION_ITEM_REFERENCES,
         USELESS_DEPRECATED,
         UNSUPPORTED_NAKED_FUNCTIONS,
+        MISSING_ABI,
     ]
 }
 
@@ -2944,3 +2945,28 @@ declare_lint! {
 }
 
 declare_lint_pass!(UnusedDocComment => [UNUSED_DOC_COMMENTS]);
+
+declare_lint! {
+    /// The `missing_abi` lint detects cases where the ABI is omitted from
+    /// extern declarations.
+    ///
+    /// ### Example
+    ///
+    /// ```rust,compile_fail
+    /// #![deny(missing_abi)]
+    ///
+    /// extern fn foo() {}
+    /// ```
+    ///
+    /// {{produces}}
+    ///
+    /// ### Explanation
+    ///
+    /// Historically, Rust implicitly selected C as the ABI for extern
+    /// declarations. We expect to add new ABIs, like `C-unwind`, in the future,
+    /// though this has not yet happened, and especially with their addition
+    /// seeing the ABI easily will make code review easier.
+    pub MISSING_ABI,
+    Allow,
+    "No declared ABI for extern declaration"
+}

--- a/compiler/rustc_lint_defs/src/lib.rs
+++ b/compiler/rustc_lint_defs/src/lib.rs
@@ -6,6 +6,7 @@ use rustc_ast::node_id::{NodeId, NodeMap};
 use rustc_data_structures::stable_hasher::{HashStable, StableHasher, ToStableHashKey};
 use rustc_span::edition::Edition;
 use rustc_span::{sym, symbol::Ident, MultiSpan, Span, Symbol};
+use rustc_target::spec::abi::Abi;
 
 pub mod builtin;
 
@@ -252,6 +253,7 @@ pub enum BuiltinLintDiagnostics {
     UnusedImports(String, Vec<(Span, String)>),
     RedundantImport(Vec<(Span, bool)>, Ident),
     DeprecatedMacro(Option<Symbol>, Span),
+    MissingAbi(Span, Abi),
     UnusedDocComment(Span),
     PatternsInFnsWithoutBody(Span, Ident),
 }

--- a/compiler/rustc_llvm/src/lib.rs
+++ b/compiler/rustc_llvm/src/lib.rs
@@ -38,7 +38,7 @@ pub fn initialize_available_targets() {
         ($cfg:meta, $($method:ident),*) => { {
             #[cfg($cfg)]
             fn init() {
-                extern {
+                extern "C" {
                     $(fn $method();)*
                 }
                 unsafe {

--- a/library/core/src/sync/atomic.rs
+++ b/library/core/src/sync/atomic.rs
@@ -809,7 +809,7 @@ impl AtomicBool {
     /// ```ignore (extern-declaration)
     /// # fn main() {
     /// use std::sync::atomic::AtomicBool;
-    /// extern {
+    /// extern "C" {
     ///     fn my_atomic_op(arg: *mut bool);
     /// }
     ///
@@ -2068,7 +2068,7 @@ macro_rules! atomic_int {
             /// # fn main() {
             #[doc = concat!($extra_feature, "use std::sync::atomic::", stringify!($atomic_type), ";")]
             ///
-            /// extern {
+            /// extern "C" {
             #[doc = concat!("    fn my_atomic_op(arg: *mut ", stringify!($int_type), ");")]
             /// }
             ///

--- a/library/std/src/ffi/c_str.rs
+++ b/library/std/src/ffi/c_str.rs
@@ -86,7 +86,7 @@ use crate::sys;
 /// use std::ffi::CString;
 /// use std::os::raw::c_char;
 ///
-/// extern {
+/// extern "C" {
 ///     fn my_printer(s: *const c_char);
 /// }
 ///
@@ -144,7 +144,7 @@ pub struct CString {
 /// use std::ffi::CStr;
 /// use std::os::raw::c_char;
 ///
-/// extern { fn my_string() -> *const c_char; }
+/// extern "C" { fn my_string() -> *const c_char; }
 ///
 /// unsafe {
 ///     let slice = CStr::from_ptr(my_string());
@@ -159,7 +159,7 @@ pub struct CString {
 /// use std::os::raw::c_char;
 ///
 /// fn work(data: &CStr) {
-///     extern { fn work_with(data: *const c_char); }
+///     extern "C" { fn work_with(data: *const c_char); }
 ///
 ///     unsafe { work_with(data.as_ptr()) }
 /// }
@@ -174,7 +174,7 @@ pub struct CString {
 /// use std::ffi::CStr;
 /// use std::os::raw::c_char;
 ///
-/// extern { fn my_string() -> *const c_char; }
+/// extern "C" { fn my_string() -> *const c_char; }
 ///
 /// fn my_string_safe() -> String {
 ///     unsafe {
@@ -359,7 +359,7 @@ impl CString {
     /// use std::ffi::CString;
     /// use std::os::raw::c_char;
     ///
-    /// extern { fn puts(s: *const c_char); }
+    /// extern "C" { fn puts(s: *const c_char); }
     ///
     /// let to_print = CString::new("Hello!").expect("CString::new failed");
     /// unsafe {
@@ -465,7 +465,7 @@ impl CString {
     /// use std::ffi::CString;
     /// use std::os::raw::c_char;
     ///
-    /// extern {
+    /// extern "C" {
     ///     fn some_extern_function(s: *mut c_char);
     /// }
     ///
@@ -1147,7 +1147,7 @@ impl CStr {
     /// use std::ffi::CStr;
     /// use std::os::raw::c_char;
     ///
-    /// extern {
+    /// extern "C" {
     ///     fn my_string() -> *const c_char;
     /// }
     ///

--- a/library/std/src/keyword_docs.rs
+++ b/library/std/src/keyword_docs.rs
@@ -401,7 +401,7 @@ mod enum_keyword {}
 ///
 /// ```rust
 /// #[no_mangle]
-/// pub extern fn callable_from_c(x: i32) -> bool {
+/// pub extern "C" fn callable_from_c(x: i32) -> bool {
 ///     x % 3 == 0
 /// }
 /// ```

--- a/library/std/src/sys/unix/weak.rs
+++ b/library/std/src/sys/unix/weak.rs
@@ -28,7 +28,7 @@ use crate::sync::atomic::{self, AtomicUsize, Ordering};
 
 macro_rules! weak {
     (fn $name:ident($($t:ty),*) -> $ret:ty) => (
-        static $name: crate::sys::weak::Weak<unsafe extern fn($($t),*) -> $ret> =
+        static $name: crate::sys::weak::Weak<unsafe extern "C" fn($($t),*) -> $ret> =
             crate::sys::weak::Weak::new(concat!(stringify!($name), '\0'));
     )
 }

--- a/src/doc/unstable-book/src/language-features/link-args.md
+++ b/src/doc/unstable-book/src/language-features/link-args.md
@@ -15,7 +15,7 @@ usage would be:
 #![feature(link_args)]
 
 #[link_args = "-foo -bar -baz"]
-extern {}
+extern "C" {}
 # fn main() {}
 ```
 

--- a/src/test/codegen/call-llvm-intrinsics.rs
+++ b/src/test/codegen/call-llvm-intrinsics.rs
@@ -13,7 +13,7 @@ impl Drop for A {
     }
 }
 
-extern {
+extern "C" {
     #[link_name = "llvm.sqrt.f32"]
     fn sqrt(x: f32) -> f32;
 }

--- a/src/test/codegen/dealloc-no-unwind.rs
+++ b/src/test/codegen/dealloc-no-unwind.rs
@@ -8,7 +8,7 @@ struct A;
 
 impl Drop for A {
     fn drop(&mut self) {
-        extern { fn foo(); }
+        extern "C" { fn foo(); }
         unsafe { foo(); }
     }
 }

--- a/src/test/codegen/debug-column.rs
+++ b/src/test/codegen/debug-column.rs
@@ -18,7 +18,7 @@ fn main() {
     }
 }
 
-extern {
+extern "C" {
     fn giraffe();
     fn turtle();
 }

--- a/src/test/codegen/debug-linkage-name.rs
+++ b/src/test/codegen/debug-linkage-name.rs
@@ -26,17 +26,17 @@ pub mod xyz {
     // CHECK: !DISubprogram(name: "e",
     // CHECK:               linkageName:
     // CHECK-SAME:          line: 29,
-    pub extern fn e() {}
+    pub extern "C" fn e() {}
 
     // CHECK: !DISubprogram(name: "f",
     // CHECK-NOT:           linkageName:
     // CHECK-SAME:          line: 35,
     #[no_mangle]
-    pub extern fn f() {}
+    pub extern "C" fn f() {}
 
     // CHECK: !DISubprogram(name: "g",
     // CHECK-NOT:           linkageName:
     // CHECK-SAME:          line: 41,
     #[export_name = "g"]
-    pub extern fn g() {}
+    pub extern "C" fn g() {}
 }

--- a/src/test/codegen/export-no-mangle.rs
+++ b/src/test/codegen/export-no-mangle.rs
@@ -13,19 +13,19 @@ mod private {
 
     // CHECK: void @a()
     #[no_mangle]
-    pub extern fn a() {}
+    pub extern "C" fn a() {}
 
     // CHECK: void @b()
     #[export_name = "b"]
-    extern fn b() {}
+    extern "C" fn b() {}
 
     // CHECK: void @c()
     #[export_name = "c"]
     #[inline]
-    extern fn c() {}
+    extern "C" fn c() {}
 
     // CHECK: void @d()
     #[export_name = "d"]
     #[inline(always)]
-    extern fn d() {}
+    extern "C" fn d() {}
 }

--- a/src/test/codegen/ffi-const.rs
+++ b/src/test/codegen/ffi-const.rs
@@ -4,7 +4,7 @@
 
 pub fn bar() { unsafe { foo() } }
 
-extern {
+extern "C" {
     // CHECK-LABEL: declare void @foo()
     // CHECK-SAME: [[ATTRS:#[0-9]+]]
     // CHECK-DAG: attributes [[ATTRS]] = { {{.*}}readnone{{.*}} }

--- a/src/test/codegen/ffi-out-of-bounds-loads.rs
+++ b/src/test/codegen/ffi-out-of-bounds-loads.rs
@@ -11,7 +11,7 @@ struct S {
     f3: i32,
 }
 
-extern {
+extern "C" {
     fn foo(s: S);
 }
 

--- a/src/test/codegen/ffi-pure.rs
+++ b/src/test/codegen/ffi-pure.rs
@@ -4,7 +4,7 @@
 
 pub fn bar() { unsafe { foo() } }
 
-extern {
+extern "C" {
     // CHECK-LABEL: declare void @foo()
     // CHECK-SAME: [[ATTRS:#[0-9]+]]
     // CHECK-DAG: attributes [[ATTRS]] = { {{.*}}readonly{{.*}} }

--- a/src/test/codegen/ffi-returns-twice.rs
+++ b/src/test/codegen/ffi-returns-twice.rs
@@ -4,7 +4,7 @@
 
 pub fn bar() { unsafe { foo() } }
 
-extern {
+extern "C" {
     // CHECK-LABEL: declare void @foo()
     // CHECK-SAME: [[ATTRS:#[0-9]+]]
     // CHECK-DAG: attributes [[ATTRS]] = { {{.*}}returns_twice{{.*}} }

--- a/src/test/codegen/issue-47278.rs
+++ b/src/test/codegen/issue-47278.rs
@@ -6,4 +6,4 @@ pub struct Foo(u64);
 
 // CHECK: define {{.*}} @foo(
 #[no_mangle]
-pub extern fn foo(_: Foo) -> Foo { loop {} }
+pub extern "C" fn foo(_: Foo) -> Foo { loop {} }

--- a/src/test/codegen/repr-transparent-aggregates-1.rs
+++ b/src/test/codegen/repr-transparent-aggregates-1.rs
@@ -36,19 +36,19 @@ pub enum TeBigS {
 
 // CHECK: define void @test_BigS(%BigS* [[BIGS_RET_ATTRS:.*]], %BigS* [[BIGS_ARG_ATTRS1:.*]] byval(%BigS) [[BIGS_ARG_ATTRS2:.*]])
 #[no_mangle]
-pub extern fn test_BigS(_: BigS) -> BigS { loop {} }
+pub extern "C" fn test_BigS(_: BigS) -> BigS { loop {} }
 
 // CHECK: define void @test_TsBigS(%TsBigS* [[BIGS_RET_ATTRS]], %TsBigS* [[BIGS_ARG_ATTRS1]] byval(%TsBigS) [[BIGS_ARG_ATTRS2:.*]])
 #[no_mangle]
-pub extern fn test_TsBigS(_: TsBigS) -> TsBigS { loop {} }
+pub extern "C" fn test_TsBigS(_: TsBigS) -> TsBigS { loop {} }
 
 // CHECK: define void @test_TuBigS(%TuBigS* [[BIGS_RET_ATTRS]], %TuBigS* [[BIGS_ARG_ATTRS1]] byval(%TuBigS) [[BIGS_ARG_ATTRS2:.*]])
 #[no_mangle]
-pub extern fn test_TuBigS(_: TuBigS) -> TuBigS { loop {} }
+pub extern "C" fn test_TuBigS(_: TuBigS) -> TuBigS { loop {} }
 
 // CHECK: define void @test_TeBigS(%"TeBigS::Variant"* [[BIGS_RET_ATTRS]], %"TeBigS::Variant"* [[BIGS_ARG_ATTRS1]] byval(%"TeBigS::Variant") [[BIGS_ARG_ATTRS2]])
 #[no_mangle]
-pub extern fn test_TeBigS(_: TeBigS) -> TeBigS { loop {} }
+pub extern "C" fn test_TeBigS(_: TeBigS) -> TeBigS { loop {} }
 
 
 #[derive(Clone, Copy)]
@@ -72,16 +72,16 @@ pub enum TeBigU {
 
 // CHECK: define void @test_BigU(%BigU* [[BIGU_RET_ATTRS:.*]], %BigU* [[BIGU_ARG_ATTRS1:.*]] byval(%BigU) [[BIGU_ARG_ATTRS2:.*]])
 #[no_mangle]
-pub extern fn test_BigU(_: BigU) -> BigU { loop {} }
+pub extern "C" fn test_BigU(_: BigU) -> BigU { loop {} }
 
 // CHECK: define void @test_TsBigU(%TsBigU* [[BIGU_RET_ATTRS:.*]], %TsBigU* [[BIGU_ARG_ATTRS1]] byval(%TsBigU) [[BIGU_ARG_ATTRS2]])
 #[no_mangle]
-pub extern fn test_TsBigU(_: TsBigU) -> TsBigU { loop {} }
+pub extern "C" fn test_TsBigU(_: TsBigU) -> TsBigU { loop {} }
 
 // CHECK: define void @test_TuBigU(%TuBigU* [[BIGU_RET_ATTRS]], %TuBigU* [[BIGU_ARG_ATTRS1]] byval(%TuBigU) [[BIGU_ARG_ATTRS2]])
 #[no_mangle]
-pub extern fn test_TuBigU(_: TuBigU) -> TuBigU { loop {} }
+pub extern "C" fn test_TuBigU(_: TuBigU) -> TuBigU { loop {} }
 
 // CHECK: define void @test_TeBigU(%"TeBigU::Variant"* [[BIGU_RET_ATTRS]], %"TeBigU::Variant"* [[BIGU_ARG_ATTRS1]] byval(%"TeBigU::Variant") [[BIGU_ARG_ATTRS2]])
 #[no_mangle]
-pub extern fn test_TeBigU(_: TeBigU) -> TeBigU { loop {} }
+pub extern "C" fn test_TeBigU(_: TeBigU) -> TeBigU { loop {} }

--- a/src/test/codegen/repr-transparent.rs
+++ b/src/test/codegen/repr-transparent.rs
@@ -19,21 +19,21 @@ pub struct F32(f32);
 
 // CHECK: define float @test_F32(float %_1)
 #[no_mangle]
-pub extern fn test_F32(_: F32) -> F32 { loop {} }
+pub extern "C" fn test_F32(_: F32) -> F32 { loop {} }
 
 #[repr(transparent)]
 pub struct Ptr(*mut u8);
 
 // CHECK: define i8* @test_Ptr(i8* %_1)
 #[no_mangle]
-pub extern fn test_Ptr(_: Ptr) -> Ptr { loop {} }
+pub extern "C" fn test_Ptr(_: Ptr) -> Ptr { loop {} }
 
 #[repr(transparent)]
 pub struct WithZst(u64, Zst1);
 
 // CHECK: define i64 @test_WithZst(i64 %_1)
 #[no_mangle]
-pub extern fn test_WithZst(_: WithZst) -> WithZst { loop {} }
+pub extern "C" fn test_WithZst(_: WithZst) -> WithZst { loop {} }
 
 #[repr(transparent)]
 pub struct WithZeroSizedArray(*const f32, [i8; 0]);
@@ -41,14 +41,14 @@ pub struct WithZeroSizedArray(*const f32, [i8; 0]);
 // Apparently we use i32* when newtype-unwrapping f32 pointers. Whatever.
 // CHECK: define i32* @test_WithZeroSizedArray(i32* %_1)
 #[no_mangle]
-pub extern fn test_WithZeroSizedArray(_: WithZeroSizedArray) -> WithZeroSizedArray { loop {} }
+pub extern "C" fn test_WithZeroSizedArray(_: WithZeroSizedArray) -> WithZeroSizedArray { loop {} }
 
 #[repr(transparent)]
 pub struct Generic<T>(T);
 
 // CHECK: define double @test_Generic(double %_1)
 #[no_mangle]
-pub extern fn test_Generic(_: Generic<f64>) -> Generic<f64> { loop {} }
+pub extern "C" fn test_Generic(_: Generic<f64>) -> Generic<f64> { loop {} }
 
 #[repr(transparent)]
 pub struct GenericPlusZst<T>(T, Zst2);
@@ -58,14 +58,14 @@ pub enum Bool { True, False, FileNotFound }
 
 // CHECK: define{{( zeroext)?}} i8 @test_Gpz(i8{{( zeroext)?}} %_1)
 #[no_mangle]
-pub extern fn test_Gpz(_: GenericPlusZst<Bool>) -> GenericPlusZst<Bool> { loop {} }
+pub extern "C" fn test_Gpz(_: GenericPlusZst<Bool>) -> GenericPlusZst<Bool> { loop {} }
 
 #[repr(transparent)]
 pub struct LifetimePhantom<'a, T: 'a>(*const T, PhantomData<&'a T>);
 
 // CHECK: define i16* @test_LifetimePhantom(i16* %_1)
 #[no_mangle]
-pub extern fn test_LifetimePhantom(_: LifetimePhantom<i16>) -> LifetimePhantom<i16> { loop {} }
+pub extern "C" fn test_LifetimePhantom(_: LifetimePhantom<i16>) -> LifetimePhantom<i16> { loop {} }
 
 // This works despite current alignment resrictions because PhantomData is always align(1)
 #[repr(transparent)]
@@ -75,28 +75,28 @@ pub struct Px;
 
 // CHECK: define float @test_UnitPhantom(float %_1)
 #[no_mangle]
-pub extern fn test_UnitPhantom(_: UnitPhantom<f32, Px>) -> UnitPhantom<f32, Px> { loop {} }
+pub extern "C" fn test_UnitPhantom(_: UnitPhantom<f32, Px>) -> UnitPhantom<f32, Px> { loop {} }
 
 #[repr(transparent)]
 pub struct TwoZsts(Zst1, i8, Zst2);
 
 // CHECK: define{{( signext)?}} i8 @test_TwoZsts(i8{{( signext)?}} %_1)
 #[no_mangle]
-pub extern fn test_TwoZsts(_: TwoZsts) -> TwoZsts { loop {} }
+pub extern "C" fn test_TwoZsts(_: TwoZsts) -> TwoZsts { loop {} }
 
 #[repr(transparent)]
 pub struct Nested1(Zst2, Generic<f64>);
 
 // CHECK: define double @test_Nested1(double %_1)
 #[no_mangle]
-pub extern fn test_Nested1(_: Nested1) -> Nested1 { loop {} }
+pub extern "C" fn test_Nested1(_: Nested1) -> Nested1 { loop {} }
 
 #[repr(transparent)]
 pub struct Nested2(Nested1, Zst1);
 
 // CHECK: define double @test_Nested2(double %_1)
 #[no_mangle]
-pub extern fn test_Nested2(_: Nested2) -> Nested2 { loop {} }
+pub extern "C" fn test_Nested2(_: Nested2) -> Nested2 { loop {} }
 
 #[repr(simd)]
 struct f32x4(f32, f32, f32, f32);
@@ -106,7 +106,7 @@ pub struct Vector(f32x4);
 
 // CHECK: define <4 x float> @test_Vector(<4 x float> %_1)
 #[no_mangle]
-pub extern fn test_Vector(_: Vector) -> Vector { loop {} }
+pub extern "C" fn test_Vector(_: Vector) -> Vector { loop {} }
 
 trait Mirror { type It: ?Sized; }
 impl<T: ?Sized> Mirror for T { type It = Self; }
@@ -116,7 +116,7 @@ pub struct StructWithProjection(<f32 as Mirror>::It);
 
 // CHECK: define float @test_Projection(float %_1)
 #[no_mangle]
-pub extern fn test_Projection(_: StructWithProjection) -> StructWithProjection { loop {} }
+pub extern "C" fn test_Projection(_: StructWithProjection) -> StructWithProjection { loop {} }
 
 #[repr(transparent)]
 pub enum EnumF32 {
@@ -125,7 +125,7 @@ pub enum EnumF32 {
 
 // CHECK: define float @test_EnumF32(float %_1)
 #[no_mangle]
-pub extern fn test_EnumF32(_: EnumF32) -> EnumF32 { loop {} }
+pub extern "C" fn test_EnumF32(_: EnumF32) -> EnumF32 { loop {} }
 
 #[repr(transparent)]
 pub enum EnumF32WithZsts {
@@ -134,7 +134,7 @@ pub enum EnumF32WithZsts {
 
 // CHECK: define float @test_EnumF32WithZsts(float %_1)
 #[no_mangle]
-pub extern fn test_EnumF32WithZsts(_: EnumF32WithZsts) -> EnumF32WithZsts { loop {} }
+pub extern "C" fn test_EnumF32WithZsts(_: EnumF32WithZsts) -> EnumF32WithZsts { loop {} }
 
 #[repr(transparent)]
 pub union UnionF32 {
@@ -143,7 +143,7 @@ pub union UnionF32 {
 
 // CHECK: define float @test_UnionF32(float %_1)
 #[no_mangle]
-pub extern fn test_UnionF32(_: UnionF32) -> UnionF32 { loop {} }
+pub extern "C" fn test_UnionF32(_: UnionF32) -> UnionF32 { loop {} }
 
 #[repr(transparent)]
 pub union UnionF32WithZsts {
@@ -154,7 +154,7 @@ pub union UnionF32WithZsts {
 
 // CHECK: define float @test_UnionF32WithZsts(float %_1)
 #[no_mangle]
-pub extern fn test_UnionF32WithZsts(_: UnionF32WithZsts) -> UnionF32WithZsts { loop {} }
+pub extern "C" fn test_UnionF32WithZsts(_: UnionF32WithZsts) -> UnionF32WithZsts { loop {} }
 
 
 // All that remains to be tested are aggregates. They are tested in separate files called repr-

--- a/src/test/codegen/riscv-abi/call-llvm-intrinsics.rs
+++ b/src/test/codegen/riscv-abi/call-llvm-intrinsics.rs
@@ -13,7 +13,7 @@ impl Drop for A {
     }
 }
 
-extern {
+extern "C" {
     #[link_name = "llvm.sqrt.f32"]
     fn sqrt(x: f32) -> f32;
 }

--- a/src/test/codegen/target-cpu-on-functions.rs
+++ b/src/test/codegen/target-cpu-on-functions.rs
@@ -9,7 +9,7 @@
 
 // CHECK-LABEL: define {{.*}} @exported() {{.*}} #0
 #[no_mangle]
-pub extern fn exported() {
+pub extern "C" fn exported() {
     not_exported();
 }
 

--- a/src/test/codegen/unwind-extern-exports.rs
+++ b/src/test/codegen/unwind-extern-exports.rs
@@ -11,7 +11,7 @@
 // "C" ABI
 // pub extern fn foo() {} // FIXME right now we don't abort-on-panic but add `nounwind` nevertheless
 #[unwind(allowed)]
-pub extern fn foo_allowed() {}
+pub extern "C" fn foo_allowed() {}
 
 // "Rust"
 // (`extern "Rust"` could be removed as all `fn` get it implicitly; we leave it in for clarity.)

--- a/src/test/codegen/unwind-extern-imports.rs
+++ b/src/test/codegen/unwind-extern-imports.rs
@@ -4,7 +4,7 @@
 #![crate_type = "lib"]
 #![feature(unwind_attributes)]
 
-extern {
+extern "C" {
 // CHECK: Function Attrs:{{.*}}nounwind
 // CHECK-NEXT: declare void @extern_fn
     fn extern_fn();

--- a/src/test/debuginfo/type-names.rs
+++ b/src/test/debuginfo/type-names.rs
@@ -23,7 +23,6 @@
 // gdbg-check:type = struct Struct2
 // gdbr-check:type = type_names::mod1::Struct2
 
-
 // ENUMS
 // gdb-command:whatis simple_enum_1
 // gdbg-check:type = union Enum1
@@ -45,7 +44,6 @@
 // gdbg-check:type = union Enum3<type_names::Struct1>
 // gdbr-check:type = type_names::mod1::mod2::Enum3<type_names::Struct1>
 
-
 // TUPLES
 // gdb-command:whatis tuple1
 // gdbg-check:type = struct (u32, type_names::Struct1, type_names::mod1::mod2::Enum3<type_names::mod1::Struct2>)
@@ -55,7 +53,6 @@
 // gdbg-check:type = struct ((type_names::Struct1, type_names::mod1::mod2::Struct3), type_names::mod1::Enum2, char)
 // gdbr-check:type = ((type_names::Struct1, type_names::mod1::mod2::Struct3), type_names::mod1::Enum2, char)
 
-
 // BOX
 // gdb-command:whatis box1
 // gdbg-check:type = struct (alloc::boxed::Box<f32>, i32)
@@ -64,7 +61,6 @@
 // gdb-command:whatis box2
 // gdbg-check:type = struct (alloc::boxed::Box<type_names::mod1::mod2::Enum3<f32>>, i32)
 // gdbr-check:type = (alloc::boxed::Box<type_names::mod1::mod2::Enum3<f32>>, i32)
-
 
 // REFERENCES
 // gdb-command:whatis ref1
@@ -82,7 +78,6 @@
 // gdb-command:whatis mut_ref2
 // gdbg-check:type = struct (&mut type_names::GenericStruct<type_names::mod1::Enum2, f64>, i32)
 // gdbr-check:type = (&mut type_names::GenericStruct<type_names::mod1::Enum2, f64>, i32)
-
 
 // RAW POINTERS
 // gdb-command:whatis mut_ptr1
@@ -109,7 +104,6 @@
 // gdbg-check:type = struct (*const type_names::mod1::mod2::Enum3<type_names::Struct1>, isize)
 // gdbr-check:type = (*const type_names::mod1::mod2::Enum3<type_names::Struct1>, isize)
 
-
 // VECTORS
 // gdb-command:whatis fixed_size_vec1
 // gdbg-check:type = struct ([type_names::Struct1; 3], i16)
@@ -126,7 +120,6 @@
 // gdb-command:whatis slice2
 // gdbg-check:type = struct &[type_names::mod1::Enum2]
 // gdbr-check:type = &[type_names::mod1::Enum2]
-
 
 // TRAITS
 // gdb-command:whatis box_trait
@@ -152,7 +145,6 @@
 // gdb-command:whatis generic_mut_ref_trait
 // gdbg-check:type = struct &mut Trait2<type_names::mod1::mod2::Struct3, type_names::GenericStruct<usize, isize>>
 // gdbr-check:type = type_names::&mut Trait2<type_names::mod1::mod2::Struct3, type_names::GenericStruct<usize, isize>>
-
 
 // BARE FUNCTIONS
 // gdb-command:whatis rust_fn
@@ -199,7 +191,6 @@
 // gdbg-check:type = struct (unsafe extern "C" fn(*const u8, ...) -> isize, usize)
 // gdbr-check:type = (unsafe extern "C" fn(*const u8, ...) -> isize, usize)
 
-
 // CLOSURES
 // gdb-command:whatis closure1
 // gdbg-check:type = struct (closure, usize)
@@ -219,7 +210,7 @@ use std::marker::PhantomData;
 use std::ptr;
 
 pub struct Struct1;
-struct GenericStruct<T1, T2>(PhantomData<(T1,T2)>);
+struct GenericStruct<T1, T2>(PhantomData<(T1, T2)>);
 
 enum Enum1 {
     Variant1,
@@ -246,8 +237,12 @@ mod mod1 {
     }
 }
 
-trait Trait1 { fn dummy(&self) { } }
-trait Trait2<T1, T2> { fn dummy(&self, _: T1, _:T2) { } }
+trait Trait1 {
+    fn dummy(&self) {}
+}
+trait Trait2<T1, T2> {
+    fn dummy(&self, _: T1, _: T2) {}
+}
 
 impl Trait1 for isize {}
 impl<T1, T2> Trait2<T1, T2> for isize {}
@@ -257,16 +252,26 @@ extern "C" fn extern_c_fn(_: isize) {}
 unsafe fn unsafe_fn(_: Result<char, f64>) {}
 extern "stdcall" fn extern_stdcall_fn() {}
 
-fn rust_fn_with_return_value(_: f64) -> usize { 4 }
-extern "C" fn extern_c_fn_with_return_value() -> Struct1 { Struct1 }
-unsafe fn unsafe_fn_with_return_value(_: GenericStruct<u16, u8>) -> mod1::Struct2 { mod1::Struct2 }
-extern "stdcall" fn extern_stdcall_fn_with_return_value(_: Box<isize>) -> usize { 0 }
+fn rust_fn_with_return_value(_: f64) -> usize {
+    4
+}
+extern "C" fn extern_c_fn_with_return_value() -> Struct1 {
+    Struct1
+}
+unsafe fn unsafe_fn_with_return_value(_: GenericStruct<u16, u8>) -> mod1::Struct2 {
+    mod1::Struct2
+}
+extern "stdcall" fn extern_stdcall_fn_with_return_value(_: Box<isize>) -> usize {
+    0
+}
 
-fn generic_function<T>(x: T) -> T { x }
+fn generic_function<T>(x: T) -> T {
+    x
+}
 
 #[allow(improper_ctypes)]
-extern {
-    fn printf(_:*const u8, ...) -> isize;
+extern "C" {
+    fn printf(_: *const u8, ...) -> isize;
 }
 
 // In many of the cases below, the type that is actually under test is wrapped
@@ -277,7 +282,6 @@ extern {
 // printed correctly, so the tests below just construct a tuple type that will
 // then *contain* the type name that we want to see.
 fn main() {
-
     // Structs
     let simple_struct = Struct1;
     let generic_struct1: GenericStruct<mod1::Struct2, mod1::mod2::Struct3> =
@@ -336,11 +340,11 @@ fn main() {
     let mut_ref_trait = (&mut mut_int1) as &mut Trait1;
 
     let generic_box_trait = (box 0_isize) as Box<Trait2<i32, mod1::Struct2>>;
-    let generic_ref_trait  = (&0_isize) as &Trait2<Struct1, Struct1>;
+    let generic_ref_trait = (&0_isize) as &Trait2<Struct1, Struct1>;
 
     let mut generic_mut_ref_trait_impl = 0_isize;
-    let generic_mut_ref_trait = (&mut generic_mut_ref_trait_impl) as
-        &mut Trait2<mod1::mod2::Struct3, GenericStruct<usize, isize>>;
+    let generic_mut_ref_trait = (&mut generic_mut_ref_trait_impl)
+        as &mut Trait2<mod1::mod2::Struct3, GenericStruct<usize, isize>>;
 
     // Bare Functions
     let rust_fn = (rust_fn, 0_usize);
@@ -364,11 +368,13 @@ fn main() {
     // how that maps to rustc's internal representation of these forms.
     // Once closures have reached their 1.0 form, the tests below should
     // probably be expanded.
-    let closure1 = (|x:isize| {}, 0_usize);
-    let closure2 = (|x:i8, y: f32| { (x as f32) + y }, 0_usize);
+    let closure1 = (|x: isize| {}, 0_usize);
+    let closure2 = (|x: i8, y: f32| (x as f32) + y, 0_usize);
 
     zzz(); // #break
 }
 
 #[inline(never)]
-fn zzz() { () }
+fn zzz() {
+    ()
+}

--- a/src/test/incremental/foreign.rs
+++ b/src/test/incremental/foreign.rs
@@ -13,7 +13,7 @@ use std::ffi::CString;
 mod mlibc {
     use libc::{c_char, c_long, c_longlong};
 
-    extern {
+    extern "C" {
         pub fn atol(x: *const c_char) -> c_long;
         pub fn atoll(x: *const c_char) -> c_longlong;
     }
@@ -31,6 +31,8 @@ fn atoll(s: String) -> i64 {
 
 pub fn main() {
     assert_eq!(atol("1024".to_string()) * 10, atol("10240".to_string()));
-    assert_eq!((atoll("11111111111111111".to_string()) * 10),
-             atoll("111111111111111110".to_string()));
+    assert_eq!(
+        (atoll("11111111111111111".to_string()) * 10),
+        atoll("111111111111111110".to_string())
+    );
 }

--- a/src/test/incremental/hashes/inherent_impls.rs
+++ b/src/test/incremental/hashes/inherent_impls.rs
@@ -271,7 +271,7 @@ impl Foo {
 impl Foo {
     #[rustc_clean(cfg="cfail2", except="hir_owner,hir_owner_nodes,fn_sig,typeck")]
     #[rustc_clean(cfg="cfail3")]
-    pub extern fn make_method_extern(&self) { }
+    pub extern "C" fn make_method_extern(&self) { }
 }
 
 

--- a/src/test/incremental/hashes/trait_defs.rs
+++ b/src/test/incremental/hashes/trait_defs.rs
@@ -312,7 +312,7 @@ trait TraitAddExternModifier {
 trait TraitAddExternModifier {
     #[rustc_dirty(label="hir_owner", cfg="cfail2")]
     #[rustc_clean(label="hir_owner", cfg="cfail3")]
-    extern fn method();
+    extern "C" fn method();
 }
 
 

--- a/src/test/run-make-fulldeps/archive-duplicate-names/foo.rs
+++ b/src/test/run-make-fulldeps/archive-duplicate-names/foo.rs
@@ -1,7 +1,7 @@
 #![crate_type = "rlib"]
 
 #[link(name = "foo", kind = "static")]
-extern {
+extern "C" {
     fn foo();
     fn bar();
 }

--- a/src/test/run-make-fulldeps/c-dynamic-dylib/foo.rs
+++ b/src/test/run-make-fulldeps/c-dynamic-dylib/foo.rs
@@ -1,7 +1,7 @@
 #![crate_type = "dylib"]
 
 #[link(name = "cfoo")]
-extern {
+extern "C" {
     fn foo();
 }
 

--- a/src/test/run-make-fulldeps/c-dynamic-rlib/foo.rs
+++ b/src/test/run-make-fulldeps/c-dynamic-rlib/foo.rs
@@ -1,7 +1,7 @@
 #![crate_type = "rlib"]
 
 #[link(name = "cfoo")]
-extern {
+extern "C" {
     fn foo();
 }
 

--- a/src/test/run-make-fulldeps/c-static-dylib/foo.rs
+++ b/src/test/run-make-fulldeps/c-static-dylib/foo.rs
@@ -1,7 +1,7 @@
 #![crate_type = "dylib"]
 
 #[link(name = "cfoo", kind = "static")]
-extern {
+extern "C" {
     fn foo();
 }
 

--- a/src/test/run-make-fulldeps/c-static-rlib/foo.rs
+++ b/src/test/run-make-fulldeps/c-static-rlib/foo.rs
@@ -1,7 +1,7 @@
 #![crate_type = "rlib"]
 
 #[link(name = "cfoo", kind = "static")]
-extern {
+extern "C" {
     fn foo();
 }
 

--- a/src/test/run-make-fulldeps/cdylib-dylib-linkage/foo.rs
+++ b/src/test/run-make-fulldeps/cdylib-dylib-linkage/foo.rs
@@ -3,11 +3,11 @@
 extern crate bar;
 
 #[no_mangle]
-pub extern fn foo() {
+pub extern "C" fn foo() {
     bar::bar();
 }
 
 #[no_mangle]
-pub extern fn bar(a: u32, b: u32) -> u32 {
+pub extern "C" fn bar(a: u32, b: u32) -> u32 {
     a + b
 }

--- a/src/test/run-make-fulldeps/cdylib-fewer-symbols/foo.rs
+++ b/src/test/run-make-fulldeps/cdylib-fewer-symbols/foo.rs
@@ -1,6 +1,6 @@
 #![crate_type = "cdylib"]
 
 #[no_mangle]
-pub extern fn foo() -> u32 {
+pub extern "C" fn foo() -> u32 {
     3
 }

--- a/src/test/run-make-fulldeps/cdylib/foo.rs
+++ b/src/test/run-make-fulldeps/cdylib/foo.rs
@@ -3,11 +3,11 @@
 extern crate bar;
 
 #[no_mangle]
-pub extern fn foo() {
+pub extern "C" fn foo() {
     bar::bar();
 }
 
 #[no_mangle]
-pub extern fn bar(a: u32, b: u32) -> u32 {
+pub extern "C" fn bar(a: u32, b: u32) -> u32 {
     a + b
 }

--- a/src/test/run-make-fulldeps/compiler-lookup-paths/d.rs
+++ b/src/test/run-make-fulldeps/compiler-lookup-paths/d.rs
@@ -1,4 +1,4 @@
 #![crate_type = "rlib"]
 
 #[link(name = "native", kind = "static")]
-extern {}
+extern "C" {}

--- a/src/test/run-make-fulldeps/compiler-rt-works-on-mingw/foo.rs
+++ b/src/test/run-make-fulldeps/compiler-rt-works-on-mingw/foo.rs
@@ -1,6 +1,10 @@
-extern { fn foo(); }
+extern "C" {
+    fn foo();
+}
 
 pub fn main() {
-    unsafe { foo(); }
+    unsafe {
+        foo();
+    }
     assert_eq!(7f32.powi(3), 343f32);
 }

--- a/src/test/run-make-fulldeps/cross-lang-lto-upstream-rlibs/staticlib.rs
+++ b/src/test/run-make-fulldeps/cross-lang-lto-upstream-rlibs/staticlib.rs
@@ -3,6 +3,6 @@
 extern crate upstream;
 
 #[no_mangle]
-pub extern fn bar() {
+pub extern "C" fn bar() {
     upstream::foo();
 }

--- a/src/test/run-make-fulldeps/extern-fn-generic/test.rs
+++ b/src/test/run-make-fulldeps/extern-fn-generic/test.rs
@@ -1,22 +1,20 @@
 extern crate testcrate;
 
-extern "C" fn bar<T>(ts: testcrate::TestStruct<T>) -> T { ts.y }
+extern "C" fn bar<T>(ts: testcrate::TestStruct<T>) -> T {
+    ts.y
+}
 
 #[link(name = "test", kind = "static")]
-extern {
+extern "C" {
     fn call(c: extern "C" fn(testcrate::TestStruct<i32>) -> i32) -> i32;
 }
 
 fn main() {
     // Let's test calling it cross crate
-    let back = unsafe {
-        testcrate::call(testcrate::foo::<i32>)
-    };
+    let back = unsafe { testcrate::call(testcrate::foo::<i32>) };
     assert_eq!(3, back);
 
     // And just within this crate
-    let back = unsafe {
-        call(bar::<i32>)
-    };
+    let back = unsafe { call(bar::<i32>) };
     assert_eq!(3, back);
 }

--- a/src/test/run-make-fulldeps/extern-fn-generic/testcrate.rs
+++ b/src/test/run-make-fulldeps/extern-fn-generic/testcrate.rs
@@ -3,12 +3,14 @@
 #[repr(C)]
 pub struct TestStruct<T> {
     pub x: u8,
-    pub y: T
+    pub y: T,
 }
 
-pub extern "C" fn foo<T>(ts: TestStruct<T>) -> T { ts.y }
+pub extern "C" fn foo<T>(ts: TestStruct<T>) -> T {
+    ts.y
+}
 
 #[link(name = "test", kind = "static")]
-extern {
+extern "C" {
     pub fn call(c: extern "C" fn(TestStruct<i32>) -> i32) -> i32;
 }

--- a/src/test/run-make-fulldeps/extern-fn-mangle/test.rs
+++ b/src/test/run-make-fulldeps/extern-fn-mangle/test.rs
@@ -1,11 +1,15 @@
 #[no_mangle]
-pub extern "C" fn foo() -> i32 { 3 }
+pub extern "C" fn foo() -> i32 {
+    3
+}
 
 #[no_mangle]
-pub extern "C" fn bar() -> i32 { 5 }
+pub extern "C" fn bar() -> i32 {
+    5
+}
 
 #[link(name = "test", kind = "static")]
-extern {
+extern "C" {
     fn add() -> i32;
 }
 

--- a/src/test/run-make-fulldeps/extern-fn-struct-passing-abi/test.rs
+++ b/src/test/run-make-fulldeps/extern-fn-struct-passing-abi/test.rs
@@ -7,7 +7,7 @@ struct Rect {
     a: i32,
     b: i32,
     c: i32,
-    d: i32
+    d: i32,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -15,7 +15,7 @@ struct Rect {
 struct BiggerRect {
     s: Rect,
     a: i32,
-    b: i32
+    b: i32,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -23,7 +23,7 @@ struct BiggerRect {
 struct FloatRect {
     a: i32,
     b: i32,
-    c: f64
+    c: f64,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -33,14 +33,14 @@ struct Huge {
     b: i32,
     c: i32,
     d: i32,
-    e: i32
+    e: i32,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[repr(C)]
 struct FloatPoint {
     x: f64,
-    y: f64
+    y: f64,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -58,13 +58,22 @@ struct IntOdd {
 }
 
 #[link(name = "test", kind = "static")]
-extern {
+extern "C" {
     fn byval_rect(a: i32, b: i32, c: i32, d: i32, e: i32, s: Rect);
 
     fn byval_many_rect(a: i32, b: i32, c: i32, d: i32, e: i32, f: i32, s: Rect);
 
-    fn byval_rect_floats(a: f32, b: f32, c: f64, d: f32, e: f32,
-                         f: f32, g: f64, s: Rect, t: FloatRect);
+    fn byval_rect_floats(
+        a: f32,
+        b: f32,
+        c: f64,
+        d: f32,
+        e: f32,
+        f: f32,
+        g: f64,
+        s: Rect,
+        t: FloatRect,
+    );
 
     fn byval_rect_with_float(a: i32, b: i32, c: f32, d: i32, e: i32, f: i32, s: Rect);
 
@@ -107,12 +116,7 @@ fn main() {
         byval_many_rect(1, 2, 3, 4, 5, 6, s);
         byval_rect_floats(1., 2., 3., 4., 5., 6., 7., s, u);
         byval_rect_with_float(1, 2, 3.0, 4, 5, 6, s);
-        byval_rect_with_many_huge(v, v, v, v, v, v, Rect {
-            a: 123,
-            b: 456,
-            c: 789,
-            d: 420
-        });
+        byval_rect_with_many_huge(v, v, v, v, v, v, Rect { a: 123, b: 456, c: 789, d: 420 });
         split_rect(1, 2, s);
         split_rect_floats(1., 2., u);
         split_rect_with_floats(1, 2, 3.0, 4, 5.0, 6, s);

--- a/src/test/run-make-fulldeps/extern-fn-with-extern-types/test.rs
+++ b/src/test/run-make-fulldeps/extern-fn-with-extern-types/test.rs
@@ -1,7 +1,7 @@
 #![feature(extern_types)]
 
 #[link(name = "ctest", kind = "static")]
-extern {
+extern "C" {
     type data;
 
     fn data_create(magic: u32) -> *mut data;

--- a/src/test/run-make-fulldeps/extern-fn-with-packed-struct/test.rs
+++ b/src/test/run-make-fulldeps/extern-fn-with-packed-struct/test.rs
@@ -3,11 +3,11 @@
 struct Foo {
     a: i8,
     b: i16,
-    c: i8
+    c: i8,
 }
 
 #[link(name = "test", kind = "static")]
-extern {
+extern "C" {
     fn foo(f: Foo) -> Foo;
 }
 

--- a/src/test/run-make-fulldeps/extern-fn-with-union/test.rs
+++ b/src/test/run-make-fulldeps/extern-fn-with-union/test.rs
@@ -2,7 +2,7 @@ extern crate testcrate;
 
 use std::mem;
 
-extern {
+extern "C" {
     fn give_back(tu: testcrate::TestUnion) -> u64;
 }
 
@@ -10,14 +10,10 @@ fn main() {
     let magic: u64 = 0xDEADBEEF;
 
     // Let's test calling it cross crate
-    let back = unsafe {
-        testcrate::give_back(mem::transmute(magic))
-    };
+    let back = unsafe { testcrate::give_back(mem::transmute(magic)) };
     assert_eq!(magic, back);
 
     // And just within this crate
-    let back = unsafe {
-        give_back(mem::transmute(magic))
-    };
+    let back = unsafe { give_back(mem::transmute(magic)) };
     assert_eq!(magic, back);
 }

--- a/src/test/run-make-fulldeps/extern-fn-with-union/testcrate.rs
+++ b/src/test/run-make-fulldeps/extern-fn-with-union/testcrate.rs
@@ -2,10 +2,10 @@
 
 #[repr(C)]
 pub struct TestUnion {
-    _val: u64
+    _val: u64,
 }
 
 #[link(name = "ctest", kind = "static")]
-extern {
+extern "C" {
     pub fn give_back(tu: TestUnion) -> u64;
 }

--- a/src/test/run-make-fulldeps/glibc-staticlib-args/library.rs
+++ b/src/test/run-make-fulldeps/glibc-staticlib-args/library.rs
@@ -1,4 +1,4 @@
 #[no_mangle]
-pub extern fn args_check() {
+pub extern "C" fn args_check() {
     assert_ne!(std::env::args_os().count(), 0);
 }

--- a/src/test/run-make-fulldeps/interdependent-c-libraries/bar.rs
+++ b/src/test/run-make-fulldeps/interdependent-c-libraries/bar.rs
@@ -3,10 +3,12 @@
 extern crate foo;
 
 #[link(name = "bar", kind = "static")]
-extern {
+extern "C" {
     fn bar();
 }
 
 pub fn doit() {
-    unsafe { bar(); }
+    unsafe {
+        bar();
+    }
 }

--- a/src/test/run-make-fulldeps/interdependent-c-libraries/foo.rs
+++ b/src/test/run-make-fulldeps/interdependent-c-libraries/foo.rs
@@ -1,10 +1,12 @@
 #![crate_type = "rlib"]
 
 #[link(name = "foo", kind = "static")]
-extern {
+extern "C" {
     fn foo();
 }
 
 pub fn doit() {
-    unsafe { foo(); }
+    unsafe {
+        foo();
+    }
 }

--- a/src/test/run-make-fulldeps/issue-14500/foo.rs
+++ b/src/test/run-make-fulldeps/issue-14500/foo.rs
@@ -1,5 +1,5 @@
 #[no_mangle]
-pub extern fn foo() {}
+pub extern "C" fn foo() {}
 
 #[no_mangle]
 pub static FOO_STATIC: u8 = 0;

--- a/src/test/run-make-fulldeps/issue-15460/foo.rs
+++ b/src/test/run-make-fulldeps/issue-15460/foo.rs
@@ -1,6 +1,6 @@
 #![crate_type = "dylib"]
 
 #[link(name = "foo", kind = "static")]
-extern {
+extern "C" {
     pub fn foo();
 }

--- a/src/test/run-make-fulldeps/issue-25581/test.rs
+++ b/src/test/run-make-fulldeps/issue-25581/test.rs
@@ -1,11 +1,11 @@
 #[link(name = "test", kind = "static")]
-extern {
+extern "C" {
     fn slice_len(s: &[u8]) -> usize;
     fn slice_elem(s: &[u8], idx: usize) -> u8;
 }
 
 fn main() {
-    let data = [1,2,3,4,5];
+    let data = [1, 2, 3, 4, 5];
 
     unsafe {
         assert_eq!(data.len(), slice_len(&data) as usize);

--- a/src/test/run-make-fulldeps/issue-28595/a.rs
+++ b/src/test/run-make-fulldeps/issue-28595/a.rs
@@ -1,6 +1,6 @@
 #![crate_type = "rlib"]
 
 #[link(name = "a", kind = "static")]
-extern {
+extern "C" {
     pub fn a();
 }

--- a/src/test/run-make-fulldeps/issue-28595/b.rs
+++ b/src/test/run-make-fulldeps/issue-28595/b.rs
@@ -1,11 +1,12 @@
 extern crate a;
 
 #[link(name = "b", kind = "static")]
-extern {
+extern "C" {
     pub fn b();
 }
 
-
 fn main() {
-    unsafe { b(); }
+    unsafe {
+        b();
+    }
 }

--- a/src/test/run-make-fulldeps/link-cfg/dep-with-staticlib.rs
+++ b/src/test/run-make-fulldeps/link-cfg/dep-with-staticlib.rs
@@ -3,6 +3,6 @@
 
 #[link(name = "return1", cfg(foo))]
 #[link(name = "return3", kind = "static", cfg(bar))]
-extern {
+extern "C" {
     pub fn my_function() -> i32;
 }

--- a/src/test/run-make-fulldeps/link-cfg/dep.rs
+++ b/src/test/run-make-fulldeps/link-cfg/dep.rs
@@ -3,6 +3,6 @@
 
 #[link(name = "return1", cfg(foo))]
 #[link(name = "return2", cfg(bar))]
-extern {
+extern "C" {
     pub fn my_function() -> i32;
 }

--- a/src/test/run-make-fulldeps/link-cfg/no-deps.rs
+++ b/src/test/run-make-fulldeps/link-cfg/no-deps.rs
@@ -2,7 +2,7 @@
 
 #[link(name = "return1", cfg(foo))]
 #[link(name = "return2", cfg(bar))]
-extern {
+extern "C" {
     fn my_function() -> i32;
 }
 

--- a/src/test/run-make-fulldeps/link-path-order/main.rs
+++ b/src/test/run-make-fulldeps/link-path-order/main.rs
@@ -2,15 +2,13 @@
 
 extern crate libc;
 
-#[link(name="foo", kind = "static")]
-extern {
+#[link(name = "foo", kind = "static")]
+extern "C" {
     fn should_return_one() -> libc::c_int;
 }
 
 fn main() {
-    let result = unsafe {
-        should_return_one()
-    };
+    let result = unsafe { should_return_one() };
 
     if result != 1 {
         std::process::exit(255);

--- a/src/test/run-make-fulldeps/linkage-attr-on-static/bar.rs
+++ b/src/test/run-make-fulldeps/linkage-attr-on-static/bar.rs
@@ -5,7 +5,7 @@
 static BAZ: i32 = 21;
 
 #[link(name = "foo", kind = "static")]
-extern {
+extern "C" {
     fn what() -> i32;
 }
 

--- a/src/test/run-make-fulldeps/long-linker-command-lines/foo.rs
+++ b/src/test/run-make-fulldeps/long-linker-command-lines/foo.rs
@@ -25,7 +25,7 @@ fn write_test_case(file: &Path, n: usize) -> HashSet<String> {
         writeln!(f, "#[link(name = \"S{}{}S\")]", prefix, i).unwrap();
         libs.insert(format!("{}{}", prefix, i));
     }
-    writeln!(f, "extern {{}}\nfn main() {{}}").unwrap();
+    writeln!(f, "extern \"C\" {{}}\nfn main() {{}}").unwrap();
     f.into_inner().unwrap();
 
     libs

--- a/src/test/run-make-fulldeps/longjmp-across-rust/main.rs
+++ b/src/test/run-make-fulldeps/longjmp-across-rust/main.rs
@@ -1,6 +1,6 @@
 #[link(name = "foo", kind = "static")]
-extern {
-    fn test_start(f: extern fn());
+extern "C" {
+    fn test_start(f: extern "C" fn());
     fn test_end();
 }
 
@@ -13,11 +13,10 @@ fn main() {
 struct A;
 
 impl Drop for A {
-    fn drop(&mut self) {
-    }
+    fn drop(&mut self) {}
 }
 
-extern fn test_middle() {
+extern "C" fn test_middle() {
     let _a = A;
     foo();
 }

--- a/src/test/run-make-fulldeps/lto-no-link-whole-rlib/lib1.rs
+++ b/src/test/run-make-fulldeps/lto-no-link-whole-rlib/lib1.rs
@@ -1,7 +1,7 @@
 #![crate_type = "rlib"]
 
 #[link(name = "foo", kind = "static")]
-extern {
+extern "C" {
     fn foo() -> i32;
 }
 

--- a/src/test/run-make-fulldeps/lto-no-link-whole-rlib/lib2.rs
+++ b/src/test/run-make-fulldeps/lto-no-link-whole-rlib/lib2.rs
@@ -3,7 +3,7 @@
 extern crate lib1;
 
 #[link(name = "bar", kind = "static")]
-extern {
+extern "C" {
     fn foo() -> i32;
 }
 

--- a/src/test/run-make-fulldeps/manual-link/foo.rs
+++ b/src/test/run-make-fulldeps/manual-link/foo.rs
@@ -1,9 +1,11 @@
 #![crate_type = "rlib"]
 
-extern {
+extern "C" {
     fn bar();
 }
 
 pub fn foo() {
-    unsafe { bar(); }
+    unsafe {
+        bar();
+    }
 }

--- a/src/test/run-make-fulldeps/no-duplicate-libs/main.rs
+++ b/src/test/run-make-fulldeps/no-duplicate-libs/main.rs
@@ -1,7 +1,7 @@
 #[link(name = "foo")] // linker should drop this library, no symbols used
 #[link(name = "bar")] // symbol comes from this library
 #[link(name = "foo")] // now linker picks up `foo` b/c `bar` library needs it
-extern {
+extern "C" {
     fn bar();
 }
 

--- a/src/test/run-make-fulldeps/sanitizer-cdylib-link/library.rs
+++ b/src/test/run-make-fulldeps/sanitizer-cdylib-link/library.rs
@@ -1,5 +1,5 @@
 #[no_mangle]
-pub extern fn overflow() {
+pub extern "C" fn overflow() {
     let xs = [0, 1, 2, 3];
     let _y = unsafe { *xs.as_ptr().offset(4) };
 }

--- a/src/test/run-make-fulldeps/sanitizer-cdylib-link/program.rs
+++ b/src/test/run-make-fulldeps/sanitizer-cdylib-link/program.rs
@@ -1,4 +1,4 @@
-extern {
+extern "C" {
     fn overflow();
 }
 

--- a/src/test/run-make-fulldeps/sanitizer-dylib-link/library.rs
+++ b/src/test/run-make-fulldeps/sanitizer-dylib-link/library.rs
@@ -1,5 +1,5 @@
 #[no_mangle]
-pub extern fn overflow() {
+pub extern "C" fn overflow() {
     let xs = [0, 1, 2, 3];
     let _y = unsafe { *xs.as_ptr().offset(4) };
 }

--- a/src/test/run-make-fulldeps/sanitizer-dylib-link/program.rs
+++ b/src/test/run-make-fulldeps/sanitizer-dylib-link/program.rs
@@ -1,4 +1,4 @@
-extern {
+extern "C" {
     fn overflow();
 }
 

--- a/src/test/run-make-fulldeps/sanitizer-staticlib-link/library.rs
+++ b/src/test/run-make-fulldeps/sanitizer-staticlib-link/library.rs
@@ -1,5 +1,5 @@
 #[no_mangle]
-pub extern fn overflow() {
+pub extern "C" fn overflow() {
     let xs = [0, 1, 2, 3];
     let _y = unsafe { *xs.as_ptr().offset(4) };
 }

--- a/src/test/run-make-fulldeps/sanitizer-staticlib-link/program.rs
+++ b/src/test/run-make-fulldeps/sanitizer-staticlib-link/program.rs
@@ -1,5 +1,5 @@
 #[link(name = "library")]
-extern {
+extern "C" {
     fn overflow();
 }
 

--- a/src/test/run-make-fulldeps/save-analysis-fail/foo.rs
+++ b/src/test/run-make-fulldeps/save-analysis-fail/foo.rs
@@ -1,4 +1,4 @@
-#![ crate_name = "test" ]
+#![crate_name = "test"]
 #![feature(box_syntax)]
 #![feature(rustc_private)]
 
@@ -9,10 +9,9 @@ extern crate krate2;
 extern crate krate2 as krate3;
 
 use rustc_graphviz::RenderOption;
-use std::collections::{HashMap,HashSet};
 use std::cell::RefCell;
+use std::collections::{HashMap, HashSet};
 use std::io::Write;
-
 
 use sub::sub2 as msalias;
 use sub::sub2;
@@ -30,7 +29,7 @@ static bob: Option<graphviz::RenderOption> = None;
 // buglink test - see issue #1337.
 
 fn test_alias<I: Iterator>(i: Option<<I as Iterator>::Item>) {
-    let s = sub_struct{ field2: 45u32, };
+    let s = sub_struct { field2: 45u32 };
 
     // import tests
     fn foo(x: &Write) {}
@@ -80,7 +79,7 @@ mod sub {
 
         pub enum nested_enum {
             Nest2 = 2,
-            Nest3 = 3
+            Nest3 = 3,
         }
     }
 }
@@ -101,7 +100,9 @@ struct some_fields {
 type SF = some_fields;
 
 trait SuperTrait {
-    fn qux(&self) { panic!(); }
+    fn qux(&self) {
+        panic!();
+    }
 }
 
 trait SomeTrait: SuperTrait {
@@ -136,8 +137,7 @@ impl SomeTrait for some_fields {
     }
 }
 
-impl SuperTrait for some_fields {
-}
+impl SuperTrait for some_fields {}
 
 impl SubTrait for some_fields {}
 
@@ -150,17 +150,14 @@ impl some_fields {
         42
     }
 
-    fn align_to<T>(&mut self) {
-
-    }
+    fn align_to<T>(&mut self) {}
 
     fn test(&mut self) {
         self.align_to::<bool>();
     }
 }
 
-impl SuperTrait for nofields {
-}
+impl SuperTrait for nofields {}
 impl SomeTrait for nofields {
     fn Method(&self, x: u32) -> u32 {
         self.Method(x);
@@ -186,59 +183,70 @@ enum SomeEnum<'a> {
     Ints(isize, isize),
     Floats(f64, f64),
     Strings(&'a str, &'a str, &'a str),
-    MyTypes(MyType, MyType)
+    MyTypes(MyType, MyType),
 }
 
 #[derive(Copy, Clone)]
 enum SomeOtherEnum {
     SomeConst1,
     SomeConst2,
-    SomeConst3
+    SomeConst3,
 }
 
 enum SomeStructEnum {
-    EnumStruct{a:isize, b:isize},
-    EnumStruct2{f1:MyType, f2:MyType},
-    EnumStruct3{f1:MyType, f2:MyType, f3:SomeEnum<'static>}
+    EnumStruct { a: isize, b: isize },
+    EnumStruct2 { f1: MyType, f2: MyType },
+    EnumStruct3 { f1: MyType, f2: MyType, f3: SomeEnum<'static> },
 }
 
 fn matchSomeEnum(val: SomeEnum) {
     match val {
-        SomeEnum::Ints(int1, int2) => { println(&(int1+int2).to_string()); }
-        SomeEnum::Floats(float1, float2) => { println(&(float2*float1).to_string()); }
-        SomeEnum::Strings(.., s3) => { println(s3); }
-        SomeEnum::MyTypes(mt1, mt2) => { println(&(mt1.field1 - mt2.field1).to_string()); }
+        SomeEnum::Ints(int1, int2) => {
+            println(&(int1 + int2).to_string());
+        }
+        SomeEnum::Floats(float1, float2) => {
+            println(&(float2 * float1).to_string());
+        }
+        SomeEnum::Strings(.., s3) => {
+            println(s3);
+        }
+        SomeEnum::MyTypes(mt1, mt2) => {
+            println(&(mt1.field1 - mt2.field1).to_string());
+        }
     }
 }
 
 fn matchSomeStructEnum(se: SomeStructEnum) {
     match se {
-        SomeStructEnum::EnumStruct{a:a, ..} => println(&a.to_string()),
-        SomeStructEnum::EnumStruct2{f1:f1, f2:f_2} => println(&f_2.field1.to_string()),
-        SomeStructEnum::EnumStruct3{f1, ..} => println(&f1.field1.to_string()),
+        SomeStructEnum::EnumStruct { a: a, .. } => println(&a.to_string()),
+        SomeStructEnum::EnumStruct2 { f1: f1, f2: f_2 } => println(&f_2.field1.to_string()),
+        SomeStructEnum::EnumStruct3 { f1, .. } => println(&f1.field1.to_string()),
     }
 }
-
 
 fn matchSomeStructEnum2(se: SomeStructEnum) {
     use SomeStructEnum::*;
     match se {
-        EnumStruct{a: ref aaa, ..} => println(&aaa.to_string()),
-        EnumStruct2{f1, f2: f2} => println(&f1.field1.to_string()),
-        EnumStruct3{f1, f3: SomeEnum::Ints(..), f2} => println(&f1.field1.to_string()),
-        _ => {},
+        EnumStruct { a: ref aaa, .. } => println(&aaa.to_string()),
+        EnumStruct2 { f1, f2: f2 } => println(&f1.field1.to_string()),
+        EnumStruct3 { f1, f3: SomeEnum::Ints(..), f2 } => println(&f1.field1.to_string()),
+        _ => {}
     }
 }
 
 fn matchSomeOtherEnum(val: SomeOtherEnum) {
     use SomeOtherEnum::{SomeConst2, SomeConst3};
     match val {
-        SomeOtherEnum::SomeConst1 => { println("I'm const1."); }
-        SomeConst2 | SomeConst3 => { println("I'm const2 or const3."); }
+        SomeOtherEnum::SomeConst1 => {
+            println("I'm const1.");
+        }
+        SomeConst2 | SomeConst3 => {
+            println("I'm const2 or const3.");
+        }
     }
 }
 
-fn hello<X: SomeTrait>((z, a) : (u32, String), ex: X) {
+fn hello<X: SomeTrait>((z, a): (u32, String), ex: X) {
     SameDir2::hello(43);
 
     println(&yy.to_string());
@@ -253,8 +261,8 @@ fn hello<X: SomeTrait>((z, a) : (u32, String), ex: X) {
     let x = 32.0f32;
     let _ = (x + ((x * x) + 1.0).sqrt()).ln();
 
-    let s: Box<SomeTrait> = box some_fields {field1: 43};
-    let s2: Box<some_fields> =  box some_fields {field1: 43};
+    let s: Box<SomeTrait> = box some_fields { field1: 43 };
+    let s2: Box<some_fields> = box some_fields { field1: 43 };
     let s3 = box nofields;
 
     s.Method(43);
@@ -307,8 +315,9 @@ mod macro_use_test {
     }
 }
 
-fn main() { // foo
-    let s = box some_fields {field1: 43};
+fn main() {
+    // foo
+    let s = box some_fields { field1: 43 };
     hello((43, "a".to_string()), *s);
     sub::sub2::hello();
     sub2::sub3::hello();
@@ -329,26 +338,24 @@ fn main() { // foo
     let vs = variable_str!(32);
 
     let mut candidates: RefCell<HashMap<&'static str, &'static str>> = RefCell::new(HashMap::new());
-    let _ = blah {
-        used_link_args: RefCell::new([]),
-    };
+    let _ = blah { used_link_args: RefCell::new([]) };
     let s1 = nofields;
-    let s2 = SF { field1: 55};
-    let s3: some_fields = some_fields{ field1: 55};
-    let s4: msalias::nested_struct = sub::sub2::nested_struct{ field2: 55};
-    let s4: msalias::nested_struct = sub2::nested_struct{ field2: 55};
+    let s2 = SF { field1: 55 };
+    let s3: some_fields = some_fields { field1: 55 };
+    let s4: msalias::nested_struct = sub::sub2::nested_struct { field2: 55 };
+    let s4: msalias::nested_struct = sub2::nested_struct { field2: 55 };
     println(&s2.field1.to_string());
-    let s5: MyType = box some_fields{ field1: 55};
-    let s = SameDir::SameStruct{name: "Bob".to_string()};
-    let s = SubDir::SubStruct{name:"Bob".to_string()};
+    let s5: MyType = box some_fields { field1: 55 };
+    let s = SameDir::SameStruct { name: "Bob".to_string() };
+    let s = SubDir::SubStruct { name: "Bob".to_string() };
     let s6: SomeEnum = SomeEnum::MyTypes(box s2.clone(), s5);
     let s7: SomeEnum = SomeEnum::Strings("one", "two", "three");
     matchSomeEnum(s6);
     matchSomeEnum(s7);
     let s8: SomeOtherEnum = SomeOtherEnum::SomeConst2;
     matchSomeOtherEnum(s8);
-    let s9: SomeStructEnum = SomeStructEnum::EnumStruct2{ f1: box some_fields{ field1:10 },
-                                                          f2: box s2 };
+    let s9: SomeStructEnum =
+        SomeStructEnum::EnumStruct2 { f1: box some_fields { field1: 10 }, f2: box s2 };
     matchSomeStructEnum(s9);
 
     for x in &vec![1, 2, 3] {
@@ -409,8 +416,7 @@ impl<'a> Pattern<'a> for CharEqPattern {
 
 struct CharSearcher<'a>(<CharEqPattern as Pattern<'a>>::Searcher);
 
-pub trait Error {
-}
+pub trait Error {}
 
 impl Error + 'static {
     pub fn is<T: Error + 'static>(&self) -> bool {
@@ -437,13 +443,13 @@ fn test_format_args() {
     print!("x is {}, y is {1}, name is {n}", x, y, n = name);
 }
 
-extern {
+extern "C" {
     static EXTERN_FOO: u8;
     fn extern_foo(a: u8, b: i32) -> String;
 }
 
 struct Rls699 {
-  f: u32,
+    f: u32,
 }
 
 fn new(f: u32) -> Rls699 {

--- a/src/test/run-make-fulldeps/static-dylib-by-default/bar.rs
+++ b/src/test/run-make-fulldeps/static-dylib-by-default/bar.rs
@@ -3,6 +3,6 @@
 extern crate foo;
 
 #[no_mangle]
-pub extern fn bar() {
+pub extern "C" fn bar() {
     foo::foo();
 }

--- a/src/test/run-make-fulldeps/static-nobundle/bbb.rs
+++ b/src/test/run-make-fulldeps/static-nobundle/bbb.rs
@@ -2,7 +2,7 @@
 #![feature(static_nobundle)]
 
 #[link(name = "aaa", kind = "static-nobundle")]
-extern {
+extern "C" {
     pub fn native_func();
 }
 

--- a/src/test/run-make-fulldeps/staticlib-blank-lib/foo.rs
+++ b/src/test/run-make-fulldeps/staticlib-blank-lib/foo.rs
@@ -1,6 +1,6 @@
 #![crate_type = "staticlib"]
 
 #[link(name = "foo", kind = "static")]
-extern {}
+extern "C" {}
 
 fn main() {}

--- a/src/test/run-make-fulldeps/std-core-cycle/foo.rs
+++ b/src/test/run-make-fulldeps/std-core-cycle/foo.rs
@@ -6,6 +6,6 @@ extern crate bar;
 static A: bar::A = bar::A;
 
 #[no_mangle]
-pub extern fn a(a: u32, b: u32) -> u32 {
+pub extern "C" fn a(a: u32, b: u32) -> u32 {
     a / b
 }

--- a/src/test/run-make-fulldeps/target-specs/foo.rs
+++ b/src/test/run-make-fulldeps/target-specs/foo.rs
@@ -1,19 +1,21 @@
 #![feature(lang_items, no_core, auto_traits)]
 #![no_core]
 
-#[lang="copy"]
-trait Copy { }
+#[lang = "copy"]
+trait Copy {}
 
-#[lang="sized"]
-trait Sized { }
+#[lang = "sized"]
+trait Sized {}
 
 #[lang = "freeze"]
 auto trait Freeze {}
 
-#[lang="start"]
-fn start(_main: *const u8, _argc: isize, _argv: *const *const u8) -> isize { 0 }
+#[lang = "start"]
+fn start(_main: *const u8, _argc: isize, _argv: *const *const u8) -> isize {
+    0
+}
 
-extern {
+extern "C" {
     fn _foo() -> [u8; 16];
 }
 

--- a/src/test/run-make/issue-36710/foo.rs
+++ b/src/test/run-make/issue-36710/foo.rs
@@ -3,7 +3,9 @@
 // For linking libstdc++ on MinGW
 #![cfg_attr(all(windows, target_env = "gnu"), feature(static_nobundle))]
 
-extern { fn get() -> u32; }
+extern "C" {
+    fn get() -> u32;
+}
 
 fn main() {
     let i = unsafe { get() };

--- a/src/test/run-make/wasm-import-module/bar.rs
+++ b/src/test/run-make/wasm-import-module/bar.rs
@@ -4,13 +4,13 @@
 extern crate foo;
 
 #[link(wasm_import_module = "./me")]
-extern {
+extern "C" {
     #[link_name = "me_in_dep"]
     fn dep();
 }
 
 #[no_mangle]
-pub extern fn foo() {
+pub extern "C" fn foo() {
     unsafe {
         foo::dep();
         dep();

--- a/src/test/run-make/wasm-import-module/foo.rs
+++ b/src/test/run-make/wasm-import-module/foo.rs
@@ -2,6 +2,6 @@
 #![deny(warnings)]
 
 #[link(wasm_import_module = "./dep")]
-extern {
+extern "C" {
     pub fn dep();
 }

--- a/src/test/run-pass-valgrind/osx-frameworks.rs
+++ b/src/test/run-pass-valgrind/osx-frameworks.rs
@@ -6,13 +6,15 @@ extern crate libc;
 
 #[cfg(target_os = "macos")]
 #[link(name = "CoreFoundation", kind = "framework")]
-extern {
+extern "C" {
     fn CFRunLoopGetTypeID() -> libc::c_ulong;
 }
 
 #[cfg(target_os = "macos")]
 pub fn main() {
-    unsafe { CFRunLoopGetTypeID(); }
+    unsafe {
+        CFRunLoopGetTypeID();
+    }
 }
 
 #[cfg(not(target_os = "macos"))]

--- a/src/test/rustdoc-ui/check-doc-alias-attr-location.rs
+++ b/src/test/rustdoc-ui/check-doc-alias-attr-location.rs
@@ -5,7 +5,7 @@ pub trait Foo {
 }
 
 #[doc(alias = "foo")] //~ ERROR
-extern {}
+extern "C" {}
 
 #[doc(alias = "bar")] //~ ERROR
 impl Bar {
@@ -17,5 +17,7 @@ impl Bar {
 impl Foo for Bar {
     #[doc(alias = "assoc")] //~ ERROR
     type X = i32;
-    fn foo() -> Self::X { 0 }
+    fn foo() -> Self::X {
+        0
+    }
 }

--- a/src/test/rustdoc-ui/coverage/basic.rs
+++ b/src/test/rustdoc-ui/coverage/basic.rs
@@ -45,6 +45,6 @@ macro_rules! some_macro {
     () => {};
 }
 
-extern {
+extern "C" {
     pub type ExternType;
 }

--- a/src/test/rustdoc/auxiliary/issue-34274.rs
+++ b/src/test/rustdoc/auxiliary/issue-34274.rs
@@ -1,3 +1,3 @@
-extern {
+extern "C" {
     pub fn extern_c_fn();
 }

--- a/src/test/rustdoc/foreigntype-reexport.rs
+++ b/src/test/rustdoc/foreigntype-reexport.rs
@@ -1,7 +1,7 @@
 #![feature(extern_types)]
 
 mod sub {
-    extern {
+    extern "C" {
         /// Another extern type.
         pub type C2;
         pub fn f2();
@@ -10,7 +10,7 @@ mod sub {
 }
 
 pub mod sub2 {
-    extern {
+    extern "C" {
         // @has foreigntype_reexport/sub2/foreigntype.C.html
         pub type C;
         // @has foreigntype_reexport/sub2/fn.f.html
@@ -21,7 +21,7 @@ pub mod sub2 {
 }
 
 mod sub3 {
-    extern {
+    extern "C" {
         pub type C4;
         pub fn f4();
         pub static K4: usize;
@@ -35,7 +35,7 @@ mod sub3 {
 // @has foreigntype_reexport/index.html '//a[@class="foreigntype"]' 'C2'
 // @has foreigntype_reexport/index.html '//a[@class="fn"]' 'f2'
 // @has foreigntype_reexport/index.html '//a[@class="static"]' 'K2'
-pub use self::sub::{C2, f2, K as K2};
+pub use self::sub::{f2, C2, K as K2};
 
 // @has foreigntype_reexport/index.html '//a[@class="foreigntype"]' 'C'
 // @has foreigntype_reexport/index.html '//a[@class="fn"]' 'f'
@@ -43,7 +43,7 @@ pub use self::sub::{C2, f2, K as K2};
 // @has foreigntype_reexport/index.html '//code' 'pub use self::sub2::C as C3;'
 // @has foreigntype_reexport/index.html '//code' 'pub use self::sub2::f as f3;'
 // @has foreigntype_reexport/index.html '//code' 'pub use self::sub2::K3;'
-pub use self::sub2::{C as C3, f as f3, K3};
+pub use self::sub2::{f as f3, C as C3, K3};
 
 // @has foreigntype_reexport/foreigntype.C4.html
 // @has foreigntype_reexport/fn.f4.html

--- a/src/test/rustdoc/foreigntype.rs
+++ b/src/test/rustdoc/foreigntype.rs
@@ -1,6 +1,6 @@
 #![feature(extern_types)]
 
-extern {
+extern "C" {
     // @has foreigntype/foreigntype.ExtType.html
     pub type ExtType;
 }

--- a/src/test/rustdoc/inline_local/glob-extern-no-defaults.rs
+++ b/src/test/rustdoc/inline_local/glob-extern-no-defaults.rs
@@ -3,7 +3,7 @@
 #![crate_name = "foo"]
 
 mod mod1 {
-    extern {
+    extern "C" {
         pub fn public_fn();
         fn private_fn();
     }

--- a/src/test/rustdoc/inline_local/glob-extern.rs
+++ b/src/test/rustdoc/inline_local/glob-extern.rs
@@ -1,7 +1,7 @@
 #![crate_name = "foo"]
 
 mod mod1 {
-    extern {
+    extern "C" {
         pub fn public_fn();
         fn private_fn();
     }

--- a/src/test/rustdoc/issue-22038.rs
+++ b/src/test/rustdoc/issue-22038.rs
@@ -1,4 +1,4 @@
-extern {
+extern "C" {
     // @has issue_22038/fn.foo1.html \
     //      '//*[@class="rust fn"]' 'pub unsafe extern "C" fn foo1()'
     pub fn foo1();
@@ -12,7 +12,7 @@ extern "system" {
 
 // @has issue_22038/fn.bar.html \
 //      '//*[@class="rust fn"]' 'pub extern "C" fn bar()'
-pub extern fn bar() {}
+pub extern "C" fn bar() {}
 
 // @has issue_22038/fn.baz.html \
 //      '//*[@class="rust fn"]' 'pub extern "system" fn baz()'

--- a/src/test/rustdoc/sanitizer-option.rs
+++ b/src/test/rustdoc/sanitizer-option.rs
@@ -7,7 +7,7 @@
 // correctly, then linking will fail.
 
 /// ```
-/// extern {
+/// extern "C" {
 ///     fn __sanitizer_print_stack_trace();
 /// }
 ///

--- a/src/test/rustdoc/titles.rs
+++ b/src/test/rustdoc/titles.rs
@@ -7,7 +7,7 @@ pub mod foo_mod {
     pub struct __Thing {}
 }
 
-extern {
+extern "C" {
     // @matches 'foo/fn.foo_ffn.html' '//h1' 'Function foo::foo_ffn'
     pub fn foo_ffn();
 }
@@ -30,7 +30,7 @@ pub type FooType = FooStruct;
 // @matches 'foo/macro.foo_macro.html' '//h1' 'Macro foo::foo_macro'
 #[macro_export]
 macro_rules! foo_macro {
-    () => ();
+    () => {};
 }
 
 // @matches 'foo/primitive.bool.html' '//h1' 'Primitive Type bool'
@@ -40,7 +40,7 @@ mod bool {}
 // @matches 'foo/static.FOO_STATIC.html' '//h1' 'Static foo::FOO_STATIC'
 pub static FOO_STATIC: FooStruct = FooStruct;
 
-extern {
+extern "C" {
     // @matches 'foo/static.FOO_FSTATIC.html' '//h1' 'Static foo::FOO_FSTATIC'
     pub static FOO_FSTATIC: FooStruct;
 }

--- a/src/test/ui-fulldeps/switch-stdout.rs
+++ b/src/test/ui-fulldeps/switch-stdout.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 fn switch_stdout_to(file: File) {
     use std::os::unix::prelude::*;
 
-    extern {
+    extern "C" {
         fn dup2(old: i32, new: i32) -> i32;
     }
 
@@ -29,8 +29,7 @@ fn switch_stdout_to(file: File) {
     const STD_OUTPUT_HANDLE: u32 = (-11i32) as u32;
 
     unsafe {
-        let rc = SetStdHandle(STD_OUTPUT_HANDLE,
-                              file.into_raw_handle() as *mut _);
+        let rc = SetStdHandle(STD_OUTPUT_HANDLE, file.into_raw_handle() as *mut _);
         assert!(rc != 0);
     }
 }

--- a/src/test/ui/abi/anon-extern-mod.rs
+++ b/src/test/ui/abi/anon-extern-mod.rs
@@ -7,7 +7,7 @@
 extern crate libc;
 
 #[link(name = "rust_test_helpers", kind = "static")]
-extern {
+extern "C" {
     fn rust_get_test_int() -> libc::intptr_t;
 }
 

--- a/src/test/ui/abi/auxiliary/anon-extern-mod-cross-crate-1.rs
+++ b/src/test/ui/abi/auxiliary/anon-extern-mod-cross-crate-1.rs
@@ -1,9 +1,9 @@
-#![crate_name="anonexternmod"]
+#![crate_name = "anonexternmod"]
 #![feature(rustc_private)]
 
 extern crate libc;
 
 #[link(name = "rust_test_helpers", kind = "static")]
-extern {
+extern "C" {
     pub fn rust_get_test_int() -> libc::intptr_t;
 }

--- a/src/test/ui/abi/auxiliary/foreign_lib.rs
+++ b/src/test/ui/abi/auxiliary/foreign_lib.rs
@@ -1,12 +1,11 @@
-#![crate_name="foreign_lib"]
-
+#![crate_name = "foreign_lib"]
 #![feature(rustc_private)]
 
 pub mod rustrt {
     extern crate libc;
 
     #[link(name = "rust_test_helpers", kind = "static")]
-    extern {
+    extern "C" {
         pub fn rust_get_test_int() -> libc::intptr_t;
     }
 }
@@ -14,7 +13,7 @@ pub mod rustrt {
 pub mod rustrt2 {
     extern crate libc;
 
-    extern {
+    extern "C" {
         pub fn rust_get_test_int() -> libc::intptr_t;
     }
 }
@@ -24,7 +23,7 @@ pub mod rustrt3 {
     // Ensures that we don't ICE or trigger LLVM asserts when
     // importing the same symbol under different types.
     // See https://github.com/rust-lang/rust/issues/32740.
-    extern {
+    extern "C" {
         pub fn rust_get_test_int() -> *const u8;
     }
 }

--- a/src/test/ui/abi/c-stack-as-value.rs
+++ b/src/test/ui/abi/c-stack-as-value.rs
@@ -8,7 +8,7 @@ mod rustrt {
     extern crate libc;
 
     #[link(name = "rust_test_helpers", kind = "static")]
-    extern {
+    extern "C" {
         pub fn rust_get_test_int() -> libc::intptr_t;
     }
 }

--- a/src/test/ui/abi/cabi-int-widening.rs
+++ b/src/test/ui/abi/cabi-int-widening.rs
@@ -2,7 +2,7 @@
 // ignore-wasm32-bare no libc to test ffi with
 
 #[link(name = "rust_test_helpers", kind = "static")]
-extern {
+extern "C" {
     fn rust_int8_to_int32(_: i8) -> i32;
 }
 

--- a/src/test/ui/abi/consts/auxiliary/anon-extern-mod-cross-crate-1.rs
+++ b/src/test/ui/abi/consts/auxiliary/anon-extern-mod-cross-crate-1.rs
@@ -1,9 +1,9 @@
-#![crate_name="anonexternmod"]
+#![crate_name = "anonexternmod"]
 #![feature(rustc_private)]
 
 extern crate libc;
 
 #[link(name = "rust_test_helpers", kind = "static")]
-extern {
+extern "C" {
     pub fn rust_get_test_int() -> libc::intptr_t;
 }

--- a/src/test/ui/abi/cross-crate/auxiliary/anon-extern-mod-cross-crate-1.rs
+++ b/src/test/ui/abi/cross-crate/auxiliary/anon-extern-mod-cross-crate-1.rs
@@ -1,9 +1,9 @@
-#![crate_name="anonexternmod"]
+#![crate_name = "anonexternmod"]
 #![feature(rustc_private)]
 
 extern crate libc;
 
 #[link(name = "rust_test_helpers", kind = "static")]
-extern {
+extern "C" {
     pub fn rust_get_test_int() -> libc::intptr_t;
 }

--- a/src/test/ui/abi/extern/auxiliary/extern-crosscrate-source.rs
+++ b/src/test/ui/abi/extern/auxiliary/extern-crosscrate-source.rs
@@ -1,4 +1,4 @@
-#![crate_name="externcallback"]
+#![crate_name = "externcallback"]
 #![crate_type = "lib"]
 #![feature(rustc_private)]
 
@@ -8,10 +8,11 @@ pub mod rustrt {
     extern crate libc;
 
     #[link(name = "rust_test_helpers", kind = "static")]
-    extern {
-        pub fn rust_dbg_call(cb: extern "C" fn(libc::uintptr_t) -> libc::uintptr_t,
-                             data: libc::uintptr_t)
-                             -> libc::uintptr_t;
+    extern "C" {
+        pub fn rust_dbg_call(
+            cb: extern "C" fn(libc::uintptr_t) -> libc::uintptr_t,
+            data: libc::uintptr_t,
+        ) -> libc::uintptr_t;
     }
 }
 
@@ -22,10 +23,6 @@ pub fn fact(n: libc::uintptr_t) -> libc::uintptr_t {
     }
 }
 
-pub extern fn cb(data: libc::uintptr_t) -> libc::uintptr_t {
-    if data == 1 {
-        data
-    } else {
-        fact(data - 1) * data
-    }
+pub extern "C" fn cb(data: libc::uintptr_t) -> libc::uintptr_t {
+    if data == 1 { data } else { fact(data - 1) * data }
 }

--- a/src/test/ui/abi/extern/extern-call-deep.rs
+++ b/src/test/ui/abi/extern/extern-call-deep.rs
@@ -10,19 +10,16 @@ mod rustrt {
     extern crate libc;
 
     #[link(name = "rust_test_helpers", kind = "static")]
-    extern {
-        pub fn rust_dbg_call(cb: extern "C" fn(libc::uintptr_t) -> libc::uintptr_t,
-                             data: libc::uintptr_t)
-                             -> libc::uintptr_t;
+    extern "C" {
+        pub fn rust_dbg_call(
+            cb: extern "C" fn(libc::uintptr_t) -> libc::uintptr_t,
+            data: libc::uintptr_t,
+        ) -> libc::uintptr_t;
     }
 }
 
-extern fn cb(data: libc::uintptr_t) -> libc::uintptr_t {
-    if data == 1 {
-        data
-    } else {
-        count(data - 1) + 1
-    }
+extern "C" fn cb(data: libc::uintptr_t) -> libc::uintptr_t {
+    if data == 1 { data } else { count(data - 1) + 1 }
 }
 
 fn count(n: libc::uintptr_t) -> libc::uintptr_t {

--- a/src/test/ui/abi/extern/extern-call-deep2.rs
+++ b/src/test/ui/abi/extern/extern-call-deep2.rs
@@ -1,7 +1,6 @@
 // run-pass
 #![allow(unused_must_use)]
 // ignore-emscripten no threads support
-
 #![feature(rustc_private)]
 
 extern crate libc;
@@ -11,19 +10,16 @@ mod rustrt {
     extern crate libc;
 
     #[link(name = "rust_test_helpers", kind = "static")]
-    extern {
-        pub fn rust_dbg_call(cb: extern "C" fn(libc::uintptr_t) -> libc::uintptr_t,
-                             data: libc::uintptr_t)
-                             -> libc::uintptr_t;
+    extern "C" {
+        pub fn rust_dbg_call(
+            cb: extern "C" fn(libc::uintptr_t) -> libc::uintptr_t,
+            data: libc::uintptr_t,
+        ) -> libc::uintptr_t;
     }
 }
 
-extern fn cb(data: libc::uintptr_t) -> libc::uintptr_t {
-    if data == 1 {
-        data
-    } else {
-        count(data - 1) + 1
-    }
+extern "C" fn cb(data: libc::uintptr_t) -> libc::uintptr_t {
+    if data == 1 { data } else { count(data - 1) + 1 }
 }
 
 fn count(n: libc::uintptr_t) -> libc::uintptr_t {
@@ -36,9 +32,10 @@ fn count(n: libc::uintptr_t) -> libc::uintptr_t {
 pub fn main() {
     // Make sure we're on a thread with small Rust stacks (main currently
     // has a large stack)
-    thread::spawn(move|| {
+    thread::spawn(move || {
         let result = count(1000);
         println!("result = {}", result);
         assert_eq!(result, 1000);
-    }).join();
+    })
+    .join();
 }

--- a/src/test/ui/abi/extern/extern-call-direct.rs
+++ b/src/test/ui/abi/extern/extern-call-direct.rs
@@ -2,7 +2,7 @@
 // Test direct calls to extern fns.
 
 
-extern fn f(x: usize) -> usize { x * 2 }
+extern "C" fn f(x: usize) -> usize { x * 2 }
 
 pub fn main() {
     let x = f(22);

--- a/src/test/ui/abi/extern/extern-call-indirect.rs
+++ b/src/test/ui/abi/extern/extern-call-indirect.rs
@@ -9,19 +9,16 @@ mod rustrt {
     extern crate libc;
 
     #[link(name = "rust_test_helpers", kind = "static")]
-    extern {
-        pub fn rust_dbg_call(cb: extern "C" fn(libc::uintptr_t) -> libc::uintptr_t,
-                             data: libc::uintptr_t)
-                             -> libc::uintptr_t;
+    extern "C" {
+        pub fn rust_dbg_call(
+            cb: extern "C" fn(libc::uintptr_t) -> libc::uintptr_t,
+            data: libc::uintptr_t,
+        ) -> libc::uintptr_t;
     }
 }
 
-extern fn cb(data: libc::uintptr_t) -> libc::uintptr_t {
-    if data == 1 {
-        data
-    } else {
-        fact(data - 1) * data
-    }
+extern "C" fn cb(data: libc::uintptr_t) -> libc::uintptr_t {
+    if data == 1 { data } else { fact(data - 1) * data }
 }
 
 fn fact(n: libc::uintptr_t) -> libc::uintptr_t {

--- a/src/test/ui/abi/extern/extern-call-scrub.rs
+++ b/src/test/ui/abi/extern/extern-call-scrub.rs
@@ -5,7 +5,6 @@
 // directions
 
 // ignore-emscripten no threads support
-
 #![feature(rustc_private)]
 
 extern crate libc;
@@ -15,19 +14,16 @@ mod rustrt {
     extern crate libc;
 
     #[link(name = "rust_test_helpers", kind = "static")]
-    extern {
-        pub fn rust_dbg_call(cb: extern "C" fn(libc::uintptr_t) -> libc::uintptr_t,
-                             data: libc::uintptr_t)
-                             -> libc::uintptr_t;
+    extern "C" {
+        pub fn rust_dbg_call(
+            cb: extern "C" fn(libc::uintptr_t) -> libc::uintptr_t,
+            data: libc::uintptr_t,
+        ) -> libc::uintptr_t;
     }
 }
 
-extern fn cb(data: libc::uintptr_t) -> libc::uintptr_t {
-    if data == 1 {
-        data
-    } else {
-        count(data - 1) + count(data - 1)
-    }
+extern "C" fn cb(data: libc::uintptr_t) -> libc::uintptr_t {
+    if data == 1 { data } else { count(data - 1) + count(data - 1) }
 }
 
 fn count(n: libc::uintptr_t) -> libc::uintptr_t {
@@ -40,9 +36,10 @@ fn count(n: libc::uintptr_t) -> libc::uintptr_t {
 pub fn main() {
     // Make sure we're on a thread with small Rust stacks (main currently
     // has a large stack)
-    thread::spawn(move|| {
+    thread::spawn(move || {
         let result = count(12);
         println!("result = {}", result);
         assert_eq!(result, 2048);
-    }).join();
+    })
+    .join();
 }

--- a/src/test/ui/abi/extern/extern-pass-TwoU16s.rs
+++ b/src/test/ui/abi/extern/extern-pass-TwoU16s.rs
@@ -8,17 +8,18 @@
 
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub struct TwoU16s {
-    one: u16, two: u16
+    one: u16,
+    two: u16,
 }
 
 #[link(name = "rust_test_helpers", kind = "static")]
-extern {
+extern "C" {
     pub fn rust_dbg_extern_identity_TwoU16s(v: TwoU16s) -> TwoU16s;
 }
 
 pub fn main() {
     unsafe {
-        let x = TwoU16s {one: 22, two: 23};
+        let x = TwoU16s { one: 22, two: 23 };
         let y = rust_dbg_extern_identity_TwoU16s(x);
         assert_eq!(x, y);
     }

--- a/src/test/ui/abi/extern/extern-pass-TwoU32s.rs
+++ b/src/test/ui/abi/extern/extern-pass-TwoU32s.rs
@@ -8,17 +8,18 @@
 
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub struct TwoU32s {
-    one: u32, two: u32
+    one: u32,
+    two: u32,
 }
 
 #[link(name = "rust_test_helpers", kind = "static")]
-extern {
+extern "C" {
     pub fn rust_dbg_extern_identity_TwoU32s(v: TwoU32s) -> TwoU32s;
 }
 
 pub fn main() {
     unsafe {
-        let x = TwoU32s {one: 22, two: 23};
+        let x = TwoU32s { one: 22, two: 23 };
         let y = rust_dbg_extern_identity_TwoU32s(x);
         assert_eq!(x, y);
     }

--- a/src/test/ui/abi/extern/extern-pass-TwoU64s.rs
+++ b/src/test/ui/abi/extern/extern-pass-TwoU64s.rs
@@ -8,17 +8,18 @@
 
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub struct TwoU64s {
-    one: u64, two: u64
+    one: u64,
+    two: u64,
 }
 
 #[link(name = "rust_test_helpers", kind = "static")]
-extern {
+extern "C" {
     pub fn rust_dbg_extern_identity_TwoU64s(v: TwoU64s) -> TwoU64s;
 }
 
 pub fn main() {
     unsafe {
-        let x = TwoU64s {one: 22, two: 23};
+        let x = TwoU64s { one: 22, two: 23 };
         let y = rust_dbg_extern_identity_TwoU64s(x);
         assert_eq!(x, y);
     }

--- a/src/test/ui/abi/extern/extern-pass-TwoU8s.rs
+++ b/src/test/ui/abi/extern/extern-pass-TwoU8s.rs
@@ -8,17 +8,18 @@
 
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub struct TwoU8s {
-    one: u8, two: u8
+    one: u8,
+    two: u8,
 }
 
 #[link(name = "rust_test_helpers", kind = "static")]
-extern {
+extern "C" {
     pub fn rust_dbg_extern_identity_TwoU8s(v: TwoU8s) -> TwoU8s;
 }
 
 pub fn main() {
     unsafe {
-        let x = TwoU8s {one: 22, two: 23};
+        let x = TwoU8s { one: 22, two: 23 };
         let y = rust_dbg_extern_identity_TwoU8s(x);
         assert_eq!(x, y);
     }

--- a/src/test/ui/abi/extern/extern-pass-char.rs
+++ b/src/test/ui/abi/extern/extern-pass-char.rs
@@ -3,9 +3,8 @@
 
 // Test a function that takes/returns a u8.
 
-
 #[link(name = "rust_test_helpers", kind = "static")]
-extern {
+extern "C" {
     pub fn rust_dbg_extern_identity_u8(v: u8) -> u8;
 }
 

--- a/src/test/ui/abi/extern/extern-pass-double.rs
+++ b/src/test/ui/abi/extern/extern-pass-double.rs
@@ -2,7 +2,7 @@
 // ignore-wasm32-bare no libc for ffi testing
 
 #[link(name = "rust_test_helpers", kind = "static")]
-extern {
+extern "C" {
     pub fn rust_dbg_extern_identity_double(v: f64) -> f64;
 }
 

--- a/src/test/ui/abi/extern/extern-pass-empty.rs
+++ b/src/test/ui/abi/extern/extern-pass-empty.rs
@@ -27,7 +27,7 @@ struct ManyInts {
 struct Empty;
 
 #[link(name = "rust_test_helpers", kind = "static")]
-extern {
+extern "C" {
     fn rust_dbg_extern_empty_struct(v1: ManyInts, e: Empty, v2: ManyInts);
 }
 
@@ -39,7 +39,7 @@ pub fn main() {
             arg3: 4,
             arg4: 5,
             arg5: 6,
-            arg6: TwoU8s { one: 7, two: 8, }
+            arg6: TwoU8s { one: 7, two: 8 },
         };
         let y = ManyInts {
             arg1: 1,
@@ -47,7 +47,7 @@ pub fn main() {
             arg3: 3,
             arg4: 4,
             arg5: 5,
-            arg6: TwoU8s { one: 6, two: 7, }
+            arg6: TwoU8s { one: 6, two: 7 },
         };
         let empty = Empty;
         rust_dbg_extern_empty_struct(x, empty, y);

--- a/src/test/ui/abi/extern/extern-pass-u32.rs
+++ b/src/test/ui/abi/extern/extern-pass-u32.rs
@@ -3,9 +3,8 @@
 
 // Test a function that takes/returns a u32.
 
-
 #[link(name = "rust_test_helpers", kind = "static")]
-extern {
+extern "C" {
     pub fn rust_dbg_extern_identity_u32(v: u32) -> u32;
 }
 

--- a/src/test/ui/abi/extern/extern-pass-u64.rs
+++ b/src/test/ui/abi/extern/extern-pass-u64.rs
@@ -3,9 +3,8 @@
 
 // Test a call to a function that takes/returns a u64.
 
-
 #[link(name = "rust_test_helpers", kind = "static")]
-extern {
+extern "C" {
     pub fn rust_dbg_extern_identity_u64(v: u64) -> u64;
 }
 

--- a/src/test/ui/abi/extern/extern-return-TwoU16s.rs
+++ b/src/test/ui/abi/extern/extern-return-TwoU16s.rs
@@ -4,11 +4,12 @@
 // ignore-wasm32-bare no libc to test ffi with
 
 pub struct TwoU16s {
-    one: u16, two: u16
+    one: u16,
+    two: u16,
 }
 
 #[link(name = "rust_test_helpers", kind = "static")]
-extern {
+extern "C" {
     pub fn rust_dbg_extern_return_TwoU16s() -> TwoU16s;
 }
 

--- a/src/test/ui/abi/extern/extern-return-TwoU32s.rs
+++ b/src/test/ui/abi/extern/extern-return-TwoU32s.rs
@@ -4,11 +4,12 @@
 // ignore-wasm32-bare no libc to test ffi with
 
 pub struct TwoU32s {
-    one: u32, two: u32
+    one: u32,
+    two: u32,
 }
 
 #[link(name = "rust_test_helpers", kind = "static")]
-extern {
+extern "C" {
     pub fn rust_dbg_extern_return_TwoU32s() -> TwoU32s;
 }
 

--- a/src/test/ui/abi/extern/extern-return-TwoU64s.rs
+++ b/src/test/ui/abi/extern/extern-return-TwoU64s.rs
@@ -4,11 +4,12 @@
 // ignore-wasm32-bare no libc to test ffi with
 
 pub struct TwoU64s {
-    one: u64, two: u64
+    one: u64,
+    two: u64,
 }
 
 #[link(name = "rust_test_helpers", kind = "static")]
-extern {
+extern "C" {
     pub fn rust_dbg_extern_return_TwoU64s() -> TwoU64s;
 }
 

--- a/src/test/ui/abi/extern/extern-return-TwoU8s.rs
+++ b/src/test/ui/abi/extern/extern-return-TwoU8s.rs
@@ -4,11 +4,12 @@
 // ignore-wasm32-bare no libc to test ffi with
 
 pub struct TwoU8s {
-    one: u8, two: u8
+    one: u8,
+    two: u8,
 }
 
 #[link(name = "rust_test_helpers", kind = "static")]
-extern {
+extern "C" {
     pub fn rust_dbg_extern_return_TwoU8s() -> TwoU8s;
 }
 

--- a/src/test/ui/abi/foreign/auxiliary/foreign_lib.rs
+++ b/src/test/ui/abi/foreign/auxiliary/foreign_lib.rs
@@ -1,12 +1,11 @@
-#![crate_name="foreign_lib"]
-
+#![crate_name = "foreign_lib"]
 #![feature(rustc_private)]
 
 pub mod rustrt {
     extern crate libc;
 
     #[link(name = "rust_test_helpers", kind = "static")]
-    extern {
+    extern "C" {
         pub fn rust_get_test_int() -> libc::intptr_t;
     }
 }
@@ -14,7 +13,7 @@ pub mod rustrt {
 pub mod rustrt2 {
     extern crate libc;
 
-    extern {
+    extern "C" {
         pub fn rust_get_test_int() -> libc::intptr_t;
     }
 }
@@ -24,7 +23,7 @@ pub mod rustrt3 {
     // Ensures that we don't ICE or trigger LLVM asserts when
     // importing the same symbol under different types.
     // See https://github.com/rust-lang/rust/issues/32740.
-    extern {
+    extern "C" {
         pub fn rust_get_test_int() -> *const u8;
     }
 }

--- a/src/test/ui/abi/foreign/foreign-call-no-runtime.rs
+++ b/src/test/ui/abi/foreign/foreign-call-no-runtime.rs
@@ -9,45 +9,50 @@ use std::mem;
 use std::thread;
 
 #[link(name = "rust_test_helpers", kind = "static")]
-extern {
-    fn rust_dbg_call(cb: extern "C" fn(libc::uintptr_t),
-                     data: libc::uintptr_t) -> libc::uintptr_t;
+extern "C" {
+    fn rust_dbg_call(cb: extern "C" fn(libc::uintptr_t), data: libc::uintptr_t) -> libc::uintptr_t;
 }
 
 pub fn main() {
     unsafe {
-        thread::spawn(move|| {
+        thread::spawn(move || {
             let i: isize = 100;
             rust_dbg_call(callback_isize, mem::transmute(&i));
-        }).join().unwrap();
+        })
+        .join()
+        .unwrap();
 
-        thread::spawn(move|| {
+        thread::spawn(move || {
             let i: i32 = 100;
             rust_dbg_call(callback_i32, mem::transmute(&i));
-        }).join().unwrap();
+        })
+        .join()
+        .unwrap();
 
-        thread::spawn(move|| {
+        thread::spawn(move || {
             let i: i64 = 100;
             rust_dbg_call(callback_i64, mem::transmute(&i));
-        }).join().unwrap();
+        })
+        .join()
+        .unwrap();
     }
 }
 
-extern fn callback_isize(data: libc::uintptr_t) {
+extern "C" fn callback_isize(data: libc::uintptr_t) {
     unsafe {
         let data: *const isize = mem::transmute(data);
         assert_eq!(*data, 100);
     }
 }
 
-extern fn callback_i64(data: libc::uintptr_t) {
+extern "C" fn callback_i64(data: libc::uintptr_t) {
     unsafe {
         let data: *const i64 = mem::transmute(data);
         assert_eq!(*data, 100);
     }
 }
 
-extern fn callback_i32(data: libc::uintptr_t) {
+extern "C" fn callback_i32(data: libc::uintptr_t) {
     unsafe {
         let data: *const i32 = mem::transmute(data);
         assert_eq!(*data, 100);

--- a/src/test/ui/abi/foreign/foreign-fn-with-byval.rs
+++ b/src/test/ui/abi/foreign/foreign-fn-with-byval.rs
@@ -11,17 +11,15 @@ pub struct S {
 }
 
 #[link(name = "rust_test_helpers", kind = "static")]
-extern {
+extern "C" {
     pub fn get_x(x: S) -> u64;
     pub fn get_y(x: S) -> u64;
     pub fn get_z(x: S) -> u64;
 }
 
 #[inline(never)]
-fn indirect_call(func: unsafe extern fn(s: S) -> u64, s: S) -> u64 {
-    unsafe {
-        func(s)
-    }
+fn indirect_call(func: unsafe extern "C" fn(s: S) -> u64, s: S) -> u64 {
+    unsafe { func(s) }
 }
 
 fn main() {

--- a/src/test/ui/abi/foreign/foreign-no-abi.rs
+++ b/src/test/ui/abi/foreign/foreign-no-abi.rs
@@ -10,7 +10,7 @@ mod rustrt {
     extern crate libc;
 
     #[link(name = "rust_test_helpers", kind = "static")]
-    extern {
+    extern "C" {
         pub fn rust_get_test_int() -> libc::intptr_t;
     }
 }

--- a/src/test/ui/abi/issues/issue-62350-sysv-neg-reg-counts.rs
+++ b/src/test/ui/abi/issues/issue-62350-sysv-neg-reg-counts.rs
@@ -5,13 +5,18 @@
 // ignore-wasm32-bare no libc to test ffi with
 
 #[derive(Copy, Clone)]
-pub struct QuadFloats { a: f32, b: f32, c: f32, d: f32 }
+pub struct QuadFloats {
+    a: f32,
+    b: f32,
+    c: f32,
+    d: f32,
+}
 
 mod rustrt {
     use super::QuadFloats;
 
     #[link(name = "rust_test_helpers", kind = "static")]
-    extern {
+    extern "C" {
         pub fn get_c_exhaust_sysv64_ints(
             _: *const (),
             _: *const (),
@@ -28,12 +33,7 @@ mod rustrt {
 fn test() {
     unsafe {
         let null = std::ptr::null();
-        let q = QuadFloats {
-            a: 10.2,
-            b: 20.3,
-            c: 30.4,
-            d: 40.5
-        };
+        let q = QuadFloats { a: 10.2, b: 20.3, c: 30.4, d: 40.5 };
         assert_eq!(
             rustrt::get_c_exhaust_sysv64_ints(null, null, null, null, null, null, null, q),
             q.c,

--- a/src/test/ui/abi/mir/mir_codegen_calls_variadic.rs
+++ b/src/test/ui/abi/mir/mir_codegen_calls_variadic.rs
@@ -2,21 +2,18 @@
 // ignore-wasm32-bare no libc to test ffi with
 
 #[link(name = "rust_test_helpers", kind = "static")]
-extern {
+extern "C" {
     fn rust_interesting_average(_: i64, ...) -> f64;
 }
 
 fn test<T, U>(a: i64, b: i64, c: i64, d: i64, e: i64, f: T, g: U) -> i64 {
     unsafe {
-        rust_interesting_average(6, a, a as f64,
-                                    b, b as f64,
-                                    c, c as f64,
-                                    d, d as f64,
-                                    e, e as f64,
-                                    f, g) as i64
+        rust_interesting_average(
+            6, a, a as f64, b, b as f64, c, c as f64, d, d as f64, e, e as f64, f, g,
+        ) as i64
     }
 }
 
-fn main(){
+fn main() {
     assert_eq!(test(10, 20, 30, 40, 50, 60_i64, 60.0_f64), 70);
 }

--- a/src/test/ui/abi/segfault-no-out-of-stack.rs
+++ b/src/test/ui/abi/segfault-no-out-of-stack.rs
@@ -3,39 +3,37 @@
 #![allow(unused_imports)]
 // ignore-emscripten can't run commands
 // ignore-sgx no processes
-
 #![feature(rustc_private)]
 
 extern crate libc;
 
-use std::process::{Command, ExitStatus};
 use std::env;
+use std::process::{Command, ExitStatus};
 
 #[link(name = "rust_test_helpers", kind = "static")]
-extern {
+extern "C" {
     fn rust_get_null_ptr() -> *mut ::libc::c_char;
 }
 
 #[cfg(unix)]
-fn check_status(status: std::process::ExitStatus)
-{
+fn check_status(status: std::process::ExitStatus) {
     use libc;
     use std::os::unix::process::ExitStatusExt;
 
-    assert!(status.signal() == Some(libc::SIGSEGV)
-            || status.signal() == Some(libc::SIGBUS));
+    assert!(status.signal() == Some(libc::SIGSEGV) || status.signal() == Some(libc::SIGBUS));
 }
 
 #[cfg(not(unix))]
-fn check_status(status: std::process::ExitStatus)
-{
+fn check_status(status: std::process::ExitStatus) {
     assert!(!status.success());
 }
 
 fn main() {
     let args: Vec<String> = env::args().collect();
     if args.len() > 1 && args[1] == "segfault" {
-        unsafe { *rust_get_null_ptr() = 1; }; // trigger a segfault
+        unsafe {
+            *rust_get_null_ptr() = 1;
+        }; // trigger a segfault
     } else {
         let segfault = Command::new(&args[0]).arg("segfault").output().unwrap();
         let stderr = String::from_utf8_lossy(&segfault.stderr);

--- a/src/test/ui/abi/stack-probes.rs
+++ b/src/test/ui/abi/stack-probes.rs
@@ -11,13 +11,13 @@
 // ignore-emscripten no processes
 // ignore-sgx no processes
 
+use std::env;
 use std::mem::MaybeUninit;
 use std::process::Command;
 use std::thread;
-use std::env;
 
 #[link(name = "rust_test_helpers", kind = "static")]
-extern {
+extern "C" {
     #[link_name = "rust_dbg_extern_identity_u64"]
     fn black_box(u: u64);
 }
@@ -30,7 +30,7 @@ fn main() {
             "child-thread" => thread::spawn(|| recurse(&MaybeUninit::uninit())).join().unwrap(),
             _ => panic!(),
         }
-        return
+        return;
     }
 
     let me = env::current_exe().unwrap();

--- a/src/test/ui/abi/statics/static-mut-foreign.rs
+++ b/src/test/ui/abi/statics/static-mut-foreign.rs
@@ -10,7 +10,7 @@
 extern crate libc;
 
 #[link(name = "rust_test_helpers", kind = "static")]
-extern {
+extern "C" {
     static mut rust_dbg_static_mut: libc::c_int;
     pub fn rust_dbg_static_mut_check_four();
 }

--- a/src/test/ui/abi/struct-enums/struct-return.rs
+++ b/src/test/ui/abi/struct-enums/struct-return.rs
@@ -4,25 +4,42 @@
 
 #[repr(C)]
 #[derive(Copy, Clone)]
-pub struct Quad { a: u64, b: u64, c: u64, d: u64 }
+pub struct Quad {
+    a: u64,
+    b: u64,
+    c: u64,
+    d: u64,
+}
 
 #[repr(C)]
 #[derive(Copy, Clone)]
-pub struct Floats { a: f64, b: u8, c: f64 }
+pub struct Floats {
+    a: f64,
+    b: u8,
+    c: f64,
+}
 
 #[repr(C)]
 #[derive(Copy, Clone)]
-pub struct CharCharDouble { a: u8, b: u8, c: f64 }
+pub struct CharCharDouble {
+    a: u8,
+    b: u8,
+    c: f64,
+}
 
 #[repr(C)]
 #[derive(Copy, Clone)]
-pub struct CharCharFloat { a: u8, b: u8, c: f32 }
+pub struct CharCharFloat {
+    a: u8,
+    b: u8,
+    c: f32,
+}
 
 mod rustrt {
-    use super::{Floats, Quad, CharCharDouble, CharCharFloat};
+    use super::{CharCharDouble, CharCharFloat, Floats, Quad};
 
     #[link(name = "rust_test_helpers", kind = "static")]
-    extern {
+    extern "C" {
         pub fn rust_dbg_abi_1(q: Quad) -> Quad;
         pub fn rust_dbg_abi_2(f: Floats) -> Floats;
         pub fn rust_dbg_abi_3(a: CharCharDouble) -> CharCharDouble;
@@ -32,10 +49,12 @@ mod rustrt {
 
 fn test1() {
     unsafe {
-        let q = Quad { a: 0xaaaa_aaaa_aaaa_aaaa,
-                 b: 0xbbbb_bbbb_bbbb_bbbb,
-                 c: 0xcccc_cccc_cccc_cccc,
-                 d: 0xdddd_dddd_dddd_dddd };
+        let q = Quad {
+            a: 0xaaaa_aaaa_aaaa_aaaa,
+            b: 0xbbbb_bbbb_bbbb_bbbb,
+            c: 0xcccc_cccc_cccc_cccc,
+            d: 0xdddd_dddd_dddd_dddd,
+        };
         let qq = rustrt::rust_dbg_abi_1(q);
         println!("a: {:x}", qq.a as usize);
         println!("b: {:x}", qq.b as usize);
@@ -51,9 +70,7 @@ fn test1() {
 #[cfg(target_pointer_width = "64")]
 fn test2() {
     unsafe {
-        let f = Floats { a: 1.234567890e-15_f64,
-                 b: 0b_1010_1010,
-                 c: 1.0987654321e-15_f64 };
+        let f = Floats { a: 1.234567890e-15_f64, b: 0b_1010_1010, c: 1.0987654321e-15_f64 };
         let ff = rustrt::rust_dbg_abi_2(f);
         println!("a: {}", ff.a as f64);
         println!("b: {}", ff.b as usize);
@@ -65,17 +82,12 @@ fn test2() {
 }
 
 #[cfg(target_pointer_width = "32")]
-fn test2() {
-}
+fn test2() {}
 
 #[cfg(target_pointer_width = "64")]
 fn test3() {
     unsafe {
-        let a = CharCharDouble {
-            a: 1,
-            b: 2,
-            c: 3.,
-        };
+        let a = CharCharDouble { a: 1, b: 2, c: 3. };
         let b = rustrt::rust_dbg_abi_3(a);
         println!("a: {}", b.a);
         println!("b: {}", b.b);
@@ -91,11 +103,7 @@ fn test3() {}
 
 fn test4() {
     unsafe {
-        let a = CharCharFloat {
-            a: 1,
-            b: 2,
-            c: 3.,
-        };
+        let a = CharCharFloat { a: 1, b: 2, c: 3. };
         let b = rustrt::rust_dbg_abi_4(a);
         println!("a: {}", b.a);
         println!("b: {}", b.b);

--- a/src/test/ui/abi/variadic-ffi.rs
+++ b/src/test/ui/abi/variadic-ffi.rs
@@ -5,7 +5,7 @@
 use std::ffi::VaList;
 
 #[link(name = "rust_test_helpers", kind = "static")]
-extern {
+extern "C" {
     fn rust_interesting_average(_: u64, ...) -> f64;
 
     // FIXME: we need to disable this lint for `VaList`,
@@ -61,7 +61,7 @@ pub fn main() {
     }
 
     // A function that takes a function pointer
-    unsafe fn call(fp: unsafe extern fn(u64, ...) -> f64) {
+    unsafe fn call(fp: unsafe extern "C" fn(u64, ...) -> f64) {
         let (x1, x2, x3, x4) = (10i64, 10.0f64, 20i64, 20.0f64);
         assert_eq!(fp(2, x1, x2, x3, x4) as i64, 30);
     }
@@ -70,7 +70,7 @@ pub fn main() {
         call(rust_interesting_average);
 
         // Make a function pointer, pass indirectly
-        let x: unsafe extern fn(u64, ...) -> f64 = rust_interesting_average;
+        let x: unsafe extern "C" fn(u64, ...) -> f64 = rust_interesting_average;
         call(x);
     }
 

--- a/src/test/ui/attributes/item-attributes.rs
+++ b/src/test/ui/attributes/item-attributes.rs
@@ -5,7 +5,6 @@
 // check-pass
 
 #![feature(rustc_attrs)]
-
 #![rustc_dummy = "val"]
 #![rustc_dummy = "val"]
 #![rustc_dummy]
@@ -21,14 +20,14 @@ mod test_single_attr_outer {
     pub static X: isize = 10;
 
     #[rustc_dummy = "val"]
-    pub fn f() { }
+    pub fn f() {}
 
     #[rustc_dummy = "val"]
     pub mod mod1 {}
 
     pub mod rustrt {
         #[rustc_dummy = "val"]
-        extern {}
+        extern "C" {}
     }
 }
 
@@ -39,7 +38,7 @@ mod test_multi_attr_outer {
 
     #[rustc_dummy = "val"]
     #[rustc_dummy = "val"]
-    pub fn f() { }
+    pub fn f() {}
 
     #[rustc_dummy = "val"]
     #[rustc_dummy = "val"]
@@ -48,12 +47,14 @@ mod test_multi_attr_outer {
     pub mod rustrt {
         #[rustc_dummy = "val"]
         #[rustc_dummy = "val"]
-        extern {}
+        extern "C" {}
     }
 
     #[rustc_dummy = "val"]
     #[rustc_dummy = "val"]
-    struct T {x: isize}
+    struct T {
+        x: isize,
+    }
 }
 
 mod test_stmt_single_attr_outer {
@@ -62,41 +63,36 @@ mod test_stmt_single_attr_outer {
         static X: isize = 10;
 
         #[rustc_dummy = "val"]
-        fn f() { }
+        fn f() {}
 
         #[rustc_dummy = "val"]
-        mod mod1 {
-        }
+        mod mod1 {}
 
         mod rustrt {
             #[rustc_dummy = "val"]
-            extern {
-            }
+            extern "C" {}
         }
     }
 }
 
 mod test_stmt_multi_attr_outer {
     pub fn f() {
-
         #[rustc_dummy = "val"]
         #[rustc_dummy = "val"]
         static X: isize = 10;
 
         #[rustc_dummy = "val"]
         #[rustc_dummy = "val"]
-        fn f() { }
+        fn f() {}
 
         #[rustc_dummy = "val"]
         #[rustc_dummy = "val"]
-        mod mod1 {
-        }
+        mod mod1 {}
 
         mod rustrt {
             #[rustc_dummy = "val"]
             #[rustc_dummy = "val"]
-            extern {
-            }
+            extern "C" {}
         }
     }
 }
@@ -114,7 +110,7 @@ mod test_attr_inner_then_outer {
         #![rustc_dummy = "val"]
         // This is an attribute of fn f
         #[rustc_dummy = "val"]
-        fn f() { }
+        fn f() {}
     }
 }
 
@@ -126,7 +122,7 @@ mod test_attr_inner_then_outer_multi {
         // This is an attribute of fn f
         #[rustc_dummy = "val"]
         #[rustc_dummy = "val"]
-        fn f() { }
+        fn f() {}
     }
 }
 
@@ -134,7 +130,7 @@ mod test_distinguish_syntax_ext {
     pub fn f() {
         format!("test{}", "s");
         #[rustc_dummy = "val"]
-        fn g() { }
+        fn g() {}
     }
 }
 
@@ -143,12 +139,12 @@ mod test_other_forms {
     #[rustc_dummy(word)]
     #[rustc_dummy(attr(word))]
     #[rustc_dummy(key1 = "val", key2 = "val", attr)]
-    pub fn f() { }
+    pub fn f() {}
 }
 
 mod test_foreign_items {
     pub mod rustrt {
-        extern {
+        extern "C" {
             #![rustc_dummy]
 
             #[rustc_dummy]
@@ -156,7 +152,6 @@ mod test_foreign_items {
         }
     }
 }
-
 
 // FIXME(#623): - these aren't supported yet
 /*mod test_literals {

--- a/src/test/ui/attributes/obsolete-attr.rs
+++ b/src/test/ui/attributes/obsolete-attr.rs
@@ -1,6 +1,6 @@
 // Obsolete attributes fall back to unstable custom attributes.
 
-#[ab_isize="stdcall"] extern {}
+#[ab_isize = "stdcall"] extern "C" {}
 //~^ ERROR cannot find attribute `ab_isize` in this scope
 
 #[fixed_stack_segment] fn f() {}

--- a/src/test/ui/attributes/obsolete-attr.stderr
+++ b/src/test/ui/attributes/obsolete-attr.stderr
@@ -7,7 +7,7 @@ LL | #[fixed_stack_segment] fn f() {}
 error: cannot find attribute `ab_isize` in this scope
   --> $DIR/obsolete-attr.rs:3:3
    |
-LL | #[ab_isize="stdcall"] extern {}
+LL | #[ab_isize = "stdcall"] extern "C" {}
    |   ^^^^^^^^
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/auxiliary/extern-statics.rs
+++ b/src/test/ui/auxiliary/extern-statics.rs
@@ -1,4 +1,4 @@
-extern {
+extern "C" {
     pub static XA: u8;
     pub static mut XB: u8;
 }

--- a/src/test/ui/auxiliary/link-cfg-works-transitive-dylib.rs
+++ b/src/test/ui/auxiliary/link-cfg-works-transitive-dylib.rs
@@ -1,4 +1,4 @@
 #![feature(link_cfg)]
 
 #[link(name = "foo", cfg(foo))]
-extern {}
+extern "C" {}

--- a/src/test/ui/auxiliary/link-cfg-works-transitive-rlib.rs
+++ b/src/test/ui/auxiliary/link-cfg-works-transitive-rlib.rs
@@ -4,4 +4,4 @@
 #![crate_type = "rlib"]
 
 #[link(name = "foo", cfg(foo))]
-extern {}
+extern "C" {}

--- a/src/test/ui/auxiliary/lto-duplicate-symbols1.rs
+++ b/src/test/ui/auxiliary/lto-duplicate-symbols1.rs
@@ -3,4 +3,4 @@
 #![crate_type = "rlib"]
 
 #[no_mangle]
-pub extern fn foo() {}
+pub extern "C" fn foo() {}

--- a/src/test/ui/auxiliary/lto-duplicate-symbols2.rs
+++ b/src/test/ui/auxiliary/lto-duplicate-symbols2.rs
@@ -3,4 +3,4 @@
 #![crate_type = "rlib"]
 
 #[no_mangle]
-pub extern fn foo() {}
+pub extern "C" fn foo() {}

--- a/src/test/ui/bad/bad-extern-link-attrs.rs
+++ b/src/test/ui/bad/bad-extern-link-attrs.rs
@@ -2,6 +2,6 @@
 #[link(name = "")] //~ ERROR: with empty name
 #[link(name = "foo")]
 #[link(name = "foo", kind = "bar")] //~ ERROR: unknown kind
-extern {}
+extern "C" {}
 
 fn main() {}

--- a/src/test/ui/c-stack-returning-int64.rs
+++ b/src/test/ui/c-stack-returning-int64.rs
@@ -11,7 +11,7 @@ use std::ffi::CString;
 mod mlibc {
     use libc::{c_char, c_long, c_longlong};
 
-    extern {
+    extern "C" {
         pub fn atol(x: *const c_char) -> c_long;
         pub fn atoll(x: *const c_char) -> c_longlong;
     }
@@ -29,6 +29,8 @@ fn atoll(s: String) -> i64 {
 
 pub fn main() {
     assert_eq!(atol("1024".to_string()) * 10, atol("10240".to_string()));
-    assert_eq!((atoll("11111111111111111".to_string()) * 10),
-             atoll("111111111111111110".to_string()));
+    assert_eq!(
+        (atoll("11111111111111111".to_string()) * 10),
+        atoll("111111111111111110".to_string())
+    );
 }

--- a/src/test/ui/c-variadic/variadic-ffi-1.rs
+++ b/src/test/ui/c-variadic/variadic-ffi-1.rs
@@ -6,7 +6,7 @@ extern "stdcall" {
     fn printf(_: *const u8, ...); //~ ERROR: variadic function must have C or cdecl calling
 }
 
-extern {
+extern "C" {
     fn foo(f: isize, x: u8, ...);
 }
 
@@ -14,7 +14,7 @@ extern "C" fn bar(f: isize, x: u8) {}
 
 fn main() {
     unsafe {
-        foo();  //~ ERROR this function takes at least 2 arguments but 0 arguments were supplied
+        foo(); //~ ERROR this function takes at least 2 arguments but 0 arguments were supplied
         foo(1); //~ ERROR this function takes at least 2 arguments but 1 argument was supplied
 
         let x: unsafe extern "C" fn(f: isize, x: u8) = foo; //~ ERROR mismatched types
@@ -22,8 +22,8 @@ fn main() {
 
         foo(1, 2, 3f32); //~ ERROR can't pass
         foo(1, 2, true); //~ ERROR can't pass
-        foo(1, 2, 1i8);  //~ ERROR can't pass
-        foo(1, 2, 1u8);  //~ ERROR can't pass
+        foo(1, 2, 1i8); //~ ERROR can't pass
+        foo(1, 2, 1u8); //~ ERROR can't pass
         foo(1, 2, 1i16); //~ ERROR can't pass
         foo(1, 2, 1u16); //~ ERROR can't pass
     }

--- a/src/test/ui/c-variadic/variadic-ffi-no-fixed-args.rs
+++ b/src/test/ui/c-variadic/variadic-ffi-no-fixed-args.rs
@@ -1,6 +1,6 @@
-extern {
+extern "C" {
     fn foo(...);
-    //~^ ERROR C-variadic function must be declared with at least one named argument
+//~^ ERROR C-variadic function must be declared with at least one named argument
 }
 
 fn main() {}

--- a/src/test/ui/cfg/conditional-compile.rs
+++ b/src/test/ui/cfg/conditional-compile.rs
@@ -16,13 +16,13 @@ static b: bool = true;
 
 mod rustrt {
     #[cfg(bogus)]
-    extern {
+    extern "C" {
         // This symbol doesn't exist and would be a link error if this
         // module was codegened
         pub fn bogus();
     }
 
-    extern {}
+    extern "C" {}
 }
 
 #[cfg(bogus)]
@@ -31,52 +31,56 @@ type t = isize;
 type t = bool;
 
 #[cfg(bogus)]
-enum tg { foo, }
+enum tg {
+    foo,
+}
 
-enum tg { bar, }
-
-#[cfg(bogus)]
-struct r {
-  i: isize,
+enum tg {
+    bar,
 }
 
 #[cfg(bogus)]
-fn r(i:isize) -> r {
-    r {
-        i: i
-    }
+struct r {
+    i: isize,
+}
+
+#[cfg(bogus)]
+fn r(i: isize) -> r {
+    r { i: i }
 }
 
 struct r {
-  i: isize,
+    i: isize,
 }
 
-fn r(i:isize) -> r {
-    r {
-        i: i
-    }
+fn r(i: isize) -> r {
+    r { i: i }
 }
 
 #[cfg(bogus)]
 mod m {
     // This needs to parse but would fail in typeck. Since it's not in
     // the current config it should not be typechecked.
-    pub fn bogus() { return 0; }
+    pub fn bogus() {
+        return 0;
+    }
 }
 
 mod m {
     // Submodules have slightly different code paths than the top-level
     // module, so let's make sure this jazz works here as well
     #[cfg(bogus)]
-    pub fn f() { }
+    pub fn f() {}
 
-    pub fn f() { }
+    pub fn f() {}
 }
 
 // Since the bogus configuration isn't defined main will just be
 // parsed, but nothing further will be done with it
 #[cfg(bogus)]
-pub fn main() { panic!() }
+pub fn main() {
+    panic!()
+}
 
 pub fn main() {
     // Exercise some of the configured items in ways that wouldn't be possible
@@ -90,8 +94,10 @@ pub fn main() {
 
 fn test_in_fn_ctxt() {
     #[cfg(bogus)]
-    fn f() { panic!() }
-    fn f() { }
+    fn f() {
+        panic!()
+    }
+    fn f() {}
     f();
 
     #[cfg(bogus)]
@@ -102,7 +108,7 @@ fn test_in_fn_ctxt() {
 
 mod test_foreign_items {
     pub mod rustrt {
-        extern {
+        extern "C" {
             #[cfg(bogus)]
             pub fn write() -> String;
             pub fn write() -> String;
@@ -117,19 +123,19 @@ mod test_use_statements {
 
 mod test_methods {
     struct Foo {
-        bar: usize
+        bar: usize,
     }
 
     impl Fooable for Foo {
         #[cfg(bogus)]
-        fn what(&self) { }
+        fn what(&self) {}
 
-        fn what(&self) { }
+        fn what(&self) {}
 
         #[cfg(bogus)]
-        fn the(&self) { }
+        fn the(&self) {}
 
-        fn the(&self) { }
+        fn the(&self) {}
     }
 
     trait Fooable {

--- a/src/test/ui/check-doc-alias-attr-location.rs
+++ b/src/test/ui/check-doc-alias-attr-location.rs
@@ -7,7 +7,7 @@ pub trait Foo {
 }
 
 #[doc(alias = "foo")] //~ ERROR
-extern {}
+extern "C" {}
 
 #[doc(alias = "bar")] //~ ERROR
 impl Bar {
@@ -19,5 +19,7 @@ impl Bar {
 impl Foo for Bar {
     #[doc(alias = "assoc")] //~ ERROR
     type X = i32;
-    fn foo() -> Self::X { 0 }
+    fn foo() -> Self::X {
+        0
+    }
 }

--- a/src/test/ui/consts/auxiliary/cci_const.rs
+++ b/src/test/ui/consts/auxiliary/cci_const.rs
@@ -1,4 +1,4 @@
-pub extern fn bar() {
+pub extern "C" fn bar() {
 }
 
 pub const foopy: &'static str = "hi there";

--- a/src/test/ui/consts/auxiliary/issue-63226.rs
+++ b/src/test/ui/consts/auxiliary/issue-63226.rs
@@ -1,5 +1,5 @@
 pub struct VTable{
-    state:extern fn(),
+    state:extern "C" fn(),
 }
 
 impl VTable{
@@ -11,4 +11,4 @@ impl VTable{
         &VTable{state};
 }
 
-extern fn state() {}
+extern "C" fn state() {}

--- a/src/test/ui/consts/const-cast.rs
+++ b/src/test/ui/consts/const-cast.rs
@@ -7,7 +7,7 @@ struct TestStruct {
 
 unsafe impl Sync for TestStruct {}
 
-extern fn foo() {}
+extern "C" fn foo() {}
 const x: extern "C" fn() = foo;
 static y: TestStruct = TestStruct { x: x as *const u8 };
 

--- a/src/test/ui/consts/const-eval/extern_fat_pointer.rs
+++ b/src/test/ui/consts/const-eval/extern_fat_pointer.rs
@@ -2,7 +2,7 @@
 
 #![feature(extern_types)]
 
-extern {
+extern "C" {
     type Opaque;
 }
 

--- a/src/test/ui/consts/const-extern-fn/const-extern-fn-call-extern-fn.rs
+++ b/src/test/ui/consts/const-extern-fn/const-extern-fn-call-extern-fn.rs
@@ -4,16 +4,16 @@ extern "C" {
     fn regular_in_block();
 }
 
-const extern fn bar() {
+const extern "C" fn bar() {
     unsafe {
         regular_in_block();
         //~^ ERROR: calls in constant functions
     }
 }
 
-extern fn regular() {}
+extern "C" fn regular() {}
 
-const extern fn foo() {
+const extern "C" fn foo() {
     unsafe {
         regular();
         //~^ ERROR: calls in constant functions

--- a/src/test/ui/consts/const-extern-fn/const-extern-fn-min-const-fn.rs
+++ b/src/test/ui/consts/const-extern-fn/const-extern-fn-min-const-fn.rs
@@ -1,10 +1,10 @@
 #![feature(const_extern_fn)]
 
-const extern fn unsize(x: &[u8; 3]) -> &[u8] { x }
+const extern "C" fn unsize(x: &[u8; 3]) -> &[u8] { x }
 const unsafe extern "C" fn closure() -> fn() { || {} }
 //~^ ERROR function pointer
 //~| ERROR function pointer cast
-const unsafe extern fn use_float() { 1.0 + 1.0; }
+const unsafe extern "C" fn use_float() { 1.0 + 1.0; }
 //~^ ERROR floating point arithmetic
 const extern "C" fn ptr_cast(val: *const u8) { val as usize; }
 //~^ ERROR casting pointers to integers

--- a/src/test/ui/consts/const-extern-fn/const-extern-fn-min-const-fn.stderr
+++ b/src/test/ui/consts/const-extern-fn/const-extern-fn-min-const-fn.stderr
@@ -17,10 +17,10 @@ LL | const unsafe extern "C" fn closure() -> fn() { || {} }
    = help: add `#![feature(const_fn_fn_ptr_basics)]` to the crate attributes to enable
 
 error[E0658]: floating point arithmetic is not allowed in constant functions
-  --> $DIR/const-extern-fn-min-const-fn.rs:7:38
+  --> $DIR/const-extern-fn-min-const-fn.rs:7:42
    |
-LL | const unsafe extern fn use_float() { 1.0 + 1.0; }
-   |                                      ^^^^^^^^^
+LL | const unsafe extern "C" fn use_float() { 1.0 + 1.0; }
+   |                                          ^^^^^^^^^
    |
    = note: see issue #57241 <https://github.com/rust-lang/rust/issues/57241> for more information
    = help: add `#![feature(const_fn_floating_point_arithmetic)]` to the crate attributes to enable

--- a/src/test/ui/consts/const-extern-fn/const-extern-fn-requires-unsafe.rs
+++ b/src/test/ui/consts/const-extern-fn/const-extern-fn-requires-unsafe.rs
@@ -1,6 +1,6 @@
 #![feature(const_extern_fn)]
 
-const unsafe extern fn foo() -> usize { 5 }
+const unsafe extern "C" fn foo() -> usize { 5 }
 
 fn main() {
     let a: [u8; foo()];

--- a/src/test/ui/consts/const-extern-fn/const-extern-fn.rs
+++ b/src/test/ui/consts/const-extern-fn/const-extern-fn.rs
@@ -1,7 +1,7 @@
 // run-pass
 #![feature(const_extern_fn)]
 
-const extern fn foo1(val: u8) -> u8 {
+const extern "C" fn foo1(val: u8) -> u8 {
     val + 1
 }
 
@@ -9,7 +9,7 @@ const extern "C" fn foo2(val: u8) -> u8 {
     val + 1
 }
 
-const unsafe extern fn bar1(val: bool) -> bool {
+const unsafe extern "C" fn bar1(val: bool) -> bool {
     !val
 }
 
@@ -28,8 +28,8 @@ fn main() {
     assert!(bar1_res);
     assert_eq!(bar1_res, bar2_res);
 
-    let _foo1_cast: extern fn(u8) -> u8 = foo1;
-    let _foo2_cast: extern fn(u8) -> u8 = foo2;
-    let _bar1_cast: unsafe extern fn(bool) -> bool = bar1;
-    let _bar2_cast: unsafe extern fn(bool) -> bool = bar2;
+    let _foo1_cast: extern "C" fn(u8) -> u8 = foo1;
+    let _foo2_cast: extern "C" fn(u8) -> u8 = foo2;
+    let _bar1_cast: unsafe extern "C" fn(bool) -> bool = bar1;
+    let _bar2_cast: unsafe extern "C" fn(bool) -> bool = bar2;
 }

--- a/src/test/ui/consts/const-extern-function.rs
+++ b/src/test/ui/consts/const-extern-function.rs
@@ -1,7 +1,7 @@
 // run-pass
 #![allow(non_upper_case_globals)]
 
-extern fn foopy() {}
+extern "C" fn foopy() {}
 
 static f: extern "C" fn() = foopy;
 static s: S = S { f: foopy };

--- a/src/test/ui/consts/const-size_of_val-align_of_val-extern-type.rs
+++ b/src/test/ui/consts/const-size_of_val-align_of_val-extern-type.rs
@@ -2,9 +2,9 @@
 #![feature(core_intrinsics)]
 #![feature(const_size_of_val, const_align_of_val)]
 
-use std::intrinsics::{size_of_val, min_align_of_val};
+use std::intrinsics::{min_align_of_val, size_of_val};
 
-extern {
+extern "C" {
     type Opaque;
 }
 

--- a/src/test/ui/cross-crate/auxiliary/cci_const.rs
+++ b/src/test/ui/cross-crate/auxiliary/cci_const.rs
@@ -1,4 +1,4 @@
-pub extern fn bar() {
+pub extern "C" fn bar() {
 }
 
 pub const foopy: &'static str = "hi there";

--- a/src/test/ui/duplicate/dupe-symbols-2.rs
+++ b/src/test/ui/duplicate/dupe-symbols-2.rs
@@ -6,13 +6,13 @@
 
 pub mod a {
     #[no_mangle]
-    pub extern fn fail() {
+    pub extern "C" fn fail() {
     }
 }
 
 pub mod b {
     #[no_mangle]
-    pub extern fn fail() {
+    pub extern "C" fn fail() {
     //~^ symbol `fail` is already defined
     }
 }

--- a/src/test/ui/duplicate/dupe-symbols-2.stderr
+++ b/src/test/ui/duplicate/dupe-symbols-2.stderr
@@ -1,8 +1,8 @@
 error: symbol `fail` is already defined
   --> $DIR/dupe-symbols-2.rs:15:5
    |
-LL |     pub extern fn fail() {
-   |     ^^^^^^^^^^^^^^^^^^^^
+LL |     pub extern "C" fn fail() {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/empty/empty-linkname.rs
+++ b/src/test/ui/empty/empty-linkname.rs
@@ -1,5 +1,4 @@
 #[link(name = "")] //~ ERROR: given with empty name
-extern {
-}
+extern "C" {}
 
 fn main() {}

--- a/src/test/ui/error-codes/E0044.rs
+++ b/src/test/ui/error-codes/E0044.rs
@@ -1,9 +1,8 @@
-extern {
+extern "C" {
     fn sqrt<T>(f: T) -> T;
-    //~^ ERROR foreign items may not have type parameters [E0044]
-    //~| HELP replace the type parameters with concrete types
-    //~| NOTE can't have type parameters
+//~^ ERROR foreign items may not have type parameters [E0044]
+//~| HELP replace the type parameters with concrete types
+//~| NOTE can't have type parameters
 }
 
-fn main() {
-}
+fn main() {}

--- a/src/test/ui/error-codes/E0130.rs
+++ b/src/test/ui/error-codes/E0130.rs
@@ -1,7 +1,6 @@
-extern {
+extern "C" {
     fn foo((a, b): (u32, u32));
-    //~^ ERROR E0130
+//~^ ERROR E0130
 }
 
-fn main() {
-}
+fn main() {}

--- a/src/test/ui/error-codes/E0454.rs
+++ b/src/test/ui/error-codes/E0454.rs
@@ -1,4 +1,4 @@
-#[link(name = "")] extern {}
+#[link(name = "")] extern "C" {}
 //~^ ERROR E0454
 
 fn main() {

--- a/src/test/ui/error-codes/E0454.stderr
+++ b/src/test/ui/error-codes/E0454.stderr
@@ -1,7 +1,7 @@
 error[E0454]: `#[link(name = "")]` given with empty name
   --> $DIR/E0454.rs:1:1
    |
-LL | #[link(name = "")] extern {}
+LL | #[link(name = "")] extern "C" {}
    | ^^^^^^^^^^^^^^^^^^ empty name given
 
 error: aborting due to previous error

--- a/src/test/ui/error-codes/E0458.rs
+++ b/src/test/ui/error-codes/E0458.rs
@@ -1,5 +1,5 @@
-#[link(kind = "wonderful_unicorn")] extern {} //~ ERROR E0458
-                                              //~| ERROR E0459
+#[link(kind = "wonderful_unicorn")] extern "C" {} //~ ERROR E0458
+                                                  //~| ERROR E0459
 
 fn main() {
 }

--- a/src/test/ui/error-codes/E0458.stderr
+++ b/src/test/ui/error-codes/E0458.stderr
@@ -1,7 +1,7 @@
 error[E0458]: unknown kind: `wonderful_unicorn`
   --> $DIR/E0458.rs:1:8
    |
-LL | #[link(kind = "wonderful_unicorn")] extern {}
+LL | #[link(kind = "wonderful_unicorn")] extern "C" {}
    | -------^^^^^^^^^^^^^^^^^^^^^^^^^^--
    |        |
    |        unknown kind
@@ -9,7 +9,7 @@ LL | #[link(kind = "wonderful_unicorn")] extern {}
 error[E0459]: `#[link(...)]` specified without `name = "foo"`
   --> $DIR/E0458.rs:1:1
    |
-LL | #[link(kind = "wonderful_unicorn")] extern {}
+LL | #[link(kind = "wonderful_unicorn")] extern "C" {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `name` argument
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/error-codes/E0459.rs
+++ b/src/test/ui/error-codes/E0459.rs
@@ -1,4 +1,4 @@
-#[link(kind = "dylib")] extern {} //~ ERROR E0459
+#[link(kind = "dylib")] extern "C" {} //~ ERROR E0459
 
 fn main() {
 }

--- a/src/test/ui/error-codes/E0459.stderr
+++ b/src/test/ui/error-codes/E0459.stderr
@@ -1,7 +1,7 @@
 error[E0459]: `#[link(...)]` specified without `name = "foo"`
   --> $DIR/E0459.rs:1:1
    |
-LL | #[link(kind = "dylib")] extern {}
+LL | #[link(kind = "dylib")] extern "C" {}
    | ^^^^^^^^^^^^^^^^^^^^^^^ missing `name` argument
 
 error: aborting due to previous error

--- a/src/test/ui/error-codes/E0617.rs
+++ b/src/test/ui/error-codes/E0617.rs
@@ -1,4 +1,4 @@
-extern {
+extern "C" {
     fn printf(c: *const i8, ...);
 }
 

--- a/src/test/ui/extern/auxiliary/extern-take-value.rs
+++ b/src/test/ui/extern/auxiliary/extern-take-value.rs
@@ -1,5 +1,5 @@
-pub extern fn f() -> i32 { 1 }
-pub extern fn g() -> i32 { 2 }
+pub extern "C" fn f() -> i32 { 1 }
+pub extern "C" fn g() -> i32 { 2 }
 
-pub fn get_f() -> extern fn() -> i32 { f }
-pub fn get_g() -> extern fn() -> i32 { g }
+pub fn get_f() -> extern "C" fn() -> i32 { f }
+pub fn get_g() -> extern "C" fn() -> i32 { g }

--- a/src/test/ui/extern/auxiliary/extern_calling_convention.rs
+++ b/src/test/ui/extern/auxiliary/extern_calling_convention.rs
@@ -15,7 +15,7 @@ pub extern "win64" fn foo(a: isize, b: isize, c: isize, d: isize) {
 
 #[inline(never)]
 #[cfg(not(target_arch = "x86_64"))]
-pub extern fn foo(a: isize, b: isize, c: isize, d: isize) {
+pub extern "C" fn foo(a: isize, b: isize, c: isize, d: isize) {
     assert_eq!(a, 1);
     assert_eq!(b, 2);
     assert_eq!(c, 3);

--- a/src/test/ui/extern/extern-1.rs
+++ b/src/test/ui/extern/extern-1.rs
@@ -2,7 +2,7 @@
 #![allow(dead_code)]
 // pretty-expanded FIXME #23616
 
-extern fn f() {
+extern "C" fn f() {
 }
 
 pub fn main() {

--- a/src/test/ui/extern/extern-compare-with-return-type.rs
+++ b/src/test/ui/extern/extern-compare-with-return-type.rs
@@ -3,23 +3,23 @@
 #![allow(non_camel_case_types)]
 
 // `dbg!()` differentiates these functions to ensure they won't be merged.
-extern fn voidret1() { dbg!() }
-extern fn voidret2() { dbg!() }
+extern "C" fn voidret1() { dbg!() }
+extern "C" fn voidret2() { dbg!() }
 
-extern fn uintret() -> usize { 22 }
+extern "C" fn uintret() -> usize { 22 }
 
-extern fn uintvoidret(_x: usize) {}
+extern "C" fn uintvoidret(_x: usize) {}
 
-extern fn uintuintuintuintret(x: usize, y: usize, z: usize) -> usize { x+y+z }
-type uintuintuintuintret = extern fn(usize,usize,usize) -> usize;
+extern "C" fn uintuintuintuintret(x: usize, y: usize, z: usize) -> usize { x+y+z }
+type uintuintuintuintret = extern "C" fn(usize,usize,usize) -> usize;
 
 pub fn main() {
-    assert!(voidret1 as extern fn() == voidret1 as extern fn());
-    assert!(voidret1 as extern fn() != voidret2 as extern fn());
+    assert!(voidret1 as extern "C" fn() == voidret1 as extern "C" fn());
+    assert!(voidret1 as extern "C" fn() != voidret2 as extern "C" fn());
 
-    assert!(uintret as extern fn() -> usize == uintret as extern fn() -> usize);
+    assert!(uintret as extern "C" fn() -> usize == uintret as extern "C" fn() -> usize);
 
-    assert!(uintvoidret as extern fn(usize) == uintvoidret as extern fn(usize));
+    assert!(uintvoidret as extern "C" fn(usize) == uintvoidret as extern "C" fn(usize));
 
     assert!(uintuintuintuintret as uintuintuintuintret ==
             uintuintuintuintret as uintuintuintuintret);

--- a/src/test/ui/extern/extern-main-fn.rs
+++ b/src/test/ui/extern/extern-main-fn.rs
@@ -1,1 +1,1 @@
-extern fn main() {} //~ ERROR: `main` function has wrong type [E0580]
+extern "C" fn main() {} //~ ERROR: `main` function has wrong type [E0580]

--- a/src/test/ui/extern/extern-main-fn.stderr
+++ b/src/test/ui/extern/extern-main-fn.stderr
@@ -1,8 +1,8 @@
 error[E0580]: `main` function has wrong type
   --> $DIR/extern-main-fn.rs:1:1
    |
-LL | extern fn main() {}
-   | ^^^^^^^^^^^^^^^^ expected "Rust" fn, found "C" fn
+LL | extern "C" fn main() {}
+   | ^^^^^^^^^^^^^^^^^^^^ expected "Rust" fn, found "C" fn
    |
    = note: expected fn pointer `fn()`
               found fn pointer `extern "C" fn()`

--- a/src/test/ui/extern/extern-methods.rs
+++ b/src/test/ui/extern/extern-methods.rs
@@ -5,7 +5,7 @@
 
 trait A {
     extern "fastcall" fn test1(i: i32);
-    extern fn test2(i: i32);
+    extern "C" fn test2(i: i32);
 }
 
 struct S;
@@ -19,7 +19,7 @@ impl A for S {
     extern "fastcall" fn test1(i: i32) {
         assert_eq!(i, 1);
     }
-    extern fn test2(i: i32) {
+    extern "C" fn test2(i: i32) {
         assert_eq!(i, 2);
     }
 }

--- a/src/test/ui/extern/extern-pub.rs
+++ b/src/test/ui/extern/extern-pub.rs
@@ -1,9 +1,8 @@
 // run-pass
 // pretty-expanded FIXME #23616
 
-extern {
+extern "C" {
     pub fn free(p: *const u8);
 }
 
-pub fn main() {
-}
+pub fn main() {}

--- a/src/test/ui/extern/extern-rust.rs
+++ b/src/test/ui/extern/extern-rust.rs
@@ -5,7 +5,7 @@
 pub struct Foo(u32);
 
 // ICE trigger, bad handling of differing types between rust and external ABIs
-pub extern fn bar() -> Foo {
+pub extern "C" fn bar() -> Foo {
     Foo(0)
 }
 

--- a/src/test/ui/extern/extern-types-distinct-types.rs
+++ b/src/test/ui/extern/extern-types-distinct-types.rs
@@ -1,6 +1,6 @@
 #![feature(extern_types)]
 
-extern {
+extern "C" {
     type A;
     type B;
 }
@@ -9,4 +9,4 @@ fn foo(r: &A) -> &B {
     r //~ ERROR mismatched types
 }
 
-fn main() { }
+fn main() {}

--- a/src/test/ui/extern/extern-types-manual-sync-send.rs
+++ b/src/test/ui/extern/extern-types-manual-sync-send.rs
@@ -3,15 +3,15 @@
 
 #![feature(extern_types)]
 
-extern {
+extern "C" {
     type A;
 }
 
-unsafe impl Sync for A { }
-unsafe impl Send for A { }
+unsafe impl Sync for A {}
+unsafe impl Send for A {}
 
-fn assert_sync<T: ?Sized + Sync>() { }
-fn assert_send<T: ?Sized + Send>() { }
+fn assert_sync<T: ?Sized + Sync>() {}
+fn assert_send<T: ?Sized + Send>() {}
 
 fn main() {
     assert_sync::<A>();

--- a/src/test/ui/extern/extern-types-not-sync-send.rs
+++ b/src/test/ui/extern/extern-types-not-sync-send.rs
@@ -2,12 +2,12 @@
 
 #![feature(extern_types)]
 
-extern {
+extern "C" {
     type A;
 }
 
-fn assert_sync<T: ?Sized + Sync>() { }
-fn assert_send<T: ?Sized + Send>() { }
+fn assert_sync<T: ?Sized + Sync>() {}
+fn assert_send<T: ?Sized + Send>() {}
 
 fn main() {
     assert_sync::<A>();

--- a/src/test/ui/extern/extern-types-not-sync-send.stderr
+++ b/src/test/ui/extern/extern-types-not-sync-send.stderr
@@ -1,7 +1,7 @@
 error[E0277]: `A` cannot be shared between threads safely
   --> $DIR/extern-types-not-sync-send.rs:13:19
    |
-LL | fn assert_sync<T: ?Sized + Sync>() { }
+LL | fn assert_sync<T: ?Sized + Sync>() {}
    |                            ---- required by this bound in `assert_sync`
 ...
 LL |     assert_sync::<A>();
@@ -12,7 +12,7 @@ LL |     assert_sync::<A>();
 error[E0277]: `A` cannot be sent between threads safely
   --> $DIR/extern-types-not-sync-send.rs:16:19
    |
-LL | fn assert_send<T: ?Sized + Send>() { }
+LL | fn assert_send<T: ?Sized + Send>() {}
    |                            ---- required by this bound in `assert_send`
 ...
 LL |     assert_send::<A>();

--- a/src/test/ui/extern/extern-types-pointer-cast.rs
+++ b/src/test/ui/extern/extern-types-pointer-cast.rs
@@ -2,10 +2,9 @@
 #![allow(dead_code)]
 // Test that pointers to extern types can be cast from/to usize,
 // despite being !Sized.
-
 #![feature(extern_types)]
 
-extern {
+extern "C" {
     type A;
 }
 

--- a/src/test/ui/extern/extern-types-size_of_val.rs
+++ b/src/test/ui/extern/extern-types-size_of_val.rs
@@ -1,16 +1,14 @@
 // run-pass
 #![feature(extern_types)]
 
-use std::mem::{size_of_val, align_of_val};
+use std::mem::{align_of_val, size_of_val};
 
-extern {
+extern "C" {
     type A;
 }
 
 fn main() {
-    let x: &A = unsafe {
-        &*(1usize as *const A)
-    };
+    let x: &A = unsafe { &*(1usize as *const A) };
 
     assert_eq!(size_of_val(x), 0);
     assert_eq!(align_of_val(x), 1);

--- a/src/test/ui/extern/extern-types-thin-pointer.rs
+++ b/src/test/ui/extern/extern-types-thin-pointer.rs
@@ -2,12 +2,11 @@
 #![allow(dead_code)]
 // Test that pointers and references to extern types are thin, ie they have the same size and
 // alignment as a pointer to ().
-
 #![feature(extern_types)]
 
 use std::mem::{align_of, size_of};
 
-extern {
+extern "C" {
     type A;
 }
 

--- a/src/test/ui/extern/extern-types-trait-impl.rs
+++ b/src/test/ui/extern/extern-types-trait-impl.rs
@@ -1,22 +1,21 @@
 // run-pass
 #![allow(dead_code)]
 // Test that traits can be implemented for extern types.
-
 #![feature(extern_types)]
 
-extern {
+extern "C" {
     type A;
 }
 
 trait Foo {
-    fn foo(&self) { }
+    fn foo(&self) {}
 }
 
 impl Foo for A {
-    fn foo(&self) { }
+    fn foo(&self) {}
 }
 
-fn assert_foo<T: ?Sized + Foo>() { }
+fn assert_foo<T: ?Sized + Foo>() {}
 
 fn use_foo<T: ?Sized + Foo>(x: &dyn Foo) {
     x.foo();

--- a/src/test/ui/extern/extern-types-unsized.rs
+++ b/src/test/ui/extern/extern-types-unsized.rs
@@ -2,7 +2,7 @@
 
 #![feature(extern_types)]
 
-extern {
+extern "C" {
     type A;
 }
 
@@ -16,7 +16,7 @@ struct Bar<T: ?Sized> {
     tail: T,
 }
 
-fn assert_sized<T>() { }
+fn assert_sized<T>() {}
 
 fn main() {
     assert_sized::<A>();

--- a/src/test/ui/extern/extern-types-unsized.stderr
+++ b/src/test/ui/extern/extern-types-unsized.stderr
@@ -1,7 +1,7 @@
 error[E0277]: the size for values of type `A` cannot be known at compilation time
   --> $DIR/extern-types-unsized.rs:22:20
    |
-LL | fn assert_sized<T>() { }
+LL | fn assert_sized<T>() {}
    |                 - required by this bound in `assert_sized`
 ...
 LL |     assert_sized::<A>();
@@ -10,13 +10,13 @@ LL |     assert_sized::<A>();
    = help: the trait `Sized` is not implemented for `A`
 help: consider relaxing the implicit `Sized` restriction
    |
-LL | fn assert_sized<T: ?Sized>() { }
+LL | fn assert_sized<T: ?Sized>() {}
    |                  ^^^^^^^^
 
 error[E0277]: the size for values of type `A` cannot be known at compilation time
   --> $DIR/extern-types-unsized.rs:25:5
    |
-LL | fn assert_sized<T>() { }
+LL | fn assert_sized<T>() {}
    |                 - required by this bound in `assert_sized`
 ...
 LL |     assert_sized::<Foo>();
@@ -26,13 +26,13 @@ LL |     assert_sized::<Foo>();
    = note: required because it appears within the type `Foo`
 help: consider relaxing the implicit `Sized` restriction
    |
-LL | fn assert_sized<T: ?Sized>() { }
+LL | fn assert_sized<T: ?Sized>() {}
    |                  ^^^^^^^^
 
 error[E0277]: the size for values of type `A` cannot be known at compilation time
   --> $DIR/extern-types-unsized.rs:28:5
    |
-LL | fn assert_sized<T>() { }
+LL | fn assert_sized<T>() {}
    |                 - required by this bound in `assert_sized`
 ...
 LL |     assert_sized::<Bar<A>>();
@@ -42,13 +42,13 @@ LL |     assert_sized::<Bar<A>>();
    = note: required because it appears within the type `Bar<A>`
 help: consider relaxing the implicit `Sized` restriction
    |
-LL | fn assert_sized<T: ?Sized>() { }
+LL | fn assert_sized<T: ?Sized>() {}
    |                  ^^^^^^^^
 
 error[E0277]: the size for values of type `A` cannot be known at compilation time
   --> $DIR/extern-types-unsized.rs:31:5
    |
-LL | fn assert_sized<T>() { }
+LL | fn assert_sized<T>() {}
    |                 - required by this bound in `assert_sized`
 ...
 LL |     assert_sized::<Bar<Bar<A>>>();
@@ -59,7 +59,7 @@ LL |     assert_sized::<Bar<Bar<A>>>();
    = note: required because it appears within the type `Bar<Bar<A>>`
 help: consider relaxing the implicit `Sized` restriction
    |
-LL | fn assert_sized<T: ?Sized>() { }
+LL | fn assert_sized<T: ?Sized>() {}
    |                  ^^^^^^^^
 
 error: aborting due to 4 previous errors

--- a/src/test/ui/extern/extern-wrong-value-type.rs
+++ b/src/test/ui/extern/extern-wrong-value-type.rs
@@ -1,4 +1,4 @@
-extern fn f() {
+extern "C" fn f() {
 }
 
 fn is_fn<F>(_: F) where F: Fn() {}

--- a/src/test/ui/extern/issue-10025.rs
+++ b/src/test/ui/extern/issue-10025.rs
@@ -1,6 +1,6 @@
 // run-pass
-#![allow(dead_code)]
 // pretty-expanded FIXME #23616
+#![allow(dead_code)]
 
 unsafe extern fn foo() {}
 unsafe extern "C" fn bar() {}

--- a/src/test/ui/extern/issue-36122-accessing-externed-dst.rs
+++ b/src/test/ui/extern/issue-36122-accessing-externed-dst.rs
@@ -1,5 +1,5 @@
 fn main() {
-    extern {
+    extern "C" {
         static symbol: [usize]; //~ ERROR: the size for values of type
     }
     println!("{}", symbol[0]);

--- a/src/test/ui/feature-gates/feature-gate-cfg-target-thread-local.rs
+++ b/src/test/ui/feature-gates/feature-gate-cfg-target-thread-local.rs
@@ -5,10 +5,9 @@
 
 extern crate cfg_target_thread_local;
 
-extern {
+extern "C" {
     #[cfg_attr(target_thread_local, thread_local)]
     //~^ `cfg(target_thread_local)` is experimental and subject to change
-
     static FOO: u32;
 }
 

--- a/src/test/ui/feature-gates/feature-gate-extern_types.rs
+++ b/src/test/ui/feature-gates/feature-gate-extern_types.rs
@@ -1,4 +1,4 @@
-extern {
+extern "C" {
     type T; //~ ERROR extern types are experimental
 }
 

--- a/src/test/ui/feature-gates/feature-gate-ffi_const.rs
+++ b/src/test/ui/feature-gates/feature-gate-ffi_const.rs
@@ -1,6 +1,6 @@
 #![crate_type = "lib"]
 
-extern {
+extern "C" {
     #[ffi_const] //~ ERROR the `#[ffi_const]` attribute is an experimental feature
     pub fn foo();
 }

--- a/src/test/ui/feature-gates/feature-gate-ffi_pure.rs
+++ b/src/test/ui/feature-gates/feature-gate-ffi_pure.rs
@@ -1,6 +1,6 @@
 #![crate_type = "lib"]
 
-extern {
+extern "C" {
     #[ffi_pure] //~ ERROR the `#[ffi_pure]` attribute is an experimental feature
     pub fn foo();
 }

--- a/src/test/ui/feature-gates/feature-gate-ffi_returns_twice.rs
+++ b/src/test/ui/feature-gates/feature-gate-ffi_returns_twice.rs
@@ -1,6 +1,6 @@
 #![crate_type = "lib"]
 
-extern {
+extern "C" {
     #[ffi_returns_twice] //~ ERROR the `#[ffi_returns_twice]` attribute is an experimental feature
     pub fn foo();
 }

--- a/src/test/ui/feature-gates/feature-gate-link_args.rs
+++ b/src/test/ui/feature-gates/feature-gate-link_args.rs
@@ -5,13 +5,12 @@
 // sidestep warning (which is correct, but misleading for
 // purposes of this test)
 #![allow(unused_attributes)]
-
 #![link_args = "-l unexpected_use_as_inner_attr_on_mod"]
 //~^ ERROR the `link_args` attribute is experimental
 
 #[link_args = "-l expected_use_case"]
 //~^ ERROR the `link_args` attribute is experimental
-extern {}
+extern "C" {}
 
 #[link_args = "-l unexected_use_on_non_extern_item"]
 //~^ ERROR: the `link_args` attribute is experimental

--- a/src/test/ui/feature-gates/feature-gate-link_args.stderr
+++ b/src/test/ui/feature-gates/feature-gate-link_args.stderr
@@ -1,5 +1,5 @@
 error[E0658]: the `link_args` attribute is experimental and not portable across platforms, it is recommended to use `#[link(name = "foo")] instead
-  --> $DIR/feature-gate-link_args.rs:12:1
+  --> $DIR/feature-gate-link_args.rs:11:1
    |
 LL | #[link_args = "-l expected_use_case"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -8,7 +8,7 @@ LL | #[link_args = "-l expected_use_case"]
    = help: add `#![feature(link_args)]` to the crate attributes to enable
 
 error[E0658]: the `link_args` attribute is experimental and not portable across platforms, it is recommended to use `#[link(name = "foo")] instead
-  --> $DIR/feature-gate-link_args.rs:16:1
+  --> $DIR/feature-gate-link_args.rs:15:1
    |
 LL | #[link_args = "-l unexected_use_on_non_extern_item"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -17,7 +17,7 @@ LL | #[link_args = "-l unexected_use_on_non_extern_item"]
    = help: add `#![feature(link_args)]` to the crate attributes to enable
 
 error[E0658]: the `link_args` attribute is experimental and not portable across platforms, it is recommended to use `#[link(name = "foo")] instead
-  --> $DIR/feature-gate-link_args.rs:9:1
+  --> $DIR/feature-gate-link_args.rs:8:1
    |
 LL | #![link_args = "-l unexpected_use_as_inner_attr_on_mod"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/feature-gates/feature-gate-link_cfg.rs
+++ b/src/test/ui/feature-gates/feature-gate-link_cfg.rs
@@ -1,5 +1,5 @@
 #[link(name = "foo", cfg(foo))]
 //~^ ERROR: is unstable
-extern {}
+extern "C" {}
 
 fn main() {}

--- a/src/test/ui/feature-gates/feature-gate-link_llvm_intrinsics.rs
+++ b/src/test/ui/feature-gates/feature-gate-link_llvm_intrinsics.rs
@@ -1,8 +1,7 @@
-extern {
+extern "C" {
     #[link_name = "llvm.sqrt.f32"]
     fn sqrt(x: f32) -> f32;
-    //~^ ERROR linking to LLVM intrinsics is experimental
+//~^ ERROR linking to LLVM intrinsics is experimental
 }
 
-fn main(){
-}
+fn main() {}

--- a/src/test/ui/feature-gates/feature-gate-linkage.rs
+++ b/src/test/ui/feature-gates/feature-gate-linkage.rs
@@ -1,4 +1,4 @@
-extern {
+extern "C" {
     #[linkage = "extern_weak"] static foo: isize;
     //~^ ERROR: the `linkage` attribute is experimental and not portable
 }

--- a/src/test/ui/feature-gates/feature-gate-non_ascii_idents.rs
+++ b/src/test/ui/feature-gates/feature-gate-non_ascii_idents.rs
@@ -26,7 +26,7 @@ enum Bär { //~ ERROR non-ascii idents
     }
 }
 
-extern {
+extern "C" {
     fn qüx();  //~ ERROR non-ascii idents
 }
 

--- a/src/test/ui/feature-gates/feature-gate-simd-ffi.rs
+++ b/src/test/ui/feature-gates/feature-gate-simd-ffi.rs
@@ -5,7 +5,7 @@
 #[derive(Copy, Clone)]
 struct LocalSimd(u8, u8);
 
-extern {
+extern "C" {
     fn baz() -> LocalSimd; //~ ERROR use of SIMD type
     fn qux(x: LocalSimd); //~ ERROR use of SIMD type
 }

--- a/src/test/ui/feature-gates/feature-gate-static-nobundle.rs
+++ b/src/test/ui/feature-gates/feature-gate-static-nobundle.rs
@@ -1,5 +1,5 @@
-#[link(name="foo", kind="static-nobundle")]
+#[link(name = "foo", kind = "static-nobundle")]
 //~^ ERROR: kind="static-nobundle" is unstable
-extern {}
+extern "C" {}
 
 fn main() {}

--- a/src/test/ui/feature-gates/feature-gate-static-nobundle.stderr
+++ b/src/test/ui/feature-gates/feature-gate-static-nobundle.stderr
@@ -1,8 +1,8 @@
 error[E0658]: kind="static-nobundle" is unstable
   --> $DIR/feature-gate-static-nobundle.rs:1:1
    |
-LL | #[link(name="foo", kind="static-nobundle")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | #[link(name = "foo", kind = "static-nobundle")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #37403 <https://github.com/rust-lang/rust/issues/37403> for more information
    = help: add `#![feature(static_nobundle)]` to the crate attributes to enable

--- a/src/test/ui/feature-gates/feature-gate-unwind-attributes.rs
+++ b/src/test/ui/feature-gates/feature-gate-unwind-attributes.rs
@@ -3,12 +3,12 @@
 
 #![crate_type = "lib"]
 
-extern {
-// CHECK: Function Attrs: nounwind
-// CHECK-NEXT: declare void @extern_fn
+extern "C" {
+    // CHECK: Function Attrs: nounwind
+    // CHECK-NEXT: declare void @extern_fn
     fn extern_fn();
-// CHECK-NOT: Function Attrs: nounwind
-// CHECK: declare void @unwinding_extern_fn
+    // CHECK-NOT: Function Attrs: nounwind
+    // CHECK: declare void @unwinding_extern_fn
     #[unwind(allowed)] //~ ERROR the `#[unwind]` attribute is an experimental feature
     fn unwinding_extern_fn();
 }

--- a/src/test/ui/feature-gates/issue-43106-gating-of-builtin-attrs.rs
+++ b/src/test/ui/feature-gates/issue-43106-gating-of-builtin-attrs.rs
@@ -536,7 +536,7 @@ mod link_name {
     //~^ WARN attribute should be applied to a foreign function or static [unused_attributes]
     //~| WARN this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
     //~| HELP try `#[link(name = "1900")]` instead
-    extern { }
+    extern "C" { }
     //~^ NOTE not a foreign function or static
 
     mod inner { #![link_name="1900"] }

--- a/src/test/ui/feature-gates/issue-43106-gating-of-builtin-attrs.stderr
+++ b/src/test/ui/feature-gates/issue-43106-gating-of-builtin-attrs.stderr
@@ -403,8 +403,8 @@ warning: attribute should be applied to a foreign function or static
 LL |     #[link_name = "1900"]
    |     ^^^^^^^^^^^^^^^^^^^^^
 ...
-LL |     extern { }
-   |     ---------- not a foreign function or static
+LL |     extern "C" { }
+   |     -------------- not a foreign function or static
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 help: try `#[link(name = "1900")]` instead

--- a/src/test/ui/ffi_const2.rs
+++ b/src/test/ui/ffi_const2.rs
@@ -1,6 +1,6 @@
 #![feature(ffi_const, ffi_pure)]
 
-extern {
+extern "C" {
     #[ffi_pure] //~ ERROR `#[ffi_const]` function cannot be `#[ffi_pure]`
     #[ffi_const]
     pub fn baz();

--- a/src/test/ui/foreign-unsafe-fn-called.rs
+++ b/src/test/ui/foreign-unsafe-fn-called.rs
@@ -1,5 +1,5 @@
 mod test {
-    extern {
+    extern "C" {
         pub fn free();
     }
 }

--- a/src/test/ui/foreign/foreign-fn-linkname.rs
+++ b/src/test/ui/foreign/foreign-fn-linkname.rs
@@ -10,7 +10,7 @@ use std::ffi::CString;
 mod mlibc {
     use libc::{c_char, size_t};
 
-    extern {
+    extern "C" {
         #[link_name = "strlen"]
         pub fn my_strlen(str: *const c_char) -> size_t;
     }
@@ -19,9 +19,7 @@ mod mlibc {
 fn strlen(str: String) -> usize {
     // C string is terminated with a zero
     let s = CString::new(str).unwrap();
-    unsafe {
-        mlibc::my_strlen(s.as_ptr()) as usize
-    }
+    unsafe { mlibc::my_strlen(s.as_ptr()) as usize }
 }
 
 pub fn main() {

--- a/src/test/ui/foreign/foreign-int-types.rs
+++ b/src/test/ui/foreign/foreign-int-types.rs
@@ -3,11 +3,10 @@
 #![allow(dead_code)]
 
 mod xx {
-    extern {
+    extern "C" {
         pub fn strlen(str: *const u8) -> usize;
         pub fn foo(x: isize, y: usize);
     }
 }
 
-fn main() {
-}
+fn main() {}

--- a/src/test/ui/foreign/foreign-mod-unused-const.rs
+++ b/src/test/ui/foreign/foreign-mod-unused-const.rs
@@ -3,10 +3,9 @@
 // pretty-expanded FIXME #23616
 
 mod foo {
-    extern {
+    extern "C" {
         pub static errno: u32;
     }
 }
 
-pub fn main() {
-}
+pub fn main() {}

--- a/src/test/ui/foreign/foreign2.rs
+++ b/src/test/ui/foreign/foreign2.rs
@@ -2,29 +2,28 @@
 #![allow(dead_code)]
 // ignore-wasm32-bare no libc to test ffi with
 // pretty-expanded FIXME #23616
-
 #![feature(rustc_private)]
 
 extern crate libc;
 
 mod bar {
-    extern {}
+    extern "C" {}
 }
 
 mod zed {
-    extern {}
+    extern "C" {}
 }
 
 mod mlibc {
     use libc::{c_int, c_void, size_t, ssize_t};
 
-    extern {
+    extern "C" {
         pub fn write(fd: c_int, buf: *const c_void, count: size_t) -> ssize_t;
     }
 }
 
 mod baz {
-    extern {}
+    extern "C" {}
 }
 
-pub fn main() { }
+pub fn main() {}

--- a/src/test/ui/functions-closures/auxiliary/fn-abi.rs
+++ b/src/test/ui/functions-closures/auxiliary/fn-abi.rs
@@ -1,2 +1,2 @@
 #[no_mangle]
-pub extern fn foo() {}
+pub extern "C" fn foo() {}

--- a/src/test/ui/functions-closures/fn-abi.rs
+++ b/src/test/ui/functions-closures/fn-abi.rs
@@ -7,12 +7,12 @@
 
 extern crate fn_abi;
 
-extern {
+extern "C" {
     fn foo();
 }
 
 pub fn main() {
     // Will only type check if the type of _p and the decl of foo use the
     // same ABI
-    let _p: unsafe extern fn() = foo;
+    let _p: unsafe extern "C" fn() = foo;
 }

--- a/src/test/ui/generics/generic-extern-lifetime.rs
+++ b/src/test/ui/generics/generic-extern-lifetime.rs
@@ -1,15 +1,15 @@
 // Test to make sure the names of the lifetimes are correctly resolved
 // in extern blocks.
 
-extern {
-   pub fn life<'a>(x:&'a i32);
-   pub fn life2<'b>(x:&'a i32, y:&'b i32); //~ ERROR use of undeclared lifetime name `'a`
-   pub fn life3<'a>(x:&'a i32, y:&i32) -> &'a i32;
-   pub fn life4<'b>(x: for<'c> fn(&'a i32)); //~ ERROR use of undeclared lifetime name `'a`
-   pub fn life5<'b>(x: for<'c> fn(&'b i32));
-   pub fn life6<'b>(x: for<'c> fn(&'c i32));
-   pub fn life7<'b>() -> for<'c> fn(&'a i32); //~ ERROR use of undeclared lifetime name `'a`
-   pub fn life8<'b>() -> for<'c> fn(&'b i32);
-   pub fn life9<'b>() -> for<'c> fn(&'c i32);
+extern "C" {
+    pub fn life<'a>(x: &'a i32);
+    pub fn life2<'b>(x: &'a i32, y: &'b i32); //~ ERROR use of undeclared lifetime name `'a`
+    pub fn life3<'a>(x: &'a i32, y: &i32) -> &'a i32;
+    pub fn life4<'b>(x: for<'c> fn(&'a i32)); //~ ERROR use of undeclared lifetime name `'a`
+    pub fn life5<'b>(x: for<'c> fn(&'b i32));
+    pub fn life6<'b>(x: for<'c> fn(&'c i32));
+    pub fn life7<'b>() -> for<'c> fn(&'a i32); //~ ERROR use of undeclared lifetime name `'a`
+    pub fn life8<'b>() -> for<'c> fn(&'b i32);
+    pub fn life9<'b>() -> for<'c> fn(&'c i32);
 }
 fn main() {}

--- a/src/test/ui/generics/generic-extern-lifetime.stderr
+++ b/src/test/ui/generics/generic-extern-lifetime.stderr
@@ -1,32 +1,32 @@
 error[E0261]: use of undeclared lifetime name `'a`
-  --> $DIR/generic-extern-lifetime.rs:6:24
+  --> $DIR/generic-extern-lifetime.rs:6:26
    |
-LL |    pub fn life2<'b>(x:&'a i32, y:&'b i32);
-   |                        ^^ undeclared lifetime
+LL |     pub fn life2<'b>(x: &'a i32, y: &'b i32);
+   |                          ^^ undeclared lifetime
 
 error[E0261]: use of undeclared lifetime name `'a`
-  --> $DIR/generic-extern-lifetime.rs:8:36
+  --> $DIR/generic-extern-lifetime.rs:8:37
    |
-LL |    pub fn life4<'b>(x: for<'c> fn(&'a i32));
-   |                                    ^^ undeclared lifetime
+LL |     pub fn life4<'b>(x: for<'c> fn(&'a i32));
+   |                                     ^^ undeclared lifetime
    |
    = note: for more information on higher-ranked polymorphism, visit https://doc.rust-lang.org/nomicon/hrtb.html
 help: consider making the type lifetime-generic with a new `'a` lifetime
    |
-LL |    pub fn life4<'b>(x: for<'c, 'a> fn(&'a i32));
-   |                              ^^^^
+LL |     pub fn life4<'b>(x: for<'c, 'a> fn(&'a i32));
+   |                               ^^^^
 
 error[E0261]: use of undeclared lifetime name `'a`
-  --> $DIR/generic-extern-lifetime.rs:11:38
+  --> $DIR/generic-extern-lifetime.rs:11:39
    |
-LL |    pub fn life7<'b>() -> for<'c> fn(&'a i32);
-   |                                      ^^ undeclared lifetime
+LL |     pub fn life7<'b>() -> for<'c> fn(&'a i32);
+   |                                       ^^ undeclared lifetime
    |
    = note: for more information on higher-ranked polymorphism, visit https://doc.rust-lang.org/nomicon/hrtb.html
 help: consider making the type lifetime-generic with a new `'a` lifetime
    |
-LL |    pub fn life7<'b>() -> for<'c, 'a> fn(&'a i32);
-   |                                ^^^^
+LL |     pub fn life7<'b>() -> for<'c, 'a> fn(&'a i32);
+   |                                 ^^^^
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/generics/generic-extern.rs
+++ b/src/test/ui/generics/generic-extern.rs
@@ -1,4 +1,4 @@
-extern {
+extern "C" {
     fn foo<T>(); //~ ERROR foreign items may not have type parameters
 }
 

--- a/src/test/ui/generics/generic-no-mangle.fixed
+++ b/src/test/ui/generics/generic-no-mangle.fixed
@@ -6,7 +6,7 @@
 pub fn foo<T>() {} //~ ERROR functions generic over types or consts must be mangled
 
 
-pub extern fn bar<T>() {} //~ ERROR functions generic over types or consts must be mangled
+pub extern "C" fn bar<T>() {} //~ ERROR functions generic over types or consts must be mangled
 
 #[no_mangle]
 pub fn baz(x: &i32) -> &i32 { x }

--- a/src/test/ui/generics/generic-no-mangle.rs
+++ b/src/test/ui/generics/generic-no-mangle.rs
@@ -6,7 +6,7 @@
 pub fn foo<T>() {} //~ ERROR functions generic over types or consts must be mangled
 
 #[no_mangle]
-pub extern fn bar<T>() {} //~ ERROR functions generic over types or consts must be mangled
+pub extern "C" fn bar<T>() {} //~ ERROR functions generic over types or consts must be mangled
 
 #[no_mangle]
 pub fn baz(x: &i32) -> &i32 { x }

--- a/src/test/ui/generics/generic-no-mangle.stderr
+++ b/src/test/ui/generics/generic-no-mangle.stderr
@@ -17,8 +17,8 @@ error: functions generic over types or consts must be mangled
    |
 LL | #[no_mangle]
    | ------------ help: remove this attribute
-LL | pub extern fn bar<T>() {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | pub extern "C" fn bar<T>() {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/hashmap/hashmap-memory.rs
+++ b/src/test/ui/hashmap/hashmap-memory.rs
@@ -23,7 +23,7 @@ mod map_reduce {
 
     pub type putter<'a> = Box<dyn FnMut(String, String) + 'a>;
 
-    pub type mapper = extern fn(String, putter);
+    pub type mapper = extern "C" fn(String, putter);
 
     enum ctrl_proto { find_reducer(Vec<u8>, Sender<isize>), mapper_done, }
 

--- a/src/test/ui/imports/glob-resolve1.rs
+++ b/src/test/ui/imports/glob-resolve1.rs
@@ -5,11 +5,15 @@ use bar::*;
 mod bar {
     use self::fpriv as import;
     fn fpriv() {}
-    extern {
+    extern "C" {
         fn epriv();
     }
-    enum A { A1 }
-    pub enum B { B1 }
+    enum A {
+        A1,
+    }
+    pub enum B {
+        B1,
+    }
 
     struct C;
 

--- a/src/test/ui/imports/glob-resolve1.stderr
+++ b/src/test/ui/imports/glob-resolve1.stderr
@@ -1,5 +1,5 @@
 error[E0425]: cannot find function `fpriv` in this scope
-  --> $DIR/glob-resolve1.rs:22:5
+  --> $DIR/glob-resolve1.rs:26:5
    |
 LL |     fpriv();
    |     ^^^^^ not found in this scope
@@ -10,7 +10,7 @@ LL | use bar::fpriv;
    |
 
 error[E0425]: cannot find function `epriv` in this scope
-  --> $DIR/glob-resolve1.rs:23:5
+  --> $DIR/glob-resolve1.rs:27:5
    |
 LL |     epriv();
    |     ^^^^^ not found in this scope
@@ -21,23 +21,25 @@ LL | use bar::epriv;
    |
 
 error[E0423]: expected value, found enum `B`
-  --> $DIR/glob-resolve1.rs:24:5
+  --> $DIR/glob-resolve1.rs:28:5
    |
 LL |     B;
    |     ^
    |
 note: the enum is defined here
-  --> $DIR/glob-resolve1.rs:12:5
+  --> $DIR/glob-resolve1.rs:14:5
    |
-LL |     pub enum B { B1 }
-   |     ^^^^^^^^^^^^^^^^^
+LL | /     pub enum B {
+LL | |         B1,
+LL | |     }
+   | |_____^
 help: you might have meant to use the following enum variant
    |
 LL |     B::B1;
    |     ^^^^^
 
 error[E0425]: cannot find value `C` in this scope
-  --> $DIR/glob-resolve1.rs:25:5
+  --> $DIR/glob-resolve1.rs:29:5
    |
 LL |     C;
    |     ^ not found in this scope
@@ -48,7 +50,7 @@ LL | use bar::C;
    |
 
 error[E0425]: cannot find function `import` in this scope
-  --> $DIR/glob-resolve1.rs:26:5
+  --> $DIR/glob-resolve1.rs:30:5
    |
 LL |     import();
    |     ^^^^^^ not found in this scope
@@ -59,9 +61,9 @@ LL | use other::import;
    |
 
 error[E0412]: cannot find type `A` in this scope
-  --> $DIR/glob-resolve1.rs:28:11
+  --> $DIR/glob-resolve1.rs:32:11
    |
-LL |     pub enum B { B1 }
+LL |     pub enum B {
    |     ---------- similarly named enum `B` defined here
 ...
 LL |     foo::<A>();
@@ -77,9 +79,9 @@ LL | use bar::A;
    |
 
 error[E0412]: cannot find type `C` in this scope
-  --> $DIR/glob-resolve1.rs:29:11
+  --> $DIR/glob-resolve1.rs:33:11
    |
-LL |     pub enum B { B1 }
+LL |     pub enum B {
    |     ---------- similarly named enum `B` defined here
 ...
 LL |     foo::<C>();
@@ -95,9 +97,9 @@ LL | use bar::C;
    |
 
 error[E0412]: cannot find type `D` in this scope
-  --> $DIR/glob-resolve1.rs:30:11
+  --> $DIR/glob-resolve1.rs:34:11
    |
-LL |     pub enum B { B1 }
+LL |     pub enum B {
    |     ---------- similarly named enum `B` defined here
 ...
 LL |     foo::<D>();

--- a/src/test/ui/issues/auxiliary/issue-13620-1.rs
+++ b/src/test/ui/issues/auxiliary/issue-13620-1.rs
@@ -1,8 +1,8 @@
 pub struct Foo {
-    pub foo: extern fn()
+    pub foo: extern "C" fn()
 }
 
-extern fn the_foo() {}
+extern "C" fn the_foo() {}
 
 pub const FOO: Foo = Foo {
     foo: the_foo

--- a/src/test/ui/issues/auxiliary/issue-15562.rs
+++ b/src/test/ui/issues/auxiliary/issue-15562.rs
@@ -1,5 +1,5 @@
 #![crate_type = "lib"]
 
-extern {
+extern "C" {
     pub fn transmute();
 }

--- a/src/test/ui/issues/auxiliary/issue-16725.rs
+++ b/src/test/ui/issues/auxiliary/issue-16725.rs
@@ -1,3 +1,3 @@
-extern {
+extern "C" {
     fn bar();
 }

--- a/src/test/ui/issues/auxiliary/issue-25185-1.rs
+++ b/src/test/ui/issues/auxiliary/issue-25185-1.rs
@@ -3,6 +3,6 @@
 #![crate_type = "rlib"]
 
 #[link(name = "rust_test_helpers", kind = "static")]
-extern {
+extern "C" {
     pub fn rust_dbg_extern_identity_u32(u: u32) -> u32;
 }

--- a/src/test/ui/issues/issue-10764.rs
+++ b/src/test/ui/issues/issue-10764.rs
@@ -1,5 +1,5 @@
 fn f(_: extern "Rust" fn()) {}
-extern fn bar() {}
+extern "C" fn bar() {}
 
 fn main() { f(bar) }
 //~^ ERROR mismatched types

--- a/src/test/ui/issues/issue-10877.rs
+++ b/src/test/ui/issues/issue-10877.rs
@@ -1,12 +1,14 @@
-struct Foo { x: isize }
-extern {
+struct Foo {
+    x: isize,
+}
+extern "C" {
     fn foo(1: ());
     //~^ ERROR: patterns aren't allowed in foreign function declarations
     fn bar((): isize);
     //~^ ERROR: patterns aren't allowed in foreign function declarations
     fn baz(Foo { x }: isize);
     //~^ ERROR: patterns aren't allowed in foreign function declarations
-    fn qux((x,y): ());
+    fn qux((x, y): ());
     //~^ ERROR: patterns aren't allowed in foreign function declarations
     fn this_is_actually_ok(a: usize);
     fn and_so_is_this(_: usize);

--- a/src/test/ui/issues/issue-10877.stderr
+++ b/src/test/ui/issues/issue-10877.stderr
@@ -1,26 +1,26 @@
 error[E0130]: patterns aren't allowed in foreign function declarations
-  --> $DIR/issue-10877.rs:3:12
+  --> $DIR/issue-10877.rs:5:12
    |
 LL |     fn foo(1: ());
    |            ^ pattern not allowed in foreign function
 
 error[E0130]: patterns aren't allowed in foreign function declarations
-  --> $DIR/issue-10877.rs:5:12
+  --> $DIR/issue-10877.rs:7:12
    |
 LL |     fn bar((): isize);
    |            ^^ pattern not allowed in foreign function
 
 error[E0130]: patterns aren't allowed in foreign function declarations
-  --> $DIR/issue-10877.rs:7:12
+  --> $DIR/issue-10877.rs:9:12
    |
 LL |     fn baz(Foo { x }: isize);
    |            ^^^^^^^^^ pattern not allowed in foreign function
 
 error[E0130]: patterns aren't allowed in foreign function declarations
-  --> $DIR/issue-10877.rs:9:12
+  --> $DIR/issue-10877.rs:11:12
    |
-LL |     fn qux((x,y): ());
-   |            ^^^^^ pattern not allowed in foreign function
+LL |     fn qux((x, y): ());
+   |            ^^^^^^ pattern not allowed in foreign function
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/issues/issue-1251.rs
+++ b/src/test/ui/issues/issue-1251.rs
@@ -3,15 +3,14 @@
 #![allow(dead_code)]
 // pretty-expanded FIXME #23616
 // ignore-wasm32-bare no libc to test ffi with
-
 #![feature(rustc_private)]
 
 mod rustrt {
     extern crate libc;
 
-    extern {
+    extern "C" {
         pub fn rust_get_test_int() -> libc::intptr_t;
     }
 }
 
-pub fn main() { }
+pub fn main() {}

--- a/src/test/ui/issues/issue-14227.rs
+++ b/src/test/ui/issues/issue-14227.rs
@@ -1,4 +1,4 @@
-extern {
+extern "C" {
     pub static symbol: u32;
 }
 static CRASH: u32 = symbol;

--- a/src/test/ui/issues/issue-15487.rs
+++ b/src/test/ui/issues/issue-15487.rs
@@ -3,12 +3,11 @@
 // ignore-windows
 // ignore-wasm32-bare no libs to link
 // ignore-sgx no libs to link
-
 #![feature(link_args)]
 
-#[link_args="-lc  -lm"]
-#[link_args=" -lc"]
-#[link_args="-lc "]
-extern {}
+#[link_args = "-lc  -lm"]
+#[link_args = " -lc"]
+#[link_args = "-lc "]
+extern "C" {}
 
 fn main() {}

--- a/src/test/ui/issues/issue-15562.rs
+++ b/src/test/ui/issues/issue-15562.rs
@@ -16,4 +16,4 @@ pub fn main() {
 // The above extern is NOT `extern "rust-intrinsic"` and thus
 // means it'll try to find a corresponding symbol to link to.
 #[no_mangle]
-pub extern fn transmute() {}
+pub extern "C" fn transmute() {}

--- a/src/test/ui/issues/issue-16149.rs
+++ b/src/test/ui/issues/issue-16149.rs
@@ -1,4 +1,4 @@
-extern {
+extern "C" {
     static externalValue: isize;
 }
 
@@ -6,6 +6,6 @@ fn main() {
     let boolValue = match 42 {
         externalValue => true,
         //~^ ERROR match bindings cannot shadow statics
-        _ => false
+        _ => false,
     };
 }

--- a/src/test/ui/issues/issue-16250.rs
+++ b/src/test/ui/issues/issue-16250.rs
@@ -2,9 +2,8 @@
 
 pub struct Foo;
 
-extern {
+extern "C" {
     pub fn foo(x: (Foo)); //~ ERROR `extern` block uses type `Foo`
 }
 
-fn main() {
-}
+fn main() {}

--- a/src/test/ui/issues/issue-16538.rs
+++ b/src/test/ui/issues/issue-16538.rs
@@ -1,6 +1,6 @@
 mod Y {
     pub type X = usize;
-    extern {
+    extern "C" {
         pub static x: *const usize;
     }
     pub fn foo(value: *const X) -> *const X {

--- a/src/test/ui/issues/issue-1866.rs
+++ b/src/test/ui/issues/issue-1866.rs
@@ -9,7 +9,7 @@ mod a {
     pub type rust_task = usize;
     pub mod rustrt {
         use super::rust_task;
-        extern {
+        extern "C" {
             pub fn rust_task_is_unwinding(rt: *const rust_task) -> bool;
         }
     }
@@ -19,11 +19,11 @@ mod b {
     pub type rust_task = bool;
     pub mod rustrt {
         use super::rust_task;
-        extern {
+        extern "C" {
             pub fn rust_task_is_unwinding(rt: *const rust_task) -> bool;
-            //~^ WARN `rust_task_is_unwinding` redeclared with a different signature
+        //~^ WARN `rust_task_is_unwinding` redeclared with a different signature
         }
     }
 }
 
-pub fn main() { }
+pub fn main() {}

--- a/src/test/ui/issues/issue-18804/auxiliary/lib.rs
+++ b/src/test/ui/issues/issue-18804/auxiliary/lib.rs
@@ -1,10 +1,10 @@
 #![crate_type = "rlib"]
 #![feature(linkage)]
 
-pub fn foo<T>() -> *const() {
-    extern {
+pub fn foo<T>() -> *const () {
+    extern "C" {
         #[linkage = "extern_weak"]
-        static FOO: *const();
+        static FOO: *const ();
     }
     unsafe { FOO }
 }

--- a/src/test/ui/issues/issue-20313-rpass.rs
+++ b/src/test/ui/issues/issue-20313-rpass.rs
@@ -1,13 +1,11 @@
 // run-pass
 #![allow(dead_code)]
 // pretty-expanded FIXME #23616
-
 #![feature(link_llvm_intrinsics)]
 
-extern {
+extern "C" {
     #[link_name = "llvm.sqrt.f32"]
     fn sqrt(x: f32) -> f32;
 }
 
-fn main(){
-}
+fn main() {}

--- a/src/test/ui/issues/issue-20313.rs
+++ b/src/test/ui/issues/issue-20313.rs
@@ -1,7 +1,6 @@
-extern {
+extern "C" {
     #[link_name = "llvm.sqrt.f32"]
     fn sqrt(x: f32) -> f32; //~ ERROR linking to LLVM intrinsics is experimental
 }
 
-fn main(){
-}
+fn main() {}

--- a/src/test/ui/issues/issue-2214.rs
+++ b/src/test/ui/issues/issue-2214.rs
@@ -5,13 +5,11 @@
 
 extern crate libc;
 
-use std::mem;
 use libc::{c_double, c_int};
+use std::mem;
 
 fn to_c_int(v: &mut isize) -> &mut c_int {
-    unsafe {
-        mem::transmute_copy(&v)
-    }
+    unsafe { mem::transmute_copy(&v) }
 }
 
 fn lgamma(n: c_double, value: &mut isize) -> c_double {
@@ -23,21 +21,21 @@ fn lgamma(n: c_double, value: &mut isize) -> c_double {
 mod m {
     use libc::{c_double, c_int};
 
-    extern {
+    extern "C" {
         #[cfg(all(unix, not(target_os = "vxworks")))]
         #[link_name="lgamma_r"]
         pub fn lgamma(n: c_double, sign: &mut c_int) -> c_double;
         #[cfg(windows)]
-        #[link_name="lgamma"]
+        #[link_name = "lgamma"]
         pub fn lgamma(n: c_double, sign: &mut c_int) -> c_double;
         #[cfg(target_os = "vxworks")]
-        #[link_name="lgamma"]
+        #[link_name = "lgamma"]
         pub fn lgamma(n: c_double, sign: &mut c_int) -> c_double;
     }
 }
 
 pub fn main() {
-  let mut y: isize = 5;
-  let x: &mut isize = &mut y;
-  assert_eq!(lgamma(1.0 as c_double, x), 0.0 as c_double);
+    let mut y: isize = 5;
+    let x: &mut isize = &mut y;
+    assert_eq!(lgamma(1.0 as c_double, x), 0.0 as c_double);
 }

--- a/src/test/ui/issues/issue-26997.rs
+++ b/src/test/ui/issues/issue-26997.rs
@@ -7,7 +7,7 @@ pub struct Foo {
 
 impl Foo {
     #[allow(improper_ctypes_definitions)]
-    pub extern fn foo_new() -> Foo {
+    pub extern "C" fn foo_new() -> Foo {
         Foo { x: 21, y: 33 }
     }
 }

--- a/src/test/ui/issues/issue-28324.rs
+++ b/src/test/ui/issues/issue-28324.rs
@@ -1,4 +1,4 @@
-extern {
+extern "C" {
     static error_message_count: u32;
 }
 

--- a/src/test/ui/issues/issue-28472.rs
+++ b/src/test/ui/issues/issue-28472.rs
@@ -1,6 +1,6 @@
 // Check that the visibility modifier is included in the span of foreign items.
 
-extern {
+extern "C" {
   fn foo();
 
   pub //~ ERROR the name `foo` is defined multiple times

--- a/src/test/ui/issues/issue-28600.rs
+++ b/src/test/ui/issues/issue-28600.rs
@@ -7,7 +7,7 @@ impl Test {
     #[allow(dead_code)]
     #[allow(unused_variables)]
     #[allow(improper_ctypes_definitions)]
-    pub extern fn test(val: &str) {
+    pub extern "C" fn test(val: &str) {
 
     }
 }

--- a/src/test/ui/issues/issue-28676.rs
+++ b/src/test/ui/issues/issue-28676.rs
@@ -5,27 +5,32 @@
 // ignore-wasm32-bare no libc to test ffi with
 
 #[derive(Copy, Clone)]
-pub struct Quad { a: u64, b: u64, c: u64, d: u64 }
+pub struct Quad {
+    a: u64,
+    b: u64,
+    c: u64,
+    d: u64,
+}
 
 mod rustrt {
     use super::Quad;
 
     #[link(name = "rust_test_helpers", kind = "static")]
-    extern {
-        pub fn get_c_many_params(_: *const (), _: *const (),
-                                 _: *const (), _: *const (), f: Quad) -> u64;
+    extern "C" {
+        pub fn get_c_many_params(
+            _: *const (),
+            _: *const (),
+            _: *const (),
+            _: *const (),
+            f: Quad,
+        ) -> u64;
     }
 }
 
 fn test() {
     unsafe {
         let null = std::ptr::null();
-        let q = Quad {
-            a: 1,
-            b: 2,
-            c: 3,
-            d: 4
-        };
+        let q = Quad { a: 1, b: 2, c: 3, d: 4 };
         assert_eq!(rustrt::get_c_many_params(null, null, null, null, q), q.c);
     }
 }

--- a/src/test/ui/issues/issue-32201.rs
+++ b/src/test/ui/issues/issue-32201.rs
@@ -1,4 +1,4 @@
-extern {
+extern "C" {
     fn foo(a: i32, ...);
 }
 

--- a/src/test/ui/issues/issue-3656.rs
+++ b/src/test/ui/issues/issue-3656.rs
@@ -1,14 +1,12 @@
 // run-pass
 #![allow(dead_code)]
 #![allow(improper_ctypes)]
-
 // Issue #3656
 // Incorrect struct size computation in the FFI, because of not taking
 // the alignment of elements into account.
 
 // pretty-expanded FIXME #23616
 // ignore-wasm32-bare no libc to test with
-
 #![feature(rustc_private)]
 
 extern crate libc;
@@ -21,10 +19,9 @@ pub struct KEYGEN {
     salt_size: u32,
 }
 
-extern {
+extern "C" {
     // Bogus signature, just need to test if it compiles.
     pub fn malloc(data: KEYGEN);
 }
 
-pub fn main() {
-}
+pub fn main() {}

--- a/src/test/ui/issues/issue-43925.rs
+++ b/src/test/ui/issues/issue-43925.rs
@@ -1,4 +1,4 @@
-#[link(name="foo", cfg("rlib"))] //~ ERROR invalid argument for `cfg(..)`
-extern {}
+#[link(name = "foo", cfg("rlib"))] //~ ERROR invalid argument for `cfg(..)`
+extern "C" {}
 
 fn main() {}

--- a/src/test/ui/issues/issue-43925.stderr
+++ b/src/test/ui/issues/issue-43925.stderr
@@ -1,8 +1,8 @@
 error: invalid argument for `cfg(..)`
-  --> $DIR/issue-43925.rs:1:24
+  --> $DIR/issue-43925.rs:1:26
    |
-LL | #[link(name="foo", cfg("rlib"))]
-   |                        ^^^^^^
+LL | #[link(name = "foo", cfg("rlib"))]
+   |                          ^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-43926.rs
+++ b/src/test/ui/issues/issue-43926.rs
@@ -1,4 +1,4 @@
-#[link(name="foo", cfg())] //~ ERROR `cfg()` must have an argument
-extern {}
+#[link(name = "foo", cfg())] //~ ERROR `cfg()` must have an argument
+extern "C" {}
 
 fn main() {}

--- a/src/test/ui/issues/issue-43926.stderr
+++ b/src/test/ui/issues/issue-43926.stderr
@@ -1,8 +1,8 @@
 error: `cfg()` must have an argument
-  --> $DIR/issue-43926.rs:1:20
+  --> $DIR/issue-43926.rs:1:22
    |
-LL | #[link(name="foo", cfg())]
-   |                    ^^^^^
+LL | #[link(name = "foo", cfg())]
+   |                      ^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-51907.rs
+++ b/src/test/ui/issues/issue-51907.rs
@@ -1,15 +1,15 @@
 // run-pass
 trait Foo {
-    extern fn borrow(&self);
-    extern fn take(self: Box<Self>);
+    extern "C" fn borrow(&self);
+    extern "C" fn take(self: Box<Self>);
 }
 
 struct Bar;
 impl Foo for Bar {
     #[allow(improper_ctypes_definitions)]
-    extern fn borrow(&self) {}
+    extern "C" fn borrow(&self) {}
     #[allow(improper_ctypes_definitions)]
-    extern fn take(self: Box<Self>) {}
+    extern "C" fn take(self: Box<Self>) {}
 }
 
 fn main() {

--- a/src/test/ui/issues/issue-5791.rs
+++ b/src/test/ui/issues/issue-5791.rs
@@ -3,7 +3,7 @@
 #![warn(clashing_extern_declarations)]
 // pretty-expanded FIXME #23616
 
-extern {
+extern "C" {
     #[link_name = "malloc"]
     fn malloc1(len: i32) -> *const u8;
     #[link_name = "malloc"]
@@ -11,4 +11,4 @@ extern {
     fn malloc2(len: i32, foo: i32) -> *const u8;
 }
 
-pub fn main () {}
+pub fn main() {}

--- a/src/test/ui/issues/issue-6470.rs
+++ b/src/test/ui/issues/issue-6470.rs
@@ -1,7 +1,6 @@
 // build-pass
 #![allow(dead_code)]
 #![allow(improper_ctypes)]
-
 // pretty-expanded FIXME #23616
 #![allow(non_snake_case)]
 
@@ -10,9 +9,9 @@ pub mod Bar {
         v: isize,
     }
 
-    extern {
+    extern "C" {
         pub fn foo(v: *const Foo) -> Foo;
     }
 }
 
-pub fn main() { }
+pub fn main() {}

--- a/src/test/ui/link-cfg-works.rs
+++ b/src/test/ui/link-cfg-works.rs
@@ -4,10 +4,10 @@
 
 #![feature(link_cfg)]
 
-extern crate link_cfg_works_transitive_rlib;
 extern crate link_cfg_works_transitive_dylib;
+extern crate link_cfg_works_transitive_rlib;
 
 #[link(name = "foo", cfg(foo))]
-extern {}
+extern "C" {}
 
 fn main() {}

--- a/src/test/ui/linkage-attr/auxiliary/def_colliding_external.rs
+++ b/src/test/ui/linkage-attr/auxiliary/def_colliding_external.rs
@@ -1,7 +1,7 @@
 #![feature(linkage)]
 #![crate_type = "lib"]
 
-extern {
-    #[linkage="external"]
+extern "C" {
+    #[linkage = "external"]
     pub static collision: *const i32;
 }

--- a/src/test/ui/linkage-attr/invalid-link-args.rs
+++ b/src/test/ui/linkage-attr/invalid-link-args.rs
@@ -9,6 +9,6 @@
 #![feature(link_args)]
 
 #[link_args = "aFdEfSeVEEE"]
-extern {}
+extern "C" {}
 
-fn main() { }
+fn main() {}

--- a/src/test/ui/linkage-attr/linkage-detect-local-generated-name-collision.rs
+++ b/src/test/ui/linkage-attr/linkage-detect-local-generated-name-collision.rs
@@ -3,8 +3,8 @@
 #![feature(linkage)]
 
 mod dep1 {
-    extern {
-        #[linkage="external"]
+    extern "C" {
+        #[linkage = "external"]
         #[no_mangle]
         pub static collision: *const i32; //~ ERROR symbol `collision` is already defined
     }
@@ -20,6 +20,6 @@ mod dep2 {
 
 fn main() {
     unsafe {
-       println!("{:p}", &dep1::collision);
+        println!("{:p}", &dep1::collision);
     }
 }

--- a/src/test/ui/linkage-attr/linkage2.rs
+++ b/src/test/ui/linkage-attr/linkage2.rs
@@ -7,9 +7,10 @@
 
 #![feature(linkage)]
 
-extern {
-    #[linkage = "extern_weak"] static foo: i32;
-    //~^ ERROR: must have type `*const T` or `*mut T` due to `#[linkage]` attribute
+extern "C" {
+    #[linkage = "extern_weak"]
+    static foo: i32;
+//~^ ERROR: must have type `*const T` or `*mut T` due to `#[linkage]` attribute
 }
 
 fn main() {

--- a/src/test/ui/linkage-attr/linkage2.stderr
+++ b/src/test/ui/linkage-attr/linkage2.stderr
@@ -1,8 +1,8 @@
 error: must have type `*const T` or `*mut T` due to `#[linkage]` attribute
-  --> $DIR/linkage2.rs:11:32
+  --> $DIR/linkage2.rs:12:5
    |
-LL |     #[linkage = "extern_weak"] static foo: i32;
-   |                                ^^^^^^^^^^^^^^^^
+LL |     static foo: i32;
+   |     ^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/linkage-attr/linkage3.rs
+++ b/src/test/ui/linkage-attr/linkage3.rs
@@ -6,9 +6,10 @@
 
 #![feature(linkage)]
 
-extern {
-    #[linkage = "foo"] static foo: *const i32;
-    //~^ ERROR: invalid linkage specified
+extern "C" {
+    #[linkage = "foo"]
+    static foo: *const i32;
+//~^ ERROR: invalid linkage specified
 }
 
 fn main() {

--- a/src/test/ui/linkage-attr/linkage3.stderr
+++ b/src/test/ui/linkage-attr/linkage3.stderr
@@ -1,8 +1,8 @@
 error: invalid linkage specified
-  --> $DIR/linkage3.rs:10:24
+  --> $DIR/linkage3.rs:11:5
    |
-LL |     #[linkage = "foo"] static foo: *const i32;
-   |                        ^^^^^^^^^^^^^^^^^^^^^^^
+LL |     static foo: *const i32;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/linkage1.rs
+++ b/src/test/ui/linkage1.rs
@@ -9,7 +9,7 @@
 
 extern crate linkage1 as other;
 
-extern {
+extern "C" {
     #[linkage = "extern_weak"]
     static foo: *const isize;
     #[linkage = "extern_weak"]

--- a/src/test/ui/lint/dead-code/leading-underscore.rs
+++ b/src/test/ui/lint/dead-code/leading-underscore.rs
@@ -8,7 +8,7 @@ static _X: usize = 0;
 fn _foo() {}
 
 struct _Y {
-    _z: usize
+    _z: usize,
 }
 
 enum _Z {}
@@ -23,7 +23,7 @@ mod _bar {
     fn _qux() {}
 }
 
-extern {
+extern "C" {
     #[link_name = "abort"]
     fn _abort() -> !;
 }

--- a/src/test/ui/lint/dead-code/lint-dead-code-3.rs
+++ b/src/test/ui/lint/dead-code/lint-dead-code-3.rs
@@ -7,7 +7,7 @@
 
 
 pub use extern_foo as x;
-extern {
+extern "C" {
     pub fn extern_foo();
 }
 
@@ -47,7 +47,7 @@ mod blah {
     // `malloc` below, which are also used.
     enum c_void {}
 
-    extern {
+    extern "C" {
         fn free(p: *const c_void);
         fn malloc(size: usize) -> *const c_void;
     }
@@ -58,7 +58,7 @@ mod blah {
 }
 
 enum c_void {} //~ ERROR: enum is never used
-extern {
+extern "C" {
     fn free(p: *const c_void); //~ ERROR: function is never used
 }
 

--- a/src/test/ui/lint/inline-trait-and-foreign-items.rs
+++ b/src/test/ui/lint/inline-trait-and-foreign-items.rs
@@ -26,7 +26,7 @@ impl Trait for () {
     type U = impl Trait; //~ ERROR could not find defining uses
 }
 
-extern {
+extern "C" {
     #[inline] //~ ERROR attribute should be applied to function or closure
     static X: u32;
 

--- a/src/test/ui/lint/lint-ctypes-enum.rs
+++ b/src/test/ui/lint/lint-ctypes-enum.rs
@@ -5,36 +5,57 @@
 
 use std::num;
 
-enum Z { }
-enum U { A }
-enum B { C, D }
-enum T { E, F, G }
+enum Z {}
+enum U {
+    A,
+}
+enum B {
+    C,
+    D,
+}
+enum T {
+    E,
+    F,
+    G,
+}
 
 #[repr(C)]
-enum ReprC { A, B, C }
+enum ReprC {
+    A,
+    B,
+    C,
+}
 
 #[repr(u8)]
-enum U8 { A, B, C }
+enum U8 {
+    A,
+    B,
+    C,
+}
 
 #[repr(isize)]
-enum Isize { A, B, C }
+enum Isize {
+    A,
+    B,
+    C,
+}
 
 #[repr(transparent)]
 struct TransparentStruct<T>(T, std::marker::PhantomData<Z>);
 
 #[repr(transparent)]
 enum TransparentEnum<T> {
-   Variant(T, std::marker::PhantomData<Z>),
+    Variant(T, std::marker::PhantomData<Z>),
 }
 
 #[repr(transparent)]
 union TransparentUnion<T: Copy> {
-   field: T,
+    field: T,
 }
 
 struct Rust<T>(T);
 
-extern {
+extern "C" {
    fn zf(x: Z);
    fn uf(x: U); //~ ERROR `extern` block uses type `U`
    fn bf(x: B); //~ ERROR `extern` block uses type `B`

--- a/src/test/ui/lint/lint-ctypes-enum.stderr
+++ b/src/test/ui/lint/lint-ctypes-enum.stderr
@@ -1,5 +1,5 @@
 error: `extern` block uses type `U`, which is not FFI-safe
-  --> $DIR/lint-ctypes-enum.rs:39:13
+  --> $DIR/lint-ctypes-enum.rs:60:13
    |
 LL |    fn uf(x: U);
    |             ^ not FFI-safe
@@ -14,11 +14,13 @@ LL | #![deny(improper_ctypes)]
 note: the type is defined here
   --> $DIR/lint-ctypes-enum.rs:9:1
    |
-LL | enum U { A }
-   | ^^^^^^^^^^^^
+LL | / enum U {
+LL | |     A,
+LL | | }
+   | |_^
 
 error: `extern` block uses type `B`, which is not FFI-safe
-  --> $DIR/lint-ctypes-enum.rs:40:13
+  --> $DIR/lint-ctypes-enum.rs:61:13
    |
 LL |    fn bf(x: B);
    |             ^ not FFI-safe
@@ -26,13 +28,16 @@ LL |    fn bf(x: B);
    = help: consider adding a `#[repr(C)]`, `#[repr(transparent)]`, or integer `#[repr(...)]` attribute to this enum
    = note: enum has no representation hint
 note: the type is defined here
-  --> $DIR/lint-ctypes-enum.rs:10:1
+  --> $DIR/lint-ctypes-enum.rs:12:1
    |
-LL | enum B { C, D }
-   | ^^^^^^^^^^^^^^^
+LL | / enum B {
+LL | |     C,
+LL | |     D,
+LL | | }
+   | |_^
 
 error: `extern` block uses type `T`, which is not FFI-safe
-  --> $DIR/lint-ctypes-enum.rs:41:13
+  --> $DIR/lint-ctypes-enum.rs:62:13
    |
 LL |    fn tf(x: T);
    |             ^ not FFI-safe
@@ -40,13 +45,17 @@ LL |    fn tf(x: T);
    = help: consider adding a `#[repr(C)]`, `#[repr(transparent)]`, or integer `#[repr(...)]` attribute to this enum
    = note: enum has no representation hint
 note: the type is defined here
-  --> $DIR/lint-ctypes-enum.rs:11:1
+  --> $DIR/lint-ctypes-enum.rs:16:1
    |
-LL | enum T { E, F, G }
-   | ^^^^^^^^^^^^^^^^^^
+LL | / enum T {
+LL | |     E,
+LL | |     F,
+LL | |     G,
+LL | | }
+   | |_^
 
 error: `extern` block uses type `Option<Unique<u8>>`, which is not FFI-safe
-  --> $DIR/lint-ctypes-enum.rs:48:17
+  --> $DIR/lint-ctypes-enum.rs:69:17
    |
 LL |    fn unique(x: Option<std::ptr::Unique<u8>>);
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
@@ -55,7 +64,7 @@ LL |    fn unique(x: Option<std::ptr::Unique<u8>>);
    = note: enum has no representation hint
 
 error: `extern` block uses type `u128`, which is not FFI-safe
-  --> $DIR/lint-ctypes-enum.rs:54:23
+  --> $DIR/lint-ctypes-enum.rs:75:23
    |
 LL |    fn nonzero_u128(x: Option<num::NonZeroU128>);
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
@@ -63,7 +72,7 @@ LL |    fn nonzero_u128(x: Option<num::NonZeroU128>);
    = note: 128-bit integers don't currently have a known stable ABI
 
 error: `extern` block uses type `i128`, which is not FFI-safe
-  --> $DIR/lint-ctypes-enum.rs:61:23
+  --> $DIR/lint-ctypes-enum.rs:82:23
    |
 LL |    fn nonzero_i128(x: Option<num::NonZeroI128>);
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
@@ -71,7 +80,7 @@ LL |    fn nonzero_i128(x: Option<num::NonZeroI128>);
    = note: 128-bit integers don't currently have a known stable ABI
 
 error: `extern` block uses type `Option<TransparentUnion<NonZeroU8>>`, which is not FFI-safe
-  --> $DIR/lint-ctypes-enum.rs:66:28
+  --> $DIR/lint-ctypes-enum.rs:87:28
    |
 LL |    fn transparent_union(x: Option<TransparentUnion<num::NonZeroU8>>);
    |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
@@ -80,7 +89,7 @@ LL |    fn transparent_union(x: Option<TransparentUnion<num::NonZeroU8>>);
    = note: enum has no representation hint
 
 error: `extern` block uses type `Option<Rust<NonZeroU8>>`, which is not FFI-safe
-  --> $DIR/lint-ctypes-enum.rs:68:20
+  --> $DIR/lint-ctypes-enum.rs:89:20
    |
 LL |    fn repr_rust(x: Option<Rust<num::NonZeroU8>>);
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
@@ -89,7 +98,7 @@ LL |    fn repr_rust(x: Option<Rust<num::NonZeroU8>>);
    = note: enum has no representation hint
 
 error: `extern` block uses type `std::result::Result<(), NonZeroI32>`, which is not FFI-safe
-  --> $DIR/lint-ctypes-enum.rs:69:20
+  --> $DIR/lint-ctypes-enum.rs:90:20
    |
 LL |    fn no_result(x: Result<(), num::NonZeroI32>);
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe

--- a/src/test/ui/lint/lint-ctypes-fn.rs
+++ b/src/test/ui/lint/lint-ctypes-fn.rs
@@ -27,7 +27,7 @@ pub struct ZeroSize;
 
 pub type RustFn = fn();
 
-pub type RustBadRet = extern fn() -> Box<u32>;
+pub type RustBadRet = extern "C" fn() -> Box<u32>;
 
 pub type CVoidRet = ();
 
@@ -116,7 +116,7 @@ pub extern "C" fn transparent_str(p: TransparentStr) { }
 
 pub extern "C" fn transparent_fn(p: TransparentBadFn) { }
 
-pub extern "C" fn good3(fptr: Option<extern fn()>) { }
+pub extern "C" fn good3(fptr: Option<extern "C" fn()>) { }
 
 pub extern "C" fn good4(aptr: &[u8; 4 as usize]) { }
 
@@ -124,9 +124,9 @@ pub extern "C" fn good5(s: StructWithProjection) { }
 
 pub extern "C" fn good6(s: StructWithProjectionAndLifetime) { }
 
-pub extern "C" fn good7(fptr: extern fn() -> ()) { }
+pub extern "C" fn good7(fptr: extern "C" fn() -> ()) { }
 
-pub extern "C" fn good8(fptr: extern fn() -> !) { }
+pub extern "C" fn good8(fptr: extern "C" fn() -> !) { }
 
 pub extern "C" fn good9() -> () { }
 

--- a/src/test/ui/lint/lint-ctypes.rs
+++ b/src/test/ui/lint/lint-ctypes.rs
@@ -20,7 +20,7 @@ pub type I32Pair = (i32, i32);
 #[repr(C)]
 pub struct ZeroSize;
 pub type RustFn = fn();
-pub type RustBadRet = extern fn() -> Box<u32>;
+pub type RustBadRet = extern "C" fn() -> Box<u32>;
 pub type CVoidRet = ();
 pub struct Foo;
 #[repr(transparent)]
@@ -43,7 +43,7 @@ pub struct TransparentCustomZst(i32, ZeroSize);
 #[repr(C)]
 pub struct ZeroSizeWithPhantomData(::std::marker::PhantomData<i32>);
 
-extern {
+extern "C" {
     pub fn ptr_type1(size: *const Foo); //~ ERROR: uses type `Foo`
     pub fn ptr_type2(size: *const Foo); //~ ERROR: uses type `Foo`
     pub fn slice_type(p: &[u32]); //~ ERROR: uses type `[u32]`
@@ -73,12 +73,12 @@ extern {
     pub static static_u128_type: u128; //~ ERROR: uses type `u128`
     pub static static_u128_array_type: [u128; 16]; //~ ERROR: uses type `u128`
 
-    pub fn good3(fptr: Option<extern fn()>);
+    pub fn good3(fptr: Option<extern "C" fn()>);
     pub fn good4(aptr: &[u8; 4 as usize]);
     pub fn good5(s: StructWithProjection);
     pub fn good6(s: StructWithProjectionAndLifetime);
-    pub fn good7(fptr: extern fn() -> ());
-    pub fn good8(fptr: extern fn() -> !);
+    pub fn good7(fptr: extern "C" fn() -> ());
+    pub fn good8(fptr: extern "C" fn() -> !);
     pub fn good9() -> ();
     pub fn good10() -> CVoidRet;
     pub fn good11(size: isize);
@@ -96,12 +96,12 @@ extern {
 }
 
 #[allow(improper_ctypes)]
-extern {
+extern "C" {
     pub fn good19(_: &String);
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-extern {
+extern "C" {
     pub fn good1(size: *const libc::c_int);
     pub fn good2(size: *const libc::c_uint);
 }

--- a/src/test/ui/lint/unreachable_pub-pub_crate.rs
+++ b/src/test/ui/lint/unreachable_pub-pub_crate.rs
@@ -41,7 +41,7 @@ mod private_mod {
     }
     define_empty_struct_with_visibility!(pub, Fluorine);
 
-    extern {
+    extern "C" {
         pub fn catalyze() -> bool; //~ WARNING unreachable_pub
     }
 

--- a/src/test/ui/lint/unreachable_pub.rs
+++ b/src/test/ui/lint/unreachable_pub.rs
@@ -37,7 +37,7 @@ mod private_mod {
     }
     define_empty_struct_with_visibility!(pub, Fluorine);
 
-    extern {
+    extern "C" {
         pub fn catalyze() -> bool; //~ WARNING unreachable_pub
     }
 

--- a/src/test/ui/lint/warn-unused-inline-on-fn-prototypes.rs
+++ b/src/test/ui/lint/warn-unused-inline-on-fn-prototypes.rs
@@ -5,7 +5,7 @@ trait Trait {
     fn foo();
 }
 
-extern {
+extern "C" {
     #[inline] //~ ERROR `#[inline]` is ignored on function prototypes
     fn foo();
 }

--- a/src/test/ui/macros/macros-in-extern.rs
+++ b/src/test/ui/macros/macros-in-extern.rs
@@ -10,7 +10,7 @@ macro_rules! returns_isize(
 );
 
 macro takes_u32_returns_u32($ident:ident) {
-    fn $ident (arg: u32) -> u32;
+    fn $ident(arg: u32) -> u32;
 }
 
 macro_rules! emits_nothing(
@@ -25,8 +25,14 @@ macro_rules! emits_multiple(
 );
 
 mod defs {
-    #[no_mangle] extern fn f1() -> u32 { 1 }
-    #[no_mangle] extern fn f2() -> u32 { 2 }
+    #[no_mangle]
+    extern "C" fn f1() -> u32 {
+        1
+    }
+    #[no_mangle]
+    extern "C" fn f2() -> u32 {
+        2
+    }
 }
 
 fn main() {
@@ -37,7 +43,7 @@ fn main() {
 }
 
 #[link(name = "rust_test_helpers", kind = "static")]
-extern {
+extern "C" {
     returns_isize!(rust_get_test_int);
     takes_u32_returns_u32!(rust_dbg_extern_identity_u32);
     emits_nothing!();

--- a/src/test/ui/mir/mir_codegen_calls.rs
+++ b/src/test/ui/mir/mir_codegen_calls.rs
@@ -75,7 +75,7 @@ fn test8() -> isize {
 }
 
 #[allow(improper_ctypes_definitions)]
-extern fn simple_extern(x: u32, y: (u32, u32)) -> u32 {
+extern "C" fn simple_extern(x: u32, y: (u32, u32)) -> u32 {
     x + y.0 * y.1
 }
 

--- a/src/test/ui/mismatched_types/issue-26480.rs
+++ b/src/test/ui/mismatched_types/issue-26480.rs
@@ -1,4 +1,4 @@
-extern {
+extern "C" {
     fn write(fildes: i32, buf: *const i8, nbyte: u64) -> i64;
 }
 

--- a/src/test/ui/nil-decl-in-foreign.rs
+++ b/src/test/ui/nil-decl-in-foreign.rs
@@ -6,9 +6,9 @@
 // pretty-expanded FIXME #23616
 
 mod libc {
-    extern {
+    extern "C" {
         pub fn printf(x: ());
     }
 }
 
-pub fn main() { }
+pub fn main() {}

--- a/src/test/ui/no-patterns-in-args.rs
+++ b/src/test/ui/no-patterns-in-args.rs
@@ -1,10 +1,10 @@
-extern {
+extern "C" {
     fn f1(mut arg: u8); //~ ERROR patterns aren't allowed in foreign function declarations
     fn f2(&arg: u8); //~ ERROR patterns aren't allowed in foreign function declarations
     fn f3(arg @ _: u8); //~ ERROR patterns aren't allowed in foreign function declarations
     fn g1(arg: u8); // OK
     fn g2(_: u8); // OK
-    // fn g3(u8); // Not yet
+// fn g3(u8); // Not yet
 }
 
 type A1 = fn(mut arg: u8); //~ ERROR patterns aren't allowed in function pointer types

--- a/src/test/ui/no_owned_box_lang_item.rs
+++ b/src/test/ui/no_owned_box_lang_item.rs
@@ -11,6 +11,6 @@ fn main() {
     let x = box 1i32;
 }
 
-#[lang = "eh_personality"] extern fn eh_personality() {}
+#[lang = "eh_personality"] extern "C" fn eh_personality() {}
 #[lang = "eh_catch_typeinfo"] static EH_CATCH_TYPEINFO: u8 = 0;
 #[lang = "panic_impl"] fn panic_impl(panic: &PanicInfo) -> ! { loop {} }

--- a/src/test/ui/nullable-pointer-size.rs
+++ b/src/test/ui/nullable-pointer-size.rs
@@ -31,5 +31,5 @@ macro_rules! check_type {
 pub fn main() {
     check_type!(&'static isize);
     check_type!(Box<isize>);
-    check_type!(extern fn());
+    check_type!(extern "C" fn());
 }

--- a/src/test/ui/osx-frameworks.rs
+++ b/src/test/ui/osx-frameworks.rs
@@ -1,8 +1,7 @@
 // ignore-macos this is supposed to succeed on osx
 
 #[link(name = "foo", kind = "framework")]
-extern {}
+extern "C" {}
 //~^^ ERROR: native frameworks are only available on macOS
 
-fn main() {
-}
+fn main() {}

--- a/src/test/ui/panic-runtime/auxiliary/panic-runtime-abort.rs
+++ b/src/test/ui/panic-runtime/auxiliary/panic-runtime-abort.rs
@@ -8,10 +8,10 @@
 #![panic_runtime]
 
 #[no_mangle]
-pub extern fn __rust_maybe_catch_panic() {}
+pub extern "C" fn __rust_maybe_catch_panic() {}
 
 #[no_mangle]
-pub extern fn __rust_start_panic() {}
+pub extern "C" fn __rust_start_panic() {}
 
 #[no_mangle]
-pub extern fn rust_eh_personality() {}
+pub extern "C" fn rust_eh_personality() {}

--- a/src/test/ui/panic-runtime/auxiliary/panic-runtime-unwind.rs
+++ b/src/test/ui/panic-runtime/auxiliary/panic-runtime-unwind.rs
@@ -8,10 +8,10 @@
 #![panic_runtime]
 
 #[no_mangle]
-pub extern fn __rust_maybe_catch_panic() {}
+pub extern "C" fn __rust_maybe_catch_panic() {}
 
 #[no_mangle]
-pub extern fn __rust_start_panic() {}
+pub extern "C" fn __rust_start_panic() {}
 
 #[no_mangle]
-pub extern fn rust_eh_personality() {}
+pub extern "C" fn rust_eh_personality() {}

--- a/src/test/ui/panic-runtime/auxiliary/panic-runtime-unwind2.rs
+++ b/src/test/ui/panic-runtime/auxiliary/panic-runtime-unwind2.rs
@@ -8,10 +8,10 @@
 #![panic_runtime]
 
 #[no_mangle]
-pub extern fn __rust_maybe_catch_panic() {}
+pub extern "C" fn __rust_maybe_catch_panic() {}
 
 #[no_mangle]
-pub extern fn __rust_start_panic() {}
+pub extern "C" fn __rust_start_panic() {}
 
 #[no_mangle]
-pub extern fn rust_eh_personality() {}
+pub extern "C" fn rust_eh_personality() {}

--- a/src/test/ui/parser/attrs-after-extern-mod.rs
+++ b/src/test/ui/parser/attrs-after-extern-mod.rs
@@ -2,6 +2,6 @@
 
 fn main() {}
 
-extern {
+extern "C" {
     #[cfg(stage37)] //~ ERROR expected item after attributes
 }

--- a/src/test/ui/parser/attrs-after-extern-mod.stderr
+++ b/src/test/ui/parser/attrs-after-extern-mod.stderr
@@ -1,8 +1,8 @@
 error: expected item after attributes
   --> $DIR/attrs-after-extern-mod.rs:6:5
    |
-LL | extern {
-   |        - while parsing this item list starting here
+LL | extern "C" {
+   |            - while parsing this item list starting here
 LL |     #[cfg(stage37)]
    |     ^^^^^^^^^^^^^^^
 LL | }

--- a/src/test/ui/parser/bad-lit-suffixes.stderr
+++ b/src/test/ui/parser/bad-lit-suffixes.stderr
@@ -110,5 +110,16 @@ LL |     1.0e10suffix;
    |
    = help: valid suffixes are `f32` and `f64`
 
-error: aborting due to 16 previous errors
+error: extern declarations without an explicit ABI are deprecated
+  --> $DIR/bad-lit-suffixes.rs:5:1
+   |
+LL | / extern
+LL | |     "C"suffix
+LL | | {}
+   | |__^ ABI should be specified here
+   |
+   = note: `#[deny(missing_abi)]` on by default
+   = help: the default ABI is C
+
+error: aborting due to 17 previous errors
 

--- a/src/test/ui/parser/bad-lit-suffixes.stderr
+++ b/src/test/ui/parser/bad-lit-suffixes.stderr
@@ -110,16 +110,5 @@ LL |     1.0e10suffix;
    |
    = help: valid suffixes are `f32` and `f64`
 
-error: extern declarations without an explicit ABI are deprecated
-  --> $DIR/bad-lit-suffixes.rs:5:1
-   |
-LL | / extern
-LL | |     "C"suffix
-LL | | {}
-   | |__^ ABI should be specified here
-   |
-   = note: `#[deny(missing_abi)]` on by default
-   = help: the default ABI is C
-
-error: aborting due to 17 previous errors
+error: aborting due to 16 previous errors
 

--- a/src/test/ui/parser/doc-before-extern-rbrace.rs
+++ b/src/test/ui/parser/doc-before-extern-rbrace.rs
@@ -1,6 +1,6 @@
 fn main() {}
 
-extern {
+extern "C" {
     /// hi
     //~^ ERROR found a documentation comment that doesn't document anything
 }

--- a/src/test/ui/parser/duplicate-visibility.rs
+++ b/src/test/ui/parser/duplicate-visibility.rs
@@ -1,6 +1,6 @@
 fn main() {}
 
-extern {
+extern "C" {
     pub pub fn foo();
     //~^ ERROR visibility `pub` is not followed by an item
     //~| ERROR non-item in item list

--- a/src/test/ui/parser/duplicate-visibility.stderr
+++ b/src/test/ui/parser/duplicate-visibility.stderr
@@ -9,8 +9,8 @@ LL |     pub pub fn foo();
 error: non-item in item list
   --> $DIR/duplicate-visibility.rs:4:9
    |
-LL | extern {
-   |        - item list starts here
+LL | extern "C" {
+   |            - item list starts here
 LL |     pub pub fn foo();
    |         ^^^ non-item starts here
 ...

--- a/src/test/ui/parser/extern-no-fn.rs
+++ b/src/test/ui/parser/extern-no-fn.rs
@@ -1,4 +1,4 @@
-extern {
+extern "C" {
     f(); //~ ERROR expected one of `!` or `::`, found `(`
 }
 

--- a/src/test/ui/parser/extern-no-fn.stderr
+++ b/src/test/ui/parser/extern-no-fn.stderr
@@ -1,8 +1,8 @@
 error: expected one of `!` or `::`, found `(`
   --> $DIR/extern-no-fn.rs:2:6
    |
-LL | extern {
-   |        - while parsing this item list starting here
+LL | extern "C" {
+   |            - while parsing this item list starting here
 LL |     f();
    |      ^ expected one of `!` or `::`
 LL | }

--- a/src/test/ui/parser/fn-body-eq-expr-semi.rs
+++ b/src/test/ui/parser/fn-body-eq-expr-semi.rs
@@ -5,7 +5,7 @@ fn syntax() {
     fn bar() -> u8 = 42; //~ ERROR function body cannot be `= expression;`
 }
 
-extern {
+extern "C" {
     fn foo() = 42; //~ ERROR function body cannot be `= expression;`
     //~^ ERROR incorrect function inside `extern` block
     fn bar() -> u8 = 42; //~ ERROR function body cannot be `= expression;`

--- a/src/test/ui/parser/fn-body-eq-expr-semi.stderr
+++ b/src/test/ui/parser/fn-body-eq-expr-semi.stderr
@@ -89,8 +89,8 @@ LL |     fn bar() -> u8 { 42 }
 error: incorrect function inside `extern` block
   --> $DIR/fn-body-eq-expr-semi.rs:9:8
    |
-LL | extern {
-   | ------ `extern` blocks define existing foreign functions and functions inside of them cannot have a body
+LL | extern "C" {
+   | ---------- `extern` blocks define existing foreign functions and functions inside of them cannot have a body
 LL |     fn foo() = 42;
    |        ^^^   ----- help: remove the invalid body: `;`
    |        |
@@ -102,8 +102,8 @@ LL |     fn foo() = 42;
 error: incorrect function inside `extern` block
   --> $DIR/fn-body-eq-expr-semi.rs:11:8
    |
-LL | extern {
-   | ------ `extern` blocks define existing foreign functions and functions inside of them cannot have a body
+LL | extern "C" {
+   | ---------- `extern` blocks define existing foreign functions and functions inside of them cannot have a body
 ...
 LL |     fn bar() -> u8 = 42;
    |        ^^^         ----- help: remove the invalid body: `;`

--- a/src/test/ui/parser/fn-body-optional-semantic-fail.rs
+++ b/src/test/ui/parser/fn-body-optional-semantic-fail.rs
@@ -20,7 +20,7 @@ fn main() {
         fn f4() {} // OK.
     }
 
-    extern {
+    extern "C" {
         fn f5(); // OK.
         fn f6() {} //~ ERROR incorrect function inside `extern` block
     }

--- a/src/test/ui/parser/fn-body-optional-semantic-fail.stderr
+++ b/src/test/ui/parser/fn-body-optional-semantic-fail.stderr
@@ -25,8 +25,8 @@ LL |         fn f3();
 error: incorrect function inside `extern` block
   --> $DIR/fn-body-optional-semantic-fail.rs:25:12
    |
-LL |     extern {
-   |     ------ `extern` blocks define existing foreign functions and functions inside of them cannot have a body
+LL |     extern "C" {
+   |     ---------- `extern` blocks define existing foreign functions and functions inside of them cannot have a body
 LL |         fn f5(); // OK.
 LL |         fn f6() {}
    |            ^^   -- help: remove the invalid body: `;`

--- a/src/test/ui/parser/fn-body-optional-syntactic-pass.rs
+++ b/src/test/ui/parser/fn-body-optional-syntactic-pass.rs
@@ -24,8 +24,8 @@ fn syntax() {
         fn f() {}
     }
 
-    extern {
+    extern "C" {
         fn f();
-        fn f() {}
+        fn f();
     }
 }

--- a/src/test/ui/parser/fn-header-semantic-fail.rs
+++ b/src/test/ui/parser/fn-header-semantic-fail.rs
@@ -47,7 +47,7 @@ fn main() {
         //~^ ERROR functions cannot be both `const` and `async`
     }
 
-    extern {
+    extern "C" {
         async fn fe1(); //~ ERROR functions in `extern` blocks cannot have qualifiers
         unsafe fn fe2(); //~ ERROR functions in `extern` blocks cannot have qualifiers
         const fn fe3(); //~ ERROR functions in `extern` blocks cannot have qualifiers

--- a/src/test/ui/parser/fn-header-semantic-fail.stderr
+++ b/src/test/ui/parser/fn-header-semantic-fail.stderr
@@ -105,8 +105,8 @@ LL |         const async unsafe extern "C" fn fi5() {}
 error: functions in `extern` blocks cannot have qualifiers
   --> $DIR/fn-header-semantic-fail.rs:51:18
    |
-LL |     extern {
-   |     ------ in this `extern` block
+LL |     extern "C" {
+   |     ---------- in this `extern` block
 LL |         async fn fe1();
    |                  ^^^
    |
@@ -118,8 +118,8 @@ LL |         fn fe1();
 error: functions in `extern` blocks cannot have qualifiers
   --> $DIR/fn-header-semantic-fail.rs:52:19
    |
-LL |     extern {
-   |     ------ in this `extern` block
+LL |     extern "C" {
+   |     ---------- in this `extern` block
 LL |         async fn fe1();
 LL |         unsafe fn fe2();
    |                   ^^^
@@ -132,8 +132,8 @@ LL |         fn fe2();
 error: functions in `extern` blocks cannot have qualifiers
   --> $DIR/fn-header-semantic-fail.rs:53:18
    |
-LL |     extern {
-   |     ------ in this `extern` block
+LL |     extern "C" {
+   |     ---------- in this `extern` block
 ...
 LL |         const fn fe3();
    |                  ^^^
@@ -146,8 +146,8 @@ LL |         fn fe3();
 error: functions in `extern` blocks cannot have qualifiers
   --> $DIR/fn-header-semantic-fail.rs:54:23
    |
-LL |     extern {
-   |     ------ in this `extern` block
+LL |     extern "C" {
+   |     ---------- in this `extern` block
 ...
 LL |         extern "C" fn fe4();
    |                       ^^^
@@ -160,8 +160,8 @@ LL |         fn fe4();
 error: functions in `extern` blocks cannot have qualifiers
   --> $DIR/fn-header-semantic-fail.rs:55:42
    |
-LL |     extern {
-   |     ------ in this `extern` block
+LL |     extern "C" {
+   |     ---------- in this `extern` block
 ...
 LL |         const async unsafe extern "C" fn fe5();
    |                                          ^^^

--- a/src/test/ui/parser/fn-header-syntactic-pass.rs
+++ b/src/test/ui/parser/fn-header-syntactic-pass.rs
@@ -37,11 +37,11 @@ fn syntax() {
         const async unsafe extern "C" fn f();
     }
 
-    extern {
-        async fn f();
-        unsafe fn f();
-        const fn f();
-        extern "C" fn f();
-        const async unsafe extern "C" fn f();
+    extern "C" {
+        fn f();
+        fn f();
+        fn f();
+        fn f();
+        fn f();
     }
 }

--- a/src/test/ui/parser/foreign-const-semantic-fail.rs
+++ b/src/test/ui/parser/foreign-const-semantic-fail.rs
@@ -1,6 +1,6 @@
 fn main() {}
 
-extern {
+extern "C" {
     const A: isize;
     //~^ ERROR extern items cannot be `const`
     const B: isize = 42;

--- a/src/test/ui/parser/foreign-const-semantic-fail.stderr
+++ b/src/test/ui/parser/foreign-const-semantic-fail.stderr
@@ -21,8 +21,8 @@ LL |     const B: isize = 42;
 error: incorrect `static` inside `extern` block
   --> $DIR/foreign-const-semantic-fail.rs:6:11
    |
-LL | extern {
-   | ------ `extern` blocks define existing foreign statics and statics inside of them cannot have a body
+LL | extern "C" {
+   | ---------- `extern` blocks define existing foreign statics and statics inside of them cannot have a body
 ...
 LL |     const B: isize = 42;
    |           ^          -- the invalid body

--- a/src/test/ui/parser/foreign-const-syntactic-fail.rs
+++ b/src/test/ui/parser/foreign-const-syntactic-fail.rs
@@ -3,7 +3,7 @@
 fn main() {}
 
 #[cfg(FALSE)]
-extern {
+extern "C" {
     const A: isize; //~ ERROR extern items cannot be `const`
     const B: isize = 42; //~ ERROR extern items cannot be `const`
 }

--- a/src/test/ui/parser/foreign-static-semantic-fail.rs
+++ b/src/test/ui/parser/foreign-static-semantic-fail.rs
@@ -2,7 +2,7 @@
 
 fn main() {}
 
-extern {
+extern "C" {
     static X: u8 = 0; //~ ERROR incorrect `static` inside `extern` block
     static mut Y: u8 = 0; //~ ERROR incorrect `static` inside `extern` block
 }

--- a/src/test/ui/parser/foreign-static-semantic-fail.stderr
+++ b/src/test/ui/parser/foreign-static-semantic-fail.stderr
@@ -1,8 +1,8 @@
 error: incorrect `static` inside `extern` block
   --> $DIR/foreign-static-semantic-fail.rs:6:12
    |
-LL | extern {
-   | ------ `extern` blocks define existing foreign statics and statics inside of them cannot have a body
+LL | extern "C" {
+   | ---------- `extern` blocks define existing foreign statics and statics inside of them cannot have a body
 LL |     static X: u8 = 0;
    |            ^       - the invalid body
    |            |
@@ -13,8 +13,8 @@ LL |     static X: u8 = 0;
 error: incorrect `static` inside `extern` block
   --> $DIR/foreign-static-semantic-fail.rs:7:16
    |
-LL | extern {
-   | ------ `extern` blocks define existing foreign statics and statics inside of them cannot have a body
+LL | extern "C" {
+   | ---------- `extern` blocks define existing foreign statics and statics inside of them cannot have a body
 LL |     static X: u8 = 0;
 LL |     static mut Y: u8 = 0;
    |                ^       - the invalid body

--- a/src/test/ui/parser/foreign-static-syntactic-pass.rs
+++ b/src/test/ui/parser/foreign-static-syntactic-pass.rs
@@ -5,7 +5,7 @@
 fn main() {}
 
 #[cfg(FALSE)]
-extern {
-    static X: u8 = 0;
-    static mut Y: u8 = 0;
+extern "C" {
+    static X: u8;
+    static mut Y: u8;
 }

--- a/src/test/ui/parser/no-const-fn-in-extern-block.rs
+++ b/src/test/ui/parser/no-const-fn-in-extern-block.rs
@@ -1,4 +1,4 @@
-extern {
+extern "C" {
     const fn foo();
     //~^ ERROR functions in `extern` blocks cannot have qualifiers
     const unsafe fn bar();

--- a/src/test/ui/parser/no-const-fn-in-extern-block.stderr
+++ b/src/test/ui/parser/no-const-fn-in-extern-block.stderr
@@ -1,8 +1,8 @@
 error: functions in `extern` blocks cannot have qualifiers
   --> $DIR/no-const-fn-in-extern-block.rs:2:14
    |
-LL | extern {
-   | ------ in this `extern` block
+LL | extern "C" {
+   | ---------- in this `extern` block
 LL |     const fn foo();
    |              ^^^
    |
@@ -14,8 +14,8 @@ LL |     fn foo();
 error: functions in `extern` blocks cannot have qualifiers
   --> $DIR/no-const-fn-in-extern-block.rs:4:21
    |
-LL | extern {
-   | ------ in this `extern` block
+LL | extern "C" {
+   | ---------- in this `extern` block
 ...
 LL |     const unsafe fn bar();
    |                     ^^^

--- a/src/test/ui/parser/self-param-semantic-fail.rs
+++ b/src/test/ui/parser/self-param-semantic-fail.rs
@@ -23,7 +23,7 @@ fn free() {
     //~^ ERROR `self` parameter is only allowed in associated functions
 }
 
-extern {
+extern "C" {
     fn f1(self);
     //~^ ERROR `self` parameter is only allowed in associated functions
     fn f2(mut self);
@@ -40,8 +40,8 @@ extern {
     fn f7(self: u8);
     //~^ ERROR `self` parameter is only allowed in associated functions
     fn f8(mut self: u8);
-    //~^ ERROR `self` parameter is only allowed in associated functions
-    //~| ERROR patterns aren't allowed in
+//~^ ERROR `self` parameter is only allowed in associated functions
+//~| ERROR patterns aren't allowed in
 }
 
 type X1 = fn(self);

--- a/src/test/ui/parser/self-param-syntactic-pass.rs
+++ b/src/test/ui/parser/self-param-syntactic-pass.rs
@@ -18,7 +18,7 @@ fn free() {
 }
 
 #[cfg(FALSE)]
-extern {
+extern "C" {
     fn f(self);
     fn f(mut self);
     fn f(&self);

--- a/src/test/ui/parser/unsafe-foreign-mod.rs
+++ b/src/test/ui/parser/unsafe-foreign-mod.rs
@@ -1,7 +1,3 @@
-unsafe extern {
-    //~^ ERROR extern block cannot be declared unsafe
-}
-
 unsafe extern "C" {
     //~^ ERROR extern block cannot be declared unsafe
 }

--- a/src/test/ui/parser/unsafe-foreign-mod.stderr
+++ b/src/test/ui/parser/unsafe-foreign-mod.stderr
@@ -1,14 +1,8 @@
 error: extern block cannot be declared unsafe
   --> $DIR/unsafe-foreign-mod.rs:1:1
    |
-LL | unsafe extern {
-   | ^^^^^^
-
-error: extern block cannot be declared unsafe
-  --> $DIR/unsafe-foreign-mod.rs:5:1
-   |
 LL | unsafe extern "C" {
    | ^^^^^^
 
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 

--- a/src/test/ui/parser/variadic-ffi-semantic-restrictions.rs
+++ b/src/test/ui/parser/variadic-ffi-semantic-restrictions.rs
@@ -20,22 +20,22 @@ extern "C" fn f2_3(..., x: isize) {}
 //~^ ERROR only foreign or `unsafe extern "C" functions may be C-variadic
 //~| ERROR `...` must be the last argument of a C-variadic function
 
-extern fn f3_1(x: isize, ...) {}
+extern "C" fn f3_1(x: isize, ...) {}
 //~^ ERROR only foreign or `unsafe extern "C" functions may be C-variadic
 
-extern fn f3_2(...) {}
+extern "C" fn f3_2(...) {}
 //~^ ERROR only foreign or `unsafe extern "C" functions may be C-variadic
 //~| ERROR C-variadic function must be declared with at least one named argument
 
-extern fn f3_3(..., x: isize) {}
+extern "C" fn f3_3(..., x: isize) {}
 //~^ ERROR only foreign or `unsafe extern "C" functions may be C-variadic
 //~| ERROR `...` must be the last argument of a C-variadic function
 
-extern {
+extern "C" {
     fn e_f1(...);
     //~^ ERROR C-variadic function must be declared with at least one named argument
     fn e_f2(..., x: isize);
-    //~^ ERROR `...` must be the last argument of a C-variadic function
+//~^ ERROR `...` must be the last argument of a C-variadic function
 }
 
 struct X;

--- a/src/test/ui/parser/variadic-ffi-semantic-restrictions.stderr
+++ b/src/test/ui/parser/variadic-ffi-semantic-restrictions.stderr
@@ -47,34 +47,34 @@ LL | extern "C" fn f2_3(..., x: isize) {}
    |                    ^^^
 
 error: only foreign or `unsafe extern "C" functions may be C-variadic
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:23:26
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:23:30
    |
-LL | extern fn f3_1(x: isize, ...) {}
-   |                          ^^^
+LL | extern "C" fn f3_1(x: isize, ...) {}
+   |                              ^^^
 
 error: C-variadic function must be declared with at least one named argument
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:26:16
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:26:20
    |
-LL | extern fn f3_2(...) {}
-   |                ^^^
+LL | extern "C" fn f3_2(...) {}
+   |                    ^^^
 
 error: only foreign or `unsafe extern "C" functions may be C-variadic
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:26:16
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:26:20
    |
-LL | extern fn f3_2(...) {}
-   |                ^^^
+LL | extern "C" fn f3_2(...) {}
+   |                    ^^^
 
 error: `...` must be the last argument of a C-variadic function
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:30:16
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:30:20
    |
-LL | extern fn f3_3(..., x: isize) {}
-   |                ^^^
+LL | extern "C" fn f3_3(..., x: isize) {}
+   |                    ^^^
 
 error: only foreign or `unsafe extern "C" functions may be C-variadic
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:30:16
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:30:20
    |
-LL | extern fn f3_3(..., x: isize) {}
-   |                ^^^
+LL | extern "C" fn f3_3(..., x: isize) {}
+   |                    ^^^
 
 error: C-variadic function must be declared with at least one named argument
   --> $DIR/variadic-ffi-semantic-restrictions.rs:35:13

--- a/src/test/ui/priv-in-bad-locations.rs
+++ b/src/test/ui/priv-in-bad-locations.rs
@@ -1,4 +1,4 @@
-pub extern { //~ ERROR unnecessary visibility qualifier
+pub extern "C" { //~ ERROR unnecessary visibility qualifier
     pub fn bar();
 }
 

--- a/src/test/ui/priv-in-bad-locations.stderr
+++ b/src/test/ui/priv-in-bad-locations.stderr
@@ -1,7 +1,7 @@
 error[E0449]: unnecessary visibility qualifier
   --> $DIR/priv-in-bad-locations.rs:1:1
    |
-LL | pub extern {
+LL | pub extern "C" {
    | ^^^ `pub` not permitted here because it's implied
    |
    = note: place qualifiers on individual foreign items instead

--- a/src/test/ui/privacy/privacy1.rs
+++ b/src/test/ui/privacy/privacy1.rs
@@ -61,7 +61,7 @@ mod bar {
         pub fn bar() {}
     }
 
-    extern {
+    extern "C" {
         fn epriv();
         pub fn epub();
     }

--- a/src/test/ui/privacy/private-in-public-warn.rs
+++ b/src/test/ui/privacy/private-in-public-warn.rs
@@ -29,7 +29,7 @@ mod types {
         fn f2() -> Priv { panic!() } //~ ERROR private type `types::Priv` in public interface
         //~^ WARNING hard error
     }
-    extern {
+    extern "C" {
         pub static ES: Priv; //~ ERROR private type `types::Priv` in public interface
         //~^ WARNING hard error
         pub fn ef1(arg: Priv); //~ ERROR private type `types::Priv` in public interface

--- a/src/test/ui/privacy/pub-extern-privacy.rs
+++ b/src/test/ui/privacy/pub-extern-privacy.rs
@@ -6,7 +6,7 @@
 use std::mem::transmute;
 
 mod a {
-    extern {
+    extern "C" {
         pub fn free(x: *const u8);
     }
 }

--- a/src/test/ui/proc-macro/macros-in-extern-derive.rs
+++ b/src/test/ui/proc-macro/macros-in-extern-derive.rs
@@ -1,4 +1,4 @@
-extern {
+extern "C" {
     #[derive(Copy)] //~ ERROR `derive` may only be applied to structs, enums and unions
     fn f();
 }

--- a/src/test/ui/proc-macro/macros-in-extern.rs
+++ b/src/test/ui/proc-macro/macros-in-extern.rs
@@ -11,12 +11,14 @@ fn main() {
 }
 
 #[link(name = "rust_test_helpers", kind = "static")]
-extern {
+extern "C" {
     #[empty_attr]
     fn some_definitely_unknown_symbol_which_should_be_removed();
 
     #[identity_attr]
     fn rust_get_test_int() -> isize;
 
-    identity!(fn rust_dbg_extern_identity_u32(arg: u32) -> u32;);
+    identity!(
+        fn rust_dbg_extern_identity_u32(arg: u32) -> u32;
+    );
 }

--- a/src/test/ui/proc-macro/signature.rs
+++ b/src/test/ui/proc-macro/signature.rs
@@ -7,7 +7,7 @@
 extern crate proc_macro;
 
 #[proc_macro_derive(A)]
-pub unsafe extern fn foo(a: i32, b: u32) -> u32 {
+pub unsafe extern "C" fn foo(a: i32, b: u32) -> u32 {
     //~^ ERROR: mismatched types
     loop {}
 }

--- a/src/test/ui/proc-macro/signature.stderr
+++ b/src/test/ui/proc-macro/signature.stderr
@@ -1,7 +1,7 @@
 error[E0308]: mismatched types
   --> $DIR/signature.rs:10:1
    |
-LL | / pub unsafe extern fn foo(a: i32, b: u32) -> u32 {
+LL | / pub unsafe extern "C" fn foo(a: i32, b: u32) -> u32 {
 LL | |
 LL | |     loop {}
 LL | | }

--- a/src/test/ui/proc-macro/span-preservation.rs
+++ b/src/test/ui/proc-macro/span-preservation.rs
@@ -35,7 +35,7 @@ fn c() {
 }
 
 #[recollect_attr]
-extern fn bar() {
+extern "C" fn bar() {
     0 //~ ERROR mismatched types
 }
 

--- a/src/test/ui/proc-macro/span-preservation.stderr
+++ b/src/test/ui/proc-macro/span-preservation.stderr
@@ -37,8 +37,8 @@ LL |     let y = Foo { a: 10, b: 10isize };
 error[E0308]: mismatched types
   --> $DIR/span-preservation.rs:39:5
    |
-LL | extern fn bar() {
-   |                 - possibly return type missing here?
+LL | extern "C" fn bar() {
+   |                     - possibly return type missing here?
 LL |     0
    |     ^ expected `()`, found integer
 

--- a/src/test/ui/range/issue-54505-no-std.rs
+++ b/src/test/ui/range/issue-54505-no-std.rs
@@ -13,7 +13,7 @@ use core::ops::RangeBounds;
 
 #[cfg(any(not(target_arch = "wasm32"), target_os = "emscripten"))]
 #[lang = "eh_personality"]
-extern fn eh_personality() {}
+extern "C" fn eh_personality() {}
 #[cfg(target_os = "emscripten")]
 #[lang = "eh_catch_typeinfo"]
 static EH_CATCH_TYPEINFO: u8 = 0;

--- a/src/test/ui/rfc-2008-non-exhaustive/improper_ctypes/extern_crate_improper.rs
+++ b/src/test/ui/rfc-2008-non-exhaustive/improper_ctypes/extern_crate_improper.rs
@@ -6,9 +6,9 @@ extern crate types;
 // This test checks that non-exhaustive types with `#[repr(C)]` from an extern crate are considered
 // improper.
 
-use types::{NonExhaustiveEnum, NormalStruct, UnitStruct, TupleStruct, NonExhaustiveVariants};
+use types::{NonExhaustiveEnum, NonExhaustiveVariants, NormalStruct, TupleStruct, UnitStruct};
 
-extern {
+extern "C" {
     pub fn non_exhaustive_enum(_: NonExhaustiveEnum);
     //~^ ERROR `extern` block uses type `NonExhaustiveEnum`, which is not FFI-safe
     pub fn non_exhaustive_normal_struct(_: NormalStruct);
@@ -21,4 +21,4 @@ extern {
     //~^ ERROR `extern` block uses type `NonExhaustiveVariants`, which is not FFI-safe
 }
 
-fn main() { }
+fn main() {}

--- a/src/test/ui/rfc-2008-non-exhaustive/improper_ctypes/same_crate_proper.rs
+++ b/src/test/ui/rfc-2008-non-exhaustive/improper_ctypes/same_crate_proper.rs
@@ -9,7 +9,7 @@
 pub enum NonExhaustiveEnum {
     Unit,
     Tuple(u32),
-    Struct { field: u32 }
+    Struct { field: u32 },
 }
 
 #[non_exhaustive]
@@ -25,16 +25,19 @@ pub struct UnitStruct;
 
 #[non_exhaustive]
 #[repr(C)]
-pub struct TupleStruct (pub u16, pub u16);
+pub struct TupleStruct(pub u16, pub u16);
 
 #[repr(C)]
 pub enum NonExhaustiveVariants {
-    #[non_exhaustive] Unit,
-    #[non_exhaustive] Tuple(u32),
-    #[non_exhaustive] Struct { field: u32 }
+    #[non_exhaustive]
+    Unit,
+    #[non_exhaustive]
+    Tuple(u32),
+    #[non_exhaustive]
+    Struct { field: u32 },
 }
 
-extern {
+extern "C" {
     // Unit structs aren't tested here because they will trigger `improper_ctypes` anyway.
     pub fn non_exhaustive_enum(_: NonExhaustiveEnum);
     pub fn non_exhaustive_normal_struct(_: NormalStruct);
@@ -42,4 +45,4 @@ extern {
     pub fn non_exhaustive_variant(_: NonExhaustiveVariants);
 }
 
-fn main() { }
+fn main() {}

--- a/src/test/ui/rfc-2627-raw-dylib/feature-gate-raw-dylib-2.rs
+++ b/src/test/ui/rfc-2627-raw-dylib/feature-gate-raw-dylib-2.rs
@@ -1,5 +1,5 @@
-#[link(name="foo")]
-extern {
+#[link(name = "foo")]
+extern "C" {
     #[link_ordinal(42)]
     //~^ ERROR: the `#[link_ordinal]` attribute is an experimental feature
     fn foo();

--- a/src/test/ui/rfc-2627-raw-dylib/feature-gate-raw-dylib.rs
+++ b/src/test/ui/rfc-2627-raw-dylib/feature-gate-raw-dylib.rs
@@ -1,5 +1,5 @@
-#[link(name="foo", kind="raw-dylib")]
+#[link(name = "foo", kind = "raw-dylib")]
 //~^ ERROR: kind="raw-dylib" is unstable
-extern {}
+extern "C" {}
 
 fn main() {}

--- a/src/test/ui/rfc-2627-raw-dylib/feature-gate-raw-dylib.stderr
+++ b/src/test/ui/rfc-2627-raw-dylib/feature-gate-raw-dylib.stderr
@@ -1,8 +1,8 @@
 error[E0658]: kind="raw-dylib" is unstable
   --> $DIR/feature-gate-raw-dylib.rs:1:1
    |
-LL | #[link(name="foo", kind="raw-dylib")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | #[link(name = "foo", kind = "raw-dylib")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #58713 <https://github.com/rust-lang/rust/issues/58713> for more information
    = help: add `#![feature(raw_dylib)]` to the crate attributes to enable

--- a/src/test/ui/rfc-2627-raw-dylib/link-ordinal-and-name.rs
+++ b/src/test/ui/rfc-2627-raw-dylib/link-ordinal-and-name.rs
@@ -2,7 +2,7 @@
 //~^ WARN the feature `raw_dylib` is incomplete
 
 #[link(name="foo")]
-extern {
+extern "C" {
     #[link_name="foo"]
     #[link_ordinal(42)]
     //~^ ERROR cannot use `#[link_name]` with `#[link_ordinal]`

--- a/src/test/ui/rfc-2627-raw-dylib/link-ordinal-invalid-format.rs
+++ b/src/test/ui/rfc-2627-raw-dylib/link-ordinal-invalid-format.rs
@@ -1,8 +1,8 @@
 #![feature(raw_dylib)]
 //~^ WARN the feature `raw_dylib` is incomplete
 
-#[link(name="foo")]
-extern {
+#[link(name = "foo")]
+extern "C" {
     #[link_ordinal("JustMonika")]
     //~^ ERROR illegal ordinal format in `link_ordinal`
     fn foo();

--- a/src/test/ui/rfc-2627-raw-dylib/link-ordinal-too-large.rs
+++ b/src/test/ui/rfc-2627-raw-dylib/link-ordinal-too-large.rs
@@ -1,8 +1,8 @@
 #![feature(raw_dylib)]
 //~^ WARN the feature `raw_dylib` is incomplete
 
-#[link(name="foo")]
-extern {
+#[link(name = "foo")]
+extern "C" {
     #[link_ordinal(18446744073709551616)]
     //~^ ERROR ordinal value in `link_ordinal` is too large: `18446744073709551616`
     fn foo();

--- a/src/test/ui/safe-extern-statics-mut.rs
+++ b/src/test/ui/safe-extern-statics-mut.rs
@@ -3,7 +3,7 @@
 extern crate extern_statics;
 use extern_statics::*;
 
-extern {
+extern "C" {
     static mut B: u8;
 }
 

--- a/src/test/ui/safe-extern-statics.rs
+++ b/src/test/ui/safe-extern-statics.rs
@@ -3,7 +3,7 @@
 extern crate extern_statics;
 use extern_statics::*;
 
-extern {
+extern "C" {
     static A: u8;
 }
 

--- a/src/test/ui/sepcomp/sepcomp-extern.rs
+++ b/src/test/ui/sepcomp/sepcomp-extern.rs
@@ -6,7 +6,7 @@
 
 extern crate sepcomp_extern_lib;
 
-extern {
+extern "C" {
     fn foo() -> usize;
 }
 

--- a/src/test/ui/signal-alternate-stack-cleanup.rs
+++ b/src/test/ui/signal-alternate-stack-cleanup.rs
@@ -13,11 +13,11 @@ extern crate libc;
 
 use libc::*;
 
-unsafe extern fn signal_handler(signum: c_int, _: *mut siginfo_t, _: *mut c_void) {
+unsafe extern "C" fn signal_handler(signum: c_int, _: *mut siginfo_t, _: *mut c_void) {
     assert_eq!(signum, SIGWINCH);
 }
 
-extern fn send_signal() {
+extern "C" fn send_signal() {
     unsafe {
         raise(SIGWINCH);
     }

--- a/src/test/ui/simple_global_asm.rs
+++ b/src/test/ui/simple_global_asm.rs
@@ -5,20 +5,26 @@
 #![allow(dead_code)]
 
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-global_asm!(r#"
+global_asm!(
+    r#"
     .global foo
     .global _foo
 foo:
 _foo:
     ret
-"#);
+"#
+);
 
-extern {
+extern "C" {
     fn foo();
 }
 
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-fn main() { unsafe { foo(); } }
+fn main() {
+    unsafe {
+        foo();
+    }
+}
 
 #[cfg(not(any(target_arch = "x86_64", target_arch = "x86")))]
 fn main() {}

--- a/src/test/ui/span/lint-unused-unsafe.rs
+++ b/src/test/ui/span/lint-unused-unsafe.rs
@@ -5,7 +5,7 @@
 
 
 mod foo {
-    extern {
+    extern "C" {
         pub fn bar();
     }
 }

--- a/src/test/ui/static/static-mut-foreign-requires-unsafe.rs
+++ b/src/test/ui/static/static-mut-foreign-requires-unsafe.rs
@@ -1,9 +1,9 @@
-extern {
+extern "C" {
     static mut a: i32;
 }
 
 fn main() {
-    a += 3;     //~ ERROR: requires unsafe
-    a = 4;      //~ ERROR: requires unsafe
+    a += 3; //~ ERROR: requires unsafe
+    a = 4; //~ ERROR: requires unsafe
     let _b = a; //~ ERROR: requires unsafe
 }

--- a/src/test/ui/static_sized_requirement.rs
+++ b/src/test/ui/static_sized_requirement.rs
@@ -7,6 +7,6 @@
 #[lang = "sized"]
 trait Sized {}
 
-extern {
+extern "C" {
     pub static A: u32;
 }

--- a/src/test/ui/stmt_expr_attrs_no_feature.rs
+++ b/src/test/ui/stmt_expr_attrs_no_feature.rs
@@ -89,7 +89,7 @@ item_mac!(e);
 
 // check that the gate visitor works right:
 
-extern {
+extern "C" {
     #[cfg(unset)]
     fn x(a: [u8; #[rustc_dummy] 5]);
     fn y(a: [u8; #[rustc_dummy] 5]); //~ ERROR attributes on expressions are experimental

--- a/src/test/ui/structs-enums/class-dtor.rs
+++ b/src/test/ui/structs-enums/class-dtor.rs
@@ -5,7 +5,7 @@
 // pretty-expanded FIXME #23616
 
 struct cat {
-  done : extern fn(usize),
+  done : extern "C" fn(usize),
   meows : usize,
 }
 
@@ -15,7 +15,7 @@ impl Drop for cat {
     }
 }
 
-fn cat(done: extern fn(usize)) -> cat {
+fn cat(done: extern "C" fn(usize)) -> cat {
     cat {
         meows: 0,
         done: done

--- a/src/test/ui/structs-enums/foreign-struct.rs
+++ b/src/test/ui/structs-enums/foreign-struct.rs
@@ -6,14 +6,14 @@
 
 // pretty-expanded FIXME #23616
 
-pub enum void { }
+pub enum void {}
 
 mod bindgen {
     use super::void;
 
-    extern {
+    extern "C" {
         pub fn printf(v: void);
     }
 }
 
-pub fn main() { }
+pub fn main() {}

--- a/src/test/ui/symbol-names/impl1.rs
+++ b/src/test/ui/symbol-names/impl1.rs
@@ -60,7 +60,7 @@ fn main() {
         }
 
         // Test type mangling, by putting them in an `impl` header.
-        impl Bar for [&'_ (dyn Foo<Assoc = extern fn(&u8, ...)> + AutoTrait); 3] {
+        impl Bar for [&'_ (dyn Foo<Assoc = extern "C" fn(&u8, ...)> + AutoTrait); 3] {
             #[rustc_symbol_name]
             //[legacy]~^ ERROR symbol-name(_ZN209_$LT$$u5b$$RF$dyn$u20$impl1..Foo$u2b$Assoc$u20$$u3d$$u20$extern$u20$$u22$C$u22$$u20$fn$LP$$RF$u8$C$$u20$...$RP$$u2b$impl1..AutoTrait$u3b$$u20$3$u5d$$u20$as$u20$impl1..main..$u7b$$u7b$closure$u7d$$u7d$..Bar$GT$6method
             //[legacy]~| ERROR demangling(<[&dyn impl1::Foo+Assoc = extern "C" fn(&u8, ::.)+impl1::AutoTrait; 3] as impl1::main::{{closure}}::Bar>::method

--- a/src/test/ui/threads-sendsync/thread-local-extern-static.rs
+++ b/src/test/ui/threads-sendsync/thread-local-extern-static.rs
@@ -11,7 +11,7 @@ extern crate thread_local_extern_static;
 use std::cell::Cell;
 
 #[cfg(target_thread_local)]
-extern {
+extern "C" {
     #[thread_local]
     static FOO: Cell<u32>;
 }

--- a/src/test/ui/type-param.rs
+++ b/src/test/ui/type-param.rs
@@ -6,6 +6,6 @@
 
 // pretty-expanded FIXME #23616
 
-type lteq<T> = extern fn(T) -> bool;
+type lteq<T> = extern "C" fn(T) -> bool;
 
 pub fn main() { }

--- a/src/test/ui/type-params-in-for-each.rs
+++ b/src/test/ui/type-params-in-for-each.rs
@@ -14,7 +14,7 @@ fn range_<F>(lo: usize, hi: usize, mut it: F) where F: FnMut(usize) {
     while lo_ < hi { it(lo_); lo_ += 1; }
 }
 
-fn create_index<T>(_index: Vec<S<T>> , _hash_fn: extern fn(T) -> usize) {
+fn create_index<T>(_index: Vec<S<T>> , _hash_fn: extern "C" fn(T) -> usize) {
     range_(0, 256, |_i| {
         let _bucket: Vec<T> = Vec::new();
     })

--- a/src/test/ui/unique/unique-ffi-symbols.rs
+++ b/src/test/ui/unique/unique-ffi-symbols.rs
@@ -3,12 +3,12 @@
 // whenever the item path wasn't enough to disambiguate between them.
 fn main() {
     let a = {
-        extern fn good() -> i32 { return 0; }
-        good as extern fn() -> i32
+        extern "C" fn good() -> i32 { return 0; }
+        good as extern "C" fn() -> i32
     };
     let b = {
-        extern fn good() -> i32 { return 5; }
-        good as extern fn() -> i32
+        extern "C" fn good() -> i32 { return 5; }
+        good as extern "C" fn() -> i32
     };
 
     assert!(a != b);

--- a/src/test/ui/warn-ctypes-inhibit.rs
+++ b/src/test/ui/warn-ctypes-inhibit.rs
@@ -4,14 +4,12 @@
 // compile-flags:-D improper-ctypes
 
 // pretty-expanded FIXME #23616
-
 #![allow(improper_ctypes)]
 
 mod libc {
-    extern {
+    extern "C" {
         pub fn malloc(size: isize) -> *const u8;
     }
 }
 
-pub fn main() {
-}
+pub fn main() {}

--- a/src/test/ui/wasm-import-module.rs
+++ b/src/test/ui/wasm-import-module.rs
@@ -1,10 +1,10 @@
 #[link(name = "...", wasm_import_module)] //~ ERROR: must be of the form
-extern {}
+extern "C" {}
 
 #[link(name = "...", wasm_import_module(x))] //~ ERROR: must be of the form
-extern {}
+extern "C" {}
 
 #[link(name = "...", wasm_import_module())] //~ ERROR: must be of the form
-extern {}
+extern "C" {}
 
 fn main() {}


### PR DESCRIPTION
This adds a new lint, missing_abi, which lints on omitted ABIs on extern blocks, function declarations, and function pointers.

It is currently not emitting the best possible diagnostics -- we need to track the span of "extern" at least or do some heuristic searching based on the available spans -- but seems good enough for an initial pass than can be expanded in future PRs.

This is a pretty large PR, but mostly due to updating a large number of tests to include ABIs; I can split that into a separate PR if it would be helpful, but test updates are already in dedicated commits.