### PR TITLE
Add doc alias for iterator fold

### DIFF
--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -1977,6 +1977,8 @@ pub trait Iterator {
     /// assert_eq!(result, result2);
     /// ```
     #[inline]
+    #[doc(alias = "reduce")]
+    #[doc(alias = "inject")]
     #[stable(feature = "rust1", since = "1.0.0")]
     fn fold<B, F>(mut self, init: B, mut f: F) -> B
     where

--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -1976,9 +1976,9 @@ pub trait Iterator {
     /// // they're the same
     /// assert_eq!(result, result2);
     /// ```
-    #[inline]
     #[doc(alias = "reduce")]
     #[doc(alias = "inject")]
+    #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     fn fold<B, F>(mut self, init: B, mut f: F) -> B
     where


### PR DESCRIPTION
fold is known in python and javascript as reduce,
not sure about inject but it was written in doc there.

This was my first confusion when coming into rust, I somehow cannot find where is reduce, sometimes I still forget that it is known as `fold`.