### PR TITLE
Make `max_log_info` easily greppable (for figuring out why debug logging is disabled)

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -382,6 +382,10 @@ changelog-seen = 1
 # Overrides the `debug-assertions` option, if defined.
 #
 # Defaults to rust.debug-assertions value
+#
+# If you see a message from `tracing` saying
+# `max_level_info` is enabled and means logging won't be shown,
+# set this value to `true`.
 #debug-logging = debug-assertions
 
 # Debuginfo level for most of Rust code, corresponds to the `-C debuginfo=N` option of `rustc`.


### PR DESCRIPTION
Follow-up to https://github.com/rust-lang/rust/pull/77678#issuecomment-705545608. I'll make a PR to the dev-guide shortly changing `debug = true` to `debug-logging = true` and using this text.

Ideally wouldn't be merged before https://github.com/rust-lang/rust/pull/77678, but it practice it won't hurt anything.

r? @Mark-Simulacrum 