### PR TITLE
Include libunwind in the rust-src component.

### DIFF
--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -1022,7 +1022,7 @@ impl Step for Src {
         copy_src_dirs(
             builder,
             &builder.src,
-            &["library"],
+            &["library", "src/llvm-project/libunwind"],
             &[
                 // not needed and contains symlinks which rustup currently
                 // chokes on when unpacking.


### PR DESCRIPTION
Some targets, such as musl, need the libunwind source to build the unwind crate (referenced [here](https://github.com/rust-lang/rust/blob/0da58007451a154da2480160429e1604a1f5f0ec/library/unwind/build.rs#L142)).

Fixes rust-lang/wg-cargo-std-aware#59