### PR TITLE
Revert implementing `Iterator::nth[_back]` in terms of `advance_by[_back]`

### DIFF
--- a/library/core/src/iter/traits/double_ended.rs
+++ b/library/core/src/iter/traits/double_ended.rs
@@ -174,9 +174,14 @@ pub trait DoubleEndedIterator: Iterator {
     /// ```
     #[inline]
     #[stable(feature = "iter_nth_back", since = "1.37.0")]
-    fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
-        self.advance_back_by(n).ok()?;
-        self.next_back()
+    fn nth_back(&mut self, mut n: usize) -> Option<Self::Item> {
+        for x in self.rev() {
+            if n == 0 {
+                return Some(x);
+            }
+            n -= 1;
+        }
+        None
     }
 
     /// This is the reverse version of [`Iterator::try_fold()`]: it takes

--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -363,9 +363,14 @@ pub trait Iterator {
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
-    fn nth(&mut self, n: usize) -> Option<Self::Item> {
-        self.advance_by(n).ok()?;
-        self.next()
+    fn nth(&mut self, mut n: usize) -> Option<Self::Item> {
+        while let Some(x) = self.next() {
+            if n == 0 {
+                return Some(x);
+            }
+            n -= 1;
+        }
+        None
     }
 
     /// Creates an iterator starting at the same point, but stepping by


### PR DESCRIPTION
See https://github.com/rust-lang/rust/pull/76909#issuecomment-704459025.

cc @ecstatic-morse @scottmcm

r? @ghost