### PR TITLE
BTreeMap: replace Root with NodeRef<Owned, ...>

### DIFF
--- a/library/alloc/src/collections/btree/append.rs
+++ b/library/alloc/src/collections/btree/append.rs
@@ -34,7 +34,7 @@ impl<K, V> Root<K, V> {
     where
         I: Iterator<Item = (K, V)>,
     {
-        let mut cur_node = self.node_as_mut().last_leaf_edge().into_node();
+        let mut cur_node = self.borrow_mut().last_leaf_edge().into_node();
         // Iterate through all key-value pairs, pushing them into nodes at the right level.
         for (key, value) in iter {
             // Try to push key-value pair into the current leaf node.
@@ -86,7 +86,7 @@ impl<K, V> Root<K, V> {
 
     fn fix_right_edge(&mut self) {
         // Handle underfull nodes, start from the top.
-        let mut cur_node = self.node_as_mut();
+        let mut cur_node = self.borrow_mut();
         while let Internal(internal) = cur_node.force() {
             // Check if right-most child is underfull.
             let mut last_kv = internal.last_kv().consider_for_balancing();

--- a/library/alloc/src/collections/btree/map/entry.rs
+++ b/library/alloc/src/collections/btree/map/entry.rs
@@ -286,7 +286,7 @@ impl<'a, K: Ord, V> VacantEntry<'a, K, V> {
                 // Safety: We have consumed self.handle and the reference returned.
                 let map = unsafe { self.dormant_map.awaken() };
                 let root = map.root.as_mut().unwrap();
-                root.push_internal_level().push(ins.k, ins.v, ins.right);
+                root.push_internal_level().push(ins.kv.0, ins.kv.1, ins.right);
                 map.length += 1;
                 val_ptr
             }

--- a/library/alloc/src/collections/btree/map/tests.rs
+++ b/library/alloc/src/collections/btree/map/tests.rs
@@ -49,7 +49,7 @@ impl<K, V> BTreeMap<K, V> {
     // Panics if the map (or the code navigating it) is corrupted.
     fn check_invariants(&self) {
         if let Some(root) = &self.root {
-            let root_node = root.node_as_ref();
+            let root_node = root.reborrow();
 
             // Check the back pointers top-down, before we attempt to rely on
             // more serious navigation code.
@@ -92,7 +92,7 @@ impl<K, V> BTreeMap<K, V> {
         K: Debug,
     {
         if let Some(root) = self.root.as_ref() {
-            root.node_as_ref().dump_keys()
+            root.reborrow().dump_keys()
         } else {
             String::from("not yet allocated")
         }

--- a/library/alloc/src/collections/btree/node/tests.rs
+++ b/library/alloc/src/collections/btree/node/tests.rs
@@ -74,16 +74,19 @@ fn test_splitpoint() {
 
 #[test]
 fn test_partial_cmp_eq() {
-    let mut root1: Root<i32, ()> = Root::new_leaf();
-    let mut leaf1 = unsafe { root1.leaf_node_as_mut() };
+    let mut root1 = NodeRef::new();
+    let mut leaf1 = root1.borrow_mut();
     leaf1.push(1, ());
+    let mut root1 = root1.forget_type();
     root1.push_internal_level();
-    let root2: Root<i32, ()> = Root::new_leaf();
+    let root2 = Root::new_leaf();
+    root1.reborrow().assert_back_pointers();
+    root2.reborrow().assert_back_pointers();
 
-    let leaf_edge_1a = root1.node_as_ref().first_leaf_edge().forget_node_type();
-    let leaf_edge_1b = root1.node_as_ref().last_leaf_edge().forget_node_type();
-    let top_edge_1 = root1.node_as_ref().first_edge();
-    let top_edge_2 = root2.node_as_ref().first_edge();
+    let leaf_edge_1a = root1.reborrow().first_leaf_edge().forget_node_type();
+    let leaf_edge_1b = root1.reborrow().last_leaf_edge().forget_node_type();
+    let top_edge_1 = root1.reborrow().first_edge();
+    let top_edge_2 = root2.reborrow().first_edge();
 
     assert!(leaf_edge_1a == leaf_edge_1a);
     assert!(leaf_edge_1a != leaf_edge_1b);
@@ -100,8 +103,8 @@ fn test_partial_cmp_eq() {
     assert_eq!(top_edge_1.partial_cmp(&top_edge_2), None);
 
     root1.pop_internal_level();
-    unsafe { root1.into_ref().deallocate_and_ascend() };
-    unsafe { root2.into_ref().deallocate_and_ascend() };
+    unsafe { root1.deallocate_and_ascend() };
+    unsafe { root2.deallocate_and_ascend() };
 }
 
 #[test]

--- a/library/alloc/src/collections/btree/split.rs
+++ b/library/alloc/src/collections/btree/split.rs
@@ -9,7 +9,7 @@ impl<K, V> Root<K, V> {
         K: Borrow<Q>,
     {
         debug_assert!(right_root.height() == 0);
-        debug_assert!(right_root.node_as_ref().len() == 0);
+        debug_assert!(right_root.len() == 0);
 
         let left_root = self;
         for _ in 0..left_root.height() {
@@ -17,8 +17,8 @@ impl<K, V> Root<K, V> {
         }
 
         {
-            let mut left_node = left_root.node_as_mut();
-            let mut right_node = right_root.node_as_mut();
+            let mut left_node = left_root.borrow_mut();
+            let mut right_node = right_root.borrow_mut();
 
             loop {
                 let mut split_edge = match search_node(left_node, key) {
@@ -48,7 +48,7 @@ impl<K, V> Root<K, V> {
 
     /// Removes empty levels on the top, but keeps an empty leaf if the entire tree is empty.
     fn fix_top(&mut self) {
-        while self.height() > 0 && self.node_as_ref().len() == 0 {
+        while self.height() > 0 && self.len() == 0 {
             self.pop_internal_level();
         }
     }
@@ -57,7 +57,7 @@ impl<K, V> Root<K, V> {
         self.fix_top();
 
         {
-            let mut cur_node = self.node_as_mut();
+            let mut cur_node = self.borrow_mut();
 
             while let Internal(node) = cur_node.force() {
                 let mut last_kv = node.last_kv().consider_for_balancing();
@@ -83,7 +83,7 @@ impl<K, V> Root<K, V> {
         self.fix_top();
 
         {
-            let mut cur_node = self.node_as_mut();
+            let mut cur_node = self.borrow_mut();
 
             while let Internal(node) = cur_node.force() {
                 let mut first_kv = node.first_kv().consider_for_balancing();

--- a/src/test/debuginfo/pretty-std-collections.rs
+++ b/src/test/debuginfo/pretty-std-collections.rs
@@ -101,7 +101,7 @@ fn main() {
         btree_set.insert(i);
     }
 
-    let mut empty_btree_set: BTreeSet<i32> = BTreeSet::new();
+    let empty_btree_set: BTreeSet<i32> = BTreeSet::new();
 
     // BTreeMap
     let mut btree_map = BTreeMap::new();
@@ -109,7 +109,7 @@ fn main() {
         btree_map.insert(i, i);
     }
 
-    let mut empty_btree_map: BTreeMap<i32, u32> = BTreeMap::new();
+    let empty_btree_map: BTreeMap<i32, u32> = BTreeMap::new();
 
     let mut option_btree_map: BTreeMap<bool, Option<bool>> = BTreeMap::new();
     option_btree_map.insert(false, None);


### PR DESCRIPTION
`NodeRef<marker::Owned, …>` already exists as a representation of root nodes, and it makes more sense to alias `Root` to that than to reuse the space-efficient `BoxedNode` that is oblivious to height, where height is required.

r? @Mark-Simulacrum 