### PR TITLE
resolve: prohibit anon const non-static lifetimes

### DIFF
--- a/compiler/rustc_resolve/src/late/lifetimes.rs
+++ b/compiler/rustc_resolve/src/late/lifetimes.rs
@@ -1777,6 +1777,10 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
         let result = loop {
             match *scope {
                 Scope::Body { id, s } => {
+                    // Non-static lifetimes are prohibited in anonymous constants under
+                    // `min_const_generics`.
+                    self.maybe_emit_forbidden_non_static_lifetime_error(id, lifetime_ref);
+
                     outermost_body = Some(id);
                     scope = s;
                 }

--- a/src/test/ui/const-generics/min_const_generics/forbid-non-static-lifetimes.rs
+++ b/src/test/ui/const-generics/min_const_generics/forbid-non-static-lifetimes.rs
@@ -1,0 +1,27 @@
+#![feature(min_const_generics)]
+
+// This test checks that non-static lifetimes are prohibited under `min_const_generics`. It
+// currently emits an error with `min_const_generics`. This will ICE under `const_generics`.
+
+fn test<const N: usize>() {}
+
+fn issue_75323_and_74447_1<'a>() -> &'a () {
+    test::<{ let _: &'a (); 3 },>();
+   //~^ ERROR a non-static lifetime is not allowed in a `const`
+    &()
+}
+
+fn issue_75323_and_74447_2() {
+    test::<{ let _: &(); 3 },>();
+}
+
+fn issue_75323_and_74447_3() {
+    test::<{ let _: &'static (); 3 },>();
+}
+
+fn issue_73375<'a>() {
+    [(); (|_: &'a u8| (), 0).1];
+    //~^ ERROR a non-static lifetime is not allowed in a `const`
+}
+
+fn main() {}

--- a/src/test/ui/const-generics/min_const_generics/forbid-non-static-lifetimes.stderr
+++ b/src/test/ui/const-generics/min_const_generics/forbid-non-static-lifetimes.stderr
@@ -1,0 +1,21 @@
+error[E0658]: a non-static lifetime is not allowed in a `const`
+  --> $DIR/forbid-non-static-lifetimes.rs:9:22
+   |
+LL |     test::<{ let _: &'a (); 3 },>();
+   |                      ^^
+   |
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
+   = help: add `#![feature(const_generics)]` to the crate attributes to enable
+
+error[E0658]: a non-static lifetime is not allowed in a `const`
+  --> $DIR/forbid-non-static-lifetimes.rs:23:16
+   |
+LL |     [(); (|_: &'a u8| (), 0).1];
+   |                ^^
+   |
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
+   = help: add `#![feature(const_generics)]` to the crate attributes to enable
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0658`.


### PR DESCRIPTION
Fixes #75323, fixes #74447 and fixes #73375.

This PR prohibits non-static lifetimes in anonymous constants when only the `min_const_generics` feature is enabled. ~~To do so, `to_region_vid`'s `bug!` had to be changed into a delayed bug, which unfortunately required providing it a `TyCtxt`.~~

--- 
~~While I am happy with how the implementation of the error turned out in `rustc_passes::check_const`,  emitting an error wasn't sufficient to avoid hitting the ICE later. I also tried implementing the error in `rustc_mir::transform::check_consts::validation` and that worked, but it didn't silence the ICE either. To silence the ICE, I changed it to a delayed bug which worked but was more invasive that I would have liked, and required I return an incorrect lifetime. It's possible that this check should be implemented earlier in the compiler to make the invasive changes unnecessary, but I wasn't sure where that would be and wanted to get some feedback first.~~
The approach taken by this PR has been changed to implement the error in name resolution, which ended up being much simpler.

cc @rust-lang/wg-const-eval 
r? @lcnr