### PR TITLE
Rollup of 10 pull requests

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes/E0424.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0424.md
@@ -21,7 +21,7 @@ impl Foo {
 The `self` keyword can only be used inside methods, which are associated
 functions (functions defined inside of a `trait` or `impl` block) that have a
 `self` receiver as its first parameter, like `self`, `&self`, `&mut self` or
-`self: &mut Pin<Self>` (this last one is an example of an ["abitrary `self`
+`self: &mut Pin<Self>` (this last one is an example of an ["arbitrary `self`
 type"](https://github.com/rust-lang/rust/issues/44874)).
 
 Check if the associated function's parameter list should have contained a `self`

--- a/compiler/rustc_middle/src/ty/normalize_erasing_regions.rs
+++ b/compiler/rustc_middle/src/ty/normalize_erasing_regions.rs
@@ -27,6 +27,7 @@ impl<'tcx> TyCtxt<'tcx> {
             value,
             param_env,
         );
+        debug_assert_eq!(param_env.reveal(), ty::Reveal::All);
 
         // Erase first before we do the real query -- this keeps the
         // cache from being too polluted.

--- a/config.toml.example
+++ b/config.toml.example
@@ -370,13 +370,13 @@ changelog-seen = 1
 # binary, otherwise they are omitted.
 #
 # Defaults to rust.debug value
-#debug-assertions = debug
+#debug-assertions = rust.debug (boolean)
 
 # Whether or not debug assertions are enabled for the standard library.
 # Overrides the `debug-assertions` option, if defined.
 #
 # Defaults to rust.debug-assertions value
-#debug-assertions-std = debug-assertions
+#debug-assertions-std = rust.debug-assertions (boolean)
 
 # Whether or not to leave debug! and trace! calls in the rust binary.
 # Overrides the `debug-assertions` option, if defined.
@@ -386,7 +386,7 @@ changelog-seen = 1
 # If you see a message from `tracing` saying
 # `max_level_info` is enabled and means logging won't be shown,
 # set this value to `true`.
-#debug-logging = debug-assertions
+#debug-logging = rust.debug-assertions (boolean)
 
 # Debuginfo level for most of Rust code, corresponds to the `-C debuginfo=N` option of `rustc`.
 # `0` - no debug info

--- a/config.toml.example
+++ b/config.toml.example
@@ -13,7 +13,7 @@
 # If it does not match the version that is currently running,
 # `x.py` will prompt you to update it and read the changelog.
 # See `src/bootstrap/CHANGELOG.md` for more information.
-changelog-seen = 1
+changelog-seen = 2
 
 # =============================================================================
 # Global Settings

--- a/library/alloc/src/alloc.rs
+++ b/library/alloc/src/alloc.rs
@@ -376,7 +376,7 @@ pub fn handle_alloc_error(layout: Layout) -> ! {
 #[doc(hidden)]
 #[allow(unused_attributes)]
 #[unstable(feature = "alloc_internals", issue = "none")]
-pub mod __default_lib_allocator {
+pub mod __alloc_error_handler {
     use crate::alloc::Layout;
 
     // called via generated `__rust_alloc_error_handler`

--- a/library/alloc/src/alloc.rs
+++ b/library/alloc/src/alloc.rs
@@ -14,8 +14,9 @@ mod tests;
 
 extern "Rust" {
     // These are the magic symbols to call the global allocator.  rustc generates
-    // them from the `#[global_allocator]` attribute if there is one, or uses the
-    // default implementations in libstd (`__rdl_alloc` etc in `src/libstd/alloc.rs`)
+    // them to call `__rg_alloc` etc if there is a `#[global_allocator]` attribute
+    // (the code expanding that attribute macro generates those functions), or to call
+    // the default implementations in libstd (`__rdl_alloc` etc in `src/libstd/alloc.rs`)
     // otherwise.
     #[rustc_allocator]
     #[rustc_allocator_nounwind]

--- a/library/alloc/src/vec.rs
+++ b/library/alloc/src/vec.rs
@@ -1477,7 +1477,7 @@ impl<T> Vec<T> {
     /// may be chosen to be `'static`.
     ///
     /// This function is similar to the [`leak`][Box::leak] function on [`Box`]
-    /// except there are no way to undo the leak yet.
+    /// except that there is no way to recover the leaked memory.
     ///
     /// This function is mainly useful for data that lives for the remainder of
     /// the program's life. Dropping the returned reference will cause a memory

--- a/library/alloc/src/vec.rs
+++ b/library/alloc/src/vec.rs
@@ -1476,7 +1476,7 @@ impl<T> Vec<T> {
     /// `'a`. If the type has only static references, or none at all, then this
     /// may be chosen to be `'static`.
     ///
-    /// This function is similar to the `leak` function on `Box`.
+    /// This function is similar to the [`leak`][Box::leak] function on [`Box`].
     ///
     /// This function is mainly useful for data that lives for the remainder of
     /// the program's life. Dropping the returned reference will cause a memory

--- a/library/alloc/src/vec.rs
+++ b/library/alloc/src/vec.rs
@@ -1476,7 +1476,8 @@ impl<T> Vec<T> {
     /// `'a`. If the type has only static references, or none at all, then this
     /// may be chosen to be `'static`.
     ///
-    /// This function is similar to the [`leak`][Box::leak] function on [`Box`].
+    /// This function is similar to the [`leak`][Box::leak] function on [`Box`]
+    /// except there are no way to undo the leak yet.
     ///
     /// This function is mainly useful for data that lives for the remainder of
     /// the program's life. Dropping the returned reference will cause a memory

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -85,7 +85,7 @@
 //! # Contributing changes to the documentation
 //!
 //! Check out the rust contribution guidelines [here](
-//! https://rustc-dev-guide.rust-lang.org/getting-started.html).
+//! https://rustc-dev-guide.rust-lang.org/contributing.html#writing-documentation).
 //! The source for this documentation can be found on
 //! [GitHub](https://github.com/rust-lang/rust).
 //! To contribute changes, make sure you read the guidelines first, then submit

--- a/library/std/src/os/linux/fs.rs
+++ b/library/std/src/os/linux/fs.rs
@@ -20,7 +20,7 @@ pub trait MetadataExt {
     /// Unix platforms. The `os::unix::fs::MetadataExt` trait contains the
     /// cross-Unix abstractions contained within the raw stat.
     ///
-    /// [`stat`]: crate::os::linux::raw::stat
+    /// [`stat`]: struct@crate::os::linux::raw::stat
     ///
     /// # Examples
     ///

--- a/library/std/src/sys/windows/c.rs
+++ b/library/std/src/sys/windows/c.rs
@@ -47,7 +47,6 @@ pub type LPWCH = *mut WCHAR;
 pub type LPWIN32_FIND_DATAW = *mut WIN32_FIND_DATAW;
 pub type LPWSADATA = *mut WSADATA;
 pub type LPWSAPROTOCOL_INFO = *mut WSAPROTOCOL_INFO;
-pub type LPSTR = *mut CHAR;
 pub type LPWSTR = *mut WCHAR;
 pub type LPFILETIME = *mut FILETIME;
 pub type LPWSABUF = *mut WSABUF;
@@ -876,16 +875,6 @@ extern "system" {
     pub fn DeleteFileW(lpPathName: LPCWSTR) -> BOOL;
     pub fn GetCurrentDirectoryW(nBufferLength: DWORD, lpBuffer: LPWSTR) -> DWORD;
     pub fn SetCurrentDirectoryW(lpPathName: LPCWSTR) -> BOOL;
-    pub fn WideCharToMultiByte(
-        CodePage: UINT,
-        dwFlags: DWORD,
-        lpWideCharStr: LPCWSTR,
-        cchWideChar: c_int,
-        lpMultiByteStr: LPSTR,
-        cbMultiByte: c_int,
-        lpDefaultChar: LPCSTR,
-        lpUsedDefaultChar: LPBOOL,
-    ) -> c_int;
 
     pub fn closesocket(socket: SOCKET) -> c_int;
     pub fn recv(socket: SOCKET, buf: *mut c_void, len: c_int, flags: c_int) -> c_int;

--- a/library/unwind/src/libunwind.rs
+++ b/library/unwind/src/libunwind.rs
@@ -89,7 +89,7 @@ extern "C" {
 }
 
 cfg_if::cfg_if! {
-if #[cfg(all(any(target_os = "ios", target_os = "netbsd", not(target_arch = "arm"))))] {
+if #[cfg(any(target_os = "ios", target_os = "netbsd", not(target_arch = "arm")))] {
     // Not ARM EHABI
     #[repr(C)]
     #[derive(Copy, Clone, PartialEq)]


### PR DESCRIPTION
Successful merges:

 - #77195 (Link to documentation-specific guidelines.)
 - #77629 (Cleanup of `eat_while()` in lexer)
 - #77709 (Link Vec leak doc to Box)
 - #77738 (fix __rust_alloc_error_handler comment)
 - #77748 (Dead code cleanup in windows-gnu std)
 - #77752 (require `Reveal::All` in `normalize_erasing_regions`)
 - #77766 (Clarify the debug-related values should take boolean)
 - #77777 (doc: disambiguate stat in MetadataExt::as_raw_stat)
 - #77782 (Fix typo in error code description)
 - #77787 (Update `changelog-seen` in config.toml.example)

Failed merges:


r? @ghost