### PR TITLE
Stabilize `Option::unwrap_none` and `Option::expect_none`

### DIFF
--- a/compiler/rustc_codegen_ssa/src/lib.rs
+++ b/compiler/rustc_codegen_ssa/src/lib.rs
@@ -1,6 +1,5 @@
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
 #![feature(bool_to_option)]
-#![feature(option_expect_none)]
 #![feature(box_patterns)]
 #![feature(try_blocks)]
 #![feature(in_band_lifetimes)]

--- a/compiler/rustc_middle/src/lib.rs
+++ b/compiler/rustc_middle/src/lib.rs
@@ -37,7 +37,6 @@
 #![feature(extern_types)]
 #![feature(nll)]
 #![feature(once_cell)]
-#![feature(option_expect_none)]
 #![feature(or_patterns)]
 #![feature(min_specialization)]
 #![feature(trusted_len)]

--- a/compiler/rustc_mir/src/lib.rs
+++ b/compiler/rustc_mir/src/lib.rs
@@ -24,7 +24,6 @@ Rust MIR: a lowered representation of Rust.
 #![feature(associated_type_defaults)]
 #![feature(stmt_expr_attributes)]
 #![feature(trait_alias)]
-#![feature(option_expect_none)]
 #![feature(or_patterns)]
 #![feature(once_cell)]
 #![recursion_limit = "256"]

--- a/compiler/rustc_span/src/lib.rs
+++ b/compiler/rustc_span/src/lib.rs
@@ -12,7 +12,6 @@
 #![feature(negative_impls)]
 #![feature(nll)]
 #![feature(min_specialization)]
-#![feature(option_expect_none)]
 
 #[macro_use]
 extern crate rustc_macros;

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -1038,8 +1038,6 @@ impl<T: fmt::Debug> Option<T> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(option_expect_none)]
-    ///
     /// use std::collections::HashMap;
     /// let mut squares = HashMap::new();
     /// for i in -10..=10 {
@@ -1049,8 +1047,6 @@ impl<T: fmt::Debug> Option<T> {
     /// ```
     ///
     /// ```{.should_panic}
-    /// #![feature(option_expect_none)]
-    ///
     /// use std::collections::HashMap;
     /// let mut sqrts = HashMap::new();
     /// for i in -10..=10 {
@@ -1061,7 +1057,7 @@ impl<T: fmt::Debug> Option<T> {
     /// ```
     #[inline]
     #[track_caller]
-    #[unstable(feature = "option_expect_none", reason = "newly added", issue = "62633")]
+    #[stable(feature = "option_expect_none", since = "1.49.0")]
     pub fn expect_none(self, msg: &str) {
         if let Some(val) = self {
             expect_none_failed(msg, &val);
@@ -1080,8 +1076,6 @@ impl<T: fmt::Debug> Option<T> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(option_unwrap_none)]
-    ///
     /// use std::collections::HashMap;
     /// let mut squares = HashMap::new();
     /// for i in -10..=10 {
@@ -1091,8 +1085,6 @@ impl<T: fmt::Debug> Option<T> {
     /// ```
     ///
     /// ```{.should_panic}
-    /// #![feature(option_unwrap_none)]
-    ///
     /// use std::collections::HashMap;
     /// let mut sqrts = HashMap::new();
     /// for i in -10..=10 {
@@ -1103,7 +1095,7 @@ impl<T: fmt::Debug> Option<T> {
     /// ```
     #[inline]
     #[track_caller]
-    #[unstable(feature = "option_unwrap_none", reason = "newly added", issue = "62633")]
+    #[stable(feature = "option_unwrap_none", since = "1.49.0")]
     pub fn unwrap_none(self) {
         if let Some(val) = self {
             expect_none_failed("called `Option::unwrap_none()` on a `Some` value", &val);

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -52,7 +52,6 @@
 #![feature(const_raw_ptr_deref)]
 #![feature(never_type)]
 #![feature(unwrap_infallible)]
-#![feature(option_unwrap_none)]
 #![feature(peekable_next_if)]
 #![feature(partition_point)]
 #![feature(once_cell)]

--- a/src/test/ui/rfc-2091-track-caller/std-panic-locations.rs
+++ b/src/test/ui/rfc-2091-track-caller/std-panic-locations.rs
@@ -1,7 +1,6 @@
 // run-pass
 // ignore-wasm32-bare compiled with panic=abort by default
 
-#![feature(option_expect_none, option_unwrap_none)]
 #![allow(unconditional_panic)]
 
 //! Test that panic locations for `#[track_caller]` functions in std have the correct


### PR DESCRIPTION
cc #62633

These methods have been on nightly for over a year without any issues.