### PR TITLE
[beta] backports

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -37,7 +37,7 @@
 [submodule "src/llvm-project"]
 	path = src/llvm-project
 	url = https://github.com/rust-lang/llvm-project.git
-	branch = rustc/11.0-2020-08-20
+	branch = rustc/11.0-2020-09-22
 [submodule "src/doc/embedded-book"]
 	path = src/doc/embedded-book
 	url = https://github.com/rust-embedded/book.git

--- a/library/core/src/any.rs
+++ b/library/core/src/any.rs
@@ -435,7 +435,7 @@ impl TypeId {
     /// assert_eq!(is_string(&"cookie monster".to_string()), true);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_const_unstable(feature = "const_type_id", issue = "63084")]
+    #[rustc_const_unstable(feature = "const_type_id", issue = "77125")]
     pub const fn of<T: ?Sized + 'static>() -> TypeId {
         TypeId { t: intrinsics::type_id::<T>() }
     }

--- a/library/core/src/any.rs
+++ b/library/core/src/any.rs
@@ -435,7 +435,7 @@ impl TypeId {
     /// assert_eq!(is_string(&"cookie monster".to_string()), true);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_const_stable(feature = "const_type_id", since = "1.46.0")]
+    #[rustc_const_unstable(feature = "const_type_id", issue = "63084")]
     pub const fn of<T: ?Sized + 'static>() -> TypeId {
         TypeId { t: intrinsics::type_id::<T>() }
     }

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -807,7 +807,7 @@ extern "rust-intrinsic" {
     /// crate it is invoked in.
     ///
     /// The stabilized version of this intrinsic is [`crate::any::TypeId::of`].
-    #[rustc_const_unstable(feature = "const_type_id", issue = "63084")]
+    #[rustc_const_unstable(feature = "const_type_id", issue = "77125")]
     pub fn type_id<T: ?Sized + 'static>() -> u64;
 
     /// A guard for unsafe functions that cannot ever be executed if `T` is uninhabited:

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -807,7 +807,7 @@ extern "rust-intrinsic" {
     /// crate it is invoked in.
     ///
     /// The stabilized version of this intrinsic is [`crate::any::TypeId::of`].
-    #[rustc_const_stable(feature = "const_type_id", since = "1.46.0")]
+    #[rustc_const_unstable(feature = "const_type_id", issue = "63084")]
     pub fn type_id<T: ?Sized + 'static>() -> u64;
 
     /// A guard for unsafe functions that cannot ever be executed if `T` is uninhabited:

--- a/library/core/src/iter/adapters/fuse.rs
+++ b/library/core/src/iter/adapters/fuse.rs
@@ -116,7 +116,7 @@ where
     }
 
     #[inline]
-    unsafe fn get_unchecked(&mut self, idx: usize) -> Self::Item
+    unsafe fn __iterator_get_unchecked(&mut self, idx: usize) -> Self::Item
     where
         Self: TrustedRandomAccess,
     {

--- a/library/core/src/iter/adapters/mod.rs
+++ b/library/core/src/iter/adapters/mod.rs
@@ -215,7 +215,7 @@ where
         self.it.count()
     }
 
-    unsafe fn get_unchecked(&mut self, idx: usize) -> T
+    unsafe fn __iterator_get_unchecked(&mut self, idx: usize) -> T
     where
         Self: TrustedRandomAccess,
     {
@@ -350,7 +350,7 @@ where
         self.it.map(T::clone).fold(init, f)
     }
 
-    unsafe fn get_unchecked(&mut self, idx: usize) -> T
+    unsafe fn __iterator_get_unchecked(&mut self, idx: usize) -> T
     where
         Self: TrustedRandomAccess,
     {
@@ -865,7 +865,7 @@ where
         self.iter.fold(init, map_fold(self.f, g))
     }
 
-    unsafe fn get_unchecked(&mut self, idx: usize) -> B
+    unsafe fn __iterator_get_unchecked(&mut self, idx: usize) -> B
     where
         Self: TrustedRandomAccess,
     {
@@ -1304,7 +1304,7 @@ where
         self.iter.fold(init, enumerate(self.count, fold))
     }
 
-    unsafe fn get_unchecked(&mut self, idx: usize) -> <Self as Iterator>::Item
+    unsafe fn __iterator_get_unchecked(&mut self, idx: usize) -> <Self as Iterator>::Item
     where
         Self: TrustedRandomAccess,
     {

--- a/library/core/src/iter/adapters/zip.rs
+++ b/library/core/src/iter/adapters/zip.rs
@@ -59,7 +59,7 @@ where
     }
 
     #[inline]
-    unsafe fn get_unchecked(&mut self, idx: usize) -> Self::Item
+    unsafe fn __iterator_get_unchecked(&mut self, idx: usize) -> Self::Item
     where
         Self: TrustedRandomAccess,
     {
@@ -197,12 +197,14 @@ where
             let i = self.index;
             self.index += 1;
             // SAFETY: `i` is smaller than `self.len`, thus smaller than `self.a.len()` and `self.b.len()`
-            unsafe { Some((self.a.get_unchecked(i), self.b.get_unchecked(i))) }
+            unsafe {
+                Some((self.a.__iterator_get_unchecked(i), self.b.__iterator_get_unchecked(i)))
+            }
         } else if A::may_have_side_effect() && self.index < self.a.size() {
             // match the base implementation's potential side effects
             // SAFETY: we just checked that `self.index` < `self.a.len()`
             unsafe {
-                self.a.get_unchecked(self.index);
+                self.a.__iterator_get_unchecked(self.index);
             }
             self.index += 1;
             None
@@ -229,13 +231,13 @@ where
                 // ensures that `end` is smaller than or equal to `self.len`,
                 // so `i` is also smaller than `self.len`.
                 unsafe {
-                    self.a.get_unchecked(i);
+                    self.a.__iterator_get_unchecked(i);
                 }
             }
             if B::may_have_side_effect() {
                 // SAFETY: same as above.
                 unsafe {
-                    self.b.get_unchecked(i);
+                    self.b.__iterator_get_unchecked(i);
                 }
             }
         }
