### PR TITLE
Use intra docs links in core::{ascii, option, str, pattern, hash::map}

### DIFF
--- a/library/core/src/ascii.rs
+++ b/library/core/src/ascii.rs
@@ -6,8 +6,6 @@
 //!
 //! The [`escape_default`] function provides an iterator over the bytes of an
 //! escaped version of the character given.
-//!
-//! [`escape_default`]: fn.escape_default.html
 
 #![stable(feature = "core_ascii", since = "1.26.0")]
 
@@ -20,8 +18,6 @@ use crate::str::from_utf8_unchecked;
 ///
 /// This `struct` is created by the [`escape_default`] function. See its
 /// documentation for more.
-///
-/// [`escape_default`]: fn.escape_default.html
 #[stable(feature = "rust1", since = "1.0.0")]
 #[derive(Clone)]
 pub struct EscapeDefault {

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -1502,8 +1502,6 @@ unsafe impl<A> TrustedLen for IterMut<'_, A> {}
 /// The iterator yields one value if the [`Option`] is a [`Some`], otherwise none.
 ///
 /// This `struct` is created by the [`Option::into_iter`] function.
-///
-/// [`Option::into_iter`]: enum.Option.html#method.into_iter
 #[derive(Clone, Debug)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct IntoIter<A> {

--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -4,7 +4,7 @@
 //!
 //! For more details, see the [`std::str`] module.
 //!
-//! [`std::str`]: self
+//! [`std::str`]: ../../std/str/index.html
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
@@ -83,9 +83,6 @@ pub trait FromStr: Sized {
     /// If parsing succeeds, return the value inside [`Ok`], otherwise
     /// when the string is ill-formatted return an error specific to the
     /// inside [`Err`]. The error type is specific to implementation of the trait.
-    ///
-    /// [`Ok`]: ../../std/result/enum.Result.html#variant.Ok
-    /// [`Err`]: ../../std/result/enum.Result.html#variant.Err
     ///
     /// # Examples
     ///
@@ -269,10 +266,8 @@ impl Utf8Error {
 ///
 /// If you are sure that the byte slice is valid UTF-8, and you don't want to
 /// incur the overhead of the validity check, there is an unsafe version of
-/// this function, [`from_utf8_unchecked`][fromutf8u], which has the same
+/// this function, [`from_utf8_unchecked`], which has the same
 /// behavior but skips the check.
-///
-/// [fromutf8u]: fn.from_utf8_unchecked.html
 ///
 /// If you need a `String` instead of a `&str`, consider
 /// [`String::from_utf8`][string].
@@ -318,10 +313,8 @@ impl Utf8Error {
 /// assert!(str::from_utf8(&sparkle_heart).is_err());
 /// ```
 ///
-/// See the docs for [`Utf8Error`][error] for more details on the kinds of
+/// See the docs for [`Utf8Error`] for more details on the kinds of
 /// errors that can be returned.
-///
-/// [error]: struct.Utf8Error.html
 ///
 /// A "stack allocated string":
 ///
@@ -371,10 +364,8 @@ pub fn from_utf8(v: &[u8]) -> Result<&str, Utf8Error> {
 ///
 /// assert!(str::from_utf8_mut(&mut invalid).is_err());
 /// ```
-/// See the docs for [`Utf8Error`][error] for more details on the kinds of
+/// See the docs for [`Utf8Error`] for more details on the kinds of
 /// errors that can be returned.
-///
-/// [error]: struct.Utf8Error.html
 #[stable(feature = "str_mut_extras", since = "1.20.0")]
 pub fn from_utf8_mut(v: &mut [u8]) -> Result<&mut str, Utf8Error> {
     run_utf8_validation(v)?;
@@ -385,9 +376,7 @@ pub fn from_utf8_mut(v: &mut [u8]) -> Result<&mut str, Utf8Error> {
 /// Converts a slice of bytes to a string slice without checking
 /// that the string contains valid UTF-8.
 ///
-/// See the safe version, [`from_utf8`][fromutf8], for more information.
-///
-/// [fromutf8]: fn.from_utf8.html
+/// See the safe version, [`from_utf8`], for more information.
 ///
 /// # Safety
 ///

--- a/library/core/src/str/pattern.rs
+++ b/library/core/src/str/pattern.rs
@@ -28,7 +28,7 @@
 //! assert_eq!(s.find(|c: char| c.is_ascii_punctuation()), Some(35));
 //! ```
 //!
-//! [pattern-impls]: trait.Pattern.html#implementors
+//! [pattern-impls]: Pattern#implementors
 
 #![unstable(
     feature = "pattern",

--- a/library/std/src/collections/hash/map.rs
+++ b/library/std/src/collections/hash/map.rs
@@ -1298,9 +1298,7 @@ pub struct RawEntryBuilderMut<'a, K: 'a, V: 'a, S: 'a> {
 /// This `enum` is constructed through the [`raw_entry_mut`] method on [`HashMap`],
 /// then calling one of the methods of that [`RawEntryBuilderMut`].
 ///
-/// [`Entry`]: enum.Entry.html
 /// [`raw_entry_mut`]: HashMap::raw_entry_mut
-/// [`RawEntryBuilderMut`]: struct.RawEntryBuilderMut.html
 #[unstable(feature = "hash_raw_entry", issue = "56167")]
 pub enum RawEntryMut<'a, K: 'a, V: 'a, S: 'a> {
     /// An occupied entry.
@@ -1705,8 +1703,6 @@ impl<K: Debug, V: Debug> Debug for Entry<'_, K, V> {
 
 /// A view into an occupied entry in a `HashMap`.
 /// It is part of the [`Entry`] enum.
-///
-/// [`Entry`]: enum.Entry.html
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct OccupiedEntry<'a, K: 'a, V: 'a> {
     base: base::RustcOccupiedEntry<'a, K, V>,
@@ -1721,8 +1717,6 @@ impl<K: Debug, V: Debug> Debug for OccupiedEntry<'_, K, V> {
 
 /// A view into a vacant entry in a `HashMap`.
 /// It is part of the [`Entry`] enum.
-///
-/// [`Entry`]: enum.Entry.html
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct VacantEntry<'a, K: 'a, V: 'a> {
     base: base::RustcVacantEntry<'a, K, V>,


### PR DESCRIPTION
Partial fix for #75080

@rustbot modify labels: T-doc A-intra-doc-links

r? @jyn514