### PR TITLE
Improve wording of "cannot multiply" type error

### DIFF
--- a/compiler/rustc_typeck/src/check/op.rs
+++ b/compiler/rustc_typeck/src/check/op.rs
@@ -302,7 +302,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                 true,
                             ),
                             hir::BinOpKind::Mul => (
-                                format!("cannot multiply `{}` to `{}`", rhs_ty, lhs_ty),
+                                format!("cannot multiply `{}` by `{}`", lhs_ty, rhs_ty),
                                 Some("std::ops::Mul"),
                                 true,
                             ),

--- a/library/core/src/ops/arith.rs
+++ b/library/core/src/ops/arith.rs
@@ -302,7 +302,7 @@ sub_impl! { usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 f32 f64 }
 #[lang = "mul"]
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_on_unimplemented(
-    message = "cannot multiply `{Rhs}` to `{Self}`",
+    message = "cannot multiply `{Self}` by `{Rhs}`",
     label = "no implementation for `{Self} * {Rhs}`"
 )]
 #[doc(alias = "*")]
@@ -826,7 +826,7 @@ sub_assign_impl! { usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 f32 f64 }
 #[lang = "mul_assign"]
 #[stable(feature = "op_assign_traits", since = "1.8.0")]
 #[rustc_on_unimplemented(
-    message = "cannot multiply-assign `{Rhs}` to `{Self}`",
+    message = "cannot multiply-assign `{Self}` by `{Rhs}`",
     label = "no implementation for `{Self} *= {Rhs}`"
 )]
 #[doc(alias = "*")]

--- a/src/test/ui/binop/binop-mul-bool.rs
+++ b/src/test/ui/binop/binop-mul-bool.rs
@@ -1,3 +1,3 @@
-// error-pattern:cannot multiply `bool` to `bool`
+// error-pattern:cannot multiply `bool` by `bool`
 
 fn main() { let x = true * false; }

--- a/src/test/ui/binop/binop-mul-bool.stderr
+++ b/src/test/ui/binop/binop-mul-bool.stderr
@@ -1,4 +1,4 @@
-error[E0369]: cannot multiply `bool` to `bool`
+error[E0369]: cannot multiply `bool` by `bool`
   --> $DIR/binop-mul-bool.rs:3:26
    |
 LL | fn main() { let x = true * false; }

--- a/src/test/ui/binop/binop-mul-i32-f32.rs
+++ b/src/test/ui/binop/binop-mul-i32-f32.rs
@@ -1,0 +1,5 @@
+fn foo(x: i32, y: f32) -> f32 {
+    x * y //~ ERROR cannot multiply `i32` by `f32`
+}
+
+fn main() {}

--- a/src/test/ui/binop/binop-mul-i32-f32.stderr
+++ b/src/test/ui/binop/binop-mul-i32-f32.stderr
@@ -1,0 +1,11 @@
+error[E0277]: cannot multiply `i32` by `f32`
+  --> $DIR/binop-mul-i32-f32.rs:2:7
+   |
+LL |     x * y
+   |       ^ no implementation for `i32 * f32`
+   |
+   = help: the trait `Mul<f32>` is not implemented for `i32`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/issues/issue-28837.rs
+++ b/src/test/ui/issues/issue-28837.rs
@@ -7,7 +7,7 @@ fn main() {
 
     a - a; //~ ERROR cannot subtract `A` from `A`
 
-    a * a; //~ ERROR cannot multiply `A` to `A`
+    a * a; //~ ERROR cannot multiply `A` by `A`
 
     a / a; //~ ERROR cannot divide `A` by `A`
 

--- a/src/test/ui/issues/issue-28837.stderr
+++ b/src/test/ui/issues/issue-28837.stderr
@@ -18,7 +18,7 @@ LL |     a - a;
    |
    = note: an implementation of `std::ops::Sub` might be missing for `A`
 
-error[E0369]: cannot multiply `A` to `A`
+error[E0369]: cannot multiply `A` by `A`
   --> $DIR/issue-28837.rs:10:7
    |
 LL |     a * a;

--- a/src/test/ui/issues/issue-35668.rs
+++ b/src/test/ui/issues/issue-35668.rs
@@ -1,6 +1,6 @@
 fn func<'a, T>(a: &'a [T]) -> impl Iterator<Item=&'a T> {
     a.iter().map(|a| a*a)
