### PR TITLE
Auto-prioritize issues with `regression-untriaged`

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -75,6 +75,7 @@ label = "I-prioritize"
 
 [autolabel."I-prioritize"]
 trigger_labels = [
+    "regression-untriaged",
     "regression-from-stable-to-stable",
     "regression-from-stable-to-beta",
     "regression-from-stable-to-nightly",


### PR DESCRIPTION
This auto-prioritizes issues with the `regression-untriaged` label. (I just added it per <https://github.com/rust-lang/rust/pull/77725#discussion_r502135703>.)

Cc #77725

r? @Mark-Simulacrum
