### PR TITLE
MIR-opt: Generalize &(*_1) optimization to mutable references

### DIFF
--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -649,6 +649,14 @@ impl BorrowKind {
             BorrowKind::Mut { allow_two_phase_borrow } => allow_two_phase_borrow,
         }
     }
+
+    /// Returns the mutability of the borrow
+    pub fn mutability(&self) -> Mutability {
+        match self {
+            BorrowKind::Shared | BorrowKind::Shallow | BorrowKind::Unique => Mutability::Not,
+            BorrowKind::Mut { .. } => Mutability::Mut,
+        }
+    }
 }
 
 ///////////////////////////////////////////////////////////////////////////

--- a/src/test/mir-opt/and_star.opt_immutable.InstCombine.diff
+++ b/src/test/mir-opt/and_star.opt_immutable.InstCombine.diff
@@ -1,0 +1,44 @@
+- // MIR for `opt_immutable` before InstCombine
++ // MIR for `opt_immutable` after InstCombine
+  
+  fn opt_immutable(_1: &[u8]) -> () {
+      debug dst => _1;                     // in scope 0 at $DIR/and_star.rs:7:18: 7:21
+      let mut _0: ();                      // return place in scope 0 at $DIR/and_star.rs:7:30: 7:30
+      let _2: std::option::Option<&u8>;    // in scope 0 at $DIR/and_star.rs:8:5: 8:15
+      let mut _3: &[u8];                   // in scope 0 at $DIR/and_star.rs:8:5: 8:8
+      let mut _6: usize;                   // in scope 0 at $DIR/and_star.rs:8:5: 8:15
+      scope 1 {
+          debug self => _3;                // in scope 1 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
+          debug index => _6;               // in scope 1 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
+          let mut _4: usize;               // in scope 1 at $DIR/and_star.rs:8:5: 8:15
+          let mut _5: &[u8];               // in scope 1 at $DIR/and_star.rs:8:5: 8:15
+      }
+  
+      bb0: {
+          StorageLive(_2);                 // scope 0 at $DIR/and_star.rs:8:5: 8:15
+          StorageLive(_3);                 // scope 0 at $DIR/and_star.rs:8:5: 8:8
+-         _3 = &(*_1);                     // scope 0 at $DIR/and_star.rs:8:5: 8:8
++         _3 = _1;                         // scope 0 at $DIR/and_star.rs:8:5: 8:8
+          StorageLive(_6);                 // scope 0 at $DIR/and_star.rs:8:5: 8:15
+          _6 = const 0_usize;              // scope 0 at $DIR/and_star.rs:8:5: 8:15
+          StorageLive(_4);                 // scope 1 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
+          _4 = move _6;                    // scope 1 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
+          StorageLive(_5);                 // scope 1 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
+          _5 = _3;                         // scope 1 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
+          _2 = <usize as SliceIndex<[u8]>>::get(move _4, move _5) -> bb1; // scope 1 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
+                                           // mir::Constant
+                                           // + span: $SRC_DIR/core/src/slice/mod.rs:LL:COL
+                                           // + literal: Const { ty: for<'r> fn(usize, &'r [u8]) -> std::option::Option<&'r <usize as std::slice::SliceIndex<[u8]>>::Output> {<usize as std::slice::SliceIndex<[u8]>>::get}, val: Value(Scalar(<ZST>)) }
+      }
+  
+      bb1: {
+          StorageDead(_5);                 // scope 1 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
+          StorageDead(_4);                 // scope 1 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
+          StorageDead(_6);                 // scope 0 at $DIR/and_star.rs:8:5: 8:15
+          StorageDead(_3);                 // scope 0 at $DIR/and_star.rs:8:14: 8:15
+          StorageDead(_2);                 // scope 0 at $DIR/and_star.rs:8:15: 8:16
+          _0 = const ();                   // scope 0 at $DIR/and_star.rs:7:30: 9:2
+          return;                          // scope 0 at $DIR/and_star.rs:9:2: 9:2
+      }
+  }
+  

