### PR TITLE
Stabilize feature(binary_heap_into_iter_sorted)

### DIFF
--- a/library/alloc/src/collections/binary_heap.rs
+++ b/library/alloc/src/collections/binary_heap.rs
@@ -720,18 +720,27 @@ impl<T> BinaryHeap<T> {
     /// Returns an iterator which retrieves elements in heap order.
     /// This method consumes the original heap.
     ///
+    /// One good use for this is if you need the largest (or smallest) `k`
+    /// items from an iterator, but you're not sure exactly how many you'll
+    /// need -- just that `k` is much less than all of them -- so want to
+    /// compute those items on-demand.
+    ///
+    /// You could collect into a `Vec` and sort everything, but that's `O(n log n)`.
+    ///
+    /// By instead collecting into a `BinaryHeap` and using this method,
+    /// the complexity improves to `O(n + k log n)`.
+    ///
     /// # Examples
     ///
     /// Basic usage:
     ///
     /// ```
-    /// #![feature(binary_heap_into_iter_sorted)]
     /// use std::collections::BinaryHeap;
     /// let heap = BinaryHeap::from(vec![1, 2, 3, 4, 5]);
     ///
     /// assert_eq!(heap.into_iter_sorted().take(2).collect::<Vec<_>>(), vec![5, 4]);
     /// ```
-    #[unstable(feature = "binary_heap_into_iter_sorted", issue = "59278")]
+    #[stable(feature = "binary_heap_into_iter_sorted", since = "1.48.0")]
     pub fn into_iter_sorted(self) -> IntoIterSorted<T> {
         IntoIterSorted { inner: self }
     }
@@ -1173,13 +1182,20 @@ impl<T> ExactSizeIterator for IntoIter<T> {
 #[stable(feature = "fused", since = "1.26.0")]
 impl<T> FusedIterator for IntoIter<T> {}
 
-#[unstable(feature = "binary_heap_into_iter_sorted", issue = "59278")]
+/// An owning iterator over the elements of a `BinaryHeap`.
+///
+/// This `struct` is created by the [`into_iter_sorted`] method on [`BinaryHeap`].
+/// See its documentation for more.
+///
+/// [`into_iter_sorted`]: struct.BinaryHeap.html#method.into_iter_sorted
+/// [`BinaryHeap`]: struct.BinaryHeap.html
+#[stable(feature = "binary_heap_into_iter_sorted", since = "1.48.0")]
 #[derive(Clone, Debug)]
 pub struct IntoIterSorted<T> {
     inner: BinaryHeap<T>,
 }
 
-#[unstable(feature = "binary_heap_into_iter_sorted", issue = "59278")]
+#[stable(feature = "binary_heap_into_iter_sorted", since = "1.48.0")]
 impl<T: Ord> Iterator for IntoIterSorted<T> {
     type Item = T;
 
@@ -1195,10 +1211,10 @@ impl<T: Ord> Iterator for IntoIterSorted<T> {
     }
 }
 
-#[unstable(feature = "binary_heap_into_iter_sorted", issue = "59278")]
+#[stable(feature = "binary_heap_into_iter_sorted", since = "1.48.0")]
 impl<T: Ord> ExactSizeIterator for IntoIterSorted<T> {}
 
-#[unstable(feature = "binary_heap_into_iter_sorted", issue = "59278")]
+#[stable(feature = "binary_heap_into_iter_sorted", since = "1.48.0")]
 impl<T: Ord> FusedIterator for IntoIterSorted<T> {}
 
 #[unstable(feature = "trusted_len", issue = "37572")]

--- a/library/alloc/tests/lib.rs
+++ b/library/alloc/tests/lib.rs
@@ -9,7 +9,6 @@
 #![feature(try_reserve)]
 #![feature(unboxed_closures)]
 #![feature(associated_type_bounds)]
-#![feature(binary_heap_into_iter_sorted)]
 #![feature(binary_heap_drain_sorted)]
 #![feature(slice_ptr_get)]
 #![feature(split_inclusive)]


### PR DESCRIPTION
This came up on an itertools issue, and looks like it's baked sufficiently, so I figured I'd ask about stabilization.

This would stabilize the following API:
https://doc.rust-lang.org/nightly/std/collections/struct.BinaryHeap.html#method.into_iter_sorted
```
impl<T: Ord> BinaryHeap {
    fn into_iter_sorted(self) -> IntoIterSorted<T>;
}
impl<T: Ord> Iterator for IntoIterSorted<T> { type Item = T; }
impl<T: Ord> ExactSizeIterator for IntoIterSorted<T> ;
impl<T: Ord> FusedIterator for IntoIterSorted<T> ;
impl<T: Clone> Clone for IntoIterSorted<T>;
impl<T: Debug> Debug for IntoIterSorted<T>;
```

There were comments about wishing that the ordinary `.into_iter()` could just be the sorted one, but `.iter()` cannot be in that order so that's not necessarily good.  And anyways, `IntoIter` already implements `DoubleEndedIterator` so we can't really change the order even if we wanted to.

So I think the remaining potential questions are naming (it was originally proposed as `into_iter_ordered` but went in as `into_iter_sorted`, which I agree is more consistent with elsewhere in the library) and the standard whether this is useful enough (one could certainly use `from_fn` on the heap's pop, but that's potentially suboptimal as it doesn't have a `size_hint`).

This needs an FCP, so picking a libs member explicitly:
r? @KodrAus 

Tracking issue #59278 (which also covers a drain version which I've intentionally not included here)
