### PR TITLE
Warn for #[unstable] on trait impls when it has no effect.

### DIFF
--- a/compiler/rustc_passes/src/stability.rs
+++ b/compiler/rustc_passes/src/stability.rs
@@ -561,10 +561,10 @@ impl Visitor<'tcx> for Checker<'tcx> {
                                 INEFFECTIVE_UNSTABLE_TRAIT_IMPL,
                                 item.hir_id,
                                 span,
-                                |lint| lint.build(
-                                    "An `#[unstable]` annotation here has no effect. \
-                                    See issue #55436 <https://github.com/rust-lang/rust/issues/55436> for more information.",
-                                ).emit()
+                                |lint| lint
+                                    .build("an `#[unstable]` annotation here has no effect")
+                                    .note("see issue #55436 <https://github.com/rust-lang/rust/issues/55436> for more information")
+                                    .emit()
                             );
                         }
                     }

--- a/compiler/rustc_passes/src/stability.rs
+++ b/compiler/rustc_passes/src/stability.rs
@@ -555,7 +555,7 @@ impl Visitor<'tcx> for Checker<'tcx> {
                             .iter()
                             .find(|a| a.has_name(sym::unstable))
                             .map_or(item.span, |a| a.span);
-                        self.tcx.sess.span_warn(
+                        self.tcx.sess.span_err(
                             span,
                             "An `#[unstable]` annotation here has no effect. \
                             See issue #55436 <https://github.com/rust-lang/rust/issues/55436> for more information.",

--- a/compiler/rustc_session/src/lint/builtin.rs
+++ b/compiler/rustc_session/src/lint/builtin.rs
@@ -5,7 +5,7 @@
 //! lints are all available in `rustc_lint::builtin`.
 
 use crate::lint::FutureIncompatibleInfo;
-use crate::{declare_lint, declare_lint_pass};
+use crate::{declare_lint, declare_lint_pass, declare_tool_lint};
 use rustc_span::edition::Edition;
 use rustc_span::symbol::sym;
 
@@ -555,6 +555,12 @@ declare_lint! {
     };
 }
 
+declare_tool_lint! {
+    pub rustc::INEFFECTIVE_UNSTABLE_TRAIT_IMPL,
+    Deny,
+    "detects `#[unstable]` on stable trait implementations for stable types"
+}
+
 declare_lint_pass! {
     /// Does nothing as a lint pass, but registers some `Lint`s
     /// that are used by other parts of the compiler.
@@ -630,6 +636,7 @@ declare_lint_pass! {
         INCOMPLETE_INCLUDE,
         CENUM_IMPL_DROP_CAST,
         CONST_EVALUATABLE_UNCHECKED,
+        INEFFECTIVE_UNSTABLE_TRAIT_IMPL,
     ]
 }
 

--- a/library/alloc/src/task.rs
+++ b/library/alloc/src/task.rs
@@ -33,6 +33,7 @@ pub trait Wake {
     }
 }
 
+#[allow(rustc::ineffective_unstable_trait_impl)]
 #[unstable(feature = "wake_trait", issue = "69912")]
 impl<W: Wake + Send + Sync + 'static> From<Arc<W>> for Waker {
     fn from(waker: Arc<W>) -> Waker {
@@ -42,6 +43,7 @@ impl<W: Wake + Send + Sync + 'static> From<Arc<W>> for Waker {
     }
 }
 
+#[allow(rustc::ineffective_unstable_trait_impl)]
 #[unstable(feature = "wake_trait", issue = "69912")]
 impl<W: Wake + Send + Sync + 'static> From<Arc<W>> for RawWaker {
     fn from(waker: Arc<W>) -> RawWaker {

--- a/library/std/src/error.rs
+++ b/library/std/src/error.rs
@@ -389,11 +389,7 @@ impl Error for ! {}
 )]
 impl Error for AllocErr {}
 