--- a/src/test/mir-opt/and_star.opt_mutable.InstCombine.diff
+++ b/src/test/mir-opt/and_star.opt_mutable.InstCombine.diff
@@ -1,0 +1,43 @@
+- // MIR for `opt_mutable` before InstCombine
++ // MIR for `opt_mutable` after InstCombine
+  
+  fn opt_mutable(_1: &mut [u8]) -> () {
+      debug dst => _1;                     // in scope 0 at $DIR/and_star.rs:2:16: 2:19
+      let mut _0: ();                      // return place in scope 0 at $DIR/and_star.rs:2:32: 2:32
+      let _2: std::option::Option<&mut u8>; // in scope 0 at $DIR/and_star.rs:3:5: 3:19
+      let mut _3: &mut [u8];               // in scope 0 at $DIR/and_star.rs:3:5: 3:8
+      let mut _6: usize;                   // in scope 0 at $DIR/and_star.rs:3:5: 3:19
+      scope 1 {
+          debug self => _3;                // in scope 1 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
+          debug index => _6;               // in scope 1 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
+          let mut _4: usize;               // in scope 1 at $DIR/and_star.rs:3:5: 3:19
+          let mut _5: &mut [u8];           // in scope 1 at $DIR/and_star.rs:3:5: 3:19
+      }
+  
+      bb0: {
+          StorageLive(_2);                 // scope 0 at $DIR/and_star.rs:3:5: 3:19
+          StorageLive(_3);                 // scope 0 at $DIR/and_star.rs:3:5: 3:8
+          _3 = &mut (*_1);                 // scope 0 at $DIR/and_star.rs:3:5: 3:8
+          StorageLive(_6);                 // scope 0 at $DIR/and_star.rs:3:5: 3:19
+          _6 = const 0_usize;              // scope 0 at $DIR/and_star.rs:3:5: 3:19
+          StorageLive(_4);                 // scope 1 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
+          _4 = move _6;                    // scope 1 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
+          StorageLive(_5);                 // scope 1 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
+          _5 = &mut (*_3);                 // scope 1 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
+          _2 = <usize as SliceIndex<[u8]>>::get_mut(move _4, move _5) -> bb1; // scope 1 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
+                                           // mir::Constant
+                                           // + span: $SRC_DIR/core/src/slice/mod.rs:LL:COL
+                                           // + literal: Const { ty: for<'r> fn(usize, &'r mut [u8]) -> std::option::Option<&'r mut <usize as std::slice::SliceIndex<[u8]>>::Output> {<usize as std::slice::SliceIndex<[u8]>>::get_mut}, val: Value(Scalar(<ZST>)) }
+      }
+  
+      bb1: {
+          StorageDead(_5);                 // scope 1 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
+          StorageDead(_4);                 // scope 1 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
+          StorageDead(_6);                 // scope 0 at $DIR/and_star.rs:3:5: 3:19
+          StorageDead(_3);                 // scope 0 at $DIR/and_star.rs:3:18: 3:19
+          StorageDead(_2);                 // scope 0 at $DIR/and_star.rs:3:19: 3:20
+          _0 = const ();                   // scope 0 at $DIR/and_star.rs:2:32: 4:2
+          return;                          // scope 0 at $DIR/and_star.rs:4:2: 4:2
+      }
+  }
+  

