### PR TITLE
Add as_str() to string::Drain.

### DIFF
--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -2475,21 +2475,21 @@ impl<'a> Drain<'a> {
     /// let _ = drain.next().unwrap();
     /// assert_eq!(drain.as_str(), "bc");
     /// ```
-    #[unstable(feature = "string_drain_as_str", issue = "none")] // Note: uncomment AsRef impls below when stabilizing.
+    #[unstable(feature = "string_drain_as_str", issue = "76905")] // Note: uncomment AsRef impls below when stabilizing.
     pub fn as_str(&self) -> &str {
         self.iter.as_str()
     }
 }
 
 // Uncomment when stabilizing `string_drain_as_str`.
-// #[unstable(feature = "string_drain_as_str", issue = "none")]
+// #[unstable(feature = "string_drain_as_str", issue = "76905")]
 // impl<'a> AsRef<str> for Drain<'a> {
 //     fn as_ref(&self) -> &str {
 //         self.as_str()
 //     }
 // }
 //
-// #[unstable(feature = "string_drain_as_str", issue = "none")]
+// #[unstable(feature = "string_drain_as_str", issue = "76905")]
 // impl<'a> AsRef<[u8]> for Drain<'a> {
 //     fn as_ref(&self) -> &[u8] {
 //         self.as_str().as_bytes()

--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -2439,7 +2439,7 @@ pub struct Drain<'a> {
 #[stable(feature = "collection_debug", since = "1.17.0")]
 impl fmt::Debug for Drain<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.pad("Drain { .. }")
+        f.debug_tuple("Drain").field(&self.as_str()).finish()
     }
 }
 

--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -2481,14 +2481,14 @@ impl<'a> Drain<'a> {
     }
 }
 
-#[unstable(feature = "string_drain_as_str", issue = "none")]
+#[stable(feature = "string_drain_as_ref", since = "1.48.0")]
 impl<'a> AsRef<str> for Drain<'a> {
     fn as_ref(&self) -> &str {
         self.as_str()
     }
 }
 
-#[unstable(feature = "string_drain_as_str", issue = "none")]
+#[stable(feature = "string_drain_as_ref", since = "1.48.0")]
 impl<'a> AsRef<[u8]> for Drain<'a> {
     fn as_ref(&self) -> &[u8] {
         self.as_str().as_bytes()

--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -2475,25 +2475,26 @@ impl<'a> Drain<'a> {
     /// let _ = drain.next().unwrap();
     /// assert_eq!(drain.as_str(), "bc");
     /// ```
-    #[unstable(feature = "string_drain_as_str", issue = "none")]
+    #[unstable(feature = "string_drain_as_str", issue = "none")] // Note: uncomment AsRef impls below when stabilizing.
     pub fn as_str(&self) -> &str {
         self.iter.as_str()
     }
 }
 
-#[stable(feature = "string_drain_as_ref", since = "1.48.0")]
-impl<'a> AsRef<str> for Drain<'a> {
-    fn as_ref(&self) -> &str {
-        self.as_str()
-    }
-}
-
-#[stable(feature = "string_drain_as_ref", since = "1.48.0")]
-impl<'a> AsRef<[u8]> for Drain<'a> {
-    fn as_ref(&self) -> &[u8] {
-        self.as_str().as_bytes()
-    }
-}
+// Uncomment when stabilizing `string_drain_as_str`.
+// #[unstable(feature = "string_drain_as_str", issue = "none")]
+// impl<'a> AsRef<str> for Drain<'a> {
+//     fn as_ref(&self) -> &str {
+//         self.as_str()
+//     }
+// }
+//
+// #[unstable(feature = "string_drain_as_str", issue = "none")]
+// impl<'a> AsRef<[u8]> for Drain<'a> {
+//     fn as_ref(&self) -> &[u8] {
+//         self.as_str().as_bytes()
+//     }
+// }
 
 #[stable(feature = "drain", since = "1.6.0")]
 impl Iterator for Drain<'_> {

--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -2462,6 +2462,32 @@ impl Drop for Drain<'_> {
     }
 }
 
+impl<'a> Drain<'a> {
+    /// Returns the remaining (sub)string of this iterator as a slice.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(string_drain_as_str)]
+    /// let mut s = String::from("abc");
+    /// let mut drain = s.drain(..);
+    /// assert_eq!(drain.as_str(), "abc");
+    /// let _ = drain.next().unwrap();
+    /// assert_eq!(drain.as_str(), "bc");
+    /// ```
+    #[unstable(feature = "string_drain_as_str", issue = "none")]
+    pub fn as_str(&self) -> &str {
+        self.iter.as_str()
+    }
+}
+
+#[unstable(feature = "string_drain_as_str", issue = "none")]
+impl<'a> AsRef<str> for Drain<'a> {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
 #[stable(feature = "drain", since = "1.6.0")]
 impl Iterator for Drain<'_> {
     type Item = char;

--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -2488,6 +2488,13 @@ impl<'a> AsRef<str> for Drain<'a> {
     }
 }
 
+#[unstable(feature = "string_drain_as_str", issue = "none")]
+impl<'a> AsRef<[u8]> for Drain<'a> {
+    fn as_ref(&self) -> &[u8] {
+        self.as_str().as_bytes()
+    }
+}
+
 #[stable(feature = "drain", since = "1.6.0")]
 impl Iterator for Drain<'_> {
     type Item = char;


### PR DESCRIPTION
Vec's Drain recently [had its `.as_slice()` stabilized](https://github.com/rust-lang/rust/pull/72584), but String's Drain was still missing the analogous `.as_str()`. This adds that.

Also improves the Debug implementation, which now shows the remaining data instead of just `"Drain { .. }"`.