### PR TITLE
Don't warn if the config file is somewhere other than `config.toml`

### DIFF
--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -515,7 +515,6 @@ impl Config {
         config.rust_codegen_backends = vec![INTERNER.intern_str("llvm")];
         config.deny_warnings = true;
         config.missing_tools = false;
-        config.config = PathBuf::from("config.toml");
 
         // set by bootstrap.py
         config.build = TargetSelection::from_user(&env!("BUILD_TRIPLE"));
@@ -558,10 +557,10 @@ impl Config {
         #[cfg(test)]
         let get_toml = |_| TomlConfig::default();
         #[cfg(not(test))]
-        let get_toml = |file: PathBuf| {
+        let get_toml = |file: &Path| {
             use std::process;
 
-            let contents = t!(fs::read_to_string(&file), "`include` config not found");
+            let contents = t!(fs::read_to_string(file), "`include` config not found");
             match toml::from_str(&contents) {
                 Ok(table) => table,
                 Err(err) => {
@@ -571,18 +570,21 @@ impl Config {
             }
         };
 
-        let mut toml = flags.config.map(get_toml).unwrap_or_else(TomlConfig::default);
+        let mut toml = flags.config.as_deref().map(get_toml).unwrap_or_else(TomlConfig::default);
         if let Some(include) = &toml.profile {
             let mut include_path = config.src.clone();
             include_path.push("src");
             include_path.push("bootstrap");
             include_path.push("defaults");
             include_path.push(format!("config.toml.{}", include));
-            let included_toml = get_toml(include_path);
+            let included_toml = get_toml(&include_path);
             toml.merge(included_toml);
         }
 
         config.changelog_seen = toml.changelog_seen;
+        if let Some(cfg) = flags.config {
+            config.config = cfg;
+        }
 
         let build = toml.build.unwrap_or_default();
 


### PR DESCRIPTION
Previously, `config.config` was always hardcoded as `"config.toml"`.
I thought that it was being overridden with the actual value later, but
it turns out `flags.config` was being completely discarded. This keeps
`config.config` in sync with `flags.config`.

Fixes https://github.com/rust-lang/rust/issues/77293
r? @Mark-Simulacrum 
cc @davidtwco 