### PR TITLE
Fix grammar in note for orphan-rule error [E0210]

### DIFF
--- a/compiler/rustc_typeck/src/coherence/orphan.rs
+++ b/compiler/rustc_typeck/src/coherence/orphan.rs
@@ -110,7 +110,7 @@ impl ItemLikeVisitor<'v> for OrphanChecker<'tcx> {
                             )
                             .note(
                                 "implementing a foreign trait is only possible if at \
-                                    least one of the types for which is it implemented is local, \
+                                    least one of the types for which it is implemented is local, \
                                     and no uncovered type parameters appear before that first \
                                     local type",
                             )
@@ -135,7 +135,7 @@ impl ItemLikeVisitor<'v> for OrphanChecker<'tcx> {
                                 local type",
                                 param_ty,
                             )).note("implementing a foreign trait is only possible if at \
-                                    least one of the types for which is it implemented is local"
+                                    least one of the types for which it is implemented is local"
                             ).note("only traits defined in the current crate can be \
                                     implemented for a type parameter"
                             ).emit();

--- a/src/test/ui/coherence/coherence-all-remote.stderr
+++ b/src/test/ui/coherence/coherence-all-remote.stderr
@@ -4,7 +4,7 @@ error[E0210]: type parameter `T` must be used as the type parameter for some loc
 LL | impl<T> Remote1<T> for isize { }
    |      ^ type parameter `T` must be used as the type parameter for some local type
    |
-   = note: implementing a foreign trait is only possible if at least one of the types for which is it implemented is local
+   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter
 
 error: aborting due to previous error

--- a/src/test/ui/coherence/coherence-bigint-param.stderr
+++ b/src/test/ui/coherence/coherence-bigint-param.stderr
@@ -4,7 +4,7 @@ error[E0210]: type parameter `T` must be covered by another type when it appears
 LL | impl<T> Remote1<BigInt> for T { }
    |      ^ type parameter `T` must be covered by another type when it appears before the first local type (`BigInt`)
    |
