### PR TITLE
[experiment/perf] Disable jemalloc's time-delayed purging, for extra determinism.

### DIFF
--- a/compiler/rustc/src/main.rs
+++ b/compiler/rustc/src/main.rs
@@ -24,6 +24,12 @@ fn main() {
         static _F5: unsafe extern "C" fn(*mut c_void, usize) -> *mut c_void = jemalloc_sys::realloc;
         #[used]
         static _F6: unsafe extern "C" fn(*mut c_void) = jemalloc_sys::free;
+
+        // HACK(eddyb) disable time-delayed purging to remove the main (only?)
+        // source of non-determinism in `jemalloc`.
+        #[used]
+        #[export_name = "malloc_conf"]
+        static MALLOC_CONF: &'static [u8; 34] = b"dirty_decay_ms:0,muzzy_decay_ms:0\0";
     }
 
     rustc_driver::set_sigpipe_handler();


### PR DESCRIPTION
When ASLR is disabled<sup>1</sup>, the default glibc allocator appears to behave deterministically<sup>2</sup>, but `jemalloc` does not, and its own non-determinism leaks into the addresses being allocated, effectively becoming a form of ASLR<sup>3</sup>.
<sup>1</sup> either system-wide or by running `rustc` under `setarch -R ...`
<sup>2</sup> at least in my limited testing, on `libcore`, check-only i.e. without any LLVM threads, though I should try single-threaded LLVM
<sup>3</sup> any variation in addresses causes even more non-determinism because of how `rustc` uses (`Fx`)`HashMap`s keyed on types that hash "by address" (such as interned references)

(To be clear, this "non-determinism" doesn't affect compilation behavior/outputs, at least I'm not aware of a way that it does, but it does affect measurements such as `instructions:u` measured by [`perf.rust-lang.org`](https://perf.rust-lang.org))

Turns out that this behavior is caused by `jemalloc` defaulting to a 10 second delay before "purging"<sup>4</sup> memory, and so for `rustc` executions taking longer than 10 seconds, purging will start taking place, in unpredictable<sup>5</sup> patterns.
See `jemalloc` documentation: http://jemalloc.net/jemalloc.3.html#opt.dirty_decay_ms.
<sup>4</sup> using `madvise` to inform the kernel that it can reuse the physical backing memory - AFAIK, if userspace tries to use that memory again, the kernel will allocate zeroed physical memory to it, having lost the original data
<sup>5</sup> the timer will not expire in the exact same place on every execution, so different parts of memory will be purged first, which cascades into variations in allocation/deallocation behavior in `jemalloc`

This PR sets both `dirty_decay_ms` and `muzzy_decay_ms` to 0, which is documented as removing the reliance on timers:
> **`opt.dirty_decay_ms`**:
> ... A decay time of 0 causes all unused dirty pages to be purged immediately upon creation. ...
> **`opt.muzzy_decay_ms`**:
> ... A decay time of 0 causes all unused muzzy pages to be purged immediately upon creation. ...

And I've confirmed that, at least for my testcase, the resulting `jemalloc` behavior is just as deterministic as the glibc allocator.

However, I don't know the full performance implications of these settings, hence opening this PR to test it. I also want to see whether we can observe a reduction in variation between identical runs on [`perf.rust-lang.org`](https://perf.rust-lang.org).

cc @Mark-Simulacrum 