### PR TITLE
Take 2: Add `take_...` functions to slices

### DIFF
--- a/library/core/src/ops/mod.rs
+++ b/library/core/src/ops/mod.rs
@@ -181,6 +181,9 @@ pub use self::range::{Range, RangeFrom, RangeFull, RangeTo};
 #[stable(feature = "inclusive_range", since = "1.26.0")]
 pub use self::range::{Bound, RangeBounds, RangeInclusive, RangeToInclusive};
 
+#[unstable(feature = "one_sided_range", issue = "69780")]
+pub use self::range::OneSidedRange;
+
 #[unstable(feature = "try_trait", issue = "42327")]
 pub use self::r#try::Try;
 

--- a/library/core/src/ops/range.rs
+++ b/library/core/src/ops/range.rs
@@ -1004,3 +1004,21 @@ impl<T> RangeBounds<T> for RangeToInclusive<&T> {
         Included(self.end)
     }
 }
+
+/// `OneSidedRange` is implemented by Rust's built-in range types which
+/// are unbounded on one side. For example, `a..`, `..b` and `..=c` implement
+/// `OneSidedRange`, but `..`, `d..e`, and `f..=g` do not.
+///
+/// Types which implement `OneSidedRange<T>` must return `Bound::Unbounded`
+/// from exactly one of `RangeBounds::start_bound` and `RangeBounds::end_bound`.
+#[unstable(feature = "one_sided_range", issue = "69780")]
+pub trait OneSidedRange<T: ?Sized>: RangeBounds<T> {}
+
+#[unstable(feature = "one_sided_range", issue = "69780")]
+impl<T> OneSidedRange<T> for RangeTo<T> where Self: RangeBounds<T> {}
+
+#[unstable(feature = "one_sided_range", issue = "69780")]
+impl<T> OneSidedRange<T> for RangeFrom<T> where Self: RangeBounds<T> {}
+
+#[unstable(feature = "one_sided_range", issue = "69780")]
+impl<T> OneSidedRange<T> for RangeToInclusive<T> where Self: RangeBounds<T> {}

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -3381,7 +3381,8 @@ impl<T> [T] {
     #[inline]
     #[unstable(feature = "slice_take", issue = "62280")]
     pub fn take_last<'a>(self: &mut &'a Self) -> Option<&'a T> {
-        self.take((self.len() - 1)..).map(|res| &res[0])
+        let i = self.len().checked_sub(1)?;
+        self.take(i..).map(|res| &res[0])
     }
 
     /// Returns a mutable reference to the last element of the slice,
@@ -3404,7 +3405,8 @@ impl<T> [T] {
     #[inline]
     #[unstable(feature = "slice_take", issue = "62280")]
     pub fn take_last_mut<'a>(self: &mut &'a mut Self) -> Option<&'a mut T> {
-        self.take_mut((self.len() - 1)..).map(|res| &mut res[0])
+        let i = self.len().checked_sub(1)?;
+        self.take_mut(i..).map(|res| &mut res[0])
     }
 }
 

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -3335,7 +3335,9 @@ impl<T> [T] {
     #[inline]
     #[unstable(feature = "slice_take", issue = "62280")]
     pub fn take_first<'a>(self: &mut &'a Self) -> Option<&'a T> {
-        self.take(..=0).map(|res| &res[0])
+        let (first, rem) = self.split_first()?;
+        *self = rem;
+        Some(first)
     }
 
     /// Returns a mutable reference to the first element of the slice,
@@ -3358,7 +3360,9 @@ impl<T> [T] {
     #[inline]
     #[unstable(feature = "slice_take", issue = "62280")]
     pub fn take_first_mut<'a>(self: &mut &'a mut Self) -> Option<&'a mut T> {
-        self.take_mut(..=0).map(|res| &mut res[0])
+        let (first, rem) = mem::take(self).split_first_mut()?;
+        *self = rem;
+        Some(first)
     }
 
     /// Returns a reference to the last element of the slice,
