### PR TITLE
Implement Make `handle_alloc_error` default to panic (for no_std + liballoc)

### DIFF
--- a/compiler/rustc_codegen_llvm/src/lib.rs
+++ b/compiler/rustc_codegen_llvm/src/lib.rs
@@ -95,8 +95,9 @@ impl ExtraBackendMethods for LlvmCodegenBackend {
         tcx: TyCtxt<'tcx>,
         mods: &mut ModuleLlvm,
         kind: AllocatorKind,
+        has_alloc_error_handler: bool,
     ) {
-        unsafe { allocator::codegen(tcx, mods, kind) }
+        unsafe { allocator::codegen(tcx, mods, kind, has_alloc_error_handler) }
     }
     fn compile_codegen_unit(
         &self,

--- a/compiler/rustc_codegen_ssa/src/base.rs
+++ b/compiler/rustc_codegen_ssa/src/base.rs
@@ -538,8 +538,9 @@ pub fn codegen_crate<B: ExtraBackendMethods>(
         let llmod_id =
             cgu_name_builder.build_cgu_name(LOCAL_CRATE, &["crate"], Some("allocator")).to_string();
         let mut modules = backend.new_metadata(tcx, &llmod_id);
-        tcx.sess
-            .time("write_allocator_module", || backend.codegen_allocator(tcx, &mut modules, kind));
+        tcx.sess.time("write_allocator_module", || {
+            backend.codegen_allocator(tcx, &mut modules, kind, tcx.lang_items().oom().is_some())
+        });
 
         Some(ModuleCodegen { name: llmod_id, module_llvm: modules, kind: ModuleKind::Allocator })
     } else {

--- a/compiler/rustc_codegen_ssa/src/traits/backend.rs
+++ b/compiler/rustc_codegen_ssa/src/traits/backend.rs
@@ -109,6 +109,7 @@ pub trait ExtraBackendMethods: CodegenBackend + WriteBackendMethods + Sized + Se
         tcx: TyCtxt<'tcx>,
         mods: &mut Self::Module,
         kind: AllocatorKind,
+        has_alloc_error_handler: bool,
     );
     /// This generates the codegen unit and returns it along with
     /// a `u64` giving an estimate of the unit's processing cost.

--- a/compiler/rustc_feature/src/active.rs
+++ b/compiler/rustc_feature/src/active.rs
@@ -593,6 +593,9 @@ declare_features! (
     /// Allows to use the `#[cmse_nonsecure_entry]` attribute.
     (active, cmse_nonsecure_entry, "1.48.0", Some(75835), None),
 
+    /// Allows rustc to inject a default alloc_error_handler
+    (active, default_alloc_error_handler, "1.48.0", Some(66741), None),
+
     // -------------------------------------------------------------------------
     // feature-group-end: actual feature gates
     // -------------------------------------------------------------------------

--- a/compiler/rustc_passes/src/weak_lang_items.rs
+++ b/compiler/rustc_passes/src/weak_lang_items.rs
@@ -64,7 +64,10 @@ fn verify<'tcx>(tcx: TyCtxt<'tcx>, items: &lang_items::LanguageItems) {
             if item == LangItem::PanicImpl {
                 tcx.sess.err("`#[panic_handler]` function required, but not found");
             } else if item == LangItem::Oom {
-                tcx.sess.err("`#[alloc_error_handler]` function required, but not found");
+                if !tcx.features().default_alloc_error_handler {
+                    tcx.sess.err("`#[alloc_error_handler]` function required, but not found.");
+                    tcx.sess.note_without_error("Use `#![feature(default_alloc_error_handler)]` for a default error handler.");
+                }
             } else {
                 tcx.sess.err(&format!("language item required, but not found: `{}`", name));
             }

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -415,6 +415,7 @@ symbols! {
         decl_macro,
         declare_lint_pass,
         decode,
+        default_alloc_error_handler,
         default_lib_allocator,
         default_type_parameter_fallback,
         default_type_params,

--- a/src/test/ui/allocator/auxiliary/helper.rs
+++ b/src/test/ui/allocator/auxiliary/helper.rs
@@ -1,8 +1,10 @@
 // no-prefer-dynamic
 
 #![crate_type = "rlib"]
+#![no_std]
 
-use std::fmt;
+extern crate alloc;
+use alloc::fmt;
 
 pub fn work_with(p: &fmt::Debug) {
     drop(p);

--- a/src/test/ui/allocator/no_std-alloc-error-handler-custom.rs
+++ b/src/test/ui/allocator/no_std-alloc-error-handler-custom.rs
@@ -1,0 +1,97 @@
+// run-pass
+// ignore-android no libc
+// ignore-cloudabi no libc
+// ignore-emscripten no libc
+// ignore-sgx no libc
+// ignore-wasm32 no libc
+// only-linux
+// compile-flags:-C panic=abort
+// aux-build:helper.rs
+
+#![feature(start, rustc_private, new_uninit, panic_info_message)]
+#![feature(alloc_error_handler)]
+#![no_std]
+
+extern crate alloc;
+extern crate libc;
+
+// ARM targets need these symbols
+#[no_mangle]
+pub fn __aeabi_unwind_cpp_pr0() {}
+
+#[no_mangle]
+pub fn __aeabi_unwind_cpp_pr1() {}
+
+use core::ptr::null_mut;
+use core::alloc::{GlobalAlloc, Layout};
+use alloc::boxed::Box;
+
+extern crate helper;
+
+struct MyAllocator;
+
+#[alloc_error_handler]
+fn my_oom(layout: Layout) -> !
+{
+    use alloc::fmt::write;
+    unsafe {
+        let size = layout.size();
+        let mut s = alloc::string::String::new();
+        write(&mut s, format_args!("My OOM: failed to allocate {} bytes!\n", size)).unwrap();
+        let s = s.as_str();
+        libc::write(libc::STDERR_FILENO, s as *const _ as _, s.len());
+        libc::exit(0)
+    }
+}
+
+unsafe impl GlobalAlloc for MyAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        if layout.size() < 4096 {
+            libc::malloc(layout.size()) as _
+        } else {
+            null_mut()
+        }
+    }
+    unsafe fn dealloc(&self, _ptr: *mut u8, _layout: Layout) {}
+}
+
+#[global_allocator]
+static A: MyAllocator = MyAllocator;
+
+#[panic_handler]
+fn panic(panic_info: &core::panic::PanicInfo) -> ! {
+    unsafe {
+        if let Some(s) = panic_info.payload().downcast_ref::<&str>() {
+            const PSTR: &str = "panic occurred: ";
+            const CR: &str = "\n";
+            libc::write(libc::STDERR_FILENO, PSTR as *const _ as _, PSTR.len());
+            libc::write(libc::STDERR_FILENO, s as *const _ as _, s.len());
+            libc::write(libc::STDERR_FILENO, CR as *const _ as _, CR.len());
+        }
+        if let Some(args) = panic_info.message() {
+            let mut s = alloc::string::String::new();
+            alloc::fmt::write(&mut s, *args).unwrap();
+            let s = s.as_str();
+            const PSTR: &str = "panic occurred: ";
+            const CR: &str = "\n";
+            libc::write(libc::STDERR_FILENO, PSTR as *const _ as _, PSTR.len());
+            libc::write(libc::STDERR_FILENO, s as *const _ as _, s.len());
+            libc::write(libc::STDERR_FILENO, CR as *const _ as _, CR.len());
+        } else {
+            const PSTR: &str = "panic occurred\n";
+            libc::write(libc::STDERR_FILENO, PSTR as *const _ as _, PSTR.len());
+        }
+        libc::exit(1)
+    }
+}
+
+#[derive(Debug)]
+struct Page([[u64; 32]; 16]);
+
+#[start]
+pub fn main(_argc: isize, _argv: *const *const u8) -> isize {
+    let zero = Box::<Page>::new_zeroed();
+    let zero = unsafe { zero.assume_init() };
+    helper::work_with(&zero);
+    1
+}

--- a/src/test/ui/allocator/no_std-alloc-error-handler-default.rs
+++ b/src/test/ui/allocator/no_std-alloc-error-handler-default.rs
@@ -1,0 +1,84 @@
+// run-pass
+// ignore-android no libc
+// ignore-cloudabi no libc
+// ignore-emscripten no libc
+// ignore-sgx no libc
+// ignore-wasm32 no libc
+// only-linux
+// compile-flags:-C panic=abort
+// aux-build:helper.rs
+// gate-test-default_alloc_error_handler
+
+#![feature(start, rustc_private, new_uninit, panic_info_message)]
+#![feature(default_alloc_error_handler)]
+#![no_std]
+
+extern crate alloc;
+extern crate libc;
+
+// ARM targets need these symbols
+#[no_mangle]
+pub fn __aeabi_unwind_cpp_pr0() {}
+
+#[no_mangle]
+pub fn __aeabi_unwind_cpp_pr1() {}
+
+use alloc::boxed::Box;
+use core::alloc::{GlobalAlloc, Layout};
+use core::ptr::null_mut;
+
+extern crate helper;
+
+struct MyAllocator;
+
+unsafe impl GlobalAlloc for MyAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        if layout.size() < 4096 {
+            libc::malloc(layout.size()) as _
+        } else {
+            null_mut()
+        }
+    }
+    unsafe fn dealloc(&self, _ptr: *mut u8, _layout: Layout) {}
+}
+
+#[global_allocator]
+static A: MyAllocator = MyAllocator;
+
+#[panic_handler]
+fn panic(panic_info: &core::panic::PanicInfo) -> ! {
+    unsafe {
+        if let Some(s) = panic_info.payload().downcast_ref::<&str>() {
+            const PSTR: &str = "panic occurred: ";
+            const CR: &str = "\n";
+            libc::write(libc::STDERR_FILENO, PSTR as *const _ as _, PSTR.len());
+            libc::write(libc::STDERR_FILENO, s as *const _ as _, s.len());
+            libc::write(libc::STDERR_FILENO, CR as *const _ as _, CR.len());
+        }
+        if let Some(args) = panic_info.message() {
+            let mut s = alloc::string::String::new();
+            alloc::fmt::write(&mut s, *args).unwrap();
+            let s = s.as_str();
+            const PSTR: &str = "panic occurred: ";
+            const CR: &str = "\n";
+            libc::write(libc::STDERR_FILENO, PSTR as *const _ as _, PSTR.len());
+            libc::write(libc::STDERR_FILENO, s as *const _ as _, s.len());
+            libc::write(libc::STDERR_FILENO, CR as *const _ as _, CR.len());
+        } else {
+            const PSTR: &str = "panic occurred\n";
+            libc::write(libc::STDERR_FILENO, PSTR as *const _ as _, PSTR.len());
+        }
+        libc::exit(0)
+    }
+}
+
+#[derive(Debug)]
+struct Page([[u64; 32]; 16]);
+
+#[start]
+pub fn main(_argc: isize, _argv: *const *const u8) -> isize {
+    let zero = Box::<Page>::new_zeroed();
+    let zero = unsafe { zero.assume_init() };
+    helper::work_with(&zero);
+    1
+}

--- a/src/test/ui/missing/missing-alloc_error_handler.stderr
+++ b/src/test/ui/missing/missing-alloc_error_handler.stderr
@@ -1,4 +1,6 @@
-error: `#[alloc_error_handler]` function required, but not found
+error: `#[alloc_error_handler]` function required, but not found.
+
+note: Use `#![feature(default_alloc_error_handler)]` for a default error handler.
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Related: https://github.com/rust-lang/rust/issues/66741

Guarded with `#![feature(default_alloc_error_handler)]` a default
`alloc_error_handler` is called, if a custom allocator is used and no
other custom `#[alloc_error_handler]` is defined.