### PR TITLE
Fix dangling reference during Arc deallocation

### DIFF
--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -140,6 +140,7 @@
 #![feature(try_trait)]
 #![feature(type_alias_impl_trait)]
 #![feature(associated_type_bounds)]
+#![feature(atomic_mut_ptr)]
 // Allow testing this library
 
 #[cfg(test)]

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -1416,7 +1416,26 @@ unsafe impl<#[may_dangle] T: ?Sized> Drop for Arc<T> {
         // Because `fetch_sub` is already atomic, we do not need to synchronize
         // with other threads unless we are going to delete the object. This
         // same logic applies to the below `fetch_sub` to the `weak` count.
-        if self.inner().strong.fetch_sub(1, Release) != 1 {
+        //
+        // However, we have a slight problem taking references here. Reference
+        // pointers are marked in ABI to be always valid for dereferencing. But
+        // after decrementing the atomic another thread may deallocate the memory
+        // block while the `&self` argument of `fetch_sub` still points to it.
+        //
+        // ```
+        // pub fn fetch_sub(&self, val: $int_type, order: Ordering) -> $int_type {
+        //     unsafe { atomic_sub(self.v.get(), val, order) }
+        //     // HERE
+        // }
+        // ```
+        //
+        // To avoid this situation we do not pass a reference to the atomic to any method and
+        // instead use the intrinsic on the pointer.
+        if {
+            let strong = self.inner().strong.as_mut_ptr();
+            let prev = unsafe { core::intrinsics::atomic_xsub_rel(strong, 1) };
+            prev != 1
+        } {
             return;
         }
 
@@ -1905,7 +1924,13 @@ impl<T: ?Sized> Drop for Weak<T> {
         // ref, which can only happen after the lock is released.
         let inner = if let Some(inner) = self.inner() { inner } else { return };
 
-        if inner.weak.fetch_sub(1, Release) == 1 {
+        if {
+            // Do not use `fetch_sub` of the atomic to avoid asserting that it is valid to
+            // dereference this memory after the operation. See Arc::drop() for a discussion.
+            let weak = inner.weak.as_mut_ptr();
+            let prev = unsafe { core::intrinsics::atomic_xsub_rel(weak, 1) };
+            prev == 1
+        } {
             acquire!(inner.weak);
             unsafe { Global.dealloc(self.ptr.cast(), Layout::for_value(self.ptr.as_ref())) }
         }


### PR DESCRIPTION
This implements roughly what was proposed as Option 1 and in [this comment](https://github.com/rust-lang/rust/issues/55005#issuecomment-644409424), using a raw pointer-based atomic access to side-step the issue for now. But it does so in an even more immediate manner by not increasing the interface of atomics. If a design is added it would be logical to switch.