### PR TITLE
Bump bootstrap compiler

### DIFF
--- a/src/stage0.txt
+++ b/src/stage0.txt
@@ -12,7 +12,7 @@
 # source tarball for a stable release you'll likely see `1.x.0` for rustc and
 # `0.(x+1).0` for Cargo where they were released on `date`.
 
-date: 2020-10-07
+date: 2020-10-16
 rustc: beta
 cargo: beta
 


### PR DESCRIPTION
Mainly to bring in #77953 to fix https://github.com/rust-lang/cargo/issues/8517.
