### PR TITLE
Rollup of 10 pull requests

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -1333,9 +1333,6 @@ fn add_late_link_args(
     crate_type: CrateType,
     codegen_results: &CodegenResults,
 ) {
-    if let Some(args) = sess.target.target.options.late_link_args.get(&flavor) {
-        cmd.args(args);
-    }
     let any_dynamic_crate = crate_type == CrateType::Dylib
         || codegen_results.crate_info.dependency_formats.iter().any(|(ty, list)| {
             *ty == crate_type && list.iter().any(|&linkage| linkage == Linkage::Dynamic)
@@ -1348,6 +1345,9 @@ fn add_late_link_args(
         if let Some(args) = sess.target.target.options.late_link_args_static.get(&flavor) {
             cmd.args(args);
         }
+    }
+    if let Some(args) = sess.target.target.options.late_link_args.get(&flavor) {
+        cmd.args(args);
     }
 }
 

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -682,25 +682,31 @@ pub enum BorrowKind {
     /// implicit closure bindings. It is needed when the closure
     /// is borrowing or mutating a mutable referent, e.g.:
     ///
-    ///    let x: &mut isize = ...;
-    ///    let y = || *x += 5;
+    /// ```
+    /// let x: &mut isize = ...;
+    /// let y = || *x += 5;
+    /// ```
     ///
     /// If we were to try to translate this closure into a more explicit
     /// form, we'd encounter an error with the code as written:
     ///
-    ///    struct Env { x: & &mut isize }
-    ///    let x: &mut isize = ...;
-    ///    let y = (&mut Env { &x }, fn_ptr);  // Closure is pair of env and fn
-    ///    fn fn_ptr(env: &mut Env) { **env.x += 5; }
+    /// ```
+    /// struct Env { x: & &mut isize }
+    /// let x: &mut isize = ...;
+    /// let y = (&mut Env { &x }, fn_ptr);  // Closure is pair of env and fn
+    /// fn fn_ptr(env: &mut Env) { **env.x += 5; }
+    /// ```
     ///
     /// This is then illegal because you cannot mutate a `&mut` found
     /// in an aliasable location. To solve, you'd have to translate with
     /// an `&mut` borrow:
     ///
-    ///    struct Env { x: & &mut isize }
-    ///    let x: &mut isize = ...;
-    ///    let y = (&mut Env { &mut x }, fn_ptr); // changed from &x to &mut x
-    ///    fn fn_ptr(env: &mut Env) { **env.x += 5; }
+    /// ```
+    /// struct Env { x: & &mut isize }
+    /// let x: &mut isize = ...;
+    /// let y = (&mut Env { &mut x }, fn_ptr); // changed from &x to &mut x
+    /// fn fn_ptr(env: &mut Env) { **env.x += 5; }
+    /// ```
     ///
     /// Now the assignment to `**env.x` is legal, but creating a
     /// mutable pointer to `x` is not because `x` is not mutable. We

--- a/compiler/rustc_mir/src/transform/const_prop.rs
+++ b/compiler/rustc_mir/src/transform/const_prop.rs
@@ -1046,9 +1046,9 @@ impl<'mir, 'tcx> MutVisitor<'tcx> for ConstPropagator<'mir, 'tcx> {
     fn visit_operand(&mut self, operand: &mut Operand<'tcx>, location: Location) {
         self.super_operand(operand, location);
 
-        // Only const prop copies and moves on `mir_opt_level=3` as doing so
-        // currently increases compile time.
-        if self.tcx.sess.opts.debugging_opts.mir_opt_level >= 3 {
+        // Only const prop copies and moves on `mir_opt_level=2` as doing so
+        // currently slightly increases compile time in some cases.
+        if self.tcx.sess.opts.debugging_opts.mir_opt_level >= 2 {
             self.propagate_operand(operand)
         }
     }
@@ -1246,8 +1246,8 @@ impl<'mir, 'tcx> MutVisitor<'tcx> for ConstPropagator<'mir, 'tcx> {
             | TerminatorKind::InlineAsm { .. } => {}
             // Every argument in our function calls have already been propagated in `visit_operand`.
             //
-            // NOTE: because LLVM codegen gives performance regressions with it, so this is gated
-            // on `mir_opt_level=3`.
+            // NOTE: because LLVM codegen gives slight performance regressions with it, so this is
+            // gated on `mir_opt_level=2`.
             TerminatorKind::Call { .. } => {}
         }
 

--- a/compiler/rustc_mir/src/transform/mod.rs
+++ b/compiler/rustc_mir/src/transform/mod.rs
@@ -36,7 +36,6 @@ pub mod match_branches;
 pub mod no_landing_pads;
 pub mod nrvo;
 pub mod promote_consts;
-pub mod qualify_min_const_fn;
 pub mod remove_noop_landing_pads;
 pub mod remove_unneeded_drops;
 pub mod required_consts;

--- a/compiler/rustc_parse/src/lib.rs
+++ b/compiler/rustc_parse/src/lib.rs
@@ -299,7 +299,7 @@ pub fn nt_to_tokenstream(nt: &Nonterminal, sess: &ParseSess, span: Span) -> Toke
     // FIXME(#43081): Avoid this pretty-print + reparse hack
     let source = pprust::nonterminal_to_string(nt);
     let filename = FileName::macro_expansion_source_code(&source);
-    let tokens_for_real = parse_stream_from_source_str(filename, source, sess, Some(span));
+    let reparsed_tokens = parse_stream_from_source_str(filename, source, sess, Some(span));
 
     // During early phases of the compiler the AST could get modified
     // directly (e.g., attributes added or removed) and the internal cache
@@ -325,7 +325,7 @@ pub fn nt_to_tokenstream(nt: &Nonterminal, sess: &ParseSess, span: Span) -> Toke
     // modifications, including adding/removing typically non-semantic
     // tokens such as extra braces and commas, don't happen.
     if let Some(tokens) = tokens {
-        if tokenstream_probably_equal_for_proc_macro(&tokens, &tokens_for_real, sess) {
+        if tokenstream_probably_equal_for_proc_macro(&tokens, &reparsed_tokens, sess) {
             return tokens;
         }
         info!(
@@ -333,9 +333,9 @@ pub fn nt_to_tokenstream(nt: &Nonterminal, sess: &ParseSess, span: Span) -> Toke
                 going with stringified version"
         );
         info!("cached tokens: {:?}", tokens);
-        info!("reparsed tokens: {:?}", tokens_for_real);
+        info!("reparsed tokens: {:?}", reparsed_tokens);
     }
-    tokens_for_real
+    reparsed_tokens
 }
 
 // See comments in `Nonterminal::to_tokenstream` for why we care about
@@ -344,8 +344,8 @@ pub fn nt_to_tokenstream(nt: &Nonterminal, sess: &ParseSess, span: Span) -> Toke
 // This is otherwise the same as `eq_unspanned`, only recursing with a
 // different method.
 pub fn tokenstream_probably_equal_for_proc_macro(
-    first: &TokenStream,
-    other: &TokenStream,
+    tokens: &TokenStream,
+    reparsed_tokens: &TokenStream,
     sess: &ParseSess,
 ) -> bool {
     // When checking for `probably_eq`, we ignore certain tokens that aren't
@@ -460,10 +460,11 @@ pub fn tokenstream_probably_equal_for_proc_macro(
 
     // Break tokens after we expand any nonterminals, so that we break tokens
     // that are produced as a result of nonterminal expansion.
-    let t1 = first.trees().filter(semantic_tree).flat_map(expand_nt).flat_map(break_tokens);
-    let t2 = other.trees().filter(semantic_tree).flat_map(expand_nt).flat_map(break_tokens);
+    let tokens = tokens.trees().filter(semantic_tree).flat_map(expand_nt).flat_map(break_tokens);
+    let reparsed_tokens =
+        reparsed_tokens.trees().filter(semantic_tree).flat_map(expand_nt).flat_map(break_tokens);
 
-    t1.eq_by(t2, |t1, t2| tokentree_probably_equal_for_proc_macro(&t1, &t2, sess))
+    tokens.eq_by(reparsed_tokens, |t, rt| tokentree_probably_equal_for_proc_macro(&t, &rt, sess))
 }
 
 // See comments in `Nonterminal::to_tokenstream` for why we care about
@@ -472,16 +473,20 @@ pub fn tokenstream_probably_equal_for_proc_macro(
 // This is otherwise the same as `eq_unspanned`, only recursing with a
 // different method.
 pub fn tokentree_probably_equal_for_proc_macro(
-    first: &TokenTree,
-    other: &TokenTree,
+    token: &TokenTree,
+    reparsed_token: &TokenTree,
     sess: &ParseSess,
 ) -> bool {
-    match (first, other) {
-        (TokenTree::Token(token), TokenTree::Token(token2)) => {
-            token_probably_equal_for_proc_macro(token, token2)
+    match (token, reparsed_token) {
+        (TokenTree::Token(token), TokenTree::Token(reparsed_token)) => {
+            token_probably_equal_for_proc_macro(token, reparsed_token)
         }
-        (TokenTree::Delimited(_, delim, tts), TokenTree::Delimited(_, delim2, tts2)) => {
-            delim == delim2 && tokenstream_probably_equal_for_proc_macro(&tts, &tts2, sess)
+        (
+            TokenTree::Delimited(_, delim, tokens),
+            TokenTree::Delimited(_, reparsed_delim, reparsed_tokens),
+        ) => {
+            delim == reparsed_delim
+                && tokenstream_probably_equal_for_proc_macro(tokens, reparsed_tokens, sess)
         }
         _ => false,
     }

--- a/compiler/rustc_parse/src/lib.rs
+++ b/compiler/rustc_parse/src/lib.rs
@@ -7,7 +7,7 @@
 #![feature(or_patterns)]
 
 use rustc_ast as ast;
-use rustc_ast::token::{self, DelimToken, Nonterminal, Token, TokenKind};
+use rustc_ast::token::{self, Nonterminal, Token, TokenKind};
 use rustc_ast::tokenstream::{self, Spacing, TokenStream, TokenTree};
 use rustc_ast_pretty::pprust;
 use rustc_data_structures::sync::Lrc;
@@ -359,9 +359,6 @@ pub fn tokenstream_probably_equal_for_proc_macro(
                 // The pretty printer tends to add trailing commas to
                 // everything, and in particular, after struct fields.
                 | token::Comma
-                // The pretty printer emits `NoDelim` as whitespace.
-                | token::OpenDelim(DelimToken::NoDelim)
-                | token::CloseDelim(DelimToken::NoDelim)
                 // The pretty printer collapses many semicolons into one.
                 | token::Semi
                 // We don't preserve leading `|` tokens in patterns, so

--- a/compiler/rustc_target/src/spec/windows_gnu_base.rs
+++ b/compiler/rustc_target/src/spec/windows_gnu_base.rs
@@ -23,6 +23,7 @@ pub fn opts() -> TargetOptions {
         "-lmsvcrt".to_string(),
         "-lmingwex".to_string(),
         "-lmingw32".to_string(),
+        "-lgcc".to_string(), // alas, mingw* libraries above depend on libgcc
         // mingw's msvcrt is a weird hybrid import library and static library.
         // And it seems that the linker fails to use import symbols from msvcrt
         // that are required from functions in msvcrt in certain cases. For example
@@ -41,8 +42,6 @@ pub fn opts() -> TargetOptions {
         // the shared libgcc_s-dw2-1.dll. This is required to support
         // unwinding across DLL boundaries.
         "-lgcc_s".to_string(),
-        "-lgcc".to_string(),
-        "-lkernel32".to_string(),
     ];
     late_link_args_dynamic.insert(LinkerFlavor::Gcc, dynamic_unwind_libs.clone());
     late_link_args_dynamic.insert(LinkerFlavor::Lld(LldFlavor::Ld), dynamic_unwind_libs);
@@ -54,10 +53,6 @@ pub fn opts() -> TargetOptions {
         // boundaries when unwinding across FFI boundaries.
         "-lgcc_eh".to_string(),
         "-l:libpthread.a".to_string(),
-        "-lgcc".to_string(),
-        // libpthread depends on libmsvcrt, so we need to link it *again*.
-        "-lmsvcrt".to_string(),
-        "-lkernel32".to_string(),
     ];
     late_link_args_static.insert(LinkerFlavor::Gcc, static_unwind_libs.clone());
     late_link_args_static.insert(LinkerFlavor::Lld(LldFlavor::Ld), static_unwind_libs);

--- a/library/alloc/benches/vec.rs
+++ b/library/alloc/benches/vec.rs
@@ -1,4 +1,4 @@
-use rand::prelude::*;
+use rand::RngCore;
 use std::iter::{repeat, FromIterator};
 use test::{black_box, Bencher};
 

--- a/library/core/tests/num/mod.rs
+++ b/library/core/tests/num/mod.rs
@@ -634,14 +634,18 @@ assume_usize_width! {
 macro_rules! test_float {
     ($modname: ident, $fty: ty, $inf: expr, $neginf: expr, $nan: expr) => {
         mod $modname {
-            // FIXME(nagisa): these tests should test for sign of -0.0
             #[test]
             fn min() {
                 assert_eq!((0.0 as $fty).min(0.0), 0.0);
+                assert!((0.0 as $fty).min(0.0).is_sign_positive());
                 assert_eq!((-0.0 as $fty).min(-0.0), -0.0);
+                assert!((-0.0 as $fty).min(-0.0).is_sign_negative());
                 assert_eq!((9.0 as $fty).min(9.0), 9.0);
                 assert_eq!((-9.0 as $fty).min(0.0), -9.0);
                 assert_eq!((0.0 as $fty).min(9.0), 0.0);
+                assert!((0.0 as $fty).min(9.0).is_sign_positive());
+                assert_eq!((-0.0 as $fty).min(9.0), -0.0);
+                assert!((-0.0 as $fty).min(9.0).is_sign_negative());
                 assert_eq!((-0.0 as $fty).min(-9.0), -9.0);
                 assert_eq!(($inf as $fty).min(9.0), 9.0);
                 assert_eq!((9.0 as $fty).min($inf), 9.0);
@@ -660,11 +664,19 @@ macro_rules! test_float {
             #[test]
             fn max() {
                 assert_eq!((0.0 as $fty).max(0.0), 0.0);
+                assert!((0.0 as $fty).max(0.0).is_sign_positive());
                 assert_eq!((-0.0 as $fty).max(-0.0), -0.0);
+                assert!((-0.0 as $fty).max(-0.0).is_sign_negative());
                 assert_eq!((9.0 as $fty).max(9.0), 9.0);
                 assert_eq!((-9.0 as $fty).max(0.0), 0.0);
+                assert!((-9.0 as $fty).max(0.0).is_sign_positive());
+                assert_eq!((-9.0 as $fty).max(-0.0), -0.0);
+                assert!((-9.0 as $fty).max(-0.0).is_sign_negative());
                 assert_eq!((0.0 as $fty).max(9.0), 9.0);
+                assert_eq!((0.0 as $fty).max(-9.0), 0.0);
+                assert!((0.0 as $fty).max(-9.0).is_sign_positive());
                 assert_eq!((-0.0 as $fty).max(-9.0), -0.0);
+                assert!((-0.0 as $fty).max(-9.0).is_sign_negative());
                 assert_eq!(($inf as $fty).max(9.0), $inf);
                 assert_eq!((9.0 as $fty).max($inf), $inf);
                 assert_eq!(($inf as $fty).max(-9.0), $inf);

--- a/library/std/src/collections/hash/map.rs
+++ b/library/std/src/collections/hash/map.rs
@@ -1102,6 +1102,16 @@ where
 /// documentation for more.
 ///
 /// [`iter`]: HashMap::iter
+///
+/// # Example
+///
+/// ```
+/// use std::collections::HashMap;
+///
+/// let mut map = HashMap::new();
+/// map.insert("a", 1);
+/// let iter = map.iter();
+/// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct Iter<'a, K: 'a, V: 'a> {
     base: base::Iter<'a, K, V>,
@@ -1129,6 +1139,16 @@ impl<K: Debug, V: Debug> fmt::Debug for Iter<'_, K, V> {
 /// documentation for more.
 ///
 /// [`iter_mut`]: HashMap::iter_mut
+///
+/// # Example
+///
+/// ```
+/// use std::collections::HashMap;
+///
+/// let mut map = HashMap::new();
+/// map.insert("a", 1);
+/// let iter = map.iter_mut();
+/// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct IterMut<'a, K: 'a, V: 'a> {
     base: base::IterMut<'a, K, V>,
@@ -1148,6 +1168,16 @@ impl<'a, K, V> IterMut<'a, K, V> {
 /// (provided by the `IntoIterator` trait). See its documentation for more.
 ///
 /// [`into_iter`]: IntoIterator::into_iter
+///
+/// # Example
+///
+/// ```
+/// use std::collections::HashMap;
+///
+/// let mut map = HashMap::new();
+/// map.insert("a", 1);
+/// let iter = map.into_iter();
+/// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct IntoIter<K, V> {
     base: base::IntoIter<K, V>,
@@ -1167,6 +1197,16 @@ impl<K, V> IntoIter<K, V> {
 /// documentation for more.
 ///
 /// [`keys`]: HashMap::keys
+///
+/// # Example
+///
+/// ```
+/// use std::collections::HashMap;
+///
+/// let mut map = HashMap::new();
+/// map.insert("a", 1);
+/// let iter_keys = map.keys();
+/// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct Keys<'a, K: 'a, V: 'a> {
     inner: Iter<'a, K, V>,
@@ -1194,6 +1234,16 @@ impl<K: Debug, V> fmt::Debug for Keys<'_, K, V> {
 /// documentation for more.
 ///
 /// [`values`]: HashMap::values
+///
+/// # Example
+///
+/// ```
+/// use std::collections::HashMap;
+///
+/// let mut map = HashMap::new();
+/// map.insert("a", 1);
+/// let iter_values = map.values();
+/// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct Values<'a, K: 'a, V: 'a> {
     inner: Iter<'a, K, V>,
@@ -1221,6 +1271,16 @@ impl<K, V: Debug> fmt::Debug for Values<'_, K, V> {
 /// documentation for more.
 ///
 /// [`drain`]: HashMap::drain
+///
+/// # Example
+///
+/// ```
+/// use std::collections::HashMap;
+///
+/// let mut map = HashMap::new();
+/// map.insert("a", 1);
+/// let iter = map.drain();
+/// ```
 #[stable(feature = "drain", since = "1.6.0")]
 pub struct Drain<'a, K: 'a, V: 'a> {
     base: base::Drain<'a, K, V>,
@@ -1239,6 +1299,18 @@ impl<'a, K, V> Drain<'a, K, V> {
 /// This `struct` is created by the [`drain_filter`] method on [`HashMap`].
 ///
 /// [`drain_filter`]: HashMap::drain_filter
+///
+/// # Example
+///
+/// ```
+/// #![feature(hash_drain_filter)]
+///
+/// use std::collections::HashMap;
+///
+/// let mut map = HashMap::new();
+/// map.insert("a", 1);
+/// let iter = map.drain_filter(|_k, v| *v % 2 == 0);
+/// ```
 #[unstable(feature = "hash_drain_filter", issue = "59618")]
 pub struct DrainFilter<'a, K, V, F>
 where
@@ -1253,6 +1325,16 @@ where
 /// documentation for more.
 ///
 /// [`values_mut`]: HashMap::values_mut
+///
+/// # Example
+///
+/// ```
+/// use std::collections::HashMap;
+///
+/// let mut map = HashMap::new();
+/// map.insert("a", 1);
+/// let iter_values = map.values_mut();
+/// ```
 #[stable(feature = "map_values_mut", since = "1.10.0")]
 pub struct ValuesMut<'a, K: 'a, V: 'a> {
     inner: IterMut<'a, K, V>,
@@ -1264,6 +1346,18 @@ pub struct ValuesMut<'a, K: 'a, V: 'a> {
 /// See its documentation for more.
 ///
 /// [`into_keys`]: HashMap::into_keys
+///
+/// # Example
+///
+/// ```
+/// #![feature(map_into_keys_values)]
+///
+/// use std::collections::HashMap;
+///
+/// let mut map = HashMap::new();
+/// map.insert("a", 1);
+/// let iter_keys = map.into_keys();
+/// ```
 #[unstable(feature = "map_into_keys_values", issue = "75294")]
 pub struct IntoKeys<K, V> {
     inner: IntoIter<K, V>,
@@ -1275,6 +1369,18 @@ pub struct IntoKeys<K, V> {
 /// See its documentation for more.
 ///
 /// [`into_values`]: HashMap::into_values
+///
+/// # Example
+///
+/// ```
+/// #![feature(map_into_keys_values)]
+///
+/// use std::collections::HashMap;
+///
+/// let mut map = HashMap::new();
+/// map.insert("a", 1);
+/// let iter_keys = map.into_values();
+/// ```
 #[unstable(feature = "map_into_keys_values", issue = "75294")]
 pub struct IntoValues<K, V> {
     inner: IntoIter<K, V>,
@@ -1285,7 +1391,6 @@ pub struct IntoValues<K, V> {
 /// See the [`HashMap::raw_entry_mut`] docs for usage examples.
 ///
 /// [`HashMap::raw_entry_mut`]: HashMap::raw_entry_mut
-
 #[unstable(feature = "hash_raw_entry", issue = "56167")]
 pub struct RawEntryBuilderMut<'a, K: 'a, V: 'a, S: 'a> {
     map: &'a mut HashMap<K, V, S>,

--- a/src/test/ui/proc-macro/issue-75930-derive-cfg.rs
+++ b/src/test/ui/proc-macro/issue-75930-derive-cfg.rs
@@ -1,29 +1,65 @@
 // check-pass
-// compile-flags: -Z span-debug
+// compile-flags: -Z span-debug --error-format human
 // aux-build:test-macros.rs
 
 // Regression test for issue #75930
 // Tests that we cfg-strip all targets before invoking
 // a derive macro
+// We need '--error-format human' to stop compiletest from
+// trying to interpret proc-macro output as JSON messages
+// (a pretty-printed struct may cause a line to start with '{' )
+// FIXME: We currently lose spans here (see issue #43081)
 
 #[macro_use]
 extern crate test_macros;
 
+#[print_helper(a)]
+#[cfg_attr(not(FALSE), allow(dead_code))]
+#[print_attr]
 #[derive(Print)]
+#[print_helper(b)]
 struct Foo<#[cfg(FALSE)] A, B> {
     #[cfg(FALSE)] first: String,
-    second: bool,
+    #[cfg_attr(FALSE, deny(warnings))] second: bool,
     third: [u8; {
         #[cfg(FALSE)] struct Bar;
         #[cfg(not(FALSE))] struct Inner;
         #[cfg(FALSE)] let a = 25;
         match true {
             #[cfg(FALSE)] true => {},
-            false => {},
+            #[cfg_attr(not(FALSE), allow(warnings))] false => {},
             _ => {}
         };
+
+        #[print_helper(should_be_removed)]
+        fn removed_fn() {
+            #![cfg(FALSE)]
+        }
+
+        #[print_helper(c)] #[cfg(not(FALSE))] fn kept_fn() {
+            #![cfg(not(FALSE))]
+            let my_val = true;
+        }
+
+        enum TupleEnum {
+            Foo(
+                #[cfg(FALSE)] u8,
+                #[cfg(FALSE)] bool,
+                #[cfg(not(FALSE))] i32,
+                #[cfg(FALSE)] String, u8
+            )
+        }
+
+        struct TupleStruct(
+            #[cfg(FALSE)] String,
+            #[cfg(not(FALSE))] i32,
+            #[cfg(FALSE)] bool,
+            u8
+        );
+
         0
     }],
+    #[print_helper(d)]
     fourth: B
 }
 

--- a/src/test/ui/proc-macro/issue-75930-derive-cfg.stdout
+++ b/src/test/ui/proc-macro/issue-75930-derive-cfg.stdout
@@ -1,13 +1,1288 @@
-PRINT-DERIVE INPUT (DISPLAY): struct Foo < B >
+PRINT-ATTR INPUT (DISPLAY): #[allow(dead_code)] #[derive(Print)] #[print_helper(b)] #[print_helper(a)]
+struct Foo < #[cfg(FALSE)] A, B >
+{
+    #[cfg(FALSE)] first : String, #[cfg_attr(FALSE, deny(warnings))] second :
+    bool, third :
+    [u8 ;
+     {
+         #[cfg(FALSE)] struct Bar ; #[cfg(not(FALSE))] struct Inner ;
+         #[cfg(FALSE)] let a = 25 ; match true
+         {
+             #[cfg(FALSE)] true => { },
+             #[cfg_attr(not(FALSE), allow(warnings))] false => { }, _ => { }
+         } ; #[print_helper(should_be_removed)] fn removed_fn()
+         { # ! [cfg(FALSE)] } #[print_helper(c)] #[cfg(not(FALSE))] fn
+         kept_fn() { # ! [cfg(not(FALSE))] let my_val = true ; } enum
+         TupleEnum
+         {
+             Foo(#[cfg(FALSE)] u8, #[cfg(FALSE)] bool, #[cfg(not(FALSE))] i32,
+                 #[cfg(FALSE)] String, u8)
+         } struct
+         TupleStruct(#[cfg(FALSE)] String, #[cfg(not(FALSE))] i32,
+                     #[cfg(FALSE)] bool, u8) ; 0
+     }], #[print_helper(d)] fourth : B
+}
+PRINT-ATTR INPUT (DEBUG): TokenStream [
+    Punct {
+        ch: '#',
+        spacing: Alone,
+        span: $DIR/issue-75930-derive-cfg.rs:17:24: 17:40 (#0),
+    },
+    Group {
+        delimiter: Bracket,
+        stream: TokenStream [
+            Ident {
+                ident: "allow",
+                span: $DIR/issue-75930-derive-cfg.rs:17:24: 17:29 (#0),
+            },
+            Group {
+                delimiter: Parenthesis,
+                stream: TokenStream [
+                    Ident {
+                        ident: "dead_code",
+                        span: $DIR/issue-75930-derive-cfg.rs:17:30: 17:39 (#0),
+                    },
+                ],
+                span: $DIR/issue-75930-derive-cfg.rs:17:29: 17:40 (#0),
+            },
+        ],
+        span: $DIR/issue-75930-derive-cfg.rs:17:24: 17:40 (#0),
+    },
+    Punct {
+        ch: '#',
+        spacing: Alone,
+        span: $DIR/issue-75930-derive-cfg.rs:19:1: 19:17 (#0),
+    },
+    Group {
+        delimiter: Bracket,
+        stream: TokenStream [
+            Ident {
+                ident: "derive",
+                span: $DIR/issue-75930-derive-cfg.rs:19:3: 19:9 (#0),
+            },
+            Group {
+                delimiter: Parenthesis,
+                stream: TokenStream [
+                    Ident {
+                        ident: "Print",
+                        span: $DIR/issue-75930-derive-cfg.rs:19:10: 19:15 (#0),
+                    },
+                ],
+                span: $DIR/issue-75930-derive-cfg.rs:19:9: 19:16 (#0),
+            },
+        ],
+        span: $DIR/issue-75930-derive-cfg.rs:19:1: 19:17 (#0),
+    },
+    Punct {
+        ch: '#',
+        spacing: Alone,
+        span: $DIR/issue-75930-derive-cfg.rs:20:1: 20:19 (#0),
+    },
+    Group {
+        delimiter: Bracket,
+        stream: TokenStream [
+            Ident {
+                ident: "print_helper",
+                span: $DIR/issue-75930-derive-cfg.rs:20:3: 20:15 (#0),
+            },
+            Group {
+                delimiter: Parenthesis,
+                stream: TokenStream [
+                    Ident {
+                        ident: "b",
+                        span: $DIR/issue-75930-derive-cfg.rs:20:16: 20:17 (#0),
+                    },
+                ],
+                span: $DIR/issue-75930-derive-cfg.rs:20:15: 20:18 (#0),
+            },
+        ],
+        span: $DIR/issue-75930-derive-cfg.rs:20:1: 20:19 (#0),
+    },
+    Punct {
+        ch: '#',
+        spacing: Alone,
+        span: $DIR/issue-75930-derive-cfg.rs:16:1: 16:19 (#0),
+    },
+    Group {
+        delimiter: Bracket,
+        stream: TokenStream [
+            Ident {
+                ident: "print_helper",
+                span: $DIR/issue-75930-derive-cfg.rs:16:3: 16:15 (#0),
+            },
+            Group {
+                delimiter: Parenthesis,
+                stream: TokenStream [
+                    Ident {
+                        ident: "a",
+                        span: $DIR/issue-75930-derive-cfg.rs:16:16: 16:17 (#0),
+                    },
+                ],
+                span: $DIR/issue-75930-derive-cfg.rs:16:15: 16:18 (#0),
+            },
+        ],
+        span: $DIR/issue-75930-derive-cfg.rs:16:1: 16:19 (#0),
+    },
+    Ident {
+        ident: "struct",
+        span: $DIR/issue-75930-derive-cfg.rs:21:1: 21:7 (#0),
+    },
+    Ident {
+        ident: "Foo",
+        span: $DIR/issue-75930-derive-cfg.rs:21:8: 21:11 (#0),
+    },
+    Punct {
+        ch: '<',
+        spacing: Joint,
+        span: $DIR/issue-75930-derive-cfg.rs:21:11: 21:12 (#0),
+    },
+    Punct {
+        ch: '#',
+        spacing: Alone,
+        span: $DIR/issue-75930-derive-cfg.rs:21:12: 21:13 (#0),
+    },
+    Group {
+        delimiter: Bracket,
+        stream: TokenStream [
+            Ident {
+                ident: "cfg",
+                span: $DIR/issue-75930-derive-cfg.rs:21:14: 21:17 (#0),
+            },
+            Group {
+                delimiter: Parenthesis,
+                stream: TokenStream [
+                    Ident {
+                        ident: "FALSE",
+                        span: $DIR/issue-75930-derive-cfg.rs:21:18: 21:23 (#0),
+                    },
+                ],
+                span: $DIR/issue-75930-derive-cfg.rs:21:17: 21:24 (#0),
+            },
+        ],
+        span: $DIR/issue-75930-derive-cfg.rs:21:13: 21:25 (#0),
+    },
+    Ident {
+        ident: "A",
+        span: $DIR/issue-75930-derive-cfg.rs:21:26: 21:27 (#0),
+    },
+    Punct {
+        ch: ',',
+        spacing: Alone,
+        span: $DIR/issue-75930-derive-cfg.rs:21:27: 21:28 (#0),
+    },
+    Ident {
+        ident: "B",
+        span: $DIR/issue-75930-derive-cfg.rs:21:29: 21:30 (#0),
+    },
+    Punct {
+        ch: '>',
+        spacing: Alone,
+        span: $DIR/issue-75930-derive-cfg.rs:21:30: 21:31 (#0),
+    },
+    Group {
+        delimiter: Brace,
+        stream: TokenStream [
+            Punct {
+                ch: '#',
+                spacing: Alone,
+                span: $DIR/issue-75930-derive-cfg.rs:22:5: 22:6 (#0),
+            },
+            Group {
+                delimiter: Bracket,
+                stream: TokenStream [
+                    Ident {
+                        ident: "cfg",
+                        span: $DIR/issue-75930-derive-cfg.rs:22:7: 22:10 (#0),
+                    },
+                    Group {
+                        delimiter: Parenthesis,
+                        stream: TokenStream [
+                            Ident {
+                                ident: "FALSE",
+                                span: $DIR/issue-75930-derive-cfg.rs:22:11: 22:16 (#0),
+                            },
+                        ],
+                        span: $DIR/issue-75930-derive-cfg.rs:22:10: 22:17 (#0),
+                    },
+                ],
+                span: $DIR/issue-75930-derive-cfg.rs:22:6: 22:18 (#0),
+            },
+            Ident {
+                ident: "first",
+                span: $DIR/issue-75930-derive-cfg.rs:22:19: 22:24 (#0),
+            },
+            Punct {
+                ch: ':',
+                spacing: Alone,
+                span: $DIR/issue-75930-derive-cfg.rs:22:24: 22:25 (#0),
+            },
+            Ident {
+                ident: "String",
+                span: $DIR/issue-75930-derive-cfg.rs:22:26: 22:32 (#0),
+            },
+            Punct {
+                ch: ',',
+                spacing: Alone,
+                span: $DIR/issue-75930-derive-cfg.rs:22:32: 22:33 (#0),
+            },
+            Punct {
+                ch: '#',
+                spacing: Alone,
+                span: $DIR/issue-75930-derive-cfg.rs:23:5: 23:6 (#0),
+            },
+            Group {
+                delimiter: Bracket,
+                stream: TokenStream [
+                    Ident {
+                        ident: "cfg_attr",
+                        span: $DIR/issue-75930-derive-cfg.rs:23:7: 23:15 (#0),
+                    },
+                    Group {
+                        delimiter: Parenthesis,
+                        stream: TokenStream [
+                            Ident {
+                                ident: "FALSE",
+                                span: $DIR/issue-75930-derive-cfg.rs:23:16: 23:21 (#0),
+                            },
+                            Punct {
+                                ch: ',',
+                                spacing: Alone,
+                                span: $DIR/issue-75930-derive-cfg.rs:23:21: 23:22 (#0),
+                            },
+                            Ident {
+                                ident: "deny",
+                                span: $DIR/issue-75930-derive-cfg.rs:23:23: 23:27 (#0),
+                            },
+                            Group {
+                                delimiter: Parenthesis,
+                                stream: TokenStream [
+                                    Ident {
+                                        ident: "warnings",
+                                        span: $DIR/issue-75930-derive-cfg.rs:23:28: 23:36 (#0),
+                                    },
+                                ],
+                                span: $DIR/issue-75930-derive-cfg.rs:23:27: 23:37 (#0),
+                            },
+                        ],
+                        span: $DIR/issue-75930-derive-cfg.rs:23:15: 23:38 (#0),
+                    },
+                ],
+                span: $DIR/issue-75930-derive-cfg.rs:23:6: 23:39 (#0),
+            },
+            Ident {
+                ident: "second",
+                span: $DIR/issue-75930-derive-cfg.rs:23:40: 23:46 (#0),
+            },
+            Punct {
+                ch: ':',
+                spacing: Alone,
+                span: $DIR/issue-75930-derive-cfg.rs:23:46: 23:47 (#0),
+            },
+            Ident {
+                ident: "bool",
+                span: $DIR/issue-75930-derive-cfg.rs:23:48: 23:52 (#0),
+            },
+            Punct {
+                ch: ',',
+                spacing: Alone,
+                span: $DIR/issue-75930-derive-cfg.rs:23:52: 23:53 (#0),
+            },
+            Ident {
+                ident: "third",
+                span: $DIR/issue-75930-derive-cfg.rs:24:5: 24:10 (#0),
+            },
+            Punct {
+                ch: ':',
+                spacing: Alone,
+                span: $DIR/issue-75930-derive-cfg.rs:24:10: 24:11 (#0),
+            },
+            Group {
+                delimiter: Bracket,
+                stream: TokenStream [
+                    Ident {
+                        ident: "u8",
+                        span: $DIR/issue-75930-derive-cfg.rs:24:13: 24:15 (#0),
+                    },
+                    Punct {
+                        ch: ';',
+                        spacing: Alone,
+                        span: $DIR/issue-75930-derive-cfg.rs:24:15: 24:16 (#0),
+                    },
+                    Group {
+                        delimiter: Brace,
+                        stream: TokenStream [
+                            Punct {
+                                ch: '#',
+                                spacing: Alone,
+                                span: $DIR/issue-75930-derive-cfg.rs:25:9: 25:10 (#0),
+                            },
+                            Group {
+                                delimiter: Bracket,
+                                stream: TokenStream [
+                                    Ident {
+                                        ident: "cfg",
+                                        span: $DIR/issue-75930-derive-cfg.rs:25:11: 25:14 (#0),
+                                    },
+                                    Group {
+                                        delimiter: Parenthesis,
+                                        stream: TokenStream [
+                                            Ident {
+                                                ident: "FALSE",
+                                                span: $DIR/issue-75930-derive-cfg.rs:25:15: 25:20 (#0),
+                                            },
+                                        ],
+                                        span: $DIR/issue-75930-derive-cfg.rs:25:14: 25:21 (#0),
+                                    },
+                                ],
+                                span: $DIR/issue-75930-derive-cfg.rs:25:10: 25:22 (#0),
+                            },
+                            Ident {
+                                ident: "struct",
+                                span: $DIR/issue-75930-derive-cfg.rs:25:23: 25:29 (#0),
+                            },
+                            Ident {
+                                ident: "Bar",
+                                span: $DIR/issue-75930-derive-cfg.rs:25:30: 25:33 (#0),
+                            },
+                            Punct {
+                                ch: ';',
+                                spacing: Alone,
+                                span: $DIR/issue-75930-derive-cfg.rs:25:33: 25:34 (#0),
+                            },
+                            Punct {
+                                ch: '#',
+                                spacing: Alone,
+                                span: $DIR/issue-75930-derive-cfg.rs:26:9: 26:10 (#0),
+                            },
+                            Group {
+                                delimiter: Bracket,
+                                stream: TokenStream [
+                                    Ident {
+                                        ident: "cfg",
+                                        span: $DIR/issue-75930-derive-cfg.rs:26:11: 26:14 (#0),
+                                    },
+                                    Group {
+                                        delimiter: Parenthesis,
+                                        stream: TokenStream [
+                                            Ident {
+                                                ident: "not",
+                                                span: $DIR/issue-75930-derive-cfg.rs:26:15: 26:18 (#0),
+                                            },
+                                            Group {
+                                                delimiter: Parenthesis,
+                                                stream: TokenStream [
+                                                    Ident {
+                                                        ident: "FALSE",
+                                                        span: $DIR/issue-75930-derive-cfg.rs:26:19: 26:24 (#0),
+                                                    },
+                                                ],
+                                                span: $DIR/issue-75930-derive-cfg.rs:26:18: 26:25 (#0),
+                                            },
+                                        ],
+                                        span: $DIR/issue-75930-derive-cfg.rs:26:14: 26:26 (#0),
+                                    },
+                                ],
+                                span: $DIR/issue-75930-derive-cfg.rs:26:10: 26:27 (#0),
+                            },
+                            Ident {
+                                ident: "struct",
+                                span: $DIR/issue-75930-derive-cfg.rs:26:28: 26:34 (#0),
+                            },
+                            Ident {
+                                ident: "Inner",
+                                span: $DIR/issue-75930-derive-cfg.rs:26:35: 26:40 (#0),
+                            },
+                            Punct {
+                                ch: ';',
+                                spacing: Alone,
+                                span: $DIR/issue-75930-derive-cfg.rs:26:40: 26:41 (#0),
+                            },
+                            Punct {
+                                ch: '#',
+                                spacing: Alone,
+                                span: $DIR/issue-75930-derive-cfg.rs:27:9: 27:10 (#0),
+                            },
+                            Group {
+                                delimiter: Bracket,
+                                stream: TokenStream [
+                                    Ident {
+                                        ident: "cfg",
+                                        span: $DIR/issue-75930-derive-cfg.rs:27:11: 27:14 (#0),
+                                    },
+                                    Group {
+                                        delimiter: Parenthesis,
+                                        stream: TokenStream [
+                                            Ident {
+                                                ident: "FALSE",
+                                                span: $DIR/issue-75930-derive-cfg.rs:27:15: 27:20 (#0),
+                                            },
+                                        ],
+                                        span: $DIR/issue-75930-derive-cfg.rs:27:14: 27:21 (#0),
+                                    },
+                                ],
+                                span: $DIR/issue-75930-derive-cfg.rs:27:10: 27:22 (#0),
+                            },
+                            Ident {
+                                ident: "let",
+                                span: $DIR/issue-75930-derive-cfg.rs:27:23: 27:26 (#0),
+                            },
+                            Ident {
+                                ident: "a",
+                                span: $DIR/issue-75930-derive-cfg.rs:27:27: 27:28 (#0),
+                            },
+                            Punct {
+                                ch: '=',
+                                spacing: Alone,
+                                span: $DIR/issue-75930-derive-cfg.rs:27:29: 27:30 (#0),
+                            },
+                            Literal {
+                                kind: Integer,
+                                symbol: "25",
+                                suffix: None,
+                                span: $DIR/issue-75930-derive-cfg.rs:27:31: 27:33 (#0),
+                            },
+                            Punct {
+                                ch: ';',
+                                spacing: Alone,
+                                span: $DIR/issue-75930-derive-cfg.rs:27:33: 27:34 (#0),
+                            },
+                            Ident {
+                                ident: "match",
+                                span: $DIR/issue-75930-derive-cfg.rs:28:9: 28:14 (#0),
+                            },
+                            Ident {
+                                ident: "true",
+                                span: $DIR/issue-75930-derive-cfg.rs:28:15: 28:19 (#0),
+                            },
+                            Group {
+                                delimiter: Brace,
+                                stream: TokenStream [
+                                    Punct {
+                                        ch: '#',
+                                        spacing: Alone,
+                                        span: $DIR/issue-75930-derive-cfg.rs:29:13: 29:14 (#0),
+                                    },
+                                    Group {
+                                        delimiter: Bracket,
+                                        stream: TokenStream [
+                                            Ident {
+                                                ident: "cfg",
+                                                span: $DIR/issue-75930-derive-cfg.rs:29:15: 29:18 (#0),
+                                            },
+                                            Group {
+                                                delimiter: Parenthesis,
+                                                stream: TokenStream [
+                                                    Ident {
+                                                        ident: "FALSE",
+                                                        span: $DIR/issue-75930-derive-cfg.rs:29:19: 29:24 (#0),
+                                                    },
+                                                ],
+                                                span: $DIR/issue-75930-derive-cfg.rs:29:18: 29:25 (#0),
+                                            },
+                                        ],
+                                        span: $DIR/issue-75930-derive-cfg.rs:29:14: 29:26 (#0),
+                                    },
+                                    Ident {
+                                        ident: "true",
+                                        span: $DIR/issue-75930-derive-cfg.rs:29:27: 29:31 (#0),
+                                    },
+                                    Punct {
+                                        ch: '=',
+                                        spacing: Joint,
+                                        span: $DIR/issue-75930-derive-cfg.rs:29:32: 29:34 (#0),
+                                    },
+                                    Punct {
+                                        ch: '>',
+                                        spacing: Alone,
+                                        span: $DIR/issue-75930-derive-cfg.rs:29:32: 29:34 (#0),
+                                    },
+                                    Group {
+                                        delimiter: Brace,
+                                        stream: TokenStream [],
+                                        span: $DIR/issue-75930-derive-cfg.rs:29:35: 29:37 (#0),
+                                    },
+                                    Punct {
+                                        ch: ',',
+                                        spacing: Alone,
+                                        span: $DIR/issue-75930-derive-cfg.rs:29:37: 29:38 (#0),
+                                    },
+                                    Punct {
+                                        ch: '#',
+                                        spacing: Alone,
+                                        span: $DIR/issue-75930-derive-cfg.rs:30:13: 30:14 (#0),
+                                    },
+                                    Group {
+                                        delimiter: Bracket,
+                                        stream: TokenStream [
+                                            Ident {
+                                                ident: "cfg_attr",
+                                                span: $DIR/issue-75930-derive-cfg.rs:30:15: 30:23 (#0),
+                                            },
+                                            Group {
+                                                delimiter: Parenthesis,
+                                                stream: TokenStream [
+                                                    Ident {
+                                                        ident: "not",
+                                                        span: $DIR/issue-75930-derive-cfg.rs:30:24: 30:27 (#0),
+                                                    },
+                                                    Group {
+                                                        delimiter: Parenthesis,
+                                                        stream: TokenStream [
+                                                            Ident {
+                                                                ident: "FALSE",
+                                                                span: $DIR/issue-75930-derive-cfg.rs:30:28: 30:33 (#0),
+                                                            },
+                                                        ],
+                                                        span: $DIR/issue-75930-derive-cfg.rs:30:27: 30:34 (#0),
+                                                    },
+                                                    Punct {
+                                                        ch: ',',
+                                                        spacing: Alone,
+                                                        span: $DIR/issue-75930-derive-cfg.rs:30:34: 30:35 (#0),
+                                                    },
+                                                    Ident {
+                                                        ident: "allow",
+                                                        span: $DIR/issue-75930-derive-cfg.rs:30:36: 30:41 (#0),
+                                                    },
+                                                    Group {
+                                                        delimiter: Parenthesis,
+                                                        stream: TokenStream [
+                                                            Ident {
+                                                                ident: "warnings",
+                                                                span: $DIR/issue-75930-derive-cfg.rs:30:42: 30:50 (#0),
+                                                            },
+                                                        ],
+                                                        span: $DIR/issue-75930-derive-cfg.rs:30:41: 30:51 (#0),
+                                                    },
+                                                ],
+                                                span: $DIR/issue-75930-derive-cfg.rs:30:23: 30:52 (#0),
+                                            },
+                                        ],
+                                        span: $DIR/issue-75930-derive-cfg.rs:30:14: 30:53 (#0),
+                                    },
+                                    Ident {
+                                        ident: "false",
+                                        span: $DIR/issue-75930-derive-cfg.rs:30:54: 30:59 (#0),
+                                    },
+                                    Punct {
+                                        ch: '=',
+                                        spacing: Joint,
+                                        span: $DIR/issue-75930-derive-cfg.rs:30:60: 30:62 (#0),
+                                    },
+                                    Punct {
+                                        ch: '>',
+                                        spacing: Alone,
+                                        span: $DIR/issue-75930-derive-cfg.rs:30:60: 30:62 (#0),
+                                    },
+                                    Group {
+                                        delimiter: Brace,
+                                        stream: TokenStream [],
+                                        span: $DIR/issue-75930-derive-cfg.rs:30:63: 30:65 (#0),
+                                    },
+                                    Punct {
+                                        ch: ',',
+                                        spacing: Alone,
+                                        span: $DIR/issue-75930-derive-cfg.rs:30:65: 30:66 (#0),
+                                    },
+                                    Ident {
+                                        ident: "_",
+                                        span: $DIR/issue-75930-derive-cfg.rs:31:13: 31:14 (#0),
+                                    },
+                                    Punct {
+                                        ch: '=',
+                                        spacing: Joint,
+                                        span: $DIR/issue-75930-derive-cfg.rs:31:15: 31:17 (#0),
+                                    },
+                                    Punct {
+                                        ch: '>',
+                                        spacing: Alone,
+                                        span: $DIR/issue-75930-derive-cfg.rs:31:15: 31:17 (#0),
+                                    },
+                                    Group {
+                                        delimiter: Brace,
+                                        stream: TokenStream [],
+                                        span: $DIR/issue-75930-derive-cfg.rs:31:18: 31:20 (#0),
+                                    },
+                                ],
+                                span: $DIR/issue-75930-derive-cfg.rs:28:20: 32:10 (#0),
+                            },
+                            Punct {
+                                ch: ';',
+                                spacing: Alone,
+                                span: $DIR/issue-75930-derive-cfg.rs:32:10: 32:11 (#0),
+                            },
+                            Punct {
+                                ch: '#',
+                                spacing: Alone,
+                                span: $DIR/issue-75930-derive-cfg.rs:34:9: 34:10 (#0),
+                            },
+                            Group {
+                                delimiter: Bracket,
+                                stream: TokenStream [
+                                    Ident {
+                                        ident: "print_helper",
+                                        span: $DIR/issue-75930-derive-cfg.rs:34:11: 34:23 (#0),
+                                    },
+                                    Group {
+                                        delimiter: Parenthesis,
+                                        stream: TokenStream [
+                                            Ident {
+                                                ident: "should_be_removed",
+                                                span: $DIR/issue-75930-derive-cfg.rs:34:24: 34:41 (#0),
+                                            },
+                                        ],
+                                        span: $DIR/issue-75930-derive-cfg.rs:34:23: 34:42 (#0),
+                                    },
+                                ],
+                                span: $DIR/issue-75930-derive-cfg.rs:34:10: 34:43 (#0),
+                            },
+                            Ident {
+                                ident: "fn",
+                                span: $DIR/issue-75930-derive-cfg.rs:35:9: 35:11 (#0),
+                            },
+                            Ident {
+                                ident: "removed_fn",
+                                span: $DIR/issue-75930-derive-cfg.rs:35:12: 35:22 (#0),
+                            },
+                            Group {
+                                delimiter: Parenthesis,
+                                stream: TokenStream [],
+                                span: $DIR/issue-75930-derive-cfg.rs:35:22: 35:24 (#0),
+                            },
+                            Group {
+                                delimiter: Brace,
+                                stream: TokenStream [
+                                    Punct {
+                                        ch: '#',
+                                        spacing: Joint,
+                                        span: $DIR/issue-75930-derive-cfg.rs:36:13: 36:14 (#0),
+                                    },
+                                    Punct {
+                                        ch: '!',
+                                        spacing: Alone,
+                                        span: $DIR/issue-75930-derive-cfg.rs:36:14: 36:15 (#0),
+                                    },
+                                    Group {
+                                        delimiter: Bracket,
+                                        stream: TokenStream [
+                                            Ident {
+                                                ident: "cfg",
+                                                span: $DIR/issue-75930-derive-cfg.rs:36:16: 36:19 (#0),
+                                            },
+                                            Group {
+                                                delimiter: Parenthesis,
+                                                stream: TokenStream [
+                                                    Ident {
+                                                        ident: "FALSE",
+                                                        span: $DIR/issue-75930-derive-cfg.rs:36:20: 36:25 (#0),
+                                                    },
+                                                ],
+                                                span: $DIR/issue-75930-derive-cfg.rs:36:19: 36:26 (#0),
+                                            },
+                                        ],
+                                        span: $DIR/issue-75930-derive-cfg.rs:36:15: 36:27 (#0),
+                                    },
+                                ],
+                                span: $DIR/issue-75930-derive-cfg.rs:35:25: 37:10 (#0),
+                            },
+                            Punct {
+                                ch: '#',
+                                spacing: Alone,
+                                span: $DIR/issue-75930-derive-cfg.rs:39:9: 39:10 (#0),
+                            },
+                            Group {
+                                delimiter: Bracket,
+                                stream: TokenStream [
+                                    Ident {
+                                        ident: "print_helper",
+                                        span: $DIR/issue-75930-derive-cfg.rs:39:11: 39:23 (#0),
+                                    },
+                                    Group {
+                                        delimiter: Parenthesis,
+                                        stream: TokenStream [
+                                            Ident {
+                                                ident: "c",
+                                                span: $DIR/issue-75930-derive-cfg.rs:39:24: 39:25 (#0),
+                                            },
+                                        ],
+                                        span: $DIR/issue-75930-derive-cfg.rs:39:23: 39:26 (#0),
+                                    },
+                                ],
+                                span: $DIR/issue-75930-derive-cfg.rs:39:10: 39:27 (#0),
+                            },
+                            Punct {
+                                ch: '#',
+                                spacing: Alone,
+                                span: $DIR/issue-75930-derive-cfg.rs:39:28: 39:29 (#0),
+                            },
+                            Group {
+                                delimiter: Bracket,
+                                stream: TokenStream [
+                                    Ident {
+                                        ident: "cfg",
+                                        span: $DIR/issue-75930-derive-cfg.rs:39:30: 39:33 (#0),
+                                    },
+                                    Group {
+                                        delimiter: Parenthesis,
+                                        stream: TokenStream [
+                                            Ident {
+                                                ident: "not",
+                                                span: $DIR/issue-75930-derive-cfg.rs:39:34: 39:37 (#0),
+                                            },
+                                            Group {
+                                                delimiter: Parenthesis,
+                                                stream: TokenStream [
+                                                    Ident {
+                                                        ident: "FALSE",
+                                                        span: $DIR/issue-75930-derive-cfg.rs:39:38: 39:43 (#0),
+                                                    },
+                                                ],
+                                                span: $DIR/issue-75930-derive-cfg.rs:39:37: 39:44 (#0),
+                                            },
+                                        ],
+                                        span: $DIR/issue-75930-derive-cfg.rs:39:33: 39:45 (#0),
+                                    },
+                                ],
+                                span: $DIR/issue-75930-derive-cfg.rs:39:29: 39:46 (#0),
+                            },
+                            Ident {
+                                ident: "fn",
+                                span: $DIR/issue-75930-derive-cfg.rs:39:47: 39:49 (#0),
+                            },
+                            Ident {
+                                ident: "kept_fn",
+                                span: $DIR/issue-75930-derive-cfg.rs:39:50: 39:57 (#0),
+                            },
+                            Group {
+                                delimiter: Parenthesis,
+                                stream: TokenStream [],
+                                span: $DIR/issue-75930-derive-cfg.rs:39:57: 39:59 (#0),
+                            },
+                            Group {
+                                delimiter: Brace,
+                                stream: TokenStream [
+                                    Punct {
+                                        ch: '#',
+                                        spacing: Joint,
+                                        span: $DIR/issue-75930-derive-cfg.rs:40:13: 40:14 (#0),
+                                    },
+                                    Punct {
+                                        ch: '!',
+                                        spacing: Alone,
+                                        span: $DIR/issue-75930-derive-cfg.rs:40:14: 40:15 (#0),
+                                    },
+                                    Group {
+                                        delimiter: Bracket,
+                                        stream: TokenStream [
+                                            Ident {
+                                                ident: "cfg",
+                                                span: $DIR/issue-75930-derive-cfg.rs:40:16: 40:19 (#0),
+                                            },
+                                            Group {
+                                                delimiter: Parenthesis,
+                                                stream: TokenStream [
+                                                    Ident {
+                                                        ident: "not",
+                                                        span: $DIR/issue-75930-derive-cfg.rs:40:20: 40:23 (#0),
+                                                    },
+                                                    Group {
+                                                        delimiter: Parenthesis,
+                                                        stream: TokenStream [
+                                                            Ident {
+                                                                ident: "FALSE",
+                                                                span: $DIR/issue-75930-derive-cfg.rs:40:24: 40:29 (#0),
+                                                            },
+                                                        ],
+                                                        span: $DIR/issue-75930-derive-cfg.rs:40:23: 40:30 (#0),
+                                                    },
+                                                ],
+                                                span: $DIR/issue-75930-derive-cfg.rs:40:19: 40:31 (#0),
+                                            },
+                                        ],
+                                        span: $DIR/issue-75930-derive-cfg.rs:40:15: 40:32 (#0),
+                                    },
+                                    Ident {
+                                        ident: "let",
+                                        span: $DIR/issue-75930-derive-cfg.rs:41:13: 41:16 (#0),
+                                    },
+                                    Ident {
+                                        ident: "my_val",
+                                        span: $DIR/issue-75930-derive-cfg.rs:41:17: 41:23 (#0),
+                                    },
+                                    Punct {
+                                        ch: '=',
+                                        spacing: Alone,
+                                        span: $DIR/issue-75930-derive-cfg.rs:41:24: 41:25 (#0),
+                                    },
+                                    Ident {
+                                        ident: "true",
+                                        span: $DIR/issue-75930-derive-cfg.rs:41:26: 41:30 (#0),
+                                    },
+                                    Punct {
+                                        ch: ';',
+                                        spacing: Alone,
+                                        span: $DIR/issue-75930-derive-cfg.rs:41:30: 41:31 (#0),
+                                    },
+                                ],
+                                span: $DIR/issue-75930-derive-cfg.rs:39:60: 42:10 (#0),
+                            },
+                            Ident {
+                                ident: "enum",
+                                span: $DIR/issue-75930-derive-cfg.rs:44:9: 44:13 (#0),
+                            },
+                            Ident {
+                                ident: "TupleEnum",
+                                span: $DIR/issue-75930-derive-cfg.rs:44:14: 44:23 (#0),
+                            },
+                            Group {
+                                delimiter: Brace,
+                                stream: TokenStream [
+                                    Ident {
+                                        ident: "Foo",
+                                        span: $DIR/issue-75930-derive-cfg.rs:45:13: 45:16 (#0),
+                                    },
+                                    Group {
+                                        delimiter: Parenthesis,
+                                        stream: TokenStream [
+                                            Punct {
+                                                ch: '#',
+                                                spacing: Alone,
+                                                span: $DIR/issue-75930-derive-cfg.rs:46:17: 46:18 (#0),
+                                            },
+                                            Group {
+                                                delimiter: Bracket,
+                                                stream: TokenStream [
+                                                    Ident {
+                                                        ident: "cfg",
+                                                        span: $DIR/issue-75930-derive-cfg.rs:46:19: 46:22 (#0),
+                                                    },
+                                                    Group {
+                                                        delimiter: Parenthesis,
+                                                        stream: TokenStream [
+                                                            Ident {
+                                                                ident: "FALSE",
+                                                                span: $DIR/issue-75930-derive-cfg.rs:46:23: 46:28 (#0),
+                                                            },
+                                                        ],
+                                                        span: $DIR/issue-75930-derive-cfg.rs:46:22: 46:29 (#0),
+                                                    },
+                                                ],
+                                                span: $DIR/issue-75930-derive-cfg.rs:46:18: 46:30 (#0),
+                                            },
+                                            Ident {
+                                                ident: "u8",
+                                                span: $DIR/issue-75930-derive-cfg.rs:46:31: 46:33 (#0),
+                                            },
+                                            Punct {
+                                                ch: ',',
+                                                spacing: Alone,
+                                                span: $DIR/issue-75930-derive-cfg.rs:46:33: 46:34 (#0),
+                                            },
+                                            Punct {
+                                                ch: '#',
+                                                spacing: Alone,
+                                                span: $DIR/issue-75930-derive-cfg.rs:47:17: 47:18 (#0),
+                                            },
+                                            Group {
+                                                delimiter: Bracket,
+                                                stream: TokenStream [
+                                                    Ident {
+                                                        ident: "cfg",
+                                                        span: $DIR/issue-75930-derive-cfg.rs:47:19: 47:22 (#0),
+                                                    },
+                                                    Group {
+                                                        delimiter: Parenthesis,
+                                                        stream: TokenStream [
+                                                            Ident {
+                                                                ident: "FALSE",
+                                                                span: $DIR/issue-75930-derive-cfg.rs:47:23: 47:28 (#0),
+                                                            },
+                                                        ],
+                                                        span: $DIR/issue-75930-derive-cfg.rs:47:22: 47:29 (#0),
+                                                    },
+                                                ],
+                                                span: $DIR/issue-75930-derive-cfg.rs:47:18: 47:30 (#0),
+                                            },
+                                            Ident {
+                                                ident: "bool",
+                                                span: $DIR/issue-75930-derive-cfg.rs:47:31: 47:35 (#0),
+                                            },
+                                            Punct {
+                                                ch: ',',
+                                                spacing: Alone,
+                                                span: $DIR/issue-75930-derive-cfg.rs:47:35: 47:36 (#0),
+                                            },
+                                            Punct {
+                                                ch: '#',
+                                                spacing: Alone,
+                                                span: $DIR/issue-75930-derive-cfg.rs:48:17: 48:18 (#0),
+                                            },
+                                            Group {
+                                                delimiter: Bracket,
+                                                stream: TokenStream [
+                                                    Ident {
+                                                        ident: "cfg",
+                                                        span: $DIR/issue-75930-derive-cfg.rs:48:19: 48:22 (#0),
+                                                    },
+                                                    Group {
+                                                        delimiter: Parenthesis,
+                                                        stream: TokenStream [
+                                                            Ident {
+                                                                ident: "not",
+                                                                span: $DIR/issue-75930-derive-cfg.rs:48:23: 48:26 (#0),
+                                                            },
+                                                            Group {
+                                                                delimiter: Parenthesis,
+                                                                stream: TokenStream [
+                                                                    Ident {
+                                                                        ident: "FALSE",
+                                                                        span: $DIR/issue-75930-derive-cfg.rs:48:27: 48:32 (#0),
+                                                                    },
+                                                                ],
+                                                                span: $DIR/issue-75930-derive-cfg.rs:48:26: 48:33 (#0),
+                                                            },
+                                                        ],
+                                                        span: $DIR/issue-75930-derive-cfg.rs:48:22: 48:34 (#0),
+                                                    },
+                                                ],
+                                                span: $DIR/issue-75930-derive-cfg.rs:48:18: 48:35 (#0),
+                                            },
+                                            Ident {
+                                                ident: "i32",
+                                                span: $DIR/issue-75930-derive-cfg.rs:48:36: 48:39 (#0),
+                                            },
+                                            Punct {
+                                                ch: ',',
+                                                spacing: Alone,
+                                                span: $DIR/issue-75930-derive-cfg.rs:48:39: 48:40 (#0),
+                                            },
+                                            Punct {
+                                                ch: '#',
+                                                spacing: Alone,
+                                                span: $DIR/issue-75930-derive-cfg.rs:49:17: 49:18 (#0),
+                                            },
+                                            Group {
+                                                delimiter: Bracket,
+                                                stream: TokenStream [
+                                                    Ident {
+                                                        ident: "cfg",
+                                                        span: $DIR/issue-75930-derive-cfg.rs:49:19: 49:22 (#0),
+                                                    },
+                                                    Group {
+                                                        delimiter: Parenthesis,
+                                                        stream: TokenStream [
+                                                            Ident {
+                                                                ident: "FALSE",
+                                                                span: $DIR/issue-75930-derive-cfg.rs:49:23: 49:28 (#0),
+                                                            },
+                                                        ],
+                                                        span: $DIR/issue-75930-derive-cfg.rs:49:22: 49:29 (#0),
+                                                    },
+                                                ],
+                                                span: $DIR/issue-75930-derive-cfg.rs:49:18: 49:30 (#0),
+                                            },
+                                            Ident {
+                                                ident: "String",
+                                                span: $DIR/issue-75930-derive-cfg.rs:49:31: 49:37 (#0),
+                                            },
+                                            Punct {
+                                                ch: ',',
+                                                spacing: Alone,
+                                                span: $DIR/issue-75930-derive-cfg.rs:49:37: 49:38 (#0),
+                                            },
+                                            Ident {
+                                                ident: "u8",
+                                                span: $DIR/issue-75930-derive-cfg.rs:49:39: 49:41 (#0),
+                                            },
+                                        ],
+                                        span: $DIR/issue-75930-derive-cfg.rs:45:16: 50:14 (#0),
+                                    },
+                                ],
+                                span: $DIR/issue-75930-derive-cfg.rs:44:24: 51:10 (#0),
+                            },
+                            Ident {
+                                ident: "struct",
+                                span: $DIR/issue-75930-derive-cfg.rs:53:9: 53:15 (#0),
+                            },
+                            Ident {
+                                ident: "TupleStruct",
+                                span: $DIR/issue-75930-derive-cfg.rs:53:16: 53:27 (#0),
+                            },
+                            Group {
+                                delimiter: Parenthesis,
+                                stream: TokenStream [
+                                    Punct {
+                                        ch: '#',
+                                        spacing: Alone,
+                                        span: $DIR/issue-75930-derive-cfg.rs:54:13: 54:14 (#0),
+                                    },
+                                    Group {
+                                        delimiter: Bracket,
+                                        stream: TokenStream [
+                                            Ident {
+                                                ident: "cfg",
+                                                span: $DIR/issue-75930-derive-cfg.rs:54:15: 54:18 (#0),
+                                            },
+                                            Group {
+                                                delimiter: Parenthesis,
+                                                stream: TokenStream [
+                                                    Ident {
+                                                        ident: "FALSE",
+                                                        span: $DIR/issue-75930-derive-cfg.rs:54:19: 54:24 (#0),
+                                                    },
+                                                ],
+                                                span: $DIR/issue-75930-derive-cfg.rs:54:18: 54:25 (#0),
+                                            },
+                                        ],
+                                        span: $DIR/issue-75930-derive-cfg.rs:54:14: 54:26 (#0),
+                                    },
+                                    Ident {
+                                        ident: "String",
+                                        span: $DIR/issue-75930-derive-cfg.rs:54:27: 54:33 (#0),
+                                    },
+                                    Punct {
+                                        ch: ',',
+                                        spacing: Alone,
+                                        span: $DIR/issue-75930-derive-cfg.rs:54:33: 54:34 (#0),
+                                    },
+                                    Punct {
+                                        ch: '#',
+                                        spacing: Alone,
+                                        span: $DIR/issue-75930-derive-cfg.rs:55:13: 55:14 (#0),
+                                    },
+                                    Group {
+                                        delimiter: Bracket,
+                                        stream: TokenStream [
+                                            Ident {
+                                                ident: "cfg",
+                                                span: $DIR/issue-75930-derive-cfg.rs:55:15: 55:18 (#0),
+                                            },
+                                            Group {
+                                                delimiter: Parenthesis,
+                                                stream: TokenStream [
+                                                    Ident {
+                                                        ident: "not",
+                                                        span: $DIR/issue-75930-derive-cfg.rs:55:19: 55:22 (#0),
+                                                    },
+                                                    Group {
+                                                        delimiter: Parenthesis,
+                                                        stream: TokenStream [
+                                                            Ident {
+                                                                ident: "FALSE",
+                                                                span: $DIR/issue-75930-derive-cfg.rs:55:23: 55:28 (#0),
+                                                            },
+                                                        ],
+                                                        span: $DIR/issue-75930-derive-cfg.rs:55:22: 55:29 (#0),
+                                                    },
+                                                ],
+                                                span: $DIR/issue-75930-derive-cfg.rs:55:18: 55:30 (#0),
+                                            },
+                                        ],
+                                        span: $DIR/issue-75930-derive-cfg.rs:55:14: 55:31 (#0),
+                                    },
+                                    Ident {
+                                        ident: "i32",
+                                        span: $DIR/issue-75930-derive-cfg.rs:55:32: 55:35 (#0),
+                                    },
+                                    Punct {
+                                        ch: ',',
+                                        spacing: Alone,
+                                        span: $DIR/issue-75930-derive-cfg.rs:55:35: 55:36 (#0),
+                                    },
+                                    Punct {
+                                        ch: '#',
+                                        spacing: Alone,
+                                        span: $DIR/issue-75930-derive-cfg.rs:56:13: 56:14 (#0),
+                                    },
+                                    Group {
+                                        delimiter: Bracket,
+                                        stream: TokenStream [
+                                            Ident {
+                                                ident: "cfg",
+                                                span: $DIR/issue-75930-derive-cfg.rs:56:15: 56:18 (#0),
+                                            },
+                                            Group {
+                                                delimiter: Parenthesis,
+                                                stream: TokenStream [
+                                                    Ident {
+                                                        ident: "FALSE",
+                                                        span: $DIR/issue-75930-derive-cfg.rs:56:19: 56:24 (#0),
+                                                    },
+                                                ],
+                                                span: $DIR/issue-75930-derive-cfg.rs:56:18: 56:25 (#0),
+                                            },
+                                        ],
+                                        span: $DIR/issue-75930-derive-cfg.rs:56:14: 56:26 (#0),
+                                    },
+                                    Ident {
+                                        ident: "bool",
+                                        span: $DIR/issue-75930-derive-cfg.rs:56:27: 56:31 (#0),
+                                    },
+                                    Punct {
+                                        ch: ',',
+                                        spacing: Alone,
+                                        span: $DIR/issue-75930-derive-cfg.rs:56:31: 56:32 (#0),
+                                    },
+                                    Ident {
+                                        ident: "u8",
+                                        span: $DIR/issue-75930-derive-cfg.rs:57:13: 57:15 (#0),
+                                    },
+                                ],
+                                span: $DIR/issue-75930-derive-cfg.rs:53:27: 58:10 (#0),
+                            },
+                            Punct {
+                                ch: ';',
+                                spacing: Alone,
+                                span: $DIR/issue-75930-derive-cfg.rs:58:10: 58:11 (#0),
+                            },
+                            Literal {
+                                kind: Integer,
+                                symbol: "0",
+                                suffix: None,
+                                span: $DIR/issue-75930-derive-cfg.rs:60:9: 60:10 (#0),
+                            },
+                        ],
+                        span: $DIR/issue-75930-derive-cfg.rs:24:17: 61:6 (#0),
+                    },
+                ],
+                span: $DIR/issue-75930-derive-cfg.rs:24:12: 61:7 (#0),
+            },
+            Punct {
+                ch: ',',
+                spacing: Alone,
+                span: $DIR/issue-75930-derive-cfg.rs:61:7: 61:8 (#0),
+            },
+            Punct {
+                ch: '#',
+                spacing: Alone,
+                span: $DIR/issue-75930-derive-cfg.rs:62:5: 62:6 (#0),
+            },
+            Group {
+                delimiter: Bracket,
+                stream: TokenStream [
+                    Ident {
+                        ident: "print_helper",
+                        span: $DIR/issue-75930-derive-cfg.rs:62:7: 62:19 (#0),
+                    },
+                    Group {
+                        delimiter: Parenthesis,
+                        stream: TokenStream [
+                            Ident {
+                                ident: "d",
+                                span: $DIR/issue-75930-derive-cfg.rs:62:20: 62:21 (#0),
+                            },
+                        ],
+                        span: $DIR/issue-75930-derive-cfg.rs:62:19: 62:22 (#0),
+                    },
+                ],
+                span: $DIR/issue-75930-derive-cfg.rs:62:6: 62:23 (#0),
+            },
+            Ident {
+                ident: "fourth",
+                span: $DIR/issue-75930-derive-cfg.rs:63:5: 63:11 (#0),
+            },
+            Punct {
+                ch: ':',
+                spacing: Alone,
+                span: $DIR/issue-75930-derive-cfg.rs:63:11: 63:12 (#0),
+            },
+            Ident {
+                ident: "B",
+                span: $DIR/issue-75930-derive-cfg.rs:63:13: 63:14 (#0),
+            },
+        ],
+        span: $DIR/issue-75930-derive-cfg.rs:21:32: 64:2 (#0),
+    },
+]
+PRINT-DERIVE INPUT (DISPLAY): #[allow(dead_code)] #[print_helper(b)] #[print_helper(a)] struct Foo < B >
 {
     second : bool, third :
     [u8 ;
      {
          #[cfg(not(FALSE))] struct Inner ; match true
-         { false => { } _ => { } } ; 0
-     }], fourth : B,
+         { #[allow(warnings)] false => { } _ => { } } ; #[print_helper(c)]
+         #[cfg(not(FALSE))] fn kept_fn()
+         { # ! [cfg(not(FALSE))] let my_val = true ; } enum TupleEnum
+         { Foo(#[cfg(not(FALSE))] i32, u8), } struct
+         TupleStruct(#[cfg(not(FALSE))] i32, u8) ; 0
+     }], #[print_helper(d)] fourth : B,
 }
 PRINT-DERIVE INPUT (DEBUG): TokenStream [
+    Punct {
+        ch: '#',
+        spacing: Alone,
+        span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+    },
+    Group {
+        delimiter: Bracket,
+        stream: TokenStream [
+            Ident {
+                ident: "allow",
+                span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+            },
+            Group {
+                delimiter: Parenthesis,
+                stream: TokenStream [
+                    Ident {
+                        ident: "dead_code",
+                        span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+                    },
+                ],
+                span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+            },
+        ],
+        span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+    },
+    Punct {
+        ch: '#',
+        spacing: Alone,
+        span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+    },
+    Group {
+        delimiter: Bracket,
+        stream: TokenStream [
+            Ident {
+                ident: "print_helper",
+                span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+            },
+            Group {
+                delimiter: Parenthesis,
+                stream: TokenStream [
+                    Ident {
+                        ident: "b",
+                        span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+                    },
+                ],
+                span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+            },
+        ],
+        span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+    },
+    Punct {
+        ch: '#',
+        spacing: Alone,
+        span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+    },
+    Group {
+        delimiter: Bracket,
+        stream: TokenStream [
+            Ident {
+                ident: "print_helper",
+                span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+            },
+            Group {
+                delimiter: Parenthesis,
+                stream: TokenStream [
+                    Ident {
+                        ident: "a",
+                        span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+                    },
+                ],
+                span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+            },
+        ],
+        span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+    },
     Ident {
         ident: "struct",
         span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
@@ -134,6 +1409,31 @@ PRINT-DERIVE INPUT (DEBUG): TokenStream [
                             Group {
                                 delimiter: Brace,
                                 stream: TokenStream [
+                                    Punct {
+                                        ch: '#',
+                                        spacing: Alone,
+                                        span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+                                    },
+                                    Group {
+                                        delimiter: Bracket,
+                                        stream: TokenStream [
+                                            Ident {
+                                                ident: "allow",
+                                                span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+                                            },
+                                            Group {
+                                                delimiter: Parenthesis,
+                                                stream: TokenStream [
+                                                    Ident {
+                                                        ident: "warnings",
+                                                        span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+                                                    },
+                                                ],
+                                                span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+                                            },
+                                        ],
+                                        span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+                                    },
                                     Ident {
                                         ident: "false",
                                         span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
@@ -180,6 +1480,291 @@ PRINT-DERIVE INPUT (DEBUG): TokenStream [
                                 spacing: Alone,
                                 span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
                             },
+                            Punct {
+                                ch: '#',
+                                spacing: Alone,
+                                span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+                            },
+                            Group {
+                                delimiter: Bracket,
+                                stream: TokenStream [
+                                    Ident {
+                                        ident: "print_helper",
+                                        span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+                                    },
+                                    Group {
+                                        delimiter: Parenthesis,
+                                        stream: TokenStream [
+                                            Ident {
+                                                ident: "c",
+                                                span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+                                            },
+                                        ],
+                                        span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+                                    },
+                                ],
+                                span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+                            },
+                            Punct {
+                                ch: '#',
+                                spacing: Alone,
+                                span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+                            },
+                            Group {
+                                delimiter: Bracket,
+                                stream: TokenStream [
+                                    Ident {
+                                        ident: "cfg",
+                                        span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+                                    },
+                                    Group {
+                                        delimiter: Parenthesis,
+                                        stream: TokenStream [
+                                            Ident {
+                                                ident: "not",
+                                                span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+                                            },
+                                            Group {
+                                                delimiter: Parenthesis,
+                                                stream: TokenStream [
+                                                    Ident {
+                                                        ident: "FALSE",
+                                                        span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+                                                    },
+                                                ],
+                                                span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+                                            },
+                                        ],
+                                        span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+                                    },
+                                ],
+                                span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+                            },
+                            Ident {
+                                ident: "fn",
+                                span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+                            },
+                            Ident {
+                                ident: "kept_fn",
+                                span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+                            },
+                            Group {
+                                delimiter: Parenthesis,
+                                stream: TokenStream [],
+                                span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+                            },
+                            Group {
+                                delimiter: Brace,
+                                stream: TokenStream [
+                                    Punct {
+                                        ch: '#',
+                                        spacing: Joint,
+                                        span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+                                    },
+                                    Punct {
+                                        ch: '!',
+                                        spacing: Alone,
+                                        span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+                                    },
+                                    Group {
+                                        delimiter: Bracket,
+                                        stream: TokenStream [
+                                            Ident {
+                                                ident: "cfg",
+                                                span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+                                            },
+                                            Group {
+                                                delimiter: Parenthesis,
+                                                stream: TokenStream [
+                                                    Ident {
+                                                        ident: "not",
+                                                        span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+                                                    },
+                                                    Group {
+                                                        delimiter: Parenthesis,
+                                                        stream: TokenStream [
+                                                            Ident {
+                                                                ident: "FALSE",
+                                                                span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+                                                            },
+                                                        ],
+                                                        span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+                                                    },
+                                                ],
+                                                span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+                                            },
+                                        ],
+                                        span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+                                    },
+                                    Ident {
+                                        ident: "let",
+                                        span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+                                    },
+                                    Ident {
+                                        ident: "my_val",
+                                        span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+                                    },
+                                    Punct {
+                                        ch: '=',
+                                        spacing: Alone,
+                                        span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+                                    },
+                                    Ident {
+                                        ident: "true",
+                                        span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+                                    },
+                                    Punct {
+                                        ch: ';',
+                                        spacing: Alone,
+                                        span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+                                    },
+                                ],
+                                span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+                            },
+                            Ident {
+                                ident: "enum",
+                                span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+                            },
+                            Ident {
+                                ident: "TupleEnum",
+                                span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+                            },
+                            Group {
+                                delimiter: Brace,
+                                stream: TokenStream [
+                                    Ident {
+                                        ident: "Foo",
+                                        span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+                                    },
+                                    Group {
+                                        delimiter: Parenthesis,
+                                        stream: TokenStream [
+                                            Punct {
+                                                ch: '#',
+                                                spacing: Alone,
+                                                span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+                                            },
+                                            Group {
+                                                delimiter: Bracket,
+                                                stream: TokenStream [
+                                                    Ident {
+                                                        ident: "cfg",
+                                                        span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+                                                    },
+                                                    Group {
+                                                        delimiter: Parenthesis,
+                                                        stream: TokenStream [
+                                                            Ident {
+                                                                ident: "not",
+                                                                span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+                                                            },
+                                                            Group {
+                                                                delimiter: Parenthesis,
+                                                                stream: TokenStream [
+                                                                    Ident {
+                                                                        ident: "FALSE",
+                                                                        span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+                                                                    },
+                                                                ],
+                                                                span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+                                                            },
+                                                        ],
+                                                        span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+                                                    },
+                                                ],
+                                                span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+                                            },
+                                            Ident {
+                                                ident: "i32",
+                                                span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+                                            },
+                                            Punct {
+                                                ch: ',',
+                                                spacing: Alone,
+                                                span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+                                            },
+                                            Ident {
+                                                ident: "u8",
+                                                span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+                                            },
+                                        ],
+                                        span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+                                    },
+                                    Punct {
+                                        ch: ',',
+                                        spacing: Alone,
+                                        span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+                                    },
+                                ],
+                                span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+                            },
+                            Ident {
+                                ident: "struct",
+                                span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+                            },
+                            Ident {
+                                ident: "TupleStruct",
+                                span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+                            },
+                            Group {
+                                delimiter: Parenthesis,
+                                stream: TokenStream [
+                                    Punct {
+                                        ch: '#',
+                                        spacing: Alone,
+                                        span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+                                    },
+                                    Group {
+                                        delimiter: Bracket,
+                                        stream: TokenStream [
+                                            Ident {
+                                                ident: "cfg",
+                                                span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+                                            },
+                                            Group {
+                                                delimiter: Parenthesis,
+                                                stream: TokenStream [
+                                                    Ident {
+                                                        ident: "not",
+                                                        span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+                                                    },
+                                                    Group {
+                                                        delimiter: Parenthesis,
+                                                        stream: TokenStream [
+                                                            Ident {
+                                                                ident: "FALSE",
+                                                                span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+                                                            },
+                                                        ],
+                                                        span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+                                                    },
+                                                ],
+                                                span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+                                            },
+                                        ],
+                                        span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+                                    },
+                                    Ident {
+                                        ident: "i32",
+                                        span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+                                    },
+                                    Punct {
+                                        ch: ',',
+                                        spacing: Alone,
+                                        span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+                                    },
+                                    Ident {
+                                        ident: "u8",
+                                        span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+                                    },
+                                ],
+                                span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+                            },
+                            Punct {
+                                ch: ';',
+                                spacing: Alone,
+                                span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+                            },
                             Literal {
                                 kind: Integer,
                                 symbol: "0",
@@ -195,6 +1780,31 @@ PRINT-DERIVE INPUT (DEBUG): TokenStream [
             Punct {
                 ch: ',',
                 spacing: Alone,
+                span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+            },
+            Punct {
+                ch: '#',
+                spacing: Alone,
+                span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+            },
+            Group {
+                delimiter: Bracket,
+                stream: TokenStream [
+                    Ident {
+                        ident: "print_helper",
+                        span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+                    },
+                    Group {
+                        delimiter: Parenthesis,
+                        stream: TokenStream [
+                            Ident {
+                                ident: "d",
+                                span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+                            },
+                        ],
+                        span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
+                    },
+                ],
                 span: $DIR/issue-75930-derive-cfg.rs:1:1: 1:1 (#0),
             },
             Ident {

--- a/src/tools/clippy/clippy_lints/src/lib.rs
+++ b/src/tools/clippy/clippy_lints/src/lib.rs
@@ -6,6 +6,7 @@
 #![feature(concat_idents)]
 #![feature(crate_visibility_modifier)]
 #![feature(drain_filter)]
+#![feature(in_band_lifetimes)]
 #![feature(or_patterns)]
 #![feature(rustc_private)]
 #![feature(stmt_expr_attributes)]

--- a/src/tools/clippy/clippy_lints/src/missing_const_for_fn.rs
+++ b/src/tools/clippy/clippy_lints/src/missing_const_for_fn.rs
@@ -4,7 +4,7 @@ use rustc_hir::intravisit::FnKind;
 use rustc_hir::{Body, Constness, FnDecl, GenericParamKind, HirId};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::lint::in_external_macro;
-use rustc_mir::transform::qualify_min_const_fn::is_min_const_fn;
+use crate::utils::qualify_min_const_fn::is_min_const_fn;
 use rustc_session::{declare_lint_pass, declare_tool_lint};
 use rustc_span::Span;
 use rustc_typeck::hir_ty_to_ty;

--- a/src/tools/clippy/clippy_lints/src/utils/mod.rs
+++ b/src/tools/clippy/clippy_lints/src/utils/mod.rs
@@ -20,6 +20,7 @@ pub mod paths;
 pub mod ptr;
 pub mod sugg;
 pub mod usage;
+pub mod qualify_min_const_fn;
 
 pub use self::attrs::*;
 pub use self::diagnostics::*;

--- a/src/tools/clippy/clippy_lints/src/utils/qualify_min_const_fn.rs
+++ b/src/tools/clippy/clippy_lints/src/utils/qualify_min_const_fn.rs
@@ -3,7 +3,7 @@ use rustc_hir::def_id::DefId;
 use rustc_middle::mir::*;
 use rustc_middle::ty::subst::GenericArgKind;
 use rustc_middle::ty::{self, adjustment::PointerCast, Ty, TyCtxt};
-use rustc_span::symbol::{sym, Symbol};
+use rustc_span::symbol::{sym};
 use rustc_span::Span;
 use rustc_target::spec::abi::Abi::RustIntrinsic;
 use std::borrow::Cow;
@@ -11,14 +11,6 @@ use std::borrow::Cow;
 type McfResult = Result<(), (Span, Cow<'static, str>)>;
 
 pub fn is_min_const_fn(tcx: TyCtxt<'tcx>, def_id: DefId, body: &'a Body<'tcx>) -> McfResult {
-    // Prevent const trait methods from being annotated as `stable`.
-    if tcx.features().staged_api {
-        let hir_id = tcx.hir().local_def_id_to_hir_id(def_id.expect_local());
-        if rustc_mir::const_eval::is_parent_const_impl_raw(tcx, hir_id) {
-            return Err((body.span, "trait methods cannot be stable const fn".into()));
-        }
-    }
-
     let mut current = def_id;
     loop {
         let predicates = tcx.predicates_of(current);
@@ -40,19 +32,12 @@ pub fn is_min_const_fn(tcx: TyCtxt<'tcx>, def_id: DefId, body: &'a Body<'tcx>) -
                 ty::PredicateAtom::Subtype(_) => {
                     panic!("subtype predicate on function: {:#?}", predicate)
                 }
-                ty::PredicateAtom::Trait(pred, constness) => {
+                ty::PredicateAtom::Trait(pred, _) => {
                     if Some(pred.def_id()) == tcx.lang_items().sized_trait() {
                         continue;
                     }
                     match pred.self_ty().kind() {
                         ty::Param(ref p) => {
-                            // Allow `T: ?const Trait`
-                            if constness == hir::Constness::NotConst
-                                && feature_allowed(tcx, def_id, sym::const_trait_bound_opt_out)
-                            {
-                                continue;
-                            }
-
                             let generics = tcx.generics_of(current);
                             let def = generics.type_param(p, tcx);
                             let span = tcx.def_span(def.def_id);
@@ -77,18 +62,17 @@ pub fn is_min_const_fn(tcx: TyCtxt<'tcx>, def_id: DefId, body: &'a Body<'tcx>) -
     }
 
     for local in &body.local_decls {
-        check_ty(tcx, local.ty, local.source_info.span, def_id)?;
+        check_ty(tcx, local.ty, local.source_info.span)?;
     }
     // impl trait is gone in MIR, so check the return type manually
     check_ty(
         tcx,
         tcx.fn_sig(def_id).output().skip_binder(),
         body.local_decls.iter().next().unwrap().source_info.span,
-        def_id,
     )?;
 
     for bb in body.basic_blocks() {
-        check_terminator(tcx, body, def_id, bb.terminator())?;
+        check_terminator(tcx, body, bb.terminator())?;
         for stmt in &bb.statements {
             check_statement(tcx, body, def_id, stmt)?;
         }
@@ -96,7 +80,7 @@ pub fn is_min_const_fn(tcx: TyCtxt<'tcx>, def_id: DefId, body: &'a Body<'tcx>) -
     Ok(())
 }
 
-fn check_ty(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>, span: Span, fn_def_id: DefId) -> McfResult {
+fn check_ty(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>, span: Span) -> McfResult {
     for arg in ty.walk() {
         let ty = match arg.unpack() {
             GenericArgKind::Type(ty) => ty,
@@ -108,15 +92,11 @@ fn check_ty(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>, span: Span, fn_def_id: DefId) -> Mc
 
         match ty.kind() {
             ty::Ref(_, _, hir::Mutability::Mut) => {
-                if !feature_allowed(tcx, fn_def_id, sym::const_mut_refs) {
                     return Err((span, "mutable references in const fn are unstable".into()));
-                }
             }
             ty::Opaque(..) => return Err((span, "`impl Trait` in const fn is unstable".into())),
             ty::FnPtr(..) => {
-                if !tcx.const_fn_is_allowed_fn_ptr(fn_def_id) {
                     return Err((span, "function pointers in const fn are unstable".into()));
-                }
             }
             ty::Dynamic(preds, _) => {
                 for pred in preds.iter() {
@@ -161,12 +141,12 @@ fn check_rvalue(
             Err((span, "cannot access thread local storage in const fn".into()))
         }
         Rvalue::Repeat(operand, _) | Rvalue::Use(operand) => {
-            check_operand(tcx, operand, span, def_id, body)
+            check_operand(tcx, operand, span, body)
         }
         Rvalue::Len(place)
         | Rvalue::Discriminant(place)
         | Rvalue::Ref(_, _, place)
-        | Rvalue::AddressOf(_, place) => check_place(tcx, *place, span, def_id, body),
+        | Rvalue::AddressOf(_, place) => check_place(tcx, *place, span,  body),
         Rvalue::Cast(CastKind::Misc, operand, cast_ty) => {
             use rustc_middle::ty::cast::CastTy;
             let cast_in = CastTy::from_ty(operand.ty(body, tcx)).expect("bad input type for cast");
@@ -175,14 +155,14 @@ fn check_rvalue(
                 (CastTy::Ptr(_) | CastTy::FnPtr, CastTy::Int(_)) => {
                     Err((span, "casting pointers to ints is unstable in const fn".into()))
                 }
-                _ => check_operand(tcx, operand, span, def_id, body),
+                _ => check_operand(tcx, operand, span, body),
             }
         }
         Rvalue::Cast(
             CastKind::Pointer(PointerCast::MutToConstPointer | PointerCast::ArrayToPointer),
             operand,
             _,
-        ) => check_operand(tcx, operand, span, def_id, body),
+        ) => check_operand(tcx, operand, span, body),
         Rvalue::Cast(
             CastKind::Pointer(
                 PointerCast::UnsafeFnPointer
@@ -204,7 +184,7 @@ fn check_rvalue(
             };
             let unsized_ty = tcx.struct_tail_erasing_lifetimes(pointee_ty, tcx.param_env(def_id));
             if let ty::Slice(_) | ty::Str = unsized_ty.kind() {
-                check_operand(tcx, op, span, def_id, body)?;
+                check_operand(tcx, op, span, body)?;
                 // Casting/coercing things to slices is fine.
                 Ok(())
             } else {
@@ -214,8 +194,8 @@ fn check_rvalue(
         }
         // binops are fine on integers
         Rvalue::BinaryOp(_, lhs, rhs) | Rvalue::CheckedBinaryOp(_, lhs, rhs) => {
-            check_operand(tcx, lhs, span, def_id, body)?;
-            check_operand(tcx, rhs, span, def_id, body)?;
+            check_operand(tcx, lhs, span, body)?;
+            check_operand(tcx, rhs, span, body)?;
             let ty = lhs.ty(body, tcx);
             if ty.is_integral() || ty.is_bool() || ty.is_char() {
                 Ok(())
@@ -230,14 +210,14 @@ fn check_rvalue(
         Rvalue::UnaryOp(_, operand) => {
             let ty = operand.ty(body, tcx);
             if ty.is_integral() || ty.is_bool() {
-                check_operand(tcx, operand, span, def_id, body)
+                check_operand(tcx, operand, span, body)
             } else {
                 Err((span, "only int and `bool` operations are stable in const fn".into()))
             }
         }
         Rvalue::Aggregate(_, operands) => {
             for operand in operands {
-                check_operand(tcx, operand, span, def_id, body)?;
+                check_operand(tcx, operand, span, body)?;
             }
             Ok(())
         }
@@ -253,15 +233,15 @@ fn check_statement(
     let span = statement.source_info.span;
     match &statement.kind {
         StatementKind::Assign(box (place, rval)) => {
-            check_place(tcx, *place, span, def_id, body)?;
+            check_place(tcx, *place, span,  body)?;
             check_rvalue(tcx, body, def_id, rval, span)
         }
 
-        StatementKind::FakeRead(_, place) => check_place(tcx, **place, span, def_id, body),
+        StatementKind::FakeRead(_, place) => check_place(tcx, **place, span, body),
 
         // just an assignment
         StatementKind::SetDiscriminant { place, .. } => {
-            check_place(tcx, **place, span, def_id, body)
+            check_place(tcx, **place, span,  body)
         }
 
         StatementKind::LlvmInlineAsm { .. } => {
@@ -282,11 +262,10 @@ fn check_operand(
     tcx: TyCtxt<'tcx>,
     operand: &Operand<'tcx>,
     span: Span,
-    def_id: DefId,
     body: &Body<'tcx>,
 ) -> McfResult {
     match operand {
-        Operand::Move(place) | Operand::Copy(place) => check_place(tcx, *place, span, def_id, body),
+        Operand::Move(place) | Operand::Copy(place) => check_place(tcx, *place, span, body),
         Operand::Constant(c) => match c.check_static_ptr(tcx) {
             Some(_) => Err((span, "cannot access `static` items in const fn".into())),
             None => Ok(()),
@@ -298,7 +277,6 @@ fn check_place(
     tcx: TyCtxt<'tcx>,
     place: Place<'tcx>,
     span: Span,
-    def_id: DefId,
     body: &Body<'tcx>,
 ) -> McfResult {
     let mut cursor = place.projection.as_ref();
@@ -310,9 +288,7 @@ fn check_place(
                 if let Some(def) = base_ty.ty_adt_def() {
                     // No union field accesses in `const fn`
                     if def.is_union() {
-                        if !feature_allowed(tcx, def_id, sym::const_fn_union) {
                             return Err((span, "accessing union fields is unstable".into()));
-                        }
                     }
                 }
             }
@@ -327,48 +303,9 @@ fn check_place(
     Ok(())
 }
 
-/// Returns `true` if the given feature gate is allowed within the function with the given `DefId`.
-fn feature_allowed(tcx: TyCtxt<'tcx>, def_id: DefId, feature_gate: Symbol) -> bool {
-    // All features require that the corresponding gate be enabled,
-    // even if the function has `#[allow_internal_unstable(the_gate)]`.
-    if !tcx.features().enabled(feature_gate) {
-        return false;
-    }
-
-    // If this crate is not using stability attributes, or this function is not claiming to be a
-    // stable `const fn`, that is all that is required.
-    if !tcx.features().staged_api || tcx.has_attr(def_id, sym::rustc_const_unstable) {
-        return true;
-    }
-
-    // However, we cannot allow stable `const fn`s to use unstable features without an explicit
-    // opt-in via `allow_internal_unstable`.
-    rustc_mir::transform::check_consts::allow_internal_unstable(tcx, def_id, feature_gate)
-}
-
-/// Returns `true` if the given library feature gate is allowed within the function with the given `DefId`.
-pub fn lib_feature_allowed(tcx: TyCtxt<'tcx>, def_id: DefId, feature_gate: Symbol) -> bool {
-    // All features require that the corresponding gate be enabled,
-    // even if the function has `#[allow_internal_unstable(the_gate)]`.
-    if !tcx.features().declared_lib_features.iter().any(|&(sym, _)| sym == feature_gate) {
-        return false;
-    }
-
-    // If this crate is not using stability attributes, or this function is not claiming to be a
-    // stable `const fn`, that is all that is required.
-    if !tcx.features().staged_api || tcx.has_attr(def_id, sym::rustc_const_unstable) {
-        return true;
-    }
-
-    // However, we cannot allow stable `const fn`s to use unstable features without an explicit
-    // opt-in via `allow_internal_unstable`.
-    rustc_mir::transform::check_consts::allow_internal_unstable(tcx, def_id, feature_gate)
-}
-
 fn check_terminator(
     tcx: TyCtxt<'tcx>,
     body: &'a Body<'tcx>,
-    def_id: DefId,
     terminator: &Terminator<'tcx>,
 ) -> McfResult {
     let span = terminator.source_info.span;
@@ -380,14 +317,14 @@ fn check_terminator(
         | TerminatorKind::Resume
         | TerminatorKind::Unreachable => Ok(()),
 
-        TerminatorKind::Drop { place, .. } => check_place(tcx, *place, span, def_id, body),
+        TerminatorKind::Drop { place, .. } => check_place(tcx, *place, span,  body),
         TerminatorKind::DropAndReplace { place, value, .. } => {
-            check_place(tcx, *place, span, def_id, body)?;
-            check_operand(tcx, value, span, def_id, body)
+            check_place(tcx, *place, span,  body)?;
+            check_operand(tcx, value, span, body)
         }
 
         TerminatorKind::SwitchInt { discr, switch_ty: _, values: _, targets: _ } => {
-            check_operand(tcx, discr, span, def_id, body)
+            check_operand(tcx, discr, span, body)
         }
 
         TerminatorKind::Abort => Err((span, "abort is not stable in const fn".into())),
@@ -405,15 +342,7 @@ fn check_terminator(
         } => {
             let fn_ty = func.ty(body, tcx);
             if let ty::FnDef(fn_def_id, _) = *fn_ty.kind() {
-                // Allow unstable const if we opt in by using #[allow_internal_unstable]
-                // on function or macro declaration.
                 if !rustc_mir::const_eval::is_min_const_fn(tcx, fn_def_id)
-                    && !rustc_mir::const_eval::is_unstable_const_fn(tcx, fn_def_id)
-                        .map(|feature| {
-                            span.allows_unstable(feature)
-                                || lib_feature_allowed(tcx, def_id, feature)
-                        })
-                        .unwrap_or(false)
                 {
                     return Err((
                         span,
@@ -432,7 +361,6 @@ fn check_terminator(
                 // transmutes in const fn before we add more hacks to this.
                 if tcx.fn_sig(fn_def_id).abi() == RustIntrinsic
                     && tcx.item_name(fn_def_id) == sym::transmute
-                    && !feature_allowed(tcx, def_id, sym::const_fn_transmute)
                 {
                     return Err((
                         span,
@@ -440,10 +368,10 @@ fn check_terminator(
                     ));
                 }
 
-                check_operand(tcx, func, span, fn_def_id, body)?;
+                check_operand(tcx, func, span, body)?;
 
                 for arg in args {
-                    check_operand(tcx, arg, span, fn_def_id, body)?;
+                    check_operand(tcx, arg, span, body)?;
                 }
                 Ok(())
             } else {
@@ -452,7 +380,7 @@ fn check_terminator(
         }
 
         TerminatorKind::Assert { cond, expected: _, msg: _, target: _, cleanup: _ } => {
-            check_operand(tcx, cond, span, def_id, body)
+            check_operand(tcx, cond, span, body)
         }
 
         TerminatorKind::InlineAsm { .. } => {


### PR DESCRIPTION
Successful merges:

 - #76917 (Add missing code examples on HashMap types)
 - #77107 (Enable const propagation into operands at mir_opt_level=2)
 - #77129 (Update cargo)
 - #77167 (Fix FIXME in core::num test: Check sign of zero in min/max tests.)
 - #77184 (Rust vec bench import specific rand::RngCore)
 - #77208 (Late link args order)
 - #77209 (Fix documentation highlighting in ty::BorrowKind)
 - #77231 (Move helper function for `missing_const_for_fn` out of rustc to clippy)
 - #77235 (pretty-print-reparse hack: Rename some variables for clarity)
 - #77243 (Test more attributes in test issue-75930-derive-cfg.rs)

Failed merges:


r? @ghost