### PR TITLE
Add asm! support for mips64

### DIFF
--- a/compiler/rustc_codegen_llvm/src/asm.rs
+++ b/compiler/rustc_codegen_llvm/src/asm.rs
@@ -259,7 +259,7 @@ impl AsmBuilderMethods<'tcx> for Builder<'a, 'll, 'tcx> {
                 InlineAsmArch::RiscV32 | InlineAsmArch::RiscV64 => {}
                 InlineAsmArch::Nvptx64 => {}
                 InlineAsmArch::Hexagon => {}
-                InlineAsmArch::Mips => {}
+                InlineAsmArch::Mips | InlineAsmArch::Mips64 => {}
             }
         }
         if !options.contains(InlineAsmOptions::NOMEM) {
@@ -710,6 +710,7 @@ fn llvm_fixup_input(
             // MIPS only supports register-length arithmetics.
             Primitive::Int(Integer::I8 | Integer::I16, _) => bx.zext(value, bx.cx.type_i32()),
             Primitive::F32 => bx.bitcast(value, bx.cx.type_i32()),
+            Primitive::F64 => bx.bitcast(value, bx.cx.type_i64()),
             _ => value,
         },
         _ => value,
@@ -785,6 +786,7 @@ fn llvm_fixup_output(
             Primitive::Int(Integer::I8, _) => bx.trunc(value, bx.cx.type_i8()),
             Primitive::Int(Integer::I16, _) => bx.trunc(value, bx.cx.type_i16()),
             Primitive::F32 => bx.bitcast(value, bx.cx.type_f32()),
+            Primitive::F64 => bx.bitcast(value, bx.cx.type_f64()),
             _ => value,
         },
         _ => value,
@@ -854,6 +856,7 @@ fn llvm_fixup_output_type(
             // MIPS only supports register-length arithmetics.
             Primitive::Int(Integer::I8 | Integer::I16, _) => cx.type_i32(),
             Primitive::F32 => cx.type_i32(),
+            Primitive::F64 => cx.type_i64(),
             _ => layout.llvm_type(cx),
         },
         _ => layout.llvm_type(cx),

--- a/compiler/rustc_target/src/asm/mips.rs
+++ b/compiler/rustc_target/src/asm/mips.rs
@@ -45,31 +45,31 @@ impl MipsInlineAsmRegClass {
 // The reserved registers are somewhat taken from <https://git.io/JUR1k#L150>.
 def_regs! {
     Mips MipsInlineAsmReg MipsInlineAsmRegClass {
-        v0: reg = ["$2", "$v0"],
-        v1: reg = ["$3", "$v1"],
-        a0: reg = ["$4", "$a0"],
-        a1: reg = ["$5", "$a1"],
-        a2: reg = ["$6", "$a2"],
-        a3: reg = ["$7", "$a3"],
+        r2: reg = ["$2"],
+        r3: reg = ["$3"],
+        r4: reg = ["$4"],
+        r5: reg = ["$5"],
+        r6: reg = ["$6"],
+        r7: reg = ["$7"],
         // FIXME: Reserve $t0, $t1 if in mips16 mode.
-        t0: reg = ["$8", "$t0"],
-        t1: reg = ["$9", "$t1"],
-        t2: reg = ["$10", "$t2"],
-        t3: reg = ["$11", "$t3"],
-        t4: reg = ["$12", "$t4"],
-        t5: reg = ["$13", "$t5"],
-        t6: reg = ["$14", "$t6"],
-        t7: reg = ["$15", "$t7"],
-        s0: reg = ["$16", "$s0"],
-        s1: reg = ["$17", "$s1"],
-        s2: reg = ["$18", "$s2"],
-        s3: reg = ["$19", "$s3"],
-        s4: reg = ["$20", "$s4"],
-        s5: reg = ["$21", "$s5"],
-        s6: reg = ["$22", "$s6"],
-        s7: reg = ["$23", "$s7"],
-        t8: reg = ["$24", "$t8"],
-        t9: reg = ["$25", "$t9"],
+        r8: reg = ["$8"],
+        r9: reg = ["$9"],
+        r10: reg = ["$10"],
+        r11: reg = ["$11"],
+        r12: reg = ["$12"],
+        r13: reg = ["$13"],
+        r14: reg = ["$14"],
+        r15: reg = ["$15"],
+        r16: reg = ["$16"],
+        r17: reg = ["$17"],
+        r18: reg = ["$18"],
+        r19: reg = ["$19"],
+        r20: reg = ["$20"],
+        r21: reg = ["$21"],
+        r22: reg = ["$22"],
+        r23: reg = ["$23"],
+        r24: reg = ["$24"],
+        r25: reg = ["$25"],
         f0: freg = ["$f0"],
         f1: freg = ["$f1"],
         f2: freg = ["$f2"],
@@ -102,21 +102,21 @@ def_regs! {
         f29: freg = ["$f29"],
         f30: freg = ["$f30"],
         f31: freg = ["$f31"],
-        #error = ["$0", "$zero"] =>
+        #error = ["$0"] =>
             "constant zero cannot be used as an operand for inline asm",
-        #error = ["$1", "$at"] =>
+        #error = ["$1"] =>
             "reserved for assembler (Assembler Temp)",
-        #error = ["$26", "$k0"] =>
+        #error = ["$26"] =>
             "OS-reserved register cannot be used as an operand for inline asm",
-        #error = ["$27", "$k1"] =>
+        #error = ["$27"] =>
             "OS-reserved register cannot be used as an operand for inline asm",
-        #error = ["$28", "$gp"] =>
+        #error = ["$28"] =>
             "the global pointer cannot be used as an operand for inline asm",
-        #error = ["$29", "$sp"] =>
+        #error = ["$29"] =>
             "the stack pointer cannot be used as an operand for inline asm",
-        #error = ["$30", "$s8", "$fp"] =>
+        #error = ["$30"] =>
             "the frame pointer cannot be used as an operand for inline asm",
-        #error = ["$31", "$ra"] =>
+        #error = ["$31"] =>
             "the return address register cannot be used as an operand for inline asm",
     }
 }

--- a/compiler/rustc_target/src/asm/mips.rs
+++ b/compiler/rustc_target/src/asm/mips.rs
@@ -32,11 +32,12 @@ impl MipsInlineAsmRegClass {
 
     pub fn supported_types(
         self,
-        _arch: InlineAsmArch,
+        arch: InlineAsmArch,
     ) -> &'static [(InlineAsmType, Option<&'static str>)] {
-        match self {
-            Self::reg => types! { _: I8, I16, I32, F32; },
-            Self::freg => types! { _: F32, F64; },
+        match (self, arch) {
+            (Self::reg, InlineAsmArch::Mips64) => types! { _: I8, I16, I32, I64, F32, F64; },
+            (Self::reg, _) => types! { _: I8, I16, I32, F32; },
+            (Self::freg, _) => types! { _: F32, F64; },
         }
     }
 }

--- a/compiler/rustc_target/src/asm/mips.rs
+++ b/compiler/rustc_target/src/asm/mips.rs
@@ -36,7 +36,7 @@ impl MipsInlineAsmRegClass {
     ) -> &'static [(InlineAsmType, Option<&'static str>)] {
         match self {
             Self::reg => types! { _: I8, I16, I32, F32; },
-            Self::freg => types! { _: F32; },
+            Self::freg => types! { _: F32, F64; },
         }
     }
 }

