### PR TITLE
Add help note to unconstrained const parameter

### DIFF
--- a/src/test/ui/const-generics/issues/issue-68366.rs
+++ b/src/test/ui/const-generics/issues/issue-68366.rs
@@ -1,0 +1,18 @@
+// Checks that const expressions have a useful note explaining why they can't be evaluated.
+// The note should relate to the fact that it cannot be shown forall N that it maps 1-1 to a new
+// type.
+
+#![feature(const_generics)]
+#![allow(incomplete_features)]
+
+struct Collatz<const N: Option<usize>>;
+
+impl <const N: usize> Collatz<{Some(N)}> {}
+//~^ ERROR the const parameter
+
+struct Foo;
+
+impl<const N: usize> Foo {}
+//~^ ERROR the const parameter
+
+fn main() {}

--- a/src/test/ui/const-generics/issues/issue-68366.stderr
+++ b/src/test/ui/const-generics/issues/issue-68366.stderr
@@ -1,0 +1,21 @@
+error[E0207]: the const parameter `N` is not constrained by the impl trait, self type, or predicates
+  --> $DIR/issue-68366.rs:10:13
+   |
+LL | impl <const N: usize> Collatz<{Some(N)}> {}
+   |             ^ unconstrained const parameter
+   |
+   = note: expressions using a const parameter must map each value to a distinct output value
+   = note: proving the result of expressions other than the parameter are unique is not supported
+
+error[E0207]: the const parameter `N` is not constrained by the impl trait, self type, or predicates
+  --> $DIR/issue-68366.rs:15:12
+   |
+LL | impl<const N: usize> Foo {}
+   |            ^ unconstrained const parameter
+   |
+   = note: expressions using a const parameter must map each value to a distinct output value
+   = note: proving the result of expressions other than the parameter are unique is not supported
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0207`.


### PR DESCRIPTION
Resolves #68366, since it is currently intended behaviour.
If demonstrating `T -> U` is injective, there should be an additional word that it is not **yet** supported.

r? @lcnr 

