### PR TITLE
Avoid rehashing Fingerprint as a map key

### DIFF
--- a/compiler/rustc_data_structures/src/lib.rs
+++ b/compiler/rustc_data_structures/src/lib.rs
@@ -103,6 +103,7 @@ pub use atomic_ref::AtomicRef;
 pub mod frozen;
 pub mod tagged_ptr;
 pub mod temp_dir;
+pub mod unhash;
 
 pub struct OnDrop<F: Fn()>(pub F);
 

--- a/compiler/rustc_data_structures/src/unhash.rs
+++ b/compiler/rustc_data_structures/src/unhash.rs
@@ -1,0 +1,29 @@
+use std::collections::{HashMap, HashSet};
+use std::hash::{BuildHasherDefault, Hasher};
+
+pub type UnhashMap<K, V> = HashMap<K, V, BuildHasherDefault<Unhasher>>;
+pub type UnhashSet<V> = HashSet<V, BuildHasherDefault<Unhasher>>;
+
+/// This no-op hasher expects only a single `write_u64` call. It's intended for
+/// map keys that already have hash-like quality, like `Fingerprint`.
+#[derive(Default)]
+pub struct Unhasher {
+    value: u64,
+}
+
+impl Hasher for Unhasher {
+    #[inline]
+    fn finish(&self) -> u64 {
+        self.value
+    }
+
+    fn write(&mut self, _bytes: &[u8]) {
+        unimplemented!("use write_u64");
+    }
+
+    #[inline]
+    fn write_u64(&mut self, value: u64) {
+        debug_assert_eq!(0, self.value, "Unhasher doesn't mix values!");
+        self.value = value;
+    }
+}


### PR DESCRIPTION
This introduces a no-op `Unhasher` for map keys that are already hash-
like, for example `Fingerprint` and its wrapper `DefPathHash`. For these
we can directly produce the `u64` hash for maps. The first use of this
is `def_path_hash_to_def_id: Option<UnhashMap<DefPathHash, DefId>>`.

cc #56308
r? @eddyb 