### PR TITLE
Use correct article in help message for conversion or cast

### DIFF
--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -210,6 +210,18 @@ impl TyKind<'tcx> {
             _ => false,
         }
     }
+
+    /// Get the article ("a" or "an") to use with this type.
+    ///
+    /// **Panics if `self` is [`TyKind::Error`].**
+    pub fn article(&self) -> &'static str {
+        match self {
+            Int(_) | Float(_) | Array(_, _) => "an",
+            Adt(def, _) if def.is_enum() => "an",
+            Error(_) => panic!(),
+            _ => "a",
+        }
+    }
 }
 
 // `TyKind` is used a lot. Make sure it doesn't unintentionally get bigger.

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -212,13 +212,13 @@ impl TyKind<'tcx> {
     }
 
     /// Get the article ("a" or "an") to use with this type.
-    ///
-    /// **Panics if `self` is [`TyKind::Error`].**
     pub fn article(&self) -> &'static str {
         match self {
             Int(_) | Float(_) | Array(_, _) => "an",
             Adt(def, _) if def.is_enum() => "an",
-            Error(_) => panic!(),
+            // This should never happen, but ICEing and causing the user's code
+            // to not compile felt too harsh.
+            Error(_) => "a",
             _ => "a",
         }
     }

--- a/compiler/rustc_typeck/src/check/demand.rs
+++ b/compiler/rustc_typeck/src/check/demand.rs
@@ -752,8 +752,18 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             }
         }
 
-        let msg = format!("you can convert an `{}` to `{}`", checked_ty, expected_ty);
-        let cast_msg = format!("you can cast an `{} to `{}`", checked_ty, expected_ty);
+        let msg = format!(
+            "you can convert {} `{}` to `{}`",
+            checked_ty.kind().article(),
+            checked_ty,
+            expected_ty
+        );
+        let cast_msg = format!(
+            "you can cast {} `{} to `{}`",
+            checked_ty.kind().article(),
+            checked_ty,
+            expected_ty
+        );
         let lit_msg = format!(
             "change the type of the numeric literal from `{}` to `{}`",
             checked_ty, expected_ty,

--- a/compiler/rustc_typeck/src/check/demand.rs
+++ b/compiler/rustc_typeck/src/check/demand.rs
@@ -827,7 +827,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     let suggestion = format!("{}::from({})", checked_ty, lhs_src);
                     (lhs_expr.span, msg, suggestion)
                 } else {
-                    let msg = format!("{} and panic if the converted value wouldn't fit", msg);
+                    let msg = format!("{} and panic if the converted value doesn't fit", msg);
                     let suggestion =
                         format!("{}{}.try_into().unwrap()", prefix, with_opt_paren(&src));
                     (expr.span, msg, suggestion)

--- a/compiler/rustc_typeck/src/check/demand.rs
+++ b/compiler/rustc_typeck/src/check/demand.rs
@@ -753,16 +753,18 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         }
 
         let msg = format!(
-            "you can convert {} `{}` to `{}`",
+            "you can convert {} `{}` to {} `{}`",
             checked_ty.kind().article(),
             checked_ty,
-            expected_ty
+            expected_ty.kind().article(),
+            expected_ty,
         );
         let cast_msg = format!(
-            "you can cast {} `{} to `{}`",
+            "you can cast {} `{}` to {} `{}`",
             checked_ty.kind().article(),
             checked_ty,
-            expected_ty
+            expected_ty.kind().article(),
+            expected_ty,
         );
         let lit_msg = format!(
             "change the type of the numeric literal from `{}` to `{}`",

--- a/src/test/ui/associated-types/associated-types-path-2.stderr
+++ b/src/test/ui/associated-types/associated-types-path-2.stderr
@@ -47,7 +47,7 @@ LL |     let _: i32 = f2(2i32);
    |            |
    |            expected due to this
    |
-help: you can convert an `u32` to `i32` and panic if the converted value wouldn't fit
+help: you can convert a `u32` to `i32` and panic if the converted value wouldn't fit
    |
 LL |     let _: i32 = f2(2i32).try_into().unwrap();
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/associated-types/associated-types-path-2.stderr
+++ b/src/test/ui/associated-types/associated-types-path-2.stderr
@@ -47,7 +47,7 @@ LL |     let _: i32 = f2(2i32);
    |            |
    |            expected due to this
    |
-help: you can convert a `u32` to `i32` and panic if the converted value wouldn't fit
+help: you can convert a `u32` to an `i32` and panic if the converted value wouldn't fit
    |
 LL |     let _: i32 = f2(2i32).try_into().unwrap();
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/associated-types/associated-types-path-2.stderr
+++ b/src/test/ui/associated-types/associated-types-path-2.stderr
@@ -47,7 +47,7 @@ LL |     let _: i32 = f2(2i32);
    |            |
    |            expected due to this
    |
-help: you can convert a `u32` to an `i32` and panic if the converted value wouldn't fit
+help: you can convert a `u32` to an `i32` and panic if the converted value doesn't fit
    |
 LL |     let _: i32 = f2(2i32).try_into().unwrap();
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/indexing-requires-a-uint.stderr
+++ b/src/test/ui/indexing-requires-a-uint.stderr
@@ -13,7 +13,7 @@ error[E0308]: mismatched types
 LL |     bar::<isize>(i);  // i should not be re-coerced back to an isize
    |                  ^ expected `isize`, found `usize`
    |
-help: you can convert an `usize` to `isize` and panic if the converted value wouldn't fit
+help: you can convert a `usize` to `isize` and panic if the converted value wouldn't fit
    |
 LL |     bar::<isize>(i.try_into().unwrap());  // i should not be re-coerced back to an isize
    |                  ^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/indexing-requires-a-uint.stderr
+++ b/src/test/ui/indexing-requires-a-uint.stderr
@@ -13,7 +13,7 @@ error[E0308]: mismatched types
 LL |     bar::<isize>(i);  // i should not be re-coerced back to an isize
    |                  ^ expected `isize`, found `usize`
    |
-help: you can convert a `usize` to `isize` and panic if the converted value wouldn't fit
+help: you can convert a `usize` to an `isize` and panic if the converted value wouldn't fit
    |
 LL |     bar::<isize>(i.try_into().unwrap());  // i should not be re-coerced back to an isize
    |                  ^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/indexing-requires-a-uint.stderr
+++ b/src/test/ui/indexing-requires-a-uint.stderr
@@ -13,7 +13,7 @@ error[E0308]: mismatched types
 LL |     bar::<isize>(i);  // i should not be re-coerced back to an isize
    |                  ^ expected `isize`, found `usize`
    |
-help: you can convert a `usize` to an `isize` and panic if the converted value wouldn't fit
+help: you can convert a `usize` to an `isize` and panic if the converted value doesn't fit
    |
 LL |     bar::<isize>(i.try_into().unwrap());  // i should not be re-coerced back to an isize
    |                  ^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/integer-literal-suffix-inference.stderr
+++ b/src/test/ui/integer-literal-suffix-inference.stderr
@@ -328,7 +328,7 @@ error[E0308]: mismatched types
 LL |     id_u8(b16);
    |           ^^^ expected `u8`, found `u16`
    |
-help: you can convert an `u16` to `u8` and panic if the converted value wouldn't fit
+help: you can convert a `u16` to `u8` and panic if the converted value wouldn't fit
    |
 LL |     id_u8(b16.try_into().unwrap());
    |           ^^^^^^^^^^^^^^^^^^^^^^^
@@ -339,7 +339,7 @@ error[E0308]: mismatched types
 LL |     id_u8(b32);
    |           ^^^ expected `u8`, found `u32`
    |
-help: you can convert an `u32` to `u8` and panic if the converted value wouldn't fit
+help: you can convert a `u32` to `u8` and panic if the converted value wouldn't fit
    |
 LL |     id_u8(b32.try_into().unwrap());
    |           ^^^^^^^^^^^^^^^^^^^^^^^
@@ -350,7 +350,7 @@ error[E0308]: mismatched types
 LL |     id_u8(b64);
    |           ^^^ expected `u8`, found `u64`
    |
-help: you can convert an `u64` to `u8` and panic if the converted value wouldn't fit
+help: you can convert a `u64` to `u8` and panic if the converted value wouldn't fit
    |
 LL |     id_u8(b64.try_into().unwrap());
    |           ^^^^^^^^^^^^^^^^^^^^^^^
@@ -361,7 +361,7 @@ error[E0308]: mismatched types
 LL |     id_u8(bsize);
    |           ^^^^^ expected `u8`, found `usize`
    |
-help: you can convert an `usize` to `u8` and panic if the converted value wouldn't fit
+help: you can convert a `usize` to `u8` and panic if the converted value wouldn't fit
    |
 LL |     id_u8(bsize.try_into().unwrap());
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -373,7 +373,7 @@ LL |     id_u16(b8);
    |            ^^
    |            |
    |            expected `u16`, found `u8`
-   |            help: you can convert an `u8` to `u16`: `b8.into()`
+   |            help: you can convert a `u8` to `u16`: `b8.into()`
 
 error[E0308]: mismatched types
   --> $DIR/integer-literal-suffix-inference.rs:169:12
@@ -381,7 +381,7 @@ error[E0308]: mismatched types
 LL |     id_u16(b32);
    |            ^^^ expected `u16`, found `u32`
    |
-help: you can convert an `u32` to `u16` and panic if the converted value wouldn't fit
+help: you can convert a `u32` to `u16` and panic if the converted value wouldn't fit
    |
 LL |     id_u16(b32.try_into().unwrap());
    |            ^^^^^^^^^^^^^^^^^^^^^^^
@@ -392,7 +392,7 @@ error[E0308]: mismatched types
 LL |     id_u16(b64);
    |            ^^^ expected `u16`, found `u64`
    |
-help: you can convert an `u64` to `u16` and panic if the converted value wouldn't fit
+help: you can convert a `u64` to `u16` and panic if the converted value wouldn't fit
    |
 LL |     id_u16(b64.try_into().unwrap());
    |            ^^^^^^^^^^^^^^^^^^^^^^^
@@ -403,7 +403,7 @@ error[E0308]: mismatched types
 LL |     id_u16(bsize);
    |            ^^^^^ expected `u16`, found `usize`
    |
-help: you can convert an `usize` to `u16` and panic if the converted value wouldn't fit
+help: you can convert a `usize` to `u16` and panic if the converted value wouldn't fit
    |
 LL |     id_u16(bsize.try_into().unwrap());
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -415,7 +415,7 @@ LL |     id_u32(b8);
    |            ^^
    |            |
    |            expected `u32`, found `u8`
-   |            help: you can convert an `u8` to `u32`: `b8.into()`
+   |            help: you can convert a `u8` to `u32`: `b8.into()`
 
 error[E0308]: mismatched types
   --> $DIR/integer-literal-suffix-inference.rs:182:12
@@ -424,7 +424,7 @@ LL |     id_u32(b16);
    |            ^^^
    |            |
    |            expected `u32`, found `u16`
-   |            help: you can convert an `u16` to `u32`: `b16.into()`
+   |            help: you can convert a `u16` to `u32`: `b16.into()`
 
 error[E0308]: mismatched types
   --> $DIR/integer-literal-suffix-inference.rs:186:12
@@ -432,7 +432,7 @@ error[E0308]: mismatched types
 LL |     id_u32(b64);
    |            ^^^ expected `u32`, found `u64`
    |
-help: you can convert an `u64` to `u32` and panic if the converted value wouldn't fit
+help: you can convert a `u64` to `u32` and panic if the converted value wouldn't fit
    |
 LL |     id_u32(b64.try_into().unwrap());
    |            ^^^^^^^^^^^^^^^^^^^^^^^
@@ -443,7 +443,7 @@ error[E0308]: mismatched types
 LL |     id_u32(bsize);
    |            ^^^^^ expected `u32`, found `usize`
    |
-help: you can convert an `usize` to `u32` and panic if the converted value wouldn't fit
+help: you can convert a `usize` to `u32` and panic if the converted value wouldn't fit
    |
 LL |     id_u32(bsize.try_into().unwrap());
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -455,7 +455,7 @@ LL |     id_u64(b8);
    |            ^^
    |            |
    |            expected `u64`, found `u8`
-   |            help: you can convert an `u8` to `u64`: `b8.into()`
+   |            help: you can convert a `u8` to `u64`: `b8.into()`
 
 error[E0308]: mismatched types
   --> $DIR/integer-literal-suffix-inference.rs:196:12
@@ -464,7 +464,7 @@ LL |     id_u64(b16);
    |            ^^^
    |            |
    |            expected `u64`, found `u16`
-   |            help: you can convert an `u16` to `u64`: `b16.into()`
+   |            help: you can convert a `u16` to `u64`: `b16.into()`
 
 error[E0308]: mismatched types
   --> $DIR/integer-literal-suffix-inference.rs:199:12
@@ -473,7 +473,7 @@ LL |     id_u64(b32);
    |            ^^^
    |            |
    |            expected `u64`, found `u32`
-   |            help: you can convert an `u32` to `u64`: `b32.into()`
+   |            help: you can convert a `u32` to `u64`: `b32.into()`
 
 error[E0308]: mismatched types
   --> $DIR/integer-literal-suffix-inference.rs:203:12
@@ -481,7 +481,7 @@ error[E0308]: mismatched types
 LL |     id_u64(bsize);
    |            ^^^^^ expected `u64`, found `usize`
    |
-help: you can convert an `usize` to `u64` and panic if the converted value wouldn't fit
+help: you can convert a `usize` to `u64` and panic if the converted value wouldn't fit
    |
 LL |     id_u64(bsize.try_into().unwrap());
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -493,7 +493,7 @@ LL |     id_usize(b8);
    |              ^^
    |              |
    |              expected `usize`, found `u8`
-   |              help: you can convert an `u8` to `usize`: `b8.into()`
+   |              help: you can convert a `u8` to `usize`: `b8.into()`
 
 error[E0308]: mismatched types
   --> $DIR/integer-literal-suffix-inference.rs:210:14
@@ -502,7 +502,7 @@ LL |     id_usize(b16);
    |              ^^^
    |              |
    |              expected `usize`, found `u16`
-   |              help: you can convert an `u16` to `usize`: `b16.into()`
+   |              help: you can convert a `u16` to `usize`: `b16.into()`
 
 error[E0308]: mismatched types
   --> $DIR/integer-literal-suffix-inference.rs:213:14
@@ -510,7 +510,7 @@ error[E0308]: mismatched types
 LL |     id_usize(b32);
    |              ^^^ expected `usize`, found `u32`
    |
-help: you can convert an `u32` to `usize` and panic if the converted value wouldn't fit
+help: you can convert a `u32` to `usize` and panic if the converted value wouldn't fit
    |
 LL |     id_usize(b32.try_into().unwrap());
    |              ^^^^^^^^^^^^^^^^^^^^^^^
@@ -521,7 +521,7 @@ error[E0308]: mismatched types
 LL |     id_usize(b64);
    |              ^^^ expected `usize`, found `u64`
    |
-help: you can convert an `u64` to `usize` and panic if the converted value wouldn't fit
+help: you can convert a `u64` to `usize` and panic if the converted value wouldn't fit
    |
 LL |     id_usize(b64.try_into().unwrap());
    |              ^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/integer-literal-suffix-inference.stderr
+++ b/src/test/ui/integer-literal-suffix-inference.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL |     id_i8(a16);
    |           ^^^ expected `i8`, found `i16`
    |
-help: you can convert an `i16` to an `i8` and panic if the converted value wouldn't fit
+help: you can convert an `i16` to an `i8` and panic if the converted value doesn't fit
    |
 LL |     id_i8(a16.try_into().unwrap());
    |           ^^^^^^^^^^^^^^^^^^^^^^^
@@ -15,7 +15,7 @@ error[E0308]: mismatched types
 LL |     id_i8(a32);
    |           ^^^ expected `i8`, found `i32`
    |
-help: you can convert an `i32` to an `i8` and panic if the converted value wouldn't fit
+help: you can convert an `i32` to an `i8` and panic if the converted value doesn't fit
    |
 LL |     id_i8(a32.try_into().unwrap());
    |           ^^^^^^^^^^^^^^^^^^^^^^^
@@ -26,7 +26,7 @@ error[E0308]: mismatched types
 LL |     id_i8(a64);
    |           ^^^ expected `i8`, found `i64`
    |
-help: you can convert an `i64` to an `i8` and panic if the converted value wouldn't fit
+help: you can convert an `i64` to an `i8` and panic if the converted value doesn't fit
    |
 LL |     id_i8(a64.try_into().unwrap());
    |           ^^^^^^^^^^^^^^^^^^^^^^^
@@ -37,7 +37,7 @@ error[E0308]: mismatched types
 LL |     id_i8(asize);
    |           ^^^^^ expected `i8`, found `isize`
    |
-help: you can convert an `isize` to an `i8` and panic if the converted value wouldn't fit
+help: you can convert an `isize` to an `i8` and panic if the converted value doesn't fit
    |
 LL |     id_i8(asize.try_into().unwrap());
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -57,7 +57,7 @@ error[E0308]: mismatched types
 LL |     id_i16(a32);
    |            ^^^ expected `i16`, found `i32`
    |
-help: you can convert an `i32` to an `i16` and panic if the converted value wouldn't fit
+help: you can convert an `i32` to an `i16` and panic if the converted value doesn't fit
    |
 LL |     id_i16(a32.try_into().unwrap());
    |            ^^^^^^^^^^^^^^^^^^^^^^^
@@ -68,7 +68,7 @@ error[E0308]: mismatched types
 LL |     id_i16(a64);
    |            ^^^ expected `i16`, found `i64`
    |
-help: you can convert an `i64` to an `i16` and panic if the converted value wouldn't fit
+help: you can convert an `i64` to an `i16` and panic if the converted value doesn't fit
    |
 LL |     id_i16(a64.try_into().unwrap());
    |            ^^^^^^^^^^^^^^^^^^^^^^^
@@ -79,7 +79,7 @@ error[E0308]: mismatched types
 LL |     id_i16(asize);
    |            ^^^^^ expected `i16`, found `isize`
    |
-help: you can convert an `isize` to an `i16` and panic if the converted value wouldn't fit
+help: you can convert an `isize` to an `i16` and panic if the converted value doesn't fit
    |
 LL |     id_i16(asize.try_into().unwrap());
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -108,7 +108,7 @@ error[E0308]: mismatched types
 LL |     id_i32(a64);
    |            ^^^ expected `i32`, found `i64`
    |
-help: you can convert an `i64` to an `i32` and panic if the converted value wouldn't fit
+help: you can convert an `i64` to an `i32` and panic if the converted value doesn't fit
    |
 LL |     id_i32(a64.try_into().unwrap());
    |            ^^^^^^^^^^^^^^^^^^^^^^^
@@ -119,7 +119,7 @@ error[E0308]: mismatched types
 LL |     id_i32(asize);
    |            ^^^^^ expected `i32`, found `isize`
    |
-help: you can convert an `isize` to an `i32` and panic if the converted value wouldn't fit
+help: you can convert an `isize` to an `i32` and panic if the converted value doesn't fit
    |
 LL |     id_i32(asize.try_into().unwrap());
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -157,7 +157,7 @@ error[E0308]: mismatched types
 LL |     id_i64(asize);
    |            ^^^^^ expected `i64`, found `isize`
    |
-help: you can convert an `isize` to an `i64` and panic if the converted value wouldn't fit
+help: you can convert an `isize` to an `i64` and panic if the converted value doesn't fit
    |
 LL |     id_i64(asize.try_into().unwrap());
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -186,7 +186,7 @@ error[E0308]: mismatched types
 LL |     id_isize(a32);
    |              ^^^ expected `isize`, found `i32`
    |
-help: you can convert an `i32` to an `isize` and panic if the converted value wouldn't fit
+help: you can convert an `i32` to an `isize` and panic if the converted value doesn't fit
    |
 LL |     id_isize(a32.try_into().unwrap());
    |              ^^^^^^^^^^^^^^^^^^^^^^^
@@ -197,7 +197,7 @@ error[E0308]: mismatched types
 LL |     id_isize(a64);
    |              ^^^ expected `isize`, found `i64`
    |
-help: you can convert an `i64` to an `isize` and panic if the converted value wouldn't fit
+help: you can convert an `i64` to an `isize` and panic if the converted value doesn't fit
    |
 LL |     id_isize(a64.try_into().unwrap());
    |              ^^^^^^^^^^^^^^^^^^^^^^^
@@ -208,7 +208,7 @@ error[E0308]: mismatched types
 LL |     id_i8(c16);
    |           ^^^ expected `i8`, found `i16`
    |
-help: you can convert an `i16` to an `i8` and panic if the converted value wouldn't fit
+help: you can convert an `i16` to an `i8` and panic if the converted value doesn't fit
    |
 LL |     id_i8(c16.try_into().unwrap());
    |           ^^^^^^^^^^^^^^^^^^^^^^^
@@ -219,7 +219,7 @@ error[E0308]: mismatched types
 LL |     id_i8(c32);
    |           ^^^ expected `i8`, found `i32`
    |
-help: you can convert an `i32` to an `i8` and panic if the converted value wouldn't fit
+help: you can convert an `i32` to an `i8` and panic if the converted value doesn't fit
    |
 LL |     id_i8(c32.try_into().unwrap());
    |           ^^^^^^^^^^^^^^^^^^^^^^^
@@ -230,7 +230,7 @@ error[E0308]: mismatched types
 LL |     id_i8(c64);
    |           ^^^ expected `i8`, found `i64`
    |
-help: you can convert an `i64` to an `i8` and panic if the converted value wouldn't fit
+help: you can convert an `i64` to an `i8` and panic if the converted value doesn't fit
    |
 LL |     id_i8(c64.try_into().unwrap());
    |           ^^^^^^^^^^^^^^^^^^^^^^^
@@ -250,7 +250,7 @@ error[E0308]: mismatched types
 LL |     id_i16(c32);
    |            ^^^ expected `i16`, found `i32`
    |
-help: you can convert an `i32` to an `i16` and panic if the converted value wouldn't fit
+help: you can convert an `i32` to an `i16` and panic if the converted value doesn't fit
    |
 LL |     id_i16(c32.try_into().unwrap());
    |            ^^^^^^^^^^^^^^^^^^^^^^^
@@ -261,7 +261,7 @@ error[E0308]: mismatched types
 LL |     id_i16(c64);
    |            ^^^ expected `i16`, found `i64`
    |
-help: you can convert an `i64` to an `i16` and panic if the converted value wouldn't fit
+help: you can convert an `i64` to an `i16` and panic if the converted value doesn't fit
    |
 LL |     id_i16(c64.try_into().unwrap());
    |            ^^^^^^^^^^^^^^^^^^^^^^^
@@ -290,7 +290,7 @@ error[E0308]: mismatched types
 LL |     id_i32(c64);
    |            ^^^ expected `i32`, found `i64`
    |
-help: you can convert an `i64` to an `i32` and panic if the converted value wouldn't fit
+help: you can convert an `i64` to an `i32` and panic if the converted value doesn't fit
    |
 LL |     id_i32(c64.try_into().unwrap());
    |            ^^^^^^^^^^^^^^^^^^^^^^^
@@ -328,7 +328,7 @@ error[E0308]: mismatched types
 LL |     id_u8(b16);
    |           ^^^ expected `u8`, found `u16`
    |
-help: you can convert a `u16` to a `u8` and panic if the converted value wouldn't fit
+help: you can convert a `u16` to a `u8` and panic if the converted value doesn't fit
    |
 LL |     id_u8(b16.try_into().unwrap());
    |           ^^^^^^^^^^^^^^^^^^^^^^^
@@ -339,7 +339,7 @@ error[E0308]: mismatched types
 LL |     id_u8(b32);
    |           ^^^ expected `u8`, found `u32`
    |
-help: you can convert a `u32` to a `u8` and panic if the converted value wouldn't fit
+help: you can convert a `u32` to a `u8` and panic if the converted value doesn't fit
    |
 LL |     id_u8(b32.try_into().unwrap());
    |           ^^^^^^^^^^^^^^^^^^^^^^^
@@ -350,7 +350,7 @@ error[E0308]: mismatched types
 LL |     id_u8(b64);
    |           ^^^ expected `u8`, found `u64`
    |
-help: you can convert a `u64` to a `u8` and panic if the converted value wouldn't fit
+help: you can convert a `u64` to a `u8` and panic if the converted value doesn't fit
    |
 LL |     id_u8(b64.try_into().unwrap());
    |           ^^^^^^^^^^^^^^^^^^^^^^^
@@ -361,7 +361,7 @@ error[E0308]: mismatched types
 LL |     id_u8(bsize);
    |           ^^^^^ expected `u8`, found `usize`
    |
-help: you can convert a `usize` to a `u8` and panic if the converted value wouldn't fit
+help: you can convert a `usize` to a `u8` and panic if the converted value doesn't fit
    |
 LL |     id_u8(bsize.try_into().unwrap());
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -381,7 +381,7 @@ error[E0308]: mismatched types
 LL |     id_u16(b32);
    |            ^^^ expected `u16`, found `u32`
    |
-help: you can convert a `u32` to a `u16` and panic if the converted value wouldn't fit
+help: you can convert a `u32` to a `u16` and panic if the converted value doesn't fit
    |
 LL |     id_u16(b32.try_into().unwrap());
    |            ^^^^^^^^^^^^^^^^^^^^^^^
@@ -392,7 +392,7 @@ error[E0308]: mismatched types
 LL |     id_u16(b64);
    |            ^^^ expected `u16`, found `u64`
    |
-help: you can convert a `u64` to a `u16` and panic if the converted value wouldn't fit
+help: you can convert a `u64` to a `u16` and panic if the converted value doesn't fit
    |
 LL |     id_u16(b64.try_into().unwrap());
    |            ^^^^^^^^^^^^^^^^^^^^^^^
@@ -403,7 +403,7 @@ error[E0308]: mismatched types
 LL |     id_u16(bsize);
    |            ^^^^^ expected `u16`, found `usize`
    |
-help: you can convert a `usize` to a `u16` and panic if the converted value wouldn't fit
+help: you can convert a `usize` to a `u16` and panic if the converted value doesn't fit
    |
 LL |     id_u16(bsize.try_into().unwrap());
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -432,7 +432,7 @@ error[E0308]: mismatched types
 LL |     id_u32(b64);
    |            ^^^ expected `u32`, found `u64`
    |
-help: you can convert a `u64` to a `u32` and panic if the converted value wouldn't fit
+help: you can convert a `u64` to a `u32` and panic if the converted value doesn't fit
    |
 LL |     id_u32(b64.try_into().unwrap());
    |            ^^^^^^^^^^^^^^^^^^^^^^^
@@ -443,7 +443,7 @@ error[E0308]: mismatched types
 LL |     id_u32(bsize);
    |            ^^^^^ expected `u32`, found `usize`
    |
-help: you can convert a `usize` to a `u32` and panic if the converted value wouldn't fit
+help: you can convert a `usize` to a `u32` and panic if the converted value doesn't fit
    |
 LL |     id_u32(bsize.try_into().unwrap());
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -481,7 +481,7 @@ error[E0308]: mismatched types
 LL |     id_u64(bsize);
    |            ^^^^^ expected `u64`, found `usize`
    |
-help: you can convert a `usize` to a `u64` and panic if the converted value wouldn't fit
+help: you can convert a `usize` to a `u64` and panic if the converted value doesn't fit
    |
 LL |     id_u64(bsize.try_into().unwrap());
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -510,7 +510,7 @@ error[E0308]: mismatched types
 LL |     id_usize(b32);
    |              ^^^ expected `usize`, found `u32`
    |
-help: you can convert a `u32` to a `usize` and panic if the converted value wouldn't fit
+help: you can convert a `u32` to a `usize` and panic if the converted value doesn't fit
    |
 LL |     id_usize(b32.try_into().unwrap());
    |              ^^^^^^^^^^^^^^^^^^^^^^^
@@ -521,7 +521,7 @@ error[E0308]: mismatched types
 LL |     id_usize(b64);
    |              ^^^ expected `usize`, found `u64`
    |
-help: you can convert a `u64` to a `usize` and panic if the converted value wouldn't fit
+help: you can convert a `u64` to a `usize` and panic if the converted value doesn't fit
    |
 LL |     id_usize(b64.try_into().unwrap());
    |              ^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/integer-literal-suffix-inference.stderr
+++ b/src/test/ui/integer-literal-suffix-inference.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL |     id_i8(a16);
    |           ^^^ expected `i8`, found `i16`
    |
-help: you can convert an `i16` to `i8` and panic if the converted value wouldn't fit
+help: you can convert an `i16` to an `i8` and panic if the converted value wouldn't fit
    |
 LL |     id_i8(a16.try_into().unwrap());
    |           ^^^^^^^^^^^^^^^^^^^^^^^
@@ -15,7 +15,7 @@ error[E0308]: mismatched types
 LL |     id_i8(a32);
    |           ^^^ expected `i8`, found `i32`
    |
-help: you can convert an `i32` to `i8` and panic if the converted value wouldn't fit
+help: you can convert an `i32` to an `i8` and panic if the converted value wouldn't fit
    |
 LL |     id_i8(a32.try_into().unwrap());
    |           ^^^^^^^^^^^^^^^^^^^^^^^
@@ -26,7 +26,7 @@ error[E0308]: mismatched types
 LL |     id_i8(a64);
    |           ^^^ expected `i8`, found `i64`
    |
-help: you can convert an `i64` to `i8` and panic if the converted value wouldn't fit
+help: you can convert an `i64` to an `i8` and panic if the converted value wouldn't fit
    |
 LL |     id_i8(a64.try_into().unwrap());
    |           ^^^^^^^^^^^^^^^^^^^^^^^
@@ -37,7 +37,7 @@ error[E0308]: mismatched types
 LL |     id_i8(asize);
    |           ^^^^^ expected `i8`, found `isize`
    |
-help: you can convert an `isize` to `i8` and panic if the converted value wouldn't fit
+help: you can convert an `isize` to an `i8` and panic if the converted value wouldn't fit
    |
 LL |     id_i8(asize.try_into().unwrap());
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -49,7 +49,7 @@ LL |     id_i16(a8);
    |            ^^
    |            |
    |            expected `i16`, found `i8`
-   |            help: you can convert an `i8` to `i16`: `a8.into()`
+   |            help: you can convert an `i8` to an `i16`: `a8.into()`
 
 error[E0308]: mismatched types
   --> $DIR/integer-literal-suffix-inference.rs:55:12
@@ -57,7 +57,7 @@ error[E0308]: mismatched types
 LL |     id_i16(a32);
    |            ^^^ expected `i16`, found `i32`
    |
-help: you can convert an `i32` to `i16` and panic if the converted value wouldn't fit
+help: you can convert an `i32` to an `i16` and panic if the converted value wouldn't fit
    |
 LL |     id_i16(a32.try_into().unwrap());
    |            ^^^^^^^^^^^^^^^^^^^^^^^
@@ -68,7 +68,7 @@ error[E0308]: mismatched types
 LL |     id_i16(a64);
    |            ^^^ expected `i16`, found `i64`
    |
-help: you can convert an `i64` to `i16` and panic if the converted value wouldn't fit
+help: you can convert an `i64` to an `i16` and panic if the converted value wouldn't fit
    |
 LL |     id_i16(a64.try_into().unwrap());
    |            ^^^^^^^^^^^^^^^^^^^^^^^
@@ -79,7 +79,7 @@ error[E0308]: mismatched types
 LL |     id_i16(asize);
    |            ^^^^^ expected `i16`, found `isize`
    |
-help: you can convert an `isize` to `i16` and panic if the converted value wouldn't fit
+help: you can convert an `isize` to an `i16` and panic if the converted value wouldn't fit
    |
 LL |     id_i16(asize.try_into().unwrap());
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -91,7 +91,7 @@ LL |     id_i32(a8);
    |            ^^
    |            |
    |            expected `i32`, found `i8`
-   |            help: you can convert an `i8` to `i32`: `a8.into()`
+   |            help: you can convert an `i8` to an `i32`: `a8.into()`
 
 error[E0308]: mismatched types
   --> $DIR/integer-literal-suffix-inference.rs:68:12
@@ -100,7 +100,7 @@ LL |     id_i32(a16);
    |            ^^^
    |            |
    |            expected `i32`, found `i16`
-   |            help: you can convert an `i16` to `i32`: `a16.into()`
+   |            help: you can convert an `i16` to an `i32`: `a16.into()`
 
 error[E0308]: mismatched types
   --> $DIR/integer-literal-suffix-inference.rs:72:12
@@ -108,7 +108,7 @@ error[E0308]: mismatched types
 LL |     id_i32(a64);
    |            ^^^ expected `i32`, found `i64`
    |
-help: you can convert an `i64` to `i32` and panic if the converted value wouldn't fit
+help: you can convert an `i64` to an `i32` and panic if the converted value wouldn't fit
    |
 LL |     id_i32(a64.try_into().unwrap());
    |            ^^^^^^^^^^^^^^^^^^^^^^^
@@ -119,7 +119,7 @@ error[E0308]: mismatched types
 LL |     id_i32(asize);
    |            ^^^^^ expected `i32`, found `isize`
    |
-help: you can convert an `isize` to `i32` and panic if the converted value wouldn't fit
+help: you can convert an `isize` to an `i32` and panic if the converted value wouldn't fit
    |
 LL |     id_i32(asize.try_into().unwrap());
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -131,7 +131,7 @@ LL |     id_i64(a8);
    |            ^^
    |            |
    |            expected `i64`, found `i8`
-   |            help: you can convert an `i8` to `i64`: `a8.into()`
+   |            help: you can convert an `i8` to an `i64`: `a8.into()`
 
 error[E0308]: mismatched types
   --> $DIR/integer-literal-suffix-inference.rs:82:12
@@ -140,7 +140,7 @@ LL |     id_i64(a16);
    |            ^^^
    |            |
    |            expected `i64`, found `i16`
-   |            help: you can convert an `i16` to `i64`: `a16.into()`
+   |            help: you can convert an `i16` to an `i64`: `a16.into()`
 
 error[E0308]: mismatched types
   --> $DIR/integer-literal-suffix-inference.rs:85:12
@@ -149,7 +149,7 @@ LL |     id_i64(a32);
    |            ^^^
    |            |
    |            expected `i64`, found `i32`
-   |            help: you can convert an `i32` to `i64`: `a32.into()`
+   |            help: you can convert an `i32` to an `i64`: `a32.into()`
 
 error[E0308]: mismatched types
   --> $DIR/integer-literal-suffix-inference.rs:89:12
@@ -157,7 +157,7 @@ error[E0308]: mismatched types
 LL |     id_i64(asize);
    |            ^^^^^ expected `i64`, found `isize`
    |
-help: you can convert an `isize` to `i64` and panic if the converted value wouldn't fit
+help: you can convert an `isize` to an `i64` and panic if the converted value wouldn't fit
    |
 LL |     id_i64(asize.try_into().unwrap());
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -169,7 +169,7 @@ LL |     id_isize(a8);
    |              ^^
    |              |
    |              expected `isize`, found `i8`
-   |              help: you can convert an `i8` to `isize`: `a8.into()`
+   |              help: you can convert an `i8` to an `isize`: `a8.into()`
 
 error[E0308]: mismatched types
   --> $DIR/integer-literal-suffix-inference.rs:96:14
@@ -178,7 +178,7 @@ LL |     id_isize(a16);
    |              ^^^
    |              |
    |              expected `isize`, found `i16`
-   |              help: you can convert an `i16` to `isize`: `a16.into()`
+   |              help: you can convert an `i16` to an `isize`: `a16.into()`
 
 error[E0308]: mismatched types
   --> $DIR/integer-literal-suffix-inference.rs:99:14
@@ -186,7 +186,7 @@ error[E0308]: mismatched types
 LL |     id_isize(a32);
    |              ^^^ expected `isize`, found `i32`
    |
-help: you can convert an `i32` to `isize` and panic if the converted value wouldn't fit
+help: you can convert an `i32` to an `isize` and panic if the converted value wouldn't fit
    |
 LL |     id_isize(a32.try_into().unwrap());
    |              ^^^^^^^^^^^^^^^^^^^^^^^
@@ -197,7 +197,7 @@ error[E0308]: mismatched types
 LL |     id_isize(a64);
    |              ^^^ expected `isize`, found `i64`
    |
-help: you can convert an `i64` to `isize` and panic if the converted value wouldn't fit
+help: you can convert an `i64` to an `isize` and panic if the converted value wouldn't fit
    |
 LL |     id_isize(a64.try_into().unwrap());
    |              ^^^^^^^^^^^^^^^^^^^^^^^
@@ -208,7 +208,7 @@ error[E0308]: mismatched types
 LL |     id_i8(c16);
    |           ^^^ expected `i8`, found `i16`
    |
-help: you can convert an `i16` to `i8` and panic if the converted value wouldn't fit
+help: you can convert an `i16` to an `i8` and panic if the converted value wouldn't fit
    |
 LL |     id_i8(c16.try_into().unwrap());
    |           ^^^^^^^^^^^^^^^^^^^^^^^
@@ -219,7 +219,7 @@ error[E0308]: mismatched types
 LL |     id_i8(c32);
    |           ^^^ expected `i8`, found `i32`
    |
-help: you can convert an `i32` to `i8` and panic if the converted value wouldn't fit
+help: you can convert an `i32` to an `i8` and panic if the converted value wouldn't fit
    |
 LL |     id_i8(c32.try_into().unwrap());
    |           ^^^^^^^^^^^^^^^^^^^^^^^
@@ -230,7 +230,7 @@ error[E0308]: mismatched types
 LL |     id_i8(c64);
    |           ^^^ expected `i8`, found `i64`
    |
-help: you can convert an `i64` to `i8` and panic if the converted value wouldn't fit
+help: you can convert an `i64` to an `i8` and panic if the converted value wouldn't fit
    |
 LL |     id_i8(c64.try_into().unwrap());
    |           ^^^^^^^^^^^^^^^^^^^^^^^
@@ -242,7 +242,7 @@ LL |     id_i16(c8);
    |            ^^
    |            |
    |            expected `i16`, found `i8`
-   |            help: you can convert an `i8` to `i16`: `c8.into()`
+   |            help: you can convert an `i8` to an `i16`: `c8.into()`
 
 error[E0308]: mismatched types
   --> $DIR/integer-literal-suffix-inference.rs:122:12
@@ -250,7 +250,7 @@ error[E0308]: mismatched types
 LL |     id_i16(c32);
    |            ^^^ expected `i16`, found `i32`
    |
-help: you can convert an `i32` to `i16` and panic if the converted value wouldn't fit
+help: you can convert an `i32` to an `i16` and panic if the converted value wouldn't fit
    |
 LL |     id_i16(c32.try_into().unwrap());
    |            ^^^^^^^^^^^^^^^^^^^^^^^
@@ -261,7 +261,7 @@ error[E0308]: mismatched types
 LL |     id_i16(c64);
    |            ^^^ expected `i16`, found `i64`
    |
-help: you can convert an `i64` to `i16` and panic if the converted value wouldn't fit
+help: you can convert an `i64` to an `i16` and panic if the converted value wouldn't fit
    |
 LL |     id_i16(c64.try_into().unwrap());
    |            ^^^^^^^^^^^^^^^^^^^^^^^
@@ -273,7 +273,7 @@ LL |     id_i32(c8);
    |            ^^
    |            |
    |            expected `i32`, found `i8`
-   |            help: you can convert an `i8` to `i32`: `c8.into()`
+   |            help: you can convert an `i8` to an `i32`: `c8.into()`
 
 error[E0308]: mismatched types
   --> $DIR/integer-literal-suffix-inference.rs:132:12
@@ -282,7 +282,7 @@ LL |     id_i32(c16);
    |            ^^^
    |            |
    |            expected `i32`, found `i16`
-   |            help: you can convert an `i16` to `i32`: `c16.into()`
+   |            help: you can convert an `i16` to an `i32`: `c16.into()`
 
 error[E0308]: mismatched types
   --> $DIR/integer-literal-suffix-inference.rs:136:12
@@ -290,7 +290,7 @@ error[E0308]: mismatched types
 LL |     id_i32(c64);
    |            ^^^ expected `i32`, found `i64`
    |
-help: you can convert an `i64` to `i32` and panic if the converted value wouldn't fit
+help: you can convert an `i64` to an `i32` and panic if the converted value wouldn't fit
    |
 LL |     id_i32(c64.try_into().unwrap());
    |            ^^^^^^^^^^^^^^^^^^^^^^^
@@ -302,7 +302,7 @@ LL |     id_i64(a8);
    |            ^^
    |            |
    |            expected `i64`, found `i8`
-   |            help: you can convert an `i8` to `i64`: `a8.into()`
+   |            help: you can convert an `i8` to an `i64`: `a8.into()`
 
 error[E0308]: mismatched types
   --> $DIR/integer-literal-suffix-inference.rs:143:12
@@ -311,7 +311,7 @@ LL |     id_i64(a16);
    |            ^^^
    |            |
    |            expected `i64`, found `i16`
-   |            help: you can convert an `i16` to `i64`: `a16.into()`
+   |            help: you can convert an `i16` to an `i64`: `a16.into()`
 
 error[E0308]: mismatched types
   --> $DIR/integer-literal-suffix-inference.rs:146:12
@@ -320,7 +320,7 @@ LL |     id_i64(a32);
    |            ^^^
    |            |
    |            expected `i64`, found `i32`
-   |            help: you can convert an `i32` to `i64`: `a32.into()`
+   |            help: you can convert an `i32` to an `i64`: `a32.into()`
 
 error[E0308]: mismatched types
   --> $DIR/integer-literal-suffix-inference.rs:152:11
@@ -328,7 +328,7 @@ error[E0308]: mismatched types
 LL |     id_u8(b16);
    |           ^^^ expected `u8`, found `u16`
    |
-help: you can convert a `u16` to `u8` and panic if the converted value wouldn't fit
+help: you can convert a `u16` to a `u8` and panic if the converted value wouldn't fit
    |
 LL |     id_u8(b16.try_into().unwrap());
    |           ^^^^^^^^^^^^^^^^^^^^^^^
@@ -339,7 +339,7 @@ error[E0308]: mismatched types
 LL |     id_u8(b32);
    |           ^^^ expected `u8`, found `u32`
    |
-help: you can convert a `u32` to `u8` and panic if the converted value wouldn't fit
+help: you can convert a `u32` to a `u8` and panic if the converted value wouldn't fit
    |
 LL |     id_u8(b32.try_into().unwrap());
    |           ^^^^^^^^^^^^^^^^^^^^^^^
@@ -350,7 +350,7 @@ error[E0308]: mismatched types
 LL |     id_u8(b64);
    |           ^^^ expected `u8`, found `u64`
    |
-help: you can convert a `u64` to `u8` and panic if the converted value wouldn't fit
+help: you can convert a `u64` to a `u8` and panic if the converted value wouldn't fit
    |
 LL |     id_u8(b64.try_into().unwrap());
    |           ^^^^^^^^^^^^^^^^^^^^^^^
@@ -361,7 +361,7 @@ error[E0308]: mismatched types
 LL |     id_u8(bsize);
    |           ^^^^^ expected `u8`, found `usize`
    |
-help: you can convert a `usize` to `u8` and panic if the converted value wouldn't fit
+help: you can convert a `usize` to a `u8` and panic if the converted value wouldn't fit
    |
 LL |     id_u8(bsize.try_into().unwrap());
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -373,7 +373,7 @@ LL |     id_u16(b8);
    |            ^^
    |            |
    |            expected `u16`, found `u8`
-   |            help: you can convert a `u8` to `u16`: `b8.into()`
+   |            help: you can convert a `u8` to a `u16`: `b8.into()`
 
 error[E0308]: mismatched types
   --> $DIR/integer-literal-suffix-inference.rs:169:12
@@ -381,7 +381,7 @@ error[E0308]: mismatched types
 LL |     id_u16(b32);
    |            ^^^ expected `u16`, found `u32`
    |
-help: you can convert a `u32` to `u16` and panic if the converted value wouldn't fit
+help: you can convert a `u32` to a `u16` and panic if the converted value wouldn't fit
    |
 LL |     id_u16(b32.try_into().unwrap());
    |            ^^^^^^^^^^^^^^^^^^^^^^^
@@ -392,7 +392,7 @@ error[E0308]: mismatched types
 LL |     id_u16(b64);
    |            ^^^ expected `u16`, found `u64`
    |
-help: you can convert a `u64` to `u16` and panic if the converted value wouldn't fit
+help: you can convert a `u64` to a `u16` and panic if the converted value wouldn't fit
    |
 LL |     id_u16(b64.try_into().unwrap());
    |            ^^^^^^^^^^^^^^^^^^^^^^^
@@ -403,7 +403,7 @@ error[E0308]: mismatched types
 LL |     id_u16(bsize);
    |            ^^^^^ expected `u16`, found `usize`
    |
-help: you can convert a `usize` to `u16` and panic if the converted value wouldn't fit
+help: you can convert a `usize` to a `u16` and panic if the converted value wouldn't fit
    |
 LL |     id_u16(bsize.try_into().unwrap());
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -415,7 +415,7 @@ LL |     id_u32(b8);
    |            ^^
    |            |
    |            expected `u32`, found `u8`
-   |            help: you can convert a `u8` to `u32`: `b8.into()`
+   |            help: you can convert a `u8` to a `u32`: `b8.into()`
 
 error[E0308]: mismatched types
   --> $DIR/integer-literal-suffix-inference.rs:182:12
@@ -424,7 +424,7 @@ LL |     id_u32(b16);
    |            ^^^
    |            |
    |            expected `u32`, found `u16`
-   |            help: you can convert a `u16` to `u32`: `b16.into()`
+   |            help: you can convert a `u16` to a `u32`: `b16.into()`
 
 error[E0308]: mismatched types
   --> $DIR/integer-literal-suffix-inference.rs:186:12
@@ -432,7 +432,7 @@ error[E0308]: mismatched types
 LL |     id_u32(b64);
    |            ^^^ expected `u32`, found `u64`
    |
-help: you can convert a `u64` to `u32` and panic if the converted value wouldn't fit
+help: you can convert a `u64` to a `u32` and panic if the converted value wouldn't fit
    |
 LL |     id_u32(b64.try_into().unwrap());
    |            ^^^^^^^^^^^^^^^^^^^^^^^
@@ -443,7 +443,7 @@ error[E0308]: mismatched types
 LL |     id_u32(bsize);
    |            ^^^^^ expected `u32`, found `usize`
    |
-help: you can convert a `usize` to `u32` and panic if the converted value wouldn't fit
+help: you can convert a `usize` to a `u32` and panic if the converted value wouldn't fit
    |
 LL |     id_u32(bsize.try_into().unwrap());
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -455,7 +455,7 @@ LL |     id_u64(b8);
    |            ^^
    |            |
    |            expected `u64`, found `u8`
-   |            help: you can convert a `u8` to `u64`: `b8.into()`
+   |            help: you can convert a `u8` to a `u64`: `b8.into()`
 
 error[E0308]: mismatched types
   --> $DIR/integer-literal-suffix-inference.rs:196:12
@@ -464,7 +464,7 @@ LL |     id_u64(b16);
    |            ^^^
    |            |
    |            expected `u64`, found `u16`
-   |            help: you can convert a `u16` to `u64`: `b16.into()`
+   |            help: you can convert a `u16` to a `u64`: `b16.into()`
 
 error[E0308]: mismatched types
   --> $DIR/integer-literal-suffix-inference.rs:199:12
@@ -473,7 +473,7 @@ LL |     id_u64(b32);
    |            ^^^
    |            |
    |            expected `u64`, found `u32`
-   |            help: you can convert a `u32` to `u64`: `b32.into()`
+   |            help: you can convert a `u32` to a `u64`: `b32.into()`
 
 error[E0308]: mismatched types
   --> $DIR/integer-literal-suffix-inference.rs:203:12
@@ -481,7 +481,7 @@ error[E0308]: mismatched types
 LL |     id_u64(bsize);
    |            ^^^^^ expected `u64`, found `usize`
    |
-help: you can convert a `usize` to `u64` and panic if the converted value wouldn't fit
+help: you can convert a `usize` to a `u64` and panic if the converted value wouldn't fit
    |
 LL |     id_u64(bsize.try_into().unwrap());
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -493,7 +493,7 @@ LL |     id_usize(b8);
    |              ^^
    |              |
    |              expected `usize`, found `u8`
-   |              help: you can convert a `u8` to `usize`: `b8.into()`
+   |              help: you can convert a `u8` to a `usize`: `b8.into()`
 
 error[E0308]: mismatched types
   --> $DIR/integer-literal-suffix-inference.rs:210:14
@@ -502,7 +502,7 @@ LL |     id_usize(b16);
    |              ^^^
    |              |
    |              expected `usize`, found `u16`
-   |              help: you can convert a `u16` to `usize`: `b16.into()`
+   |              help: you can convert a `u16` to a `usize`: `b16.into()`
 
 error[E0308]: mismatched types
   --> $DIR/integer-literal-suffix-inference.rs:213:14
@@ -510,7 +510,7 @@ error[E0308]: mismatched types
 LL |     id_usize(b32);
    |              ^^^ expected `usize`, found `u32`
    |
-help: you can convert a `u32` to `usize` and panic if the converted value wouldn't fit
+help: you can convert a `u32` to a `usize` and panic if the converted value wouldn't fit
    |
 LL |     id_usize(b32.try_into().unwrap());
    |              ^^^^^^^^^^^^^^^^^^^^^^^
@@ -521,7 +521,7 @@ error[E0308]: mismatched types
 LL |     id_usize(b64);
    |              ^^^ expected `usize`, found `u64`
    |
-help: you can convert a `u64` to `usize` and panic if the converted value wouldn't fit
+help: you can convert a `u64` to a `usize` and panic if the converted value wouldn't fit
    |
 LL |     id_usize(b64.try_into().unwrap());
    |              ^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/issues/issue-13359.stderr
+++ b/src/test/ui/issues/issue-13359.stderr
@@ -15,7 +15,7 @@ error[E0308]: mismatched types
 LL |     bar(1*(1 as usize));
    |         ^^^^^^^^^^^^^^ expected `u32`, found `usize`
    |
-help: you can convert an `usize` to `u32` and panic if the converted value wouldn't fit
+help: you can convert a `usize` to `u32` and panic if the converted value wouldn't fit
    |
 LL |     bar((1*(1 as usize)).try_into().unwrap());
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/issues/issue-13359.stderr
+++ b/src/test/ui/issues/issue-13359.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL |     foo(1*(1 as isize));
    |         ^^^^^^^^^^^^^^ expected `i16`, found `isize`
    |
-help: you can convert an `isize` to `i16` and panic if the converted value wouldn't fit
+help: you can convert an `isize` to an `i16` and panic if the converted value wouldn't fit
    |
 LL |     foo((1*(1 as isize)).try_into().unwrap());
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -15,7 +15,7 @@ error[E0308]: mismatched types
 LL |     bar(1*(1 as usize));
    |         ^^^^^^^^^^^^^^ expected `u32`, found `usize`
    |
-help: you can convert a `usize` to `u32` and panic if the converted value wouldn't fit
+help: you can convert a `usize` to a `u32` and panic if the converted value wouldn't fit
    |
 LL |     bar((1*(1 as usize)).try_into().unwrap());
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/issues/issue-13359.stderr
+++ b/src/test/ui/issues/issue-13359.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL |     foo(1*(1 as isize));
    |         ^^^^^^^^^^^^^^ expected `i16`, found `isize`
    |
-help: you can convert an `isize` to an `i16` and panic if the converted value wouldn't fit
+help: you can convert an `isize` to an `i16` and panic if the converted value doesn't fit
    |
 LL |     foo((1*(1 as isize)).try_into().unwrap());
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -15,7 +15,7 @@ error[E0308]: mismatched types
 LL |     bar(1*(1 as usize));
    |         ^^^^^^^^^^^^^^ expected `u32`, found `usize`
    |
-help: you can convert a `usize` to a `u32` and panic if the converted value wouldn't fit
+help: you can convert a `usize` to a `u32` and panic if the converted value doesn't fit
    |
 LL |     bar((1*(1 as usize)).try_into().unwrap());
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/methods/method-ambig-one-trait-unknown-int-type.stderr
+++ b/src/test/ui/methods/method-ambig-one-trait-unknown-int-type.stderr
@@ -14,7 +14,7 @@ LL |     let y: usize = x.foo();
    |            |
    |            expected due to this
    |
-help: you can convert an `isize` to `usize` and panic if the converted value wouldn't fit
+help: you can convert an `isize` to a `usize` and panic if the converted value wouldn't fit
    |
 LL |     let y: usize = x.foo().try_into().unwrap();
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/methods/method-ambig-one-trait-unknown-int-type.stderr
+++ b/src/test/ui/methods/method-ambig-one-trait-unknown-int-type.stderr
@@ -14,7 +14,7 @@ LL |     let y: usize = x.foo();
    |            |
    |            expected due to this
    |
-help: you can convert an `isize` to a `usize` and panic if the converted value wouldn't fit
+help: you can convert an `isize` to a `usize` and panic if the converted value doesn't fit
    |
 LL |     let y: usize = x.foo().try_into().unwrap();
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/mismatched_types/issue-26480.stderr
+++ b/src/test/ui/mismatched_types/issue-26480.stderr
@@ -8,7 +8,7 @@ LL |     write!(hello);
    |     -------------- in this macro invocation
    |
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
-help: you can convert an `usize` to `u64` and panic if the converted value wouldn't fit
+help: you can convert a `usize` to `u64` and panic if the converted value wouldn't fit
    |
 LL |                   ($arr.len() * size_of($arr[0])).try_into().unwrap());
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/mismatched_types/issue-26480.stderr
+++ b/src/test/ui/mismatched_types/issue-26480.stderr
@@ -8,7 +8,7 @@ LL |     write!(hello);
    |     -------------- in this macro invocation
    |
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
-help: you can convert a `usize` to a `u64` and panic if the converted value wouldn't fit
+help: you can convert a `usize` to a `u64` and panic if the converted value doesn't fit
    |
 LL |                   ($arr.len() * size_of($arr[0])).try_into().unwrap());
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/mismatched_types/issue-26480.stderr
+++ b/src/test/ui/mismatched_types/issue-26480.stderr
@@ -8,7 +8,7 @@ LL |     write!(hello);
    |     -------------- in this macro invocation
    |
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
-help: you can convert a `usize` to `u64` and panic if the converted value wouldn't fit
+help: you can convert a `usize` to a `u64` and panic if the converted value wouldn't fit
    |
 LL |                   ($arr.len() * size_of($arr[0])).try_into().unwrap());
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/numeric/const-scope.stderr
+++ b/src/test/ui/numeric/const-scope.stderr
@@ -57,7 +57,7 @@ LL |     let d: i8 = c;
    |            |
    |            expected due to this
    |
