### PR TITLE
remove public visibility previously needed for rustfmt

### DIFF
--- a/compiler/rustc_expand/src/module.rs
+++ b/compiler/rustc_expand/src/module.rs
@@ -219,8 +219,7 @@ fn error_cannot_declare_mod_here<'a, T>(
 
 /// Derive a submodule path from the first found `#[path = "path_string"]`.
 /// The provided `dir_path` is joined with the `path_string`.
-// Public for rustfmt usage.
-pub fn submod_path_from_attr(
+pub(super) fn submod_path_from_attr(
     sess: &Session,
     attrs: &[Attribute],
     dir_path: &Path,


### PR DESCRIPTION
`submod_path_from_attr` in rustc_expand::module was previously public because it was also consumed by rustfmt. However, we've done a bit of refactoring in rustfmt and no longer need to use this function. 

This changes the visibility to the parent mod as was originally going to be done before the rustfmt dependency was realized (https://github.com/rust-lang/rust/commit/c189565edc5c9fc516170885b3a3061b936205fb#diff-cd1b379893bae95f7991d5a3f3c6d337R201)