### PR TITLE
Use `try{}` in `try_fold` to decouple iterators in the library from `Try` details

### DIFF
--- a/library/core/src/iter/adapters/chain.rs
+++ b/library/core/src/iter/adapters/chain.rs
@@ -109,7 +109,7 @@ where
             acc = b.try_fold(acc, f)?;
             // we don't fuse the second iterator
         }
-        Try::from_ok(acc)
+        try { acc }
     }
 
     fn fold<Acc, F>(self, mut acc: Acc, mut f: F) -> Acc
@@ -292,7 +292,7 @@ where
             acc = a.try_rfold(acc, f)?;
             // we don't fuse the second iterator
         }
-        Try::from_ok(acc)
+        try { acc }
     }
 
     fn rfold<Acc, F>(self, mut acc: Acc, mut f: F) -> Acc

--- a/library/core/src/iter/adapters/flatten.rs
+++ b/library/core/src/iter/adapters/flatten.rs
@@ -317,7 +317,7 @@ where
         }
         self.backiter = None;
 
-        Try::from_ok(init)
+        try { init }
     }
 
     #[inline]
@@ -397,7 +397,7 @@ where
         }
         self.frontiter = None;
 
-        Try::from_ok(init)
+        try { init }
     }
 
     #[inline]

--- a/library/core/src/iter/adapters/fuse.rs
+++ b/library/core/src/iter/adapters/fuse.rs
@@ -303,7 +303,7 @@ where
             acc = iter.try_fold(acc, fold)?;
             self.iter = None;
         }
-        Try::from_ok(acc)
+        try { acc }
     }
 
     #[inline]
@@ -353,7 +353,7 @@ where
             acc = iter.try_rfold(acc, fold)?;
             self.iter = None;
         }
-        Try::from_ok(acc)
+        try { acc }
     }
 
     #[inline]

--- a/library/core/src/iter/adapters/mod.rs
+++ b/library/core/src/iter/adapters/mod.rs
@@ -2381,11 +2381,7 @@ where
         }
 
         let n = self.len();
-        if n == 0 {
-            try { init }
-        } else {
-            self.iter.try_rfold(init, check(n, fold)).into_try()
-        }
+        if n == 0 { try { init } } else { self.iter.try_rfold(init, check(n, fold)).into_try() }
     }
 
     fn rfold<Acc, Fold>(mut self, init: Acc, fold: Fold) -> Acc

--- a/library/core/src/iter/adapters/mod.rs
+++ b/library/core/src/iter/adapters/mod.rs
@@ -579,7 +579,7 @@ where
         })?;
 
         if is_empty {
-            return Try::from_ok(acc);
+            return try { acc };
         }
 
         loop {
@@ -715,7 +715,7 @@ where
         if self.first_take {
             self.first_take = false;
             match self.iter.next() {
-                None => return Try::from_ok(acc),
+                None => return try { acc },
                 Some(x) => acc = f(acc, x)?,
             }
         }
@@ -792,7 +792,7 @@ where
         }
 
         match self.next_back() {
-            None => Try::from_ok(init),
+            None => try { init },
             Some(x) => {
                 let acc = f(init, x)?;
                 from_fn(nth_back(&mut self.iter, self.step)).try_fold(acc, f)
@@ -1075,7 +1075,7 @@ fn filter_try_fold<'a, T, Acc, R: Try<Ok = Acc>>(
     predicate: &'a mut impl FnMut(&T) -> bool,
     mut fold: impl FnMut(Acc, T) -> R + 'a,
 ) -> impl FnMut(Acc, T) -> R + 'a {
-    move |acc, item| if predicate(&item) { fold(acc, item) } else { R::from_ok(acc) }
+    move |acc, item| if predicate(&item) { fold(acc, item) } else { try { acc } }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -1229,7 +1229,7 @@ fn filter_map_try_fold<'a, T, B, Acc, R: Try<Ok = Acc>>(
 ) -> impl FnMut(Acc, T) -> R + 'a {
     move |acc, item| match f(item) {
         Some(x) => fold(acc, x),
-        None => R::from_ok(acc),
+        None => try { acc },
     }
 }
 
