### PR TITLE
Use `RTLD_DEEPBIND` for loading dylibs/proc-macros

### DIFF
--- a/compiler/rustc_metadata/src/dynamic_lib.rs
+++ b/compiler/rustc_metadata/src/dynamic_lib.rs
@@ -99,7 +99,9 @@ mod dl {
         let s = CString::new(filename.as_bytes()).unwrap();
 
         let mut dlerror = error::lock();
-        let ret = unsafe { libc::dlopen(s.as_ptr(), libc::RTLD_LAZY | libc::RTLD_LOCAL) };
+        let ret = unsafe {
+            libc::dlopen(s.as_ptr(), libc::RTLD_LAZY | libc::RTLD_LOCAL | libc::RTLD_DEEPBIND)
+        };
 
         if !ret.is_null() {
             return Ok(ret.cast());


### PR DESCRIPTION
This should fix https://github.com/rust-lang/rust/issues/76980, by loading symbols from proc macro dylibs from the dylib itself, before falling back to symbols provided by the compiler or its dependencies.