### PR TITLE
Update Option Documentation

### DIFF
--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -667,7 +667,7 @@ impl<T> Option<T> {
     /// Returns [`None`] if the option is [`None`], otherwise calls `predicate`
     /// with the wrapped value and returns:
     ///
-    /// - [`Some(t)`] if `predicate` returns `true` (where `t` is the wrapped
+    /// - [`Some`] if `predicate` returns `true` (where `t` is the wrapped
     ///   value), and
     /// - [`None`] if `predicate` returns `false`.
     ///
@@ -686,8 +686,6 @@ impl<T> Option<T> {
     /// assert_eq!(Some(3).filter(is_even), None);
     /// assert_eq!(Some(4).filter(is_even), Some(4));
     /// ```
-    ///
-    /// [`Some(t)`]: Some
     #[inline]
     #[stable(feature = "option_filter", since = "1.27.0")]
     pub fn filter<P: FnOnce(&T) -> bool>(self, predicate: P) -> Self {


### PR DESCRIPTION
This patch updates the Option documentation for the filter function so that the Some variant link is correctly rendered.

Here is how it currently looks for the latest stable release:

![image](https://user-images.githubusercontent.com/2665334/96327830-11cbc000-0ff2-11eb-8d27-b6750da23576.png)