### PR TITLE
Fix rust.use-lld when linker is not set

### DIFF
--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -863,7 +863,12 @@ impl Build {
             && !target.contains("msvc")
         {
             Some(self.cc(target))
-        } else if can_use_lld && self.config.use_lld && self.build == target {
+        } else if target.contains("msvc")
+            && can_use_lld
+            && self.config.use_lld
+            && self.build == target
+        {
+            // Currently we support using LLD directly via `rust.use_lld` option only with MSVC
             Some(&self.initial_lld)
         } else {
             None


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/pull/76127#issuecomment-685419195

Previously when `[<target>].linker` was not configured `rust.use-lld` would set it to `rust-lld` on platforms where it should not.