### PR TITLE
Simplify some code in rustc_llvm/build.rs now that LLVM 8 is required

### DIFF
--- a/compiler/rustc_llvm/build.rs
+++ b/compiler/rustc_llvm/build.rs
@@ -70,7 +70,7 @@ fn main() {
     let host = env::var("HOST").expect("HOST was not set");
     let is_crossed = target != host;
 
-    let mut optional_components = vec![
+    let optional_components = &[
         "x86",
         "arm",
         "aarch64",
@@ -85,6 +85,7 @@ fn main() {
         "sparc",
         "nvptx",
         "hexagon",
+        "riscv",
     ];
 
     let mut version_cmd = Command::new(&llvm_config);
@@ -94,12 +95,8 @@ fn main() {
     let (major, _minor) = if let (Some(major), Some(minor)) = (parts.next(), parts.next()) {
         (major, minor)
     } else {
-        (6, 0)
+        (8, 0)
     };
-
-    if major > 6 {
-        optional_components.push("riscv");
-    }
 
     let required_components = &[
         "ipo",


### PR DESCRIPTION
LLVM 8 is required since 8506bb006040cf8e8cb004202706c81e62ddacee
so this is safe to do.