-help: you can convert an `i32` to an `i8` and panic if the converted value wouldn't fit
+help: you can convert an `i32` to an `i8` and panic if the converted value doesn't fit
    |
 LL |     let d: i8 = c.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/numeric/const-scope.stderr
+++ b/src/test/ui/numeric/const-scope.stderr
@@ -57,7 +57,7 @@ LL |     let d: i8 = c;
    |            |
    |            expected due to this
    |
-help: you can convert an `i32` to `i8` and panic if the converted value wouldn't fit
+help: you can convert an `i32` to an `i8` and panic if the converted value wouldn't fit
    |
 LL |     let d: i8 = c.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/numeric/len.stderr
+++ b/src/test/ui/numeric/len.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL |     test(array.len());
    |          ^^^^^^^^^^^ expected `u32`, found `usize`
    |
-help: you can convert an `usize` to `u32` and panic if the converted value wouldn't fit
+help: you can convert a `usize` to `u32` and panic if the converted value wouldn't fit
    |
 LL |     test(array.len().try_into().unwrap());
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/numeric/len.stderr
+++ b/src/test/ui/numeric/len.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL |     test(array.len());
    |          ^^^^^^^^^^^ expected `u32`, found `usize`
    |
-help: you can convert a `usize` to `u32` and panic if the converted value wouldn't fit
+help: you can convert a `usize` to a `u32` and panic if the converted value wouldn't fit
    |
 LL |     test(array.len().try_into().unwrap());
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/numeric/len.stderr
+++ b/src/test/ui/numeric/len.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL |     test(array.len());
    |          ^^^^^^^^^^^ expected `u32`, found `usize`
    |
-help: you can convert a `usize` to a `u32` and panic if the converted value wouldn't fit
+help: you can convert a `usize` to a `u32` and panic if the converted value doesn't fit
    |
 LL |     test(array.len().try_into().unwrap());
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/numeric/numeric-cast-2.stderr
+++ b/src/test/ui/numeric/numeric-cast-2.stderr
@@ -18,7 +18,7 @@ LL |     let y: i64 = x + x;
    |            ---   ^^^^^
    |            |     |
    |            |     expected `i64`, found `u16`
-   |            |     help: you can convert an `u16` to `i64`: `(x + x).into()`
+   |            |     help: you can convert a `u16` to `i64`: `(x + x).into()`
    |            expected due to this
 
 error[E0308]: mismatched types
@@ -28,7 +28,7 @@ LL |     let z: i32 = x + x;
    |            ---   ^^^^^
    |            |     |
    |            |     expected `i32`, found `u16`
-   |            |     help: you can convert an `u16` to `i32`: `(x + x).into()`
+   |            |     help: you can convert a `u16` to `i32`: `(x + x).into()`
    |            expected due to this
 
 error: aborting due to 3 previous errors

--- a/src/test/ui/numeric/numeric-cast-2.stderr
+++ b/src/test/ui/numeric/numeric-cast-2.stderr
@@ -6,7 +6,7 @@ LL |     let x: u16 = foo();
    |            |
    |            expected due to this
    |
-help: you can convert an `i32` to a `u16` and panic if the converted value wouldn't fit
+help: you can convert an `i32` to a `u16` and panic if the converted value doesn't fit
    |
 LL |     let x: u16 = foo().try_into().unwrap();
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/numeric/numeric-cast-2.stderr
+++ b/src/test/ui/numeric/numeric-cast-2.stderr
@@ -6,7 +6,7 @@ LL |     let x: u16 = foo();
    |            |
    |            expected due to this
    |
-help: you can convert an `i32` to `u16` and panic if the converted value wouldn't fit
+help: you can convert an `i32` to a `u16` and panic if the converted value wouldn't fit
    |
 LL |     let x: u16 = foo().try_into().unwrap();
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -18,7 +18,7 @@ LL |     let y: i64 = x + x;
    |            ---   ^^^^^
    |            |     |
    |            |     expected `i64`, found `u16`
-   |            |     help: you can convert a `u16` to `i64`: `(x + x).into()`
+   |            |     help: you can convert a `u16` to an `i64`: `(x + x).into()`
    |            expected due to this
 
 error[E0308]: mismatched types
@@ -28,7 +28,7 @@ LL |     let z: i32 = x + x;
    |            ---   ^^^^^
    |            |     |
    |            |     expected `i32`, found `u16`
-   |            |     help: you can convert a `u16` to `i32`: `(x + x).into()`
+   |            |     help: you can convert a `u16` to an `i32`: `(x + x).into()`
    |            expected due to this
 
 error: aborting due to 3 previous errors

--- a/src/test/ui/numeric/numeric-cast-binop.stderr
+++ b/src/test/ui/numeric/numeric-cast-binop.stderr
@@ -60,7 +60,7 @@ LL |         x_u16 > x_u8;
    |                 ^^^^
    |                 |
    |                 expected `u16`, found `u8`
-   |                 help: you can convert an `u8` to `u16`: `x_u8.into()`
+   |                 help: you can convert a `u8` to `u16`: `x_u8.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:36:17
@@ -113,7 +113,7 @@ LL |         x_u32 > x_u8;
    |                 ^^^^
    |                 |
    |                 expected `u32`, found `u8`
-   |                 help: you can convert an `u8` to `u32`: `x_u8.into()`
+   |                 help: you can convert a `u8` to `u32`: `x_u8.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:47:17
@@ -122,7 +122,7 @@ LL |         x_u32 > x_u16;
    |                 ^^^^^
    |                 |
    |                 expected `u32`, found `u16`
-   |                 help: you can convert an `u16` to `u32`: `x_u16.into()`
+   |                 help: you can convert a `u16` to `u32`: `x_u16.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:49:17
@@ -152,7 +152,7 @@ error[E0308]: mismatched types
 LL |         x_u32 > x_usize;
    |                 ^^^^^^^ expected `u32`, found `usize`
    |
-help: you can convert an `usize` to `u32` and panic if the converted value wouldn't fit
+help: you can convert a `usize` to `u32` and panic if the converted value wouldn't fit
    |
 LL |         x_u32 > x_usize.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -164,7 +164,7 @@ LL |         x_u64 > x_u8;
    |                 ^^^^
    |                 |
    |                 expected `u64`, found `u8`
-   |                 help: you can convert an `u8` to `u64`: `x_u8.into()`
+   |                 help: you can convert a `u8` to `u64`: `x_u8.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:58:17
@@ -173,7 +173,7 @@ LL |         x_u64 > x_u16;
    |                 ^^^^^
    |                 |
    |                 expected `u64`, found `u16`
-   |                 help: you can convert an `u16` to `u64`: `x_u16.into()`
+   |                 help: you can convert a `u16` to `u64`: `x_u16.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:60:17
@@ -182,7 +182,7 @@ LL |         x_u64 > x_u32;
    |                 ^^^^^
    |                 |
    |                 expected `u64`, found `u32`
-   |                 help: you can convert an `u32` to `u64`: `x_u32.into()`
+   |                 help: you can convert a `u32` to `u64`: `x_u32.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:62:17
@@ -201,7 +201,7 @@ error[E0308]: mismatched types
 LL |         x_u64 > x_usize;
    |                 ^^^^^^^ expected `u64`, found `usize`
    |
-help: you can convert an `usize` to `u64` and panic if the converted value wouldn't fit
+help: you can convert a `usize` to `u64` and panic if the converted value wouldn't fit
    |
 LL |         x_u64 > x_usize.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -213,7 +213,7 @@ LL |         x_u128 > x_u8;
    |                  ^^^^
    |                  |
    |                  expected `u128`, found `u8`
-   |                  help: you can convert an `u8` to `u128`: `x_u8.into()`
+   |                  help: you can convert a `u8` to `u128`: `x_u8.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:69:18
@@ -222,7 +222,7 @@ LL |         x_u128 > x_u16;
    |                  ^^^^^
    |                  |
    |                  expected `u128`, found `u16`
-   |                  help: you can convert an `u16` to `u128`: `x_u16.into()`
+   |                  help: you can convert a `u16` to `u128`: `x_u16.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:71:18
@@ -231,7 +231,7 @@ LL |         x_u128 > x_u32;
    |                  ^^^^^
    |                  |
    |                  expected `u128`, found `u32`
