### PR TITLE
Simplify SyncOnceCell's `take` and `drop`.

### DIFF
--- a/library/std/src/sync/once.rs
+++ b/library/std/src/sync/once.rs
@@ -191,6 +191,7 @@ struct WaiterQueue<'a> {
 
 impl Once {
     /// Creates a new `Once` value.
+    #[inline]
     #[stable(feature = "once_new", since = "1.2.0")]
     #[rustc_const_stable(feature = "const_once_new", since = "1.32.0")]
     pub const fn new() -> Once {


### PR DESCRIPTION
Prevents copies by using `assume_init_read` and `assume_init_drop`.