### PR TITLE
Note that parallel-compiler = true causes tests to fail

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -371,6 +371,7 @@
 #incremental = false
 
 # Build a multi-threaded rustc
+# FIXME(#75760): Some UI tests fail when this option is enabled.
 #parallel-compiler = false
 
 # The default linker that will be hard-coded into the generated compiler for


### PR DESCRIPTION
Mentioning #75760.