### PR TITLE
hint: Make `spin_loop_hint` a side-effect for all targets

### DIFF
--- a/library/core/src/hint.rs
+++ b/library/core/src/hint.rs
@@ -93,6 +93,15 @@ pub fn spin_loop() {
             unsafe { crate::arch::arm::__yield() };
         }
     }
+    // This makes sure that spin_loop is always a side-effect on all platfomrs,
+    // allowing users to work around https://github.com/rust-lang/rust/issues/28728
+    // Remove when that bug is fixed.
+    #[cfg(not(miri))]
+    // SAFETY: the inline assembly is a no-op.
+    unsafe {
+        // FIXME: Cannot use `asm!` because it doesn't support MIPS and other architectures.
+        llvm_asm!("" : : : : "volatile");
+    }
 }
 
 /// An identity function that *__hints__* to the compiler to be maximally pessimistic about what


### PR DESCRIPTION
In https://github.com/rust-lang/rust-clippy/issues/6161 and https://github.com/rust-lang/rust-clippy/issues/6162 we were discussing changes to the `empty_loop` lint. That lint prohibits code like:
```rust
loop { }
```
for two reasons:
  - Hot dead-looping unnecessarily wastes CPU cycles
  - An [LLVM codegen bug](https://github.com/rust-lang/rust/issues/28728) means that this code can cause UB

For `std` targets we recommend either panicking or replacing the code with:
```rust
loop {
  std::thread::sleep(...); // Could also be std::thread::yield_now();
}
```

For `no_std` targets, in an ideal world, we would just recommend panicking or replacing the code with:
```rust
loop {
  core::sync::atomic::spin_loop_hint();
}
```

While this would fix the performance issue (on some platforms), it wouldn't fix the LLVM codegen issue on _all_ platforms. This change makes it so `spin_loop_hint` is always a side-effect from LLVM's perspective. This makes giving recommendations to users much easier. This change has no runtime costs (except that is disables optimizations we want disabled anyway). It also makes the behavior more consistent across targets (as spin_loop_hint is already a side-effect on x86 and (most) ARM targets).

Without this change, we [would have to recommend](https://github.com/rust-lang/rust-clippy/pull/6162#issuecomment-708062490) very weird, `unsafe` things (like `read_volatile`). Furthermore, those recommendations would become stale once the LLVM codegen bug was fixed. With this change, we can recommend a fix that still makes sense once LLVM is fixed.

CC: @jonas-schievink @RalfJung @jyn514 @flip1995

Signed-off-by: Joe Richey <joerichey@google.com>