### PR TITLE
Simpler diagnostic when passing arg to closure and missing borrow

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
@@ -685,6 +685,11 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                     _ => None,
                 };
 
+                let found_node = match found_did {
+                    Some(found_did) => self.tcx.hir().get_if_local(found_did),
+                    None => None,
+                };
+
                 let found_span = found_did
                     .and_then(|did| self.tcx.hir().span_if_local(did))
                     .map(|sp| self.tcx.sess.source_map().guess_head_span(sp)); // the sp could be an fn def
@@ -694,7 +699,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                     // but we want to complain about them only once.
                     return;
                 }
-
+ 
                 self.reported_closure_mismatch.borrow_mut().insert((span, found_span));
 
                 let found = match found_trait_ref.skip_binder().substs.type_at(1).kind() {
@@ -717,6 +722,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                         found_span,
                         found_trait_ref,
                         expected_trait_ref,
+                        found_node,
                     )
                 } else {
                     let (closure_span, found) = found_did


### PR DESCRIPTION
Hey! It's a working draft for the #64915 issue.
I've started it with help from @estebank but at this point, I have some questions, which I will be glad if someone will little clear it up a bit.
As @estebank suggested, I've done a small initial approach and the next steps are:

> If you look there that has an FnDecl with a field inputs that has data for each closure arg
> But this is on the HIR, which is the internal representation of what the user wrote, where the error deals in ty::Ty
> So we need to look at those, identify what the difference was
> Go back to the hir
> Find the argument type
> And extract the span of that type to add a & in front of it in the same way you already did

So I've got this FnDecl with an array of Ty's (but how to understand which ty from this array should I get, i mean borrow problem can be 2nd 3rd.. any argument in array?)

> error deals in ty::Ty
As I see, Ty has TyKind and I can be asked is it `Rptr`, but where to get another Ty to compare it `kinds`?

> Go back to the hir, Find the argument type
This is about TyKind, right?
