### PR TITLE
rustdoc: Fix font CSS for crate lists

### DIFF
--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -126,6 +126,10 @@ h1, h2, h3, h4,
 	font-family: "Fira Sans", sans-serif;
 }
 
+.content ul.crate a.crate {
+	font: 16px/1.6 "Fira Sans";
+}
+
 ol, ul {
 	padding-left: 25px;
 }

--- a/src/librustdoc/html/static/themes/ayu.css
+++ b/src/librustdoc/html/static/themes/ayu.css
@@ -178,9 +178,6 @@ pre {
 .content span.externcrate, .content span.mod, .content a.mod {
 	color: #acccf9;
 }
-.content ul.crate a.crate {
-	font: 16px/1.6 "Fira Sans";
-}
 .content span.struct, .content a.struct {
 	color: #ffa0a5;
 }


### PR DESCRIPTION
I had put it in the wrong file in #76126. This should fix it now. Thank
you to @ollie27 for pointing this out!

---

@rustbot modify labels: T-rustdoc C-bug