-   |                  help: you can convert an `u32` to `u128`: `x_u32.into()`
+   |                  help: you can convert a `u32` to `u128`: `x_u32.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:73:18
@@ -240,7 +240,7 @@ LL |         x_u128 > x_u64;
    |                  ^^^^^
    |                  |
    |                  expected `u128`, found `u64`
-   |                  help: you can convert an `u64` to `u128`: `x_u64.into()`
+   |                  help: you can convert a `u64` to `u128`: `x_u64.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:75:18
@@ -248,7 +248,7 @@ error[E0308]: mismatched types
 LL |         x_u128 > x_usize;
    |                  ^^^^^^^ expected `u128`, found `usize`
    |
-help: you can convert an `usize` to `u128` and panic if the converted value wouldn't fit
+help: you can convert a `usize` to `u128` and panic if the converted value wouldn't fit
    |
 LL |         x_u128 > x_usize.try_into().unwrap();
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -260,7 +260,7 @@ LL |         x_usize > x_u8;
    |                   ^^^^
    |                   |
    |                   expected `usize`, found `u8`
-   |                   help: you can convert an `u8` to `usize`: `x_u8.into()`
+   |                   help: you can convert a `u8` to `usize`: `x_u8.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:80:19
@@ -269,7 +269,7 @@ LL |         x_usize > x_u16;
    |                   ^^^^^
    |                   |
    |                   expected `usize`, found `u16`
-   |                   help: you can convert an `u16` to `usize`: `x_u16.into()`
+   |                   help: you can convert a `u16` to `usize`: `x_u16.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:82:19
@@ -277,7 +277,7 @@ error[E0308]: mismatched types
 LL |         x_usize > x_u32;
    |                   ^^^^^ expected `usize`, found `u32`
    |
-help: you can convert an `u32` to `usize` and panic if the converted value wouldn't fit
+help: you can convert a `u32` to `usize` and panic if the converted value wouldn't fit
    |
 LL |         x_usize > x_u32.try_into().unwrap();
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -288,7 +288,7 @@ error[E0308]: mismatched types
 LL |         x_usize > x_u64;
    |                   ^^^^^ expected `usize`, found `u64`
    |
-help: you can convert an `u64` to `usize` and panic if the converted value wouldn't fit
+help: you can convert a `u64` to `usize` and panic if the converted value wouldn't fit
    |
 LL |         x_usize > x_u64.try_into().unwrap();
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -299,7 +299,7 @@ error[E0308]: mismatched types
 LL |         x_usize > x_u128;
    |                   ^^^^^^ expected `usize`, found `u128`
    |
-help: you can convert an `u128` to `usize` and panic if the converted value wouldn't fit
+help: you can convert a `u128` to `usize` and panic if the converted value wouldn't fit
    |
 LL |         x_usize > x_u128.try_into().unwrap();
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1012,7 +1012,7 @@ error[E0308]: mismatched types
 LL |         x_i8 > x_u8;
    |                ^^^^ expected `i8`, found `u8`
    |
-help: you can convert an `u8` to `i8` and panic if the converted value wouldn't fit
+help: you can convert a `u8` to `i8` and panic if the converted value wouldn't fit
    |
 LL |         x_i8 > x_u8.try_into().unwrap();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1023,7 +1023,7 @@ error[E0308]: mismatched types
 LL |         x_i8 > x_u16;
    |                ^^^^^ expected `i8`, found `u16`
    |
-help: you can convert an `u16` to `i8` and panic if the converted value wouldn't fit
+help: you can convert a `u16` to `i8` and panic if the converted value wouldn't fit
    |
 LL |         x_i8 > x_u16.try_into().unwrap();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1034,7 +1034,7 @@ error[E0308]: mismatched types
 LL |         x_i8 > x_u32;
    |                ^^^^^ expected `i8`, found `u32`
    |
-help: you can convert an `u32` to `i8` and panic if the converted value wouldn't fit
+help: you can convert a `u32` to `i8` and panic if the converted value wouldn't fit
    |
 LL |         x_i8 > x_u32.try_into().unwrap();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1045,7 +1045,7 @@ error[E0308]: mismatched types
 LL |         x_i8 > x_u64;
    |                ^^^^^ expected `i8`, found `u64`
    |
-help: you can convert an `u64` to `i8` and panic if the converted value wouldn't fit
+help: you can convert a `u64` to `i8` and panic if the converted value wouldn't fit
    |
 LL |         x_i8 > x_u64.try_into().unwrap();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1056,7 +1056,7 @@ error[E0308]: mismatched types
 LL |         x_i8 > x_u128;
    |                ^^^^^^ expected `i8`, found `u128`
    |
-help: you can convert an `u128` to `i8` and panic if the converted value wouldn't fit
+help: you can convert a `u128` to `i8` and panic if the converted value wouldn't fit
    |
 LL |         x_i8 > x_u128.try_into().unwrap();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1067,7 +1067,7 @@ error[E0308]: mismatched types
 LL |         x_i8 > x_usize;
    |                ^^^^^^^ expected `i8`, found `usize`
    |
-help: you can convert an `usize` to `i8` and panic if the converted value wouldn't fit
+help: you can convert a `usize` to `i8` and panic if the converted value wouldn't fit
    |
 LL |         x_i8 > x_usize.try_into().unwrap();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1079,7 +1079,7 @@ LL |         x_i16 > x_u8;
    |                 ^^^^
    |                 |
    |                 expected `i16`, found `u8`
-   |                 help: you can convert an `u8` to `i16`: `x_u8.into()`
+   |                 help: you can convert a `u8` to `i16`: `x_u8.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:257:17
@@ -1087,7 +1087,7 @@ error[E0308]: mismatched types
 LL |         x_i16 > x_u16;
    |                 ^^^^^ expected `i16`, found `u16`
    |
-help: you can convert an `u16` to `i16` and panic if the converted value wouldn't fit
+help: you can convert a `u16` to `i16` and panic if the converted value wouldn't fit
    |
 LL |         x_i16 > x_u16.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1098,7 +1098,7 @@ error[E0308]: mismatched types
 LL |         x_i16 > x_u32;
    |                 ^^^^^ expected `i16`, found `u32`
    |
-help: you can convert an `u32` to `i16` and panic if the converted value wouldn't fit
+help: you can convert a `u32` to `i16` and panic if the converted value wouldn't fit
    |
 LL |         x_i16 > x_u32.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1109,7 +1109,7 @@ error[E0308]: mismatched types
 LL |         x_i16 > x_u64;
    |                 ^^^^^ expected `i16`, found `u64`
    |
-help: you can convert an `u64` to `i16` and panic if the converted value wouldn't fit
+help: you can convert a `u64` to `i16` and panic if the converted value wouldn't fit
    |
 LL |         x_i16 > x_u64.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1120,7 +1120,7 @@ error[E0308]: mismatched types
 LL |         x_i16 > x_u128;
    |                 ^^^^^^ expected `i16`, found `u128`
    |
-help: you can convert an `u128` to `i16` and panic if the converted value wouldn't fit
+help: you can convert a `u128` to `i16` and panic if the converted value wouldn't fit
    |
 LL |         x_i16 > x_u128.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1131,7 +1131,7 @@ error[E0308]: mismatched types
 LL |         x_i16 > x_usize;
    |                 ^^^^^^^ expected `i16`, found `usize`
    |
-help: you can convert an `usize` to `i16` and panic if the converted value wouldn't fit
+help: you can convert a `usize` to `i16` and panic if the converted value wouldn't fit
    |
 LL |         x_i16 > x_usize.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1143,7 +1143,7 @@ LL |         x_i32 > x_u8;
    |                 ^^^^
    |                 |
    |                 expected `i32`, found `u8`
-   |                 help: you can convert an `u8` to `i32`: `x_u8.into()`
+   |                 help: you can convert a `u8` to `i32`: `x_u8.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:270:17
@@ -1152,7 +1152,7 @@ LL |         x_i32 > x_u16;
    |                 ^^^^^
    |                 |
    |                 expected `i32`, found `u16`
-   |                 help: you can convert an `u16` to `i32`: `x_u16.into()`
+   |                 help: you can convert a `u16` to `i32`: `x_u16.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:272:17
@@ -1160,7 +1160,7 @@ error[E0308]: mismatched types
 LL |         x_i32 > x_u32;
    |                 ^^^^^ expected `i32`, found `u32`
    |
-help: you can convert an `u32` to `i32` and panic if the converted value wouldn't fit
+help: you can convert a `u32` to `i32` and panic if the converted value wouldn't fit
    |
 LL |         x_i32 > x_u32.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1171,7 +1171,7 @@ error[E0308]: mismatched types
 LL |         x_i32 > x_u64;
    |                 ^^^^^ expected `i32`, found `u64`
    |
-help: you can convert an `u64` to `i32` and panic if the converted value wouldn't fit
+help: you can convert a `u64` to `i32` and panic if the converted value wouldn't fit
    |
 LL |         x_i32 > x_u64.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1182,7 +1182,7 @@ error[E0308]: mismatched types
 LL |         x_i32 > x_u128;
    |                 ^^^^^^ expected `i32`, found `u128`
    |
-help: you can convert an `u128` to `i32` and panic if the converted value wouldn't fit
+help: you can convert a `u128` to `i32` and panic if the converted value wouldn't fit
    |
 LL |         x_i32 > x_u128.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1193,7 +1193,7 @@ error[E0308]: mismatched types
 LL |         x_i32 > x_usize;
    |                 ^^^^^^^ expected `i32`, found `usize`
    |
-help: you can convert an `usize` to `i32` and panic if the converted value wouldn't fit
+help: you can convert a `usize` to `i32` and panic if the converted value wouldn't fit
    |
 LL |         x_i32 > x_usize.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1205,7 +1205,7 @@ LL |         x_i64 > x_u8;
    |                 ^^^^
    |                 |
    |                 expected `i64`, found `u8`
-   |                 help: you can convert an `u8` to `i64`: `x_u8.into()`
+   |                 help: you can convert a `u8` to `i64`: `x_u8.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:283:17
@@ -1214,7 +1214,7 @@ LL |         x_i64 > x_u16;
    |                 ^^^^^
    |                 |
    |                 expected `i64`, found `u16`
-   |                 help: you can convert an `u16` to `i64`: `x_u16.into()`
+   |                 help: you can convert a `u16` to `i64`: `x_u16.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:285:17
@@ -1223,7 +1223,7 @@ LL |         x_i64 > x_u32;
    |                 ^^^^^
    |                 |
    |                 expected `i64`, found `u32`
-   |                 help: you can convert an `u32` to `i64`: `x_u32.into()`
+   |                 help: you can convert a `u32` to `i64`: `x_u32.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:287:17
@@ -1231,7 +1231,7 @@ error[E0308]: mismatched types
 LL |         x_i64 > x_u64;
    |                 ^^^^^ expected `i64`, found `u64`
    |
-help: you can convert an `u64` to `i64` and panic if the converted value wouldn't fit
+help: you can convert a `u64` to `i64` and panic if the converted value wouldn't fit
    |
 LL |         x_i64 > x_u64.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1242,7 +1242,7 @@ error[E0308]: mismatched types
 LL |         x_i64 > x_u128;
    |                 ^^^^^^ expected `i64`, found `u128`
    |
-help: you can convert an `u128` to `i64` and panic if the converted value wouldn't fit
+help: you can convert a `u128` to `i64` and panic if the converted value wouldn't fit
    |
 LL |         x_i64 > x_u128.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1253,7 +1253,7 @@ error[E0308]: mismatched types
 LL |         x_i64 > x_usize;
    |                 ^^^^^^^ expected `i64`, found `usize`
    |
-help: you can convert an `usize` to `i64` and panic if the converted value wouldn't fit
+help: you can convert a `usize` to `i64` and panic if the converted value wouldn't fit
    |
 LL |         x_i64 > x_usize.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1265,7 +1265,7 @@ LL |         x_i128 > x_u8;
    |                  ^^^^
    |                  |
    |                  expected `i128`, found `u8`
-   |                  help: you can convert an `u8` to `i128`: `x_u8.into()`
+   |                  help: you can convert a `u8` to `i128`: `x_u8.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:296:18
@@ -1274,7 +1274,7 @@ LL |         x_i128 > x_u16;
    |                  ^^^^^
    |                  |
    |                  expected `i128`, found `u16`
-   |                  help: you can convert an `u16` to `i128`: `x_u16.into()`
+   |                  help: you can convert a `u16` to `i128`: `x_u16.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:298:18
@@ -1283,7 +1283,7 @@ LL |         x_i128 > x_u32;
    |                  ^^^^^
    |                  |
    |                  expected `i128`, found `u32`
-   |                  help: you can convert an `u32` to `i128`: `x_u32.into()`
+   |                  help: you can convert a `u32` to `i128`: `x_u32.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:300:18
@@ -1292,7 +1292,7 @@ LL |         x_i128 > x_u64;
    |                  ^^^^^
    |                  |
    |                  expected `i128`, found `u64`
-   |                  help: you can convert an `u64` to `i128`: `x_u64.into()`
+   |                  help: you can convert a `u64` to `i128`: `x_u64.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:302:18
@@ -1300,7 +1300,7 @@ error[E0308]: mismatched types
 LL |         x_i128 > x_u128;
    |                  ^^^^^^ expected `i128`, found `u128`
    |
-help: you can convert an `u128` to `i128` and panic if the converted value wouldn't fit
+help: you can convert a `u128` to `i128` and panic if the converted value wouldn't fit
    |
 LL |         x_i128 > x_u128.try_into().unwrap();
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1311,7 +1311,7 @@ error[E0308]: mismatched types
 LL |         x_i128 > x_usize;
    |                  ^^^^^^^ expected `i128`, found `usize`
    |
-help: you can convert an `usize` to `i128` and panic if the converted value wouldn't fit
+help: you can convert a `usize` to `i128` and panic if the converted value wouldn't fit
    |
 LL |         x_i128 > x_usize.try_into().unwrap();
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1323,7 +1323,7 @@ LL |         x_isize > x_u8;
    |                   ^^^^
    |                   |
    |                   expected `isize`, found `u8`
-   |                   help: you can convert an `u8` to `isize`: `x_u8.into()`
+   |                   help: you can convert a `u8` to `isize`: `x_u8.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:309:19
@@ -1331,7 +1331,7 @@ error[E0308]: mismatched types
 LL |         x_isize > x_u16;
    |                   ^^^^^ expected `isize`, found `u16`
    |
-help: you can convert an `u16` to `isize` and panic if the converted value wouldn't fit
+help: you can convert a `u16` to `isize` and panic if the converted value wouldn't fit
    |
 LL |         x_isize > x_u16.try_into().unwrap();
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1342,7 +1342,7 @@ error[E0308]: mismatched types
 LL |         x_isize > x_u32;
    |                   ^^^^^ expected `isize`, found `u32`
    |
-help: you can convert an `u32` to `isize` and panic if the converted value wouldn't fit
+help: you can convert a `u32` to `isize` and panic if the converted value wouldn't fit
    |
 LL |         x_isize > x_u32.try_into().unwrap();
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1353,7 +1353,7 @@ error[E0308]: mismatched types
 LL |         x_isize > x_u64;
    |                   ^^^^^ expected `isize`, found `u64`
    |
-help: you can convert an `u64` to `isize` and panic if the converted value wouldn't fit
+help: you can convert a `u64` to `isize` and panic if the converted value wouldn't fit
    |
 LL |         x_isize > x_u64.try_into().unwrap();
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1364,7 +1364,7 @@ error[E0308]: mismatched types
 LL |         x_isize > x_u128;
    |                   ^^^^^^ expected `isize`, found `u128`
    |
-help: you can convert an `u128` to `isize` and panic if the converted value wouldn't fit
+help: you can convert a `u128` to `isize` and panic if the converted value wouldn't fit
    |
 LL |         x_isize > x_u128.try_into().unwrap();
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1375,7 +1375,7 @@ error[E0308]: mismatched types
 LL |         x_isize > x_usize;
    |                   ^^^^^^^ expected `isize`, found `usize`
    |
-help: you can convert an `usize` to `isize` and panic if the converted value wouldn't fit
+help: you can convert a `usize` to `isize` and panic if the converted value wouldn't fit
    |
 LL |         x_isize > x_usize.try_into().unwrap();
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/numeric/numeric-cast-binop.stderr
+++ b/src/test/ui/numeric/numeric-cast-binop.stderr
@@ -60,7 +60,7 @@ LL |         x_u16 > x_u8;
    |                 ^^^^
    |                 |
    |                 expected `u16`, found `u8`
-   |                 help: you can convert a `u8` to `u16`: `x_u8.into()`
+   |                 help: you can convert a `u8` to a `u16`: `x_u8.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:36:17
@@ -113,7 +113,7 @@ LL |         x_u32 > x_u8;
    |                 ^^^^
    |                 |
    |                 expected `u32`, found `u8`
-   |                 help: you can convert a `u8` to `u32`: `x_u8.into()`
+   |                 help: you can convert a `u8` to a `u32`: `x_u8.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:47:17
@@ -122,7 +122,7 @@ LL |         x_u32 > x_u16;
    |                 ^^^^^
    |                 |
    |                 expected `u32`, found `u16`
-   |                 help: you can convert a `u16` to `u32`: `x_u16.into()`
+   |                 help: you can convert a `u16` to a `u32`: `x_u16.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:49:17
@@ -152,7 +152,7 @@ error[E0308]: mismatched types
 LL |         x_u32 > x_usize;
    |                 ^^^^^^^ expected `u32`, found `usize`
    |
-help: you can convert a `usize` to `u32` and panic if the converted value wouldn't fit
+help: you can convert a `usize` to a `u32` and panic if the converted value wouldn't fit
    |
 LL |         x_u32 > x_usize.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -164,7 +164,7 @@ LL |         x_u64 > x_u8;
    |                 ^^^^
    |                 |
    |                 expected `u64`, found `u8`
-   |                 help: you can convert a `u8` to `u64`: `x_u8.into()`
+   |                 help: you can convert a `u8` to a `u64`: `x_u8.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:58:17
@@ -173,7 +173,7 @@ LL |         x_u64 > x_u16;
    |                 ^^^^^
    |                 |
    |                 expected `u64`, found `u16`
-   |                 help: you can convert a `u16` to `u64`: `x_u16.into()`
+   |                 help: you can convert a `u16` to a `u64`: `x_u16.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:60:17
@@ -182,7 +182,7 @@ LL |         x_u64 > x_u32;
    |                 ^^^^^
    |                 |
    |                 expected `u64`, found `u32`
-   |                 help: you can convert a `u32` to `u64`: `x_u32.into()`
+   |                 help: you can convert a `u32` to a `u64`: `x_u32.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:62:17
@@ -201,7 +201,7 @@ error[E0308]: mismatched types
 LL |         x_u64 > x_usize;
    |                 ^^^^^^^ expected `u64`, found `usize`
    |
-help: you can convert a `usize` to `u64` and panic if the converted value wouldn't fit
+help: you can convert a `usize` to a `u64` and panic if the converted value wouldn't fit
    |
 LL |         x_u64 > x_usize.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -213,7 +213,7 @@ LL |         x_u128 > x_u8;
    |                  ^^^^
    |                  |
    |                  expected `u128`, found `u8`
-   |                  help: you can convert a `u8` to `u128`: `x_u8.into()`
+   |                  help: you can convert a `u8` to a `u128`: `x_u8.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:69:18
@@ -222,7 +222,7 @@ LL |         x_u128 > x_u16;
    |                  ^^^^^
    |                  |
    |                  expected `u128`, found `u16`
-   |                  help: you can convert a `u16` to `u128`: `x_u16.into()`
+   |                  help: you can convert a `u16` to a `u128`: `x_u16.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:71:18
@@ -231,7 +231,7 @@ LL |         x_u128 > x_u32;
    |                  ^^^^^
    |                  |
    |                  expected `u128`, found `u32`
-   |                  help: you can convert a `u32` to `u128`: `x_u32.into()`
+   |                  help: you can convert a `u32` to a `u128`: `x_u32.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:73:18
@@ -240,7 +240,7 @@ LL |         x_u128 > x_u64;
    |                  ^^^^^
    |                  |
    |                  expected `u128`, found `u64`
-   |                  help: you can convert a `u64` to `u128`: `x_u64.into()`
+   |                  help: you can convert a `u64` to a `u128`: `x_u64.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:75:18
@@ -248,7 +248,7 @@ error[E0308]: mismatched types
 LL |         x_u128 > x_usize;
    |                  ^^^^^^^ expected `u128`, found `usize`
    |
-help: you can convert a `usize` to `u128` and panic if the converted value wouldn't fit
+help: you can convert a `usize` to a `u128` and panic if the converted value wouldn't fit
    |
 LL |         x_u128 > x_usize.try_into().unwrap();
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -260,7 +260,7 @@ LL |         x_usize > x_u8;
    |                   ^^^^
    |                   |
    |                   expected `usize`, found `u8`
-   |                   help: you can convert a `u8` to `usize`: `x_u8.into()`
+   |                   help: you can convert a `u8` to a `usize`: `x_u8.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:80:19
@@ -269,7 +269,7 @@ LL |         x_usize > x_u16;
    |                   ^^^^^
    |                   |
    |                   expected `usize`, found `u16`
-   |                   help: you can convert a `u16` to `usize`: `x_u16.into()`
+   |                   help: you can convert a `u16` to a `usize`: `x_u16.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:82:19
@@ -277,7 +277,7 @@ error[E0308]: mismatched types
 LL |         x_usize > x_u32;
    |                   ^^^^^ expected `usize`, found `u32`
    |
-help: you can convert a `u32` to `usize` and panic if the converted value wouldn't fit
+help: you can convert a `u32` to a `usize` and panic if the converted value wouldn't fit
    |
 LL |         x_usize > x_u32.try_into().unwrap();
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -288,7 +288,7 @@ error[E0308]: mismatched types
 LL |         x_usize > x_u64;
    |                   ^^^^^ expected `usize`, found `u64`
    |
-help: you can convert a `u64` to `usize` and panic if the converted value wouldn't fit
+help: you can convert a `u64` to a `usize` and panic if the converted value wouldn't fit
    |
 LL |         x_usize > x_u64.try_into().unwrap();
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -299,7 +299,7 @@ error[E0308]: mismatched types
 LL |         x_usize > x_u128;
    |                   ^^^^^^ expected `usize`, found `u128`
    |
-help: you can convert a `u128` to `usize` and panic if the converted value wouldn't fit
+help: you can convert a `u128` to a `usize` and panic if the converted value wouldn't fit
    |
 LL |         x_usize > x_u128.try_into().unwrap();
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -366,7 +366,7 @@ LL |         x_i16 > x_i8;
    |                 ^^^^
    |                 |
    |                 expected `i16`, found `i8`
-   |                 help: you can convert an `i8` to `i16`: `x_i8.into()`
+   |                 help: you can convert an `i8` to an `i16`: `x_i8.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:105:17
@@ -419,7 +419,7 @@ LL |         x_i32 > x_i8;
    |                 ^^^^
    |                 |
    |                 expected `i32`, found `i8`
-   |                 help: you can convert an `i8` to `i32`: `x_i8.into()`
+   |                 help: you can convert an `i8` to an `i32`: `x_i8.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:116:17
@@ -428,7 +428,7 @@ LL |         x_i32 > x_i16;
    |                 ^^^^^
    |                 |
    |                 expected `i32`, found `i16`
-   |                 help: you can convert an `i16` to `i32`: `x_i16.into()`
+   |                 help: you can convert an `i16` to an `i32`: `x_i16.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:118:17
@@ -458,7 +458,7 @@ error[E0308]: mismatched types
 LL |         x_i32 > x_isize;
    |                 ^^^^^^^ expected `i32`, found `isize`
    |
-help: you can convert an `isize` to `i32` and panic if the converted value wouldn't fit
+help: you can convert an `isize` to an `i32` and panic if the converted value wouldn't fit
    |
 LL |         x_i32 > x_isize.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -470,7 +470,7 @@ LL |         x_i64 > x_i8;
    |                 ^^^^
    |                 |
    |                 expected `i64`, found `i8`
-   |                 help: you can convert an `i8` to `i64`: `x_i8.into()`
+   |                 help: you can convert an `i8` to an `i64`: `x_i8.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:127:17
@@ -479,7 +479,7 @@ LL |         x_i64 > x_i16;
    |                 ^^^^^
    |                 |
    |                 expected `i64`, found `i16`
-   |                 help: you can convert an `i16` to `i64`: `x_i16.into()`
+   |                 help: you can convert an `i16` to an `i64`: `x_i16.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:129:17
@@ -488,7 +488,7 @@ LL |         x_i64 > x_i32;
    |                 ^^^^^
    |                 |
    |                 expected `i64`, found `i32`
-   |                 help: you can convert an `i32` to `i64`: `x_i32.into()`
+   |                 help: you can convert an `i32` to an `i64`: `x_i32.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:131:17
@@ -507,7 +507,7 @@ error[E0308]: mismatched types
 LL |         x_i64 > x_isize;
    |                 ^^^^^^^ expected `i64`, found `isize`
    |
-help: you can convert an `isize` to `i64` and panic if the converted value wouldn't fit
+help: you can convert an `isize` to an `i64` and panic if the converted value wouldn't fit
    |
 LL |         x_i64 > x_isize.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -519,7 +519,7 @@ LL |         x_i128 > x_i8;
    |                  ^^^^
    |                  |
    |                  expected `i128`, found `i8`
-   |                  help: you can convert an `i8` to `i128`: `x_i8.into()`
+   |                  help: you can convert an `i8` to an `i128`: `x_i8.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:138:18
@@ -528,7 +528,7 @@ LL |         x_i128 > x_i16;
    |                  ^^^^^
    |                  |
    |                  expected `i128`, found `i16`
-   |                  help: you can convert an `i16` to `i128`: `x_i16.into()`
+   |                  help: you can convert an `i16` to an `i128`: `x_i16.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:140:18
@@ -537,7 +537,7 @@ LL |         x_i128 > x_i32;
    |                  ^^^^^
    |                  |
    |                  expected `i128`, found `i32`
-   |                  help: you can convert an `i32` to `i128`: `x_i32.into()`
+   |                  help: you can convert an `i32` to an `i128`: `x_i32.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:142:18
@@ -546,7 +546,7 @@ LL |         x_i128 > x_i64;
    |                  ^^^^^
    |                  |
    |                  expected `i128`, found `i64`
-   |                  help: you can convert an `i64` to `i128`: `x_i64.into()`
+   |                  help: you can convert an `i64` to an `i128`: `x_i64.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:144:18
@@ -554,7 +554,7 @@ error[E0308]: mismatched types
 LL |         x_i128 > x_isize;
    |                  ^^^^^^^ expected `i128`, found `isize`
    |
-help: you can convert an `isize` to `i128` and panic if the converted value wouldn't fit
+help: you can convert an `isize` to an `i128` and panic if the converted value wouldn't fit
    |
 LL |         x_i128 > x_isize.try_into().unwrap();
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -566,7 +566,7 @@ LL |         x_isize > x_i8;
    |                   ^^^^
    |                   |
    |                   expected `isize`, found `i8`
-   |                   help: you can convert an `i8` to `isize`: `x_i8.into()`
+   |                   help: you can convert an `i8` to an `isize`: `x_i8.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:149:19
@@ -575,7 +575,7 @@ LL |         x_isize > x_i16;
    |                   ^^^^^
    |                   |
    |                   expected `isize`, found `i16`
