### PR TITLE
Allow `blur` to work even when `rustdoc` is not the main `<body>`

### DIFF
--- a/src/librustdoc/html/layout.rs
+++ b/src/librustdoc/html/layout.rs
@@ -62,7 +62,7 @@ pub fn render<T: Print, S: Print>(
     #crate-search{{background-image:url(\"{static_root_path}down-arrow{suffix}.svg\");}}\
     </style>\
 </head>\
-<body class=\"rustdoc {css_class}\">\
+<body id=\"rustdoc\" class=\"{css_class}\">\
     <!--[if lte IE 8]>\
     <div class=\"warning\">\
         This old browser is unsupported and will most likely display funky \

--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -1223,6 +1223,7 @@ fn init_id_map() -> FxHashMap<String, usize> {
     map.insert("theme-choices".to_owned(), 1);
     map.insert("settings-menu".to_owned(), 1);
     map.insert("main".to_owned(), 1);
+    map.insert("rustdoc".to_owned(), 1);
     map.insert("search".to_owned(), 1);
     map.insert("crate-search".to_owned(), 1);
     map.insert("render-detail".to_owned(), 1);

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -355,12 +355,12 @@ function defocusSearchBar() {
             if (hasClass(help, "hidden")) {
                 ev.preventDefault();
                 removeClass(help, "hidden");
-                addClass(document.body, "blur");
+                addClass(document.getElementById("rustdoc"), "blur");
             }
         } else if (hasClass(help, "hidden") === false) {
             ev.preventDefault();
             addClass(help, "hidden");
-            removeClass(document.body, "blur");
+            removeClass(document.getElementById("rustdoc"), "blur");
         }
     }
 

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -330,7 +330,7 @@ nav.sub {
 	padding-left: 0;
 }
 
-.rustdoc:not(.source) .example-wrap {
+#rustdoc:not(.source) .example-wrap {
 	display: inline-flex;
 	margin-bottom: 10px;
 	position: relative;
@@ -349,12 +349,12 @@ nav.sub {
 	text-align: right;
 }
 
-.rustdoc:not(.source) .example-wrap > pre.rust {
+#rustdoc:not(.source) .example-wrap > pre.rust {
 	width: 100%;
 	overflow-x: auto;
 }
 
-.rustdoc:not(.source) .example-wrap > pre {
+#rustdoc:not(.source) .example-wrap > pre {
 	margin: 0;
 }
 
@@ -1320,7 +1320,7 @@ h4 > .notable-traits {
 		padding-top: 0px;
 	}
 
-	.rustdoc > .sidebar {
+	#rustdoc > .sidebar {
 		height: 45px;
 		min-height: 40px;
 		margin: 0;
@@ -1373,7 +1373,7 @@ h4 > .notable-traits {
 		height: 45px;
 	}
 
-	.rustdoc.source > .sidebar > .sidebar-menu {
+	#rustdoc.source > .sidebar > .sidebar-menu {
 		display: none;
 	}
 


### PR DESCRIPTION
Part of https://github.com/rust-lang/docs.rs/issues/1076

r? @jyn514 