### PR TITLE
library: Forward compiler-builtins "mem" feature

### DIFF
--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -59,6 +59,7 @@ gimli-symbolize = []
 panic-unwind = ["panic_unwind"]
 profiler = ["profiler_builtins"]
 compiler-builtins-c = ["alloc/compiler-builtins-c"]
+compiler-builtins-mem = ["alloc/compiler-builtins-mem"]
 llvm-libunwind = ["unwind/llvm-libunwind"]
 
 # Make panics and failed asserts immediately abort without formatting any message

--- a/library/test/Cargo.toml
+++ b/library/test/Cargo.toml
@@ -25,6 +25,7 @@ proc_macro = { path = "../proc_macro" }
 default = ["std_detect_file_io", "std_detect_dlsym_getauxval", "panic-unwind"]
 backtrace = ["std/backtrace"]
 compiler-builtins-c = ["std/compiler-builtins-c"]
+compiler-builtins-mem = ["std/compiler-builtins-mem"]
 llvm-libunwind = ["std/llvm-libunwind"]
 panic-unwind = ["std/panic_unwind"]
 panic_immediate_abort = ["std/panic_immediate_abort"]


### PR DESCRIPTION
This fixes https://github.com/rust-lang/wg-cargo-std-aware/issues/53

Now users will be able to do:
```
cargo build -Zbuild-std=core -Zbuild-std-features=compiler-builtins-mem
```
and correctly get the Rust implemenations for `memcpy` and friends.

Signed-off-by: Joe Richey <joerichey@google.com>