-   = note: implementing a foreign trait is only possible if at least one of the types for which is it implemented is local, and no uncovered type parameters appear before that first local type
+   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local, and no uncovered type parameters appear before that first local type
    = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`, where `T0` is the first and `Tn` is the last
 
 error: aborting due to previous error

--- a/src/test/ui/coherence/coherence-cross-crate-conflict.stderr
+++ b/src/test/ui/coherence/coherence-cross-crate-conflict.stderr
@@ -13,7 +13,7 @@ error[E0210]: type parameter `A` must be used as the type parameter for some loc
 LL | impl<A> Foo for A {
    |      ^ type parameter `A` must be used as the type parameter for some local type
    |
-   = note: implementing a foreign trait is only possible if at least one of the types for which is it implemented is local
+   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/coherence/coherence-lone-type-parameter.stderr
+++ b/src/test/ui/coherence/coherence-lone-type-parameter.stderr
@@ -4,7 +4,7 @@ error[E0210]: type parameter `T` must be used as the type parameter for some loc
 LL | impl<T> Remote for T { }
    |      ^ type parameter `T` must be used as the type parameter for some local type
    |
-   = note: implementing a foreign trait is only possible if at least one of the types for which is it implemented is local
+   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter
 
 error: aborting due to previous error

--- a/src/test/ui/coherence/impl[t]-foreign-for-fundamental[t].stderr
+++ b/src/test/ui/coherence/impl[t]-foreign-for-fundamental[t].stderr
@@ -4,7 +4,7 @@ error[E0210]: type parameter `T` must be used as the type parameter for some loc
 LL | impl<T> Remote for Box<T> {
    |      ^ type parameter `T` must be used as the type parameter for some local type
    |
-   = note: implementing a foreign trait is only possible if at least one of the types for which is it implemented is local
+   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter
 
 error: aborting due to previous error

--- a/src/test/ui/coherence/impl[t]-foreign[foreign]-for-fundamental[t].stderr
+++ b/src/test/ui/coherence/impl[t]-foreign[foreign]-for-fundamental[t].stderr
@@ -4,7 +4,7 @@ error[E0210]: type parameter `T` must be used as the type parameter for some loc
 LL | impl<T> Remote1<u32> for Box<T> {
    |      ^ type parameter `T` must be used as the type parameter for some local type
    |
-   = note: implementing a foreign trait is only possible if at least one of the types for which is it implemented is local
+   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter
 
 error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
@@ -13,7 +13,7 @@ error[E0210]: type parameter `T` must be used as the type parameter for some loc
 LL | impl<'a, T> Remote1<u32> for &'a T {
    |          ^ type parameter `T` must be used as the type parameter for some local type
    |
-   = note: implementing a foreign trait is only possible if at least one of the types for which is it implemented is local
+   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/coherence/impl[t]-foreign[foreign]-for-t.stderr
+++ b/src/test/ui/coherence/impl[t]-foreign[foreign]-for-t.stderr
@@ -4,7 +4,7 @@ error[E0210]: type parameter `T` must be used as the type parameter for some loc
 LL | impl<T> Remote1<u32> for T {
    |      ^ type parameter `T` must be used as the type parameter for some local type
    |
-   = note: implementing a foreign trait is only possible if at least one of the types for which is it implemented is local
+   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter
 
 error: aborting due to previous error

--- a/src/test/ui/coherence/impl[t]-foreign[fundamental[t]]-for-foreign.stderr
+++ b/src/test/ui/coherence/impl[t]-foreign[fundamental[t]]-for-foreign.stderr
@@ -4,7 +4,7 @@ error[E0210]: type parameter `T` must be used as the type parameter for some loc
 LL | impl<T> Remote1<Box<T>> for u32 {
    |      ^ type parameter `T` must be used as the type parameter for some local type
    |
-   = note: implementing a foreign trait is only possible if at least one of the types for which is it implemented is local
+   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter
 
 error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
@@ -13,7 +13,7 @@ error[E0210]: type parameter `T` must be used as the type parameter for some loc
 LL | impl<'a, T> Remote1<&'a T> for u32 {
    |          ^ type parameter `T` must be used as the type parameter for some local type
    |
-   = note: implementing a foreign trait is only possible if at least one of the types for which is it implemented is local
+   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/coherence/impl[t]-foreign[fundamental[t]]-for-fundamental[t].stderr
+++ b/src/test/ui/coherence/impl[t]-foreign[fundamental[t]]-for-fundamental[t].stderr
@@ -4,7 +4,7 @@ error[E0210]: type parameter `T` must be used as the type parameter for some loc
 LL | impl<'a, T> Remote1<Box<T>> for &'a T {
    |          ^ type parameter `T` must be used as the type parameter for some local type
    |
-   = note: implementing a foreign trait is only possible if at least one of the types for which is it implemented is local
+   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter
 
 error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
@@ -13,7 +13,7 @@ error[E0210]: type parameter `T` must be used as the type parameter for some loc
 LL | impl<'a, T> Remote1<&'a T> for Box<T> {
    |          ^ type parameter `T` must be used as the type parameter for some local type
    |
-   = note: implementing a foreign trait is only possible if at least one of the types for which is it implemented is local
+   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/coherence/impl[t]-foreign[fundamental[t]]-for-t.stderr
+++ b/src/test/ui/coherence/impl[t]-foreign[fundamental[t]]-for-t.stderr
@@ -4,7 +4,7 @@ error[E0210]: type parameter `T` must be used as the type parameter for some loc
 LL | impl<T> Remote1<Box<T>> for T {
    |      ^ type parameter `T` must be used as the type parameter for some local type
    |
-   = note: implementing a foreign trait is only possible if at least one of the types for which is it implemented is local
+   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter
 
 error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
@@ -13,7 +13,7 @@ error[E0210]: type parameter `T` must be used as the type parameter for some loc
 LL | impl<'a, T> Remote1<&'a T> for T {
    |          ^ type parameter `T` must be used as the type parameter for some local type
    |
-   = note: implementing a foreign trait is only possible if at least one of the types for which is it implemented is local
+   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/coherence/impl[t]-foreign[fundamental[t]_local]-for-foreign.stderr
+++ b/src/test/ui/coherence/impl[t]-foreign[fundamental[t]_local]-for-foreign.stderr
@@ -4,7 +4,7 @@ error[E0210]: type parameter `T` must be covered by another type when it appears
 LL | impl<T> Remote2<Box<T>, Local> for u32 {
    |      ^ type parameter `T` must be covered by another type when it appears before the first local type (`Local`)
    |
-   = note: implementing a foreign trait is only possible if at least one of the types for which is it implemented is local, and no uncovered type parameters appear before that first local type
+   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local, and no uncovered type parameters appear before that first local type
    = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`, where `T0` is the first and `Tn` is the last
 
 error[E0210]: type parameter `T` must be covered by another type when it appears before the first local type (`Local`)
