### PR TITLE
Mark `repr128` as `incomplete_features`

### DIFF
--- a/compiler/rustc_feature/src/active.rs
+++ b/compiler/rustc_feature/src/active.rs
@@ -622,6 +622,7 @@ pub const INCOMPLETE_FEATURES: &[Symbol] = &[
     sym::lazy_normalization_consts,
     sym::specialization,
     sym::inline_const,
+    sym::repr128,
 ];
 
 /// Some features are not allowed to be used together at the same time, if

--- a/src/test/ui/enum-discriminant/discriminant_size.rs
+++ b/src/test/ui/enum-discriminant/discriminant_size.rs
@@ -1,5 +1,6 @@
 // run-pass
 #![feature(core_intrinsics, repr128)]
+//~^ WARN the feature `repr128` is incomplete
 
 use std::intrinsics::discriminant_value;
 

--- a/src/test/ui/enum-discriminant/discriminant_size.stderr
+++ b/src/test/ui/enum-discriminant/discriminant_size.stderr
@@ -1,0 +1,11 @@
+warning: the feature `repr128` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/discriminant_size.rs:2:29
+   |
+LL | #![feature(core_intrinsics, repr128)]
+   |                             ^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #56071 <https://github.com/rust-lang/rust/issues/56071> for more information
+
+warning: 1 warning emitted
+

--- a/src/test/ui/enum-discriminant/issue-70509-partial_eq.rs
+++ b/src/test/ui/enum-discriminant/issue-70509-partial_eq.rs
@@ -1,5 +1,6 @@
 // run-pass
 #![feature(repr128, arbitrary_enum_discriminant)]
+//~^ WARN the feature `repr128` is incomplete
 
 #[derive(PartialEq, Debug)]
 #[repr(i128)]

--- a/src/test/ui/enum-discriminant/issue-70509-partial_eq.stderr
+++ b/src/test/ui/enum-discriminant/issue-70509-partial_eq.stderr
@@ -1,0 +1,11 @@
+warning: the feature `repr128` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/issue-70509-partial_eq.rs:2:12
+   |
+LL | #![feature(repr128, arbitrary_enum_discriminant)]
+   |            ^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #56071 <https://github.com/rust-lang/rust/issues/56071> for more information
+
+warning: 1 warning emitted
+

--- a/src/test/ui/enum-discriminant/repr128.rs
+++ b/src/test/ui/enum-discriminant/repr128.rs
@@ -1,5 +1,6 @@
 // run-pass
 #![feature(repr128, core_intrinsics, discriminant_kind)]
+//~^ WARN the feature `repr128` is incomplete
 
 use std::intrinsics::discriminant_value;
 use std::marker::DiscriminantKind;

--- a/src/test/ui/enum-discriminant/repr128.stderr
+++ b/src/test/ui/enum-discriminant/repr128.stderr
@@ -1,0 +1,11 @@
+warning: the feature `repr128` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/repr128.rs:2:12
+   |
+LL | #![feature(repr128, core_intrinsics, discriminant_kind)]
+   |            ^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #56071 <https://github.com/rust-lang/rust/issues/56071> for more information
+
+warning: 1 warning emitted
+

--- a/src/test/ui/issues/issue-43398.rs
+++ b/src/test/ui/issues/issue-43398.rs
@@ -2,6 +2,7 @@
 
 #![feature(core_intrinsics)]
 #![feature(repr128)]
+//~^ WARN the feature `repr128` is incomplete
 
 #[repr(i128)]
 enum Big { A, B }

--- a/src/test/ui/issues/issue-43398.stderr
+++ b/src/test/ui/issues/issue-43398.stderr
@@ -1,0 +1,11 @@
+warning: the feature `repr128` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/issue-43398.rs:4:12
+   |
+LL | #![feature(repr128)]
+   |            ^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #56071 <https://github.com/rust-lang/rust/issues/56071> for more information
+
+warning: 1 warning emitted
+

--- a/src/tools/clippy/tests/ui/auxiliary/proc_macro_attr.rs
+++ b/src/tools/clippy/tests/ui/auxiliary/proc_macro_attr.rs
@@ -3,6 +3,7 @@
 
 #![crate_type = "proc-macro"]
 #![feature(repr128, proc_macro_hygiene, proc_macro_quote, box_patterns)]
+#![allow(incomplete_features)]
 #![allow(clippy::useless_conversion)]
 
 extern crate proc_macro;

--- a/src/tools/clippy/tests/ui/auxiliary/proc_macro_derive.rs
+++ b/src/tools/clippy/tests/ui/auxiliary/proc_macro_derive.rs
@@ -3,6 +3,7 @@
 
 #![crate_type = "proc-macro"]
 #![feature(repr128, proc_macro_quote)]
+#![allow(incomplete_features)]
 
 extern crate proc_macro;
 

--- a/src/tools/clippy/tests/ui/crashes/auxiliary/proc_macro_crash.rs
+++ b/src/tools/clippy/tests/ui/crashes/auxiliary/proc_macro_crash.rs
@@ -6,6 +6,7 @@
 // contain a proc-macro.
 
 #![feature(repr128)]
+#![allow(incomplete_features)]
 #![crate_type = "proc-macro"]
 
 extern crate proc_macro;


### PR DESCRIPTION
As mentioned in https://github.com/rust-lang/rust/issues/56071 and noticed in https://github.com/rust-lang/rust/issues/77457, `repr(u128)` and `repr(i128)` do not work properly due to lack of LLVM support. We should thus warn users trying to use the feature that they may encounter ICEs when using it.

Closes https://github.com/rust-lang/rust/issues/77457.