### PR TITLE
Fix `x.py clippy`

### DIFF
--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -371,7 +371,7 @@ impl<'a> Builder<'a> {
                 tool::CargoMiri,
                 native::Lld
             ),
-            Kind::Check | Kind::Clippy | Kind::Fix | Kind::Format => describe!(
+            Kind::Check | Kind::Clippy { .. } | Kind::Fix | Kind::Format => describe!(
                 check::Std,
                 check::Rustc,
                 check::Rustdoc,
@@ -540,7 +540,7 @@ impl<'a> Builder<'a> {
         let (kind, paths) = match build.config.cmd {
             Subcommand::Build { ref paths } => (Kind::Build, &paths[..]),
             Subcommand::Check { ref paths, all_targets: _ } => (Kind::Check, &paths[..]),
-            Subcommand::Clippy { ref paths } => (Kind::Clippy, &paths[..]),
+            Subcommand::Clippy { ref paths, .. } => (Kind::Clippy, &paths[..]),
             Subcommand::Fix { ref paths } => (Kind::Fix, &paths[..]),
             Subcommand::Doc { ref paths, .. } => (Kind::Doc, &paths[..]),
             Subcommand::Test { ref paths, .. } => (Kind::Test, &paths[..]),

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -851,8 +851,8 @@ impl<'a> Builder<'a> {
             }
             rustflags.env("RUSTFLAGS_BOOTSTRAP");
             if cmd == "clippy" {
-                // clippy overwrites any sysroot we pass on the command line.
-                // Tell it to use the appropriate sysroot instead.
+                // clippy overwrites sysroot if we pass it to cargo.
+                // Pass it directly to clippy instead.
                 // NOTE: this can't be fixed in clippy because we explicitly don't set `RUSTC`,
                 // so it has no way of knowing the sysroot.
                 rustflags.arg("--sysroot");
@@ -867,8 +867,7 @@ impl<'a> Builder<'a> {
                 // Explicitly does *not* set `--cfg=bootstrap`, since we're using a nightly clippy.
                 let host_version = Command::new("rustc").arg("--version").output().map_err(|_| ());
                 let output = host_version.and_then(|output| {
-                    if output.status.success()
-                    {
+                    if output.status.success() {
                         Ok(output)
                     } else {
                         Err(())

--- a/src/bootstrap/check.rs
+++ b/src/bootstrap/check.rs
@@ -1,13 +1,11 @@
 //! Implementation of compiling the compiler and standard library, in "check"-based modes.
 
+use crate::builder::{Builder, Kind, RunConfig, ShouldRun, Step};
 use crate::cache::Interned;
 use crate::compile::{add_to_sysroot, run_cargo, rustc_cargo, rustc_cargo_env, std_cargo};
 use crate::config::TargetSelection;
 use crate::tool::{prepare_tool_cargo, SourceType};
 use crate::INTERNER;
-use crate::{
-    builder::{Builder, Kind, RunConfig, ShouldRun, Step},
-};
 use crate::{Compiler, Mode, Subcommand};
 use std::path::PathBuf;
 

--- a/src/bootstrap/flags.rs
+++ b/src/bootstrap/flags.rs
@@ -55,6 +55,7 @@ pub enum Subcommand {
         paths: Vec<PathBuf>,
     },
     Clippy {
+        fix: bool,
         paths: Vec<PathBuf>,
     },
     Fix {
@@ -272,6 +273,9 @@ To learn more about a subcommand, run `./x.py <subcommand> -h`",
             }
             "bench" => {
                 opts.optmulti("", "test-args", "extra arguments", "ARGS");
+            }
+            "clippy" => {
+                opts.optflag("", "fix", "automatically apply lint suggestions");
             }
             "doc" => {
                 opts.optflag("", "open", "open the docs in a browser");
@@ -513,7 +517,7 @@ Arguments:
             "check" | "c" => {
                 Subcommand::Check { paths, all_targets: matches.opt_present("all-targets") }
             }
-            "clippy" => Subcommand::Clippy { paths },
+            "clippy" => Subcommand::Clippy { paths, fix: matches.opt_present("fix") },
             "fix" => Subcommand::Fix { paths },
             "test" | "t" => Subcommand::Test {
                 paths,


### PR DESCRIPTION
I don't think this ever worked.

Fixes https://github.com/rust-lang/rust/issues/77309. `--fix` support is a work in progress, but works for a very small subset of `libtest`. 

This works by using the host `cargo-clippy` driver; it does not use `stage0.txt` at all. To mitigate confusion from this, it gives an error if you don't have `rustc +nightly` as the default rustc in `$PATH`. Additionally, it means that bootstrap can't set `RUSTC`; this makes it no longer possible for clippy to detect the sysroot itself. Instead, bootstrap passes the sysroot to cargo.

r? @ghost