### PR TITLE
Add aarch64-unknown-linux-musl host builds

### DIFF
--- a/src/ci/docker/host-x86_64/dist-arm-linux/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-arm-linux/Dockerfile
@@ -6,6 +6,14 @@ RUN sh /scripts/cross-apt-packages.sh
 COPY scripts/crosstool-ng-1.24.sh /scripts/
 RUN sh /scripts/crosstool-ng-1.24.sh
 
+WORKDIR /build
+
+COPY scripts/musl-toolchain.sh /build/
+# We need to mitigate rust-lang/rust#34978 when compiling musl itself as well
+RUN CFLAGS="-Wa,--compress-debug-sections=none -Wl,--compress-debug-sections=none" \
+    CXXFLAGS="-Wa,--compress-debug-sections=none -Wl,--compress-debug-sections=none" \
+    bash musl-toolchain.sh aarch64 && rm -rf build
+
 COPY scripts/rustbuild-setup.sh /scripts/
 RUN sh /scripts/rustbuild-setup.sh
 USER rustbuild
@@ -25,7 +33,8 @@ ENV CC_arm_unknown_linux_gnueabi=arm-unknown-linux-gnueabi-gcc \
     AR_arm_unknown_linux_gnueabi=arm-unknown-linux-gnueabi-ar \
     CXX_arm_unknown_linux_gnueabi=arm-unknown-linux-gnueabi-g++
 
-ENV HOSTS=arm-unknown-linux-gnueabi
+ENV HOSTS=arm-unknown-linux-gnueabi,aarch64-unknown-linux-musl
 
-ENV RUST_CONFIGURE_ARGS --enable-full-tools --disable-docs
+ENV RUST_CONFIGURE_ARGS --enable-full-tools --disable-docs --musl-root-aarch64=/usr/local/aarch64-linux-musl \
+    --set target.aarch64-unknown-linux-musl.crt-static=false
 ENV SCRIPT python3 ../x.py dist --host $HOSTS --target $HOSTS

--- a/src/ci/docker/host-x86_64/dist-arm-linux/arm-linux-gnueabi.config
+++ b/src/ci/docker/host-x86_64/dist-arm-linux/arm-linux-gnueabi.config
@@ -14,6 +14,7 @@ CT_CONFIGURE_has_autoconf_2_65_or_newer=y
 CT_CONFIGURE_has_autoreconf_2_65_or_newer=y
 CT_CONFIGURE_has_automake_1_15_or_newer=y
 CT_CONFIGURE_has_gnu_m4_1_4_12_or_newer=y
+CT_CONFIGURE_has_python_3_4_or_newer=y
 CT_CONFIGURE_has_bison_2_7_or_newer=y
 CT_CONFIGURE_has_python=y
 CT_CONFIGURE_has_git=y
@@ -132,12 +133,6 @@ CT_ARCH_ARM=y
 # CT_ARCH_XTENSA is not set
 CT_ARCH="arm"
 CT_ARCH_CHOICE_KSYM="ARM"
-# CT_ARCH_ALPHA_EV4 is not set
-# CT_ARCH_ALPHA_EV45 is not set
-# CT_ARCH_ALPHA_EV5 is not set
-# CT_ARCH_ALPHA_EV56 is not set
-# CT_ARCH_ALPHA_EV6 is not set
-# CT_ARCH_ALPHA_EV67 is not set
 CT_ARCH_CPU=""
 CT_ARCH_TUNE=""
 CT_ARCH_ARM_SHOW=y
@@ -371,8 +366,6 @@ CT_ALL_BINUTILS_CHOICES="BINUTILS"
 # C-library
 #
 CT_LIBC_GLIBC=y
-# CT_LIBC_NEWLIB is not set
-# CT_LIBC_NONE is not set
 # CT_LIBC_UCLIBC is not set
 CT_LIBC="glibc"
 CT_LIBC_CHOICE_KSYM="GLIBC"
@@ -389,6 +382,7 @@ CT_GLIBC_USE="GLIBC"
 CT_GLIBC_PKG_NAME="glibc"
 CT_GLIBC_SRC_RELEASE=y
 CT_GLIBC_PATCH_ORDER="global"
+# CT_GLIBC_V_2_29 is not set
 # CT_GLIBC_V_2_28 is not set
 # CT_GLIBC_V_2_27 is not set
 # CT_GLIBC_V_2_26 is not set
@@ -407,7 +401,6 @@ CT_GLIBC_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"
 CT_GLIBC_SIGNATURE_FORMAT="packed/.sig"
 CT_GLIBC_2_29_or_older=y
 CT_GLIBC_older_than_2_29=y
-CT_GLIBC_REQUIRE_older_than_2_29=y
 CT_GLIBC_2_27_or_older=y
 CT_GLIBC_older_than_2_27=y
 CT_GLIBC_2_26_or_older=y
@@ -447,12 +440,6 @@ CT_GLIBC_FORCE_UNWIND=y
 CT_GLIBC_KERNEL_VERSION_AS_HEADERS=y
 # CT_GLIBC_KERNEL_VERSION_CHOSEN is not set
 CT_GLIBC_MIN_KERNEL="3.2.101"
-# CT_GLIBC_SSP_DEFAULT is not set
-# CT_GLIBC_SSP_NO is not set
-# CT_GLIBC_SSP_YES is not set
-# CT_GLIBC_SSP_ALL is not set
-# CT_GLIBC_SSP_STRONG is not set
-# CT_NEWLIB_USE_REDHAT is not set
 CT_ALL_LIBC_CHOICES="AVR_LIBC BIONIC GLIBC MINGW_W64 MOXIEBOX MUSL NEWLIB NONE UCLIBC"
 CT_LIBC_SUPPORT_THREADS_ANY=y
 CT_LIBC_SUPPORT_THREADS_NATIVE=y

