### PR TITLE
Feature request, move part of std::io into core::io to be used by rust-libc such as relibc

### DIFF
--- a/library/std/src/io/buffered.rs
+++ b/library/std/src/io/buffered.rs
@@ -1,17 +1,13 @@
+
 //! Buffering wrappers for I/O traits
 
-#[cfg(test)]
-mod tests;
+use core::prelude::v1::*;
+use io::prelude::*;
 
-use crate::io::prelude::*;
-
-use crate::cmp;
-use crate::error;
-use crate::fmt;
-use crate::io::{
-    self, Error, ErrorKind, Initializer, IoSlice, IoSliceMut, SeekFrom, DEFAULT_BUF_SIZE,
-};
-use crate::memchr;
+use core::cmp;
+use core::fmt;
+use io::{self, Initializer, DEFAULT_BUF_SIZE, Error, ErrorKind, SeekFrom, IoSlice, IoSliceMut};
+use io::memchr;
 
 /// The `BufReader<R>` struct adds buffering to any reader.
 ///
@@ -52,7 +48,6 @@ use crate::memchr;
 ///     Ok(())
 /// }
 /// ```
-#[stable(feature = "rust1", since = "1.0.0")]
 pub struct BufReader<R> {
     inner: R,
     buf: Box<[u8]>,
@@ -76,7 +71,6 @@ impl<R: Read> BufReader<R> {
     ///     Ok(())
     /// }
     /// ```
-    #[stable(feature = "rust1", since = "1.0.0")]
     pub fn new(inner: R) -> BufReader<R> {
         BufReader::with_capacity(DEFAULT_BUF_SIZE, inner)
     }
@@ -97,7 +91,6 @@ impl<R: Read> BufReader<R> {
     ///     Ok(())
     /// }
     /// ```
-    #[stable(feature = "rust1", since = "1.0.0")]
     pub fn with_capacity(capacity: usize, inner: R) -> BufReader<R> {
         unsafe {
             let mut buffer = Vec::with_capacity(capacity);
@@ -127,7 +120,6 @@ impl<R> BufReader<R> {
     ///     Ok(())
     /// }
     /// ```
-    #[stable(feature = "rust1", since = "1.0.0")]
     pub fn get_ref(&self) -> &R {
         &self.inner
     }
@@ -150,7 +142,6 @@ impl<R> BufReader<R> {
     ///     Ok(())
     /// }
     /// ```
-    #[stable(feature = "rust1", since = "1.0.0")]
     pub fn get_mut(&mut self) -> &mut R {
         &mut self.inner
     }
@@ -178,7 +169,6 @@ impl<R> BufReader<R> {
     ///     Ok(())
     /// }
     /// ```
-    #[stable(feature = "bufreader_buffer", since = "1.37.0")]
     pub fn buffer(&self) -> &[u8] {
         &self.buf[self.pos..self.cap]
     }
@@ -201,7 +191,6 @@ impl<R> BufReader<R> {
     ///     Ok(())
     /// }
     /// ```
-    #[stable(feature = "buffered_io_capacity", since = "1.46.0")]
     pub fn capacity(&self) -> usize {
         self.buf.len()
     }
@@ -225,7 +214,6 @@ impl<R> BufReader<R> {
     ///     Ok(())
     /// }
     /// ```
-    #[stable(feature = "rust1", since = "1.0.0")]
     pub fn into_inner(self) -> R {
         self.inner
     }
@@ -243,7 +231,6 @@ impl<R: Seek> BufReader<R> {
     /// the buffer will not be flushed, allowing for more efficient seeks.
     /// This method does not return the location of the underlying reader, so the caller
     /// must track this information themselves if it is required.
-    #[unstable(feature = "bufreader_seek_relative", issue = "31100")]
     pub fn seek_relative(&mut self, offset: i64) -> io::Result<()> {
         let pos = self.pos as u64;
         if offset < 0 {
@@ -263,7 +250,6 @@ impl<R: Seek> BufReader<R> {
     }
 }
 
-#[stable(feature = "rust1", since = "1.0.0")]
 impl<R: Read> Read for BufReader<R> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         // If we don't have any buffered data and we're doing a massive read
@@ -305,7 +291,6 @@ impl<R: Read> Read for BufReader<R> {
     }
 }
 
-#[stable(feature = "rust1", since = "1.0.0")]
 impl<R: Read> BufRead for BufReader<R> {
     fn fill_buf(&mut self) -> io::Result<&[u8]> {
         // If we've reached the end of our internal buffer then we need to fetch
@@ -325,7 +310,6 @@ impl<R: Read> BufRead for BufReader<R> {
     }
 }
 
-#[stable(feature = "rust1", since = "1.0.0")]
 impl<R> fmt::Debug for BufReader<R>
 where
     R: fmt::Debug,
@@ -338,7 +322,6 @@ where
     }
 }
 
-#[stable(feature = "rust1", since = "1.0.0")]
 impl<R: Seek> Seek for BufReader<R> {
     /// Seek to an offset, in bytes, in the underlying reader.
     ///
@@ -492,10 +475,9 @@ impl<R: Seek> Seek for BufReader<R> {
 /// [`TcpStream::write`]: Write::write
 /// [`TcpStream`]: crate::net::TcpStream
 /// [`flush`]: Write::flush
-#[stable(feature = "rust1", since = "1.0.0")]
 pub struct BufWriter<W: Write> {
     inner: Option<W>,
-    buf: Vec<u8>,
+    pub buf: Vec<u8>,
     // #30888: If the inner writer panics in a call to write, we don't want to
     // write the buffered data a second time in BufWriter's destructor. This
     // flag tells the Drop impl if it should skip the flush.
@@ -527,7 +509,6 @@ pub struct BufWriter<W: Write> {
 /// };
 /// ```
 #[derive(Debug)]
-#[stable(feature = "rust1", since = "1.0.0")]
 pub struct IntoInnerError<W>(W, Error);
 
 impl<W: Write> BufWriter<W> {
@@ -542,7 +523,6 @@ impl<W: Write> BufWriter<W> {
     ///
     /// let mut buffer = BufWriter::new(TcpStream::connect("127.0.0.1:34254").unwrap());
     /// ```
-    #[stable(feature = "rust1", since = "1.0.0")]
     pub fn new(inner: W) -> BufWriter<W> {
         BufWriter::with_capacity(DEFAULT_BUF_SIZE, inner)
     }
@@ -560,7 +540,6 @@ impl<W: Write> BufWriter<W> {
     /// let stream = TcpStream::connect("127.0.0.1:34254").unwrap();
     /// let mut buffer = BufWriter::with_capacity(100, stream);
     /// ```
-    #[stable(feature = "rust1", since = "1.0.0")]
     pub fn with_capacity(capacity: usize, inner: W) -> BufWriter<W> {
         BufWriter { inner: Some(inner), buf: Vec::with_capacity(capacity), panicked: false }
     }
@@ -632,6 +611,10 @@ impl<W: Write> BufWriter<W> {
         Ok(())
     }
 
+    pub fn purge_buf(&mut self) {
+        self.buf = vec![];
+    }
+
     /// Buffer some data without flushing it, regardless of the size of the
     /// data. Writes as much as possible without exceeding capacity. Returns
     /// the number of bytes written.
@@ -655,7 +638,6 @@ impl<W: Write> BufWriter<W> {
     /// // we can use reference just like buffer
     /// let reference = buffer.get_ref();
     /// ```
-    #[stable(feature = "rust1", since = "1.0.0")]
     pub fn get_ref(&self) -> &W {
         self.inner.as_ref().unwrap()
     }
@@ -675,7 +657,6 @@ impl<W: Write> BufWriter<W> {
     /// // we can use reference just like buffer
     /// let reference = buffer.get_mut();
     /// ```
-    #[stable(feature = "rust1", since = "1.0.0")]
     pub fn get_mut(&mut self) -> &mut W {
         self.inner.as_mut().unwrap()
     }
@@ -693,7 +674,6 @@ impl<W: Write> BufWriter<W> {
     /// // See how many bytes are currently buffered
     /// let bytes_buffered = buf_writer.buffer().len();
     /// ```
-    #[stable(feature = "bufreader_buffer", since = "1.37.0")]
     pub fn buffer(&self) -> &[u8] {
         &self.buf
     }
@@ -713,7 +693,6 @@ impl<W: Write> BufWriter<W> {
     /// // Calculate how many bytes can be written without flushing
     /// let without_flush = capacity - buf_writer.buffer().len();
     /// ```
-    #[stable(feature = "buffered_io_capacity", since = "1.46.0")]
     pub fn capacity(&self) -> usize {
         self.buf.capacity()
     }
@@ -737,7 +716,6 @@ impl<W: Write> BufWriter<W> {
     /// // unwrap the TcpStream and flush the buffer
     /// let stream = buffer.into_inner().unwrap();
     /// ```
-    #[stable(feature = "rust1", since = "1.0.0")]
     pub fn into_inner(mut self) -> Result<W, IntoInnerError<BufWriter<W>>> {
         match self.flush_buf() {
             Err(e) => Err(IntoInnerError(self, e)),
@@ -746,7 +724,6 @@ impl<W: Write> BufWriter<W> {
     }
 }
 
-#[stable(feature = "rust1", since = "1.0.0")]
 impl<W: Write> Write for BufWriter<W> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         if self.buf.len() + buf.len() > self.buf.capacity() {
@@ -810,7 +787,6 @@ impl<W: Write> Write for BufWriter<W> {
     }
 }
 
-#[stable(feature = "rust1", since = "1.0.0")]
 impl<W: Write> fmt::Debug for BufWriter<W>
 where
     W: fmt::Debug,
@@ -823,7 +799,6 @@ where
     }
 }
 
-#[stable(feature = "rust1", since = "1.0.0")]
 impl<W: Write + Seek> Seek for BufWriter<W> {
     /// Seek to the offset, in bytes, in the underlying writer.
     ///
@@ -834,7 +809,6 @@ impl<W: Write + Seek> Seek for BufWriter<W> {
     }
 }
 
-#[stable(feature = "rust1", since = "1.0.0")]
 impl<W: Write> Drop for BufWriter<W> {
     fn drop(&mut self) {
         if self.inner.is_some() && !self.panicked {
@@ -874,7 +848,6 @@ impl<W> IntoInnerError<W> {
     ///     }
     /// };
     /// ```
-    #[stable(feature = "rust1", since = "1.0.0")]
     pub fn error(&self) -> &Error {
         &self.1
     }
@@ -909,28 +882,17 @@ impl<W> IntoInnerError<W> {
     ///     }
     /// };
     /// ```
-    #[stable(feature = "rust1", since = "1.0.0")]
     pub fn into_inner(self) -> W {
         self.0
     }
 }
 
-#[stable(feature = "rust1", since = "1.0.0")]
 impl<W> From<IntoInnerError<W>> for Error {
     fn from(iie: IntoInnerError<W>) -> Error {
         iie.1
     }
 }
 
-#[stable(feature = "rust1", since = "1.0.0")]
-impl<W: Send + fmt::Debug> error::Error for IntoInnerError<W> {
-    #[allow(deprecated, deprecated_in_future)]
-    fn description(&self) -> &str {
-        error::Error::description(self.error())
-    }
-}
-
-#[stable(feature = "rust1", since = "1.0.0")]
 impl<W> fmt::Display for IntoInnerError<W> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.error().fmt(f)
@@ -1267,9 +1229,8 @@ impl<'a, W: Write> Write for LineWriterShim<'a, W> {
 ///     Ok(())
 /// }
 /// ```
-#[stable(feature = "rust1", since = "1.0.0")]
 pub struct LineWriter<W: Write> {
-    inner: BufWriter<W>,
+    pub inner: BufWriter<W>,
 }
 
 impl<W: Write> LineWriter<W> {
@@ -1287,7 +1248,6 @@ impl<W: Write> LineWriter<W> {
     ///     Ok(())
     /// }
     /// ```
-    #[stable(feature = "rust1", since = "1.0.0")]
     pub fn new(inner: W) -> LineWriter<W> {
         // Lines typically aren't that long, don't use a giant buffer
         LineWriter::with_capacity(1024, inner)
@@ -1308,7 +1268,6 @@ impl<W: Write> LineWriter<W> {
     ///     Ok(())
     /// }
     /// ```
-    #[stable(feature = "rust1", since = "1.0.0")]
     pub fn with_capacity(capacity: usize, inner: W) -> LineWriter<W> {
         LineWriter { inner: BufWriter::with_capacity(capacity, inner) }
     }
@@ -1329,7 +1288,6 @@ impl<W: Write> LineWriter<W> {
     ///     Ok(())
     /// }
     /// ```
-    #[stable(feature = "rust1", since = "1.0.0")]
     pub fn get_ref(&self) -> &W {
         self.inner.get_ref()
     }
@@ -1354,7 +1312,6 @@ impl<W: Write> LineWriter<W> {
     ///     Ok(())
     /// }
     /// ```
-    #[stable(feature = "rust1", since = "1.0.0")]
     pub fn get_mut(&mut self) -> &mut W {
         self.inner.get_mut()
     }
@@ -1382,15 +1339,17 @@ impl<W: Write> LineWriter<W> {
     ///     Ok(())
     /// }
     /// ```
-    #[stable(feature = "rust1", since = "1.0.0")]
     pub fn into_inner(self) -> Result<W, IntoInnerError<LineWriter<W>>> {
         self.inner
             .into_inner()
             .map_err(|IntoInnerError(buf, e)| IntoInnerError(LineWriter { inner: buf }, e))
     }
+
+    pub fn purge(&mut self) {
+        self.inner.purge_buf();
+    }
 }
 
-#[stable(feature = "rust1", since = "1.0.0")]
 impl<W: Write> Write for LineWriter<W> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         LineWriterShim::new(&mut self.inner).write(buf)
@@ -1421,7 +1380,6 @@ impl<W: Write> Write for LineWriter<W> {
     }
 }
 
-#[stable(feature = "rust1", since = "1.0.0")]
 impl<W: Write> fmt::Debug for LineWriter<W>
 where
     W: fmt::Debug,

--- a/library/std/src/io/impls.rs
+++ b/library/std/src/io/impls.rs
@@ -1,17 +1,15 @@
-#[cfg(test)]
-mod tests;
-
-use crate::cmp;
-use crate::fmt;
-use crate::io::{
-    self, BufRead, Error, ErrorKind, Initializer, IoSlice, IoSliceMut, Read, Seek, SeekFrom, Write,
-};
-use crate::mem;
+#[cfg(feature="alloc")] use alloc::boxed::Box;
+use core::cmp;
+use io::{self, SeekFrom, Read, Initializer, Write, Seek, Error, ErrorKind, IoSlice, IoSliceMut};
+#[cfg(feature="alloc")] use io::BufRead;
+use core::fmt;
+use core::mem;
+#[cfg(feature="alloc")] use alloc::string::String;
+#[cfg(feature="alloc")] use alloc::vec::Vec;
 
 // =============================================================================
 // Forwarding implementations
 
-#[stable(feature = "rust1", since = "1.0.0")]
 impl<R: Read + ?Sized> Read for &mut R {
     #[inline]
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
@@ -33,11 +31,13 @@ impl<R: Read + ?Sized> Read for &mut R {
         (**self).initializer()
     }
 
+    #[cfg(feature="alloc")]
     #[inline]
     fn read_to_end(&mut self, buf: &mut Vec<u8>) -> io::Result<usize> {
         (**self).read_to_end(buf)
     }
 
+    #[cfg(feature="alloc")]
     #[inline]
     fn read_to_string(&mut self, buf: &mut String) -> io::Result<usize> {
         (**self).read_to_string(buf)
@@ -48,7 +48,7 @@ impl<R: Read + ?Sized> Read for &mut R {
         (**self).read_exact(buf)
     }
 }
-#[stable(feature = "rust1", since = "1.0.0")]
+
 impl<W: Write + ?Sized> Write for &mut W {
     #[inline]
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
@@ -80,14 +80,13 @@ impl<W: Write + ?Sized> Write for &mut W {
         (**self).write_fmt(fmt)
     }
 }
-#[stable(feature = "rust1", since = "1.0.0")]
 impl<S: Seek + ?Sized> Seek for &mut S {
     #[inline]
     fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
         (**self).seek(pos)
     }
 }
-#[stable(feature = "rust1", since = "1.0.0")]
+#[cfg(feature="alloc")]
 impl<B: BufRead + ?Sized> BufRead for &mut B {
     #[inline]
     fn fill_buf(&mut self) -> io::Result<&[u8]> {
@@ -110,7 +109,7 @@ impl<B: BufRead + ?Sized> BufRead for &mut B {
     }
 }
 
-#[stable(feature = "rust1", since = "1.0.0")]
+#[cfg(feature="alloc")]
 impl<R: Read + ?Sized> Read for Box<R> {
     #[inline]
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
@@ -132,11 +131,13 @@ impl<R: Read + ?Sized> Read for Box<R> {
         (**self).initializer()
     }
 
+    #[cfg(feature="alloc")]
     #[inline]
     fn read_to_end(&mut self, buf: &mut Vec<u8>) -> io::Result<usize> {
         (**self).read_to_end(buf)
     }
 
+    #[cfg(feature="alloc")]
     #[inline]
     fn read_to_string(&mut self, buf: &mut String) -> io::Result<usize> {
         (**self).read_to_string(buf)
@@ -147,7 +148,7 @@ impl<R: Read + ?Sized> Read for Box<R> {
         (**self).read_exact(buf)
     }
 }
-#[stable(feature = "rust1", since = "1.0.0")]
+#[cfg(feature="alloc")]
 impl<W: Write + ?Sized> Write for Box<W> {
     #[inline]
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
@@ -179,14 +180,14 @@ impl<W: Write + ?Sized> Write for Box<W> {
         (**self).write_fmt(fmt)
     }
 }
-#[stable(feature = "rust1", since = "1.0.0")]
+#[cfg(feature="alloc")]
 impl<S: Seek + ?Sized> Seek for Box<S> {
     #[inline]
     fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
         (**self).seek(pos)
     }
 }
-#[stable(feature = "rust1", since = "1.0.0")]
+#[cfg(feature="alloc")]
 impl<B: BufRead + ?Sized> BufRead for Box<B> {
     #[inline]
     fn fill_buf(&mut self) -> io::Result<&[u8]> {
@@ -211,6 +212,7 @@ impl<B: BufRead + ?Sized> BufRead for Box<B> {
 
 // Used by panicking::default_hook
 #[cfg(test)]
+#[cfg(feature="alloc")]
 /// This impl is only used by printing logic, so any error returned is always
 /// of kind `Other`, and should be ignored.
 impl Write for Box<dyn (::realstd::io::Write) + Send> {
@@ -230,7 +232,6 @@ impl Write for Box<dyn (::realstd::io::Write) + Send> {
 ///
 /// Note that reading updates the slice to point to the yet unread part.
 /// The slice will be empty when EOF is reached.
-#[stable(feature = "rust1", since = "1.0.0")]
 impl Read for &[u8] {
     #[inline]
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
@@ -293,6 +294,7 @@ impl Read for &[u8] {
         Ok(())
     }
 
+    #[cfg(feature="alloc")]
     #[inline]
     fn read_to_end(&mut self, buf: &mut Vec<u8>) -> io::Result<usize> {
         buf.extend_from_slice(*self);
@@ -302,7 +304,7 @@ impl Read for &[u8] {
     }
 }
 
-#[stable(feature = "rust1", since = "1.0.0")]
+#[cfg(feature="alloc")]
 impl BufRead for &[u8] {
     #[inline]
     fn fill_buf(&mut self) -> io::Result<&[u8]> {
@@ -320,7 +322,6 @@ impl BufRead for &[u8] {
 ///
 /// Note that writing updates the slice to point to the yet unwritten part.
 /// The slice will be empty when it has been completely overwritten.
-#[stable(feature = "rust1", since = "1.0.0")]
 impl Write for &mut [u8] {
     #[inline]
     fn write(&mut self, data: &[u8]) -> io::Result<usize> {
@@ -366,7 +367,7 @@ impl Write for &mut [u8] {
 
 /// Write is implemented for `Vec<u8>` by appending to the vector.
 /// The vector will grow as needed.
-#[stable(feature = "rust1", since = "1.0.0")]
+#[cfg(feature="alloc")]
 impl Write for Vec<u8> {
     #[inline]
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {

--- a/library/std/src/io/prelude.rs
+++ b/library/std/src/io/prelude.rs
@@ -8,7 +8,8 @@
 //! use std::io::prelude::*;
 //! ```
 
-#![stable(feature = "rust1", since = "1.0.0")]
+pub use super::{Read, Write, Seek};
+#[cfg(feature="alloc")] pub use super::BufRead;
 
-#[stable(feature = "rust1", since = "1.0.0")]
-pub use super::{BufRead, Read, Seek, Write};
+#[cfg(feature="alloc")] pub use alloc::boxed::Box;
+#[cfg(feature="alloc")] pub use alloc::vec::Vec;

--- a/library/std/src/io/sys_io.rs
+++ b/library/std/src/io/sys_io.rs
@@ -1,0 +1,47 @@
+use core::mem;
+
+#[derive(Copy, Clone)]
+pub struct IoSlice<'a>(&'a [u8]);
+
+impl<'a> IoSlice<'a> {
+    #[inline]
+    pub fn new(buf: &'a [u8]) -> IoSlice<'a> {
+        IoSlice(buf)
+    }
+
+    #[inline]
+    pub fn advance(&mut self, n: usize) {
+        self.0 = &self.0[n..]
+    }
+
+    #[inline]
+    pub fn as_slice(&self) -> &[u8] {
+        self.0
+    }
+}
+
+pub struct IoSliceMut<'a>(&'a mut [u8]);
+
+impl<'a> IoSliceMut<'a> {
+    #[inline]
+    pub fn new(buf: &'a mut [u8]) -> IoSliceMut<'a> {
+        IoSliceMut(buf)
+    }
+
+    #[inline]
+    pub fn advance(&mut self, n: usize) {
+        let slice = mem::replace(&mut self.0, &mut []);
+        let (_, remaining) = slice.split_at_mut(n);
+        self.0 = remaining;
+    }
+
+    #[inline]
+    pub fn as_slice(&self) -> &[u8] {
+        self.0
+    }
+
+    #[inline]
+    pub fn as_mut_slice(&mut self) -> &mut [u8] {
+        self.0
+    }
+}

--- a/library/std/src/io/util.rs
+++ b/library/std/src/io/util.rs
@@ -1,11 +1,9 @@
 #![allow(missing_copy_implementations)]
 
-#[cfg(test)]
-mod tests;
-
-use crate::fmt;
-use crate::io::{self, BufRead, ErrorKind, Initializer, IoSlice, IoSliceMut, Read, Write};
-use crate::mem::MaybeUninit;
+use core::fmt;
+use io::{self, Read, Initializer, Write, ErrorKind, IoSlice, IoSliceMut};
+use core::mem::MaybeUninit;
+#[cfg(feature="alloc")] use io::BufRead;
 
 /// Copies the entire contents of a reader into a writer.
 ///
@@ -45,7 +43,6 @@ use crate::mem::MaybeUninit;
 ///     Ok(())
 /// }
 /// ```
-#[stable(feature = "rust1", since = "1.0.0")]
 pub fn copy<R: ?Sized, W: ?Sized>(reader: &mut R, writer: &mut W) -> io::Result<u64>
 where
     R: Read,
@@ -61,18 +58,21 @@ where
     //     based on its privileged knowledge of unstable rustc
     //     internals;
     unsafe {
-        reader.initializer().initialize(buf.assume_init_mut());
+        reader.initializer().initialize(&mut buf.assume_init());
     }
 
     let mut written = 0;
     loop {
-        let len = match reader.read(unsafe { buf.assume_init_mut() }) {
-            Ok(0) => return Ok(written),
+        let len = match reader.read(unsafe { &mut buf.assume_init() } ) {
+            Ok(0) => return Ok(written), // why written here, not 0
             Ok(len) => len,
             Err(ref e) if e.kind() == ErrorKind::Interrupted => continue,
             Err(e) => return Err(e),
         };
-        writer.write_all(unsafe { &buf.assume_init_ref()[..len] })?;
+        unsafe {
+            let buf_u8: &mut [u8] = core::slice::from_raw_parts_mut(buf.as_mut_ptr() as *mut u8, len);
+            writer.write_all(buf_u8)?;
+        }
         written += len as u64;
     }
 }
@@ -81,7 +81,6 @@ where
 ///
 /// This struct is generally created by calling [`empty()`]. Please see
 /// the documentation of [`empty()`] for more details.
-#[stable(feature = "rust1", since = "1.0.0")]
 pub struct Empty {
     _priv: (),
 }
@@ -101,12 +100,10 @@ pub struct Empty {
 /// io::empty().read_to_string(&mut buffer).unwrap();
 /// assert!(buffer.is_empty());
 /// ```
-#[stable(feature = "rust1", since = "1.0.0")]
 pub fn empty() -> Empty {
     Empty { _priv: () }
 }
 
-#[stable(feature = "rust1", since = "1.0.0")]
 impl Read for Empty {
     #[inline]
     fn read(&mut self, _buf: &mut [u8]) -> io::Result<usize> {
@@ -118,7 +115,7 @@ impl Read for Empty {
         Initializer::nop()
     }
 }
-#[stable(feature = "rust1", since = "1.0.0")]
+#[cfg(feature="alloc")]
 impl BufRead for Empty {
     #[inline]
     fn fill_buf(&mut self) -> io::Result<&[u8]> {
@@ -128,7 +125,6 @@ impl BufRead for Empty {
     fn consume(&mut self, _n: usize) {}
 }
 
-#[stable(feature = "std_debug", since = "1.16.0")]
 impl fmt::Debug for Empty {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.pad("Empty { .. }")
@@ -139,7 +135,6 @@ impl fmt::Debug for Empty {
 ///
 /// This struct is generally created by calling [`repeat()`]. Please
 /// see the documentation of [`repeat()`] for more details.
-#[stable(feature = "rust1", since = "1.0.0")]
 pub struct Repeat {
     byte: u8,
 }
@@ -158,12 +153,10 @@ pub struct Repeat {
 /// io::repeat(0b101).read_exact(&mut buffer).unwrap();
 /// assert_eq!(buffer, [0b101, 0b101, 0b101]);
 /// ```
-#[stable(feature = "rust1", since = "1.0.0")]
 pub fn repeat(byte: u8) -> Repeat {
     Repeat { byte }
 }
 
-#[stable(feature = "rust1", since = "1.0.0")]
 impl Read for Repeat {
     #[inline]
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
@@ -193,7 +186,6 @@ impl Read for Repeat {
     }
 }
 
-#[stable(feature = "std_debug", since = "1.16.0")]
 impl fmt::Debug for Repeat {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.pad("Repeat { .. }")
@@ -204,7 +196,6 @@ impl fmt::Debug for Repeat {
 ///
 /// This struct is generally created by calling [`sink`]. Please
 /// see the documentation of [`sink()`] for more details.
-#[stable(feature = "rust1", since = "1.0.0")]
 pub struct Sink {
     _priv: (),
 }
@@ -225,12 +216,10 @@ pub struct Sink {
 /// let num_bytes = io::sink().write(&buffer).unwrap();
 /// assert_eq!(num_bytes, 5);
 /// ```
-#[stable(feature = "rust1", since = "1.0.0")]
 pub fn sink() -> Sink {
     Sink { _priv: () }
 }
 
-#[stable(feature = "rust1", since = "1.0.0")]
 impl Write for Sink {
     #[inline]
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
@@ -254,7 +243,6 @@ impl Write for Sink {
     }
 }
 
-#[stable(feature = "write_mt", since = "1.48.0")]
 impl Write for &Sink {
     #[inline]
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
@@ -278,7 +266,6 @@ impl Write for &Sink {
     }
 }
 
-#[stable(feature = "std_debug", since = "1.16.0")]
 impl fmt::Debug for Sink {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.pad("Sink { .. }")


### PR DESCRIPTION
Get std::io to be  an core::io component so that can be used by runtime implemenation.

Especially for posix libc implemenation in rust with
* syscall(Linux)
* win32 api (windows)
* syscall(osx)
* syscall(redox)
* ? (fedora)
and so on.

This is for https://github.com/redox-os/relibc

Also for 
https://github.com/rulibc/rulibc
The fork of relibc that act as an msvcrt/mingw/cygwin/msys2 alternative on win32

glibc/musl alternative on linux world.

redox support will alomost unchanged with the upstream  Thttps://github.com/redox-os/relibc


And makes platform dependent IoSliceMut can be customized by the user
And give the default impl for windows/posix.


https://github.com/rust-lang/rust/issues/36193
related
