### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/compiler/rustc_typeck/src/collect/type_of.rs
+++ b/compiler/rustc_typeck/src/collect/type_of.rs
@@ -112,12 +112,16 @@ pub(super) fn opt_const_param_of(tcx: TyCtxt<'_>, def_id: LocalDefId) -> Option<
                         tcx.sess.delay_span_bug(tcx.def_span(def_id), "anon const with Res::Err");
                         return None;
                     }
-                    _ => span_bug!(
-                        DUMMY_SP,
-                        "unexpected anon const res {:?} in path: {:?}",
-                        res,
-                        path,
-                    ),
+                    _ => {
+                        // If the user tries to specify generics on a type that does not take them,
+                        // e.g. `usize<T>`, we may hit this branch, in which case we treat it as if
+                        // no arguments have been passed. An error should already have been emitted.
+                        tcx.sess.delay_span_bug(
+                            tcx.def_span(def_id),
+                            &format!("unexpected anon const res {:?} in path: {:?}", res, path),
+                        );
+                        return None;
+                    }
                 };
 
                 generics

--- a/library/core/src/iter/adapters/chain.rs
+++ b/library/core/src/iter/adapters/chain.rs
@@ -109,7 +109,7 @@ where
             acc = b.try_fold(acc, f)?;
             // we don't fuse the second iterator
         }
-        Try::from_ok(acc)
+        try { acc }
     }
 
     fn fold<Acc, F>(self, mut acc: Acc, mut f: F) -> Acc
@@ -292,7 +292,7 @@ where
             acc = a.try_rfold(acc, f)?;
             // we don't fuse the second iterator
         }
-        Try::from_ok(acc)
+        try { acc }
     }
 
     fn rfold<Acc, F>(self, mut acc: Acc, mut f: F) -> Acc

--- a/library/core/src/iter/adapters/flatten.rs
+++ b/library/core/src/iter/adapters/flatten.rs
@@ -317,7 +317,7 @@ where
         }
         self.backiter = None;
 
-        Try::from_ok(init)
+        try { init }
     }
 
     #[inline]
@@ -397,7 +397,7 @@ where
         }
         self.frontiter = None;
 
-        Try::from_ok(init)
+        try { init }
     }
 
     #[inline]

--- a/library/core/src/iter/adapters/fuse.rs
+++ b/library/core/src/iter/adapters/fuse.rs
@@ -303,7 +303,7 @@ where
             acc = iter.try_fold(acc, fold)?;
             self.iter = None;
         }
-        Try::from_ok(acc)
+        try { acc }
     }
 
     #[inline]
@@ -353,7 +353,7 @@ where
             acc = iter.try_rfold(acc, fold)?;
             self.iter = None;
         }
-        Try::from_ok(acc)
+        try { acc }
     }
 
     #[inline]

--- a/library/core/src/iter/adapters/mod.rs
+++ b/library/core/src/iter/adapters/mod.rs
@@ -2381,11 +2381,7 @@ where
         }
 
         let n = self.len();
-        if n == 0 {
-            try { init }
-        } else {
-            self.iter.try_rfold(init, check(n, fold)).into_try()
-        }
+        if n == 0 { try { init } } else { self.iter.try_rfold(init, check(n, fold)).into_try() }
     }
 
     fn rfold<Acc, Fold>(mut self, init: Acc, fold: Fold) -> Acc

