### PR TITLE
Give a better error message when x.py uses the wrong stage for CI

### DIFF
--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -616,7 +616,13 @@ impl Config {
                 | Subcommand::Build { .. }
                 | Subcommand::Bench { .. }
                 | Subcommand::Dist { .. }
-                | Subcommand::Install { .. } => assert_eq!(config.stage, 2),
+                | Subcommand::Install { .. } => {
+                    assert_eq!(
+                        config.stage, 2,
+                        "x.py should be run with `--stage 2` on CI, but was run with `--stage {}`",
+                        config.stage,
+                    );
+                }
                 Subcommand::Clean { .. }
                 | Subcommand::Check { .. }
                 | Subcommand::Clippy { .. }


### PR DESCRIPTION
r? @shepmaster