### PR TITLE
const_eval: do not try to resolve instances containing bound vars

### DIFF
--- a/compiler/rustc_middle/src/ty/consts/kind.rs
+++ b/compiler/rustc_middle/src/ty/consts/kind.rs
@@ -110,11 +110,7 @@ impl<'tcx> ConstKind<'tcx> {
             struct Meh;
             impl<'tcx> ty::fold::TypeVisitor<'tcx> for Meh {
                 fn visit_ty(&mut self, ty: Ty<'tcx>) -> bool {
-                    if matches!(ty.kind, ty::Bound(..)) {
-                        true
-                    } else {
-                        ty.super_visit_with(self)
-                    }
+                    if matches!(ty.kind, ty::Bound(..)) { true } else { ty.super_visit_with(self) }
                 }
 
                 fn visit_const(&mut self, ct: &'tcx ty::Const<'tcx>) -> bool {
@@ -125,18 +121,19 @@ impl<'tcx> ConstKind<'tcx> {
                     }
                 }
             }
-            
+
             // HACK(eddyb) when the query key would contain inference variables,
             // attempt using identity substs and `ParamEnv` instead, that will succeed
             // when the expression doesn't depend on any parameters.
             // FIXME(eddyb, skinny121) pass `InferCtxt` into here when it's available, so that
             // we can call `infcx.const_eval_resolve` which handles inference variables.
-            let param_env_and_substs =
-                if param_env_and_substs.needs_infer() || param_env_and_substs.visit_with(&mut Meh) {
-                    tcx.param_env(def.did).and(InternalSubsts::identity_for_item(tcx, def.did))
-                } else {
-                    param_env_and_substs
-                };
+            let param_env_and_substs = if param_env_and_substs.needs_infer()
+                || param_env_and_substs.visit_with(&mut Meh)
+            {
+                tcx.param_env(def.did).and(InternalSubsts::identity_for_item(tcx, def.did))
+            } else {
+                param_env_and_substs
+            };
 
             // FIXME(eddyb) maybe the `const_eval_*` methods should take
             // `ty::ParamEnvAnd<SubstsRef>` instead of having them separate.

--- a/compiler/rustc_mir/src/interpret/eval_context.rs
+++ b/compiler/rustc_mir/src/interpret/eval_context.rs
@@ -530,11 +530,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
         struct Meh;
         impl<'tcx> ty::fold::TypeVisitor<'tcx> for Meh {
             fn visit_ty(&mut self, ty: Ty<'tcx>) -> bool {
-                if matches!(ty.kind(), ty::Bound(..)) {
-                    true
-                } else {
-                    ty.super_visit_with(self)
-                }
+                if matches!(ty.kind(), ty::Bound(..)) { true } else { ty.super_visit_with(self) }
             }
 
             fn visit_const(&mut self, ct: &'tcx ty::Const<'tcx>) -> bool {

--- a/src/test/ui/const-generics/const_evaluatable_checked/codegen-select-ice.rs
+++ b/src/test/ui/const-generics/const_evaluatable_checked/codegen-select-ice.rs
@@ -1,0 +1,32 @@
+// run-pass
+#![feature(const_generics, const_evaluatable_checked)]
+#![allow(incomplete_features)]
+
+trait FromBytesLittleEndian {
+    const N: usize;
+    fn from_bytes_le(other: &[u8; Self::N]) -> Self;
+}
+
+impl FromBytesLittleEndian for u32 {
+    const N: usize = 4;
+    fn from_bytes_le(other: &[u8; 4]) -> Self {
+        Self::from_le_bytes(*other)
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct Header(u32);
+
+impl FromBytesLittleEndian for Header {
+    const N: usize = 4;
+    fn from_bytes_le(r: &[u8; 4]) -> Self {
+        Self(FromBytesLittleEndian::from_bytes_le(r))
+        // This previously caused an ICE in the above line.
+    }
+}
+
+fn main() {
+    let data = [1, 2, 3, 4];
+    let h = Header::from_bytes_le(&data);
+    assert_eq!(h, Header(0x04030201));
+}

--- a/src/test/ui/const-generics/issues/issue-64494.full.stderr
+++ b/src/test/ui/const-generics/issues/issue-64494.full.stderr
@@ -1,18 +1,12 @@
-error: constant expression depends on a generic parameter
-  --> $DIR/issue-64494.rs:16:53
+error[E0119]: conflicting implementations of trait `MyTrait`:
+  --> $DIR/issue-64494.rs:18:1
    |
 LL | impl<T: Foo> MyTrait for T where Is<{T::VAL == 5}>: True {}
-   |                                                     ^^^^
-   |
-   = note: this may fail depending on what value the parameter takes
-
-error: constant expression depends on a generic parameter
-  --> $DIR/issue-64494.rs:19:53
-   |
+   | ------------------------------------ first implementation here
+LL |
 LL | impl<T: Foo> MyTrait for T where Is<{T::VAL == 6}>: True {}
-   |                                                     ^^^^
-   |
-   = note: this may fail depending on what value the parameter takes
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation
 
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0119`.

--- a/src/test/ui/const-generics/issues/issue-64494.min.stderr
+++ b/src/test/ui/const-generics/issues/issue-64494.min.stderr
@@ -7,7 +7,7 @@ LL | impl<T: Foo> MyTrait for T where Is<{T::VAL == 5}>: True {}
    = note: type parameters are currently not permitted in anonymous constants
 
 error: generic parameters must not be used inside of non trivial constant values
-  --> $DIR/issue-64494.rs:19:38
+  --> $DIR/issue-64494.rs:18:38
    |
 LL | impl<T: Foo> MyTrait for T where Is<{T::VAL == 6}>: True {}
    |                                      ^^^^^^ non-trivial anonymous constants must not depend on the parameter `T`
@@ -15,11 +15,11 @@ LL | impl<T: Foo> MyTrait for T where Is<{T::VAL == 6}>: True {}
    = note: type parameters are currently not permitted in anonymous constants
 
 error[E0119]: conflicting implementations of trait `MyTrait`:
-  --> $DIR/issue-64494.rs:19:1
+  --> $DIR/issue-64494.rs:18:1
    |
 LL | impl<T: Foo> MyTrait for T where Is<{T::VAL == 5}>: True {}
    | ------------------------------------ first implementation here
-...
+LL |
 LL | impl<T: Foo> MyTrait for T where Is<{T::VAL == 6}>: True {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation
 

--- a/src/test/ui/const-generics/issues/issue-64494.rs
+++ b/src/test/ui/const-generics/issues/issue-64494.rs
@@ -14,11 +14,9 @@ struct Is<const T: bool>;
 impl True for Is<{true}> {}
 
 impl<T: Foo> MyTrait for T where Is<{T::VAL == 5}>: True {}
-//[full]~^ ERROR constant expression depends on a generic parameter
-//[min]~^^ ERROR generic parameters must not be used inside of non trivial constant values
+//[min]~^ ERROR generic parameters must not be used inside of non trivial constant values
 impl<T: Foo> MyTrait for T where Is<{T::VAL == 6}>: True {}
-//[full]~^ ERROR constant expression depends on a generic parameter
-//[min]~^^ ERROR generic parameters must not be used inside of non trivial constant values
-//[min]~| ERROR conflicting implementations of trait `MyTrait`
+//[min]~^ ERROR generic parameters must not be used inside of non trivial constant values
+//~^^ ERROR conflicting implementations of trait
 
 fn main() {}


### PR DESCRIPTION
This is still just a bodge, if it seems like the correct solution here I will clean this up.

cc #76560 Implements the step

- fix ICE "error: internal compiler error: Encountered error `Unimplemented` selecting..." ([playground](https://play.integer32.com/?version=nightly&mode=debug&edition=2018&gist=615f3d1aaba3cfc182a11d5e25a012ad))

cc @shepmaster 

r? @eddyb