### PR TITLE
Apply `#![deny(unsafe_op_in_unsafe_fn)]` to sys/windows

### DIFF
--- a/library/std/src/sys/windows/alloc.rs
+++ b/library/std/src/sys/windows/alloc.rs
@@ -65,10 +65,10 @@ unsafe impl GlobalAlloc for System {
         // SAFETY: HeapFree is safe if ptr was allocated by this allocator
         let err = unsafe {
             if layout.align() <= MIN_ALIGN {
-                c::HeapFree(c::GetProcessHeap(), 0, ptr as c::LPVOID);
+                c::HeapFree(c::GetProcessHeap(), 0, ptr as c::LPVOID)
             } else {
                 let header = get_header(ptr);
-                c::HeapFree(c::GetProcessHeap(), 0, header.0 as c::LPVOID);
+                c::HeapFree(c::GetProcessHeap(), 0, header.0 as c::LPVOID)
             }
         };
         debug_assert!(err != 0, "Failed to free heap memory: {}", c::GetLastError());

--- a/library/std/src/sys/windows/alloc.rs
+++ b/library/std/src/sys/windows/alloc.rs
@@ -70,7 +70,7 @@ unsafe impl GlobalAlloc for System {
                 let header = get_header(ptr);
                 c::HeapFree(c::GetProcessHeap(), 0, header.0 as c::LPVOID);
             }
-        }
+        };
         debug_assert!(err != 0, "Failed to free heap memory: {}", c::GetLastError());
     }
 

--- a/library/std/src/sys/windows/alloc.rs
+++ b/library/std/src/sys/windows/alloc.rs
@@ -71,7 +71,7 @@ unsafe impl GlobalAlloc for System {
                 c::HeapFree(c::GetProcessHeap(), 0, header.0 as c::LPVOID)
             }
         };
-        debug_assert!(err != 0, "Failed to free heap memory: {}", unsafe {c::GetLastError()});
+        debug_assert!(err != 0, "Failed to free heap memory: {}", unsafe { c::GetLastError() });
     }
 
     #[inline]
@@ -79,14 +79,10 @@ unsafe impl GlobalAlloc for System {
         if layout.align() <= MIN_ALIGN {
             // SAFETY: HeapReAlloc is safe if ptr was allocated by this allocator
             // and new_size is not 0.
-            unsafe {
-                c::HeapReAlloc(c::GetProcessHeap(), 0, ptr as c::LPVOID, new_size) as *mut u8
-            }
+            unsafe { c::HeapReAlloc(c::GetProcessHeap(), 0, ptr as c::LPVOID, new_size) as *mut u8 }
         } else {
             // SAFETY: The safety contract for `realloc_fallback` must be upheld by the caller
-            unsafe {
-                realloc_fallback(self, ptr, layout, new_size)
-            }
+            unsafe { realloc_fallback(self, ptr, layout, new_size) }
         }
     }
 }

--- a/library/std/src/sys/windows/alloc.rs
+++ b/library/std/src/sys/windows/alloc.rs
@@ -1,3 +1,5 @@
+#![deny(unsafe_op_in_unsafe_fn)]
+
 use crate::alloc::{GlobalAlloc, Layout, System};
 use crate::sys::c;
 use crate::sys_common::alloc::{realloc_fallback, MIN_ALIGN};
