### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/compiler/rustc_driver/src/lib.rs
+++ b/compiler/rustc_driver/src/lib.rs
@@ -155,8 +155,7 @@ pub fn run_compiler(
             ),
         }
     }
-    let diagnostic_output =
-        emitter.map(|emitter| DiagnosticOutput::Raw(emitter)).unwrap_or(DiagnosticOutput::Default);
+    let diagnostic_output = emitter.map(DiagnosticOutput::Raw).unwrap_or(DiagnosticOutput::Default);
     let matches = match handle_options(&args) {
         Some(matches) => matches,
         None => return Ok(()),

--- a/compiler/rustc_driver/src/lib.rs
+++ b/compiler/rustc_driver/src/lib.rs
@@ -155,7 +155,7 @@ pub fn run_compiler(
             ),
         }
     }
-    let diagnostic_output = emitter.map(DiagnosticOutput::Raw).unwrap_or(DiagnosticOutput::Default);
+    let diagnostic_output = emitter.map_or(DiagnosticOutput::Default, DiagnosticOutput::Raw);
     let matches = match handle_options(&args) {
         Some(matches) => matches,
         None => return Ok(()),

--- a/compiler/rustc_span/src/lib.rs
+++ b/compiler/rustc_span/src/lib.rs
@@ -1861,7 +1861,7 @@ where
         }
 
         if *self == DUMMY_SP {
-            std::hash::Hash::hash(&TAG_INVALID_SPAN, hasher);
+            Hash::hash(&TAG_INVALID_SPAN, hasher);
             return;
         }
 
@@ -1872,28 +1872,28 @@ where
         let (file_lo, line_lo, col_lo) = match ctx.byte_pos_to_line_and_col(span.lo) {
             Some(pos) => pos,
             None => {
-                std::hash::Hash::hash(&TAG_INVALID_SPAN, hasher);
+                Hash::hash(&TAG_INVALID_SPAN, hasher);
                 span.ctxt.hash_stable(ctx, hasher);
                 return;
             }
         };
 
         if !file_lo.contains(span.hi) {
-            std::hash::Hash::hash(&TAG_INVALID_SPAN, hasher);
+            Hash::hash(&TAG_INVALID_SPAN, hasher);
             span.ctxt.hash_stable(ctx, hasher);
             return;
         }
 
-        std::hash::Hash::hash(&TAG_VALID_SPAN, hasher);
+        Hash::hash(&TAG_VALID_SPAN, hasher);
         // We truncate the stable ID hash and line and column numbers. The chances
         // of causing a collision this way should be minimal.
-        std::hash::Hash::hash(&(file_lo.name_hash as u64), hasher);
+        Hash::hash(&(file_lo.name_hash as u64), hasher);
 
         let col = (col_lo.0 as u64) & 0xFF;
         let line = ((line_lo as u64) & 0xFF_FF_FF) << 8;
         let len = ((span.hi - span.lo).0 as u64) << 32;
         let line_col_len = col | line | len;
-        std::hash::Hash::hash(&line_col_len, hasher);
+        Hash::hash(&line_col_len, hasher);
         span.ctxt.hash_stable(ctx, hasher);
     }
 }

--- a/compiler/rustc_typeck/src/check/op.rs
+++ b/compiler/rustc_typeck/src/check/op.rs
@@ -2,6 +2,7 @@
 
 use super::method::MethodCallee;
 use super::FnCtxt;
+use rustc_ast as ast;
 use rustc_errors::{self, struct_span_err, Applicability, DiagnosticBuilder};
 use rustc_hir as hir;
 use rustc_infer::infer::type_variable::{TypeVariableOrigin, TypeVariableOriginKind};
