### PR TITLE
Revert "resolve: Avoid "self-confirming" import resolutions in one more case"

### DIFF
--- a/compiler/rustc_resolve/src/imports.rs
+++ b/compiler/rustc_resolve/src/imports.rs
@@ -875,12 +875,6 @@ impl<'a, 'b> ImportResolver<'a, 'b> {
     /// consolidate multiple unresolved import errors into a single diagnostic.
     fn finalize_import(&mut self, import: &'b Import<'b>) -> Option<UnresolvedImportError> {
         let orig_vis = import.vis.replace(ty::Visibility::Invisible);
-        let orig_unusable_binding = match &import.kind {
-            ImportKind::Single { target_bindings, .. } => {
-                Some(mem::replace(&mut self.r.unusable_binding, target_bindings[TypeNS].get()))
-            }
-            _ => None,
-        };
         let prev_ambiguity_errors_len = self.r.ambiguity_errors.len();
         let path_res = self.r.resolve_path(
             &import.module_path,
@@ -891,9 +885,6 @@ impl<'a, 'b> ImportResolver<'a, 'b> {
             import.crate_lint(),
         );
         let no_ambiguity = self.r.ambiguity_errors.len() == prev_ambiguity_errors_len;
-        if let Some(orig_unusable_binding) = orig_unusable_binding {
-            self.r.unusable_binding = orig_unusable_binding;
-        }
         import.vis.set(orig_vis);
         if let PathResult::Failed { .. } | PathResult::NonModule(..) = path_res {
             // Consider erroneous imports used to avoid duplicate diagnostics.
@@ -904,7 +895,8 @@ impl<'a, 'b> ImportResolver<'a, 'b> {
                 // Consistency checks, analogous to `finalize_macro_resolutions`.
                 if let Some(initial_module) = import.imported_module.get() {
                     if !ModuleOrUniformRoot::same_def(module, initial_module) && no_ambiguity {
-                        span_bug!(import.span, "inconsistent resolution for an import");
+                        let msg = "inconsistent resolution for an import";
+                        self.r.session.span_err(import.span, msg);
                     }
                 } else {
                     if self.r.privacy_errors.is_empty() {
@@ -926,7 +918,6 @@ impl<'a, 'b> ImportResolver<'a, 'b> {
             }
             PathResult::Failed { is_error_from_last_segment: true, span, label, suggestion } => {
                 if no_ambiguity {
-                    assert!(import.imported_module.get().is_none());
                     let err = match self.make_path_suggestion(
                         span,
                         import.module_path.clone(),

--- a/src/test/ui/imports/issue-62767.rs
+++ b/src/test/ui/imports/issue-62767.rs
@@ -1,5 +1,4 @@
-// check-pass
-
+// Minimized case from #62767.
 mod m {
     pub enum Same {
         Same,
@@ -8,8 +7,22 @@ mod m {
 
 use m::*;
 
-// The variant `Same` introduced by this import is not considered when resolving the prefix
-// `Same::` during import validation (issue #62767).
-use Same::Same;
+// The variant `Same` introduced by this import is also considered when resolving the prefix
+// `Same::` during import validation to avoid effects similar to time travel (#74556).
+use Same::Same; //~ ERROR unresolved import `Same`
+
+// Case from #74556.
+mod foo {
+    pub mod bar {
+        pub mod bar {
+            pub fn foobar() {}
+        }
+    }
+}
+
+use foo::*;
+use bar::bar; //~ ERROR unresolved import `bar::bar`
+              //~| ERROR inconsistent resolution for an import
+use bar::foobar;
 
 fn main() {}

--- a/src/test/ui/imports/issue-62767.stderr
+++ b/src/test/ui/imports/issue-62767.stderr
@@ -1,0 +1,21 @@
+error: inconsistent resolution for an import
+  --> $DIR/issue-62767.rs:24:5
+   |
+LL | use bar::bar;
+   |     ^^^^^^^^
+
+error[E0432]: unresolved import `Same`
+  --> $DIR/issue-62767.rs:12:5
+   |
+LL | use Same::Same;
+   |     ^^^^ `Same` is a variant, not a module
+
+error[E0432]: unresolved import `bar::bar`
+  --> $DIR/issue-62767.rs:24:5
+   |
+LL | use bar::bar;
+   |     ^^^^^^^^ no `bar` in `foo::bar::bar`
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0432`.


### PR DESCRIPTION
And remove the assert that https://github.com/rust-lang/rust/pull/70236 tried to avoid instead.

Closes https://github.com/rust-lang/rust/issues/74556.