### PR TITLE
Add format specifier suggestion

### DIFF
--- a/src/test/ui/fmt/format-args-capture-missing-variables.stderr
+++ b/src/test/ui/fmt/format-args-capture-missing-variables.stderr
@@ -1,8 +1,8 @@
 error: named argument never used
-  --> $DIR/format-args-capture-missing-variables.rs:10:51
+  --> $DIR/format-args-capture-missing-variables.rs:10:14
    |
 LL |     format!("{valuea} {valueb}", valuea=5, valuec=7);
-   |             -------------------                   ^ named argument never used
+   |             -^^^^^^^^-^^^^^^^^-                   ^ named argument never used
    |             |
    |             formatting specifier missing
 

--- a/src/test/ui/if/ifmt-bad-arg.stderr
+++ b/src/test/ui/if/ifmt-bad-arg.stderr
@@ -13,10 +13,10 @@ LL |     format!("{1}", 1);
    = note: positional arguments are zero-based
 
 error: argument never used
-  --> $DIR/ifmt-bad-arg.rs:9:20
+  --> $DIR/ifmt-bad-arg.rs:9:14
    |
 LL |     format!("{1}", 1);
-   |             -----  ^ argument never used
+   |             -^^^-  ^ argument never used
    |             |
    |             formatting specifier missing
 
@@ -90,36 +90,38 @@ LL |     format!("", 1, 2);
    |             |   |
    |             |   argument never used
    |             multiple missing formatting specifiers
+   |
+   = note: format specifiers use curly braces: `{}`
 
 error: argument never used
-  --> $DIR/ifmt-bad-arg.rs:33:22
+  --> $DIR/ifmt-bad-arg.rs:33:14
    |
 LL |     format!("{}", 1, 2);
-   |             ----     ^ argument never used
+   |             -^^-     ^ argument never used
    |             |
    |             formatting specifier missing
 
 error: argument never used
-  --> $DIR/ifmt-bad-arg.rs:34:20
+  --> $DIR/ifmt-bad-arg.rs:34:14
    |
 LL |     format!("{1}", 1, 2);
-   |             -----  ^ argument never used
+   |             -^^^-  ^ argument never used
    |             |
    |             formatting specifier missing
 
 error: named argument never used
-  --> $DIR/ifmt-bad-arg.rs:35:26
+  --> $DIR/ifmt-bad-arg.rs:35:14
    |
 LL |     format!("{}", 1, foo=2);
-   |             ----         ^ named argument never used
+   |             -^^-         ^ named argument never used
    |             |
    |             formatting specifier missing
 
 error: argument never used
-  --> $DIR/ifmt-bad-arg.rs:36:22
+  --> $DIR/ifmt-bad-arg.rs:36:14
    |
 LL |     format!("{foo}", 1, foo=2);
-   |             -------  ^ argument never used
+   |             -^^^^^-  ^ argument never used
    |             |
    |             formatting specifier missing
 
@@ -130,12 +132,14 @@ LL |     format!("", foo=2);
    |             --      ^ named argument never used
    |             |
    |             formatting specifier missing
+   |
+   = note: format specifiers use curly braces: `{}`
 
 error: multiple unused formatting arguments
-  --> $DIR/ifmt-bad-arg.rs:38:32
+  --> $DIR/ifmt-bad-arg.rs:38:14
    |
 LL |     format!("{} {}", 1, 2, foo=1, bar=2);
-   |             -------            ^      ^ named argument never used
+   |             -^^-^^-            ^      ^ named argument never used
    |             |                  |
    |             |                  named argument never used
    |             multiple missing formatting specifiers
@@ -165,10 +169,10 @@ LL |     format!("{valuea} {valueb}", valuea=5, valuec=7);
    = help: if you intended to capture `valueb` from the surrounding scope, add `#![feature(format_args_capture)]` to the crate attributes
 
 error: named argument never used
-  --> $DIR/ifmt-bad-arg.rs:45:51
+  --> $DIR/ifmt-bad-arg.rs:45:14
    |
 LL |     format!("{valuea} {valueb}", valuea=5, valuec=7);
-   |             -------------------                   ^ named argument never used
+   |             -^^^^^^^^-^^^^^^^^-                   ^ named argument never used
    |             |
    |             formatting specifier missing
 

--- a/src/test/ui/macros/format-foreign.stderr
+++ b/src/test/ui/macros/format-foreign.stderr
@@ -45,10 +45,10 @@ LL |         {}!\n
    |
 
 error: argument never used
-  --> $DIR/format-foreign.rs:12:30
+  --> $DIR/format-foreign.rs:12:15
    |
 LL |     println!("{} %f", "one", 2.0);
