### PR TITLE
[DRAFT] Change `Symbol::as_str()` to `&self -> &str`.

### DIFF
--- a/compiler/rustc_ast_passes/src/feature_gate.rs
+++ b/compiler/rustc_ast_passes/src/feature_gate.rs
@@ -47,7 +47,7 @@ impl<'a> PostExpansionVisitor<'a> {
     fn check_abi(&self, abi: ast::StrLit) {
         let ast::StrLit { symbol_unescaped, span, .. } = abi;
 
-        match &*symbol_unescaped.as_str() {
+        match symbol_unescaped.as_str() {
             // Stable
             "Rust" | "C" | "cdecl" | "stdcall" | "fastcall" | "aapcs" | "win64" | "sysv64"
             | "system" => {}

--- a/compiler/rustc_attr/src/builtin.rs
+++ b/compiler/rustc_attr/src/builtin.rs
@@ -283,7 +283,7 @@ where
 
                                     // These unwraps are safe because `get` ensures the meta item
                                     // is a name/value pair string literal.
-                                    issue_num = match &*issue.unwrap().as_str() {
+                                    issue_num = match issue.unwrap().as_str() {
                                         "none" => None,
                                         issue => {
                                             let emit_diag = |msg: &str| {

--- a/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
@@ -2014,8 +2014,8 @@ fn prepare_enum_metadata(
                 let item_name;
                 let discriminant_name = match enum_type.kind() {
                     ty::Adt(..) => {
-                        item_name = tcx.item_name(enum_def_id).as_str();
-                        &*item_name
+                        item_name = tcx.item_name(enum_def_id);
+                        item_name.as_str()
                     }
                     ty::Generator(..) => enum_name.as_str(),
                     _ => bug!(),
@@ -2483,7 +2483,8 @@ pub fn create_global_var_metadata(cx: &CodegenCx<'ll, '_>, def_id: DefId, global
     let is_local_to_unit = is_node_local_to_unit(cx, def_id);
     let variable_type = Instance::mono(cx.tcx, def_id).ty(cx.tcx, ty::ParamEnv::reveal_all());
     let type_metadata = type_metadata(cx, variable_type, span);
-    let var_name = tcx.item_name(def_id).as_str();
+    let var_name = tcx.item_name(def_id);
+    let var_name = var_name.as_str();
     let linkage_name = mangled_name_of_instance(cx, Instance::mono(tcx, def_id)).name;
     // When empty, linkage_name field is omitted,
     // which is what we want for no_mangle statics

--- a/compiler/rustc_hir/src/definitions.rs
+++ b/compiler/rustc_hir/src/definitions.rs
@@ -214,10 +214,10 @@ impl DefPath {
     where
         F: FnOnce(CrateNum) -> Symbol,
     {
-        let crate_name_str = crate_imported_name(self.krate).as_str();
-        let mut s = String::with_capacity(crate_name_str.len() + self.data.len() * 16);
+        let crate_name = crate_imported_name(self.krate);
+        let mut s = String::with_capacity(crate_name.as_str().len() + self.data.len() * 16);
 
-        write!(s, "::{}", crate_name_str).unwrap();
+        write!(s, "::{}", crate_name).unwrap();
 
         for component in &self.data {
             if component.disambiguator == 0 {

--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -948,8 +948,8 @@ fn encode_and_write_metadata(
 
     let need_metadata_file = tcx.sess.opts.output_types.contains_key(&OutputType::Metadata);
     if need_metadata_file {
-        let crate_name = &tcx.crate_name(LOCAL_CRATE).as_str();
-        let out_filename = filename_for_metadata(tcx.sess, crate_name, outputs);
+        let crate_name = &tcx.crate_name(LOCAL_CRATE);
+        let out_filename = filename_for_metadata(tcx.sess, crate_name.as_str(), outputs);
         // To avoid races with another rustc process scanning the output directory,
         // we need to write the file somewhere else and atomically move it to its
         // final destination, with an `fs::rename` call. In order for the rename to

--- a/compiler/rustc_metadata/src/locator.rs
+++ b/compiler/rustc_metadata/src/locator.rs
@@ -932,7 +932,8 @@ impl CrateError {
                 let candidates = libraries
                     .iter()
                     .filter_map(|(_, lib)| {
-                        let crate_name = &lib.metadata.get_root().name().as_str();
+                        let crate_name = lib.metadata.get_root().name();
+                        let crate_name = crate_name.as_str();
                         match (&lib.source.dylib, &lib.source.rlib) {
                             (Some((pd, _)), Some((pr, _))) => Some(format!(
                                 "\ncrate `{}`: {}\n{:>padding$}",

--- a/compiler/rustc_metadata/src/native_libs.rs
+++ b/compiler/rustc_metadata/src/native_libs.rs
@@ -65,7 +65,7 @@ impl ItemLikeVisitor<'tcx> for Collector<'tcx> {
                         Some(name) => name,
                         None => continue, // skip like historical compilers
                     };
-                    lib.kind = match &*kind.as_str() {
+                    lib.kind = match kind.as_str() {
                         "static" => NativeLibKind::StaticBundle,
                         "static-nobundle" => NativeLibKind::StaticNoBundle,
                         "dylib" => NativeLibKind::Dylib,

--- a/compiler/rustc_middle/src/hir/map/collector.rs
+++ b/compiler/rustc_middle/src/hir/map/collector.rs
@@ -86,7 +86,9 @@ fn upstream_crates(cstore: &dyn CrateStore) -> Vec<(Symbol, Fingerprint, Svh)> {
             (name, disambiguator, hash)
         })
         .collect();
-    upstream_crates.sort_unstable_by_key(|&(name, dis, _)| (name.as_str(), dis));
+    upstream_crates.sort_unstable_by(|&(name1, dis1, _), &(name2, dis2, _)| {
+        (name1.as_str(), dis1).partial_cmp(&(name2.as_str(), dis2)).unwrap()
+    });
     upstream_crates
 }
 

--- a/compiler/rustc_middle/src/middle/mod.rs
+++ b/compiler/rustc_middle/src/middle/mod.rs
@@ -22,7 +22,7 @@ pub mod lib_features {
                 .map(|(f, s)| (*f, Some(*s)))
                 .chain(self.unstable.iter().map(|f| (*f, None)))
                 .collect();
-            all_features.sort_unstable_by_key(|f| f.0.as_str());
+            all_features.sort_unstable_by(|a, b| a.0.as_str().partial_cmp(b.0.as_str()).unwrap());
             all_features
         }
     }

--- a/compiler/rustc_middle/src/middle/stability.rs
+++ b/compiler/rustc_middle/src/middle/stability.rs
@@ -184,7 +184,8 @@ pub fn deprecation_suggestion(
 pub fn deprecation_message(depr: &Deprecation, kind: &str, path: &str) -> (String, &'static Lint) {
     let (message, lint) = if deprecation_in_effect(
         depr.is_since_rustc_version,
-        depr.since.map(Symbol::as_str).as_deref(),
+        // njn: surely can use as_str() somehow here
+        depr.since.map(Symbol::as_str2).as_deref(),
     ) {
         (format!("use of deprecated {} `{}`", kind, path), DEPRECATED)
     } else {

--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -2222,7 +2222,7 @@ impl<'tcx> Debug for Rvalue<'tcx> {
                             if let Some(upvars) = tcx.upvars_mentioned(def_id) {
                                 for (&var_id, place) in upvars.keys().zip(places) {
                                     let var_name = tcx.hir().name(var_id);
-                                    struct_fmt.field(&var_name.as_str(), place);
+                                    struct_fmt.field(var_name.as_str(), place);
                                 }
                             }
 
@@ -2241,7 +2241,7 @@ impl<'tcx> Debug for Rvalue<'tcx> {
                             if let Some(upvars) = tcx.upvars_mentioned(def_id) {
                                 for (&var_id, place) in upvars.keys().zip(places) {
                                     let var_name = tcx.hir().name(var_id);
-                                    struct_fmt.field(&var_name.as_str(), place);
+                                    struct_fmt.field(var_name.as_str(), place);
                                 }
                             }
 

--- a/compiler/rustc_middle/src/mir/mono.rs
+++ b/compiler/rustc_middle/src/mir/mono.rs
@@ -436,7 +436,7 @@ impl CodegenUnitNameBuilder<'tcx> {
         if self.tcx.sess.opts.debugging_opts.human_readable_cgu_names {
             cgu_name
         } else {
-            Symbol::intern(&CodegenUnit::mangle_name(&cgu_name.as_str()))
+            Symbol::intern(&CodegenUnit::mangle_name(cgu_name.as_str()))
         }
     }
 

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -1183,8 +1183,8 @@ impl<'tcx> TyCtxt<'tcx> {
     }
 
     pub fn consider_optimizing<T: Fn() -> String>(&self, msg: T) -> bool {
-        let cname = self.crate_name(LOCAL_CRATE).as_str();
-        self.sess.consider_optimizing(&cname, msg)
+        let cname = self.crate_name(LOCAL_CRATE);
+        self.sess.consider_optimizing(cname.as_str(), msg)
     }
 
     pub fn lib_features(self) -> &'tcx middle::lib_features::LibFeatures {

--- a/compiler/rustc_middle/src/ty/query/profiling_support.rs
+++ b/compiler/rustc_middle/src/ty/query/profiling_support.rs
@@ -80,7 +80,7 @@ impl<'p, 'c, 'tcx> QueryKeyStringBuilder<'p, 'c, 'tcx> {
             }
         }
 
-        let name = &*name.as_str();
+        let name = name.as_str();
         let components = [
             StringComponent::Ref(parent_string_id),
             StringComponent::Value("::"),

--- a/compiler/rustc_mir/src/borrow_check/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_mir/src/borrow_check/diagnostics/conflict_errors.rs
@@ -340,7 +340,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                             tcx,
                             generics,
                             &mut err,
-                            &param.name.as_str(),
+                            param.name.as_str(),
                             "Copy",
                             None,
                         );

--- a/compiler/rustc_mir/src/borrow_check/diagnostics/mod.rs
+++ b/compiler/rustc_mir/src/borrow_check/diagnostics/mod.rs
@@ -316,7 +316,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
         let decl = &self.body.local_decls[local];
         match self.local_names[local] {
             Some(name) if !decl.from_compiler_desugaring() => {
-                buf.push_str(&name.as_str());
+                buf.push_str(name.as_str());
                 Ok(())
             }
             _ => Err(()),

--- a/compiler/rustc_mir/src/monomorphize/partitioning/merging.rs
+++ b/compiler/rustc_mir/src/monomorphize/partitioning/merging.rs
@@ -4,7 +4,7 @@ use rustc_data_structures::fx::FxHashMap;
 use rustc_hir::def_id::LOCAL_CRATE;
 use rustc_middle::mir::mono::{CodegenUnit, CodegenUnitNameBuilder};
 use rustc_middle::ty::TyCtxt;
-use rustc_span::symbol::{Symbol, SymbolStr};
+use rustc_span::symbol::Symbol;
 
 use crate::monomorphize::partitioning::PreInliningPartitioning;
 
@@ -25,11 +25,13 @@ pub fn merge_codegen_units<'tcx>(
     // smallest into each other) we're sure to start off with a deterministic
     // order (sorted by name). This'll mean that if two cgus have the same size
     // the stable sort below will keep everything nice and deterministic.
-    codegen_units.sort_by_cached_key(|cgu| cgu.name().as_str());
+    codegen_units.sort_by(|a, b| a.name().as_str().partial_cmp(b.name().as_str()).unwrap());
 
     // This map keeps track of what got merged into what.
-    let mut cgu_contents: FxHashMap<Symbol, Vec<SymbolStr>> =
-        codegen_units.iter().map(|cgu| (cgu.name(), vec![cgu.name().as_str()])).collect();
+    let mut cgu_contents: FxHashMap<Symbol, Vec<String>> = codegen_units
+        .iter()
+        .map(|cgu| (cgu.name(), vec![cgu.name().as_str().to_owned()]))
+        .collect();
 
     // Merge the two smallest codegen units until the target size is reached.
     while codegen_units.len() > target_cgu_count {

--- a/compiler/rustc_mir/src/monomorphize/partitioning/mod.rs
+++ b/compiler/rustc_mir/src/monomorphize/partitioning/mod.rs
@@ -203,7 +203,7 @@ pub fn partition<'tcx>(
         internalization_candidates: _,
     } = post_inlining;
 
-    result.sort_by_cached_key(|cgu| cgu.name().as_str());
+    result.sort_by(|a, b| a.name().as_str().partial_cmp(b.name().as_str()).unwrap());
 
     result
 }

--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -1398,7 +1398,8 @@ impl<'a> Parser<'a> {
                 );
             }
             LitError::InvalidIntSuffix => {
-                let suf = suffix.expect("suffix error with no suffix").as_str();
+                let suf = suffix.expect("suffix error with no suffix");
+                let suf = suf.as_str();
                 if looks_like_width_suffix(&['i', 'u'], &suf) {
                     // If it looks like a width, try to be helpful.
                     let msg = format!("invalid width `{}` for integer literal", &suf[1..]);
@@ -1414,7 +1415,8 @@ impl<'a> Parser<'a> {
                 }
             }
             LitError::InvalidFloatSuffix => {
-                let suf = suffix.expect("suffix error with no suffix").as_str();
+                let suf = suffix.expect("suffix error with no suffix");
+                let suf = suf.as_str();
                 if looks_like_width_suffix(&['f'], &suf) {
                     // If it looks like a width, try to be helpful.
                     let msg = format!("invalid width `{}` for float literal", &suf[1..]);

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -1,4 +1,3 @@
-use std::cmp::Reverse;
 use std::ptr;
 
 use rustc_ast::util::lev_distance::find_best_match_for_name;
@@ -711,7 +710,7 @@ impl<'a> Resolver<'a> {
         });
 
         // Make sure error reporting is deterministic.
-        suggestions.sort_by_cached_key(|suggestion| suggestion.candidate.as_str());
+        suggestions.sort_by(|a, b| a.candidate.as_str().partial_cmp(b.candidate.as_str()).unwrap());
 
         match find_best_match_for_name(
             suggestions.iter().map(|suggestion| &suggestion.candidate),
@@ -1306,12 +1305,12 @@ impl<'a, 'b> ImportResolver<'a, 'b> {
             return None;
         }
 
-        // Sort extern crate names in reverse order to get
+        // Sort extern crate names in *reverse* order to get
         // 1) some consistent ordering for emitted diagnostics, and
         // 2) `std` suggestions before `core` suggestions.
         let mut extern_crate_names =
             self.r.extern_prelude.iter().map(|(ident, _)| ident.name).collect::<Vec<_>>();
-        extern_crate_names.sort_by_key(|name| Reverse(name.as_str()));
+        extern_crate_names.sort_by(|a, b| b.as_str().partial_cmp(a.as_str()).unwrap());
 
         for name in extern_crate_names.into_iter() {
             // Replace first ident with a crate name and check if that is valid.

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -946,7 +946,7 @@ impl<'a> LateResolutionVisitor<'a, '_, '_> {
 
         let name = path[path.len() - 1].ident.name;
         // Make sure error reporting is deterministic.
-        names.sort_by_cached_key(|suggestion| suggestion.candidate.as_str());
+        names.sort_by(|a, b| a.candidate.as_str().partial_cmp(b.candidate.as_str()).unwrap());
 
         match find_best_match_for_name(
             names.iter().map(|suggestion| &suggestion.candidate),

--- a/compiler/rustc_symbol_mangling/src/v0.rs
+++ b/compiler/rustc_symbol_mangling/src/v0.rs
@@ -536,8 +536,8 @@ impl Printer<'tcx> for SymbolMangler<'tcx> {
         self.push("C");
         let fingerprint = self.tcx.crate_disambiguator(cnum).to_fingerprint();
         self.push_disambiguator(fingerprint.to_smaller_hash());
-        let name = self.tcx.original_crate_name(cnum).as_str();
-        self.push_ident(&name);
+        let name = self.tcx.original_crate_name(cnum);
+        self.push_ident(name.as_str());
         Ok(self)
     }
     fn path_qualified(
@@ -596,13 +596,13 @@ impl Printer<'tcx> for SymbolMangler<'tcx> {
             }
         };
 
-        let name = disambiguated_data.data.get_opt_name().map(|s| s.as_str());
+        let name = disambiguated_data.data.get_opt_name();
 
         self.path_append_ns(
             print_prefix,
             ns,
             disambiguated_data.disambiguator as u64,
-            name.as_ref().map_or("", |s| &s[..]),
+            name.as_ref().map_or("", |name| name.as_str()),
         )
     }
     fn path_generic_args(

--- a/compiler/rustc_typeck/src/check/method/probe.rs
+++ b/compiler/rustc_typeck/src/check/method/probe.rs
@@ -1008,7 +1008,7 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
             .collect();
 
         // Sort them by the name so we have a stable result.
-        names.sort_by_cached_key(|n| n.as_str());
+        names.sort_by(|a, b| a.as_str().partial_cmp(b.as_str()).unwrap());
         names
     }
 

--- a/src/librustdoc/clean/cfg.rs
+++ b/src/librustdoc/clean/cfg.rs
@@ -443,7 +443,7 @@ impl<'a> fmt::Display for Display<'a> {
                     (sym::unix, None) => "Unix",
                     (sym::windows, None) => "Windows",
                     (sym::debug_assertions, None) => "debug-assertions enabled",
-                    (sym::target_os, Some(os)) => match &*os.as_str() {
+                    (sym::target_os, Some(os)) => match os.as_str() {
                         "android" => "Android",
                         "dragonfly" => "DragonFly BSD",
                         "emscripten" => "Emscripten",
@@ -463,7 +463,7 @@ impl<'a> fmt::Display for Display<'a> {
                         "windows" => "Windows",
                         _ => "",
                     },
-                    (sym::target_arch, Some(arch)) => match &*arch.as_str() {
+                    (sym::target_arch, Some(arch)) => match arch.as_str() {
                         "aarch64" => "AArch64",
                         "arm" => "ARM",
                         "asmjs" => "JavaScript",
@@ -479,7 +479,7 @@ impl<'a> fmt::Display for Display<'a> {
                         "x86_64" => "x86-64",
                         _ => "",
                     },
-                    (sym::target_vendor, Some(vendor)) => match &*vendor.as_str() {
+                    (sym::target_vendor, Some(vendor)) => match vendor.as_str() {
                         "apple" => "Apple",
                         "pc" => "PC",
                         "rumprun" => "Rumprun",
@@ -487,7 +487,7 @@ impl<'a> fmt::Display for Display<'a> {
                         "fortanix" => "Fortanix",
                         _ => "",
                     },
-                    (sym::target_env, Some(env)) => match &*env.as_str() {
+                    (sym::target_env, Some(env)) => match env.as_str() {
                         "gnu" => "GNU",
                         "msvc" => "MSVC",
                         "musl" => "musl",

--- a/src/test/ui-fulldeps/auxiliary/lint-group-plugin-test.rs
+++ b/src/test/ui-fulldeps/auxiliary/lint-group-plugin-test.rs
@@ -22,7 +22,7 @@ declare_lint_pass!(Pass => [TEST_LINT, PLEASE_LINT]);
 
 impl<'tcx> LateLintPass<'tcx> for Pass {
     fn check_item(&mut self, cx: &LateContext, it: &rustc_hir::Item) {
-        match &*it.ident.as_str() {
+        match it.ident.as_str() {
             "lintme" => cx.lint(TEST_LINT, |lint| {
                 lint.build("item is named 'lintme'").set_span(it.span).emit()
             }),

--- a/src/tools/clippy/clippy_lints/src/consts.rs
+++ b/src/tools/clippy/clippy_lints/src/consts.rs
@@ -249,8 +249,8 @@ impl<'a, 'tcx> ConstEvalLateContext<'a, 'tcx> {
                     if let ExprKind::Path(qpath) = &callee.kind;
                     let res = self.typeck_results.qpath_res(qpath, callee.hir_id);
                     if let Some(def_id) = res.opt_def_id();
-                    let def_path: Vec<_> = self.lcx.get_def_path(def_id).into_iter().map(Symbol::as_str).collect();
-                    let def_path: Vec<&str> = def_path.iter().take(4).map(|s| &**s).collect();
+                    let def_path = self.lcx.get_def_path(def_id);
+                    let def_path: Vec<&str> = def_path.iter().take(4).map(|s| s.as_str()).collect();
                     if let ["core", "num", int_impl, "max_value"] = *def_path;
                     then {
                        let value = match int_impl {

--- a/src/tools/clippy/clippy_lints/src/floating_point_arithmetic.rs
+++ b/src/tools/clippy/clippy_lints/src/floating_point_arithmetic.rs
@@ -701,7 +701,7 @@ impl<'tcx> LateLintPass<'tcx> for FloatingPointArithmetic {
             let recv_ty = cx.typeck_results().expr_ty(&args[0]);
 
             if recv_ty.is_floating_point() {
-                match &*path.ident.name.as_str() {
+                match path.ident.name.as_str() {
                     "ln" => check_ln1p(cx, expr, args),
                     "log" => check_log_base(cx, expr, args),
                     "powf" => check_powf(cx, expr, args),

--- a/src/tools/clippy/clippy_lints/src/methods/manual_saturating_arithmetic.rs
+++ b/src/tools/clippy/clippy_lints/src/methods/manual_saturating_arithmetic.rs
@@ -93,7 +93,7 @@ fn is_min_or_max<'tcx>(cx: &LateContext<'tcx>, expr: &hir::Expr<'_>) -> Option<M
         if let hir::ExprKind::Path(path) = &func.kind;
         if let hir::QPath::TypeRelative(_, segment) = path;
         then {
-            match &*segment.ident.as_str() {
+            match segment.ident.as_str() {
                 "max_value" => return Some(MinMax::Max),
                 "min_value" => return Some(MinMax::Min),
                 _ => {}

--- a/src/tools/clippy/clippy_lints/src/methods/mod.rs
+++ b/src/tools/clippy/clippy_lints/src/methods/mod.rs
@@ -22,7 +22,7 @@ use rustc_middle::lint::in_external_macro;
 use rustc_middle::ty::{self, TraitRef, Ty, TyS};
 use rustc_session::{declare_lint_pass, declare_tool_lint};
 use rustc_span::source_map::Span;
-use rustc_span::symbol::{sym, SymbolStr};
+use rustc_span::symbol::sym;
 
 use crate::consts::{constant, Constant};
 use crate::utils::usage::mutated_variables;
@@ -1442,8 +1442,7 @@ impl<'tcx> LateLintPass<'tcx> for Methods {
         }
 
         let (method_names, arg_lists, method_spans) = method_calls(expr, 2);
-        let method_names: Vec<SymbolStr> = method_names.iter().map(|s| s.as_str()).collect();
-        let method_names: Vec<&str> = method_names.iter().map(|s| &**s).collect();
+        let method_names: Vec<&str> = method_names.iter().map(|s| s.as_str()).collect();
 
         match method_names.as_slice() {
             ["unwrap", "get"] => lint_get_unwrap(cx, expr, arg_lists[1], false),

--- a/src/tools/clippy/clippy_lints/src/misc.rs
+++ b/src/tools/clippy/clippy_lints/src/misc.rs
@@ -434,15 +434,16 @@ impl<'tcx> LateLintPass<'tcx> for MiscLints {
         }
         let binding = match expr.kind {
             ExprKind::Path(ref qpath) if !matches!(qpath, hir::QPath::LangItem(..)) => {
-                let binding = last_path_segment(qpath).ident.as_str();
-                if binding.starts_with('_') &&
-                    !binding.starts_with("__") &&
-                    binding != "_result" && // FIXME: #944
+                let binding = last_path_segment(qpath).ident;
+                let binding_str = binding.as_str();
+                if binding_str.starts_with('_') &&
+                    !binding_str.starts_with("__") &&
+                    binding_str != "_result" && // FIXME: #944
                     is_used(cx, expr) &&
                     // don't lint if the declaration is in a macro
                     non_macro_local(cx, cx.qpath_res(qpath, expr.hir_id))
                 {
-                    Some(binding)
+                    Some(binding.name)
                 } else {
                     None
                 }
@@ -450,7 +451,7 @@ impl<'tcx> LateLintPass<'tcx> for MiscLints {
             ExprKind::Field(_, ident) => {
                 let name = ident.as_str();
                 if name.starts_with('_') && !name.starts_with("__") {
-                    Some(name)
+                    Some(ident.name)
                 } else {
                     None
                 }

--- a/src/tools/clippy/clippy_lints/src/multiple_crate_versions.rs
+++ b/src/tools/clippy/clippy_lints/src/multiple_crate_versions.rs
@@ -43,7 +43,8 @@ impl LateLintPass<'_> for MultipleCrateVersions {
         }
 
         let metadata = unwrap_cargo_metadata!(cx, MULTIPLE_CRATE_VERSIONS, true);
-        let local_name = cx.tcx.crate_name(LOCAL_CRATE).as_str();
+        let local_name = cx.tcx.crate_name(LOCAL_CRATE);
+        let local_name = local_name.as_str();
         let mut packages = metadata.packages;
         packages.sort_by(|a, b| a.name.cmp(&b.name));
 

--- a/src/tools/clippy/clippy_lints/src/open_options.rs
+++ b/src/tools/clippy/clippy_lints/src/open_options.rs
@@ -83,7 +83,7 @@ fn get_open_options(cx: &LateContext<'_>, argument: &Expr<'_>, options: &mut Vec
                 _ => Argument::Unknown,
             };
 
-            match &*path.ident.as_str() {
+            match path.ident.as_str() {
                 "create" => {
                     options.push((OpenOption::Create, argument_option));
                 },

--- a/src/tools/clippy/clippy_lints/src/serde_api.rs
+++ b/src/tools/clippy/clippy_lints/src/serde_api.rs
@@ -34,7 +34,7 @@ impl<'tcx> LateLintPass<'tcx> for SerdeAPI {
                     let mut seen_str = None;
                     let mut seen_string = None;
                     for item in items {
-                        match &*item.ident.as_str() {
+                        match item.ident.as_str() {
                             "visit_str" => seen_str = Some(item.span),
                             "visit_string" => seen_string = Some(item.span),
                             _ => {},

--- a/src/tools/clippy/clippy_lints/src/types.rs
+++ b/src/tools/clippy/clippy_lints/src/types.rs
@@ -693,7 +693,7 @@ impl<'tcx> LateLintPass<'tcx> for UnitCmp {
                     if let ExprKind::Binary(ref cmp, ref left, _) = expr.kind {
                         let op = cmp.node;
                         if op.is_comparison() && is_unit(cx.typeck_results().expr_ty(left)) {
-                            let result = match &*symbol.as_str() {
+                            let result = match symbol.as_str() {
                                 "assert_eq" | "debug_assert_eq" => "succeed",
                                 "assert_ne" | "debug_assert_ne" => "fail",
                                 _ => return,

--- a/src/tools/clippy/clippy_lints/src/unused_io_amount.rs
+++ b/src/tools/clippy/clippy_lints/src/unused_io_amount.rs
@@ -53,7 +53,7 @@ impl<'tcx> LateLintPass<'tcx> for UnusedIoAmount {
                 }
             },
 
-            hir::ExprKind::MethodCall(ref path, _, ref args, _) => match &*path.ident.as_str() {
+            hir::ExprKind::MethodCall(ref path, _, ref args, _) => match path.ident.as_str() {
                 "expect" | "unwrap" | "unwrap_or" | "unwrap_or_else" => {
                     check_method_call(cx, &args[0], expr);
                 },


### PR DESCRIPTION
This is based on an idea from @oli-obk. The code is incomplete for the moment, and I won't have time to work on it further, but somebody else might be interested in taking it over.

Pros:
- `&str` is nicer to work with than `SymbolStr`, e.g. avoids the need for some `&` and `&*` occurrences.
- It would be nice to eliminate `SymbolStr`.
- It avoids the lie that `SymbolStr` strings have a `static` lifetime, replacing it with a smaller lie that the strings have a lifetime tied to the lifetime of the input `Symbol`.

Cons:
- That lifetime is still a lie, and it's possible to cause crashes with this.
- The lie is less obvious in a vanilla `&str` than it is within a `SymbolStr`.
- We can't mark `&str` as `!Send` and `!Sync`.
- I haven't yet eliminated `SymbolStr` entirely. The `to_stable_hash_key()` is the hardest case.

I'm totally ambivalent about whether this should land, but it seemed worth putting up here for others to look at.

r? @ghost