### PR TITLE
Stabilize `IpAddr::is_ipv4` and `is_ipv6` as const

### DIFF
--- a/library/std/src/net/ip.rs
+++ b/library/std/src/net/ip.rs
@@ -263,8 +263,9 @@ impl IpAddr {
     /// assert_eq!(IpAddr::V4(Ipv4Addr::new(203, 0, 113, 6)).is_ipv4(), true);
     /// assert_eq!(IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 0)).is_ipv4(), false);
     /// ```
+    #[rustc_const_stable(feature = "const_ip", since = "1.48.0")]
     #[stable(feature = "ipaddr_checker", since = "1.16.0")]
-    pub fn is_ipv4(&self) -> bool {
+    pub const fn is_ipv4(&self) -> bool {
         matches!(self, IpAddr::V4(_))
     }
 
@@ -281,8 +282,9 @@ impl IpAddr {
     /// assert_eq!(IpAddr::V4(Ipv4Addr::new(203, 0, 113, 6)).is_ipv6(), false);
     /// assert_eq!(IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 0)).is_ipv6(), true);
     /// ```
+    #[rustc_const_stable(feature = "const_ip", since = "1.48.0")]
     #[stable(feature = "ipaddr_checker", since = "1.16.0")]
-    pub fn is_ipv6(&self) -> bool {
+    pub const fn is_ipv6(&self) -> bool {
         matches!(self, IpAddr::V6(_))
     }
 }

--- a/library/std/src/net/ip.rs
+++ b/library/std/src/net/ip.rs
@@ -263,7 +263,7 @@ impl IpAddr {
     /// assert_eq!(IpAddr::V4(Ipv4Addr::new(203, 0, 113, 6)).is_ipv4(), true);
     /// assert_eq!(IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 0)).is_ipv4(), false);
     /// ```
-    #[rustc_const_stable(feature = "const_ip", since = "1.48.0")]
+    #[rustc_const_stable(feature = "const_ip", since = "1.50.0")]
     #[stable(feature = "ipaddr_checker", since = "1.16.0")]
     pub const fn is_ipv4(&self) -> bool {
         matches!(self, IpAddr::V4(_))
@@ -282,7 +282,7 @@ impl IpAddr {
     /// assert_eq!(IpAddr::V4(Ipv4Addr::new(203, 0, 113, 6)).is_ipv6(), false);
     /// assert_eq!(IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 0)).is_ipv6(), true);
     /// ```
-    #[rustc_const_stable(feature = "const_ip", since = "1.48.0")]
+    #[rustc_const_stable(feature = "const_ip", since = "1.50.0")]
     #[stable(feature = "ipaddr_checker", since = "1.16.0")]
     pub const fn is_ipv6(&self) -> bool {
         matches!(self, IpAddr::V6(_))

--- a/src/test/ui/consts/std/net/ip.rs
+++ b/src/test/ui/consts/std/net/ip.rs
@@ -1,0 +1,13 @@
+// run-pass
+
+use std::net::{IpAddr, Ipv4Addr};
+
+fn main() {
+    const IP_ADDRESS : IpAddr = IpAddr::V4(Ipv4Addr::LOCALHOST);
+
+    const IS_IP_V4 : bool = IP_ADDRESS.is_ipv4();
+    assert!(IS_IP_V4);
+
+    const IS_IP_V6 : bool = IP_ADDRESS.is_ipv6();
+    assert!(!IS_IP_V6);
+}


### PR DESCRIPTION
Insta-stabilize the methods `is_ipv4` and `is_ipv6` of `std::net::IpAddr` as const, in the same way as [PR#76198](https://github.com/rust-lang/rust/pull/76198).

Possible because of the recent stabilization of const control flow.

Part of #76225 and #76205.