### PR TITLE
Disable atomics on avr target.

### DIFF
--- a/compiler/rustc_target/src/spec/avr_gnu_base.rs
+++ b/compiler/rustc_target/src/spec/avr_gnu_base.rs
@@ -45,6 +45,8 @@ pub fn target(target_cpu: String) -> TargetResult {
             late_link_args: vec![(LinkerFlavor::Gcc, vec!["-lgcc".to_owned()])]
                 .into_iter()
                 .collect(),
+            max_atomic_width: Some(0),
+            atomic_cas: false,
             ..TargetOptions::default()
         },
     })


### PR DESCRIPTION
`max_atomic_width` was missing in the spec, which means it fell back to the pointer width of 16 bits.

Fixes #76363.