@@ -6,56 +8,87 @@ use crate::sys_common::alloc::{realloc_fallback, MIN_ALIGN};
 struct Header(*mut u8);
 
 unsafe fn get_header<'a>(ptr: *mut u8) -> &'a mut Header {
-    &mut *(ptr as *mut Header).offset(-1)
+    // SAFETY: the safety contract must be upheld by the caller
+    unsafe { &mut *(ptr as *mut Header).offset(-1) }
 }
 
 unsafe fn align_ptr(ptr: *mut u8, align: usize) -> *mut u8 {
-    let aligned = ptr.add(align - (ptr as usize & (align - 1)));
-    *get_header(aligned) = Header(ptr);
-    aligned
+    // SAFETY: the safety contract must be upheld by the caller
+    unsafe {
+        let aligned = ptr.add(align - (ptr as usize & (align - 1)));
+        *get_header(aligned) = Header(ptr);
+        aligned
+    }
 }
 
 #[inline]
 unsafe fn allocate_with_flags(layout: Layout, flags: c::DWORD) -> *mut u8 {
     if layout.align() <= MIN_ALIGN {
-        return c::HeapAlloc(c::GetProcessHeap(), flags, layout.size()) as *mut u8;
+        // SAFETY: `layout.size()` comes from `Layout` and is valid.
+        return unsafe { c::HeapAlloc(c::GetProcessHeap(), flags, layout.size()) as *mut u8 };
     }
 
-    let size = layout.size() + layout.align();
-    let ptr = c::HeapAlloc(c::GetProcessHeap(), flags, size);
-    if ptr.is_null() { ptr as *mut u8 } else { align_ptr(ptr as *mut u8, layout.align()) }
+    let ptr = unsafe {
+        // SAFETY: The caller must ensure that
+        // `layout.size()` + `layout.size()` does not overflow.
+        let size = layout.size() + layout.align();
+        c::HeapAlloc(c::GetProcessHeap(), flags, size)
+    };
+
+    if ptr.is_null() {
+        ptr as *mut u8
+    } else {
+        // SAFETY: `ptr` is a valid pointer
+        // with enough allocated space to store the header.
+        unsafe { align_ptr(ptr as *mut u8, layout.align()) }
+    }
 }
 
+// SAFETY: All methods implemented follow the contract rules defined
+// in `GlobalAlloc`.
 #[stable(feature = "alloc_system_type", since = "1.28.0")]
 unsafe impl GlobalAlloc for System {
     #[inline]
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-        allocate_with_flags(layout, 0)
+        // SAFETY: the safety contract for `allocate_with_flags` must be upheld by the caller.
+        unsafe { allocate_with_flags(layout, 0) }
     }
 
     #[inline]
     unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
-        allocate_with_flags(layout, c::HEAP_ZERO_MEMORY)
+        // SAFETY: the safety contract for `allocate_with_flags must be upheld by the caller.
+        unsafe { allocate_with_flags(layout, c::HEAP_ZERO_MEMORY) }
     }
 
     #[inline]
     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
-        if layout.align() <= MIN_ALIGN {
-            let err = c::HeapFree(c::GetProcessHeap(), 0, ptr as c::LPVOID);
-            debug_assert!(err != 0, "Failed to free heap memory: {}", c::GetLastError());
-        } else {
-            let header = get_header(ptr);
-            let err = c::HeapFree(c::GetProcessHeap(), 0, header.0 as c::LPVOID);
-            debug_assert!(err != 0, "Failed to free heap memory: {}", c::GetLastError());
+        // SAFETY: HeapFree is safe if ptr was allocated by this allocator
+        let err = unsafe {
+            if layout.align() <= MIN_ALIGN {
+                c::HeapFree(c::GetProcessHeap(), 0, ptr as c::LPVOID);
+            } else {
+                let header = get_header(ptr);
+                c::HeapFree(c::GetProcessHeap(), 0, header.0 as c::LPVOID);
+            }
         }
+        debug_assert!(err != 0, "Failed to free heap memory: {}", c::GetLastError());
     }
 
     #[inline]
     unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
-        if layout.align() <= MIN_ALIGN {
-            c::HeapReAlloc(c::GetProcessHeap(), 0, ptr as c::LPVOID, new_size) as *mut u8
-        } else {
-            realloc_fallback(self, ptr, layout, new_size)
+        unsafe {
+            if layout.align() <= MIN_ALIGN {
+                // SAFETY: HeapReAlloc is safe if ptr was allocated by this allocator
+                // and new_size is not 0.
+                unsafe {
+                    c::HeapReAlloc(c::GetProcessHeap(), 0, ptr as c::LPVOID, new_size) as *mut u8
+                }
+            } else {
+                // SAFETY: The safety contract for `realloc_fallback` must be upheld by the caller
+                unsafe {
+                    realloc_fallback(self, ptr, layout, new_size)
+                }
+            }
         }
     }
 }

