### PR TITLE
Add fold_mut alternative to Iterator trait

### DIFF
--- a/library/core/benches/iter.rs
+++ b/library/core/benches/iter.rs
@@ -345,3 +345,63 @@ fn bench_partial_cmp(b: &mut Bencher) {
 fn bench_lt(b: &mut Bencher) {
     b.iter(|| (0..100000).map(black_box).lt((0..100000).map(black_box)))
 }
+
+#[bench]
+fn bench_fold_vec(b: &mut Bencher) {
+    b.iter(|| {
+        (0..100000).map(black_box).fold(Vec::new(), |mut v, n| {
+            if n % 2 == 0 {
+                v.push(n * 3);
+            }
+            v
+        })
+    });
+}
+
+#[bench]
+fn bench_fold_mut_vec(b: &mut Bencher) {
+    b.iter(|| {
+        (0..100000).map(black_box).fold_mut(Vec::new(), |v, n| {
+            if n % 2 == 0 {
+                v.push(n * 3);
+            }
+        })
+    });
+}
+
+#[bench]
+fn bench_fold_map(b: &mut Bencher) {
+    use std::collections::HashMap;
+
+    b.iter(|| {
+        (0..100000).map(black_box).fold(HashMap::new(), |mut hm, n| {
+            *hm.entry(n % 3).or_insert(0) += 1;
+            hm
+        })
+    });
+}
+
+#[bench]
+fn bench_fold_mut_map(b: &mut Bencher) {
+    use std::collections::HashMap;
+
+    b.iter(|| {
+        (0..100000).map(black_box).fold_mut(HashMap::new(), |hm, n| {
+            *hm.entry(n % 3).or_insert(0) += 1;
+        })
+    });
+}
+
+#[bench]
+fn bench_fold_num(b: &mut Bencher) {
+    b.iter(|| (0..100000).map(black_box).fold(0, |sum, n| sum + n));
+}
+
+#[bench]
+fn bench_fold_mut_num(b: &mut Bencher) {
+    b.iter(|| {
+        (0..100000).map(black_box).fold_mut(0, |sum, n| {
+            *sum += n;
+        })
+    });
+}

--- a/library/core/benches/iter.rs
+++ b/library/core/benches/iter.rs
@@ -347,7 +347,7 @@ fn bench_lt(b: &mut Bencher) {
 }
 
 #[bench]
-fn bench_fold_vec(b: &mut Bencher) {
+fn bench_fold_fold_mut_vec(b: &mut Bencher) {
     b.iter(|| {
         (0..100000).map(black_box).fold(Vec::new(), |mut v, n| {
             if n % 2 == 0 {
@@ -359,7 +359,7 @@ fn bench_fold_vec(b: &mut Bencher) {
 }
 
 #[bench]
-fn bench_fold_mut_vec(b: &mut Bencher) {
+fn bench_fold_fold_mut_vec_mut(b: &mut Bencher) {
     b.iter(|| {
         (0..100000).map(black_box).fold_mut(Vec::new(), |v, n| {
             if n % 2 == 0 {
@@ -370,7 +370,7 @@ fn bench_fold_mut_vec(b: &mut Bencher) {
 }
 
 #[bench]
-fn bench_fold_map(b: &mut Bencher) {
+fn bench_fold_fold_mut_hashmap(b: &mut Bencher) {
     use std::collections::HashMap;
 
     b.iter(|| {
@@ -382,7 +382,7 @@ fn bench_fold_map(b: &mut Bencher) {
 }
 
 #[bench]
-fn bench_fold_mut_map(b: &mut Bencher) {
+fn bench_fold_fold_mut_hashmap_mut(b: &mut Bencher) {
     use std::collections::HashMap;
 
     b.iter(|| {
@@ -393,14 +393,47 @@ fn bench_fold_mut_map(b: &mut Bencher) {
 }
 
 #[bench]
-fn bench_fold_num(b: &mut Bencher) {
+fn bench_fold_fold_mut_num(b: &mut Bencher) {
     b.iter(|| (0..100000).map(black_box).fold(0, |sum, n| sum + n));
 }
 
 #[bench]
-fn bench_fold_mut_num(b: &mut Bencher) {
+fn bench_fold_fold_mut_num_mut(b: &mut Bencher) {
     b.iter(|| {
         (0..100000).map(black_box).fold_mut(0, |sum, n| {
+            *sum += n;
+        })
+    });
+}
+
+#[bench]
+fn bench_fold_fold_mut_chain(b: &mut Bencher) {
+    b.iter(|| (0i64..1000000).chain(0..1000000).map(black_box).fold(0, |sum, n| sum + n));
+}
+
+#[bench]
+fn bench_fold_fold_mut_chain_mut(b: &mut Bencher) {
+    b.iter(|| {
+        (0i64..1000000).chain(0..1000000).map(black_box).fold_mut(0, |sum, n| {
+            *sum += n;
+        })
+    });
+}
+
+#[bench]
+fn bench_fold_fold_mut_chain_flat_map(b: &mut Bencher) {
+    b.iter(|| {
+        (0i64..1000000)
+            .flat_map(|x| once(x).chain(once(x)))
+            .map(black_box)
+            .fold(0, |sum, n| sum + n)
+    });
+}
+
+#[bench]
+fn bench_fold_fold_mut_chain_flat_map_mut(b: &mut Bencher) {
+    b.iter(|| {
+        (0i64..1000000).flat_map(|x| once(x).chain(once(x))).map(black_box).fold_mut(0, |sum, n| {
             *sum += n;
         })
     });

--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -2015,7 +2015,7 @@ pub trait Iterator {
     /// assert_eq!(counts[&'a'], 5);
     /// ```
     #[inline]
-    #[unstable(feature = "iterator_fold_mut", issue = "76725")]
+    #[unstable(feature = "iterator_fold_mut", issue = "76751")]
     fn fold_mut<B, F>(mut self, init: B, mut f: F) -> B
     where
         Self: Sized,

--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -1990,6 +1990,44 @@ pub trait Iterator {
         accum
     }
 
+    /// An iterator method that applies a function, producing a single, final value.
+    ///
+    /// `fold_mut()` is very similar to [`fold()`] except that the closure
+    /// takes a `&mut` to the 'accumulator' and does not need to return a new value.
+    ///
+    /// [`fold()`]: Iterator::fold
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// #![feature(iterator_fold_mut)]
+    /// use std::collections::HashMap;
+    ///
+    /// let word = "abracadabra";
+    ///
+    /// // the count of each letter in a HashMap
+    /// let counts = word.chars().fold_mut(HashMap::new(), |map, c| {
+    ///   *map.entry(c).or_insert(0) += 1;
+    /// });
+    ///
+    /// assert_eq!(counts[&'a'], 5);
+    /// ```
+    #[inline]
+    #[unstable(feature = "iterator_fold_mut", issue = "76725")]
+    fn fold_mut<B, F>(mut self, init: B, mut f: F) -> B
+    where
+        Self: Sized,
+        F: FnMut(&mut B, Self::Item),
+    {
+        let mut accum = init;
+        while let Some(x) = self.next() {
+            f(&mut accum, x);
+        }
+        accum
+    }
+
     /// The same as [`fold()`], but uses the first element in the
     /// iterator as the initial value, folding every subsequent element into it.
     /// If the iterator is empty, return [`None`]; otherwise, return the result

--- a/library/core/tests/iter.rs
+++ b/library/core/tests/iter.rs
@@ -3222,3 +3222,15 @@ fn test_flatten_non_fused_inner() {
     assert_eq!(iter.next(), Some(1));
     assert_eq!(iter.next(), None);
 }
+
+#[test]
+fn test_fold_mut() {
+    let nums = [1, 2, 3, 4, 5];
+    let result = nums.iter().fold_mut(Vec::new(), |v, i| {
+        if i % 2 == 0 {
+            v.push(i * 3);
+        }
+    });
+
+    assert_eq!(result, vec![6, 12]);
+}


### PR DESCRIPTION
**This PR**
Adds a `fold_mut` alternative to `fold` for the `Iterator` trait
Closes #76725 

**Why?**
Most of the background is in https://github.com/rust-lang/rust/issues/76725 but the TL;DR is that it might be faster and it might be ergonomic in some cases.

**Questions:**
1. I've never contributed library code here before - once I added `unstable` the tests started failing. Do I need to use nightly rust? Do I need to specify the feature config somewhere? Do I need that specified for the tests and benchmarks?
1. Are those docs are sufficient? I was offloading everything to `fold()` which is a little lazy maybe
1. Do we want all those benchmarks? Is it bloating the library/causing unnecessary time increase in the benchmarks?
1. Should this be implemented for other structs that have custom `fold` implementations like `VecDeque`, etc.?
1. Should we track a separate issue to improve the performance of `fold` itself? I imagine that, in general, the runtimes should be the same