### PR TITLE
Remove a stray ignore-tidy-undocumented-unsafe

### DIFF
--- a/library/core/src/ptr/unique.rs
+++ b/library/core/src/ptr/unique.rs
@@ -4,8 +4,6 @@ use crate::marker::{PhantomData, Unsize};
 use crate::mem;
 use crate::ops::{CoerceUnsized, DispatchFromDyn};
 
-// ignore-tidy-undocumented-unsafe
-
 /// A wrapper around a raw non-null `*mut T` that indicates that the possessor
 /// of this wrapper owns the referent. Useful for building abstractions like
 /// `Box<T>`, `Vec<T>`, `String`, and `HashMap<K, V>`.


### PR DESCRIPTION
There were no undocumented unsafe blocks in the file. This shouldn't require any special review.