### PR TITLE
Force posix-style quoting on lld, independent of host platform

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/command.rs
+++ b/compiler/rustc_codegen_ssa/src/back/command.rs
@@ -111,6 +111,12 @@ impl Command {
                     LldFlavor::Link => "link",
                     LldFlavor::Ld64 => "darwin",
                 });
+                if let LldFlavor::Wasm = flavor {
+                    // LLVM expects host-specific formatting for @file
+                    // arguments, but we always generate posix formatted files
+                    // at this time. Indicate as such.
+                    c.arg("--rsp-quoting=posix");
+                }
                 c
             }
         };


### PR DESCRIPTION
This just blindly applies the logic from @eddyb's comment here: https://github.com/rust-lang/rust/issues/76466#issuecomment-699024973

Hopefully, this fixed #76466 -- I cannot test this though.