### PR TITLE
Static mutex is static

### DIFF
--- a/library/std/src/sys/unix/os.rs
+++ b/library/std/src/sys/unix/os.rs
@@ -470,7 +470,7 @@ pub unsafe fn environ() -> *mut *const *const c_char {
     &mut environ
 }
 
-pub unsafe fn env_lock() -> StaticMutexGuard<'static> {
+pub unsafe fn env_lock() -> StaticMutexGuard {
     // It is UB to attempt to acquire this mutex reentrantly!
     static ENV_LOCK: StaticMutex = StaticMutex::new();
     ENV_LOCK.lock()

--- a/library/std/src/sys/vxworks/os.rs
+++ b/library/std/src/sys/vxworks/os.rs
@@ -212,7 +212,7 @@ pub unsafe fn environ() -> *mut *const *const c_char {
     &mut environ
 }
 
-pub unsafe fn env_lock() -> StaticMutexGuard<'static> {
+pub unsafe fn env_lock() -> StaticMutexGuard {
     // It is UB to attempt to acquire this mutex reentrantly!
     static ENV_LOCK: StaticMutex = StaticMutex::new();
     ENV_LOCK.lock()

--- a/library/std/src/sys_common/mutex.rs
+++ b/library/std/src/sys_common/mutex.rs
@@ -28,8 +28,9 @@ impl StaticMutex {
     /// Calls raw_lock() and then returns an RAII guard to guarantee the mutex
     /// will be unlocked.
     ///
-    /// It is undefined behaviour to call this function while locked, or if the
-    /// mutex has been moved since the last time this was called.
+    /// It is undefined behaviour to call this function while locked by the
+    /// same thread, or if the mutex has been moved since the last time this
+    /// was called.
     #[inline]
     pub unsafe fn lock(&self) -> StaticMutexGuard<'_> {
         self.0.lock();

--- a/library/std/src/sys_common/mutex.rs
+++ b/library/std/src/sys_common/mutex.rs
@@ -3,8 +3,7 @@ use crate::sys::mutex as imp;
 /// An OS-based mutual exclusion lock, meant for use in static variables.
 ///
 /// This mutex has a const constructor ([`StaticMutex::new`]), does not
-/// implement `Drop` to cleanup resources, and causes UB when moved or used
-/// reentrantly.
+/// implement `Drop` to cleanup resources, and causes UB when used reentrantly.
 ///
 /// This mutex does not implement poisoning.
 ///
@@ -16,11 +15,6 @@ unsafe impl Sync for StaticMutex {}
 
 impl StaticMutex {
     /// Creates a new mutex for use.
-    ///
-    /// Behavior is undefined if the mutex is moved after it is
-    /// first used with any of the functions below.
-    /// Also, the behavior is undefined if this mutex is ever used reentrantly,
-    /// i.e., `lock` is called by the thread currently holding the lock.
     pub const fn new() -> Self {
         Self(imp::Mutex::new())
     }
@@ -29,19 +23,18 @@ impl StaticMutex {
     /// will be unlocked.
     ///
     /// It is undefined behaviour to call this function while locked by the
-    /// same thread, or if the mutex has been moved since the last time this
-    /// was called.
+    /// same thread.
     #[inline]
-    pub unsafe fn lock(&self) -> StaticMutexGuard<'_> {
+    pub unsafe fn lock(&'static self) -> StaticMutexGuard {
         self.0.lock();
         StaticMutexGuard(&self.0)
     }
 }
 
 #[must_use]
-pub struct StaticMutexGuard<'a>(&'a imp::Mutex);
+pub struct StaticMutexGuard(&'static imp::Mutex);
 
-impl Drop for StaticMutexGuard<'_> {
+impl Drop for StaticMutexGuard {
     #[inline]
     fn drop(&mut self) {
         unsafe {


### PR DESCRIPTION
StaticMutex is only ever used with as a static (as the name already suggests). So it doesn't have to be generic over a lifetime, but can simply assume 'static.

This 'static lifetime guarantees the object is never moved, so this is no longer a manually checked requirement for unsafe calls to lock().

@rustbot modify labels: +T-libs +A-concurrency +C-cleanup