### PR TITLE
Warn on broken intra-doc links added to cross-crate re-exports

### DIFF
--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -514,6 +514,7 @@ fn build_module(cx: &DocContext<'_>, did: DefId, visited: &mut FxHashSet<DefId>)
                                 },
                                 did: None,
                             },
+                            false,
                         )),
                     });
                 } else if let Some(i) =

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -498,7 +498,7 @@ fn build_module(cx: &DocContext<'_>, did: DefId, visited: &mut FxHashSet<DefId>)
                         visibility: clean::Public,
                         stability: None,
                         deprecation: None,
-                        inner: clean::ImportItem(clean::Import::Simple(
+                        inner: clean::ImportItem(clean::Import::new_simple(
                             item.ident.to_string(),
                             clean::ImportSource {
                                 path: clean::Path {
@@ -514,7 +514,7 @@ fn build_module(cx: &DocContext<'_>, did: DefId, visited: &mut FxHashSet<DefId>)
                                 },
                                 did: None,
                             },
-                            false,
+                            true,
                         )),
                     });
                 } else if let Some(i) =

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -2269,12 +2269,12 @@ impl Clean<Vec<Item>> for doctree::Import<'_> {
                         visibility: self.vis.clean(cx),
                         stability: None,
                         deprecation: None,
-                        inner: ImportItem(Import::Glob(resolve_use_source(cx, path))),
+                        inner: ImportItem(Import::Glob(resolve_use_source(cx, path), false)),
                     });
                     return items;
                 }
             }
-            Import::Glob(resolve_use_source(cx, path))
+            Import::Glob(resolve_use_source(cx, path), true)
         } else {
             let name = self.name;
             if !please_inline {
@@ -2297,6 +2297,9 @@ impl Clean<Vec<Item>> for doctree::Import<'_> {
                     Some(self.attrs),
                     &mut visited,
                 ) {
+                    // In case this is a macro, we don't want to show the reexport, only the macro
+                    // itself.
+                    let is_macro = matches!(path.res, Res::Def(DefKind::Macro(_), _));
                     items.push(Item {
                         name: None,
                         attrs: self.attrs.clean(cx),
@@ -2308,12 +2311,13 @@ impl Clean<Vec<Item>> for doctree::Import<'_> {
                         inner: ImportItem(Import::Simple(
                             self.name.clean(cx),
                             resolve_use_source(cx, path),
+                            is_macro,
                         )),
                     });
                     return items;
                 }
             }
-            Import::Simple(name.clean(cx), resolve_use_source(cx, path))
+            Import::Simple(name.clean(cx), resolve_use_source(cx, path), false)
         };
 
         vec![Item {

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -2232,12 +2232,6 @@ impl Clean<Vec<Item>> for doctree::ExternCrate<'_> {
 
 impl Clean<Vec<Item>> for doctree::Import<'_> {
     fn clean(&self, cx: &DocContext<'_>) -> Vec<Item> {
-        // We need this comparison because some imports (for std types for example)
-        // are "inserted" as well but directly by the compiler and they should not be
-        // taken into account.
-        if self.span.is_dummy() {
-            return Vec::new();
-        }
         // We consider inlining the documentation of `pub use` statements, but we
         // forcefully don't inline if this is not public or if the
         // #[doc(no_inline)] attribute is present.

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -2269,12 +2269,12 @@ impl Clean<Vec<Item>> for doctree::Import<'_> {
                         visibility: self.vis.clean(cx),
                         stability: None,
                         deprecation: None,
-                        inner: ImportItem(Import::Glob(resolve_use_source(cx, path), false)),
+                        inner: ImportItem(Import::new_glob(resolve_use_source(cx, path), false)),
                     });
                     return items;
                 }
             }
