### PR TITLE
Change DocFragments from enum variant fields to structs with a nested enum

### DIFF
--- a/src/librustdoc/passes/calculate_doc_coverage.rs
+++ b/src/librustdoc/passes/calculate_doc_coverage.rs
@@ -232,7 +232,12 @@ impl fold::DocFolder for CoverageCalculator {
                 let mut tests = Tests { found_tests: 0 };
 
                 find_testable_code(
-                    &i.attrs.doc_strings.iter().map(|d| d.as_str()).collect::<Vec<_>>().join("\n"),
+                    &i.attrs
+                        .doc_strings
+                        .iter()
+                        .map(|d| d.doc.as_str())
+                        .collect::<Vec<_>>()
+                        .join("\n"),
                     &mut tests,
                     ErrorCodes::No,
                     false,

--- a/src/librustdoc/passes/mod.rs
+++ b/src/librustdoc/passes/mod.rs
@@ -8,7 +8,7 @@ use std::mem;
 use std::ops::Range;
 
 use self::Condition::*;
-use crate::clean::{self, GetDefId, Item};
+use crate::clean::{self, DocFragmentKind, GetDefId, Item};
 use crate::core::DocContext;
 use crate::fold::{DocFolder, StripItem};
 
@@ -314,11 +314,11 @@ crate fn span_of_attrs(attrs: &clean::Attributes) -> Option<Span> {
     if attrs.doc_strings.is_empty() {
         return None;
     }
-    let start = attrs.doc_strings[0].span();
+    let start = attrs.doc_strings[0].span;
     if start == DUMMY_SP {
         return None;
     }
-    let end = attrs.doc_strings.last().expect("no doc strings provided").span();
+    let end = attrs.doc_strings.last().expect("no doc strings provided").span;
     Some(start.to(end))
 }
 
@@ -333,10 +333,8 @@ crate fn source_span_for_markdown_range(
     md_range: &Range<usize>,
     attrs: &clean::Attributes,
 ) -> Option<Span> {
-    let is_all_sugared_doc = attrs.doc_strings.iter().all(|frag| match frag {
-        clean::DocFragment::SugaredDoc(..) => true,
-        _ => false,
-    });
+    let is_all_sugared_doc =
+        attrs.doc_strings.iter().all(|frag| frag.kind == DocFragmentKind::SugaredDoc);
 
     if !is_all_sugared_doc {
         return None;

--- a/src/librustdoc/passes/unindent_comments.rs
+++ b/src/librustdoc/passes/unindent_comments.rs
@@ -36,13 +36,7 @@ impl clean::Attributes {
 
 fn unindent_fragments(docs: &mut Vec<DocFragment>) {
     for fragment in docs {
-        match *fragment {
-            DocFragment::SugaredDoc(_, _, ref mut doc_string)
-            | DocFragment::RawDoc(_, _, ref mut doc_string)
-            | DocFragment::Include(_, _, _, ref mut doc_string) => {
-                *doc_string = unindent(doc_string)
-            }
-        }
+        fragment.doc = unindent(&fragment.doc);
     }
 }
 


### PR DESCRIPTION
This makes the code a lot easier to work with. It also makes it easier
to add new fields without updating each variant and `match`
individually.

- Name the `Kind` variant after `DocFragmentKind` from `collapse_docs`
- Remove unneeded impls

Progress towards https://github.com/rust-lang/rust/issues/77254.
r? @GuillaumeGomez 