### PR TITLE
Add asm! support for MIPS

### DIFF
--- a/compiler/rustc_target/src/asm/mips.rs
+++ b/compiler/rustc_target/src/asm/mips.rs
@@ -1,0 +1,132 @@
+use super::{InlineAsmArch, InlineAsmType};
+use rustc_macros::HashStable_Generic;
+use std::fmt;
+
+def_reg_class! {
+    Mips MipsInlineAsmRegClass {
+        reg,
+        freg,
+    }
+}
+
+impl MipsInlineAsmRegClass {
+    pub fn valid_modifiers(self, _arch: super::InlineAsmArch) -> &'static [char] {
+        &[]
+    }
+
+    pub fn suggest_class(self, _arch: InlineAsmArch, _ty: InlineAsmType) -> Option<Self> {
+        None
+    }
+
+    pub fn suggest_modifier(
+        self,
+        _arch: InlineAsmArch,
+        _ty: InlineAsmType,
+    ) -> Option<(char, &'static str)> {
+        None
+    }
+
+    pub fn default_modifier(self, _arch: InlineAsmArch) -> Option<(char, &'static str)> {
+        None
+    }
+
+    pub fn supported_types(
+        self,
+        _arch: InlineAsmArch,
+    ) -> &'static [(InlineAsmType, Option<&'static str>)] {
+        match self {
+            Self::reg => types! { _: I8, I16, I32, F32; },
+            Self::freg => types! { _: F32; },
+        }
+    }
+}
+
+// The reserved registers are somewhat taken from <https://git.io/JUR1k#L150>.
+def_regs! {
+    Mips MipsInlineAsmReg MipsInlineAsmRegClass {
+        v0: reg = ["$2", "$v0"],
+        v1: reg = ["$3", "$v1"],
+        a0: reg = ["$4", "$a0"],
+        a1: reg = ["$5", "$a1"],
+        a2: reg = ["$6", "$a2"],
+        a3: reg = ["$7", "$a3"],
+        // FIXME: Reserve $t0, $t1 if in mips16 mode.
+        t0: reg = ["$8", "$t0"],
+        t1: reg = ["$9", "$t1"],
+        t2: reg = ["$10", "$t2"],
+        t3: reg = ["$11", "$t3"],
+        t4: reg = ["$12", "$t4"],
+        t5: reg = ["$13", "$t5"],
+        t6: reg = ["$14", "$t6"],
+        t7: reg = ["$15", "$t7"],
+        s0: reg = ["$16", "$s0"],
+        s1: reg = ["$17", "$s1"],
+        s2: reg = ["$18", "$s2"],
+        s3: reg = ["$19", "$s3"],
+        s4: reg = ["$20", "$s4"],
+        s5: reg = ["$21", "$s5"],
+        s6: reg = ["$22", "$s6"],
+        s7: reg = ["$23", "$s7"],
+        t8: reg = ["$24", "$t8"],
+        t9: reg = ["$25", "$t9"],
+        f0: freg = ["$f0"],
+        f1: freg = ["$f1"],
+        f2: freg = ["$f2"],
+        f3: freg = ["$f3"],
+        f4: freg = ["$f4"],
+        f5: freg = ["$f5"],
+        f6: freg = ["$f6"],
+        f7: freg = ["$f7"],
+        f8: freg = ["$f8"],
+        f9: freg = ["$f9"],
+        f10: freg = ["$f10"],
+        f11: freg = ["$f11"],
+        f12: freg = ["$f12"],
+        f13: freg = ["$f13"],
+        f14: freg = ["$f14"],
+        f15: freg = ["$f15"],
+        f16: freg = ["$f16"],
+        f17: freg = ["$f17"],
+        f18: freg = ["$f18"],
+        f19: freg = ["$f19"],
+        f20: freg = ["$f20"],
+        f21: freg = ["$f21"],
+        f22: freg = ["$f22"],
+        f23: freg = ["$f23"],
+        f24: freg = ["$f24"],
+        f25: freg = ["$f25"],
+        f26: freg = ["$f26"],
+        f27: freg = ["$f27"],
+        f28: freg = ["$f28"],
+        f29: freg = ["$f29"],
+        f30: freg = ["$f30"],
+        f31: freg = ["$f31"],
+        #error = ["$0", "$zero"] =>
+            "constant zero cannot be used as an operand for inline asm",
+        #error = ["$1", "$at"] =>
+            "reserved for assembler (Assembler Temp)",
+        #error = ["$26", "$k0"] =>
+            "OS-reserved register cannot be used as an operand for inline asm",
+        #error = ["$27", "$k1"] =>
+            "OS-reserved register cannot be used as an operand for inline asm",
+        #error = ["$28", "$gp"] =>
+            "the global pointer cannot be used as an operand for inline asm",
+        #error = ["$29", "$sp"] =>
+            "the stack pointer cannot be used as an operand for inline asm",
+        #error = ["$30", "$s8", "$fp"] =>
+            "the frame pointer cannot be used as an operand for inline asm",
+        #error = ["$31", "$ra"] =>
+            "the return address register cannot be used as an operand for inline asm",
+    }
+}
+
+impl MipsInlineAsmReg {
+    pub fn emit(
+        self,
+        out: &mut dyn fmt::Write,
+        _arch: InlineAsmArch,
+        _modifier: Option<char>,
+    ) -> fmt::Result {
+        out.write_str(self.name())
+    }
+}

