### PR TITLE
Implement a specialized version std::iter::Enumerate for TrustedLen

### DIFF
--- a/library/core/src/iter/adapters/zip.rs
+++ b/library/core/src/iter/adapters/zip.rs
@@ -384,7 +384,8 @@ impl<A: Debug + TrustedRandomAccess, B: Debug + TrustedRandomAccess> ZipFmt<A, B
 ///
 /// # Safety
 ///
-/// The iterator's `size_hint` must be exact and cheap to call.
+/// The iterator's `size_hint` must be exact and cheap to call, which also
+/// means that the number of items must fit into an `usize`.
 ///
 /// `size` may not be overridden.
 ///


### PR DESCRIPTION
This allows to hint at the compiler via `intrinsics::assume()` that the
returned index is smaller than the length of the underlying iterator and
allows the compiler to optimize code better based on that.

Fixes https://github.com/rust-lang/rust/issues/75935

----

A benchmark comes in a bit.