### PR TITLE
Use `is_unstable_const_fn` instead of `is_min_const_fn` in rustdoc where appropriate

### DIFF
--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -901,7 +901,8 @@ impl Clean<Item> for doctree::Function<'_> {
 
         let did = cx.tcx.hir().local_def_id(self.id);
         let constness = if is_const_fn(cx.tcx, did.to_def_id())
-            && !is_unstable_const_fn(cx.tcx, did.to_def_id()).is_some() {
+            && !is_unstable_const_fn(cx.tcx, did.to_def_id()).is_some()
+        {
             hir::Constness::Const
         } else {
             hir::Constness::NotConst

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -23,7 +23,7 @@ use rustc_middle::middle::stability;
 use rustc_middle::ty::fold::TypeFolder;
 use rustc_middle::ty::subst::InternalSubsts;
 use rustc_middle::ty::{self, AdtKind, Lift, Ty, TyCtxt};
-use rustc_mir::const_eval::is_min_const_fn;
+use rustc_mir::const_eval::{is_min_const_fn, is_unstable_const_fn};
 use rustc_span::hygiene::MacroKind;
 use rustc_span::symbol::{kw, sym, Ident, Symbol};
 use rustc_span::{self, Pos};
@@ -900,7 +900,7 @@ impl Clean<Item> for doctree::Function<'_> {
             enter_impl_trait(cx, || (self.generics.clean(cx), (self.decl, self.body).clean(cx)));
 
         let did = cx.tcx.hir().local_def_id(self.id);
-        let constness = if is_min_const_fn(cx.tcx, did.to_def_id()) {
+        let constness = if !is_unstable_const_fn(cx.tcx, did.to_def_id()).is_some() {
             hir::Constness::Const
         } else {
             hir::Constness::NotConst
@@ -1108,7 +1108,7 @@ impl Clean<Item> for hir::TraitItem<'_> {
             hir::TraitItemKind::Fn(ref sig, hir::TraitFn::Provided(body)) => {
                 let mut m = (sig, &self.generics, body, None).clean(cx);
                 if m.header.constness == hir::Constness::Const
-                    && !is_min_const_fn(cx.tcx, local_did.to_def_id())
+                    && is_unstable_const_fn(cx.tcx, local_did.to_def_id()).is_some()
                 {
                     m.header.constness = hir::Constness::NotConst;
                 }
@@ -1121,7 +1121,7 @@ impl Clean<Item> for hir::TraitItem<'_> {
                 let (all_types, ret_types) = get_all_types(&generics, &decl, cx);
                 let mut t = TyMethod { header: sig.header, decl, generics, all_types, ret_types };
                 if t.header.constness == hir::Constness::Const
-                    && !is_min_const_fn(cx.tcx, local_did.to_def_id())
+                    && is_unstable_const_fn(cx.tcx, local_did.to_def_id()).is_some()
                 {
                     t.header.constness = hir::Constness::NotConst;
                 }
@@ -1154,7 +1154,7 @@ impl Clean<Item> for hir::ImplItem<'_> {
             hir::ImplItemKind::Fn(ref sig, body) => {
                 let mut m = (sig, &self.generics, body, Some(self.defaultness)).clean(cx);
                 if m.header.constness == hir::Constness::Const
-                    && !is_min_const_fn(cx.tcx, local_did.to_def_id())
+                    && is_unstable_const_fn(cx.tcx, local_did.to_def_id()).is_some()
                 {
                     m.header.constness = hir::Constness::NotConst;
                 }

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -23,7 +23,7 @@ use rustc_middle::middle::stability;
 use rustc_middle::ty::fold::TypeFolder;
 use rustc_middle::ty::subst::InternalSubsts;
 use rustc_middle::ty::{self, AdtKind, Lift, Ty, TyCtxt};
-use rustc_mir::const_eval::{is_min_const_fn, is_unstable_const_fn};
+use rustc_mir::const_eval::{is_const_fn, is_min_const_fn, is_unstable_const_fn};
 use rustc_span::hygiene::MacroKind;
 use rustc_span::symbol::{kw, sym, Ident, Symbol};
 use rustc_span::{self, Pos};
@@ -900,7 +900,8 @@ impl Clean<Item> for doctree::Function<'_> {
             enter_impl_trait(cx, || (self.generics.clean(cx), (self.decl, self.body).clean(cx)));
 
         let did = cx.tcx.hir().local_def_id(self.id);
-        let constness = if !is_unstable_const_fn(cx.tcx, did.to_def_id()).is_some() {
+        let constness = if is_const_fn(cx.tcx, did.to_def_id())
+            && !is_unstable_const_fn(cx.tcx, did.to_def_id()).is_some() {
             hir::Constness::Const
         } else {
             hir::Constness::NotConst

--- a/src/test/rustdoc/const-display.rs
+++ b/src/test/rustdoc/const-display.rs
@@ -12,7 +12,7 @@
 #[rustc_const_unstable(feature="foo", issue = "none")]
 pub const unsafe fn foo() -> u32 { 42 }
 
-// @has 'foo/fn.foo2.html' '//pre' 'pub fn foo2() -> u32'
+// @has 'foo/fn.foo2.html' '//pre' 'pub const fn foo2() -> u32'
 #[unstable(feature = "humans", issue = "none")]
 pub const fn foo2() -> u32 { 42 }
 
@@ -21,7 +21,7 @@ pub const fn foo2() -> u32 { 42 }
 #[rustc_const_stable(feature = "rust1", since = "1.0.0")]
 pub const fn bar2() -> u32 { 42 }
 
-// @has 'foo/fn.foo2_gated.html' '//pre' 'pub unsafe fn foo2_gated() -> u32'
+// @has 'foo/fn.foo2_gated.html' '//pre' 'pub const unsafe fn foo2_gated() -> u32'
 #[unstable(feature = "foo2", issue = "none")]
 pub const unsafe fn foo2_gated() -> u32 { 42 }
 
@@ -30,7 +30,7 @@ pub const unsafe fn foo2_gated() -> u32 { 42 }
 #[rustc_const_stable(feature = "rust1", since = "1.0.0")]
 pub const unsafe fn bar2_gated() -> u32 { 42 }
 
-// @has 'foo/fn.bar_not_gated.html' '//pre' 'pub unsafe fn bar_not_gated() -> u32'
+// @has 'foo/fn.bar_not_gated.html' '//pre' 'pub const unsafe fn bar_not_gated() -> u32'
 pub const unsafe fn bar_not_gated() -> u32 { 42 }
 
 pub struct Foo;

--- a/src/test/rustdoc/issue-76501.rs
+++ b/src/test/rustdoc/issue-76501.rs
@@ -1,0 +1,18 @@
+#![feature(const_fn)]
+
+// @has 'issue_76501/fn.bloop.html' '//pre' 'pub const fn bloop() -> i32'
+/// A useless function that always returns 1.
+pub const fn bloop() -> i32 {
+    1
+}
+
+/// A struct.
+pub struct Struct {}
+
+impl Struct {
+    // @has 'issue_76501/struct.Struct.html' '//*[@class="method"]' 'pub const fn bloop() -> i32'
+    /// A useless function that always returns 1.
+    pub const fn bloop() -> i32 {
+        1
+    }
+}

--- a/src/test/rustdoc/issue-76501.rs
+++ b/src/test/rustdoc/issue-76501.rs
@@ -10,9 +10,9 @@ pub const fn bloop() -> i32 {
 pub struct Struct {}
 
 impl Struct {
-    // @has 'issue_76501/struct.Struct.html' '//*[@class="method"]' 'pub const fn bloop() -> i32'
+    // @has 'issue_76501/struct.Struct.html' '//*[@class="method"]' 'pub const fn blurp() -> i32'
     /// A useless function that always returns 1.
-    pub const fn bloop() -> i32 {
+    pub const fn blurp() -> i32 {
         1
     }
 }


### PR DESCRIPTION
This closes #76501. Specifically, it allows for nightly users with the `#![feature(const_fn)]` flag enabled to still have their `const fn` declarations documented as such, while retaining the desired behavior that rustdoc *not* document functions that have the `rustc_const_unstable` attribute as `const`. 