### PR TITLE
Reword `trivial_casts` lint in rustc book to better explain what it does.

### DIFF
--- a/src/doc/rustc/src/lints/listing/allowed-by-default.md
+++ b/src/doc/rustc/src/lints/listing/allowed-by-default.md
@@ -232,7 +232,8 @@ error: lifetime name `'x` only used once
 
 ## trivial-casts
 
-This lint detects trivial casts which could be removed. Some example code
+This lint detects trivial casts which could be replaced with coercion, which may require
+type ascription or a temporary variable. Some example code
 that triggers this lint:
 
 ```rust


### PR DESCRIPTION
The current description of the trivial casts lint under the "allowed
by default" listing in the rustc book indicates the lint is for casts
which may be removed, which is less clear than saying it's for casts
which may be replaced by coercion (which is the wording used by the
error message included in the doc).

This commit changes the wording slightly to better describe what the
lint does.

This issue bit me in some recent code where I was attempting to
convert a `Vec<SomeType>` to a `Vec<SomeTraitObject>`, and
hit my project-wide `#![deny(trivial_casts)]` with
`map(|o| Box::new(o) as TraitObject)`. I'd read the book docs for
`trivial_casts` and was surprised by the error, as I took it to mean
the cast ought to be removed (rather than replaced by ascription
in this case). Removing the cast meant other code didn't compile,
and I then found issues like #23742 and realized my misunderstanding.