--- a/compiler/rustc_target/src/asm/mod.rs
+++ b/compiler/rustc_target/src/asm/mod.rs
@@ -176,6 +176,7 @@ pub enum InlineAsmArch {
     Nvptx64,
     Hexagon,
     Mips,
+    Mips64,
 }
 
 impl FromStr for InlineAsmArch {
@@ -192,6 +193,7 @@ impl FromStr for InlineAsmArch {
             "nvptx64" => Ok(Self::Nvptx64),
             "hexagon" => Ok(Self::Hexagon),
             "mips" => Ok(Self::Mips),
+            "mips64" => Ok(Self::Mips64),
             _ => Err(()),
         }
     }
@@ -259,7 +261,7 @@ impl InlineAsmReg {
             InlineAsmArch::Hexagon => {
                 Self::Hexagon(HexagonInlineAsmReg::parse(arch, has_feature, target, &name)?)
             }
-            InlineAsmArch::Mips => {
+            InlineAsmArch::Mips | InlineAsmArch::Mips64 => {
                 Self::Mips(MipsInlineAsmReg::parse(arch, has_feature, target, &name)?)
             }
         })
@@ -409,7 +411,9 @@ impl InlineAsmRegClass {
                 InlineAsmArch::Hexagon => {
                     Self::Hexagon(HexagonInlineAsmRegClass::parse(arch, name)?)
                 }
-                InlineAsmArch::Mips => Self::Mips(MipsInlineAsmRegClass::parse(arch, name)?),
+                InlineAsmArch::Mips | InlineAsmArch::Mips64 => {
+                    Self::Mips(MipsInlineAsmRegClass::parse(arch, name)?)
+                }
             })
         })
     }
