### PR TITLE
Don't warn for `missing_doc_examples` when item is #[doc(hidden)]

### DIFF
--- a/src/librustdoc/passes/doc_test_lints.rs
+++ b/src/librustdoc/passes/doc_test_lints.rs
@@ -73,7 +73,7 @@ crate fn should_have_doc_example(cx: &DocContext<'_>, item: &clean::Item) -> boo
     }
     let hir_id = cx.tcx.hir().local_def_id_to_hir_id(item.def_id.expect_local());
     if cx.tcx.hir().attrs(hir_id).lists(sym::doc).has_word(sym::hidden)
-        || inherits_doc_hidden(cx, hir_id)
+        || inherits_doc_hidden(cx.tcx, hir_id)
     {
         return false;
     }

--- a/src/librustdoc/passes/doc_test_lints.rs
+++ b/src/librustdoc/passes/doc_test_lints.rs
@@ -9,8 +9,10 @@ use crate::clean::*;
 use crate::core::DocContext;
 use crate::fold::DocFolder;
 use crate::html::markdown::{find_testable_code, ErrorCodes, Ignore, LangString};
+use crate::visit_ast::inherits_doc_hidden;
 use rustc_middle::lint::LintLevelSource;
 use rustc_session::lint;
+use rustc_span::symbol::sym;
 
 crate const CHECK_PRIVATE_ITEMS_DOC_TESTS: Pass = Pass {
     name: "check-private-items-doc-tests",
@@ -68,6 +70,11 @@ crate fn should_have_doc_example(cx: &DocContext<'_>, item: &clean::Item) -> boo
         return false;
     }
     let hir_id = cx.tcx.hir().local_def_id_to_hir_id(item.def_id.expect_local());
+    if cx.tcx.hir().attrs(hir_id).lists(sym::doc).has_word(sym::hidden)
+        || inherits_doc_hidden(cx, hir_id)
+    {
+        return false;
+    }
     let (level, source) = cx.tcx.lint_level_at_node(crate::lint::MISSING_DOC_CODE_EXAMPLES, hir_id);
     level != lint::Level::Allow || matches!(source, LintLevelSource::Default)
 }
@@ -86,7 +93,9 @@ crate fn look_for_tests<'tcx>(cx: &DocContext<'tcx>, dox: &str, item: &Item) {
     find_testable_code(&dox, &mut tests, ErrorCodes::No, false, None);
 
     if tests.found_tests == 0 && cx.tcx.sess.is_nightly_build() {
-        if should_have_doc_example(cx, &item) {
+        if cx.renderinfo.borrow().access_levels.is_public(item.def_id)
+            && should_have_doc_example(cx, &item)
+        {
             debug!("reporting error for {:?} (hir_id={:?})", item, hir_id);
             let sp = span_of_attrs(&item.attrs).unwrap_or(item.source.span());
             cx.tcx.struct_span_lint_hir(

--- a/src/librustdoc/passes/doc_test_lints.rs
+++ b/src/librustdoc/passes/doc_test_lints.rs
@@ -53,7 +53,7 @@ impl crate::doctest::Tester for Tests {
 }
 
 crate fn should_have_doc_example(cx: &DocContext<'_>, item: &clean::Item) -> bool {
-    if !cx.renderinfo.access_levels.is_public(item.def_id)
+    if !cx.cache.access_levels.is_public(item.def_id)
         || matches!(
             *item.kind,
             clean::StructFieldItem(_)

--- a/src/librustdoc/passes/doc_test_lints.rs
+++ b/src/librustdoc/passes/doc_test_lints.rs
@@ -53,7 +53,7 @@ impl crate::doctest::Tester for Tests {
 }
 
 crate fn should_have_doc_example(cx: &DocContext<'_>, item: &clean::Item) -> bool {
-    if !cx.renderinfo.borrow().access_levels.is_public(item.def_id)
+    if !cx.renderinfo.access_levels.is_public(item.def_id)
         || matches!(
             *item.kind,
             clean::StructFieldItem(_)

--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -35,9 +35,6 @@ crate fn inherits_doc_hidden(cx: &core::DocContext<'_>, mut node: hir::HirId) ->
         if cx.tcx.hir().attrs(node).lists(sym::doc).has_word(sym::hidden) {
             return true;
         }
-        if node == hir::CRATE_HIR_ID {
-            break;
-        }
     }
     false
 }

--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -29,10 +29,10 @@ fn def_id_to_path(tcx: TyCtxt<'_>, did: DefId) -> Vec<String> {
     std::iter::once(crate_name).chain(relative).collect()
 }
 
-crate fn inherits_doc_hidden(cx: &core::DocContext<'_>, mut node: hir::HirId) -> bool {
-    while let Some(id) = cx.tcx.hir().get_enclosing_scope(node) {
+crate fn inherits_doc_hidden(tcx: TyCtxt<'_>, mut node: hir::HirId) -> bool {
+    while let Some(id) = tcx.hir().get_enclosing_scope(node) {
         node = id;
-        if cx.tcx.hir().attrs(node).lists(sym::doc).has_word(sym::hidden) {
+        if tcx.hir().attrs(node).lists(sym::doc).has_word(sym::hidden) {
             return true;
         }
     }
@@ -209,7 +209,7 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
         };
 
         let is_private = !self.cx.cache.access_levels.is_public(res_did);
-        let is_hidden = inherits_doc_hidden(self.cx, res_hir_id);
+        let is_hidden = inherits_doc_hidden(self.cx.tcx, res_hir_id);
 
         // Only inline if requested or if the item would otherwise be stripped.
         if (!please_inline && !is_private && !is_hidden) || is_no_inline {

--- a/src/test/rustdoc-ui/lint-missing-doc-code-example.rs
+++ b/src/test/rustdoc-ui/lint-missing-doc-code-example.rs
@@ -12,16 +12,16 @@
 /// ```
 /// println!("hello");
 /// ```
-fn test() {
+pub fn test() {
 }
 
 #[allow(missing_docs)]
-mod module1 { //~ ERROR
+pub mod module1 { //~ ERROR
 }
 
 #[allow(rustdoc::missing_doc_code_examples)]
 /// doc
-mod module2 {
+pub mod module2 {
 
   /// doc
   pub fn test() {}
@@ -63,9 +63,22 @@ pub enum Enum {
 /// Doc
 //~^ ERROR
 #[repr(C)]
-union Union {
+pub union Union {
     /// Doc, but no code example and it's fine!
     a: i32,
     /// Doc, but no code example and it's fine!
     b: f32,
+}
+
+
+#[doc(hidden)]
+pub mod foo {
+    pub fn bar() {}
+}
+
+fn babar() {}
+
+
+mod fofoo {
+    pub fn tadam() {}
 }

--- a/src/test/rustdoc-ui/lint-missing-doc-code-example.stderr
+++ b/src/test/rustdoc-ui/lint-missing-doc-code-example.stderr
@@ -1,7 +1,7 @@
 error: missing code example in this documentation
   --> $DIR/lint-missing-doc-code-example.rs:19:1
    |
-LL | / mod module1 {
+LL | / pub mod module1 {
 LL | | }
    | |_^
    |


### PR DESCRIPTION
r? @jyn514 