### PR TITLE
Reduce boilerplate with Option::{map, and_then} ...

### DIFF
--- a/compiler/rustc_builtin_macros/src/format_foreign.rs
+++ b/compiler/rustc_builtin_macros/src/format_foreign.rs
@@ -656,17 +656,13 @@ pub mod shell {
     impl<'a> Iterator for Substitutions<'a> {
         type Item = Substitution<'a>;
         fn next(&mut self) -> Option<Self::Item> {
-            match parse_next_substitution(self.s) {
-                Some((mut sub, tail)) => {
-                    self.s = tail;
-                    if let Some(InnerSpan { start, end }) = sub.position() {
-                        sub.set_position(start + self.pos, end + self.pos);
-                        self.pos += end;
-                    }
-                    Some(sub)
-                }
-                None => None,
+            let (mut sub, tail) = parse_next_substitution(self.s)?;
+            self.s = tail;
+            if let Some(InnerSpan { start, end }) = sub.position() {
+                sub.set_position(start + self.pos, end + self.pos);
+                self.pos += end;
             }
+            Some(sub)
         }
 
         fn size_hint(&self) -> (usize, Option<usize>) {

--- a/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
@@ -1156,10 +1156,7 @@ impl<'ll> MemberDescription<'ll> {
                 self.size.bits(),
                 self.align.bits() as u32,
                 self.offset.bits(),
-                match self.discriminant {
-                    None => None,
-                    Some(value) => Some(cx.const_u64(value)),
-                },
+                self.discriminant.map(|v| cx.const_u64(v)),
                 self.flags,
                 self.type_metadata,
             )

--- a/compiler/rustc_codegen_ssa/src/mir/block.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/block.rs
@@ -41,10 +41,7 @@ impl<'a, 'tcx> TerminatorCodegenHelper<'tcx> {
         &self,
         fx: &'b mut FunctionCx<'a, 'tcx, Bx>,
     ) -> Option<&'b Bx::Funclet> {
-        match self.funclet_bb {
-            Some(funcl) => fx.funclets[funcl].as_ref(),
-            None => None,
-        }
+        self.funclet_bb.and_then(move |funcl| fx.funclets[funcl].as_ref())
     }
 
     fn lltarget<Bx: BuilderMethods<'a, 'tcx>>(

--- a/compiler/rustc_middle/src/mir/visit.rs
+++ b/compiler/rustc_middle/src/mir/visit.rs
@@ -1189,12 +1189,12 @@ impl PlaceContext {
 
     /// Returns `true` if this place context represents a storage live marker.
     pub fn is_storage_live_marker(&self) -> bool {
-        matches!(self, PlaceContext::NonUse(NonUseContext::StorageLive))
+        *self == PlaceContext::NonUse(NonUseContext::StorageLive)
     }
 
     /// Returns `true` if this place context represents a storage dead marker.
     pub fn is_storage_dead_marker(&self) -> bool {
-        matches!(self, PlaceContext::NonUse(NonUseContext::StorageDead))
+        *self == PlaceContext::NonUse(NonUseContext::StorageDead)
     }
 
     /// Returns `true` if this place context represents a use that potentially changes the value.

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -1041,10 +1041,7 @@ impl<T> Binder<T> {
 
 impl<T> Binder<Option<T>> {
     pub fn transpose(self) -> Option<Binder<T>> {
-        match self.0 {
-            Some(v) => Some(Binder(v)),
-            None => None,
-        }
+        self.0.map(Binder)
     }
 }
 

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -1766,7 +1766,7 @@ impl<'tcx> TyS<'tcx> {
 
     #[inline]
     pub fn is_never(&self) -> bool {
-        matches!(self.kind(), Never)
+        *self.kind() == Never
     }
 
     /// Checks whether a type is definitely uninhabited. This is
@@ -2019,7 +2019,7 @@ impl<'tcx> TyS<'tcx> {
 
     #[inline]
     pub fn is_char(&self) -> bool {
-        matches!(self.kind(), Char)
+        *self.kind() == Char
     }
 
     #[inline]

--- a/compiler/rustc_mir/src/borrow_check/diagnostics/find_use.rs
+++ b/compiler/rustc_mir/src/borrow_check/diagnostics/find_use.rs
@@ -117,12 +117,13 @@ impl<'cx, 'tcx> Visitor<'tcx> for DefUseVisitor<'cx, 'tcx> {
         });
 
         if found_it {
-            self.def_use_result = match def_use::categorize(context) {
-                Some(DefUse::Def) => Some(DefUseResult::Def),
-                Some(DefUse::Use) => Some(DefUseResult::UseLive { local }),
-                Some(DefUse::Drop) => Some(DefUseResult::UseDrop { local }),
-                None => None,
-            };
+            self.def_use_result = def_use::categorize(context).map(|def_use|
+                match def_use {
+                    DefUse::Def => DefUseResult::Def,
+                    DefUse::Use => DefUseResult::UseLive { local },
+                    DefUse::Drop => DefUseResult::UseDrop { local },
+                }
+            );
         }
     }
 }

--- a/compiler/rustc_mir/src/borrow_check/type_check/input_output.rs
+++ b/compiler/rustc_mir/src/borrow_check/type_check/input_output.rs
@@ -39,10 +39,8 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
             user_provided_sig = None;
         } else {
             let typeck_results = self.tcx().typeck(mir_def_id);
-            user_provided_sig = match typeck_results.user_provided_sigs.get(&mir_def_id.to_def_id())
-            {
-                None => None,
-                Some(user_provided_poly_sig) => {
+            user_provided_sig = typeck_results.user_provided_sigs.get(&mir_def_id.to_def_id()).map(
+                |user_provided_poly_sig| {
                     // Instantiate the canonicalized variables from
                     // user-provided signature (e.g., the `_` in the code
                     // above) with fresh variables.
@@ -54,18 +52,16 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
                     // Replace the bound items in the fn sig with fresh
                     // variables, so that they represent the view from
                     // "inside" the closure.
-                    Some(
-                        self.infcx
-                            .replace_bound_vars_with_fresh_vars(
-                                body.span,
-                                LateBoundRegionConversionTime::FnCall,
-                                &poly_sig,
-                            )
-                            .0,
-                    )
-                }
-            }
-        };
+                    self.infcx
+                        .replace_bound_vars_with_fresh_vars(
+                            body.span,
+                            LateBoundRegionConversionTime::FnCall,
+                            &poly_sig,
+                        )
+                        .0
+                },
+            );
+        }
 
         debug!(
             "equate_inputs_and_outputs: normalized_input_tys = {:?}, local_decls = {:?}",

--- a/compiler/rustc_serialize/src/json.rs
+++ b/compiler/rustc_serialize/src/json.rs
@@ -1500,13 +1500,14 @@ impl Stack {
 
     /// Returns the top-most element (if any).
     pub fn top(&self) -> Option<StackElement<'_>> {
-        match self.stack.last() {
-            None => None,
-            Some(&InternalIndex(i)) => Some(StackElement::Index(i)),
-            Some(&InternalKey(start, size)) => Some(StackElement::Key(
-                str::from_utf8(&self.str_buffer[start as usize..(start + size) as usize]).unwrap(),
-            )),
-        }
+        self.stack.last().map(|stack_elem|
+            match stack_elem {
+                &InternalIndex(i) => StackElement::Index(i),
+                &InternalKey(start, size) => StackElement::Key(
+                    str::from_utf8(&self.str_buffer[start as usize..(start + size) as usize]).unwrap()
+                ),
+            }
+        )
     }
 
     // Used by Parser to insert StackElement::Key elements at the top of the stack.

--- a/compiler/rustc_span/src/hygiene.rs
+++ b/compiler/rustc_span/src/hygiene.rs
@@ -759,7 +759,7 @@ impl ExpnData {
 
     #[inline]
     pub fn is_root(&self) -> bool {
-        matches!(self.kind, ExpnKind::Root)
+        self.kind == ExpnKind::Root
     }
 }
 

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -2395,13 +2395,9 @@ impl<'o, 'tcx> Iterator for TraitObligationStackList<'o, 'tcx> {
     type Item = &'o TraitObligationStack<'o, 'tcx>;
 
     fn next(&mut self) -> Option<&'o TraitObligationStack<'o, 'tcx>> {
-        match self.head {
-            Some(o) => {
-                *self = o.previous;
-                Some(o)
-            }
-            None => None,
-        }
+        let o = self.head?;
+        *self = o.previous;
+        Some(o)
     }
 }
 

--- a/compiler/rustc_typeck/src/check/demand.rs
+++ b/compiler/rustc_typeck/src/check/demand.rs
@@ -799,10 +799,12 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 // can be given the suggestion "u32::from(x) > y" rather than
                 // "x > y.try_into().unwrap()".
                 let lhs_expr_and_src = expected_ty_expr.and_then(|expr| {
-                    match self.tcx.sess.source_map().span_to_snippet(expr.span).ok() {
-                        Some(src) => Some((expr, src)),
-                        None => None,
-                    }
+                    self.tcx
+                        .sess
+                        .source_map()
+                        .span_to_snippet(expr.span)
+                        .ok()
+                        .map(|src| (expr, src))
                 });
                 let (span, msg, suggestion) = if let (Some((lhs_expr, lhs_src)), false) =
                     (lhs_expr_and_src, exp_to_found_is_fallible)


### PR DESCRIPTION
A smattering of unrelated boilerplate reductions mostly using various methods on Options.

Note that a few hunks currently do not pass `./x.py fmt --check`. The formatter wants me to un-break lines which I somewhat strongly feel makes the code less readable. The first question would be if you even agree with me in this assessment. The second question is what to do about it. Accept the formatter's output as gospel? `#[rustfmt::skip]`? Somehow improve the formatter to produce better output?


Below are two examples. Notice how in [1] the `match stack_elem` kinda melts into the `map` call and looses visual relation to its body a bit. [2] has the same problem with the `filter` call. Additionally, for the pattern of the first match arm in the innermost `match`, it's much harder to see that both elements of the tuple are almost identical. So many parenthesis with so little visual structure.... 

Edit: Red is what's proposed here, green is what the formatter wants.
[1]
![match_unsplit](https://user-images.githubusercontent.com/18645382/95690760-3e5e9100-0c1a-11eb-8b1a-136a801564cf.png)
[2]
![inner_match](https://user-images.githubusercontent.com/18645382/95690761-428aae80-0c1a-11eb-8b8d-52ccf903c5e9.png)

