### PR TITLE
Permit ty::Bool in const generics for v0 mangling

### DIFF
--- a/compiler/rustc_symbol_mangling/src/v0.rs
+++ b/compiler/rustc_symbol_mangling/src/v0.rs
@@ -504,6 +504,7 @@ impl Printer<'tcx> for SymbolMangler<'tcx> {
 
         match ct.ty.kind() {
             ty::Uint(_) => {}
+            ty::Bool => {}
             _ => {
                 bug!("symbol_names: unsupported constant of type `{}` ({:?})", ct.ty, ct);
             }

--- a/src/test/ui/symbol-names/issue-76365.rs
+++ b/src/test/ui/symbol-names/issue-76365.rs
@@ -1,0 +1,18 @@
+// check-pass
+// revisions: legacy v0
+//[legacy]compile-flags: -Z symbol-mangling-version=legacy --crate-type=lib
+    //[v0]compile-flags: -Z symbol-mangling-version=v0 --crate-type=lib
+
+#![feature(min_const_generics)]
+
+pub struct Bar<const F: bool>;
+
+impl Bar<true> {
+    pub fn foo() {}
+}
+
+impl<const F: bool> Bar<F> {
+    pub fn bar() {}
+}
+
+fn main() {}


### PR DESCRIPTION
This should unbreak using new-symbol-mangling = true in config.toml (once it lands in beta anyway).

Fixes #76365 (well, it will, but seems fine to close as soon as we have support)

r? @eddyb (for mangling) but I'm okay with some other reviewer too :)