### PR TITLE
[DO NOT MERGE] Deny some helper attr names, and error on overlap

### DIFF
--- a/compiler/rustc_builtin_macros/src/proc_macro_harness.rs
+++ b/compiler/rustc_builtin_macros/src/proc_macro_harness.rs
@@ -177,6 +177,18 @@ impl<'a> CollectProcMacros<'a> {
                         );
                     }
 
+                    let name = ident.name.as_str();
+                    if name == "derive_skip"
+                        || name == "ignore"
+                        || name == "partialeq"
+                        || name == "partialord"
+                        || name == "hash"
+                        || name == "debug"
+                    {
+                        self.handler
+                            .span_err(attr.span, &format!("`{}` is a reserved helper name", ident));
+                    }
+
                     Some(ident.name)
                 })
                 .collect()

--- a/compiler/rustc_expand/src/base.rs
+++ b/compiler/rustc_expand/src/base.rs
@@ -12,7 +12,7 @@ use rustc_data_structures::sync::{self, Lrc};
 use rustc_errors::{DiagnosticBuilder, ErrorReported};
 use rustc_parse::{self, nt_to_tokenstream, parser, MACRO_ARGUMENTS};
 use rustc_session::{parse::ParseSess, Limit, Session};
-use rustc_span::def_id::{DefId, LOCAL_CRATE};
+use rustc_span::def_id::{CrateNum, DefId, LOCAL_CRATE};
 use rustc_span::edition::Edition;
 use rustc_span::hygiene::{AstPass, ExpnData, ExpnId, ExpnKind};
 use rustc_span::source_map::SourceMap;
@@ -257,6 +257,9 @@ pub enum ExpandResult<T, U> {
 
 // `meta_item` is the attribute, and `item` is the item being modified.
 pub trait MultiItemModifier {
+    fn krate(&self) -> Option<CrateNum> {
+        None
+    }
     fn expand(
         &self,
         ecx: &mut ExtCtxt<'_>,

--- a/compiler/rustc_expand/src/proc_macro.rs
+++ b/compiler/rustc_expand/src/proc_macro.rs
@@ -8,6 +8,7 @@ use rustc_data_structures::sync::Lrc;
 use rustc_errors::{struct_span_err, Applicability, ErrorReported};
 use rustc_lexer::is_ident;
 use rustc_parse::nt_to_tokenstream;
+use rustc_span::def_id::CrateNum;
 use rustc_span::symbol::sym;
 use rustc_span::{Span, DUMMY_SP};
 
@@ -63,10 +64,14 @@ impl base::AttrProcMacro for AttrProcMacro {
 }
 
 pub struct ProcMacroDerive {
+    pub krate: CrateNum,
     pub client: pm::bridge::client::Client<fn(pm::TokenStream) -> pm::TokenStream>,
 }
 
 impl MultiItemModifier for ProcMacroDerive {
+    fn krate(&self) -> Option<CrateNum> {
+        Some(self.krate)
+    }
     fn expand(
         &self,
         ecx: &mut ExtCtxt<'_>,

--- a/compiler/rustc_metadata/src/rmeta/decoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder.rs
@@ -772,7 +772,10 @@ impl<'a, 'tcx> CrateMetadataRef<'a> {
                     attributes.iter().cloned().map(Symbol::intern).collect::<Vec<_>>();
                 (
                     trait_name,
-                    SyntaxExtensionKind::Derive(Box::new(ProcMacroDerive { client })),
+                    SyntaxExtensionKind::Derive(Box::new(ProcMacroDerive {
+                        client,
+                        krate: self.cnum,
+                    })),
                     helper_attrs,
                 )
             }


### PR DESCRIPTION
This is for running a Crater experiment to get a lower bound on the
amount of problems caused by derive helper attributes overlapping.