### PR TITLE
Refactor `TraitRef::trait_def_id`

### DIFF
--- a/compiler/rustc_save_analysis/src/sig.rs
+++ b/compiler/rustc_save_analysis/src/sig.rs
@@ -297,10 +297,7 @@ impl<'hir> Sig for hir::Ty<'hir> {
                         hir::GenericBound::Trait(
                             hir::PolyTraitRef {
                                 bound_generic_params,
-                                trait_ref: hir::TraitRef {
-                                    path: trait_ref.path,
-                                    hir_ref_id: trait_ref.hir_ref_id,
-                                },
+                                trait_ref: *trait_ref,
                                 span: *span,
                             },
                             hir::TraitBoundModifier::None,


### PR DESCRIPTION
Refactor `TraitRef` to verify path resolution at AST lowering time.

Closes #60465