### PR TITLE
Remove duplicated library links between std and libc

### DIFF
--- a/library/std/build.rs
+++ b/library/std/build.rs
@@ -8,10 +8,6 @@ fn main() {
             println!("cargo:rustc-link-lib=dl");
             println!("cargo:rustc-link-lib=log");
             println!("cargo:rustc-link-lib=gcc");
-        } else if !target.contains("musl") {
-            println!("cargo:rustc-link-lib=dl");
-            println!("cargo:rustc-link-lib=rt");
-            println!("cargo:rustc-link-lib=pthread");
         }
     } else if target.contains("freebsd") {
         println!("cargo:rustc-link-lib=execinfo");


### PR DESCRIPTION
The libc crate is already responsible for linking in the appropriate
libraries, and std doing the same thing results in duplicated library
names on the linker command line. Removing this duplication slightly
reduces linker time, and makes it simpler to adjust the set or order of
linked libraries in one place (such as to add static linking support).