### PR TITLE
Ensure that all LLVM components requested by tests are available on CI

### DIFF
--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -104,6 +104,8 @@ if [ "$RUST_RELEASE_CHANNEL" = "nightly" ] || [ "$DIST_REQUIRE_ALL_TOOLS" = "" ]
     RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --enable-missing-tools"
 fi
 
+export COMPILETEST_NEEDS_ALL_LLVM_COMPONENTS=1
+
 # Print the date from the local machine and the date from an external source to
 # check for clock drifts. An HTTP URL is used instead of HTTPS since on Azure
 # Pipelines it happened that the certificates were marked as expired.

--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -208,10 +208,13 @@ impl EarlyProps {
                 config.parse_name_value_directive(line, "needs-llvm-components")
             {
                 let components: HashSet<_> = config.llvm_components.split_whitespace().collect();
-                if !needed_components
+                if let Some(missing_component) = needed_components
                     .split_whitespace()
-                    .all(|needed_component| components.contains(needed_component))
+                    .find(|needed_component| !components.contains(needed_component))
                 {
+                    if env::var_os("COMPILETEST_NEEDS_ALL_LLVM_COMPONENTS").is_some() {
+                        panic!("missing LLVM component: {}", missing_component);
+                    }
                     return true;
                 }
             }


### PR DESCRIPTION
Addresses https://github.com/rust-lang/rust/pull/75064#issuecomment-667722652

I used an environment variable because passing a command line option all the way from CI to compiletest would be just too much hassle for this task.
I added a new variable, but any of the already existing ones defined by CI could be used instead.
r? @Mark-Simulacrum  