### PR TITLE
Fix sidebar scroll on mobile devices

### DIFF
--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -2716,10 +2716,6 @@ function defocusSearchBar() {
         };
     }
 
-    window.onresize = function() {
-        hideSidebar();
-    };
-
     if (main) {
         onEachLazy(main.getElementsByClassName("loading-content"), function(e) {
             e.remove();


### PR DESCRIPTION
Fixes #77942.

The issue was coming from the appearance/disappearance of the "wrapper" on the mobile devices web browsers, which triggers the "resize" event, calling the `hideSidebar` function is the JS code.

r? @jyn514 