### PR TITLE
Fix stabilization marker for future_readiness_fns

### DIFF
--- a/library/core/src/future/mod.rs
+++ b/library/core/src/future/mod.rs
@@ -21,9 +21,9 @@ pub use self::future::Future;
 #[unstable(feature = "into_future", issue = "67644")]
 pub use into_future::IntoFuture;
 
-#[stable(feature = "future_readiness_fns", since = "1.47.0")]
+#[stable(feature = "future_readiness_fns", since = "1.48.0")]
 pub use pending::{pending, Pending};
-#[stable(feature = "future_readiness_fns", since = "1.47.0")]
+#[stable(feature = "future_readiness_fns", since = "1.48.0")]
 pub use ready::{ready, Ready};
 
 #[unstable(feature = "future_poll_fn", issue = "72302")]

--- a/library/core/src/future/pending.rs
+++ b/library/core/src/future/pending.rs
@@ -11,7 +11,7 @@ use crate::task::{Context, Poll};
 /// documentation for more.
 ///
 /// [`pending`]: fn.pending.html
-#[stable(feature = "future_readiness_fns", since = "1.47.0")]
+#[stable(feature = "future_readiness_fns", since = "1.48.0")]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Pending<T> {
     _data: marker::PhantomData<T>,
@@ -31,12 +31,12 @@ pub struct Pending<T> {
 /// unreachable!();
 /// # }
 /// ```
-#[stable(feature = "future_readiness_fns", since = "1.47.0")]
+#[stable(feature = "future_readiness_fns", since = "1.48.0")]
 pub fn pending<T>() -> Pending<T> {
     Pending { _data: marker::PhantomData }
 }
 
-#[stable(feature = "future_readiness_fns", since = "1.47.0")]
+#[stable(feature = "future_readiness_fns", since = "1.48.0")]
 impl<T> Future for Pending<T> {
     type Output = T;
 
@@ -45,17 +45,17 @@ impl<T> Future for Pending<T> {
     }
 }
 
-#[stable(feature = "future_readiness_fns", since = "1.47.0")]
+#[stable(feature = "future_readiness_fns", since = "1.48.0")]
 impl<T> Unpin for Pending<T> {}
 
-#[stable(feature = "future_readiness_fns", since = "1.47.0")]
+#[stable(feature = "future_readiness_fns", since = "1.48.0")]
 impl<T> Debug for Pending<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Pending").finish()
     }
 }
 
-#[stable(feature = "future_readiness_fns", since = "1.47.0")]
+#[stable(feature = "future_readiness_fns", since = "1.48.0")]
 impl<T> Clone for Pending<T> {
     fn clone(&self) -> Self {
         pending()

--- a/library/core/src/future/ready.rs
+++ b/library/core/src/future/ready.rs
@@ -8,15 +8,15 @@ use crate::task::{Context, Poll};
 /// documentation for more.
 ///
 /// [`ready`]: fn.ready.html
-#[stable(feature = "future_readiness_fns", since = "1.47.0")]
+#[stable(feature = "future_readiness_fns", since = "1.48.0")]
 #[derive(Debug, Clone)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Ready<T>(Option<T>);
 
-#[stable(feature = "future_readiness_fns", since = "1.47.0")]
+#[stable(feature = "future_readiness_fns", since = "1.48.0")]
 impl<T> Unpin for Ready<T> {}
 
-#[stable(feature = "future_readiness_fns", since = "1.47.0")]
+#[stable(feature = "future_readiness_fns", since = "1.48.0")]
 impl<T> Future for Ready<T> {
     type Output = T;
 
@@ -42,7 +42,7 @@ impl<T> Future for Ready<T> {
 /// assert_eq!(a.await, 1);
 /// # }
 /// ```
-#[stable(feature = "future_readiness_fns", since = "1.47.0")]
+#[stable(feature = "future_readiness_fns", since = "1.48.0")]
 pub fn ready<T>(t: T) -> Ready<T> {
     Ready(Some(t))
 }

--- a/library/std/src/future.rs
+++ b/library/std/src/future.rs
@@ -9,7 +9,7 @@ pub use core::future::Future;
 pub use core::future::{from_generator, get_context, ResumeTy};
 
 #[doc(inline)]
-#[stable(feature = "future_readiness_fns", since = "1.47.0")]
+#[stable(feature = "future_readiness_fns", since = "1.48.0")]
 pub use core::future::{pending, ready, Pending, Ready};
 
 #[doc(inline)]


### PR DESCRIPTION
Updated the rustc version in which this will be stabilized from `1.47.0 -> 1.48.0`. Fixes https://github.com/rust-lang/rust/pull/74328#issuecomment-692133125. Ref #70921.

r? @Dylan-DPC 