### PR TITLE
Re-use the Vec<T> memory when creating an Rc<[T]> instead of copying …

### DIFF
--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -1542,15 +1542,9 @@ impl<T: ?Sized> From<Box<T>> for Rc<T> {
 #[stable(feature = "shared_from_slice", since = "1.21.0")]
 impl<T> From<Vec<T>> for Rc<[T]> {
     #[inline]
-    fn from(mut v: Vec<T>) -> Rc<[T]> {
-        unsafe {
-            let rc = Rc::copy_from_slice(&v);
-
-            // Allow the Vec to free its memory, but not destroy its contents
-            v.set_len(0);
-
-            rc
-        }
+    fn from(v: Vec<T>) -> Rc<[T]> {
+        let v = v.into_boxed_slice();
+        Rc::from_box(v)
     }
 }
 

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -2196,15 +2196,9 @@ impl<T: ?Sized> From<Box<T>> for Arc<T> {
 #[stable(feature = "shared_from_slice", since = "1.21.0")]
 impl<T> From<Vec<T>> for Arc<[T]> {
     #[inline]
-    fn from(mut v: Vec<T>) -> Arc<[T]> {
-        unsafe {
-            let arc = Arc::copy_from_slice(&v);
-
-            // Allow the Vec to free its memory, but not destroy its contents
-            v.set_len(0);
-
-            arc
-        }
+    fn from(v: Vec<T>) -> Arc<[T]> {
+        let v = v.into_boxed_slice();
+        Arc::from_box(v)
     }
 }
 


### PR DESCRIPTION
…all elements

Rc::copy_from_slice() would allocate the Rc together with the slice,
which reduces the number of allocations but then has to copy all
elements to the new location.

Going via Vec::into_boxed_slice() would do a realloc(), which usually is
very cheap and then reuses the Vec memory while only doing a new
allocation for the Rc itself.

For bigger Vecs (16MB) this gives a speedup of about 15% here, while for
small Vecs (128 bytes) the results are inconclusive.

It might make sense to keep the old behaviour up to a certain size for
fewer allocations and better cache locality.