-#[unstable(
-    feature = "allocator_api",
-    reason = "the precise API and guarantees it provides may be tweaked.",
-    issue = "32838"
-)]
+#[stable(feature = "alloc_layout", since = "1.28.0")]
 impl Error for LayoutErr {}
 
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/library/std/src/panic.rs
+++ b/library/std/src/panic.rs
@@ -232,16 +232,16 @@ impl<T: ?Sized> RefUnwindSafe for RwLock<T> {}
 #[stable(feature = "unwind_safe_atomic_refs", since = "1.14.0")]
 impl RefUnwindSafe for atomic::AtomicIsize {}
 #[cfg(target_has_atomic_load_store = "8")]
-#[unstable(feature = "integer_atomics", issue = "32976")]
+#[stable(feature = "integer_atomics_stable", since = "1.34.0")]
 impl RefUnwindSafe for atomic::AtomicI8 {}
 #[cfg(target_has_atomic_load_store = "16")]
-#[unstable(feature = "integer_atomics", issue = "32976")]
+#[stable(feature = "integer_atomics_stable", since = "1.34.0")]
 impl RefUnwindSafe for atomic::AtomicI16 {}
 #[cfg(target_has_atomic_load_store = "32")]
-#[unstable(feature = "integer_atomics", issue = "32976")]
+#[stable(feature = "integer_atomics_stable", since = "1.34.0")]
 impl RefUnwindSafe for atomic::AtomicI32 {}
 #[cfg(target_has_atomic_load_store = "64")]
-#[unstable(feature = "integer_atomics", issue = "32976")]
+#[stable(feature = "integer_atomics_stable", since = "1.34.0")]
 impl RefUnwindSafe for atomic::AtomicI64 {}
 #[cfg(target_has_atomic_load_store = "128")]
 #[unstable(feature = "integer_atomics", issue = "32976")]
@@ -251,16 +251,16 @@ impl RefUnwindSafe for atomic::AtomicI128 {}
 #[stable(feature = "unwind_safe_atomic_refs", since = "1.14.0")]
 impl RefUnwindSafe for atomic::AtomicUsize {}
 #[cfg(target_has_atomic_load_store = "8")]
-#[unstable(feature = "integer_atomics", issue = "32976")]
+#[stable(feature = "integer_atomics_stable", since = "1.34.0")]
 impl RefUnwindSafe for atomic::AtomicU8 {}
 #[cfg(target_has_atomic_load_store = "16")]
-#[unstable(feature = "integer_atomics", issue = "32976")]
+#[stable(feature = "integer_atomics_stable", since = "1.34.0")]
 impl RefUnwindSafe for atomic::AtomicU16 {}
 #[cfg(target_has_atomic_load_store = "32")]
-#[unstable(feature = "integer_atomics", issue = "32976")]
+#[stable(feature = "integer_atomics_stable", since = "1.34.0")]
 impl RefUnwindSafe for atomic::AtomicU32 {}
 #[cfg(target_has_atomic_load_store = "64")]
-#[unstable(feature = "integer_atomics", issue = "32976")]
+#[stable(feature = "integer_atomics_stable", since = "1.34.0")]
 impl RefUnwindSafe for atomic::AtomicU64 {}
 #[cfg(target_has_atomic_load_store = "128")]
 #[unstable(feature = "integer_atomics", issue = "32976")]

--- a/src/test/ui/stability-attribute/stability-attribute-trait-impl.rs
+++ b/src/test/ui/stability-attribute/stability-attribute-trait-impl.rs
@@ -22,7 +22,7 @@ impl StableTrait for UnstableType {}
 impl UnstableTrait for StableType {}
 
 #[unstable(feature = "x", issue = "none")]
-//~^ ERROR An `#[unstable]` annotation here has no effect.
+//~^ ERROR an `#[unstable]` annotation here has no effect [rustc::ineffective_unstable_trait_impl]
 impl StableTrait for StableType {}
 
 fn main() {}

