### PR TITLE
Rustdoc: Fix macros 2.0 and built-in derives being shown at the wrong path

### DIFF
--- a/library/std/src/prelude/v1.rs
+++ b/library/std/src/prelude/v1.rs
@@ -41,17 +41,17 @@ pub use crate::result::Result::{self, Err, Ok};
 pub use core::prelude::v1::{
     asm, assert, cfg, column, compile_error, concat, concat_idents, env, file, format_args,
     format_args_nl, global_asm, include, include_bytes, include_str, line, llvm_asm, log_syntax,
-    module_path, option_env, stringify, trace_macros,
+    module_path, option_env, stringify, trace_macros, Clone, Copy, Debug, Default, Eq, Hash, Ord,
+    PartialEq, PartialOrd,
 };
 
-// FIXME: Attribute and derive macros are not documented because for them rustdoc generates
+// FIXME: Attribute and internal derive macros are not documented because for them rustdoc generates
 // dead links which fail link checker testing.
 #[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
 #[allow(deprecated)]
 #[doc(hidden)]
 pub use core::prelude::v1::{
-    bench, global_allocator, test, test_case, Clone, Copy, Debug, Default, Eq, Hash, Ord,
-    PartialEq, PartialOrd, RustcDecodable, RustcEncodable,
+    bench, global_allocator, test, test_case, RustcDecodable, RustcEncodable,
 };
 
 #[unstable(

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -173,8 +173,8 @@ crate fn record_extern_fqn(cx: &DocContext<'_>, did: DefId, kind: clean::TypeKin
         if matches!(
             cx.enter_resolver(|r| r.cstore().load_macro_untracked(did, cx.sess())),
             LoadedMacro::MacroDef(def, _)
-                if matches!(&def.kind, ast::ItemKind::MacroDef(def)
-                    if !def.macro_rules)
+                if matches!(&def.kind, ast::ItemKind::MacroDef(ast_def)
+                    if !ast_def.macro_rules)
         ) {
             once(crate_name).chain(relative).collect()
         } else {

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -169,7 +169,17 @@ crate fn record_extern_fqn(cx: &DocContext<'_>, did: DefId, kind: clean::TypeKin
         if !s.is_empty() { Some(s) } else { None }
     });
     let fqn = if let clean::TypeKind::Macro = kind {
-        vec![crate_name, relative.last().expect("relative was empty")]
+        // Check to see if it is a macro 2.0 or built-in macro
+        if matches!(
+            cx.enter_resolver(|r| r.cstore().load_macro_untracked(did, cx.sess())),
+            LoadedMacro::MacroDef(def, _)
+                if matches!(&def.kind, ast::ItemKind::MacroDef(def)
+                    if !def.macro_rules)
+        ) {
+            once(crate_name).chain(relative).collect()
+        } else {
+            vec![crate_name, relative.last().expect("relative was empty")]
+        }
     } else {
         once(crate_name).chain(relative).collect()
     };

--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -93,38 +93,24 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
             });
             // HACK: rustdoc has no way to lookup `doctree::Module`s by their HirId. Instead,
             // lookup the module by its name, by looking at each path segment one at a time.
-            // Once #80415 is merged, this whole `for` loop research can be replaced by that.
             let mut cur_mod = &mut top_level_module;
             for path_segment in macro_parent_module.data {
+                // Path segments may refer to a module (in which case they belong to the type
+                // namespace), which is _necessary_ for the macro to be accessible outside it
+                // (no "associated macros" as of yet). Else we bail with an outer `continue`.
                 let path_segment_ty_ns = match path_segment.data {
                     rustc_hir::definitions::DefPathData::TypeNs(symbol) => symbol,
-                    _ => {
-                        // If the path segment is not from the type namespace
-                        // (_e.g._, it can be from a value namespace in the case of `f::` in:
-                        // `fn f() { pub macro m() {} }`
-                        // then the item is not accessible, and should thus act as if it didn't
-                        // exist (unless "associated macros" (inside an `impl`) were a thing…).
-                        continue 'exported_macros;
-                    }
+                    _ => continue 'exported_macros,
                 };
-                // The obtained name in the type namespace may belong to something that is not
-                // a `mod`ule (_e.g._, it could be an `enum` with a `pub macro` defined within
-                // the block used for a discriminant.
-                if let Some(child_mod) =
-                    cur_mod.mods.iter_mut().find(|module| module.name == Some(path_segment_ty_ns))
-                {
-                    cur_mod = child_mod;
-                } else {
-                    // If the macro's parent def path is not exclusively made of module
-                    // components, then it is not accessible (c.f. previous `continue`).
-                    continue 'exported_macros;
+                // Descend into the child module that matches this path segment (if any).
+                match cur_mod.mods.iter_mut().find(|child| child.name == Some(path_segment_ty_ns)) {
+                    Some(child_mod) => cur_mod = &mut *child_mod,
+                    None => continue 'exported_macros,
                 }
             }
             cur_mod.macros.push((def, None));
         }
