### PR TITLE
Invalidate local LLVM cache less often

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -36,8 +36,8 @@ changelog-seen = 1
 # toolchain or changing LLVM locally, you probably want to set this to true.
 #
 # It's currently false by default due to being newly added; please file bugs if
-# enabling this did not work for you on Linux (macOS and Windows support is
-# coming soon).
+# enabling this did not work for you on x86_64-unknown-linux-gnu.
+# Other target triples are currently not supported; see #77084.
 #
 # We also currently only support this when building LLVM for the build triple.
 #
@@ -380,7 +380,7 @@ changelog-seen = 1
 
 # Whether or not to leave debug! and trace! calls in the rust binary.
 # Overrides the `debug-assertions` option, if defined.
-# 
+#
 # Defaults to rust.debug-assertions value
 #debug-logging = debug-assertions
 


### PR DESCRIPTION
This avoids a download of LLVM after every rebase. The downside to this is that if we land some patch affecting LLVM built in CI that breaks this option, but that PR does not update the LLVM submodule, we'll likely not notice until the next update -- but this seems unlikely to happen in practice and I am not personally worried about it.

r? @alexcrichton 