### PR TITLE
Upgrade libz-sys to 1.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1657,9 +1657,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.0.27"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ca8894883d250240341478bf987467332fbdd5da5c42426c69a8f93dbc302f2"
+checksum = "602113192b08db8f38796c4e85c39e960c145965140e918018bcde1952429655"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
The current version has warnings that become errors on new versions of clang shipped in XCode:

```
warning: src/zlib/gzlib.c:214:15: error: implicitly declaring library function 'snprintf' with type 'int (char *, unsigned long, const char *, ...)' [-Werror,-Wimplicit-function-declaration]
warning:         (void)snprintf(state->path, len + 1, "%s", (const char *)path);
warning:               ^
warning: src/zlib/gzlib.c:214:15: note: include the header <stdio.h> or explicitly provide a declaration for 'snprintf'
warning: 1 error generated.

warning: src/zlib/gzwrite.c:428:11: error: implicitly declaring library function 'vsnprintf' with type 'int (char *, unsigned long, const char *, __builtin_va_list)' [-Werror,-Wimplicit-function-declaration
warning:     len = vsnprintf(next, state->size, format, va);
warning:           ^
warning: src/zlib/gzwrite.c:428:11: note: include the header <stdio.h> or explicitly provide a declaration for 'vsnprintf'
warning: 1 error generated.
```

r? @Mark-Simulacrum 

/cc @joshtriplett 