### PR TITLE
Rollup of 13 pull requests

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes.rs
+++ b/compiler/rustc_error_codes/src/error_codes.rs
@@ -441,6 +441,7 @@ E0752: include_str!("./error_codes/E0752.md"),
 E0753: include_str!("./error_codes/E0753.md"),
 E0754: include_str!("./error_codes/E0754.md"),
 E0755: include_str!("./error_codes/E0755.md"),
+E0756: include_str!("./error_codes/E0756.md"),
 E0758: include_str!("./error_codes/E0758.md"),
 E0759: include_str!("./error_codes/E0759.md"),
 E0760: include_str!("./error_codes/E0760.md"),
@@ -633,7 +634,6 @@ E0774: include_str!("./error_codes/E0774.md"),
     E0722, // Malformed `#[optimize]` attribute
     E0726, // non-explicit (not `'_`) elided lifetime in unsupported position
 //  E0738, // Removed; errored on `#[track_caller] fn`s in `extern "Rust" { ... }`.
-    E0756, // `#[ffi_const]` is only allowed on foreign functions
     E0757, // `#[ffi_const]` functions cannot be `#[ffi_pure]`
     E0772, // `'static' obligation coming from `impl dyn Trait {}` or `impl Foo for dyn Bar {}`.
 }

--- a/compiler/rustc_error_codes/src/error_codes/E0756.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0756.md
@@ -1,0 +1,29 @@
+The `ffi_const` attribute was used on something other than a foreign function
+declaration.
+
+Erroneous code example:
+
+```compile_fail,E0756
+#![feature(ffi_const)]
+
+#[ffi_const] // error!
+pub fn foo() {}
+# fn main() {}
+```
+
+The `ffi_const` attribute can only be used on foreign function declarations
+which have no side effects except for their return value:
+
+```
+#![feature(ffi_const)]
+
+extern "C" {
+    #[ffi_const] // ok!
+    pub fn strlen(s: *const i8) -> i32;
+}
+# fn main() {}
+```
+
+You can get more information about it in the [unstable Rust Book].
+
+[unstable Rust Book]: https://doc.rust-lang.org/nightly/unstable-book/language-features/ffi-const.html

