### PR TITLE
Use a single function for query manipulations

### DIFF
--- a/compiler/rustc_macros/src/query.rs
+++ b/compiler/rustc_macros/src/query.rs
@@ -500,7 +500,7 @@ pub fn rustc_queries(input: TokenStream) -> TokenStream {
                 ::rustc_middle::dep_graph::DepKind::#name => {
                     if <#arg as DepNodeParams<TyCtxt<'_>>>::can_reconstruct_query_key() {
                         if let Some(key) = <#arg as DepNodeParams<TyCtxt<'_>>>::recover($tcx, $dep_node) {
-                            crate::ty::query::queries::#name::query(
+                            call_query::<crate::ty::query::queries::#name<'_>, _>(
                                 $tcx,
                                 DUMMY_SP,
                                 key,

--- a/compiler/rustc_macros/src/query.rs
+++ b/compiler/rustc_macros/src/query.rs
@@ -500,11 +500,11 @@ pub fn rustc_queries(input: TokenStream) -> TokenStream {
                 ::rustc_middle::dep_graph::DepKind::#name => {
                     if <#arg as DepNodeParams<TyCtxt<'_>>>::can_reconstruct_query_key() {
                         if let Some(key) = <#arg as DepNodeParams<TyCtxt<'_>>>::recover($tcx, $dep_node) {
-                            force_query::<crate::ty::query::queries::#name<'_>, _>(
+                            crate::ty::query::queries::#name::query(
                                 $tcx,
-                                key,
                                 DUMMY_SP,
-                                *$dep_node
+                                key,
+                                QueryCaller::Force(*$dep_node),
                             );
                             return true;
                         }

--- a/compiler/rustc_middle/src/ty/query/plumbing.rs
+++ b/compiler/rustc_middle/src/ty/query/plumbing.rs
@@ -402,19 +402,6 @@ macro_rules! define_queries_inner {
             ) -> Self::Value {
                 handle_cycle_error!([$($modifiers)*][tcx, error])
             }
-        }
-
-        impl queries::$name<$tcx> {
-            $(#[$attr])*
-            #[inline(always)]
-            pub fn query(
-                tcx: TyCtxt<$tcx>,
-                span: Span,
-                key: query_keys::$name<$tcx>,
-                caller: QueryCaller<DepKind>,
-            ) -> Option<<queries::$name<$tcx> as QueryConfig>::Stored> {
-                call_query::<queries::$name<'_>, _>(tcx, span, key, caller)
-            }
         })*
 
         #[derive(Copy, Clone)]