--- a/library/std/src/sys/windows/args.rs
+++ b/library/std/src/sys/windows/args.rs
@@ -1,4 +1,5 @@
 #![allow(dead_code)] // runtime init functions not used during testing
+#![deny(unsafe_op_in_unsafe_fn)]
 
 #[cfg(test)]
 mod tests;
@@ -52,11 +53,14 @@ unsafe fn parse_lp_cmd_line<F: Fn() -> OsString>(
     const TAB: u16 = '\t' as u16;
     const SPACE: u16 = ' ' as u16;
     let mut ret_val = Vec::new();
-    if lp_cmd_line.is_null() || *lp_cmd_line == 0 {
-        ret_val.push(exe_name());
-        return ret_val;
-    }
-    let mut cmd_line = {
+
+    //SAFETY: the caller must supply a valid pointer
+    let mut cmd_line = unsafe {
+        if lp_cmd_line.is_null() || *lp_cmd_line == 0 {
+            ret_val.push(exe_name());
+            return ret_val;
+        }
+
         let mut end = 0;
         while *lp_cmd_line.offset(end) != 0 {
             end += 1;

--- a/library/std/src/sys/windows/args.rs
+++ b/library/std/src/sys/windows/args.rs
@@ -54,7 +54,7 @@ unsafe fn parse_lp_cmd_line<F: Fn() -> OsString>(
     const SPACE: u16 = ' ' as u16;
     let mut ret_val = Vec::new();
 
-    //SAFETY: the caller must supply a valid pointer
+    // SAFETY: the caller must supply a pointer that is valid to dereference
     let mut cmd_line = unsafe {
         if lp_cmd_line.is_null() || *lp_cmd_line == 0 {
             ret_val.push(exe_name());

--- a/library/std/src/sys/windows/c.rs
+++ b/library/std/src/sys/windows/c.rs
@@ -1,6 +1,7 @@
 //! C definitions used by libnative that don't belong in liblibc
 
 #![allow(nonstandard_style)]
+#![deny(unsafe_op_in_unsafe_fn)]
 #![cfg_attr(test, allow(dead_code))]
 #![unstable(issue = "none", feature = "windows_c")]
 

--- a/library/std/src/sys/windows/cmath.rs
+++ b/library/std/src/sys/windows/cmath.rs
@@ -1,3 +1,4 @@
+#![deny(unsafe_op_in_unsafe_fn)]
 #![cfg(not(test))]
 
 use libc::{c_double, c_float};

--- a/library/std/src/sys/windows/compat.rs
+++ b/library/std/src/sys/windows/compat.rs
@@ -45,7 +45,12 @@ macro_rules! compat_fn {
             static PTR: AtomicUsize = AtomicUsize::new(0);
 
             #[allow(unused_variables)]
-            unsafe extern "system" fn fallback($($argname: $argtype),*) -> $rettype $body
+            unsafe extern "system" fn fallback($($argname: $argtype),*) -> $rettype {
+                #[allow(unused_unsafe)]
+                unsafe {
+                    $body
+                }
+            }
 
             /// This address is stored in `PTR` to incidate an unavailable API.
             ///

--- a/library/std/src/sys/windows/compat.rs
+++ b/library/std/src/sys/windows/compat.rs
@@ -11,6 +11,8 @@
 //! manner we pay a semi-large one-time cost up front for detecting whether a
 //! function is available but afterwards it's just a load and a jump.
 
+#![deny(unsafe_op_in_unsafe_fn)]
+
 use crate::ffi::CString;
 use crate::sys::c;
 
@@ -86,7 +88,9 @@ macro_rules! compat_fn {
             }
 
             pub unsafe fn call($($argname: $argtype),*) -> $rettype {
-                mem::transmute::<usize, F>(addr())($($argname),*)
+                unsafe {
+                    mem::transmute::<usize, F>(addr())($($argname),*)
+                }
             }
         }
 

--- a/library/std/src/sys/windows/env.rs
+++ b/library/std/src/sys/windows/env.rs
@@ -1,3 +1,5 @@
+#![deny(unsafe_op_in_unsafe_fn)]
+
 pub mod os {
     pub const FAMILY: &str = "windows";
     pub const OS: &str = "windows";

--- a/library/std/src/sys/windows/ext/ffi.rs
+++ b/library/std/src/sys/windows/ext/ffi.rs
@@ -50,6 +50,7 @@
 //! [`collect`]: crate::iter::Iterator::collect
 //! [U+FFFD]: crate::char::REPLACEMENT_CHARACTER
 
+#![deny(unsafe_op_in_unsafe_fn)]
 #![stable(feature = "rust1", since = "1.0.0")]
 
 use crate::ffi::{OsStr, OsString};

--- a/library/std/src/sys/windows/ext/fs.rs
+++ b/library/std/src/sys/windows/ext/fs.rs
@@ -1,5 +1,6 @@
 //! Windows-specific extensions for the primitives in the `std::fs` module.
 
+#![deny(unsafe_op_in_unsafe_fn)]
 #![stable(feature = "rust1", since = "1.0.0")]
 
 use crate::fs::{self, Metadata, OpenOptions};

--- a/library/std/src/sys/windows/ext/io.rs
+++ b/library/std/src/sys/windows/ext/io.rs
@@ -1,5 +1,6 @@
 //! Windows-specific extensions to general I/O primitives.
 
+#![deny(unsafe_op_in_unsafe_fn)]
 #![stable(feature = "rust1", since = "1.0.0")]
 
 use crate::fs;

--- a/library/std/src/sys/windows/ext/mod.rs
+++ b/library/std/src/sys/windows/ext/mod.rs
@@ -6,6 +6,7 @@
 //! `std` types and idioms with Windows in a way that the normal
 //! platform-agnostic idioms would not normally support.
 
+#![deny(unsafe_op_in_unsafe_fn)]
 #![stable(feature = "rust1", since = "1.0.0")]
 #![doc(cfg(windows))]
 #![allow(missing_docs)]

--- a/library/std/src/sys/windows/ext/process.rs
+++ b/library/std/src/sys/windows/ext/process.rs
@@ -1,5 +1,6 @@
 //! Extensions to `std::process` for Windows.
 
+#![deny(unsafe_op_in_unsafe_fn)]
 #![stable(feature = "process_extensions", since = "1.2.0")]
 
 use crate::os::windows::io::{AsRawHandle, FromRawHandle, IntoRawHandle, RawHandle};

--- a/library/std/src/sys/windows/ext/raw.rs
+++ b/library/std/src/sys/windows/ext/raw.rs
@@ -1,5 +1,6 @@
 //! Windows-specific primitives.
 
+#![deny(unsafe_op_in_unsafe_fn)]
 #![stable(feature = "raw_ext", since = "1.1.0")]
 
 use crate::os::raw::c_void;

--- a/library/std/src/sys/windows/ext/thread.rs
+++ b/library/std/src/sys/windows/ext/thread.rs
@@ -1,5 +1,6 @@
 //! Extensions to `std::thread` for Windows.
 
+#![deny(unsafe_op_in_unsafe_fn)]
 #![stable(feature = "thread_extensions", since = "1.9.0")]
 
 use crate::os::windows::io::{AsRawHandle, IntoRawHandle, RawHandle};

--- a/library/std/src/sys/windows/fs.rs
+++ b/library/std/src/sys/windows/fs.rs
@@ -1,3 +1,5 @@
+#![deny(unsafe_op_in_unsafe_fn)]
+
 use crate::os::windows::prelude::*;
 
 use crate::ffi::OsString;
@@ -862,7 +864,8 @@ pub fn copy(from: &Path, to: &Path) -> io::Result<u64> {
         lpData: c::LPVOID,
     ) -> c::DWORD {
         if dwStreamNumber == 1 {
-            *(lpData as *mut i64) = StreamBytesTransferred;
+            //SAFETY: We pass a *mut i64 as lpData to CopyFileExW, so we must get it back
+            unsafe { *(lpData as *mut i64) = StreamBytesTransferred };
         }
         c::PROGRESS_CONTINUE
     }

--- a/library/std/src/sys/windows/handle.rs
+++ b/library/std/src/sys/windows/handle.rs
@@ -1,3 +1,4 @@
+#![deny(unsafe_op_in_unsafe_fn)]
 #![unstable(issue = "none", feature = "windows_handle")]
 
 use crate::cmp;
@@ -120,7 +121,10 @@ impl RawHandle {
     ) -> io::Result<Option<usize>> {
         let len = cmp::min(buf.len(), <c::DWORD>::MAX as usize) as c::DWORD;
         let mut amt = 0;
-        let res = cvt(c::ReadFile(self.0, buf.as_ptr() as c::LPVOID, len, &mut amt, overlapped));
+        // SAFETY: the safety contract must be upheld by the caller
+        let res = unsafe {
+            cvt(c::ReadFile(self.0, buf.as_ptr() as c::LPVOID, len, &mut amt, overlapped))
+        };
         match res {
             Ok(_) => Ok(Some(amt as usize)),
             Err(e) => {

--- a/library/std/src/sys/windows/io.rs
+++ b/library/std/src/sys/windows/io.rs
@@ -1,3 +1,5 @@
+#![deny(unsafe_op_in_unsafe_fn)]
+
 use crate::marker::PhantomData;
 use crate::slice;
 use crate::sys::c;

--- a/library/std/src/sys/windows/memchr.rs
+++ b/library/std/src/sys/windows/memchr.rs
@@ -2,4 +2,5 @@
 // Copyright 2015 Andrew Gallant, bluss and Nicolas Koch
 
 // Fallback memchr is fastest on Windows.
+#![deny(unsafe_op_in_unsafe_fn)]
 pub use core::slice::memchr::{memchr, memrchr};

--- a/library/std/src/sys/windows/mod.rs
+++ b/library/std/src/sys/windows/mod.rs
@@ -1,3 +1,4 @@
+#![deny(unsafe_op_in_unsafe_fn)]
 #![allow(missing_docs, nonstandard_style)]
 
 use crate::ffi::{OsStr, OsString};

--- a/library/std/src/sys/windows/mutex.rs
+++ b/library/std/src/sys/windows/mutex.rs
@@ -135,7 +135,8 @@ impl Mutex {
             n => return n as *const _,
         }
         unsafe {
-            let inner = box Inner { remutex: ReentrantMutex::uninitialized(), held: Cell::new(false) };
+            let inner =
+                box Inner { remutex: ReentrantMutex::uninitialized(), held: Cell::new(false) };
             inner.remutex.init();
             let inner = Box::into_raw(inner);
             match self.lock.compare_and_swap(0, inner as usize, Ordering::SeqCst) {
@@ -182,9 +183,7 @@ impl ReentrantMutex {
     #[inline]
     pub unsafe fn try_lock(&self) -> bool {
         // SAFETY: The caller must ensure that the mutex is not moved or copied
-        unsafe {
-            c::TryEnterCriticalSection(UnsafeCell::raw_get(self.inner.as_ptr())) != 0
-        }
+        unsafe { c::TryEnterCriticalSection(UnsafeCell::raw_get(self.inner.as_ptr())) != 0 }
     }
 
     pub unsafe fn unlock(&self) {

--- a/library/std/src/sys/windows/mutex.rs
+++ b/library/std/src/sys/windows/mutex.rs
@@ -134,15 +134,10 @@ impl Mutex {
             0 => {}
             n => return n as *const _,
         }
-        let inner = box Inner { remutex: ReentrantMutex::uninitialized(), held: Cell::new(false) };
         unsafe {
+            let inner = box Inner { remutex: ReentrantMutex::uninitialized(), held: Cell::new(false) };
             inner.remutex.init();
-        }
-    }
-
-    unsafe fn flag_locked(&self) -> bool {
-        // SAFETY: The caller must ensure that the mutex is not moved or copied
-        unsafe {
+            let inner = Box::into_raw(inner);
             match self.lock.compare_and_swap(0, inner as usize, Ordering::SeqCst) {
                 0 => inner,
                 n => {

--- a/library/std/src/sys/windows/mutex.rs
+++ b/library/std/src/sys/windows/mutex.rs
@@ -67,6 +67,7 @@ impl Mutex {
     #[inline]
     pub unsafe fn init(&mut self) {}
     pub unsafe fn lock(&self) {
+        // SAFETY: The caller must ensure that the mutex is not moved or copied
         unsafe {
             match kind() {
                 Kind::SRWLock => c::AcquireSRWLockExclusive(raw(self)),
@@ -83,6 +84,7 @@ impl Mutex {
         }
     }
     pub unsafe fn try_lock(&self) -> bool {
+        // SAFETY: The caller must ensure that the mutex is not moved or copied
         unsafe {
             match kind() {
                 Kind::SRWLock => c::TryAcquireSRWLockExclusive(raw(self)) != 0,
@@ -102,6 +104,7 @@ impl Mutex {
         }
     }
     pub unsafe fn unlock(&self) {
+        // SAFETY: The caller must ensure that the mutex is not moved or copied
         unsafe {
             match kind() {
                 Kind::SRWLock => c::ReleaseSRWLockExclusive(raw(self)),
@@ -114,6 +117,7 @@ impl Mutex {
         }
     }
     pub unsafe fn destroy(&self) {
+        // SAFETY: The caller must ensure that the mutex is not moved or copied
         unsafe {
             match kind() {
                 Kind::SRWLock => {}
@@ -134,8 +138,10 @@ impl Mutex {
         unsafe {
             inner.remutex.init();
         }
-        let inner = Box::into_raw(inner);
-        
+    }
+
+    unsafe fn flag_locked(&self) -> bool {
+        // SAFETY: The caller must ensure that the mutex is not moved or copied
         unsafe {
             match self.lock.compare_and_swap(0, inner as usize, Ordering::SeqCst) {
                 0 => inner,

--- a/library/std/src/sys/windows/net.rs
+++ b/library/std/src/sys/windows/net.rs
@@ -1,3 +1,4 @@
+#![deny(unsafe_op_in_unsafe_fn)]
 #![unstable(issue = "none", feature = "windows_net")]
 
 use crate::cmp;

--- a/library/std/src/sys/windows/os.rs
+++ b/library/std/src/sys/windows/os.rs
@@ -1,5 +1,5 @@
 //! Implementation of `std::os` functionality for Windows.
-
+#![deny(unsafe_op_in_unsafe_fn)]
 #![allow(nonstandard_style)]
 
 #[cfg(test)]

--- a/library/std/src/sys/windows/os_str.rs
+++ b/library/std/src/sys/windows/os_str.rs
@@ -1,3 +1,5 @@
+#![deny(unsafe_op_in_unsafe_fn)]
+
 /// The underlying OsString/OsStr implementation on Windows is a
 /// wrapper around the "WTF-8" encoding; see the `wtf8` module for more.
 use crate::borrow::Cow;

--- a/library/std/src/sys/windows/path.rs
+++ b/library/std/src/sys/windows/path.rs
@@ -1,3 +1,5 @@
+#![deny(unsafe_op_in_unsafe_fn)]
+
 use crate::ffi::OsStr;
 use crate::mem;
 use crate::path::Prefix;
@@ -16,7 +18,8 @@ fn os_str_as_u8_slice(s: &OsStr) -> &[u8] {
     unsafe { mem::transmute(s) }
 }
 unsafe fn u8_slice_as_os_str(s: &[u8]) -> &OsStr {
-    mem::transmute(s)
+    // SAFETY: the safety contract must be upheld by the caller
+    unsafe { mem::transmute(s) }
 }
 
 #[inline]

--- a/library/std/src/sys/windows/pipe.rs
+++ b/library/std/src/sys/windows/pipe.rs
@@ -1,3 +1,5 @@
+#![deny(unsafe_op_in_unsafe_fn)]
+
 use crate::os::windows::prelude::*;
 
 use crate::ffi::OsStr;
@@ -364,5 +366,6 @@ unsafe fn slice_to_end(v: &mut Vec<u8>) -> &mut [u8] {
     if v.capacity() == v.len() {
         v.reserve(1);
     }
-    slice::from_raw_parts_mut(v.as_mut_ptr().add(v.len()), v.capacity() - v.len())
+    //SAFETY: `v` is a valid slice, and we reserve enough space
+    unsafe { slice::from_raw_parts_mut(v.as_mut_ptr().add(v.len()), v.capacity() - v.len()) }
 }

--- a/library/std/src/sys/windows/process.rs
+++ b/library/std/src/sys/windows/process.rs
@@ -1,3 +1,4 @@
+#![deny(unsafe_op_in_unsafe_fn)]
 #![unstable(feature = "process_internals", issue = "none")]
 
 #[cfg(test)]

--- a/library/std/src/sys/windows/rand.rs
+++ b/library/std/src/sys/windows/rand.rs
@@ -1,3 +1,5 @@
+#![deny(unsafe_op_in_unsafe_fn)]
+
 use crate::io;
 use crate::mem;
 use crate::sys::c;

--- a/library/std/src/sys/windows/rwlock.rs
+++ b/library/std/src/sys/windows/rwlock.rs
@@ -1,3 +1,5 @@
+#![deny(unsafe_op_in_unsafe_fn)]
+
 use crate::cell::UnsafeCell;
 use crate::sys::c;
 
@@ -14,27 +16,27 @@ impl RWLock {
     }
     #[inline]
     pub unsafe fn read(&self) {
-        c::AcquireSRWLockShared(self.inner.get())
+        unsafe { c::AcquireSRWLockShared(self.inner.get()) }
     }
     #[inline]
     pub unsafe fn try_read(&self) -> bool {
-        c::TryAcquireSRWLockShared(self.inner.get()) != 0
+        unsafe { c::TryAcquireSRWLockShared(self.inner.get()) != 0 }
     }
     #[inline]
     pub unsafe fn write(&self) {
-        c::AcquireSRWLockExclusive(self.inner.get())
+        unsafe { c::AcquireSRWLockExclusive(self.inner.get()) }
     }
     #[inline]
     pub unsafe fn try_write(&self) -> bool {
-        c::TryAcquireSRWLockExclusive(self.inner.get()) != 0
+        unsafe { c::TryAcquireSRWLockExclusive(self.inner.get()) != 0 }
     }
     #[inline]
     pub unsafe fn read_unlock(&self) {
-        c::ReleaseSRWLockShared(self.inner.get())
+        unsafe { c::ReleaseSRWLockShared(self.inner.get()) }
     }
     #[inline]
     pub unsafe fn write_unlock(&self) {
-        c::ReleaseSRWLockExclusive(self.inner.get())
+        unsafe { c::ReleaseSRWLockExclusive(self.inner.get()) }
     }
 
     #[inline]

--- a/library/std/src/sys/windows/stack_overflow_uwp.rs
+++ b/library/std/src/sys/windows/stack_overflow_uwp.rs
@@ -1,3 +1,4 @@
+#![deny(unsafe_op_in_unsafe_fn)]
 #![cfg_attr(test, allow(dead_code))]
 
 pub struct Handler;

--- a/library/std/src/sys/windows/stdio.rs
+++ b/library/std/src/sys/windows/stdio.rs
@@ -1,3 +1,4 @@
+#![deny(unsafe_op_in_unsafe_fn)]
 #![unstable(issue = "none", feature = "windows_stdio")]
 
 use crate::char::decode_utf16;

--- a/library/std/src/sys/windows/stdio_uwp.rs
+++ b/library/std/src/sys/windows/stdio_uwp.rs
@@ -1,3 +1,4 @@
+#![deny(unsafe_op_in_unsafe_fn)]
 #![unstable(issue = "none", feature = "windows_stdio")]
 
 use crate::io;

--- a/library/std/src/sys/windows/thread_local_dtor.rs
+++ b/library/std/src/sys/windows/thread_local_dtor.rs
@@ -1,3 +1,4 @@
+#![deny(unsafe_op_in_unsafe_fn)]
 #![unstable(feature = "thread_local_internals", issue = "none")]
 #![cfg(target_thread_local)]
 

--- a/library/std/src/sys/windows/time.rs
+++ b/library/std/src/sys/windows/time.rs
@@ -1,3 +1,5 @@
+#![deny(unsafe_op_in_unsafe_fn)]
+
 use crate::cmp::Ordering;
 use crate::convert::TryInto;
 use crate::fmt;


### PR DESCRIPTION
Put unsafe operations in unsafe blocks for sys/windows. Partial fix for #73904.