### PR TITLE
[Experimental] Performance test new paging-based measureme data sink.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1868,6 +1868,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "measureme"
+version = "0.8.0"
+source = "git+https://github.com/michaelwoerister/measureme.git?branch=paged_sinks#26d150475c8d83613beffe970d1c18dd2494f607"
+dependencies = [
+ "memmap",
+ "parking_lot 0.11.0",
+ "rustc-hash",
+]
+
+[[package]]
 name = "memchr"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2954,7 +2964,7 @@ dependencies = [
  "jobserver",
  "lazy_static",
  "libc",
- "measureme",
+ "measureme 0.7.1",
  "parking_lot 0.10.2",
  "rustc-ap-rustc_graphviz",
  "rustc-ap-rustc_index",
@@ -3358,7 +3368,7 @@ version = "0.0.0"
 dependencies = [
  "bitflags",
  "libc",
- "measureme",
+ "measureme 0.8.0",
  "rustc-demangle",
  "rustc_ast",
  "rustc_attr",
@@ -3423,7 +3433,7 @@ dependencies = [
  "indexmap",
  "jobserver",
  "libc",
- "measureme",
+ "measureme 0.8.0",
  "parking_lot 0.10.2",
  "rustc-hash",
  "rustc-rayon",
@@ -3726,7 +3736,7 @@ version = "0.0.0"
 dependencies = [
  "bitflags",
  "chalk-ir",
- "measureme",
+ "measureme 0.8.0",
  "polonius-engine",
  "rustc-rayon-core",
  "rustc_apfloat",

--- a/compiler/rustc_codegen_llvm/Cargo.toml
+++ b/compiler/rustc_codegen_llvm/Cargo.toml
@@ -11,7 +11,7 @@ doctest = false
 [dependencies]
 bitflags = "1.0"
 libc = "0.2"
-measureme = "0.7.1"
+measureme = { git = "https://github.com/michaelwoerister/measureme.git", branch = "paged_sinks" }
 snap = "1"
 tracing = "0.1"
 rustc_middle = { path = "../rustc_middle" }

--- a/compiler/rustc_data_structures/Cargo.toml
+++ b/compiler/rustc_data_structures/Cargo.toml
@@ -24,7 +24,7 @@ rustc-hash = "1.1.0"
 smallvec = { version = "1.0", features = ["union", "may_dangle"] }
 rustc_index = { path = "../rustc_index", package = "rustc_index" }
 bitflags = "1.2.1"
-measureme = "0.7.1"
+measureme = { git = "https://github.com/michaelwoerister/measureme.git", branch = "paged_sinks" }
 libc = "0.2"
 stacker = "0.1.11"
 tempfile = "3.0.5"

--- a/compiler/rustc_data_structures/src/profiling.rs
+++ b/compiler/rustc_data_structures/src/profiling.rs
@@ -100,12 +100,12 @@ use parking_lot::RwLock;
 cfg_if! {
     if #[cfg(any(windows, target_os = "wasi"))] {
         /// FileSerializationSink is faster on Windows
-        type SerializationSink = measureme::FileSerializationSink;
+        type SerializationSink = measureme::FileSinkConfig;
     } else if #[cfg(target_arch = "wasm32")] {
         type SerializationSink = measureme::ByteVecSink;
     } else {
         /// MmapSerializatioSink is faster on macOS and Linux
-        type SerializationSink = measureme::MmapSerializationSink;
+        type SerializationSink = measureme::PagedSinkConfig;
     }
 }
 
@@ -400,7 +400,7 @@ impl SelfProfiler {
         output_directory: &Path,
         crate_name: Option<&str>,
         event_filters: &Option<Vec<String>>,
-    ) -> Result<SelfProfiler, Box<dyn Error>> {
+    ) -> Result<SelfProfiler, Box<dyn Error + 'static + Send + Sync>> {
         fs::create_dir_all(output_directory)?;
 
         let crate_name = crate_name.unwrap_or("unknown-crate");

--- a/compiler/rustc_data_structures/src/profiling.rs
+++ b/compiler/rustc_data_structures/src/profiling.rs
@@ -105,7 +105,7 @@ cfg_if! {
         type SerializationSink = measureme::ByteVecSink;
     } else {
         /// MmapSerializatioSink is faster on macOS and Linux
-        type SerializationSink = measureme::PagedSinkConfig;
+        type SerializationSink = measureme::PagedSinkConfig2;
     }
 }
 

--- a/compiler/rustc_middle/Cargo.toml
+++ b/compiler/rustc_middle/Cargo.toml
@@ -28,5 +28,5 @@ rustc_ast = { path = "../rustc_ast" }
 rustc_span = { path = "../rustc_span" }
 chalk-ir = "0.21.0"
 smallvec = { version = "1.0", features = ["union", "may_dangle"] }
-measureme = "0.7.1"
+measureme = { git = "https://github.com/michaelwoerister/measureme.git", branch = "paged_sinks" }
 rustc_session = { path = "../rustc_session" }

--- a/src/tools/tidy/src/extdeps.rs
+++ b/src/tools/tidy/src/extdeps.rs
@@ -4,7 +4,10 @@ use std::fs;
 use std::path::Path;
 
 /// List of allowed sources for packages.
-const ALLOWED_SOURCES: &[&str] = &["\"registry+https://github.com/rust-lang/crates.io-index\""];
+const ALLOWED_SOURCES: &[&str] = &[
+    "\"registry+https://github.com/rust-lang/crates.io-index\"",
+    "\"git+https://github.com/michaelwoerister/measureme.git?branch=paged_sinks#c00409471a2d4ba17012303037fdf82952fea92b\"",
+];
 
 /// Checks for external package sources. `root` is the path to the directory that contains the
 /// workspace `Cargo.toml`.

--- a/src/tools/tidy/src/extdeps.rs
+++ b/src/tools/tidy/src/extdeps.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 /// List of allowed sources for packages.
 const ALLOWED_SOURCES: &[&str] = &[
     "\"registry+https://github.com/rust-lang/crates.io-index\"",
-    "\"git+https://github.com/michaelwoerister/measureme.git?branch=paged_sinks#c00409471a2d4ba17012303037fdf82952fea92b\"",
+    "\"git+https://github.com/michaelwoerister/measureme.git?branch=paged_sinks#26d150475c8d83613beffe970d1c18dd2494f607\"",
 ];
 
 /// Checks for external package sources. `root` is the path to the directory that contains the


### PR DESCRIPTION
This PR will try to make sure that the new `measureme` file format (as described in https://github.com/rust-lang/measureme/issues/128) does not regress performance while doing self-profiling. 

The perf.rlo run is actually expected to fail (because the tools on the perf server cannot handle the new format yet) but hopefully we'll still get the top-level timings that should show potential regressions. 

The implementation of the new format as referenced by this PR is not production ready yet, but it should give a good indication of final performance. Once we know if this method of performance testing actually yields results, we can also test an alternative implementation that is slightly simpler.

cc @wesleywiser @Mark-Simulacrum 