### PR TITLE
make replace_prefix only take &str as arguments 

### DIFF
--- a/compiler/rustc_driver/src/args.rs
+++ b/compiler/rustc_driver/src/args.rs
@@ -4,8 +4,7 @@ use std::fs;
 use std::io;
 
 pub fn arg_expand(arg: String) -> Result<Vec<String>, Error> {
-    if arg.starts_with('@') {
-        let path = &arg[1..];
+    if let Some(path) = arg.strip_prefix('@') {
         let file = match fs::read_to_string(path) {
             Ok(file) => file,
             Err(ref err) if err.kind() == io::ErrorKind::InvalidData => {

--- a/compiler/rustc_mir/src/borrow_check/diagnostics/move_errors.rs
+++ b/compiler/rustc_mir/src/borrow_check/diagnostics/move_errors.rs
@@ -492,8 +492,8 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
             {
                 if let Ok(pat_snippet) = self.infcx.tcx.sess.source_map().span_to_snippet(pat_span)
                 {
-                    if pat_snippet.starts_with('&') {
-                        let pat_snippet = pat_snippet[1..].trim_start();
+                    if let Some(stripped) = pat_snippet.strip_prefix('&') {
+                        let pat_snippet = stripped.trim_start();
                         let (suggestion, to_remove) = if pat_snippet.starts_with("mut")
                             && pat_snippet["mut".len()..].starts_with(rustc_lexer::is_whitespace)
                         {

--- a/compiler/rustc_mir/src/borrow_check/diagnostics/mutability_errors.rs
+++ b/compiler/rustc_mir/src/borrow_check/diagnostics/mutability_errors.rs
@@ -631,9 +631,8 @@ fn suggest_ampmut<'tcx>(
                 let lt_name = &src[1..ws_pos];
                 let ty = &src[ws_pos..];
                 return (assignment_rhs_span, format!("&{} mut {}", lt_name, ty));
-            } else if src.starts_with('&') {
-                let borrowed_expr = &src[1..];
-                return (assignment_rhs_span, format!("&mut {}", borrowed_expr));
+            } else if let Some(stripped) = src.strip_prefix('&') {
+                return (assignment_rhs_span, format!("&mut {}", stripped));
             }
         }
     }

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -1418,9 +1418,9 @@ impl<'tcx> LifetimeContext<'_, 'tcx> {
                         if snippet.starts_with('&') && !snippet.starts_with("&'") {
                             introduce_suggestion
                                 .push((param.span, format!("&{} {}", lt_name, &snippet[1..])));
-                        } else if snippet.starts_with("&'_ ") {
+                        } else if let Some(stripped) = snippet.strip_prefix("&'_ ") {
                             introduce_suggestion
-                                .push((param.span, format!("&{} {}", lt_name, &snippet[4..])));
+                                .push((param.span, format!("&{} {}", lt_name, stripped)));
                         }
                     }
                 }

--- a/compiler/rustc_session/src/search_paths.rs
+++ b/compiler/rustc_session/src/search_paths.rs
@@ -56,16 +56,16 @@ impl PathKind {
 
 impl SearchPath {
     pub fn from_cli_opt(path: &str, output: config::ErrorOutputType) -> Self {
-        let (kind, path) = if path.starts_with("native=") {
-            (PathKind::Native, &path["native=".len()..])
-        } else if path.starts_with("crate=") {
-            (PathKind::Crate, &path["crate=".len()..])
-        } else if path.starts_with("dependency=") {
-            (PathKind::Dependency, &path["dependency=".len()..])
-        } else if path.starts_with("framework=") {
-            (PathKind::Framework, &path["framework=".len()..])
-        } else if path.starts_with("all=") {
-            (PathKind::All, &path["all=".len()..])
+        let (kind, path) = if let Some(stripped) = path.strip_prefix("native=") {
+            (PathKind::Native, stripped)
+        } else if let Some(stripped) = path.strip_prefix("crate=") {
+            (PathKind::Crate, stripped)
+        } else if let Some(stripped) = path.strip_prefix("dependency=") {
+            (PathKind::Dependency, stripped)
+        } else if let Some(stripped) = path.strip_prefix("framework=") {
+            (PathKind::Framework, stripped)
+        } else if let Some(stripped) = path.strip_prefix("all=") {
+            (PathKind::All, stripped)
         } else {
             (PathKind::All, path)
         };

--- a/compiler/rustc_typeck/src/check/demand.rs
+++ b/compiler/rustc_typeck/src/check/demand.rs
@@ -362,16 +362,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         false
     }
 
-    fn replace_prefix<A, B, C>(&self, s: A, old: B, new: C) -> Option<String>
-    where
-        A: AsRef<str>,
-        B: AsRef<str>,
-        C: AsRef<str>,
-    {
-        let s = s.as_ref();
-        let old = old.as_ref();
+    fn replace_prefix(&self, s: &str, old: &str, new: &str) -> Option<String> {
         if let Some(stripped) = s.strip_prefix(old) {
-            Some(new.as_ref().to_owned() + stripped)
+            Some(new.to_string() + stripped)
         } else {
             None
         }
@@ -422,7 +415,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 (&ty::Str, &ty::Array(arr, _) | &ty::Slice(arr)) if arr == self.tcx.types.u8 => {
                     if let hir::ExprKind::Lit(_) = expr.kind {
                         if let Ok(src) = sm.span_to_snippet(sp) {
-                            if let Some(src) = self.replace_prefix(src, "b\"", "\"") {
+                            if let Some(src) = self.replace_prefix(&src, "b\"", "\"") {
                                 return Some((
                                     sp,
                                     "consider removing the leading `b`",
@@ -436,7 +429,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 (&ty::Array(arr, _) | &ty::Slice(arr), &ty::Str) if arr == self.tcx.types.u8 => {
                     if let hir::ExprKind::Lit(_) = expr.kind {
                         if let Ok(src) = sm.span_to_snippet(sp) {
-                            if let Some(src) = self.replace_prefix(src, "\"", "b\"") {
+                            if let Some(src) = self.replace_prefix(&src, "\"", "b\"") {
                                 return Some((
                                     sp,
                                     "consider adding a leading `b`",
@@ -561,7 +554,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 // we may want to suggest removing a `&`.
                 if sm.is_imported(expr.span) {
                     if let Ok(src) = sm.span_to_snippet(sp) {
-                        if let Some(src) = self.replace_prefix(src, "&", "") {
+                        if let Some(src) = self.replace_prefix(&src, "&", "") {
                             return Some((
                                 sp,
                                 "consider removing the borrow",
@@ -598,7 +591,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                     match mutbl_a {
                                         hir::Mutability::Mut => {
                                             if let Some(s) =
-                                                self.replace_prefix(src, "&mut ", new_prefix)
+                                                self.replace_prefix(&src, "&mut ", &new_prefix)
                                             {
                                                 Some((s, Applicability::MachineApplicable))
                                             } else {
@@ -607,7 +600,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                         }
                                         hir::Mutability::Not => {
                                             if let Some(s) =
-                                                self.replace_prefix(src, "&", new_prefix)
+                                                self.replace_prefix(&src, "&", &new_prefix)
                                             {
                                                 Some((s, Applicability::Unspecified))
                                             } else {
@@ -621,7 +614,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                     match mutbl_a {
                                         hir::Mutability::Mut => {
                                             if let Some(s) =
-                                                self.replace_prefix(src, "&mut ", new_prefix)
+                                                self.replace_prefix(&src, "&mut ", &new_prefix)
                                             {
                                                 Some((s, Applicability::MachineApplicable))
                                             } else {
@@ -630,7 +623,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                         }
                                         hir::Mutability::Not => {
                                             if let Some(s) =
-                                                self.replace_prefix(src, "&", new_prefix)
+                                                self.replace_prefix(&src, "&", &new_prefix)
                                             {
                                                 Some((s, Applicability::MachineApplicable))
                                             } else {

--- a/compiler/rustc_typeck/src/check/demand.rs
+++ b/compiler/rustc_typeck/src/check/demand.rs
@@ -370,7 +370,11 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     {
         let s = s.as_ref();
         let old = old.as_ref();
-        if s.starts_with(old) { Some(new.as_ref().to_owned() + &s[old.len()..]) } else { None }
+        if let Some(stripped) = s.strip_prefix(old) {
+            Some(new.as_ref().to_owned() + stripped)
+        } else {
+            None
+        }
     }
 
     /// This function is used to determine potential "simple" improvements or users' errors and

--- a/compiler/rustc_typeck/src/check/op.rs
+++ b/compiler/rustc_typeck/src/check/op.rs
@@ -589,10 +589,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                 } else {
                                     msg
                                 },
-                                if lstring.starts_with('&') {
+                                if let Some(stripped) = lstring.strip_prefix('&') {
                                     // let a = String::new();
                                     // let _ = &a + "bar";
-                                    lstring[1..].to_string()
+                                    stripped.to_string()
                                 } else {
                                     format!("{}.to_owned()", lstring)
                                 },
@@ -617,10 +617,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     is_assign,
                 ) {
                     (Ok(l), Ok(r), IsAssign::No) => {
-                        let to_string = if l.starts_with('&') {
+                        let to_string = if let Some(stripped) = l.strip_prefix('&') {
                             // let a = String::new(); let b = String::new();
                             // let _ = &a + b;
-                            l[1..].to_string()
+                            stripped.to_string()
                         } else {
                             format!("{}.to_owned()", l)
                         };

--- a/compiler/rustc_typeck/src/collect.rs
+++ b/compiler/rustc_typeck/src/collect.rs
@@ -2341,8 +2341,8 @@ fn from_target_feature(
                         item.span(),
                         format!("`{}` is not valid for this target", feature),
                     );
-                    if feature.starts_with('+') {
-                        let valid = supported_target_features.contains_key(&feature[1..]);
+                    if let Some(stripped) = feature.strip_prefix('+') {
+                        let valid = supported_target_features.contains_key(stripped);
                         if valid {
                             err.help("consider removing the leading `+` in the feature name");
                         }


### PR DESCRIPTION
included the clippy::manual strip commit to not run into merge conflicts later.

r? @lcnr 