### PR TITLE
Avoid extraneous space between visibility kw and ident for statics

### DIFF
--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -2289,7 +2289,7 @@ fn item_static(w: &mut Buffer, cx: &Context, it: &clean::Item, s: &clean::Static
     render_attributes(w, it, false);
     write!(
         w,
-        "{vis}static {mutability} {name}: {typ}</pre>",
+        "{vis}static {mutability}{name}: {typ}</pre>",
         vis = it.visibility.print_with_space(),
         mutability = s.mutability.print_with_space(),
         name = it.name.as_ref().unwrap(),

--- a/src/test/rustdoc/static.rs
+++ b/src/test/rustdoc/static.rs
@@ -1,0 +1,12 @@
+// compile-flags: --document-private-items
+
+#![crate_type = "lib"]
+
+// @has static/static.FOO.html '//pre[@class="static"]' 'static FOO: usize'
+static FOO: usize = 1;
+
+// @has static/static.BAR.html '//pre[@class="static"]' 'pub static BAR: usize'
+pub static BAR: usize = 1;
+
+// @has static/static.BAZ.html '//pre[@class="static"]' 'pub static mut BAZ: usize'
+pub static mut BAZ: usize = 1;

--- a/src/test/rustdoc/static.rs
+++ b/src/test/rustdoc/static.rs
@@ -2,11 +2,11 @@
 
 #![crate_type = "lib"]
 
-// @has static/static.FOO.html '//pre[@class="static"]' 'static FOO: usize'
+// @has static/static.FOO.html '//pre' 'static FOO: usize'
 static FOO: usize = 1;
 
-// @has static/static.BAR.html '//pre[@class="static"]' 'pub static BAR: usize'
+// @has static/static.BAR.html '//pre' 'pub static BAR: usize'
 pub static BAR: usize = 1;
 
-// @has static/static.BAZ.html '//pre[@class="static"]' 'pub static mut BAZ: usize'
+// @has static/static.BAZ.html '//pre' 'pub static mut BAZ: usize'
 pub static mut BAZ: usize = 1;


### PR DESCRIPTION
Today, given a static like `static mut FOO: usize = 1`, rustdoc would
emit `static mut  FOO: usize = 1`, as it emits both the mutability kw
with a space and reserves a space after the mutability kw. This patch
fixes that misformatting.

This patch also adds some tests for emit of other statics, as I could
not find an existing test devoted to statics.