### PR TITLE
Remove unnecessary rustc_const_stable attributes.

### DIFF
--- a/library/std/src/sys/unsupported/mutex.rs
+++ b/library/std/src/sys/unsupported/mutex.rs
@@ -10,7 +10,6 @@ unsafe impl Send for Mutex {}
 unsafe impl Sync for Mutex {} // no threads on this platform
 
 impl Mutex {
-    #[rustc_const_stable(feature = "const_sys_mutex_new", since = "1.0.0")]
     pub const fn new() -> Mutex {
         Mutex { locked: UnsafeCell::new(false) }
     }

--- a/library/std/src/sys_common/mutex.rs
+++ b/library/std/src/sys_common/mutex.rs
@@ -21,7 +21,6 @@ impl StaticMutex {
     /// first used with any of the functions below.
     /// Also, the behavior is undefined if this mutex is ever used reentrantly,
     /// i.e., `lock` is called by the thread currently holding the lock.
-    #[rustc_const_stable(feature = "const_sys_mutex_new", since = "1.0.0")]
     pub const fn new() -> Self {
         Self(imp::Mutex::new())
     }


### PR DESCRIPTION
These attributes were added in https://github.com/rust-lang/rust/pull/74033#discussion_r450593156 because of [std::io::lazy::Lazy::new](https://github.com/rust-lang/rust/blob/0c03aee8b81185d65b5821518661c30ecdb42de5/src/libstd/io/lazy.rs#L21-L23). But [std::io::lazy::Lazy is gone now](https://github.com/rust-lang/rust/pull/77154), so this can be cleaned up.

@rustbot modify labels: +T-libs +C-cleanup