### PR TITLE
Fix rustdoc rendering of by-value mutable arguments in async fn

### DIFF
--- a/compiler/rustc_ast_lowering/src/item.rs
+++ b/compiler/rustc_ast_lowering/src/item.rs
@@ -1096,9 +1096,12 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 // Check if this is a binding pattern, if so, we can optimize and avoid adding a
                 // `let <pat> = __argN;` statement. In this case, we do not rename the parameter.
                 let (ident, is_simple_parameter) = match parameter.pat.kind {
-                    hir::PatKind::Binding(hir::BindingAnnotation::Unannotated, _, ident, _) => {
-                        (ident, true)
-                    }
+                    hir::PatKind::Binding(
+                        hir::BindingAnnotation::Unannotated | hir::BindingAnnotation::Mutable,
+                        _,
+                        ident,
+                        _,
+                    ) => (ident, true),
                     _ => {
                         // Replace the ident for bindings that aren't simple.
                         let name = format!("__arg{}", index);

--- a/compiler/rustc_ast_lowering/src/item.rs
+++ b/compiler/rustc_ast_lowering/src/item.rs
@@ -1102,10 +1102,13 @@ impl<'hir> LoweringContext<'_, 'hir> {
                         ident,
                         _,
                     ) => (ident, true),
-                    // For `ref mut` arguments, we can't reuse the binding, but
+                    // For `ref mut` or wildcard arguments, we can't reuse the binding, but
                     // we can keep the same name for the parameter.
                     // This lets rustdoc render it correctly in documentation.
                     hir::PatKind::Binding(_, _, ident, _) => (ident, false),
+                    hir::PatKind::Wild => {
+                        (Ident::with_dummy_span(rustc_span::symbol::kw::Underscore), false)
+                    }
                     _ => {
                         // Replace the ident for bindings that aren't simple.
                         let name = format!("__arg{}", index);

--- a/compiler/rustc_ast_lowering/src/item.rs
+++ b/compiler/rustc_ast_lowering/src/item.rs
@@ -1102,6 +1102,10 @@ impl<'hir> LoweringContext<'_, 'hir> {
                         ident,
                         _,
                     ) => (ident, true),
+                    // For `ref mut` arguments, we can't reuse the binding, but
+                    // we can keep the same name for the parameter.
+                    // This lets rustdoc render it correctly in documentation.
+                    hir::PatKind::Binding(_, _, ident, _) => (ident, false),
                     _ => {
                         // Replace the ident for bindings that aren't simple.
                         let name = format!("__arg{}", index);

--- a/src/test/rustdoc/async-fn.rs
+++ b/src/test/rustdoc/async-fn.rs
@@ -20,6 +20,12 @@ pub async unsafe fn qux() -> char {
     '⚠'
 }
 
+// @has async_fn/fn.mut_args.html '//pre[@class="rust fn"]' 'pub async fn mut_args(a: usize)'
+pub async fn mut_args(mut a: usize) {}
+
+// @has async_fn/fn.mut_ref.html '//pre[@class="rust fn"]' 'pub async fn mut_ref(x: i32)'
+pub async fn mut_ref(ref mut x: i32) {}
+
 trait Bar {}
 
 impl Bar for () {}
@@ -32,9 +38,11 @@ pub async fn quux() -> impl Bar {
 // @has async_fn/struct.Foo.html
 // @matches - '//code' 'pub async fn f\(\)$'
 // @matches - '//code' 'pub async unsafe fn g\(\)$'
+// @matches - '//code' 'pub async fn mut_self\(self, first: usize\)$'
 pub struct Foo;
 
 impl Foo {
     pub async fn f() {}
     pub async unsafe fn g() {}
+    pub async fn mut_self(mut self, mut first: usize) {}
 }

--- a/src/test/rustdoc/async-fn.rs
+++ b/src/test/rustdoc/async-fn.rs
@@ -1,4 +1,5 @@
 // edition:2018
+#![feature(min_const_generics)]
 
 // @has async_fn/fn.foo.html '//pre[@class="rust fn"]' 'pub async fn foo() -> Option<Foo>'
 pub async fn foo() -> Option<Foo> {
@@ -46,3 +47,8 @@ impl Foo {
     pub async unsafe fn g() {}
     pub async fn mut_self(mut self, mut first: usize) {}
 }
+
+pub trait Trait<const N: usize> {}
+// @has async_fn/fn.const_generics.html
+// @has - '//pre[@class="rust fn"]' 'pub async fn const_generics<const N: usize>(_: impl Trait<N>)'
+pub async fn const_generics<const N: usize>(_: impl Trait<N>) {}

--- a/src/test/rustdoc/const-generics/const-generics-docs.rs
+++ b/src/test/rustdoc/const-generics/const-generics-docs.rs
@@ -70,8 +70,7 @@ pub async fn a_sink<const N: usize>(v: [u8; N]) -> impl Trait<N> {
 }
 
 // @has foo/fn.b_sink.html '//pre[@class="rust fn"]' \
-//      'pub async fn b_sink<const N: usize>(__arg0: impl Trait<N>)'
-// FIXME(const_generics): This should be `_` not `__arg0`.
+//      'pub async fn b_sink<const N: usize>(_: impl Trait<N>)'
 pub async fn b_sink<const N: usize>(_: impl Trait<N>) {}
 
 // @has foo/fn.concrete.html '//pre[@class="rust fn"]' \


### PR DESCRIPTION
r? @jyn514 

Fixes #76517.