### PR TITLE
Update `changelog-seen` in config.toml.example

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -13,7 +13,7 @@
 # If it does not match the version that is currently running,
 # `x.py` will prompt you to update it and read the changelog.
 # See `src/bootstrap/CHANGELOG.md` for more information.
-changelog-seen = 1
+changelog-seen = 2
 
 # =============================================================================
 # Global Settings


### PR DESCRIPTION
This got out of sync when the version was bumped last time in #77133

Long-term we may want to find an easier way to maintain this that
doesn't require bumping the version in three different places. Off the
top of my head I can't think of anything, though. It _is_ documented in src/bootstrap/README.md, although I don't know how many people read that.

r? @Mark-Simulacrum 
cc @spastorino 