### PR TITLE
Align rustc_metadata Table to word boundary

### DIFF
--- a/compiler/rustc_metadata/src/rmeta/table.rs
+++ b/compiler/rustc_metadata/src/rmeta/table.rs
@@ -172,8 +172,16 @@ where
 
     pub(crate) fn encode(&self, buf: &mut Encoder) -> Lazy<Table<I, T>> {
         let pos = buf.position();
+        // Since all of the data are serialized as u32, adding some padding
+        // should make encoding/decoding slightly faster.
+        let pad = (4 - (pos % 4)) % 4;
+        let pad_bytes = [0, 0, 0];
+        buf.emit_raw_bytes(&pad_bytes[..pad]);
         buf.emit_raw_bytes(&self.bytes);
-        Lazy::from_position_and_meta(NonZeroUsize::new(pos as usize).unwrap(), self.bytes.len())
+        Lazy::from_position_and_meta(
+            NonZeroUsize::new(pos as usize + pad).unwrap(),
+            self.bytes.len(),
+        )
     }
 }
 


### PR DESCRIPTION
This can save a few cycles when converting the bytes to u32. That said, probably very marginal benefits. The motivation is more like, borrowing ideas from FlatBuffers/Cap'n Proto.

I wonder if inserting arbitrary paddings (without communicating them to the decoder) between lazy items are OK? From my understanding it's fine, since lazy items are only referenced by relative/absolute position and does not have to be in a packed layout.

Also note for perf: this will not reduce the instruction count, which is the default metric, since the decoder part uses the same (machine) code.