### PR TITLE
build-manifest: stop generating numbered channel names except for stable

### DIFF
--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -252,12 +252,13 @@ impl Builder {
         }
         let manifest = self.build_manifest();
 
-        let rust_version = self.versions.rustc_version();
         self.write_channel_files(self.versions.channel(), &manifest);
-        if self.versions.channel() != rust_version {
-            self.write_channel_files(&rust_version, &manifest);
-        }
         if self.versions.channel() == "stable" {
+            // channel-rust-1.XX.YY.toml
+            let rust_version = self.versions.rustc_version();
+            self.write_channel_files(rust_version, &manifest);
+
+            // channel-rust-1.XX.toml
             let major_minor = rust_version.split('.').take(2).collect::<Vec<_>>().join(".");
             self.write_channel_files(&major_minor, &manifest);
         }


### PR DESCRIPTION
This fixes numbered channel names being created for the nightly channel, and once the root cause of this rides the trains, for beta.

r? @Mark-Simulacrum 