### PR TITLE
Disable use of `--eh-frame-hdr` on wasm32.

### DIFF
--- a/compiler/rustc_target/src/spec/wasm32_base.rs
+++ b/compiler/rustc_target/src/spec/wasm32_base.rs
@@ -83,6 +83,7 @@ pub fn options() -> TargetOptions {
         dll_prefix: String::new(),
         dll_suffix: ".wasm".to_string(),
         linker_is_gnu: false,
+        eh_frame_header: false,
 
         max_atomic_width: Some(64),
 


### PR DESCRIPTION
Set wasm32's `TargetOptions::eh_frame_header` to false so that we don't pass `--eh-frame-hdr` to `wasm-ld`, which doesn't support that flag.

r? @alexcrichton 