### PR TITLE
Refactor versions detection in build-manifest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,6 +230,7 @@ dependencies = [
 name = "build-manifest"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "serde",
  "serde_json",
  "toml",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -231,8 +231,10 @@ name = "build-manifest"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "flate2",
  "serde",
  "serde_json",
+ "tar",
  "toml",
 ]
 

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -2356,15 +2356,9 @@ impl Step for HashSign {
         cmd.arg(sign);
         cmd.arg(distdir(builder));
         cmd.arg(today.trim());
-        cmd.arg(builder.rust_package_vers());
         cmd.arg(addr);
-        cmd.arg(builder.package_vers(&builder.release_num("cargo")));
-        cmd.arg(builder.package_vers(&builder.release_num("rls")));
-        cmd.arg(builder.package_vers(&builder.release_num("rust-analyzer/crates/rust-analyzer")));
-        cmd.arg(builder.package_vers(&builder.release_num("clippy")));
-        cmd.arg(builder.package_vers(&builder.release_num("miri")));
-        cmd.arg(builder.package_vers(&builder.release_num("rustfmt")));
-        cmd.arg(builder.llvm_tools_package_vers());
+        cmd.arg(&builder.config.channel);
+        cmd.arg(&builder.src);
 
         builder.create_dir(&distdir(builder));
 

--- a/src/tools/build-manifest/Cargo.toml
+++ b/src/tools/build-manifest/Cargo.toml
@@ -8,3 +8,4 @@ edition = "2018"
 toml = "0.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+anyhow = "1.0.32"

--- a/src/tools/build-manifest/Cargo.toml
+++ b/src/tools/build-manifest/Cargo.toml
@@ -9,3 +9,5 @@ toml = "0.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 anyhow = "1.0.32"
+flate2 = "1.0.16"
+tar = "0.4.29"

--- a/src/tools/build-manifest/README.md
+++ b/src/tools/build-manifest/README.md
@@ -21,10 +21,9 @@ Then, you can generate the manifest and all the packages from `path/to/dist` to
 
 ```
 $ BUILD_MANIFEST_DISABLE_SIGNING=1 cargo +nightly run \
-    path/to/dist path/to/output 1970-01-01 \
-    nightly nightly nightly nightly nightly nightly nightly nightly \
-    http://example.com
+    path/to/dist path/to/output 1970-01-01 http://example.com \
+    CHANNEL path/to/rust/repo
 ```
 
-In the future, if the tool complains about missing arguments just add more
-`nightly`s in the middle.
+Remember to replace `CHANNEL` with the channel you produced dist artifacts of
+and `path/to/rust/repo` with the path to your checkout of the Rust repository.

--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -4,8 +4,10 @@
 //! via `x.py dist hash-and-sign`; the cmdline arguments are set up
 //! by rustbuild (in `src/bootstrap/dist.rs`).
 
-use serde::Serialize;
+mod versions;
 
+use crate::versions::PkgType;
+use serde::Serialize;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::env;
@@ -334,35 +336,6 @@ fn main() {
         should_sign,
     }
     .build();
-}
-
-enum PkgType {
-    RustSrc,
-    Cargo,
-    Rls,
-    RustAnalyzer,
-    Clippy,
-    Rustfmt,
-    LlvmTools,
-    Miri,
-    Other,
-}
-
-impl PkgType {
-    fn from_component(component: &str) -> Self {
-        use PkgType::*;
-        match component {
-            "rust-src" => RustSrc,
-            "cargo" => Cargo,
-            "rls" | "rls-preview" => Rls,
-            "rust-analyzer" | "rust-analyzer-preview" => RustAnalyzer,
-            "clippy" | "clippy-preview" => Clippy,
-            "rustfmt" | "rustfmt-preview" => Rustfmt,
-            "llvm-tools" | "llvm-tools-preview" => LlvmTools,
-            "miri" | "miri-preview" => Miri,
-            _ => Other,
-        }
-    }
 }
 
 impl Builder {
@@ -702,7 +675,7 @@ impl Builder {
             Rustfmt => format!("rustfmt-{}-{}.tar.gz", self.rustfmt_release, target),
             LlvmTools => format!("llvm-tools-{}-{}.tar.gz", self.llvm_tools_release, target),
             Miri => format!("miri-{}-{}.tar.gz", self.miri_release, target),
-            Other => format!("{}-{}-{}.tar.gz", component, self.rust_release, target),
+            Other(_) => format!("{}-{}-{}.tar.gz", component, self.rust_release, target),
         }
     }
 

