### PR TITLE
Set `incremental = true` in config.toml.example

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -368,9 +368,11 @@
 #backtrace = true
 
 # Whether to always use incremental compilation when building rustc
-#incremental = false
+# Defaults to `false`, but it's recommended that contributors set it to `true`.
+incremental = true
 
 # Build a multi-threaded rustc
+# FIXME(#75760): Some UI tests fail when this option is enabled.
 #parallel-compiler = false
 
 # The default linker that will be hard-coded into the generated compiler for


### PR DESCRIPTION
This does not affect any x.py defaults, or any contributors that have an
existing config.toml. It only affects the settings for new contributors.

This has been recommended by rustc-dev-guide for many months.
I'm not aware of people running into much trouble with it and it saves
an *enormous* amount of time when recompiling. It also requires
recompiling all of `rustc` when changed.

r? @Mark-Simulacrum 