### PR TITLE
Mark inactive enum variants along "otherwise" edge as uninitialized 

### DIFF
--- a/compiler/rustc_mir/src/dataflow/drop_flag_effects.rs
+++ b/compiler/rustc_mir/src/dataflow/drop_flag_effects.rs
@@ -1,7 +1,6 @@
 use crate::util::elaborate_drops::DropFlagState;
 use rustc_middle::mir::{self, Body, Location};
 use rustc_middle::ty::{self, TyCtxt};
-use rustc_target::abi::VariantIdx;
 
 use super::indexes::MovePathIndex;
 use super::move_paths::{InitKind, LookupResult, MoveData};
@@ -226,45 +225,6 @@ pub(crate) fn for_location_inits<'tcx, F>(
                 callback(mpi);
             }
             InitKind::NonPanicPathOnly => (),
-        }
-    }
-}
-
-/// Calls `handle_inactive_variant` for each descendant move path of `enum_place` that contains a
-/// `Downcast` to a variant besides the `active_variant`.
-///
-/// NOTE: If there are no move paths corresponding to an inactive variant,
-/// `handle_inactive_variant` will not be called for that variant.
-pub(crate) fn on_all_inactive_variants<'tcx>(
-    tcx: TyCtxt<'tcx>,
-    body: &mir::Body<'tcx>,
-    move_data: &MoveData<'tcx>,
-    enum_place: mir::Place<'tcx>,
-    active_variant: VariantIdx,
-    mut handle_inactive_variant: impl FnMut(MovePathIndex),
-) {
-    let enum_mpi = match move_data.rev_lookup.find(enum_place.as_ref()) {
-        LookupResult::Exact(mpi) => mpi,
-        LookupResult::Parent(_) => return,
-    };
-
-    let enum_path = &move_data.move_paths[enum_mpi];
-    for (variant_mpi, variant_path) in enum_path.children(&move_data.move_paths) {
-        // Because of the way we build the `MoveData` tree, each child should have exactly one more
-        // projection than `enum_place`. This additional projection must be a downcast since the
-        // base is an enum.
-        let (downcast, base_proj) = variant_path.place.projection.split_last().unwrap();
-        assert_eq!(enum_place.projection.len(), base_proj.len());
-
-        let variant_idx = match *downcast {
-            mir::ProjectionElem::Downcast(_, idx) => idx,
-            _ => unreachable!(),
-        };
-
-        if variant_idx != active_variant {
-            on_all_children_bits(tcx, body, move_data, variant_mpi, |mpi| {
-                handle_inactive_variant(mpi)
-            });
         }
     }
 }

