### PR TITLE
Doc formating consistency between slice sort and sort_unstable, and big O notation consistency

### DIFF
--- a/library/alloc/src/raw_vec.rs
+++ b/library/alloc/src/raw_vec.rs
@@ -259,7 +259,7 @@ impl<T, A: AllocRef> RawVec<T, A> {
     /// Ensures that the buffer contains at least enough space to hold `len +
     /// additional` elements. If it doesn't already have enough capacity, will
     /// reallocate enough space plus comfortable slack space to get amortized
-    /// `O(1)` behavior. Will limit this behavior if it would needlessly cause
+    /// *O*(1) behavior. Will limit this behavior if it would needlessly cause
     /// itself to panic.
     ///
     /// If `len` exceeds `self.capacity()`, this may fail to actually allocate

--- a/library/alloc/src/slice.rs
+++ b/library/alloc/src/slice.rs
@@ -169,7 +169,7 @@ mod hack {
 impl<T> [T] {
     /// Sorts the slice.
     ///
-    /// This sort is stable (i.e., does not reorder equal elements) and `O(n * log(n))` worst-case.
+    /// This sort is stable (i.e., does not reorder equal elements) and *O*(*n* \* log(*n*)) worst-case.
     ///
     /// When applicable, unstable sorting is preferred because it is generally faster than stable
     /// sorting and it doesn't allocate auxiliary memory.
@@ -204,7 +204,7 @@ impl<T> [T] {
 
     /// Sorts the slice with a comparator function.
     ///
-    /// This sort is stable (i.e., does not reorder equal elements) and `O(n * log(n))` worst-case.
+    /// This sort is stable (i.e., does not reorder equal elements) and *O*(*n* \* log(*n*)) worst-case.
     ///
     /// The comparator function must define a total ordering for the elements in the slice. If
     /// the ordering is not total, the order of the elements is unspecified. An order is a
@@ -258,8 +258,8 @@ impl<T> [T] {
 
     /// Sorts the slice with a key extraction function.
     ///
-    /// This sort is stable (i.e., does not reorder equal elements) and `O(m * n * log(n))`
-    /// worst-case, where the key function is `O(m)`.
+    /// This sort is stable (i.e., does not reorder equal elements) and *O*(*m* \* *n* \* log(*n*))
+    /// worst-case, where the key function is *O*(*m*).
     ///
     /// For expensive key functions (e.g. functions that are not simple property accesses or
     /// basic operations), [`sort_by_cached_key`](#method.sort_by_cached_key) is likely to be
@@ -301,8 +301,8 @@ impl<T> [T] {
     ///
     /// During sorting, the key function is called only once per element.
     ///
-    /// This sort is stable (i.e., does not reorder equal elements) and `O(m * n + n * log(n))`
-    /// worst-case, where the key function is `O(m)`.
+    /// This sort is stable (i.e., does not reorder equal elements) and *O*(*m* \* *n* + *n* \* log(*n*))
+    /// worst-case, where the key function is *O*(*m*).
     ///
     /// For simple key functions (e.g., functions that are property accesses or
     /// basic operations), [`sort_by_key`](#method.sort_by_key) is likely to be
@@ -946,7 +946,7 @@ where
 /// 1. for every `i` in `1..runs.len()`: `runs[i - 1].len > runs[i].len`
 /// 2. for every `i` in `2..runs.len()`: `runs[i - 2].len > runs[i - 1].len + runs[i].len`
 ///
-/// The invariants ensure that the total running time is `O(n * log(n))` worst-case.
+/// The invariants ensure that the total running time is *O*(*n* \* log(*n*)) worst-case.
 fn merge_sort<T, F>(v: &mut [T], mut is_less: F)
 where
     F: FnMut(&T, &T) -> bool,

--- a/library/alloc/src/vec.rs
+++ b/library/alloc/src/vec.rs
@@ -259,7 +259,7 @@ use crate::raw_vec::RawVec;
 /// `Vec` does not guarantee any particular growth strategy when reallocating
 /// when full, nor when [`reserve`] is called. The current strategy is basic
 /// and it may prove desirable to use a non-constant growth factor. Whatever
-/// strategy is used will of course guarantee `O(1)` amortized [`push`].
+/// strategy is used will of course guarantee *O*(1) amortized [`push`].
 ///
 /// `vec![x; n]`, `vec![a, b, c, d]`, and
 /// [`Vec::with_capacity(n)`][`Vec::with_capacity`], will all produce a `Vec`

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -1948,10 +1948,10 @@ impl<T> [T] {
     ///
     /// The comparator function must define a total ordering for the elements in the slice. If
     /// the ordering is not total, the order of the elements is unspecified. An order is a
-    /// total order if it is (for all a, b and c):
+    /// total order if it is (for all `a`, `b` and `c`):
     ///
-    /// * total and antisymmetric: exactly one of a < b, a == b or a > b is true; and
-    /// * transitive, a < b and b < c implies a < c. The same must hold for both == and >.
+    /// * total and antisymmetric: exactly one of `a < b`, `a == b` or `a > b` is true, and
+    /// * transitive, `a < b` and `b < c` implies `a < c`. The same must hold for both `==` and `>`.
     ///
     /// For example, while [`f64`] doesn't implement [`Ord`] because `NaN != NaN`, we can use
     /// `partial_cmp` as our sort function when we know the slice doesn't contain a `NaN`.

--- a/library/core/src/str/traits.rs
+++ b/library/core/src/str/traits.rs
@@ -89,7 +89,7 @@ fn str_index_overflow_fail() -> ! {
 /// self`. Equivalent to `&self[0 .. len]` or `&mut self[0 .. len]`. Unlike
 /// other indexing operations, this can never panic.
 ///
-/// This operation is `O(1)`.
+/// This operation is *O*(1).
 ///
 /// Prior to 1.20.0, these indexing operations were still supported by
 /// direct implementation of `Index` and `IndexMut`.
@@ -130,7 +130,7 @@ unsafe impl SliceIndex<str> for ops::RangeFull {
 /// Returns a slice of the given string from the byte range
 /// [`begin`, `end`).
 ///
-/// This operation is `O(1)`.
+/// This operation is *O*(1).
 ///
 /// Prior to 1.20.0, these indexing operations were still supported by
 /// direct implementation of `Index` and `IndexMut`.
@@ -237,7 +237,7 @@ unsafe impl SliceIndex<str> for ops::Range<usize> {
 /// Returns a slice of the given string from the byte range [`0`, `end`).
 /// Equivalent to `&self[0 .. end]` or `&mut self[0 .. end]`.
 ///
-/// This operation is `O(1)`.
+/// This operation is *O*(1).
 ///
 /// Prior to 1.20.0, these indexing operations were still supported by
 /// direct implementation of `Index` and `IndexMut`.
@@ -308,7 +308,7 @@ unsafe impl SliceIndex<str> for ops::RangeTo<usize> {
 /// `len`). Equivalent to `&self[begin .. len]` or `&mut self[begin ..
 /// len]`.
 ///
-/// This operation is `O(1)`.
+/// This operation is *O*(1).
 ///
 /// Prior to 1.20.0, these indexing operations were still supported by
 /// direct implementation of `Index` and `IndexMut`.
@@ -385,7 +385,7 @@ unsafe impl SliceIndex<str> for ops::RangeFrom<usize> {
 /// self[begin .. end + 1]`, except if `end` has the maximum value for
 /// `usize`.
 ///
-/// This operation is `O(1)`.
+/// This operation is *O*(1).
 ///
 /// # Panics
 ///
@@ -441,7 +441,7 @@ unsafe impl SliceIndex<str> for ops::RangeInclusive<usize> {
 /// Equivalent to `&self [0 .. end + 1]`, except if `end` has the maximum
 /// value for `usize`.
 ///
-/// This operation is `O(1)`.
+/// This operation is *O*(1).
 ///
 /// # Panics
 ///


### PR DESCRIPTION
Updated documentation for slice sorting methods to be consistent between stable and unstable versions, which just ended up being minor formatting differences.

I also went through and updated any doc comments with big O notation to be consistent with #74010 by italicizing them rather than having them in a code block.