### PR TITLE
Fix `x.py setup` sets `changelog-seen`

### DIFF
--- a/src/bootstrap/bin/main.rs
+++ b/src/bootstrap/bin/main.rs
@@ -7,13 +7,15 @@
 
 use std::env;
 
-use bootstrap::{Build, Config, Subcommand};
+use bootstrap::{Build, Config, Subcommand, VERSION};
 
 fn main() {
     let args = env::args().skip(1).collect::<Vec<_>>();
     let config = Config::parse(&args);
 
-    let changelog_suggestion = check_version(&config);
+    // check_version warnings are not printed during setup
+    let changelog_suggestion =
+        if matches!(config.cmd, Subcommand::Setup {..}) { None } else { check_version(&config) };
 
     // NOTE: Since `./configure` generates a `config.toml`, distro maintainers will see the
     // changelog warning, not the `x.py setup` message.
@@ -40,8 +42,6 @@ fn main() {
 }
 
 fn check_version(config: &Config) -> Option<String> {
-    const VERSION: usize = 2;
-
     let mut msg = String::new();
 
     let suggestion = if let Some(seen) = config.changelog_seen {

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -179,6 +179,8 @@ const LLVM_TOOLS: &[&str] = &[
     "llvm-ar", // used for creating and modifying archive files
 ];
 
+pub const VERSION: usize = 2;
+
 /// A structure representing a Rust compiler.
 ///
 /// Each compiler has a `stage` that it is associated with and a `host` that

--- a/src/bootstrap/setup.rs
+++ b/src/bootstrap/setup.rs
@@ -1,4 +1,4 @@
-use crate::t;
+use crate::{t, VERSION};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::{
@@ -69,8 +69,9 @@ pub fn setup(src_path: &Path, profile: Profile) {
     let path = cfg_file.unwrap_or_else(|| src_path.join("config.toml"));
     let settings = format!(
         "# Includes one of the default files in src/bootstrap/defaults\n\
-    profile = \"{}\"\n",
-        profile
+    profile = \"{}\"\n\
+    changelog-seen = {}\n",
+        profile, VERSION
     );
     t!(fs::write(path, settings));
 


### PR DESCRIPTION
Fixes #77572 by setting changelog-seen in setup.rs