### PR TITLE
Add built-in implementations of `Default` for function definition and…

### DIFF
--- a/compiler/rustc_hir/src/lang_items.rs
+++ b/compiler/rustc_hir/src/lang_items.rs
@@ -157,7 +157,7 @@ where
 }
 
 language_item_table! {
-//  Variant name,            Name,                    Method name,             Target;
+//  Variant name,            Name,                     Method name,                Target;
     Bool,                    sym::bool,                bool_impl,                  Target::Impl;
     Char,                    sym::char,                char_impl,                  Target::Impl;
     Str,                     sym::str,                 str_impl,                   Target::Impl;
@@ -196,6 +196,7 @@ language_item_table! {
     StructuralTeq,           sym::structural_teq,      structural_teq_trait,       Target::Trait;
     Copy,                    sym::copy,                copy_trait,                 Target::Trait;
     Clone,                   sym::clone,               clone_trait,                Target::Trait;
+    Default,                 kw::Default,              default_trait,              Target::Trait;
     Sync,                    sym::sync,                sync_trait,                 Target::Trait;
     DiscriminantKind,        sym::discriminant_kind,   discriminant_kind_trait,    Target::Trait;
     // The associated item of `trait DiscriminantKind`.

--- a/compiler/rustc_middle/src/mir/mono.rs
+++ b/compiler/rustc_middle/src/mir/mono.rs
@@ -344,7 +344,8 @@ impl<'tcx> CodegenUnit<'tcx> {
                             | InstanceDef::Virtual(..)
                             | InstanceDef::ClosureOnceShim { .. }
                             | InstanceDef::DropGlue(..)
-                            | InstanceDef::CloneShim(..) => None,
+                            | InstanceDef::CloneShim(..)
+                            | InstanceDef::DefaultShim(..) => None,
                         }
                     }
                     MonoItem::Static(def_id) => {

--- a/compiler/rustc_middle/src/mir/visit.rs
+++ b/compiler/rustc_middle/src/mir/visit.rs
@@ -351,7 +351,8 @@ macro_rules! make_mir_visitor {
 
                         ty::InstanceDef::FnPtrShim(_def_id, ty) |
                         ty::InstanceDef::DropGlue(_def_id, Some(ty)) |
-                        ty::InstanceDef::CloneShim(_def_id, ty) => {
+                        ty::InstanceDef::CloneShim(_def_id, ty) |
+                        ty::InstanceDef::DefaultShim(_def_id, ty) => {
                             // FIXME(eddyb) use a better `TyContext` here.
                             self.visit_ty(ty, TyContext::Location(location));
                         }

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -2949,7 +2949,8 @@ impl<'tcx> TyCtxt<'tcx> {
             | ty::InstanceDef::Virtual(..)
             | ty::InstanceDef::ClosureOnceShim { .. }
             | ty::InstanceDef::DropGlue(..)
-            | ty::InstanceDef::CloneShim(..) => self.mir_shims(instance),
+            | ty::InstanceDef::CloneShim(..)
+            | ty::InstanceDef::DefaultShim(..) => self.mir_shims(instance),
         }
     }
 

--- a/compiler/rustc_middle/src/ty/structural_impls.rs
+++ b/compiler/rustc_middle/src/ty/structural_impls.rs
@@ -707,6 +707,9 @@ impl<'a, 'tcx> Lift<'tcx> for ty::InstanceDef<'a> {
             ty::InstanceDef::CloneShim(def_id, ty) => {
                 Some(ty::InstanceDef::CloneShim(def_id, tcx.lift(ty)?))
             }
+            ty::InstanceDef::DefaultShim(def_id, ty) => {
+                Some(ty::InstanceDef::DefaultShim(def_id, tcx.lift(ty)?))
+            }
         }
     }
 }
@@ -888,6 +891,7 @@ impl<'tcx> TypeFoldable<'tcx> for ty::instance::Instance<'tcx> {
                 }
                 DropGlue(did, ty) => DropGlue(did.fold_with(folder), ty.fold_with(folder)),
                 CloneShim(did, ty) => CloneShim(did.fold_with(folder), ty.fold_with(folder)),
+                DefaultShim(did, ty) => DefaultShim(did.fold_with(folder), ty.fold_with(folder)),
             },
         }
     }
@@ -900,7 +904,7 @@ impl<'tcx> TypeFoldable<'tcx> for ty::instance::Instance<'tcx> {
             VtableShim(did) | ReifyShim(did) | Intrinsic(did) | Virtual(did, _) => {
                 did.visit_with(visitor)
             }
