### PR TITLE
Properly handle lint spans after MIR inlining

### DIFF
--- a/compiler/rustc_errors/src/emitter.rs
+++ b/compiler/rustc_errors/src/emitter.rs
@@ -357,7 +357,8 @@ pub trait Emitter {
                 }
 
                 if matches!(trace.kind, ExpnKind::Inlined) {
-                    new_labels.push((trace.call_site, "in the inlined copy of this".to_string()));
+                    new_labels
+                        .push((trace.call_site, "in the inlined copy of this code".to_string()));
                 } else if always_backtrace {
                     new_labels.push((
                         trace.def_site,

--- a/compiler/rustc_errors/src/emitter.rs
+++ b/compiler/rustc_errors/src/emitter.rs
@@ -296,7 +296,7 @@ pub trait Emitter {
 
                     // Skip past non-macro entries, just in case there
                     // are some which do actually involve macros.
-                    ExpnKind::Desugaring(..) | ExpnKind::AstPass(..) => None,
+                    ExpnKind::Inlined | ExpnKind::Desugaring(..) | ExpnKind::AstPass(..) => None,
 
                     ExpnKind::Macro(macro_kind, _) => Some(macro_kind),
                 }
@@ -356,7 +356,9 @@ pub trait Emitter {
                     continue;
                 }
 
-                if always_backtrace {
+                if matches!(trace.kind, ExpnKind::Inlined) {
+                    new_labels.push((trace.call_site, "in the inlined copy of this".to_string()));
+                } else if always_backtrace {
                     new_labels.push((
                         trace.def_site,
                         format!(

--- a/compiler/rustc_middle/src/lint.rs
+++ b/compiler/rustc_middle/src/lint.rs
@@ -358,7 +358,9 @@ pub fn struct_lint_level<'s, 'd>(
 pub fn in_external_macro(sess: &Session, span: Span) -> bool {
     let expn_data = span.ctxt().outer_expn_data();
     match expn_data.kind {
-        ExpnKind::Root | ExpnKind::Desugaring(DesugaringKind::ForLoop(_)) => false,
+        ExpnKind::Inlined | ExpnKind::Root | ExpnKind::Desugaring(DesugaringKind::ForLoop(_)) => {
+            false
+        }
         ExpnKind::AstPass(_) | ExpnKind::Desugaring(_) => true, // well, it's "external"
         ExpnKind::Macro(MacroKind::Bang, _) => {
             // Dummy span for the `def_site` means it's an external macro.

--- a/compiler/rustc_mir/src/transform/inline.rs
+++ b/compiler/rustc_mir/src/transform/inline.rs
@@ -8,6 +8,7 @@ use rustc_middle::mir::visit::*;
 use rustc_middle::mir::*;
 use rustc_middle::ty::subst::Subst;
 use rustc_middle::ty::{self, ConstKind, Instance, InstanceDef, ParamEnv, Ty, TyCtxt};
+use rustc_span::{hygiene::ExpnKind, ExpnData, Span};
 use rustc_target::spec::abi::Abi;
 
 use super::simplify::{remove_dead_blocks, CfgSimplifier};
@@ -488,6 +489,8 @@ impl Inliner<'tcx> {
                     cleanup_block: cleanup,
                     in_cleanup_block: false,
                     tcx: self.tcx,
+                    callsite_span: callsite.source_info.span,
+                    body_span: callee_body.span,
                 };
 
                 // Map all `Local`s, `SourceScope`s and `BasicBlock`s to new ones
@@ -699,6 +702,8 @@ struct Integrator<'a, 'tcx> {
     cleanup_block: Option<BasicBlock>,
     in_cleanup_block: bool,
     tcx: TyCtxt<'tcx>,
+    callsite_span: Span,
+    body_span: Span,
 }
 
 impl<'a, 'tcx> Integrator<'a, 'tcx> {
@@ -741,6 +746,14 @@ impl<'a, 'tcx> MutVisitor<'tcx> for Integrator<'a, 'tcx> {
 
     fn visit_source_scope(&mut self, scope: &mut SourceScope) {
         *scope = self.map_scope(*scope);
+    }
+
+    fn visit_span(&mut self, span: &mut Span) {
+        // Make sure that all spans track the fact that they were inlined.
+        *span = self.callsite_span.fresh_expansion(ExpnData {
+            def_site: self.body_span,
+            ..ExpnData::default(ExpnKind::Inlined, *span, self.tcx.sess.edition(), None)
+        });
     }
 
     fn visit_place(&mut self, place: &mut Place<'tcx>, context: PlaceContext, location: Location) {

--- a/compiler/rustc_save_analysis/src/lib.rs
+++ b/compiler/rustc_save_analysis/src/lib.rs
@@ -799,7 +799,9 @@ impl<'tcx> SaveContext<'tcx> {
 
             // These are not macros.
             // FIXME(eddyb) maybe there is a way to handle them usefully?
-            ExpnKind::Root | ExpnKind::AstPass(_) | ExpnKind::Desugaring(_) => return None,
+            ExpnKind::Inlined | ExpnKind::Root | ExpnKind::AstPass(_) | ExpnKind::Desugaring(_) => {
+                return None;
+            }
         };
 
         let callee_span = self.span_from_span(callee.def_site);

--- a/compiler/rustc_span/src/hygiene.rs
+++ b/compiler/rustc_span/src/hygiene.rs
@@ -766,6 +766,8 @@ pub enum ExpnKind {
     AstPass(AstPass),
     /// Desugaring done by the compiler during HIR lowering.
     Desugaring(DesugaringKind),
+    /// MIR inlining
+    Inlined,
 }
 
 impl ExpnKind {
@@ -779,6 +781,7 @@ impl ExpnKind {
             },
             ExpnKind::AstPass(kind) => kind.descr().to_string(),
             ExpnKind::Desugaring(kind) => format!("desugaring of {}", kind.descr()),
+            ExpnKind::Inlined => "inlined source".to_string(),
         }
     }
 }

--- a/src/test/mir-opt/dest-prop/cycle.main.DestinationPropagation.diff
+++ b/src/test/mir-opt/dest-prop/cycle.main.DestinationPropagation.diff
@@ -19,7 +19,7 @@
 -                 debug z => _3;           // in scope 3 at $DIR/cycle.rs:11:9: 11:10
 +                 debug z => _4;           // in scope 3 at $DIR/cycle.rs:11:9: 11:10
                   scope 4 (inlined std::mem::drop::<i32>) { // at $DIR/cycle.rs:14:5: 14:12
-                      debug _x => _6;      // in scope 4 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+                      debug _x => _6;      // in scope 4 at $DIR/cycle.rs:14:5: 14:12
                   }
               }
           }
@@ -56,7 +56,7 @@
           StorageLive(_6);                 // scope 3 at $DIR/cycle.rs:14:10: 14:11
 -         _6 = _1;                         // scope 3 at $DIR/cycle.rs:14:10: 14:11
 +         _6 = _4;                         // scope 3 at $DIR/cycle.rs:14:10: 14:11
-          _5 = const ();                   // scope 4 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+          _5 = const ();                   // scope 4 at $DIR/cycle.rs:14:5: 14:12
           StorageDead(_6);                 // scope 3 at $DIR/cycle.rs:14:11: 14:12
           StorageDead(_5);                 // scope 3 at $DIR/cycle.rs:14:12: 14:13
           _0 = const ();                   // scope 0 at $DIR/cycle.rs:8:11: 15:2

--- a/src/test/mir-opt/dest-prop/union.main.DestinationPropagation.diff
+++ b/src/test/mir-opt/dest-prop/union.main.DestinationPropagation.diff
@@ -12,7 +12,7 @@
           scope 2 {
           }
           scope 3 (inlined std::mem::drop::<u32>) { // at $DIR/union.rs:15:5: 15:27
-              debug _x => _4;              // in scope 3 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+              debug _x => _4;              // in scope 3 at $DIR/union.rs:15:5: 15:27
           }
       }
   
@@ -31,7 +31,7 @@
           StorageLive(_3);                 // scope 1 at $DIR/union.rs:15:5: 15:27
           StorageLive(_4);                 // scope 1 at $DIR/union.rs:15:10: 15:26
           _4 = (_1.0: u32);                // scope 2 at $DIR/union.rs:15:19: 15:24
-          _3 = const ();                   // scope 3 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+          _3 = const ();                   // scope 3 at $DIR/union.rs:15:5: 15:27
           StorageDead(_4);                 // scope 1 at $DIR/union.rs:15:26: 15:27
           StorageDead(_3);                 // scope 1 at $DIR/union.rs:15:27: 15:28
           _0 = const ();                   // scope 0 at $DIR/union.rs:8:11: 16:2

--- a/src/test/mir-opt/generator_drop_cleanup.main-{closure#0}.generator_drop.0.mir
+++ b/src/test/mir-opt/generator_drop_cleanup.main-{closure#0}.generator_drop.0.mir
@@ -27,8 +27,8 @@ fn main::{closure#0}(_1: *mut [generator@$DIR/generator-drop-cleanup.rs:10:15: 1
         debug _s => (((*_1) as variant#3).0: std::string::String); // in scope 1 at $DIR/generator-drop-cleanup.rs:11:13: 11:15
     }
     scope 2 (inlined String::new) {      // at $DIR/generator-drop-cleanup.rs:11:18: 11:31
-        let mut _6: std::vec::Vec<u8>;   // in scope 2 at $SRC_DIR/alloc/src/string.rs:LL:COL
-        scope 3 (inlined Vec::<u8>::new) { // at $SRC_DIR/alloc/src/string.rs:LL:COL
+        let mut _6: std::vec::Vec<u8>;   // in scope 2 at $DIR/generator-drop-cleanup.rs:11:18: 11:31
+        scope 3 (inlined Vec::<u8>::new) { // at $DIR/generator-drop-cleanup.rs:11:18: 11:31
         }
     }
 

--- a/src/test/mir-opt/inline/inline_any_operand.bar.Inline.after.mir
+++ b/src/test/mir-opt/inline/inline_any_operand.bar.Inline.after.mir
@@ -9,10 +9,10 @@ fn bar() -> bool {
     scope 1 {
         debug f => _1;                   // in scope 1 at $DIR/inline-any-operand.rs:11:9: 11:10
         scope 2 (inlined foo) {          // at $DIR/inline-any-operand.rs:12:5: 12:13
-            debug x => _3;               // in scope 2 at $DIR/inline-any-operand.rs:16:8: 16:9
-            debug y => _4;               // in scope 2 at $DIR/inline-any-operand.rs:16:16: 16:17
-            let mut _5: i32;             // in scope 2 at $DIR/inline-any-operand.rs:17:5: 17:6
-            let mut _6: i32;             // in scope 2 at $DIR/inline-any-operand.rs:17:10: 17:11
+            debug x => _3;               // in scope 2 at $DIR/inline-any-operand.rs:12:5: 12:13
+            debug y => _4;               // in scope 2 at $DIR/inline-any-operand.rs:12:5: 12:13
+            let mut _5: i32;             // in scope 2 at $DIR/inline-any-operand.rs:12:5: 12:13
+            let mut _6: i32;             // in scope 2 at $DIR/inline-any-operand.rs:12:5: 12:13
         }
     }
 
@@ -28,13 +28,13 @@ fn bar() -> bool {
         _3 = const 1_i32;                // scope 1 at $DIR/inline-any-operand.rs:12:5: 12:13
         StorageLive(_4);                 // scope 1 at $DIR/inline-any-operand.rs:12:5: 12:13
         _4 = const -1_i32;               // scope 1 at $DIR/inline-any-operand.rs:12:5: 12:13
-        StorageLive(_5);                 // scope 2 at $DIR/inline-any-operand.rs:17:5: 17:6
-        _5 = _3;                         // scope 2 at $DIR/inline-any-operand.rs:17:5: 17:6
-        StorageLive(_6);                 // scope 2 at $DIR/inline-any-operand.rs:17:10: 17:11
-        _6 = _4;                         // scope 2 at $DIR/inline-any-operand.rs:17:10: 17:11
-        _0 = Eq(move _5, move _6);       // scope 2 at $DIR/inline-any-operand.rs:17:5: 17:11
-        StorageDead(_6);                 // scope 2 at $DIR/inline-any-operand.rs:17:10: 17:11
-        StorageDead(_5);                 // scope 2 at $DIR/inline-any-operand.rs:17:10: 17:11
+        StorageLive(_5);                 // scope 2 at $DIR/inline-any-operand.rs:12:5: 12:13
+        _5 = _3;                         // scope 2 at $DIR/inline-any-operand.rs:12:5: 12:13
+        StorageLive(_6);                 // scope 2 at $DIR/inline-any-operand.rs:12:5: 12:13
+        _6 = _4;                         // scope 2 at $DIR/inline-any-operand.rs:12:5: 12:13
+        _0 = Eq(move _5, move _6);       // scope 2 at $DIR/inline-any-operand.rs:12:5: 12:13
+        StorageDead(_6);                 // scope 2 at $DIR/inline-any-operand.rs:12:5: 12:13
+        StorageDead(_5);                 // scope 2 at $DIR/inline-any-operand.rs:12:5: 12:13
         StorageDead(_4);                 // scope 1 at $DIR/inline-any-operand.rs:12:5: 12:13
         StorageDead(_3);                 // scope 1 at $DIR/inline-any-operand.rs:12:5: 12:13
         StorageDead(_2);                 // scope 1 at $DIR/inline-any-operand.rs:12:12: 12:13

--- a/src/test/mir-opt/inline/inline_closure.foo.Inline.after.mir
+++ b/src/test/mir-opt/inline/inline_closure.foo.Inline.after.mir
@@ -14,8 +14,8 @@ fn foo(_1: T, _2: i32) -> i32 {
     scope 1 {
         debug x => _3;                   // in scope 1 at $DIR/inline-closure.rs:11:9: 11:10
         scope 2 (inlined foo::<T>::{closure#0}) { // at $DIR/inline-closure.rs:12:5: 12:12
-            debug _t => _8;              // in scope 2 at $DIR/inline-closure.rs:11:14: 11:16
-            debug _q => _9;              // in scope 2 at $DIR/inline-closure.rs:11:18: 11:20
+            debug _t => _8;              // in scope 2 at $DIR/inline-closure.rs:12:5: 12:12
+            debug _q => _9;              // in scope 2 at $DIR/inline-closure.rs:12:5: 12:12
         }
     }
 
@@ -34,7 +34,7 @@ fn foo(_1: T, _2: i32) -> i32 {
         _8 = move (_5.0: i32);           // scope 1 at $DIR/inline-closure.rs:12:5: 12:12
         StorageLive(_9);                 // scope 1 at $DIR/inline-closure.rs:12:5: 12:12
         _9 = move (_5.1: i32);           // scope 1 at $DIR/inline-closure.rs:12:5: 12:12
-        _0 = _8;                         // scope 2 at $DIR/inline-closure.rs:11:22: 11:24
+        _0 = _8;                         // scope 2 at $DIR/inline-closure.rs:12:5: 12:12
         StorageDead(_9);                 // scope 1 at $DIR/inline-closure.rs:12:5: 12:12
         StorageDead(_8);                 // scope 1 at $DIR/inline-closure.rs:12:5: 12:12
         StorageDead(_7);                 // scope 1 at $DIR/inline-closure.rs:12:11: 12:12

--- a/src/test/mir-opt/inline/inline_closure_borrows_arg.foo.Inline.after.mir
+++ b/src/test/mir-opt/inline/inline_closure_borrows_arg.foo.Inline.after.mir
@@ -14,11 +14,11 @@ fn foo(_1: T, _2: &i32) -> i32 {
     scope 1 {
         debug x => _3;                   // in scope 1 at $DIR/inline-closure-borrows-arg.rs:12:9: 12:10
         scope 2 (inlined foo::<T>::{closure#0}) { // at $DIR/inline-closure-borrows-arg.rs:16:5: 16:12
-            debug r => _8;               // in scope 2 at $DIR/inline-closure-borrows-arg.rs:12:14: 12:15
-            debug _s => _9;              // in scope 2 at $DIR/inline-closure-borrows-arg.rs:12:23: 12:25
-            let _10: &i32;               // in scope 2 at $DIR/inline-closure-borrows-arg.rs:13:13: 13:21
+            debug r => _8;               // in scope 2 at $DIR/inline-closure-borrows-arg.rs:16:5: 16:12
+            debug _s => _9;              // in scope 2 at $DIR/inline-closure-borrows-arg.rs:16:5: 16:12
+            let _10: &i32;               // in scope 2 at $DIR/inline-closure-borrows-arg.rs:16:5: 16:12
             scope 3 {
-                debug variable => _10;   // in scope 3 at $DIR/inline-closure-borrows-arg.rs:13:13: 13:21
+                debug variable => _10;   // in scope 3 at $DIR/inline-closure-borrows-arg.rs:16:5: 16:12
             }
         }
     }
@@ -38,10 +38,10 @@ fn foo(_1: T, _2: &i32) -> i32 {
         _8 = move (_5.0: &i32);          // scope 1 at $DIR/inline-closure-borrows-arg.rs:16:5: 16:12
         StorageLive(_9);                 // scope 1 at $DIR/inline-closure-borrows-arg.rs:16:5: 16:12
         _9 = move (_5.1: &i32);          // scope 1 at $DIR/inline-closure-borrows-arg.rs:16:5: 16:12
-        StorageLive(_10);                // scope 2 at $DIR/inline-closure-borrows-arg.rs:13:13: 13:21
-        _10 = _8;                        // scope 2 at $DIR/inline-closure-borrows-arg.rs:13:24: 13:27
-        _0 = (*_8);                      // scope 3 at $DIR/inline-closure-borrows-arg.rs:14:9: 14:18
-        StorageDead(_10);                // scope 2 at $DIR/inline-closure-borrows-arg.rs:15:5: 15:6
+        StorageLive(_10);                // scope 2 at $DIR/inline-closure-borrows-arg.rs:16:5: 16:12
+        _10 = _8;                        // scope 2 at $DIR/inline-closure-borrows-arg.rs:16:5: 16:12
+        _0 = (*_8);                      // scope 3 at $DIR/inline-closure-borrows-arg.rs:16:5: 16:12
+        StorageDead(_10);                // scope 2 at $DIR/inline-closure-borrows-arg.rs:16:5: 16:12
         StorageDead(_9);                 // scope 1 at $DIR/inline-closure-borrows-arg.rs:16:5: 16:12
         StorageDead(_8);                 // scope 1 at $DIR/inline-closure-borrows-arg.rs:16:5: 16:12
         StorageDead(_7);                 // scope 1 at $DIR/inline-closure-borrows-arg.rs:16:11: 16:12

--- a/src/test/mir-opt/inline/inline_closure_captures.foo.Inline.after.mir
+++ b/src/test/mir-opt/inline/inline_closure_captures.foo.Inline.after.mir
@@ -14,10 +14,10 @@ fn foo(_1: T, _2: i32) -> (i32, T) {
     scope 1 {
         debug x => _3;                   // in scope 1 at $DIR/inline-closure-captures.rs:11:9: 11:10
         scope 2 (inlined foo::<T>::{closure#0}) { // at $DIR/inline-closure-captures.rs:12:5: 12:9
-            debug _q => _9;              // in scope 2 at $DIR/inline-closure-captures.rs:11:14: 11:16
-            debug q => (*((*_6).0: &i32)); // in scope 2 at $DIR/inline-closure-captures.rs:10:23: 10:24
-            debug t => (*((*_6).1: &T)); // in scope 2 at $DIR/inline-closure-captures.rs:10:17: 10:18
-            let mut _10: T;              // in scope 2 at $DIR/inline-closure-captures.rs:11:22: 11:23
+            debug _q => _9;              // in scope 2 at $DIR/inline-closure-captures.rs:12:5: 12:9
+            debug q => (*((*_6).0: &i32)); // in scope 2 at $DIR/inline-closure-captures.rs:12:5: 12:9
+            debug t => (*((*_6).1: &T)); // in scope 2 at $DIR/inline-closure-captures.rs:12:5: 12:9
+            let mut _10: T;              // in scope 2 at $DIR/inline-closure-captures.rs:12:5: 12:9
         }
     }
 
@@ -39,11 +39,11 @@ fn foo(_1: T, _2: i32) -> (i32, T) {
         (_7.0: i32) = move _8;           // scope 1 at $DIR/inline-closure-captures.rs:12:5: 12:9
         StorageLive(_9);                 // scope 1 at $DIR/inline-closure-captures.rs:12:5: 12:9
         _9 = move (_7.0: i32);           // scope 1 at $DIR/inline-closure-captures.rs:12:5: 12:9
-        (_0.0: i32) = (*((*_6).0: &i32)); // scope 2 at $DIR/inline-closure-captures.rs:11:19: 11:20
-        StorageLive(_10);                // scope 2 at $DIR/inline-closure-captures.rs:11:22: 11:23
-        _10 = (*((*_6).1: &T));          // scope 2 at $DIR/inline-closure-captures.rs:11:22: 11:23
-        (_0.1: T) = move _10;            // scope 2 at $DIR/inline-closure-captures.rs:11:18: 11:24
-        StorageDead(_10);                // scope 2 at $DIR/inline-closure-captures.rs:11:23: 11:24
+        (_0.0: i32) = (*((*_6).0: &i32)); // scope 2 at $DIR/inline-closure-captures.rs:12:5: 12:9
+        StorageLive(_10);                // scope 2 at $DIR/inline-closure-captures.rs:12:5: 12:9
+        _10 = (*((*_6).1: &T));          // scope 2 at $DIR/inline-closure-captures.rs:12:5: 12:9
+        (_0.1: T) = move _10;            // scope 2 at $DIR/inline-closure-captures.rs:12:5: 12:9
+        StorageDead(_10);                // scope 2 at $DIR/inline-closure-captures.rs:12:5: 12:9
         StorageDead(_9);                 // scope 1 at $DIR/inline-closure-captures.rs:12:5: 12:9
         StorageDead(_8);                 // scope 1 at $DIR/inline-closure-captures.rs:12:8: 12:9
         StorageDead(_7);                 // scope 1 at $DIR/inline-closure-captures.rs:12:8: 12:9

--- a/src/test/mir-opt/inline/inline_compatibility.inlined_no_sanitize.Inline.diff
+++ b/src/test/mir-opt/inline/inline_compatibility.inlined_no_sanitize.Inline.diff
@@ -16,7 +16,7 @@
 -     }
 - 
 -     bb1: {
-+         _1 = const ();                   // scope 1 at $DIR/inline-compatibility.rs:39:29: 39:31
++         _1 = const ();                   // scope 1 at $DIR/inline-compatibility.rs:25:5: 25:18
           StorageDead(_1);                 // scope 0 at $DIR/inline-compatibility.rs:25:18: 25:19
           _0 = const ();                   // scope 0 at $DIR/inline-compatibility.rs:24:37: 26:2
           return;                          // scope 0 at $DIR/inline-compatibility.rs:26:2: 26:2

--- a/src/test/mir-opt/inline/inline_compatibility.inlined_target_feature.Inline.diff
+++ b/src/test/mir-opt/inline/inline_compatibility.inlined_target_feature.Inline.diff
@@ -16,7 +16,7 @@
 -     }
 - 
 -     bb1: {
-+         _1 = const ();                   // scope 1 at $DIR/inline-compatibility.rs:35:32: 35:34
++         _1 = const ();                   // scope 1 at $DIR/inline-compatibility.rs:14:5: 14:21
           StorageDead(_1);                 // scope 0 at $DIR/inline-compatibility.rs:14:21: 14:22
           _0 = const ();                   // scope 0 at $DIR/inline-compatibility.rs:13:40: 15:2
           return;                          // scope 0 at $DIR/inline-compatibility.rs:15:2: 15:2

--- a/src/test/mir-opt/inline/inline_into_box_place.main.Inline.32bit.diff
+++ b/src/test/mir-opt/inline/inline_into_box_place.main.Inline.32bit.diff
@@ -19,7 +19,7 @@
           _2 = Box(std::vec::Vec<u32>);    // scope 0 at $DIR/inline-into-box-place.rs:8:29: 8:43
 -         (*_2) = Vec::<u32>::new() -> [return: bb1, unwind: bb4]; // scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
 +         _4 = &mut (*_2);                 // scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
-+         ((*_4).0: alloc::raw_vec::RawVec<u32>) = const alloc::raw_vec::RawVec::<u32> { ptr: Unique::<u32> { pointer: {0x4 as *const u32}, _marker: PhantomData::<u32> }, cap: 0_usize, alloc: std::alloc::Global }; // scope 2 at $SRC_DIR/alloc/src/vec.rs:LL:COL
++         ((*_4).0: alloc::raw_vec::RawVec<u32>) = const alloc::raw_vec::RawVec::<u32> { ptr: Unique::<u32> { pointer: {0x4 as *const u32}, _marker: PhantomData::<u32> }, cap: 0_usize, alloc: std::alloc::Global }; // scope 2 at $DIR/inline-into-box-place.rs:8:33: 8:43
 +                                          // ty::Const
 +                                          // + ty: alloc::raw_vec::RawVec<u32>
 +                                          // + val: Value(ByRef { alloc: Allocation { bytes: [4, 0, 0, 0, 0, 0, 0, 0], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [255], len: Size { raw: 8 } }, size: Size { raw: 8 }, align: Align { pow2: 2 }, mutability: Not, extra: () }, offset: Size { raw: 0 } })
@@ -30,10 +30,10 @@
 -     }
 - 
 -     bb1: {
-+                                          // + span: $SRC_DIR/alloc/src/vec.rs:LL:COL
++                                          // + span: $DIR/inline-into-box-place.rs:8:33: 8:43
 +                                          // + user_ty: UserType(0)
 +                                          // + literal: Const { ty: alloc::raw_vec::RawVec<u32>, val: Value(ByRef { alloc: Allocation { bytes: [4, 0, 0, 0, 0, 0, 0, 0], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [255], len: Size { raw: 8 } }, size: Size { raw: 8 }, align: Align { pow2: 2 }, mutability: Not, extra: () }, offset: Size { raw: 0 } }) }
-+         ((*_4).1: usize) = const 0_usize; // scope 2 at $SRC_DIR/alloc/src/vec.rs:LL:COL
++         ((*_4).1: usize) = const 0_usize; // scope 2 at $DIR/inline-into-box-place.rs:8:33: 8:43
           _1 = move _2;                    // scope 0 at $DIR/inline-into-box-place.rs:8:29: 8:43
           StorageDead(_2);                 // scope 0 at $DIR/inline-into-box-place.rs:8:42: 8:43
           _0 = const ();                   // scope 0 at $DIR/inline-into-box-place.rs:7:11: 9:2

--- a/src/test/mir-opt/inline/inline_into_box_place.main.Inline.64bit.diff
+++ b/src/test/mir-opt/inline/inline_into_box_place.main.Inline.64bit.diff
@@ -19,7 +19,7 @@
           _2 = Box(std::vec::Vec<u32>);    // scope 0 at $DIR/inline-into-box-place.rs:8:29: 8:43
 -         (*_2) = Vec::<u32>::new() -> [return: bb1, unwind: bb4]; // scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
 +         _4 = &mut (*_2);                 // scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
-+         ((*_4).0: alloc::raw_vec::RawVec<u32>) = const alloc::raw_vec::RawVec::<u32> { ptr: Unique::<u32> { pointer: {0x4 as *const u32}, _marker: PhantomData::<u32> }, cap: 0_usize, alloc: std::alloc::Global }; // scope 2 at $SRC_DIR/alloc/src/vec.rs:LL:COL
++         ((*_4).0: alloc::raw_vec::RawVec<u32>) = const alloc::raw_vec::RawVec::<u32> { ptr: Unique::<u32> { pointer: {0x4 as *const u32}, _marker: PhantomData::<u32> }, cap: 0_usize, alloc: std::alloc::Global }; // scope 2 at $DIR/inline-into-box-place.rs:8:33: 8:43
 +                                          // ty::Const
 +                                          // + ty: alloc::raw_vec::RawVec<u32>
 +                                          // + val: Value(ByRef { alloc: Allocation { bytes: [4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [65535], len: Size { raw: 16 } }, size: Size { raw: 16 }, align: Align { pow2: 3 }, mutability: Not, extra: () }, offset: Size { raw: 0 } })
@@ -30,10 +30,10 @@
 -     }
 - 
 -     bb1: {
-+                                          // + span: $SRC_DIR/alloc/src/vec.rs:LL:COL
++                                          // + span: $DIR/inline-into-box-place.rs:8:33: 8:43
 +                                          // + user_ty: UserType(0)
 +                                          // + literal: Const { ty: alloc::raw_vec::RawVec<u32>, val: Value(ByRef { alloc: Allocation { bytes: [4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [65535], len: Size { raw: 16 } }, size: Size { raw: 16 }, align: Align { pow2: 3 }, mutability: Not, extra: () }, offset: Size { raw: 0 } }) }
-+         ((*_4).1: usize) = const 0_usize; // scope 2 at $SRC_DIR/alloc/src/vec.rs:LL:COL
++         ((*_4).1: usize) = const 0_usize; // scope 2 at $DIR/inline-into-box-place.rs:8:33: 8:43
           _1 = move _2;                    // scope 0 at $DIR/inline-into-box-place.rs:8:29: 8:43
           StorageDead(_2);                 // scope 0 at $DIR/inline-into-box-place.rs:8:42: 8:43
           _0 = const ();                   // scope 0 at $DIR/inline-into-box-place.rs:7:11: 9:2

--- a/src/test/mir-opt/inline/inline_retag.bar.Inline.after.mir
+++ b/src/test/mir-opt/inline/inline_retag.bar.Inline.after.mir
@@ -15,10 +15,10 @@ fn bar() -> bool {
         let mut _9: &i32;                // in scope 1 at $DIR/inline-retag.rs:12:11: 12:14
         let mut _10: &i32;               // in scope 1 at $DIR/inline-retag.rs:12:7: 12:9
         scope 2 (inlined foo) {          // at $DIR/inline-retag.rs:12:5: 12:15
-            debug x => _3;               // in scope 2 at $DIR/inline-retag.rs:16:8: 16:9
-            debug y => _6;               // in scope 2 at $DIR/inline-retag.rs:16:17: 16:18
-            let mut _11: i32;            // in scope 2 at $DIR/inline-retag.rs:17:5: 17:7
-            let mut _12: i32;            // in scope 2 at $DIR/inline-retag.rs:17:11: 17:13
+            debug x => _3;               // in scope 2 at $DIR/inline-retag.rs:12:5: 12:15
+            debug y => _6;               // in scope 2 at $DIR/inline-retag.rs:12:5: 12:15
+            let mut _11: i32;            // in scope 2 at $DIR/inline-retag.rs:12:5: 12:15
+            let mut _12: i32;            // in scope 2 at $DIR/inline-retag.rs:12:5: 12:15
         }
     }
 
@@ -58,15 +58,15 @@ fn bar() -> bool {
         Retag(_7);                       // scope 1 at $DIR/inline-retag.rs:12:11: 12:14
         _6 = &(*_7);                     // scope 1 at $DIR/inline-retag.rs:12:11: 12:14
         Retag(_6);                       // scope 1 at $DIR/inline-retag.rs:12:11: 12:14
-        Retag(_3);                       // scope 2 at $DIR/inline-retag.rs:16:1: 18:2
-        Retag(_6);                       // scope 2 at $DIR/inline-retag.rs:16:1: 18:2
-        StorageLive(_11);                // scope 2 at $DIR/inline-retag.rs:17:5: 17:7
-        _11 = (*_3);                     // scope 2 at $DIR/inline-retag.rs:17:5: 17:7
-        StorageLive(_12);                // scope 2 at $DIR/inline-retag.rs:17:11: 17:13
-        _12 = (*_6);                     // scope 2 at $DIR/inline-retag.rs:17:11: 17:13
-        _0 = Eq(move _11, move _12);     // scope 2 at $DIR/inline-retag.rs:17:5: 17:13
-        StorageDead(_12);                // scope 2 at $DIR/inline-retag.rs:17:12: 17:13
-        StorageDead(_11);                // scope 2 at $DIR/inline-retag.rs:17:12: 17:13
+        Retag(_3);                       // scope 2 at $DIR/inline-retag.rs:12:5: 12:15
+        Retag(_6);                       // scope 2 at $DIR/inline-retag.rs:12:5: 12:15
+        StorageLive(_11);                // scope 2 at $DIR/inline-retag.rs:12:5: 12:15
+        _11 = (*_3);                     // scope 2 at $DIR/inline-retag.rs:12:5: 12:15
+        StorageLive(_12);                // scope 2 at $DIR/inline-retag.rs:12:5: 12:15
+        _12 = (*_6);                     // scope 2 at $DIR/inline-retag.rs:12:5: 12:15
+        _0 = Eq(move _11, move _12);     // scope 2 at $DIR/inline-retag.rs:12:5: 12:15
+        StorageDead(_12);                // scope 2 at $DIR/inline-retag.rs:12:5: 12:15
+        StorageDead(_11);                // scope 2 at $DIR/inline-retag.rs:12:5: 12:15
         StorageDead(_6);                 // scope 1 at $DIR/inline-retag.rs:12:14: 12:15
         StorageDead(_3);                 // scope 1 at $DIR/inline-retag.rs:12:14: 12:15
         StorageDead(_2);                 // scope 1 at $DIR/inline-retag.rs:12:14: 12:15

--- a/src/test/mir-opt/inline/inline_specialization.main.Inline.diff
+++ b/src/test/mir-opt/inline/inline_specialization.main.Inline.diff
@@ -19,7 +19,7 @@
 -     }
 - 
 -     bb1: {
-+         _1 = const 123_u32;              // scope 2 at $DIR/inline-specialization.rs:14:31: 14:34
++         _1 = const 123_u32;              // scope 2 at $DIR/inline-specialization.rs:5:13: 5:38
           _0 = const ();                   // scope 0 at $DIR/inline-specialization.rs:4:11: 6:2
           StorageDead(_1);                 // scope 0 at $DIR/inline-specialization.rs:6:1: 6:2
           return;                          // scope 0 at $DIR/inline-specialization.rs:6:2: 6:2

--- a/src/test/mir-opt/inline/inline_trait_method_2.test2.Inline.after.mir
+++ b/src/test/mir-opt/inline/inline_trait_method_2.test2.Inline.after.mir
@@ -6,8 +6,8 @@ fn test2(_1: &dyn X) -> bool {
     let mut _2: &dyn X;                  // in scope 0 at $DIR/inline-trait-method_2.rs:5:10: 5:11
     let mut _3: &dyn X;                  // in scope 0 at $DIR/inline-trait-method_2.rs:5:10: 5:11
     scope 1 (inlined test) {             // at $DIR/inline-trait-method_2.rs:5:5: 5:12
-        debug x => _2;                   // in scope 1 at $DIR/inline-trait-method_2.rs:9:9: 9:10
-        let mut _4: &dyn X;              // in scope 1 at $DIR/inline-trait-method_2.rs:10:5: 10:6
+        debug x => _2;                   // in scope 1 at $DIR/inline-trait-method_2.rs:5:5: 5:12
+        let mut _4: &dyn X;              // in scope 1 at $DIR/inline-trait-method_2.rs:5:5: 5:12
     }
 
     bb0: {
@@ -16,16 +16,16 @@ fn test2(_1: &dyn X) -> bool {
         _3 = &(*_1);                     // scope 0 at $DIR/inline-trait-method_2.rs:5:10: 5:11
         _2 = move _3 as &dyn X (Pointer(Unsize)); // scope 0 at $DIR/inline-trait-method_2.rs:5:10: 5:11
         StorageDead(_3);                 // scope 0 at $DIR/inline-trait-method_2.rs:5:10: 5:11
-        StorageLive(_4);                 // scope 1 at $DIR/inline-trait-method_2.rs:10:5: 10:6
-        _4 = _2;                         // scope 1 at $DIR/inline-trait-method_2.rs:10:5: 10:6
-        _0 = <dyn X as X>::y(move _4) -> bb1; // scope 1 at $DIR/inline-trait-method_2.rs:10:5: 10:10
+        StorageLive(_4);                 // scope 1 at $DIR/inline-trait-method_2.rs:5:5: 5:12
+        _4 = _2;                         // scope 1 at $DIR/inline-trait-method_2.rs:5:5: 5:12
+        _0 = <dyn X as X>::y(move _4) -> bb1; // scope 1 at $DIR/inline-trait-method_2.rs:5:5: 5:12
                                          // mir::Constant
-                                         // + span: $DIR/inline-trait-method_2.rs:10:7: 10:8
+                                         // + span: $DIR/inline-trait-method_2.rs:5:5: 5:12
                                          // + literal: Const { ty: for<'r> fn(&'r dyn X) -> bool {<dyn X as X>::y}, val: Value(Scalar(<ZST>)) }
     }
 
     bb1: {
-        StorageDead(_4);                 // scope 1 at $DIR/inline-trait-method_2.rs:10:9: 10:10
+        StorageDead(_4);                 // scope 1 at $DIR/inline-trait-method_2.rs:5:5: 5:12
         StorageDead(_2);                 // scope 0 at $DIR/inline-trait-method_2.rs:5:11: 5:12
         return;                          // scope 0 at $DIR/inline-trait-method_2.rs:6:2: 6:2
     }

--- a/src/test/mir-opt/inline/issue_58867_inline_as_ref_as_mut.a.Inline.after.mir
+++ b/src/test/mir-opt/inline/issue_58867_inline_as_ref_as_mut.a.Inline.after.mir
@@ -7,8 +7,8 @@ fn a(_1: &mut [T]) -> &mut [T] {
     let mut _3: &mut [T];                // in scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:3:5: 3:15
     let mut _4: &mut [T];                // in scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:3:5: 3:6
     scope 1 (inlined <[T] as AsMut<[T]>>::as_mut) { // at $DIR/issue-58867-inline-as-ref-as-mut.rs:3:5: 3:15
-        debug self => _4;                // in scope 1 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
-        let mut _5: &mut [T];            // in scope 1 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
+        debug self => _4;                // in scope 1 at $DIR/issue-58867-inline-as-ref-as-mut.rs:3:5: 3:15
+        let mut _5: &mut [T];            // in scope 1 at $DIR/issue-58867-inline-as-ref-as-mut.rs:3:5: 3:15
     }
 
     bb0: {
@@ -16,10 +16,10 @@ fn a(_1: &mut [T]) -> &mut [T] {
         StorageLive(_3);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:3:5: 3:15
         StorageLive(_4);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:3:5: 3:6
         _4 = &mut (*_1);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:3:5: 3:6
-        StorageLive(_5);                 // scope 1 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
-        _5 = &mut (*_4);                 // scope 1 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
-        _3 = &mut (*_5);                 // scope 1 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
-        StorageDead(_5);                 // scope 1 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
+        StorageLive(_5);                 // scope 1 at $DIR/issue-58867-inline-as-ref-as-mut.rs:3:5: 3:15
+        _5 = &mut (*_4);                 // scope 1 at $DIR/issue-58867-inline-as-ref-as-mut.rs:3:5: 3:15
+        _3 = &mut (*_5);                 // scope 1 at $DIR/issue-58867-inline-as-ref-as-mut.rs:3:5: 3:15
+        StorageDead(_5);                 // scope 1 at $DIR/issue-58867-inline-as-ref-as-mut.rs:3:5: 3:15
         _2 = &mut (*_3);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:3:5: 3:15
         StorageDead(_4);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:3:14: 3:15
         _0 = &mut (*_2);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:3:5: 3:15

--- a/src/test/mir-opt/inline/issue_58867_inline_as_ref_as_mut.b.Inline.after.mir
+++ b/src/test/mir-opt/inline/issue_58867_inline_as_ref_as_mut.b.Inline.after.mir
@@ -7,9 +7,9 @@ fn b(_1: &mut Box<T>) -> &mut T {
     let mut _3: &mut T;                  // in scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:8:5: 8:15
     let mut _4: &mut std::boxed::Box<T>; // in scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:8:5: 8:6
     scope 1 (inlined <Box<T> as AsMut<T>>::as_mut) { // at $DIR/issue-58867-inline-as-ref-as-mut.rs:8:5: 8:15
-        debug self => _4;                // in scope 1 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
-        let mut _5: &mut T;              // in scope 1 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
-        let mut _6: &mut T;              // in scope 1 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
+        debug self => _4;                // in scope 1 at $DIR/issue-58867-inline-as-ref-as-mut.rs:8:5: 8:15
+        let mut _5: &mut T;              // in scope 1 at $DIR/issue-58867-inline-as-ref-as-mut.rs:8:5: 8:15
+        let mut _6: &mut T;              // in scope 1 at $DIR/issue-58867-inline-as-ref-as-mut.rs:8:5: 8:15
     }
 
     bb0: {
@@ -17,13 +17,13 @@ fn b(_1: &mut Box<T>) -> &mut T {
         StorageLive(_3);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:8:5: 8:15
         StorageLive(_4);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:8:5: 8:6
         _4 = &mut (*_1);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:8:5: 8:6
-        StorageLive(_5);                 // scope 1 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
-        StorageLive(_6);                 // scope 1 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
-        _6 = &mut (*(*_4));              // scope 1 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
-        _5 = &mut (*_6);                 // scope 1 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
-        _3 = &mut (*_5);                 // scope 1 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
-        StorageDead(_6);                 // scope 1 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
-        StorageDead(_5);                 // scope 1 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
+        StorageLive(_5);                 // scope 1 at $DIR/issue-58867-inline-as-ref-as-mut.rs:8:5: 8:15
+        StorageLive(_6);                 // scope 1 at $DIR/issue-58867-inline-as-ref-as-mut.rs:8:5: 8:15
+        _6 = &mut (*(*_4));              // scope 1 at $DIR/issue-58867-inline-as-ref-as-mut.rs:8:5: 8:15
+        _5 = &mut (*_6);                 // scope 1 at $DIR/issue-58867-inline-as-ref-as-mut.rs:8:5: 8:15
+        _3 = &mut (*_5);                 // scope 1 at $DIR/issue-58867-inline-as-ref-as-mut.rs:8:5: 8:15
+        StorageDead(_6);                 // scope 1 at $DIR/issue-58867-inline-as-ref-as-mut.rs:8:5: 8:15
+        StorageDead(_5);                 // scope 1 at $DIR/issue-58867-inline-as-ref-as-mut.rs:8:5: 8:15
         _2 = &mut (*_3);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:8:5: 8:15
         StorageDead(_4);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:8:14: 8:15
         _0 = &mut (*_2);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:8:5: 8:15

--- a/src/test/mir-opt/inline/issue_58867_inline_as_ref_as_mut.c.Inline.after.mir
+++ b/src/test/mir-opt/inline/issue_58867_inline_as_ref_as_mut.c.Inline.after.mir
@@ -6,14 +6,14 @@ fn c(_1: &[T]) -> &[T] {
     let _2: &[T];                        // in scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:13:5: 13:15
     let mut _3: &[T];                    // in scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:13:5: 13:6
     scope 1 (inlined <[T] as AsRef<[T]>>::as_ref) { // at $DIR/issue-58867-inline-as-ref-as-mut.rs:13:5: 13:15
-        debug self => _3;                // in scope 1 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
+        debug self => _3;                // in scope 1 at $DIR/issue-58867-inline-as-ref-as-mut.rs:13:5: 13:15
     }
 
     bb0: {
         StorageLive(_2);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:13:5: 13:15
         StorageLive(_3);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:13:5: 13:6
         _3 = &(*_1);                     // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:13:5: 13:6
-        _2 = _3;                         // scope 1 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
+        _2 = _3;                         // scope 1 at $DIR/issue-58867-inline-as-ref-as-mut.rs:13:5: 13:15
         _0 = &(*_2);                     // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:13:5: 13:15
         StorageDead(_3);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:13:14: 13:15
         StorageDead(_2);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:14:1: 14:2

--- a/src/test/mir-opt/inline/issue_58867_inline_as_ref_as_mut.d.Inline.after.mir
+++ b/src/test/mir-opt/inline/issue_58867_inline_as_ref_as_mut.d.Inline.after.mir
@@ -6,14 +6,14 @@ fn d(_1: &Box<T>) -> &T {
     let _2: &T;                          // in scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:18:5: 18:15
     let mut _3: &std::boxed::Box<T>;     // in scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:18:5: 18:6
     scope 1 (inlined <Box<T> as AsRef<T>>::as_ref) { // at $DIR/issue-58867-inline-as-ref-as-mut.rs:18:5: 18:15
-        debug self => _3;                // in scope 1 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
+        debug self => _3;                // in scope 1 at $DIR/issue-58867-inline-as-ref-as-mut.rs:18:5: 18:15
     }
 
     bb0: {
         StorageLive(_2);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:18:5: 18:15
         StorageLive(_3);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:18:5: 18:6
         _3 = &(*_1);                     // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:18:5: 18:6
-        _2 = &(*(*_3));                  // scope 1 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
+        _2 = &(*(*_3));                  // scope 1 at $DIR/issue-58867-inline-as-ref-as-mut.rs:18:5: 18:15
         _0 = &(*_2);                     // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:18:5: 18:15
         StorageDead(_3);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:18:14: 18:15
         StorageDead(_2);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:19:1: 19:2

--- a/src/test/mir-opt/inline/issue_76997_inline_scopes_parenting.main.Inline.after.mir
+++ b/src/test/mir-opt/inline/issue_76997_inline_scopes_parenting.main.Inline.after.mir
@@ -10,10 +10,10 @@ fn main() -> () {
     scope 1 {
         debug f => _1;                   // in scope 1 at $DIR/issue-76997-inline-scopes-parenting.rs:5:9: 5:10
         scope 2 (inlined main::{closure#0}) { // at $DIR/issue-76997-inline-scopes-parenting.rs:6:5: 6:10
-            debug x => _5;               // in scope 2 at $DIR/issue-76997-inline-scopes-parenting.rs:5:14: 5:15
-            let _6: ();                  // in scope 2 at $DIR/issue-76997-inline-scopes-parenting.rs:5:23: 5:24
+            debug x => _5;               // in scope 2 at $DIR/issue-76997-inline-scopes-parenting.rs:6:5: 6:10
+            let _6: ();                  // in scope 2 at $DIR/issue-76997-inline-scopes-parenting.rs:6:5: 6:10
             scope 3 {
-                debug y => _6;           // in scope 3 at $DIR/issue-76997-inline-scopes-parenting.rs:5:23: 5:24
+                debug y => _6;           // in scope 3 at $DIR/issue-76997-inline-scopes-parenting.rs:6:5: 6:10
             }
         }
     }
@@ -27,10 +27,10 @@ fn main() -> () {
         (_3.0: ()) = move _4;            // scope 1 at $DIR/issue-76997-inline-scopes-parenting.rs:6:5: 6:10
         StorageLive(_5);                 // scope 1 at $DIR/issue-76997-inline-scopes-parenting.rs:6:5: 6:10
         _5 = move (_3.0: ());            // scope 1 at $DIR/issue-76997-inline-scopes-parenting.rs:6:5: 6:10
-        StorageLive(_6);                 // scope 2 at $DIR/issue-76997-inline-scopes-parenting.rs:5:23: 5:24
-        _6 = const ();                   // scope 2 at $DIR/issue-76997-inline-scopes-parenting.rs:5:27: 5:28
-        _0 = const ();                   // scope 3 at $DIR/issue-76997-inline-scopes-parenting.rs:5:30: 5:31
-        StorageDead(_6);                 // scope 2 at $DIR/issue-76997-inline-scopes-parenting.rs:5:32: 5:33
+        StorageLive(_6);                 // scope 2 at $DIR/issue-76997-inline-scopes-parenting.rs:6:5: 6:10
+        _6 = const ();                   // scope 2 at $DIR/issue-76997-inline-scopes-parenting.rs:6:5: 6:10
+        _0 = const ();                   // scope 3 at $DIR/issue-76997-inline-scopes-parenting.rs:6:5: 6:10
+        StorageDead(_6);                 // scope 2 at $DIR/issue-76997-inline-scopes-parenting.rs:6:5: 6:10
         StorageDead(_5);                 // scope 1 at $DIR/issue-76997-inline-scopes-parenting.rs:6:5: 6:10
         StorageDead(_4);                 // scope 1 at $DIR/issue-76997-inline-scopes-parenting.rs:6:9: 6:10
         StorageDead(_3);                 // scope 1 at $DIR/issue-76997-inline-scopes-parenting.rs:6:9: 6:10

--- a/src/test/mir-opt/issue_73223.main.PreCodegen.32bit.diff
+++ b/src/test/mir-opt/issue_73223.main.PreCodegen.32bit.diff
@@ -36,30 +36,30 @@
                       debug arg0 => _25;   // in scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                       debug arg1 => _28;   // in scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                       scope 6 (inlined ArgumentV1::new::<&i32>) { // at $SRC_DIR/std/src/macros.rs:LL:COL
-                          debug x => _25;  // in scope 6 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-                          debug f => _24;  // in scope 6 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-                          let mut _23: for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>; // in scope 6 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-                          let mut _24: for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>; // in scope 6 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-                          let mut _25: &&i32; // in scope 6 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+                          debug x => _25;  // in scope 6 at $SRC_DIR/std/src/macros.rs:LL:COL
+                          debug f => _24;  // in scope 6 at $SRC_DIR/std/src/macros.rs:LL:COL
+                          let mut _23: for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>; // in scope 6 at $SRC_DIR/std/src/macros.rs:LL:COL
+                          let mut _24: for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>; // in scope 6 at $SRC_DIR/std/src/macros.rs:LL:COL
+                          let mut _25: &&i32; // in scope 6 at $SRC_DIR/std/src/macros.rs:LL:COL
                           scope 7 {
                           }
                       }
                       scope 8 (inlined ArgumentV1::new::<&i32>) { // at $SRC_DIR/std/src/macros.rs:LL:COL
-                          debug x => _28;  // in scope 8 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-                          debug f => _27;  // in scope 8 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-                          let mut _26: for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>; // in scope 8 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-                          let mut _27: for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>; // in scope 8 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-                          let mut _28: &&i32; // in scope 8 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+                          debug x => _28;  // in scope 8 at $SRC_DIR/std/src/macros.rs:LL:COL
+                          debug f => _27;  // in scope 8 at $SRC_DIR/std/src/macros.rs:LL:COL
+                          let mut _26: for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>; // in scope 8 at $SRC_DIR/std/src/macros.rs:LL:COL
+                          let mut _27: for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>; // in scope 8 at $SRC_DIR/std/src/macros.rs:LL:COL
+                          let mut _28: &&i32; // in scope 8 at $SRC_DIR/std/src/macros.rs:LL:COL
                           scope 9 {
                           }
                       }
                   }
                   scope 10 (inlined Arguments::new_v1) { // at $SRC_DIR/std/src/macros.rs:LL:COL
-                      debug pieces => _29; // in scope 10 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-                      debug args => _31;   // in scope 10 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-                      let mut _29: &[&str]; // in scope 10 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-                      let mut _30: std::option::Option<&[std::fmt::rt::v1::Argument]>; // in scope 10 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-                      let mut _31: &[std::fmt::ArgumentV1]; // in scope 10 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+                      debug pieces => _29; // in scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
+                      debug args => _31;   // in scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
+                      let mut _29: &[&str]; // in scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
+                      let mut _30: std::option::Option<&[std::fmt::rt::v1::Argument]>; // in scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
+                      let mut _31: &[std::fmt::ArgumentV1]; // in scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
                   }
               }
           }
@@ -139,53 +139,53 @@
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // + literal: Const { ty: for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> {<&i32 as std::fmt::Debug>::fmt}, val: Value(Scalar(<ZST>)) }
-          StorageLive(_23);                // scope 7 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          _23 = transmute::<for<'r, 's, 't0> fn(&'r &i32, &'s mut Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>, for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>>(move _24) -> bb3; // scope 7 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+          StorageLive(_23);                // scope 7 at $SRC_DIR/std/src/macros.rs:LL:COL
+          _23 = transmute::<for<'r, 's, 't0> fn(&'r &i32, &'s mut Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>, for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>>(move _24) -> bb3; // scope 7 at $SRC_DIR/std/src/macros.rs:LL:COL
                                            // mir::Constant
-                                           // + span: $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+                                           // + span: $SRC_DIR/std/src/macros.rs:LL:COL
                                            // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>) -> for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> {std::intrinsics::transmute::<for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>, for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>>}, val: Value(Scalar(<ZST>)) }
       }
   
       bb3: {
-          (_21.0: &core::fmt::Opaque) = transmute::<&&i32, &core::fmt::Opaque>(move _25) -> bb4; // scope 7 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+          (_21.0: &core::fmt::Opaque) = transmute::<&&i32, &core::fmt::Opaque>(move _25) -> bb4; // scope 7 at $SRC_DIR/std/src/macros.rs:LL:COL
                                            // mir::Constant
-                                           // + span: $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+                                           // + span: $SRC_DIR/std/src/macros.rs:LL:COL
                                            // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(&&i32) -> &core::fmt::Opaque {std::intrinsics::transmute::<&&i32, &core::fmt::Opaque>}, val: Value(Scalar(<ZST>)) }
       }
   
       bb4: {
-          (_21.1: for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>) = move _23; // scope 7 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          StorageDead(_23);                // scope 7 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+          (_21.1: for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>) = move _23; // scope 7 at $SRC_DIR/std/src/macros.rs:LL:COL
+          StorageDead(_23);                // scope 7 at $SRC_DIR/std/src/macros.rs:LL:COL
           _27 = <&i32 as Debug>::fmt as for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> (Pointer(ReifyFnPointer)); // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // + literal: Const { ty: for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> {<&i32 as std::fmt::Debug>::fmt}, val: Value(Scalar(<ZST>)) }
-          StorageLive(_26);                // scope 9 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          _26 = transmute::<for<'r, 's, 't0> fn(&'r &i32, &'s mut Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>, for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>>(move _27) -> bb5; // scope 9 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+          StorageLive(_26);                // scope 9 at $SRC_DIR/std/src/macros.rs:LL:COL
+          _26 = transmute::<for<'r, 's, 't0> fn(&'r &i32, &'s mut Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>, for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>>(move _27) -> bb5; // scope 9 at $SRC_DIR/std/src/macros.rs:LL:COL
                                            // mir::Constant
-                                           // + span: $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+                                           // + span: $SRC_DIR/std/src/macros.rs:LL:COL
                                            // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>) -> for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> {std::intrinsics::transmute::<for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>, for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>>}, val: Value(Scalar(<ZST>)) }
       }
   
       bb5: {
-          (_22.0: &core::fmt::Opaque) = transmute::<&&i32, &core::fmt::Opaque>(move _28) -> bb6; // scope 9 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+          (_22.0: &core::fmt::Opaque) = transmute::<&&i32, &core::fmt::Opaque>(move _28) -> bb6; // scope 9 at $SRC_DIR/std/src/macros.rs:LL:COL
                                            // mir::Constant
-                                           // + span: $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+                                           // + span: $SRC_DIR/std/src/macros.rs:LL:COL
                                            // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(&&i32) -> &core::fmt::Opaque {std::intrinsics::transmute::<&&i32, &core::fmt::Opaque>}, val: Value(Scalar(<ZST>)) }
       }
   
       bb6: {
-          (_22.1: for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>) = move _26; // scope 9 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          StorageDead(_26);                // scope 9 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+          (_22.1: for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>) = move _26; // scope 9 at $SRC_DIR/std/src/macros.rs:LL:COL
+          StorageDead(_26);                // scope 9 at $SRC_DIR/std/src/macros.rs:LL:COL
           _16 = [move _21, move _22];      // scope 5 at $SRC_DIR/std/src/macros.rs:LL:COL
           _15 = &_16;                      // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
           _31 = move _15 as &[std::fmt::ArgumentV1] (Pointer(Unsize)); // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageLive(_30);                // scope 10 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          discriminant(_30) = 0;           // scope 10 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          (_13.0: &[&str]) = move _29;     // scope 10 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          (_13.1: std::option::Option<&[std::fmt::rt::v1::Argument]>) = move _30; // scope 10 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          (_13.2: &[std::fmt::ArgumentV1]) = move _31; // scope 10 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          StorageDead(_30);                // scope 10 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+          StorageLive(_30);                // scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
+          discriminant(_30) = 0;           // scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
+          (_13.0: &[&str]) = move _29;     // scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
+          (_13.1: std::option::Option<&[std::fmt::rt::v1::Argument]>) = move _30; // scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
+          (_13.2: &[std::fmt::ArgumentV1]) = move _31; // scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
+          StorageDead(_30);                // scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
           _12 = &_13;                      // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
           begin_panic_fmt(move _12);       // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
                                            // mir::Constant

--- a/src/test/mir-opt/issue_73223.main.PreCodegen.64bit.diff
+++ b/src/test/mir-opt/issue_73223.main.PreCodegen.64bit.diff
@@ -36,30 +36,30 @@
                       debug arg0 => _25;   // in scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                       debug arg1 => _28;   // in scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                       scope 6 (inlined ArgumentV1::new::<&i32>) { // at $SRC_DIR/std/src/macros.rs:LL:COL
-                          debug x => _25;  // in scope 6 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-                          debug f => _24;  // in scope 6 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-                          let mut _23: for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>; // in scope 6 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-                          let mut _24: for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>; // in scope 6 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-                          let mut _25: &&i32; // in scope 6 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+                          debug x => _25;  // in scope 6 at $SRC_DIR/std/src/macros.rs:LL:COL
+                          debug f => _24;  // in scope 6 at $SRC_DIR/std/src/macros.rs:LL:COL
+                          let mut _23: for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>; // in scope 6 at $SRC_DIR/std/src/macros.rs:LL:COL
+                          let mut _24: for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>; // in scope 6 at $SRC_DIR/std/src/macros.rs:LL:COL
+                          let mut _25: &&i32; // in scope 6 at $SRC_DIR/std/src/macros.rs:LL:COL
                           scope 7 {
                           }
                       }
                       scope 8 (inlined ArgumentV1::new::<&i32>) { // at $SRC_DIR/std/src/macros.rs:LL:COL
-                          debug x => _28;  // in scope 8 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-                          debug f => _27;  // in scope 8 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-                          let mut _26: for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>; // in scope 8 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-                          let mut _27: for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>; // in scope 8 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-                          let mut _28: &&i32; // in scope 8 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+                          debug x => _28;  // in scope 8 at $SRC_DIR/std/src/macros.rs:LL:COL
+                          debug f => _27;  // in scope 8 at $SRC_DIR/std/src/macros.rs:LL:COL
+                          let mut _26: for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>; // in scope 8 at $SRC_DIR/std/src/macros.rs:LL:COL
+                          let mut _27: for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>; // in scope 8 at $SRC_DIR/std/src/macros.rs:LL:COL
+                          let mut _28: &&i32; // in scope 8 at $SRC_DIR/std/src/macros.rs:LL:COL
                           scope 9 {
                           }
                       }
                   }
                   scope 10 (inlined Arguments::new_v1) { // at $SRC_DIR/std/src/macros.rs:LL:COL
-                      debug pieces => _29; // in scope 10 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-                      debug args => _31;   // in scope 10 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-                      let mut _29: &[&str]; // in scope 10 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-                      let mut _30: std::option::Option<&[std::fmt::rt::v1::Argument]>; // in scope 10 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-                      let mut _31: &[std::fmt::ArgumentV1]; // in scope 10 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+                      debug pieces => _29; // in scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
+                      debug args => _31;   // in scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
+                      let mut _29: &[&str]; // in scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
+                      let mut _30: std::option::Option<&[std::fmt::rt::v1::Argument]>; // in scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
+                      let mut _31: &[std::fmt::ArgumentV1]; // in scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
                   }
               }
           }
@@ -139,53 +139,53 @@
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // + literal: Const { ty: for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> {<&i32 as std::fmt::Debug>::fmt}, val: Value(Scalar(<ZST>)) }
-          StorageLive(_23);                // scope 7 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          _23 = transmute::<for<'r, 's, 't0> fn(&'r &i32, &'s mut Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>, for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>>(move _24) -> bb3; // scope 7 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+          StorageLive(_23);                // scope 7 at $SRC_DIR/std/src/macros.rs:LL:COL
+          _23 = transmute::<for<'r, 's, 't0> fn(&'r &i32, &'s mut Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>, for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>>(move _24) -> bb3; // scope 7 at $SRC_DIR/std/src/macros.rs:LL:COL
                                            // mir::Constant
-                                           // + span: $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+                                           // + span: $SRC_DIR/std/src/macros.rs:LL:COL
                                            // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>) -> for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> {std::intrinsics::transmute::<for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>, for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>>}, val: Value(Scalar(<ZST>)) }
       }
   
       bb3: {
-          (_21.0: &core::fmt::Opaque) = transmute::<&&i32, &core::fmt::Opaque>(move _25) -> bb4; // scope 7 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+          (_21.0: &core::fmt::Opaque) = transmute::<&&i32, &core::fmt::Opaque>(move _25) -> bb4; // scope 7 at $SRC_DIR/std/src/macros.rs:LL:COL
                                            // mir::Constant
-                                           // + span: $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+                                           // + span: $SRC_DIR/std/src/macros.rs:LL:COL
                                            // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(&&i32) -> &core::fmt::Opaque {std::intrinsics::transmute::<&&i32, &core::fmt::Opaque>}, val: Value(Scalar(<ZST>)) }
       }
   
       bb4: {
-          (_21.1: for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>) = move _23; // scope 7 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          StorageDead(_23);                // scope 7 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+          (_21.1: for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>) = move _23; // scope 7 at $SRC_DIR/std/src/macros.rs:LL:COL
+          StorageDead(_23);                // scope 7 at $SRC_DIR/std/src/macros.rs:LL:COL
           _27 = <&i32 as Debug>::fmt as for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> (Pointer(ReifyFnPointer)); // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // + literal: Const { ty: for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> {<&i32 as std::fmt::Debug>::fmt}, val: Value(Scalar(<ZST>)) }
-          StorageLive(_26);                // scope 9 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          _26 = transmute::<for<'r, 's, 't0> fn(&'r &i32, &'s mut Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>, for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>>(move _27) -> bb5; // scope 9 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+          StorageLive(_26);                // scope 9 at $SRC_DIR/std/src/macros.rs:LL:COL
+          _26 = transmute::<for<'r, 's, 't0> fn(&'r &i32, &'s mut Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>, for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>>(move _27) -> bb5; // scope 9 at $SRC_DIR/std/src/macros.rs:LL:COL
                                            // mir::Constant
-                                           // + span: $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+                                           // + span: $SRC_DIR/std/src/macros.rs:LL:COL
                                            // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>) -> for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> {std::intrinsics::transmute::<for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>, for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>>}, val: Value(Scalar(<ZST>)) }
       }
   
       bb5: {
-          (_22.0: &core::fmt::Opaque) = transmute::<&&i32, &core::fmt::Opaque>(move _28) -> bb6; // scope 9 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+          (_22.0: &core::fmt::Opaque) = transmute::<&&i32, &core::fmt::Opaque>(move _28) -> bb6; // scope 9 at $SRC_DIR/std/src/macros.rs:LL:COL
                                            // mir::Constant
-                                           // + span: $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+                                           // + span: $SRC_DIR/std/src/macros.rs:LL:COL
                                            // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(&&i32) -> &core::fmt::Opaque {std::intrinsics::transmute::<&&i32, &core::fmt::Opaque>}, val: Value(Scalar(<ZST>)) }
       }
   
       bb6: {
-          (_22.1: for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>) = move _26; // scope 9 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          StorageDead(_26);                // scope 9 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+          (_22.1: for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>) = move _26; // scope 9 at $SRC_DIR/std/src/macros.rs:LL:COL
+          StorageDead(_26);                // scope 9 at $SRC_DIR/std/src/macros.rs:LL:COL
           _16 = [move _21, move _22];      // scope 5 at $SRC_DIR/std/src/macros.rs:LL:COL
           _15 = &_16;                      // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
           _31 = move _15 as &[std::fmt::ArgumentV1] (Pointer(Unsize)); // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageLive(_30);                // scope 10 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          discriminant(_30) = 0;           // scope 10 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          (_13.0: &[&str]) = move _29;     // scope 10 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          (_13.1: std::option::Option<&[std::fmt::rt::v1::Argument]>) = move _30; // scope 10 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          (_13.2: &[std::fmt::ArgumentV1]) = move _31; // scope 10 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          StorageDead(_30);                // scope 10 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+          StorageLive(_30);                // scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
+          discriminant(_30) = 0;           // scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
+          (_13.0: &[&str]) = move _29;     // scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
+          (_13.1: std::option::Option<&[std::fmt::rt::v1::Argument]>) = move _30; // scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
+          (_13.2: &[std::fmt::ArgumentV1]) = move _31; // scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
+          StorageDead(_30);                // scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
           _12 = &_13;                      // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
           begin_panic_fmt(move _12);       // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
                                            // mir::Constant

--- a/src/test/mir-opt/issue_73223.main.SimplifyArmIdentity.32bit.diff
+++ b/src/test/mir-opt/issue_73223.main.SimplifyArmIdentity.32bit.diff
@@ -59,32 +59,32 @@
                       debug arg0 => _36;   // in scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                       debug arg1 => _37;   // in scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                       scope 6 (inlined ArgumentV1::new::<&i32>) { // at $SRC_DIR/std/src/macros.rs:LL:COL
-                          debug x => _39;  // in scope 6 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-                          debug f => _40;  // in scope 6 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-                          let mut _46: for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>; // in scope 6 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-                          let mut _47: for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>; // in scope 6 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-                          let mut _48: &core::fmt::Opaque; // in scope 6 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-                          let mut _49: &&i32; // in scope 6 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+                          debug x => _39;  // in scope 6 at $SRC_DIR/std/src/macros.rs:LL:COL
+                          debug f => _40;  // in scope 6 at $SRC_DIR/std/src/macros.rs:LL:COL
+                          let mut _46: for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>; // in scope 6 at $SRC_DIR/std/src/macros.rs:LL:COL
+                          let mut _47: for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>; // in scope 6 at $SRC_DIR/std/src/macros.rs:LL:COL
+                          let mut _48: &core::fmt::Opaque; // in scope 6 at $SRC_DIR/std/src/macros.rs:LL:COL
+                          let mut _49: &&i32; // in scope 6 at $SRC_DIR/std/src/macros.rs:LL:COL
                           scope 7 {
                           }
                       }
                       scope 8 (inlined ArgumentV1::new::<&i32>) { // at $SRC_DIR/std/src/macros.rs:LL:COL
-                          debug x => _42;  // in scope 8 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-                          debug f => _43;  // in scope 8 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-                          let mut _50: for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>; // in scope 8 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-                          let mut _51: for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>; // in scope 8 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-                          let mut _52: &core::fmt::Opaque; // in scope 8 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-                          let mut _53: &&i32; // in scope 8 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+                          debug x => _42;  // in scope 8 at $SRC_DIR/std/src/macros.rs:LL:COL
+                          debug f => _43;  // in scope 8 at $SRC_DIR/std/src/macros.rs:LL:COL
+                          let mut _50: for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>; // in scope 8 at $SRC_DIR/std/src/macros.rs:LL:COL
+                          let mut _51: for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>; // in scope 8 at $SRC_DIR/std/src/macros.rs:LL:COL
+                          let mut _52: &core::fmt::Opaque; // in scope 8 at $SRC_DIR/std/src/macros.rs:LL:COL
+                          let mut _53: &&i32; // in scope 8 at $SRC_DIR/std/src/macros.rs:LL:COL
                           scope 9 {
                           }
                       }
                   }
                   scope 10 (inlined Arguments::new_v1) { // at $SRC_DIR/std/src/macros.rs:LL:COL
-                      debug pieces => _23; // in scope 10 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-                      debug args => _27;   // in scope 10 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-                      let mut _54: &[&str]; // in scope 10 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-                      let mut _55: std::option::Option<&[std::fmt::rt::v1::Argument]>; // in scope 10 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-                      let mut _56: &[std::fmt::ArgumentV1]; // in scope 10 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+                      debug pieces => _23; // in scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
+                      debug args => _27;   // in scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
+                      let mut _54: &[&str]; // in scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
+                      let mut _55: std::option::Option<&[std::fmt::rt::v1::Argument]>; // in scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
+                      let mut _56: &[std::fmt::ArgumentV1]; // in scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
                   }
               }
           }
@@ -217,32 +217,32 @@
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // + literal: Const { ty: for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> {<&i32 as std::fmt::Debug>::fmt}, val: Value(Scalar(<ZST>)) }
-          StorageLive(_46);                // scope 7 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          StorageLive(_47);                // scope 7 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          _47 = _40;                       // scope 7 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          _46 = transmute::<for<'r, 's, 't0> fn(&'r &i32, &'s mut Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>, for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>>(move _47) -> bb5; // scope 7 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+          StorageLive(_46);                // scope 7 at $SRC_DIR/std/src/macros.rs:LL:COL
+          StorageLive(_47);                // scope 7 at $SRC_DIR/std/src/macros.rs:LL:COL
+          _47 = _40;                       // scope 7 at $SRC_DIR/std/src/macros.rs:LL:COL
+          _46 = transmute::<for<'r, 's, 't0> fn(&'r &i32, &'s mut Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>, for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>>(move _47) -> bb5; // scope 7 at $SRC_DIR/std/src/macros.rs:LL:COL
                                            // mir::Constant
-                                           // + span: $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+                                           // + span: $SRC_DIR/std/src/macros.rs:LL:COL
                                            // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>) -> for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> {std::intrinsics::transmute::<for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>, for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>>}, val: Value(Scalar(<ZST>)) }
       }
   
       bb5: {
-          StorageDead(_47);                // scope 7 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          StorageLive(_48);                // scope 7 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          StorageLive(_49);                // scope 7 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          _49 = _39;                       // scope 7 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          _48 = transmute::<&&i32, &core::fmt::Opaque>(move _49) -> bb6; // scope 7 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+          StorageDead(_47);                // scope 7 at $SRC_DIR/std/src/macros.rs:LL:COL
+          StorageLive(_48);                // scope 7 at $SRC_DIR/std/src/macros.rs:LL:COL
+          StorageLive(_49);                // scope 7 at $SRC_DIR/std/src/macros.rs:LL:COL
+          _49 = _39;                       // scope 7 at $SRC_DIR/std/src/macros.rs:LL:COL
+          _48 = transmute::<&&i32, &core::fmt::Opaque>(move _49) -> bb6; // scope 7 at $SRC_DIR/std/src/macros.rs:LL:COL
                                            // mir::Constant
-                                           // + span: $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+                                           // + span: $SRC_DIR/std/src/macros.rs:LL:COL
                                            // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(&&i32) -> &core::fmt::Opaque {std::intrinsics::transmute::<&&i32, &core::fmt::Opaque>}, val: Value(Scalar(<ZST>)) }
       }
   
       bb6: {
-          StorageDead(_49);                // scope 7 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          (_38.0: &core::fmt::Opaque) = move _48; // scope 7 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          (_38.1: for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>) = move _46; // scope 7 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          StorageDead(_48);                // scope 7 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          StorageDead(_46);                // scope 7 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+          StorageDead(_49);                // scope 7 at $SRC_DIR/std/src/macros.rs:LL:COL
+          (_38.0: &core::fmt::Opaque) = move _48; // scope 7 at $SRC_DIR/std/src/macros.rs:LL:COL
+          (_38.1: for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>) = move _46; // scope 7 at $SRC_DIR/std/src/macros.rs:LL:COL
+          StorageDead(_48);                // scope 7 at $SRC_DIR/std/src/macros.rs:LL:COL
+          StorageDead(_46);                // scope 7 at $SRC_DIR/std/src/macros.rs:LL:COL
           StorageDead(_40);                // scope 5 at $SRC_DIR/std/src/macros.rs:LL:COL
           StorageDead(_39);                // scope 5 at $SRC_DIR/std/src/macros.rs:LL:COL
           StorageLive(_41);                // scope 5 at $SRC_DIR/std/src/macros.rs:LL:COL
@@ -253,32 +253,32 @@
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // + literal: Const { ty: for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> {<&i32 as std::fmt::Debug>::fmt}, val: Value(Scalar(<ZST>)) }
-          StorageLive(_50);                // scope 9 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          StorageLive(_51);                // scope 9 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          _51 = _43;                       // scope 9 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          _50 = transmute::<for<'r, 's, 't0> fn(&'r &i32, &'s mut Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>, for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>>(move _51) -> bb7; // scope 9 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+          StorageLive(_50);                // scope 9 at $SRC_DIR/std/src/macros.rs:LL:COL
+          StorageLive(_51);                // scope 9 at $SRC_DIR/std/src/macros.rs:LL:COL
+          _51 = _43;                       // scope 9 at $SRC_DIR/std/src/macros.rs:LL:COL
+          _50 = transmute::<for<'r, 's, 't0> fn(&'r &i32, &'s mut Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>, for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>>(move _51) -> bb7; // scope 9 at $SRC_DIR/std/src/macros.rs:LL:COL
                                            // mir::Constant
-                                           // + span: $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+                                           // + span: $SRC_DIR/std/src/macros.rs:LL:COL
                                            // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>) -> for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> {std::intrinsics::transmute::<for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>, for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>>}, val: Value(Scalar(<ZST>)) }
       }
   
       bb7: {
-          StorageDead(_51);                // scope 9 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          StorageLive(_52);                // scope 9 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          StorageLive(_53);                // scope 9 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          _53 = _42;                       // scope 9 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          _52 = transmute::<&&i32, &core::fmt::Opaque>(move _53) -> bb8; // scope 9 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+          StorageDead(_51);                // scope 9 at $SRC_DIR/std/src/macros.rs:LL:COL
+          StorageLive(_52);                // scope 9 at $SRC_DIR/std/src/macros.rs:LL:COL
+          StorageLive(_53);                // scope 9 at $SRC_DIR/std/src/macros.rs:LL:COL
+          _53 = _42;                       // scope 9 at $SRC_DIR/std/src/macros.rs:LL:COL
+          _52 = transmute::<&&i32, &core::fmt::Opaque>(move _53) -> bb8; // scope 9 at $SRC_DIR/std/src/macros.rs:LL:COL
                                            // mir::Constant
-                                           // + span: $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+                                           // + span: $SRC_DIR/std/src/macros.rs:LL:COL
                                            // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(&&i32) -> &core::fmt::Opaque {std::intrinsics::transmute::<&&i32, &core::fmt::Opaque>}, val: Value(Scalar(<ZST>)) }
       }
   
       bb8: {
-          StorageDead(_53);                // scope 9 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          (_41.0: &core::fmt::Opaque) = move _52; // scope 9 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          (_41.1: for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>) = move _50; // scope 9 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          StorageDead(_52);                // scope 9 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          StorageDead(_50);                // scope 9 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+          StorageDead(_53);                // scope 9 at $SRC_DIR/std/src/macros.rs:LL:COL
+          (_41.0: &core::fmt::Opaque) = move _52; // scope 9 at $SRC_DIR/std/src/macros.rs:LL:COL
+          (_41.1: for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>) = move _50; // scope 9 at $SRC_DIR/std/src/macros.rs:LL:COL
+          StorageDead(_52);                // scope 9 at $SRC_DIR/std/src/macros.rs:LL:COL
+          StorageDead(_50);                // scope 9 at $SRC_DIR/std/src/macros.rs:LL:COL
           StorageDead(_43);                // scope 5 at $SRC_DIR/std/src/macros.rs:LL:COL
           StorageDead(_42);                // scope 5 at $SRC_DIR/std/src/macros.rs:LL:COL
           _30 = [move _38, move _41];      // scope 5 at $SRC_DIR/std/src/macros.rs:LL:COL
@@ -290,18 +290,18 @@
           _28 = _29;                       // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
           _27 = move _28 as &[std::fmt::ArgumentV1] (Pointer(Unsize)); // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
           StorageDead(_28);                // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageLive(_54);                // scope 10 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          _54 = _23;                       // scope 10 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          StorageLive(_55);                // scope 10 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          discriminant(_55) = 0;           // scope 10 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          StorageLive(_56);                // scope 10 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          _56 = _27;                       // scope 10 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          (_22.0: &[&str]) = move _54;     // scope 10 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          (_22.1: std::option::Option<&[std::fmt::rt::v1::Argument]>) = move _55; // scope 10 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          (_22.2: &[std::fmt::ArgumentV1]) = move _56; // scope 10 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          StorageDead(_56);                // scope 10 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          StorageDead(_55);                // scope 10 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          StorageDead(_54);                // scope 10 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+          StorageLive(_54);                // scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
+          _54 = _23;                       // scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
+          StorageLive(_55);                // scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
+          discriminant(_55) = 0;           // scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
+          StorageLive(_56);                // scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
+          _56 = _27;                       // scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
+          (_22.0: &[&str]) = move _54;     // scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
+          (_22.1: std::option::Option<&[std::fmt::rt::v1::Argument]>) = move _55; // scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
+          (_22.2: &[std::fmt::ArgumentV1]) = move _56; // scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
+          StorageDead(_56);                // scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
+          StorageDead(_55);                // scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
+          StorageDead(_54);                // scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
           StorageDead(_27);                // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
           StorageDead(_23);                // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
           _21 = &_22;                      // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL

--- a/src/test/mir-opt/issue_73223.main.SimplifyArmIdentity.64bit.diff
+++ b/src/test/mir-opt/issue_73223.main.SimplifyArmIdentity.64bit.diff
@@ -59,32 +59,32 @@
                       debug arg0 => _36;   // in scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                       debug arg1 => _37;   // in scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                       scope 6 (inlined ArgumentV1::new::<&i32>) { // at $SRC_DIR/std/src/macros.rs:LL:COL
-                          debug x => _39;  // in scope 6 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-                          debug f => _40;  // in scope 6 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-                          let mut _46: for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>; // in scope 6 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-                          let mut _47: for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>; // in scope 6 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-                          let mut _48: &core::fmt::Opaque; // in scope 6 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-                          let mut _49: &&i32; // in scope 6 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+                          debug x => _39;  // in scope 6 at $SRC_DIR/std/src/macros.rs:LL:COL
+                          debug f => _40;  // in scope 6 at $SRC_DIR/std/src/macros.rs:LL:COL
+                          let mut _46: for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>; // in scope 6 at $SRC_DIR/std/src/macros.rs:LL:COL
+                          let mut _47: for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>; // in scope 6 at $SRC_DIR/std/src/macros.rs:LL:COL
+                          let mut _48: &core::fmt::Opaque; // in scope 6 at $SRC_DIR/std/src/macros.rs:LL:COL
+                          let mut _49: &&i32; // in scope 6 at $SRC_DIR/std/src/macros.rs:LL:COL
                           scope 7 {
                           }
                       }
                       scope 8 (inlined ArgumentV1::new::<&i32>) { // at $SRC_DIR/std/src/macros.rs:LL:COL
-                          debug x => _42;  // in scope 8 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-                          debug f => _43;  // in scope 8 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-                          let mut _50: for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>; // in scope 8 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-                          let mut _51: for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>; // in scope 8 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-                          let mut _52: &core::fmt::Opaque; // in scope 8 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-                          let mut _53: &&i32; // in scope 8 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+                          debug x => _42;  // in scope 8 at $SRC_DIR/std/src/macros.rs:LL:COL
+                          debug f => _43;  // in scope 8 at $SRC_DIR/std/src/macros.rs:LL:COL
+                          let mut _50: for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>; // in scope 8 at $SRC_DIR/std/src/macros.rs:LL:COL
+                          let mut _51: for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>; // in scope 8 at $SRC_DIR/std/src/macros.rs:LL:COL
+                          let mut _52: &core::fmt::Opaque; // in scope 8 at $SRC_DIR/std/src/macros.rs:LL:COL
+                          let mut _53: &&i32; // in scope 8 at $SRC_DIR/std/src/macros.rs:LL:COL
                           scope 9 {
                           }
                       }
                   }
                   scope 10 (inlined Arguments::new_v1) { // at $SRC_DIR/std/src/macros.rs:LL:COL
-                      debug pieces => _23; // in scope 10 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-                      debug args => _27;   // in scope 10 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-                      let mut _54: &[&str]; // in scope 10 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-                      let mut _55: std::option::Option<&[std::fmt::rt::v1::Argument]>; // in scope 10 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-                      let mut _56: &[std::fmt::ArgumentV1]; // in scope 10 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+                      debug pieces => _23; // in scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
+                      debug args => _27;   // in scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
+                      let mut _54: &[&str]; // in scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
+                      let mut _55: std::option::Option<&[std::fmt::rt::v1::Argument]>; // in scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
+                      let mut _56: &[std::fmt::ArgumentV1]; // in scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
                   }
               }
           }
@@ -217,32 +217,32 @@
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // + literal: Const { ty: for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> {<&i32 as std::fmt::Debug>::fmt}, val: Value(Scalar(<ZST>)) }
-          StorageLive(_46);                // scope 7 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          StorageLive(_47);                // scope 7 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          _47 = _40;                       // scope 7 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          _46 = transmute::<for<'r, 's, 't0> fn(&'r &i32, &'s mut Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>, for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>>(move _47) -> bb5; // scope 7 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+          StorageLive(_46);                // scope 7 at $SRC_DIR/std/src/macros.rs:LL:COL
+          StorageLive(_47);                // scope 7 at $SRC_DIR/std/src/macros.rs:LL:COL
+          _47 = _40;                       // scope 7 at $SRC_DIR/std/src/macros.rs:LL:COL
+          _46 = transmute::<for<'r, 's, 't0> fn(&'r &i32, &'s mut Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>, for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>>(move _47) -> bb5; // scope 7 at $SRC_DIR/std/src/macros.rs:LL:COL
                                            // mir::Constant
-                                           // + span: $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+                                           // + span: $SRC_DIR/std/src/macros.rs:LL:COL
                                            // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>) -> for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> {std::intrinsics::transmute::<for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>, for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>>}, val: Value(Scalar(<ZST>)) }
       }
   
       bb5: {
-          StorageDead(_47);                // scope 7 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          StorageLive(_48);                // scope 7 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          StorageLive(_49);                // scope 7 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          _49 = _39;                       // scope 7 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          _48 = transmute::<&&i32, &core::fmt::Opaque>(move _49) -> bb6; // scope 7 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+          StorageDead(_47);                // scope 7 at $SRC_DIR/std/src/macros.rs:LL:COL
+          StorageLive(_48);                // scope 7 at $SRC_DIR/std/src/macros.rs:LL:COL
+          StorageLive(_49);                // scope 7 at $SRC_DIR/std/src/macros.rs:LL:COL
+          _49 = _39;                       // scope 7 at $SRC_DIR/std/src/macros.rs:LL:COL
+          _48 = transmute::<&&i32, &core::fmt::Opaque>(move _49) -> bb6; // scope 7 at $SRC_DIR/std/src/macros.rs:LL:COL
                                            // mir::Constant
-                                           // + span: $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+                                           // + span: $SRC_DIR/std/src/macros.rs:LL:COL
                                            // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(&&i32) -> &core::fmt::Opaque {std::intrinsics::transmute::<&&i32, &core::fmt::Opaque>}, val: Value(Scalar(<ZST>)) }
       }
   
       bb6: {
-          StorageDead(_49);                // scope 7 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          (_38.0: &core::fmt::Opaque) = move _48; // scope 7 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          (_38.1: for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>) = move _46; // scope 7 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          StorageDead(_48);                // scope 7 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          StorageDead(_46);                // scope 7 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+          StorageDead(_49);                // scope 7 at $SRC_DIR/std/src/macros.rs:LL:COL
+          (_38.0: &core::fmt::Opaque) = move _48; // scope 7 at $SRC_DIR/std/src/macros.rs:LL:COL
+          (_38.1: for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>) = move _46; // scope 7 at $SRC_DIR/std/src/macros.rs:LL:COL
+          StorageDead(_48);                // scope 7 at $SRC_DIR/std/src/macros.rs:LL:COL
+          StorageDead(_46);                // scope 7 at $SRC_DIR/std/src/macros.rs:LL:COL
           StorageDead(_40);                // scope 5 at $SRC_DIR/std/src/macros.rs:LL:COL
           StorageDead(_39);                // scope 5 at $SRC_DIR/std/src/macros.rs:LL:COL
           StorageLive(_41);                // scope 5 at $SRC_DIR/std/src/macros.rs:LL:COL
@@ -253,32 +253,32 @@
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // + literal: Const { ty: for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> {<&i32 as std::fmt::Debug>::fmt}, val: Value(Scalar(<ZST>)) }
-          StorageLive(_50);                // scope 9 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          StorageLive(_51);                // scope 9 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          _51 = _43;                       // scope 9 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          _50 = transmute::<for<'r, 's, 't0> fn(&'r &i32, &'s mut Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>, for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>>(move _51) -> bb7; // scope 9 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+          StorageLive(_50);                // scope 9 at $SRC_DIR/std/src/macros.rs:LL:COL
+          StorageLive(_51);                // scope 9 at $SRC_DIR/std/src/macros.rs:LL:COL
+          _51 = _43;                       // scope 9 at $SRC_DIR/std/src/macros.rs:LL:COL
+          _50 = transmute::<for<'r, 's, 't0> fn(&'r &i32, &'s mut Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>, for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>>(move _51) -> bb7; // scope 9 at $SRC_DIR/std/src/macros.rs:LL:COL
                                            // mir::Constant
-                                           // + span: $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+                                           // + span: $SRC_DIR/std/src/macros.rs:LL:COL
                                            // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>) -> for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> {std::intrinsics::transmute::<for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>, for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>>}, val: Value(Scalar(<ZST>)) }
       }
   
       bb7: {
-          StorageDead(_51);                // scope 9 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          StorageLive(_52);                // scope 9 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          StorageLive(_53);                // scope 9 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          _53 = _42;                       // scope 9 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          _52 = transmute::<&&i32, &core::fmt::Opaque>(move _53) -> bb8; // scope 9 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+          StorageDead(_51);                // scope 9 at $SRC_DIR/std/src/macros.rs:LL:COL
+          StorageLive(_52);                // scope 9 at $SRC_DIR/std/src/macros.rs:LL:COL
+          StorageLive(_53);                // scope 9 at $SRC_DIR/std/src/macros.rs:LL:COL
+          _53 = _42;                       // scope 9 at $SRC_DIR/std/src/macros.rs:LL:COL
+          _52 = transmute::<&&i32, &core::fmt::Opaque>(move _53) -> bb8; // scope 9 at $SRC_DIR/std/src/macros.rs:LL:COL
                                            // mir::Constant
-                                           // + span: $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+                                           // + span: $SRC_DIR/std/src/macros.rs:LL:COL
                                            // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(&&i32) -> &core::fmt::Opaque {std::intrinsics::transmute::<&&i32, &core::fmt::Opaque>}, val: Value(Scalar(<ZST>)) }
       }
   
       bb8: {
-          StorageDead(_53);                // scope 9 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          (_41.0: &core::fmt::Opaque) = move _52; // scope 9 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          (_41.1: for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>) = move _50; // scope 9 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          StorageDead(_52);                // scope 9 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          StorageDead(_50);                // scope 9 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+          StorageDead(_53);                // scope 9 at $SRC_DIR/std/src/macros.rs:LL:COL
+          (_41.0: &core::fmt::Opaque) = move _52; // scope 9 at $SRC_DIR/std/src/macros.rs:LL:COL
+          (_41.1: for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>) = move _50; // scope 9 at $SRC_DIR/std/src/macros.rs:LL:COL
+          StorageDead(_52);                // scope 9 at $SRC_DIR/std/src/macros.rs:LL:COL
+          StorageDead(_50);                // scope 9 at $SRC_DIR/std/src/macros.rs:LL:COL
           StorageDead(_43);                // scope 5 at $SRC_DIR/std/src/macros.rs:LL:COL
           StorageDead(_42);                // scope 5 at $SRC_DIR/std/src/macros.rs:LL:COL
           _30 = [move _38, move _41];      // scope 5 at $SRC_DIR/std/src/macros.rs:LL:COL
@@ -290,18 +290,18 @@
           _28 = _29;                       // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
           _27 = move _28 as &[std::fmt::ArgumentV1] (Pointer(Unsize)); // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
           StorageDead(_28);                // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageLive(_54);                // scope 10 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          _54 = _23;                       // scope 10 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          StorageLive(_55);                // scope 10 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          discriminant(_55) = 0;           // scope 10 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          StorageLive(_56);                // scope 10 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          _56 = _27;                       // scope 10 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          (_22.0: &[&str]) = move _54;     // scope 10 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          (_22.1: std::option::Option<&[std::fmt::rt::v1::Argument]>) = move _55; // scope 10 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          (_22.2: &[std::fmt::ArgumentV1]) = move _56; // scope 10 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          StorageDead(_56);                // scope 10 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          StorageDead(_55);                // scope 10 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          StorageDead(_54);                // scope 10 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+          StorageLive(_54);                // scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
+          _54 = _23;                       // scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
+          StorageLive(_55);                // scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
+          discriminant(_55) = 0;           // scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
+          StorageLive(_56);                // scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
+          _56 = _27;                       // scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
+          (_22.0: &[&str]) = move _54;     // scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
+          (_22.1: std::option::Option<&[std::fmt::rt::v1::Argument]>) = move _55; // scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
+          (_22.2: &[std::fmt::ArgumentV1]) = move _56; // scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
+          StorageDead(_56);                // scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
+          StorageDead(_55);                // scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
+          StorageDead(_54);                // scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
           StorageDead(_27);                // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
           StorageDead(_23);                // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
           _21 = &_22;                      // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL

--- a/src/test/mir-opt/remove_unneeded_drops.cannot_opt_generic.RemoveUnneededDrops.diff
+++ b/src/test/mir-opt/remove_unneeded_drops.cannot_opt_generic.RemoveUnneededDrops.diff
@@ -7,15 +7,15 @@
       let _2: ();                          // in scope 0 at $DIR/remove_unneeded_drops.rs:21:5: 21:12
       let mut _3: T;                       // in scope 0 at $DIR/remove_unneeded_drops.rs:21:10: 21:11
       scope 1 (inlined std::mem::drop::<T>) { // at $DIR/remove_unneeded_drops.rs:21:5: 21:12
-          debug _x => _3;                  // in scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+          debug _x => _3;                  // in scope 1 at $DIR/remove_unneeded_drops.rs:21:5: 21:12
       }
   
       bb0: {
           StorageLive(_2);                 // scope 0 at $DIR/remove_unneeded_drops.rs:21:5: 21:12
           StorageLive(_3);                 // scope 0 at $DIR/remove_unneeded_drops.rs:21:10: 21:11
           _3 = move _1;                    // scope 0 at $DIR/remove_unneeded_drops.rs:21:10: 21:11
-          _2 = const ();                   // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-          drop(_3) -> [return: bb2, unwind: bb1]; // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+          _2 = const ();                   // scope 1 at $DIR/remove_unneeded_drops.rs:21:5: 21:12
+          drop(_3) -> [return: bb2, unwind: bb1]; // scope 1 at $DIR/remove_unneeded_drops.rs:21:5: 21:12
       }
   
       bb1 (cleanup): {

--- a/src/test/mir-opt/remove_unneeded_drops.dont_opt.RemoveUnneededDrops.diff
+++ b/src/test/mir-opt/remove_unneeded_drops.dont_opt.RemoveUnneededDrops.diff
@@ -7,15 +7,15 @@
       let _2: ();                          // in scope 0 at $DIR/remove_unneeded_drops.rs:9:5: 9:12
       let mut _3: std::vec::Vec<bool>;     // in scope 0 at $DIR/remove_unneeded_drops.rs:9:10: 9:11
       scope 1 (inlined std::mem::drop::<Vec<bool>>) { // at $DIR/remove_unneeded_drops.rs:9:5: 9:12
-          debug _x => _3;                  // in scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+          debug _x => _3;                  // in scope 1 at $DIR/remove_unneeded_drops.rs:9:5: 9:12
       }
   
       bb0: {
           StorageLive(_2);                 // scope 0 at $DIR/remove_unneeded_drops.rs:9:5: 9:12
           StorageLive(_3);                 // scope 0 at $DIR/remove_unneeded_drops.rs:9:10: 9:11
           _3 = move _1;                    // scope 0 at $DIR/remove_unneeded_drops.rs:9:10: 9:11
-          _2 = const ();                   // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-          drop(_3) -> [return: bb2, unwind: bb1]; // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+          _2 = const ();                   // scope 1 at $DIR/remove_unneeded_drops.rs:9:5: 9:12
+          drop(_3) -> [return: bb2, unwind: bb1]; // scope 1 at $DIR/remove_unneeded_drops.rs:9:5: 9:12
       }
   
       bb1 (cleanup): {

--- a/src/test/mir-opt/remove_unneeded_drops.opt.RemoveUnneededDrops.diff
+++ b/src/test/mir-opt/remove_unneeded_drops.opt.RemoveUnneededDrops.diff
@@ -7,15 +7,15 @@
       let _2: ();                          // in scope 0 at $DIR/remove_unneeded_drops.rs:4:5: 4:12
       let mut _3: bool;                    // in scope 0 at $DIR/remove_unneeded_drops.rs:4:10: 4:11
       scope 1 (inlined std::mem::drop::<bool>) { // at $DIR/remove_unneeded_drops.rs:4:5: 4:12
-          debug _x => _3;                  // in scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+          debug _x => _3;                  // in scope 1 at $DIR/remove_unneeded_drops.rs:4:5: 4:12
       }
   
       bb0: {
           StorageLive(_2);                 // scope 0 at $DIR/remove_unneeded_drops.rs:4:5: 4:12
           StorageLive(_3);                 // scope 0 at $DIR/remove_unneeded_drops.rs:4:10: 4:11
           _3 = _1;                         // scope 0 at $DIR/remove_unneeded_drops.rs:4:10: 4:11
-          _2 = const ();                   // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
--         drop(_3) -> bb1;                 // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+          _2 = const ();                   // scope 1 at $DIR/remove_unneeded_drops.rs:4:5: 4:12
+-         drop(_3) -> bb1;                 // scope 1 at $DIR/remove_unneeded_drops.rs:4:5: 4:12
 -     }
 - 
 -     bb1: {

--- a/src/test/mir-opt/remove_unneeded_drops.opt_generic_copy.RemoveUnneededDrops.diff
+++ b/src/test/mir-opt/remove_unneeded_drops.opt_generic_copy.RemoveUnneededDrops.diff
@@ -7,15 +7,15 @@
       let _2: ();                          // in scope 0 at $DIR/remove_unneeded_drops.rs:14:5: 14:12
       let mut _3: T;                       // in scope 0 at $DIR/remove_unneeded_drops.rs:14:10: 14:11
       scope 1 (inlined std::mem::drop::<T>) { // at $DIR/remove_unneeded_drops.rs:14:5: 14:12
-          debug _x => _3;                  // in scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+          debug _x => _3;                  // in scope 1 at $DIR/remove_unneeded_drops.rs:14:5: 14:12
       }
   
       bb0: {
           StorageLive(_2);                 // scope 0 at $DIR/remove_unneeded_drops.rs:14:5: 14:12
           StorageLive(_3);                 // scope 0 at $DIR/remove_unneeded_drops.rs:14:10: 14:11
           _3 = _1;                         // scope 0 at $DIR/remove_unneeded_drops.rs:14:10: 14:11
-          _2 = const ();                   // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
--         drop(_3) -> bb1;                 // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+          _2 = const ();                   // scope 1 at $DIR/remove_unneeded_drops.rs:14:5: 14:12
+-         drop(_3) -> bb1;                 // scope 1 at $DIR/remove_unneeded_drops.rs:14:5: 14:12
 -     }
 - 
 -     bb1: {

--- a/src/test/mir-opt/simplify_arm.id_try.SimplifyArmIdentity.diff
+++ b/src/test/mir-opt/simplify_arm.id_try.SimplifyArmIdentity.diff
@@ -23,13 +23,13 @@
 +         debug err => ((_0 as Err).0: i32); // in scope 2 at $DIR/simplify-arm.rs:24:14: 24:15
           scope 3 {
               scope 7 (inlined <i32 as From<i32>>::from) { // at $DIR/simplify-arm.rs:24:14: 24:15
--                 debug t => _9;           // in scope 7 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
-+                 debug t => ((_0 as Err).0: i32); // in scope 7 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
+-                 debug t => _9;           // in scope 7 at $DIR/simplify-arm.rs:24:14: 24:15
++                 debug t => ((_0 as Err).0: i32); // in scope 7 at $DIR/simplify-arm.rs:24:14: 24:15
               }
               scope 8 (inlined <std::result::Result<u8, i32> as Try>::from_error) { // at $DIR/simplify-arm.rs:24:13: 24:15
--                 debug v => _8;           // in scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
-+                 debug v => ((_0 as Err).0: i32); // in scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
-                  let mut _12: i32;        // in scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
+-                 debug v => _8;           // in scope 8 at $DIR/simplify-arm.rs:24:13: 24:15
++                 debug v => ((_0 as Err).0: i32); // in scope 8 at $DIR/simplify-arm.rs:24:13: 24:15
+                  let mut _12: i32;        // in scope 8 at $DIR/simplify-arm.rs:24:13: 24:15
               }
           }
       }
@@ -40,7 +40,7 @@
           }
       }
       scope 6 (inlined <std::result::Result<u8, i32> as Try>::into_result) { // at $DIR/simplify-arm.rs:24:13: 24:15
-          debug self => _4;                // in scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+          debug self => _4;                // in scope 6 at $DIR/simplify-arm.rs:24:13: 24:15
       }
   
       bb0: {
@@ -48,7 +48,7 @@
           StorageLive(_3);                 // scope 0 at $DIR/simplify-arm.rs:24:13: 24:15
           StorageLive(_4);                 // scope 0 at $DIR/simplify-arm.rs:24:13: 24:14
           _4 = _1;                         // scope 0 at $DIR/simplify-arm.rs:24:13: 24:14
-          _3 = move _4;                    // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+          _3 = move _4;                    // scope 6 at $DIR/simplify-arm.rs:24:13: 24:15
           StorageDead(_4);                 // scope 0 at $DIR/simplify-arm.rs:24:14: 24:15
           _5 = discriminant(_3);           // scope 0 at $DIR/simplify-arm.rs:24:14: 24:15
           switchInt(move _5) -> [0_isize: bb1, 1_isize: bb3, otherwise: bb2]; // scope 0 at $DIR/simplify-arm.rs:24:14: 24:15
@@ -80,16 +80,16 @@
 -         StorageLive(_8);                 // scope 3 at $DIR/simplify-arm.rs:24:14: 24:15
 -         StorageLive(_9);                 // scope 3 at $DIR/simplify-arm.rs:24:14: 24:15
 -         _9 = _6;                         // scope 3 at $DIR/simplify-arm.rs:24:14: 24:15
--         _8 = move _9;                    // scope 7 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
+-         _8 = move _9;                    // scope 7 at $DIR/simplify-arm.rs:24:14: 24:15
 -         StorageDead(_9);                 // scope 3 at $DIR/simplify-arm.rs:24:14: 24:15
--         StorageLive(_12);                // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
--         _12 = move _8;                   // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
--         ((_0 as Err).0: i32) = move _12; // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
--         discriminant(_0) = 1;            // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
--         StorageDead(_12);                // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
+-         StorageLive(_12);                // scope 8 at $DIR/simplify-arm.rs:24:13: 24:15
+-         _12 = move _8;                   // scope 8 at $DIR/simplify-arm.rs:24:13: 24:15
+-         ((_0 as Err).0: i32) = move _12; // scope 8 at $DIR/simplify-arm.rs:24:13: 24:15
+-         discriminant(_0) = 1;            // scope 8 at $DIR/simplify-arm.rs:24:13: 24:15
+-         StorageDead(_12);                // scope 8 at $DIR/simplify-arm.rs:24:13: 24:15
 -         StorageDead(_8);                 // scope 3 at $DIR/simplify-arm.rs:24:14: 24:15
 -         StorageDead(_6);                 // scope 0 at $DIR/simplify-arm.rs:24:14: 24:15
-+         _0 = move _3;                    // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
++         _0 = move _3;                    // scope 8 at $DIR/simplify-arm.rs:24:13: 24:15
           StorageDead(_3);                 // scope 0 at $DIR/simplify-arm.rs:24:15: 24:16
           StorageDead(_2);                 // scope 0 at $DIR/simplify-arm.rs:26:1: 26:2
           goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:26:2: 26:2

--- a/src/test/mir-opt/simplify_arm.id_try.SimplifyBranchSame.diff
+++ b/src/test/mir-opt/simplify_arm.id_try.SimplifyBranchSame.diff
@@ -21,11 +21,11 @@
           debug err => ((_0 as Err).0: i32); // in scope 2 at $DIR/simplify-arm.rs:24:14: 24:15
           scope 3 {
               scope 7 (inlined <i32 as From<i32>>::from) { // at $DIR/simplify-arm.rs:24:14: 24:15
-                  debug t => ((_0 as Err).0: i32); // in scope 7 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
+                  debug t => ((_0 as Err).0: i32); // in scope 7 at $DIR/simplify-arm.rs:24:14: 24:15
               }
               scope 8 (inlined <std::result::Result<u8, i32> as Try>::from_error) { // at $DIR/simplify-arm.rs:24:13: 24:15
-                  debug v => ((_0 as Err).0: i32); // in scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
-                  let mut _12: i32;        // in scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
+                  debug v => ((_0 as Err).0: i32); // in scope 8 at $DIR/simplify-arm.rs:24:13: 24:15
+                  let mut _12: i32;        // in scope 8 at $DIR/simplify-arm.rs:24:13: 24:15
               }
           }
       }
@@ -35,7 +35,7 @@
           }
       }
       scope 6 (inlined <std::result::Result<u8, i32> as Try>::into_result) { // at $DIR/simplify-arm.rs:24:13: 24:15
-          debug self => _4;                // in scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+          debug self => _4;                // in scope 6 at $DIR/simplify-arm.rs:24:13: 24:15
       }
   
       bb0: {
@@ -43,7 +43,7 @@
           StorageLive(_3);                 // scope 0 at $DIR/simplify-arm.rs:24:13: 24:15
           StorageLive(_4);                 // scope 0 at $DIR/simplify-arm.rs:24:13: 24:14
           _4 = _1;                         // scope 0 at $DIR/simplify-arm.rs:24:13: 24:14
-          _3 = move _4;                    // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+          _3 = move _4;                    // scope 6 at $DIR/simplify-arm.rs:24:13: 24:15
           StorageDead(_4);                 // scope 0 at $DIR/simplify-arm.rs:24:14: 24:15
           _5 = discriminant(_3);           // scope 0 at $DIR/simplify-arm.rs:24:14: 24:15
 -         switchInt(move _5) -> [0_isize: bb1, 1_isize: bb3, otherwise: bb2]; // scope 0 at $DIR/simplify-arm.rs:24:14: 24:15
@@ -63,7 +63,7 @@
 -     }
 - 
 -     bb3: {
--         _0 = move _3;                    // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
+-         _0 = move _3;                    // scope 8 at $DIR/simplify-arm.rs:24:13: 24:15
 -         StorageDead(_3);                 // scope 0 at $DIR/simplify-arm.rs:24:15: 24:16
 -         StorageDead(_2);                 // scope 0 at $DIR/simplify-arm.rs:26:1: 26:2
 -         goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:26:2: 26:2

--- a/src/test/mir-opt/simplify_try.try_identity.DestinationPropagation.diff
+++ b/src/test/mir-opt/simplify_try.try_identity.DestinationPropagation.diff
@@ -21,11 +21,11 @@
           debug err => ((_0 as Err).0: i32); // in scope 2 at $DIR/simplify_try.rs:8:14: 8:15
           scope 3 {
               scope 7 (inlined <i32 as From<i32>>::from) { // at $DIR/simplify_try.rs:8:14: 8:15
-                  debug t => ((_0 as Err).0: i32); // in scope 7 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
+                  debug t => ((_0 as Err).0: i32); // in scope 7 at $DIR/simplify_try.rs:8:14: 8:15
               }
               scope 8 (inlined <std::result::Result<u32, i32> as Try>::from_error) { // at $DIR/simplify_try.rs:8:13: 8:15
-                  debug v => ((_0 as Err).0: i32); // in scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
-                  let mut _12: i32;        // in scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
+                  debug v => ((_0 as Err).0: i32); // in scope 8 at $DIR/simplify_try.rs:8:13: 8:15
+                  let mut _12: i32;        // in scope 8 at $DIR/simplify_try.rs:8:13: 8:15
               }
           }
       }
@@ -35,8 +35,8 @@
           }
       }
       scope 6 (inlined <std::result::Result<u32, i32> as Try>::into_result) { // at $DIR/simplify_try.rs:8:13: 8:15
--         debug self => _4;                // in scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
-+         debug self => _0;                // in scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+-         debug self => _4;                // in scope 6 at $DIR/simplify_try.rs:8:13: 8:15
++         debug self => _0;                // in scope 6 at $DIR/simplify_try.rs:8:13: 8:15
       }
   
       bb0: {
@@ -44,13 +44,13 @@
 -         StorageLive(_3);                 // scope 0 at $DIR/simplify_try.rs:8:13: 8:15
 -         StorageLive(_4);                 // scope 0 at $DIR/simplify_try.rs:8:13: 8:14
 -         _4 = _1;                         // scope 0 at $DIR/simplify_try.rs:8:13: 8:14
--         _3 = move _4;                    // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+-         _3 = move _4;                    // scope 6 at $DIR/simplify_try.rs:8:13: 8:15
 -         StorageDead(_4);                 // scope 0 at $DIR/simplify_try.rs:8:14: 8:15
 -         _5 = discriminant(_3);           // scope 0 at $DIR/simplify_try.rs:8:14: 8:15
 +         nop;                             // scope 0 at $DIR/simplify_try.rs:8:13: 8:15
 +         nop;                             // scope 0 at $DIR/simplify_try.rs:8:13: 8:14
 +         _0 = _1;                         // scope 0 at $DIR/simplify_try.rs:8:13: 8:14
-+         nop;                             // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
++         nop;                             // scope 6 at $DIR/simplify_try.rs:8:13: 8:15
 +         nop;                             // scope 0 at $DIR/simplify_try.rs:8:14: 8:15
 +         _5 = discriminant(_0);           // scope 0 at $DIR/simplify_try.rs:8:14: 8:15
           goto -> bb1;                     // scope 0 at $DIR/simplify_try.rs:8:14: 8:15

--- a/src/test/mir-opt/simplify_try.try_identity.SimplifyArmIdentity.diff
+++ b/src/test/mir-opt/simplify_try.try_identity.SimplifyArmIdentity.diff
@@ -23,13 +23,13 @@
 +         debug err => ((_0 as Err).0: i32); // in scope 2 at $DIR/simplify_try.rs:8:14: 8:15
           scope 3 {
               scope 7 (inlined <i32 as From<i32>>::from) { // at $DIR/simplify_try.rs:8:14: 8:15
--                 debug t => _9;           // in scope 7 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
-+                 debug t => ((_0 as Err).0: i32); // in scope 7 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
+-                 debug t => _9;           // in scope 7 at $DIR/simplify_try.rs:8:14: 8:15
++                 debug t => ((_0 as Err).0: i32); // in scope 7 at $DIR/simplify_try.rs:8:14: 8:15
               }
               scope 8 (inlined <std::result::Result<u32, i32> as Try>::from_error) { // at $DIR/simplify_try.rs:8:13: 8:15
--                 debug v => _8;           // in scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
-+                 debug v => ((_0 as Err).0: i32); // in scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
-                  let mut _12: i32;        // in scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
+-                 debug v => _8;           // in scope 8 at $DIR/simplify_try.rs:8:13: 8:15
++                 debug v => ((_0 as Err).0: i32); // in scope 8 at $DIR/simplify_try.rs:8:13: 8:15
+                  let mut _12: i32;        // in scope 8 at $DIR/simplify_try.rs:8:13: 8:15
               }
           }
       }
@@ -40,7 +40,7 @@
           }
       }
       scope 6 (inlined <std::result::Result<u32, i32> as Try>::into_result) { // at $DIR/simplify_try.rs:8:13: 8:15
-          debug self => _4;                // in scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+          debug self => _4;                // in scope 6 at $DIR/simplify_try.rs:8:13: 8:15
       }
   
       bb0: {
@@ -48,7 +48,7 @@
           StorageLive(_3);                 // scope 0 at $DIR/simplify_try.rs:8:13: 8:15
           StorageLive(_4);                 // scope 0 at $DIR/simplify_try.rs:8:13: 8:14
           _4 = _1;                         // scope 0 at $DIR/simplify_try.rs:8:13: 8:14
-          _3 = move _4;                    // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+          _3 = move _4;                    // scope 6 at $DIR/simplify_try.rs:8:13: 8:15
           StorageDead(_4);                 // scope 0 at $DIR/simplify_try.rs:8:14: 8:15
           _5 = discriminant(_3);           // scope 0 at $DIR/simplify_try.rs:8:14: 8:15
           switchInt(move _5) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/simplify_try.rs:8:14: 8:15
@@ -76,16 +76,16 @@
 -         StorageLive(_8);                 // scope 3 at $DIR/simplify_try.rs:8:14: 8:15
 -         StorageLive(_9);                 // scope 3 at $DIR/simplify_try.rs:8:14: 8:15
 -         _9 = _6;                         // scope 3 at $DIR/simplify_try.rs:8:14: 8:15
--         _8 = move _9;                    // scope 7 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
+-         _8 = move _9;                    // scope 7 at $DIR/simplify_try.rs:8:14: 8:15
 -         StorageDead(_9);                 // scope 3 at $DIR/simplify_try.rs:8:14: 8:15
--         StorageLive(_12);                // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
--         _12 = move _8;                   // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
--         ((_0 as Err).0: i32) = move _12; // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
--         discriminant(_0) = 1;            // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
--         StorageDead(_12);                // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
+-         StorageLive(_12);                // scope 8 at $DIR/simplify_try.rs:8:13: 8:15
+-         _12 = move _8;                   // scope 8 at $DIR/simplify_try.rs:8:13: 8:15
+-         ((_0 as Err).0: i32) = move _12; // scope 8 at $DIR/simplify_try.rs:8:13: 8:15
+-         discriminant(_0) = 1;            // scope 8 at $DIR/simplify_try.rs:8:13: 8:15
+-         StorageDead(_12);                // scope 8 at $DIR/simplify_try.rs:8:13: 8:15
 -         StorageDead(_8);                 // scope 3 at $DIR/simplify_try.rs:8:14: 8:15
 -         StorageDead(_6);                 // scope 0 at $DIR/simplify_try.rs:8:14: 8:15
-+         _0 = move _3;                    // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
++         _0 = move _3;                    // scope 8 at $DIR/simplify_try.rs:8:13: 8:15
           StorageDead(_3);                 // scope 0 at $DIR/simplify_try.rs:8:15: 8:16
           StorageDead(_2);                 // scope 0 at $DIR/simplify_try.rs:10:1: 10:2
           return;                          // scope 0 at $DIR/simplify_try.rs:10:2: 10:2

--- a/src/test/mir-opt/simplify_try.try_identity.SimplifyBranchSame.after.mir
+++ b/src/test/mir-opt/simplify_try.try_identity.SimplifyBranchSame.after.mir
@@ -20,11 +20,11 @@ fn try_identity(_1: std::result::Result<u32, i32>) -> std::result::Result<u32, i
         debug err => ((_0 as Err).0: i32); // in scope 2 at $DIR/simplify_try.rs:8:14: 8:15
         scope 3 {
             scope 7 (inlined <i32 as From<i32>>::from) { // at $DIR/simplify_try.rs:8:14: 8:15
-                debug t => ((_0 as Err).0: i32); // in scope 7 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
+                debug t => ((_0 as Err).0: i32); // in scope 7 at $DIR/simplify_try.rs:8:14: 8:15
             }
             scope 8 (inlined <std::result::Result<u32, i32> as Try>::from_error) { // at $DIR/simplify_try.rs:8:13: 8:15
-                debug v => ((_0 as Err).0: i32); // in scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
-                let mut _12: i32;        // in scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
+                debug v => ((_0 as Err).0: i32); // in scope 8 at $DIR/simplify_try.rs:8:13: 8:15
+                let mut _12: i32;        // in scope 8 at $DIR/simplify_try.rs:8:13: 8:15
             }
         }
     }
@@ -34,7 +34,7 @@ fn try_identity(_1: std::result::Result<u32, i32>) -> std::result::Result<u32, i
         }
     }
     scope 6 (inlined <std::result::Result<u32, i32> as Try>::into_result) { // at $DIR/simplify_try.rs:8:13: 8:15
-        debug self => _4;                // in scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+        debug self => _4;                // in scope 6 at $DIR/simplify_try.rs:8:13: 8:15
     }
 
     bb0: {
@@ -42,7 +42,7 @@ fn try_identity(_1: std::result::Result<u32, i32>) -> std::result::Result<u32, i
         StorageLive(_3);                 // scope 0 at $DIR/simplify_try.rs:8:13: 8:15
         StorageLive(_4);                 // scope 0 at $DIR/simplify_try.rs:8:13: 8:14
         _4 = _1;                         // scope 0 at $DIR/simplify_try.rs:8:13: 8:14
-        _3 = move _4;                    // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+        _3 = move _4;                    // scope 6 at $DIR/simplify_try.rs:8:13: 8:15
         StorageDead(_4);                 // scope 0 at $DIR/simplify_try.rs:8:14: 8:15
         _5 = discriminant(_3);           // scope 0 at $DIR/simplify_try.rs:8:14: 8:15
         goto -> bb1;                     // scope 0 at $DIR/simplify_try.rs:8:14: 8:15

--- a/src/test/mir-opt/simplify_try.try_identity.SimplifyLocals.after.mir
+++ b/src/test/mir-opt/simplify_try.try_identity.SimplifyLocals.after.mir
@@ -10,10 +10,10 @@ fn try_identity(_1: std::result::Result<u32, i32>) -> std::result::Result<u32, i
         debug err => ((_0 as Err).0: i32); // in scope 2 at $DIR/simplify_try.rs:8:14: 8:15
         scope 3 {
             scope 7 (inlined <i32 as From<i32>>::from) { // at $DIR/simplify_try.rs:8:14: 8:15
-                debug t => ((_0 as Err).0: i32); // in scope 7 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
+                debug t => ((_0 as Err).0: i32); // in scope 7 at $DIR/simplify_try.rs:8:14: 8:15
             }
             scope 8 (inlined <std::result::Result<u32, i32> as Try>::from_error) { // at $DIR/simplify_try.rs:8:13: 8:15
-                debug v => ((_0 as Err).0: i32); // in scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
+                debug v => ((_0 as Err).0: i32); // in scope 8 at $DIR/simplify_try.rs:8:13: 8:15
             }
         }
     }
@@ -23,7 +23,7 @@ fn try_identity(_1: std::result::Result<u32, i32>) -> std::result::Result<u32, i
         }
     }
     scope 6 (inlined <std::result::Result<u32, i32> as Try>::into_result) { // at $DIR/simplify_try.rs:8:13: 8:15
-        debug self => _0;                // in scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+        debug self => _0;                // in scope 6 at $DIR/simplify_try.rs:8:13: 8:15
     }
 
     bb0: {

--- a/src/test/ui/const_prop/inline_spans.rs
+++ b/src/test/ui/const_prop/inline_spans.rs
@@ -5,10 +5,10 @@
 
 fn main() {
     let _ = add(u8::MAX, 1);
+    //~^ ERROR this arithmetic operation will overflow
 }
 
 #[inline(always)]
 fn add(x: u8, y: u8) -> u8 {
     x + y
-    //~^ ERROR this arithmetic operation will overflow
 }

--- a/src/test/ui/const_prop/inline_spans.rs
+++ b/src/test/ui/const_prop/inline_spans.rs
@@ -1,0 +1,14 @@
+// build-fail
+// compile-flags: -Zmir-opt-level=2
+
+#![deny(warnings)]
+
+fn main() {
+    let _ = add(u8::MAX, 1);
+}
+
+#[inline(always)]
+fn add(x: u8, y: u8) -> u8 {
+    x + y
+    //~^ ERROR this arithmetic operation will overflow
+}

--- a/src/test/ui/const_prop/inline_spans.stderr
+++ b/src/test/ui/const_prop/inline_spans.stderr
@@ -1,0 +1,10 @@
+error: this arithmetic operation will overflow
+  --> $DIR/inline_spans.rs:12:5
+   |
+LL |     x + y
+   |     ^^^^^ attempt to compute `u8::MAX + 1_u8` which would overflow
+   |
+   = note: `#[deny(arithmetic_overflow)]` on by default
+
+error: aborting due to previous error
+

--- a/src/test/ui/const_prop/inline_spans.stderr
+++ b/src/test/ui/const_prop/inline_spans.stderr
@@ -5,7 +5,7 @@ LL |     let _ = add(u8::MAX, 1);
    |             ^^^^^^^^^^^^^^^ attempt to compute `u8::MAX + 1_u8`, which would overflow
 ...
 LL |     x + y
-   |     ----- in the inlined copy of this
+   |     ----- in the inlined copy of this code
    |
    = note: `#[deny(arithmetic_overflow)]` on by default
 

--- a/src/test/ui/const_prop/inline_spans.stderr
+++ b/src/test/ui/const_prop/inline_spans.stderr
@@ -1,8 +1,11 @@
 error: this arithmetic operation will overflow
-  --> $DIR/inline_spans.rs:12:5
+  --> $DIR/inline_spans.rs:7:13
    |
+LL |     let _ = add(u8::MAX, 1);
+   |             ^^^^^^^^^^^^^^^ attempt to compute `u8::MAX + 1_u8`, which would overflow
+...
 LL |     x + y
-   |     ^^^^^ attempt to compute `u8::MAX + 1_u8` which would overflow
+   |     ----- in the inlined copy of this
    |
    = note: `#[deny(arithmetic_overflow)]` on by default
 


### PR DESCRIPTION
The first commit shows what happens when we apply mir inlining and then cause lints on the inlined MIR.
The second commit fixes that.

r? @wesleywiser 