### PR TITLE
Skip CI when drafts are opened

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       SCCACHE_BUCKET: rust-lang-ci-sccache2
       TOOLSTATE_REPO: "https://github.com/rust-lang-nursery/rust-toolstate"
       CACHE_DOMAIN: ci-caches.rust-lang.org
-    if: "github.event_name == 'pull_request'"
+    if: "github.event_name == 'pull_request' && github.event.pull_request.draft == false"
     strategy:
       matrix:
         include:

--- a/src/ci/github-actions/ci.yml
+++ b/src/ci/github-actions/ci.yml
@@ -271,7 +271,7 @@ jobs:
     name: PR
     env:
       <<: [*shared-ci-variables, *public-variables]
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
     strategy:
       matrix:
         include:


### PR DESCRIPTION
There is no particular reason to run CI against an unfinished PR,
since it is likely the author already knows it will fail. When
the PR is no longer a draft later commits will cause CI to rerun,
and bors exists, so this should be no problem for workflows.

Resolves #67357