--- a/library/core/src/iter/adapters/mod.rs
+++ b/library/core/src/iter/adapters/mod.rs
@@ -579,7 +579,7 @@ where
         })?;
 
         if is_empty {
-            return Try::from_ok(acc);
+            return try { acc };
         }
 
         loop {
@@ -715,7 +715,7 @@ where
         if self.first_take {
             self.first_take = false;
             match self.iter.next() {
-                None => return Try::from_ok(acc),
+                None => return try { acc },
                 Some(x) => acc = f(acc, x)?,
             }
         }
@@ -792,7 +792,7 @@ where
         }
 
         match self.next_back() {
-            None => Try::from_ok(init),
+            None => try { init },
             Some(x) => {
                 let acc = f(init, x)?;
                 from_fn(nth_back(&mut self.iter, self.step)).try_fold(acc, f)
@@ -1075,7 +1075,7 @@ fn filter_try_fold<'a, T, Acc, R: Try<Ok = Acc>>(
     predicate: &'a mut impl FnMut(&T) -> bool,
     mut fold: impl FnMut(Acc, T) -> R + 'a,
 ) -> impl FnMut(Acc, T) -> R + 'a {
-    move |acc, item| if predicate(&item) { fold(acc, item) } else { R::from_ok(acc) }
+    move |acc, item| if predicate(&item) { fold(acc, item) } else { try { acc } }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -1229,7 +1229,7 @@ fn filter_map_try_fold<'a, T, B, Acc, R: Try<Ok = Acc>>(
 ) -> impl FnMut(Acc, T) -> R + 'a {
     move |acc, item| match f(item) {
         Some(x) => fold(acc, x),
-        None => R::from_ok(acc),
+        None => try { acc },
     }
 }
 
