### PR TITLE
Test structural matching for all range types

### DIFF
--- a/library/core/tests/ops.rs
+++ b/library/core/tests/ops.rs
@@ -1,4 +1,4 @@
-use core::ops::{Bound, Range, RangeFrom, RangeFull, RangeInclusive, RangeTo};
+use core::ops::{Bound, Range, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive};
 
 // Test the Range structs and syntax.
 
@@ -57,6 +57,12 @@ fn test_range_inclusive() {
     r = RangeInclusive::new(1, -1);
     assert_eq!(r.size_hint(), (0, Some(0)));
     assert_eq!(r.next(), None);
+}
+
+#[test]
+fn test_range_to_inclusive() {
+    // Not much to test.
+    let _ = RangeToInclusive { end: 42 };
 }
 
 #[test]
@@ -150,4 +156,44 @@ fn test_range_syntax_in_return_statement() {
         return ..;
     }
     // Not much to test.
+}
+
+#[test]
+fn range_structural_match() {
+    // test that all range types can be structurally matched upon
+
+    const RANGE: Range<usize> = 0..1000;
+    match RANGE {
+        RANGE => {}
+        _ => unreachable!(),
+    }
+
+    const RANGE_FROM: RangeFrom<usize> = 0..;
+    match RANGE_FROM {
+        RANGE_FROM => {}
+        _ => unreachable!(),
+    }
+
+    const RANGE_FULL: RangeFull = ..;
+    match RANGE_FULL {
+        RANGE_FULL => {}
+    }
+
+    const RANGE_INCLUSIVE: RangeInclusive<usize> = 0..=999;
+    match RANGE_INCLUSIVE {
+        RANGE_INCLUSIVE => {}
+        _ => unreachable!(),
+    }
+
+    const RANGE_TO: RangeTo<usize> = ..1000;
+    match RANGE_TO {
+        RANGE_TO => {}
+        _ => unreachable!(),
+    }
+
+    const RANGE_TO_INCLUSIVE: RangeToInclusive<usize> = ..=999;
+    match RANGE_TO_INCLUSIVE {
+        RANGE_TO_INCLUSIVE => {}
+        _ => unreachable!(),
+    }
 }


### PR DESCRIPTION
As of #70166 all range types (`core::ops::Range` etc.) can be structurally matched upon, and by extension used in const generics. In reference to the fact that this is a publicly observable property of these types, and thus falls under the Rust stability guarantees of the standard library, a regression test was added in #70283. 

This regression test was implemented by me by testing for the ability to use the range types within const generics, but that is not the actual property the std guarantees now (const generics is still unstable). This PR addresses that situation by adding extra tests for the range types that directly test whether they can be structurally matched upon.

Note: also adds the otherwise unrelated test `test_range_to_inclusive` for completeness with the other range unit tests