### PR TITLE
Respect `-Z proc-macro-backtrace` flag for panics inside libproc_macro

### DIFF
--- a/src/test/ui-fulldeps/auxiliary/proc-macro-panic.rs
+++ b/src/test/ui-fulldeps/auxiliary/proc-macro-panic.rs
@@ -1,0 +1,13 @@
+// force-host
+// no-prefer-dynamic
+
+#![crate_type = "proc-macro"]
+
+extern crate proc_macro;
+use proc_macro::{TokenStream, Ident, Span};
+
+#[proc_macro]
+pub fn panic_in_libproc_macro(_: TokenStream) -> TokenStream {
+    Ident::new("", Span::call_site());
+    TokenStream::new()
+}

--- a/src/test/ui-fulldeps/issue-76270-panic-in-libproc-macro.rs
+++ b/src/test/ui-fulldeps/issue-76270-panic-in-libproc-macro.rs
@@ -1,0 +1,17 @@
+// aux-build:proc-macro-panic.rs
+// edition:2018
+// ignore-stage1
+// only-linux
+//
+// FIXME: This should be a normal (stage1, all platforms) test in
+// src/test/ui/proc-macro once issue #59998 is fixed.
+
+// Regression test for issue #76270
+// Tests that we don't print an ICE message when a panic
+// occurs in libproc-macro (when `-Z proc-macro-backtrace` is not specified)
+
+extern crate proc_macro_panic;
+
+proc_macro_panic::panic_in_libproc_macro!(); //~ ERROR proc macro panicked
+
+fn main() {}

--- a/src/test/ui-fulldeps/issue-76270-panic-in-libproc-macro.stderr
+++ b/src/test/ui-fulldeps/issue-76270-panic-in-libproc-macro.stderr
@@ -1,0 +1,10 @@
+error: proc macro panicked
+  --> $DIR/issue-76270-panic-in-libproc-macro.rs:15:1
+   |
+LL | proc_macro_panic::panic_in_libproc_macro!();
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: message: `""` is not a valid identifier
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Fixes #76270

Previously, any panic occuring during a call to a libproc_macro method
(e.g. calling `Ident::new` with an invalid identifier) would always
cause an ICE message to be printed.