### PR TITLE
Return values up to 128 bits in registers

### DIFF
--- a/compiler/rustc_target/src/abi/call/mod.rs
+++ b/compiler/rustc_target/src/abi/call/mod.rs
@@ -610,3 +610,15 @@ impl<'a, Ty> FnAbi<'a, Ty> {
         Ok(())
     }
 }
+
+/// Returns the maximum size of return values to be passed by value in the Rust ABI.
+///
+/// Return values beyond this size will use an implicit out-pointer instead.
+pub fn max_ret_by_val<C: HasTargetSpec + HasDataLayout>(spec: &C) -> Size {
+    match spec.target_spec().arch.as_str() {
+        // System-V will pass return values up to 128 bits in RAX/RDX.
+        "x86_64" => Size::from_bits(128),
+
+        _ => spec.data_layout().pointer_size,
+    }
+}

--- a/src/test/codegen/return-value-in-reg.rs
+++ b/src/test/codegen/return-value-in-reg.rs
@@ -1,0 +1,32 @@
+//! This test checks that types of up to 128 bits are returned by-value instead of via out-pointer.
+
+// compile-flags: -C no-prepopulate-passes -O
+// only-x86_64
+
+#![crate_type = "lib"]
+
+pub struct S {
+    a: u64,
+    b: u32,
+    c: u32,
+}
+
+// CHECK: define i128 @modify(%S* noalias nocapture dereferenceable(16) %s)
+#[no_mangle]
+pub fn modify(s: S) -> S {
+    S { a: s.a + s.a, b: s.b + s.b, c: s.c + s.c }
+}
+
+#[repr(packed)]
+pub struct TooBig {
+    a: u64,
+    b: u32,
+    c: u32,
+    d: u8,
+}
+
+// CHECK: define void @m_big(%TooBig* [[ATTRS:.*sret.*]], %TooBig* [[ATTRS2:.*]] %s)
+#[no_mangle]
+pub fn m_big(s: TooBig) -> TooBig {
+    TooBig { a: s.a + s.a, b: s.b + s.b, c: s.c + s.c, d: s.d + s.d }
+}


### PR DESCRIPTION
This fixes https://github.com/rust-lang/rust/issues/26494#issuecomment-619506345 by making Rust's default ABI pass return values up to 128 bits in size in registers, just like the System V ABI.

The result is that these methods from the comment linked above now generate the same code, making the Rust ABI as efficient as the `"C"` ABI:

```rust
pub struct Stats { x: u32, y: u32, z: u32, }

pub extern "C" fn sum_c(a: &Stats, b: &Stats) -> Stats {
    return Stats {x: a.x + b.x, y: a.y + b.y, z: a.z + b.z };
}

pub fn sum_rust(a: &Stats, b: &Stats) -> Stats {
    return Stats {x: a.x + b.x, y: a.y + b.y, z: a.z + b.z };
}
```

```asm
sum_rust:
	movl	(%rsi), %eax
	addl	(%rdi), %eax
	movl	4(%rsi), %ecx
	addl	4(%rdi), %ecx
	movl	8(%rsi), %edx
	addl	8(%rdi), %edx
	shlq	$32, %rcx
	orq	%rcx, %rax
	retq
```