### PR TITLE
Modify executable checking to be more universal

### DIFF
--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -737,6 +737,7 @@ impl Step for Tidy {
         let mut cmd = builder.tool_cmd(Tool::Tidy);
         cmd.arg(&builder.src);
         cmd.arg(&builder.initial_cargo);
+        cmd.arg(&builder.out);
         if builder.is_verbose() {
             cmd.arg("--verbose");
         }

--- a/src/tools/tidy/src/main.rs
+++ b/src/tools/tidy/src/main.rs
@@ -13,6 +13,8 @@ use std::process;
 fn main() {
     let root_path: PathBuf = env::args_os().nth(1).expect("need path to root of repo").into();
     let cargo: PathBuf = env::args_os().nth(2).expect("need path to cargo").into();
+    let output_directory: PathBuf =
+        env::args_os().nth(3).expect("need path to output directory").into();
 
     let src_path = root_path.join("src");
     let library_path = root_path.join("library");
@@ -36,9 +38,9 @@ fn main() {
     unit_tests::check(&library_path, &mut bad);
 
     // Checks that need to be done for both the compiler and std libraries.
-    bins::check(&src_path, &mut bad);
-    bins::check(&compiler_path, &mut bad);
-    bins::check(&library_path, &mut bad);
+    bins::check(&src_path, &output_directory, &mut bad);
+    bins::check(&compiler_path, &output_directory, &mut bad);
+    bins::check(&library_path, &output_directory, &mut bad);
 
     style::check(&src_path, &mut bad);
     style::check(&compiler_path, &mut bad);


### PR DESCRIPTION
This uses a dummy file to check if the filesystem being used supports the executable bit in general.

Supersedes #74753.