### PR TITLE
Add `try_remove` to `Vec`

### DIFF
--- a/library/alloc/src/vec.rs
+++ b/library/alloc/src/vec.rs
@@ -1088,6 +1088,39 @@ impl<T> Vec<T> {
         }
     }
 
+    /// Tries to remove an element from the vector. If the element at `index` does not exist,
+    /// `None` is returned. Otherwise `Some(T)` is returned
+    /// 
+    /// # Examples
+    /// ```
+    /// let mut v = vec![1, 2, 3];
+    /// assert_eq!(v.remove(0), Some(1));
+    /// assert_eq!(v.remove(2), None);
+    /// ```
+    pub fn try_remove(&mut self, index: usize) -> Option<T> {
+        let len = self.len();
+        if index >= len {
+            None
+        } else {
+            unsafe {
+                // infallible
+                let ret;
+                {
+                    // the place we are taking from.
+                    let ptr = self.as_mut_ptr().add(index);
+                    // copy it out, unsafely having a copy of the value on
+                    // the stack and in the vector at the same time.
+                    ret = ptr::read(ptr);
+    
+                    // Shift everything down to fill in that spot.
+                    ptr::copy(ptr.offset(1), ptr, len - index - 1);
+                }
+                self.set_len(len - 1);
+                Some(ret)
+            }
+        }
+    }
+
     /// Retains only the elements specified by the predicate.
     ///
     /// In other words, remove all elements `e` such that `f(&e)` returns `false`.

--- a/library/alloc/src/vec.rs
+++ b/library/alloc/src/vec.rs
@@ -1077,6 +1077,7 @@ impl<T> Vec<T> {
     ///
     /// # Examples
     /// ```
+    /// #![feature(vec_try_remove)]
     /// let mut v = vec![1, 2, 3];
     /// assert_eq!(v.try_remove(0), Some(1));
     /// assert_eq!(v.try_remove(2), None);

--- a/library/alloc/src/vec.rs
+++ b/library/alloc/src/vec.rs
@@ -1065,39 +1065,23 @@ impl<T> Vec<T> {
         fn assert_failed(index: usize, len: usize) -> ! {
             panic!("removal index (is {}) should be < len (is {})", index, len);
         }
-
-        let len = self.len();
-        if index >= len {
-            assert_failed(index, len);
-        }
-        unsafe {
-            // infallible
-            let ret;
-            {
-                // the place we are taking from.
-                let ptr = self.as_mut_ptr().add(index);
-                // copy it out, unsafely having a copy of the value on
-                // the stack and in the vector at the same time.
-                ret = ptr::read(ptr);
-
-                // Shift everything down to fill in that spot.
-                ptr::copy(ptr.offset(1), ptr, len - index - 1);
-            }
-            self.set_len(len - 1);
-            ret
+        if let Some(retval) = self.try_remove(index) {
+            retval
+        } else {
+            assert_failed(index, self.len());
         }
     }
 
     /// Tries to remove an element from the vector. If the element at `index` does not exist,
     /// `None` is returned. Otherwise `Some(T)` is returned
-    /// 
+    ///
     /// # Examples
     /// ```
     /// let mut v = vec![1, 2, 3];
-    /// assert_eq!(v.remove(0), Some(1));
-    /// assert_eq!(v.remove(2), None);
+    /// assert_eq!(v.try_remove(0), Some(1));
+    /// assert_eq!(v.try_remove(2), None);
     /// ```
-    #![unstable(feature = "vec_try_remove", issue = "77481")]
+    #[unstable(feature = "vec_try_remove", issue = "77481")]
     pub fn try_remove(&mut self, index: usize) -> Option<T> {
         let len = self.len();
         if index >= len {
@@ -1112,7 +1096,6 @@ impl<T> Vec<T> {
                     // copy it out, unsafely having a copy of the value on
                     // the stack and in the vector at the same time.
                     ret = ptr::read(ptr);
-    
                     // Shift everything down to fill in that spot.
                     ptr::copy(ptr.offset(1), ptr, len - index - 1);
                 }

--- a/library/alloc/src/vec.rs
+++ b/library/alloc/src/vec.rs
@@ -1097,6 +1097,7 @@ impl<T> Vec<T> {
     /// assert_eq!(v.remove(0), Some(1));
     /// assert_eq!(v.remove(2), None);
     /// ```
+    #![unstable(feature = "vec_try_remove", issue = "77481")]
     pub fn try_remove(&mut self, index: usize) -> Option<T> {
         let len = self.len();
         if index >= len {

--- a/library/alloc/tests/lib.rs
+++ b/library/alloc/tests/lib.rs
@@ -20,6 +20,7 @@
 #![feature(inplace_iteration)]
 #![feature(iter_map_while)]
 #![feature(int_bits_const)]
+#![feature(vec_try_remove)]
 
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};

--- a/library/alloc/tests/vec.rs
+++ b/library/alloc/tests/vec.rs
@@ -1,3 +1,5 @@
+#![feature(vec_try_remove)]
+
 use std::borrow::Cow;
 use std::cell::Cell;
 use std::collections::TryReserveError::*;
@@ -516,6 +518,21 @@ fn test_slice_out_of_bounds_5() {
 fn test_swap_remove_empty() {
     let mut vec = Vec::<i32>::new();
     vec.swap_remove(0);
+}
+
+#[test]
+fn test_try_remove() {
+    let mut vec = vec![1, 2, 3];
+    // We are attempting to remove vec[0] which contains 1
+    assert_eq!(vec.try_remove(0), Some(1));
+    // Now `vec` looks like: [2, 3]
+    // We will now try to remove vec[2] which does not exist
+    // This should return `None`
+    assert_eq!(vec.try_remove(2), None);
+
+    // We will try the same thing with an empty vector
+    let mut v = vec![];
+    assert!(v.try_remove(0).is_none());
 }
 
 #[test]

--- a/library/alloc/tests/vec.rs
+++ b/library/alloc/tests/vec.rs
@@ -1,5 +1,3 @@
-#![feature(vec_try_remove)]
-
 use std::borrow::Cow;
 use std::cell::Cell;
 use std::collections::TryReserveError::*;
@@ -531,7 +529,7 @@ fn test_try_remove() {
     assert_eq!(vec.try_remove(2), None);
 
     // We will try the same thing with an empty vector
-    let mut v = vec![];
+    let mut v: Vec<u8> = vec![];
     assert!(v.try_remove(0).is_none());
 }
 


### PR DESCRIPTION
This provides a 'non-panicky' way of removing an element from a vector. When the index exists, we return it; Otherwise, `None` is returned.

Tracking issue: #77481 