### PR TITLE
Finish off revisions for const generics UI tests.

### DIFF
--- a/src/test/ui/const-generics/const_evaluatable_checked/feature-gate-const_evaluatable_checked.full.stderr
+++ b/src/test/ui/const-generics/const_evaluatable_checked/feature-gate-const_evaluatable_checked.full.stderr
@@ -1,5 +1,5 @@
 error: constant expression depends on a generic parameter
-  --> $DIR/feature-gate-const_evaluatable_checked.rs:6:30
+  --> $DIR/feature-gate-const_evaluatable_checked.rs:9:30
    |
 LL | fn test<const N: usize>() -> Arr<N> where Arr<N>: Default {
    |                              ^^^^^^

--- a/src/test/ui/const-generics/const_evaluatable_checked/feature-gate-const_evaluatable_checked.min.stderr
+++ b/src/test/ui/const-generics/const_evaluatable_checked/feature-gate-const_evaluatable_checked.min.stderr
@@ -1,0 +1,10 @@
+error: generic parameters must not be used inside of non trivial constant values
+  --> $DIR/feature-gate-const_evaluatable_checked.rs:6:33
+   |
+LL | type Arr<const N: usize> = [u8; N - 1];
+   |                                 ^ non-trivial anonymous constants must not depend on the parameter `N`
+   |
+   = help: it is currently only allowed to use either `N` or `{ N }` as generic constants
+
+error: aborting due to previous error
+

--- a/src/test/ui/const-generics/const_evaluatable_checked/feature-gate-const_evaluatable_checked.rs
+++ b/src/test/ui/const-generics/const_evaluatable_checked/feature-gate-const_evaluatable_checked.rs
@@ -1,10 +1,13 @@
-#![feature(const_generics)]
-#![allow(incomplete_features)]
+// revisions: full min
+#![cfg_attr(full, feature(const_generics))]
+#![cfg_attr(full, allow(incomplete_features))]
+#![cfg_attr(min, feature(min_const_generics))]
 
 type Arr<const N: usize> = [u8; N - 1];
+//[min]~^ ERROR generic parameters must not be used inside of non trivial constant values
 
 fn test<const N: usize>() -> Arr<N> where Arr<N>: Default {
-    //~^ ERROR constant expression depends
+    //[full]~^ ERROR constant expression depends
     Default::default()
 }
 

--- a/src/test/ui/const-generics/const_evaluatable_checked/simple.min.stderr
+++ b/src/test/ui/const-generics/const_evaluatable_checked/simple.min.stderr
@@ -1,0 +1,10 @@
+error: generic parameters must not be used inside of non trivial constant values
+  --> $DIR/simple.rs:8:33
+   |
+LL | type Arr<const N: usize> = [u8; N - 1];
+   |                                 ^ non-trivial anonymous constants must not depend on the parameter `N`
+   |
+   = help: it is currently only allowed to use either `N` or `{ N }` as generic constants
+
+error: aborting due to previous error
+

--- a/src/test/ui/const-generics/const_evaluatable_checked/simple.rs
+++ b/src/test/ui/const-generics/const_evaluatable_checked/simple.rs
@@ -1,8 +1,12 @@
-// run-pass
-#![feature(const_generics, const_evaluatable_checked)]
+// [full] run-pass
+// revisions: full min
+#![cfg_attr(full, feature(const_generics))]
+#![cfg_attr(min, feature(min_const_generics))]
+#![feature(const_evaluatable_checked)]
 #![allow(incomplete_features)]
 
 type Arr<const N: usize> = [u8; N - 1];
+//[min]~^ ERROR generic parameters must not be used inside of non trivial constant values
 
 fn test<const N: usize>() -> Arr<N> where Arr<N>: Default {
     Default::default()

--- a/src/test/ui/const-generics/const_evaluatable_checked/simple_fail.full.stderr
+++ b/src/test/ui/const-generics/const_evaluatable_checked/simple_fail.full.stderr
@@ -1,5 +1,5 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/simple_fail.rs:4:33
+  --> $DIR/simple_fail.rs:7:33
    |
 LL | type Arr<const N: usize> = [u8; N - 1];
    |                                 ^^^^^ attempt to compute `0_usize - 1_usize` which would overflow

--- a/src/test/ui/const-generics/const_evaluatable_checked/simple_fail.min.stderr
+++ b/src/test/ui/const-generics/const_evaluatable_checked/simple_fail.min.stderr
@@ -1,0 +1,10 @@
+error: generic parameters must not be used inside of non trivial constant values
+  --> $DIR/simple_fail.rs:7:33
+   |
+LL | type Arr<const N: usize> = [u8; N - 1];
+   |                                 ^ non-trivial anonymous constants must not depend on the parameter `N`
+   |
+   = help: it is currently only allowed to use either `N` or `{ N }` as generic constants
+
+error: aborting due to previous error
+

--- a/src/test/ui/const-generics/const_evaluatable_checked/simple_fail.rs
+++ b/src/test/ui/const-generics/const_evaluatable_checked/simple_fail.rs
@@ -1,7 +1,11 @@
-#![feature(const_generics, const_evaluatable_checked)]
+// revisions: full min
+#![cfg_attr(full, feature(const_generics))]
+#![cfg_attr(min, feature(min_const_generics))]
+#![feature(const_evaluatable_checked)]
 #![allow(incomplete_features)]
 
-type Arr<const N: usize> = [u8; N - 1]; //~ ERROR evaluation of constant
+type Arr<const N: usize> = [u8; N - 1]; //[full]~ ERROR evaluation of constant
+//[min]~^ ERROR generic parameters must not be used inside of non trivial constant values
 
 fn test<const N: usize>() -> Arr<N> where Arr<N>: Sized {
     todo!()

--- a/src/test/ui/const-generics/type-dependent/auxiliary/type_dependent_lib.rs
+++ b/src/test/ui/const-generics/type-dependent/auxiliary/type_dependent_lib.rs
@@ -1,5 +1,6 @@
-#![feature(const_generics)]
-#![allow(incomplete_features)]
+#![cfg_attr(full, feature(const_generics))]
+#![cfg_attr(full, allow(incomplete_features))]
+#![cfg_attr(min, feature(min_const_generics))]
 
 pub struct Struct<const N: usize>(());
 


### PR DESCRIPTION
This time it really does fix it. 😅 The only ones left are `min-and-full-same-time.rs`, which doesn't need it, and `array-impls/` which check the feature indirectly.

Fixes #75279.

r? @lcnr