### PR TITLE
Allow ascii whitespace char for doc aliases 

### DIFF
--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -303,6 +303,16 @@ impl CheckAttrVisitor<'tcx> {
                                 .emit();
                             return false;
                         }
+                        if doc_alias.starts_with(' ') || doc_alias.ends_with(' ') {
+                            self.tcx
+                                .sess
+                                .struct_span_err(
+                                    meta.span(),
+                                    "`#[doc(alias = \"...\")]` cannot start or end with ' '",
+                                )
+                                .emit();
+                            return false;
+                        }
                         if let Some(err) = match target {
                             Target::Impl => Some("implementation block"),
                             Target::ForeignMod => Some("extern block"),

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -287,8 +287,9 @@ impl CheckAttrVisitor<'tcx> {
                             self.doc_alias_str_error(meta);
                             return false;
                         }
-                        if let Some(c) =
-                            doc_alias.chars().find(|&c| c == '"' || c == '\'' || c.is_whitespace())
+                        if let Some(c) = doc_alias
+                            .chars()
+                            .find(|&c| c == '"' || c == '\'' || (c.is_whitespace() && c != ' '))
                         {
                             self.tcx
                                 .sess

--- a/src/test/rustdoc-js/doc-alias-whitespace.js
+++ b/src/test/rustdoc-js/doc-alias-whitespace.js
@@ -1,0 +1,19 @@
+// exact-check
+
+const QUERY = [
+    'Demon Lord',
+];
+
+const EXPECTED = [
+    {
+        'others': [
+            {
+                'path': 'doc_alias_whitespace',
+                'name': 'Struct',
+                'alias': 'Demon Lord',
+                'href': '../doc_alias_whitespace/struct.Struct.html',
+                'is_alias': true
+            },
+        ],
+    },
+];

--- a/src/test/rustdoc-js/doc-alias-whitespace.rs
+++ b/src/test/rustdoc-js/doc-alias-whitespace.rs
@@ -1,0 +1,4 @@
+#![feature(doc_alias)]
+
+#[doc(alias = "Demon Lord")]
+pub struct Struct;

--- a/src/test/rustdoc-ui/check-doc-alias-attr.rs
+++ b/src/test/rustdoc-ui/check-doc-alias-attr.rs
@@ -12,4 +12,6 @@ pub struct Bar;
 #[doc(alias = "
 ")] //~^ ERROR
 #[doc(alias = "\t")] //~ ERROR
+#[doc(alias = " hello")] //~ ERROR
+#[doc(alias = "hello ")] //~ ERROR
 pub struct Foo;

--- a/src/test/rustdoc-ui/check-doc-alias-attr.rs
+++ b/src/test/rustdoc-ui/check-doc-alias-attr.rs
@@ -11,6 +11,5 @@ pub struct Bar;
 #[doc(alias = "\n")] //~ ERROR
 #[doc(alias = "
 ")] //~^ ERROR
-#[doc(alias = " ")] //~ ERROR
 #[doc(alias = "\t")] //~ ERROR
 pub struct Foo;

--- a/src/test/rustdoc-ui/check-doc-alias-attr.stderr
+++ b/src/test/rustdoc-ui/check-doc-alias-attr.stderr
@@ -36,17 +36,11 @@ LL |   #[doc(alias = "
 LL | | ")]
    | |_^
 
-error: ' ' character isn't allowed in `#[doc(alias = "...")]`
-  --> $DIR/check-doc-alias-attr.rs:14:7
-   |
-LL | #[doc(alias = " ")]
-   |       ^^^^^^^^^^^
-
 error: '\t' character isn't allowed in `#[doc(alias = "...")]`
-  --> $DIR/check-doc-alias-attr.rs:15:7
+  --> $DIR/check-doc-alias-attr.rs:14:7
    |
 LL | #[doc(alias = "\t")]
    |       ^^^^^^^^^^^^
 
-error: aborting due to 8 previous errors
+error: aborting due to 7 previous errors
 

--- a/src/test/rustdoc-ui/check-doc-alias-attr.stderr
+++ b/src/test/rustdoc-ui/check-doc-alias-attr.stderr
@@ -42,5 +42,17 @@ error: '\t' character isn't allowed in `#[doc(alias = "...")]`
 LL | #[doc(alias = "\t")]
    |       ^^^^^^^^^^^^
 
-error: aborting due to 7 previous errors
+error: `#[doc(alias = "...")]` cannot start or end with ' '
+  --> $DIR/check-doc-alias-attr.rs:15:7
+   |
+LL | #[doc(alias = " hello")]
+   |       ^^^^^^^^^^^^^^^^
+
+error: `#[doc(alias = "...")]` cannot start or end with ' '
+  --> $DIR/check-doc-alias-attr.rs:16:7
+   |
+LL | #[doc(alias = "hello ")]
+   |       ^^^^^^^^^^^^^^^^
+
+error: aborting due to 9 previous errors
 

--- a/src/test/ui/check-doc-alias-attr.rs
+++ b/src/test/ui/check-doc-alias-attr.rs
@@ -12,4 +12,6 @@ pub struct Bar;
 #[doc(alias = "
 ")] //~^ ERROR
 #[doc(alias = "\t")] //~ ERROR
+#[doc(alias = " hello")] //~ ERROR
+#[doc(alias = "hello ")] //~ ERROR
 pub struct Foo;

--- a/src/test/ui/check-doc-alias-attr.rs
+++ b/src/test/ui/check-doc-alias-attr.rs
@@ -11,6 +11,5 @@ pub struct Bar;
 #[doc(alias = "\n")] //~ ERROR
 #[doc(alias = "
 ")] //~^ ERROR
-#[doc(alias = " ")] //~ ERROR
 #[doc(alias = "\t")] //~ ERROR
 pub struct Foo;

--- a/src/test/ui/check-doc-alias-attr.stderr
+++ b/src/test/ui/check-doc-alias-attr.stderr
@@ -36,17 +36,11 @@ LL |   #[doc(alias = "
 LL | | ")]
    | |_^
 
-error: ' ' character isn't allowed in `#[doc(alias = "...")]`
-  --> $DIR/check-doc-alias-attr.rs:14:7
-   |
-LL | #[doc(alias = " ")]
-   |       ^^^^^^^^^^^
-
 error: '\t' character isn't allowed in `#[doc(alias = "...")]`
-  --> $DIR/check-doc-alias-attr.rs:15:7
+  --> $DIR/check-doc-alias-attr.rs:14:7
    |
 LL | #[doc(alias = "\t")]
    |       ^^^^^^^^^^^^
 
-error: aborting due to 8 previous errors
+error: aborting due to 7 previous errors
 

--- a/src/test/ui/check-doc-alias-attr.stderr
+++ b/src/test/ui/check-doc-alias-attr.stderr
@@ -42,5 +42,17 @@ error: '\t' character isn't allowed in `#[doc(alias = "...")]`
 LL | #[doc(alias = "\t")]
    |       ^^^^^^^^^^^^
 
-error: aborting due to 7 previous errors
+error: `#[doc(alias = "...")]` cannot start or end with ' '
+  --> $DIR/check-doc-alias-attr.rs:15:7
+   |
+LL | #[doc(alias = " hello")]
+   |       ^^^^^^^^^^^^^^^^
+
+error: `#[doc(alias = "...")]` cannot start or end with ' '
+  --> $DIR/check-doc-alias-attr.rs:16:7
+   |
+LL | #[doc(alias = "hello ")]
+   |       ^^^^^^^^^^^^^^^^
+
+error: aborting due to 9 previous errors
 


### PR DESCRIPTION
Fixes issue from https://github.com/rust-lang/rust/issues/76705#issuecomment-703123847

cc @lopopolo @ollie27 

r? @jyn514 