--- a/compiler/rustc_target/src/asm/mod.rs
+++ b/compiler/rustc_target/src/asm/mod.rs
@@ -152,6 +152,7 @@ macro_rules! types {
 mod aarch64;
 mod arm;
 mod hexagon;
+mod mips;
 mod nvptx;
 mod riscv;
 mod x86;
@@ -159,6 +160,7 @@ mod x86;
 pub use aarch64::{AArch64InlineAsmReg, AArch64InlineAsmRegClass};
 pub use arm::{ArmInlineAsmReg, ArmInlineAsmRegClass};
 pub use hexagon::{HexagonInlineAsmReg, HexagonInlineAsmRegClass};
+pub use mips::{MipsInlineAsmReg, MipsInlineAsmRegClass};
 pub use nvptx::{NvptxInlineAsmReg, NvptxInlineAsmRegClass};
 pub use riscv::{RiscVInlineAsmReg, RiscVInlineAsmRegClass};
 pub use x86::{X86InlineAsmReg, X86InlineAsmRegClass};
@@ -173,6 +175,7 @@ pub enum InlineAsmArch {
     RiscV64,
     Nvptx64,
     Hexagon,
+    Mips,
 }
 
 impl FromStr for InlineAsmArch {
@@ -188,6 +191,7 @@ impl FromStr for InlineAsmArch {
             "riscv64" => Ok(Self::RiscV64),
             "nvptx64" => Ok(Self::Nvptx64),
             "hexagon" => Ok(Self::Hexagon),
+            "mips" => Ok(Self::Mips),
             _ => Err(()),
         }
     }
@@ -201,6 +205,7 @@ pub enum InlineAsmReg {
     RiscV(RiscVInlineAsmReg),
     Nvptx(NvptxInlineAsmReg),
     Hexagon(HexagonInlineAsmReg),
+    Mips(MipsInlineAsmReg),
 }
 
 impl InlineAsmReg {
@@ -211,6 +216,7 @@ impl InlineAsmReg {
             Self::AArch64(r) => r.name(),
             Self::RiscV(r) => r.name(),
             Self::Hexagon(r) => r.name(),
+            Self::Mips(r) => r.name(),
         }
     }
 
@@ -221,6 +227,7 @@ impl InlineAsmReg {
             Self::AArch64(r) => InlineAsmRegClass::AArch64(r.reg_class()),
             Self::RiscV(r) => InlineAsmRegClass::RiscV(r.reg_class()),
             Self::Hexagon(r) => InlineAsmRegClass::Hexagon(r.reg_class()),
+            Self::Mips(r) => InlineAsmRegClass::Mips(r.reg_class()),
         }
     }
 
