### PR TITLE
Avoid SeqCst or static mut in mach_timebase_info and QueryPerformanceFrequency caches

### DIFF
--- a/library/std/src/sys/unix/time.rs
+++ b/library/std/src/sys/unix/time.rs
@@ -235,11 +235,11 @@ mod inner {
         static INITIALIZED: AtomicBool = AtomicBool::new(false);
         static INFO_BITS: AtomicU64 = AtomicU64::new(0);
 
-        // If a previous thread has filled in this global INITIALIZED, use that.
+        // If a previous thread has initialized `INFO_BITS`, use that.
         if INITIALIZED.load(Ordering::Acquire) {
-            // The Acquire/Release pair used for INITIALIZED ensures that this
-            // load can see the corresponding `INFO_BITS` store, despite them
-            // both being Relaxed.
+            // Note: `Relaxed` is correct here and below -- the `Acquire` /
+            // `Release` pair used for `INITIALIZED` ensures this load can see
+            // the corresponding store below.
             return info_from_bits(INFO_BITS.load(Ordering::Relaxed));
         }
 
@@ -253,7 +253,7 @@ mod inner {
             mach_timebase_info(&mut info);
         }
 
-        // Note: This is racy, but the race is against other threads trying to
+        // This is racy, but the race should be against other threads trying to
         // write the same value.
         INFO_BITS.store(info_to_bits(info), Ordering::Relaxed);
 

--- a/library/std/src/sys/windows/time.rs
+++ b/library/std/src/sys/windows/time.rs
@@ -165,7 +165,7 @@ fn intervals2dur(intervals: u64) -> Duration {
 
 mod perf_counter {
     use super::NANOS_PER_SEC;
-    use crate::sync::atomic::{AtomicUsize, Ordering::SeqCst};
+    use crate::sync::atomic::{AtomicU64, Ordering};
     use crate::sys::c;
     use crate::sys::cvt;
     use crate::sys_common::mul_div_u64;
@@ -197,27 +197,25 @@ mod perf_counter {
     }
 
     fn frequency() -> c::LARGE_INTEGER {
-        static mut FREQUENCY: c::LARGE_INTEGER = 0;
-        static STATE: AtomicUsize = AtomicUsize::new(0);
+        // Either the cached result of `QueryPerformanceFrequency` or `0` for
+        // uninitialized. Storing this as a single `AtomicU64` allows us to use
+        // `Relaxed` operations, as we are only interested in the effects on a
+        // single memory location.
+        static FREQUENCY: AtomicU64 = AtomicU64::new(0);
 
-        unsafe {
-            // If a previous thread has filled in this global state, use that.
-            if STATE.load(SeqCst) == 2 {
-                return FREQUENCY;
-            }
-
-            // ... otherwise learn for ourselves ...
-            let mut frequency = 0;
-            cvt(c::QueryPerformanceFrequency(&mut frequency)).unwrap();
-
-            // ... and attempt to be the one thread that stores it globally for
-            // all other threads
-            if STATE.compare_exchange(0, 1, SeqCst, SeqCst).is_ok() {
-                FREQUENCY = frequency;
-                STATE.store(2, SeqCst);
-            }
-            frequency
+        let cached = FREQUENCY.load(Ordering::Relaxed);
+        // If a previous thread has filled in this global state, use that.
+        if cached != 0 {
+            return cached as c::LARGE_INTEGER;
         }
+        // ... otherwise learn for ourselves ...
+        let mut frequency = 0;
+        unsafe {
+            cvt(c::QueryPerformanceFrequency(&mut frequency)).unwrap();
+        }
+
+        FREQUENCY.store(frequency as u64, Ordering::Relaxed);
+        frequency
     }
 
     fn query() -> c::LARGE_INTEGER {


### PR DESCRIPTION
This patch went through a couple iterations but the end result is replacing a pattern where an `AtomicUsize` (updated with many SeqCst ops) guards a `static mut` with a single `AtomicU64` that is known to use 0 as a value indicating that it is not initialized.

The code in both places exists to cache values used in the conversion of Instants to Durations on macOS, iOS, and Windows.

I have no numbers to prove that this improves performance (It seems a little futile to benchmark something like this), but it's much simpler, safer, and in practice we'd expect it to be faster everywhere where Relaxed operations on AtomicU64 are cheaper than SeqCst operations on AtomicUsize, which is a lot of places.

Anyway, it also removes a bunch of unsafe code and greatly simplifies the logic, so IMO that alone would be worth it unless it was a regression.

If you want to take a look at the assembly output though, see https://godbolt.org/z/rbr6vn for x86_64, https://godbolt.org/z/cqcbqv for aarch64 (Note that this just the output of the mac side, but i'd expect the windows part to be the same and don't feel like doing another godbolt for it). There are several versions of this function in the godbolt:

- `info_new`: version in the current patch
- `info_less_new`: version in initial PR
- `info_original`: version currently in the tree
- `info_orig_but_better_orderings`: a version that just tries to change the original code's orderings from SeqCst to the (probably) minimal orderings required for soundness/correctness.

The biggest concern I have here is if we can use AtomicU64, or if there are targets that dont have it that this code supports. AFAICT: no. (If that changes in the future, it's easy enough to do something different for them)

r? @Amanieu because he caught a couple issues last time I tried to do a patch reducing orderings 😅

---

<details>
<summary>I rewrote this whole message so the original is inside here</summary>

I happened to notice the code we use for caching the result of mach_timebase_info uses SeqCst exclusively.

However, thinking a little more, it's actually pretty easy to avoid the static mut by packing the timebase info into an AtomicU64.

This entirely avoids needing to do the compare_exchange. The AtomicU64 can be read/written using Relaxed ops, which on current macos/ios platforms (x86_64/aarch64) have no overhead compared to direct loads/stores. This simplifies the code and makes it a lot safer too.

I have no numbers to prove that this improves performance (It seems a little futile to benchmark something like this), although it should do that on both targets it applies to.

That said, it also removes a bunch of unsafe code and simplifies the logic (arguably at least — there are only two states now, initialized or not), so I think it's a net win even without concrete numbers.

If you want to take a look at the assembly output though, see below. It has the new version, the original, and a version of the original with lower Orderings (which is still worse than the version in this PR)

- godbolt.org/z/obfqf9 x86_64-apple-darwin

- godbolt.org/z/Wz5cWc aarch64-unknown-linux-gnu (godbolt can't do aarch64-apple-ios but that doesn't matter here)

A different (and more efficient) option than this would be to just use the AtomicU64 and use the knowledge that after initialization the denominator should be nonzero... That felt like it's relying on too many things I'm not confident in, so I didn't want to do that.
</details>