### PR TITLE
require `Reveal::All` in `normalize_erasing_regions`

### DIFF
--- a/compiler/rustc_middle/src/ty/normalize_erasing_regions.rs
+++ b/compiler/rustc_middle/src/ty/normalize_erasing_regions.rs
@@ -27,6 +27,7 @@ impl<'tcx> TyCtxt<'tcx> {
             value,
             param_env,
         );
+        debug_assert_eq!(param_env.reveal(), ty::Reveal::All);
 
         // Erase first before we do the real query -- this keeps the
         // cache from being too polluted.


### PR DESCRIPTION
would have caught a bug in mir inlining, see https://github.com/rust-lang/rust/pull/77568#discussion_r500325317
