### PR TITLE
-Zvalidate-mir: Assert that storage is allocated on local use

### DIFF
--- a/src/test/mir-opt/simplify_try_if_let.rs
+++ b/src/test/mir-opt/simplify_try_if_let.rs
@@ -1,4 +1,7 @@
 // compile-flags: -Zmir-opt-level=1 -Zunsound-mir-opts
+// ignore-test
+// FIXME: the pass is unsound and causes ICEs in the MIR validator
+
 // EMIT_MIR simplify_try_if_let.{impl#0}-append.SimplifyArmIdentity.diff
 
 use std::ptr::NonNull;
@@ -19,7 +22,7 @@ impl LinkedList {
 
     pub fn append(&mut self, other: &mut Self) {
         match self.tail {
-            None => { },
+            None => {}
             Some(mut tail) => {
                 // `as_mut` is okay here because we have exclusive access to the entirety
                 // of both lists.


### PR DESCRIPTION
This extends the MIR validator to check that locals are only used when their backing storage is currently allocated via `StorageLive`.

The result of this is that miscompilations such as https://github.com/rust-lang/rust/issues/77359 are caught and turned into ICEs.

The PR currently fails tests because miscompilations such as https://github.com/rust-lang/rust/issues/77359 are caught and turned into ICEs.

I have confirmed that tests pass (even with `-Zvalidate-mir`) once `SimplifyArmIdentity` is turned into a no-op (except mir-opt tests, of course).