--- a/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/static_impl_trait.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/static_impl_trait.rs
@@ -488,18 +488,16 @@ impl<'tcx> Visitor<'tcx> for HirTraitObjectVisitor {
     }
 
     fn visit_ty(&mut self, t: &'tcx hir::Ty<'tcx>) {
-        match t.kind {
-            TyKind::TraitObject(
-                poly_trait_refs,
-                Lifetime { name: LifetimeName::ImplicitObjectLifetimeDefault, .. },
-            ) => {
-                for ptr in poly_trait_refs {
-                    if Some(self.1) == ptr.trait_ref.trait_def_id() {
-                        self.0.push(ptr.span);
-                    }
+        if let TyKind::TraitObject(
+            poly_trait_refs,
+            Lifetime { name: LifetimeName::ImplicitObjectLifetimeDefault, .. },
+        ) = t.kind
+        {
+            for ptr in poly_trait_refs {
+                if Some(self.1) == ptr.trait_ref.trait_def_id() {
+                    self.0.push(ptr.span);
                 }
             }
-            _ => {}
         }
         walk_ty(self, t);
     }

--- a/compiler/rustc_middle/src/ty/error.rs
+++ b/compiler/rustc_middle/src/ty/error.rs
@@ -832,14 +832,11 @@ fn foo(&self) -> Self::T { String::new() }
                 kind: hir::ItemKind::Impl { items, .. }, ..
             })) => {
                 for item in &items[..] {
-                    match item.kind {
-                        hir::AssocItemKind::Type => {
-                            if self.type_of(self.hir().local_def_id(item.id.hir_id)) == found {
-                                db.span_label(item.span, "expected this associated type");
-                                return true;
-                            }
+                    if let hir::AssocItemKind::Type = item.kind {
+                        if self.type_of(self.hir().local_def_id(item.id.hir_id)) == found {
+                            db.span_label(item.span, "expected this associated type");
+                            return true;
                         }
-                        _ => {}
                     }
                 }
             }

--- a/compiler/rustc_middle/src/ty/layout.rs
+++ b/compiler/rustc_middle/src/ty/layout.rs
@@ -1259,11 +1259,11 @@ impl<'tcx> LayoutCx<'tcx, TyCtxt<'tcx>> {
                 tcx.layout_raw(param_env.and(normalized))?
             }
 
-            ty::Bound(..) | ty::Placeholder(..) | ty::GeneratorWitness(..) | ty::Infer(_) => {
+            ty::Placeholder(..) | ty::GeneratorWitness(..) | ty::Infer(_) => {
                 bug!("Layout::compute: unexpected type `{}`", ty)
             }
 
-            ty::Param(_) | ty::Error(_) => {
+            ty::Bound(..) | ty::Param(_) | ty::Error(_) => {
                 return Err(LayoutError::Unknown(ty));
             }
         })

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -2125,15 +2125,8 @@ fn for_each_def(tcx: TyCtxt<'_>, mut collect_fn: impl for<'b> FnMut(&'b Ident, N
     // Iterate all local crate items no matter where they are defined.
     let hir = tcx.hir();
     for item in hir.krate().items.values() {
-        if item.ident.name.as_str().is_empty() {
+        if item.ident.name.as_str().is_empty() || matches!(item.kind, ItemKind::Use(_, _)) {
             continue;
-        }
-
-        match item.kind {
-            ItemKind::Use(_, _) => {
-                continue;
-            }
-            _ => {}
         }
 
         if let Some(local_def_id) = hir.definitions().opt_hir_id_to_local_def_id(item.hir_id) {

--- a/compiler/rustc_mir/src/interpret/operand.rs
+++ b/compiler/rustc_mir/src/interpret/operand.rs
@@ -549,7 +549,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
         };
         // Early-return cases.
         let val_val = match val.val {
-            ty::ConstKind::Param(_) => throw_inval!(TooGeneric),
+            ty::ConstKind::Param(_) | ty::ConstKind::Bound(..) => throw_inval!(TooGeneric),
             ty::ConstKind::Error(_) => throw_inval!(TypeckError(ErrorReported)),
             ty::ConstKind::Unevaluated(def, substs, promoted) => {
                 let instance = self.resolve(def.did, substs)?;
@@ -561,9 +561,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 // happening.
                 return Ok(self.const_eval(GlobalId { instance, promoted }, val.ty)?);
             }
-            ty::ConstKind::Infer(..)
-            | ty::ConstKind::Bound(..)
-            | ty::ConstKind::Placeholder(..) => {
+            ty::ConstKind::Infer(..) | ty::ConstKind::Placeholder(..) => {
                 span_bug!(self.cur_span(), "const_to_op: Unexpected ConstKind {:?}", val)
             }
             ty::ConstKind::Value(val_val) => val_val,

--- a/compiler/rustc_mir/src/transform/mod.rs
+++ b/compiler/rustc_mir/src/transform/mod.rs
@@ -38,6 +38,7 @@ pub mod nrvo;
 pub mod promote_consts;
 pub mod qualify_min_const_fn;
 pub mod remove_noop_landing_pads;
+pub mod remove_unneeded_drops;
 pub mod required_consts;
 pub mod rustc_peek;
 pub mod simplify;
@@ -461,6 +462,7 @@ fn run_optimization_passes<'tcx>(
 
     // The main optimizations that we do on MIR.
     let optimizations: &[&dyn MirPass<'tcx>] = &[
+        &remove_unneeded_drops::RemoveUnneededDrops::new(def_id),
         &match_branches::MatchBranchSimplification,
         // inst combine is after MatchBranchSimplification to clean up Ne(_1, false)
         &instcombine::InstCombine,

--- a/compiler/rustc_mir/src/transform/mod.rs
+++ b/compiler/rustc_mir/src/transform/mod.rs
@@ -462,7 +462,7 @@ fn run_optimization_passes<'tcx>(
 
     // The main optimizations that we do on MIR.
     let optimizations: &[&dyn MirPass<'tcx>] = &[
-        &remove_unneeded_drops::RemoveUnneededDrops::new(def_id),
+        &remove_unneeded_drops::RemoveUnneededDrops,
         &match_branches::MatchBranchSimplification,
         // inst combine is after MatchBranchSimplification to clean up Ne(_1, false)
         &instcombine::InstCombine,

--- a/compiler/rustc_mir/src/transform/remove_unneeded_drops.rs
+++ b/compiler/rustc_mir/src/transform/remove_unneeded_drops.rs
@@ -6,15 +6,7 @@ use rustc_middle::mir::visit::Visitor;
 use rustc_middle::mir::*;
 use rustc_middle::ty::TyCtxt;
 
-pub struct RemoveUnneededDrops {
-    def_id: LocalDefId,
-}
-
-impl RemoveUnneededDrops {
-    pub fn new(def_id: LocalDefId) -> Self {
-        Self { def_id }
-    }
-}
+pub struct RemoveUnneededDrops;
 
 impl<'tcx> MirPass<'tcx> for RemoveUnneededDrops {
     fn run_pass(&self, tcx: TyCtxt<'tcx>, source: MirSource<'tcx>, body: &mut Body<'tcx>) {
@@ -23,7 +15,7 @@ impl<'tcx> MirPass<'tcx> for RemoveUnneededDrops {
             tcx,
             body,
             optimizations: vec![],
-            def_id: self.def_id,
+            def_id: source.def_id().expect_local(),
         };
         opt_finder.visit_body(body);
         for (loc, target) in opt_finder.optimizations {

--- a/compiler/rustc_mir/src/transform/remove_unneeded_drops.rs
+++ b/compiler/rustc_mir/src/transform/remove_unneeded_drops.rs
@@ -29,7 +29,8 @@ impl<'tcx> MirPass<'tcx> for RemoveUnneededDrops {
 impl<'a, 'tcx> Visitor<'tcx> for RemoveUnneededDropsOptimizationFinder<'a, 'tcx> {
     fn visit_terminator(&mut self, terminator: &Terminator<'tcx>, location: Location) {
         match terminator.kind {
-            TerminatorKind::Drop { place, target, .. } => {
+            TerminatorKind::Drop { place, target, .. }
+            | TerminatorKind::DropAndReplace { place, target, .. } => {
                 let ty = place.ty(self.body, self.tcx);
                 let needs_drop = ty.ty.needs_drop(self.tcx, self.tcx.param_env(self.def_id));
                 if !needs_drop {

--- a/compiler/rustc_mir/src/transform/remove_unneeded_drops.rs
+++ b/compiler/rustc_mir/src/transform/remove_unneeded_drops.rs
@@ -1,0 +1,57 @@
+//! This pass replaces a drop of a type that does not need dropping, with a goto
+
+use crate::transform::{MirPass, MirSource};
+use rustc_hir::def_id::LocalDefId;
+use rustc_middle::mir::visit::Visitor;
+use rustc_middle::mir::*;
+use rustc_middle::ty::TyCtxt;
+
+pub struct RemoveUnneededDrops {
+    def_id: LocalDefId,
+}
+
+impl RemoveUnneededDrops {
+    pub fn new(def_id: LocalDefId) -> Self {
+        Self { def_id }
+    }
+}
+
+impl<'tcx> MirPass<'tcx> for RemoveUnneededDrops {
+    fn run_pass(&self, tcx: TyCtxt<'tcx>, source: MirSource<'tcx>, body: &mut Body<'tcx>) {
+        trace!("Running SimplifyComparisonIntegral on {:?}", source);
+        let mut opt_finder = RemoveUnneededDropsOptimizationFinder {
+            tcx,
+            body,
+            optimizations: vec![],
+            def_id: self.def_id,
+        };
+        opt_finder.visit_body(body);
+        for (loc, target) in opt_finder.optimizations {
+            let terminator = body.basic_blocks_mut()[loc.block].terminator_mut();
+            debug!("SUCCESS: replacing `drop` with goto({:?})", target);
+            terminator.kind = TerminatorKind::Goto { target };
+        }
+    }
+}
+
+impl<'a, 'tcx> Visitor<'tcx> for RemoveUnneededDropsOptimizationFinder<'a, 'tcx> {
+    fn visit_terminator(&mut self, terminator: &Terminator<'tcx>, location: Location) {
+        match terminator.kind {
+            TerminatorKind::Drop { place, target, .. } => {
+                let ty = place.ty(self.body, self.tcx);
+                let needs_drop = ty.ty.needs_drop(self.tcx, self.tcx.param_env(self.def_id));
+                if !needs_drop {
+                    self.optimizations.push((location, target));
+                }
+            }
+            _ => {}
+        }
+        self.super_terminator(terminator, location);
+    }
+}
+pub struct RemoveUnneededDropsOptimizationFinder<'a, 'tcx> {
+    tcx: TyCtxt<'tcx>,
+    body: &'a Body<'tcx>,
+    optimizations: Vec<(Location, BasicBlock)>,
+    def_id: LocalDefId,
+}

--- a/compiler/rustc_mir/src/transform/remove_unneeded_drops.rs
+++ b/compiler/rustc_mir/src/transform/remove_unneeded_drops.rs
@@ -18,7 +18,7 @@ impl RemoveUnneededDrops {
 
 impl<'tcx> MirPass<'tcx> for RemoveUnneededDrops {
     fn run_pass(&self, tcx: TyCtxt<'tcx>, source: MirSource<'tcx>, body: &mut Body<'tcx>) {
-        trace!("Running SimplifyComparisonIntegral on {:?}", source);
+        trace!("Running RemoveUnneededDrops on {:?}", source);
         let mut opt_finder = RemoveUnneededDropsOptimizationFinder {
             tcx,
             body,

--- a/compiler/rustc_parse/src/lexer/tokentrees.rs
+++ b/compiler/rustc_parse/src/lexer/tokentrees.rs
@@ -149,12 +149,9 @@ impl<'a> TokenTreesReader<'a> {
                             }
                         }
 
-                        match (open_brace, delim) {
-                            //only add braces
-                            (DelimToken::Brace, DelimToken::Brace) => {
-                                self.matching_block_spans.push((open_brace_span, close_brace_span));
-                            }
-                            _ => {}
+                        //only add braces
+                        if let (DelimToken::Brace, DelimToken::Brace) = (open_brace, delim) {
+                            self.matching_block_spans.push((open_brace_span, close_brace_span));
                         }
 
                         if self.open_braces.is_empty() {

--- a/compiler/rustc_parse/src/lib.rs
+++ b/compiler/rustc_parse/src/lib.rs
@@ -3,6 +3,7 @@
 #![feature(bool_to_option)]
 #![feature(crate_visibility_modifier)]
 #![feature(bindings_after_at)]
+#![feature(iter_order_by)]
 #![feature(or_patterns)]
 
 use rustc_ast as ast;
@@ -459,14 +460,10 @@ pub fn tokenstream_probably_equal_for_proc_macro(
 
     // Break tokens after we expand any nonterminals, so that we break tokens
     // that are produced as a result of nonterminal expansion.
-    let mut t1 = first.trees().filter(semantic_tree).flat_map(expand_nt).flat_map(break_tokens);
-    let mut t2 = other.trees().filter(semantic_tree).flat_map(expand_nt).flat_map(break_tokens);
-    for (t1, t2) in t1.by_ref().zip(t2.by_ref()) {
-        if !tokentree_probably_equal_for_proc_macro(&t1, &t2, sess) {
-            return false;
-        }
-    }
-    t1.next().is_none() && t2.next().is_none()
+    let t1 = first.trees().filter(semantic_tree).flat_map(expand_nt).flat_map(break_tokens);
+    let t2 = other.trees().filter(semantic_tree).flat_map(expand_nt).flat_map(break_tokens);
+
+    t1.eq_by(t2, |t1, t2| tokentree_probably_equal_for_proc_macro(&t1, &t2, sess))
 }
 
 // See comments in `Nonterminal::to_tokenstream` for why we care about

--- a/compiler/rustc_parse_format/src/lib.rs
+++ b/compiler/rustc_parse_format/src/lib.rs
@@ -527,12 +527,9 @@ impl<'a> Parser<'a> {
 
         // fill character
         if let Some(&(_, c)) = self.cur.peek() {
-            match self.cur.clone().nth(1) {
-                Some((_, '>' | '<' | '^')) => {
-                    spec.fill = Some(c);
-                    self.cur.next();
-                }
-                _ => {}
+            if let Some((_, '>' | '<' | '^')) = self.cur.clone().nth(1) {
+                spec.fill = Some(c);
+                self.cur.next();
             }
         }
         // Alignment

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -534,11 +534,8 @@ impl<'a> ModuleData<'a> {
                 if ns != TypeNS {
                     return;
                 }
-                match binding.res() {
-                    Res::Def(DefKind::Trait | DefKind::TraitAlias, _) => {
-                        collected_traits.push((name, binding))
-                    }
-                    _ => (),
+                if let Res::Def(DefKind::Trait | DefKind::TraitAlias, _) = binding.res() {
+                    collected_traits.push((name, binding))
                 }
             });
             *traits = Some(collected_traits.into_boxed_slice());

--- a/compiler/rustc_span/src/lib.rs
+++ b/compiler/rustc_span/src/lib.rs
@@ -1558,58 +1558,71 @@ pub trait Pos {
     fn to_u32(&self) -> u32;
 }
 
-/// A byte offset. Keep this small (currently 32-bits), as AST contains
-/// a lot of them.
-#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Debug)]
-pub struct BytePos(pub u32);
+macro_rules! impl_pos {
+    (
+        $(
+            $(#[$attr:meta])*
+            $vis:vis struct $ident:ident($inner_vis:vis $inner_ty:ty);
+        )*
+    ) => {
+        $(
+            $(#[$attr])*
+            $vis struct $ident($inner_vis $inner_ty);
 
-/// A character offset. Because of multibyte UTF-8 characters, a byte offset
-/// is not equivalent to a character offset. The `SourceMap` will convert `BytePos`
-/// values to `CharPos` values as necessary.
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
-pub struct CharPos(pub usize);
+            impl Pos for $ident {
+                #[inline(always)]
+                fn from_usize(n: usize) -> $ident {
+                    $ident(n as $inner_ty)
+                }
 
-// FIXME: lots of boilerplate in these impls, but so far my attempts to fix
-// have been unsuccessful.
+                #[inline(always)]
+                fn to_usize(&self) -> usize {
+                    self.0 as usize
+                }
 
-impl Pos for BytePos {
-    #[inline(always)]
-    fn from_usize(n: usize) -> BytePos {
-        BytePos(n as u32)
-    }
+                #[inline(always)]
+                fn from_u32(n: u32) -> $ident {
+                    $ident(n as $inner_ty)
+                }
 
-    #[inline(always)]
-    fn to_usize(&self) -> usize {
-        self.0 as usize
-    }
+                #[inline(always)]
+                fn to_u32(&self) -> u32 {
+                    self.0 as u32
+                }
+            }
 
-    #[inline(always)]
-    fn from_u32(n: u32) -> BytePos {
-        BytePos(n)
-    }
+            impl Add for $ident {
+                type Output = $ident;
 
-    #[inline(always)]
-    fn to_u32(&self) -> u32 {
-        self.0
-    }
+                #[inline(always)]
+                fn add(self, rhs: $ident) -> $ident {
+                    $ident((self.to_usize() + rhs.to_usize()) as $inner_ty)
+                }
+            }
+
+            impl Sub for $ident {
+                type Output = $ident;
+
+                #[inline(always)]
+                fn sub(self, rhs: $ident) -> $ident {
+                    $ident((self.to_usize() - rhs.to_usize()) as $inner_ty)
+                }
+            }
+        )*
+    };
 }
 
-impl Add for BytePos {
-    type Output = BytePos;
+impl_pos! {
+    /// A byte offset. Keep this small (currently 32-bits), as AST contains
+    /// a lot of them.
+    #[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Debug)]
+    pub struct BytePos(pub u32);
 
-    #[inline(always)]
-    fn add(self, rhs: BytePos) -> BytePos {
-        BytePos((self.to_usize() + rhs.to_usize()) as u32)
-    }
-}
-
-impl Sub for BytePos {
-    type Output = BytePos;
-
-    #[inline(always)]
-    fn sub(self, rhs: BytePos) -> BytePos {
-        BytePos((self.to_usize() - rhs.to_usize()) as u32)
-    }
+    /// A character offset. Because of multibyte UTF-8 characters, a byte offset
+    /// is not equivalent to a character offset. The `SourceMap` will convert `BytePos`
+    /// values to `CharPos` values as necessary.
+    #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
+    pub struct CharPos(pub usize);
 }
 
 impl<S: rustc_serialize::Encoder> Encodable<S> for BytePos {
@@ -1621,46 +1634,6 @@ impl<S: rustc_serialize::Encoder> Encodable<S> for BytePos {
 impl<D: rustc_serialize::Decoder> Decodable<D> for BytePos {
     fn decode(d: &mut D) -> Result<BytePos, D::Error> {
         Ok(BytePos(d.read_u32()?))
-    }
-}
-
-impl Pos for CharPos {
-    #[inline(always)]
-    fn from_usize(n: usize) -> CharPos {
-        CharPos(n)
-    }
-
-    #[inline(always)]
-    fn to_usize(&self) -> usize {
-        self.0
-    }
-
-    #[inline(always)]
-    fn from_u32(n: u32) -> CharPos {
-        CharPos(n as usize)
-    }
-
-    #[inline(always)]
-    fn to_u32(&self) -> u32 {
-        self.0 as u32
-    }
-}
-
-impl Add for CharPos {
-    type Output = CharPos;
-
-    #[inline(always)]
-    fn add(self, rhs: CharPos) -> CharPos {
-        CharPos(self.to_usize() + rhs.to_usize())
-    }
-}
-
-impl Sub for CharPos {
-    type Output = CharPos;
-
-    #[inline(always)]
-    fn sub(self, rhs: CharPos) -> CharPos {
-        CharPos(self.to_usize() - rhs.to_usize())
     }
 }
 

--- a/compiler/rustc_span/src/lib.rs
+++ b/compiler/rustc_span/src/lib.rs
@@ -1596,7 +1596,7 @@ macro_rules! impl_pos {
 
                 #[inline(always)]
                 fn add(self, rhs: $ident) -> $ident {
-                    $ident((self.to_usize() + rhs.to_usize()) as $inner_ty)
+                    $ident(self.0 + rhs.0)
                 }
             }
 
@@ -1605,7 +1605,7 @@ macro_rules! impl_pos {
 
                 #[inline(always)]
                 fn sub(self, rhs: $ident) -> $ident {
-                    $ident((self.to_usize() - rhs.to_usize()) as $inner_ty)
+                    $ident(self.0 - rhs.0)
                 }
             }
         )*

--- a/compiler/rustc_symbol_mangling/src/v0.rs
+++ b/compiler/rustc_symbol_mangling/src/v0.rs
@@ -152,11 +152,8 @@ impl SymbolMangler<'tcx> {
         let _ = write!(self.out, "{}", ident.len());
 
         // Write a separating `_` if necessary (leading digit or `_`).
-        match ident.chars().next() {
-            Some('_' | '0'..='9') => {
-                self.push("_");
-            }
-            _ => {}
+        if let Some('_' | '0'..='9') = ident.chars().next() {
+            self.push("_");
         }
 
         self.push(ident);

--- a/config.toml.example
+++ b/config.toml.example
@@ -9,6 +9,12 @@
 # a custom configuration file can also be specified with `--config` to the build
 # system.
 
+# Keeps track of the last version of `x.py` used.
+# If it does not match the version that is currently running,
+# `x.py` will prompt you to update it and read the changelog.
+# See `src/bootstrap/CHANGELOG.md` for more information.
+changelog-seen = 1
+
 # =============================================================================
 # Global Settings
 # =============================================================================

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -80,6 +80,7 @@
 #![feature(const_int_pow)]
 #![feature(constctlz)]
 #![feature(const_panic)]
+#![feature(const_pin)]
 #![feature(const_fn_union)]
 #![feature(const_generics)]
 #![feature(const_option)]

--- a/library/core/src/pin.rs
+++ b/library/core/src/pin.rs
@@ -708,8 +708,9 @@ impl<'a, T: ?Sized> Pin<&'a T> {
 impl<'a, T: ?Sized> Pin<&'a mut T> {
     /// Converts this `Pin<&mut T>` into a `Pin<&T>` with the same lifetime.
     #[inline(always)]
+    #[rustc_const_unstable(feature = "const_pin", issue = "76654")]
     #[stable(feature = "pin", since = "1.33.0")]
-    pub fn into_ref(self) -> Pin<&'a T> {
+    pub const fn into_ref(self) -> Pin<&'a T> {
         Pin { pointer: self.pointer }
     }
 
@@ -722,9 +723,10 @@ impl<'a, T: ?Sized> Pin<&'a mut T> {
     /// that lives for as long as the borrow of the `Pin`, not the lifetime of
     /// the `Pin` itself. This method allows turning the `Pin` into a reference
     /// with the same lifetime as the original `Pin`.
-    #[stable(feature = "pin", since = "1.33.0")]
     #[inline(always)]
-    pub fn get_mut(self) -> &'a mut T
+    #[stable(feature = "pin", since = "1.33.0")]
+    #[rustc_const_unstable(feature = "const_pin", issue = "76654")]
+    pub const fn get_mut(self) -> &'a mut T
     where
         T: Unpin,
     {
@@ -741,9 +743,10 @@ impl<'a, T: ?Sized> Pin<&'a mut T> {
     ///
     /// If the underlying data is `Unpin`, `Pin::get_mut` should be used
     /// instead.
-    #[stable(feature = "pin", since = "1.33.0")]
     #[inline(always)]
-    pub unsafe fn get_unchecked_mut(self) -> &'a mut T {
+    #[stable(feature = "pin", since = "1.33.0")]
+    #[rustc_const_unstable(feature = "const_pin", issue = "76654")]
+    pub const unsafe fn get_unchecked_mut(self) -> &'a mut T {
         self.pointer
     }
 

--- a/library/core/src/pin.rs
+++ b/library/core/src/pin.rs
@@ -471,9 +471,10 @@ impl<P: Deref<Target: Unpin>> Pin<P> {
     ///
     /// Unlike `Pin::new_unchecked`, this method is safe because the pointer
     /// `P` dereferences to an [`Unpin`] type, which cancels the pinning guarantees.
-    #[stable(feature = "pin", since = "1.33.0")]
     #[inline(always)]
-    pub fn new(pointer: P) -> Pin<P> {
+    #[rustc_const_unstable(feature = "const_pin", issue = "76654")]
+    #[stable(feature = "pin", since = "1.33.0")]
+    pub const fn new(pointer: P) -> Pin<P> {
         // SAFETY: the value pointed to is `Unpin`, and so has no requirements
         // around pinning.
         unsafe { Pin::new_unchecked(pointer) }
@@ -483,9 +484,10 @@ impl<P: Deref<Target: Unpin>> Pin<P> {
     ///
     /// This requires that the data inside this `Pin` is [`Unpin`] so that we
     /// can ignore the pinning invariants when unwrapping it.
-    #[stable(feature = "pin_into_inner", since = "1.39.0")]
     #[inline(always)]
-    pub fn into_inner(pin: Pin<P>) -> P {
+    #[rustc_const_unstable(feature = "const_pin", issue = "76654")]
+    #[stable(feature = "pin_into_inner", since = "1.39.0")]
+    pub const fn into_inner(pin: Pin<P>) -> P {
         pin.pointer
     }
 }
@@ -556,9 +558,10 @@ impl<P: Deref> Pin<P> {
     ///
     /// [`mem::swap`]: crate::mem::swap
     #[lang = "new_unchecked"]
-    #[stable(feature = "pin", since = "1.33.0")]
     #[inline(always)]
-    pub unsafe fn new_unchecked(pointer: P) -> Pin<P> {
+    #[rustc_const_unstable(feature = "const_pin", issue = "76654")]
+    #[stable(feature = "pin", since = "1.33.0")]
+    pub const unsafe fn new_unchecked(pointer: P) -> Pin<P> {
         Pin { pointer }
     }
 
@@ -589,9 +592,10 @@ impl<P: Deref> Pin<P> {
     ///
     /// If the underlying data is [`Unpin`], [`Pin::into_inner`] should be used
     /// instead.
-    #[stable(feature = "pin_into_inner", since = "1.39.0")]
     #[inline(always)]
-    pub unsafe fn into_inner_unchecked(pin: Pin<P>) -> P {
+    #[rustc_const_unstable(feature = "const_pin", issue = "76654")]
+    #[stable(feature = "pin_into_inner", since = "1.39.0")]
+    pub const unsafe fn into_inner_unchecked(pin: Pin<P>) -> P {
         pin.pointer
     }
 }
@@ -693,17 +697,18 @@ impl<'a, T: ?Sized> Pin<&'a T> {
     /// with the same lifetime as the original `Pin`.
     ///
     /// ["pinning projections"]: self#projections-and-structural-pinning
-    #[stable(feature = "pin", since = "1.33.0")]
     #[inline(always)]
-    pub fn get_ref(self) -> &'a T {
+    #[rustc_const_unstable(feature = "const_pin", issue = "76654")]
+    #[stable(feature = "pin", since = "1.33.0")]
+    pub const fn get_ref(self) -> &'a T {
         self.pointer
     }
 }
 
 impl<'a, T: ?Sized> Pin<&'a mut T> {
     /// Converts this `Pin<&mut T>` into a `Pin<&T>` with the same lifetime.
-    #[stable(feature = "pin", since = "1.33.0")]
     #[inline(always)]
+    #[stable(feature = "pin", since = "1.33.0")]
     pub fn into_ref(self) -> Pin<&'a T> {
         Pin { pointer: self.pointer }
     }

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -39,6 +39,7 @@
 #![feature(iter_order_by)]
 #![feature(cmp_min_max_by)]
 #![feature(iter_map_while)]
+#![feature(const_pin)]
 #![feature(const_slice_from_raw_parts)]
 #![feature(const_raw_ptr_deref)]
 #![feature(never_type)]
@@ -74,6 +75,7 @@ mod num;
 mod ops;
 mod option;
 mod pattern;
+mod pin;
 mod ptr;
 mod result;
 mod slice;

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -39,6 +39,7 @@
 #![feature(iter_order_by)]
 #![feature(cmp_min_max_by)]
 #![feature(iter_map_while)]
+#![feature(const_mut_refs)]
 #![feature(const_pin)]
 #![feature(const_slice_from_raw_parts)]
 #![feature(const_raw_ptr_deref)]

--- a/library/core/tests/pin.rs
+++ b/library/core/tests/pin.rs
@@ -1,0 +1,21 @@
+use core::pin::Pin;
+
+#[test]
+fn pin_const() {
+    // test that the methods of `Pin` are usable in a const context
+
+    const POINTER: &'static usize = &2;
+
+    const PINNED: Pin<&'static usize> = Pin::new(POINTER);
+    const PINNED_UNCHECKED: Pin<&'static usize> = unsafe { Pin::new_unchecked(POINTER) };
+    assert_eq!(PINNED_UNCHECKED, PINNED);
+
+    const INNER: &'static usize = Pin::into_inner(PINNED);
+    assert_eq!(INNER, POINTER);
+
+    const INNER_UNCHECKED: &'static usize = unsafe { Pin::into_inner_unchecked(PINNED) };
+    assert_eq!(INNER_UNCHECKED, POINTER);
+
+    const REF: &'static usize = PINNED.get_ref();
+    assert_eq!(REF, POINTER)
+}

--- a/library/core/tests/pin.rs
+++ b/library/core/tests/pin.rs
@@ -17,5 +17,15 @@ fn pin_const() {
     assert_eq!(INNER_UNCHECKED, POINTER);
 
     const REF: &'static usize = PINNED.get_ref();
-    assert_eq!(REF, POINTER)
+    assert_eq!(REF, POINTER);
+
+    // Note: `pin_mut_const` tests that the methods of `Pin<&mut T>` are usable in a const context.
+    // A const fn is used because `&mut` is not (yet) usable in constants.
+    const fn pin_mut_const() {
+        let _ = Pin::new(&mut 2).into_ref();
+        let _ = Pin::new(&mut 2).get_mut();
+        let _ = unsafe { Pin::new(&mut 2).get_unchecked_mut() };
+    }
+
+    pin_mut_const();
 }

--- a/library/std/src/io/stdio.rs
+++ b/library/std/src/io/stdio.rs
@@ -607,7 +607,7 @@ impl Write for Stdout {
     }
 }
 
-#[stable(feature = "write_mt", since = "1.47.0")]
+#[stable(feature = "write_mt", since = "1.48.0")]
 impl Write for &Stdout {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         self.lock().write(buf)
@@ -810,7 +810,7 @@ impl Write for Stderr {
     }
 }
 
-#[stable(feature = "write_mt", since = "1.47.0")]
+#[stable(feature = "write_mt", since = "1.48.0")]
 impl Write for &Stderr {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         self.lock().write(buf)

--- a/library/std/src/io/stdio.rs
+++ b/library/std/src/io/stdio.rs
@@ -584,26 +584,26 @@ impl fmt::Debug for Stdout {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl Write for Stdout {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.lock().write(buf)
+        (&*self).write(buf)
     }
     fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
-        self.lock().write_vectored(bufs)
+        (&*self).write_vectored(bufs)
     }
     #[inline]
     fn is_write_vectored(&self) -> bool {
-        self.lock().is_write_vectored()
+        io::Write::is_write_vectored(&&*self)
     }
     fn flush(&mut self) -> io::Result<()> {
-        self.lock().flush()
+        (&*self).flush()
     }
     fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
-        self.lock().write_all(buf)
+        (&*self).write_all(buf)
     }
     fn write_all_vectored(&mut self, bufs: &mut [IoSlice<'_>]) -> io::Result<()> {
-        self.lock().write_all_vectored(bufs)
+        (&*self).write_all_vectored(bufs)
     }
     fn write_fmt(&mut self, args: fmt::Arguments<'_>) -> io::Result<()> {
-        self.lock().write_fmt(args)
+        (&*self).write_fmt(args)
     }
 }
 
@@ -787,26 +787,26 @@ impl fmt::Debug for Stderr {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl Write for Stderr {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.lock().write(buf)
+        (&*self).write(buf)
     }
     fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
-        self.lock().write_vectored(bufs)
+        (&*self).write_vectored(bufs)
     }
     #[inline]
     fn is_write_vectored(&self) -> bool {
-        self.lock().is_write_vectored()
+        io::Write::is_write_vectored(&&*self)
     }
     fn flush(&mut self) -> io::Result<()> {
-        self.lock().flush()
+        (&*self).flush()
     }
     fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
-        self.lock().write_all(buf)
+        (&*self).write_all(buf)
     }
     fn write_all_vectored(&mut self, bufs: &mut [IoSlice<'_>]) -> io::Result<()> {
-        self.lock().write_all_vectored(bufs)
+        (&*self).write_all_vectored(bufs)
     }
     fn write_fmt(&mut self, args: fmt::Arguments<'_>) -> io::Result<()> {
-        self.lock().write_fmt(args)
+        (&*self).write_fmt(args)
     }
 }
 

--- a/library/std/src/io/stdio.rs
+++ b/library/std/src/io/stdio.rs
@@ -606,6 +606,33 @@ impl Write for Stdout {
         self.lock().write_fmt(args)
     }
 }
+
+#[stable(feature = "write_mt", since = "1.47.0")]
+impl Write for &Stdout {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.lock().write(buf)
+    }
+    fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
+        self.lock().write_vectored(bufs)
+    }
+    #[inline]
+    fn is_write_vectored(&self) -> bool {
+        self.lock().is_write_vectored()
+    }
+    fn flush(&mut self) -> io::Result<()> {
+        self.lock().flush()
+    }
+    fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
+        self.lock().write_all(buf)
+    }
+    fn write_all_vectored(&mut self, bufs: &mut [IoSlice<'_>]) -> io::Result<()> {
+        self.lock().write_all_vectored(bufs)
+    }
+    fn write_fmt(&mut self, args: fmt::Arguments<'_>) -> io::Result<()> {
+        self.lock().write_fmt(args)
+    }
+}
+
 #[stable(feature = "rust1", since = "1.0.0")]
 impl Write for StdoutLock<'_> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
@@ -782,6 +809,33 @@ impl Write for Stderr {
         self.lock().write_fmt(args)
     }
 }
+
+#[stable(feature = "write_mt", since = "1.47.0")]
+impl Write for &Stderr {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.lock().write(buf)
+    }
+    fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
+        self.lock().write_vectored(bufs)
+    }
+    #[inline]
+    fn is_write_vectored(&self) -> bool {
+        self.lock().is_write_vectored()
+    }
+    fn flush(&mut self) -> io::Result<()> {
+        self.lock().flush()
+    }
+    fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
+        self.lock().write_all(buf)
+    }
+    fn write_all_vectored(&mut self, bufs: &mut [IoSlice<'_>]) -> io::Result<()> {
+        self.lock().write_all_vectored(bufs)
+    }
+    fn write_fmt(&mut self, args: fmt::Arguments<'_>) -> io::Result<()> {
+        self.lock().write_fmt(args)
+    }
+}
+
 #[stable(feature = "rust1", since = "1.0.0")]
 impl Write for StderrLock<'_> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {

--- a/library/std/src/io/util.rs
+++ b/library/std/src/io/util.rs
@@ -248,7 +248,7 @@ impl Write for Sink {
     }
 }
 
-#[stable(feature = "write_mt", since = "1.47.0")]
+#[stable(feature = "write_mt", since = "1.48.0")]
 impl Write for &Sink {
     #[inline]
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {

--- a/library/std/src/io/util.rs
+++ b/library/std/src/io/util.rs
@@ -248,6 +248,30 @@ impl Write for Sink {
     }
 }
 
+#[stable(feature = "write_mt", since = "1.47.0")]
+impl Write for &Sink {
+    #[inline]
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        Ok(buf.len())
+    }
+
+    #[inline]
+    fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
+        let total_len = bufs.iter().map(|b| b.len()).sum();
+        Ok(total_len)
+    }
+
+    #[inline]
+    fn is_write_vectored(&self) -> bool {
+        true
+    }
+
+    #[inline]
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
 #[stable(feature = "std_debug", since = "1.16.0")]
 impl fmt::Debug for Sink {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -262,6 +262,25 @@ impl Write for ChildStdin {
     }
 }
 
+#[stable(feature = "write_mt", since = "1.47.0")]
+impl Write for &ChildStdin {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.inner.write(buf)
+    }
+
+    fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
+        self.inner.write_vectored(bufs)
+    }
+
+    fn is_write_vectored(&self) -> bool {
+        self.inner.is_write_vectored()
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
 impl AsInner<AnonPipe> for ChildStdin {
     fn as_inner(&self) -> &AnonPipe {
         &self.inner

--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -246,19 +246,19 @@ pub struct ChildStdin {
 #[stable(feature = "process", since = "1.0.0")]
 impl Write for ChildStdin {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.inner.write(buf)
+        (&*self).write(buf)
     }
 
     fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
-        self.inner.write_vectored(bufs)
+        (&*self).write_vectored(bufs)
     }
 
     fn is_write_vectored(&self) -> bool {
-        self.inner.is_write_vectored()
+        io::Write::is_write_vectored(&&*self)
     }
 
     fn flush(&mut self) -> io::Result<()> {
-        Ok(())
+        (&*self).flush()
     }
 }
 

--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -262,7 +262,7 @@ impl Write for ChildStdin {
     }
 }
 
-#[stable(feature = "write_mt", since = "1.47.0")]
+#[stable(feature = "write_mt", since = "1.48.0")]
 impl Write for &ChildStdin {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         self.inner.write(buf)

--- a/src/bootstrap/CHANGELOG.md
+++ b/src/bootstrap/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Changelog
+
+All notable changes to bootstrap will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [Non-breaking changes since the last major version]
+
+- Add a changelog for x.py [#76626](https://github.com/rust-lang/rust/pull/76626)
+- Optionally, download LLVM from CI on Linux and NixOS
+  + [#76439](https://github.com/rust-lang/rust/pull/76349)
+  + [#76667](https://github.com/rust-lang/rust/pull/76667)
+  + [#76708](https://github.com/rust-lang/rust/pull/76708)
+- Distribute rustc sources as part of `rustc-dev` [#76856](https://github.com/rust-lang/rust/pull/76856)
+- Make the default stage for x.py configurable [#76625](https://github.com/rust-lang/rust/pull/76625)
+- Add a dedicated debug-logging option [#76588](https://github.com/rust-lang/rust/pull/76588)
+- Add sample defaults for x.py [#76628](https://github.com/rust-lang/rust/pull/76628)
+
+## [Version 0] - 2020-09-11
+
+This is the first changelog entry, and it does not attempt to be an exhaustive list of features in x.py.
+Instead, this documents the changes to bootstrap in the past 2 months.
+
+- Improve defaults in `x.py` [#73964](https://github.com/rust-lang/rust/pull/73964)
+  (see [blog post] for details)
+- Set `ninja = true` by default [#74922](https://github.com/rust-lang/rust/pull/74922)
+- Avoid trying to inversely cross-compile for build triple from host triples [#76415](https://github.com/rust-lang/rust/pull/76415)
+- Allow blessing expect-tests in tools [#75975](https://github.com/rust-lang/rust/pull/75975)
+- `x.py check` checks tests/examples/benches [#76258](https://github.com/rust-lang/rust/pull/76258)
+- Fix `rust.use-lld` when linker is not set [#76326](https://github.com/rust-lang/rust/pull/76326)
+- Build tests with LLD if `use-lld = true` was passed [#76378](https://github.com/rust-lang/rust/pull/76378)
+
+[blog post]: https://blog.rust-lang.org/inside-rust/2020/08/30/changes-to-x-py-defaults.html

--- a/src/bootstrap/README.md
+++ b/src/bootstrap/README.md
@@ -313,6 +313,20 @@ are:
   `Config` struct.
 * Adding a sanity check? Take a look at `bootstrap/sanity.rs`.
 
+If you make a major change, please remember to:
+
++ Update `VERSION` in `src/bootstrap/main.rs`.
+* Update `changelog-seen = N` in `config.toml.example`.
+* Add an entry in `src/bootstrap/CHANGELOG.md`.
+
+A 'major change' includes
+
+* A new option or
+* A change in the default options.
+
+Changes that do not affect contributors to the compiler or users
+building rustc from source don't need an update to `VERSION`.
+
 If you have any questions feel free to reach out on the `#t-infra` channel in
 the [Rust Zulip server][rust-zulip] or ask on internals.rust-lang.org. When
 you encounter bugs, please file issues on the rust-lang/rust issue tracker.

--- a/src/bootstrap/bin/main.rs
+++ b/src/bootstrap/bin/main.rs
@@ -12,5 +12,40 @@ use bootstrap::{Build, Config};
 fn main() {
     let args = env::args().skip(1).collect::<Vec<_>>();
     let config = Config::parse(&args);
+
+    let changelog_suggestion = check_version(&config);
+    if let Some(suggestion) = &changelog_suggestion {
+        println!("{}", suggestion);
+    }
+
     Build::new(config).build();
+
+    if let Some(suggestion) = changelog_suggestion {
+        println!("{}", suggestion);
+        println!("note: this message was printed twice to make it more likely to be seen");
+    }
+}
+
+fn check_version(config: &Config) -> Option<String> {
+    const VERSION: usize = 1;
+
+    let mut msg = String::new();
+
+    let suggestion = if let Some(seen) = config.changelog_seen {
+        if seen != VERSION {
+            msg.push_str("warning: there have been changes to x.py since you last updated.\n");
+            format!("update `config.toml` to use `changelog-seen = {}` instead", VERSION)
+        } else {
+            return None;
+        }
+    } else {
+        msg.push_str("warning: x.py has made several changes recently you may want to look at\n");
+        format!("add `changelog-seen = {}` to `config.toml`", VERSION)
+    };
+
+    msg.push_str("help: consider looking at the changes in `src/bootstrap/CHANGELOG.md`\n");
+    msg.push_str("note: to silence this warning, ");
+    msg.push_str(&suggestion);
+
+    Some(msg)
 }

--- a/src/bootstrap/builder/tests.rs
+++ b/src/bootstrap/builder/tests.rs
@@ -91,6 +91,54 @@ mod defaults {
     }
 
     #[test]
+    fn build_cross_compile() {
+        let config = Config { stage: 1, ..configure("build", &["B"], &["B"]) };
+        let build = Build::new(config);
+        let mut builder = Builder::new(&build);
+        builder.run_step_descriptions(&Builder::get_step_descriptions(Kind::Build), &[]);
+
+        let a = TargetSelection::from_user("A");
+        let b = TargetSelection::from_user("B");
+
+        // Ideally, this build wouldn't actually have `target: a`
+        // rustdoc/rustcc/std here (the user only requested a host=B build, so
+        // there's not really a need for us to build for target A in this case
+        // (since we're producing stage 1 libraries/binaries).  But currently
+        // rustbuild is just a bit buggy here; this should be fixed though.
+        assert_eq!(
+            first(builder.cache.all::<compile::Std>()),
+            &[
+                compile::Std { compiler: Compiler { host: a, stage: 0 }, target: a },
+                compile::Std { compiler: Compiler { host: a, stage: 1 }, target: a },
+                compile::Std { compiler: Compiler { host: a, stage: 0 }, target: b },
+                compile::Std { compiler: Compiler { host: a, stage: 1 }, target: b },
+            ]
+        );
+        assert_eq!(
+            first(builder.cache.all::<compile::Assemble>()),
+            &[
+                compile::Assemble { target_compiler: Compiler { host: a, stage: 0 } },
+                compile::Assemble { target_compiler: Compiler { host: a, stage: 1 } },
+                compile::Assemble { target_compiler: Compiler { host: b, stage: 1 } },
+            ]
+        );
+        assert_eq!(
+            first(builder.cache.all::<tool::Rustdoc>()),
+            &[
+                tool::Rustdoc { compiler: Compiler { host: a, stage: 1 } },
+                tool::Rustdoc { compiler: Compiler { host: b, stage: 1 } },
+            ],
+        );
+        assert_eq!(
+            first(builder.cache.all::<compile::Rustc>()),
+            &[
+                compile::Rustc { compiler: Compiler { host: a, stage: 0 }, target: a },
+                compile::Rustc { compiler: Compiler { host: a, stage: 0 }, target: b },
+            ]
+        );
+    }
+
+    #[test]
     fn doc_default() {
         let mut config = configure("doc", &[], &[]);
         config.compiler_docs = true;

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -42,6 +42,7 @@ macro_rules! check_ci_llvm {
 /// `config.toml.example`.
 #[derive(Default)]
 pub struct Config {
+    pub changelog_seen: Option<usize>,
     pub ccache: Option<String>,
     /// Call Build::ninja() instead of this.
     pub ninja_in_file: bool,
@@ -273,6 +274,7 @@ impl Target {
 #[derive(Deserialize, Default)]
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 struct TomlConfig {
+    changelog_seen: Option<usize>,
     build: Option<Build>,
     install: Option<Install>,
     llvm: Option<Llvm>,
@@ -283,7 +285,10 @@ struct TomlConfig {
 }
 
 impl Merge for TomlConfig {
-    fn merge(&mut self, TomlConfig { build, install, llvm, rust, dist, target, profile: _ }: Self) {
+    fn merge(
+        &mut self,
+        TomlConfig { build, install, llvm, rust, dist, target, profile: _, changelog_seen: _ }: Self,
+    ) {
         fn do_merge<T: Merge>(x: &mut Option<T>, y: Option<T>) {
             if let Some(new) = y {
                 if let Some(original) = x {
@@ -571,6 +576,8 @@ impl Config {
             let included_toml = get_toml(include_path);
             toml.merge(included_toml);
         }
+
+        config.changelog_seen = toml.changelog_seen;
 
         let build = toml.build.unwrap_or_default();
 

--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -752,6 +752,7 @@ impl Step for RustcBook {
         let out_listing = out_base.join("src/lints");
         builder.cp_r(&builder.src.join("src/doc/rustc"), &out_base);
         builder.info(&format!("Generating lint docs ({})", self.target));
+
         let rustc = builder.rustc(self.compiler);
         // The tool runs `rustc` for extracting output examples, so it needs a
         // functional sysroot.
@@ -762,7 +763,8 @@ impl Step for RustcBook {
         cmd.arg("--out");
         cmd.arg(&out_listing);
         cmd.arg("--rustc");
-        cmd.arg(rustc);
+        cmd.arg(&rustc);
+        cmd.arg("--rustc-target").arg(&self.target.rustc_target_arg());
         if builder.config.verbose() {
             cmd.arg("--verbose");
         }

--- a/src/bootstrap/tool.rs
+++ b/src/bootstrap/tool.rs
@@ -471,7 +471,11 @@ impl Step for Rustdoc {
 
     fn make_run(run: RunConfig<'_>) {
         run.builder.ensure(Rustdoc {
-            compiler: run.builder.compiler(run.builder.top_stage, run.build_triple()),
+            // Note: this is somewhat unique in that we actually want a *target*
+            // compiler here, because rustdoc *is* a compiler. We won't be using
+            // this as the compiler to build with, but rather this is "what
+            // compiler are we producing"?
+            compiler: run.builder.compiler(run.builder.top_stage, run.target),
         });
     }
 

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -350,14 +350,22 @@ pub fn build_impl(
         }
     }
 
-    let for_ = if let Some(did) = did.as_local() {
-        let hir_id = tcx.hir().local_def_id_to_hir_id(did);
-        match tcx.hir().expect_item(hir_id).kind {
-            hir::ItemKind::Impl { self_ty, .. } => self_ty.clean(cx),
-            _ => panic!("did given to build_impl was not an impl"),
+    let impl_item = match did.as_local() {
+        Some(did) => {
+            let hir_id = tcx.hir().local_def_id_to_hir_id(did);
+            match tcx.hir().expect_item(hir_id).kind {
+                hir::ItemKind::Impl { self_ty, ref generics, ref items, .. } => {
+                    Some((self_ty, generics, items))
+                }
+                _ => panic!("`DefID` passed to `build_impl` is not an `impl"),
+            }
         }
-    } else {
-        tcx.type_of(did).clean(cx)
+        None => None,
+    };
+
+    let for_ = match impl_item {
+        Some((self_ty, _, _)) => self_ty.clean(cx),
+        None => tcx.type_of(did).clean(cx),
     };
 
     // Only inline impl if the implementing type is
@@ -377,17 +385,12 @@ pub fn build_impl(
     }
 
     let predicates = tcx.explicit_predicates_of(did);
-    let (trait_items, generics) = if let Some(did) = did.as_local() {
-        let hir_id = tcx.hir().local_def_id_to_hir_id(did);
-        match tcx.hir().expect_item(hir_id).kind {
-            hir::ItemKind::Impl { ref generics, ref items, .. } => (
-                items.iter().map(|item| tcx.hir().impl_item(item.id).clean(cx)).collect::<Vec<_>>(),
-                generics.clean(cx),
-            ),
-            _ => panic!("did given to build_impl was not an impl"),
-        }
-    } else {
-        (
+    let (trait_items, generics) = match impl_item {
+        Some((_, generics, items)) => (
+            items.iter().map(|item| tcx.hir().impl_item(item.id).clean(cx)).collect::<Vec<_>>(),
+            generics.clean(cx),
+        ),
+        None => (
             tcx.associated_items(did)
                 .in_definition_order()
                 .filter_map(|item| {
@@ -399,7 +402,7 @@ pub fn build_impl(
                 })
                 .collect::<Vec<_>>(),
             clean::enter_impl_trait(cx, || (tcx.generics_of(did), predicates).clean(cx)),
-        )
+        ),
     };
     let polarity = tcx.impl_polarity(did);
     let trait_ = associated_trait.clean(cx).map(|bound| match bound {

--- a/src/test/mir-opt/dest-prop/cycle.main.DestinationPropagation.diff
+++ b/src/test/mir-opt/dest-prop/cycle.main.DestinationPropagation.diff
@@ -57,10 +57,6 @@
 -         _6 = _1;                         // scope 3 at $DIR/cycle.rs:14:10: 14:11
 +         _6 = _4;                         // scope 3 at $DIR/cycle.rs:14:10: 14:11
           _5 = const ();                   // scope 4 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-          drop(_6) -> bb2;                 // scope 4 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-      }
-  
-      bb2: {
           StorageDead(_6);                 // scope 3 at $DIR/cycle.rs:14:11: 14:12
           StorageDead(_5);                 // scope 3 at $DIR/cycle.rs:14:12: 14:13
           _0 = const ();                   // scope 0 at $DIR/cycle.rs:8:11: 15:2

--- a/src/test/mir-opt/dest-prop/union.main.DestinationPropagation.diff
+++ b/src/test/mir-opt/dest-prop/union.main.DestinationPropagation.diff
@@ -32,10 +32,6 @@
           StorageLive(_4);                 // scope 1 at $DIR/union.rs:15:10: 15:26
           _4 = (_1.0: u32);                // scope 2 at $DIR/union.rs:15:19: 15:24
           _3 = const ();                   // scope 3 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-          drop(_4) -> bb2;                 // scope 3 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-      }
-  
-      bb2: {
           StorageDead(_4);                 // scope 1 at $DIR/union.rs:15:26: 15:27
           StorageDead(_3);                 // scope 1 at $DIR/union.rs:15:27: 15:28
           _0 = const ();                   // scope 0 at $DIR/union.rs:8:11: 16:2

--- a/src/test/mir-opt/issue_76432.rs
+++ b/src/test/mir-opt/issue_76432.rs
@@ -1,0 +1,16 @@
+// Check that we do not insert StorageDead at each target if StorageDead was never seen
+
+// EMIT_MIR issue_76432.test.SimplifyComparisonIntegral.diff
+use std::fmt::Debug;
+
+fn test<T: Copy + Debug + PartialEq>(x: T) {
+    let v: &[T] = &[x, x, x];
+    match v {
+        [ref v1, ref v2, ref v3] => [v1 as *const _, v2 as *const _, v3 as *const _],
+        _ => unreachable!(),
+    };
+}
+
+fn main() {
+    test(0u32);
+}

--- a/src/test/mir-opt/issue_76432.test.SimplifyComparisonIntegral.diff
+++ b/src/test/mir-opt/issue_76432.test.SimplifyComparisonIntegral.diff
@@ -1,0 +1,116 @@
+- // MIR for `test` before SimplifyComparisonIntegral
++ // MIR for `test` after SimplifyComparisonIntegral
+  
+  fn test(_1: T) -> () {
+      debug x => _1;                       // in scope 0 at $DIR/issue_76432.rs:6:38: 6:39
+      let mut _0: ();                      // return place in scope 0 at $DIR/issue_76432.rs:6:44: 6:44
+      let _2: &[T];                        // in scope 0 at $DIR/issue_76432.rs:7:9: 7:10
+      let mut _3: &[T; 3];                 // in scope 0 at $DIR/issue_76432.rs:7:19: 7:29
+      let _4: &[T; 3];                     // in scope 0 at $DIR/issue_76432.rs:7:19: 7:29
+      let _5: [T; 3];                      // in scope 0 at $DIR/issue_76432.rs:7:20: 7:29
+      let mut _6: T;                       // in scope 0 at $DIR/issue_76432.rs:7:21: 7:22
+      let mut _7: T;                       // in scope 0 at $DIR/issue_76432.rs:7:24: 7:25
+      let mut _8: T;                       // in scope 0 at $DIR/issue_76432.rs:7:27: 7:28
+      let _9: [*const T; 3];               // in scope 0 at $DIR/issue_76432.rs:8:5: 11:6
+      let mut _10: usize;                  // in scope 0 at $DIR/issue_76432.rs:9:9: 9:33
+      let mut _11: usize;                  // in scope 0 at $DIR/issue_76432.rs:9:9: 9:33
+      let mut _12: bool;                   // in scope 0 at $DIR/issue_76432.rs:9:9: 9:33
+      let mut _16: *const T;               // in scope 0 at $DIR/issue_76432.rs:9:38: 9:52
+      let mut _17: *const T;               // in scope 0 at $DIR/issue_76432.rs:9:38: 9:52
+      let mut _18: *const T;               // in scope 0 at $DIR/issue_76432.rs:9:54: 9:68
+      let mut _19: *const T;               // in scope 0 at $DIR/issue_76432.rs:9:54: 9:68
+      let mut _20: *const T;               // in scope 0 at $DIR/issue_76432.rs:9:70: 9:84
+      let mut _21: *const T;               // in scope 0 at $DIR/issue_76432.rs:9:70: 9:84
+      let mut _22: !;                      // in scope 0 at $SRC_DIR/std/src/macros.rs:LL:COL
+      scope 1 {
+          debug v => _2;                   // in scope 1 at $DIR/issue_76432.rs:7:9: 7:10
+          let _13: &T;                     // in scope 1 at $DIR/issue_76432.rs:9:10: 9:16
+          let _14: &T;                     // in scope 1 at $DIR/issue_76432.rs:9:18: 9:24
+          let _15: &T;                     // in scope 1 at $DIR/issue_76432.rs:9:26: 9:32
+          scope 2 {
+              debug v1 => _13;             // in scope 2 at $DIR/issue_76432.rs:9:10: 9:16
+              debug v2 => _14;             // in scope 2 at $DIR/issue_76432.rs:9:18: 9:24
+              debug v3 => _15;             // in scope 2 at $DIR/issue_76432.rs:9:26: 9:32
+          }
+      }
+  
+      bb0: {
+          StorageLive(_2);                 // scope 0 at $DIR/issue_76432.rs:7:9: 7:10
+          StorageLive(_3);                 // scope 0 at $DIR/issue_76432.rs:7:19: 7:29
+          StorageLive(_4);                 // scope 0 at $DIR/issue_76432.rs:7:19: 7:29
+          StorageLive(_5);                 // scope 0 at $DIR/issue_76432.rs:7:20: 7:29
+          StorageLive(_6);                 // scope 0 at $DIR/issue_76432.rs:7:21: 7:22
+          _6 = _1;                         // scope 0 at $DIR/issue_76432.rs:7:21: 7:22
+          StorageLive(_7);                 // scope 0 at $DIR/issue_76432.rs:7:24: 7:25
+          _7 = _1;                         // scope 0 at $DIR/issue_76432.rs:7:24: 7:25
+          StorageLive(_8);                 // scope 0 at $DIR/issue_76432.rs:7:27: 7:28
+          _8 = _1;                         // scope 0 at $DIR/issue_76432.rs:7:27: 7:28
+          _5 = [move _6, move _7, move _8]; // scope 0 at $DIR/issue_76432.rs:7:20: 7:29
+          StorageDead(_8);                 // scope 0 at $DIR/issue_76432.rs:7:28: 7:29
+          StorageDead(_7);                 // scope 0 at $DIR/issue_76432.rs:7:28: 7:29
+          StorageDead(_6);                 // scope 0 at $DIR/issue_76432.rs:7:28: 7:29
+          _4 = &_5;                        // scope 0 at $DIR/issue_76432.rs:7:19: 7:29
+          _3 = _4;                         // scope 0 at $DIR/issue_76432.rs:7:19: 7:29
+          _2 = move _3 as &[T] (Pointer(Unsize)); // scope 0 at $DIR/issue_76432.rs:7:19: 7:29
+          StorageDead(_3);                 // scope 0 at $DIR/issue_76432.rs:7:28: 7:29
+          StorageDead(_4);                 // scope 0 at $DIR/issue_76432.rs:7:29: 7:30
+          StorageLive(_9);                 // scope 1 at $DIR/issue_76432.rs:8:5: 11:6
+          _10 = Len((*_2));                // scope 1 at $DIR/issue_76432.rs:9:9: 9:33
+          _11 = const 3_usize;             // scope 1 at $DIR/issue_76432.rs:9:9: 9:33
+-         _12 = Eq(move _10, const 3_usize); // scope 1 at $DIR/issue_76432.rs:9:9: 9:33
+-         switchInt(move _12) -> [false: bb1, otherwise: bb2]; // scope 1 at $DIR/issue_76432.rs:9:9: 9:33
++         nop;                             // scope 1 at $DIR/issue_76432.rs:9:9: 9:33
++         switchInt(move _10) -> [3_usize: bb2, otherwise: bb1]; // scope 1 at $DIR/issue_76432.rs:9:9: 9:33
+      }
+  
+      bb1: {
+          StorageLive(_22);                // scope 1 at $SRC_DIR/std/src/macros.rs:LL:COL
+          begin_panic::<&str>(const "internal error: entered unreachable code"); // scope 1 at $SRC_DIR/std/src/macros.rs:LL:COL
+                                           // mir::Constant
+                                           // + span: $SRC_DIR/std/src/macros.rs:LL:COL
+                                           // + literal: Const { ty: fn(&str) -> ! {std::rt::begin_panic::<&str>}, val: Value(Scalar(<ZST>)) }
+                                           // ty::Const
+                                           // + ty: &str
+                                           // + val: Value(Slice { data: Allocation { bytes: [105, 110, 116, 101, 114, 110, 97, 108, 32, 101, 114, 114, 111, 114, 58, 32, 101, 110, 116, 101, 114, 101, 100, 32, 117, 110, 114, 101, 97, 99, 104, 97, 98, 108, 101, 32, 99, 111, 100, 101], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [1099511627775], len: Size { raw: 40 } }, size: Size { raw: 40 }, align: Align { pow2: 0 }, mutability: Not, extra: () }, start: 0, end: 40 })
+                                           // mir::Constant
+                                           // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                                           // + literal: Const { ty: &str, val: Value(Slice { data: Allocation { bytes: [105, 110, 116, 101, 114, 110, 97, 108, 32, 101, 114, 114, 111, 114, 58, 32, 101, 110, 116, 101, 114, 101, 100, 32, 117, 110, 114, 101, 97, 99, 104, 97, 98, 108, 101, 32, 99, 111, 100, 101], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [1099511627775], len: Size { raw: 40 } }, size: Size { raw: 40 }, align: Align { pow2: 0 }, mutability: Not, extra: () }, start: 0, end: 40 }) }
+      }
+  
+      bb2: {
+          StorageLive(_13);                // scope 1 at $DIR/issue_76432.rs:9:10: 9:16
+          _13 = &(*_2)[0 of 3];            // scope 1 at $DIR/issue_76432.rs:9:10: 9:16
+          StorageLive(_14);                // scope 1 at $DIR/issue_76432.rs:9:18: 9:24
+          _14 = &(*_2)[1 of 3];            // scope 1 at $DIR/issue_76432.rs:9:18: 9:24
+          StorageLive(_15);                // scope 1 at $DIR/issue_76432.rs:9:26: 9:32
+          _15 = &(*_2)[2 of 3];            // scope 1 at $DIR/issue_76432.rs:9:26: 9:32
+          StorageLive(_16);                // scope 2 at $DIR/issue_76432.rs:9:38: 9:52
+          StorageLive(_17);                // scope 2 at $DIR/issue_76432.rs:9:38: 9:52
+          _17 = &raw const (*_13);         // scope 2 at $DIR/issue_76432.rs:9:38: 9:40
+          _16 = _17;                       // scope 2 at $DIR/issue_76432.rs:9:38: 9:52
+          StorageLive(_18);                // scope 2 at $DIR/issue_76432.rs:9:54: 9:68
+          StorageLive(_19);                // scope 2 at $DIR/issue_76432.rs:9:54: 9:68
+          _19 = &raw const (*_14);         // scope 2 at $DIR/issue_76432.rs:9:54: 9:56
+          _18 = _19;                       // scope 2 at $DIR/issue_76432.rs:9:54: 9:68
+          StorageLive(_20);                // scope 2 at $DIR/issue_76432.rs:9:70: 9:84
+          StorageLive(_21);                // scope 2 at $DIR/issue_76432.rs:9:70: 9:84
+          _21 = &raw const (*_15);         // scope 2 at $DIR/issue_76432.rs:9:70: 9:72
+          _20 = _21;                       // scope 2 at $DIR/issue_76432.rs:9:70: 9:84
+          _9 = [move _16, move _18, move _20]; // scope 2 at $DIR/issue_76432.rs:9:37: 9:85
+          StorageDead(_21);                // scope 2 at $DIR/issue_76432.rs:9:84: 9:85
+          StorageDead(_20);                // scope 2 at $DIR/issue_76432.rs:9:84: 9:85
+          StorageDead(_19);                // scope 2 at $DIR/issue_76432.rs:9:84: 9:85
+          StorageDead(_18);                // scope 2 at $DIR/issue_76432.rs:9:84: 9:85
+          StorageDead(_17);                // scope 2 at $DIR/issue_76432.rs:9:84: 9:85
+          StorageDead(_16);                // scope 2 at $DIR/issue_76432.rs:9:84: 9:85
+          StorageDead(_15);                // scope 1 at $DIR/issue_76432.rs:9:84: 9:85
+          StorageDead(_14);                // scope 1 at $DIR/issue_76432.rs:9:84: 9:85
+          StorageDead(_13);                // scope 1 at $DIR/issue_76432.rs:9:84: 9:85
+          StorageDead(_9);                 // scope 1 at $DIR/issue_76432.rs:11:6: 11:7
+          _0 = const ();                   // scope 0 at $DIR/issue_76432.rs:6:44: 12:2
+          StorageDead(_5);                 // scope 0 at $DIR/issue_76432.rs:12:1: 12:2
+          StorageDead(_2);                 // scope 0 at $DIR/issue_76432.rs:12:1: 12:2
+          return;                          // scope 0 at $DIR/issue_76432.rs:12:2: 12:2
+      }
+  }
+  

--- a/src/test/mir-opt/remove_unneeded_drops.cannot_opt_generic.RemoveUnneededDrops.diff
+++ b/src/test/mir-opt/remove_unneeded_drops.cannot_opt_generic.RemoveUnneededDrops.diff
@@ -1,0 +1,32 @@
+- // MIR for `cannot_opt_generic` before RemoveUnneededDrops
++ // MIR for `cannot_opt_generic` after RemoveUnneededDrops
+  
+  fn cannot_opt_generic(_1: T) -> () {
+      debug x => _1;                       // in scope 0 at $DIR/remove_unneeded_drops.rs:19:26: 19:27
+      let mut _0: ();                      // return place in scope 0 at $DIR/remove_unneeded_drops.rs:19:32: 19:32
+      let _2: ();                          // in scope 0 at $DIR/remove_unneeded_drops.rs:20:5: 20:12
+      let mut _3: T;                       // in scope 0 at $DIR/remove_unneeded_drops.rs:20:10: 20:11
+      scope 1 {
+          debug _x => _3;                  // in scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+      }
+  
+      bb0: {
+          StorageLive(_2);                 // scope 0 at $DIR/remove_unneeded_drops.rs:20:5: 20:12
+          StorageLive(_3);                 // scope 0 at $DIR/remove_unneeded_drops.rs:20:10: 20:11
+          _3 = move _1;                    // scope 0 at $DIR/remove_unneeded_drops.rs:20:10: 20:11
+          _2 = const ();                   // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+          drop(_3) -> [return: bb2, unwind: bb1]; // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+      }
+  
+      bb1 (cleanup): {
+          resume;                          // scope 0 at $DIR/remove_unneeded_drops.rs:19:1: 21:2
+      }
+  
+      bb2: {
+          StorageDead(_3);                 // scope 0 at $DIR/remove_unneeded_drops.rs:20:11: 20:12
+          StorageDead(_2);                 // scope 0 at $DIR/remove_unneeded_drops.rs:20:12: 20:13
+          _0 = const ();                   // scope 0 at $DIR/remove_unneeded_drops.rs:19:32: 21:2
+          return;                          // scope 0 at $DIR/remove_unneeded_drops.rs:21:2: 21:2
+      }
+  }
+  

--- a/src/test/mir-opt/remove_unneeded_drops.dont_opt.RemoveUnneededDrops.diff
+++ b/src/test/mir-opt/remove_unneeded_drops.dont_opt.RemoveUnneededDrops.diff
@@ -1,0 +1,32 @@
+- // MIR for `dont_opt` before RemoveUnneededDrops
++ // MIR for `dont_opt` after RemoveUnneededDrops
+  
+  fn dont_opt(_1: Vec<bool>) -> () {
+      debug x => _1;                       // in scope 0 at $DIR/remove_unneeded_drops.rs:7:13: 7:14
+      let mut _0: ();                      // return place in scope 0 at $DIR/remove_unneeded_drops.rs:7:27: 7:27
+      let _2: ();                          // in scope 0 at $DIR/remove_unneeded_drops.rs:8:5: 8:12
+      let mut _3: std::vec::Vec<bool>;     // in scope 0 at $DIR/remove_unneeded_drops.rs:8:10: 8:11
+      scope 1 {
+          debug _x => _3;                  // in scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+      }
+  
+      bb0: {
+          StorageLive(_2);                 // scope 0 at $DIR/remove_unneeded_drops.rs:8:5: 8:12
+          StorageLive(_3);                 // scope 0 at $DIR/remove_unneeded_drops.rs:8:10: 8:11
+          _3 = move _1;                    // scope 0 at $DIR/remove_unneeded_drops.rs:8:10: 8:11
+          _2 = const ();                   // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+          drop(_3) -> [return: bb2, unwind: bb1]; // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+      }
+  
+      bb1 (cleanup): {
+          resume;                          // scope 0 at $DIR/remove_unneeded_drops.rs:7:1: 9:2
+      }
+  
+      bb2: {
+          StorageDead(_3);                 // scope 0 at $DIR/remove_unneeded_drops.rs:8:11: 8:12
+          StorageDead(_2);                 // scope 0 at $DIR/remove_unneeded_drops.rs:8:12: 8:13
+          _0 = const ();                   // scope 0 at $DIR/remove_unneeded_drops.rs:7:27: 9:2
+          return;                          // scope 0 at $DIR/remove_unneeded_drops.rs:9:2: 9:2
+      }
+  }
+  

--- a/src/test/mir-opt/remove_unneeded_drops.opt.RemoveUnneededDrops.diff
+++ b/src/test/mir-opt/remove_unneeded_drops.opt.RemoveUnneededDrops.diff
@@ -16,10 +16,9 @@
           _3 = _1;                         // scope 0 at $DIR/remove_unneeded_drops.rs:3:10: 3:11
           _2 = const ();                   // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
 -         drop(_3) -> bb1;                 // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-+         goto -> bb1;                     // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-      }
-  
-      bb1: {
+-     }
+- 
+-     bb1: {
           StorageDead(_3);                 // scope 0 at $DIR/remove_unneeded_drops.rs:3:11: 3:12
           StorageDead(_2);                 // scope 0 at $DIR/remove_unneeded_drops.rs:3:12: 3:13
           _0 = const ();                   // scope 0 at $DIR/remove_unneeded_drops.rs:2:17: 4:2

--- a/src/test/mir-opt/remove_unneeded_drops.opt.RemoveUnneededDrops.diff
+++ b/src/test/mir-opt/remove_unneeded_drops.opt.RemoveUnneededDrops.diff
@@ -1,0 +1,29 @@
+- // MIR for `opt` before RemoveUnneededDrops
++ // MIR for `opt` after RemoveUnneededDrops
+  
+  fn opt(_1: bool) -> () {
+      debug x => _1;                       // in scope 0 at $DIR/remove_unneeded_drops.rs:2:8: 2:9
+      let mut _0: ();                      // return place in scope 0 at $DIR/remove_unneeded_drops.rs:2:17: 2:17
+      let _2: ();                          // in scope 0 at $DIR/remove_unneeded_drops.rs:3:5: 3:12
+      let mut _3: bool;                    // in scope 0 at $DIR/remove_unneeded_drops.rs:3:10: 3:11
+      scope 1 {
+          debug _x => _3;                  // in scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+      }
+  
+      bb0: {
+          StorageLive(_2);                 // scope 0 at $DIR/remove_unneeded_drops.rs:3:5: 3:12
+          StorageLive(_3);                 // scope 0 at $DIR/remove_unneeded_drops.rs:3:10: 3:11
+          _3 = _1;                         // scope 0 at $DIR/remove_unneeded_drops.rs:3:10: 3:11
+          _2 = const ();                   // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+-         drop(_3) -> bb1;                 // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
++         goto -> bb1;                     // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+      }
+  
+      bb1: {
+          StorageDead(_3);                 // scope 0 at $DIR/remove_unneeded_drops.rs:3:11: 3:12
+          StorageDead(_2);                 // scope 0 at $DIR/remove_unneeded_drops.rs:3:12: 3:13
+          _0 = const ();                   // scope 0 at $DIR/remove_unneeded_drops.rs:2:17: 4:2
+          return;                          // scope 0 at $DIR/remove_unneeded_drops.rs:4:2: 4:2
+      }
+  }
+  

--- a/src/test/mir-opt/remove_unneeded_drops.opt_generic_copy.RemoveUnneededDrops.diff
+++ b/src/test/mir-opt/remove_unneeded_drops.opt_generic_copy.RemoveUnneededDrops.diff
@@ -16,10 +16,9 @@
           _3 = _1;                         // scope 0 at $DIR/remove_unneeded_drops.rs:13:10: 13:11
           _2 = const ();                   // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
 -         drop(_3) -> bb1;                 // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-+         goto -> bb1;                     // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-      }
-  
-      bb1: {
+-     }
+- 
+-     bb1: {
           StorageDead(_3);                 // scope 0 at $DIR/remove_unneeded_drops.rs:13:11: 13:12
           StorageDead(_2);                 // scope 0 at $DIR/remove_unneeded_drops.rs:13:12: 13:13
           _0 = const ();                   // scope 0 at $DIR/remove_unneeded_drops.rs:12:36: 14:2

--- a/src/test/mir-opt/remove_unneeded_drops.opt_generic_copy.RemoveUnneededDrops.diff
+++ b/src/test/mir-opt/remove_unneeded_drops.opt_generic_copy.RemoveUnneededDrops.diff
@@ -1,0 +1,29 @@
+- // MIR for `opt_generic_copy` before RemoveUnneededDrops
++ // MIR for `opt_generic_copy` after RemoveUnneededDrops
+  
+  fn opt_generic_copy(_1: T) -> () {
+      debug x => _1;                       // in scope 0 at $DIR/remove_unneeded_drops.rs:12:30: 12:31
+      let mut _0: ();                      // return place in scope 0 at $DIR/remove_unneeded_drops.rs:12:36: 12:36
+      let _2: ();                          // in scope 0 at $DIR/remove_unneeded_drops.rs:13:5: 13:12
+      let mut _3: T;                       // in scope 0 at $DIR/remove_unneeded_drops.rs:13:10: 13:11
+      scope 1 {
+          debug _x => _3;                  // in scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+      }
+  
+      bb0: {
+          StorageLive(_2);                 // scope 0 at $DIR/remove_unneeded_drops.rs:13:5: 13:12
+          StorageLive(_3);                 // scope 0 at $DIR/remove_unneeded_drops.rs:13:10: 13:11
+          _3 = _1;                         // scope 0 at $DIR/remove_unneeded_drops.rs:13:10: 13:11
+          _2 = const ();                   // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+-         drop(_3) -> bb1;                 // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
++         goto -> bb1;                     // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
+      }
+  
+      bb1: {
+          StorageDead(_3);                 // scope 0 at $DIR/remove_unneeded_drops.rs:13:11: 13:12
+          StorageDead(_2);                 // scope 0 at $DIR/remove_unneeded_drops.rs:13:12: 13:13
+          _0 = const ();                   // scope 0 at $DIR/remove_unneeded_drops.rs:12:36: 14:2
+          return;                          // scope 0 at $DIR/remove_unneeded_drops.rs:14:2: 14:2
+      }
+  }
+  

--- a/src/test/mir-opt/remove_unneeded_drops.rs
+++ b/src/test/mir-opt/remove_unneeded_drops.rs
@@ -1,0 +1,28 @@
+// EMIT_MIR remove_unneeded_drops.opt.RemoveUnneededDrops.diff
+fn opt(x: bool) {
+    drop(x);
+}
+
+// EMIT_MIR remove_unneeded_drops.dont_opt.RemoveUnneededDrops.diff
+fn dont_opt(x: Vec<bool>) {
+    drop(x);
+}
+
+// EMIT_MIR remove_unneeded_drops.opt_generic_copy.RemoveUnneededDrops.diff
+fn opt_generic_copy<T: Copy>(x: T) {
+    drop(x);
+}
+
+// EMIT_MIR remove_unneeded_drops.cannot_opt_generic.RemoveUnneededDrops.diff
+// since the pass is not running on monomorphisized code,
+// we can't (but probably should) optimize this
+fn cannot_opt_generic<T>(x: T) {
+    drop(x);
+}
+
+fn main() {
+    opt(true);
+    opt_generic_copy(42);
+    cannot_opt_generic(42);
+    dont_opt(vec![true]);
+}

--- a/src/test/ui/const-generics/issues/issue-73260.rs
+++ b/src/test/ui/const-generics/issues/issue-73260.rs
@@ -1,0 +1,20 @@
+// compile-flags: -Zsave-analysis
+
+#![feature(const_generics)]
+#![allow(incomplete_features)]
+struct Arr<const N: usize>
+where Assert::<{N < usize::max_value() / 2}>: IsTrue, //~ ERROR constant expression
+{
+}
+
+enum Assert<const CHECK: bool> {}
+
+trait IsTrue {}
+
+impl IsTrue for Assert<true> {}
+
+fn main() {
+    let x: Arr<{usize::max_value()}> = Arr {};
+    //~^ ERROR mismatched types
+    //~| ERROR mismatched types
+}

--- a/src/test/ui/const-generics/issues/issue-73260.stderr
+++ b/src/test/ui/const-generics/issues/issue-73260.stderr
@@ -1,0 +1,29 @@
+error: constant expression depends on a generic parameter
+  --> $DIR/issue-73260.rs:6:47
+   |
+LL | where Assert::<{N < usize::max_value() / 2}>: IsTrue,
+   |                                               ^^^^^^
+   |
+   = note: this may fail depending on what value the parameter takes
+
+error[E0308]: mismatched types
+  --> $DIR/issue-73260.rs:17:12
+   |
+LL |     let x: Arr<{usize::max_value()}> = Arr {};
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^ expected `false`, found `true`
+   |
+   = note: expected type `false`
+              found type `true`
+
+error[E0308]: mismatched types
+  --> $DIR/issue-73260.rs:17:40
+   |
+LL |     let x: Arr<{usize::max_value()}> = Arr {};
+   |                                        ^^^ expected `false`, found `true`
+   |
+   = note: expected type `false`
+              found type `true`
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/const-generics/issues/issue-74634.rs
+++ b/src/test/ui/const-generics/issues/issue-74634.rs
@@ -1,0 +1,27 @@
+#![feature(const_generics)]
+#![allow(incomplete_features)]
+
+trait If<const COND: bool> {}
+impl If<true> for () {}
+
+trait IsZero<const N: u8> {
+    type Answer;
+}
+
+struct True;
+struct False;
+
+impl<const N: u8> IsZero<N> for ()
+where (): If<{N == 0}> { //~ERROR constant expression
+    type Answer = True;
+}
+
+trait Foobar<const N: u8> {}
+
+impl<const N: u8> Foobar<N> for ()
+where (): IsZero<N, Answer = True> {}
+
+impl<const N: u8> Foobar<N> for ()
+where (): IsZero<N, Answer = False> {}
+
+fn main() {}

--- a/src/test/ui/const-generics/issues/issue-74634.stderr
+++ b/src/test/ui/const-generics/issues/issue-74634.stderr
@@ -1,0 +1,10 @@
+error: constant expression depends on a generic parameter
+  --> $DIR/issue-74634.rs:15:11
+   |
+LL | where (): If<{N == 0}> {
+   |           ^^^^^^^^^^^^
+   |
+   = note: this may fail depending on what value the parameter takes
+
+error: aborting due to previous error
+

--- a/src/test/ui/const-generics/issues/issue-76595.rs
+++ b/src/test/ui/const-generics/issues/issue-76595.rs
@@ -1,0 +1,18 @@
+#![feature(const_generics, const_evaluatable_checked)]
+#![allow(incomplete_features)]
+
+struct Bool<const B: bool>;
+
+trait True {}
+
+impl True for Bool<true> {}
+
+fn test<T, const P: usize>() where Bool<{core::mem::size_of::<T>() > 4}>: True {
+    todo!()
+}
+
+fn main() {
+    test::<2>();
+    //~^ ERROR wrong number of type
+    //~| ERROR constant expression depends
+}

--- a/src/test/ui/const-generics/issues/issue-76595.stderr
+++ b/src/test/ui/const-generics/issues/issue-76595.stderr
@@ -1,0 +1,21 @@
+error[E0107]: wrong number of type arguments: expected 1, found 0
+  --> $DIR/issue-76595.rs:15:5
+   |
+LL |     test::<2>();
+   |     ^^^^^^^^^ expected 1 type argument
+
+error: constant expression depends on a generic parameter
+  --> $DIR/issue-76595.rs:15:5
+   |
+LL | fn test<T, const P: usize>() where Bool<{core::mem::size_of::<T>() > 4}>: True {
+   |    ---- required by a bound in this
+...
+LL |     test::<2>();
+   |     ^^^^^^^^^
+   |
+   = note: this may fail depending on what value the parameter takes
+   = note: required by this bound in `test`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0107`.

--- a/src/test/ui/const-generics/issues/issue-76595.stderr
+++ b/src/test/ui/const-generics/issues/issue-76595.stderr
@@ -8,13 +8,12 @@ error: constant expression depends on a generic parameter
   --> $DIR/issue-76595.rs:15:5
    |
 LL | fn test<T, const P: usize>() where Bool<{core::mem::size_of::<T>() > 4}>: True {
-   |    ---- required by a bound in this
+   |                                                                           ---- required by this bound in `test`
 ...
 LL |     test::<2>();
    |     ^^^^^^^^^
    |
    = note: this may fail depending on what value the parameter takes
-   = note: required by this bound in `test`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/ffi_const.stderr
+++ b/src/test/ui/ffi_const.stderr
@@ -6,3 +6,4 @@ LL | #[ffi_const]
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0756`.

--- a/src/tools/lint-docs/src/groups.rs
+++ b/src/tools/lint-docs/src/groups.rs
@@ -18,10 +18,10 @@ static GROUP_DESCRIPTIONS: &[(&str, &str)] = &[
 /// Updates the documentation of lint groups.
 pub(crate) fn generate_group_docs(
     lints: &[Lint],
-    rustc_path: &Path,
+    rustc: crate::Rustc<'_>,
     out_path: &Path,
 ) -> Result<(), Box<dyn Error>> {
-    let groups = collect_groups(rustc_path)?;
+    let groups = collect_groups(rustc)?;
     let groups_path = out_path.join("groups.md");
     let contents = fs::read_to_string(&groups_path)
         .map_err(|e| format!("could not read {}: {}", groups_path.display(), e))?;
@@ -36,9 +36,9 @@ pub(crate) fn generate_group_docs(
 type LintGroups = BTreeMap<String, BTreeSet<String>>;
 
 /// Collects the group names from rustc.
-fn collect_groups(rustc: &Path) -> Result<LintGroups, Box<dyn Error>> {
+fn collect_groups(rustc: crate::Rustc<'_>) -> Result<LintGroups, Box<dyn Error>> {
     let mut result = BTreeMap::new();
-    let mut cmd = Command::new(rustc);
+    let mut cmd = Command::new(rustc.path);
     cmd.arg("-Whelp");
     let output = cmd.output().map_err(|e| format!("failed to run command {:?}\n{}", cmd, e))?;
     if !output.status.success() {

--- a/src/tools/lint-docs/src/main.rs
+++ b/src/tools/lint-docs/src/main.rs
@@ -13,6 +13,7 @@ fn doit() -> Result<(), Box<dyn Error>> {
     let mut src_path = None;
     let mut out_path = None;
     let mut rustc_path = None;
+    let mut rustc_target = None;
     let mut verbose = false;
     while let Some(arg) = args.next() {
         match arg.as_str() {
@@ -34,6 +35,12 @@ fn doit() -> Result<(), Box<dyn Error>> {
                     None => return Err("--rustc requires a value".into()),
                 };
             }
+            "--rustc-target" => {
+                rustc_target = match args.next() {
+                    Some(s) => Some(s),
+                    None => return Err("--rustc-target requires a value".into()),
+                };
+            }
             "-v" | "--verbose" => verbose = true,
             s => return Err(format!("unexpected argument `{}`", s).into()),
         }
@@ -47,10 +54,16 @@ fn doit() -> Result<(), Box<dyn Error>> {
     if rustc_path.is_none() {
         return Err("--rustc must be specified to the path of rustc".into());
     }
+    if rustc_target.is_none() {
+        return Err("--rustc-target must be specified to the rustc target".into());
+    }
     lint_docs::extract_lint_docs(
         &src_path.unwrap(),
         &out_path.unwrap(),
-        &rustc_path.unwrap(),
+        lint_docs::Rustc {
+            path: rustc_path.as_deref().unwrap(),
+            target: rustc_target.as_deref().unwrap(),
+        },
         verbose,
     )
 }


### PR DESCRIPTION
Successful merges:

 - #76131 (Don't use `zip` to compare iterators during pretty-print hack)
 - #76150 (Don't recommend ManuallyDrop to customize drop order)
 - #76275 (Implementation of Write for some immutable ref structs)
 - #76489 (Add explanation for E0756)
 - #76581 (do not ICE on bound variables, return `TooGeneric` instead)
 - #76626 (Add a changelog for x.py and nag contributors until they read it)
 - #76655 (Make some methods of `Pin` unstable const)
 - #76659 (SimplifyComparisonIntegral: fix miscompilation)
 - #76673 (MIR pass to remove unneeded drops on types not needing drop)
 - #76783 (Only get ImplKind::Impl once)
 - #76799 (Fix cross compiling dist/build invocations)
 - #76888 (use if let instead of single match arm expressions)
 - #77022 (Reduce boilerplate for BytePos and CharPos)

Failed merges:


r? @ghost