### PR TITLE
Optimize const value interning for ZST types

### DIFF
--- a/compiler/rustc_mir/src/interpret/intern.rs
+++ b/compiler/rustc_mir/src/interpret/intern.rs
@@ -187,6 +187,12 @@ impl<'rt, 'mir, 'tcx: 'mir, M: CompileTimeMachine<'mir, 'tcx>> ValueVisitor<'mir
                 return walked;
             }
         }
+
+        // ZSTs do not need validation unless they're uninhabited
+        if mplace.layout.is_zst() && !mplace.layout.abi.is_uninhabited() {
+            return Ok(());
+        }
+
         self.walk_aggregate(mplace, fields)
     }
 

--- a/src/test/ui/issues/issue-68010-large-zst-consts.rs
+++ b/src/test/ui/issues/issue-68010-large-zst-consts.rs
@@ -1,0 +1,5 @@
+// build-pass
+
+fn main() {
+    println!("{}", [(); std::usize::MAX].len());
+}


### PR DESCRIPTION
Interning can skip any inhabited ZST type in general.

Fixes #68010

r? @oli-obk 