### PR TITLE
Turn on UnreachablePropagation by default

### DIFF
--- a/compiler/rustc_mir/src/transform/unreachable_prop.rs
+++ b/compiler/rustc_mir/src/transform/unreachable_prop.rs
@@ -12,13 +12,7 @@ use std::borrow::Cow;
 pub struct UnreachablePropagation;
 
 impl MirPass<'_> for UnreachablePropagation {
-    fn run_pass<'tcx>(&self, tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
-        if tcx.sess.opts.debugging_opts.mir_opt_level < 3 {
-            // Enable only under -Zmir-opt-level=3 as in some cases (check the deeply-nested-opt
-            // perf benchmark) LLVM may spend quite a lot of time optimizing the generated code.
-            return;
-        }
-
+    fn run_pass<'tcx>(&self, _tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
         let mut unreachable_blocks = FxHashSet::default();
         let mut replacements = FxHashMap::default();
 

--- a/src/test/mir-opt/simplify_arm.id.SimplifyArmIdentity.diff
+++ b/src/test/mir-opt/simplify_arm.id.SimplifyArmIdentity.diff
@@ -14,19 +14,15 @@
   
       bb0: {
           _2 = discriminant(_1);           // scope 0 at $DIR/simplify-arm.rs:11:9: 11:16
-          switchInt(move _2) -> [0_isize: bb1, 1_isize: bb3, otherwise: bb2]; // scope 0 at $DIR/simplify-arm.rs:11:9: 11:16
+          switchInt(move _2) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/simplify-arm.rs:11:9: 11:16
       }
   
       bb1: {
           discriminant(_0) = 0;            // scope 0 at $DIR/simplify-arm.rs:12:17: 12:21
-          goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:10:5: 13:6
+          goto -> bb3;                     // scope 0 at $DIR/simplify-arm.rs:10:5: 13:6
       }
   
       bb2: {
-          unreachable;                     // scope 0 at $DIR/simplify-arm.rs:10:11: 10:12
-      }
-  
-      bb3: {
 -         StorageLive(_3);                 // scope 0 at $DIR/simplify-arm.rs:11:14: 11:15
 -         _3 = ((_1 as Some).0: u8);       // scope 0 at $DIR/simplify-arm.rs:11:14: 11:15
 -         StorageLive(_4);                 // scope 1 at $DIR/simplify-arm.rs:11:25: 11:26
@@ -36,10 +32,10 @@
 -         StorageDead(_4);                 // scope 1 at $DIR/simplify-arm.rs:11:26: 11:27
 -         StorageDead(_3);                 // scope 0 at $DIR/simplify-arm.rs:11:26: 11:27
 +         _0 = move _1;                    // scope 1 at $DIR/simplify-arm.rs:11:20: 11:27
-          goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:10:5: 13:6
+          goto -> bb3;                     // scope 0 at $DIR/simplify-arm.rs:10:5: 13:6
       }
   
-      bb4: {
+      bb3: {
           return;                          // scope 0 at $DIR/simplify-arm.rs:14:2: 14:2
       }
   }

--- a/src/test/mir-opt/simplify_arm.id.SimplifyBranchSame.diff
+++ b/src/test/mir-opt/simplify_arm.id.SimplifyBranchSame.diff
@@ -13,26 +13,22 @@
   
       bb0: {
           _2 = discriminant(_1);           // scope 0 at $DIR/simplify-arm.rs:11:9: 11:16
--         switchInt(move _2) -> [0_isize: bb1, 1_isize: bb3, otherwise: bb2]; // scope 0 at $DIR/simplify-arm.rs:11:9: 11:16
+-         switchInt(move _2) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/simplify-arm.rs:11:9: 11:16
 +         goto -> bb1;                     // scope 0 at $DIR/simplify-arm.rs:11:9: 11:16
       }
   
       bb1: {
 -         discriminant(_0) = 0;            // scope 0 at $DIR/simplify-arm.rs:12:17: 12:21
--         goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:10:5: 13:6
+-         goto -> bb3;                     // scope 0 at $DIR/simplify-arm.rs:10:5: 13:6
 -     }
 - 
 -     bb2: {
--         unreachable;                     // scope 0 at $DIR/simplify-arm.rs:10:11: 10:12
--     }
-- 
--     bb3: {
           _0 = move _1;                    // scope 1 at $DIR/simplify-arm.rs:11:20: 11:27
--         goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:10:5: 13:6
+-         goto -> bb3;                     // scope 0 at $DIR/simplify-arm.rs:10:5: 13:6
 +         goto -> bb2;                     // scope 0 at $DIR/simplify-arm.rs:10:5: 13:6
       }
   
