### PR TITLE
expand: Stop normalizing `NtIdent`s before passing them to built-in macros

### DIFF
--- a/compiler/rustc_builtin_macros/src/asm.rs
+++ b/compiler/rustc_builtin_macros/src/asm.rs
@@ -368,7 +368,7 @@ fn parse_reg<'a>(
     explicit_reg: &mut bool,
 ) -> Result<ast::InlineAsmRegOrRegClass, DiagnosticBuilder<'a>> {
     p.expect(&token::OpenDelim(token::DelimToken::Paren))?;
-    let result = match p.token.kind {
+    let result = match p.token.uninterpolate().kind {
         token::Ident(name, false) => ast::InlineAsmRegOrRegClass::RegClass(name),
         token::Literal(token::Lit { kind: token::LitKind::Str, symbol, suffix: _ }) => {
             *explicit_reg = true;

--- a/compiler/rustc_builtin_macros/src/concat_idents.rs
+++ b/compiler/rustc_builtin_macros/src/concat_idents.rs
@@ -27,15 +27,15 @@ pub fn expand_concat_idents<'cx>(
                 }
             }
         } else {
-            match e {
-                TokenTree::Token(Token { kind: token::Ident(name, _), .. }) => {
-                    res_str.push_str(&name.as_str())
-                }
-                _ => {
-                    cx.span_err(sp, "concat_idents! requires ident args.");
-                    return DummyResult::any(sp);
+            if let TokenTree::Token(token) = e {
+                if let Some((ident, _)) = token.ident() {
+                    res_str.push_str(&ident.name.as_str());
+                    continue;
                 }
             }
+
+            cx.span_err(sp, "concat_idents! requires ident args.");
+            return DummyResult::any(sp);
         }
     }
 

--- a/compiler/rustc_expand/src/base.rs
+++ b/compiler/rustc_expand/src/base.rs
@@ -312,7 +312,7 @@ where
         ts: TokenStream,
     ) -> Result<TokenStream, ErrorReported> {
         // FIXME setup implicit context in TLS before calling self.
-        Ok((*self)(ts))
+        Ok(self(ts))
     }
 }
 
@@ -338,7 +338,7 @@ where
         annotated: TokenStream,
     ) -> Result<TokenStream, ErrorReported> {
         // FIXME setup implicit context in TLS before calling self.
-        Ok((*self)(annotation, annotated))
+        Ok(self(annotation, annotated))
     }
 }
 
@@ -365,7 +365,7 @@ where
         span: Span,
         input: TokenStream,
     ) -> Box<dyn MacResult + 'cx> {
-        (*self)(ecx, span, input)
+        self(ecx, span, input)
     }
 }
 

--- a/compiler/rustc_expand/src/base.rs
+++ b/compiler/rustc_expand/src/base.rs
@@ -1,10 +1,9 @@
 use crate::expand::{self, AstFragment, Invocation};
 use crate::module::DirectoryOwnership;
 
-use rustc_ast::mut_visit::{self, MutVisitor};
 use rustc_ast::ptr::P;
 use rustc_ast::token;
-use rustc_ast::tokenstream::{self, TokenStream};
+use rustc_ast::tokenstream::TokenStream;
 use rustc_ast::visit::{AssocCtxt, Visitor};
 use rustc_ast::{self as ast, Attribute, NodeId, PatKind};
 use rustc_attr::{self as attr, Deprecation, HasAttrs, Stability};
@@ -364,30 +363,8 @@ where
         &self,
         ecx: &'cx mut ExtCtxt<'_>,
         span: Span,
-        mut input: TokenStream,
+        input: TokenStream,
     ) -> Box<dyn MacResult + 'cx> {
-        struct AvoidInterpolatedIdents;
-
-        impl MutVisitor for AvoidInterpolatedIdents {
-            fn visit_tt(&mut self, tt: &mut tokenstream::TokenTree) {
-                if let tokenstream::TokenTree::Token(token) = tt {
-                    if let token::Interpolated(nt) = &token.kind {
-                        if let token::NtIdent(ident, is_raw) = **nt {
-                            *tt = tokenstream::TokenTree::token(
-                                token::Ident(ident.name, is_raw),
-                                ident.span,
-                            );
-                        }
-                    }
-                }
-                mut_visit::noop_visit_tt(tt, self)
-            }
-
-            fn visit_mac(&mut self, mac: &mut ast::MacCall) {
-                mut_visit::noop_visit_mac(mac, self)
-            }
-        }
-        AvoidInterpolatedIdents.visit_tts(&mut input);
         (*self)(ecx, span, input)
     }
 }


### PR DESCRIPTION
Built-in macros should be able to deal with `NtIdents` in the input by themselves like any other parser code.

You can't imagine how bad mutable AST visitors are, *especially* if they are modifying tokens.
This is one step towards removing token visiting from the visitor infrastructure (https://github.com/rust-lang/rust/pull/77271 also works in this direction.)