### PR TITLE
Don't force graphviz diagrams to render in Courier

### DIFF
--- a/compiler/rustc_graphviz/src/lib.rs
+++ b/compiler/rustc_graphviz/src/lib.rs
@@ -634,7 +634,7 @@ where
     let mut graph_attrs = Vec::new();
     let mut content_attrs = Vec::new();
     if options.contains(&RenderOption::Monospace) {
-        let font = r#"fontname="Courier, monospace""#;
+        let font = r#"fontname="monospace""#;
         graph_attrs.push(font);
         content_attrs.push(font);
     };

--- a/compiler/rustc_mir/src/util/graphviz.rs
+++ b/compiler/rustc_mir/src/util/graphviz.rs
@@ -55,7 +55,7 @@ where
     writeln!(w, "{} {}Mir_{} {{", kind, cluster, def_name)?;
 
     // Global graph properties
-    let font = r#"fontname="Courier, monospace""#;
+    let font = r#"fontname="monospace""#;
     let mut graph_attrs = vec![font];
     let mut content_attrs = vec![font];
 

--- a/src/test/mir-opt/graphviz.main.mir_map.0.dot
+++ b/src/test/mir-opt/graphviz.main.mir_map.0.dot
@@ -1,7 +1,7 @@
 digraph Mir_0_3 {
-    graph [fontname="Courier, monospace"];
-    node [fontname="Courier, monospace"];
-    edge [fontname="Courier, monospace"];
+    graph [fontname="monospace"];
+    node [fontname="monospace"];
+    edge [fontname="monospace"];
     label=<fn main() -&gt; ()<br align="left"/>>;
     bb0__0_3 [shape="none", label=<<table border="0" cellborder="1" cellspacing="0"><tr><td bgcolor="gray" align="center" colspan="1">0</td></tr><tr><td align="left" balign="left">_0 = const ()<br/></td></tr><tr><td align="left">goto</td></tr></table>>];
     bb1__0_3 [shape="none", label=<<table border="0" cellborder="1" cellspacing="0"><tr><td bgcolor="gray" align="center" colspan="1">1</td></tr><tr><td align="left">resume</td></tr></table>>];


### PR DESCRIPTION
I went to render a graphviz diagram for rust-lang/rustc-dev-guide#882, and found that they are now much harder to read on my 13 inch laptop monitor. Courier is very thin (for [interesting historical reasons](https://en.wikipedia.org/wiki/Courier_(typeface)#Courier_New)), so I'm not happy that we are overriding the system monospace font with it.

@richkadel Could you just use a VSCode extension that handles `monospace` correctly? [This one](https://marketplace.visualstudio.com/items?itemName=EFanZh.graphviz-preview) works just fine. I'm surprised such a simple feature is broken, and I'd prefer not to bend over backwards to support its absence.

r? @richkadel (We're probably the only two people who care ATM)