### PR TITLE
add `insert` to `Option`

### DIFF
--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -562,10 +562,6 @@ impl<T> Option<T> {
         }
     }
 
-    /////////////////////////////////////////////////////////////////////////
-    // Setting a new value
-    /////////////////////////////////////////////////////////////////////////
-
     /// Inserts `value` into the option then returns a mutable reference to it.
     ///
     /// If the option already contains a value, the old value is dropped.

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -574,17 +574,22 @@ impl<T> Option<T> {
     /// ```
     /// #![feature(option_insert)]
     ///
-    /// let mut o = None;
-    /// let v = o.insert(3);
-    /// assert_eq!(*v, 3);
+    /// let mut opt = None;
+    /// let val = opt.insert(1);
+    /// assert_eq!(*val, 1);
+    /// assert_eq!(opt.unwrap(), 1);
+    /// let val = opt.insert(2);
+    /// assert_eq!(*val, 2);
+    /// *val = 3;
+    /// assert_eq!(opt.unwrap(), 3);
     /// ```
     #[inline]
-    #[unstable(feature = "option_insert", reason = "new API", issue = "none")]
-    pub fn insert(&mut self, v: T) -> &mut T {
-        *self = Some(v);
+    #[unstable(feature = "option_insert", reason = "newly added", issue = "none")]
+    pub fn insert(&mut self, val: T) -> &mut T {
+        *self = Some(val);
 
-        match *self {
-            Some(ref mut v) => v,
+        match self {
+            Some(v) => v,
             // SAFETY: the code above just filled the option
             None => unsafe { hint::unreachable_unchecked() },
         }
@@ -839,8 +844,8 @@ impl<T> Option<T> {
     /// ```
     #[inline]
     #[stable(feature = "option_entry", since = "1.20.0")]
-    pub fn get_or_insert(&mut self, v: T) -> &mut T {
-        self.get_or_insert_with(|| v)
+    pub fn get_or_insert(&mut self, val: T) -> &mut T {
+        self.get_or_insert_with(|| val)
     }
 
     /// Inserts a value computed from `f` into the option if it is [`None`], then
@@ -867,8 +872,8 @@ impl<T> Option<T> {
             *self = Some(f());
         }
 
-        match *self {
-            Some(ref mut v) => v,
+        match self {
+            Some(v) => v,
             // SAFETY: a `None` variant for `self` would have been replaced by a `Some`
             // variant in the code above.
             None => unsafe { hint::unreachable_unchecked() },

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -568,6 +568,8 @@ impl<T> Option<T> {
 
     /// Inserts `value` into the option then returns a mutable reference to it.
     ///
+    /// If the option already contains a value, the old value is dropped.
+    ///
     /// # Example
     ///
     /// ```

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -563,6 +563,52 @@ impl<T> Option<T> {
     }
 
     /////////////////////////////////////////////////////////////////////////
+    // Setting a new value
+    /////////////////////////////////////////////////////////////////////////
+
+    /// Inserts `v` into the option then returns a mutable reference
+    /// to the contained value.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// #![feature(option_insert)]
+    ///
+    /// let mut o = None;
+    /// let v = o.insert(3);
+    /// assert_eq!(*v, 3);
+    /// ```
+    #[inline]
+    #[unstable(feature = "option_insert", reason = "new API", issue = "none")]
+    pub fn insert(&mut self, v: T) -> &mut T {
+        self.insert_with(|| v)
+    }
+
+    /// Inserts a value computed from `f` into the option, then returns a
+    /// mutable reference to the contained value.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// #![feature(option_insert)]
+    ///
+    /// let mut o = None;
+    /// let v = o.insert_with(|| 3);
+    /// assert_eq!(*v, 3);
+    /// ```
+    #[inline]
+    #[unstable(feature = "option_insert", reason = "new API", issue = "none")]
+    pub fn insert_with<F: FnOnce() -> T>(&mut self, f: F) -> &mut T {
+        *self = Some(f());
+
+        match *self {
+            Some(ref mut v) => v,
+            // SAFETY: the code above just filled the option
+            None => unsafe { hint::unreachable_unchecked() },
+        }
+    }
+
+    /////////////////////////////////////////////////////////////////////////
     // Iterator constructors
     /////////////////////////////////////////////////////////////////////////
 

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -581,25 +581,7 @@ impl<T> Option<T> {
     #[inline]
     #[unstable(feature = "option_insert", reason = "new API", issue = "none")]
     pub fn insert(&mut self, v: T) -> &mut T {
-        self.insert_with(|| v)
-    }
-
-    /// Inserts a value computed from `f` into the option, then returns a
-    /// mutable reference to the contained value.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// #![feature(option_insert)]
-    ///
-    /// let mut o = None;
-    /// let v = o.insert_with(|| 3);
-    /// assert_eq!(*v, 3);
-    /// ```
-    #[inline]
-    #[unstable(feature = "option_insert", reason = "new API", issue = "none")]
-    pub fn insert_with<F: FnOnce() -> T>(&mut self, f: F) -> &mut T {
-        *self = Some(f());
+        *self = Some(v);
 
         match *self {
             Some(ref mut v) => v,

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -566,8 +566,7 @@ impl<T> Option<T> {
     // Setting a new value
     /////////////////////////////////////////////////////////////////////////
 
-    /// Inserts `v` into the option then returns a mutable reference
-    /// to the contained value.
+    /// Inserts `value` into the option then returns a mutable reference to it.
     ///
     /// # Example
     ///
@@ -585,8 +584,8 @@ impl<T> Option<T> {
     /// ```
     #[inline]
     #[unstable(feature = "option_insert", reason = "newly added", issue = "none")]
-    pub fn insert(&mut self, val: T) -> &mut T {
-        *self = Some(val);
+    pub fn insert(&mut self, value: T) -> &mut T {
+        *self = Some(value);
 
         match self {
             Some(v) => v,
@@ -825,7 +824,7 @@ impl<T> Option<T> {
     // Entry-like operations to insert if None and return a reference
     /////////////////////////////////////////////////////////////////////////
 
-    /// Inserts `v` into the option if it is [`None`], then
+    /// Inserts `value` into the option if it is [`None`], then
     /// returns a mutable reference to the contained value.
     ///
     /// # Examples
@@ -844,12 +843,12 @@ impl<T> Option<T> {
     /// ```
     #[inline]
     #[stable(feature = "option_entry", since = "1.20.0")]
-    pub fn get_or_insert(&mut self, val: T) -> &mut T {
-        self.get_or_insert_with(|| val)
+    pub fn get_or_insert(&mut self, value: T) -> &mut T {
+        self.get_or_insert_with(|| value)
     }
 
-    /// Inserts a value computed from `f` into the option if it is [`None`], then
-    /// returns a mutable reference to the contained value.
+    /// Inserts a value computed from `f` into the option if it is [`None`],
+    /// then returns a mutable reference to the contained value.
     ///
     /// # Examples
     ///

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -581,7 +581,7 @@ impl<T> Option<T> {
     /// assert_eq!(opt.unwrap(), 3);
     /// ```
     #[inline]
-    #[unstable(feature = "option_insert", reason = "newly added", issue = "none")]
+    #[unstable(feature = "option_insert", reason = "newly added", issue = "78271")]
     pub fn insert(&mut self, value: T) -> &mut T {
         *self = Some(value);
 


### PR DESCRIPTION
This removes a cause of `unwrap` and code complexity.

This allows replacing

```
option_value = Some(build());
option_value.as_mut().unwrap()
```

with

```
option_value.insert(build())
```

It's also useful in contexts not requiring the mutability of the reference.

Here's a typical cache example:

```
let checked_cache = cache.as_ref().filter(|e| e.is_valid());
let content = match checked_cache {
	Some(e) => &e.content,
	None => {
	    cache = Some(compute_cache_entry());
	    // unwrap is OK because we just filled the option
	    &cache.as_ref().unwrap().content
	}
};
```

It can be changed into

```
let checked_cache = cache.as_ref().filter(|e| e.is_valid());
let content = match checked_cache {
	Some(e) => &e.content,
	None => &cache.insert(compute_cache_entry()).content,
};
```

*(edited: I removed `insert_with`)*