@@ -3380,8 +3384,9 @@ impl<T> [T] {
     #[inline]
     #[unstable(feature = "slice_take", issue = "62280")]
     pub fn take_last<'a>(self: &mut &'a Self) -> Option<&'a T> {
-        let i = self.len().checked_sub(1)?;
-        self.take(i..).map(|res| &res[0])
+        let (last, rem) = self.split_last()?;
+        *self = rem;
+        Some(last)
     }
 
     /// Returns a mutable reference to the last element of the slice,
@@ -3404,8 +3409,9 @@ impl<T> [T] {
     #[inline]
     #[unstable(feature = "slice_take", issue = "62280")]
     pub fn take_last_mut<'a>(self: &mut &'a mut Self) -> Option<&'a mut T> {
-        let i = self.len().checked_sub(1)?;
-        self.take_mut(i..).map(|res| &mut res[0])
+        let (last, rem) = mem::take(self).split_last_mut()?;
+        *self = rem;
+        Some(last)
     }
 }
 

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -3188,10 +3188,11 @@ impl<T> [T] {
         left
     }
 
-    /// Removes and returns the portion of the slice specified by `range`.
+    /// Returns the subslice corresponding to the given range,
+    /// and modifies the slice to no longer include this subslice.
     ///
-    /// If the provided `range` starts or ends outside of the slice,
-    /// `None` is returned and the slice is not modified.
+    /// Returns `None` and does not modify the slice if the given
+    /// range is out of bounds.
     ///
     /// # Examples
     ///
@@ -3250,10 +3251,11 @@ impl<T> [T] {
         }
     }
 
-    /// Removes and returns the portion of the mutable slice specified by `range`.
+    /// Returns the mutable subslice corresponding to the given range,
+    /// and modifies the slice to no longer include this subslice.
     ///
-    /// If the provided `range` starts or ends outside of the slice,
-    /// `None` is returned and the slice is not modified.
+    /// Returns `None` and does not modify the slice if the given
+    /// range is out of bounds.
     ///
     /// # Examples
     ///
@@ -3315,9 +3317,8 @@ impl<T> [T] {
         }
     }
 
-    /// Takes the first element out of the slice.
-    ///
-    /// Returns a reference pointing to the first element of the old slice.
+    /// Returns a reference to the first element of the slice,
+    /// and modifies the slice to no longer include this element.
     ///
     /// Returns `None` if the slice is empty.
     ///
@@ -3338,9 +3339,8 @@ impl<T> [T] {
         self.take(..=0).map(|res| &res[0])
     }
 
-    /// Takes the first element out of the mutable slice.
-    ///
-    /// Returns a mutable reference pointing to the first element of the old slice.
+    /// Returns a mutable reference to the first element of the slice,
+    /// and modifies the slice to no longer include this element.
     ///
     /// Returns `None` if the slice is empty.
     ///
@@ -3362,9 +3362,8 @@ impl<T> [T] {
         self.take_mut(..=0).map(|res| &mut res[0])
     }
 
-    /// Takes the last element out of the slice.
-    ///
-    /// Returns a reference pointing to the last element of the old slice.
+    /// Returns a reference to the last element of the slice,
+    /// and modifies the slice to no longer include this element.
     ///
     /// Returns `None` if the slice is empty.
     ///
@@ -3385,9 +3384,8 @@ impl<T> [T] {
         self.take((self.len() - 1)..).map(|res| &res[0])
     }
 