--- a/src/test/ui/stability-attribute/stability-attribute-trait-impl.rs
+++ b/src/test/ui/stability-attribute/stability-attribute-trait-impl.rs
@@ -1,0 +1,28 @@
+#![feature(staged_api)]
+
+#[stable(feature = "x", since = "1")]
+struct StableType;
+
+#[unstable(feature = "x", issue = "none")]
+struct UnstableType;
+
+#[stable(feature = "x", since = "1")]
+trait StableTrait {}
+
+#[unstable(feature = "x", issue = "none")]
+trait UnstableTrait {}
+
+#[unstable(feature = "x", issue = "none")]
+impl UnstableTrait for UnstableType {}
+
+#[unstable(feature = "x", issue = "none")]
+impl StableTrait for UnstableType {}
+
+#[unstable(feature = "x", issue = "none")]
+impl UnstableTrait for StableType {}
+
+#[unstable(feature = "x", issue = "none")]
+//~^ ERROR An `#[unstable]` annotation here has no effect.
+impl StableTrait for StableType {}
+
+fn main() {}

--- a/src/test/ui/stability-attribute/stability-attribute-trait-impl.stderr
+++ b/src/test/ui/stability-attribute/stability-attribute-trait-impl.stderr
@@ -1,10 +1,11 @@
-error: An `#[unstable]` annotation here has no effect. See issue #55436 <https://github.com/rust-lang/rust/issues/55436> for more information.
+error: an `#[unstable]` annotation here has no effect
   --> $DIR/stability-attribute-trait-impl.rs:24:1
    |
 LL | #[unstable(feature = "x", issue = "none")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[deny(rustc::ineffective_unstable_trait_impl)]` on by default
+   = note: see issue #55436 <https://github.com/rust-lang/rust/issues/55436> for more information
 
 error: aborting due to previous error
 

--- a/src/test/ui/stability-attribute/stability-attribute-trait-impl.stderr
+++ b/src/test/ui/stability-attribute/stability-attribute-trait-impl.stderr
@@ -1,0 +1,10 @@
+error: An `#[unstable]` annotation here has no effect. See issue #55436 <https://github.com/rust-lang/rust/issues/55436> for more information.
+  --> $DIR/stability-attribute-trait-impl.rs:24:1
+   |
+LL | #[unstable(feature = "x", issue = "none")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `#[deny(rustc::ineffective_unstable_trait_impl)]` on by default
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Earlier today I sent a PR with an `#[unstable]` attribute on a trait `impl`, but was informed that this attribute has no effect there. (comment: https://github.com/rust-lang/rust/pull/76525#issuecomment-689678895, issue: https://github.com/rust-lang/rust/issues/55436)

This PR adds a warning for this situation. Trait `impl` blocks with `#[unstable]` where both the type and the trait are stable will result in a warning:

```
warning: An `#[unstable]` annotation here has no effect. See issue #55436 <https://github.com/rust-lang/rust/issues/55436> for more information.
   --> library/std/src/panic.rs:235:1
    |
235 | #[unstable(feature = "integer_atomics", issue = "32976")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

---

It detects three problems in the existing code:

1. A few `RefUnwindSafe` implementations for the atomic integer types in `library/std/src/panic.rs`. Example:
https://github.com/rust-lang/rust/blob/d92155bf6ae0b7d79fc83cbeeb0cc0c765353471/library/std/src/panic.rs#L235-L236
2. An implementation of `Error` for `LayoutErr` in `library/std/srd/error.rs`:
https://github.com/rust-lang/rust/blob/d92155bf6ae0b7d79fc83cbeeb0cc0c765353471/library/std/src/error.rs#L392-L397
3. `From` implementations for `Waker` and `RawWaker` in `library/alloc/src/task.rs`. Example:
https://github.com/rust-lang/rust/blob/d92155bf6ae0b7d79fc83cbeeb0cc0c765353471/library/alloc/src/task.rs#L36-L37

Case 3 interesting: It has a bound with an `#[unstable]` trait (`W: Wake`), so appears to have not much effect on stable code. It does however break similar blanket implementations. It would also have immediate effect if `Wake` was implemented for any stable type. (Which is not the case right now, but there are no warnings in place to prevent it.) Whether this case is a problem or not is not clear to me. If it isn't, adding a simple `c.visit_generics(..);` to this PR will stop the warning for this case.