### PR TITLE
Make RawFd implement the RawFd traits

### DIFF
--- a/library/std/src/sys/unix/ext/io.rs
+++ b/library/std/src/sys/unix/ext/io.rs
@@ -70,14 +70,14 @@ impl AsRawFd for RawFd {
 }
 #[stable(feature = "raw_fd_reflexive_traits", since = "1.48.0")]
 impl IntoRawFd for RawFd {
-    fn as_raw_fd(self) -> RawFd {
+    fn into_raw_fd(self) -> RawFd {
         self
     }
 }
 #[stable(feature = "raw_fd_reflexive_traits", since = "1.48.0")]
 impl FromRawFd for RawFd {
     unsafe fn from_raw_fd(fd: RawFd) -> RawFd {
-        self
+        fd
     }
 }
 

--- a/library/std/src/sys/unix/ext/io.rs
+++ b/library/std/src/sys/unix/ext/io.rs
@@ -62,6 +62,25 @@ pub trait IntoRawFd {
     fn into_raw_fd(self) -> RawFd;
 }
 
+#[stable(feature = "raw_fd_reflexive_traits", since = "1.48.0")]
+impl AsRawFd for RawFd {
+    fn as_raw_fd(&self) -> RawFd {
+        *self
+    }
+}
+#[stable(feature = "raw_fd_reflexive_traits", since = "1.48.0")]
+impl IntoRawFd for RawFd {
+    fn as_raw_fd(self) -> RawFd {
+        self
+    }
+}
+#[stable(feature = "raw_fd_reflexive_traits", since = "1.48.0")]
+impl FromRawFd for RawFd {
+    unsafe fn from_raw_fd(fd: RawFd) -> RawFd {
+        self
+    }
+}
+
 #[stable(feature = "rust1", since = "1.0.0")]
 impl AsRawFd for fs::File {
     fn as_raw_fd(&self) -> RawFd {

--- a/library/std/src/sys/vxworks/ext/io.rs
+++ b/library/std/src/sys/vxworks/ext/io.rs
@@ -63,6 +63,26 @@ pub trait IntoRawFd {
     fn into_raw_fd(self) -> RawFd;
 }
 
+#[stable(feature = "raw_fd_reflexive_traits", since = "1.48.0")]
+impl AsRawFd for RawFd {
+    fn as_raw_fd(&self) -> RawFd {
+        *self
+    }
+}
+#[stable(feature = "raw_fd_reflexive_traits", since = "1.48.0")]
+impl IntoRawFd for RawFd {
+    fn as_raw_fd(self) -> RawFd {
+        self
+    }
+}
+#[stable(feature = "raw_fd_reflexive_traits", since = "1.48.0")]
+impl FromRawFd for RawFd {
+    unsafe fn from_raw_fd(fd: RawFd) -> RawFd {
+        self
+    }
+}
+
+
 #[stable(feature = "rust1", since = "1.0.0")]
 impl AsRawFd for fs::File {
     fn as_raw_fd(&self) -> RawFd {

--- a/library/std/src/sys/vxworks/ext/io.rs
+++ b/library/std/src/sys/vxworks/ext/io.rs
@@ -82,7 +82,6 @@ impl FromRawFd for RawFd {
     }
 }
 
-
 #[stable(feature = "rust1", since = "1.0.0")]
 impl AsRawFd for fs::File {
     fn as_raw_fd(&self) -> RawFd {

--- a/library/std/src/sys/vxworks/ext/io.rs
+++ b/library/std/src/sys/vxworks/ext/io.rs
@@ -71,14 +71,14 @@ impl AsRawFd for RawFd {
 }
 #[stable(feature = "raw_fd_reflexive_traits", since = "1.48.0")]
 impl IntoRawFd for RawFd {
-    fn as_raw_fd(self) -> RawFd {
+    fn into_raw_fd(self) -> RawFd {
         self
     }
 }
 #[stable(feature = "raw_fd_reflexive_traits", since = "1.48.0")]
 impl FromRawFd for RawFd {
     unsafe fn from_raw_fd(fd: RawFd) -> RawFd {
-        self
+        fd
     }
 }
 

--- a/library/std/src/sys/wasi/ext/io.rs
+++ b/library/std/src/sys/wasi/ext/io.rs
@@ -71,7 +71,6 @@ impl FromRawFd for RawFd {
     }
 }
 
-
 impl AsRawFd for net::TcpStream {
     fn as_raw_fd(&self) -> RawFd {
         self.as_inner().fd().as_raw()

--- a/library/std/src/sys/wasi/ext/io.rs
+++ b/library/std/src/sys/wasi/ext/io.rs
@@ -52,6 +52,26 @@ pub trait IntoRawFd {
     fn into_raw_fd(self) -> RawFd;
 }
 
+#[stable(feature = "raw_fd_reflexive_traits", since = "1.48.0")]
+impl AsRawFd for RawFd {
+    fn as_raw_fd(&self) -> RawFd {
+        *self
+    }
+}
+#[stable(feature = "raw_fd_reflexive_traits", since = "1.48.0")]
+impl IntoRawFd for RawFd {
+    fn as_raw_fd(self) -> RawFd {
+        self
+    }
+}
+#[stable(feature = "raw_fd_reflexive_traits", since = "1.48.0")]
+impl FromRawFd for RawFd {
+    unsafe fn from_raw_fd(fd: RawFd) -> RawFd {
+        self
+    }
+}
+
+
 impl AsRawFd for net::TcpStream {
     fn as_raw_fd(&self) -> RawFd {
         self.as_inner().fd().as_raw()

--- a/library/std/src/sys/wasi/ext/io.rs
+++ b/library/std/src/sys/wasi/ext/io.rs
@@ -60,14 +60,14 @@ impl AsRawFd for RawFd {
 }
 #[stable(feature = "raw_fd_reflexive_traits", since = "1.48.0")]
 impl IntoRawFd for RawFd {
-    fn as_raw_fd(self) -> RawFd {
+    fn into_raw_fd(self) -> RawFd {
         self
     }
 }
 #[stable(feature = "raw_fd_reflexive_traits", since = "1.48.0")]
 impl FromRawFd for RawFd {
     unsafe fn from_raw_fd(fd: RawFd) -> RawFd {
-        self
+        fd
     }
 }
 


### PR DESCRIPTION
This PR makes `RawFd` implement `AsRawFd`, `IntoRawFd` and `FromRawFd`, so it can be passed to interfaces that use one of those traits as a bound.