### PR TITLE
Rename `core::future::poll_fn` to `core::future::from_fn`

### DIFF
--- a/library/core/src/future/from_fn.rs
+++ b/library/core/src/future/from_fn.rs
@@ -10,49 +10,48 @@ use crate::task::{Context, Poll};
 /// # Examples
 ///
 /// ```
-/// #![feature(future_poll_fn)]
+/// #![feature(future_from_fn)]
 /// # async fn run() {
-/// use core::future::poll_fn;
+/// use core::future;
 /// use core::task::{Context, Poll};
 ///
-/// fn read_line(_cx: &mut Context<'_>) -> Poll<String> {
+/// let fut = future::from_fn(|_cx: &mut Context<'_>| -> Poll<String> {
 ///     Poll::Ready("Hello, World!".into())
-/// }
+/// });
 ///
-/// let read_future = poll_fn(read_line);
-/// assert_eq!(read_future.await, "Hello, World!".to_owned());
+/// assert_eq!(fut.await, "Hello, World!".to_owned());
 /// # };
 /// ```
-#[unstable(feature = "future_poll_fn", issue = "72302")]
-pub fn poll_fn<T, F>(f: F) -> PollFn<F>
+#[unstable(feature = "future_from_fn", issue = "72302")]
+pub fn from_fn<T, F>(f: F) -> FromFn<F>
 where
     F: FnMut(&mut Context<'_>) -> Poll<T>,
 {
-    PollFn { f }
+    FromFn { f }
 }
 
 /// A Future that wraps a function returning `Poll`.
 ///
-/// This `struct` is created by [`poll_fn()`]. See its
+/// This `struct` is created by [`from_fn()`]. See its
 /// documentation for more.
 #[must_use = "futures do nothing unless you `.await` or poll them"]
-#[unstable(feature = "future_poll_fn", issue = "72302")]
-pub struct PollFn<F> {
+#[unstable(feature = "future_from_fn", issue = "72302")]
+pub struct FromFn<F> {
     f: F,
 }
 
-#[unstable(feature = "future_poll_fn", issue = "72302")]
-impl<F> Unpin for PollFn<F> {}
+#[unstable(feature = "future_from_fn", issue = "72302")]
+impl<F> Unpin for FromFn<F> {}
 
-#[unstable(feature = "future_poll_fn", issue = "72302")]
-impl<F> fmt::Debug for PollFn<F> {
+#[unstable(feature = "future_from_fn", issue = "72302")]
+impl<F> fmt::Debug for FromFn<F> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("PollFn").finish()
+        f.debug_struct("FromFn").finish()
     }
 }
 
-#[unstable(feature = "future_poll_fn", issue = "72302")]
-impl<T, F> Future for PollFn<F>
+#[unstable(feature = "future_from_fn", issue = "72302")]
+impl<T, F> Future for FromFn<F>
 where
     F: FnMut(&mut Context<'_>) -> Poll<T>,
 {

--- a/library/core/src/future/mod.rs
+++ b/library/core/src/future/mod.rs
@@ -9,10 +9,10 @@ use crate::{
     task::{Context, Poll},
 };
 
+mod from_fn;
 mod future;
 mod into_future;
 mod pending;
-mod poll_fn;
 mod ready;
 
 #[stable(feature = "futures_api", since = "1.36.0")]
@@ -26,8 +26,8 @@ pub use pending::{pending, Pending};
 #[stable(feature = "future_readiness_fns", since = "1.48.0")]
 pub use ready::{ready, Ready};
 
-#[unstable(feature = "future_poll_fn", issue = "72302")]
-pub use poll_fn::{poll_fn, PollFn};
+#[unstable(feature = "future_from_fn", issue = "72302")]
+pub use from_fn::{from_fn, FromFn};
 
 /// This type is needed because:
 ///

--- a/library/std/src/future.rs
+++ b/library/std/src/future.rs
@@ -13,5 +13,9 @@ pub use core::future::{from_generator, get_context, ResumeTy};
 pub use core::future::{pending, ready, Pending, Ready};
 
 #[doc(inline)]
+#[unstable(feature = "future_from_fn", issue = "72302")]
+pub use core::future::{from_fn, FromFn};
+
+#[doc(inline)]
 #[unstable(feature = "into_future", issue = "67644")]
 pub use core::future::IntoFuture;

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -258,6 +258,7 @@
 #![feature(external_doc)]
 #![feature(fn_traits)]
 #![feature(format_args_nl)]
+#![feature(future_from_fn)]
 #![feature(gen_future)]
 #![feature(generator_trait)]
 #![feature(global_asm)]


### PR DESCRIPTION
Tracking issue: https://github.com/rust-lang/rust/issues/72302.

This patch renames `core::future::poll_fn` to `core::future::from_fn` as suggested by @Koxiaet in https://github.com/rust-lang/rust/pull/72303#issuecomment-632671212. This makes the API more consistent with similar functions already in the stdlib, for example [`std::iter::from_fn`](https://doc.rust-lang.org/std/iter/fn.from_fn.html), and removes some awkwardness from the naming (I remember being confused by what `poll_fn` meant when I first encountered it).

## Drawbacks

The main rationale not to name this `core::future::from_fn` is that the `futures` crate also exposes [`futures::future::lazy`](https://docs.rs/futures/0.3.5/futures/future/fn.lazy.html) which also takes a closure. That would mean we'd have two functions that take a closure at top level. However the stdlib exposes `std::iter::once`, which exists next to `std::iter::from_fn` with both functions creating an iterator from a function; meaning there would be precedent for having both functions in the same hierarchy.

However I don't think `futures::future::lazy` is a good fit for the stdlib, and I'd be surprised if we saw it stabilized. It was designed before we had `async/.await` in the language, as a convenience function to create "lazy values" . But most of its uses have been replaced by async blocks since:

```rust
// lazy
use std::future::lazy;
let fut = lazy(|_| "world");
println!("hello {}", fut.await);

// async blocks
let fut = async { "world" };
println!("hello {}", fut.await);
```
With the expected addition of async closures to the language, it's likely the uses for `futures::future::lazy` will only decrease further. Async closures are expected to be able to take closures, take borrows as arguments, and support `.await` inside of the closure body. Which makes it seem quite likely we'll only ever expose a single "create a future from a closure" method in the `core::future` hierarchy.

---

cc/ @rust-lang/wg-async-foundations 