--- a/src/test/mir-opt/issue_41888.main.ElaborateDrops.after.mir
+++ b/src/test/mir-opt/issue_41888.main.ElaborateDrops.after.mir
@@ -9,9 +9,8 @@ fn main() -> () {
     let mut _5: isize;                   // in scope 0 at $DIR/issue-41888.rs:10:16: 10:24
     let mut _7: bool;                    // in scope 0 at $DIR/issue-41888.rs:15:1: 15:2
     let mut _8: bool;                    // in scope 0 at $DIR/issue-41888.rs:15:1: 15:2
-    let mut _9: bool;                    // in scope 0 at $DIR/issue-41888.rs:15:1: 15:2
+    let mut _9: isize;                   // in scope 0 at $DIR/issue-41888.rs:15:1: 15:2
     let mut _10: isize;                  // in scope 0 at $DIR/issue-41888.rs:15:1: 15:2
-    let mut _11: isize;                  // in scope 0 at $DIR/issue-41888.rs:15:1: 15:2
     scope 1 {
         debug e => _1;                   // in scope 1 at $DIR/issue-41888.rs:7:9: 7:10
         let _6: K;                       // in scope 1 at $DIR/issue-41888.rs:10:21: 10:23
@@ -21,7 +20,6 @@ fn main() -> () {
     }
 
     bb0: {
-        _9 = const false;                // scope 0 at $DIR/issue-41888.rs:7:9: 7:10
         _7 = const false;                // scope 0 at $DIR/issue-41888.rs:7:9: 7:10
         _8 = const false;                // scope 0 at $DIR/issue-41888.rs:7:9: 7:10
         StorageLive(_1);                 // scope 0 at $DIR/issue-41888.rs:7:9: 7:10
@@ -79,7 +77,6 @@ fn main() -> () {
 
     bb10: {
         StorageLive(_6);                 // scope 1 at $DIR/issue-41888.rs:10:21: 10:23
-        _9 = const false;                // scope 1 at $DIR/issue-41888.rs:10:21: 10:23
         _6 = move ((_1 as F).0: K);      // scope 1 at $DIR/issue-41888.rs:10:21: 10:23
         _0 = const ();                   // scope 2 at $DIR/issue-41888.rs:10:29: 13:10
         StorageDead(_6);                 // scope 1 at $DIR/issue-41888.rs:13:9: 13:10
@@ -93,7 +90,6 @@ fn main() -> () {
     bb12: {
         _7 = const false;                // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
         _8 = const false;                // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
-        _9 = const false;                // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
         StorageDead(_1);                 // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
         StorageDead(_2);                 // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
         return;                          // scope 0 at $DIR/issue-41888.rs:15:2: 15:2
@@ -102,7 +98,6 @@ fn main() -> () {
     bb13 (cleanup): {
         _7 = const true;                 // scope 1 at $DIR/issue-41888.rs:9:9: 9:10
         _8 = const true;                 // scope 1 at $DIR/issue-41888.rs:9:9: 9:10
-        _9 = const true;                 // scope 1 at $DIR/issue-41888.rs:9:9: 9:10
         _1 = move _3;                    // scope 1 at $DIR/issue-41888.rs:9:9: 9:10
         goto -> bb7;                     // scope 1 at $DIR/issue-41888.rs:9:9: 9:10
     }
@@ -110,7 +105,6 @@ fn main() -> () {
     bb14: {
         _7 = const true;                 // scope 1 at $DIR/issue-41888.rs:9:9: 9:10
         _8 = const true;                 // scope 1 at $DIR/issue-41888.rs:9:9: 9:10
-        _9 = const true;                 // scope 1 at $DIR/issue-41888.rs:9:9: 9:10
         _1 = move _3;                    // scope 1 at $DIR/issue-41888.rs:9:9: 9:10
         goto -> bb6;                     // scope 1 at $DIR/issue-41888.rs:9:9: 9:10
     }
@@ -138,8 +132,8 @@ fn main() -> () {
     }
 
     bb20: {
-        _10 = discriminant(_1);          // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
-        switchInt(move _10) -> [0_isize: bb15, otherwise: bb18]; // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
+        _9 = discriminant(_1);           // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
+        switchInt(move _9) -> [0_isize: bb15, otherwise: bb18]; // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
     }
 
     bb21: {
@@ -147,8 +141,8 @@ fn main() -> () {
     }
 
     bb22 (cleanup): {
-        _11 = discriminant(_1);          // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
-        switchInt(move _11) -> [0_isize: bb17, otherwise: bb19]; // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
+        _10 = discriminant(_1);          // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
+        switchInt(move _10) -> [0_isize: bb17, otherwise: bb19]; // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
     }
 
     bb23 (cleanup): {


### PR DESCRIPTION
This is a slight improvement on #68528 and #73879. Previously, the interface to the dataflow framework did not allow edge-specific effects along the "otherwise" edge of a `SwitchInt` terminator. #77242 fixed this. Now we can mark enum variants whose discriminant is handled in an integer-valued `SwitchInt` edge as definitely uninitialized along the "otherwise" edge. Notably, this applies within an `else` block attached to an `if let` expression.