-    /// Takes the last element out of the mutable slice.
-    ///
-    /// Returns a mutable reference pointing to the last element of the old slice.
+    /// Returns a mutable reference to the last element of the slice,
+    /// and modifies the slice to no longer include this element.
     ///
     /// Returns `None` if the slice is empty.
     ///

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -3240,8 +3240,7 @@ impl<T> [T] {
         if split_index > self.len() {
             return None;
         }
-        let original = crate::mem::take(self);
-        let (front, back) = original.split_at(split_index);
+        let (front, back) = self.split_at(split_index);
         if taking_front {
             *self = back;
             Some(front)

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -39,6 +39,7 @@
 #![feature(try_trait)]
 #![feature(slice_internals)]
 #![feature(slice_partition_dedup)]
+#![feature(slice_take)]
 #![feature(int_error_matching)]
 #![feature(array_value_iter)]
 #![feature(iter_advance_by)]

--- a/library/core/tests/slice.rs
+++ b/library/core/tests/slice.rs
@@ -2038,3 +2038,107 @@ fn test_slice_run_destructors() {
 
     assert_eq!(x.get(), 1);
 }
+
+macro_rules! take_tests {
+    (slice: &$slice:expr, $($tts:tt)*) => {
+        take_tests!(ty: &[_], slice: &$slice, $($tts)*);
+    };
+    (slice: &mut $slice:expr, $($tts:tt)*) => {
+        take_tests!(ty: &mut [_], slice: &mut $slice, $($tts)*);
+    };
+    (ty: $ty:ty, slice: $slice:expr, method: $method:ident, $(($test_name:ident, ($($args:expr),*), $output:expr, $remaining:expr),)*) => {
+        $(
+            #[test]
+            fn $test_name() {
+                let mut slice: $ty = $slice;
+                assert_eq!($output, slice.$method($($args)*));
+                let remaining: $ty = $remaining;
+                assert_eq!(remaining, slice);
+            }
+        )*
+    };
+}
+
+take_tests! {
+    slice: &[0, 1, 2, 3], method: take,
+    (take_in_bounds_range_to, (..1), Some(&[0] as _), &[1, 2, 3]),
+    (take_in_bounds_range_to_inclusive, (..=0), Some(&[0] as _), &[1, 2, 3]),
+    (take_in_bounds_range_from, (2..), Some(&[2, 3] as _), &[0, 1]),
+    (take_oob_range_to, (..5), None, &[0, 1, 2, 3]),
+    (take_oob_range_to_inclusive, (..=4), None, &[0, 1, 2, 3]),
+    (take_oob_range_from, (5..), None, &[0, 1, 2, 3]),
+}
+
+take_tests! {
+    slice: &mut [0, 1, 2, 3], method: take_mut,
+    (take_mut_in_bounds_range_to, (..1), Some(&mut [0] as _), &mut [1, 2, 3]),
+    (take_mut_in_bounds_range_to_inclusive, (..=0), Some(&mut [0] as _), &mut [1, 2, 3]),
+    (take_mut_in_bounds_range_from, (2..), Some(&mut [2, 3] as _), &mut [0, 1]),
+    (take_mut_oob_range_to, (..5), None, &mut [0, 1, 2, 3]),
+    (take_mut_oob_range_to_inclusive, (..=4), None, &mut [0, 1, 2, 3]),
+    (take_mut_oob_range_from, (5..), None, &mut [0, 1, 2, 3]),
+}
+
+take_tests! {
+    ty: &[_], slice: &[1, 2], method: take_first,
+    (take_first_nonempty, (), Some(&1), &[2]),
+}
+
+take_tests! {
+    ty: &mut [_], slice: &mut [1, 2], method: take_first_mut,
+    (take_first_mut_nonempty, (), Some(&mut 1), &mut [2]),
+}
+
+take_tests! {
+    ty: &[_], slice: &[1, 2], method: take_last,
+    (take_last_nonempty, (), Some(&2), &[1]),
+}
+
+take_tests! {
+    ty: &mut [_], slice: &mut [1, 2], method: take_last_mut,
+    (take_last_mut_nonempty, (), Some(&mut 2), &mut [1]),
+}
+
+take_tests! {
+    ty: &[()], slice: &[], method: take_first,
+    (take_first_empty, (), None, &[]),
+}
+
+take_tests! {
+    ty: &mut [()], slice: &mut [], method: take_first_mut,
+    (take_first_mut_empty, (), None, &mut []),
+}
+
+take_tests! {
+    ty: &[()], slice: &[], method: take_last,
+    (take_last_empty, (), None, &[]),
+}
+
+take_tests! {
+    ty: &mut [()], slice: &mut [], method: take_last_mut,
+    (take_last_mut_empty, (), None, &mut []),
+}
+
+const EMPTY_MAX: &'static [()] = &[(); std::usize::MAX];
+
+// can't be a constant due to const mutability rules
+// see https://github.com/rust-lang/rust/issues/57349#issuecomment-597395059
+macro_rules! empty_max_mut {
+    () => {
+        &mut [(); std::usize::MAX] as _
+    };
+}
+
+take_tests! {
+    slice: &[(); ::std::usize::MAX], method: take,
+    (take_in_bounds_max_range_to, (..::std::usize::MAX), Some(EMPTY_MAX), &[(); 0]),
+    (take_oob_max_range_to_inclusive, (..=::std::usize::MAX), None, EMPTY_MAX),
+    (take_in_bounds_max_range_from, (::std::usize::MAX..), Some(&[] as _), EMPTY_MAX),
+}
+
+take_tests! {
+    slice: &mut [(); ::std::usize::MAX], method: take_mut,
+    (take_mut_in_bounds_max_range_to, (..::std::usize::MAX), Some(empty_max_mut!()), &mut [(); 0]),
+    (take_mut_oob_max_range_to_inclusive, (..=::std::usize::MAX), None, empty_max_mut!()),
+    (take_mut_in_bounds_max_range_from, (::std::usize::MAX..), Some(&mut [] as _), empty_max_mut!()),
+}

--- a/library/core/tests/slice.rs
+++ b/library/core/tests/slice.rs
@@ -2118,27 +2118,3 @@ take_tests! {
     ty: &mut [()], slice: &mut [], method: take_last_mut,
     (take_last_mut_empty, (), None, &mut []),
 }
-
-const EMPTY_MAX: &'static [()] = &[(); std::usize::MAX];
-
-// can't be a constant due to const mutability rules
-// see https://github.com/rust-lang/rust/issues/57349#issuecomment-597395059
-macro_rules! empty_max_mut {
-    () => {
-        &mut [(); std::usize::MAX] as _
-    };
-}
-
-take_tests! {
-    slice: &[(); ::std::usize::MAX], method: take,
-    (take_in_bounds_max_range_to, (..::std::usize::MAX), Some(EMPTY_MAX), &[(); 0]),
-    (take_oob_max_range_to_inclusive, (..=::std::usize::MAX), None, EMPTY_MAX),
-    (take_in_bounds_max_range_from, (::std::usize::MAX..), Some(&[] as _), EMPTY_MAX),
-}
-
-take_tests! {
-    slice: &mut [(); ::std::usize::MAX], method: take_mut,
-    (take_mut_in_bounds_max_range_to, (..::std::usize::MAX), Some(empty_max_mut!()), &mut [(); 0]),
-    (take_mut_oob_max_range_to_inclusive, (..=::std::usize::MAX), None, empty_max_mut!()),
-    (take_mut_in_bounds_max_range_from, (::std::usize::MAX..), Some(&mut [] as _), empty_max_mut!()),
-}


### PR DESCRIPTION
Revival of #62282

This PR adds the following slice methods:

- take
- take_mut
- take_first
- take_first_mut
- take_last
- take_last_mut

The first commit is just the code of the previous PR. I removed some tests that hung compilation (see #77062), I can add them back once that's fixed. I also slightly reworded the doc comments as requested in the previous PR, let me know if that can be improved still.

r? @LukasKalbertodt cc @cramertj @nox 