### PR TITLE
update the version of itertools and parking_lot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3291,7 +3291,7 @@ dependencies = [
 name = "rustc_ast_passes"
 version = "0.0.0"
 dependencies = [
- "itertools 0.8.2",
+ "itertools 0.9.0",
  "rustc_ast",
  "rustc_ast_pretty",
  "rustc_attr",
@@ -3423,7 +3423,7 @@ dependencies = [
  "jobserver",
  "libc",
  "measureme",
- "parking_lot 0.10.2",
+ "parking_lot 0.11.0",
  "rustc-hash",
  "rustc-rayon",
  "rustc-rayon-core",
@@ -3752,7 +3752,7 @@ name = "rustc_mir"
 version = "0.0.0"
 dependencies = [
  "either",
- "itertools 0.8.2",
+ "itertools 0.9.0",
  "log_settings",
  "polonius-engine",
  "regex",
@@ -3877,7 +3877,7 @@ dependencies = [
 name = "rustc_query_system"
 version = "0.0.0"
 dependencies = [
- "parking_lot 0.10.2",
+ "parking_lot 0.11.0",
  "rustc-rayon-core",
  "rustc_arena",
  "rustc_data_structures",
@@ -4110,7 +4110,7 @@ name = "rustdoc"
 version = "0.0.0"
 dependencies = [
  "expect-test",
- "itertools 0.8.2",
+ "itertools 0.9.0",
  "minifier",
  "pulldown-cmark",
  "rustc-rayon",

--- a/compiler/rustc_ast_passes/Cargo.toml
+++ b/compiler/rustc_ast_passes/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.0.0"
 edition = "2018"
 
 [dependencies]
-itertools = "0.8"
+itertools = "0.9"
 tracing = "0.1"
 rustc_ast_pretty = { path = "../rustc_ast_pretty" }
 rustc_attr = { path = "../rustc_attr" }

--- a/compiler/rustc_data_structures/Cargo.toml
+++ b/compiler/rustc_data_structures/Cargo.toml
@@ -30,7 +30,7 @@ stacker = "0.1.11"
 tempfile = "3.0.5"
 
 [dependencies.parking_lot]
-version = "0.10"
+version = "0.11"
 features = ["nightly"]
 
 [target.'cfg(windows)'.dependencies]

--- a/compiler/rustc_mir/Cargo.toml
+++ b/compiler/rustc_mir/Cargo.toml
@@ -10,7 +10,7 @@ doctest = false
 [dependencies]
 either = "1.5.0"
 rustc_graphviz = { path = "../rustc_graphviz" }
-itertools = "0.8"
+itertools = "0.9"
 tracing = "0.1"
 log_settings = "0.1.1"
 polonius-engine = "0.12.0"

--- a/compiler/rustc_query_system/Cargo.toml
+++ b/compiler/rustc_query_system/Cargo.toml
@@ -17,5 +17,5 @@ rustc_macros = { path = "../rustc_macros" }
 rustc_index = { path = "../rustc_index" }
 rustc_serialize = { path = "../rustc_serialize" }
 rustc_span = { path = "../rustc_span" }
-parking_lot = "0.10"
+parking_lot = "0.11"
 smallvec = { version = "1.0", features = ["union", "may_dangle"] }

--- a/src/librustdoc/Cargo.toml
+++ b/src/librustdoc/Cargo.toml
@@ -15,7 +15,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 smallvec = "1.0"
 tempfile = "3"
-itertools = "0.8"
+itertools = "0.9"
 
 [dev-dependencies]
 expect-test = "1.0"


### PR DESCRIPTION
this is to avoid compiling multiple version of the crates in rustc speeding up compilation of rustc

an old version of parking_lot is still used in measureme but new version will not be released for some time see [zulip chat](https://rust-lang.zulipchat.com/#narrow/stream/187831-t-compiler.2Fwg-self-profile/topic/new.20release.20of.20measureme)
