### PR TITLE
Add Pin::static_ref, static_mut.

### DIFF
--- a/library/core/src/pin.rs
+++ b/library/core/src/pin.rs
@@ -795,6 +795,20 @@ impl<T: ?Sized> Pin<&'static T> {
     }
 }
 
+impl<T: ?Sized> Pin<&'static T> {
+    /// Get a pinned mutable reference from a static mutable reference.
+    ///
+    /// This is safe, because the `'static` lifetime guarantees the data will
+    /// never be moved.
+    #[unstable(feature = "pin_static_ref", issue = "none")]
+    #[rustc_const_unstable(feature = "const_pin", issue = "76654")]
+    pub const fn static_mut(r: &'static mut T) -> Pin<&'static mut T> {
+        // SAFETY: The 'static lifetime guarantees the data will not be
+        // moved/invalidated until it gets dropped (which is never).
+        unsafe { Pin::new_unchecked(r) }
+    }
+}
+
 #[stable(feature = "pin", since = "1.33.0")]
 impl<P: Deref> Deref for Pin<P> {
     type Target = P::Target;

--- a/library/core/src/pin.rs
+++ b/library/core/src/pin.rs
@@ -784,12 +784,12 @@ impl<'a, T: ?Sized> Pin<&'a mut T> {
 impl<T: ?Sized> Pin<&'static T> {
     /// Get a pinned reference from a static reference.
     ///
-    /// This is safe, because the `'static` lifetime guarantees the data will
-    /// never be moved.
+    /// This is safe, because `T` is borrowed for the `'static` lifetime, which
+    /// never ends.
     #[unstable(feature = "pin_static_ref", issue = "none")]
     #[rustc_const_unstable(feature = "const_pin", issue = "76654")]
     pub const fn static_ref(r: &'static T) -> Pin<&'static T> {
-        // SAFETY: The 'static lifetime guarantees the data will not be
+        // SAFETY: The 'static borrow guarantees the data will not be
         // moved/invalidated until it gets dropped (which is never).
         unsafe { Pin::new_unchecked(r) }
     }
@@ -798,12 +798,12 @@ impl<T: ?Sized> Pin<&'static T> {
 impl<T: ?Sized> Pin<&'static T> {
     /// Get a pinned mutable reference from a static mutable reference.
     ///
-    /// This is safe, because the `'static` lifetime guarantees the data will
-    /// never be moved.
+    /// This is safe, because `T` is borrowed for the `'static` lifetime, which
+    /// never ends.
     #[unstable(feature = "pin_static_ref", issue = "none")]
     #[rustc_const_unstable(feature = "const_pin", issue = "76654")]
     pub const fn static_mut(r: &'static mut T) -> Pin<&'static mut T> {
-        // SAFETY: The 'static lifetime guarantees the data will not be
+        // SAFETY: The 'static borrow guarantees the data will not be
         // moved/invalidated until it gets dropped (which is never).
         unsafe { Pin::new_unchecked(r) }
     }

--- a/library/core/src/pin.rs
+++ b/library/core/src/pin.rs
@@ -781,6 +781,19 @@ impl<'a, T: ?Sized> Pin<&'a mut T> {
     }
 }
 
+impl<T: ?Sized> Pin<&'static T> {
+    /// Get a pinned reference from a static reference.
+    ///
+    /// This is safe, because the `'static` lifetime guarantees the data will
+    /// never be moved.
+    #[unstable(feature = "pin_static_ref", issue = "none")]
+    pub fn new_static(r: &'static T) -> Pin<&'static T> {
+        // SAFETY: The 'static lifetime guarantees the data will not be
+        // moved/invalidated until it gets dropped (which is never).
+        unsafe { Pin::new_unchecked(r) }
+    }
+}
+
 #[stable(feature = "pin", since = "1.33.0")]
 impl<P: Deref> Deref for Pin<P> {
     type Target = P::Target;

--- a/library/core/src/pin.rs
+++ b/library/core/src/pin.rs
@@ -788,7 +788,7 @@ impl<T: ?Sized> Pin<&'static T> {
     /// never be moved.
     #[unstable(feature = "pin_static_ref", issue = "none")]
     #[rustc_const_unstable(feature = "const_pin", issue = "76654")]
-    pub const fn new_static(r: &'static T) -> Pin<&'static T> {
+    pub const fn static_ref(r: &'static T) -> Pin<&'static T> {
         // SAFETY: The 'static lifetime guarantees the data will not be
         // moved/invalidated until it gets dropped (which is never).
         unsafe { Pin::new_unchecked(r) }

--- a/library/core/src/pin.rs
+++ b/library/core/src/pin.rs
@@ -787,7 +787,8 @@ impl<T: ?Sized> Pin<&'static T> {
     /// This is safe, because the `'static` lifetime guarantees the data will
     /// never be moved.
     #[unstable(feature = "pin_static_ref", issue = "none")]
-    pub fn new_static(r: &'static T) -> Pin<&'static T> {
+    #[rustc_const_unstable(feature = "const_pin", issue = "76654")]
+    pub const fn new_static(r: &'static T) -> Pin<&'static T> {
         // SAFETY: The 'static lifetime guarantees the data will not be
         // moved/invalidated until it gets dropped (which is never).
         unsafe { Pin::new_unchecked(r) }

--- a/library/core/src/pin.rs
+++ b/library/core/src/pin.rs
@@ -795,7 +795,7 @@ impl<T: ?Sized> Pin<&'static T> {
     }
 }
 
-impl<T: ?Sized> Pin<&'static T> {
+impl<T: ?Sized> Pin<&'static mut T> {
     /// Get a pinned mutable reference from a static mutable reference.
     ///
     /// This is safe, because `T` is borrowed for the `'static` lifetime, which


### PR DESCRIPTION
This adds `Pin::static_ref` and `Pin::static_mut`, which convert a static reference to a pinned static reference.

Static references are effectively already pinned, as what they refer to has to live forever and can never be moved.

---

Context: I want to update the `sys` and `sys_common` mutexes/rwlocks/condvars to use `Pin<&self>` in their functions, instead of only warning in the unsafety comments that they may not be moved. That should make them a little bit less dangerous to use. Putting such an object in a `static` (e.g. through `sys_common::StaticMutex`) fulfills the requirements about never moving it, but right now there's no safe way to get a `Pin<&T>` to a `static`. This solves that.