### PR TITLE
Late link args order

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -1333,9 +1333,6 @@ fn add_late_link_args(
     crate_type: CrateType,
     codegen_results: &CodegenResults,
 ) {
-    if let Some(args) = sess.target.target.options.late_link_args.get(&flavor) {
-        cmd.args(args);
-    }
     let any_dynamic_crate = crate_type == CrateType::Dylib
         || codegen_results.crate_info.dependency_formats.iter().any(|(ty, list)| {
             *ty == crate_type && list.iter().any(|&linkage| linkage == Linkage::Dynamic)
@@ -1348,6 +1345,9 @@ fn add_late_link_args(
         if let Some(args) = sess.target.target.options.late_link_args_static.get(&flavor) {
             cmd.args(args);
         }
+    }
+    if let Some(args) = sess.target.target.options.late_link_args.get(&flavor) {
+        cmd.args(args);
     }
 }
 

--- a/compiler/rustc_target/src/spec/windows_gnu_base.rs
+++ b/compiler/rustc_target/src/spec/windows_gnu_base.rs
@@ -23,6 +23,7 @@ pub fn opts() -> TargetOptions {
         "-lmsvcrt".to_string(),
         "-lmingwex".to_string(),
         "-lmingw32".to_string(),
+        "-lgcc".to_string(), // alas, mingw* libraries above depend on libgcc
         // mingw's msvcrt is a weird hybrid import library and static library.
         // And it seems that the linker fails to use import symbols from msvcrt
         // that are required from functions in msvcrt in certain cases. For example
@@ -41,8 +42,6 @@ pub fn opts() -> TargetOptions {
         // the shared libgcc_s-dw2-1.dll. This is required to support
         // unwinding across DLL boundaries.
         "-lgcc_s".to_string(),
-        "-lgcc".to_string(),
-        "-lkernel32".to_string(),
     ];
     late_link_args_dynamic.insert(LinkerFlavor::Gcc, dynamic_unwind_libs.clone());
     late_link_args_dynamic.insert(LinkerFlavor::Lld(LldFlavor::Ld), dynamic_unwind_libs);
@@ -54,10 +53,6 @@ pub fn opts() -> TargetOptions {
         // boundaries when unwinding across FFI boundaries.
         "-lgcc_eh".to_string(),
         "-l:libpthread.a".to_string(),
-        "-lgcc".to_string(),
-        // libpthread depends on libmsvcrt, so we need to link it *again*.
-        "-lmsvcrt".to_string(),
-        "-lkernel32".to_string(),
     ];
     late_link_args_static.insert(LinkerFlavor::Gcc, static_unwind_libs.clone());
     late_link_args_static.insert(LinkerFlavor::Lld(LldFlavor::Ld), static_unwind_libs);


### PR DESCRIPTION
MSYS2 changed how winpthreads is built and as the result it now depends on more mingw-w64 libraries.

This PR affects only MinGW targets since nobody else is using `late_link_args_{dynamic,static}`. Now the order is similar to how it used to be before https://github.com/rust-lang/rust/pull/67502.