### PR TITLE
Make `tcx.visibility()` work for items in the local crate

### DIFF
--- a/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
@@ -288,6 +288,7 @@ pub fn provide(providers: &mut Providers) {
             Lrc::new(link_args::collect(tcx))
         },
 
+        visibility: crate::rmeta::encoder::visibility,
         // Returns a map from a sufficiently visible external item (i.e., an
         // external item that is visible from at least one local module) to a
         // sufficiently visible parent (considering modules that re-export the


### PR DESCRIPTION
This also changes rustc_metadata to use `tcx.visibility()` for `record!`ing metadata.

See https://github.com/rust-lang/rust/pull/77820#issuecomment-706728351 for the history.

r? @petrochenkov 