@@ -277,7 +279,9 @@ where
             let i = self.len;
             // SAFETY: `i` is smaller than the previous value of `self.len`,
             // which is also smaller than or equal to `self.a.len()` and `self.b.len()`
-            unsafe { Some((self.a.get_unchecked(i), self.b.get_unchecked(i))) }
+            unsafe {
+                Some((self.a.__iterator_get_unchecked(i), self.b.__iterator_get_unchecked(i)))
+            }
         } else {
             None
         }
@@ -287,7 +291,7 @@ where
     unsafe fn get_unchecked(&mut self, idx: usize) -> <Self as Iterator>::Item {
         // SAFETY: the caller must uphold the contract for
         // `Iterator::get_unchecked`.
-        unsafe { (self.a.get_unchecked(idx), self.b.get_unchecked(idx)) }
+        unsafe { (self.a.__iterator_get_unchecked(idx), self.b.__iterator_get_unchecked(idx)) }
     }
 }
 
@@ -430,6 +434,6 @@ unsafe impl<I: Iterator + TrustedRandomAccess> SpecTrustedRandomAccess for I {
     unsafe fn try_get_unchecked(&mut self, index: usize) -> Self::Item {
         // SAFETY: the caller must uphold the contract for
         // `Iterator::get_unchecked`.
-        unsafe { self.get_unchecked(index) }
+        unsafe { self.__iterator_get_unchecked(index) }
     }
 }

