### PR TITLE
Change error message for ty param in const

### DIFF
--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -466,7 +466,7 @@ impl<'a> Resolver<'a> {
                 );
                 err
             }
-            ResolutionError::ParamInNonTrivialAnonConst(name) => {
+            ResolutionError::ParamInNonTrivialAnonConst { name, is_type } => {
                 let mut err = self.session.struct_span_err(
                     span,
                     "generic parameters must not be used inside of non trivial constant values",
@@ -478,9 +478,19 @@ impl<'a> Resolver<'a> {
                         name
                     ),
                 );
-                err.help(
-                    &format!("it is currently only allowed to use either `{0}` or `{{ {0} }}` as generic constants", name)
-                );
+
+                if is_type {
+                    err.note(&format!(
+                        "type parameters are currently not permitted in anonymous constants"
+                    ));
+                } else {
+                    err.help(
+                        &format!("it is currently only allowed to use either `{0}` or `{{ {0} }}` as generic constants",
+                                 name
+                        )
+                    );
+                }
+
                 err
             }
             ResolutionError::SelfInTyParamDefault => {

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -480,9 +480,7 @@ impl<'a> Resolver<'a> {
                 );
 
                 if is_type {
-                    err.note(&format!(
-                        "type parameters are currently not permitted in anonymous constants"
-                    ));
+                    err.note("type parameters are currently not permitted in anonymous constants");
                 } else {
                     err.help(
                         &format!("it is currently only allowed to use either `{0}` or `{{ {0} }}` as generic constants",

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -221,7 +221,7 @@ enum ResolutionError<'a> {
     /// generic parameters must not be used inside of non trivial constant values.
     ///
     /// This error is only emitted when using `min_const_generics`.
-    ParamInNonTrivialAnonConst(Symbol),
+    ParamInNonTrivialAnonConst { name: Symbol, is_type: bool },
     /// Error E0735: type parameters with a default cannot use `Self`
     SelfInTyParamDefault,
     /// Error E0767: use of unreachable label
@@ -2638,9 +2638,10 @@ impl<'a> Resolver<'a> {
                                     if record_used {
                                         self.report_error(
                                             span,
-                                            ResolutionError::ParamInNonTrivialAnonConst(
-                                                rib_ident.name,
-                                            ),
+                                            ResolutionError::ParamInNonTrivialAnonConst {
+                                                name: rib_ident.name,
+                                                is_type: true,
+                                            },
                                         );
                                     }
                                     return Res::Err;
@@ -2718,7 +2719,10 @@ impl<'a> Resolver<'a> {
                                 if record_used {
                                     self.report_error(
                                         span,
-                                        ResolutionError::ParamInNonTrivialAnonConst(rib_ident.name),
+                                        ResolutionError::ParamInNonTrivialAnonConst {
+                                            name: rib_ident.name,
+                                            is_type: false,
+                                        },
                                     );
                                 }
                                 return Res::Err;

--- a/src/test/ui/const-generics/issues/issue-64494.min.stderr
+++ b/src/test/ui/const-generics/issues/issue-64494.min.stderr
@@ -4,7 +4,7 @@ error: generic parameters must not be used inside of non trivial constant values
 LL | impl<T: Foo> MyTrait for T where Is<{T::VAL == 5}>: True {}
    |                                      ^^^^^^ non-trivial anonymous constants must not depend on the parameter `T`
    |
-   = help: it is currently only allowed to use either `T` or `{ T }` as generic constants
+   = note: type parameters are currently not permitted in anonymous constants
 
 error: generic parameters must not be used inside of non trivial constant values
   --> $DIR/issue-64494.rs:19:38
@@ -12,7 +12,7 @@ error: generic parameters must not be used inside of non trivial constant values
 LL | impl<T: Foo> MyTrait for T where Is<{T::VAL == 6}>: True {}
    |                                      ^^^^^^ non-trivial anonymous constants must not depend on the parameter `T`
    |
-   = help: it is currently only allowed to use either `T` or `{ T }` as generic constants
+   = note: type parameters are currently not permitted in anonymous constants
 
 error[E0119]: conflicting implementations of trait `MyTrait`:
   --> $DIR/issue-64494.rs:19:1

--- a/src/test/ui/const-generics/issues/issue-67739.min.stderr
+++ b/src/test/ui/const-generics/issues/issue-67739.min.stderr
@@ -4,7 +4,7 @@ error: generic parameters must not be used inside of non trivial constant values
 LL |         [0u8; mem::size_of::<Self::Associated>()];
    |                              ^^^^^^^^^^^^^^^^ non-trivial anonymous constants must not depend on the parameter `Self`
    |
-   = help: it is currently only allowed to use either `Self` or `{ Self }` as generic constants
+   = note: type parameters are currently not permitted in anonymous constants
 
 error: aborting due to previous error
 

--- a/src/test/ui/const-generics/issues/issue-76701-ty-param-in-const.full.stderr
+++ b/src/test/ui/const-generics/issues/issue-76701-ty-param-in-const.full.stderr
@@ -1,0 +1,18 @@
+error: constant expression depends on a generic parameter
+  --> $DIR/issue-76701-ty-param-in-const.rs:6:21
+   |
+LL | fn ty_param<T>() -> [u8; std::mem::size_of::<T>()] {
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this may fail depending on what value the parameter takes
+
+error: constant expression depends on a generic parameter
+  --> $DIR/issue-76701-ty-param-in-const.rs:12:37
+   |
+LL | fn const_param<const N: usize>() -> [u8; N + 1] {
+   |                                     ^^^^^^^^^^^
+   |
+   = note: this may fail depending on what value the parameter takes
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/const-generics/issues/issue-76701-ty-param-in-const.min.stderr
+++ b/src/test/ui/const-generics/issues/issue-76701-ty-param-in-const.min.stderr
@@ -1,0 +1,18 @@
+error: generic parameters must not be used inside of non trivial constant values
+  --> $DIR/issue-76701-ty-param-in-const.rs:6:46
+   |
+LL | fn ty_param<T>() -> [u8; std::mem::size_of::<T>()] {
+   |                                              ^ non-trivial anonymous constants must not depend on the parameter `T`
+   |
+   = note: type parameters are currently not permitted in anonymous constants
+
+error: generic parameters must not be used inside of non trivial constant values
+  --> $DIR/issue-76701-ty-param-in-const.rs:12:42
+   |
+LL | fn const_param<const N: usize>() -> [u8; N + 1] {
+   |                                          ^ non-trivial anonymous constants must not depend on the parameter `N`
+   |
+   = help: it is currently only allowed to use either `N` or `{ N }` as generic constants
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/const-generics/issues/issue-76701-ty-param-in-const.rs
+++ b/src/test/ui/const-generics/issues/issue-76701-ty-param-in-const.rs
@@ -1,0 +1,18 @@
+// revisions: full min
+#![cfg_attr(full, feature(const_generics))]
+#![cfg_attr(full, allow(incomplete_features))]
+#![cfg_attr(min, feature(min_const_generics))]
+
+fn ty_param<T>() -> [u8; std::mem::size_of::<T>()] {
+    //[full]~^ ERROR constant expression depends on a generic parameter
+    //[min]~^^ ERROR generic parameters must not be used inside of non trivial constant values
+    todo!()
+}
+
+fn const_param<const N: usize>() -> [u8; N + 1] {
+    //[full]~^ ERROR constant expression depends on a generic parameter
+    //[min]~^^ ERROR generic parameters must not be used inside of non trivial constant values
+    todo!()
+}
+
+fn main() {}

--- a/src/test/ui/const-generics/min_const_generics/self-ty-in-const-1.stderr
+++ b/src/test/ui/const-generics/min_const_generics/self-ty-in-const-1.stderr
@@ -4,7 +4,7 @@ error: generic parameters must not be used inside of non trivial constant values
 LL |     fn t1() -> [u8; std::mem::size_of::<Self>()];
    |                                         ^^^^ non-trivial anonymous constants must not depend on the parameter `Self`
    |
-   = help: it is currently only allowed to use either `Self` or `{ Self }` as generic constants
+   = note: type parameters are currently not permitted in anonymous constants
 
 error: generic `Self` types are currently not permitted in anonymous constants
   --> $DIR/self-ty-in-const-1.rs:14:41

--- a/src/test/ui/const-generics/params-in-ct-in-ty-param-lazy-norm.min.stderr
+++ b/src/test/ui/const-generics/params-in-ct-in-ty-param-lazy-norm.min.stderr
@@ -12,7 +12,7 @@ error: generic parameters must not be used inside of non trivial constant values
 LL | struct Foo<T, U = [u8; std::mem::size_of::<T>()]>(T, U);
    |                                            ^ non-trivial anonymous constants must not depend on the parameter `T`
    |
-   = help: it is currently only allowed to use either `T` or `{ T }` as generic constants
+   = note: type parameters are currently not permitted in anonymous constants
 
 error: constant values inside of type parameter defaults must not depend on generic parameters
   --> $DIR/params-in-ct-in-ty-param-lazy-norm.rs:12:21


### PR DESCRIPTION
This PR introduces the following changes:

* Change error message for type param in a const expression when using
`min_const_generics`
* Change `ParamInNonTrivialAnonConst` to contain an extra `bool` used for
distinguishing whether the passed-in symbol is a type or a value.

Fixes #76701 