### PR TITLE
unix/vxworks: make DirEntry slightly smaller

### DIFF
--- a/library/std/src/sys/unix/fs.rs
+++ b/library/std/src/sys/unix/fs.rs
@@ -949,18 +949,16 @@ pub fn readdir(p: &Path) -> io::Result<ReadDir> {
             Err(Error::last_os_error())
         } else {
             let inner = InnerReadDir { dirp: Dir(ptr), root };
-            cfg_if::cfg_if! {
-                if #[cfg(not(any(
+            Ok(ReadDir {
+                inner: Arc::new(inner),
+                #[cfg(not(any(
                     target_os = "solaris",
                     target_os = "illumos",
                     target_os = "fuchsia",
                     target_os = "redox",
-                )))] {
-                    Ok(ReadDir { inner: Arc::new(inner), end_of_stream: false })
-                } else {
-                    Ok(ReadDir { inner: Arc::new(inner) })
-                }
-            }
+                )))]
+                end_of_stream: false,
+            })
         }
     }
 }

--- a/library/std/src/sys/unix/fs.rs
+++ b/library/std/src/sys/unix/fs.rs
@@ -185,6 +185,12 @@ struct InnerReadDir {
 
 pub struct ReadDir {
     inner: Arc<InnerReadDir>,
+    #[cfg(not(any(
+        target_os = "solaris",
+        target_os = "illumos",
+        target_os = "fuchsia",
+        target_os = "redox",
+    )))]
     end_of_stream: bool,
 }
 
@@ -943,7 +949,18 @@ pub fn readdir(p: &Path) -> io::Result<ReadDir> {
             Err(Error::last_os_error())
         } else {
             let inner = InnerReadDir { dirp: Dir(ptr), root };
-            Ok(ReadDir { inner: Arc::new(inner), end_of_stream: false })
+            cfg_if::cfg_if! {
+                if #[cfg(not(any(
+                    target_os = "solaris",
+                    target_os = "illumos",
+                    target_os = "fuchsia",
+                    target_os = "redox",
+                )))] {
+                    Ok(ReadDir { inner: Arc::new(inner), end_of_stream: false })
+                } else {
+                    Ok(ReadDir { inner: Arc::new(inner) })
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
`DirEntry` contains a `ReadDir` handle, which used to just be a wrapper
on `Arc<InnerReadDir>`. Commit af75314ecdbc5 added `end_of_stream: bool`
which is not needed by `DirEntry`, but adds 8 bytes after padding. We
can let `DirEntry` have an `Arc<InnerReadDir>` directly to avoid that.
