### PR TITLE
Add variable name to VarError for NotPresent variant

### DIFF
--- a/library/std/src/env.rs
+++ b/library/std/src/env.rs
@@ -208,7 +208,7 @@ pub fn var<K: AsRef<OsStr>>(key: K) -> Result<String, VarError> {
 fn _var(key: &OsStr) -> Result<String, VarError> {
     match var_os(key) {
         Some(s) => s.into_string().map_err(VarError::NotUnicode),
-        None => Err(VarError::NotPresent),
+        None => Err(VarError::NotPresent(key.to_os_string())),
     }
 }
 
@@ -252,7 +252,7 @@ pub enum VarError {
     /// The specified environment variable was not present in the current
     /// process's environment.
     #[stable(feature = "env", since = "1.0.0")]
-    NotPresent,
+    NotPresent(OsString),
 
     /// The specified environment variable was found, but it did not contain
     /// valid unicode data. The found data is returned as a payload of this
@@ -265,7 +265,7 @@ pub enum VarError {
 impl fmt::Display for VarError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
-            VarError::NotPresent => write!(f, "environment variable not found"),
+            VarError::NotPresent(ref s) => write!(f, "environment variable {:?} not found", s),
             VarError::NotUnicode(ref s) => {
                 write!(f, "environment variable was not valid unicode: {:?}", s)
             }
@@ -278,7 +278,7 @@ impl Error for VarError {
     #[allow(deprecated)]
     fn description(&self) -> &str {
         match *self {
-            VarError::NotPresent => "environment variable not found",
+            VarError::NotPresent(..) => "environment variable not found",
             VarError::NotUnicode(..) => "environment variable was not valid unicode",
         }
     }


### PR DESCRIPTION
Hi,
This PR is probably not going to fly as is but it is a rough sketch of what I want to do. To me it makes a lot of sense to have the variable name in the error instead of ugly wrappers in calling libraries.
If you have even just 4 or 5 environment variables in your application it can get daunting very quickly to find out what is wrong.
For me this is also a sort of security guarantee to ensure quick identification of the erroneous source.
Thank you for anyone reviewing this.