### PR TITLE
feat: Update hashbrown to instantiate less llvm IR

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1507,9 +1507,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00d63df3d41950fb462ed38308eea019113ad1508da725bbedcd0fa5a85ef5f7"
+checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+
+[[package]]
+name = "hashbrown"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "362385356d610bd1e5a408ddf8d022041774b683f345a1d2cfcb4f60f8ae2db5"
 dependencies = [
  "compiler_builtins",
  "rustc-std-workspace-alloc",
@@ -1653,7 +1659,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55e2e4c765aa53a0424761bf9f41aa7a6ac1efa87238f59560640e27fca028f2"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.9.1",
 ]
 
 [[package]]
@@ -2351,9 +2357,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.4.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "260e51e7efe62b592207e9e13a68e43692a7a279171d6ba57abd208bf23645ad"
+checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
 
 [[package]]
 name = "opaque-debug"
@@ -4987,7 +4993,7 @@ dependencies = [
  "core",
  "dlmalloc",
  "fortanix-sgx-abi",
- "hashbrown",
+ "hashbrown 0.11.0",
  "hermit-abi",
  "libc",
  "miniz_oxide",

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -20,7 +20,7 @@ libc = { version = "0.2.88", default-features = false, features = ['rustc-dep-of
 compiler_builtins = { version = "0.1.39" }
 profiler_builtins = { path = "../profiler_builtins", optional = true }
 unwind = { path = "../unwind" }
-hashbrown = { version = "0.9.0", default-features = false, features = ['rustc-dep-of-std'] }
+hashbrown = { version = "0.11", default-features = false, features = ['rustc-dep-of-std'] }
 
 # Dependencies of the `backtrace` crate
 addr2line = { version = "0.14.0", optional = true, default-features = false }

--- a/src/etc/gdb_providers.py
+++ b/src/etc/gdb_providers.py
@@ -349,17 +349,18 @@ class StdHashMapProvider:
         self.show_values = show_values
 
         table = self.table()
-        capacity = int(table["bucket_mask"]) + 1
-        ctrl = table["ctrl"]["pointer"]
+        table_inner = table["table"]
+        capacity = int(table_inner["bucket_mask"]) + 1
+        ctrl = table_inner["ctrl"]["pointer"]
 
-        self.size = int(table["items"])
+        self.size = int(table_inner["items"])
         self.pair_type = table.type.template_argument(0).strip_typedefs()
 
-        self.new_layout = not table.type.has_key("data")
+        self.new_layout = not table_inner.type.has_key("data")
         if self.new_layout:
             self.data_ptr = ctrl.cast(self.pair_type.pointer())
         else:
-            self.data_ptr = table["data"]["pointer"]
+            self.data_ptr = table_inner["data"]["pointer"]
 
         self.valid_indices = []
         for idx in range(capacity):

--- a/src/etc/lldb_providers.py
+++ b/src/etc/lldb_providers.py
@@ -563,7 +563,7 @@ class StdHashMapSyntheticProvider:
             # HashSet wraps either std HashMap or hashbrown::HashSet, which both
             # wrap hashbrown::HashMap, so either way we "unwrap" twice.
             hashbrown_hashmap = self.valobj.GetChildAtIndex(0).GetChildAtIndex(0)
-        return hashbrown_hashmap.GetChildMemberWithName("table")
+        return hashbrown_hashmap.GetChildMemberWithName("table").GetChildMemberWithName("table")
 
     def has_children(self):
         # type: () -> bool

--- a/src/etc/natvis/libstd.natvis
+++ b/src/etc/natvis/libstd.natvis
@@ -50,22 +50,22 @@
   </Type>
 
   <Type Name="std::collections::hash::set::HashSet&lt;*,*&gt;">
-    <DisplayString>{{ len={base.map.table.items} }}</DisplayString>
+    <DisplayString>{{ len={base.map.table.table.items} }}</DisplayString>
     <Expand>
-      <Item Name="[len]">base.map.table.items</Item>
-      <Item Name="[capacity]">base.map.table.items + base.map.table.growth_left</Item>
+      <Item Name="[len]">base.map.table.table.items</Item>
+      <Item Name="[capacity]">base.map.table.table.items + base.map.table.table.growth_left</Item>
       <Item Name="[state]">base.map.hash_builder</Item>
 
       <CustomListItems>
         <Variable Name="i" InitialValue="0" />
-        <Variable Name="n" InitialValue="base.map.table.items" />
-        <Size>base.map.table.items</Size>
+        <Variable Name="n" InitialValue="base.map.table.table.items" />
+        <Size>base.map.table.table.items</Size>
         <Loop>
           <Break Condition="n == 0" />
-          <If Condition="(base.map.table.ctrl.pointer[i] &amp; 0x80) == 0">
+          <If Condition="(base.map.table.table.ctrl.pointer[i] &amp; 0x80) == 0">
             <!-- Bucket is populated -->
             <Exec>n--</Exec>
-            <Item>(($T1*)base.map.table.ctrl.pointer)[-(i + 1)]</Item>
+            <Item>(($T1*)base.map.table.table.ctrl.pointer)[-(i + 1)]</Item>
           </If>
           <Exec>i++</Exec>
         </Loop>

--- a/src/etc/natvis/libstd.natvis
+++ b/src/etc/natvis/libstd.natvis
@@ -26,22 +26,22 @@
   -->
 
   <Type Name="std::collections::hash::map::HashMap&lt;*,*,*&gt;">
-    <DisplayString>{{ len={base.table.items} }}</DisplayString>
+    <DisplayString>{{ len={base.table.table.items} }}</DisplayString>
     <Expand>
-      <Item Name="[len]">base.table.items</Item>
-      <Item Name="[capacity]">base.table.items + base.table.growth_left</Item>
+      <Item Name="[len]">base.table.table.items</Item>
+      <Item Name="[capacity]">base.table.table.items + base.table.table.growth_left</Item>
       <Item Name="[state]">base.hash_builder</Item>
 
       <CustomListItems>
         <Variable Name="i" InitialValue="0" />
-        <Variable Name="n" InitialValue="base.table.items" />
-        <Size>base.table.items</Size>
+        <Variable Name="n" InitialValue="base.table.table.items" />
+        <Size>base.table.table.items</Size>
         <Loop>
           <Break Condition="n == 0" />
-          <If Condition="(base.table.ctrl.pointer[i] &amp; 0x80) == 0">
+          <If Condition="(base.table.table.ctrl.pointer[i] &amp; 0x80) == 0">
             <!-- Bucket is populated -->
             <Exec>n--</Exec>
-            <Item Name="{((tuple&lt;$T1, $T2&gt;*)base.table.ctrl.pointer)[-(i + 1)].__0}">((tuple&lt;$T1, $T2&gt;*)base.table.ctrl.pointer)[-(i + 1)].__1</Item>
+            <Item Name="{((tuple&lt;$T1, $T2&gt;*)base.table.table.ctrl.pointer)[-(i + 1)].__0}">((tuple&lt;$T1, $T2&gt;*)base.table.table.ctrl.pointer)[-(i + 1)].__1</Item>
           </If>
           <Exec>i++</Exec>
         </Loop>


### PR DESCRIPTION
Includes https://github.com/rust-lang/hashbrown/pull/204 and https://github.com/rust-lang/hashbrown/pull/205 (not yet merged) which both serve to reduce the amount of IR generated for hashmaps.

Inspired by the llvm-lines data gathered in https://github.com/rust-lang/rust/pull/76680 (cc @Julian-Wollersberger)