### PR TITLE
Removing erroneous semicolon in transmute documentation

### DIFF
--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -904,7 +904,7 @@ extern "rust-intrinsic" {
     /// let raw_bytes = [0x78, 0x56, 0x34, 0x12];
     ///
     /// let num = unsafe {
-    ///     std::mem::transmute::<[u8; 4], u32>(raw_bytes);
+    ///     std::mem::transmute::<[u8; 4], u32>(raw_bytes)
     /// };
     ///
     /// // use `u32::from_ne_bytes` instead


### PR DESCRIPTION
There is a semicolon in the example code that causes the expected value to not be returned. 