### PR TITLE
Set `deny-warnings = false` in contributor defaults

### DIFF
--- a/src/bootstrap/defaults/config.toml.codegen
+++ b/src/bootstrap/defaults/config.toml.codegen
@@ -11,3 +11,9 @@ assertions = true
 debug-logging = true
 # This greatly increases the speed of rebuilds, especially when there are only minor changes. However, it makes the initial build slightly slower.
 incremental = true
+
+[rust]
+# This allows building even with warnings present.
+# This is convenient especially for larger changes and refactoring,
+# since it doesn't require constantly changing imports and variable names.
+deny-warnings = false

--- a/src/bootstrap/defaults/config.toml.compiler
+++ b/src/bootstrap/defaults/config.toml.compiler
@@ -6,3 +6,9 @@
 debug-logging = true
 # This greatly increases the speed of rebuilds, especially when there are only minor changes. However, it makes the initial build slightly slower.
 incremental = true
+
+[rust]
+# This allows building even with warnings present.
+# This is convenient especially for larger changes and refactoring,
+# since it doesn't require constantly changing imports and variable names.
+deny-warnings = false

--- a/src/bootstrap/defaults/config.toml.library
+++ b/src/bootstrap/defaults/config.toml.library
@@ -8,3 +8,7 @@ bench-stage = 0
 [rust]
 # This greatly increases the speed of rebuilds, especially when there are only minor changes. However, it makes the initial build slightly slower.
 incremental = true
+# This allows building even with warnings present.
+# This is convenient especially for larger changes and refactoring,
+# since it doesn't require constantly changing imports and variable names.
+deny-warnings = false


### PR DESCRIPTION
This makes it easier to make rapid changes without having to constantly
fix warnings.