### PR TITLE
add `#[track_caller]` to `local_def_id_to_hir_id`

### DIFF
--- a/compiler/rustc_hir/src/definitions.rs
+++ b/compiler/rustc_hir/src/definitions.rs
@@ -313,6 +313,7 @@ impl Definitions {
     }
 
     #[inline]
+    #[track_caller]
     pub fn local_def_id_to_hir_id(&self, id: LocalDefId) -> hir::HirId {
         self.def_id_to_hir_id[id].unwrap()
     }


### PR DESCRIPTION
Improves one of the more frequent ICE