### PR TITLE
Link to "Contributing to Rust" rather than "Getting Started".

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,14 +2,14 @@
 
 Thank you for your interest in contributing to Rust!
 
-To get started, read the [Getting Started] guide in the [rustc-dev-guide].
+To get started, read the [Contributing to Rust] chapter of the [rustc-dev-guide].
 
 ## Bug reports
 
 Did a compiler error message tell you to come here? If you want to create an ICE report,
 refer to [this section][contributing-bug-reports] and [open an issue][issue template].
 
-[Getting Started]: https://rustc-dev-guide.rust-lang.org/getting-started.html
+[Contributing to Rust]: https://rustc-dev-guide.rust-lang.org/contributing.html#contributing-to-rust
 [rustc-dev-guide]: https://rustc-dev-guide.rust-lang.org/
 [contributing-bug-reports]: https://rustc-dev-guide.rust-lang.org/contributing.html#bug-reports
 [issue template]: https://github.com/rust-lang/rust/issues/new/choose


### PR DESCRIPTION
Change to link to "Contributing to Rust" chapter of `rustc` Dev Guide, primarily on the basis that:

 * The GitHub "first contribution" Issue "pop-up" says "Be sure to review the [contributing guidelines] and [code of conduct]" and links to this file.

 * The "Bug Report" section _seems_ to restrict itself to if "a compiler error message [told] you to come here".

 * The previous content of `CONTRIBUTING.md` now lives in the "Contributing to Rust" chapter. 

When/if the guide/"Getting Started" section gets revised to not be `rustc`-specific, the choice of linked chapter could be updated.

In the meantime this prevents leading first time contributors into a confusing cul de sac.

_[I wasn't planning to make a PR for this until discussion in #77215 concluded but the discovery that the "first issue" pop-up also links to this document IMO makes it a higher priority to make the link useful sooner rather than later.]_

Related issues:

 * https://github.com/rust-lang/rust/issues/77215

 * https://github.com/rust-lang/rustc-dev-guide/issues/775#issuecomment-699063082