### PR TITLE
Make it more clear what an about async fn's returns when referring to what it returns

### DIFF
--- a/src/test/ui/async-await/issues/issue-63388-1.stderr
+++ b/src/test/ui/async-await/issues/issue-63388-1.stderr
@@ -2,12 +2,14 @@ error[E0623]: lifetime mismatch
   --> $DIR/issue-63388-1.rs:14:9
    |
 LL |         &'a self, foo: &dyn Foo
-   |         -------- this parameter and the return type are declared with different lifetimes...
+   |         -------- this parameter and the returned future are declared with different lifetimes...
 LL |     ) -> &dyn Foo
    |          --------
+   |          |
+   |          this `async fn` implicitly returns an `impl Future<Output = &dyn Foo>`
 LL |     {
 LL |         foo
-   |         ^^^ ...but data from `foo` is returned here
+   |         ^^^ ...but data from `foo` is held across an await point here
 
 error: aborting due to previous error
 

--- a/src/test/ui/async-await/multiple-lifetimes/ret-impl-trait-one.stderr
+++ b/src/test/ui/async-await/multiple-lifetimes/ret-impl-trait-one.stderr
@@ -4,8 +4,9 @@ error[E0623]: lifetime mismatch
 LL | async fn async_ret_impl_trait1<'a, 'b>(a: &'a u8, b: &'b u8) -> impl Trait<'a> {
    |                                           ------                ^^^^^^^^^^^^^^
    |                                           |                     |
-   |                                           |                     ...but data from `b` is returned here
-   |                                           this parameter and the return type are declared with different lifetimes...
+   |                                           |                     ...but data from `b` is held across an await point here
+   |                                           |                     this `async fn` implicitly returns an `impl Future<Output = impl Trait<'a>>`
+   |                                           this parameter and the returned future are declared with different lifetimes...
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-76547.nll.stderr
+++ b/src/test/ui/issues/issue-76547.nll.stderr
@@ -1,0 +1,20 @@
+error: lifetime may not live long enough
+  --> $DIR/issue-76547.rs:19:14
+   |
+LL | async fn fut(bufs: &mut [&mut [u8]]) {
+   |              ^^^^  -     - let's call the lifetime of this reference `'2`
+   |              |     |
+   |              |     let's call the lifetime of this reference `'1`
+   |              assignment requires that `'1` must outlive `'2`
+
+error: lifetime may not live long enough
+  --> $DIR/issue-76547.rs:33:15
+   |
+LL | async fn fut2(bufs: &mut [&mut [u8]]) -> i32 {
+   |               ^^^^  -     - let's call the lifetime of this reference `'2`
+   |               |     |
+   |               |     let's call the lifetime of this reference `'1`
+   |               assignment requires that `'1` must outlive `'2`
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/issues/issue-76547.rs
+++ b/src/test/ui/issues/issue-76547.rs
@@ -1,0 +1,38 @@
+// Test for for diagnostic improvement issue #76547
+// edition:2018
+
+use std::{
+    future::Future,
+    task::{Context, Poll}
+};
+use std::pin::Pin;
+
+pub struct ListFut<'a>(&'a mut [&'a mut [u8]]);
+impl<'a> Future for ListFut<'a> {
+    type Output = ();
+
+    fn poll(self: Pin<&mut Self>, _cx: &mut Context) -> Poll<Self::Output> {
+        unimplemented!()
+    }
+}
+
+async fn fut(bufs: &mut [&mut [u8]]) {
+    ListFut(bufs).await
+    //~^ ERROR lifetime mismatch
+}
+
+pub struct ListFut2<'a>(&'a mut [&'a mut [u8]]);
+impl<'a> Future for ListFut2<'a> {
+    type Output = i32;
+
+    fn poll(self: Pin<&mut Self>, _cx: &mut Context) -> Poll<Self::Output> {
+        unimplemented!()
+    }
+}
+
+async fn fut2(bufs: &mut [&mut [u8]]) -> i32 {
+    ListFut2(bufs).await
+    //~^ ERROR lifetime mismatch
+}
+
+fn main() {}

--- a/src/test/ui/issues/issue-76547.rs
+++ b/src/test/ui/issues/issue-76547.rs
@@ -1,4 +1,4 @@
-// Test for for diagnostic improvement issue #76547
+// Test for diagnostic improvement issue #76547
 // edition:2018
 
 use std::{

--- a/src/test/ui/issues/issue-76547.stderr
+++ b/src/test/ui/issues/issue-76547.stderr
@@ -1,0 +1,25 @@
+error[E0623]: lifetime mismatch
+  --> $DIR/issue-76547.rs:20:13
+   |
+LL | async fn fut(bufs: &mut [&mut [u8]]) {
+   |                          ---------   -
+   |                          |           |
+   |                          |           this `async fn` implicitly returns an `impl Future<Output = ()>`
+   |                          this parameter and the returned future are declared with different lifetimes...
+LL |     ListFut(bufs).await
+   |             ^^^^ ...but data from `bufs` is held across an await point here
+
+error[E0623]: lifetime mismatch
+  --> $DIR/issue-76547.rs:34:14
+   |
+LL | async fn fut2(bufs: &mut [&mut [u8]]) -> i32 {
+   |                           ---------      ---
+   |                           |              |
+   |                           |              this `async fn` implicitly returns an `impl Future<Output = i32>`
+   |                           this parameter and the returned future are declared with different lifetimes...
+LL |     ListFut2(bufs).await
+   |              ^^^^ ...but data from `bufs` is held across an await point here
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/self/arbitrary_self_types_pin_lifetime_mismatch-async.stderr
+++ b/src/test/ui/self/arbitrary_self_types_pin_lifetime_mismatch-async.stderr
@@ -2,25 +2,28 @@ error[E0623]: lifetime mismatch
   --> $DIR/arbitrary_self_types_pin_lifetime_mismatch-async.rs:8:52
    |
 LL |     async fn a(self: Pin<&Foo>, f: &Foo) -> &Foo { f }
-   |                          ----               ----   ^ ...but data from `f` is returned here
-   |                          |
-   |                          this parameter and the return type are declared with different lifetimes...
+   |                          ----               ----   ^ ...but data from `f` is held across an await point here
+   |                          |                  |
+   |                          |                  this `async fn` implicitly returns an `impl Future<Output = &Foo>`
+   |                          this parameter and the returned future are declared with different lifetimes...
 
 error[E0623]: lifetime mismatch
   --> $DIR/arbitrary_self_types_pin_lifetime_mismatch-async.rs:11:82
    |
 LL |     async fn c(self: Pin<&Self>, f: &Foo, g: &Foo) -> (Pin<&Foo>, &Foo) { (self, f) }
-   |                          -----                        -----------------          ^ ...but data from `f` is returned here
-   |                          |
-   |                          this parameter and the return type are declared with different lifetimes...
+   |                          -----                        -----------------          ^ ...but data from `f` is held across an await point here
+   |                          |                            |
+   |                          |                            this `async fn` implicitly returns an `impl Future<Output = (Pin<&Foo>, &Foo)>`
+   |                          this parameter and the returned future are declared with different lifetimes...
 
 error[E0623]: lifetime mismatch
   --> $DIR/arbitrary_self_types_pin_lifetime_mismatch-async.rs:17:64
    |
 LL |     async fn bar<'a>(self: Alias<&Self>, arg: &'a ()) -> &() { arg }
-   |                                  -----                   ---   ^^^ ...but data from `arg` is returned here
-   |                                  |
-   |                                  this parameter and the return type are declared with different lifetimes...
+   |                                  -----                   ---   ^^^ ...but data from `arg` is held across an await point here
+   |                                  |                       |
+   |                                  |                       this `async fn` implicitly returns an `impl Future<Output = &()>`
+   |                                  this parameter and the returned future are declared with different lifetimes...
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/self/elision/lt-ref-self-async.stderr
+++ b/src/test/ui/self/elision/lt-ref-self-async.stderr
@@ -3,60 +3,66 @@ error[E0623]: lifetime mismatch
    |
 LL |     async fn ref_self(&self, f: &u32) -> &u32 {
    |                       -----              ----
-   |                       |
-   |                       this parameter and the return type are declared with different lifetimes...
+   |                       |                  |
+   |                       |                  this `async fn` implicitly returns an `impl Future<Output = &u32>`
+   |                       this parameter and the returned future are declared with different lifetimes...
 LL |         f
-   |         ^ ...but data from `f` is returned here
+   |         ^ ...but data from `f` is held across an await point here
 
 error[E0623]: lifetime mismatch
   --> $DIR/lt-ref-self-async.rs:19:9
    |
 LL |     async fn ref_Self(self: &Self, f: &u32) -> &u32 {
    |                             -----              ----
-   |                             |
-   |                             this parameter and the return type are declared with different lifetimes...
+   |                             |                  |
+   |                             |                  this `async fn` implicitly returns an `impl Future<Output = &u32>`
+   |                             this parameter and the returned future are declared with different lifetimes...
 LL |         f
-   |         ^ ...but data from `f` is returned here
+   |         ^ ...but data from `f` is held across an await point here
 
 error[E0623]: lifetime mismatch
   --> $DIR/lt-ref-self-async.rs:23:9
    |
 LL |     async fn box_ref_Self(self: Box<&Self>, f: &u32) -> &u32 {
    |                                     -----               ----
-   |                                     |
-   |                                     this parameter and the return type are declared with different lifetimes...
+   |                                     |                   |
+   |                                     |                   this `async fn` implicitly returns an `impl Future<Output = &u32>`
+   |                                     this parameter and the returned future are declared with different lifetimes...
 LL |         f
-   |         ^ ...but data from `f` is returned here
+   |         ^ ...but data from `f` is held across an await point here
 
 error[E0623]: lifetime mismatch
   --> $DIR/lt-ref-self-async.rs:27:9
    |
 LL |     async fn pin_ref_Self(self: Pin<&Self>, f: &u32) -> &u32 {
    |                                     -----               ----
-   |                                     |
-   |                                     this parameter and the return type are declared with different lifetimes...
+   |                                     |                   |
+   |                                     |                   this `async fn` implicitly returns an `impl Future<Output = &u32>`
+   |                                     this parameter and the returned future are declared with different lifetimes...
 LL |         f
-   |         ^ ...but data from `f` is returned here
+   |         ^ ...but data from `f` is held across an await point here
 
 error[E0623]: lifetime mismatch
   --> $DIR/lt-ref-self-async.rs:31:9
    |
 LL |     async fn box_box_ref_Self(self: Box<Box<&Self>>, f: &u32) -> &u32 {
    |                                             -----                ----
-   |                                             |
-   |                                             this parameter and the return type are declared with different lifetimes...
+   |                                             |                    |
+   |                                             |                    this `async fn` implicitly returns an `impl Future<Output = &u32>`
+   |                                             this parameter and the returned future are declared with different lifetimes...
 LL |         f
-   |         ^ ...but data from `f` is returned here
+   |         ^ ...but data from `f` is held across an await point here
 
 error[E0623]: lifetime mismatch
   --> $DIR/lt-ref-self-async.rs:35:9
    |
 LL |     async fn box_pin_Self(self: Box<Pin<&Self>>, f: &u32) -> &u32 {
    |                                         -----                ----
-   |                                         |
-   |                                         this parameter and the return type are declared with different lifetimes...
+   |                                         |                    |
+   |                                         |                    this `async fn` implicitly returns an `impl Future<Output = &u32>`
+   |                                         this parameter and the returned future are declared with different lifetimes...
 LL |         f
-   |         ^ ...but data from `f` is returned here
+   |         ^ ...but data from `f` is held across an await point here
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/self/elision/ref-mut-self-async.stderr
+++ b/src/test/ui/self/elision/ref-mut-self-async.stderr
@@ -3,60 +3,66 @@ error[E0623]: lifetime mismatch
    |
 LL |     async fn ref_self(&mut self, f: &u32) -> &u32 {
    |                       ---------              ----
-   |                       |
-   |                       this parameter and the return type are declared with different lifetimes...
+   |                       |                      |
+   |                       |                      this `async fn` implicitly returns an `impl Future<Output = &u32>`
+   |                       this parameter and the returned future are declared with different lifetimes...
 LL |         f
-   |         ^ ...but data from `f` is returned here
+   |         ^ ...but data from `f` is held across an await point here
 
 error[E0623]: lifetime mismatch
   --> $DIR/ref-mut-self-async.rs:19:9
    |
 LL |     async fn ref_Self(self: &mut Self, f: &u32) -> &u32 {
    |                             ---------              ----
-   |                             |
-   |                             this parameter and the return type are declared with different lifetimes...
+   |                             |                      |
+   |                             |                      this `async fn` implicitly returns an `impl Future<Output = &u32>`
+   |                             this parameter and the returned future are declared with different lifetimes...
 LL |         f
-   |         ^ ...but data from `f` is returned here
+   |         ^ ...but data from `f` is held across an await point here
 
 error[E0623]: lifetime mismatch
   --> $DIR/ref-mut-self-async.rs:23:9
    |
 LL |     async fn box_ref_Self(self: Box<&mut Self>, f: &u32) -> &u32 {
    |                                     ---------               ----
-   |                                     |
-   |                                     this parameter and the return type are declared with different lifetimes...
+   |                                     |                       |
+   |                                     |                       this `async fn` implicitly returns an `impl Future<Output = &u32>`
+   |                                     this parameter and the returned future are declared with different lifetimes...
 LL |         f
-   |         ^ ...but data from `f` is returned here
+   |         ^ ...but data from `f` is held across an await point here
 
 error[E0623]: lifetime mismatch
   --> $DIR/ref-mut-self-async.rs:27:9
    |
 LL |     async fn pin_ref_Self(self: Pin<&mut Self>, f: &u32) -> &u32 {
    |                                     ---------               ----
-   |                                     |
-   |                                     this parameter and the return type are declared with different lifetimes...
+   |                                     |                       |
+   |                                     |                       this `async fn` implicitly returns an `impl Future<Output = &u32>`
+   |                                     this parameter and the returned future are declared with different lifetimes...
 LL |         f
-   |         ^ ...but data from `f` is returned here
+   |         ^ ...but data from `f` is held across an await point here
 
 error[E0623]: lifetime mismatch
   --> $DIR/ref-mut-self-async.rs:31:9
    |
 LL |     async fn box_box_ref_Self(self: Box<Box<&mut Self>>, f: &u32) -> &u32 {
    |                                             ---------                ----
-   |                                             |
-   |                                             this parameter and the return type are declared with different lifetimes...
+   |                                             |                        |
+   |                                             |                        this `async fn` implicitly returns an `impl Future<Output = &u32>`
+   |                                             this parameter and the returned future are declared with different lifetimes...
 LL |         f
-   |         ^ ...but data from `f` is returned here
+   |         ^ ...but data from `f` is held across an await point here
 
 error[E0623]: lifetime mismatch
   --> $DIR/ref-mut-self-async.rs:35:9
    |
 LL |     async fn box_pin_ref_Self(self: Box<Pin<&mut Self>>, f: &u32) -> &u32 {
    |                                             ---------                ----
-   |                                             |
-   |                                             this parameter and the return type are declared with different lifetimes...
+   |                                             |                        |
+   |                                             |                        this `async fn` implicitly returns an `impl Future<Output = &u32>`
+   |                                             this parameter and the returned future are declared with different lifetimes...
 LL |         f
-   |         ^ ...but data from `f` is returned here
+   |         ^ ...but data from `f` is held across an await point here
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/self/elision/ref-mut-struct-async.stderr
+++ b/src/test/ui/self/elision/ref-mut-struct-async.stderr
@@ -3,50 +3,55 @@ error[E0623]: lifetime mismatch
    |
 LL |     async fn ref_Struct(self: &mut Struct, f: &u32) -> &u32 {
    |                               -----------              ----
-   |                               |
-   |                               this parameter and the return type are declared with different lifetimes...
+   |                               |                        |
+   |                               |                        this `async fn` implicitly returns an `impl Future<Output = &u32>`
+   |                               this parameter and the returned future are declared with different lifetimes...
 LL |         f
-   |         ^ ...but data from `f` is returned here
+   |         ^ ...but data from `f` is held across an await point here
 
 error[E0623]: lifetime mismatch
   --> $DIR/ref-mut-struct-async.rs:17:9
    |
 LL |     async fn box_ref_Struct(self: Box<&mut Struct>, f: &u32) -> &u32 {
    |                                       -----------               ----
-   |                                       |
-   |                                       this parameter and the return type are declared with different lifetimes...
+   |                                       |                         |
+   |                                       |                         this `async fn` implicitly returns an `impl Future<Output = &u32>`
+   |                                       this parameter and the returned future are declared with different lifetimes...
 LL |         f
-   |         ^ ...but data from `f` is returned here
+   |         ^ ...but data from `f` is held across an await point here
 
 error[E0623]: lifetime mismatch
   --> $DIR/ref-mut-struct-async.rs:21:9
    |
 LL |     async fn pin_ref_Struct(self: Pin<&mut Struct>, f: &u32) -> &u32 {
    |                                       -----------               ----
-   |                                       |
-   |                                       this parameter and the return type are declared with different lifetimes...
+   |                                       |                         |
+   |                                       |                         this `async fn` implicitly returns an `impl Future<Output = &u32>`
+   |                                       this parameter and the returned future are declared with different lifetimes...
 LL |         f
-   |         ^ ...but data from `f` is returned here
+   |         ^ ...but data from `f` is held across an await point here
 
 error[E0623]: lifetime mismatch
   --> $DIR/ref-mut-struct-async.rs:25:9
    |
 LL |     async fn box_box_ref_Struct(self: Box<Box<&mut Struct>>, f: &u32) -> &u32 {
    |                                               -----------                ----
-   |                                               |
-   |                                               this parameter and the return type are declared with different lifetimes...
+   |                                               |                          |
+   |                                               |                          this `async fn` implicitly returns an `impl Future<Output = &u32>`
+   |                                               this parameter and the returned future are declared with different lifetimes...
 LL |         f
-   |         ^ ...but data from `f` is returned here
+   |         ^ ...but data from `f` is held across an await point here
 
 error[E0623]: lifetime mismatch
   --> $DIR/ref-mut-struct-async.rs:29:9
    |
 LL |     async fn box_pin_ref_Struct(self: Box<Pin<&mut Struct>>, f: &u32) -> &u32 {
    |                                               -----------                ----
-   |                                               |
-   |                                               this parameter and the return type are declared with different lifetimes...
+   |                                               |                          |
+   |                                               |                          this `async fn` implicitly returns an `impl Future<Output = &u32>`
+   |                                               this parameter and the returned future are declared with different lifetimes...
 LL |         f
-   |         ^ ...but data from `f` is returned here
+   |         ^ ...but data from `f` is held across an await point here
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/self/elision/ref-self-async.stderr
+++ b/src/test/ui/self/elision/ref-self-async.stderr
@@ -3,70 +3,77 @@ error[E0623]: lifetime mismatch
    |
 LL |     async fn ref_self(&self, f: &u32) -> &u32 {
    |                       -----              ----
-   |                       |
-   |                       this parameter and the return type are declared with different lifetimes...
+   |                       |                  |
+   |                       |                  this `async fn` implicitly returns an `impl Future<Output = &u32>`
+   |                       this parameter and the returned future are declared with different lifetimes...
 LL |         f
-   |         ^ ...but data from `f` is returned here
+   |         ^ ...but data from `f` is held across an await point here
 
 error[E0623]: lifetime mismatch
   --> $DIR/ref-self-async.rs:29:9
    |
 LL |     async fn ref_Self(self: &Self, f: &u32) -> &u32 {
    |                             -----              ----
-   |                             |
-   |                             this parameter and the return type are declared with different lifetimes...
+   |                             |                  |
+   |                             |                  this `async fn` implicitly returns an `impl Future<Output = &u32>`
+   |                             this parameter and the returned future are declared with different lifetimes...
 LL |         f
-   |         ^ ...but data from `f` is returned here
+   |         ^ ...but data from `f` is held across an await point here
 
 error[E0623]: lifetime mismatch
   --> $DIR/ref-self-async.rs:33:9
    |
 LL |     async fn box_ref_Self(self: Box<&Self>, f: &u32) -> &u32 {
    |                                     -----               ----
-   |                                     |
-   |                                     this parameter and the return type are declared with different lifetimes...
+   |                                     |                   |
+   |                                     |                   this `async fn` implicitly returns an `impl Future<Output = &u32>`
+   |                                     this parameter and the returned future are declared with different lifetimes...
 LL |         f
-   |         ^ ...but data from `f` is returned here
+   |         ^ ...but data from `f` is held across an await point here
 
 error[E0623]: lifetime mismatch
   --> $DIR/ref-self-async.rs:37:9
    |
 LL |     async fn pin_ref_Self(self: Pin<&Self>, f: &u32) -> &u32 {
    |                                     -----               ----
-   |                                     |
-   |                                     this parameter and the return type are declared with different lifetimes...
+   |                                     |                   |
+   |                                     |                   this `async fn` implicitly returns an `impl Future<Output = &u32>`
+   |                                     this parameter and the returned future are declared with different lifetimes...
 LL |         f
-   |         ^ ...but data from `f` is returned here
+   |         ^ ...but data from `f` is held across an await point here
 
 error[E0623]: lifetime mismatch
   --> $DIR/ref-self-async.rs:41:9
    |
 LL |     async fn box_box_ref_Self(self: Box<Box<&Self>>, f: &u32) -> &u32 {
    |                                             -----                ----
-   |                                             |
-   |                                             this parameter and the return type are declared with different lifetimes...
+   |                                             |                    |
+   |                                             |                    this `async fn` implicitly returns an `impl Future<Output = &u32>`
+   |                                             this parameter and the returned future are declared with different lifetimes...
 LL |         f
-   |         ^ ...but data from `f` is returned here
+   |         ^ ...but data from `f` is held across an await point here
 
 error[E0623]: lifetime mismatch
   --> $DIR/ref-self-async.rs:45:9
    |
 LL |     async fn box_pin_ref_Self(self: Box<Pin<&Self>>, f: &u32) -> &u32 {
    |                                             -----                ----
-   |                                             |
-   |                                             this parameter and the return type are declared with different lifetimes...
+   |                                             |                    |
+   |                                             |                    this `async fn` implicitly returns an `impl Future<Output = &u32>`
+   |                                             this parameter and the returned future are declared with different lifetimes...
 LL |         f
-   |         ^ ...but data from `f` is returned here
+   |         ^ ...but data from `f` is held across an await point here
 
 error[E0623]: lifetime mismatch
   --> $DIR/ref-self-async.rs:49:9
    |
 LL |     async fn wrap_ref_Self_Self(self: Wrap<&Self, Self>, f: &u8) -> &u8 {
    |                                            -----                    ---
-   |                                            |
-   |                                            this parameter and the return type are declared with different lifetimes...
+   |                                            |                        |
+   |                                            |                        this `async fn` implicitly returns an `impl Future<Output = &u8>`
+   |                                            this parameter and the returned future are declared with different lifetimes...
 LL |         f
-   |         ^ ...but data from `f` is returned here
+   |         ^ ...but data from `f` is held across an await point here
 
 error: aborting due to 7 previous errors
 

--- a/src/test/ui/self/elision/ref-struct-async.stderr
+++ b/src/test/ui/self/elision/ref-struct-async.stderr
@@ -3,50 +3,55 @@ error[E0623]: lifetime mismatch
    |
 LL |     async fn ref_Struct(self: &Struct, f: &u32) -> &u32 {
    |                               -------              ----
-   |                               |
-   |                               this parameter and the return type are declared with different lifetimes...
+   |                               |                    |
+   |                               |                    this `async fn` implicitly returns an `impl Future<Output = &u32>`
+   |                               this parameter and the returned future are declared with different lifetimes...
 LL |         f
-   |         ^ ...but data from `f` is returned here
+   |         ^ ...but data from `f` is held across an await point here
 
 error[E0623]: lifetime mismatch
   --> $DIR/ref-struct-async.rs:17:9
    |
 LL |     async fn box_ref_Struct(self: Box<&Struct>, f: &u32) -> &u32 {
    |                                       -------               ----
-   |                                       |
-   |                                       this parameter and the return type are declared with different lifetimes...
+   |                                       |                     |
+   |                                       |                     this `async fn` implicitly returns an `impl Future<Output = &u32>`
+   |                                       this parameter and the returned future are declared with different lifetimes...
 LL |         f
-   |         ^ ...but data from `f` is returned here
+   |         ^ ...but data from `f` is held across an await point here
 
 error[E0623]: lifetime mismatch
   --> $DIR/ref-struct-async.rs:21:9
    |
 LL |     async fn pin_ref_Struct(self: Pin<&Struct>, f: &u32) -> &u32 {
    |                                       -------               ----
-   |                                       |
-   |                                       this parameter and the return type are declared with different lifetimes...
+   |                                       |                     |
+   |                                       |                     this `async fn` implicitly returns an `impl Future<Output = &u32>`
+   |                                       this parameter and the returned future are declared with different lifetimes...
 LL |         f
-   |         ^ ...but data from `f` is returned here
+   |         ^ ...but data from `f` is held across an await point here
 
 error[E0623]: lifetime mismatch
   --> $DIR/ref-struct-async.rs:25:9
    |
 LL |     async fn box_box_ref_Struct(self: Box<Box<&Struct>>, f: &u32) -> &u32 {
    |                                               -------                ----
-   |                                               |
-   |                                               this parameter and the return type are declared with different lifetimes...
+   |                                               |                      |
+   |                                               |                      this `async fn` implicitly returns an `impl Future<Output = &u32>`
+   |                                               this parameter and the returned future are declared with different lifetimes...
 LL |         f
-   |         ^ ...but data from `f` is returned here
+   |         ^ ...but data from `f` is held across an await point here
 
 error[E0623]: lifetime mismatch
   --> $DIR/ref-struct-async.rs:29:9
    |
 LL |     async fn box_pin_Struct(self: Box<Pin<&Struct>>, f: &u32) -> &u32 {
    |                                           -------                ----
-   |                                           |
-   |                                           this parameter and the return type are declared with different lifetimes...
+   |                                           |                      |
+   |                                           |                      this `async fn` implicitly returns an `impl Future<Output = &u32>`
+   |                                           this parameter and the returned future are declared with different lifetimes...
 LL |         f
-   |         ^ ...but data from `f` is returned here
+   |         ^ ...but data from `f` is held across an await point here
 
 error: aborting due to 5 previous errors
 


### PR DESCRIPTION
see #76547

This is *likely* not the ONLY place that this happens to be unclear, but we can move this fn to rustc_middle or something like that and reuse it if need be, to apply it to more diagnostics

One outstanding question I have is, if the fn returns (), should I make the message more clear (what about `fn f()` vs `fn f() -> ()`, can you tell those apart in the hir?) 


R? @tmandry 

@rustbot modify labels +A-diagnostics +T-compiler