### PR TITLE
Optimize Option::clone to Copy when possible

### DIFF
--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -1228,7 +1228,7 @@ fn expect_none_failed(msg: &str, value: &dyn fmt::Debug) -> ! {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: Clone> Clone for Option<T> {
     #[inline]
-    fn clone(&self) -> Self {
+    default fn clone(&self) -> Self {
         match self {
             Some(x) => Some(x.clone()),
             None => None,
@@ -1236,13 +1236,27 @@ impl<T: Clone> Clone for Option<T> {
     }
 
     #[inline]
-    fn clone_from(&mut self, source: &Self) {
+    default fn clone_from(&mut self, source: &Self) {
         match (self, source) {
             (Some(to), Some(from)) => to.clone_from(from),
             (to, from) => *to = from.clone(),
         }
     }
 }
+
+#[stable(feature = "rust1", since = "1.0.0")]
+impl<T: Copy> Clone for Option<T> {
+    #[inline]
+    fn clone(&self) -> Self {
+        *self
+    }
+
+    #[inline]
+    fn clone_from(&mut self, source: &Self) {
+        *self = *source
+    }
+}
+
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T> Default for Option<T> {

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -134,8 +134,8 @@
 use crate::iter::{FromIterator, FusedIterator, TrustedLen};
 use crate::pin::Pin;
 use crate::{
-    convert, fmt, hint, mem,
-    ops::{self, Deref, DerefMut},
+    convert, fmt, hint, mem, ptr,
+    ops::{self, Deref, DerefMut, Range},
 };
 
 /// The `Option` type. See [the module level documentation](self) for more.
@@ -1257,6 +1257,16 @@ impl<T: Copy> Clone for Option<T> {
     }
 }
 
+// Range<T> is not Copy even if T is copy (see #27186),
+// so provide an efficient implementation.
+#[stable(feature = "rust1", since = "1.0.0")]
+impl<T: Copy> Clone for Option<Range<T>> {
+    #[inline]
+    fn clone(&self) -> Self {
+        // SAFETY: 'self' is not Drop so memcpy is OK.
+        unsafe { ptr::read(self as *const Self) }
+    }
+}
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T> Default for Option<T> {


### PR DESCRIPTION
This is a pair of commits that attempt to improve the codegen of 
Option::clone.

The first commit "specializes" `Option<T: Copy>::clone` to a memcpy. For 
example, as of this PR, cloning an `Option<[u8; 8]>)` branches on the 
Option's discriminant [link](https://rust.godbolt.org/z/K4Tzfo). Copying 
the bytes without a branch is more efficient.

The second commit adds the same optimization but specialized for Range. 
Range<T: Copy> is famously not Copy (see #27186 and related); I do not 
propose to necro that discussion but I would like to see a more efficient 
clone(). Because Range is not Copy, this version uses unsafe `ptr::read` to 
achieve the same effect.

*Note*: the first commit has a user-visible behavior change in that 
Option<T>::clone() will no longer invoke T::clone() if T is Copy. This was 
considered as OK in [RFC 1521](https://github.com/rust-lang/rfcs/pull/1521) 
but it might be worth calling out in release notes.