### PR TITLE
Suggest `const_fn_transmute`, not `const_fn`

### DIFF
--- a/compiler/rustc_mir/src/transform/check_consts/ops.rs
+++ b/compiler/rustc_mir/src/transform/check_consts/ops.rs
@@ -489,7 +489,14 @@ impl NonConstOp for Transmute {
     }
 
     fn emit_error(&self, ccx: &ConstCx<'_, '_>, span: Span) {
-        mcf_emit_error(ccx, span, "can only call `transmute` from const items, not `const fn`");
+        feature_err(
+            &ccx.tcx.sess.parse_sess,
+            sym::const_fn_transmute,
+            span,
+            &format!("`transmute` is not allowed in {}s", ccx.const_kind()),
+        )
+        .note("`transmute` is only allowed in constants and statics for now")
+        .emit();
     }
 }
 

--- a/src/test/ui/feature-gates/feature-gate-const_fn_transmute.rs
+++ b/src/test/ui/feature-gates/feature-gate-const_fn_transmute.rs
@@ -6,33 +6,33 @@ struct Foo(u32);
 const TRANSMUTED_U32: u32 = unsafe { mem::transmute(Foo(3)) };
 
 const fn transmute_fn() -> u32 { unsafe { mem::transmute(Foo(3)) } }
-//~^ ERROR can only call `transmute` from const items, not `const fn`
+//~^ ERROR `transmute`
 
 const fn transmute_fn_intrinsic() -> u32 { unsafe { std::intrinsics::transmute(Foo(3)) } }
-//~^ ERROR can only call `transmute` from const items, not `const fn`
+//~^ ERROR `transmute`
 
 const fn transmute_fn_core_intrinsic() -> u32 { unsafe { core::intrinsics::transmute(Foo(3)) } }
-//~^ ERROR can only call `transmute` from const items, not `const fn`
+//~^ ERROR `transmute`
 
 const unsafe fn unsafe_transmute_fn() -> u32 { mem::transmute(Foo(3)) }
-//~^ ERROR can only call `transmute` from const items, not `const fn`
+//~^ ERROR `transmute`
 
 const unsafe fn unsafe_transmute_fn_intrinsic() -> u32 { std::intrinsics::transmute(Foo(3)) }
-//~^ ERROR can only call `transmute` from const items, not `const fn`
+//~^ ERROR `transmute`
 
 const unsafe fn unsafe_transmute_fn_core_intrinsic() -> u32 { core::intrinsics::transmute(Foo(3)) }
-//~^ ERROR can only call `transmute` from const items, not `const fn`
+//~^ ERROR `transmute`
 
 const fn safe_transmute_fn() -> u32 { mem::transmute(Foo(3)) }
-//~^ ERROR can only call `transmute` from const items, not `const fn`
+//~^ ERROR `transmute`
 //~| ERROR call to unsafe function is unsafe and requires unsafe function or block
 
 const fn safe_transmute_fn_intrinsic() -> u32 { std::intrinsics::transmute(Foo(3)) }
-//~^ ERROR can only call `transmute` from const items, not `const fn`
+//~^ ERROR `transmute`
 //~| ERROR call to unsafe function is unsafe and requires unsafe function or block
 
 const fn safe_transmute_fn_core_intrinsic() -> u32 { core::intrinsics::transmute(Foo(3)) }
-//~^ ERROR can only call `transmute` from const items, not `const fn`
+//~^ ERROR `transmute`
 //~| ERROR call to unsafe function is unsafe and requires unsafe function or block
 
 fn main() {}

--- a/src/test/ui/feature-gates/feature-gate-const_fn_transmute.stderr
+++ b/src/test/ui/feature-gates/feature-gate-const_fn_transmute.stderr
@@ -1,83 +1,92 @@
-error[E0723]: can only call `transmute` from const items, not `const fn`
+error[E0658]: `transmute` is not allowed in constant functions
   --> $DIR/feature-gate-const_fn_transmute.rs:8:43
    |
 LL | const fn transmute_fn() -> u32 { unsafe { mem::transmute(Foo(3)) } }
    |                                           ^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
