### PR TITLE
Ignore `|` and `+` tokens during proc-macro pretty-print check

### DIFF
--- a/compiler/rustc_parse/src/lib.rs
+++ b/compiler/rustc_parse/src/lib.rs
@@ -353,6 +353,12 @@ pub fn tokenstream_probably_equal_for_proc_macro(
                 | token::CloseDelim(DelimToken::NoDelim)
                 // The pretty printer collapses many semicolons into one.
                 | token::Semi
+                // We don't preserve leading `|` tokens in patterns, so
+                // we ignore them entirely
+                | token::BinOp(token::BinOpToken::Or)
+                // We don't preserve trailing '+' tokens in trait bounds,
+                // so we ignore them entirely
+                | token::BinOp(token::BinOpToken::Plus)
                 // The pretty printer can turn `$crate` into `::crate_name`
                 | token::ModSep = token.kind {
                 return false;

--- a/src/test/ui/proc-macro/issue-76182-leading-vert-pat.rs
+++ b/src/test/ui/proc-macro/issue-76182-leading-vert-pat.rs
@@ -1,0 +1,16 @@
+// check-pass
+// aux-build:test-macros.rs
+// compile-flags: -Z span-debug
+//
+// Regression test for issue #76182
+// Tests that we properly handle patterns with a leading vert
+
+#![no_std] // Don't load unnecessary hygiene information from std
+extern crate std;
+
+extern crate test_macros;
+
+#[test_macros::print_attr]
+fn main() {
+    match () { | () => () }
+}

--- a/src/test/ui/proc-macro/issue-76182-leading-vert-pat.stdout
+++ b/src/test/ui/proc-macro/issue-76182-leading-vert-pat.stdout
@@ -1,0 +1,62 @@
+PRINT-ATTR INPUT (DISPLAY): fn main() { match() { | () => () } }
+PRINT-ATTR INPUT (DEBUG): TokenStream [
+    Ident {
+        ident: "fn",
+        span: $DIR/issue-76182-leading-vert-pat.rs:14:1: 14:3 (#0),
+    },
+    Ident {
+        ident: "main",
+        span: $DIR/issue-76182-leading-vert-pat.rs:14:4: 14:8 (#0),
+    },
+    Group {
+        delimiter: Parenthesis,
+        stream: TokenStream [],
+        span: $DIR/issue-76182-leading-vert-pat.rs:14:8: 14:10 (#0),
+    },
+    Group {
+        delimiter: Brace,
+        stream: TokenStream [
+            Ident {
+                ident: "match",
+                span: $DIR/issue-76182-leading-vert-pat.rs:15:5: 15:10 (#0),
+            },
+            Group {
+                delimiter: Parenthesis,
+                stream: TokenStream [],
+                span: $DIR/issue-76182-leading-vert-pat.rs:15:11: 15:13 (#0),
+            },
+            Group {
+                delimiter: Brace,
+                stream: TokenStream [
+                    Punct {
+                        ch: '|',
+                        spacing: Alone,
+                        span: $DIR/issue-76182-leading-vert-pat.rs:15:16: 15:17 (#0),
+                    },
+                    Group {
+                        delimiter: Parenthesis,
+                        stream: TokenStream [],
+                        span: $DIR/issue-76182-leading-vert-pat.rs:15:18: 15:20 (#0),
+                    },
+                    Punct {
+                        ch: '=',
+                        spacing: Joint,
+                        span: $DIR/issue-76182-leading-vert-pat.rs:15:21: 15:23 (#0),
+                    },
+                    Punct {
+                        ch: '>',
+                        spacing: Alone,
+                        span: $DIR/issue-76182-leading-vert-pat.rs:15:21: 15:23 (#0),
+                    },
+                    Group {
+                        delimiter: Parenthesis,
+                        stream: TokenStream [],
+                        span: $DIR/issue-76182-leading-vert-pat.rs:15:24: 15:26 (#0),
+                    },
+                ],
+                span: $DIR/issue-76182-leading-vert-pat.rs:15:14: 15:28 (#0),
+            },
+        ],
+        span: $DIR/issue-76182-leading-vert-pat.rs:14:11: 16:2 (#0),
+    },
+]

--- a/src/test/ui/proc-macro/trailing-plus.rs
+++ b/src/test/ui/proc-macro/trailing-plus.rs
@@ -1,0 +1,14 @@
+// check-pass
+// aux-build:test-macros.rs
+// compile-flags: -Z span-debug
+
+#![no_std] // Don't load unnecessary hygiene information from std
+extern crate std;
+
+extern crate test_macros;
+
+#[test_macros::print_attr]
+fn foo<T>() where T: Copy + {
+}
+
+fn main() {}

--- a/src/test/ui/proc-macro/trailing-plus.stdout
+++ b/src/test/ui/proc-macro/trailing-plus.stdout
@@ -1,0 +1,57 @@
+PRINT-ATTR INPUT (DISPLAY): fn foo < T > () where T : Copy + { }
+PRINT-ATTR INPUT (DEBUG): TokenStream [
+    Ident {
+        ident: "fn",
+        span: $DIR/trailing-plus.rs:11:1: 11:3 (#0),
+    },
+    Ident {
+        ident: "foo",
+        span: $DIR/trailing-plus.rs:11:4: 11:7 (#0),
+    },
+    Punct {
+        ch: '<',
+        spacing: Alone,
+        span: $DIR/trailing-plus.rs:11:7: 11:8 (#0),
+    },
+    Ident {
+        ident: "T",
+        span: $DIR/trailing-plus.rs:11:8: 11:9 (#0),
+    },
+    Punct {
+        ch: '>',
+        spacing: Alone,
+        span: $DIR/trailing-plus.rs:11:9: 11:10 (#0),
+    },
+    Group {
+        delimiter: Parenthesis,
+        stream: TokenStream [],
+        span: $DIR/trailing-plus.rs:11:10: 11:12 (#0),
+    },
+    Ident {
+        ident: "where",
+        span: $DIR/trailing-plus.rs:11:13: 11:18 (#0),
+    },
+    Ident {
+        ident: "T",
+        span: $DIR/trailing-plus.rs:11:19: 11:20 (#0),
+    },
+    Punct {
+        ch: ':',
+        spacing: Alone,
+        span: $DIR/trailing-plus.rs:11:20: 11:21 (#0),
+    },
+    Ident {
+        ident: "Copy",
+        span: $DIR/trailing-plus.rs:11:22: 11:26 (#0),
+    },
+    Punct {
+        ch: '+',
+        spacing: Alone,
+        span: $DIR/trailing-plus.rs:11:27: 11:28 (#0),
+    },
+    Group {
+        delimiter: Brace,
+        stream: TokenStream [],
+        span: $DIR/trailing-plus.rs:11:29: 12:2 (#0),
+    },
+]


### PR DESCRIPTION
Fixes #76182

This is an alternative to PR #76188

These tokens are not preserved in the AST in certain cases
(e.g. a leading `|` in a pattern or a trailing `+` in a trait bound).

This PR ignores them entirely during the pretty-print/reparse check
to avoid spuriously using the re-parsed tokenstream.