### PR TITLE
Fixing memory exhaustion when formatting short code suggestion 

### DIFF
--- a/compiler/rustc_errors/src/emitter.rs
+++ b/compiler/rustc_errors/src/emitter.rs
@@ -959,15 +959,15 @@ impl EmitterWriter {
                         '_',
                         line_offset + pos,
                         width_offset + depth,
-                        code_offset + annotation.start_col - left,
+                        (code_offset + annotation.start_col).saturating_sub(left),
                         style,
                     );
                 }
                 _ if self.teach => {
                     buffer.set_style_range(
                         line_offset,
-                        code_offset + annotation.start_col - left,
-                        code_offset + annotation.end_col - left,
+                        (code_offset + annotation.start_col).saturating_sub(left),
+                        (code_offset + annotation.end_col).saturating_sub(left),
                         style,
                         annotation.is_primary,
                     );

--- a/compiler/rustc_parse/src/parser/mod.rs
+++ b/compiler/rustc_parse/src/parser/mod.rs
@@ -694,9 +694,13 @@ impl<'a> Parser<'a> {
                                 Ok(t) => {
                                     // Parsed successfully, therefore most probably the code only
                                     // misses a separator.
+                                    let mut exp_span = self.sess.source_map().next_point(sp);
+                                    if self.sess.source_map().is_multiline(exp_span) {
+                                        exp_span = sp;
+                                    }
                                     expect_err
                                         .span_suggestion_short(
-                                            self.sess.source_map().next_point(sp),
+                                            exp_span,
                                             &format!("missing `{}`", token_str),
                                             token_str,
                                             Applicability::MaybeIncorrect,

--- a/src/test/ui/issue-76597.fixed
+++ b/src/test/ui/issue-76597.fixed
@@ -3,7 +3,7 @@
 #![allow(dead_code)]
 #![allow(unused_variables)]
 fn f(
-                                     x: u8
+                                     x: u8,
                                      y: u8,
 ) {}
 //~^^ ERROR: expected one of `!`, `(`, `)`, `+`, `,`, `::`, or `<`, found `y`

--- a/src/test/ui/issue-76597.rs
+++ b/src/test/ui/issue-76597.rs
@@ -1,0 +1,7 @@
+fn f(
+                                     x: u8
+                                     y: u8,
+) {}
+//~^^ ERROR: expected one of `!`, `(`, `)`, `+`, `,`, `::`, or `<`, found `y`
+
+fn main() {}

--- a/src/test/ui/issue-76597.stderr
+++ b/src/test/ui/issue-76597.stderr
@@ -1,14 +1,13 @@
 error: expected one of `!`, `(`, `)`, `+`, `,`, `::`, or `<`, found `y`
-  --> $DIR/issue-76597.rs:3:38
+  --> $DIR/issue-76597.rs:7:38
    |
-LL |   ...                   x: u8
-   |                              - expected one of 7 possible tokens
-   |  ____________________________|
-   | |
-LL | | ...                   y: u8,
-|  | |                       ^ unexpected token
-|  | |
-   |   help: missing `,`
+LL | ...                   x: u8
+   |                            -
+   |                            |
+   |                            expected one of 7 possible tokens
+   |                            help: missing `,`
+LL | ...                   y: u8,
+   |                       ^ unexpected token
 
 error: aborting due to previous error
 

--- a/src/test/ui/issue-76597.stderr
+++ b/src/test/ui/issue-76597.stderr
@@ -1,0 +1,14 @@
+error: expected one of `!`, `(`, `)`, `+`, `,`, `::`, or `<`, found `y`
+  --> $DIR/issue-76597.rs:3:38
+   |
+LL |   ...                   x: u8
+   |                              - expected one of 7 possible tokens
+   |  ____________________________|
+   | |
+LL | | ...                   y: u8,
+|  | |                       ^ unexpected token
+|  | |
+   |   help: missing `,`
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Details can be found in issue #76597. This PR replaces substractions with `saturating_sub`'s to avoid usize wrapping leading to memory exhaustion when formatting short suggestion messages.