### PR TITLE
bootstrap: Print units for "finished in xxx" message

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@ standard library, and documentation.
 
 **Note: this README is for _users_ rather than _contributors_.
 If you wish to _contribute_ to the compiler, you should read the
-[Getting Started][gettingstarted] of the rustc-dev-guide instead of this
-section.**
+[Getting Started][gettingstarted] section of the rustc-dev-guide instead.**
 
 ## Quick Start
 

--- a/src/bootstrap/util.rs
+++ b/src/bootstrap/util.rs
@@ -122,7 +122,7 @@ impl Drop for TimeIt {
     fn drop(&mut self) {
         let time = self.1.elapsed();
         if !self.0 {
-            println!("\tfinished in {}.{:03}", time.as_secs(), time.subsec_millis());
+            println!("\tfinished in {}.{:03} seconds", time.as_secs(), time.subsec_millis());
         }
     }
 }


### PR DESCRIPTION
It now says "finished in xxx seconds".

Also slightly improved some wording in the README.
