### PR TITLE
Improve ayu doc source line number contrast

### DIFF
--- a/src/librustdoc/html/static/themes/ayu.css
+++ b/src/librustdoc/html/static/themes/ayu.css
@@ -129,9 +129,10 @@ pre {
 	color: #ffb44c;
 }
 
-.line-numbers span { color: #5c6773ab; }
+.line-numbers span { color: #5c6773; }
 .line-numbers .line-highlighted {
-	background-color: rgba(255, 236, 164, 0.06) !important;
+	color: #708090;
+	background-color: rgba(255, 236, 164, 0.06);
 	padding-right: 4px;
 	border-right: 1px solid #ffb44c;
 }


### PR DESCRIPTION
Improve contrast of foreground line number.

Before

![image](https://user-images.githubusercontent.com/4687791/92305696-1bf2ab80-efbc-11ea-8b5c-a24c4f6261e0.png)

After

![image](https://user-images.githubusercontent.com/4687791/92305700-2a40c780-efbc-11ea-9061-dbfcb1e71980.png)

r? @Cldfire 

I think we should add the line for light and dark theme too, it looks better and clearer that way.