### PR TITLE
Use separate sysroot directories for `check` and `build`

### DIFF
--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -689,11 +689,14 @@ impl Step for Sysroot {
     /// 1-3.
     fn run(self, builder: &Builder<'_>) -> Interned<PathBuf> {
         let compiler = self.compiler;
-        let sysroot = if compiler.stage == 0 {
-            builder.out.join(&compiler.host.triple).join("stage0-sysroot")
+        let sysroot = if builder.kind == Kind::Check {
+            "check-sysroot".to_owned()
+        } else if compiler.stage == 0 {
+            "stage0-sysroot".to_owned()
         } else {
-            builder.out.join(&compiler.host.triple).join(format!("stage{}", compiler.stage))
+            format!("stage{}", compiler.stage)
         };
+        let sysroot = builder.out.join(&compiler.host.triple).join(sysroot);
         let _ = fs::remove_dir_all(&sysroot);
         t!(fs::create_dir_all(&sysroot));
 


### PR DESCRIPTION
This allows running both in parallel, I think. I don't know how to test this; I tried running `x.py check` and `x.py build` at the same time but it seems to be non-deterministic whether that causes an error.

Hopefully fixes https://github.com/rust-lang/rust/issues/76661.

r? @Mark-Simulacrum 