--- a/src/test/mir-opt/and_star.opt_mutable.InstCombine.diff
+++ b/src/test/mir-opt/and_star.opt_mutable.InstCombine.diff
@@ -17,13 +17,14 @@
       bb0: {
           StorageLive(_2);                 // scope 0 at $DIR/and_star.rs:3:5: 3:19
           StorageLive(_3);                 // scope 0 at $DIR/and_star.rs:3:5: 3:8
-          _3 = &mut (*_1);                 // scope 0 at $DIR/and_star.rs:3:5: 3:8
+-         _3 = &mut (*_1);                 // scope 0 at $DIR/and_star.rs:3:5: 3:8
++         _3 = _1;                         // scope 0 at $DIR/and_star.rs:3:5: 3:8
           StorageLive(_6);                 // scope 0 at $DIR/and_star.rs:3:5: 3:19
           _6 = const 0_usize;              // scope 0 at $DIR/and_star.rs:3:5: 3:19
           StorageLive(_4);                 // scope 1 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
           _4 = move _6;                    // scope 1 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
           StorageLive(_5);                 // scope 1 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
-          _5 = &mut (*_3);                 // scope 1 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
+          _5 = _3;                         // scope 1 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
           _2 = <usize as SliceIndex<[u8]>>::get_mut(move _4, move _5) -> bb1; // scope 1 at $SRC_DIR/core/src/slice/mod.rs:LL:COL
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/slice/mod.rs:LL:COL

--- a/src/test/mir-opt/and_star.rs
+++ b/src/test/mir-opt/and_star.rs
@@ -1,0 +1,14 @@
+// EMIT_MIR and_star.opt_mutable.InstCombine.diff
+fn opt_mutable(dst: &mut [u8]) {
+    dst.get_mut(0);
+}
+
+// EMIT_MIR and_star.opt_immutable.InstCombine.diff
+fn opt_immutable(dst: &[u8]) {
+    dst.get(0);
+}
+
+fn main() {
+    opt_mutable(&mut [1]);
+    opt_immutable(&[1])
+}

--- a/src/test/mir-opt/funky_arms.float_to_exponential_common.ConstProp.diff
+++ b/src/test/mir-opt/funky_arms.float_to_exponential_common.ConstProp.diff
@@ -78,7 +78,7 @@
   
       bb6: {
           StorageLive(_18);                // scope 2 at $DIR/funky_arms.rs:28:46: 28:49
-          _18 = &mut (*_1);                // scope 2 at $DIR/funky_arms.rs:28:46: 28:49
+          _18 = _1;                        // scope 2 at $DIR/funky_arms.rs:28:46: 28:49
           StorageLive(_19);                // scope 2 at $DIR/funky_arms.rs:28:51: 28:54
           _19 = _2;                        // scope 2 at $DIR/funky_arms.rs:28:51: 28:54
           StorageLive(_20);                // scope 2 at $DIR/funky_arms.rs:28:56: 28:60
@@ -95,7 +95,7 @@
           StorageLive(_10);                // scope 2 at $DIR/funky_arms.rs:24:17: 24:26
           _10 = ((_7 as Some).0: usize);   // scope 2 at $DIR/funky_arms.rs:24:17: 24:26
           StorageLive(_11);                // scope 3 at $DIR/funky_arms.rs:26:43: 26:46
-          _11 = &mut (*_1);                // scope 3 at $DIR/funky_arms.rs:26:43: 26:46
+          _11 = _1;                        // scope 3 at $DIR/funky_arms.rs:26:43: 26:46
           StorageLive(_12);                // scope 3 at $DIR/funky_arms.rs:26:48: 26:51
           _12 = _2;                        // scope 3 at $DIR/funky_arms.rs:26:48: 26:51
           StorageLive(_13);                // scope 3 at $DIR/funky_arms.rs:26:53: 26:57

--- a/src/test/mir-opt/inline/issue_58867_inline_as_ref_as_mut.a.Inline.after.mir
+++ b/src/test/mir-opt/inline/issue_58867_inline_as_ref_as_mut.a.Inline.after.mir
@@ -8,7 +8,6 @@ fn a(_1: &mut [T]) -> &mut [T] {
     let mut _4: &mut [T];                // in scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:3:5: 3:6
     scope 1 {
         debug self => _4;                // in scope 1 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
-        let mut _5: &mut [T];            // in scope 1 at $DIR/issue-58867-inline-as-ref-as-mut.rs:3:5: 3:15
     }
 
     bb0: {
@@ -16,10 +15,7 @@ fn a(_1: &mut [T]) -> &mut [T] {
         StorageLive(_3);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:3:5: 3:15
         StorageLive(_4);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:3:5: 3:6
         _4 = &mut (*_1);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:3:5: 3:6
-        StorageLive(_5);                 // scope 1 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
-        _5 = &mut (*_4);                 // scope 1 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
-        _3 = &mut (*_5);                 // scope 1 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
-        StorageDead(_5);                 // scope 1 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
+        _3 = _4;                         // scope 1 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
         _2 = &mut (*_3);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:3:5: 3:15
         StorageDead(_4);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:3:14: 3:15
         _0 = &mut (*_2);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:3:5: 3:15

--- a/src/test/mir-opt/inline/issue_58867_inline_as_ref_as_mut.b.Inline.after.mir
+++ b/src/test/mir-opt/inline/issue_58867_inline_as_ref_as_mut.b.Inline.after.mir
@@ -9,7 +9,6 @@ fn b(_1: &mut Box<T>) -> &mut T {
     scope 1 {
         debug self => _4;                // in scope 1 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
         let mut _5: &mut T;              // in scope 1 at $DIR/issue-58867-inline-as-ref-as-mut.rs:8:5: 8:15
-        let mut _6: &mut T;              // in scope 1 at $DIR/issue-58867-inline-as-ref-as-mut.rs:8:5: 8:15
     }
 
     bb0: {
@@ -18,11 +17,8 @@ fn b(_1: &mut Box<T>) -> &mut T {
         StorageLive(_4);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:8:5: 8:6
         _4 = &mut (*_1);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:8:5: 8:6
         StorageLive(_5);                 // scope 1 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
-        StorageLive(_6);                 // scope 1 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
-        _6 = &mut (*(*_4));              // scope 1 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
-        _5 = &mut (*_6);                 // scope 1 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
-        _3 = &mut (*_5);                 // scope 1 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
-        StorageDead(_6);                 // scope 1 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
+        _5 = &mut (*(*_4));              // scope 1 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
+        _3 = _5;                         // scope 1 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
         StorageDead(_5);                 // scope 1 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
         _2 = &mut (*_3);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:8:5: 8:15
         StorageDead(_4);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:8:14: 8:15

--- a/src/test/mir-opt/nrvo_simple.nrvo.RenameReturnPlace.diff
+++ b/src/test/mir-opt/nrvo_simple.nrvo.RenameReturnPlace.diff
@@ -20,17 +20,12 @@
 -         _2 = [const 0_u8; 1024];         // scope 0 at $DIR/nrvo-simple.rs:3:19: 3:28
 +         _0 = [const 0_u8; 1024];         // scope 0 at $DIR/nrvo-simple.rs:3:19: 3:28
           StorageLive(_3);                 // scope 1 at $DIR/nrvo-simple.rs:4:5: 4:19
-          StorageLive(_5);                 // scope 1 at $DIR/nrvo-simple.rs:4:10: 4:18
-          StorageLive(_6);                 // scope 1 at $DIR/nrvo-simple.rs:4:10: 4:18
 -         _6 = &mut _2;                    // scope 1 at $DIR/nrvo-simple.rs:4:10: 4:18
 +         _6 = &mut _0;                    // scope 1 at $DIR/nrvo-simple.rs:4:10: 4:18
-          _5 = &mut (*_6);                 // scope 1 at $DIR/nrvo-simple.rs:4:10: 4:18
-          _3 = move _1(move _5) -> bb1;    // scope 1 at $DIR/nrvo-simple.rs:4:5: 4:19
+          _3 = move _1(move _6) -> bb1;    // scope 1 at $DIR/nrvo-simple.rs:4:5: 4:19
       }
   
       bb1: {
-          StorageDead(_5);                 // scope 1 at $DIR/nrvo-simple.rs:4:18: 4:19
-          StorageDead(_6);                 // scope 1 at $DIR/nrvo-simple.rs:4:19: 4:20
           StorageDead(_3);                 // scope 1 at $DIR/nrvo-simple.rs:4:19: 4:20
 -         _0 = _2;                         // scope 1 at $DIR/nrvo-simple.rs:5:5: 5:8
 -         StorageDead(_2);                 // scope 0 at $DIR/nrvo-simple.rs:6:1: 6:2


### PR DESCRIPTION
Running ```RUSTC_LOG=rustc_mir::transform::instcombine ./x.py test --stage 1 src/test/mir-opt --bless | grep "replacing \`&mut*" | wc -l``` yields 10601, so it seems to be a fairly usable optimization on rust-std.