### PR TITLE
Fix suggestions for x.py setup

### DIFF
--- a/src/bootstrap/flags.rs
+++ b/src/bootstrap/flags.rs
@@ -542,7 +542,14 @@ Arguments:
                         |path| format!("{} is not a valid UTF8 string", path.to_string_lossy())
                     ));
 
-                    profile_string.parse().expect("unknown profile")
+                    profile_string.parse().unwrap_or_else(|_| {
+                        eprintln!("error: unknown profile {}", profile_string);
+                        eprintln!("help: the available profiles are:");
+                        for choice in Profile::all() {
+                            eprintln!("- {}", choice);
+                        }
+                        std::process::exit(1);
+                    })
                 } else {
                     t!(crate::setup::interactive_path())
                 };

--- a/src/bootstrap/flags.rs
+++ b/src/bootstrap/flags.rs
@@ -12,6 +12,7 @@ use getopts::Options;
 
 use crate::builder::Builder;
 use crate::config::{Config, TargetSelection};
+use crate::setup::Profile;
 use crate::{Build, DocTests};
 
 /// Deserialized version of all flags for this compile.
@@ -94,7 +95,7 @@ pub enum Subcommand {
         paths: Vec<PathBuf>,
     },
     Setup {
-        path: String,
+        profile: Profile,
     },
 }
 
@@ -533,18 +534,19 @@ Arguments:
                 Subcommand::Run { paths }
             }
             "setup" => {
-                let path = if paths.len() > 1 {
+                let profile = if paths.len() > 1 {
                     println!("\nat most one profile can be passed to setup\n");
                     usage(1, &opts, verbose, &subcommand_help)
                 } else if let Some(path) = paths.pop() {
-                    t!(path.into_os_string().into_string().map_err(|path| format!(
-                        "{} is not a valid UTF8 string",
-                        path.to_string_lossy()
-                    )))
+                    let profile_string = t!(path.into_os_string().into_string().map_err(
+                        |path| format!("{} is not a valid UTF8 string", path.to_string_lossy())
+                    ));
+
+                    profile_string.parse().expect("unknown profile")
                 } else {
                     t!(crate::setup::interactive_path())
                 };
-                Subcommand::Setup { path }
+                Subcommand::Setup { profile }
             }
             _ => {
                 usage(1, &opts, verbose, &subcommand_help);

--- a/src/bootstrap/flags.rs
+++ b/src/bootstrap/flags.rs
@@ -542,8 +542,8 @@ Arguments:
                         |path| format!("{} is not a valid UTF8 string", path.to_string_lossy())
                     ));
 
-                    profile_string.parse().unwrap_or_else(|_| {
-                        eprintln!("error: unknown profile {}", profile_string);
+                    profile_string.parse().unwrap_or_else(|err| {
+                        eprintln!("error: {}", err);
                         eprintln!("help: the available profiles are:");
                         for choice in Profile::all() {
                             eprintln!("- {}", choice);

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -471,8 +471,8 @@ impl Build {
             return clean::clean(self, all);
         }
 
-        if let Subcommand::Setup { path: include_name } = &self.config.cmd {
-            return setup::setup(&self.config.src, include_name);
+        if let Subcommand::Setup { profile } = &self.config.cmd {
+            return setup::setup(&self.config.src, *profile);
         }
 
         {

--- a/src/bootstrap/setup.rs
+++ b/src/bootstrap/setup.rs
@@ -40,9 +40,9 @@ pub fn setup(src_path: &Path, include_name: &str) {
     println!("`x.py` will now use the configuration at {}", include_path);
 
     let suggestions = match include_name {
-        "codegen" | "compiler" => &["check", "build", "test"][..],
+        "llvm" | "codegen" | "compiler" => &["check", "build", "test"][..],
         "library" => &["check", "build", "test library/std", "doc"],
-        "user" => &["dist", "build"],
+        "maintainer" | "user" => &["dist", "build"],
         _ => return,
     };
 

--- a/src/bootstrap/setup.rs
+++ b/src/bootstrap/setup.rs
@@ -18,6 +18,10 @@ impl Profile {
     fn include_path(&self, src_path: &Path) -> PathBuf {
         PathBuf::from(format!("{}/src/bootstrap/defaults/config.{}.toml", src_path.display(), self))
     }
+
+    pub fn all() -> impl Iterator<Item = Self> {
+        [Profile::Compiler, Profile::Codegen, Profile::Library, Profile::User].iter().copied()
+    }
 }
 
 #[derive(Debug)]

--- a/src/bootstrap/setup.rs
+++ b/src/bootstrap/setup.rs
@@ -24,13 +24,8 @@ impl Profile {
     }
 }
 
-#[derive(Debug)]
-pub struct ProfileErr {
-    pub name: String,
-}
-
 impl FromStr for Profile {
-    type Err = ProfileErr;
+    type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
@@ -38,7 +33,7 @@ impl FromStr for Profile {
             "b" | "compiler" => Ok(Profile::Compiler),
             "c" | "llvm" | "codegen" => Ok(Profile::Codegen),
             "d" | "maintainer" | "user" => Ok(Profile::User),
-            _ => Err(ProfileErr { name: s.to_string() }),
+            _ => Err(format!("unknown profile: '{}'", s)),
         }
     }
 }
@@ -116,8 +111,8 @@ d) Install Rust from source"
         io::stdin().read_line(&mut input)?;
         break match input.trim().to_lowercase().parse() {
             Ok(profile) => profile,
-            Err(ProfileErr { name }) => {
-                println!("error: unrecognized option '{}'", name);
+            Err(err) => {
+                println!("error: {}", err);
                 println!("note: press Ctrl+C to exit");
                 continue;
             }


### PR DESCRIPTION
#76631 introduced a new `setup` command to x.py

By default the command prompts for a profile to use:

```
Welcome to the Rust project! What do you want to do with x.py?
a) Contribute to the standard library
b) Contribute to the compiler
c) Contribute to the compiler, and also modify LLVM or codegen
d) Install Rust from source
```

and then displays command suggestions, depending on which profile was chosen. However [the mapping between chosen profile](https://github.com/rust-lang/rust/blob/9cba260df0f1c67ea3690035cd5611a7465a1560/src/bootstrap/setup.rs#L75-L85) and [suggestion](https://github.com/rust-lang/rust/blob/9cba260df0f1c67ea3690035cd5611a7465a1560/src/bootstrap/setup.rs#L42-L47) isn't exact, leading to suggestions not being shown if the user presses `c` or `d`. (because "c" is translated to "llvm" and "d" to "maintainer", but suggestions trigger for "codegen" and "user" respectively)

A more thorough refactor would stop using "strings-as-type" to make sure this kind of error doesn't happen, but it may be overkill for that kind of "script" program?

Tagging the setup command author: @jyn514 