### PR TITLE
Allow a unique name to be assigned to dataflow graphviz output

### DIFF
--- a/compiler/rustc_mir/src/borrow_check/mod.rs
+++ b/compiler/rustc_mir/src/borrow_check/mod.rs
@@ -205,6 +205,7 @@ fn do_mir_borrowck<'a, 'tcx>(
 
     let mut flow_inits = MaybeInitializedPlaces::new(tcx, &body, &mdpe)
         .into_engine(tcx, &body, def.did.to_def_id())
+        .pass_name("borrowck")
         .iterate_to_fixpoint()
         .into_results_cursor(&body);
 
@@ -264,12 +265,15 @@ fn do_mir_borrowck<'a, 'tcx>(
 
     let flow_borrows = Borrows::new(tcx, &body, regioncx.clone(), &borrow_set)
         .into_engine(tcx, &body, def.did.to_def_id())
+        .pass_name("borrowck")
         .iterate_to_fixpoint();
     let flow_uninits = MaybeUninitializedPlaces::new(tcx, &body, &mdpe)
         .into_engine(tcx, &body, def.did.to_def_id())
+        .pass_name("borrowck")
         .iterate_to_fixpoint();
     let flow_ever_inits = EverInitializedPlaces::new(tcx, &body, &mdpe)
         .into_engine(tcx, &body, def.did.to_def_id())
+        .pass_name("borrowck")
         .iterate_to_fixpoint();
 
     let movable_generator = match tcx.hir().get(id) {

--- a/compiler/rustc_mir/src/transform/check_consts/validation.rs
+++ b/compiler/rustc_mir/src/transform/check_consts/validation.rs
@@ -57,6 +57,7 @@ impl Qualifs<'mir, 'tcx> {
             MaybeMutBorrowedLocals::mut_borrows_only(tcx, &body, param_env)
                 .unsound_ignore_borrow_on_drop()
                 .into_engine(tcx, &body, def_id.to_def_id())
+                .pass_name("const_qualification")
                 .iterate_to_fixpoint()
                 .into_results_cursor(&body)
         });

--- a/compiler/rustc_mir/src/transform/elaborate_drops.rs
+++ b/compiler/rustc_mir/src/transform/elaborate_drops.rs
@@ -44,6 +44,7 @@ impl<'tcx> MirPass<'tcx> for ElaborateDrops {
             let inits = MaybeInitializedPlaces::new(tcx, body, &env)
                 .into_engine(tcx, body, def_id)
                 .dead_unwinds(&dead_unwinds)
+                .pass_name("elaborate_drops")
                 .iterate_to_fixpoint()
                 .into_results_cursor(body);
 
@@ -51,6 +52,7 @@ impl<'tcx> MirPass<'tcx> for ElaborateDrops {
                 .mark_inactive_variants_as_uninit()
                 .into_engine(tcx, body, def_id)
                 .dead_unwinds(&dead_unwinds)
+                .pass_name("elaborate_drops")
                 .iterate_to_fixpoint()
                 .into_results_cursor(body);
 
@@ -83,6 +85,7 @@ fn find_dead_unwinds<'tcx>(
     let mut dead_unwinds = BitSet::new_empty(body.basic_blocks().len());
     let mut flow_inits = MaybeInitializedPlaces::new(tcx, body, &env)
         .into_engine(tcx, body, def_id)
+        .pass_name("find_dead_unwinds")
         .iterate_to_fixpoint()
         .into_results_cursor(body);
     for (bb, bb_data) in body.basic_blocks().iter_enumerated() {

--- a/compiler/rustc_mir/src/transform/generator.rs
+++ b/compiler/rustc_mir/src/transform/generator.rs
@@ -467,8 +467,10 @@ fn locals_live_across_suspend_points(
 
     // Calculate the MIR locals which have been previously
     // borrowed (even if they are still active).
-    let borrowed_locals_results =
-        MaybeBorrowedLocals::all_borrows().into_engine(tcx, body_ref, def_id).iterate_to_fixpoint();
+    let borrowed_locals_results = MaybeBorrowedLocals::all_borrows()
+        .into_engine(tcx, body_ref, def_id)
+        .pass_name("generator")
+        .iterate_to_fixpoint();
 
     let mut borrowed_locals_cursor =
         dataflow::ResultsCursor::new(body_ref, &borrowed_locals_results);
@@ -484,6 +486,7 @@ fn locals_live_across_suspend_points(
     // Calculate the liveness of MIR locals ignoring borrows.
     let mut liveness = MaybeLiveLocals
         .into_engine(tcx, body_ref, def_id)
+        .pass_name("generator")
         .iterate_to_fixpoint()
         .into_results_cursor(body_ref);
 

--- a/src/tools/clippy/clippy_lints/src/redundant_clone.rs
+++ b/src/tools/clippy/clippy_lints/src/redundant_clone.rs
@@ -87,6 +87,7 @@ impl<'tcx> LateLintPass<'tcx> for RedundantClone {
 
         let maybe_storage_live_result = MaybeStorageLive
             .into_engine(cx.tcx, mir, def_id.to_def_id())
+            .pass_name("redundant_clone")
             .iterate_to_fixpoint()
             .into_results_cursor(mir);
         let mut possible_borrower = {


### PR DESCRIPTION
Previously, if the same analysis were invoked multiple times in a single compilation session, the graphviz output for later runs would overwrite that of previous runs. Allow callers to add a unique identifier to each run so this can be avoided.