### PR TITLE
Calculate visibilities once in resolve

### DIFF
--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -2381,15 +2381,6 @@ impl VisibilityKind<'_> {
             VisibilityKind::Crate(..) | VisibilityKind::Restricted { .. } => true,
         }
     }
-
-    pub fn descr(&self) -> &'static str {
-        match *self {
-            VisibilityKind::Public => "public",
-            VisibilityKind::Inherited => "private",
-            VisibilityKind::Crate(..) => "crate-visible",
-            VisibilityKind::Restricted { .. } => "restricted",
-        }
-    }
 }
 
 #[derive(Debug, HashStable_Generic)]

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -28,7 +28,6 @@ use rustc_middle::ty::{self, SymbolName, Ty, TyCtxt};
 use rustc_serialize::{opaque, Encodable, Encoder};
 use rustc_session::config::CrateType;
 use rustc_span::hygiene::{ExpnDataEncodeMode, HygieneEncodeContext};
-use rustc_span::source_map::Spanned;
 use rustc_span::symbol::{sym, Ident, Symbol};
 use rustc_span::{self, ExternalSource, FileName, SourceFile, Span, SyntaxContext};
 use rustc_target::abi::VariantIdx;
@@ -436,8 +435,7 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
 
     fn encode_info_for_items(&mut self) {
         let krate = self.tcx.hir().krate();
-        let vis = Spanned { span: rustc_span::DUMMY_SP, node: hir::VisibilityKind::Public };
-        self.encode_info_for_mod(hir::CRATE_HIR_ID, &krate.item.module, &krate.item.attrs, &vis);
+        self.encode_info_for_mod(hir::CRATE_HIR_ID, &krate.item.module, &krate.item.attrs);
 
         // Proc-macro crates only export proc-macro items, which are looked
         // up using `proc_macro_data`
@@ -739,12 +737,8 @@ impl EncodeContext<'a, 'tcx> {
             is_non_exhaustive: variant.is_field_list_non_exhaustive(),
         };
 
-        let enum_id = tcx.hir().local_def_id_to_hir_id(def.did.expect_local());
-        let enum_vis = &tcx.hir().expect_item(enum_id).vis;
-
         record!(self.tables.kind[def_id] <- EntryKind::Variant(self.lazy(data)));
-        record!(self.tables.visibility[def_id] <-
-            ty::Visibility::from_hir(enum_vis, enum_id, self.tcx));
+        record!(self.tables.visibility[def_id] <- self.tcx.visibility(def_id));
         record!(self.tables.span[def_id] <- self.tcx.def_span(def_id));
         record!(self.tables.attributes[def_id] <- &self.tcx.get_attrs(def_id)[..]);
         record!(self.tables.expn_that_defined[def_id] <- self.tcx.expansion_that_defined(def_id));
@@ -785,17 +779,8 @@ impl EncodeContext<'a, 'tcx> {
             is_non_exhaustive: variant.is_field_list_non_exhaustive(),
         };
 
-        // Variant constructors have the same visibility as the parent enums, unless marked as
-        // non-exhaustive, in which case they are lowered to `pub(crate)`.
-        let enum_id = tcx.hir().local_def_id_to_hir_id(def.did.expect_local());
-        let enum_vis = &tcx.hir().expect_item(enum_id).vis;
-        let mut ctor_vis = ty::Visibility::from_hir(enum_vis, enum_id, tcx);
-        if variant.is_field_list_non_exhaustive() && ctor_vis == ty::Visibility::Public {
-            ctor_vis = ty::Visibility::Restricted(DefId::local(CRATE_DEF_INDEX));
-        }
-
         record!(self.tables.kind[def_id] <- EntryKind::Variant(self.lazy(data)));
-        record!(self.tables.visibility[def_id] <- ctor_vis);
+        record!(self.tables.visibility[def_id] <- self.tcx.visibility(def_id));
         record!(self.tables.span[def_id] <- self.tcx.def_span(def_id));
         self.encode_stability(def_id);
         self.encode_deprecation(def_id);
@@ -811,13 +796,7 @@ impl EncodeContext<'a, 'tcx> {
         self.encode_promoted_mir(def_id.expect_local());
     }
 
-    fn encode_info_for_mod(
-        &mut self,
-        id: hir::HirId,
-        md: &hir::Mod<'_>,
-        attrs: &[ast::Attribute],
-        vis: &hir::Visibility<'_>,
-    ) {
+    fn encode_info_for_mod(&mut self, id: hir::HirId, md: &hir::Mod<'_>, attrs: &[ast::Attribute]) {
         let tcx = self.tcx;
         let local_def_id = tcx.hir().local_def_id(id);
         let def_id = local_def_id.to_def_id();
@@ -850,7 +829,7 @@ impl EncodeContext<'a, 'tcx> {
         };
 
         record!(self.tables.kind[def_id] <- EntryKind::Mod(self.lazy(data)));
-        record!(self.tables.visibility[def_id] <- ty::Visibility::from_hir(vis, id, self.tcx));
+        record!(self.tables.visibility[def_id] <- self.tcx.visibility(def_id));
         record!(self.tables.span[def_id] <- self.tcx.def_span(def_id));
         record!(self.tables.attributes[def_id] <- attrs);
         if self.is_proc_macro {
@@ -881,7 +860,7 @@ impl EncodeContext<'a, 'tcx> {
         let variant_data = tcx.hir().expect_variant_data(variant_id);
 
         record!(self.tables.kind[def_id] <- EntryKind::Field);
-        record!(self.tables.visibility[def_id] <- field.vis);
+        record!(self.tables.visibility[def_id] <- self.tcx.visibility(def_id));
         record!(self.tables.span[def_id] <- self.tcx.def_span(def_id));
         record!(self.tables.attributes[def_id] <- variant_data.fields()[field_index].attrs);
         record!(self.tables.expn_that_defined[def_id] <- self.tcx.expansion_that_defined(def_id));
@@ -906,25 +885,8 @@ impl EncodeContext<'a, 'tcx> {
             is_non_exhaustive: variant.is_field_list_non_exhaustive(),
         };
 
-        let struct_id = tcx.hir().local_def_id_to_hir_id(adt_def.did.expect_local());
-        let struct_vis = &tcx.hir().expect_item(struct_id).vis;
-        let mut ctor_vis = ty::Visibility::from_hir(struct_vis, struct_id, tcx);
-        for field in &variant.fields {
-            if ctor_vis.is_at_least(field.vis, tcx) {
-                ctor_vis = field.vis;
-            }
-        }
-
-        // If the structure is marked as non_exhaustive then lower the visibility
-        // to within the crate.
-        if adt_def.non_enum_variant().is_field_list_non_exhaustive()
-            && ctor_vis == ty::Visibility::Public
-        {
-            ctor_vis = ty::Visibility::Restricted(DefId::local(CRATE_DEF_INDEX));
-        }
-
         record!(self.tables.kind[def_id] <- EntryKind::Struct(self.lazy(data), adt_def.repr));
-        record!(self.tables.visibility[def_id] <- ctor_vis);
+        record!(self.tables.visibility[def_id] <- self.tcx.visibility(def_id));
         record!(self.tables.span[def_id] <- self.tcx.def_span(def_id));
         record!(self.tables.expn_that_defined[def_id] <- self.tcx.expansion_that_defined(def_id));
         self.encode_stability(def_id);
@@ -1030,7 +992,7 @@ impl EncodeContext<'a, 'tcx> {
                 EntryKind::AssocType(container)
             }
         });
-        record!(self.tables.visibility[def_id] <- trait_item.vis);
+        record!(self.tables.visibility[def_id] <- self.tcx.visibility(def_id));
         record!(self.tables.span[def_id] <- ast_item.span);
         record!(self.tables.attributes[def_id] <- ast_item.attrs);
         self.encode_ident_span(def_id, ast_item.ident);
@@ -1112,7 +1074,7 @@ impl EncodeContext<'a, 'tcx> {
             }
             ty::AssocKind::Type => EntryKind::AssocType(container)
         });
-        record!(self.tables.visibility[def_id] <- impl_item.vis);
+        record!(self.tables.visibility[def_id] <- self.tcx.visibility(def_id));
         record!(self.tables.span[def_id] <- ast_item.span);
         record!(self.tables.attributes[def_id] <- ast_item.attrs);
         self.encode_ident_span(def_id, impl_item.ident);
@@ -1261,7 +1223,7 @@ impl EncodeContext<'a, 'tcx> {
                 EntryKind::Fn(self.lazy(data))
             }
             hir::ItemKind::Mod(ref m) => {
-                return self.encode_info_for_mod(item.hir_id, m, &item.attrs, &item.vis);
+                return self.encode_info_for_mod(item.hir_id, m, &item.attrs);
             }
             hir::ItemKind::ForeignMod(_) => EntryKind::ForeignMod,
             hir::ItemKind::GlobalAsm(..) => EntryKind::GlobalAsm,
@@ -1352,8 +1314,7 @@ impl EncodeContext<'a, 'tcx> {
             hir::ItemKind::ExternCrate(_) |
             hir::ItemKind::Use(..) => bug!("cannot encode info for item {:?}", item),
         });
