### PR TITLE
Rename File::with_options to builder

### DIFF
--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -368,16 +368,16 @@ impl File {
     /// # Examples
     ///
     /// ```no_run
-    /// #![feature(with_options)]
+    /// #![feature(file_builder)]
     /// use std::fs::File;
     ///
     /// fn main() -> std::io::Result<()> {
-    ///     let _ = File::with_options().read(true).open("foo.txt")?;
+    ///     let _ = File::builder().read(true).open("foo.txt")?;
     ///     Ok(())
     /// }
     /// ```
-    #[unstable(feature = "with_options", issue = "65439")]
-    pub fn with_options() -> OpenOptions {
+    #[unstable(feature = "file_builder", issue = "65439")]
+    pub fn builder() -> OpenOptions {
         OpenOptions::new()
     }
 

--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -358,18 +358,12 @@ impl File {
         OpenOptions::new().write(true).create(true).truncate(true).open(path.as_ref())
     }
 
-    /// Returns a new OpenOptions object.
+    /// Returns a builder struct to configure how a file is opened.
     ///
-    /// This function returns a new OpenOptions object that you can use to
-    /// open or create a file with specific options if `open()` or `create()`
-    /// are not appropriate.
+    /// This function returns an empty [`OpenOptions`] object
+    /// to avoid the need of importing [`OpenOptions`].
     ///
-    /// It is equivalent to `OpenOptions::new()` but allows you to write more
-    /// readable code. Instead of `OpenOptions::new().read(true).open("foo.txt")`
-    /// you can write `File::with_options().read(true).open("foo.txt")`. This
-    /// also avoids the need to import `OpenOptions`.
-    ///
-    /// See the [`OpenOptions::new`] function for more details.
+    /// See [`OpenOptions::new`] function for more details.
     ///
     /// # Examples
     ///
@@ -378,7 +372,7 @@ impl File {
     /// use std::fs::File;
     ///
     /// fn main() -> std::io::Result<()> {
-    ///     let mut f = File::with_options().read(true).open("foo.txt")?;
+    ///     let _ = File::with_options().read(true).open("foo.txt")?;
     ///     Ok(())
     /// }
     /// ```


### PR DESCRIPTION
This patch implements this idea: https://github.com/rust-lang/rust/issues/65439#issuecomment-652581360

Java APIs often use builder pattern and name the builder function as `builder`.
At least we have a prio-art to follow. An arguments against `with_options` 
is that [it often receives arguments](https://grep.app/search?q=with_options%28&case=true&words=true&filter[lang][0]=Rust).
