### PR TITLE
Move `EarlyOtherwiseBranch` to mir-opt-level 2

### DIFF
--- a/compiler/rustc_mir/src/transform/early_otherwise_branch.rs
+++ b/compiler/rustc_mir/src/transform/early_otherwise_branch.rs
@@ -26,7 +26,7 @@ pub struct EarlyOtherwiseBranch;
 
 impl<'tcx> MirPass<'tcx> for EarlyOtherwiseBranch {
     fn run_pass(&self, tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
-        if tcx.sess.opts.debugging_opts.mir_opt_level < 1 {
+        if tcx.sess.opts.debugging_opts.mir_opt_level < 2 {
             return;
         }
         trace!("running EarlyOtherwiseBranch on {:?}", body.source);


### PR DESCRIPTION
cc #75119 

This didn't have an [effect in most cases](https://perf.rust-lang.org/compare.html?start=81e02708f1f4760244756548981277d5199baa9a&end=2e0edc0f28c5647141bedba02e7a222d3a5dc9c3&stat=instructions:u), and is not trivially sound. Let it bake at `mir-opt-level=2` for a while.

Also, this missed the cutoff for beta, so we'll have to backport this.
r? @wesleywiser 