### PR TITLE
Suggest correct place to add `self` parameter when inside closure

### DIFF
--- a/src/test/ui/error-codes/E0424.rs
+++ b/src/test/ui/error-codes/E0424.rs
@@ -10,6 +10,10 @@ impl Foo {
     fn baz(_: i32) {
         self.bar(); //~ ERROR E0424
     }
+
+    fn qux() {
+        let _ = || self.bar(); //~ ERROR E0424
+    }
 }
 
 fn main () {

--- a/src/test/ui/error-codes/E0424.stderr
+++ b/src/test/ui/error-codes/E0424.stderr
@@ -24,14 +24,27 @@ help: add a `self` receiver parameter to make the associated `fn` a method
 LL |     fn baz(&self, _: i32) {
    |            ^^^^^^
 
+error[E0424]: expected value, found module `self`
+  --> $DIR/E0424.rs:15:20
+   |
+LL |     fn qux() {
+   |        --- this function doesn't have a `self` parameter
+LL |         let _ = || self.bar();
+   |                    ^^^^ `self` value is a keyword only available in methods with a `self` parameter
+   |
+help: add a `self` receiver parameter to make the associated `fn` a method
+   |
+LL |     fn qux(&self) {
+   |            ^^^^^
+
 error[E0424]: expected unit struct, unit variant or constant, found module `self`
-  --> $DIR/E0424.rs:16:9
+  --> $DIR/E0424.rs:20:9
    |
 LL | fn main () {
    |    ---- this function can't have a `self` parameter
 LL |     let self = "self";
    |         ^^^^ `self` value is a keyword and may not be bound to variables or shadowed
 
-error: aborting due to 3 previous errors
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0424`.

--- a/src/test/ui/issues/issue-5099.rs
+++ b/src/test/ui/issues/issue-5099.rs
@@ -5,6 +5,9 @@ trait B <A> {
     fn b(x: i32) {
         this.b(x); //~ ERROR cannot find value `this` in this scope
     }
+    fn c() {
+        let _ = || this.a; //~ ERROR cannot find value `this` in this scope
+    }
 }
 
 fn main() {}

--- a/src/test/ui/issues/issue-5099.stderr
+++ b/src/test/ui/issues/issue-5099.stderr
@@ -28,6 +28,21 @@ help: if you meant to use `self`, you are also missing a `self` receiver argumen
 LL |     fn b(&self, x: i32) {
    |          ^^^^^^
 
-error: aborting due to 2 previous errors
+error[E0425]: cannot find value `this` in this scope
+  --> $DIR/issue-5099.rs:9:20
+   |
+LL |         let _ = || this.a;
+   |                    ^^^^ not found in this scope
+   |
+help: you might have meant to use `self` here instead
+   |
+LL |         let _ = || self.a;
+   |                    ^^^^
+help: if you meant to use `self`, you are also missing a `self` receiver argument
+   |
+LL |     fn c(&self) {
+   |          ^^^^^
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0425`.


### PR DESCRIPTION
It would incorrectly suggest adding it as a parameter to the closure instead of the containing function.

[For example](https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=1936bcd1e5f981573386e0cee985c3c0):
```
help: add a `self` receiver parameter to make the associated `fn` a method
  |
5 |         let _ = || self&self;
  |                        ^^^^^
```

`DiagnosticMetadata.current_function` is only used for these messages so tweaking its behavior should be ok.