### PR TITLE
Update `std::os` module documentation.

### DIFF
--- a/library/std/src/os/linux/fs.rs
+++ b/library/std/src/os/linux/fs.rs
@@ -1,3 +1,5 @@
+//! Linux-specific extensions to primitives in the `std::fs` module.
+
 #![stable(feature = "metadata_ext", since = "1.1.0")]
 
 use crate::fs::Metadata;

--- a/library/std/src/os/linux/mod.rs
+++ b/library/std/src/os/linux/mod.rs
@@ -1,4 +1,4 @@
-//! Linux-specific definitions
+//! Linux-specific definitions.
 
 #![stable(feature = "raw_ext", since = "1.1.0")]
 

--- a/library/std/src/os/linux/raw.rs
+++ b/library/std/src/os/linux/raw.rs
@@ -1,4 +1,4 @@
-//! Linux-specific raw type definitions
+//! Linux-specific raw type definitions.
 
 #![stable(feature = "raw_ext", since = "1.1.0")]
 #![rustc_deprecated(

--- a/library/std/src/sys/unix/ext/ffi.rs
+++ b/library/std/src/sys/unix/ext/ffi.rs
@@ -1,4 +1,4 @@
-//! Unix-specific extension to the primitives in the `std::ffi` module
+//! Unix-specific extension to the primitives in the `std::ffi` module.
 //!
 //! # Examples
 //!

--- a/library/std/src/sys/unix/ext/io.rs
+++ b/library/std/src/sys/unix/ext/io.rs
@@ -1,4 +1,4 @@
-//! Unix-specific extensions to general I/O primitives
+//! Unix-specific extensions to general I/O primitives.
 
 #![stable(feature = "rust1", since = "1.0.0")]
 

--- a/library/std/src/sys/unix/ext/net.rs
+++ b/library/std/src/sys/unix/ext/net.rs
@@ -1,6 +1,6 @@
-#![stable(feature = "unix_socket", since = "1.10.0")]
+//! Unix-specific networking functionality.
 
-//! Unix-specific networking functionality
+#![stable(feature = "unix_socket", since = "1.10.0")]
 
 #[cfg(all(test, not(target_os = "emscripten")))]
 mod tests;

--- a/library/std/src/sys/unix/ext/raw.rs
+++ b/library/std/src/sys/unix/ext/raw.rs
@@ -1,4 +1,4 @@
-//! Unix-specific primitives available on all unix platforms
+//! Unix-specific primitives available on all unix platforms.
 
 #![stable(feature = "raw_ext", since = "1.1.0")]
 #![rustc_deprecated(

--- a/library/std/src/sys/windows/ext/io.rs
+++ b/library/std/src/sys/windows/ext/io.rs
@@ -1,3 +1,5 @@
+//! Windows-specific extensions to general I/O primitives.
+
 #![stable(feature = "rust1", since = "1.0.0")]
 
 use crate::fs;

--- a/library/std/src/sys/windows/ext/raw.rs
+++ b/library/std/src/sys/windows/ext/raw.rs
@@ -1,4 +1,4 @@
-//! Windows-specific primitives
+//! Windows-specific primitives.
 
 #![stable(feature = "raw_ext", since = "1.1.0")]
 


### PR DESCRIPTION
Adds missing descriptions for the modules `std::os::linux::fs` and `std::os::windows::io`.
Also adds punctuation for consistency with other descriptions.