### PR TITLE
Update bootstrap readme

### DIFF
--- a/src/bootstrap/README.md
+++ b/src/bootstrap/README.md
@@ -26,10 +26,10 @@ The script accepts commands, flags, and arguments to determine what to do:
 
   ```
   # build the whole compiler
-  ./x.py build
+  ./x.py build --stage 2
 
   # build the stage1 compiler
-  ./x.py build --stage 1
+  ./x.py build
 
   # build stage0 libstd
   ./x.py build --stage 0 library/std
@@ -43,8 +43,8 @@ The script accepts commands, flags, and arguments to determine what to do:
   that belong to stage n or earlier:
 
   ```
-  # keep old build products for stage 0 and build stage 1
-  ./x.py build --keep-stage 0 --stage 1
+  # build stage 1, keeping old build products for stage 0
+  ./x.py build --keep-stage 0
   ```
 
 * `test` - a command for executing unit tests. Like the `build` command this
@@ -123,24 +123,8 @@ that (b) leverage Rust as much as possible!
 
 ## Incremental builds
 
-You can configure rustbuild to use incremental compilation. Because
-incremental is new and evolving rapidly, if you want to use it, it is
-recommended that you replace the snapshot with a locally installed
-nightly build of rustc. You will want to keep this up to date.
-
-To follow this course of action, first thing you will want to do is to
-install a nightly, presumably using `rustup`. You will then want to
-configure your directory to use this build, like so:
-
-```sh
-# configure to use local rust instead of downloading a beta.
-# `--local-rust-root` is optional here. If elided, we will
-# use whatever rustc we find on your PATH.
-$ ./configure --local-rust-root=~/.cargo/ --enable-local-rebuild
-```
-
-After that, you can use the `--incremental` flag to actually do
-incremental builds:
+You can configure rustbuild to use incremental compilation with the
+`--incremental` flag:
 
 ```sh
 $ ./x.py build --incremental
@@ -150,9 +134,7 @@ The `--incremental` flag will store incremental compilation artifacts
 in `build/<host>/stage0-incremental`. Note that we only use incremental
 compilation for the stage0 -> stage1 compilation -- this is because
 the stage1 compiler is changing, and we don't try to cache and reuse
-incremental artifacts across different versions of the compiler. For
-this reason, `--incremental` defaults to `--stage 1` (though you can
-manually select a higher stage, if you prefer).
+incremental artifacts across different versions of the compiler.
 
 You can always drop the `--incremental` to build as normal (but you
 will still be using the local nightly as your bootstrap).
@@ -331,8 +313,8 @@ are:
   `Config` struct.
 * Adding a sanity check? Take a look at `bootstrap/sanity.rs`.
 
-If you have any questions feel free to reach out on `#infra` channel in the
-[Rust Discord server][rust-discord] or ask on internals.rust-lang.org. When
+If you have any questions feel free to reach out on the `#t-infra` channel in
+the [Rust Zulip server][rust-zulip] or ask on internals.rust-lang.org. When
 you encounter bugs, please file issues on the rust-lang/rust issue tracker.
 
-[rust-discord]: https://discord.gg/rust-lang
+[rust-zulip]: https://rust-lang.zulipchat.com/#narrow/stream/242791-t-infra


### PR DESCRIPTION
- Reflect changes in x.py defaults
- Remove recommendation to use nightly for incremental; it works fine on
beta
- Remove note that incremental chooses stage 1 by default; stage 1 is
already the default
- Update Discord -> Zulip

r? @Mark-Simulacrum 