### PR TITLE
Use `Self` in docs when possible

### DIFF
--- a/library/alloc/src/collections/binary_heap.rs
+++ b/library/alloc/src/collections/binary_heap.rs
@@ -30,7 +30,7 @@
 //! // Explicitly implement the trait so the queue becomes a min-heap
 //! // instead of a max-heap.
 //! impl Ord for State {
-//!     fn cmp(&self, other: &State) -> Ordering {
+//!     fn cmp(&self, other: &Self) -> Ordering {
 //!         // Notice that the we flip the ordering on costs.
 //!         // In case of a tie we compare positions - this step is necessary
 //!         // to make implementations of `PartialEq` and `Ord` consistent.
@@ -41,7 +41,7 @@
 //!
 //! // `PartialOrd` needs to be implemented as well.
 //! impl PartialOrd for State {
-//!     fn partial_cmp(&self, other: &State) -> Option<Ordering> {
+//!     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
 //!         Some(self.cmp(other))
 //!     }
 //! }

--- a/library/core/src/cmp.rs
+++ b/library/core/src/cmp.rs
@@ -726,19 +726,19 @@ impl PartialOrd for Ordering {
 /// }
 ///
 /// impl PartialOrd for Person {
-///     fn partial_cmp(&self, other: &Person) -> Option<Ordering> {
+///     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
 ///         Some(self.cmp(other))
 ///     }
 /// }
 ///
 /// impl Ord for Person {
-///     fn cmp(&self, other: &Person) -> Ordering {
+///     fn cmp(&self, other: &Self) -> Ordering {
 ///         self.height.cmp(&other.height)
 ///     }
 /// }
 ///
 /// impl PartialEq for Person {
-///     fn eq(&self, other: &Person) -> bool {
+///     fn eq(&self, other: &Self) -> bool {
 ///         self.height == other.height
 ///     }
 /// }

--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -643,9 +643,9 @@ macro_rules! impls {
 /// }
 ///
 /// impl<R: ResType> ExternalResource<R> {
-///     fn new() -> ExternalResource<R> {
+///     fn new() -> Self {
 ///         let size_of_res = mem::size_of::<R>();
-///         ExternalResource {
+///         Self {
 ///             resource_handle: foreign_lib::new(size_of_res),
 ///             resource_type: PhantomData,
 ///         }

--- a/library/core/src/ops/arith.rs
+++ b/library/core/src/ops/arith.rs
@@ -128,10 +128,10 @@ add_impl! { usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 f32 f64 }
 /// }
 ///
 /// impl Sub for Point {
-///     type Output = Point;
+///     type Output = Self;
 ///
-///     fn sub(self, other: Point) -> Point {
-///         Point {
+///     fn sub(self, other: Self) -> Self::Output {
+///         Self {
 ///             x: self.x - other.x,
 ///             y: self.y - other.y,
 ///         }
@@ -241,7 +241,7 @@ sub_impl! { usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 f32 f64 }
 ///         // Reduce to lowest terms by dividing by the greatest common
 ///         // divisor.
 ///         let gcd = gcd(numerator, denominator);
-///         Rational {
+///         Self {
 ///             numerator: numerator / gcd,
 ///             denominator: denominator / gcd,
 ///         }
@@ -255,7 +255,7 @@ sub_impl! { usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 f32 f64 }
 ///     fn mul(self, rhs: Self) -> Self {
 ///         let numerator = self.numerator * rhs.numerator;
 ///         let denominator = self.denominator * rhs.denominator;
-///         Rational::new(numerator, denominator)
+///         Self::new(numerator, denominator)
 ///     }
 /// }
 ///
@@ -291,7 +291,7 @@ sub_impl! { usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 f32 f64 }
 ///     type Output = Self;
 ///
 ///     fn mul(self, rhs: Scalar) -> Self::Output {
-///         Vector { value: self.value.iter().map(|v| v * rhs.value).collect() }
+///         Self { value: self.value.iter().map(|v| v * rhs.value).collect() }
 ///     }
 /// }
 ///
@@ -369,7 +369,7 @@ mul_impl! { usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 f32 f64 }
 ///         // Reduce to lowest terms by dividing by the greatest common
 ///         // divisor.
 ///         let gcd = gcd(numerator, denominator);
-///         Rational {
+///         Self {
 ///             numerator: numerator / gcd,
 ///             denominator: denominator / gcd,
 ///         }
@@ -387,7 +387,7 @@ mul_impl! { usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 f32 f64 }
 ///
 ///         let numerator = self.numerator * rhs.denominator;
 ///         let denominator = self.denominator * rhs.numerator;
-///         Rational::new(numerator, denominator)
+///         Self::new(numerator, denominator)
 ///     }
 /// }
 ///
@@ -423,7 +423,7 @@ mul_impl! { usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 f32 f64 }
 ///     type Output = Self;
 ///
 ///     fn div(self, rhs: Scalar) -> Self::Output {
-///         Vector { value: self.value.iter().map(|v| v / rhs.value).collect() }
+///         Self { value: self.value.iter().map(|v| v / rhs.value).collect() }
 ///     }
 /// }
 ///
@@ -515,7 +515,7 @@ div_impl_float! { f32 f64 }
 ///         let len = self.slice.len();
 ///         let rem = len % modulus;
 ///         let start = len - rem;
-///         SplitSlice {slice: &self.slice[start..]}
+///         Self {slice: &self.slice[start..]}
 ///     }
 /// }
 ///
@@ -615,7 +615,7 @@ rem_impl_float! { f32 f64 }
 /// }
 ///
 /// impl Neg for Sign {
-///     type Output = Sign;
+///     type Output = Self;
 ///
 ///     fn neg(self) -> Self::Output {
 ///         match self {

--- a/library/core/src/ops/bit.rs
+++ b/library/core/src/ops/bit.rs
@@ -15,7 +15,7 @@
 /// }
 ///
 /// impl Not for Answer {
-///     type Output = Answer;
+///     type Output = Self;
 ///
 ///     fn not(self) -> Self::Output {
 ///         match self {
@@ -85,7 +85,7 @@ not_impl! { bool usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 }
 ///
 ///     // rhs is the "right-hand side" of the expression `a & b`
 ///     fn bitand(self, rhs: Self) -> Self::Output {
-///         Scalar(self.0 & rhs.0)
+///         Self(self.0 & rhs.0)
 ///     }
 /// }
 ///
@@ -106,10 +106,13 @@ not_impl! { bool usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 }
 /// impl BitAnd for BooleanVector {
 ///     type Output = Self;
 ///
-///     fn bitand(self, BooleanVector(rhs): Self) -> Self::Output {
-///         let BooleanVector(lhs) = self;
+///     fn bitand(self, Self(rhs): Self) -> Self::Output {
+///         let Self(lhs) = self;
 ///         assert_eq!(lhs.len(), rhs.len());
-///         BooleanVector(lhs.iter().zip(rhs.iter()).map(|(x, y)| *x && *y).collect())
+///         Self(lhs.iter()
+///                 .zip(rhs.iter())
+///                 .map(|(x, y)| *x && *y)
+///                 .collect())
 ///     }
 /// }
 ///
@@ -179,8 +182,8 @@ bitand_impl! { bool usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 }
 ///     type Output = Self;
 ///
 ///     // rhs is the "right-hand side" of the expression `a | b`
-///     fn bitor(self, rhs: Self) -> Self {
-///         Scalar(self.0 | rhs.0)
+///     fn bitor(self, rhs: Self) -> Self::Output {
+///         Self(self.0 | rhs.0)
 ///     }
 /// }
 ///
@@ -201,10 +204,10 @@ bitand_impl! { bool usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 }
 /// impl BitOr for BooleanVector {
 ///     type Output = Self;
 ///
-///     fn bitor(self, BooleanVector(rhs): Self) -> Self::Output {
-///         let BooleanVector(lhs) = self;
+///     fn bitor(self, Self(rhs): Self) -> Self::Output {
+///         let Self(lhs) = self;
 ///         assert_eq!(lhs.len(), rhs.len());
-///         BooleanVector(lhs.iter().zip(rhs.iter()).map(|(x, y)| *x || *y).collect())
+///         Self(lhs.iter().zip(rhs.iter()).map(|(x, y)| *x || *y).collect())
 ///     }
 /// }
 ///
@@ -275,7 +278,7 @@ bitor_impl! { bool usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 }
 ///
 ///     // rhs is the "right-hand side" of the expression `a ^ b`
 ///     fn bitxor(self, rhs: Self) -> Self::Output {
-///         Scalar(self.0 ^ rhs.0)
+///         Self(self.0 ^ rhs.0)
 ///     }
 /// }
 ///
@@ -296,13 +299,13 @@ bitor_impl! { bool usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 }
 /// impl BitXor for BooleanVector {
 ///     type Output = Self;
 ///
-///     fn bitxor(self, BooleanVector(rhs): Self) -> Self::Output {
-///         let BooleanVector(lhs) = self;
+///     fn bitxor(self, Self(rhs): Self) -> Self::Output {
+///         let Self(lhs) = self;
 ///         assert_eq!(lhs.len(), rhs.len());
-///         BooleanVector(lhs.iter()
-///                          .zip(rhs.iter())
-///                          .map(|(x, y)| (*x || *y) && !(*x && *y))
-///                          .collect())
+///         Self(lhs.iter()
+///                 .zip(rhs.iter())
+///                 .map(|(x, y)| (*x || *y) && !(*x && *y))
+///                 .collect())
 ///     }
 /// }
 ///
@@ -375,9 +378,9 @@ bitxor_impl! { bool usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 }
 /// impl Shl<Scalar> for Scalar {
 ///     type Output = Self;
 ///
-///     fn shl(self, Scalar(rhs): Self) -> Scalar {
-///         let Scalar(lhs) = self;
-///         Scalar(lhs << rhs)
+///     fn shl(self, Self(rhs): Self) -> Self::Output {
+///         let Self(lhs) = self;
+///         Self(lhs << rhs)
 ///     }
 /// }
 ///
@@ -400,10 +403,10 @@ bitxor_impl! { bool usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 }
 ///     fn shl(self, rhs: usize) -> Self::Output {
 ///         // Rotate the vector by `rhs` places.
 ///         let (a, b) = self.vec.split_at(rhs);
-///         let mut spun_vector: Vec<T> = vec![];
+///         let mut spun_vector = vec![];
 ///         spun_vector.extend_from_slice(b);
 ///         spun_vector.extend_from_slice(a);
-///         SpinVector { vec: spun_vector }
+///         Self { vec: spun_vector }
 ///     }
 /// }
 ///
@@ -493,9 +496,9 @@ shl_impl_all! { u8 u16 u32 u64 u128 usize i8 i16 i32 i64 isize i128 }
 /// impl Shr<Scalar> for Scalar {
 ///     type Output = Self;
 ///
-///     fn shr(self, Scalar(rhs): Self) -> Scalar {
-///         let Scalar(lhs) = self;
-///         Scalar(lhs >> rhs)
+///     fn shr(self, Self(rhs): Self) -> Self::Output {
+///         let Self(lhs) = self;
+///         Self(lhs >> rhs)
 ///     }
 /// }
 ///
@@ -518,10 +521,10 @@ shl_impl_all! { u8 u16 u32 u64 u128 usize i8 i16 i32 i64 isize i128 }
 ///     fn shr(self, rhs: usize) -> Self::Output {
 ///         // Rotate the vector by `rhs` places.
 ///         let (a, b) = self.vec.split_at(self.vec.len() - rhs);
-///         let mut spun_vector: Vec<T> = vec![];
+///         let mut spun_vector = vec![];
 ///         spun_vector.extend_from_slice(b);
 ///         spun_vector.extend_from_slice(a);
-///         SpinVector { vec: spun_vector }
+///         Self { vec: spun_vector }
 ///     }
 /// }
 ///
@@ -606,7 +609,7 @@ shr_impl_all! { u8 u16 u32 u64 u128 usize i8 i16 i32 i64 i128 isize }
 /// impl BitAndAssign for Scalar {
 ///     // rhs is the "right-hand side" of the expression `a &= b`
 ///     fn bitand_assign(&mut self, rhs: Self) {
-///         *self = Scalar(self.0 & rhs.0)
+///         *self = Self(self.0 & rhs.0)
 ///     }
 /// }
 ///
@@ -640,11 +643,11 @@ shr_impl_all! { u8 u16 u32 u64 u128 usize i8 i16 i32 i64 i128 isize }
 ///     // `rhs` is the "right-hand side" of the expression `a &= b`.
 ///     fn bitand_assign(&mut self, rhs: Self) {
 ///         assert_eq!(self.0.len(), rhs.0.len());
-///         *self = BooleanVector(self.0
-///                                   .iter()
-///                                   .zip(rhs.0.iter())
-///                                   .map(|(x, y)| *x && *y)
-///                                   .collect());
+///         *self = Self(self.0
+///                          .iter()
+///                          .zip(rhs.0.iter())
+///                          .map(|(x, y)| *x && *y)
+///                          .collect());
 ///     }
 /// }
 ///

--- a/library/core/src/ops/mod.rs
+++ b/library/core/src/ops/mod.rs
@@ -49,18 +49,18 @@
 //! }
 //!
 //! impl Add for Point {
-//!     type Output = Point;
+//!     type Output = Self;
 //!
-//!     fn add(self, other: Point) -> Point {
-//!         Point {x: self.x + other.x, y: self.y + other.y}
+//!     fn add(self, other: Self) -> Self {
+//!         Self {x: self.x + other.x, y: self.y + other.y}
 //!     }
 //! }
 //!
 //! impl Sub for Point {
-//!     type Output = Point;
+//!     type Output = Self;
 //!
-//!     fn sub(self, other: Point) -> Point {
-//!         Point {x: self.x - other.x, y: self.y - other.y}
+//!     fn sub(self, other: Self) -> Self {
+//!         Self {x: self.x - other.x, y: self.y - other.y}
 //!     }
 //! }
 //!


### PR DESCRIPTION
Fixes #76542.

I used `rg '\s*//[!/]\s+fn [\w_]+\(&?self, ' .` in `library/` to find instances, I found some with that and some by manually checking.

@rustbot modify labels: C-enhancement T-doc