### PR TITLE
Add `#![feature(const_fn_floating_point_arithmetic)]`

### DIFF
--- a/compiler/rustc_feature/src/active.rs
+++ b/compiler/rustc_feature/src/active.rs
@@ -585,7 +585,7 @@ declare_features! (
     (active, const_evaluatable_checked, "1.48.0", Some(76560), None),
 
     /// Allows basic arithmetic on floating point types in a `const fn`.
-    (active, const_fn_floating_point_arithmetic, "1.48.0", Some(57563), None),
+    (active, const_fn_floating_point_arithmetic, "1.48.0", Some(57241), None),
 
     // -------------------------------------------------------------------------
     // feature-group-end: actual feature gates

--- a/compiler/rustc_feature/src/active.rs
+++ b/compiler/rustc_feature/src/active.rs
@@ -584,6 +584,9 @@ declare_features! (
     /// Allows non trivial generic constants which have to be manually propageted upwards.
     (active, const_evaluatable_checked, "1.48.0", Some(76560), None),
 
+    /// Allows basic arithmetic on floating point types in a `const fn`.
+    (active, const_fn_floating_point_arithmetic, "1.48.0", Some(57563), None),
+
     // -------------------------------------------------------------------------
     // feature-group-end: actual feature gates
     // -------------------------------------------------------------------------

--- a/compiler/rustc_mir/src/transform/check_consts/ops.rs
+++ b/compiler/rustc_mir/src/transform/check_consts/ops.rs
@@ -113,6 +113,30 @@ impl NonConstOp for Abort {
 }
 
 #[derive(Debug)]
+pub struct FloatingPointOp;
+impl NonConstOp for FloatingPointOp {
+    const STOPS_CONST_CHECKING: bool = true;
+
+    fn status_in_item(&self, ccx: &ConstCx<'_, '_>) -> Status {
+        if ccx.const_kind() == hir::ConstContext::ConstFn {
+            Status::Unstable(sym::const_fn_floating_point_arithmetic)
+        } else {
+            Status::Allowed
+        }
+    }
+
+    fn emit_error(&self, ccx: &ConstCx<'_, '_>, span: Span) {
+        feature_err(
+            &ccx.tcx.sess.parse_sess,
+            sym::const_fn_floating_point_arithmetic,
+            span,
+            &format!("floating point arithmetic is not allowed in {}s", ccx.const_kind()),
+        )
+        .emit();
+    }
+}
+
+#[derive(Debug)]
 pub struct NonPrimitiveOp;
 impl NonConstOp for NonPrimitiveOp {
     const STOPS_CONST_CHECKING: bool = true;

--- a/compiler/rustc_mir/src/transform/check_consts/validation.rs
+++ b/compiler/rustc_mir/src/transform/check_consts/validation.rs
@@ -540,8 +540,12 @@ impl Visitor<'tcx> for Validator<'mir, 'tcx> {
 
             Rvalue::UnaryOp(_, ref operand) => {
                 let ty = operand.ty(self.body, self.tcx);
-                if !(ty.is_integral() || ty.is_bool()) {
-                    self.check_op(ops::NonPrimitiveOp)
+                if is_int_bool_or_char(ty) {
+                    // Int, bool, and char operations are fine.
+                } else if ty.is_floating_point() {
+                    self.check_op(ops::FloatingPointOp);
+                } else {
+                    span_bug!(self.span, "non-primitive type in `Rvalue::UnaryOp`: {:?}", ty);
                 }
             }
 
@@ -550,7 +554,9 @@ impl Visitor<'tcx> for Validator<'mir, 'tcx> {
                 let lhs_ty = lhs.ty(self.body, self.tcx);
                 let rhs_ty = rhs.ty(self.body, self.tcx);
 
-                if let ty::RawPtr(_) | ty::FnPtr(..) = lhs_ty.kind() {
+                if is_int_bool_or_char(lhs_ty) && is_int_bool_or_char(rhs_ty) {
+                    // Int, bool, and char operations are fine.
+                } else if lhs_ty.is_fn_ptr() || lhs_ty.is_unsafe_ptr() {
                     assert_eq!(lhs_ty, rhs_ty);
                     assert!(
                         op == BinOp::Eq
@@ -563,12 +569,15 @@ impl Visitor<'tcx> for Validator<'mir, 'tcx> {
                     );
 
                     self.check_op(ops::RawPtrComparison);
-                }
-
-                if !(lhs_ty.is_integral() || lhs_ty.is_bool() || lhs_ty.is_char())
-                    || !(rhs_ty.is_integral() || rhs_ty.is_bool() || rhs_ty.is_char())
-                {
-                    self.check_op(ops::NonPrimitiveOp)
+                } else if lhs_ty.is_floating_point() || rhs_ty.is_floating_point() {
+                    self.check_op(ops::FloatingPointOp);
+                } else {
+                    span_bug!(
+                        self.span,
+                        "non-primitive type in `Rvalue::BinaryOp`: {:?} ⚬ {:?}",
+                        lhs_ty,
+                        rhs_ty
+                    );
                 }
             }
         }
@@ -866,4 +875,8 @@ fn place_as_reborrow(
             _ => None,
         }
     })
+}
+
+fn is_int_bool_or_char(ty: Ty<'_>) -> bool {
+    ty.is_bool() || ty.is_integral() || ty.is_char()
 }

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -351,6 +351,7 @@ symbols! {
         const_evaluatable_checked,
         const_extern_fn,
         const_fn,
+        const_fn_floating_point_arithmetic,
         const_fn_transmute,
         const_fn_union,
         const_generics,

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -82,6 +82,7 @@
 #![feature(const_pin)]
 #![feature(const_fn_union)]
 #![feature(const_fn)]
+#![cfg_attr(not(bootstrap), feature(const_fn_floating_point_arithmetic))]
 #![feature(const_generics)]
 #![feature(const_option)]
 #![feature(const_precise_live_drops)]

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -236,6 +236,7 @@
 #![feature(clamp)]
 #![feature(concat_idents)]
 #![feature(const_cstr_unchecked)]
+#![cfg_attr(not(bootstrap), feature(const_fn_floating_point_arithmetic))]
 #![feature(const_fn_transmute)]
 #![feature(const_fn)]
 #![feature(const_ip)]

--- a/src/test/ui/consts/const-extern-fn/const-extern-fn-min-const-fn.rs
+++ b/src/test/ui/consts/const-extern-fn/const-extern-fn-min-const-fn.rs
@@ -4,7 +4,7 @@ const extern fn unsize(x: &[u8; 3]) -> &[u8] { x }
 const unsafe extern "C" fn closure() -> fn() { || {} }
 //~^ ERROR function pointers in const fn are unstable
 const unsafe extern fn use_float() { 1.0 + 1.0; }
-//~^ ERROR only int, `bool` and `char` operations are stable in const fn
+//~^ ERROR floating point arithmetic
 const extern "C" fn ptr_cast(val: *const u8) { val as usize; }
 //~^ ERROR casting pointers to integers
 

--- a/src/test/ui/consts/const-extern-fn/const-extern-fn-min-const-fn.stderr
+++ b/src/test/ui/consts/const-extern-fn/const-extern-fn-min-const-fn.stderr
@@ -13,7 +13,7 @@ error[E0658]: floating point arithmetic is not allowed in constant functions
 LL | const unsafe extern fn use_float() { 1.0 + 1.0; }
    |                                      ^^^^^^^^^
    |
-   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
+   = note: see issue #57241 <https://github.com/rust-lang/rust/issues/57241> for more information
    = help: add `#![feature(const_fn_floating_point_arithmetic)]` to the crate attributes to enable
 
 error[E0658]: casting pointers to integers in constant functions is unstable

--- a/src/test/ui/consts/const-extern-fn/const-extern-fn-min-const-fn.stderr
+++ b/src/test/ui/consts/const-extern-fn/const-extern-fn-min-const-fn.stderr
@@ -7,14 +7,14 @@ LL | const unsafe extern "C" fn closure() -> fn() { || {} }
    = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
-error[E0723]: only int, `bool` and `char` operations are stable in const fn
+error[E0658]: floating point arithmetic is not allowed in constant functions
   --> $DIR/const-extern-fn-min-const-fn.rs:6:38
    |
 LL | const unsafe extern fn use_float() { 1.0 + 1.0; }
    |                                      ^^^^^^^^^
    |
    = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
-   = help: add `#![feature(const_fn)]` to the crate attributes to enable
+   = help: add `#![feature(const_fn_floating_point_arithmetic)]` to the crate attributes to enable
 
 error[E0658]: casting pointers to integers in constant functions is unstable
   --> $DIR/const-extern-fn-min-const-fn.rs:8:48

--- a/src/test/ui/consts/const_fn_floating_point_arithmetic.gated.stderr
+++ b/src/test/ui/consts/const_fn_floating_point_arithmetic.gated.stderr
@@ -1,0 +1,8 @@
+error: fatal error triggered by #[rustc_error]
+  --> $DIR/const_fn_floating_point_arithmetic.rs:20:1
+   |
+LL | fn main() {}
+   | ^^^^^^^^^
+
+error: aborting due to previous error
+

--- a/src/test/ui/consts/const_fn_floating_point_arithmetic.rs
+++ b/src/test/ui/consts/const_fn_floating_point_arithmetic.rs
@@ -1,0 +1,20 @@
+// gate-test-const_fn_floating_point_arithmetic
+
+// revisions: stock gated
+
+#![feature(rustc_attrs)]
+#![cfg_attr(gated, feature(const_fn_floating_point_arithmetic))]
+
+const fn add(f: f32) -> f32 { f + 2.0 }
+//[stock]~^ floating point arithmetic
+const fn sub(f: f32) -> f32 { 2.0 - f }
+//[stock]~^ floating point arithmetic
+const fn mul(f: f32, g: f32) -> f32 { f * g }
+//[stock]~^ floating point arithmetic
+const fn div(f: f32, g: f32) -> f32 { f / g }
+//[stock]~^ floating point arithmetic
+const fn neg(f: f32) -> f32 { -f }
+//[stock]~^ floating point arithmetic
+
+#[rustc_error]
+fn main() {} //[gated]~ fatal error triggered by #[rustc_error]

--- a/src/test/ui/consts/const_fn_floating_point_arithmetic.stock.stderr
+++ b/src/test/ui/consts/const_fn_floating_point_arithmetic.stock.stderr
@@ -4,7 +4,7 @@ error[E0658]: floating point arithmetic is not allowed in constant functions
 LL | const fn add(f: f32) -> f32 { f + 2.0 }
    |                               ^^^^^^^
    |
-   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
+   = note: see issue #57241 <https://github.com/rust-lang/rust/issues/57241> for more information
    = help: add `#![feature(const_fn_floating_point_arithmetic)]` to the crate attributes to enable
 
 error[E0658]: floating point arithmetic is not allowed in constant functions
@@ -13,7 +13,7 @@ error[E0658]: floating point arithmetic is not allowed in constant functions
 LL | const fn sub(f: f32) -> f32 { 2.0 - f }
    |                               ^^^^^^^
    |
-   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
+   = note: see issue #57241 <https://github.com/rust-lang/rust/issues/57241> for more information
    = help: add `#![feature(const_fn_floating_point_arithmetic)]` to the crate attributes to enable
 
 error[E0658]: floating point arithmetic is not allowed in constant functions
@@ -22,7 +22,7 @@ error[E0658]: floating point arithmetic is not allowed in constant functions
 LL | const fn mul(f: f32, g: f32) -> f32 { f * g }
    |                                       ^^^^^
    |
-   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
+   = note: see issue #57241 <https://github.com/rust-lang/rust/issues/57241> for more information
    = help: add `#![feature(const_fn_floating_point_arithmetic)]` to the crate attributes to enable
 
 error[E0658]: floating point arithmetic is not allowed in constant functions
@@ -31,7 +31,7 @@ error[E0658]: floating point arithmetic is not allowed in constant functions
 LL | const fn div(f: f32, g: f32) -> f32 { f / g }
    |                                       ^^^^^
    |
-   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
+   = note: see issue #57241 <https://github.com/rust-lang/rust/issues/57241> for more information
    = help: add `#![feature(const_fn_floating_point_arithmetic)]` to the crate attributes to enable
 
 error[E0658]: floating point arithmetic is not allowed in constant functions
@@ -40,7 +40,7 @@ error[E0658]: floating point arithmetic is not allowed in constant functions
 LL | const fn neg(f: f32) -> f32 { -f }
    |                               ^^
    |
-   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
+   = note: see issue #57241 <https://github.com/rust-lang/rust/issues/57241> for more information
    = help: add `#![feature(const_fn_floating_point_arithmetic)]` to the crate attributes to enable
 
 error: aborting due to 5 previous errors

--- a/src/test/ui/consts/const_fn_floating_point_arithmetic.stock.stderr
+++ b/src/test/ui/consts/const_fn_floating_point_arithmetic.stock.stderr
@@ -1,0 +1,48 @@
+error[E0658]: floating point arithmetic is not allowed in constant functions
+  --> $DIR/const_fn_floating_point_arithmetic.rs:8:31
+   |
+LL | const fn add(f: f32) -> f32 { f + 2.0 }
+   |                               ^^^^^^^
+   |
+   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
+   = help: add `#![feature(const_fn_floating_point_arithmetic)]` to the crate attributes to enable
+
+error[E0658]: floating point arithmetic is not allowed in constant functions
+  --> $DIR/const_fn_floating_point_arithmetic.rs:10:31
+   |
+LL | const fn sub(f: f32) -> f32 { 2.0 - f }
+   |                               ^^^^^^^
+   |
+   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
+   = help: add `#![feature(const_fn_floating_point_arithmetic)]` to the crate attributes to enable
+
+error[E0658]: floating point arithmetic is not allowed in constant functions
+  --> $DIR/const_fn_floating_point_arithmetic.rs:12:39
+   |
+LL | const fn mul(f: f32, g: f32) -> f32 { f * g }
+   |                                       ^^^^^
+   |
+   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
+   = help: add `#![feature(const_fn_floating_point_arithmetic)]` to the crate attributes to enable
+
+error[E0658]: floating point arithmetic is not allowed in constant functions
+  --> $DIR/const_fn_floating_point_arithmetic.rs:14:39
+   |
+LL | const fn div(f: f32, g: f32) -> f32 { f / g }
+   |                                       ^^^^^
+   |
+   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
+   = help: add `#![feature(const_fn_floating_point_arithmetic)]` to the crate attributes to enable
+
+error[E0658]: floating point arithmetic is not allowed in constant functions
+  --> $DIR/const_fn_floating_point_arithmetic.rs:16:31
+   |
+LL | const fn neg(f: f32) -> f32 { -f }
+   |                               ^^
+   |
+   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
+   = help: add `#![feature(const_fn_floating_point_arithmetic)]` to the crate attributes to enable
+
+error: aborting due to 5 previous errors
+
+For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/consts/const_let_eq_float.rs
+++ b/src/test/ui/consts/const_let_eq_float.rs
@@ -1,6 +1,6 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// run-pass
 
-#![feature(const_fn)]
+#![feature(const_fn_floating_point_arithmetic)]
 
 struct Foo<T>(T);
 struct Bar<T> { x: T }

--- a/src/test/ui/consts/min_const_fn/min_const_fn.rs
+++ b/src/test/ui/consts/min_const_fn/min_const_fn.rs
@@ -77,14 +77,6 @@ const fn foo11<T: std::fmt::Display>(t: T) -> T { t }
 //~^ ERROR trait bounds other than `Sized` on const fn parameters are unstable
 const fn foo11_2<T: Send>(t: T) -> T { t }
 //~^ ERROR trait bounds other than `Sized` on const fn parameters are unstable
-const fn foo19(f: f32) -> f32 { f * 2.0 }
-//~^ ERROR floating point arithmetic
-const fn foo19_2(f: f32) -> f32 { 2.0 - f }
-//~^ ERROR floating point arithmetic
-const fn foo19_3(f: f32) -> f32 { -f }
-//~^ ERROR floating point arithmetic
-const fn foo19_4(f: f32, g: f32) -> f32 { f / g }
-//~^ ERROR floating point arithmetic
 
 static BAR: u32 = 42;
 const fn foo25() -> u32 { BAR } //~ ERROR cannot refer to statics

--- a/src/test/ui/consts/min_const_fn/min_const_fn.rs
+++ b/src/test/ui/consts/min_const_fn/min_const_fn.rs
@@ -78,13 +78,13 @@ const fn foo11<T: std::fmt::Display>(t: T) -> T { t }
 const fn foo11_2<T: Send>(t: T) -> T { t }
 //~^ ERROR trait bounds other than `Sized` on const fn parameters are unstable
 const fn foo19(f: f32) -> f32 { f * 2.0 }
-//~^ ERROR int, `bool` and `char` operations
+//~^ ERROR floating point arithmetic
 const fn foo19_2(f: f32) -> f32 { 2.0 - f }
-//~^ ERROR int, `bool` and `char` operations
+//~^ ERROR floating point arithmetic
 const fn foo19_3(f: f32) -> f32 { -f }
-//~^ ERROR int, `bool` and `char` operations
+//~^ ERROR floating point arithmetic
 const fn foo19_4(f: f32, g: f32) -> f32 { f / g }
-//~^ ERROR int, `bool` and `char` operations
+//~^ ERROR floating point arithmetic
 
 static BAR: u32 = 42;
 const fn foo25() -> u32 { BAR } //~ ERROR cannot refer to statics

--- a/src/test/ui/consts/min_const_fn/min_const_fn.stderr
+++ b/src/test/ui/consts/min_const_fn/min_const_fn.stderr
@@ -76,44 +76,8 @@ LL | const fn foo11_2<T: Send>(t: T) -> T { t }
    = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
-error[E0658]: floating point arithmetic is not allowed in constant functions
-  --> $DIR/min_const_fn.rs:80:33
-   |
-LL | const fn foo19(f: f32) -> f32 { f * 2.0 }
-   |                                 ^^^^^^^
-   |
-   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
-   = help: add `#![feature(const_fn_floating_point_arithmetic)]` to the crate attributes to enable
-
-error[E0658]: floating point arithmetic is not allowed in constant functions
-  --> $DIR/min_const_fn.rs:82:35
-   |
-LL | const fn foo19_2(f: f32) -> f32 { 2.0 - f }
-   |                                   ^^^^^^^
-   |
-   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
-   = help: add `#![feature(const_fn_floating_point_arithmetic)]` to the crate attributes to enable
-
-error[E0658]: floating point arithmetic is not allowed in constant functions
-  --> $DIR/min_const_fn.rs:84:35
-   |
-LL | const fn foo19_3(f: f32) -> f32 { -f }
-   |                                   ^^
-   |
-   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
-   = help: add `#![feature(const_fn_floating_point_arithmetic)]` to the crate attributes to enable
-
-error[E0658]: floating point arithmetic is not allowed in constant functions
-  --> $DIR/min_const_fn.rs:86:43
-   |
-LL | const fn foo19_4(f: f32, g: f32) -> f32 { f / g }
-   |                                           ^^^^^
-   |
-   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
-   = help: add `#![feature(const_fn_floating_point_arithmetic)]` to the crate attributes to enable
-
 error[E0013]: constant functions cannot refer to statics
-  --> $DIR/min_const_fn.rs:90:27
+  --> $DIR/min_const_fn.rs:82:27
    |
 LL | const fn foo25() -> u32 { BAR }
    |                           ^^^
@@ -121,7 +85,7 @@ LL | const fn foo25() -> u32 { BAR }
    = help: consider extracting the value of the `static` to a `const`, and referring to that
 
 error[E0013]: constant functions cannot refer to statics
-  --> $DIR/min_const_fn.rs:91:37
+  --> $DIR/min_const_fn.rs:83:37
    |
 LL | const fn foo26() -> &'static u32 { &BAR }
    |                                     ^^^
@@ -129,7 +93,7 @@ LL | const fn foo26() -> &'static u32 { &BAR }
    = help: consider extracting the value of the `static` to a `const`, and referring to that
 
 error[E0658]: casting pointers to integers in constant functions is unstable
-  --> $DIR/min_const_fn.rs:92:42
+  --> $DIR/min_const_fn.rs:84:42
    |
 LL | const fn foo30(x: *const u32) -> usize { x as usize }
    |                                          ^^^^^^^^^^
@@ -138,7 +102,7 @@ LL | const fn foo30(x: *const u32) -> usize { x as usize }
    = help: add `#![feature(const_raw_ptr_to_usize_cast)]` to the crate attributes to enable
 
 error[E0658]: casting pointers to integers in constant functions is unstable
-  --> $DIR/min_const_fn.rs:94:63
+  --> $DIR/min_const_fn.rs:86:63
    |
 LL | const fn foo30_with_unsafe(x: *const u32) -> usize { unsafe { x as usize } }
    |                                                               ^^^^^^^^^^
@@ -147,7 +111,7 @@ LL | const fn foo30_with_unsafe(x: *const u32) -> usize { unsafe { x as usize } 
    = help: add `#![feature(const_raw_ptr_to_usize_cast)]` to the crate attributes to enable
 
 error[E0658]: casting pointers to integers in constant functions is unstable
-  --> $DIR/min_const_fn.rs:96:42
+  --> $DIR/min_const_fn.rs:88:42
    |
 LL | const fn foo30_2(x: *mut u32) -> usize { x as usize }
    |                                          ^^^^^^^^^^
@@ -156,7 +120,7 @@ LL | const fn foo30_2(x: *mut u32) -> usize { x as usize }
    = help: add `#![feature(const_raw_ptr_to_usize_cast)]` to the crate attributes to enable
 
 error[E0658]: casting pointers to integers in constant functions is unstable
-  --> $DIR/min_const_fn.rs:98:63
+  --> $DIR/min_const_fn.rs:90:63
    |
 LL | const fn foo30_2_with_unsafe(x: *mut u32) -> usize { unsafe { x as usize } }
    |                                                               ^^^^^^^^^^
@@ -165,7 +129,7 @@ LL | const fn foo30_2_with_unsafe(x: *mut u32) -> usize { unsafe { x as usize } 
    = help: add `#![feature(const_raw_ptr_to_usize_cast)]` to the crate attributes to enable
 
 error[E0658]: mutable references are not allowed in constant functions
-  --> $DIR/min_const_fn.rs:101:14
+  --> $DIR/min_const_fn.rs:93:14
    |
 LL | const fn inc(x: &mut i32) { *x += 1 }
    |              ^
@@ -174,7 +138,7 @@ LL | const fn inc(x: &mut i32) { *x += 1 }
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
 
 error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable
-  --> $DIR/min_const_fn.rs:110:6
+  --> $DIR/min_const_fn.rs:102:6
    |
 LL | impl<T: std::fmt::Debug> Foo<T> {
    |      ^
@@ -183,7 +147,7 @@ LL | impl<T: std::fmt::Debug> Foo<T> {
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable
-  --> $DIR/min_const_fn.rs:115:6
+  --> $DIR/min_const_fn.rs:107:6
    |
 LL | impl<T: std::fmt::Debug + Sized> Foo<T> {
    |      ^
@@ -192,7 +156,7 @@ LL | impl<T: std::fmt::Debug + Sized> Foo<T> {
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable
-  --> $DIR/min_const_fn.rs:120:6
+  --> $DIR/min_const_fn.rs:112:6
    |
 LL | impl<T: Sync + Sized> Foo<T> {
    |      ^
@@ -201,7 +165,7 @@ LL | impl<T: Sync + Sized> Foo<T> {
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable
-  --> $DIR/min_const_fn.rs:126:34
+  --> $DIR/min_const_fn.rs:118:34
    |
 LL | const fn no_apit2(_x: AlanTuring<impl std::fmt::Debug>) {}
    |                                  ^^^^^^^^^^^^^^^^^^^^
@@ -210,7 +174,7 @@ LL | const fn no_apit2(_x: AlanTuring<impl std::fmt::Debug>) {}
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable
-  --> $DIR/min_const_fn.rs:128:22
+  --> $DIR/min_const_fn.rs:120:22
    |
 LL | const fn no_apit(_x: impl std::fmt::Debug) {}
    |                      ^^^^^^^^^^^^^^^^^^^^
@@ -219,7 +183,7 @@ LL | const fn no_apit(_x: impl std::fmt::Debug) {}
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable
-  --> $DIR/min_const_fn.rs:129:23
+  --> $DIR/min_const_fn.rs:121:23
    |
 LL | const fn no_dyn_trait(_x: &dyn std::fmt::Debug) {}
    |                       ^^
@@ -228,7 +192,7 @@ LL | const fn no_dyn_trait(_x: &dyn std::fmt::Debug) {}
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable
-  --> $DIR/min_const_fn.rs:130:32
+  --> $DIR/min_const_fn.rs:122:32
    |
 LL | const fn no_dyn_trait_ret() -> &'static dyn std::fmt::Debug { &() }
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -237,7 +201,7 @@ LL | const fn no_dyn_trait_ret() -> &'static dyn std::fmt::Debug { &() }
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable
-  --> $DIR/min_const_fn.rs:135:41
+  --> $DIR/min_const_fn.rs:127:41
    |
 LL | const fn really_no_traits_i_mean_it() { (&() as &dyn std::fmt::Debug, ()).1 }
    |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -246,7 +210,7 @@ LL | const fn really_no_traits_i_mean_it() { (&() as &dyn std::fmt::Debug, ()).1
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: function pointers in const fn are unstable
-  --> $DIR/min_const_fn.rs:138:21
+  --> $DIR/min_const_fn.rs:130:21
    |
 LL | const fn no_fn_ptrs(_x: fn()) {}
    |                     ^^
@@ -255,7 +219,7 @@ LL | const fn no_fn_ptrs(_x: fn()) {}
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: function pointers in const fn are unstable
-  --> $DIR/min_const_fn.rs:140:27
+  --> $DIR/min_const_fn.rs:132:27
    |
 LL | const fn no_fn_ptrs2() -> fn() { fn foo() {} foo }
    |                           ^^^^
@@ -263,7 +227,7 @@ LL | const fn no_fn_ptrs2() -> fn() { fn foo() {} foo }
    = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
-error: aborting due to 30 previous errors
+error: aborting due to 26 previous errors
 
 Some errors have detailed explanations: E0013, E0493, E0658, E0723.
 For more information about an error, try `rustc --explain E0013`.

--- a/src/test/ui/consts/min_const_fn/min_const_fn.stderr
+++ b/src/test/ui/consts/min_const_fn/min_const_fn.stderr
@@ -76,41 +76,41 @@ LL | const fn foo11_2<T: Send>(t: T) -> T { t }
    = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
-error[E0723]: only int, `bool` and `char` operations are stable in const fn
+error[E0658]: floating point arithmetic is not allowed in constant functions
   --> $DIR/min_const_fn.rs:80:33
    |
 LL | const fn foo19(f: f32) -> f32 { f * 2.0 }
    |                                 ^^^^^^^
    |
    = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
-   = help: add `#![feature(const_fn)]` to the crate attributes to enable
+   = help: add `#![feature(const_fn_floating_point_arithmetic)]` to the crate attributes to enable
 
-error[E0723]: only int, `bool` and `char` operations are stable in const fn
+error[E0658]: floating point arithmetic is not allowed in constant functions
   --> $DIR/min_const_fn.rs:82:35
    |
 LL | const fn foo19_2(f: f32) -> f32 { 2.0 - f }
    |                                   ^^^^^^^
    |
    = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
-   = help: add `#![feature(const_fn)]` to the crate attributes to enable
+   = help: add `#![feature(const_fn_floating_point_arithmetic)]` to the crate attributes to enable
 
-error[E0723]: only int, `bool` and `char` operations are stable in const fn
+error[E0658]: floating point arithmetic is not allowed in constant functions
   --> $DIR/min_const_fn.rs:84:35
    |
 LL | const fn foo19_3(f: f32) -> f32 { -f }
    |                                   ^^
    |
    = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
-   = help: add `#![feature(const_fn)]` to the crate attributes to enable
+   = help: add `#![feature(const_fn_floating_point_arithmetic)]` to the crate attributes to enable
 
-error[E0723]: only int, `bool` and `char` operations are stable in const fn
+error[E0658]: floating point arithmetic is not allowed in constant functions
   --> $DIR/min_const_fn.rs:86:43
    |
 LL | const fn foo19_4(f: f32, g: f32) -> f32 { f / g }
    |                                           ^^^^^
    |
    = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
-   = help: add `#![feature(const_fn)]` to the crate attributes to enable
+   = help: add `#![feature(const_fn_floating_point_arithmetic)]` to the crate attributes to enable
 
 error[E0013]: constant functions cannot refer to statics
   --> $DIR/min_const_fn.rs:90:27

--- a/src/test/ui/consts/min_const_fn/min_const_fn_libstd_stability.rs
+++ b/src/test/ui/consts/min_const_fn/min_const_fn_libstd_stability.rs
@@ -3,7 +3,7 @@
             we're apparently really bad at it",
             issue = "none")]
 
-#![feature(const_fn, foo, foo2)]
+#![feature(const_fn, const_fn_floating_point_arithmetic, foo, foo2)]
 #![feature(staged_api)]
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -25,9 +25,9 @@ const fn bar2() -> u32 { foo2() } //~ ERROR not yet stable as a const fn
 
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_const_stable(feature = "rust1", since = "1.0.0")]
-// conformity is required, even with `const_fn` feature gate
+// Const-stable functions cannot rely on unstable const-eval features.
 const fn bar3() -> u32 { (5f32 + 6f32) as u32 }
-//~^ ERROR const-stable function cannot use `#[feature(const_fn)]`
+//~^ ERROR const-stable function cannot use `#[feature(const_fn_floating_point_arithmetic)]`
 
 // check whether this function cannot be called even with the feature gate active
 #[unstable(feature = "foo2", issue = "none")]

--- a/src/test/ui/consts/min_const_fn/min_const_fn_libstd_stability.stderr
+++ b/src/test/ui/consts/min_const_fn/min_const_fn_libstd_stability.stderr
@@ -14,7 +14,7 @@ LL | const fn bar2() -> u32 { foo2() }
    |
    = help: Const-stable functions can only call other const-stable functions
 
-error: const-stable function cannot use `#[feature(const_fn)]`
+error: const-stable function cannot use `#[feature(const_fn_floating_point_arithmetic)]`
   --> $DIR/min_const_fn_libstd_stability.rs:29:26
    |
 LL | const fn bar3() -> u32 { (5f32 + 6f32) as u32 }

--- a/src/test/ui/consts/min_const_fn/min_const_unsafe_fn_libstd_stability.rs
+++ b/src/test/ui/consts/min_const_fn/min_const_unsafe_fn_libstd_stability.rs
@@ -3,7 +3,7 @@
             we're apparently really bad at it",
             issue = "none")]
 
-#![feature(const_fn, foo, foo2)]
+#![feature(const_fn, const_fn_floating_point_arithmetic, foo, foo2)]
 #![feature(staged_api)]
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -27,7 +27,7 @@ const unsafe fn bar2() -> u32 { unsafe { foo2() } } //~ ERROR not yet stable as 
 #[rustc_const_stable(feature = "rust1", since = "1.0.0")]
 // conformity is required, even with `const_fn` feature gate
 const unsafe fn bar3() -> u32 { (5f32 + 6f32) as u32 }
-//~^ ERROR const-stable function cannot use `#[feature(const_fn)]`
+//~^ ERROR const-stable function cannot use `#[feature(const_fn_floating_point_arithmetic)]`
 
 // check whether this function cannot be called even with the feature gate active
 #[unstable(feature = "foo2", issue = "none")]

--- a/src/test/ui/consts/min_const_fn/min_const_unsafe_fn_libstd_stability.stderr
+++ b/src/test/ui/consts/min_const_fn/min_const_unsafe_fn_libstd_stability.stderr
@@ -14,7 +14,7 @@ LL | const unsafe fn bar2() -> u32 { unsafe { foo2() } }
    |
    = help: Const-stable functions can only call other const-stable functions
 
-error: const-stable function cannot use `#[feature(const_fn)]`
+error: const-stable function cannot use `#[feature(const_fn_floating_point_arithmetic)]`
   --> $DIR/min_const_unsafe_fn_libstd_stability.rs:29:33
    |
 LL | const unsafe fn bar3() -> u32 { (5f32 + 6f32) as u32 }


### PR DESCRIPTION
cc #76618 

This is a template for splitting up `const_fn` into granular feature gates. I think this will make it easier, both for us and for users, to track stabilization of each individual feature. We don't *have* to do this, however. We could also keep stabilizing things out from under `const_fn`.

cc @rust-lang/wg-const-eval 
r? @oli-obk 
