### PR TITLE
Make `TerminatorKind::Abort` an error in all const contexts

### DIFF
--- a/compiler/rustc_mir/src/transform/check_consts/ops.rs
+++ b/compiler/rustc_mir/src/transform/check_consts/ops.rs
@@ -44,12 +44,14 @@ pub trait NonConstOp: std::fmt::Debug {
 #[derive(Debug)]
 pub struct Abort;
 impl NonConstOp for Abort {
-    fn status_in_item(&self, ccx: &ConstCx<'_, '_>) -> Status {
-        mcf_status_in_item(ccx)
-    }
-
     fn build_error(&self, ccx: &ConstCx<'_, 'tcx>, span: Span) -> DiagnosticBuilder<'tcx> {
-        mcf_build_error(ccx, span, "abort is not stable in const fn")
+        struct_span_err!(
+            ccx.tcx.sess,
+            span,
+            E0723,
+            "unwind strategies besides the default are not allowed in {}s",
+            ccx.const_kind(),
+        )
     }
 }
 


### PR DESCRIPTION
I'm not too up-to-date on FFI-unwind stuff, but `Abort` denotes that panics inside function calls (usually across an FFI boundary) will abort immediately. These semantics are not supported by ~~Miri~~ the const-eval engine AFAICT, and I don't think you can even enable them on the current stable. Forbid them in all const-contexts before that last part changes.

r? @oli-obk 
cc @RalfJung (for long-term plan around `Abort` in Miri)