### PR TITLE
Remove shrink_to_fit from default ToString::to_string implementation.

### DIFF
--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -2200,7 +2200,6 @@ impl<T: fmt::Display + ?Sized> ToString for T {
         let mut buf = String::new();
         buf.write_fmt(format_args!("{}", self))
             .expect("a Display implementation returned an error unexpectedly");
-        buf.shrink_to_fit();
         buf
     }
 }


### PR DESCRIPTION
As suggested by @scottmcm on Zulip. shrink_to_fit() seems like the wrong thing to do here in most use cases of to_string(). Would be intereseting to see if it makes any difference in a timer run.

r? @joshtriplett