### PR TITLE
revert const_type_id stabilization

### DIFF
--- a/library/core/src/any.rs
+++ b/library/core/src/any.rs
@@ -435,7 +435,7 @@ impl TypeId {
     /// assert_eq!(is_string(&"cookie monster".to_string()), true);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_const_unstable(feature = "const_type_id", issue = "63084")]
+    #[rustc_const_unstable(feature = "const_type_id", issue = "77125")]
     pub const fn of<T: ?Sized + 'static>() -> TypeId {
         TypeId { t: intrinsics::type_id::<T>() }
     }

--- a/library/core/src/any.rs
+++ b/library/core/src/any.rs
@@ -435,7 +435,7 @@ impl TypeId {
     /// assert_eq!(is_string(&"cookie monster".to_string()), true);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_const_stable(feature = "const_type_id", since = "1.46.0")]
+    #[rustc_const_unstable(feature = "const_type_id", issue = "63084")]
     pub const fn of<T: ?Sized + 'static>() -> TypeId {
         TypeId { t: intrinsics::type_id::<T>() }
     }

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -807,7 +807,7 @@ extern "rust-intrinsic" {
     /// crate it is invoked in.
     ///
     /// The stabilized version of this intrinsic is [`crate::any::TypeId::of`].
-    #[rustc_const_unstable(feature = "const_type_id", issue = "63084")]
+    #[rustc_const_unstable(feature = "const_type_id", issue = "77125")]
     pub fn type_id<T: ?Sized + 'static>() -> u64;
 
     /// A guard for unsafe functions that cannot ever be executed if `T` is uninhabited:

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -807,7 +807,7 @@ extern "rust-intrinsic" {
     /// crate it is invoked in.
     ///
     /// The stabilized version of this intrinsic is [`crate::any::TypeId::of`].
-    #[rustc_const_stable(feature = "const_type_id", since = "1.46.0")]
+    #[rustc_const_unstable(feature = "const_type_id", issue = "63084")]
     pub fn type_id<T: ?Sized + 'static>() -> u64;
 
     /// A guard for unsafe functions that cannot ever be executed if `T` is uninhabited:

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -90,6 +90,7 @@
 #![feature(const_slice_ptr_len)]
 #![feature(const_size_of_val)]
 #![feature(const_align_of_val)]
+#![feature(const_type_id)]
 #![feature(const_type_name)]
 #![feature(const_likely)]
 #![feature(const_unreachable_unchecked)]

--- a/src/test/ui/consts/const-typeid-of-rpass.rs
+++ b/src/test/ui/consts/const-typeid-of-rpass.rs
@@ -1,4 +1,5 @@
 // run-pass
+#![feature(const_type_id)]
 #![feature(core_intrinsics)]
 
 use std::any::TypeId;

--- a/src/test/ui/consts/issue-73976-monomorphic.rs
+++ b/src/test/ui/consts/issue-73976-monomorphic.rs
@@ -5,6 +5,7 @@
 // will be properly rejected. This test will ensure that monomorphic use of these
 // would not be wrongly rejected in patterns.
 
+#![feature(const_type_id)]
 #![feature(const_type_name)]
 
 use std::any::{self, TypeId};

--- a/src/test/ui/consts/issue-73976-polymorphic.rs
+++ b/src/test/ui/consts/issue-73976-polymorphic.rs
@@ -5,6 +5,7 @@
 // This test case should either run-pass or be rejected at compile time.
 // Currently we just disallow this usage and require pattern is monomorphic.
 
+#![feature(const_type_id)]
 #![feature(const_type_name)]
 
 use std::any::{self, TypeId};

--- a/src/test/ui/consts/issue-73976-polymorphic.stderr
+++ b/src/test/ui/consts/issue-73976-polymorphic.stderr
@@ -1,23 +1,23 @@
 error: constant pattern depends on a generic parameter
-  --> $DIR/issue-73976-polymorphic.rs:19:37
+  --> $DIR/issue-73976-polymorphic.rs:20:37
    |
 LL |     matches!(GetTypeId::<T>::VALUE, GetTypeId::<T>::VALUE)
    |                                     ^^^^^^^^^^^^^^^^^^^^^
 
 error: constant pattern depends on a generic parameter
-  --> $DIR/issue-73976-polymorphic.rs:31:42
+  --> $DIR/issue-73976-polymorphic.rs:32:42
    |
 LL |     matches!(GetTypeNameLen::<T>::VALUE, GetTypeNameLen::<T>::VALUE)
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: constant pattern depends on a generic parameter
-  --> $DIR/issue-73976-polymorphic.rs:19:37
+  --> $DIR/issue-73976-polymorphic.rs:20:37
    |
 LL |     matches!(GetTypeId::<T>::VALUE, GetTypeId::<T>::VALUE)
    |                                     ^^^^^^^^^^^^^^^^^^^^^
 
 error: constant pattern depends on a generic parameter
-  --> $DIR/issue-73976-polymorphic.rs:31:42
+  --> $DIR/issue-73976-polymorphic.rs:32:42
    |
 LL |     matches!(GetTypeNameLen::<T>::VALUE, GetTypeNameLen::<T>::VALUE)
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
This reverts #72488, which is currently on beta and scheduled to stabilize in `1.47.0`, based on https://github.com/rust-lang/rust/pull/75923#issuecomment-696676511

It turns out we might not be quite ready to stabilize `TypeId` in const contexts before having a chance to rework its internals. Since `TypeId` is a bit of an oddity we want to be careful about how those internals are currently being relied on while making changes. That will be easier to do without having to also consider compile-time contexts.

r? @eddyb 