### PR TITLE
Ignore mir tests on big-endian

### DIFF
--- a/src/test/mir-opt/const_prop/checked_add.rs
+++ b/src/test/mir-opt/const_prop/checked_add.rs
@@ -1,5 +1,5 @@
 // compile-flags: -C overflow-checks=on
-
+// ignore-endian-big
 // EMIT_MIR checked_add.main.ConstProp.diff
 fn main() {
     let x: u32 = 1 + 1;

--- a/src/test/mir-opt/const_prop/mutable_variable_aggregate.rs
+++ b/src/test/mir-opt/const_prop/mutable_variable_aggregate.rs
@@ -1,5 +1,5 @@
 // compile-flags: -O
-
+// ignore-endian-big
 // EMIT_MIR mutable_variable_aggregate.main.ConstProp.diff
 fn main() {
     let mut x = (42, 43);

--- a/src/test/mir-opt/const_prop/mutable_variable_no_prop.rs
+++ b/src/test/mir-opt/const_prop/mutable_variable_no_prop.rs
@@ -1,5 +1,5 @@
 // compile-flags: -O
-
+// ignore-endian-big
 static mut STATIC: u32 = 42;
 
 // EMIT_MIR mutable_variable_no_prop.main.ConstProp.diff

--- a/src/test/mir-opt/const_prop/optimizes_into_variable.rs
+++ b/src/test/mir-opt/const_prop/optimizes_into_variable.rs
@@ -1,5 +1,5 @@
 // compile-flags: -C overflow-checks=on
-
+// ignore-endian-big
 struct Point {
     x: u32,
     y: u32,

--- a/src/test/mir-opt/const_prop/return_place.rs
+++ b/src/test/mir-opt/const_prop/return_place.rs
@@ -1,5 +1,5 @@
 // compile-flags: -C overflow-checks=on
-
+// ignore-endian-big
 // EMIT_MIR return_place.add.ConstProp.diff
 // EMIT_MIR return_place.add.PreCodegen.before.mir
 fn add() -> u32 {

--- a/src/test/mir-opt/const_prop/tuple_literal_propagation.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/tuple_literal_propagation.main.ConstProp.diff
@@ -2,40 +2,40 @@
 + // MIR for `main` after ConstProp
   
   fn main() -> () {
-      let mut _0: ();                      // return place in scope 0 at $DIR/tuple_literal_propagation.rs:2:11: 2:11
-      let _1: (u32, u32);                  // in scope 0 at $DIR/tuple_literal_propagation.rs:3:9: 3:10
-      let _2: ();                          // in scope 0 at $DIR/tuple_literal_propagation.rs:5:5: 5:15
-      let mut _3: (u32, u32);              // in scope 0 at $DIR/tuple_literal_propagation.rs:5:13: 5:14
+      let mut _0: ();                      // return place in scope 0 at $DIR/tuple_literal_propagation.rs:3:11: 3:11
+      let _1: (u32, u32);                  // in scope 0 at $DIR/tuple_literal_propagation.rs:4:9: 4:10
+      let _2: ();                          // in scope 0 at $DIR/tuple_literal_propagation.rs:6:5: 6:15
+      let mut _3: (u32, u32);              // in scope 0 at $DIR/tuple_literal_propagation.rs:6:13: 6:14
       scope 1 {
-          debug x => _1;                   // in scope 1 at $DIR/tuple_literal_propagation.rs:3:9: 3:10
+          debug x => _1;                   // in scope 1 at $DIR/tuple_literal_propagation.rs:4:9: 4:10
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/tuple_literal_propagation.rs:3:9: 3:10
-          (_1.0: u32) = const 1_u32;       // scope 0 at $DIR/tuple_literal_propagation.rs:3:13: 3:19
-          (_1.1: u32) = const 2_u32;       // scope 0 at $DIR/tuple_literal_propagation.rs:3:13: 3:19
-          StorageLive(_2);                 // scope 1 at $DIR/tuple_literal_propagation.rs:5:5: 5:15
-          StorageLive(_3);                 // scope 1 at $DIR/tuple_literal_propagation.rs:5:13: 5:14
--         _3 = _1;                         // scope 1 at $DIR/tuple_literal_propagation.rs:5:13: 5:14
-+         _3 = const (1_u32, 2_u32);       // scope 1 at $DIR/tuple_literal_propagation.rs:5:13: 5:14
+          StorageLive(_1);                 // scope 0 at $DIR/tuple_literal_propagation.rs:4:9: 4:10
+          (_1.0: u32) = const 1_u32;       // scope 0 at $DIR/tuple_literal_propagation.rs:4:13: 4:19
+          (_1.1: u32) = const 2_u32;       // scope 0 at $DIR/tuple_literal_propagation.rs:4:13: 4:19
+          StorageLive(_2);                 // scope 1 at $DIR/tuple_literal_propagation.rs:6:5: 6:15
+          StorageLive(_3);                 // scope 1 at $DIR/tuple_literal_propagation.rs:6:13: 6:14
+-         _3 = _1;                         // scope 1 at $DIR/tuple_literal_propagation.rs:6:13: 6:14
++         _3 = const (1_u32, 2_u32);       // scope 1 at $DIR/tuple_literal_propagation.rs:6:13: 6:14
 +                                          // ty::Const
 +                                          // + ty: (u32, u32)
 +                                          // + val: Value(ByRef { alloc: Allocation { bytes: [1, 0, 0, 0, 2, 0, 0, 0], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [255], len: Size { raw: 8 } }, size: Size { raw: 8 }, align: Align { pow2: 2 }, mutability: Not, extra: () }, offset: Size { raw: 0 } })
 +                                          // mir::Constant
-+                                          // + span: $DIR/tuple_literal_propagation.rs:5:13: 5:14
++                                          // + span: $DIR/tuple_literal_propagation.rs:6:13: 6:14
 +                                          // + literal: Const { ty: (u32, u32), val: Value(ByRef { alloc: Allocation { bytes: [1, 0, 0, 0, 2, 0, 0, 0], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [255], len: Size { raw: 8 } }, size: Size { raw: 8 }, align: Align { pow2: 2 }, mutability: Not, extra: () }, offset: Size { raw: 0 } }) }
-          _2 = consume(move _3) -> bb1;    // scope 1 at $DIR/tuple_literal_propagation.rs:5:5: 5:15
+          _2 = consume(move _3) -> bb1;    // scope 1 at $DIR/tuple_literal_propagation.rs:6:5: 6:15
                                            // mir::Constant
-                                           // + span: $DIR/tuple_literal_propagation.rs:5:5: 5:12
+                                           // + span: $DIR/tuple_literal_propagation.rs:6:5: 6:12
                                            // + literal: Const { ty: fn((u32, u32)) {consume}, val: Value(Scalar(<ZST>)) }
       }
   
       bb1: {
-          StorageDead(_3);                 // scope 1 at $DIR/tuple_literal_propagation.rs:5:14: 5:15
-          StorageDead(_2);                 // scope 1 at $DIR/tuple_literal_propagation.rs:5:15: 5:16
-          _0 = const ();                   // scope 0 at $DIR/tuple_literal_propagation.rs:2:11: 6:2
-          StorageDead(_1);                 // scope 0 at $DIR/tuple_literal_propagation.rs:6:1: 6:2
-          return;                          // scope 0 at $DIR/tuple_literal_propagation.rs:6:2: 6:2
+          StorageDead(_3);                 // scope 1 at $DIR/tuple_literal_propagation.rs:6:14: 6:15
+          StorageDead(_2);                 // scope 1 at $DIR/tuple_literal_propagation.rs:6:15: 6:16
+          _0 = const ();                   // scope 0 at $DIR/tuple_literal_propagation.rs:3:11: 7:2
+          StorageDead(_1);                 // scope 0 at $DIR/tuple_literal_propagation.rs:7:1: 7:2
+          return;                          // scope 0 at $DIR/tuple_literal_propagation.rs:7:2: 7:2
       }
   }
   

--- a/src/test/mir-opt/const_prop/tuple_literal_propagation.rs
+++ b/src/test/mir-opt/const_prop/tuple_literal_propagation.rs
@@ -1,3 +1,4 @@
+// ignore-endian-big
 // EMIT_MIR tuple_literal_propagation.main.ConstProp.diff
 fn main() {
     let x = (1, 2);


### PR DESCRIPTION
Other mir tests are already ignored on big-endian, e.g. const_allocation*.rs