### PR TITLE
Add optimization to avoid load of address

### DIFF
--- a/compiler/rustc_mir/src/transform/instcombine.rs
+++ b/compiler/rustc_mir/src/transform/instcombine.rs
@@ -4,9 +4,14 @@ use crate::transform::{MirPass, MirSource};
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_hir::Mutability;
 use rustc_index::vec::Idx;
-use rustc_middle::mir::visit::{MutVisitor, Visitor};
 use rustc_middle::mir::{
-    BinOp, Body, Constant, Local, Location, Operand, Place, PlaceRef, ProjectionElem, Rvalue,
+    visit::PlaceContext,
+    visit::{MutVisitor, Visitor},
+    Statement,
+};
+use rustc_middle::mir::{
+    BinOp, Body, BorrowKind, Constant, Local, Location, Operand, Place, PlaceRef, ProjectionElem,
+    Rvalue,
 };
 use rustc_middle::ty::{self, TyCtxt};
 use std::mem;
@@ -71,7 +76,33 @@ impl<'tcx> MutVisitor<'tcx> for InstCombineVisitor<'tcx> {
             *rvalue = Rvalue::Use(operand);
         }
 
+        if let Some(place) = self.optimizations.unneeded_deref.remove(&location) {
+            debug!("unneeded_deref: replacing {:?} with {:?}", rvalue, place);
+            *rvalue = Rvalue::Use(Operand::Copy(place));
+        }
+
         self.super_rvalue(rvalue, location)
+    }
+}
+
+struct MutatingUseVisitor {
+    has_mutating_use: bool,
+    local_to_look_for: Local,
+}
+
+impl MutatingUseVisitor {
+    fn has_mutating_use_in_stmt(local: Local, stmt: &Statement<'tcx>, location: Location) -> bool {
+        let mut _self = Self { has_mutating_use: false, local_to_look_for: local };
+        _self.visit_statement(stmt, location);
+        _self.has_mutating_use
+    }
+}
+
+impl<'tcx> Visitor<'tcx> for MutatingUseVisitor {
+    fn visit_local(&mut self, local: &Local, context: PlaceContext, _: Location) {
+        if *local == self.local_to_look_for {
+            self.has_mutating_use |= context.is_mutating_use();
+        }
     }
 }
 
@@ -85,6 +116,85 @@ struct OptimizationFinder<'b, 'tcx> {
 impl OptimizationFinder<'b, 'tcx> {
     fn new(body: &'b Body<'tcx>, tcx: TyCtxt<'tcx>) -> OptimizationFinder<'b, 'tcx> {
         OptimizationFinder { body, tcx, optimizations: OptimizationList::default() }
+    }
+
+    fn find_deref_of_address(&mut self, rvalue: &Rvalue<'tcx>, location: Location) -> Option<()> {
+        // Look for the sequence
+        //
+        // _2 = &_1;
+        // ...
+        // _5 = (*_2);
+        //
+        // which we can replace the last statement with `_5 = _1;` to avoid the load of `_2`.
+        if let Rvalue::Use(op) = rvalue {
+            let local_being_derefed = match op.place()?.as_ref() {
+                PlaceRef { local, projection: [ProjectionElem::Deref] } => Some(local),
+                _ => None,
+            }?;
+
+            let stmt_index = location.statement_index;
+            // Look behind for statement that assigns the local from a address of operator.
+            // 6 is chosen as a heuristic determined by seeing the number of times
+            // the optimization kicked in compiling rust std.
+            let lower_index = stmt_index.saturating_sub(6);
+            let statements_to_look_in = self.body.basic_blocks()[location.block].statements
+                [lower_index..stmt_index]
+                .iter()
+                .rev();
+            for stmt in statements_to_look_in {
+                match &stmt.kind {
+                    // Exhaustive match on statements to detect conditions that warrant we bail out of the optimization.
+                    rustc_middle::mir::StatementKind::Assign(box (l, r))
+                        if l.local == local_being_derefed =>
+                    {
+                        match r {
+                            // Looking for immutable reference e.g _local_being_deref = &_1;
+                            Rvalue::Ref(
+                                _,
+                                // Only apply the optimization if it is an immutable borrow.
+                                BorrowKind::Shared,
+                                place_taken_address_of,
+                            ) => {
+                                self.optimizations
+                                    .unneeded_deref
+                                    .insert(location, *place_taken_address_of);
+                                return Some(());
+                            }
+
+                            // We found an assignment of `local_being_deref` that is not an immutable ref, e.g the following sequence
+                            // _2 = &_1;
+                            // _3 = &5
+                            // _2 = _3;  <-- this means it is no longer valid to replace the last statement with `_5 = _1;`
+                            // _5 = (*_2);
+                            _ => return None,
+                        }
+                    }
+
+                    // Inline asm can do anything, so bail out of the optimization.
+                    rustc_middle::mir::StatementKind::LlvmInlineAsm(_) => return None,
+
+                    // Check that `local_being_deref` is not being used in a mutating way which can cause misoptimization.
+                    rustc_middle::mir::StatementKind::Assign(box (_, _))
+                    | rustc_middle::mir::StatementKind::Coverage(_)
+                    | rustc_middle::mir::StatementKind::Nop
+                    | rustc_middle::mir::StatementKind::FakeRead(_, _)
+                    | rustc_middle::mir::StatementKind::StorageLive(_)
+                    | rustc_middle::mir::StatementKind::StorageDead(_)
+                    | rustc_middle::mir::StatementKind::Retag(_, _)
+                    | rustc_middle::mir::StatementKind::AscribeUserType(_, _)
+                    | rustc_middle::mir::StatementKind::SetDiscriminant { .. } => {
+                        if MutatingUseVisitor::has_mutating_use_in_stmt(
+                            local_being_derefed,
+                            stmt,
+                            location,
+                        ) {
+                            return None;
+                        }
+                    }
+                }
+            }
+        }
+        Some(())
     }
 
     fn find_unneeded_equality_comparison(&mut self, rvalue: &Rvalue<'tcx>, location: Location) {
@@ -153,6 +263,8 @@ impl Visitor<'tcx> for OptimizationFinder<'b, 'tcx> {
             }
         }
 
+        let _ = self.find_deref_of_address(rvalue, location);
+
         self.find_unneeded_equality_comparison(rvalue, location);
 
         self.super_rvalue(rvalue, location)
@@ -164,4 +276,5 @@ struct OptimizationList<'tcx> {
     and_stars: FxHashSet<Location>,
     arrays_lengths: FxHashMap<Location, Constant<'tcx>>,
     unneeded_equality_comparison: FxHashMap<Location, Operand<'tcx>>,
+    unneeded_deref: FxHashMap<Location, Place<'tcx>>,
 }

--- a/src/test/mir-opt/const_prop/ref_deref.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/ref_deref.main.ConstProp.diff
@@ -19,7 +19,7 @@
                                            // + span: $DIR/ref_deref.rs:5:6: 5:10
                                            // + literal: Const { ty: &i32, val: Unevaluated(WithOptConstParam { did: DefId(0:3 ~ ref_deref[317d]::main[0]), const_param_did: None }, [], Some(promoted[0])) }
           _2 = _4;                         // scope 0 at $DIR/ref_deref.rs:5:6: 5:10
--         _1 = (*_2);                      // scope 0 at $DIR/ref_deref.rs:5:5: 5:10
+-         _1 = (*_4);                      // scope 0 at $DIR/ref_deref.rs:5:5: 5:10
 +         _1 = const 4_i32;                // scope 0 at $DIR/ref_deref.rs:5:5: 5:10
           StorageDead(_2);                 // scope 0 at $DIR/ref_deref.rs:5:10: 5:11
           StorageDead(_1);                 // scope 0 at $DIR/ref_deref.rs:5:10: 5:11

--- a/src/test/mir-opt/const_prop/ref_deref_project.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/ref_deref_project.main.ConstProp.diff
@@ -19,7 +19,7 @@
                                            // + span: $DIR/ref_deref_project.rs:5:6: 5:17
                                            // + literal: Const { ty: &(i32, i32), val: Unevaluated(WithOptConstParam { did: DefId(0:3 ~ ref_deref_project[317d]::main[0]), const_param_did: None }, [], Some(promoted[0])) }
           _2 = &((*_4).1: i32);            // scope 0 at $DIR/ref_deref_project.rs:5:6: 5:17
-          _1 = (*_2);                      // scope 0 at $DIR/ref_deref_project.rs:5:5: 5:17
+          _1 = ((*_4).1: i32);             // scope 0 at $DIR/ref_deref_project.rs:5:5: 5:17
           StorageDead(_2);                 // scope 0 at $DIR/ref_deref_project.rs:5:17: 5:18
           StorageDead(_1);                 // scope 0 at $DIR/ref_deref_project.rs:5:17: 5:18
           _0 = const ();                   // scope 0 at $DIR/ref_deref_project.rs:4:11: 6:2