@@ -565,7 +569,7 @@ pub fn allocatable_registers(
             hexagon::fill_reg_map(arch, has_feature, target, &mut map);
             map
         }
-        InlineAsmArch::Mips => {
+        InlineAsmArch::Mips | InlineAsmArch::Mips64 => {
             let mut map = mips::regclass_map();
             mips::fill_reg_map(arch, has_feature, target, &mut map);
             map

--- a/src/doc/unstable-book/src/library-features/asm.md
+++ b/src/doc/unstable-book/src/library-features/asm.md
@@ -27,7 +27,7 @@ Inline assembly is currently supported on the following architectures:
 - RISC-V
 - NVPTX
 - Hexagon
-- MIPS32
+- MIPS32r2 and MIPS64r2
 
 ## Basic usage
 
@@ -513,8 +513,8 @@ Here is the list of currently supported register classes:
 | ARM | `qreg` | `q[0-15]` | `w` |
 | ARM | `qreg_low8` | `q[0-7]` | `t` |
 | ARM | `qreg_low4` | `q[0-3]` | `x` |
-| MIPS32 | `reg` | `$[2-25]` | `r` |
-| MIPS32 | `freg` | `$f[0-31]` | `f` |
+| MIPS | `reg` | `$[2-25]` | `r` |
+| MIPS | `freg` | `$f[0-31]` | `f` |
 | NVPTX | `reg16` | None\* | `h` |
 | NVPTX | `reg32` | None\* | `r` |
 | NVPTX | `reg64` | None\* | `l` |
@@ -552,6 +552,8 @@ Each register class has constraints on which value types they can be used with. 
 | ARM | `qreg` | `neon` | `i8x16`, `i16x8`, `i32x4`, `i64x2`, `f32x4` |
 | MIPS32 | `reg` | None | `i8`, `i16`, `i32`, `f32` |
 | MIPS32 | `freg` | None | `f32`, `f64` |
+| MIPS64 | `reg` | None | `i8`, `i16`, `i32`, `i64`, `f32`, `f64` |
+| MIPS64 | `freg` | None | `f32`, `f64` |
 | NVPTX | `reg16` | None | `i8`, `i16` |
 | NVPTX | `reg32` | None | `i8`, `i16`, `i32`, `f32` |
 | NVPTX | `reg64` | None | `i8`, `i16`, `i32`, `f32`, `i64`, `f64` |
@@ -637,11 +639,11 @@ Some registers cannot be used for input or output operands:
 | x86 | `st([0-7])` | x87 registers are not currently supported (but may be in the future). |
 | AArch64 | `xzr` | This is a constant zero register which can't be modified. |
 | ARM | `pc` | This is the program counter, not a real register. |
-| MIPS32 | `$0` or `$zero` | This is a constant zero register which can't be modified. |
-| MIPS32 | `$1` or `$at` | Reserved for assembler. |
-| MIPS32 | `$26`/`$k0`, `$27`/`$k1` | OS-reserved registers. |
-| MIPS32 | `$28`/`$gp` | Global pointer cannot be used as inputs or outputs. |
-| MIPS32 | `$ra` | Return address cannot be used as inputs or outputs. |
+| MIPS | `$0` or `$zero` | This is a constant zero register which can't be modified. |
+| MIPS | `$1` or `$at` | Reserved for assembler. |
+| MIPS | `$26`/`$k0`, `$27`/`$k1` | OS-reserved registers. |
+| MIPS | `$28`/`$gp` | Global pointer cannot be used as inputs or outputs. |
+| MIPS | `$ra` | Return address cannot be used as inputs or outputs. |
 | RISC-V | `x0` | This is a constant zero register which can't be modified. |
 | RISC-V | `gp`, `tp` | These registers are reserved and cannot be used as inputs or outputs. |
 | Hexagon | `lr` | This is the link register which cannot be used as an input or output. |
@@ -689,8 +691,8 @@ The supported modifiers are a subset of LLVM's (and GCC's) [asm template argumen
 | ARM | `dreg` | None | `d0` | `P` |
 | ARM | `qreg` | None | `q0` | `q` |
 | ARM | `qreg` | `e` / `f` | `d0` / `d1` | `e` / `f` |
-| MIPS32 | `reg` | None | `$2` | None |
-| MIPS32 | `freg` | None | `$f0` | None |
+| MIPS | `reg` | None | `$2` | None |
+| MIPS | `freg` | None | `$f0` | None |
 | NVPTX | `reg16` | None | `rs0` | None |
 | NVPTX | `reg32` | None | `r0` | None |
 | NVPTX | `reg64` | None | `rd0` | None |

--- a/src/doc/unstable-book/src/library-features/asm.md
+++ b/src/doc/unstable-book/src/library-features/asm.md
@@ -551,7 +551,7 @@ Each register class has constraints on which value types they can be used with. 
 | ARM | `dreg` | `vfp2` | `i64`, `f64`, `i8x8`, `i16x4`, `i32x2`, `i64x1`, `f32x2` |
 | ARM | `qreg` | `neon` | `i8x16`, `i16x8`, `i32x4`, `i64x2`, `f32x4` |
 | MIPS32 | `reg` | None | `i8`, `i16`, `i32`, `f32` |
-| MIPS32 | `freg` | None | `f32` |
+| MIPS32 | `freg` | None | `f32`, `f64` |
 | NVPTX | `reg16` | None | `i8`, `i16` |
 | NVPTX | `reg32` | None | `i8`, `i16`, `i32`, `f32` |
 | NVPTX | `reg64` | None | `i8`, `i16`, `i32`, `f32`, `i64`, `f64` |

--- a/src/doc/unstable-book/src/library-features/asm.md
+++ b/src/doc/unstable-book/src/library-features/asm.md
@@ -602,7 +602,6 @@ Some registers have multiple names. These are all treated by the compiler as ide
 | ARM | `r13` | `sp` |
 | ARM | `r14` | `lr` |
 | ARM | `r15` | `pc` |
-| MIPS32 | `$[2-25]` | Please [see the Wikipedia page][mips-regs] |
 | RISC-V | `x0` | `zero` |
 | RISC-V | `x1` | `ra` |
 | RISC-V | `x2` | `sp` |
@@ -622,8 +621,6 @@ Some registers have multiple names. These are all treated by the compiler as ide
 | Hexagon | `r29` | `sp` |
 | Hexagon | `r30` | `fr` |
 | Hexagon | `r31` | `lr` |
-
-[mips-regs]: https://en.wikibooks.org/wiki/MIPS_Assembly/Register_File#Registers
 
 Some registers cannot be used for input or output operands:
 

--- a/src/test/assembly/asm/mips-types.rs
+++ b/src/test/assembly/asm/mips-types.rs
@@ -72,8 +72,6 @@ macro_rules! check_reg { ($func:ident, $ty:ty, $reg:tt) => {
 // CHECK: #NO_APP
 #[no_mangle]
 pub unsafe fn sym_static() {
-    dont_merge(stringify!($func));
-
     asm!("la $v1, {}", sym extern_static);
 }
 
@@ -83,8 +81,6 @@ pub unsafe fn sym_static() {
 // CHECK: #NO_APP
 #[no_mangle]
 pub unsafe fn sym_fn() {
-    dont_merge(stringify!($func));
-
     asm!("la $v1, {}", sym extern_func);
 }
 

--- a/src/test/assembly/asm/mips-types.rs
+++ b/src/test/assembly/asm/mips-types.rs
@@ -1,6 +1,8 @@
 // no-system-llvm
+// revisions: mips32 mips64
 // assembly-output: emit-asm
-// compile-flags: --target mips-unknown-linux-gnu
+//[mips32] compile-flags: --target mips-unknown-linux-gnu
+//[mips64] compile-flags: --target mips64-unknown-linux-gnuabi64
 // needs-llvm-components: mips
 
 #![feature(no_core, lang_items, rustc_attrs, repr_simd)]
@@ -32,7 +34,9 @@ impl Copy for i8 {}
 impl Copy for u8 {}
 impl Copy for i16 {}
 impl Copy for i32 {}
+impl Copy for i64 {}
 impl Copy for f32 {}
+impl Copy for f64 {}
 impl Copy for ptr {}
 extern "C" {
     fn extern_func();
@@ -44,168 +48,190 @@ extern "Rust" {
     fn dont_merge(s: &str);
 }
 
-macro_rules! check { ($func:ident, $ty:ty, $class:ident) => {
+macro_rules! check { ($func:ident, $ty:ty, $class:ident, $mov:literal) => {
     #[no_mangle]
     pub unsafe fn $func(x: $ty) -> $ty {
         dont_merge(stringify!($func));
 
         let y;
-        asm!("move {}, {}", out($class) y, in($class) x);
+        asm!(concat!($mov," {}, {}"), out($class) y, in($class) x);
         y
     }
 };}
 
-macro_rules! check_reg { ($func:ident, $ty:ty, $reg:tt) => {
+macro_rules! check_reg { ($func:ident, $ty:ty, $reg:tt, $mov:literal) => {
     #[no_mangle]
     pub unsafe fn $func(x: $ty) -> $ty {
         dont_merge(stringify!($func));
 
         let y;
-        asm!(concat!("move ", $reg, ", ", $reg), lateout($reg) y, in($reg) x);
+        asm!(concat!($mov, " ", $reg, ", ", $reg), lateout($reg) y, in($reg) x);
         y
     }
 };}
 
-// CHECK-LABEL: sym_static:
-// CHECK: #APP
-// CHECK: lw $3, %got(extern_static)
-// CHECK: #NO_APP
+// mips32-LABEL: sym_static_32:
+// mips32: #APP
+// mips32: lw $3, %got(extern_static)
+// mips32: #NO_APP
+#[cfg(mips32)]
 #[no_mangle]
-pub unsafe fn sym_static() {
-    asm!("la $v1, {}", sym extern_static);
+pub unsafe fn sym_static_32() {
+    asm!("lw $v1, {}", sym extern_static);
 }
 
-// CHECK-LABEL: sym_fn:
-// CHECK: #APP
-// CHECK: lw $3, %got(extern_func)
-// CHECK: #NO_APP
+// mips32-LABEL: sym_fn_32:
+// mips32: #APP
+// mips32: lw $3, %got(extern_func)
+// mips32: #NO_APP
+#[cfg(mips32)]
 #[no_mangle]
-pub unsafe fn sym_fn() {
-    asm!("la $v1, {}", sym extern_func);
+pub unsafe fn sym_fn_32() {
+    asm!("lw $v1, {}", sym extern_func);
+}
+
+// mips64-LABEL: sym_static_64:
+// mips64: #APP
+// mips64: ld $3, %got_disp(extern_static)
+// mips64: #NO_APP
+#[cfg(mips64)]
+#[no_mangle]
+pub unsafe fn sym_static_64() {
+    asm!("ld $v1, {}", sym extern_static);
+}
+
+// mips64-LABEL: sym_fn_64:
+// mips64: #APP
+// mips64: ld $3, %got_disp(extern_func)
+// mips64: #NO_APP
+#[cfg(mips64)]
+#[no_mangle]
+pub unsafe fn sym_fn_64() {
+    asm!("ld $v1, {}", sym extern_func);
 }
 
 // CHECK-LABEL: reg_f32:
 // CHECK: #APP
 // CHECK: mov.s $f{{[0-9]+}}, $f{{[0-9]+}}
 // CHECK: #NO_APP
-#[no_mangle]
-pub unsafe fn reg_f32(x: f32) -> f32 {
-    dont_merge("reg_f32");
-    let y;
-    asm!("mov.s {}, {}", out(freg) y, in(freg) x);
-    y
-}
+check!(reg_f32, f32, freg, "mov.s");
 
 // CHECK-LABEL: f0_f32:
 // CHECK: #APP
 // CHECK: mov.s $f0, $f0
 // CHECK: #NO_APP
 #[no_mangle]
-pub unsafe fn f0_f32(x: f32) -> f32 {
-    dont_merge("f0_f32");
-    let y;
-    asm!("mov.s $f0, $f0", lateout("$f0") y, in("$f0") x);
-    y
-}
+check_reg!(f0_f32, f32, "$f0", "mov.s");
+
+// CHECK-LABEL: reg_f32_64:
+// CHECK: #APP
+// CHECK: mov.d $f{{[0-9]+}}, $f{{[0-9]+}}
+// CHECK: #NO_APP
+check!(reg_f32_64, f32, freg, "mov.d");
+
+// CHECK-LABEL: f0_f32_64:
+// CHECK: #APP
+// CHECK: mov.d $f0, $f0
+// CHECK: #NO_APP
+#[no_mangle]
+check_reg!(f0_f32_64, f32, "$f0", "mov.d");
 
 // CHECK-LABEL: reg_f64:
 // CHECK: #APP
 // CHECK: mov.d $f{{[0-9]+}}, $f{{[0-9]+}}
 // CHECK: #NO_APP
 #[no_mangle]
-pub unsafe fn reg_f64(x: f64) -> f64 {
-    dont_merge("reg_f64");
-    let y;
-    asm!("mov.d {}, {}", out(freg) y, in(freg) x);
-    y
-}
+check!(reg_f64, f64, freg, "mov.d");
 
 // CHECK-LABEL: f0_f64:
 // CHECK: #APP
 // CHECK: mov.d $f0, $f0
 // CHECK: #NO_APP
 #[no_mangle]
-pub unsafe fn f0_f64(x: f64) -> f64 {
-    dont_merge("f0_f64");
-    let y;
-    asm!("mov.d $f0, $f0", lateout("$f0") y, in("$f0") x);
-    y
-}
+check_reg!(f0_f64, f64, "$f0", "mov.d");
 
 // CHECK-LABEL: reg_ptr:
 // CHECK: #APP
 // CHECK: move ${{[0-9]+}}, ${{[0-9]+}}
 // CHECK: #NO_APP
-check!(reg_ptr, ptr, reg);
+check!(reg_ptr, ptr, reg, "move");
 
 // CHECK-LABEL: reg_i32:
 // CHECK: #APP
 // CHECK: move ${{[0-9]+}}, ${{[0-9]+}}
 // CHECK: #NO_APP
-check!(reg_i32, i32, reg);
+check!(reg_i32, i32, reg, "move");
 
 // CHECK-LABEL: reg_f32_soft:
 // CHECK: #APP
 // CHECK: move ${{[0-9]+}}, ${{[0-9]+}}
 // CHECK: #NO_APP
-check!(reg_f32_soft, f32, reg);
+check!(reg_f32_soft, f32, reg, "move");
+
+// mips64-LABEL: reg_f64_soft:
+// mips64: #APP
+// mips64: move ${{[0-9]+}}, ${{[0-9]+}}
+// mips64: #NO_APP
+#[cfg(mips64)]
+check!(reg_f64_soft, f64, reg, "move");
 
 // CHECK-LABEL: reg_i8:
 // CHECK: #APP
 // CHECK: move ${{[0-9]+}}, ${{[0-9]+}}
 // CHECK: #NO_APP
-check!(reg_i8, i8, reg);
+check!(reg_i8, i8, reg, "move");
 
 // CHECK-LABEL: reg_u8:
 // CHECK: #APP
 // CHECK: move ${{[0-9]+}}, ${{[0-9]+}}
 // CHECK: #NO_APP
-check!(reg_u8, u8, reg);
+check!(reg_u8, u8, reg, "move");
 
 // CHECK-LABEL: reg_i16:
 // CHECK: #APP
 // CHECK: move ${{[0-9]+}}, ${{[0-9]+}}
 // CHECK: #NO_APP
-check!(reg_i16, i16, reg);
+check!(reg_i16, i16, reg, "move");
 
-// CHECK-LABEL: t0_ptr:
+// mips64-LABEL: reg_i64:
+// mips64: #APP
+// mips64: move ${{[0-9]+}}, ${{[0-9]+}}
+// mips64: #NO_APP
+#[cfg(mips64)]
+check!(reg_i64, i64, reg, "move");
+
+// CHECK-LABEL: r8_ptr:
 // CHECK: #APP
 // CHECK: move $8, $8
 // CHECK: #NO_APP
-check_reg!(t0_ptr, ptr, "$t0");
+check_reg!(r8_ptr, ptr, "$8", "move");
 
-// CHECK-LABEL: t0_i32:
+// CHECK-LABEL: r8_i32:
 // CHECK: #APP
 // CHECK: move $8, $8
 // CHECK: #NO_APP
-check_reg!(t0_i32, i32, "$t0");
+check_reg!(r8_i32, i32, "$8", "move");
 
-// CHECK-LABEL: t0_f32:
+// CHECK-LABEL: r8_f32:
 // CHECK: #APP
 // CHECK: move $8, $8
 // CHECK: #NO_APP
-check_reg!(t0_f32, f32, "$t0");
+check_reg!(r8_f32, f32, "$8", "move");
 
-// CHECK-LABEL: t0_i8:
+// CHECK-LABEL: r8_i8:
 // CHECK: #APP
 // CHECK: move $8, $8
 // CHECK: #NO_APP
-check_reg!(t0_i8, i8, "$t0");
+check_reg!(r8_i8, i8, "$8", "move");
 
-// CHECK-LABEL: t0_u8:
+// CHECK-LABEL: r8_u8:
 // CHECK: #APP
 // CHECK: move $8, $8
 // CHECK: #NO_APP
-check_reg!(t0_u8, u8, "$t0");
-
-// CHECK-LABEL: t0_i16:
-// CHECK: #APP
-// CHECK: move $8, $8
-// CHECK: #NO_APP
-check_reg!(t0_i16, i16, "$t0");
+check_reg!(r8_u8, u8, "$8", "move");
 
 // CHECK-LABEL: r8_i16:
 // CHECK: #APP
 // CHECK: move $8, $8
 // CHECK: #NO_APP
-check_reg!(r8_i16, i16, "$8");
+check_reg!(r8_i16, i16, "$8", "move");

--- a/src/test/assembly/asm/mips-types.rs
+++ b/src/test/assembly/asm/mips-types.rs
@@ -108,6 +108,30 @@ pub unsafe fn f0_f32(x: f32) -> f32 {
     y
 }
 
+// CHECK-LABEL: reg_f64:
+// CHECK: #APP
+// CHECK: mov.d $f{{[0-9]+}}, $f{{[0-9]+}}
+// CHECK: #NO_APP
+#[no_mangle]
+pub unsafe fn reg_f64(x: f64) -> f64 {
+    dont_merge("reg_f64");
+    let y;
+    asm!("mov.d {}, {}", out(freg) y, in(freg) x);
+    y
+}
+
+// CHECK-LABEL: f0_f64:
+// CHECK: #APP
+// CHECK: mov.d $f0, $f0
+// CHECK: #NO_APP
+#[no_mangle]
+pub unsafe fn f0_f64(x: f64) -> f64 {
+    dont_merge("f0_f64");
+    let y;
+    asm!("mov.d $f0, $f0", lateout("$f0") y, in("$f0") x);
+    y
+}
+
 // CHECK-LABEL: reg_ptr:
 // CHECK: #APP
 // CHECK: move ${{[0-9]+}}, ${{[0-9]+}}


### PR DESCRIPTION
- [x] Updated `src/doc/unstable-book/src/library-features/asm.md`.
- [ ] No vector type support. I don't know much about those types.

cc #76839
