### PR TITLE
Improve documentation for `std::{f32,f64}::mul_add`

### DIFF
--- a/library/std/src/f32.rs
+++ b/library/std/src/f32.rs
@@ -206,8 +206,11 @@ impl f32 {
     /// Fused multiply-add. Computes `(self * a) + b` with only one rounding
     /// error, yielding a more accurate result than an unfused multiply-add.
     ///
-    /// Using `mul_add` can be more performant than an unfused multiply-add if
-    /// the target architecture has a dedicated `fma` CPU instruction.
+    /// Using `mul_add` *can* be more performant than an unfused multiply-add if
+    /// the target architecture has a dedicated `fma` CPU instruction. However,
+    /// this is not always true, and care must be taken not to overload the
+    /// architecture's available FMA units when using many FMA instructions
+    /// in a row, which can cause a stall and performance degradation.
     ///
     /// # Examples
     ///

--- a/library/std/src/f32.rs
+++ b/library/std/src/f32.rs
@@ -206,11 +206,10 @@ impl f32 {
     /// Fused multiply-add. Computes `(self * a) + b` with only one rounding
     /// error, yielding a more accurate result than an unfused multiply-add.
     ///
-    /// Using `mul_add` *can* be more performant than an unfused multiply-add if
+    /// Using `mul_add` *may* be more performant than an unfused multiply-add if
     /// the target architecture has a dedicated `fma` CPU instruction. However,
-    /// this is not always true, and care must be taken not to overload the
-    /// architecture's available FMA units when using many FMA instructions
-    /// in a row, which can cause a stall and performance degradation.
+    /// this is not always true, and will be heavily dependant on designing
+    /// algorithms with specific target hardware in mind.
     ///
     /// # Examples
     ///

--- a/library/std/src/f64.rs
+++ b/library/std/src/f64.rs
@@ -206,8 +206,11 @@ impl f64 {
     /// Fused multiply-add. Computes `(self * a) + b` with only one rounding
     /// error, yielding a more accurate result than an unfused multiply-add.
     ///
-    /// Using `mul_add` can be more performant than an unfused multiply-add if
-    /// the target architecture has a dedicated `fma` CPU instruction.
+    /// Using `mul_add` *can* be more performant than an unfused multiply-add if
+    /// the target architecture has a dedicated `fma` CPU instruction. However,
+    /// this is not always true, and care must be taken not to overload the
+    /// architecture's available FMA units when using many FMA instructions
+    /// in a row, which can cause a stall and performance degradation.
     ///
     /// # Examples
     ///

--- a/library/std/src/f64.rs
+++ b/library/std/src/f64.rs
@@ -206,11 +206,10 @@ impl f64 {
     /// Fused multiply-add. Computes `(self * a) + b` with only one rounding
     /// error, yielding a more accurate result than an unfused multiply-add.
     ///
-    /// Using `mul_add` *can* be more performant than an unfused multiply-add if
+    /// Using `mul_add` *may* be more performant than an unfused multiply-add if
     /// the target architecture has a dedicated `fma` CPU instruction. However,
-    /// this is not always true, and care must be taken not to overload the
-    /// architecture's available FMA units when using many FMA instructions
-    /// in a row, which can cause a stall and performance degradation.
+    /// this is not always true, and will be heavily dependant on designing
+    /// algorithms with specific target hardware in mind.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
Makes it more clear that performance improvement is not guaranteed when using FMA, even when the target architecture supports it natively.