### PR TITLE
Add missing_docs lint to the rustdoc lint group

### DIFF
--- a/compiler/rustc_lint/src/lib.rs
+++ b/compiler/rustc_lint/src/lib.rs
@@ -306,6 +306,7 @@ fn register_builtins(store: &mut LintStore, no_interleave_lints: bool) {
         "rustdoc",
         BROKEN_INTRA_DOC_LINKS,
         INVALID_CODEBLOCK_ATTRIBUTES,
+        MISSING_DOCS,
         MISSING_DOC_CODE_EXAMPLES,
         PRIVATE_DOC_TESTS
     );

--- a/src/test/rustdoc-ui/lint-group.rs
+++ b/src/test/rustdoc-ui/lint-group.rs
@@ -22,3 +22,7 @@ pub fn no_doctest() {} //~^ ERROR missing code example in this documentation
 /// println!("sup");
 /// ```
 fn private_doctest() {} //~^^^^^ ERROR documentation test in private item
+
+pub fn no_doc() {}
+//~^ ERROR missing documentation for a function
+//~^^ ERROR missing code example in this documentation

--- a/src/test/rustdoc-ui/lint-group.stderr
+++ b/src/test/rustdoc-ui/lint-group.stderr
@@ -1,3 +1,16 @@
+error: missing documentation for a function
+  --> $DIR/lint-group.rs:26:1
+   |
+LL | pub fn no_doc() {}
+   | ^^^^^^^^^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/lint-group.rs:7:9
+   |
+LL | #![deny(rustdoc)]
+   |         ^^^^^^^
+   = note: `#[deny(missing_docs)]` implied by `#[deny(rustdoc)]`
+
 error: missing code example in this documentation
   --> $DIR/lint-group.rs:16:1
    |
@@ -28,6 +41,12 @@ LL | #![deny(rustdoc)]
    |         ^^^^^^^
    = note: `#[deny(private_doc_tests)]` implied by `#[deny(rustdoc)]`
 
+error: missing code example in this documentation
+  --> $DIR/lint-group.rs:26:1
+   |
+LL | pub fn no_doc() {}
+   | ^^^^^^^^^^^^^^^^^^
+
 error: unresolved link to `error`
   --> $DIR/lint-group.rs:9:29
    |
@@ -42,5 +61,5 @@ LL | #![deny(rustdoc)]
    = note: `#[deny(broken_intra_doc_links)]` implied by `#[deny(rustdoc)]`
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
-error: aborting due to 3 previous errors
+error: aborting due to 5 previous errors
 


### PR DESCRIPTION
Just realized that the `rustdoc` lint group didn't have the `missing_docs` lint inside.

r? @jyn514 