### PR TITLE
Fix 'FIXME' about using NonZeroU32 instead of u32.

### DIFF
--- a/compiler/rustc_feature/src/accepted.rs
+++ b/compiler/rustc_feature/src/accepted.rs
@@ -1,6 +1,6 @@
 //! List of the accepted feature gates.
 
-use super::{Feature, State};
+use super::{to_nonzero, Feature, State};
 use rustc_span::symbol::sym;
 
 macro_rules! declare_features {
@@ -14,7 +14,7 @@ macro_rules! declare_features {
                     state: State::Accepted,
                     name: sym::$feature,
                     since: $ver,
-                    issue: $issue,
+                    issue: to_nonzero($issue),
                     edition: None,
                     description: concat!($($doc,)*),
                 }

--- a/compiler/rustc_feature/src/active.rs
+++ b/compiler/rustc_feature/src/active.rs
@@ -1,6 +1,6 @@
 //! List of the active feature gates.
 
-use super::{Feature, State};
+use super::{to_nonzero, Feature, State};
 
 use rustc_span::edition::Edition;
 use rustc_span::symbol::{sym, Symbol};
@@ -29,7 +29,7 @@ macro_rules! declare_features {
                     state: State::Active { set: set!($feature) },
                     name: sym::$feature,
                     since: $ver,
-                    issue: $issue,
+                    issue: to_nonzero($issue),
                     edition: $edition,
                     description: concat!($($doc,)*),
                 }

--- a/compiler/rustc_feature/src/lib.rs
+++ b/compiler/rustc_feature/src/lib.rs
@@ -46,15 +46,9 @@ pub struct Feature {
     pub state: State,
     pub name: Symbol,
     pub since: &'static str,
-    issue: Option<u32>, // FIXME: once #58732 is done make this an Option<NonZeroU32>
+    issue: Option<NonZeroU32>,
     pub edition: Option<Edition>,
     description: &'static str,
-}
-
-impl Feature {
-    fn issue(&self) -> Option<NonZeroU32> {
-        self.issue.and_then(NonZeroU32::new)
-    }
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -102,8 +96,8 @@ impl UnstableFeatures {
 fn find_lang_feature_issue(feature: Symbol) -> Option<NonZeroU32> {
     if let Some(info) = ACTIVE_FEATURES.iter().find(|t| t.name == feature) {
         // FIXME (#28244): enforce that active features have issue numbers
-        // assert!(info.issue().is_some())
-        info.issue()
+        // assert!(info.issue.is_some())
+        info.issue
     } else {
         // search in Accepted, Removed, or Stable Removed features
         let found = ACCEPTED_FEATURES
@@ -112,9 +106,16 @@ fn find_lang_feature_issue(feature: Symbol) -> Option<NonZeroU32> {
             .chain(STABLE_REMOVED_FEATURES)
             .find(|t| t.name == feature);
         match found {
-            Some(found) => found.issue(),
+            Some(found) => found.issue,
             None => panic!("feature `{}` is not declared anywhere", feature),
         }
+    }
+}
+
+const fn to_nonzero(n: Option<u32>) -> Option<NonZeroU32> {
+    match n {
+        None => None,
+        Some(n) => NonZeroU32::new(n),
     }
 }
 

--- a/compiler/rustc_feature/src/lib.rs
+++ b/compiler/rustc_feature/src/lib.rs
@@ -113,6 +113,8 @@ fn find_lang_feature_issue(feature: Symbol) -> Option<NonZeroU32> {
 }
 
 const fn to_nonzero(n: Option<u32>) -> Option<NonZeroU32> {
+    // Can be replaced with `n.and_then(NonZeroU32::new)` if that is ever usable
+    // in const context. Requires https://github.com/rust-lang/rfcs/pull/2632.
     match n {
         None => None,
         Some(n) => NonZeroU32::new(n),

--- a/compiler/rustc_feature/src/removed.rs
+++ b/compiler/rustc_feature/src/removed.rs
@@ -1,6 +1,6 @@
 //! List of the removed feature gates.
 
-use super::{Feature, State};
+use super::{to_nonzero, Feature, State};
 use rustc_span::symbol::sym;
 
 macro_rules! declare_features {
@@ -14,7 +14,7 @@ macro_rules! declare_features {
                     state: State::Removed { reason: $reason },
                     name: sym::$feature,
                     since: $ver,
-                    issue: $issue,
+                    issue: to_nonzero($issue),
                     edition: None,
                     description: concat!($($doc,)*),
                 }
@@ -32,7 +32,7 @@ macro_rules! declare_features {
                     state: State::Stabilized { reason: None },
                     name: sym::$feature,
                     since: $ver,
-                    issue: $issue,
+                    issue: to_nonzero($issue),
                     edition: None,
                     description: concat!($($doc,)*),
                 }


### PR DESCRIPTION
It was blocked by #58732 (const fn NonZeroU32::new), which is fixed now.