### PR TITLE
Remove outdated line from `publish_toolstate` hook

### DIFF
--- a/src/tools/publish_toolstate.py
+++ b/src/tools/publish_toolstate.py
@@ -157,9 +157,6 @@ def issue(
 
         cc @{}, do you think you would have time to do the follow-up work?
         If so, that would be great!
-
-        And nominating for compiler team prioritization.
-
         ''').format(
             relevant_pr_number, tool, status_description,
             REPOS.get(tool), relevant_pr_user


### PR DESCRIPTION
We no longer add `I-nominated` to toolstate failure issues since T-compiler changed its meeting preparation workflow.