-   |                   help: you can convert an `i16` to `isize`: `x_i16.into()`
+   |                   help: you can convert an `i16` to an `isize`: `x_i16.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:151:19
@@ -583,7 +583,7 @@ error[E0308]: mismatched types
 LL |         x_isize > x_i32;
    |                   ^^^^^ expected `isize`, found `i32`
    |
-help: you can convert an `i32` to `isize` and panic if the converted value wouldn't fit
+help: you can convert an `i32` to an `isize` and panic if the converted value wouldn't fit
    |
 LL |         x_isize > x_i32.try_into().unwrap();
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -594,7 +594,7 @@ error[E0308]: mismatched types
 LL |         x_isize > x_i64;
    |                   ^^^^^ expected `isize`, found `i64`
    |
-help: you can convert an `i64` to `isize` and panic if the converted value wouldn't fit
+help: you can convert an `i64` to an `isize` and panic if the converted value wouldn't fit
    |
 LL |         x_isize > x_i64.try_into().unwrap();
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -605,7 +605,7 @@ error[E0308]: mismatched types
 LL |         x_isize > x_i128;
    |                   ^^^^^^ expected `isize`, found `i128`
    |
-help: you can convert an `i128` to `isize` and panic if the converted value wouldn't fit
+help: you can convert an `i128` to an `isize` and panic if the converted value wouldn't fit
    |
 LL |         x_isize > x_i128.try_into().unwrap();
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -616,7 +616,7 @@ error[E0308]: mismatched types
 LL |         x_u8 > x_i8;
    |                ^^^^ expected `u8`, found `i8`
    |
-help: you can convert an `i8` to `u8` and panic if the converted value wouldn't fit
+help: you can convert an `i8` to a `u8` and panic if the converted value wouldn't fit
    |
 LL |         x_u8 > x_i8.try_into().unwrap();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -682,7 +682,7 @@ error[E0308]: mismatched types
 LL |         x_u16 > x_i8;
    |                 ^^^^ expected `u16`, found `i8`
    |
-help: you can convert an `i8` to `u16` and panic if the converted value wouldn't fit
+help: you can convert an `i8` to a `u16` and panic if the converted value wouldn't fit
    |
 LL |         x_u16 > x_i8.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -693,7 +693,7 @@ error[E0308]: mismatched types
 LL |         x_u16 > x_i16;
    |                 ^^^^^ expected `u16`, found `i16`
    |
-help: you can convert an `i16` to `u16` and panic if the converted value wouldn't fit
+help: you can convert an `i16` to a `u16` and panic if the converted value wouldn't fit
    |
 LL |         x_u16 > x_i16.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -737,7 +737,7 @@ error[E0308]: mismatched types
 LL |         x_u16 > x_isize;
    |                 ^^^^^^^ expected `u16`, found `isize`
    |
-help: you can convert an `isize` to `u16` and panic if the converted value wouldn't fit
+help: you can convert an `isize` to a `u16` and panic if the converted value wouldn't fit
    |
 LL |         x_u16 > x_isize.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -748,7 +748,7 @@ error[E0308]: mismatched types
 LL |         x_u32 > x_i8;
    |                 ^^^^ expected `u32`, found `i8`
    |
-help: you can convert an `i8` to `u32` and panic if the converted value wouldn't fit
+help: you can convert an `i8` to a `u32` and panic if the converted value wouldn't fit
    |
 LL |         x_u32 > x_i8.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -759,7 +759,7 @@ error[E0308]: mismatched types
 LL |         x_u32 > x_i16;
    |                 ^^^^^ expected `u32`, found `i16`
    |
-help: you can convert an `i16` to `u32` and panic if the converted value wouldn't fit
+help: you can convert an `i16` to a `u32` and panic if the converted value wouldn't fit
    |
 LL |         x_u32 > x_i16.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -770,7 +770,7 @@ error[E0308]: mismatched types
 LL |         x_u32 > x_i32;
    |                 ^^^^^ expected `u32`, found `i32`
    |
-help: you can convert an `i32` to `u32` and panic if the converted value wouldn't fit
+help: you can convert an `i32` to a `u32` and panic if the converted value wouldn't fit
    |
 LL |         x_u32 > x_i32.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -803,7 +803,7 @@ error[E0308]: mismatched types
 LL |         x_u32 > x_isize;
    |                 ^^^^^^^ expected `u32`, found `isize`
    |
-help: you can convert an `isize` to `u32` and panic if the converted value wouldn't fit
+help: you can convert an `isize` to a `u32` and panic if the converted value wouldn't fit
    |
 LL |         x_u32 > x_isize.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -814,7 +814,7 @@ error[E0308]: mismatched types
 LL |         x_u64 > x_i8;
    |                 ^^^^ expected `u64`, found `i8`
    |
-help: you can convert an `i8` to `u64` and panic if the converted value wouldn't fit
+help: you can convert an `i8` to a `u64` and panic if the converted value wouldn't fit
    |
 LL |         x_u64 > x_i8.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -825,7 +825,7 @@ error[E0308]: mismatched types
 LL |         x_u64 > x_i16;
    |                 ^^^^^ expected `u64`, found `i16`
    |
-help: you can convert an `i16` to `u64` and panic if the converted value wouldn't fit
+help: you can convert an `i16` to a `u64` and panic if the converted value wouldn't fit
    |
 LL |         x_u64 > x_i16.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -836,7 +836,7 @@ error[E0308]: mismatched types
 LL |         x_u64 > x_i32;
    |                 ^^^^^ expected `u64`, found `i32`
    |
-help: you can convert an `i32` to `u64` and panic if the converted value wouldn't fit
+help: you can convert an `i32` to a `u64` and panic if the converted value wouldn't fit
    |
 LL |         x_u64 > x_i32.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -847,7 +847,7 @@ error[E0308]: mismatched types
 LL |         x_u64 > x_i64;
    |                 ^^^^^ expected `u64`, found `i64`
    |
-help: you can convert an `i64` to `u64` and panic if the converted value wouldn't fit
+help: you can convert an `i64` to a `u64` and panic if the converted value wouldn't fit
    |
 LL |         x_u64 > x_i64.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -869,7 +869,7 @@ error[E0308]: mismatched types
 LL |         x_u64 > x_isize;
    |                 ^^^^^^^ expected `u64`, found `isize`
    |
-help: you can convert an `isize` to `u64` and panic if the converted value wouldn't fit
+help: you can convert an `isize` to a `u64` and panic if the converted value wouldn't fit
    |
 LL |         x_u64 > x_isize.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -880,7 +880,7 @@ error[E0308]: mismatched types
 LL |         x_u128 > x_i8;
    |                  ^^^^ expected `u128`, found `i8`
    |
-help: you can convert an `i8` to `u128` and panic if the converted value wouldn't fit
+help: you can convert an `i8` to a `u128` and panic if the converted value wouldn't fit
    |
 LL |         x_u128 > x_i8.try_into().unwrap();
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -891,7 +891,7 @@ error[E0308]: mismatched types
 LL |         x_u128 > x_i16;
    |                  ^^^^^ expected `u128`, found `i16`
    |
-help: you can convert an `i16` to `u128` and panic if the converted value wouldn't fit
+help: you can convert an `i16` to a `u128` and panic if the converted value wouldn't fit
    |
 LL |         x_u128 > x_i16.try_into().unwrap();
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -902,7 +902,7 @@ error[E0308]: mismatched types
 LL |         x_u128 > x_i32;
    |                  ^^^^^ expected `u128`, found `i32`
    |
-help: you can convert an `i32` to `u128` and panic if the converted value wouldn't fit
+help: you can convert an `i32` to a `u128` and panic if the converted value wouldn't fit
    |
 LL |         x_u128 > x_i32.try_into().unwrap();
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -913,7 +913,7 @@ error[E0308]: mismatched types
 LL |         x_u128 > x_i64;
    |                  ^^^^^ expected `u128`, found `i64`
    |
-help: you can convert an `i64` to `u128` and panic if the converted value wouldn't fit
+help: you can convert an `i64` to a `u128` and panic if the converted value wouldn't fit
    |
 LL |         x_u128 > x_i64.try_into().unwrap();
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -924,7 +924,7 @@ error[E0308]: mismatched types
 LL |         x_u128 > x_i128;
    |                  ^^^^^^ expected `u128`, found `i128`
    |
-help: you can convert an `i128` to `u128` and panic if the converted value wouldn't fit
+help: you can convert an `i128` to a `u128` and panic if the converted value wouldn't fit
    |
 LL |         x_u128 > x_i128.try_into().unwrap();
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -935,7 +935,7 @@ error[E0308]: mismatched types
 LL |         x_u128 > x_isize;
    |                  ^^^^^^^ expected `u128`, found `isize`
    |
-help: you can convert an `isize` to `u128` and panic if the converted value wouldn't fit
+help: you can convert an `isize` to a `u128` and panic if the converted value wouldn't fit
    |
 LL |         x_u128 > x_isize.try_into().unwrap();
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -946,7 +946,7 @@ error[E0308]: mismatched types
 LL |         x_usize > x_i8;
    |                   ^^^^ expected `usize`, found `i8`
    |
-help: you can convert an `i8` to `usize` and panic if the converted value wouldn't fit
+help: you can convert an `i8` to a `usize` and panic if the converted value wouldn't fit
    |
 LL |         x_usize > x_i8.try_into().unwrap();
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -957,7 +957,7 @@ error[E0308]: mismatched types
 LL |         x_usize > x_i16;
    |                   ^^^^^ expected `usize`, found `i16`
    |
-help: you can convert an `i16` to `usize` and panic if the converted value wouldn't fit
+help: you can convert an `i16` to a `usize` and panic if the converted value wouldn't fit
    |
 LL |         x_usize > x_i16.try_into().unwrap();
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -968,7 +968,7 @@ error[E0308]: mismatched types
 LL |         x_usize > x_i32;
    |                   ^^^^^ expected `usize`, found `i32`
    |
-help: you can convert an `i32` to `usize` and panic if the converted value wouldn't fit
+help: you can convert an `i32` to a `usize` and panic if the converted value wouldn't fit
    |
 LL |         x_usize > x_i32.try_into().unwrap();
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -979,7 +979,7 @@ error[E0308]: mismatched types
 LL |         x_usize > x_i64;
    |                   ^^^^^ expected `usize`, found `i64`
    |
-help: you can convert an `i64` to `usize` and panic if the converted value wouldn't fit
+help: you can convert an `i64` to a `usize` and panic if the converted value wouldn't fit
    |
 LL |         x_usize > x_i64.try_into().unwrap();
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -990,7 +990,7 @@ error[E0308]: mismatched types
 LL |         x_usize > x_i128;
    |                   ^^^^^^ expected `usize`, found `i128`
    |
-help: you can convert an `i128` to `usize` and panic if the converted value wouldn't fit
+help: you can convert an `i128` to a `usize` and panic if the converted value wouldn't fit
    |
 LL |         x_usize > x_i128.try_into().unwrap();
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1001,7 +1001,7 @@ error[E0308]: mismatched types
 LL |         x_usize > x_isize;
    |                   ^^^^^^^ expected `usize`, found `isize`
    |
-help: you can convert an `isize` to `usize` and panic if the converted value wouldn't fit
+help: you can convert an `isize` to a `usize` and panic if the converted value wouldn't fit
    |
 LL |         x_usize > x_isize.try_into().unwrap();
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1012,7 +1012,7 @@ error[E0308]: mismatched types
 LL |         x_i8 > x_u8;
    |                ^^^^ expected `i8`, found `u8`
    |
-help: you can convert a `u8` to `i8` and panic if the converted value wouldn't fit
+help: you can convert a `u8` to an `i8` and panic if the converted value wouldn't fit
    |
 LL |         x_i8 > x_u8.try_into().unwrap();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1023,7 +1023,7 @@ error[E0308]: mismatched types
 LL |         x_i8 > x_u16;
    |                ^^^^^ expected `i8`, found `u16`
    |
-help: you can convert a `u16` to `i8` and panic if the converted value wouldn't fit
+help: you can convert a `u16` to an `i8` and panic if the converted value wouldn't fit
    |
 LL |         x_i8 > x_u16.try_into().unwrap();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1034,7 +1034,7 @@ error[E0308]: mismatched types
 LL |         x_i8 > x_u32;
    |                ^^^^^ expected `i8`, found `u32`
    |
-help: you can convert a `u32` to `i8` and panic if the converted value wouldn't fit
+help: you can convert a `u32` to an `i8` and panic if the converted value wouldn't fit
    |
 LL |         x_i8 > x_u32.try_into().unwrap();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1045,7 +1045,7 @@ error[E0308]: mismatched types
 LL |         x_i8 > x_u64;
    |                ^^^^^ expected `i8`, found `u64`
    |
-help: you can convert a `u64` to `i8` and panic if the converted value wouldn't fit
+help: you can convert a `u64` to an `i8` and panic if the converted value wouldn't fit
    |
 LL |         x_i8 > x_u64.try_into().unwrap();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1056,7 +1056,7 @@ error[E0308]: mismatched types
 LL |         x_i8 > x_u128;
    |                ^^^^^^ expected `i8`, found `u128`
    |
-help: you can convert a `u128` to `i8` and panic if the converted value wouldn't fit
+help: you can convert a `u128` to an `i8` and panic if the converted value wouldn't fit
    |
 LL |         x_i8 > x_u128.try_into().unwrap();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1067,7 +1067,7 @@ error[E0308]: mismatched types
 LL |         x_i8 > x_usize;
    |                ^^^^^^^ expected `i8`, found `usize`
    |
-help: you can convert a `usize` to `i8` and panic if the converted value wouldn't fit
+help: you can convert a `usize` to an `i8` and panic if the converted value wouldn't fit
    |
 LL |         x_i8 > x_usize.try_into().unwrap();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1079,7 +1079,7 @@ LL |         x_i16 > x_u8;
    |                 ^^^^
    |                 |
    |                 expected `i16`, found `u8`
-   |                 help: you can convert a `u8` to `i16`: `x_u8.into()`
+   |                 help: you can convert a `u8` to an `i16`: `x_u8.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:257:17
@@ -1087,7 +1087,7 @@ error[E0308]: mismatched types
 LL |         x_i16 > x_u16;
    |                 ^^^^^ expected `i16`, found `u16`
    |
-help: you can convert a `u16` to `i16` and panic if the converted value wouldn't fit
+help: you can convert a `u16` to an `i16` and panic if the converted value wouldn't fit
    |
 LL |         x_i16 > x_u16.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1098,7 +1098,7 @@ error[E0308]: mismatched types
 LL |         x_i16 > x_u32;
    |                 ^^^^^ expected `i16`, found `u32`
    |
-help: you can convert a `u32` to `i16` and panic if the converted value wouldn't fit
+help: you can convert a `u32` to an `i16` and panic if the converted value wouldn't fit
    |
 LL |         x_i16 > x_u32.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1109,7 +1109,7 @@ error[E0308]: mismatched types
 LL |         x_i16 > x_u64;
    |                 ^^^^^ expected `i16`, found `u64`
    |
-help: you can convert a `u64` to `i16` and panic if the converted value wouldn't fit
+help: you can convert a `u64` to an `i16` and panic if the converted value wouldn't fit
    |
 LL |         x_i16 > x_u64.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1120,7 +1120,7 @@ error[E0308]: mismatched types
 LL |         x_i16 > x_u128;
    |                 ^^^^^^ expected `i16`, found `u128`
    |
-help: you can convert a `u128` to `i16` and panic if the converted value wouldn't fit
+help: you can convert a `u128` to an `i16` and panic if the converted value wouldn't fit
    |
 LL |         x_i16 > x_u128.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1131,7 +1131,7 @@ error[E0308]: mismatched types
 LL |         x_i16 > x_usize;
    |                 ^^^^^^^ expected `i16`, found `usize`
    |
-help: you can convert a `usize` to `i16` and panic if the converted value wouldn't fit
+help: you can convert a `usize` to an `i16` and panic if the converted value wouldn't fit
    |
 LL |         x_i16 > x_usize.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1143,7 +1143,7 @@ LL |         x_i32 > x_u8;
    |                 ^^^^
    |                 |
    |                 expected `i32`, found `u8`
-   |                 help: you can convert a `u8` to `i32`: `x_u8.into()`
+   |                 help: you can convert a `u8` to an `i32`: `x_u8.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:270:17
@@ -1152,7 +1152,7 @@ LL |         x_i32 > x_u16;
    |                 ^^^^^
    |                 |
    |                 expected `i32`, found `u16`
-   |                 help: you can convert a `u16` to `i32`: `x_u16.into()`
+   |                 help: you can convert a `u16` to an `i32`: `x_u16.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:272:17
@@ -1160,7 +1160,7 @@ error[E0308]: mismatched types
 LL |         x_i32 > x_u32;
    |                 ^^^^^ expected `i32`, found `u32`
    |
-help: you can convert a `u32` to `i32` and panic if the converted value wouldn't fit
+help: you can convert a `u32` to an `i32` and panic if the converted value wouldn't fit
    |
 LL |         x_i32 > x_u32.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1171,7 +1171,7 @@ error[E0308]: mismatched types
 LL |         x_i32 > x_u64;
    |                 ^^^^^ expected `i32`, found `u64`
    |
-help: you can convert a `u64` to `i32` and panic if the converted value wouldn't fit
+help: you can convert a `u64` to an `i32` and panic if the converted value wouldn't fit
    |
 LL |         x_i32 > x_u64.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1182,7 +1182,7 @@ error[E0308]: mismatched types
 LL |         x_i32 > x_u128;
    |                 ^^^^^^ expected `i32`, found `u128`
    |
-help: you can convert a `u128` to `i32` and panic if the converted value wouldn't fit
+help: you can convert a `u128` to an `i32` and panic if the converted value wouldn't fit
    |
 LL |         x_i32 > x_u128.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1193,7 +1193,7 @@ error[E0308]: mismatched types
 LL |         x_i32 > x_usize;
    |                 ^^^^^^^ expected `i32`, found `usize`
    |
-help: you can convert a `usize` to `i32` and panic if the converted value wouldn't fit
+help: you can convert a `usize` to an `i32` and panic if the converted value wouldn't fit
    |
 LL |         x_i32 > x_usize.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1205,7 +1205,7 @@ LL |         x_i64 > x_u8;
    |                 ^^^^
    |                 |
    |                 expected `i64`, found `u8`
-   |                 help: you can convert a `u8` to `i64`: `x_u8.into()`
+   |                 help: you can convert a `u8` to an `i64`: `x_u8.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:283:17
@@ -1214,7 +1214,7 @@ LL |         x_i64 > x_u16;
    |                 ^^^^^
    |                 |
    |                 expected `i64`, found `u16`
-   |                 help: you can convert a `u16` to `i64`: `x_u16.into()`
+   |                 help: you can convert a `u16` to an `i64`: `x_u16.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:285:17
@@ -1223,7 +1223,7 @@ LL |         x_i64 > x_u32;
    |                 ^^^^^
    |                 |
    |                 expected `i64`, found `u32`
-   |                 help: you can convert a `u32` to `i64`: `x_u32.into()`
+   |                 help: you can convert a `u32` to an `i64`: `x_u32.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:287:17
@@ -1231,7 +1231,7 @@ error[E0308]: mismatched types
 LL |         x_i64 > x_u64;
    |                 ^^^^^ expected `i64`, found `u64`
    |
-help: you can convert a `u64` to `i64` and panic if the converted value wouldn't fit
+help: you can convert a `u64` to an `i64` and panic if the converted value wouldn't fit
    |
 LL |         x_i64 > x_u64.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1242,7 +1242,7 @@ error[E0308]: mismatched types
 LL |         x_i64 > x_u128;
    |                 ^^^^^^ expected `i64`, found `u128`
    |
-help: you can convert a `u128` to `i64` and panic if the converted value wouldn't fit
+help: you can convert a `u128` to an `i64` and panic if the converted value wouldn't fit
    |
 LL |         x_i64 > x_u128.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1253,7 +1253,7 @@ error[E0308]: mismatched types
 LL |         x_i64 > x_usize;
    |                 ^^^^^^^ expected `i64`, found `usize`
    |
-help: you can convert a `usize` to `i64` and panic if the converted value wouldn't fit
+help: you can convert a `usize` to an `i64` and panic if the converted value wouldn't fit
    |
 LL |         x_i64 > x_usize.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1265,7 +1265,7 @@ LL |         x_i128 > x_u8;
    |                  ^^^^
    |                  |
    |                  expected `i128`, found `u8`
-   |                  help: you can convert a `u8` to `i128`: `x_u8.into()`
+   |                  help: you can convert a `u8` to an `i128`: `x_u8.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:296:18
@@ -1274,7 +1274,7 @@ LL |         x_i128 > x_u16;
    |                  ^^^^^
    |                  |
    |                  expected `i128`, found `u16`
-   |                  help: you can convert a `u16` to `i128`: `x_u16.into()`
+   |                  help: you can convert a `u16` to an `i128`: `x_u16.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:298:18
@@ -1283,7 +1283,7 @@ LL |         x_i128 > x_u32;
    |                  ^^^^^
    |                  |
    |                  expected `i128`, found `u32`
-   |                  help: you can convert a `u32` to `i128`: `x_u32.into()`
+   |                  help: you can convert a `u32` to an `i128`: `x_u32.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:300:18
@@ -1292,7 +1292,7 @@ LL |         x_i128 > x_u64;
    |                  ^^^^^
    |                  |
    |                  expected `i128`, found `u64`
-   |                  help: you can convert a `u64` to `i128`: `x_u64.into()`
+   |                  help: you can convert a `u64` to an `i128`: `x_u64.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:302:18
@@ -1300,7 +1300,7 @@ error[E0308]: mismatched types
 LL |         x_i128 > x_u128;
    |                  ^^^^^^ expected `i128`, found `u128`
    |
-help: you can convert a `u128` to `i128` and panic if the converted value wouldn't fit
+help: you can convert a `u128` to an `i128` and panic if the converted value wouldn't fit
    |
 LL |         x_i128 > x_u128.try_into().unwrap();
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1311,7 +1311,7 @@ error[E0308]: mismatched types
 LL |         x_i128 > x_usize;
    |                  ^^^^^^^ expected `i128`, found `usize`
    |
-help: you can convert a `usize` to `i128` and panic if the converted value wouldn't fit
+help: you can convert a `usize` to an `i128` and panic if the converted value wouldn't fit
    |
 LL |         x_i128 > x_usize.try_into().unwrap();
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1323,7 +1323,7 @@ LL |         x_isize > x_u8;
    |                   ^^^^
    |                   |
    |                   expected `isize`, found `u8`
-   |                   help: you can convert a `u8` to `isize`: `x_u8.into()`
+   |                   help: you can convert a `u8` to an `isize`: `x_u8.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:309:19
@@ -1331,7 +1331,7 @@ error[E0308]: mismatched types
 LL |         x_isize > x_u16;
    |                   ^^^^^ expected `isize`, found `u16`
    |
-help: you can convert a `u16` to `isize` and panic if the converted value wouldn't fit
+help: you can convert a `u16` to an `isize` and panic if the converted value wouldn't fit
    |
 LL |         x_isize > x_u16.try_into().unwrap();
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1342,7 +1342,7 @@ error[E0308]: mismatched types
 LL |         x_isize > x_u32;
    |                   ^^^^^ expected `isize`, found `u32`
    |
-help: you can convert a `u32` to `isize` and panic if the converted value wouldn't fit
+help: you can convert a `u32` to an `isize` and panic if the converted value wouldn't fit
    |
 LL |         x_isize > x_u32.try_into().unwrap();
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1353,7 +1353,7 @@ error[E0308]: mismatched types
 LL |         x_isize > x_u64;
    |                   ^^^^^ expected `isize`, found `u64`
    |
-help: you can convert a `u64` to `isize` and panic if the converted value wouldn't fit
+help: you can convert a `u64` to an `isize` and panic if the converted value wouldn't fit
    |
 LL |         x_isize > x_u64.try_into().unwrap();
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1364,7 +1364,7 @@ error[E0308]: mismatched types
 LL |         x_isize > x_u128;
    |                   ^^^^^^ expected `isize`, found `u128`
    |
-help: you can convert a `u128` to `isize` and panic if the converted value wouldn't fit
+help: you can convert a `u128` to an `isize` and panic if the converted value wouldn't fit
    |
 LL |         x_isize > x_u128.try_into().unwrap();
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1375,7 +1375,7 @@ error[E0308]: mismatched types
 LL |         x_isize > x_usize;
    |                   ^^^^^^^ expected `isize`, found `usize`
    |
-help: you can convert a `usize` to `isize` and panic if the converted value wouldn't fit
+help: you can convert a `usize` to an `isize` and panic if the converted value wouldn't fit
    |
 LL |         x_isize > x_usize.try_into().unwrap();
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/numeric/numeric-cast-binop.stderr
+++ b/src/test/ui/numeric/numeric-cast-binop.stderr
@@ -152,7 +152,7 @@ error[E0308]: mismatched types
 LL |         x_u32 > x_usize;
    |                 ^^^^^^^ expected `u32`, found `usize`
    |
-help: you can convert a `usize` to a `u32` and panic if the converted value wouldn't fit
+help: you can convert a `usize` to a `u32` and panic if the converted value doesn't fit
    |
 LL |         x_u32 > x_usize.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -201,7 +201,7 @@ error[E0308]: mismatched types
 LL |         x_u64 > x_usize;
    |                 ^^^^^^^ expected `u64`, found `usize`
    |
-help: you can convert a `usize` to a `u64` and panic if the converted value wouldn't fit
+help: you can convert a `usize` to a `u64` and panic if the converted value doesn't fit
    |
 LL |         x_u64 > x_usize.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -248,7 +248,7 @@ error[E0308]: mismatched types
 LL |         x_u128 > x_usize;
    |                  ^^^^^^^ expected `u128`, found `usize`
    |
-help: you can convert a `usize` to a `u128` and panic if the converted value wouldn't fit
+help: you can convert a `usize` to a `u128` and panic if the converted value doesn't fit
    |
 LL |         x_u128 > x_usize.try_into().unwrap();
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -277,7 +277,7 @@ error[E0308]: mismatched types
 LL |         x_usize > x_u32;
    |                   ^^^^^ expected `usize`, found `u32`
    |
-help: you can convert a `u32` to a `usize` and panic if the converted value wouldn't fit
+help: you can convert a `u32` to a `usize` and panic if the converted value doesn't fit
    |
 LL |         x_usize > x_u32.try_into().unwrap();
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -288,7 +288,7 @@ error[E0308]: mismatched types
 LL |         x_usize > x_u64;
    |                   ^^^^^ expected `usize`, found `u64`
    |
-help: you can convert a `u64` to a `usize` and panic if the converted value wouldn't fit
+help: you can convert a `u64` to a `usize` and panic if the converted value doesn't fit
    |
 LL |         x_usize > x_u64.try_into().unwrap();
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -299,7 +299,7 @@ error[E0308]: mismatched types
 LL |         x_usize > x_u128;
    |                   ^^^^^^ expected `usize`, found `u128`
    |
-help: you can convert a `u128` to a `usize` and panic if the converted value wouldn't fit
+help: you can convert a `u128` to a `usize` and panic if the converted value doesn't fit
    |
 LL |         x_usize > x_u128.try_into().unwrap();
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -458,7 +458,7 @@ error[E0308]: mismatched types
 LL |         x_i32 > x_isize;
    |                 ^^^^^^^ expected `i32`, found `isize`
    |
-help: you can convert an `isize` to an `i32` and panic if the converted value wouldn't fit
+help: you can convert an `isize` to an `i32` and panic if the converted value doesn't fit
    |
 LL |         x_i32 > x_isize.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -507,7 +507,7 @@ error[E0308]: mismatched types
 LL |         x_i64 > x_isize;
    |                 ^^^^^^^ expected `i64`, found `isize`
    |
-help: you can convert an `isize` to an `i64` and panic if the converted value wouldn't fit
+help: you can convert an `isize` to an `i64` and panic if the converted value doesn't fit
    |
 LL |         x_i64 > x_isize.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -554,7 +554,7 @@ error[E0308]: mismatched types
 LL |         x_i128 > x_isize;
    |                  ^^^^^^^ expected `i128`, found `isize`
    |
-help: you can convert an `isize` to an `i128` and panic if the converted value wouldn't fit
+help: you can convert an `isize` to an `i128` and panic if the converted value doesn't fit
    |
 LL |         x_i128 > x_isize.try_into().unwrap();
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -583,7 +583,7 @@ error[E0308]: mismatched types
 LL |         x_isize > x_i32;
    |                   ^^^^^ expected `isize`, found `i32`
    |
-help: you can convert an `i32` to an `isize` and panic if the converted value wouldn't fit
+help: you can convert an `i32` to an `isize` and panic if the converted value doesn't fit
    |
 LL |         x_isize > x_i32.try_into().unwrap();
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -594,7 +594,7 @@ error[E0308]: mismatched types
 LL |         x_isize > x_i64;
    |                   ^^^^^ expected `isize`, found `i64`
    |
-help: you can convert an `i64` to an `isize` and panic if the converted value wouldn't fit
+help: you can convert an `i64` to an `isize` and panic if the converted value doesn't fit
    |
 LL |         x_isize > x_i64.try_into().unwrap();
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -605,7 +605,7 @@ error[E0308]: mismatched types
 LL |         x_isize > x_i128;
    |                   ^^^^^^ expected `isize`, found `i128`
    |
-help: you can convert an `i128` to an `isize` and panic if the converted value wouldn't fit
+help: you can convert an `i128` to an `isize` and panic if the converted value doesn't fit
    |
 LL |         x_isize > x_i128.try_into().unwrap();
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -616,7 +616,7 @@ error[E0308]: mismatched types
 LL |         x_u8 > x_i8;
    |                ^^^^ expected `u8`, found `i8`
    |
-help: you can convert an `i8` to a `u8` and panic if the converted value wouldn't fit
+help: you can convert an `i8` to a `u8` and panic if the converted value doesn't fit
    |
 LL |         x_u8 > x_i8.try_into().unwrap();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -682,7 +682,7 @@ error[E0308]: mismatched types
 LL |         x_u16 > x_i8;
    |                 ^^^^ expected `u16`, found `i8`
    |
-help: you can convert an `i8` to a `u16` and panic if the converted value wouldn't fit
+help: you can convert an `i8` to a `u16` and panic if the converted value doesn't fit
    |
 LL |         x_u16 > x_i8.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -693,7 +693,7 @@ error[E0308]: mismatched types
 LL |         x_u16 > x_i16;
    |                 ^^^^^ expected `u16`, found `i16`
    |
-help: you can convert an `i16` to a `u16` and panic if the converted value wouldn't fit
+help: you can convert an `i16` to a `u16` and panic if the converted value doesn't fit
    |
 LL |         x_u16 > x_i16.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -737,7 +737,7 @@ error[E0308]: mismatched types
 LL |         x_u16 > x_isize;
    |                 ^^^^^^^ expected `u16`, found `isize`
    |
-help: you can convert an `isize` to a `u16` and panic if the converted value wouldn't fit
+help: you can convert an `isize` to a `u16` and panic if the converted value doesn't fit
    |
 LL |         x_u16 > x_isize.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -748,7 +748,7 @@ error[E0308]: mismatched types
 LL |         x_u32 > x_i8;
    |                 ^^^^ expected `u32`, found `i8`
    |
-help: you can convert an `i8` to a `u32` and panic if the converted value wouldn't fit
+help: you can convert an `i8` to a `u32` and panic if the converted value doesn't fit
    |
 LL |         x_u32 > x_i8.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -759,7 +759,7 @@ error[E0308]: mismatched types
 LL |         x_u32 > x_i16;
    |                 ^^^^^ expected `u32`, found `i16`
    |
-help: you can convert an `i16` to a `u32` and panic if the converted value wouldn't fit
+help: you can convert an `i16` to a `u32` and panic if the converted value doesn't fit
    |
 LL |         x_u32 > x_i16.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -770,7 +770,7 @@ error[E0308]: mismatched types
 LL |         x_u32 > x_i32;
    |                 ^^^^^ expected `u32`, found `i32`
    |
-help: you can convert an `i32` to a `u32` and panic if the converted value wouldn't fit
+help: you can convert an `i32` to a `u32` and panic if the converted value doesn't fit
    |
 LL |         x_u32 > x_i32.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -803,7 +803,7 @@ error[E0308]: mismatched types
 LL |         x_u32 > x_isize;
    |                 ^^^^^^^ expected `u32`, found `isize`
    |
-help: you can convert an `isize` to a `u32` and panic if the converted value wouldn't fit
+help: you can convert an `isize` to a `u32` and panic if the converted value doesn't fit
    |
 LL |         x_u32 > x_isize.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -814,7 +814,7 @@ error[E0308]: mismatched types
 LL |         x_u64 > x_i8;
    |                 ^^^^ expected `u64`, found `i8`
    |
-help: you can convert an `i8` to a `u64` and panic if the converted value wouldn't fit
+help: you can convert an `i8` to a `u64` and panic if the converted value doesn't fit
    |
 LL |         x_u64 > x_i8.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -825,7 +825,7 @@ error[E0308]: mismatched types
 LL |         x_u64 > x_i16;
    |                 ^^^^^ expected `u64`, found `i16`
    |
-help: you can convert an `i16` to a `u64` and panic if the converted value wouldn't fit
+help: you can convert an `i16` to a `u64` and panic if the converted value doesn't fit
    |
 LL |         x_u64 > x_i16.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -836,7 +836,7 @@ error[E0308]: mismatched types
 LL |         x_u64 > x_i32;
    |                 ^^^^^ expected `u64`, found `i32`
    |
-help: you can convert an `i32` to a `u64` and panic if the converted value wouldn't fit
+help: you can convert an `i32` to a `u64` and panic if the converted value doesn't fit
    |
 LL |         x_u64 > x_i32.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -847,7 +847,7 @@ error[E0308]: mismatched types
 LL |         x_u64 > x_i64;
    |                 ^^^^^ expected `u64`, found `i64`
    |
-help: you can convert an `i64` to a `u64` and panic if the converted value wouldn't fit
+help: you can convert an `i64` to a `u64` and panic if the converted value doesn't fit
    |
 LL |         x_u64 > x_i64.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -869,7 +869,7 @@ error[E0308]: mismatched types
 LL |         x_u64 > x_isize;
    |                 ^^^^^^^ expected `u64`, found `isize`
    |
-help: you can convert an `isize` to a `u64` and panic if the converted value wouldn't fit
+help: you can convert an `isize` to a `u64` and panic if the converted value doesn't fit
    |
 LL |         x_u64 > x_isize.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -880,7 +880,7 @@ error[E0308]: mismatched types
 LL |         x_u128 > x_i8;
    |                  ^^^^ expected `u128`, found `i8`
    |
-help: you can convert an `i8` to a `u128` and panic if the converted value wouldn't fit
+help: you can convert an `i8` to a `u128` and panic if the converted value doesn't fit
    |
 LL |         x_u128 > x_i8.try_into().unwrap();
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -891,7 +891,7 @@ error[E0308]: mismatched types
 LL |         x_u128 > x_i16;
    |                  ^^^^^ expected `u128`, found `i16`
    |
-help: you can convert an `i16` to a `u128` and panic if the converted value wouldn't fit
+help: you can convert an `i16` to a `u128` and panic if the converted value doesn't fit
    |
 LL |         x_u128 > x_i16.try_into().unwrap();
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -902,7 +902,7 @@ error[E0308]: mismatched types
 LL |         x_u128 > x_i32;
    |                  ^^^^^ expected `u128`, found `i32`
    |
