### PR TITLE
Include trailing comma in field/variant spans

### DIFF
--- a/src/test/mir-opt/unusual_item_types.Test-X-{constructor#0}.mir_map.0.32bit.mir
+++ b/src/test/mir-opt/unusual_item_types.Test-X-{constructor#0}.mir_map.0.32bit.mir
@@ -1,11 +1,11 @@
 // MIR for `Test::X` 0 mir_map
 
 fn Test::X(_1: usize) -> Test {
-    let mut _0: Test;                    // return place in scope 0 at $DIR/unusual-item-types.rs:16:5: 16:13
+    let mut _0: Test;                    // return place in scope 0 at $DIR/unusual-item-types.rs:16:5: 16:14
 
     bb0: {
-        ((_0 as X).0: usize) = move _1;  // scope 0 at $DIR/unusual-item-types.rs:16:5: 16:13
-        discriminant(_0) = 0;            // scope 0 at $DIR/unusual-item-types.rs:16:5: 16:13
-        return;                          // scope 0 at $DIR/unusual-item-types.rs:16:5: 16:13
+        ((_0 as X).0: usize) = move _1;  // scope 0 at $DIR/unusual-item-types.rs:16:5: 16:14
+        discriminant(_0) = 0;            // scope 0 at $DIR/unusual-item-types.rs:16:5: 16:14
+        return;                          // scope 0 at $DIR/unusual-item-types.rs:16:5: 16:14
     }
 }

--- a/src/test/mir-opt/unusual_item_types.Test-X-{constructor#0}.mir_map.0.64bit.mir
+++ b/src/test/mir-opt/unusual_item_types.Test-X-{constructor#0}.mir_map.0.64bit.mir
@@ -1,11 +1,11 @@
 // MIR for `Test::X` 0 mir_map
 
 fn Test::X(_1: usize) -> Test {
-    let mut _0: Test;                    // return place in scope 0 at $DIR/unusual-item-types.rs:16:5: 16:13
+    let mut _0: Test;                    // return place in scope 0 at $DIR/unusual-item-types.rs:16:5: 16:14
 
     bb0: {
-        ((_0 as X).0: usize) = move _1;  // scope 0 at $DIR/unusual-item-types.rs:16:5: 16:13
-        discriminant(_0) = 0;            // scope 0 at $DIR/unusual-item-types.rs:16:5: 16:13
-        return;                          // scope 0 at $DIR/unusual-item-types.rs:16:5: 16:13
+        ((_0 as X).0: usize) = move _1;  // scope 0 at $DIR/unusual-item-types.rs:16:5: 16:14
+        discriminant(_0) = 0;            // scope 0 at $DIR/unusual-item-types.rs:16:5: 16:14
+        return;                          // scope 0 at $DIR/unusual-item-types.rs:16:5: 16:14
     }
 }

--- a/src/test/ui/derive-uninhabited-enum-38885.stderr
+++ b/src/test/ui/derive-uninhabited-enum-38885.stderr
@@ -2,7 +2,7 @@ warning: variant is never constructed: `Void`
   --> $DIR/derive-uninhabited-enum-38885.rs:13:5
    |
 LL |     Void(Void),
-   |     ^^^^^^^^^^
+   |     ^^^^^^^^^^^
    |
    = note: `-W dead-code` implied by `-W unused`
 

--- a/src/test/ui/discrim/discrim-overflow-2.stderr
+++ b/src/test/ui/discrim/discrim-overflow-2.stderr
@@ -2,7 +2,7 @@ error[E0370]: enum discriminant overflowed
   --> $DIR/discrim-overflow-2.rs:15:9
    |
 LL |         OhNo,
-   |         ^^^^ overflowed on value after 127
+   |         ^^^^^ overflowed on value after 127
    |
    = note: explicitly set `OhNo = -128` if that is desired outcome
 
@@ -10,7 +10,7 @@ error[E0370]: enum discriminant overflowed
   --> $DIR/discrim-overflow-2.rs:24:9
    |
 LL |         OhNo,
-   |         ^^^^ overflowed on value after 255
+   |         ^^^^^ overflowed on value after 255
    |
    = note: explicitly set `OhNo = 0` if that is desired outcome
 
@@ -18,7 +18,7 @@ error[E0370]: enum discriminant overflowed
   --> $DIR/discrim-overflow-2.rs:33:9
    |
 LL |         OhNo,
-   |         ^^^^ overflowed on value after 32767
+   |         ^^^^^ overflowed on value after 32767
    |
    = note: explicitly set `OhNo = -32768` if that is desired outcome
 
@@ -26,7 +26,7 @@ error[E0370]: enum discriminant overflowed
   --> $DIR/discrim-overflow-2.rs:42:9
    |
 LL |         OhNo,
-   |         ^^^^ overflowed on value after 65535
+   |         ^^^^^ overflowed on value after 65535
    |
    = note: explicitly set `OhNo = 0` if that is desired outcome
 
@@ -34,7 +34,7 @@ error[E0370]: enum discriminant overflowed
   --> $DIR/discrim-overflow-2.rs:51:9
    |
 LL |         OhNo,
-   |         ^^^^ overflowed on value after 2147483647
+   |         ^^^^^ overflowed on value after 2147483647
    |
    = note: explicitly set `OhNo = -2147483648` if that is desired outcome
 
@@ -42,7 +42,7 @@ error[E0370]: enum discriminant overflowed
   --> $DIR/discrim-overflow-2.rs:60:9
    |
 LL |         OhNo,
-   |         ^^^^ overflowed on value after 4294967295
+   |         ^^^^^ overflowed on value after 4294967295
    |
    = note: explicitly set `OhNo = 0` if that is desired outcome
 
@@ -50,7 +50,7 @@ error[E0370]: enum discriminant overflowed
   --> $DIR/discrim-overflow-2.rs:69:9
    |
 LL |         OhNo,
-   |         ^^^^ overflowed on value after 9223372036854775807
+   |         ^^^^^ overflowed on value after 9223372036854775807
    |
    = note: explicitly set `OhNo = -9223372036854775808` if that is desired outcome
 
@@ -58,7 +58,7 @@ error[E0370]: enum discriminant overflowed
   --> $DIR/discrim-overflow-2.rs:78:9
    |
 LL |         OhNo,
-   |         ^^^^ overflowed on value after 18446744073709551615
+   |         ^^^^^ overflowed on value after 18446744073709551615
    |
    = note: explicitly set `OhNo = 0` if that is desired outcome
 

--- a/src/test/ui/discrim/discrim-overflow.stderr
+++ b/src/test/ui/discrim/discrim-overflow.stderr
@@ -2,7 +2,7 @@ error[E0370]: enum discriminant overflowed
   --> $DIR/discrim-overflow.rs:13:9
    |
 LL |         OhNo,
-   |         ^^^^ overflowed on value after 127
+   |         ^^^^^ overflowed on value after 127
    |
    = note: explicitly set `OhNo = -128` if that is desired outcome
 
@@ -10,7 +10,7 @@ error[E0370]: enum discriminant overflowed
   --> $DIR/discrim-overflow.rs:24:9
    |
 LL |         OhNo,
-   |         ^^^^ overflowed on value after 255
+   |         ^^^^^ overflowed on value after 255
    |
    = note: explicitly set `OhNo = 0` if that is desired outcome
 
@@ -18,7 +18,7 @@ error[E0370]: enum discriminant overflowed
   --> $DIR/discrim-overflow.rs:35:9
    |
 LL |         OhNo,
-   |         ^^^^ overflowed on value after 32767
+   |         ^^^^^ overflowed on value after 32767
    |
    = note: explicitly set `OhNo = -32768` if that is desired outcome
 
@@ -26,7 +26,7 @@ error[E0370]: enum discriminant overflowed
   --> $DIR/discrim-overflow.rs:46:9
    |
 LL |         OhNo,
-   |         ^^^^ overflowed on value after 65535
+   |         ^^^^^ overflowed on value after 65535
    |
    = note: explicitly set `OhNo = 0` if that is desired outcome
 
@@ -34,7 +34,7 @@ error[E0370]: enum discriminant overflowed
   --> $DIR/discrim-overflow.rs:58:9
    |
 LL |         OhNo,
-   |         ^^^^ overflowed on value after 2147483647
+   |         ^^^^^ overflowed on value after 2147483647
    |
    = note: explicitly set `OhNo = -2147483648` if that is desired outcome
 
@@ -42,7 +42,7 @@ error[E0370]: enum discriminant overflowed
   --> $DIR/discrim-overflow.rs:70:9
    |
 LL |         OhNo,
-   |         ^^^^ overflowed on value after 4294967295
+   |         ^^^^^ overflowed on value after 4294967295
    |
    = note: explicitly set `OhNo = 0` if that is desired outcome
 
@@ -50,7 +50,7 @@ error[E0370]: enum discriminant overflowed
   --> $DIR/discrim-overflow.rs:82:9
    |
 LL |         OhNo,
-   |         ^^^^ overflowed on value after 9223372036854775807
+   |         ^^^^^ overflowed on value after 9223372036854775807
    |
    = note: explicitly set `OhNo = -9223372036854775808` if that is desired outcome
 
@@ -58,7 +58,7 @@ error[E0370]: enum discriminant overflowed
   --> $DIR/discrim-overflow.rs:94:9
    |
 LL |         OhNo,
-   |         ^^^^ overflowed on value after 18446744073709551615
+   |         ^^^^^ overflowed on value after 18446744073709551615
    |
    = note: explicitly set `OhNo = 0` if that is desired outcome
 

--- a/src/test/ui/empty/empty-struct-braces-pat-1.stderr
+++ b/src/test/ui/empty/empty-struct-braces-pat-1.stderr
@@ -18,7 +18,7 @@ LL |         XE::XEmpty3 => ()
 LL |     XEmpty3 {},
    |     ------- `XE::XEmpty3` defined here
 LL |     XEmpty4,
-   |     ------- similarly named unit variant `XEmpty4` defined here
+   |     -------- similarly named unit variant `XEmpty4` defined here
    |
 help: use struct pattern syntax instead
    |

--- a/src/test/ui/empty/empty-struct-braces-pat-3.stderr
+++ b/src/test/ui/empty/empty-struct-braces-pat-3.stderr
@@ -19,7 +19,7 @@ LL |     XEmpty3 {},
    |     ------- `XE::XEmpty3` defined here
 LL |     XEmpty4,
 LL |     XEmpty5(),
-   |     --------- similarly named tuple variant `XEmpty5` defined here
+   |     ---------- similarly named tuple variant `XEmpty5` defined here
    |
 help: use struct pattern syntax instead
    |
@@ -51,7 +51,7 @@ LL |     XEmpty3 {},
    |     ------- `XE::XEmpty3` defined here
 LL |     XEmpty4,
 LL |     XEmpty5(),
-   |     --------- similarly named tuple variant `XEmpty5` defined here
+   |     ---------- similarly named tuple variant `XEmpty5` defined here
    |
 help: use struct pattern syntax instead
    |

--- a/src/test/ui/empty/empty-struct-tuple-pat.stderr
+++ b/src/test/ui/empty/empty-struct-tuple-pat.stderr
@@ -34,9 +34,9 @@ LL |         XE::XEmpty5 => (),
   ::: $DIR/auxiliary/empty-struct.rs:7:5
    |
 LL |     XEmpty4,
-   |     ------- similarly named unit variant `XEmpty4` defined here
+   |     -------- similarly named unit variant `XEmpty4` defined here
 LL |     XEmpty5(),
-   |     --------- `XE::XEmpty5` defined here
+   |     ---------- `XE::XEmpty5` defined here
    |
 help: use the tuple variant pattern syntax instead
    |

--- a/src/test/ui/empty/empty-struct-unit-pat.stderr
+++ b/src/test/ui/empty/empty-struct-unit-pat.stderr
@@ -59,7 +59,7 @@ LL |         XE::XEmpty4() => (),
   ::: $DIR/auxiliary/empty-struct.rs:8:5
    |
 LL |     XEmpty5(),
-   |     --------- similarly named tuple variant `XEmpty5` defined here
+   |     ---------- similarly named tuple variant `XEmpty5` defined here
 
 error[E0532]: expected tuple struct or tuple variant, found unit variant `E::Empty4`
   --> $DIR/empty-struct-unit-pat.rs:46:9
@@ -78,7 +78,7 @@ LL |         XE::XEmpty4(..) => (),
   ::: $DIR/auxiliary/empty-struct.rs:8:5
    |
 LL |     XEmpty5(),
-   |     --------- similarly named tuple variant `XEmpty5` defined here
+   |     ---------- similarly named tuple variant `XEmpty5` defined here
 
 error: aborting due to 8 previous errors
 

--- a/src/test/ui/enum-discriminant/feature-gate-arbitrary_enum_discriminant.stderr
+++ b/src/test/ui/enum-discriminant/feature-gate-arbitrary_enum_discriminant.stderr
@@ -23,10 +23,10 @@ LL |   Unit = 1,
    |          ^ disallowed custom discriminant
 LL |
 LL |   Tuple() = 2,
-   |   ----------- tuple variant defined here
+   |   ------------ tuple variant defined here
 LL |
 LL |   Struct{} = 3,
-   |   ------------ struct variant defined here
+   |   ------------- struct variant defined here
    |
    = note: see issue #60553 <https://github.com/rust-lang/rust/issues/60553> for more information
    = help: add `#![feature(arbitrary_enum_discriminant)]` to the crate attributes to enable

--- a/src/test/ui/enum/enum-size-variance.stderr
+++ b/src/test/ui/enum/enum-size-variance.stderr
@@ -2,7 +2,7 @@ warning: enum variant is more than three times larger (32 bytes) than the next l
   --> $DIR/enum-size-variance.rs:18:5
    |
 LL |     L(i64, i64, i64, i64),
-   |     ^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^
    |
 note: the lint level is defined here
   --> $DIR/enum-size-variance.rs:3:9

--- a/src/test/ui/error-codes/E0023.stderr
+++ b/src/test/ui/error-codes/E0023.stderr
@@ -2,7 +2,7 @@ error[E0023]: this pattern has 1 field, but the corresponding tuple variant has 
   --> $DIR/E0023.rs:11:9
    |
 LL |     Apple(String, String),
-   |     --------------------- tuple variant defined here
+   |     ---------------------- tuple variant defined here
 ...
 LL |         Fruit::Apple(a) => {},
    |         ^^^^^^^^^^^^^^^ expected 2 fields, found 1
@@ -11,7 +11,7 @@ error[E0023]: this pattern has 3 fields, but the corresponding tuple variant has
   --> $DIR/E0023.rs:12:9
    |
 LL |     Apple(String, String),
-   |     --------------------- tuple variant defined here
+   |     ---------------------- tuple variant defined here
 ...
 LL |         Fruit::Apple(a, b, c) => {},
    |         ^^^^^^^^^^^^^^^^^^^^^ expected 2 fields, found 3
@@ -20,7 +20,7 @@ error[E0023]: this pattern has 2 fields, but the corresponding tuple variant has
   --> $DIR/E0023.rs:13:9
    |
 LL |     Pear(u32),
-   |     --------- tuple variant defined here
+   |     ---------- tuple variant defined here
 ...
 LL |         Fruit::Pear(1, 2) => {},
    |         ^^^^^^^^^^^^^^^^^ expected 1 field, found 2
@@ -29,7 +29,7 @@ error[E0023]: this pattern has 2 fields, but the corresponding tuple variant has
   --> $DIR/E0023.rs:14:9
    |
 LL |     Orange((String, String)),
-   |     ------------------------ tuple variant defined here
+   |     ------------------------- tuple variant defined here
 ...
 LL |         Fruit::Orange(a, b) => {},
    |         ^^^^^^^^^^^^^^^^^^^ expected 1 field, found 2
@@ -43,7 +43,7 @@ error[E0023]: this pattern has 0 fields, but the corresponding tuple variant has
   --> $DIR/E0023.rs:15:9
    |
 LL |     Banana(()),
-   |     ---------- tuple variant defined here
+   |     ----------- tuple variant defined here
 ...
 LL |         Fruit::Banana() => {},
    |         ^^^^^^^^^^^^^^^ expected 1 field, found 0

--- a/src/test/ui/error-codes/E0124.stderr
+++ b/src/test/ui/error-codes/E0124.stderr
@@ -2,9 +2,9 @@ error[E0124]: field `field1` is already declared
   --> $DIR/E0124.rs:3:5
    |
 LL |     field1: i32,
-   |     ----------- `field1` first declared here
+   |     ------------ `field1` first declared here
 LL |     field1: i32,
-   |     ^^^^^^^^^^^ field already declared
+   |     ^^^^^^^^^^^^ field already declared
 
 error: aborting due to previous error
 

--- a/src/test/ui/error-codes/E0370.stderr
+++ b/src/test/ui/error-codes/E0370.stderr
@@ -2,7 +2,7 @@ error[E0370]: enum discriminant overflowed
   --> $DIR/E0370.rs:7:5
    |
 LL |     Y,
-   |     ^ overflowed on value after 9223372036854775807
+   |     ^^ overflowed on value after 9223372036854775807
    |
    = note: explicitly set `Y = -9223372036854775808` if that is desired outcome
 

--- a/src/test/ui/error-codes/E0618.stderr
+++ b/src/test/ui/error-codes/E0618.stderr
@@ -2,7 +2,7 @@ error[E0618]: expected function, found enum variant `X::Entry`
   --> $DIR/E0618.rs:6:5
    |
 LL |     Entry,
-   |     ----- `X::Entry` defined here
+   |     ------ `X::Entry` defined here
 ...
 LL |     X::Entry();
    |     ^^^^^^^^--

--- a/src/test/ui/extern-flag/public-and-private.stderr
+++ b/src/test/ui/extern-flag/public-and-private.stderr
@@ -2,7 +2,7 @@ error: type `S` from private dependency 'somedep' in public interface
   --> $DIR/public-and-private.rs:10:5
    |
 LL |     pub field: somedep::S,
-   |     ^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^
    |
 note: the lint level is defined here
   --> $DIR/public-and-private.rs:5:9

--- a/src/test/ui/feature-gates/feature-gate-untagged_unions.stderr
+++ b/src/test/ui/feature-gates/feature-gate-untagged_unions.stderr
@@ -35,25 +35,25 @@ error[E0740]: unions may not contain fields that need dropping
   --> $DIR/feature-gate-untagged_unions.rs:10:5
    |
 LL |     a: String,
-   |     ^^^^^^^^^
+   |     ^^^^^^^^^^
    |
 note: `std::mem::ManuallyDrop` can be used to wrap the type
   --> $DIR/feature-gate-untagged_unions.rs:10:5
    |
 LL |     a: String,
-   |     ^^^^^^^^^
+   |     ^^^^^^^^^^
 
 error[E0740]: unions may not contain fields that need dropping
   --> $DIR/feature-gate-untagged_unions.rs:14:5
    |
 LL |     a: T,
-   |     ^^^^
+   |     ^^^^^
    |
 note: `std::mem::ManuallyDrop` can be used to wrap the type
   --> $DIR/feature-gate-untagged_unions.rs:14:5
    |
 LL |     a: T,
-   |     ^^^^
+   |     ^^^^^
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/hygiene/fields-definition.stderr
+++ b/src/test/ui/hygiene/fields-definition.stderr
@@ -2,9 +2,9 @@ error[E0124]: field `a` is already declared
   --> $DIR/fields-definition.rs:14:13
    |
 LL |             a: u8,
-   |             ----- `a` first declared here
+   |             ------ `a` first declared here
 LL |             $a: u8,
-   |             ^^^^^^ field already declared
+   |             ^^^^^^^ field already declared
 ...
 LL | legacy!(a);
    | ----------- in this macro invocation

--- a/src/test/ui/issues/issue-15524.stderr
+++ b/src/test/ui/issues/issue-15524.stderr
@@ -13,7 +13,7 @@ LL |     A = 1,
    |         - first use of `1`
 ...
 LL |     D,
-   |     ^ enum already has `1`
+   |     ^^ enum already has `1`
 
 error[E0081]: discriminant value `1` already exists
   --> $DIR/issue-15524.rs:11:9

--- a/src/test/ui/issues/issue-32004.stderr
+++ b/src/test/ui/issues/issue-32004.stderr
@@ -2,7 +2,7 @@ error[E0532]: expected unit struct, unit variant or constant, found tuple varian
   --> $DIR/issue-32004.rs:10:9
    |
 LL |     Bar(i32),
-   |     -------- `Foo::Bar` defined here
+   |     --------- `Foo::Bar` defined here
 LL |     Baz
    |     --- similarly named unit variant `Baz` defined here
 ...

--- a/src/test/ui/issues/issue-47706.stderr
+++ b/src/test/ui/issues/issue-47706.stderr
@@ -11,7 +11,7 @@ error[E0593]: function is expected to take 0 arguments, but it takes 1 argument
   --> $DIR/issue-47706.rs:27:9
    |
 LL |     Bar(i32),
-   |     -------- takes 1 argument
+   |     --------- takes 1 argument
 ...
 LL | fn foo<F>(f: F)
    |    --- required by a bound in this

--- a/src/test/ui/issues/issue-50480.stderr
+++ b/src/test/ui/issues/issue-50480.stderr
@@ -14,7 +14,7 @@ error[E0277]: `i32` is not an iterator
   --> $DIR/issue-50480.rs:3:24
    |
 LL | struct Foo(NotDefined, <i32 as Iterator>::Item, Vec<i32>, String);
-   |                        ^^^^^^^^^^^^^^^^^^^^^^^ `i32` is not an iterator
+   |                        ^^^^^^^^^^^^^^^^^^^^^^^^ `i32` is not an iterator
    |
    = help: the trait `Iterator` is not implemented for `i32`
    = note: if you want to iterate between `start` until a value `end`, use the exclusive range syntax `start..end` or the inclusive range syntax `start..=end`
@@ -26,7 +26,7 @@ LL | #[derive(Clone, Copy)]
    |                 ^^^^
 LL |
 LL | struct Foo(NotDefined, <i32 as Iterator>::Item, Vec<i32>, String);
-   |                                                 --------  ------ this field does not implement `Copy`
+   |                                                 --------- ------ this field does not implement `Copy`
    |                                                 |
    |                                                 this field does not implement `Copy`
    |

--- a/src/test/ui/issues/issue-5100.stderr
+++ b/src/test/ui/issues/issue-5100.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/issue-5100.rs:8:9
    |
 LL | enum A { B, C }
-   |          - unit variant defined here
+   |          -- unit variant defined here
 ...
 LL |     match (true, false) {
    |           ------------- this expression has type `(bool, bool)`

--- a/src/test/ui/issues/issue-63983.stderr
+++ b/src/test/ui/issues/issue-63983.stderr
@@ -2,7 +2,7 @@ error[E0532]: expected unit struct, unit variant or constant, found tuple varian
   --> $DIR/issue-63983.rs:8:9
    |
 LL |     Tuple(i32),
-   |     ---------- `MyEnum::Tuple` defined here
+   |     ----------- `MyEnum::Tuple` defined here
 ...
 LL |         MyEnum::Tuple => "",
    |         ^^^^^^^^^^^^^ help: use the tuple variant pattern syntax instead: `MyEnum::Tuple(_)`
@@ -11,7 +11,7 @@ error[E0532]: expected unit struct, unit variant or constant, found struct varia
   --> $DIR/issue-63983.rs:10:9
    |
 LL |     Struct{ s: i32 },
-   |     ---------------- `MyEnum::Struct` defined here
+   |     ----------------- `MyEnum::Struct` defined here
 ...
 LL |         MyEnum::Struct => "",
    |         ^^^^^^^^^^^^^^ help: use struct pattern syntax instead: `MyEnum::Struct { s }`

--- a/src/test/ui/issues/issue-7867.stderr
+++ b/src/test/ui/issues/issue-7867.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/issue-7867.rs:7:9
    |
 LL | enum A { B, C }
-   |          - unit variant defined here
+   |          -- unit variant defined here
 ...
 LL |     match (true, false) {
    |           ------------- this expression has type `(bool, bool)`

--- a/src/test/ui/lint/dead-code/lint-dead-code-4.stderr
+++ b/src/test/ui/lint/dead-code/lint-dead-code-4.stderr
@@ -2,7 +2,7 @@ error: field is never read: `b`
   --> $DIR/lint-dead-code-4.rs:7:5
    |
 LL |     b: bool,
-   |     ^^^^^^^
+   |     ^^^^^^^^
    |
 note: the lint level is defined here
   --> $DIR/lint-dead-code-4.rs:3:9
@@ -14,7 +14,7 @@ error: variant is never constructed: `X`
   --> $DIR/lint-dead-code-4.rs:15:5
    |
 LL |     X,
-   |     ^
+   |     ^^
 
 error: variant is never constructed: `Y`
   --> $DIR/lint-dead-code-4.rs:16:5
@@ -24,7 +24,7 @@ LL | |         a: String,
 LL | |         b: i32,
 LL | |         c: i32,
 LL | |     },
-   | |_____^
+   | |______^
 
 error: enum is never used: `ABC`
   --> $DIR/lint-dead-code-4.rs:24:6
@@ -36,19 +36,19 @@ error: variant is never constructed: `I`
   --> $DIR/lint-dead-code-4.rs:36:5
    |
 LL |     I,
-   |     ^
+   |     ^^
 
 error: field is never read: `b`
   --> $DIR/lint-dead-code-4.rs:39:9
    |
 LL |         b: i32,
-   |         ^^^^^^
+   |         ^^^^^^^
 
 error: field is never read: `c`
   --> $DIR/lint-dead-code-4.rs:40:9
    |
 LL |         c: i32,
-   |         ^^^^^^
+   |         ^^^^^^^
 
 error: variant is never constructed: `K`
   --> $DIR/lint-dead-code-4.rs:42:5
@@ -60,13 +60,13 @@ error: field is never read: `x`
   --> $DIR/lint-dead-code-4.rs:61:5
    |
 LL |     x: usize,
-   |     ^^^^^^^^
+   |     ^^^^^^^^^
 
 error: field is never read: `c`
   --> $DIR/lint-dead-code-4.rs:63:5
    |
 LL |     c: bool,
-   |     ^^^^^^^
+   |     ^^^^^^^^
 
 error: aborting due to 10 previous errors
 

--- a/src/test/ui/lint/dead-code/lint-dead-code-5.stderr
+++ b/src/test/ui/lint/dead-code/lint-dead-code-5.stderr
@@ -14,13 +14,13 @@ error: variant is never constructed: `Variant5`
   --> $DIR/lint-dead-code-5.rs:13:5
    |
 LL |     Variant5 { _x: isize },
-   |     ^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: variant is never constructed: `Variant6`
   --> $DIR/lint-dead-code-5.rs:14:5
    |
 LL |     Variant6(isize),
-   |     ^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^
 
 error: enum is never used: `Enum3`
   --> $DIR/lint-dead-code-5.rs:35:6

--- a/src/test/ui/lint/dead-code/unused-struct-variant.stderr
+++ b/src/test/ui/lint/dead-code/unused-struct-variant.stderr
@@ -2,7 +2,7 @@ error: variant is never constructed: `Bar`
   --> $DIR/unused-struct-variant.rs:8:5
    |
 LL |     Bar(B),
-   |     ^^^^^^
+   |     ^^^^^^^
    |
 note: the lint level is defined here
   --> $DIR/unused-struct-variant.rs:1:9

--- a/src/test/ui/lint/dead-code/unused-variant.stderr
+++ b/src/test/ui/lint/dead-code/unused-variant.stderr
@@ -2,7 +2,7 @@ error: variant is never constructed: `Variant1`
   --> $DIR/unused-variant.rs:5:5
    |
 LL |     Variant1,
-   |     ^^^^^^^^
+   |     ^^^^^^^^^
    |
 note: the lint level is defined here
   --> $DIR/unused-variant.rs:1:9

--- a/src/test/ui/lint/lint-missing-doc.stderr
+++ b/src/test/ui/lint/lint-missing-doc.stderr
@@ -20,7 +20,7 @@ error: missing documentation for a struct field
   --> $DIR/lint-missing-doc.rs:19:5
    |
 LL |     pub a: isize,
-   |     ^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^
 
 error: missing documentation for a module
   --> $DIR/lint-missing-doc.rs:30:1
@@ -86,7 +86,7 @@ error: missing documentation for a struct field
   --> $DIR/lint-missing-doc.rs:120:9
    |
 LL |         a: isize,
-   |         ^^^^^^^^
+   |         ^^^^^^^^^
 
 error: missing documentation for a constant
   --> $DIR/lint-missing-doc.rs:151:1

--- a/src/test/ui/lint/unreachable_pub-pub_crate.stderr
+++ b/src/test/ui/lint/unreachable_pub-pub_crate.stderr
@@ -37,7 +37,7 @@ warning: unreachable `pub` field
   --> $DIR/unreachable_pub-pub_crate.rs:20:9
    |
 LL |         pub neutrons: usize,
-   |         ---^^^^^^^^^^^^^^^^
+   |         ---^^^^^^^^^^^^^^^^^
    |         |
    |         help: consider restricting its visibility: `pub(crate)`
 

--- a/src/test/ui/lint/unreachable_pub.stderr
+++ b/src/test/ui/lint/unreachable_pub.stderr
@@ -37,7 +37,7 @@ warning: unreachable `pub` field
   --> $DIR/unreachable_pub.rs:16:9
    |
 LL |         pub neutrons: usize,
-   |         ---^^^^^^^^^^^^^^^^
+   |         ---^^^^^^^^^^^^^^^^^
    |         |
    |         help: consider restricting its visibility: `crate`
 

--- a/src/test/ui/malformed/issue-69341-malformed-derive-inert.stderr
+++ b/src/test/ui/malformed/issue-69341-malformed-derive-inert.stderr
@@ -8,7 +8,7 @@ error[E0774]: `derive` may only be applied to structs, enums and unions
   --> $DIR/issue-69341-malformed-derive-inert.rs:8:5
    |
 LL |     path: (),
-   |     ^^^^^^^^
+   |     ^^^^^^^^^
 
 error: cannot find derive macro `parse` in this scope
   --> $DIR/issue-69341-malformed-derive-inert.rs:4:14

--- a/src/test/ui/match/match-pattern-field-mismatch.stderr
+++ b/src/test/ui/match/match-pattern-field-mismatch.stderr
@@ -2,7 +2,7 @@ error[E0023]: this pattern has 2 fields, but the corresponding tuple variant has
   --> $DIR/match-pattern-field-mismatch.rs:10:11
    |
 LL |         Rgb(usize, usize, usize),
-   |         ------------------------ tuple variant defined here
+   |         ------------------------- tuple variant defined here
 ...
 LL |           Color::Rgb(_, _) => { }
    |           ^^^^^^^^^^^^^^^^ expected 3 fields, found 2

--- a/src/test/ui/namespace/namespace-mix.stderr
+++ b/src/test/ui/namespace/namespace-mix.stderr
@@ -46,9 +46,9 @@ error[E0423]: expected value, found struct variant `m7::V`
   --> $DIR/namespace-mix.rs:100:11
    |
 LL |         V {},
-   |         ---- `m7::V` defined here
+   |         ----- `m7::V` defined here
 LL |         TV(),
-   |         ---- similarly named tuple variant `TV` defined here
+   |         ----- similarly named tuple variant `TV` defined here
 ...
 LL |     check(m7::V);
    |           ^^^^^
@@ -79,7 +79,7 @@ LL |     check(xm7::V);
 LL |         V {},
    |         - `xm7::V` defined here
 LL |         TV(),
-   |         ---- similarly named tuple variant `TV` defined here
+   |         ----- similarly named tuple variant `TV` defined here
    |
 help: use struct literal syntax instead
    |

--- a/src/test/ui/opt-in-copy.stderr
+++ b/src/test/ui/opt-in-copy.stderr
@@ -2,7 +2,7 @@ error[E0204]: the trait `Copy` may not be implemented for this type
   --> $DIR/opt-in-copy.rs:7:6
    |
 LL |     but_i_cant: CantCopyThis,
-   |     ------------------------ this field does not implement `Copy`
+   |     ------------------------- this field does not implement `Copy`
 ...
 LL | impl Copy for IWantToCopyThis {}
    |      ^^^^

--- a/src/test/ui/parser/recover-from-bad-variant.stderr
+++ b/src/test/ui/parser/recover-from-bad-variant.stderr
@@ -13,7 +13,7 @@ error[E0532]: expected tuple struct or tuple variant, found struct variant `Enum
   --> $DIR/recover-from-bad-variant.rs:10:9
    |
 LL |     Foo { a: usize, b: usize },
-   |     -------------------------- `Enum::Foo` defined here
+   |     --------------------------- `Enum::Foo` defined here
 ...
 LL |         Enum::Foo(a, b) => {}
    |         ^^^^^^^^^^^^^^^ help: use struct pattern syntax instead: `Enum::Foo { a, b }`

--- a/src/test/ui/parser/tag-variant-disr-non-nullary.stderr
+++ b/src/test/ui/parser/tag-variant-disr-non-nullary.stderr
@@ -13,9 +13,9 @@ LL |     Black = 0x000000,
 LL |     White = 0xffffff,
    |             ^^^^^^^^ disallowed custom discriminant
 LL |     Other(usize),
-   |     ------------ tuple variant defined here
+   |     ------------- tuple variant defined here
 LL |     Other2(usize, usize),
-   |     -------------------- tuple variant defined here
+   |     --------------------- tuple variant defined here
    |
    = note: see issue #60553 <https://github.com/rust-lang/rust/issues/60553> for more information
    = help: add `#![feature(arbitrary_enum_discriminant)]` to the crate attributes to enable

--- a/src/test/ui/pattern/issue-74539.stderr
+++ b/src/test/ui/pattern/issue-74539.stderr
@@ -22,7 +22,7 @@ error[E0023]: this pattern has 1 field, but the corresponding tuple variant has 
   --> $DIR/issue-74539.rs:8:9
    |
 LL |     A(u8, u8),
-   |     --------- tuple variant defined here
+   |     ---------- tuple variant defined here
 ...
 LL |         E::A(x @ ..) => {
    |         ^^^^^^^^^^^^ expected 2 fields, found 1

--- a/src/test/ui/pattern/pattern-error-continue.stderr
+++ b/src/test/ui/pattern/pattern-error-continue.stderr
@@ -8,7 +8,7 @@ error[E0532]: expected tuple struct or tuple variant, found unit variant `A::D`
   --> $DIR/pattern-error-continue.rs:18:9
    |
 LL |     B(isize, isize),
-   |     --------------- similarly named tuple variant `B` defined here
+   |     ---------------- similarly named tuple variant `B` defined here
 ...
 LL |         A::D(_) => (),
    |         ^^^-
@@ -19,7 +19,7 @@ error[E0023]: this pattern has 3 fields, but the corresponding tuple variant has
   --> $DIR/pattern-error-continue.rs:17:9
    |
 LL |     B(isize, isize),
-   |     --------------- tuple variant defined here
+   |     ---------------- tuple variant defined here
 ...
 LL |         A::B(_, _, _) => (),
    |         ^^^^^^^^^^^^^ expected 2 fields, found 3

--- a/src/test/ui/privacy/pub-priv-dep/pub-priv1.stderr
+++ b/src/test/ui/privacy/pub-priv-dep/pub-priv1.stderr
@@ -2,7 +2,7 @@ error: type `OtherType` from private dependency 'priv_dep' in public interface
   --> $DIR/pub-priv1.rs:20:5
    |
 LL |     pub field: OtherType,
-   |     ^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^
    |
 note: the lint level is defined here
   --> $DIR/pub-priv1.rs:3:9

--- a/src/test/ui/proc-macro/parent-source-spans.stderr
+++ b/src/test/ui/proc-macro/parent-source-spans.stderr
@@ -148,7 +148,7 @@ LL |     one!("hello", "world");
   ::: $SRC_DIR/core/src/result.rs:LL:COL
    |
 LL |     Ok(#[stable(feature = "rust1", since = "1.0.0")] T),
-   |     --------------------------------------------------- similarly named tuple variant `Ok` defined here
+   |     ---------------------------------------------------- similarly named tuple variant `Ok` defined here
    |
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -164,7 +164,7 @@ LL |     two!("yay", "rust");
   ::: $SRC_DIR/core/src/result.rs:LL:COL
    |
 LL |     Ok(#[stable(feature = "rust1", since = "1.0.0")] T),
-   |     --------------------------------------------------- similarly named tuple variant `Ok` defined here
+   |     ---------------------------------------------------- similarly named tuple variant `Ok` defined here
    |
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -180,7 +180,7 @@ LL |     three!("hip", "hop");
   ::: $SRC_DIR/core/src/result.rs:LL:COL
    |
 LL |     Ok(#[stable(feature = "rust1", since = "1.0.0")] T),
-   |     --------------------------------------------------- similarly named tuple variant `Ok` defined here
+   |     ---------------------------------------------------- similarly named tuple variant `Ok` defined here
    |
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/range/range_traits-1.stderr
+++ b/src/test/ui/range/range_traits-1.stderr
@@ -2,7 +2,7 @@ error[E0277]: can't compare `std::ops::Range<usize>` with `std::ops::Range<usize
   --> $DIR/range_traits-1.rs:5:5
    |
 LL |     a: Range<usize>,
-   |     ^^^^^^^^^^^^^^^ no implementation for `std::ops::Range<usize> < std::ops::Range<usize>` and `std::ops::Range<usize> > std::ops::Range<usize>`
+   |     ^^^^^^^^^^^^^^^^ no implementation for `std::ops::Range<usize> < std::ops::Range<usize>` and `std::ops::Range<usize> > std::ops::Range<usize>`
    |
    = help: the trait `PartialOrd` is not implemented for `std::ops::Range<usize>`
    = note: required by `std::cmp::PartialOrd::partial_cmp`
@@ -12,7 +12,7 @@ error[E0277]: can't compare `std::ops::RangeTo<usize>` with `std::ops::RangeTo<u
   --> $DIR/range_traits-1.rs:12:5
    |
 LL |     b: RangeTo<usize>,
-   |     ^^^^^^^^^^^^^^^^^ no implementation for `std::ops::RangeTo<usize> < std::ops::RangeTo<usize>` and `std::ops::RangeTo<usize> > std::ops::RangeTo<usize>`
+   |     ^^^^^^^^^^^^^^^^^^ no implementation for `std::ops::RangeTo<usize> < std::ops::RangeTo<usize>` and `std::ops::RangeTo<usize> > std::ops::RangeTo<usize>`
    |
    = help: the trait `PartialOrd` is not implemented for `std::ops::RangeTo<usize>`
    = note: required by `std::cmp::PartialOrd::partial_cmp`
@@ -22,7 +22,7 @@ error[E0277]: can't compare `std::ops::RangeFrom<usize>` with `std::ops::RangeFr
   --> $DIR/range_traits-1.rs:19:5
    |
 LL |     c: RangeFrom<usize>,
-   |     ^^^^^^^^^^^^^^^^^^^ no implementation for `std::ops::RangeFrom<usize> < std::ops::RangeFrom<usize>` and `std::ops::RangeFrom<usize> > std::ops::RangeFrom<usize>`
+   |     ^^^^^^^^^^^^^^^^^^^^ no implementation for `std::ops::RangeFrom<usize> < std::ops::RangeFrom<usize>` and `std::ops::RangeFrom<usize> > std::ops::RangeFrom<usize>`
    |
    = help: the trait `PartialOrd` is not implemented for `std::ops::RangeFrom<usize>`
    = note: required by `std::cmp::PartialOrd::partial_cmp`
@@ -32,7 +32,7 @@ error[E0277]: can't compare `std::ops::RangeFull` with `std::ops::RangeFull`
   --> $DIR/range_traits-1.rs:26:5
    |
 LL |     d: RangeFull,
-   |     ^^^^^^^^^^^^ no implementation for `std::ops::RangeFull < std::ops::RangeFull` and `std::ops::RangeFull > std::ops::RangeFull`
+   |     ^^^^^^^^^^^^^ no implementation for `std::ops::RangeFull < std::ops::RangeFull` and `std::ops::RangeFull > std::ops::RangeFull`
    |
    = help: the trait `PartialOrd` is not implemented for `std::ops::RangeFull`
    = note: required by `std::cmp::PartialOrd::partial_cmp`
@@ -42,7 +42,7 @@ error[E0277]: can't compare `std::ops::RangeInclusive<usize>` with `std::ops::Ra
   --> $DIR/range_traits-1.rs:33:5
    |
 LL |     e: RangeInclusive<usize>,
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^ no implementation for `std::ops::RangeInclusive<usize> < std::ops::RangeInclusive<usize>` and `std::ops::RangeInclusive<usize> > std::ops::RangeInclusive<usize>`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ no implementation for `std::ops::RangeInclusive<usize> < std::ops::RangeInclusive<usize>` and `std::ops::RangeInclusive<usize> > std::ops::RangeInclusive<usize>`
    |
    = help: the trait `PartialOrd` is not implemented for `std::ops::RangeInclusive<usize>`
    = note: required by `std::cmp::PartialOrd::partial_cmp`
@@ -52,7 +52,7 @@ error[E0277]: can't compare `std::ops::RangeToInclusive<usize>` with `std::ops::
   --> $DIR/range_traits-1.rs:40:5
    |
 LL |     f: RangeToInclusive<usize>,
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ no implementation for `std::ops::RangeToInclusive<usize> < std::ops::RangeToInclusive<usize>` and `std::ops::RangeToInclusive<usize> > std::ops::RangeToInclusive<usize>`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ no implementation for `std::ops::RangeToInclusive<usize> < std::ops::RangeToInclusive<usize>` and `std::ops::RangeToInclusive<usize> > std::ops::RangeToInclusive<usize>`
    |
    = help: the trait `PartialOrd` is not implemented for `std::ops::RangeToInclusive<usize>`
    = note: required by `std::cmp::PartialOrd::partial_cmp`
@@ -62,7 +62,7 @@ error[E0277]: can't compare `std::ops::Range<usize>` with `std::ops::Range<usize
   --> $DIR/range_traits-1.rs:5:5
    |
 LL |     a: Range<usize>,
-   |     ^^^^^^^^^^^^^^^ no implementation for `std::ops::Range<usize> < std::ops::Range<usize>` and `std::ops::Range<usize> > std::ops::Range<usize>`
+   |     ^^^^^^^^^^^^^^^^ no implementation for `std::ops::Range<usize> < std::ops::Range<usize>` and `std::ops::Range<usize> > std::ops::Range<usize>`
    |
    = help: the trait `PartialOrd` is not implemented for `std::ops::Range<usize>`
    = note: required by `std::cmp::PartialOrd::partial_cmp`
@@ -72,7 +72,7 @@ error[E0277]: can't compare `std::ops::RangeTo<usize>` with `std::ops::RangeTo<u
   --> $DIR/range_traits-1.rs:12:5
    |
 LL |     b: RangeTo<usize>,
-   |     ^^^^^^^^^^^^^^^^^ no implementation for `std::ops::RangeTo<usize> < std::ops::RangeTo<usize>` and `std::ops::RangeTo<usize> > std::ops::RangeTo<usize>`
+   |     ^^^^^^^^^^^^^^^^^^ no implementation for `std::ops::RangeTo<usize> < std::ops::RangeTo<usize>` and `std::ops::RangeTo<usize> > std::ops::RangeTo<usize>`
    |
    = help: the trait `PartialOrd` is not implemented for `std::ops::RangeTo<usize>`
    = note: required by `std::cmp::PartialOrd::partial_cmp`
@@ -82,7 +82,7 @@ error[E0277]: can't compare `std::ops::RangeFrom<usize>` with `std::ops::RangeFr
   --> $DIR/range_traits-1.rs:19:5
    |
 LL |     c: RangeFrom<usize>,
-   |     ^^^^^^^^^^^^^^^^^^^ no implementation for `std::ops::RangeFrom<usize> < std::ops::RangeFrom<usize>` and `std::ops::RangeFrom<usize> > std::ops::RangeFrom<usize>`
+   |     ^^^^^^^^^^^^^^^^^^^^ no implementation for `std::ops::RangeFrom<usize> < std::ops::RangeFrom<usize>` and `std::ops::RangeFrom<usize> > std::ops::RangeFrom<usize>`
    |
    = help: the trait `PartialOrd` is not implemented for `std::ops::RangeFrom<usize>`
    = note: required by `std::cmp::PartialOrd::partial_cmp`
@@ -92,7 +92,7 @@ error[E0277]: can't compare `std::ops::RangeFull` with `std::ops::RangeFull`
   --> $DIR/range_traits-1.rs:26:5
    |
 LL |     d: RangeFull,
-   |     ^^^^^^^^^^^^ no implementation for `std::ops::RangeFull < std::ops::RangeFull` and `std::ops::RangeFull > std::ops::RangeFull`
+   |     ^^^^^^^^^^^^^ no implementation for `std::ops::RangeFull < std::ops::RangeFull` and `std::ops::RangeFull > std::ops::RangeFull`
    |
    = help: the trait `PartialOrd` is not implemented for `std::ops::RangeFull`
    = note: required by `std::cmp::PartialOrd::partial_cmp`
@@ -102,7 +102,7 @@ error[E0277]: can't compare `std::ops::RangeInclusive<usize>` with `std::ops::Ra
   --> $DIR/range_traits-1.rs:33:5
    |
 LL |     e: RangeInclusive<usize>,
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^ no implementation for `std::ops::RangeInclusive<usize> < std::ops::RangeInclusive<usize>` and `std::ops::RangeInclusive<usize> > std::ops::RangeInclusive<usize>`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ no implementation for `std::ops::RangeInclusive<usize> < std::ops::RangeInclusive<usize>` and `std::ops::RangeInclusive<usize> > std::ops::RangeInclusive<usize>`
    |
    = help: the trait `PartialOrd` is not implemented for `std::ops::RangeInclusive<usize>`
    = note: required by `std::cmp::PartialOrd::partial_cmp`
@@ -112,7 +112,7 @@ error[E0277]: can't compare `std::ops::RangeToInclusive<usize>` with `std::ops::
   --> $DIR/range_traits-1.rs:40:5
    |
 LL |     f: RangeToInclusive<usize>,
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ no implementation for `std::ops::RangeToInclusive<usize> < std::ops::RangeToInclusive<usize>` and `std::ops::RangeToInclusive<usize> > std::ops::RangeToInclusive<usize>`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ no implementation for `std::ops::RangeToInclusive<usize> < std::ops::RangeToInclusive<usize>` and `std::ops::RangeToInclusive<usize> > std::ops::RangeToInclusive<usize>`
    |
    = help: the trait `PartialOrd` is not implemented for `std::ops::RangeToInclusive<usize>`
    = note: required by `std::cmp::PartialOrd::partial_cmp`
@@ -122,7 +122,7 @@ error[E0277]: can't compare `std::ops::Range<usize>` with `std::ops::Range<usize
   --> $DIR/range_traits-1.rs:5:5
    |
 LL |     a: Range<usize>,
-   |     ^^^^^^^^^^^^^^^ no implementation for `std::ops::Range<usize> < std::ops::Range<usize>` and `std::ops::Range<usize> > std::ops::Range<usize>`
+   |     ^^^^^^^^^^^^^^^^ no implementation for `std::ops::Range<usize> < std::ops::Range<usize>` and `std::ops::Range<usize> > std::ops::Range<usize>`
    |
    = help: the trait `PartialOrd` is not implemented for `std::ops::Range<usize>`
    = note: required by `std::cmp::PartialOrd::partial_cmp`
@@ -132,7 +132,7 @@ error[E0277]: can't compare `std::ops::RangeTo<usize>` with `std::ops::RangeTo<u
   --> $DIR/range_traits-1.rs:12:5
    |
 LL |     b: RangeTo<usize>,
-   |     ^^^^^^^^^^^^^^^^^ no implementation for `std::ops::RangeTo<usize> < std::ops::RangeTo<usize>` and `std::ops::RangeTo<usize> > std::ops::RangeTo<usize>`
+   |     ^^^^^^^^^^^^^^^^^^ no implementation for `std::ops::RangeTo<usize> < std::ops::RangeTo<usize>` and `std::ops::RangeTo<usize> > std::ops::RangeTo<usize>`
    |
    = help: the trait `PartialOrd` is not implemented for `std::ops::RangeTo<usize>`
    = note: required by `std::cmp::PartialOrd::partial_cmp`
@@ -142,7 +142,7 @@ error[E0277]: can't compare `std::ops::RangeFrom<usize>` with `std::ops::RangeFr
   --> $DIR/range_traits-1.rs:19:5
    |
 LL |     c: RangeFrom<usize>,
-   |     ^^^^^^^^^^^^^^^^^^^ no implementation for `std::ops::RangeFrom<usize> < std::ops::RangeFrom<usize>` and `std::ops::RangeFrom<usize> > std::ops::RangeFrom<usize>`
+   |     ^^^^^^^^^^^^^^^^^^^^ no implementation for `std::ops::RangeFrom<usize> < std::ops::RangeFrom<usize>` and `std::ops::RangeFrom<usize> > std::ops::RangeFrom<usize>`
    |
    = help: the trait `PartialOrd` is not implemented for `std::ops::RangeFrom<usize>`
    = note: required by `std::cmp::PartialOrd::partial_cmp`
@@ -152,7 +152,7 @@ error[E0277]: can't compare `std::ops::RangeFull` with `std::ops::RangeFull`
   --> $DIR/range_traits-1.rs:26:5
    |
 LL |     d: RangeFull,
-   |     ^^^^^^^^^^^^ no implementation for `std::ops::RangeFull < std::ops::RangeFull` and `std::ops::RangeFull > std::ops::RangeFull`
+   |     ^^^^^^^^^^^^^ no implementation for `std::ops::RangeFull < std::ops::RangeFull` and `std::ops::RangeFull > std::ops::RangeFull`
    |
    = help: the trait `PartialOrd` is not implemented for `std::ops::RangeFull`
    = note: required by `std::cmp::PartialOrd::partial_cmp`
@@ -162,7 +162,7 @@ error[E0277]: can't compare `std::ops::RangeInclusive<usize>` with `std::ops::Ra
   --> $DIR/range_traits-1.rs:33:5
    |
 LL |     e: RangeInclusive<usize>,
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^ no implementation for `std::ops::RangeInclusive<usize> < std::ops::RangeInclusive<usize>` and `std::ops::RangeInclusive<usize> > std::ops::RangeInclusive<usize>`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ no implementation for `std::ops::RangeInclusive<usize> < std::ops::RangeInclusive<usize>` and `std::ops::RangeInclusive<usize> > std::ops::RangeInclusive<usize>`
    |
    = help: the trait `PartialOrd` is not implemented for `std::ops::RangeInclusive<usize>`
    = note: required by `std::cmp::PartialOrd::partial_cmp`
@@ -172,7 +172,7 @@ error[E0277]: can't compare `std::ops::RangeToInclusive<usize>` with `std::ops::
   --> $DIR/range_traits-1.rs:40:5
    |
 LL |     f: RangeToInclusive<usize>,
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ no implementation for `std::ops::RangeToInclusive<usize> < std::ops::RangeToInclusive<usize>` and `std::ops::RangeToInclusive<usize> > std::ops::RangeToInclusive<usize>`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ no implementation for `std::ops::RangeToInclusive<usize> < std::ops::RangeToInclusive<usize>` and `std::ops::RangeToInclusive<usize> > std::ops::RangeToInclusive<usize>`
    |
    = help: the trait `PartialOrd` is not implemented for `std::ops::RangeToInclusive<usize>`
    = note: required by `std::cmp::PartialOrd::partial_cmp`
@@ -182,7 +182,7 @@ error[E0277]: can't compare `std::ops::Range<usize>` with `std::ops::Range<usize
   --> $DIR/range_traits-1.rs:5:5
    |
 LL |     a: Range<usize>,
-   |     ^^^^^^^^^^^^^^^ no implementation for `std::ops::Range<usize> < std::ops::Range<usize>` and `std::ops::Range<usize> > std::ops::Range<usize>`
+   |     ^^^^^^^^^^^^^^^^ no implementation for `std::ops::Range<usize> < std::ops::Range<usize>` and `std::ops::Range<usize> > std::ops::Range<usize>`
    |
    = help: the trait `PartialOrd` is not implemented for `std::ops::Range<usize>`
    = note: required by `std::cmp::PartialOrd::partial_cmp`
@@ -192,7 +192,7 @@ error[E0277]: can't compare `std::ops::RangeTo<usize>` with `std::ops::RangeTo<u
   --> $DIR/range_traits-1.rs:12:5
    |
 LL |     b: RangeTo<usize>,
-   |     ^^^^^^^^^^^^^^^^^ no implementation for `std::ops::RangeTo<usize> < std::ops::RangeTo<usize>` and `std::ops::RangeTo<usize> > std::ops::RangeTo<usize>`
+   |     ^^^^^^^^^^^^^^^^^^ no implementation for `std::ops::RangeTo<usize> < std::ops::RangeTo<usize>` and `std::ops::RangeTo<usize> > std::ops::RangeTo<usize>`
    |
    = help: the trait `PartialOrd` is not implemented for `std::ops::RangeTo<usize>`
    = note: required by `std::cmp::PartialOrd::partial_cmp`
@@ -202,7 +202,7 @@ error[E0277]: can't compare `std::ops::RangeFrom<usize>` with `std::ops::RangeFr
   --> $DIR/range_traits-1.rs:19:5
    |
 LL |     c: RangeFrom<usize>,
-   |     ^^^^^^^^^^^^^^^^^^^ no implementation for `std::ops::RangeFrom<usize> < std::ops::RangeFrom<usize>` and `std::ops::RangeFrom<usize> > std::ops::RangeFrom<usize>`
+   |     ^^^^^^^^^^^^^^^^^^^^ no implementation for `std::ops::RangeFrom<usize> < std::ops::RangeFrom<usize>` and `std::ops::RangeFrom<usize> > std::ops::RangeFrom<usize>`
    |
    = help: the trait `PartialOrd` is not implemented for `std::ops::RangeFrom<usize>`
    = note: required by `std::cmp::PartialOrd::partial_cmp`
@@ -212,7 +212,7 @@ error[E0277]: can't compare `std::ops::RangeFull` with `std::ops::RangeFull`
   --> $DIR/range_traits-1.rs:26:5
    |
 LL |     d: RangeFull,
-   |     ^^^^^^^^^^^^ no implementation for `std::ops::RangeFull < std::ops::RangeFull` and `std::ops::RangeFull > std::ops::RangeFull`
+   |     ^^^^^^^^^^^^^ no implementation for `std::ops::RangeFull < std::ops::RangeFull` and `std::ops::RangeFull > std::ops::RangeFull`
    |
    = help: the trait `PartialOrd` is not implemented for `std::ops::RangeFull`
    = note: required by `std::cmp::PartialOrd::partial_cmp`
@@ -222,7 +222,7 @@ error[E0277]: can't compare `std::ops::RangeInclusive<usize>` with `std::ops::Ra
   --> $DIR/range_traits-1.rs:33:5
    |
 LL |     e: RangeInclusive<usize>,
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^ no implementation for `std::ops::RangeInclusive<usize> < std::ops::RangeInclusive<usize>` and `std::ops::RangeInclusive<usize> > std::ops::RangeInclusive<usize>`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ no implementation for `std::ops::RangeInclusive<usize> < std::ops::RangeInclusive<usize>` and `std::ops::RangeInclusive<usize> > std::ops::RangeInclusive<usize>`
    |
    = help: the trait `PartialOrd` is not implemented for `std::ops::RangeInclusive<usize>`
    = note: required by `std::cmp::PartialOrd::partial_cmp`
@@ -232,7 +232,7 @@ error[E0277]: can't compare `std::ops::RangeToInclusive<usize>` with `std::ops::
   --> $DIR/range_traits-1.rs:40:5
    |
 LL |     f: RangeToInclusive<usize>,
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ no implementation for `std::ops::RangeToInclusive<usize> < std::ops::RangeToInclusive<usize>` and `std::ops::RangeToInclusive<usize> > std::ops::RangeToInclusive<usize>`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ no implementation for `std::ops::RangeToInclusive<usize> < std::ops::RangeToInclusive<usize>` and `std::ops::RangeToInclusive<usize> > std::ops::RangeToInclusive<usize>`
    |
    = help: the trait `PartialOrd` is not implemented for `std::ops::RangeToInclusive<usize>`
    = note: required by `std::cmp::PartialOrd::partial_cmp`
@@ -242,7 +242,7 @@ error[E0277]: can't compare `std::ops::Range<usize>` with `std::ops::Range<usize
   --> $DIR/range_traits-1.rs:5:5
    |
 LL |     a: Range<usize>,
-   |     ^^^^^^^^^^^^^^^ no implementation for `std::ops::Range<usize> < std::ops::Range<usize>` and `std::ops::Range<usize> > std::ops::Range<usize>`
+   |     ^^^^^^^^^^^^^^^^ no implementation for `std::ops::Range<usize> < std::ops::Range<usize>` and `std::ops::Range<usize> > std::ops::Range<usize>`
    |
    = help: the trait `PartialOrd` is not implemented for `std::ops::Range<usize>`
    = note: required by `std::cmp::PartialOrd::partial_cmp`
@@ -252,7 +252,7 @@ error[E0277]: can't compare `std::ops::RangeTo<usize>` with `std::ops::RangeTo<u
   --> $DIR/range_traits-1.rs:12:5
    |
 LL |     b: RangeTo<usize>,
-   |     ^^^^^^^^^^^^^^^^^ no implementation for `std::ops::RangeTo<usize> < std::ops::RangeTo<usize>` and `std::ops::RangeTo<usize> > std::ops::RangeTo<usize>`
+   |     ^^^^^^^^^^^^^^^^^^ no implementation for `std::ops::RangeTo<usize> < std::ops::RangeTo<usize>` and `std::ops::RangeTo<usize> > std::ops::RangeTo<usize>`
    |
    = help: the trait `PartialOrd` is not implemented for `std::ops::RangeTo<usize>`
    = note: required by `std::cmp::PartialOrd::partial_cmp`
@@ -262,7 +262,7 @@ error[E0277]: can't compare `std::ops::RangeFrom<usize>` with `std::ops::RangeFr
   --> $DIR/range_traits-1.rs:19:5
    |
 LL |     c: RangeFrom<usize>,
-   |     ^^^^^^^^^^^^^^^^^^^ no implementation for `std::ops::RangeFrom<usize> < std::ops::RangeFrom<usize>` and `std::ops::RangeFrom<usize> > std::ops::RangeFrom<usize>`
+   |     ^^^^^^^^^^^^^^^^^^^^ no implementation for `std::ops::RangeFrom<usize> < std::ops::RangeFrom<usize>` and `std::ops::RangeFrom<usize> > std::ops::RangeFrom<usize>`
    |
    = help: the trait `PartialOrd` is not implemented for `std::ops::RangeFrom<usize>`
    = note: required by `std::cmp::PartialOrd::partial_cmp`
@@ -272,7 +272,7 @@ error[E0277]: can't compare `std::ops::RangeFull` with `std::ops::RangeFull`
   --> $DIR/range_traits-1.rs:26:5
    |
 LL |     d: RangeFull,
-   |     ^^^^^^^^^^^^ no implementation for `std::ops::RangeFull < std::ops::RangeFull` and `std::ops::RangeFull > std::ops::RangeFull`
+   |     ^^^^^^^^^^^^^ no implementation for `std::ops::RangeFull < std::ops::RangeFull` and `std::ops::RangeFull > std::ops::RangeFull`
    |
    = help: the trait `PartialOrd` is not implemented for `std::ops::RangeFull`
    = note: required by `std::cmp::PartialOrd::partial_cmp`
@@ -282,7 +282,7 @@ error[E0277]: can't compare `std::ops::RangeInclusive<usize>` with `std::ops::Ra
   --> $DIR/range_traits-1.rs:33:5
    |
 LL |     e: RangeInclusive<usize>,
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^ no implementation for `std::ops::RangeInclusive<usize> < std::ops::RangeInclusive<usize>` and `std::ops::RangeInclusive<usize> > std::ops::RangeInclusive<usize>`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ no implementation for `std::ops::RangeInclusive<usize> < std::ops::RangeInclusive<usize>` and `std::ops::RangeInclusive<usize> > std::ops::RangeInclusive<usize>`
    |
    = help: the trait `PartialOrd` is not implemented for `std::ops::RangeInclusive<usize>`
    = note: required by `std::cmp::PartialOrd::partial_cmp`
@@ -292,7 +292,7 @@ error[E0277]: can't compare `std::ops::RangeToInclusive<usize>` with `std::ops::
   --> $DIR/range_traits-1.rs:40:5
    |
 LL |     f: RangeToInclusive<usize>,
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ no implementation for `std::ops::RangeToInclusive<usize> < std::ops::RangeToInclusive<usize>` and `std::ops::RangeToInclusive<usize> > std::ops::RangeToInclusive<usize>`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ no implementation for `std::ops::RangeToInclusive<usize> < std::ops::RangeToInclusive<usize>` and `std::ops::RangeToInclusive<usize> > std::ops::RangeToInclusive<usize>`
    |
    = help: the trait `PartialOrd` is not implemented for `std::ops::RangeToInclusive<usize>`
    = note: required by `std::cmp::PartialOrd::partial_cmp`
@@ -302,7 +302,7 @@ error[E0277]: the trait bound `std::ops::Range<usize>: Ord` is not satisfied
   --> $DIR/range_traits-1.rs:5:5
    |
 LL |     a: Range<usize>,
-   |     ^^^^^^^^^^^^^^^ the trait `Ord` is not implemented for `std::ops::Range<usize>`
+   |     ^^^^^^^^^^^^^^^^ the trait `Ord` is not implemented for `std::ops::Range<usize>`
    |
    = note: required by `std::cmp::Ord::cmp`
    = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -311,7 +311,7 @@ error[E0277]: the trait bound `std::ops::RangeTo<usize>: Ord` is not satisfied
   --> $DIR/range_traits-1.rs:12:5
    |
 LL |     b: RangeTo<usize>,
-   |     ^^^^^^^^^^^^^^^^^ the trait `Ord` is not implemented for `std::ops::RangeTo<usize>`
+   |     ^^^^^^^^^^^^^^^^^^ the trait `Ord` is not implemented for `std::ops::RangeTo<usize>`
    |
    = note: required by `std::cmp::Ord::cmp`
    = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -320,7 +320,7 @@ error[E0277]: the trait bound `std::ops::RangeFrom<usize>: Ord` is not satisfied
   --> $DIR/range_traits-1.rs:19:5
    |
 LL |     c: RangeFrom<usize>,
-   |     ^^^^^^^^^^^^^^^^^^^ the trait `Ord` is not implemented for `std::ops::RangeFrom<usize>`
+   |     ^^^^^^^^^^^^^^^^^^^^ the trait `Ord` is not implemented for `std::ops::RangeFrom<usize>`
    |
    = note: required by `std::cmp::Ord::cmp`
    = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -329,7 +329,7 @@ error[E0277]: the trait bound `std::ops::RangeFull: Ord` is not satisfied
   --> $DIR/range_traits-1.rs:26:5
    |
 LL |     d: RangeFull,
-   |     ^^^^^^^^^^^^ the trait `Ord` is not implemented for `std::ops::RangeFull`
+   |     ^^^^^^^^^^^^^ the trait `Ord` is not implemented for `std::ops::RangeFull`
    |
    = note: required by `std::cmp::Ord::cmp`
    = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -338,7 +338,7 @@ error[E0277]: the trait bound `std::ops::RangeInclusive<usize>: Ord` is not sati
   --> $DIR/range_traits-1.rs:33:5
    |
 LL |     e: RangeInclusive<usize>,
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Ord` is not implemented for `std::ops::RangeInclusive<usize>`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Ord` is not implemented for `std::ops::RangeInclusive<usize>`
    |
    = note: required by `std::cmp::Ord::cmp`
    = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -347,7 +347,7 @@ error[E0277]: the trait bound `std::ops::RangeToInclusive<usize>: Ord` is not sa
   --> $DIR/range_traits-1.rs:40:5
    |
 LL |     f: RangeToInclusive<usize>,
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Ord` is not implemented for `std::ops::RangeToInclusive<usize>`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Ord` is not implemented for `std::ops::RangeToInclusive<usize>`
    |
    = note: required by `std::cmp::Ord::cmp`
    = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/src/test/ui/repr/repr-transparent.stderr
+++ b/src/test/ui/repr/repr-transparent.stderr
@@ -26,7 +26,7 @@ error[E0690]: transparent struct needs exactly one non-zero-sized field, but has
   --> $DIR/repr-transparent.rs:24:1
    |
 LL | struct MultipleNonZst(u8, u8);
-   | ^^^^^^^^^^^^^^^^^^^^^^--^^--^^
+   | ^^^^^^^^^^^^^^^^^^^^^^---^--^^
    | |                     |   |
    | |                     |   this field is non-zero-sized
    | |                     this field is non-zero-sized
@@ -36,7 +36,7 @@ error[E0690]: transparent struct needs exactly one non-zero-sized field, but has
   --> $DIR/repr-transparent.rs:30:1
    |
 LL | pub struct StructWithProjection(f32, <f32 as Mirror>::It);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---^^-------------------^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^----^-------------------^^
    | |                               |    |
    | |                               |    this field is non-zero-sized
    | |                               this field is non-zero-sized
@@ -52,7 +52,7 @@ error[E0691]: zero-sized field in transparent struct has alignment larger than 1
   --> $DIR/repr-transparent.rs:40:24
    |
 LL | struct GenericAlign<T>(ZstAlign32<T>, u32);
-   |                        ^^^^^^^^^^^^^ has alignment larger than 1
+   |                        ^^^^^^^^^^^^^^ has alignment larger than 1
 
 error[E0084]: unsupported representation for zero-variant enum
   --> $DIR/repr-transparent.rs:42:1
@@ -80,7 +80,7 @@ error[E0690]: the variant of a transparent enum needs exactly one non-zero-sized
 LL | enum TooManyFieldsEnum {
    | ^^^^^^^^^^^^^^^^^^^^^^ needs exactly one non-zero-sized field, but has 2
 LL |     Foo(u32, String),
-   |         ---  ------ this field is non-zero-sized
+   |         ---- ------ this field is non-zero-sized
    |         |
    |         this field is non-zero-sized
 
@@ -90,9 +90,9 @@ error[E0731]: transparent enum needs exactly one variant, but has 2
 LL | enum TooManyVariants {
    | ^^^^^^^^^^^^^^^^^^^^ needs exactly one variant, but has 2
 LL |     Foo(String),
-   |     -----------
+   |     ------------
 LL |     Bar,
-   |     --- too many variants in `TooManyVariants`
+   |     ---- too many variants in `TooManyVariants`
 
 error[E0691]: zero-sized field in transparent enum has alignment larger than 1
   --> $DIR/repr-transparent.rs:65:14
@@ -104,7 +104,7 @@ error[E0691]: zero-sized field in transparent enum has alignment larger than 1
   --> $DIR/repr-transparent.rs:70:11
    |
 LL |     Foo { bar: ZstAlign32<T>, baz: u32 }
-   |           ^^^^^^^^^^^^^^^^^^ has alignment larger than 1
+   |           ^^^^^^^^^^^^^^^^^^^ has alignment larger than 1
 
 error[E0690]: transparent union needs exactly one non-zero-sized field, but has 0
   --> $DIR/repr-transparent.rs:74:1
@@ -118,7 +118,7 @@ error[E0690]: transparent union needs exactly one non-zero-sized field, but has 
 LL | union TooManyFields {
    | ^^^^^^^^^^^^^^^^^^^ needs exactly one non-zero-sized field, but has 2
 LL |     u: u32,
-   |     ------ this field is non-zero-sized
+   |     ------- this field is non-zero-sized
 LL |     s: i32
    |     ------ this field is non-zero-sized
 

--- a/src/test/ui/resolve/privacy-enum-ctor.stderr
+++ b/src/test/ui/resolve/privacy-enum-ctor.stderr
@@ -34,7 +34,7 @@ error[E0423]: expected value, found struct variant `Z::Struct`
 LL | /             Struct {
 LL | |                 s: u8,
 LL | |             },
-   | |_____________- `Z::Struct` defined here
+   | |______________- `Z::Struct` defined here
 ...
 LL |           let _: Z = Z::Struct;
    |                      ^^^^^^^^^ help: use struct literal syntax instead: `Z::Struct { s: val }`
@@ -73,7 +73,7 @@ error[E0423]: expected value, found struct variant `m::E::Struct`
 LL | /         Struct {
 LL | |             s: u8,
 LL | |         },
-   | |_________- `m::E::Struct` defined here
+   | |__________- `m::E::Struct` defined here
 ...
 LL |       let _: E = m::E::Struct;
    |                  ^^^^^^^^^^^^ help: use struct literal syntax instead: `m::E::Struct { s: val }`
@@ -105,7 +105,7 @@ error[E0423]: expected value, found struct variant `E::Struct`
 LL | /         Struct {
 LL | |             s: u8,
 LL | |         },
-   | |_________- `E::Struct` defined here
+   | |__________- `E::Struct` defined here
 ...
 LL |       let _: E = E::Struct;
    |                  ^^^^^^^^^ help: use struct literal syntax instead: `E::Struct { s: val }`
@@ -185,7 +185,7 @@ error[E0423]: expected value, found struct variant `m::n::Z::Struct`
 LL | /             Struct {
 LL | |                 s: u8,
 LL | |             },
-   | |_____________- `m::n::Z::Struct` defined here
+   | |______________- `m::n::Z::Struct` defined here
 ...
 LL |       let _: Z = m::n::Z::Struct;
    |                  ^^^^^^^^^^^^^^^ help: use struct literal syntax instead: `m::n::Z::Struct { s: val }`
@@ -260,7 +260,7 @@ error[E0308]: mismatched types
   --> $DIR/privacy-enum-ctor.rs:27:20
    |
 LL |             Fn(u8),
-   |             ------ fn(u8) -> Z {Z::Fn} defined here
+   |             ------- fn(u8) -> Z {Z::Fn} defined here
 ...
 LL |         let _: Z = Z::Fn;
    |                -   ^^^^^ expected enum `Z`, found fn item
@@ -278,7 +278,7 @@ error[E0618]: expected function, found enum variant `Z::Unit`
   --> $DIR/privacy-enum-ctor.rs:31:17
    |
 LL |             Unit,
-   |             ---- `Z::Unit` defined here
+   |             ----- `Z::Unit` defined here
 ...
 LL |         let _ = Z::Unit();
    |                 ^^^^^^^--
@@ -294,7 +294,7 @@ error[E0308]: mismatched types
   --> $DIR/privacy-enum-ctor.rs:43:16
    |
 LL |         Fn(u8),
-   |         ------ fn(u8) -> E {E::Fn} defined here
+   |         ------- fn(u8) -> E {E::Fn} defined here
 ...
 LL |     let _: E = m::E::Fn;
    |            -   ^^^^^^^^ expected enum `E`, found fn item
@@ -312,7 +312,7 @@ error[E0618]: expected function, found enum variant `m::E::Unit`
   --> $DIR/privacy-enum-ctor.rs:47:16
    |
 LL |         Unit,
-   |         ---- `m::E::Unit` defined here
+   |         ----- `m::E::Unit` defined here
 ...
 LL |     let _: E = m::E::Unit();
    |                ^^^^^^^^^^--
@@ -328,7 +328,7 @@ error[E0308]: mismatched types
   --> $DIR/privacy-enum-ctor.rs:51:16
    |
 LL |         Fn(u8),
-   |         ------ fn(u8) -> E {E::Fn} defined here
+   |         ------- fn(u8) -> E {E::Fn} defined here
 ...
 LL |     let _: E = E::Fn;
    |            -   ^^^^^ expected enum `E`, found fn item
@@ -346,7 +346,7 @@ error[E0618]: expected function, found enum variant `E::Unit`
   --> $DIR/privacy-enum-ctor.rs:55:16
    |
 LL |         Unit,
-   |         ---- `E::Unit` defined here
+   |         ----- `E::Unit` defined here
 ...
 LL |     let _: E = E::Unit();
    |                ^^^^^^^--

--- a/src/test/ui/rfc-2008-non-exhaustive/variant.stderr
+++ b/src/test/ui/rfc-2008-non-exhaustive/variant.stderr
@@ -8,7 +8,7 @@ note: the tuple variant `Tuple` is defined here
   --> $DIR/auxiliary/variants.rs:5:23
    |
 LL |     #[non_exhaustive] Tuple(u32),
-   |                       ^^^^^^^^^^
+   |                       ^^^^^^^^^^^
 
 error[E0603]: unit variant `Unit` is private
   --> $DIR/variant.rs:14:47
@@ -20,7 +20,7 @@ note: the unit variant `Unit` is defined here
   --> $DIR/auxiliary/variants.rs:4:23
    |
 LL |     #[non_exhaustive] Unit,
-   |                       ^^^^
+   |                       ^^^^^
 
 error[E0603]: unit variant `Unit` is private
   --> $DIR/variant.rs:18:32
@@ -32,7 +32,7 @@ note: the unit variant `Unit` is defined here
   --> $DIR/auxiliary/variants.rs:4:23
    |
 LL |     #[non_exhaustive] Unit,
-   |                       ^^^^
+   |                       ^^^^^
 
 error[E0603]: tuple variant `Tuple` is private
   --> $DIR/variant.rs:20:32
@@ -44,7 +44,7 @@ note: the tuple variant `Tuple` is defined here
   --> $DIR/auxiliary/variants.rs:5:23
    |
 LL |     #[non_exhaustive] Tuple(u32),
-   |                       ^^^^^^^^^^
+   |                       ^^^^^^^^^^^
 
 error[E0603]: tuple variant `Tuple` is private
   --> $DIR/variant.rs:26:35
@@ -56,7 +56,7 @@ note: the tuple variant `Tuple` is defined here
   --> $DIR/auxiliary/variants.rs:5:23
    |
 LL |     #[non_exhaustive] Tuple(u32),
-   |                       ^^^^^^^^^^
+   |                       ^^^^^^^^^^^
 
 error[E0639]: cannot create non-exhaustive variant using struct expression
   --> $DIR/variant.rs:8:26

--- a/src/test/ui/span/E0204.stderr
+++ b/src/test/ui/span/E0204.stderr
@@ -2,7 +2,7 @@ error[E0204]: the trait `Copy` may not be implemented for this type
   --> $DIR/E0204.rs:5:6
    |
 LL |     foo: Vec<u32>,
-   |     ------------- this field does not implement `Copy`
+   |     -------------- this field does not implement `Copy`
 ...
 LL | impl Copy for Foo { }
    |      ^^^^
@@ -14,7 +14,7 @@ LL | #[derive(Copy)]
    |          ^^^^
 LL | struct Foo2<'a> {
 LL |     ty: &'a mut bool,
-   |     ---------------- this field does not implement `Copy`
+   |     ----------------- this field does not implement `Copy`
    |
    = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/span/pub-struct-field.stderr
+++ b/src/test/ui/span/pub-struct-field.stderr
@@ -2,18 +2,18 @@ error[E0124]: field `bar` is already declared
   --> $DIR/pub-struct-field.rs:6:5
    |
 LL |     bar: u8,
-   |     ------- `bar` first declared here
+   |     -------- `bar` first declared here
 LL |     pub bar: u8,
-   |     ^^^^^^^^^^^ field already declared
+   |     ^^^^^^^^^^^^ field already declared
 
 error[E0124]: field `bar` is already declared
   --> $DIR/pub-struct-field.rs:7:5
    |
 LL |     bar: u8,
-   |     ------- `bar` first declared here
+   |     -------- `bar` first declared here
 LL |     pub bar: u8,
 LL |     pub(crate) bar: u8,
-   |     ^^^^^^^^^^^^^^^^^^ field already declared
+   |     ^^^^^^^^^^^^^^^^^^^ field already declared
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/structs/struct-fields-decl-dupe.stderr
+++ b/src/test/ui/structs/struct-fields-decl-dupe.stderr
@@ -2,9 +2,9 @@ error[E0124]: field `foo` is already declared
   --> $DIR/struct-fields-decl-dupe.rs:3:5
    |
 LL |     foo: isize,
-   |     ---------- `foo` first declared here
+   |     ----------- `foo` first declared here
 LL |     foo: isize,
-   |     ^^^^^^^^^^ field already declared
+   |     ^^^^^^^^^^^ field already declared
 
 error: aborting due to previous error
 

--- a/src/test/ui/suggestions/fn-or-tuple-struct-without-args.stderr
+++ b/src/test/ui/suggestions/fn-or-tuple-struct-without-args.stderr
@@ -2,9 +2,9 @@ error[E0423]: expected value, found struct variant `E::B`
   --> $DIR/fn-or-tuple-struct-without-args.rs:36:16
    |
 LL |     A(usize),
-   |     -------- similarly named tuple variant `A` defined here
+   |     --------- similarly named tuple variant `A` defined here
 LL |     B { a: usize },
-   |     -------------- `E::B` defined here
+   |     --------------- `E::B` defined here
 ...
 LL |     let _: E = E::B;
    |                ^^^^
@@ -130,7 +130,7 @@ error[E0308]: mismatched types
   --> $DIR/fn-or-tuple-struct-without-args.rs:35:16
    |
 LL |     A(usize),
-   |     -------- fn(usize) -> E {E::A} defined here
+   |     --------- fn(usize) -> E {E::A} defined here
 ...
 LL |     let _: E = E::A;
    |            -   ^^^^ expected enum `E`, found fn item

--- a/src/test/ui/traits/traits-issue-71136.stderr
+++ b/src/test/ui/traits/traits-issue-71136.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `Foo: Clone` is not satisfied
   --> $DIR/traits-issue-71136.rs:5:5
    |
 LL |     the_foos: Vec<Foo>,
-   |     ^^^^^^^^^^^^^^^^^^ expected an implementor of trait `Clone`
+   |     ^^^^^^^^^^^^^^^^^^^ expected an implementor of trait `Clone`
    |
    = note: required because of the requirements on the impl of `Clone` for `Vec<Foo>`
    = note: required by `clone`

--- a/src/test/ui/type-alias-enum-variants/incorrect-variant-form-through-alias-caught.stderr
+++ b/src/test/ui/type-alias-enum-variants/incorrect-variant-form-through-alias-caught.stderr
@@ -20,7 +20,7 @@ error[E0618]: expected function, found enum variant `Alias::Unit`
   --> $DIR/incorrect-variant-form-through-alias-caught.rs:17:5
    |
 LL | enum Enum { Braced {}, Unit, Tuple() }
-   |                        ---- `Alias::Unit` defined here
+   |                        ----- `Alias::Unit` defined here
 ...
 LL |     Alias::Unit();
    |     ^^^^^^^^^^^--

--- a/src/test/ui/union/issue-41073.stderr
+++ b/src/test/ui/union/issue-41073.stderr
@@ -2,13 +2,13 @@ error[E0740]: unions may not contain fields that need dropping
   --> $DIR/issue-41073.rs:4:5
    |
 LL |     a: A,
-   |     ^^^^
+   |     ^^^^^
    |
 note: `std::mem::ManuallyDrop` can be used to wrap the type
   --> $DIR/issue-41073.rs:4:5
    |
 LL |     a: A,
-   |     ^^^^
+   |     ^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/union/union-custom-drop.stderr
+++ b/src/test/ui/union/union-custom-drop.stderr
@@ -2,13 +2,13 @@ error[E0740]: unions may not contain fields that need dropping
   --> $DIR/union-custom-drop.rs:7:5
    |
 LL |     bar: Bar,
-   |     ^^^^^^^^
+   |     ^^^^^^^^^
    |
 note: `std::mem::ManuallyDrop` can be used to wrap the type
   --> $DIR/union-custom-drop.rs:7:5
    |
 LL |     bar: Bar,
-   |     ^^^^^^^^
+   |     ^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/union/union-derive-eq.stderr
+++ b/src/test/ui/union/union-derive-eq.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `PartialEqNotEq: Eq` is not satisfied
   --> $DIR/union-derive-eq.rs:15:5
    |
 LL |     a: PartialEqNotEq,
-   |     ^^^^^^^^^^^^^^^^^ the trait `Eq` is not implemented for `PartialEqNotEq`
+   |     ^^^^^^^^^^^^^^^^^^ the trait `Eq` is not implemented for `PartialEqNotEq`
    | 
   ::: $SRC_DIR/core/src/cmp.rs:LL:COL
    |

--- a/src/test/ui/union/union-fields-1.stderr
+++ b/src/test/ui/union/union-fields-1.stderr
@@ -2,7 +2,7 @@ error: field is never read: `c`
   --> $DIR/union-fields-1.rs:6:5
    |
 LL |     c: u8,
-   |     ^^^^^
+   |     ^^^^^^
    |
 note: the lint level is defined here
   --> $DIR/union-fields-1.rs:1:9
@@ -14,7 +14,7 @@ error: field is never read: `a`
   --> $DIR/union-fields-1.rs:9:5
    |
 LL |     a: u8,
-   |     ^^^^^
+   |     ^^^^^^
 
 error: field is never read: `a`
   --> $DIR/union-fields-1.rs:13:20
@@ -26,7 +26,7 @@ error: field is never read: `c`
   --> $DIR/union-fields-1.rs:18:5
    |
 LL |     c: u8,
-   |     ^^^^^
+   |     ^^^^^^
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/union/union-lint-dead-code.stderr
+++ b/src/test/ui/union/union-lint-dead-code.stderr
@@ -2,7 +2,7 @@ error: field is never read: `b`
   --> $DIR/union-lint-dead-code.rs:5:5
    |
 LL |     b: bool,
-   |     ^^^^^^^
+   |     ^^^^^^^^
    |
 note: the lint level is defined here
   --> $DIR/union-lint-dead-code.rs:1:9

--- a/src/test/ui/union/union-with-drop-fields.stderr
+++ b/src/test/ui/union/union-with-drop-fields.stderr
@@ -2,37 +2,37 @@ error[E0740]: unions may not contain fields that need dropping
   --> $DIR/union-with-drop-fields.rs:9:5
    |
 LL |     a: String,
-   |     ^^^^^^^^^
+   |     ^^^^^^^^^^
    |
 note: `std::mem::ManuallyDrop` can be used to wrap the type
   --> $DIR/union-with-drop-fields.rs:9:5
    |
 LL |     a: String,
-   |     ^^^^^^^^^
+   |     ^^^^^^^^^^
 
 error[E0740]: unions may not contain fields that need dropping
   --> $DIR/union-with-drop-fields.rs:17:5
    |
 LL |     a: S,
-   |     ^^^^
+   |     ^^^^^
    |
 note: `std::mem::ManuallyDrop` can be used to wrap the type
   --> $DIR/union-with-drop-fields.rs:17:5
    |
 LL |     a: S,
-   |     ^^^^
+   |     ^^^^^
 
 error[E0740]: unions may not contain fields that need dropping
   --> $DIR/union-with-drop-fields.rs:22:5
    |
 LL |     a: T,
-   |     ^^^^
+   |     ^^^^^
    |
 note: `std::mem::ManuallyDrop` can be used to wrap the type
   --> $DIR/union-with-drop-fields.rs:22:5
    |
 LL |     a: T,
-   |     ^^^^
+   |     ^^^^^
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/variants/variant-size-differences.stderr
+++ b/src/test/ui/variants/variant-size-differences.stderr
@@ -2,7 +2,7 @@ error: enum variant is more than three times larger (1024 bytes) than the next l
   --> $DIR/variant-size-differences.rs:5:5
    |
 LL |     VBig([u8; 1024]),
-   |     ^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^
    |
 note: the lint level is defined here
   --> $DIR/variant-size-differences.rs:1:9


### PR DESCRIPTION
A trailing comma is logically part of the field/variant that it appears
after, since it can be (implicitly) removed by cfg-stripping. Including
the trailing comma in the span of the field/variant ensures that we are
consistent about which tokens belong to a field/variant.