### PR TITLE
Allow disabling const_item_mutation lint for all uses of a specific const item

### DIFF
--- a/src/test/ui/lint/lint-const-item-mutation.rs
+++ b/src/test/ui/lint/lint-const-item-mutation.rs
@@ -47,7 +47,7 @@ fn main() {
         *MY_STRUCT.raw_ptr = 0;
     }
 
-    MUTABLE.msg = "wow"; // no warning, because Drop observes the mutation
+    MUTABLE.msg = "wow"; //~ WARN attempting to modify
     MUTABLE2.msg = "wow"; //~ WARN attempting to modify
     VEC.push(0); //~ WARN taking a mutable reference to a `const` item
 }

--- a/src/test/ui/lint/lint-const-item-mutation.stderr
+++ b/src/test/ui/lint/lint-const-item-mutation.stderr
@@ -86,6 +86,19 @@ LL | const MY_STRUCT: MyStruct = MyStruct { field: true, inner_array: ['a'], raw
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: attempting to modify a `const` item
+  --> $DIR/lint-const-item-mutation.rs:50:5
+   |
+LL |     MUTABLE.msg = "wow";
+   |     ^^^^^^^^^^^^^^^^^^^
+   |
+   = note: each usage of a `const` item creates a new temporary - the original `const` item will not be modified
+note: `const` item defined here
+  --> $DIR/lint-const-item-mutation.rs:29:1
+   |
+LL | const MUTABLE: Mutable = Mutable { msg: "" };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: attempting to modify a `const` item
   --> $DIR/lint-const-item-mutation.rs:51:5
    |
 LL |     MUTABLE2.msg = "wow";
@@ -123,5 +136,5 @@ note: `const` item defined here
 LL | const VEC: Vec<i32> = Vec::new();
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: 8 warnings emitted
+warning: 9 warnings emitted
 

--- a/src/test/ui/lint/sneaky-const-mutation.rs
+++ b/src/test/ui/lint/sneaky-const-mutation.rs
@@ -1,0 +1,82 @@
+// run-pass
+// edition:2018
+
+#![feature(once_cell)]
+#![deny(const_item_mutation)]
+
+mod library {
+    use std::lazy::SyncLazy;
+    use std::ops::{Deref, DerefMut};
+    use std::ptr;
+    use std::sync::atomic::{AtomicPtr, Ordering};
+    use std::sync::Mutex;
+
+    pub struct Options {
+        pub include_prefix: &'static str,
+    }
+
+    static INCLUDE_PREFIX: SyncLazy<Mutex<&'static str>> = SyncLazy::new(Mutex::default);
+
+    impl Options {
+        fn current() -> Self {
+            Options {
+                include_prefix: *INCLUDE_PREFIX.lock().unwrap(),
+            }
+        }
+    }
+
+    pub struct Cfg {
+        options: AtomicPtr<Options>,
+    }
+
+    pub const CFG: Cfg = Cfg {
+        options: AtomicPtr::new(ptr::null_mut()),
+    };
+
+    impl Deref for Cfg {
+        type Target = Options;
+        fn deref(&self) -> &Self::Target {
+            let options = Box::into_raw(Box::new(Options::current()));
+            let prev = self
+                .options
+                .compare_and_swap(ptr::null_mut(), options, Ordering::Relaxed);
+            if !prev.is_null() {
+                // compare_and_swap did nothing.
+                let _ = unsafe { Box::from_raw(options) };
+                panic!();
+            }
+            unsafe { &*options }
+        }
+    }
+
+    impl DerefMut for Cfg {
+        fn deref_mut(&mut self) -> &mut Self::Target {
+            let options = self.options.get_mut();
+            if !options.is_null() {
+                panic!();
+            }
+            *options = Box::into_raw(Box::new(Options::current()));
+            unsafe { &mut **options }
+        }
+    }
+
+    impl Drop for Cfg {
+        fn drop(&mut self) {
+            let options = *self.options.get_mut();
+            if let Some(options) = unsafe { options.as_mut() } {
+                *INCLUDE_PREFIX.lock().unwrap() = options.include_prefix;
+                let _ = unsafe { Box::from_raw(options) };
+            }
+        }
+    }
+}
+
+use library::CFG;
+
+fn main() {
+    assert_eq!(CFG.include_prefix, "");
+
+    CFG.include_prefix = "path/to";
+
+    assert_eq!(CFG.include_prefix, "path/to");
+}

--- a/src/test/ui/lint/sneaky-const-mutation.rs
+++ b/src/test/ui/lint/sneaky-const-mutation.rs
@@ -29,6 +29,7 @@ mod library {
         options: AtomicPtr<Options>,
     }
 
+    #[allow(const_item_mutation)]
     pub const CFG: Cfg = Cfg {
         options: AtomicPtr::new(ptr::null_mut()),
     };


### PR DESCRIPTION
Closes #77425.

The const_item_mutation lint will look at whether `allow(const_item_mutation)` is present on the const being "mutated", and if so, respect that as suppressing const_item_mutation for all uses of that const.

```rust
#[allow(const_item_mutation)]
const MYCONST: MyConst = MyConst {...};


MYCONST.foo = ""; // does not trigger const_item_mutation
```

This supersedes the special case around consts having a `Drop` impl introduced in #77251, so it is removed in this PR.

r? @Aaron1011