### PR TITLE
Better error message for `async` blocks in a const-context

### DIFF
--- a/compiler/rustc_mir/src/transform/check_consts/ops.rs
+++ b/compiler/rustc_mir/src/transform/check_consts/ops.rs
@@ -151,14 +151,15 @@ impl NonConstOp for FnPtrCast {
 }
 
 #[derive(Debug)]
-pub struct Generator;
+pub struct Generator(pub hir::GeneratorKind);
 impl NonConstOp for Generator {
     fn status_in_item(&self, _: &ConstCx<'_, '_>) -> Status {
         Status::Forbidden
     }
 
     fn build_error(&self, ccx: &ConstCx<'_, 'tcx>, span: Span) -> DiagnosticBuilder<'tcx> {
-        ccx.tcx.sess.struct_span_err(span, "Generators and `async` functions cannot be `const`")
+        let msg = format!("{}s are not allowed in {}s", self.0, ccx.const_kind());
+        ccx.tcx.sess.struct_span_err(span, &msg)
     }
 }
 

--- a/src/test/ui/consts/async-block.rs
+++ b/src/test/ui/consts/async-block.rs
@@ -1,0 +1,8 @@
+// From <https://github.com/rust-lang/rust/issues/77361>
+
+// edition:2018
+
+const _: i32 = { core::mem::ManuallyDrop::new(async { 0 }); 4 };
+//~^ `async` block
+
+fn main() {}

--- a/src/test/ui/consts/async-block.stderr
+++ b/src/test/ui/consts/async-block.stderr
@@ -1,0 +1,8 @@
+error: `async` blocks are not allowed in constants
+  --> $DIR/async-block.rs:5:47
+   |
+LL | const _: i32 = { core::mem::ManuallyDrop::new(async { 0 }); 4 };
+   |                                               ^^^^^^^^^^^
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Improves the error message for the case in #77361.

r? @oli-obk 