### PR TITLE
Add `--keep-stage-std` to `x.py` for keeping only standard library artifacts

### DIFF
--- a/src/bootstrap/CHANGELOG.md
+++ b/src/bootstrap/CHANGELOG.md
@@ -15,6 +15,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Make the default stage for x.py configurable [#76625](https://github.com/rust-lang/rust/pull/76625)
 - Add a dedicated debug-logging option [#76588](https://github.com/rust-lang/rust/pull/76588)
 - Add sample defaults for x.py [#76628](https://github.com/rust-lang/rust/pull/76628)
+- Add `--keep-stage-std`, which behaves like `keep-stage` but allows the stage
+  0 compiler artifacts (i.e., stage1/bin/rustc) to be rebuilt if changed
+  [#77120](https://github.com/rust-lang/rust/pull/77120).
+
 
 ## [Version 0] - 2020-09-11
 

--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -59,7 +59,9 @@ impl Step for Std {
         let target = self.target;
         let compiler = self.compiler;
 
-        if builder.config.keep_stage.contains(&compiler.stage) {
+        if builder.config.keep_stage.contains(&compiler.stage)
+            || builder.config.keep_stage_std.contains(&compiler.stage)
+        {
             builder.info("Warning: Using a potentially old libstd. This may not behave well.");
             builder.ensure(StdLink { compiler, target_compiler: compiler, target });
             return;
@@ -472,6 +474,11 @@ impl Step for Rustc {
 
         if builder.config.keep_stage.contains(&compiler.stage) {
             builder.info("Warning: Using a potentially old librustc. This may not behave well.");
+            builder.info("Warning: Use `--keep-stage-std` if you want to rebuild the compiler when it changes");
+            builder.info(
+                "Warning: Please file a GitHub issue if `--keep-stage-std` doesn't work for you.",
+            );
+            builder.info("Warning: It may replace `--keep-stage` in the future");
             builder.ensure(RustcLink { compiler, target_compiler: compiler, target });
             return;
         }

--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -475,10 +475,6 @@ impl Step for Rustc {
         if builder.config.keep_stage.contains(&compiler.stage) {
             builder.info("Warning: Using a potentially old librustc. This may not behave well.");
             builder.info("Warning: Use `--keep-stage-std` if you want to rebuild the compiler when it changes");
-            builder.info(
-                "Warning: Please file a GitHub issue if `--keep-stage-std` doesn't work for you.",
-            );
-            builder.info("Warning: It may replace `--keep-stage` in the future");
             builder.ensure(RustcLink { compiler, target_compiler: compiler, target });
             return;
         }

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -71,6 +71,7 @@ pub struct Config {
     pub on_fail: Option<String>,
     pub stage: u32,
     pub keep_stage: Vec<u32>,
+    pub keep_stage_std: Vec<u32>,
     pub src: PathBuf,
     pub jobs: Option<u32>,
     pub cmd: Subcommand,
@@ -539,6 +540,7 @@ impl Config {
         config.incremental = flags.incremental;
         config.dry_run = flags.dry_run;
         config.keep_stage = flags.keep_stage;
+        config.keep_stage_std = flags.keep_stage_std;
         config.bindir = "bin".into(); // default
         if let Some(value) = flags.deny_warnings {
             config.deny_warnings = value;

--- a/src/bootstrap/flags.rs
+++ b/src/bootstrap/flags.rs
@@ -19,6 +19,7 @@ pub struct Flags {
     pub on_fail: Option<String>,
     pub stage: Option<u32>,
     pub keep_stage: Vec<u32>,
+    pub keep_stage_std: Vec<u32>,
 
     pub host: Option<Vec<TargetSelection>>,
     pub target: Option<Vec<TargetSelection>>,
@@ -141,6 +142,13 @@ To learn more about a subcommand, run `./x.py <subcommand> -h`",
             "",
             "keep-stage",
             "stage(s) to keep without recompiling \
+            (pass multiple times to keep e.g., both stages 0 and 1)",
+            "N",
+        );
+        opts.optmulti(
+            "",
+            "keep-stage-std",
+            "stage(s) of the standard library to keep without recompiling \
             (pass multiple times to keep e.g., both stages 0 and 1)",
             "N",
         );
@@ -510,7 +518,9 @@ Arguments:
                 println!("--stage not supported for x.py check, always treated as stage 0");
                 process::exit(1);
             }
-            if matches.opt_str("keep-stage").is_some() {
+            if matches.opt_str("keep-stage").is_some()
+                || matches.opt_str("keep-stage-std").is_some()
+            {
                 println!("--keep-stage not supported for x.py check, only one stage available");
                 process::exit(1);
             }
@@ -527,6 +537,11 @@ Arguments:
                 .opt_strs("keep-stage")
                 .into_iter()
                 .map(|j| j.parse().expect("`keep-stage` should be a number"))
+                .collect(),
+            keep_stage_std: matches
+                .opt_strs("keep-stage-std")
+                .into_iter()
+                .map(|j| j.parse().expect("`keep-stage-std` should be a number"))
                 .collect(),
             host: if matches.opt_present("host") {
                 Some(


### PR DESCRIPTION
Unlike `--keep-stage 0`, `--keep-stage-std 0` will allow the stage 0 compiler artifacts (i.e., stage1/bin/rustc) to be rebuilt if it has changed. This allows contributors to iterate on later stages of the compiler in tandem with the standard library without needing to to rebuild the entire compiler. I often run into this when working on const-checking, since I may need to add a feature gate or make a small tweak to the standard library.