### PR TITLE
Set `MDBOOK_OUTPUT__HTML__INPUT_404` on linkchecker

### DIFF
--- a/src/tools/linkchecker/linkcheck.sh
+++ b/src/tools/linkchecker/linkcheck.sh
@@ -34,6 +34,9 @@ then
     exit 1
 fi
 
+# Avoid failure caused by newer mdbook.
+export MDBOOK_OUTPUT__HTML__INPUT_404=""
+
 book_name=""
 # Iterative will avoid cleaning up, so you can quickly run it repeatedly.
 iterative=0


### PR DESCRIPTION
This is found in https://github.com/rust-lang/nomicon/pull/240.
It seems the spurious failure shows up without this flag.
