### PR TITLE
rustbuild: Build tests with LLD if `use-lld = true` was passed

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -429,7 +429,7 @@
 # supported platforms. The LLD from the bootstrap distribution will be used
 # and not the LLD compiled during the bootstrap.
 #
-# LLD will not be used if we're cross linking or running tests.
+# LLD will not be used if we're cross linking.
 #
 # Explicitly setting the linker for a target will override this option when targeting MSVC.
 #use-lld = false

--- a/src/bootstrap/bin/rustc.rs
+++ b/src/bootstrap/bin/rustc.rs
@@ -112,6 +112,9 @@ fn main() {
         if let Ok(host_linker) = env::var("RUSTC_HOST_LINKER") {
             cmd.arg(format!("-Clinker={}", host_linker));
         }
+        if env::var_os("RUSTC_HOST_FUSE_LD_LLD").is_some() {
+            cmd.arg("-Clink-args=-fuse-ld=lld");
+        }
 
         if let Ok(s) = env::var("RUSTC_HOST_CRT_STATIC") {
             if s == "true" {

--- a/src/bootstrap/bin/rustdoc.rs
+++ b/src/bootstrap/bin/rustdoc.rs
@@ -42,10 +42,13 @@ fn main() {
     if env::var_os("RUSTC_FORCE_UNSTABLE").is_some() {
         cmd.arg("-Z").arg("force-unstable-if-unmarked");
     }
-    if let Some(linker) = env::var_os("RUSTC_TARGET_LINKER") {
+    if let Some(linker) = env::var_os("RUSTDOC_LINKER") {
         let mut arg = OsString::from("-Clinker=");
         arg.push(&linker);
         cmd.arg(arg);
+    }
+    if env::var_os("RUSTDOC_FUSE_LD_LLD").is_some() {
+        cmd.arg("-Clink-args=-fuse-ld=lld");
     }
 
     // Needed to be able to run all rustdoc tests.

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -756,7 +756,10 @@ impl<'a> Builder<'a> {
         cmd.env_remove("MFLAGS");
 
         if let Some(linker) = self.linker(compiler.host) {
-            cmd.env("RUSTC_TARGET_LINKER", linker);
+            cmd.env("RUSTDOC_LINKER", linker);
+        }
+        if self.config.use_lld && !compiler.host.contains("msvc") {
+            cmd.env("RUSTDOC_FUSE_LD_LLD", "1");
         }
         cmd
     }
@@ -1043,6 +1046,9 @@ impl<'a> Builder<'a> {
 
         if let Some(host_linker) = self.linker(compiler.host) {
             cargo.env("RUSTC_HOST_LINKER", host_linker);
+        }
+        if self.config.use_lld && !compiler.host.contains("msvc") {
+            cargo.env("RUSTC_HOST_FUSE_LD_LLD", "1");
         }
 
         if let Some(target_linker) = self.linker(target) {

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -755,7 +755,7 @@ impl<'a> Builder<'a> {
         cmd.env_remove("MAKEFLAGS");
         cmd.env_remove("MFLAGS");
 
-        if let Some(linker) = self.linker(compiler.host, true) {
+        if let Some(linker) = self.linker(compiler.host) {
             cmd.env("RUSTC_TARGET_LINKER", linker);
         }
         cmd
@@ -1041,11 +1041,11 @@ impl<'a> Builder<'a> {
             }
         }
 
-        if let Some(host_linker) = self.linker(compiler.host, true) {
+        if let Some(host_linker) = self.linker(compiler.host) {
             cargo.env("RUSTC_HOST_LINKER", host_linker);
         }
 
-        if let Some(target_linker) = self.linker(target, true) {
+        if let Some(target_linker) = self.linker(target) {
             let target = crate::envify(&target.triple);
             cargo.env(&format!("CARGO_TARGET_{}_LINKER", target), target_linker);
         }

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -758,7 +758,7 @@ impl<'a> Builder<'a> {
         if let Some(linker) = self.linker(compiler.host) {
             cmd.env("RUSTDOC_LINKER", linker);
         }
-        if self.config.use_lld && !compiler.host.contains("msvc") {
+        if self.is_fuse_ld_lld(compiler.host) {
             cmd.env("RUSTDOC_FUSE_LD_LLD", "1");
         }
         cmd
@@ -1047,7 +1047,7 @@ impl<'a> Builder<'a> {
         if let Some(host_linker) = self.linker(compiler.host) {
             cargo.env("RUSTC_HOST_LINKER", host_linker);
         }
-        if self.config.use_lld && !compiler.host.contains("msvc") {
+        if self.is_fuse_ld_lld(compiler.host) {
             cargo.env("RUSTC_HOST_FUSE_LD_LLD", "1");
         }
 
@@ -1055,8 +1055,7 @@ impl<'a> Builder<'a> {
             let target = crate::envify(&target.triple);
             cargo.env(&format!("CARGO_TARGET_{}_LINKER", target), target_linker);
         }
-
-        if self.config.use_lld && !target.contains("msvc") {
+        if self.is_fuse_ld_lld(target) {
             rustflags.arg("-Clink-args=-fuse-ld=lld");
         }
 

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -863,13 +863,17 @@ impl Build {
             && !target.contains("msvc")
         {
             Some(self.cc(target))
-        } else if target.contains("msvc") && self.config.use_lld && self.build == target {
-            // `rust.use_lld` means using LLD directly only for MSVC, for other targets it only
-            // adds `-fuse-ld=lld` to already selected linker.
+        } else if self.config.use_lld && !self.is_fuse_ld_lld(target) && self.build == target {
             Some(&self.initial_lld)
         } else {
             None
         }
+    }
+
+    // LLD is used through `-fuse-ld=lld` rather than directly.
+    // Only MSVC targets use LLD directly at the moment.
+    fn is_fuse_ld_lld(&self, target: TargetSelection) -> bool {
+        self.config.use_lld && !target.contains("msvc")
     }
 
     /// Returns if this target should statically link the C runtime, if specified

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -850,7 +850,7 @@ impl Build {
     }
 
     /// Returns the path to the linker for the given target if it needs to be overridden.
-    fn linker(&self, target: TargetSelection, can_use_lld: bool) -> Option<&Path> {
+    fn linker(&self, target: TargetSelection) -> Option<&Path> {
         if let Some(linker) = self.config.target_config.get(&target).and_then(|c| c.linker.as_ref())
         {
             Some(linker)
@@ -863,12 +863,9 @@ impl Build {
             && !target.contains("msvc")
         {
             Some(self.cc(target))
-        } else if target.contains("msvc")
-            && can_use_lld
-            && self.config.use_lld
-            && self.build == target
-        {
-            // Currently we support using LLD directly via `rust.use_lld` option only with MSVC
+        } else if target.contains("msvc") && self.config.use_lld && self.build == target {
+            // `rust.use_lld` means using LLD directly only for MSVC, for other targets it only
+            // adds `-fuse-ld=lld` to already selected linker.
             Some(&self.initial_lld)
         } else {
             None

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -600,7 +600,7 @@ impl Step for RustdocTheme {
             .env("CFG_RELEASE_CHANNEL", &builder.config.channel)
             .env("RUSTDOC_REAL", builder.rustdoc(self.compiler))
             .env("RUSTC_BOOTSTRAP", "1");
-        if let Some(linker) = builder.linker(self.compiler.host, true) {
+        if let Some(linker) = builder.linker(self.compiler.host) {
             cmd.env("RUSTC_TARGET_LINKER", linker);
         }
         try_run(builder, &mut cmd);
@@ -1061,8 +1061,7 @@ impl Step for Compiletest {
         flags.push("-Zunstable-options".to_string());
         flags.push(builder.config.cmd.rustc_args().join(" "));
 
-        // Don't use LLD here since we want to test that rustc finds and uses a linker by itself.
-        if let Some(linker) = builder.linker(target, false) {
+        if let Some(linker) = builder.linker(target) {
             cmd.arg("--linker").arg(linker);
         }
 

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -601,7 +601,10 @@ impl Step for RustdocTheme {
             .env("RUSTDOC_REAL", builder.rustdoc(self.compiler))
             .env("RUSTC_BOOTSTRAP", "1");
         if let Some(linker) = builder.linker(self.compiler.host) {
-            cmd.env("RUSTC_TARGET_LINKER", linker);
+            cmd.env("RUSTDOC_LINKER", linker);
+        }
+        if builder.config.use_lld && !self.compiler.host.contains("msvc") {
+            cmd.env("RUSTDOC_FUSE_LD_LLD", "1");
         }
         try_run(builder, &mut cmd);
     }

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -603,7 +603,7 @@ impl Step for RustdocTheme {
         if let Some(linker) = builder.linker(self.compiler.host) {
             cmd.env("RUSTDOC_LINKER", linker);
         }
-        if builder.config.use_lld && !self.compiler.host.contains("msvc") {
+        if builder.is_fuse_ld_lld(self.compiler.host) {
             cmd.env("RUSTDOC_FUSE_LD_LLD", "1");
         }
         try_run(builder, &mut cmd);
@@ -1070,14 +1070,14 @@ impl Step for Compiletest {
 
         let mut hostflags = flags.clone();
         hostflags.push(format!("-Lnative={}", builder.test_helpers_out(compiler.host).display()));
-        if builder.config.use_lld && !compiler.host.triple.contains("msvc") {
+        if builder.is_fuse_ld_lld(compiler.host) {
             hostflags.push("-Clink-args=-fuse-ld=lld".to_string());
         }
         cmd.arg("--host-rustcflags").arg(hostflags.join(" "));
 
         let mut targetflags = flags;
         targetflags.push(format!("-Lnative={}", builder.test_helpers_out(target).display()));
-        if builder.config.use_lld && !target.contains("msvc") {
+        if builder.is_fuse_ld_lld(target) {
             targetflags.push("-Clink-args=-fuse-ld=lld".to_string());
         }
         cmd.arg("--target-rustcflags").arg(targetflags.join(" "));

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -1067,10 +1067,16 @@ impl Step for Compiletest {
 
         let mut hostflags = flags.clone();
         hostflags.push(format!("-Lnative={}", builder.test_helpers_out(compiler.host).display()));
+        if builder.config.use_lld && !compiler.host.triple.contains("msvc") {
+            hostflags.push("-Clink-args=-fuse-ld=lld".to_string());
+        }
         cmd.arg("--host-rustcflags").arg(hostflags.join(" "));
 
         let mut targetflags = flags;
         targetflags.push(format!("-Lnative={}", builder.test_helpers_out(target).display()));
+        if builder.config.use_lld && !target.contains("msvc") {
+            targetflags.push("-Clink-args=-fuse-ld=lld".to_string());
+        }
         cmd.arg("--target-rustcflags").arg(targetflags.join(" "));
 
         cmd.arg("--docck-python").arg(builder.python());

--- a/src/test/run-make-fulldeps/tools.mk
+++ b/src/test/run-make-fulldeps/tools.mk
@@ -11,8 +11,8 @@ BARE_RUSTDOC := $(HOST_RPATH_ENV) '$(RUSTDOC)'
 RUSTC := $(BARE_RUSTC) --out-dir $(TMPDIR) -L $(TMPDIR) $(RUSTFLAGS)
 RUSTDOC := $(BARE_RUSTDOC) -L $(TARGET_RPATH_DIR)
 ifdef RUSTC_LINKER
-RUSTC := $(RUSTC) -Clinker=$(RUSTC_LINKER)
-RUSTDOC := $(RUSTDOC) -Clinker=$(RUSTC_LINKER)
+RUSTC := $(RUSTC) -Clinker='$(RUSTC_LINKER)'
+RUSTDOC := $(RUSTDOC) -Clinker='$(RUSTC_LINKER)'
 endif
 #CC := $(CC) -L $(TMPDIR)
 HTMLDOCCK := '$(PYTHON)' '$(S)/src/etc/htmldocck.py'


### PR DESCRIPTION
Addresses https://github.com/rust-lang/rust/pull/76127#discussion_r479932392.

Our test suite is generally ready to run with an explicitly specified linker (https://github.com/rust-lang/rust/pull/45191),
 so LLD specified with `use-lld = true` works as well.

Only 4 tests fail (on `x86_64-pc-windows-msvc`):
```
ui/panic-runtime/lto-unwind.rs
run-make-fulldeps/debug-assertions
run-make-fulldeps/foreign-exceptions
run-make-fulldeps/test-harness
```
All of them are legitimate issues with LLD (or at least with combination Rust+LLD) and manifest in segfaults on access to TLS (https://github.com/rust-lang/rust/pull/76127#issuecomment-683473325). UPD: These issues are caused by https://github.com/rust-lang/rust/issues/72145 and appear because I had `-Ctarget-cpu=native` set.

UPD: Further commits build tests with LLD for non-MSVC targets and propagate LLD to more places when `use-lld` is enabled.