--     bb4: {
+-     bb3: {
 +     bb2: {
           return;                          // scope 0 at $DIR/simplify-arm.rs:14:2: 14:2
       }

--- a/src/test/mir-opt/simplify_arm.id_result.SimplifyArmIdentity.diff
+++ b/src/test/mir-opt/simplify_arm.id_result.SimplifyArmIdentity.diff
@@ -20,7 +20,7 @@
   
       bb0: {
           _2 = discriminant(_1);           // scope 0 at $DIR/simplify-arm.rs:18:9: 18:14
-          switchInt(move _2) -> [0_isize: bb3, 1_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/simplify-arm.rs:18:9: 18:14
+          switchInt(move _2) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/simplify-arm.rs:18:9: 18:14
       }
   
       bb1: {
@@ -33,14 +33,10 @@
 -         StorageDead(_6);                 // scope 2 at $DIR/simplify-arm.rs:19:24: 19:25
 -         StorageDead(_5);                 // scope 0 at $DIR/simplify-arm.rs:19:24: 19:25
 +         _0 = move _1;                    // scope 2 at $DIR/simplify-arm.rs:19:19: 19:25
-          goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:17:5: 20:6
+          goto -> bb3;                     // scope 0 at $DIR/simplify-arm.rs:17:5: 20:6
       }
   
       bb2: {
-          unreachable;                     // scope 0 at $DIR/simplify-arm.rs:17:11: 17:12
-      }
-  
-      bb3: {
 -         StorageLive(_3);                 // scope 0 at $DIR/simplify-arm.rs:18:12: 18:13
 -         _3 = ((_1 as Ok).0: u8);         // scope 0 at $DIR/simplify-arm.rs:18:12: 18:13
 -         StorageLive(_4);                 // scope 1 at $DIR/simplify-arm.rs:18:21: 18:22
@@ -50,10 +46,10 @@
 -         StorageDead(_4);                 // scope 1 at $DIR/simplify-arm.rs:18:22: 18:23
 -         StorageDead(_3);                 // scope 0 at $DIR/simplify-arm.rs:18:22: 18:23
 +         _0 = move _1;                    // scope 1 at $DIR/simplify-arm.rs:18:18: 18:23
-          goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:17:5: 20:6
+          goto -> bb3;                     // scope 0 at $DIR/simplify-arm.rs:17:5: 20:6
       }
   
-      bb4: {
+      bb3: {
           return;                          // scope 0 at $DIR/simplify-arm.rs:21:2: 21:2
       }
   }

--- a/src/test/mir-opt/simplify_arm.id_result.SimplifyBranchSame.diff
+++ b/src/test/mir-opt/simplify_arm.id_result.SimplifyBranchSame.diff
@@ -18,26 +18,22 @@
   
       bb0: {
           _2 = discriminant(_1);           // scope 0 at $DIR/simplify-arm.rs:18:9: 18:14
--         switchInt(move _2) -> [0_isize: bb3, 1_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/simplify-arm.rs:18:9: 18:14
+-         switchInt(move _2) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/simplify-arm.rs:18:9: 18:14
 +         goto -> bb1;                     // scope 0 at $DIR/simplify-arm.rs:18:9: 18:14
       }
   
       bb1: {
 -         _0 = move _1;                    // scope 2 at $DIR/simplify-arm.rs:19:19: 19:25
--         goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:17:5: 20:6
+-         goto -> bb3;                     // scope 0 at $DIR/simplify-arm.rs:17:5: 20:6
 -     }
 - 
 -     bb2: {
--         unreachable;                     // scope 0 at $DIR/simplify-arm.rs:17:11: 17:12
--     }
-- 
--     bb3: {
           _0 = move _1;                    // scope 1 at $DIR/simplify-arm.rs:18:18: 18:23
--         goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:17:5: 20:6
+-         goto -> bb3;                     // scope 0 at $DIR/simplify-arm.rs:17:5: 20:6
 +         goto -> bb2;                     // scope 0 at $DIR/simplify-arm.rs:17:5: 20:6
       }
   
--     bb4: {
+-     bb3: {
 +     bb2: {
           return;                          // scope 0 at $DIR/simplify-arm.rs:21:2: 21:2
       }

--- a/src/test/mir-opt/simplify_arm.id_try.SimplifyArmIdentity.diff
+++ b/src/test/mir-opt/simplify_arm.id_try.SimplifyArmIdentity.diff
@@ -51,7 +51,7 @@
           _3 = move _4;                    // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
           StorageDead(_4);                 // scope 0 at $DIR/simplify-arm.rs:24:14: 24:15
           _5 = discriminant(_3);           // scope 0 at $DIR/simplify-arm.rs:24:14: 24:15
-          switchInt(move _5) -> [0_isize: bb1, 1_isize: bb3, otherwise: bb2]; // scope 0 at $DIR/simplify-arm.rs:24:14: 24:15
+          switchInt(move _5) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/simplify-arm.rs:24:14: 24:15
       }
   
       bb1: {
@@ -67,14 +67,10 @@
 -         discriminant(_0) = 0;            // scope 1 at $DIR/simplify-arm.rs:25:5: 25:10
 -         StorageDead(_11);                // scope 1 at $DIR/simplify-arm.rs:25:9: 25:10
           StorageDead(_2);                 // scope 0 at $DIR/simplify-arm.rs:26:1: 26:2
-          goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:26:2: 26:2
+          goto -> bb3;                     // scope 0 at $DIR/simplify-arm.rs:26:2: 26:2
       }
   
       bb2: {
-          unreachable;                     // scope 0 at $DIR/simplify-arm.rs:24:13: 24:15
-      }
-  
-      bb3: {
 -         StorageLive(_6);                 // scope 0 at $DIR/simplify-arm.rs:24:14: 24:15
 -         _6 = ((_3 as Err).0: i32);       // scope 0 at $DIR/simplify-arm.rs:24:14: 24:15
 -         StorageLive(_8);                 // scope 3 at $DIR/simplify-arm.rs:24:14: 24:15
@@ -92,10 +88,10 @@
 +         _0 = move _3;                    // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
           StorageDead(_3);                 // scope 0 at $DIR/simplify-arm.rs:24:15: 24:16
           StorageDead(_2);                 // scope 0 at $DIR/simplify-arm.rs:26:1: 26:2
-          goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:26:2: 26:2
+          goto -> bb3;                     // scope 0 at $DIR/simplify-arm.rs:26:2: 26:2
       }
   
-      bb4: {
+      bb3: {
           return;                          // scope 0 at $DIR/simplify-arm.rs:26:2: 26:2
       }
   }

--- a/src/test/mir-opt/simplify_arm.id_try.SimplifyBranchSame.diff
+++ b/src/test/mir-opt/simplify_arm.id_try.SimplifyBranchSame.diff
@@ -46,7 +46,7 @@
           _3 = move _4;                    // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
           StorageDead(_4);                 // scope 0 at $DIR/simplify-arm.rs:24:14: 24:15
           _5 = discriminant(_3);           // scope 0 at $DIR/simplify-arm.rs:24:14: 24:15
--         switchInt(move _5) -> [0_isize: bb1, 1_isize: bb3, otherwise: bb2]; // scope 0 at $DIR/simplify-arm.rs:24:14: 24:15
+-         switchInt(move _5) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/simplify-arm.rs:24:14: 24:15
 +         goto -> bb1;                     // scope 0 at $DIR/simplify-arm.rs:24:14: 24:15
       }
   
@@ -54,22 +54,18 @@
           _0 = move _3;                    // scope 1 at $DIR/simplify-arm.rs:25:5: 25:10
           StorageDead(_3);                 // scope 0 at $DIR/simplify-arm.rs:24:15: 24:16
           StorageDead(_2);                 // scope 0 at $DIR/simplify-arm.rs:26:1: 26:2
--         goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:26:2: 26:2
+-         goto -> bb3;                     // scope 0 at $DIR/simplify-arm.rs:26:2: 26:2
 +         goto -> bb2;                     // scope 0 at $DIR/simplify-arm.rs:26:2: 26:2
       }
   
       bb2: {
--         unreachable;                     // scope 0 at $DIR/simplify-arm.rs:24:13: 24:15
--     }
-- 
--     bb3: {
 -         _0 = move _3;                    // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
 -         StorageDead(_3);                 // scope 0 at $DIR/simplify-arm.rs:24:15: 24:16
 -         StorageDead(_2);                 // scope 0 at $DIR/simplify-arm.rs:26:1: 26:2
--         goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:26:2: 26:2
+-         goto -> bb3;                     // scope 0 at $DIR/simplify-arm.rs:26:2: 26:2
 -     }
 - 
--     bb4: {
+-     bb3: {
           return;                          // scope 0 at $DIR/simplify-arm.rs:26:2: 26:2
       }
   }

--- a/src/test/mir-opt/simplify_arm_identity.main.SimplifyArmIdentity.64bit.diff
+++ b/src/test/mir-opt/simplify_arm_identity.main.SimplifyArmIdentity.64bit.diff
@@ -23,20 +23,16 @@
           discriminant(_1) = 0;            // scope 0 at $DIR/simplify-arm-identity.rs:18:18: 18:29
           StorageLive(_2);                 // scope 1 at $DIR/simplify-arm-identity.rs:19:18: 22:6
           _3 = const 0_isize;              // scope 1 at $DIR/simplify-arm-identity.rs:20:9: 20:20
-          goto -> bb3;                     // scope 1 at $DIR/simplify-arm-identity.rs:20:9: 20:20
+          goto -> bb2;                     // scope 1 at $DIR/simplify-arm-identity.rs:20:9: 20:20
       }
   
       bb1: {
           ((_2 as Foo).0: u8) = const 0_u8; // scope 1 at $DIR/simplify-arm-identity.rs:21:21: 21:32
           discriminant(_2) = 0;            // scope 1 at $DIR/simplify-arm-identity.rs:21:21: 21:32
-          goto -> bb4;                     // scope 1 at $DIR/simplify-arm-identity.rs:19:18: 22:6
+          goto -> bb3;                     // scope 1 at $DIR/simplify-arm-identity.rs:19:18: 22:6
       }
   
       bb2: {
-          unreachable;                     // scope 1 at $DIR/simplify-arm-identity.rs:19:24: 19:25
-      }
-  
-      bb3: {
           StorageLive(_4);                 // scope 1 at $DIR/simplify-arm-identity.rs:20:18: 20:19
           _4 = ((_1 as Foo).0: u8);        // scope 1 at $DIR/simplify-arm-identity.rs:20:18: 20:19
           StorageLive(_5);                 // scope 3 at $DIR/simplify-arm-identity.rs:20:33: 20:34
@@ -45,10 +41,10 @@
           discriminant(_2) = 0;            // scope 3 at $DIR/simplify-arm-identity.rs:20:24: 20:35
           StorageDead(_5);                 // scope 3 at $DIR/simplify-arm-identity.rs:20:34: 20:35
           StorageDead(_4);                 // scope 1 at $DIR/simplify-arm-identity.rs:20:34: 20:35
-          goto -> bb4;                     // scope 1 at $DIR/simplify-arm-identity.rs:19:18: 22:6
+          goto -> bb3;                     // scope 1 at $DIR/simplify-arm-identity.rs:19:18: 22:6
       }
   
-      bb4: {
+      bb3: {
           StorageDead(_2);                 // scope 1 at $DIR/simplify-arm-identity.rs:22:6: 22:7
           _0 = const ();                   // scope 0 at $DIR/simplify-arm-identity.rs:17:11: 23:2
           StorageDead(_1);                 // scope 0 at $DIR/simplify-arm-identity.rs:23:1: 23:2


### PR DESCRIPTION
This was added in https://github.com/rust-lang/rust/pull/66329, but turned off by default since it ran into pathological LLVM behavior leading to huge compile time regressions (https://github.com/rust-lang/rust/issues/68105). Let's see if that is still the case.