--- a/src/test/mir-opt/inline/inline_closure_borrows_arg.foo.Inline.after.mir
+++ b/src/test/mir-opt/inline/inline_closure_borrows_arg.foo.Inline.after.mir
@@ -9,13 +9,14 @@ fn foo(_1: T, _2: &i32) -> i32 {
     let mut _5: (&i32, &i32);            // in scope 0 at $DIR/inline-closure-borrows-arg.rs:16:5: 16:12
     let mut _6: &i32;                    // in scope 0 at $DIR/inline-closure-borrows-arg.rs:16:7: 16:8
     let mut _7: &i32;                    // in scope 0 at $DIR/inline-closure-borrows-arg.rs:16:10: 16:11
-    let mut _8: &i32;                    // in scope 0 at $DIR/inline-closure-borrows-arg.rs:16:5: 16:12
     let mut _9: &i32;                    // in scope 0 at $DIR/inline-closure-borrows-arg.rs:16:5: 16:12
+    let mut _10: &i32;                   // in scope 0 at $DIR/inline-closure-borrows-arg.rs:16:5: 16:12
     scope 1 {
         debug x => _3;                   // in scope 1 at $DIR/inline-closure-borrows-arg.rs:12:9: 12:10
         scope 2 {
-            debug r => _8;               // in scope 2 at $DIR/inline-closure-borrows-arg.rs:12:14: 12:15
-            debug _s => _9;              // in scope 2 at $DIR/inline-closure-borrows-arg.rs:12:23: 12:25
+            debug r => _9;               // in scope 2 at $DIR/inline-closure-borrows-arg.rs:12:14: 12:15
+            debug _s => _10;             // in scope 2 at $DIR/inline-closure-borrows-arg.rs:12:23: 12:25
+            let _8: &i32;                // in scope 2 at $DIR/inline-closure-borrows-arg.rs:16:5: 16:12
         }
     }
     scope 3 {
@@ -33,13 +34,16 @@ fn foo(_1: T, _2: &i32) -> i32 {
         _7 = &(*_2);                     // scope 1 at $DIR/inline-closure-borrows-arg.rs:16:10: 16:11
         (_5.0: &i32) = move _6;          // scope 1 at $DIR/inline-closure-borrows-arg.rs:16:5: 16:12
         (_5.1: &i32) = move _7;          // scope 1 at $DIR/inline-closure-borrows-arg.rs:16:5: 16:12
-        StorageLive(_8);                 // scope 1 at $DIR/inline-closure-borrows-arg.rs:16:5: 16:12
-        _8 = move (_5.0: &i32);          // scope 1 at $DIR/inline-closure-borrows-arg.rs:16:5: 16:12
         StorageLive(_9);                 // scope 1 at $DIR/inline-closure-borrows-arg.rs:16:5: 16:12
-        _9 = move (_5.1: &i32);          // scope 1 at $DIR/inline-closure-borrows-arg.rs:16:5: 16:12
-        _0 = (*_8);                      // scope 3 at $DIR/inline-closure-borrows-arg.rs:14:9: 14:18
+        _9 = move (_5.0: &i32);          // scope 1 at $DIR/inline-closure-borrows-arg.rs:16:5: 16:12
+        StorageLive(_10);                // scope 1 at $DIR/inline-closure-borrows-arg.rs:16:5: 16:12
+        _10 = move (_5.1: &i32);         // scope 1 at $DIR/inline-closure-borrows-arg.rs:16:5: 16:12
+        StorageLive(_8);                 // scope 2 at $DIR/inline-closure-borrows-arg.rs:13:13: 13:21
+        _8 = _9;                         // scope 2 at $DIR/inline-closure-borrows-arg.rs:13:24: 13:27
+        _0 = (*_9);                      // scope 3 at $DIR/inline-closure-borrows-arg.rs:14:9: 14:18
+        StorageDead(_8);                 // scope 2 at $DIR/inline-closure-borrows-arg.rs:15:5: 15:6
+        StorageDead(_10);                // scope 1 at $DIR/inline-closure-borrows-arg.rs:16:5: 16:12
         StorageDead(_9);                 // scope 1 at $DIR/inline-closure-borrows-arg.rs:16:5: 16:12
-        StorageDead(_8);                 // scope 1 at $DIR/inline-closure-borrows-arg.rs:16:5: 16:12
         StorageDead(_7);                 // scope 1 at $DIR/inline-closure-borrows-arg.rs:16:11: 16:12
         StorageDead(_6);                 // scope 1 at $DIR/inline-closure-borrows-arg.rs:16:11: 16:12
         StorageDead(_5);                 // scope 1 at $DIR/inline-closure-borrows-arg.rs:16:11: 16:12

--- a/src/test/mir-opt/inst_combine_deref.deep_opt.InstCombine.diff
+++ b/src/test/mir-opt/inst_combine_deref.deep_opt.InstCombine.diff
@@ -1,0 +1,92 @@
+- // MIR for `deep_opt` before InstCombine
++ // MIR for `deep_opt` after InstCombine
+  
+  fn deep_opt() -> (u64, u64, u64) {
+      let mut _0: (u64, u64, u64);         // return place in scope 0 at $DIR/inst_combine_deref.rs:10:18: 10:33
+      let _1: u64;                         // in scope 0 at $DIR/inst_combine_deref.rs:11:9: 11:11
+      let mut _10: u64;                    // in scope 0 at $DIR/inst_combine_deref.rs:20:6: 20:8
+      let mut _11: u64;                    // in scope 0 at $DIR/inst_combine_deref.rs:20:10: 20:12
+      let mut _12: u64;                    // in scope 0 at $DIR/inst_combine_deref.rs:20:14: 20:16
+      scope 1 {
+          debug x1 => _1;                  // in scope 1 at $DIR/inst_combine_deref.rs:11:9: 11:11
+          let _2: u64;                     // in scope 1 at $DIR/inst_combine_deref.rs:12:9: 12:11
+          scope 2 {
+              debug x2 => _2;              // in scope 2 at $DIR/inst_combine_deref.rs:12:9: 12:11
+              let _3: u64;                 // in scope 2 at $DIR/inst_combine_deref.rs:13:9: 13:11
+              scope 3 {
+                  debug x3 => _3;          // in scope 3 at $DIR/inst_combine_deref.rs:13:9: 13:11
+                  let _4: &u64;            // in scope 3 at $DIR/inst_combine_deref.rs:14:9: 14:11
+                  scope 4 {
+                      debug y1 => _4;      // in scope 4 at $DIR/inst_combine_deref.rs:14:9: 14:11
+                      let _5: &u64;        // in scope 4 at $DIR/inst_combine_deref.rs:15:9: 15:11
+                      scope 5 {
+                          debug y2 => _5;  // in scope 5 at $DIR/inst_combine_deref.rs:15:9: 15:11
+                          let _6: &u64;    // in scope 5 at $DIR/inst_combine_deref.rs:16:9: 16:11
+                          scope 6 {
+                              debug y3 => _6; // in scope 6 at $DIR/inst_combine_deref.rs:16:9: 16:11
+                              let _7: u64; // in scope 6 at $DIR/inst_combine_deref.rs:17:9: 17:11
+                              scope 7 {
+                                  debug z1 => _7; // in scope 7 at $DIR/inst_combine_deref.rs:17:9: 17:11
+                                  let _8: u64; // in scope 7 at $DIR/inst_combine_deref.rs:18:9: 18:11
+                                  scope 8 {
+                                      debug z2 => _8; // in scope 8 at $DIR/inst_combine_deref.rs:18:9: 18:11
+                                      let _9: u64; // in scope 8 at $DIR/inst_combine_deref.rs:19:9: 19:11
+                                      scope 9 {
+                                          debug z3 => _9; // in scope 9 at $DIR/inst_combine_deref.rs:19:9: 19:11
+                                      }
+                                  }
+                              }
+                          }
+                      }
+                  }
+              }
+          }
+      }
+  
+      bb0: {
+          StorageLive(_1);                 // scope 0 at $DIR/inst_combine_deref.rs:11:9: 11:11
+          _1 = const 1_u64;                // scope 0 at $DIR/inst_combine_deref.rs:11:14: 11:15
+          StorageLive(_2);                 // scope 1 at $DIR/inst_combine_deref.rs:12:9: 12:11
+          _2 = const 2_u64;                // scope 1 at $DIR/inst_combine_deref.rs:12:14: 12:15
+          StorageLive(_3);                 // scope 2 at $DIR/inst_combine_deref.rs:13:9: 13:11
+          _3 = const 3_u64;                // scope 2 at $DIR/inst_combine_deref.rs:13:14: 13:15
+          StorageLive(_4);                 // scope 3 at $DIR/inst_combine_deref.rs:14:9: 14:11
+          _4 = &_1;                        // scope 3 at $DIR/inst_combine_deref.rs:14:14: 14:17
+          StorageLive(_5);                 // scope 4 at $DIR/inst_combine_deref.rs:15:9: 15:11
+          _5 = &_2;                        // scope 4 at $DIR/inst_combine_deref.rs:15:14: 15:17
+          StorageLive(_6);                 // scope 5 at $DIR/inst_combine_deref.rs:16:9: 16:11
+          _6 = &_3;                        // scope 5 at $DIR/inst_combine_deref.rs:16:14: 16:17
+          StorageLive(_7);                 // scope 6 at $DIR/inst_combine_deref.rs:17:9: 17:11
+-         _7 = (*_4);                      // scope 6 at $DIR/inst_combine_deref.rs:17:14: 17:17
++         _7 = _1;                         // scope 6 at $DIR/inst_combine_deref.rs:17:14: 17:17
+          StorageLive(_8);                 // scope 7 at $DIR/inst_combine_deref.rs:18:9: 18:11
+-         _8 = (*_5);                      // scope 7 at $DIR/inst_combine_deref.rs:18:14: 18:17
++         _8 = _2;                         // scope 7 at $DIR/inst_combine_deref.rs:18:14: 18:17
+          StorageLive(_9);                 // scope 8 at $DIR/inst_combine_deref.rs:19:9: 19:11
+-         _9 = (*_6);                      // scope 8 at $DIR/inst_combine_deref.rs:19:14: 19:17
++         _9 = _3;                         // scope 8 at $DIR/inst_combine_deref.rs:19:14: 19:17
+          StorageLive(_10);                // scope 9 at $DIR/inst_combine_deref.rs:20:6: 20:8
+          _10 = _7;                        // scope 9 at $DIR/inst_combine_deref.rs:20:6: 20:8
+          StorageLive(_11);                // scope 9 at $DIR/inst_combine_deref.rs:20:10: 20:12
+          _11 = _8;                        // scope 9 at $DIR/inst_combine_deref.rs:20:10: 20:12
+          StorageLive(_12);                // scope 9 at $DIR/inst_combine_deref.rs:20:14: 20:16
+          _12 = _9;                        // scope 9 at $DIR/inst_combine_deref.rs:20:14: 20:16
+          (_0.0: u64) = move _10;          // scope 9 at $DIR/inst_combine_deref.rs:20:5: 20:17
+          (_0.1: u64) = move _11;          // scope 9 at $DIR/inst_combine_deref.rs:20:5: 20:17
+          (_0.2: u64) = move _12;          // scope 9 at $DIR/inst_combine_deref.rs:20:5: 20:17
+          StorageDead(_12);                // scope 9 at $DIR/inst_combine_deref.rs:20:16: 20:17
+          StorageDead(_11);                // scope 9 at $DIR/inst_combine_deref.rs:20:16: 20:17
+          StorageDead(_10);                // scope 9 at $DIR/inst_combine_deref.rs:20:16: 20:17
+          StorageDead(_9);                 // scope 8 at $DIR/inst_combine_deref.rs:21:1: 21:2
+          StorageDead(_8);                 // scope 7 at $DIR/inst_combine_deref.rs:21:1: 21:2
+          StorageDead(_7);                 // scope 6 at $DIR/inst_combine_deref.rs:21:1: 21:2
+          StorageDead(_6);                 // scope 5 at $DIR/inst_combine_deref.rs:21:1: 21:2
+          StorageDead(_5);                 // scope 4 at $DIR/inst_combine_deref.rs:21:1: 21:2
+          StorageDead(_4);                 // scope 3 at $DIR/inst_combine_deref.rs:21:1: 21:2
+          StorageDead(_3);                 // scope 2 at $DIR/inst_combine_deref.rs:21:1: 21:2
+          StorageDead(_2);                 // scope 1 at $DIR/inst_combine_deref.rs:21:1: 21:2
+          StorageDead(_1);                 // scope 0 at $DIR/inst_combine_deref.rs:21:1: 21:2
+          return;                          // scope 0 at $DIR/inst_combine_deref.rs:21:2: 21:2
+      }
+  }
+  

--- a/src/test/mir-opt/inst_combine_deref.deep_opt.InstCombine.diff
+++ b/src/test/mir-opt/inst_combine_deref.deep_opt.InstCombine.diff
@@ -2,37 +2,37 @@
 + // MIR for `deep_opt` after InstCombine
   
   fn deep_opt() -> (u64, u64, u64) {
-      let mut _0: (u64, u64, u64);         // return place in scope 0 at $DIR/inst_combine_deref.rs:10:18: 10:33
-      let _1: u64;                         // in scope 0 at $DIR/inst_combine_deref.rs:11:9: 11:11
-      let mut _10: u64;                    // in scope 0 at $DIR/inst_combine_deref.rs:20:6: 20:8
-      let mut _11: u64;                    // in scope 0 at $DIR/inst_combine_deref.rs:20:10: 20:12
-      let mut _12: u64;                    // in scope 0 at $DIR/inst_combine_deref.rs:20:14: 20:16
+      let mut _0: (u64, u64, u64);         // return place in scope 0 at $DIR/inst_combine_deref.rs:11:18: 11:33
+      let _1: u64;                         // in scope 0 at $DIR/inst_combine_deref.rs:12:9: 12:11
+      let mut _10: u64;                    // in scope 0 at $DIR/inst_combine_deref.rs:21:6: 21:8
+      let mut _11: u64;                    // in scope 0 at $DIR/inst_combine_deref.rs:21:10: 21:12
+      let mut _12: u64;                    // in scope 0 at $DIR/inst_combine_deref.rs:21:14: 21:16
       scope 1 {
-          debug x1 => _1;                  // in scope 1 at $DIR/inst_combine_deref.rs:11:9: 11:11
-          let _2: u64;                     // in scope 1 at $DIR/inst_combine_deref.rs:12:9: 12:11
+          debug x1 => _1;                  // in scope 1 at $DIR/inst_combine_deref.rs:12:9: 12:11
+          let _2: u64;                     // in scope 1 at $DIR/inst_combine_deref.rs:13:9: 13:11
           scope 2 {
-              debug x2 => _2;              // in scope 2 at $DIR/inst_combine_deref.rs:12:9: 12:11
-              let _3: u64;                 // in scope 2 at $DIR/inst_combine_deref.rs:13:9: 13:11
+              debug x2 => _2;              // in scope 2 at $DIR/inst_combine_deref.rs:13:9: 13:11
+              let _3: u64;                 // in scope 2 at $DIR/inst_combine_deref.rs:14:9: 14:11
               scope 3 {
-                  debug x3 => _3;          // in scope 3 at $DIR/inst_combine_deref.rs:13:9: 13:11
-                  let _4: &u64;            // in scope 3 at $DIR/inst_combine_deref.rs:14:9: 14:11
+                  debug x3 => _3;          // in scope 3 at $DIR/inst_combine_deref.rs:14:9: 14:11
+                  let _4: &u64;            // in scope 3 at $DIR/inst_combine_deref.rs:15:9: 15:11
                   scope 4 {
-                      debug y1 => _4;      // in scope 4 at $DIR/inst_combine_deref.rs:14:9: 14:11
-                      let _5: &u64;        // in scope 4 at $DIR/inst_combine_deref.rs:15:9: 15:11
+                      debug y1 => _4;      // in scope 4 at $DIR/inst_combine_deref.rs:15:9: 15:11
+                      let _5: &u64;        // in scope 4 at $DIR/inst_combine_deref.rs:16:9: 16:11
                       scope 5 {
-                          debug y2 => _5;  // in scope 5 at $DIR/inst_combine_deref.rs:15:9: 15:11
-                          let _6: &u64;    // in scope 5 at $DIR/inst_combine_deref.rs:16:9: 16:11
+                          debug y2 => _5;  // in scope 5 at $DIR/inst_combine_deref.rs:16:9: 16:11
+                          let _6: &u64;    // in scope 5 at $DIR/inst_combine_deref.rs:17:9: 17:11
                           scope 6 {
-                              debug y3 => _6; // in scope 6 at $DIR/inst_combine_deref.rs:16:9: 16:11
-                              let _7: u64; // in scope 6 at $DIR/inst_combine_deref.rs:17:9: 17:11
+                              debug y3 => _6; // in scope 6 at $DIR/inst_combine_deref.rs:17:9: 17:11
+                              let _7: u64; // in scope 6 at $DIR/inst_combine_deref.rs:18:9: 18:11
                               scope 7 {
-                                  debug z1 => _7; // in scope 7 at $DIR/inst_combine_deref.rs:17:9: 17:11
-                                  let _8: u64; // in scope 7 at $DIR/inst_combine_deref.rs:18:9: 18:11
+                                  debug z1 => _7; // in scope 7 at $DIR/inst_combine_deref.rs:18:9: 18:11
+                                  let _8: u64; // in scope 7 at $DIR/inst_combine_deref.rs:19:9: 19:11
                                   scope 8 {
-                                      debug z2 => _8; // in scope 8 at $DIR/inst_combine_deref.rs:18:9: 18:11
-                                      let _9: u64; // in scope 8 at $DIR/inst_combine_deref.rs:19:9: 19:11
+                                      debug z2 => _8; // in scope 8 at $DIR/inst_combine_deref.rs:19:9: 19:11
+                                      let _9: u64; // in scope 8 at $DIR/inst_combine_deref.rs:20:9: 20:11
                                       scope 9 {
-                                          debug z3 => _9; // in scope 9 at $DIR/inst_combine_deref.rs:19:9: 19:11
+                                          debug z3 => _9; // in scope 9 at $DIR/inst_combine_deref.rs:20:9: 20:11
                                       }
                                   }
                               }
@@ -44,49 +44,49 @@
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/inst_combine_deref.rs:11:9: 11:11
-          _1 = const 1_u64;                // scope 0 at $DIR/inst_combine_deref.rs:11:14: 11:15
-          StorageLive(_2);                 // scope 1 at $DIR/inst_combine_deref.rs:12:9: 12:11
-          _2 = const 2_u64;                // scope 1 at $DIR/inst_combine_deref.rs:12:14: 12:15
-          StorageLive(_3);                 // scope 2 at $DIR/inst_combine_deref.rs:13:9: 13:11
-          _3 = const 3_u64;                // scope 2 at $DIR/inst_combine_deref.rs:13:14: 13:15
-          StorageLive(_4);                 // scope 3 at $DIR/inst_combine_deref.rs:14:9: 14:11
-          _4 = &_1;                        // scope 3 at $DIR/inst_combine_deref.rs:14:14: 14:17
-          StorageLive(_5);                 // scope 4 at $DIR/inst_combine_deref.rs:15:9: 15:11
-          _5 = &_2;                        // scope 4 at $DIR/inst_combine_deref.rs:15:14: 15:17
-          StorageLive(_6);                 // scope 5 at $DIR/inst_combine_deref.rs:16:9: 16:11
-          _6 = &_3;                        // scope 5 at $DIR/inst_combine_deref.rs:16:14: 16:17
-          StorageLive(_7);                 // scope 6 at $DIR/inst_combine_deref.rs:17:9: 17:11
--         _7 = (*_4);                      // scope 6 at $DIR/inst_combine_deref.rs:17:14: 17:17
-+         _7 = _1;                         // scope 6 at $DIR/inst_combine_deref.rs:17:14: 17:17
-          StorageLive(_8);                 // scope 7 at $DIR/inst_combine_deref.rs:18:9: 18:11
--         _8 = (*_5);                      // scope 7 at $DIR/inst_combine_deref.rs:18:14: 18:17
-+         _8 = _2;                         // scope 7 at $DIR/inst_combine_deref.rs:18:14: 18:17
-          StorageLive(_9);                 // scope 8 at $DIR/inst_combine_deref.rs:19:9: 19:11
--         _9 = (*_6);                      // scope 8 at $DIR/inst_combine_deref.rs:19:14: 19:17
-+         _9 = _3;                         // scope 8 at $DIR/inst_combine_deref.rs:19:14: 19:17
-          StorageLive(_10);                // scope 9 at $DIR/inst_combine_deref.rs:20:6: 20:8
-          _10 = _7;                        // scope 9 at $DIR/inst_combine_deref.rs:20:6: 20:8
-          StorageLive(_11);                // scope 9 at $DIR/inst_combine_deref.rs:20:10: 20:12
-          _11 = _8;                        // scope 9 at $DIR/inst_combine_deref.rs:20:10: 20:12
-          StorageLive(_12);                // scope 9 at $DIR/inst_combine_deref.rs:20:14: 20:16
-          _12 = _9;                        // scope 9 at $DIR/inst_combine_deref.rs:20:14: 20:16
-          (_0.0: u64) = move _10;          // scope 9 at $DIR/inst_combine_deref.rs:20:5: 20:17
-          (_0.1: u64) = move _11;          // scope 9 at $DIR/inst_combine_deref.rs:20:5: 20:17
-          (_0.2: u64) = move _12;          // scope 9 at $DIR/inst_combine_deref.rs:20:5: 20:17
-          StorageDead(_12);                // scope 9 at $DIR/inst_combine_deref.rs:20:16: 20:17
-          StorageDead(_11);                // scope 9 at $DIR/inst_combine_deref.rs:20:16: 20:17
-          StorageDead(_10);                // scope 9 at $DIR/inst_combine_deref.rs:20:16: 20:17
-          StorageDead(_9);                 // scope 8 at $DIR/inst_combine_deref.rs:21:1: 21:2
-          StorageDead(_8);                 // scope 7 at $DIR/inst_combine_deref.rs:21:1: 21:2
-          StorageDead(_7);                 // scope 6 at $DIR/inst_combine_deref.rs:21:1: 21:2
-          StorageDead(_6);                 // scope 5 at $DIR/inst_combine_deref.rs:21:1: 21:2
-          StorageDead(_5);                 // scope 4 at $DIR/inst_combine_deref.rs:21:1: 21:2
-          StorageDead(_4);                 // scope 3 at $DIR/inst_combine_deref.rs:21:1: 21:2
-          StorageDead(_3);                 // scope 2 at $DIR/inst_combine_deref.rs:21:1: 21:2
-          StorageDead(_2);                 // scope 1 at $DIR/inst_combine_deref.rs:21:1: 21:2
-          StorageDead(_1);                 // scope 0 at $DIR/inst_combine_deref.rs:21:1: 21:2
-          return;                          // scope 0 at $DIR/inst_combine_deref.rs:21:2: 21:2
+          StorageLive(_1);                 // scope 0 at $DIR/inst_combine_deref.rs:12:9: 12:11
+          _1 = const 1_u64;                // scope 0 at $DIR/inst_combine_deref.rs:12:14: 12:15
+          StorageLive(_2);                 // scope 1 at $DIR/inst_combine_deref.rs:13:9: 13:11
+          _2 = const 2_u64;                // scope 1 at $DIR/inst_combine_deref.rs:13:14: 13:15
+          StorageLive(_3);                 // scope 2 at $DIR/inst_combine_deref.rs:14:9: 14:11
+          _3 = const 3_u64;                // scope 2 at $DIR/inst_combine_deref.rs:14:14: 14:15
+          StorageLive(_4);                 // scope 3 at $DIR/inst_combine_deref.rs:15:9: 15:11
+          _4 = &_1;                        // scope 3 at $DIR/inst_combine_deref.rs:15:14: 15:17
+          StorageLive(_5);                 // scope 4 at $DIR/inst_combine_deref.rs:16:9: 16:11
+          _5 = &_2;                        // scope 4 at $DIR/inst_combine_deref.rs:16:14: 16:17
+          StorageLive(_6);                 // scope 5 at $DIR/inst_combine_deref.rs:17:9: 17:11
+          _6 = &_3;                        // scope 5 at $DIR/inst_combine_deref.rs:17:14: 17:17
+          StorageLive(_7);                 // scope 6 at $DIR/inst_combine_deref.rs:18:9: 18:11
+-         _7 = (*_4);                      // scope 6 at $DIR/inst_combine_deref.rs:18:14: 18:17
++         _7 = _1;                         // scope 6 at $DIR/inst_combine_deref.rs:18:14: 18:17
+          StorageLive(_8);                 // scope 7 at $DIR/inst_combine_deref.rs:19:9: 19:11
+-         _8 = (*_5);                      // scope 7 at $DIR/inst_combine_deref.rs:19:14: 19:17
++         _8 = _2;                         // scope 7 at $DIR/inst_combine_deref.rs:19:14: 19:17
+          StorageLive(_9);                 // scope 8 at $DIR/inst_combine_deref.rs:20:9: 20:11
+-         _9 = (*_6);                      // scope 8 at $DIR/inst_combine_deref.rs:20:14: 20:17
++         _9 = _3;                         // scope 8 at $DIR/inst_combine_deref.rs:20:14: 20:17
+          StorageLive(_10);                // scope 9 at $DIR/inst_combine_deref.rs:21:6: 21:8
+          _10 = _7;                        // scope 9 at $DIR/inst_combine_deref.rs:21:6: 21:8
+          StorageLive(_11);                // scope 9 at $DIR/inst_combine_deref.rs:21:10: 21:12
+          _11 = _8;                        // scope 9 at $DIR/inst_combine_deref.rs:21:10: 21:12
+          StorageLive(_12);                // scope 9 at $DIR/inst_combine_deref.rs:21:14: 21:16
+          _12 = _9;                        // scope 9 at $DIR/inst_combine_deref.rs:21:14: 21:16
+          (_0.0: u64) = move _10;          // scope 9 at $DIR/inst_combine_deref.rs:21:5: 21:17
+          (_0.1: u64) = move _11;          // scope 9 at $DIR/inst_combine_deref.rs:21:5: 21:17
+          (_0.2: u64) = move _12;          // scope 9 at $DIR/inst_combine_deref.rs:21:5: 21:17
+          StorageDead(_12);                // scope 9 at $DIR/inst_combine_deref.rs:21:16: 21:17
+          StorageDead(_11);                // scope 9 at $DIR/inst_combine_deref.rs:21:16: 21:17
+          StorageDead(_10);                // scope 9 at $DIR/inst_combine_deref.rs:21:16: 21:17
+          StorageDead(_9);                 // scope 8 at $DIR/inst_combine_deref.rs:22:1: 22:2
+          StorageDead(_8);                 // scope 7 at $DIR/inst_combine_deref.rs:22:1: 22:2
+          StorageDead(_7);                 // scope 6 at $DIR/inst_combine_deref.rs:22:1: 22:2
+          StorageDead(_6);                 // scope 5 at $DIR/inst_combine_deref.rs:22:1: 22:2
+          StorageDead(_5);                 // scope 4 at $DIR/inst_combine_deref.rs:22:1: 22:2
+          StorageDead(_4);                 // scope 3 at $DIR/inst_combine_deref.rs:22:1: 22:2
+          StorageDead(_3);                 // scope 2 at $DIR/inst_combine_deref.rs:22:1: 22:2
+          StorageDead(_2);                 // scope 1 at $DIR/inst_combine_deref.rs:22:1: 22:2
+          StorageDead(_1);                 // scope 0 at $DIR/inst_combine_deref.rs:22:1: 22:2
+          return;                          // scope 0 at $DIR/inst_combine_deref.rs:22:2: 22:2
       }
   }
   

--- a/src/test/mir-opt/inst_combine_deref.do_not_miscompile.InstCombine.diff
+++ b/src/test/mir-opt/inst_combine_deref.do_not_miscompile.InstCombine.diff
@@ -1,0 +1,85 @@
+- // MIR for `do_not_miscompile` before InstCombine
++ // MIR for `do_not_miscompile` after InstCombine
+  
+  fn do_not_miscompile() -> () {
+      let mut _0: ();                      // return place in scope 0 at $DIR/inst_combine_deref.rs:53:24: 53:24
+      let _1: i32;                         // in scope 0 at $DIR/inst_combine_deref.rs:54:9: 54:10
+      let mut _5: &i32;                    // in scope 0 at $DIR/inst_combine_deref.rs:58:10: 58:12
+      let _6: &i32;                        // in scope 0 at $DIR/inst_combine_deref.rs:58:10: 58:12
+      let _7: ();                          // in scope 0 at $DIR/inst_combine_deref.rs:59:5: 59:23
+      let mut _8: bool;                    // in scope 0 at $DIR/inst_combine_deref.rs:59:5: 59:23
+      let mut _9: bool;                    // in scope 0 at $DIR/inst_combine_deref.rs:59:13: 59:21
+      let mut _10: i32;                    // in scope 0 at $DIR/inst_combine_deref.rs:59:13: 59:15
+      let mut _11: !;                      // in scope 0 at $SRC_DIR/std/src/macros.rs:LL:COL
+      scope 1 {
+          debug x => _1;                   // in scope 1 at $DIR/inst_combine_deref.rs:54:9: 54:10
+          let _2: i32;                     // in scope 1 at $DIR/inst_combine_deref.rs:55:9: 55:10
+          scope 2 {
+              debug a => _2;               // in scope 2 at $DIR/inst_combine_deref.rs:55:9: 55:10
+              let mut _3: &i32;            // in scope 2 at $DIR/inst_combine_deref.rs:56:9: 56:14
+              scope 3 {
+                  debug y => _3;           // in scope 3 at $DIR/inst_combine_deref.rs:56:9: 56:14
+                  let _4: &mut &i32;       // in scope 3 at $DIR/inst_combine_deref.rs:57:9: 57:10
+                  scope 4 {
+                      debug z => _4;       // in scope 4 at $DIR/inst_combine_deref.rs:57:9: 57:10
+                  }
+              }
+          }
+      }
+  
+      bb0: {
+          StorageLive(_1);                 // scope 0 at $DIR/inst_combine_deref.rs:54:9: 54:10
+          _1 = const 42_i32;               // scope 0 at $DIR/inst_combine_deref.rs:54:13: 54:15
+          StorageLive(_2);                 // scope 1 at $DIR/inst_combine_deref.rs:55:9: 55:10
+          _2 = const 99_i32;               // scope 1 at $DIR/inst_combine_deref.rs:55:13: 55:15
+          StorageLive(_3);                 // scope 2 at $DIR/inst_combine_deref.rs:56:9: 56:14
+          _3 = &_1;                        // scope 2 at $DIR/inst_combine_deref.rs:56:17: 56:19
+          StorageLive(_4);                 // scope 3 at $DIR/inst_combine_deref.rs:57:9: 57:10
+          _4 = &mut _3;                    // scope 3 at $DIR/inst_combine_deref.rs:57:13: 57:19
+          StorageLive(_5);                 // scope 4 at $DIR/inst_combine_deref.rs:58:10: 58:12
+          StorageLive(_6);                 // scope 4 at $DIR/inst_combine_deref.rs:58:10: 58:12
+          _6 = &_2;                        // scope 4 at $DIR/inst_combine_deref.rs:58:10: 58:12
+-         _5 = &(*_6);                     // scope 4 at $DIR/inst_combine_deref.rs:58:10: 58:12
++         _5 = _6;                         // scope 4 at $DIR/inst_combine_deref.rs:58:10: 58:12
+          (*_4) = move _5;                 // scope 4 at $DIR/inst_combine_deref.rs:58:5: 58:12
+          StorageDead(_5);                 // scope 4 at $DIR/inst_combine_deref.rs:58:11: 58:12
+          StorageDead(_6);                 // scope 4 at $DIR/inst_combine_deref.rs:58:12: 58:13
+          StorageLive(_7);                 // scope 4 at $DIR/inst_combine_deref.rs:59:5: 59:23
+          StorageLive(_8);                 // scope 4 at $DIR/inst_combine_deref.rs:59:5: 59:23
+          StorageLive(_9);                 // scope 4 at $DIR/inst_combine_deref.rs:59:13: 59:21
+          StorageLive(_10);                // scope 4 at $DIR/inst_combine_deref.rs:59:13: 59:15
+          _10 = (*_3);                     // scope 4 at $DIR/inst_combine_deref.rs:59:13: 59:15
+          _9 = Eq(move _10, const 99_i32); // scope 4 at $DIR/inst_combine_deref.rs:59:13: 59:21
+          StorageDead(_10);                // scope 4 at $DIR/inst_combine_deref.rs:59:20: 59:21
+          _8 = Not(move _9);               // scope 4 at $DIR/inst_combine_deref.rs:59:5: 59:23
+          StorageDead(_9);                 // scope 4 at $DIR/inst_combine_deref.rs:59:22: 59:23
+          switchInt(_8) -> [false: bb1, otherwise: bb2]; // scope 4 at $DIR/inst_combine_deref.rs:59:5: 59:23
+      }
+  
+      bb1: {
+          _7 = const ();                   // scope 4 at $DIR/inst_combine_deref.rs:59:5: 59:23
+          StorageDead(_8);                 // scope 4 at $DIR/inst_combine_deref.rs:59:22: 59:23
+          StorageDead(_7);                 // scope 4 at $DIR/inst_combine_deref.rs:59:22: 59:23
+          _0 = const ();                   // scope 0 at $DIR/inst_combine_deref.rs:53:24: 60:2
+          StorageDead(_4);                 // scope 3 at $DIR/inst_combine_deref.rs:60:1: 60:2
+          StorageDead(_3);                 // scope 2 at $DIR/inst_combine_deref.rs:60:1: 60:2
+          StorageDead(_2);                 // scope 1 at $DIR/inst_combine_deref.rs:60:1: 60:2
+          StorageDead(_1);                 // scope 0 at $DIR/inst_combine_deref.rs:60:1: 60:2
+          return;                          // scope 0 at $DIR/inst_combine_deref.rs:60:2: 60:2
+      }
+  
+      bb2: {
+          StorageLive(_11);                // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
+          begin_panic::<&str>(const "assertion failed: *y == 99"); // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
+                                           // mir::Constant
+                                           // + span: $SRC_DIR/std/src/macros.rs:LL:COL
+                                           // + literal: Const { ty: fn(&str) -> ! {std::rt::begin_panic::<&str>}, val: Value(Scalar(<ZST>)) }
+                                           // ty::Const
+                                           // + ty: &str
+                                           // + val: Value(Slice { data: Allocation { bytes: [97, 115, 115, 101, 114, 116, 105, 111, 110, 32, 102, 97, 105, 108, 101, 100, 58, 32, 42, 121, 32, 61, 61, 32, 57, 57], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [67108863], len: Size { raw: 26 } }, size: Size { raw: 26 }, align: Align { pow2: 0 }, mutability: Not, extra: () }, start: 0, end: 26 })
+                                           // mir::Constant
+                                           // + span: $DIR/inst_combine_deref.rs:1:1: 1:1
+                                           // + literal: Const { ty: &str, val: Value(Slice { data: Allocation { bytes: [97, 115, 115, 101, 114, 116, 105, 111, 110, 32, 102, 97, 105, 108, 101, 100, 58, 32, 42, 121, 32, 61, 61, 32, 57, 57], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [67108863], len: Size { raw: 26 } }, size: Size { raw: 26 }, align: Align { pow2: 0 }, mutability: Not, extra: () }, start: 0, end: 26 }) }
+      }
+  }
+  

--- a/src/test/mir-opt/inst_combine_deref.do_not_miscompile.InstCombine.diff
+++ b/src/test/mir-opt/inst_combine_deref.do_not_miscompile.InstCombine.diff
@@ -2,70 +2,70 @@
 + // MIR for `do_not_miscompile` after InstCombine
   
   fn do_not_miscompile() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/inst_combine_deref.rs:53:24: 53:24
-      let _1: i32;                         // in scope 0 at $DIR/inst_combine_deref.rs:54:9: 54:10
-      let mut _5: &i32;                    // in scope 0 at $DIR/inst_combine_deref.rs:58:10: 58:12
-      let _6: &i32;                        // in scope 0 at $DIR/inst_combine_deref.rs:58:10: 58:12
-      let _7: ();                          // in scope 0 at $DIR/inst_combine_deref.rs:59:5: 59:23
-      let mut _8: bool;                    // in scope 0 at $DIR/inst_combine_deref.rs:59:5: 59:23
-      let mut _9: bool;                    // in scope 0 at $DIR/inst_combine_deref.rs:59:13: 59:21
-      let mut _10: i32;                    // in scope 0 at $DIR/inst_combine_deref.rs:59:13: 59:15
+      let mut _0: ();                      // return place in scope 0 at $DIR/inst_combine_deref.rs:54:24: 54:24
+      let _1: i32;                         // in scope 0 at $DIR/inst_combine_deref.rs:55:9: 55:10
+      let mut _5: &i32;                    // in scope 0 at $DIR/inst_combine_deref.rs:59:10: 59:12
+      let _6: &i32;                        // in scope 0 at $DIR/inst_combine_deref.rs:59:10: 59:12
+      let _7: ();                          // in scope 0 at $DIR/inst_combine_deref.rs:60:5: 60:23
+      let mut _8: bool;                    // in scope 0 at $DIR/inst_combine_deref.rs:60:5: 60:23
+      let mut _9: bool;                    // in scope 0 at $DIR/inst_combine_deref.rs:60:13: 60:21
+      let mut _10: i32;                    // in scope 0 at $DIR/inst_combine_deref.rs:60:13: 60:15
       let mut _11: !;                      // in scope 0 at $SRC_DIR/std/src/macros.rs:LL:COL
       scope 1 {
-          debug x => _1;                   // in scope 1 at $DIR/inst_combine_deref.rs:54:9: 54:10
-          let _2: i32;                     // in scope 1 at $DIR/inst_combine_deref.rs:55:9: 55:10
+          debug x => _1;                   // in scope 1 at $DIR/inst_combine_deref.rs:55:9: 55:10
+          let _2: i32;                     // in scope 1 at $DIR/inst_combine_deref.rs:56:9: 56:10
           scope 2 {
-              debug a => _2;               // in scope 2 at $DIR/inst_combine_deref.rs:55:9: 55:10
-              let mut _3: &i32;            // in scope 2 at $DIR/inst_combine_deref.rs:56:9: 56:14
+              debug a => _2;               // in scope 2 at $DIR/inst_combine_deref.rs:56:9: 56:10
+              let mut _3: &i32;            // in scope 2 at $DIR/inst_combine_deref.rs:57:9: 57:14
               scope 3 {
-                  debug y => _3;           // in scope 3 at $DIR/inst_combine_deref.rs:56:9: 56:14
-                  let _4: &mut &i32;       // in scope 3 at $DIR/inst_combine_deref.rs:57:9: 57:10
+                  debug y => _3;           // in scope 3 at $DIR/inst_combine_deref.rs:57:9: 57:14
+                  let _4: &mut &i32;       // in scope 3 at $DIR/inst_combine_deref.rs:58:9: 58:10
                   scope 4 {
-                      debug z => _4;       // in scope 4 at $DIR/inst_combine_deref.rs:57:9: 57:10
+                      debug z => _4;       // in scope 4 at $DIR/inst_combine_deref.rs:58:9: 58:10
                   }
               }
           }
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/inst_combine_deref.rs:54:9: 54:10
-          _1 = const 42_i32;               // scope 0 at $DIR/inst_combine_deref.rs:54:13: 54:15
-          StorageLive(_2);                 // scope 1 at $DIR/inst_combine_deref.rs:55:9: 55:10
-          _2 = const 99_i32;               // scope 1 at $DIR/inst_combine_deref.rs:55:13: 55:15
-          StorageLive(_3);                 // scope 2 at $DIR/inst_combine_deref.rs:56:9: 56:14
-          _3 = &_1;                        // scope 2 at $DIR/inst_combine_deref.rs:56:17: 56:19
-          StorageLive(_4);                 // scope 3 at $DIR/inst_combine_deref.rs:57:9: 57:10
-          _4 = &mut _3;                    // scope 3 at $DIR/inst_combine_deref.rs:57:13: 57:19
-          StorageLive(_5);                 // scope 4 at $DIR/inst_combine_deref.rs:58:10: 58:12
-          StorageLive(_6);                 // scope 4 at $DIR/inst_combine_deref.rs:58:10: 58:12
-          _6 = &_2;                        // scope 4 at $DIR/inst_combine_deref.rs:58:10: 58:12
--         _5 = &(*_6);                     // scope 4 at $DIR/inst_combine_deref.rs:58:10: 58:12
-+         _5 = _6;                         // scope 4 at $DIR/inst_combine_deref.rs:58:10: 58:12
-          (*_4) = move _5;                 // scope 4 at $DIR/inst_combine_deref.rs:58:5: 58:12
-          StorageDead(_5);                 // scope 4 at $DIR/inst_combine_deref.rs:58:11: 58:12
-          StorageDead(_6);                 // scope 4 at $DIR/inst_combine_deref.rs:58:12: 58:13
-          StorageLive(_7);                 // scope 4 at $DIR/inst_combine_deref.rs:59:5: 59:23
-          StorageLive(_8);                 // scope 4 at $DIR/inst_combine_deref.rs:59:5: 59:23
-          StorageLive(_9);                 // scope 4 at $DIR/inst_combine_deref.rs:59:13: 59:21
-          StorageLive(_10);                // scope 4 at $DIR/inst_combine_deref.rs:59:13: 59:15
-          _10 = (*_3);                     // scope 4 at $DIR/inst_combine_deref.rs:59:13: 59:15
-          _9 = Eq(move _10, const 99_i32); // scope 4 at $DIR/inst_combine_deref.rs:59:13: 59:21
-          StorageDead(_10);                // scope 4 at $DIR/inst_combine_deref.rs:59:20: 59:21
-          _8 = Not(move _9);               // scope 4 at $DIR/inst_combine_deref.rs:59:5: 59:23
-          StorageDead(_9);                 // scope 4 at $DIR/inst_combine_deref.rs:59:22: 59:23
-          switchInt(_8) -> [false: bb1, otherwise: bb2]; // scope 4 at $DIR/inst_combine_deref.rs:59:5: 59:23
+          StorageLive(_1);                 // scope 0 at $DIR/inst_combine_deref.rs:55:9: 55:10
+          _1 = const 42_i32;               // scope 0 at $DIR/inst_combine_deref.rs:55:13: 55:15
+          StorageLive(_2);                 // scope 1 at $DIR/inst_combine_deref.rs:56:9: 56:10
+          _2 = const 99_i32;               // scope 1 at $DIR/inst_combine_deref.rs:56:13: 56:15
+          StorageLive(_3);                 // scope 2 at $DIR/inst_combine_deref.rs:57:9: 57:14
+          _3 = &_1;                        // scope 2 at $DIR/inst_combine_deref.rs:57:17: 57:19
+          StorageLive(_4);                 // scope 3 at $DIR/inst_combine_deref.rs:58:9: 58:10
+          _4 = &mut _3;                    // scope 3 at $DIR/inst_combine_deref.rs:58:13: 58:19
+          StorageLive(_5);                 // scope 4 at $DIR/inst_combine_deref.rs:59:10: 59:12
+          StorageLive(_6);                 // scope 4 at $DIR/inst_combine_deref.rs:59:10: 59:12
+          _6 = &_2;                        // scope 4 at $DIR/inst_combine_deref.rs:59:10: 59:12
+-         _5 = &(*_6);                     // scope 4 at $DIR/inst_combine_deref.rs:59:10: 59:12
++         _5 = _6;                         // scope 4 at $DIR/inst_combine_deref.rs:59:10: 59:12
+          (*_4) = move _5;                 // scope 4 at $DIR/inst_combine_deref.rs:59:5: 59:12
+          StorageDead(_5);                 // scope 4 at $DIR/inst_combine_deref.rs:59:11: 59:12
+          StorageDead(_6);                 // scope 4 at $DIR/inst_combine_deref.rs:59:12: 59:13
+          StorageLive(_7);                 // scope 4 at $DIR/inst_combine_deref.rs:60:5: 60:23
+          StorageLive(_8);                 // scope 4 at $DIR/inst_combine_deref.rs:60:5: 60:23
+          StorageLive(_9);                 // scope 4 at $DIR/inst_combine_deref.rs:60:13: 60:21
+          StorageLive(_10);                // scope 4 at $DIR/inst_combine_deref.rs:60:13: 60:15
+          _10 = (*_3);                     // scope 4 at $DIR/inst_combine_deref.rs:60:13: 60:15
+          _9 = Eq(move _10, const 99_i32); // scope 4 at $DIR/inst_combine_deref.rs:60:13: 60:21
+          StorageDead(_10);                // scope 4 at $DIR/inst_combine_deref.rs:60:20: 60:21
+          _8 = Not(move _9);               // scope 4 at $DIR/inst_combine_deref.rs:60:5: 60:23
+          StorageDead(_9);                 // scope 4 at $DIR/inst_combine_deref.rs:60:22: 60:23
+          switchInt(_8) -> [false: bb1, otherwise: bb2]; // scope 4 at $DIR/inst_combine_deref.rs:60:5: 60:23
       }
   
       bb1: {
-          _7 = const ();                   // scope 4 at $DIR/inst_combine_deref.rs:59:5: 59:23
-          StorageDead(_8);                 // scope 4 at $DIR/inst_combine_deref.rs:59:22: 59:23
-          StorageDead(_7);                 // scope 4 at $DIR/inst_combine_deref.rs:59:22: 59:23
-          _0 = const ();                   // scope 0 at $DIR/inst_combine_deref.rs:53:24: 60:2
-          StorageDead(_4);                 // scope 3 at $DIR/inst_combine_deref.rs:60:1: 60:2
-          StorageDead(_3);                 // scope 2 at $DIR/inst_combine_deref.rs:60:1: 60:2
-          StorageDead(_2);                 // scope 1 at $DIR/inst_combine_deref.rs:60:1: 60:2
-          StorageDead(_1);                 // scope 0 at $DIR/inst_combine_deref.rs:60:1: 60:2
-          return;                          // scope 0 at $DIR/inst_combine_deref.rs:60:2: 60:2
+          _7 = const ();                   // scope 4 at $DIR/inst_combine_deref.rs:60:5: 60:23
+          StorageDead(_8);                 // scope 4 at $DIR/inst_combine_deref.rs:60:22: 60:23
+          StorageDead(_7);                 // scope 4 at $DIR/inst_combine_deref.rs:60:22: 60:23
+          _0 = const ();                   // scope 0 at $DIR/inst_combine_deref.rs:54:24: 61:2
+          StorageDead(_4);                 // scope 3 at $DIR/inst_combine_deref.rs:61:1: 61:2
+          StorageDead(_3);                 // scope 2 at $DIR/inst_combine_deref.rs:61:1: 61:2
+          StorageDead(_2);                 // scope 1 at $DIR/inst_combine_deref.rs:61:1: 61:2
+          StorageDead(_1);                 // scope 0 at $DIR/inst_combine_deref.rs:61:1: 61:2
+          return;                          // scope 0 at $DIR/inst_combine_deref.rs:61:2: 61:2
       }
   
       bb2: {

--- a/src/test/mir-opt/inst_combine_deref.dont_opt.InstCombine.diff
+++ b/src/test/mir-opt/inst_combine_deref.dont_opt.InstCombine.diff
@@ -1,0 +1,53 @@
+- // MIR for `dont_opt` before InstCombine
++ // MIR for `dont_opt` after InstCombine
+  
+  fn dont_opt() -> u64 {
+      let mut _0: u64;                     // return place in scope 0 at $DIR/inst_combine_deref.rs:42:18: 42:21
+      let _1: i32;                         // in scope 0 at $DIR/inst_combine_deref.rs:43:9: 43:10
+      let mut _5: &i32;                    // in scope 0 at $DIR/inst_combine_deref.rs:47:10: 47:14
+      scope 1 {
+          debug y => _1;                   // in scope 1 at $DIR/inst_combine_deref.rs:43:9: 43:10
+          let _2: &i32;                    // in scope 1 at $DIR/inst_combine_deref.rs:44:9: 44:13
+          scope 2 {
+              debug _ref => _2;            // in scope 2 at $DIR/inst_combine_deref.rs:44:9: 44:13
+              let _3: i32;                 // in scope 2 at $DIR/inst_combine_deref.rs:45:9: 45:10
+              scope 3 {
+                  debug x => _3;           // in scope 3 at $DIR/inst_combine_deref.rs:45:9: 45:10
+                  let mut _4: &i32;        // in scope 3 at $DIR/inst_combine_deref.rs:46:9: 46:15
+                  scope 4 {
+                      debug _1 => _4;      // in scope 4 at $DIR/inst_combine_deref.rs:46:9: 46:15
+                      let _6: i32;         // in scope 4 at $DIR/inst_combine_deref.rs:48:9: 48:11
+                      scope 5 {
+                          debug _4 => _6;  // in scope 5 at $DIR/inst_combine_deref.rs:48:9: 48:11
+                      }
+                  }
+              }
+          }
+      }
+  
+      bb0: {
+          StorageLive(_1);                 // scope 0 at $DIR/inst_combine_deref.rs:43:9: 43:10
+          _1 = const 5_i32;                // scope 0 at $DIR/inst_combine_deref.rs:43:13: 43:14
+          StorageLive(_2);                 // scope 1 at $DIR/inst_combine_deref.rs:44:9: 44:13
+          _2 = &_1;                        // scope 1 at $DIR/inst_combine_deref.rs:44:16: 44:18
+          StorageLive(_3);                 // scope 2 at $DIR/inst_combine_deref.rs:45:9: 45:10
+          _3 = const 5_i32;                // scope 2 at $DIR/inst_combine_deref.rs:45:13: 45:14
+          StorageLive(_4);                 // scope 3 at $DIR/inst_combine_deref.rs:46:9: 46:15
+          _4 = &_3;                        // scope 3 at $DIR/inst_combine_deref.rs:46:18: 46:20
+          StorageLive(_5);                 // scope 4 at $DIR/inst_combine_deref.rs:47:10: 47:14
+-         _5 = &(*_2);                     // scope 4 at $DIR/inst_combine_deref.rs:47:10: 47:14
++         _5 = _2;                         // scope 4 at $DIR/inst_combine_deref.rs:47:10: 47:14
+          _4 = move _5;                    // scope 4 at $DIR/inst_combine_deref.rs:47:5: 47:14
+          StorageDead(_5);                 // scope 4 at $DIR/inst_combine_deref.rs:47:13: 47:14
+          StorageLive(_6);                 // scope 4 at $DIR/inst_combine_deref.rs:48:9: 48:11
+          _6 = (*_4);                      // scope 4 at $DIR/inst_combine_deref.rs:48:14: 48:17
+          _0 = const 0_u64;                // scope 5 at $DIR/inst_combine_deref.rs:49:5: 49:6
+          StorageDead(_6);                 // scope 4 at $DIR/inst_combine_deref.rs:50:1: 50:2
+          StorageDead(_4);                 // scope 3 at $DIR/inst_combine_deref.rs:50:1: 50:2
+          StorageDead(_3);                 // scope 2 at $DIR/inst_combine_deref.rs:50:1: 50:2
+          StorageDead(_2);                 // scope 1 at $DIR/inst_combine_deref.rs:50:1: 50:2
+          StorageDead(_1);                 // scope 0 at $DIR/inst_combine_deref.rs:50:1: 50:2
+          return;                          // scope 0 at $DIR/inst_combine_deref.rs:50:2: 50:2
+      }
+  }
+  

--- a/src/test/mir-opt/inst_combine_deref.dont_opt.InstCombine.diff
+++ b/src/test/mir-opt/inst_combine_deref.dont_opt.InstCombine.diff
@@ -2,23 +2,23 @@
 + // MIR for `dont_opt` after InstCombine
   
   fn dont_opt() -> u64 {
-      let mut _0: u64;                     // return place in scope 0 at $DIR/inst_combine_deref.rs:42:18: 42:21
-      let _1: i32;                         // in scope 0 at $DIR/inst_combine_deref.rs:43:9: 43:10
-      let mut _5: &i32;                    // in scope 0 at $DIR/inst_combine_deref.rs:47:10: 47:14
+      let mut _0: u64;                     // return place in scope 0 at $DIR/inst_combine_deref.rs:43:18: 43:21
+      let _1: i32;                         // in scope 0 at $DIR/inst_combine_deref.rs:44:9: 44:10
+      let mut _5: &i32;                    // in scope 0 at $DIR/inst_combine_deref.rs:48:10: 48:14
       scope 1 {
-          debug y => _1;                   // in scope 1 at $DIR/inst_combine_deref.rs:43:9: 43:10
-          let _2: &i32;                    // in scope 1 at $DIR/inst_combine_deref.rs:44:9: 44:13
+          debug y => _1;                   // in scope 1 at $DIR/inst_combine_deref.rs:44:9: 44:10
+          let _2: &i32;                    // in scope 1 at $DIR/inst_combine_deref.rs:45:9: 45:13
           scope 2 {
-              debug _ref => _2;            // in scope 2 at $DIR/inst_combine_deref.rs:44:9: 44:13
-              let _3: i32;                 // in scope 2 at $DIR/inst_combine_deref.rs:45:9: 45:10
+              debug _ref => _2;            // in scope 2 at $DIR/inst_combine_deref.rs:45:9: 45:13
+              let _3: i32;                 // in scope 2 at $DIR/inst_combine_deref.rs:46:9: 46:10
               scope 3 {
-                  debug x => _3;           // in scope 3 at $DIR/inst_combine_deref.rs:45:9: 45:10
-                  let mut _4: &i32;        // in scope 3 at $DIR/inst_combine_deref.rs:46:9: 46:15
+                  debug x => _3;           // in scope 3 at $DIR/inst_combine_deref.rs:46:9: 46:10
+                  let mut _4: &i32;        // in scope 3 at $DIR/inst_combine_deref.rs:47:9: 47:15
                   scope 4 {
-                      debug _1 => _4;      // in scope 4 at $DIR/inst_combine_deref.rs:46:9: 46:15
-                      let _6: i32;         // in scope 4 at $DIR/inst_combine_deref.rs:48:9: 48:11
+                      debug _1 => _4;      // in scope 4 at $DIR/inst_combine_deref.rs:47:9: 47:15
+                      let _6: i32;         // in scope 4 at $DIR/inst_combine_deref.rs:49:9: 49:11
                       scope 5 {
-                          debug _4 => _6;  // in scope 5 at $DIR/inst_combine_deref.rs:48:9: 48:11
+                          debug _4 => _6;  // in scope 5 at $DIR/inst_combine_deref.rs:49:9: 49:11
                       }
                   }
               }
@@ -26,28 +26,28 @@
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/inst_combine_deref.rs:43:9: 43:10
-          _1 = const 5_i32;                // scope 0 at $DIR/inst_combine_deref.rs:43:13: 43:14
-          StorageLive(_2);                 // scope 1 at $DIR/inst_combine_deref.rs:44:9: 44:13
-          _2 = &_1;                        // scope 1 at $DIR/inst_combine_deref.rs:44:16: 44:18
-          StorageLive(_3);                 // scope 2 at $DIR/inst_combine_deref.rs:45:9: 45:10
-          _3 = const 5_i32;                // scope 2 at $DIR/inst_combine_deref.rs:45:13: 45:14
-          StorageLive(_4);                 // scope 3 at $DIR/inst_combine_deref.rs:46:9: 46:15
-          _4 = &_3;                        // scope 3 at $DIR/inst_combine_deref.rs:46:18: 46:20
-          StorageLive(_5);                 // scope 4 at $DIR/inst_combine_deref.rs:47:10: 47:14
--         _5 = &(*_2);                     // scope 4 at $DIR/inst_combine_deref.rs:47:10: 47:14
-+         _5 = _2;                         // scope 4 at $DIR/inst_combine_deref.rs:47:10: 47:14
-          _4 = move _5;                    // scope 4 at $DIR/inst_combine_deref.rs:47:5: 47:14
-          StorageDead(_5);                 // scope 4 at $DIR/inst_combine_deref.rs:47:13: 47:14
-          StorageLive(_6);                 // scope 4 at $DIR/inst_combine_deref.rs:48:9: 48:11
-          _6 = (*_4);                      // scope 4 at $DIR/inst_combine_deref.rs:48:14: 48:17
-          _0 = const 0_u64;                // scope 5 at $DIR/inst_combine_deref.rs:49:5: 49:6
-          StorageDead(_6);                 // scope 4 at $DIR/inst_combine_deref.rs:50:1: 50:2
-          StorageDead(_4);                 // scope 3 at $DIR/inst_combine_deref.rs:50:1: 50:2
-          StorageDead(_3);                 // scope 2 at $DIR/inst_combine_deref.rs:50:1: 50:2
-          StorageDead(_2);                 // scope 1 at $DIR/inst_combine_deref.rs:50:1: 50:2
-          StorageDead(_1);                 // scope 0 at $DIR/inst_combine_deref.rs:50:1: 50:2
-          return;                          // scope 0 at $DIR/inst_combine_deref.rs:50:2: 50:2
+          StorageLive(_1);                 // scope 0 at $DIR/inst_combine_deref.rs:44:9: 44:10
+          _1 = const 5_i32;                // scope 0 at $DIR/inst_combine_deref.rs:44:13: 44:14
+          StorageLive(_2);                 // scope 1 at $DIR/inst_combine_deref.rs:45:9: 45:13
+          _2 = &_1;                        // scope 1 at $DIR/inst_combine_deref.rs:45:16: 45:18
+          StorageLive(_3);                 // scope 2 at $DIR/inst_combine_deref.rs:46:9: 46:10
+          _3 = const 5_i32;                // scope 2 at $DIR/inst_combine_deref.rs:46:13: 46:14
+          StorageLive(_4);                 // scope 3 at $DIR/inst_combine_deref.rs:47:9: 47:15
+          _4 = &_3;                        // scope 3 at $DIR/inst_combine_deref.rs:47:18: 47:20
+          StorageLive(_5);                 // scope 4 at $DIR/inst_combine_deref.rs:48:10: 48:14
+-         _5 = &(*_2);                     // scope 4 at $DIR/inst_combine_deref.rs:48:10: 48:14
++         _5 = _2;                         // scope 4 at $DIR/inst_combine_deref.rs:48:10: 48:14
+          _4 = move _5;                    // scope 4 at $DIR/inst_combine_deref.rs:48:5: 48:14
+          StorageDead(_5);                 // scope 4 at $DIR/inst_combine_deref.rs:48:13: 48:14
+          StorageLive(_6);                 // scope 4 at $DIR/inst_combine_deref.rs:49:9: 49:11
+          _6 = (*_4);                      // scope 4 at $DIR/inst_combine_deref.rs:49:14: 49:17
+          _0 = const 0_u64;                // scope 5 at $DIR/inst_combine_deref.rs:50:5: 50:6
+          StorageDead(_6);                 // scope 4 at $DIR/inst_combine_deref.rs:51:1: 51:2
+          StorageDead(_4);                 // scope 3 at $DIR/inst_combine_deref.rs:51:1: 51:2
+          StorageDead(_3);                 // scope 2 at $DIR/inst_combine_deref.rs:51:1: 51:2
+          StorageDead(_2);                 // scope 1 at $DIR/inst_combine_deref.rs:51:1: 51:2
+          StorageDead(_1);                 // scope 0 at $DIR/inst_combine_deref.rs:51:1: 51:2
+          return;                          // scope 0 at $DIR/inst_combine_deref.rs:51:2: 51:2
       }
   }
   

--- a/src/test/mir-opt/inst_combine_deref.opt_struct.InstCombine.diff
+++ b/src/test/mir-opt/inst_combine_deref.opt_struct.InstCombine.diff
@@ -1,0 +1,44 @@
+- // MIR for `opt_struct` before InstCombine
++ // MIR for `opt_struct` after InstCombine
+  
+  fn opt_struct(_1: S) -> u64 {
+      debug s => _1;                       // in scope 0 at $DIR/inst_combine_deref.rs:29:15: 29:16
+      let mut _0: u64;                     // return place in scope 0 at $DIR/inst_combine_deref.rs:29:24: 29:27
+      let _2: &u64;                        // in scope 0 at $DIR/inst_combine_deref.rs:30:9: 30:10
+      let mut _5: u64;                     // in scope 0 at $DIR/inst_combine_deref.rs:33:5: 33:7
+      let mut _6: u64;                     // in scope 0 at $DIR/inst_combine_deref.rs:33:10: 33:11
+      scope 1 {
+          debug a => _2;                   // in scope 1 at $DIR/inst_combine_deref.rs:30:9: 30:10
+          let _3: &u64;                    // in scope 1 at $DIR/inst_combine_deref.rs:31:9: 31:10
+          scope 2 {
+              debug b => _3;               // in scope 2 at $DIR/inst_combine_deref.rs:31:9: 31:10
+              let _4: u64;                 // in scope 2 at $DIR/inst_combine_deref.rs:32:9: 32:10
+              scope 3 {
+                  debug x => _4;           // in scope 3 at $DIR/inst_combine_deref.rs:32:9: 32:10
+              }
+          }
+      }
+  
+      bb0: {
+          StorageLive(_2);                 // scope 0 at $DIR/inst_combine_deref.rs:30:9: 30:10
+          _2 = &(_1.0: u64);               // scope 0 at $DIR/inst_combine_deref.rs:30:13: 30:17
+          StorageLive(_3);                 // scope 1 at $DIR/inst_combine_deref.rs:31:9: 31:10
+          _3 = &(_1.1: u64);               // scope 1 at $DIR/inst_combine_deref.rs:31:13: 31:17
+          StorageLive(_4);                 // scope 2 at $DIR/inst_combine_deref.rs:32:9: 32:10
+-         _4 = (*_2);                      // scope 2 at $DIR/inst_combine_deref.rs:32:13: 32:15
++         _4 = (_1.0: u64);                // scope 2 at $DIR/inst_combine_deref.rs:32:13: 32:15
+          StorageLive(_5);                 // scope 3 at $DIR/inst_combine_deref.rs:33:5: 33:7
+-         _5 = (*_3);                      // scope 3 at $DIR/inst_combine_deref.rs:33:5: 33:7
++         _5 = (_1.1: u64);                // scope 3 at $DIR/inst_combine_deref.rs:33:5: 33:7
+          StorageLive(_6);                 // scope 3 at $DIR/inst_combine_deref.rs:33:10: 33:11
+          _6 = _4;                         // scope 3 at $DIR/inst_combine_deref.rs:33:10: 33:11
+          _0 = Add(move _5, move _6);      // scope 3 at $DIR/inst_combine_deref.rs:33:5: 33:11
+          StorageDead(_6);                 // scope 3 at $DIR/inst_combine_deref.rs:33:10: 33:11
+          StorageDead(_5);                 // scope 3 at $DIR/inst_combine_deref.rs:33:10: 33:11
+          StorageDead(_4);                 // scope 2 at $DIR/inst_combine_deref.rs:34:1: 34:2
+          StorageDead(_3);                 // scope 1 at $DIR/inst_combine_deref.rs:34:1: 34:2
+          StorageDead(_2);                 // scope 0 at $DIR/inst_combine_deref.rs:34:1: 34:2
+          return;                          // scope 0 at $DIR/inst_combine_deref.rs:34:2: 34:2
+      }
+  }
+  

--- a/src/test/mir-opt/inst_combine_deref.opt_struct.InstCombine.diff
+++ b/src/test/mir-opt/inst_combine_deref.opt_struct.InstCombine.diff
@@ -2,43 +2,43 @@
 + // MIR for `opt_struct` after InstCombine
   
   fn opt_struct(_1: S) -> u64 {
-      debug s => _1;                       // in scope 0 at $DIR/inst_combine_deref.rs:29:15: 29:16
-      let mut _0: u64;                     // return place in scope 0 at $DIR/inst_combine_deref.rs:29:24: 29:27
-      let _2: &u64;                        // in scope 0 at $DIR/inst_combine_deref.rs:30:9: 30:10
-      let mut _5: u64;                     // in scope 0 at $DIR/inst_combine_deref.rs:33:5: 33:7
-      let mut _6: u64;                     // in scope 0 at $DIR/inst_combine_deref.rs:33:10: 33:11
+      debug s => _1;                       // in scope 0 at $DIR/inst_combine_deref.rs:30:15: 30:16
+      let mut _0: u64;                     // return place in scope 0 at $DIR/inst_combine_deref.rs:30:24: 30:27
+      let _2: &u64;                        // in scope 0 at $DIR/inst_combine_deref.rs:31:9: 31:10
+      let mut _5: u64;                     // in scope 0 at $DIR/inst_combine_deref.rs:34:5: 34:7
+      let mut _6: u64;                     // in scope 0 at $DIR/inst_combine_deref.rs:34:10: 34:11
       scope 1 {
-          debug a => _2;                   // in scope 1 at $DIR/inst_combine_deref.rs:30:9: 30:10
-          let _3: &u64;                    // in scope 1 at $DIR/inst_combine_deref.rs:31:9: 31:10
+          debug a => _2;                   // in scope 1 at $DIR/inst_combine_deref.rs:31:9: 31:10
+          let _3: &u64;                    // in scope 1 at $DIR/inst_combine_deref.rs:32:9: 32:10
           scope 2 {
-              debug b => _3;               // in scope 2 at $DIR/inst_combine_deref.rs:31:9: 31:10
-              let _4: u64;                 // in scope 2 at $DIR/inst_combine_deref.rs:32:9: 32:10
+              debug b => _3;               // in scope 2 at $DIR/inst_combine_deref.rs:32:9: 32:10
+              let _4: u64;                 // in scope 2 at $DIR/inst_combine_deref.rs:33:9: 33:10
               scope 3 {
-                  debug x => _4;           // in scope 3 at $DIR/inst_combine_deref.rs:32:9: 32:10
+                  debug x => _4;           // in scope 3 at $DIR/inst_combine_deref.rs:33:9: 33:10
               }
           }
       }
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/inst_combine_deref.rs:30:9: 30:10
-          _2 = &(_1.0: u64);               // scope 0 at $DIR/inst_combine_deref.rs:30:13: 30:17
-          StorageLive(_3);                 // scope 1 at $DIR/inst_combine_deref.rs:31:9: 31:10
-          _3 = &(_1.1: u64);               // scope 1 at $DIR/inst_combine_deref.rs:31:13: 31:17
-          StorageLive(_4);                 // scope 2 at $DIR/inst_combine_deref.rs:32:9: 32:10
--         _4 = (*_2);                      // scope 2 at $DIR/inst_combine_deref.rs:32:13: 32:15
-+         _4 = (_1.0: u64);                // scope 2 at $DIR/inst_combine_deref.rs:32:13: 32:15
-          StorageLive(_5);                 // scope 3 at $DIR/inst_combine_deref.rs:33:5: 33:7
--         _5 = (*_3);                      // scope 3 at $DIR/inst_combine_deref.rs:33:5: 33:7
-+         _5 = (_1.1: u64);                // scope 3 at $DIR/inst_combine_deref.rs:33:5: 33:7
-          StorageLive(_6);                 // scope 3 at $DIR/inst_combine_deref.rs:33:10: 33:11
-          _6 = _4;                         // scope 3 at $DIR/inst_combine_deref.rs:33:10: 33:11
-          _0 = Add(move _5, move _6);      // scope 3 at $DIR/inst_combine_deref.rs:33:5: 33:11
-          StorageDead(_6);                 // scope 3 at $DIR/inst_combine_deref.rs:33:10: 33:11
-          StorageDead(_5);                 // scope 3 at $DIR/inst_combine_deref.rs:33:10: 33:11
-          StorageDead(_4);                 // scope 2 at $DIR/inst_combine_deref.rs:34:1: 34:2
-          StorageDead(_3);                 // scope 1 at $DIR/inst_combine_deref.rs:34:1: 34:2
-          StorageDead(_2);                 // scope 0 at $DIR/inst_combine_deref.rs:34:1: 34:2
-          return;                          // scope 0 at $DIR/inst_combine_deref.rs:34:2: 34:2
+          StorageLive(_2);                 // scope 0 at $DIR/inst_combine_deref.rs:31:9: 31:10
+          _2 = &(_1.0: u64);               // scope 0 at $DIR/inst_combine_deref.rs:31:13: 31:17
+          StorageLive(_3);                 // scope 1 at $DIR/inst_combine_deref.rs:32:9: 32:10
+          _3 = &(_1.1: u64);               // scope 1 at $DIR/inst_combine_deref.rs:32:13: 32:17
+          StorageLive(_4);                 // scope 2 at $DIR/inst_combine_deref.rs:33:9: 33:10
+-         _4 = (*_2);                      // scope 2 at $DIR/inst_combine_deref.rs:33:13: 33:15
++         _4 = (_1.0: u64);                // scope 2 at $DIR/inst_combine_deref.rs:33:13: 33:15
+          StorageLive(_5);                 // scope 3 at $DIR/inst_combine_deref.rs:34:5: 34:7
+-         _5 = (*_3);                      // scope 3 at $DIR/inst_combine_deref.rs:34:5: 34:7
++         _5 = (_1.1: u64);                // scope 3 at $DIR/inst_combine_deref.rs:34:5: 34:7
+          StorageLive(_6);                 // scope 3 at $DIR/inst_combine_deref.rs:34:10: 34:11
+          _6 = _4;                         // scope 3 at $DIR/inst_combine_deref.rs:34:10: 34:11
+          _0 = Add(move _5, move _6);      // scope 3 at $DIR/inst_combine_deref.rs:34:5: 34:11
+          StorageDead(_6);                 // scope 3 at $DIR/inst_combine_deref.rs:34:10: 34:11
+          StorageDead(_5);                 // scope 3 at $DIR/inst_combine_deref.rs:34:10: 34:11
+          StorageDead(_4);                 // scope 2 at $DIR/inst_combine_deref.rs:35:1: 35:2
+          StorageDead(_3);                 // scope 1 at $DIR/inst_combine_deref.rs:35:1: 35:2
+          StorageDead(_2);                 // scope 0 at $DIR/inst_combine_deref.rs:35:1: 35:2
+          return;                          // scope 0 at $DIR/inst_combine_deref.rs:35:2: 35:2
       }
   }
   

--- a/src/test/mir-opt/inst_combine_deref.rs
+++ b/src/test/mir-opt/inst_combine_deref.rs
@@ -1,0 +1,68 @@
+// EMIT_MIR inst_combine_deref.simple_opt.InstCombine.diff
+fn simple_opt() -> u64 {
+    let x = 5;
+    let y = &x;
+    let z = *y;
+    z
+}
+
+// EMIT_MIR inst_combine_deref.deep_opt.InstCombine.diff
+fn deep_opt() -> (u64, u64, u64) {
+    let x1 = 1;
+    let x2 = 2;
+    let x3 = 3;
+    let y1 = &x1;
+    let y2 = &x2;
+    let y3 = &x3;
+    let z1 = *y1;
+    let z2 = *y2;
+    let z3 = *y3;
+    (z1, z2, z3)
+}
+
+struct S {
+    a: u64,
+    b: u64,
+}
+
+// EMIT_MIR inst_combine_deref.opt_struct.InstCombine.diff
+fn opt_struct(s: S) -> u64 {
+    let a = &s.a;
+    let b = &s.b;
+    let x = *a;
+    *b + x
+}
+
+// EMIT_MIR inst_combine_deref.dont_opt.InstCombine.diff
+// do not optimize a sequence looking like this:
+// _1 = &_2;
+// _1 = _3;
+// _4 = *_1;
+// as the _1 = _3 assignment makes it not legal to replace the last statement with _4 = _2
+fn dont_opt() -> u64 {
+    let y = 5;
+    let _ref = &y;
+    let x = 5;
+    let mut _1 = &x;
+    _1 = _ref;
+    let _4 = *_1;
+    0
+}
+
+// EMIT_MIR inst_combine_deref.do_not_miscompile.InstCombine.diff
+fn do_not_miscompile() {
+    let x = 42;
+    let a = 99;
+    let mut y = &x;
+    let z = &mut y;
+    *z = &a;
+    assert!(*y == 99);
+}
+
+fn main() {
+    simple_opt();
+    deep_opt();
+    opt_struct(S { a: 0, b: 1 });
+    dont_opt();
+    do_not_miscompile();
+}

--- a/src/test/mir-opt/inst_combine_deref.rs
+++ b/src/test/mir-opt/inst_combine_deref.rs
@@ -1,3 +1,4 @@
+// compile-flags: -O
 // EMIT_MIR inst_combine_deref.simple_opt.InstCombine.diff
 fn simple_opt() -> u64 {
     let x = 5;

--- a/src/test/mir-opt/inst_combine_deref.simple_opt.InstCombine.diff
+++ b/src/test/mir-opt/inst_combine_deref.simple_opt.InstCombine.diff
@@ -1,0 +1,34 @@
+- // MIR for `simple_opt` before InstCombine
++ // MIR for `simple_opt` after InstCombine
+  
+  fn simple_opt() -> u64 {
+      let mut _0: u64;                     // return place in scope 0 at $DIR/inst_combine_deref.rs:2:20: 2:23
+      let _1: u64;                         // in scope 0 at $DIR/inst_combine_deref.rs:3:9: 3:10
+      scope 1 {
+          debug x => _1;                   // in scope 1 at $DIR/inst_combine_deref.rs:3:9: 3:10
+          let _2: &u64;                    // in scope 1 at $DIR/inst_combine_deref.rs:4:9: 4:10
+          scope 2 {
+              debug y => _2;               // in scope 2 at $DIR/inst_combine_deref.rs:4:9: 4:10
+              let _3: u64;                 // in scope 2 at $DIR/inst_combine_deref.rs:5:9: 5:10
+              scope 3 {
+                  debug z => _3;           // in scope 3 at $DIR/inst_combine_deref.rs:5:9: 5:10
+              }
+          }
+      }
+  
+      bb0: {
+          StorageLive(_1);                 // scope 0 at $DIR/inst_combine_deref.rs:3:9: 3:10
+          _1 = const 5_u64;                // scope 0 at $DIR/inst_combine_deref.rs:3:13: 3:14
+          StorageLive(_2);                 // scope 1 at $DIR/inst_combine_deref.rs:4:9: 4:10
+          _2 = &_1;                        // scope 1 at $DIR/inst_combine_deref.rs:4:13: 4:15
+          StorageLive(_3);                 // scope 2 at $DIR/inst_combine_deref.rs:5:9: 5:10
+-         _3 = (*_2);                      // scope 2 at $DIR/inst_combine_deref.rs:5:13: 5:15
++         _3 = _1;                         // scope 2 at $DIR/inst_combine_deref.rs:5:13: 5:15
+          _0 = _3;                         // scope 3 at $DIR/inst_combine_deref.rs:6:5: 6:6
+          StorageDead(_3);                 // scope 2 at $DIR/inst_combine_deref.rs:7:1: 7:2
+          StorageDead(_2);                 // scope 1 at $DIR/inst_combine_deref.rs:7:1: 7:2
+          StorageDead(_1);                 // scope 0 at $DIR/inst_combine_deref.rs:7:1: 7:2
+          return;                          // scope 0 at $DIR/inst_combine_deref.rs:7:2: 7:2
+      }
+  }
+  

--- a/src/test/mir-opt/inst_combine_deref.simple_opt.InstCombine.diff
+++ b/src/test/mir-opt/inst_combine_deref.simple_opt.InstCombine.diff
@@ -2,33 +2,33 @@
 + // MIR for `simple_opt` after InstCombine
   
   fn simple_opt() -> u64 {
-      let mut _0: u64;                     // return place in scope 0 at $DIR/inst_combine_deref.rs:2:20: 2:23
-      let _1: u64;                         // in scope 0 at $DIR/inst_combine_deref.rs:3:9: 3:10
+      let mut _0: u64;                     // return place in scope 0 at $DIR/inst_combine_deref.rs:3:20: 3:23
+      let _1: u64;                         // in scope 0 at $DIR/inst_combine_deref.rs:4:9: 4:10
       scope 1 {
-          debug x => _1;                   // in scope 1 at $DIR/inst_combine_deref.rs:3:9: 3:10
-          let _2: &u64;                    // in scope 1 at $DIR/inst_combine_deref.rs:4:9: 4:10
+          debug x => _1;                   // in scope 1 at $DIR/inst_combine_deref.rs:4:9: 4:10
+          let _2: &u64;                    // in scope 1 at $DIR/inst_combine_deref.rs:5:9: 5:10
           scope 2 {
-              debug y => _2;               // in scope 2 at $DIR/inst_combine_deref.rs:4:9: 4:10
-              let _3: u64;                 // in scope 2 at $DIR/inst_combine_deref.rs:5:9: 5:10
+              debug y => _2;               // in scope 2 at $DIR/inst_combine_deref.rs:5:9: 5:10
+              let _3: u64;                 // in scope 2 at $DIR/inst_combine_deref.rs:6:9: 6:10
               scope 3 {
-                  debug z => _3;           // in scope 3 at $DIR/inst_combine_deref.rs:5:9: 5:10
+                  debug z => _3;           // in scope 3 at $DIR/inst_combine_deref.rs:6:9: 6:10
               }
           }
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/inst_combine_deref.rs:3:9: 3:10
-          _1 = const 5_u64;                // scope 0 at $DIR/inst_combine_deref.rs:3:13: 3:14
-          StorageLive(_2);                 // scope 1 at $DIR/inst_combine_deref.rs:4:9: 4:10
-          _2 = &_1;                        // scope 1 at $DIR/inst_combine_deref.rs:4:13: 4:15
-          StorageLive(_3);                 // scope 2 at $DIR/inst_combine_deref.rs:5:9: 5:10
--         _3 = (*_2);                      // scope 2 at $DIR/inst_combine_deref.rs:5:13: 5:15
-+         _3 = _1;                         // scope 2 at $DIR/inst_combine_deref.rs:5:13: 5:15
-          _0 = _3;                         // scope 3 at $DIR/inst_combine_deref.rs:6:5: 6:6
-          StorageDead(_3);                 // scope 2 at $DIR/inst_combine_deref.rs:7:1: 7:2
-          StorageDead(_2);                 // scope 1 at $DIR/inst_combine_deref.rs:7:1: 7:2
-          StorageDead(_1);                 // scope 0 at $DIR/inst_combine_deref.rs:7:1: 7:2
-          return;                          // scope 0 at $DIR/inst_combine_deref.rs:7:2: 7:2
+          StorageLive(_1);                 // scope 0 at $DIR/inst_combine_deref.rs:4:9: 4:10
+          _1 = const 5_u64;                // scope 0 at $DIR/inst_combine_deref.rs:4:13: 4:14
+          StorageLive(_2);                 // scope 1 at $DIR/inst_combine_deref.rs:5:9: 5:10
+          _2 = &_1;                        // scope 1 at $DIR/inst_combine_deref.rs:5:13: 5:15
+          StorageLive(_3);                 // scope 2 at $DIR/inst_combine_deref.rs:6:9: 6:10
+-         _3 = (*_2);                      // scope 2 at $DIR/inst_combine_deref.rs:6:13: 6:15
++         _3 = _1;                         // scope 2 at $DIR/inst_combine_deref.rs:6:13: 6:15
+          _0 = _3;                         // scope 3 at $DIR/inst_combine_deref.rs:7:5: 7:6
+          StorageDead(_3);                 // scope 2 at $DIR/inst_combine_deref.rs:8:1: 8:2
+          StorageDead(_2);                 // scope 1 at $DIR/inst_combine_deref.rs:8:1: 8:2
+          StorageDead(_1);                 // scope 0 at $DIR/inst_combine_deref.rs:8:1: 8:2
+          return;                          // scope 0 at $DIR/inst_combine_deref.rs:8:2: 8:2
       }
   }
   


### PR DESCRIPTION
Look for the sequence
```rust
_2 = &_1;
...
_5 = (*_2)
```

in which we can replace the last statement with `_5 = _1` to avoid the load of _2