### PR TITLE
Add c as a shorthand check alternative for new options #77603

### DIFF
--- a/src/bootstrap/flags.rs
+++ b/src/bootstrap/flags.rs
@@ -253,7 +253,7 @@ To learn more about a subcommand, run `./x.py <subcommand> -h`",
                         `/<build_base>/rustfix_missing_coverage.txt`",
                 );
             }
-            "check" => {
+            "check" | "c" => {
                 opts.optflag("", "all-targets", "Check all targets");
             }
             "bench" => {


### PR DESCRIPTION
There is a missing "c" that is a shorthand for "check" in newly added match arm for handling check-specific options.