### PR TITLE
Rust 1.47.0 stable release, take 2

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -84,8 +84,6 @@ Compatibility Notes
   `Delimiter::None`.
 - [Moved support for the CloudABI target to tier 3.][75568]
 - [`linux-gnu` targets now require minimum kernel 2.6.32 and glibc 2.11.][74163]
-- [We have reports of some proc macros encountering as yet undiagnosed problems in linked C++
-  code, but the root cause is as yet undiagnosed.][76980]
 
 Internal Only
 --------

--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/Dockerfile
@@ -95,7 +95,7 @@ ENV RUST_CONFIGURE_ARGS \
       --set target.x86_64-unknown-linux-gnu.linker=clang \
       --set target.x86_64-unknown-linux-gnu.ar=/rustroot/bin/llvm-ar \
       --set target.x86_64-unknown-linux-gnu.ranlib=/rustroot/bin/llvm-ranlib \
-      --set llvm.thin-lto=true \
+      --set llvm.thin-lto=false \
       --set rust.jemalloc
 ENV SCRIPT python2.7 ../x.py dist --host $HOSTS --target $HOSTS
 ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=clang


### PR DESCRIPTION
This PR adds a workaround for https://github.com/rust-lang/rust/issues/76980 to the existing stable 1.47.0 branch. I will invalidate the dev artifacts and issue another pre-release once the PR is merged, to let people test this change.

r? @ghost