### PR TITLE
Remove arena's dependency on `rustc_data_structures`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3350,7 +3350,6 @@ dependencies = [
 name = "rustc_arena"
 version = "0.0.0"
 dependencies = [
- "rustc_data_structures",
  "smallvec 1.4.2",
 ]
 

--- a/compiler/rustc_arena/Cargo.toml
+++ b/compiler/rustc_arena/Cargo.toml
@@ -5,5 +5,4 @@ version = "0.0.0"
 edition = "2018"
 
 [dependencies]
-rustc_data_structures = { path = "../rustc_data_structures" }
 smallvec = { version = "1.0", features = ["union", "may_dangle"] }

--- a/compiler/rustc_arena/src/lib.rs
+++ b/compiler/rustc_arena/src/lib.rs
@@ -16,7 +16,6 @@
 #![feature(maybe_uninit_slice)]
 #![cfg_attr(test, feature(test))]
 
-use rustc_data_structures::cold_path;
 use smallvec::SmallVec;
 
 use std::alloc::Layout;
@@ -26,6 +25,12 @@ use std::marker::{PhantomData, Send};
 use std::mem::{self, MaybeUninit};
 use std::ptr;
 use std::slice;
+
+#[inline(never)]
+#[cold]
+pub fn cold_path<F: FnOnce() -> R, R>(f: F) -> R {
+    f()
+}
 
 /// An arena that can hold objects of only one type.
 pub struct TypedArena<T> {


### PR DESCRIPTION
`rustc_arena` currently has a dependency on `rustc_data_structures` because of a trivial "don't inline me" function. This PR copies that function and removes the dependency.