### PR TITLE
Don't allow implementing trait directly on type-alias-impl-trait

### DIFF
--- a/compiler/rustc_typeck/src/coherence/orphan.rs
+++ b/compiler/rustc_typeck/src/coherence/orphan.rs
@@ -230,6 +230,14 @@ impl ItemLikeVisitor<'v> for OrphanChecker<'tcx> {
                     return;
                 }
             }
+
+            if let ty::Opaque(def_id, _) = *trait_ref.self_ty().kind() {
+                self.tcx
+                    .sess
+                    .struct_span_err(sp, "cannot implement trait on type alias impl trait")
+                    .span_note(self.tcx.def_span(def_id), "type alias impl trait defined here")
+                    .emit();
+            }
         }
     }
 

--- a/src/test/ui/type-alias-impl-trait/issue-76202-trait-impl-for-tait.rs
+++ b/src/test/ui/type-alias-impl-trait/issue-76202-trait-impl-for-tait.rs
@@ -1,0 +1,23 @@
+// Regression test for issue #76202
+// Tests that we don't ICE when we have a trait impl on a TAIT.
+
+#![feature(type_alias_impl_trait)]
+
+trait Dummy {}
+impl Dummy for () {}
+
+type F = impl Dummy;
+fn f() -> F {}
+
+trait Test {
+    fn test(self);
+}
+
+impl Test for F { //~ ERROR cannot implement trait
+    fn test(self) {}
+}
+
+fn main() {
+    let x: F = f();
+    x.test();
+}

--- a/src/test/ui/type-alias-impl-trait/issue-76202-trait-impl-for-tait.stderr
+++ b/src/test/ui/type-alias-impl-trait/issue-76202-trait-impl-for-tait.stderr
@@ -1,0 +1,14 @@
+error: cannot implement trait on type alias impl trait
+  --> $DIR/issue-76202-trait-impl-for-tait.rs:16:1
+   |
+LL | impl Test for F {
+   | ^^^^^^^^^^^^^^^
+   |
+note: type alias impl trait defined here
+  --> $DIR/issue-76202-trait-impl-for-tait.rs:9:10
+   |
+LL | type F = impl Dummy;
+   |          ^^^^^^^^^^
+
+error: aborting due to previous error
+


### PR DESCRIPTION
This is specifically disallowed by the RFC, but we never added a check
for it.

Fixes #76202