-help: you can convert an `i32` to a `u128` and panic if the converted value wouldn't fit
+help: you can convert an `i32` to a `u128` and panic if the converted value doesn't fit
    |
 LL |         x_u128 > x_i32.try_into().unwrap();
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -913,7 +913,7 @@ error[E0308]: mismatched types
 LL |         x_u128 > x_i64;
    |                  ^^^^^ expected `u128`, found `i64`
    |
-help: you can convert an `i64` to a `u128` and panic if the converted value wouldn't fit
+help: you can convert an `i64` to a `u128` and panic if the converted value doesn't fit
    |
 LL |         x_u128 > x_i64.try_into().unwrap();
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -924,7 +924,7 @@ error[E0308]: mismatched types
 LL |         x_u128 > x_i128;
    |                  ^^^^^^ expected `u128`, found `i128`
    |
-help: you can convert an `i128` to a `u128` and panic if the converted value wouldn't fit
+help: you can convert an `i128` to a `u128` and panic if the converted value doesn't fit
    |
 LL |         x_u128 > x_i128.try_into().unwrap();
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -935,7 +935,7 @@ error[E0308]: mismatched types
 LL |         x_u128 > x_isize;
    |                  ^^^^^^^ expected `u128`, found `isize`
    |
-help: you can convert an `isize` to a `u128` and panic if the converted value wouldn't fit
+help: you can convert an `isize` to a `u128` and panic if the converted value doesn't fit
    |
 LL |         x_u128 > x_isize.try_into().unwrap();
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -946,7 +946,7 @@ error[E0308]: mismatched types
 LL |         x_usize > x_i8;
    |                   ^^^^ expected `usize`, found `i8`
    |
-help: you can convert an `i8` to a `usize` and panic if the converted value wouldn't fit
+help: you can convert an `i8` to a `usize` and panic if the converted value doesn't fit
    |
 LL |         x_usize > x_i8.try_into().unwrap();
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -957,7 +957,7 @@ error[E0308]: mismatched types
 LL |         x_usize > x_i16;
    |                   ^^^^^ expected `usize`, found `i16`
    |
-help: you can convert an `i16` to a `usize` and panic if the converted value wouldn't fit
+help: you can convert an `i16` to a `usize` and panic if the converted value doesn't fit
    |
 LL |         x_usize > x_i16.try_into().unwrap();
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -968,7 +968,7 @@ error[E0308]: mismatched types
 LL |         x_usize > x_i32;
    |                   ^^^^^ expected `usize`, found `i32`
    |
-help: you can convert an `i32` to a `usize` and panic if the converted value wouldn't fit
+help: you can convert an `i32` to a `usize` and panic if the converted value doesn't fit
    |
 LL |         x_usize > x_i32.try_into().unwrap();
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -979,7 +979,7 @@ error[E0308]: mismatched types
 LL |         x_usize > x_i64;
    |                   ^^^^^ expected `usize`, found `i64`
    |
-help: you can convert an `i64` to a `usize` and panic if the converted value wouldn't fit
+help: you can convert an `i64` to a `usize` and panic if the converted value doesn't fit
    |
 LL |         x_usize > x_i64.try_into().unwrap();
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -990,7 +990,7 @@ error[E0308]: mismatched types
 LL |         x_usize > x_i128;
    |                   ^^^^^^ expected `usize`, found `i128`
    |
-help: you can convert an `i128` to a `usize` and panic if the converted value wouldn't fit
+help: you can convert an `i128` to a `usize` and panic if the converted value doesn't fit
    |
 LL |         x_usize > x_i128.try_into().unwrap();
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1001,7 +1001,7 @@ error[E0308]: mismatched types
 LL |         x_usize > x_isize;
    |                   ^^^^^^^ expected `usize`, found `isize`
    |
-help: you can convert an `isize` to a `usize` and panic if the converted value wouldn't fit
+help: you can convert an `isize` to a `usize` and panic if the converted value doesn't fit
    |
 LL |         x_usize > x_isize.try_into().unwrap();
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1012,7 +1012,7 @@ error[E0308]: mismatched types
 LL |         x_i8 > x_u8;
    |                ^^^^ expected `i8`, found `u8`
    |
-help: you can convert a `u8` to an `i8` and panic if the converted value wouldn't fit
+help: you can convert a `u8` to an `i8` and panic if the converted value doesn't fit
    |
 LL |         x_i8 > x_u8.try_into().unwrap();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1023,7 +1023,7 @@ error[E0308]: mismatched types
 LL |         x_i8 > x_u16;
    |                ^^^^^ expected `i8`, found `u16`
    |
-help: you can convert a `u16` to an `i8` and panic if the converted value wouldn't fit
+help: you can convert a `u16` to an `i8` and panic if the converted value doesn't fit
    |
 LL |         x_i8 > x_u16.try_into().unwrap();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1034,7 +1034,7 @@ error[E0308]: mismatched types
 LL |         x_i8 > x_u32;
    |                ^^^^^ expected `i8`, found `u32`
    |
-help: you can convert a `u32` to an `i8` and panic if the converted value wouldn't fit
+help: you can convert a `u32` to an `i8` and panic if the converted value doesn't fit
    |
 LL |         x_i8 > x_u32.try_into().unwrap();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1045,7 +1045,7 @@ error[E0308]: mismatched types
 LL |         x_i8 > x_u64;
    |                ^^^^^ expected `i8`, found `u64`
    |
-help: you can convert a `u64` to an `i8` and panic if the converted value wouldn't fit
+help: you can convert a `u64` to an `i8` and panic if the converted value doesn't fit
    |
 LL |         x_i8 > x_u64.try_into().unwrap();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1056,7 +1056,7 @@ error[E0308]: mismatched types
 LL |         x_i8 > x_u128;
    |                ^^^^^^ expected `i8`, found `u128`
    |
-help: you can convert a `u128` to an `i8` and panic if the converted value wouldn't fit
+help: you can convert a `u128` to an `i8` and panic if the converted value doesn't fit
    |
 LL |         x_i8 > x_u128.try_into().unwrap();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1067,7 +1067,7 @@ error[E0308]: mismatched types
 LL |         x_i8 > x_usize;
    |                ^^^^^^^ expected `i8`, found `usize`
    |
-help: you can convert a `usize` to an `i8` and panic if the converted value wouldn't fit
+help: you can convert a `usize` to an `i8` and panic if the converted value doesn't fit
    |
 LL |         x_i8 > x_usize.try_into().unwrap();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1087,7 +1087,7 @@ error[E0308]: mismatched types
 LL |         x_i16 > x_u16;
    |                 ^^^^^ expected `i16`, found `u16`
    |
-help: you can convert a `u16` to an `i16` and panic if the converted value wouldn't fit
+help: you can convert a `u16` to an `i16` and panic if the converted value doesn't fit
    |
 LL |         x_i16 > x_u16.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1098,7 +1098,7 @@ error[E0308]: mismatched types
 LL |         x_i16 > x_u32;
    |                 ^^^^^ expected `i16`, found `u32`
    |
-help: you can convert a `u32` to an `i16` and panic if the converted value wouldn't fit
+help: you can convert a `u32` to an `i16` and panic if the converted value doesn't fit
    |
 LL |         x_i16 > x_u32.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1109,7 +1109,7 @@ error[E0308]: mismatched types
 LL |         x_i16 > x_u64;
    |                 ^^^^^ expected `i16`, found `u64`
    |
-help: you can convert a `u64` to an `i16` and panic if the converted value wouldn't fit
+help: you can convert a `u64` to an `i16` and panic if the converted value doesn't fit
    |
 LL |         x_i16 > x_u64.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1120,7 +1120,7 @@ error[E0308]: mismatched types
 LL |         x_i16 > x_u128;
    |                 ^^^^^^ expected `i16`, found `u128`
    |
-help: you can convert a `u128` to an `i16` and panic if the converted value wouldn't fit
+help: you can convert a `u128` to an `i16` and panic if the converted value doesn't fit
    |
 LL |         x_i16 > x_u128.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1131,7 +1131,7 @@ error[E0308]: mismatched types
 LL |         x_i16 > x_usize;
    |                 ^^^^^^^ expected `i16`, found `usize`
    |
-help: you can convert a `usize` to an `i16` and panic if the converted value wouldn't fit
+help: you can convert a `usize` to an `i16` and panic if the converted value doesn't fit
    |
 LL |         x_i16 > x_usize.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1160,7 +1160,7 @@ error[E0308]: mismatched types
 LL |         x_i32 > x_u32;
    |                 ^^^^^ expected `i32`, found `u32`
    |
-help: you can convert a `u32` to an `i32` and panic if the converted value wouldn't fit
+help: you can convert a `u32` to an `i32` and panic if the converted value doesn't fit
    |
 LL |         x_i32 > x_u32.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1171,7 +1171,7 @@ error[E0308]: mismatched types
 LL |         x_i32 > x_u64;
    |                 ^^^^^ expected `i32`, found `u64`
    |
-help: you can convert a `u64` to an `i32` and panic if the converted value wouldn't fit
+help: you can convert a `u64` to an `i32` and panic if the converted value doesn't fit
    |
 LL |         x_i32 > x_u64.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1182,7 +1182,7 @@ error[E0308]: mismatched types
 LL |         x_i32 > x_u128;
    |                 ^^^^^^ expected `i32`, found `u128`
    |
-help: you can convert a `u128` to an `i32` and panic if the converted value wouldn't fit
+help: you can convert a `u128` to an `i32` and panic if the converted value doesn't fit
    |
 LL |         x_i32 > x_u128.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1193,7 +1193,7 @@ error[E0308]: mismatched types
 LL |         x_i32 > x_usize;
    |                 ^^^^^^^ expected `i32`, found `usize`
    |
-help: you can convert a `usize` to an `i32` and panic if the converted value wouldn't fit
+help: you can convert a `usize` to an `i32` and panic if the converted value doesn't fit
    |
 LL |         x_i32 > x_usize.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1231,7 +1231,7 @@ error[E0308]: mismatched types
 LL |         x_i64 > x_u64;
    |                 ^^^^^ expected `i64`, found `u64`
    |
-help: you can convert a `u64` to an `i64` and panic if the converted value wouldn't fit
+help: you can convert a `u64` to an `i64` and panic if the converted value doesn't fit
    |
 LL |         x_i64 > x_u64.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1242,7 +1242,7 @@ error[E0308]: mismatched types
 LL |         x_i64 > x_u128;
    |                 ^^^^^^ expected `i64`, found `u128`
    |
-help: you can convert a `u128` to an `i64` and panic if the converted value wouldn't fit
+help: you can convert a `u128` to an `i64` and panic if the converted value doesn't fit
    |
 LL |         x_i64 > x_u128.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1253,7 +1253,7 @@ error[E0308]: mismatched types
 LL |         x_i64 > x_usize;
    |                 ^^^^^^^ expected `i64`, found `usize`
    |
-help: you can convert a `usize` to an `i64` and panic if the converted value wouldn't fit
+help: you can convert a `usize` to an `i64` and panic if the converted value doesn't fit
    |
 LL |         x_i64 > x_usize.try_into().unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1300,7 +1300,7 @@ error[E0308]: mismatched types
 LL |         x_i128 > x_u128;
    |                  ^^^^^^ expected `i128`, found `u128`
    |
-help: you can convert a `u128` to an `i128` and panic if the converted value wouldn't fit
+help: you can convert a `u128` to an `i128` and panic if the converted value doesn't fit
    |
 LL |         x_i128 > x_u128.try_into().unwrap();
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1311,7 +1311,7 @@ error[E0308]: mismatched types
 LL |         x_i128 > x_usize;
    |                  ^^^^^^^ expected `i128`, found `usize`
    |
-help: you can convert a `usize` to an `i128` and panic if the converted value wouldn't fit
+help: you can convert a `usize` to an `i128` and panic if the converted value doesn't fit
    |
 LL |         x_i128 > x_usize.try_into().unwrap();
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1331,7 +1331,7 @@ error[E0308]: mismatched types
 LL |         x_isize > x_u16;
    |                   ^^^^^ expected `isize`, found `u16`
    |
-help: you can convert a `u16` to an `isize` and panic if the converted value wouldn't fit
+help: you can convert a `u16` to an `isize` and panic if the converted value doesn't fit
    |
 LL |         x_isize > x_u16.try_into().unwrap();
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1342,7 +1342,7 @@ error[E0308]: mismatched types
 LL |         x_isize > x_u32;
    |                   ^^^^^ expected `isize`, found `u32`
    |
-help: you can convert a `u32` to an `isize` and panic if the converted value wouldn't fit
+help: you can convert a `u32` to an `isize` and panic if the converted value doesn't fit
    |
 LL |         x_isize > x_u32.try_into().unwrap();
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1353,7 +1353,7 @@ error[E0308]: mismatched types
 LL |         x_isize > x_u64;
    |                   ^^^^^ expected `isize`, found `u64`
    |
-help: you can convert a `u64` to an `isize` and panic if the converted value wouldn't fit
+help: you can convert a `u64` to an `isize` and panic if the converted value doesn't fit
    |
 LL |         x_isize > x_u64.try_into().unwrap();
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1364,7 +1364,7 @@ error[E0308]: mismatched types
 LL |         x_isize > x_u128;
    |                   ^^^^^^ expected `isize`, found `u128`
    |
-help: you can convert a `u128` to an `isize` and panic if the converted value wouldn't fit
+help: you can convert a `u128` to an `isize` and panic if the converted value doesn't fit
    |
 LL |         x_isize > x_u128.try_into().unwrap();
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1375,7 +1375,7 @@ error[E0308]: mismatched types
 LL |         x_isize > x_usize;
    |                   ^^^^^^^ expected `isize`, found `usize`
    |
-help: you can convert a `usize` to an `isize` and panic if the converted value wouldn't fit
+help: you can convert a `usize` to an `isize` and panic if the converted value doesn't fit
    |
 LL |         x_isize > x_usize.try_into().unwrap();
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/numeric/numeric-cast.stderr
+++ b/src/test/ui/numeric/numeric-cast.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL |     foo::<usize>(x_u64);
    |                  ^^^^^ expected `usize`, found `u64`
    |
-help: you can convert an `u64` to `usize` and panic if the converted value wouldn't fit
+help: you can convert a `u64` to `usize` and panic if the converted value wouldn't fit
    |
 LL |     foo::<usize>(x_u64.try_into().unwrap());
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -15,7 +15,7 @@ error[E0308]: mismatched types
 LL |     foo::<usize>(x_u32);
    |                  ^^^^^ expected `usize`, found `u32`
    |
-help: you can convert an `u32` to `usize` and panic if the converted value wouldn't fit
+help: you can convert a `u32` to `usize` and panic if the converted value wouldn't fit
    |
 LL |     foo::<usize>(x_u32.try_into().unwrap());
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -27,7 +27,7 @@ LL |     foo::<usize>(x_u16);
    |                  ^^^^^
    |                  |
    |                  expected `usize`, found `u16`
-   |                  help: you can convert an `u16` to `usize`: `x_u16.into()`
+   |                  help: you can convert a `u16` to `usize`: `x_u16.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:29:18
@@ -36,7 +36,7 @@ LL |     foo::<usize>(x_u8);
    |                  ^^^^
    |                  |
    |                  expected `usize`, found `u8`
-   |                  help: you can convert an `u8` to `usize`: `x_u8.into()`
+   |                  help: you can convert a `u8` to `usize`: `x_u8.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:31:18
@@ -99,7 +99,7 @@ error[E0308]: mismatched types
 LL |     foo::<isize>(x_usize);
    |                  ^^^^^^^ expected `isize`, found `usize`
    |
-help: you can convert an `usize` to `isize` and panic if the converted value wouldn't fit
+help: you can convert a `usize` to `isize` and panic if the converted value wouldn't fit
    |
 LL |     foo::<isize>(x_usize.try_into().unwrap());
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -110,7 +110,7 @@ error[E0308]: mismatched types
 LL |     foo::<isize>(x_u64);
    |                  ^^^^^ expected `isize`, found `u64`
    |
-help: you can convert an `u64` to `isize` and panic if the converted value wouldn't fit
+help: you can convert a `u64` to `isize` and panic if the converted value wouldn't fit
    |
 LL |     foo::<isize>(x_u64.try_into().unwrap());
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -121,7 +121,7 @@ error[E0308]: mismatched types
 LL |     foo::<isize>(x_u32);
    |                  ^^^^^ expected `isize`, found `u32`
    |
-help: you can convert an `u32` to `isize` and panic if the converted value wouldn't fit
+help: you can convert a `u32` to `isize` and panic if the converted value wouldn't fit
    |
 LL |     foo::<isize>(x_u32.try_into().unwrap());
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -132,7 +132,7 @@ error[E0308]: mismatched types
 LL |     foo::<isize>(x_u16);
    |                  ^^^^^ expected `isize`, found `u16`
    |
-help: you can convert an `u16` to `isize` and panic if the converted value wouldn't fit
+help: you can convert a `u16` to `isize` and panic if the converted value wouldn't fit
    |
 LL |     foo::<isize>(x_u16.try_into().unwrap());
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -144,7 +144,7 @@ LL |     foo::<isize>(x_u8);
    |                  ^^^^
    |                  |
    |                  expected `isize`, found `u8`
-   |                  help: you can convert an `u8` to `isize`: `x_u8.into()`
+   |                  help: you can convert a `u8` to `isize`: `x_u8.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:55:18
@@ -192,7 +192,7 @@ error[E0308]: mismatched types
 LL |     foo::<u64>(x_usize);
    |                ^^^^^^^ expected `u64`, found `usize`
    |
-help: you can convert an `usize` to `u64` and panic if the converted value wouldn't fit
+help: you can convert a `usize` to `u64` and panic if the converted value wouldn't fit
    |
 LL |     foo::<u64>(x_usize.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -204,7 +204,7 @@ LL |     foo::<u64>(x_u32);
    |                ^^^^^
    |                |
    |                expected `u64`, found `u32`
-   |                help: you can convert an `u32` to `u64`: `x_u32.into()`
+   |                help: you can convert a `u32` to `u64`: `x_u32.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:71:16
@@ -213,7 +213,7 @@ LL |     foo::<u64>(x_u16);
    |                ^^^^^
    |                |
    |                expected `u64`, found `u16`
-   |                help: you can convert an `u16` to `u64`: `x_u16.into()`
+   |                help: you can convert a `u16` to `u64`: `x_u16.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:73:16
@@ -222,7 +222,7 @@ LL |     foo::<u64>(x_u8);
    |                ^^^^
    |                |
    |                expected `u64`, found `u8`
-   |                help: you can convert an `u8` to `u64`: `x_u8.into()`
+   |                help: you can convert a `u8` to `u64`: `x_u8.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:75:16
@@ -285,7 +285,7 @@ error[E0308]: mismatched types
 LL |     foo::<i64>(x_usize);
    |                ^^^^^^^ expected `i64`, found `usize`
    |
