### PR TITLE
Expand `NtExpr` tokens only in key-value attributes

### DIFF
--- a/compiler/rustc_ast/src/tokenstream.rs
+++ b/compiler/rustc_ast/src/tokenstream.rs
@@ -318,6 +318,10 @@ impl TokenStream {
         }
     }
 
+    pub fn trees_ref(&self) -> CursorRef<'_> {
+        CursorRef::new(self)
+    }
+
     pub fn trees(&self) -> Cursor {
         self.clone().into_trees()
     }
@@ -408,6 +412,36 @@ impl TokenStreamBuilder {
     }
 }
 
+/// By-reference iterator over a `TokenStream`.
+#[derive(Clone)]
+pub struct CursorRef<'t> {
+    stream: &'t TokenStream,
+    index: usize,
+}
+
+impl<'t> CursorRef<'t> {
+    fn new(stream: &TokenStream) -> CursorRef<'_> {
+        CursorRef { stream, index: 0 }
+    }
+
+    fn next_with_spacing(&mut self) -> Option<&'t TreeAndSpacing> {
+        self.stream.0.get(self.index).map(|tree| {
+            self.index += 1;
+            tree
+        })
+    }
+}
+
+impl<'t> Iterator for CursorRef<'t> {
+    type Item = &'t TokenTree;
+
+    fn next(&mut self) -> Option<&'t TokenTree> {
+        self.next_with_spacing().map(|(tree, _)| tree)
+    }
+}
+
+/// Owning by-value iterator over a `TokenStream`.
+/// FIXME: Many uses of this can be replaced with by-reference iterator to avoid clones.
 #[derive(Clone)]
 pub struct Cursor {
     pub stream: TokenStream,

--- a/compiler/rustc_expand/src/mbe/transcribe.rs
+++ b/compiler/rustc_expand/src/mbe/transcribe.rs
@@ -20,6 +20,10 @@ use std::mem;
 struct Marker(ExpnId, Transparency);
 
 impl MutVisitor for Marker {
+    fn token_visiting_enabled(&self) -> bool {
+        true
+    }
+
     fn visit_span(&mut self, span: &mut Span) {
         *span = span.apply_mark(self.0, self.1)
     }
@@ -277,7 +281,7 @@ pub(super) fn transcribe<'a>(
             // preserve syntax context.
             mbe::TokenTree::Token(token) => {
                 let mut tt = TokenTree::Token(token);
-                marker.visit_tt(&mut tt);
+                mut_visit::visit_tt(&mut tt, &mut marker);
                 result.push(tt.into());
             }
 

--- a/compiler/rustc_expand/src/mut_visit/tests.rs
+++ b/compiler/rustc_expand/src/mut_visit/tests.rs
@@ -15,6 +15,9 @@ fn fake_print_crate(s: &mut pprust::State<'_>, krate: &ast::Crate) {
 struct ToZzIdentMutVisitor;
 
 impl MutVisitor for ToZzIdentMutVisitor {
+    fn token_visiting_enabled(&self) -> bool {
+        true
+    }
     fn visit_ident(&mut self, ident: &mut Ident) {
         *ident = Ident::from_str("zz");
     }

--- a/compiler/rustc_resolve/src/build_reduced_graph.rs
+++ b/compiler/rustc_resolve/src/build_reduced_graph.rs
@@ -15,7 +15,6 @@ use crate::{
 };
 use crate::{Module, ModuleData, ModuleKind, NameBinding, NameBindingKind, Segment, ToNameBinding};
 
-use rustc_ast::token::{self, Token};
 use rustc_ast::visit::{self, AssocCtxt, Visitor};
 use rustc_ast::{self as ast, Block, ForeignItem, ForeignItemKind, Item, ItemKind, NodeId};
 use rustc_ast::{AssocItem, AssocItemKind, MetaItemKind, StmtKind};
@@ -1393,16 +1392,6 @@ impl<'a, 'b> Visitor<'b> for BuildReducedGraphVisitor<'a, 'b> {
         }
 
         visit::walk_assoc_item(self, item, ctxt);
-    }
-
-    fn visit_token(&mut self, t: Token) {
-        if let token::Interpolated(nt) = t.kind {
-            if let token::NtExpr(ref expr) = *nt {
-                if let ast::ExprKind::MacCall(..) = expr.kind {
-                    self.visit_invoc(expr.id);
-                }
-            }
-        }
     }
 
     fn visit_attribute(&mut self, attr: &'b ast::Attribute) {

--- a/compiler/rustc_resolve/src/def_collector.rs
+++ b/compiler/rustc_resolve/src/def_collector.rs
@@ -1,5 +1,4 @@
 use crate::Resolver;
-use rustc_ast::token::{self, Token};
 use rustc_ast::visit::{self, FnKind};
 use rustc_ast::walk_list;
 use rustc_ast::*;
@@ -253,16 +252,6 @@ impl<'a, 'b> visit::Visitor<'a> for DefCollector<'a, 'b> {
         match stmt.kind {
             StmtKind::MacCall(..) => self.visit_macro_invoc(stmt.id),
             _ => visit::walk_stmt(self, stmt),
-        }
-    }
-
-    fn visit_token(&mut self, t: Token) {
-        if let token::Interpolated(nt) = t.kind {
-            if let token::NtExpr(ref expr) = *nt {
-                if let ExprKind::MacCall(..) = expr.kind {
-                    self.visit_macro_invoc(expr.id);
-                }
-            }
         }
     }
 

--- a/library/core/src/sync/atomic.rs
+++ b/library/core/src/sync/atomic.rs
@@ -2275,64 +2275,56 @@ atomic_int! {
     "AtomicU128::new(0)",
     u128 AtomicU128 ATOMIC_U128_INIT
 }
-#[cfg(target_has_atomic_load_store = "ptr")]
-#[cfg(target_pointer_width = "16")]
-macro_rules! ptr_width {
-    () => {
-        2
-    };
+
+macro_rules! atomic_int_ptr_sized {
+    ( $($target_pointer_width:literal $align:literal)* ) => { $(
+        #[cfg(target_has_atomic_load_store = "ptr")]
+        #[cfg(target_pointer_width = $target_pointer_width)]
+        atomic_int! {
+            cfg(target_has_atomic = "ptr"),
+            cfg(target_has_atomic_equal_alignment = "ptr"),
+            stable(feature = "rust1", since = "1.0.0"),
+            stable(feature = "extended_compare_and_swap", since = "1.10.0"),
+            stable(feature = "atomic_debug", since = "1.3.0"),
+            stable(feature = "atomic_access", since = "1.15.0"),
+            stable(feature = "atomic_from", since = "1.23.0"),
+            stable(feature = "atomic_nand", since = "1.27.0"),
+            rustc_const_stable(feature = "const_integer_atomics", since = "1.34.0"),
+            stable(feature = "rust1", since = "1.0.0"),
+            "isize", "../../../std/primitive.isize.html",
+            "",
+            atomic_min, atomic_max,
+            $align,
+            "AtomicIsize::new(0)",
+            isize AtomicIsize ATOMIC_ISIZE_INIT
+        }
+        #[cfg(target_has_atomic_load_store = "ptr")]
+        #[cfg(target_pointer_width = $target_pointer_width)]
+        atomic_int! {
+            cfg(target_has_atomic = "ptr"),
+            cfg(target_has_atomic_equal_alignment = "ptr"),
+            stable(feature = "rust1", since = "1.0.0"),
+            stable(feature = "extended_compare_and_swap", since = "1.10.0"),
+            stable(feature = "atomic_debug", since = "1.3.0"),
+            stable(feature = "atomic_access", since = "1.15.0"),
+            stable(feature = "atomic_from", since = "1.23.0"),
+            stable(feature = "atomic_nand", since = "1.27.0"),
+            rustc_const_stable(feature = "const_integer_atomics", since = "1.34.0"),
+            stable(feature = "rust1", since = "1.0.0"),
+            "usize", "../../../std/primitive.usize.html",
+            "",
+            atomic_umin, atomic_umax,
+            $align,
+            "AtomicUsize::new(0)",
+            usize AtomicUsize ATOMIC_USIZE_INIT
+        }
+    )* };
 }
-#[cfg(target_has_atomic_load_store = "ptr")]
-#[cfg(target_pointer_width = "32")]
-macro_rules! ptr_width {
-    () => {
-        4
-    };
-}
-#[cfg(target_has_atomic_load_store = "ptr")]
-#[cfg(target_pointer_width = "64")]
-macro_rules! ptr_width {
-    () => {
-        8
-    };
-}
-#[cfg(target_has_atomic_load_store = "ptr")]
-atomic_int! {
-    cfg(target_has_atomic = "ptr"),
-    cfg(target_has_atomic_equal_alignment = "ptr"),
-    stable(feature = "rust1", since = "1.0.0"),
-    stable(feature = "extended_compare_and_swap", since = "1.10.0"),
-    stable(feature = "atomic_debug", since = "1.3.0"),
-    stable(feature = "atomic_access", since = "1.15.0"),
-    stable(feature = "atomic_from", since = "1.23.0"),
-    stable(feature = "atomic_nand", since = "1.27.0"),
-    rustc_const_stable(feature = "const_integer_atomics", since = "1.34.0"),
-    stable(feature = "rust1", since = "1.0.0"),
-    "isize", "../../../std/primitive.isize.html",
-    "",
-    atomic_min, atomic_max,
-    ptr_width!(),
-    "AtomicIsize::new(0)",
-    isize AtomicIsize ATOMIC_ISIZE_INIT
-}
-#[cfg(target_has_atomic_load_store = "ptr")]
-atomic_int! {
-    cfg(target_has_atomic = "ptr"),
-    cfg(target_has_atomic_equal_alignment = "ptr"),
-    stable(feature = "rust1", since = "1.0.0"),
-    stable(feature = "extended_compare_and_swap", since = "1.10.0"),
-    stable(feature = "atomic_debug", since = "1.3.0"),
-    stable(feature = "atomic_access", since = "1.15.0"),
-    stable(feature = "atomic_from", since = "1.23.0"),
-    stable(feature = "atomic_nand", since = "1.27.0"),
-    rustc_const_stable(feature = "const_integer_atomics", since = "1.34.0"),
-    stable(feature = "rust1", since = "1.0.0"),
-    "usize", "../../../std/primitive.usize.html",
-    "",
-    atomic_umin, atomic_umax,
-    ptr_width!(),
-    "AtomicUsize::new(0)",
-    usize AtomicUsize ATOMIC_USIZE_INIT
+
+atomic_int_ptr_sized! {
+    "16" 2
+    "32" 4
+    "64" 8
 }
 
 #[inline]

--- a/src/test/ui/attributes/auxiliary/key-value-expansion.rs
+++ b/src/test/ui/attributes/auxiliary/key-value-expansion.rs
@@ -1,0 +1,12 @@
+// force-host
+// no-prefer-dynamic
+
+#![crate_type = "proc-macro"]
+
+extern crate proc_macro;
+use proc_macro::*;
+
+#[proc_macro_derive(EthabiContract, attributes(ethabi_contract_options))]
+pub fn ethabi_derive(input: TokenStream) -> TokenStream {
+    Default::default()
+}

--- a/src/test/ui/attributes/key-value-expansion.rs
+++ b/src/test/ui/attributes/key-value-expansion.rs
@@ -1,0 +1,55 @@
+// Regression tests for issue #55414, expansion happens in the value of a key-value attribute,
+// and the expanded expression is more complex than simply a macro call.
+
+// aux-build:key-value-expansion.rs
+
+#![feature(rustc_attrs)]
+
+extern crate key_value_expansion;
+
+// Minimized test case.
+
+macro_rules! bug {
+    ($expr:expr) => {
+        #[rustc_dummy = $expr] // Any key-value attribute, not necessarily `doc`
+        //~^ ERROR unexpected token: `(7u32)`
+        struct S;
+    };
+}
+
+// Any expressions containing macro call `X` that's more complex than `X` itself.
+// Parentheses will work.
+bug!((column!()));
+
+// Original test case.
+
+macro_rules! bug {
+    () => {
+        bug!("bug" + stringify!(found));
+    };
+    ($test:expr) => {
+        #[doc = $test] //~ ERROR unexpected token: `"bug" + "found"`
+        struct Test {}
+    };
+}
+
+bug!();
+
+// Test case from #66804.
+
+macro_rules! doc_comment {
+    ($x:expr) => {
+        #[doc = $x] //~ ERROR unexpected token: `{
+        extern {}
+    };
+}
+
+macro_rules! some_macro {
+    ($t1: ty) => {
+        doc_comment! {format!("{coor}", coor = stringify!($t1)).as_str()}
+    };
+}
+
+some_macro!(u8);
+
+fn main() {}

--- a/src/test/ui/attributes/key-value-expansion.stderr
+++ b/src/test/ui/attributes/key-value-expansion.stderr
@@ -1,0 +1,44 @@
+error: unexpected token: `(7u32)`
+  --> $DIR/key-value-expansion.rs:14:25
+   |
+LL |         #[rustc_dummy = $expr] // Any key-value attribute, not necessarily `doc`
+   |                         ^^^^^
+...
+LL | bug!((column!()));
+   | ------------------ in this macro invocation
+   |
+   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: unexpected token: `"bug" + "found"`
+  --> $DIR/key-value-expansion.rs:31:17
+   |
+LL |         #[doc = $test]
+   |                 ^^^^^
+...
+LL | bug!();
+   | ------- in this macro invocation
+   |
+   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: unexpected token: `{
+    let res =
+        ::alloc::fmt::format(::core::fmt::Arguments::new_v1(&[""],
+                                                            &match (&"u8",) {
+                                                                 (arg0,) =>
+                                                                 [::core::fmt::ArgumentV1::new(arg0,
+                                                                                               ::core::fmt::Display::fmt)],
+                                                             }));
+    res
+}.as_str()`
+  --> $DIR/key-value-expansion.rs:42:17
+   |
+LL |         #[doc = $x]
+   |                 ^^
+...
+LL | some_macro!(u8);
+   | ---------------- in this macro invocation
+   |
+   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 3 previous errors
+

--- a/src/test/ui/attributes/nonterminal-expansion.rs
+++ b/src/test/ui/attributes/nonterminal-expansion.rs
@@ -1,0 +1,17 @@
+// Macros were previously expanded in `Expr` nonterminal tokens, now they are not.
+
+macro_rules! pass_nonterminal {
+    ($n:expr) => {
+        #[repr(align($n))] //~ ERROR expected unsuffixed literal or identifier, found `n!()`
+                           //~| ERROR unrecognized representation hint
+        struct S;
+    };
+}
+
+macro_rules! n {
+    () => { 32 };
+}
+
+pass_nonterminal!(n!());
+
+fn main() {}

--- a/src/test/ui/attributes/nonterminal-expansion.stderr
+++ b/src/test/ui/attributes/nonterminal-expansion.stderr
@@ -1,0 +1,25 @@
+error: expected unsuffixed literal or identifier, found `n!()`
+  --> $DIR/nonterminal-expansion.rs:5:22
+   |
+LL |         #[repr(align($n))]
+   |                      ^^
+...
+LL | pass_nonterminal!(n!());
+   | ------------------------ in this macro invocation
+   |
+   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0552]: unrecognized representation hint
+  --> $DIR/nonterminal-expansion.rs:5:16
+   |
+LL |         #[repr(align($n))]
+   |                ^^^^^^^^^
+...
+LL | pass_nonterminal!(n!());
+   | ------------------------ in this macro invocation
+   |
+   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0552`.

--- a/src/test/ui/conditional-compilation/cfg-attr-syntax-validation.rs
+++ b/src/test/ui/conditional-compilation/cfg-attr-syntax-validation.rs
@@ -29,6 +29,7 @@ macro_rules! generate_s10 {
     ($expr: expr) => {
         #[cfg(feature = $expr)]
         //~^ ERROR expected unsuffixed literal or identifier, found `concat!("nonexistent")`
+        //~| ERROR expected unsuffixed literal or identifier, found `concat!("nonexistent")`
         struct S10;
     }
 }

--- a/src/test/ui/conditional-compilation/cfg-attr-syntax-validation.stderr
+++ b/src/test/ui/conditional-compilation/cfg-attr-syntax-validation.stderr
@@ -63,7 +63,18 @@ LL | generate_s10!(concat!("nonexistent"));
    |
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 10 previous errors
+error: expected unsuffixed literal or identifier, found `concat!("nonexistent")`
+  --> $DIR/cfg-attr-syntax-validation.rs:30:25
+   |
+LL |         #[cfg(feature = $expr)]
+   |                         ^^^^^
+...
+LL | generate_s10!(concat!("nonexistent"));
+   | -------------------------------------- in this macro invocation
+   |
+   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 11 previous errors
 
 Some errors have detailed explanations: E0537, E0565.
 For more information about an error, try `rustc --explain E0537`.

--- a/src/test/ui/proc-macro/auxiliary/test-macros.rs
+++ b/src/test/ui/proc-macro/auxiliary/test-macros.rs
@@ -112,6 +112,12 @@ pub fn print_attr(_: TokenStream, input: TokenStream) -> TokenStream {
     print_helper(input, "ATTR")
 }
 
+#[proc_macro_attribute]
+pub fn print_attr_args(args: TokenStream, input: TokenStream) -> TokenStream {
+    print_helper(args, "ATTR_ARGS");
+    input
+}
+
 #[proc_macro_derive(Print, attributes(print_helper))]
 pub fn print_derive(input: TokenStream) -> TokenStream {
     print_helper(input, "DERIVE");

--- a/src/test/ui/proc-macro/nonterminal-expansion.rs
+++ b/src/test/ui/proc-macro/nonterminal-expansion.rs
@@ -1,0 +1,37 @@
+// check-pass
+// compile-flags: -Z span-debug
+// aux-build:test-macros.rs
+
+#![no_std] // Don't load unnecessary hygiene information from std
+extern crate std;
+
+#[macro_use]
+extern crate test_macros;
+
+macro_rules! pass_nonterminal {
+    ($line:expr) => {
+        #[print_attr_args(a, $line, b)]
+        struct S;
+    };
+}
+
+// `line!()` is not expanded before it's passed to the proc macro.
+pass_nonterminal!(line!());
+
+// Test case from #43860.
+
+#[macro_export]
+macro_rules! use_contract {
+    ($name: ident, $path: expr) => {
+        #[derive(Empty)]
+        #[empty_helper(path = $path)] // OK
+        pub struct $name<T, C> {
+            api: T,
+            contract: C,
+        }
+    };
+}
+
+use_contract!(ContractName, file!());
+
+fn main() {}

--- a/src/test/ui/proc-macro/nonterminal-expansion.stdout
+++ b/src/test/ui/proc-macro/nonterminal-expansion.stdout
@@ -1,0 +1,42 @@
+PRINT-ATTR_ARGS INPUT (DISPLAY): a, line!(), b
+PRINT-ATTR_ARGS RE-COLLECTED (DISPLAY): a, line ! (), b
+PRINT-ATTR_ARGS INPUT (DEBUG): TokenStream [
+    Ident {
+        ident: "a",
+        span: $DIR/nonterminal-expansion.rs:13:27: 13:28 (#4),
+    },
+    Punct {
+        ch: ',',
+        spacing: Alone,
+        span: $DIR/nonterminal-expansion.rs:13:28: 13:29 (#4),
+    },
+    Group {
+        delimiter: None,
+        stream: TokenStream [
+            Ident {
+                ident: "line",
+                span: $DIR/nonterminal-expansion.rs:19:19: 19:23 (#0),
+            },
+            Punct {
+                ch: '!',
+                spacing: Alone,
+                span: $DIR/nonterminal-expansion.rs:19:23: 19:24 (#0),
+            },
+            Group {
+                delimiter: Parenthesis,
+                stream: TokenStream [],
+                span: $DIR/nonterminal-expansion.rs:19:24: 19:26 (#0),
+            },
+        ],
+        span: $DIR/nonterminal-expansion.rs:13:30: 13:35 (#4),
+    },
+    Punct {
+        ch: ',',
+        spacing: Alone,
+        span: $DIR/nonterminal-expansion.rs:13:35: 13:36 (#4),
+    },
+    Ident {
+        ident: "b",
+        span: $DIR/nonterminal-expansion.rs:13:37: 13:38 (#4),
+    },
+]


### PR DESCRIPTION
Implement the experiment described in https://github.com/rust-lang/rust/issues/55414#issuecomment-554005412

This PR also removes some customization points and token visiting functionality from AST visitors.
Read-only visitor no longer visits tokens, mutable visitor visits tokens only when specifically enabled, mutable token visiting is restricted to its single intended use case.

I haven't changed the representation of `MacArgs::Eq` yet, but it potentially can use a `TokenTree` or a `Token` instead of `TokenStream`.
It's hard to get rid of `Nonterminal::NtExpr` there (and e.g. replace it with `ast::Expr`) due to the dual nature of key-value attributes (the value is both an expression and a token stream, depending on context), and `Nonterminal` has all the machinery for maintaining both representations in sync.

Fixes https://github.com/rust-lang/rust/issues/55414
Fixes https://github.com/rust-lang/rust/issues/43860 