### PR TITLE
Fix span for unicode escape suggestion.

### DIFF
--- a/compiler/rustc_parse/src/lexer/unescape_error_reporting.rs
+++ b/compiler/rustc_parse/src/lexer/unescape_error_reporting.rs
@@ -181,10 +181,9 @@ pub(crate) fn emit_unescape_error(
 
             if suggestion_len > 0 {
                 suggestion.push('}');
-                let lo = char_span.lo();
-                let hi = lo + BytePos(suggestion_len as u32);
+                let hi = char_span.lo() + BytePos(suggestion_len as u32);
                 diag.span_suggestion(
-                    span.with_lo(lo).with_hi(hi),
+                    span.with_hi(hi),
                     "format of unicode escape sequences uses braces",
                     suggestion,
                     Applicability::MaybeIncorrect,

--- a/src/test/ui/fmt/format-string-error-2.stderr
+++ b/src/test/ui/fmt/format-string-error-2.stderr
@@ -2,9 +2,7 @@ error: incorrect unicode escape sequence
   --> $DIR/format-string-error-2.rs:77:20
    |
 LL |     println!("\x7B}\u8 {", 1);
-   |                    ^^-
-   |                      |
-   |                      help: format of unicode escape sequences uses braces: `\u{8}`
+   |                    ^^^ help: format of unicode escape sequences uses braces: `\u{8}`
 
 error: invalid format string: expected `'}'`, found `'a'`
   --> $DIR/format-string-error-2.rs:5:5

--- a/src/test/ui/parser/issue-23620-invalid-escapes.stderr
+++ b/src/test/ui/parser/issue-23620-invalid-escapes.stderr
@@ -80,9 +80,9 @@ error: incorrect unicode escape sequence
   --> $DIR/issue-23620-invalid-escapes.rs:32:14
    |
 LL |     let _ = "\u8f";
-   |              ^^--
-   |                |
-   |                help: format of unicode escape sequences uses braces: `\u{8f}`
+   |              ^^^-
+   |              |
+   |              help: format of unicode escape sequences uses braces: `\u{8f}`
 
 error: aborting due to 13 previous errors
 


### PR DESCRIPTION
If a unicode escape is missing the curly braces, the suggested fix is to add the curly braces, but the span for the fix was incorrect. It was not covering the `\u`, but the suggested text includes the `\u`, causing the resulting fix to be `"\u\u{1234}"`. This changes it so that the span includes the `\u`. An alternate fix would be to remove `\u` from the suggested fix, but I think the error message reads better if the entire escape is included.