@@ -252,6 +259,9 @@ impl InlineAsmReg {
             InlineAsmArch::Hexagon => {
                 Self::Hexagon(HexagonInlineAsmReg::parse(arch, has_feature, target, &name)?)
             }
+            InlineAsmArch::Mips => {
+                Self::Mips(MipsInlineAsmReg::parse(arch, has_feature, target, &name)?)
+            }
         })
     }
 
@@ -269,6 +279,7 @@ impl InlineAsmReg {
             Self::AArch64(r) => r.emit(out, arch, modifier),
             Self::RiscV(r) => r.emit(out, arch, modifier),
             Self::Hexagon(r) => r.emit(out, arch, modifier),
+            Self::Mips(r) => r.emit(out, arch, modifier),
         }
     }
 
@@ -279,6 +290,7 @@ impl InlineAsmReg {
             Self::AArch64(_) => cb(self),
             Self::RiscV(_) => cb(self),
             Self::Hexagon(r) => r.overlapping_regs(|r| cb(Self::Hexagon(r))),
+            Self::Mips(_) => cb(self),
         }
     }
 }
@@ -291,6 +303,7 @@ pub enum InlineAsmRegClass {
     RiscV(RiscVInlineAsmRegClass),
     Nvptx(NvptxInlineAsmRegClass),
     Hexagon(HexagonInlineAsmRegClass),
+    Mips(MipsInlineAsmRegClass),
 }
 
 impl InlineAsmRegClass {
@@ -302,6 +315,7 @@ impl InlineAsmRegClass {
             Self::RiscV(r) => r.name(),
             Self::Nvptx(r) => r.name(),
             Self::Hexagon(r) => r.name(),
+            Self::Mips(r) => r.name(),
         }
     }
 
@@ -316,6 +330,7 @@ impl InlineAsmRegClass {
             Self::RiscV(r) => r.suggest_class(arch, ty).map(InlineAsmRegClass::RiscV),
             Self::Nvptx(r) => r.suggest_class(arch, ty).map(InlineAsmRegClass::Nvptx),
             Self::Hexagon(r) => r.suggest_class(arch, ty).map(InlineAsmRegClass::Hexagon),
+            Self::Mips(r) => r.suggest_class(arch, ty).map(InlineAsmRegClass::Mips),
         }
     }
 
@@ -337,6 +352,7 @@ impl InlineAsmRegClass {
             Self::RiscV(r) => r.suggest_modifier(arch, ty),
             Self::Nvptx(r) => r.suggest_modifier(arch, ty),
             Self::Hexagon(r) => r.suggest_modifier(arch, ty),
+            Self::Mips(r) => r.suggest_modifier(arch, ty),
         }
     }
 
@@ -354,6 +370,7 @@ impl InlineAsmRegClass {
             Self::RiscV(r) => r.default_modifier(arch),
             Self::Nvptx(r) => r.default_modifier(arch),
             Self::Hexagon(r) => r.default_modifier(arch),
+            Self::Mips(r) => r.default_modifier(arch),
         }
     }
 
@@ -370,6 +387,7 @@ impl InlineAsmRegClass {
             Self::RiscV(r) => r.supported_types(arch),
             Self::Nvptx(r) => r.supported_types(arch),
             Self::Hexagon(r) => r.supported_types(arch),
+            Self::Mips(r) => r.supported_types(arch),
         }
     }
 
@@ -391,6 +409,7 @@ impl InlineAsmRegClass {
                 InlineAsmArch::Hexagon => {
                     Self::Hexagon(HexagonInlineAsmRegClass::parse(arch, name)?)
                 }
+                InlineAsmArch::Mips => Self::Mips(MipsInlineAsmRegClass::parse(arch, name)?),
             })
         })
     }
@@ -405,6 +424,7 @@ impl InlineAsmRegClass {
             Self::RiscV(r) => r.valid_modifiers(arch),
             Self::Nvptx(r) => r.valid_modifiers(arch),
             Self::Hexagon(r) => r.valid_modifiers(arch),
+            Self::Mips(r) => r.valid_modifiers(arch),
         }
     }
 }
