### PR TITLE
Install std for non-host targets

### DIFF
--- a/src/bootstrap/install.rs
+++ b/src/bootstrap/install.rs
@@ -192,7 +192,7 @@ install!((self, builder, _config),
         builder.ensure(dist::Docs { host: self.target });
         install_docs(builder, self.compiler.stage, self.target);
     };
-    Std, "library/std", true, only_hosts: true, {
+    Std, "library/std", true, only_hosts: false, {
         for target in &builder.targets {
             builder.ensure(dist::Std {
                 compiler: self.compiler,


### PR DESCRIPTION
It seems reasonable that when configuring various targets you'd expect all of them to get std installed, even if you're not building compiler toolchains for each of those.

cc #76990

r? @alexcrichton 