### PR TITLE
fix def collector for impl trait

### DIFF
--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -538,6 +538,11 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                         }
                         self.visit_fn_ret_ty(&f.decl.output)
                     }
+                    TyKind::ImplTrait(_, ref bounds) => {
+                        self.with_hir_id_owner(None, |this| {
+                            walk_list!(this, visit_param_bound, bounds);
+                        });
+                    }
                     _ => visit::walk_ty(self, t),
                 }
             }

--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -2210,7 +2210,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                         .attrs
                         .iter()
                         .filter(|attr| self.sess.check_name(attr, sym::rustc_synthetic))
-                        .map(|_| hir::SyntheticTyParamKind::Rustc)
+                        .map(|_| hir::SyntheticTyParamKind::FromAttr)
                         .next(),
                 };
 

--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -2210,7 +2210,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                         .attrs
                         .iter()
                         .filter(|attr| self.sess.check_name(attr, sym::rustc_synthetic))
-                        .map(|_| hir::SyntheticTyParamKind::ImplTrait)
+                        .map(|_| hir::SyntheticTyParamKind::Rustc)
                         .next(),
                 };
 

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -509,7 +509,7 @@ impl Generics<'hir> {
 pub enum SyntheticTyParamKind {
     ImplTrait,
     // Created by the `#[rustc_synthetic]` attribute.
-    Rustc,
+    FromAttr,
 }
 
 /// A where-clause in a definition.

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -508,6 +508,8 @@ impl Generics<'hir> {
 #[derive(HashStable_Generic)]
 pub enum SyntheticTyParamKind {
     ImplTrait,
+    // Created by the `#[rustc_synthetic]` attribute.
+    Rustc,
 }
 
 /// A where-clause in a definition.

--- a/compiler/rustc_passes/src/hir_id_validator.rs
+++ b/compiler/rustc_passes/src/hir_id_validator.rs
@@ -170,7 +170,8 @@ impl<'a, 'hir> intravisit::Visitor<'hir> for HirIdValidator<'a, 'hir> {
             ..
         } = param.kind
         {
-            // Do nothing because bodging is fun.
+            // Synthetic impl trait parameters are owned by the node of the desugared type.
+            // This means it is correct for them to have a different owner.
         } else {
             intravisit::walk_generic_param(self, param);
         }

--- a/compiler/rustc_passes/src/hir_id_validator.rs
+++ b/compiler/rustc_passes/src/hir_id_validator.rs
@@ -163,4 +163,16 @@ impl<'a, 'hir> intravisit::Visitor<'hir> for HirIdValidator<'a, 'hir> {
         // we are currently in. So for those it's correct that they have a
         // different owner.
     }
+
+    fn visit_generic_param(&mut self, param: &'hir hir::GenericParam<'hir>) {
+        if let hir::GenericParamKind::Type {
+            synthetic: Some(hir::SyntheticTyParamKind::ImplTrait),
+            ..
+        } = param.kind
+        {
+            // Do nothing because bodging is fun.
+        } else {
+            intravisit::walk_generic_param(self, param);
+        }
+    }
 }

