### PR TITLE
Use IOV_MAX and UIO_MAXIOV constants in limit vectored I/O

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1610,9 +1610,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.74"
+version = "0.2.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2f02823cf78b754822df5f7f268fb59822e7296276d3e069d8e8cb26a14bd10"
+checksum = "f2f96b10ec2560088a8e76961b00d47107b3a625fecb76dedb29ee7ccbf98235"
 dependencies = [
  "rustc-std-workspace-core",
 ]

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -16,7 +16,7 @@ cfg-if = { version = "0.1.8", features = ['rustc-dep-of-std'] }
 panic_unwind = { path = "../panic_unwind", optional = true }
 panic_abort = { path = "../panic_abort" }
 core = { path = "../core" }
-libc = { version = "0.2.74", default-features = false, features = ['rustc-dep-of-std'] }
+libc = { version = "0.2.77", default-features = false, features = ['rustc-dep-of-std'] }
 compiler_builtins = { version = "0.1.35" }
 profiler_builtins = { path = "../profiler_builtins", optional = true }
 unwind = { path = "../unwind" }

--- a/library/std/src/sys/unix/fd.rs
+++ b/library/std/src/sys/unix/fd.rs
@@ -6,7 +6,6 @@ mod tests;
 use crate::cmp;
 use crate::io::{self, Initializer, IoSlice, IoSliceMut, Read};
 use crate::mem;
-#[cfg(not(any(target_os = "redox", target_env = "newlib")))]
 use crate::sys::cvt;
 use crate::sys_common::AsInner;
 

--- a/library/std/src/sys/unix/fd.rs
+++ b/library/std/src/sys/unix/fd.rs
@@ -7,7 +7,6 @@ use crate::cmp;
 use crate::io::{self, Initializer, IoSlice, IoSliceMut, Read};
 use crate::mem;
 #[cfg(not(any(target_os = "redox", target_env = "newlib")))]
-use crate::sync::atomic::{AtomicUsize, Ordering};
 use crate::sys::cvt;
 use crate::sys_common::AsInner;
 
@@ -31,24 +30,35 @@ const READ_LIMIT: usize = c_int::MAX as usize - 1;
 #[cfg(not(target_os = "macos"))]
 const READ_LIMIT: usize = libc::ssize_t::MAX as usize;
 
-#[cfg(not(any(target_os = "redox", target_env = "newlib")))]
-fn max_iov() -> usize {
-    static LIM: AtomicUsize = AtomicUsize::new(0);
-
-    let mut lim = LIM.load(Ordering::Relaxed);
-    if lim == 0 {
-        let ret = unsafe { libc::sysconf(libc::_SC_IOV_MAX) };
-
-        // 16 is the minimum value required by POSIX.
-        lim = if ret > 0 { ret as usize } else { 16 };
-        LIM.store(lim, Ordering::Relaxed);
-    }
-
-    lim
+#[cfg(any(
+    target_os = "dragonfly",
+    target_os = "freebsd",
+    target_os = "ios",
+    target_os = "macos",
+    target_os = "netbsd",
+    target_os = "openbsd",
+))]
+const fn max_iov() -> usize {
+    libc::IOV_MAX as usize
 }
 
-#[cfg(any(target_os = "redox", target_env = "newlib"))]
-fn max_iov() -> usize {
+#[cfg(any(target_os = "android", target_os = "emscripten", target_os = "linux"))]
+const fn max_iov() -> usize {
+    libc::UIO_MAXIOV as usize
+}
+
+#[cfg(not(any(
+    target_os = "android",
+    target_os = "dragonfly",
+    target_os = "emscripten",
+    target_os = "freebsd",
+    target_os = "ios",
+    target_os = "linux",
+    target_os = "macos",
+    target_os = "netbsd",
+    target_os = "openbsd",
+)))]
+const fn max_iov() -> usize {
     16 // The minimum value required by POSIX.
 }
 

--- a/library/std/src/sys/unix/process/process_unix.rs
+++ b/library/std/src/sys/unix/process/process_unix.rs
@@ -459,7 +459,15 @@ impl ExitStatus {
     }
 
     fn exited(&self) -> bool {
-        unsafe { libc::WIFEXITED(self.0) }
+        // On Linux-like OSes this function is safe, on others it is not. See
+        // libc issue: https://github.com/rust-lang/libc/issues/1888.
+        #[cfg_attr(
+            any(target_os = "linux", target_os = "android", target_os = "emscripten"),
+            allow(unused_unsafe)
+        )]
+        unsafe {
+            libc::WIFEXITED(self.0)
+        }
     }
 
     pub fn success(&self) -> bool {
@@ -467,10 +475,22 @@ impl ExitStatus {
     }
 
     pub fn code(&self) -> Option<i32> {
+        // On Linux-like OSes this function is safe, on others it is not. See
+        // libc issue: https://github.com/rust-lang/libc/issues/1888.
+        #[cfg_attr(
+            any(target_os = "linux", target_os = "android", target_os = "emscripten"),
+            allow(unused_unsafe)
+        )]
         if self.exited() { Some(unsafe { libc::WEXITSTATUS(self.0) }) } else { None }
     }
 
     pub fn signal(&self) -> Option<i32> {
+        // On Linux-like OSes this function is safe, on others it is not. See
+        // libc issue: https://github.com/rust-lang/libc/issues/1888.
+        #[cfg_attr(
+            any(target_os = "linux", target_os = "android", target_os = "emscripten"),
+            allow(unused_unsafe)
+        )]
         if !self.exited() { Some(unsafe { libc::WTERMSIG(self.0) }) } else { None }
     }
 }


### PR DESCRIPTION
Also updates the libc dependency to 0.2.77 (from 0.2.74) as the
constants were only recently added.

Related #68042, #75005

r? @Amanieu (also reviewed #75005)