### PR TITLE
ci: avoid moving the build directory on GHA

### DIFF
--- a/src/ci/scripts/symlink-build-dir.sh
+++ b/src/ci/scripts/symlink-build-dir.sh
@@ -12,22 +12,4 @@ source "$(cd "$(dirname "$0")" && pwd)/../shared.sh"
 if isWindows && isAzurePipelines; then
     cmd //c "mkdir c:\\MORE_SPACE"
     cmd //c "mklink /J build c:\\MORE_SPACE"
-elif isLinux && isGitHubActions && ! isSelfHostedGitHubActions; then
-    sudo mkdir -p /mnt/more-space
-    sudo chown -R "$(whoami):" /mnt/more-space
-
-    # Switch the whole workspace to the /mnt partition, which has more space.
-    # We don't just symlink the `obj` directory as doing that creates problems
-    # with the docker container.
-    current_dir="$(readlink -f "$(pwd)")"
-    cd /tmp
-    mv "${current_dir}" /mnt/more-space/workspace
-    ln -s /mnt/more-space/workspace "${current_dir}"
-    cd "${current_dir}"
-
-    # Move the Docker data directory to /mnt
-    sudo systemctl stop docker.service
-    sudo mv /var/lib/docker /mnt/docker
-    sudo ln -s /mnt/docker /var/lib/docker
-    sudo systemctl start docker.service
 fi


### PR DESCRIPTION
While waiting for a PR job to start testing my code, I noticed the symlink-build-dir step took 10 minutes to complete, so I investigated what caused that.

It seems like something changed in the build environment between version 20200901.1 (where the step took 45 seconds) and version 20200908.1 (where the step took 10 minutes). At the time of writing this commit, the rust-lang organization is on vertsion 20200908.1, while the rust-lang-ci organization is at version 20200901.1 (and is not affected by this yet).

There is no need for this step anymore on GHA, as our XL builders got an increase in the root paritition size, so this commit removes the code that moved stuff around on GHA (while keeping it on Azure).

For the record, at the time of writing this, the disk situation is:

```
Filesystem      Size  Used Avail Use% Mounted on
/dev/sda1       667G   60G  607G   9% /
/dev/sdb1       110G  4.1G  101G   4% /mnt
```

r? @Mark-Simulacrum 