### PR TITLE
Fix intra-docs link in core::ffi::VaList

### DIFF
--- a/library/core/src/ffi.rs
+++ b/library/core/src/ffi.rs
@@ -280,7 +280,7 @@ impl<'a, 'f: 'a> DerefMut for VaList<'a, 'f> {
 // within a private module. Once RFC 2145 has been implemented look into
 // improving this.
 mod sealed_trait {
-    /// Trait which permits the allowed types to be used with [VaList::arg].
+    /// Trait which permits the allowed types to be used with [super::VaListImpl::arg].
     #[unstable(
         feature = "c_variadic",
         reason = "the `c_variadic` feature has not been properly tested on \


### PR DESCRIPTION
At some point, `VaList` was changes to be a [wrapper](https://github.com/rust-lang/rust/blob/1661f77/library/core/src/ffi.rs#L177-L201) over `VaListImpl`, and now the `Arg` method exists on [`VaListImpl`](https://github.com/rust-lang/rust/blob/1661f77/library/core/src/ffi.rs#L333-L336). This PR fixes the intradoc links so that when `--document-private-items` is ran on std (via [patch](https://gist.github.com/aDotInTheVoid/42c82306210203f9c9093c952b765ab4)), it works