--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -3251,7 +3251,7 @@ pub trait Iterator {
     #[inline]
     #[doc(hidden)]
     #[unstable(feature = "trusted_random_access", issue = "none")]
-    unsafe fn get_unchecked(&mut self, _idx: usize) -> Self::Item
+    unsafe fn __iterator_get_unchecked(&mut self, _idx: usize) -> Self::Item
     where
         Self: TrustedRandomAccess,
     {

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -92,6 +92,7 @@
 #![feature(const_slice_ptr_len)]
 #![feature(const_size_of_val)]
 #![feature(const_align_of_val)]
+#![feature(const_type_id)]
 #![feature(const_type_name)]
 #![feature(const_likely)]
 #![feature(const_unreachable_unchecked)]

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -3922,7 +3922,7 @@ macro_rules! iterator {
             }
 
             #[doc(hidden)]
-            unsafe fn get_unchecked(&mut self, idx: usize) -> Self::Item {
+            unsafe fn __iterator_get_unchecked(&mut self, idx: usize) -> Self::Item {
                 // SAFETY: the caller must guarantee that `i` is in bounds of
                 // the underlying slice, so `i` cannot overflow an `isize`, and
                 // the returned references is guaranteed to refer to an element
@@ -5022,7 +5022,7 @@ impl<'a, T> Iterator for Windows<'a, T> {
     }
 
     #[doc(hidden)]
-    unsafe fn get_unchecked(&mut self, idx: usize) -> Self::Item {
+    unsafe fn __iterator_get_unchecked(&mut self, idx: usize) -> Self::Item {
         // SAFETY: since the caller guarantees that `i` is in bounds,
         // which means that `i` cannot overflow an `isize`, and the
         // slice created by `from_raw_parts` is a subslice of `self.v`
@@ -5161,7 +5161,7 @@ impl<'a, T> Iterator for Chunks<'a, T> {
     }
 
     #[doc(hidden)]
-    unsafe fn get_unchecked(&mut self, idx: usize) -> Self::Item {
+    unsafe fn __iterator_get_unchecked(&mut self, idx: usize) -> Self::Item {
         let start = idx * self.chunk_size;
         let end = match start.checked_add(self.chunk_size) {
             None => self.v.len(),
@@ -5310,7 +5310,7 @@ impl<'a, T> Iterator for ChunksMut<'a, T> {
     }
 
     #[doc(hidden)]
-    unsafe fn get_unchecked(&mut self, idx: usize) -> Self::Item {
+    unsafe fn __iterator_get_unchecked(&mut self, idx: usize) -> Self::Item {
         let start = idx * self.chunk_size;
         let end = match start.checked_add(self.chunk_size) {
             None => self.v.len(),
@@ -5463,7 +5463,7 @@ impl<'a, T> Iterator for ChunksExact<'a, T> {
     }
 
     #[doc(hidden)]
-    unsafe fn get_unchecked(&mut self, idx: usize) -> Self::Item {
+    unsafe fn __iterator_get_unchecked(&mut self, idx: usize) -> Self::Item {
         let start = idx * self.chunk_size;
         // SAFETY: mostly identical to `Chunks::get_unchecked`.
         unsafe { from_raw_parts(self.v.as_ptr().add(start), self.chunk_size) }
@@ -5597,7 +5597,7 @@ impl<'a, T> Iterator for ChunksExactMut<'a, T> {
     }
 
     #[doc(hidden)]
-    unsafe fn get_unchecked(&mut self, idx: usize) -> Self::Item {
+    unsafe fn __iterator_get_unchecked(&mut self, idx: usize) -> Self::Item {
         let start = idx * self.chunk_size;
         // SAFETY: see comments for `ChunksMut::get_unchecked`.
         unsafe { from_raw_parts_mut(self.v.as_mut_ptr().add(start), self.chunk_size) }
@@ -5723,10 +5723,10 @@ impl<'a, T, const N: usize> Iterator for ArrayChunks<'a, T, N> {
         self.iter.last()
     }
 
-    unsafe fn get_unchecked(&mut self, i: usize) -> &'a [T; N] {
+    unsafe fn __iterator_get_unchecked(&mut self, i: usize) -> &'a [T; N] {
         // SAFETY: The safety guarantees of `get_unchecked` are transferred to
         // the caller.
-        unsafe { self.iter.get_unchecked(i) }
+        unsafe { self.iter.__iterator_get_unchecked(i) }
     }
 }
 
@@ -5853,7 +5853,7 @@ impl<'a, T> Iterator for RChunks<'a, T> {
     }
 
     #[doc(hidden)]
-    unsafe fn get_unchecked(&mut self, idx: usize) -> Self::Item {
+    unsafe fn __iterator_get_unchecked(&mut self, idx: usize) -> Self::Item {
         let end = self.v.len() - idx * self.chunk_size;
         let start = match end.checked_sub(self.chunk_size) {
             None => 0,
@@ -5999,7 +5999,7 @@ impl<'a, T> Iterator for RChunksMut<'a, T> {
     }
 
     #[doc(hidden)]
-    unsafe fn get_unchecked(&mut self, idx: usize) -> Self::Item {
+    unsafe fn __iterator_get_unchecked(&mut self, idx: usize) -> Self::Item {
         let end = self.v.len() - idx * self.chunk_size;
         let start = match end.checked_sub(self.chunk_size) {
             None => 0,
@@ -6145,7 +6145,7 @@ impl<'a, T> Iterator for RChunksExact<'a, T> {
     }
 
     #[doc(hidden)]
-    unsafe fn get_unchecked(&mut self, idx: usize) -> Self::Item {
+    unsafe fn __iterator_get_unchecked(&mut self, idx: usize) -> Self::Item {
         let end = self.v.len() - idx * self.chunk_size;
         let start = end - self.chunk_size;
         // SAFETY:
@@ -6286,7 +6286,7 @@ impl<'a, T> Iterator for RChunksExactMut<'a, T> {
     }
 
     #[doc(hidden)]
-    unsafe fn get_unchecked(&mut self, idx: usize) -> Self::Item {
+    unsafe fn __iterator_get_unchecked(&mut self, idx: usize) -> Self::Item {
         let end = self.v.len() - idx * self.chunk_size;
         let start = end - self.chunk_size;
         // SAFETY: see comments for `RChunksMut::get_unchecked`.

--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -824,10 +824,10 @@ impl Iterator for Bytes<'_> {
     }
 
     #[inline]
-    unsafe fn get_unchecked(&mut self, idx: usize) -> u8 {
+    unsafe fn __iterator_get_unchecked(&mut self, idx: usize) -> u8 {
         // SAFETY: the caller must uphold the safety contract
         // for `Iterator::get_unchecked`.
-        unsafe { self.0.get_unchecked(idx) }
+        unsafe { self.0.__iterator_get_unchecked(idx) }
     }
 }
 

--- a/src/librustc_mir/transform/simplify_try.rs
+++ b/src/librustc_mir/transform/simplify_try.rs
@@ -616,7 +616,7 @@ impl<'a, 'tcx> SimplifyBranchSameOptimizationFinder<'a, 'tcx> {
                     && bb_l.terminator().kind == bb_r.terminator().kind;
                     let statement_check = || {
                         bb_l.statements.iter().zip(&bb_r.statements).try_fold(StatementEquality::TrivialEqual, |acc,(l,r)| {
-                            let stmt_equality = self.statement_equality(*adt_matched_on, &l, bb_l_idx, &r, bb_r_idx);
+                            let stmt_equality = self.statement_equality(*adt_matched_on, &l, bb_l_idx, &r, bb_r_idx, self.tcx.sess.opts.debugging_opts.mir_opt_level);
                             if matches!(stmt_equality, StatementEquality::NotEqual) {
                                 // short circuit
                                 None
@@ -676,6 +676,7 @@ impl<'a, 'tcx> SimplifyBranchSameOptimizationFinder<'a, 'tcx> {
         x_bb_idx: BasicBlock,
         y: &Statement<'tcx>,
         y_bb_idx: BasicBlock,
+        mir_opt_level: usize,
     ) -> StatementEquality {
         let helper = |rhs: &Rvalue<'tcx>,
                       place: &Box<Place<'tcx>>,
@@ -694,7 +695,13 @@ impl<'a, 'tcx> SimplifyBranchSameOptimizationFinder<'a, 'tcx> {
 
             match rhs {
                 Rvalue::Use(operand) if operand.place() == Some(adt_matched_on) => {
-                    StatementEquality::ConsideredEqual(side_to_choose)
+                    // FIXME(76803): This logic is currently broken because it does not take into
+                    // account the current discriminant value.
+                    if mir_opt_level > 2 {
+                        StatementEquality::ConsideredEqual(side_to_choose)
+                    } else {
+                        StatementEquality::NotEqual
+                    }
                 }
                 _ => {
                     trace!(

--- a/src/test/mir-opt/simplify_arm.id.SimplifyBranchSame.diff
+++ b/src/test/mir-opt/simplify_arm.id.SimplifyBranchSame.diff
@@ -13,27 +13,24 @@
   
       bb0: {
           _2 = discriminant(_1);           // scope 0 at $DIR/simplify-arm.rs:11:9: 11:16
--         switchInt(move _2) -> [0_isize: bb1, 1_isize: bb3, otherwise: bb2]; // scope 0 at $DIR/simplify-arm.rs:11:9: 11:16
-+         goto -> bb1;                     // scope 0 at $DIR/simplify-arm.rs:11:9: 11:16
+          switchInt(move _2) -> [0_isize: bb1, 1_isize: bb3, otherwise: bb2]; // scope 0 at $DIR/simplify-arm.rs:11:9: 11:16
       }
   
       bb1: {
--         discriminant(_0) = 0;            // scope 0 at $DIR/simplify-arm.rs:12:17: 12:21
--         goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:10:5: 13:6
--     }
-- 
--     bb2: {
--         unreachable;                     // scope 0 at $DIR/simplify-arm.rs:10:11: 10:12
--     }
-- 
--     bb3: {
-          _0 = move _1;                    // scope 1 at $DIR/simplify-arm.rs:11:20: 11:27
--         goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:10:5: 13:6
-+         goto -> bb2;                     // scope 0 at $DIR/simplify-arm.rs:10:5: 13:6
+          discriminant(_0) = 0;            // scope 0 at $DIR/simplify-arm.rs:12:17: 12:21
+          goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:10:5: 13:6
       }
   
--     bb4: {
-+     bb2: {
+      bb2: {
+          unreachable;                     // scope 0 at $DIR/simplify-arm.rs:10:11: 10:12
+      }
+  
+      bb3: {
+          _0 = move _1;                    // scope 1 at $DIR/simplify-arm.rs:11:20: 11:27
+          goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:10:5: 13:6
+      }
+  
+      bb4: {
           return;                          // scope 0 at $DIR/simplify-arm.rs:14:2: 14:2
       }
   }

--- a/src/test/ui/consts/const-typeid-of-rpass.rs
+++ b/src/test/ui/consts/const-typeid-of-rpass.rs
@@ -1,4 +1,5 @@
 // run-pass
+#![feature(const_type_id)]
 #![feature(core_intrinsics)]
 
 use std::any::TypeId;

--- a/src/test/ui/consts/issue-73976-monomorphic.rs
+++ b/src/test/ui/consts/issue-73976-monomorphic.rs
@@ -5,6 +5,7 @@
 // will be properly rejected. This test will ensure that monomorphic use of these
 // would not be wrongly rejected in patterns.
 
+#![feature(const_type_id)]
 #![feature(const_type_name)]
 
 use std::any::{self, TypeId};

--- a/src/test/ui/consts/issue-73976-polymorphic.rs
+++ b/src/test/ui/consts/issue-73976-polymorphic.rs
@@ -5,6 +5,7 @@
 // This test case should either run-pass or be rejected at compile time.
 // Currently we just disallow this usage and require pattern is monomorphic.
 
+#![feature(const_type_id)]
 #![feature(const_type_name)]
 
 use std::any::{self, TypeId};

--- a/src/test/ui/consts/issue-73976-polymorphic.stderr
+++ b/src/test/ui/consts/issue-73976-polymorphic.stderr
@@ -1,23 +1,23 @@
 error: constant pattern depends on a generic parameter
-  --> $DIR/issue-73976-polymorphic.rs:19:37
+  --> $DIR/issue-73976-polymorphic.rs:20:37
    |
 LL |     matches!(GetTypeId::<T>::VALUE, GetTypeId::<T>::VALUE)
    |                                     ^^^^^^^^^^^^^^^^^^^^^
 
 error: constant pattern depends on a generic parameter
-  --> $DIR/issue-73976-polymorphic.rs:31:42
+  --> $DIR/issue-73976-polymorphic.rs:32:42
    |
 LL |     matches!(GetTypeNameLen::<T>::VALUE, GetTypeNameLen::<T>::VALUE)
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: constant pattern depends on a generic parameter
-  --> $DIR/issue-73976-polymorphic.rs:19:37
+  --> $DIR/issue-73976-polymorphic.rs:20:37
    |
 LL |     matches!(GetTypeId::<T>::VALUE, GetTypeId::<T>::VALUE)
    |                                     ^^^^^^^^^^^^^^^^^^^^^
 
 error: constant pattern depends on a generic parameter
-  --> $DIR/issue-73976-polymorphic.rs:31:42
+  --> $DIR/issue-73976-polymorphic.rs:32:42
    |
 LL |     matches!(GetTypeNameLen::<T>::VALUE, GetTypeNameLen::<T>::VALUE)
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/mir/issue-76803-branches-not-same.rs
+++ b/src/test/ui/mir/issue-76803-branches-not-same.rs
@@ -1,0 +1,19 @@
+// run-pass
+
+#[derive(Debug, Eq, PartialEq)]
+pub enum Type {
+    A,
+    B,
+}
+
+
+pub fn encode(v: Type) -> Type {
+    match v {
+        Type::A => Type::B,
+        _ => v,
+    }
+}
+
+fn main() {
+  assert_eq!(Type::B, encode(Type::A));
+}


### PR DESCRIPTION
This backports the following:
 *  revert const_type_id stabilization #77083 
 * [mir-opt] Disable the `ConsideredEqual` logic in SimplifyBranchSame opt #76837 
 * Rename Iterator::get_unchecked #77201 (manually, because of file renaming and other issues on master causing literal cherry-pick to fail)
 *  Rebase LLVM onto 11.0.0-rc3 #77063 (bumping direct to master, see https://github.com/rust-lang/rust/pull/77063#issuecomment-700231036).

The last two have not yet been approved by compiler team, but I'm posting this now and going to go ahead and approve as I expect both to get approved and we want testing as much as possible before release in ~2 weeks.

r? @ghost