@@ -1660,7 +1660,7 @@ impl<I: Iterator> Iterator for Peekable<I> {
         R: Try<Ok = B>,
     {
         let acc = match self.peeked.take() {
-            Some(None) => return Try::from_ok(init),
+            Some(None) => return try { init },
             Some(Some(v)) => f(init, v)?,
             None => init,
         };
@@ -1703,7 +1703,7 @@ where
         R: Try<Ok = B>,
     {
         match self.peeked.take() {
-            Some(None) => Try::from_ok(init),
+            Some(None) => try { init },
             Some(Some(v)) => match self.iter.try_rfold(init, &mut f).into_result() {
                 Ok(acc) => f(acc, v),
                 Err(e) => {
@@ -1938,7 +1938,7 @@ where
         if !self.flag {
             match self.next() {
                 Some(v) => init = fold(init, v)?,
-                None => return Try::from_ok(init),
+                None => return try { init },
             }
         }
         self.iter.try_fold(init, fold)
@@ -2065,13 +2065,13 @@ where
                     ControlFlow::from_try(fold(acc, x))
                 } else {
                     *flag = true;
-                    ControlFlow::Break(Try::from_ok(acc))
+                    ControlFlow::Break(try { acc })
                 }
             }
         }
 
         if self.flag {
-            Try::from_ok(init)
+            try { init }
         } else {
             let flag = &mut self.flag;
             let p = &mut self.predicate;
@@ -2180,7 +2180,7 @@ where
         let Self { iter, predicate } = self;
         iter.try_fold(init, |acc, x| match predicate(x) {
             Some(item) => ControlFlow::from_try(fold(acc, item)),
-            None => ControlFlow::Break(Try::from_ok(acc)),
+            None => ControlFlow::Break(try { acc }),
         })
         .into_try()
     }
@@ -2316,7 +2316,7 @@ where
         if n > 0 {
             // nth(n) skips n+1
             if self.iter.nth(n - 1).is_none() {
-                return Try::from_ok(init);
+                return try { init };
             }
         }
         self.iter.try_fold(init, fold)
@@ -2382,7 +2382,7 @@ where
 
         let n = self.len();
         if n == 0 {
-            Try::from_ok(init)
+            try { init }
         } else {
             self.iter.try_rfold(init, check(n, fold)).into_try()
         }
@@ -2509,7 +2509,7 @@ where
         }
 
         if self.n == 0 {
-            Try::from_ok(init)
+            try { init }
         } else {
             let n = &mut self.n;
             self.iter.try_fold(init, check(n, fold)).into_try()
@@ -2587,11 +2587,11 @@ where
         R: Try<Ok = Acc>,
     {
         if self.n == 0 {
-            Try::from_ok(init)
+            try { init }
         } else {
             let len = self.iter.len();
             if len > self.n && self.iter.nth_back(len - self.n - 1).is_none() {
-                Try::from_ok(init)
+                try { init }
             } else {
                 self.iter.try_rfold(init, fold)
             }
@@ -2687,7 +2687,7 @@ where
             mut fold: impl FnMut(Acc, B) -> R + 'a,
         ) -> impl FnMut(Acc, T) -> ControlFlow<Acc, R> + 'a {
             move |acc, x| match f(state, x) {
-                None => ControlFlow::Break(Try::from_ok(acc)),
+                None => ControlFlow::Break(try { acc }),
                 Some(x) => ControlFlow::from_try(fold(acc, x)),
             }
         }
@@ -2951,7 +2951,7 @@ where
                 Ok(x) => ControlFlow::from_try(f(acc, x)),
                 Err(e) => {
                     *error = Err(e);
-                    ControlFlow::Break(Try::from_ok(acc))
+                    ControlFlow::Break(try { acc })
                 }
             })
             .into_try()

--- a/library/core/src/iter/range.rs
+++ b/library/core/src/iter/range.rs
@@ -713,7 +713,7 @@ impl<A: Step> Iterator for ops::RangeInclusive<A> {
         R: Try<Ok = B>,
     {
         if self.is_empty() {
-            return Try::from_ok(init);
+            return try { init };
         }
 
         let mut accum = init;
@@ -731,7 +731,7 @@ impl<A: Step> Iterator for ops::RangeInclusive<A> {
             accum = f(accum, self.start.clone())?;
         }
 
-        Try::from_ok(accum)
+        try { accum }
     }
 
     #[inline]
@@ -818,7 +818,7 @@ impl<A: Step> DoubleEndedIterator for ops::RangeInclusive<A> {
         R: Try<Ok = B>,
     {
         if self.is_empty() {
-            return Try::from_ok(init);
+            return try { init };
         }
 
         let mut accum = init;
@@ -836,7 +836,7 @@ impl<A: Step> DoubleEndedIterator for ops::RangeInclusive<A> {
             accum = f(accum, self.start.clone())?;
         }
 
-        Try::from_ok(accum)
+        try { accum }
     }
 
     #[inline]

--- a/library/core/src/iter/traits/double_ended.rs
+++ b/library/core/src/iter/traits/double_ended.rs
@@ -221,7 +221,7 @@ pub trait DoubleEndedIterator: Iterator {
         while let Some(x) = self.next_back() {
             accum = f(accum, x)?;
         }
-        Try::from_ok(accum)
+        try { accum }
     }
 
     /// An iterator method that reduces the iterator's elements to a single,

--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -1887,7 +1887,7 @@ pub trait Iterator {
         while let Some(x) = self.next() {
             accum = f(accum, x)?;
         }
-        Try::from_ok(accum)
+        try { accum }
     }
 
     /// An iterator method that applies a fallible function to each item in the

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -127,6 +127,7 @@
 #![feature(std_internals)]
 #![feature(stmt_expr_attributes)]
 #![feature(transparent_unions)]
+#![feature(try_blocks)]
 #![feature(unboxed_closures)]
 #![feature(unsized_locals)]
 #![feature(untagged_unions)]

--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -1184,7 +1184,7 @@ impl Stdio {
     }
 
     /// This stream will be ignored. This is the equivalent of attaching the
-    /// stream to `/dev/null`
+    /// stream to `/dev/null`.
     ///
     /// # Examples
     ///

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -2792,6 +2792,10 @@ function defocusSearchBar() {
         addClass(popup, "hidden");
         popup.id = "help";
 
+        var book_info = document.createElement("span");
+        book_info.innerHTML = "You can find more information in \
+            <a href=\"https://doc.rust-lang.org/rustdoc/\">the rustdoc book</a>.";
+
         var container = document.createElement("div");
         var shortcuts = [
             ["?", "Show this help dialog"],
@@ -2825,6 +2829,7 @@ function defocusSearchBar() {
         addClass(div_infos, "infos");
         div_infos.innerHTML = "<h2>Search Tricks</h2>" + infos;
 
+        container.appendChild(book_info);
         container.appendChild(div_shortcuts);
         container.appendChild(div_infos);
 

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -796,14 +796,22 @@ body.blur > :not(#help) {
 	clear: left;
 	display: block;
 }
+#help > div > span {
+	text-align: center;
+	display: block;
+	margin: 10px 0;
+	font-size: 18px;
+	border-bottom: 1px solid #ccc;
+	padding-bottom: 4px;
+	margin-bottom: 6px;
+}
 #help dd { margin: 5px 35px; }
 #help .infos { padding-left: 0; }
 #help h1, #help h2 { margin-top: 0; }
 #help > div div {
 	width: 50%;
 	float: left;
-	padding: 20px;
-	padding-left: 17px;
+	padding: 0 20px 20px 17px;;
 }
 
 .stab {

--- a/src/librustdoc/html/static/themes/ayu.css
+++ b/src/librustdoc/html/static/themes/ayu.css
@@ -219,7 +219,8 @@ a {
 }
 
 .docblock:not(.type-decl) a:not(.srclink):not(.test-arrow),
-.docblock-short a:not(.srclink):not(.test-arrow), .stability a {
+.docblock-short a:not(.srclink):not(.test-arrow), .stability a,
+#help a {
 	color: #39AFD7;
 }
 
@@ -273,6 +274,10 @@ a {
 	box-shadow: 0px 6px 20px 0px black;
 	border: none;
 	border-radius: 4px;
+}
+
+#help > div > span {
+	border-bottom-color: #5c6773;
 }
 
 .since {

--- a/src/librustdoc/html/static/themes/dark.css
+++ b/src/librustdoc/html/static/themes/dark.css
@@ -177,7 +177,8 @@ a {
 }
 
 .docblock:not(.type-decl) a:not(.srclink):not(.test-arrow),
-.docblock-short a:not(.srclink):not(.test-arrow), .stability a {
+.docblock-short a:not(.srclink):not(.test-arrow), .stability a,
+#help a {
 	color: #D2991D;
 }
 
@@ -229,6 +230,10 @@ a.test-arrow {
 #help > div {
 	background: #4d4d4d;
 	border-color: #bfbfbf;
+}
+
+#help > div > span {
+	border-bottom-color: #bfbfbf;
 }
 
 #help dt {

--- a/src/librustdoc/html/static/themes/light.css
+++ b/src/librustdoc/html/static/themes/light.css
@@ -175,7 +175,8 @@ a {
 }
 
 .docblock:not(.type-decl) a:not(.srclink):not(.test-arrow),
-.docblock-short a:not(.srclink):not(.test-arrow), .stability a {
+.docblock-short a:not(.srclink):not(.test-arrow), .stability a,
+#help a {
 	color: #3873AD;
 }
 
@@ -227,6 +228,10 @@ a.test-arrow {
 #help > div {
 	background: #e9e9e9;
 	border-color: #bfbfbf;
+}
+
+#help > div > span {
+	border-bottom-color: #bfbfbf;
 }
 
 .since {

--- a/src/stage0.txt
+++ b/src/stage0.txt
@@ -20,7 +20,7 @@ cargo: beta
 # bootstrapping issues with use of new syntax in this repo. If you're looking at
 # the beta/stable branch, this key should be omitted, as we don't want to depend
 # on rustfmt from nightly there.
-rustfmt: nightly-2020-10-07
+rustfmt: nightly-2020-10-12
 
 # When making a stable release the process currently looks like:
 #

--- a/src/test/ui/usize-generic-argument-parent.rs
+++ b/src/test/ui/usize-generic-argument-parent.rs
@@ -1,0 +1,5 @@
+fn foo() {
+    let x: usize<foo>; //~ ERROR const arguments are not allowed for this type
+}
+
+fn main() {}

--- a/src/test/ui/usize-generic-argument-parent.stderr
+++ b/src/test/ui/usize-generic-argument-parent.stderr
@@ -1,0 +1,9 @@
+error[E0109]: const arguments are not allowed for this type
+  --> $DIR/usize-generic-argument-parent.rs:2:18
+   |
+LL |     let x: usize<foo>;
+   |                  ^^^ const argument not allowed
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0109`.


### PR DESCRIPTION
Successful merges:

 - #77877 (Use `try{}` in `try_fold` to decouple iterators in the library from `Try` details)
 - #78089 (Fix issue with specifying generic arguments for primitive types)
 - #78099 (Add missing punctuation)
 - #78103 (Add link to rustdoc book in rustdoc help popup)

Failed merges:


r? @ghost