### PR TITLE
[DO NOT MERGE] Experiment: disable the niche optimization for most enums

### DIFF
--- a/compiler/rustc_data_structures/src/macros.rs
+++ b/compiler/rustc_data_structures/src/macros.rs
@@ -2,7 +2,7 @@
 #[macro_export]
 macro_rules! static_assert_size {
     ($ty:ty, $size:expr) => {
-        const _: [(); $size] = [(); ::std::mem::size_of::<$ty>()];
+        //        const _: [(); $size] = [(); ::std::mem::size_of::<$ty>()];
     };
 }
 

--- a/compiler/rustc_middle/src/ty/layout.rs
+++ b/compiler/rustc_middle/src/ty/layout.rs
@@ -1216,7 +1216,9 @@ impl<'tcx> LayoutCx<'tcx, TyCtxt<'tcx>> {
                 };
 
                 let best_layout = match (tagged_layout, niche_filling_layout) {
-                    (tagged_layout, Some(niche_filling_layout)) => {
+                    (tagged_layout, Some(niche_filling_layout))
+                        if niche_filling_layout.size <= Size::from_bytes(16) =>
+                    {
                         // Pick the smaller layout; otherwise,
                         // pick the layout with the larger niche; otherwise,
                         // pick tagged as it has simpler codegen.
@@ -1226,7 +1228,7 @@ impl<'tcx> LayoutCx<'tcx, TyCtxt<'tcx>> {
                             (layout.size, cmp::Reverse(niche_size))
                         })
                     }
-                    (tagged_layout, None) => tagged_layout,
+                    (tagged_layout, _) => tagged_layout,
                 };
 
                 tcx.intern_layout(best_layout)


### PR DESCRIPTION
(Only keep the niche optimization for small enum to avoid cases where the size would be doubling)

PR #70477 and #75866 have shown that trying to optimization more often lead to performance regressions.
It would be interesting to know if there would be performance improvements by using the niche optimization less often.

My hypotheses is that the generated code for `match` when using the niche optimization is sub-optimal and should deserve to be optimized. This experiment should show how much speed we could expect to gain by optimizing it.

I'm kindly asking for a pref run of this PR. 

cc @eddyb @erikdesjardins  