### PR TITLE
Enable RenameReturnPlace MIR optimization on mir-opt-level >= 2

### DIFF
--- a/compiler/rustc_mir/src/transform/nrvo.rs
+++ b/compiler/rustc_mir/src/transform/nrvo.rs
@@ -36,12 +36,6 @@ impl<'tcx> MirPass<'tcx> for RenameReturnPlace {
             return;
         }
 
-        if tcx.sess.opts.debugging_opts.mir_opt_level >= 2 {
-            // The `DestinationPropagation` pass runs at level 2, so this pass is redundant (and
-            // fails some asserts).
-            return;
-        }
-
         let returned_local = match local_eligible_for_nrvo(body) {
             Some(l) => l,
             None => {


### PR DESCRIPTION
The destination propagation as currently implemented does not supersede the NRVO, e.g., the destination propagation never applies if either local has an address taken, while NRVO might.

Additionally, the issue with failing assertions had been already resolved.

Continue running both optimizations at mir-opt-level >= 2.