### PR TITLE
Hide help button on mobile

### DIFF
--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -1544,6 +1544,14 @@ h4 > .notable-traits {
 		left: 0;
 		top: 100%;
 	}
+
+	/* We don't display the help button on mobile devices. */
+	.help-button {
+		display: none;
+	}
+	.search-container > div {
+		width: calc(100% - 32px);
+	}
 }
 
 @media print {


### PR DESCRIPTION
Addresses #77899.

This PR is just a quick fix for now: we're still debating about whether or not we want to display this help popup and if so, how. I'll open an issue once this PR is merged to discuss about it.

Before:

![Screenshot from 2020-10-15 17-56-39](https://user-images.githubusercontent.com/3050060/96155127-df499680-0f0f-11eb-8a13-77c537141f21.png)

After:

![Screenshot from 2020-10-15 17-55-06](https://user-images.githubusercontent.com/3050060/96154957-ac070780-0f0f-11eb-9d90-7d8f79a6bf37.png)

r? @jyn514 