### PR TITLE
Strip a single leading tab when rendering dataflow diffs

### DIFF
--- a/compiler/rustc_mir/src/dataflow/framework/graphviz.rs
+++ b/compiler/rustc_mir/src/dataflow/framework/graphviz.rs
@@ -578,7 +578,7 @@ where
         return String::new();
     }
 
-    let re = Regex::new("\u{001f}([+-])").unwrap();
+    let re = Regex::new("\t?\u{001f}([+-])").unwrap();
 
     let raw_diff = format!("{:#?}", DebugDiffWithAdapter { new, old, ctxt });
 


### PR DESCRIPTION
The `fmt_diff_with` formatter uses a tab to separate additions from subtractions. Strip it when rendering those diffs on separate lines.

r? @Mark-Simulacrum (since you're speedy)