-help: you can convert an `usize` to `i64` and panic if the converted value wouldn't fit
+help: you can convert a `usize` to `i64` and panic if the converted value wouldn't fit
    |
 LL |     foo::<i64>(x_usize.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -296,7 +296,7 @@ error[E0308]: mismatched types
 LL |     foo::<i64>(x_u64);
    |                ^^^^^ expected `i64`, found `u64`
    |
-help: you can convert an `u64` to `i64` and panic if the converted value wouldn't fit
+help: you can convert a `u64` to `i64` and panic if the converted value wouldn't fit
    |
 LL |     foo::<i64>(x_u64.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -308,7 +308,7 @@ LL |     foo::<i64>(x_u32);
    |                ^^^^^
    |                |
    |                expected `i64`, found `u32`
-   |                help: you can convert an `u32` to `i64`: `x_u32.into()`
+   |                help: you can convert a `u32` to `i64`: `x_u32.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:94:16
@@ -317,7 +317,7 @@ LL |     foo::<i64>(x_u16);
    |                ^^^^^
    |                |
    |                expected `i64`, found `u16`
-   |                help: you can convert an `u16` to `i64`: `x_u16.into()`
+   |                help: you can convert a `u16` to `i64`: `x_u16.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:96:16
@@ -326,7 +326,7 @@ LL |     foo::<i64>(x_u8);
    |                ^^^^
    |                |
    |                expected `i64`, found `u8`
-   |                help: you can convert an `u8` to `i64`: `x_u8.into()`
+   |                help: you can convert a `u8` to `i64`: `x_u8.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:98:16
@@ -372,7 +372,7 @@ error[E0308]: mismatched types
 LL |     foo::<u32>(x_usize);
    |                ^^^^^^^ expected `u32`, found `usize`
    |
-help: you can convert an `usize` to `u32` and panic if the converted value wouldn't fit
+help: you can convert a `usize` to `u32` and panic if the converted value wouldn't fit
    |
 LL |     foo::<u32>(x_usize.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -383,7 +383,7 @@ error[E0308]: mismatched types
 LL |     foo::<u32>(x_u64);
    |                ^^^^^ expected `u32`, found `u64`
    |
-help: you can convert an `u64` to `u32` and panic if the converted value wouldn't fit
+help: you can convert a `u64` to `u32` and panic if the converted value wouldn't fit
    |
 LL |     foo::<u32>(x_u64.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -395,7 +395,7 @@ LL |     foo::<u32>(x_u16);
    |                ^^^^^
    |                |
    |                expected `u32`, found `u16`
-   |                help: you can convert an `u16` to `u32`: `x_u16.into()`
+   |                help: you can convert a `u16` to `u32`: `x_u16.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:117:16
@@ -404,7 +404,7 @@ LL |     foo::<u32>(x_u8);
    |                ^^^^
    |                |
    |                expected `u32`, found `u8`
-   |                help: you can convert an `u8` to `u32`: `x_u8.into()`
+   |                help: you can convert a `u8` to `u32`: `x_u8.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:119:16
@@ -467,7 +467,7 @@ error[E0308]: mismatched types
 LL |     foo::<i32>(x_usize);
    |                ^^^^^^^ expected `i32`, found `usize`
    |
-help: you can convert an `usize` to `i32` and panic if the converted value wouldn't fit
+help: you can convert a `usize` to `i32` and panic if the converted value wouldn't fit
    |
 LL |     foo::<i32>(x_usize.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -478,7 +478,7 @@ error[E0308]: mismatched types
 LL |     foo::<i32>(x_u64);
    |                ^^^^^ expected `i32`, found `u64`
    |
-help: you can convert an `u64` to `i32` and panic if the converted value wouldn't fit
+help: you can convert a `u64` to `i32` and panic if the converted value wouldn't fit
    |
 LL |     foo::<i32>(x_u64.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -489,7 +489,7 @@ error[E0308]: mismatched types
 LL |     foo::<i32>(x_u32);
    |                ^^^^^ expected `i32`, found `u32`
    |
-help: you can convert an `u32` to `i32` and panic if the converted value wouldn't fit
+help: you can convert a `u32` to `i32` and panic if the converted value wouldn't fit
    |
 LL |     foo::<i32>(x_u32.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -501,7 +501,7 @@ LL |     foo::<i32>(x_u16);
    |                ^^^^^
    |                |
    |                expected `i32`, found `u16`
-   |                help: you can convert an `u16` to `i32`: `x_u16.into()`
+   |                help: you can convert a `u16` to `i32`: `x_u16.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:140:16
@@ -510,7 +510,7 @@ LL |     foo::<i32>(x_u8);
    |                ^^^^
    |                |
    |                expected `i32`, found `u8`
-   |                help: you can convert an `u8` to `i32`: `x_u8.into()`
+   |                help: you can convert a `u8` to `i32`: `x_u8.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:142:16
@@ -558,7 +558,7 @@ error[E0308]: mismatched types
 LL |     foo::<u16>(x_usize);
    |                ^^^^^^^ expected `u16`, found `usize`
    |
-help: you can convert an `usize` to `u16` and panic if the converted value wouldn't fit
+help: you can convert a `usize` to `u16` and panic if the converted value wouldn't fit
    |
 LL |     foo::<u16>(x_usize.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -569,7 +569,7 @@ error[E0308]: mismatched types
 LL |     foo::<u16>(x_u64);
    |                ^^^^^ expected `u16`, found `u64`
    |
-help: you can convert an `u64` to `u16` and panic if the converted value wouldn't fit
+help: you can convert a `u64` to `u16` and panic if the converted value wouldn't fit
    |
 LL |     foo::<u16>(x_u64.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -580,7 +580,7 @@ error[E0308]: mismatched types
 LL |     foo::<u16>(x_u32);
    |                ^^^^^ expected `u16`, found `u32`
    |
-help: you can convert an `u32` to `u16` and panic if the converted value wouldn't fit
+help: you can convert a `u32` to `u16` and panic if the converted value wouldn't fit
    |
 LL |     foo::<u16>(x_u32.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -592,7 +592,7 @@ LL |     foo::<u16>(x_u8);
    |                ^^^^
    |                |
    |                expected `u16`, found `u8`
-   |                help: you can convert an `u8` to `u16`: `x_u8.into()`
+   |                help: you can convert a `u8` to `u16`: `x_u8.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:163:16
@@ -655,7 +655,7 @@ error[E0308]: mismatched types
 LL |     foo::<i16>(x_usize);
    |                ^^^^^^^ expected `i16`, found `usize`
    |
-help: you can convert an `usize` to `i16` and panic if the converted value wouldn't fit
+help: you can convert a `usize` to `i16` and panic if the converted value wouldn't fit
    |
 LL |     foo::<i16>(x_usize.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -666,7 +666,7 @@ error[E0308]: mismatched types
 LL |     foo::<i16>(x_u64);
    |                ^^^^^ expected `i16`, found `u64`
    |
-help: you can convert an `u64` to `i16` and panic if the converted value wouldn't fit
+help: you can convert a `u64` to `i16` and panic if the converted value wouldn't fit
    |
 LL |     foo::<i16>(x_u64.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -677,7 +677,7 @@ error[E0308]: mismatched types
 LL |     foo::<i16>(x_u32);
    |                ^^^^^ expected `i16`, found `u32`
    |
-help: you can convert an `u32` to `i16` and panic if the converted value wouldn't fit
+help: you can convert a `u32` to `i16` and panic if the converted value wouldn't fit
    |
 LL |     foo::<i16>(x_u32.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -688,7 +688,7 @@ error[E0308]: mismatched types
 LL |     foo::<i16>(x_u16);
    |                ^^^^^ expected `i16`, found `u16`
    |
-help: you can convert an `u16` to `i16` and panic if the converted value wouldn't fit
+help: you can convert a `u16` to `i16` and panic if the converted value wouldn't fit
    |
 LL |     foo::<i16>(x_u16.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -700,7 +700,7 @@ LL |     foo::<i16>(x_u8);
    |                ^^^^
    |                |
    |                expected `i16`, found `u8`
-   |                help: you can convert an `u8` to `i16`: `x_u8.into()`
+   |                help: you can convert a `u8` to `i16`: `x_u8.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:186:16
@@ -750,7 +750,7 @@ error[E0308]: mismatched types
 LL |     foo::<u8>(x_usize);
    |               ^^^^^^^ expected `u8`, found `usize`
    |
-help: you can convert an `usize` to `u8` and panic if the converted value wouldn't fit
+help: you can convert a `usize` to `u8` and panic if the converted value wouldn't fit
    |
 LL |     foo::<u8>(x_usize.try_into().unwrap());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -761,7 +761,7 @@ error[E0308]: mismatched types
 LL |     foo::<u8>(x_u64);
    |               ^^^^^ expected `u8`, found `u64`
    |
-help: you can convert an `u64` to `u8` and panic if the converted value wouldn't fit
+help: you can convert a `u64` to `u8` and panic if the converted value wouldn't fit
    |
 LL |     foo::<u8>(x_u64.try_into().unwrap());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -772,7 +772,7 @@ error[E0308]: mismatched types
 LL |     foo::<u8>(x_u32);
    |               ^^^^^ expected `u8`, found `u32`
    |
-help: you can convert an `u32` to `u8` and panic if the converted value wouldn't fit
+help: you can convert a `u32` to `u8` and panic if the converted value wouldn't fit
    |
 LL |     foo::<u8>(x_u32.try_into().unwrap());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -783,7 +783,7 @@ error[E0308]: mismatched types
 LL |     foo::<u8>(x_u16);
    |               ^^^^^ expected `u8`, found `u16`
    |
-help: you can convert an `u16` to `u8` and panic if the converted value wouldn't fit
+help: you can convert a `u16` to `u8` and panic if the converted value wouldn't fit
    |
 LL |     foo::<u8>(x_u16.try_into().unwrap());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -849,7 +849,7 @@ error[E0308]: mismatched types
 LL |     foo::<i8>(x_usize);
    |               ^^^^^^^ expected `i8`, found `usize`
    |
-help: you can convert an `usize` to `i8` and panic if the converted value wouldn't fit
+help: you can convert a `usize` to `i8` and panic if the converted value wouldn't fit
    |
 LL |     foo::<i8>(x_usize.try_into().unwrap());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -860,7 +860,7 @@ error[E0308]: mismatched types
 LL |     foo::<i8>(x_u64);
    |               ^^^^^ expected `i8`, found `u64`
    |
-help: you can convert an `u64` to `i8` and panic if the converted value wouldn't fit
+help: you can convert a `u64` to `i8` and panic if the converted value wouldn't fit
    |
 LL |     foo::<i8>(x_u64.try_into().unwrap());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -871,7 +871,7 @@ error[E0308]: mismatched types
 LL |     foo::<i8>(x_u32);
    |               ^^^^^ expected `i8`, found `u32`
    |
-help: you can convert an `u32` to `i8` and panic if the converted value wouldn't fit
+help: you can convert a `u32` to `i8` and panic if the converted value wouldn't fit
    |
 LL |     foo::<i8>(x_u32.try_into().unwrap());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -882,7 +882,7 @@ error[E0308]: mismatched types
 LL |     foo::<i8>(x_u16);
    |               ^^^^^ expected `i8`, found `u16`
    |
-help: you can convert an `u16` to `i8` and panic if the converted value wouldn't fit
+help: you can convert a `u16` to `i8` and panic if the converted value wouldn't fit
    |
 LL |     foo::<i8>(x_u16.try_into().unwrap());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -893,7 +893,7 @@ error[E0308]: mismatched types
 LL |     foo::<i8>(x_u8);
    |               ^^^^ expected `i8`, found `u8`
    |
-help: you can convert an `u8` to `i8` and panic if the converted value wouldn't fit
+help: you can convert a `u8` to `i8` and panic if the converted value wouldn't fit
    |
 LL |     foo::<i8>(x_u8.try_into().unwrap());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -948,7 +948,7 @@ error[E0308]: mismatched types
 LL |     foo::<f64>(x_usize);
    |                ^^^^^^^ expected `f64`, found `usize`
    |
-help: you can cast an `usize to `f64`, producing the floating point representation of the integer,
+help: you can cast a `usize to `f64`, producing the floating point representation of the integer,
    |                                              rounded if necessary
 LL |     foo::<f64>(x_usize as f64);
    |                ^^^^^^^^^^^^^^
@@ -959,7 +959,7 @@ error[E0308]: mismatched types
 LL |     foo::<f64>(x_u64);
    |                ^^^^^ expected `f64`, found `u64`
    |
-help: you can cast an `u64 to `f64`, producing the floating point representation of the integer,
+help: you can cast a `u64 to `f64`, producing the floating point representation of the integer,
    |                                              rounded if necessary
 LL |     foo::<f64>(x_u64 as f64);
    |                ^^^^^^^^^^^^
@@ -970,7 +970,7 @@ error[E0308]: mismatched types
 LL |     foo::<f64>(x_u32);
    |                ^^^^^ expected `f64`, found `u32`
    |
-help: you can convert an `u32` to `f64`, producing the floating point representation of the integer
+help: you can convert a `u32` to `f64`, producing the floating point representation of the integer
    |
 LL |     foo::<f64>(x_u32.into());
    |                ^^^^^^^^^^^^
@@ -981,7 +981,7 @@ error[E0308]: mismatched types
 LL |     foo::<f64>(x_u16);
    |                ^^^^^ expected `f64`, found `u16`
    |
-help: you can convert an `u16` to `f64`, producing the floating point representation of the integer
+help: you can convert a `u16` to `f64`, producing the floating point representation of the integer
    |
 LL |     foo::<f64>(x_u16.into());
    |                ^^^^^^^^^^^^
@@ -992,7 +992,7 @@ error[E0308]: mismatched types
 LL |     foo::<f64>(x_u8);
    |                ^^^^ expected `f64`, found `u8`
    |
-help: you can convert an `u8` to `f64`, producing the floating point representation of the integer
+help: you can convert a `u8` to `f64`, producing the floating point representation of the integer
    |
 LL |     foo::<f64>(x_u8.into());
    |                ^^^^^^^^^^^
@@ -1067,7 +1067,7 @@ error[E0308]: mismatched types
 LL |     foo::<f32>(x_usize);
    |                ^^^^^^^ expected `f32`, found `usize`
    |
-help: you can cast an `usize to `f32`, producing the floating point representation of the integer,
+help: you can cast a `usize to `f32`, producing the floating point representation of the integer,
    |                                              rounded if necessary
 LL |     foo::<f32>(x_usize as f32);
    |                ^^^^^^^^^^^^^^
@@ -1078,7 +1078,7 @@ error[E0308]: mismatched types
 LL |     foo::<f32>(x_u64);
    |                ^^^^^ expected `f32`, found `u64`
    |
-help: you can cast an `u64 to `f32`, producing the floating point representation of the integer,
+help: you can cast a `u64 to `f32`, producing the floating point representation of the integer,
    |                                              rounded if necessary
 LL |     foo::<f32>(x_u64 as f32);
    |                ^^^^^^^^^^^^
@@ -1089,7 +1089,7 @@ error[E0308]: mismatched types
 LL |     foo::<f32>(x_u32);
    |                ^^^^^ expected `f32`, found `u32`
    |
-help: you can cast an `u32 to `f32`, producing the floating point representation of the integer,
+help: you can cast a `u32 to `f32`, producing the floating point representation of the integer,
    |                                              rounded if necessary
 LL |     foo::<f32>(x_u32 as f32);
    |                ^^^^^^^^^^^^
@@ -1100,7 +1100,7 @@ error[E0308]: mismatched types
 LL |     foo::<f32>(x_u16);
    |                ^^^^^ expected `f32`, found `u16`
    |
-help: you can convert an `u16` to `f32`, producing the floating point representation of the integer
+help: you can convert a `u16` to `f32`, producing the floating point representation of the integer
    |
 LL |     foo::<f32>(x_u16.into());
    |                ^^^^^^^^^^^^
@@ -1111,7 +1111,7 @@ error[E0308]: mismatched types
 LL |     foo::<f32>(x_u8);
    |                ^^^^ expected `f32`, found `u8`
    |
-help: you can convert an `u8` to `f32`, producing the floating point representation of the integer
+help: you can convert a `u8` to `f32`, producing the floating point representation of the integer
    |
 LL |     foo::<f32>(x_u8.into());
    |                ^^^^^^^^^^^
@@ -1178,7 +1178,7 @@ LL |     foo::<u32>(x_u8 as u16);
    |                ^^^^^^^^^^^
    |                |
    |                expected `u32`, found `u16`
-   |                help: you can convert an `u16` to `u32`: `(x_u8 as u16).into()`
+   |                help: you can convert a `u16` to `u32`: `(x_u8 as u16).into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:291:16

--- a/src/test/ui/numeric/numeric-cast.stderr
+++ b/src/test/ui/numeric/numeric-cast.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL |     foo::<usize>(x_u64);
    |                  ^^^^^ expected `usize`, found `u64`
    |
-help: you can convert a `u64` to `usize` and panic if the converted value wouldn't fit
+help: you can convert a `u64` to a `usize` and panic if the converted value wouldn't fit
    |
 LL |     foo::<usize>(x_u64.try_into().unwrap());
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -15,7 +15,7 @@ error[E0308]: mismatched types
 LL |     foo::<usize>(x_u32);
    |                  ^^^^^ expected `usize`, found `u32`
    |
-help: you can convert a `u32` to `usize` and panic if the converted value wouldn't fit
+help: you can convert a `u32` to a `usize` and panic if the converted value wouldn't fit
    |
 LL |     foo::<usize>(x_u32.try_into().unwrap());
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -27,7 +27,7 @@ LL |     foo::<usize>(x_u16);
    |                  ^^^^^
    |                  |
    |                  expected `usize`, found `u16`
-   |                  help: you can convert a `u16` to `usize`: `x_u16.into()`
+   |                  help: you can convert a `u16` to a `usize`: `x_u16.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:29:18
@@ -36,7 +36,7 @@ LL |     foo::<usize>(x_u8);
    |                  ^^^^
    |                  |
    |                  expected `usize`, found `u8`
-   |                  help: you can convert a `u8` to `usize`: `x_u8.into()`
+   |                  help: you can convert a `u8` to a `usize`: `x_u8.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:31:18
@@ -44,7 +44,7 @@ error[E0308]: mismatched types
 LL |     foo::<usize>(x_isize);
    |                  ^^^^^^^ expected `usize`, found `isize`
    |
-help: you can convert an `isize` to `usize` and panic if the converted value wouldn't fit
+help: you can convert an `isize` to a `usize` and panic if the converted value wouldn't fit
    |
 LL |     foo::<usize>(x_isize.try_into().unwrap());
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -55,7 +55,7 @@ error[E0308]: mismatched types
 LL |     foo::<usize>(x_i64);
    |                  ^^^^^ expected `usize`, found `i64`
    |
-help: you can convert an `i64` to `usize` and panic if the converted value wouldn't fit
+help: you can convert an `i64` to a `usize` and panic if the converted value wouldn't fit
    |
 LL |     foo::<usize>(x_i64.try_into().unwrap());
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -66,7 +66,7 @@ error[E0308]: mismatched types
 LL |     foo::<usize>(x_i32);
    |                  ^^^^^ expected `usize`, found `i32`
    |
-help: you can convert an `i32` to `usize` and panic if the converted value wouldn't fit
+help: you can convert an `i32` to a `usize` and panic if the converted value wouldn't fit
    |
 LL |     foo::<usize>(x_i32.try_into().unwrap());
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -77,7 +77,7 @@ error[E0308]: mismatched types
 LL |     foo::<usize>(x_i16);
    |                  ^^^^^ expected `usize`, found `i16`
    |
-help: you can convert an `i16` to `usize` and panic if the converted value wouldn't fit
+help: you can convert an `i16` to a `usize` and panic if the converted value wouldn't fit
    |
 LL |     foo::<usize>(x_i16.try_into().unwrap());
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -88,7 +88,7 @@ error[E0308]: mismatched types
 LL |     foo::<usize>(x_i8);
    |                  ^^^^ expected `usize`, found `i8`
    |
-help: you can convert an `i8` to `usize` and panic if the converted value wouldn't fit
+help: you can convert an `i8` to a `usize` and panic if the converted value wouldn't fit
    |
 LL |     foo::<usize>(x_i8.try_into().unwrap());
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -99,7 +99,7 @@ error[E0308]: mismatched types
 LL |     foo::<isize>(x_usize);
    |                  ^^^^^^^ expected `isize`, found `usize`
    |
-help: you can convert a `usize` to `isize` and panic if the converted value wouldn't fit
+help: you can convert a `usize` to an `isize` and panic if the converted value wouldn't fit
    |
 LL |     foo::<isize>(x_usize.try_into().unwrap());
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -110,7 +110,7 @@ error[E0308]: mismatched types
 LL |     foo::<isize>(x_u64);
    |                  ^^^^^ expected `isize`, found `u64`
    |
-help: you can convert a `u64` to `isize` and panic if the converted value wouldn't fit
+help: you can convert a `u64` to an `isize` and panic if the converted value wouldn't fit
    |
 LL |     foo::<isize>(x_u64.try_into().unwrap());
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -121,7 +121,7 @@ error[E0308]: mismatched types
 LL |     foo::<isize>(x_u32);
    |                  ^^^^^ expected `isize`, found `u32`
    |
-help: you can convert a `u32` to `isize` and panic if the converted value wouldn't fit
+help: you can convert a `u32` to an `isize` and panic if the converted value wouldn't fit
    |
 LL |     foo::<isize>(x_u32.try_into().unwrap());
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -132,7 +132,7 @@ error[E0308]: mismatched types
 LL |     foo::<isize>(x_u16);
    |                  ^^^^^ expected `isize`, found `u16`
    |
-help: you can convert a `u16` to `isize` and panic if the converted value wouldn't fit
+help: you can convert a `u16` to an `isize` and panic if the converted value wouldn't fit
    |
 LL |     foo::<isize>(x_u16.try_into().unwrap());
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -144,7 +144,7 @@ LL |     foo::<isize>(x_u8);
    |                  ^^^^
    |                  |
    |                  expected `isize`, found `u8`
-   |                  help: you can convert a `u8` to `isize`: `x_u8.into()`
+   |                  help: you can convert a `u8` to an `isize`: `x_u8.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:55:18
@@ -152,7 +152,7 @@ error[E0308]: mismatched types
 LL |     foo::<isize>(x_i64);
    |                  ^^^^^ expected `isize`, found `i64`
    |
-help: you can convert an `i64` to `isize` and panic if the converted value wouldn't fit
+help: you can convert an `i64` to an `isize` and panic if the converted value wouldn't fit
    |
 LL |     foo::<isize>(x_i64.try_into().unwrap());
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -163,7 +163,7 @@ error[E0308]: mismatched types
 LL |     foo::<isize>(x_i32);
    |                  ^^^^^ expected `isize`, found `i32`
    |
-help: you can convert an `i32` to `isize` and panic if the converted value wouldn't fit
+help: you can convert an `i32` to an `isize` and panic if the converted value wouldn't fit
    |
 LL |     foo::<isize>(x_i32.try_into().unwrap());
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -175,7 +175,7 @@ LL |     foo::<isize>(x_i16);
    |                  ^^^^^
    |                  |
    |                  expected `isize`, found `i16`
-   |                  help: you can convert an `i16` to `isize`: `x_i16.into()`
+   |                  help: you can convert an `i16` to an `isize`: `x_i16.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:61:18
@@ -184,7 +184,7 @@ LL |     foo::<isize>(x_i8);
    |                  ^^^^
    |                  |
    |                  expected `isize`, found `i8`
-   |                  help: you can convert an `i8` to `isize`: `x_i8.into()`
+   |                  help: you can convert an `i8` to an `isize`: `x_i8.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:66:16
@@ -192,7 +192,7 @@ error[E0308]: mismatched types
 LL |     foo::<u64>(x_usize);
    |                ^^^^^^^ expected `u64`, found `usize`
    |
-help: you can convert a `usize` to `u64` and panic if the converted value wouldn't fit
+help: you can convert a `usize` to a `u64` and panic if the converted value wouldn't fit
    |
 LL |     foo::<u64>(x_usize.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -204,7 +204,7 @@ LL |     foo::<u64>(x_u32);
    |                ^^^^^
    |                |
    |                expected `u64`, found `u32`
-   |                help: you can convert a `u32` to `u64`: `x_u32.into()`
+   |                help: you can convert a `u32` to a `u64`: `x_u32.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:71:16
@@ -213,7 +213,7 @@ LL |     foo::<u64>(x_u16);
    |                ^^^^^
    |                |
    |                expected `u64`, found `u16`
-   |                help: you can convert a `u16` to `u64`: `x_u16.into()`
+   |                help: you can convert a `u16` to a `u64`: `x_u16.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:73:16
@@ -222,7 +222,7 @@ LL |     foo::<u64>(x_u8);
    |                ^^^^
    |                |
    |                expected `u64`, found `u8`
-   |                help: you can convert a `u8` to `u64`: `x_u8.into()`
+   |                help: you can convert a `u8` to a `u64`: `x_u8.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:75:16
@@ -230,7 +230,7 @@ error[E0308]: mismatched types
 LL |     foo::<u64>(x_isize);
    |                ^^^^^^^ expected `u64`, found `isize`
    |
-help: you can convert an `isize` to `u64` and panic if the converted value wouldn't fit
+help: you can convert an `isize` to a `u64` and panic if the converted value wouldn't fit
    |
 LL |     foo::<u64>(x_isize.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -241,7 +241,7 @@ error[E0308]: mismatched types
 LL |     foo::<u64>(x_i64);
    |                ^^^^^ expected `u64`, found `i64`
    |
-help: you can convert an `i64` to `u64` and panic if the converted value wouldn't fit
+help: you can convert an `i64` to a `u64` and panic if the converted value wouldn't fit
    |
 LL |     foo::<u64>(x_i64.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -252,7 +252,7 @@ error[E0308]: mismatched types
 LL |     foo::<u64>(x_i32);
    |                ^^^^^ expected `u64`, found `i32`
    |
-help: you can convert an `i32` to `u64` and panic if the converted value wouldn't fit
+help: you can convert an `i32` to a `u64` and panic if the converted value wouldn't fit
    |
 LL |     foo::<u64>(x_i32.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -263,7 +263,7 @@ error[E0308]: mismatched types
 LL |     foo::<u64>(x_i16);
    |                ^^^^^ expected `u64`, found `i16`
    |
-help: you can convert an `i16` to `u64` and panic if the converted value wouldn't fit
+help: you can convert an `i16` to a `u64` and panic if the converted value wouldn't fit
    |
 LL |     foo::<u64>(x_i16.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -274,7 +274,7 @@ error[E0308]: mismatched types
 LL |     foo::<u64>(x_i8);
    |                ^^^^ expected `u64`, found `i8`
    |
-help: you can convert an `i8` to `u64` and panic if the converted value wouldn't fit
+help: you can convert an `i8` to a `u64` and panic if the converted value wouldn't fit
    |
 LL |     foo::<u64>(x_i8.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -285,7 +285,7 @@ error[E0308]: mismatched types
 LL |     foo::<i64>(x_usize);
    |                ^^^^^^^ expected `i64`, found `usize`
    |
-help: you can convert a `usize` to `i64` and panic if the converted value wouldn't fit
+help: you can convert a `usize` to an `i64` and panic if the converted value wouldn't fit
    |
 LL |     foo::<i64>(x_usize.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -296,7 +296,7 @@ error[E0308]: mismatched types
 LL |     foo::<i64>(x_u64);
    |                ^^^^^ expected `i64`, found `u64`
    |
-help: you can convert a `u64` to `i64` and panic if the converted value wouldn't fit
+help: you can convert a `u64` to an `i64` and panic if the converted value wouldn't fit
    |
 LL |     foo::<i64>(x_u64.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -308,7 +308,7 @@ LL |     foo::<i64>(x_u32);
    |                ^^^^^
    |                |
    |                expected `i64`, found `u32`
-   |                help: you can convert a `u32` to `i64`: `x_u32.into()`
+   |                help: you can convert a `u32` to an `i64`: `x_u32.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:94:16
@@ -317,7 +317,7 @@ LL |     foo::<i64>(x_u16);
    |                ^^^^^
    |                |
    |                expected `i64`, found `u16`
-   |                help: you can convert a `u16` to `i64`: `x_u16.into()`
+   |                help: you can convert a `u16` to an `i64`: `x_u16.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:96:16
@@ -326,7 +326,7 @@ LL |     foo::<i64>(x_u8);
    |                ^^^^
    |                |
    |                expected `i64`, found `u8`
-   |                help: you can convert a `u8` to `i64`: `x_u8.into()`
+   |                help: you can convert a `u8` to an `i64`: `x_u8.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:98:16
@@ -334,7 +334,7 @@ error[E0308]: mismatched types
 LL |     foo::<i64>(x_isize);
    |                ^^^^^^^ expected `i64`, found `isize`
    |
-help: you can convert an `isize` to `i64` and panic if the converted value wouldn't fit
+help: you can convert an `isize` to an `i64` and panic if the converted value wouldn't fit
    |
 LL |     foo::<i64>(x_isize.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -346,7 +346,7 @@ LL |     foo::<i64>(x_i32);
    |                ^^^^^
    |                |
    |                expected `i64`, found `i32`
-   |                help: you can convert an `i32` to `i64`: `x_i32.into()`
+   |                help: you can convert an `i32` to an `i64`: `x_i32.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:103:16
@@ -355,7 +355,7 @@ LL |     foo::<i64>(x_i16);
    |                ^^^^^
    |                |
    |                expected `i64`, found `i16`
-   |                help: you can convert an `i16` to `i64`: `x_i16.into()`
+   |                help: you can convert an `i16` to an `i64`: `x_i16.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:105:16
@@ -364,7 +364,7 @@ LL |     foo::<i64>(x_i8);
    |                ^^^^
    |                |
    |                expected `i64`, found `i8`
-   |                help: you can convert an `i8` to `i64`: `x_i8.into()`
+   |                help: you can convert an `i8` to an `i64`: `x_i8.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:110:16
@@ -372,7 +372,7 @@ error[E0308]: mismatched types
 LL |     foo::<u32>(x_usize);
    |                ^^^^^^^ expected `u32`, found `usize`
    |
-help: you can convert a `usize` to `u32` and panic if the converted value wouldn't fit
+help: you can convert a `usize` to a `u32` and panic if the converted value wouldn't fit
    |
 LL |     foo::<u32>(x_usize.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -383,7 +383,7 @@ error[E0308]: mismatched types
 LL |     foo::<u32>(x_u64);
    |                ^^^^^ expected `u32`, found `u64`
    |
-help: you can convert a `u64` to `u32` and panic if the converted value wouldn't fit
+help: you can convert a `u64` to a `u32` and panic if the converted value wouldn't fit
    |
 LL |     foo::<u32>(x_u64.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -395,7 +395,7 @@ LL |     foo::<u32>(x_u16);
    |                ^^^^^
    |                |
    |                expected `u32`, found `u16`
-   |                help: you can convert a `u16` to `u32`: `x_u16.into()`
+   |                help: you can convert a `u16` to a `u32`: `x_u16.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:117:16
@@ -404,7 +404,7 @@ LL |     foo::<u32>(x_u8);
    |                ^^^^
    |                |
    |                expected `u32`, found `u8`
-   |                help: you can convert a `u8` to `u32`: `x_u8.into()`
+   |                help: you can convert a `u8` to a `u32`: `x_u8.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:119:16
@@ -412,7 +412,7 @@ error[E0308]: mismatched types
 LL |     foo::<u32>(x_isize);
    |                ^^^^^^^ expected `u32`, found `isize`
    |
-help: you can convert an `isize` to `u32` and panic if the converted value wouldn't fit
+help: you can convert an `isize` to a `u32` and panic if the converted value wouldn't fit
    |
 LL |     foo::<u32>(x_isize.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -423,7 +423,7 @@ error[E0308]: mismatched types
 LL |     foo::<u32>(x_i64);
    |                ^^^^^ expected `u32`, found `i64`
    |
-help: you can convert an `i64` to `u32` and panic if the converted value wouldn't fit
+help: you can convert an `i64` to a `u32` and panic if the converted value wouldn't fit
    |
 LL |     foo::<u32>(x_i64.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -434,7 +434,7 @@ error[E0308]: mismatched types
 LL |     foo::<u32>(x_i32);
    |                ^^^^^ expected `u32`, found `i32`
    |
-help: you can convert an `i32` to `u32` and panic if the converted value wouldn't fit
+help: you can convert an `i32` to a `u32` and panic if the converted value wouldn't fit
    |
 LL |     foo::<u32>(x_i32.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -445,7 +445,7 @@ error[E0308]: mismatched types
 LL |     foo::<u32>(x_i16);
    |                ^^^^^ expected `u32`, found `i16`
    |
-help: you can convert an `i16` to `u32` and panic if the converted value wouldn't fit
+help: you can convert an `i16` to a `u32` and panic if the converted value wouldn't fit
    |
 LL |     foo::<u32>(x_i16.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -456,7 +456,7 @@ error[E0308]: mismatched types
 LL |     foo::<u32>(x_i8);
    |                ^^^^ expected `u32`, found `i8`
    |
-help: you can convert an `i8` to `u32` and panic if the converted value wouldn't fit
+help: you can convert an `i8` to a `u32` and panic if the converted value wouldn't fit
    |
 LL |     foo::<u32>(x_i8.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -467,7 +467,7 @@ error[E0308]: mismatched types
 LL |     foo::<i32>(x_usize);
    |                ^^^^^^^ expected `i32`, found `usize`
    |
-help: you can convert a `usize` to `i32` and panic if the converted value wouldn't fit
+help: you can convert a `usize` to an `i32` and panic if the converted value wouldn't fit
    |
 LL |     foo::<i32>(x_usize.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -478,7 +478,7 @@ error[E0308]: mismatched types
 LL |     foo::<i32>(x_u64);
    |                ^^^^^ expected `i32`, found `u64`
    |
-help: you can convert a `u64` to `i32` and panic if the converted value wouldn't fit
+help: you can convert a `u64` to an `i32` and panic if the converted value wouldn't fit
    |
 LL |     foo::<i32>(x_u64.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -489,7 +489,7 @@ error[E0308]: mismatched types
 LL |     foo::<i32>(x_u32);
    |                ^^^^^ expected `i32`, found `u32`
    |
-help: you can convert a `u32` to `i32` and panic if the converted value wouldn't fit
+help: you can convert a `u32` to an `i32` and panic if the converted value wouldn't fit
    |
 LL |     foo::<i32>(x_u32.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -501,7 +501,7 @@ LL |     foo::<i32>(x_u16);
    |                ^^^^^
    |                |
    |                expected `i32`, found `u16`
-   |                help: you can convert a `u16` to `i32`: `x_u16.into()`
+   |                help: you can convert a `u16` to an `i32`: `x_u16.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:140:16
@@ -510,7 +510,7 @@ LL |     foo::<i32>(x_u8);
    |                ^^^^
    |                |
    |                expected `i32`, found `u8`
-   |                help: you can convert a `u8` to `i32`: `x_u8.into()`
+   |                help: you can convert a `u8` to an `i32`: `x_u8.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:142:16
@@ -518,7 +518,7 @@ error[E0308]: mismatched types
 LL |     foo::<i32>(x_isize);
    |                ^^^^^^^ expected `i32`, found `isize`
    |
-help: you can convert an `isize` to `i32` and panic if the converted value wouldn't fit
+help: you can convert an `isize` to an `i32` and panic if the converted value wouldn't fit
    |
 LL |     foo::<i32>(x_isize.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -529,7 +529,7 @@ error[E0308]: mismatched types
 LL |     foo::<i32>(x_i64);
    |                ^^^^^ expected `i32`, found `i64`
    |
-help: you can convert an `i64` to `i32` and panic if the converted value wouldn't fit
+help: you can convert an `i64` to an `i32` and panic if the converted value wouldn't fit
    |
 LL |     foo::<i32>(x_i64.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -541,7 +541,7 @@ LL |     foo::<i32>(x_i16);
    |                ^^^^^
    |                |
    |                expected `i32`, found `i16`
-   |                help: you can convert an `i16` to `i32`: `x_i16.into()`
+   |                help: you can convert an `i16` to an `i32`: `x_i16.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:149:16
@@ -550,7 +550,7 @@ LL |     foo::<i32>(x_i8);
    |                ^^^^
    |                |
    |                expected `i32`, found `i8`
-   |                help: you can convert an `i8` to `i32`: `x_i8.into()`
+   |                help: you can convert an `i8` to an `i32`: `x_i8.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:154:16
@@ -558,7 +558,7 @@ error[E0308]: mismatched types
 LL |     foo::<u16>(x_usize);
    |                ^^^^^^^ expected `u16`, found `usize`
    |
-help: you can convert a `usize` to `u16` and panic if the converted value wouldn't fit
+help: you can convert a `usize` to a `u16` and panic if the converted value wouldn't fit
    |
 LL |     foo::<u16>(x_usize.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -569,7 +569,7 @@ error[E0308]: mismatched types
 LL |     foo::<u16>(x_u64);
    |                ^^^^^ expected `u16`, found `u64`
    |
-help: you can convert a `u64` to `u16` and panic if the converted value wouldn't fit
+help: you can convert a `u64` to a `u16` and panic if the converted value wouldn't fit
    |
 LL |     foo::<u16>(x_u64.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -580,7 +580,7 @@ error[E0308]: mismatched types
 LL |     foo::<u16>(x_u32);
    |                ^^^^^ expected `u16`, found `u32`
    |
-help: you can convert a `u32` to `u16` and panic if the converted value wouldn't fit
+help: you can convert a `u32` to a `u16` and panic if the converted value wouldn't fit
    |
 LL |     foo::<u16>(x_u32.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -592,7 +592,7 @@ LL |     foo::<u16>(x_u8);
    |                ^^^^
    |                |
    |                expected `u16`, found `u8`
-   |                help: you can convert a `u8` to `u16`: `x_u8.into()`
+   |                help: you can convert a `u8` to a `u16`: `x_u8.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:163:16
@@ -600,7 +600,7 @@ error[E0308]: mismatched types
 LL |     foo::<u16>(x_isize);
    |                ^^^^^^^ expected `u16`, found `isize`
    |
-help: you can convert an `isize` to `u16` and panic if the converted value wouldn't fit
+help: you can convert an `isize` to a `u16` and panic if the converted value wouldn't fit
    |
 LL |     foo::<u16>(x_isize.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -611,7 +611,7 @@ error[E0308]: mismatched types
 LL |     foo::<u16>(x_i64);
    |                ^^^^^ expected `u16`, found `i64`
    |
-help: you can convert an `i64` to `u16` and panic if the converted value wouldn't fit
+help: you can convert an `i64` to a `u16` and panic if the converted value wouldn't fit
    |
 LL |     foo::<u16>(x_i64.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -622,7 +622,7 @@ error[E0308]: mismatched types
 LL |     foo::<u16>(x_i32);
    |                ^^^^^ expected `u16`, found `i32`
    |
-help: you can convert an `i32` to `u16` and panic if the converted value wouldn't fit
+help: you can convert an `i32` to a `u16` and panic if the converted value wouldn't fit
    |
 LL |     foo::<u16>(x_i32.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -633,7 +633,7 @@ error[E0308]: mismatched types
 LL |     foo::<u16>(x_i16);
    |                ^^^^^ expected `u16`, found `i16`
    |
-help: you can convert an `i16` to `u16` and panic if the converted value wouldn't fit
+help: you can convert an `i16` to a `u16` and panic if the converted value wouldn't fit
    |
 LL |     foo::<u16>(x_i16.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -644,7 +644,7 @@ error[E0308]: mismatched types
 LL |     foo::<u16>(x_i8);
    |                ^^^^ expected `u16`, found `i8`
    |
-help: you can convert an `i8` to `u16` and panic if the converted value wouldn't fit
+help: you can convert an `i8` to a `u16` and panic if the converted value wouldn't fit
    |
 LL |     foo::<u16>(x_i8.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -655,7 +655,7 @@ error[E0308]: mismatched types
 LL |     foo::<i16>(x_usize);
    |                ^^^^^^^ expected `i16`, found `usize`
    |
-help: you can convert a `usize` to `i16` and panic if the converted value wouldn't fit
+help: you can convert a `usize` to an `i16` and panic if the converted value wouldn't fit
    |
 LL |     foo::<i16>(x_usize.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -666,7 +666,7 @@ error[E0308]: mismatched types
 LL |     foo::<i16>(x_u64);
    |                ^^^^^ expected `i16`, found `u64`
    |
-help: you can convert a `u64` to `i16` and panic if the converted value wouldn't fit
+help: you can convert a `u64` to an `i16` and panic if the converted value wouldn't fit
    |
 LL |     foo::<i16>(x_u64.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -677,7 +677,7 @@ error[E0308]: mismatched types
 LL |     foo::<i16>(x_u32);
    |                ^^^^^ expected `i16`, found `u32`
    |
-help: you can convert a `u32` to `i16` and panic if the converted value wouldn't fit
+help: you can convert a `u32` to an `i16` and panic if the converted value wouldn't fit
    |
 LL |     foo::<i16>(x_u32.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -688,7 +688,7 @@ error[E0308]: mismatched types
 LL |     foo::<i16>(x_u16);
    |                ^^^^^ expected `i16`, found `u16`
    |
-help: you can convert a `u16` to `i16` and panic if the converted value wouldn't fit
+help: you can convert a `u16` to an `i16` and panic if the converted value wouldn't fit
    |
 LL |     foo::<i16>(x_u16.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -700,7 +700,7 @@ LL |     foo::<i16>(x_u8);
    |                ^^^^
    |                |
    |                expected `i16`, found `u8`
-   |                help: you can convert a `u8` to `i16`: `x_u8.into()`
+   |                help: you can convert a `u8` to an `i16`: `x_u8.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:186:16
@@ -708,7 +708,7 @@ error[E0308]: mismatched types
 LL |     foo::<i16>(x_isize);
    |                ^^^^^^^ expected `i16`, found `isize`
    |
-help: you can convert an `isize` to `i16` and panic if the converted value wouldn't fit
+help: you can convert an `isize` to an `i16` and panic if the converted value wouldn't fit
    |
 LL |     foo::<i16>(x_isize.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -719,7 +719,7 @@ error[E0308]: mismatched types
 LL |     foo::<i16>(x_i64);
    |                ^^^^^ expected `i16`, found `i64`
    |
-help: you can convert an `i64` to `i16` and panic if the converted value wouldn't fit
+help: you can convert an `i64` to an `i16` and panic if the converted value wouldn't fit
    |
 LL |     foo::<i16>(x_i64.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -730,7 +730,7 @@ error[E0308]: mismatched types
 LL |     foo::<i16>(x_i32);
    |                ^^^^^ expected `i16`, found `i32`
    |
-help: you can convert an `i32` to `i16` and panic if the converted value wouldn't fit
+help: you can convert an `i32` to an `i16` and panic if the converted value wouldn't fit
    |
 LL |     foo::<i16>(x_i32.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -742,7 +742,7 @@ LL |     foo::<i16>(x_i8);
    |                ^^^^
    |                |
    |                expected `i16`, found `i8`
-   |                help: you can convert an `i8` to `i16`: `x_i8.into()`
+   |                help: you can convert an `i8` to an `i16`: `x_i8.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:198:15
@@ -750,7 +750,7 @@ error[E0308]: mismatched types
 LL |     foo::<u8>(x_usize);
    |               ^^^^^^^ expected `u8`, found `usize`
    |
-help: you can convert a `usize` to `u8` and panic if the converted value wouldn't fit
+help: you can convert a `usize` to a `u8` and panic if the converted value wouldn't fit
    |
 LL |     foo::<u8>(x_usize.try_into().unwrap());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -761,7 +761,7 @@ error[E0308]: mismatched types
 LL |     foo::<u8>(x_u64);
    |               ^^^^^ expected `u8`, found `u64`
    |
-help: you can convert a `u64` to `u8` and panic if the converted value wouldn't fit
+help: you can convert a `u64` to a `u8` and panic if the converted value wouldn't fit
    |
 LL |     foo::<u8>(x_u64.try_into().unwrap());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -772,7 +772,7 @@ error[E0308]: mismatched types
 LL |     foo::<u8>(x_u32);
    |               ^^^^^ expected `u8`, found `u32`
    |
-help: you can convert a `u32` to `u8` and panic if the converted value wouldn't fit
+help: you can convert a `u32` to a `u8` and panic if the converted value wouldn't fit
    |
 LL |     foo::<u8>(x_u32.try_into().unwrap());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -783,7 +783,7 @@ error[E0308]: mismatched types
 LL |     foo::<u8>(x_u16);
    |               ^^^^^ expected `u8`, found `u16`
    |
-help: you can convert a `u16` to `u8` and panic if the converted value wouldn't fit
+help: you can convert a `u16` to a `u8` and panic if the converted value wouldn't fit
    |
 LL |     foo::<u8>(x_u16.try_into().unwrap());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -794,7 +794,7 @@ error[E0308]: mismatched types
 LL |     foo::<u8>(x_isize);
    |               ^^^^^^^ expected `u8`, found `isize`
    |
-help: you can convert an `isize` to `u8` and panic if the converted value wouldn't fit
+help: you can convert an `isize` to a `u8` and panic if the converted value wouldn't fit
    |
 LL |     foo::<u8>(x_isize.try_into().unwrap());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -805,7 +805,7 @@ error[E0308]: mismatched types
 LL |     foo::<u8>(x_i64);
    |               ^^^^^ expected `u8`, found `i64`
    |
-help: you can convert an `i64` to `u8` and panic if the converted value wouldn't fit
+help: you can convert an `i64` to a `u8` and panic if the converted value wouldn't fit
    |
 LL |     foo::<u8>(x_i64.try_into().unwrap());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -816,7 +816,7 @@ error[E0308]: mismatched types
 LL |     foo::<u8>(x_i32);
    |               ^^^^^ expected `u8`, found `i32`
    |
-help: you can convert an `i32` to `u8` and panic if the converted value wouldn't fit
+help: you can convert an `i32` to a `u8` and panic if the converted value wouldn't fit
    |
 LL |     foo::<u8>(x_i32.try_into().unwrap());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -827,7 +827,7 @@ error[E0308]: mismatched types
 LL |     foo::<u8>(x_i16);
    |               ^^^^^ expected `u8`, found `i16`
    |
-help: you can convert an `i16` to `u8` and panic if the converted value wouldn't fit
+help: you can convert an `i16` to a `u8` and panic if the converted value wouldn't fit
    |
 LL |     foo::<u8>(x_i16.try_into().unwrap());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -838,7 +838,7 @@ error[E0308]: mismatched types
 LL |     foo::<u8>(x_i8);
    |               ^^^^ expected `u8`, found `i8`
    |
-help: you can convert an `i8` to `u8` and panic if the converted value wouldn't fit
+help: you can convert an `i8` to a `u8` and panic if the converted value wouldn't fit
    |
 LL |     foo::<u8>(x_i8.try_into().unwrap());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -849,7 +849,7 @@ error[E0308]: mismatched types
 LL |     foo::<i8>(x_usize);
    |               ^^^^^^^ expected `i8`, found `usize`
    |
-help: you can convert a `usize` to `i8` and panic if the converted value wouldn't fit
+help: you can convert a `usize` to an `i8` and panic if the converted value wouldn't fit
    |
 LL |     foo::<i8>(x_usize.try_into().unwrap());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -860,7 +860,7 @@ error[E0308]: mismatched types
 LL |     foo::<i8>(x_u64);
    |               ^^^^^ expected `i8`, found `u64`
    |
-help: you can convert a `u64` to `i8` and panic if the converted value wouldn't fit
+help: you can convert a `u64` to an `i8` and panic if the converted value wouldn't fit
    |
 LL |     foo::<i8>(x_u64.try_into().unwrap());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -871,7 +871,7 @@ error[E0308]: mismatched types
 LL |     foo::<i8>(x_u32);
    |               ^^^^^ expected `i8`, found `u32`
    |
-help: you can convert a `u32` to `i8` and panic if the converted value wouldn't fit
+help: you can convert a `u32` to an `i8` and panic if the converted value wouldn't fit
    |
 LL |     foo::<i8>(x_u32.try_into().unwrap());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -882,7 +882,7 @@ error[E0308]: mismatched types
 LL |     foo::<i8>(x_u16);
    |               ^^^^^ expected `i8`, found `u16`
    |
-help: you can convert a `u16` to `i8` and panic if the converted value wouldn't fit
+help: you can convert a `u16` to an `i8` and panic if the converted value wouldn't fit
    |
 LL |     foo::<i8>(x_u16.try_into().unwrap());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -893,7 +893,7 @@ error[E0308]: mismatched types
 LL |     foo::<i8>(x_u8);
    |               ^^^^ expected `i8`, found `u8`
    |
-help: you can convert a `u8` to `i8` and panic if the converted value wouldn't fit
+help: you can convert a `u8` to an `i8` and panic if the converted value wouldn't fit
    |
 LL |     foo::<i8>(x_u8.try_into().unwrap());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -904,7 +904,7 @@ error[E0308]: mismatched types
 LL |     foo::<i8>(x_isize);
    |               ^^^^^^^ expected `i8`, found `isize`
    |
-help: you can convert an `isize` to `i8` and panic if the converted value wouldn't fit
+help: you can convert an `isize` to an `i8` and panic if the converted value wouldn't fit
    |
 LL |     foo::<i8>(x_isize.try_into().unwrap());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -915,7 +915,7 @@ error[E0308]: mismatched types
 LL |     foo::<i8>(x_i64);
    |               ^^^^^ expected `i8`, found `i64`
    |
-help: you can convert an `i64` to `i8` and panic if the converted value wouldn't fit
+help: you can convert an `i64` to an `i8` and panic if the converted value wouldn't fit
    |
 LL |     foo::<i8>(x_i64.try_into().unwrap());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -926,7 +926,7 @@ error[E0308]: mismatched types
 LL |     foo::<i8>(x_i32);
    |               ^^^^^ expected `i8`, found `i32`
    |
-help: you can convert an `i32` to `i8` and panic if the converted value wouldn't fit
+help: you can convert an `i32` to an `i8` and panic if the converted value wouldn't fit
    |
 LL |     foo::<i8>(x_i32.try_into().unwrap());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -937,7 +937,7 @@ error[E0308]: mismatched types
 LL |     foo::<i8>(x_i16);
    |               ^^^^^ expected `i8`, found `i16`
    |
-help: you can convert an `i16` to `i8` and panic if the converted value wouldn't fit
+help: you can convert an `i16` to an `i8` and panic if the converted value wouldn't fit
    |
 LL |     foo::<i8>(x_i16.try_into().unwrap());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -948,7 +948,7 @@ error[E0308]: mismatched types
 LL |     foo::<f64>(x_usize);
    |                ^^^^^^^ expected `f64`, found `usize`
    |
-help: you can cast a `usize to `f64`, producing the floating point representation of the integer,
+help: you can cast a `usize` to an `f64`, producing the floating point representation of the integer,
    |                                              rounded if necessary
 LL |     foo::<f64>(x_usize as f64);
    |                ^^^^^^^^^^^^^^
@@ -959,7 +959,7 @@ error[E0308]: mismatched types
 LL |     foo::<f64>(x_u64);
    |                ^^^^^ expected `f64`, found `u64`
    |
-help: you can cast a `u64 to `f64`, producing the floating point representation of the integer,
+help: you can cast a `u64` to an `f64`, producing the floating point representation of the integer,
    |                                              rounded if necessary
 LL |     foo::<f64>(x_u64 as f64);
    |                ^^^^^^^^^^^^
@@ -970,7 +970,7 @@ error[E0308]: mismatched types
 LL |     foo::<f64>(x_u32);
    |                ^^^^^ expected `f64`, found `u32`
    |
-help: you can convert a `u32` to `f64`, producing the floating point representation of the integer
+help: you can convert a `u32` to an `f64`, producing the floating point representation of the integer
    |
 LL |     foo::<f64>(x_u32.into());
    |                ^^^^^^^^^^^^
@@ -981,7 +981,7 @@ error[E0308]: mismatched types
 LL |     foo::<f64>(x_u16);
    |                ^^^^^ expected `f64`, found `u16`
    |
-help: you can convert a `u16` to `f64`, producing the floating point representation of the integer
+help: you can convert a `u16` to an `f64`, producing the floating point representation of the integer
    |
 LL |     foo::<f64>(x_u16.into());
    |                ^^^^^^^^^^^^
@@ -992,7 +992,7 @@ error[E0308]: mismatched types
 LL |     foo::<f64>(x_u8);
    |                ^^^^ expected `f64`, found `u8`
    |
-help: you can convert a `u8` to `f64`, producing the floating point representation of the integer
+help: you can convert a `u8` to an `f64`, producing the floating point representation of the integer
    |
 LL |     foo::<f64>(x_u8.into());
    |                ^^^^^^^^^^^
@@ -1003,7 +1003,7 @@ error[E0308]: mismatched types
 LL |     foo::<f64>(x_isize);
    |                ^^^^^^^ expected `f64`, found `isize`
    |
-help: you can convert an `isize` to `f64`, producing the floating point representation of the integer, rounded if necessary
+help: you can convert an `isize` to an `f64`, producing the floating point representation of the integer, rounded if necessary
    |
 LL |     foo::<f64>(x_isize as f64);
    |                ^^^^^^^^^^^^^^
@@ -1014,7 +1014,7 @@ error[E0308]: mismatched types
 LL |     foo::<f64>(x_i64);
    |                ^^^^^ expected `f64`, found `i64`
    |
-help: you can convert an `i64` to `f64`, producing the floating point representation of the integer, rounded if necessary
+help: you can convert an `i64` to an `f64`, producing the floating point representation of the integer, rounded if necessary
    |
 LL |     foo::<f64>(x_i64 as f64);
    |                ^^^^^^^^^^^^
@@ -1025,7 +1025,7 @@ error[E0308]: mismatched types
 LL |     foo::<f64>(x_i32);
    |                ^^^^^ expected `f64`, found `i32`
    |
-help: you can convert an `i32` to `f64`, producing the floating point representation of the integer
+help: you can convert an `i32` to an `f64`, producing the floating point representation of the integer
    |
 LL |     foo::<f64>(x_i32.into());
    |                ^^^^^^^^^^^^
@@ -1036,7 +1036,7 @@ error[E0308]: mismatched types
 LL |     foo::<f64>(x_i16);
    |                ^^^^^ expected `f64`, found `i16`
    |
-help: you can convert an `i16` to `f64`, producing the floating point representation of the integer
+help: you can convert an `i16` to an `f64`, producing the floating point representation of the integer
    |
 LL |     foo::<f64>(x_i16.into());
    |                ^^^^^^^^^^^^
@@ -1047,7 +1047,7 @@ error[E0308]: mismatched types
 LL |     foo::<f64>(x_i8);
    |                ^^^^ expected `f64`, found `i8`
    |
-help: you can convert an `i8` to `f64`, producing the floating point representation of the integer
+help: you can convert an `i8` to an `f64`, producing the floating point representation of the integer
    |
 LL |     foo::<f64>(x_i8.into());
    |                ^^^^^^^^^^^
@@ -1059,7 +1059,7 @@ LL |     foo::<f64>(x_f32);
    |                ^^^^^
    |                |
    |                expected `f64`, found `f32`
-   |                help: you can convert an `f32` to `f64`: `x_f32.into()`
+   |                help: you can convert an `f32` to an `f64`: `x_f32.into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:266:16
@@ -1067,7 +1067,7 @@ error[E0308]: mismatched types
 LL |     foo::<f32>(x_usize);
    |                ^^^^^^^ expected `f32`, found `usize`
    |
-help: you can cast a `usize to `f32`, producing the floating point representation of the integer,
+help: you can cast a `usize` to an `f32`, producing the floating point representation of the integer,
    |                                              rounded if necessary
 LL |     foo::<f32>(x_usize as f32);
    |                ^^^^^^^^^^^^^^
@@ -1078,7 +1078,7 @@ error[E0308]: mismatched types
 LL |     foo::<f32>(x_u64);
    |                ^^^^^ expected `f32`, found `u64`
    |
-help: you can cast a `u64 to `f32`, producing the floating point representation of the integer,
+help: you can cast a `u64` to an `f32`, producing the floating point representation of the integer,
    |                                              rounded if necessary
 LL |     foo::<f32>(x_u64 as f32);
    |                ^^^^^^^^^^^^
@@ -1089,7 +1089,7 @@ error[E0308]: mismatched types
 LL |     foo::<f32>(x_u32);
    |                ^^^^^ expected `f32`, found `u32`
    |
-help: you can cast a `u32 to `f32`, producing the floating point representation of the integer,
+help: you can cast a `u32` to an `f32`, producing the floating point representation of the integer,
    |                                              rounded if necessary
 LL |     foo::<f32>(x_u32 as f32);
    |                ^^^^^^^^^^^^
@@ -1100,7 +1100,7 @@ error[E0308]: mismatched types
 LL |     foo::<f32>(x_u16);
    |                ^^^^^ expected `f32`, found `u16`
    |
-help: you can convert a `u16` to `f32`, producing the floating point representation of the integer
+help: you can convert a `u16` to an `f32`, producing the floating point representation of the integer
    |
 LL |     foo::<f32>(x_u16.into());
    |                ^^^^^^^^^^^^
@@ -1111,7 +1111,7 @@ error[E0308]: mismatched types
 LL |     foo::<f32>(x_u8);
    |                ^^^^ expected `f32`, found `u8`
    |
-help: you can convert a `u8` to `f32`, producing the floating point representation of the integer
+help: you can convert a `u8` to an `f32`, producing the floating point representation of the integer
    |
 LL |     foo::<f32>(x_u8.into());
    |                ^^^^^^^^^^^
@@ -1122,7 +1122,7 @@ error[E0308]: mismatched types
 LL |     foo::<f32>(x_isize);
    |                ^^^^^^^ expected `f32`, found `isize`
    |
-help: you can convert an `isize` to `f32`, producing the floating point representation of the integer, rounded if necessary
+help: you can convert an `isize` to an `f32`, producing the floating point representation of the integer, rounded if necessary
    |
 LL |     foo::<f32>(x_isize as f32);
    |                ^^^^^^^^^^^^^^
@@ -1133,7 +1133,7 @@ error[E0308]: mismatched types
 LL |     foo::<f32>(x_i64);
    |                ^^^^^ expected `f32`, found `i64`
    |
-help: you can convert an `i64` to `f32`, producing the floating point representation of the integer, rounded if necessary
+help: you can convert an `i64` to an `f32`, producing the floating point representation of the integer, rounded if necessary
    |
 LL |     foo::<f32>(x_i64 as f32);
    |                ^^^^^^^^^^^^
@@ -1144,7 +1144,7 @@ error[E0308]: mismatched types
 LL |     foo::<f32>(x_i32);
    |                ^^^^^ expected `f32`, found `i32`
    |
-help: you can convert an `i32` to `f32`, producing the floating point representation of the integer, rounded if necessary
+help: you can convert an `i32` to an `f32`, producing the floating point representation of the integer, rounded if necessary
    |
 LL |     foo::<f32>(x_i32 as f32);
    |                ^^^^^^^^^^^^
@@ -1155,7 +1155,7 @@ error[E0308]: mismatched types
 LL |     foo::<f32>(x_i16);
    |                ^^^^^ expected `f32`, found `i16`
    |
-help: you can convert an `i16` to `f32`, producing the floating point representation of the integer
+help: you can convert an `i16` to an `f32`, producing the floating point representation of the integer
    |
 LL |     foo::<f32>(x_i16.into());
    |                ^^^^^^^^^^^^
@@ -1166,7 +1166,7 @@ error[E0308]: mismatched types
 LL |     foo::<f32>(x_i8);
    |                ^^^^ expected `f32`, found `i8`
    |
-help: you can convert an `i8` to `f32`, producing the floating point representation of the integer
+help: you can convert an `i8` to an `f32`, producing the floating point representation of the integer
    |
 LL |     foo::<f32>(x_i8.into());
    |                ^^^^^^^^^^^
@@ -1178,7 +1178,7 @@ LL |     foo::<u32>(x_u8 as u16);
    |                ^^^^^^^^^^^
    |                |
    |                expected `u32`, found `u16`
-   |                help: you can convert a `u16` to `u32`: `(x_u8 as u16).into()`
+   |                help: you can convert a `u16` to a `u32`: `(x_u8 as u16).into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:291:16
@@ -1187,7 +1187,7 @@ LL |     foo::<i32>(-x_i8);
    |                ^^^^^
    |                |
    |                expected `i32`, found `i8`
-   |                help: you can convert an `i8` to `i32`: `(-x_i8).into()`
+   |                help: you can convert an `i8` to an `i32`: `(-x_i8).into()`
 
 error: aborting due to 113 previous errors
 

--- a/src/test/ui/numeric/numeric-cast.stderr
+++ b/src/test/ui/numeric/numeric-cast.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL |     foo::<usize>(x_u64);
    |                  ^^^^^ expected `usize`, found `u64`
    |
-help: you can convert a `u64` to a `usize` and panic if the converted value wouldn't fit
+help: you can convert a `u64` to a `usize` and panic if the converted value doesn't fit
    |
 LL |     foo::<usize>(x_u64.try_into().unwrap());
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -15,7 +15,7 @@ error[E0308]: mismatched types
 LL |     foo::<usize>(x_u32);
    |                  ^^^^^ expected `usize`, found `u32`
    |
-help: you can convert a `u32` to a `usize` and panic if the converted value wouldn't fit
+help: you can convert a `u32` to a `usize` and panic if the converted value doesn't fit
    |
 LL |     foo::<usize>(x_u32.try_into().unwrap());
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -44,7 +44,7 @@ error[E0308]: mismatched types
 LL |     foo::<usize>(x_isize);
    |                  ^^^^^^^ expected `usize`, found `isize`
    |
-help: you can convert an `isize` to a `usize` and panic if the converted value wouldn't fit
+help: you can convert an `isize` to a `usize` and panic if the converted value doesn't fit
    |
 LL |     foo::<usize>(x_isize.try_into().unwrap());
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -55,7 +55,7 @@ error[E0308]: mismatched types
 LL |     foo::<usize>(x_i64);
    |                  ^^^^^ expected `usize`, found `i64`
    |
-help: you can convert an `i64` to a `usize` and panic if the converted value wouldn't fit
+help: you can convert an `i64` to a `usize` and panic if the converted value doesn't fit
    |
 LL |     foo::<usize>(x_i64.try_into().unwrap());
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -66,7 +66,7 @@ error[E0308]: mismatched types
 LL |     foo::<usize>(x_i32);
    |                  ^^^^^ expected `usize`, found `i32`
    |
-help: you can convert an `i32` to a `usize` and panic if the converted value wouldn't fit
+help: you can convert an `i32` to a `usize` and panic if the converted value doesn't fit
    |
 LL |     foo::<usize>(x_i32.try_into().unwrap());
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -77,7 +77,7 @@ error[E0308]: mismatched types
 LL |     foo::<usize>(x_i16);
    |                  ^^^^^ expected `usize`, found `i16`
    |
-help: you can convert an `i16` to a `usize` and panic if the converted value wouldn't fit
+help: you can convert an `i16` to a `usize` and panic if the converted value doesn't fit
    |
 LL |     foo::<usize>(x_i16.try_into().unwrap());
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -88,7 +88,7 @@ error[E0308]: mismatched types
 LL |     foo::<usize>(x_i8);
    |                  ^^^^ expected `usize`, found `i8`
    |
-help: you can convert an `i8` to a `usize` and panic if the converted value wouldn't fit
+help: you can convert an `i8` to a `usize` and panic if the converted value doesn't fit
    |
 LL |     foo::<usize>(x_i8.try_into().unwrap());
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -99,7 +99,7 @@ error[E0308]: mismatched types
 LL |     foo::<isize>(x_usize);
    |                  ^^^^^^^ expected `isize`, found `usize`
    |
-help: you can convert a `usize` to an `isize` and panic if the converted value wouldn't fit
+help: you can convert a `usize` to an `isize` and panic if the converted value doesn't fit
    |
 LL |     foo::<isize>(x_usize.try_into().unwrap());
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -110,7 +110,7 @@ error[E0308]: mismatched types
 LL |     foo::<isize>(x_u64);
    |                  ^^^^^ expected `isize`, found `u64`
    |
-help: you can convert a `u64` to an `isize` and panic if the converted value wouldn't fit
+help: you can convert a `u64` to an `isize` and panic if the converted value doesn't fit
    |
 LL |     foo::<isize>(x_u64.try_into().unwrap());
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -121,7 +121,7 @@ error[E0308]: mismatched types
 LL |     foo::<isize>(x_u32);
    |                  ^^^^^ expected `isize`, found `u32`
    |
-help: you can convert a `u32` to an `isize` and panic if the converted value wouldn't fit
+help: you can convert a `u32` to an `isize` and panic if the converted value doesn't fit
    |
 LL |     foo::<isize>(x_u32.try_into().unwrap());
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -132,7 +132,7 @@ error[E0308]: mismatched types
 LL |     foo::<isize>(x_u16);
    |                  ^^^^^ expected `isize`, found `u16`
    |
-help: you can convert a `u16` to an `isize` and panic if the converted value wouldn't fit
+help: you can convert a `u16` to an `isize` and panic if the converted value doesn't fit
    |
 LL |     foo::<isize>(x_u16.try_into().unwrap());
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -152,7 +152,7 @@ error[E0308]: mismatched types
 LL |     foo::<isize>(x_i64);
    |                  ^^^^^ expected `isize`, found `i64`
    |
-help: you can convert an `i64` to an `isize` and panic if the converted value wouldn't fit
+help: you can convert an `i64` to an `isize` and panic if the converted value doesn't fit
    |
 LL |     foo::<isize>(x_i64.try_into().unwrap());
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -163,7 +163,7 @@ error[E0308]: mismatched types
 LL |     foo::<isize>(x_i32);
    |                  ^^^^^ expected `isize`, found `i32`
    |
-help: you can convert an `i32` to an `isize` and panic if the converted value wouldn't fit
+help: you can convert an `i32` to an `isize` and panic if the converted value doesn't fit
    |
 LL |     foo::<isize>(x_i32.try_into().unwrap());
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -192,7 +192,7 @@ error[E0308]: mismatched types
 LL |     foo::<u64>(x_usize);
    |                ^^^^^^^ expected `u64`, found `usize`
    |
-help: you can convert a `usize` to a `u64` and panic if the converted value wouldn't fit
+help: you can convert a `usize` to a `u64` and panic if the converted value doesn't fit
    |
 LL |     foo::<u64>(x_usize.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -230,7 +230,7 @@ error[E0308]: mismatched types
 LL |     foo::<u64>(x_isize);
    |                ^^^^^^^ expected `u64`, found `isize`
    |
-help: you can convert an `isize` to a `u64` and panic if the converted value wouldn't fit
+help: you can convert an `isize` to a `u64` and panic if the converted value doesn't fit
    |
 LL |     foo::<u64>(x_isize.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -241,7 +241,7 @@ error[E0308]: mismatched types
 LL |     foo::<u64>(x_i64);
    |                ^^^^^ expected `u64`, found `i64`
    |
-help: you can convert an `i64` to a `u64` and panic if the converted value wouldn't fit
+help: you can convert an `i64` to a `u64` and panic if the converted value doesn't fit
    |
 LL |     foo::<u64>(x_i64.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -252,7 +252,7 @@ error[E0308]: mismatched types
 LL |     foo::<u64>(x_i32);
    |                ^^^^^ expected `u64`, found `i32`
    |
-help: you can convert an `i32` to a `u64` and panic if the converted value wouldn't fit
+help: you can convert an `i32` to a `u64` and panic if the converted value doesn't fit
    |
 LL |     foo::<u64>(x_i32.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -263,7 +263,7 @@ error[E0308]: mismatched types
 LL |     foo::<u64>(x_i16);
    |                ^^^^^ expected `u64`, found `i16`
    |
-help: you can convert an `i16` to a `u64` and panic if the converted value wouldn't fit
+help: you can convert an `i16` to a `u64` and panic if the converted value doesn't fit
    |
 LL |     foo::<u64>(x_i16.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -274,7 +274,7 @@ error[E0308]: mismatched types
 LL |     foo::<u64>(x_i8);
    |                ^^^^ expected `u64`, found `i8`
    |
-help: you can convert an `i8` to a `u64` and panic if the converted value wouldn't fit
+help: you can convert an `i8` to a `u64` and panic if the converted value doesn't fit
    |
 LL |     foo::<u64>(x_i8.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -285,7 +285,7 @@ error[E0308]: mismatched types
 LL |     foo::<i64>(x_usize);
    |                ^^^^^^^ expected `i64`, found `usize`
    |
-help: you can convert a `usize` to an `i64` and panic if the converted value wouldn't fit
+help: you can convert a `usize` to an `i64` and panic if the converted value doesn't fit
    |
 LL |     foo::<i64>(x_usize.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -296,7 +296,7 @@ error[E0308]: mismatched types
 LL |     foo::<i64>(x_u64);
    |                ^^^^^ expected `i64`, found `u64`
    |
-help: you can convert a `u64` to an `i64` and panic if the converted value wouldn't fit
+help: you can convert a `u64` to an `i64` and panic if the converted value doesn't fit
    |
 LL |     foo::<i64>(x_u64.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -334,7 +334,7 @@ error[E0308]: mismatched types
 LL |     foo::<i64>(x_isize);
    |                ^^^^^^^ expected `i64`, found `isize`
    |
-help: you can convert an `isize` to an `i64` and panic if the converted value wouldn't fit
+help: you can convert an `isize` to an `i64` and panic if the converted value doesn't fit
    |
 LL |     foo::<i64>(x_isize.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -372,7 +372,7 @@ error[E0308]: mismatched types
 LL |     foo::<u32>(x_usize);
    |                ^^^^^^^ expected `u32`, found `usize`
    |
-help: you can convert a `usize` to a `u32` and panic if the converted value wouldn't fit
+help: you can convert a `usize` to a `u32` and panic if the converted value doesn't fit
    |
 LL |     foo::<u32>(x_usize.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -383,7 +383,7 @@ error[E0308]: mismatched types
 LL |     foo::<u32>(x_u64);
    |                ^^^^^ expected `u32`, found `u64`
    |
-help: you can convert a `u64` to a `u32` and panic if the converted value wouldn't fit
+help: you can convert a `u64` to a `u32` and panic if the converted value doesn't fit
    |
 LL |     foo::<u32>(x_u64.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -412,7 +412,7 @@ error[E0308]: mismatched types
 LL |     foo::<u32>(x_isize);
    |                ^^^^^^^ expected `u32`, found `isize`
    |
-help: you can convert an `isize` to a `u32` and panic if the converted value wouldn't fit
+help: you can convert an `isize` to a `u32` and panic if the converted value doesn't fit
    |
 LL |     foo::<u32>(x_isize.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -423,7 +423,7 @@ error[E0308]: mismatched types
 LL |     foo::<u32>(x_i64);
    |                ^^^^^ expected `u32`, found `i64`
    |
-help: you can convert an `i64` to a `u32` and panic if the converted value wouldn't fit
+help: you can convert an `i64` to a `u32` and panic if the converted value doesn't fit
    |
 LL |     foo::<u32>(x_i64.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -434,7 +434,7 @@ error[E0308]: mismatched types
 LL |     foo::<u32>(x_i32);
    |                ^^^^^ expected `u32`, found `i32`
    |
-help: you can convert an `i32` to a `u32` and panic if the converted value wouldn't fit
+help: you can convert an `i32` to a `u32` and panic if the converted value doesn't fit
    |
 LL |     foo::<u32>(x_i32.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -445,7 +445,7 @@ error[E0308]: mismatched types
 LL |     foo::<u32>(x_i16);
    |                ^^^^^ expected `u32`, found `i16`
    |
-help: you can convert an `i16` to a `u32` and panic if the converted value wouldn't fit
+help: you can convert an `i16` to a `u32` and panic if the converted value doesn't fit
    |
 LL |     foo::<u32>(x_i16.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -456,7 +456,7 @@ error[E0308]: mismatched types
 LL |     foo::<u32>(x_i8);
    |                ^^^^ expected `u32`, found `i8`
    |
-help: you can convert an `i8` to a `u32` and panic if the converted value wouldn't fit
+help: you can convert an `i8` to a `u32` and panic if the converted value doesn't fit
    |
 LL |     foo::<u32>(x_i8.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -467,7 +467,7 @@ error[E0308]: mismatched types
 LL |     foo::<i32>(x_usize);
    |                ^^^^^^^ expected `i32`, found `usize`
    |
-help: you can convert a `usize` to an `i32` and panic if the converted value wouldn't fit
+help: you can convert a `usize` to an `i32` and panic if the converted value doesn't fit
    |
 LL |     foo::<i32>(x_usize.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -478,7 +478,7 @@ error[E0308]: mismatched types
 LL |     foo::<i32>(x_u64);
    |                ^^^^^ expected `i32`, found `u64`
    |
-help: you can convert a `u64` to an `i32` and panic if the converted value wouldn't fit
+help: you can convert a `u64` to an `i32` and panic if the converted value doesn't fit
    |
 LL |     foo::<i32>(x_u64.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -489,7 +489,7 @@ error[E0308]: mismatched types
 LL |     foo::<i32>(x_u32);
    |                ^^^^^ expected `i32`, found `u32`
    |
-help: you can convert a `u32` to an `i32` and panic if the converted value wouldn't fit
+help: you can convert a `u32` to an `i32` and panic if the converted value doesn't fit
    |
 LL |     foo::<i32>(x_u32.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -518,7 +518,7 @@ error[E0308]: mismatched types
 LL |     foo::<i32>(x_isize);
    |                ^^^^^^^ expected `i32`, found `isize`
    |
-help: you can convert an `isize` to an `i32` and panic if the converted value wouldn't fit
+help: you can convert an `isize` to an `i32` and panic if the converted value doesn't fit
    |
 LL |     foo::<i32>(x_isize.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -529,7 +529,7 @@ error[E0308]: mismatched types
 LL |     foo::<i32>(x_i64);
    |                ^^^^^ expected `i32`, found `i64`
    |
-help: you can convert an `i64` to an `i32` and panic if the converted value wouldn't fit
+help: you can convert an `i64` to an `i32` and panic if the converted value doesn't fit
    |
 LL |     foo::<i32>(x_i64.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -558,7 +558,7 @@ error[E0308]: mismatched types
 LL |     foo::<u16>(x_usize);
    |                ^^^^^^^ expected `u16`, found `usize`
    |
-help: you can convert a `usize` to a `u16` and panic if the converted value wouldn't fit
+help: you can convert a `usize` to a `u16` and panic if the converted value doesn't fit
    |
 LL |     foo::<u16>(x_usize.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -569,7 +569,7 @@ error[E0308]: mismatched types
 LL |     foo::<u16>(x_u64);
    |                ^^^^^ expected `u16`, found `u64`
    |
-help: you can convert a `u64` to a `u16` and panic if the converted value wouldn't fit
+help: you can convert a `u64` to a `u16` and panic if the converted value doesn't fit
    |
 LL |     foo::<u16>(x_u64.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -580,7 +580,7 @@ error[E0308]: mismatched types
 LL |     foo::<u16>(x_u32);
    |                ^^^^^ expected `u16`, found `u32`
    |
-help: you can convert a `u32` to a `u16` and panic if the converted value wouldn't fit
+help: you can convert a `u32` to a `u16` and panic if the converted value doesn't fit
    |
 LL |     foo::<u16>(x_u32.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -600,7 +600,7 @@ error[E0308]: mismatched types
 LL |     foo::<u16>(x_isize);
    |                ^^^^^^^ expected `u16`, found `isize`
    |
-help: you can convert an `isize` to a `u16` and panic if the converted value wouldn't fit
+help: you can convert an `isize` to a `u16` and panic if the converted value doesn't fit
    |
 LL |     foo::<u16>(x_isize.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -611,7 +611,7 @@ error[E0308]: mismatched types
 LL |     foo::<u16>(x_i64);
    |                ^^^^^ expected `u16`, found `i64`
    |
-help: you can convert an `i64` to a `u16` and panic if the converted value wouldn't fit
+help: you can convert an `i64` to a `u16` and panic if the converted value doesn't fit
    |
 LL |     foo::<u16>(x_i64.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -622,7 +622,7 @@ error[E0308]: mismatched types
 LL |     foo::<u16>(x_i32);
    |                ^^^^^ expected `u16`, found `i32`
    |
-help: you can convert an `i32` to a `u16` and panic if the converted value wouldn't fit
+help: you can convert an `i32` to a `u16` and panic if the converted value doesn't fit
    |
 LL |     foo::<u16>(x_i32.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -633,7 +633,7 @@ error[E0308]: mismatched types
 LL |     foo::<u16>(x_i16);
    |                ^^^^^ expected `u16`, found `i16`
    |
-help: you can convert an `i16` to a `u16` and panic if the converted value wouldn't fit
+help: you can convert an `i16` to a `u16` and panic if the converted value doesn't fit
    |
 LL |     foo::<u16>(x_i16.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -644,7 +644,7 @@ error[E0308]: mismatched types
 LL |     foo::<u16>(x_i8);
    |                ^^^^ expected `u16`, found `i8`
    |
-help: you can convert an `i8` to a `u16` and panic if the converted value wouldn't fit
+help: you can convert an `i8` to a `u16` and panic if the converted value doesn't fit
    |
 LL |     foo::<u16>(x_i8.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -655,7 +655,7 @@ error[E0308]: mismatched types
 LL |     foo::<i16>(x_usize);
    |                ^^^^^^^ expected `i16`, found `usize`
    |
-help: you can convert a `usize` to an `i16` and panic if the converted value wouldn't fit
+help: you can convert a `usize` to an `i16` and panic if the converted value doesn't fit
    |
 LL |     foo::<i16>(x_usize.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -666,7 +666,7 @@ error[E0308]: mismatched types
 LL |     foo::<i16>(x_u64);
    |                ^^^^^ expected `i16`, found `u64`
    |
-help: you can convert a `u64` to an `i16` and panic if the converted value wouldn't fit
+help: you can convert a `u64` to an `i16` and panic if the converted value doesn't fit
    |
 LL |     foo::<i16>(x_u64.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -677,7 +677,7 @@ error[E0308]: mismatched types
 LL |     foo::<i16>(x_u32);
    |                ^^^^^ expected `i16`, found `u32`
    |
-help: you can convert a `u32` to an `i16` and panic if the converted value wouldn't fit
+help: you can convert a `u32` to an `i16` and panic if the converted value doesn't fit
    |
 LL |     foo::<i16>(x_u32.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -688,7 +688,7 @@ error[E0308]: mismatched types
 LL |     foo::<i16>(x_u16);
    |                ^^^^^ expected `i16`, found `u16`
    |
-help: you can convert a `u16` to an `i16` and panic if the converted value wouldn't fit
+help: you can convert a `u16` to an `i16` and panic if the converted value doesn't fit
    |
 LL |     foo::<i16>(x_u16.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -708,7 +708,7 @@ error[E0308]: mismatched types
 LL |     foo::<i16>(x_isize);
    |                ^^^^^^^ expected `i16`, found `isize`
    |
-help: you can convert an `isize` to an `i16` and panic if the converted value wouldn't fit
+help: you can convert an `isize` to an `i16` and panic if the converted value doesn't fit
    |
 LL |     foo::<i16>(x_isize.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -719,7 +719,7 @@ error[E0308]: mismatched types
 LL |     foo::<i16>(x_i64);
    |                ^^^^^ expected `i16`, found `i64`
    |
-help: you can convert an `i64` to an `i16` and panic if the converted value wouldn't fit
+help: you can convert an `i64` to an `i16` and panic if the converted value doesn't fit
    |
 LL |     foo::<i16>(x_i64.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -730,7 +730,7 @@ error[E0308]: mismatched types
 LL |     foo::<i16>(x_i32);
    |                ^^^^^ expected `i16`, found `i32`
    |
-help: you can convert an `i32` to an `i16` and panic if the converted value wouldn't fit
+help: you can convert an `i32` to an `i16` and panic if the converted value doesn't fit
    |
 LL |     foo::<i16>(x_i32.try_into().unwrap());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -750,7 +750,7 @@ error[E0308]: mismatched types
 LL |     foo::<u8>(x_usize);
    |               ^^^^^^^ expected `u8`, found `usize`
    |
-help: you can convert a `usize` to a `u8` and panic if the converted value wouldn't fit
+help: you can convert a `usize` to a `u8` and panic if the converted value doesn't fit
    |
 LL |     foo::<u8>(x_usize.try_into().unwrap());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -761,7 +761,7 @@ error[E0308]: mismatched types
 LL |     foo::<u8>(x_u64);
    |               ^^^^^ expected `u8`, found `u64`
    |
-help: you can convert a `u64` to a `u8` and panic if the converted value wouldn't fit
+help: you can convert a `u64` to a `u8` and panic if the converted value doesn't fit
    |
 LL |     foo::<u8>(x_u64.try_into().unwrap());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -772,7 +772,7 @@ error[E0308]: mismatched types
 LL |     foo::<u8>(x_u32);
    |               ^^^^^ expected `u8`, found `u32`
    |
-help: you can convert a `u32` to a `u8` and panic if the converted value wouldn't fit
+help: you can convert a `u32` to a `u8` and panic if the converted value doesn't fit
    |
 LL |     foo::<u8>(x_u32.try_into().unwrap());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -783,7 +783,7 @@ error[E0308]: mismatched types
 LL |     foo::<u8>(x_u16);
    |               ^^^^^ expected `u8`, found `u16`
    |
-help: you can convert a `u16` to a `u8` and panic if the converted value wouldn't fit
+help: you can convert a `u16` to a `u8` and panic if the converted value doesn't fit
    |
 LL |     foo::<u8>(x_u16.try_into().unwrap());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -794,7 +794,7 @@ error[E0308]: mismatched types
 LL |     foo::<u8>(x_isize);
    |               ^^^^^^^ expected `u8`, found `isize`
    |
-help: you can convert an `isize` to a `u8` and panic if the converted value wouldn't fit
+help: you can convert an `isize` to a `u8` and panic if the converted value doesn't fit
    |
 LL |     foo::<u8>(x_isize.try_into().unwrap());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -805,7 +805,7 @@ error[E0308]: mismatched types
 LL |     foo::<u8>(x_i64);
    |               ^^^^^ expected `u8`, found `i64`
    |
-help: you can convert an `i64` to a `u8` and panic if the converted value wouldn't fit
+help: you can convert an `i64` to a `u8` and panic if the converted value doesn't fit
    |
 LL |     foo::<u8>(x_i64.try_into().unwrap());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -816,7 +816,7 @@ error[E0308]: mismatched types
 LL |     foo::<u8>(x_i32);
    |               ^^^^^ expected `u8`, found `i32`
    |
-help: you can convert an `i32` to a `u8` and panic if the converted value wouldn't fit
+help: you can convert an `i32` to a `u8` and panic if the converted value doesn't fit
    |
 LL |     foo::<u8>(x_i32.try_into().unwrap());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -827,7 +827,7 @@ error[E0308]: mismatched types
 LL |     foo::<u8>(x_i16);
    |               ^^^^^ expected `u8`, found `i16`
    |
-help: you can convert an `i16` to a `u8` and panic if the converted value wouldn't fit
+help: you can convert an `i16` to a `u8` and panic if the converted value doesn't fit
    |
 LL |     foo::<u8>(x_i16.try_into().unwrap());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -838,7 +838,7 @@ error[E0308]: mismatched types
 LL |     foo::<u8>(x_i8);
    |               ^^^^ expected `u8`, found `i8`
    |
-help: you can convert an `i8` to a `u8` and panic if the converted value wouldn't fit
+help: you can convert an `i8` to a `u8` and panic if the converted value doesn't fit
    |
 LL |     foo::<u8>(x_i8.try_into().unwrap());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -849,7 +849,7 @@ error[E0308]: mismatched types
 LL |     foo::<i8>(x_usize);
    |               ^^^^^^^ expected `i8`, found `usize`
    |
-help: you can convert a `usize` to an `i8` and panic if the converted value wouldn't fit
+help: you can convert a `usize` to an `i8` and panic if the converted value doesn't fit
    |
 LL |     foo::<i8>(x_usize.try_into().unwrap());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -860,7 +860,7 @@ error[E0308]: mismatched types
 LL |     foo::<i8>(x_u64);
    |               ^^^^^ expected `i8`, found `u64`
    |
-help: you can convert a `u64` to an `i8` and panic if the converted value wouldn't fit
+help: you can convert a `u64` to an `i8` and panic if the converted value doesn't fit
    |
 LL |     foo::<i8>(x_u64.try_into().unwrap());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -871,7 +871,7 @@ error[E0308]: mismatched types
 LL |     foo::<i8>(x_u32);
    |               ^^^^^ expected `i8`, found `u32`
    |
-help: you can convert a `u32` to an `i8` and panic if the converted value wouldn't fit
+help: you can convert a `u32` to an `i8` and panic if the converted value doesn't fit
    |
 LL |     foo::<i8>(x_u32.try_into().unwrap());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -882,7 +882,7 @@ error[E0308]: mismatched types
 LL |     foo::<i8>(x_u16);
    |               ^^^^^ expected `i8`, found `u16`
    |
-help: you can convert a `u16` to an `i8` and panic if the converted value wouldn't fit
+help: you can convert a `u16` to an `i8` and panic if the converted value doesn't fit
    |
 LL |     foo::<i8>(x_u16.try_into().unwrap());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -893,7 +893,7 @@ error[E0308]: mismatched types
 LL |     foo::<i8>(x_u8);
    |               ^^^^ expected `i8`, found `u8`
    |
-help: you can convert a `u8` to an `i8` and panic if the converted value wouldn't fit
+help: you can convert a `u8` to an `i8` and panic if the converted value doesn't fit
    |
 LL |     foo::<i8>(x_u8.try_into().unwrap());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -904,7 +904,7 @@ error[E0308]: mismatched types
 LL |     foo::<i8>(x_isize);
    |               ^^^^^^^ expected `i8`, found `isize`
    |
-help: you can convert an `isize` to an `i8` and panic if the converted value wouldn't fit
+help: you can convert an `isize` to an `i8` and panic if the converted value doesn't fit
    |
 LL |     foo::<i8>(x_isize.try_into().unwrap());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -915,7 +915,7 @@ error[E0308]: mismatched types
 LL |     foo::<i8>(x_i64);
    |               ^^^^^ expected `i8`, found `i64`
    |
-help: you can convert an `i64` to an `i8` and panic if the converted value wouldn't fit
+help: you can convert an `i64` to an `i8` and panic if the converted value doesn't fit
    |
 LL |     foo::<i8>(x_i64.try_into().unwrap());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -926,7 +926,7 @@ error[E0308]: mismatched types
 LL |     foo::<i8>(x_i32);
    |               ^^^^^ expected `i8`, found `i32`
    |
-help: you can convert an `i32` to an `i8` and panic if the converted value wouldn't fit
+help: you can convert an `i32` to an `i8` and panic if the converted value doesn't fit
    |
 LL |     foo::<i8>(x_i32.try_into().unwrap());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -937,7 +937,7 @@ error[E0308]: mismatched types
 LL |     foo::<i8>(x_i16);
    |               ^^^^^ expected `i8`, found `i16`
    |
-help: you can convert an `i16` to an `i8` and panic if the converted value wouldn't fit
+help: you can convert an `i16` to an `i8` and panic if the converted value doesn't fit
    |
 LL |     foo::<i8>(x_i16.try_into().unwrap());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/numeric/numeric-suffix.stderr
+++ b/src/test/ui/numeric/numeric-suffix.stderr
@@ -1236,7 +1236,7 @@ error[E0308]: mismatched types
 LL |     foo::<f64>(42_u32);
    |                ^^^^^^ expected `f64`, found `u32`
    |
-help: you can convert an `u32` to `f64`, producing the floating point representation of the integer
+help: you can convert a `u32` to `f64`, producing the floating point representation of the integer
    |
 LL |     foo::<f64>(42_u32.into());
    |                ^^^^^^^^^^^^^
@@ -1247,7 +1247,7 @@ error[E0308]: mismatched types
 LL |     foo::<f64>(42_u16);
    |                ^^^^^^ expected `f64`, found `u16`
    |
-help: you can convert an `u16` to `f64`, producing the floating point representation of the integer
+help: you can convert a `u16` to `f64`, producing the floating point representation of the integer
    |
 LL |     foo::<f64>(42_u16.into());
    |                ^^^^^^^^^^^^^
@@ -1258,7 +1258,7 @@ error[E0308]: mismatched types
 LL |     foo::<f64>(42_u8);
    |                ^^^^^ expected `f64`, found `u8`
    |
-help: you can convert an `u8` to `f64`, producing the floating point representation of the integer
+help: you can convert a `u8` to `f64`, producing the floating point representation of the integer
    |
 LL |     foo::<f64>(42_u8.into());
    |                ^^^^^^^^^^^^
@@ -1368,7 +1368,7 @@ error[E0308]: mismatched types
 LL |     foo::<f32>(42_u16);
    |                ^^^^^^ expected `f32`, found `u16`
    |
-help: you can convert an `u16` to `f32`, producing the floating point representation of the integer
+help: you can convert a `u16` to `f32`, producing the floating point representation of the integer
    |
 LL |     foo::<f32>(42_u16.into());
    |                ^^^^^^^^^^^^^
@@ -1379,7 +1379,7 @@ error[E0308]: mismatched types
 LL |     foo::<f32>(42_u8);
    |                ^^^^^ expected `f32`, found `u8`
    |
-help: you can convert an `u8` to `f32`, producing the floating point representation of the integer
+help: you can convert a `u8` to `f32`, producing the floating point representation of the integer
    |
 LL |     foo::<f32>(42_u8.into());
    |                ^^^^^^^^^^^^
@@ -1457,7 +1457,7 @@ LL |     foo::<u32>(42_u8 as u16);
    |                ^^^^^^^^^^^^
    |                |
    |                expected `u32`, found `u16`
-   |                help: you can convert an `u16` to `u32`: `(42_u8 as u16).into()`
+   |                help: you can convert a `u16` to `u32`: `(42_u8 as u16).into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:296:16

--- a/src/test/ui/numeric/numeric-suffix.stderr
+++ b/src/test/ui/numeric/numeric-suffix.stderr
@@ -1236,7 +1236,7 @@ error[E0308]: mismatched types
 LL |     foo::<f64>(42_u32);
    |                ^^^^^^ expected `f64`, found `u32`
    |
-help: you can convert a `u32` to `f64`, producing the floating point representation of the integer
+help: you can convert a `u32` to an `f64`, producing the floating point representation of the integer
    |
 LL |     foo::<f64>(42_u32.into());
    |                ^^^^^^^^^^^^^
@@ -1247,7 +1247,7 @@ error[E0308]: mismatched types
 LL |     foo::<f64>(42_u16);
    |                ^^^^^^ expected `f64`, found `u16`
    |
-help: you can convert a `u16` to `f64`, producing the floating point representation of the integer
+help: you can convert a `u16` to an `f64`, producing the floating point representation of the integer
    |
 LL |     foo::<f64>(42_u16.into());
    |                ^^^^^^^^^^^^^
@@ -1258,7 +1258,7 @@ error[E0308]: mismatched types
 LL |     foo::<f64>(42_u8);
    |                ^^^^^ expected `f64`, found `u8`
    |
-help: you can convert a `u8` to `f64`, producing the floating point representation of the integer
+help: you can convert a `u8` to an `f64`, producing the floating point representation of the integer
    |
 LL |     foo::<f64>(42_u8.into());
    |                ^^^^^^^^^^^^
@@ -1291,7 +1291,7 @@ error[E0308]: mismatched types
 LL |     foo::<f64>(42_i32);
    |                ^^^^^^ expected `f64`, found `i32`
    |
-help: you can convert an `i32` to `f64`, producing the floating point representation of the integer
+help: you can convert an `i32` to an `f64`, producing the floating point representation of the integer
    |
 LL |     foo::<f64>(42_i32.into());
    |                ^^^^^^^^^^^^^
@@ -1302,7 +1302,7 @@ error[E0308]: mismatched types
 LL |     foo::<f64>(42_i16);
    |                ^^^^^^ expected `f64`, found `i16`
    |
-help: you can convert an `i16` to `f64`, producing the floating point representation of the integer
+help: you can convert an `i16` to an `f64`, producing the floating point representation of the integer
    |
 LL |     foo::<f64>(42_i16.into());
    |                ^^^^^^^^^^^^^
@@ -1313,7 +1313,7 @@ error[E0308]: mismatched types
 LL |     foo::<f64>(42_i8);
    |                ^^^^^ expected `f64`, found `i8`
    |
-help: you can convert an `i8` to `f64`, producing the floating point representation of the integer
+help: you can convert an `i8` to an `f64`, producing the floating point representation of the integer
    |
 LL |     foo::<f64>(42_i8.into());
    |                ^^^^^^^^^^^^
@@ -1368,7 +1368,7 @@ error[E0308]: mismatched types
 LL |     foo::<f32>(42_u16);
    |                ^^^^^^ expected `f32`, found `u16`
    |
-help: you can convert a `u16` to `f32`, producing the floating point representation of the integer
+help: you can convert a `u16` to an `f32`, producing the floating point representation of the integer
    |
 LL |     foo::<f32>(42_u16.into());
    |                ^^^^^^^^^^^^^
@@ -1379,7 +1379,7 @@ error[E0308]: mismatched types
 LL |     foo::<f32>(42_u8);
    |                ^^^^^ expected `f32`, found `u8`
    |
-help: you can convert a `u8` to `f32`, producing the floating point representation of the integer
+help: you can convert a `u8` to an `f32`, producing the floating point representation of the integer
    |
 LL |     foo::<f32>(42_u8.into());
    |                ^^^^^^^^^^^^
@@ -1423,7 +1423,7 @@ error[E0308]: mismatched types
 LL |     foo::<f32>(42_i16);
    |                ^^^^^^ expected `f32`, found `i16`
    |
-help: you can convert an `i16` to `f32`, producing the floating point representation of the integer
+help: you can convert an `i16` to an `f32`, producing the floating point representation of the integer
    |
 LL |     foo::<f32>(42_i16.into());
    |                ^^^^^^^^^^^^^
@@ -1434,7 +1434,7 @@ error[E0308]: mismatched types
 LL |     foo::<f32>(42_i8);
    |                ^^^^^ expected `f32`, found `i8`
    |
-help: you can convert an `i8` to `f32`, producing the floating point representation of the integer
+help: you can convert an `i8` to an `f32`, producing the floating point representation of the integer
    |
 LL |     foo::<f32>(42_i8.into());
    |                ^^^^^^^^^^^^
@@ -1457,7 +1457,7 @@ LL |     foo::<u32>(42_u8 as u16);
    |                ^^^^^^^^^^^^
    |                |
    |                expected `u32`, found `u16`
-   |                help: you can convert a `u16` to `u32`: `(42_u8 as u16).into()`
+   |                help: you can convert a `u16` to a `u32`: `(42_u8 as u16).into()`
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:296:16
@@ -1466,7 +1466,7 @@ LL |     foo::<i32>(-42_i8);
    |                ^^^^^^
    |                |
    |                expected `i32`, found `i8`
-   |                help: you can convert an `i8` to `i32`: `(-42_i8).into()`
+   |                help: you can convert an `i8` to an `i32`: `(-42_i8).into()`
 
 error: aborting due to 134 previous errors
 

--- a/src/test/ui/proc-macro/span-preservation.stderr
+++ b/src/test/ui/proc-macro/span-preservation.stderr
@@ -15,7 +15,7 @@ LL |     match x {
 LL |         Some(x) => { return x },
    |                             ^ expected `usize`, found `isize`
    |
-help: you can convert an `isize` to `usize` and panic if the converted value wouldn't fit
+help: you can convert an `isize` to a `usize` and panic if the converted value wouldn't fit
    |
 LL |         Some(x) => { return x.try_into().unwrap() },
    |                             ^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/proc-macro/span-preservation.stderr
+++ b/src/test/ui/proc-macro/span-preservation.stderr
@@ -15,7 +15,7 @@ LL |     match x {
 LL |         Some(x) => { return x },
    |                             ^ expected `usize`, found `isize`
    |
-help: you can convert an `isize` to a `usize` and panic if the converted value wouldn't fit
+help: you can convert an `isize` to a `usize` and panic if the converted value doesn't fit
    |
 LL |         Some(x) => { return x.try_into().unwrap() },
    |                             ^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/shift-various-bad-types.stderr
+++ b/src/test/ui/shift-various-bad-types.stderr
@@ -30,7 +30,7 @@ LL |     let _: i32 = 22_i64 >> 1_i32;
    |            |
    |            expected due to this
    |
-help: you can convert an `i64` to `i32` and panic if the converted value wouldn't fit
+help: you can convert an `i64` to an `i32` and panic if the converted value wouldn't fit
    |
 LL |     let _: i32 = (22_i64 >> 1_i32).try_into().unwrap();
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/shift-various-bad-types.stderr
+++ b/src/test/ui/shift-various-bad-types.stderr
@@ -30,7 +30,7 @@ LL |     let _: i32 = 22_i64 >> 1_i32;
    |            |
    |            expected due to this
    |
-help: you can convert an `i64` to an `i32` and panic if the converted value wouldn't fit
+help: you can convert an `i64` to an `i32` and panic if the converted value doesn't fit
    |
 LL |     let _: i32 = (22_i64 >> 1_i32).try_into().unwrap();
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/suggestions/type-mismatch-struct-field-shorthand-2.stderr
+++ b/src/test/ui/suggestions/type-mismatch-struct-field-shorthand-2.stderr
@@ -5,7 +5,7 @@ LL |     let _ = RGB { r, g, c };
    |                   ^
    |                   |
    |                   expected `f64`, found `f32`
-   |                   help: you can convert an `f32` to `f64`: `r: r.into()`
+   |                   help: you can convert an `f32` to an `f64`: `r: r.into()`
 
 error[E0308]: mismatched types
   --> $DIR/type-mismatch-struct-field-shorthand-2.rs:5:22
@@ -14,7 +14,7 @@ LL |     let _ = RGB { r, g, c };
    |                      ^
    |                      |
    |                      expected `f64`, found `f32`
-   |                      help: you can convert an `f32` to `f64`: `g: g.into()`
+   |                      help: you can convert an `f32` to an `f64`: `g: g.into()`
 
 error[E0560]: struct `RGB` has no field named `c`
   --> $DIR/type-mismatch-struct-field-shorthand-2.rs:5:25

--- a/src/test/ui/suggestions/type-mismatch-struct-field-shorthand.stderr
+++ b/src/test/ui/suggestions/type-mismatch-struct-field-shorthand.stderr
@@ -5,7 +5,7 @@ LL |     let _ = RGB { r, g, b };
    |                   ^
    |                   |
    |                   expected `f64`, found `f32`
-   |                   help: you can convert an `f32` to `f64`: `r: r.into()`
+   |                   help: you can convert an `f32` to an `f64`: `r: r.into()`
 
 error[E0308]: mismatched types
   --> $DIR/type-mismatch-struct-field-shorthand.rs:8:22
@@ -14,7 +14,7 @@ LL |     let _ = RGB { r, g, b };
    |                      ^
    |                      |
    |                      expected `f64`, found `f32`
-   |                      help: you can convert an `f32` to `f64`: `g: g.into()`
+   |                      help: you can convert an `f32` to an `f64`: `g: g.into()`
 
 error[E0308]: mismatched types
   --> $DIR/type-mismatch-struct-field-shorthand.rs:8:25
@@ -23,7 +23,7 @@ LL |     let _ = RGB { r, g, b };
    |                         ^
    |                         |
    |                         expected `f64`, found `f32`
-   |                         help: you can convert an `f32` to `f64`: `b: b.into()`
+   |                         help: you can convert an `f32` to an `f64`: `b: b.into()`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/tail-typeck.stderr
+++ b/src/test/ui/tail-typeck.stderr
@@ -6,7 +6,7 @@ LL | fn f() -> isize { return g(); }
    |           |
    |           expected `isize` because of return type
    |
-help: you can convert an `usize` to `isize` and panic if the converted value wouldn't fit
+help: you can convert a `usize` to `isize` and panic if the converted value wouldn't fit
    |
 LL | fn f() -> isize { return g().try_into().unwrap(); }
    |                          ^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/tail-typeck.stderr
+++ b/src/test/ui/tail-typeck.stderr
@@ -6,7 +6,7 @@ LL | fn f() -> isize { return g(); }
    |           |
    |           expected `isize` because of return type
    |
-help: you can convert a `usize` to `isize` and panic if the converted value wouldn't fit
+help: you can convert a `usize` to an `isize` and panic if the converted value wouldn't fit
    |
 LL | fn f() -> isize { return g().try_into().unwrap(); }
    |                          ^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/tail-typeck.stderr
+++ b/src/test/ui/tail-typeck.stderr
@@ -6,7 +6,7 @@ LL | fn f() -> isize { return g(); }
    |           |
    |           expected `isize` because of return type
    |
-help: you can convert a `usize` to an `isize` and panic if the converted value wouldn't fit
+help: you can convert a `usize` to an `isize` and panic if the converted value doesn't fit
    |
 LL | fn f() -> isize { return g().try_into().unwrap(); }
    |                          ^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/trivial-bounds/trivial-bounds-inconsistent-projection-error.stderr
+++ b/src/test/ui/trivial-bounds/trivial-bounds-inconsistent-projection-error.stderr
@@ -7,7 +7,7 @@ LL | fn global_bound_is_hidden() -> u8
 LL |     B::get_x()
    |     ^^^^^^^^^^ expected `u8`, found `i32`
    |
-help: you can convert an `i32` to a `u8` and panic if the converted value wouldn't fit
+help: you can convert an `i32` to a `u8` and panic if the converted value doesn't fit
    |
 LL |     B::get_x().try_into().unwrap()
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/trivial-bounds/trivial-bounds-inconsistent-projection-error.stderr
+++ b/src/test/ui/trivial-bounds/trivial-bounds-inconsistent-projection-error.stderr
@@ -7,7 +7,7 @@ LL | fn global_bound_is_hidden() -> u8
 LL |     B::get_x()
    |     ^^^^^^^^^^ expected `u8`, found `i32`
    |
-help: you can convert an `i32` to `u8` and panic if the converted value wouldn't fit
+help: you can convert an `i32` to a `u8` and panic if the converted value wouldn't fit
    |
 LL |     B::get_x().try_into().unwrap()
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/tutorial-suffix-inference-test.stderr
+++ b/src/test/ui/tutorial-suffix-inference-test.stderr
@@ -5,7 +5,7 @@ LL |     identity_u16(x);
    |                  ^
    |                  |
    |                  expected `u16`, found `u8`
-   |                  help: you can convert an `u8` to `u16`: `x.into()`
+   |                  help: you can convert a `u8` to `u16`: `x.into()`
 
 error[E0308]: mismatched types
   --> $DIR/tutorial-suffix-inference-test.rs:12:18

--- a/src/test/ui/tutorial-suffix-inference-test.stderr
+++ b/src/test/ui/tutorial-suffix-inference-test.stderr
@@ -13,7 +13,7 @@ error[E0308]: mismatched types
 LL |     identity_u16(y);
    |                  ^ expected `u16`, found `i32`
    |
-help: you can convert an `i32` to a `u16` and panic if the converted value wouldn't fit
+help: you can convert an `i32` to a `u16` and panic if the converted value doesn't fit
    |
 LL |     identity_u16(y.try_into().unwrap());
    |                  ^^^^^^^^^^^^^^^^^^^^^
@@ -24,7 +24,7 @@ error[E0308]: mismatched types
 LL |     identity_u16(a);
    |                  ^ expected `u16`, found `isize`
    |
-help: you can convert an `isize` to a `u16` and panic if the converted value wouldn't fit
+help: you can convert an `isize` to a `u16` and panic if the converted value doesn't fit
    |
 LL |     identity_u16(a.try_into().unwrap());
    |                  ^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/tutorial-suffix-inference-test.stderr
+++ b/src/test/ui/tutorial-suffix-inference-test.stderr
@@ -5,7 +5,7 @@ LL |     identity_u16(x);
    |                  ^
    |                  |
    |                  expected `u16`, found `u8`
-   |                  help: you can convert a `u8` to `u16`: `x.into()`
+   |                  help: you can convert a `u8` to a `u16`: `x.into()`
 
 error[E0308]: mismatched types
   --> $DIR/tutorial-suffix-inference-test.rs:12:18
@@ -13,7 +13,7 @@ error[E0308]: mismatched types
 LL |     identity_u16(y);
    |                  ^ expected `u16`, found `i32`
    |
-help: you can convert an `i32` to `u16` and panic if the converted value wouldn't fit
+help: you can convert an `i32` to a `u16` and panic if the converted value wouldn't fit
    |
 LL |     identity_u16(y.try_into().unwrap());
    |                  ^^^^^^^^^^^^^^^^^^^^^
@@ -24,7 +24,7 @@ error[E0308]: mismatched types
 LL |     identity_u16(a);
    |                  ^ expected `u16`, found `isize`
    |
-help: you can convert an `isize` to `u16` and panic if the converted value wouldn't fit
+help: you can convert an `isize` to a `u16` and panic if the converted value wouldn't fit
    |
 LL |     identity_u16(a.try_into().unwrap());
    |                  ^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/wrong-ret-type.stderr
+++ b/src/test/ui/wrong-ret-type.stderr
@@ -6,7 +6,7 @@ LL | fn mk_int() -> usize { let i: isize = 3; return i; }
    |                |
    |                expected `usize` because of return type
    |
-help: you can convert an `isize` to `usize` and panic if the converted value wouldn't fit
+help: you can convert an `isize` to a `usize` and panic if the converted value wouldn't fit
    |
 LL | fn mk_int() -> usize { let i: isize = 3; return i.try_into().unwrap(); }
    |                                                 ^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/wrong-ret-type.stderr
+++ b/src/test/ui/wrong-ret-type.stderr
@@ -6,7 +6,7 @@ LL | fn mk_int() -> usize { let i: isize = 3; return i; }
    |                |
    |                expected `usize` because of return type
    |
-help: you can convert an `isize` to a `usize` and panic if the converted value wouldn't fit
+help: you can convert an `isize` to a `usize` and panic if the converted value doesn't fit
    |
 LL | fn mk_int() -> usize { let i: isize = 3; return i.try_into().unwrap(); }
    |                                                 ^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Before it always used `an`; now it uses the correct article for the type.