-
         self.cx.renderinfo.get_mut().exact_paths = self.exact_paths;
-
         top_level_module
     }
 

--- a/src/test/rustdoc/auxiliary/macro_pub_in_module.rs
+++ b/src/test/rustdoc/auxiliary/macro_pub_in_module.rs
@@ -8,6 +8,6 @@ pub mod some_module {
     mod private {
         pub macro external_macro() {}
     }
-    // @has external_crate/some_module/macro.external_macro.html
+
     pub use private::external_macro;
 }

--- a/src/test/rustdoc/auxiliary/macro_pub_in_module.rs
+++ b/src/test/rustdoc/auxiliary/macro_pub_in_module.rs
@@ -1,0 +1,13 @@
+// edition:2018
+
+#![feature(decl_macro)]
+#![crate_name = "external_crate"]
+
+pub mod some_module {
+    /* == Make sure the logic is not affected by a re-export == */
+    mod private {
+        pub macro external_macro() {}
+    }
+    // @has external_crate/some_module/macro.external_macro.html
+    pub use private::external_macro;
+}

--- a/src/test/rustdoc/macro_pub_in_module.rs
+++ b/src/test/rustdoc/macro_pub_in_module.rs
@@ -1,9 +1,17 @@
 //! See issue #74355
+#![feature(decl_macro, no_core, rustc_attrs)]
 #![crate_name = "krate"]
-#![feature(decl_macro)]
+#![no_core]
 
