### PR TITLE
Add a x86_64-pebble target for userspace Pebble programs

### DIFF
--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -679,6 +679,8 @@ supported_targets! {
 
     ("mipsel-sony-psp", mipsel_sony_psp),
     ("thumbv4t-none-eabi", thumbv4t_none_eabi),
+
+    ("x86_64-pebble", x86_64_pebble),
 }
 
 /// Everything `rustc` knows about how to compile for a specific target.

--- a/compiler/rustc_target/src/spec/x86_64_pebble.ld
+++ b/compiler/rustc_target/src/spec/x86_64_pebble.ld
@@ -1,0 +1,48 @@
+ENTRY(_start)
+OUTPUT_FORMAT(elf64-x86-64)
+
+IMAGE_START = 0x10000;
+
+PHDRS {
+    text PT_LOAD;
+    rodata PT_LOAD FLAGS(4);
+    data PT_LOAD;
+    caps PT_NOTE;
+}
+
+SECTIONS {
+    . = IMAGE_START;
+
+    .text : {
+        *(.text .text.*)
+        . = ALIGN(4K);
+    } :text
+
+    .rodata : {
+        *(.rodata .rodata.*)
+        /* No need to align, because .got is aligned below */
+    } :rodata
+
+    .got : {
+        *(.got)
+        . = ALIGN(4K);
+    } :rodata
+
+    .data : {
+        *(.data .data.*)
+        . = ALIGN(4K);
+    } :data
+
+    .bss : {
+        *(.bss .bss.*)
+        . = ALIGN(4K);
+    } :data
+
+    .caps : {
+        KEEP(*(.caps))
+    } :caps
+
+    /DISCARD/ : {
+        *(.eh_frame*)
+    }
+}

--- a/compiler/rustc_target/src/spec/x86_64_pebble.rs
+++ b/compiler/rustc_target/src/spec/x86_64_pebble.rs
@@ -1,0 +1,46 @@
+use crate::spec::{LinkerFlavor, LldFlavor, Target, TargetOptions, TargetResult};
+
+/*
+ * For Pebble userspace images, we need to force the linker to keep the `.caps` section, which it thinks is unused.
+ * As far as I know, the only way to reliably do this is to use a custom linker script. Since we have to anyway, we
+ * use it to lay out the segments nicely.
+ */
+const LINKER_SCRIPT: &str = include_str!("./x86_64_pebble.ld");
+
+pub fn target() -> TargetResult {
+    let options = TargetOptions {
+        cpu: "x86-64".to_string(),
+        max_atomic_width: Some(64),
+        /*
+         * NOTE: this should be temporary. When the Pebble kernel can handle userspace tasks that use these
+         * features, LLVM can be allowed to generate instructions that use them.
+         */
+        features: "-mmx,-sse,-sse2,-sse3,-sse4.1,-sse4.2,-3dnow,-3dnowa,-avx,-avx2,+soft-float"
+            .to_string(),
+
+        target_family: None,
+        executables: true,
+
+        linker: Some("rust-lld".to_owned()),
+        lld_flavor: LldFlavor::Ld,
+        linker_is_gnu: true,
+        link_script: Some(LINKER_SCRIPT.to_string()),
+
+        ..Default::default()
+    };
+
+    Ok(Target {
+        llvm_target: "x86_64-unknown-none".to_string(),
+        target_endian: "little".to_string(),
+        target_pointer_width: "64".to_string(),
+        target_c_int_width: "32".to_string(),
+        data_layout: "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+            .to_string(),
+        arch: "x86_64".to_string(),
+        target_os: "pebble".to_string(),
+        target_env: String::new(),
+        target_vendor: String::new(),
+        linker_flavor: LinkerFlavor::Lld(LldFlavor::Ld),
+        options,
+    })
+}

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -219,6 +219,7 @@ target | std | host | notes
 `x86_64-uwp-windows-gnu` | ✓ |  |
 `x86_64-uwp-windows-msvc` | ✓ |  |
 `x86_64-wrs-vxworks` | ? |  |
+`x86_64-pebble` |  |  | 64-bit Pebble
 
 [runs on NVIDIA GPUs]: https://github.com/japaric-archived/nvptx#targets
 [^apple]: These targets are only available on macOS.


### PR DESCRIPTION
This PR adds a new target, `x86_64-pebble`, for targetting userspace Pebble programs. [Pebble](https://github.com/IsaacWoods/pebble) is a toy(ish) microkernel I've been developing for a few years, so this would be a target similar to other novel platforms such as Redox or Hermit - probably the least established though. The use of Rust is a key feature of the project, so having a userspace target in `rustc` would be a boon, and would significantly lower the requirements required to contribute to Pebble (which currently requires a custom fork of `rustc`).

This proposes Pebble as a Tier-3 target - I believe the target imposes very little maintance burden, and I would happily be fully responsible for keeping it building and tested out-of-tree.