### PR TITLE
Cache `eval_to_allocation_raw` on disk

### DIFF
--- a/compiler/rustc_middle/src/mir/interpret/value.rs
+++ b/compiler/rustc_middle/src/mir/interpret/value.rs
@@ -13,7 +13,7 @@ use crate::ty::{ParamEnv, Ty, TyCtxt};
 use super::{sign_extend, truncate, AllocId, Allocation, InterpResult, Pointer, PointerArithmetic};
 
 /// Represents the result of const evaluation via the `eval_to_allocation` query.
-#[derive(Clone, HashStable)]
+#[derive(Clone, HashStable, TyEncodable, TyDecodable)]
 pub struct ConstAlloc<'tcx> {
     // the value lives here, at offset 0, and that allocation definitely is a `AllocKind::Memory`
     // (so you can use `AllocMap::unwrap_memory`).

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -716,10 +716,7 @@ rustc_queries! {
                 "const-evaluating + checking `{}`",
                 key.value.display(tcx)
             }
-            cache_on_disk_if(_, opt_result) {
-                // Only store results without errors
-                opt_result.map_or(true, |r| r.is_ok())
-            }
+            cache_on_disk_if { true }
         }
 
         /// Evaluates const items or anonymous constants
@@ -734,10 +731,7 @@ rustc_queries! {
                 "simplifying constant for the type system `{}`",
                 key.value.display(tcx)
             }
-            cache_on_disk_if(_, opt_result) {
-                // Only store results without errors
-                opt_result.map_or(true, |r| r.is_ok())
-            }
+            cache_on_disk_if { true }
         }
 
         /// Destructure a constant ADT or array into its variant index and its

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -716,6 +716,10 @@ rustc_queries! {
                 "const-evaluating + checking `{}`",
                 key.value.display(tcx)
             }
+            cache_on_disk_if(_, opt_result) {
+                // Only store results without errors
+                opt_result.map_or(true, |r| r.is_ok())
+            }
         }
 
         /// Evaluates const items or anonymous constants


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/74949#issuecomment-695833161 regressed the performance on these queries, this PR gets the perf back.