### PR TITLE
rustc_metadata: Do not forget to encode inherent impls for foreign types

### DIFF
--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -1753,6 +1753,7 @@ impl EncodeContext<'a, 'tcx> {
         self.encode_const_stability(def_id);
         self.encode_deprecation(def_id);
         self.encode_item_type(def_id);
+        self.encode_inherent_implementations(def_id);
         if let hir::ForeignItemKind::Fn(..) = nitem.kind {
             record!(self.tables.fn_sig[def_id] <- tcx.fn_sig(def_id));
             self.encode_variances_of(def_id);

--- a/src/test/ui/extern/auxiliary/extern-types-inherent-impl.rs
+++ b/src/test/ui/extern/auxiliary/extern-types-inherent-impl.rs
@@ -1,0 +1,9 @@
+#![feature(extern_types)]
+
+extern "C" {
+    pub type CrossCrate;
+}
+
+impl CrossCrate {
+    pub fn foo(&self) {}
+}

--- a/src/test/ui/extern/extern-types-inherent-impl.rs
+++ b/src/test/ui/extern/extern-types-inherent-impl.rs
@@ -1,19 +1,26 @@
-// run-pass
-#![allow(dead_code)]
 // Test that inherent impls can be defined for extern types.
+
+// check-pass
+// aux-build:extern-types-inherent-impl.rs
 
 #![feature(extern_types)]
 
-extern {
-    type A;
+extern crate extern_types_inherent_impl;
+use extern_types_inherent_impl::CrossCrate;
+
+extern "C" {
+    type Local;
 }
 
-impl A {
-    fn foo(&self) { }
+impl Local {
+    fn foo(&self) {}
 }
 
-fn use_foo(x: &A) {
+fn use_foo(x: &Local, y: &CrossCrate) {
+    Local::foo(x);
     x.foo();
+    CrossCrate::foo(y);
+    y.foo();
 }
 
-fn main() { }
+fn main() {}


### PR DESCRIPTION
So I tried to move FFI interface for LLVM from `rustc_codegen_llvm` to `rustc_llvm` and immediately encountered this fascinating issue.

Fixes https://github.com/rust-lang/rust/issues/46665.