### PR TITLE
lint: Do not provide suggestions for non standard characters

### DIFF
--- a/src/test/ui/lint/special-upper-lower-cases.rs
+++ b/src/test/ui/lint/special-upper-lower-cases.rs
@@ -1,0 +1,24 @@
+// (#77273) These characters are in the general categories of
+// "Uppercase/Lowercase Letter".
+// The diagnostics don't provide meaningful suggestions for them
+// as we cannot convert them properly.
+
+// check-pass
+
+#![feature(non_ascii_idents)]
+#![allow(uncommon_codepoints, unused)]
+
+struct 𝕟𝕠𝕥𝕒𝕔𝕒𝕞𝕖𝕝;
+//~^ WARN: type `𝕟𝕠𝕥𝕒𝕔𝕒𝕞𝕖𝕝` should have an upper camel case name
+
+// FIXME: How we should handle this?
+struct 𝕟𝕠𝕥_𝕒_𝕔𝕒𝕞𝕖𝕝;
+//~^ WARN: type `𝕟𝕠𝕥_𝕒_𝕔𝕒𝕞𝕖𝕝` should have an upper camel case name
+
+static 𝗻𝗼𝗻𝘂𝗽𝗽𝗲𝗿𝗰𝗮𝘀𝗲: i32 = 1;
+//~^ WARN: static variable `𝗻𝗼𝗻𝘂𝗽𝗽𝗲𝗿𝗰𝗮𝘀𝗲` should have an upper case name
+
+fn main() {
+    let 𝓢𝓝𝓐𝓐𝓐𝓐𝓚𝓔𝓢 = 1;
+    //~^ WARN: variable `𝓢𝓝𝓐𝓐𝓐𝓐𝓚𝓔𝓢` should have a snake case name
+}

--- a/src/test/ui/lint/special-upper-lower-cases.stderr
+++ b/src/test/ui/lint/special-upper-lower-cases.stderr
@@ -1,0 +1,32 @@
+warning: type `𝕟𝕠𝕥𝕒𝕔𝕒𝕞𝕖𝕝` should have an upper camel case name
+  --> $DIR/special-upper-lower-cases.rs:11:8
+   |
+LL | struct 𝕟𝕠𝕥𝕒𝕔𝕒𝕞𝕖𝕝;
+   |        ^^^^^^^^^
+   |
+   = note: `#[warn(non_camel_case_types)]` on by default
+
+warning: type `𝕟𝕠𝕥_𝕒_𝕔𝕒𝕞𝕖𝕝` should have an upper camel case name
+  --> $DIR/special-upper-lower-cases.rs:15:8
+   |
+LL | struct 𝕟𝕠𝕥_𝕒_𝕔𝕒𝕞𝕖𝕝;
+   |        ^^^^^^^^^^^ help: convert the identifier to upper camel case: `𝕟𝕠𝕥𝕒𝕔𝕒𝕞𝕖𝕝`
+
+warning: static variable `𝗻𝗼𝗻𝘂𝗽𝗽𝗲𝗿𝗰𝗮𝘀𝗲` should have an upper case name
+  --> $DIR/special-upper-lower-cases.rs:18:8
+   |
+LL | static 𝗻𝗼𝗻𝘂𝗽𝗽𝗲𝗿𝗰𝗮𝘀𝗲: i32 = 1;
+   |        ^^^^^^^^^^^^
+   |
+   = note: `#[warn(non_upper_case_globals)]` on by default
+
+warning: variable `𝓢𝓝𝓐𝓐𝓐𝓐𝓚𝓔𝓢` should have a snake case name
+  --> $DIR/special-upper-lower-cases.rs:22:9
+   |
+LL |     let 𝓢𝓝𝓐𝓐𝓐𝓐𝓚𝓔𝓢 = 1;
+   |         ^^^^^^^^^
+   |
+   = note: `#[warn(non_snake_case)]` on by default
+
+warning: 4 warnings emitted
+


### PR DESCRIPTION
Fixes #77273

Only provide suggestions if the case-fixed result is different than the original.