@@ -543,6 +563,11 @@ pub fn allocatable_registers(
         InlineAsmArch::Hexagon => {
             let mut map = hexagon::regclass_map();
             hexagon::fill_reg_map(arch, has_feature, target, &mut map);
+            map
+        }
+        InlineAsmArch::Mips => {
+            let mut map = mips::regclass_map();
+            mips::fill_reg_map(arch, has_feature, target, &mut map);
             map
         }
     }

--- a/src/doc/unstable-book/src/library-features/asm.md
+++ b/src/doc/unstable-book/src/library-features/asm.md
@@ -27,6 +27,7 @@ Inline assembly is currently supported on the following architectures:
 - RISC-V
 - NVPTX
 - Hexagon
+- MIPS32
 
 ## Basic usage
 
@@ -493,6 +494,8 @@ Here is the list of currently supported register classes:
 | ARM | `qreg` | `q[0-15]` | `w` |
 | ARM | `qreg_low8` | `q[0-7]` | `t` |
 | ARM | `qreg_low4` | `q[0-3]` | `x` |
+| MIPS32 | `reg` | `$[2-25]` | `r` |
+| MIPS32 | `freg` | `$f[0-31]` | `f` |
 | NVPTX | `reg16` | None\* | `h` |
 | NVPTX | `reg32` | None\* | `r` |
 | NVPTX | `reg64` | None\* | `l` |
@@ -528,6 +531,8 @@ Each register class has constraints on which value types they can be used with. 
 | ARM | `sreg` | `vfp2` | `i32`, `f32` |
 | ARM | `dreg` | `vfp2` | `i64`, `f64`, `i8x8`, `i16x4`, `i32x2`, `i64x1`, `f32x2` |
 | ARM | `qreg` | `neon` | `i8x16`, `i16x8`, `i32x4`, `i64x2`, `f32x4` |
+| MIPS32 | `reg` | None | `i8`, `i16`, `i32`, `f32` |
+| MIPS32 | `freg` | None | `f32` |
 | NVPTX | `reg16` | None | `i8`, `i16` |
 | NVPTX | `reg32` | None | `i8`, `i16`, `i32`, `f32` |
 | NVPTX | `reg64` | None | `i8`, `i16`, `i32`, `f32`, `i64`, `f64` |
@@ -576,6 +581,7 @@ Some registers have multiple names. These are all treated by the compiler as ide
 | ARM | `r13` | `sp` |
 | ARM | `r14` | `lr` |
 | ARM | `r15` | `pc` |
+| MIPS32 | `$[2-25]` | Please [see the Wikipedia page][mips-regs] |
 | RISC-V | `x0` | `zero` |
 | RISC-V | `x1` | `ra` |
 | RISC-V | `x2` | `sp` |
@@ -596,12 +602,14 @@ Some registers have multiple names. These are all treated by the compiler as ide
 | Hexagon | `r30` | `fr` |
 | Hexagon | `r31` | `lr` |
 
+[mips-regs]: https://en.wikibooks.org/wiki/MIPS_Assembly/Register_File#Registers
+
 Some registers cannot be used for input or output operands:
 
 | Architecture | Unsupported register | Reason |
 | ------------ | -------------------- | ------ |
 | All | `sp` | The stack pointer must be restored to its original value at the end of an asm code block. |
-| All | `bp` (x86), `x29` (AArch64), `x8` (RISC-V), `fr` (Hexagon) | The frame pointer cannot be used as an input or output. |
+| All | `bp` (x86), `x29` (AArch64), `x8` (RISC-V), `fr` (Hexagon), `$fp` (MIPS) | The frame pointer cannot be used as an input or output. |
 | ARM | `r7` or `r11` | On ARM the frame pointer can be either `r7` or `r11` depending on the target. The frame pointer cannot be used as an input or output. |
 | ARM | `r6` | `r6` is used internally by LLVM as a base pointer and therefore cannot be used as an input or output. |
 | x86 | `k0` | This is a constant zero register which can't be modified. |
@@ -610,6 +618,11 @@ Some registers cannot be used for input or output operands:
 | x86 | `st([0-7])` | x87 registers are not currently supported (but may be in the future). |
 | AArch64 | `xzr` | This is a constant zero register which can't be modified. |
 | ARM | `pc` | This is the program counter, not a real register. |
