### PR TITLE
[DO NOT MERGE] Measure cost of per function section

### DIFF
--- a/compiler/rustc_codegen_llvm/src/back/write.rs
+++ b/compiler/rustc_codegen_llvm/src/back/write.rs
@@ -128,7 +128,7 @@ pub fn target_machine_factory(
     let (opt_level, _) = to_llvm_opt_settings(optlvl);
     let use_softfp = sess.opts.cg.soft_float;
 
-    let ffunction_sections = sess.target.target.options.function_sections;
+    let ffunction_sections = false;
     let fdata_sections = ffunction_sections;
 
     let code_model = to_llvm_code_model(sess.code_model());

--- a/compiler/rustc_codegen_llvm/src/back/write.rs
+++ b/compiler/rustc_codegen_llvm/src/back/write.rs
@@ -128,7 +128,8 @@ pub fn target_machine_factory(
     let (opt_level, _) = to_llvm_opt_settings(optlvl);
     let use_softfp = sess.opts.cg.soft_float;
 
-    let ffunction_sections = false;
+    let ffunction_sections =
+        sess.target.target.options.function_sections && optlvl != config::OptLevel::No;
     let fdata_sections = ffunction_sections;
 
     let code_model = to_llvm_code_model(sess.code_model());


### PR DESCRIPTION
I was experimenting with using per function sections instead of a single `.text` section in cg_clif to see if it reduced binary size. It brings the size down for the test I used from 26MB to 15MB like the output of cg_llvm in debug mode. When I measured the linker time the result was a lot less positive: ~0.4s turned into ~0.7s. That is a 75% slowdown. It would be interesting to know what the cost is for cg_llvm over the full rustc-perf benchmark suite.

Can someone start a perf run for me?