### PR TITLE
Enable link-shared for LLVM on non-Windows targets

### DIFF
--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -129,6 +129,10 @@ impl Step for Llvm {
                 Err(m) => m,
             };
 
+        if builder.config.llvm_link_shared && target.contains("windows") {
+            panic!("shared linking to LLVM is not currently supported on Windows");
+        }
+
         builder.info(&format!("Building LLVM for {}", target));
         t!(stamp.remove());
         let _time = util::timeit(&builder);

--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -75,6 +75,13 @@ if [ "$DEPLOY$DEPLOY_ALT" = "1" ]; then
   RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --set rust.remap-debuginfo"
   RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --debuginfo-level-std=1"
 
+  # If we're distributing binaries, we want a shared LLVM link. We're already
+  # going to link LLVM to the LLVM tools dynamically, so we need to ship a
+  # libLLVM library anyway.
+  if !isWindows; then
+    RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --set llvm.link-shared=true"
+  fi
+
   if [ "$NO_LLVM_ASSERTIONS" = "1" ]; then
     RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --disable-llvm-assertions"
   elif [ "$DEPLOY_ALT" != "" ]; then


### PR DESCRIPTION
Even when LLVM is not generally participating in a shared link with rustc, we
will likely still link to the shared dylib from rust-lld, so we still need to
promote it.

Hopefully fixes #76698.