### PR TITLE
Add #[track_caller] to more panicking Cell functions

### DIFF
--- a/library/core/src/cell.rs
+++ b/library/core/src/cell.rs
@@ -700,6 +700,7 @@ impl<T> RefCell<T> {
     /// ```
     #[inline]
     #[stable(feature = "refcell_replace", since = "1.24.0")]
+    #[track_caller]
     pub fn replace(&self, t: T) -> T {
         mem::replace(&mut *self.borrow_mut(), t)
     }
@@ -722,6 +723,7 @@ impl<T> RefCell<T> {
     /// ```
     #[inline]
     #[stable(feature = "refcell_replace_swap", since = "1.35.0")]
+    #[track_caller]
     pub fn replace_with<F: FnOnce(&mut T) -> T>(&self, f: F) -> T {
         let mut_borrow = &mut *self.borrow_mut();
         let replacement = f(mut_borrow);
@@ -1056,6 +1058,7 @@ impl<T: Clone> Clone for RefCell<T> {
     ///
     /// Panics if the value is currently mutably borrowed.
     #[inline]
+    #[track_caller]
     fn clone(&self) -> RefCell<T> {
         RefCell::new(self.borrow().clone())
     }


### PR DESCRIPTION
Continuation of #74526

Adds the #[track_caller] attribute to almost all panicking Cell
functions. The ones that borrow two Cells in their function
body are spared, because the panic location helps pinpoint
which of the two borrows failed. You'd need to have
full debuginfo and backtraces enabled together with column
info in order to be able to discern the cases.
Column info in debuginfo is only available on non-Windows platforms.