### PR TITLE
rustbuild: don't enable llvm AVR backend when no experiemental-targets are enabled in config.toml

### DIFF
--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -155,7 +155,7 @@ impl Step for Llvm {
 
         let llvm_exp_targets = match builder.config.llvm_experimental_targets {
             Some(ref s) => s,
-            None => "AVR",
+            None => "",
         };
 
         let assertions = if builder.config.llvm_assertions { "ON" } else { "OFF" };


### PR DESCRIPTION
Fixes #76470