--- a/src/ci/docker/host-x86_64/dist-various-1/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-various-1/Dockerfile
@@ -84,10 +84,6 @@ RUN env \
     CXX=arm-linux-gnueabihf-g++ CXXFLAGS="-march=armv7-a" \
     bash musl.sh armv7hf && \
     env \
-    CC=aarch64-linux-gnu-gcc \
-    CXX=aarch64-linux-gnu-g++ \
-    bash musl.sh aarch64 && \
-    env \
     CC=mips-openwrt-linux-gcc \
     CXX=mips-openwrt-linux-g++ \
     bash musl.sh mips && \
@@ -130,7 +126,6 @@ ENV TARGETS=$TARGETS,arm-unknown-linux-musleabihf
 ENV TARGETS=$TARGETS,armv5te-unknown-linux-gnueabi
 ENV TARGETS=$TARGETS,armv5te-unknown-linux-musleabi
 ENV TARGETS=$TARGETS,armv7-unknown-linux-musleabihf
-ENV TARGETS=$TARGETS,aarch64-unknown-linux-musl
 ENV TARGETS=$TARGETS,aarch64-unknown-none
 ENV TARGETS=$TARGETS,aarch64-unknown-none-softfloat
 ENV TARGETS=$TARGETS,sparc64-unknown-linux-gnu
@@ -185,7 +180,6 @@ ENV RUST_CONFIGURE_ARGS \
       --musl-root-arm=/musl-arm \
       --musl-root-armhf=/musl-armhf \
       --musl-root-armv7hf=/musl-armv7hf \
-      --musl-root-aarch64=/musl-aarch64 \
       --musl-root-mips=/musl-mips \
       --musl-root-mipsel=/musl-mipsel \
       --musl-root-mips64=/musl-mips64 \

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -62,7 +62,7 @@ target | std | host | notes
 `aarch64-linux-android` | ✓ |  | ARM64 Android
 `aarch64-pc-windows-msvc` | ✓ |  | ARM64 Windows MSVC
 `aarch64-unknown-linux-gnu` | ✓ | ✓ | ARM64 Linux (kernel 4.2, glibc 2.17)
-`aarch64-unknown-linux-musl` | ✓ |  | ARM64 Linux with MUSL
+`aarch64-unknown-linux-musl` | ✓ | ✓ | ARM64 Linux with MUSL
 `aarch64-unknown-none` | * |  | Bare ARM64, hardfloat
 `aarch64-unknown-none-softfloat` | * |  | Bare ARM64, softfloat
 `arm-linux-androideabi` | ✓ |  | ARMv7 Android

--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -16,6 +16,7 @@ use std::process::{Command, Stdio};
 
 static HOSTS: &[&str] = &[
     "aarch64-unknown-linux-gnu",
+    "aarch64-unknown-linux-musl",
     "arm-unknown-linux-gnueabi",
     "arm-unknown-linux-gnueabihf",
     "armv7-unknown-linux-gnueabihf",


### PR DESCRIPTION
This adds aarch64-unknown-linux-musl to the hosts list and adds the build to the dist-arm-linux builder as @Mark-Simulacrum suggested to me in Zulip. @jyn514 requested to be mentioned :smile: 

I had to update the config for crosstool-ng as it had a prompt about the glibc version.

I ran `src/ci/docker/run.sh dist-arm-linux` to test it.

```
Build completed successfully in 1:31:50
Compile requests              8180
Compile requests executed     8135
Cache hits                     287
Cache misses                  7848
Cache timeouts                   0
Cache read errors                0
Forced recaches                  0
Cache write errors               0
Compilation failures             0
Cache errors                     0
Non-cacheable compilations       0
Non-cacheable calls             36
Non-compilation calls            9
Unsupported compiler calls       0
Average cache write          0.000 s
Average cache read miss      6.389 s
Average cache read hit       0.000 s
Cache location             Local disk: "/sccache"
Cache size                     202 MiB
Max cache size                  10 GiB
== clock drift check ==
  local time: Sun Sep  6 19:30:17 UTC 2020
  network time: Sun, 06 Sep 2020 19:30:17 GMT
== end clock drift check ==
```

Only errors were in miri due to struct fields being private (already been reported [here](https://github.com/rust-lang/rust/issues/76337))

Edit: Maybe it is helpful if I add that it is a working compiler
```sh
/rust-nightly-aarch64-unknown-linux-musl # ash install.sh 
install: creating uninstall script at /usr/local/lib/rustlib/uninstall.sh
install: installing component 'rustc'
install: installing component 'cargo'
install: installing component 'rls-preview'
install: installing component 'rust-analyzer-preview'
install: installing component 'clippy-preview'
install: installing component 'rustfmt-preview'
install: installing component 'llvm-tools-preview'
install: installing component 'rust-analysis-aarch64-unknown-linux-musl'
install: installing component 'rust-std-aarch64-unknown-linux-musl'
install: WARNING: failed to run ldconfig. this may happen when not installing as root. run with --verbose to see the error

    Rust is ready to roll.

/ # cat test.rs 
fn main() { println!("hello world"); }
/ # rustc test.rs
/ # ./test
hello world
 # file test
test: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, not stripped
```