### PR TITLE
Remove many unnecessary manual link resolves from library

### DIFF
--- a/library/alloc/src/boxed.rs
+++ b/library/alloc/src/boxed.rs
@@ -126,9 +126,7 @@
 //!
 //! [ucg#198]: https://github.com/rust-lang/unsafe-code-guidelines/issues/198
 //! [dereferencing]: core::ops::Deref
-//! [`Box<T>`]: Box
 //! [`Box::<T>::from_raw(value)`]: Box::from_raw
-//! [`Box::<T>::into_raw`]: Box::into_raw
 //! [`Global`]: crate::alloc::Global
 //! [`Layout`]: crate::alloc::Layout
 //! [`Layout::for_value(&*value)`]: crate::alloc::Layout::for_value

--- a/library/alloc/src/str.rs
+++ b/library/alloc/src/str.rs
@@ -451,8 +451,6 @@ impl str {
 
     /// Converts a [`Box<str>`] into a [`String`] without copying or allocating.
     ///
-    /// [`Box<str>`]: Box
-    ///
     /// # Examples
     ///
     /// Basic usage:

--- a/library/core/src/borrow.rs
+++ b/library/core/src/borrow.rs
@@ -40,7 +40,6 @@
 /// provide a reference to related type `T`, it is often better to use
 /// [`AsRef<T>`] as more types can safely implement it.
 ///
-/// [`BorrowMut<T>`]: BorrowMut
 /// [`Box<T>`]: ../../std/boxed/struct.Box.html
 /// [`Mutex<T>`]: ../../std/sync/struct.Mutex.html
 /// [`Rc<T>`]: ../../std/rc/struct.Rc.html
@@ -183,8 +182,6 @@ pub trait Borrow<Borrowed: ?Sized> {
 /// As a companion to [`Borrow<T>`] this trait allows a type to borrow as
 /// an underlying type by providing a mutable reference. See [`Borrow<T>`]
 /// for more information on borrowing as another type.
-///
-/// [`Borrow<T>`]: Borrow
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait BorrowMut<Borrowed: ?Sized>: Borrow<Borrowed> {
     /// Mutably borrows from an owned value.

--- a/library/core/src/convert/mod.rs
+++ b/library/core/src/convert/mod.rs
@@ -135,8 +135,6 @@ pub const fn identity<T>(x: T) -> T {
 /// Since both [`String`] and [`&str`] implement `AsRef<str>` we can accept both as input argument.
 ///
 /// [`&str`]: primitive@str
-/// [`Option<T>`]: Option
-/// [`Result<T, E>`]: Result
 /// [`Borrow`]: crate::borrow::Borrow
 /// [`Eq`]: crate::cmp::Eq
 /// [`Ord`]: crate::cmp::Ord
@@ -168,9 +166,6 @@ pub trait AsRef<T: ?Sized> {
 ///
 /// **Note: This trait must not fail**. If the conversion can fail, use a
 /// dedicated method which returns an [`Option<T>`] or a [`Result<T, E>`].
-///
-/// [`Option<T>`]: Option
-/// [`Result<T, E>`]: Result
 ///
 /// # Generic Implementations
 ///
@@ -270,8 +265,6 @@ pub trait AsMut<T: ?Sized> {
 /// is_hello(s);
 /// ```
 ///
-/// [`Option<T>`]: Option
-/// [`Result<T, E>`]: Result
 /// [`String`]: ../../std/string/struct.String.html
 /// [`Vec`]: ../../std/vec/struct.Vec.html
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -359,8 +352,6 @@ pub trait Into<T>: Sized {
 /// }
 /// ```
 ///
-/// [`Option<T>`]: Option
-/// [`Result<T, E>`]: Result
 /// [`String`]: ../../std/string/struct.String.html
 /// [`from`]: From::from
 /// [book]: ../../book/ch09-00-error-handling.html

--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -805,8 +805,6 @@ pub trait Iterator {
     /// assert_eq!(iter.next(), Some(5));
     /// assert_eq!(iter.next(), None);
     /// ```
-    ///
-    /// [`Option<T>`]: Option
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     fn filter_map<B, F>(self, f: F) -> FilterMap<Self, F>

--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -650,7 +650,6 @@ pub unsafe fn zeroed<T>() -> T {
 /// (Notice that the rules around uninitialized integers are not finalized yet, but
 /// until they are, it is advisable to avoid them.)
 ///
-/// [`MaybeUninit<T>`]: MaybeUninit
 /// [uninit]: MaybeUninit::uninit
 /// [assume_init]: MaybeUninit::assume_init
 /// [inv]: MaybeUninit#initialization-invariant

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -512,7 +512,6 @@ impl<T> Option<T> {
     /// result of a function call, it is recommended to use [`ok_or_else`], which is
     /// lazily evaluated.
     ///
-    /// [`Result<T, E>`]: Result
     /// [`Ok(v)`]: Ok
     /// [`Err(err)`]: Err
     /// [`Some(v)`]: Some
@@ -539,7 +538,6 @@ impl<T> Option<T> {
     /// Transforms the `Option<T>` into a [`Result<T, E>`], mapping [`Some(v)`] to
     /// [`Ok(v)`] and [`None`] to [`Err(err())`].
     ///
-    /// [`Result<T, E>`]: Result
     /// [`Ok(v)`]: Ok
     /// [`Err(err())`]: Err
     /// [`Some(v)`]: Some

--- a/library/core/src/pin.rs
+++ b/library/core/src/pin.rs
@@ -349,7 +349,6 @@
 //! mutable reference even when you just have [`Pin`]`<&mut Self>` (such as in your own
 //! [`poll`] implementation).
 //!
-//! [`Pin<P>`]: Pin
 //! [`Deref`]: crate::ops::Deref
 //! [`DerefMut`]: crate::ops::DerefMut
 //! [`mem::swap`]: crate::mem::swap
@@ -364,7 +363,6 @@
 //! [`RefCell<T>`]: crate::cell::RefCell
 //! [`drop`]: Drop::drop
 //! [`VecDeque<T>`]: ../../std/collections/struct.VecDeque.html
-//! [`Option<T>`]: Option
 //! [`Some(v)`]: Some
 //! [`ptr::write`]: crate::ptr::write
 //! [`Future`]: crate::future::Future

--- a/library/core/src/result.rs
+++ b/library/core/src/result.rs
@@ -368,8 +368,6 @@ impl<T, E> Result<T, E> {
     /// Converts `self` into an [`Option<T>`], consuming `self`,
     /// and discarding the error, if any.
     ///
-    /// [`Option<T>`]: Option
-    ///
     /// # Examples
     ///
     /// Basic usage:
@@ -394,8 +392,6 @@ impl<T, E> Result<T, E> {
     ///
     /// Converts `self` into an [`Option<E>`], consuming `self`,
     /// and discarding the success value, if any.
-    ///
-    /// [`Option<E>`]: Option
     ///
     /// # Examples
     ///
@@ -1008,8 +1004,6 @@ impl<T: fmt::Debug, E> Result<T, E> {
     ///
     /// Panics if the value is an [`Ok`], with a custom panic message provided
     /// by the [`Ok`]'s value.
-    ///
-    ///
     ///
     /// # Examples
     ///

--- a/library/std/src/error.rs
+++ b/library/std/src/error.rs
@@ -42,8 +42,6 @@ use crate::string;
 /// via [`Error::source()`]. This makes it possible for the high-level
 /// module to provide its own errors while also revealing some of the
 /// implementation for debugging via `source` chains.
-///
-/// [`Result<T, E>`]: Result
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait Error: Debug + Display {
     /// The lower-level source of this error, if any.

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -240,7 +240,6 @@
 //!
 //! [`File`]: crate::fs::File
 //! [`TcpStream`]: crate::net::TcpStream
-//! [`Vec<T>`]: Vec
 //! [`io::stdout`]: stdout
 //! [`io::Result`]: self::Result
 //! [`?` operator]: ../../book/appendix-02-operators.html
@@ -1984,7 +1983,6 @@ pub trait BufRead: Read {
     /// also yielded an error.
     ///
     /// [`io::Result`]: self::Result
-    /// [`Vec<u8>`]: Vec
     /// [`read_until`]: BufRead::read_until
     ///
     /// # Examples

--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -1775,7 +1775,6 @@ impl Path {
     /// Any non-Unicode sequences are replaced with
     /// [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD].
     ///
-    /// [`Cow<str>`]: Cow
     /// [U+FFFD]: super::char::REPLACEMENT_CHARACTER
     ///
     /// # Examples

--- a/library/std/src/primitive_docs.rs
+++ b/library/std/src/primitive_docs.rs
@@ -184,9 +184,6 @@ mod prim_bool {}
 /// because `!` coerces to `Result<!, ConnectionError>` automatically.
 ///
 /// [`String::from_str`]: str::FromStr::from_str
-/// [`Result<String, !>`]: Result
-/// [`Result<T, !>`]: Result
-/// [`Result<!, E>`]: Result
 /// [`String`]: string::String
 /// [`FromStr`]: str::FromStr
 ///


### PR DESCRIPTION
Now that #76934 has merged, we can remove a lot of these! E.g, this is
no longer necessary:

    [`Vec<T>`]: Vec

cc @jyn514