### PR TITLE
Rust vec bench import specific rand::RngCore

### DIFF
--- a/library/alloc/benches/vec.rs
+++ b/library/alloc/benches/vec.rs
@@ -1,4 +1,4 @@
-use rand::prelude::*;
+use rand::RngCore;
 use std::iter::{repeat, FromIterator};
 use test::{black_box, Bencher};
 


### PR DESCRIPTION
Using `RngCore` import for side effects is clearer than `*` which may bring it unnecessary more stuff than needed, it is also more explicit doing so.

@pickfire change `LEN = 16384` (and pos) and `once` instead of `[0].iter()` after this.

@rustbot modify labels: +C-cleanup +A-testsuite