### PR TITLE
Add missing definitions required by the sparc-unknown-linux-gnu target

### DIFF
--- a/library/panic_unwind/src/gcc.rs
+++ b/library/panic_unwind/src/gcc.rs
@@ -114,7 +114,7 @@ const UNWIND_DATA_REG: (i32, i32) = (3, 4); // R3, R4 / X3, X4
 #[cfg(target_arch = "s390x")]
 const UNWIND_DATA_REG: (i32, i32) = (6, 7); // R6, R7
 
-#[cfg(target_arch = "sparc64")]
+#[cfg(any(target_arch = "sparc", target_arch = "sparc64"))]
 const UNWIND_DATA_REG: (i32, i32) = (24, 25); // I0, I1
 
 #[cfg(target_arch = "hexagon")]

--- a/library/std/src/os/linux/raw.rs
+++ b/library/std/src/os/linux/raw.rs
@@ -29,6 +29,7 @@ pub use self::arch::{blkcnt_t, blksize_t, ino_t, nlink_t, off_t, stat, time_t};
     target_arch = "x86",
     target_arch = "le32",
     target_arch = "powerpc",
+    target_arch = "sparc",
     target_arch = "arm",
     target_arch = "asmjs",
     target_arch = "wasm32"

--- a/library/std/src/sys_common/alloc.rs
+++ b/library/std/src/sys_common/alloc.rs
@@ -12,6 +12,7 @@ use crate::ptr;
     target_arch = "mips",
     target_arch = "powerpc",
     target_arch = "powerpc64",
+    target_arch = "sparc",
     target_arch = "asmjs",
     target_arch = "wasm32",
     target_arch = "hexagon",

--- a/library/unwind/src/libunwind.rs
+++ b/library/unwind/src/libunwind.rs
@@ -51,7 +51,7 @@ pub const unwinder_private_data_size: usize = 2;
 #[cfg(target_arch = "s390x")]
 pub const unwinder_private_data_size: usize = 2;
 
-#[cfg(target_arch = "sparc64")]
+#[cfg(any(target_arch = "sparc", target_arch = "sparc64"))]
 pub const unwinder_private_data_size: usize = 2;
 
 #[cfg(any(target_arch = "riscv64", target_arch = "riscv32"))]


### PR DESCRIPTION
This PR adds a few missing definitions required by sparc-unknown-linux-target which were discovered during build tests.