-            Import::Glob(resolve_use_source(cx, path), true)
+            Import::new_glob(resolve_use_source(cx, path), true)
         } else {
             let name = self.name;
             if !please_inline {
@@ -2297,9 +2297,6 @@ impl Clean<Vec<Item>> for doctree::Import<'_> {
                     Some(self.attrs),
                     &mut visited,
                 ) {
-                    // In case this is a macro, we don't want to show the reexport, only the macro
-                    // itself.
-                    let is_macro = matches!(path.res, Res::Def(DefKind::Macro(_), _));
                     items.push(Item {
                         name: None,
                         attrs: self.attrs.clean(cx),
@@ -2308,16 +2305,16 @@ impl Clean<Vec<Item>> for doctree::Import<'_> {
                         visibility: self.vis.clean(cx),
                         stability: None,
                         deprecation: None,
-                        inner: ImportItem(Import::Simple(
+                        inner: ImportItem(Import::new_simple(
                             self.name.clean(cx),
                             resolve_use_source(cx, path),
-                            is_macro,
+                            false,
                         )),
                     });
                     return items;
                 }
             }
-            Import::Simple(name.clean(cx), resolve_use_source(cx, path), false)
+            Import::new_simple(name.clean(cx), resolve_use_source(cx, path), true)
         };
 
         vec![Item {

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -2260,17 +2260,7 @@ impl Clean<Vec<Item>> for doctree::Import<'_> {
         let inner = if self.glob {
             if !denied {
                 let mut visited = FxHashSet::default();
-                if let Some(mut items) = inline::try_inline_glob(cx, path.res, &mut visited) {
-                    items.push(Item {
-                        name: None,
-                        attrs: self.attrs.clean(cx),
-                        source: self.span.clean(cx),
-                        def_id: cx.tcx.hir().local_def_id(self.id).to_def_id(),
-                        visibility: self.vis.clean(cx),
-                        stability: None,
-                        deprecation: None,
-                        inner: ImportItem(Import::new_glob(resolve_use_source(cx, path), false)),
-                    });
+                if let Some(items) = inline::try_inline_glob(cx, path.res, &mut visited) {
                     return items;
                 }
             }

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -1655,9 +1655,20 @@ pub struct Impl {
 #[derive(Clone, Debug)]
 pub enum Import {
     // use source as str;
-    Simple(String, ImportSource),
+    // The bool indicates wether it imports a macro or not.
+    Simple(String, ImportSource, bool),
     // use source::*;
-    Glob(ImportSource),
+    // The bool indicates wether this is from an import.
+    Glob(ImportSource, bool),
+}
+
+impl Import {
+    pub fn should_be_displayed(&self) -> bool {
+        match *self {
+            Self::Simple(_, _, is_macro) => !is_macro,
+            Self::Glob(_, is_from_import) => is_from_import,
+        }
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -177,6 +177,7 @@ impl Item {
     pub fn is_stripped(&self) -> bool {
         match self.inner {
             StrippedItem(..) => true,
+            ImportItem(ref i) => !i.should_be_displayed,
             _ => false,
         }
     }
@@ -1653,22 +1654,28 @@ pub struct Impl {
 }
 
 #[derive(Clone, Debug)]
-pub enum Import {
-    // use source as str;
-    // The bool indicates whether it imports a macro or not.
-    Simple(String, ImportSource, bool),
-    // use source::*;
-    // The bool indicates whether this is from an import.
-    Glob(ImportSource, bool),
+pub struct Import {
+    pub kind: ImportKind,
+    pub source: ImportSource,
+    pub should_be_displayed: bool,
 }
 
 impl Import {
-    pub fn should_be_displayed(&self) -> bool {
-        match *self {
-            Self::Simple(_, _, is_macro) => !is_macro,
-            Self::Glob(_, is_from_import) => is_from_import,
-        }
+    pub fn new_simple(name: String, source: ImportSource, should_be_displayed: bool) -> Self {
+        Self { kind: ImportKind::Simple(name), source, should_be_displayed }
     }
+
+    pub fn new_glob(source: ImportSource, should_be_displayed: bool) -> Self {
+        Self { kind: ImportKind::Glob, source, should_be_displayed }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum ImportKind {
+    // use source as str;
+    Simple(String),
+    // use source::*;
+    Glob,
 }
 
 #[derive(Clone, Debug)]

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -1655,10 +1655,10 @@ pub struct Impl {
 #[derive(Clone, Debug)]
 pub enum Import {
     // use source as str;
-    // The bool indicates wether it imports a macro or not.
+    // The bool indicates whether it imports a macro or not.
     Simple(String, ImportSource, bool),
     // use source::*;
-    // The bool indicates wether this is from an import.
+    // The bool indicates whether this is from an import.
     Glob(ImportSource, bool),
 }
 

--- a/src/librustdoc/doctree.rs
+++ b/src/librustdoc/doctree.rs
@@ -245,6 +245,7 @@ pub struct ExternCrate<'hir> {
     pub span: Span,
 }
 
+#[derive(Debug)]
 pub struct Import<'hir> {
     pub name: Symbol,
     pub id: hir::HirId,

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -1149,19 +1149,19 @@ impl PrintWithSpace for hir::Mutability {
 
 impl clean::Import {
     crate fn print(&self) -> impl fmt::Display + '_ {
-        display_fn(move |f| match *self {
-            clean::Import::Simple(ref name, ref src, _) => {
-                if *name == src.path.last_name() {
-                    write!(f, "use {};", src.print())
+        display_fn(move |f| match self.kind {
+            clean::ImportKind::Simple(ref name) => {
+                if *name == self.source.path.last_name() {
+                    write!(f, "use {};", self.source.print())
                 } else {
-                    write!(f, "use {} as {};", src.print(), *name)
+                    write!(f, "use {} as {};", self.source.print(), *name)
                 }
             }
-            clean::Import::Glob(ref src, _) => {
-                if src.path.segments.is_empty() {
+            clean::ImportKind::Glob => {
+                if self.source.path.segments.is_empty() {
                     write!(f, "use *;")
                 } else {
-                    write!(f, "use {}::*;", src.print())
+                    write!(f, "use {}::*;", self.source.print())
                 }
             }
         })

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -1150,14 +1150,14 @@ impl PrintWithSpace for hir::Mutability {
 impl clean::Import {
     crate fn print(&self) -> impl fmt::Display + '_ {
         display_fn(move |f| match *self {
-            clean::Import::Simple(ref name, ref src) => {
+            clean::Import::Simple(ref name, ref src, _) => {
                 if *name == src.path.last_name() {
                     write!(f, "use {};", src.print())
                 } else {
                     write!(f, "use {} as {};", src.print(), *name)
                 }
             }
-            clean::Import::Glob(ref src) => {
+            clean::Import::Glob(ref src, _) => {
                 if src.path.segments.is_empty() {
                     write!(f, "use *;")
                 } else {

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -2074,12 +2074,14 @@ fn item_module(w: &mut Buffer, cx: &Context, item: &clean::Item, items: &[clean:
             }
 
             clean::ImportItem(ref import) => {
-                write!(
-                    w,
-                    "<tr><td><code>{}{}</code></td></tr>",
-                    myitem.visibility.print_with_space(),
-                    import.print()
-                );
+                if import.should_be_displayed() {
+                    write!(
+                        w,
+                        "<tr><td><code>{}{}</code></td></tr>",
+                        myitem.visibility.print_with_space(),
+                        import.print()
+                    );
+                }
             }
 
             _ => {

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -2074,14 +2074,12 @@ fn item_module(w: &mut Buffer, cx: &Context, item: &clean::Item, items: &[clean:
             }
 
             clean::ImportItem(ref import) => {
-                if import.should_be_displayed() {
-                    write!(
-                        w,
-                        "<tr><td><code>{}{}</code></td></tr>",
-                        myitem.visibility.print_with_space(),
-                        import.print()
-                    );
-                }
+                write!(
+                    w,
+                    "<tr><td><code>{}{}</code></td></tr>",
+                    myitem.visibility.print_with_space(),
+                    import.print()
+                );
             }
 
             _ => {
@@ -4440,8 +4438,9 @@ fn item_ty_to_strs(ty: &ItemType) -> (&'static str, &'static str) {
 fn sidebar_module(buf: &mut Buffer, items: &[clean::Item]) {
     let mut sidebar = String::new();
 
-    if items.iter().any(|it| it.type_() == ItemType::ExternCrate || it.type_() == ItemType::Import)
-    {
+    if items.iter().any(|it| {
+        it.type_() == ItemType::ExternCrate || (it.type_() == ItemType::Import && !it.is_stripped())
+    }) {
         sidebar.push_str(&format!(
             "<li><a href=\"#{id}\">{name}</a></li>",
             id = "reexports",

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -758,7 +758,7 @@ impl<'a, 'tcx> DocFolder for LinkCollector<'a, 'tcx> {
                 debug!("ignoring extern crate item {:?}", item.def_id);
                 return self.fold_item_recur(item);
             }
-            ImportItem(Import::Simple(ref name, ..)) => Some(name.clone()),
+            ImportItem(Import { kind: ImportKind::Simple(ref name, ..), .. }) => Some(name.clone()),
             MacroItem(..) => None,
             _ => item.name.clone(),
         };

--- a/src/test/rustdoc-ui/auxiliary/intra-doc-broken.rs
+++ b/src/test/rustdoc-ui/auxiliary/intra-doc-broken.rs
@@ -1,0 +1,4 @@
+#![crate_name = "intra_doc_broken"]
+
+/// [not_found]
+pub fn foo() {}

--- a/src/test/rustdoc-ui/intra-doc-broken-reexport.rs
+++ b/src/test/rustdoc-ui/intra-doc-broken-reexport.rs
@@ -1,0 +1,8 @@
+// aux-build:intra-doc-broken.rs
+// check-pass
+
+#![deny(broken_intra_doc_links)]
+
+extern crate intra_doc_broken;
+
+pub use intra_doc_broken::foo;

--- a/src/test/rustdoc-ui/pub-export-lint.rs
+++ b/src/test/rustdoc-ui/pub-export-lint.rs
@@ -1,8 +1,5 @@
 #![deny(broken_intra_doc_links)]
 
-/// [somewhere]
-//~^ ERROR unresolved link to `somewhere`
-pub use std::str::*;
 /// [aloha]
 //~^ ERROR unresolved link to `aloha`
 pub use std::task::RawWakerVTable;

--- a/src/test/rustdoc-ui/pub-export-lint.rs
+++ b/src/test/rustdoc-ui/pub-export-lint.rs
@@ -1,0 +1,8 @@
+#![deny(broken_intra_doc_links)]
+
+/// [somewhere]
+//~^ ERROR unresolved link to `somewhere`
+pub use std::str::*;
+/// [aloha]
+//~^ ERROR unresolved link to `aloha`
+pub use std::task::RawWakerVTable;

--- a/src/test/rustdoc-ui/pub-export-lint.stderr
+++ b/src/test/rustdoc-ui/pub-export-lint.stderr
@@ -1,4 +1,4 @@
-error: unresolved link to `somewhere`
+error: unresolved link to `aloha`
   --> $DIR/pub-export-lint.rs:3:6
    |
 LL | /// [aloha]
@@ -11,13 +11,5 @@ LL | #![deny(broken_intra_doc_links)]
    |         ^^^^^^^^^^^^^^^^^^^^^^
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
-error: unresolved link to `aloha`
-  --> $DIR/pub-export-lint.rs:6:6
-   |
-LL | /// [aloha]
-   |      ^^^^^ the module `pub_export_lint` contains no item named `aloha`
-   |
-   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
-
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 

--- a/src/test/rustdoc-ui/pub-export-lint.stderr
+++ b/src/test/rustdoc-ui/pub-export-lint.stderr
@@ -1,0 +1,23 @@
+error: unresolved link to `somewhere`
+  --> $DIR/pub-export-lint.rs:3:6
+   |
+LL | /// [somewhere]
+   |      ^^^^^^^^^ the module `pub_export_lint` contains no item named `somewhere`
+   |
+note: the lint level is defined here
+  --> $DIR/pub-export-lint.rs:1:9
+   |
+LL | #![deny(broken_intra_doc_links)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^
+   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
+
+error: unresolved link to `aloha`
+  --> $DIR/pub-export-lint.rs:6:6
+   |
+LL | /// [aloha]
+   |      ^^^^^ the module `pub_export_lint` contains no item named `aloha`
+   |
+   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
+
+error: aborting due to 2 previous errors
+

--- a/src/test/rustdoc-ui/pub-export-lint.stderr
+++ b/src/test/rustdoc-ui/pub-export-lint.stderr
@@ -1,8 +1,8 @@
 error: unresolved link to `somewhere`
   --> $DIR/pub-export-lint.rs:3:6
    |
-LL | /// [somewhere]
-   |      ^^^^^^^^^ the module `pub_export_lint` contains no item named `somewhere`
+LL | /// [aloha]
+   |      ^^^^^ no item named `aloha` in scope
    |
 note: the lint level is defined here
   --> $DIR/pub-export-lint.rs:1:9

--- a/src/test/rustdoc/reexport-check.rs
+++ b/src/test/rustdoc/reexport-check.rs
@@ -7,5 +7,3 @@ pub use std::i32;
 // @!has 'foo/index.html' '//code' 'pub use self::string::String;'
 // @has 'foo/index.html' '//tr[@class="module-item"]' 'String'
 pub use std::string::String;
-// @!has 'foo/index.html' '//code' 'pub use self::string::*;'
-pub use std::string::*;

--- a/src/test/rustdoc/reexport-check.rs
+++ b/src/test/rustdoc/reexport-check.rs
@@ -1,0 +1,11 @@
+#![crate_name = "foo"]
+
+// @!has 'foo/index.html' '//code' 'pub use self::i32;'
+// @has 'foo/index.html' '//tr[@class="module-item"]' 'i32'
+// @has 'foo/i32/index.html'
+pub use std::i32;
+// @!has 'foo/index.html' '//code' 'pub use self::string::String;'
+// @has 'foo/index.html' '//tr[@class="module-item"]' 'String'
+pub use std::string::String;
+// @!has 'foo/index.html' '//code' 'pub use self::string::*;'
+pub use std::string::*;


### PR DESCRIPTION
This emits `broken_intra_doc_links` for docs applied to pub use statements that point to external items and are inlined.
Does not address #77200 - any existing broken links from the original crate will not show warnings.

r? @jyn514 