### PR TITLE
[WIP] Internal lint: warn on public cross-crate re-exports

### DIFF
--- a/compiler/rustc_lint/src/lib.rs
+++ b/compiler/rustc_lint/src/lib.rs
@@ -451,6 +451,8 @@ fn register_internals(store: &mut LintStore) {
     store.register_early_pass(|| box LintPassImpl);
     store.register_lints(&TyTyKind::get_lints());
     store.register_late_pass(|| box TyTyKind);
+    store.register_lints(&PubReexportChecker::get_lints());
+    store.register_late_pass(|| box PubReexportChecker);
     store.register_group(
         false,
         "rustc::internal",
@@ -461,6 +463,7 @@ fn register_internals(store: &mut LintStore) {
             LintId::of(LINT_PASS_IMPL_WITHOUT_MACRO),
             LintId::of(TY_PASS_BY_REFERENCE),
             LintId::of(USAGE_OF_QUALIFIED_TY),
+            LintId::of(PUB_CROSS_CRATE_REEXPORT),
         ],
     );
 }


### PR DESCRIPTION
Addresses #65233. I haven't yet addressed any of the warnings, but I'm opening this to make sure T-compiler is still interested in doing this. If so I'll remove most of the re-exports and replace any usages with the original path.

Example output:

```
warning: publicly re-exporting an item from a different crate
 --> compiler/rustc_typeck/src/expr_use_visitor.rs:8:63
  |
8 | pub use rustc_middle::hir::place::{PlaceBase, PlaceWithHirId, Projection};
  |                                                               ^^^^^^^^^^
  |
  = note: facade crates are discouraged; import from the original crate instead
```