--- a/compiler/rustc_resolve/src/def_collector.rs
+++ b/compiler/rustc_resolve/src/def_collector.rs
@@ -239,13 +239,13 @@ impl<'a, 'b> visit::Visitor<'a> for DefCollector<'a, 'b> {
 
     fn visit_ty(&mut self, ty: &'a Ty) {
         match ty.kind {
-            TyKind::MacCall(..) => return self.visit_macro_invoc(ty.id),
+            TyKind::MacCall(..) => self.visit_macro_invoc(ty.id),
             TyKind::ImplTrait(node_id, _) => {
-                self.create_def(node_id, DefPathData::ImplTrait, ty.span);
+                let parent_def = self.create_def(node_id, DefPathData::ImplTrait, ty.span);
+                self.with_parent(parent_def, |this| visit::walk_ty(this, ty));
             }
-            _ => {}
+            _ => visit::walk_ty(self, ty),
         }
-        visit::walk_ty(self, ty);
     }
 
     fn visit_stmt(&mut self, stmt: &'a Stmt) {

--- a/compiler/rustc_save_analysis/src/dump_visitor.rs
+++ b/compiler/rustc_save_analysis/src/dump_visitor.rs
@@ -320,6 +320,15 @@ impl<'tcx> DumpVisitor<'tcx> {
         for param in generics.params {
             match param.kind {
                 hir::GenericParamKind::Lifetime { .. } => {}
+                hir::GenericParamKind::Type {
+                    synthetic: Some(hir::SyntheticTyParamKind::ImplTrait),
+                    ..
+                } => {
+                    return self
+                        .nest_typeck_results(self.tcx.hir().local_def_id(param.hir_id), |this| {
+                            this.visit_generics(generics)
+                        });
+                }
                 hir::GenericParamKind::Type { .. } => {
                     let param_ss = param.name.ident().span;
                     let name = escape(self.span.snippet(param_ss));
@@ -351,7 +360,8 @@ impl<'tcx> DumpVisitor<'tcx> {
                 hir::GenericParamKind::Const { .. } => {}
             }
         }
-        self.visit_generics(generics);
+
+        self.visit_generics(generics)
     }
 
     fn process_fn(

--- a/compiler/rustc_typeck/src/astconv/generics.rs
+++ b/compiler/rustc_typeck/src/astconv/generics.rs
@@ -550,7 +550,8 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
         let explicit = !seg.infer_args;
         let impl_trait = generics.params.iter().any(|param| match param.kind {
             ty::GenericParamDefKind::Type {
-                synthetic: Some(hir::SyntheticTyParamKind::ImplTrait),
+                synthetic:
+                    Some(hir::SyntheticTyParamKind::ImplTrait | hir::SyntheticTyParamKind::Rustc),
                 ..
             } => true,
             _ => false,

--- a/compiler/rustc_typeck/src/astconv/generics.rs
+++ b/compiler/rustc_typeck/src/astconv/generics.rs
@@ -548,14 +548,18 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
         generics: &ty::Generics,
     ) -> bool {
         let explicit = !seg.infer_args;
-        let impl_trait = generics.params.iter().any(|param| match param.kind {
-            ty::GenericParamDefKind::Type {
-                synthetic:
-                    Some(hir::SyntheticTyParamKind::ImplTrait | hir::SyntheticTyParamKind::Rustc),
-                ..
-            } => true,
-            _ => false,
-        });
+        let impl_trait =
+            generics.params.iter().any(|param| match param.kind {
+                ty::GenericParamDefKind::Type {
+                    synthetic:
+                        Some(
+                            hir::SyntheticTyParamKind::ImplTrait
+                            | hir::SyntheticTyParamKind::FromAttr,
+                        ),
+                    ..
+                } => true,
+                _ => false,
+            });
 
         if explicit && impl_trait {
             let spans = seg

--- a/src/test/ui/impl-trait/closure-in-impl-trait-arg.rs
+++ b/src/test/ui/impl-trait/closure-in-impl-trait-arg.rs
@@ -1,0 +1,7 @@
+// run-pass
+#![allow(unused_must_use)]
+fn bug(_: impl Iterator<Item = [(); { |x: u32| { x }; 4 }]>) {}
+
+fn main() {
+    bug(std::iter::empty());
+}

--- a/src/test/ui/impl-trait/closure-in-impl-trait.rs
+++ b/src/test/ui/impl-trait/closure-in-impl-trait.rs
@@ -1,0 +1,14 @@
+// run-pass
+#![allow(unused_must_use)]
+fn bug<T>() -> impl Iterator<Item = [(); { |x: u32| { x }; 4 }]> {
+    std::iter::empty()
+}
+
+fn ok<T>() -> Box<dyn Iterator<Item = [(); { |x: u32| { x }; 4 }]>> {
+    Box::new(std::iter::empty())
+}
+
+fn main() {
+    for _item in ok::<u32>() {}
+    for _item in bug::<u32>() {}
+}


### PR DESCRIPTION
fixes #77329

We now consistently make `impl Trait` a hir owner, requiring some special casing for synthetic generic params.

r? @eddyb 