### PR TITLE
Impl Default for PhantomPinned

### DIFF
--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -772,7 +772,7 @@ pub auto trait Unpin {}
 ///
 /// If a type contains a `PhantomPinned`, it will not implement `Unpin` by default.
 #[stable(feature = "pin", since = "1.33.0")]
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[derive(Debug, Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct PhantomPinned;
 
 #[stable(feature = "pin", since = "1.33.0")]


### PR DESCRIPTION
`PhantomPinned` is just a marker type, with an obvious default value (the only value). So I can't think of a reason not to do this. Sure, it's used in exotic situations with unsafe code. But the people writing that code can decide for themselves if they can derive `Default`, and in many situations the derived impl will make sense:

```rust
#[derive(Default)]
struct NeedsPin {
   marker: PhantomPinned,
   buf: [u8; 1024],
   ptr_to_data: Option<*const u8>,
}
```