### PR TITLE
use sort_unstable to sort primitive types

### DIFF
--- a/compiler/rustc_ast/src/util/lev_distance.rs
+++ b/compiler/rustc_ast/src/util/lev_distance.rs
@@ -103,6 +103,7 @@ fn find_match_by_sorted_words<'a>(iter_names: Vec<&'a Symbol>, lookup: &str) -> 
 
 fn sort_by_words(name: &str) -> String {
     let mut split_words: Vec<&str> = name.split('_').collect();
-    split_words.sort();
+    // We are sorting primitive &strs and can use unstable sort here
+    split_words.sort_unstable();
     split_words.join("_")
 }

--- a/compiler/rustc_ast_lowering/src/expr.rs
+++ b/compiler/rustc_ast_lowering/src/expr.rs
@@ -1121,7 +1121,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 // features. We check that at least one type is available for
                 // the current target.
                 let reg_class = reg.reg_class();
-                let mut required_features = vec![];
+                let mut required_features: Vec<&str> = vec![];
                 for &(_, feature) in reg_class.supported_types(asm_arch) {
                     if let Some(feature) = feature {
                         if self.sess.target_features.contains(&Symbol::intern(feature)) {
@@ -1135,7 +1135,8 @@ impl<'hir> LoweringContext<'_, 'hir> {
                         break;
                     }
                 }
-                required_features.sort();
+                // We are sorting primitive strs here and can use unstable sort here
+                required_features.sort_unstable();
                 required_features.dedup();
                 match &required_features[..] {
                     [] => {}

--- a/compiler/rustc_lint/src/non_ascii_idents.rs
+++ b/compiler/rustc_lint/src/non_ascii_idents.rs
@@ -212,7 +212,8 @@ impl EarlyLintPass for NonAsciiIdents {
                         }
                     }
 
-                    ch_list.sort();
+                    // We sort primitive chars here and can use unstable sort
+                    ch_list.sort_unstable();
                     ch_list.dedup();
                     lint_reports.insert((sp, ch_list), augment_script_set);
                 }

--- a/compiler/rustc_mir/src/monomorphize/partitioning/merging.rs
+++ b/compiler/rustc_mir/src/monomorphize/partitioning/merging.rs
@@ -74,7 +74,9 @@ pub fn merge_codegen_units<'tcx>(
 
                 // Sort the names, so things are deterministic and easy to
                 // predict.
-                cgu_contents.sort();
+
+                // We are sorting primitive &strs here so we can use unstable sort
+                cgu_contents.sort_unstable();
 
                 (current_cgu_name, cgu_contents.join("--"))
             })

--- a/compiler/rustc_mir/src/transform/simplify_try.rs
+++ b/compiler/rustc_mir/src/transform/simplify_try.rs
@@ -230,8 +230,8 @@ fn get_arm_identity_info<'a, 'tcx>(
             }
         }
     }
-
-    nop_stmts.sort();
+    // We sort primitive usize here so we can use unstable sort
+    nop_stmts.sort_unstable();
 
     // Use one of the statements we're going to discard between the point
     // where the storage location for the variant field becomes live and

--- a/compiler/rustc_typeck/src/check/mod.rs
+++ b/compiler/rustc_typeck/src/check/mod.rs
@@ -4266,11 +4266,13 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             None
                         }
                     })
-                    .collect::<Vec<_>>();
+                    .collect::<Vec<usize>>();
 
                 // Both checked and coerced types could have matched, thus we need to remove
                 // duplicates.
-                referenced_in.sort();
+
+                // We sort primitive type usize here and can use unstable sort
+                referenced_in.sort_unstable();
                 referenced_in.dedup();
 
                 if let (Some(ref_in), None) = (referenced_in.pop(), referenced_in.pop()) {


### PR DESCRIPTION
It's not important to retain original order if we have &[1, 1, 2, 3] for example.

clippy::stable_sort_primitive