### PR TITLE
Rollup of 10 pull requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/tracking_issue.md
+++ b/.github/ISSUE_TEMPLATE/tracking_issue.md
@@ -23,7 +23,7 @@ The feature gate for the issue is `#![feature(FFF)]`.
 ### About tracking issues
 
 Tracking issues are used to record the overall progress of implementation.
-They are also uses as hubs connecting to other relevant issues, e.g., bugs or open design questions.
+They are also used as hubs connecting to other relevant issues, e.g., bugs or open design questions.
 A tracking issue is however *not* meant for large scale discussion, questions, or bug reports about a feature.
 Instead, open a dedicated issue for the specific matter and add the relevant feature gate label.
 

--- a/compiler/rustc_expand/src/module.rs
+++ b/compiler/rustc_expand/src/module.rs
@@ -219,8 +219,7 @@ fn error_cannot_declare_mod_here<'a, T>(
 
 /// Derive a submodule path from the first found `#[path = "path_string"]`.
 /// The provided `dir_path` is joined with the `path_string`.
-// Public for rustfmt usage.
-pub fn submod_path_from_attr(
+pub(super) fn submod_path_from_attr(
     sess: &Session,
     attrs: &[Attribute],
     dir_path: &Path,

--- a/compiler/rustc_middle/src/ty/trait_def.rs
+++ b/compiler/rustc_middle/src/ty/trait_def.rs
@@ -167,7 +167,7 @@ impl<'tcx> TyCtxt<'tcx> {
         }
     }
 
-    /// Returns a vector containing all impls
+    /// Returns an iterator containing all impls
     pub fn all_impls(self, def_id: DefId) -> impl Iterator<Item = DefId> + 'tcx {
         let TraitImpls { blanket_impls, non_blanket_impls } = self.trait_impls_of(def_id);
 

--- a/library/std/src/time.rs
+++ b/library/std/src/time.rs
@@ -457,12 +457,13 @@ impl SystemTime {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```no_run
     /// use std::time::SystemTime;
     ///
     /// let sys_time = SystemTime::now();
-    /// let difference = sys_time.duration_since(sys_time)
-    ///                          .expect("Clock may have gone backwards");
+    /// let new_sys_time = SystemTime::now();
+    /// let difference = new_sys_time.duration_since(sys_time)
+    ///     .expect("Clock may have gone backwards");
     /// println!("{:?}", difference);
     /// ```
     #[stable(feature = "time2", since = "1.8.0")]

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -796,7 +796,7 @@ impl<'a> Builder<'a> {
         if cmd == "doc" || cmd == "rustdoc" {
             let my_out = match mode {
                 // This is the intended out directory for compiler documentation.
-                Mode::Rustc | Mode::ToolRustc | Mode::Codegen => self.compiler_doc_out(target),
+                Mode::Rustc | Mode::ToolRustc => self.compiler_doc_out(target),
                 Mode::Std => out_dir.join(target.triple).join("doc"),
                 _ => panic!("doc mode {:?} not expected", mode),
             };
@@ -874,7 +874,7 @@ impl<'a> Builder<'a> {
 
         match mode {
             Mode::Std | Mode::ToolBootstrap | Mode::ToolStd => {}
-            Mode::Rustc | Mode::Codegen | Mode::ToolRustc => {
+            Mode::Rustc | Mode::ToolRustc => {
                 // Build proc macros both for the host and the target
                 if target != compiler.host && cmd != "check" {
                     cargo.arg("-Zdual-proc-macros");
@@ -1059,7 +1059,7 @@ impl<'a> Builder<'a> {
         }
 
         let debuginfo_level = match mode {
-            Mode::Rustc | Mode::Codegen => self.config.rust_debuginfo_level_rustc,
+            Mode::Rustc => self.config.rust_debuginfo_level_rustc,
             Mode::Std => self.config.rust_debuginfo_level_std,
             Mode::ToolBootstrap | Mode::ToolStd | Mode::ToolRustc => {
                 self.config.rust_debuginfo_level_tools
@@ -1196,7 +1196,7 @@ impl<'a> Builder<'a> {
             rustdocflags.arg("-Winvalid_codeblock_attributes");
         }
 
-        if let Mode::Rustc | Mode::Codegen = mode {
+        if mode == Mode::Rustc {
             rustflags.arg("-Zunstable-options");
             rustflags.arg("-Wrustc::internal");
         }
@@ -1359,7 +1359,7 @@ impl<'a> Builder<'a> {
         // When we build Rust dylibs they're all intended for intermediate
         // usage, so make sure we pass the -Cprefer-dynamic flag instead of
         // linking all deps statically into the dylib.
-        if let Mode::Std | Mode::Rustc | Mode::Codegen = mode {
+        if matches!(mode, Mode::Std | Mode::Rustc) {
             rustflags.arg("-Cprefer-dynamic");
         }
 

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -300,9 +300,6 @@ pub enum Mode {
     /// Build librustc, and compiler libraries, placing output in the "stageN-rustc" directory.
     Rustc,
 
-    /// Build codegen libraries, placing output in the "stageN-codegen" directory
-    Codegen,
-
     /// Build a tool, placing output in the "stage0-bootstrap-tools"
     /// directory. This is for miscellaneous sets of tools that are built
     /// using the bootstrap stage0 compiler in its entirety (target libraries
@@ -572,7 +569,6 @@ impl Build {
         let suffix = match mode {
             Mode::Std => "-std",
             Mode::Rustc => "-rustc",
-            Mode::Codegen => "-codegen",
             Mode::ToolBootstrap => "-bootstrap-tools",
             Mode::ToolStd | Mode::ToolRustc => "-tools",
         };

--- a/src/doc/rustc/src/linker-plugin-lto.md
+++ b/src/doc/rustc/src/linker-plugin-lto.md
@@ -100,20 +100,20 @@ LLVM. However, the approximation is usually reliable.
 
 The following table shows known good combinations of toolchain versions.
 
-|           |  Clang 7  |  Clang 8  |  Clang 9  |  Clang 10 |
-|-----------|-----------|-----------|-----------|-----------|
-| Rust 1.34 |     ✗     |     ✓     |     ✗     |     ✗     |
-| Rust 1.35 |     ✗     |     ✓     |     ✗     |     ✗     |
-| Rust 1.36 |     ✗     |     ✓     |     ✗     |     ✗     |
-| Rust 1.37 |     ✗     |     ✓     |     ✗     |     ✗     |
-| Rust 1.38 |     ✗     |     ✗     |     ✓     |     ✗     |
-| Rust 1.39 |     ✗     |     ✗     |     ✓     |     ✗     |
-| Rust 1.40 |     ✗     |     ✗     |     ✓     |     ✗     |
-| Rust 1.41 |     ✗     |     ✗     |     ✓     |     ✗     |
-| Rust 1.42 |     ✗     |     ✗     |     ✓     |     ✗     |
-| Rust 1.43 |     ✗     |     ✗     |     ✓     |     ✗     |
-| Rust 1.44 |     ✗     |     ✗     |     ✓     |     ✗     |
-| Rust 1.45 |     ✗     |     ✗     |     ✗     |     ✓     |
-| Rust 1.46 |     ✗     |     ✗     |     ✗     |     ✓     |
+| Rust Version | Clang Version |
+|--------------|---------------|
+| Rust 1.34    |    Clang 8    |
+| Rust 1.35    |    Clang 8    |
+| Rust 1.36    |    Clang 8    |
+| Rust 1.37    |    Clang 8    |
+| Rust 1.38    |    Clang 9    |
+| Rust 1.39    |    Clang 9    |
+| Rust 1.40    |    Clang 9    |
+| Rust 1.41    |    Clang 9    |
+| Rust 1.42    |    Clang 9    |
+| Rust 1.43    |    Clang 9    |
+| Rust 1.44    |    Clang 9    |
+| Rust 1.45    |    Clang 10   |
+| Rust 1.46    |    Clang 10   |
 
 Note that the compatibility policy for this feature might change in the future.

--- a/src/doc/rustc/src/linker-plugin-lto.md
+++ b/src/doc/rustc/src/linker-plugin-lto.md
@@ -100,17 +100,20 @@ LLVM. However, the approximation is usually reliable.
 
 The following table shows known good combinations of toolchain versions.
 
-|           |  Clang 7  |  Clang 8  |  Clang 9  |
-|-----------|-----------|-----------|-----------|
-| Rust 1.34 |     ✗     |     ✓     |     ✗     |
-| Rust 1.35 |     ✗     |     ✓     |     ✗     |
-| Rust 1.36 |     ✗     |     ✓     |     ✗     |
-| Rust 1.37 |     ✗     |     ✓     |     ✗     |
-| Rust 1.38 |     ✗     |     ✗     |     ✓     |
-| Rust 1.39 |     ✗     |     ✗     |     ✓     |
-| Rust 1.40 |     ✗     |     ✗     |     ✓     |
-| Rust 1.41 |     ✗     |     ✗     |     ✓     |
-| Rust 1.42 |     ✗     |     ✗     |     ✓     |
-| Rust 1.43 |     ✗     |     ✗     |     ✓     |
+|           |  Clang 7  |  Clang 8  |  Clang 9  |  Clang 10 |
+|-----------|-----------|-----------|-----------|-----------|
+| Rust 1.34 |     ✗     |     ✓     |     ✗     |     ✗     |
+| Rust 1.35 |     ✗     |     ✓     |     ✗     |     ✗     |
+| Rust 1.36 |     ✗     |     ✓     |     ✗     |     ✗     |
+| Rust 1.37 |     ✗     |     ✓     |     ✗     |     ✗     |
+| Rust 1.38 |     ✗     |     ✗     |     ✓     |     ✗     |
+| Rust 1.39 |     ✗     |     ✗     |     ✓     |     ✗     |
+| Rust 1.40 |     ✗     |     ✗     |     ✓     |     ✗     |
+| Rust 1.41 |     ✗     |     ✗     |     ✓     |     ✗     |
+| Rust 1.42 |     ✗     |     ✗     |     ✓     |     ✗     |
+| Rust 1.43 |     ✗     |     ✗     |     ✓     |     ✗     |
+| Rust 1.44 |     ✗     |     ✗     |     ✓     |     ✗     |
+| Rust 1.45 |     ✗     |     ✗     |     ✗     |     ✓     |
+| Rust 1.46 |     ✗     |     ✗     |     ✗     |     ✓     |
 
 Note that the compatibility policy for this feature might change in the future.

--- a/src/etc/natvis/libstd.natvis
+++ b/src/etc/natvis/libstd.natvis
@@ -41,7 +41,7 @@
           <If Condition="(base.table.ctrl.pointer[i] &amp; 0x80) == 0">
             <!-- Bucket is populated -->
             <Exec>n--</Exec>
-            <Item Name="{static_cast&lt;tuple&lt;$T1, $T2&gt;*&gt;(base.table.ctrl.pointer)[-(i + 1)].__0}">static_cast&lt;tuple&lt;$T1, $T2&gt;*&gt;(base.table.ctrl.pointer)[-(i + 1)].__1</Item>
+            <Item Name="{((tuple&lt;$T1, $T2&gt;*)base.table.ctrl.pointer)[-(i + 1)].__0}">((tuple&lt;$T1, $T2&gt;*)base.table.ctrl.pointer)[-(i + 1)].__1</Item>
           </If>
           <Exec>i++</Exec>
         </Loop>
@@ -65,7 +65,7 @@
           <If Condition="(map.base.table.ctrl.pointer[i] &amp; 0x80) == 0">
             <!-- Bucket is populated -->
             <Exec>n--</Exec>
-            <Item>static_cast&lt;$T1*&gt;(map.base.table.ctrl.pointer)[-(i + 1)]</Item>
+            <Item>(($T1*)map.base.table.ctrl.pointer)[-(i + 1)]</Item>
           </If>
           <Exec>i++</Exec>
         </Loop>

--- a/src/librustdoc/html/static/themes/ayu.css
+++ b/src/librustdoc/html/static/themes/ayu.css
@@ -129,9 +129,10 @@ pre {
 	color: #ffb44c;
 }
 
-.line-numbers span { color: #5c6773ab; }
+.line-numbers span { color: #5c6773; }
 .line-numbers .line-highlighted {
-	background-color: rgba(255, 236, 164, 0.06) !important;
+	color: #708090;
+	background-color: rgba(255, 236, 164, 0.06);
 	padding-right: 4px;
 	border-right: 1px solid #ffb44c;
 }

--- a/src/test/ui/const-generics/issues/issue-68366.rs
+++ b/src/test/ui/const-generics/issues/issue-68366.rs
@@ -1,0 +1,18 @@
+// Checks that const expressions have a useful note explaining why they can't be evaluated.
+// The note should relate to the fact that it cannot be shown forall N that it maps 1-1 to a new
+// type.
+
+#![feature(const_generics)]
+#![allow(incomplete_features)]
+
+struct Collatz<const N: Option<usize>>;
+
+impl <const N: usize> Collatz<{Some(N)}> {}
+//~^ ERROR the const parameter
+
+struct Foo;
+
+impl<const N: usize> Foo {}
+//~^ ERROR the const parameter
+
+fn main() {}

--- a/src/test/ui/const-generics/issues/issue-68366.stderr
+++ b/src/test/ui/const-generics/issues/issue-68366.stderr
@@ -1,0 +1,21 @@
+error[E0207]: the const parameter `N` is not constrained by the impl trait, self type, or predicates
+  --> $DIR/issue-68366.rs:10:13
+   |
+LL | impl <const N: usize> Collatz<{Some(N)}> {}
+   |             ^ unconstrained const parameter
+   |
+   = note: expressions using a const parameter must map each value to a distinct output value
+   = note: proving the result of expressions other than the parameter are unique is not supported
+
+error[E0207]: the const parameter `N` is not constrained by the impl trait, self type, or predicates
+  --> $DIR/issue-68366.rs:15:12
+   |
+LL | impl<const N: usize> Foo {}
+   |            ^ unconstrained const parameter
+   |
+   = note: expressions using a const parameter must map each value to a distinct output value
+   = note: proving the result of expressions other than the parameter are unique is not supported
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0207`.


### PR DESCRIPTION
Successful merges:

 - #76162 (Make duration_since documentation more clear)
 - #76355 (remove public visibility previously needed for rustfmt)
 - #76374 (Improve ayu doc source line number contrast)
 - #76379 (rustbuild: Remove `Mode::Codegen`)
 - #76389 (Fix HashMap visualizers in Visual Studio (Code))
 - #76396 (Fix typo in tracking issue template)
 - #76401 (Add help note to unconstrained const parameter)
 - #76402 (Update linker-plugin-lto.md to contain up to rust 1.46)
 - #76403 (Fix documentation for TyCtxt::all_impls)
 - #76498 (Update cargo)

Failed merges:

 - #76458 (Add drain_filter method to HashMap and HashSet)

r? @ghost