### PR TITLE
BTreeMap: consider leaf nodes to have empty edges

### DIFF
--- a/src/etc/gdb_providers.py
+++ b/src/etc/gdb_providers.py
@@ -215,8 +215,17 @@ def children_of_node(boxed_node, height, want_values):
         return node.cast(internal_type.pointer())
 
     node_ptr = unwrap_unique_or_non_null(boxed_node["ptr"])
-    node_ptr = cast_to_internal(node_ptr) if height > 0 else node_ptr
-    leaf = node_ptr["data"] if height > 0 else node_ptr.dereference()
+    if height > 0:
+        node_ptr = cast_to_internal(node_ptr)
+        if node_ptr.type.has_key("_wraps"):
+            # Built with recent standard library.
+            node_ptr = node_ptr["_wraps"]
+            leaf = node_ptr["leaf"]
+        else:
+            # Built with older standard library.
+            leaf = node_ptr["data"]
+    else:
+        leaf = node_ptr.dereference()
     keys = leaf["keys"]
     values = leaf["vals"]
     length = int(leaf["len"])


### PR DESCRIPTION
Tried to make internal and leaf nodes more alike, because:
- The btree code is ambiguous about leaf edges (i.e., edges within leaf nodes). Iteration relies on them heavily, but some of the comments in node.rs suggest there are no leaf edges. In my definition of edges, internal edges contain a pointer to a child node, leaf edges don't.
- The btree code splits up / repeats some methods according to whether the node is leaf or internal, while the only difference is the kind of leaf edge contents.

r? @Mark-Simulacrum 