--- a/src/tools/build-manifest/src/versions.rs
+++ b/src/tools/build-manifest/src/versions.rs
@@ -1,4 +1,10 @@
+use anyhow::{Context, Error};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Hash, Eq, PartialEq, Clone)]
 pub(crate) enum PkgType {
+    Rust,
     RustSrc,
     Cargo,
     Rls,
@@ -13,6 +19,7 @@ pub(crate) enum PkgType {
 impl PkgType {
     pub(crate) fn from_component(component: &str) -> Self {
         match component {
+            "rust" => PkgType::Rust,
             "rust-src" => PkgType::RustSrc,
             "cargo" => PkgType::Cargo,
             "rls" | "rls-preview" => PkgType::Rls,
@@ -24,4 +31,111 @@ impl PkgType {
             other => PkgType::Other(other.into()),
         }
     }
+
+    fn rust_monorepo_path(&self) -> Option<&'static str> {
+        match self {
+            PkgType::Cargo => Some("src/tools/cargo"),
+            PkgType::Rls => Some("src/tools/rls"),
+            PkgType::RustAnalyzer => Some("src/tools/rust-analyzer/crates/rust-analyzer"),
+            PkgType::Clippy => Some("src/tools/clippy"),
+            PkgType::Rustfmt => Some("src/tools/rustfmt"),
+            PkgType::Miri => Some("src/tools/miri"),
+            PkgType::Rust => None,
+            PkgType::RustSrc => None,
+            PkgType::LlvmTools => None,
+            PkgType::Other(_) => None,
+        }
+    }
+
+    fn tarball_component_name(&self) -> &str {
+        match self {
+            PkgType::Rust => "rust",
+            PkgType::RustSrc => "rust-src",
+            PkgType::Cargo => "cargo",
+            PkgType::Rls => "rls",
+            PkgType::RustAnalyzer => "rust-analyzer",
+            PkgType::Clippy => "clippy",
+            PkgType::Rustfmt => "rustfmt",
+            PkgType::LlvmTools => "llvm-tools",
+            PkgType::Miri => "miri",
+            PkgType::Other(component) => component,
+        }
+    }
+}
+
+pub(crate) struct Versions {
+    channel: String,
+    rustc_version: String,
+    monorepo_root: PathBuf,
+    package_versions: HashMap<PkgType, String>,
+}
+
+impl Versions {
+    pub(crate) fn new(channel: &str, monorepo_root: &Path) -> Result<Self, Error> {
+        Ok(Self {
+            channel: channel.into(),
+            rustc_version: std::fs::read_to_string(monorepo_root.join("src").join("version"))
+                .context("failed to read the rustc version from src/version")?
+                .trim()
+                .to_string(),
+            monorepo_root: monorepo_root.into(),
+            package_versions: HashMap::new(),
+        })
+    }
+
+    pub(crate) fn channel(&self) -> &str {
+        &self.channel
+    }
+
+    pub(crate) fn tarball_name(
+        &mut self,
+        package: &PkgType,
+        target: &str,
+    ) -> Result<String, Error> {
+        Ok(format!(
+            "{}-{}-{}.tar.gz",
+            package.tarball_component_name(),
+            self.package_version(package).with_context(|| format!(
+                "failed to get the package version for component {:?}",
+                package,
+            ))?,
+            target
+        ))
+    }
+
+    pub(crate) fn package_version(&mut self, package: &PkgType) -> Result<String, Error> {
+        match self.package_versions.get(package) {
+            Some(release) => Ok(release.clone()),
+            None => {
+                let version = match package.rust_monorepo_path() {
+                    Some(path) => {
+                        let path = self.monorepo_root.join(path).join("Cargo.toml");
+                        let cargo_toml: CargoToml = toml::from_slice(&std::fs::read(path)?)?;
+                        cargo_toml.package.version
+                    }
+                    None => self.rustc_version.clone(),
+                };
+
+                let release = match self.channel.as_str() {
+                    "stable" => version,
+                    "beta" => "beta".into(),
+                    "nightly" => "nightly".into(),
+                    _ => format!("{}-dev", version),
+                };
+
+                self.package_versions.insert(package.clone(), release.clone());
+                Ok(release)
+            }
+        }
+    }
+}
+
+#[derive(serde::Deserialize)]
+struct CargoToml {
+    package: CargoTomlPackage,
+}
+
+#[derive(serde::Deserialize)]
+struct CargoTomlPackage {
+    version: String,
 }

--- a/src/tools/build-manifest/src/versions.rs
+++ b/src/tools/build-manifest/src/versions.rs
@@ -1,0 +1,27 @@
+pub(crate) enum PkgType {
+    RustSrc,
+    Cargo,
+    Rls,
+    RustAnalyzer,
+    Clippy,
+    Rustfmt,
+    LlvmTools,
+    Miri,
+    Other(String),
+}
+
+impl PkgType {
+    pub(crate) fn from_component(component: &str) -> Self {
+        match component {
+            "rust-src" => PkgType::RustSrc,
+            "cargo" => PkgType::Cargo,
+            "rls" | "rls-preview" => PkgType::Rls,
+            "rust-analyzer" | "rust-analyzer-preview" => PkgType::RustAnalyzer,
+            "clippy" | "clippy-preview" => PkgType::Clippy,
+            "rustfmt" | "rustfmt-preview" => PkgType::Rustfmt,
+            "llvm-tools" | "llvm-tools-preview" => PkgType::LlvmTools,
+            "miri" | "miri-preview" => PkgType::Miri,
+            other => PkgType::Other(other.into()),
+        }
+    }
+}

--- a/src/tools/build-manifest/src/versions.rs
+++ b/src/tools/build-manifest/src/versions.rs
@@ -38,6 +38,8 @@ impl PkgType {
         }
     }
 
+    /// The directory containing the `Cargo.toml` of this component inside the monorepo, to
+    /// retrieve the source code version. If `None` is returned Rust's version will be used.
     fn rust_monorepo_path(&self) -> Option<&'static str> {
         match self {
             PkgType::Cargo => Some("src/tools/cargo"),
@@ -53,6 +55,7 @@ impl PkgType {
         }
     }
 
+    /// First part of the tarball name.
     fn tarball_component_name(&self) -> &str {
         match self {
             PkgType::Rust => "rust",
@@ -68,6 +71,8 @@ impl PkgType {
         }
     }
 
+    /// Whether this package has the same version as Rust itself, or has its own `version` and
+    /// `git-commit-hash` files inside the tarball.
     fn should_use_rust_version(&self) -> bool {
         match self {
             PkgType::Cargo => false,

--- a/src/tools/build-manifest/src/versions.rs
+++ b/src/tools/build-manifest/src/versions.rs
@@ -1,6 +1,12 @@
 use anyhow::{Context, Error};
+use flate2::read::GzDecoder;
 use std::collections::HashMap;
+use std::fs::File;
+use std::io::Read;
 use std::path::{Path, PathBuf};
+use tar::Archive;
+
+const DEFAULT_TARGET: &str = "x86_64-unknown-linux-gnu";
 
 #[derive(Debug, Hash, Eq, PartialEq, Clone)]
 pub(crate) enum PkgType {
@@ -61,17 +67,46 @@ impl PkgType {
             PkgType::Other(component) => component,
         }
     }
+
+    fn should_use_rust_version(&self) -> bool {
+        match self {
+            PkgType::Cargo => false,
+            PkgType::Rls => false,
+            PkgType::RustAnalyzer => false,
+            PkgType::Clippy => false,
+            PkgType::Rustfmt => false,
+            PkgType::LlvmTools => false,
+            PkgType::Miri => false,
+
+            PkgType::Rust => true,
+            PkgType::RustSrc => true,
+            PkgType::Other(_) => true,
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub(crate) struct VersionInfo {
+    pub(crate) version: Option<String>,
+    pub(crate) git_commit: Option<String>,
+    pub(crate) present: bool,
 }
 
 pub(crate) struct Versions {
     channel: String,
     rustc_version: String,
     monorepo_root: PathBuf,
+    dist_path: PathBuf,
     package_versions: HashMap<PkgType, String>,
+    versions: HashMap<PkgType, VersionInfo>,
 }
 
 impl Versions {
-    pub(crate) fn new(channel: &str, monorepo_root: &Path) -> Result<Self, Error> {
+    pub(crate) fn new(
+        channel: &str,
+        dist_path: &Path,
+        monorepo_root: &Path,
+    ) -> Result<Self, Error> {
         Ok(Self {
             channel: channel.into(),
             rustc_version: std::fs::read_to_string(monorepo_root.join("src").join("version"))
@@ -79,12 +114,78 @@ impl Versions {
                 .trim()
                 .to_string(),
             monorepo_root: monorepo_root.into(),
+            dist_path: dist_path.into(),
             package_versions: HashMap::new(),
+            versions: HashMap::new(),
         })
     }
 
     pub(crate) fn channel(&self) -> &str {
         &self.channel
+    }
+
+    pub(crate) fn version(&mut self, mut package: &PkgType) -> Result<VersionInfo, Error> {
+        if package.should_use_rust_version() {
+            package = &PkgType::Rust;
+        }
+
+        match self.versions.get(package) {
+            Some(version) => Ok(version.clone()),
+            None => {
+                let version_info = self.load_version_from_tarball(package)?;
+                self.versions.insert(package.clone(), version_info.clone());
+                Ok(version_info)
+            }
+        }
+    }
+
+    fn load_version_from_tarball(&mut self, package: &PkgType) -> Result<VersionInfo, Error> {
+        let tarball_name = self.tarball_name(package, DEFAULT_TARGET)?;
+        let tarball = self.dist_path.join(tarball_name);
+
+        let file = match File::open(&tarball) {
+            Ok(file) => file,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                // Missing tarballs do not return an error, but return empty data.
+                return Ok(VersionInfo::default());
+            }
+            Err(err) => return Err(err.into()),
+        };
+        let mut tar = Archive::new(GzDecoder::new(file));
+
+        let mut version = None;
+        let mut git_commit = None;
+        for entry in tar.entries()? {
+            let mut entry = entry?;
+
+            let dest;
+            match entry.path()?.components().nth(1).and_then(|c| c.as_os_str().to_str()) {
+                Some("version") => dest = &mut version,
+                Some("git-commit-hash") => dest = &mut git_commit,
+                _ => continue,
+            }
+            let mut buf = String::new();
+            entry.read_to_string(&mut buf)?;
+            *dest = Some(buf);
+
+            // Short circuit to avoid reading the whole tar file if not necessary.
+            if version.is_some() && git_commit.is_some() {
+                break;
+            }
+        }
+
+        Ok(VersionInfo { version, git_commit, present: true })
+    }
+
+    pub(crate) fn disable_version(&mut self, package: &PkgType) {
+        match self.versions.get_mut(package) {
+            Some(version) => {
+                *version = VersionInfo::default();
+            }
+            None => {
+                self.versions.insert(package.clone(), VersionInfo::default());
+            }
+        }
     }
 
     pub(crate) fn tarball_name(


### PR DESCRIPTION
This PR refactors how `build-manifest` handles versions, making the following changes:

* `build-manifest` now detects the "package releases" on its own, without relying on rustbuild providing them through CLI arguments. This drastically simplifies calling the tool outside of `x.py`, and will allow to ship the prebuilt tool in a tarball in the future, with the goal of stopping to invoke `x.py` during `promote-release`.
* The `tar` command is not used to extract the version and the git hash from tarballs anymore. The `flate2` and `tar` crates are used instead. This makes detecting those pieces of data way faster, as the archive is decompressed just once and we stop parsing the archive once all the information is retrieved.
* The code to extract the version and the git hash now stores all the collected data dynamically, without requiring to add new fields to the `Builder` struct every time.

I tested the changes locally and it should behave the same as before.

r? @Mark-Simulacrum 