### PR TITLE
Erase all regions before constructing an LLVM type

### DIFF
--- a/compiler/rustc_codegen_llvm/src/type_of.rs
+++ b/compiler/rustc_codegen_llvm/src/type_of.rs
@@ -252,7 +252,8 @@ impl<'tcx> LayoutLlvmExt<'tcx> for TyAndLayout<'tcx> {
 
         // Make sure lifetimes are erased, to avoid generating distinct LLVM
         // types for Rust types that only differ in the choice of lifetimes.
-        let normal_ty = cx.tcx.erase_regions(&self.ty);
+        // Note that we erase *all* regions, include late-bound regions.
+        let normal_ty = cx.tcx.erase_early_and_late_regions(&self.ty);
 
         let mut defer = None;
         let llty = if self.ty != normal_ty {

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -347,6 +347,11 @@ rustc_queries! {
             anon
             desc { "erasing regions from `{:?}`", ty }
         }
+
+        query erase_early_and_late_regions_ty(ty: Ty<'tcx>) -> Ty<'tcx> {
+            anon
+            desc { "erasing early and late regions for `{:?}`", ty }
+        }
     }
 
     Linking {

--- a/src/test/ui/higher-rank-trait-bounds/issue-55976-invalid-ir.rs
+++ b/src/test/ui/higher-rank-trait-bounds/issue-55976-invalid-ir.rs
@@ -1,0 +1,13 @@
+// Regression test for issue #55976
+// Tests that we don't generate invalid LLVM IR when certain
+// higher-ranked trait bounds are involved.
+
+// run-pass
+
+pub struct Foo<T>(T, [u8; 64]);
+
+pub fn abc<'a>(x: &Foo<Box<dyn for<'b> Fn(&'b u8)>>) -> &Foo<Box<dyn Fn(&'a u8)>> { x }
+
+fn main() {
+    abc(&Foo(Box::new(|_x| ()), [0; 64]));
+}


### PR DESCRIPTION
Fixes #55976

Previously, we only erased early-bound regions. However, two types that
differ only in their regions (including late-bound regions) are
indistinguishable to LLVM, so it's safe to erase all regions.