-   |              -------         ^^^ argument never used
+   |              -^^----         ^^^ argument never used
    |              |
    |              formatting specifier missing
 

--- a/src/test/ui/macros/format-unused-lables.stderr
+++ b/src/test/ui/macros/format-unused-lables.stderr
@@ -7,6 +7,8 @@ LL |     println!("Test", 123, 456, 789);
    |              |       |    argument never used
    |              |       argument never used
    |              multiple missing formatting specifiers
+   |
+   = note: format specifiers use curly braces: `{}`
 
 error: multiple unused formatting arguments
   --> $DIR/format-unused-lables.rs:6:9
@@ -19,6 +21,8 @@ LL |         456,
    |         ^^^ argument never used
 LL |         789
    |         ^^^ argument never used
+   |
+   = note: format specifiers use curly braces: `{}`
 
 error: named argument never used
   --> $DIR/format-unused-lables.rs:11:35
@@ -27,6 +31,8 @@ LL |     println!("Some stuff", UNUSED="args");
    |              ------------         ^^^^^^ named argument never used
    |              |
    |              formatting specifier missing
+   |
+   = note: format specifiers use curly braces: `{}`
 
 error: multiple unused formatting arguments
   --> $DIR/format-unused-lables.rs:14:9

--- a/src/test/ui/suggestions/issue-68293-missing-format-specifier.rs
+++ b/src/test/ui/suggestions/issue-68293-missing-format-specifier.rs
@@ -1,0 +1,38 @@
+// Issue 68293: This tests that the following changes work:
+// the suggestion "format specifiers use curly braces: `{}`" is made
+// found format specifiers are pointed at
+
+fn no_format_specifiers_one_unused_argument() {
+  println!("list: ", 1);
+  //~^ ERROR argument never used
+  //~| NOTE formatting specifier missing
+  //~| NOTE format specifiers use curly braces: `{}`
+  //~| NOTE argument never used
+}
+
+fn no_format_specifiers_multiple_unused_arguments() {
+  println!("list: ", 3, 4, 5);
+  //~^ ERROR multiple unused formatting arguments
+  //~| NOTE multiple missing formatting specifiers
+  //~| NOTE format specifiers use curly braces: `{}`
+  //~| NOTE argument never used
+  //~| NOTE argument never used
+  //~| NOTE argument never used
+}
+
+fn missing_format_specifiers_one_unused_argument() {
+  println!("list: a{}, b{}", 1, 2, 3);
+  //~^ ERROR argument never used
+  //~| NOTE formatting specifier missing
+  //~| NOTE argument never used
+}
+
+fn missing_format_specifiers_multiple_unused_arguments() {
+  println!("list: a{}, b{} c{}", 1, 2, 3, 4, 5);
+  //~^ ERROR multiple unused formatting arguments
+  //~| NOTE multiple missing formatting specifiers
+  //~| NOTE argument never used
+  //~| NOTE argument never used
+}
+
+fn main() {}

--- a/src/test/ui/suggestions/issue-68293-missing-format-specifier.stderr
+++ b/src/test/ui/suggestions/issue-68293-missing-format-specifier.stderr
@@ -1,0 +1,41 @@
+error: argument never used
+  --> $DIR/issue-68293-missing-format-specifier.rs:6:22
+   |
+LL |   println!("list: ", 1);
+   |            --------  ^ argument never used
+   |            |
+   |            formatting specifier missing
+   |
+   = note: format specifiers use curly braces: `{}`
+
+error: multiple unused formatting arguments
+  --> $DIR/issue-68293-missing-format-specifier.rs:14:22
+   |
+LL |   println!("list: ", 3, 4, 5);
+   |            --------  ^  ^  ^ argument never used
+   |            |         |  |
+   |            |         |  argument never used
+   |            |         argument never used
+   |            multiple missing formatting specifiers
+   |
+   = note: format specifiers use curly braces: `{}`
+
+error: argument never used
+  --> $DIR/issue-68293-missing-format-specifier.rs:24:20
+   |
+LL |   println!("list: a{}, b{}", 1, 2, 3);
+   |            --------^^---^^-        ^ argument never used
+   |            |
+   |            formatting specifier missing
+
+error: multiple unused formatting arguments
+  --> $DIR/issue-68293-missing-format-specifier.rs:31:20
+   |
+LL |   println!("list: a{}, b{} c{}", 1, 2, 3, 4, 5);
+   |            --------^^---^^--^^-           ^  ^ argument never used
+   |            |                              |
+   |            |                              argument never used
+   |            multiple missing formatting specifiers
+
+error: aborting due to 4 previous errors
+


### PR DESCRIPTION
When format specifier is missing from the format string:
- Found format specifiers are pointed at
- Suggest format specifier if none is present

Fix #68293