### PR TITLE
Simplify doc-cfg rendering based on the current context

### DIFF
--- a/src/librustdoc/clean/cfg.rs
+++ b/src/librustdoc/clean/cfg.rs
@@ -205,6 +205,8 @@ impl Cfg {
     /// Attempt to simplify this cfg by assuming that `assume` is already known to be true, will
     /// return `None` if simplification managed to completely eliminate any requirements from this
     /// `Cfg`.
+    ///
+    /// See `tests::test_simplify_with` for examples.
     pub(crate) fn simplify_with(&self, assume: &Cfg) -> Option<Cfg> {
         if self == assume {
             return None;

--- a/src/librustdoc/clean/cfg.rs
+++ b/src/librustdoc/clean/cfg.rs
@@ -201,6 +201,35 @@ impl Cfg {
             _ => false,
         }
     }
+
+    /// Attempt to simplify this cfg by assuming that `assume` is already known to be true, will
+    /// return `None` if simplification managed to completely eliminate any requirements from this
+    /// `Cfg`.
+    pub(crate) fn simplify_with(&self, assume: &Cfg) -> Option<Cfg> {
+        if self == assume {
+            return None;
+        }
+
+        if let Cfg::All(a) = self {
+            let mut sub_cfgs: Vec<Cfg> = if let Cfg::All(b) = assume {
+                a.iter().filter(|a| !b.contains(a)).cloned().collect()
+            } else {
+                a.iter().filter(|&a| a != assume).cloned().collect()
+            };
+            let len = sub_cfgs.len();
+            return match len {
+                0 => None,
+                1 => sub_cfgs.pop(),
+                _ => Some(Cfg::All(sub_cfgs)),
+            };
+        } else if let Cfg::All(b) = assume {
+            if b.contains(self) {
+                return None;
+            }
+        }
+
+        Some(self.clone())
+    }
 }
 
 impl ops::Not for Cfg {

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -2170,7 +2170,7 @@ fn stability_tags(item: &clean::Item, parent: &clean::Item) -> String {
         (cfg, _) => cfg.as_deref().cloned(),
     };
 
-    info!("Portability {:?} - {:?} = {:?}", item.attrs.cfg, parent.attrs.cfg, cfg);
+    debug!("Portability {:?} - {:?} = {:?}", item.attrs.cfg, parent.attrs.cfg, cfg);
     if let Some(ref cfg) = cfg {
         tags += &tag_html("portability", &cfg.render_long_plain(), &cfg.render_short_html());
     }
@@ -2259,7 +2259,7 @@ fn short_stability(item: &clean::Item, cx: &Context, parent: Option<&clean::Item
         (cfg, _) => cfg.as_deref().cloned(),
     };
 
-    info!(
+    debug!(
         "Portability {:?} - {:?} = {:?}",
         item.attrs.cfg,
         parent.and_then(|p| p.attrs.cfg.as_ref()),

--- a/src/test/rustdoc/doc-cfg-simplification.rs
+++ b/src/test/rustdoc/doc-cfg-simplification.rs
@@ -1,0 +1,182 @@
+#![crate_name = "globuliferous"]
+#![feature(doc_cfg)]
+
+// @has 'globuliferous/index.html'
+// @count   - '//*[@class="stab portability"]' 1
+// @matches - '//*[@class="stab portability"]' '^ratel$'
+
+// @has 'globuliferous/ratel/index.html'
+// @count   - '//*[@class="stab portability"]' 8
+// @matches - '//*[@class="stab portability"]' 'crate feature ratel'
+// @matches - '//*[@class="stab portability"]' '^zoonosology$'
+// @matches - '//*[@class="stab portability"]' '^yusho$'
+// @matches - '//*[@class="stab portability"]' '^nunciative$'
+// @matches - '//*[@class="stab portability"]' '^thionic$'
+// @matches - '//*[@class="stab portability"]' '^zincic$'
+// @matches - '//*[@class="stab portability"]' '^cosmotellurian$'
+// @matches - '//*[@class="stab portability"]' '^aposiopesis$'
+#[doc(cfg(feature = "ratel"))]
+pub mod ratel {
+    // @has 'globuliferous/ratel/fn.ovicide.html'
+    // @count   - '//*[@class="stab portability"]' 1
+    // @matches - '//*[@class="stab portability"]' 'crate feature ratel'
+    pub fn ovicide() {}
+
+    // @has 'globuliferous/ratel/fn.zoonosology.html'
+    // @count   - '//*[@class="stab portability"]' 1
+    // @matches - '//*[@class="stab portability"]' 'crate features ratel and zoonosology'
+    #[doc(cfg(feature = "zoonosology"))]
+    pub fn zoonosology() {}
+
+    // @has 'globuliferous/ratel/constant.DIAGRAPHICS.html'
+    // @count   - '//*[@class="stab portability"]' 1
+    // @matches - '//*[@class="stab portability"]' 'crate feature ratel'
+    pub const DIAGRAPHICS: () = ();
+
+    // @has 'globuliferous/ratel/constant.YUSHO.html'
+    // @count   - '//*[@class="stab portability"]' 1
+    // @matches - '//*[@class="stab portability"]' 'crate features ratel and yusho'
+    #[doc(cfg(feature = "yusho"))]
+    pub const YUSHO: () = ();
+
+    // @has 'globuliferous/ratel/static.KEYBUGLE.html'
+    // @count   - '//*[@class="stab portability"]' 1
+    // @matches - '//*[@class="stab portability"]' 'crate feature ratel'
+    pub static KEYBUGLE: () = ();
+
+    // @has 'globuliferous/ratel/static.NUNCIATIVE.html'
+    // @count   - '//*[@class="stab portability"]' 1
+    // @matches - '//*[@class="stab portability"]' 'crate features ratel and nunciative'
+    #[doc(cfg(feature = "nunciative"))]
+    pub static NUNCIATIVE: () = ();
+
+    // @has 'globuliferous/ratel/type.Wrick.html'
+    // @count   - '//*[@class="stab portability"]' 1
+    // @matches - '//*[@class="stab portability"]' 'crate feature ratel'
+    pub type Wrick = ();
+
+    // @has 'globuliferous/ratel/type.Thionic.html'
+    // @count   - '//*[@class="stab portability"]' 1
+    // @matches - '//*[@class="stab portability"]' 'crate features ratel and thionic'
+    #[doc(cfg(feature = "thionic"))]
+    pub type Thionic = ();
+
+    // @has 'globuliferous/ratel/struct.Eventration.html'
+    // @count   - '//*[@class="stab portability"]' 1
+    // @matches - '//*[@class="stab portability"]' 'crate feature ratel'
+    pub struct Eventration;
+
+    // @has 'globuliferous/ratel/struct.Zincic.html'
+    // @count   - '//*[@class="stab portability"]' 2
+    // @matches - '//*[@class="stab portability"]' 'crate features ratel and zincic'
+    // @matches - '//*[@class="stab portability"]' 'crate feature rutherford'
+    #[doc(cfg(feature = "zincic"))]
+    pub struct Zincic {
+        pub rectigrade: (),
+
+        #[doc(cfg(feature = "rutherford"))]
+        pub rutherford: (),
+    }
+
+    // @has 'globuliferous/ratel/enum.Cosmotellurian.html'
+    // @count   - '//*[@class="stab portability"]' 10
+    // @matches - '//*[@class="stab portability"]' 'crate features ratel and cosmotellurian'
+    // @matches - '//*[@class="stab portability"]' 'crate feature biotaxy'
+    // @matches - '//*[@class="stab portability"]' 'crate feature xiphopagus'
+    // @matches - '//*[@class="stab portability"]' 'crate feature juxtapositive'
+    // @matches - '//*[@class="stab portability"]' 'crate feature fuero'
+    // @matches - '//*[@class="stab portability"]' 'crate feature palaeophile'
+    // @matches - '//*[@class="stab portability"]' 'crate feature broadcloth'
+    // @matches - '//*[@class="stab portability"]' 'crate features broadcloth and xanthocomic'
+    // @matches - '//*[@class="stab portability"]' 'crate feature broadcloth'
+    // @matches - '//*[@class="stab portability"]' 'crate features broadcloth and whosoever'
+    #[doc(cfg(feature = "cosmotellurian"))]
+    pub enum Cosmotellurian {
+        Groundsel {
+            jagger: (),
+
+            #[doc(cfg(feature = "xiphopagus"))]
+            xiphopagus: (),
+        },
+
+        #[doc(cfg(feature = "biotaxy"))]
+        Biotaxy {
+            glossography: (),
+
+            #[doc(cfg(feature = "juxtapositive"))]
+            juxtapositive: (),
+        },
+    }
+
+    impl Cosmotellurian {
+        pub fn uxoricide() {}
+
+        #[doc(cfg(feature = "fuero"))]
+        pub fn fuero() {}
+
+        pub const MAMELLE: () = ();
+
+        #[doc(cfg(feature = "palaeophile"))]
+        pub const PALAEOPHILE: () = ();
+    }
+
+    #[doc(cfg(feature = "broadcloth"))]
+    impl Cosmotellurian {
+        pub fn trabeculated() {}
+
+        #[doc(cfg(feature = "xanthocomic"))]
+        pub fn xanthocomic() {}
+
+        pub const BRACHIFEROUS: () = ();
+
+        #[doc(cfg(feature = "whosoever"))]
+        pub const WHOSOEVER: () = ();
+    }
+
+    // @has 'globuliferous/ratel/trait.Gnotobiology.html'
+    // @count   - '//*[@class="stab portability"]' 4
+    // @matches - '//*[@class="stab portability"]' 'crate feature ratel'
+    // @matches - '//*[@class="stab portability"]' 'crate feature unzymotic'
+    // @matches - '//*[@class="stab portability"]' 'crate feature summate'
+    // @matches - '//*[@class="stab portability"]' 'crate feature unctuous'
+    pub trait Gnotobiology {
+        const XYLOTHERAPY: ();
+
+        #[doc(cfg(feature = "unzymotic"))]
+        const UNZYMOTIC: ();
+
+        type Lepadoid;
+
+        #[doc(cfg(feature = "summate"))]
+        type Summate;
+
+        fn decalcomania();
+
+        #[doc(cfg(feature = "unctuous"))]
+        fn unctuous();
+    }
+
+    // @has 'globuliferous/ratel/trait.Aposiopesis.html'
+    // @count   - '//*[@class="stab portability"]' 4
+    // @matches - '//*[@class="stab portability"]' 'crate features ratel and aposiopesis'
+    // @matches - '//*[@class="stab portability"]' 'crate feature umbracious'
+    // @matches - '//*[@class="stab portability"]' 'crate feature uakari'
+    // @matches - '//*[@class="stab portability"]' 'crate feature rotograph'
+    #[doc(cfg(feature = "aposiopesis"))]
+    pub trait Aposiopesis {
+        const REDHIBITION: ();
+
+        #[doc(cfg(feature = "umbracious"))]
+        const UMBRACIOUS: ();
+
+        type Ophthalmoscope;
+
+        #[doc(cfg(feature = "uakari"))]
+        type Uakari;
+
+        fn meseems();
+
+        #[doc(cfg(feature = "rotograph"))]
+        fn rotograph();
+    }
+}

--- a/src/test/rustdoc/doc-cfg.rs
+++ b/src/test/rustdoc/doc-cfg.rs
@@ -10,9 +10,8 @@ pub struct Portable;
 // @has doc_cfg/unix_only/index.html \
 //  '//*[@id="main"]/*[@class="stability"]/*[@class="stab portability"]' \
 //  'This is supported on Unix only.'
-// @matches - '//*[@class="module-item"]//*[@class="stab portability"]' '\AUnix\Z'
-// @matches - '//*[@class="module-item"]//*[@class="stab portability"]' '\AUnix and ARM\Z'
-// @count - '//*[@class="stab portability"]' 3
+// @matches - '//*[@class="module-item"]//*[@class="stab portability"]' '\AARM\Z'
+// @count - '//*[@class="stab portability"]' 2
 #[doc(cfg(unix))]
 pub mod unix_only {
     // @has doc_cfg/unix_only/fn.unix_only_function.html \
@@ -26,7 +25,7 @@ pub mod unix_only {
     // @has doc_cfg/unix_only/trait.ArmOnly.html \
     //  '//*[@id="main"]/*[@class="stability"]/*[@class="stab portability"]' \
     //  'This is supported on Unix and ARM only.'
-    // @count - '//*[@class="stab portability"]' 3
+    // @count - '//*[@class="stab portability"]' 2
     #[doc(cfg(target_arch = "arm"))]
     pub trait ArmOnly {
         fn unix_and_arm_only_function();

--- a/src/test/rustdoc/duplicate-cfg.rs
+++ b/src/test/rustdoc/duplicate-cfg.rs
@@ -14,45 +14,41 @@
 pub struct Foo;
 
 // @has 'foo/bar/index.html'
-// @matches '-' '//*[@class="module-item"]//*[@class="stab portability"]' '^sync$'
-// @has '-' '//*[@class="module-item"]//*[@class="stab portability"]/@title' 'This is supported on crate feature `sync` only'
-
-// @has 'foo/bar/struct.Bar.html'
 // @has '-' '//*[@class="stab portability"]' 'This is supported on crate feature sync only.'
 #[doc(cfg(feature = "sync"))]
 pub mod bar {
+    // @has 'foo/bar/struct.Bar.html'
+    // @has '-' '//*[@class="stab portability"]' 'This is supported on crate feature sync only.'
     #[doc(cfg(feature = "sync"))]
     pub struct Bar;
 }
 
 // @has 'foo/baz/index.html'
-// @matches '-' '//*[@class="module-item"]//*[@class="stab portability"]' '^sync and send$'
-// @has '-' '//*[@class="module-item"]//*[@class="stab portability"]/@title' 'This is supported on crate features `sync` and `send` only'
-
-// @has 'foo/baz/struct.Baz.html'
 // @has '-' '//*[@class="stab portability"]' 'This is supported on crate features sync and send only.'
 #[doc(cfg(all(feature = "sync", feature = "send")))]
 pub mod baz {
+    // @has 'foo/baz/struct.Baz.html'
+    // @has '-' '//*[@class="stab portability"]' 'This is supported on crate features sync and send only.'
     #[doc(cfg(feature = "sync"))]
     pub struct Baz;
 }
 
-// @has 'foo/qux/struct.Qux.html'
-// @has '-' '//*[@class="stab portability"]' 'This is supported on crate features sync and send only.'
+// @has 'foo/qux/index.html'
+// @has '-' '//*[@class="stab portability"]' 'This is supported on crate feature sync only.'
 #[doc(cfg(feature = "sync"))]
 pub mod qux {
+    // @has 'foo/qux/struct.Qux.html'
+    // @has '-' '//*[@class="stab portability"]' 'This is supported on crate features sync and send only.'
     #[doc(cfg(all(feature = "sync", feature = "send")))]
     pub struct Qux;
 }
 
 // @has 'foo/quux/index.html'
-// @matches '-' '//*[@class="module-item"]//*[@class="stab portability"]' '^sync and send and foo and bar$'
-// @has '-' '//*[@class="module-item"]//*[@class="stab portability"]/@title' 'This is supported on crate feature `sync` and crate feature `send` and `foo` and `bar` only'
-
-// @has 'foo/quux/struct.Quux.html'
-// @has '-' '//*[@class="stab portability"]' 'This is supported on crate feature sync and crate feature send and foo and bar only.'
+// @has '-' '//*[@class="stab portability"]' 'This is supported on crate feature sync and crate feature send and foo only.'
 #[doc(cfg(all(feature = "sync", feature = "send", foo)))]
 pub mod quux {
+    // @has 'foo/quux/struct.Quux.html'
+    // @has '-' '//*[@class="stab portability"]' 'This is supported on crate feature sync and crate feature send and foo and bar only.'
     #[doc(cfg(all(feature = "send", feature = "sync", bar)))]
     pub struct Quux;
 }


### PR DESCRIPTION
For sub-items on a page don't show cfg that has already been rendered on
a parent item. At its simplest this means not showing anything that is
shown in the portability message at the top of the page, but also for
things like fields of an enum variant if that variant itself is
cfg-gated then don't repeat those cfg on each field of the variant.

This does not touch trait implementation rendering, as that is more
complex and there are existing issues around how it deals with doc-cfg
that need to be fixed first.

### Screenshots, left is current, right is new:

![image](https://user-images.githubusercontent.com/81079/95387261-c2e6a200-08f0-11eb-90d4-0a9734acd922.png)

![image](https://user-images.githubusercontent.com/81079/95387458-06411080-08f1-11eb-81f7-5dd7f37695dd.png)

![image](https://user-images.githubusercontent.com/81079/95387702-6637b700-08f1-11eb-82f4-46b6cd9b24f2.png)

![image](https://user-images.githubusercontent.com/81079/95387905-b9aa0500-08f1-11eb-8d95-8b618d31d419.png)

![image](https://user-images.githubusercontent.com/81079/95388300-5bc9ed00-08f2-11eb-9ac9-b92cbdb60b89.png)

cc #43781 