-        record!(self.tables.visibility[def_id] <-
-            ty::Visibility::from_hir(&item.vis, item.hir_id, tcx));
+        record!(self.tables.visibility[def_id] <- self.tcx.visibility(def_id));
         record!(self.tables.span[def_id] <- self.tcx.def_span(def_id));
         record!(self.tables.attributes[def_id] <- item.attrs);
         record!(self.tables.expn_that_defined[def_id] <- self.tcx.expansion_that_defined(def_id));
@@ -1470,7 +1431,7 @@ impl EncodeContext<'a, 'tcx> {
     fn encode_info_for_macro_def(&mut self, macro_def: &hir::MacroDef<'_>) {
         let def_id = self.tcx.hir().local_def_id(macro_def.hir_id).to_def_id();
         record!(self.tables.kind[def_id] <- EntryKind::MacroDef(self.lazy(macro_def.ast.clone())));
-        record!(self.tables.visibility[def_id] <- ty::Visibility::Public);
+        record!(self.tables.visibility[def_id] <- self.tcx.visibility(def_id));
         record!(self.tables.span[def_id] <- macro_def.span);
         record!(self.tables.attributes[def_id] <- macro_def.attrs);
         self.encode_ident_span(def_id, macro_def.ident);
@@ -1480,7 +1441,6 @@ impl EncodeContext<'a, 'tcx> {
 
     fn encode_info_for_generic_param(&mut self, def_id: DefId, kind: EntryKind, encode_type: bool) {
         record!(self.tables.kind[def_id] <- kind);
-        record!(self.tables.visibility[def_id] <- ty::Visibility::Public);
         record!(self.tables.span[def_id] <- self.tcx.def_span(def_id));
         if encode_type {
             self.encode_item_type(def_id);
@@ -1505,7 +1465,6 @@ impl EncodeContext<'a, 'tcx> {
 
             _ => bug!("closure that is neither generator nor closure"),
         });
-        record!(self.tables.visibility[def_id.to_def_id()] <- ty::Visibility::Public);
         record!(self.tables.span[def_id.to_def_id()] <- self.tcx.def_span(def_id));
         record!(self.tables.attributes[def_id.to_def_id()] <- &self.tcx.get_attrs(def_id.to_def_id())[..]);
         self.encode_item_type(def_id.to_def_id());
@@ -1525,7 +1484,6 @@ impl EncodeContext<'a, 'tcx> {
         let qualifs = self.tcx.mir_const_qualif(def_id);
 
         record!(self.tables.kind[def_id.to_def_id()] <- EntryKind::AnonConst(qualifs, const_data));
-        record!(self.tables.visibility[def_id.to_def_id()] <- ty::Visibility::Public);
         record!(self.tables.span[def_id.to_def_id()] <- self.tcx.def_span(def_id));
         self.encode_item_type(def_id.to_def_id());
         self.encode_generics(def_id.to_def_id());
@@ -1762,8 +1720,7 @@ impl EncodeContext<'a, 'tcx> {
             hir::ForeignItemKind::Static(_, hir::Mutability::Not) => EntryKind::ForeignImmStatic,
             hir::ForeignItemKind::Type => EntryKind::ForeignType,
         });
-        record!(self.tables.visibility[def_id] <-
-            ty::Visibility::from_hir(&nitem.vis, nitem.hir_id, self.tcx));
+        record!(self.tables.visibility[def_id] <- self.tcx.visibility(def_id));
         record!(self.tables.span[def_id] <- nitem.span);
         record!(self.tables.attributes[def_id] <- nitem.attrs);
         self.encode_ident_span(def_id, nitem.ident);

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -1267,6 +1267,7 @@ rustc_queries! {
 
     TypeChecking {
         query visibility(def_id: DefId) -> ty::Visibility {
+            eval_always
             desc { |tcx| "computing visibility of `{}`", tcx.def_path_str(def_id) }
         }
     }

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -22,7 +22,7 @@ use crate::ty::{
     ExistentialPredicate, FloatVar, FloatVid, GenericParamDefKind, InferConst, InferTy, IntVar,
     IntVid, List, ParamConst, ParamTy, PolyFnSig, Predicate, PredicateInner, PredicateKind,
     ProjectionTy, Region, RegionKind, ReprOptions, TraitObjectVisitor, Ty, TyKind, TyS, TyVar,
-    TyVid, TypeAndMut,
+    TyVid, TypeAndMut, Visibility,
 };
 use rustc_ast as ast;
 use rustc_ast::expand::allocator::AllocatorKind;
@@ -911,6 +911,9 @@ pub struct GlobalCtxt<'tcx> {
     /// Common consts, pre-interned for your convenience.
     pub consts: CommonConsts<'tcx>,
 
+    /// Visibilities produced by resolver.
+    pub visibilities: FxHashMap<LocalDefId, Visibility>,
+
     /// Resolutions of `extern crate` items produced by resolver.
     extern_crate_map: FxHashMap<LocalDefId, CrateNum>,
 
@@ -1124,6 +1127,7 @@ impl<'tcx> TyCtxt<'tcx> {
             types: common_types,
             lifetimes: common_lifetimes,
             consts: common_consts,
+            visibilities: resolutions.visibilities,
             extern_crate_map: resolutions.extern_crate_map,
             trait_map,
             export_map: resolutions.export_map,

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -125,6 +125,7 @@ mod sty;
 pub struct ResolverOutputs {
     pub definitions: rustc_hir::definitions::Definitions,
     pub cstore: Box<CrateStoreDyn>,
+    pub visibilities: FxHashMap<LocalDefId, Visibility>,
     pub extern_crate_map: FxHashMap<LocalDefId, CrateNum>,
     pub maybe_unused_trait_imports: FxHashSet<LocalDefId>,
     pub maybe_unused_extern_crates: Vec<(LocalDefId, Span)>,

--- a/compiler/rustc_privacy/src/lib.rs
+++ b/compiler/rustc_privacy/src/lib.rs
@@ -1,6 +1,7 @@
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
 #![feature(in_band_lifetimes)]
 #![feature(nll)]
+#![feature(or_patterns)]
 #![recursion_limit = "256"]
 
 use rustc_attr as attr;
@@ -14,13 +15,14 @@ use rustc_hir::{AssocItemKind, HirIdSet, Node, PatKind};
 use rustc_middle::bug;
 use rustc_middle::hir::map::Map;
 use rustc_middle::middle::privacy::{AccessLevel, AccessLevels};
+use rustc_middle::span_bug;
 use rustc_middle::ty::fold::TypeVisitor;
 use rustc_middle::ty::query::Providers;
 use rustc_middle::ty::subst::InternalSubsts;
 use rustc_middle::ty::{self, GenericParamDefKind, TraitRef, Ty, TyCtxt, TypeFoldable};
 use rustc_session::lint;
 use rustc_span::hygiene::Transparency;
-use rustc_span::symbol::{kw, sym, Ident};
+use rustc_span::symbol::{kw, Ident};
 use rustc_span::Span;
 
 use std::marker::PhantomData;
@@ -233,125 +235,6 @@ where
     }
 }
 
-fn def_id_visibility<'tcx>(
-    tcx: TyCtxt<'tcx>,
-    def_id: DefId,
-) -> (ty::Visibility, Span, &'static str) {
-    match def_id.as_local().map(|def_id| tcx.hir().local_def_id_to_hir_id(def_id)) {
-        Some(hir_id) => {
-            let vis = match tcx.hir().get(hir_id) {
-                Node::Item(item) => &item.vis,
-                Node::ForeignItem(foreign_item) => &foreign_item.vis,
-                Node::MacroDef(macro_def) => {
-                    if tcx.sess.contains_name(&macro_def.attrs, sym::macro_export) {
-                        return (ty::Visibility::Public, macro_def.span, "public");
-                    } else {
-                        &macro_def.vis
-                    }
-                }
-                Node::TraitItem(..) | Node::Variant(..) => {
-                    return def_id_visibility(tcx, tcx.hir().get_parent_did(hir_id).to_def_id());
-                }
-                Node::ImplItem(impl_item) => {
-                    match tcx.hir().get(tcx.hir().get_parent_item(hir_id)) {
-                        Node::Item(item) => match &item.kind {
-                            hir::ItemKind::Impl { of_trait: None, .. } => &impl_item.vis,
-                            hir::ItemKind::Impl { of_trait: Some(trait_ref), .. } => {
-                                return def_id_visibility(tcx, trait_ref.path.res.def_id());
-                            }
-                            kind => bug!("unexpected item kind: {:?}", kind),
-                        },
-                        node => bug!("unexpected node kind: {:?}", node),
-                    }
-                }
-                Node::Ctor(vdata) => {
-                    let parent_hir_id = tcx.hir().get_parent_node(hir_id);
-                    match tcx.hir().get(parent_hir_id) {
-                        Node::Variant(..) => {
-                            let parent_did = tcx.hir().local_def_id(parent_hir_id);
-                            let (mut ctor_vis, mut span, mut descr) =
-                                def_id_visibility(tcx, parent_did.to_def_id());
-
-                            let adt_def = tcx.adt_def(tcx.hir().get_parent_did(hir_id).to_def_id());
-                            let ctor_did = tcx.hir().local_def_id(vdata.ctor_hir_id().unwrap());
-                            let variant = adt_def.variant_with_ctor_id(ctor_did.to_def_id());
-
-                            if variant.is_field_list_non_exhaustive()
-                                && ctor_vis == ty::Visibility::Public
-                            {
-                                ctor_vis =
-                                    ty::Visibility::Restricted(DefId::local(CRATE_DEF_INDEX));
-                                let attrs = tcx.get_attrs(variant.def_id);
-                                span = tcx
-                                    .sess
-                                    .find_by_name(&attrs, sym::non_exhaustive)
-                                    .unwrap()
-                                    .span;
-                                descr = "crate-visible";
-                            }
-
-                            return (ctor_vis, span, descr);
-                        }
-                        Node::Item(..) => {
-                            let item = match tcx.hir().get(parent_hir_id) {
-                                Node::Item(item) => item,
-                                node => bug!("unexpected node kind: {:?}", node),
-                            };
-                            let (mut ctor_vis, mut span, mut descr) = (
-                                ty::Visibility::from_hir(&item.vis, parent_hir_id, tcx),
-                                item.vis.span,
-                                item.vis.node.descr(),
-                            );
-                            for field in vdata.fields() {
-                                let field_vis = ty::Visibility::from_hir(&field.vis, hir_id, tcx);
-                                if ctor_vis.is_at_least(field_vis, tcx) {
-                                    ctor_vis = field_vis;
-                                    span = field.vis.span;
-                                    descr = field.vis.node.descr();
-                                }
-                            }
-
-                            // If the structure is marked as non_exhaustive then lower the
-                            // visibility to within the crate.
-                            if ctor_vis == ty::Visibility::Public {
-                                let adt_def =
-                                    tcx.adt_def(tcx.hir().get_parent_did(hir_id).to_def_id());
-                                if adt_def.non_enum_variant().is_field_list_non_exhaustive() {
-                                    ctor_vis =
-                                        ty::Visibility::Restricted(DefId::local(CRATE_DEF_INDEX));
-                                    span = tcx
-                                        .sess
-                                        .find_by_name(&item.attrs, sym::non_exhaustive)
-                                        .unwrap()
-                                        .span;
-                                    descr = "crate-visible";
-                                }
-                            }
-
-                            return (ctor_vis, span, descr);
-                        }
-                        node => bug!("unexpected node kind: {:?}", node),
-                    }
-                }
-                Node::Expr(expr) => {
-                    return (
-                        ty::Visibility::Restricted(tcx.parent_module(expr.hir_id).to_def_id()),
-                        expr.span,
-                        "private",
-                    );
-                }
-                node => bug!("unexpected node kind: {:?}", node),
-            };
-            (ty::Visibility::from_hir(vis, hir_id, tcx), vis.span, vis.node.descr())
-        }
-        None => {
-            let vis = tcx.visibility(def_id);
-            let descr = if vis == ty::Visibility::Public { "public" } else { "private" };
-            (vis, tcx.def_span(def_id), descr)
-        }
-    }
-}
-
 fn min(vis1: ty::Visibility, vis2: ty::Visibility, tcx: TyCtxt<'_>) -> ty::Visibility {
     if vis1.is_at_least(vis2, tcx) { vis2 } else { vis1 }
 }
@@ -424,7 +307,7 @@ trait VisibilityLike: Sized {
 impl VisibilityLike for ty::Visibility {
     const MAX: Self = ty::Visibility::Public;
     fn new_min(find: &FindMin<'_, '_, Self>, def_id: DefId) -> Self {
-        min(def_id_visibility(find.tcx, def_id).0, find.min, find.tcx)
+        min(find.tcx.visibility(def_id), find.min, find.tcx)
     }
 }
 impl VisibilityLike for Option<AccessLevel> {
@@ -534,17 +417,16 @@ impl EmbargoVisitor<'tcx> {
             let hir_id = item_id.id;
             let item_def_id = self.tcx.hir().local_def_id(hir_id);
             let def_kind = self.tcx.def_kind(item_def_id);
-            let item = self.tcx.hir().expect_item(hir_id);
-            let vis = ty::Visibility::from_hir(&item.vis, hir_id, self.tcx);
+            let vis = self.tcx.visibility(item_def_id);
             self.update_macro_reachable_def(hir_id, def_kind, vis, defining_mod);
         }
         if let Some(exports) = self.tcx.module_exports(module_def_id) {
             for export in exports {
                 if export.vis.is_accessible_from(defining_mod, self.tcx) {
                     if let Res::Def(def_kind, def_id) = export.res {
-                        let vis = def_id_visibility(self.tcx, def_id).0;
                         if let Some(def_id) = def_id.as_local() {
                             let hir_id = self.tcx.hir().local_def_id_to_hir_id(def_id);
+                            let vis = self.tcx.visibility(def_id.to_def_id());
                             self.update_macro_reachable_def(hir_id, def_kind, vis, defining_mod);
                         }
                     }
@@ -596,7 +478,7 @@ impl EmbargoVisitor<'tcx> {
                     {
                         for field in struct_def.fields() {
                             let field_vis =
-                                ty::Visibility::from_hir(&field.vis, field.hir_id, self.tcx);
+                                self.tcx.visibility(self.tcx.hir().local_def_id(field.hir_id));
                             if field_vis.is_accessible_from(module, self.tcx) {
                                 self.reach(field.hir_id, level).ty();
                             }
@@ -1015,11 +897,10 @@ impl DefIdVisitor<'tcx> for ReachEverythingInTheInterfaceVisitor<'_, 'tcx> {
     }
     fn visit_def_id(&mut self, def_id: DefId, _kind: &str, _descr: &dyn fmt::Display) -> bool {
         if let Some(def_id) = def_id.as_local() {
-            let hir_id = self.ev.tcx.hir().local_def_id_to_hir_id(def_id);
-            if let ((ty::Visibility::Public, ..), _)
-            | (_, Some(AccessLevel::ReachableFromImplTrait)) =
-                (def_id_visibility(self.tcx(), def_id.to_def_id()), self.access_level)
+            if let (ty::Visibility::Public, _) | (_, Some(AccessLevel::ReachableFromImplTrait)) =
+                (self.tcx().visibility(def_id.to_def_id()), self.access_level)
             {
+                let hir_id = self.ev.tcx.hir().local_def_id_to_hir_id(def_id);
                 self.ev.update(hir_id, self.access_level);
             }
         }
@@ -1184,9 +1065,7 @@ impl<'tcx> TypePrivacyVisitor<'tcx> {
     }
 
     fn item_is_accessible(&self, did: DefId) -> bool {
-        def_id_visibility(self.tcx, did)
-            .0
-            .is_accessible_from(self.current_item.to_def_id(), self.tcx)
+        self.tcx.visibility(did).is_accessible_from(self.current_item.to_def_id(), self.tcx)
     }
 
     // Take node-id of an expression or pattern and check its type for privacy.
@@ -1840,8 +1719,21 @@ impl SearchInterfaceForPrivateItemsVisitor<'tcx> {
             None => return false,
         };
 
-        let (vis, vis_span, vis_descr) = def_id_visibility(self.tcx, def_id);
+        let vis = self.tcx.visibility(def_id);
         if !vis.is_at_least(self.required_visibility, self.tcx) {
+            let vis_descr = match vis {
+                ty::Visibility::Public => "public",
+                ty::Visibility::Invisible => "private",
+                ty::Visibility::Restricted(vis_def_id) => {
+                    if vis_def_id == self.tcx.parent_module(hir_id).to_def_id() {
+                        "private"
+                    } else if vis_def_id.is_top_level_module() {
+                        "crate-private"
+                    } else {
+                        "restricted"
+                    }
+                }
+            };
             let make_msg = || format!("{} {} `{}` in public interface", vis_descr, kind, descr);
             if self.has_pub_restricted || self.has_old_errors || self.in_assoc_ty {
                 let mut err = if kind == "trait" {
@@ -1849,6 +1741,8 @@ impl SearchInterfaceForPrivateItemsVisitor<'tcx> {
                 } else {
                     struct_span_err!(self.tcx.sess, self.span, E0446, "{}", make_msg())
                 };
+                let vis_span =
+                    self.tcx.sess.source_map().guess_head_span(self.tcx.def_span(def_id));
                 err.span_label(self.span, format!("can't leak {} {}", vis_descr, kind));
                 err.span_label(vis_span, format!("`{}` declared as {}", descr, vis_descr));
                 err.emit();
@@ -1965,7 +1859,7 @@ impl<'a, 'tcx> Visitor<'tcx> for PrivateItemsInPublicInterfacesVisitor<'a, 'tcx>
 
     fn visit_item(&mut self, item: &'tcx hir::Item<'tcx>) {
         let tcx = self.tcx;
-        let item_visibility = ty::Visibility::from_hir(&item.vis, item.hir_id, tcx);
+        let item_visibility = tcx.visibility(tcx.hir().local_def_id(item.hir_id).to_def_id());
 
         match item.kind {
             // Crates are always public.
@@ -2019,7 +1913,7 @@ impl<'a, 'tcx> Visitor<'tcx> for PrivateItemsInPublicInterfacesVisitor<'a, 'tcx>
             // Subitems of foreign modules have their own publicity.
             hir::ItemKind::ForeignMod(ref foreign_mod) => {
                 for foreign_item in foreign_mod.items {
-                    let vis = ty::Visibility::from_hir(&foreign_item.vis, item.hir_id, tcx);
+                    let vis = tcx.visibility(tcx.hir().local_def_id(foreign_item.hir_id));
                     self.check(foreign_item.hir_id, vis).generics().predicates().ty();
                 }
             }
@@ -2028,7 +1922,7 @@ impl<'a, 'tcx> Visitor<'tcx> for PrivateItemsInPublicInterfacesVisitor<'a, 'tcx>
                 self.check(item.hir_id, item_visibility).generics().predicates();
 
                 for field in struct_def.fields() {
-                    let field_visibility = ty::Visibility::from_hir(&field.vis, item.hir_id, tcx);
+                    let field_visibility = tcx.visibility(tcx.hir().local_def_id(field.hir_id));
                     self.check(field.hir_id, min(item_visibility, field_visibility, tcx)).ty();
                 }
             }
@@ -2040,10 +1934,9 @@ impl<'a, 'tcx> Visitor<'tcx> for PrivateItemsInPublicInterfacesVisitor<'a, 'tcx>
                 let impl_vis = ty::Visibility::of_impl(item.hir_id, tcx, &Default::default());
                 self.check(item.hir_id, impl_vis).generics().predicates();
                 for impl_item_ref in items {
-                    let impl_item = tcx.hir().impl_item(impl_item_ref.id);
                     let impl_item_vis = if of_trait.is_none() {
                         min(
-                            ty::Visibility::from_hir(&impl_item.vis, item.hir_id, tcx),
+                            tcx.visibility(tcx.hir().local_def_id(impl_item_ref.id.hir_id)),
                             impl_vis,
                             tcx,
                         )
@@ -2064,11 +1957,61 @@ impl<'a, 'tcx> Visitor<'tcx> for PrivateItemsInPublicInterfacesVisitor<'a, 'tcx>
 
 pub fn provide(providers: &mut Providers) {
     *providers = Providers {
+        visibility,
         privacy_access_levels,
         check_private_in_public,
         check_mod_privacy,
         ..*providers
     };
+}
+
+fn visibility(tcx: TyCtxt<'_>, def_id: DefId) -> ty::Visibility {
+    let def_id = def_id.expect_local();
+    match tcx.visibilities.get(&def_id) {
+        Some(vis) => *vis,
+        None => {
+            let hir_id = tcx.hir().local_def_id_to_hir_id(def_id);
+            match tcx.hir().get(hir_id) {
+                // Unique types created for closures participate in type privacy checking.
+                // They have visibilities inherited from the module they are defined in.
+                Node::Expr(hir::Expr { kind: hir::ExprKind::Closure(..), .. }) => {
+                    ty::Visibility::Restricted(tcx.parent_module(hir_id).to_def_id())
+                }
+                // - AST lowering may clone `use` items and the clones don't
+                //   get their entries in the resolver's visibility table.
+                // - AST lowering also creates opaque type items with inherited visibilies.
+                //   Visibility on them should have no effect, but to avoid the visibility
+                //   query failing on some items, we provide it for opaque types as well.
+                Node::Item(hir::Item {
+                    vis,
+                    kind: hir::ItemKind::Use(..) | hir::ItemKind::OpaqueTy(..),
+                    ..
+                }) => ty::Visibility::from_hir(vis, hir_id, tcx),
+                // Visibilities of trait impl items are inherited from their traits
+                // and are not filled in resolve.
+                Node::ImplItem(impl_item) => {
+                    match tcx.hir().get(tcx.hir().get_parent_item(hir_id)) {
+                        Node::Item(hir::Item {
+                            kind: hir::ItemKind::Impl { of_trait: Some(tr), .. },
+                            ..
+                        }) => tr.path.res.opt_def_id().map_or_else(
+                            || {
+                                tcx.sess.delay_span_bug(tr.path.span, "trait without a def-id");
+                                ty::Visibility::Public
+                            },
+                            |def_id| tcx.visibility(def_id),
+                        ),
+                        _ => span_bug!(impl_item.span, "the parent is not a trait impl"),
+                    }
+                }
+                _ => span_bug!(
+                    tcx.def_span(def_id),
+                    "visibility table unexpectedly missing a def-id: {:?}",
+                    def_id,
+                ),
+            }
+        }
+    }
 }
 
 fn check_mod_privacy(tcx: TyCtxt<'_>, module_def_id: LocalDefId) {

--- a/compiler/rustc_resolve/src/def_collector.rs
+++ b/compiler/rustc_resolve/src/def_collector.rs
@@ -76,6 +76,7 @@ impl<'a, 'b> visit::Visitor<'a> for DefCollector<'a, 'b> {
         let def_data = match &i.kind {
             ItemKind::Impl { .. } => DefPathData::Impl,
             ItemKind::Mod(..) if i.ident.name == kw::Invalid => {
+                // Fake crate root item from expand.
                 return visit::walk_item(self, i);
             }
             ItemKind::Mod(..)

--- a/compiler/rustc_typeck/src/collect.rs
+++ b/compiler/rustc_typeck/src/collect.rs
@@ -851,7 +851,6 @@ fn convert_variant(
     parent_did: LocalDefId,
 ) -> ty::VariantDef {
     let mut seen_fields: FxHashMap<Ident, Span> = Default::default();
-    let hir_id = tcx.hir().local_def_id_to_hir_id(variant_did.unwrap_or(parent_did));
     let fields = def
         .fields()
         .iter()
@@ -868,11 +867,7 @@ fn convert_variant(
                 seen_fields.insert(f.ident.normalize_to_macros_2_0(), f.span);
             }
 
-            ty::FieldDef {
-                did: fid.to_def_id(),
-                ident: f.ident,
-                vis: ty::Visibility::from_hir(&f.vis, hir_id, tcx),
-            }
+            ty::FieldDef { did: fid.to_def_id(), ident: f.ident, vis: tcx.visibility(fid) }
         })
         .collect();
     let recovered = match def {

--- a/src/test/ui/error-codes/E0445.stderr
+++ b/src/test/ui/error-codes/E0445.stderr
@@ -1,18 +1,27 @@
 error[E0445]: private trait `Foo` in public interface
   --> $DIR/E0445.rs:5:1
    |
+LL | trait Foo {
+   | --------- `Foo` declared as private
+...
 LL | pub trait Bar : Foo {}
    | ^^^^^^^^^^^^^^^^^^^^^^ can't leak private trait
 
 error[E0445]: private trait `Foo` in public interface
   --> $DIR/E0445.rs:7:1
    |
+LL | trait Foo {
+   | --------- `Foo` declared as private
+...
 LL | pub struct Bar2<T: Foo>(pub T);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak private trait
 
 error[E0445]: private trait `Foo` in public interface
   --> $DIR/E0445.rs:9:1
    |
+LL | trait Foo {
+   | --------- `Foo` declared as private
+...
 LL | pub fn foo<T: Foo> (t: T) {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak private trait
 

--- a/src/test/ui/error-codes/E0446.stderr
+++ b/src/test/ui/error-codes/E0446.stderr
@@ -2,7 +2,7 @@ error[E0446]: private type `Bar` in public interface
   --> $DIR/E0446.rs:4:5
    |
 LL |     struct Bar(u32);
-   |     - `Bar` declared as private
+   |     ---------------- `Bar` declared as private
 LL | 
 LL |     pub fn bar() -> Bar {
    |     ^^^^^^^^^^^^^^^^^^^ can't leak private type

--- a/src/test/ui/issues/issue-18389.stderr
+++ b/src/test/ui/issues/issue-18389.stderr
@@ -2,7 +2,7 @@ error[E0445]: private trait `Private<<Self as Public>::P, <Self as Public>::R>` 
   --> $DIR/issue-18389.rs:7:1
    |
 LL |   trait Private<P, R> {
-   |   - `Private<<Self as Public>::P, <Self as Public>::R>` declared as private
+   |   ------------------- `Private<<Self as Public>::P, <Self as Public>::R>` declared as private
 ...
 LL | / pub trait Public: Private<
 LL | |

--- a/src/test/ui/issues/issue-30079.stderr
+++ b/src/test/ui/issues/issue-30079.stderr
@@ -12,7 +12,7 @@ error[E0446]: private type `m2::Priv` in public interface
   --> $DIR/issue-30079.rs:18:9
    |
 LL |     struct Priv;
-   |     - `m2::Priv` declared as private
+   |     ------------ `m2::Priv` declared as private
 LL |     impl ::std::ops::Deref for ::SemiPriv {
 LL |         type Target = Priv;
    |         ^^^^^^^^^^^^^^^^^^^ can't leak private type
@@ -21,7 +21,7 @@ error[E0446]: private type `m3::Priv` in public interface
   --> $DIR/issue-30079.rs:35:9
    |
 LL |     struct Priv;
-   |     - `m3::Priv` declared as private
+   |     ------------ `m3::Priv` declared as private
 LL |     impl ::SemiPrivTrait for () {
 LL |         type Assoc = Priv;
    |         ^^^^^^^^^^^^^^^^^^ can't leak private type

--- a/src/test/ui/privacy/private-in-public-assoc-ty.stderr
+++ b/src/test/ui/privacy/private-in-public-assoc-ty.stderr
@@ -2,7 +2,7 @@ error[E0446]: private type `Priv` in public interface
   --> $DIR/private-in-public-assoc-ty.rs:17:9
    |
 LL |     struct Priv;
-   |     - `Priv` declared as private
+   |     ------------ `Priv` declared as private
 ...
 LL |         type A = Priv;
    |         ^^^^^^^^^^^^^^ can't leak private type
@@ -39,7 +39,7 @@ error[E0446]: private type `Priv` in public interface
   --> $DIR/private-in-public-assoc-ty.rs:34:9
    |
 LL |     struct Priv;
-   |     - `Priv` declared as private
+   |     ------------ `Priv` declared as private
 ...
 LL |         type Alias4 = Priv;
    |         ^^^^^^^^^^^^^^^^^^^ can't leak private type
@@ -48,7 +48,7 @@ error[E0446]: private type `Priv` in public interface
   --> $DIR/private-in-public-assoc-ty.rs:41:9
    |
 LL |     struct Priv;
-   |     - `Priv` declared as private
+   |     ------------ `Priv` declared as private
 ...
 LL |         type Alias1 = Priv;
    |         ^^^^^^^^^^^^^^^^^^^ can't leak private type
@@ -57,7 +57,7 @@ error[E0445]: private trait `PrivTr` in public interface
   --> $DIR/private-in-public-assoc-ty.rs:44:9
    |
 LL |     trait PrivTr {}
-   |     - `PrivTr` declared as private
+   |     ------------ `PrivTr` declared as private
 ...
 LL |         type Exist = impl PrivTr;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak private trait

--- a/src/test/ui/privacy/private-in-public-lint.stderr
+++ b/src/test/ui/privacy/private-in-public-lint.stderr
@@ -2,7 +2,7 @@ error[E0446]: private type `m1::Priv` in public interface
   --> $DIR/private-in-public-lint.rs:6:9
    |
 LL |     struct Priv;
-   |     - `m1::Priv` declared as private
+   |     ------------ `m1::Priv` declared as private
 ...
 LL |         pub fn f() -> Priv {Priv}
    |         ^^^^^^^^^^^^^^^^^^ can't leak private type
@@ -11,7 +11,7 @@ error[E0446]: private type `m2::Priv` in public interface
   --> $DIR/private-in-public-lint.rs:15:9
    |
 LL |     struct Priv;
-   |     - `m2::Priv` declared as private
+   |     ------------ `m2::Priv` declared as private
 ...
 LL |         pub fn f() -> Priv {Priv}
    |         ^^^^^^^^^^^^^^^^^^ can't leak private type

--- a/src/test/ui/privacy/private-in-public-warn.stderr
+++ b/src/test/ui/privacy/private-in-public-warn.stderr
@@ -43,7 +43,7 @@ error[E0446]: private type `types::Priv` in public interface
   --> $DIR/private-in-public-warn.rs:26:9
    |
 LL |     struct Priv;
-   |     - `types::Priv` declared as private
+   |     ------------ `types::Priv` declared as private
 ...
 LL |         type Alias = Priv;
    |         ^^^^^^^^^^^^^^^^^^ can't leak private type
@@ -97,7 +97,7 @@ error[E0446]: private type `types::Priv` in public interface
   --> $DIR/private-in-public-warn.rs:41:9
    |
 LL |     struct Priv;
-   |     - `types::Priv` declared as private
+   |     ------------ `types::Priv` declared as private
 ...
 LL |         type Alias = Priv;
    |         ^^^^^^^^^^^^^^^^^^ can't leak private type
@@ -250,7 +250,7 @@ error[E0446]: private type `impls::Priv` in public interface
   --> $DIR/private-in-public-warn.rs:135:9
    |
 LL |     struct Priv;
-   |     - `impls::Priv` declared as private
+   |     ------------ `impls::Priv` declared as private
 ...
 LL |         type Alias = Priv;
    |         ^^^^^^^^^^^^^^^^^^ can't leak private type
@@ -268,7 +268,7 @@ error[E0446]: private type `aliases_pub::Priv` in public interface
   --> $DIR/private-in-public-warn.rs:210:9
    |
 LL |     struct Priv;
-   |     - `aliases_pub::Priv` declared as private
+   |     ------------ `aliases_pub::Priv` declared as private
 ...
 LL |         type Check = Priv;
    |         ^^^^^^^^^^^^^^^^^^ can't leak private type
@@ -277,7 +277,7 @@ error[E0446]: private type `aliases_pub::Priv` in public interface
   --> $DIR/private-in-public-warn.rs:213:9
    |
 LL |     struct Priv;
-   |     - `aliases_pub::Priv` declared as private
+   |     ------------ `aliases_pub::Priv` declared as private
 ...
 LL |         type Check = Priv;
    |         ^^^^^^^^^^^^^^^^^^ can't leak private type
@@ -286,7 +286,7 @@ error[E0446]: private type `aliases_pub::Priv` in public interface
   --> $DIR/private-in-public-warn.rs:216:9
    |
 LL |     struct Priv;
-   |     - `aliases_pub::Priv` declared as private
+   |     ------------ `aliases_pub::Priv` declared as private
 ...
 LL |         type Check = Priv;
    |         ^^^^^^^^^^^^^^^^^^ can't leak private type
@@ -295,7 +295,7 @@ error[E0446]: private type `aliases_pub::Priv` in public interface
   --> $DIR/private-in-public-warn.rs:219:9
    |
 LL |     struct Priv;
-   |     - `aliases_pub::Priv` declared as private
+   |     ------------ `aliases_pub::Priv` declared as private
 ...
 LL |         type Check = Priv;
    |         ^^^^^^^^^^^^^^^^^^ can't leak private type

--- a/src/test/ui/privacy/private-in-public.stderr
+++ b/src/test/ui/privacy/private-in-public.stderr
@@ -2,7 +2,7 @@ error[E0446]: private type `types::Priv` in public interface
   --> $DIR/private-in-public.rs:13:5
    |
 LL |     struct Priv;
-   |     - `types::Priv` declared as private
+   |     ------------ `types::Priv` declared as private
 ...
 LL |     pub const C: Priv = Priv;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak private type
@@ -11,7 +11,7 @@ error[E0446]: private type `types::Priv` in public interface
   --> $DIR/private-in-public.rs:14:5
    |
 LL |     struct Priv;
-   |     - `types::Priv` declared as private
+   |     ------------ `types::Priv` declared as private
 ...
 LL |     pub static S: Priv = Priv;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak private type
@@ -20,7 +20,7 @@ error[E0446]: private type `types::Priv` in public interface
   --> $DIR/private-in-public.rs:15:5
    |
 LL |     struct Priv;
-   |     - `types::Priv` declared as private
+   |     ------------ `types::Priv` declared as private
 ...
 LL |     pub fn f1(arg: Priv) {}
    |     ^^^^^^^^^^^^^^^^^^^^ can't leak private type
@@ -29,7 +29,7 @@ error[E0446]: private type `types::Priv` in public interface
   --> $DIR/private-in-public.rs:16:5
    |
 LL |     struct Priv;
-   |     - `types::Priv` declared as private
+   |     ------------ `types::Priv` declared as private
 ...
 LL |     pub fn f2() -> Priv { panic!() }
    |     ^^^^^^^^^^^^^^^^^^^ can't leak private type
@@ -38,7 +38,7 @@ error[E0446]: private type `types::Priv` in public interface
   --> $DIR/private-in-public.rs:17:19
    |
 LL |     struct Priv;
-   |     - `types::Priv` declared as private
+   |     ------------ `types::Priv` declared as private
 ...
 LL |     pub struct S1(pub Priv);
    |                   ^^^^^^^^ can't leak private type
@@ -47,7 +47,7 @@ error[E0446]: private type `types::Priv` in public interface
   --> $DIR/private-in-public.rs:18:21
    |
 LL |     struct Priv;
-   |     - `types::Priv` declared as private
+   |     ------------ `types::Priv` declared as private
 ...
 LL |     pub struct S2 { pub field: Priv }
    |                     ^^^^^^^^^^^^^^^ can't leak private type
@@ -56,7 +56,7 @@ error[E0446]: private type `types::Priv` in public interface
   --> $DIR/private-in-public.rs:20:9
    |
 LL |     struct Priv;
-   |     - `types::Priv` declared as private
+   |     ------------ `types::Priv` declared as private
 ...
 LL |         pub const C: Priv = Priv;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak private type
@@ -65,7 +65,7 @@ error[E0446]: private type `types::Priv` in public interface
   --> $DIR/private-in-public.rs:21:9
    |
 LL |     struct Priv;
-   |     - `types::Priv` declared as private
+   |     ------------ `types::Priv` declared as private
 ...
 LL |         pub fn f1(arg: Priv) {}
    |         ^^^^^^^^^^^^^^^^^^^^ can't leak private type
@@ -74,7 +74,7 @@ error[E0446]: private type `types::Priv` in public interface
   --> $DIR/private-in-public.rs:22:9
    |
 LL |     struct Priv;
-   |     - `types::Priv` declared as private
+   |     ------------ `types::Priv` declared as private
 ...
 LL |         pub fn f2() -> Priv { panic!() }
    |         ^^^^^^^^^^^^^^^^^^^ can't leak private type
@@ -83,7 +83,7 @@ error[E0445]: private trait `traits::PrivTr` in public interface
   --> $DIR/private-in-public.rs:31:5
    |
 LL |     trait PrivTr {}
-   |     - `traits::PrivTr` declared as private
+   |     ------------ `traits::PrivTr` declared as private
 ...
 LL |     pub enum E<T: PrivTr> { V(T) }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak private trait
@@ -92,7 +92,7 @@ error[E0445]: private trait `traits::PrivTr` in public interface
   --> $DIR/private-in-public.rs:32:5
    |
 LL |     trait PrivTr {}
-   |     - `traits::PrivTr` declared as private
+   |     ------------ `traits::PrivTr` declared as private
 ...
 LL |     pub fn f<T: PrivTr>(arg: T) {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak private trait
@@ -101,7 +101,7 @@ error[E0445]: private trait `traits::PrivTr` in public interface
   --> $DIR/private-in-public.rs:33:5
    |
 LL |     trait PrivTr {}
-   |     - `traits::PrivTr` declared as private
+   |     ------------ `traits::PrivTr` declared as private
 ...
 LL |     pub struct S1<T: PrivTr>(T);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak private trait
@@ -110,7 +110,7 @@ error[E0445]: private trait `traits::PrivTr` in public interface
   --> $DIR/private-in-public.rs:34:5
    |
 LL |       trait PrivTr {}
-   |       - `traits::PrivTr` declared as private
+   |       ------------ `traits::PrivTr` declared as private
 ...
 LL | /     impl<T: PrivTr> Pub<T> {
 LL | |         pub fn f<U: PrivTr>(arg: U) {}
@@ -121,7 +121,7 @@ error[E0445]: private trait `traits::PrivTr` in public interface
   --> $DIR/private-in-public.rs:35:9
    |
 LL |     trait PrivTr {}
-   |     - `traits::PrivTr` declared as private
+   |     ------------ `traits::PrivTr` declared as private
 ...
 LL |         pub fn f<U: PrivTr>(arg: U) {}
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak private trait
@@ -130,7 +130,7 @@ error[E0445]: private trait `traits_where::PrivTr` in public interface
   --> $DIR/private-in-public.rs:44:5
    |
 LL |     trait PrivTr {}
-   |     - `traits_where::PrivTr` declared as private
+   |     ------------ `traits_where::PrivTr` declared as private
 ...
 LL |     pub enum E<T> where T: PrivTr { V(T) }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak private trait
@@ -139,7 +139,7 @@ error[E0445]: private trait `traits_where::PrivTr` in public interface
   --> $DIR/private-in-public.rs:46:5
    |
 LL |     trait PrivTr {}
-   |     - `traits_where::PrivTr` declared as private
+   |     ------------ `traits_where::PrivTr` declared as private
 ...
 LL |     pub fn f<T>(arg: T) where T: PrivTr {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak private trait
@@ -148,7 +148,7 @@ error[E0445]: private trait `traits_where::PrivTr` in public interface
   --> $DIR/private-in-public.rs:48:5
    |
 LL |     trait PrivTr {}
-   |     - `traits_where::PrivTr` declared as private
+   |     ------------ `traits_where::PrivTr` declared as private
 ...
 LL |     pub struct S1<T>(T) where T: PrivTr;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak private trait
@@ -157,7 +157,7 @@ error[E0445]: private trait `traits_where::PrivTr` in public interface
   --> $DIR/private-in-public.rs:50:5
    |
 LL |       trait PrivTr {}
-   |       - `traits_where::PrivTr` declared as private
+   |       ------------ `traits_where::PrivTr` declared as private
 ...
 LL | /     impl<T> Pub<T> where T: PrivTr {
 LL | |
@@ -170,7 +170,7 @@ error[E0445]: private trait `traits_where::PrivTr` in public interface
   --> $DIR/private-in-public.rs:52:9
    |
 LL |     trait PrivTr {}
-   |     - `traits_where::PrivTr` declared as private
+   |     ------------ `traits_where::PrivTr` declared as private
 ...
 LL |         pub fn f<U>(arg: U) where U: PrivTr {}
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak private trait
@@ -179,7 +179,7 @@ error[E0446]: private type `generics::Priv` in public interface
   --> $DIR/private-in-public.rs:63:5
    |
 LL |     struct Priv<T = u8>(T);
-   |     - `generics::Priv` declared as private
+   |     ----------------------- `generics::Priv` declared as private
 ...
 LL |     pub fn f1(arg: [Priv; 1]) {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak private type
@@ -188,7 +188,7 @@ error[E0446]: private type `generics::Priv` in public interface
   --> $DIR/private-in-public.rs:64:5
    |
 LL |     struct Priv<T = u8>(T);
-   |     - `generics::Priv` declared as private
+   |     ----------------------- `generics::Priv` declared as private
 ...
 LL |     pub fn f2(arg: Pub<Priv>) {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak private type
@@ -197,7 +197,7 @@ error[E0446]: private type `generics::Priv<generics::Pub>` in public interface
   --> $DIR/private-in-public.rs:65:5
    |
 LL |     struct Priv<T = u8>(T);
-   |     - `generics::Priv<generics::Pub>` declared as private
+   |     ----------------------- `generics::Priv<generics::Pub>` declared as private
 ...
 LL |     pub fn f3(arg: Priv<Pub>) {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak private type
@@ -206,7 +206,7 @@ error[E0446]: private type `impls::Priv` in public interface
   --> $DIR/private-in-public.rs:80:9
    |
 LL |     struct Priv;
-   |     - `impls::Priv` declared as private
+   |     ------------ `impls::Priv` declared as private
 ...
 LL |         pub fn f(arg: Priv) {}
    |         ^^^^^^^^^^^^^^^^^^^ can't leak private type
@@ -215,7 +215,7 @@ error[E0445]: private trait `aliases_pub::PrivTr` in public interface
   --> $DIR/private-in-public.rs:104:5
    |
 LL |     trait PrivTr {
-   |     - `aliases_pub::PrivTr` declared as private
+   |     ------------ `aliases_pub::PrivTr` declared as private
 ...
 LL |     pub fn f3(arg: <Priv as PrivTr>::Assoc) {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak private trait
@@ -224,7 +224,7 @@ error[E0446]: private type `aliases_pub::Priv` in public interface
   --> $DIR/private-in-public.rs:104:5
    |
 LL |     struct Priv;
-   |     - `aliases_pub::Priv` declared as private
+   |     ------------ `aliases_pub::Priv` declared as private
 ...
 LL |     pub fn f3(arg: <Priv as PrivTr>::Assoc) {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak private type
@@ -233,7 +233,7 @@ error[E0446]: private type `aliases_pub::Priv` in public interface
   --> $DIR/private-in-public.rs:109:9
    |
 LL |     struct Priv;
-   |     - `aliases_pub::Priv` declared as private
+   |     ------------ `aliases_pub::Priv` declared as private
 ...
 LL |         pub fn f(arg: Priv) {}
    |         ^^^^^^^^^^^^^^^^^^^ can't leak private type
@@ -242,7 +242,7 @@ error[E0446]: private type `Priv1` in public interface
   --> $DIR/private-in-public.rs:131:5
    |
 LL |     struct Priv1;
-   |     - `Priv1` declared as private
+   |     ------------- `Priv1` declared as private
 ...
 LL |     pub fn f1(arg: PrivUseAlias) {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak private type
@@ -251,7 +251,7 @@ error[E0446]: private type `Priv2` in public interface
   --> $DIR/private-in-public.rs:132:5
    |
 LL |     struct Priv2;
-   |     - `Priv2` declared as private
+   |     ------------- `Priv2` declared as private
 ...
 LL |     pub fn f2(arg: PrivAlias) {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak private type
@@ -260,7 +260,7 @@ error[E0445]: private trait `aliases_priv::PrivTr` in public interface
   --> $DIR/private-in-public.rs:133:5
    |
 LL |     trait PrivTr {
-   |     - `aliases_priv::PrivTr` declared as private
+   |     ------------ `aliases_priv::PrivTr` declared as private
 ...
 LL |     pub fn f3(arg: <Priv as PrivTr>::Assoc) {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak private trait
@@ -269,7 +269,7 @@ error[E0446]: private type `aliases_priv::Priv` in public interface
   --> $DIR/private-in-public.rs:133:5
    |
 LL |     struct Priv;
-   |     - `aliases_priv::Priv` declared as private
+   |     ------------ `aliases_priv::Priv` declared as private
 ...
 LL |     pub fn f3(arg: <Priv as PrivTr>::Assoc) {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak private type
@@ -278,7 +278,7 @@ error[E0446]: private type `aliases_params::Priv` in public interface
   --> $DIR/private-in-public.rs:143:5
    |
 LL |     struct Priv;
-   |     - `aliases_params::Priv` declared as private
+   |     ------------ `aliases_params::Priv` declared as private
 ...
 LL |     pub fn f2(arg: PrivAliasGeneric) {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak private type
@@ -287,7 +287,7 @@ error[E0446]: private type `aliases_params::Priv` in public interface
   --> $DIR/private-in-public.rs:145:5
    |
 LL |     struct Priv;
-   |     - `aliases_params::Priv` declared as private
+   |     ------------ `aliases_params::Priv` declared as private
 ...
 LL |     pub fn f3(arg: Result<u8>) {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak private type

--- a/src/test/ui/privacy/private-inferred-type.stderr
+++ b/src/test/ui/privacy/private-inferred-type.stderr
@@ -2,7 +2,7 @@ error[E0446]: private type `Priv` in public interface
   --> $DIR/private-inferred-type.rs:61:36
    |
 LL |     struct Priv;
-   |     - `Priv` declared as private
+   |     ------------ `Priv` declared as private
 ...
 LL |     impl TraitWithAssocTy for u8 { type AssocTy = Priv; }
    |                                    ^^^^^^^^^^^^^^^^^^^^ can't leak private type
@@ -11,7 +11,7 @@ error[E0446]: private type `S2` in public interface
   --> $DIR/private-inferred-type.rs:83:9
    |
 LL |     struct S2;
-   |     - `S2` declared as private
+   |     ---------- `S2` declared as private
 ...
 LL |         type Target = S2Alias;
    |         ^^^^^^^^^^^^^^^^^^^^^^ can't leak private type

--- a/src/test/ui/privacy/restricted/private-in-public.stderr
+++ b/src/test/ui/privacy/restricted/private-in-public.stderr
@@ -2,7 +2,7 @@ error[E0446]: private type `Priv` in public interface
   --> $DIR/private-in-public.rs:8:9
    |
 LL |     struct Priv;
-   |     - `Priv` declared as private
+   |     ------------ `Priv` declared as private
 ...
 LL |         pub(crate) fn g(_: Priv) {}
    |         ^^^^^^^^^^^^^^^^^^^^^^^^ can't leak private type
@@ -11,7 +11,7 @@ error[E0446]: private type `Priv` in public interface
   --> $DIR/private-in-public.rs:9:9
    |
 LL |     struct Priv;
-   |     - `Priv` declared as private
+   |     ------------ `Priv` declared as private
 ...
 LL |         crate fn h(_: Priv) {}
    |         ^^^^^^^^^^^^^^^^^^^ can't leak private type

--- a/src/test/ui/proc-macro/issue-50493.rs
+++ b/src/test/ui/proc-macro/issue-50493.rs
@@ -3,8 +3,7 @@
 #[macro_use]
 extern crate issue_50493;
 
-#[derive(Derive)] //~ ERROR field `field` of struct `Restricted` is private
-                  //~| ERROR field `field` of struct `Restricted` is private
+#[derive(Derive)]
 struct Restricted {
     pub(in restricted) field: usize, //~ visibilities can only be restricted to ancestor modules
 }

--- a/src/test/ui/proc-macro/issue-50493.stderr
+++ b/src/test/ui/proc-macro/issue-50493.stderr
@@ -1,26 +1,9 @@
 error[E0742]: visibilities can only be restricted to ancestor modules
-  --> $DIR/issue-50493.rs:9:12
+  --> $DIR/issue-50493.rs:8:12
    |
 LL |     pub(in restricted) field: usize,
    |            ^^^^^^^^^^
 
-error[E0616]: field `field` of struct `Restricted` is private
-  --> $DIR/issue-50493.rs:6:10
-   |
-LL | #[derive(Derive)]
-   |          ^^^^^^ private field
-   |
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+error: aborting due to previous error
 
-error[E0616]: field `field` of struct `Restricted` is private
-  --> $DIR/issue-50493.rs:6:10
-   |
-LL | #[derive(Derive)]
-   |          ^^^^^^ private field
-   |
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error: aborting due to 3 previous errors
-
-Some errors have detailed explanations: E0616, E0742.
-For more information about an error, try `rustc --explain E0616`.
+For more information about this error, try `rustc --explain E0742`.

--- a/src/test/ui/pub/issue-33174-restricted-type-in-public-interface.rs
+++ b/src/test/ui/pub/issue-33174-restricted-type-in-public-interface.rs
@@ -1,11 +1,11 @@
-#![allow(non_camel_case_types)]  // genus is always capitalized
+#![allow(non_camel_case_types)] // genus is always capitalized
 
 pub(crate) struct Snail;
-//~^ NOTE `Snail` declared as crate-visible
+//~^ NOTE `Snail` declared as private
 
 mod sea {
     pub(super) struct Turtle;
-    //~^ NOTE `Turtle` declared as restricted
+    //~^ NOTE `Turtle` declared as crate-private
 }
 
 struct Tortoise;
@@ -16,11 +16,11 @@ pub struct Shell<T> {
 }
 
 pub type Helix_pomatia = Shell<Snail>;
-//~^ ERROR crate-visible type `Snail` in public interface
-//~| NOTE can't leak crate-visible type
+//~^ ERROR private type `Snail` in public interface
+//~| NOTE can't leak private type
 pub type Dermochelys_coriacea = Shell<sea::Turtle>;
-//~^ ERROR restricted type `Turtle` in public interface
-//~| NOTE can't leak restricted type
+//~^ ERROR crate-private type `Turtle` in public interface
+//~| NOTE can't leak crate-private type
 pub type Testudo_graeca = Shell<Tortoise>;
 //~^ ERROR private type `Tortoise` in public interface
 //~| NOTE can't leak private type

--- a/src/test/ui/pub/issue-33174-restricted-type-in-public-interface.stderr
+++ b/src/test/ui/pub/issue-33174-restricted-type-in-public-interface.stderr
@@ -1,26 +1,26 @@
-error[E0446]: crate-visible type `Snail` in public interface
+error[E0446]: private type `Snail` in public interface
   --> $DIR/issue-33174-restricted-type-in-public-interface.rs:18:1
    |
 LL | pub(crate) struct Snail;
-   | ---------- `Snail` declared as crate-visible
+   | ------------------------ `Snail` declared as private
 ...
 LL | pub type Helix_pomatia = Shell<Snail>;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak crate-visible type
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak private type
 
-error[E0446]: restricted type `Turtle` in public interface
+error[E0446]: crate-private type `Turtle` in public interface
   --> $DIR/issue-33174-restricted-type-in-public-interface.rs:21:1
    |
 LL |     pub(super) struct Turtle;
-   |     ---------- `Turtle` declared as restricted
+   |     ------------------------- `Turtle` declared as crate-private
 ...
 LL | pub type Dermochelys_coriacea = Shell<sea::Turtle>;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak restricted type
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak crate-private type
 
 error[E0446]: private type `Tortoise` in public interface
   --> $DIR/issue-33174-restricted-type-in-public-interface.rs:24:1
    |
 LL | struct Tortoise;
-   | - `Tortoise` declared as private
+   | ---------------- `Tortoise` declared as private
 ...
 LL | pub type Testudo_graeca = Shell<Tortoise>;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak private type


### PR DESCRIPTION
Then use them through a query based on resolver outputs.

Item visibilities were previously calculated in three places - initially in `rustc_resolve`, then in `rustc_privacy` during type privacy checkin, and then in `rustc_metadata` during metadata encoding.
The visibility logic is not entirely trivial, especially for things like constructors or enum variants, and all of it was duplicated.

This PR deduplicates all the visibility calculations, visibilities are determined once during early name resolution and then stored in `ResolverOutputs` and are later available through `tcx` as a query `tcx.visibility(def_id)`.
(This query existed previously, but only worked for other crates.)

Some special cases (e.g. visibilities for closure types, which are needed for type privacy checking) are not processed in resolve, but deferred and performed directly in the query instead.