### PR TITLE
Add unstable book docs for `-Zunsound-mir-opts`

### DIFF
--- a/src/doc/unstable-book/src/compiler-flags/unsound-mir-opts.md
+++ b/src/doc/unstable-book/src/compiler-flags/unsound-mir-opts.md
@@ -1,0 +1,8 @@
+# `unsound-mir-opts`
+
+--------------------
+
+The `-Zunsound-mir-opts` compiler flag enables [MIR optimization passes] which can cause unsound behavior.
+This flag should only be used by MIR optimization tests in the rustc test suite.
+
+[MIR optimization passes]: https://rustc-dev-guide.rust-lang.org/mir/optimizations.html


### PR DESCRIPTION
The `-Zunsound-mir-opts` flag was added in #76899.