### PR TITLE
Test clippy on PR CI on changes

### DIFF
--- a/src/ci/scripts/should-skip-this.sh
+++ b/src/ci/scripts/should-skip-this.sh
@@ -14,6 +14,10 @@ elif git diff HEAD^ | grep --quiet "^index .* 160000"; then
     # Submodules pseudo-files inside git have the 160000 permissions, so when
     # those files are present in the diff a submodule was updated.
     echo "Executing the job since submodules are updated"
+elif git diff --name-only HEAD^ | grep --quiet src/tools/clippy; then
+    # There is not an easy blanket search for subtrees. For now, manually list
+    # clippy.
+    echo "Executing the job since clippy subtree was updated"
 else
     echo "Not executing this job since no submodules were updated"
     ciCommandSetEnv SKIP_JOB 1


### PR DESCRIPTION
This runs the tools builder (which builds and tests tools, including clippy) when the clippy submodule changes. This essentially returns us to the prior state when clippy was a submodule; it makes sense for us to test it on CI when it changes. It might make sense for it to be tested regardless of changing but it is somewhat rare for it to fail and we don't want to add to CI time for the majority of PRs which don't affect it.

Fixes #76999.