-   = help: add `#![feature(const_fn)]` to the crate attributes to enable
+   = note: see issue #53605 <https://github.com/rust-lang/rust/issues/53605> for more information
+   = help: add `#![feature(const_fn_transmute)]` to the crate attributes to enable
+   = note: `transmute` is only allowed in constants and statics for now
 
-error[E0723]: can only call `transmute` from const items, not `const fn`
+error[E0658]: `transmute` is not allowed in constant functions
   --> $DIR/feature-gate-const_fn_transmute.rs:11:53
    |
 LL | const fn transmute_fn_intrinsic() -> u32 { unsafe { std::intrinsics::transmute(Foo(3)) } }
    |                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
-   = help: add `#![feature(const_fn)]` to the crate attributes to enable
+   = note: see issue #53605 <https://github.com/rust-lang/rust/issues/53605> for more information
+   = help: add `#![feature(const_fn_transmute)]` to the crate attributes to enable
+   = note: `transmute` is only allowed in constants and statics for now
 
-error[E0723]: can only call `transmute` from const items, not `const fn`
+error[E0658]: `transmute` is not allowed in constant functions
   --> $DIR/feature-gate-const_fn_transmute.rs:14:58
    |
 LL | const fn transmute_fn_core_intrinsic() -> u32 { unsafe { core::intrinsics::transmute(Foo(3)) } }
    |                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
-   = help: add `#![feature(const_fn)]` to the crate attributes to enable
+   = note: see issue #53605 <https://github.com/rust-lang/rust/issues/53605> for more information
+   = help: add `#![feature(const_fn_transmute)]` to the crate attributes to enable
+   = note: `transmute` is only allowed in constants and statics for now
 
-error[E0723]: can only call `transmute` from const items, not `const fn`
+error[E0658]: `transmute` is not allowed in constant functions
   --> $DIR/feature-gate-const_fn_transmute.rs:17:48
    |
 LL | const unsafe fn unsafe_transmute_fn() -> u32 { mem::transmute(Foo(3)) }
    |                                                ^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
-   = help: add `#![feature(const_fn)]` to the crate attributes to enable
+   = note: see issue #53605 <https://github.com/rust-lang/rust/issues/53605> for more information
+   = help: add `#![feature(const_fn_transmute)]` to the crate attributes to enable
+   = note: `transmute` is only allowed in constants and statics for now
 
-error[E0723]: can only call `transmute` from const items, not `const fn`
+error[E0658]: `transmute` is not allowed in constant functions
   --> $DIR/feature-gate-const_fn_transmute.rs:20:58
    |
 LL | const unsafe fn unsafe_transmute_fn_intrinsic() -> u32 { std::intrinsics::transmute(Foo(3)) }
    |                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
-   = help: add `#![feature(const_fn)]` to the crate attributes to enable
+   = note: see issue #53605 <https://github.com/rust-lang/rust/issues/53605> for more information
+   = help: add `#![feature(const_fn_transmute)]` to the crate attributes to enable
+   = note: `transmute` is only allowed in constants and statics for now
 
-error[E0723]: can only call `transmute` from const items, not `const fn`
+error[E0658]: `transmute` is not allowed in constant functions
   --> $DIR/feature-gate-const_fn_transmute.rs:23:63
    |
 LL | const unsafe fn unsafe_transmute_fn_core_intrinsic() -> u32 { core::intrinsics::transmute(Foo(3)) }
    |                                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
-   = help: add `#![feature(const_fn)]` to the crate attributes to enable
+   = note: see issue #53605 <https://github.com/rust-lang/rust/issues/53605> for more information
+   = help: add `#![feature(const_fn_transmute)]` to the crate attributes to enable
+   = note: `transmute` is only allowed in constants and statics for now
 
