### PR TITLE
When arriving on a search result page, we want to focus on the search…

### DIFF
--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -576,6 +576,7 @@ function defocusSearchBar() {
         // suddenly your search is gone!
         if (search_input.value === "") {
             search_input.value = params.search || "";
+            search_input.focus();
         }
 
         /**


### PR DESCRIPTION
When you arrive on a search result page (for example, any page with a URL parameter "search=..."), you get the search results but since the focus isn't on the search input, you can't navigate using the keyboard, which is a bit annoying. This PR fixes it.

r? @jyn514 