### PR TITLE
Link to documentation-specific guidelines.

### DIFF
--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -85,7 +85,7 @@
 //! # Contributing changes to the documentation
 //!
 //! Check out the rust contribution guidelines [here](
-//! https://rustc-dev-guide.rust-lang.org/getting-started.html).
+//! https://rustc-dev-guide.rust-lang.org/contributing.html#writing-documentation).
 //! The source for this documentation can be found on
 //! [GitHub](https://github.com/rust-lang/rust).
 //! To contribute changes, make sure you read the guidelines first, then submit


### PR DESCRIPTION
Changed contribution information URL because it's not obvious how to get from the current URL to the documentation-specific content.

The current URL points to this "Getting Started" page, which contains nothing specific about documentation[*] and instead launches into how to *build* `rustc` which is not a strict prerequisite for contributing documentation fixes:

 * https://rustc-dev-guide.rust-lang.org/getting-started.html

[*] The most specific content is a "Writing documentation" bullet point which is not itself a link to anything (I guess a patch for that might be helpful too).

### Why?

Making this change will make it easier for people who wish to make small "drive by" documentation fixes (and read contribution guidelines ;) ) which I find are often how I start contributing to a project. (Exhibit A: https://github.com/rust-lang/rust/pull/77050 :) )

### Background

My impression is the change of content linked is an unintentional change due to a couple of other changes:
 
 * Originally, the link pointed to  `contributing.md` which started with a "table of contents" linking to each section. But the content in `contributing.md` was removed and replaced with a link to the "Getting Started" section here:

    * https://github.com/rust-lang/rust/commit/3f6928f1f6eff367e6ddbfb63ebc5e568ffe0eb1#diff-6a3371457528722a734f3c51d9238c13L1

   But the changed link doesn't actually point to the equivalent content, which is now located here:

    * https://rustc-dev-guide.rust-lang.org/contributing.html

   (If the "Guide to Rustc Development" is now considered the canonical location of "How to Contribute" content it might be a good idea to merge some of the "Contributing" Introduction section into the "Getting Started" section.)

 * This was then compounded by changing the link from `contributing.md` to  `contributing.html` here:

     * https://github.com/rust-lang/rust/pull/74037/files#diff-242481015141f373dcb178e93cffa850L88

    In order to even find the new location of the previous `contributing.md` content I ended up needing to do a GitHub search of the `rust-lang` org for the phrase "Documentation improvements are very welcome". :D
