### PR TITLE
Update linker-plugin-lto.md to contain up to rust 1.46

### DIFF
--- a/src/doc/rustc/src/linker-plugin-lto.md
+++ b/src/doc/rustc/src/linker-plugin-lto.md
@@ -100,20 +100,20 @@ LLVM. However, the approximation is usually reliable.
 
 The following table shows known good combinations of toolchain versions.
 
-|           |  Clang 7  |  Clang 8  |  Clang 9  |  Clang 10 |
-|-----------|-----------|-----------|-----------|-----------|
-| Rust 1.34 |     ✗     |     ✓     |     ✗     |     ✗     |
-| Rust 1.35 |     ✗     |     ✓     |     ✗     |     ✗     |
-| Rust 1.36 |     ✗     |     ✓     |     ✗     |     ✗     |
-| Rust 1.37 |     ✗     |     ✓     |     ✗     |     ✗     |
-| Rust 1.38 |     ✗     |     ✗     |     ✓     |     ✗     |
-| Rust 1.39 |     ✗     |     ✗     |     ✓     |     ✗     |
-| Rust 1.40 |     ✗     |     ✗     |     ✓     |     ✗     |
-| Rust 1.41 |     ✗     |     ✗     |     ✓     |     ✗     |
-| Rust 1.42 |     ✗     |     ✗     |     ✓     |     ✗     |
-| Rust 1.43 |     ✗     |     ✗     |     ✓     |     ✗     |
-| Rust 1.44 |     ✗     |     ✗     |     ✓     |     ✗     |
-| Rust 1.45 |     ✗     |     ✗     |     ✗     |     ✓     |
-| Rust 1.46 |     ✗     |     ✗     |     ✗     |     ✓     |
+| Rust Version | Clang Version |
+|--------------|---------------|
+| Rust 1.34    |    Clang 8    |
+| Rust 1.35    |    Clang 8    |
+| Rust 1.36    |    Clang 8    |
+| Rust 1.37    |    Clang 8    |
+| Rust 1.38    |    Clang 9    |
+| Rust 1.39    |    Clang 9    |
+| Rust 1.40    |    Clang 9    |
+| Rust 1.41    |    Clang 9    |
+| Rust 1.42    |    Clang 9    |
+| Rust 1.43    |    Clang 9    |
+| Rust 1.44    |    Clang 9    |
+| Rust 1.45    |    Clang 10   |
+| Rust 1.46    |    Clang 10   |
 
 Note that the compatibility policy for this feature might change in the future.

--- a/src/doc/rustc/src/linker-plugin-lto.md
+++ b/src/doc/rustc/src/linker-plugin-lto.md
@@ -100,17 +100,20 @@ LLVM. However, the approximation is usually reliable.
 
 The following table shows known good combinations of toolchain versions.
 
-|           |  Clang 7  |  Clang 8  |  Clang 9  |
-|-----------|-----------|-----------|-----------|
-| Rust 1.34 |     ✗     |     ✓     |     ✗     |
-| Rust 1.35 |     ✗     |     ✓     |     ✗     |
-| Rust 1.36 |     ✗     |     ✓     |     ✗     |
-| Rust 1.37 |     ✗     |     ✓     |     ✗     |
-| Rust 1.38 |     ✗     |     ✗     |     ✓     |
-| Rust 1.39 |     ✗     |     ✗     |     ✓     |
-| Rust 1.40 |     ✗     |     ✗     |     ✓     |
-| Rust 1.41 |     ✗     |     ✗     |     ✓     |
-| Rust 1.42 |     ✗     |     ✗     |     ✓     |
-| Rust 1.43 |     ✗     |     ✗     |     ✓     |
+|           |  Clang 7  |  Clang 8  |  Clang 9  |  Clang 10 |
+|-----------|-----------|-----------|-----------|-----------|
+| Rust 1.34 |     ✗     |     ✓     |     ✗     |     ✗     |
+| Rust 1.35 |     ✗     |     ✓     |     ✗     |     ✗     |
+| Rust 1.36 |     ✗     |     ✓     |     ✗     |     ✗     |
+| Rust 1.37 |     ✗     |     ✓     |     ✗     |     ✗     |
+| Rust 1.38 |     ✗     |     ✗     |     ✓     |     ✗     |
+| Rust 1.39 |     ✗     |     ✗     |     ✓     |     ✗     |
+| Rust 1.40 |     ✗     |     ✗     |     ✓     |     ✗     |
+| Rust 1.41 |     ✗     |     ✗     |     ✓     |     ✗     |
+| Rust 1.42 |     ✗     |     ✗     |     ✓     |     ✗     |
+| Rust 1.43 |     ✗     |     ✗     |     ✓     |     ✗     |
+| Rust 1.44 |     ✗     |     ✗     |     ✓     |     ✗     |
+| Rust 1.45 |     ✗     |     ✗     |     ✗     |     ✓     |
+| Rust 1.46 |     ✗     |     ✗     |     ✗     |     ✓     |
 
 Note that the compatibility policy for this feature might change in the future.


### PR DESCRIPTION
Hi,
this is the same as https://github.com/rust-lang/rust/pull/72290, if anyone has suggestions on how to automate this please say :)
otherwise, you can check the versions I've added via:

```sh
$ rustup install 1.44.0
$ rustc +1.44.0 -Vv
rustc 1.44.0 (49cae5576 2020-06-01)
binary: rustc
commit-hash: 49cae55760da0a43428eba73abcb659bb70cf2e4
commit-date: 2020-06-01
host: x86_64-unknown-linux-gnu
release: 1.44.0
LLVM version: 9.0

$ rustup install 1.45.0
$ rustc +1.45.0 -Vv
rustc 1.45.0 (5c1f21c3b 2020-07-13)
binary: rustc
commit-hash: 5c1f21c3b82297671ad3ae1e8c942d2ca92e84f2
commit-date: 2020-07-13
host: x86_64-unknown-linux-gnu
release: 1.45.0
LLVM version: 10.0

$ rustup install 1.46.0
$ rustc +stable -Vv
rustc 1.46.0 (04488afe3 2020-08-24)
binary: rustc
commit-hash: 04488afe34512aa4c33566eb16d8c912a3ae04f9
commit-date: 2020-08-24
host: x86_64-unknown-linux-gnu
release: 1.46.0
LLVM version: 10.0
```