### PR TITLE
stabilize `int_error_matching`

### DIFF
--- a/compiler/rustc_middle/src/lib.rs
+++ b/compiler/rustc_middle/src/lib.rs
@@ -50,7 +50,6 @@
 #![feature(associated_type_bounds)]
 #![feature(rustc_attrs)]
 #![feature(hash_raw_entry)]
-#![feature(int_error_matching)]
 #![recursion_limit = "512"]
 
 #[macro_use]

--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -5293,43 +5293,38 @@ pub struct ParseIntError {
 }
 
 /// Enum to store the various types of errors that can cause parsing an integer to fail.
-#[unstable(
-    feature = "int_error_matching",
-    reason = "it can be useful to match errors when making error messages \
-              for integer parsing",
-    issue = "22639"
-)]
+#[stable(feature = "int_error_matching", since = "1.47.0")]
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum IntErrorKind {
     /// Value being parsed is empty.
     ///
     /// Among other causes, this variant will be constructed when parsing an empty string.
+    #[stable(feature = "int_error_matching", since = "1.47.0")]
     Empty,
     /// Contains an invalid digit.
     ///
     /// Among other causes, this variant will be constructed when parsing a string that
     /// contains a letter.
+    #[stable(feature = "int_error_matching", since = "1.47.0")]
     InvalidDigit,
     /// Integer is too large to store in target integer type.
+    #[stable(feature = "int_error_matching", since = "1.47.0")]
     Overflow,
     /// Integer is too small to store in target integer type.
+    #[stable(feature = "int_error_matching", since = "1.47.0")]
     Underflow,
     /// Value was Zero
     ///
     /// This variant will be emitted when the parsing string has a value of zero, which
     /// would be illegal for non-zero types.
+    #[stable(feature = "int_error_matching", since = "1.47.0")]
     Zero,
 }
 
 impl ParseIntError {
     /// Outputs the detailed cause of parsing an integer failing.
-    #[unstable(
-        feature = "int_error_matching",
-        reason = "it can be useful to match errors when making error messages \
-                  for integer parsing",
-        issue = "22639"
-    )]
+    #[stable(feature = "int_error_matching", since = "1.47.0")]
     pub fn kind(&self) -> &IntErrorKind {
         &self.kind
     }

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -30,7 +30,6 @@
 #![feature(try_trait)]
 #![feature(slice_internals)]
 #![feature(slice_partition_dedup)]
-#![feature(int_error_matching)]
 #![feature(array_value_iter)]
 #![feature(iter_partition_in_place)]
 #![feature(iter_is_partitioned)]

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -265,7 +265,6 @@
 #![feature(hash_raw_entry)]
 #![feature(hashmap_internals)]
 #![feature(int_error_internals)]
-#![feature(int_error_matching)]
 #![feature(integer_atomics)]
 #![feature(into_future)]
 #![feature(lang_items)]

--- a/library/std/src/num.rs
+++ b/library/std/src/num.rs
@@ -22,12 +22,7 @@ pub use core::num::{NonZeroI128, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI8, 
 #[stable(feature = "nonzero", since = "1.28.0")]
 pub use core::num::{NonZeroU128, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU8, NonZeroUsize};
 
-#[unstable(
-    feature = "int_error_matching",
-    reason = "it can be useful to match errors when making error messages \
-              for integer parsing",
-    issue = "22639"
-)]
+#[stable(feature = "int_error_matching", since = "1.47.0")]
 pub use core::num::IntErrorKind;
 
 #[cfg(test)]


### PR DESCRIPTION
- PR: https://github.com/rust-lang/rust/pull/55705
- Tracking issue: #22639

The original PR was my first `std` contribution. Since then a few people have called for it to be stabilized. See discussion on https://github.com/rust-lang/rust/issues/22639

A significant number of people seem to be using this feature in their projects https://github.com/search?p=2&q=%23%21%5Bfeature%28int_error_matching%29%5D&type=Code

# Unanswered questions

> If this is to be stabilized, I think that the terminology has to be improved: `IntErrorKind` uses `Underflow` to refer to negative overflow, but underflow usually means when the absolute value of a floating-point number is so small it becomes 0 (or a subnormal).

_Originally posted by @tspiteri in https://github.com/rust-lang/rust/issues/22639#issuecomment-520167905_

> Maybe `PosOverflow` and `NegOverflow`?

_Originally posted by @JarrettBillingsley in https://github.com/rust-lang/rust/issues/22639#issuecomment-539685390_

I personally don't think it needs to change as in this position underflow is clearly associated with integers and seems consistent with other uses of the word underflow in `std`. I am interested to hear others thoughts.