-    //~^ ERROR cannot multiply `&T` to `&T`
+    //~^ ERROR cannot multiply `&T` by `&T`
 }
 
 fn main() {

--- a/src/test/ui/issues/issue-35668.stderr
+++ b/src/test/ui/issues/issue-35668.stderr
@@ -1,4 +1,4 @@
-error[E0369]: cannot multiply `&T` to `&T`
+error[E0369]: cannot multiply `&T` by `&T`
   --> $DIR/issue-35668.rs:2:23
    |
 LL |     a.iter().map(|a| a*a)

--- a/src/test/ui/issues/issue-3820.rs
+++ b/src/test/ui/issues/issue-3820.rs
@@ -11,5 +11,5 @@ impl Thing {
 fn main() {
     let u = Thing {x: 2};
     let _v = u.mul(&3); // This is ok
-    let w = u * 3; //~ ERROR cannot multiply `{integer}` to `Thing`
+    let w = u * 3; //~ ERROR cannot multiply `Thing` by `{integer}`
 }

--- a/src/test/ui/issues/issue-3820.stderr
+++ b/src/test/ui/issues/issue-3820.stderr
@@ -1,4 +1,4 @@
-error[E0369]: cannot multiply `{integer}` to `Thing`
+error[E0369]: cannot multiply `Thing` by `{integer}`
   --> $DIR/issue-3820.rs:14:15
    |
 LL |     let w = u * 3;

--- a/src/test/ui/mismatched_types/binops.rs
+++ b/src/test/ui/mismatched_types/binops.rs
@@ -1,7 +1,7 @@
 fn main() {
     1 + Some(1); //~ ERROR cannot add `Option<{integer}>` to `{integer}`
     2 as usize - Some(1); //~ ERROR cannot subtract `Option<{integer}>` from `usize`
-    3 * (); //~ ERROR cannot multiply `()` to `{integer}`
+    3 * (); //~ ERROR cannot multiply `{integer}` by `()`
     4 / ""; //~ ERROR cannot divide `{integer}` by `&str`
     5 < String::new(); //~ ERROR can't compare `{integer}` with `String`
     6 == Ok(1); //~ ERROR can't compare `{integer}` with `std::result::Result<{integer}, _>`

--- a/src/test/ui/mismatched_types/binops.stderr
+++ b/src/test/ui/mismatched_types/binops.stderr
@@ -14,7 +14,7 @@ LL |     2 as usize - Some(1);
    |
    = help: the trait `Sub<Option<{integer}>>` is not implemented for `usize`
 
-error[E0277]: cannot multiply `()` to `{integer}`
+error[E0277]: cannot multiply `{integer}` by `()`
   --> $DIR/binops.rs:4:7
    |
 LL |     3 * ();

--- a/src/test/ui/pattern/pattern-tyvar-2.rs
+++ b/src/test/ui/pattern/pattern-tyvar-2.rs
@@ -1,6 +1,6 @@
 enum Bar { T1((), Option<Vec<isize>>), T2, }
 
 fn foo(t: Bar) -> isize { match t { Bar::T1(_, Some(x)) => { return x * 3; } _ => { panic!(); } } }
-//~^ ERROR cannot multiply `{integer}` to `Vec<isize>`
+//~^ ERROR cannot multiply `Vec<isize>` by `{integer}`
 
 fn main() { }

--- a/src/test/ui/pattern/pattern-tyvar-2.stderr
+++ b/src/test/ui/pattern/pattern-tyvar-2.stderr
@@ -1,4 +1,4 @@
-error[E0369]: cannot multiply `{integer}` to `Vec<isize>`
+error[E0369]: cannot multiply `Vec<isize>` by `{integer}`
   --> $DIR/pattern-tyvar-2.rs:3:71
    |
 LL | fn foo(t: Bar) -> isize { match t { Bar::T1(_, Some(x)) => { return x * 3; } _ => { panic!(); } } }

--- a/src/test/ui/traits/trait-resolution-in-overloaded-op.rs
+++ b/src/test/ui/traits/trait-resolution-in-overloaded-op.rs
@@ -5,7 +5,7 @@ trait MyMul<Rhs, Res> {
 }
 
 fn foo<T: MyMul<f64, f64>>(a: &T, b: f64) -> f64 {
-    a * b //~ ERROR cannot multiply `f64` to `&T`
+    a * b //~ ERROR cannot multiply `&T` by `f64`
 }
 
 fn main() {}

--- a/src/test/ui/traits/trait-resolution-in-overloaded-op.stderr
+++ b/src/test/ui/traits/trait-resolution-in-overloaded-op.stderr
@@ -1,4 +1,4 @@
-error[E0369]: cannot multiply `f64` to `&T`
+error[E0369]: cannot multiply `&T` by `f64`
   --> $DIR/trait-resolution-in-overloaded-op.rs:8:7
    |
 LL |     a * b


### PR DESCRIPTION
For example, if you had this code:

    fn foo(x: i32, y: f32) -> f32 {
        x * y
    }

You would get this error:

    error[E0277]: cannot multiply `f32` to `i32`
     --> src/lib.rs:2:7
      |
    2 |     x * y
      |       ^ no implementation for `i32 * f32`
      |
      = help: the trait `Mul<f32>` is not implemented for `i32`

However, that's not usually how people describe multiplication. People
usually describe multiplication like how the division error words it:

    error[E0277]: cannot divide `i32` by `f32`
     --> src/lib.rs:2:7
      |
    2 |     x / y
      |       ^ no implementation for `i32 / f32`
      |
      = help: the trait `Div<f32>` is not implemented for `i32`

So that's what this change does. It changes this:

    error[E0277]: cannot multiply `f32` to `i32`
     --> src/lib.rs:2:7
      |
    2 |     x * y
      |       ^ no implementation for `i32 * f32`
      |
      = help: the trait `Mul<f32>` is not implemented for `i32`

To this:

    error[E0277]: cannot multiply `i32` by `f32`
     --> src/lib.rs:2:7
      |
    2 |     x * y
      |       ^ no implementation for `i32 * f32`
      |
      = help: the trait `Mul<f32>` is not implemented for `i32`
