### PR TITLE
Disable the SimplifyArmIdentity mir-opt

### DIFF
--- a/compiler/rustc_mir/src/transform/simplify_try.rs
+++ b/compiler/rustc_mir/src/transform/simplify_try.rs
@@ -367,7 +367,12 @@ fn optimization_applies<'tcx>(
 }
 
 impl<'tcx> MirPass<'tcx> for SimplifyArmIdentity {
-    fn run_pass(&self, _tcx: TyCtxt<'tcx>, source: MirSource<'tcx>, body: &mut Body<'tcx>) {
+    fn run_pass(&self, tcx: TyCtxt<'tcx>, source: MirSource<'tcx>, body: &mut Body<'tcx>) {
+        // FIXME(77359): This optimization can result in unsoundness.
+        if !tcx.sess.opts.debugging_opts.unsound_mir_opts {
+            return;
+        }
+
         trace!("running SimplifyArmIdentity on {:?}", source);
         let local_uses = LocalUseCounter::get_local_uses(body);
         let (basic_blocks, local_decls, debug_info) =

--- a/src/test/codegen/try_identity.rs
+++ b/src/test/codegen/try_identity.rs
@@ -1,4 +1,4 @@
-// compile-flags: -C no-prepopulate-passes -Z mir-opt-level=2
+// compile-flags: -C no-prepopulate-passes -Z mir-opt-level=2 -Zunsound-mir-opts
 
 // Ensure that `x?` has no overhead on `Result<T, E>` due to identity `match`es in lowering.
 // This requires inlining to trigger the MIR optimizations in `SimplifyArmIdentity`.

--- a/src/test/mir-opt/simplify-arm.rs
+++ b/src/test/mir-opt/simplify-arm.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Z mir-opt-level=2
+// compile-flags: -Z mir-opt-level=2 -Zunsound-mir-opts
 // EMIT_MIR simplify_arm.id.SimplifyArmIdentity.diff
 // EMIT_MIR simplify_arm.id.SimplifyBranchSame.diff
 // EMIT_MIR simplify_arm.id_result.SimplifyArmIdentity.diff

--- a/src/test/mir-opt/simplify-locals-removes-unused-discriminant-reads.rs
+++ b/src/test/mir-opt/simplify-locals-removes-unused-discriminant-reads.rs
@@ -1,3 +1,5 @@
+// compile-flags: -Zunsound-mir-opts
+
 fn map(x: Option<Box<()>>) -> Option<Box<()>> {
     match x {
         None => None,

--- a/src/test/mir-opt/simplify_locals_removes_unused_discriminant_reads.map.SimplifyLocals.32bit.diff
+++ b/src/test/mir-opt/simplify_locals_removes_unused_discriminant_reads.map.SimplifyLocals.32bit.diff
@@ -2,25 +2,25 @@
 + // MIR for `map` after SimplifyLocals
   
   fn map(_1: Option<Box<()>>) -> Option<Box<()>> {
-      debug x => _1;                       // in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:1:8: 1:9
-      let mut _0: std::option::Option<std::boxed::Box<()>>; // return place in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:1:31: 1:46
--     let mut _2: isize;                   // in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:3:9: 3:13
--     let _3: std::boxed::Box<()>;         // in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:4:14: 4:15
--     let mut _4: std::boxed::Box<()>;     // in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:4:25: 4:26
--     let mut _5: bool;                    // in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:6:1: 6:2
--     let mut _6: isize;                   // in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:6:1: 6:2
--     let mut _7: isize;                   // in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:6:1: 6:2
+      debug x => _1;                       // in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:3:8: 3:9
+      let mut _0: std::option::Option<std::boxed::Box<()>>; // return place in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:3:31: 3:46
+-     let mut _2: isize;                   // in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:5:9: 5:13
+-     let _3: std::boxed::Box<()>;         // in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:6:14: 6:15
+-     let mut _4: std::boxed::Box<()>;     // in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:6:25: 6:26
+-     let mut _5: bool;                    // in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:8:1: 8:2
+-     let mut _6: isize;                   // in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:8:1: 8:2
+-     let mut _7: isize;                   // in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:8:1: 8:2
       scope 1 {
-          debug x => ((_0 as Some).0: std::boxed::Box<()>); // in scope 1 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:4:14: 4:15
+          debug x => ((_0 as Some).0: std::boxed::Box<()>); // in scope 1 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:6:14: 6:15
       }
   
       bb0: {
--         _5 = const false;                // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:3:9: 3:13
--         _5 = const true;                 // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:3:9: 3:13
--         _2 = discriminant(_1);           // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:3:9: 3:13
-          _0 = move _1;                    // scope 1 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:4:20: 4:27
--         _6 = discriminant(_1);           // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:6:1: 6:2
-          return;                          // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:6:2: 6:2
+-         _5 = const false;                // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:5:9: 5:13
+-         _5 = const true;                 // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:5:9: 5:13
+-         _2 = discriminant(_1);           // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:5:9: 5:13
+          _0 = move _1;                    // scope 1 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:6:20: 6:27
+-         _6 = discriminant(_1);           // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:8:1: 8:2
+          return;                          // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:8:2: 8:2
       }
   }
   

--- a/src/test/mir-opt/simplify_locals_removes_unused_discriminant_reads.map.SimplifyLocals.64bit.diff
+++ b/src/test/mir-opt/simplify_locals_removes_unused_discriminant_reads.map.SimplifyLocals.64bit.diff
@@ -2,25 +2,25 @@
 + // MIR for `map` after SimplifyLocals
   
   fn map(_1: Option<Box<()>>) -> Option<Box<()>> {
-      debug x => _1;                       // in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:1:8: 1:9
-      let mut _0: std::option::Option<std::boxed::Box<()>>; // return place in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:1:31: 1:46
--     let mut _2: isize;                   // in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:3:9: 3:13
--     let _3: std::boxed::Box<()>;         // in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:4:14: 4:15
--     let mut _4: std::boxed::Box<()>;     // in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:4:25: 4:26
--     let mut _5: bool;                    // in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:6:1: 6:2
--     let mut _6: isize;                   // in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:6:1: 6:2
--     let mut _7: isize;                   // in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:6:1: 6:2
+      debug x => _1;                       // in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:3:8: 3:9
+      let mut _0: std::option::Option<std::boxed::Box<()>>; // return place in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:3:31: 3:46
+-     let mut _2: isize;                   // in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:5:9: 5:13
+-     let _3: std::boxed::Box<()>;         // in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:6:14: 6:15
+-     let mut _4: std::boxed::Box<()>;     // in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:6:25: 6:26
+-     let mut _5: bool;                    // in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:8:1: 8:2
+-     let mut _6: isize;                   // in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:8:1: 8:2
+-     let mut _7: isize;                   // in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:8:1: 8:2
       scope 1 {
-          debug x => ((_0 as Some).0: std::boxed::Box<()>); // in scope 1 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:4:14: 4:15
+          debug x => ((_0 as Some).0: std::boxed::Box<()>); // in scope 1 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:6:14: 6:15
       }
   
       bb0: {
--         _5 = const false;                // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:3:9: 3:13
--         _5 = const true;                 // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:3:9: 3:13
--         _2 = discriminant(_1);           // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:3:9: 3:13
-          _0 = move _1;                    // scope 1 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:4:20: 4:27
--         _6 = discriminant(_1);           // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:6:1: 6:2
-          return;                          // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:6:2: 6:2
+-         _5 = const false;                // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:5:9: 5:13
+-         _5 = const true;                 // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:5:9: 5:13
+-         _2 = discriminant(_1);           // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:5:9: 5:13
+          _0 = move _1;                    // scope 1 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:6:20: 6:27
+-         _6 = discriminant(_1);           // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:8:1: 8:2
+          return;                          // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:8:2: 8:2
       }
   }
   

--- a/src/test/mir-opt/simplify_try.rs
+++ b/src/test/mir-opt/simplify_try.rs
@@ -1,3 +1,4 @@
+// compile-flags: -Zunsound-mir-opts
 // EMIT_MIR simplify_try.try_identity.SimplifyArmIdentity.diff
 // EMIT_MIR simplify_try.try_identity.SimplifyBranchSame.after.mir
 // EMIT_MIR simplify_try.try_identity.SimplifyLocals.after.mir

--- a/src/test/mir-opt/simplify_try.try_identity.DestinationPropagation.diff
+++ b/src/test/mir-opt/simplify_try.try_identity.DestinationPropagation.diff
@@ -2,35 +2,35 @@
 + // MIR for `try_identity` after DestinationPropagation
   
   fn try_identity(_1: std::result::Result<u32, i32>) -> std::result::Result<u32, i32> {
-      debug x => _1;                       // in scope 0 at $DIR/simplify_try.rs:6:17: 6:18
-      let mut _0: std::result::Result<u32, i32>; // return place in scope 0 at $DIR/simplify_try.rs:6:41: 6:57
-      let _2: u32;                         // in scope 0 at $DIR/simplify_try.rs:7:9: 7:10
-      let mut _3: std::result::Result<u32, i32>; // in scope 0 at $DIR/simplify_try.rs:7:13: 7:15
-      let mut _4: std::result::Result<u32, i32>; // in scope 0 at $DIR/simplify_try.rs:7:13: 7:14
-      let mut _5: isize;                   // in scope 0 at $DIR/simplify_try.rs:7:14: 7:15
-      let _6: i32;                         // in scope 0 at $DIR/simplify_try.rs:7:14: 7:15
-      let mut _7: !;                       // in scope 0 at $DIR/simplify_try.rs:7:14: 7:15
-      let mut _8: i32;                     // in scope 0 at $DIR/simplify_try.rs:7:14: 7:15
-      let mut _9: i32;                     // in scope 0 at $DIR/simplify_try.rs:7:14: 7:15
-      let _10: u32;                        // in scope 0 at $DIR/simplify_try.rs:7:13: 7:15
-      let mut _11: u32;                    // in scope 0 at $DIR/simplify_try.rs:8:8: 8:9
+      debug x => _1;                       // in scope 0 at $DIR/simplify_try.rs:7:17: 7:18
+      let mut _0: std::result::Result<u32, i32>; // return place in scope 0 at $DIR/simplify_try.rs:7:41: 7:57
+      let _2: u32;                         // in scope 0 at $DIR/simplify_try.rs:8:9: 8:10
+      let mut _3: std::result::Result<u32, i32>; // in scope 0 at $DIR/simplify_try.rs:8:13: 8:15
+      let mut _4: std::result::Result<u32, i32>; // in scope 0 at $DIR/simplify_try.rs:8:13: 8:14
+      let mut _5: isize;                   // in scope 0 at $DIR/simplify_try.rs:8:14: 8:15
+      let _6: i32;                         // in scope 0 at $DIR/simplify_try.rs:8:14: 8:15
+      let mut _7: !;                       // in scope 0 at $DIR/simplify_try.rs:8:14: 8:15
+      let mut _8: i32;                     // in scope 0 at $DIR/simplify_try.rs:8:14: 8:15
+      let mut _9: i32;                     // in scope 0 at $DIR/simplify_try.rs:8:14: 8:15
+      let _10: u32;                        // in scope 0 at $DIR/simplify_try.rs:8:13: 8:15
+      let mut _11: u32;                    // in scope 0 at $DIR/simplify_try.rs:9:8: 9:9
       scope 1 {
-          debug y => ((_0 as Ok).0: u32);  // in scope 1 at $DIR/simplify_try.rs:7:9: 7:10
+          debug y => ((_0 as Ok).0: u32);  // in scope 1 at $DIR/simplify_try.rs:8:9: 8:10
       }
       scope 2 {
-          debug err => ((_0 as Err).0: i32); // in scope 2 at $DIR/simplify_try.rs:7:14: 7:15
+          debug err => ((_0 as Err).0: i32); // in scope 2 at $DIR/simplify_try.rs:8:14: 8:15
           scope 3 {
               scope 7 {
                   debug t => ((_0 as Err).0: i32); // in scope 7 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
               }
               scope 8 {
                   debug v => ((_0 as Err).0: i32); // in scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
-                  let mut _12: i32;        // in scope 8 at $DIR/simplify_try.rs:7:14: 7:15
+                  let mut _12: i32;        // in scope 8 at $DIR/simplify_try.rs:8:14: 8:15
               }
           }
       }
       scope 4 {
-          debug val => ((_0 as Ok).0: u32); // in scope 4 at $DIR/simplify_try.rs:7:13: 7:15
+          debug val => ((_0 as Ok).0: u32); // in scope 4 at $DIR/simplify_try.rs:8:13: 8:15
           scope 5 {
           }
       }
@@ -40,29 +40,29 @@
       }
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/simplify_try.rs:7:9: 7:10
--         StorageLive(_3);                 // scope 0 at $DIR/simplify_try.rs:7:13: 7:15
--         StorageLive(_4);                 // scope 0 at $DIR/simplify_try.rs:7:13: 7:14
--         _4 = _1;                         // scope 0 at $DIR/simplify_try.rs:7:13: 7:14
+          StorageLive(_2);                 // scope 0 at $DIR/simplify_try.rs:8:9: 8:10
+-         StorageLive(_3);                 // scope 0 at $DIR/simplify_try.rs:8:13: 8:15
+-         StorageLive(_4);                 // scope 0 at $DIR/simplify_try.rs:8:13: 8:14
+-         _4 = _1;                         // scope 0 at $DIR/simplify_try.rs:8:13: 8:14
 -         _3 = move _4;                    // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
--         StorageDead(_4);                 // scope 0 at $DIR/simplify_try.rs:7:14: 7:15
--         _5 = discriminant(_3);           // scope 0 at $DIR/simplify_try.rs:7:14: 7:15
-+         nop;                             // scope 0 at $DIR/simplify_try.rs:7:13: 7:15
-+         nop;                             // scope 0 at $DIR/simplify_try.rs:7:13: 7:14
-+         _0 = _1;                         // scope 0 at $DIR/simplify_try.rs:7:13: 7:14
+-         StorageDead(_4);                 // scope 0 at $DIR/simplify_try.rs:8:14: 8:15
+-         _5 = discriminant(_3);           // scope 0 at $DIR/simplify_try.rs:8:14: 8:15
++         nop;                             // scope 0 at $DIR/simplify_try.rs:8:13: 8:15
++         nop;                             // scope 0 at $DIR/simplify_try.rs:8:13: 8:14
++         _0 = _1;                         // scope 0 at $DIR/simplify_try.rs:8:13: 8:14
 +         nop;                             // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
-+         nop;                             // scope 0 at $DIR/simplify_try.rs:7:14: 7:15
-+         _5 = discriminant(_0);           // scope 0 at $DIR/simplify_try.rs:7:14: 7:15
-          goto -> bb1;                     // scope 0 at $DIR/simplify_try.rs:7:14: 7:15
++         nop;                             // scope 0 at $DIR/simplify_try.rs:8:14: 8:15
++         _5 = discriminant(_0);           // scope 0 at $DIR/simplify_try.rs:8:14: 8:15
+          goto -> bb1;                     // scope 0 at $DIR/simplify_try.rs:8:14: 8:15
       }
   
       bb1: {
--         _0 = move _3;                    // scope 1 at $DIR/simplify_try.rs:8:5: 8:10
--         StorageDead(_3);                 // scope 0 at $DIR/simplify_try.rs:7:15: 7:16
-+         nop;                             // scope 1 at $DIR/simplify_try.rs:8:5: 8:10
-+         nop;                             // scope 0 at $DIR/simplify_try.rs:7:15: 7:16
-          StorageDead(_2);                 // scope 0 at $DIR/simplify_try.rs:9:1: 9:2
-          return;                          // scope 0 at $DIR/simplify_try.rs:9:2: 9:2
+-         _0 = move _3;                    // scope 1 at $DIR/simplify_try.rs:9:5: 9:10
+-         StorageDead(_3);                 // scope 0 at $DIR/simplify_try.rs:8:15: 8:16
++         nop;                             // scope 1 at $DIR/simplify_try.rs:9:5: 9:10
++         nop;                             // scope 0 at $DIR/simplify_try.rs:8:15: 8:16
+          StorageDead(_2);                 // scope 0 at $DIR/simplify_try.rs:10:1: 10:2
+          return;                          // scope 0 at $DIR/simplify_try.rs:10:2: 10:2
       }
   }
   

--- a/src/test/mir-opt/simplify_try.try_identity.SimplifyArmIdentity.diff
+++ b/src/test/mir-opt/simplify_try.try_identity.SimplifyArmIdentity.diff
@@ -2,25 +2,25 @@
 + // MIR for `try_identity` after SimplifyArmIdentity
   
   fn try_identity(_1: std::result::Result<u32, i32>) -> std::result::Result<u32, i32> {
-      debug x => _1;                       // in scope 0 at $DIR/simplify_try.rs:6:17: 6:18
-      let mut _0: std::result::Result<u32, i32>; // return place in scope 0 at $DIR/simplify_try.rs:6:41: 6:57
-      let _2: u32;                         // in scope 0 at $DIR/simplify_try.rs:7:9: 7:10
-      let mut _3: std::result::Result<u32, i32>; // in scope 0 at $DIR/simplify_try.rs:7:13: 7:15
-      let mut _4: std::result::Result<u32, i32>; // in scope 0 at $DIR/simplify_try.rs:7:13: 7:14
-      let mut _5: isize;                   // in scope 0 at $DIR/simplify_try.rs:7:14: 7:15
-      let _6: i32;                         // in scope 0 at $DIR/simplify_try.rs:7:14: 7:15
-      let mut _7: !;                       // in scope 0 at $DIR/simplify_try.rs:7:14: 7:15
-      let mut _8: i32;                     // in scope 0 at $DIR/simplify_try.rs:7:14: 7:15
-      let mut _9: i32;                     // in scope 0 at $DIR/simplify_try.rs:7:14: 7:15
-      let _10: u32;                        // in scope 0 at $DIR/simplify_try.rs:7:13: 7:15
-      let mut _11: u32;                    // in scope 0 at $DIR/simplify_try.rs:8:8: 8:9
+      debug x => _1;                       // in scope 0 at $DIR/simplify_try.rs:7:17: 7:18
+      let mut _0: std::result::Result<u32, i32>; // return place in scope 0 at $DIR/simplify_try.rs:7:41: 7:57
+      let _2: u32;                         // in scope 0 at $DIR/simplify_try.rs:8:9: 8:10
+      let mut _3: std::result::Result<u32, i32>; // in scope 0 at $DIR/simplify_try.rs:8:13: 8:15
+      let mut _4: std::result::Result<u32, i32>; // in scope 0 at $DIR/simplify_try.rs:8:13: 8:14
+      let mut _5: isize;                   // in scope 0 at $DIR/simplify_try.rs:8:14: 8:15
+      let _6: i32;                         // in scope 0 at $DIR/simplify_try.rs:8:14: 8:15
+      let mut _7: !;                       // in scope 0 at $DIR/simplify_try.rs:8:14: 8:15
+      let mut _8: i32;                     // in scope 0 at $DIR/simplify_try.rs:8:14: 8:15
+      let mut _9: i32;                     // in scope 0 at $DIR/simplify_try.rs:8:14: 8:15
+      let _10: u32;                        // in scope 0 at $DIR/simplify_try.rs:8:13: 8:15
+      let mut _11: u32;                    // in scope 0 at $DIR/simplify_try.rs:9:8: 9:9
       scope 1 {
--         debug y => _2;                   // in scope 1 at $DIR/simplify_try.rs:7:9: 7:10
-+         debug y => ((_0 as Ok).0: u32);  // in scope 1 at $DIR/simplify_try.rs:7:9: 7:10
+-         debug y => _2;                   // in scope 1 at $DIR/simplify_try.rs:8:9: 8:10
++         debug y => ((_0 as Ok).0: u32);  // in scope 1 at $DIR/simplify_try.rs:8:9: 8:10
       }
       scope 2 {
--         debug err => _6;                 // in scope 2 at $DIR/simplify_try.rs:7:14: 7:15
-+         debug err => ((_0 as Err).0: i32); // in scope 2 at $DIR/simplify_try.rs:7:14: 7:15
+-         debug err => _6;                 // in scope 2 at $DIR/simplify_try.rs:8:14: 8:15
++         debug err => ((_0 as Err).0: i32); // in scope 2 at $DIR/simplify_try.rs:8:14: 8:15
           scope 3 {
               scope 7 {
 -                 debug t => _9;           // in scope 7 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
@@ -29,13 +29,13 @@
               scope 8 {
 -                 debug v => _8;           // in scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
 +                 debug v => ((_0 as Err).0: i32); // in scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
-                  let mut _12: i32;        // in scope 8 at $DIR/simplify_try.rs:7:14: 7:15
+                  let mut _12: i32;        // in scope 8 at $DIR/simplify_try.rs:8:14: 8:15
               }
           }
       }
       scope 4 {
--         debug val => _10;                // in scope 4 at $DIR/simplify_try.rs:7:13: 7:15
-+         debug val => ((_0 as Ok).0: u32); // in scope 4 at $DIR/simplify_try.rs:7:13: 7:15
+-         debug val => _10;                // in scope 4 at $DIR/simplify_try.rs:8:13: 8:15
++         debug val => ((_0 as Ok).0: u32); // in scope 4 at $DIR/simplify_try.rs:8:13: 8:15
           scope 5 {
           }
       }
@@ -44,51 +44,51 @@
       }
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/simplify_try.rs:7:9: 7:10
-          StorageLive(_3);                 // scope 0 at $DIR/simplify_try.rs:7:13: 7:15
-          StorageLive(_4);                 // scope 0 at $DIR/simplify_try.rs:7:13: 7:14
-          _4 = _1;                         // scope 0 at $DIR/simplify_try.rs:7:13: 7:14
+          StorageLive(_2);                 // scope 0 at $DIR/simplify_try.rs:8:9: 8:10
+          StorageLive(_3);                 // scope 0 at $DIR/simplify_try.rs:8:13: 8:15
+          StorageLive(_4);                 // scope 0 at $DIR/simplify_try.rs:8:13: 8:14
+          _4 = _1;                         // scope 0 at $DIR/simplify_try.rs:8:13: 8:14
           _3 = move _4;                    // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
-          StorageDead(_4);                 // scope 0 at $DIR/simplify_try.rs:7:14: 7:15
-          _5 = discriminant(_3);           // scope 0 at $DIR/simplify_try.rs:7:14: 7:15
-          switchInt(move _5) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/simplify_try.rs:7:14: 7:15
+          StorageDead(_4);                 // scope 0 at $DIR/simplify_try.rs:8:14: 8:15
+          _5 = discriminant(_3);           // scope 0 at $DIR/simplify_try.rs:8:14: 8:15
+          switchInt(move _5) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/simplify_try.rs:8:14: 8:15
       }
   
       bb1: {
--         StorageLive(_10);                // scope 0 at $DIR/simplify_try.rs:7:13: 7:15
--         _10 = ((_3 as Ok).0: u32);       // scope 0 at $DIR/simplify_try.rs:7:13: 7:15
--         _2 = _10;                        // scope 5 at $DIR/simplify_try.rs:7:13: 7:15
--         StorageDead(_10);                // scope 0 at $DIR/simplify_try.rs:7:14: 7:15
-+         _0 = move _3;                    // scope 1 at $DIR/simplify_try.rs:8:5: 8:10
-          StorageDead(_3);                 // scope 0 at $DIR/simplify_try.rs:7:15: 7:16
--         StorageLive(_11);                // scope 1 at $DIR/simplify_try.rs:8:8: 8:9
--         _11 = _2;                        // scope 1 at $DIR/simplify_try.rs:8:8: 8:9
--         ((_0 as Ok).0: u32) = move _11;  // scope 1 at $DIR/simplify_try.rs:8:5: 8:10
--         discriminant(_0) = 0;            // scope 1 at $DIR/simplify_try.rs:8:5: 8:10
--         StorageDead(_11);                // scope 1 at $DIR/simplify_try.rs:8:9: 8:10
-          StorageDead(_2);                 // scope 0 at $DIR/simplify_try.rs:9:1: 9:2
-          return;                          // scope 0 at $DIR/simplify_try.rs:9:2: 9:2
+-         StorageLive(_10);                // scope 0 at $DIR/simplify_try.rs:8:13: 8:15
+-         _10 = ((_3 as Ok).0: u32);       // scope 0 at $DIR/simplify_try.rs:8:13: 8:15
+-         _2 = _10;                        // scope 5 at $DIR/simplify_try.rs:8:13: 8:15
+-         StorageDead(_10);                // scope 0 at $DIR/simplify_try.rs:8:14: 8:15
++         _0 = move _3;                    // scope 1 at $DIR/simplify_try.rs:9:5: 9:10
+          StorageDead(_3);                 // scope 0 at $DIR/simplify_try.rs:8:15: 8:16
+-         StorageLive(_11);                // scope 1 at $DIR/simplify_try.rs:9:8: 9:9
+-         _11 = _2;                        // scope 1 at $DIR/simplify_try.rs:9:8: 9:9
+-         ((_0 as Ok).0: u32) = move _11;  // scope 1 at $DIR/simplify_try.rs:9:5: 9:10
+-         discriminant(_0) = 0;            // scope 1 at $DIR/simplify_try.rs:9:5: 9:10
+-         StorageDead(_11);                // scope 1 at $DIR/simplify_try.rs:9:9: 9:10
+          StorageDead(_2);                 // scope 0 at $DIR/simplify_try.rs:10:1: 10:2
+          return;                          // scope 0 at $DIR/simplify_try.rs:10:2: 10:2
       }
   
       bb2: {
--         StorageLive(_6);                 // scope 0 at $DIR/simplify_try.rs:7:14: 7:15
--         _6 = ((_3 as Err).0: i32);       // scope 0 at $DIR/simplify_try.rs:7:14: 7:15
--         StorageLive(_8);                 // scope 3 at $DIR/simplify_try.rs:7:14: 7:15
--         StorageLive(_9);                 // scope 3 at $DIR/simplify_try.rs:7:14: 7:15
--         _9 = _6;                         // scope 3 at $DIR/simplify_try.rs:7:14: 7:15
+-         StorageLive(_6);                 // scope 0 at $DIR/simplify_try.rs:8:14: 8:15
+-         _6 = ((_3 as Err).0: i32);       // scope 0 at $DIR/simplify_try.rs:8:14: 8:15
+-         StorageLive(_8);                 // scope 3 at $DIR/simplify_try.rs:8:14: 8:15
+-         StorageLive(_9);                 // scope 3 at $DIR/simplify_try.rs:8:14: 8:15
+-         _9 = _6;                         // scope 3 at $DIR/simplify_try.rs:8:14: 8:15
 -         _8 = move _9;                    // scope 7 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
--         StorageDead(_9);                 // scope 3 at $DIR/simplify_try.rs:7:14: 7:15
+-         StorageDead(_9);                 // scope 3 at $DIR/simplify_try.rs:8:14: 8:15
 -         StorageLive(_12);                // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
 -         _12 = move _8;                   // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
 -         ((_0 as Err).0: i32) = move _12; // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
 -         discriminant(_0) = 1;            // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
 -         StorageDead(_12);                // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
--         StorageDead(_8);                 // scope 3 at $DIR/simplify_try.rs:7:14: 7:15
--         StorageDead(_6);                 // scope 0 at $DIR/simplify_try.rs:7:14: 7:15
+-         StorageDead(_8);                 // scope 3 at $DIR/simplify_try.rs:8:14: 8:15
+-         StorageDead(_6);                 // scope 0 at $DIR/simplify_try.rs:8:14: 8:15
 +         _0 = move _3;                    // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
-          StorageDead(_3);                 // scope 0 at $DIR/simplify_try.rs:7:15: 7:16
-          StorageDead(_2);                 // scope 0 at $DIR/simplify_try.rs:9:1: 9:2
-          return;                          // scope 0 at $DIR/simplify_try.rs:7:14: 7:15
+          StorageDead(_3);                 // scope 0 at $DIR/simplify_try.rs:8:15: 8:16
+          StorageDead(_2);                 // scope 0 at $DIR/simplify_try.rs:10:1: 10:2
+          return;                          // scope 0 at $DIR/simplify_try.rs:8:14: 8:15
       }
   }
   

--- a/src/test/mir-opt/simplify_try.try_identity.SimplifyBranchSame.after.mir
+++ b/src/test/mir-opt/simplify_try.try_identity.SimplifyBranchSame.after.mir
@@ -1,35 +1,35 @@
 // MIR for `try_identity` after SimplifyBranchSame
 
 fn try_identity(_1: std::result::Result<u32, i32>) -> std::result::Result<u32, i32> {
-    debug x => _1;                       // in scope 0 at $DIR/simplify_try.rs:6:17: 6:18
-    let mut _0: std::result::Result<u32, i32>; // return place in scope 0 at $DIR/simplify_try.rs:6:41: 6:57
-    let _2: u32;                         // in scope 0 at $DIR/simplify_try.rs:7:9: 7:10
-    let mut _3: std::result::Result<u32, i32>; // in scope 0 at $DIR/simplify_try.rs:7:13: 7:15
-    let mut _4: std::result::Result<u32, i32>; // in scope 0 at $DIR/simplify_try.rs:7:13: 7:14
-    let mut _5: isize;                   // in scope 0 at $DIR/simplify_try.rs:7:14: 7:15
-    let _6: i32;                         // in scope 0 at $DIR/simplify_try.rs:7:14: 7:15
-    let mut _7: !;                       // in scope 0 at $DIR/simplify_try.rs:7:14: 7:15
-    let mut _8: i32;                     // in scope 0 at $DIR/simplify_try.rs:7:14: 7:15
-    let mut _9: i32;                     // in scope 0 at $DIR/simplify_try.rs:7:14: 7:15
-    let _10: u32;                        // in scope 0 at $DIR/simplify_try.rs:7:13: 7:15
-    let mut _11: u32;                    // in scope 0 at $DIR/simplify_try.rs:8:8: 8:9
+    debug x => _1;                       // in scope 0 at $DIR/simplify_try.rs:7:17: 7:18
+    let mut _0: std::result::Result<u32, i32>; // return place in scope 0 at $DIR/simplify_try.rs:7:41: 7:57
+    let _2: u32;                         // in scope 0 at $DIR/simplify_try.rs:8:9: 8:10
+    let mut _3: std::result::Result<u32, i32>; // in scope 0 at $DIR/simplify_try.rs:8:13: 8:15
+    let mut _4: std::result::Result<u32, i32>; // in scope 0 at $DIR/simplify_try.rs:8:13: 8:14
+    let mut _5: isize;                   // in scope 0 at $DIR/simplify_try.rs:8:14: 8:15
+    let _6: i32;                         // in scope 0 at $DIR/simplify_try.rs:8:14: 8:15
+    let mut _7: !;                       // in scope 0 at $DIR/simplify_try.rs:8:14: 8:15
+    let mut _8: i32;                     // in scope 0 at $DIR/simplify_try.rs:8:14: 8:15
+    let mut _9: i32;                     // in scope 0 at $DIR/simplify_try.rs:8:14: 8:15
+    let _10: u32;                        // in scope 0 at $DIR/simplify_try.rs:8:13: 8:15
+    let mut _11: u32;                    // in scope 0 at $DIR/simplify_try.rs:9:8: 9:9
     scope 1 {
-        debug y => ((_0 as Ok).0: u32);  // in scope 1 at $DIR/simplify_try.rs:7:9: 7:10
+        debug y => ((_0 as Ok).0: u32);  // in scope 1 at $DIR/simplify_try.rs:8:9: 8:10
     }
     scope 2 {
-        debug err => ((_0 as Err).0: i32); // in scope 2 at $DIR/simplify_try.rs:7:14: 7:15
+        debug err => ((_0 as Err).0: i32); // in scope 2 at $DIR/simplify_try.rs:8:14: 8:15
         scope 3 {
             scope 7 {
                 debug t => ((_0 as Err).0: i32); // in scope 7 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
             }
             scope 8 {
                 debug v => ((_0 as Err).0: i32); // in scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
-                let mut _12: i32;        // in scope 8 at $DIR/simplify_try.rs:7:14: 7:15
+                let mut _12: i32;        // in scope 8 at $DIR/simplify_try.rs:8:14: 8:15
             }
         }
     }
     scope 4 {
-        debug val => ((_0 as Ok).0: u32); // in scope 4 at $DIR/simplify_try.rs:7:13: 7:15
+        debug val => ((_0 as Ok).0: u32); // in scope 4 at $DIR/simplify_try.rs:8:13: 8:15
         scope 5 {
         }
     }
@@ -38,20 +38,20 @@ fn try_identity(_1: std::result::Result<u32, i32>) -> std::result::Result<u32, i
     }
 
     bb0: {
-        StorageLive(_2);                 // scope 0 at $DIR/simplify_try.rs:7:9: 7:10
-        StorageLive(_3);                 // scope 0 at $DIR/simplify_try.rs:7:13: 7:15
-        StorageLive(_4);                 // scope 0 at $DIR/simplify_try.rs:7:13: 7:14
-        _4 = _1;                         // scope 0 at $DIR/simplify_try.rs:7:13: 7:14
+        StorageLive(_2);                 // scope 0 at $DIR/simplify_try.rs:8:9: 8:10
+        StorageLive(_3);                 // scope 0 at $DIR/simplify_try.rs:8:13: 8:15
+        StorageLive(_4);                 // scope 0 at $DIR/simplify_try.rs:8:13: 8:14
+        _4 = _1;                         // scope 0 at $DIR/simplify_try.rs:8:13: 8:14
         _3 = move _4;                    // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
-        StorageDead(_4);                 // scope 0 at $DIR/simplify_try.rs:7:14: 7:15
-        _5 = discriminant(_3);           // scope 0 at $DIR/simplify_try.rs:7:14: 7:15
-        goto -> bb1;                     // scope 0 at $DIR/simplify_try.rs:7:14: 7:15
+        StorageDead(_4);                 // scope 0 at $DIR/simplify_try.rs:8:14: 8:15
+        _5 = discriminant(_3);           // scope 0 at $DIR/simplify_try.rs:8:14: 8:15
+        goto -> bb1;                     // scope 0 at $DIR/simplify_try.rs:8:14: 8:15
     }
 
     bb1: {
-        _0 = move _3;                    // scope 1 at $DIR/simplify_try.rs:8:5: 8:10
-        StorageDead(_3);                 // scope 0 at $DIR/simplify_try.rs:7:15: 7:16
-        StorageDead(_2);                 // scope 0 at $DIR/simplify_try.rs:9:1: 9:2
-        return;                          // scope 0 at $DIR/simplify_try.rs:9:2: 9:2
+        _0 = move _3;                    // scope 1 at $DIR/simplify_try.rs:9:5: 9:10
+        StorageDead(_3);                 // scope 0 at $DIR/simplify_try.rs:8:15: 8:16
+        StorageDead(_2);                 // scope 0 at $DIR/simplify_try.rs:10:1: 10:2
+        return;                          // scope 0 at $DIR/simplify_try.rs:10:2: 10:2
     }
 }

--- a/src/test/mir-opt/simplify_try.try_identity.SimplifyLocals.after.mir
+++ b/src/test/mir-opt/simplify_try.try_identity.SimplifyLocals.after.mir
@@ -1,13 +1,13 @@
 // MIR for `try_identity` after SimplifyLocals
 
 fn try_identity(_1: std::result::Result<u32, i32>) -> std::result::Result<u32, i32> {
-    debug x => _1;                       // in scope 0 at $DIR/simplify_try.rs:6:17: 6:18
-    let mut _0: std::result::Result<u32, i32>; // return place in scope 0 at $DIR/simplify_try.rs:6:41: 6:57
+    debug x => _1;                       // in scope 0 at $DIR/simplify_try.rs:7:17: 7:18
+    let mut _0: std::result::Result<u32, i32>; // return place in scope 0 at $DIR/simplify_try.rs:7:41: 7:57
     scope 1 {
-        debug y => ((_0 as Ok).0: u32);  // in scope 1 at $DIR/simplify_try.rs:7:9: 7:10
+        debug y => ((_0 as Ok).0: u32);  // in scope 1 at $DIR/simplify_try.rs:8:9: 8:10
     }
     scope 2 {
-        debug err => ((_0 as Err).0: i32); // in scope 2 at $DIR/simplify_try.rs:7:14: 7:15
+        debug err => ((_0 as Err).0: i32); // in scope 2 at $DIR/simplify_try.rs:8:14: 8:15
         scope 3 {
             scope 7 {
                 debug t => ((_0 as Err).0: i32); // in scope 7 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
@@ -18,7 +18,7 @@ fn try_identity(_1: std::result::Result<u32, i32>) -> std::result::Result<u32, i
         }
     }
     scope 4 {
-        debug val => ((_0 as Ok).0: u32); // in scope 4 at $DIR/simplify_try.rs:7:13: 7:15
+        debug val => ((_0 as Ok).0: u32); // in scope 4 at $DIR/simplify_try.rs:8:13: 8:15
         scope 5 {
         }
     }
@@ -27,7 +27,7 @@ fn try_identity(_1: std::result::Result<u32, i32>) -> std::result::Result<u32, i
     }
 
     bb0: {
-        _0 = _1;                         // scope 0 at $DIR/simplify_try.rs:7:13: 7:14
-        return;                          // scope 0 at $DIR/simplify_try.rs:9:2: 9:2
+        _0 = _1;                         // scope 0 at $DIR/simplify_try.rs:8:13: 8:14
+        return;                          // scope 0 at $DIR/simplify_try.rs:10:2: 10:2
     }
 }

--- a/src/test/mir-opt/simplify_try_if_let.rs
+++ b/src/test/mir-opt/simplify_try_if_let.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmir-opt-level=1
+// compile-flags: -Zmir-opt-level=1 -Zunsound-mir-opts
 // EMIT_MIR simplify_try_if_let.{impl#0}-append.SimplifyArmIdentity.diff
 
 use std::ptr::NonNull;

--- a/src/test/ui/mir/issue-77359-simplify-arm-identity-.rs
+++ b/src/test/ui/mir/issue-77359-simplify-arm-identity-.rs
@@ -1,0 +1,35 @@
+// run-pass
+
+#![allow(dead_code)]
+
+#[derive(Debug)]
+enum MyEnum {
+    Variant1(Vec<u8>),
+    Variant2,
+    Variant3,
+    Variant4,
+}
+
+fn f(arg1: &bool, arg2: &bool, arg3: bool) -> MyStruct {
+    if *arg1 {
+        println!("{:?}", f(&arg2, arg2, arg3));
+        MyStruct(None)
+    } else {
+        match if arg3 { Some(MyEnum::Variant3) } else { None } {
+            Some(t) => {
+                let ah = t;
+                return MyStruct(Some(ah));
+            }
+            _ => MyStruct(None)
+        }
+    }
+}
+
+#[derive(Debug)]
+struct MyStruct(Option<MyEnum>);
+
+fn main() {
+    let arg1 = true;
+    let arg2 = false;
+    f(&arg1, &arg2, true);
+}


### PR DESCRIPTION
The optimization still has some bugs that need to be worked out
such as #77359.

We can try re-enabling this again after the known issues are resolved.

r? @oli-obk 