### PR TITLE
Include `llvm-dis`, `llc` and `opt` in `llvm-tools-preview` component

### DIFF
--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -177,6 +177,9 @@ const LLVM_TOOLS: &[&str] = &[
     "llvm-size", // used to prints the size of the linker sections of a program
     "llvm-strip", // used to discard symbols from binary files to reduce their size
     "llvm-ar", // used for creating and modifying archive files
+    "llvm-dis", // used to disassemble LLVM bitcode
+    "llc",     // used to compile LLVM bytecode
+    "opt",     // used to optimize LLVM bytecode
 ];
 
 /// A structure representing a Rust compiler.


### PR DESCRIPTION
Fixes #55890

It's useful to have `llc` and `opt` available when debugging an LLVM
miscompilation,.