### PR TITLE
Add settings to rustdoc to use the system theme

### DIFF
--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -1386,11 +1386,11 @@ impl Setting {
                 description,
             ),
             Setting::Select { js_data_name, description, default_value, ref options } => format!(
-                "<div class='setting-line'>\
+                "<div class=\"setting-line\">\
                      <div>{}</div>\
-                     <label class='select-wrapper'>\
-                         <select id='{}' autocomplete='off'>{}</select>\
-                         <img src='{}down-arrow{}.svg' alt='Select item'>\
+                     <label class=\"select-wrapper\">\
+                         <select id=\"{}\" autocomplete=\"off\">{}</select>\
+                         <img src=\"{}down-arrow{}.svg\" alt=\"Select item\">\
                      </label>\
                  </div>",
                 description,

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -1365,7 +1365,7 @@ enum Setting {
 impl Setting {
     fn display(&self, root_path: &str, suffix: &str) -> String {
         match *self {
-            Setting::Section { ref description, ref sub_settings } => format!(
+            Setting::Section { description, ref sub_settings } => format!(
                 "<div class='setting-line'>\
                      <div class='title'>{}</div>\
                      <div class='sub-settings'>{}</div>
@@ -1373,7 +1373,7 @@ impl Setting {
                 description,
                 sub_settings.iter().map(|s| s.display(root_path, suffix)).collect::<String>()
             ),
-            Setting::Toggle { ref js_data_name, ref description, ref default_value } => format!(
+            Setting::Toggle { js_data_name, description, default_value } => format!(
                 "<div class='setting-line'>\
                      <label class='toggle'>\
                      <input type='checkbox' id='{}' {}>\
@@ -1382,15 +1382,10 @@ impl Setting {
                      <div>{}</div>\
                  </div>",
                 js_data_name,
-                if *default_value { " checked" } else { "" },
+                if default_value { " checked" } else { "" },
                 description,
             ),
-            Setting::Select {
-                ref js_data_name,
-                ref description,
-                ref default_value,
-                ref options,
-            } => format!(
+            Setting::Select { js_data_name, description, default_value, ref options } => format!(
                 "<div class='setting-line'>\
                      <div>{}</div>\
                      <label class='select-wrapper'>\
@@ -1405,7 +1400,7 @@ impl Setting {
                     .map(|opt| format!(
                         "<option value=\"{}\" {}>{}</option>",
                         opt.0,
-                        if &opt.0 == *default_value { "selected" } else { "" },
+                        if &opt.0 == default_value { "selected" } else { "" },
                         opt.1,
                     ))
                     .collect::<String>(),

--- a/src/librustdoc/html/static/settings.css
+++ b/src/librustdoc/html/static/settings.css
@@ -4,7 +4,6 @@
 }
 
 .setting-line > div {
-	max-width: calc(100% - 74px);
 	display: inline-block;
 	vertical-align: top;
 	font-size: 17px;
@@ -28,6 +27,45 @@
 
 .toggle input {
 	display: none;
+}
+
+.select-wrapper {
+	float: right;
+
+	position: relative;
+
+	height: 27px;
+	min-width: 25%;
+}
+
+.select-wrapper select {
+	appearance: none;
+	-moz-appearance: none;
+	-webkit-appearance: none;
+
+	background: none;
+	border: 2px solid #ccc;
+	padding-right: 28px;
+
+	width: 100%;
+}
+
+.select-wrapper img {
+	pointer-events: none;
+
+	position: absolute;
+	right: 0;
+	bottom: 0;
+
+	background: #ccc;
+
+	height: 100%;
+	width: 28px;
+	padding: 0px 4px;
+}
+
+.select-wrapper select option {
+	color: initial;
 }
 
 .slider {

--- a/src/librustdoc/html/static/settings.css
+++ b/src/librustdoc/html/static/settings.css
@@ -31,9 +31,7 @@
 
 .select-wrapper {
 	float: right;
-
 	position: relative;
-
 	height: 27px;
 	min-width: 25%;
 }
@@ -42,23 +40,18 @@
 	appearance: none;
 	-moz-appearance: none;
 	-webkit-appearance: none;
-
 	background: none;
 	border: 2px solid #ccc;
 	padding-right: 28px;
-
 	width: 100%;
 }
 
 .select-wrapper img {
 	pointer-events: none;
-
 	position: absolute;
 	right: 0;
 	bottom: 0;
-
 	background: #ccc;
-
 	height: 100%;
 	width: 28px;
 	padding: 0px 4px;

--- a/src/librustdoc/html/static/settings.js
+++ b/src/librustdoc/html/static/settings.js
@@ -1,21 +1,21 @@
 // Local js definitions:
-/* global getCurrentValue, updateLocalStorage */
+/* global getCurrentValue, updateLocalStorage, updateSystemTheme */
 
 (function () {
     function changeSetting(settingName, value) {
-        updateLocalStorage('rustdoc-' + settingName, value);
+        updateLocalStorage("rustdoc-" + settingName, value);
 
         switch (settingName) {
-            case 'preferred-dark-theme':
-            case 'preferred-light-theme':
-            case 'use-system-theme':
+            case "preferred-dark-theme":
+            case "preferred-light-theme":
+            case "use-system-theme":
                 updateSystemTheme();
                 break;
         }
     }
 
     function getSettingValue(settingName) {
-        return getCurrentValue('rustdoc-' + settingName);
+        return getCurrentValue("rustdoc-" + settingName);
     }
 
     function setEvents() {
@@ -23,9 +23,10 @@
             toggles: document.getElementsByClassName("slider"),
             selects: document.getElementsByClassName("select-wrapper")
         };
+        var i;
 
         if (elems.toggles && elems.toggles.length > 0) {
-            for (var i = 0; i < elems.toggles.length; ++i) {
+            for (i = 0; i < elems.toggles.length; ++i) {
                 var toggle = elems.toggles[i].previousElementSibling;
                 var settingId = toggle.id;
                 var settingValue = getSettingValue(settingId);
@@ -39,8 +40,8 @@
         }
 
         if (elems.selects && elems.selects.length > 0) {
-            for (var i = 0; i < elems.selects.length; ++i) {
-                var select = elems.selects[i].getElementsByTagName('select')[0];
+            for (i = 0; i < elems.selects.length; ++i) {
+                var select = elems.selects[i].getElementsByTagName("select")[0];
                 var settingId = select.id;
                 var settingValue = getSettingValue(settingId);
                 if (settingValue !== null) {

--- a/src/librustdoc/html/static/settings.js
+++ b/src/librustdoc/html/static/settings.js
@@ -2,8 +2,16 @@
 /* global getCurrentValue, updateLocalStorage */
 
 (function () {
-    function changeSetting(settingName, isEnabled) {
-        updateLocalStorage('rustdoc-' + settingName, isEnabled);
+    function changeSetting(settingName, value) {
+        updateLocalStorage('rustdoc-' + settingName, value);
+
+        switch (settingName) {
+            case 'preferred-dark-theme':
+            case 'preferred-light-theme':
+            case 'use-system-theme':
+                updateSystemTheme();
+                break;
+        }
     }
 
     function getSettingValue(settingName) {
@@ -11,20 +19,37 @@
     }
 
     function setEvents() {
-        var elems = document.getElementsByClassName("slider");
-        if (!elems || elems.length === 0) {
-            return;
-        }
-        for (var i = 0; i < elems.length; ++i) {
-            var toggle = elems[i].previousElementSibling;
-            var settingId = toggle.id;
-            var settingValue = getSettingValue(settingId);
-            if (settingValue !== null) {
-                toggle.checked = settingValue === "true";
+        var elems = {
+            toggles: document.getElementsByClassName("slider"),
+            selects: document.getElementsByClassName("select-wrapper")
+        };
+
+        if (elems.toggles && elems.toggles.length > 0) {
+            for (var i = 0; i < elems.toggles.length; ++i) {
+                var toggle = elems.toggles[i].previousElementSibling;
+                var settingId = toggle.id;
+                var settingValue = getSettingValue(settingId);
+                if (settingValue !== null) {
+                    toggle.checked = settingValue === "true";
+                }
+                toggle.onchange = function() {
+                    changeSetting(this.id, this.checked);
+                };
             }
-            toggle.onchange = function() {
-                changeSetting(this.id, this.checked);
-            };
+        }
+
+        if (elems.selects && elems.selects.length > 0) {
+            for (var i = 0; i < elems.selects.length; ++i) {
+                var select = elems.selects[i].getElementsByTagName('select')[0];
+                var settingId = select.id;
+                var settingValue = getSettingValue(settingId);
+                if (settingValue !== null) {
+                    select.value = settingValue;
+                }
+                select.onchange = function() {
+                    changeSetting(this.id, this.value);
+                };
+            }
         }
     }
 

--- a/src/librustdoc/html/static/storage.js
+++ b/src/librustdoc/html/static/storage.js
@@ -118,11 +118,71 @@ function switchTheme(styleElem, mainStyleElem, newTheme, saveTheme) {
     }
 }
 
-function getSystemValue() {
-    var property = getComputedStyle(document.documentElement).getPropertyValue('content');
-    return property.replace(/[\"\']/g, "");
+function useSystemTheme(value) {
+    if (value === undefined) {
+        value = true;
+    }
+
+    updateLocalStorage("rustdoc-use-system-theme", value);
+
+    // update the toggle if we're on the settings page
+    var toggle = document.getElementById("use-system-theme");
+    if (toggle && toggle instanceof HTMLInputElement) {
+        toggle.checked = value;
+    }
 }
 
-switchTheme(currentTheme, mainTheme,
-            getCurrentValue("rustdoc-theme") || getSystemValue() || "light",
-            false);
+var updateSystemTheme = (function() {
+    if (!window.matchMedia) {
+        // fallback to the CSS computed value
+        return function() {
+            let cssTheme = getComputedStyle(document.documentElement)
+                .getPropertyValue('content');
+
+            switchTheme(
+                currentTheme,
+                mainTheme,
+                JSON.parse(cssTheme) || light,
+                true
+            );
+        };
+    }
+
+    // only listen to (prefers-color-scheme: dark) because light is the default
+    var mql = window.matchMedia("(prefers-color-scheme: dark)");
+
+    function handlePreferenceChange(mql) {
+        // maybe the user has disabled the setting in the meantime!
+        if (getCurrentValue("rustdoc-use-system-theme") !== "false") {
+            var lightTheme = getCurrentValue("rustdoc-preferred-light-theme") || "light";
+            var darkTheme = getCurrentValue("rustdoc-preferred-dark-theme") || "dark";
+
+            if (mql.matches) {
+                // prefers a dark theme
+                switchTheme(currentTheme, mainTheme, darkTheme, true);
+            } else {
+                // prefers a light theme, or has no preference
+                switchTheme(currentTheme, mainTheme, lightTheme, true);
+            }
+
+            // note: we save the theme so that it doesn't suddenly change when
+            // the user disables "use-system-theme" and reloads the page or
+            // navigates to another page
+        }
+    }
+
+    mql.addListener(handlePreferenceChange);
+
+    return function() {
+        handlePreferenceChange(mql);
+    };
+})();
+
+if (getCurrentValue("rustdoc-use-system-theme") !== "false" && window.matchMedia) {
+    // call the function to initialize the theme at least once!
+    updateSystemTheme();
+} else {
+    switchTheme(currentTheme, mainTheme,
+                getCurrentValue("rustdoc-theme") || "light",
+                false);
+}

--- a/src/librustdoc/html/static/storage.js
+++ b/src/librustdoc/html/static/storage.js
@@ -1,8 +1,10 @@
 // From rust:
 /* global resourcesSuffix */
 
+var darkThemes = ["dark", "ayu"];
 var currentTheme = document.getElementById("themeStyle");
 var mainTheme = document.getElementById("mainThemeStyle");
+var localStoredTheme = getCurrentValue("rustdoc-theme");
 
 var savedHref = [];
 
@@ -179,6 +181,14 @@ var updateSystemTheme = (function() {
 })();
 
 if (getCurrentValue("rustdoc-use-system-theme") !== "false" && window.matchMedia) {
+    // update the preferred dark theme if the user is already using a dark theme
+    // See https://github.com/rust-lang/rust/pull/77809#issuecomment-707875732
+    if (getCurrentValue("rustdoc-use-system-theme") === null
+        && getCurrentValue("rustdoc-preferred-dark-theme") === null
+        && darkThemes.indexOf(localStoredTheme) >= 0) {
+        updateLocalStorage("rustdoc-preferred-dark-theme", localStoredTheme);
+    }
+
     // call the function to initialize the theme at least once!
     updateSystemTheme();
 } else {

--- a/src/librustdoc/html/static/storage.js
+++ b/src/librustdoc/html/static/storage.js
@@ -110,8 +110,8 @@ function switchTheme(styleElem, mainStyleElem, newTheme, saveTheme) {
     });
     if (found === true) {
         styleElem.href = newHref;
-        // If this new value comes from a system setting or from the previously saved theme, no
-        // need to save it.
+        // If this new value comes from a system setting or from the previously
+        // saved theme, no need to save it.
         if (saveTheme === true) {
             updateLocalStorage("rustdoc-theme", newTheme);
         }
@@ -182,7 +182,10 @@ if (getCurrentValue("rustdoc-use-system-theme") !== "false" && window.matchMedia
     // call the function to initialize the theme at least once!
     updateSystemTheme();
 } else {
-    switchTheme(currentTheme, mainTheme,
-                getCurrentValue("rustdoc-theme") || "light",
-                false);
+    switchTheme(
+        currentTheme,
+        mainTheme,
+        getCurrentValue("rustdoc-theme") || "light",
+        false
+    );
 }


### PR DESCRIPTION
This PR adds new settings to `rustdoc` to use the operating system color scheme.

![click](https://user-images.githubusercontent.com/11479594/95668052-bf604e80-0b6e-11eb-8a17-473aaae510c9.gif)

`rustdoc` actually had [basic support for this](https://github.com/rust-lang/rust/blob/b1af43bc63bc7417938df056f7f25d456cc11b0e/src/librustdoc/html/static/storage.js#L121), but the setting wasn't visible and couldn't be set back once the theme was explicitly set by the user. It also didn't update if the operating system theme preference changed while viewing a page.

I'm using [this method](https://developer.mozilla.org/en-US/docs/Web/CSS/Media_Queries/Testing_media_queries#Receiving_query_notifications) to query and listen to changes to the `(prefers-color-scheme: dark)` media query. I kept the old method (based on `getComputedStyle`) as a fallback in case the user-agent doesn't support `window.matchMedia` (so like... [pretty much nobody](https://caniuse.com/?search=matchMedia)).

Since there's now more than one official ""dark"" theme in `rustdoc` (and also to support custom/third-party themes), the preferred dark and light themes can be configured in the settings page (the defaults are just "dark" and "light").

This is also my very first "proper" PR to Rust! Please let me know if I did anything wrong :).
