### PR TITLE
Use GITHUB_ENV instead of set-env

### DIFF
--- a/src/tools/clippy/.github/workflows/deploy.yml
+++ b/src/tools/clippy/.github/workflows/deploy.yml
@@ -34,10 +34,10 @@ jobs:
       if: startswith(github.ref, 'refs/tags/')
       run: |
         TAG=$(basename ${{ github.ref }})
-        echo "::set-env name=TAG_NAME::$TAG"
+        echo "TAG_NAME=${TAG}" >> ${GITHUB_ENV}
     - name: Set beta to true
       if: github.ref == 'refs/heads/beta'
-      run: echo "::set-env name=BETA::true"
+      run: echo "BETA=true" >> ${GITHUB_ENV}
 
     - name: Use scripts and templates from master branch
       run: |


### PR DESCRIPTION
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

> Action and workflow authors who are setting environment variables via stdout should update any usage of the set-env and add-path workflow commands to use the new environment files.