+| MIPS32 | `$0` or `$zero` | This is a constant zero register which can't be modified. |
+| MIPS32 | `$1` or `$at` | Reserved for assembler. |
+| MIPS32 | `$26`/`$k0`, `$27`/`$k1` | OS-reserved registers. |
+| MIPS32 | `$28`/`$gp` | Global pointer cannot be used as inputs or outputs. |
+| MIPS32 | `$ra` | Return address cannot be used as inputs or outputs. |
 | RISC-V | `x0` | This is a constant zero register which can't be modified. |
 | RISC-V | `gp`, `tp` | These registers are reserved and cannot be used as inputs or outputs. |
 | Hexagon | `lr` | This is the link register which cannot be used as an input or output. |
@@ -657,6 +670,8 @@ The supported modifiers are a subset of LLVM's (and GCC's) [asm template argumen
 | ARM | `dreg` | None | `d0` | `P` |
 | ARM | `qreg` | None | `q0` | `q` |
 | ARM | `qreg` | `e` / `f` | `d0` / `d1` | `e` / `f` |
+| MIPS32 | `reg` | None | `$2` | None |
+| MIPS32 | `freg` | None | `$f0` | None |
 | NVPTX | `reg16` | None | `rs0` | None |
 | NVPTX | `reg32` | None | `r0` | None |
 | NVPTX | `reg64` | None | `rd0` | None |

--- a/src/test/assembly/asm/mips-types.rs
+++ b/src/test/assembly/asm/mips-types.rs
@@ -1,0 +1,191 @@
+// no-system-llvm
+// assembly-output: emit-asm
+// compile-flags: --target mips-unknown-linux-gnu
+// needs-llvm-components: mips
+
+#![feature(no_core, lang_items, rustc_attrs, repr_simd)]
+#![crate_type = "rlib"]
+#![no_core]
+#![allow(asm_sub_register, non_camel_case_types)]
+
+#[rustc_builtin_macro]
+macro_rules! asm {
+    () => {};
+}
+#[rustc_builtin_macro]
+macro_rules! concat {
+    () => {};
+}
+#[rustc_builtin_macro]
+macro_rules! stringify {
+    () => {};
+}
+
+#[lang = "sized"]
+trait Sized {}
+#[lang = "copy"]
+trait Copy {}
+
+type ptr = *const i32;
+
+impl Copy for i8 {}
+impl Copy for u8 {}
+impl Copy for i16 {}
+impl Copy for i32 {}
+impl Copy for f32 {}
+impl Copy for ptr {}
+extern "C" {
+    fn extern_func();
+    static extern_static: u8;
+}
+
+// Hack to avoid function merging
+extern "Rust" {
+    fn dont_merge(s: &str);
+}
+
+macro_rules! check { ($func:ident, $ty:ty, $class:ident) => {
+    #[no_mangle]
+    pub unsafe fn $func(x: $ty) -> $ty {
+        dont_merge(stringify!($func));
+
+        let y;
+        asm!("move {}, {}", out($class) y, in($class) x);
+        y
+    }
+};}
+
+macro_rules! check_reg { ($func:ident, $ty:ty, $reg:tt) => {
+    #[no_mangle]
+    pub unsafe fn $func(x: $ty) -> $ty {
+        dont_merge(stringify!($func));
+
+        let y;
+        asm!(concat!("move ", $reg, ", ", $reg), lateout($reg) y, in($reg) x);
+        y
+    }
+};}
+
+// CHECK-LABEL: sym_static:
+// CHECK: #APP
+// CHECK: lw $3, %got(extern_static)
+// CHECK: #NO_APP
+#[no_mangle]
+pub unsafe fn sym_static() {
+    dont_merge(stringify!($func));
+
+    asm!("la $v1, {}", sym extern_static);
+}
+
+// CHECK-LABEL: sym_fn:
+// CHECK: #APP
+// CHECK: lw $3, %got(extern_func)
+// CHECK: #NO_APP
+#[no_mangle]
+pub unsafe fn sym_fn() {
+    dont_merge(stringify!($func));
+
+    asm!("la $v1, {}", sym extern_func);
+}
+
+// CHECK-LABEL: reg_f32:
+// CHECK: #APP
+// CHECK: mov.s $f{{[0-9]+}}, $f{{[0-9]+}}
+// CHECK: #NO_APP
+#[no_mangle]
+pub unsafe fn reg_f32(x: f32) -> f32 {
+    dont_merge("reg_f32");
+    let y;
+    asm!("mov.s {}, {}", out(freg) y, in(freg) x);
+    y
+}
+
+// CHECK-LABEL: f0_f32:
+// CHECK: #APP
+// CHECK: mov.s $f0, $f0
+// CHECK: #NO_APP
+#[no_mangle]
+pub unsafe fn f0_f32(x: f32) -> f32 {
+    dont_merge("f0_f32");
+    let y;
+    asm!("mov.s $f0, $f0", lateout("$f0") y, in("$f0") x);
+    y
+}
+
+// CHECK-LABEL: reg_ptr:
+// CHECK: #APP
+// CHECK: move ${{[0-9]+}}, ${{[0-9]+}}
+// CHECK: #NO_APP
+check!(reg_ptr, ptr, reg);
+
+// CHECK-LABEL: reg_i32:
+// CHECK: #APP
+// CHECK: move ${{[0-9]+}}, ${{[0-9]+}}
+// CHECK: #NO_APP
+check!(reg_i32, i32, reg);
+
+// CHECK-LABEL: reg_f32_soft:
+// CHECK: #APP
+// CHECK: move ${{[0-9]+}}, ${{[0-9]+}}
+// CHECK: #NO_APP
+check!(reg_f32_soft, f32, reg);
+
+// CHECK-LABEL: reg_i8:
+// CHECK: #APP
+// CHECK: move ${{[0-9]+}}, ${{[0-9]+}}
+// CHECK: #NO_APP
+check!(reg_i8, i8, reg);
+
+// CHECK-LABEL: reg_u8:
+// CHECK: #APP
+// CHECK: move ${{[0-9]+}}, ${{[0-9]+}}
+// CHECK: #NO_APP
+check!(reg_u8, u8, reg);
+
+// CHECK-LABEL: reg_i16:
+// CHECK: #APP
+// CHECK: move ${{[0-9]+}}, ${{[0-9]+}}
+// CHECK: #NO_APP
+check!(reg_i16, i16, reg);
+
+// CHECK-LABEL: t0_ptr:
+// CHECK: #APP
+// CHECK: move $8, $8
+// CHECK: #NO_APP
+check_reg!(t0_ptr, ptr, "$t0");
+
+// CHECK-LABEL: t0_i32:
+// CHECK: #APP
+// CHECK: move $8, $8
+// CHECK: #NO_APP
+check_reg!(t0_i32, i32, "$t0");
+
+// CHECK-LABEL: t0_f32:
+// CHECK: #APP
+// CHECK: move $8, $8
+// CHECK: #NO_APP
+check_reg!(t0_f32, f32, "$t0");
+
+// CHECK-LABEL: t0_i8:
+// CHECK: #APP
+// CHECK: move $8, $8
+// CHECK: #NO_APP
+check_reg!(t0_i8, i8, "$t0");
+
+// CHECK-LABEL: t0_u8:
+// CHECK: #APP
+// CHECK: move $8, $8
+// CHECK: #NO_APP
+check_reg!(t0_u8, u8, "$t0");
+
+// CHECK-LABEL: t0_i16:
+// CHECK: #APP
+// CHECK: move $8, $8
+// CHECK: #NO_APP
+check_reg!(t0_i16, i16, "$t0");
+
+// CHECK-LABEL: r8_i16:
+// CHECK: #APP
+// CHECK: move $8, $8
+// CHECK: #NO_APP
+check_reg!(r8_i16, i16, "$8");


### PR DESCRIPTION
For now, I only add support for mips32.
mips64 may come in future PRs if I could learn more about the target.