### PR TITLE
Remove special case for x86_64-*-windows-gnu in panic_abort

### DIFF
--- a/library/panic_abort/src/lib.rs
+++ b/library/panic_abort/src/lib.rs
@@ -108,24 +108,8 @@ pub unsafe extern "C" fn __rust_start_panic(_payload: usize) -> u32 {
 // runtime at all.
 pub mod personalities {
     #[rustc_std_internal_symbol]
-    #[cfg(not(any(
-        all(target_arch = "wasm32", not(target_os = "emscripten"),),
-        all(target_os = "windows", target_env = "gnu", target_arch = "x86_64",),
-    )))]
+    #[cfg(not(all(target_arch = "wasm32", not(target_os = "emscripten"))))]
     pub extern "C" fn rust_eh_personality() {}
-
-    // On x86_64-pc-windows-gnu we use our own personality function that needs
-    // to return `ExceptionContinueSearch` as we're passing on all our frames.
-    #[rustc_std_internal_symbol]
-    #[cfg(all(target_os = "windows", target_env = "gnu", target_arch = "x86_64"))]
-    pub extern "C" fn rust_eh_personality(
-        _record: usize,
-        _frame: usize,
-        _context: usize,
-        _dispatcher: usize,
-    ) -> u32 {
-        1 // `ExceptionContinueSearch`
-    }
 
     // Similar to above, this corresponds to the `eh_catch_typeinfo` lang item
     // that's only used on Emscripten currently.


### PR DESCRIPTION
I don't see why we need this special case and the tests pass without it.