### PR TITLE
Create a single source scope for promoteds

### DIFF
--- a/src/test/mir-opt/const_promotion_extern_static.FOO-promoted[0].ConstProp.after.mir
+++ b/src/test/mir-opt/const_promotion_extern_static.FOO-promoted[0].ConstProp.after.mir
@@ -5,8 +5,6 @@ promoted[0] in FOO: &[&i32; 1] = {
     let mut _1: [&i32; 1];               // in scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:46
     let mut _2: &i32;                    // in scope 0 at $DIR/const-promotion-extern-static.rs:13:32: 13:45
     let mut _3: &i32;                    // in scope 0 at $DIR/const-promotion-extern-static.rs:13:42: 13:43
-    scope 1 {
-    }
 
     bb0: {
         _3 = const {alloc2: &i32};       // scope 0 at $DIR/const-promotion-extern-static.rs:13:42: 13:43


### PR DESCRIPTION
A promoted inherits all scopes from the parent body.  At the same time,
almost all statements and terminators inside the promoted body so far
refer only to one of those scopes: the outermost one.

Instead of inheriting all scopes, inherit only a single scope
corresponding to the location of the promoted, making sure that there
are no references to other scopes.
