### PR TITLE
Document -Z codegen-backend in the unstable book

### DIFF
--- a/src/doc/unstable-book/src/compiler-flags/codegen-backend.md
+++ b/src/doc/unstable-book/src/compiler-flags/codegen-backend.md
@@ -12,6 +12,9 @@ backend. The library must be of crate type `dylib` and must contain a function
 named `__rustc_codegen_backend` with a signature of `fn() -> Box<dyn rustc_codegen_ssa::traits::CodegenBackend>`.
 
 ## Example
+See also the [`hotplug_codegen_backend`](https://github.com/rust-lang/rust/tree/master/src/test/run-make-fulldeps/hotplug_codegen_backend) test
+for a full example.
+
 ```rust,ignore
 use rustc_codegen_ssa::traits::CodegenBackend;
 

--- a/src/doc/unstable-book/src/compiler-flags/codegen-backend.md
+++ b/src/doc/unstable-book/src/compiler-flags/codegen-backend.md
@@ -8,8 +8,8 @@ This feature allows you to specify a path to a dynamic library to use as rustc's
 code generation backend at runtime.
 
 Set the `-Zcodegen-backend=<path>` compiler flag to specify the location of the
-backend. The library must contain a function named `__rustc_codegen_backend`
-with a signature of `fn() -> Box<dyn rustc_codegen_ssa::traits::CodegenBackend>`.
+backend. The library must be of crate type `dylib` and must contain a function
+named `__rustc_codegen_backend` with a signature of `fn() -> Box<dyn rustc_codegen_ssa::traits::CodegenBackend>`.
 
 ## Example
 ```rust,ignore

--- a/src/doc/unstable-book/src/compiler-flags/codegen-backend.md
+++ b/src/doc/unstable-book/src/compiler-flags/codegen-backend.md
@@ -1,0 +1,28 @@
+# `codegen-backend`
+
+The tracking issue for this feature is: [#77933](https://github.com/rust-lang/rust/issues/77933).
+
+------------------------
+
+This feature allows you to specify a path to a dynamic library to use as rustc's
+code generation backend at runtime.
+
+Set the `-Zcodegen-backend=<path>` compiler flag to specify the location of the
+backend. The library must contain a function named `__rustc_codegen_backend`
+with a signature of `fn() -> Box<dyn rustc_codegen_ssa::traits::CodegenBackend>`.
+
+## Example
+```rust
+use rustc_codegen_ssa::traits::CodegenBackend;
+
+struct MyBackend;
+
+impl CodegenBackend for MyBackend {
+   // Implement codegen methods
+}
+
+#[no_mangle]
+pub fn __rustc_codegen_backend() -> Box<dyn CodegenBackend> {
+    Box::new(MyBackend)
+}
+```

--- a/src/doc/unstable-book/src/compiler-flags/codegen-backend.md
+++ b/src/doc/unstable-book/src/compiler-flags/codegen-backend.md
@@ -12,7 +12,7 @@ backend. The library must contain a function named `__rustc_codegen_backend`
 with a signature of `fn() -> Box<dyn rustc_codegen_ssa::traits::CodegenBackend>`.
 
 ## Example
-```rust
+```rust,ignore
 use rustc_codegen_ssa::traits::CodegenBackend;
 
 struct MyBackend;


### PR DESCRIPTION
### [Rendered](https://github.com/XAMPPRocky/rust/blob/codegen-backend-docs/src/doc/unstable-book/src/compiler-flags/codegen-backend.md)

Companion PR to #77933 tracking issue.

cc @bjorn3 