### PR TITLE
Use Pin to pin RWLock.

### DIFF
--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -289,6 +289,7 @@
 #![feature(panic_info_message)]
 #![feature(panic_internals)]
 #![feature(panic_unwind)]
+#![feature(pin_static_ref)]
 #![feature(prelude_import)]
 #![feature(ptr_internals)]
 #![feature(raw)]

--- a/library/std/src/sync/rwlock.rs
+++ b/library/std/src/sync/rwlock.rs
@@ -5,6 +5,7 @@ use crate::cell::UnsafeCell;
 use crate::fmt;
 use crate::mem;
 use crate::ops::{Deref, DerefMut};
+use crate::pin::Pin;
 use crate::ptr;
 use crate::sys_common::poison::{self, LockResult, TryLockError, TryLockResult};
 use crate::sys_common::rwlock as sys;
@@ -64,7 +65,7 @@ use crate::sys_common::rwlock as sys;
 /// [`Mutex`]: super::Mutex
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct RwLock<T: ?Sized> {
-    inner: Box<sys::RWLock>,
+    inner: Pin<Box<sys::RWLock>>,
     poison: poison::Flag,
     data: UnsafeCell<T>,
 }
@@ -128,7 +129,7 @@ impl<T> RwLock<T> {
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn new(t: T) -> RwLock<T> {
         RwLock {
-            inner: box sys::RWLock::new(),
+            inner: Box::pin(sys::RWLock::new()),
             poison: poison::Flag::new(),
             data: UnsafeCell::new(t),
         }
@@ -178,10 +179,9 @@ impl<T: ?Sized> RwLock<T> {
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn read(&self) -> LockResult<RwLockReadGuard<'_, T>> {
-        unsafe {
-            self.inner.read();
-            RwLockReadGuard::new(self)
-        }
+        self.inner.as_ref().read();
+        // SAFETY: We've gotten a read-lock on the rwlock.
+        unsafe { RwLockReadGuard::new(self) }
     }
 
     /// Attempts to acquire this rwlock with shared read access.
@@ -217,12 +217,11 @@ impl<T: ?Sized> RwLock<T> {
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn try_read(&self) -> TryLockResult<RwLockReadGuard<'_, T>> {
-        unsafe {
-            if self.inner.try_read() {
-                Ok(RwLockReadGuard::new(self)?)
-            } else {
-                Err(TryLockError::WouldBlock)
-            }
+        if self.inner.as_ref().try_read() {
+            // SAFETY: We've gotten a read-lock on the rwlock.
+            unsafe { Ok(RwLockReadGuard::new(self)?) }
+        } else {
+            Err(TryLockError::WouldBlock)
         }
     }
 
@@ -260,10 +259,9 @@ impl<T: ?Sized> RwLock<T> {
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn write(&self) -> LockResult<RwLockWriteGuard<'_, T>> {
-        unsafe {
-            self.inner.write();
-            RwLockWriteGuard::new(self)
-        }
+        self.inner.as_ref().write();
+        // SAFETY: We've gotten a write-lock on the rwlock.
+        unsafe { RwLockWriteGuard::new(self) }
     }
 
     /// Attempts to lock this rwlock with exclusive write access.
@@ -299,12 +297,11 @@ impl<T: ?Sized> RwLock<T> {
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn try_write(&self) -> TryLockResult<RwLockWriteGuard<'_, T>> {
-        unsafe {
-            if self.inner.try_write() {
-                Ok(RwLockWriteGuard::new(self)?)
-            } else {
-                Err(TryLockError::WouldBlock)
-            }
+        if self.inner.as_ref().try_write() {
+            // SAFETY: We've gotten a write-lock on the rwlock.
+            unsafe { Ok(RwLockWriteGuard::new(self)?) }
+        } else {
+            Err(TryLockError::WouldBlock)
         }
     }
 
@@ -374,7 +371,6 @@ impl<T: ?Sized> RwLock<T> {
                 (ptr::read(inner), ptr::read(poison), ptr::read(data))
             };
             mem::forget(self);
-            inner.destroy(); // Keep in sync with the `Drop` impl.
             drop(inner);
 
             poison::map_result(poison.borrow(), |_| data.into_inner())
@@ -406,14 +402,6 @@ impl<T: ?Sized> RwLock<T> {
     pub fn get_mut(&mut self) -> LockResult<&mut T> {
         let data = self.data.get_mut();
         poison::map_result(self.poison.borrow(), |_| data)
-    }
-}
-
-#[stable(feature = "rust1", since = "1.0.0")]
-unsafe impl<#[may_dangle] T: ?Sized> Drop for RwLock<T> {
-    fn drop(&mut self) {
-        // IMPORTANT: This code needs to be kept in sync with `RwLock::into_inner`.
-        unsafe { self.inner.destroy() }
     }
 }
 
@@ -524,8 +512,10 @@ impl<T: ?Sized> DerefMut for RwLockWriteGuard<'_, T> {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: ?Sized> Drop for RwLockReadGuard<'_, T> {
     fn drop(&mut self) {
+        // SAFETY: The fact that we have a RwLockReadGuard proves this thread
+        // has this rwlock read-locked.
         unsafe {
-            self.lock.inner.read_unlock();
+            self.lock.inner.as_ref().read_unlock();
         }
     }
 }
@@ -534,8 +524,10 @@ impl<T: ?Sized> Drop for RwLockReadGuard<'_, T> {
 impl<T: ?Sized> Drop for RwLockWriteGuard<'_, T> {
     fn drop(&mut self) {
         self.lock.poison.done(&self.poison);
+        // SAFETY: The fact that we have a RwLockWriteGuard proves this thread
+        // has this rwlock write-locked.
         unsafe {
-            self.lock.inner.write_unlock();
+            self.lock.inner.as_ref().write_unlock();
         }
     }
 }

--- a/library/std/src/sys_common/rwlock.rs
+++ b/library/std/src/sys_common/rwlock.rs
@@ -1,3 +1,4 @@
+use crate::pin::Pin;
 use crate::sys::rwlock as imp;
 
 /// An OS-based reader-writer lock.
@@ -18,53 +19,41 @@ impl RWLock {
 
     /// Acquires shared access to the underlying lock, blocking the current
     /// thread to do so.
-    ///
-    /// Behavior is undefined if the rwlock has been moved between this and any
-    /// previous method call.
     #[inline]
-    pub unsafe fn read(&self) {
-        self.0.read()
+    pub fn read(self: Pin<&Self>) {
+        unsafe { self.0.read() }
     }
 
     /// Attempts to acquire shared access to this lock, returning whether it
     /// succeeded or not.
     ///
     /// This function does not block the current thread.
-    ///
-    /// Behavior is undefined if the rwlock has been moved between this and any
-    /// previous method call.
     #[inline]
-    pub unsafe fn try_read(&self) -> bool {
-        self.0.try_read()
+    pub fn try_read(self: Pin<&Self>) -> bool {
+        unsafe { self.0.try_read() }
     }
 
     /// Acquires write access to the underlying lock, blocking the current thread
     /// to do so.
-    ///
-    /// Behavior is undefined if the rwlock has been moved between this and any
-    /// previous method call.
     #[inline]
-    pub unsafe fn write(&self) {
-        self.0.write()
+    pub fn write(self: Pin<&Self>) {
+        unsafe { self.0.write() }
     }
 
     /// Attempts to acquire exclusive access to this lock, returning whether it
     /// succeeded or not.
     ///
     /// This function does not block the current thread.
-    ///
-    /// Behavior is undefined if the rwlock has been moved between this and any
-    /// previous method call.
     #[inline]
-    pub unsafe fn try_write(&self) -> bool {
-        self.0.try_write()
+    pub fn try_write(self: Pin<&Self>) -> bool {
+        unsafe { self.0.try_write() }
     }
 
     /// Unlocks previously acquired shared access to this lock.
     ///
     /// Behavior is undefined if the current thread does not have shared access.
     #[inline]
-    pub unsafe fn read_unlock(&self) {
+    pub unsafe fn read_unlock(self: Pin<&Self>) {
         self.0.read_unlock()
     }
 
@@ -73,16 +62,16 @@ impl RWLock {
     /// Behavior is undefined if the current thread does not currently have
     /// exclusive access.
     #[inline]
-    pub unsafe fn write_unlock(&self) {
+    pub unsafe fn write_unlock(self: Pin<&Self>) {
         self.0.write_unlock()
     }
+}
 
-    /// Destroys OS-related resources with this RWLock.
-    ///
-    /// Behavior is undefined if there are any currently active users of this
-    /// lock.
+impl Drop for RWLock {
     #[inline]
-    pub unsafe fn destroy(&self) {
-        self.0.destroy()
+    fn drop(&mut self) {
+        // SAFETY: The rwlock wasn't moved since using any of its
+        // functions, because they all require a Pin.
+        unsafe { self.0.destroy() }
     }
 }


### PR DESCRIPTION
Use Pin to guarantee the no-moving requirement of `sys_common::RWLock`.

This makes some things safe that were unsafe before.

`sys_common::RWLock::destroy` is now changed to a regular (safe) Drop implementation, because it no longer has unsafe requirements.

This change leaves the unsafe `sys::RwLock` untouched. Those implementations should probably also use a `Pin` to make them a bit safer, and move their `destroy()` to `Drop`. But that can be a later change. (I want to wait for #77666 and #77657 before touching `sys`.)

---

r? @withoutboats 

Following our conversation on Zulip, this is a better example where `Pin<&Self>` is useful.