### PR TITLE
Add cfg(target_has_atomic_equal_alignment) and use it for Atomic::from_mut.

### DIFF
--- a/compiler/rustc_feature/src/builtin_attrs.rs
+++ b/compiler/rustc_feature/src/builtin_attrs.rs
@@ -26,6 +26,11 @@ const GATED_CFGS: &[GatedCfg] = &[
     (sym::target_thread_local, sym::cfg_target_thread_local, cfg_fn!(cfg_target_thread_local)),
     (sym::target_has_atomic, sym::cfg_target_has_atomic, cfg_fn!(cfg_target_has_atomic)),
     (sym::target_has_atomic_load_store, sym::cfg_target_has_atomic, cfg_fn!(cfg_target_has_atomic)),
+    (
+        sym::target_has_atomic_equal_alignment,
+        sym::cfg_target_has_atomic,
+        cfg_fn!(cfg_target_has_atomic),
+    ),
     (sym::sanitize, sym::cfg_sanitize, cfg_fn!(cfg_sanitize)),
     (sym::version, sym::cfg_version, cfg_fn!(cfg_version)),
 ];

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -12,6 +12,7 @@ use rustc_data_structures::fx::FxHashSet;
 use rustc_data_structures::impl_stable_hash_via_hash;
 use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
 
+use rustc_target::abi::{Align, TargetDataLayout};
 use rustc_target::spec::{Target, TargetTriple};
 
 use crate::parse::CrateConfig;
