### PR TITLE
Docs: nlink example typo

### DIFF
--- a/library/std/src/sys/unix/ext/fs.rs
+++ b/library/std/src/sys/unix/ext/fs.rs
@@ -428,7 +428,7 @@ pub trait MetadataExt {
     /// ```no_run
     /// use std::fs;
     /// use std::os::unix::fs::MetadataExt;
-    ///  use std::io;
+    /// use std::io;
     ///
     /// fn main() -> io::Result<()> {
     ///     let meta = fs::metadata("some_file")?;

--- a/library/std/src/sys/vxworks/ext/fs.rs
+++ b/library/std/src/sys/vxworks/ext/fs.rs
@@ -427,7 +427,7 @@ pub trait MetadataExt {
     /// ```no_run
     /// use std::fs;
     /// use std::os::unix::fs::MetadataExt;
-    ///  use std::io;
+    /// use std::io;
     ///
     /// fn main() -> io::Result<()> {
     ///     let meta = fs::metadata("some_file")?;


### PR DESCRIPTION
Small typo fix for the `nlink` function, extra whitespace before the `use` declaration