### PR TITLE
Use Intra-doc links for std::io::buffered

### DIFF
--- a/library/std/src/io/buffered/bufreader.rs
+++ b/library/std/src/io/buffered/bufreader.rs
@@ -21,7 +21,7 @@ use crate::io::{self, BufRead, Initializer, IoSliceMut, Read, Seek, SeekFrom, DE
 /// unwrapping the `BufReader<R>` with [`BufReader::into_inner`] can also cause
 /// data loss.
 ///
-/// [`TcpStream::read`]: Read::read
+/// [`TcpStream::read`]: super::super::super::net::TcpStream::read
 /// [`TcpStream`]: crate::net::TcpStream
 ///
 /// # Examples

--- a/library/std/src/io/buffered/bufreader.rs
+++ b/library/std/src/io/buffered/bufreader.rs
@@ -21,6 +21,7 @@ use crate::io::{self, BufRead, Initializer, IoSliceMut, Read, Seek, SeekFrom, DE
 /// unwrapping the `BufReader<R>` with [`BufReader::into_inner`] can also cause
 /// data loss.
 ///
+// HACK(#78696): can't use `crate` for associated items
 /// [`TcpStream::read`]: super::super::super::net::TcpStream::read
 /// [`TcpStream`]: crate::net::TcpStream
 ///

--- a/library/std/src/io/buffered/bufwriter.rs
+++ b/library/std/src/io/buffered/bufwriter.rs
@@ -59,6 +59,7 @@ use crate::io::{
 /// together by the buffer and will all be written out in one system call when
 /// the `stream` is flushed.
 ///
+// HACK(#78696): can't use `crate` for associated items
 /// [`TcpStream::write`]: super::super::super::net::TcpStream::write
 /// [`TcpStream`]: crate::net::TcpStream
 /// [`flush`]: BufWriter::flush

--- a/library/std/src/io/buffered/bufwriter.rs
+++ b/library/std/src/io/buffered/bufwriter.rs
@@ -59,9 +59,9 @@ use crate::io::{
 /// together by the buffer and will all be written out in one system call when
 /// the `stream` is flushed.
 ///
-/// [`TcpStream::write`]: Write::write
+/// [`TcpStream::write`]: super::super::super::net::TcpStream::write
 /// [`TcpStream`]: crate::net::TcpStream
-/// [`flush`]: Write::flush
+/// [`flush`]: BufWriter::flush
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct BufWriter<W: Write> {
     inner: Option<W>,


### PR DESCRIPTION
Helps with #75080. I used the implicit link style for intrinsics, as that was what `minnumf32` and others already had.

@rustbot modify labels: T-doc, A-intra-doc-links

r? @jyn514