@@ -426,7 +413,7 @@ macro_rules! define_queries_inner {
             $($(#[$attr])*
             #[inline(always)]
             pub fn $name(self, key: query_helper_param_ty!($($K)*)) {
-                queries::$name::query(
+                call_query::<queries::$name<'_>, _>(
                     self.tcx,
                     DUMMY_SP,
                     key.into_query_param(),
@@ -514,7 +501,7 @@ macro_rules! define_queries_inner {
             pub fn $name(self, key: query_helper_param_ty!($($K)*))
                 -> <queries::$name<$tcx> as QueryConfig>::Stored
             {
-                let ret = queries::$name::query(
+                let ret = call_query::<queries::$name<'_>, _>(
                     self.tcx,
                     self.span,
                     key.into_query_param(),

--- a/compiler/rustc_query_system/src/query/plumbing.rs
+++ b/compiler/rustc_query_system/src/query/plumbing.rs
@@ -614,6 +614,8 @@ where
 /// This function is particularly useful when executing passes for their
 /// side-effects -- e.g., in order to report errors for erroneous programs.
 ///
+/// Return `true` if the query has already been executed.
+///
 /// Note: The optimization is only available during incr. comp.
 #[inline(never)]
 fn ensure_query_impl<CTX, K, V>(tcx: CTX, key: &K, query: &QueryVtable<CTX, K, V>) -> bool

--- a/compiler/rustc_query_system/src/query/plumbing.rs
+++ b/compiler/rustc_query_system/src/query/plumbing.rs
@@ -14,6 +14,7 @@ use rustc_data_structures::cold_path;
 use rustc_data_structures::fingerprint::Fingerprint;
 use rustc_data_structures::fx::{FxHashMap, FxHasher};
 use rustc_data_structures::sharded::Sharded;
+use rustc_data_structures::stable_hasher::HashStable;
 use rustc_data_structures::sync::{Lock, LockGuard};
 use rustc_data_structures::thin_vec::ThinVec;
 use rustc_errors::{Diagnostic, FatalError};
@@ -157,7 +158,7 @@ where
 
 impl<'tcx, D, Q, C> JobOwner<'tcx, D, Q, C>
 where
-    D: Copy + Clone + Eq + Hash,
+    D: Copy + Clone + Eq + Hash + DepKind,
     Q: Clone,
     C: QueryCache,
 {
@@ -179,7 +180,8 @@ where
         query: &QueryVtable<CTX, C::Key, C::Value>,
     ) -> TryGetJob<'b, CTX::DepKind, CTX::Query, C>
     where
-        CTX: QueryContext,
+        CTX: QueryContext<DepKind = D, Query = Q>,
+        Q: HashStable<CTX::StableHashingContext>,
     {
         let lock = &mut *lookup.lock;
 
@@ -622,31 +624,6 @@ where
     (result, dep_node_index)
 }
 
-#[inline(never)]
-fn get_query_impl<CTX, C>(
-    tcx: CTX,
-    state: &QueryState<CTX::DepKind, CTX::Query, C>,
-    span: Span,
-    key: C::Key,
-    query: &QueryVtable<CTX, C::Key, C::Value>,
-) -> C::Stored
-where
-    CTX: QueryContext,
-    C: QueryCache,
-    C::Key: crate::dep_graph::DepNodeParams<CTX>,
-{
-    try_get_cached(
-        tcx,
-        state,
-        key,
-        |value, index| {
-            tcx.dep_graph().read_index(index);
-            value.clone()
-        },
-        |key, lookup| try_execute_query(tcx, state, span, key, lookup, query),
-    )
-}
-
 /// Ensure that either this query has all green inputs or been executed.
 /// Executing `query::ensure(D)` is considered a read of the dep-node `D`.
 ///
@@ -686,43 +663,6 @@ where
     }
 }
 
-#[inline(never)]
-fn force_query_impl<CTX, C>(
-    tcx: CTX,
-    state: &QueryState<CTX::DepKind, CTX::Query, C>,
-    key: C::Key,
-    span: Span,
-    dep_node: DepNode<CTX::DepKind>,
-    query: &QueryVtable<CTX, C::Key, C::Value>,
-) where
-    C: QueryCache,
-    C::Key: crate::dep_graph::DepNodeParams<CTX>,
-    CTX: QueryContext,
-{
-    // We may be concurrently trying both execute and force a query.
-    // Ensure that only one of them runs the query.
-
-    try_get_cached(
-        tcx,
-        state,
-        key,
-        |_, _| {
-            // Cache hit, do nothing
-        },
-        |key, lookup| {
-            let job = match JobOwner::<'_, CTX::DepKind, CTX::Query, C>::try_start(
-                tcx, state, span, &key, lookup, query,
-            ) {
-                TryGetJob::NotYetStarted(job) => job,
-                TryGetJob::Cycle(_) => return,
-                #[cfg(parallel_compiler)]
-                TryGetJob::JobCompleted(_) => return,
-            };
-            force_query_with_job(tcx, key, job, dep_node, query);
-        },
-    );
-}
-
 pub enum QueryCaller<DK> {
     Ensure,
     Get,
@@ -744,23 +684,58 @@ where
     C::Stored: Clone,
     CTX: QueryContext,
 {
-    match caller {
-        QueryCaller::Ensure => {
-            if ensure_query_impl(tcx, &key, query) {
-                return None;
-            }
-            let _ = get_query_impl(tcx, state, span, key, query);
-            None
-        }
-        QueryCaller::Get => {
-            let ret = get_query_impl(tcx, state, span, key, query);
-            Some(ret)
-        }
-        QueryCaller::Force(dep_node) => {
-            force_query_impl(tcx, state, key, span, dep_node, query);
-            None
+    if let QueryCaller::Ensure = caller {
+        if ensure_query_impl(tcx, &key, query) {
+            return None;
         }
     }
+
+    try_get_cached(
+        tcx,
+        state,
+        key,
+        |value, index| {
+            match &caller {
+                QueryCaller::Ensure => {
+                    tcx.dep_graph().read_index(index);
+                    None
+                }
+                QueryCaller::Get => {
+                    tcx.dep_graph().read_index(index);
+                    Some(value.clone())
+                }
+                QueryCaller::Force(_) => {
+                    // Cache hit, do nothing
+                    None
+                }
+            }
+        },
+        |key, lookup| {
+            match &caller {
+                QueryCaller::Ensure => {
+                    try_execute_query(tcx, state, span, key, lookup, query);
+                    None
+                }
+                QueryCaller::Get => {
+                    let value = try_execute_query(tcx, state, span, key, lookup, query);
+                    Some(value)
+                }
+                QueryCaller::Force(dep_node) => {
+                    // We may be concurrently trying both execute and force a query.
+                    // Ensure that only one of them runs the query.
+
+                    let job = match JobOwner::try_start(tcx, state, span, &key, lookup, query) {
+                        TryGetJob::NotYetStarted(job) => job,
+                        TryGetJob::Cycle(_) => return None,
+                        #[cfg(parallel_compiler)]
+                        TryGetJob::JobCompleted(_) => return None,
+                    };
+                    force_query_with_job(tcx, key, job, *dep_node, query);
+                    None
+                }
+            }
+        },
+    )
 }
 
 #[inline(always)]

--- a/compiler/rustc_query_system/src/query/plumbing.rs
+++ b/compiler/rustc_query_system/src/query/plumbing.rs
@@ -20,6 +20,7 @@ use rustc_data_structures::thin_vec::ThinVec;
 use rustc_errors::{Diagnostic, FatalError};
 use rustc_span::Span;
 use std::collections::hash_map::Entry;
+use std::fmt::Debug;
 use std::hash::{Hash, Hasher};
 use std::mem;
 use std::num::NonZeroU32;
@@ -425,7 +426,8 @@ where
                 return v;
             }
         };
-        return force_query_with_job(tcx, key, job, *dep_node, query).0;
+        let (result, dep_node_index) = force_query_with_job(tcx, key, job.id, *dep_node, query);
+        return job.complete(result, dep_node_index);
     };
 
     let job = match job {
@@ -442,7 +444,8 @@ where
     // expensive for some `DepKind`s.
     if !tcx.dep_graph().is_fully_enabled() {
         let null_dep_node = DepNode::new_no_params(DepKind::NULL);
-        return force_query_with_job(tcx, key, job, null_dep_node, query).0;
+        let (result, dep_node_index) = force_query_with_job(tcx, key, job.id, null_dep_node, query);
+        return job.complete(result, dep_node_index);
     }
 
     if query.anon {
@@ -492,7 +495,8 @@ where
         }
     }
 
-    let (result, dep_node_index) = force_query_with_job(tcx, key, job, dep_node, query);
+    let (result, dep_node_index) = force_query_with_job(tcx, key, job.id, dep_node, query);
+    let result = job.complete(result, dep_node_index);
     tcx.dep_graph().read_index(dep_node_index);
     result
 }
@@ -586,15 +590,15 @@ fn incremental_verify_ich<CTX, K, V>(
 }
 
 #[inline(always)]
-fn force_query_with_job<C, CTX>(
+fn force_query_with_job<CTX, K, V>(
     tcx: CTX,
-    key: C::Key,
-    job: JobOwner<'_, CTX::DepKind, CTX::Query, C>,
+    key: K,
+    job_id: QueryJobId<CTX::DepKind>,
     dep_node: DepNode<CTX::DepKind>,
-    query: &QueryVtable<CTX, C::Key, C::Value>,
-) -> (C::Stored, DepNodeIndex)
+    query: &QueryVtable<CTX, K, V>,
+) -> (V, DepNodeIndex)
 where
-    C: QueryCache,
+    K: Eq + Clone + Debug,
     CTX: QueryContext,
 {
     // If the following assertion triggers, it can have two reasons:
@@ -614,7 +618,7 @@ where
     let prof_timer = tcx.profiler().query_provider();
 
     let ((result, dep_node_index), diagnostics) = with_diagnostics(|diagnostics| {
-        tcx.start_query(job.id, diagnostics, |tcx| {
+        tcx.start_query(job_id, diagnostics, |tcx| {
             if query.eval_always {
                 tcx.dep_graph().with_eval_always_task(
                     dep_node,
@@ -636,8 +640,6 @@ where
             tcx.store_diagnostics(dep_node_index, diagnostics);
         }
     }
-
-    let result = job.complete(result, dep_node_index);
 
     (result, dep_node_index)
 }

--- a/compiler/rustc_query_system/src/query/plumbing.rs
+++ b/compiler/rustc_query_system/src/query/plumbing.rs
@@ -441,20 +441,17 @@ where
         // promoted to the current session during
         // `try_mark_green()`, so we can ignore them here.
         let loaded = tcx.start_query(job_id, None, |tcx| {
-            let marked = tcx.dep_graph().try_mark_green_and_read(tcx, &dep_node);
-            marked.map(|(prev_dep_node_index, dep_node_index)| {
-                (
-                    load_from_disk_and_cache_in_memory(
-                        tcx,
-                        key.clone(),
-                        prev_dep_node_index,
-                        dep_node_index,
-                        &dep_node,
-                        query,
-                    ),
-                    dep_node_index,
-                )
-            })
+            let (prev_dep_node_index, dep_node_index) =
+                tcx.dep_graph().try_mark_green_and_read(tcx, &dep_node)?;
+            let result = load_from_disk_and_cache_in_memory(
+                tcx,
+                key.clone(),
+                prev_dep_node_index,
+                dep_node_index,
+                &dep_node,
+                query,
+            );
+            Some((result, dep_node_index))
         });
         if let Some((result, dep_node_index)) = loaded {
             return (result, dep_node_index, false);

--- a/compiler/rustc_query_system/src/query/plumbing.rs
+++ b/compiler/rustc_query_system/src/query/plumbing.rs
@@ -562,7 +562,7 @@ fn force_query_with_job<CTX, K, V>(
     query: &QueryVtable<CTX, K, V>,
 ) -> (V, DepNodeIndex)
 where
-    K: Eq + Clone + Debug,
+    K: Debug,
     CTX: QueryContext,
 {
     // If the following assertion triggers, it can have two reasons:


### PR DESCRIPTION
There are three ways to invoke a query: get the value, ensure it runs, or have it automatically forced.

The three corresponding methods are merged into a single point of entry.
The goal is to increase the code sharing between the three cases.