### PR TITLE
clarify that `changelog-seen = 1` goes to the beginning of config.toml

### DIFF
--- a/src/bootstrap/bin/main.rs
+++ b/src/bootstrap/bin/main.rs
@@ -40,7 +40,7 @@ fn check_version(config: &Config) -> Option<String> {
         }
     } else {
         msg.push_str("warning: x.py has made several changes recently you may want to look at\n");
-        format!("add `changelog-seen = {}` to `config.toml`", VERSION)
+        format!("add `changelog-seen = {}` at the top of `config.toml`", VERSION)
     };
 
     msg.push_str("help: consider looking at the changes in `src/bootstrap/CHANGELOG.md`\n");


### PR DESCRIPTION
Fixes #77105