### PR TITLE
Add a default filter for `library/std` to `build` if there are no filters

### DIFF
--- a/src/bootstrap/CHANGELOG.md
+++ b/src/bootstrap/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 None.
 
+## [Version 3] - 2020-10-03
+
+- `x.py build` no longer builds tools by default. If you want all tools, use `build src/tools`. If you want only the default tools from before, specify them one by one: `x.py build src/tools/{rustdoc,cargo,...}`. [#77489](https://github.com/rust-lang/rust/pull/77489)
+
 ## [Version 2] - 2020-09-25
 
 - `host` now defaults to the value of `build` in all cases

--- a/src/bootstrap/bin/main.rs
+++ b/src/bootstrap/bin/main.rs
@@ -40,7 +40,7 @@ fn main() {
 }
 
 fn check_version(config: &Config) -> Option<String> {
-    const VERSION: usize = 2;
+    const VERSION: usize = 3;
 
     let mut msg = String::new();
 

--- a/src/bootstrap/flags.rs
+++ b/src/bootstrap/flags.rs
@@ -483,7 +483,12 @@ Arguments:
         }
 
         let cmd = match subcommand.as_str() {
-            "build" | "b" => Subcommand::Build { paths },
+            "build" | "b" => {
+                if paths.is_empty() {
+                    paths.push(PathBuf::from("library/std"));
+                }
+                Subcommand::Build { paths }
+            }
             "check" | "c" => Subcommand::Check { paths },
             "clippy" => Subcommand::Clippy { paths },
             "fix" => Subcommand::Fix { paths },

--- a/src/bootstrap/tool.rs
+++ b/src/bootstrap/tool.rs
@@ -311,7 +311,7 @@ macro_rules! bootstrap_tool {
             type Output = PathBuf;
 
             fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
-                run.path($path)
+                run.path($path).path("src/tools")
             }
 
             fn make_run(run: RunConfig<'_>) {


### PR DESCRIPTION
- Add an opt-in way to build all tools with `x.py build src/tools`
- Add an entry in the changelog
- Bump the major version

This implements https://github.com/rust-lang/compiler-team/issues/351.

r? @Mark-Simulacrum on the implementation