### PR TITLE
Re-land PR #71840 (Rework MIR drop tree lowering)

### DIFF
--- a/compiler/rustc_mir/src/dataflow/move_paths/builder.rs
+++ b/compiler/rustc_mir/src/dataflow/move_paths/builder.rs
@@ -362,7 +362,7 @@ impl<'b, 'a, 'tcx> Gatherer<'b, 'a, 'tcx> {
     fn gather_terminator(&mut self, term: &Terminator<'tcx>) {
         match term.kind {
             TerminatorKind::Goto { target: _ }
-            | TerminatorKind::FalseEdges { .. }
+            | TerminatorKind::FalseEdge { .. }
             | TerminatorKind::FalseUnwind { .. }
             // In some sense returning moves the return place into the current
             // call's destination, however, since there are no statements after

--- a/compiler/rustc_mir/src/dataflow/move_paths/builder.rs
+++ b/compiler/rustc_mir/src/dataflow/move_paths/builder.rs
@@ -362,12 +362,16 @@ impl<'b, 'a, 'tcx> Gatherer<'b, 'a, 'tcx> {
     fn gather_terminator(&mut self, term: &Terminator<'tcx>) {
         match term.kind {
             TerminatorKind::Goto { target: _ }
+            | TerminatorKind::FalseEdges { .. }
+            | TerminatorKind::FalseUnwind { .. }
+            // In some sense returning moves the return place into the current
+            // call's destination, however, since there are no statements after
+            // this that could possibly access the return place, this doesn't
+            // need recording.
             | TerminatorKind::Return
             | TerminatorKind::Resume
             | TerminatorKind::Abort
             | TerminatorKind::GeneratorDrop
-            | TerminatorKind::FalseEdge { .. }
-            | TerminatorKind::FalseUnwind { .. }
             | TerminatorKind::Unreachable => {}
 
             TerminatorKind::Assert { ref cond, .. } => {

--- a/compiler/rustc_mir/src/dataflow/move_paths/builder.rs
+++ b/compiler/rustc_mir/src/dataflow/move_paths/builder.rs
@@ -362,16 +362,13 @@ impl<'b, 'a, 'tcx> Gatherer<'b, 'a, 'tcx> {
     fn gather_terminator(&mut self, term: &Terminator<'tcx>) {
         match term.kind {
             TerminatorKind::Goto { target: _ }
+            | TerminatorKind::Return
             | TerminatorKind::Resume
             | TerminatorKind::Abort
             | TerminatorKind::GeneratorDrop
             | TerminatorKind::FalseEdge { .. }
             | TerminatorKind::FalseUnwind { .. }
             | TerminatorKind::Unreachable => {}
-
-            TerminatorKind::Return => {
-                self.gather_move(Place::return_place());
-            }
 
             TerminatorKind::Assert { ref cond, .. } => {
                 self.gather_operand(cond);

--- a/compiler/rustc_mir/src/util/elaborate_drops.rs
+++ b/compiler/rustc_mir/src/util/elaborate_drops.rs
@@ -231,8 +231,6 @@ where
                     .patch_terminator(bb, TerminatorKind::Goto { target: self.succ });
             }
             DropStyle::Static => {
-                let loc = self.terminator_loc(bb);
-                self.elaborator.clear_drop_flag(loc, self.path, DropFlagMode::Deep);
                 self.elaborator.patch().patch_terminator(
                     bb,
                     TerminatorKind::Drop {
@@ -243,9 +241,7 @@ where
                 );
             }
             DropStyle::Conditional => {
-                let unwind = self.unwind; // FIXME(#43234)
-                let succ = self.succ;
-                let drop_bb = self.complete_drop(Some(DropFlagMode::Deep), succ, unwind);
+                let drop_bb = self.complete_drop(self.succ, self.unwind);
                 self.elaborator
                     .patch()
                     .patch_terminator(bb, TerminatorKind::Goto { target: drop_bb });
@@ -317,7 +313,7 @@ where
                 // our own drop flag.
                 path: self.path,
             }
-            .complete_drop(None, succ, unwind)
+            .complete_drop(succ, unwind)
         }
     }
 
@@ -346,13 +342,7 @@ where
         // Clear the "master" drop flag at the end. This is needed
         // because the "master" drop protects the ADT's discriminant,
         // which is invalidated after the ADT is dropped.
-        let (succ, unwind) = (self.succ, self.unwind); // FIXME(#43234)
-        (
-            self.drop_flag_reset_block(DropFlagMode::Shallow, succ, unwind),
-            unwind.map(|unwind| {
-                self.drop_flag_reset_block(DropFlagMode::Shallow, unwind, Unwind::InCleanup)
-            }),
-        )
+        (self.drop_flag_reset_block(DropFlagMode::Shallow, self.succ, self.unwind), self.unwind)
     }
 
     /// Creates a full drop ladder, consisting of 2 connected half-drop-ladders
@@ -884,11 +874,7 @@ where
                     self.open_drop_for_adt(def, substs)
                 }
             }
-            ty::Dynamic(..) => {
-                let unwind = self.unwind; // FIXME(#43234)
-                let succ = self.succ;
-                self.complete_drop(Some(DropFlagMode::Deep), succ, unwind)
-            }
+            ty::Dynamic(..) => self.complete_drop(self.succ, self.unwind),
             ty::Array(ety, size) => {
                 let size = size.try_eval_usize(self.tcx(), self.elaborator.param_env());
                 self.open_drop_for_array(ety, size)
@@ -899,20 +885,10 @@ where
         }
     }
 
-    fn complete_drop(
-        &mut self,
-        drop_mode: Option<DropFlagMode>,
-        succ: BasicBlock,
-        unwind: Unwind,
-    ) -> BasicBlock {
-        debug!("complete_drop({:?},{:?})", self, drop_mode);
+    fn complete_drop(&mut self, succ: BasicBlock, unwind: Unwind) -> BasicBlock {
+        debug!("complete_drop(succ={:?}, unwind={:?})", succ, unwind);
 
         let drop_block = self.drop_block(succ, unwind);
-        let drop_block = if let Some(mode) = drop_mode {
-            self.drop_flag_reset_block(mode, drop_block, unwind)
-        } else {
-            drop_block
-        };
 
         self.drop_flag_test_block(drop_block, succ, unwind)
     }
@@ -927,6 +903,11 @@ where
     ) -> BasicBlock {
         debug!("drop_flag_reset_block({:?},{:?})", self, mode);
 
+        if unwind.is_cleanup() {
+            // The drop flag isn't read again on the unwind path, so don't
+            // bother setting it.
+            return succ;
+        }
         let block = self.new_block(unwind, TerminatorKind::Goto { target: succ });
         let block_start = Location { block, statement_index: 0 };
         self.elaborator.clear_drop_flag(block_start, self.path, mode);
@@ -1042,11 +1023,6 @@ where
 
     fn new_temp(&mut self, ty: Ty<'tcx>) -> Local {
         self.elaborator.patch().new_temp(ty, self.source_info.span)
-    }
-
-    fn terminator_loc(&mut self, bb: BasicBlock) -> Location {
-        let body = self.elaborator.body();
-        self.elaborator.patch().terminator_loc(body, bb)
     }
 
     fn constant_usize(&self, val: u16) -> Operand<'tcx> {

--- a/compiler/rustc_mir/src/util/graphviz.rs
+++ b/compiler/rustc_mir/src/util/graphviz.rs
@@ -114,21 +114,16 @@ where
     let (blk, bgcolor) = if data.is_cleanup {
         (format!("{} (cleanup)", block.index()), "lightblue")
     } else {
-        let color = if dark_mode {
-            "dimgray"
-        } else {
-            "gray"
-        };
-        (format!("{}", block.index()), "gray")
+        let color = if dark_mode { "dimgray" } else { "gray" };
+        (format!("{}", block.index()), color)
     };
     write!(
         w,
         r#"<tr><td bgcolor="{bgcolor}" {attrs} colspan="{colspan}">{blk}</td></tr>"#,
-        bgcolor = if dark_mode { "dimgray" } else { "gray" },
         attrs = r#"align="center""#,
         colspan = num_cols,
         blk = blk,
-        color = color
+        bgcolor = bgcolor
     )?;
 
     init(w)?;

--- a/compiler/rustc_mir/src/util/graphviz.rs
+++ b/compiler/rustc_mir/src/util/graphviz.rs
@@ -111,13 +111,24 @@ where
     write!(w, r#"<table border="0" cellborder="1" cellspacing="0">"#)?;
 
     // Basic block number at the top.
+    let (blk, bgcolor) = if data.is_cleanup {
+        (format!("{} (cleanup)", block.index()), "lightblue")
+    } else {
+        let color = if dark_mode {
+            "dimgray"
+        } else {
+            "gray"
+        };
+        (format!("{}", block.index()), "gray")
+    };
     write!(
         w,
         r#"<tr><td bgcolor="{bgcolor}" {attrs} colspan="{colspan}">{blk}</td></tr>"#,
         bgcolor = if dark_mode { "dimgray" } else { "gray" },
         attrs = r#"align="center""#,
         colspan = num_cols,
-        blk = block.index()
+        blk = blk,
+        color = color
     )?;
 
     init(w)?;

--- a/compiler/rustc_mir_build/src/build/block.rs
+++ b/compiler/rustc_mir_build/src/build/block.rs
@@ -28,14 +28,16 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         self.in_opt_scope(opt_destruction_scope.map(|de| (de, source_info)), move |this| {
             this.in_scope((region_scope, source_info), LintLevel::Inherited, move |this| {
                 if targeted_by_break {
-                    // This is a `break`-able block
-                    let exit_block = this.cfg.start_new_block();
-                    let block_exit =
-                        this.in_breakable_scope(None, exit_block, destination, |this| {
-                            this.ast_block_stmts(destination, block, span, stmts, expr, safety_mode)
-                        });
-                    this.cfg.goto(unpack!(block_exit), source_info, exit_block);
-                    exit_block.unit()
+                    this.in_breakable_scope(None, destination, span, |this| {
+                        Some(this.ast_block_stmts(
+                            destination,
+                            block,
+                            span,
+                            stmts,
+                            expr,
+                            safety_mode,
+                        ))
+                    })
                 } else {
                     this.ast_block_stmts(destination, block, span, stmts, expr, safety_mode)
                 }

--- a/compiler/rustc_mir_build/src/build/expr/into.rs
+++ b/compiler/rustc_mir_build/src/build/expr/into.rs
@@ -140,23 +140,19 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 // body, even when the exact code in the body cannot unwind
 
                 let loop_block = this.cfg.start_new_block();
-                let exit_block = this.cfg.start_new_block();
 
                 // Start the loop.
                 this.cfg.goto(block, source_info, loop_block);
 
-                this.in_breakable_scope(Some(loop_block), exit_block, destination, move |this| {
+                this.in_breakable_scope(Some(loop_block), destination, expr_span, move |this| {
                     // conduct the test, if necessary
                     let body_block = this.cfg.start_new_block();
-                    let diverge_cleanup = this.diverge_cleanup();
                     this.cfg.terminate(
                         loop_block,
                         source_info,
-                        TerminatorKind::FalseUnwind {
-                            real_target: body_block,
-                            unwind: Some(diverge_cleanup),
-                        },
+                        TerminatorKind::FalseUnwind { real_target: body_block, unwind: None },
                     );
+                    this.diverge_from(loop_block);
 
                     // The “return” value of the loop body must always be an unit. We therefore
                     // introduce a unit temporary as the destination for the loop body.
@@ -164,8 +160,10 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     // Execute the body, branching back to the test.
                     let body_block_end = unpack!(this.into(tmp, body_block, body));
                     this.cfg.goto(body_block_end, source_info, loop_block);
-                });
-                exit_block.unit()
+
+                    // Loops are only exited by `break` expressions.
+                    None
+                })
             }
             ExprKind::Call { ty, fun, args, from_hir_call, fn_span } => {
                 let intrinsic = match *ty.kind() {
@@ -206,7 +204,6 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                         .collect();
 
                     let success = this.cfg.start_new_block();
-                    let cleanup = this.diverge_cleanup();
 
                     this.record_operands_moved(&args);
 
@@ -218,7 +215,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                         TerminatorKind::Call {
                             func: fun,
                             args,
-                            cleanup: Some(cleanup),
+                            cleanup: None,
                             // FIXME(varkor): replace this with an uninhabitedness-based check.
                             // This requires getting access to the current module to call
                             // `tcx.is_ty_uninhabited_from`, which is currently tricky to do.
@@ -231,6 +228,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                             fn_span,
                         },
                     );
+                    this.diverge_from(block);
                     success.unit()
                 }
             }
@@ -437,12 +435,12 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 let scope = this.local_scope();
                 let value = unpack!(block = this.as_operand(block, scope, value));
                 let resume = this.cfg.start_new_block();
-                let cleanup = this.generator_drop_cleanup();
                 this.cfg.terminate(
                     block,
                     source_info,
-                    TerminatorKind::Yield { value, resume, resume_arg: destination, drop: cleanup },
+                    TerminatorKind::Yield { value, resume, resume_arg: destination, drop: None },
                 );
+                this.generator_drop_cleanup(block);
                 resume.unit()
             }
 

--- a/compiler/rustc_mir_build/src/build/matches/test.rs
+++ b/compiler/rustc_mir_build/src/build/matches/test.rs
@@ -434,7 +434,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     literal: method,
                 }),
                 args: vec![val, expect],
-                destination: Some((eq_result.clone(), eq_block)),
+                destination: Some((eq_result, eq_block)),
                 cleanup: None,
                 from_hir_call: false,
                 fn_span: source_info.span,

--- a/compiler/rustc_mir_build/src/build/matches/test.rs
+++ b/compiler/rustc_mir_build/src/build/matches/test.rs
@@ -418,7 +418,6 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         let bool_ty = self.hir.bool_ty();
         let eq_result = self.temp(bool_ty, source_info.span);
         let eq_block = self.cfg.start_new_block();
-        let cleanup = self.diverge_cleanup();
         self.cfg.terminate(
             block,
             source_info,
@@ -435,12 +434,13 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     literal: method,
                 }),
                 args: vec![val, expect],
-                destination: Some((eq_result, eq_block)),
-                cleanup: Some(cleanup),
+                destination: Some((eq_result.clone(), eq_block)),
+                cleanup: None,
                 from_hir_call: false,
                 fn_span: source_info.span,
             },
         );
+        self.diverge_from(block);
 
         if let [success_block, fail_block] = *make_target_blocks(self) {
             // check the result

--- a/compiler/rustc_mir_build/src/build/mod.rs
+++ b/compiler/rustc_mir_build/src/build/mod.rs
@@ -345,11 +345,6 @@ struct Builder<'a, 'tcx> {
 
     var_debug_info: Vec<VarDebugInfo<'tcx>>,
 
-    /// Cached block with the `RESUME` terminator; this is created
-    /// when first set of cleanups are built.
-    cached_resume_block: Option<BasicBlock>,
-    /// Cached block with the `RETURN` terminator.
-    cached_return_block: Option<BasicBlock>,
     /// Cached block with the `UNREACHABLE` terminator.
     cached_unreachable_block: Option<BasicBlock>,
 }
@@ -609,50 +604,34 @@ where
         region::Scope { id: body.value.hir_id.local_id, data: region::ScopeData::CallSite };
     let arg_scope =
         region::Scope { id: body.value.hir_id.local_id, data: region::ScopeData::Arguments };
-    let mut block = START_BLOCK;
     let source_info = builder.source_info(span);
     let call_site_s = (call_site_scope, source_info);
-    unpack!(
-        block = builder.in_scope(call_site_s, LintLevel::Inherited, |builder| {
-            if should_abort_on_panic(tcx, fn_def_id, abi) {
-                builder.schedule_abort();
-            }
-
-            let arg_scope_s = (arg_scope, source_info);
-            // `return_block` is called when we evaluate a `return` expression, so
-            // we just use `START_BLOCK` here.
-            unpack!(
-                block = builder.in_breakable_scope(
-                    None,
-                    START_BLOCK,
-                    Place::return_place(),
-                    |builder| {
-                        builder.in_scope(arg_scope_s, LintLevel::Inherited, |builder| {
-                            builder.args_and_body(
-                                block,
-                                fn_def_id.to_def_id(),
-                                &arguments,
-                                arg_scope,
-                                &body.value,
-                            )
-                        })
-                    },
-                )
-            );
-            // Attribute epilogue to function's closing brace
-            let fn_end = span_with_body.shrink_to_hi();
-            let source_info = builder.source_info(fn_end);
-            let return_block = builder.return_block();
-            builder.cfg.goto(block, source_info, return_block);
-            builder.cfg.terminate(return_block, source_info, TerminatorKind::Return);
-            // Attribute any unreachable codepaths to the function's closing brace
-            if let Some(unreachable_block) = builder.cached_unreachable_block {
-                builder.cfg.terminate(unreachable_block, source_info, TerminatorKind::Unreachable);
-            }
-            return_block.unit()
-        })
-    );
-    assert_eq!(block, builder.return_block());
+    unpack!(builder.in_scope(call_site_s, LintLevel::Inherited, |builder| {
+        let arg_scope_s = (arg_scope, source_info);
+        // Attribute epilogue to function's closing brace
+        let fn_end = span_with_body.shrink_to_hi();
+        let return_block =
+            unpack!(builder.in_breakable_scope(None, Place::return_place(), fn_end, |builder| {
+                Some(builder.in_scope(arg_scope_s, LintLevel::Inherited, |builder| {
+                    builder.args_and_body(
+                        START_BLOCK,
+                        fn_def_id.to_def_id(),
+                        &arguments,
+                        arg_scope,
+                        &body.value,
+                    )
+                }))
+            }));
+        let source_info = builder.source_info(fn_end);
+        builder.cfg.terminate(return_block, source_info, TerminatorKind::Return);
+        let should_abort = should_abort_on_panic(tcx, fn_def_id, abi);
+        builder.build_drop_trees(should_abort);
+        // Attribute any unreachable codepaths to the function's closing brace
+        if let Some(unreachable_block) = builder.cached_unreachable_block {
+            builder.cfg.terminate(unreachable_block, source_info, TerminatorKind::Unreachable);
+        }
+        return_block.unit()
+    }));
 
     let spread_arg = if abi == Abi::RustCall {
         // RustCall pseudo-ABI untuples the last argument.
@@ -686,8 +665,7 @@ fn construct_const<'a, 'tcx>(
     let source_info = builder.source_info(span);
     builder.cfg.terminate(block, source_info, TerminatorKind::Return);
 
-    // Constants can't `return` so a return block should not be created.
-    assert_eq!(builder.cached_return_block, None);
+    builder.build_drop_trees(false);
 
     // Constants may be match expressions in which case an unreachable block may
     // be created, so terminate it properly.
@@ -754,7 +732,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             fn_span: span,
             arg_count,
             generator_kind,
-            scopes: Default::default(),
+            scopes: scope::Scopes::new(),
             block_context: BlockContext::new(),
             source_scopes: IndexVec::new(),
             source_scope: OUTERMOST_SOURCE_SCOPE,
@@ -767,8 +745,6 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             var_indices: Default::default(),
             unit_temp: None,
             var_debug_info: vec![],
-            cached_resume_block: None,
-            cached_return_block: None,
             cached_unreachable_block: None,
         };
 
@@ -1000,17 +976,6 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 let tmp = self.temp(ty, fn_span);
                 self.unit_temp = Some(tmp);
                 tmp
-            }
-        }
-    }
-
-    fn return_block(&mut self) -> BasicBlock {
-        match self.cached_return_block {
-            Some(rb) => rb,
-            None => {
-                let rb = self.cfg.start_new_block();
-                self.cached_return_block = Some(rb);
-                rb
             }
         }
     }

--- a/compiler/rustc_mir_build/src/build/scope.rs
+++ b/compiler/rustc_mir_build/src/build/scope.rs
@@ -85,7 +85,6 @@ use crate::build::{BlockAnd, BlockAndExtension, BlockFrame, Builder, CFG};
 use crate::thir::{Expr, ExprRef, LintLevel};
 use rustc_data_structures::fx::FxHashMap;
 use rustc_hir as hir;
-use rustc_hir::GeneratorKind;
 use rustc_index::vec::IndexVec;
 use rustc_middle::middle::region;
 use rustc_middle::mir::*;
@@ -364,7 +363,7 @@ impl DropTree {
                         target: blocks[drop_data.1].unwrap(),
                         // The caller will handle this if needed.
                         unwind: None,
-                        location: drop_data.0.local.into(),
+                        place: drop_data.0.local.into(),
                     };
                     cfg.terminate(block, drop_data.0.source_info, terminator);
                 }
@@ -1389,7 +1388,8 @@ impl<'tcx> DropTreeBuilder<'tcx> for Unwind {
             | TerminatorKind::Unreachable
             | TerminatorKind::Yield { .. }
             | TerminatorKind::GeneratorDrop
-            | TerminatorKind::FalseEdges { .. } => {
+            | TerminatorKind::FalseEdge { .. }
+            | TerminatorKind::InlineAsm {.. } => {
                 span_bug!(term.source_info.span, "cannot unwind from {:?}", term.kind)
             }
         }

--- a/compiler/rustc_mir_build/src/build/scope.rs
+++ b/compiler/rustc_mir_build/src/build/scope.rs
@@ -6,30 +6,31 @@ contents, and then pop it off. Every scope is named by a
 
 ### SEME Regions
 
-When pushing a new scope, we record the current point in the graph (a
+When pushing a new [Scope], we record the current point in the graph (a
 basic block); this marks the entry to the scope. We then generate more
 stuff in the control-flow graph. Whenever the scope is exited, either
 via a `break` or `return` or just by fallthrough, that marks an exit
 from the scope. Each lexical scope thus corresponds to a single-entry,
 multiple-exit (SEME) region in the control-flow graph.
 
-For now, we keep a mapping from each `region::Scope` to its
-corresponding SEME region for later reference (see caveat in next
-paragraph). This is because region scopes are tied to
-them. Eventually, when we shift to non-lexical lifetimes, there should
-be no need to remember this mapping.
+For now, we record the `region::Scope` to each SEME region for later reference
+(see caveat in next paragraph). This is because destruction scopes are tied to
+them. This may change in the future so that MIR lowering determines its own
+destruction scopes.
 
 ### Not so SEME Regions
 
 In the course of building matches, it sometimes happens that certain code
 (namely guards) gets executed multiple times. This means that the scope lexical
 scope may in fact correspond to multiple, disjoint SEME regions. So in fact our
-mapping is from one scope to a vector of SEME regions.
+mapping is from one scope to a vector of SEME regions. Since the SEME regions
+are disjoint, the mapping is still one-to-one for the set of SEME regions that
+we're currently in.
 
-Also in matches, the scopes assigned to arms are not even SEME regions! Each
-arm has a single region with one entry for each pattern. We manually
+Also in matches, the scopes assigned to arms are not always even SEME regions!
+Each arm has a single region with one entry for each pattern. We manually
 manipulate the scheduled drops in this scope to avoid dropping things multiple
-times, although drop elaboration would clean this up for value drops.
+times.
 
 ### Drops
 
@@ -60,25 +61,23 @@ that for now); any later drops would also drop `y`.
 
 There are numerous "normal" ways to early exit a scope: `break`,
 `continue`, `return` (panics are handled separately). Whenever an
-early exit occurs, the method `exit_scope` is called. It is given the
+early exit occurs, the method `break_scope` is called. It is given the
 current point in execution where the early exit occurs, as well as the
 scope you want to branch to (note that all early exits from to some
-other enclosing scope). `exit_scope` will record this exit point and
-also add all drops.
+other enclosing scope). `break_scope` will record the set of drops currently
+scheduled in a [DropTree]. Later, before `in_breakable_scope` exits, the drops
+will be added to the CFG.
 
-Panics are handled in a similar fashion, except that a panic always
-returns out to the `DIVERGE_BLOCK`. To trigger a panic, simply call
-`panic(p)` with the current point `p`. Or else you can call
-`diverge_cleanup`, which will produce a block that you can branch to
-which does the appropriate cleanup and then diverges. `panic(p)`
-simply calls `diverge_cleanup()` and adds an edge from `p` to the
-result.
+Panics are handled in a similar fashion, except that the drops are added to the
+mir once the rest of the function has finished being lowered. If a terminator
+can panic, call `diverge_from(block)` with the block containing the terminator
+`block`.
 
-### Loop scopes
+### Breakable scopes
 
 In addition to the normal scope stack, we track a loop scope stack
-that contains only loops. It tracks where a `break` and `continue`
-should go to.
+that contains only loops and breakable blocks. It tracks where a `break`,
+`continue` or `return` should go to.
 
 */
 
@@ -87,11 +86,24 @@ use crate::thir::{Expr, ExprRef, LintLevel};
 use rustc_data_structures::fx::FxHashMap;
 use rustc_hir as hir;
 use rustc_hir::GeneratorKind;
+use rustc_index::vec::IndexVec;
 use rustc_middle::middle::region;
 use rustc_middle::mir::*;
 use rustc_span::{Span, DUMMY_SP};
-use std::collections::hash_map::Entry;
-use std::mem;
+
+#[derive(Debug)]
+pub struct Scopes<'tcx> {
+    scopes: Vec<Scope>,
+    /// The current set of breakable scopes. See module comment for more details.
+    breakable_scopes: Vec<BreakableScope<'tcx>>,
+
+    /// Drops that need to be done on unwind paths. See the comment on
+    /// [DropTree] for more details.
+    unwind_drops: DropTree,
+
+    /// Drops that need to be done on paths to the `GeneratorDrop` terminator.
+    generator_drops: DropTree,
+}
 
 #[derive(Debug)]
 struct Scope {
@@ -112,73 +124,45 @@ struct Scope {
 
     moved_locals: Vec<Local>,
 
-    /// The cache for drop chain on “normal” exit into a particular BasicBlock.
-    cached_exits: FxHashMap<(BasicBlock, region::Scope), BasicBlock>,
+    /// The drop index that will drop everything in and below this scope on an
+    /// unwind path.
+    cached_unwind_block: Option<DropIdx>,
 
-    /// The cache for drop chain on "generator drop" exit.
-    cached_generator_drop: Option<BasicBlock>,
-
-    /// The cache for drop chain on "unwind" exit.
-    cached_unwind: CachedBlock,
+    /// The drop index that will drop everything in and below this scope on a
+    /// generator drop path.
+    cached_generator_drop_block: Option<DropIdx>,
 }
 
-#[derive(Debug, Default)]
-crate struct Scopes<'tcx> {
-    scopes: Vec<Scope>,
-    /// The current set of breakable scopes. See module comment for more details.
-    breakable_scopes: Vec<BreakableScope<'tcx>>,
-}
-
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 struct DropData {
-    /// span where drop obligation was incurred (typically where place was declared)
-    span: Span,
+    /// The `Span` where drop obligation was incurred (typically where place was
+    /// declared)
+    source_info: SourceInfo,
 
     /// local to drop
     local: Local,
 
     /// Whether this is a value Drop or a StorageDead.
     kind: DropKind,
-
-    /// The cached blocks for unwinds.
-    cached_block: CachedBlock,
 }
 
-#[derive(Debug, Default, Clone, Copy)]
-struct CachedBlock {
-    /// The cached block for the cleanups-on-diverge path. This block
-    /// contains code to run the current drop and all the preceding
-    /// drops (i.e., those having lower index in Drop’s Scope drop
-    /// array)
-    unwind: Option<BasicBlock>,
-
-    /// The cached block for unwinds during cleanups-on-generator-drop path
-    ///
-    /// This is split from the standard unwind path here to prevent drop
-    /// elaboration from creating drop flags that would have to be captured
-    /// by the generator. I'm not sure how important this optimization is,
-    /// but it is here.
-    generator_drop: Option<BasicBlock>,
-}
-
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub(crate) enum DropKind {
     Value,
     Storage,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 struct BreakableScope<'tcx> {
     /// Region scope of the loop
     region_scope: region::Scope,
-    /// Where the body of the loop begins. `None` if block
-    continue_block: Option<BasicBlock>,
-    /// Block to branch into when the loop or block terminates (either by being
-    /// `break`-en out from, or by having its condition to become false)
-    break_block: BasicBlock,
     /// The destination of the loop/block expression itself (i.e., where to put
-    /// the result of a `break` expression)
+    /// the result of a `break` or `return` expression)
     break_destination: Place<'tcx>,
+    /// Drops that happen on the `break`/`return` path.
+    break_drops: DropTree,
+    /// Drops that happen on the `continue` path.
+    continue_drops: Option<DropTree>,
 }
 
 /// The target of an expression that breaks out of a scope
@@ -189,61 +173,33 @@ crate enum BreakableTarget {
     Return,
 }
 
-impl CachedBlock {
-    fn invalidate(&mut self) {
-        *self = CachedBlock::default();
-    }
+rustc_index::newtype_index! {
+    struct DropIdx { .. }
+}
 
-    fn get(&self, generator_drop: bool) -> Option<BasicBlock> {
-        if generator_drop { self.generator_drop } else { self.unwind }
-    }
+const ROOT_NODE: DropIdx = DropIdx::from_u32(0);
 
-    fn ref_mut(&mut self, generator_drop: bool) -> &mut Option<BasicBlock> {
-        if generator_drop { &mut self.generator_drop } else { &mut self.unwind }
-    }
+/// A tree of drops that we have deferred lowering. It's used for:
+///
+/// * Drops on unwind paths
+/// * Drops on generator drop paths (when a suspended generator is dropped)
+/// * Drops on return and loop exit paths
+///
+/// Once no more nodes could be added to the tree, we lower it to MIR in one go
+/// in `build_drop_tree`.
+#[derive(Debug)]
+struct DropTree {
+    /// Drops in the tree.
+    drops: IndexVec<DropIdx, (DropData, DropIdx)>,
+    /// Map for finding the inverse of the `next_drop` relation:
+    ///
+    /// `previous_drops[(drops[i].1, drops[i].0.local, drops[i].0.kind] == i`
+    previous_drops: FxHashMap<(DropIdx, Local, DropKind), DropIdx>,
+    /// Edges into the `DropTree` that need to be added once it's lowered.
+    entry_points: Vec<(DropIdx, BasicBlock)>,
 }
 
 impl Scope {
-    /// Invalidates all the cached blocks in the scope.
-    ///
-    /// Should always be run for all inner scopes when a drop is pushed into some scope enclosing a
-    /// larger extent of code.
-    ///
-    /// `storage_only` controls whether to invalidate only drop paths that run `StorageDead`.
-    /// `this_scope_only` controls whether to invalidate only drop paths that refer to the current
-    /// top-of-scope (as opposed to dependent scopes).
-    fn invalidate_cache(
-        &mut self,
-        storage_only: bool,
-        generator_kind: Option<GeneratorKind>,
-        this_scope_only: bool,
-    ) {
-        // FIXME: maybe do shared caching of `cached_exits` etc. to handle functions
-        // with lots of `try!`?
-
-        // cached exits drop storage and refer to the top-of-scope
-        self.cached_exits.clear();
-
-        // the current generator drop and unwind refer to top-of-scope
-        self.cached_generator_drop = None;
-
-        let ignore_unwinds = storage_only && generator_kind.is_none();
-        if !ignore_unwinds {
-            self.cached_unwind.invalidate();
-        }
-
-        if !ignore_unwinds && !this_scope_only {
-            for drop_data in &mut self.drops {
-                drop_data.cached_block.invalidate();
-            }
-        }
-    }
-
-    /// Given a span and this scope's source scope, make a SourceInfo.
-    fn source_info(&self, span: Span) -> SourceInfo {
-        SourceInfo { span, scope: self.source_scope }
-    }
-
     /// Whether there's anything to do for the cleanup path, that is,
     /// when unwinding through this scope. This includes destructors,
     /// but not StorageDead statements, which don't get emitted at all
@@ -261,11 +217,182 @@ impl Scope {
             DropKind::Storage => false,
         })
     }
+
+    fn invalidate_cache(&mut self) {
+        self.cached_unwind_block = None;
+        self.cached_generator_drop_block = None;
+    }
+}
+
+/// A trait that determined how [DropTree::lower_to_mir] creates its blocks and
+/// links to any entry nodes.
+trait DropTreeBuilder<'tcx> {
+    /// Create a new block for the tree. This should call either
+    /// `cfg.start_new_block()` or `cfg.start_new_cleanup_block()`.
+    fn make_block(cfg: &mut CFG<'tcx>) -> BasicBlock;
+
+    /// Links a block outside the drop tree, `from`, to the block `to` inside
+    /// the drop tree.
+    fn add_entry(cfg: &mut CFG<'tcx>, from: BasicBlock, to: BasicBlock);
+}
+
+impl DropTree {
+    fn new() -> Self {
+        let fake_source_info = SourceInfo::outermost(DUMMY_SP);
+        let fake_data =
+            DropData { source_info: fake_source_info, local: Local::MAX, kind: DropKind::Storage };
+        let drop_idx = DropIdx::MAX;
+        let drops = IndexVec::from_elem_n((fake_data, drop_idx), 1);
+        Self { drops, entry_points: Vec::new(), previous_drops: FxHashMap::default() }
+    }
+
+    fn add_drop(&mut self, drop: DropData, next: DropIdx) -> DropIdx {
+        let drops = &mut self.drops;
+        *self
+            .previous_drops
+            .entry((next, drop.local, drop.kind))
+            .or_insert_with(|| drops.push((drop, next)))
+    }
+
+    fn add_entry(&mut self, from: BasicBlock, to: DropIdx) {
+        debug_assert!(to < self.drops.next_index());
+        self.entry_points.push((to, from));
+    }
+
+    fn build_mir<'tcx, T: DropTreeBuilder<'tcx>>(
+        &mut self,
+        cfg: &mut CFG<'tcx>,
+        blocks: &mut IndexVec<DropIdx, Option<BasicBlock>>,
+    ) {
+        debug!("DropTree::build_mir(drops = {:#?})", self);
+        assert_eq!(blocks.len(), self.drops.len());
+
+        self.assign_blocks::<T>(cfg, blocks);
+        self.link_blocks(cfg, blocks)
+    }
+
+    /// Assign blocks for all of the drops in the drop tree that need them.
+    fn assign_blocks<'tcx, T: DropTreeBuilder<'tcx>>(
+        &mut self,
+        cfg: &mut CFG<'tcx>,
+        blocks: &mut IndexVec<DropIdx, Option<BasicBlock>>,
+    ) {
+        // StorageDead statements can share blocks with each other and also with
+        // a Drop terminator. We iterate through the blocks to find which blocks
+        // need
+        #[derive(Clone, Copy)]
+        enum Block {
+            // This drop is unreachable
+            None,
+            // This drop is only reachable through the `StorageDead` with the
+            // specified index.
+            Shares(DropIdx),
+            // This drop has more than one way of being reached, or it is
+            // branched to from outside the tree, or it's predecessor is a
+            // `Value` drop.
+            Own,
+        }
+
+        let mut needs_block = IndexVec::from_elem(Block::None, &self.drops);
+        if blocks[ROOT_NODE].is_some() {
+            // In some cases (such as drops for `continue`) the root node
+            // already has a block. In this case, make sure that we don't
+            // override it.
+            needs_block[ROOT_NODE] = Block::Own;
+        }
+
+        // Sort so that we only need to check the last
+        let entry_points = &mut self.entry_points;
+        entry_points.sort();
+
+        for (drop_idx, drop_data) in self.drops.iter_enumerated().rev() {
+            if entry_points.last().map_or(false, |entry_point| entry_point.0 == drop_idx) {
+                let block = *blocks[drop_idx].get_or_insert_with(|| T::make_block(cfg));
+                needs_block[drop_idx] = Block::Own;
+                while entry_points.last().map_or(false, |entry_point| entry_point.0 == drop_idx) {
+                    let entry_block = entry_points.pop().unwrap().1;
+                    T::add_entry(cfg, entry_block, block);
+                }
+            }
+            match needs_block[drop_idx] {
+                Block::None => continue,
+                Block::Own => {
+                    blocks[drop_idx].get_or_insert_with(|| T::make_block(cfg));
+                }
+                Block::Shares(pred) => {
+                    blocks[drop_idx] = blocks[pred];
+                }
+            }
+            if let DropKind::Value = drop_data.0.kind {
+                needs_block[drop_data.1] = Block::Own;
+            } else {
+                if drop_idx != ROOT_NODE {
+                    match &mut needs_block[drop_data.1] {
+                        pred @ Block::None => *pred = Block::Shares(drop_idx),
+                        pred @ Block::Shares(_) => *pred = Block::Own,
+                        Block::Own => (),
+                    }
+                }
+            }
+        }
+
+        debug!("assign_blocks: blocks = {:#?}", blocks);
+        assert!(entry_points.is_empty());
+    }
+
+    fn link_blocks<'tcx>(
+        &self,
+        cfg: &mut CFG<'tcx>,
+        blocks: &IndexVec<DropIdx, Option<BasicBlock>>,
+    ) {
+        for (drop_idx, drop_data) in self.drops.iter_enumerated().rev() {
+            let block = if let Some(block) = blocks[drop_idx] {
+                block
+            } else {
+                continue;
+            };
+            match drop_data.0.kind {
+                DropKind::Value => {
+                    let terminator = TerminatorKind::Drop {
+                        target: blocks[drop_data.1].unwrap(),
+                        // The caller will handle this if needed.
+                        unwind: None,
+                        location: drop_data.0.local.into(),
+                    };
+                    cfg.terminate(block, drop_data.0.source_info, terminator);
+                }
+                // Root nodes don't correspond to a drop.
+                DropKind::Storage if drop_idx == ROOT_NODE => {}
+                DropKind::Storage => {
+                    let stmt = Statement {
+                        source_info: drop_data.0.source_info,
+                        kind: StatementKind::StorageDead(drop_data.0.local),
+                    };
+                    cfg.push(block, stmt);
+                    let target = blocks[drop_data.1].unwrap();
+                    if target != block {
+                        // Diagnostics don't use this `Span` but debuginfo
+                        // might. Since we don't want breakpoints to be placed
+                        // here, especially when this is on an unwind path, we
+                        // use `DUMMY_SP`.
+                        let source_info = SourceInfo { span: DUMMY_SP, ..drop_data.0.source_info };
+                        let terminator = TerminatorKind::Goto { target };
+                        cfg.terminate(block, source_info, terminator);
+                    }
+                }
+            }
+        }
+    }
 }
 
 impl<'tcx> Scopes<'tcx> {
-    fn len(&self) -> usize {
-        self.scopes.len()
+    pub(crate) fn new() -> Self {
+        Self {
+            scopes: Vec::new(),
+            breakable_scopes: Vec::new(),
+            unwind_drops: DropTree::new(),
+            generator_drops: DropTree::new(),
+        }
     }
 
     fn push_scope(&mut self, region_scope: (region::Scope, SourceInfo), vis_scope: SourceScope) {
@@ -276,93 +403,28 @@ impl<'tcx> Scopes<'tcx> {
             region_scope_span: region_scope.1.span,
             drops: vec![],
             moved_locals: vec![],
-            cached_generator_drop: None,
-            cached_exits: Default::default(),
-            cached_unwind: CachedBlock::default(),
+            cached_unwind_block: None,
+            cached_generator_drop_block: None,
         });
     }
 
-    fn pop_scope(
-        &mut self,
-        region_scope: (region::Scope, SourceInfo),
-    ) -> (Scope, Option<BasicBlock>) {
+    fn pop_scope(&mut self, region_scope: (region::Scope, SourceInfo)) -> Scope {
         let scope = self.scopes.pop().unwrap();
         assert_eq!(scope.region_scope, region_scope.0);
-        let unwind_to =
-            self.scopes.last().and_then(|next_scope| next_scope.cached_unwind.get(false));
-        (scope, unwind_to)
+        scope
     }
 
-    fn may_panic(&self, scope_count: usize) -> bool {
-        let len = self.len();
-        self.scopes[(len - scope_count)..].iter().any(|s| s.needs_cleanup())
-    }
-
-    /// Finds the breakable scope for a given label. This is used for
-    /// resolving `return`, `break` and `continue`.
-    fn find_breakable_scope(
-        &self,
-        span: Span,
-        target: BreakableTarget,
-    ) -> (BasicBlock, region::Scope, Option<Place<'tcx>>) {
-        let get_scope = |scope: region::Scope| {
-            // find the loop-scope by its `region::Scope`.
-            self.breakable_scopes
-                .iter()
-                .rfind(|breakable_scope| breakable_scope.region_scope == scope)
-                .unwrap_or_else(|| span_bug!(span, "no enclosing breakable scope found"))
-        };
-        match target {
-            BreakableTarget::Return => {
-                let scope = &self.breakable_scopes[0];
-                if scope.break_destination != Place::return_place() {
-                    span_bug!(span, "`return` in item with no return scope");
-                }
-                (scope.break_block, scope.region_scope, Some(scope.break_destination))
-            }
-            BreakableTarget::Break(scope) => {
-                let scope = get_scope(scope);
-                (scope.break_block, scope.region_scope, Some(scope.break_destination))
-            }
-            BreakableTarget::Continue(scope) => {
-                let scope = get_scope(scope);
-                let continue_block = scope
-                    .continue_block
-                    .unwrap_or_else(|| span_bug!(span, "missing `continue` block"));
-                (continue_block, scope.region_scope, None)
-            }
-        }
-    }
-
-    fn num_scopes_above(&self, region_scope: region::Scope, span: Span) -> usize {
-        let scope_count = self
-            .scopes
+    fn scope_index(&self, region_scope: region::Scope, span: Span) -> usize {
+        self.scopes
             .iter()
-            .rev()
-            .position(|scope| scope.region_scope == region_scope)
-            .unwrap_or_else(|| span_bug!(span, "region_scope {:?} does not enclose", region_scope));
-        let len = self.len();
-        assert!(scope_count < len, "should not use `exit_scope` to pop ALL scopes");
-        scope_count
-    }
-
-    fn iter_mut(&mut self) -> impl DoubleEndedIterator<Item = &mut Scope> + '_ {
-        self.scopes.iter_mut().rev()
-    }
-
-    fn top_scopes(&mut self, count: usize) -> impl DoubleEndedIterator<Item = &mut Scope> + '_ {
-        let len = self.len();
-        self.scopes[len - count..].iter_mut()
+            .rposition(|scope| scope.region_scope == region_scope)
+            .unwrap_or_else(|| span_bug!(span, "region_scope {:?} does not enclose", region_scope))
     }
 
     /// Returns the topmost active scope, which is known to be alive until
     /// the next scope expression.
-    pub(super) fn topmost(&self) -> region::Scope {
+    fn topmost(&self) -> region::Scope {
         self.scopes.last().expect("topmost_scope: no scopes present").region_scope
-    }
-
-    fn source_info(&self, index: usize, span: Span) -> SourceInfo {
-        self.scopes[self.len() - index].source_info(span)
     }
 }
 
@@ -371,28 +433,50 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
     // ==========================
     //  Start a breakable scope, which tracks where `continue`, `break` and
     //  `return` should branch to.
-    crate fn in_breakable_scope<F, R>(
+    crate fn in_breakable_scope<F>(
         &mut self,
         loop_block: Option<BasicBlock>,
-        break_block: BasicBlock,
         break_destination: Place<'tcx>,
+        span: Span,
         f: F,
-    ) -> R
+    ) -> BlockAnd<()>
     where
-        F: FnOnce(&mut Builder<'a, 'tcx>) -> R,
+        F: FnOnce(&mut Builder<'a, 'tcx>) -> Option<BlockAnd<()>>,
     {
         let region_scope = self.scopes.topmost();
         let scope = BreakableScope {
             region_scope,
-            continue_block: loop_block,
-            break_block,
             break_destination,
+            break_drops: DropTree::new(),
+            continue_drops: loop_block.map(|_| DropTree::new()),
         };
         self.scopes.breakable_scopes.push(scope);
-        let res = f(self);
+        let normal_exit_block = f(self);
         let breakable_scope = self.scopes.breakable_scopes.pop().unwrap();
         assert!(breakable_scope.region_scope == region_scope);
-        res
+        let break_block = self.build_exit_tree(breakable_scope.break_drops, None);
+        breakable_scope.continue_drops.map(|drops| {
+            self.build_exit_tree(drops, loop_block);
+        });
+        match (normal_exit_block, break_block) {
+            (Some(block), None) | (None, Some(block)) => block,
+            (None, None) => self.cfg.start_new_block().unit(),
+            (Some(normal_block), Some(exit_block)) => {
+                let target = self.cfg.start_new_block();
+                let source_info = self.source_info(span);
+                self.cfg.terminate(
+                    unpack!(normal_block),
+                    source_info,
+                    TerminatorKind::Goto { target },
+                );
+                self.cfg.terminate(
+                    unpack!(exit_block),
+                    source_info,
+                    TerminatorKind::Goto { target },
+                );
+                target.unit()
+            }
+        }
     }
 
     crate fn in_opt_scope<F, R>(
@@ -476,46 +560,51 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         mut block: BasicBlock,
     ) -> BlockAnd<()> {
         debug!("pop_scope({:?}, {:?})", region_scope, block);
-        // If we are emitting a `drop` statement, we need to have the cached
-        // diverge cleanup pads ready in case that drop panics.
-        if self.scopes.may_panic(1) {
-            self.diverge_cleanup();
-        }
-        let (scope, unwind_to) = self.scopes.pop_scope(region_scope);
-        let unwind_to = unwind_to.unwrap_or_else(|| self.resume_block());
 
-        unpack!(
-            block = build_scope_drops(
-                &mut self.cfg,
-                self.generator_kind,
-                &scope,
-                block,
-                unwind_to,
-                self.arg_count,
-                false, // not generator
-                false, // not unwind path
-            )
-        );
+        block = self.leave_top_scope(block);
+
+        self.scopes.pop_scope(region_scope);
 
         block.unit()
     }
 
+    /// Sets up the drops for breaking from `block` to `target`.
     crate fn break_scope(
         &mut self,
         mut block: BasicBlock,
         value: Option<ExprRef<'tcx>>,
-        scope: BreakableTarget,
+        target: BreakableTarget,
         source_info: SourceInfo,
     ) -> BlockAnd<()> {
-        let (mut target_block, region_scope, destination) =
-            self.scopes.find_breakable_scope(source_info.span, scope);
-        if let BreakableTarget::Return = scope {
-            // We call this now, rather than when we start lowering the
-            // function so that the return block doesn't precede the entire
-            // rest of the CFG. Some passes and LLVM prefer blocks to be in
-            // approximately CFG order.
-            target_block = self.return_block();
-        }
+        let span = source_info.span;
+
+        let get_scope_index = |scope: region::Scope| {
+            // find the loop-scope by its `region::Scope`.
+            self.scopes
+                .breakable_scopes
+                .iter()
+                .rposition(|breakable_scope| breakable_scope.region_scope == scope)
+                .unwrap_or_else(|| span_bug!(span, "no enclosing breakable scope found"))
+        };
+        let (break_index, destination) = match target {
+            BreakableTarget::Return => {
+                let scope = &self.scopes.breakable_scopes[0];
+                if scope.break_destination != Place::return_place() {
+                    span_bug!(span, "`return` in item with no return scope");
+                }
+                (0, Some(scope.break_destination))
+            }
+            BreakableTarget::Break(scope) => {
+                let break_index = get_scope_index(scope);
+                let scope = &self.scopes.breakable_scopes[break_index];
+                (break_index, Some(scope.break_destination))
+            }
+            BreakableTarget::Continue(scope) => {
+                let break_index = get_scope_index(scope);
+                (break_index, None)
+            }
+        };
+
         if let Some(destination) = destination {
             if let Some(value) = value {
                 debug!("stmt_expr Break val block_context.push(SubExpr)");
@@ -528,131 +617,57 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         } else {
             assert!(value.is_none(), "`return` and `break` should have a destination");
         }
-        self.exit_scope(source_info.span, region_scope, block, target_block);
+
+        let region_scope = self.scopes.breakable_scopes[break_index].region_scope;
+        let scope_index = self.scopes.scope_index(region_scope, span);
+        let drops = if destination.is_some() {
+            &mut self.scopes.breakable_scopes[break_index].break_drops
+        } else {
+            self.scopes.breakable_scopes[break_index].continue_drops.as_mut().unwrap()
+        };
+        let mut drop_idx = ROOT_NODE;
+        for scope in &self.scopes.scopes[scope_index + 1..] {
+            for drop in &scope.drops {
+                drop_idx = drops.add_drop(*drop, drop_idx);
+            }
+        }
+        drops.add_entry(block, drop_idx);
+
+        // `build_drop_tree` doesn't have access to our source_info, so we
+        // create a dummy terminator now. `TerminatorKind::Resume` is used
+        // because MIR type checking will panic if it hasn't been overwritten.
+        self.cfg.terminate(block, source_info, TerminatorKind::Resume);
+
         self.cfg.start_new_block().unit()
     }
 
-    /// Branch out of `block` to `target`, exiting all scopes up to
-    /// and including `region_scope`. This will insert whatever drops are
-    /// needed. See module comment for details.
-    crate fn exit_scope(
+    crate fn exit_top_scope(
         &mut self,
-        span: Span,
-        region_scope: region::Scope,
         mut block: BasicBlock,
         target: BasicBlock,
+        source_info: SourceInfo,
     ) {
-        debug!(
-            "exit_scope(region_scope={:?}, block={:?}, target={:?})",
-            region_scope, block, target
-        );
-        let scope_count = self.scopes.num_scopes_above(region_scope, span);
-
-        // If we are emitting a `drop` statement, we need to have the cached
-        // diverge cleanup pads ready in case that drop panics.
-        let may_panic = self.scopes.may_panic(scope_count);
-        if may_panic {
-            self.diverge_cleanup();
-        }
-
-        let mut scopes = self.scopes.top_scopes(scope_count + 1).rev();
-        let mut scope = scopes.next().unwrap();
-        for next_scope in scopes {
-            if scope.drops.is_empty() {
-                scope = next_scope;
-                continue;
-            }
-            let source_info = scope.source_info(span);
-            block = match scope.cached_exits.entry((target, region_scope)) {
-                Entry::Occupied(e) => {
-                    self.cfg.goto(block, source_info, *e.get());
-                    return;
-                }
-                Entry::Vacant(v) => {
-                    let b = self.cfg.start_new_block();
-                    self.cfg.goto(block, source_info, b);
-                    v.insert(b);
-                    b
-                }
-            };
-
-            let unwind_to = next_scope.cached_unwind.get(false).unwrap_or_else(|| {
-                debug_assert!(!may_panic, "cached block not present?");
-                START_BLOCK
-            });
-
-            unpack!(
-                block = build_scope_drops(
-                    &mut self.cfg,
-                    self.generator_kind,
-                    scope,
-                    block,
-                    unwind_to,
-                    self.arg_count,
-                    false, // not generator
-                    false, // not unwind path
-                )
-            );
-
-            scope = next_scope;
-        }
-
-        self.cfg.goto(block, self.scopes.source_info(scope_count, span), target);
+        block = self.leave_top_scope(block);
+        self.cfg.terminate(block, source_info, TerminatorKind::Goto { target });
     }
 
-    /// Creates a path that performs all required cleanup for dropping a generator.
-    ///
-    /// This path terminates in GeneratorDrop. Returns the start of the path.
-    /// None indicates there’s no cleanup to do at this point.
-    crate fn generator_drop_cleanup(&mut self) -> Option<BasicBlock> {
-        // Fill in the cache for unwinds
-        self.diverge_cleanup_gen(true);
+    fn leave_top_scope(&mut self, block: BasicBlock) -> BasicBlock {
+        // If we are emitting a `drop` statement, we need to have the cached
+        // diverge cleanup pads ready in case that drop panics.
+        let needs_cleanup = self.scopes.scopes.last().map_or(false, |scope| scope.needs_cleanup());
+        let is_generator = self.generator_kind.is_some();
+        let unwind_to = if needs_cleanup { self.diverge_cleanup() } else { DropIdx::MAX };
 
-        let src_info = self.scopes.source_info(self.scopes.len(), self.fn_span);
-        let resume_block = self.resume_block();
-        let mut scopes = self.scopes.iter_mut().peekable();
-        let mut block = self.cfg.start_new_block();
-        let result = block;
-
-        while let Some(scope) = scopes.next() {
-            block = if let Some(b) = scope.cached_generator_drop {
-                self.cfg.goto(block, src_info, b);
-                return Some(result);
-            } else {
-                let b = self.cfg.start_new_block();
-                scope.cached_generator_drop = Some(b);
-                self.cfg.goto(block, src_info, b);
-                b
-            };
-
-            let unwind_to = scopes
-                .peek()
-                .as_ref()
-                .map(|scope| {
-                    scope
-                        .cached_unwind
-                        .get(true)
-                        .unwrap_or_else(|| span_bug!(src_info.span, "cached block not present?"))
-                })
-                .unwrap_or(resume_block);
-
-            unpack!(
-                block = build_scope_drops(
-                    &mut self.cfg,
-                    self.generator_kind,
-                    scope,
-                    block,
-                    unwind_to,
-                    self.arg_count,
-                    true, // is generator
-                    true, // is cached path
-                )
-            );
-        }
-
-        self.cfg.terminate(block, src_info, TerminatorKind::GeneratorDrop);
-
-        Some(result)
+        let scope = self.scopes.scopes.last().expect("leave_top_scope called with no scopes");
+        unpack!(build_scope_drops(
+            &mut self.cfg,
+            &mut self.scopes.unwind_drops,
+            scope,
+            block,
+            unwind_to,
+            is_generator && needs_cleanup,
+            self.arg_count,
+        ))
     }
 
     /// Creates a new source scope, nested in the current one.
@@ -728,15 +743,6 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         }
     }
 
-    // Schedule an abort block - this is used for some ABIs that cannot unwind
-    crate fn schedule_abort(&mut self) -> BasicBlock {
-        let source_info = self.scopes.source_info(self.scopes.len(), self.fn_span);
-        let abortblk = self.cfg.start_new_cleanup_block();
-        self.cfg.terminate(abortblk, source_info, TerminatorKind::Abort);
-        self.cached_resume_block = Some(abortblk);
-        abortblk
-    }
-
     // Scheduling drops
     // ================
     crate fn schedule_drop_storage_and_value(
@@ -749,11 +755,10 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         self.schedule_drop(span, region_scope, local, DropKind::Value);
     }
 
-    /// Indicates that `place` should be dropped on exit from
-    /// `region_scope`.
+    /// Indicates that `place` should be dropped on exit from `region_scope`.
     ///
-    /// When called with `DropKind::Storage`, `place` should be a local
-    /// with an index higher than the current `self.arg_count`.
+    /// When called with `DropKind::Storage`, `place` shouldn't be the return
+    /// place, or a function parameter.
     crate fn schedule_drop(
         &mut self,
         span: Span,
@@ -781,70 +786,74 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             }
         };
 
-        for scope in self.scopes.iter_mut() {
-            let this_scope = scope.region_scope == region_scope;
-            // When building drops, we try to cache chains of drops in such a way so these drops
-            // could be reused by the drops which would branch into the cached (already built)
-            // blocks.  This, however, means that whenever we add a drop into a scope which already
-            // had some blocks built (and thus, cached) for it, we must invalidate all caches which
-            // might branch into the scope which had a drop just added to it. This is necessary,
-            // because otherwise some other code might use the cache to branch into already built
-            // chain of drops, essentially ignoring the newly added drop.
-            //
-            // For example consider there’s two scopes with a drop in each. These are built and
-            // thus the caches are filled:
-            //
-            // +--------------------------------------------------------+
-            // | +---------------------------------+                    |
-            // | | +--------+     +-------------+  |  +---------------+ |
-            // | | | return | <-+ | drop(outer) | <-+ |  drop(middle) | |
-            // | | +--------+     +-------------+  |  +---------------+ |
-            // | +------------|outer_scope cache|--+                    |
-            // +------------------------------|middle_scope cache|------+
-            //
-            // Now, a new, inner-most scope is added along with a new drop into both inner-most and
-            // outer-most scopes:
-            //
-            // +------------------------------------------------------------+
-            // | +----------------------------------+                       |
-            // | | +--------+      +-------------+  |   +---------------+   | +-------------+
-            // | | | return | <+   | drop(new)   | <-+  |  drop(middle) | <--+| drop(inner) |
-            // | | +--------+  |   | drop(outer) |  |   +---------------+   | +-------------+
-            // | |             +-+ +-------------+  |                       |
-            // | +---|invalid outer_scope cache|----+                       |
-            // +----=----------------|invalid middle_scope cache|-----------+
-            //
-            // If, when adding `drop(new)` we do not invalidate the cached blocks for both
-            // outer_scope and middle_scope, then, when building drops for the inner (right-most)
-            // scope, the old, cached blocks, without `drop(new)` will get used, producing the
-            // wrong results.
-            //
-            // The cache and its invalidation for unwind branch is somewhat special. The cache is
-            // per-drop, rather than per scope, which has a several different implications. Adding
-            // a new drop into a scope will not invalidate cached blocks of the prior drops in the
-            // scope. That is true, because none of the already existing drops will have an edge
-            // into a block with the newly added drop.
-            //
-            // Note that this code iterates scopes from the inner-most to the outer-most,
-            // invalidating caches of each scope visited. This way bare minimum of the
-            // caches gets invalidated. i.e., if a new drop is added into the middle scope, the
-            // cache of outer scope stays intact.
-            scope.invalidate_cache(!needs_drop, self.generator_kind, this_scope);
-            if this_scope {
+        // When building drops, we try to cache chains of drops to reduce the
+        // number of `DropTree::add_drop` calls. This, however, means that
+        // whenever we add a drop into a scope which already had some entries
+        // in the drop tree built (and thus, cached) for it, we must invalidate
+        // all caches which might branch into the scope which had a drop just
+        // added to it. This is necessary, because otherwise some other code
+        // might use the cache to branch into already built chain of drops,
+        // essentially ignoring the newly added drop.
+        //
+        // For example consider there’s two scopes with a drop in each. These
+        // are built and thus the caches are filled:
+        //
+        // +--------------------------------------------------------+
+        // | +---------------------------------+                    |
+        // | | +--------+     +-------------+  |  +---------------+ |
+        // | | | return | <-+ | drop(outer) | <-+ |  drop(middle) | |
+        // | | +--------+     +-------------+  |  +---------------+ |
+        // | +------------|outer_scope cache|--+                    |
+        // +------------------------------|middle_scope cache|------+
+        //
+        // Now, a new, inner-most scope is added along with a new drop into
+        // both inner-most and outer-most scopes:
+        //
+        // +------------------------------------------------------------+
+        // | +----------------------------------+                       |
+        // | | +--------+      +-------------+  |   +---------------+   | +-------------+
+        // | | | return | <+   | drop(new)   | <-+  |  drop(middle) | <--+| drop(inner) |
+        // | | +--------+  |   | drop(outer) |  |   +---------------+   | +-------------+
+        // | |             +-+ +-------------+  |                       |
+        // | +---|invalid outer_scope cache|----+                       |
+        // +----=----------------|invalid middle_scope cache|-----------+
+        //
+        // If, when adding `drop(new)` we do not invalidate the cached blocks for both
+        // outer_scope and middle_scope, then, when building drops for the inner (right-most)
+        // scope, the old, cached blocks, without `drop(new)` will get used, producing the
+        // wrong results.
+        //
+        // Note that this code iterates scopes from the inner-most to the outer-most,
+        // invalidating caches of each scope visited. This way bare minimum of the
+        // caches gets invalidated. i.e., if a new drop is added into the middle scope, the
+        // cache of outer scope stays intact.
+        //
+        // Since we only cache drops for the unwind path and the generator drop
+        // path, we only need to invalidate the cache for drops that happen on
+        // the unwind or generator drop paths. This means that for
+        // non-generators we don't need to invalidate caches for `DropKind::Storage`.
+        let invalidate_caches = needs_drop || self.generator_kind.is_some();
+        for scope in self.scopes.scopes.iter_mut().rev() {
+            if invalidate_caches {
+                scope.invalidate_cache();
+            }
+
+            if scope.region_scope == region_scope {
                 let region_scope_span =
                     region_scope.span(self.hir.tcx(), &self.hir.region_scope_tree);
                 // Attribute scope exit drops to scope's closing brace.
                 let scope_end = self.hir.tcx().sess.source_map().end_point(region_scope_span);
 
                 scope.drops.push(DropData {
-                    span: scope_end,
+                    source_info: SourceInfo { span: scope_end, scope: scope.source_scope },
                     local,
                     kind: drop_kind,
-                    cached_block: CachedBlock::default(),
                 });
+
                 return;
             }
         }
+
         span_bug!(span, "region scope {:?} not in scope to drop {:?}", region_scope, local);
     }
 
@@ -893,8 +902,9 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
 
             Some(local_scope) => self
                 .scopes
+                .scopes
                 .iter_mut()
-                .find(|scope| scope.region_scope == local_scope)
+                .rfind(|scope| scope.region_scope == local_scope)
                 .unwrap_or_else(|| bug!("scope {:?} not found in scope list!", local_scope)),
         };
 
@@ -944,13 +954,16 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     // Manually drop the condition on both branches.
                     let top_scope = self.scopes.scopes.last_mut().unwrap();
                     let top_drop_data = top_scope.drops.pop().unwrap();
+                    if self.generator_kind.is_some() {
+                        top_scope.invalidate_cache();
+                    }
 
                     match top_drop_data.kind {
                         DropKind::Value { .. } => {
                             bug!("Drop scheduled on top of condition variable")
                         }
                         DropKind::Storage => {
-                            let source_info = top_scope.source_info(top_drop_data.span);
+                            let source_info = top_drop_data.source_info;
                             let local = top_drop_data.local;
                             assert_eq!(local, cond_temp, "Drop scheduled on top of condition");
                             self.cfg.push(
@@ -963,8 +976,6 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                             );
                         }
                     }
-
-                    top_scope.invalidate_cache(true, self.generator_kind, true);
                 } else {
                     bug!("Expected as_local_operand to produce a temporary");
                 }
@@ -974,62 +985,86 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         (true_block, false_block)
     }
 
-    /// Creates a path that performs all required cleanup for unwinding.
+    /// Returns the [DropIdx] for the innermost drop if the function unwound at
+    /// this point. The `DropIdx` will be created if it doesn't already exist.
+    fn diverge_cleanup(&mut self) -> DropIdx {
+        let is_generator = self.generator_kind.is_some();
+        let (uncached_scope, mut cached_drop) = self
+            .scopes
+            .scopes
+            .iter()
+            .enumerate()
+            .rev()
+            .find_map(|(scope_idx, scope)| {
+                scope.cached_unwind_block.map(|cached_block| (scope_idx + 1, cached_block))
+            })
+            .unwrap_or((0, ROOT_NODE));
+
+        for scope in &mut self.scopes.scopes[uncached_scope..] {
+            for drop in &scope.drops {
+                if is_generator || drop.kind == DropKind::Value {
+                    cached_drop = self.scopes.unwind_drops.add_drop(*drop, cached_drop);
+                }
+            }
+            scope.cached_unwind_block = Some(cached_drop);
+        }
+
+        cached_drop
+    }
+
+    /// Prepares to create a path that performs all required cleanup for a
+    /// terminator that can unwind at the given basic block.
     ///
-    /// This path terminates in Resume. Returns the start of the path.
-    /// See module comment for more details.
-    crate fn diverge_cleanup(&mut self) -> BasicBlock {
-        self.diverge_cleanup_gen(false)
+    /// This path terminates in Resume. The path isn't created until after all
+    /// of the non-unwind paths in this item have been lowered.
+    crate fn diverge_from(&mut self, start: BasicBlock) {
+        debug_assert!(
+            matches!(
+                self.cfg.block_data(start).terminator().kind,
+                TerminatorKind::Assert { .. }
+                | TerminatorKind::Call {..}
+                | TerminatorKind::DropAndReplace { .. }
+                | TerminatorKind::FalseUnwind { .. }
+            ),
+            "diverge_from called on block with terminator that cannot unwind."
+        );
+
+        let next_drop = self.diverge_cleanup();
+        self.scopes.unwind_drops.add_entry(start, next_drop);
     }
 
-    fn resume_block(&mut self) -> BasicBlock {
-        if let Some(target) = self.cached_resume_block {
-            target
-        } else {
-            let resumeblk = self.cfg.start_new_cleanup_block();
-            self.cfg.terminate(
-                resumeblk,
-                SourceInfo::outermost(self.fn_span),
-                TerminatorKind::Resume,
-            );
-            self.cached_resume_block = Some(resumeblk);
-            resumeblk
-        }
-    }
+    /// Sets up a path that performs all required cleanup for dropping a
+    /// generator, starting from the given block that ends in
+    /// [TerminatorKind::Yield].
+    ///
+    /// This path terminates in GeneratorDrop.
+    crate fn generator_drop_cleanup(&mut self, yield_block: BasicBlock) {
+        debug_assert!(
+            matches!(
+                self.cfg.block_data(yield_block).terminator().kind,
+                TerminatorKind::Yield { .. }
+            ),
+            "generator_drop_cleanup called on block with non-yield terminator."
+        );
+        let (uncached_scope, mut cached_drop) = self
+            .scopes
+            .scopes
+            .iter()
+            .enumerate()
+            .rev()
+            .find_map(|(scope_idx, scope)| {
+                scope.cached_generator_drop_block.map(|cached_block| (scope_idx + 1, cached_block))
+            })
+            .unwrap_or((0, ROOT_NODE));
 
-    fn diverge_cleanup_gen(&mut self, generator_drop: bool) -> BasicBlock {
-        // Build up the drops in **reverse** order. The end result will
-        // look like:
-        //
-        //    scopes[n] -> scopes[n-1] -> ... -> scopes[0]
-        //
-        // However, we build this in **reverse order**. That is, we
-        // process scopes[0], then scopes[1], etc, pointing each one at
-        // the result generates from the one before. Along the way, we
-        // store caches. If everything is cached, we'll just walk right
-        // to left reading the cached results but never created anything.
-
-        // Find the last cached block
-        debug!("diverge_cleanup_gen(self.scopes = {:?})", self.scopes);
-        let cached_cleanup = self.scopes.iter_mut().enumerate().find_map(|(idx, ref scope)| {
-            let cached_block = scope.cached_unwind.get(generator_drop)?;
-            Some((cached_block, idx))
-        });
-        let (mut target, first_uncached) =
-            cached_cleanup.unwrap_or_else(|| (self.resume_block(), self.scopes.len()));
-
-        for scope in self.scopes.top_scopes(first_uncached) {
-            target = build_diverge_scope(
-                &mut self.cfg,
-                scope.region_scope_span,
-                scope,
-                target,
-                generator_drop,
-                self.generator_kind,
-            );
+        for scope in &mut self.scopes.scopes[uncached_scope..] {
+            for drop in &scope.drops {
+                cached_drop = self.scopes.generator_drops.add_drop(*drop, cached_drop);
+            }
+            scope.cached_generator_drop_block = Some(cached_drop);
         }
 
-        target
+        self.scopes.generator_drops.add_entry(yield_block, cached_drop);
     }
 
     /// Utility function for *non*-scope code to build their own drops
@@ -1042,21 +1077,18 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
     ) -> BlockAnd<()> {
         let source_info = self.source_info(span);
         let next_target = self.cfg.start_new_block();
-        let diverge_target = self.diverge_cleanup();
+
         self.cfg.terminate(
             block,
             source_info,
-            TerminatorKind::DropAndReplace {
-                place,
-                value,
-                target: next_target,
-                unwind: Some(diverge_target),
-            },
+            TerminatorKind::DropAndReplace { place, value, target: next_target, unwind: None },
         );
+        self.diverge_from(block);
+
         next_target.unit()
     }
 
-    /// Creates an Assert terminator and return the success block.
+    /// Creates an `Assert` terminator and return the success block.
     /// If the boolean condition operand is not the expected value,
     /// a runtime panic will be caused with the given message.
     crate fn assert(
@@ -1068,51 +1100,41 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         span: Span,
     ) -> BasicBlock {
         let source_info = self.source_info(span);
-
         let success_block = self.cfg.start_new_block();
-        let cleanup = self.diverge_cleanup();
 
         self.cfg.terminate(
             block,
             source_info,
-            TerminatorKind::Assert {
-                cond,
-                expected,
-                msg,
-                target: success_block,
-                cleanup: Some(cleanup),
-            },
+            TerminatorKind::Assert { cond, expected, msg, target: success_block, cleanup: None },
         );
+        self.diverge_from(block);
 
         success_block
     }
 
-    // `match` arm scopes
-    // ==================
     /// Unschedules any drops in the top scope.
     ///
     /// This is only needed for `match` arm scopes, because they have one
     /// entrance per pattern, but only one exit.
-    pub(crate) fn clear_top_scope(&mut self, region_scope: region::Scope) {
+    crate fn clear_top_scope(&mut self, region_scope: region::Scope) {
         let top_scope = self.scopes.scopes.last_mut().unwrap();
 
         assert_eq!(top_scope.region_scope, region_scope);
 
         top_scope.drops.clear();
-        top_scope.invalidate_cache(false, self.generator_kind, true);
+        top_scope.invalidate_cache();
     }
 }
 
-/// Builds drops for pop_scope and exit_scope.
+/// Builds drops for `pop_scope` and `leave_top_scope`.
 fn build_scope_drops<'tcx>(
     cfg: &mut CFG<'tcx>,
-    generator_kind: Option<GeneratorKind>,
+    unwind_drops: &mut DropTree,
     scope: &Scope,
     mut block: BasicBlock,
-    last_unwind_to: BasicBlock,
+    mut unwind_to: DropIdx,
+    storage_dead_on_unwind: bool,
     arg_count: usize,
-    generator_drop: bool,
-    is_cached_path: bool,
 ) -> BlockAnd<()> {
     debug!("build_scope_drops({:?} -> {:?})", block, scope);
 
@@ -1135,37 +1157,43 @@ fn build_scope_drops<'tcx>(
     // drops for the unwind path should have already been generated by
     // `diverge_cleanup_gen`.
 
-    for drop_idx in (0..scope.drops.len()).rev() {
-        let drop_data = &scope.drops[drop_idx];
-        let source_info = scope.source_info(drop_data.span);
+    for drop_data in scope.drops.iter().rev() {
+        let source_info = drop_data.source_info;
         let local = drop_data.local;
 
         match drop_data.kind {
             DropKind::Value => {
+                // `unwind_to` should drop the value that we're about to
+                // schedule. If dropping this value panics, then we continue
+                // with the *next* value on the unwind path.
+                debug_assert_eq!(unwind_drops.drops[unwind_to].0.local, drop_data.local);
+                debug_assert_eq!(unwind_drops.drops[unwind_to].0.kind, drop_data.kind);
+                unwind_to = unwind_drops.drops[unwind_to].1;
+
                 // If the operand has been moved, and we are not on an unwind
                 // path, then don't generate the drop. (We only take this into
                 // account for non-unwind paths so as not to disturb the
                 // caching mechanism.)
-                if !is_cached_path && scope.moved_locals.iter().any(|&o| o == local) {
+                if scope.moved_locals.iter().any(|&o| o == local) {
                     continue;
                 }
 
-                let unwind_to = get_unwind_to(scope, generator_kind, drop_idx, generator_drop)
-                    .unwrap_or(last_unwind_to);
+                unwind_drops.add_entry(block, unwind_to);
 
                 let next = cfg.start_new_block();
                 cfg.terminate(
                     block,
                     source_info,
-                    TerminatorKind::Drop {
-                        place: local.into(),
-                        target: next,
-                        unwind: Some(unwind_to),
-                    },
+                    TerminatorKind::Drop { place: local.into(), target: next, unwind: None },
                 );
                 block = next;
             }
             DropKind::Storage => {
+                if storage_dead_on_unwind {
+                    debug_assert_eq!(unwind_drops.drops[unwind_to].0.local, drop_data.local);
+                    debug_assert_eq!(unwind_drops.drops[unwind_to].0.kind, drop_data.kind);
+                    unwind_to = unwind_drops.drops[unwind_to].1;
+                }
                 // Only temps and vars need their storage dead.
                 assert!(local.index() > arg_count);
                 cfg.push(block, Statement { source_info, kind: StatementKind::StorageDead(local) });
@@ -1175,139 +1203,180 @@ fn build_scope_drops<'tcx>(
     block.unit()
 }
 
-fn get_unwind_to(
-    scope: &Scope,
-    generator_kind: Option<GeneratorKind>,
-    unwind_from: usize,
-    generator_drop: bool,
-) -> Option<BasicBlock> {
-    for drop_idx in (0..unwind_from).rev() {
-        let drop_data = &scope.drops[drop_idx];
-        match (generator_kind, &drop_data.kind) {
-            (Some(_), DropKind::Storage) => {
-                return Some(drop_data.cached_block.get(generator_drop).unwrap_or_else(|| {
-                    span_bug!(drop_data.span, "cached block not present for {:?}", drop_data)
-                }));
+impl<'a, 'tcx: 'a> Builder<'a, 'tcx> {
+    /// Build a drop tree for a breakable scope.
+    ///
+    /// If `continue_block` is `Some`, then the tree is for `continue` inside a
+    /// loop. Otherwise this is for `break` or `return`.
+    fn build_exit_tree(
+        &mut self,
+        mut drops: DropTree,
+        continue_block: Option<BasicBlock>,
+    ) -> Option<BlockAnd<()>> {
+        let mut blocks = IndexVec::from_elem(None, &drops.drops);
+        blocks[ROOT_NODE] = continue_block;
+
+        drops.build_mir::<ExitScopes>(&mut self.cfg, &mut blocks);
+
+        // Link the exit drop tree to unwind drop tree.
+        if drops.drops.iter().any(|(drop, _)| drop.kind == DropKind::Value) {
+            let unwind_target = self.diverge_cleanup();
+            let mut unwind_indices = IndexVec::from_elem_n(unwind_target, 1);
+            for (drop_idx, drop_data) in drops.drops.iter_enumerated().skip(1) {
+                match drop_data.0.kind {
+                    DropKind::Storage => {
+                        if self.generator_kind.is_some() {
+                            let unwind_drop = self
+                                .scopes
+                                .unwind_drops
+                                .add_drop(drop_data.0, unwind_indices[drop_data.1]);
+                            unwind_indices.push(unwind_drop);
+                        } else {
+                            unwind_indices.push(unwind_indices[drop_data.1]);
+                        }
+                    }
+                    DropKind::Value => {
+                        let unwind_drop = self
+                            .scopes
+                            .unwind_drops
+                            .add_drop(drop_data.0, unwind_indices[drop_data.1]);
+                        self.scopes
+                            .unwind_drops
+                            .add_entry(blocks[drop_idx].unwrap(), unwind_indices[drop_data.1]);
+                        unwind_indices.push(unwind_drop);
+                    }
+                }
             }
-            (None, DropKind::Value) => {
-                return Some(drop_data.cached_block.get(generator_drop).unwrap_or_else(|| {
-                    span_bug!(drop_data.span, "cached block not present for {:?}", drop_data)
-                }));
-            }
-            _ => (),
+        }
+        blocks[ROOT_NODE].map(BasicBlock::unit)
+    }
+
+    /// Build the unwind and generator drop trees.
+    crate fn build_drop_trees(&mut self, should_abort: bool) {
+        if self.generator_kind.is_some() {
+            self.build_generator_drop_trees(should_abort);
+        } else {
+            Self::build_unwind_tree(
+                &mut self.cfg,
+                &mut self.scopes.unwind_drops,
+                self.fn_span,
+                should_abort,
+                &mut None,
+            );
         }
     }
-    None
+
+    fn build_generator_drop_trees(&mut self, should_abort: bool) {
+        // Build the drop tree for dropping the generator while it's suspended.
+        let drops = &mut self.scopes.generator_drops;
+        let cfg = &mut self.cfg;
+        let fn_span = self.fn_span;
+        let mut blocks = IndexVec::from_elem(None, &drops.drops);
+        drops.build_mir::<GeneratorDrop>(cfg, &mut blocks);
+        if let Some(root_block) = blocks[ROOT_NODE] {
+            cfg.terminate(
+                root_block,
+                SourceInfo::outermost(fn_span),
+                TerminatorKind::GeneratorDrop,
+            );
+        }
+
+        // Build the drop tree for unwinding in the normal control flow paths.
+        let resume_block = &mut None;
+        let unwind_drops = &mut self.scopes.unwind_drops;
+        Self::build_unwind_tree(cfg, unwind_drops, fn_span, should_abort, resume_block);
+
+        // Build the drop tree for unwinding when dropping a suspended
+        // generator.
+        //
+        // This is a different tree to the standard unwind paths here to
+        // prevent drop elaboration from creating drop flags that would have
+        // to be captured by the generator. I'm not sure how important this
+        // optimization is, but it is here.
+        for (drop_idx, drop_data) in drops.drops.iter_enumerated() {
+            if let DropKind::Value = drop_data.0.kind {
+                debug_assert!(drop_data.1 < drops.drops.next_index());
+                drops.entry_points.push((drop_data.1, blocks[drop_idx].unwrap()));
+            }
+        }
+        Self::build_unwind_tree(cfg, drops, fn_span, should_abort, resume_block);
+    }
+
+    fn build_unwind_tree(
+        cfg: &mut CFG<'tcx>,
+        drops: &mut DropTree,
+        fn_span: Span,
+        should_abort: bool,
+        resume_block: &mut Option<BasicBlock>,
+    ) {
+        let mut blocks = IndexVec::from_elem(None, &drops.drops);
+        blocks[ROOT_NODE] = *resume_block;
+        drops.build_mir::<Unwind>(cfg, &mut blocks);
+        if let (None, Some(resume)) = (*resume_block, blocks[ROOT_NODE]) {
+            // `TerminatorKind::Abort` is used for `#[unwind(aborts)]`
+            // functions.
+            let terminator =
+                if should_abort { TerminatorKind::Abort } else { TerminatorKind::Resume };
+
+            cfg.terminate(resume, SourceInfo::outermost(fn_span), terminator);
+
+            *resume_block = blocks[ROOT_NODE];
+        }
+    }
 }
 
-fn build_diverge_scope<'tcx>(
-    cfg: &mut CFG<'tcx>,
-    span: Span,
-    scope: &mut Scope,
-    mut target: BasicBlock,
-    generator_drop: bool,
-    generator_kind: Option<GeneratorKind>,
-) -> BasicBlock {
-    // Build up the drops in **reverse** order. The end result will
-    // look like:
-    //
-    //    [drops[n]] -...-> [drops[0]] -> [target]
-    //
-    // The code in this function reads from right to left. At each
-    // point, we check for cached blocks representing the
-    // remainder. If everything is cached, we'll just walk right to
-    // left reading the cached results but never create anything.
+// DropTreeBuilder implementations.
 
-    let source_scope = scope.source_scope;
-    let source_info = |span| SourceInfo { span, scope: source_scope };
+struct ExitScopes;
 
-    // We keep track of StorageDead statements to prepend to our current block
-    // and store them here, in reverse order.
-    let mut storage_deads = vec![];
+impl<'tcx> DropTreeBuilder<'tcx> for ExitScopes {
+    fn make_block(cfg: &mut CFG<'tcx>) -> BasicBlock {
+        cfg.start_new_block()
+    }
+    fn add_entry(cfg: &mut CFG<'tcx>, from: BasicBlock, to: BasicBlock) {
+        cfg.block_data_mut(from).terminator_mut().kind = TerminatorKind::Goto { target: to };
+    }
+}
 
-    let mut target_built_by_us = false;
+struct GeneratorDrop;
 
-    // Build up the drops. Here we iterate the vector in
-    // *forward* order, so that we generate drops[0] first (right to
-    // left in diagram above).
-    debug!("build_diverge_scope({:?})", scope.drops);
-    for (j, drop_data) in scope.drops.iter_mut().enumerate() {
-        debug!("build_diverge_scope drop_data[{}]: {:?}", j, drop_data);
-        // Only full value drops are emitted in the diverging path,
-        // not StorageDead, except in the case of generators.
-        //
-        // Note: This may not actually be what we desire (are we
-        // "freeing" stack storage as we unwind, or merely observing a
-        // frozen stack)? In particular, the intent may have been to
-        // match the behavior of clang, but on inspection eddyb says
-        // this is not what clang does.
-        match drop_data.kind {
-            DropKind::Storage if generator_kind.is_some() => {
-                storage_deads.push(Statement {
-                    source_info: source_info(drop_data.span),
-                    kind: StatementKind::StorageDead(drop_data.local),
-                });
-                if !target_built_by_us {
-                    // We cannot add statements to an existing block, so we create a new
-                    // block for our StorageDead statements.
-                    let block = cfg.start_new_cleanup_block();
-                    let source_info = SourceInfo { span: DUMMY_SP, scope: source_scope };
-                    cfg.goto(block, source_info, target);
-                    target = block;
-                    target_built_by_us = true;
-                }
-                *drop_data.cached_block.ref_mut(generator_drop) = Some(target);
-            }
-            DropKind::Storage => {}
-            DropKind::Value => {
-                let cached_block = drop_data.cached_block.ref_mut(generator_drop);
-                target = if let Some(cached_block) = *cached_block {
-                    storage_deads.clear();
-                    target_built_by_us = false;
-                    cached_block
-                } else {
-                    push_storage_deads(cfg, target, &mut storage_deads);
-                    let block = cfg.start_new_cleanup_block();
-                    cfg.terminate(
-                        block,
-                        source_info(drop_data.span),
-                        TerminatorKind::Drop {
-                            place: drop_data.local.into(),
-                            target,
-                            unwind: None,
-                        },
-                    );
-                    *cached_block = Some(block);
-                    target_built_by_us = true;
-                    block
-                };
-            }
+impl<'tcx> DropTreeBuilder<'tcx> for GeneratorDrop {
+    fn make_block(cfg: &mut CFG<'tcx>) -> BasicBlock {
+        cfg.start_new_block()
+    }
+    fn add_entry(cfg: &mut CFG<'tcx>, from: BasicBlock, to: BasicBlock) {
+        let kind = &mut cfg.block_data_mut(from).terminator_mut().kind;
+        if let TerminatorKind::Yield { drop, .. } = kind {
+            *drop = Some(to);
         };
     }
-    push_storage_deads(cfg, target, &mut storage_deads);
-    *scope.cached_unwind.ref_mut(generator_drop) = Some(target);
-
-    assert!(storage_deads.is_empty());
-    debug!("build_diverge_scope({:?}, {:?}) = {:?}", scope, span, target);
-
-    target
 }
 
-fn push_storage_deads<'tcx>(
-    cfg: &mut CFG<'tcx>,
-    target: BasicBlock,
-    storage_deads: &mut Vec<Statement<'tcx>>,
-) {
-    if storage_deads.is_empty() {
-        return;
+struct Unwind;
+
+impl<'tcx> DropTreeBuilder<'tcx> for Unwind {
+    fn make_block(cfg: &mut CFG<'tcx>) -> BasicBlock {
+        cfg.start_new_cleanup_block()
     }
-    let statements = &mut cfg.block_data_mut(target).statements;
-    storage_deads.reverse();
-    debug!(
-        "push_storage_deads({:?}), storage_deads={:?}, statements={:?}",
-        target, storage_deads, statements
-    );
-    storage_deads.append(statements);
-    mem::swap(statements, storage_deads);
-    assert!(storage_deads.is_empty());
+    fn add_entry(cfg: &mut CFG<'tcx>, from: BasicBlock, to: BasicBlock) {
+        let term = &mut cfg.block_data_mut(from).terminator_mut().kind;
+        match term {
+            TerminatorKind::Drop { unwind, .. }
+            | TerminatorKind::DropAndReplace { unwind, .. }
+            | TerminatorKind::FalseUnwind { unwind, .. }
+            | TerminatorKind::Call { cleanup: unwind, .. }
+            | TerminatorKind::Assert { cleanup: unwind, .. } => {
+                *unwind = Some(to);
+            }
+            TerminatorKind::Goto { .. }
+            | TerminatorKind::SwitchInt { .. }
+            | TerminatorKind::Resume
+            | TerminatorKind::Abort
+            | TerminatorKind::Return
+            | TerminatorKind::Unreachable
+            | TerminatorKind::Yield { .. }
+            | TerminatorKind::GeneratorDrop
+            | TerminatorKind::FalseEdges { .. } => bug!("cannot unwind from {:?}", term),
+        }
+    }
 }

--- a/compiler/rustc_mir_build/src/build/scope.rs
+++ b/compiler/rustc_mir_build/src/build/scope.rs
@@ -69,7 +69,7 @@ scheduled in a [DropTree]. Later, before `in_breakable_scope` exits, the drops
 will be added to the CFG.
 
 Panics are handled in a similar fashion, except that the drops are added to the
-mir once the rest of the function has finished being lowered. If a terminator
+MIR once the rest of the function has finished being lowered. If a terminator
 can panic, call `diverge_from(block)` with the block containing the terminator
 `block`.
 
@@ -285,8 +285,8 @@ impl DropTree {
         blocks: &mut IndexVec<DropIdx, Option<BasicBlock>>,
     ) {
         // StorageDead statements can share blocks with each other and also with
-        // a Drop terminator. We iterate through the blocks to find which blocks
-        // need
+        // a Drop terminator. We iterate through the drops to find which drops
+        // need their own block.
         #[derive(Clone, Copy)]
         enum Block {
             // This drop is unreachable
@@ -295,7 +295,7 @@ impl DropTree {
             // specified index.
             Shares(DropIdx),
             // This drop has more than one way of being reached, or it is
-            // branched to from outside the tree, or it's predecessor is a
+            // branched to from outside the tree, or its predecessor is a
             // `Value` drop.
             Own,
         }
@@ -308,7 +308,7 @@ impl DropTree {
             needs_block[ROOT_NODE] = Block::Own;
         }
 
-        // Sort so that we only need to check the last
+        // Sort so that we only need to check the last value.
         let entry_points = &mut self.entry_points;
         entry_points.sort();
 

--- a/compiler/rustc_mir_build/src/build/scope.rs
+++ b/compiler/rustc_mir_build/src/build/scope.rs
@@ -185,14 +185,14 @@ const ROOT_NODE: DropIdx = DropIdx::from_u32(0);
 /// * Drops on return and loop exit paths
 ///
 /// Once no more nodes could be added to the tree, we lower it to MIR in one go
-/// in `build_drop_tree`.
+/// in `build_mir`.
 #[derive(Debug)]
 struct DropTree {
     /// Drops in the tree.
     drops: IndexVec<DropIdx, (DropData, DropIdx)>,
     /// Map for finding the inverse of the `next_drop` relation:
     ///
-    /// `previous_drops[(drops[i].1, drops[i].0.local, drops[i].0.kind] == i`
+    /// `previous_drops[(drops[i].1, drops[i].0.local, drops[i].0.kind)] == i`
     previous_drops: FxHashMap<(DropIdx, Local, DropKind), DropIdx>,
     /// Edges into the `DropTree` that need to be added once it's lowered.
     entry_points: Vec<(DropIdx, BasicBlock)>,

--- a/compiler/rustc_mir_build/src/build/scope.rs
+++ b/compiler/rustc_mir_build/src/build/scope.rs
@@ -223,7 +223,7 @@ impl Scope {
     }
 }
 
-/// A trait that determined how [DropTree::lower_to_mir] creates its blocks and
+/// A trait that determined how [DropTree] creates its blocks and
 /// links to any entry nodes.
 trait DropTreeBuilder<'tcx> {
     /// Create a new block for the tree. This should call either

--- a/src/test/codegen/drop.rs
+++ b/src/test/codegen/drop.rs
@@ -23,13 +23,13 @@ pub fn droppy() {
 // FIXME(eddyb) the `void @` forces a match on the instruction, instead of the
 // comment, that's `; call core::intrinsics::drop_in_place::<drop::SomeUniqueName>`
 // for the `v0` mangling, should switch to matching on that once `legacy` is gone.
+// CHECK-NOT: call void @{{.*}}drop_in_place{{.*}}SomeUniqueName
+// CHECK: invoke void @{{.*}}drop_in_place{{.*}}SomeUniqueName
+// CHECK: invoke void @{{.*}}drop_in_place{{.*}}SomeUniqueName
 // CHECK-NOT: invoke void @{{.*}}drop_in_place{{.*}}SomeUniqueName
 // CHECK: call void @{{.*}}drop_in_place{{.*}}SomeUniqueName
 // CHECK: call void @{{.*}}drop_in_place{{.*}}SomeUniqueName
-// CHECK-NOT: call void @{{.*}}drop_in_place{{.*}}SomeUniqueName
-// CHECK: invoke void @{{.*}}drop_in_place{{.*}}SomeUniqueName
 // CHECK: call void @{{.*}}drop_in_place{{.*}}SomeUniqueName
-// CHECK: invoke void @{{.*}}drop_in_place{{.*}}SomeUniqueName
 // CHECK: call void @{{.*}}drop_in_place{{.*}}SomeUniqueName
 // CHECK-NOT: {{(call|invoke) void @.*}}drop_in_place{{.*}}SomeUniqueName
 // The next line checks for the } that ends the function definition

--- a/src/test/mir-opt/basic_assignment.main.SimplifyCfg-initial.after.mir
+++ b/src/test/mir-opt/basic_assignment.main.SimplifyCfg-initial.after.mir
@@ -41,44 +41,44 @@ fn main() -> () {
         StorageLive(_5);                 // scope 3 at $DIR/basic_assignment.rs:19:9: 19:15
         StorageLive(_6);                 // scope 4 at $DIR/basic_assignment.rs:23:14: 23:20
         _6 = move _4;                    // scope 4 at $DIR/basic_assignment.rs:23:14: 23:20
-        replace(_5 <- move _6) -> [return: bb2, unwind: bb5]; // scope 4 at $DIR/basic_assignment.rs:23:5: 23:11
+        replace(_5 <- move _6) -> [return: bb1, unwind: bb5]; // scope 4 at $DIR/basic_assignment.rs:23:5: 23:11
     }
 
-    bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/basic_assignment.rs:10:1: 24:2
+    bb1: {
+        drop(_6) -> [return: bb2, unwind: bb6]; // scope 4 at $DIR/basic_assignment.rs:23:19: 23:20
     }
 
     bb2: {
-        drop(_6) -> [return: bb6, unwind: bb4]; // scope 4 at $DIR/basic_assignment.rs:23:19: 23:20
-    }
-
-    bb3 (cleanup): {
-        drop(_4) -> bb1;                 // scope 2 at $DIR/basic_assignment.rs:24:1: 24:2
-    }
-
-    bb4 (cleanup): {
-        drop(_5) -> bb3;                 // scope 3 at $DIR/basic_assignment.rs:24:1: 24:2
-    }
-
-    bb5 (cleanup): {
-        drop(_6) -> bb4;                 // scope 4 at $DIR/basic_assignment.rs:23:19: 23:20
-    }
-
-    bb6: {
         StorageDead(_6);                 // scope 4 at $DIR/basic_assignment.rs:23:19: 23:20
         _0 = const ();                   // scope 0 at $DIR/basic_assignment.rs:10:11: 24:2
-        drop(_5) -> [return: bb7, unwind: bb3]; // scope 3 at $DIR/basic_assignment.rs:24:1: 24:2
+        drop(_5) -> [return: bb3, unwind: bb7]; // scope 3 at $DIR/basic_assignment.rs:24:1: 24:2
     }
 
-    bb7: {
+    bb3: {
         StorageDead(_5);                 // scope 3 at $DIR/basic_assignment.rs:24:1: 24:2
-        drop(_4) -> [return: bb8, unwind: bb1]; // scope 2 at $DIR/basic_assignment.rs:24:1: 24:2
+        drop(_4) -> [return: bb4, unwind: bb8]; // scope 2 at $DIR/basic_assignment.rs:24:1: 24:2
     }
 
-    bb8: {
+    bb4: {
         StorageDead(_4);                 // scope 2 at $DIR/basic_assignment.rs:24:1: 24:2
         StorageDead(_2);                 // scope 1 at $DIR/basic_assignment.rs:24:1: 24:2
         StorageDead(_1);                 // scope 0 at $DIR/basic_assignment.rs:24:1: 24:2
         return;                          // scope 0 at $DIR/basic_assignment.rs:24:2: 24:2
+    }
+
+    bb5 (cleanup): {
+        drop(_6) -> bb6;                 // scope 4 at $DIR/basic_assignment.rs:23:19: 23:20
+    }
+
+    bb6 (cleanup): {
+        drop(_5) -> bb7;                 // scope 3 at $DIR/basic_assignment.rs:24:1: 24:2
+    }
+
+    bb7 (cleanup): {
+        drop(_4) -> bb8;                 // scope 2 at $DIR/basic_assignment.rs:24:1: 24:2
+    }
+
+    bb8 (cleanup): {
+        resume;                          // scope 0 at $DIR/basic_assignment.rs:10:1: 24:2
     }
 }

--- a/src/test/mir-opt/box_expr.main.ElaborateDrops.before.mir
+++ b/src/test/mir-opt/box_expr.main.ElaborateDrops.before.mir
@@ -14,53 +14,53 @@ fn main() -> () {
         StorageLive(_1);                 // scope 0 at $DIR/box_expr.rs:7:9: 7:10
         StorageLive(_2);                 // scope 0 at $DIR/box_expr.rs:7:13: 7:25
         _2 = Box(S);                     // scope 0 at $DIR/box_expr.rs:7:13: 7:25
-        (*_2) = S::new() -> [return: bb2, unwind: bb3]; // scope 0 at $DIR/box_expr.rs:7:17: 7:25
+        (*_2) = S::new() -> [return: bb1, unwind: bb7]; // scope 0 at $DIR/box_expr.rs:7:17: 7:25
                                          // mir::Constant
                                          // + span: $DIR/box_expr.rs:7:17: 7:23
                                          // + literal: Const { ty: fn() -> S {S::new}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/box_expr.rs:6:1: 9:2
+    bb1: {
+        _1 = move _2;                    // scope 0 at $DIR/box_expr.rs:7:13: 7:25
+        drop(_2) -> bb2;                 // scope 0 at $DIR/box_expr.rs:7:24: 7:25
     }
 
     bb2: {
-        _1 = move _2;                    // scope 0 at $DIR/box_expr.rs:7:13: 7:25
-        drop(_2) -> bb4;                 // scope 0 at $DIR/box_expr.rs:7:24: 7:25
-    }
-
-    bb3 (cleanup): {
-        drop(_2) -> bb1;                 // scope 0 at $DIR/box_expr.rs:7:24: 7:25
-    }
-
-    bb4: {
         StorageDead(_2);                 // scope 0 at $DIR/box_expr.rs:7:24: 7:25
         StorageLive(_3);                 // scope 1 at $DIR/box_expr.rs:8:5: 8:12
         StorageLive(_4);                 // scope 1 at $DIR/box_expr.rs:8:10: 8:11
         _4 = move _1;                    // scope 1 at $DIR/box_expr.rs:8:10: 8:11
-        _3 = std::mem::drop::<Box<S>>(move _4) -> [return: bb5, unwind: bb7]; // scope 1 at $DIR/box_expr.rs:8:5: 8:12
+        _3 = std::mem::drop::<Box<S>>(move _4) -> [return: bb3, unwind: bb5]; // scope 1 at $DIR/box_expr.rs:8:5: 8:12
                                          // mir::Constant
                                          // + span: $DIR/box_expr.rs:8:5: 8:9
                                          // + literal: Const { ty: fn(std::boxed::Box<S>) {std::mem::drop::<std::boxed::Box<S>>}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb5: {
+    bb3: {
         StorageDead(_4);                 // scope 1 at $DIR/box_expr.rs:8:11: 8:12
         StorageDead(_3);                 // scope 1 at $DIR/box_expr.rs:8:12: 8:13
         _0 = const ();                   // scope 0 at $DIR/box_expr.rs:6:11: 9:2
-        drop(_1) -> bb8;                 // scope 0 at $DIR/box_expr.rs:9:1: 9:2
+        drop(_1) -> bb4;                 // scope 0 at $DIR/box_expr.rs:9:1: 9:2
     }
 
-    bb6 (cleanup): {
-        drop(_1) -> bb1;                 // scope 0 at $DIR/box_expr.rs:9:1: 9:2
+    bb4: {
+        StorageDead(_1);                 // scope 0 at $DIR/box_expr.rs:9:1: 9:2
+        return;                          // scope 0 at $DIR/box_expr.rs:9:2: 9:2
     }
 
-    bb7 (cleanup): {
+    bb5 (cleanup): {
         drop(_4) -> bb6;                 // scope 1 at $DIR/box_expr.rs:8:11: 8:12
     }
 
-    bb8: {
-        StorageDead(_1);                 // scope 0 at $DIR/box_expr.rs:9:1: 9:2
-        return;                          // scope 0 at $DIR/box_expr.rs:9:2: 9:2
+    bb6 (cleanup): {
+        drop(_1) -> bb8;                 // scope 0 at $DIR/box_expr.rs:9:1: 9:2
+    }
+
+    bb7 (cleanup): {
+        drop(_2) -> bb8;                 // scope 0 at $DIR/box_expr.rs:7:24: 7:25
+    }
+
+    bb8 (cleanup): {
+        resume;                          // scope 0 at $DIR/box_expr.rs:6:1: 9:2
     }
 }

--- a/src/test/mir-opt/const_promotion_extern_static.BAR.PromoteTemps.diff
+++ b/src/test/mir-opt/const_promotion_extern_static.BAR.PromoteTemps.diff
@@ -33,20 +33,20 @@
 +                                          // + literal: Const { ty: &[&i32; 1], val: Unevaluated(WithOptConstParam { did: DefId(0:6 ~ const_promotion_extern_static[317d]::BAR), const_param_did: None }, [], Some(promoted[0])) }
 +         _2 = &(*_6);                     // scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:35
           _1 = move _2 as &[&i32] (Pointer(Unsize)); // scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:35
-          _0 = core::slice::<impl [&i32]>::as_ptr(move _1) -> [return: bb2, unwind: bb1]; // scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:44
+          _0 = core::slice::<impl [&i32]>::as_ptr(move _1) -> [return: bb1, unwind: bb2]; // scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:44
                                            // mir::Constant
                                            // + span: $DIR/const-promotion-extern-static.rs:9:36: 9:42
                                            // + literal: Const { ty: for<'r> fn(&'r [&i32]) -> *const &i32 {core::slice::<impl [&i32]>::as_ptr}, val: Value(Scalar(<ZST>)) }
       }
   
-      bb1 (cleanup): {
-          resume;                          // scope 0 at $DIR/const-promotion-extern-static.rs:9:1: 9:45
-      }
-  
-      bb2: {
+      bb1: {
 -         StorageDead(_5);                 // scope 0 at $DIR/const-promotion-extern-static.rs:9:43: 9:44
 -         StorageDead(_3);                 // scope 0 at $DIR/const-promotion-extern-static.rs:9:43: 9:44
           return;                          // scope 0 at $DIR/const-promotion-extern-static.rs:9:1: 9:45
+      }
+  
+      bb2 (cleanup): {
+          resume;                          // scope 0 at $DIR/const-promotion-extern-static.rs:9:1: 9:45
       }
 - }
 - 

--- a/src/test/mir-opt/const_promotion_extern_static.FOO.PromoteTemps.diff
+++ b/src/test/mir-opt/const_promotion_extern_static.FOO.PromoteTemps.diff
@@ -35,20 +35,20 @@
 +                                          // + literal: Const { ty: &[&i32; 1], val: Unevaluated(WithOptConstParam { did: DefId(0:7 ~ const_promotion_extern_static[317d]::FOO), const_param_did: None }, [], Some(promoted[0])) }
 +         _2 = &(*_6);                     // scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:46
           _1 = move _2 as &[&i32] (Pointer(Unsize)); // scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:46
-          _0 = core::slice::<impl [&i32]>::as_ptr(move _1) -> [return: bb2, unwind: bb1]; // scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:55
+          _0 = core::slice::<impl [&i32]>::as_ptr(move _1) -> [return: bb1, unwind: bb2]; // scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:55
                                            // mir::Constant
                                            // + span: $DIR/const-promotion-extern-static.rs:13:47: 13:53
                                            // + literal: Const { ty: for<'r> fn(&'r [&i32]) -> *const &i32 {core::slice::<impl [&i32]>::as_ptr}, val: Value(Scalar(<ZST>)) }
       }
   
-      bb1 (cleanup): {
-          resume;                          // scope 0 at $DIR/const-promotion-extern-static.rs:13:1: 13:56
-      }
-  
-      bb2: {
+      bb1: {
 -         StorageDead(_5);                 // scope 0 at $DIR/const-promotion-extern-static.rs:13:54: 13:55
 -         StorageDead(_3);                 // scope 0 at $DIR/const-promotion-extern-static.rs:13:54: 13:55
           return;                          // scope 0 at $DIR/const-promotion-extern-static.rs:13:1: 13:56
+      }
+  
+      bb2 (cleanup): {
+          resume;                          // scope 0 at $DIR/const-promotion-extern-static.rs:13:1: 13:56
       }
   }
 - 

--- a/src/test/mir-opt/const_prop/boxes.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/boxes.main.ConstProp.diff
@@ -23,18 +23,18 @@
           _2 = (*_3);                      // scope 0 at $DIR/boxes.rs:12:13: 12:22
           _1 = Add(move _2, const 0_i32);  // scope 0 at $DIR/boxes.rs:12:13: 12:26
           StorageDead(_2);                 // scope 0 at $DIR/boxes.rs:12:25: 12:26
-          drop(_3) -> [return: bb2, unwind: bb1]; // scope 0 at $DIR/boxes.rs:12:26: 12:27
+          drop(_3) -> [return: bb1, unwind: bb2]; // scope 0 at $DIR/boxes.rs:12:26: 12:27
       }
   
-      bb1 (cleanup): {
-          resume;                          // scope 0 at $DIR/boxes.rs:11:1: 13:2
-      }
-  
-      bb2: {
+      bb1: {
           StorageDead(_3);                 // scope 0 at $DIR/boxes.rs:12:26: 12:27
           _0 = const ();                   // scope 0 at $DIR/boxes.rs:11:11: 13:2
           StorageDead(_1);                 // scope 0 at $DIR/boxes.rs:13:1: 13:2
           return;                          // scope 0 at $DIR/boxes.rs:13:2: 13:2
+      }
+  
+      bb2 (cleanup): {
+          resume;                          // scope 0 at $DIR/boxes.rs:11:1: 13:2
       }
   }
   

--- a/src/test/mir-opt/early_otherwise_branch_68867.try_sum.EarlyOtherwiseBranch.before-SimplifyBranches-after-copy-prop.after.diff
+++ b/src/test/mir-opt/early_otherwise_branch_68867.try_sum.EarlyOtherwiseBranch.before-SimplifyBranches-after-copy-prop.after.diff
@@ -109,7 +109,7 @@
 -         StorageDead(_4);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:29:1: 29:2
 +         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:28:6: 28:7
 +         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:29:1: 29:2
-          return;                          // scope 0 at $DIR/early_otherwise_branch_68867.rs:27:14: 27:28
+          return;                          // scope 0 at $DIR/early_otherwise_branch_68867.rs:29:2: 29:2
       }
   
 +     bb2: {

--- a/src/test/mir-opt/early_otherwise_branch_68867.try_sum.EarlyOtherwiseBranch.diff
+++ b/src/test/mir-opt/early_otherwise_branch_68867.try_sum.EarlyOtherwiseBranch.diff
@@ -89,7 +89,7 @@
           StorageDead(_33);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:27:27: 27:28
           StorageDead(_3);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:28:6: 28:7
           StorageDead(_4);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:29:1: 29:2
-          return;                          // scope 0 at $DIR/early_otherwise_branch_68867.rs:27:14: 27:28
+          return;                          // scope 0 at $DIR/early_otherwise_branch_68867.rs:29:2: 29:2
       }
   
 -     bb3: {

--- a/src/test/mir-opt/generator_drop_cleanup.main-{closure#0}.generator_drop.0.mir
+++ b/src/test/mir-opt/generator_drop_cleanup.main-{closure#0}.generator_drop.0.mir
@@ -34,31 +34,31 @@ fn main::{closure#0}(_1: *mut [generator@$DIR/generator-drop-cleanup.rs:10:15: 1
 
     bb0: {
         _9 = discriminant((*_1));        // scope 0 at $DIR/generator-drop-cleanup.rs:10:15: 13:6
-        switchInt(move _9) -> [0_u32: bb7, 3_u32: bb11, otherwise: bb12]; // scope 0 at $DIR/generator-drop-cleanup.rs:10:15: 13:6
+        switchInt(move _9) -> [0_u32: bb7, 3_u32: bb10, otherwise: bb11]; // scope 0 at $DIR/generator-drop-cleanup.rs:10:15: 13:6
     }
 
-    bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/generator-drop-cleanup.rs:10:15: 13:6
+    bb1: {
+        StorageDead(_5);                 // scope 1 at $DIR/generator-drop-cleanup.rs:12:13: 12:14
+        StorageDead(_4);                 // scope 1 at $DIR/generator-drop-cleanup.rs:12:14: 12:15
+        drop((((*_1) as variant#3).0: std::string::String)) -> [return: bb2, unwind: bb5]; // scope 0 at $DIR/generator-drop-cleanup.rs:13:5: 13:6
     }
 
-    bb2 (cleanup): {
+    bb2: {
         nop;                             // scope 0 at $DIR/generator-drop-cleanup.rs:13:5: 13:6
         goto -> bb8;                     // scope 0 at $DIR/generator-drop-cleanup.rs:13:5: 13:6
     }
 
     bb3: {
-        StorageDead(_5);                 // scope 1 at $DIR/generator-drop-cleanup.rs:12:13: 12:14
-        StorageDead(_4);                 // scope 1 at $DIR/generator-drop-cleanup.rs:12:14: 12:15
-        drop((((*_1) as variant#3).0: std::string::String)) -> [return: bb4, unwind: bb2]; // scope 0 at $DIR/generator-drop-cleanup.rs:13:5: 13:6
-    }
-
-    bb4: {
-        nop;                             // scope 0 at $DIR/generator-drop-cleanup.rs:13:5: 13:6
-        goto -> bb9;                     // scope 0 at $DIR/generator-drop-cleanup.rs:13:5: 13:6
-    }
-
-    bb5: {
         return;                          // scope 0 at $DIR/generator-drop-cleanup.rs:10:15: 13:6
+    }
+
+    bb4 (cleanup): {
+        resume;                          // scope 0 at $DIR/generator-drop-cleanup.rs:10:15: 13:6
+    }
+
+    bb5 (cleanup): {
+        nop;                             // scope 0 at $DIR/generator-drop-cleanup.rs:13:5: 13:6
+        goto -> bb4;                     // scope 0 at $DIR/generator-drop-cleanup.rs:13:5: 13:6
     }
 
     bb6: {
@@ -66,28 +66,24 @@ fn main::{closure#0}(_1: *mut [generator@$DIR/generator-drop-cleanup.rs:10:15: 1
     }
 
     bb7: {
-        goto -> bb10;                    // scope 0 at $DIR/generator-drop-cleanup.rs:10:15: 13:6
+        goto -> bb9;                     // scope 0 at $DIR/generator-drop-cleanup.rs:10:15: 13:6
     }
 
-    bb8 (cleanup): {
-        goto -> bb1;                     // scope 0 at $DIR/generator-drop-cleanup.rs:13:5: 13:6
+    bb8: {
+        goto -> bb3;                     // scope 0 at $DIR/generator-drop-cleanup.rs:13:5: 13:6
     }
 
     bb9: {
-        goto -> bb5;                     // scope 0 at $DIR/generator-drop-cleanup.rs:13:5: 13:6
-    }
-
-    bb10: {
         goto -> bb6;                     // scope 0 at $DIR/generator-drop-cleanup.rs:10:15: 13:6
     }
 
-    bb11: {
+    bb10: {
         StorageLive(_4);                 // scope 0 at $DIR/generator-drop-cleanup.rs:10:15: 13:6
         StorageLive(_5);                 // scope 0 at $DIR/generator-drop-cleanup.rs:10:15: 13:6
-        goto -> bb3;                     // scope 0 at $DIR/generator-drop-cleanup.rs:10:15: 13:6
+        goto -> bb1;                     // scope 0 at $DIR/generator-drop-cleanup.rs:10:15: 13:6
     }
 
-    bb12: {
+    bb11: {
         return;                          // scope 0 at $DIR/generator-drop-cleanup.rs:10:15: 13:6
     }
 }

--- a/src/test/mir-opt/generator_storage_dead_unwind.main-{closure#0}.StateTransform.before.mir
+++ b/src/test/mir-opt/generator_storage_dead_unwind.main-{closure#0}.StateTransform.before.mir
@@ -26,86 +26,86 @@ yields ()
         (_4.0: i32) = const 6_i32;       // scope 1 at $DIR/generator-storage-dead-unwind.rs:24:17: 24:23
         StorageLive(_5);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:25:9: 25:14
         StorageLive(_6);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:25:9: 25:14
-        _5 = yield(move _6) -> [resume: bb2, drop: bb4]; // scope 2 at $DIR/generator-storage-dead-unwind.rs:25:9: 25:14
+        _5 = yield(move _6) -> [resume: bb1, drop: bb5]; // scope 2 at $DIR/generator-storage-dead-unwind.rs:25:9: 25:14
     }
 
-    bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/generator-storage-dead-unwind.rs:22:16: 28:6
-    }
-
-    bb2: {
+    bb1: {
         StorageDead(_6);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:25:13: 25:14
         StorageDead(_5);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:25:14: 25:15
         StorageLive(_7);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:26:9: 26:16
         StorageLive(_8);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:26:14: 26:15
         _8 = move _3;                    // scope 2 at $DIR/generator-storage-dead-unwind.rs:26:14: 26:15
-        _7 = take::<Foo>(move _8) -> [return: bb7, unwind: bb9]; // scope 2 at $DIR/generator-storage-dead-unwind.rs:26:9: 26:16
+        _7 = take::<Foo>(move _8) -> [return: bb2, unwind: bb9]; // scope 2 at $DIR/generator-storage-dead-unwind.rs:26:9: 26:16
                                          // mir::Constant
                                          // + span: $DIR/generator-storage-dead-unwind.rs:26:9: 26:13
                                          // + literal: Const { ty: fn(Foo) {take::<Foo>}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb3 (cleanup): {
-        StorageDead(_3);                 // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
-        drop(_1) -> bb1;                 // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
-    }
-
-    bb4: {
-        StorageDead(_6);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:25:13: 25:14
-        StorageDead(_5);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:25:14: 25:15
-        StorageDead(_4);                 // scope 1 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
-        drop(_3) -> [return: bb5, unwind: bb3]; // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
-    }
-
-    bb5: {
-        StorageDead(_3);                 // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
-        drop(_1) -> [return: bb6, unwind: bb1]; // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
-    }
-
-    bb6: {
-        generator_drop;                  // scope 0 at $DIR/generator-storage-dead-unwind.rs:22:16: 28:6
-    }
-
-    bb7: {
+    bb2: {
         StorageDead(_8);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:26:15: 26:16
         StorageDead(_7);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:26:16: 26:17
         StorageLive(_9);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:27:9: 27:16
         StorageLive(_10);                // scope 2 at $DIR/generator-storage-dead-unwind.rs:27:14: 27:15
         _10 = move _4;                   // scope 2 at $DIR/generator-storage-dead-unwind.rs:27:14: 27:15
-        _9 = take::<Bar>(move _10) -> [return: bb10, unwind: bb11]; // scope 2 at $DIR/generator-storage-dead-unwind.rs:27:9: 27:16
+        _9 = take::<Bar>(move _10) -> [return: bb3, unwind: bb8]; // scope 2 at $DIR/generator-storage-dead-unwind.rs:27:9: 27:16
                                          // mir::Constant
                                          // + span: $DIR/generator-storage-dead-unwind.rs:27:9: 27:13
                                          // + literal: Const { ty: fn(Bar) {take::<Bar>}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb8 (cleanup): {
-        StorageDead(_4);                 // scope 1 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
-        StorageDead(_3);                 // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
-        drop(_1) -> bb1;                 // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
-    }
-
-    bb9 (cleanup): {
-        StorageDead(_8);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:26:15: 26:16
-        StorageDead(_7);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:26:16: 26:17
-        goto -> bb8;                     // scope 2 at $DIR/generator-storage-dead-unwind.rs:1:1: 1:1
-    }
-
-    bb10: {
+    bb3: {
         StorageDead(_10);                // scope 2 at $DIR/generator-storage-dead-unwind.rs:27:15: 27:16
         StorageDead(_9);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:27:16: 27:17
         _0 = const ();                   // scope 0 at $DIR/generator-storage-dead-unwind.rs:22:19: 28:6
         StorageDead(_4);                 // scope 1 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
         StorageDead(_3);                 // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
-        drop(_1) -> [return: bb12, unwind: bb1]; // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
+        drop(_1) -> [return: bb4, unwind: bb11]; // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
+    }
+
+    bb4: {
+        return;                          // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:6: 28:6
+    }
+
+    bb5: {
+        StorageDead(_6);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:25:13: 25:14
+        StorageDead(_5);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:25:14: 25:15
+        StorageDead(_4);                 // scope 1 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
+        drop(_3) -> [return: bb6, unwind: bb12]; // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
+    }
+
+    bb6: {
+        StorageDead(_3);                 // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
+        drop(_1) -> [return: bb7, unwind: bb11]; // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
+    }
+
+    bb7: {
+        generator_drop;                  // scope 0 at $DIR/generator-storage-dead-unwind.rs:22:16: 28:6
+    }
+
+    bb8 (cleanup): {
+        StorageDead(_10);                // scope 2 at $DIR/generator-storage-dead-unwind.rs:27:15: 27:16
+        StorageDead(_9);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:27:16: 27:17
+        goto -> bb10;                    // scope 2 at $DIR/generator-storage-dead-unwind.rs:1:1: 1:1
+    }
+
+    bb9 (cleanup): {
+        StorageDead(_8);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:26:15: 26:16
+        StorageDead(_7);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:26:16: 26:17
+        goto -> bb10;                    // scope 2 at $DIR/generator-storage-dead-unwind.rs:1:1: 1:1
+    }
+
+    bb10 (cleanup): {
+        StorageDead(_4);                 // scope 1 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
+        StorageDead(_3);                 // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
+        drop(_1) -> bb11;                // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
     }
 
     bb11 (cleanup): {
-        StorageDead(_10);                // scope 2 at $DIR/generator-storage-dead-unwind.rs:27:15: 27:16
-        StorageDead(_9);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:27:16: 27:17
-        goto -> bb8;                     // scope 2 at $DIR/generator-storage-dead-unwind.rs:1:1: 1:1
+        resume;                          // scope 0 at $DIR/generator-storage-dead-unwind.rs:22:16: 28:6
     }
 
-    bb12: {
-        return;                          // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:6: 28:6
+    bb12 (cleanup): {
+        StorageDead(_3);                 // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
+        drop(_1) -> bb11;                // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
     }
 }

--- a/src/test/mir-opt/graphviz.main.mir_map.0.dot.mir
+++ b/src/test/mir-opt/graphviz.main.mir_map.0.dot.mir
@@ -3,8 +3,5 @@ digraph Mir_0_3 {
     node [fontname="Courier, monospace"];
     edge [fontname="Courier, monospace"];
     label=<fn main() -&gt; ()<br align="left"/>>;
-    bb0__0_3 [shape="none", label=<<table border="0" cellborder="1" cellspacing="0"><tr><td bgcolor="gray" align="center" colspan="1">0</td></tr><tr><td align="left" balign="left">_0 = const ()<br/></td></tr><tr><td align="left">goto</td></tr></table>>];
-    bb1__0_3 [shape="none", label=<<table border="0" cellborder="1" cellspacing="0"><tr><td bgcolor="gray" align="center" colspan="1">1</td></tr><tr><td align="left">resume</td></tr></table>>];
-    bb2__0_3 [shape="none", label=<<table border="0" cellborder="1" cellspacing="0"><tr><td bgcolor="gray" align="center" colspan="1">2</td></tr><tr><td align="left">return</td></tr></table>>];
-    bb0__0_3 -> bb2__0_3 [label=""];
+    bb0__0_3 [shape="none", label=<<table border="0" cellborder="1" cellspacing="0"><tr><td bgcolor="gray" align="center" colspan="1">0</td></tr><tr><td align="left" balign="left">_0 = const ()<br/></td></tr><tr><td align="left">return</td></tr></table>>];
 }

--- a/src/test/mir-opt/inline/inline_into_box_place.main.Inline.32bit.diff
+++ b/src/test/mir-opt/inline/inline_into_box_place.main.Inline.32bit.diff
@@ -17,7 +17,7 @@
           StorageLive(_1);                 // scope 0 at $DIR/inline-into-box-place.rs:8:9: 8:11
           StorageLive(_2);                 // scope 0 at $DIR/inline-into-box-place.rs:8:29: 8:43
           _2 = Box(std::vec::Vec<u32>);    // scope 0 at $DIR/inline-into-box-place.rs:8:29: 8:43
--         (*_2) = Vec::<u32>::new() -> [return: bb2, unwind: bb4]; // scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
+-         (*_2) = Vec::<u32>::new() -> [return: bb1, unwind: bb4]; // scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
 +         _4 = &mut (*_2);                 // scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
 +         ((*_4).0: alloc::raw_vec::RawVec<u32>) = const alloc::raw_vec::RawVec::<u32> { ptr: Unique::<u32> { pointer: {0x4 as *const u32}, _marker: PhantomData::<u32> }, cap: 0_usize, alloc: std::alloc::Global }; // scope 2 at $SRC_DIR/alloc/src/vec.rs:LL:COL
 +                                          // ty::Const
@@ -27,34 +27,33 @@
 -                                          // + span: $DIR/inline-into-box-place.rs:8:33: 8:41
 -                                          // + user_ty: UserType(1)
 -                                          // + literal: Const { ty: fn() -> std::vec::Vec<u32> {std::vec::Vec::<u32>::new}, val: Value(Scalar(<ZST>)) }
+-     }
+- 
+-     bb1: {
 +                                          // + span: $SRC_DIR/alloc/src/vec.rs:LL:COL
 +                                          // + user_ty: UserType(0)
 +                                          // + literal: Const { ty: alloc::raw_vec::RawVec<u32>, val: Value(ByRef { alloc: Allocation { bytes: [4, 0, 0, 0, 0, 0, 0, 0], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [255], len: Size { raw: 8 } }, size: Size { raw: 8 }, align: Align { pow2: 2 }, mutability: Not, extra: () }, offset: Size { raw: 0 } }) }
 +         ((*_4).1: usize) = const 0_usize; // scope 2 at $SRC_DIR/alloc/src/vec.rs:LL:COL
-+         _1 = move _2;                    // scope 0 at $DIR/inline-into-box-place.rs:8:29: 8:43
-+         StorageDead(_2);                 // scope 0 at $DIR/inline-into-box-place.rs:8:42: 8:43
-+         _0 = const ();                   // scope 0 at $DIR/inline-into-box-place.rs:7:11: 9:2
-+         drop(_1) -> [return: bb2, unwind: bb1]; // scope 0 at $DIR/inline-into-box-place.rs:9:1: 9:2
+          _1 = move _2;                    // scope 0 at $DIR/inline-into-box-place.rs:8:29: 8:43
+          StorageDead(_2);                 // scope 0 at $DIR/inline-into-box-place.rs:8:42: 8:43
+          _0 = const ();                   // scope 0 at $DIR/inline-into-box-place.rs:7:11: 9:2
+-         drop(_1) -> [return: bb2, unwind: bb3]; // scope 0 at $DIR/inline-into-box-place.rs:9:1: 9:2
++         drop(_1) -> [return: bb1, unwind: bb2]; // scope 0 at $DIR/inline-into-box-place.rs:9:1: 9:2
       }
   
-      bb1 (cleanup): {
-          resume;                          // scope 0 at $DIR/inline-into-box-place.rs:7:1: 9:2
-      }
-  
-      bb2: {
--         _1 = move _2;                    // scope 0 at $DIR/inline-into-box-place.rs:8:29: 8:43
--         StorageDead(_2);                 // scope 0 at $DIR/inline-into-box-place.rs:8:42: 8:43
--         _0 = const ();                   // scope 0 at $DIR/inline-into-box-place.rs:7:11: 9:2
--         drop(_1) -> [return: bb3, unwind: bb1]; // scope 0 at $DIR/inline-into-box-place.rs:9:1: 9:2
--     }
-- 
--     bb3: {
+-     bb2: {
++     bb1: {
           StorageDead(_1);                 // scope 0 at $DIR/inline-into-box-place.rs:9:1: 9:2
           return;                          // scope 0 at $DIR/inline-into-box-place.rs:9:2: 9:2
+      }
+  
+-     bb3 (cleanup): {
++     bb2 (cleanup): {
+          resume;                          // scope 0 at $DIR/inline-into-box-place.rs:7:1: 9:2
 -     }
 - 
 -     bb4 (cleanup): {
--         _3 = alloc::alloc::box_free::<Vec<u32>>(move (_2.0: std::ptr::Unique<std::vec::Vec<u32>>)) -> bb1; // scope 0 at $DIR/inline-into-box-place.rs:8:42: 8:43
+-         _3 = alloc::alloc::box_free::<Vec<u32>>(move (_2.0: std::ptr::Unique<std::vec::Vec<u32>>)) -> bb3; // scope 0 at $DIR/inline-into-box-place.rs:8:42: 8:43
 -                                          // mir::Constant
 -                                          // + span: $DIR/inline-into-box-place.rs:8:42: 8:43
 -                                          // + literal: Const { ty: unsafe fn(std::ptr::Unique<std::vec::Vec<u32>>) {alloc::alloc::box_free::<std::vec::Vec<u32>>}, val: Value(Scalar(<ZST>)) }

--- a/src/test/mir-opt/inline/inline_into_box_place.main.Inline.64bit.diff
+++ b/src/test/mir-opt/inline/inline_into_box_place.main.Inline.64bit.diff
@@ -17,7 +17,7 @@
           StorageLive(_1);                 // scope 0 at $DIR/inline-into-box-place.rs:8:9: 8:11
           StorageLive(_2);                 // scope 0 at $DIR/inline-into-box-place.rs:8:29: 8:43
           _2 = Box(std::vec::Vec<u32>);    // scope 0 at $DIR/inline-into-box-place.rs:8:29: 8:43
--         (*_2) = Vec::<u32>::new() -> [return: bb2, unwind: bb4]; // scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
+-         (*_2) = Vec::<u32>::new() -> [return: bb1, unwind: bb4]; // scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
 +         _4 = &mut (*_2);                 // scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
 +         ((*_4).0: alloc::raw_vec::RawVec<u32>) = const alloc::raw_vec::RawVec::<u32> { ptr: Unique::<u32> { pointer: {0x4 as *const u32}, _marker: PhantomData::<u32> }, cap: 0_usize, alloc: std::alloc::Global }; // scope 2 at $SRC_DIR/alloc/src/vec.rs:LL:COL
 +                                          // ty::Const
@@ -27,34 +27,33 @@
 -                                          // + span: $DIR/inline-into-box-place.rs:8:33: 8:41
 -                                          // + user_ty: UserType(1)
 -                                          // + literal: Const { ty: fn() -> std::vec::Vec<u32> {std::vec::Vec::<u32>::new}, val: Value(Scalar(<ZST>)) }
+-     }
+- 
+-     bb1: {
 +                                          // + span: $SRC_DIR/alloc/src/vec.rs:LL:COL
 +                                          // + user_ty: UserType(0)
 +                                          // + literal: Const { ty: alloc::raw_vec::RawVec<u32>, val: Value(ByRef { alloc: Allocation { bytes: [4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [65535], len: Size { raw: 16 } }, size: Size { raw: 16 }, align: Align { pow2: 3 }, mutability: Not, extra: () }, offset: Size { raw: 0 } }) }
 +         ((*_4).1: usize) = const 0_usize; // scope 2 at $SRC_DIR/alloc/src/vec.rs:LL:COL
-+         _1 = move _2;                    // scope 0 at $DIR/inline-into-box-place.rs:8:29: 8:43
-+         StorageDead(_2);                 // scope 0 at $DIR/inline-into-box-place.rs:8:42: 8:43
-+         _0 = const ();                   // scope 0 at $DIR/inline-into-box-place.rs:7:11: 9:2
-+         drop(_1) -> [return: bb2, unwind: bb1]; // scope 0 at $DIR/inline-into-box-place.rs:9:1: 9:2
+          _1 = move _2;                    // scope 0 at $DIR/inline-into-box-place.rs:8:29: 8:43
+          StorageDead(_2);                 // scope 0 at $DIR/inline-into-box-place.rs:8:42: 8:43
+          _0 = const ();                   // scope 0 at $DIR/inline-into-box-place.rs:7:11: 9:2
+-         drop(_1) -> [return: bb2, unwind: bb3]; // scope 0 at $DIR/inline-into-box-place.rs:9:1: 9:2
++         drop(_1) -> [return: bb1, unwind: bb2]; // scope 0 at $DIR/inline-into-box-place.rs:9:1: 9:2
       }
   
-      bb1 (cleanup): {
-          resume;                          // scope 0 at $DIR/inline-into-box-place.rs:7:1: 9:2
-      }
-  
-      bb2: {
--         _1 = move _2;                    // scope 0 at $DIR/inline-into-box-place.rs:8:29: 8:43
--         StorageDead(_2);                 // scope 0 at $DIR/inline-into-box-place.rs:8:42: 8:43
--         _0 = const ();                   // scope 0 at $DIR/inline-into-box-place.rs:7:11: 9:2
--         drop(_1) -> [return: bb3, unwind: bb1]; // scope 0 at $DIR/inline-into-box-place.rs:9:1: 9:2
--     }
-- 
--     bb3: {
+-     bb2: {
++     bb1: {
           StorageDead(_1);                 // scope 0 at $DIR/inline-into-box-place.rs:9:1: 9:2
           return;                          // scope 0 at $DIR/inline-into-box-place.rs:9:2: 9:2
+      }
+  
+-     bb3 (cleanup): {
++     bb2 (cleanup): {
+          resume;                          // scope 0 at $DIR/inline-into-box-place.rs:7:1: 9:2
 -     }
 - 
 -     bb4 (cleanup): {
--         _3 = alloc::alloc::box_free::<Vec<u32>>(move (_2.0: std::ptr::Unique<std::vec::Vec<u32>>)) -> bb1; // scope 0 at $DIR/inline-into-box-place.rs:8:42: 8:43
+-         _3 = alloc::alloc::box_free::<Vec<u32>>(move (_2.0: std::ptr::Unique<std::vec::Vec<u32>>)) -> bb3; // scope 0 at $DIR/inline-into-box-place.rs:8:42: 8:43
 -                                          // mir::Constant
 -                                          // + span: $DIR/inline-into-box-place.rs:8:42: 8:43
 -                                          // + literal: Const { ty: unsafe fn(std::ptr::Unique<std::vec::Vec<u32>>) {alloc::alloc::box_free::<std::vec::Vec<u32>>}, val: Value(Scalar(<ZST>)) }

--- a/src/test/mir-opt/instrument_coverage.main.InstrumentCoverage.diff
+++ b/src/test/mir-opt/instrument_coverage.main.InstrumentCoverage.diff
@@ -9,40 +9,40 @@
   
       bb0: {
 +         Coverage::Counter(0) for /the/src/instrument_coverage.rs:10:11 - 16:2; // scope 0 at /the/src/instrument_coverage.rs:11:5: 15:6
-          falseUnwind -> [real: bb1, cleanup: bb2]; // scope 0 at /the/src/instrument_coverage.rs:11:5: 15:6
+          falseUnwind -> [real: bb1, cleanup: bb6]; // scope 0 at /the/src/instrument_coverage.rs:11:5: 15:6
       }
   
       bb1: {
           StorageLive(_2);                 // scope 0 at /the/src/instrument_coverage.rs:12:12: 12:17
-          _2 = bar() -> [return: bb3, unwind: bb2]; // scope 0 at /the/src/instrument_coverage.rs:12:12: 12:17
+          _2 = bar() -> [return: bb2, unwind: bb6]; // scope 0 at /the/src/instrument_coverage.rs:12:12: 12:17
                                            // mir::Constant
                                            // + span: /the/src/instrument_coverage.rs:12:12: 12:15
                                            // + literal: Const { ty: fn() -> bool {bar}, val: Value(Scalar(<ZST>)) }
       }
   
-      bb2 (cleanup): {
-          resume;                          // scope 0 at /the/src/instrument_coverage.rs:10:1: 16:2
+      bb2: {
+          FakeRead(ForMatchedPlace, _2);   // scope 0 at /the/src/instrument_coverage.rs:12:12: 12:17
+          switchInt(_2) -> [false: bb4, otherwise: bb3]; // scope 0 at /the/src/instrument_coverage.rs:12:9: 14:10
       }
   
       bb3: {
-          FakeRead(ForMatchedPlace, _2);   // scope 0 at /the/src/instrument_coverage.rs:12:12: 12:17
-          switchInt(_2) -> [false: bb5, otherwise: bb4]; // scope 0 at /the/src/instrument_coverage.rs:12:9: 14:10
+          falseEdge -> [real: bb5, imaginary: bb4]; // scope 0 at /the/src/instrument_coverage.rs:12:9: 14:10
       }
   
       bb4: {
-          falseEdge -> [real: bb6, imaginary: bb5]; // scope 0 at /the/src/instrument_coverage.rs:12:9: 14:10
-      }
-  
-      bb5: {
           _1 = const ();                   // scope 0 at /the/src/instrument_coverage.rs:12:9: 14:10
           StorageDead(_2);                 // scope 0 at /the/src/instrument_coverage.rs:15:5: 15:6
           goto -> bb0;                     // scope 0 at /the/src/instrument_coverage.rs:11:5: 15:6
       }
   
-      bb6: {
+      bb5: {
           _0 = const ();                   // scope 0 at /the/src/instrument_coverage.rs:13:13: 13:18
           StorageDead(_2);                 // scope 0 at /the/src/instrument_coverage.rs:15:5: 15:6
           return;                          // scope 0 at /the/src/instrument_coverage.rs:16:2: 16:2
+      }
+  
+      bb6 (cleanup): {
+          resume;                          // scope 0 at /the/src/instrument_coverage.rs:10:1: 16:2
       }
   }
   

--- a/src/test/mir-opt/issue_38669.main.SimplifyCfg-initial.after.mir
+++ b/src/test/mir-opt/issue_38669.main.SimplifyCfg-initial.after.mir
@@ -15,43 +15,43 @@ fn main() -> () {
         StorageLive(_1);                 // scope 0 at $DIR/issue-38669.rs:5:9: 5:25
         _1 = const false;                // scope 0 at $DIR/issue-38669.rs:5:28: 5:33
         FakeRead(ForLet, _1);            // scope 0 at $DIR/issue-38669.rs:5:9: 5:25
-        goto -> bb2;                     // scope 1 at $DIR/issue-38669.rs:6:5: 11:6
+        goto -> bb1;                     // scope 1 at $DIR/issue-38669.rs:6:5: 11:6
     }
 
-    bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/issue-38669.rs:4:1: 12:2
+    bb1: {
+        falseUnwind -> [real: bb2, cleanup: bb6]; // scope 1 at $DIR/issue-38669.rs:6:5: 11:6
     }
 
     bb2: {
-        falseUnwind -> [real: bb3, cleanup: bb1]; // scope 1 at $DIR/issue-38669.rs:6:5: 11:6
-    }
-
-    bb3: {
         StorageLive(_3);                 // scope 1 at $DIR/issue-38669.rs:7:9: 9:10
         StorageLive(_4);                 // scope 1 at $DIR/issue-38669.rs:7:12: 7:24
         _4 = _1;                         // scope 1 at $DIR/issue-38669.rs:7:12: 7:24
         FakeRead(ForMatchedPlace, _4);   // scope 1 at $DIR/issue-38669.rs:7:12: 7:24
-        switchInt(_4) -> [false: bb5, otherwise: bb4]; // scope 1 at $DIR/issue-38669.rs:7:9: 9:10
+        switchInt(_4) -> [false: bb4, otherwise: bb3]; // scope 1 at $DIR/issue-38669.rs:7:9: 9:10
+    }
+
+    bb3: {
+        falseEdge -> [real: bb5, imaginary: bb4]; // scope 1 at $DIR/issue-38669.rs:7:9: 9:10
     }
 
     bb4: {
-        falseEdge -> [real: bb6, imaginary: bb5]; // scope 1 at $DIR/issue-38669.rs:7:9: 9:10
-    }
-
-    bb5: {
         _3 = const ();                   // scope 1 at $DIR/issue-38669.rs:7:9: 9:10
         StorageDead(_4);                 // scope 1 at $DIR/issue-38669.rs:9:9: 9:10
         StorageDead(_3);                 // scope 1 at $DIR/issue-38669.rs:9:9: 9:10
         _1 = const true;                 // scope 1 at $DIR/issue-38669.rs:10:9: 10:28
         _2 = const ();                   // scope 1 at $DIR/issue-38669.rs:6:10: 11:6
-        goto -> bb2;                     // scope 1 at $DIR/issue-38669.rs:6:5: 11:6
+        goto -> bb1;                     // scope 1 at $DIR/issue-38669.rs:6:5: 11:6
     }
 
-    bb6: {
+    bb5: {
         _0 = const ();                   // scope 1 at $DIR/issue-38669.rs:8:13: 8:18
         StorageDead(_4);                 // scope 1 at $DIR/issue-38669.rs:9:9: 9:10
         StorageDead(_3);                 // scope 1 at $DIR/issue-38669.rs:9:9: 9:10
         StorageDead(_1);                 // scope 0 at $DIR/issue-38669.rs:12:1: 12:2
         return;                          // scope 0 at $DIR/issue-38669.rs:12:2: 12:2
+    }
+
+    bb6 (cleanup): {
+        resume;                          // scope 0 at $DIR/issue-38669.rs:4:1: 12:2
     }
 }

--- a/src/test/mir-opt/issue_41110.main.ElaborateDrops.after.mir
+++ b/src/test/mir-opt/issue_41110.main.ElaborateDrops.after.mir
@@ -20,38 +20,22 @@ fn main() -> () {
         StorageLive(_3);                 // scope 0 at $DIR/issue-41110.rs:8:21: 8:27
         StorageLive(_4);                 // scope 0 at $DIR/issue-41110.rs:8:21: 8:22
         _4 = S;                          // scope 0 at $DIR/issue-41110.rs:8:21: 8:22
-        _3 = S::id(move _4) -> [return: bb2, unwind: bb4]; // scope 0 at $DIR/issue-41110.rs:8:21: 8:27
+        _3 = S::id(move _4) -> [return: bb1, unwind: bb4]; // scope 0 at $DIR/issue-41110.rs:8:21: 8:27
                                          // mir::Constant
                                          // + span: $DIR/issue-41110.rs:8:23: 8:25
                                          // + literal: Const { ty: fn(S) -> S {S::id}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/issue-41110.rs:7:1: 9:2
-    }
-
-    bb2: {
+    bb1: {
         StorageDead(_4);                 // scope 0 at $DIR/issue-41110.rs:8:26: 8:27
         _5 = const false;                // scope 0 at $DIR/issue-41110.rs:8:13: 8:28
-        _1 = S::other(move _2, move _3) -> [return: bb6, unwind: bb5]; // scope 0 at $DIR/issue-41110.rs:8:13: 8:28
+        _1 = S::other(move _2, move _3) -> [return: bb2, unwind: bb3]; // scope 0 at $DIR/issue-41110.rs:8:13: 8:28
                                          // mir::Constant
                                          // + span: $DIR/issue-41110.rs:8:15: 8:20
                                          // + literal: Const { ty: fn(S, S) {S::other}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb3 (cleanup): {
-        goto -> bb9;                     // scope 0 at $DIR/issue-41110.rs:8:27: 8:28
-    }
-
-    bb4 (cleanup): {
-        goto -> bb3;                     // scope 0 at $DIR/issue-41110.rs:8:26: 8:27
-    }
-
-    bb5 (cleanup): {
-        goto -> bb3;                     // scope 0 at $DIR/issue-41110.rs:8:27: 8:28
-    }
-
-    bb6: {
+    bb2: {
         StorageDead(_3);                 // scope 0 at $DIR/issue-41110.rs:8:27: 8:28
         _5 = const false;                // scope 0 at $DIR/issue-41110.rs:8:27: 8:28
         StorageDead(_2);                 // scope 0 at $DIR/issue-41110.rs:8:27: 8:28
@@ -60,16 +44,27 @@ fn main() -> () {
         return;                          // scope 0 at $DIR/issue-41110.rs:9:2: 9:2
     }
 
+    bb3 (cleanup): {
+        goto -> bb5;                     // scope 0 at $DIR/issue-41110.rs:8:27: 8:28
+    }
+
+    bb4 (cleanup): {
+        goto -> bb5;                     // scope 0 at $DIR/issue-41110.rs:8:26: 8:27
+    }
+
+    bb5 (cleanup): {
+        goto -> bb8;                     // scope 0 at $DIR/issue-41110.rs:8:27: 8:28
+    }
+
+    bb6 (cleanup): {
+        resume;                          // scope 0 at $DIR/issue-41110.rs:7:1: 9:2
+    }
+
     bb7 (cleanup): {
-        drop(_2) -> bb1;                 // scope 0 at $DIR/issue-41110.rs:8:27: 8:28
+        drop(_2) -> bb6;                 // scope 0 at $DIR/issue-41110.rs:8:27: 8:28
     }
 
     bb8 (cleanup): {
-        _5 = const false;                // scope 0 at $DIR/issue-41110.rs:8:27: 8:28
-        goto -> bb7;                     // scope 0 at $DIR/issue-41110.rs:8:27: 8:28
-    }
-
-    bb9 (cleanup): {
-        switchInt(_5) -> [false: bb1, otherwise: bb8]; // scope 0 at $DIR/issue-41110.rs:8:27: 8:28
+        switchInt(_5) -> [false: bb6, otherwise: bb7]; // scope 0 at $DIR/issue-41110.rs:8:27: 8:28
     }
 }

--- a/src/test/mir-opt/issue_41110.test.ElaborateDrops.after.mir
+++ b/src/test/mir-opt/issue_41110.test.ElaborateDrops.after.mir
@@ -25,17 +25,13 @@ fn test() -> () {
         StorageLive(_3);                 // scope 2 at $DIR/issue-41110.rs:17:5: 17:12
         StorageLive(_4);                 // scope 2 at $DIR/issue-41110.rs:17:10: 17:11
         _4 = move _2;                    // scope 2 at $DIR/issue-41110.rs:17:10: 17:11
-        _3 = std::mem::drop::<S>(move _4) -> [return: bb2, unwind: bb5]; // scope 2 at $DIR/issue-41110.rs:17:5: 17:12
+        _3 = std::mem::drop::<S>(move _4) -> [return: bb1, unwind: bb7]; // scope 2 at $DIR/issue-41110.rs:17:5: 17:12
                                          // mir::Constant
                                          // + span: $DIR/issue-41110.rs:17:5: 17:9
                                          // + literal: Const { ty: fn(S) {std::mem::drop::<S>}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/issue-41110.rs:14:1: 19:2
-    }
-
-    bb2: {
+    bb1: {
         StorageDead(_4);                 // scope 2 at $DIR/issue-41110.rs:17:11: 17:12
         StorageDead(_3);                 // scope 2 at $DIR/issue-41110.rs:17:12: 17:13
         StorageLive(_5);                 // scope 2 at $DIR/issue-41110.rs:18:9: 18:10
@@ -44,63 +40,62 @@ fn test() -> () {
         goto -> bb12;                    // scope 2 at $DIR/issue-41110.rs:18:5: 18:6
     }
 
-    bb3 (cleanup): {
-        goto -> bb15;                    // scope 0 at $DIR/issue-41110.rs:19:1: 19:2
+    bb2: {
+        goto -> bb3;                     // scope 2 at $DIR/issue-41110.rs:18:9: 18:10
     }
 
-    bb4 (cleanup): {
-        goto -> bb3;                     // scope 1 at $DIR/issue-41110.rs:19:1: 19:2
-    }
-
-    bb5 (cleanup): {
-        goto -> bb4;                     // scope 2 at $DIR/issue-41110.rs:17:11: 17:12
-    }
-
-    bb6: {
-        goto -> bb8;                     // scope 2 at $DIR/issue-41110.rs:18:9: 18:10
-    }
-
-    bb7 (cleanup): {
-        goto -> bb4;                     // scope 2 at $DIR/issue-41110.rs:18:9: 18:10
-    }
-
-    bb8: {
+    bb3: {
         StorageDead(_5);                 // scope 2 at $DIR/issue-41110.rs:18:9: 18:10
         _0 = const ();                   // scope 0 at $DIR/issue-41110.rs:14:15: 19:2
-        drop(_2) -> [return: bb9, unwind: bb3]; // scope 1 at $DIR/issue-41110.rs:19:1: 19:2
+        drop(_2) -> [return: bb4, unwind: bb9]; // scope 1 at $DIR/issue-41110.rs:19:1: 19:2
     }
 
-    bb9: {
+    bb4: {
         StorageDead(_2);                 // scope 1 at $DIR/issue-41110.rs:19:1: 19:2
-        goto -> bb10;                    // scope 0 at $DIR/issue-41110.rs:19:1: 19:2
+        goto -> bb5;                     // scope 0 at $DIR/issue-41110.rs:19:1: 19:2
     }
 
-    bb10: {
+    bb5: {
         _6 = const false;                // scope 0 at $DIR/issue-41110.rs:19:1: 19:2
         StorageDead(_1);                 // scope 0 at $DIR/issue-41110.rs:19:1: 19:2
         return;                          // scope 0 at $DIR/issue-41110.rs:19:2: 19:2
     }
 
-    bb11 (cleanup): {
-        _2 = move _5;                    // scope 2 at $DIR/issue-41110.rs:18:5: 18:6
-        goto -> bb7;                     // scope 2 at $DIR/issue-41110.rs:18:5: 18:6
+    bb6 (cleanup): {
+        goto -> bb8;                     // scope 2 at $DIR/issue-41110.rs:18:9: 18:10
     }
 
-    bb12: {
+    bb7 (cleanup): {
+        goto -> bb8;                     // scope 2 at $DIR/issue-41110.rs:17:11: 17:12
+    }
+
+    bb8 (cleanup): {
+        goto -> bb9;                     // scope 1 at $DIR/issue-41110.rs:19:1: 19:2
+    }
+
+    bb9 (cleanup): {
+        goto -> bb14;                    // scope 0 at $DIR/issue-41110.rs:19:1: 19:2
+    }
+
+    bb10 (cleanup): {
+        resume;                          // scope 0 at $DIR/issue-41110.rs:14:1: 19:2
+    }
+
+    bb11 (cleanup): {
         _2 = move _5;                    // scope 2 at $DIR/issue-41110.rs:18:5: 18:6
         goto -> bb6;                     // scope 2 at $DIR/issue-41110.rs:18:5: 18:6
     }
 
+    bb12: {
+        _2 = move _5;                    // scope 2 at $DIR/issue-41110.rs:18:5: 18:6
+        goto -> bb2;                     // scope 2 at $DIR/issue-41110.rs:18:5: 18:6
+    }
+
     bb13 (cleanup): {
-        drop(_1) -> bb1;                 // scope 0 at $DIR/issue-41110.rs:19:1: 19:2
+        drop(_1) -> bb10;                // scope 0 at $DIR/issue-41110.rs:19:1: 19:2
     }
 
     bb14 (cleanup): {
-        _6 = const false;                // scope 0 at $DIR/issue-41110.rs:19:1: 19:2
-        goto -> bb13;                    // scope 0 at $DIR/issue-41110.rs:19:1: 19:2
-    }
-
-    bb15 (cleanup): {
-        switchInt(_6) -> [false: bb1, otherwise: bb14]; // scope 0 at $DIR/issue-41110.rs:19:1: 19:2
+        switchInt(_6) -> [false: bb10, otherwise: bb13]; // scope 0 at $DIR/issue-41110.rs:19:1: 19:2
     }
 }

--- a/src/test/mir-opt/issue_41697.{impl#0}-{constant#0}.SimplifyCfg-promote-consts.after.32bit.mir
+++ b/src/test/mir-opt/issue_41697.{impl#0}-{constant#0}.SimplifyCfg-promote-consts.after.32bit.mir
@@ -6,15 +6,15 @@
 
     bb0: {
         _1 = CheckedAdd(const 1_usize, const 1_usize); // scope 0 at $DIR/issue-41697.rs:18:19: 18:22
-        assert(!move (_1.1: bool), "attempt to compute `{} + {}`, which would overflow", const 1_usize, const 1_usize) -> [success: bb2, unwind: bb1]; // scope 0 at $DIR/issue-41697.rs:18:19: 18:22
+        assert(!move (_1.1: bool), "attempt to compute `{} + {}`, which would overflow", const 1_usize, const 1_usize) -> [success: bb1, unwind: bb2]; // scope 0 at $DIR/issue-41697.rs:18:19: 18:22
     }
 
-    bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/issue-41697.rs:18:19: 18:22
-    }
-
-    bb2: {
+    bb1: {
         _0 = move (_1.0: usize);         // scope 0 at $DIR/issue-41697.rs:18:19: 18:22
         return;                          // scope 0 at $DIR/issue-41697.rs:18:19: 18:22
+    }
+
+    bb2 (cleanup): {
+        resume;                          // scope 0 at $DIR/issue-41697.rs:18:19: 18:22
     }
 }

--- a/src/test/mir-opt/issue_41697.{impl#0}-{constant#0}.SimplifyCfg-promote-consts.after.64bit.mir
+++ b/src/test/mir-opt/issue_41697.{impl#0}-{constant#0}.SimplifyCfg-promote-consts.after.64bit.mir
@@ -6,15 +6,15 @@
 
     bb0: {
         _1 = CheckedAdd(const 1_usize, const 1_usize); // scope 0 at $DIR/issue-41697.rs:18:19: 18:22
-        assert(!move (_1.1: bool), "attempt to compute `{} + {}`, which would overflow", const 1_usize, const 1_usize) -> [success: bb2, unwind: bb1]; // scope 0 at $DIR/issue-41697.rs:18:19: 18:22
+        assert(!move (_1.1: bool), "attempt to compute `{} + {}`, which would overflow", const 1_usize, const 1_usize) -> [success: bb1, unwind: bb2]; // scope 0 at $DIR/issue-41697.rs:18:19: 18:22
     }
 
-    bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/issue-41697.rs:18:19: 18:22
-    }
-
-    bb2: {
+    bb1: {
         _0 = move (_1.0: usize);         // scope 0 at $DIR/issue-41697.rs:18:19: 18:22
         return;                          // scope 0 at $DIR/issue-41697.rs:18:19: 18:22
+    }
+
+    bb2 (cleanup): {
+        resume;                          // scope 0 at $DIR/issue-41697.rs:18:19: 18:22
     }
 }

--- a/src/test/mir-opt/issue_41888.main.ElaborateDrops.after.mir
+++ b/src/test/mir-opt/issue_41888.main.ElaborateDrops.after.mir
@@ -26,30 +26,22 @@ fn main() -> () {
         _8 = const false;                // scope 0 at $DIR/issue-41888.rs:7:9: 7:10
         StorageLive(_1);                 // scope 0 at $DIR/issue-41888.rs:7:9: 7:10
         StorageLive(_2);                 // scope 1 at $DIR/issue-41888.rs:8:8: 8:14
-        _2 = cond() -> [return: bb2, unwind: bb3]; // scope 1 at $DIR/issue-41888.rs:8:8: 8:14
+        _2 = cond() -> [return: bb1, unwind: bb11]; // scope 1 at $DIR/issue-41888.rs:8:8: 8:14
                                          // mir::Constant
                                          // + span: $DIR/issue-41888.rs:8:8: 8:12
                                          // + literal: Const { ty: fn() -> bool {cond}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/issue-41888.rs:6:1: 15:2
+    bb1: {
+        switchInt(_2) -> [false: bb2, otherwise: bb3]; // scope 1 at $DIR/issue-41888.rs:8:5: 14:6
     }
 
     bb2: {
-        switchInt(_2) -> [false: bb4, otherwise: bb5]; // scope 1 at $DIR/issue-41888.rs:8:5: 14:6
-    }
-
-    bb3 (cleanup): {
-        goto -> bb1;                     // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
-    }
-
-    bb4: {
         _0 = const ();                   // scope 1 at $DIR/issue-41888.rs:8:5: 14:6
-        goto -> bb11;                    // scope 1 at $DIR/issue-41888.rs:8:5: 14:6
+        goto -> bb8;                     // scope 1 at $DIR/issue-41888.rs:8:5: 14:6
     }
 
-    bb5: {
+    bb3: {
         StorageLive(_3);                 // scope 1 at $DIR/issue-41888.rs:9:13: 9:20
         StorageLive(_4);                 // scope 1 at $DIR/issue-41888.rs:9:18: 9:19
         _4 = K;                          // scope 1 at $DIR/issue-41888.rs:9:18: 9:19
@@ -58,39 +50,35 @@ fn main() -> () {
         goto -> bb14;                    // scope 1 at $DIR/issue-41888.rs:9:9: 9:10
     }
 
-    bb6: {
-        goto -> bb8;                     // scope 1 at $DIR/issue-41888.rs:9:19: 9:20
+    bb4: {
+        goto -> bb5;                     // scope 1 at $DIR/issue-41888.rs:9:19: 9:20
     }
 
-    bb7 (cleanup): {
-        goto -> bb3;                     // scope 1 at $DIR/issue-41888.rs:9:19: 9:20
-    }
-
-    bb8: {
+    bb5: {
         StorageDead(_3);                 // scope 1 at $DIR/issue-41888.rs:9:19: 9:20
         _5 = discriminant(_1);           // scope 1 at $DIR/issue-41888.rs:10:16: 10:24
-        switchInt(move _5) -> [0_isize: bb10, otherwise: bb9]; // scope 1 at $DIR/issue-41888.rs:10:16: 10:24
+        switchInt(move _5) -> [0_isize: bb7, otherwise: bb6]; // scope 1 at $DIR/issue-41888.rs:10:16: 10:24
     }
 
-    bb9: {
+    bb6: {
         _0 = const ();                   // scope 1 at $DIR/issue-41888.rs:10:9: 13:10
-        goto -> bb11;                    // scope 1 at $DIR/issue-41888.rs:10:9: 13:10
+        goto -> bb8;                     // scope 1 at $DIR/issue-41888.rs:10:9: 13:10
     }
 
-    bb10: {
+    bb7: {
         StorageLive(_6);                 // scope 1 at $DIR/issue-41888.rs:10:21: 10:23
         _9 = const false;                // scope 1 at $DIR/issue-41888.rs:10:21: 10:23
         _6 = move ((_1 as F).0: K);      // scope 1 at $DIR/issue-41888.rs:10:21: 10:23
         _0 = const ();                   // scope 2 at $DIR/issue-41888.rs:10:29: 13:10
         StorageDead(_6);                 // scope 1 at $DIR/issue-41888.rs:13:9: 13:10
-        goto -> bb11;                    // scope 1 at $DIR/issue-41888.rs:10:9: 13:10
+        goto -> bb8;                     // scope 1 at $DIR/issue-41888.rs:10:9: 13:10
     }
 
-    bb11: {
-        goto -> bb21;                    // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
+    bb8: {
+        goto -> bb20;                    // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
     }
 
-    bb12: {
+    bb9: {
         _7 = const false;                // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
         _8 = const false;                // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
         _9 = const false;                // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
@@ -99,12 +87,24 @@ fn main() -> () {
         return;                          // scope 0 at $DIR/issue-41888.rs:15:2: 15:2
     }
 
+    bb10 (cleanup): {
+        goto -> bb11;                    // scope 1 at $DIR/issue-41888.rs:9:19: 9:20
+    }
+
+    bb11 (cleanup): {
+        goto -> bb12;                    // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
+    }
+
+    bb12 (cleanup): {
+        resume;                          // scope 0 at $DIR/issue-41888.rs:6:1: 15:2
+    }
+
     bb13 (cleanup): {
         _7 = const true;                 // scope 1 at $DIR/issue-41888.rs:9:9: 9:10
         _8 = const true;                 // scope 1 at $DIR/issue-41888.rs:9:9: 9:10
         _9 = const true;                 // scope 1 at $DIR/issue-41888.rs:9:9: 9:10
         _1 = move _3;                    // scope 1 at $DIR/issue-41888.rs:9:9: 9:10
-        goto -> bb7;                     // scope 1 at $DIR/issue-41888.rs:9:9: 9:10
+        goto -> bb10;                    // scope 1 at $DIR/issue-41888.rs:9:9: 9:10
     }
 
     bb14: {
@@ -112,46 +112,41 @@ fn main() -> () {
         _8 = const true;                 // scope 1 at $DIR/issue-41888.rs:9:9: 9:10
         _9 = const true;                 // scope 1 at $DIR/issue-41888.rs:9:9: 9:10
         _1 = move _3;                    // scope 1 at $DIR/issue-41888.rs:9:9: 9:10
-        goto -> bb6;                     // scope 1 at $DIR/issue-41888.rs:9:9: 9:10
+        goto -> bb4;                     // scope 1 at $DIR/issue-41888.rs:9:9: 9:10
     }
 
     bb15: {
         _7 = const false;                // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
-        goto -> bb12;                    // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
+        goto -> bb9;                     // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
     }
 
     bb16 (cleanup): {
-        _7 = const false;                // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
-        goto -> bb1;                     // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
+        goto -> bb12;                    // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
     }
 
-    bb17 (cleanup): {
-        goto -> bb16;                    // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
+    bb17: {
+        drop(_1) -> [return: bb15, unwind: bb12]; // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
     }
 
-    bb18: {
-        drop(_1) -> [return: bb15, unwind: bb16]; // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
+    bb18 (cleanup): {
+        drop(_1) -> bb12;                // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
     }
 
-    bb19 (cleanup): {
-        drop(_1) -> bb16;                // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
+    bb19: {
+        _10 = discriminant(_1);          // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
+        switchInt(move _10) -> [0_isize: bb15, otherwise: bb17]; // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
     }
 
     bb20: {
-        _10 = discriminant(_1);          // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
-        switchInt(move _10) -> [0_isize: bb15, otherwise: bb18]; // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
+        switchInt(_7) -> [false: bb15, otherwise: bb19]; // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
     }
 
-    bb21: {
-        switchInt(_7) -> [false: bb15, otherwise: bb20]; // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
+    bb21 (cleanup): {
+        _11 = discriminant(_1);          // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
+        switchInt(move _11) -> [0_isize: bb16, otherwise: bb18]; // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
     }
 
     bb22 (cleanup): {
-        _11 = discriminant(_1);          // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
-        switchInt(move _11) -> [0_isize: bb17, otherwise: bb19]; // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
-    }
-
-    bb23 (cleanup): {
-        switchInt(_7) -> [false: bb16, otherwise: bb22]; // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
+        switchInt(_7) -> [false: bb12, otherwise: bb21]; // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
     }
 }

--- a/src/test/mir-opt/issue_49232.main.mir_map.0.mir
+++ b/src/test/mir-opt/issue_49232.main.mir_map.0.mir
@@ -17,70 +17,52 @@ fn main() -> () {
     }
 
     bb1: {
-        falseUnwind -> [real: bb3, cleanup: bb4]; // scope 0 at $DIR/issue-49232.rs:6:5: 14:6
+        falseUnwind -> [real: bb2, cleanup: bb11]; // scope 0 at $DIR/issue-49232.rs:6:5: 14:6
     }
 
     bb2: {
-        goto -> bb14;                    // scope 0 at $DIR/issue-49232.rs:15:2: 15:2
-    }
-
-    bb3: {
         StorageLive(_2);                 // scope 0 at $DIR/issue-49232.rs:7:13: 7:19
         StorageLive(_3);                 // scope 0 at $DIR/issue-49232.rs:8:19: 8:23
         _3 = const true;                 // scope 0 at $DIR/issue-49232.rs:8:19: 8:23
         FakeRead(ForMatchedPlace, _3);   // scope 0 at $DIR/issue-49232.rs:8:19: 8:23
-        switchInt(_3) -> [false: bb5, otherwise: bb6]; // scope 0 at $DIR/issue-49232.rs:9:17: 9:22
+        switchInt(_3) -> [false: bb3, otherwise: bb4]; // scope 0 at $DIR/issue-49232.rs:9:17: 9:22
     }
 
-    bb4 (cleanup): {
-        resume;                          // scope 0 at $DIR/issue-49232.rs:5:1: 15:2
+    bb3: {
+        falseEdge -> [real: bb5, imaginary: bb4]; // scope 0 at $DIR/issue-49232.rs:9:17: 9:22
+    }
+
+    bb4: {
+        _0 = const ();                   // scope 0 at $DIR/issue-49232.rs:10:25: 10:30
+        goto -> bb10;                    // scope 0 at $DIR/issue-49232.rs:10:25: 10:30
     }
 
     bb5: {
-        falseEdge -> [real: bb7, imaginary: bb6]; // scope 0 at $DIR/issue-49232.rs:9:17: 9:22
+        _2 = const 4_i32;                // scope 0 at $DIR/issue-49232.rs:9:26: 9:27
+        goto -> bb8;                     // scope 0 at $DIR/issue-49232.rs:8:13: 11:14
     }
 
     bb6: {
-        _0 = const ();                   // scope 0 at $DIR/issue-49232.rs:10:25: 10:30
-        goto -> bb8;                     // scope 0 at $DIR/issue-49232.rs:10:25: 10:30
-    }
-
-    bb7: {
-        _2 = const 4_i32;                // scope 0 at $DIR/issue-49232.rs:9:26: 9:27
-        goto -> bb12;                    // scope 0 at $DIR/issue-49232.rs:8:13: 11:14
-    }
-
-    bb8: {
-        StorageDead(_3);                 // scope 0 at $DIR/issue-49232.rs:12:10: 12:11
-        goto -> bb9;                     // scope 0 at $DIR/issue-49232.rs:10:25: 10:30
-    }
-
-    bb9: {
-        StorageDead(_2);                 // scope 0 at $DIR/issue-49232.rs:14:5: 14:6
-        goto -> bb2;                     // scope 0 at $DIR/issue-49232.rs:10:25: 10:30
-    }
-
-    bb10: {
         unreachable;                     // scope 0 at $DIR/issue-49232.rs:10:25: 10:30
     }
 
-    bb11: {
-        goto -> bb12;                    // scope 0 at $DIR/issue-49232.rs:8:13: 11:14
+    bb7: {
+        goto -> bb8;                     // scope 0 at $DIR/issue-49232.rs:8:13: 11:14
     }
 
-    bb12: {
+    bb8: {
         FakeRead(ForLet, _2);            // scope 0 at $DIR/issue-49232.rs:7:13: 7:19
         StorageDead(_3);                 // scope 0 at $DIR/issue-49232.rs:12:10: 12:11
         StorageLive(_5);                 // scope 1 at $DIR/issue-49232.rs:13:9: 13:22
         StorageLive(_6);                 // scope 1 at $DIR/issue-49232.rs:13:14: 13:21
         _6 = &_2;                        // scope 1 at $DIR/issue-49232.rs:13:14: 13:21
-        _5 = std::mem::drop::<&i32>(move _6) -> [return: bb13, unwind: bb4]; // scope 1 at $DIR/issue-49232.rs:13:9: 13:22
+        _5 = std::mem::drop::<&i32>(move _6) -> [return: bb9, unwind: bb11]; // scope 1 at $DIR/issue-49232.rs:13:9: 13:22
                                          // mir::Constant
                                          // + span: $DIR/issue-49232.rs:13:9: 13:13
                                          // + literal: Const { ty: fn(&i32) {std::mem::drop::<&i32>}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb13: {
+    bb9: {
         StorageDead(_6);                 // scope 1 at $DIR/issue-49232.rs:13:21: 13:22
         StorageDead(_5);                 // scope 1 at $DIR/issue-49232.rs:13:22: 13:23
         _1 = const ();                   // scope 0 at $DIR/issue-49232.rs:6:10: 14:6
@@ -88,7 +70,13 @@ fn main() -> () {
         goto -> bb1;                     // scope 0 at $DIR/issue-49232.rs:6:5: 14:6
     }
 
-    bb14: {
+    bb10: {
+        StorageDead(_3);                 // scope 0 at $DIR/issue-49232.rs:12:10: 12:11
+        StorageDead(_2);                 // scope 0 at $DIR/issue-49232.rs:14:5: 14:6
         return;                          // scope 0 at $DIR/issue-49232.rs:15:2: 15:2
+    }
+
+    bb11 (cleanup): {
+        resume;                          // scope 0 at $DIR/issue-49232.rs:5:1: 15:2
     }
 }

--- a/src/test/mir-opt/issue_62289.test.ElaborateDrops.before.mir
+++ b/src/test/mir-opt/issue_62289.test.ElaborateDrops.before.mir
@@ -30,89 +30,89 @@ fn test() -> Option<Box<u32>> {
         StorageLive(_3);                 // scope 0 at $DIR/issue-62289.rs:9:15: 9:20
         StorageLive(_4);                 // scope 0 at $DIR/issue-62289.rs:9:15: 9:19
         _4 = Option::<u32>::None;        // scope 0 at $DIR/issue-62289.rs:9:15: 9:19
-        _3 = <Option<u32> as Try>::into_result(move _4) -> [return: bb2, unwind: bb3]; // scope 0 at $DIR/issue-62289.rs:9:15: 9:20
+        _3 = <Option<u32> as Try>::into_result(move _4) -> [return: bb1, unwind: bb12]; // scope 0 at $DIR/issue-62289.rs:9:15: 9:20
                                          // mir::Constant
                                          // + span: $DIR/issue-62289.rs:9:15: 9:20
                                          // + literal: Const { ty: fn(std::option::Option<u32>) -> std::result::Result<<std::option::Option<u32> as std::ops::Try>::Ok, <std::option::Option<u32> as std::ops::Try>::Error> {<std::option::Option<u32> as std::ops::Try>::into_result}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/issue-62289.rs:8:1: 10:2
+    bb1: {
+        StorageDead(_4);                 // scope 0 at $DIR/issue-62289.rs:9:19: 9:20
+        _5 = discriminant(_3);           // scope 0 at $DIR/issue-62289.rs:9:19: 9:20
+        switchInt(move _5) -> [0_isize: bb2, 1_isize: bb4, otherwise: bb3]; // scope 0 at $DIR/issue-62289.rs:9:19: 9:20
     }
 
     bb2: {
-        StorageDead(_4);                 // scope 0 at $DIR/issue-62289.rs:9:19: 9:20
-        _5 = discriminant(_3);           // scope 0 at $DIR/issue-62289.rs:9:19: 9:20
-        switchInt(move _5) -> [0_isize: bb4, 1_isize: bb6, otherwise: bb5]; // scope 0 at $DIR/issue-62289.rs:9:19: 9:20
-    }
-
-    bb3 (cleanup): {
-        drop(_2) -> bb1;                 // scope 0 at $DIR/issue-62289.rs:9:20: 9:21
-    }
-
-    bb4: {
         StorageLive(_10);                // scope 0 at $DIR/issue-62289.rs:9:15: 9:20
         _10 = ((_3 as Ok).0: u32);       // scope 0 at $DIR/issue-62289.rs:9:15: 9:20
         (*_2) = _10;                     // scope 4 at $DIR/issue-62289.rs:9:15: 9:20
         StorageDead(_10);                // scope 0 at $DIR/issue-62289.rs:9:19: 9:20
         _1 = move _2;                    // scope 0 at $DIR/issue-62289.rs:9:10: 9:21
-        drop(_2) -> [return: bb12, unwind: bb11]; // scope 0 at $DIR/issue-62289.rs:9:20: 9:21
+        drop(_2) -> [return: bb7, unwind: bb11]; // scope 0 at $DIR/issue-62289.rs:9:20: 9:21
     }
 
-    bb5: {
+    bb3: {
         unreachable;                     // scope 0 at $DIR/issue-62289.rs:9:15: 9:20
     }
 
-    bb6: {
+    bb4: {
         StorageLive(_6);                 // scope 0 at $DIR/issue-62289.rs:9:19: 9:20
         _6 = ((_3 as Err).0: std::option::NoneError); // scope 0 at $DIR/issue-62289.rs:9:19: 9:20
         StorageLive(_8);                 // scope 2 at $DIR/issue-62289.rs:9:19: 9:20
         StorageLive(_9);                 // scope 2 at $DIR/issue-62289.rs:9:19: 9:20
         _9 = _6;                         // scope 2 at $DIR/issue-62289.rs:9:19: 9:20
-        _8 = <NoneError as From<NoneError>>::from(move _9) -> [return: bb8, unwind: bb3]; // scope 2 at $DIR/issue-62289.rs:9:19: 9:20
+        _8 = <NoneError as From<NoneError>>::from(move _9) -> [return: bb5, unwind: bb12]; // scope 2 at $DIR/issue-62289.rs:9:19: 9:20
                                          // mir::Constant
                                          // + span: $DIR/issue-62289.rs:9:19: 9:20
                                          // + literal: Const { ty: fn(std::option::NoneError) -> std::option::NoneError {<std::option::NoneError as std::convert::From<std::option::NoneError>>::from}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb7: {
-        return;                          // scope 0 at $DIR/issue-62289.rs:10:2: 10:2
-    }
-
-    bb8: {
+    bb5: {
         StorageDead(_9);                 // scope 2 at $DIR/issue-62289.rs:9:19: 9:20
-        _0 = <Option<Box<u32>> as Try>::from_error(move _8) -> [return: bb9, unwind: bb3]; // scope 2 at $DIR/issue-62289.rs:9:19: 9:20
+        _0 = <Option<Box<u32>> as Try>::from_error(move _8) -> [return: bb6, unwind: bb12]; // scope 2 at $DIR/issue-62289.rs:9:19: 9:20
                                          // mir::Constant
                                          // + span: $DIR/issue-62289.rs:9:15: 9:20
                                          // + literal: Const { ty: fn(<std::option::Option<std::boxed::Box<u32>> as std::ops::Try>::Error) -> std::option::Option<std::boxed::Box<u32>> {<std::option::Option<std::boxed::Box<u32>> as std::ops::Try>::from_error}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb9: {
+    bb6: {
         StorageDead(_8);                 // scope 2 at $DIR/issue-62289.rs:9:19: 9:20
         StorageDead(_6);                 // scope 0 at $DIR/issue-62289.rs:9:19: 9:20
-        drop(_2) -> bb10;                // scope 0 at $DIR/issue-62289.rs:9:20: 9:21
+        drop(_2) -> bb9;                 // scope 0 at $DIR/issue-62289.rs:9:20: 9:21
+    }
+
+    bb7: {
+        StorageDead(_2);                 // scope 0 at $DIR/issue-62289.rs:9:20: 9:21
+        _0 = Option::<Box<u32>>::Some(move _1); // scope 0 at $DIR/issue-62289.rs:9:5: 9:22
+        drop(_1) -> bb8;                 // scope 0 at $DIR/issue-62289.rs:9:21: 9:22
+    }
+
+    bb8: {
+        StorageDead(_1);                 // scope 0 at $DIR/issue-62289.rs:9:21: 9:22
+        StorageDead(_3);                 // scope 0 at $DIR/issue-62289.rs:10:1: 10:2
+        goto -> bb10;                    // scope 0 at $DIR/issue-62289.rs:10:2: 10:2
+    }
+
+    bb9: {
+        StorageDead(_2);                 // scope 0 at $DIR/issue-62289.rs:9:20: 9:21
+        StorageDead(_1);                 // scope 0 at $DIR/issue-62289.rs:9:21: 9:22
+        StorageDead(_3);                 // scope 0 at $DIR/issue-62289.rs:10:1: 10:2
+        goto -> bb10;                    // scope 0 at $DIR/issue-62289.rs:10:2: 10:2
     }
 
     bb10: {
-        StorageDead(_2);                 // scope 0 at $DIR/issue-62289.rs:9:20: 9:21
-        StorageDead(_1);                 // scope 0 at $DIR/issue-62289.rs:9:21: 9:22
-        StorageDead(_3);                 // scope 0 at $DIR/issue-62289.rs:10:1: 10:2
-        goto -> bb7;                     // scope 0 at $DIR/issue-62289.rs:9:19: 9:20
+        return;                          // scope 0 at $DIR/issue-62289.rs:10:2: 10:2
     }
 
     bb11 (cleanup): {
-        drop(_1) -> bb1;                 // scope 0 at $DIR/issue-62289.rs:9:21: 9:22
-    }
-
-    bb12: {
-        StorageDead(_2);                 // scope 0 at $DIR/issue-62289.rs:9:20: 9:21
-        _0 = Option::<Box<u32>>::Some(move _1); // scope 0 at $DIR/issue-62289.rs:9:5: 9:22
         drop(_1) -> bb13;                // scope 0 at $DIR/issue-62289.rs:9:21: 9:22
     }
 
-    bb13: {
-        StorageDead(_1);                 // scope 0 at $DIR/issue-62289.rs:9:21: 9:22
-        StorageDead(_3);                 // scope 0 at $DIR/issue-62289.rs:10:1: 10:2
-        goto -> bb7;                     // scope 0 at $DIR/issue-62289.rs:10:2: 10:2
+    bb12 (cleanup): {
+        drop(_2) -> bb13;                // scope 0 at $DIR/issue-62289.rs:9:20: 9:21
+    }
+
+    bb13 (cleanup): {
+        resume;                          // scope 0 at $DIR/issue-62289.rs:8:1: 10:2
     }
 }

--- a/src/test/mir-opt/issue_72181.bar.mir_map.0.32bit.mir
+++ b/src/test/mir-opt/issue_72181.bar.mir_map.0.32bit.mir
@@ -12,14 +12,6 @@ fn bar(_1: [(Never, u32); 1]) -> u32 {
         _2 = (_1[0 of 1].1: u32);        // scope 0 at $DIR/issue-72181.rs:19:13: 19:14
         _0 = _2;                         // scope 1 at $DIR/issue-72181.rs:19:46: 19:47
         StorageDead(_2);                 // scope 0 at $DIR/issue-72181.rs:19:48: 19:49
-        goto -> bb2;                     // scope 0 at $DIR/issue-72181.rs:19:49: 19:49
-    }
-
-    bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/issue-72181.rs:19:1: 19:49
-    }
-
-    bb2: {
         return;                          // scope 0 at $DIR/issue-72181.rs:19:49: 19:49
     }
 }

--- a/src/test/mir-opt/issue_72181.bar.mir_map.0.64bit.mir
+++ b/src/test/mir-opt/issue_72181.bar.mir_map.0.64bit.mir
@@ -12,14 +12,6 @@ fn bar(_1: [(Never, u32); 1]) -> u32 {
         _2 = (_1[0 of 1].1: u32);        // scope 0 at $DIR/issue-72181.rs:19:13: 19:14
         _0 = _2;                         // scope 1 at $DIR/issue-72181.rs:19:46: 19:47
         StorageDead(_2);                 // scope 0 at $DIR/issue-72181.rs:19:48: 19:49
-        goto -> bb2;                     // scope 0 at $DIR/issue-72181.rs:19:49: 19:49
-    }
-
-    bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/issue-72181.rs:19:1: 19:49
-    }
-
-    bb2: {
         return;                          // scope 0 at $DIR/issue-72181.rs:19:49: 19:49
     }
 }

--- a/src/test/mir-opt/issue_72181.foo.mir_map.0.32bit.mir
+++ b/src/test/mir-opt/issue_72181.foo.mir_map.0.32bit.mir
@@ -12,20 +12,16 @@ fn foo(_1: [(Never, u32); 1]) -> u32 {
         _2 = const 0_usize;              // scope 0 at $DIR/issue-72181.rs:16:43: 16:44
         _3 = Len(_1);                    // scope 0 at $DIR/issue-72181.rs:16:40: 16:45
         _4 = Lt(_2, _3);                 // scope 0 at $DIR/issue-72181.rs:16:40: 16:45
-        assert(move _4, "index out of bounds: the length is {} but the index is {}", move _3, _2) -> [success: bb2, unwind: bb1]; // scope 0 at $DIR/issue-72181.rs:16:40: 16:45
+        assert(move _4, "index out of bounds: the length is {} but the index is {}", move _3, _2) -> [success: bb1, unwind: bb2]; // scope 0 at $DIR/issue-72181.rs:16:40: 16:45
     }
 
-    bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/issue-72181.rs:16:1: 16:49
-    }
-
-    bb2: {
+    bb1: {
         _0 = (_1[_2].1: u32);            // scope 0 at $DIR/issue-72181.rs:16:40: 16:47
         StorageDead(_2);                 // scope 0 at $DIR/issue-72181.rs:16:48: 16:49
-        goto -> bb3;                     // scope 0 at $DIR/issue-72181.rs:16:49: 16:49
+        return;                          // scope 0 at $DIR/issue-72181.rs:16:49: 16:49
     }
 
-    bb3: {
-        return;                          // scope 0 at $DIR/issue-72181.rs:16:49: 16:49
+    bb2 (cleanup): {
+        resume;                          // scope 0 at $DIR/issue-72181.rs:16:1: 16:49
     }
 }

--- a/src/test/mir-opt/issue_72181.foo.mir_map.0.64bit.mir
+++ b/src/test/mir-opt/issue_72181.foo.mir_map.0.64bit.mir
@@ -12,20 +12,16 @@ fn foo(_1: [(Never, u32); 1]) -> u32 {
         _2 = const 0_usize;              // scope 0 at $DIR/issue-72181.rs:16:43: 16:44
         _3 = Len(_1);                    // scope 0 at $DIR/issue-72181.rs:16:40: 16:45
         _4 = Lt(_2, _3);                 // scope 0 at $DIR/issue-72181.rs:16:40: 16:45
-        assert(move _4, "index out of bounds: the length is {} but the index is {}", move _3, _2) -> [success: bb2, unwind: bb1]; // scope 0 at $DIR/issue-72181.rs:16:40: 16:45
+        assert(move _4, "index out of bounds: the length is {} but the index is {}", move _3, _2) -> [success: bb1, unwind: bb2]; // scope 0 at $DIR/issue-72181.rs:16:40: 16:45
     }
 
-    bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/issue-72181.rs:16:1: 16:49
-    }
-
-    bb2: {
+    bb1: {
         _0 = (_1[_2].1: u32);            // scope 0 at $DIR/issue-72181.rs:16:40: 16:47
         StorageDead(_2);                 // scope 0 at $DIR/issue-72181.rs:16:48: 16:49
-        goto -> bb3;                     // scope 0 at $DIR/issue-72181.rs:16:49: 16:49
+        return;                          // scope 0 at $DIR/issue-72181.rs:16:49: 16:49
     }
 
-    bb3: {
-        return;                          // scope 0 at $DIR/issue-72181.rs:16:49: 16:49
+    bb2 (cleanup): {
+        resume;                          // scope 0 at $DIR/issue-72181.rs:16:1: 16:49
     }
 }

--- a/src/test/mir-opt/issue_72181.main.mir_map.0.32bit.mir
+++ b/src/test/mir-opt/issue_72181.main.mir_map.0.32bit.mir
@@ -22,17 +22,13 @@ fn main() -> () {
 
     bb0: {
         StorageLive(_1);                 // scope 0 at $DIR/issue-72181.rs:24:13: 24:34
-        _1 = std::mem::size_of::<Foo>() -> [return: bb2, unwind: bb1]; // scope 0 at $DIR/issue-72181.rs:24:13: 24:34
+        _1 = std::mem::size_of::<Foo>() -> [return: bb1, unwind: bb3]; // scope 0 at $DIR/issue-72181.rs:24:13: 24:34
                                          // mir::Constant
                                          // + span: $DIR/issue-72181.rs:24:13: 24:32
                                          // + literal: Const { ty: fn() -> usize {std::mem::size_of::<Foo>}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/issue-72181.rs:23:1: 28:2
-    }
-
-    bb2: {
+    bb1: {
         StorageDead(_1);                 // scope 0 at $DIR/issue-72181.rs:24:34: 24:35
         StorageLive(_2);                 // scope 1 at $DIR/issue-72181.rs:26:9: 26:10
         StorageLive(_3);                 // scope 1 at $DIR/issue-72181.rs:26:14: 26:27
@@ -48,19 +44,19 @@ fn main() -> () {
         _6 = const 0_usize;              // scope 4 at $DIR/issue-72181.rs:27:24: 27:25
         _7 = Len(_2);                    // scope 4 at $DIR/issue-72181.rs:27:22: 27:26
         _8 = Lt(_6, _7);                 // scope 4 at $DIR/issue-72181.rs:27:22: 27:26
-        assert(move _8, "index out of bounds: the length is {} but the index is {}", move _7, _6) -> [success: bb3, unwind: bb1]; // scope 4 at $DIR/issue-72181.rs:27:22: 27:26
+        assert(move _8, "index out of bounds: the length is {} but the index is {}", move _7, _6) -> [success: bb2, unwind: bb3]; // scope 4 at $DIR/issue-72181.rs:27:22: 27:26
     }
 
-    bb3: {
+    bb2: {
         _5 = (_2[_6].0: u64);            // scope 4 at $DIR/issue-72181.rs:27:22: 27:28
         StorageDead(_6);                 // scope 2 at $DIR/issue-72181.rs:27:30: 27:31
         StorageDead(_5);                 // scope 2 at $DIR/issue-72181.rs:27:30: 27:31
         _0 = const ();                   // scope 0 at $DIR/issue-72181.rs:23:11: 28:2
         StorageDead(_2);                 // scope 1 at $DIR/issue-72181.rs:28:1: 28:2
-        goto -> bb4;                     // scope 0 at $DIR/issue-72181.rs:28:2: 28:2
+        return;                          // scope 0 at $DIR/issue-72181.rs:28:2: 28:2
     }
 
-    bb4: {
-        return;                          // scope 0 at $DIR/issue-72181.rs:28:2: 28:2
+    bb3 (cleanup): {
+        resume;                          // scope 0 at $DIR/issue-72181.rs:23:1: 28:2
     }
 }

--- a/src/test/mir-opt/issue_72181.main.mir_map.0.64bit.mir
+++ b/src/test/mir-opt/issue_72181.main.mir_map.0.64bit.mir
@@ -22,17 +22,13 @@ fn main() -> () {
 
     bb0: {
         StorageLive(_1);                 // scope 0 at $DIR/issue-72181.rs:24:13: 24:34
-        _1 = std::mem::size_of::<Foo>() -> [return: bb2, unwind: bb1]; // scope 0 at $DIR/issue-72181.rs:24:13: 24:34
+        _1 = std::mem::size_of::<Foo>() -> [return: bb1, unwind: bb3]; // scope 0 at $DIR/issue-72181.rs:24:13: 24:34
                                          // mir::Constant
                                          // + span: $DIR/issue-72181.rs:24:13: 24:32
                                          // + literal: Const { ty: fn() -> usize {std::mem::size_of::<Foo>}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/issue-72181.rs:23:1: 28:2
-    }
-
-    bb2: {
+    bb1: {
         StorageDead(_1);                 // scope 0 at $DIR/issue-72181.rs:24:34: 24:35
         StorageLive(_2);                 // scope 1 at $DIR/issue-72181.rs:26:9: 26:10
         StorageLive(_3);                 // scope 1 at $DIR/issue-72181.rs:26:14: 26:27
@@ -48,19 +44,19 @@ fn main() -> () {
         _6 = const 0_usize;              // scope 4 at $DIR/issue-72181.rs:27:24: 27:25
         _7 = Len(_2);                    // scope 4 at $DIR/issue-72181.rs:27:22: 27:26
         _8 = Lt(_6, _7);                 // scope 4 at $DIR/issue-72181.rs:27:22: 27:26
-        assert(move _8, "index out of bounds: the length is {} but the index is {}", move _7, _6) -> [success: bb3, unwind: bb1]; // scope 4 at $DIR/issue-72181.rs:27:22: 27:26
+        assert(move _8, "index out of bounds: the length is {} but the index is {}", move _7, _6) -> [success: bb2, unwind: bb3]; // scope 4 at $DIR/issue-72181.rs:27:22: 27:26
     }
 
-    bb3: {
+    bb2: {
         _5 = (_2[_6].0: u64);            // scope 4 at $DIR/issue-72181.rs:27:22: 27:28
         StorageDead(_6);                 // scope 2 at $DIR/issue-72181.rs:27:30: 27:31
         StorageDead(_5);                 // scope 2 at $DIR/issue-72181.rs:27:30: 27:31
         _0 = const ();                   // scope 0 at $DIR/issue-72181.rs:23:11: 28:2
         StorageDead(_2);                 // scope 1 at $DIR/issue-72181.rs:28:1: 28:2
-        goto -> bb4;                     // scope 0 at $DIR/issue-72181.rs:28:2: 28:2
+        return;                          // scope 0 at $DIR/issue-72181.rs:28:2: 28:2
     }
 
-    bb4: {
-        return;                          // scope 0 at $DIR/issue-72181.rs:28:2: 28:2
+    bb3 (cleanup): {
+        resume;                          // scope 0 at $DIR/issue-72181.rs:23:1: 28:2
     }
 }

--- a/src/test/mir-opt/issue_72181_1.f.mir_map.0.mir
+++ b/src/test/mir-opt/issue_72181_1.f.mir_map.0.mir
@@ -13,25 +13,17 @@ fn f(_1: Void) -> ! {
         unreachable;                     // scope 0 at $DIR/issue-72181-1.rs:11:11: 11:12
     }
 
-    bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/issue-72181-1.rs:10:1: 12:2
-    }
-
-    bb2: {
+    bb1: {
         unreachable;                     // scope 0 at $DIR/issue-72181-1.rs:11:5: 11:15
     }
 
-    bb3: {
+    bb2: {
         StorageDead(_3);                 // scope 0 at $DIR/issue-72181-1.rs:11:14: 11:15
         unreachable;                     // scope 0 at $DIR/issue-72181-1.rs:10:20: 12:2
     }
 
-    bb4: {
+    bb3: {
         StorageDead(_2);                 // scope 0 at $DIR/issue-72181-1.rs:12:1: 12:2
-        goto -> bb5;                     // scope 0 at $DIR/issue-72181-1.rs:12:2: 12:2
-    }
-
-    bb5: {
         return;                          // scope 0 at $DIR/issue-72181-1.rs:12:2: 12:2
     }
 }

--- a/src/test/mir-opt/issue_72181_1.main.mir_map.0.mir
+++ b/src/test/mir-opt/issue_72181_1.main.mir_map.0.mir
@@ -21,41 +21,37 @@ fn main() -> () {
         StorageLive(_2);                 // scope 0 at $DIR/issue-72181-1.rs:16:9: 16:10
         StorageLive(_3);                 // scope 2 at $DIR/issue-72181-1.rs:17:41: 17:43
         _3 = ();                         // scope 2 at $DIR/issue-72181-1.rs:17:41: 17:43
-        _2 = transmute::<(), Void>(move _3) -> [return: bb2, unwind: bb1]; // scope 2 at $DIR/issue-72181-1.rs:17:9: 17:44
+        _2 = transmute::<(), Void>(move _3) -> [return: bb1, unwind: bb4]; // scope 2 at $DIR/issue-72181-1.rs:17:9: 17:44
                                          // mir::Constant
                                          // + span: $DIR/issue-72181-1.rs:17:9: 17:40
                                          // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(()) -> Void {std::intrinsics::transmute::<(), Void>}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/issue-72181-1.rs:15:1: 21:2
-    }
-
-    bb2: {
+    bb1: {
         StorageDead(_3);                 // scope 2 at $DIR/issue-72181-1.rs:17:43: 17:44
         FakeRead(ForLet, _2);            // scope 0 at $DIR/issue-72181-1.rs:16:9: 16:10
         AscribeUserType(_2, o, UserTypeProjection { base: UserType(1), projs: [] }); // scope 0 at $DIR/issue-72181-1.rs:16:12: 16:16
         StorageLive(_4);                 // scope 1 at $DIR/issue-72181-1.rs:20:5: 20:9
         StorageLive(_5);                 // scope 1 at $DIR/issue-72181-1.rs:20:7: 20:8
         _5 = move _2;                    // scope 1 at $DIR/issue-72181-1.rs:20:7: 20:8
-        f(move _5) -> bb1;               // scope 1 at $DIR/issue-72181-1.rs:20:5: 20:9
+        f(move _5) -> bb4;               // scope 1 at $DIR/issue-72181-1.rs:20:5: 20:9
                                          // mir::Constant
                                          // + span: $DIR/issue-72181-1.rs:20:5: 20:6
                                          // + literal: Const { ty: fn(Void) -> ! {f}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb3: {
+    bb2: {
         StorageDead(_5);                 // scope 1 at $DIR/issue-72181-1.rs:20:8: 20:9
         StorageDead(_4);                 // scope 1 at $DIR/issue-72181-1.rs:20:9: 20:10
         StorageDead(_2);                 // scope 0 at $DIR/issue-72181-1.rs:21:1: 21:2
         unreachable;                     // scope 0 at $DIR/issue-72181-1.rs:15:11: 21:2
     }
 
-    bb4: {
-        goto -> bb5;                     // scope 0 at $DIR/issue-72181-1.rs:21:2: 21:2
+    bb3: {
+        return;                          // scope 0 at $DIR/issue-72181-1.rs:21:2: 21:2
     }
 
-    bb5: {
-        return;                          // scope 0 at $DIR/issue-72181-1.rs:21:2: 21:2
+    bb4 (cleanup): {
+        resume;                          // scope 0 at $DIR/issue-72181-1.rs:15:1: 21:2
     }
 }

--- a/src/test/mir-opt/issue_73223.main.SimplifyArmIdentity.32bit.diff
+++ b/src/test/mir-opt/issue_73223.main.SimplifyArmIdentity.32bit.diff
@@ -106,7 +106,7 @@
           _0 = const ();                   // scope 0 at $DIR/issue-73223.rs:4:17: 4:23
           StorageDead(_2);                 // scope 0 at $DIR/issue-73223.rs:5:6: 5:7
           StorageDead(_1);                 // scope 0 at $DIR/issue-73223.rs:9:1: 9:2
-          return;                          // scope 0 at $DIR/issue-73223.rs:4:17: 4:23
+          return;                          // scope 0 at $DIR/issue-73223.rs:9:2: 9:2
       }
   
       bb2: {

--- a/src/test/mir-opt/issue_73223.main.SimplifyArmIdentity.64bit.diff
+++ b/src/test/mir-opt/issue_73223.main.SimplifyArmIdentity.64bit.diff
@@ -106,7 +106,7 @@
           _0 = const ();                   // scope 0 at $DIR/issue-73223.rs:4:17: 4:23
           StorageDead(_2);                 // scope 0 at $DIR/issue-73223.rs:5:6: 5:7
           StorageDead(_1);                 // scope 0 at $DIR/issue-73223.rs:9:1: 9:2
-          return;                          // scope 0 at $DIR/issue-73223.rs:4:17: 4:23
+          return;                          // scope 0 at $DIR/issue-73223.rs:9:2: 9:2
       }
   
       bb2: {

--- a/src/test/mir-opt/loop_test.main.SimplifyCfg-promote-consts.after.mir
+++ b/src/test/mir-opt/loop_test.main.SimplifyCfg-promote-consts.after.mir
@@ -17,41 +17,41 @@ fn main() -> () {
         StorageLive(_2);                 // scope 0 at $DIR/loop_test.rs:10:8: 10:12
         _2 = const true;                 // scope 0 at $DIR/loop_test.rs:10:8: 10:12
         FakeRead(ForMatchedPlace, _2);   // scope 0 at $DIR/loop_test.rs:10:8: 10:12
-        switchInt(_2) -> [false: bb3, otherwise: bb2]; // scope 0 at $DIR/loop_test.rs:10:5: 12:6
+        switchInt(_2) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/loop_test.rs:10:5: 12:6
     }
 
-    bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/loop_test.rs:6:1: 17:2
+    bb1: {
+        falseEdge -> [real: bb3, imaginary: bb2]; // scope 0 at $DIR/loop_test.rs:10:5: 12:6
     }
 
     bb2: {
-        falseEdge -> [real: bb4, imaginary: bb3]; // scope 0 at $DIR/loop_test.rs:10:5: 12:6
-    }
-
-    bb3: {
         _1 = const ();                   // scope 0 at $DIR/loop_test.rs:10:5: 12:6
         StorageDead(_2);                 // scope 0 at $DIR/loop_test.rs:12:5: 12:6
         StorageDead(_1);                 // scope 0 at $DIR/loop_test.rs:12:5: 12:6
         StorageLive(_4);                 // scope 0 at $DIR/loop_test.rs:13:5: 16:6
-        goto -> bb5;                     // scope 0 at $DIR/loop_test.rs:13:5: 16:6
+        goto -> bb4;                     // scope 0 at $DIR/loop_test.rs:13:5: 16:6
     }
 
-    bb4: {
+    bb3: {
         _0 = const ();                   // scope 0 at $DIR/loop_test.rs:11:9: 11:15
         StorageDead(_2);                 // scope 0 at $DIR/loop_test.rs:12:5: 12:6
         StorageDead(_1);                 // scope 0 at $DIR/loop_test.rs:12:5: 12:6
         return;                          // scope 0 at $DIR/loop_test.rs:17:2: 17:2
     }
 
-    bb5: {
-        falseUnwind -> [real: bb6, cleanup: bb1]; // scope 0 at $DIR/loop_test.rs:13:5: 16:6
+    bb4: {
+        falseUnwind -> [real: bb5, cleanup: bb6]; // scope 0 at $DIR/loop_test.rs:13:5: 16:6
     }
 
-    bb6: {
+    bb5: {
         StorageLive(_6);                 // scope 0 at $DIR/loop_test.rs:14:13: 14:14
         _6 = const 1_i32;                // scope 0 at $DIR/loop_test.rs:14:17: 14:18
         FakeRead(ForLet, _6);            // scope 0 at $DIR/loop_test.rs:14:13: 14:14
         StorageDead(_6);                 // scope 0 at $DIR/loop_test.rs:16:5: 16:6
-        goto -> bb5;                     // scope 0 at $DIR/loop_test.rs:15:9: 15:17
+        goto -> bb4;                     // scope 0 at $DIR/loop_test.rs:1:1: 1:1
+    }
+
+    bb6 (cleanup): {
+        resume;                          // scope 0 at $DIR/loop_test.rs:6:1: 17:2
     }
 }

--- a/src/test/mir-opt/match_arm_scopes.complicated_match.SimplifyCfg-initial.after-ElaborateDrops.after.diff
+++ b/src/test/mir-opt/match_arm_scopes.complicated_match.SimplifyCfg-initial.after-ElaborateDrops.after.diff
@@ -32,54 +32,50 @@
   
       bb0: {
 -         FakeRead(ForMatchedPlace, _2);   // scope 0 at $DIR/match-arm-scopes.rs:14:11: 14:16
--         switchInt((_2.0: bool)) -> [false: bb2, otherwise: bb3]; // scope 0 at $DIR/match-arm-scopes.rs:15:10: 15:15
-+         switchInt((_2.0: bool)) -> [false: bb6, otherwise: bb2]; // scope 0 at $DIR/match-arm-scopes.rs:15:10: 15:15
+-         switchInt((_2.0: bool)) -> [false: bb1, otherwise: bb2]; // scope 0 at $DIR/match-arm-scopes.rs:15:10: 15:15
++         switchInt((_2.0: bool)) -> [false: bb5, otherwise: bb1]; // scope 0 at $DIR/match-arm-scopes.rs:15:10: 15:15
       }
   
-      bb1 (cleanup): {
-          resume;                          // scope 0 at $DIR/match-arm-scopes.rs:13:1: 18:2
+      bb1: {
+-         falseEdge -> [real: bb8, imaginary: bb3]; // scope 0 at $DIR/match-arm-scopes.rs:15:9: 15:22
++         switchInt((_2.1: bool)) -> [false: bb10, otherwise: bb2]; // scope 0 at $DIR/match-arm-scopes.rs:15:29: 15:34
       }
   
       bb2: {
--         falseEdge -> [real: bb9, imaginary: bb4]; // scope 0 at $DIR/match-arm-scopes.rs:15:9: 15:22
-+         switchInt((_2.1: bool)) -> [false: bb14, otherwise: bb3]; // scope 0 at $DIR/match-arm-scopes.rs:15:29: 15:34
+-         switchInt((_2.1: bool)) -> [false: bb3, otherwise: bb4]; // scope 0 at $DIR/match-arm-scopes.rs:15:29: 15:34
++         switchInt((_2.0: bool)) -> [false: bb3, otherwise: bb17]; // scope 0 at $DIR/match-arm-scopes.rs:16:10: 16:14
       }
   
       bb3: {
--         switchInt((_2.1: bool)) -> [false: bb4, otherwise: bb5]; // scope 0 at $DIR/match-arm-scopes.rs:15:29: 15:34
-+         switchInt((_2.0: bool)) -> [false: bb4, otherwise: bb21]; // scope 0 at $DIR/match-arm-scopes.rs:16:10: 16:14
-      }
-  
-      bb4: {
--         falseEdge -> [real: bb18, imaginary: bb6]; // scope 0 at $DIR/match-arm-scopes.rs:15:25: 15:38
+-         falseEdge -> [real: bb14, imaginary: bb5]; // scope 0 at $DIR/match-arm-scopes.rs:15:25: 15:38
+-     }
+- 
+-     bb4: {
+-         switchInt((_2.0: bool)) -> [false: bb6, otherwise: bb5]; // scope 0 at $DIR/match-arm-scopes.rs:16:10: 16:14
 -     }
 - 
 -     bb5: {
--         switchInt((_2.0: bool)) -> [false: bb7, otherwise: bb6]; // scope 0 at $DIR/match-arm-scopes.rs:16:10: 16:14
+-         falseEdge -> [real: bb22, imaginary: bb6]; // scope 0 at $DIR/match-arm-scopes.rs:16:9: 16:21
 -     }
 - 
 -     bb6: {
--         falseEdge -> [real: bb26, imaginary: bb7]; // scope 0 at $DIR/match-arm-scopes.rs:16:9: 16:21
--     }
-- 
--     bb7: {
           StorageLive(_15);                // scope 0 at $DIR/match-arm-scopes.rs:16:32: 16:33
           _15 = (_2.1: bool);              // scope 0 at $DIR/match-arm-scopes.rs:16:32: 16:33
           StorageLive(_16);                // scope 0 at $DIR/match-arm-scopes.rs:16:35: 16:36
           _16 = move (_2.2: std::string::String); // scope 0 at $DIR/match-arm-scopes.rs:16:35: 16:36
--         goto -> bb25;                    // scope 0 at $DIR/match-arm-scopes.rs:14:5: 17:6
-+         goto -> bb20;                    // scope 0 at $DIR/match-arm-scopes.rs:14:5: 17:6
+-         goto -> bb21;                    // scope 0 at $DIR/match-arm-scopes.rs:14:5: 17:6
++         goto -> bb16;                    // scope 0 at $DIR/match-arm-scopes.rs:14:5: 17:6
+      }
+  
+-     bb7: {
++     bb4: {
+          _0 = const 1_i32;                // scope 1 at $DIR/match-arm-scopes.rs:15:77: 15:78
+-         drop(_7) -> [return: bb20, unwind: bb27]; // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78
++         drop(_7) -> [return: bb15, unwind: bb22]; // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78
       }
   
 -     bb8: {
 +     bb5: {
-          _0 = const 1_i32;                // scope 1 at $DIR/match-arm-scopes.rs:15:77: 15:78
--         drop(_7) -> [return: bb24, unwind: bb14]; // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78
-+         drop(_7) -> [return: bb19, unwind: bb10]; // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78
-      }
-  
--     bb9: {
-+     bb6: {
           StorageLive(_6);                 // scope 0 at $DIR/match-arm-scopes.rs:15:17: 15:18
           _6 = &(_2.1: bool);              // scope 0 at $DIR/match-arm-scopes.rs:15:17: 15:18
           StorageLive(_8);                 // scope 0 at $DIR/match-arm-scopes.rs:15:20: 15:21
@@ -90,52 +86,33 @@
           StorageLive(_10);                // scope 0 at $DIR/match-arm-scopes.rs:15:45: 15:49
           _10 = _1;                        // scope 0 at $DIR/match-arm-scopes.rs:15:45: 15:49
 -         FakeRead(ForMatchedPlace, _10);  // scope 0 at $DIR/match-arm-scopes.rs:15:45: 15:49
--         switchInt(_10) -> [false: bb11, otherwise: bb10]; // scope 0 at $DIR/match-arm-scopes.rs:15:42: 15:73
-+         switchInt(_10) -> [false: bb7, otherwise: bb8]; // scope 0 at $DIR/match-arm-scopes.rs:15:42: 15:73
+-         switchInt(_10) -> [false: bb10, otherwise: bb9]; // scope 0 at $DIR/match-arm-scopes.rs:15:42: 15:73
++         switchInt(_10) -> [false: bb6, otherwise: bb7]; // scope 0 at $DIR/match-arm-scopes.rs:15:42: 15:73
       }
   
--     bb10: {
--         falseEdge -> [real: bb12, imaginary: bb11]; // scope 0 at $DIR/match-arm-scopes.rs:15:42: 15:73
+-     bb9: {
+-         falseEdge -> [real: bb11, imaginary: bb10]; // scope 0 at $DIR/match-arm-scopes.rs:15:42: 15:73
 -     }
 - 
--     bb11: {
-+     bb7: {
+-     bb10: {
++     bb6: {
           _9 = (*_6);                      // scope 0 at $DIR/match-arm-scopes.rs:15:70: 15:71
           StorageDead(_10);                // scope 0 at $DIR/match-arm-scopes.rs:15:72: 15:73
--         switchInt(move _9) -> [false: bb17, otherwise: bb16]; // scope 0 at $DIR/match-arm-scopes.rs:15:42: 15:73
-+         switchInt(move _9) -> [false: bb13, otherwise: bb12]; // scope 0 at $DIR/match-arm-scopes.rs:15:42: 15:73
+-         switchInt(move _9) -> [false: bb13, otherwise: bb12]; // scope 0 at $DIR/match-arm-scopes.rs:15:42: 15:73
++         switchInt(move _9) -> [false: bb9, otherwise: bb8]; // scope 0 at $DIR/match-arm-scopes.rs:15:42: 15:73
+      }
+  
+-     bb11: {
++     bb7: {
+          _0 = const 3_i32;                // scope 0 at $DIR/match-arm-scopes.rs:15:59: 15:60
+          StorageDead(_10);                // scope 0 at $DIR/match-arm-scopes.rs:15:72: 15:73
+          StorageDead(_9);                 // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78
+-         goto -> bb25;                    // scope 0 at $DIR/match-arm-scopes.rs:1:1: 1:1
++         goto -> bb20;                    // scope 0 at $DIR/match-arm-scopes.rs:1:1: 1:1
       }
   
 -     bb12: {
 +     bb8: {
-          _0 = const 3_i32;                // scope 0 at $DIR/match-arm-scopes.rs:15:59: 15:60
-          StorageDead(_10);                // scope 0 at $DIR/match-arm-scopes.rs:15:72: 15:73
-          StorageDead(_9);                 // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78
-          StorageDead(_8);                 // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78
-          StorageDead(_6);                 // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78
--         goto -> bb15;                    // scope 0 at $DIR/match-arm-scopes.rs:15:52: 15:60
-+         goto -> bb11;                    // scope 0 at $DIR/match-arm-scopes.rs:15:52: 15:60
-      }
-  
--     bb13: {
-+     bb9: {
-          return;                          // scope 0 at $DIR/match-arm-scopes.rs:18:2: 18:2
-      }
-  
--     bb14 (cleanup): {
--         drop(_2) -> bb1;                 // scope 0 at $DIR/match-arm-scopes.rs:18:1: 18:2
-+     bb10 (cleanup): {
-+         goto -> bb25;                    // scope 0 at $DIR/match-arm-scopes.rs:18:1: 18:2
-      }
-  
--     bb15: {
--         drop(_2) -> [return: bb13, unwind: bb1]; // scope 0 at $DIR/match-arm-scopes.rs:18:1: 18:2
-+     bb11: {
-+         drop(_2) -> [return: bb9, unwind: bb1]; // scope 0 at $DIR/match-arm-scopes.rs:18:1: 18:2
-      }
-  
--     bb16: {
-+     bb12: {
           StorageDead(_9);                 // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78
 -         FakeRead(ForMatchGuard, _3);     // scope 0 at $DIR/match-arm-scopes.rs:15:72: 15:73
 -         FakeRead(ForMatchGuard, _4);     // scope 0 at $DIR/match-arm-scopes.rs:15:72: 15:73
@@ -145,21 +122,21 @@
           _5 = (_2.1: bool);               // scope 0 at $DIR/match-arm-scopes.rs:15:17: 15:18
           StorageLive(_7);                 // scope 0 at $DIR/match-arm-scopes.rs:15:20: 15:21
           _7 = move (_2.2: std::string::String); // scope 0 at $DIR/match-arm-scopes.rs:15:20: 15:21
--         goto -> bb8;                     // scope 0 at $DIR/match-arm-scopes.rs:14:5: 17:6
-+         goto -> bb5;                     // scope 0 at $DIR/match-arm-scopes.rs:14:5: 17:6
+-         goto -> bb7;                     // scope 0 at $DIR/match-arm-scopes.rs:14:5: 17:6
++         goto -> bb4;                     // scope 0 at $DIR/match-arm-scopes.rs:14:5: 17:6
       }
   
--     bb17: {
-+     bb13: {
+-     bb13: {
++     bb9: {
           StorageDead(_9);                 // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78
           StorageDead(_8);                 // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78
           StorageDead(_6);                 // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78
--         falseEdge -> [real: bb3, imaginary: bb4]; // scope 0 at $DIR/match-arm-scopes.rs:15:42: 15:73
-+         goto -> bb2;                     // scope 0 at $DIR/match-arm-scopes.rs:15:42: 15:73
+-         falseEdge -> [real: bb2, imaginary: bb3]; // scope 0 at $DIR/match-arm-scopes.rs:15:42: 15:73
++         goto -> bb1;                     // scope 0 at $DIR/match-arm-scopes.rs:15:42: 15:73
       }
   
--     bb18: {
-+     bb14: {
+-     bb14: {
++     bb10: {
           StorageLive(_6);                 // scope 0 at $DIR/match-arm-scopes.rs:15:26: 15:27
           _6 = &(_2.0: bool);              // scope 0 at $DIR/match-arm-scopes.rs:15:26: 15:27
           StorageLive(_8);                 // scope 0 at $DIR/match-arm-scopes.rs:15:36: 15:37
@@ -170,35 +147,33 @@
           StorageLive(_13);                // scope 0 at $DIR/match-arm-scopes.rs:15:45: 15:49
           _13 = _1;                        // scope 0 at $DIR/match-arm-scopes.rs:15:45: 15:49
 -         FakeRead(ForMatchedPlace, _13);  // scope 0 at $DIR/match-arm-scopes.rs:15:45: 15:49
--         switchInt(_13) -> [false: bb20, otherwise: bb19]; // scope 0 at $DIR/match-arm-scopes.rs:15:42: 15:73
-+         switchInt(_13) -> [false: bb15, otherwise: bb16]; // scope 0 at $DIR/match-arm-scopes.rs:15:42: 15:73
+-         switchInt(_13) -> [false: bb16, otherwise: bb15]; // scope 0 at $DIR/match-arm-scopes.rs:15:42: 15:73
++         switchInt(_13) -> [false: bb11, otherwise: bb12]; // scope 0 at $DIR/match-arm-scopes.rs:15:42: 15:73
       }
   
--     bb19: {
--         falseEdge -> [real: bb21, imaginary: bb20]; // scope 0 at $DIR/match-arm-scopes.rs:15:42: 15:73
+-     bb15: {
+-         falseEdge -> [real: bb17, imaginary: bb16]; // scope 0 at $DIR/match-arm-scopes.rs:15:42: 15:73
 -     }
 - 
--     bb20: {
-+     bb15: {
+-     bb16: {
++     bb11: {
           _12 = (*_6);                     // scope 0 at $DIR/match-arm-scopes.rs:15:70: 15:71
           StorageDead(_13);                // scope 0 at $DIR/match-arm-scopes.rs:15:72: 15:73
--         switchInt(move _12) -> [false: bb23, otherwise: bb22]; // scope 0 at $DIR/match-arm-scopes.rs:15:42: 15:73
-+         switchInt(move _12) -> [false: bb18, otherwise: bb17]; // scope 0 at $DIR/match-arm-scopes.rs:15:42: 15:73
+-         switchInt(move _12) -> [false: bb19, otherwise: bb18]; // scope 0 at $DIR/match-arm-scopes.rs:15:42: 15:73
++         switchInt(move _12) -> [false: bb14, otherwise: bb13]; // scope 0 at $DIR/match-arm-scopes.rs:15:42: 15:73
       }
   
--     bb21: {
-+     bb16: {
+-     bb17: {
++     bb12: {
           _0 = const 3_i32;                // scope 0 at $DIR/match-arm-scopes.rs:15:59: 15:60
           StorageDead(_13);                // scope 0 at $DIR/match-arm-scopes.rs:15:72: 15:73
           StorageDead(_12);                // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78
-          StorageDead(_8);                 // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78
-          StorageDead(_6);                 // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78
--         goto -> bb15;                    // scope 0 at $DIR/match-arm-scopes.rs:15:52: 15:60
-+         goto -> bb11;                    // scope 0 at $DIR/match-arm-scopes.rs:15:52: 15:60
+-         goto -> bb25;                    // scope 0 at $DIR/match-arm-scopes.rs:1:1: 1:1
++         goto -> bb20;                    // scope 0 at $DIR/match-arm-scopes.rs:1:1: 1:1
       }
   
--     bb22: {
-+     bb17: {
+-     bb18: {
++     bb13: {
           StorageDead(_12);                // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78
 -         FakeRead(ForMatchGuard, _3);     // scope 0 at $DIR/match-arm-scopes.rs:15:72: 15:73
 -         FakeRead(ForMatchGuard, _4);     // scope 0 at $DIR/match-arm-scopes.rs:15:72: 15:73
@@ -208,82 +183,98 @@
           _5 = (_2.0: bool);               // scope 0 at $DIR/match-arm-scopes.rs:15:26: 15:27
           StorageLive(_7);                 // scope 0 at $DIR/match-arm-scopes.rs:15:36: 15:37
           _7 = move (_2.2: std::string::String); // scope 0 at $DIR/match-arm-scopes.rs:15:36: 15:37
--         goto -> bb8;                     // scope 0 at $DIR/match-arm-scopes.rs:14:5: 17:6
-+         goto -> bb5;                     // scope 0 at $DIR/match-arm-scopes.rs:14:5: 17:6
+-         goto -> bb7;                     // scope 0 at $DIR/match-arm-scopes.rs:14:5: 17:6
++         goto -> bb4;                     // scope 0 at $DIR/match-arm-scopes.rs:14:5: 17:6
       }
   
--     bb23: {
-+     bb18: {
+-     bb19: {
++     bb14: {
           StorageDead(_12);                // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78
           StorageDead(_8);                 // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78
           StorageDead(_6);                 // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78
--         falseEdge -> [real: bb5, imaginary: bb6]; // scope 0 at $DIR/match-arm-scopes.rs:15:42: 15:73
-+         goto -> bb3;                     // scope 0 at $DIR/match-arm-scopes.rs:15:42: 15:73
+-         falseEdge -> [real: bb4, imaginary: bb5]; // scope 0 at $DIR/match-arm-scopes.rs:15:42: 15:73
++         goto -> bb2;                     // scope 0 at $DIR/match-arm-scopes.rs:15:42: 15:73
       }
   
--     bb24: {
-+     bb19: {
+-     bb20: {
++     bb15: {
           StorageDead(_7);                 // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78
           StorageDead(_5);                 // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78
           StorageDead(_8);                 // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78
           StorageDead(_6);                 // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78
--         goto -> bb28;                    // scope 0 at $DIR/match-arm-scopes.rs:14:5: 17:6
-+         goto -> bb23;                    // scope 0 at $DIR/match-arm-scopes.rs:14:5: 17:6
+-         goto -> bb24;                    // scope 0 at $DIR/match-arm-scopes.rs:14:5: 17:6
++         goto -> bb19;                    // scope 0 at $DIR/match-arm-scopes.rs:14:5: 17:6
       }
   
--     bb25: {
-+     bb20: {
+-     bb21: {
++     bb16: {
           _0 = const 2_i32;                // scope 2 at $DIR/match-arm-scopes.rs:16:41: 16:42
--         drop(_16) -> [return: bb27, unwind: bb14]; // scope 0 at $DIR/match-arm-scopes.rs:16:41: 16:42
-+         drop(_16) -> [return: bb22, unwind: bb10]; // scope 0 at $DIR/match-arm-scopes.rs:16:41: 16:42
+-         drop(_16) -> [return: bb23, unwind: bb27]; // scope 0 at $DIR/match-arm-scopes.rs:16:41: 16:42
++         drop(_16) -> [return: bb18, unwind: bb22]; // scope 0 at $DIR/match-arm-scopes.rs:16:41: 16:42
       }
   
--     bb26: {
-+     bb21: {
+-     bb22: {
++     bb17: {
           StorageLive(_15);                // scope 0 at $DIR/match-arm-scopes.rs:16:16: 16:17
           _15 = (_2.1: bool);              // scope 0 at $DIR/match-arm-scopes.rs:16:16: 16:17
           StorageLive(_16);                // scope 0 at $DIR/match-arm-scopes.rs:16:19: 16:20
           _16 = move (_2.2: std::string::String); // scope 0 at $DIR/match-arm-scopes.rs:16:19: 16:20
--         goto -> bb25;                    // scope 0 at $DIR/match-arm-scopes.rs:14:5: 17:6
-+         goto -> bb20;                    // scope 0 at $DIR/match-arm-scopes.rs:14:5: 17:6
+-         goto -> bb21;                    // scope 0 at $DIR/match-arm-scopes.rs:14:5: 17:6
++         goto -> bb16;                    // scope 0 at $DIR/match-arm-scopes.rs:14:5: 17:6
       }
   
--     bb27: {
-+     bb22: {
+-     bb23: {
++     bb18: {
           StorageDead(_16);                // scope 0 at $DIR/match-arm-scopes.rs:16:41: 16:42
           StorageDead(_15);                // scope 0 at $DIR/match-arm-scopes.rs:16:41: 16:42
--         goto -> bb28;                    // scope 0 at $DIR/match-arm-scopes.rs:14:5: 17:6
-+         goto -> bb23;                    // scope 0 at $DIR/match-arm-scopes.rs:14:5: 17:6
+-         goto -> bb24;                    // scope 0 at $DIR/match-arm-scopes.rs:14:5: 17:6
++         goto -> bb19;                    // scope 0 at $DIR/match-arm-scopes.rs:14:5: 17:6
       }
   
--     bb28: {
--         drop(_2) -> [return: bb13, unwind: bb1]; // scope 0 at $DIR/match-arm-scopes.rs:18:1: 18:2
-+     bb23: {
-+         goto -> bb29;                    // scope 0 at $DIR/match-arm-scopes.rs:18:1: 18:2
+-     bb24: {
+-         drop(_2) -> [return: bb26, unwind: bb28]; // scope 0 at $DIR/match-arm-scopes.rs:18:1: 18:2
++     bb19: {
++         goto -> bb26;                    // scope 0 at $DIR/match-arm-scopes.rs:18:1: 18:2
+      }
+  
+-     bb25: {
++     bb20: {
+          StorageDead(_8);                 // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78
+          StorageDead(_6);                 // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78
+-         drop(_2) -> [return: bb26, unwind: bb28]; // scope 0 at $DIR/match-arm-scopes.rs:18:1: 18:2
++         drop(_2) -> [return: bb21, unwind: bb23]; // scope 0 at $DIR/match-arm-scopes.rs:18:1: 18:2
+      }
+  
+-     bb26: {
++     bb21: {
+          return;                          // scope 0 at $DIR/match-arm-scopes.rs:18:2: 18:2
+      }
+  
+-     bb27 (cleanup): {
+-         drop(_2) -> bb28;                // scope 0 at $DIR/match-arm-scopes.rs:18:1: 18:2
++     bb22 (cleanup): {
++         goto -> bb27;                    // scope 0 at $DIR/match-arm-scopes.rs:18:1: 18:2
+      }
+  
+-     bb28 (cleanup): {
++     bb23 (cleanup): {
+          resume;                          // scope 0 at $DIR/match-arm-scopes.rs:13:1: 18:2
 +     }
 + 
-+     bb24 (cleanup): {
-+         goto -> bb1;                     // scope 0 at $DIR/match-arm-scopes.rs:18:1: 18:2
++     bb24: {
++         goto -> bb21;                    // scope 0 at $DIR/match-arm-scopes.rs:18:1: 18:2
 +     }
 + 
 +     bb25 (cleanup): {
-+         goto -> bb24;                    // scope 0 at $DIR/match-arm-scopes.rs:18:1: 18:2
++         goto -> bb23;                    // scope 0 at $DIR/match-arm-scopes.rs:18:1: 18:2
 +     }
 + 
 +     bb26: {
-+         goto -> bb9;                     // scope 0 at $DIR/match-arm-scopes.rs:18:1: 18:2
++         goto -> bb24;                    // scope 0 at $DIR/match-arm-scopes.rs:18:1: 18:2
 +     }
 + 
 +     bb27 (cleanup): {
-+         goto -> bb1;                     // scope 0 at $DIR/match-arm-scopes.rs:18:1: 18:2
-+     }
-+ 
-+     bb28 (cleanup): {
-+         goto -> bb27;                    // scope 0 at $DIR/match-arm-scopes.rs:18:1: 18:2
-+     }
-+ 
-+     bb29: {
-+         goto -> bb26;                    // scope 0 at $DIR/match-arm-scopes.rs:18:1: 18:2
++         goto -> bb23;                    // scope 0 at $DIR/match-arm-scopes.rs:18:1: 18:2
       }
   }
   

--- a/src/test/mir-opt/match_false_edges.full_tested_match.PromoteTemps.after.mir
+++ b/src/test/mir-opt/match_false_edges.full_tested_match.PromoteTemps.after.mir
@@ -29,31 +29,27 @@ fn full_tested_match() -> () {
         _2 = Option::<i32>::Some(const 42_i32); // scope 0 at $DIR/match_false_edges.rs:15:19: 15:27
         FakeRead(ForMatchedPlace, _2);   // scope 0 at $DIR/match_false_edges.rs:15:19: 15:27
         _3 = discriminant(_2);           // scope 0 at $DIR/match_false_edges.rs:16:9: 16:16
-        switchInt(move _3) -> [0_isize: bb2, 1_isize: bb3, otherwise: bb5]; // scope 0 at $DIR/match_false_edges.rs:16:9: 16:16
+        switchInt(move _3) -> [0_isize: bb1, 1_isize: bb2, otherwise: bb4]; // scope 0 at $DIR/match_false_edges.rs:16:9: 16:16
     }
 
-    bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/match_false_edges.rs:14:1: 20:2
+    bb1: {
+        _1 = (const 3_i32, const 3_i32); // scope 0 at $DIR/match_false_edges.rs:18:17: 18:23
+        goto -> bb10;                    // scope 0 at $DIR/match_false_edges.rs:15:13: 19:6
     }
 
     bb2: {
-        _1 = (const 3_i32, const 3_i32); // scope 0 at $DIR/match_false_edges.rs:18:17: 18:23
-        goto -> bb11;                    // scope 0 at $DIR/match_false_edges.rs:15:13: 19:6
+        falseEdge -> [real: bb5, imaginary: bb3]; // scope 0 at $DIR/match_false_edges.rs:16:9: 16:16
     }
 
     bb3: {
-        falseEdge -> [real: bb6, imaginary: bb4]; // scope 0 at $DIR/match_false_edges.rs:16:9: 16:16
+        falseEdge -> [real: bb9, imaginary: bb1]; // scope 0 at $DIR/match_false_edges.rs:17:9: 17:16
     }
 
     bb4: {
-        falseEdge -> [real: bb10, imaginary: bb2]; // scope 0 at $DIR/match_false_edges.rs:17:9: 17:16
-    }
-
-    bb5: {
         unreachable;                     // scope 0 at $DIR/match_false_edges.rs:15:19: 15:27
     }
 
-    bb6: {
+    bb5: {
         StorageLive(_6);                 // scope 0 at $DIR/match_false_edges.rs:16:14: 16:15
         _11 = const full_tested_match::promoted[0]; // scope 0 at $DIR/match_false_edges.rs:16:14: 16:15
                                          // ty::Const
@@ -65,17 +61,17 @@ fn full_tested_match() -> () {
         _6 = &(((*_11) as Some).0: i32); // scope 0 at $DIR/match_false_edges.rs:16:14: 16:15
         _4 = &shallow _2;                // scope 0 at $DIR/match_false_edges.rs:15:19: 15:27
         StorageLive(_7);                 // scope 0 at $DIR/match_false_edges.rs:16:20: 16:27
-        _7 = guard() -> [return: bb7, unwind: bb1]; // scope 0 at $DIR/match_false_edges.rs:16:20: 16:27
+        _7 = guard() -> [return: bb6, unwind: bb11]; // scope 0 at $DIR/match_false_edges.rs:16:20: 16:27
                                          // mir::Constant
                                          // + span: $DIR/match_false_edges.rs:16:20: 16:25
                                          // + literal: Const { ty: fn() -> bool {guard}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb7: {
-        switchInt(move _7) -> [false: bb9, otherwise: bb8]; // scope 0 at $DIR/match_false_edges.rs:16:20: 16:27
+    bb6: {
+        switchInt(move _7) -> [false: bb8, otherwise: bb7]; // scope 0 at $DIR/match_false_edges.rs:16:20: 16:27
     }
 
-    bb8: {
+    bb7: {
         StorageDead(_7);                 // scope 0 at $DIR/match_false_edges.rs:16:36: 16:37
         FakeRead(ForMatchGuard, _4);     // scope 0 at $DIR/match_false_edges.rs:16:26: 16:27
         FakeRead(ForGuardBinding, _6);   // scope 0 at $DIR/match_false_edges.rs:16:26: 16:27
@@ -87,16 +83,16 @@ fn full_tested_match() -> () {
         StorageDead(_8);                 // scope 2 at $DIR/match_false_edges.rs:16:36: 16:37
         StorageDead(_5);                 // scope 0 at $DIR/match_false_edges.rs:16:36: 16:37
         StorageDead(_6);                 // scope 0 at $DIR/match_false_edges.rs:16:36: 16:37
-        goto -> bb11;                    // scope 0 at $DIR/match_false_edges.rs:15:13: 19:6
+        goto -> bb10;                    // scope 0 at $DIR/match_false_edges.rs:15:13: 19:6
+    }
+
+    bb8: {
+        StorageDead(_7);                 // scope 0 at $DIR/match_false_edges.rs:16:36: 16:37
+        StorageDead(_6);                 // scope 0 at $DIR/match_false_edges.rs:16:36: 16:37
+        goto -> bb3;                     // scope 0 at $DIR/match_false_edges.rs:16:20: 16:27
     }
 
     bb9: {
-        StorageDead(_7);                 // scope 0 at $DIR/match_false_edges.rs:16:36: 16:37
-        StorageDead(_6);                 // scope 0 at $DIR/match_false_edges.rs:16:36: 16:37
-        goto -> bb4;                     // scope 0 at $DIR/match_false_edges.rs:16:20: 16:27
-    }
-
-    bb10: {
         StorageLive(_9);                 // scope 0 at $DIR/match_false_edges.rs:17:14: 17:15
         _9 = ((_2 as Some).0: i32);      // scope 0 at $DIR/match_false_edges.rs:17:14: 17:15
         StorageLive(_10);                // scope 3 at $DIR/match_false_edges.rs:17:24: 17:25
@@ -104,13 +100,17 @@ fn full_tested_match() -> () {
         _1 = (const 2_i32, move _10);    // scope 3 at $DIR/match_false_edges.rs:17:20: 17:26
         StorageDead(_10);                // scope 3 at $DIR/match_false_edges.rs:17:25: 17:26
         StorageDead(_9);                 // scope 0 at $DIR/match_false_edges.rs:17:25: 17:26
-        goto -> bb11;                    // scope 0 at $DIR/match_false_edges.rs:15:13: 19:6
+        goto -> bb10;                    // scope 0 at $DIR/match_false_edges.rs:15:13: 19:6
     }
 
-    bb11: {
+    bb10: {
         StorageDead(_2);                 // scope 0 at $DIR/match_false_edges.rs:19:6: 19:7
         StorageDead(_1);                 // scope 0 at $DIR/match_false_edges.rs:19:6: 19:7
         _0 = const ();                   // scope 0 at $DIR/match_false_edges.rs:14:28: 20:2
         return;                          // scope 0 at $DIR/match_false_edges.rs:20:2: 20:2
+    }
+
+    bb11 (cleanup): {
+        resume;                          // scope 0 at $DIR/match_false_edges.rs:14:1: 20:2
     }
 }

--- a/src/test/mir-opt/match_false_edges.full_tested_match2.PromoteTemps.before.mir
+++ b/src/test/mir-opt/match_false_edges.full_tested_match2.PromoteTemps.before.mir
@@ -28,22 +28,18 @@ fn full_tested_match2() -> () {
         _2 = Option::<i32>::Some(const 42_i32); // scope 0 at $DIR/match_false_edges.rs:26:19: 26:27
         FakeRead(ForMatchedPlace, _2);   // scope 0 at $DIR/match_false_edges.rs:26:19: 26:27
         _3 = discriminant(_2);           // scope 0 at $DIR/match_false_edges.rs:27:9: 27:16
-        switchInt(move _3) -> [0_isize: bb2, 1_isize: bb3, otherwise: bb5]; // scope 0 at $DIR/match_false_edges.rs:27:9: 27:16
+        switchInt(move _3) -> [0_isize: bb1, 1_isize: bb2, otherwise: bb4]; // scope 0 at $DIR/match_false_edges.rs:27:9: 27:16
     }
 
-    bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/match_false_edges.rs:25:1: 31:2
+    bb1: {
+        falseEdge -> [real: bb9, imaginary: bb3]; // scope 0 at $DIR/match_false_edges.rs:28:9: 28:13
     }
 
     bb2: {
-        falseEdge -> [real: bb10, imaginary: bb4]; // scope 0 at $DIR/match_false_edges.rs:28:9: 28:13
+        falseEdge -> [real: bb5, imaginary: bb1]; // scope 0 at $DIR/match_false_edges.rs:27:9: 27:16
     }
 
     bb3: {
-        falseEdge -> [real: bb6, imaginary: bb2]; // scope 0 at $DIR/match_false_edges.rs:27:9: 27:16
-    }
-
-    bb4: {
         StorageLive(_9);                 // scope 0 at $DIR/match_false_edges.rs:29:14: 29:15
         _9 = ((_2 as Some).0: i32);      // scope 0 at $DIR/match_false_edges.rs:29:14: 29:15
         StorageLive(_10);                // scope 3 at $DIR/match_false_edges.rs:29:24: 29:25
@@ -51,29 +47,29 @@ fn full_tested_match2() -> () {
         _1 = (const 2_i32, move _10);    // scope 3 at $DIR/match_false_edges.rs:29:20: 29:26
         StorageDead(_10);                // scope 3 at $DIR/match_false_edges.rs:29:25: 29:26
         StorageDead(_9);                 // scope 0 at $DIR/match_false_edges.rs:29:25: 29:26
-        goto -> bb11;                    // scope 0 at $DIR/match_false_edges.rs:26:13: 30:6
+        goto -> bb10;                    // scope 0 at $DIR/match_false_edges.rs:26:13: 30:6
     }
 
-    bb5: {
+    bb4: {
         unreachable;                     // scope 0 at $DIR/match_false_edges.rs:26:19: 26:27
     }
 
-    bb6: {
+    bb5: {
         StorageLive(_6);                 // scope 0 at $DIR/match_false_edges.rs:27:14: 27:15
         _6 = &((_2 as Some).0: i32);     // scope 0 at $DIR/match_false_edges.rs:27:14: 27:15
         _4 = &shallow _2;                // scope 0 at $DIR/match_false_edges.rs:26:19: 26:27
         StorageLive(_7);                 // scope 0 at $DIR/match_false_edges.rs:27:20: 27:27
-        _7 = guard() -> [return: bb7, unwind: bb1]; // scope 0 at $DIR/match_false_edges.rs:27:20: 27:27
+        _7 = guard() -> [return: bb6, unwind: bb11]; // scope 0 at $DIR/match_false_edges.rs:27:20: 27:27
                                          // mir::Constant
                                          // + span: $DIR/match_false_edges.rs:27:20: 27:25
                                          // + literal: Const { ty: fn() -> bool {guard}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb7: {
-        switchInt(move _7) -> [false: bb9, otherwise: bb8]; // scope 0 at $DIR/match_false_edges.rs:27:20: 27:27
+    bb6: {
+        switchInt(move _7) -> [false: bb8, otherwise: bb7]; // scope 0 at $DIR/match_false_edges.rs:27:20: 27:27
     }
 
-    bb8: {
+    bb7: {
         StorageDead(_7);                 // scope 0 at $DIR/match_false_edges.rs:27:36: 27:37
         FakeRead(ForMatchGuard, _4);     // scope 0 at $DIR/match_false_edges.rs:27:26: 27:27
         FakeRead(ForGuardBinding, _6);   // scope 0 at $DIR/match_false_edges.rs:27:26: 27:27
@@ -85,24 +81,28 @@ fn full_tested_match2() -> () {
         StorageDead(_8);                 // scope 2 at $DIR/match_false_edges.rs:27:36: 27:37
         StorageDead(_5);                 // scope 0 at $DIR/match_false_edges.rs:27:36: 27:37
         StorageDead(_6);                 // scope 0 at $DIR/match_false_edges.rs:27:36: 27:37
-        goto -> bb11;                    // scope 0 at $DIR/match_false_edges.rs:26:13: 30:6
+        goto -> bb10;                    // scope 0 at $DIR/match_false_edges.rs:26:13: 30:6
+    }
+
+    bb8: {
+        StorageDead(_7);                 // scope 0 at $DIR/match_false_edges.rs:27:36: 27:37
+        StorageDead(_6);                 // scope 0 at $DIR/match_false_edges.rs:27:36: 27:37
+        falseEdge -> [real: bb3, imaginary: bb1]; // scope 0 at $DIR/match_false_edges.rs:27:20: 27:27
     }
 
     bb9: {
-        StorageDead(_7);                 // scope 0 at $DIR/match_false_edges.rs:27:36: 27:37
-        StorageDead(_6);                 // scope 0 at $DIR/match_false_edges.rs:27:36: 27:37
-        falseEdge -> [real: bb4, imaginary: bb2]; // scope 0 at $DIR/match_false_edges.rs:27:20: 27:27
+        _1 = (const 3_i32, const 3_i32); // scope 0 at $DIR/match_false_edges.rs:28:17: 28:23
+        goto -> bb10;                    // scope 0 at $DIR/match_false_edges.rs:26:13: 30:6
     }
 
     bb10: {
-        _1 = (const 3_i32, const 3_i32); // scope 0 at $DIR/match_false_edges.rs:28:17: 28:23
-        goto -> bb11;                    // scope 0 at $DIR/match_false_edges.rs:26:13: 30:6
-    }
-
-    bb11: {
         StorageDead(_2);                 // scope 0 at $DIR/match_false_edges.rs:30:6: 30:7
         StorageDead(_1);                 // scope 0 at $DIR/match_false_edges.rs:30:6: 30:7
         _0 = const ();                   // scope 0 at $DIR/match_false_edges.rs:25:29: 31:2
         return;                          // scope 0 at $DIR/match_false_edges.rs:31:2: 31:2
+    }
+
+    bb11 (cleanup): {
+        resume;                          // scope 0 at $DIR/match_false_edges.rs:25:1: 31:2
     }
 }

--- a/src/test/mir-opt/match_false_edges.main.PromoteTemps.before.mir
+++ b/src/test/mir-opt/match_false_edges.main.PromoteTemps.before.mir
@@ -39,49 +39,45 @@ fn main() -> () {
         _2 = Option::<i32>::Some(const 1_i32); // scope 0 at $DIR/match_false_edges.rs:35:19: 35:26
         FakeRead(ForMatchedPlace, _2);   // scope 0 at $DIR/match_false_edges.rs:35:19: 35:26
         _4 = discriminant(_2);           // scope 0 at $DIR/match_false_edges.rs:36:9: 36:17
-        switchInt(move _4) -> [1_isize: bb3, otherwise: bb2]; // scope 0 at $DIR/match_false_edges.rs:36:9: 36:17
+        switchInt(move _4) -> [1_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/match_false_edges.rs:36:9: 36:17
     }
 
-    bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/match_false_edges.rs:34:1: 41:2
+    bb1: {
+        falseEdge -> [real: bb9, imaginary: bb4]; // scope 0 at $DIR/match_false_edges.rs:37:9: 37:11
     }
 
     bb2: {
-        falseEdge -> [real: bb10, imaginary: bb5]; // scope 0 at $DIR/match_false_edges.rs:37:9: 37:11
+        falseEdge -> [real: bb5, imaginary: bb1]; // scope 0 at $DIR/match_false_edges.rs:36:9: 36:17
     }
 
     bb3: {
-        falseEdge -> [real: bb6, imaginary: bb2]; // scope 0 at $DIR/match_false_edges.rs:36:9: 36:17
-    }
-
-    bb4: {
         StorageLive(_14);                // scope 0 at $DIR/match_false_edges.rs:39:9: 39:11
         _14 = _2;                        // scope 0 at $DIR/match_false_edges.rs:39:9: 39:11
         _1 = const 4_i32;                // scope 5 at $DIR/match_false_edges.rs:39:15: 39:16
         StorageDead(_14);                // scope 0 at $DIR/match_false_edges.rs:39:15: 39:16
-        goto -> bb15;                    // scope 0 at $DIR/match_false_edges.rs:35:13: 40:6
+        goto -> bb14;                    // scope 0 at $DIR/match_false_edges.rs:35:13: 40:6
+    }
+
+    bb4: {
+        falseEdge -> [real: bb10, imaginary: bb3]; // scope 0 at $DIR/match_false_edges.rs:38:9: 38:16
     }
 
     bb5: {
-        falseEdge -> [real: bb11, imaginary: bb4]; // scope 0 at $DIR/match_false_edges.rs:38:9: 38:16
-    }
-
-    bb6: {
         StorageLive(_7);                 // scope 0 at $DIR/match_false_edges.rs:36:14: 36:16
         _7 = &((_2 as Some).0: i32);     // scope 0 at $DIR/match_false_edges.rs:36:14: 36:16
         _5 = &shallow _2;                // scope 0 at $DIR/match_false_edges.rs:35:19: 35:26
         StorageLive(_8);                 // scope 0 at $DIR/match_false_edges.rs:36:21: 36:28
-        _8 = guard() -> [return: bb7, unwind: bb1]; // scope 0 at $DIR/match_false_edges.rs:36:21: 36:28
+        _8 = guard() -> [return: bb6, unwind: bb15]; // scope 0 at $DIR/match_false_edges.rs:36:21: 36:28
                                          // mir::Constant
                                          // + span: $DIR/match_false_edges.rs:36:21: 36:26
                                          // + literal: Const { ty: fn() -> bool {guard}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb7: {
-        switchInt(move _8) -> [false: bb9, otherwise: bb8]; // scope 0 at $DIR/match_false_edges.rs:36:21: 36:28
+    bb6: {
+        switchInt(move _8) -> [false: bb8, otherwise: bb7]; // scope 0 at $DIR/match_false_edges.rs:36:21: 36:28
     }
 
-    bb8: {
+    bb7: {
         StorageDead(_8);                 // scope 0 at $DIR/match_false_edges.rs:36:32: 36:33
         FakeRead(ForMatchGuard, _5);     // scope 0 at $DIR/match_false_edges.rs:36:27: 36:28
         FakeRead(ForGuardBinding, _7);   // scope 0 at $DIR/match_false_edges.rs:36:27: 36:28
@@ -90,42 +86,42 @@ fn main() -> () {
         _1 = const 1_i32;                // scope 2 at $DIR/match_false_edges.rs:36:32: 36:33
         StorageDead(_6);                 // scope 0 at $DIR/match_false_edges.rs:36:32: 36:33
         StorageDead(_7);                 // scope 0 at $DIR/match_false_edges.rs:36:32: 36:33
-        goto -> bb15;                    // scope 0 at $DIR/match_false_edges.rs:35:13: 40:6
+        goto -> bb14;                    // scope 0 at $DIR/match_false_edges.rs:35:13: 40:6
+    }
+
+    bb8: {
+        StorageDead(_8);                 // scope 0 at $DIR/match_false_edges.rs:36:32: 36:33
+        StorageDead(_7);                 // scope 0 at $DIR/match_false_edges.rs:36:32: 36:33
+        falseEdge -> [real: bb1, imaginary: bb1]; // scope 0 at $DIR/match_false_edges.rs:36:21: 36:28
     }
 
     bb9: {
-        StorageDead(_8);                 // scope 0 at $DIR/match_false_edges.rs:36:32: 36:33
-        StorageDead(_7);                 // scope 0 at $DIR/match_false_edges.rs:36:32: 36:33
-        falseEdge -> [real: bb2, imaginary: bb2]; // scope 0 at $DIR/match_false_edges.rs:36:21: 36:28
-    }
-
-    bb10: {
         StorageLive(_9);                 // scope 0 at $DIR/match_false_edges.rs:37:9: 37:11
         _9 = _2;                         // scope 0 at $DIR/match_false_edges.rs:37:9: 37:11
         _1 = const 2_i32;                // scope 3 at $DIR/match_false_edges.rs:37:15: 37:16
         StorageDead(_9);                 // scope 0 at $DIR/match_false_edges.rs:37:15: 37:16
-        goto -> bb15;                    // scope 0 at $DIR/match_false_edges.rs:35:13: 40:6
+        goto -> bb14;                    // scope 0 at $DIR/match_false_edges.rs:35:13: 40:6
     }
 
-    bb11: {
+    bb10: {
         StorageLive(_11);                // scope 0 at $DIR/match_false_edges.rs:38:14: 38:15
         _11 = &((_2 as Some).0: i32);    // scope 0 at $DIR/match_false_edges.rs:38:14: 38:15
         _5 = &shallow _2;                // scope 0 at $DIR/match_false_edges.rs:35:19: 35:26
         StorageLive(_12);                // scope 0 at $DIR/match_false_edges.rs:38:20: 38:29
         StorageLive(_13);                // scope 0 at $DIR/match_false_edges.rs:38:27: 38:28
         _13 = (*_11);                    // scope 0 at $DIR/match_false_edges.rs:38:27: 38:28
-        _12 = guard2(move _13) -> [return: bb12, unwind: bb1]; // scope 0 at $DIR/match_false_edges.rs:38:20: 38:29
+        _12 = guard2(move _13) -> [return: bb11, unwind: bb15]; // scope 0 at $DIR/match_false_edges.rs:38:20: 38:29
                                          // mir::Constant
                                          // + span: $DIR/match_false_edges.rs:38:20: 38:26
                                          // + literal: Const { ty: fn(i32) -> bool {guard2}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb12: {
+    bb11: {
         StorageDead(_13);                // scope 0 at $DIR/match_false_edges.rs:38:28: 38:29
-        switchInt(move _12) -> [false: bb14, otherwise: bb13]; // scope 0 at $DIR/match_false_edges.rs:38:20: 38:29
+        switchInt(move _12) -> [false: bb13, otherwise: bb12]; // scope 0 at $DIR/match_false_edges.rs:38:20: 38:29
     }
 
-    bb13: {
+    bb12: {
         StorageDead(_12);                // scope 0 at $DIR/match_false_edges.rs:38:33: 38:34
         FakeRead(ForMatchGuard, _5);     // scope 0 at $DIR/match_false_edges.rs:38:28: 38:29
         FakeRead(ForGuardBinding, _11);  // scope 0 at $DIR/match_false_edges.rs:38:28: 38:29
@@ -134,19 +130,23 @@ fn main() -> () {
         _1 = const 3_i32;                // scope 4 at $DIR/match_false_edges.rs:38:33: 38:34
         StorageDead(_10);                // scope 0 at $DIR/match_false_edges.rs:38:33: 38:34
         StorageDead(_11);                // scope 0 at $DIR/match_false_edges.rs:38:33: 38:34
-        goto -> bb15;                    // scope 0 at $DIR/match_false_edges.rs:35:13: 40:6
+        goto -> bb14;                    // scope 0 at $DIR/match_false_edges.rs:35:13: 40:6
+    }
+
+    bb13: {
+        StorageDead(_12);                // scope 0 at $DIR/match_false_edges.rs:38:33: 38:34
+        StorageDead(_11);                // scope 0 at $DIR/match_false_edges.rs:38:33: 38:34
+        falseEdge -> [real: bb3, imaginary: bb3]; // scope 0 at $DIR/match_false_edges.rs:38:20: 38:29
     }
 
     bb14: {
-        StorageDead(_12);                // scope 0 at $DIR/match_false_edges.rs:38:33: 38:34
-        StorageDead(_11);                // scope 0 at $DIR/match_false_edges.rs:38:33: 38:34
-        falseEdge -> [real: bb4, imaginary: bb4]; // scope 0 at $DIR/match_false_edges.rs:38:20: 38:29
-    }
-
-    bb15: {
         StorageDead(_2);                 // scope 0 at $DIR/match_false_edges.rs:40:6: 40:7
         StorageDead(_1);                 // scope 0 at $DIR/match_false_edges.rs:40:6: 40:7
         _0 = const ();                   // scope 0 at $DIR/match_false_edges.rs:34:11: 41:2
         return;                          // scope 0 at $DIR/match_false_edges.rs:41:2: 41:2
+    }
+
+    bb15 (cleanup): {
+        resume;                          // scope 0 at $DIR/match_false_edges.rs:34:1: 41:2
     }
 }

--- a/src/test/mir-opt/nll/region_subtyping_basic.main.nll.0.32bit.mir
+++ b/src/test/mir-opt/nll/region_subtyping_basic.main.nll.0.32bit.mir
@@ -5,21 +5,21 @@
 | '_#1r | Local | ['_#1r]
 |
 | Inferred Region Values
-| '_#0r | U0 | {bb0[0..=8], bb1[0], bb2[0..=8], bb3[0], bb4[0..=1], bb5[0..=3], bb6[0..=3], bb7[0..=2], bb8[0..=5], '_#0r, '_#1r}
-| '_#1r | U0 | {bb0[0..=8], bb1[0], bb2[0..=8], bb3[0], bb4[0..=1], bb5[0..=3], bb6[0..=3], bb7[0..=2], bb8[0..=5], '_#1r}
+| '_#0r | U0 | {bb0[0..=8], bb1[0..=8], bb2[0], bb3[0..=1], bb4[0..=3], bb5[0..=3], bb6[0..=2], bb7[0..=5], bb8[0], '_#0r, '_#1r}
+| '_#1r | U0 | {bb0[0..=8], bb1[0..=8], bb2[0], bb3[0..=1], bb4[0..=3], bb5[0..=3], bb6[0..=2], bb7[0..=5], bb8[0], '_#1r}
 | '_#2r | U0 | {}
-| '_#3r | U0 | {bb2[0..=8], bb3[0], bb5[0..=2]}
-| '_#4r | U0 | {bb2[1..=8], bb3[0], bb5[0..=2]}
-| '_#5r | U0 | {bb2[4..=8], bb3[0], bb5[0..=2]}
+| '_#3r | U0 | {bb1[0..=8], bb2[0], bb4[0..=2]}
+| '_#4r | U0 | {bb1[1..=8], bb2[0], bb4[0..=2]}
+| '_#5r | U0 | {bb1[4..=8], bb2[0], bb4[0..=2]}
 |
 | Inference Constraints
-| '_#0r live at {bb0[0..=8], bb1[0], bb2[0..=8], bb3[0], bb4[0..=1], bb5[0..=3], bb6[0..=3], bb7[0..=2], bb8[0..=5]}
-| '_#1r live at {bb0[0..=8], bb1[0], bb2[0..=8], bb3[0], bb4[0..=1], bb5[0..=3], bb6[0..=3], bb7[0..=2], bb8[0..=5]}
-| '_#3r live at {bb2[0]}
-| '_#4r live at {bb2[1..=3]}
-| '_#5r live at {bb2[4..=8], bb3[0], bb5[0..=2]}
-| '_#3r: '_#4r due to Assignment at Single(bb2[0])
-| '_#4r: '_#5r due to Assignment at Single(bb2[3])
+| '_#0r live at {bb0[0..=8], bb1[0..=8], bb2[0], bb3[0..=1], bb4[0..=3], bb5[0..=3], bb6[0..=2], bb7[0..=5], bb8[0]}
+| '_#1r live at {bb0[0..=8], bb1[0..=8], bb2[0], bb3[0..=1], bb4[0..=3], bb5[0..=3], bb6[0..=2], bb7[0..=5], bb8[0]}
+| '_#3r live at {bb1[0]}
+| '_#4r live at {bb1[1..=3]}
+| '_#5r live at {bb1[4..=8], bb2[0], bb4[0..=2]}
+| '_#3r: '_#4r due to Assignment at Single(bb1[0])
+| '_#4r: '_#5r due to Assignment at Single(bb1[3])
 |
 fn main() -> () {
     let mut _0: ();                      // return place in scope 0 at $DIR/region-subtyping-basic.rs:16:11: 16:11
@@ -52,66 +52,66 @@ fn main() -> () {
         _3 = const Const(Value(Scalar(0x00000000)): usize); // bb0[5]: scope 1 at $DIR/region-subtyping-basic.rs:18:16: 18:17
         _4 = Len(_1);                    // bb0[6]: scope 1 at $DIR/region-subtyping-basic.rs:18:14: 18:18
         _5 = Lt(_3, _4);                 // bb0[7]: scope 1 at $DIR/region-subtyping-basic.rs:18:14: 18:18
-        assert(move _5, "index out of bounds: the length is {} but the index is {}", move _4, _3) -> [success: bb2, unwind: bb1]; // bb0[8]: scope 1 at $DIR/region-subtyping-basic.rs:18:14: 18:18
+        assert(move _5, "index out of bounds: the length is {} but the index is {}", move _4, _3) -> [success: bb1, unwind: bb8]; // bb0[8]: scope 1 at $DIR/region-subtyping-basic.rs:18:14: 18:18
     }
 
-    bb1 (cleanup): {
-        resume;                          // bb1[0]: scope 0 at $DIR/region-subtyping-basic.rs:16:1: 25:2
+    bb1: {
+        _2 = &'_#3r _1[_3];              // bb1[0]: scope 1 at $DIR/region-subtyping-basic.rs:18:13: 18:18
+        FakeRead(ForLet, _2);            // bb1[1]: scope 1 at $DIR/region-subtyping-basic.rs:18:9: 18:10
+        StorageLive(_6);                 // bb1[2]: scope 2 at $DIR/region-subtyping-basic.rs:19:9: 19:10
+        _6 = _2;                         // bb1[3]: scope 2 at $DIR/region-subtyping-basic.rs:19:13: 19:14
+        FakeRead(ForLet, _6);            // bb1[4]: scope 2 at $DIR/region-subtyping-basic.rs:19:9: 19:10
+        StorageLive(_7);                 // bb1[5]: scope 3 at $DIR/region-subtyping-basic.rs:20:8: 20:12
+        _7 = const Const(Value(Scalar(0x01)): bool); // bb1[6]: scope 3 at $DIR/region-subtyping-basic.rs:20:8: 20:12
+        FakeRead(ForMatchedPlace, _7);   // bb1[7]: scope 3 at $DIR/region-subtyping-basic.rs:20:8: 20:12
+        switchInt(_7) -> [Const(Value(Scalar(0x00)): bool): bb3, otherwise: bb2]; // bb1[8]: scope 3 at $DIR/region-subtyping-basic.rs:20:5: 24:6
     }
 
     bb2: {
-        _2 = &'_#3r _1[_3];              // bb2[0]: scope 1 at $DIR/region-subtyping-basic.rs:18:13: 18:18
-        FakeRead(ForLet, _2);            // bb2[1]: scope 1 at $DIR/region-subtyping-basic.rs:18:9: 18:10
-        StorageLive(_6);                 // bb2[2]: scope 2 at $DIR/region-subtyping-basic.rs:19:9: 19:10
-        _6 = _2;                         // bb2[3]: scope 2 at $DIR/region-subtyping-basic.rs:19:13: 19:14
-        FakeRead(ForLet, _6);            // bb2[4]: scope 2 at $DIR/region-subtyping-basic.rs:19:9: 19:10
-        StorageLive(_7);                 // bb2[5]: scope 3 at $DIR/region-subtyping-basic.rs:20:8: 20:12
-        _7 = const Const(Value(Scalar(0x01)): bool); // bb2[6]: scope 3 at $DIR/region-subtyping-basic.rs:20:8: 20:12
-        FakeRead(ForMatchedPlace, _7);   // bb2[7]: scope 3 at $DIR/region-subtyping-basic.rs:20:8: 20:12
-        switchInt(_7) -> [Const(Value(Scalar(0x00)): bool): bb4, otherwise: bb3]; // bb2[8]: scope 3 at $DIR/region-subtyping-basic.rs:20:5: 24:6
+        falseEdge -> [real: bb4, imaginary: bb3]; // bb2[0]: scope 3 at $DIR/region-subtyping-basic.rs:20:5: 24:6
     }
 
     bb3: {
-        falseEdge -> [real: bb5, imaginary: bb4]; // bb3[0]: scope 3 at $DIR/region-subtyping-basic.rs:20:5: 24:6
-    }
-
-    bb4: {
-        StorageLive(_10);                // bb4[0]: scope 3 at $DIR/region-subtyping-basic.rs:23:9: 23:18
-        _10 = Const(Value(Scalar(<ZST>)): fn(usize) -> bool {use_x})(const Const(Value(Scalar(0x00000016)): usize)) -> [return: bb7, unwind: bb1]; // bb4[1]: scope 3 at $DIR/region-subtyping-basic.rs:23:9: 23:18
+        StorageLive(_10);                // bb3[0]: scope 3 at $DIR/region-subtyping-basic.rs:23:9: 23:18
+        _10 = Const(Value(Scalar(<ZST>)): fn(usize) -> bool {use_x})(const Const(Value(Scalar(0x00000016)): usize)) -> [return: bb6, unwind: bb8]; // bb3[1]: scope 3 at $DIR/region-subtyping-basic.rs:23:9: 23:18
                                          // mir::Constant
                                          // + span: $DIR/region-subtyping-basic.rs:23:9: 23:14
                                          // + literal: Const { ty: fn(usize) -> bool {use_x}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb5: {
-        StorageLive(_8);                 // bb5[0]: scope 3 at $DIR/region-subtyping-basic.rs:21:9: 21:18
-        StorageLive(_9);                 // bb5[1]: scope 3 at $DIR/region-subtyping-basic.rs:21:15: 21:17
-        _9 = (*_6);                      // bb5[2]: scope 3 at $DIR/region-subtyping-basic.rs:21:15: 21:17
-        _8 = Const(Value(Scalar(<ZST>)): fn(usize) -> bool {use_x})(move _9) -> [return: bb6, unwind: bb1]; // bb5[3]: scope 3 at $DIR/region-subtyping-basic.rs:21:9: 21:18
+    bb4: {
+        StorageLive(_8);                 // bb4[0]: scope 3 at $DIR/region-subtyping-basic.rs:21:9: 21:18
+        StorageLive(_9);                 // bb4[1]: scope 3 at $DIR/region-subtyping-basic.rs:21:15: 21:17
+        _9 = (*_6);                      // bb4[2]: scope 3 at $DIR/region-subtyping-basic.rs:21:15: 21:17
+        _8 = Const(Value(Scalar(<ZST>)): fn(usize) -> bool {use_x})(move _9) -> [return: bb5, unwind: bb8]; // bb4[3]: scope 3 at $DIR/region-subtyping-basic.rs:21:9: 21:18
                                          // mir::Constant
                                          // + span: $DIR/region-subtyping-basic.rs:21:9: 21:14
                                          // + literal: Const { ty: fn(usize) -> bool {use_x}, val: Value(Scalar(<ZST>)) }
     }
 
+    bb5: {
+        StorageDead(_9);                 // bb5[0]: scope 3 at $DIR/region-subtyping-basic.rs:21:17: 21:18
+        StorageDead(_8);                 // bb5[1]: scope 3 at $DIR/region-subtyping-basic.rs:21:18: 21:19
+        _0 = const Const(Value(Scalar(<ZST>)): ()); // bb5[2]: scope 3 at $DIR/region-subtyping-basic.rs:20:13: 22:6
+        goto -> bb7;                     // bb5[3]: scope 3 at $DIR/region-subtyping-basic.rs:20:5: 24:6
+    }
+
     bb6: {
-        StorageDead(_9);                 // bb6[0]: scope 3 at $DIR/region-subtyping-basic.rs:21:17: 21:18
-        StorageDead(_8);                 // bb6[1]: scope 3 at $DIR/region-subtyping-basic.rs:21:18: 21:19
-        _0 = const Const(Value(Scalar(<ZST>)): ()); // bb6[2]: scope 3 at $DIR/region-subtyping-basic.rs:20:13: 22:6
-        goto -> bb8;                     // bb6[3]: scope 3 at $DIR/region-subtyping-basic.rs:20:5: 24:6
+        StorageDead(_10);                // bb6[0]: scope 3 at $DIR/region-subtyping-basic.rs:23:18: 23:19
+        _0 = const Const(Value(Scalar(<ZST>)): ()); // bb6[1]: scope 3 at $DIR/region-subtyping-basic.rs:22:12: 24:6
+        goto -> bb7;                     // bb6[2]: scope 3 at $DIR/region-subtyping-basic.rs:20:5: 24:6
     }
 
     bb7: {
-        StorageDead(_10);                // bb7[0]: scope 3 at $DIR/region-subtyping-basic.rs:23:18: 23:19
-        _0 = const Const(Value(Scalar(<ZST>)): ()); // bb7[1]: scope 3 at $DIR/region-subtyping-basic.rs:22:12: 24:6
-        goto -> bb8;                     // bb7[2]: scope 3 at $DIR/region-subtyping-basic.rs:20:5: 24:6
+        StorageDead(_6);                 // bb7[0]: scope 2 at $DIR/region-subtyping-basic.rs:25:1: 25:2
+        StorageDead(_3);                 // bb7[1]: scope 1 at $DIR/region-subtyping-basic.rs:25:1: 25:2
+        StorageDead(_2);                 // bb7[2]: scope 1 at $DIR/region-subtyping-basic.rs:25:1: 25:2
+        StorageDead(_1);                 // bb7[3]: scope 0 at $DIR/region-subtyping-basic.rs:25:1: 25:2
+        StorageDead(_7);                 // bb7[4]: scope 0 at $DIR/region-subtyping-basic.rs:25:1: 25:2
+        return;                          // bb7[5]: scope 0 at $DIR/region-subtyping-basic.rs:25:2: 25:2
     }
 
-    bb8: {
-        StorageDead(_6);                 // bb8[0]: scope 2 at $DIR/region-subtyping-basic.rs:25:1: 25:2
-        StorageDead(_3);                 // bb8[1]: scope 1 at $DIR/region-subtyping-basic.rs:25:1: 25:2
-        StorageDead(_2);                 // bb8[2]: scope 1 at $DIR/region-subtyping-basic.rs:25:1: 25:2
-        StorageDead(_1);                 // bb8[3]: scope 0 at $DIR/region-subtyping-basic.rs:25:1: 25:2
-        StorageDead(_7);                 // bb8[4]: scope 0 at $DIR/region-subtyping-basic.rs:25:1: 25:2
-        return;                          // bb8[5]: scope 0 at $DIR/region-subtyping-basic.rs:25:2: 25:2
+    bb8 (cleanup): {
+        resume;                          // bb8[0]: scope 0 at $DIR/region-subtyping-basic.rs:16:1: 25:2
     }
 }

--- a/src/test/mir-opt/nll/region_subtyping_basic.main.nll.0.64bit.mir
+++ b/src/test/mir-opt/nll/region_subtyping_basic.main.nll.0.64bit.mir
@@ -5,21 +5,21 @@
 | '_#1r | Local | ['_#1r]
 |
 | Inferred Region Values
-| '_#0r | U0 | {bb0[0..=8], bb1[0], bb2[0..=8], bb3[0], bb4[0..=1], bb5[0..=3], bb6[0..=3], bb7[0..=2], bb8[0..=5], '_#0r, '_#1r}
-| '_#1r | U0 | {bb0[0..=8], bb1[0], bb2[0..=8], bb3[0], bb4[0..=1], bb5[0..=3], bb6[0..=3], bb7[0..=2], bb8[0..=5], '_#1r}
+| '_#0r | U0 | {bb0[0..=8], bb1[0..=8], bb2[0], bb3[0..=1], bb4[0..=3], bb5[0..=3], bb6[0..=2], bb7[0..=5], bb8[0], '_#0r, '_#1r}
+| '_#1r | U0 | {bb0[0..=8], bb1[0..=8], bb2[0], bb3[0..=1], bb4[0..=3], bb5[0..=3], bb6[0..=2], bb7[0..=5], bb8[0], '_#1r}
 | '_#2r | U0 | {}
-| '_#3r | U0 | {bb2[0..=8], bb3[0], bb5[0..=2]}
-| '_#4r | U0 | {bb2[1..=8], bb3[0], bb5[0..=2]}
-| '_#5r | U0 | {bb2[4..=8], bb3[0], bb5[0..=2]}
+| '_#3r | U0 | {bb1[0..=8], bb2[0], bb4[0..=2]}
+| '_#4r | U0 | {bb1[1..=8], bb2[0], bb4[0..=2]}
+| '_#5r | U0 | {bb1[4..=8], bb2[0], bb4[0..=2]}
 |
 | Inference Constraints
-| '_#0r live at {bb0[0..=8], bb1[0], bb2[0..=8], bb3[0], bb4[0..=1], bb5[0..=3], bb6[0..=3], bb7[0..=2], bb8[0..=5]}
-| '_#1r live at {bb0[0..=8], bb1[0], bb2[0..=8], bb3[0], bb4[0..=1], bb5[0..=3], bb6[0..=3], bb7[0..=2], bb8[0..=5]}
-| '_#3r live at {bb2[0]}
-| '_#4r live at {bb2[1..=3]}
-| '_#5r live at {bb2[4..=8], bb3[0], bb5[0..=2]}
-| '_#3r: '_#4r due to Assignment at Single(bb2[0])
-| '_#4r: '_#5r due to Assignment at Single(bb2[3])
+| '_#0r live at {bb0[0..=8], bb1[0..=8], bb2[0], bb3[0..=1], bb4[0..=3], bb5[0..=3], bb6[0..=2], bb7[0..=5], bb8[0]}
+| '_#1r live at {bb0[0..=8], bb1[0..=8], bb2[0], bb3[0..=1], bb4[0..=3], bb5[0..=3], bb6[0..=2], bb7[0..=5], bb8[0]}
+| '_#3r live at {bb1[0]}
+| '_#4r live at {bb1[1..=3]}
+| '_#5r live at {bb1[4..=8], bb2[0], bb4[0..=2]}
+| '_#3r: '_#4r due to Assignment at Single(bb1[0])
+| '_#4r: '_#5r due to Assignment at Single(bb1[3])
 |
 fn main() -> () {
     let mut _0: ();                      // return place in scope 0 at $DIR/region-subtyping-basic.rs:16:11: 16:11
@@ -52,66 +52,66 @@ fn main() -> () {
         _3 = const Const(Value(Scalar(0x0000000000000000)): usize); // bb0[5]: scope 1 at $DIR/region-subtyping-basic.rs:18:16: 18:17
         _4 = Len(_1);                    // bb0[6]: scope 1 at $DIR/region-subtyping-basic.rs:18:14: 18:18
         _5 = Lt(_3, _4);                 // bb0[7]: scope 1 at $DIR/region-subtyping-basic.rs:18:14: 18:18
-        assert(move _5, "index out of bounds: the length is {} but the index is {}", move _4, _3) -> [success: bb2, unwind: bb1]; // bb0[8]: scope 1 at $DIR/region-subtyping-basic.rs:18:14: 18:18
+        assert(move _5, "index out of bounds: the length is {} but the index is {}", move _4, _3) -> [success: bb1, unwind: bb8]; // bb0[8]: scope 1 at $DIR/region-subtyping-basic.rs:18:14: 18:18
     }
 
-    bb1 (cleanup): {
-        resume;                          // bb1[0]: scope 0 at $DIR/region-subtyping-basic.rs:16:1: 25:2
+    bb1: {
+        _2 = &'_#3r _1[_3];              // bb1[0]: scope 1 at $DIR/region-subtyping-basic.rs:18:13: 18:18
+        FakeRead(ForLet, _2);            // bb1[1]: scope 1 at $DIR/region-subtyping-basic.rs:18:9: 18:10
+        StorageLive(_6);                 // bb1[2]: scope 2 at $DIR/region-subtyping-basic.rs:19:9: 19:10
+        _6 = _2;                         // bb1[3]: scope 2 at $DIR/region-subtyping-basic.rs:19:13: 19:14
+        FakeRead(ForLet, _6);            // bb1[4]: scope 2 at $DIR/region-subtyping-basic.rs:19:9: 19:10
+        StorageLive(_7);                 // bb1[5]: scope 3 at $DIR/region-subtyping-basic.rs:20:8: 20:12
+        _7 = const Const(Value(Scalar(0x01)): bool); // bb1[6]: scope 3 at $DIR/region-subtyping-basic.rs:20:8: 20:12
+        FakeRead(ForMatchedPlace, _7);   // bb1[7]: scope 3 at $DIR/region-subtyping-basic.rs:20:8: 20:12
+        switchInt(_7) -> [Const(Value(Scalar(0x00)): bool): bb3, otherwise: bb2]; // bb1[8]: scope 3 at $DIR/region-subtyping-basic.rs:20:5: 24:6
     }
 
     bb2: {
-        _2 = &'_#3r _1[_3];              // bb2[0]: scope 1 at $DIR/region-subtyping-basic.rs:18:13: 18:18
-        FakeRead(ForLet, _2);            // bb2[1]: scope 1 at $DIR/region-subtyping-basic.rs:18:9: 18:10
-        StorageLive(_6);                 // bb2[2]: scope 2 at $DIR/region-subtyping-basic.rs:19:9: 19:10
-        _6 = _2;                         // bb2[3]: scope 2 at $DIR/region-subtyping-basic.rs:19:13: 19:14
-        FakeRead(ForLet, _6);            // bb2[4]: scope 2 at $DIR/region-subtyping-basic.rs:19:9: 19:10
-        StorageLive(_7);                 // bb2[5]: scope 3 at $DIR/region-subtyping-basic.rs:20:8: 20:12
-        _7 = const Const(Value(Scalar(0x01)): bool); // bb2[6]: scope 3 at $DIR/region-subtyping-basic.rs:20:8: 20:12
-        FakeRead(ForMatchedPlace, _7);   // bb2[7]: scope 3 at $DIR/region-subtyping-basic.rs:20:8: 20:12
-        switchInt(_7) -> [Const(Value(Scalar(0x00)): bool): bb4, otherwise: bb3]; // bb2[8]: scope 3 at $DIR/region-subtyping-basic.rs:20:5: 24:6
+        falseEdge -> [real: bb4, imaginary: bb3]; // bb2[0]: scope 3 at $DIR/region-subtyping-basic.rs:20:5: 24:6
     }
 
     bb3: {
-        falseEdge -> [real: bb5, imaginary: bb4]; // bb3[0]: scope 3 at $DIR/region-subtyping-basic.rs:20:5: 24:6
-    }
-
-    bb4: {
-        StorageLive(_10);                // bb4[0]: scope 3 at $DIR/region-subtyping-basic.rs:23:9: 23:18
-        _10 = Const(Value(Scalar(<ZST>)): fn(usize) -> bool {use_x})(const Const(Value(Scalar(0x0000000000000016)): usize)) -> [return: bb7, unwind: bb1]; // bb4[1]: scope 3 at $DIR/region-subtyping-basic.rs:23:9: 23:18
+        StorageLive(_10);                // bb3[0]: scope 3 at $DIR/region-subtyping-basic.rs:23:9: 23:18
+        _10 = Const(Value(Scalar(<ZST>)): fn(usize) -> bool {use_x})(const Const(Value(Scalar(0x0000000000000016)): usize)) -> [return: bb6, unwind: bb8]; // bb3[1]: scope 3 at $DIR/region-subtyping-basic.rs:23:9: 23:18
                                          // mir::Constant
                                          // + span: $DIR/region-subtyping-basic.rs:23:9: 23:14
                                          // + literal: Const { ty: fn(usize) -> bool {use_x}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb5: {
-        StorageLive(_8);                 // bb5[0]: scope 3 at $DIR/region-subtyping-basic.rs:21:9: 21:18
-        StorageLive(_9);                 // bb5[1]: scope 3 at $DIR/region-subtyping-basic.rs:21:15: 21:17
-        _9 = (*_6);                      // bb5[2]: scope 3 at $DIR/region-subtyping-basic.rs:21:15: 21:17
-        _8 = Const(Value(Scalar(<ZST>)): fn(usize) -> bool {use_x})(move _9) -> [return: bb6, unwind: bb1]; // bb5[3]: scope 3 at $DIR/region-subtyping-basic.rs:21:9: 21:18
+    bb4: {
+        StorageLive(_8);                 // bb4[0]: scope 3 at $DIR/region-subtyping-basic.rs:21:9: 21:18
+        StorageLive(_9);                 // bb4[1]: scope 3 at $DIR/region-subtyping-basic.rs:21:15: 21:17
+        _9 = (*_6);                      // bb4[2]: scope 3 at $DIR/region-subtyping-basic.rs:21:15: 21:17
+        _8 = Const(Value(Scalar(<ZST>)): fn(usize) -> bool {use_x})(move _9) -> [return: bb5, unwind: bb8]; // bb4[3]: scope 3 at $DIR/region-subtyping-basic.rs:21:9: 21:18
                                          // mir::Constant
                                          // + span: $DIR/region-subtyping-basic.rs:21:9: 21:14
                                          // + literal: Const { ty: fn(usize) -> bool {use_x}, val: Value(Scalar(<ZST>)) }
     }
 
+    bb5: {
+        StorageDead(_9);                 // bb5[0]: scope 3 at $DIR/region-subtyping-basic.rs:21:17: 21:18
+        StorageDead(_8);                 // bb5[1]: scope 3 at $DIR/region-subtyping-basic.rs:21:18: 21:19
+        _0 = const Const(Value(Scalar(<ZST>)): ()); // bb5[2]: scope 3 at $DIR/region-subtyping-basic.rs:20:13: 22:6
+        goto -> bb7;                     // bb5[3]: scope 3 at $DIR/region-subtyping-basic.rs:20:5: 24:6
+    }
+
     bb6: {
-        StorageDead(_9);                 // bb6[0]: scope 3 at $DIR/region-subtyping-basic.rs:21:17: 21:18
-        StorageDead(_8);                 // bb6[1]: scope 3 at $DIR/region-subtyping-basic.rs:21:18: 21:19
-        _0 = const Const(Value(Scalar(<ZST>)): ()); // bb6[2]: scope 3 at $DIR/region-subtyping-basic.rs:20:13: 22:6
-        goto -> bb8;                     // bb6[3]: scope 3 at $DIR/region-subtyping-basic.rs:20:5: 24:6
+        StorageDead(_10);                // bb6[0]: scope 3 at $DIR/region-subtyping-basic.rs:23:18: 23:19
+        _0 = const Const(Value(Scalar(<ZST>)): ()); // bb6[1]: scope 3 at $DIR/region-subtyping-basic.rs:22:12: 24:6
+        goto -> bb7;                     // bb6[2]: scope 3 at $DIR/region-subtyping-basic.rs:20:5: 24:6
     }
 
     bb7: {
-        StorageDead(_10);                // bb7[0]: scope 3 at $DIR/region-subtyping-basic.rs:23:18: 23:19
-        _0 = const Const(Value(Scalar(<ZST>)): ()); // bb7[1]: scope 3 at $DIR/region-subtyping-basic.rs:22:12: 24:6
-        goto -> bb8;                     // bb7[2]: scope 3 at $DIR/region-subtyping-basic.rs:20:5: 24:6
+        StorageDead(_6);                 // bb7[0]: scope 2 at $DIR/region-subtyping-basic.rs:25:1: 25:2
+        StorageDead(_3);                 // bb7[1]: scope 1 at $DIR/region-subtyping-basic.rs:25:1: 25:2
+        StorageDead(_2);                 // bb7[2]: scope 1 at $DIR/region-subtyping-basic.rs:25:1: 25:2
+        StorageDead(_1);                 // bb7[3]: scope 0 at $DIR/region-subtyping-basic.rs:25:1: 25:2
+        StorageDead(_7);                 // bb7[4]: scope 0 at $DIR/region-subtyping-basic.rs:25:1: 25:2
+        return;                          // bb7[5]: scope 0 at $DIR/region-subtyping-basic.rs:25:2: 25:2
     }
 
-    bb8: {
-        StorageDead(_6);                 // bb8[0]: scope 2 at $DIR/region-subtyping-basic.rs:25:1: 25:2
-        StorageDead(_3);                 // bb8[1]: scope 1 at $DIR/region-subtyping-basic.rs:25:1: 25:2
-        StorageDead(_2);                 // bb8[2]: scope 1 at $DIR/region-subtyping-basic.rs:25:1: 25:2
-        StorageDead(_1);                 // bb8[3]: scope 0 at $DIR/region-subtyping-basic.rs:25:1: 25:2
-        StorageDead(_7);                 // bb8[4]: scope 0 at $DIR/region-subtyping-basic.rs:25:1: 25:2
-        return;                          // bb8[5]: scope 0 at $DIR/region-subtyping-basic.rs:25:2: 25:2
+    bb8 (cleanup): {
+        resume;                          // bb8[0]: scope 0 at $DIR/region-subtyping-basic.rs:16:1: 25:2
     }
 }

--- a/src/test/mir-opt/no_drop_for_inactive_variant.unwrap.SimplifyCfg-elaborate-drops.after.mir
+++ b/src/test/mir-opt/no_drop_for_inactive_variant.unwrap.SimplifyCfg-elaborate-drops.after.mir
@@ -41,12 +41,12 @@ fn unwrap(_1: Option<T>) -> T {
         _3 = move ((_1 as Some).0: T);   // scope 0 at $DIR/no-drop-for-inactive-variant.rs:9:14: 9:15
         _0 = move _3;                    // scope 1 at $DIR/no-drop-for-inactive-variant.rs:9:20: 9:21
         StorageDead(_3);                 // scope 0 at $DIR/no-drop-for-inactive-variant.rs:9:20: 9:21
-        _6 = discriminant(_1);           // scope 0 at $DIR/no-drop-for-inactive-variant.rs:12:1: 12:2
+        _5 = discriminant(_1);           // scope 0 at $DIR/no-drop-for-inactive-variant.rs:12:1: 12:2
         return;                          // scope 0 at $DIR/no-drop-for-inactive-variant.rs:12:2: 12:2
     }
 
     bb4 (cleanup): {
-        _5 = discriminant(_1);           // scope 0 at $DIR/no-drop-for-inactive-variant.rs:12:1: 12:2
+        _7 = discriminant(_1);           // scope 0 at $DIR/no-drop-for-inactive-variant.rs:12:1: 12:2
         resume;                          // scope 0 at $DIR/no-drop-for-inactive-variant.rs:7:1: 12:2
     }
 }

--- a/src/test/mir-opt/no_spurious_drop_after_call.main.ElaborateDrops.before.mir
+++ b/src/test/mir-opt/no_spurious_drop_after_call.main.ElaborateDrops.before.mir
@@ -20,25 +20,21 @@ fn main() -> () {
                                          // + span: $DIR/no-spurious-drop-after-call.rs:9:20: 9:22
                                          // + literal: Const { ty: &str, val: Value(Slice { data: Allocation { bytes: [], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [], len: Size { raw: 0 } }, size: Size { raw: 0 }, align: Align { pow2: 0 }, mutability: Not, extra: () }, start: 0, end: 0 }) }
         _3 = &(*_4);                     // scope 0 at $DIR/no-spurious-drop-after-call.rs:9:20: 9:22
-        _2 = <str as ToString>::to_string(move _3) -> bb2; // scope 0 at $DIR/no-spurious-drop-after-call.rs:9:20: 9:34
+        _2 = <str as ToString>::to_string(move _3) -> bb1; // scope 0 at $DIR/no-spurious-drop-after-call.rs:9:20: 9:34
                                          // mir::Constant
                                          // + span: $DIR/no-spurious-drop-after-call.rs:9:23: 9:32
                                          // + literal: Const { ty: for<'r> fn(&'r str) -> std::string::String {<str as std::string::ToString>::to_string}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/no-spurious-drop-after-call.rs:8:1: 10:2
-    }
-
-    bb2: {
+    bb1: {
         StorageDead(_3);                 // scope 0 at $DIR/no-spurious-drop-after-call.rs:9:33: 9:34
-        _1 = std::mem::drop::<String>(move _2) -> [return: bb3, unwind: bb4]; // scope 0 at $DIR/no-spurious-drop-after-call.rs:9:5: 9:35
+        _1 = std::mem::drop::<String>(move _2) -> [return: bb2, unwind: bb3]; // scope 0 at $DIR/no-spurious-drop-after-call.rs:9:5: 9:35
                                          // mir::Constant
                                          // + span: $DIR/no-spurious-drop-after-call.rs:9:5: 9:19
                                          // + literal: Const { ty: fn(std::string::String) {std::mem::drop::<std::string::String>}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb3: {
+    bb2: {
         StorageDead(_2);                 // scope 0 at $DIR/no-spurious-drop-after-call.rs:9:34: 9:35
         StorageDead(_4);                 // scope 0 at $DIR/no-spurious-drop-after-call.rs:9:35: 9:36
         StorageDead(_1);                 // scope 0 at $DIR/no-spurious-drop-after-call.rs:9:35: 9:36
@@ -46,7 +42,11 @@ fn main() -> () {
         return;                          // scope 0 at $DIR/no-spurious-drop-after-call.rs:10:2: 10:2
     }
 
+    bb3 (cleanup): {
+        drop(_2) -> bb4;                 // scope 0 at $DIR/no-spurious-drop-after-call.rs:9:34: 9:35
+    }
+
     bb4 (cleanup): {
-        drop(_2) -> bb1;                 // scope 0 at $DIR/no-spurious-drop-after-call.rs:9:34: 9:35
+        resume;                          // scope 0 at $DIR/no-spurious-drop-after-call.rs:8:1: 10:2
     }
 }

--- a/src/test/mir-opt/packed_struct_drop_aligned.main.SimplifyCfg-elaborate-drops.after.32bit.mir
+++ b/src/test/mir-opt/packed_struct_drop_aligned.main.SimplifyCfg-elaborate-drops.after.32bit.mir
@@ -31,18 +31,18 @@ fn main() -> () {
         drop(_6) -> [return: bb4, unwind: bb3]; // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:5: 7:8
     }
 
-    bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/packed-struct-drop-aligned.rs:5:1: 8:2
-    }
-
-    bb2: {
+    bb1: {
         StorageDead(_1);                 // scope 0 at $DIR/packed-struct-drop-aligned.rs:8:1: 8:2
         return;                          // scope 0 at $DIR/packed-struct-drop-aligned.rs:8:2: 8:2
     }
 
+    bb2 (cleanup): {
+        resume;                          // scope 0 at $DIR/packed-struct-drop-aligned.rs:5:1: 8:2
+    }
+
     bb3 (cleanup): {
         (_1.0: Aligned) = move _4;       // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:5: 7:8
-        drop(_1) -> bb1;                 // scope 0 at $DIR/packed-struct-drop-aligned.rs:8:1: 8:2
+        drop(_1) -> bb2;                 // scope 0 at $DIR/packed-struct-drop-aligned.rs:8:1: 8:2
     }
 
     bb4: {
@@ -50,6 +50,6 @@ fn main() -> () {
         (_1.0: Aligned) = move _4;       // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:5: 7:8
         StorageDead(_4);                 // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:28: 7:29
         _0 = const ();                   // scope 0 at $DIR/packed-struct-drop-aligned.rs:5:11: 8:2
-        drop(_1) -> [return: bb2, unwind: bb1]; // scope 0 at $DIR/packed-struct-drop-aligned.rs:8:1: 8:2
+        drop(_1) -> [return: bb1, unwind: bb2]; // scope 0 at $DIR/packed-struct-drop-aligned.rs:8:1: 8:2
     }
 }

--- a/src/test/mir-opt/packed_struct_drop_aligned.main.SimplifyCfg-elaborate-drops.after.64bit.mir
+++ b/src/test/mir-opt/packed_struct_drop_aligned.main.SimplifyCfg-elaborate-drops.after.64bit.mir
@@ -31,18 +31,18 @@ fn main() -> () {
         drop(_6) -> [return: bb4, unwind: bb3]; // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:5: 7:8
     }
 
-    bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/packed-struct-drop-aligned.rs:5:1: 8:2
-    }
-
-    bb2: {
+    bb1: {
         StorageDead(_1);                 // scope 0 at $DIR/packed-struct-drop-aligned.rs:8:1: 8:2
         return;                          // scope 0 at $DIR/packed-struct-drop-aligned.rs:8:2: 8:2
     }
 
+    bb2 (cleanup): {
+        resume;                          // scope 0 at $DIR/packed-struct-drop-aligned.rs:5:1: 8:2
+    }
+
     bb3 (cleanup): {
         (_1.0: Aligned) = move _4;       // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:5: 7:8
-        drop(_1) -> bb1;                 // scope 0 at $DIR/packed-struct-drop-aligned.rs:8:1: 8:2
+        drop(_1) -> bb2;                 // scope 0 at $DIR/packed-struct-drop-aligned.rs:8:1: 8:2
     }
 
     bb4: {
@@ -50,6 +50,6 @@ fn main() -> () {
         (_1.0: Aligned) = move _4;       // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:5: 7:8
         StorageDead(_4);                 // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:28: 7:29
         _0 = const ();                   // scope 0 at $DIR/packed-struct-drop-aligned.rs:5:11: 8:2
-        drop(_1) -> [return: bb2, unwind: bb1]; // scope 0 at $DIR/packed-struct-drop-aligned.rs:8:1: 8:2
+        drop(_1) -> [return: bb1, unwind: bb2]; // scope 0 at $DIR/packed-struct-drop-aligned.rs:8:1: 8:2
     }
 }

--- a/src/test/mir-opt/retag.main.SimplifyCfg-elaborate-drops.after.mir
+++ b/src/test/mir-opt/retag.main.SimplifyCfg-elaborate-drops.after.mir
@@ -70,29 +70,21 @@ fn main() -> () {
         Retag(_7);                       // scope 1 at $DIR/retag.rs:32:29: 32:35
         _6 = &mut (*_7);                 // scope 1 at $DIR/retag.rs:32:29: 32:35
         Retag([2phase] _6);              // scope 1 at $DIR/retag.rs:32:29: 32:35
-        _3 = Test::foo(move _4, move _6) -> [return: bb2, unwind: bb3]; // scope 1 at $DIR/retag.rs:32:17: 32:36
+        _3 = Test::foo(move _4, move _6) -> [return: bb1, unwind: bb7]; // scope 1 at $DIR/retag.rs:32:17: 32:36
                                          // mir::Constant
                                          // + span: $DIR/retag.rs:32:25: 32:28
                                          // + literal: Const { ty: for<'r, 'x> fn(&'r Test, &'x mut i32) -> &'x mut i32 {Test::foo}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/retag.rs:29:1: 51:2
-    }
-
-    bb2: {
+    bb1: {
         Retag(_3);                       // scope 1 at $DIR/retag.rs:32:17: 32:36
         StorageDead(_6);                 // scope 1 at $DIR/retag.rs:32:35: 32:36
         StorageDead(_4);                 // scope 1 at $DIR/retag.rs:32:35: 32:36
         StorageDead(_7);                 // scope 1 at $DIR/retag.rs:32:36: 32:37
-        drop(_5) -> [return: bb4, unwind: bb1]; // scope 1 at $DIR/retag.rs:32:36: 32:37
+        drop(_5) -> [return: bb2, unwind: bb8]; // scope 1 at $DIR/retag.rs:32:36: 32:37
     }
 
-    bb3 (cleanup): {
-        drop(_5) -> bb1;                 // scope 1 at $DIR/retag.rs:32:36: 32:37
-    }
-
-    bb4: {
+    bb2: {
         StorageDead(_5);                 // scope 1 at $DIR/retag.rs:32:36: 32:37
         StorageLive(_8);                 // scope 2 at $DIR/retag.rs:33:13: 33:14
         StorageLive(_9);                 // scope 2 at $DIR/retag.rs:33:19: 33:20
@@ -138,10 +130,10 @@ fn main() -> () {
         Retag(_18);                      // scope 6 at $DIR/retag.rs:44:16: 44:18
         _17 = &(*_18);                   // scope 6 at $DIR/retag.rs:44:16: 44:18
         Retag(_17);                      // scope 6 at $DIR/retag.rs:44:16: 44:18
-        _15 = move _16(move _17) -> bb5; // scope 6 at $DIR/retag.rs:44:14: 44:19
+        _15 = move _16(move _17) -> bb3; // scope 6 at $DIR/retag.rs:44:14: 44:19
     }
 
-    bb5: {
+    bb3: {
         Retag(_15);                      // scope 6 at $DIR/retag.rs:44:14: 44:19
         StorageDead(_17);                // scope 6 at $DIR/retag.rs:44:18: 44:19
         StorageDead(_16);                // scope 6 at $DIR/retag.rs:44:18: 44:19
@@ -166,25 +158,21 @@ fn main() -> () {
         Retag(_23);                      // scope 7 at $DIR/retag.rs:47:21: 47:23
         _22 = &(*_23);                   // scope 7 at $DIR/retag.rs:47:21: 47:23
         Retag(_22);                      // scope 7 at $DIR/retag.rs:47:21: 47:23
-        _19 = Test::foo_shr(move _20, move _22) -> [return: bb6, unwind: bb7]; // scope 7 at $DIR/retag.rs:47:5: 47:24
+        _19 = Test::foo_shr(move _20, move _22) -> [return: bb4, unwind: bb6]; // scope 7 at $DIR/retag.rs:47:5: 47:24
                                          // mir::Constant
                                          // + span: $DIR/retag.rs:47:13: 47:20
                                          // + literal: Const { ty: for<'r, 'x> fn(&'r Test, &'x i32) -> &'x i32 {Test::foo_shr}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb6: {
+    bb4: {
         Retag(_19);                      // scope 7 at $DIR/retag.rs:47:5: 47:24
         StorageDead(_22);                // scope 7 at $DIR/retag.rs:47:23: 47:24
         StorageDead(_20);                // scope 7 at $DIR/retag.rs:47:23: 47:24
         StorageDead(_23);                // scope 7 at $DIR/retag.rs:47:24: 47:25
-        drop(_21) -> [return: bb8, unwind: bb1]; // scope 7 at $DIR/retag.rs:47:24: 47:25
+        drop(_21) -> [return: bb5, unwind: bb8]; // scope 7 at $DIR/retag.rs:47:24: 47:25
     }
 
-    bb7 (cleanup): {
-        drop(_21) -> bb1;                // scope 7 at $DIR/retag.rs:47:24: 47:25
-    }
-
-    bb8: {
+    bb5: {
         StorageDead(_21);                // scope 7 at $DIR/retag.rs:47:24: 47:25
         StorageDead(_19);                // scope 7 at $DIR/retag.rs:47:24: 47:25
         StorageLive(_25);                // scope 7 at $DIR/retag.rs:50:9: 50:11
@@ -199,5 +187,17 @@ fn main() -> () {
         StorageDead(_13);                // scope 1 at $DIR/retag.rs:51:1: 51:2
         StorageDead(_1);                 // scope 0 at $DIR/retag.rs:51:1: 51:2
         return;                          // scope 0 at $DIR/retag.rs:51:2: 51:2
+    }
+
+    bb6 (cleanup): {
+        drop(_21) -> bb8;                // scope 7 at $DIR/retag.rs:47:24: 47:25
+    }
+
+    bb7 (cleanup): {
+        drop(_5) -> bb8;                 // scope 1 at $DIR/retag.rs:32:36: 32:37
+    }
+
+    bb8 (cleanup): {
+        resume;                          // scope 0 at $DIR/retag.rs:29:1: 51:2
     }
 }

--- a/src/test/mir-opt/simple_match.match_bool.mir_map.0.32bit.mir
+++ b/src/test/mir-opt/simple_match.match_bool.mir_map.0.32bit.mir
@@ -6,32 +6,24 @@ fn match_bool(_1: bool) -> usize {
 
     bb0: {
         FakeRead(ForMatchedPlace, _1);   // scope 0 at $DIR/simple-match.rs:6:11: 6:12
-        switchInt(_1) -> [false: bb3, otherwise: bb2]; // scope 0 at $DIR/simple-match.rs:7:9: 7:13
+        switchInt(_1) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/simple-match.rs:7:9: 7:13
     }
 
-    bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/simple-match.rs:5:1: 10:2
+    bb1: {
+        falseEdge -> [real: bb3, imaginary: bb2]; // scope 0 at $DIR/simple-match.rs:7:9: 7:13
     }
 
     bb2: {
-        falseEdge -> [real: bb4, imaginary: bb3]; // scope 0 at $DIR/simple-match.rs:7:9: 7:13
+        _0 = const 20_usize;             // scope 0 at $DIR/simple-match.rs:8:14: 8:16
+        goto -> bb4;                     // scope 0 at $DIR/simple-match.rs:6:5: 9:6
     }
 
     bb3: {
-        _0 = const 20_usize;             // scope 0 at $DIR/simple-match.rs:8:14: 8:16
-        goto -> bb5;                     // scope 0 at $DIR/simple-match.rs:6:5: 9:6
+        _0 = const 10_usize;             // scope 0 at $DIR/simple-match.rs:7:17: 7:19
+        goto -> bb4;                     // scope 0 at $DIR/simple-match.rs:6:5: 9:6
     }
 
     bb4: {
-        _0 = const 10_usize;             // scope 0 at $DIR/simple-match.rs:7:17: 7:19
-        goto -> bb5;                     // scope 0 at $DIR/simple-match.rs:6:5: 9:6
-    }
-
-    bb5: {
-        goto -> bb6;                     // scope 0 at $DIR/simple-match.rs:10:2: 10:2
-    }
-
-    bb6: {
         return;                          // scope 0 at $DIR/simple-match.rs:10:2: 10:2
     }
 }

--- a/src/test/mir-opt/simple_match.match_bool.mir_map.0.64bit.mir
+++ b/src/test/mir-opt/simple_match.match_bool.mir_map.0.64bit.mir
@@ -6,32 +6,24 @@ fn match_bool(_1: bool) -> usize {
 
     bb0: {
         FakeRead(ForMatchedPlace, _1);   // scope 0 at $DIR/simple-match.rs:6:11: 6:12
-        switchInt(_1) -> [false: bb3, otherwise: bb2]; // scope 0 at $DIR/simple-match.rs:7:9: 7:13
+        switchInt(_1) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/simple-match.rs:7:9: 7:13
     }
 
-    bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/simple-match.rs:5:1: 10:2
+    bb1: {
+        falseEdge -> [real: bb3, imaginary: bb2]; // scope 0 at $DIR/simple-match.rs:7:9: 7:13
     }
 
     bb2: {
-        falseEdge -> [real: bb4, imaginary: bb3]; // scope 0 at $DIR/simple-match.rs:7:9: 7:13
+        _0 = const 20_usize;             // scope 0 at $DIR/simple-match.rs:8:14: 8:16
+        goto -> bb4;                     // scope 0 at $DIR/simple-match.rs:6:5: 9:6
     }
 
     bb3: {
-        _0 = const 20_usize;             // scope 0 at $DIR/simple-match.rs:8:14: 8:16
-        goto -> bb5;                     // scope 0 at $DIR/simple-match.rs:6:5: 9:6
+        _0 = const 10_usize;             // scope 0 at $DIR/simple-match.rs:7:17: 7:19
+        goto -> bb4;                     // scope 0 at $DIR/simple-match.rs:6:5: 9:6
     }
 
     bb4: {
-        _0 = const 10_usize;             // scope 0 at $DIR/simple-match.rs:7:17: 7:19
-        goto -> bb5;                     // scope 0 at $DIR/simple-match.rs:6:5: 9:6
-    }
-
-    bb5: {
-        goto -> bb6;                     // scope 0 at $DIR/simple-match.rs:10:2: 10:2
-    }
-
-    bb6: {
         return;                          // scope 0 at $DIR/simple-match.rs:10:2: 10:2
     }
 }

--- a/src/test/mir-opt/simplify_arm.id_try.SimplifyArmIdentity.diff
+++ b/src/test/mir-opt/simplify_arm.id_try.SimplifyArmIdentity.diff
@@ -92,7 +92,7 @@
 +         _0 = move _3;                    // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
           StorageDead(_3);                 // scope 0 at $DIR/simplify-arm.rs:24:15: 24:16
           StorageDead(_2);                 // scope 0 at $DIR/simplify-arm.rs:26:1: 26:2
-          goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:24:14: 24:15
+          goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:26:2: 26:2
       }
   
       bb4: {

--- a/src/test/mir-opt/simplify_arm.id_try.SimplifyBranchSame.diff
+++ b/src/test/mir-opt/simplify_arm.id_try.SimplifyBranchSame.diff
@@ -66,7 +66,7 @@
 -         _0 = move _3;                    // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
 -         StorageDead(_3);                 // scope 0 at $DIR/simplify-arm.rs:24:15: 24:16
 -         StorageDead(_2);                 // scope 0 at $DIR/simplify-arm.rs:26:1: 26:2
--         goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:24:14: 24:15
+-         goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:26:2: 26:2
 -     }
 - 
 -     bb4: {

--- a/src/test/mir-opt/simplify_cfg.main.SimplifyCfg-early-opt.diff
+++ b/src/test/mir-opt/simplify_cfg.main.SimplifyCfg-early-opt.diff
@@ -13,40 +13,40 @@
 - 
 -     bb1: {
           StorageLive(_2);                 // scope 0 at $DIR/simplify_cfg.rs:7:12: 7:17
--         _2 = bar() -> bb3;               // scope 0 at $DIR/simplify_cfg.rs:7:12: 7:17
+-         _2 = bar() -> bb2;               // scope 0 at $DIR/simplify_cfg.rs:7:12: 7:17
 +         _2 = bar() -> bb1;               // scope 0 at $DIR/simplify_cfg.rs:7:12: 7:17
                                            // mir::Constant
                                            // + span: $DIR/simplify_cfg.rs:7:12: 7:15
                                            // + literal: Const { ty: fn() -> bool {bar}, val: Value(Scalar(<ZST>)) }
       }
   
--     bb2 (cleanup): {
--         resume;                          // scope 0 at $DIR/simplify_cfg.rs:5:1: 11:2
+-     bb2: {
+-         nop;                             // scope 0 at $DIR/simplify_cfg.rs:7:12: 7:17
+-         switchInt(_2) -> [false: bb4, otherwise: bb3]; // scope 0 at $DIR/simplify_cfg.rs:7:9: 9:10
 +     bb1: {
 +         switchInt(_2) -> [false: bb2, otherwise: bb3]; // scope 0 at $DIR/simplify_cfg.rs:7:9: 9:10
       }
   
 -     bb3: {
--         nop;                             // scope 0 at $DIR/simplify_cfg.rs:7:12: 7:17
--         switchInt(_2) -> [false: bb5, otherwise: bb4]; // scope 0 at $DIR/simplify_cfg.rs:7:9: 9:10
+-         goto -> bb5;                     // scope 0 at $DIR/simplify_cfg.rs:7:9: 9:10
 -     }
 - 
 -     bb4: {
--         goto -> bb6;                     // scope 0 at $DIR/simplify_cfg.rs:7:9: 9:10
--     }
-- 
--     bb5: {
 +     bb2: {
           _1 = const ();                   // scope 0 at $DIR/simplify_cfg.rs:7:9: 9:10
           StorageDead(_2);                 // scope 0 at $DIR/simplify_cfg.rs:10:5: 10:6
           goto -> bb0;                     // scope 0 at $DIR/simplify_cfg.rs:6:5: 10:6
       }
   
--     bb6: {
+-     bb5: {
 +     bb3: {
           _0 = const ();                   // scope 0 at $DIR/simplify_cfg.rs:8:13: 8:18
           StorageDead(_2);                 // scope 0 at $DIR/simplify_cfg.rs:10:5: 10:6
           return;                          // scope 0 at $DIR/simplify_cfg.rs:11:2: 11:2
+-     }
+- 
+-     bb6 (cleanup): {
+-         resume;                          // scope 0 at $DIR/simplify_cfg.rs:5:1: 11:2
       }
   }
   

--- a/src/test/mir-opt/simplify_cfg.main.SimplifyCfg-initial.diff
+++ b/src/test/mir-opt/simplify_cfg.main.SimplifyCfg-initial.diff
@@ -9,78 +9,70 @@
   
       bb0: {
 -         goto -> bb1;                     // scope 0 at $DIR/simplify_cfg.rs:6:5: 10:6
-+         falseUnwind -> [real: bb1, cleanup: bb2]; // scope 0 at $DIR/simplify_cfg.rs:6:5: 10:6
++         falseUnwind -> [real: bb1, cleanup: bb6]; // scope 0 at $DIR/simplify_cfg.rs:6:5: 10:6
       }
   
       bb1: {
--         falseUnwind -> [real: bb3, cleanup: bb4]; // scope 0 at $DIR/simplify_cfg.rs:6:5: 10:6
+-         falseUnwind -> [real: bb2, cleanup: bb11]; // scope 0 at $DIR/simplify_cfg.rs:6:5: 10:6
 -     }
 - 
 -     bb2: {
--         goto -> bb13;                    // scope 0 at $DIR/simplify_cfg.rs:11:2: 11:2
--     }
-- 
--     bb3: {
           StorageLive(_2);                 // scope 0 at $DIR/simplify_cfg.rs:7:12: 7:17
--         _2 = bar() -> [return: bb5, unwind: bb4]; // scope 0 at $DIR/simplify_cfg.rs:7:12: 7:17
-+         _2 = bar() -> [return: bb3, unwind: bb2]; // scope 0 at $DIR/simplify_cfg.rs:7:12: 7:17
+-         _2 = bar() -> [return: bb3, unwind: bb11]; // scope 0 at $DIR/simplify_cfg.rs:7:12: 7:17
++         _2 = bar() -> [return: bb2, unwind: bb6]; // scope 0 at $DIR/simplify_cfg.rs:7:12: 7:17
                                            // mir::Constant
                                            // + span: $DIR/simplify_cfg.rs:7:12: 7:15
                                            // + literal: Const { ty: fn() -> bool {bar}, val: Value(Scalar(<ZST>)) }
       }
   
--     bb4 (cleanup): {
-+     bb2 (cleanup): {
-          resume;                          // scope 0 at $DIR/simplify_cfg.rs:5:1: 11:2
+-     bb3: {
++     bb2: {
+          FakeRead(ForMatchedPlace, _2);   // scope 0 at $DIR/simplify_cfg.rs:7:12: 7:17
+-         switchInt(_2) -> [false: bb5, otherwise: bb4]; // scope 0 at $DIR/simplify_cfg.rs:7:9: 9:10
++         switchInt(_2) -> [false: bb4, otherwise: bb3]; // scope 0 at $DIR/simplify_cfg.rs:7:9: 9:10
+      }
+  
+-     bb4: {
+-         falseEdge -> [real: bb6, imaginary: bb5]; // scope 0 at $DIR/simplify_cfg.rs:7:9: 9:10
++     bb3: {
++         falseEdge -> [real: bb5, imaginary: bb4]; // scope 0 at $DIR/simplify_cfg.rs:7:9: 9:10
       }
   
 -     bb5: {
-+     bb3: {
-          FakeRead(ForMatchedPlace, _2);   // scope 0 at $DIR/simplify_cfg.rs:7:12: 7:17
--         switchInt(_2) -> [false: bb7, otherwise: bb6]; // scope 0 at $DIR/simplify_cfg.rs:7:9: 9:10
-+         switchInt(_2) -> [false: bb5, otherwise: bb4]; // scope 0 at $DIR/simplify_cfg.rs:7:9: 9:10
-      }
-  
--     bb6: {
--         falseEdge -> [real: bb8, imaginary: bb7]; // scope 0 at $DIR/simplify_cfg.rs:7:9: 9:10
 +     bb4: {
-+         falseEdge -> [real: bb6, imaginary: bb5]; // scope 0 at $DIR/simplify_cfg.rs:7:9: 9:10
-      }
-  
--     bb7: {
-+     bb5: {
           _1 = const ();                   // scope 0 at $DIR/simplify_cfg.rs:7:9: 9:10
--         goto -> bb12;                    // scope 0 at $DIR/simplify_cfg.rs:7:9: 9:10
+-         goto -> bb9;                     // scope 0 at $DIR/simplify_cfg.rs:7:9: 9:10
 +         StorageDead(_2);                 // scope 0 at $DIR/simplify_cfg.rs:10:5: 10:6
 +         goto -> bb0;                     // scope 0 at $DIR/simplify_cfg.rs:6:5: 10:6
       }
   
--     bb8: {
-+     bb6: {
+-     bb6: {
++     bb5: {
           _0 = const ();                   // scope 0 at $DIR/simplify_cfg.rs:8:13: 8:18
--         goto -> bb9;                     // scope 0 at $DIR/simplify_cfg.rs:8:13: 8:18
+-         goto -> bb10;                    // scope 0 at $DIR/simplify_cfg.rs:8:13: 8:18
+-     }
+- 
+-     bb7: {
+-         unreachable;                     // scope 0 at $DIR/simplify_cfg.rs:7:18: 9:10
+-     }
+- 
+-     bb8: {
+-         goto -> bb9;                     // scope 0 at $DIR/simplify_cfg.rs:7:9: 9:10
 -     }
 - 
 -     bb9: {
           StorageDead(_2);                 // scope 0 at $DIR/simplify_cfg.rs:10:5: 10:6
--         goto -> bb2;                     // scope 0 at $DIR/simplify_cfg.rs:8:13: 8:18
--     }
-- 
--     bb10: {
--         unreachable;                     // scope 0 at $DIR/simplify_cfg.rs:7:18: 9:10
--     }
-- 
--     bb11: {
--         goto -> bb12;                    // scope 0 at $DIR/simplify_cfg.rs:7:9: 9:10
--     }
-- 
--     bb12: {
--         StorageDead(_2);                 // scope 0 at $DIR/simplify_cfg.rs:10:5: 10:6
 -         goto -> bb1;                     // scope 0 at $DIR/simplify_cfg.rs:6:5: 10:6
 -     }
 - 
--     bb13: {
+-     bb10: {
+-         StorageDead(_2);                 // scope 0 at $DIR/simplify_cfg.rs:10:5: 10:6
           return;                          // scope 0 at $DIR/simplify_cfg.rs:11:2: 11:2
+      }
+  
+-     bb11 (cleanup): {
++     bb6 (cleanup): {
+          resume;                          // scope 0 at $DIR/simplify_cfg.rs:5:1: 11:2
       }
   }
   

--- a/src/test/mir-opt/simplify_try.try_identity.SimplifyArmIdentity.diff
+++ b/src/test/mir-opt/simplify_try.try_identity.SimplifyArmIdentity.diff
@@ -88,7 +88,7 @@
 +         _0 = move _3;                    // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
           StorageDead(_3);                 // scope 0 at $DIR/simplify_try.rs:8:15: 8:16
           StorageDead(_2);                 // scope 0 at $DIR/simplify_try.rs:10:1: 10:2
-          return;                          // scope 0 at $DIR/simplify_try.rs:8:14: 8:15
+          return;                          // scope 0 at $DIR/simplify_try.rs:10:2: 10:2
       }
   }
   

--- a/src/test/mir-opt/spanview_block.main.mir_map.0.html.mir
+++ b/src/test/mir-opt/spanview_block.main.mir_map.0.html.mir
@@ -61,7 +61,6 @@
 <body>
 <div class="code" style="counter-reset: line 4"><span class="line"><span class="code" style="--layer: 0">fn main() </span><span><span class="code even" style="--layer: 1" title="0: $DIR/spanview-block.rs:5:11: 5:13:
     5:11-5:13: Assign: _0 = const ()
-    5:13-5:13: Goto: goto -&gt; bb2"><span class="annotation">0⦊</span>{}<span class="annotation">⦉0</span></span></span><span><span class="code odd" style="--layer: 1" title="2: $DIR/spanview-block.rs:5:13: 5:13:
-    5:13-5:13: Return: return"><span class="annotation">2⦊</span>‸<span class="annotation">⦉2</span></span></span></span></div>
+    5:13-5:13: Return: return"><span class="annotation">0⦊</span>{}<span class="annotation">⦉0</span></span></span></span></div>
 </body>
 </html>

--- a/src/test/mir-opt/spanview_statement.main.mir_map.0.html.mir
+++ b/src/test/mir-opt/spanview_statement.main.mir_map.0.html.mir
@@ -60,8 +60,7 @@
 </head>
 <body>
 <div class="code" style="counter-reset: line 4"><span class="line"><span class="code" style="--layer: 0">fn main() </span><span><span class="code even" style="--layer: 1" title="0[0]: $DIR/spanview-statement.rs:5:11: 5:13:
-    5:11-5:13: Assign: _0 = const ()"><span class="annotation">0[0]⦊</span>{}<span class="annotation">⦉0[0]</span></span></span><span><span class="code odd" style="--layer: 1" title="0:Goto: $DIR/spanview-statement.rs:5:13: 5:13:
-    5:13-5:13: Goto: goto -&gt; bb2"><span class="annotation">0:Goto⦊</span>‸<span class="annotation">⦉0:Goto</span></span></span><span><span class="code even" style="--layer: 1" title="2:Return: $DIR/spanview-statement.rs:5:13: 5:13:
-    5:13-5:13: Return: return"><span class="annotation">2:Return⦊</span>‸<span class="annotation">⦉2:Return</span></span></span></span></div>
+    5:11-5:13: Assign: _0 = const ()"><span class="annotation">0[0]⦊</span>{}<span class="annotation">⦉0[0]</span></span></span><span><span class="code odd" style="--layer: 1" title="0:Return: $DIR/spanview-statement.rs:5:13: 5:13:
+    5:13-5:13: Return: return"><span class="annotation">0:Return⦊</span>‸<span class="annotation">⦉0:Return</span></span></span></span></div>
 </body>
 </html>

--- a/src/test/mir-opt/spanview_terminator.main.mir_map.0.html.mir
+++ b/src/test/mir-opt/spanview_terminator.main.mir_map.0.html.mir
@@ -59,8 +59,7 @@
     </style>
 </head>
 <body>
-<div class="code" style="counter-reset: line 4"><span class="line"><span class="code" style="--layer: 0">fn main() {}</span><span><span class="code even" style="--layer: 1" title="0:Goto: $DIR/spanview-terminator.rs:5:13: 5:13:
-    5:13-5:13: Goto: goto -&gt; bb2"><span class="annotation">0:Goto⦊</span>‸<span class="annotation">⦉0:Goto</span></span></span><span><span class="code odd" style="--layer: 1" title="2:Return: $DIR/spanview-terminator.rs:5:13: 5:13:
-    5:13-5:13: Return: return"><span class="annotation">2:Return⦊</span>‸<span class="annotation">⦉2:Return</span></span></span></span></div>
+<div class="code" style="counter-reset: line 4"><span class="line"><span class="code" style="--layer: 0">fn main() {}</span><span><span class="code even" style="--layer: 1" title="0:Return: $DIR/spanview-terminator.rs:5:13: 5:13:
+    5:13-5:13: Return: return"><span class="annotation">0:Return⦊</span>‸<span class="annotation">⦉0:Return</span></span></span></span></div>
 </body>
 </html>

--- a/src/test/mir-opt/storage_live_dead_in_statics.XXX.mir_map.0.mir
+++ b/src/test/mir-opt/storage_live_dead_in_statics.XXX.mir_map.0.mir
@@ -159,8 +159,4 @@ static XXX: &Foo = {
         StorageDead(_1);                 // scope 0 at $DIR/storage_live_dead_in_statics.rs:23:1: 23:2
         return;                          // scope 0 at $DIR/storage_live_dead_in_statics.rs:5:1: 23:3
     }
-
-    bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/storage_live_dead_in_statics.rs:5:1: 23:3
-    }
 }

--- a/src/test/mir-opt/uniform_array_move_out.move_out_by_subslice.mir_map.0.mir
+++ b/src/test/mir-opt/uniform_array_move_out.move_out_by_subslice.mir_map.0.mir
@@ -22,78 +22,62 @@ fn move_out_by_subslice() -> () {
         _3 = Box(i32);                   // scope 0 at $DIR/uniform_array_move_out.rs:11:14: 11:19
         (*_3) = const 1_i32;             // scope 0 at $DIR/uniform_array_move_out.rs:11:18: 11:19
         _2 = move _3;                    // scope 0 at $DIR/uniform_array_move_out.rs:11:14: 11:19
-        drop(_3) -> [return: bb4, unwind: bb2]; // scope 0 at $DIR/uniform_array_move_out.rs:11:18: 11:19
+        drop(_3) -> [return: bb1, unwind: bb9]; // scope 0 at $DIR/uniform_array_move_out.rs:11:18: 11:19
     }
 
-    bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/uniform_array_move_out.rs:10:1: 13:2
-    }
-
-    bb2 (cleanup): {
-        drop(_2) -> bb1;                 // scope 0 at $DIR/uniform_array_move_out.rs:11:26: 11:27
-    }
-
-    bb3 (cleanup): {
-        drop(_3) -> bb2;                 // scope 0 at $DIR/uniform_array_move_out.rs:11:18: 11:19
-    }
-
-    bb4: {
+    bb1: {
         StorageDead(_3);                 // scope 0 at $DIR/uniform_array_move_out.rs:11:18: 11:19
         StorageLive(_4);                 // scope 0 at $DIR/uniform_array_move_out.rs:11:21: 11:26
         StorageLive(_5);                 // scope 0 at $DIR/uniform_array_move_out.rs:11:21: 11:26
         _5 = Box(i32);                   // scope 0 at $DIR/uniform_array_move_out.rs:11:21: 11:26
         (*_5) = const 2_i32;             // scope 0 at $DIR/uniform_array_move_out.rs:11:25: 11:26
         _4 = move _5;                    // scope 0 at $DIR/uniform_array_move_out.rs:11:21: 11:26
-        drop(_5) -> [return: bb7, unwind: bb5]; // scope 0 at $DIR/uniform_array_move_out.rs:11:25: 11:26
+        drop(_5) -> [return: bb2, unwind: bb8]; // scope 0 at $DIR/uniform_array_move_out.rs:11:25: 11:26
     }
 
-    bb5 (cleanup): {
-        drop(_4) -> bb2;                 // scope 0 at $DIR/uniform_array_move_out.rs:11:26: 11:27
-    }
-
-    bb6 (cleanup): {
-        drop(_5) -> bb5;                 // scope 0 at $DIR/uniform_array_move_out.rs:11:25: 11:26
-    }
-
-    bb7: {
+    bb2: {
         StorageDead(_5);                 // scope 0 at $DIR/uniform_array_move_out.rs:11:25: 11:26
         _1 = [move _2, move _4];         // scope 0 at $DIR/uniform_array_move_out.rs:11:13: 11:27
-        drop(_4) -> [return: bb8, unwind: bb2]; // scope 0 at $DIR/uniform_array_move_out.rs:11:26: 11:27
+        drop(_4) -> [return: bb3, unwind: bb9]; // scope 0 at $DIR/uniform_array_move_out.rs:11:26: 11:27
     }
 
-    bb8: {
+    bb3: {
         StorageDead(_4);                 // scope 0 at $DIR/uniform_array_move_out.rs:11:26: 11:27
-        drop(_2) -> [return: bb9, unwind: bb1]; // scope 0 at $DIR/uniform_array_move_out.rs:11:26: 11:27
+        drop(_2) -> [return: bb4, unwind: bb10]; // scope 0 at $DIR/uniform_array_move_out.rs:11:26: 11:27
     }
 
-    bb9: {
+    bb4: {
         StorageDead(_2);                 // scope 0 at $DIR/uniform_array_move_out.rs:11:26: 11:27
         FakeRead(ForLet, _1);            // scope 0 at $DIR/uniform_array_move_out.rs:11:9: 11:10
         StorageLive(_6);                 // scope 1 at $DIR/uniform_array_move_out.rs:12:10: 12:17
         _6 = move _1[0..2];              // scope 1 at $DIR/uniform_array_move_out.rs:12:10: 12:17
         _0 = const ();                   // scope 0 at $DIR/uniform_array_move_out.rs:10:27: 13:2
-        drop(_6) -> [return: bb12, unwind: bb10]; // scope 1 at $DIR/uniform_array_move_out.rs:13:1: 13:2
+        drop(_6) -> [return: bb5, unwind: bb7]; // scope 1 at $DIR/uniform_array_move_out.rs:13:1: 13:2
+    }
+
+    bb5: {
+        StorageDead(_6);                 // scope 1 at $DIR/uniform_array_move_out.rs:13:1: 13:2
+        drop(_1) -> [return: bb6, unwind: bb10]; // scope 0 at $DIR/uniform_array_move_out.rs:13:1: 13:2
+    }
+
+    bb6: {
+        StorageDead(_1);                 // scope 0 at $DIR/uniform_array_move_out.rs:13:1: 13:2
+        return;                          // scope 0 at $DIR/uniform_array_move_out.rs:13:2: 13:2
+    }
+
+    bb7 (cleanup): {
+        drop(_1) -> bb10;                // scope 0 at $DIR/uniform_array_move_out.rs:13:1: 13:2
+    }
+
+    bb8 (cleanup): {
+        drop(_4) -> bb9;                 // scope 0 at $DIR/uniform_array_move_out.rs:11:26: 11:27
+    }
+
+    bb9 (cleanup): {
+        drop(_2) -> bb10;                // scope 0 at $DIR/uniform_array_move_out.rs:11:26: 11:27
     }
 
     bb10 (cleanup): {
-        drop(_1) -> bb1;                 // scope 0 at $DIR/uniform_array_move_out.rs:13:1: 13:2
-    }
-
-    bb11 (cleanup): {
-        drop(_6) -> bb10;                // scope 1 at $DIR/uniform_array_move_out.rs:13:1: 13:2
-    }
-
-    bb12: {
-        StorageDead(_6);                 // scope 1 at $DIR/uniform_array_move_out.rs:13:1: 13:2
-        drop(_1) -> [return: bb13, unwind: bb1]; // scope 0 at $DIR/uniform_array_move_out.rs:13:1: 13:2
-    }
-
-    bb13: {
-        StorageDead(_1);                 // scope 0 at $DIR/uniform_array_move_out.rs:13:1: 13:2
-        goto -> bb14;                    // scope 0 at $DIR/uniform_array_move_out.rs:13:2: 13:2
-    }
-
-    bb14: {
-        return;                          // scope 0 at $DIR/uniform_array_move_out.rs:13:2: 13:2
+        resume;                          // scope 0 at $DIR/uniform_array_move_out.rs:10:1: 13:2
     }
 }

--- a/src/test/mir-opt/uniform_array_move_out.move_out_from_end.mir_map.0.mir
+++ b/src/test/mir-opt/uniform_array_move_out.move_out_from_end.mir_map.0.mir
@@ -22,78 +22,62 @@ fn move_out_from_end() -> () {
         _3 = Box(i32);                   // scope 0 at $DIR/uniform_array_move_out.rs:5:14: 5:19
         (*_3) = const 1_i32;             // scope 0 at $DIR/uniform_array_move_out.rs:5:18: 5:19
         _2 = move _3;                    // scope 0 at $DIR/uniform_array_move_out.rs:5:14: 5:19
-        drop(_3) -> [return: bb4, unwind: bb2]; // scope 0 at $DIR/uniform_array_move_out.rs:5:18: 5:19
+        drop(_3) -> [return: bb1, unwind: bb9]; // scope 0 at $DIR/uniform_array_move_out.rs:5:18: 5:19
     }
 
-    bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/uniform_array_move_out.rs:4:1: 7:2
-    }
-
-    bb2 (cleanup): {
-        drop(_2) -> bb1;                 // scope 0 at $DIR/uniform_array_move_out.rs:5:26: 5:27
-    }
-
-    bb3 (cleanup): {
-        drop(_3) -> bb2;                 // scope 0 at $DIR/uniform_array_move_out.rs:5:18: 5:19
-    }
-
-    bb4: {
+    bb1: {
         StorageDead(_3);                 // scope 0 at $DIR/uniform_array_move_out.rs:5:18: 5:19
         StorageLive(_4);                 // scope 0 at $DIR/uniform_array_move_out.rs:5:21: 5:26
         StorageLive(_5);                 // scope 0 at $DIR/uniform_array_move_out.rs:5:21: 5:26
         _5 = Box(i32);                   // scope 0 at $DIR/uniform_array_move_out.rs:5:21: 5:26
         (*_5) = const 2_i32;             // scope 0 at $DIR/uniform_array_move_out.rs:5:25: 5:26
         _4 = move _5;                    // scope 0 at $DIR/uniform_array_move_out.rs:5:21: 5:26
-        drop(_5) -> [return: bb7, unwind: bb5]; // scope 0 at $DIR/uniform_array_move_out.rs:5:25: 5:26
+        drop(_5) -> [return: bb2, unwind: bb8]; // scope 0 at $DIR/uniform_array_move_out.rs:5:25: 5:26
     }
 
-    bb5 (cleanup): {
-        drop(_4) -> bb2;                 // scope 0 at $DIR/uniform_array_move_out.rs:5:26: 5:27
-    }
-
-    bb6 (cleanup): {
-        drop(_5) -> bb5;                 // scope 0 at $DIR/uniform_array_move_out.rs:5:25: 5:26
-    }
-
-    bb7: {
+    bb2: {
         StorageDead(_5);                 // scope 0 at $DIR/uniform_array_move_out.rs:5:25: 5:26
         _1 = [move _2, move _4];         // scope 0 at $DIR/uniform_array_move_out.rs:5:13: 5:27
-        drop(_4) -> [return: bb8, unwind: bb2]; // scope 0 at $DIR/uniform_array_move_out.rs:5:26: 5:27
+        drop(_4) -> [return: bb3, unwind: bb9]; // scope 0 at $DIR/uniform_array_move_out.rs:5:26: 5:27
     }
 
-    bb8: {
+    bb3: {
         StorageDead(_4);                 // scope 0 at $DIR/uniform_array_move_out.rs:5:26: 5:27
-        drop(_2) -> [return: bb9, unwind: bb1]; // scope 0 at $DIR/uniform_array_move_out.rs:5:26: 5:27
+        drop(_2) -> [return: bb4, unwind: bb10]; // scope 0 at $DIR/uniform_array_move_out.rs:5:26: 5:27
     }
 
-    bb9: {
+    bb4: {
         StorageDead(_2);                 // scope 0 at $DIR/uniform_array_move_out.rs:5:26: 5:27
         FakeRead(ForLet, _1);            // scope 0 at $DIR/uniform_array_move_out.rs:5:9: 5:10
         StorageLive(_6);                 // scope 1 at $DIR/uniform_array_move_out.rs:6:14: 6:16
         _6 = move _1[1 of 2];            // scope 1 at $DIR/uniform_array_move_out.rs:6:14: 6:16
         _0 = const ();                   // scope 0 at $DIR/uniform_array_move_out.rs:4:24: 7:2
-        drop(_6) -> [return: bb12, unwind: bb10]; // scope 1 at $DIR/uniform_array_move_out.rs:7:1: 7:2
+        drop(_6) -> [return: bb5, unwind: bb7]; // scope 1 at $DIR/uniform_array_move_out.rs:7:1: 7:2
+    }
+
+    bb5: {
+        StorageDead(_6);                 // scope 1 at $DIR/uniform_array_move_out.rs:7:1: 7:2
+        drop(_1) -> [return: bb6, unwind: bb10]; // scope 0 at $DIR/uniform_array_move_out.rs:7:1: 7:2
+    }
+
+    bb6: {
+        StorageDead(_1);                 // scope 0 at $DIR/uniform_array_move_out.rs:7:1: 7:2
+        return;                          // scope 0 at $DIR/uniform_array_move_out.rs:7:2: 7:2
+    }
+
+    bb7 (cleanup): {
+        drop(_1) -> bb10;                // scope 0 at $DIR/uniform_array_move_out.rs:7:1: 7:2
+    }
+
+    bb8 (cleanup): {
+        drop(_4) -> bb9;                 // scope 0 at $DIR/uniform_array_move_out.rs:5:26: 5:27
+    }
+
+    bb9 (cleanup): {
+        drop(_2) -> bb10;                // scope 0 at $DIR/uniform_array_move_out.rs:5:26: 5:27
     }
 
     bb10 (cleanup): {
-        drop(_1) -> bb1;                 // scope 0 at $DIR/uniform_array_move_out.rs:7:1: 7:2
-    }
-
-    bb11 (cleanup): {
-        drop(_6) -> bb10;                // scope 1 at $DIR/uniform_array_move_out.rs:7:1: 7:2
-    }
-
-    bb12: {
-        StorageDead(_6);                 // scope 1 at $DIR/uniform_array_move_out.rs:7:1: 7:2
-        drop(_1) -> [return: bb13, unwind: bb1]; // scope 0 at $DIR/uniform_array_move_out.rs:7:1: 7:2
-    }
-
-    bb13: {
-        StorageDead(_1);                 // scope 0 at $DIR/uniform_array_move_out.rs:7:1: 7:2
-        goto -> bb14;                    // scope 0 at $DIR/uniform_array_move_out.rs:7:2: 7:2
-    }
-
-    bb14: {
-        return;                          // scope 0 at $DIR/uniform_array_move_out.rs:7:2: 7:2
+        resume;                          // scope 0 at $DIR/uniform_array_move_out.rs:4:1: 7:2
     }
 }

--- a/src/test/mir-opt/unusual_item_types.E-V-{constant#0}.mir_map.0.32bit.mir
+++ b/src/test/mir-opt/unusual_item_types.E-V-{constant#0}.mir_map.0.32bit.mir
@@ -7,8 +7,4 @@ E::V::{constant#0}: isize = {
         _0 = const 5_isize;              // scope 0 at $DIR/unusual-item-types.rs:22:9: 22:10
         return;                          // scope 0 at $DIR/unusual-item-types.rs:22:9: 22:10
     }
-
-    bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/unusual-item-types.rs:22:9: 22:10
-    }
 }

--- a/src/test/mir-opt/unusual_item_types.E-V-{constant#0}.mir_map.0.64bit.mir
+++ b/src/test/mir-opt/unusual_item_types.E-V-{constant#0}.mir_map.0.64bit.mir
@@ -7,8 +7,4 @@ E::V::{constant#0}: isize = {
         _0 = const 5_isize;              // scope 0 at $DIR/unusual-item-types.rs:22:9: 22:10
         return;                          // scope 0 at $DIR/unusual-item-types.rs:22:9: 22:10
     }
-
-    bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/unusual-item-types.rs:22:9: 22:10
-    }
 }

--- a/src/test/mir-opt/unusual_item_types.core.ptr-drop_in_place.Vec_i32_.AddMovesForPackedDrops.before.32bit.mir
+++ b/src/test/mir-opt/unusual_item_types.core.ptr-drop_in_place.Vec_i32_.AddMovesForPackedDrops.before.32bit.mir
@@ -6,7 +6,7 @@ fn drop_in_place(_1: *mut Vec<i32>) -> () {
     let mut _3: ();                      // in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
 
     bb0: {
-        goto -> bb7;                     // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        goto -> bb6;                     // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
     }
 
     bb1: {
@@ -22,20 +22,16 @@ fn drop_in_place(_1: *mut Vec<i32>) -> () {
     }
 
     bb4 (cleanup): {
-        goto -> bb2;                     // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        drop(((*_1).0: alloc::raw_vec::RawVec<i32>)) -> bb2; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
     }
 
-    bb5 (cleanup): {
-        drop(((*_1).0: alloc::raw_vec::RawVec<i32>)) -> bb4; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+    bb5: {
+        drop(((*_1).0: alloc::raw_vec::RawVec<i32>)) -> [return: bb3, unwind: bb2]; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
     }
 
     bb6: {
-        drop(((*_1).0: alloc::raw_vec::RawVec<i32>)) -> [return: bb3, unwind: bb4]; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-    }
-
-    bb7: {
         _2 = &mut (*_1);                 // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-        _3 = <Vec<i32> as Drop>::drop(move _2) -> [return: bb6, unwind: bb5]; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        _3 = <Vec<i32> as Drop>::drop(move _2) -> [return: bb5, unwind: bb4]; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
                                          // mir::Constant
                                          // + span: $SRC_DIR/core/src/ptr/mod.rs:LL:COL
                                          // + literal: Const { ty: for<'r> fn(&'r mut std::vec::Vec<i32>) {<std::vec::Vec<i32> as std::ops::Drop>::drop}, val: Value(Scalar(<ZST>)) }

--- a/src/test/mir-opt/unusual_item_types.core.ptr-drop_in_place.Vec_i32_.AddMovesForPackedDrops.before.64bit.mir
+++ b/src/test/mir-opt/unusual_item_types.core.ptr-drop_in_place.Vec_i32_.AddMovesForPackedDrops.before.64bit.mir
@@ -6,7 +6,7 @@ fn drop_in_place(_1: *mut Vec<i32>) -> () {
     let mut _3: ();                      // in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
 
     bb0: {
-        goto -> bb7;                     // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        goto -> bb6;                     // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
     }
 
     bb1: {
@@ -22,20 +22,16 @@ fn drop_in_place(_1: *mut Vec<i32>) -> () {
     }
 
     bb4 (cleanup): {
-        goto -> bb2;                     // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        drop(((*_1).0: alloc::raw_vec::RawVec<i32>)) -> bb2; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
     }
 
-    bb5 (cleanup): {
-        drop(((*_1).0: alloc::raw_vec::RawVec<i32>)) -> bb4; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+    bb5: {
+        drop(((*_1).0: alloc::raw_vec::RawVec<i32>)) -> [return: bb3, unwind: bb2]; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
     }
 
     bb6: {
-        drop(((*_1).0: alloc::raw_vec::RawVec<i32>)) -> [return: bb3, unwind: bb4]; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-    }
-
-    bb7: {
         _2 = &mut (*_1);                 // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-        _3 = <Vec<i32> as Drop>::drop(move _2) -> [return: bb6, unwind: bb5]; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+        _3 = <Vec<i32> as Drop>::drop(move _2) -> [return: bb5, unwind: bb4]; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
                                          // mir::Constant
                                          // + span: $SRC_DIR/core/src/ptr/mod.rs:LL:COL
                                          // + literal: Const { ty: for<'r> fn(&'r mut std::vec::Vec<i32>) {<std::vec::Vec<i32> as std::ops::Drop>::drop}, val: Value(Scalar(<ZST>)) }

--- a/src/test/mir-opt/unusual_item_types.{impl#0}-ASSOCIATED_CONSTANT.mir_map.0.32bit.mir
+++ b/src/test/mir-opt/unusual_item_types.{impl#0}-ASSOCIATED_CONSTANT.mir_map.0.32bit.mir
@@ -7,8 +7,4 @@ const <impl at $DIR/unusual-item-types.rs:9:1: 11:2>::ASSOCIATED_CONSTANT: i32 =
         _0 = const 2_i32;                // scope 0 at $DIR/unusual-item-types.rs:10:38: 10:39
         return;                          // scope 0 at $DIR/unusual-item-types.rs:10:5: 10:40
     }
-
-    bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/unusual-item-types.rs:10:5: 10:40
-    }
 }

--- a/src/test/mir-opt/unusual_item_types.{impl#0}-ASSOCIATED_CONSTANT.mir_map.0.64bit.mir
+++ b/src/test/mir-opt/unusual_item_types.{impl#0}-ASSOCIATED_CONSTANT.mir_map.0.64bit.mir
@@ -7,8 +7,4 @@ const <impl at $DIR/unusual-item-types.rs:9:1: 11:2>::ASSOCIATED_CONSTANT: i32 =
         _0 = const 2_i32;                // scope 0 at $DIR/unusual-item-types.rs:10:38: 10:39
         return;                          // scope 0 at $DIR/unusual-item-types.rs:10:5: 10:40
     }
-
-    bb1 (cleanup): {
-        resume;                          // scope 0 at $DIR/unusual-item-types.rs:10:5: 10:40
-    }
 }

--- a/src/test/mir-opt/while_storage.while_loop.PreCodegen.after.mir
+++ b/src/test/mir-opt/while_storage.while_loop.PreCodegen.after.mir
@@ -52,7 +52,7 @@ fn while_loop(_1: bool) -> () {
     bb6: {
         _0 = const ();                   // scope 0 at $DIR/while-storage.rs:12:13: 12:18
         StorageDead(_4);                 // scope 0 at $DIR/while-storage.rs:14:5: 14:6
-        goto -> bb7;                     // scope 0 at $DIR/while-storage.rs:12:13: 12:18
+        goto -> bb7;                     // scope 0 at $DIR/while-storage.rs:1:1: 1:1
     }
 
     bb7: {

--- a/src/test/run-make-fulldeps/instrument-coverage-cov-reports-base/expected_export_coverage.coverage_of_if_else.json
+++ b/src/test/run-make-fulldeps/instrument-coverage-cov-reports-base/expected_export_coverage.coverage_of_if_else.json
@@ -16,15 +16,15 @@
               "percent": 100
             },
             "lines": {
-              "count": 46,
+              "count": 40,
               "covered": 19,
-              "percent": 41.30434782608695
+              "percent": 47.5
             },
             "regions": {
-              "count": 75,
+              "count": 71,
               "covered": 23,
-              "notcovered": 52,
-              "percent": 30.666666666666664
+              "notcovered": 48,
+              "percent": 32.3943661971831
             }
           }
         }
@@ -41,15 +41,15 @@
           "percent": 100
         },
         "lines": {
-          "count": 46,
+          "count": 40,
           "covered": 19,
-          "percent": 41.30434782608695
+          "percent": 47.5
         },
         "regions": {
-          "count": 75,
+          "count": 71,
           "covered": 23,
-          "notcovered": 52,
-          "percent": 30.666666666666664
+          "notcovered": 48,
+          "percent": 32.3943661971831
         }
       }
     }

--- a/src/test/run-make-fulldeps/instrument-coverage-cov-reports-base/typical_show_coverage.coverage_of_if_else.txt
+++ b/src/test/run-make-fulldeps/instrument-coverage-cov-reports-base/typical_show_coverage.coverage_of_if_else.txt
@@ -20,13 +20,13 @@
    16|      0|    } else {
    17|      0|        return;
    18|      0|    }
-   19|      0|
-   20|      0|    let mut countdown = 0;
+   19|       |
+   20|       |    let mut countdown = 0;
    21|      2|    if true {
                      ^1
    22|      2|        countdown = 10;
    23|      2|    }
-   24|      0|
+   24|       |
    25|      2|    if countdown > 7 {
                      ^1
    26|      2|        countdown -= 4;
@@ -40,13 +40,13 @@
    32|      0|    } else {
    33|      0|        return;
    34|      0|    }
-   35|      0|
-   36|      0|    let mut countdown = 0;
+   35|       |
+   36|       |    let mut countdown = 0;
    37|      2|    if true {
                      ^1
    38|      2|        countdown = 10;
    39|      2|    }
-   40|      0|
+   40|       |
    41|      2|    if countdown > 7 {
                      ^1
    42|      2|        countdown -= 4;

--- a/src/test/run-make-fulldeps/instrument-coverage-cov-reports-link-dead-code/expected_export_coverage.coverage_of_if_else.json
+++ b/src/test/run-make-fulldeps/instrument-coverage-cov-reports-link-dead-code/expected_export_coverage.coverage_of_if_else.json
@@ -16,15 +16,15 @@
               "percent": 100
             },
             "lines": {
-              "count": 46,
+              "count": 40,
               "covered": 19,
-              "percent": 41.30434782608695
+              "percent": 47.5
             },
             "regions": {
-              "count": 75,
+              "count": 71,
               "covered": 23,
-              "notcovered": 52,
-              "percent": 30.666666666666664
+              "notcovered": 48,
+              "percent": 32.3943661971831
             }
           }
         }
@@ -41,15 +41,15 @@
           "percent": 100
         },
         "lines": {
-          "count": 46,
+          "count": 40,
           "covered": 19,
-          "percent": 41.30434782608695
+          "percent": 47.5
         },
         "regions": {
-          "count": 75,
+          "count": 71,
           "covered": 23,
-          "notcovered": 52,
-          "percent": 30.666666666666664
+          "notcovered": 48,
+          "percent": 32.3943661971831
         }
       }
     }

--- a/src/test/run-make-fulldeps/instrument-coverage-cov-reports-link-dead-code/typical_show_coverage.coverage_of_if_else.txt
+++ b/src/test/run-make-fulldeps/instrument-coverage-cov-reports-link-dead-code/typical_show_coverage.coverage_of_if_else.txt
@@ -20,13 +20,13 @@
    16|      0|    } else {
    17|      0|        return;
    18|      0|    }
-   19|      0|
-   20|      0|    let mut countdown = 0;
+   19|       |
+   20|       |    let mut countdown = 0;
    21|      2|    if true {
                      ^1
    22|      2|        countdown = 10;
    23|      2|    }
-   24|      0|
+   24|       |
    25|      2|    if countdown > 7 {
                      ^1
    26|      2|        countdown -= 4;
@@ -40,13 +40,13 @@
    32|      0|    } else {
    33|      0|        return;
    34|      0|    }
-   35|      0|
-   36|      0|    let mut countdown = 0;
+   35|       |
+   36|       |    let mut countdown = 0;
    37|      2|    if true {
                      ^1
    38|      2|        countdown = 10;
    39|      2|    }
-   40|      0|
+   40|       |
    41|      2|    if countdown > 7 {
                      ^1
    42|      2|        countdown -= 4;

--- a/src/test/run-make-fulldeps/instrument-coverage-mir-cov-html-base/expected_mir_dump.coverage_of_if_else/coverage_of_if_else.main.-------.InstrumentCoverage.0.html
+++ b/src/test/run-make-fulldeps/instrument-coverage-mir-cov-html-base/expected_mir_dump.coverage_of_if_else/coverage_of_if_else.main.-------.InstrumentCoverage.0.html
@@ -61,13 +61,13 @@
 <body>
 <div class="code" style="counter-reset: line 2"><span class="line"><span class="code" style="--layer: 0">fn main() {</span></span>
 <span class="line"><span class="code" style="--layer: 0">    let mut countdown = 0;</span></span>
-<span class="line"><span class="code" style="--layer: 0">    </span><span><span class="code even" style="--layer: 1" title="bb2: ../instrument-coverage/coverage_of_if_else.rs:5:5: 7:6:
-    5:5-7:6: FalseEdge: falseEdge -&gt; [real: bb4, imaginary: bb3]"><span class="annotation">2⦊</span></span></span><span class="code even" style="--layer: 2" title="bb4: ../instrument-coverage/coverage_of_if_else.rs:5:5: 7:6:
+<span class="line"><span class="code" style="--layer: 0">    </span><span><span class="code even" style="--layer: 1" title="bb1: ../instrument-coverage/coverage_of_if_else.rs:5:5: 7:6:
+    5:5-7:6: FalseEdge: falseEdge -&gt; [real: bb3, imaginary: bb2]"><span class="annotation">1⦊</span></span></span><span class="code even" style="--layer: 2" title="bb3: ../instrument-coverage/coverage_of_if_else.rs:5:5: 7:6:
     6:9-6:23: Assign: _1 = const 10_i32
     5:13-7:6: Assign: _2 = const ()
-    5:5-7:6: Goto: goto -&gt; bb5"><span class="annotation">4⦊</span></span><span class="code even" style="--layer: 3" title="bb3: ../instrument-coverage/coverage_of_if_else.rs:5:5: 7:6:
+    5:5-7:6: Goto: goto -&gt; bb4"><span class="annotation">3⦊</span></span><span class="code even" style="--layer: 3" title="bb2: ../instrument-coverage/coverage_of_if_else.rs:5:5: 7:6:
     5:5-7:6: Assign: _2 = const ()
-    5:5-7:6: Goto: goto -&gt; bb5"><span class="annotation">3⦊</span>if </span><span class="code even" style="--layer: 4" title="bb0: ../instrument-coverage/coverage_of_if_else.rs:5:8: 5:12:
+    5:5-7:6: Goto: goto -&gt; bb4"><span class="annotation">2⦊</span>if </span><span class="code even" style="--layer: 4" title="bb0: ../instrument-coverage/coverage_of_if_else.rs:5:8: 5:12:
     4:9-4:22: StorageLive: StorageLive(_1)
     4:25-4:26: Assign: _1 = const 0_i32
     4:9-4:22: FakeRead: FakeRead(ForLet, _1)
@@ -75,29 +75,29 @@
     5:8-5:12: StorageLive: StorageLive(_3)
     5:8-5:12: Assign: _3 = const true
     5:8-5:12: FakeRead: FakeRead(ForMatchedPlace, _3)
-    5:5-7:6: SwitchInt: switchInt(_3) -&gt; [false: bb3, otherwise: bb2]"><span class="annotation">0⦊</span>true<span class="annotation">⦉0</span></span><span class="code even" style="--layer: 3" title="bb3: ../instrument-coverage/coverage_of_if_else.rs:5:5: 7:6:
+    5:5-7:6: SwitchInt: switchInt(_3) -&gt; [false: bb2, otherwise: bb1]"><span class="annotation">0⦊</span>true<span class="annotation">⦉0</span></span><span class="code even" style="--layer: 3" title="bb2: ../instrument-coverage/coverage_of_if_else.rs:5:5: 7:6:
     5:5-7:6: Assign: _2 = const ()
-    5:5-7:6: Goto: goto -&gt; bb5"> {</span></span>
-<span class="line"><span class="code even" style="--layer: 3" title="bb3: ../instrument-coverage/coverage_of_if_else.rs:5:5: 7:6:
+    5:5-7:6: Goto: goto -&gt; bb4"> {</span></span>
+<span class="line"><span class="code even" style="--layer: 3" title="bb2: ../instrument-coverage/coverage_of_if_else.rs:5:5: 7:6:
     5:5-7:6: Assign: _2 = const ()
-    5:5-7:6: Goto: goto -&gt; bb5">        countdown = 10;</span></span>
-<span class="line"><span class="code even" style="--layer: 3" title="bb3: ../instrument-coverage/coverage_of_if_else.rs:5:5: 7:6:
+    5:5-7:6: Goto: goto -&gt; bb4">        countdown = 10;</span></span>
+<span class="line"><span class="code even" style="--layer: 3" title="bb2: ../instrument-coverage/coverage_of_if_else.rs:5:5: 7:6:
     5:5-7:6: Assign: _2 = const ()
-    5:5-7:6: Goto: goto -&gt; bb5">    }<span class="annotation">⦉3</span></span><span class="code even" style="--layer: 2" title="bb4: ../instrument-coverage/coverage_of_if_else.rs:5:5: 7:6:
+    5:5-7:6: Goto: goto -&gt; bb4">    }<span class="annotation">⦉2</span></span><span class="code even" style="--layer: 2" title="bb3: ../instrument-coverage/coverage_of_if_else.rs:5:5: 7:6:
     6:9-6:23: Assign: _1 = const 10_i32
     5:13-7:6: Assign: _2 = const ()
-    5:5-7:6: Goto: goto -&gt; bb5"><span class="annotation">⦉4</span></span><span><span class="code even" style="--layer: 1" title="bb2: ../instrument-coverage/coverage_of_if_else.rs:5:5: 7:6:
-    5:5-7:6: FalseEdge: falseEdge -&gt; [real: bb4, imaginary: bb3]"><span class="annotation">⦉2</span></span></span><span class="code" style="--layer: 0"></span></span>
+    5:5-7:6: Goto: goto -&gt; bb4"><span class="annotation">⦉3</span></span><span><span class="code even" style="--layer: 1" title="bb1: ../instrument-coverage/coverage_of_if_else.rs:5:5: 7:6:
+    5:5-7:6: FalseEdge: falseEdge -&gt; [real: bb3, imaginary: bb2]"><span class="annotation">⦉1</span></span></span><span class="code" style="--layer: 0"></span></span>
 <span class="line"><span class="code" style="--layer: 0"></span></span>
-<span class="line"><span class="code" style="--layer: 0">    </span><span><span class="code odd" style="--layer: 1" title="bb6: ../instrument-coverage/coverage_of_if_else.rs:9:5: 18:6:
-    9:5-18:6: FalseEdge: falseEdge -&gt; [real: bb8, imaginary: bb7]"><span class="annotation">6⦊</span></span></span><span class="code even" style="--layer: 2" title="bb9: ../instrument-coverage/coverage_of_if_else.rs:9:5: 18:6:
+<span class="line"><span class="code" style="--layer: 0">    </span><span><span class="code odd" style="--layer: 1" title="bb5: ../instrument-coverage/coverage_of_if_else.rs:9:5: 18:6:
+    9:5-18:6: FalseEdge: falseEdge -&gt; [real: bb7, imaginary: bb6]"><span class="annotation">5⦊</span></span></span><span class="code even" style="--layer: 2" title="bb8: ../instrument-coverage/coverage_of_if_else.rs:9:5: 18:6:
     10:9-10:23: Assign: _1 = move (_7.0: i32)
     9:22-11:6: Assign: _4 = const ()
-    9:5-18:6: Goto: goto -&gt; bb28"><span class="annotation">9⦊</span></span><span class="code even" style="--layer: 3" title="bb25: ../instrument-coverage/coverage_of_if_else.rs:9:5: 18:6:
+    9:5-18:6: Goto: goto -&gt; bb25"><span class="annotation">8⦊</span></span><span class="code even" style="--layer: 3" title="bb24: ../instrument-coverage/coverage_of_if_else.rs:9:5: 18:6:
     15:9-15:23: Assign: _1 = move (_19.0: i32)
     11:29-16:6: Assign: _4 = const ()
     18:5-18:6: StorageDead: StorageDead(_8)
-    9:5-18:6: Goto: goto -&gt; bb28"><span class="annotation">25⦊</span>if </span><span class="code even" style="--layer: 4" title="bb5: ../instrument-coverage/coverage_of_if_else.rs:9:8: 9:21:
+    9:5-18:6: Goto: goto -&gt; bb25"><span class="annotation">24⦊</span>if </span><span class="code even" style="--layer: 4" title="bb4: ../instrument-coverage/coverage_of_if_else.rs:9:8: 9:21:
     7:5-7:6: StorageDead: StorageDead(_3)
     7:5-7:6: StorageDead: StorageDead(_2)
     9:5-18:6: StorageLive: StorageLive(_4)
@@ -107,61 +107,50 @@
     9:8-9:21: Assign: _5 = Gt(move _6, const 7_i32)
     9:20-9:21: StorageDead: StorageDead(_6)
     9:8-9:21: FakeRead: FakeRead(ForMatchedPlace, _5)
-    9:5-18:6: SwitchInt: switchInt(_5) -&gt; [false: bb7, otherwise: bb6]"><span class="annotation">5⦊</span>countdown &gt; 7<span class="annotation">⦉5</span></span><span class="code even" style="--layer: 3" title="bb25: ../instrument-coverage/coverage_of_if_else.rs:9:5: 18:6:
+    9:5-18:6: SwitchInt: switchInt(_5) -&gt; [false: bb6, otherwise: bb5]"><span class="annotation">4⦊</span>countdown &gt; 7<span class="annotation">⦉4</span></span><span class="code even" style="--layer: 3" title="bb24: ../instrument-coverage/coverage_of_if_else.rs:9:5: 18:6:
     15:9-15:23: Assign: _1 = move (_19.0: i32)
     11:29-16:6: Assign: _4 = const ()
     18:5-18:6: StorageDead: StorageDead(_8)
-    9:5-18:6: Goto: goto -&gt; bb28"> {</span></span>
-<span class="line"><span class="code even" style="--layer: 3" title="bb25: ../instrument-coverage/coverage_of_if_else.rs:9:5: 18:6:
+    9:5-18:6: Goto: goto -&gt; bb25"> {</span></span>
+<span class="line"><span class="code even" style="--layer: 3" title="bb24: ../instrument-coverage/coverage_of_if_else.rs:9:5: 18:6:
     15:9-15:23: Assign: _1 = move (_19.0: i32)
     11:29-16:6: Assign: _4 = const ()
     18:5-18:6: StorageDead: StorageDead(_8)
-    9:5-18:6: Goto: goto -&gt; bb28">        </span><span class="code odd" style="--layer: 4" title="bb8: ../instrument-coverage/coverage_of_if_else.rs:10:9: 10:23:
+    9:5-18:6: Goto: goto -&gt; bb25">        </span><span class="code odd" style="--layer: 4" title="bb7: ../instrument-coverage/coverage_of_if_else.rs:10:9: 10:23:
     10:9-10:23: Assign: _7 = CheckedSub(_1, const 4_i32)
-    10:9-10:23: Assert: assert(!move (_7.1: bool), &quot;attempt to compute `{} - {}`, which would overflow&quot;, _1, const 4_i32) -&gt; [success: bb9, unwind: bb1]"><span class="annotation">8⦊</span>countdown -= 4<span class="annotation">⦉8</span></span><span class="code even" style="--layer: 3" title="bb25: ../instrument-coverage/coverage_of_if_else.rs:9:5: 18:6:
+    10:9-10:23: Assert: assert(!move (_7.1: bool), &quot;attempt to compute `{} - {}`, which would overflow&quot;, _1, const 4_i32) -&gt; [success: bb8, unwind: bb78]"><span class="annotation">7⦊</span>countdown -= 4<span class="annotation">⦉7</span></span><span class="code even" style="--layer: 3" title="bb24: ../instrument-coverage/coverage_of_if_else.rs:9:5: 18:6:
     15:9-15:23: Assign: _1 = move (_19.0: i32)
     11:29-16:6: Assign: _4 = const ()
     18:5-18:6: StorageDead: StorageDead(_8)
-    9:5-18:6: Goto: goto -&gt; bb28">;</span></span>
-<span class="line"><span class="code even" style="--layer: 3" title="bb25: ../instrument-coverage/coverage_of_if_else.rs:9:5: 18:6:
+    9:5-18:6: Goto: goto -&gt; bb25">;</span></span>
+<span class="line"><span class="code even" style="--layer: 3" title="bb24: ../instrument-coverage/coverage_of_if_else.rs:9:5: 18:6:
     15:9-15:23: Assign: _1 = move (_19.0: i32)
     11:29-16:6: Assign: _4 = const ()
     18:5-18:6: StorageDead: StorageDead(_8)
-    9:5-18:6: Goto: goto -&gt; bb28">    } else </span><span class="code even" style="--layer: 4" title="bb10: ../instrument-coverage/coverage_of_if_else.rs:11:12: 18:6:
-    11:12-18:6: FalseEdge: falseEdge -&gt; [real: bb12, imaginary: bb11]"><span class="annotation">10⦊</span>if </span><span class="code even" style="--layer: 5" title="bb7: ../instrument-coverage/coverage_of_if_else.rs:11:15: 11:28:
+    9:5-18:6: Goto: goto -&gt; bb25">    } else </span><span class="code even" style="--layer: 4" title="bb9: ../instrument-coverage/coverage_of_if_else.rs:11:12: 18:6:
+    11:12-18:6: FalseEdge: falseEdge -&gt; [real: bb11, imaginary: bb10]"><span class="annotation">9⦊</span>if </span><span class="code even" style="--layer: 5" title="bb6: ../instrument-coverage/coverage_of_if_else.rs:11:15: 11:28:
     11:15-11:28: StorageLive: StorageLive(_8)
     11:15-11:24: StorageLive: StorageLive(_9)
     11:15-11:24: Assign: _9 = _1
     11:15-11:28: Assign: _8 = Gt(move _9, const 2_i32)
     11:27-11:28: StorageDead: StorageDead(_9)
     11:15-11:28: FakeRead: FakeRead(ForMatchedPlace, _8)
-    11:12-18:6: SwitchInt: switchInt(_8) -&gt; [false: bb11, otherwise: bb10]"><span class="annotation">7⦊</span>countdown &gt; 2<span class="annotation">⦉7</span></span><span class="code even" style="--layer: 4" title="bb10: ../instrument-coverage/coverage_of_if_else.rs:11:12: 18:6:
-    11:12-18:6: FalseEdge: falseEdge -&gt; [real: bb12, imaginary: bb11]"> {</span></span>
-<span class="line"><span class="code even" style="--layer: 4" title="bb10: ../instrument-coverage/coverage_of_if_else.rs:11:12: 18:6:
-    11:12-18:6: FalseEdge: falseEdge -&gt; [real: bb12, imaginary: bb11]">        </span><span class="code odd" style="--layer: 5" title="bb22: ../instrument-coverage/coverage_of_if_else.rs:12:9: 14:10:
-    12:9-14:10: Assign: _10 = const ()
-    12:9-14:10: Goto: goto -&gt; bb24"><span class="annotation">22⦊</span></span><span class="code even" style="--layer: 6" title="bb23: ../instrument-coverage/coverage_of_if_else.rs:12:9: 14:10:
+    11:12-18:6: SwitchInt: switchInt(_8) -&gt; [false: bb10, otherwise: bb9]"><span class="annotation">6⦊</span>countdown &gt; 2<span class="annotation">⦉6</span></span><span class="code even" style="--layer: 4" title="bb9: ../instrument-coverage/coverage_of_if_else.rs:11:12: 18:6:
+    11:12-18:6: FalseEdge: falseEdge -&gt; [real: bb11, imaginary: bb10]"> {</span></span>
+<span class="line"><span class="code even" style="--layer: 4" title="bb9: ../instrument-coverage/coverage_of_if_else.rs:11:12: 18:6:
+    11:12-18:6: FalseEdge: falseEdge -&gt; [real: bb11, imaginary: bb10]">        </span><span class="code odd" style="--layer: 5" title="bb20: ../instrument-coverage/coverage_of_if_else.rs:12:9: 14:10:
+    12:9-14:10: FalseEdge: falseEdge -&gt; [real: bb22, imaginary: bb21]"><span class="annotation">20⦊</span></span><span class="code even" style="--layer: 6" title="bb22: ../instrument-coverage/coverage_of_if_else.rs:12:9: 14:10:
     13:13-13:26: Assign: _1 = const 0_i32
     12:61-14:10: Assign: _10 = const ()
-    12:9-14:10: Goto: goto -&gt; bb24"><span class="annotation">23⦊</span></span><span class="code even" style="--layer: 7" title="bb21: ../instrument-coverage/coverage_of_if_else.rs:12:9: 14:10:
-    12:9-14:10: FalseEdge: falseEdge -&gt; [real: bb23, imaginary: bb22]"><span class="annotation">21⦊</span>if </span><span class="code even" style="--layer: 8" title="bb14: ../instrument-coverage/coverage_of_if_else.rs:12:12: 12:60:
-    12:12-12:60: Assign: _11 = const false
-    12:12-12:60: Goto: goto -&gt; bb16"><span class="annotation">14⦊</span></span><span class="code even" style="--layer: 9" title="bb15: ../instrument-coverage/coverage_of_if_else.rs:12:12: 12:60:
+    12:9-14:10: Goto: goto -&gt; bb23"><span class="annotation">22⦊</span></span><span class="code even" style="--layer: 7" title="bb21: ../instrument-coverage/coverage_of_if_else.rs:12:9: 14:10:
+    12:9-14:10: Assign: _10 = const ()
+    12:9-14:10: Goto: goto -&gt; bb23"><span class="annotation">21⦊</span>if </span><span class="code even" style="--layer: 8" title="bb14: ../instrument-coverage/coverage_of_if_else.rs:12:12: 12:60:
     12:46-12:60: StorageLive: StorageLive(_17)
     12:46-12:55: StorageLive: StorageLive(_18)
     12:46-12:55: Assign: _18 = _1
     12:46-12:60: Assign: _17 = Ne(move _18, const 9_i32)
     12:59-12:60: StorageDead: StorageDead(_18)
-    12:12-12:60: SwitchInt: switchInt(move _17) -&gt; [false: bb14, otherwise: bb13]"><span class="annotation">15⦊</span></span><span class="code even" style="--layer: 10" title="bb16: ../instrument-coverage/coverage_of_if_else.rs:12:12: 12:60:
-    12:59-12:60: StorageDead: StorageDead(_17)
-    12:59-12:60: StorageDead: StorageDead(_12)
-    12:12-12:60: FakeRead: FakeRead(ForMatchedPlace, _11)
-    12:9-14:10: SwitchInt: switchInt(_11) -&gt; [false: bb22, otherwise: bb21]"><span class="annotation">16⦊</span></span><span class="code even" style="--layer: 11" title="bb13: ../instrument-coverage/coverage_of_if_else.rs:12:12: 12:60:
-    12:12-12:60: Assign: _11 = const true
-    12:12-12:60: Goto: goto -&gt; bb16"><span class="annotation">13⦊</span></span><span class="code even" style="--layer: 12" title="bb20: ../instrument-coverage/coverage_of_if_else.rs:12:12: 12:60:
-    12:41-12:42: StorageDead: StorageDead(_15)
-    12:41-12:42: StorageDead: StorageDead(_13)
-    12:12-12:60: SwitchInt: switchInt(move _12) -&gt; [false: bb15, otherwise: bb13]"><span class="annotation">20⦊</span></span><span class="code even" style="--layer: 13" title="bb12: ../instrument-coverage/coverage_of_if_else.rs:12:12: 12:60:
+    12:12-12:60: SwitchInt: switchInt(move _17) -&gt; [false: bb13, otherwise: bb12]"><span class="annotation">14⦊</span></span><span class="code even" style="--layer: 9" title="bb11: ../instrument-coverage/coverage_of_if_else.rs:12:12: 12:60:
     12:9-14:10: StorageLive: StorageLive(_10)
     12:12-12:60: StorageLive: StorageLive(_11)
     12:12-12:42: StorageLive: StorageLive(_12)
@@ -170,25 +159,43 @@
     12:12-12:21: Assign: _14 = _1
     12:12-12:25: Assign: _13 = Lt(move _14, const 1_i32)
     12:24-12:25: StorageDead: StorageDead(_14)
-    12:12-12:42: SwitchInt: switchInt(move _13) -&gt; [false: bb19, otherwise: bb17]"><span class="annotation">12⦊</span></span><span class="code even" style="--layer: 14" title="bb18: ../instrument-coverage/coverage_of_if_else.rs:12:12: 12:42:
-    12:12-12:42: Assign: _12 = const false
-    12:12-12:42: Goto: goto -&gt; bb20"><span class="annotation">18⦊</span></span><span class="code even" style="--layer: 15" title="bb19: ../instrument-coverage/coverage_of_if_else.rs:12:12: 12:42:
-    12:29-12:42: StorageLive: StorageLive(_15)
-    12:29-12:38: StorageLive: StorageLive(_16)
-    12:29-12:38: Assign: _16 = _1
-    12:29-12:42: Assign: _15 = Gt(move _16, const 5_i32)
-    12:41-12:42: StorageDead: StorageDead(_16)
-    12:12-12:42: SwitchInt: switchInt(move _15) -&gt; [false: bb18, otherwise: bb17]"><span class="annotation">19⦊</span></span><span class="code even" style="--layer: 16" title="bb17: ../instrument-coverage/coverage_of_if_else.rs:12:12: 12:42:
+    12:12-12:42: SwitchInt: switchInt(move _13) -&gt; [false: bb18, otherwise: bb16]"><span class="annotation">11⦊</span></span><span class="code even" style="--layer: 10" title="bb13: ../instrument-coverage/coverage_of_if_else.rs:12:12: 12:60:
+    12:12-12:60: Assign: _11 = const false
+    12:12-12:60: Goto: goto -&gt; bb15"><span class="annotation">13⦊</span></span><span class="code even" style="--layer: 11" title="bb19: ../instrument-coverage/coverage_of_if_else.rs:12:12: 12:60:
+    12:41-12:42: StorageDead: StorageDead(_15)
+    12:41-12:42: StorageDead: StorageDead(_13)
+    12:12-12:60: SwitchInt: switchInt(move _12) -&gt; [false: bb14, otherwise: bb12]"><span class="annotation">19⦊</span></span><span class="code even" style="--layer: 12" title="bb15: ../instrument-coverage/coverage_of_if_else.rs:12:12: 12:60:
+    12:59-12:60: StorageDead: StorageDead(_17)
+    12:59-12:60: StorageDead: StorageDead(_12)
+    12:12-12:60: FakeRead: FakeRead(ForMatchedPlace, _11)
+    12:9-14:10: SwitchInt: switchInt(_11) -&gt; [false: bb21, otherwise: bb20]"><span class="annotation">15⦊</span></span><span class="code even" style="--layer: 13" title="bb12: ../instrument-coverage/coverage_of_if_else.rs:12:12: 12:60:
+    12:12-12:60: Assign: _11 = const true
+    12:12-12:60: Goto: goto -&gt; bb15"><span class="annotation">12⦊</span></span><span class="code even" style="--layer: 14" title="bb16: ../instrument-coverage/coverage_of_if_else.rs:12:12: 12:42:
     12:12-12:42: Assign: _12 = const true
-    12:12-12:42: Goto: goto -&gt; bb20"><span class="annotation">17⦊</span>countdown &lt; 1 || countdown &gt; 5<span class="annotation">⦉17</span></span><span class="code even" style="--layer: 15" title="bb19: ../instrument-coverage/coverage_of_if_else.rs:12:12: 12:42:
+    12:12-12:42: Goto: goto -&gt; bb19"><span class="annotation">16⦊</span></span><span class="code even" style="--layer: 15" title="bb17: ../instrument-coverage/coverage_of_if_else.rs:12:12: 12:42:
+    12:12-12:42: Assign: _12 = const false
+    12:12-12:42: Goto: goto -&gt; bb19"><span class="annotation">17⦊</span></span><span class="code even" style="--layer: 16" title="bb18: ../instrument-coverage/coverage_of_if_else.rs:12:12: 12:42:
     12:29-12:42: StorageLive: StorageLive(_15)
     12:29-12:38: StorageLive: StorageLive(_16)
     12:29-12:38: Assign: _16 = _1
     12:29-12:42: Assign: _15 = Gt(move _16, const 5_i32)
     12:41-12:42: StorageDead: StorageDead(_16)
-    12:12-12:42: SwitchInt: switchInt(move _15) -&gt; [false: bb18, otherwise: bb17]"><span class="annotation">⦉19</span></span><span class="code even" style="--layer: 14" title="bb18: ../instrument-coverage/coverage_of_if_else.rs:12:12: 12:42:
+    12:12-12:42: SwitchInt: switchInt(move _15) -&gt; [false: bb17, otherwise: bb16]"><span class="annotation">18⦊</span>countdown &lt; 1 || countdown &gt; 5<span class="annotation">⦉18</span></span><span class="code even" style="--layer: 15" title="bb17: ../instrument-coverage/coverage_of_if_else.rs:12:12: 12:42:
     12:12-12:42: Assign: _12 = const false
-    12:12-12:42: Goto: goto -&gt; bb20"><span class="annotation">⦉18</span></span><span class="code even" style="--layer: 13" title="bb12: ../instrument-coverage/coverage_of_if_else.rs:12:12: 12:60:
+    12:12-12:42: Goto: goto -&gt; bb19"><span class="annotation">⦉17</span></span><span class="code even" style="--layer: 14" title="bb16: ../instrument-coverage/coverage_of_if_else.rs:12:12: 12:42:
+    12:12-12:42: Assign: _12 = const true
+    12:12-12:42: Goto: goto -&gt; bb19"><span class="annotation">⦉16</span></span><span class="code even" style="--layer: 13" title="bb12: ../instrument-coverage/coverage_of_if_else.rs:12:12: 12:60:
+    12:12-12:60: Assign: _11 = const true
+    12:12-12:60: Goto: goto -&gt; bb15"> || countdown != 9<span class="annotation">⦉12</span></span><span class="code even" style="--layer: 12" title="bb15: ../instrument-coverage/coverage_of_if_else.rs:12:12: 12:60:
+    12:59-12:60: StorageDead: StorageDead(_17)
+    12:59-12:60: StorageDead: StorageDead(_12)
+    12:12-12:60: FakeRead: FakeRead(ForMatchedPlace, _11)
+    12:9-14:10: SwitchInt: switchInt(_11) -&gt; [false: bb21, otherwise: bb20]"><span class="annotation">⦉15</span></span><span class="code even" style="--layer: 11" title="bb19: ../instrument-coverage/coverage_of_if_else.rs:12:12: 12:60:
+    12:41-12:42: StorageDead: StorageDead(_15)
+    12:41-12:42: StorageDead: StorageDead(_13)
+    12:12-12:60: SwitchInt: switchInt(move _12) -&gt; [false: bb14, otherwise: bb12]"><span class="annotation">⦉19</span></span><span class="code even" style="--layer: 10" title="bb13: ../instrument-coverage/coverage_of_if_else.rs:12:12: 12:60:
+    12:12-12:60: Assign: _11 = const false
+    12:12-12:60: Goto: goto -&gt; bb15"><span class="annotation">⦉13</span></span><span class="code even" style="--layer: 9" title="bb11: ../instrument-coverage/coverage_of_if_else.rs:12:12: 12:60:
     12:9-14:10: StorageLive: StorageLive(_10)
     12:12-12:60: StorageLive: StorageLive(_11)
     12:12-12:42: StorageLive: StorageLive(_12)
@@ -197,108 +204,66 @@
     12:12-12:21: Assign: _14 = _1
     12:12-12:25: Assign: _13 = Lt(move _14, const 1_i32)
     12:24-12:25: StorageDead: StorageDead(_14)
-    12:12-12:42: SwitchInt: switchInt(move _13) -&gt; [false: bb19, otherwise: bb17]"> || countdown != 9<span class="annotation">⦉12</span></span><span class="code even" style="--layer: 12" title="bb20: ../instrument-coverage/coverage_of_if_else.rs:12:12: 12:60:
-    12:41-12:42: StorageDead: StorageDead(_15)
-    12:41-12:42: StorageDead: StorageDead(_13)
-    12:12-12:60: SwitchInt: switchInt(move _12) -&gt; [false: bb15, otherwise: bb13]"><span class="annotation">⦉20</span></span><span class="code even" style="--layer: 11" title="bb13: ../instrument-coverage/coverage_of_if_else.rs:12:12: 12:60:
-    12:12-12:60: Assign: _11 = const true
-    12:12-12:60: Goto: goto -&gt; bb16"><span class="annotation">⦉13</span></span><span class="code even" style="--layer: 10" title="bb16: ../instrument-coverage/coverage_of_if_else.rs:12:12: 12:60:
-    12:59-12:60: StorageDead: StorageDead(_17)
-    12:59-12:60: StorageDead: StorageDead(_12)
-    12:12-12:60: FakeRead: FakeRead(ForMatchedPlace, _11)
-    12:9-14:10: SwitchInt: switchInt(_11) -&gt; [false: bb22, otherwise: bb21]"><span class="annotation">⦉16</span></span><span class="code even" style="--layer: 9" title="bb15: ../instrument-coverage/coverage_of_if_else.rs:12:12: 12:60:
+    12:12-12:42: SwitchInt: switchInt(move _13) -&gt; [false: bb18, otherwise: bb16]"><span class="annotation">⦉11</span></span><span class="code even" style="--layer: 8" title="bb14: ../instrument-coverage/coverage_of_if_else.rs:12:12: 12:60:
     12:46-12:60: StorageLive: StorageLive(_17)
     12:46-12:55: StorageLive: StorageLive(_18)
     12:46-12:55: Assign: _18 = _1
     12:46-12:60: Assign: _17 = Ne(move _18, const 9_i32)
     12:59-12:60: StorageDead: StorageDead(_18)
-    12:12-12:60: SwitchInt: switchInt(move _17) -&gt; [false: bb14, otherwise: bb13]"><span class="annotation">⦉15</span></span><span class="code even" style="--layer: 8" title="bb14: ../instrument-coverage/coverage_of_if_else.rs:12:12: 12:60:
-    12:12-12:60: Assign: _11 = const false
-    12:12-12:60: Goto: goto -&gt; bb16"><span class="annotation">⦉14</span></span><span class="code even" style="--layer: 7" title="bb21: ../instrument-coverage/coverage_of_if_else.rs:12:9: 14:10:
-    12:9-14:10: FalseEdge: falseEdge -&gt; [real: bb23, imaginary: bb22]"> {</span></span>
+    12:12-12:60: SwitchInt: switchInt(move _17) -&gt; [false: bb13, otherwise: bb12]"><span class="annotation">⦉14</span></span><span class="code even" style="--layer: 7" title="bb21: ../instrument-coverage/coverage_of_if_else.rs:12:9: 14:10:
+    12:9-14:10: Assign: _10 = const ()
+    12:9-14:10: Goto: goto -&gt; bb23"> {</span></span>
 <span class="line"><span class="code even" style="--layer: 7" title="bb21: ../instrument-coverage/coverage_of_if_else.rs:12:9: 14:10:
-    12:9-14:10: FalseEdge: falseEdge -&gt; [real: bb23, imaginary: bb22]">            countdown = 0;</span></span>
+    12:9-14:10: Assign: _10 = const ()
+    12:9-14:10: Goto: goto -&gt; bb23">            countdown = 0;</span></span>
 <span class="line"><span class="code even" style="--layer: 7" title="bb21: ../instrument-coverage/coverage_of_if_else.rs:12:9: 14:10:
-    12:9-14:10: FalseEdge: falseEdge -&gt; [real: bb23, imaginary: bb22]">        </span><span class="code odd" style="--layer: 8" title="bb24: ../instrument-coverage/coverage_of_if_else.rs:14:9: 15:23:
+    12:9-14:10: Assign: _10 = const ()
+    12:9-14:10: Goto: goto -&gt; bb23">        </span><span class="code odd" style="--layer: 8" title="bb23: ../instrument-coverage/coverage_of_if_else.rs:14:9: 15:23:
     14:9-14:10: StorageDead: StorageDead(_11)
     14:9-14:10: StorageDead: StorageDead(_10)
     15:9-15:23: Assign: _19 = CheckedSub(_1, const 5_i32)
-    15:9-15:23: Assert: assert(!move (_19.1: bool), &quot;attempt to compute `{} - {}`, which would overflow&quot;, _1, const 5_i32) -&gt; [success: bb25, unwind: bb1]"><span class="annotation">24⦊</span>}</span><span class="code odd" style="--layer: 5" title="bb22: ../instrument-coverage/coverage_of_if_else.rs:12:9: 14:10:
-    12:9-14:10: Assign: _10 = const ()
-    12:9-14:10: Goto: goto -&gt; bb24"><span class="annotation">⦉22</span></span><span class="code even" style="--layer: 6" title="bb23: ../instrument-coverage/coverage_of_if_else.rs:12:9: 14:10:
+    15:9-15:23: Assert: assert(!move (_19.1: bool), &quot;attempt to compute `{} - {}`, which would overflow&quot;, _1, const 5_i32) -&gt; [success: bb24, unwind: bb78]"><span class="annotation">23⦊</span>}</span><span class="code odd" style="--layer: 5" title="bb20: ../instrument-coverage/coverage_of_if_else.rs:12:9: 14:10:
+    12:9-14:10: FalseEdge: falseEdge -&gt; [real: bb22, imaginary: bb21]"><span class="annotation">⦉20</span></span><span class="code even" style="--layer: 6" title="bb22: ../instrument-coverage/coverage_of_if_else.rs:12:9: 14:10:
     13:13-13:26: Assign: _1 = const 0_i32
     12:61-14:10: Assign: _10 = const ()
-    12:9-14:10: Goto: goto -&gt; bb24"><span class="annotation">⦉23</span></span><span class="code even" style="--layer: 7" title="bb21: ../instrument-coverage/coverage_of_if_else.rs:12:9: 14:10:
-    12:9-14:10: FalseEdge: falseEdge -&gt; [real: bb23, imaginary: bb22]"><span class="annotation">⦉21</span></span><span class="code even" style="--layer: 7" title="bb21: ../instrument-coverage/coverage_of_if_else.rs:12:9: 14:10:
-    12:9-14:10: FalseEdge: falseEdge -&gt; [real: bb23, imaginary: bb22]"><span class="annotation">⦉21</span></span><span class="code odd" style="--layer: 8" title="bb24: ../instrument-coverage/coverage_of_if_else.rs:14:9: 15:23:
+    12:9-14:10: Goto: goto -&gt; bb23"><span class="annotation">⦉22</span></span><span class="code even" style="--layer: 7" title="bb21: ../instrument-coverage/coverage_of_if_else.rs:12:9: 14:10:
+    12:9-14:10: Assign: _10 = const ()
+    12:9-14:10: Goto: goto -&gt; bb23"><span class="annotation">⦉21</span></span><span class="code even" style="--layer: 7" title="bb21: ../instrument-coverage/coverage_of_if_else.rs:12:9: 14:10:
+    12:9-14:10: Assign: _10 = const ()
+    12:9-14:10: Goto: goto -&gt; bb23"><span class="annotation">⦉21</span></span><span class="code odd" style="--layer: 8" title="bb23: ../instrument-coverage/coverage_of_if_else.rs:14:9: 15:23:
     14:9-14:10: StorageDead: StorageDead(_11)
     14:9-14:10: StorageDead: StorageDead(_10)
     15:9-15:23: Assign: _19 = CheckedSub(_1, const 5_i32)
-    15:9-15:23: Assert: assert(!move (_19.1: bool), &quot;attempt to compute `{} - {}`, which would overflow&quot;, _1, const 5_i32) -&gt; [success: bb25, unwind: bb1]"></span></span>
-<span class="line"><span class="code odd" style="--layer: 8" title="bb24: ../instrument-coverage/coverage_of_if_else.rs:14:9: 15:23:
+    15:9-15:23: Assert: assert(!move (_19.1: bool), &quot;attempt to compute `{} - {}`, which would overflow&quot;, _1, const 5_i32) -&gt; [success: bb24, unwind: bb78]"></span></span>
+<span class="line"><span class="code odd" style="--layer: 8" title="bb23: ../instrument-coverage/coverage_of_if_else.rs:14:9: 15:23:
     14:9-14:10: StorageDead: StorageDead(_11)
     14:9-14:10: StorageDead: StorageDead(_10)
     15:9-15:23: Assign: _19 = CheckedSub(_1, const 5_i32)
-    15:9-15:23: Assert: assert(!move (_19.1: bool), &quot;attempt to compute `{} - {}`, which would overflow&quot;, _1, const 5_i32) -&gt; [success: bb25, unwind: bb1]">        countdown -= 5<span class="annotation">⦉24</span></span><span class="code even" style="--layer: 4" title="bb10: ../instrument-coverage/coverage_of_if_else.rs:11:12: 18:6:
-    11:12-18:6: FalseEdge: falseEdge -&gt; [real: bb12, imaginary: bb11]">;</span></span>
-<span class="line"><span class="code even" style="--layer: 4" title="bb10: ../instrument-coverage/coverage_of_if_else.rs:11:12: 18:6:
-    11:12-18:6: FalseEdge: falseEdge -&gt; [real: bb12, imaginary: bb11]">    } else {</span></span>
-<span class="line"><span class="code even" style="--layer: 4" title="bb10: ../instrument-coverage/coverage_of_if_else.rs:11:12: 18:6:
-    11:12-18:6: FalseEdge: falseEdge -&gt; [real: bb12, imaginary: bb11]">        </span><span class="code even" style="--layer: 5" title="bb27: ../instrument-coverage/coverage_of_if_else.rs:17:9: 51:2:
-    51:1-51:2: StorageDead: StorageDead(_1)
-    17:9-17:15: Goto: goto -&gt; bb26"><span class="annotation">27⦊</span></span><span class="code even" style="--layer: 6" title="bb11: ../instrument-coverage/coverage_of_if_else.rs:17:9: 18:6:
-    17:9-17:15: Assign: _0 = const ()
+    15:9-15:23: Assert: assert(!move (_19.1: bool), &quot;attempt to compute `{} - {}`, which would overflow&quot;, _1, const 5_i32) -&gt; [success: bb24, unwind: bb78]">        countdown -= 5<span class="annotation">⦉23</span></span><span class="code even" style="--layer: 4" title="bb9: ../instrument-coverage/coverage_of_if_else.rs:11:12: 18:6:
+    11:12-18:6: FalseEdge: falseEdge -&gt; [real: bb11, imaginary: bb10]">;</span></span>
+<span class="line"><span class="code even" style="--layer: 4" title="bb9: ../instrument-coverage/coverage_of_if_else.rs:11:12: 18:6:
+    11:12-18:6: FalseEdge: falseEdge -&gt; [real: bb11, imaginary: bb10]">    } else {</span></span>
+<span class="line"><span class="code even" style="--layer: 4" title="bb9: ../instrument-coverage/coverage_of_if_else.rs:11:12: 18:6:
+    11:12-18:6: FalseEdge: falseEdge -&gt; [real: bb11, imaginary: bb10]">        return;</span></span>
+<span class="line"><span class="code even" style="--layer: 4" title="bb9: ../instrument-coverage/coverage_of_if_else.rs:11:12: 18:6:
+    11:12-18:6: FalseEdge: falseEdge -&gt; [real: bb11, imaginary: bb10]">    }<span class="annotation">⦉9</span></span><span class="code even" style="--layer: 3" title="bb24: ../instrument-coverage/coverage_of_if_else.rs:9:5: 18:6:
+    15:9-15:23: Assign: _1 = move (_19.0: i32)
+    11:29-16:6: Assign: _4 = const ()
     18:5-18:6: StorageDead: StorageDead(_8)
-    18:5-18:6: StorageDead: StorageDead(_5)
-    18:5-18:6: StorageDead: StorageDead(_4)
-    17:9-17:15: Goto: goto -&gt; bb27"><span class="annotation">11⦊</span>return;</span></span>
-<span class="line"><span class="code even" style="--layer: 6" title="bb11: ../instrument-coverage/coverage_of_if_else.rs:17:9: 18:6:
-    17:9-17:15: Assign: _0 = const ()
-    18:5-18:6: StorageDead: StorageDead(_8)
-    18:5-18:6: StorageDead: StorageDead(_5)
-    18:5-18:6: StorageDead: StorageDead(_4)
-    17:9-17:15: Goto: goto -&gt; bb27">    }<span class="annotation">⦉11</span></span><span><span class="code odd" style="--layer: 1" title="bb6: ../instrument-coverage/coverage_of_if_else.rs:9:5: 18:6:
-    9:5-18:6: FalseEdge: falseEdge -&gt; [real: bb8, imaginary: bb7]"><span class="annotation">⦉6</span></span></span><span class="code even" style="--layer: 2" title="bb9: ../instrument-coverage/coverage_of_if_else.rs:9:5: 18:6:
+    9:5-18:6: Goto: goto -&gt; bb25"><span class="annotation">⦉24</span></span><span class="code even" style="--layer: 2" title="bb8: ../instrument-coverage/coverage_of_if_else.rs:9:5: 18:6:
     10:9-10:23: Assign: _1 = move (_7.0: i32)
     9:22-11:6: Assign: _4 = const ()
-    9:5-18:6: Goto: goto -&gt; bb28"><span class="annotation">⦉9</span></span><span class="code even" style="--layer: 3" title="bb25: ../instrument-coverage/coverage_of_if_else.rs:9:5: 18:6:
-    15:9-15:23: Assign: _1 = move (_19.0: i32)
-    11:29-16:6: Assign: _4 = const ()
-    18:5-18:6: StorageDead: StorageDead(_8)
-    9:5-18:6: Goto: goto -&gt; bb28"><span class="annotation">⦉25</span></span><span class="code even" style="--layer: 3" title="bb25: ../instrument-coverage/coverage_of_if_else.rs:9:5: 18:6:
-    15:9-15:23: Assign: _1 = move (_19.0: i32)
-    11:29-16:6: Assign: _4 = const ()
-    18:5-18:6: StorageDead: StorageDead(_8)
-    9:5-18:6: Goto: goto -&gt; bb28"><span class="annotation">⦉25</span></span><span class="code even" style="--layer: 3" title="bb25: ../instrument-coverage/coverage_of_if_else.rs:9:5: 18:6:
-    15:9-15:23: Assign: _1 = move (_19.0: i32)
-    11:29-16:6: Assign: _4 = const ()
-    18:5-18:6: StorageDead: StorageDead(_8)
-    9:5-18:6: Goto: goto -&gt; bb28"><span class="annotation">⦉25</span></span><span class="code even" style="--layer: 4" title="bb10: ../instrument-coverage/coverage_of_if_else.rs:11:12: 18:6:
-    11:12-18:6: FalseEdge: falseEdge -&gt; [real: bb12, imaginary: bb11]"><span class="annotation">⦉10</span></span><span class="code even" style="--layer: 4" title="bb10: ../instrument-coverage/coverage_of_if_else.rs:11:12: 18:6:
-    11:12-18:6: FalseEdge: falseEdge -&gt; [real: bb12, imaginary: bb11]"><span class="annotation">⦉10</span></span><span class="code even" style="--layer: 4" title="bb10: ../instrument-coverage/coverage_of_if_else.rs:11:12: 18:6:
-    11:12-18:6: FalseEdge: falseEdge -&gt; [real: bb12, imaginary: bb11]"><span class="annotation">⦉10</span></span><span class="code even" style="--layer: 6" title="bb11: ../instrument-coverage/coverage_of_if_else.rs:17:9: 18:6:
-    17:9-17:15: Assign: _0 = const ()
-    18:5-18:6: StorageDead: StorageDead(_8)
-    18:5-18:6: StorageDead: StorageDead(_5)
-    18:5-18:6: StorageDead: StorageDead(_4)
-    17:9-17:15: Goto: goto -&gt; bb27"><span class="annotation">⦉11</span></span><span class="code even" style="--layer: 5" title="bb27: ../instrument-coverage/coverage_of_if_else.rs:17:9: 51:2:
-    51:1-51:2: StorageDead: StorageDead(_1)
-    17:9-17:15: Goto: goto -&gt; bb26"></span></span>
-<span class="line"><span class="code even" style="--layer: 5" title="bb27: ../instrument-coverage/coverage_of_if_else.rs:17:9: 51:2:
-    51:1-51:2: StorageDead: StorageDead(_1)
-    17:9-17:15: Goto: goto -&gt; bb26"></span></span>
-<span class="line"><span class="code even" style="--layer: 5" title="bb27: ../instrument-coverage/coverage_of_if_else.rs:17:9: 51:2:
-    51:1-51:2: StorageDead: StorageDead(_1)
-    17:9-17:15: Goto: goto -&gt; bb26">    let mut countdown = 0;</span></span>
-<span class="line"><span class="code even" style="--layer: 5" title="bb27: ../instrument-coverage/coverage_of_if_else.rs:17:9: 51:2:
-    51:1-51:2: StorageDead: StorageDead(_1)
-    17:9-17:15: Goto: goto -&gt; bb26">    </span><span class="code odd" style="--layer: 6" title="bb30: ../instrument-coverage/coverage_of_if_else.rs:21:5: 23:6:
+    9:5-18:6: Goto: goto -&gt; bb25"><span class="annotation">⦉8</span></span><span><span class="code odd" style="--layer: 1" title="bb5: ../instrument-coverage/coverage_of_if_else.rs:9:5: 18:6:
+    9:5-18:6: FalseEdge: falseEdge -&gt; [real: bb7, imaginary: bb6]"><span class="annotation">⦉5</span></span></span><span class="code" style="--layer: 0"></span></span>
+<span class="line"><span class="code" style="--layer: 0"></span></span>
+<span class="line"><span class="code" style="--layer: 0">    let mut countdown = 0;</span></span>
+<span class="line"><span class="code" style="--layer: 0">    </span><span><span class="code even" style="--layer: 1" title="bb27: ../instrument-coverage/coverage_of_if_else.rs:21:5: 23:6:
     21:5-23:6: Assign: _22 = const ()
-    21:5-23:6: Goto: goto -&gt; bb32"><span class="annotation">30⦊</span></span><span class="code even" style="--layer: 7" title="bb31: ../instrument-coverage/coverage_of_if_else.rs:21:5: 23:6:
+    21:5-23:6: Goto: goto -&gt; bb29"><span class="annotation">27⦊</span></span></span><span class="code even" style="--layer: 2" title="bb28: ../instrument-coverage/coverage_of_if_else.rs:21:5: 23:6:
     22:9-22:23: Assign: _21 = const 10_i32
     21:13-23:6: Assign: _22 = const ()
-    21:5-23:6: Goto: goto -&gt; bb32"><span class="annotation">31⦊</span></span><span class="code even" style="--layer: 8" title="bb29: ../instrument-coverage/coverage_of_if_else.rs:21:5: 23:6:
-    21:5-23:6: FalseEdge: falseEdge -&gt; [real: bb31, imaginary: bb30]"><span class="annotation">29⦊</span>if </span><span class="code even" style="--layer: 9" title="bb28: ../instrument-coverage/coverage_of_if_else.rs:21:8: 21:12:
+    21:5-23:6: Goto: goto -&gt; bb29"><span class="annotation">28⦊</span></span><span class="code even" style="--layer: 3" title="bb26: ../instrument-coverage/coverage_of_if_else.rs:21:5: 23:6:
+    21:5-23:6: FalseEdge: falseEdge -&gt; [real: bb28, imaginary: bb27]"><span class="annotation">26⦊</span>if </span><span class="code even" style="--layer: 4" title="bb25: ../instrument-coverage/coverage_of_if_else.rs:21:8: 21:12:
     18:5-18:6: StorageDead: StorageDead(_5)
     18:5-18:6: StorageDead: StorageDead(_4)
     20:9-20:22: StorageLive: StorageLive(_21)
@@ -308,33 +273,27 @@
     21:8-21:12: StorageLive: StorageLive(_23)
     21:8-21:12: Assign: _23 = const true
     21:8-21:12: FakeRead: FakeRead(ForMatchedPlace, _23)
-    21:5-23:6: SwitchInt: switchInt(_23) -&gt; [false: bb30, otherwise: bb29]"><span class="annotation">28⦊</span>true<span class="annotation">⦉28</span></span><span class="code even" style="--layer: 8" title="bb29: ../instrument-coverage/coverage_of_if_else.rs:21:5: 23:6:
-    21:5-23:6: FalseEdge: falseEdge -&gt; [real: bb31, imaginary: bb30]"> {</span></span>
-<span class="line"><span class="code even" style="--layer: 8" title="bb29: ../instrument-coverage/coverage_of_if_else.rs:21:5: 23:6:
-    21:5-23:6: FalseEdge: falseEdge -&gt; [real: bb31, imaginary: bb30]">        countdown = 10;</span></span>
-<span class="line"><span class="code even" style="--layer: 8" title="bb29: ../instrument-coverage/coverage_of_if_else.rs:21:5: 23:6:
-    21:5-23:6: FalseEdge: falseEdge -&gt; [real: bb31, imaginary: bb30]">    }<span class="annotation">⦉29</span></span><span class="code even" style="--layer: 7" title="bb31: ../instrument-coverage/coverage_of_if_else.rs:21:5: 23:6:
+    21:5-23:6: SwitchInt: switchInt(_23) -&gt; [false: bb27, otherwise: bb26]"><span class="annotation">25⦊</span>true<span class="annotation">⦉25</span></span><span class="code even" style="--layer: 3" title="bb26: ../instrument-coverage/coverage_of_if_else.rs:21:5: 23:6:
+    21:5-23:6: FalseEdge: falseEdge -&gt; [real: bb28, imaginary: bb27]"> {</span></span>
+<span class="line"><span class="code even" style="--layer: 3" title="bb26: ../instrument-coverage/coverage_of_if_else.rs:21:5: 23:6:
+    21:5-23:6: FalseEdge: falseEdge -&gt; [real: bb28, imaginary: bb27]">        countdown = 10;</span></span>
+<span class="line"><span class="code even" style="--layer: 3" title="bb26: ../instrument-coverage/coverage_of_if_else.rs:21:5: 23:6:
+    21:5-23:6: FalseEdge: falseEdge -&gt; [real: bb28, imaginary: bb27]">    }<span class="annotation">⦉26</span></span><span class="code even" style="--layer: 2" title="bb28: ../instrument-coverage/coverage_of_if_else.rs:21:5: 23:6:
     22:9-22:23: Assign: _21 = const 10_i32
     21:13-23:6: Assign: _22 = const ()
-    21:5-23:6: Goto: goto -&gt; bb32"><span class="annotation">⦉31</span></span><span class="code odd" style="--layer: 6" title="bb30: ../instrument-coverage/coverage_of_if_else.rs:21:5: 23:6:
+    21:5-23:6: Goto: goto -&gt; bb29"><span class="annotation">⦉28</span></span><span><span class="code even" style="--layer: 1" title="bb27: ../instrument-coverage/coverage_of_if_else.rs:21:5: 23:6:
     21:5-23:6: Assign: _22 = const ()
-    21:5-23:6: Goto: goto -&gt; bb32"><span class="annotation">⦉30</span></span><span class="code even" style="--layer: 5" title="bb27: ../instrument-coverage/coverage_of_if_else.rs:17:9: 51:2:
-    51:1-51:2: StorageDead: StorageDead(_1)
-    17:9-17:15: Goto: goto -&gt; bb26"></span></span>
-<span class="line"><span class="code even" style="--layer: 5" title="bb27: ../instrument-coverage/coverage_of_if_else.rs:17:9: 51:2:
-    51:1-51:2: StorageDead: StorageDead(_1)
-    17:9-17:15: Goto: goto -&gt; bb26"></span></span>
-<span class="line"><span class="code even" style="--layer: 5" title="bb27: ../instrument-coverage/coverage_of_if_else.rs:17:9: 51:2:
-    51:1-51:2: StorageDead: StorageDead(_1)
-    17:9-17:15: Goto: goto -&gt; bb26">    </span><span class="code even" style="--layer: 6" title="bb33: ../instrument-coverage/coverage_of_if_else.rs:25:5: 34:6:
-    25:5-34:6: FalseEdge: falseEdge -&gt; [real: bb35, imaginary: bb34]"><span class="annotation">33⦊</span></span><span class="code even" style="--layer: 7" title="bb52: ../instrument-coverage/coverage_of_if_else.rs:25:5: 34:6:
+    21:5-23:6: Goto: goto -&gt; bb29"><span class="annotation">⦉27</span></span></span><span class="code" style="--layer: 0"></span></span>
+<span class="line"><span class="code" style="--layer: 0"></span></span>
+<span class="line"><span class="code" style="--layer: 0">    </span><span><span class="code odd" style="--layer: 1" title="bb49: ../instrument-coverage/coverage_of_if_else.rs:25:5: 34:6:
     31:9-31:23: Assign: _21 = move (_39.0: i32)
     27:29-32:6: Assign: _24 = const ()
     34:5-34:6: StorageDead: StorageDead(_28)
-    25:5-34:6: Goto: goto -&gt; bb53"><span class="annotation">52⦊</span></span><span class="code even" style="--layer: 8" title="bb36: ../instrument-coverage/coverage_of_if_else.rs:25:5: 34:6:
+    25:5-34:6: Goto: goto -&gt; bb50"><span class="annotation">49⦊</span></span></span><span class="code even" style="--layer: 2" title="bb33: ../instrument-coverage/coverage_of_if_else.rs:25:5: 34:6:
     26:9-26:23: Assign: _21 = move (_27.0: i32)
     25:22-27:6: Assign: _24 = const ()
-    25:5-34:6: Goto: goto -&gt; bb53"><span class="annotation">36⦊</span>if </span><span class="code even" style="--layer: 9" title="bb32: ../instrument-coverage/coverage_of_if_else.rs:25:8: 25:21:
+    25:5-34:6: Goto: goto -&gt; bb50"><span class="annotation">33⦊</span></span><span class="code even" style="--layer: 3" title="bb30: ../instrument-coverage/coverage_of_if_else.rs:25:5: 34:6:
+    25:5-34:6: FalseEdge: falseEdge -&gt; [real: bb32, imaginary: bb31]"><span class="annotation">30⦊</span>if </span><span class="code even" style="--layer: 4" title="bb29: ../instrument-coverage/coverage_of_if_else.rs:25:8: 25:21:
     23:5-23:6: StorageDead: StorageDead(_23)
     23:5-23:6: StorageDead: StorageDead(_22)
     25:5-34:6: StorageLive: StorageLive(_24)
@@ -344,40 +303,47 @@
     25:8-25:21: Assign: _25 = Gt(move _26, const 7_i32)
     25:20-25:21: StorageDead: StorageDead(_26)
     25:8-25:21: FakeRead: FakeRead(ForMatchedPlace, _25)
-    25:5-34:6: SwitchInt: switchInt(_25) -&gt; [false: bb34, otherwise: bb33]"><span class="annotation">32⦊</span>countdown &gt; 7<span class="annotation">⦉32</span></span><span class="code even" style="--layer: 8" title="bb36: ../instrument-coverage/coverage_of_if_else.rs:25:5: 34:6:
-    26:9-26:23: Assign: _21 = move (_27.0: i32)
-    25:22-27:6: Assign: _24 = const ()
-    25:5-34:6: Goto: goto -&gt; bb53"> {</span></span>
-<span class="line"><span class="code even" style="--layer: 8" title="bb36: ../instrument-coverage/coverage_of_if_else.rs:25:5: 34:6:
-    26:9-26:23: Assign: _21 = move (_27.0: i32)
-    25:22-27:6: Assign: _24 = const ()
-    25:5-34:6: Goto: goto -&gt; bb53">        </span><span class="code odd" style="--layer: 9" title="bb35: ../instrument-coverage/coverage_of_if_else.rs:26:9: 26:23:
+    25:5-34:6: SwitchInt: switchInt(_25) -&gt; [false: bb31, otherwise: bb30]"><span class="annotation">29⦊</span>countdown &gt; 7<span class="annotation">⦉29</span></span><span class="code even" style="--layer: 3" title="bb30: ../instrument-coverage/coverage_of_if_else.rs:25:5: 34:6:
+    25:5-34:6: FalseEdge: falseEdge -&gt; [real: bb32, imaginary: bb31]"> {</span></span>
+<span class="line"><span class="code even" style="--layer: 3" title="bb30: ../instrument-coverage/coverage_of_if_else.rs:25:5: 34:6:
+    25:5-34:6: FalseEdge: falseEdge -&gt; [real: bb32, imaginary: bb31]">        </span><span class="code odd" style="--layer: 4" title="bb32: ../instrument-coverage/coverage_of_if_else.rs:26:9: 26:23:
     26:9-26:23: Assign: _27 = CheckedSub(_21, const 4_i32)
-    26:9-26:23: Assert: assert(!move (_27.1: bool), &quot;attempt to compute `{} - {}`, which would overflow&quot;, _21, const 4_i32) -&gt; [success: bb36, unwind: bb1]"><span class="annotation">35⦊</span>countdown -= 4<span class="annotation">⦉35</span></span><span class="code even" style="--layer: 8" title="bb36: ../instrument-coverage/coverage_of_if_else.rs:25:5: 34:6:
-    26:9-26:23: Assign: _21 = move (_27.0: i32)
-    25:22-27:6: Assign: _24 = const ()
-    25:5-34:6: Goto: goto -&gt; bb53">;</span></span>
-<span class="line"><span class="code even" style="--layer: 8" title="bb36: ../instrument-coverage/coverage_of_if_else.rs:25:5: 34:6:
-    26:9-26:23: Assign: _21 = move (_27.0: i32)
-    25:22-27:6: Assign: _24 = const ()
-    25:5-34:6: Goto: goto -&gt; bb53">    } else </span><span class="code even" style="--layer: 9" title="bb37: ../instrument-coverage/coverage_of_if_else.rs:27:12: 34:6:
-    27:12-34:6: FalseEdge: falseEdge -&gt; [real: bb39, imaginary: bb38]"><span class="annotation">37⦊</span>if </span><span class="code even" style="--layer: 10" title="bb34: ../instrument-coverage/coverage_of_if_else.rs:27:15: 27:28:
+    26:9-26:23: Assert: assert(!move (_27.1: bool), &quot;attempt to compute `{} - {}`, which would overflow&quot;, _21, const 4_i32) -&gt; [success: bb33, unwind: bb78]"><span class="annotation">32⦊</span>countdown -= 4<span class="annotation">⦉32</span></span><span class="code even" style="--layer: 3" title="bb30: ../instrument-coverage/coverage_of_if_else.rs:25:5: 34:6:
+    25:5-34:6: FalseEdge: falseEdge -&gt; [real: bb32, imaginary: bb31]">;</span></span>
+<span class="line"><span class="code even" style="--layer: 3" title="bb30: ../instrument-coverage/coverage_of_if_else.rs:25:5: 34:6:
+    25:5-34:6: FalseEdge: falseEdge -&gt; [real: bb32, imaginary: bb31]">    } else </span><span class="code even" style="--layer: 4" title="bb34: ../instrument-coverage/coverage_of_if_else.rs:27:12: 34:6:
+    27:12-34:6: FalseEdge: falseEdge -&gt; [real: bb36, imaginary: bb35]"><span class="annotation">34⦊</span>if </span><span class="code even" style="--layer: 5" title="bb31: ../instrument-coverage/coverage_of_if_else.rs:27:15: 27:28:
     27:15-27:28: StorageLive: StorageLive(_28)
     27:15-27:24: StorageLive: StorageLive(_29)
     27:15-27:24: Assign: _29 = _21
     27:15-27:28: Assign: _28 = Gt(move _29, const 2_i32)
     27:27-27:28: StorageDead: StorageDead(_29)
     27:15-27:28: FakeRead: FakeRead(ForMatchedPlace, _28)
-    27:12-34:6: SwitchInt: switchInt(_28) -&gt; [false: bb38, otherwise: bb37]"><span class="annotation">34⦊</span>countdown &gt; 2<span class="annotation">⦉34</span></span><span class="code even" style="--layer: 9" title="bb37: ../instrument-coverage/coverage_of_if_else.rs:27:12: 34:6:
-    27:12-34:6: FalseEdge: falseEdge -&gt; [real: bb39, imaginary: bb38]"> {</span></span>
-<span class="line"><span class="code even" style="--layer: 9" title="bb37: ../instrument-coverage/coverage_of_if_else.rs:27:12: 34:6:
-    27:12-34:6: FalseEdge: falseEdge -&gt; [real: bb39, imaginary: bb38]">        </span><span class="code odd" style="--layer: 10" title="bb48: ../instrument-coverage/coverage_of_if_else.rs:28:9: 30:10:
-    28:9-30:10: FalseEdge: falseEdge -&gt; [real: bb50, imaginary: bb49]"><span class="annotation">48⦊</span></span><span class="code even" style="--layer: 11" title="bb50: ../instrument-coverage/coverage_of_if_else.rs:28:9: 30:10:
+    27:12-34:6: SwitchInt: switchInt(_28) -&gt; [false: bb35, otherwise: bb34]"><span class="annotation">31⦊</span>countdown &gt; 2<span class="annotation">⦉31</span></span><span class="code even" style="--layer: 4" title="bb34: ../instrument-coverage/coverage_of_if_else.rs:27:12: 34:6:
+    27:12-34:6: FalseEdge: falseEdge -&gt; [real: bb36, imaginary: bb35]"> {</span></span>
+<span class="line"><span class="code even" style="--layer: 4" title="bb34: ../instrument-coverage/coverage_of_if_else.rs:27:12: 34:6:
+    27:12-34:6: FalseEdge: falseEdge -&gt; [real: bb36, imaginary: bb35]">        </span><span class="code odd" style="--layer: 5" title="bb46: ../instrument-coverage/coverage_of_if_else.rs:28:9: 30:10:
+    28:9-30:10: Assign: _30 = const ()
+    28:9-30:10: Goto: goto -&gt; bb48"><span class="annotation">46⦊</span></span><span class="code even" style="--layer: 6" title="bb47: ../instrument-coverage/coverage_of_if_else.rs:28:9: 30:10:
     29:13-29:26: Assign: _21 = const 0_i32
     28:61-30:10: Assign: _30 = const ()
-    28:9-30:10: Goto: goto -&gt; bb51"><span class="annotation">50⦊</span></span><span class="code even" style="--layer: 12" title="bb49: ../instrument-coverage/coverage_of_if_else.rs:28:9: 30:10:
-    28:9-30:10: Assign: _30 = const ()
-    28:9-30:10: Goto: goto -&gt; bb51"><span class="annotation">49⦊</span>if </span><span class="code even" style="--layer: 13" title="bb39: ../instrument-coverage/coverage_of_if_else.rs:28:12: 28:60:
+    28:9-30:10: Goto: goto -&gt; bb48"><span class="annotation">47⦊</span></span><span class="code even" style="--layer: 7" title="bb45: ../instrument-coverage/coverage_of_if_else.rs:28:9: 30:10:
+    28:9-30:10: FalseEdge: falseEdge -&gt; [real: bb47, imaginary: bb46]"><span class="annotation">45⦊</span>if </span><span class="code even" style="--layer: 8" title="bb44: ../instrument-coverage/coverage_of_if_else.rs:28:12: 28:60:
+    28:41-28:42: StorageDead: StorageDead(_35)
+    28:41-28:42: StorageDead: StorageDead(_33)
+    28:12-28:60: SwitchInt: switchInt(move _32) -&gt; [false: bb39, otherwise: bb37]"><span class="annotation">44⦊</span></span><span class="code even" style="--layer: 9" title="bb38: ../instrument-coverage/coverage_of_if_else.rs:28:12: 28:60:
+    28:12-28:60: Assign: _31 = const false
+    28:12-28:60: Goto: goto -&gt; bb40"><span class="annotation">38⦊</span></span><span class="code even" style="--layer: 10" title="bb39: ../instrument-coverage/coverage_of_if_else.rs:28:12: 28:60:
+    28:46-28:60: StorageLive: StorageLive(_37)
+    28:46-28:55: StorageLive: StorageLive(_38)
+    28:46-28:55: Assign: _38 = _21
+    28:46-28:60: Assign: _37 = Ne(move _38, const 9_i32)
+    28:59-28:60: StorageDead: StorageDead(_38)
+    28:12-28:60: SwitchInt: switchInt(move _37) -&gt; [false: bb38, otherwise: bb37]"><span class="annotation">39⦊</span></span><span class="code even" style="--layer: 11" title="bb40: ../instrument-coverage/coverage_of_if_else.rs:28:12: 28:60:
+    28:59-28:60: StorageDead: StorageDead(_37)
+    28:59-28:60: StorageDead: StorageDead(_32)
+    28:12-28:60: FakeRead: FakeRead(ForMatchedPlace, _31)
+    28:9-30:10: SwitchInt: switchInt(_31) -&gt; [false: bb46, otherwise: bb45]"><span class="annotation">40⦊</span></span><span class="code even" style="--layer: 12" title="bb36: ../instrument-coverage/coverage_of_if_else.rs:28:12: 28:60:
     28:9-30:10: StorageLive: StorageLive(_30)
     28:12-28:60: StorageLive: StorageLive(_31)
     28:12-28:42: StorageLive: StorageLive(_32)
@@ -386,59 +352,25 @@
     28:12-28:21: Assign: _34 = _21
     28:12-28:25: Assign: _33 = Lt(move _34, const 1_i32)
     28:24-28:25: StorageDead: StorageDead(_34)
-    28:12-28:42: SwitchInt: switchInt(move _33) -&gt; [false: bb46, otherwise: bb44]"><span class="annotation">39⦊</span></span><span class="code even" style="--layer: 14" title="bb47: ../instrument-coverage/coverage_of_if_else.rs:28:12: 28:60:
-    28:41-28:42: StorageDead: StorageDead(_35)
-    28:41-28:42: StorageDead: StorageDead(_33)
-    28:12-28:60: SwitchInt: switchInt(move _32) -&gt; [false: bb42, otherwise: bb40]"><span class="annotation">47⦊</span></span><span class="code even" style="--layer: 15" title="bb40: ../instrument-coverage/coverage_of_if_else.rs:28:12: 28:60:
+    28:12-28:42: SwitchInt: switchInt(move _33) -&gt; [false: bb43, otherwise: bb41]"><span class="annotation">36⦊</span></span><span class="code even" style="--layer: 13" title="bb37: ../instrument-coverage/coverage_of_if_else.rs:28:12: 28:60:
     28:12-28:60: Assign: _31 = const true
-    28:12-28:60: Goto: goto -&gt; bb43"><span class="annotation">40⦊</span></span><span class="code even" style="--layer: 16" title="bb43: ../instrument-coverage/coverage_of_if_else.rs:28:12: 28:60:
-    28:59-28:60: StorageDead: StorageDead(_37)
-    28:59-28:60: StorageDead: StorageDead(_32)
-    28:12-28:60: FakeRead: FakeRead(ForMatchedPlace, _31)
-    28:9-30:10: SwitchInt: switchInt(_31) -&gt; [false: bb49, otherwise: bb48]"><span class="annotation">43⦊</span></span><span class="code even" style="--layer: 17" title="bb42: ../instrument-coverage/coverage_of_if_else.rs:28:12: 28:60:
-    28:46-28:60: StorageLive: StorageLive(_37)
-    28:46-28:55: StorageLive: StorageLive(_38)
-    28:46-28:55: Assign: _38 = _21
-    28:46-28:60: Assign: _37 = Ne(move _38, const 9_i32)
-    28:59-28:60: StorageDead: StorageDead(_38)
-    28:12-28:60: SwitchInt: switchInt(move _37) -&gt; [false: bb41, otherwise: bb40]"><span class="annotation">42⦊</span></span><span class="code even" style="--layer: 18" title="bb41: ../instrument-coverage/coverage_of_if_else.rs:28:12: 28:60:
-    28:12-28:60: Assign: _31 = const false
-    28:12-28:60: Goto: goto -&gt; bb43"><span class="annotation">41⦊</span></span><span class="code even" style="--layer: 19" title="bb46: ../instrument-coverage/coverage_of_if_else.rs:28:12: 28:42:
-    28:29-28:42: StorageLive: StorageLive(_35)
-    28:29-28:38: StorageLive: StorageLive(_36)
-    28:29-28:38: Assign: _36 = _21
-    28:29-28:42: Assign: _35 = Gt(move _36, const 5_i32)
-    28:41-28:42: StorageDead: StorageDead(_36)
-    28:12-28:42: SwitchInt: switchInt(move _35) -&gt; [false: bb45, otherwise: bb44]"><span class="annotation">46⦊</span></span><span class="code even" style="--layer: 20" title="bb45: ../instrument-coverage/coverage_of_if_else.rs:28:12: 28:42:
-    28:12-28:42: Assign: _32 = const false
-    28:12-28:42: Goto: goto -&gt; bb47"><span class="annotation">45⦊</span></span><span class="code even" style="--layer: 21" title="bb44: ../instrument-coverage/coverage_of_if_else.rs:28:12: 28:42:
+    28:12-28:60: Goto: goto -&gt; bb40"><span class="annotation">37⦊</span></span><span class="code even" style="--layer: 14" title="bb41: ../instrument-coverage/coverage_of_if_else.rs:28:12: 28:42:
     28:12-28:42: Assign: _32 = const true
-    28:12-28:42: Goto: goto -&gt; bb47"><span class="annotation">44⦊</span>countdown &lt; 1 || countdown &gt; 5<span class="annotation">⦉44</span></span><span class="code even" style="--layer: 20" title="bb45: ../instrument-coverage/coverage_of_if_else.rs:28:12: 28:42:
+    28:12-28:42: Goto: goto -&gt; bb44"><span class="annotation">41⦊</span></span><span class="code even" style="--layer: 15" title="bb42: ../instrument-coverage/coverage_of_if_else.rs:28:12: 28:42:
     28:12-28:42: Assign: _32 = const false
-    28:12-28:42: Goto: goto -&gt; bb47"><span class="annotation">⦉45</span></span><span class="code even" style="--layer: 19" title="bb46: ../instrument-coverage/coverage_of_if_else.rs:28:12: 28:42:
+    28:12-28:42: Goto: goto -&gt; bb44"><span class="annotation">42⦊</span></span><span class="code even" style="--layer: 16" title="bb43: ../instrument-coverage/coverage_of_if_else.rs:28:12: 28:42:
     28:29-28:42: StorageLive: StorageLive(_35)
     28:29-28:38: StorageLive: StorageLive(_36)
     28:29-28:38: Assign: _36 = _21
     28:29-28:42: Assign: _35 = Gt(move _36, const 5_i32)
     28:41-28:42: StorageDead: StorageDead(_36)
-    28:12-28:42: SwitchInt: switchInt(move _35) -&gt; [false: bb45, otherwise: bb44]"><span class="annotation">⦉46</span></span><span class="code even" style="--layer: 18" title="bb41: ../instrument-coverage/coverage_of_if_else.rs:28:12: 28:60:
-    28:12-28:60: Assign: _31 = const false
-    28:12-28:60: Goto: goto -&gt; bb43"> || countdown != 9<span class="annotation">⦉41</span></span><span class="code even" style="--layer: 17" title="bb42: ../instrument-coverage/coverage_of_if_else.rs:28:12: 28:60:
-    28:46-28:60: StorageLive: StorageLive(_37)
-    28:46-28:55: StorageLive: StorageLive(_38)
-    28:46-28:55: Assign: _38 = _21
-    28:46-28:60: Assign: _37 = Ne(move _38, const 9_i32)
-    28:59-28:60: StorageDead: StorageDead(_38)
-    28:12-28:60: SwitchInt: switchInt(move _37) -&gt; [false: bb41, otherwise: bb40]"><span class="annotation">⦉42</span></span><span class="code even" style="--layer: 16" title="bb43: ../instrument-coverage/coverage_of_if_else.rs:28:12: 28:60:
-    28:59-28:60: StorageDead: StorageDead(_37)
-    28:59-28:60: StorageDead: StorageDead(_32)
-    28:12-28:60: FakeRead: FakeRead(ForMatchedPlace, _31)
-    28:9-30:10: SwitchInt: switchInt(_31) -&gt; [false: bb49, otherwise: bb48]"><span class="annotation">⦉43</span></span><span class="code even" style="--layer: 15" title="bb40: ../instrument-coverage/coverage_of_if_else.rs:28:12: 28:60:
+    28:12-28:42: SwitchInt: switchInt(move _35) -&gt; [false: bb42, otherwise: bb41]"><span class="annotation">43⦊</span>countdown &lt; 1 || countdown &gt; 5<span class="annotation">⦉43</span></span><span class="code even" style="--layer: 15" title="bb42: ../instrument-coverage/coverage_of_if_else.rs:28:12: 28:42:
+    28:12-28:42: Assign: _32 = const false
+    28:12-28:42: Goto: goto -&gt; bb44"><span class="annotation">⦉42</span></span><span class="code even" style="--layer: 14" title="bb41: ../instrument-coverage/coverage_of_if_else.rs:28:12: 28:42:
+    28:12-28:42: Assign: _32 = const true
+    28:12-28:42: Goto: goto -&gt; bb44"><span class="annotation">⦉41</span></span><span class="code even" style="--layer: 13" title="bb37: ../instrument-coverage/coverage_of_if_else.rs:28:12: 28:60:
     28:12-28:60: Assign: _31 = const true
-    28:12-28:60: Goto: goto -&gt; bb43"><span class="annotation">⦉40</span></span><span class="code even" style="--layer: 14" title="bb47: ../instrument-coverage/coverage_of_if_else.rs:28:12: 28:60:
-    28:41-28:42: StorageDead: StorageDead(_35)
-    28:41-28:42: StorageDead: StorageDead(_33)
-    28:12-28:60: SwitchInt: switchInt(move _32) -&gt; [false: bb42, otherwise: bb40]"><span class="annotation">⦉47</span></span><span class="code even" style="--layer: 13" title="bb39: ../instrument-coverage/coverage_of_if_else.rs:28:12: 28:60:
+    28:12-28:60: Goto: goto -&gt; bb40"> || countdown != 9<span class="annotation">⦉37</span></span><span class="code even" style="--layer: 12" title="bb36: ../instrument-coverage/coverage_of_if_else.rs:28:12: 28:60:
     28:9-30:10: StorageLive: StorageLive(_30)
     28:12-28:60: StorageLive: StorageLive(_31)
     28:12-28:42: StorageLive: StorageLive(_32)
@@ -447,104 +379,71 @@
     28:12-28:21: Assign: _34 = _21
     28:12-28:25: Assign: _33 = Lt(move _34, const 1_i32)
     28:24-28:25: StorageDead: StorageDead(_34)
-    28:12-28:42: SwitchInt: switchInt(move _33) -&gt; [false: bb46, otherwise: bb44]"><span class="annotation">⦉39</span></span><span class="code even" style="--layer: 12" title="bb49: ../instrument-coverage/coverage_of_if_else.rs:28:9: 30:10:
-    28:9-30:10: Assign: _30 = const ()
-    28:9-30:10: Goto: goto -&gt; bb51"> {</span></span>
-<span class="line"><span class="code even" style="--layer: 12" title="bb49: ../instrument-coverage/coverage_of_if_else.rs:28:9: 30:10:
-    28:9-30:10: Assign: _30 = const ()
-    28:9-30:10: Goto: goto -&gt; bb51">            countdown = 0;</span></span>
-<span class="line"><span class="code even" style="--layer: 12" title="bb49: ../instrument-coverage/coverage_of_if_else.rs:28:9: 30:10:
-    28:9-30:10: Assign: _30 = const ()
-    28:9-30:10: Goto: goto -&gt; bb51">        </span><span class="code odd" style="--layer: 13" title="bb51: ../instrument-coverage/coverage_of_if_else.rs:30:9: 31:23:
+    28:12-28:42: SwitchInt: switchInt(move _33) -&gt; [false: bb43, otherwise: bb41]"><span class="annotation">⦉36</span></span><span class="code even" style="--layer: 11" title="bb40: ../instrument-coverage/coverage_of_if_else.rs:28:12: 28:60:
+    28:59-28:60: StorageDead: StorageDead(_37)
+    28:59-28:60: StorageDead: StorageDead(_32)
+    28:12-28:60: FakeRead: FakeRead(ForMatchedPlace, _31)
+    28:9-30:10: SwitchInt: switchInt(_31) -&gt; [false: bb46, otherwise: bb45]"><span class="annotation">⦉40</span></span><span class="code even" style="--layer: 10" title="bb39: ../instrument-coverage/coverage_of_if_else.rs:28:12: 28:60:
+    28:46-28:60: StorageLive: StorageLive(_37)
+    28:46-28:55: StorageLive: StorageLive(_38)
+    28:46-28:55: Assign: _38 = _21
+    28:46-28:60: Assign: _37 = Ne(move _38, const 9_i32)
+    28:59-28:60: StorageDead: StorageDead(_38)
+    28:12-28:60: SwitchInt: switchInt(move _37) -&gt; [false: bb38, otherwise: bb37]"><span class="annotation">⦉39</span></span><span class="code even" style="--layer: 9" title="bb38: ../instrument-coverage/coverage_of_if_else.rs:28:12: 28:60:
+    28:12-28:60: Assign: _31 = const false
+    28:12-28:60: Goto: goto -&gt; bb40"><span class="annotation">⦉38</span></span><span class="code even" style="--layer: 8" title="bb44: ../instrument-coverage/coverage_of_if_else.rs:28:12: 28:60:
+    28:41-28:42: StorageDead: StorageDead(_35)
+    28:41-28:42: StorageDead: StorageDead(_33)
+    28:12-28:60: SwitchInt: switchInt(move _32) -&gt; [false: bb39, otherwise: bb37]"><span class="annotation">⦉44</span></span><span class="code even" style="--layer: 7" title="bb45: ../instrument-coverage/coverage_of_if_else.rs:28:9: 30:10:
+    28:9-30:10: FalseEdge: falseEdge -&gt; [real: bb47, imaginary: bb46]"> {</span></span>
+<span class="line"><span class="code even" style="--layer: 7" title="bb45: ../instrument-coverage/coverage_of_if_else.rs:28:9: 30:10:
+    28:9-30:10: FalseEdge: falseEdge -&gt; [real: bb47, imaginary: bb46]">            countdown = 0;</span></span>
+<span class="line"><span class="code even" style="--layer: 7" title="bb45: ../instrument-coverage/coverage_of_if_else.rs:28:9: 30:10:
+    28:9-30:10: FalseEdge: falseEdge -&gt; [real: bb47, imaginary: bb46]">        </span><span class="code odd" style="--layer: 8" title="bb48: ../instrument-coverage/coverage_of_if_else.rs:30:9: 31:23:
     30:9-30:10: StorageDead: StorageDead(_31)
     30:9-30:10: StorageDead: StorageDead(_30)
     31:9-31:23: Assign: _39 = CheckedSub(_21, const 5_i32)
-    31:9-31:23: Assert: assert(!move (_39.1: bool), &quot;attempt to compute `{} - {}`, which would overflow&quot;, _21, const 5_i32) -&gt; [success: bb52, unwind: bb1]"><span class="annotation">51⦊</span>}</span><span class="code odd" style="--layer: 10" title="bb48: ../instrument-coverage/coverage_of_if_else.rs:28:9: 30:10:
-    28:9-30:10: FalseEdge: falseEdge -&gt; [real: bb50, imaginary: bb49]"><span class="annotation">⦉48</span></span><span class="code even" style="--layer: 11" title="bb50: ../instrument-coverage/coverage_of_if_else.rs:28:9: 30:10:
+    31:9-31:23: Assert: assert(!move (_39.1: bool), &quot;attempt to compute `{} - {}`, which would overflow&quot;, _21, const 5_i32) -&gt; [success: bb49, unwind: bb78]"><span class="annotation">48⦊</span>}</span><span class="code odd" style="--layer: 5" title="bb46: ../instrument-coverage/coverage_of_if_else.rs:28:9: 30:10:
+    28:9-30:10: Assign: _30 = const ()
+    28:9-30:10: Goto: goto -&gt; bb48"><span class="annotation">⦉46</span></span><span class="code even" style="--layer: 6" title="bb47: ../instrument-coverage/coverage_of_if_else.rs:28:9: 30:10:
     29:13-29:26: Assign: _21 = const 0_i32
     28:61-30:10: Assign: _30 = const ()
-    28:9-30:10: Goto: goto -&gt; bb51"><span class="annotation">⦉50</span></span><span class="code even" style="--layer: 12" title="bb49: ../instrument-coverage/coverage_of_if_else.rs:28:9: 30:10:
-    28:9-30:10: Assign: _30 = const ()
-    28:9-30:10: Goto: goto -&gt; bb51"><span class="annotation">⦉49</span></span><span class="code even" style="--layer: 12" title="bb49: ../instrument-coverage/coverage_of_if_else.rs:28:9: 30:10:
-    28:9-30:10: Assign: _30 = const ()
-    28:9-30:10: Goto: goto -&gt; bb51"><span class="annotation">⦉49</span></span><span class="code odd" style="--layer: 13" title="bb51: ../instrument-coverage/coverage_of_if_else.rs:30:9: 31:23:
+    28:9-30:10: Goto: goto -&gt; bb48"><span class="annotation">⦉47</span></span><span class="code even" style="--layer: 7" title="bb45: ../instrument-coverage/coverage_of_if_else.rs:28:9: 30:10:
+    28:9-30:10: FalseEdge: falseEdge -&gt; [real: bb47, imaginary: bb46]"><span class="annotation">⦉45</span></span><span class="code even" style="--layer: 7" title="bb45: ../instrument-coverage/coverage_of_if_else.rs:28:9: 30:10:
+    28:9-30:10: FalseEdge: falseEdge -&gt; [real: bb47, imaginary: bb46]"><span class="annotation">⦉45</span></span><span class="code odd" style="--layer: 8" title="bb48: ../instrument-coverage/coverage_of_if_else.rs:30:9: 31:23:
     30:9-30:10: StorageDead: StorageDead(_31)
     30:9-30:10: StorageDead: StorageDead(_30)
     31:9-31:23: Assign: _39 = CheckedSub(_21, const 5_i32)
-    31:9-31:23: Assert: assert(!move (_39.1: bool), &quot;attempt to compute `{} - {}`, which would overflow&quot;, _21, const 5_i32) -&gt; [success: bb52, unwind: bb1]"></span></span>
-<span class="line"><span class="code odd" style="--layer: 13" title="bb51: ../instrument-coverage/coverage_of_if_else.rs:30:9: 31:23:
+    31:9-31:23: Assert: assert(!move (_39.1: bool), &quot;attempt to compute `{} - {}`, which would overflow&quot;, _21, const 5_i32) -&gt; [success: bb49, unwind: bb78]"></span></span>
+<span class="line"><span class="code odd" style="--layer: 8" title="bb48: ../instrument-coverage/coverage_of_if_else.rs:30:9: 31:23:
     30:9-30:10: StorageDead: StorageDead(_31)
     30:9-30:10: StorageDead: StorageDead(_30)
     31:9-31:23: Assign: _39 = CheckedSub(_21, const 5_i32)
-    31:9-31:23: Assert: assert(!move (_39.1: bool), &quot;attempt to compute `{} - {}`, which would overflow&quot;, _21, const 5_i32) -&gt; [success: bb52, unwind: bb1]">        countdown -= 5<span class="annotation">⦉51</span></span><span class="code even" style="--layer: 9" title="bb37: ../instrument-coverage/coverage_of_if_else.rs:27:12: 34:6:
-    27:12-34:6: FalseEdge: falseEdge -&gt; [real: bb39, imaginary: bb38]">;</span></span>
-<span class="line"><span class="code even" style="--layer: 9" title="bb37: ../instrument-coverage/coverage_of_if_else.rs:27:12: 34:6:
-    27:12-34:6: FalseEdge: falseEdge -&gt; [real: bb39, imaginary: bb38]">    } else {</span></span>
-<span class="line"><span class="code even" style="--layer: 9" title="bb37: ../instrument-coverage/coverage_of_if_else.rs:27:12: 34:6:
-    27:12-34:6: FalseEdge: falseEdge -&gt; [real: bb39, imaginary: bb38]">        </span><span class="code even" style="--layer: 10" title="bb38: ../instrument-coverage/coverage_of_if_else.rs:33:9: 51:2:
-    33:9-33:15: Assign: _0 = const ()
-    34:5-34:6: StorageDead: StorageDead(_28)
-    34:5-34:6: StorageDead: StorageDead(_25)
-    34:5-34:6: StorageDead: StorageDead(_24)
-    51:1-51:2: StorageDead: StorageDead(_21)
-    33:9-33:15: Goto: goto -&gt; bb27"><span class="annotation">38⦊</span>return;</span></span>
-<span class="line"><span class="code even" style="--layer: 10" title="bb38: ../instrument-coverage/coverage_of_if_else.rs:33:9: 51:2:
-    33:9-33:15: Assign: _0 = const ()
-    34:5-34:6: StorageDead: StorageDead(_28)
-    34:5-34:6: StorageDead: StorageDead(_25)
-    34:5-34:6: StorageDead: StorageDead(_24)
-    51:1-51:2: StorageDead: StorageDead(_21)
-    33:9-33:15: Goto: goto -&gt; bb27">    }</span><span class="code even" style="--layer: 6" title="bb33: ../instrument-coverage/coverage_of_if_else.rs:25:5: 34:6:
-    25:5-34:6: FalseEdge: falseEdge -&gt; [real: bb35, imaginary: bb34]"><span class="annotation">⦉33</span></span><span class="code even" style="--layer: 7" title="bb52: ../instrument-coverage/coverage_of_if_else.rs:25:5: 34:6:
+    31:9-31:23: Assert: assert(!move (_39.1: bool), &quot;attempt to compute `{} - {}`, which would overflow&quot;, _21, const 5_i32) -&gt; [success: bb49, unwind: bb78]">        countdown -= 5<span class="annotation">⦉48</span></span><span class="code even" style="--layer: 4" title="bb34: ../instrument-coverage/coverage_of_if_else.rs:27:12: 34:6:
+    27:12-34:6: FalseEdge: falseEdge -&gt; [real: bb36, imaginary: bb35]">;</span></span>
+<span class="line"><span class="code even" style="--layer: 4" title="bb34: ../instrument-coverage/coverage_of_if_else.rs:27:12: 34:6:
+    27:12-34:6: FalseEdge: falseEdge -&gt; [real: bb36, imaginary: bb35]">    } else {</span></span>
+<span class="line"><span class="code even" style="--layer: 4" title="bb34: ../instrument-coverage/coverage_of_if_else.rs:27:12: 34:6:
+    27:12-34:6: FalseEdge: falseEdge -&gt; [real: bb36, imaginary: bb35]">        return;</span></span>
+<span class="line"><span class="code even" style="--layer: 4" title="bb34: ../instrument-coverage/coverage_of_if_else.rs:27:12: 34:6:
+    27:12-34:6: FalseEdge: falseEdge -&gt; [real: bb36, imaginary: bb35]">    }<span class="annotation">⦉34</span></span><span class="code even" style="--layer: 3" title="bb30: ../instrument-coverage/coverage_of_if_else.rs:25:5: 34:6:
+    25:5-34:6: FalseEdge: falseEdge -&gt; [real: bb32, imaginary: bb31]"><span class="annotation">⦉30</span></span><span class="code even" style="--layer: 2" title="bb33: ../instrument-coverage/coverage_of_if_else.rs:25:5: 34:6:
+    26:9-26:23: Assign: _21 = move (_27.0: i32)
+    25:22-27:6: Assign: _24 = const ()
+    25:5-34:6: Goto: goto -&gt; bb50"><span class="annotation">⦉33</span></span><span><span class="code odd" style="--layer: 1" title="bb49: ../instrument-coverage/coverage_of_if_else.rs:25:5: 34:6:
     31:9-31:23: Assign: _21 = move (_39.0: i32)
     27:29-32:6: Assign: _24 = const ()
     34:5-34:6: StorageDead: StorageDead(_28)
-    25:5-34:6: Goto: goto -&gt; bb53"><span class="annotation">⦉52</span></span><span class="code even" style="--layer: 8" title="bb36: ../instrument-coverage/coverage_of_if_else.rs:25:5: 34:6:
-    26:9-26:23: Assign: _21 = move (_27.0: i32)
-    25:22-27:6: Assign: _24 = const ()
-    25:5-34:6: Goto: goto -&gt; bb53"><span class="annotation">⦉36</span></span><span class="code even" style="--layer: 8" title="bb36: ../instrument-coverage/coverage_of_if_else.rs:25:5: 34:6:
-    26:9-26:23: Assign: _21 = move (_27.0: i32)
-    25:22-27:6: Assign: _24 = const ()
-    25:5-34:6: Goto: goto -&gt; bb53"><span class="annotation">⦉36</span></span><span class="code even" style="--layer: 8" title="bb36: ../instrument-coverage/coverage_of_if_else.rs:25:5: 34:6:
-    26:9-26:23: Assign: _21 = move (_27.0: i32)
-    25:22-27:6: Assign: _24 = const ()
-    25:5-34:6: Goto: goto -&gt; bb53"><span class="annotation">⦉36</span></span><span class="code even" style="--layer: 9" title="bb37: ../instrument-coverage/coverage_of_if_else.rs:27:12: 34:6:
-    27:12-34:6: FalseEdge: falseEdge -&gt; [real: bb39, imaginary: bb38]"><span class="annotation">⦉37</span></span><span class="code even" style="--layer: 9" title="bb37: ../instrument-coverage/coverage_of_if_else.rs:27:12: 34:6:
-    27:12-34:6: FalseEdge: falseEdge -&gt; [real: bb39, imaginary: bb38]"><span class="annotation">⦉37</span></span><span class="code even" style="--layer: 9" title="bb37: ../instrument-coverage/coverage_of_if_else.rs:27:12: 34:6:
-    27:12-34:6: FalseEdge: falseEdge -&gt; [real: bb39, imaginary: bb38]"><span class="annotation">⦉37</span></span><span class="code even" style="--layer: 10" title="bb38: ../instrument-coverage/coverage_of_if_else.rs:33:9: 51:2:
-    33:9-33:15: Assign: _0 = const ()
-    34:5-34:6: StorageDead: StorageDead(_28)
-    34:5-34:6: StorageDead: StorageDead(_25)
-    34:5-34:6: StorageDead: StorageDead(_24)
-    51:1-51:2: StorageDead: StorageDead(_21)
-    33:9-33:15: Goto: goto -&gt; bb27"></span></span>
-<span class="line"><span class="code even" style="--layer: 10" title="bb38: ../instrument-coverage/coverage_of_if_else.rs:33:9: 51:2:
-    33:9-33:15: Assign: _0 = const ()
-    34:5-34:6: StorageDead: StorageDead(_28)
-    34:5-34:6: StorageDead: StorageDead(_25)
-    34:5-34:6: StorageDead: StorageDead(_24)
-    51:1-51:2: StorageDead: StorageDead(_21)
-    33:9-33:15: Goto: goto -&gt; bb27"></span></span>
-<span class="line"><span class="code even" style="--layer: 10" title="bb38: ../instrument-coverage/coverage_of_if_else.rs:33:9: 51:2:
-    33:9-33:15: Assign: _0 = const ()
-    34:5-34:6: StorageDead: StorageDead(_28)
-    34:5-34:6: StorageDead: StorageDead(_25)
-    34:5-34:6: StorageDead: StorageDead(_24)
-    51:1-51:2: StorageDead: StorageDead(_21)
-    33:9-33:15: Goto: goto -&gt; bb27">    let mut countdown = 0;</span></span>
-<span class="line"><span class="code even" style="--layer: 10" title="bb38: ../instrument-coverage/coverage_of_if_else.rs:33:9: 51:2:
-    33:9-33:15: Assign: _0 = const ()
-    34:5-34:6: StorageDead: StorageDead(_28)
-    34:5-34:6: StorageDead: StorageDead(_25)
-    34:5-34:6: StorageDead: StorageDead(_24)
-    51:1-51:2: StorageDead: StorageDead(_21)
-    33:9-33:15: Goto: goto -&gt; bb27">    </span><span class="code even" style="--layer: 11" title="bb56: ../instrument-coverage/coverage_of_if_else.rs:37:5: 39:6:
+    25:5-34:6: Goto: goto -&gt; bb50"><span class="annotation">⦉49</span></span></span><span class="code" style="--layer: 0"></span></span>
+<span class="line"><span class="code" style="--layer: 0"></span></span>
+<span class="line"><span class="code" style="--layer: 0">    let mut countdown = 0;</span></span>
+<span class="line"><span class="code" style="--layer: 0">    </span><span><span class="code even" style="--layer: 1" title="bb52: ../instrument-coverage/coverage_of_if_else.rs:37:5: 39:6:
+    37:5-39:6: Assign: _42 = const ()
+    37:5-39:6: Goto: goto -&gt; bb54"><span class="annotation">52⦊</span></span></span><span class="code even" style="--layer: 2" title="bb51: ../instrument-coverage/coverage_of_if_else.rs:37:5: 39:6:
+    37:5-39:6: FalseEdge: falseEdge -&gt; [real: bb53, imaginary: bb52]"><span class="annotation">51⦊</span></span><span class="code even" style="--layer: 3" title="bb53: ../instrument-coverage/coverage_of_if_else.rs:37:5: 39:6:
     38:9-38:23: Assign: _41 = const 10_i32
     37:13-39:6: Assign: _42 = const ()
-    37:5-39:6: Goto: goto -&gt; bb57"><span class="annotation">56⦊</span></span><span class="code even" style="--layer: 12" title="bb54: ../instrument-coverage/coverage_of_if_else.rs:37:5: 39:6:
-    37:5-39:6: FalseEdge: falseEdge -&gt; [real: bb56, imaginary: bb55]"><span class="annotation">54⦊</span></span><span class="code even" style="--layer: 13" title="bb55: ../instrument-coverage/coverage_of_if_else.rs:37:5: 39:6:
-    37:5-39:6: Assign: _42 = const ()
-    37:5-39:6: Goto: goto -&gt; bb57"><span class="annotation">55⦊</span>if </span><span class="code even" style="--layer: 14" title="bb53: ../instrument-coverage/coverage_of_if_else.rs:37:8: 37:12:
+    37:5-39:6: Goto: goto -&gt; bb54"><span class="annotation">53⦊</span>if </span><span class="code even" style="--layer: 4" title="bb50: ../instrument-coverage/coverage_of_if_else.rs:37:8: 37:12:
     34:5-34:6: StorageDead: StorageDead(_25)
     34:5-34:6: StorageDead: StorageDead(_24)
     36:9-36:22: StorageLive: StorageLive(_41)
@@ -554,47 +453,31 @@
     37:8-37:12: StorageLive: StorageLive(_43)
     37:8-37:12: Assign: _43 = const true
     37:8-37:12: FakeRead: FakeRead(ForMatchedPlace, _43)
-    37:5-39:6: SwitchInt: switchInt(_43) -&gt; [false: bb55, otherwise: bb54]"><span class="annotation">53⦊</span>true<span class="annotation">⦉53</span></span><span class="code even" style="--layer: 13" title="bb55: ../instrument-coverage/coverage_of_if_else.rs:37:5: 39:6:
-    37:5-39:6: Assign: _42 = const ()
-    37:5-39:6: Goto: goto -&gt; bb57"> {</span></span>
-<span class="line"><span class="code even" style="--layer: 13" title="bb55: ../instrument-coverage/coverage_of_if_else.rs:37:5: 39:6:
-    37:5-39:6: Assign: _42 = const ()
-    37:5-39:6: Goto: goto -&gt; bb57">        countdown = 10;</span></span>
-<span class="line"><span class="code even" style="--layer: 13" title="bb55: ../instrument-coverage/coverage_of_if_else.rs:37:5: 39:6:
-    37:5-39:6: Assign: _42 = const ()
-    37:5-39:6: Goto: goto -&gt; bb57">    }<span class="annotation">⦉55</span></span><span class="code even" style="--layer: 12" title="bb54: ../instrument-coverage/coverage_of_if_else.rs:37:5: 39:6:
-    37:5-39:6: FalseEdge: falseEdge -&gt; [real: bb56, imaginary: bb55]"><span class="annotation">⦉54</span></span><span class="code even" style="--layer: 11" title="bb56: ../instrument-coverage/coverage_of_if_else.rs:37:5: 39:6:
+    37:5-39:6: SwitchInt: switchInt(_43) -&gt; [false: bb52, otherwise: bb51]"><span class="annotation">50⦊</span>true<span class="annotation">⦉50</span></span><span class="code even" style="--layer: 3" title="bb53: ../instrument-coverage/coverage_of_if_else.rs:37:5: 39:6:
     38:9-38:23: Assign: _41 = const 10_i32
     37:13-39:6: Assign: _42 = const ()
-    37:5-39:6: Goto: goto -&gt; bb57"><span class="annotation">⦉56</span></span><span class="code even" style="--layer: 10" title="bb38: ../instrument-coverage/coverage_of_if_else.rs:33:9: 51:2:
-    33:9-33:15: Assign: _0 = const ()
-    34:5-34:6: StorageDead: StorageDead(_28)
-    34:5-34:6: StorageDead: StorageDead(_25)
-    34:5-34:6: StorageDead: StorageDead(_24)
-    51:1-51:2: StorageDead: StorageDead(_21)
-    33:9-33:15: Goto: goto -&gt; bb27"></span></span>
-<span class="line"><span class="code even" style="--layer: 10" title="bb38: ../instrument-coverage/coverage_of_if_else.rs:33:9: 51:2:
-    33:9-33:15: Assign: _0 = const ()
-    34:5-34:6: StorageDead: StorageDead(_28)
-    34:5-34:6: StorageDead: StorageDead(_25)
-    34:5-34:6: StorageDead: StorageDead(_24)
-    51:1-51:2: StorageDead: StorageDead(_21)
-    33:9-33:15: Goto: goto -&gt; bb27"></span></span>
-<span class="line"><span class="code even" style="--layer: 10" title="bb38: ../instrument-coverage/coverage_of_if_else.rs:33:9: 51:2:
-    33:9-33:15: Assign: _0 = const ()
-    34:5-34:6: StorageDead: StorageDead(_28)
-    34:5-34:6: StorageDead: StorageDead(_25)
-    34:5-34:6: StorageDead: StorageDead(_24)
-    51:1-51:2: StorageDead: StorageDead(_21)
-    33:9-33:15: Goto: goto -&gt; bb27">    </span><span class="code odd" style="--layer: 11" title="bb61: ../instrument-coverage/coverage_of_if_else.rs:41:5: 50:6:
-    42:9-42:23: Assign: _41 = move (_46.0: i32)
-    41:22-43:6: Assign: _0 = const ()
-    41:5-50:6: Goto: goto -&gt; bb78"><span class="annotation">61⦊</span></span><span class="code even" style="--layer: 12" title="bb58: ../instrument-coverage/coverage_of_if_else.rs:41:5: 50:6:
-    41:5-50:6: FalseEdge: falseEdge -&gt; [real: bb60, imaginary: bb59]"><span class="annotation">58⦊</span></span><span class="code even" style="--layer: 13" title="bb77: ../instrument-coverage/coverage_of_if_else.rs:41:5: 50:6:
+    37:5-39:6: Goto: goto -&gt; bb54"> {</span></span>
+<span class="line"><span class="code even" style="--layer: 3" title="bb53: ../instrument-coverage/coverage_of_if_else.rs:37:5: 39:6:
+    38:9-38:23: Assign: _41 = const 10_i32
+    37:13-39:6: Assign: _42 = const ()
+    37:5-39:6: Goto: goto -&gt; bb54">        countdown = 10;</span></span>
+<span class="line"><span class="code even" style="--layer: 3" title="bb53: ../instrument-coverage/coverage_of_if_else.rs:37:5: 39:6:
+    38:9-38:23: Assign: _41 = const 10_i32
+    37:13-39:6: Assign: _42 = const ()
+    37:5-39:6: Goto: goto -&gt; bb54">    }<span class="annotation">⦉53</span></span><span class="code even" style="--layer: 2" title="bb51: ../instrument-coverage/coverage_of_if_else.rs:37:5: 39:6:
+    37:5-39:6: FalseEdge: falseEdge -&gt; [real: bb53, imaginary: bb52]"><span class="annotation">⦉51</span></span><span><span class="code even" style="--layer: 1" title="bb52: ../instrument-coverage/coverage_of_if_else.rs:37:5: 39:6:
+    37:5-39:6: Assign: _42 = const ()
+    37:5-39:6: Goto: goto -&gt; bb54"><span class="annotation">⦉52</span></span></span><span class="code" style="--layer: 0"></span></span>
+<span class="line"><span class="code" style="--layer: 0"></span></span>
+<span class="line"><span class="code" style="--layer: 0">    </span><span><span class="code odd" style="--layer: 1" title="bb74: ../instrument-coverage/coverage_of_if_else.rs:41:5: 50:6:
     47:9-47:23: Assign: _41 = move (_58.0: i32)
     43:29-48:6: Assign: _0 = const ()
     50:5-50:6: StorageDead: StorageDead(_47)
-    41:5-50:6: Goto: goto -&gt; bb78"><span class="annotation">77⦊</span>if </span><span class="code even" style="--layer: 14" title="bb57: ../instrument-coverage/coverage_of_if_else.rs:41:8: 41:21:
+    41:5-50:6: Goto: goto -&gt; bb75"><span class="annotation">74⦊</span></span></span><span class="code even" style="--layer: 2" title="bb55: ../instrument-coverage/coverage_of_if_else.rs:41:5: 50:6:
+    41:5-50:6: FalseEdge: falseEdge -&gt; [real: bb57, imaginary: bb56]"><span class="annotation">55⦊</span></span><span class="code even" style="--layer: 3" title="bb58: ../instrument-coverage/coverage_of_if_else.rs:41:5: 50:6:
+    42:9-42:23: Assign: _41 = move (_46.0: i32)
+    41:22-43:6: Assign: _0 = const ()
+    41:5-50:6: Goto: goto -&gt; bb75"><span class="annotation">58⦊</span>if </span><span class="code even" style="--layer: 4" title="bb54: ../instrument-coverage/coverage_of_if_else.rs:41:8: 41:21:
     39:5-39:6: StorageDead: StorageDead(_43)
     39:5-39:6: StorageDead: StorageDead(_42)
     41:8-41:21: StorageLive: StorageLive(_44)
@@ -603,59 +486,57 @@
     41:8-41:21: Assign: _44 = Gt(move _45, const 7_i32)
     41:20-41:21: StorageDead: StorageDead(_45)
     41:8-41:21: FakeRead: FakeRead(ForMatchedPlace, _44)
-    41:5-50:6: SwitchInt: switchInt(_44) -&gt; [false: bb59, otherwise: bb58]"><span class="annotation">57⦊</span>countdown &gt; 7<span class="annotation">⦉57</span></span><span class="code even" style="--layer: 13" title="bb77: ../instrument-coverage/coverage_of_if_else.rs:41:5: 50:6:
-    47:9-47:23: Assign: _41 = move (_58.0: i32)
-    43:29-48:6: Assign: _0 = const ()
-    50:5-50:6: StorageDead: StorageDead(_47)
-    41:5-50:6: Goto: goto -&gt; bb78"> {</span></span>
-<span class="line"><span class="code even" style="--layer: 13" title="bb77: ../instrument-coverage/coverage_of_if_else.rs:41:5: 50:6:
-    47:9-47:23: Assign: _41 = move (_58.0: i32)
-    43:29-48:6: Assign: _0 = const ()
-    50:5-50:6: StorageDead: StorageDead(_47)
-    41:5-50:6: Goto: goto -&gt; bb78">        </span><span class="code odd" style="--layer: 14" title="bb60: ../instrument-coverage/coverage_of_if_else.rs:42:9: 42:23:
+    41:5-50:6: SwitchInt: switchInt(_44) -&gt; [false: bb56, otherwise: bb55]"><span class="annotation">54⦊</span>countdown &gt; 7<span class="annotation">⦉54</span></span><span class="code even" style="--layer: 3" title="bb58: ../instrument-coverage/coverage_of_if_else.rs:41:5: 50:6:
+    42:9-42:23: Assign: _41 = move (_46.0: i32)
+    41:22-43:6: Assign: _0 = const ()
+    41:5-50:6: Goto: goto -&gt; bb75"> {</span></span>
+<span class="line"><span class="code even" style="--layer: 3" title="bb58: ../instrument-coverage/coverage_of_if_else.rs:41:5: 50:6:
+    42:9-42:23: Assign: _41 = move (_46.0: i32)
+    41:22-43:6: Assign: _0 = const ()
+    41:5-50:6: Goto: goto -&gt; bb75">        </span><span class="code odd" style="--layer: 4" title="bb57: ../instrument-coverage/coverage_of_if_else.rs:42:9: 42:23:
     42:9-42:23: Assign: _46 = CheckedSub(_41, const 4_i32)
-    42:9-42:23: Assert: assert(!move (_46.1: bool), &quot;attempt to compute `{} - {}`, which would overflow&quot;, _41, const 4_i32) -&gt; [success: bb61, unwind: bb1]"><span class="annotation">60⦊</span>countdown -= 4<span class="annotation">⦉60</span></span><span class="code even" style="--layer: 13" title="bb77: ../instrument-coverage/coverage_of_if_else.rs:41:5: 50:6:
-    47:9-47:23: Assign: _41 = move (_58.0: i32)
-    43:29-48:6: Assign: _0 = const ()
-    50:5-50:6: StorageDead: StorageDead(_47)
-    41:5-50:6: Goto: goto -&gt; bb78">;</span></span>
-<span class="line"><span class="code even" style="--layer: 13" title="bb77: ../instrument-coverage/coverage_of_if_else.rs:41:5: 50:6:
-    47:9-47:23: Assign: _41 = move (_58.0: i32)
-    43:29-48:6: Assign: _0 = const ()
-    50:5-50:6: StorageDead: StorageDead(_47)
-    41:5-50:6: Goto: goto -&gt; bb78">    } else </span><span class="code even" style="--layer: 14" title="bb62: ../instrument-coverage/coverage_of_if_else.rs:43:12: 50:6:
-    43:12-50:6: FalseEdge: falseEdge -&gt; [real: bb64, imaginary: bb63]"><span class="annotation">62⦊</span>if </span><span class="code even" style="--layer: 15" title="bb59: ../instrument-coverage/coverage_of_if_else.rs:43:15: 43:28:
+    42:9-42:23: Assert: assert(!move (_46.1: bool), &quot;attempt to compute `{} - {}`, which would overflow&quot;, _41, const 4_i32) -&gt; [success: bb58, unwind: bb78]"><span class="annotation">57⦊</span>countdown -= 4<span class="annotation">⦉57</span></span><span class="code even" style="--layer: 3" title="bb58: ../instrument-coverage/coverage_of_if_else.rs:41:5: 50:6:
+    42:9-42:23: Assign: _41 = move (_46.0: i32)
+    41:22-43:6: Assign: _0 = const ()
+    41:5-50:6: Goto: goto -&gt; bb75">;</span></span>
+<span class="line"><span class="code even" style="--layer: 3" title="bb58: ../instrument-coverage/coverage_of_if_else.rs:41:5: 50:6:
+    42:9-42:23: Assign: _41 = move (_46.0: i32)
+    41:22-43:6: Assign: _0 = const ()
+    41:5-50:6: Goto: goto -&gt; bb75">    } else </span><span class="code even" style="--layer: 4" title="bb59: ../instrument-coverage/coverage_of_if_else.rs:43:12: 50:6:
+    43:12-50:6: FalseEdge: falseEdge -&gt; [real: bb61, imaginary: bb60]"><span class="annotation">59⦊</span>if </span><span class="code even" style="--layer: 5" title="bb56: ../instrument-coverage/coverage_of_if_else.rs:43:15: 43:28:
     43:15-43:28: StorageLive: StorageLive(_47)
     43:15-43:24: StorageLive: StorageLive(_48)
     43:15-43:24: Assign: _48 = _41
     43:15-43:28: Assign: _47 = Gt(move _48, const 2_i32)
     43:27-43:28: StorageDead: StorageDead(_48)
     43:15-43:28: FakeRead: FakeRead(ForMatchedPlace, _47)
-    43:12-50:6: SwitchInt: switchInt(_47) -&gt; [false: bb63, otherwise: bb62]"><span class="annotation">59⦊</span>countdown &gt; 2<span class="annotation">⦉59</span></span><span class="code even" style="--layer: 14" title="bb62: ../instrument-coverage/coverage_of_if_else.rs:43:12: 50:6:
-    43:12-50:6: FalseEdge: falseEdge -&gt; [real: bb64, imaginary: bb63]"> {</span></span>
-<span class="line"><span class="code even" style="--layer: 14" title="bb62: ../instrument-coverage/coverage_of_if_else.rs:43:12: 50:6:
-    43:12-50:6: FalseEdge: falseEdge -&gt; [real: bb64, imaginary: bb63]">        </span><span class="code odd" style="--layer: 15" title="bb75: ../instrument-coverage/coverage_of_if_else.rs:44:9: 46:10:
+    43:12-50:6: SwitchInt: switchInt(_47) -&gt; [false: bb60, otherwise: bb59]"><span class="annotation">56⦊</span>countdown &gt; 2<span class="annotation">⦉56</span></span><span class="code even" style="--layer: 4" title="bb59: ../instrument-coverage/coverage_of_if_else.rs:43:12: 50:6:
+    43:12-50:6: FalseEdge: falseEdge -&gt; [real: bb61, imaginary: bb60]"> {</span></span>
+<span class="line"><span class="code even" style="--layer: 4" title="bb59: ../instrument-coverage/coverage_of_if_else.rs:43:12: 50:6:
+    43:12-50:6: FalseEdge: falseEdge -&gt; [real: bb61, imaginary: bb60]">        </span><span class="code odd" style="--layer: 5" title="bb71: ../instrument-coverage/coverage_of_if_else.rs:44:9: 46:10:
+    44:9-46:10: Assign: _49 = const ()
+    44:9-46:10: Goto: goto -&gt; bb73"><span class="annotation">71⦊</span></span><span class="code even" style="--layer: 6" title="bb72: ../instrument-coverage/coverage_of_if_else.rs:44:9: 46:10:
     45:13-45:26: Assign: _41 = const 0_i32
     44:61-46:10: Assign: _49 = const ()
-    44:9-46:10: Goto: goto -&gt; bb76"><span class="annotation">75⦊</span></span><span class="code even" style="--layer: 16" title="bb74: ../instrument-coverage/coverage_of_if_else.rs:44:9: 46:10:
-    44:9-46:10: Assign: _49 = const ()
-    44:9-46:10: Goto: goto -&gt; bb76"><span class="annotation">74⦊</span></span><span class="code even" style="--layer: 17" title="bb73: ../instrument-coverage/coverage_of_if_else.rs:44:9: 46:10:
-    44:9-46:10: FalseEdge: falseEdge -&gt; [real: bb75, imaginary: bb74]"><span class="annotation">73⦊</span>if </span><span class="code even" style="--layer: 18" title="bb67: ../instrument-coverage/coverage_of_if_else.rs:44:12: 44:60:
+    44:9-46:10: Goto: goto -&gt; bb73"><span class="annotation">72⦊</span></span><span class="code even" style="--layer: 7" title="bb70: ../instrument-coverage/coverage_of_if_else.rs:44:9: 46:10:
+    44:9-46:10: FalseEdge: falseEdge -&gt; [real: bb72, imaginary: bb71]"><span class="annotation">70⦊</span>if </span><span class="code even" style="--layer: 8" title="bb63: ../instrument-coverage/coverage_of_if_else.rs:44:12: 44:60:
+    44:12-44:60: Assign: _50 = const false
+    44:12-44:60: Goto: goto -&gt; bb65"><span class="annotation">63⦊</span></span><span class="code even" style="--layer: 9" title="bb64: ../instrument-coverage/coverage_of_if_else.rs:44:12: 44:60:
     44:46-44:60: StorageLive: StorageLive(_56)
     44:46-44:55: StorageLive: StorageLive(_57)
     44:46-44:55: Assign: _57 = _41
     44:46-44:60: Assign: _56 = Ne(move _57, const 9_i32)
     44:59-44:60: StorageDead: StorageDead(_57)
-    44:12-44:60: SwitchInt: switchInt(move _56) -&gt; [false: bb66, otherwise: bb65]"><span class="annotation">67⦊</span></span><span class="code even" style="--layer: 19" title="bb68: ../instrument-coverage/coverage_of_if_else.rs:44:12: 44:60:
+    44:12-44:60: SwitchInt: switchInt(move _56) -&gt; [false: bb63, otherwise: bb62]"><span class="annotation">64⦊</span></span><span class="code even" style="--layer: 10" title="bb65: ../instrument-coverage/coverage_of_if_else.rs:44:12: 44:60:
     44:59-44:60: StorageDead: StorageDead(_56)
     44:59-44:60: StorageDead: StorageDead(_51)
     44:12-44:60: FakeRead: FakeRead(ForMatchedPlace, _50)
-    44:9-46:10: SwitchInt: switchInt(_50) -&gt; [false: bb74, otherwise: bb73]"><span class="annotation">68⦊</span></span><span class="code even" style="--layer: 20" title="bb65: ../instrument-coverage/coverage_of_if_else.rs:44:12: 44:60:
+    44:9-46:10: SwitchInt: switchInt(_50) -&gt; [false: bb71, otherwise: bb70]"><span class="annotation">65⦊</span></span><span class="code even" style="--layer: 11" title="bb62: ../instrument-coverage/coverage_of_if_else.rs:44:12: 44:60:
     44:12-44:60: Assign: _50 = const true
-    44:12-44:60: Goto: goto -&gt; bb68"><span class="annotation">65⦊</span></span><span class="code even" style="--layer: 21" title="bb72: ../instrument-coverage/coverage_of_if_else.rs:44:12: 44:60:
+    44:12-44:60: Goto: goto -&gt; bb65"><span class="annotation">62⦊</span></span><span class="code even" style="--layer: 12" title="bb69: ../instrument-coverage/coverage_of_if_else.rs:44:12: 44:60:
     44:41-44:42: StorageDead: StorageDead(_54)
     44:41-44:42: StorageDead: StorageDead(_52)
-    44:12-44:60: SwitchInt: switchInt(move _51) -&gt; [false: bb67, otherwise: bb65]"><span class="annotation">72⦊</span></span><span class="code even" style="--layer: 22" title="bb64: ../instrument-coverage/coverage_of_if_else.rs:44:12: 44:60:
+    44:12-44:60: SwitchInt: switchInt(move _51) -&gt; [false: bb64, otherwise: bb62]"><span class="annotation">69⦊</span></span><span class="code even" style="--layer: 13" title="bb61: ../instrument-coverage/coverage_of_if_else.rs:44:12: 44:60:
     44:9-46:10: StorageLive: StorageLive(_49)
     44:12-44:60: StorageLive: StorageLive(_50)
     44:12-44:42: StorageLive: StorageLive(_51)
@@ -664,29 +545,25 @@
     44:12-44:21: Assign: _53 = _41
     44:12-44:25: Assign: _52 = Lt(move _53, const 1_i32)
     44:24-44:25: StorageDead: StorageDead(_53)
-    44:12-44:42: SwitchInt: switchInt(move _52) -&gt; [false: bb71, otherwise: bb69]"><span class="annotation">64⦊</span></span><span class="code even" style="--layer: 23" title="bb66: ../instrument-coverage/coverage_of_if_else.rs:44:12: 44:60:
-    44:12-44:60: Assign: _50 = const false
-    44:12-44:60: Goto: goto -&gt; bb68"><span class="annotation">66⦊</span></span><span class="code even" style="--layer: 24" title="bb69: ../instrument-coverage/coverage_of_if_else.rs:44:12: 44:42:
-    44:12-44:42: Assign: _51 = const true
-    44:12-44:42: Goto: goto -&gt; bb72"><span class="annotation">69⦊</span></span><span class="code even" style="--layer: 25" title="bb71: ../instrument-coverage/coverage_of_if_else.rs:44:12: 44:42:
-    44:29-44:42: StorageLive: StorageLive(_54)
-    44:29-44:38: StorageLive: StorageLive(_55)
-    44:29-44:38: Assign: _55 = _41
-    44:29-44:42: Assign: _54 = Gt(move _55, const 5_i32)
-    44:41-44:42: StorageDead: StorageDead(_55)
-    44:12-44:42: SwitchInt: switchInt(move _54) -&gt; [false: bb70, otherwise: bb69]"><span class="annotation">71⦊</span></span><span class="code even" style="--layer: 26" title="bb70: ../instrument-coverage/coverage_of_if_else.rs:44:12: 44:42:
+    44:12-44:42: SwitchInt: switchInt(move _52) -&gt; [false: bb68, otherwise: bb66]"><span class="annotation">61⦊</span></span><span class="code even" style="--layer: 14" title="bb67: ../instrument-coverage/coverage_of_if_else.rs:44:12: 44:42:
     44:12-44:42: Assign: _51 = const false
-    44:12-44:42: Goto: goto -&gt; bb72"><span class="annotation">70⦊</span>countdown &lt; 1 || countdown &gt; 5<span class="annotation">⦉70</span></span><span class="code even" style="--layer: 25" title="bb71: ../instrument-coverage/coverage_of_if_else.rs:44:12: 44:42:
+    44:12-44:42: Goto: goto -&gt; bb69"><span class="annotation">67⦊</span></span><span class="code even" style="--layer: 15" title="bb68: ../instrument-coverage/coverage_of_if_else.rs:44:12: 44:42:
     44:29-44:42: StorageLive: StorageLive(_54)
     44:29-44:38: StorageLive: StorageLive(_55)
     44:29-44:38: Assign: _55 = _41
     44:29-44:42: Assign: _54 = Gt(move _55, const 5_i32)
     44:41-44:42: StorageDead: StorageDead(_55)
-    44:12-44:42: SwitchInt: switchInt(move _54) -&gt; [false: bb70, otherwise: bb69]"><span class="annotation">⦉71</span></span><span class="code even" style="--layer: 24" title="bb69: ../instrument-coverage/coverage_of_if_else.rs:44:12: 44:42:
+    44:12-44:42: SwitchInt: switchInt(move _54) -&gt; [false: bb67, otherwise: bb66]"><span class="annotation">68⦊</span></span><span class="code even" style="--layer: 16" title="bb66: ../instrument-coverage/coverage_of_if_else.rs:44:12: 44:42:
     44:12-44:42: Assign: _51 = const true
-    44:12-44:42: Goto: goto -&gt; bb72"><span class="annotation">⦉69</span></span><span class="code even" style="--layer: 23" title="bb66: ../instrument-coverage/coverage_of_if_else.rs:44:12: 44:60:
-    44:12-44:60: Assign: _50 = const false
-    44:12-44:60: Goto: goto -&gt; bb68"> || countdown != 9<span class="annotation">⦉66</span></span><span class="code even" style="--layer: 22" title="bb64: ../instrument-coverage/coverage_of_if_else.rs:44:12: 44:60:
+    44:12-44:42: Goto: goto -&gt; bb69"><span class="annotation">66⦊</span>countdown &lt; 1 || countdown &gt; 5<span class="annotation">⦉66</span></span><span class="code even" style="--layer: 15" title="bb68: ../instrument-coverage/coverage_of_if_else.rs:44:12: 44:42:
+    44:29-44:42: StorageLive: StorageLive(_54)
+    44:29-44:38: StorageLive: StorageLive(_55)
+    44:29-44:38: Assign: _55 = _41
+    44:29-44:42: Assign: _54 = Gt(move _55, const 5_i32)
+    44:41-44:42: StorageDead: StorageDead(_55)
+    44:12-44:42: SwitchInt: switchInt(move _54) -&gt; [false: bb67, otherwise: bb66]"><span class="annotation">⦉68</span></span><span class="code even" style="--layer: 14" title="bb67: ../instrument-coverage/coverage_of_if_else.rs:44:12: 44:42:
+    44:12-44:42: Assign: _51 = const false
+    44:12-44:42: Goto: goto -&gt; bb69"><span class="annotation">⦉67</span></span><span class="code even" style="--layer: 13" title="bb61: ../instrument-coverage/coverage_of_if_else.rs:44:12: 44:60:
     44:9-46:10: StorageLive: StorageLive(_49)
     44:12-44:60: StorageLive: StorageLive(_50)
     44:12-44:42: StorageLive: StorageLive(_51)
@@ -695,114 +572,70 @@
     44:12-44:21: Assign: _53 = _41
     44:12-44:25: Assign: _52 = Lt(move _53, const 1_i32)
     44:24-44:25: StorageDead: StorageDead(_53)
-    44:12-44:42: SwitchInt: switchInt(move _52) -&gt; [false: bb71, otherwise: bb69]"><span class="annotation">⦉64</span></span><span class="code even" style="--layer: 21" title="bb72: ../instrument-coverage/coverage_of_if_else.rs:44:12: 44:60:
+    44:12-44:42: SwitchInt: switchInt(move _52) -&gt; [false: bb68, otherwise: bb66]"> || countdown != 9<span class="annotation">⦉61</span></span><span class="code even" style="--layer: 12" title="bb69: ../instrument-coverage/coverage_of_if_else.rs:44:12: 44:60:
     44:41-44:42: StorageDead: StorageDead(_54)
     44:41-44:42: StorageDead: StorageDead(_52)
-    44:12-44:60: SwitchInt: switchInt(move _51) -&gt; [false: bb67, otherwise: bb65]"><span class="annotation">⦉72</span></span><span class="code even" style="--layer: 20" title="bb65: ../instrument-coverage/coverage_of_if_else.rs:44:12: 44:60:
+    44:12-44:60: SwitchInt: switchInt(move _51) -&gt; [false: bb64, otherwise: bb62]"><span class="annotation">⦉69</span></span><span class="code even" style="--layer: 11" title="bb62: ../instrument-coverage/coverage_of_if_else.rs:44:12: 44:60:
     44:12-44:60: Assign: _50 = const true
-    44:12-44:60: Goto: goto -&gt; bb68"><span class="annotation">⦉65</span></span><span class="code even" style="--layer: 19" title="bb68: ../instrument-coverage/coverage_of_if_else.rs:44:12: 44:60:
+    44:12-44:60: Goto: goto -&gt; bb65"><span class="annotation">⦉62</span></span><span class="code even" style="--layer: 10" title="bb65: ../instrument-coverage/coverage_of_if_else.rs:44:12: 44:60:
     44:59-44:60: StorageDead: StorageDead(_56)
     44:59-44:60: StorageDead: StorageDead(_51)
     44:12-44:60: FakeRead: FakeRead(ForMatchedPlace, _50)
-    44:9-46:10: SwitchInt: switchInt(_50) -&gt; [false: bb74, otherwise: bb73]"><span class="annotation">⦉68</span></span><span class="code even" style="--layer: 18" title="bb67: ../instrument-coverage/coverage_of_if_else.rs:44:12: 44:60:
+    44:9-46:10: SwitchInt: switchInt(_50) -&gt; [false: bb71, otherwise: bb70]"><span class="annotation">⦉65</span></span><span class="code even" style="--layer: 9" title="bb64: ../instrument-coverage/coverage_of_if_else.rs:44:12: 44:60:
     44:46-44:60: StorageLive: StorageLive(_56)
     44:46-44:55: StorageLive: StorageLive(_57)
     44:46-44:55: Assign: _57 = _41
     44:46-44:60: Assign: _56 = Ne(move _57, const 9_i32)
     44:59-44:60: StorageDead: StorageDead(_57)
-    44:12-44:60: SwitchInt: switchInt(move _56) -&gt; [false: bb66, otherwise: bb65]"><span class="annotation">⦉67</span></span><span class="code even" style="--layer: 17" title="bb73: ../instrument-coverage/coverage_of_if_else.rs:44:9: 46:10:
-    44:9-46:10: FalseEdge: falseEdge -&gt; [real: bb75, imaginary: bb74]"> {</span></span>
-<span class="line"><span class="code even" style="--layer: 17" title="bb73: ../instrument-coverage/coverage_of_if_else.rs:44:9: 46:10:
-    44:9-46:10: FalseEdge: falseEdge -&gt; [real: bb75, imaginary: bb74]">            countdown = 0;</span></span>
-<span class="line"><span class="code even" style="--layer: 17" title="bb73: ../instrument-coverage/coverage_of_if_else.rs:44:9: 46:10:
-    44:9-46:10: FalseEdge: falseEdge -&gt; [real: bb75, imaginary: bb74]">        </span><span class="code odd" style="--layer: 18" title="bb76: ../instrument-coverage/coverage_of_if_else.rs:46:9: 47:23:
+    44:12-44:60: SwitchInt: switchInt(move _56) -&gt; [false: bb63, otherwise: bb62]"><span class="annotation">⦉64</span></span><span class="code even" style="--layer: 8" title="bb63: ../instrument-coverage/coverage_of_if_else.rs:44:12: 44:60:
+    44:12-44:60: Assign: _50 = const false
+    44:12-44:60: Goto: goto -&gt; bb65"><span class="annotation">⦉63</span></span><span class="code even" style="--layer: 7" title="bb70: ../instrument-coverage/coverage_of_if_else.rs:44:9: 46:10:
+    44:9-46:10: FalseEdge: falseEdge -&gt; [real: bb72, imaginary: bb71]"> {</span></span>
+<span class="line"><span class="code even" style="--layer: 7" title="bb70: ../instrument-coverage/coverage_of_if_else.rs:44:9: 46:10:
+    44:9-46:10: FalseEdge: falseEdge -&gt; [real: bb72, imaginary: bb71]">            countdown = 0;</span></span>
+<span class="line"><span class="code even" style="--layer: 7" title="bb70: ../instrument-coverage/coverage_of_if_else.rs:44:9: 46:10:
+    44:9-46:10: FalseEdge: falseEdge -&gt; [real: bb72, imaginary: bb71]">        </span><span class="code odd" style="--layer: 8" title="bb73: ../instrument-coverage/coverage_of_if_else.rs:46:9: 47:23:
     46:9-46:10: StorageDead: StorageDead(_50)
     46:9-46:10: StorageDead: StorageDead(_49)
     47:9-47:23: Assign: _58 = CheckedSub(_41, const 5_i32)
-    47:9-47:23: Assert: assert(!move (_58.1: bool), &quot;attempt to compute `{} - {}`, which would overflow&quot;, _41, const 5_i32) -&gt; [success: bb77, unwind: bb1]"><span class="annotation">76⦊</span>}</span><span class="code odd" style="--layer: 15" title="bb75: ../instrument-coverage/coverage_of_if_else.rs:44:9: 46:10:
+    47:9-47:23: Assert: assert(!move (_58.1: bool), &quot;attempt to compute `{} - {}`, which would overflow&quot;, _41, const 5_i32) -&gt; [success: bb74, unwind: bb78]"><span class="annotation">73⦊</span>}</span><span class="code odd" style="--layer: 5" title="bb71: ../instrument-coverage/coverage_of_if_else.rs:44:9: 46:10:
+    44:9-46:10: Assign: _49 = const ()
+    44:9-46:10: Goto: goto -&gt; bb73"><span class="annotation">⦉71</span></span><span class="code even" style="--layer: 6" title="bb72: ../instrument-coverage/coverage_of_if_else.rs:44:9: 46:10:
     45:13-45:26: Assign: _41 = const 0_i32
     44:61-46:10: Assign: _49 = const ()
-    44:9-46:10: Goto: goto -&gt; bb76"><span class="annotation">⦉75</span></span><span class="code even" style="--layer: 16" title="bb74: ../instrument-coverage/coverage_of_if_else.rs:44:9: 46:10:
-    44:9-46:10: Assign: _49 = const ()
-    44:9-46:10: Goto: goto -&gt; bb76"><span class="annotation">⦉74</span></span><span class="code even" style="--layer: 17" title="bb73: ../instrument-coverage/coverage_of_if_else.rs:44:9: 46:10:
-    44:9-46:10: FalseEdge: falseEdge -&gt; [real: bb75, imaginary: bb74]"><span class="annotation">⦉73</span></span><span class="code even" style="--layer: 17" title="bb73: ../instrument-coverage/coverage_of_if_else.rs:44:9: 46:10:
-    44:9-46:10: FalseEdge: falseEdge -&gt; [real: bb75, imaginary: bb74]"><span class="annotation">⦉73</span></span><span class="code odd" style="--layer: 18" title="bb76: ../instrument-coverage/coverage_of_if_else.rs:46:9: 47:23:
+    44:9-46:10: Goto: goto -&gt; bb73"><span class="annotation">⦉72</span></span><span class="code even" style="--layer: 7" title="bb70: ../instrument-coverage/coverage_of_if_else.rs:44:9: 46:10:
+    44:9-46:10: FalseEdge: falseEdge -&gt; [real: bb72, imaginary: bb71]"><span class="annotation">⦉70</span></span><span class="code even" style="--layer: 7" title="bb70: ../instrument-coverage/coverage_of_if_else.rs:44:9: 46:10:
+    44:9-46:10: FalseEdge: falseEdge -&gt; [real: bb72, imaginary: bb71]"><span class="annotation">⦉70</span></span><span class="code odd" style="--layer: 8" title="bb73: ../instrument-coverage/coverage_of_if_else.rs:46:9: 47:23:
     46:9-46:10: StorageDead: StorageDead(_50)
     46:9-46:10: StorageDead: StorageDead(_49)
     47:9-47:23: Assign: _58 = CheckedSub(_41, const 5_i32)
-    47:9-47:23: Assert: assert(!move (_58.1: bool), &quot;attempt to compute `{} - {}`, which would overflow&quot;, _41, const 5_i32) -&gt; [success: bb77, unwind: bb1]"></span></span>
-<span class="line"><span class="code odd" style="--layer: 18" title="bb76: ../instrument-coverage/coverage_of_if_else.rs:46:9: 47:23:
+    47:9-47:23: Assert: assert(!move (_58.1: bool), &quot;attempt to compute `{} - {}`, which would overflow&quot;, _41, const 5_i32) -&gt; [success: bb74, unwind: bb78]"></span></span>
+<span class="line"><span class="code odd" style="--layer: 8" title="bb73: ../instrument-coverage/coverage_of_if_else.rs:46:9: 47:23:
     46:9-46:10: StorageDead: StorageDead(_50)
     46:9-46:10: StorageDead: StorageDead(_49)
     47:9-47:23: Assign: _58 = CheckedSub(_41, const 5_i32)
-    47:9-47:23: Assert: assert(!move (_58.1: bool), &quot;attempt to compute `{} - {}`, which would overflow&quot;, _41, const 5_i32) -&gt; [success: bb77, unwind: bb1]">        countdown -= 5<span class="annotation">⦉76</span></span><span class="code even" style="--layer: 14" title="bb62: ../instrument-coverage/coverage_of_if_else.rs:43:12: 50:6:
-    43:12-50:6: FalseEdge: falseEdge -&gt; [real: bb64, imaginary: bb63]">;</span></span>
-<span class="line"><span class="code even" style="--layer: 14" title="bb62: ../instrument-coverage/coverage_of_if_else.rs:43:12: 50:6:
-    43:12-50:6: FalseEdge: falseEdge -&gt; [real: bb64, imaginary: bb63]">    } else {</span></span>
-<span class="line"><span class="code even" style="--layer: 14" title="bb62: ../instrument-coverage/coverage_of_if_else.rs:43:12: 50:6:
-    43:12-50:6: FalseEdge: falseEdge -&gt; [real: bb64, imaginary: bb63]">        </span><span class="code even" style="--layer: 15" title="bb63: ../instrument-coverage/coverage_of_if_else.rs:49:9: 51:2:
-    49:9-49:15: Assign: _0 = const ()
-    50:5-50:6: StorageDead: StorageDead(_47)
-    51:1-51:2: StorageDead: StorageDead(_41)
-    51:1-51:2: StorageDead: StorageDead(_21)
-    51:1-51:2: StorageDead: StorageDead(_1)
-    51:1-51:2: StorageDead: StorageDead(_44)
-    49:9-49:15: Goto: goto -&gt; bb26"><span class="annotation">63⦊</span>return;</span></span>
-<span class="line"><span class="code even" style="--layer: 15" title="bb63: ../instrument-coverage/coverage_of_if_else.rs:49:9: 51:2:
-    49:9-49:15: Assign: _0 = const ()
-    50:5-50:6: StorageDead: StorageDead(_47)
-    51:1-51:2: StorageDead: StorageDead(_41)
-    51:1-51:2: StorageDead: StorageDead(_21)
-    51:1-51:2: StorageDead: StorageDead(_1)
-    51:1-51:2: StorageDead: StorageDead(_44)
-    49:9-49:15: Goto: goto -&gt; bb26">    }</span><span class="code odd" style="--layer: 11" title="bb61: ../instrument-coverage/coverage_of_if_else.rs:41:5: 50:6:
+    47:9-47:23: Assert: assert(!move (_58.1: bool), &quot;attempt to compute `{} - {}`, which would overflow&quot;, _41, const 5_i32) -&gt; [success: bb74, unwind: bb78]">        countdown -= 5<span class="annotation">⦉73</span></span><span class="code even" style="--layer: 4" title="bb59: ../instrument-coverage/coverage_of_if_else.rs:43:12: 50:6:
+    43:12-50:6: FalseEdge: falseEdge -&gt; [real: bb61, imaginary: bb60]">;</span></span>
+<span class="line"><span class="code even" style="--layer: 4" title="bb59: ../instrument-coverage/coverage_of_if_else.rs:43:12: 50:6:
+    43:12-50:6: FalseEdge: falseEdge -&gt; [real: bb61, imaginary: bb60]">    } else {</span></span>
+<span class="line"><span class="code even" style="--layer: 4" title="bb59: ../instrument-coverage/coverage_of_if_else.rs:43:12: 50:6:
+    43:12-50:6: FalseEdge: falseEdge -&gt; [real: bb61, imaginary: bb60]">        return;</span></span>
+<span class="line"><span class="code even" style="--layer: 4" title="bb59: ../instrument-coverage/coverage_of_if_else.rs:43:12: 50:6:
+    43:12-50:6: FalseEdge: falseEdge -&gt; [real: bb61, imaginary: bb60]">    }<span class="annotation">⦉59</span></span><span class="code even" style="--layer: 3" title="bb58: ../instrument-coverage/coverage_of_if_else.rs:41:5: 50:6:
     42:9-42:23: Assign: _41 = move (_46.0: i32)
     41:22-43:6: Assign: _0 = const ()
-    41:5-50:6: Goto: goto -&gt; bb78"><span class="annotation">⦉61</span></span><span class="code even" style="--layer: 12" title="bb58: ../instrument-coverage/coverage_of_if_else.rs:41:5: 50:6:
-    41:5-50:6: FalseEdge: falseEdge -&gt; [real: bb60, imaginary: bb59]"><span class="annotation">⦉58</span></span><span class="code even" style="--layer: 13" title="bb77: ../instrument-coverage/coverage_of_if_else.rs:41:5: 50:6:
+    41:5-50:6: Goto: goto -&gt; bb75"><span class="annotation">⦉58</span></span><span class="code even" style="--layer: 2" title="bb55: ../instrument-coverage/coverage_of_if_else.rs:41:5: 50:6:
+    41:5-50:6: FalseEdge: falseEdge -&gt; [real: bb57, imaginary: bb56]"><span class="annotation">⦉55</span></span><span><span class="code odd" style="--layer: 1" title="bb74: ../instrument-coverage/coverage_of_if_else.rs:41:5: 50:6:
     47:9-47:23: Assign: _41 = move (_58.0: i32)
     43:29-48:6: Assign: _0 = const ()
     50:5-50:6: StorageDead: StorageDead(_47)
-    41:5-50:6: Goto: goto -&gt; bb78"><span class="annotation">⦉77</span></span><span class="code even" style="--layer: 13" title="bb77: ../instrument-coverage/coverage_of_if_else.rs:41:5: 50:6:
-    47:9-47:23: Assign: _41 = move (_58.0: i32)
-    43:29-48:6: Assign: _0 = const ()
-    50:5-50:6: StorageDead: StorageDead(_47)
-    41:5-50:6: Goto: goto -&gt; bb78"><span class="annotation">⦉77</span></span><span class="code even" style="--layer: 13" title="bb77: ../instrument-coverage/coverage_of_if_else.rs:41:5: 50:6:
-    47:9-47:23: Assign: _41 = move (_58.0: i32)
-    43:29-48:6: Assign: _0 = const ()
-    50:5-50:6: StorageDead: StorageDead(_47)
-    41:5-50:6: Goto: goto -&gt; bb78"><span class="annotation">⦉77</span></span><span class="code even" style="--layer: 14" title="bb62: ../instrument-coverage/coverage_of_if_else.rs:43:12: 50:6:
-    43:12-50:6: FalseEdge: falseEdge -&gt; [real: bb64, imaginary: bb63]"><span class="annotation">⦉62</span></span><span class="code even" style="--layer: 14" title="bb62: ../instrument-coverage/coverage_of_if_else.rs:43:12: 50:6:
-    43:12-50:6: FalseEdge: falseEdge -&gt; [real: bb64, imaginary: bb63]"><span class="annotation">⦉62</span></span><span class="code even" style="--layer: 14" title="bb62: ../instrument-coverage/coverage_of_if_else.rs:43:12: 50:6:
-    43:12-50:6: FalseEdge: falseEdge -&gt; [real: bb64, imaginary: bb63]"><span class="annotation">⦉62</span></span><span class="code even" style="--layer: 15" title="bb63: ../instrument-coverage/coverage_of_if_else.rs:49:9: 51:2:
-    49:9-49:15: Assign: _0 = const ()
-    50:5-50:6: StorageDead: StorageDead(_47)
+    41:5-50:6: Goto: goto -&gt; bb75"><span class="annotation">⦉74</span></span></span><span class="code" style="--layer: 0"></span></span>
+<span class="line"><span><span class="code even" style="--layer: 1" title="bb75: ../instrument-coverage/coverage_of_if_else.rs:51:1: 51:2:
     51:1-51:2: StorageDead: StorageDead(_41)
     51:1-51:2: StorageDead: StorageDead(_21)
     51:1-51:2: StorageDead: StorageDead(_1)
     51:1-51:2: StorageDead: StorageDead(_44)
-    49:9-49:15: Goto: goto -&gt; bb26"></span></span>
-<span class="line"><span class="code even" style="--layer: 16" title="bb78: ../instrument-coverage/coverage_of_if_else.rs:51:1: 51:2:
-    51:1-51:2: StorageDead: StorageDead(_41)
-    51:1-51:2: StorageDead: StorageDead(_21)
-    51:1-51:2: StorageDead: StorageDead(_1)
-    51:1-51:2: StorageDead: StorageDead(_44)
-    51:2-51:2: Goto: goto -&gt; bb26"><span class="annotation">78⦊</span>}<span class="annotation">⦉78</span></span><span class="code even" style="--layer: 15" title="bb63: ../instrument-coverage/coverage_of_if_else.rs:49:9: 51:2:
-    49:9-49:15: Assign: _0 = const ()
-    50:5-50:6: StorageDead: StorageDead(_47)
-    51:1-51:2: StorageDead: StorageDead(_41)
-    51:1-51:2: StorageDead: StorageDead(_21)
-    51:1-51:2: StorageDead: StorageDead(_1)
-    51:1-51:2: StorageDead: StorageDead(_44)
-    49:9-49:15: Goto: goto -&gt; bb26"><span class="annotation">⦉63</span></span><span class="code even" style="--layer: 10" title="bb38: ../instrument-coverage/coverage_of_if_else.rs:33:9: 51:2:
-    33:9-33:15: Assign: _0 = const ()
-    34:5-34:6: StorageDead: StorageDead(_28)
-    34:5-34:6: StorageDead: StorageDead(_25)
-    34:5-34:6: StorageDead: StorageDead(_24)
-    51:1-51:2: StorageDead: StorageDead(_21)
-    33:9-33:15: Goto: goto -&gt; bb27"><span class="annotation">⦉38</span></span><span class="code even" style="--layer: 5" title="bb27: ../instrument-coverage/coverage_of_if_else.rs:17:9: 51:2:
-    51:1-51:2: StorageDead: StorageDead(_1)
-    17:9-17:15: Goto: goto -&gt; bb26"><span class="annotation">⦉27</span></span><span><span class="code even" style="--layer: 1" title="bb26: ../instrument-coverage/coverage_of_if_else.rs:51:2: 51:2:
-    51:2-51:2: Return: return"><span class="annotation">26⦊</span>‸<span class="annotation">⦉26</span></span></span></span></div>
+    51:2-51:2: Goto: goto -&gt; bb77"><span class="annotation">75⦊</span>}<span class="annotation">⦉75</span></span></span><span><span class="code odd" style="--layer: 1" title="bb77: ../instrument-coverage/coverage_of_if_else.rs:51:2: 51:2:
+    51:2-51:2: Return: return"><span class="annotation">77⦊</span>‸<span class="annotation">⦉77</span></span></span></span></div>
 </body>
 </html>

--- a/src/test/run-make-fulldeps/instrument-coverage-mir-cov-html-link-dead-code/expected_mir_dump.coverage_of_if_else/coverage_of_if_else.main.-------.InstrumentCoverage.0.html
+++ b/src/test/run-make-fulldeps/instrument-coverage-mir-cov-html-link-dead-code/expected_mir_dump.coverage_of_if_else/coverage_of_if_else.main.-------.InstrumentCoverage.0.html
@@ -61,13 +61,13 @@
 <body>
 <div class="code" style="counter-reset: line 2"><span class="line"><span class="code" style="--layer: 0">fn main() {</span></span>
 <span class="line"><span class="code" style="--layer: 0">    let mut countdown = 0;</span></span>
-<span class="line"><span class="code" style="--layer: 0">    </span><span><span class="code even" style="--layer: 1" title="bb2: ../instrument-coverage/coverage_of_if_else.rs:5:5: 7:6:
-    5:5-7:6: FalseEdge: falseEdge -&gt; [real: bb4, imaginary: bb3]"><span class="annotation">2⦊</span></span></span><span class="code even" style="--layer: 2" title="bb4: ../instrument-coverage/coverage_of_if_else.rs:5:5: 7:6:
+<span class="line"><span class="code" style="--layer: 0">    </span><span><span class="code even" style="--layer: 1" title="bb1: ../instrument-coverage/coverage_of_if_else.rs:5:5: 7:6:
+    5:5-7:6: FalseEdge: falseEdge -&gt; [real: bb3, imaginary: bb2]"><span class="annotation">1⦊</span></span></span><span class="code even" style="--layer: 2" title="bb3: ../instrument-coverage/coverage_of_if_else.rs:5:5: 7:6:
     6:9-6:23: Assign: _1 = const 10_i32
     5:13-7:6: Assign: _2 = const ()
-    5:5-7:6: Goto: goto -&gt; bb5"><span class="annotation">4⦊</span></span><span class="code even" style="--layer: 3" title="bb3: ../instrument-coverage/coverage_of_if_else.rs:5:5: 7:6:
+    5:5-7:6: Goto: goto -&gt; bb4"><span class="annotation">3⦊</span></span><span class="code even" style="--layer: 3" title="bb2: ../instrument-coverage/coverage_of_if_else.rs:5:5: 7:6:
     5:5-7:6: Assign: _2 = const ()
-    5:5-7:6: Goto: goto -&gt; bb5"><span class="annotation">3⦊</span>if </span><span class="code even" style="--layer: 4" title="bb0: ../instrument-coverage/coverage_of_if_else.rs:5:8: 5:12:
+    5:5-7:6: Goto: goto -&gt; bb4"><span class="annotation">2⦊</span>if </span><span class="code even" style="--layer: 4" title="bb0: ../instrument-coverage/coverage_of_if_else.rs:5:8: 5:12:
     4:9-4:22: StorageLive: StorageLive(_1)
     4:25-4:26: Assign: _1 = const 0_i32
     4:9-4:22: FakeRead: FakeRead(ForLet, _1)
@@ -75,29 +75,29 @@
     5:8-5:12: StorageLive: StorageLive(_3)
     5:8-5:12: Assign: _3 = const true
     5:8-5:12: FakeRead: FakeRead(ForMatchedPlace, _3)
-    5:5-7:6: SwitchInt: switchInt(_3) -&gt; [false: bb3, otherwise: bb2]"><span class="annotation">0⦊</span>true<span class="annotation">⦉0</span></span><span class="code even" style="--layer: 3" title="bb3: ../instrument-coverage/coverage_of_if_else.rs:5:5: 7:6:
+    5:5-7:6: SwitchInt: switchInt(_3) -&gt; [false: bb2, otherwise: bb1]"><span class="annotation">0⦊</span>true<span class="annotation">⦉0</span></span><span class="code even" style="--layer: 3" title="bb2: ../instrument-coverage/coverage_of_if_else.rs:5:5: 7:6:
     5:5-7:6: Assign: _2 = const ()
-    5:5-7:6: Goto: goto -&gt; bb5"> {</span></span>
-<span class="line"><span class="code even" style="--layer: 3" title="bb3: ../instrument-coverage/coverage_of_if_else.rs:5:5: 7:6:
+    5:5-7:6: Goto: goto -&gt; bb4"> {</span></span>
+<span class="line"><span class="code even" style="--layer: 3" title="bb2: ../instrument-coverage/coverage_of_if_else.rs:5:5: 7:6:
     5:5-7:6: Assign: _2 = const ()
-    5:5-7:6: Goto: goto -&gt; bb5">        countdown = 10;</span></span>
-<span class="line"><span class="code even" style="--layer: 3" title="bb3: ../instrument-coverage/coverage_of_if_else.rs:5:5: 7:6:
+    5:5-7:6: Goto: goto -&gt; bb4">        countdown = 10;</span></span>
+<span class="line"><span class="code even" style="--layer: 3" title="bb2: ../instrument-coverage/coverage_of_if_else.rs:5:5: 7:6:
     5:5-7:6: Assign: _2 = const ()
-    5:5-7:6: Goto: goto -&gt; bb5">    }<span class="annotation">⦉3</span></span><span class="code even" style="--layer: 2" title="bb4: ../instrument-coverage/coverage_of_if_else.rs:5:5: 7:6:
+    5:5-7:6: Goto: goto -&gt; bb4">    }<span class="annotation">⦉2</span></span><span class="code even" style="--layer: 2" title="bb3: ../instrument-coverage/coverage_of_if_else.rs:5:5: 7:6:
     6:9-6:23: Assign: _1 = const 10_i32
     5:13-7:6: Assign: _2 = const ()
-    5:5-7:6: Goto: goto -&gt; bb5"><span class="annotation">⦉4</span></span><span><span class="code even" style="--layer: 1" title="bb2: ../instrument-coverage/coverage_of_if_else.rs:5:5: 7:6:
-    5:5-7:6: FalseEdge: falseEdge -&gt; [real: bb4, imaginary: bb3]"><span class="annotation">⦉2</span></span></span><span class="code" style="--layer: 0"></span></span>
+    5:5-7:6: Goto: goto -&gt; bb4"><span class="annotation">⦉3</span></span><span><span class="code even" style="--layer: 1" title="bb1: ../instrument-coverage/coverage_of_if_else.rs:5:5: 7:6:
+    5:5-7:6: FalseEdge: falseEdge -&gt; [real: bb3, imaginary: bb2]"><span class="annotation">⦉1</span></span></span><span class="code" style="--layer: 0"></span></span>
 <span class="line"><span class="code" style="--layer: 0"></span></span>
-<span class="line"><span class="code" style="--layer: 0">    </span><span><span class="code odd" style="--layer: 1" title="bb6: ../instrument-coverage/coverage_of_if_else.rs:9:5: 18:6:
-    9:5-18:6: FalseEdge: falseEdge -&gt; [real: bb8, imaginary: bb7]"><span class="annotation">6⦊</span></span></span><span class="code even" style="--layer: 2" title="bb9: ../instrument-coverage/coverage_of_if_else.rs:9:5: 18:6:
+<span class="line"><span class="code" style="--layer: 0">    </span><span><span class="code odd" style="--layer: 1" title="bb5: ../instrument-coverage/coverage_of_if_else.rs:9:5: 18:6:
+    9:5-18:6: FalseEdge: falseEdge -&gt; [real: bb7, imaginary: bb6]"><span class="annotation">5⦊</span></span></span><span class="code even" style="--layer: 2" title="bb8: ../instrument-coverage/coverage_of_if_else.rs:9:5: 18:6:
     10:9-10:23: Assign: _1 = move (_7.0: i32)
     9:22-11:6: Assign: _4 = const ()
-    9:5-18:6: Goto: goto -&gt; bb28"><span class="annotation">9⦊</span></span><span class="code even" style="--layer: 3" title="bb25: ../instrument-coverage/coverage_of_if_else.rs:9:5: 18:6:
+    9:5-18:6: Goto: goto -&gt; bb25"><span class="annotation">8⦊</span></span><span class="code even" style="--layer: 3" title="bb24: ../instrument-coverage/coverage_of_if_else.rs:9:5: 18:6:
     15:9-15:23: Assign: _1 = move (_19.0: i32)
     11:29-16:6: Assign: _4 = const ()
     18:5-18:6: StorageDead: StorageDead(_8)
-    9:5-18:6: Goto: goto -&gt; bb28"><span class="annotation">25⦊</span>if </span><span class="code even" style="--layer: 4" title="bb5: ../instrument-coverage/coverage_of_if_else.rs:9:8: 9:21:
+    9:5-18:6: Goto: goto -&gt; bb25"><span class="annotation">24⦊</span>if </span><span class="code even" style="--layer: 4" title="bb4: ../instrument-coverage/coverage_of_if_else.rs:9:8: 9:21:
     7:5-7:6: StorageDead: StorageDead(_3)
     7:5-7:6: StorageDead: StorageDead(_2)
     9:5-18:6: StorageLive: StorageLive(_4)
@@ -107,61 +107,50 @@
     9:8-9:21: Assign: _5 = Gt(move _6, const 7_i32)
     9:20-9:21: StorageDead: StorageDead(_6)
     9:8-9:21: FakeRead: FakeRead(ForMatchedPlace, _5)
-    9:5-18:6: SwitchInt: switchInt(_5) -&gt; [false: bb7, otherwise: bb6]"><span class="annotation">5⦊</span>countdown &gt; 7<span class="annotation">⦉5</span></span><span class="code even" style="--layer: 3" title="bb25: ../instrument-coverage/coverage_of_if_else.rs:9:5: 18:6:
+    9:5-18:6: SwitchInt: switchInt(_5) -&gt; [false: bb6, otherwise: bb5]"><span class="annotation">4⦊</span>countdown &gt; 7<span class="annotation">⦉4</span></span><span class="code even" style="--layer: 3" title="bb24: ../instrument-coverage/coverage_of_if_else.rs:9:5: 18:6:
     15:9-15:23: Assign: _1 = move (_19.0: i32)
     11:29-16:6: Assign: _4 = const ()
     18:5-18:6: StorageDead: StorageDead(_8)
-    9:5-18:6: Goto: goto -&gt; bb28"> {</span></span>
-<span class="line"><span class="code even" style="--layer: 3" title="bb25: ../instrument-coverage/coverage_of_if_else.rs:9:5: 18:6:
+    9:5-18:6: Goto: goto -&gt; bb25"> {</span></span>
+<span class="line"><span class="code even" style="--layer: 3" title="bb24: ../instrument-coverage/coverage_of_if_else.rs:9:5: 18:6:
     15:9-15:23: Assign: _1 = move (_19.0: i32)
     11:29-16:6: Assign: _4 = const ()
     18:5-18:6: StorageDead: StorageDead(_8)
-    9:5-18:6: Goto: goto -&gt; bb28">        </span><span class="code odd" style="--layer: 4" title="bb8: ../instrument-coverage/coverage_of_if_else.rs:10:9: 10:23:
+    9:5-18:6: Goto: goto -&gt; bb25">        </span><span class="code odd" style="--layer: 4" title="bb7: ../instrument-coverage/coverage_of_if_else.rs:10:9: 10:23:
     10:9-10:23: Assign: _7 = CheckedSub(_1, const 4_i32)
-    10:9-10:23: Assert: assert(!move (_7.1: bool), &quot;attempt to compute `{} - {}`, which would overflow&quot;, _1, const 4_i32) -&gt; [success: bb9, unwind: bb1]"><span class="annotation">8⦊</span>countdown -= 4<span class="annotation">⦉8</span></span><span class="code even" style="--layer: 3" title="bb25: ../instrument-coverage/coverage_of_if_else.rs:9:5: 18:6:
+    10:9-10:23: Assert: assert(!move (_7.1: bool), &quot;attempt to compute `{} - {}`, which would overflow&quot;, _1, const 4_i32) -&gt; [success: bb8, unwind: bb78]"><span class="annotation">7⦊</span>countdown -= 4<span class="annotation">⦉7</span></span><span class="code even" style="--layer: 3" title="bb24: ../instrument-coverage/coverage_of_if_else.rs:9:5: 18:6:
     15:9-15:23: Assign: _1 = move (_19.0: i32)
     11:29-16:6: Assign: _4 = const ()
     18:5-18:6: StorageDead: StorageDead(_8)
-    9:5-18:6: Goto: goto -&gt; bb28">;</span></span>
-<span class="line"><span class="code even" style="--layer: 3" title="bb25: ../instrument-coverage/coverage_of_if_else.rs:9:5: 18:6:
+    9:5-18:6: Goto: goto -&gt; bb25">;</span></span>
+<span class="line"><span class="code even" style="--layer: 3" title="bb24: ../instrument-coverage/coverage_of_if_else.rs:9:5: 18:6:
     15:9-15:23: Assign: _1 = move (_19.0: i32)
     11:29-16:6: Assign: _4 = const ()
     18:5-18:6: StorageDead: StorageDead(_8)
-    9:5-18:6: Goto: goto -&gt; bb28">    } else </span><span class="code even" style="--layer: 4" title="bb10: ../instrument-coverage/coverage_of_if_else.rs:11:12: 18:6:
-    11:12-18:6: FalseEdge: falseEdge -&gt; [real: bb12, imaginary: bb11]"><span class="annotation">10⦊</span>if </span><span class="code even" style="--layer: 5" title="bb7: ../instrument-coverage/coverage_of_if_else.rs:11:15: 11:28:
+    9:5-18:6: Goto: goto -&gt; bb25">    } else </span><span class="code even" style="--layer: 4" title="bb9: ../instrument-coverage/coverage_of_if_else.rs:11:12: 18:6:
+    11:12-18:6: FalseEdge: falseEdge -&gt; [real: bb11, imaginary: bb10]"><span class="annotation">9⦊</span>if </span><span class="code even" style="--layer: 5" title="bb6: ../instrument-coverage/coverage_of_if_else.rs:11:15: 11:28:
     11:15-11:28: StorageLive: StorageLive(_8)
     11:15-11:24: StorageLive: StorageLive(_9)
     11:15-11:24: Assign: _9 = _1
     11:15-11:28: Assign: _8 = Gt(move _9, const 2_i32)
     11:27-11:28: StorageDead: StorageDead(_9)
     11:15-11:28: FakeRead: FakeRead(ForMatchedPlace, _8)
-    11:12-18:6: SwitchInt: switchInt(_8) -&gt; [false: bb11, otherwise: bb10]"><span class="annotation">7⦊</span>countdown &gt; 2<span class="annotation">⦉7</span></span><span class="code even" style="--layer: 4" title="bb10: ../instrument-coverage/coverage_of_if_else.rs:11:12: 18:6:
-    11:12-18:6: FalseEdge: falseEdge -&gt; [real: bb12, imaginary: bb11]"> {</span></span>
-<span class="line"><span class="code even" style="--layer: 4" title="bb10: ../instrument-coverage/coverage_of_if_else.rs:11:12: 18:6:
-    11:12-18:6: FalseEdge: falseEdge -&gt; [real: bb12, imaginary: bb11]">        </span><span class="code odd" style="--layer: 5" title="bb22: ../instrument-coverage/coverage_of_if_else.rs:12:9: 14:10:
-    12:9-14:10: Assign: _10 = const ()
-    12:9-14:10: Goto: goto -&gt; bb24"><span class="annotation">22⦊</span></span><span class="code even" style="--layer: 6" title="bb23: ../instrument-coverage/coverage_of_if_else.rs:12:9: 14:10:
+    11:12-18:6: SwitchInt: switchInt(_8) -&gt; [false: bb10, otherwise: bb9]"><span class="annotation">6⦊</span>countdown &gt; 2<span class="annotation">⦉6</span></span><span class="code even" style="--layer: 4" title="bb9: ../instrument-coverage/coverage_of_if_else.rs:11:12: 18:6:
+    11:12-18:6: FalseEdge: falseEdge -&gt; [real: bb11, imaginary: bb10]"> {</span></span>
+<span class="line"><span class="code even" style="--layer: 4" title="bb9: ../instrument-coverage/coverage_of_if_else.rs:11:12: 18:6:
+    11:12-18:6: FalseEdge: falseEdge -&gt; [real: bb11, imaginary: bb10]">        </span><span class="code odd" style="--layer: 5" title="bb20: ../instrument-coverage/coverage_of_if_else.rs:12:9: 14:10:
+    12:9-14:10: FalseEdge: falseEdge -&gt; [real: bb22, imaginary: bb21]"><span class="annotation">20⦊</span></span><span class="code even" style="--layer: 6" title="bb22: ../instrument-coverage/coverage_of_if_else.rs:12:9: 14:10:
     13:13-13:26: Assign: _1 = const 0_i32
     12:61-14:10: Assign: _10 = const ()
-    12:9-14:10: Goto: goto -&gt; bb24"><span class="annotation">23⦊</span></span><span class="code even" style="--layer: 7" title="bb21: ../instrument-coverage/coverage_of_if_else.rs:12:9: 14:10:
-    12:9-14:10: FalseEdge: falseEdge -&gt; [real: bb23, imaginary: bb22]"><span class="annotation">21⦊</span>if </span><span class="code even" style="--layer: 8" title="bb14: ../instrument-coverage/coverage_of_if_else.rs:12:12: 12:60:
-    12:12-12:60: Assign: _11 = const false
-    12:12-12:60: Goto: goto -&gt; bb16"><span class="annotation">14⦊</span></span><span class="code even" style="--layer: 9" title="bb15: ../instrument-coverage/coverage_of_if_else.rs:12:12: 12:60:
+    12:9-14:10: Goto: goto -&gt; bb23"><span class="annotation">22⦊</span></span><span class="code even" style="--layer: 7" title="bb21: ../instrument-coverage/coverage_of_if_else.rs:12:9: 14:10:
+    12:9-14:10: Assign: _10 = const ()
+    12:9-14:10: Goto: goto -&gt; bb23"><span class="annotation">21⦊</span>if </span><span class="code even" style="--layer: 8" title="bb14: ../instrument-coverage/coverage_of_if_else.rs:12:12: 12:60:
     12:46-12:60: StorageLive: StorageLive(_17)
     12:46-12:55: StorageLive: StorageLive(_18)
     12:46-12:55: Assign: _18 = _1
     12:46-12:60: Assign: _17 = Ne(move _18, const 9_i32)
     12:59-12:60: StorageDead: StorageDead(_18)
-    12:12-12:60: SwitchInt: switchInt(move _17) -&gt; [false: bb14, otherwise: bb13]"><span class="annotation">15⦊</span></span><span class="code even" style="--layer: 10" title="bb16: ../instrument-coverage/coverage_of_if_else.rs:12:12: 12:60:
-    12:59-12:60: StorageDead: StorageDead(_17)
-    12:59-12:60: StorageDead: StorageDead(_12)
-    12:12-12:60: FakeRead: FakeRead(ForMatchedPlace, _11)
-    12:9-14:10: SwitchInt: switchInt(_11) -&gt; [false: bb22, otherwise: bb21]"><span class="annotation">16⦊</span></span><span class="code even" style="--layer: 11" title="bb13: ../instrument-coverage/coverage_of_if_else.rs:12:12: 12:60:
-    12:12-12:60: Assign: _11 = const true
-    12:12-12:60: Goto: goto -&gt; bb16"><span class="annotation">13⦊</span></span><span class="code even" style="--layer: 12" title="bb20: ../instrument-coverage/coverage_of_if_else.rs:12:12: 12:60:
-    12:41-12:42: StorageDead: StorageDead(_15)
-    12:41-12:42: StorageDead: StorageDead(_13)
-    12:12-12:60: SwitchInt: switchInt(move _12) -&gt; [false: bb15, otherwise: bb13]"><span class="annotation">20⦊</span></span><span class="code even" style="--layer: 13" title="bb12: ../instrument-coverage/coverage_of_if_else.rs:12:12: 12:60:
+    12:12-12:60: SwitchInt: switchInt(move _17) -&gt; [false: bb13, otherwise: bb12]"><span class="annotation">14⦊</span></span><span class="code even" style="--layer: 9" title="bb11: ../instrument-coverage/coverage_of_if_else.rs:12:12: 12:60:
     12:9-14:10: StorageLive: StorageLive(_10)
     12:12-12:60: StorageLive: StorageLive(_11)
     12:12-12:42: StorageLive: StorageLive(_12)
@@ -170,25 +159,43 @@
     12:12-12:21: Assign: _14 = _1
     12:12-12:25: Assign: _13 = Lt(move _14, const 1_i32)
     12:24-12:25: StorageDead: StorageDead(_14)
-    12:12-12:42: SwitchInt: switchInt(move _13) -&gt; [false: bb19, otherwise: bb17]"><span class="annotation">12⦊</span></span><span class="code even" style="--layer: 14" title="bb18: ../instrument-coverage/coverage_of_if_else.rs:12:12: 12:42:
-    12:12-12:42: Assign: _12 = const false
-    12:12-12:42: Goto: goto -&gt; bb20"><span class="annotation">18⦊</span></span><span class="code even" style="--layer: 15" title="bb19: ../instrument-coverage/coverage_of_if_else.rs:12:12: 12:42:
-    12:29-12:42: StorageLive: StorageLive(_15)
-    12:29-12:38: StorageLive: StorageLive(_16)
-    12:29-12:38: Assign: _16 = _1
-    12:29-12:42: Assign: _15 = Gt(move _16, const 5_i32)
-    12:41-12:42: StorageDead: StorageDead(_16)
-    12:12-12:42: SwitchInt: switchInt(move _15) -&gt; [false: bb18, otherwise: bb17]"><span class="annotation">19⦊</span></span><span class="code even" style="--layer: 16" title="bb17: ../instrument-coverage/coverage_of_if_else.rs:12:12: 12:42:
+    12:12-12:42: SwitchInt: switchInt(move _13) -&gt; [false: bb18, otherwise: bb16]"><span class="annotation">11⦊</span></span><span class="code even" style="--layer: 10" title="bb13: ../instrument-coverage/coverage_of_if_else.rs:12:12: 12:60:
+    12:12-12:60: Assign: _11 = const false
+    12:12-12:60: Goto: goto -&gt; bb15"><span class="annotation">13⦊</span></span><span class="code even" style="--layer: 11" title="bb19: ../instrument-coverage/coverage_of_if_else.rs:12:12: 12:60:
+    12:41-12:42: StorageDead: StorageDead(_15)
+    12:41-12:42: StorageDead: StorageDead(_13)
+    12:12-12:60: SwitchInt: switchInt(move _12) -&gt; [false: bb14, otherwise: bb12]"><span class="annotation">19⦊</span></span><span class="code even" style="--layer: 12" title="bb15: ../instrument-coverage/coverage_of_if_else.rs:12:12: 12:60:
+    12:59-12:60: StorageDead: StorageDead(_17)
+    12:59-12:60: StorageDead: StorageDead(_12)
+    12:12-12:60: FakeRead: FakeRead(ForMatchedPlace, _11)
+    12:9-14:10: SwitchInt: switchInt(_11) -&gt; [false: bb21, otherwise: bb20]"><span class="annotation">15⦊</span></span><span class="code even" style="--layer: 13" title="bb12: ../instrument-coverage/coverage_of_if_else.rs:12:12: 12:60:
+    12:12-12:60: Assign: _11 = const true
+    12:12-12:60: Goto: goto -&gt; bb15"><span class="annotation">12⦊</span></span><span class="code even" style="--layer: 14" title="bb16: ../instrument-coverage/coverage_of_if_else.rs:12:12: 12:42:
     12:12-12:42: Assign: _12 = const true
-    12:12-12:42: Goto: goto -&gt; bb20"><span class="annotation">17⦊</span>countdown &lt; 1 || countdown &gt; 5<span class="annotation">⦉17</span></span><span class="code even" style="--layer: 15" title="bb19: ../instrument-coverage/coverage_of_if_else.rs:12:12: 12:42:
+    12:12-12:42: Goto: goto -&gt; bb19"><span class="annotation">16⦊</span></span><span class="code even" style="--layer: 15" title="bb17: ../instrument-coverage/coverage_of_if_else.rs:12:12: 12:42:
+    12:12-12:42: Assign: _12 = const false
+    12:12-12:42: Goto: goto -&gt; bb19"><span class="annotation">17⦊</span></span><span class="code even" style="--layer: 16" title="bb18: ../instrument-coverage/coverage_of_if_else.rs:12:12: 12:42:
     12:29-12:42: StorageLive: StorageLive(_15)
     12:29-12:38: StorageLive: StorageLive(_16)
     12:29-12:38: Assign: _16 = _1
     12:29-12:42: Assign: _15 = Gt(move _16, const 5_i32)
     12:41-12:42: StorageDead: StorageDead(_16)
-    12:12-12:42: SwitchInt: switchInt(move _15) -&gt; [false: bb18, otherwise: bb17]"><span class="annotation">⦉19</span></span><span class="code even" style="--layer: 14" title="bb18: ../instrument-coverage/coverage_of_if_else.rs:12:12: 12:42:
+    12:12-12:42: SwitchInt: switchInt(move _15) -&gt; [false: bb17, otherwise: bb16]"><span class="annotation">18⦊</span>countdown &lt; 1 || countdown &gt; 5<span class="annotation">⦉18</span></span><span class="code even" style="--layer: 15" title="bb17: ../instrument-coverage/coverage_of_if_else.rs:12:12: 12:42:
     12:12-12:42: Assign: _12 = const false
-    12:12-12:42: Goto: goto -&gt; bb20"><span class="annotation">⦉18</span></span><span class="code even" style="--layer: 13" title="bb12: ../instrument-coverage/coverage_of_if_else.rs:12:12: 12:60:
+    12:12-12:42: Goto: goto -&gt; bb19"><span class="annotation">⦉17</span></span><span class="code even" style="--layer: 14" title="bb16: ../instrument-coverage/coverage_of_if_else.rs:12:12: 12:42:
+    12:12-12:42: Assign: _12 = const true
+    12:12-12:42: Goto: goto -&gt; bb19"><span class="annotation">⦉16</span></span><span class="code even" style="--layer: 13" title="bb12: ../instrument-coverage/coverage_of_if_else.rs:12:12: 12:60:
+    12:12-12:60: Assign: _11 = const true
+    12:12-12:60: Goto: goto -&gt; bb15"> || countdown != 9<span class="annotation">⦉12</span></span><span class="code even" style="--layer: 12" title="bb15: ../instrument-coverage/coverage_of_if_else.rs:12:12: 12:60:
+    12:59-12:60: StorageDead: StorageDead(_17)
+    12:59-12:60: StorageDead: StorageDead(_12)
+    12:12-12:60: FakeRead: FakeRead(ForMatchedPlace, _11)
+    12:9-14:10: SwitchInt: switchInt(_11) -&gt; [false: bb21, otherwise: bb20]"><span class="annotation">⦉15</span></span><span class="code even" style="--layer: 11" title="bb19: ../instrument-coverage/coverage_of_if_else.rs:12:12: 12:60:
+    12:41-12:42: StorageDead: StorageDead(_15)
+    12:41-12:42: StorageDead: StorageDead(_13)
+    12:12-12:60: SwitchInt: switchInt(move _12) -&gt; [false: bb14, otherwise: bb12]"><span class="annotation">⦉19</span></span><span class="code even" style="--layer: 10" title="bb13: ../instrument-coverage/coverage_of_if_else.rs:12:12: 12:60:
+    12:12-12:60: Assign: _11 = const false
+    12:12-12:60: Goto: goto -&gt; bb15"><span class="annotation">⦉13</span></span><span class="code even" style="--layer: 9" title="bb11: ../instrument-coverage/coverage_of_if_else.rs:12:12: 12:60:
     12:9-14:10: StorageLive: StorageLive(_10)
     12:12-12:60: StorageLive: StorageLive(_11)
     12:12-12:42: StorageLive: StorageLive(_12)
@@ -197,108 +204,66 @@
     12:12-12:21: Assign: _14 = _1
     12:12-12:25: Assign: _13 = Lt(move _14, const 1_i32)
     12:24-12:25: StorageDead: StorageDead(_14)
-    12:12-12:42: SwitchInt: switchInt(move _13) -&gt; [false: bb19, otherwise: bb17]"> || countdown != 9<span class="annotation">⦉12</span></span><span class="code even" style="--layer: 12" title="bb20: ../instrument-coverage/coverage_of_if_else.rs:12:12: 12:60:
-    12:41-12:42: StorageDead: StorageDead(_15)
-    12:41-12:42: StorageDead: StorageDead(_13)
-    12:12-12:60: SwitchInt: switchInt(move _12) -&gt; [false: bb15, otherwise: bb13]"><span class="annotation">⦉20</span></span><span class="code even" style="--layer: 11" title="bb13: ../instrument-coverage/coverage_of_if_else.rs:12:12: 12:60:
-    12:12-12:60: Assign: _11 = const true
-    12:12-12:60: Goto: goto -&gt; bb16"><span class="annotation">⦉13</span></span><span class="code even" style="--layer: 10" title="bb16: ../instrument-coverage/coverage_of_if_else.rs:12:12: 12:60:
-    12:59-12:60: StorageDead: StorageDead(_17)
-    12:59-12:60: StorageDead: StorageDead(_12)
-    12:12-12:60: FakeRead: FakeRead(ForMatchedPlace, _11)
-    12:9-14:10: SwitchInt: switchInt(_11) -&gt; [false: bb22, otherwise: bb21]"><span class="annotation">⦉16</span></span><span class="code even" style="--layer: 9" title="bb15: ../instrument-coverage/coverage_of_if_else.rs:12:12: 12:60:
+    12:12-12:42: SwitchInt: switchInt(move _13) -&gt; [false: bb18, otherwise: bb16]"><span class="annotation">⦉11</span></span><span class="code even" style="--layer: 8" title="bb14: ../instrument-coverage/coverage_of_if_else.rs:12:12: 12:60:
     12:46-12:60: StorageLive: StorageLive(_17)
     12:46-12:55: StorageLive: StorageLive(_18)
     12:46-12:55: Assign: _18 = _1
     12:46-12:60: Assign: _17 = Ne(move _18, const 9_i32)
     12:59-12:60: StorageDead: StorageDead(_18)
-    12:12-12:60: SwitchInt: switchInt(move _17) -&gt; [false: bb14, otherwise: bb13]"><span class="annotation">⦉15</span></span><span class="code even" style="--layer: 8" title="bb14: ../instrument-coverage/coverage_of_if_else.rs:12:12: 12:60:
-    12:12-12:60: Assign: _11 = const false
-    12:12-12:60: Goto: goto -&gt; bb16"><span class="annotation">⦉14</span></span><span class="code even" style="--layer: 7" title="bb21: ../instrument-coverage/coverage_of_if_else.rs:12:9: 14:10:
-    12:9-14:10: FalseEdge: falseEdge -&gt; [real: bb23, imaginary: bb22]"> {</span></span>
+    12:12-12:60: SwitchInt: switchInt(move _17) -&gt; [false: bb13, otherwise: bb12]"><span class="annotation">⦉14</span></span><span class="code even" style="--layer: 7" title="bb21: ../instrument-coverage/coverage_of_if_else.rs:12:9: 14:10:
+    12:9-14:10: Assign: _10 = const ()
+    12:9-14:10: Goto: goto -&gt; bb23"> {</span></span>
 <span class="line"><span class="code even" style="--layer: 7" title="bb21: ../instrument-coverage/coverage_of_if_else.rs:12:9: 14:10:
-    12:9-14:10: FalseEdge: falseEdge -&gt; [real: bb23, imaginary: bb22]">            countdown = 0;</span></span>
+    12:9-14:10: Assign: _10 = const ()
+    12:9-14:10: Goto: goto -&gt; bb23">            countdown = 0;</span></span>
 <span class="line"><span class="code even" style="--layer: 7" title="bb21: ../instrument-coverage/coverage_of_if_else.rs:12:9: 14:10:
-    12:9-14:10: FalseEdge: falseEdge -&gt; [real: bb23, imaginary: bb22]">        </span><span class="code odd" style="--layer: 8" title="bb24: ../instrument-coverage/coverage_of_if_else.rs:14:9: 15:23:
+    12:9-14:10: Assign: _10 = const ()
+    12:9-14:10: Goto: goto -&gt; bb23">        </span><span class="code odd" style="--layer: 8" title="bb23: ../instrument-coverage/coverage_of_if_else.rs:14:9: 15:23:
     14:9-14:10: StorageDead: StorageDead(_11)
     14:9-14:10: StorageDead: StorageDead(_10)
     15:9-15:23: Assign: _19 = CheckedSub(_1, const 5_i32)
-    15:9-15:23: Assert: assert(!move (_19.1: bool), &quot;attempt to compute `{} - {}`, which would overflow&quot;, _1, const 5_i32) -&gt; [success: bb25, unwind: bb1]"><span class="annotation">24⦊</span>}</span><span class="code odd" style="--layer: 5" title="bb22: ../instrument-coverage/coverage_of_if_else.rs:12:9: 14:10:
-    12:9-14:10: Assign: _10 = const ()
-    12:9-14:10: Goto: goto -&gt; bb24"><span class="annotation">⦉22</span></span><span class="code even" style="--layer: 6" title="bb23: ../instrument-coverage/coverage_of_if_else.rs:12:9: 14:10:
+    15:9-15:23: Assert: assert(!move (_19.1: bool), &quot;attempt to compute `{} - {}`, which would overflow&quot;, _1, const 5_i32) -&gt; [success: bb24, unwind: bb78]"><span class="annotation">23⦊</span>}</span><span class="code odd" style="--layer: 5" title="bb20: ../instrument-coverage/coverage_of_if_else.rs:12:9: 14:10:
+    12:9-14:10: FalseEdge: falseEdge -&gt; [real: bb22, imaginary: bb21]"><span class="annotation">⦉20</span></span><span class="code even" style="--layer: 6" title="bb22: ../instrument-coverage/coverage_of_if_else.rs:12:9: 14:10:
     13:13-13:26: Assign: _1 = const 0_i32
     12:61-14:10: Assign: _10 = const ()
-    12:9-14:10: Goto: goto -&gt; bb24"><span class="annotation">⦉23</span></span><span class="code even" style="--layer: 7" title="bb21: ../instrument-coverage/coverage_of_if_else.rs:12:9: 14:10:
-    12:9-14:10: FalseEdge: falseEdge -&gt; [real: bb23, imaginary: bb22]"><span class="annotation">⦉21</span></span><span class="code even" style="--layer: 7" title="bb21: ../instrument-coverage/coverage_of_if_else.rs:12:9: 14:10:
-    12:9-14:10: FalseEdge: falseEdge -&gt; [real: bb23, imaginary: bb22]"><span class="annotation">⦉21</span></span><span class="code odd" style="--layer: 8" title="bb24: ../instrument-coverage/coverage_of_if_else.rs:14:9: 15:23:
+    12:9-14:10: Goto: goto -&gt; bb23"><span class="annotation">⦉22</span></span><span class="code even" style="--layer: 7" title="bb21: ../instrument-coverage/coverage_of_if_else.rs:12:9: 14:10:
+    12:9-14:10: Assign: _10 = const ()
+    12:9-14:10: Goto: goto -&gt; bb23"><span class="annotation">⦉21</span></span><span class="code even" style="--layer: 7" title="bb21: ../instrument-coverage/coverage_of_if_else.rs:12:9: 14:10:
+    12:9-14:10: Assign: _10 = const ()
+    12:9-14:10: Goto: goto -&gt; bb23"><span class="annotation">⦉21</span></span><span class="code odd" style="--layer: 8" title="bb23: ../instrument-coverage/coverage_of_if_else.rs:14:9: 15:23:
     14:9-14:10: StorageDead: StorageDead(_11)
     14:9-14:10: StorageDead: StorageDead(_10)
     15:9-15:23: Assign: _19 = CheckedSub(_1, const 5_i32)
-    15:9-15:23: Assert: assert(!move (_19.1: bool), &quot;attempt to compute `{} - {}`, which would overflow&quot;, _1, const 5_i32) -&gt; [success: bb25, unwind: bb1]"></span></span>
-<span class="line"><span class="code odd" style="--layer: 8" title="bb24: ../instrument-coverage/coverage_of_if_else.rs:14:9: 15:23:
+    15:9-15:23: Assert: assert(!move (_19.1: bool), &quot;attempt to compute `{} - {}`, which would overflow&quot;, _1, const 5_i32) -&gt; [success: bb24, unwind: bb78]"></span></span>
+<span class="line"><span class="code odd" style="--layer: 8" title="bb23: ../instrument-coverage/coverage_of_if_else.rs:14:9: 15:23:
     14:9-14:10: StorageDead: StorageDead(_11)
     14:9-14:10: StorageDead: StorageDead(_10)
     15:9-15:23: Assign: _19 = CheckedSub(_1, const 5_i32)
-    15:9-15:23: Assert: assert(!move (_19.1: bool), &quot;attempt to compute `{} - {}`, which would overflow&quot;, _1, const 5_i32) -&gt; [success: bb25, unwind: bb1]">        countdown -= 5<span class="annotation">⦉24</span></span><span class="code even" style="--layer: 4" title="bb10: ../instrument-coverage/coverage_of_if_else.rs:11:12: 18:6:
-    11:12-18:6: FalseEdge: falseEdge -&gt; [real: bb12, imaginary: bb11]">;</span></span>
-<span class="line"><span class="code even" style="--layer: 4" title="bb10: ../instrument-coverage/coverage_of_if_else.rs:11:12: 18:6:
-    11:12-18:6: FalseEdge: falseEdge -&gt; [real: bb12, imaginary: bb11]">    } else {</span></span>
-<span class="line"><span class="code even" style="--layer: 4" title="bb10: ../instrument-coverage/coverage_of_if_else.rs:11:12: 18:6:
-    11:12-18:6: FalseEdge: falseEdge -&gt; [real: bb12, imaginary: bb11]">        </span><span class="code even" style="--layer: 5" title="bb27: ../instrument-coverage/coverage_of_if_else.rs:17:9: 51:2:
-    51:1-51:2: StorageDead: StorageDead(_1)
-    17:9-17:15: Goto: goto -&gt; bb26"><span class="annotation">27⦊</span></span><span class="code even" style="--layer: 6" title="bb11: ../instrument-coverage/coverage_of_if_else.rs:17:9: 18:6:
-    17:9-17:15: Assign: _0 = const ()
+    15:9-15:23: Assert: assert(!move (_19.1: bool), &quot;attempt to compute `{} - {}`, which would overflow&quot;, _1, const 5_i32) -&gt; [success: bb24, unwind: bb78]">        countdown -= 5<span class="annotation">⦉23</span></span><span class="code even" style="--layer: 4" title="bb9: ../instrument-coverage/coverage_of_if_else.rs:11:12: 18:6:
+    11:12-18:6: FalseEdge: falseEdge -&gt; [real: bb11, imaginary: bb10]">;</span></span>
+<span class="line"><span class="code even" style="--layer: 4" title="bb9: ../instrument-coverage/coverage_of_if_else.rs:11:12: 18:6:
+    11:12-18:6: FalseEdge: falseEdge -&gt; [real: bb11, imaginary: bb10]">    } else {</span></span>
+<span class="line"><span class="code even" style="--layer: 4" title="bb9: ../instrument-coverage/coverage_of_if_else.rs:11:12: 18:6:
+    11:12-18:6: FalseEdge: falseEdge -&gt; [real: bb11, imaginary: bb10]">        return;</span></span>
+<span class="line"><span class="code even" style="--layer: 4" title="bb9: ../instrument-coverage/coverage_of_if_else.rs:11:12: 18:6:
+    11:12-18:6: FalseEdge: falseEdge -&gt; [real: bb11, imaginary: bb10]">    }<span class="annotation">⦉9</span></span><span class="code even" style="--layer: 3" title="bb24: ../instrument-coverage/coverage_of_if_else.rs:9:5: 18:6:
+    15:9-15:23: Assign: _1 = move (_19.0: i32)
+    11:29-16:6: Assign: _4 = const ()
     18:5-18:6: StorageDead: StorageDead(_8)
-    18:5-18:6: StorageDead: StorageDead(_5)
-    18:5-18:6: StorageDead: StorageDead(_4)
-    17:9-17:15: Goto: goto -&gt; bb27"><span class="annotation">11⦊</span>return;</span></span>
-<span class="line"><span class="code even" style="--layer: 6" title="bb11: ../instrument-coverage/coverage_of_if_else.rs:17:9: 18:6:
-    17:9-17:15: Assign: _0 = const ()
-    18:5-18:6: StorageDead: StorageDead(_8)
-    18:5-18:6: StorageDead: StorageDead(_5)
-    18:5-18:6: StorageDead: StorageDead(_4)
-    17:9-17:15: Goto: goto -&gt; bb27">    }<span class="annotation">⦉11</span></span><span><span class="code odd" style="--layer: 1" title="bb6: ../instrument-coverage/coverage_of_if_else.rs:9:5: 18:6:
-    9:5-18:6: FalseEdge: falseEdge -&gt; [real: bb8, imaginary: bb7]"><span class="annotation">⦉6</span></span></span><span class="code even" style="--layer: 2" title="bb9: ../instrument-coverage/coverage_of_if_else.rs:9:5: 18:6:
+    9:5-18:6: Goto: goto -&gt; bb25"><span class="annotation">⦉24</span></span><span class="code even" style="--layer: 2" title="bb8: ../instrument-coverage/coverage_of_if_else.rs:9:5: 18:6:
     10:9-10:23: Assign: _1 = move (_7.0: i32)
     9:22-11:6: Assign: _4 = const ()
-    9:5-18:6: Goto: goto -&gt; bb28"><span class="annotation">⦉9</span></span><span class="code even" style="--layer: 3" title="bb25: ../instrument-coverage/coverage_of_if_else.rs:9:5: 18:6:
-    15:9-15:23: Assign: _1 = move (_19.0: i32)
-    11:29-16:6: Assign: _4 = const ()
-    18:5-18:6: StorageDead: StorageDead(_8)
-    9:5-18:6: Goto: goto -&gt; bb28"><span class="annotation">⦉25</span></span><span class="code even" style="--layer: 3" title="bb25: ../instrument-coverage/coverage_of_if_else.rs:9:5: 18:6:
-    15:9-15:23: Assign: _1 = move (_19.0: i32)
-    11:29-16:6: Assign: _4 = const ()
-    18:5-18:6: StorageDead: StorageDead(_8)
-    9:5-18:6: Goto: goto -&gt; bb28"><span class="annotation">⦉25</span></span><span class="code even" style="--layer: 3" title="bb25: ../instrument-coverage/coverage_of_if_else.rs:9:5: 18:6:
-    15:9-15:23: Assign: _1 = move (_19.0: i32)
-    11:29-16:6: Assign: _4 = const ()
-    18:5-18:6: StorageDead: StorageDead(_8)
-    9:5-18:6: Goto: goto -&gt; bb28"><span class="annotation">⦉25</span></span><span class="code even" style="--layer: 4" title="bb10: ../instrument-coverage/coverage_of_if_else.rs:11:12: 18:6:
-    11:12-18:6: FalseEdge: falseEdge -&gt; [real: bb12, imaginary: bb11]"><span class="annotation">⦉10</span></span><span class="code even" style="--layer: 4" title="bb10: ../instrument-coverage/coverage_of_if_else.rs:11:12: 18:6:
-    11:12-18:6: FalseEdge: falseEdge -&gt; [real: bb12, imaginary: bb11]"><span class="annotation">⦉10</span></span><span class="code even" style="--layer: 4" title="bb10: ../instrument-coverage/coverage_of_if_else.rs:11:12: 18:6:
-    11:12-18:6: FalseEdge: falseEdge -&gt; [real: bb12, imaginary: bb11]"><span class="annotation">⦉10</span></span><span class="code even" style="--layer: 6" title="bb11: ../instrument-coverage/coverage_of_if_else.rs:17:9: 18:6:
-    17:9-17:15: Assign: _0 = const ()
-    18:5-18:6: StorageDead: StorageDead(_8)
-    18:5-18:6: StorageDead: StorageDead(_5)
-    18:5-18:6: StorageDead: StorageDead(_4)
-    17:9-17:15: Goto: goto -&gt; bb27"><span class="annotation">⦉11</span></span><span class="code even" style="--layer: 5" title="bb27: ../instrument-coverage/coverage_of_if_else.rs:17:9: 51:2:
-    51:1-51:2: StorageDead: StorageDead(_1)
-    17:9-17:15: Goto: goto -&gt; bb26"></span></span>
-<span class="line"><span class="code even" style="--layer: 5" title="bb27: ../instrument-coverage/coverage_of_if_else.rs:17:9: 51:2:
-    51:1-51:2: StorageDead: StorageDead(_1)
-    17:9-17:15: Goto: goto -&gt; bb26"></span></span>
-<span class="line"><span class="code even" style="--layer: 5" title="bb27: ../instrument-coverage/coverage_of_if_else.rs:17:9: 51:2:
-    51:1-51:2: StorageDead: StorageDead(_1)
-    17:9-17:15: Goto: goto -&gt; bb26">    let mut countdown = 0;</span></span>
-<span class="line"><span class="code even" style="--layer: 5" title="bb27: ../instrument-coverage/coverage_of_if_else.rs:17:9: 51:2:
-    51:1-51:2: StorageDead: StorageDead(_1)
-    17:9-17:15: Goto: goto -&gt; bb26">    </span><span class="code odd" style="--layer: 6" title="bb30: ../instrument-coverage/coverage_of_if_else.rs:21:5: 23:6:
+    9:5-18:6: Goto: goto -&gt; bb25"><span class="annotation">⦉8</span></span><span><span class="code odd" style="--layer: 1" title="bb5: ../instrument-coverage/coverage_of_if_else.rs:9:5: 18:6:
+    9:5-18:6: FalseEdge: falseEdge -&gt; [real: bb7, imaginary: bb6]"><span class="annotation">⦉5</span></span></span><span class="code" style="--layer: 0"></span></span>
+<span class="line"><span class="code" style="--layer: 0"></span></span>
+<span class="line"><span class="code" style="--layer: 0">    let mut countdown = 0;</span></span>
+<span class="line"><span class="code" style="--layer: 0">    </span><span><span class="code even" style="--layer: 1" title="bb27: ../instrument-coverage/coverage_of_if_else.rs:21:5: 23:6:
     21:5-23:6: Assign: _22 = const ()
-    21:5-23:6: Goto: goto -&gt; bb32"><span class="annotation">30⦊</span></span><span class="code even" style="--layer: 7" title="bb31: ../instrument-coverage/coverage_of_if_else.rs:21:5: 23:6:
+    21:5-23:6: Goto: goto -&gt; bb29"><span class="annotation">27⦊</span></span></span><span class="code even" style="--layer: 2" title="bb28: ../instrument-coverage/coverage_of_if_else.rs:21:5: 23:6:
     22:9-22:23: Assign: _21 = const 10_i32
     21:13-23:6: Assign: _22 = const ()
-    21:5-23:6: Goto: goto -&gt; bb32"><span class="annotation">31⦊</span></span><span class="code even" style="--layer: 8" title="bb29: ../instrument-coverage/coverage_of_if_else.rs:21:5: 23:6:
-    21:5-23:6: FalseEdge: falseEdge -&gt; [real: bb31, imaginary: bb30]"><span class="annotation">29⦊</span>if </span><span class="code even" style="--layer: 9" title="bb28: ../instrument-coverage/coverage_of_if_else.rs:21:8: 21:12:
+    21:5-23:6: Goto: goto -&gt; bb29"><span class="annotation">28⦊</span></span><span class="code even" style="--layer: 3" title="bb26: ../instrument-coverage/coverage_of_if_else.rs:21:5: 23:6:
+    21:5-23:6: FalseEdge: falseEdge -&gt; [real: bb28, imaginary: bb27]"><span class="annotation">26⦊</span>if </span><span class="code even" style="--layer: 4" title="bb25: ../instrument-coverage/coverage_of_if_else.rs:21:8: 21:12:
     18:5-18:6: StorageDead: StorageDead(_5)
     18:5-18:6: StorageDead: StorageDead(_4)
     20:9-20:22: StorageLive: StorageLive(_21)
@@ -308,33 +273,27 @@
     21:8-21:12: StorageLive: StorageLive(_23)
     21:8-21:12: Assign: _23 = const true
     21:8-21:12: FakeRead: FakeRead(ForMatchedPlace, _23)
-    21:5-23:6: SwitchInt: switchInt(_23) -&gt; [false: bb30, otherwise: bb29]"><span class="annotation">28⦊</span>true<span class="annotation">⦉28</span></span><span class="code even" style="--layer: 8" title="bb29: ../instrument-coverage/coverage_of_if_else.rs:21:5: 23:6:
-    21:5-23:6: FalseEdge: falseEdge -&gt; [real: bb31, imaginary: bb30]"> {</span></span>
-<span class="line"><span class="code even" style="--layer: 8" title="bb29: ../instrument-coverage/coverage_of_if_else.rs:21:5: 23:6:
-    21:5-23:6: FalseEdge: falseEdge -&gt; [real: bb31, imaginary: bb30]">        countdown = 10;</span></span>
-<span class="line"><span class="code even" style="--layer: 8" title="bb29: ../instrument-coverage/coverage_of_if_else.rs:21:5: 23:6:
-    21:5-23:6: FalseEdge: falseEdge -&gt; [real: bb31, imaginary: bb30]">    }<span class="annotation">⦉29</span></span><span class="code even" style="--layer: 7" title="bb31: ../instrument-coverage/coverage_of_if_else.rs:21:5: 23:6:
+    21:5-23:6: SwitchInt: switchInt(_23) -&gt; [false: bb27, otherwise: bb26]"><span class="annotation">25⦊</span>true<span class="annotation">⦉25</span></span><span class="code even" style="--layer: 3" title="bb26: ../instrument-coverage/coverage_of_if_else.rs:21:5: 23:6:
+    21:5-23:6: FalseEdge: falseEdge -&gt; [real: bb28, imaginary: bb27]"> {</span></span>
+<span class="line"><span class="code even" style="--layer: 3" title="bb26: ../instrument-coverage/coverage_of_if_else.rs:21:5: 23:6:
+    21:5-23:6: FalseEdge: falseEdge -&gt; [real: bb28, imaginary: bb27]">        countdown = 10;</span></span>
+<span class="line"><span class="code even" style="--layer: 3" title="bb26: ../instrument-coverage/coverage_of_if_else.rs:21:5: 23:6:
+    21:5-23:6: FalseEdge: falseEdge -&gt; [real: bb28, imaginary: bb27]">    }<span class="annotation">⦉26</span></span><span class="code even" style="--layer: 2" title="bb28: ../instrument-coverage/coverage_of_if_else.rs:21:5: 23:6:
     22:9-22:23: Assign: _21 = const 10_i32
     21:13-23:6: Assign: _22 = const ()
-    21:5-23:6: Goto: goto -&gt; bb32"><span class="annotation">⦉31</span></span><span class="code odd" style="--layer: 6" title="bb30: ../instrument-coverage/coverage_of_if_else.rs:21:5: 23:6:
+    21:5-23:6: Goto: goto -&gt; bb29"><span class="annotation">⦉28</span></span><span><span class="code even" style="--layer: 1" title="bb27: ../instrument-coverage/coverage_of_if_else.rs:21:5: 23:6:
     21:5-23:6: Assign: _22 = const ()
-    21:5-23:6: Goto: goto -&gt; bb32"><span class="annotation">⦉30</span></span><span class="code even" style="--layer: 5" title="bb27: ../instrument-coverage/coverage_of_if_else.rs:17:9: 51:2:
-    51:1-51:2: StorageDead: StorageDead(_1)
-    17:9-17:15: Goto: goto -&gt; bb26"></span></span>
-<span class="line"><span class="code even" style="--layer: 5" title="bb27: ../instrument-coverage/coverage_of_if_else.rs:17:9: 51:2:
-    51:1-51:2: StorageDead: StorageDead(_1)
-    17:9-17:15: Goto: goto -&gt; bb26"></span></span>
-<span class="line"><span class="code even" style="--layer: 5" title="bb27: ../instrument-coverage/coverage_of_if_else.rs:17:9: 51:2:
-    51:1-51:2: StorageDead: StorageDead(_1)
-    17:9-17:15: Goto: goto -&gt; bb26">    </span><span class="code even" style="--layer: 6" title="bb33: ../instrument-coverage/coverage_of_if_else.rs:25:5: 34:6:
-    25:5-34:6: FalseEdge: falseEdge -&gt; [real: bb35, imaginary: bb34]"><span class="annotation">33⦊</span></span><span class="code even" style="--layer: 7" title="bb52: ../instrument-coverage/coverage_of_if_else.rs:25:5: 34:6:
+    21:5-23:6: Goto: goto -&gt; bb29"><span class="annotation">⦉27</span></span></span><span class="code" style="--layer: 0"></span></span>
+<span class="line"><span class="code" style="--layer: 0"></span></span>
+<span class="line"><span class="code" style="--layer: 0">    </span><span><span class="code odd" style="--layer: 1" title="bb49: ../instrument-coverage/coverage_of_if_else.rs:25:5: 34:6:
     31:9-31:23: Assign: _21 = move (_39.0: i32)
     27:29-32:6: Assign: _24 = const ()
     34:5-34:6: StorageDead: StorageDead(_28)
-    25:5-34:6: Goto: goto -&gt; bb53"><span class="annotation">52⦊</span></span><span class="code even" style="--layer: 8" title="bb36: ../instrument-coverage/coverage_of_if_else.rs:25:5: 34:6:
+    25:5-34:6: Goto: goto -&gt; bb50"><span class="annotation">49⦊</span></span></span><span class="code even" style="--layer: 2" title="bb33: ../instrument-coverage/coverage_of_if_else.rs:25:5: 34:6:
     26:9-26:23: Assign: _21 = move (_27.0: i32)
     25:22-27:6: Assign: _24 = const ()
-    25:5-34:6: Goto: goto -&gt; bb53"><span class="annotation">36⦊</span>if </span><span class="code even" style="--layer: 9" title="bb32: ../instrument-coverage/coverage_of_if_else.rs:25:8: 25:21:
+    25:5-34:6: Goto: goto -&gt; bb50"><span class="annotation">33⦊</span></span><span class="code even" style="--layer: 3" title="bb30: ../instrument-coverage/coverage_of_if_else.rs:25:5: 34:6:
+    25:5-34:6: FalseEdge: falseEdge -&gt; [real: bb32, imaginary: bb31]"><span class="annotation">30⦊</span>if </span><span class="code even" style="--layer: 4" title="bb29: ../instrument-coverage/coverage_of_if_else.rs:25:8: 25:21:
     23:5-23:6: StorageDead: StorageDead(_23)
     23:5-23:6: StorageDead: StorageDead(_22)
     25:5-34:6: StorageLive: StorageLive(_24)
@@ -344,40 +303,47 @@
     25:8-25:21: Assign: _25 = Gt(move _26, const 7_i32)
     25:20-25:21: StorageDead: StorageDead(_26)
     25:8-25:21: FakeRead: FakeRead(ForMatchedPlace, _25)
-    25:5-34:6: SwitchInt: switchInt(_25) -&gt; [false: bb34, otherwise: bb33]"><span class="annotation">32⦊</span>countdown &gt; 7<span class="annotation">⦉32</span></span><span class="code even" style="--layer: 8" title="bb36: ../instrument-coverage/coverage_of_if_else.rs:25:5: 34:6:
-    26:9-26:23: Assign: _21 = move (_27.0: i32)
-    25:22-27:6: Assign: _24 = const ()
-    25:5-34:6: Goto: goto -&gt; bb53"> {</span></span>
-<span class="line"><span class="code even" style="--layer: 8" title="bb36: ../instrument-coverage/coverage_of_if_else.rs:25:5: 34:6:
-    26:9-26:23: Assign: _21 = move (_27.0: i32)
-    25:22-27:6: Assign: _24 = const ()
-    25:5-34:6: Goto: goto -&gt; bb53">        </span><span class="code odd" style="--layer: 9" title="bb35: ../instrument-coverage/coverage_of_if_else.rs:26:9: 26:23:
+    25:5-34:6: SwitchInt: switchInt(_25) -&gt; [false: bb31, otherwise: bb30]"><span class="annotation">29⦊</span>countdown &gt; 7<span class="annotation">⦉29</span></span><span class="code even" style="--layer: 3" title="bb30: ../instrument-coverage/coverage_of_if_else.rs:25:5: 34:6:
+    25:5-34:6: FalseEdge: falseEdge -&gt; [real: bb32, imaginary: bb31]"> {</span></span>
+<span class="line"><span class="code even" style="--layer: 3" title="bb30: ../instrument-coverage/coverage_of_if_else.rs:25:5: 34:6:
+    25:5-34:6: FalseEdge: falseEdge -&gt; [real: bb32, imaginary: bb31]">        </span><span class="code odd" style="--layer: 4" title="bb32: ../instrument-coverage/coverage_of_if_else.rs:26:9: 26:23:
     26:9-26:23: Assign: _27 = CheckedSub(_21, const 4_i32)
-    26:9-26:23: Assert: assert(!move (_27.1: bool), &quot;attempt to compute `{} - {}`, which would overflow&quot;, _21, const 4_i32) -&gt; [success: bb36, unwind: bb1]"><span class="annotation">35⦊</span>countdown -= 4<span class="annotation">⦉35</span></span><span class="code even" style="--layer: 8" title="bb36: ../instrument-coverage/coverage_of_if_else.rs:25:5: 34:6:
-    26:9-26:23: Assign: _21 = move (_27.0: i32)
-    25:22-27:6: Assign: _24 = const ()
-    25:5-34:6: Goto: goto -&gt; bb53">;</span></span>
-<span class="line"><span class="code even" style="--layer: 8" title="bb36: ../instrument-coverage/coverage_of_if_else.rs:25:5: 34:6:
-    26:9-26:23: Assign: _21 = move (_27.0: i32)
-    25:22-27:6: Assign: _24 = const ()
-    25:5-34:6: Goto: goto -&gt; bb53">    } else </span><span class="code even" style="--layer: 9" title="bb37: ../instrument-coverage/coverage_of_if_else.rs:27:12: 34:6:
-    27:12-34:6: FalseEdge: falseEdge -&gt; [real: bb39, imaginary: bb38]"><span class="annotation">37⦊</span>if </span><span class="code even" style="--layer: 10" title="bb34: ../instrument-coverage/coverage_of_if_else.rs:27:15: 27:28:
+    26:9-26:23: Assert: assert(!move (_27.1: bool), &quot;attempt to compute `{} - {}`, which would overflow&quot;, _21, const 4_i32) -&gt; [success: bb33, unwind: bb78]"><span class="annotation">32⦊</span>countdown -= 4<span class="annotation">⦉32</span></span><span class="code even" style="--layer: 3" title="bb30: ../instrument-coverage/coverage_of_if_else.rs:25:5: 34:6:
+    25:5-34:6: FalseEdge: falseEdge -&gt; [real: bb32, imaginary: bb31]">;</span></span>
+<span class="line"><span class="code even" style="--layer: 3" title="bb30: ../instrument-coverage/coverage_of_if_else.rs:25:5: 34:6:
+    25:5-34:6: FalseEdge: falseEdge -&gt; [real: bb32, imaginary: bb31]">    } else </span><span class="code even" style="--layer: 4" title="bb34: ../instrument-coverage/coverage_of_if_else.rs:27:12: 34:6:
+    27:12-34:6: FalseEdge: falseEdge -&gt; [real: bb36, imaginary: bb35]"><span class="annotation">34⦊</span>if </span><span class="code even" style="--layer: 5" title="bb31: ../instrument-coverage/coverage_of_if_else.rs:27:15: 27:28:
     27:15-27:28: StorageLive: StorageLive(_28)
     27:15-27:24: StorageLive: StorageLive(_29)
     27:15-27:24: Assign: _29 = _21
     27:15-27:28: Assign: _28 = Gt(move _29, const 2_i32)
     27:27-27:28: StorageDead: StorageDead(_29)
     27:15-27:28: FakeRead: FakeRead(ForMatchedPlace, _28)
-    27:12-34:6: SwitchInt: switchInt(_28) -&gt; [false: bb38, otherwise: bb37]"><span class="annotation">34⦊</span>countdown &gt; 2<span class="annotation">⦉34</span></span><span class="code even" style="--layer: 9" title="bb37: ../instrument-coverage/coverage_of_if_else.rs:27:12: 34:6:
-    27:12-34:6: FalseEdge: falseEdge -&gt; [real: bb39, imaginary: bb38]"> {</span></span>
-<span class="line"><span class="code even" style="--layer: 9" title="bb37: ../instrument-coverage/coverage_of_if_else.rs:27:12: 34:6:
-    27:12-34:6: FalseEdge: falseEdge -&gt; [real: bb39, imaginary: bb38]">        </span><span class="code odd" style="--layer: 10" title="bb48: ../instrument-coverage/coverage_of_if_else.rs:28:9: 30:10:
-    28:9-30:10: FalseEdge: falseEdge -&gt; [real: bb50, imaginary: bb49]"><span class="annotation">48⦊</span></span><span class="code even" style="--layer: 11" title="bb50: ../instrument-coverage/coverage_of_if_else.rs:28:9: 30:10:
+    27:12-34:6: SwitchInt: switchInt(_28) -&gt; [false: bb35, otherwise: bb34]"><span class="annotation">31⦊</span>countdown &gt; 2<span class="annotation">⦉31</span></span><span class="code even" style="--layer: 4" title="bb34: ../instrument-coverage/coverage_of_if_else.rs:27:12: 34:6:
+    27:12-34:6: FalseEdge: falseEdge -&gt; [real: bb36, imaginary: bb35]"> {</span></span>
+<span class="line"><span class="code even" style="--layer: 4" title="bb34: ../instrument-coverage/coverage_of_if_else.rs:27:12: 34:6:
+    27:12-34:6: FalseEdge: falseEdge -&gt; [real: bb36, imaginary: bb35]">        </span><span class="code odd" style="--layer: 5" title="bb46: ../instrument-coverage/coverage_of_if_else.rs:28:9: 30:10:
+    28:9-30:10: Assign: _30 = const ()
+    28:9-30:10: Goto: goto -&gt; bb48"><span class="annotation">46⦊</span></span><span class="code even" style="--layer: 6" title="bb47: ../instrument-coverage/coverage_of_if_else.rs:28:9: 30:10:
     29:13-29:26: Assign: _21 = const 0_i32
     28:61-30:10: Assign: _30 = const ()
-    28:9-30:10: Goto: goto -&gt; bb51"><span class="annotation">50⦊</span></span><span class="code even" style="--layer: 12" title="bb49: ../instrument-coverage/coverage_of_if_else.rs:28:9: 30:10:
-    28:9-30:10: Assign: _30 = const ()
-    28:9-30:10: Goto: goto -&gt; bb51"><span class="annotation">49⦊</span>if </span><span class="code even" style="--layer: 13" title="bb39: ../instrument-coverage/coverage_of_if_else.rs:28:12: 28:60:
+    28:9-30:10: Goto: goto -&gt; bb48"><span class="annotation">47⦊</span></span><span class="code even" style="--layer: 7" title="bb45: ../instrument-coverage/coverage_of_if_else.rs:28:9: 30:10:
+    28:9-30:10: FalseEdge: falseEdge -&gt; [real: bb47, imaginary: bb46]"><span class="annotation">45⦊</span>if </span><span class="code even" style="--layer: 8" title="bb44: ../instrument-coverage/coverage_of_if_else.rs:28:12: 28:60:
+    28:41-28:42: StorageDead: StorageDead(_35)
+    28:41-28:42: StorageDead: StorageDead(_33)
+    28:12-28:60: SwitchInt: switchInt(move _32) -&gt; [false: bb39, otherwise: bb37]"><span class="annotation">44⦊</span></span><span class="code even" style="--layer: 9" title="bb38: ../instrument-coverage/coverage_of_if_else.rs:28:12: 28:60:
+    28:12-28:60: Assign: _31 = const false
+    28:12-28:60: Goto: goto -&gt; bb40"><span class="annotation">38⦊</span></span><span class="code even" style="--layer: 10" title="bb39: ../instrument-coverage/coverage_of_if_else.rs:28:12: 28:60:
+    28:46-28:60: StorageLive: StorageLive(_37)
+    28:46-28:55: StorageLive: StorageLive(_38)
+    28:46-28:55: Assign: _38 = _21
+    28:46-28:60: Assign: _37 = Ne(move _38, const 9_i32)
+    28:59-28:60: StorageDead: StorageDead(_38)
+    28:12-28:60: SwitchInt: switchInt(move _37) -&gt; [false: bb38, otherwise: bb37]"><span class="annotation">39⦊</span></span><span class="code even" style="--layer: 11" title="bb40: ../instrument-coverage/coverage_of_if_else.rs:28:12: 28:60:
+    28:59-28:60: StorageDead: StorageDead(_37)
+    28:59-28:60: StorageDead: StorageDead(_32)
+    28:12-28:60: FakeRead: FakeRead(ForMatchedPlace, _31)
+    28:9-30:10: SwitchInt: switchInt(_31) -&gt; [false: bb46, otherwise: bb45]"><span class="annotation">40⦊</span></span><span class="code even" style="--layer: 12" title="bb36: ../instrument-coverage/coverage_of_if_else.rs:28:12: 28:60:
     28:9-30:10: StorageLive: StorageLive(_30)
     28:12-28:60: StorageLive: StorageLive(_31)
     28:12-28:42: StorageLive: StorageLive(_32)
@@ -386,59 +352,25 @@
     28:12-28:21: Assign: _34 = _21
     28:12-28:25: Assign: _33 = Lt(move _34, const 1_i32)
     28:24-28:25: StorageDead: StorageDead(_34)
-    28:12-28:42: SwitchInt: switchInt(move _33) -&gt; [false: bb46, otherwise: bb44]"><span class="annotation">39⦊</span></span><span class="code even" style="--layer: 14" title="bb47: ../instrument-coverage/coverage_of_if_else.rs:28:12: 28:60:
-    28:41-28:42: StorageDead: StorageDead(_35)
-    28:41-28:42: StorageDead: StorageDead(_33)
-    28:12-28:60: SwitchInt: switchInt(move _32) -&gt; [false: bb42, otherwise: bb40]"><span class="annotation">47⦊</span></span><span class="code even" style="--layer: 15" title="bb40: ../instrument-coverage/coverage_of_if_else.rs:28:12: 28:60:
+    28:12-28:42: SwitchInt: switchInt(move _33) -&gt; [false: bb43, otherwise: bb41]"><span class="annotation">36⦊</span></span><span class="code even" style="--layer: 13" title="bb37: ../instrument-coverage/coverage_of_if_else.rs:28:12: 28:60:
     28:12-28:60: Assign: _31 = const true
-    28:12-28:60: Goto: goto -&gt; bb43"><span class="annotation">40⦊</span></span><span class="code even" style="--layer: 16" title="bb43: ../instrument-coverage/coverage_of_if_else.rs:28:12: 28:60:
-    28:59-28:60: StorageDead: StorageDead(_37)
-    28:59-28:60: StorageDead: StorageDead(_32)
-    28:12-28:60: FakeRead: FakeRead(ForMatchedPlace, _31)
-    28:9-30:10: SwitchInt: switchInt(_31) -&gt; [false: bb49, otherwise: bb48]"><span class="annotation">43⦊</span></span><span class="code even" style="--layer: 17" title="bb42: ../instrument-coverage/coverage_of_if_else.rs:28:12: 28:60:
-    28:46-28:60: StorageLive: StorageLive(_37)
-    28:46-28:55: StorageLive: StorageLive(_38)
-    28:46-28:55: Assign: _38 = _21
-    28:46-28:60: Assign: _37 = Ne(move _38, const 9_i32)
-    28:59-28:60: StorageDead: StorageDead(_38)
-    28:12-28:60: SwitchInt: switchInt(move _37) -&gt; [false: bb41, otherwise: bb40]"><span class="annotation">42⦊</span></span><span class="code even" style="--layer: 18" title="bb41: ../instrument-coverage/coverage_of_if_else.rs:28:12: 28:60:
-    28:12-28:60: Assign: _31 = const false
-    28:12-28:60: Goto: goto -&gt; bb43"><span class="annotation">41⦊</span></span><span class="code even" style="--layer: 19" title="bb46: ../instrument-coverage/coverage_of_if_else.rs:28:12: 28:42:
-    28:29-28:42: StorageLive: StorageLive(_35)
-    28:29-28:38: StorageLive: StorageLive(_36)
-    28:29-28:38: Assign: _36 = _21
-    28:29-28:42: Assign: _35 = Gt(move _36, const 5_i32)
-    28:41-28:42: StorageDead: StorageDead(_36)
-    28:12-28:42: SwitchInt: switchInt(move _35) -&gt; [false: bb45, otherwise: bb44]"><span class="annotation">46⦊</span></span><span class="code even" style="--layer: 20" title="bb45: ../instrument-coverage/coverage_of_if_else.rs:28:12: 28:42:
-    28:12-28:42: Assign: _32 = const false
-    28:12-28:42: Goto: goto -&gt; bb47"><span class="annotation">45⦊</span></span><span class="code even" style="--layer: 21" title="bb44: ../instrument-coverage/coverage_of_if_else.rs:28:12: 28:42:
+    28:12-28:60: Goto: goto -&gt; bb40"><span class="annotation">37⦊</span></span><span class="code even" style="--layer: 14" title="bb41: ../instrument-coverage/coverage_of_if_else.rs:28:12: 28:42:
     28:12-28:42: Assign: _32 = const true
-    28:12-28:42: Goto: goto -&gt; bb47"><span class="annotation">44⦊</span>countdown &lt; 1 || countdown &gt; 5<span class="annotation">⦉44</span></span><span class="code even" style="--layer: 20" title="bb45: ../instrument-coverage/coverage_of_if_else.rs:28:12: 28:42:
+    28:12-28:42: Goto: goto -&gt; bb44"><span class="annotation">41⦊</span></span><span class="code even" style="--layer: 15" title="bb42: ../instrument-coverage/coverage_of_if_else.rs:28:12: 28:42:
     28:12-28:42: Assign: _32 = const false
-    28:12-28:42: Goto: goto -&gt; bb47"><span class="annotation">⦉45</span></span><span class="code even" style="--layer: 19" title="bb46: ../instrument-coverage/coverage_of_if_else.rs:28:12: 28:42:
+    28:12-28:42: Goto: goto -&gt; bb44"><span class="annotation">42⦊</span></span><span class="code even" style="--layer: 16" title="bb43: ../instrument-coverage/coverage_of_if_else.rs:28:12: 28:42:
     28:29-28:42: StorageLive: StorageLive(_35)
     28:29-28:38: StorageLive: StorageLive(_36)
     28:29-28:38: Assign: _36 = _21
     28:29-28:42: Assign: _35 = Gt(move _36, const 5_i32)
     28:41-28:42: StorageDead: StorageDead(_36)
-    28:12-28:42: SwitchInt: switchInt(move _35) -&gt; [false: bb45, otherwise: bb44]"><span class="annotation">⦉46</span></span><span class="code even" style="--layer: 18" title="bb41: ../instrument-coverage/coverage_of_if_else.rs:28:12: 28:60:
-    28:12-28:60: Assign: _31 = const false
-    28:12-28:60: Goto: goto -&gt; bb43"> || countdown != 9<span class="annotation">⦉41</span></span><span class="code even" style="--layer: 17" title="bb42: ../instrument-coverage/coverage_of_if_else.rs:28:12: 28:60:
-    28:46-28:60: StorageLive: StorageLive(_37)
-    28:46-28:55: StorageLive: StorageLive(_38)
-    28:46-28:55: Assign: _38 = _21
-    28:46-28:60: Assign: _37 = Ne(move _38, const 9_i32)
-    28:59-28:60: StorageDead: StorageDead(_38)
-    28:12-28:60: SwitchInt: switchInt(move _37) -&gt; [false: bb41, otherwise: bb40]"><span class="annotation">⦉42</span></span><span class="code even" style="--layer: 16" title="bb43: ../instrument-coverage/coverage_of_if_else.rs:28:12: 28:60:
-    28:59-28:60: StorageDead: StorageDead(_37)
-    28:59-28:60: StorageDead: StorageDead(_32)
-    28:12-28:60: FakeRead: FakeRead(ForMatchedPlace, _31)
-    28:9-30:10: SwitchInt: switchInt(_31) -&gt; [false: bb49, otherwise: bb48]"><span class="annotation">⦉43</span></span><span class="code even" style="--layer: 15" title="bb40: ../instrument-coverage/coverage_of_if_else.rs:28:12: 28:60:
+    28:12-28:42: SwitchInt: switchInt(move _35) -&gt; [false: bb42, otherwise: bb41]"><span class="annotation">43⦊</span>countdown &lt; 1 || countdown &gt; 5<span class="annotation">⦉43</span></span><span class="code even" style="--layer: 15" title="bb42: ../instrument-coverage/coverage_of_if_else.rs:28:12: 28:42:
+    28:12-28:42: Assign: _32 = const false
+    28:12-28:42: Goto: goto -&gt; bb44"><span class="annotation">⦉42</span></span><span class="code even" style="--layer: 14" title="bb41: ../instrument-coverage/coverage_of_if_else.rs:28:12: 28:42:
+    28:12-28:42: Assign: _32 = const true
+    28:12-28:42: Goto: goto -&gt; bb44"><span class="annotation">⦉41</span></span><span class="code even" style="--layer: 13" title="bb37: ../instrument-coverage/coverage_of_if_else.rs:28:12: 28:60:
     28:12-28:60: Assign: _31 = const true
-    28:12-28:60: Goto: goto -&gt; bb43"><span class="annotation">⦉40</span></span><span class="code even" style="--layer: 14" title="bb47: ../instrument-coverage/coverage_of_if_else.rs:28:12: 28:60:
-    28:41-28:42: StorageDead: StorageDead(_35)
-    28:41-28:42: StorageDead: StorageDead(_33)
-    28:12-28:60: SwitchInt: switchInt(move _32) -&gt; [false: bb42, otherwise: bb40]"><span class="annotation">⦉47</span></span><span class="code even" style="--layer: 13" title="bb39: ../instrument-coverage/coverage_of_if_else.rs:28:12: 28:60:
+    28:12-28:60: Goto: goto -&gt; bb40"> || countdown != 9<span class="annotation">⦉37</span></span><span class="code even" style="--layer: 12" title="bb36: ../instrument-coverage/coverage_of_if_else.rs:28:12: 28:60:
     28:9-30:10: StorageLive: StorageLive(_30)
     28:12-28:60: StorageLive: StorageLive(_31)
     28:12-28:42: StorageLive: StorageLive(_32)
@@ -447,104 +379,71 @@
     28:12-28:21: Assign: _34 = _21
     28:12-28:25: Assign: _33 = Lt(move _34, const 1_i32)
     28:24-28:25: StorageDead: StorageDead(_34)
-    28:12-28:42: SwitchInt: switchInt(move _33) -&gt; [false: bb46, otherwise: bb44]"><span class="annotation">⦉39</span></span><span class="code even" style="--layer: 12" title="bb49: ../instrument-coverage/coverage_of_if_else.rs:28:9: 30:10:
-    28:9-30:10: Assign: _30 = const ()
-    28:9-30:10: Goto: goto -&gt; bb51"> {</span></span>
-<span class="line"><span class="code even" style="--layer: 12" title="bb49: ../instrument-coverage/coverage_of_if_else.rs:28:9: 30:10:
-    28:9-30:10: Assign: _30 = const ()
-    28:9-30:10: Goto: goto -&gt; bb51">            countdown = 0;</span></span>
-<span class="line"><span class="code even" style="--layer: 12" title="bb49: ../instrument-coverage/coverage_of_if_else.rs:28:9: 30:10:
-    28:9-30:10: Assign: _30 = const ()
-    28:9-30:10: Goto: goto -&gt; bb51">        </span><span class="code odd" style="--layer: 13" title="bb51: ../instrument-coverage/coverage_of_if_else.rs:30:9: 31:23:
+    28:12-28:42: SwitchInt: switchInt(move _33) -&gt; [false: bb43, otherwise: bb41]"><span class="annotation">⦉36</span></span><span class="code even" style="--layer: 11" title="bb40: ../instrument-coverage/coverage_of_if_else.rs:28:12: 28:60:
+    28:59-28:60: StorageDead: StorageDead(_37)
+    28:59-28:60: StorageDead: StorageDead(_32)
+    28:12-28:60: FakeRead: FakeRead(ForMatchedPlace, _31)
+    28:9-30:10: SwitchInt: switchInt(_31) -&gt; [false: bb46, otherwise: bb45]"><span class="annotation">⦉40</span></span><span class="code even" style="--layer: 10" title="bb39: ../instrument-coverage/coverage_of_if_else.rs:28:12: 28:60:
+    28:46-28:60: StorageLive: StorageLive(_37)
+    28:46-28:55: StorageLive: StorageLive(_38)
+    28:46-28:55: Assign: _38 = _21
+    28:46-28:60: Assign: _37 = Ne(move _38, const 9_i32)
+    28:59-28:60: StorageDead: StorageDead(_38)
+    28:12-28:60: SwitchInt: switchInt(move _37) -&gt; [false: bb38, otherwise: bb37]"><span class="annotation">⦉39</span></span><span class="code even" style="--layer: 9" title="bb38: ../instrument-coverage/coverage_of_if_else.rs:28:12: 28:60:
+    28:12-28:60: Assign: _31 = const false
+    28:12-28:60: Goto: goto -&gt; bb40"><span class="annotation">⦉38</span></span><span class="code even" style="--layer: 8" title="bb44: ../instrument-coverage/coverage_of_if_else.rs:28:12: 28:60:
+    28:41-28:42: StorageDead: StorageDead(_35)
+    28:41-28:42: StorageDead: StorageDead(_33)
+    28:12-28:60: SwitchInt: switchInt(move _32) -&gt; [false: bb39, otherwise: bb37]"><span class="annotation">⦉44</span></span><span class="code even" style="--layer: 7" title="bb45: ../instrument-coverage/coverage_of_if_else.rs:28:9: 30:10:
+    28:9-30:10: FalseEdge: falseEdge -&gt; [real: bb47, imaginary: bb46]"> {</span></span>
+<span class="line"><span class="code even" style="--layer: 7" title="bb45: ../instrument-coverage/coverage_of_if_else.rs:28:9: 30:10:
+    28:9-30:10: FalseEdge: falseEdge -&gt; [real: bb47, imaginary: bb46]">            countdown = 0;</span></span>
+<span class="line"><span class="code even" style="--layer: 7" title="bb45: ../instrument-coverage/coverage_of_if_else.rs:28:9: 30:10:
+    28:9-30:10: FalseEdge: falseEdge -&gt; [real: bb47, imaginary: bb46]">        </span><span class="code odd" style="--layer: 8" title="bb48: ../instrument-coverage/coverage_of_if_else.rs:30:9: 31:23:
     30:9-30:10: StorageDead: StorageDead(_31)
     30:9-30:10: StorageDead: StorageDead(_30)
     31:9-31:23: Assign: _39 = CheckedSub(_21, const 5_i32)
-    31:9-31:23: Assert: assert(!move (_39.1: bool), &quot;attempt to compute `{} - {}`, which would overflow&quot;, _21, const 5_i32) -&gt; [success: bb52, unwind: bb1]"><span class="annotation">51⦊</span>}</span><span class="code odd" style="--layer: 10" title="bb48: ../instrument-coverage/coverage_of_if_else.rs:28:9: 30:10:
-    28:9-30:10: FalseEdge: falseEdge -&gt; [real: bb50, imaginary: bb49]"><span class="annotation">⦉48</span></span><span class="code even" style="--layer: 11" title="bb50: ../instrument-coverage/coverage_of_if_else.rs:28:9: 30:10:
+    31:9-31:23: Assert: assert(!move (_39.1: bool), &quot;attempt to compute `{} - {}`, which would overflow&quot;, _21, const 5_i32) -&gt; [success: bb49, unwind: bb78]"><span class="annotation">48⦊</span>}</span><span class="code odd" style="--layer: 5" title="bb46: ../instrument-coverage/coverage_of_if_else.rs:28:9: 30:10:
+    28:9-30:10: Assign: _30 = const ()
+    28:9-30:10: Goto: goto -&gt; bb48"><span class="annotation">⦉46</span></span><span class="code even" style="--layer: 6" title="bb47: ../instrument-coverage/coverage_of_if_else.rs:28:9: 30:10:
     29:13-29:26: Assign: _21 = const 0_i32
     28:61-30:10: Assign: _30 = const ()
-    28:9-30:10: Goto: goto -&gt; bb51"><span class="annotation">⦉50</span></span><span class="code even" style="--layer: 12" title="bb49: ../instrument-coverage/coverage_of_if_else.rs:28:9: 30:10:
-    28:9-30:10: Assign: _30 = const ()
-    28:9-30:10: Goto: goto -&gt; bb51"><span class="annotation">⦉49</span></span><span class="code even" style="--layer: 12" title="bb49: ../instrument-coverage/coverage_of_if_else.rs:28:9: 30:10:
-    28:9-30:10: Assign: _30 = const ()
-    28:9-30:10: Goto: goto -&gt; bb51"><span class="annotation">⦉49</span></span><span class="code odd" style="--layer: 13" title="bb51: ../instrument-coverage/coverage_of_if_else.rs:30:9: 31:23:
+    28:9-30:10: Goto: goto -&gt; bb48"><span class="annotation">⦉47</span></span><span class="code even" style="--layer: 7" title="bb45: ../instrument-coverage/coverage_of_if_else.rs:28:9: 30:10:
+    28:9-30:10: FalseEdge: falseEdge -&gt; [real: bb47, imaginary: bb46]"><span class="annotation">⦉45</span></span><span class="code even" style="--layer: 7" title="bb45: ../instrument-coverage/coverage_of_if_else.rs:28:9: 30:10:
+    28:9-30:10: FalseEdge: falseEdge -&gt; [real: bb47, imaginary: bb46]"><span class="annotation">⦉45</span></span><span class="code odd" style="--layer: 8" title="bb48: ../instrument-coverage/coverage_of_if_else.rs:30:9: 31:23:
     30:9-30:10: StorageDead: StorageDead(_31)
     30:9-30:10: StorageDead: StorageDead(_30)
     31:9-31:23: Assign: _39 = CheckedSub(_21, const 5_i32)
-    31:9-31:23: Assert: assert(!move (_39.1: bool), &quot;attempt to compute `{} - {}`, which would overflow&quot;, _21, const 5_i32) -&gt; [success: bb52, unwind: bb1]"></span></span>
-<span class="line"><span class="code odd" style="--layer: 13" title="bb51: ../instrument-coverage/coverage_of_if_else.rs:30:9: 31:23:
+    31:9-31:23: Assert: assert(!move (_39.1: bool), &quot;attempt to compute `{} - {}`, which would overflow&quot;, _21, const 5_i32) -&gt; [success: bb49, unwind: bb78]"></span></span>
+<span class="line"><span class="code odd" style="--layer: 8" title="bb48: ../instrument-coverage/coverage_of_if_else.rs:30:9: 31:23:
     30:9-30:10: StorageDead: StorageDead(_31)
     30:9-30:10: StorageDead: StorageDead(_30)
     31:9-31:23: Assign: _39 = CheckedSub(_21, const 5_i32)
-    31:9-31:23: Assert: assert(!move (_39.1: bool), &quot;attempt to compute `{} - {}`, which would overflow&quot;, _21, const 5_i32) -&gt; [success: bb52, unwind: bb1]">        countdown -= 5<span class="annotation">⦉51</span></span><span class="code even" style="--layer: 9" title="bb37: ../instrument-coverage/coverage_of_if_else.rs:27:12: 34:6:
-    27:12-34:6: FalseEdge: falseEdge -&gt; [real: bb39, imaginary: bb38]">;</span></span>
-<span class="line"><span class="code even" style="--layer: 9" title="bb37: ../instrument-coverage/coverage_of_if_else.rs:27:12: 34:6:
-    27:12-34:6: FalseEdge: falseEdge -&gt; [real: bb39, imaginary: bb38]">    } else {</span></span>
-<span class="line"><span class="code even" style="--layer: 9" title="bb37: ../instrument-coverage/coverage_of_if_else.rs:27:12: 34:6:
-    27:12-34:6: FalseEdge: falseEdge -&gt; [real: bb39, imaginary: bb38]">        </span><span class="code even" style="--layer: 10" title="bb38: ../instrument-coverage/coverage_of_if_else.rs:33:9: 51:2:
-    33:9-33:15: Assign: _0 = const ()
-    34:5-34:6: StorageDead: StorageDead(_28)
-    34:5-34:6: StorageDead: StorageDead(_25)
-    34:5-34:6: StorageDead: StorageDead(_24)
-    51:1-51:2: StorageDead: StorageDead(_21)
-    33:9-33:15: Goto: goto -&gt; bb27"><span class="annotation">38⦊</span>return;</span></span>
-<span class="line"><span class="code even" style="--layer: 10" title="bb38: ../instrument-coverage/coverage_of_if_else.rs:33:9: 51:2:
-    33:9-33:15: Assign: _0 = const ()
-    34:5-34:6: StorageDead: StorageDead(_28)
-    34:5-34:6: StorageDead: StorageDead(_25)
-    34:5-34:6: StorageDead: StorageDead(_24)
-    51:1-51:2: StorageDead: StorageDead(_21)
-    33:9-33:15: Goto: goto -&gt; bb27">    }</span><span class="code even" style="--layer: 6" title="bb33: ../instrument-coverage/coverage_of_if_else.rs:25:5: 34:6:
-    25:5-34:6: FalseEdge: falseEdge -&gt; [real: bb35, imaginary: bb34]"><span class="annotation">⦉33</span></span><span class="code even" style="--layer: 7" title="bb52: ../instrument-coverage/coverage_of_if_else.rs:25:5: 34:6:
+    31:9-31:23: Assert: assert(!move (_39.1: bool), &quot;attempt to compute `{} - {}`, which would overflow&quot;, _21, const 5_i32) -&gt; [success: bb49, unwind: bb78]">        countdown -= 5<span class="annotation">⦉48</span></span><span class="code even" style="--layer: 4" title="bb34: ../instrument-coverage/coverage_of_if_else.rs:27:12: 34:6:
+    27:12-34:6: FalseEdge: falseEdge -&gt; [real: bb36, imaginary: bb35]">;</span></span>
+<span class="line"><span class="code even" style="--layer: 4" title="bb34: ../instrument-coverage/coverage_of_if_else.rs:27:12: 34:6:
+    27:12-34:6: FalseEdge: falseEdge -&gt; [real: bb36, imaginary: bb35]">    } else {</span></span>
+<span class="line"><span class="code even" style="--layer: 4" title="bb34: ../instrument-coverage/coverage_of_if_else.rs:27:12: 34:6:
+    27:12-34:6: FalseEdge: falseEdge -&gt; [real: bb36, imaginary: bb35]">        return;</span></span>
+<span class="line"><span class="code even" style="--layer: 4" title="bb34: ../instrument-coverage/coverage_of_if_else.rs:27:12: 34:6:
+    27:12-34:6: FalseEdge: falseEdge -&gt; [real: bb36, imaginary: bb35]">    }<span class="annotation">⦉34</span></span><span class="code even" style="--layer: 3" title="bb30: ../instrument-coverage/coverage_of_if_else.rs:25:5: 34:6:
+    25:5-34:6: FalseEdge: falseEdge -&gt; [real: bb32, imaginary: bb31]"><span class="annotation">⦉30</span></span><span class="code even" style="--layer: 2" title="bb33: ../instrument-coverage/coverage_of_if_else.rs:25:5: 34:6:
+    26:9-26:23: Assign: _21 = move (_27.0: i32)
+    25:22-27:6: Assign: _24 = const ()
+    25:5-34:6: Goto: goto -&gt; bb50"><span class="annotation">⦉33</span></span><span><span class="code odd" style="--layer: 1" title="bb49: ../instrument-coverage/coverage_of_if_else.rs:25:5: 34:6:
     31:9-31:23: Assign: _21 = move (_39.0: i32)
     27:29-32:6: Assign: _24 = const ()
     34:5-34:6: StorageDead: StorageDead(_28)
-    25:5-34:6: Goto: goto -&gt; bb53"><span class="annotation">⦉52</span></span><span class="code even" style="--layer: 8" title="bb36: ../instrument-coverage/coverage_of_if_else.rs:25:5: 34:6:
-    26:9-26:23: Assign: _21 = move (_27.0: i32)
-    25:22-27:6: Assign: _24 = const ()
-    25:5-34:6: Goto: goto -&gt; bb53"><span class="annotation">⦉36</span></span><span class="code even" style="--layer: 8" title="bb36: ../instrument-coverage/coverage_of_if_else.rs:25:5: 34:6:
-    26:9-26:23: Assign: _21 = move (_27.0: i32)
-    25:22-27:6: Assign: _24 = const ()
-    25:5-34:6: Goto: goto -&gt; bb53"><span class="annotation">⦉36</span></span><span class="code even" style="--layer: 8" title="bb36: ../instrument-coverage/coverage_of_if_else.rs:25:5: 34:6:
-    26:9-26:23: Assign: _21 = move (_27.0: i32)
-    25:22-27:6: Assign: _24 = const ()
-    25:5-34:6: Goto: goto -&gt; bb53"><span class="annotation">⦉36</span></span><span class="code even" style="--layer: 9" title="bb37: ../instrument-coverage/coverage_of_if_else.rs:27:12: 34:6:
-    27:12-34:6: FalseEdge: falseEdge -&gt; [real: bb39, imaginary: bb38]"><span class="annotation">⦉37</span></span><span class="code even" style="--layer: 9" title="bb37: ../instrument-coverage/coverage_of_if_else.rs:27:12: 34:6:
-    27:12-34:6: FalseEdge: falseEdge -&gt; [real: bb39, imaginary: bb38]"><span class="annotation">⦉37</span></span><span class="code even" style="--layer: 9" title="bb37: ../instrument-coverage/coverage_of_if_else.rs:27:12: 34:6:
-    27:12-34:6: FalseEdge: falseEdge -&gt; [real: bb39, imaginary: bb38]"><span class="annotation">⦉37</span></span><span class="code even" style="--layer: 10" title="bb38: ../instrument-coverage/coverage_of_if_else.rs:33:9: 51:2:
-    33:9-33:15: Assign: _0 = const ()
-    34:5-34:6: StorageDead: StorageDead(_28)
-    34:5-34:6: StorageDead: StorageDead(_25)
-    34:5-34:6: StorageDead: StorageDead(_24)
-    51:1-51:2: StorageDead: StorageDead(_21)
-    33:9-33:15: Goto: goto -&gt; bb27"></span></span>
-<span class="line"><span class="code even" style="--layer: 10" title="bb38: ../instrument-coverage/coverage_of_if_else.rs:33:9: 51:2:
-    33:9-33:15: Assign: _0 = const ()
-    34:5-34:6: StorageDead: StorageDead(_28)
-    34:5-34:6: StorageDead: StorageDead(_25)
-    34:5-34:6: StorageDead: StorageDead(_24)
-    51:1-51:2: StorageDead: StorageDead(_21)
-    33:9-33:15: Goto: goto -&gt; bb27"></span></span>
-<span class="line"><span class="code even" style="--layer: 10" title="bb38: ../instrument-coverage/coverage_of_if_else.rs:33:9: 51:2:
-    33:9-33:15: Assign: _0 = const ()
-    34:5-34:6: StorageDead: StorageDead(_28)
-    34:5-34:6: StorageDead: StorageDead(_25)
-    34:5-34:6: StorageDead: StorageDead(_24)
-    51:1-51:2: StorageDead: StorageDead(_21)
-    33:9-33:15: Goto: goto -&gt; bb27">    let mut countdown = 0;</span></span>
-<span class="line"><span class="code even" style="--layer: 10" title="bb38: ../instrument-coverage/coverage_of_if_else.rs:33:9: 51:2:
-    33:9-33:15: Assign: _0 = const ()
-    34:5-34:6: StorageDead: StorageDead(_28)
-    34:5-34:6: StorageDead: StorageDead(_25)
-    34:5-34:6: StorageDead: StorageDead(_24)
-    51:1-51:2: StorageDead: StorageDead(_21)
-    33:9-33:15: Goto: goto -&gt; bb27">    </span><span class="code even" style="--layer: 11" title="bb56: ../instrument-coverage/coverage_of_if_else.rs:37:5: 39:6:
+    25:5-34:6: Goto: goto -&gt; bb50"><span class="annotation">⦉49</span></span></span><span class="code" style="--layer: 0"></span></span>
+<span class="line"><span class="code" style="--layer: 0"></span></span>
+<span class="line"><span class="code" style="--layer: 0">    let mut countdown = 0;</span></span>
+<span class="line"><span class="code" style="--layer: 0">    </span><span><span class="code even" style="--layer: 1" title="bb52: ../instrument-coverage/coverage_of_if_else.rs:37:5: 39:6:
+    37:5-39:6: Assign: _42 = const ()
+    37:5-39:6: Goto: goto -&gt; bb54"><span class="annotation">52⦊</span></span></span><span class="code even" style="--layer: 2" title="bb51: ../instrument-coverage/coverage_of_if_else.rs:37:5: 39:6:
+    37:5-39:6: FalseEdge: falseEdge -&gt; [real: bb53, imaginary: bb52]"><span class="annotation">51⦊</span></span><span class="code even" style="--layer: 3" title="bb53: ../instrument-coverage/coverage_of_if_else.rs:37:5: 39:6:
     38:9-38:23: Assign: _41 = const 10_i32
     37:13-39:6: Assign: _42 = const ()
-    37:5-39:6: Goto: goto -&gt; bb57"><span class="annotation">56⦊</span></span><span class="code even" style="--layer: 12" title="bb54: ../instrument-coverage/coverage_of_if_else.rs:37:5: 39:6:
-    37:5-39:6: FalseEdge: falseEdge -&gt; [real: bb56, imaginary: bb55]"><span class="annotation">54⦊</span></span><span class="code even" style="--layer: 13" title="bb55: ../instrument-coverage/coverage_of_if_else.rs:37:5: 39:6:
-    37:5-39:6: Assign: _42 = const ()
-    37:5-39:6: Goto: goto -&gt; bb57"><span class="annotation">55⦊</span>if </span><span class="code even" style="--layer: 14" title="bb53: ../instrument-coverage/coverage_of_if_else.rs:37:8: 37:12:
+    37:5-39:6: Goto: goto -&gt; bb54"><span class="annotation">53⦊</span>if </span><span class="code even" style="--layer: 4" title="bb50: ../instrument-coverage/coverage_of_if_else.rs:37:8: 37:12:
     34:5-34:6: StorageDead: StorageDead(_25)
     34:5-34:6: StorageDead: StorageDead(_24)
     36:9-36:22: StorageLive: StorageLive(_41)
@@ -554,47 +453,31 @@
     37:8-37:12: StorageLive: StorageLive(_43)
     37:8-37:12: Assign: _43 = const true
     37:8-37:12: FakeRead: FakeRead(ForMatchedPlace, _43)
-    37:5-39:6: SwitchInt: switchInt(_43) -&gt; [false: bb55, otherwise: bb54]"><span class="annotation">53⦊</span>true<span class="annotation">⦉53</span></span><span class="code even" style="--layer: 13" title="bb55: ../instrument-coverage/coverage_of_if_else.rs:37:5: 39:6:
-    37:5-39:6: Assign: _42 = const ()
-    37:5-39:6: Goto: goto -&gt; bb57"> {</span></span>
-<span class="line"><span class="code even" style="--layer: 13" title="bb55: ../instrument-coverage/coverage_of_if_else.rs:37:5: 39:6:
-    37:5-39:6: Assign: _42 = const ()
-    37:5-39:6: Goto: goto -&gt; bb57">        countdown = 10;</span></span>
-<span class="line"><span class="code even" style="--layer: 13" title="bb55: ../instrument-coverage/coverage_of_if_else.rs:37:5: 39:6:
-    37:5-39:6: Assign: _42 = const ()
-    37:5-39:6: Goto: goto -&gt; bb57">    }<span class="annotation">⦉55</span></span><span class="code even" style="--layer: 12" title="bb54: ../instrument-coverage/coverage_of_if_else.rs:37:5: 39:6:
-    37:5-39:6: FalseEdge: falseEdge -&gt; [real: bb56, imaginary: bb55]"><span class="annotation">⦉54</span></span><span class="code even" style="--layer: 11" title="bb56: ../instrument-coverage/coverage_of_if_else.rs:37:5: 39:6:
+    37:5-39:6: SwitchInt: switchInt(_43) -&gt; [false: bb52, otherwise: bb51]"><span class="annotation">50⦊</span>true<span class="annotation">⦉50</span></span><span class="code even" style="--layer: 3" title="bb53: ../instrument-coverage/coverage_of_if_else.rs:37:5: 39:6:
     38:9-38:23: Assign: _41 = const 10_i32
     37:13-39:6: Assign: _42 = const ()
-    37:5-39:6: Goto: goto -&gt; bb57"><span class="annotation">⦉56</span></span><span class="code even" style="--layer: 10" title="bb38: ../instrument-coverage/coverage_of_if_else.rs:33:9: 51:2:
-    33:9-33:15: Assign: _0 = const ()
-    34:5-34:6: StorageDead: StorageDead(_28)
-    34:5-34:6: StorageDead: StorageDead(_25)
-    34:5-34:6: StorageDead: StorageDead(_24)
-    51:1-51:2: StorageDead: StorageDead(_21)
-    33:9-33:15: Goto: goto -&gt; bb27"></span></span>
-<span class="line"><span class="code even" style="--layer: 10" title="bb38: ../instrument-coverage/coverage_of_if_else.rs:33:9: 51:2:
-    33:9-33:15: Assign: _0 = const ()
-    34:5-34:6: StorageDead: StorageDead(_28)
-    34:5-34:6: StorageDead: StorageDead(_25)
-    34:5-34:6: StorageDead: StorageDead(_24)
-    51:1-51:2: StorageDead: StorageDead(_21)
-    33:9-33:15: Goto: goto -&gt; bb27"></span></span>
-<span class="line"><span class="code even" style="--layer: 10" title="bb38: ../instrument-coverage/coverage_of_if_else.rs:33:9: 51:2:
-    33:9-33:15: Assign: _0 = const ()
-    34:5-34:6: StorageDead: StorageDead(_28)
-    34:5-34:6: StorageDead: StorageDead(_25)
-    34:5-34:6: StorageDead: StorageDead(_24)
-    51:1-51:2: StorageDead: StorageDead(_21)
-    33:9-33:15: Goto: goto -&gt; bb27">    </span><span class="code odd" style="--layer: 11" title="bb61: ../instrument-coverage/coverage_of_if_else.rs:41:5: 50:6:
-    42:9-42:23: Assign: _41 = move (_46.0: i32)
-    41:22-43:6: Assign: _0 = const ()
-    41:5-50:6: Goto: goto -&gt; bb78"><span class="annotation">61⦊</span></span><span class="code even" style="--layer: 12" title="bb58: ../instrument-coverage/coverage_of_if_else.rs:41:5: 50:6:
-    41:5-50:6: FalseEdge: falseEdge -&gt; [real: bb60, imaginary: bb59]"><span class="annotation">58⦊</span></span><span class="code even" style="--layer: 13" title="bb77: ../instrument-coverage/coverage_of_if_else.rs:41:5: 50:6:
+    37:5-39:6: Goto: goto -&gt; bb54"> {</span></span>
+<span class="line"><span class="code even" style="--layer: 3" title="bb53: ../instrument-coverage/coverage_of_if_else.rs:37:5: 39:6:
+    38:9-38:23: Assign: _41 = const 10_i32
+    37:13-39:6: Assign: _42 = const ()
+    37:5-39:6: Goto: goto -&gt; bb54">        countdown = 10;</span></span>
+<span class="line"><span class="code even" style="--layer: 3" title="bb53: ../instrument-coverage/coverage_of_if_else.rs:37:5: 39:6:
+    38:9-38:23: Assign: _41 = const 10_i32
+    37:13-39:6: Assign: _42 = const ()
+    37:5-39:6: Goto: goto -&gt; bb54">    }<span class="annotation">⦉53</span></span><span class="code even" style="--layer: 2" title="bb51: ../instrument-coverage/coverage_of_if_else.rs:37:5: 39:6:
+    37:5-39:6: FalseEdge: falseEdge -&gt; [real: bb53, imaginary: bb52]"><span class="annotation">⦉51</span></span><span><span class="code even" style="--layer: 1" title="bb52: ../instrument-coverage/coverage_of_if_else.rs:37:5: 39:6:
+    37:5-39:6: Assign: _42 = const ()
+    37:5-39:6: Goto: goto -&gt; bb54"><span class="annotation">⦉52</span></span></span><span class="code" style="--layer: 0"></span></span>
+<span class="line"><span class="code" style="--layer: 0"></span></span>
+<span class="line"><span class="code" style="--layer: 0">    </span><span><span class="code odd" style="--layer: 1" title="bb74: ../instrument-coverage/coverage_of_if_else.rs:41:5: 50:6:
     47:9-47:23: Assign: _41 = move (_58.0: i32)
     43:29-48:6: Assign: _0 = const ()
     50:5-50:6: StorageDead: StorageDead(_47)
-    41:5-50:6: Goto: goto -&gt; bb78"><span class="annotation">77⦊</span>if </span><span class="code even" style="--layer: 14" title="bb57: ../instrument-coverage/coverage_of_if_else.rs:41:8: 41:21:
+    41:5-50:6: Goto: goto -&gt; bb75"><span class="annotation">74⦊</span></span></span><span class="code even" style="--layer: 2" title="bb55: ../instrument-coverage/coverage_of_if_else.rs:41:5: 50:6:
+    41:5-50:6: FalseEdge: falseEdge -&gt; [real: bb57, imaginary: bb56]"><span class="annotation">55⦊</span></span><span class="code even" style="--layer: 3" title="bb58: ../instrument-coverage/coverage_of_if_else.rs:41:5: 50:6:
+    42:9-42:23: Assign: _41 = move (_46.0: i32)
+    41:22-43:6: Assign: _0 = const ()
+    41:5-50:6: Goto: goto -&gt; bb75"><span class="annotation">58⦊</span>if </span><span class="code even" style="--layer: 4" title="bb54: ../instrument-coverage/coverage_of_if_else.rs:41:8: 41:21:
     39:5-39:6: StorageDead: StorageDead(_43)
     39:5-39:6: StorageDead: StorageDead(_42)
     41:8-41:21: StorageLive: StorageLive(_44)
@@ -603,59 +486,57 @@
     41:8-41:21: Assign: _44 = Gt(move _45, const 7_i32)
     41:20-41:21: StorageDead: StorageDead(_45)
     41:8-41:21: FakeRead: FakeRead(ForMatchedPlace, _44)
-    41:5-50:6: SwitchInt: switchInt(_44) -&gt; [false: bb59, otherwise: bb58]"><span class="annotation">57⦊</span>countdown &gt; 7<span class="annotation">⦉57</span></span><span class="code even" style="--layer: 13" title="bb77: ../instrument-coverage/coverage_of_if_else.rs:41:5: 50:6:
-    47:9-47:23: Assign: _41 = move (_58.0: i32)
-    43:29-48:6: Assign: _0 = const ()
-    50:5-50:6: StorageDead: StorageDead(_47)
-    41:5-50:6: Goto: goto -&gt; bb78"> {</span></span>
-<span class="line"><span class="code even" style="--layer: 13" title="bb77: ../instrument-coverage/coverage_of_if_else.rs:41:5: 50:6:
-    47:9-47:23: Assign: _41 = move (_58.0: i32)
-    43:29-48:6: Assign: _0 = const ()
-    50:5-50:6: StorageDead: StorageDead(_47)
-    41:5-50:6: Goto: goto -&gt; bb78">        </span><span class="code odd" style="--layer: 14" title="bb60: ../instrument-coverage/coverage_of_if_else.rs:42:9: 42:23:
+    41:5-50:6: SwitchInt: switchInt(_44) -&gt; [false: bb56, otherwise: bb55]"><span class="annotation">54⦊</span>countdown &gt; 7<span class="annotation">⦉54</span></span><span class="code even" style="--layer: 3" title="bb58: ../instrument-coverage/coverage_of_if_else.rs:41:5: 50:6:
+    42:9-42:23: Assign: _41 = move (_46.0: i32)
+    41:22-43:6: Assign: _0 = const ()
+    41:5-50:6: Goto: goto -&gt; bb75"> {</span></span>
+<span class="line"><span class="code even" style="--layer: 3" title="bb58: ../instrument-coverage/coverage_of_if_else.rs:41:5: 50:6:
+    42:9-42:23: Assign: _41 = move (_46.0: i32)
+    41:22-43:6: Assign: _0 = const ()
+    41:5-50:6: Goto: goto -&gt; bb75">        </span><span class="code odd" style="--layer: 4" title="bb57: ../instrument-coverage/coverage_of_if_else.rs:42:9: 42:23:
     42:9-42:23: Assign: _46 = CheckedSub(_41, const 4_i32)
-    42:9-42:23: Assert: assert(!move (_46.1: bool), &quot;attempt to compute `{} - {}`, which would overflow&quot;, _41, const 4_i32) -&gt; [success: bb61, unwind: bb1]"><span class="annotation">60⦊</span>countdown -= 4<span class="annotation">⦉60</span></span><span class="code even" style="--layer: 13" title="bb77: ../instrument-coverage/coverage_of_if_else.rs:41:5: 50:6:
-    47:9-47:23: Assign: _41 = move (_58.0: i32)
-    43:29-48:6: Assign: _0 = const ()
-    50:5-50:6: StorageDead: StorageDead(_47)
-    41:5-50:6: Goto: goto -&gt; bb78">;</span></span>
-<span class="line"><span class="code even" style="--layer: 13" title="bb77: ../instrument-coverage/coverage_of_if_else.rs:41:5: 50:6:
-    47:9-47:23: Assign: _41 = move (_58.0: i32)
-    43:29-48:6: Assign: _0 = const ()
-    50:5-50:6: StorageDead: StorageDead(_47)
-    41:5-50:6: Goto: goto -&gt; bb78">    } else </span><span class="code even" style="--layer: 14" title="bb62: ../instrument-coverage/coverage_of_if_else.rs:43:12: 50:6:
-    43:12-50:6: FalseEdge: falseEdge -&gt; [real: bb64, imaginary: bb63]"><span class="annotation">62⦊</span>if </span><span class="code even" style="--layer: 15" title="bb59: ../instrument-coverage/coverage_of_if_else.rs:43:15: 43:28:
+    42:9-42:23: Assert: assert(!move (_46.1: bool), &quot;attempt to compute `{} - {}`, which would overflow&quot;, _41, const 4_i32) -&gt; [success: bb58, unwind: bb78]"><span class="annotation">57⦊</span>countdown -= 4<span class="annotation">⦉57</span></span><span class="code even" style="--layer: 3" title="bb58: ../instrument-coverage/coverage_of_if_else.rs:41:5: 50:6:
+    42:9-42:23: Assign: _41 = move (_46.0: i32)
+    41:22-43:6: Assign: _0 = const ()
+    41:5-50:6: Goto: goto -&gt; bb75">;</span></span>
+<span class="line"><span class="code even" style="--layer: 3" title="bb58: ../instrument-coverage/coverage_of_if_else.rs:41:5: 50:6:
+    42:9-42:23: Assign: _41 = move (_46.0: i32)
+    41:22-43:6: Assign: _0 = const ()
+    41:5-50:6: Goto: goto -&gt; bb75">    } else </span><span class="code even" style="--layer: 4" title="bb59: ../instrument-coverage/coverage_of_if_else.rs:43:12: 50:6:
+    43:12-50:6: FalseEdge: falseEdge -&gt; [real: bb61, imaginary: bb60]"><span class="annotation">59⦊</span>if </span><span class="code even" style="--layer: 5" title="bb56: ../instrument-coverage/coverage_of_if_else.rs:43:15: 43:28:
     43:15-43:28: StorageLive: StorageLive(_47)
     43:15-43:24: StorageLive: StorageLive(_48)
     43:15-43:24: Assign: _48 = _41
     43:15-43:28: Assign: _47 = Gt(move _48, const 2_i32)
     43:27-43:28: StorageDead: StorageDead(_48)
     43:15-43:28: FakeRead: FakeRead(ForMatchedPlace, _47)
-    43:12-50:6: SwitchInt: switchInt(_47) -&gt; [false: bb63, otherwise: bb62]"><span class="annotation">59⦊</span>countdown &gt; 2<span class="annotation">⦉59</span></span><span class="code even" style="--layer: 14" title="bb62: ../instrument-coverage/coverage_of_if_else.rs:43:12: 50:6:
-    43:12-50:6: FalseEdge: falseEdge -&gt; [real: bb64, imaginary: bb63]"> {</span></span>
-<span class="line"><span class="code even" style="--layer: 14" title="bb62: ../instrument-coverage/coverage_of_if_else.rs:43:12: 50:6:
-    43:12-50:6: FalseEdge: falseEdge -&gt; [real: bb64, imaginary: bb63]">        </span><span class="code odd" style="--layer: 15" title="bb75: ../instrument-coverage/coverage_of_if_else.rs:44:9: 46:10:
+    43:12-50:6: SwitchInt: switchInt(_47) -&gt; [false: bb60, otherwise: bb59]"><span class="annotation">56⦊</span>countdown &gt; 2<span class="annotation">⦉56</span></span><span class="code even" style="--layer: 4" title="bb59: ../instrument-coverage/coverage_of_if_else.rs:43:12: 50:6:
+    43:12-50:6: FalseEdge: falseEdge -&gt; [real: bb61, imaginary: bb60]"> {</span></span>
+<span class="line"><span class="code even" style="--layer: 4" title="bb59: ../instrument-coverage/coverage_of_if_else.rs:43:12: 50:6:
+    43:12-50:6: FalseEdge: falseEdge -&gt; [real: bb61, imaginary: bb60]">        </span><span class="code odd" style="--layer: 5" title="bb71: ../instrument-coverage/coverage_of_if_else.rs:44:9: 46:10:
+    44:9-46:10: Assign: _49 = const ()
+    44:9-46:10: Goto: goto -&gt; bb73"><span class="annotation">71⦊</span></span><span class="code even" style="--layer: 6" title="bb72: ../instrument-coverage/coverage_of_if_else.rs:44:9: 46:10:
     45:13-45:26: Assign: _41 = const 0_i32
     44:61-46:10: Assign: _49 = const ()
-    44:9-46:10: Goto: goto -&gt; bb76"><span class="annotation">75⦊</span></span><span class="code even" style="--layer: 16" title="bb74: ../instrument-coverage/coverage_of_if_else.rs:44:9: 46:10:
-    44:9-46:10: Assign: _49 = const ()
-    44:9-46:10: Goto: goto -&gt; bb76"><span class="annotation">74⦊</span></span><span class="code even" style="--layer: 17" title="bb73: ../instrument-coverage/coverage_of_if_else.rs:44:9: 46:10:
-    44:9-46:10: FalseEdge: falseEdge -&gt; [real: bb75, imaginary: bb74]"><span class="annotation">73⦊</span>if </span><span class="code even" style="--layer: 18" title="bb67: ../instrument-coverage/coverage_of_if_else.rs:44:12: 44:60:
+    44:9-46:10: Goto: goto -&gt; bb73"><span class="annotation">72⦊</span></span><span class="code even" style="--layer: 7" title="bb70: ../instrument-coverage/coverage_of_if_else.rs:44:9: 46:10:
+    44:9-46:10: FalseEdge: falseEdge -&gt; [real: bb72, imaginary: bb71]"><span class="annotation">70⦊</span>if </span><span class="code even" style="--layer: 8" title="bb63: ../instrument-coverage/coverage_of_if_else.rs:44:12: 44:60:
+    44:12-44:60: Assign: _50 = const false
+    44:12-44:60: Goto: goto -&gt; bb65"><span class="annotation">63⦊</span></span><span class="code even" style="--layer: 9" title="bb64: ../instrument-coverage/coverage_of_if_else.rs:44:12: 44:60:
     44:46-44:60: StorageLive: StorageLive(_56)
     44:46-44:55: StorageLive: StorageLive(_57)
     44:46-44:55: Assign: _57 = _41
     44:46-44:60: Assign: _56 = Ne(move _57, const 9_i32)
     44:59-44:60: StorageDead: StorageDead(_57)
-    44:12-44:60: SwitchInt: switchInt(move _56) -&gt; [false: bb66, otherwise: bb65]"><span class="annotation">67⦊</span></span><span class="code even" style="--layer: 19" title="bb68: ../instrument-coverage/coverage_of_if_else.rs:44:12: 44:60:
+    44:12-44:60: SwitchInt: switchInt(move _56) -&gt; [false: bb63, otherwise: bb62]"><span class="annotation">64⦊</span></span><span class="code even" style="--layer: 10" title="bb65: ../instrument-coverage/coverage_of_if_else.rs:44:12: 44:60:
     44:59-44:60: StorageDead: StorageDead(_56)
     44:59-44:60: StorageDead: StorageDead(_51)
     44:12-44:60: FakeRead: FakeRead(ForMatchedPlace, _50)
-    44:9-46:10: SwitchInt: switchInt(_50) -&gt; [false: bb74, otherwise: bb73]"><span class="annotation">68⦊</span></span><span class="code even" style="--layer: 20" title="bb65: ../instrument-coverage/coverage_of_if_else.rs:44:12: 44:60:
+    44:9-46:10: SwitchInt: switchInt(_50) -&gt; [false: bb71, otherwise: bb70]"><span class="annotation">65⦊</span></span><span class="code even" style="--layer: 11" title="bb62: ../instrument-coverage/coverage_of_if_else.rs:44:12: 44:60:
     44:12-44:60: Assign: _50 = const true
-    44:12-44:60: Goto: goto -&gt; bb68"><span class="annotation">65⦊</span></span><span class="code even" style="--layer: 21" title="bb72: ../instrument-coverage/coverage_of_if_else.rs:44:12: 44:60:
+    44:12-44:60: Goto: goto -&gt; bb65"><span class="annotation">62⦊</span></span><span class="code even" style="--layer: 12" title="bb69: ../instrument-coverage/coverage_of_if_else.rs:44:12: 44:60:
     44:41-44:42: StorageDead: StorageDead(_54)
     44:41-44:42: StorageDead: StorageDead(_52)
-    44:12-44:60: SwitchInt: switchInt(move _51) -&gt; [false: bb67, otherwise: bb65]"><span class="annotation">72⦊</span></span><span class="code even" style="--layer: 22" title="bb64: ../instrument-coverage/coverage_of_if_else.rs:44:12: 44:60:
+    44:12-44:60: SwitchInt: switchInt(move _51) -&gt; [false: bb64, otherwise: bb62]"><span class="annotation">69⦊</span></span><span class="code even" style="--layer: 13" title="bb61: ../instrument-coverage/coverage_of_if_else.rs:44:12: 44:60:
     44:9-46:10: StorageLive: StorageLive(_49)
     44:12-44:60: StorageLive: StorageLive(_50)
     44:12-44:42: StorageLive: StorageLive(_51)
@@ -664,29 +545,25 @@
     44:12-44:21: Assign: _53 = _41
     44:12-44:25: Assign: _52 = Lt(move _53, const 1_i32)
     44:24-44:25: StorageDead: StorageDead(_53)
-    44:12-44:42: SwitchInt: switchInt(move _52) -&gt; [false: bb71, otherwise: bb69]"><span class="annotation">64⦊</span></span><span class="code even" style="--layer: 23" title="bb66: ../instrument-coverage/coverage_of_if_else.rs:44:12: 44:60:
-    44:12-44:60: Assign: _50 = const false
-    44:12-44:60: Goto: goto -&gt; bb68"><span class="annotation">66⦊</span></span><span class="code even" style="--layer: 24" title="bb69: ../instrument-coverage/coverage_of_if_else.rs:44:12: 44:42:
-    44:12-44:42: Assign: _51 = const true
-    44:12-44:42: Goto: goto -&gt; bb72"><span class="annotation">69⦊</span></span><span class="code even" style="--layer: 25" title="bb71: ../instrument-coverage/coverage_of_if_else.rs:44:12: 44:42:
-    44:29-44:42: StorageLive: StorageLive(_54)
-    44:29-44:38: StorageLive: StorageLive(_55)
-    44:29-44:38: Assign: _55 = _41
-    44:29-44:42: Assign: _54 = Gt(move _55, const 5_i32)
-    44:41-44:42: StorageDead: StorageDead(_55)
-    44:12-44:42: SwitchInt: switchInt(move _54) -&gt; [false: bb70, otherwise: bb69]"><span class="annotation">71⦊</span></span><span class="code even" style="--layer: 26" title="bb70: ../instrument-coverage/coverage_of_if_else.rs:44:12: 44:42:
+    44:12-44:42: SwitchInt: switchInt(move _52) -&gt; [false: bb68, otherwise: bb66]"><span class="annotation">61⦊</span></span><span class="code even" style="--layer: 14" title="bb67: ../instrument-coverage/coverage_of_if_else.rs:44:12: 44:42:
     44:12-44:42: Assign: _51 = const false
-    44:12-44:42: Goto: goto -&gt; bb72"><span class="annotation">70⦊</span>countdown &lt; 1 || countdown &gt; 5<span class="annotation">⦉70</span></span><span class="code even" style="--layer: 25" title="bb71: ../instrument-coverage/coverage_of_if_else.rs:44:12: 44:42:
+    44:12-44:42: Goto: goto -&gt; bb69"><span class="annotation">67⦊</span></span><span class="code even" style="--layer: 15" title="bb68: ../instrument-coverage/coverage_of_if_else.rs:44:12: 44:42:
     44:29-44:42: StorageLive: StorageLive(_54)
     44:29-44:38: StorageLive: StorageLive(_55)
     44:29-44:38: Assign: _55 = _41
     44:29-44:42: Assign: _54 = Gt(move _55, const 5_i32)
     44:41-44:42: StorageDead: StorageDead(_55)
-    44:12-44:42: SwitchInt: switchInt(move _54) -&gt; [false: bb70, otherwise: bb69]"><span class="annotation">⦉71</span></span><span class="code even" style="--layer: 24" title="bb69: ../instrument-coverage/coverage_of_if_else.rs:44:12: 44:42:
+    44:12-44:42: SwitchInt: switchInt(move _54) -&gt; [false: bb67, otherwise: bb66]"><span class="annotation">68⦊</span></span><span class="code even" style="--layer: 16" title="bb66: ../instrument-coverage/coverage_of_if_else.rs:44:12: 44:42:
     44:12-44:42: Assign: _51 = const true
-    44:12-44:42: Goto: goto -&gt; bb72"><span class="annotation">⦉69</span></span><span class="code even" style="--layer: 23" title="bb66: ../instrument-coverage/coverage_of_if_else.rs:44:12: 44:60:
-    44:12-44:60: Assign: _50 = const false
-    44:12-44:60: Goto: goto -&gt; bb68"> || countdown != 9<span class="annotation">⦉66</span></span><span class="code even" style="--layer: 22" title="bb64: ../instrument-coverage/coverage_of_if_else.rs:44:12: 44:60:
+    44:12-44:42: Goto: goto -&gt; bb69"><span class="annotation">66⦊</span>countdown &lt; 1 || countdown &gt; 5<span class="annotation">⦉66</span></span><span class="code even" style="--layer: 15" title="bb68: ../instrument-coverage/coverage_of_if_else.rs:44:12: 44:42:
+    44:29-44:42: StorageLive: StorageLive(_54)
+    44:29-44:38: StorageLive: StorageLive(_55)
+    44:29-44:38: Assign: _55 = _41
+    44:29-44:42: Assign: _54 = Gt(move _55, const 5_i32)
+    44:41-44:42: StorageDead: StorageDead(_55)
+    44:12-44:42: SwitchInt: switchInt(move _54) -&gt; [false: bb67, otherwise: bb66]"><span class="annotation">⦉68</span></span><span class="code even" style="--layer: 14" title="bb67: ../instrument-coverage/coverage_of_if_else.rs:44:12: 44:42:
+    44:12-44:42: Assign: _51 = const false
+    44:12-44:42: Goto: goto -&gt; bb69"><span class="annotation">⦉67</span></span><span class="code even" style="--layer: 13" title="bb61: ../instrument-coverage/coverage_of_if_else.rs:44:12: 44:60:
     44:9-46:10: StorageLive: StorageLive(_49)
     44:12-44:60: StorageLive: StorageLive(_50)
     44:12-44:42: StorageLive: StorageLive(_51)
@@ -695,114 +572,70 @@
     44:12-44:21: Assign: _53 = _41
     44:12-44:25: Assign: _52 = Lt(move _53, const 1_i32)
     44:24-44:25: StorageDead: StorageDead(_53)
-    44:12-44:42: SwitchInt: switchInt(move _52) -&gt; [false: bb71, otherwise: bb69]"><span class="annotation">⦉64</span></span><span class="code even" style="--layer: 21" title="bb72: ../instrument-coverage/coverage_of_if_else.rs:44:12: 44:60:
+    44:12-44:42: SwitchInt: switchInt(move _52) -&gt; [false: bb68, otherwise: bb66]"> || countdown != 9<span class="annotation">⦉61</span></span><span class="code even" style="--layer: 12" title="bb69: ../instrument-coverage/coverage_of_if_else.rs:44:12: 44:60:
     44:41-44:42: StorageDead: StorageDead(_54)
     44:41-44:42: StorageDead: StorageDead(_52)
-    44:12-44:60: SwitchInt: switchInt(move _51) -&gt; [false: bb67, otherwise: bb65]"><span class="annotation">⦉72</span></span><span class="code even" style="--layer: 20" title="bb65: ../instrument-coverage/coverage_of_if_else.rs:44:12: 44:60:
+    44:12-44:60: SwitchInt: switchInt(move _51) -&gt; [false: bb64, otherwise: bb62]"><span class="annotation">⦉69</span></span><span class="code even" style="--layer: 11" title="bb62: ../instrument-coverage/coverage_of_if_else.rs:44:12: 44:60:
     44:12-44:60: Assign: _50 = const true
-    44:12-44:60: Goto: goto -&gt; bb68"><span class="annotation">⦉65</span></span><span class="code even" style="--layer: 19" title="bb68: ../instrument-coverage/coverage_of_if_else.rs:44:12: 44:60:
+    44:12-44:60: Goto: goto -&gt; bb65"><span class="annotation">⦉62</span></span><span class="code even" style="--layer: 10" title="bb65: ../instrument-coverage/coverage_of_if_else.rs:44:12: 44:60:
     44:59-44:60: StorageDead: StorageDead(_56)
     44:59-44:60: StorageDead: StorageDead(_51)
     44:12-44:60: FakeRead: FakeRead(ForMatchedPlace, _50)
-    44:9-46:10: SwitchInt: switchInt(_50) -&gt; [false: bb74, otherwise: bb73]"><span class="annotation">⦉68</span></span><span class="code even" style="--layer: 18" title="bb67: ../instrument-coverage/coverage_of_if_else.rs:44:12: 44:60:
+    44:9-46:10: SwitchInt: switchInt(_50) -&gt; [false: bb71, otherwise: bb70]"><span class="annotation">⦉65</span></span><span class="code even" style="--layer: 9" title="bb64: ../instrument-coverage/coverage_of_if_else.rs:44:12: 44:60:
     44:46-44:60: StorageLive: StorageLive(_56)
     44:46-44:55: StorageLive: StorageLive(_57)
     44:46-44:55: Assign: _57 = _41
     44:46-44:60: Assign: _56 = Ne(move _57, const 9_i32)
     44:59-44:60: StorageDead: StorageDead(_57)
-    44:12-44:60: SwitchInt: switchInt(move _56) -&gt; [false: bb66, otherwise: bb65]"><span class="annotation">⦉67</span></span><span class="code even" style="--layer: 17" title="bb73: ../instrument-coverage/coverage_of_if_else.rs:44:9: 46:10:
-    44:9-46:10: FalseEdge: falseEdge -&gt; [real: bb75, imaginary: bb74]"> {</span></span>
-<span class="line"><span class="code even" style="--layer: 17" title="bb73: ../instrument-coverage/coverage_of_if_else.rs:44:9: 46:10:
-    44:9-46:10: FalseEdge: falseEdge -&gt; [real: bb75, imaginary: bb74]">            countdown = 0;</span></span>
-<span class="line"><span class="code even" style="--layer: 17" title="bb73: ../instrument-coverage/coverage_of_if_else.rs:44:9: 46:10:
-    44:9-46:10: FalseEdge: falseEdge -&gt; [real: bb75, imaginary: bb74]">        </span><span class="code odd" style="--layer: 18" title="bb76: ../instrument-coverage/coverage_of_if_else.rs:46:9: 47:23:
+    44:12-44:60: SwitchInt: switchInt(move _56) -&gt; [false: bb63, otherwise: bb62]"><span class="annotation">⦉64</span></span><span class="code even" style="--layer: 8" title="bb63: ../instrument-coverage/coverage_of_if_else.rs:44:12: 44:60:
+    44:12-44:60: Assign: _50 = const false
+    44:12-44:60: Goto: goto -&gt; bb65"><span class="annotation">⦉63</span></span><span class="code even" style="--layer: 7" title="bb70: ../instrument-coverage/coverage_of_if_else.rs:44:9: 46:10:
+    44:9-46:10: FalseEdge: falseEdge -&gt; [real: bb72, imaginary: bb71]"> {</span></span>
+<span class="line"><span class="code even" style="--layer: 7" title="bb70: ../instrument-coverage/coverage_of_if_else.rs:44:9: 46:10:
+    44:9-46:10: FalseEdge: falseEdge -&gt; [real: bb72, imaginary: bb71]">            countdown = 0;</span></span>
+<span class="line"><span class="code even" style="--layer: 7" title="bb70: ../instrument-coverage/coverage_of_if_else.rs:44:9: 46:10:
+    44:9-46:10: FalseEdge: falseEdge -&gt; [real: bb72, imaginary: bb71]">        </span><span class="code odd" style="--layer: 8" title="bb73: ../instrument-coverage/coverage_of_if_else.rs:46:9: 47:23:
     46:9-46:10: StorageDead: StorageDead(_50)
     46:9-46:10: StorageDead: StorageDead(_49)
     47:9-47:23: Assign: _58 = CheckedSub(_41, const 5_i32)
-    47:9-47:23: Assert: assert(!move (_58.1: bool), &quot;attempt to compute `{} - {}`, which would overflow&quot;, _41, const 5_i32) -&gt; [success: bb77, unwind: bb1]"><span class="annotation">76⦊</span>}</span><span class="code odd" style="--layer: 15" title="bb75: ../instrument-coverage/coverage_of_if_else.rs:44:9: 46:10:
+    47:9-47:23: Assert: assert(!move (_58.1: bool), &quot;attempt to compute `{} - {}`, which would overflow&quot;, _41, const 5_i32) -&gt; [success: bb74, unwind: bb78]"><span class="annotation">73⦊</span>}</span><span class="code odd" style="--layer: 5" title="bb71: ../instrument-coverage/coverage_of_if_else.rs:44:9: 46:10:
+    44:9-46:10: Assign: _49 = const ()
+    44:9-46:10: Goto: goto -&gt; bb73"><span class="annotation">⦉71</span></span><span class="code even" style="--layer: 6" title="bb72: ../instrument-coverage/coverage_of_if_else.rs:44:9: 46:10:
     45:13-45:26: Assign: _41 = const 0_i32
     44:61-46:10: Assign: _49 = const ()
-    44:9-46:10: Goto: goto -&gt; bb76"><span class="annotation">⦉75</span></span><span class="code even" style="--layer: 16" title="bb74: ../instrument-coverage/coverage_of_if_else.rs:44:9: 46:10:
-    44:9-46:10: Assign: _49 = const ()
-    44:9-46:10: Goto: goto -&gt; bb76"><span class="annotation">⦉74</span></span><span class="code even" style="--layer: 17" title="bb73: ../instrument-coverage/coverage_of_if_else.rs:44:9: 46:10:
-    44:9-46:10: FalseEdge: falseEdge -&gt; [real: bb75, imaginary: bb74]"><span class="annotation">⦉73</span></span><span class="code even" style="--layer: 17" title="bb73: ../instrument-coverage/coverage_of_if_else.rs:44:9: 46:10:
-    44:9-46:10: FalseEdge: falseEdge -&gt; [real: bb75, imaginary: bb74]"><span class="annotation">⦉73</span></span><span class="code odd" style="--layer: 18" title="bb76: ../instrument-coverage/coverage_of_if_else.rs:46:9: 47:23:
+    44:9-46:10: Goto: goto -&gt; bb73"><span class="annotation">⦉72</span></span><span class="code even" style="--layer: 7" title="bb70: ../instrument-coverage/coverage_of_if_else.rs:44:9: 46:10:
+    44:9-46:10: FalseEdge: falseEdge -&gt; [real: bb72, imaginary: bb71]"><span class="annotation">⦉70</span></span><span class="code even" style="--layer: 7" title="bb70: ../instrument-coverage/coverage_of_if_else.rs:44:9: 46:10:
+    44:9-46:10: FalseEdge: falseEdge -&gt; [real: bb72, imaginary: bb71]"><span class="annotation">⦉70</span></span><span class="code odd" style="--layer: 8" title="bb73: ../instrument-coverage/coverage_of_if_else.rs:46:9: 47:23:
     46:9-46:10: StorageDead: StorageDead(_50)
     46:9-46:10: StorageDead: StorageDead(_49)
     47:9-47:23: Assign: _58 = CheckedSub(_41, const 5_i32)
-    47:9-47:23: Assert: assert(!move (_58.1: bool), &quot;attempt to compute `{} - {}`, which would overflow&quot;, _41, const 5_i32) -&gt; [success: bb77, unwind: bb1]"></span></span>
-<span class="line"><span class="code odd" style="--layer: 18" title="bb76: ../instrument-coverage/coverage_of_if_else.rs:46:9: 47:23:
+    47:9-47:23: Assert: assert(!move (_58.1: bool), &quot;attempt to compute `{} - {}`, which would overflow&quot;, _41, const 5_i32) -&gt; [success: bb74, unwind: bb78]"></span></span>
+<span class="line"><span class="code odd" style="--layer: 8" title="bb73: ../instrument-coverage/coverage_of_if_else.rs:46:9: 47:23:
     46:9-46:10: StorageDead: StorageDead(_50)
     46:9-46:10: StorageDead: StorageDead(_49)
     47:9-47:23: Assign: _58 = CheckedSub(_41, const 5_i32)
-    47:9-47:23: Assert: assert(!move (_58.1: bool), &quot;attempt to compute `{} - {}`, which would overflow&quot;, _41, const 5_i32) -&gt; [success: bb77, unwind: bb1]">        countdown -= 5<span class="annotation">⦉76</span></span><span class="code even" style="--layer: 14" title="bb62: ../instrument-coverage/coverage_of_if_else.rs:43:12: 50:6:
-    43:12-50:6: FalseEdge: falseEdge -&gt; [real: bb64, imaginary: bb63]">;</span></span>
-<span class="line"><span class="code even" style="--layer: 14" title="bb62: ../instrument-coverage/coverage_of_if_else.rs:43:12: 50:6:
-    43:12-50:6: FalseEdge: falseEdge -&gt; [real: bb64, imaginary: bb63]">    } else {</span></span>
-<span class="line"><span class="code even" style="--layer: 14" title="bb62: ../instrument-coverage/coverage_of_if_else.rs:43:12: 50:6:
-    43:12-50:6: FalseEdge: falseEdge -&gt; [real: bb64, imaginary: bb63]">        </span><span class="code even" style="--layer: 15" title="bb63: ../instrument-coverage/coverage_of_if_else.rs:49:9: 51:2:
-    49:9-49:15: Assign: _0 = const ()
-    50:5-50:6: StorageDead: StorageDead(_47)
-    51:1-51:2: StorageDead: StorageDead(_41)
-    51:1-51:2: StorageDead: StorageDead(_21)
-    51:1-51:2: StorageDead: StorageDead(_1)
-    51:1-51:2: StorageDead: StorageDead(_44)
-    49:9-49:15: Goto: goto -&gt; bb26"><span class="annotation">63⦊</span>return;</span></span>
-<span class="line"><span class="code even" style="--layer: 15" title="bb63: ../instrument-coverage/coverage_of_if_else.rs:49:9: 51:2:
-    49:9-49:15: Assign: _0 = const ()
-    50:5-50:6: StorageDead: StorageDead(_47)
-    51:1-51:2: StorageDead: StorageDead(_41)
-    51:1-51:2: StorageDead: StorageDead(_21)
-    51:1-51:2: StorageDead: StorageDead(_1)
-    51:1-51:2: StorageDead: StorageDead(_44)
-    49:9-49:15: Goto: goto -&gt; bb26">    }</span><span class="code odd" style="--layer: 11" title="bb61: ../instrument-coverage/coverage_of_if_else.rs:41:5: 50:6:
+    47:9-47:23: Assert: assert(!move (_58.1: bool), &quot;attempt to compute `{} - {}`, which would overflow&quot;, _41, const 5_i32) -&gt; [success: bb74, unwind: bb78]">        countdown -= 5<span class="annotation">⦉73</span></span><span class="code even" style="--layer: 4" title="bb59: ../instrument-coverage/coverage_of_if_else.rs:43:12: 50:6:
+    43:12-50:6: FalseEdge: falseEdge -&gt; [real: bb61, imaginary: bb60]">;</span></span>
+<span class="line"><span class="code even" style="--layer: 4" title="bb59: ../instrument-coverage/coverage_of_if_else.rs:43:12: 50:6:
+    43:12-50:6: FalseEdge: falseEdge -&gt; [real: bb61, imaginary: bb60]">    } else {</span></span>
+<span class="line"><span class="code even" style="--layer: 4" title="bb59: ../instrument-coverage/coverage_of_if_else.rs:43:12: 50:6:
+    43:12-50:6: FalseEdge: falseEdge -&gt; [real: bb61, imaginary: bb60]">        return;</span></span>
+<span class="line"><span class="code even" style="--layer: 4" title="bb59: ../instrument-coverage/coverage_of_if_else.rs:43:12: 50:6:
+    43:12-50:6: FalseEdge: falseEdge -&gt; [real: bb61, imaginary: bb60]">    }<span class="annotation">⦉59</span></span><span class="code even" style="--layer: 3" title="bb58: ../instrument-coverage/coverage_of_if_else.rs:41:5: 50:6:
     42:9-42:23: Assign: _41 = move (_46.0: i32)
     41:22-43:6: Assign: _0 = const ()
-    41:5-50:6: Goto: goto -&gt; bb78"><span class="annotation">⦉61</span></span><span class="code even" style="--layer: 12" title="bb58: ../instrument-coverage/coverage_of_if_else.rs:41:5: 50:6:
-    41:5-50:6: FalseEdge: falseEdge -&gt; [real: bb60, imaginary: bb59]"><span class="annotation">⦉58</span></span><span class="code even" style="--layer: 13" title="bb77: ../instrument-coverage/coverage_of_if_else.rs:41:5: 50:6:
+    41:5-50:6: Goto: goto -&gt; bb75"><span class="annotation">⦉58</span></span><span class="code even" style="--layer: 2" title="bb55: ../instrument-coverage/coverage_of_if_else.rs:41:5: 50:6:
+    41:5-50:6: FalseEdge: falseEdge -&gt; [real: bb57, imaginary: bb56]"><span class="annotation">⦉55</span></span><span><span class="code odd" style="--layer: 1" title="bb74: ../instrument-coverage/coverage_of_if_else.rs:41:5: 50:6:
     47:9-47:23: Assign: _41 = move (_58.0: i32)
     43:29-48:6: Assign: _0 = const ()
     50:5-50:6: StorageDead: StorageDead(_47)
-    41:5-50:6: Goto: goto -&gt; bb78"><span class="annotation">⦉77</span></span><span class="code even" style="--layer: 13" title="bb77: ../instrument-coverage/coverage_of_if_else.rs:41:5: 50:6:
-    47:9-47:23: Assign: _41 = move (_58.0: i32)
-    43:29-48:6: Assign: _0 = const ()
-    50:5-50:6: StorageDead: StorageDead(_47)
-    41:5-50:6: Goto: goto -&gt; bb78"><span class="annotation">⦉77</span></span><span class="code even" style="--layer: 13" title="bb77: ../instrument-coverage/coverage_of_if_else.rs:41:5: 50:6:
-    47:9-47:23: Assign: _41 = move (_58.0: i32)
-    43:29-48:6: Assign: _0 = const ()
-    50:5-50:6: StorageDead: StorageDead(_47)
-    41:5-50:6: Goto: goto -&gt; bb78"><span class="annotation">⦉77</span></span><span class="code even" style="--layer: 14" title="bb62: ../instrument-coverage/coverage_of_if_else.rs:43:12: 50:6:
-    43:12-50:6: FalseEdge: falseEdge -&gt; [real: bb64, imaginary: bb63]"><span class="annotation">⦉62</span></span><span class="code even" style="--layer: 14" title="bb62: ../instrument-coverage/coverage_of_if_else.rs:43:12: 50:6:
-    43:12-50:6: FalseEdge: falseEdge -&gt; [real: bb64, imaginary: bb63]"><span class="annotation">⦉62</span></span><span class="code even" style="--layer: 14" title="bb62: ../instrument-coverage/coverage_of_if_else.rs:43:12: 50:6:
-    43:12-50:6: FalseEdge: falseEdge -&gt; [real: bb64, imaginary: bb63]"><span class="annotation">⦉62</span></span><span class="code even" style="--layer: 15" title="bb63: ../instrument-coverage/coverage_of_if_else.rs:49:9: 51:2:
-    49:9-49:15: Assign: _0 = const ()
-    50:5-50:6: StorageDead: StorageDead(_47)
+    41:5-50:6: Goto: goto -&gt; bb75"><span class="annotation">⦉74</span></span></span><span class="code" style="--layer: 0"></span></span>
+<span class="line"><span><span class="code even" style="--layer: 1" title="bb75: ../instrument-coverage/coverage_of_if_else.rs:51:1: 51:2:
     51:1-51:2: StorageDead: StorageDead(_41)
     51:1-51:2: StorageDead: StorageDead(_21)
     51:1-51:2: StorageDead: StorageDead(_1)
     51:1-51:2: StorageDead: StorageDead(_44)
-    49:9-49:15: Goto: goto -&gt; bb26"></span></span>
-<span class="line"><span class="code even" style="--layer: 16" title="bb78: ../instrument-coverage/coverage_of_if_else.rs:51:1: 51:2:
-    51:1-51:2: StorageDead: StorageDead(_41)
-    51:1-51:2: StorageDead: StorageDead(_21)
-    51:1-51:2: StorageDead: StorageDead(_1)
-    51:1-51:2: StorageDead: StorageDead(_44)
-    51:2-51:2: Goto: goto -&gt; bb26"><span class="annotation">78⦊</span>}<span class="annotation">⦉78</span></span><span class="code even" style="--layer: 15" title="bb63: ../instrument-coverage/coverage_of_if_else.rs:49:9: 51:2:
-    49:9-49:15: Assign: _0 = const ()
-    50:5-50:6: StorageDead: StorageDead(_47)
-    51:1-51:2: StorageDead: StorageDead(_41)
-    51:1-51:2: StorageDead: StorageDead(_21)
-    51:1-51:2: StorageDead: StorageDead(_1)
-    51:1-51:2: StorageDead: StorageDead(_44)
-    49:9-49:15: Goto: goto -&gt; bb26"><span class="annotation">⦉63</span></span><span class="code even" style="--layer: 10" title="bb38: ../instrument-coverage/coverage_of_if_else.rs:33:9: 51:2:
-    33:9-33:15: Assign: _0 = const ()
-    34:5-34:6: StorageDead: StorageDead(_28)
-    34:5-34:6: StorageDead: StorageDead(_25)
-    34:5-34:6: StorageDead: StorageDead(_24)
-    51:1-51:2: StorageDead: StorageDead(_21)
-    33:9-33:15: Goto: goto -&gt; bb27"><span class="annotation">⦉38</span></span><span class="code even" style="--layer: 5" title="bb27: ../instrument-coverage/coverage_of_if_else.rs:17:9: 51:2:
-    51:1-51:2: StorageDead: StorageDead(_1)
-    17:9-17:15: Goto: goto -&gt; bb26"><span class="annotation">⦉27</span></span><span><span class="code even" style="--layer: 1" title="bb26: ../instrument-coverage/coverage_of_if_else.rs:51:2: 51:2:
-    51:2-51:2: Return: return"><span class="annotation">26⦊</span>‸<span class="annotation">⦉26</span></span></span></span></div>
+    51:2-51:2: Goto: goto -&gt; bb77"><span class="annotation">75⦊</span>}<span class="annotation">⦉75</span></span></span><span><span class="code odd" style="--layer: 1" title="bb77: ../instrument-coverage/coverage_of_if_else.rs:51:2: 51:2:
+    51:2-51:2: Return: return"><span class="annotation">77⦊</span>‸<span class="annotation">⦉77</span></span></span></span></div>
 </body>
 </html>

--- a/src/test/ui/auxiliary/issue-72470-lib.rs
+++ b/src/test/ui/auxiliary/issue-72470-lib.rs
@@ -1,0 +1,175 @@
+// compile-flags: -C opt-level=3
+// edition:2018
+
+use std::future::Future;
+use std::marker::PhantomData;
+use std::pin::Pin;
+use std::sync::atomic::AtomicUsize;
+use std::sync::Arc;
+use std::task::Poll::{Pending, Ready};
+use std::task::Waker;
+use std::task::{Context, Poll};
+use std::{
+    ptr,
+    task::{RawWaker, RawWakerVTable},
+};
+
+/// Future for the [`poll_fn`] function.
+pub struct PollFn<F> {
+    f: F,
+}
+
+impl<F> Unpin for PollFn<F> {}
+
+/// Creates a new future wrapping around a function returning [`Poll`].
+pub fn poll_fn<T, F>(f: F) -> PollFn<F>
+where
+    F: FnMut(&mut Context<'_>) -> Poll<T>,
+{
+    PollFn { f }
+}
+
+impl<T, F> Future for PollFn<F>
+where
+    F: FnMut(&mut Context<'_>) -> Poll<T>,
+{
+    type Output = T;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<T> {
+        (&mut self.f)(cx)
+    }
+}
+pub fn run<F: Future>(future: F) -> F::Output {
+    BasicScheduler.block_on(future)
+}
+
+pub(crate) struct BasicScheduler;
+
+impl BasicScheduler {
+    pub(crate) fn block_on<F>(&mut self, mut future: F) -> F::Output
+    where
+        F: Future,
+    {
+        let waker = unsafe { Waker::from_raw(raw_waker()) };
+        let mut cx = std::task::Context::from_waker(&waker);
+
+        let mut future = unsafe { Pin::new_unchecked(&mut future) };
+
+        loop {
+            if let Ready(v) = future.as_mut().poll(&mut cx) {
+                return v;
+            }
+        }
+    }
+}
+
+// ===== impl Spawner =====
+
+fn raw_waker() -> RawWaker {
+    RawWaker::new(ptr::null(), waker_vtable())
+}
+
+fn waker_vtable() -> &'static RawWakerVTable {
+    &RawWakerVTable::new(
+        clone_arc_raw,
+        wake_arc_raw,
+        wake_by_ref_arc_raw,
+        drop_arc_raw,
+    )
+}
+
+unsafe fn clone_arc_raw(_: *const ()) -> RawWaker {
+    raw_waker()
+}
+
+unsafe fn wake_arc_raw(_: *const ()) {}
+
+unsafe fn wake_by_ref_arc_raw(_: *const ()) {}
+
+unsafe fn drop_arc_raw(_: *const ()) {}
+
+struct AtomicWaker {}
+
+impl AtomicWaker {
+    /// Create an `AtomicWaker`
+    fn new() -> AtomicWaker {
+        AtomicWaker {}
+    }
+
+    fn register_by_ref(&self, _waker: &Waker) {}
+}
+
+#[allow(dead_code)]
+struct Tx<T> {
+    inner: Arc<Chan<T>>,
+}
+
+struct Rx<T> {
+    inner: Arc<Chan<T>>,
+}
+
+#[allow(dead_code)]
+struct Chan<T> {
+    tx: PhantomData<T>,
+    semaphore: Sema,
+    rx_waker: AtomicWaker,
+    rx_closed: bool,
+}
+
+fn channel<T>() -> (Tx<T>, Rx<T>) {
+    let chan = Arc::new(Chan {
+        tx: PhantomData,
+        semaphore: Sema(AtomicUsize::new(0)),
+        rx_waker: AtomicWaker::new(),
+        rx_closed: false,
+    });
+
+    (
+        Tx {
+            inner: chan.clone(),
+        },
+        Rx { inner: chan },
+    )
+}
+
+// ===== impl Rx =====
+
+impl<T> Rx<T> {
+    /// Receive the next value
+    fn recv(&mut self, cx: &mut Context<'_>) -> Poll<Option<T>> {
+        self.inner.rx_waker.register_by_ref(cx.waker());
+
+        if self.inner.rx_closed && self.inner.semaphore.is_idle() {
+            Ready(None)
+        } else {
+            Pending
+        }
+    }
+}
+
+struct Sema(AtomicUsize);
+
+impl Sema {
+    fn is_idle(&self) -> bool {
+        false
+    }
+}
+
+pub struct UnboundedReceiver<T> {
+    chan: Rx<T>,
+}
+
+pub fn unbounded_channel<T>() -> UnboundedReceiver<T> {
+    let (tx, rx) = channel();
+
+    drop(tx);
+    let rx = UnboundedReceiver { chan: rx };
+
+    rx
+}
+
+impl<T> UnboundedReceiver<T> {
+    pub async fn recv(&mut self) -> Option<T> {
+        poll_fn(|cx| self.chan.recv(cx)).await
+    }
+}

--- a/src/test/ui/issue-72470-llvm-dominate.rs
+++ b/src/test/ui/issue-72470-llvm-dominate.rs
@@ -1,0 +1,66 @@
+// compile-flags: -C opt-level=3
+// aux-build: issue-72470-lib.rs
+// edition:2018
+// check-pass
+
+// Regression test for issue #72470, using the minimization
+// in https://github.com/jonas-schievink/llvm-error
+
+extern crate issue_72470_lib;
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Mutex;
+use std::task::Poll::{Pending, Ready};
+
+#[allow(dead_code)]
+enum Msg {
+    A(Vec<()>),
+    B,
+}
+
+#[allow(dead_code)]
+enum Out {
+    _0(Option<Msg>),
+    Disabled,
+}
+
+#[allow(unused_must_use)]
+fn main() {
+    let mut rx = issue_72470_lib::unbounded_channel::<Msg>();
+    let entity = Mutex::new(());
+    issue_72470_lib::run(async move {
+        {
+            let output = {
+                let mut fut = rx.recv();
+                issue_72470_lib::poll_fn(|cx| {
+                    loop {
+                        let fut = unsafe { Pin::new_unchecked(&mut fut) };
+                        let out = match fut.poll(cx) {
+                            Ready(out) => out,
+                            Pending => {
+                                break;
+                            }
+                        };
+                        #[allow(unused_variables)]
+                        match &out {
+                            Some(_msg) => {}
+                            _ => break,
+                        }
+                        return Ready(Out::_0(out));
+                    }
+                    Ready(Out::_0(None))
+                })
+                .await
+            };
+            match output {
+                Out::_0(Some(_msg)) => {
+                    entity.lock();
+                }
+                Out::_0(None) => unreachable!(),
+                _ => unreachable!(),
+            }
+        }
+        entity.lock();
+    });
+}

--- a/src/test/ui/issue-72470-llvm-dominate.rs
+++ b/src/test/ui/issue-72470-llvm-dominate.rs
@@ -1,7 +1,7 @@
 // compile-flags: -C opt-level=3
 // aux-build: issue-72470-lib.rs
 // edition:2018
-// check-pass
+// build-pass
 
 // Regression test for issue #72470, using the minimization
 // in https://github.com/jonas-schievink/llvm-error


### PR DESCRIPTION
PR https://github.com/rust-lang/rust/pull/71840 was reverted in https://github.com/rust-lang/rust/pull/72989 to fix an LLVM error (https://github.com/rust-lang/rust/issues/72470). That LLVM error no longer occurs with the recent upgrade to LLVM 11 (https://github.com/rust-lang/rust/pull/73526), so let's try re-landing this PR.

I've cherry-picked the commits from the original PR (with the exception of the commit blessing test output), making as few modifications as possible. I addressed the rebase fallout in separate commits on top of those.

r? @matthewjasper 