### PR TITLE
Fix cross compiling dist/build invocations

### DIFF
--- a/src/bootstrap/builder/tests.rs
+++ b/src/bootstrap/builder/tests.rs
@@ -91,6 +91,54 @@ mod defaults {
     }
 
     #[test]
+    fn build_cross_compile() {
+        let config = Config { stage: 1, ..configure("build", &["B"], &["B"]) };
+        let build = Build::new(config);
+        let mut builder = Builder::new(&build);
+        builder.run_step_descriptions(&Builder::get_step_descriptions(Kind::Build), &[]);
+
+        let a = TargetSelection::from_user("A");
+        let b = TargetSelection::from_user("B");
+
+        // Ideally, this build wouldn't actually have `target: a`
+        // rustdoc/rustcc/std here (the user only requested a host=B build, so
+        // there's not really a need for us to build for target A in this case
+        // (since we're producing stage 1 libraries/binaries).  But currently
+        // rustbuild is just a bit buggy here; this should be fixed though.
+        assert_eq!(
+            first(builder.cache.all::<compile::Std>()),
+            &[
+                compile::Std { compiler: Compiler { host: a, stage: 0 }, target: a },
+                compile::Std { compiler: Compiler { host: a, stage: 1 }, target: a },
+                compile::Std { compiler: Compiler { host: a, stage: 0 }, target: b },
+                compile::Std { compiler: Compiler { host: a, stage: 1 }, target: b },
+            ]
+        );
+        assert_eq!(
+            first(builder.cache.all::<compile::Assemble>()),
+            &[
+                compile::Assemble { target_compiler: Compiler { host: a, stage: 0 } },
+                compile::Assemble { target_compiler: Compiler { host: a, stage: 1 } },
+                compile::Assemble { target_compiler: Compiler { host: b, stage: 1 } },
+            ]
+        );
+        assert_eq!(
+            first(builder.cache.all::<tool::Rustdoc>()),
+            &[
+                tool::Rustdoc { compiler: Compiler { host: a, stage: 1 } },
+                tool::Rustdoc { compiler: Compiler { host: b, stage: 1 } },
+            ],
+        );
+        assert_eq!(
+            first(builder.cache.all::<compile::Rustc>()),
+            &[
+                compile::Rustc { compiler: Compiler { host: a, stage: 0 }, target: a },
+                compile::Rustc { compiler: Compiler { host: a, stage: 0 }, target: b },
+            ]
+        );
+    }
+
+    #[test]
     fn doc_default() {
         let mut config = configure("doc", &[], &[]);
         config.compiler_docs = true;

--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -752,6 +752,7 @@ impl Step for RustcBook {
         let out_listing = out_base.join("src/lints");
         builder.cp_r(&builder.src.join("src/doc/rustc"), &out_base);
         builder.info(&format!("Generating lint docs ({})", self.target));
+
         let rustc = builder.rustc(self.compiler);
         // The tool runs `rustc` for extracting output examples, so it needs a
         // functional sysroot.
@@ -762,7 +763,8 @@ impl Step for RustcBook {
         cmd.arg("--out");
         cmd.arg(&out_listing);
         cmd.arg("--rustc");
-        cmd.arg(rustc);
+        cmd.arg(&rustc);
+        cmd.arg("--rustc-target").arg(&self.target.rustc_target_arg());
         if builder.config.verbose() {
             cmd.arg("--verbose");
         }

--- a/src/bootstrap/tool.rs
+++ b/src/bootstrap/tool.rs
@@ -471,7 +471,11 @@ impl Step for Rustdoc {
 
     fn make_run(run: RunConfig<'_>) {
         run.builder.ensure(Rustdoc {
-            compiler: run.builder.compiler(run.builder.top_stage, run.build_triple()),
+            // Note: this is somewhat unique in that we actually want a *target*
+            // compiler here, because rustdoc *is* a compiler. We won't be using
+            // this as the compiler to build with, but rather this is "what
+            // compiler are we producing"?
+            compiler: run.builder.compiler(run.builder.top_stage, run.target),
         });
     }
 

--- a/src/tools/lint-docs/src/groups.rs
+++ b/src/tools/lint-docs/src/groups.rs
@@ -18,10 +18,10 @@ static GROUP_DESCRIPTIONS: &[(&str, &str)] = &[
 /// Updates the documentation of lint groups.
 pub(crate) fn generate_group_docs(
     lints: &[Lint],
-    rustc_path: &Path,
+    rustc: crate::Rustc<'_>,
     out_path: &Path,
 ) -> Result<(), Box<dyn Error>> {
-    let groups = collect_groups(rustc_path)?;
+    let groups = collect_groups(rustc)?;
     let groups_path = out_path.join("groups.md");
     let contents = fs::read_to_string(&groups_path)
         .map_err(|e| format!("could not read {}: {}", groups_path.display(), e))?;
@@ -36,9 +36,9 @@ pub(crate) fn generate_group_docs(
 type LintGroups = BTreeMap<String, BTreeSet<String>>;
 
 /// Collects the group names from rustc.
-fn collect_groups(rustc: &Path) -> Result<LintGroups, Box<dyn Error>> {
+fn collect_groups(rustc: crate::Rustc<'_>) -> Result<LintGroups, Box<dyn Error>> {
     let mut result = BTreeMap::new();
-    let mut cmd = Command::new(rustc);
+    let mut cmd = Command::new(rustc.path);
     cmd.arg("-Whelp");
     let output = cmd.output().map_err(|e| format!("failed to run command {:?}\n{}", cmd, e))?;
     if !output.status.success() {

--- a/src/tools/lint-docs/src/main.rs
+++ b/src/tools/lint-docs/src/main.rs
@@ -13,6 +13,7 @@ fn doit() -> Result<(), Box<dyn Error>> {
     let mut src_path = None;
     let mut out_path = None;
     let mut rustc_path = None;
+    let mut rustc_target = None;
     let mut verbose = false;
     while let Some(arg) = args.next() {
         match arg.as_str() {
@@ -34,6 +35,12 @@ fn doit() -> Result<(), Box<dyn Error>> {
                     None => return Err("--rustc requires a value".into()),
                 };
             }
+            "--rustc-target" => {
+                rustc_target = match args.next() {
+                    Some(s) => Some(s),
+                    None => return Err("--rustc-target requires a value".into()),
+                };
+            }
             "-v" | "--verbose" => verbose = true,
             s => return Err(format!("unexpected argument `{}`", s).into()),
         }
@@ -47,10 +54,16 @@ fn doit() -> Result<(), Box<dyn Error>> {
     if rustc_path.is_none() {
         return Err("--rustc must be specified to the path of rustc".into());
     }
+    if rustc_target.is_none() {
+        return Err("--rustc-target must be specified to the rustc target".into());
+    }
     lint_docs::extract_lint_docs(
         &src_path.unwrap(),
         &out_path.unwrap(),
-        &rustc_path.unwrap(),
+        lint_docs::Rustc {
+            path: rustc_path.as_deref().unwrap(),
+            target: rustc_target.as_deref().unwrap(),
+        },
         verbose,
     )
 }


### PR DESCRIPTION
I am uncertain why the first commit is not affecting CI. I suspect it's because we pass --disable-docs on most of our cross-compilation builders. The second commit doesn't affect CI because CI runs x.py dist, not x.py build. 

Both commits are standalone; together they should resolve #76733. The first commit doesn't really fix that issue but rather just fixes cross-compiled x.py dist, resolving a bug introduced in #76549.