### PR TITLE
Suggest `const_mut_refs`, not `const_fn` for mutable references in `const fn`

### DIFF
--- a/compiler/rustc_mir/src/transform/check_consts/ops.rs
+++ b/compiler/rustc_mir/src/transform/check_consts/ops.rs
@@ -535,6 +535,7 @@ impl NonConstOp for UnsizingCast {
     }
 }
 
+// Types that cannot appear in the signature or locals of a `const fn`.
 pub mod ty {
     use super::*;
 
@@ -548,7 +549,13 @@ pub mod ty {
         }
 
         fn emit_error(&self, ccx: &ConstCx<'_, '_>, span: Span) {
-            mcf_emit_error(ccx, span, "mutable references in const fn are unstable");
+            feature_err(
+                &ccx.tcx.sess.parse_sess,
+                sym::const_mut_refs,
+                span,
+                &format!("mutable references are not allowed in {}s", ccx.const_kind()),
+            )
+            .emit()
         }
     }
 

--- a/src/test/ui/consts/const-mut-refs/feature-gate-const_mut_refs.rs
+++ b/src/test/ui/consts/const-mut-refs/feature-gate-const_mut_refs.rs
@@ -2,7 +2,7 @@ fn main() {
     foo(&mut 5);
 }
 
-const fn foo(x: &mut i32) -> i32 { //~ ERROR mutable references in const fn
+const fn foo(x: &mut i32) -> i32 { //~ ERROR mutable references
     *x + 1
 
 }

--- a/src/test/ui/consts/const-mut-refs/feature-gate-const_mut_refs.stderr
+++ b/src/test/ui/consts/const-mut-refs/feature-gate-const_mut_refs.stderr
@@ -1,12 +1,12 @@
-error[E0723]: mutable references in const fn are unstable
+error[E0658]: mutable references are not allowed in constant functions
   --> $DIR/feature-gate-const_mut_refs.rs:5:14
    |
 LL | const fn foo(x: &mut i32) -> i32 {
    |              ^
    |
-   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
-   = help: add `#![feature(const_fn)]` to the crate attributes to enable
+   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
+   = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0723`.
+For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/consts/const_let_assign3.stderr
+++ b/src/test/ui/consts/const_let_assign3.stderr
@@ -1,11 +1,11 @@
-error[E0723]: mutable references in const fn are unstable
+error[E0658]: mutable references are not allowed in constant functions
   --> $DIR/const_let_assign3.rs:8:18
    |
 LL |     const fn foo(&mut self, x: u32) {
    |                  ^^^^^^^^^
    |
-   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
-   = help: add `#![feature(const_fn)]` to the crate attributes to enable
+   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
+   = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
 
 error[E0764]: mutable references are not allowed in constants
   --> $DIR/const_let_assign3.rs:16:5
@@ -29,5 +29,5 @@ LL |     *y = 42;
 
 error: aborting due to 4 previous errors
 
-Some errors have detailed explanations: E0019, E0723, E0764.
+Some errors have detailed explanations: E0019, E0658, E0764.
 For more information about an error, try `rustc --explain E0019`.

--- a/src/test/ui/consts/min_const_fn/min_const_fn.rs
+++ b/src/test/ui/consts/min_const_fn/min_const_fn.rs
@@ -37,26 +37,26 @@ impl<T> Foo<T> {
     const fn into_inner(self) -> T { self.0 } //~ destructors cannot be evaluated
     const fn get(&self) -> &T { &self.0 }
     const fn get_mut(&mut self) -> &mut T { &mut self.0 }
-    //~^ mutable references in const fn are unstable
+    //~^ mutable references
 }
 impl<'a, T> Foo<T> {
     const fn new_lt(t: T) -> Self { Foo(t) }
     const fn into_inner_lt(self) -> T { self.0 } //~ destructors cannot be evaluated
     const fn get_lt(&'a self) -> &T { &self.0 }
     const fn get_mut_lt(&'a mut self) -> &mut T { &mut self.0 }
-    //~^ mutable references in const fn are unstable
+    //~^ mutable references
 }
 impl<T: Sized> Foo<T> {
     const fn new_s(t: T) -> Self { Foo(t) }
     const fn into_inner_s(self) -> T { self.0 } //~ ERROR destructors
     const fn get_s(&self) -> &T { &self.0 }
     const fn get_mut_s(&mut self) -> &mut T { &mut self.0 }
-    //~^ mutable references in const fn are unstable
+    //~^ mutable references
 }
 impl<T: ?Sized> Foo<T> {
     const fn get_sq(&self) -> &T { &self.0 }
     const fn get_mut_sq(&mut self) -> &mut T { &mut self.0 }
-    //~^ mutable references in const fn are unstable
+    //~^ mutable references
 }
 
 
@@ -99,7 +99,7 @@ const fn foo30_2_with_unsafe(x: *mut u32) -> usize { unsafe { x as usize } }
 //~^ ERROR casting pointers to integers
 const fn foo30_6() -> bool { let x = true; x }
 const fn inc(x: &mut i32) { *x += 1 }
-//~^ ERROR mutable references in const fn are unstable
+//~^ ERROR mutable references
 
 // ok
 const fn foo36(a: bool, b: bool) -> bool { a && b }

--- a/src/test/ui/consts/min_const_fn/min_const_fn.stderr
+++ b/src/test/ui/consts/min_const_fn/min_const_fn.stderr
@@ -6,14 +6,14 @@ LL |     const fn into_inner(self) -> T { self.0 }
    |                         |
    |                         constant functions cannot evaluate destructors
 
-error[E0723]: mutable references in const fn are unstable
+error[E0658]: mutable references are not allowed in constant functions
   --> $DIR/min_const_fn.rs:39:36
    |
 LL |     const fn get_mut(&mut self) -> &mut T { &mut self.0 }
    |                                    ^^^^^^
    |
-   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
-   = help: add `#![feature(const_fn)]` to the crate attributes to enable
+   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
+   = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
 
 error[E0493]: destructors cannot be evaluated at compile-time
   --> $DIR/min_const_fn.rs:44:28
@@ -23,14 +23,14 @@ LL |     const fn into_inner_lt(self) -> T { self.0 }
    |                            |
    |                            constant functions cannot evaluate destructors
 
-error[E0723]: mutable references in const fn are unstable
+error[E0658]: mutable references are not allowed in constant functions
   --> $DIR/min_const_fn.rs:46:42
    |
 LL |     const fn get_mut_lt(&'a mut self) -> &mut T { &mut self.0 }
    |                                          ^^^^^^
    |
-   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
-   = help: add `#![feature(const_fn)]` to the crate attributes to enable
+   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
+   = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
 
 error[E0493]: destructors cannot be evaluated at compile-time
   --> $DIR/min_const_fn.rs:51:27
@@ -40,23 +40,23 @@ LL |     const fn into_inner_s(self) -> T { self.0 }
    |                           |
    |                           constant functions cannot evaluate destructors
 
-error[E0723]: mutable references in const fn are unstable
+error[E0658]: mutable references are not allowed in constant functions
   --> $DIR/min_const_fn.rs:53:38
    |
 LL |     const fn get_mut_s(&mut self) -> &mut T { &mut self.0 }
    |                                      ^^^^^^
    |
-   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
-   = help: add `#![feature(const_fn)]` to the crate attributes to enable
+   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
+   = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
 
-error[E0723]: mutable references in const fn are unstable
+error[E0658]: mutable references are not allowed in constant functions
   --> $DIR/min_const_fn.rs:58:39
    |
 LL |     const fn get_mut_sq(&mut self) -> &mut T { &mut self.0 }
    |                                       ^^^^^^
    |
-   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
-   = help: add `#![feature(const_fn)]` to the crate attributes to enable
+   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
+   = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
 
 error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable
   --> $DIR/min_const_fn.rs:76:16
@@ -164,14 +164,14 @@ LL | const fn foo30_2_with_unsafe(x: *mut u32) -> usize { unsafe { x as usize } 
    = note: see issue #51910 <https://github.com/rust-lang/rust/issues/51910> for more information
    = help: add `#![feature(const_raw_ptr_to_usize_cast)]` to the crate attributes to enable
 
-error[E0723]: mutable references in const fn are unstable
+error[E0658]: mutable references are not allowed in constant functions
   --> $DIR/min_const_fn.rs:101:14
    |
 LL | const fn inc(x: &mut i32) { *x += 1 }
    |              ^
    |
-   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
-   = help: add `#![feature(const_fn)]` to the crate attributes to enable
+   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
+   = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
 
 error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable
   --> $DIR/min_const_fn.rs:110:6

--- a/src/test/ui/consts/min_const_fn/mutable_borrow.rs
+++ b/src/test/ui/consts/min_const_fn/mutable_borrow.rs
@@ -1,6 +1,6 @@
 const fn mutable_ref_in_const() -> u8 {
     let mut a = 0;
-    let b = &mut a; //~ ERROR mutable references in const fn
+    let b = &mut a; //~ ERROR mutable references
     *b
 }
 
@@ -9,7 +9,7 @@ struct X;
 impl X {
     const fn inherent_mutable_ref_in_const() -> u8 {
         let mut a = 0;
-        let b = &mut a; //~ ERROR mutable references in const fn
+        let b = &mut a; //~ ERROR mutable references
         *b
     }
 }

--- a/src/test/ui/consts/min_const_fn/mutable_borrow.stderr
+++ b/src/test/ui/consts/min_const_fn/mutable_borrow.stderr
@@ -1,21 +1,21 @@
-error[E0723]: mutable references in const fn are unstable
+error[E0658]: mutable references are not allowed in constant functions
   --> $DIR/mutable_borrow.rs:3:9
    |
 LL |     let b = &mut a;
    |         ^
    |
-   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
-   = help: add `#![feature(const_fn)]` to the crate attributes to enable
+   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
+   = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
 
-error[E0723]: mutable references in const fn are unstable
+error[E0658]: mutable references are not allowed in constant functions
   --> $DIR/mutable_borrow.rs:12:13
    |
 LL |         let b = &mut a;
    |             ^
    |
-   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
-   = help: add `#![feature(const_fn)]` to the crate attributes to enable
+   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
+   = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0723`.
+For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/unsafe/ranged_ints2_const.stderr
+++ b/src/test/ui/unsafe/ranged_ints2_const.stderr
@@ -1,20 +1,20 @@
-error[E0723]: mutable references in const fn are unstable
+error[E0658]: mutable references are not allowed in constant functions
   --> $DIR/ranged_ints2_const.rs:11:9
    |
 LL |     let y = &mut x.0;
    |         ^
    |
-   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
-   = help: add `#![feature(const_fn)]` to the crate attributes to enable
+   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
+   = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
 
-error[E0723]: mutable references in const fn are unstable
+error[E0658]: mutable references are not allowed in constant functions
   --> $DIR/ranged_ints2_const.rs:18:9
    |
 LL |     let y = unsafe { &mut x.0 };
    |         ^
    |
-   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
-   = help: add `#![feature(const_fn)]` to the crate attributes to enable
+   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
+   = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
 
 error[E0133]: mutation of layout constrained field is unsafe and requires unsafe function or block
   --> $DIR/ranged_ints2_const.rs:11:13
@@ -26,5 +26,5 @@ LL |     let y = &mut x.0;
 
 error: aborting due to 3 previous errors
 
-Some errors have detailed explanations: E0133, E0723.
+Some errors have detailed explanations: E0133, E0658.
 For more information about an error, try `rustc --explain E0133`.


### PR DESCRIPTION
Resolves #77134.

Prior to #76850, most uses of `&mut` in `const fn` ~~required~~ involved two feature gates, `const_mut_refs` and `const_fn`. The first allowed all mutable borrows of locals. The second allowed only locals, arguments and return values whose types contained `&mut`. I switched the second check to the `const_mut_refs` gate. However, I forgot update the error message with the new suggestion.

Alternatively, we could revert to having two different feature gates for this. OP's code never borrows anything mutably, so it didn't need `const_mut_refs` in the past, only `const_fn`. I'd prefer to keep everything under a single gate, however.

r? @oli-obk 