### PR TITLE
Rename/Deprecate LayoutErr in favor of LayoutError

### DIFF
--- a/library/alloc/src/collections/mod.rs
+++ b/library/alloc/src/collections/mod.rs
@@ -41,7 +41,7 @@ pub use linked_list::LinkedList;
 #[doc(no_inline)]
 pub use vec_deque::VecDeque;
 
-use crate::alloc::{Layout, LayoutErr};
+use crate::alloc::{Layout, LayoutError};
 use core::fmt::Display;
 
 /// The error type for `try_reserve` methods.
@@ -71,9 +71,9 @@ pub enum TryReserveError {
 }
 
 #[unstable(feature = "try_reserve", reason = "new API", issue = "48043")]
-impl From<LayoutErr> for TryReserveError {
+impl From<LayoutError> for TryReserveError {
     #[inline]
-    fn from(_: LayoutErr) -> Self {
+    fn from(_: LayoutError) -> Self {
         TryReserveError::CapacityOverflow
     }
 }

--- a/library/alloc/src/raw_vec.rs
+++ b/library/alloc/src/raw_vec.rs
@@ -1,7 +1,7 @@
 #![unstable(feature = "raw_vec_internals", reason = "implementation detail", issue = "none")]
 #![doc(hidden)]
 
-use core::alloc::LayoutErr;
+use core::alloc::LayoutError;
 use core::cmp;
 use core::intrinsics;
 use core::mem::{self, ManuallyDrop, MaybeUninit};
@@ -471,7 +471,7 @@ impl<T, A: AllocRef> RawVec<T, A> {
 // significant, because the number of different `A` types seen in practice is
 // much smaller than the number of `T` types.)
 fn finish_grow<A>(
-    new_layout: Result<Layout, LayoutErr>,
+    new_layout: Result<Layout, LayoutError>,
     current_memory: Option<(NonNull<u8>, Layout)>,
     alloc: &mut A,
 ) -> Result<NonNull<[u8]>, TryReserveError>

--- a/library/core/src/alloc/layout.rs
+++ b/library/core/src/alloc/layout.rs
@@ -395,7 +395,7 @@ impl Layout {
 #[stable(feature = "alloc_layout", since = "1.28.0")]
 #[rustc_deprecated(
     since = "1.51.0",
-    reason = "use LayoutError instead",
+    reason = "Name does not follow std convention, use LayoutError",
     suggestion = "LayoutError"
 )]
 pub type LayoutErr = LayoutError;

--- a/library/core/src/alloc/layout.rs
+++ b/library/core/src/alloc/layout.rs
@@ -39,7 +39,7 @@ pub struct Layout {
 
 impl Layout {
     /// Constructs a `Layout` from a given `size` and `align`,
-    /// or returns `LayoutErr` if any of the following conditions
+    /// or returns `LayoutError` if any of the following conditions
     /// are not met:
     ///
     /// * `align` must not be zero,
@@ -52,9 +52,9 @@ impl Layout {
     #[stable(feature = "alloc_layout", since = "1.28.0")]
     #[rustc_const_unstable(feature = "const_alloc_layout", issue = "67521")]
     #[inline]
-    pub const fn from_size_align(size: usize, align: usize) -> Result<Self, LayoutErr> {
+    pub const fn from_size_align(size: usize, align: usize) -> Result<Self, LayoutError> {
         if !align.is_power_of_two() {
-            return Err(LayoutErr { private: () });
+            return Err(LayoutError { private: () });
         }
 
         // (power-of-two implies align != 0.)
@@ -72,7 +72,7 @@ impl Layout {
         // Above implies that checking for summation overflow is both
         // necessary and sufficient.
         if size > usize::MAX - (align - 1) {
-            return Err(LayoutErr { private: () });
+            return Err(LayoutError { private: () });
         }
 
         // SAFETY: the conditions for `from_size_align_unchecked` have been
@@ -200,7 +200,7 @@ impl Layout {
     /// `align` violates the conditions listed in [`Layout::from_size_align`].
     #[stable(feature = "alloc_layout_manipulation", since = "1.44.0")]
     #[inline]
-    pub fn align_to(&self, align: usize) -> Result<Self, LayoutErr> {
+    pub fn align_to(&self, align: usize) -> Result<Self, LayoutError> {
         Layout::from_size_align(self.size(), cmp::max(self.align(), align))
     }
 
@@ -274,16 +274,16 @@ impl Layout {
     /// layout of the array and `offs` is the distance between the start
     /// of each element in the array.
     ///
-    /// On arithmetic overflow, returns `LayoutErr`.
+    /// On arithmetic overflow, returns `LayoutError`.
     #[unstable(feature = "alloc_layout_extra", issue = "55724")]
     #[inline]
-    pub fn repeat(&self, n: usize) -> Result<(Self, usize), LayoutErr> {
+    pub fn repeat(&self, n: usize) -> Result<(Self, usize), LayoutError> {
         // This cannot overflow. Quoting from the invariant of Layout:
         // > `size`, when rounded up to the nearest multiple of `align`,
         // > must not overflow (i.e., the rounded value must be less than
         // > `usize::MAX`)
         let padded_size = self.size() + self.padding_needed_for(self.align());
-        let alloc_size = padded_size.checked_mul(n).ok_or(LayoutErr { private: () })?;
+        let alloc_size = padded_size.checked_mul(n).ok_or(LayoutError { private: () })?;
 
         // SAFETY: self.align is already known to be valid and alloc_size has been
         // padded already.
@@ -307,7 +307,7 @@ impl Layout {
     /// start of the `next` embedded within the concatenated record
     /// (assuming that the record itself starts at offset 0).
     ///
-    /// On arithmetic overflow, returns `LayoutErr`.
+    /// On arithmetic overflow, returns `LayoutError`.
     ///
     /// # Examples
     ///
@@ -315,8 +315,8 @@ impl Layout {
     /// the fields from its fields' layouts:
     ///
     /// ```rust
-    /// # use std::alloc::{Layout, LayoutErr};
-    /// pub fn repr_c(fields: &[Layout]) -> Result<(Layout, Vec<usize>), LayoutErr> {
+    /// # use std::alloc::{Layout, LayoutError};
+    /// pub fn repr_c(fields: &[Layout]) -> Result<(Layout, Vec<usize>), LayoutError> {
     ///     let mut offsets = Vec::new();
     ///     let mut layout = Layout::from_size_align(0, 1)?;
     ///     for &field in fields {
@@ -337,12 +337,12 @@ impl Layout {
     /// ```
     #[stable(feature = "alloc_layout_manipulation", since = "1.44.0")]
     #[inline]
-    pub fn extend(&self, next: Self) -> Result<(Self, usize), LayoutErr> {
+    pub fn extend(&self, next: Self) -> Result<(Self, usize), LayoutError> {
         let new_align = cmp::max(self.align(), next.align());
         let pad = self.padding_needed_for(next.align());
 
-        let offset = self.size().checked_add(pad).ok_or(LayoutErr { private: () })?;
-        let new_size = offset.checked_add(next.size()).ok_or(LayoutErr { private: () })?;
+        let offset = self.size().checked_add(pad).ok_or(LayoutError { private: () })?;
+        let new_size = offset.checked_add(next.size()).ok_or(LayoutError { private: () })?;
 
         let layout = Layout::from_size_align(new_size, new_align)?;
         Ok((layout, offset))
@@ -359,11 +359,11 @@ impl Layout {
     /// guaranteed that all elements in the array will be properly
     /// aligned.
     ///
-    /// On arithmetic overflow, returns `LayoutErr`.
+    /// On arithmetic overflow, returns `LayoutError`.
     #[unstable(feature = "alloc_layout_extra", issue = "55724")]
     #[inline]
-    pub fn repeat_packed(&self, n: usize) -> Result<Self, LayoutErr> {
-        let size = self.size().checked_mul(n).ok_or(LayoutErr { private: () })?;
+    pub fn repeat_packed(&self, n: usize) -> Result<Self, LayoutError> {
+        let size = self.size().checked_mul(n).ok_or(LayoutError { private: () })?;
         Layout::from_size_align(size, self.align())
     }
 
@@ -372,38 +372,41 @@ impl Layout {
     /// padding is inserted, the alignment of `next` is irrelevant,
     /// and is not incorporated *at all* into the resulting layout.
     ///
-    /// On arithmetic overflow, returns `LayoutErr`.
+    /// On arithmetic overflow, returns `LayoutError`.
     #[unstable(feature = "alloc_layout_extra", issue = "55724")]
     #[inline]
-    pub fn extend_packed(&self, next: Self) -> Result<Self, LayoutErr> {
-        let new_size = self.size().checked_add(next.size()).ok_or(LayoutErr { private: () })?;
+    pub fn extend_packed(&self, next: Self) -> Result<Self, LayoutError> {
+        let new_size = self.size().checked_add(next.size()).ok_or(LayoutError { private: () })?;
         Layout::from_size_align(new_size, self.align())
     }
 
     /// Creates a layout describing the record for a `[T; n]`.
     ///
-    /// On arithmetic overflow, returns `LayoutErr`.
+    /// On arithmetic overflow, returns `LayoutError`.
     #[stable(feature = "alloc_layout_manipulation", since = "1.44.0")]
     #[inline]
-    pub fn array<T>(n: usize) -> Result<Self, LayoutErr> {
+    pub fn array<T>(n: usize) -> Result<Self, LayoutError> {
         let (layout, offset) = Layout::new::<T>().repeat(n)?;
         debug_assert_eq!(offset, mem::size_of::<T>());
         Ok(layout.pad_to_align())
     }
 }
 
+#[stable(feature = "alloc_layout", since = "1.28.0")]
+pub type LayoutErr = LayoutError;
+
 /// The parameters given to `Layout::from_size_align`
 /// or some other `Layout` constructor
 /// do not satisfy its documented constraints.
-#[stable(feature = "alloc_layout", since = "1.28.0")]
+#[stable(feature = "alloc_layout_error", since = "1.49.0")]
 #[derive(Clone, PartialEq, Eq, Debug)]
-pub struct LayoutErr {
+pub struct LayoutError {
     private: (),
 }
 
 // (we need this for downstream impl of trait Error)
 #[stable(feature = "alloc_layout", since = "1.28.0")]
-impl fmt::Display for LayoutErr {
+impl fmt::Display for LayoutError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("invalid parameters to Layout::from_size_align")
     }

--- a/library/core/src/alloc/layout.rs
+++ b/library/core/src/alloc/layout.rs
@@ -393,6 +393,11 @@ impl Layout {
 }
 
 #[stable(feature = "alloc_layout", since = "1.28.0")]
+#[rustc_deprecated(
+    since = "1.51.0",
+    reason = "use LayoutError instead",
+    suggestion = "LayoutError"
+)]
 pub type LayoutErr = LayoutError;
 
 /// The parameters given to `Layout::from_size_align`

--- a/library/core/src/alloc/mod.rs
+++ b/library/core/src/alloc/mod.rs
@@ -12,7 +12,7 @@ pub use self::layout::Layout;
 #[stable(feature = "alloc_layout", since = "1.28.0")]
 #[rustc_deprecated(
     since = "1.51.0",
-    reason = "use LayoutError instead",
+    reason = "Name does not follow std convention, use LayoutError",
     suggestion = "LayoutError"
 )]
 #[allow(deprecated, deprecated_in_future)]

--- a/library/core/src/alloc/mod.rs
+++ b/library/core/src/alloc/mod.rs
@@ -8,7 +8,15 @@ mod layout;
 #[stable(feature = "global_alloc", since = "1.28.0")]
 pub use self::global::GlobalAlloc;
 #[stable(feature = "alloc_layout", since = "1.28.0")]
-pub use self::layout::{Layout, LayoutErr};
+pub use self::layout::Layout;
+#[stable(feature = "alloc_layout", since = "1.28.0")]
+#[rustc_deprecated(
+    since = "1.51.0",
+    reason = "use LayoutError instead",
+    suggestion = "LayoutError"
+)]
+#[allow(deprecated, deprecated_in_future)]
+pub use self::layout::LayoutErr;
 
 #[stable(feature = "alloc_layout_error", since = "1.49.0")]
 pub use self::layout::LayoutError;

--- a/library/core/src/alloc/mod.rs
+++ b/library/core/src/alloc/mod.rs
@@ -10,6 +10,9 @@ pub use self::global::GlobalAlloc;
 #[stable(feature = "alloc_layout", since = "1.28.0")]
 pub use self::layout::{Layout, LayoutErr};
 
+#[stable(feature = "alloc_layout_error", since = "1.49.0")]
+pub use self::layout::LayoutError;
+
 use crate::fmt;
 use crate::ptr::{self, NonNull};
 

--- a/library/std/src/error.rs
+++ b/library/std/src/error.rs
@@ -19,7 +19,7 @@ mod tests;
 use core::array;
 use core::convert::Infallible;
 
-use crate::alloc::{AllocError, LayoutErr};
+use crate::alloc::{AllocError, LayoutError};
 use crate::any::TypeId;
 use crate::backtrace::Backtrace;
 use crate::borrow::Cow;
@@ -390,7 +390,7 @@ impl Error for ! {}
 impl Error for AllocError {}
 
 #[stable(feature = "alloc_layout", since = "1.28.0")]
-impl Error for LayoutErr {}
+impl Error for LayoutError {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl Error for str::ParseBoolError {


### PR DESCRIPTION
Implements rust-lang/wg-allocators#73.

This patch renames LayoutErr to LayoutError, and uses a type alias to support users using the old name.

The new name will be instantly stable in release 1.49 (current nightly), the type alias will become deprecated in release 1.51 (so that when the current nightly is 1.51, 1.49 will be stable).

This is the only error type in `std` that ends in `Err` rather than `Error`, if this PR lands all stdlib error types will end in `Error` :smiling_face_with_three_hearts: