### PR TITLE
Fix `string.rs` docstring

### DIFF
--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -189,8 +189,7 @@ use crate::vec::Vec;
 /// use std::mem;
 ///
 /// let story = String::from("Once upon a time...");
-///
-// FIXME Update this when vec_into_raw_parts is stabilized
+/// // FIXME Update this when vec_into_raw_parts is stabilized
 /// // Prevent automatically dropping the String's data
 /// let mut story = mem::ManuallyDrop::new(story);
 ///


### PR DESCRIPTION
Hi!
While reading docstring  for `string.rs` I found little nitpick - presence of a new line completely breaks latter code highlighting:

![](https://iili.io/2KE8ej.png)