-error[E0723]: can only call `transmute` from const items, not `const fn`
+error[E0658]: `transmute` is not allowed in constant functions
   --> $DIR/feature-gate-const_fn_transmute.rs:26:39
    |
 LL | const fn safe_transmute_fn() -> u32 { mem::transmute(Foo(3)) }
    |                                       ^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
-   = help: add `#![feature(const_fn)]` to the crate attributes to enable
+   = note: see issue #53605 <https://github.com/rust-lang/rust/issues/53605> for more information
+   = help: add `#![feature(const_fn_transmute)]` to the crate attributes to enable
+   = note: `transmute` is only allowed in constants and statics for now
 
-error[E0723]: can only call `transmute` from const items, not `const fn`
+error[E0658]: `transmute` is not allowed in constant functions
   --> $DIR/feature-gate-const_fn_transmute.rs:30:49
    |
 LL | const fn safe_transmute_fn_intrinsic() -> u32 { std::intrinsics::transmute(Foo(3)) }
    |                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
-   = help: add `#![feature(const_fn)]` to the crate attributes to enable
+   = note: see issue #53605 <https://github.com/rust-lang/rust/issues/53605> for more information
+   = help: add `#![feature(const_fn_transmute)]` to the crate attributes to enable
+   = note: `transmute` is only allowed in constants and statics for now
 
-error[E0723]: can only call `transmute` from const items, not `const fn`
+error[E0658]: `transmute` is not allowed in constant functions
   --> $DIR/feature-gate-const_fn_transmute.rs:34:54
    |
 LL | const fn safe_transmute_fn_core_intrinsic() -> u32 { core::intrinsics::transmute(Foo(3)) }
    |                                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
-   = help: add `#![feature(const_fn)]` to the crate attributes to enable
+   = note: see issue #53605 <https://github.com/rust-lang/rust/issues/53605> for more information
+   = help: add `#![feature(const_fn_transmute)]` to the crate attributes to enable
+   = note: `transmute` is only allowed in constants and statics for now
 
 error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
   --> $DIR/feature-gate-const_fn_transmute.rs:26:39
@@ -105,5 +114,5 @@ LL | const fn safe_transmute_fn_core_intrinsic() -> u32 { core::intrinsics::tran
 
 error: aborting due to 12 previous errors
 
-Some errors have detailed explanations: E0133, E0723.
+Some errors have detailed explanations: E0133, E0658.
 For more information about an error, try `rustc --explain E0133`.

--- a/src/test/ui/internal/internal-unstable-const.rs
+++ b/src/test/ui/internal/internal-unstable-const.rs
@@ -8,7 +8,7 @@
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_const_stable(feature = "rust1", since = "1.0.0")]
 pub const fn foo() -> i32 {
-    unsafe { std::mem::transmute(4u32) } //~ ERROR can only call `transmute` from const items
+    unsafe { std::mem::transmute(4u32) } //~ ERROR `transmute`
 }
 
 fn main() {}

--- a/src/test/ui/internal/internal-unstable-const.stderr
+++ b/src/test/ui/internal/internal-unstable-const.stderr
@@ -1,12 +1,13 @@
-error[E0723]: can only call `transmute` from const items, not `const fn`
+error[E0658]: `transmute` is not allowed in constant functions
   --> $DIR/internal-unstable-const.rs:11:14
    |
 LL |     unsafe { std::mem::transmute(4u32) }
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
-   = help: add `#![feature(const_fn)]` to the crate attributes to enable
+   = note: see issue #53605 <https://github.com/rust-lang/rust/issues/53605> for more information
+   = help: add `#![feature(const_fn_transmute)]` to the crate attributes to enable
+   = note: `transmute` is only allowed in constants and statics for now
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0723`.
+For more information about this error, try `rustc --explain E0658`.


### PR DESCRIPTION
More fallout from #76850 in the vein of #77134. The fix is the same. I looked through the structured errors file and didn't see any more of this kind of diagnostics bug.

r? @oli-obk