### PR TITLE
Always use the Rust version in package names

### DIFF
--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -26,24 +26,7 @@ use crate::{Compiler, DependencyType, Mode, LLVM_TOOLS};
 use time::{self, Timespec};
 
 pub fn pkgname(builder: &Builder<'_>, component: &str) -> String {
-    if component == "cargo" {
-        format!("{}-{}", component, builder.cargo_package_vers())
-    } else if component == "rls" {
-        format!("{}-{}", component, builder.rls_package_vers())
-    } else if component == "rust-analyzer" {
-        format!("{}-{}", component, builder.rust_analyzer_package_vers())
-    } else if component == "clippy" {
-        format!("{}-{}", component, builder.clippy_package_vers())
-    } else if component == "miri" {
-        format!("{}-{}", component, builder.miri_package_vers())
-    } else if component == "rustfmt" {
-        format!("{}-{}", component, builder.rustfmt_package_vers())
-    } else if component == "llvm-tools" {
-        format!("{}-{}", component, builder.llvm_tools_package_vers())
-    } else {
-        assert!(component.starts_with("rust"));
-        format!("{}-{}", component, builder.rust_package_vers())
-    }
+    format!("{}-{}", component, builder.rust_package_vers())
 }
 
 pub(crate) fn distdir(builder: &Builder<'_>) -> PathBuf {

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -1051,40 +1051,6 @@ impl Build {
         self.package_vers(&self.version)
     }
 
-    /// Returns the value of `package_vers` above for Cargo
-    fn cargo_package_vers(&self) -> String {
-        self.package_vers(&self.release_num("cargo"))
-    }
-
-    /// Returns the value of `package_vers` above for rls
-    fn rls_package_vers(&self) -> String {
-        self.package_vers(&self.release_num("rls"))
-    }
-
-    /// Returns the value of `package_vers` above for rust-analyzer
-    fn rust_analyzer_package_vers(&self) -> String {
-        self.package_vers(&self.release_num("rust-analyzer/crates/rust-analyzer"))
-    }
-
-    /// Returns the value of `package_vers` above for clippy
-    fn clippy_package_vers(&self) -> String {
-        self.package_vers(&self.release_num("clippy"))
-    }
-
-    /// Returns the value of `package_vers` above for miri
-    fn miri_package_vers(&self) -> String {
-        self.package_vers(&self.release_num("miri"))
-    }
-
-    /// Returns the value of `package_vers` above for rustfmt
-    fn rustfmt_package_vers(&self) -> String {
-        self.package_vers(&self.release_num("rustfmt"))
-    }
-
-    fn llvm_tools_package_vers(&self) -> String {
-        self.package_vers(&self.version)
-    }
-
     fn llvm_tools_vers(&self) -> String {
         self.rust_version()
     }

--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -252,7 +252,7 @@ impl Builder {
         }
         let manifest = self.build_manifest();
 
-        let rust_version = self.versions.package_version(&PkgType::Rust).unwrap();
+        let rust_version = self.versions.rustc_version();
         self.write_channel_files(self.versions.channel(), &manifest);
         if self.versions.channel() != rust_version {
             self.write_channel_files(&rust_version, &manifest);


### PR DESCRIPTION
The format of the tarballs produced by CI is roughly the following:

    {component}-{release}-{target}.{ext}

While on the beta and nightly channels `{release}` is just the channel name, on the stable channel is either the Rust version or the version of the component we're shipping:

    cargo-0.47.0-x86_64-unknown-linux-gnu.tar.xz
    clippy-0.0.212-x86_64-unknown-linux-gnu.tar.xz
    llvm-tools-1.46.0-x86_64-unknown-linux-gnu.tar.xz
    miri-0.1.0-x86_64-unknown-linux-gnu.tar.xz
    rls-1.41.0-x86_64-unknown-linux-gnu.tar.xz
    rust-1.46.0-x86_64-unknown-linux-gnu.tar.xz
    ...

This makes it really hard to get the package URL without having access to the manifest (and there is no manifest on ci-artifacts.rlo), as there is no consistent version number to use.

This PR addresses the problem by always using the Rust version number as `{release}` for the stable channel, regardless of the version number of the component we're shipping. I chose that instead of "stable" to avoid breaking the URL scheme *that* much.

Rustup should not be affected by this change, as it fetches the URLs from the manifest. Unfortunately we don't have a way to test other clients before making a stable release, as this change only affects the stable channel.

r? @Mark-Simulacrum 