### PR TITLE
Remove weird looking dashes

### DIFF
--- a/src/doc/rustdoc/src/unstable-features.md
+++ b/src/doc/rustdoc/src/unstable-features.md
@@ -100,7 +100,7 @@ Note: Because of how `macro_rules` macros are scoped in Rust, the intra-doc link
 These features operate by extending the `#[doc]` attribute, and thus can be caught by the compiler
 and enabled with a `#![feature(...)]` attribute in your crate.
 
-### Documenting platform/feature specific information
+### Documenting platform-specific or feature-specific information
 
 Because of the way Rustdoc documents a crate, the documentation it creates is specific to the target
 rustc compiles for. Anything that's specific to any other target is dropped via `#[cfg]` attribute

--- a/src/doc/rustdoc/src/unstable-features.md
+++ b/src/doc/rustdoc/src/unstable-features.md
@@ -100,7 +100,7 @@ Note: Because of how `macro_rules` macros are scoped in Rust, the intra-doc link
 These features operate by extending the `#[doc]` attribute, and thus can be caught by the compiler
 and enabled with a `#![feature(...)]` attribute in your crate.
 
-### Documenting platform-/feature-specific information
+### Documenting platform/feature specific information
 
 Because of the way Rustdoc documents a crate, the documentation it creates is specific to the target
 rustc compiles for. Anything that's specific to any other target is dropped via `#[cfg]` attribute


### PR DESCRIPTION
Removed some weird looking dashes from the unstable book. It could look like to a newcomer that someone had made a typo while writing the docs