### PR TITLE
typeck: don't suggest inaccessible private fields

### DIFF
--- a/src/test/ui/issues/issue-76077-1.fixed
+++ b/src/test/ui/issues/issue-76077-1.fixed
@@ -1,0 +1,18 @@
+// run-rustfix
+#![allow(dead_code, unused_variables)]
+
+pub mod foo {
+    #[derive(Default)]
+    pub struct Foo { invisible: bool, }
+
+    #[derive(Default)]
+    pub struct Bar { pub visible: bool, invisible: bool, }
+}
+
+fn main() {
+    let foo::Foo { .. } = foo::Foo::default();
+    //~^ ERROR pattern requires `..` due to inaccessible fields
+
+    let foo::Bar { visible, .. } = foo::Bar::default();
+    //~^ ERROR pattern requires `..` due to inaccessible fields
+}

--- a/src/test/ui/issues/issue-76077-1.rs
+++ b/src/test/ui/issues/issue-76077-1.rs
@@ -1,0 +1,18 @@
+// run-rustfix
+#![allow(dead_code, unused_variables)]
+
+pub mod foo {
+    #[derive(Default)]
+    pub struct Foo { invisible: bool, }
+
+    #[derive(Default)]
+    pub struct Bar { pub visible: bool, invisible: bool, }
+}
+
+fn main() {
+    let foo::Foo {} = foo::Foo::default();
+    //~^ ERROR pattern requires `..` due to inaccessible fields
+
+    let foo::Bar { visible } = foo::Bar::default();
+    //~^ ERROR pattern requires `..` due to inaccessible fields
+}

--- a/src/test/ui/issues/issue-76077-1.stderr
+++ b/src/test/ui/issues/issue-76077-1.stderr
@@ -1,0 +1,24 @@
+error: pattern requires `..` due to inaccessible fields
+  --> $DIR/issue-76077-1.rs:13:9
+   |
+LL |     let foo::Foo {} = foo::Foo::default();
+   |         ^^^^^^^^^^^
+   |
+help: ignore the inaccessible and unused fields
+   |
+LL |     let foo::Foo { .. } = foo::Foo::default();
+   |                  ^^^^^^
+
+error: pattern requires `..` due to inaccessible fields
+  --> $DIR/issue-76077-1.rs:16:9
+   |
+LL |     let foo::Bar { visible } = foo::Bar::default();
+   |         ^^^^^^^^^^^^^^^^^^^^
+   |
+help: ignore the inaccessible and unused fields
+   |
+LL |     let foo::Bar { visible, .. } = foo::Bar::default();
+   |                           ^^^^
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/issues/issue-76077.rs
+++ b/src/test/ui/issues/issue-76077.rs
@@ -1,0 +1,10 @@
+pub mod foo {
+    pub struct Foo {
+        you_cant_use_this_field: bool,
+    }
+}
+
+fn main() {
+    foo::Foo {};
+    //~^ ERROR cannot construct `Foo` with struct literal syntax due to inaccessible fields
+}

--- a/src/test/ui/issues/issue-76077.stderr
+++ b/src/test/ui/issues/issue-76077.stderr
@@ -1,0 +1,8 @@
+error: cannot construct `Foo` with struct literal syntax due to inaccessible fields
+  --> $DIR/issue-76077.rs:8:5
+   |
+LL |     foo::Foo {};
+   |     ^^^^^^^^
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Fixes #76077.

This PR adjusts the missing field diagnostic logic in typeck so that when none of the missing fields in a struct expr are accessible then the error is less confusing.

r? @estebank