### PR TITLE
Switch to environment files to change the environment on GHA

### DIFF
--- a/src/ci/shared.sh
+++ b/src/ci/shared.sh
@@ -104,7 +104,7 @@ function ciCommandAddPath {
     if isAzurePipelines; then
         echo "##vso[task.prependpath]${path}"
     elif isGitHubActions; then
-        echo "::add-path::${path}"
+        echo "${path}" >> "${GITHUB_PATH}"
     else
         echo "ciCommandAddPath only works inside CI!"
         exit 1
@@ -122,7 +122,7 @@ function ciCommandSetEnv {
     if isAzurePipelines; then
         echo "##vso[task.setvariable variable=${name}]${value}"
     elif isGitHubActions; then
-        echo "::set-env name=${name}::${value}"
+        echo "${name}=${value}" >> "${GITHUB_ENV}"
     else
         echo "ciCommandSetEnv only works inside CI!"
         exit 1


### PR DESCRIPTION
This PR switches our CI to use GitHub's new [environment files](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files) to set environment variables and add items to `$PATH`, as GitHub [plans to disable the old `::set-env` and `::add-path` log commands](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/) due to a [security issue](https://github.com/actions/toolkit/security/advisories/GHSA-mfwh-5m23-j46w).

Our self-hosted runners are on version 2.273.4, so they already have support for this.

r? @Mark-Simulacrum 