@@ -13,6 +14,7 @@ use rustc_middle::ty::TyKind::{Adt, Array, Char, FnDef, Never, Ref, Str, Tuple, 
 use rustc_middle::ty::{
     self, suggest_constraining_type_param, Ty, TyCtxt, TypeFoldable, TypeVisitor,
 };
+use rustc_span::source_map::Spanned;
 use rustc_span::symbol::{sym, Ident};
 use rustc_span::Span;
 use rustc_trait_selection::infer::InferCtxtExt;
@@ -673,6 +675,29 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     match actual.kind() {
                         Uint(_) if op == hir::UnOp::UnNeg => {
                             err.note("unsigned values cannot be negated");
+
+                            if let hir::ExprKind::Unary(
+                                _,
+                                hir::Expr {
+                                    kind:
+                                        hir::ExprKind::Lit(Spanned {
+                                            node: ast::LitKind::Int(1, _),
+                                            ..
+                                        }),
+                                    ..
+                                },
+                            ) = ex.kind
+                            {
+                                err.span_suggestion(
+                                    ex.span,
+                                    &format!(
+                                        "you may have meant the maximum value of `{}`",
+                                        actual
+                                    ),
+                                    format!("{}::MAX", actual),
+                                    Applicability::MaybeIncorrect,
+                                );
+                            }
                         }
                         Str | Never | Char | Tuple(_) | Array(_, _) => {}
                         Ref(_, ref lty, _) if *lty.kind() == Str => {}

--- a/config.toml.example
+++ b/config.toml.example
@@ -382,6 +382,10 @@ changelog-seen = 1
 # Overrides the `debug-assertions` option, if defined.
 #
 # Defaults to rust.debug-assertions value
+#
+# If you see a message from `tracing` saying
+# `max_level_info` is enabled and means logging won't be shown,
+# set this value to `true`.
 #debug-logging = debug-assertions
 
 # Debuginfo level for most of Rust code, corresponds to the `-C debuginfo=N` option of `rustc`.

--- a/library/alloc/src/collections/btree/map.rs
+++ b/library/alloc/src/collections/btree/map.rs
@@ -1748,6 +1748,10 @@ impl<'a, K: 'a, V: 'a> DrainFilterInner<'a, K, V> {
 
     /// Implementation of a typical `DrainFilter::size_hint` method.
     pub(super) fn size_hint(&self) -> (usize, Option<usize>) {
+        // In most of the btree iterators, `self.length` is the number of elements
+        // yet to be visited. Here, it includes elements that were visited and that
+        // the predicate decided not to drain. Making this upper bound more accurate
+        // requires maintaining an extra field and is not worth while.
         (0, Some(*self.length))
     }
 }

--- a/library/std/src/sync/mutex.rs
+++ b/library/std/src/sync/mutex.rs
@@ -276,7 +276,7 @@ impl<T: ?Sized> Mutex<T> {
     /// # Errors
     ///
     /// If another user of this mutex panicked while holding the mutex, then
-    /// this call will return failure if the mutex would otherwise be
+    /// this call will return an error if the mutex would otherwise be
     /// acquired.
     ///
     /// # Examples

--- a/src/test/compile-fail/issue-27675-unchecked-bounds.rs
+++ b/src/test/compile-fail/issue-27675-unchecked-bounds.rs
@@ -1,0 +1,19 @@
+/// The compiler previously did not properly check the bound of `From` when it was used from type
+/// of the dyn trait object (use in `copy_any` below). Since the associated type is under user
+/// control in this usage, the compiler could be tricked to believe any type implemented any trait.
+/// This would ICE, except for pure marker traits like `Copy`. It did not require providing an
+/// instance of the dyn trait type, only name said type.
+trait Setup {
+    type From: Copy;
+}
+
+fn copy<U: Setup + ?Sized>(from: &U::From) -> U::From {
+    *from
+}
+
+pub fn copy_any<T>(t: &T) -> T {
+    copy::<dyn Setup<From=T>>(t)
+    //~^ ERROR the trait bound `T: Copy` is not satisfied
+}
+
+fn main() {}

--- a/src/test/ui/feature-gates/feature-gate-negate-unsigned.stderr
+++ b/src/test/ui/feature-gates/feature-gate-negate-unsigned.stderr
@@ -2,7 +2,10 @@ error[E0600]: cannot apply unary operator `-` to type `usize`
   --> $DIR/feature-gate-negate-unsigned.rs:10:23
    |
 LL |     let _max: usize = -1;
-   |                       ^^ cannot apply unary operator `-`
+   |                       ^^
+   |                       |
+   |                       cannot apply unary operator `-`
+   |                       help: you may have meant the maximum value of `usize`: `usize::MAX`
    |
    = note: unsigned values cannot be negated
 

--- a/src/test/ui/unsigned-literal-negation.rs
+++ b/src/test/ui/unsigned-literal-negation.rs
@@ -1,0 +1,5 @@
+fn main() {
+    let x = -1 as usize; //~ ERROR: cannot apply unary operator `-`
+    let x = (-1) as usize; //~ ERROR: cannot apply unary operator `-`
+    let x: u32 = -1; //~ ERROR: cannot apply unary operator `-`
+}

--- a/src/test/ui/unsigned-literal-negation.stderr
+++ b/src/test/ui/unsigned-literal-negation.stderr
@@ -1,0 +1,36 @@
+error[E0600]: cannot apply unary operator `-` to type `usize`
+  --> $DIR/unsigned-literal-negation.rs:2:13
+   |
+LL |     let x = -1 as usize;
+   |             ^^
+   |             |
+   |             cannot apply unary operator `-`
+   |             help: you may have meant the maximum value of `usize`: `usize::MAX`
+   |
+   = note: unsigned values cannot be negated
+
+error[E0600]: cannot apply unary operator `-` to type `usize`
+  --> $DIR/unsigned-literal-negation.rs:3:13
+   |
+LL |     let x = (-1) as usize;
+   |             ^^^^
+   |             |
+   |             cannot apply unary operator `-`
+   |             help: you may have meant the maximum value of `usize`: `usize::MAX`
+   |
+   = note: unsigned values cannot be negated
+
+error[E0600]: cannot apply unary operator `-` to type `u32`
+  --> $DIR/unsigned-literal-negation.rs:4:18
+   |
+LL |     let x: u32 = -1;
+   |                  ^^
+   |                  |
+   |                  cannot apply unary operator `-`
+   |                  help: you may have meant the maximum value of `u32`: `u32::MAX`
+   |
+   = note: unsigned values cannot be negated
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0600`.


### PR DESCRIPTION
Successful merges:

 - #77449 (BTreeMap: comment why drain_filter's size_hint is somewhat pessimistic)
 - #77578 (suggest `MAX` constant if -1 is assigned to unsigned type)
 - #77660 ((docs): make mutex error comment consistent with codebase)
 - #77663 (Add compile fail test for issue 27675)
 - #77673 (Remove unnecessary lamda on emitter map.)
 - #77674 (unix/vxworks: make DirEntry slightly smaller)
 - #77687 (Use shorter path for std::hash::Hash)
 - #77701 (Make `max_log_info` easily greppable (for figuring out why debug logging is disabled))

Failed merges:


r? @ghost