### PR TITLE
rustdoc: fix min_const_generics with ty::Param

### DIFF
--- a/src/test/rustdoc/const-generics/type-alias.rs
+++ b/src/test/rustdoc/const-generics/type-alias.rs
@@ -1,0 +1,6 @@
+// ignore-tidy-linelength
+#![feature(min_const_generics)]
+#![crate_name = "foo"]
+
+// @has foo/type.CellIndex.html '//pre[@class="rust typedef"]' 'type CellIndex<const D: usize> = [i64; D];'
+pub type CellIndex<const D: usize> = [i64; D];


### PR DESCRIPTION
fixes #75913

r? @varkor cc @jyn514 