### PR TITLE
Implementation of incompatible features error

### DIFF
--- a/compiler/rustc_feature/src/active.rs
+++ b/compiler/rustc_feature/src/active.rs
@@ -605,3 +605,8 @@ pub const INCOMPLETE_FEATURES: &[Symbol] = &[
     sym::lazy_normalization_consts,
     sym::specialization,
 ];
+
+/// Some features are not allowed to be used together at the same time, if
+/// the two are present, produce an error
+pub const INCOMPATIBLE_FEATURES: &[(Symbol, Symbol)] =
+    &[(sym::const_generics, sym::min_const_generics)];

--- a/compiler/rustc_feature/src/lib.rs
+++ b/compiler/rustc_feature/src/lib.rs
@@ -131,7 +131,7 @@ pub fn find_feature_issue(feature: Symbol, issue: GateIssue) -> Option<NonZeroU3
 }
 
 pub use accepted::ACCEPTED_FEATURES;
-pub use active::{Features, ACTIVE_FEATURES, INCOMPLETE_FEATURES};
+pub use active::{Features, ACTIVE_FEATURES, INCOMPATIBLE_FEATURES, INCOMPLETE_FEATURES};
 pub use builtin_attrs::{
     deprecated_attributes, find_gated_cfg, is_builtin_attr_name, AttributeGate, AttributeTemplate,
     AttributeType, BuiltinAttribute, GatedCfg, BUILTIN_ATTRIBUTES, BUILTIN_ATTRIBUTE_MAP,

--- a/src/test/ui/const-generics/min-and-full-same-time.rs
+++ b/src/test/ui/const-generics/min-and-full-same-time.rs
@@ -1,0 +1,7 @@
+#![feature(const_generics)]
+//~^ ERROR features `const_generics` and `min_const_generics` are incompatible
+#![allow(incomplete_features)]
+#![feature(min_const_generics)]
+
+
+fn main() {}

--- a/src/test/ui/const-generics/min-and-full-same-time.stderr
+++ b/src/test/ui/const-generics/min-and-full-same-time.stderr
@@ -1,0 +1,13 @@
+error: features `const_generics` and `min_const_generics` are incompatible, using them at the same time is not allowed
+  --> $DIR/min-and-full-same-time.rs:1:12
+   |
+LL | #![feature(const_generics)]
+   |            ^^^^^^^^^^^^^^
+...
+LL | #![feature(min_const_generics)]
+   |            ^^^^^^^^^^^^^^^^^^
+   |
+   = help: remove one of these features
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Proposal of a new error: Incompatible features

This error should happen if two features which are not compatible are used together.

For now the only incompatible features are `const_generics` and `min_const_generics`

fixes #76280