### PR TITLE
do not ICE on bound variables, return `TooGeneric` instead

### DIFF
--- a/compiler/rustc_middle/src/ty/layout.rs
+++ b/compiler/rustc_middle/src/ty/layout.rs
@@ -1259,11 +1259,11 @@ impl<'tcx> LayoutCx<'tcx, TyCtxt<'tcx>> {
                 tcx.layout_raw(param_env.and(normalized))?
             }
 
-            ty::Bound(..) | ty::Placeholder(..) | ty::GeneratorWitness(..) | ty::Infer(_) => {
+            ty::Placeholder(..) | ty::GeneratorWitness(..) | ty::Infer(_) => {
                 bug!("Layout::compute: unexpected type `{}`", ty)
             }
 
-            ty::Param(_) | ty::Error(_) => {
+            ty::Bound(..) | ty::Param(_) | ty::Error(_) => {
                 return Err(LayoutError::Unknown(ty));
             }
         })

--- a/compiler/rustc_mir/src/interpret/operand.rs
+++ b/compiler/rustc_mir/src/interpret/operand.rs
@@ -549,7 +549,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
         };
         // Early-return cases.
         let val_val = match val.val {
-            ty::ConstKind::Param(_) => throw_inval!(TooGeneric),
+            ty::ConstKind::Param(_) | ty::ConstKind::Bound(..) => throw_inval!(TooGeneric),
             ty::ConstKind::Error(_) => throw_inval!(TypeckError(ErrorReported)),
             ty::ConstKind::Unevaluated(def, substs, promoted) => {
                 let instance = self.resolve(def.did, substs)?;
@@ -561,9 +561,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 // happening.
                 return Ok(self.const_eval(GlobalId { instance, promoted }, val.ty)?);
             }
-            ty::ConstKind::Infer(..)
-            | ty::ConstKind::Bound(..)
-            | ty::ConstKind::Placeholder(..) => {
+            ty::ConstKind::Infer(..) | ty::ConstKind::Placeholder(..) => {
                 span_bug!(self.cur_span(), "const_to_op: Unexpected ConstKind {:?}", val)
             }
             ty::ConstKind::Value(val_val) => val_val,

--- a/src/test/ui/const-generics/issues/issue-73260.rs
+++ b/src/test/ui/const-generics/issues/issue-73260.rs
@@ -1,0 +1,20 @@
+// compile-flags: -Zsave-analysis
+
+#![feature(const_generics)]
+#![allow(incomplete_features)]
+struct Arr<const N: usize>
+where Assert::<{N < usize::max_value() / 2}>: IsTrue, //~ ERROR constant expression
+{
+}
+
+enum Assert<const CHECK: bool> {}
+
+trait IsTrue {}
+
+impl IsTrue for Assert<true> {}
+
+fn main() {
+    let x: Arr<{usize::max_value()}> = Arr {};
+    //~^ ERROR mismatched types
+    //~| ERROR mismatched types
+}

--- a/src/test/ui/const-generics/issues/issue-73260.stderr
+++ b/src/test/ui/const-generics/issues/issue-73260.stderr
@@ -1,0 +1,29 @@
+error: constant expression depends on a generic parameter
+  --> $DIR/issue-73260.rs:6:47
+   |
+LL | where Assert::<{N < usize::max_value() / 2}>: IsTrue,
+   |                                               ^^^^^^
+   |
+   = note: this may fail depending on what value the parameter takes
+
+error[E0308]: mismatched types
+  --> $DIR/issue-73260.rs:17:12
+   |
+LL |     let x: Arr<{usize::max_value()}> = Arr {};
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^ expected `false`, found `true`
+   |
+   = note: expected type `false`
+              found type `true`
+
+error[E0308]: mismatched types
+  --> $DIR/issue-73260.rs:17:40
+   |
+LL |     let x: Arr<{usize::max_value()}> = Arr {};
+   |                                        ^^^ expected `false`, found `true`
+   |
+   = note: expected type `false`
+              found type `true`
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/const-generics/issues/issue-74634.rs
+++ b/src/test/ui/const-generics/issues/issue-74634.rs
@@ -1,0 +1,27 @@
+#![feature(const_generics)]
+#![allow(incomplete_features)]
+
+trait If<const COND: bool> {}
+impl If<true> for () {}
+
+trait IsZero<const N: u8> {
+    type Answer;
+}
+
+struct True;
+struct False;
+
+impl<const N: u8> IsZero<N> for ()
+where (): If<{N == 0}> { //~ERROR constant expression
+    type Answer = True;
+}
+
+trait Foobar<const N: u8> {}
+
+impl<const N: u8> Foobar<N> for ()
+where (): IsZero<N, Answer = True> {}
+
+impl<const N: u8> Foobar<N> for ()
+where (): IsZero<N, Answer = False> {}
+
+fn main() {}

--- a/src/test/ui/const-generics/issues/issue-74634.stderr
+++ b/src/test/ui/const-generics/issues/issue-74634.stderr
@@ -1,0 +1,10 @@
+error: constant expression depends on a generic parameter
+  --> $DIR/issue-74634.rs:15:11
+   |
+LL | where (): If<{N == 0}> {
+   |           ^^^^^^^^^^^^
+   |
+   = note: this may fail depending on what value the parameter takes
+
+error: aborting due to previous error
+

--- a/src/test/ui/const-generics/issues/issue-76595.rs
+++ b/src/test/ui/const-generics/issues/issue-76595.rs
@@ -1,0 +1,18 @@
+#![feature(const_generics, const_evaluatable_checked)]
+#![allow(incomplete_features)]
+
+struct Bool<const B: bool>;
+
+trait True {}
+
+impl True for Bool<true> {}
+
+fn test<T, const P: usize>() where Bool<{core::mem::size_of::<T>() > 4}>: True {
+    todo!()
+}
+
+fn main() {
+    test::<2>();
+    //~^ ERROR wrong number of type
+    //~| ERROR constant expression depends
+}

--- a/src/test/ui/const-generics/issues/issue-76595.stderr
+++ b/src/test/ui/const-generics/issues/issue-76595.stderr
@@ -1,0 +1,21 @@
+error[E0107]: wrong number of type arguments: expected 1, found 0
+  --> $DIR/issue-76595.rs:15:5
+   |
+LL |     test::<2>();
+   |     ^^^^^^^^^ expected 1 type argument
+
+error: constant expression depends on a generic parameter
+  --> $DIR/issue-76595.rs:15:5
+   |
+LL | fn test<T, const P: usize>() where Bool<{core::mem::size_of::<T>() > 4}>: True {
+   |    ---- required by a bound in this
+...
+LL |     test::<2>();
+   |     ^^^^^^^^^
+   |
+   = note: this may fail depending on what value the parameter takes
+   = note: required by this bound in `test`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0107`.

--- a/src/test/ui/const-generics/issues/issue-76595.stderr
+++ b/src/test/ui/const-generics/issues/issue-76595.stderr
@@ -8,13 +8,12 @@ error: constant expression depends on a generic parameter
   --> $DIR/issue-76595.rs:15:5
    |
 LL | fn test<T, const P: usize>() where Bool<{core::mem::size_of::<T>() > 4}>: True {
-   |    ---- required by a bound in this
+   |                                                                           ---- required by this bound in `test`
 ...
 LL |     test::<2>();
    |     ^^^^^^^^^
    |
    = note: this may fail depending on what value the parameter takes
-   = note: required by this bound in `test`
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
fixes #73260, fixes #74634, fixes #76595 

r? @nikomatsakis