### PR TITLE
time.rs: Make spelling of "Darwin" consistent

### DIFF
--- a/library/std/src/time.rs
+++ b/library/std/src/time.rs
@@ -159,7 +159,7 @@ pub struct Instant(time::Instant);
 /// | CloudABI  | [clock_time_get (Realtime Clock)]                                    |
 /// | SGX       | [`insecure_time` usercall]. More information on [timekeeping in SGX] |
 /// | UNIX      | [clock_gettime (Realtime Clock)]                                     |
-/// | DARWIN    | [gettimeofday]                                                       |
+/// | Darwin    | [gettimeofday]                                                       |
 /// | VXWorks   | [clock_gettime (Realtime Clock)]                                     |
 /// | WASI      | [__wasi_clock_time_get (Realtime Clock)]                             |
 /// | Windows   | [GetSystemTimePreciseAsFileTime] / [GetSystemTimeAsFileTime]         |


### PR DESCRIPTION
On line 89 of this file, the OS name is written as "Darwin", but on line 162 it is written in all-caps. Darwin is usually spelt as a standard proper noun, i.e. "Darwin", rather than in all-caps.

This change makes that form consistent in both places.