-// @has krate/some_module/macro.my_macro.html
-pub mod some_module {
-    //
+pub mod inner {
+    // @has krate/inner/macro.my_macro.html
     pub macro my_macro() {}
+
+    // @has krate/inner/macro.test.html
+    #[rustc_builtin_macro]
+    pub macro test($item:item) {}
+
+    // @has krate/inner/macro.Clone.html
+    #[rustc_builtin_macro]
+    pub macro Clone($item:item) {}
 }

--- a/src/test/rustdoc/macro_pub_in_module.rs
+++ b/src/test/rustdoc/macro_pub_in_module.rs
@@ -7,7 +7,8 @@
 #![crate_name = "krate"]
 #![no_core]
 
-// @has external_crate/some_module/macro.external_macro.html
+ // @has external_crate/some_module/macro.external_macro.html
+  // @!has external_crate/macro.external_macro.html
 extern crate external_crate;
 
 pub mod inner {

--- a/src/test/rustdoc/macro_pub_in_module.rs
+++ b/src/test/rustdoc/macro_pub_in_module.rs
@@ -1,11 +1,18 @@
+// aux-build:macro_pub_in_module.rs
+// edition:2018
+// build-aux-docs
+// @has external_crate/some_module/macro.external_macro.html
+
 //! See issue #74355
 #![feature(decl_macro, no_core, rustc_attrs)]
 #![crate_name = "krate"]
 #![no_core]
 
+extern crate external_crate;
+
 pub mod inner {
-    // @has krate/inner/macro.my_macro.html
-    pub macro my_macro() {}
+    // @has krate/inner/macro.raw_const.html
+    pub macro raw_const() {}
 
     // @has krate/inner/macro.test.html
     #[rustc_builtin_macro]
@@ -14,4 +21,29 @@ pub mod inner {
     // @has krate/inner/macro.Clone.html
     #[rustc_builtin_macro]
     pub macro Clone($item:item) {}
+
+    // Make sure the logic is not affected by a re-export.
+    mod private {
+        pub macro m() {}
+    }
+    // @has krate/inner/macro.renamed.html
+    pub use private::m as renamed;
+
+    // @has krate/inner/macro.external_macro.html
+    pub use ::external_crate::some_module::external_macro;
+}
+
+// Namespaces: Make sure the logic does not mix up a function name with a module name…
+fn both_fn_and_mod() {
+    pub macro m() {}
+}
+pub mod both_fn_and_mod {
+    // @!has krate/both_fn_and_mod/macro.m.html
+}
+
+const __: () = {
+    pub macro m() {}
+};
+pub mod __ {
+    // @!has krate/__/macro.m.html
 }

--- a/src/test/rustdoc/macro_pub_in_module.rs
+++ b/src/test/rustdoc/macro_pub_in_module.rs
@@ -1,49 +1,73 @@
 // aux-build:macro_pub_in_module.rs
 // edition:2018
 // build-aux-docs
-// @has external_crate/some_module/macro.external_macro.html
 
 //! See issue #74355
 #![feature(decl_macro, no_core, rustc_attrs)]
 #![crate_name = "krate"]
 #![no_core]
 
+// @has external_crate/some_module/macro.external_macro.html
 extern crate external_crate;
 
 pub mod inner {
     // @has krate/inner/macro.raw_const.html
+    // @!has krate/macro.raw_const.html
     pub macro raw_const() {}
 
     // @has krate/inner/macro.test.html
+    // @!has krate/macro.test.html
     #[rustc_builtin_macro]
     pub macro test($item:item) {}
 
     // @has krate/inner/macro.Clone.html
+    // @!has krate/macro.Clone.html
     #[rustc_builtin_macro]
     pub macro Clone($item:item) {}
 
-    // Make sure the logic is not affected by a re-export.
+    // Make sure the logic is not affected by re-exports.
+    mod unrenamed {
+        // @!has krate/macro.unrenamed.html
+        #[rustc_macro_transparency = "semitransparent"]
+        pub macro unrenamed() {}
+    }
+    // @has krate/inner/macro.unrenamed.html
+    pub use unrenamed::unrenamed;
+
     mod private {
+        // @!has krate/macro.m.html
         pub macro m() {}
     }
     // @has krate/inner/macro.renamed.html
+    // @!has krate/macro.renamed.html
     pub use private::m as renamed;
 
+    mod private2 {
+        // @!has krate/macro.m2.html
+        pub macro m2() {}
+    }
+    use private2 as renamed_mod;
+    // @has krate/inner/macro.m2.html
+    pub use renamed_mod::m2;
+
     // @has krate/inner/macro.external_macro.html
+    // @!has krate/macro.external_macro.html
     pub use ::external_crate::some_module::external_macro;
 }
 
 // Namespaces: Make sure the logic does not mix up a function name with a module name…
 fn both_fn_and_mod() {
-    pub macro m() {}
+    // @!has krate/macro.in_both_fn_and_mod.html
+    pub macro in_both_fn_and_mod() {}
 }
 pub mod both_fn_and_mod {
-    // @!has krate/both_fn_and_mod/macro.m.html
+    // @!has krate/both_fn_and_mod/macro.in_both_fn_and_mod.html
 }
 
 const __: () = {
-    pub macro m() {}
+    // @!has krate/macro.in_both_const_and_mod.html
+    pub macro in_both_const_and_mod() {}
 };
 pub mod __ {
-    // @!has krate/__/macro.m.html
+    // @!has krate/__/macro.in_both_const_and_mod.html
 }

--- a/src/test/rustdoc/macro_pub_in_module.rs
+++ b/src/test/rustdoc/macro_pub_in_module.rs
@@ -1,0 +1,9 @@
+//! See issue #74355
+#![crate_name = "krate"]
+#![feature(decl_macro)]
+
+// @has krate/some_module/macro.my_macro.html
+pub mod some_module {
+    //
+    pub macro my_macro() {}
+}

--- a/src/test/rustdoc/macro_pub_in_module.rs
+++ b/src/test/rustdoc/macro_pub_in_module.rs
@@ -72,3 +72,11 @@ const __: () = {
 pub mod __ {
     // @!has krate/__/macro.in_both_const_and_mod.html
 }
+
+enum Enum {
+    Crazy = {
+        // @!has krate/macro.this_is_getting_weird.html;
+        pub macro this_is_getting_weird() {}
+        42
+    },
+}


### PR DESCRIPTION
Fixes #74355

  - ~~waiting on author + draft PR since my code ought to be cleaned up _w.r.t._ the way I avoid the `.unwrap()`s:~~

      - ~~dummy items may avoid the first `?`,~~

      - ~~but within the module traversal some tests did fail (hence the second `?`), meaning the crate did not possess the exact path of the containing module (`extern` / `impl` blocks maybe? I'll look into that).~~

r? @jyn514