### PR TITLE
Returns values up to 2*usize by value

### DIFF
--- a/compiler/rustc_middle/src/ty/layout.rs
+++ b/compiler/rustc_middle/src/ty/layout.rs
@@ -2787,8 +2787,9 @@ where
                     _ => return,
                 }
 
-                let max_by_val_size =
-                    if is_ret { call::max_ret_by_val(cx) } else { Pointer.size(cx) };
+                // Return structures up to 2 pointers in size by value, matching `ScalarPair`. LLVM
+                // will usually return these in 2 registers, which is more efficient than by-ref.
+                let max_by_val_size = if is_ret { Pointer.size(cx) * 2 } else { Pointer.size(cx) };
                 let size = arg.layout.size;
 
                 if arg.layout.is_unsized() || size > max_by_val_size {

--- a/compiler/rustc_target/src/abi/call/mod.rs
+++ b/compiler/rustc_target/src/abi/call/mod.rs
@@ -610,15 +610,3 @@ impl<'a, Ty> FnAbi<'a, Ty> {
         Ok(())
     }
 }
-
-/// Returns the maximum size of return values to be passed by value in the Rust ABI.
-///
-/// Return values beyond this size will use an implicit out-pointer instead.
-pub fn max_ret_by_val<C: HasTargetSpec + HasDataLayout>(spec: &C) -> Size {
-    match spec.target_spec().arch.as_str() {
-        // System-V will pass return values up to 128 bits in RAX/RDX.
-        "x86_64" => Size::from_bits(128),
-
-        _ => spec.data_layout().pointer_size,
-    }
-}


### PR DESCRIPTION
Addresses https://github.com/rust-lang/rust/pull/76986#discussion_r498306837 and https://github.com/rust-lang/rust/pull/76986#issuecomment-696415287 by doing the optimization on all targets.

This matches what we do for functions returning `&[T]` and other fat pointers, so it should be Harmless™