### PR TITLE
Remove redundant `unsafe` block in `std::hint::unreachable_unchecked`

### DIFF
--- a/library/core/src/hint.rs
+++ b/library/core/src/hint.rs
@@ -48,7 +48,7 @@ use crate::intrinsics;
 pub const unsafe fn unreachable_unchecked() -> ! {
     // SAFETY: the safety contract for `intrinsics::unreachable` must
     // be upheld by the caller.
-    unsafe { intrinsics::unreachable() }
+    intrinsics::unreachable()
 }
 
 /// Emits a machine instruction hinting to the processor that it is running in busy-wait


### PR DESCRIPTION
The whole function is already marked as `unsafe`, and so `unsafe` blocks inside it are not needed