@@ -1660,7 +1660,7 @@ impl<I: Iterator> Iterator for Peekable<I> {
         R: Try<Ok = B>,
     {
         let acc = match self.peeked.take() {
-            Some(None) => return Try::from_ok(init),
+            Some(None) => return try { init },
             Some(Some(v)) => f(init, v)?,
             None => init,
         };
@@ -1703,7 +1703,7 @@ where
         R: Try<Ok = B>,
     {
         match self.peeked.take() {
-            Some(None) => Try::from_ok(init),
+            Some(None) => try { init },
             Some(Some(v)) => match self.iter.try_rfold(init, &mut f).into_result() {
                 Ok(acc) => f(acc, v),
                 Err(e) => {
@@ -1938,7 +1938,7 @@ where
         if !self.flag {
             match self.next() {
                 Some(v) => init = fold(init, v)?,
-                None => return Try::from_ok(init),
+                None => return try { init },
             }
         }
         self.iter.try_fold(init, fold)
@@ -2065,13 +2065,13 @@ where
                     ControlFlow::from_try(fold(acc, x))
                 } else {
                     *flag = true;
-                    ControlFlow::Break(Try::from_ok(acc))
+                    ControlFlow::Break(try { acc })
                 }
             }
         }
 
         if self.flag {
-            Try::from_ok(init)
+            try { init }
         } else {
             let flag = &mut self.flag;
             let p = &mut self.predicate;
@@ -2180,7 +2180,7 @@ where
         let Self { iter, predicate } = self;
         iter.try_fold(init, |acc, x| match predicate(x) {
             Some(item) => ControlFlow::from_try(fold(acc, item)),
-            None => ControlFlow::Break(Try::from_ok(acc)),
+            None => ControlFlow::Break(try { acc }),
         })
         .into_try()
     }
@@ -2316,7 +2316,7 @@ where
         if n > 0 {
             // nth(n) skips n+1
             if self.iter.nth(n - 1).is_none() {
-                return Try::from_ok(init);
+                return try { init };
             }
         }
         self.iter.try_fold(init, fold)
@@ -2382,7 +2382,7 @@ where
 
         let n = self.len();
         if n == 0 {
-            Try::from_ok(init)
+            try { init }
         } else {
             self.iter.try_rfold(init, check(n, fold)).into_try()
         }
@@ -2509,7 +2509,7 @@ where
         }
 
         if self.n == 0 {
-            Try::from_ok(init)
+            try { init }
         } else {
             let n = &mut self.n;
             self.iter.try_fold(init, check(n, fold)).into_try()
@@ -2587,11 +2587,11 @@ where
         R: Try<Ok = Acc>,
     {
         if self.n == 0 {
-            Try::from_ok(init)
+            try { init }
         } else {
             let len = self.iter.len();
             if len > self.n && self.iter.nth_back(len - self.n - 1).is_none() {
-                Try::from_ok(init)
+                try { init }
             } else {
                 self.iter.try_rfold(init, fold)
             }
@@ -2687,7 +2687,7 @@ where
             mut fold: impl FnMut(Acc, B) -> R + 'a,
         ) -> impl FnMut(Acc, T) -> ControlFlow<Acc, R> + 'a {
             move |acc, x| match f(state, x) {
-                None => ControlFlow::Break(Try::from_ok(acc)),
+                None => ControlFlow::Break(try { acc }),
                 Some(x) => ControlFlow::from_try(fold(acc, x)),
             }
         }
@@ -2951,7 +2951,7 @@ where
                 Ok(x) => ControlFlow::from_try(f(acc, x)),
                 Err(e) => {
                     *error = Err(e);
-                    ControlFlow::Break(Try::from_ok(acc))
+                    ControlFlow::Break(try { acc })
                 }
             })
             .into_try()

--- a/library/core/src/iter/range.rs
+++ b/library/core/src/iter/range.rs
@@ -713,7 +713,7 @@ impl<A: Step> Iterator for ops::RangeInclusive<A> {
         R: Try<Ok = B>,
     {
         if self.is_empty() {
-            return Try::from_ok(init);
+            return try { init };
         }
 
         let mut accum = init;
@@ -731,7 +731,7 @@ impl<A: Step> Iterator for ops::RangeInclusive<A> {
             accum = f(accum, self.start.clone())?;
         }
 
-        Try::from_ok(accum)
+        try { accum }
     }
 
     #[inline]
@@ -818,7 +818,7 @@ impl<A: Step> DoubleEndedIterator for ops::RangeInclusive<A> {
         R: Try<Ok = B>,
     {
         if self.is_empty() {
-            return Try::from_ok(init);
+            return try { init };
         }
 
         let mut accum = init;
@@ -836,7 +836,7 @@ impl<A: Step> DoubleEndedIterator for ops::RangeInclusive<A> {
             accum = f(accum, self.start.clone())?;
         }
 
-        Try::from_ok(accum)
+        try { accum }
     }
 
     #[inline]

--- a/library/core/src/iter/traits/double_ended.rs
+++ b/library/core/src/iter/traits/double_ended.rs
@@ -221,7 +221,7 @@ pub trait DoubleEndedIterator: Iterator {
         while let Some(x) = self.next_back() {
             accum = f(accum, x)?;
         }
-        Try::from_ok(accum)
+        try { accum }
     }
 
     /// An iterator method that reduces the iterator's elements to a single,

--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -1887,7 +1887,7 @@ pub trait Iterator {
         while let Some(x) = self.next() {
             accum = f(accum, x)?;
         }
-        Try::from_ok(accum)
+        try { accum }
     }
 
     /// An iterator method that applies a fallible function to each item in the

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -127,6 +127,7 @@
 #![feature(std_internals)]
 #![feature(stmt_expr_attributes)]
 #![feature(transparent_unions)]
+#![feature(try_blocks)]
 #![feature(unboxed_closures)]
 #![feature(unsized_locals)]
 #![feature(untagged_unions)]

--- a/src/stage0.txt
+++ b/src/stage0.txt
@@ -20,7 +20,7 @@ cargo: beta
 # bootstrapping issues with use of new syntax in this repo. If you're looking at
 # the beta/stable branch, this key should be omitted, as we don't want to depend
 # on rustfmt from nightly there.
-rustfmt: nightly-2020-10-07
+rustfmt: nightly-2020-10-12
 
 # When making a stable release the process currently looks like:
 #


### PR DESCRIPTION
I'd like to experiment with changing the `?`/`try` desugaring and correspondingly the `Try` trait (see #42327 for discussions about the suboptimalities of the current one) and this change would keep from needing any `cfg(bootstrap)` in iterator things.

This will be lowered to the same thing, so shouldn't cause any perf issues:
https://github.com/rust-lang/rust/blob/08e2d4616613716362b4b49980ff303f2b9ae654/compiler/rustc_ast_lowering/src/expr.rs#L428-L429

But ~~I'll trigger~~ I've triggered [a perf run](https://perf.rust-lang.org/compare.html?start=d65c08e9cc164b7b44de53503fae859a4fafd976&end=2c067c5235e779cd75e9f0cdfe572c64f1a12b9b) just in case. 

~~EDIT: changed to a draft because of the rustfmt-only syntax error.  zulip thread about it: https://rust-lang.zulipchat.com/#narrow/stream/122651-general/topic/New.20bootstrap.20rustfmt.20doesn't.20support.20syntax.20from.20sept.3F/near/213098097~~

EDIT: This now includes a rustfmt version bump to get through tidy.