@@ -13,7 +13,7 @@ error[E0210]: type parameter `T` must be covered by another type when it appears
 LL | impl<'a, T> Remote2<&'a T, Local> for u32 {
    |          ^ type parameter `T` must be covered by another type when it appears before the first local type (`Local`)
    |
-   = note: implementing a foreign trait is only possible if at least one of the types for which is it implemented is local, and no uncovered type parameters appear before that first local type
+   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local, and no uncovered type parameters appear before that first local type
    = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`, where `T0` is the first and `Tn` is the last
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/coherence/impl[t]-foreign[local]-for-fundamental[t].stderr
+++ b/src/test/ui/coherence/impl[t]-foreign[local]-for-fundamental[t].stderr
@@ -4,7 +4,7 @@ error[E0210]: type parameter `T` must be covered by another type when it appears
 LL | impl<T> Remote1<Local> for Box<T> {
    |      ^ type parameter `T` must be covered by another type when it appears before the first local type (`Local`)
    |
-   = note: implementing a foreign trait is only possible if at least one of the types for which is it implemented is local, and no uncovered type parameters appear before that first local type
+   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local, and no uncovered type parameters appear before that first local type
    = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`, where `T0` is the first and `Tn` is the last
 
 error[E0210]: type parameter `T` must be covered by another type when it appears before the first local type (`Local`)
@@ -13,7 +13,7 @@ error[E0210]: type parameter `T` must be covered by another type when it appears
 LL | impl<T> Remote1<Local> for &T {
    |      ^ type parameter `T` must be covered by another type when it appears before the first local type (`Local`)
    |
-   = note: implementing a foreign trait is only possible if at least one of the types for which is it implemented is local, and no uncovered type parameters appear before that first local type
+   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local, and no uncovered type parameters appear before that first local type
    = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`, where `T0` is the first and `Tn` is the last
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/coherence/impl[t]-foreign[local]-for-t.stderr
+++ b/src/test/ui/coherence/impl[t]-foreign[local]-for-t.stderr
@@ -4,7 +4,7 @@ error[E0210]: type parameter `T` must be covered by another type when it appears
 LL | impl<T> Remote1<Local> for T {
    |      ^ type parameter `T` must be covered by another type when it appears before the first local type (`Local`)
    |
-   = note: implementing a foreign trait is only possible if at least one of the types for which is it implemented is local, and no uncovered type parameters appear before that first local type
+   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local, and no uncovered type parameters appear before that first local type
    = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`, where `T0` is the first and `Tn` is the last
 
 error: aborting due to previous error

--- a/src/test/ui/coherence/impl[t]-foreign[t]-for-foreign.stderr
+++ b/src/test/ui/coherence/impl[t]-foreign[t]-for-foreign.stderr
@@ -4,7 +4,7 @@ error[E0210]: type parameter `T` must be used as the type parameter for some loc
 LL | impl<T> Remote1<T> for u32 {
    |      ^ type parameter `T` must be used as the type parameter for some local type
    |
-   = note: implementing a foreign trait is only possible if at least one of the types for which is it implemented is local
+   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter
 
 error: aborting due to previous error

--- a/src/test/ui/coherence/impl[t]-foreign[t]-for-fundamental.stderr
+++ b/src/test/ui/coherence/impl[t]-foreign[t]-for-fundamental.stderr
@@ -4,7 +4,7 @@ error[E0210]: type parameter `T` must be used as the type parameter for some loc
 LL | impl<T> Remote1<T> for Box<T> {
    |      ^ type parameter `T` must be used as the type parameter for some local type
    |
-   = note: implementing a foreign trait is only possible if at least one of the types for which is it implemented is local
+   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter
 
 error[E0210]: type parameter `B` must be used as the type parameter for some local type (e.g., `MyStruct<B>`)
@@ -13,7 +13,7 @@ error[E0210]: type parameter `B` must be used as the type parameter for some loc
 LL | impl<'a, A, B> Remote1<A> for &'a B {
    |             ^ type parameter `B` must be used as the type parameter for some local type
    |
-   = note: implementing a foreign trait is only possible if at least one of the types for which is it implemented is local
+   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/coherence/impl[t]-foreign[t]-for-t.stderr
+++ b/src/test/ui/coherence/impl[t]-foreign[t]-for-t.stderr
@@ -4,7 +4,7 @@ error[E0210]: type parameter `T` must be used as the type parameter for some loc
 LL | impl<T> Remote1<T> for T {
    |      ^ type parameter `T` must be used as the type parameter for some local type
    |
-   = note: implementing a foreign trait is only possible if at least one of the types for which is it implemented is local
+   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter
 
 error: aborting due to previous error

--- a/src/test/ui/error-codes/e0119/issue-28981.stderr
+++ b/src/test/ui/error-codes/e0119/issue-28981.stderr
@@ -14,7 +14,7 @@ error[E0210]: type parameter `Foo` must be used as the type parameter for some l
 LL | impl<Foo> Deref for Foo { }
    |      ^^^ type parameter `Foo` must be used as the type parameter for some local type
    |
-   = note: implementing a foreign trait is only possible if at least one of the types for which is it implemented is local
+   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/issues/issue-41974.stderr
+++ b/src/test/ui/issues/issue-41974.stderr
@@ -21,7 +21,7 @@ error[E0210]: type parameter `T` must be used as the type parameter for some loc
 LL | impl<T> Drop for T where T: A {
    |      ^ type parameter `T` must be used as the type parameter for some local type
    |
-   = note: implementing a foreign trait is only possible if at least one of the types for which is it implemented is local
+   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter
 
 error: aborting due to 3 previous errors

--- a/src/test/ui/orphan-check-diagnostics.stderr
+++ b/src/test/ui/orphan-check-diagnostics.stderr
@@ -4,7 +4,7 @@ error[E0210]: type parameter `T` must be used as the type parameter for some loc
 LL | impl<T> RemoteTrait for T where T: LocalTrait {}
    |      ^ type parameter `T` must be used as the type parameter for some local type
    |
-   = note: implementing a foreign trait is only possible if at least one of the types for which is it implemented is local
+   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter
 
 error: aborting due to previous error

--- a/src/test/ui/type-alias-impl-trait/incoherent-assoc-imp-trait.stderr
+++ b/src/test/ui/type-alias-impl-trait/incoherent-assoc-imp-trait.stderr
@@ -14,7 +14,7 @@ error[E0210]: type parameter `F` must be used as the type parameter for some loc
 LL | impl<F> FnOnce<()> for &F {
    |      ^ type parameter `F` must be used as the type parameter for some local type
    |
-   = note: implementing a foreign trait is only possible if at least one of the types for which is it implemented is local
+   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter
 
 error: aborting due to 2 previous errors


### PR DESCRIPTION
Fixes the grammar in the error note for [E0210] from:

_"= note: implementing a foreign trait is only possible if at least one of the types for which **is it** implemented is local"_

to:

_"= note: implementing a foreign trait is only possible if at least one of the types for which **it is** implemented is local"_

The content of this commit is the result of running the following command at the repository root:

`find . \( -type d -name .git -prune \) -o -type f -print0 | xargs -0 sed -i 's/which is it implemented/which it is implemented/g'`