@@ -748,6 +749,7 @@ pub fn default_configuration(sess: &Session) -> CrateConfig {
     let min_atomic_width = sess.target.target.min_atomic_width();
     let max_atomic_width = sess.target.target.max_atomic_width();
     let atomic_cas = sess.target.target.options.atomic_cas;
+    let layout = TargetDataLayout::parse(&sess.target.target).unwrap();
 
     let mut ret = FxHashSet::default();
     ret.reserve(6); // the minimum number of insertions
@@ -769,18 +771,27 @@ pub fn default_configuration(sess: &Session) -> CrateConfig {
     if sess.target.target.options.has_elf_tls {
         ret.insert((sym::target_thread_local, None));
     }
-    for &i in &[8, 16, 32, 64, 128] {
+    for &(i, align) in &[
+        (8, layout.i8_align.abi),
+        (16, layout.i16_align.abi),
+        (32, layout.i32_align.abi),
+        (64, layout.i64_align.abi),
+        (128, layout.i128_align.abi),
+    ] {
         if i >= min_atomic_width && i <= max_atomic_width {
-            let mut insert_atomic = |s| {
+            let mut insert_atomic = |s, align: Align| {
                 ret.insert((sym::target_has_atomic_load_store, Some(Symbol::intern(s))));
                 if atomic_cas {
                     ret.insert((sym::target_has_atomic, Some(Symbol::intern(s))));
                 }
+                if align.bits() == i {
+                    ret.insert((sym::target_has_atomic_equal_alignment, Some(Symbol::intern(s))));
+                }
             };
             let s = i.to_string();
-            insert_atomic(&s);
+            insert_atomic(&s, align);
             if &s == wordsz {
-                insert_atomic("ptr");
+                insert_atomic("ptr", layout.pointer_align.abi);
             }
         }
     }

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -749,7 +749,9 @@ pub fn default_configuration(sess: &Session) -> CrateConfig {
     let min_atomic_width = sess.target.target.min_atomic_width();
     let max_atomic_width = sess.target.target.max_atomic_width();
     let atomic_cas = sess.target.target.options.atomic_cas;
-    let layout = TargetDataLayout::parse(&sess.target.target).unwrap();
+    let layout = TargetDataLayout::parse(&sess.target.target).unwrap_or_else(|err| {
+        sess.fatal(&err);
+    });
 
     let mut ret = FxHashSet::default();
     ret.reserve(6); // the minimum number of insertions

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1071,6 +1071,7 @@ symbols! {
         target_feature,
         target_feature_11,
         target_has_atomic,
+        target_has_atomic_equal_alignment,
         target_has_atomic_load_store,
         target_os,
         target_pointer_width,

--- a/library/core/src/sync/atomic.rs
+++ b/library/core/src/sync/atomic.rs
@@ -111,9 +111,6 @@ use crate::cell::UnsafeCell;
 use crate::fmt;
 use crate::intrinsics;
 
-#[allow(unused_imports)]
-use crate::mem::align_of;
-
 use crate::hint::spin_loop;
 
 /// Signals the processor that it is inside a busy-wait spin-loop ("spin lock").
@@ -861,6 +858,7 @@ impl<T> AtomicPtr<T> {
     #[cfg(target_has_atomic_equal_alignment = "ptr")]
     #[unstable(feature = "atomic_from_mut", issue = "76314")]
     pub fn from_mut(v: &mut *mut T) -> &Self {
+        use crate::mem::align_of;
         let [] = [(); align_of::<AtomicPtr<()>>() - align_of::<*mut ()>()];
         // SAFETY:
         //  - the mutable reference guarantees unique ownership.
@@ -1311,6 +1309,7 @@ assert_eq!(some_int, 100);
                 #[$cfg_align]
                 #[unstable(feature = "atomic_from_mut", issue = "76314")]
                 pub fn from_mut(v: &mut $int_type) -> &Self {
+                    use crate::mem::align_of;
                     let [] = [(); align_of::<Self>() - align_of::<$int_type>()];
                     // SAFETY:
                     //  - the mutable reference guarantees unique ownership.

--- a/library/core/src/sync/atomic.rs
+++ b/library/core/src/sync/atomic.rs
@@ -110,6 +110,7 @@ use self::Ordering::*;
 use crate::cell::UnsafeCell;
 use crate::fmt;
 use crate::intrinsics;
+use crate::mem::align_of;
 
 use crate::hint::spin_loop;
 
@@ -325,6 +326,27 @@ impl AtomicBool {
     pub fn get_mut(&mut self) -> &mut bool {
         // SAFETY: the mutable reference guarantees unique ownership.
         unsafe { &mut *(self.v.get() as *mut bool) }
+    }
+
+    /// Get atomic access to a `&mut bool`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(atomic_from_mut)]
+    /// use std::sync::atomic::{AtomicBool, Ordering};
+    ///
+    /// let mut some_bool = true;
+    /// let a = AtomicBool::from_mut(&mut some_bool);
+    /// a.store(false, Ordering::Relaxed);
+    /// assert_eq!(some_bool, false);
+    /// ```
+    #[inline]
+    #[unstable(feature = "atomic_from_mut", issue = "76314")]
+    pub fn from_mut(v: &mut bool) -> &Self {
+        // SAFETY: the mutable reference guarantees unique ownership, and
+        // alignment of both `bool` and `Self` is 1.
+        unsafe { &*(v as *mut bool as *mut Self) }
     }
 
     /// Consumes the atomic and returns the contained value.
@@ -819,6 +841,30 @@ impl<T> AtomicPtr<T> {
         self.p.get_mut()
     }
 
+    /// Get atomic access to a pointer.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(atomic_from_mut)]
+    /// use std::sync::atomic::{AtomicPtr, Ordering};
+    ///
+    /// let mut some_ptr = &mut 123 as *mut i32;
+    /// let a = AtomicPtr::from_mut(&mut some_ptr);
+    /// a.store(&mut 456, Ordering::Relaxed);
+    /// assert_eq!(unsafe { *some_ptr }, 456);
+    /// ```
+    #[inline]
+    #[unstable(feature = "atomic_from_mut", issue = "76314")]
+    pub fn from_mut(v: &mut *mut T) -> &Self {
+        let [] = [(); align_of::<AtomicPtr<()>>() - align_of::<*mut ()>()];
+        // SAFETY:
+        //  - the mutable reference guarantees unique ownership.
+        //  - the alignment of `*mut T` and `Self` is the same on all platforms
+        //    supported by rust, as verified above.
+        unsafe { &*(v as *mut *mut T as *mut Self) }
+    }
+
     /// Consumes the atomic and returns the contained value.
     ///
     /// This is safe because passing `self` by value guarantees that no other threads are
@@ -1121,6 +1167,7 @@ macro_rules! atomic_int {
      $stable_nand:meta,
      $const_stable:meta,
      $stable_init_const:meta,
+     $(from_mut: cfg($from_mut_cfg:meta),)?
      $s_int_type:literal, $int_ref:expr,
      $extra_feature:expr,
      $min_fn:ident, $max_fn:ident,
@@ -1228,6 +1275,45 @@ assert_eq!(some_var.load(Ordering::SeqCst), 5);
                 #[$stable_access]
                 pub fn get_mut(&mut self) -> &mut $int_type {
                     self.v.get_mut()
+                }
+            }
+
+            doc_comment! {
+                concat!("Get atomic access to a `&mut ", stringify!($int_type), "`.
+
+",
+if_not_8_bit! {
+    $int_type,
+    concat!(
+        "**Note:** This function is only available on targets where `",
+        stringify!($int_type), "` has an alignment of ", $align, " bytes."
+    )
+},
+"
+
+# Examples
+
+```
+#![feature(atomic_from_mut)]
+", $extra_feature, "use std::sync::atomic::{", stringify!($atomic_type), ", Ordering};
+
+let mut some_int = 123;
+let a = ", stringify!($atomic_type), "::from_mut(&mut some_int);
+a.store(100, Ordering::Relaxed);
+assert_eq!(some_int, 100);
+```
+                "),
+                #[inline]
+                $(#[cfg($from_mut_cfg)])?
+                #[unstable(feature = "atomic_from_mut", issue = "76314")]
+                pub fn from_mut(v: &mut $int_type) -> &Self {
+                    let [] = [(); align_of::<Self>() - align_of::<$int_type>()];
+                    // SAFETY:
+                    //  - the mutable reference guarantees unique ownership.
+                    //  - the alignment of `$int_type` and `Self` is the
+                    //    same on all platforms enabled by `$from_mut_cfg`
+                    //    as verified above.
+                    unsafe { &*(v as *mut $int_type as *mut Self) }
                 }
             }
 
@@ -1989,6 +2075,7 @@ atomic_int! {
     stable(feature = "integer_atomics_stable", since = "1.34.0"),
     rustc_const_stable(feature = "const_integer_atomics", since = "1.34.0"),
     unstable(feature = "integer_atomics", issue = "32976"),
+    from_mut: cfg(not(target_arch = "x86")),
     "i64", "../../../std/primitive.i64.html",
     "",
     atomic_min, atomic_max,
@@ -2007,6 +2094,7 @@ atomic_int! {
     stable(feature = "integer_atomics_stable", since = "1.34.0"),
     rustc_const_stable(feature = "const_integer_atomics", since = "1.34.0"),
     unstable(feature = "integer_atomics", issue = "32976"),
+    from_mut: cfg(not(target_arch = "x86")),
     "u64", "../../../std/primitive.u64.html",
     "",
     atomic_umin, atomic_umax,
@@ -2025,6 +2113,7 @@ atomic_int! {
     unstable(feature = "integer_atomics", issue = "32976"),
     rustc_const_stable(feature = "const_integer_atomics", since = "1.34.0"),
     unstable(feature = "integer_atomics", issue = "32976"),
+    from_mut: cfg(not(target_arch = "x86_64")),
     "i128", "../../../std/primitive.i128.html",
     "#![feature(integer_atomics)]\n\n",
     atomic_min, atomic_max,
@@ -2043,6 +2132,7 @@ atomic_int! {
     unstable(feature = "integer_atomics", issue = "32976"),
     rustc_const_stable(feature = "const_integer_atomics", since = "1.34.0"),
     unstable(feature = "integer_atomics", issue = "32976"),
+    from_mut: cfg(not(target_arch = "x86_64")),
     "u128", "../../../std/primitive.u128.html",
     "#![feature(integer_atomics)]\n\n",
     atomic_umin, atomic_umax,

--- a/src/test/ui/atomic-from-mut-not-available.rs
+++ b/src/test/ui/atomic-from-mut-not-available.rs
@@ -1,0 +1,7 @@
+// only-x86
+// only-linux
+
+fn main() {
+    core::sync::atomic::AtomicU64::from_mut(&mut 0u64);
+    //~^ ERROR: no function or associated item named `from_mut` found for struct `AtomicU64`
+}

--- a/src/test/ui/atomic-from-mut-not-available.stderr
+++ b/src/test/ui/atomic-from-mut-not-available.stderr
@@ -1,0 +1,9 @@
+error[E0599]: no function or associated item named `from_mut` found for struct `AtomicU64` in the current scope
+  --> $DIR/atomic-from-mut-not-available.rs:5:36
+   |
+LL |     core::sync::atomic::AtomicU64::from_mut(&mut 0u64);
+   |                                    ^^^^^^^^ function or associated item not found in `AtomicU64`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0599`.

--- a/src/test/ui/feature-gates/feature-gate-cfg-target-has-atomic.rs
+++ b/src/test/ui/feature-gates/feature-gate-cfg-target-has-atomic.rs
@@ -87,6 +87,18 @@ fn main() {
     //~^ ERROR `cfg(target_has_atomic)` is experimental and subject to change
     cfg!(target_has_atomic = "ptr");
     //~^ ERROR `cfg(target_has_atomic)` is experimental and subject to change
+    cfg!(target_has_atomic_load_store = "8");
+    //~^ ERROR `cfg(target_has_atomic_load_store)` is experimental and subject to change
+    cfg!(target_has_atomic_load_store = "16");
+    //~^ ERROR `cfg(target_has_atomic_load_store)` is experimental and subject to change
+    cfg!(target_has_atomic_load_store = "32");
+    //~^ ERROR `cfg(target_has_atomic_load_store)` is experimental and subject to change
+    cfg!(target_has_atomic_load_store = "64");
+    //~^ ERROR `cfg(target_has_atomic_load_store)` is experimental and subject to change
+    cfg!(target_has_atomic_load_store = "128");
+    //~^ ERROR `cfg(target_has_atomic_load_store)` is experimental and subject to change
+    cfg!(target_has_atomic_load_store = "ptr");
+    //~^ ERROR `cfg(target_has_atomic_load_store)` is experimental and subject to change
 }
 
 #[macro_export]

--- a/src/test/ui/feature-gates/feature-gate-cfg-target-has-atomic.rs
+++ b/src/test/ui/feature-gates/feature-gate-cfg-target-has-atomic.rs
@@ -99,6 +99,18 @@ fn main() {
     //~^ ERROR `cfg(target_has_atomic_load_store)` is experimental and subject to change
     cfg!(target_has_atomic_load_store = "ptr");
     //~^ ERROR `cfg(target_has_atomic_load_store)` is experimental and subject to change
+    cfg!(target_has_atomic_equal_alignment = "8");
+    //~^ ERROR `cfg(target_has_atomic_equal_alignment)` is experimental and subject to change
+    cfg!(target_has_atomic_equal_alignment = "16");
+    //~^ ERROR `cfg(target_has_atomic_equal_alignment)` is experimental and subject to change
+    cfg!(target_has_atomic_equal_alignment = "32");
+    //~^ ERROR `cfg(target_has_atomic_equal_alignment)` is experimental and subject to change
+    cfg!(target_has_atomic_equal_alignment = "64");
+    //~^ ERROR `cfg(target_has_atomic_equal_alignment)` is experimental and subject to change
+    cfg!(target_has_atomic_equal_alignment = "128");
+    //~^ ERROR `cfg(target_has_atomic_equal_alignment)` is experimental and subject to change
+    cfg!(target_has_atomic_equal_alignment = "ptr");
+    //~^ ERROR `cfg(target_has_atomic_equal_alignment)` is experimental and subject to change
 }
 
 #[macro_export]

--- a/src/test/ui/feature-gates/feature-gate-cfg-target-has-atomic.stderr
+++ b/src/test/ui/feature-gates/feature-gate-cfg-target-has-atomic.stderr
@@ -160,6 +160,60 @@ LL |     cfg!(target_has_atomic = "ptr");
    = note: see issue #32976 <https://github.com/rust-lang/rust/issues/32976> for more information
    = help: add `#![feature(cfg_target_has_atomic)]` to the crate attributes to enable
 
-error: aborting due to 18 previous errors
+error[E0658]: `cfg(target_has_atomic_load_store)` is experimental and subject to change
+  --> $DIR/feature-gate-cfg-target-has-atomic.rs:90:10
+   |
+LL |     cfg!(target_has_atomic_load_store = "8");
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #32976 <https://github.com/rust-lang/rust/issues/32976> for more information
+   = help: add `#![feature(cfg_target_has_atomic)]` to the crate attributes to enable
+
+error[E0658]: `cfg(target_has_atomic_load_store)` is experimental and subject to change
+  --> $DIR/feature-gate-cfg-target-has-atomic.rs:92:10
+   |
+LL |     cfg!(target_has_atomic_load_store = "16");
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #32976 <https://github.com/rust-lang/rust/issues/32976> for more information
+   = help: add `#![feature(cfg_target_has_atomic)]` to the crate attributes to enable
+
+error[E0658]: `cfg(target_has_atomic_load_store)` is experimental and subject to change
+  --> $DIR/feature-gate-cfg-target-has-atomic.rs:94:10
+   |
+LL |     cfg!(target_has_atomic_load_store = "32");
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #32976 <https://github.com/rust-lang/rust/issues/32976> for more information
+   = help: add `#![feature(cfg_target_has_atomic)]` to the crate attributes to enable
+
+error[E0658]: `cfg(target_has_atomic_load_store)` is experimental and subject to change
+  --> $DIR/feature-gate-cfg-target-has-atomic.rs:96:10
+   |
+LL |     cfg!(target_has_atomic_load_store = "64");
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #32976 <https://github.com/rust-lang/rust/issues/32976> for more information
+   = help: add `#![feature(cfg_target_has_atomic)]` to the crate attributes to enable
+
+error[E0658]: `cfg(target_has_atomic_load_store)` is experimental and subject to change
+  --> $DIR/feature-gate-cfg-target-has-atomic.rs:98:10
+   |
+LL |     cfg!(target_has_atomic_load_store = "128");
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #32976 <https://github.com/rust-lang/rust/issues/32976> for more information
+   = help: add `#![feature(cfg_target_has_atomic)]` to the crate attributes to enable
+
+error[E0658]: `cfg(target_has_atomic_load_store)` is experimental and subject to change
+  --> $DIR/feature-gate-cfg-target-has-atomic.rs:100:10
+   |
+LL |     cfg!(target_has_atomic_load_store = "ptr");
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #32976 <https://github.com/rust-lang/rust/issues/32976> for more information
+   = help: add `#![feature(cfg_target_has_atomic)]` to the crate attributes to enable
+
+error: aborting due to 24 previous errors
 
 For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/feature-gates/feature-gate-cfg-target-has-atomic.stderr
+++ b/src/test/ui/feature-gates/feature-gate-cfg-target-has-atomic.stderr
@@ -214,6 +214,60 @@ LL |     cfg!(target_has_atomic_load_store = "ptr");
    = note: see issue #32976 <https://github.com/rust-lang/rust/issues/32976> for more information
    = help: add `#![feature(cfg_target_has_atomic)]` to the crate attributes to enable
 
-error: aborting due to 24 previous errors
+error[E0658]: `cfg(target_has_atomic_equal_alignment)` is experimental and subject to change
+  --> $DIR/feature-gate-cfg-target-has-atomic.rs:102:10
+   |
+LL |     cfg!(target_has_atomic_equal_alignment = "8");
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #32976 <https://github.com/rust-lang/rust/issues/32976> for more information
+   = help: add `#![feature(cfg_target_has_atomic)]` to the crate attributes to enable
+
+error[E0658]: `cfg(target_has_atomic_equal_alignment)` is experimental and subject to change
+  --> $DIR/feature-gate-cfg-target-has-atomic.rs:104:10
+   |
+LL |     cfg!(target_has_atomic_equal_alignment = "16");
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #32976 <https://github.com/rust-lang/rust/issues/32976> for more information
+   = help: add `#![feature(cfg_target_has_atomic)]` to the crate attributes to enable
+
+error[E0658]: `cfg(target_has_atomic_equal_alignment)` is experimental and subject to change
+  --> $DIR/feature-gate-cfg-target-has-atomic.rs:106:10
+   |
+LL |     cfg!(target_has_atomic_equal_alignment = "32");
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #32976 <https://github.com/rust-lang/rust/issues/32976> for more information
+   = help: add `#![feature(cfg_target_has_atomic)]` to the crate attributes to enable
+
+error[E0658]: `cfg(target_has_atomic_equal_alignment)` is experimental and subject to change
+  --> $DIR/feature-gate-cfg-target-has-atomic.rs:108:10
+   |
+LL |     cfg!(target_has_atomic_equal_alignment = "64");
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #32976 <https://github.com/rust-lang/rust/issues/32976> for more information
+   = help: add `#![feature(cfg_target_has_atomic)]` to the crate attributes to enable
+
+error[E0658]: `cfg(target_has_atomic_equal_alignment)` is experimental and subject to change
+  --> $DIR/feature-gate-cfg-target-has-atomic.rs:110:10
+   |
+LL |     cfg!(target_has_atomic_equal_alignment = "128");
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #32976 <https://github.com/rust-lang/rust/issues/32976> for more information
+   = help: add `#![feature(cfg_target_has_atomic)]` to the crate attributes to enable
+
+error[E0658]: `cfg(target_has_atomic_equal_alignment)` is experimental and subject to change
+  --> $DIR/feature-gate-cfg-target-has-atomic.rs:112:10
+   |
+LL |     cfg!(target_has_atomic_equal_alignment = "ptr");
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #32976 <https://github.com/rust-lang/rust/issues/32976> for more information
+   = help: add `#![feature(cfg_target_has_atomic)]` to the crate attributes to enable
+
+error: aborting due to 30 previous errors
 
 For more information about this error, try `rustc --explain E0658`.


### PR DESCRIPTION
Fixes some platform-specific problems with #74532 by using the actual alignment of the types instead of hardcoding a few `target_arch`s.

r? @RalfJung 