### PR TITLE
Allow path as value in name-value attribute

### DIFF
--- a/compiler/rustc_parse/src/parser/attr.rs
+++ b/compiler/rustc_parse/src/parser/attr.rs
@@ -159,6 +159,7 @@ impl<'a> Parser<'a> {
     ///     PATH `{` TOKEN_STREAM `}`
     ///     PATH
     ///     PATH `=` UNSUFFIXED_LIT
+    ///     PATH `=` PATH
     /// The delimiters or `=` are still put into the resulting token stream.
     pub fn parse_attr_item(&mut self, capture_tokens: bool) -> PResult<'a, ast::AttrItem> {
         let item = match self.token.kind {
@@ -230,6 +231,11 @@ impl<'a> Parser<'a> {
 
     crate fn parse_unsuffixed_lit(&mut self) -> PResult<'a, ast::Lit> {
         let lit = self.parse_lit()?;
+        self.require_unsuffixed(&lit);
+        Ok(lit)
+    }
+
+    crate fn require_unsuffixed(&self, lit: &ast::Lit) {
         debug!("checking if {:?} is unusuffixed", lit);
 
         if !lit.kind.is_unsuffixed() {
@@ -240,8 +246,6 @@ impl<'a> Parser<'a> {
                 )
                 .emit();
         }
-
-        Ok(lit)
     }
 
     /// Parses `cfg_attr(pred, attr_item_list)` where `attr_item_list` is comma-delimited.

--- a/compiler/rustc_parse/src/parser/mod.rs
+++ b/compiler/rustc_parse/src/parser/mod.rs
@@ -944,6 +944,8 @@ impl<'a> Parser<'a> {
                         lit.token_tree().into()
                     } else if self.check(&token::ModSep) || self.token.ident().is_some() {
                         self.collect_tokens_only(|this| this.parse_path(PathStyle::Mod))?
+                            .expect("parse_path cannot parse empty path")
+                            .create_token_stream()
                     } else {
                         let msg = "expected a literal or ::-separated path";
                         return Err(self.struct_span_err(self.token.span, msg));
@@ -1263,7 +1265,7 @@ impl<'a> Parser<'a> {
     fn collect_tokens_only<R>(
         &mut self,
         f: impl FnOnce(&mut Self) -> PResult<'a, R>,
-    ) -> PResult<'a, TokenStream> {
+    ) -> PResult<'a, Option<LazyTokenStream>> {
         let (_ignored, tokens) = self.collect_tokens(f)?;
         Ok(tokens)
     }

--- a/src/test/ui/attr-eq-token-tree.rs
+++ b/src/test/ui/attr-eq-token-tree.rs
@@ -1,2 +1,2 @@
-#[my_attr = !] //~ ERROR unexpected token: `!`
+#[my_attr = !] //~ ERROR expected a literal or ::-separated path
 fn main() {}

--- a/src/test/ui/attr-eq-token-tree.stderr
+++ b/src/test/ui/attr-eq-token-tree.stderr
@@ -1,4 +1,4 @@
-error: unexpected token: `!`
+error: expected a literal or ::-separated path
   --> $DIR/attr-eq-token-tree.rs:1:13
    |
 LL | #[my_attr = !]

--- a/src/test/ui/attributes/path-eq-path.rs
+++ b/src/test/ui/attributes/path-eq-path.rs
@@ -1,0 +1,11 @@
+#[cfg(any())]
+extern "C++" {
+    #[namespace = std::experimental]
+    type any;
+
+    #[rust = std::option::Option<T>]
+    //~^ ERROR expected one of `::` or `]`, found `<`
+    type optional;
+}
+
+fn main() {}

--- a/src/test/ui/attributes/path-eq-path.stderr
+++ b/src/test/ui/attributes/path-eq-path.stderr
@@ -1,0 +1,14 @@
+error: expected one of `::` or `]`, found `<`
+  --> $DIR/path-eq-path.rs:6:33
+   |
+LL | extern "C++" {
+   |              - while parsing this item list starting here
+...
+LL |     #[rust = std::option::Option<T>]
+   |                                 ^ expected one of `::` or `]`
+...
+LL | }
+   | - the item list ends here
+
+error: aborting due to previous error
+

--- a/src/test/ui/macros/macro-attribute.rs
+++ b/src/test/ui/macros/macro-attribute.rs
@@ -1,2 +1,2 @@
-#[doc = $not_there] //~ ERROR unexpected token: `$`
+#[doc = $not_there] //~ ERROR expected a literal or ::-separated path
 fn main() { }

--- a/src/test/ui/macros/macro-attribute.stderr
+++ b/src/test/ui/macros/macro-attribute.stderr
@@ -1,4 +1,4 @@
-error: unexpected token: `$`
+error: expected a literal or ::-separated path
   --> $DIR/macro-attribute.rs:1:9
    |
 LL | #[doc = $not_there]

--- a/src/test/ui/parser/attr-bad-meta-2.rs
+++ b/src/test/ui/parser/attr-bad-meta-2.rs
@@ -1,2 +1,2 @@
-#[path =] //~ ERROR unexpected token: `]`
+#[path =] //~ ERROR expected a literal or ::-separated path
 mod m {}

--- a/src/test/ui/parser/attr-bad-meta-2.stderr
+++ b/src/test/ui/parser/attr-bad-meta-2.stderr
@@ -1,4 +1,4 @@
-error: unexpected token: `]`
+error: expected a literal or ::-separated path
   --> $DIR/attr-bad-meta-2.rs:1:9
    |
 LL | #[path =]

--- a/src/test/ui/proc-macro/attributes-included.rs
+++ b/src/test/ui/proc-macro/attributes-included.rs
@@ -13,6 +13,7 @@ use attributes_included::*;
 #[foo]
 #[inline]
 /// doc
+#[namespace = std::experimental]
 fn foo() {
     let a: i32 = "foo"; //~ WARN: unused variable
 }

--- a/src/test/ui/proc-macro/attributes-included.stderr
+++ b/src/test/ui/proc-macro/attributes-included.stderr
@@ -1,5 +1,5 @@
 warning: unused variable: `a`
-  --> $DIR/attributes-included.rs:17:9
+  --> $DIR/attributes-included.rs:18:9
    |
 LL |     let a: i32 = "foo";
    |         ^ help: if this is intentional, prefix it with an underscore: `_a`

--- a/src/test/ui/proc-macro/auxiliary/attributes-included.rs
+++ b/src/test/ui/proc-macro/auxiliary/attributes-included.rs
@@ -6,20 +6,30 @@
 extern crate proc_macro;
 
 use proc_macro::{TokenStream, TokenTree, Delimiter, Literal, Spacing, Group};
+use std::iter;
 
 #[proc_macro_attribute]
 pub fn foo(attr: TokenStream, input: TokenStream) -> TokenStream {
     assert!(attr.is_empty());
-    let input = input.into_iter().collect::<Vec<_>>();
+    let mut input = input.into_iter().collect::<Vec<_>>();
+    let (namespace_start, namespace_end);
     {
         let mut cursor = &input[..];
         assert_inline(&mut cursor);
         assert_doc(&mut cursor);
         assert_inline(&mut cursor);
         assert_doc(&mut cursor);
+
+        // Splice out the #[namespace = ...] attribute as it is an inert
+        // attribute, not a proc macro.
+        namespace_start = input.len() - cursor.len();
+        assert_namespace(&mut cursor);
+        namespace_end = input.len() - cursor.len();
+
         assert_foo(&mut cursor);
         assert!(cursor.is_empty());
     }
+    input.splice(namespace_start..namespace_end, iter::empty());
     fold_stream(input.into_iter().collect())
 }
 
@@ -34,6 +44,7 @@ pub fn bar(attr: TokenStream, input: TokenStream) -> TokenStream {
         assert_invoc(&mut cursor);
         assert_inline(&mut cursor);
         assert_doc(&mut cursor);
+        assert_namespace(&mut cursor);
         assert_foo(&mut cursor);
         assert!(cursor.is_empty());
     }
@@ -90,6 +101,51 @@ fn assert_doc(slice: &mut &[TokenTree]) {
         _ => panic!("expected literal"),
     }
 
+    *slice = &slice[2..];
+}
+
+fn assert_namespace(slice: &mut &[TokenTree]) {
+    match &slice[0] {
+        TokenTree::Punct(tt) => assert_eq!(tt.as_char(), '#'),
+        _ => panic!("expected `#`"),
+    }
+    let inner = match &slice[1] {
+        TokenTree::Group(tt) => tt.stream().into_iter().collect::<Vec<_>>(),
+        _ => panic!("expected brackets"),
+    };
+    if inner.len() != 6 {
+        panic!("expected 6 tokens in namespace attr")
+    }
+    match &inner[0] {
+        TokenTree::Ident(tt) => assert_eq!("namespace", tt.to_string()),
+        _ => panic!("expected `namespace`"),
+    }
+    match &inner[1] {
+        TokenTree::Punct(tt) => assert_eq!(tt.as_char(), '='),
+        _ => panic!("expected `=`"),
+    }
+    match &inner[2] {
+        TokenTree::Ident(tt) => assert_eq!("std", tt.to_string()),
+        _ => panic!("expected `std`"),
+    }
+    match &inner[3] {
+        TokenTree::Punct(tt) => {
+            assert_eq!(tt.as_char(), ':');
+            assert_eq!(tt.spacing(), Spacing::Joint);
+        }
+        _ => panic!("expected `:`"),
+    }
+    match &inner[4] {
+        TokenTree::Punct(tt) => {
+            assert_eq!(tt.as_char(), ':');
+            assert_eq!(tt.spacing(), Spacing::Alone);
+        }
+        _ => panic!("expected `:`"),
+    }
+    match &inner[5] {
+        TokenTree::Ident(tt) => assert_eq!("experimental", tt.to_string()),
+        _ => panic!("expected `experimental`"),
+    }
     *slice = &slice[2..];
 }
 


### PR DESCRIPTION
This commit allows proc macros to take inert attributes that look like `#[path = ident]` or `#[path = p::p::path]`. Previously the rhs was only permitted to be an unsuffixed numeric literal or the identifier special cases `true` and `false`. However, parenthesized `#[path(key = ident)]` and `#[path(key = p::p::path)]` were already allowed; see https://docs.rs/cxx/0.4.4/cxx/attr.bridge.html for one attribute currently using that style.

My use case for this is related to C++ namespace support in https://github.com/dtolnay/cxx.

```diff
- #[cxx::bridge(namespace = co::stuff)]  // previously only one namespace can be specified
+ #[cxx::bridge]
  mod ffi {
+     #[namespace = co::server]  // now can allow different namespace for different stuff
      extern "C++" {
          ...
+     }

+     #[namespace = co::client]
+     extern "C++" {
          ...
      }
  }
```

Chesterton's fence: why was the rhs syntax restricted originally? I believe this was to leave open the possibility of `#[m1 = "...", m2 = "..."]` syntax which would be equivalent to `#[m1 = "..."] #[m2 = "..."]` but more compact (this might still happen). Allowing an "arbitrary tokenstream" on the rhs would rule that out. In this PR I've still kept the rhs syntax quite restricted, adding only mod-style paths and remaining compatible with compact syntax being introduced later.