### PR TITLE
doc: disambiguate stat in MetadataExt::as_raw_stat

### DIFF
--- a/library/std/src/os/linux/fs.rs
+++ b/library/std/src/os/linux/fs.rs
@@ -20,7 +20,7 @@ pub trait MetadataExt {
     /// Unix platforms. The `os::unix::fs::MetadataExt` trait contains the
     /// cross-Unix abstractions contained within the raw stat.
     ///
-    /// [`stat`]: crate::os::linux::raw::stat
+    /// [`stat`]: struct@crate::os::linux::raw::stat
     ///
     /// # Examples
     ///


### PR DESCRIPTION
A few architectures in `os::linux::raw` import `libc::stat`, rather than
defining that type directly. However, that also imports the _function_
called `stat`, which makes this doc link ambiguous:

    error: `crate::os::linux::raw::stat` is both a struct and a function
      --> library/std/src/os/linux/fs.rs:21:19
       |
    21 |     /// [`stat`]: crate::os::linux::raw::stat
       |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^ ambiguous link
       |
       = note: `-D broken-intra-doc-links` implied by `-D warnings`
    help: to link to the struct, prefix with the item type
       |
    21 |     /// [`stat`]: struct@crate::os::linux::raw::stat
       |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    help: to link to the function, add parentheses
       |
    21 |     /// [`stat`]: crate::os::linux::raw::stat()
       |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

We want the `struct`, so it's now prefixed accordingly.