### PR TITLE
inliner: Avoid query cycles when optimizing generators

### DIFF
--- a/src/test/mir-opt/inline/inline-async.rs
+++ b/src/test/mir-opt/inline/inline-async.rs
@@ -1,0 +1,18 @@
+// Checks that inliner doesn't introduce cycles when optimizing generators.
+// The outcome of optimization is not verfied, just the absence of the cycle.
+// Regression test for #76181.
+//
+// edition:2018
+
+#![crate_type = "lib"]
+
+pub struct S;
+
+impl S {
+    pub async fn g(&mut self) {
+        self.h();
+    }
+    pub fn h(&mut self) {
+        let _ = self.g();
+    }
+}


### PR DESCRIPTION
The HIR Id trick is insufficient to prevent query cycles when optimizing
generators, since merely requesting a layout of a generator also
computes its `optimized_mir`.

Make no attempts to inline functions into generators within the same
crate to avoid query cycles.

Fixes #76181.