### PR TITLE
Move to intra doc links in core/src/future

### DIFF
--- a/library/core/src/future/pending.rs
+++ b/library/core/src/future/pending.rs
@@ -7,7 +7,7 @@ use crate::task::{Context, Poll};
 /// Creates a future which never resolves, representing a computation that never
 /// finishes.
 ///
-/// This `struct` is created by the [`pending`] function. See its
+/// This `struct` is created by [`pending()`]. See its
 /// documentation for more.
 #[stable(feature = "future_readiness_fns", since = "1.48.0")]
 #[must_use = "futures do nothing unless you `.await` or poll them"]

--- a/library/core/src/future/pending.rs
+++ b/library/core/src/future/pending.rs
@@ -9,8 +9,6 @@ use crate::task::{Context, Poll};
 ///
 /// This `struct` is created by the [`pending`] function. See its
 /// documentation for more.
-///
-/// [`pending`]: fn.pending.html
 #[stable(feature = "future_readiness_fns", since = "1.48.0")]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Pending<T> {

--- a/library/core/src/future/poll_fn.rs
+++ b/library/core/src/future/poll_fn.rs
@@ -33,7 +33,7 @@ where
 
 /// A Future that wraps a function returning `Poll`.
 ///
-/// This `struct` is created by the [`poll_fn`] function. See its
+/// This `struct` is created by [`poll_fn()`]. See its
 /// documentation for more.
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 #[unstable(feature = "future_poll_fn", issue = "72302")]

--- a/library/core/src/future/poll_fn.rs
+++ b/library/core/src/future/poll_fn.rs
@@ -35,8 +35,6 @@ where
 ///
 /// This `struct` is created by the [`poll_fn`] function. See its
 /// documentation for more.
-///
-/// [`poll_fn`]: fn.poll_fn.html
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 #[unstable(feature = "future_poll_fn", issue = "72302")]
 pub struct PollFn<F> {

--- a/library/core/src/future/ready.rs
+++ b/library/core/src/future/ready.rs
@@ -4,7 +4,7 @@ use crate::task::{Context, Poll};
 
 /// Creates a future that is immediately ready with a value.
 ///
-/// This `struct` is created by the [`ready`] function. See its
+/// This `struct` is created by [`ready()`]. See its
 /// documentation for more.
 #[stable(feature = "future_readiness_fns", since = "1.48.0")]
 #[derive(Debug, Clone)]

--- a/library/core/src/future/ready.rs
+++ b/library/core/src/future/ready.rs
@@ -6,8 +6,6 @@ use crate::task::{Context, Poll};
 ///
 /// This `struct` is created by the [`ready`] function. See its
 /// documentation for more.
-///
-/// [`ready`]: fn.ready.html
 #[stable(feature = "future_readiness_fns", since = "1.48.0")]
 #[derive(Debug, Clone)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]


### PR DESCRIPTION
Helps with #75080.

@rustbot modify labels: T-doc A-intra-doc-links

r? @jyn514