### PR TITLE
Fix tooltip text display

### DIFF
--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -1098,6 +1098,10 @@ h3 > .collapse-toggle, h4 > .collapse-toggle {
 	border-style: solid;
 }
 
+.tooltip:hover .tooltiptext {
+	display: inline;
+}
+
 .tooltip.compile_fail, .tooltip.should_panic, .tooltip.ignore {
 	font-weight: bold;
 	font-size: 20px;


### PR DESCRIPTION
Currently, when we hover the icon, the text doesn't show up:

![Screenshot from 2020-10-07 11-30-44](https://user-images.githubusercontent.com/3050060/95313768-cc402200-0890-11eb-95a4-a1ae8e38aee1.png)

The bug was spotted by @Nemo157 

r? @jyn514 