### PR TITLE
const_evaluatable_checked: extend predicate collection

### DIFF
--- a/compiler/rustc_typeck/src/collect.rs
+++ b/compiler/rustc_typeck/src/collect.rs
@@ -2098,6 +2098,18 @@ fn const_evaluatable_predicates_of<'tcx>(
     let node = tcx.hir().get(hir_id);
 
     let mut collector = ConstCollector { tcx, preds: FxIndexSet::default() };
+    if let hir::Node::Item(item) = node {
+        if let hir::ItemKind::Impl { ref of_trait, ref self_ty, .. } = item.kind {
+            if let Some(of_trait) = of_trait {
+                warn!("const_evaluatable_predicates_of({:?}): visit impl trait_ref", def_id);
+                collector.visit_trait_ref(of_trait);
+            }
+
+            warn!("const_evaluatable_predicates_of({:?}): visit_self_ty", def_id);
+            collector.visit_ty(self_ty);
+        }
+    }
+
     if let Some(generics) = node.generics() {
         warn!("const_evaluatable_predicates_of({:?}): visit_generics", def_id);
         collector.visit_generics(generics);

--- a/src/test/ui/const-generics/const_evaluatable_checked/cross_crate_predicate.rs
+++ b/src/test/ui/const-generics/const_evaluatable_checked/cross_crate_predicate.rs
@@ -8,6 +8,7 @@ fn user<T>() {
     //~^ ERROR constant expression depends
     //~| ERROR constant expression depends
     //~| ERROR constant expression depends
+    //~| ERROR constant expression depends
 }
 
 fn main() {}

--- a/src/test/ui/const-generics/const_evaluatable_checked/cross_crate_predicate.stderr
+++ b/src/test/ui/const-generics/const_evaluatable_checked/cross_crate_predicate.stderr
@@ -33,7 +33,7 @@ LL |     let _ = const_evaluatable_lib::test1::<T>();
   ::: $DIR/auxiliary/const_evaluatable_lib.rs:6:10
    |
 LL |     [u8; std::mem::size_of::<T>() - 1]: Sized,
-   |          ---------------------------- required by this bound in `test1::{{constant}}#1`
+   |          ---------------------------- required by this bound in `test1`
    |
    = note: this may fail depending on what value the parameter takes
 
@@ -46,7 +46,7 @@ LL |     let _ = const_evaluatable_lib::test1::<T>();
   ::: $DIR/auxiliary/const_evaluatable_lib.rs:4:27
    |
 LL | pub fn test1<T>() -> [u8; std::mem::size_of::<T>() - 1]
-   |                           ---------------------------- required by this bound in `test1::{{constant}}#1`
+   |                           ---------------------------- required by this bound in `test1`
    |
    = note: this may fail depending on what value the parameter takes
 

--- a/src/test/ui/const-generics/const_evaluatable_checked/cross_crate_predicate.stderr
+++ b/src/test/ui/const-generics/const_evaluatable_checked/cross_crate_predicate.stderr
@@ -15,6 +15,19 @@ error: constant expression depends on a generic parameter
   --> $DIR/cross_crate_predicate.rs:7:13
    |
 LL |     let _ = const_evaluatable_lib::test1::<T>();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | 
+  ::: $DIR/auxiliary/const_evaluatable_lib.rs:6:41
+   |
+LL |     [u8; std::mem::size_of::<T>() - 1]: Sized,
+   |                                         ----- required by this bound in `test1`
+   |
+   = note: this may fail depending on what value the parameter takes
+
+error: constant expression depends on a generic parameter
+  --> $DIR/cross_crate_predicate.rs:7:13
+   |
+LL |     let _ = const_evaluatable_lib::test1::<T>();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    | 
   ::: $DIR/auxiliary/const_evaluatable_lib.rs:6:41
@@ -29,8 +42,13 @@ error: constant expression depends on a generic parameter
    |
 LL |     let _ = const_evaluatable_lib::test1::<T>();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | 
+  ::: $DIR/auxiliary/const_evaluatable_lib.rs:6:41
+   |
+LL |     [u8; std::mem::size_of::<T>() - 1]: Sized,
+   |                                         ----- required by this bound in `test1::{{constant}}#1`
    |
    = note: this may fail depending on what value the parameter takes
 
-error: aborting due to 3 previous errors
+error: aborting due to 4 previous errors
 

--- a/src/test/ui/const-generics/const_evaluatable_checked/cross_crate_predicate.stderr
+++ b/src/test/ui/const-generics/const_evaluatable_checked/cross_crate_predicate.stderr
@@ -4,10 +4,10 @@ error: constant expression depends on a generic parameter
 LL |     let _ = const_evaluatable_lib::test1::<T>();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    | 
-  ::: $DIR/auxiliary/const_evaluatable_lib.rs:6:41
+  ::: $DIR/auxiliary/const_evaluatable_lib.rs:6:10
    |
 LL |     [u8; std::mem::size_of::<T>() - 1]: Sized,
-   |                                         ----- required by this bound in `test1`
+   |          ---------------------------- required by this bound in `test1`
    |
    = note: this may fail depending on what value the parameter takes
 
@@ -17,23 +17,10 @@ error: constant expression depends on a generic parameter
 LL |     let _ = const_evaluatable_lib::test1::<T>();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    | 
-  ::: $DIR/auxiliary/const_evaluatable_lib.rs:6:41
+  ::: $DIR/auxiliary/const_evaluatable_lib.rs:4:27
    |
-LL |     [u8; std::mem::size_of::<T>() - 1]: Sized,
-   |                                         ----- required by this bound in `test1`
-   |
-   = note: this may fail depending on what value the parameter takes
-
-error: constant expression depends on a generic parameter
-  --> $DIR/cross_crate_predicate.rs:7:13
-   |
-LL |     let _ = const_evaluatable_lib::test1::<T>();
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   | 
-  ::: $DIR/auxiliary/const_evaluatable_lib.rs:6:41
-   |
-LL |     [u8; std::mem::size_of::<T>() - 1]: Sized,
-   |                                         ----- required by this bound in `test1::{{constant}}#1`
+LL | pub fn test1<T>() -> [u8; std::mem::size_of::<T>() - 1]
+   |                           ---------------------------- required by this bound in `test1`
    |
    = note: this may fail depending on what value the parameter takes
 
@@ -43,10 +30,23 @@ error: constant expression depends on a generic parameter
 LL |     let _ = const_evaluatable_lib::test1::<T>();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    | 
-  ::: $DIR/auxiliary/const_evaluatable_lib.rs:6:41
+  ::: $DIR/auxiliary/const_evaluatable_lib.rs:6:10
    |
 LL |     [u8; std::mem::size_of::<T>() - 1]: Sized,
-   |                                         ----- required by this bound in `test1::{{constant}}#1`
+   |          ---------------------------- required by this bound in `test1::{{constant}}#1`
+   |
+   = note: this may fail depending on what value the parameter takes
+
+error: constant expression depends on a generic parameter
+  --> $DIR/cross_crate_predicate.rs:7:13
+   |
+LL |     let _ = const_evaluatable_lib::test1::<T>();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | 
+  ::: $DIR/auxiliary/const_evaluatable_lib.rs:4:27
+   |
+LL | pub fn test1<T>() -> [u8; std::mem::size_of::<T>() - 1]
+   |                           ---------------------------- required by this bound in `test1::{{constant}}#1`
    |
    = note: this may fail depending on what value the parameter takes
 

--- a/src/test/ui/const-generics/const_evaluatable_checked/from-sig-fail.rs
+++ b/src/test/ui/const-generics/const_evaluatable_checked/from-sig-fail.rs
@@ -1,0 +1,11 @@
+#![feature(const_generics, const_evaluatable_checked)]
+#![allow(incomplete_features)]
+
+fn test<const N: usize>() -> [u8; N - 1] {
+    //~^ ERROR evaluation of constant
+    todo!()
+}
+
+fn main() {
+    test::<0>();
+}

--- a/src/test/ui/const-generics/const_evaluatable_checked/from-sig-fail.stderr
+++ b/src/test/ui/const-generics/const_evaluatable_checked/from-sig-fail.stderr
@@ -1,0 +1,9 @@
+error[E0080]: evaluation of constant value failed
+  --> $DIR/from-sig-fail.rs:4:35
+   |
+LL | fn test<const N: usize>() -> [u8; N - 1] {
+   |                                   ^^^^^ attempt to compute `0_usize - 1_usize` which would overflow
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/const-generics/const_evaluatable_checked/from-sig.rs
+++ b/src/test/ui/const-generics/const_evaluatable_checked/from-sig.rs
@@ -1,0 +1,14 @@
+// run-pass
+#![feature(const_generics, const_evaluatable_checked)]
+#![allow(incomplete_features)]
+
+struct Foo<const B: bool>;
+
+fn test<const N: usize>() -> Foo<{ N > 10 }> {
+    Foo
+}
+
+fn main() {
+    let _: Foo<true> = test::<12>();
+    let _: Foo<false> = test::<9>();
+}

--- a/src/test/ui/const-generics/const_evaluatable_checked/impl-bounds.rs
+++ b/src/test/ui/const-generics/const_evaluatable_checked/impl-bounds.rs
@@ -1,0 +1,25 @@
+// check-pass
+#![feature(const_generics, const_evaluatable_checked)]
+#![allow(incomplete_features)]
+
+use std::mem::size_of;
+
+struct Foo<T, const N: usize>(T);
+
+impl<T> Foo<T, { size_of::<T>() }> {
+    fn test() {
+        let _: [u8; std::mem::size_of::<T>()];
+    }
+}
+
+trait Bar<const N: usize> {
+    fn test_me();
+}
+
+impl<T> Bar<{ size_of::<T>() }> for Foo<T, 3> {
+    fn test_me() {
+        let _: [u8; std::mem::size_of::<T>()];
+    }
+}
+
+fn main() {}

--- a/src/test/ui/const-generics/const_evaluatable_checked/let-bindings.stderr
+++ b/src/test/ui/const-generics/const_evaluatable_checked/let-bindings.stderr
@@ -2,7 +2,7 @@ error: constant expression depends on a generic parameter
   --> $DIR/let-bindings.rs:6:68
    |
 LL | fn test<const N: usize>() -> [u8; { let x = N; N + 1 }] where [u8; { let x = N; N + 1 }]: Default {
-   |                                                                    ^^^^^^^^^^^^^^^^^^^^ required by this bound in `test::{{constant}}#0`
+   |                                                                    ^^^^^^^^^^^^^^^^^^^^ required by this bound in `test`
    |
    = help: consider moving this anonymous constant into a `const` function
 

--- a/src/test/ui/const-generics/const_evaluatable_checked/let-bindings.stderr
+++ b/src/test/ui/const-generics/const_evaluatable_checked/let-bindings.stderr
@@ -1,8 +1,10 @@
-error: constant expression depends on a generic parameter
+error: overly complex generic constant
   --> $DIR/let-bindings.rs:6:68
    |
 LL | fn test<const N: usize>() -> [u8; { let x = N; N + 1 }] where [u8; { let x = N; N + 1 }]: Default {
-   |                                                                    ^^^^^^^^^^^^^^^^^^^^ required by this bound in `test`
+   |                                                                    ^^^^^^-^^^^^^^^^^^^^
+   |                                                                          |
+   |                                                                          unsupported statement
    |
    = help: consider moving this anonymous constant into a `const` function
 

--- a/src/test/ui/const-generics/const_evaluatable_checked/let-bindings.stderr
+++ b/src/test/ui/const-generics/const_evaluatable_checked/let-bindings.stderr
@@ -1,10 +1,8 @@
-error: overly complex generic constant
+error: constant expression depends on a generic parameter
   --> $DIR/let-bindings.rs:6:68
    |
 LL | fn test<const N: usize>() -> [u8; { let x = N; N + 1 }] where [u8; { let x = N; N + 1 }]: Default {
-   |                                                                    ^^^^^^-^^^^^^^^^^^^^
-   |                                                                          |
-   |                                                                          unsupported statement
+   |                                                                    ^^^^^^^^^^^^^^^^^^^^ required by this bound in `test::{{constant}}#0`
    |
    = help: consider moving this anonymous constant into a `const` function
 

--- a/src/test/ui/const-generics/issues/issue-76595.stderr
+++ b/src/test/ui/const-generics/issues/issue-76595.stderr
@@ -8,7 +8,7 @@ error: constant expression depends on a generic parameter
   --> $DIR/issue-76595.rs:15:5
    |
 LL | fn test<T, const P: usize>() where Bool<{core::mem::size_of::<T>() > 4}>: True {
-   |                                                                           ---- required by this bound in `test`
+   |                                         ------------------------------- required by this bound in `test`
 ...
 LL |     test::<2>();
    |     ^^^^^^^^^


### PR DESCRIPTION
We now walk the hir instead of using `ty` so that we get better spans here, While I am still not completely sure if that's
what we want in the end, it does seem a lot closer to the final goal than the previous version.

We also look into type aliases (and use a `TypeVisitor` here), about which I am not completely sure, but we will see how well this works.

We also look into fn decls, so the following should work now.
```rust
fn test<T>() -> [u8; std::mem::size_of::<T>()] {
    [0; std::mem::size_of::<T>()]
}
```
Additionally, we visit the optional trait and self type of impls.

r? @oli-obk