### PR TITLE
Improve docs for `std::env::args()`

### DIFF
--- a/library/std/src/env.rs
+++ b/library/std/src/env.rs
@@ -695,21 +695,21 @@ pub struct ArgsOs {
     inner: sys::args::Args,
 }
 
-/// Returns the arguments which this program was started with (normally passed
+/// Returns the arguments that this program was started with (normally passed
 /// via the command line).
 ///
 /// The first element is traditionally the path of the executable, but it can be
 /// set to arbitrary text, and may not even exist. This means this property should
 /// not be relied upon for security purposes.
 ///
-/// On Unix systems shell usually expands unquoted arguments with glob patterns
+/// On Unix systems the shell usually expands unquoted arguments with glob patterns
 /// (such as `*` and `?`). On Windows this is not done, and such arguments are
 /// passed as-is.
 ///
-/// On glibc Linux systems, arguments are retrieved by placing a function in ".init_array".
-/// Glibc passes argc, argv, and envp to functions in ".init_array", as a non-standard extension.
-/// This allows `std::env::args` to work even in a `cdylib` or `staticlib`, as it does on macOS
-/// and Windows.
+/// On glibc Linux systems, arguments are retrieved by placing a function in `.init_array`.
+/// Glibc passes `argc`, `argv`, and `envp` to functions in `.init_array`, as a non-standard
+/// extension. This allows `std::env::args` to work even in a `cdylib` or `staticlib`, as it
+/// does on macOS and Windows.
 ///
 /// # Panics
 ///


### PR DESCRIPTION
@rustbot modify labels: T-doc