### PR TITLE
Support signed integers and `char` in v0 mangling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3276,9 +3276,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2610b7f643d18c87dff3b489950269617e6601a51f1f05aa5daefee36f64f0b"
+checksum = "6e3bad0ee36814ca07d7968269dd4b7ec89ec2da10c4bb613928d3077083c232"
 dependencies = [
  "compiler_builtins",
  "rustc-std-workspace-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3276,9 +3276,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
+checksum = "b2610b7f643d18c87dff3b489950269617e6601a51f1f05aa5daefee36f64f0b"
 dependencies = [
  "compiler_builtins",
  "rustc-std-workspace-core",

--- a/compiler/rustc_codegen_llvm/Cargo.toml
+++ b/compiler/rustc_codegen_llvm/Cargo.toml
@@ -15,7 +15,7 @@ measureme = "0.7.1"
 snap = "1"
 tracing = "0.1"
 rustc_middle = { path = "../rustc_middle" }
-rustc-demangle = "0.1.17"
+rustc-demangle = "0.1.18"
 rustc_attr = { path = "../rustc_attr" }
 rustc_codegen_ssa = { path = "../rustc_codegen_ssa" }
 rustc_data_structures = { path = "../rustc_data_structures" }

--- a/compiler/rustc_codegen_llvm/Cargo.toml
+++ b/compiler/rustc_codegen_llvm/Cargo.toml
@@ -15,7 +15,7 @@ measureme = "0.7.1"
 snap = "1"
 tracing = "0.1"
 rustc_middle = { path = "../rustc_middle" }
-rustc-demangle = "0.1"
+rustc-demangle = "0.1.17"
 rustc_attr = { path = "../rustc_attr" }
 rustc_codegen_ssa = { path = "../rustc_codegen_ssa" }
 rustc_data_structures = { path = "../rustc_data_structures" }

--- a/compiler/rustc_symbol_mangling/Cargo.toml
+++ b/compiler/rustc_symbol_mangling/Cargo.toml
@@ -10,7 +10,7 @@ doctest = false
 [dependencies]
 tracing = "0.1"
 punycode = "0.4.0"
-rustc-demangle = "0.1.17"
+rustc-demangle = "0.1.18"
 
 rustc_ast = { path = "../rustc_ast" }
 rustc_span = { path = "../rustc_span" }

--- a/compiler/rustc_symbol_mangling/Cargo.toml
+++ b/compiler/rustc_symbol_mangling/Cargo.toml
@@ -10,7 +10,7 @@ doctest = false
 [dependencies]
 tracing = "0.1"
 punycode = "0.4.0"
-rustc-demangle = "0.1.16"
+rustc-demangle = "0.1.17"
 
 rustc_ast = { path = "../rustc_ast" }
 rustc_span = { path = "../rustc_span" }

--- a/compiler/rustc_symbol_mangling/src/v0.rs
+++ b/compiler/rustc_symbol_mangling/src/v0.rs
@@ -4,6 +4,7 @@ use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_hir as hir;
 use rustc_hir::def_id::{CrateNum, DefId};
 use rustc_hir::definitions::{DefPathData, DisambiguatedDefPathData};
+use rustc_middle::mir::interpret::sign_extend;
 use rustc_middle::ty::print::{Print, Printer};
 use rustc_middle::ty::subst::{GenericArg, GenericArgKind, Subst};
 use rustc_middle::ty::{self, Instance, Ty, TyCtxt, TypeFoldable};
@@ -527,17 +528,30 @@ impl Printer<'tcx> for SymbolMangler<'tcx> {
         }
         let start = self.out.len();
 
-        match ct.ty.kind() {
-            ty::Uint(_) => {}
-            ty::Bool => {}
+        let mut neg = false;
+        let val = match ct.ty.kind() {
+            ty::Uint(_) | ty::Bool | ty::Char => {
+                ct.try_eval_bits(self.tcx, ty::ParamEnv::reveal_all(), ct.ty)
+            }
+            ty::Int(_) => {
+                let param_env = ty::ParamEnv::reveal_all();
+                ct.try_eval_bits(self.tcx, param_env, ct.ty).and_then(|b| {
+                    let sz = self.tcx.layout_of(param_env.and(ct.ty)).ok()?.size;
+                    let val = sign_extend(b, sz) as i128;
+                    if val < 0 {
+                        neg = true;
+                    }
+                    Some(val.wrapping_abs() as u128)
+                })
+            }
             _ => {
                 bug!("symbol_names: unsupported constant of type `{}` ({:?})", ct.ty, ct);
             }
-        }
+        };
         self = ct.ty.print(self)?;
 
-        if let Some(bits) = ct.try_eval_bits(self.tcx, ty::ParamEnv::reveal_all(), ct.ty) {
-            let _ = write!(self.out, "{:x}_", bits);
+        if let Some(bits) = val {
+            let _ = write!(self.out, "{}{:x}_", if neg { "n" } else { "" }, bits);
         } else {
             // NOTE(eddyb) despite having the path, we need to
             // encode a placeholder, as the path could refer

--- a/compiler/rustc_symbol_mangling/src/v0.rs
+++ b/compiler/rustc_symbol_mangling/src/v0.rs
@@ -548,9 +548,10 @@ impl Printer<'tcx> for SymbolMangler<'tcx> {
                 bug!("symbol_names: unsupported constant of type `{}` ({:?})", ct.ty, ct);
             }
         };
-        self = ct.ty.print(self)?;
 
         if let Some(bits) = val {
+            // We only print the type if the const can be evaluated.
+            self = ct.ty.print(self)?;
             let _ = write!(self.out, "{}{:x}_", if neg { "n" } else { "" }, bits);
         } else {
             // NOTE(eddyb) despite having the path, we need to

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -24,7 +24,7 @@ hashbrown = { version = "0.9.0", default-features = false, features = ['rustc-de
 
 # Dependencies of the `backtrace` crate
 addr2line = { version = "0.13.0", optional = true, default-features = false }
-rustc-demangle = { version = "0.1.17", features = ['rustc-dep-of-std'] }
+rustc-demangle = { version = "0.1.18", features = ['rustc-dep-of-std'] }
 miniz_oxide = { version = "0.4.0", optional = true, default-features = false }
 [dependencies.object]
 version = "0.20"

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -24,7 +24,7 @@ hashbrown = { version = "0.9.0", default-features = false, features = ['rustc-de
 
 # Dependencies of the `backtrace` crate
 addr2line = { version = "0.13.0", optional = true, default-features = false }
-rustc-demangle = { version = "0.1.4", features = ['rustc-dep-of-std'] }
+rustc-demangle = { version = "0.1.17", features = ['rustc-dep-of-std'] }
 miniz_oxide = { version = "0.4.0", optional = true, default-features = false }
 [dependencies.object]
 version = "0.20"

--- a/src/test/ui/symbol-names/const-generics-demangling.rs
+++ b/src/test/ui/symbol-names/const-generics-demangling.rs
@@ -1,0 +1,38 @@
+// build-fail
+// compile-flags: -Z symbol-mangling-version=v0
+
+#![feature(min_const_generics, rustc_attrs)]
+
+pub struct Unsigned<const F: u8>;
+
+#[rustc_symbol_name]
+//~^ ERROR symbol-name(_RMCs4fqI2P2rA04_25const_generics_demanglingINtB0_8UnsignedKhb_E)
+//~| ERROR demangling(<const_generics_demangling[317d481089b8c8fe]::Unsigned<11: u8>>)
+//~| ERROR demangling-alt(<const_generics_demangling::Unsigned<11>>)
+impl Unsigned<11> {}
+
+pub struct Signed<const F: i16>;
+
+#[rustc_symbol_name]
+//~^ ERROR symbol-name(_RMs_Cs4fqI2P2rA04_25const_generics_demanglingINtB2_6SignedKsn98_E)
+//~| ERROR demangling(<const_generics_demangling[317d481089b8c8fe]::Signed<-152: i16>>)
+//~| ERROR demangling-alt(<const_generics_demangling::Signed<-152>>)
+impl Signed<-152> {}
+
+pub struct Bool<const F: bool>;
+
+#[rustc_symbol_name]
+//~^ ERROR symbol-name(_RMs0_Cs4fqI2P2rA04_25const_generics_demanglingINtB3_4BoolKb1_E)
+//~| ERROR demangling(<const_generics_demangling[317d481089b8c8fe]::Bool<true: bool>>)
+//~| ERROR demangling-alt(<const_generics_demangling::Bool<true>>)
+impl Bool<true> {}
+
+pub struct Char<const F: char>;
+
+#[rustc_symbol_name]
+//~^ ERROR symbol-name(_RMs1_Cs4fqI2P2rA04_25const_generics_demanglingINtB3_4CharKc2202_E)
+//~| ERROR demangling(<const_generics_demangling[317d481089b8c8fe]::Char<'∂': char>>)
+//~| ERROR demangling-alt(<const_generics_demangling::Char<'∂'>>)
+impl Char<'∂'> {}
+
+fn main() {}

--- a/src/test/ui/symbol-names/const-generics-demangling.stderr
+++ b/src/test/ui/symbol-names/const-generics-demangling.stderr
@@ -1,0 +1,74 @@
+error: symbol-name(_RMCs4fqI2P2rA04_25const_generics_demanglingINtB0_8UnsignedKhb_E)
+  --> $DIR/const-generics-demangling.rs:8:1
+   |
+LL | #[rustc_symbol_name]
+   | ^^^^^^^^^^^^^^^^^^^^
+
+error: demangling(<const_generics_demangling[317d481089b8c8fe]::Unsigned<11: u8>>)
+  --> $DIR/const-generics-demangling.rs:8:1
+   |
+LL | #[rustc_symbol_name]
+   | ^^^^^^^^^^^^^^^^^^^^
+
+error: demangling-alt(<const_generics_demangling::Unsigned<11>>)
+  --> $DIR/const-generics-demangling.rs:8:1
+   |
+LL | #[rustc_symbol_name]
+   | ^^^^^^^^^^^^^^^^^^^^
+
+error: symbol-name(_RMs_Cs4fqI2P2rA04_25const_generics_demanglingINtB2_6SignedKsn98_E)
+  --> $DIR/const-generics-demangling.rs:16:1
+   |
+LL | #[rustc_symbol_name]
+   | ^^^^^^^^^^^^^^^^^^^^
+
+error: demangling(<const_generics_demangling[317d481089b8c8fe]::Signed<-152: i16>>)
+  --> $DIR/const-generics-demangling.rs:16:1
+   |
+LL | #[rustc_symbol_name]
+   | ^^^^^^^^^^^^^^^^^^^^
+
+error: demangling-alt(<const_generics_demangling::Signed<-152>>)
+  --> $DIR/const-generics-demangling.rs:16:1
+   |
+LL | #[rustc_symbol_name]
+   | ^^^^^^^^^^^^^^^^^^^^
+
+error: symbol-name(_RMs0_Cs4fqI2P2rA04_25const_generics_demanglingINtB3_4BoolKb1_E)
+  --> $DIR/const-generics-demangling.rs:24:1
+   |
+LL | #[rustc_symbol_name]
+   | ^^^^^^^^^^^^^^^^^^^^
+
+error: demangling(<const_generics_demangling[317d481089b8c8fe]::Bool<true: bool>>)
+  --> $DIR/const-generics-demangling.rs:24:1
+   |
+LL | #[rustc_symbol_name]
+   | ^^^^^^^^^^^^^^^^^^^^
+
+error: demangling-alt(<const_generics_demangling::Bool<true>>)
+  --> $DIR/const-generics-demangling.rs:24:1
+   |
+LL | #[rustc_symbol_name]
+   | ^^^^^^^^^^^^^^^^^^^^
+
+error: symbol-name(_RMs1_Cs4fqI2P2rA04_25const_generics_demanglingINtB3_4CharKc2202_E)
+  --> $DIR/const-generics-demangling.rs:32:1
+   |
+LL | #[rustc_symbol_name]
+   | ^^^^^^^^^^^^^^^^^^^^
+
+error: demangling(<const_generics_demangling[317d481089b8c8fe]::Char<'∂': char>>)
+  --> $DIR/const-generics-demangling.rs:32:1
+   |
+LL | #[rustc_symbol_name]
+   | ^^^^^^^^^^^^^^^^^^^^
+
+error: demangling-alt(<const_generics_demangling::Char<'∂'>>)
+  --> $DIR/const-generics-demangling.rs:32:1
+   |
+LL | #[rustc_symbol_name]
+   | ^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 12 previous errors
+

--- a/src/test/ui/symbol-names/const-generics.rs
+++ b/src/test/ui/symbol-names/const-generics.rs
@@ -1,0 +1,87 @@
+// check-pass
+// revisions: legacy v0
+//[legacy]compile-flags: -Z symbol-mangling-version=legacy --crate-type=lib
+    //[v0]compile-flags: -Z symbol-mangling-version=v0 --crate-type=lib
+
+    #![feature(min_const_generics)]
+
+    // `char`
+    pub struct Char<const F: char>;
+
+    impl Char<'A'> {
+        pub fn foo() {}
+    }
+
+    impl<const F: char> Char<F> {
+        pub fn bar() {}
+    }
+
+    // `i8`
+    pub struct I8<const F: i8>;
+
+    impl I8<{std::i8::MIN}> {
+        pub fn foo() {}
+    }
+
+    impl I8<{std::i8::MAX}> {
+        pub fn foo() {}
+    }
+
+    impl<const F: i8> I8<F> {
+        pub fn bar() {}
+    }
+
+    // `i16`
+    pub struct I16<const F: i16>;
+
+    impl I16<{std::i16::MIN}> {
+        pub fn foo() {}
+    }
+
+    impl<const F: i16> I16<F> {
+        pub fn bar() {}
+    }
+
+    // `i32`
+    pub struct I32<const F: i32>;
+
+    impl I32<{std::i32::MIN}> {
+        pub fn foo() {}
+    }
+
+    impl<const F: i32> I32<F> {
+        pub fn bar() {}
+    }
+
+    // `i64`
+    pub struct I64<const F: i64>;
+
+    impl I64<{std::i64::MIN}> {
+        pub fn foo() {}
+    }
+
+    impl<const F: i64> I64<F> {
+        pub fn bar() {}
+    }
+
+    // `i128`
+    pub struct I128<const F: i128>;
+
+    impl I128<{std::i128::MIN}> {
+        pub fn foo() {}
+    }
+
+    impl<const F: i128> I128<F> {
+        pub fn bar() {}
+    }
+
+    // `isize`
+    pub struct ISize<const F: isize>;
+
+    impl ISize<3> {
+        pub fn foo() {}
+    }
+
+    impl<const F: isize> ISize<F> {
+        pub fn bar() {}
+    }

--- a/src/tools/rust-demangler/Cargo.toml
+++ b/src/tools/rust-demangler/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 regex = "1.0"
-rustc-demangle = "0.1"
+rustc-demangle = "0.1.17"
 
 [[bin]]
 name = "rust-demangler"


### PR DESCRIPTION
Likely we want more tests, to check the output is correct too: however, I wasn't sure what kind of test we needed, so I just added one similar to that added in https://github.com/rust-lang/rust/pull/77452 for now.

r? @eddyb