### PR TITLE
Fix documentation for TyCtxt::all_impls

### DIFF
--- a/compiler/rustc_middle/src/ty/trait_def.rs
+++ b/compiler/rustc_middle/src/ty/trait_def.rs
@@ -167,7 +167,7 @@ impl<'tcx> TyCtxt<'tcx> {
         }
     }
 
-    /// Returns a vector containing all impls
+    /// Returns an iterator containing all impls
     pub fn all_impls(self, def_id: DefId) -> impl Iterator<Item = DefId> + 'tcx {
         let TraitImpls { blanket_impls, non_blanket_impls } = self.trait_impls_of(def_id);
 


### PR DESCRIPTION
`TyCtxt::all_impls` documentation was wrong about the return type.