### PR TITLE
reuse RHS allocation for vec.extend(vec.into_iter()) when they do not fit into the LHS

### DIFF
--- a/library/alloc/src/vec.rs
+++ b/library/alloc/src/vec.rs
@@ -2956,6 +2956,7 @@ impl<T> IntoIter<T> {
         unsafe { Vec::from_raw_parts(iter.buf.as_ptr(), offset as usize + iter.len(), iter.cap) }
     }
 
+    /// Move remaining elements to the end of `dest`.
     fn move_to(mut self, dest: &mut Vec<T>) {
         unsafe {
             dest.append_elements(self.as_slice() as _);

--- a/library/alloc/src/vec.rs
+++ b/library/alloc/src/vec.rs
@@ -2390,34 +2390,34 @@ impl<T> SpecExtend<T, IntoIter<T>> for Vec<T> {
         //
         // # illustration of some extend scenarios (not exhaustive)
         //
-        //   == step ==              == memory ==              == self ==         == iter / v ==
-        //                   0123456789abcdef0123456789abcdef
-        //                   0---------------1---------------
+        //     = step ==              == memory ==              == self ==         == iter / v ==
+        //                    0123456789abcdef0123456789abcdef
+        //                    0---------------1---------------
         //
         // ## non-empty self, partially consumed iterator
         //
-        //    [initial]      AAAA_-----__BBB___--------------  Vec(0x00, 4, 5)    IntoIter(0x0a, 0x0c, 0x0f, 8)
-        // ³  into_vec       AAAA_-----____BBB_--------------  Vec(0x00, 4, 5)    Vec(0x0a, 7, 8)
-        // ²  prepend        _____-----AAAABBB_--------------  Vec(0x00, 0, 5)    Vec(0x0a, 7, 8)
-        // ⁴  *self = v      ----------AAAABBB_--------------  Vec(0x0a, 7, 8)
+        //     [initial]      AAAA_-----__BBB___--------------  Vec(0x00, 4, 5)    IntoIter(0x0a, 0x0c, 0x0f, 8)
+        // ³   into_vec       AAAA_-----____BBB_--------------  Vec(0x00, 4, 5)    Vec(0x0a, 7, 8)
+        // ²   prepend        _____-----AAAABBB_--------------  Vec(0x00, 0, 5)    Vec(0x0a, 7, 8)
+        // ⁴   *self = v      ----------AAAABBB_--------------  Vec(0x0a, 7, 8)
         //
         // ## empty self, partially consumed iterator
         //
-        //    [initial]      ____------__BBBB__--------------  Vec(0x00, 0, 4)    IntoIter(0x0a, 0x0c, 0x10, 8)
-        // ³  into_vec       ____------BBBB____--------------  Vec(0x00, 0, 4)    Vec(0x0a, 4, 8)
-        // ⁴  *self = v      ----------BBBB____--------------  Vec(0x0a, 4, 8)
+        //     [initial]      ____------__BBBB__--------------  Vec(0x00, 0, 4)    IntoIter(0x0a, 0x0c, 0x10, 8)
+        // ³   into_vec       ____------BBBB____--------------  Vec(0x00, 0, 4)    Vec(0x0a, 4, 8)
+        // ⁴   *self = v      ----------BBBB____--------------  Vec(0x0a, 4, 8)
         //
         // ## empty self, pristine iterator
         //
-        //    [initial]      ----------BBBB____--------------  Vec(0x00, 0, 0)    IntoIter(0x0a, 0x0a, 0x0e, 8)
-        //    *self = v      ----------BBBB____--------------  Vec(0x0a, 4, 8)
+        //     [initial]      ----------BBBB____--------------  Vec(0x00, 0, 0)    IntoIter(0x0a, 0x0a, 0x0e, 8)
+        //     *self = v      ----------BBBB____--------------  Vec(0x0a, 4, 8)
         //
         // ## insufficient capacity
         //
-        //    [initial]      AAAAA-----BBBBBB__--------------  Vec(0x00, 5,  5)   IntoIter(0x0a, 0x0a, 0x0f, 8)
-        // ¹² reserve(6)     ----------BBBBBB__--AAAAA______-  Vec(0x14, 5,  11)  IntoIter(0x0a, 0x0a, 0x0f, 8)
-        // ²  ptr:copy_n     ----------________--AAAAABBBBBB-  Vec(0x14, 11, 11)  IntoIter(0x0a, 0x0f, 0x0f, 8)
-        // ⁴  drop           --------------------AAAAABBBBBB-  Vec(0x14, 11, 11)
+        //     [initial]      AAAAA-----BBBBBB__--------------  Vec(0x00, 5,  5)   IntoIter(0x0a, 0x0a, 0x0f, 8)
+        // ¹²⁴ reserve(6)     ----------BBBBBB__--AAAAA______-  Vec(0x14, 5,  11)  IntoIter(0x0a, 0x0a, 0x0f, 8)
+        // ²   ptr:copy_n     ----------________--AAAAABBBBBB-  Vec(0x14, 11, 11)  IntoIter(0x0a, 0x0f, 0x0f, 8)
+        // ⁴   drop           --------------------AAAAABBBBBB-  Vec(0x14, 11, 11)
         //
         //  ¹ malloc
         //  ² memcpy

--- a/library/alloc/src/vec.rs
+++ b/library/alloc/src/vec.rs
@@ -2947,6 +2947,8 @@ impl<T> IntoIter<T> {
     /// * `offset == 0` is always valid
     /// * `offset` must be positive
     unsafe fn into_vec_with_uninit_prefix(self, offset: isize) -> Vec<T> {
+        debug_assert!(offset > 0);
+        debug_assert!(offset as usize + self.len() <= self.cap);
         let dst = unsafe { self.buf.as_ptr().offset(offset) };
         if self.ptr != dst as *const _ {
             unsafe { ptr::copy(self.ptr, dst, self.len()) }

--- a/library/alloc/src/vec.rs
+++ b/library/alloc/src/vec.rs
@@ -2412,12 +2412,13 @@ impl<T> SpecExtend<T, IntoIter<T>> for Vec<T> {
         {
             // Safety: we just checked that IntoIter has sufficient capacity to prepend our elements.
             // Prepending will then fill the uninitialized prefix.
-            *self = unsafe {
+            let v = unsafe {
                 let mut v = iterator.into_vec_with_uninit_prefix(self.len() as isize);
                 ptr::copy_nonoverlapping(self.as_ptr(), v.as_mut_ptr(), self.len);
                 self.set_len(0);
                 v
             };
+            *self = v;
             return;
         }
         iterator.move_into(self);

--- a/library/alloc/src/vec.rs
+++ b/library/alloc/src/vec.rs
@@ -2204,7 +2204,7 @@ impl<T> SpecFromIter<T, IntoIter<T>> for Vec<T> {
         }
 
         let mut vec = Vec::new();
-        iterator.move_to(&mut vec);
+        iterator.move_into(&mut vec);
         vec
     }
 }
@@ -2401,7 +2401,7 @@ impl<T> SpecExtend<T, IntoIter<T>> for Vec<T> {
             };
             return;
         }
-        iterator.move_to(self);
+        iterator.move_into(self);
     }
 }
 
@@ -2959,7 +2959,7 @@ impl<T> IntoIter<T> {
     }
 
     /// Move remaining elements to the end of `dest`.
-    fn move_to(mut self, dest: &mut Vec<T>) {
+    fn move_into(mut self, dest: &mut Vec<T>) {
         unsafe {
             dest.append_elements(self.as_slice() as _);
         }


### PR DESCRIPTION
I tried a broader version of this optimization in #70793 but it regressed compile times because it emitted more IR for every single use of `extend()` and thus had to be removed from that PR. This attempt is narrower since it only applies to cases where we're extending/appending directly from another vec.

```
 name                             extend-rec-baseline.b ns/iter  extend-append.b ns/iter  diff ns/iter   diff %  speedup 
 vec::bench_extend_recycle        243                            26                               -217  -89.30%   x 9.35 
```

The aim is to improve runtime behavior, not necessarily compile time but I still want a perf-run to make sure it's not regressing significantly unlike the original attempt.