### PR TITLE
Swap self and other in vec::append when it avoids a reallocation

### DIFF
--- a/library/alloc/src/vec.rs
+++ b/library/alloc/src/vec.rs
@@ -243,8 +243,8 @@ use crate::raw_vec::RawVec;
 /// * It would penalize the general case, incurring an additional branch
 ///   on every access.
 ///
-/// `Vec` will never automatically shrink itself, even if completely empty. This
-/// ensures no unnecessary allocations or deallocations occur. Emptying a `Vec`
+/// `Vec` will not automatically shrink itself, even if completely empty, when doing so
+/// would cause unnecessary allocations or deallocations to occur. Emptying a `Vec`
 /// and then filling it back up to the same [`len`] should incur no calls to
 /// the allocator. If you wish to free up unused memory, use
 /// [`shrink_to_fit`].


### PR DESCRIPTION
Spun out from #77496

Implements #56763

This needs discussion since it slightly weakens the "no shrinking" guarantee, even though it keeps with the stated intent of the rule that

>  This ensures no unnecessary allocations or deallocations occur.