-            FnPtrShim(did, ty) | CloneShim(did, ty) => {
+            FnPtrShim(did, ty) | CloneShim(did, ty) | DefaultShim(did, ty) => {
                 did.visit_with(visitor)?;
                 ty.visit_with(visitor)
             }

--- a/compiler/rustc_mir/src/interpret/terminator.rs
+++ b/compiler/rustc_mir/src/interpret/terminator.rs
@@ -262,6 +262,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             | ty::InstanceDef::FnPtrShim(..)
             | ty::InstanceDef::DropGlue(..)
             | ty::InstanceDef::CloneShim(..)
+            | ty::InstanceDef::DefaultShim(..)
             | ty::InstanceDef::Item(_) => {
                 // We need MIR for this fn
                 let body = match M::find_mir_or_eval_fn(self, instance, args, ret, unwind)? {

--- a/compiler/rustc_mir/src/monomorphize/collector.rs
+++ b/compiler/rustc_mir/src/monomorphize/collector.rs
@@ -782,7 +782,8 @@ fn visit_instance_use<'tcx>(
         | ty::InstanceDef::ClosureOnceShim { .. }
         | ty::InstanceDef::Item(..)
         | ty::InstanceDef::FnPtrShim(..)
-        | ty::InstanceDef::CloneShim(..) => {
+        | ty::InstanceDef::CloneShim(..)
+        | ty::InstanceDef::DefaultShim(..) => {
             output.push(create_fn_mono_item(tcx, instance, source));
         }
     }
@@ -802,7 +803,8 @@ fn should_codegen_locally<'tcx>(tcx: TyCtxt<'tcx>, instance: &Instance<'tcx>) ->
         | ty::InstanceDef::FnPtrShim(..)
         | ty::InstanceDef::DropGlue(..)
         | ty::InstanceDef::Intrinsic(_)
-        | ty::InstanceDef::CloneShim(..) => return true,
+        | ty::InstanceDef::CloneShim(..)
+        | ty::InstanceDef::DefaultShim(..) => return true,
     };
 
     if tcx.is_foreign_item(def_id) {

--- a/compiler/rustc_mir/src/monomorphize/partitioning/default.rs
+++ b/compiler/rustc_mir/src/monomorphize/partitioning/default.rs
@@ -278,7 +278,8 @@ fn characteristic_def_id_of_mono_item<'tcx>(
                 | ty::InstanceDef::Intrinsic(..)
                 | ty::InstanceDef::DropGlue(..)
                 | ty::InstanceDef::Virtual(..)
-                | ty::InstanceDef::CloneShim(..) => return None,
+                | ty::InstanceDef::CloneShim(..)
+                | ty::InstanceDef::DefaultShim(..) => return None,
             };
 
             // If this is a method, we want to put it into the same module as
@@ -428,7 +429,8 @@ fn mono_item_visibility(
         | InstanceDef::Intrinsic(..)
         | InstanceDef::ClosureOnceShim { .. }
         | InstanceDef::DropGlue(..)
-        | InstanceDef::CloneShim(..) => return Visibility::Hidden,
+        | InstanceDef::CloneShim(..)
+        | InstanceDef::DefaultShim(..) => return Visibility::Hidden,
     };
 
     // The `start_fn` lang item is actually a monomorphized instance of a

--- a/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs
@@ -281,6 +281,11 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                 // types have builtin support for `Clone`.
                 let clone_conditions = self.copy_clone_conditions(obligation);
                 self.assemble_builtin_bound_candidates(clone_conditions, &mut candidates)?;
+            } else if lang_items.default_trait() == Some(def_id) {
+                // Function definition and closure types have built-in implementations of the
+                // `Default` trait.
+                let default_conditions = self.default_conditions(obligation);
+                self.assemble_builtin_bound_candidates(default_conditions, &mut candidates)?;
             }
 
             self.assemble_generator_candidates(obligation, &mut candidates)?;

--- a/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
@@ -218,6 +218,8 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                 self.copy_clone_conditions(obligation)
             } else if Some(trait_def) == lang_items.clone_trait() {
                 self.copy_clone_conditions(obligation)
+            } else if Some(trait_def) == lang_items.default_trait() {
+                self.default_conditions(obligation)
             } else {
                 bug!("unexpected builtin trait {:?}", trait_def)
             };

--- a/library/core/src/default.rs
+++ b/library/core/src/default.rs
@@ -80,6 +80,7 @@
 ///     bar: f32,
 /// }
 /// ```
+#[cfg_attr(not(bootstrap), lang = "default")]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait Default: Sized {
     /// Returns the "default value" for a type.

--- a/src/test/ui/builtin-default.rs
+++ b/src/test/ui/builtin-default.rs
@@ -1,0 +1,14 @@
+// run-pass
+// Test that `Default` is correctly implemented for builtin types.
+
+fn test_default<F: Default + Fn()>(_: F) {
+    let f = F::default();
+    f();
+}
+
+fn foo() { }
+
+fn main() {
+    test_default(foo);
+    test_default(|| ());
+}

--- a/src/test/ui/not-default-closure.rs
+++ b/src/test/ui/not-default-closure.rs
@@ -1,0 +1,15 @@
+// Check that closures do not implement `Default` if their environment is not empty.
+
+fn test_default<F: Default + Fn()>(_: F) {
+    let f = F::default();
+    f();
+}
+
+fn main() {
+    let a = "Bob";
+    let hello = move || {
+        println!("Hello {}", a);
+    };
+
+    test_default(hello); //~ ERROR the trait bound
+}

--- a/src/test/ui/not-default-closure.stderr
+++ b/src/test/ui/not-default-closure.stderr
@@ -1,0 +1,17 @@
+error[E0277]: the trait bound `[closure@$DIR/not-default-closure.rs:10:17: 12:6]: Default` is not satisfied
+  --> $DIR/not-default-closure.rs:14:5
+   |
+LL | fn test_default<F: Default + Fn()>(_: F) {
+   |                    ------- required by this bound in `test_default`
+...
+LL |     let hello = move || {
+   |                 ------- consider calling this closure
+...
+LL |     test_default(hello);
+   |     ^^^^^^^^^^^^ the trait `Default` is not implemented for `[closure@$DIR/not-default-closure.rs:10:17: 12:6]`
+   |
+   = help: use parentheses to call the closure: `hello()`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
… non-capturing closure types.

Without these implementations, there's currently no safe way to construct these types from nothing. Furthermore, there's no way to safely constrain an unsafe implementation because the necessary bounds are not expressible.

