### PR TITLE
rustc_parse: More precise spans for `tuple.0.0`

### DIFF
--- a/src/test/ui/parser/float-field.stderr
+++ b/src/test/ui/parser/float-field.stderr
@@ -271,10 +271,10 @@ LL |     s.1e1;
    = note: available fields are: `0`, `1`
 
 error[E0609]: no field `1e1` on type `(u8, u8)`
-  --> $DIR/float-field.rs:9:7
+  --> $DIR/float-field.rs:9:9
    |
 LL |     s.1.1e1;
-   |       ^^^^^
+   |         ^^^
 
 error[E0609]: no field `0x1e1` on type `S`
   --> $DIR/float-field.rs:24:7
@@ -288,7 +288,7 @@ error[E0609]: no field `0x1` on type `S`
   --> $DIR/float-field.rs:25:7
    |
 LL |     s.0x1.;
-   |       ^^^^ unknown field
+   |       ^^^ unknown field
    |
    = note: available fields are: `0`, `1`
 
@@ -296,7 +296,7 @@ error[E0609]: no field `0x1` on type `S`
   --> $DIR/float-field.rs:28:7
    |
 LL |     s.0x1.1;
-   |       ^^^^^ unknown field
+   |       ^^^ unknown field
    |
    = note: available fields are: `0`, `1`
 
@@ -304,7 +304,7 @@ error[E0609]: no field `0x1` on type `S`
   --> $DIR/float-field.rs:30:7
    |
 LL |     s.0x1.1e1;
-   |       ^^^^^^^ unknown field
+   |       ^^^ unknown field
    |
    = note: available fields are: `0`, `1`
 

--- a/src/test/ui/tuple/index-invalid.stderr
+++ b/src/test/ui/tuple/index-invalid.stderr
@@ -2,19 +2,19 @@ error[E0609]: no field `1` on type `(((),),)`
   --> $DIR/index-invalid.rs:2:22
    |
 LL |     let _ = (((),),).1.0;
-   |                      ^^^
+   |                      ^
 
 error[E0609]: no field `1` on type `((),)`
-  --> $DIR/index-invalid.rs:4:22
+  --> $DIR/index-invalid.rs:4:24
    |
 LL |     let _ = (((),),).0.1;
-   |                      ^^^
+   |                        ^
 
 error[E0609]: no field `000` on type `(((),),)`
   --> $DIR/index-invalid.rs:6:22
    |
 LL |     let _ = (((),),).000.000;
-   |                      ^^^^^^^
+   |                      ^^^
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/union/union-deref.stderr
+++ b/src/test/ui/union/union-deref.stderr
@@ -29,7 +29,7 @@ error: not automatically applying `DerefMut` on `ManuallyDrop` union field
   --> $DIR/union-deref.rs:23:14
    |
 LL |     unsafe { u.f.0.0 = Vec::new() };
-   |              ^^^^^^^
+   |              ^^^^^
    |
    = help: writing to this reference calls the destructor for the old value
    = help: add an explicit `*` if that is desired, or call `ptr::write` to not run the destructor
@@ -38,7 +38,7 @@ error: not automatically applying `DerefMut` on `ManuallyDrop` union field
   --> $DIR/union-deref.rs:25:19
    |
 LL |     unsafe { &mut u.f.0.0 };
-   |                   ^^^^^^^
+   |                   ^^^^^
    |
    = help: writing to this reference calls the destructor for the old value
    = help: add an explicit `*` if that is desired, or call `ptr::write` to not run the destructor
@@ -47,7 +47,7 @@ error: not automatically applying `DerefMut` on `ManuallyDrop` union field
   --> $DIR/union-deref.rs:27:14
    |
 LL |     unsafe { u.f.0.0.push(0) };
-   |              ^^^^^^^
+   |              ^^^^^
    |
    = help: writing to this reference calls the destructor for the old value
    = help: add an explicit `*` if that is desired, or call `ptr::write` to not run the destructor


### PR DESCRIPTION
This should help with https://github.com/rust-lang/rustfmt/issues/4355, but I haven't verified, cc @calebcartwright.