### PR TITLE
Enable GitHub Releases synchronization

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -99,3 +99,9 @@ message_on_add = """\
 - Needs `I-nominated`?
 """
 message_on_remove = "Issue #{number}'s prioritization request has been removed."
+
+[github-releases]
+format = "rustc"
+project-name = "Rust"
+changelog-path = "RELEASES.md"
+changelog-branch = "master"


### PR DESCRIPTION
This PR enables the triagebot feature to automatically populate [GitHub Releases](https://github.com/rust-lang/rust/releases) for this repository based on the changelog. See https://github.com/rust-lang/triagebot/pull/811 for the implementation of this feature on triagebot's side, and more insights on how it works.

Note: once this lands people subscribed to the ~~firehose~~ rust-lang/rust repository will probably receive a ton of notifications for all the releases being created, but this should be a one-time thing.

r? @Mark-Simulacrum 
cc @rust-lang/release 