### PR TITLE
Unset GIT_DIR in pre-commit hook

### DIFF
--- a/src/etc/pre-commit.sh
+++ b/src/etc/pre-commit.sh
@@ -7,15 +7,17 @@
 
 set -Eeuo pipefail
 
-ROOT_DIR="$(git rev-parse --show-toplevel)";
-COMMAND="$ROOT_DIR/x.py test tidy --bless";
+# https://github.com/rust-lang/rust/issues/77620#issuecomment-705144570
+unset GIT_DIR
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+COMMAND="$ROOT_DIR/x.py test tidy --bless"
 
 if [[ "$OSTYPE" == "msys" || "$OSTYPE" == "win32" ]]; then
   COMMAND="python $COMMAND"
 fi
 
-echo "Running pre-commit script '$COMMAND'";
+echo "Running pre-commit script '$COMMAND'"
 
 cd "$ROOT_DIR"
 
-$COMMAND;
+$COMMAND


### PR DESCRIPTION
Works around https://github.com/rust-lang/rust/issues/77620. This won't help any other hooks you write manually, but hopefully people won't feel the need to do that now there's an 'official' one.

r? @Mark-Simulacrum 
cc @caass 