### PR TITLE
Allow try blocks as the argument to return expressions

### DIFF
--- a/compiler/rustc_ast/src/token.rs
+++ b/compiler/rustc_ast/src/token.rs
@@ -173,6 +173,7 @@ pub fn ident_can_begin_expr(name: Symbol, span: Span, is_raw: bool) -> bool {
             kw::Move,
             kw::Return,
             kw::True,
+            kw::Try,
             kw::Unsafe,
             kw::While,
             kw::Yield,

--- a/src/test/ui/try-block/try-block-in-return.rs
+++ b/src/test/ui/try-block/try-block-in-return.rs
@@ -1,0 +1,12 @@
+// run-pass
+// compile-flags: --edition 2018
+
+#![feature(try_blocks)]
+
+fn issue_76271() -> Option<i32> {
+    return try { 4 }
+}
+
+fn main() {
+    assert_eq!(issue_76271(), Some(4));
+}


### PR DESCRIPTION
Fixes #76271

I don't think this needs to be edition-aware (phew) since `return try` in 2015 is also the start of an expression, just with a struct literal instead of a block (`return try { x: 4, y: 5 }`).