### PR TITLE
debuginfo:  Ignore HashMap .natvis tests before cdb 10.0.18362.1

### DIFF
--- a/src/test/debuginfo/pretty-std-collections-hash.rs
+++ b/src/test/debuginfo/pretty-std-collections-hash.rs
@@ -1,3 +1,7 @@
+// CDB doesn't like how libstd.natvis casts to tuples before this version.
+// https://github.com/rust-lang/rust/issues/76352#issuecomment-687640746
+// min-cdb-version: 10.0.18362.1
+
 // cdb-only
 // compile-flags:-g
 

--- a/src/tools/compiletest/src/common.rs
+++ b/src/tools/compiletest/src/common.rs
@@ -261,6 +261,9 @@ pub struct Config {
     /// Path to / name of the Microsoft Console Debugger (CDB) executable
     pub cdb: Option<OsString>,
 
+    /// Version of CDB
+    pub cdb_version: Option<[u16; 4]>,
+
     /// Path to / name of the GDB executable
     pub gdb: Option<String>,
 


### PR DESCRIPTION
CDB <10.0.18362.1 chokes on casts within HashMap's natvis visualizers.  This PR adds support for "min-cdb-version" (per existing "min-gdb-version" and "min-lldb-version" filters) and uses it.  CI uses a more recent version of CDB for testing and thus should still run the tests.

Credit to @petrochenkov per https://github.com/rust-lang/rust/issues/76352 for helping catch this.

### SDK Testing

| Win 10 SDK                                                             |  x64 CDB          | rustc 1.47.0-nightly (bf4342114 2020-08-25) built-in .natvis  | Note |
| --------------------------------------------------------------------- | ----------------- | ------------------------------------------------------------- | ---- |
| [10.0.19041.0](https://go.microsoft.com/fwlink/p/?linkid=2120843)     | 10.0.19041.1      | ✔️                                                            | CI
| [10.0.18362.1](https://go.microsoft.com/fwlink/?linkid=2083338)       | 10.0.18362.1      | ✔️                                                            | MaulingMonkey
| [10.0.17763.0](https://go.microsoft.com/fwlink/p/?LinkID=2033908)     | 10.0.17763.132    | ❌ `Unable to find type 'tuple<u64,u64> *' for cast.`
| [10.0.17134.12](https://go.microsoft.com/fwlink/p/?linkid=870807)     | 10.0.17134.12     | ❌ `Unable to find type 'tuple<u64,u64> *' for cast.`
| [10.0.16299.91](https://go.microsoft.com/fwlink/p/?linkid=864422)     | 10.0.16299.91     | ❌ `Unable to find type 'tuple<u64,u64> *' for cast.`
| [10.0.15063.468](https://go.microsoft.com/fwlink/p/?LinkId=845298)    | 10.0.15063.468    | ❌ `Unable to find type 'tuple<u64,u64> *' for cast.`
| [10.0.14393.795](https://go.microsoft.com/fwlink/p/?LinkId=838916)    | 10.0.14321.1024   | ❌ `Unable to find type 'tuple<u64,u64> *' for cast.` | petrochenkov
| [10.0.10586.212](https://go.microsoft.com/fwlink/p/?LinkID=698771)    | 10.0.10586.567    | ❌ `Expected ')' at '+ 1)].__1'`
| [10.0.10240](https://go.microsoft.com/fwlink/p/?LinkId=619296)        | 10.0.10240?       | ❔ Untested

### Rust Testing

```cmd
x.py test --stage 1 src/tools/tidy
x.py test --stage 1 --build x86_64-pc-windows-msvc src\test\debuginfo
```

Also verified test still fails when intentionally broken w/ CDB version >= min-cdb-version.
