### PR TITLE
bootstrap: set correct path for the build-manifest binary

### DIFF
--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -2617,7 +2617,7 @@ impl Step for BuildManifest {
         let image_bin = image.join("bin");
         let _ = fs::remove_dir_all(&image);
         t!(fs::create_dir_all(&image_bin));
-        builder.install(&build_manifest, &image_bin.join("build-manifest"), 0o755);
+        builder.install(&build_manifest, &image_bin, 0o755);
 
         // Prepare the overlay.
         let overlay = tmp.join("build-manifest-overlay");


### PR DESCRIPTION
This changes the path of the binary inside the tarball to be:

```
build-manifest-{release}-{target}/build-manifest/bin/build-manifest
```

...instead of:

```
build-manifest-{release}-{target}/build-manifest/bin/build-manifest/build-manifest
```

r? @Mark-Simulacrum 