### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/compiler/rustc_driver/src/lib.rs
+++ b/compiler/rustc_driver/src/lib.rs
@@ -155,8 +155,7 @@ pub fn run_compiler(
             ),
         }
     }
-    let diagnostic_output =
-        emitter.map(|emitter| DiagnosticOutput::Raw(emitter)).unwrap_or(DiagnosticOutput::Default);
+    let diagnostic_output = emitter.map(DiagnosticOutput::Raw).unwrap_or(DiagnosticOutput::Default);
     let matches = match handle_options(&args) {
         Some(matches) => matches,
         None => return Ok(()),

--- a/compiler/rustc_driver/src/lib.rs
+++ b/compiler/rustc_driver/src/lib.rs
@@ -155,7 +155,7 @@ pub fn run_compiler(
             ),
         }
     }
-    let diagnostic_output = emitter.map(DiagnosticOutput::Raw).unwrap_or(DiagnosticOutput::Default);
+    let diagnostic_output = emitter.map_or(DiagnosticOutput::Default, DiagnosticOutput::Raw);
     let matches = match handle_options(&args) {
         Some(matches) => matches,
         None => return Ok(()),

--- a/compiler/rustc_interface/src/util.rs
+++ b/compiler/rustc_interface/src/util.rs
@@ -187,7 +187,7 @@ pub fn setup_callbacks_and_run_in_thread_pool_with_globals<F: FnOnce() -> R + Se
         config = config.stack_size(size);
     }
 
-    let with_pool = move |pool: &rayon::ThreadPool| pool.install(move || f());
+    let with_pool = move |pool: &rayon::ThreadPool| pool.install(f);
 
     rustc_span::with_session_globals(edition, || {
         rustc_span::SESSION_GLOBALS.with(|session_globals| {

--- a/config.toml.example
+++ b/config.toml.example
@@ -382,6 +382,10 @@ changelog-seen = 1
 # Overrides the `debug-assertions` option, if defined.
 #
 # Defaults to rust.debug-assertions value
+#
+# If you see a message from `tracing` saying
+# `max_level_info` is enabled and means logging won't be shown,
+# set this value to `true`.
 #debug-logging = debug-assertions
 
 # Debuginfo level for most of Rust code, corresponds to the `-C debuginfo=N` option of `rustc`.

--- a/library/alloc/src/collections/btree/map.rs
+++ b/library/alloc/src/collections/btree/map.rs
@@ -1748,6 +1748,10 @@ impl<'a, K: 'a, V: 'a> DrainFilterInner<'a, K, V> {
 
     /// Implementation of a typical `DrainFilter::size_hint` method.
     pub(super) fn size_hint(&self) -> (usize, Option<usize>) {
+        // In most of the btree iterators, `self.length` is the number of elements
+        // yet to be visited. Here, it includes elements that were visited and that
+        // the predicate decided not to drain. Making this upper bound more accurate
+        // requires maintaining an extra field and is not worth while.
         (0, Some(*self.length))
     }
 }

--- a/library/core/src/fmt/mod.rs
+++ b/library/core/src/fmt/mod.rs
@@ -92,18 +92,14 @@ pub type Result = result::Result<(), Error>;
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Error;
 
-/// A collection of methods that are required to format a message into a stream.
+/// A trait for writing or formatting into Unicode-accepting buffers or streams.
 ///
-/// This trait is the type which this modules requires when formatting
-/// information. This is similar to the standard library's [`io::Write`] trait,
-/// but it is only intended for use in libcore.
+/// This trait only accepts UTF-8–encoded data and is not [flushable]. If you only
+/// want to accept Unicode and you don't need flushing, you should implement this trait;
+/// otherwise you should implement [`std::io::Write`].
 ///
-/// This trait should generally not be implemented by consumers of the standard
-/// library. The [`write!`] macro accepts an instance of [`io::Write`], and the
-/// [`io::Write`] trait is favored over implementing this trait.
-///
-/// [`write!`]: crate::write!
-/// [`io::Write`]: ../../std/io/trait.Write.html
+/// [`std::io::Write`]: ../../std/io/trait.Write.html
+/// [flushable]: ../../std/io/trait.Write.html#tymethod.flush
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait Write {
     /// Writes a string slice into this writer, returning whether the write

--- a/library/std/src/sync/mutex.rs
+++ b/library/std/src/sync/mutex.rs
@@ -276,7 +276,7 @@ impl<T: ?Sized> Mutex<T> {
     /// # Errors
     ///
     /// If another user of this mutex panicked while holding the mutex, then
-    /// this call will return failure if the mutex would otherwise be
+    /// this call will return an error if the mutex would otherwise be
     /// acquired.
     ///
     /// # Examples

--- a/src/test/compile-fail/issue-27675-unchecked-bounds.rs
+++ b/src/test/compile-fail/issue-27675-unchecked-bounds.rs
@@ -1,0 +1,19 @@
+/// The compiler previously did not properly check the bound of `From` when it was used from type
+/// of the dyn trait object (use in `copy_any` below). Since the associated type is under user
+/// control in this usage, the compiler could be tricked to believe any type implemented any trait.
+/// This would ICE, except for pure marker traits like `Copy`. It did not require providing an
+/// instance of the dyn trait type, only name said type.
+trait Setup {
+    type From: Copy;
+}
+
+fn copy<U: Setup + ?Sized>(from: &U::From) -> U::From {
+    *from
+}
+
+pub fn copy_any<T>(t: &T) -> T {
+    copy::<dyn Setup<From=T>>(t)
+    //~^ ERROR the trait bound `T: Copy` is not satisfied
+}
+
+fn main() {}


### PR DESCRIPTION
Successful merges:

 - #76750 (Don't discourage implementing `core::fmt::Write`)
 - #77449 (BTreeMap: comment why drain_filter's size_hint is somewhat pessimistic)
 - #77660 ((docs): make mutex error comment consistent with codebase)
 - #77663 (Add compile fail test for issue 27675)
 - #77673 (Remove unnecessary lamda on emitter map.)
 - #77701 (Make `max_log_info` easily greppable (for figuring out why debug logging is disabled))
 - #77702 (Remove not needed lambda.)
 - #77710 (Update submodule llvm to get LVI bugfix)

Failed merges:


r? @ghost